### PR TITLE
[ropes] change integration test to be an executable

### DIFF
--- a/libs/ropes/ropes.cabal
+++ b/libs/ropes/ropes.cabal
@@ -44,8 +44,7 @@ library
         -Wall
         -fwarn-tabs
 
-test-suite ropes-aws-test
-    type:               exitcode-stdio-1.0
+executable ropes-aws-test
     default-language:   Haskell2010
     main-is:            Main.hs
     hs-source-dirs:     test/integration-aws


### PR DESCRIPTION
These tests require AWS credentials, so should be run with other integration tests (instead of during each `stack build --test` of services using this, e.g. cargohold).