### PR TITLE
Add optional -static flag to cabal files

### DIFF
--- a/services/cannon/cannon.cabal
+++ b/services/cannon/cannon.cabal
@@ -11,6 +11,10 @@ build-type:    Simple
 cabal-version: >= 1.10
 description:   Push Notification API Service.
 
+flag static
+    Description: Enable static linking
+    Default:     False
+
 library
     default-language: Haskell2010
     hs-source-dirs:   src
@@ -73,6 +77,9 @@ executable cannon
         -with-rtsopts=-T
 
     build-depends: base, cannon
+
+    if flag(static)
+        ld-options: -static
 
 test-suite cannon-tests
     type:               exitcode-stdio-1.0

--- a/services/cargohold/cargohold.cabal
+++ b/services/cargohold/cargohold.cabal
@@ -13,6 +13,10 @@ cabal-version:  >= 1.10
 description:
     API for asset storage.
 
+flag static
+    Description: Enable static linking
+    Default:     False
+
 library
     default-language: Haskell2010
     hs-source-dirs:   src
@@ -107,6 +111,9 @@ executable cargohold
         base
       , cargohold
       , HsOpenSSL >= 0.11
+
+    if flag(static)
+        ld-options: -static
 
 test-suite cargohold-integration
     type:               exitcode-stdio-1.0

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -10,6 +10,10 @@ build-type:     Simple
 cabal-version:  >= 1.10
 description:    Conversation service implementation.
 
+flag static
+    Description: Enable static linking
+    Default:     False
+
 library
     hs-source-dirs: src
 
@@ -115,6 +119,9 @@ executable galley
         -with-rtsopts=-T
         -with-rtsopts=-N1
 
+    if flag(static)
+        ld-options: -static
+
 executable galley-schema
     main-is:            Main.hs
     default-language:   Haskell2010
@@ -129,6 +136,9 @@ executable galley-schema
       , raw-strings-qq       == 1.0.*
       , text
       , tinylog
+
+    if flag(static)
+        ld-options: -static
 
 test-suite galley-integration
     type:               exitcode-stdio-1.0

--- a/services/proxy/proxy.cabal
+++ b/services/proxy/proxy.cabal
@@ -10,6 +10,10 @@ build-type:    Simple
 cabal-version: >= 1.10
 description:   3rd party proxy
 
+flag static
+    Description: Enable static linking
+    Default:     False
+
 library
     default-language: Haskell2010
     hs-source-dirs:   src
@@ -53,4 +57,5 @@ executable proxy
     default-language: Haskell2010
     ghc-options:      -Wall -O2 -fwarn-tabs -threaded
     build-depends:    base, proxy
-
+    if flag(static)
+        ld-options: -static


### PR DESCRIPTION
In the right environment, this allows building static executables with
e.g. `stack build --flag proxy:static`