### PR TITLE
Update websockets to 0.11

### DIFF
--- a/services/cannon/cannon.cabal
+++ b/services/cannon/cannon.cabal
@@ -58,7 +58,7 @@ library
         , wai-utilities         >= 0.11
         , wai-websockets        >= 3.0
         , warp                  >= 3.0
-        , websockets            >= 0.9
+        , websockets            >= 0.11
 
 executable cannon
     main-is:            src/Main.hs

--- a/services/cannon/stack.yaml
+++ b/services/cannon/stack.yaml
@@ -16,5 +16,6 @@ extra-deps:
 - data-timeout-0.3
 - text-latin1-0.3
 - text-printer-0.5
+- websockets-0.11.1.0
 extra-package-dbs: []
 


### PR DESCRIPTION
Websockets 0.11 supports the permessage-deflate compression extension.