### PR TITLE
Various tweaks to teams.

### DIFF
--- a/libs/galley-types/src/Galley/Types/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Swagger.hs
@@ -35,6 +35,7 @@ galleyModels =
     , userClients
     , clientMismatch
     , serviceRef
+    , teamInfo
     ]
 
 event :: Model
@@ -248,6 +249,17 @@ newConversation = defineModel "NewConversation" $ do
     property "name" string' $ do
         description "The conversation name"
         optional
+    property "team" (ref teamInfo) $ do
+        description "Team information of this conversation"
+        optional
+
+teamInfo :: Model
+teamInfo = defineModel "TeamInfo" $ do
+    description "Team information"
+    property "teamid" bytes' $
+        description "Team ID"
+    property "managed" bool' $
+        description "Is this a managed team conversation?"
 
 conversationIds :: Model
 conversationIds = defineModel "ConversationIds" $ do

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -74,6 +74,7 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. request
+        .&. accept "application" "json"
         .&. contentType "application" "json"
 
     document "POST" "createTeam" $ do
@@ -88,6 +89,7 @@ sitemap = do
         .&. zauthConnId
         .&. capture "id"
         .&. request
+        .&. accept "application" "json"
         .&. contentType "application" "json"
 
     document "PUT" "updateTeam" $ do
@@ -159,11 +161,31 @@ sitemap = do
 
     --
 
+    get "/teams/:tid/members/:uid" (continue getTeamMember) $
+        zauthUserId
+        .&. capture "tid"
+        .&. capture "uid"
+        .&. accept "application" "json"
+
+    document "GET" "getTeamMember" $ do
+        summary "Get single team member"
+        parameter Path "tid" bytes' $
+            description "Team ID"
+        parameter Path "uid" bytes' $
+            description "User ID"
+        returns (ref TeamsModel.teamMember)
+        response 200 "Team member" end
+        errorResponse Error.noTeamMember
+        errorResponse Error.teamMemberNotFound
+
+    --
+
     post "/teams/:id/members" (continue addTeamMember) $
         zauthUserId
         .&. zauthConnId
         .&. capture "id"
         .&. request
+        .&. contentType "application" "json"
         .&. accept "application" "json"
 
     document "POST" "addTeamMember" $ do
@@ -195,6 +217,27 @@ sitemap = do
             description "User ID"
         errorResponse Error.noTeamMember
         errorResponse (Error.operationDenied RemoveTeamMember)
+
+    --
+
+    put "/teams/:id/members" (continue updateTeamMember) $
+        zauthUserId
+        .&. zauthConnId
+        .&. capture "id"
+        .&. request
+        .&. accept "application" "json"
+        .&. contentType "application" "json"
+
+    document "PUT" "updateTeamMember" $ do
+        summary "Update an existing team member"
+        parameter Path "id" bytes' $
+            description "Team ID"
+        body (ref TeamsModel.newTeamMember) $
+            description "JSON body"
+        errorResponse Error.noTeamMember
+        errorResponse Error.teamMemberNotFound
+        errorResponse (Error.operationDenied SetMemberPermissions)
+
     --
 
     get "/teams/:id/conversations" (continue getTeamConversations) $
@@ -209,6 +252,26 @@ sitemap = do
         returns (ref TeamsModel.teamConversationList)
         response 200 "Team conversations" end
         errorResponse Error.teamNotFound
+        errorResponse (Error.operationDenied GetTeamConversations)
+
+    --
+
+    get "/teams/:tid/conversations/:cid" (continue getTeamConversation) $
+        zauthUserId
+        .&. capture "tid"
+        .&. capture "cid"
+        .&. accept "application" "json"
+
+    document "GET" "getTeamConversation" $ do
+        summary "Get one team conversation"
+        parameter Path "tid" bytes' $
+            description "Team ID"
+        parameter Path "cid" bytes' $
+            description "Conversation ID"
+        returns (ref TeamsModel.teamConversation)
+        response 200 "Team conversation" end
+        errorResponse Error.teamNotFound
+        errorResponse Error.convNotFound
         errorResponse (Error.operationDenied GetTeamConversations)
 
     --

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -65,3 +65,6 @@ invalidPermissions = Error status403 "invalid-permissions" "The specified permis
 tooManyTeamMembers :: Error
 tooManyTeamMembers = Error status403 "too-many-team-members" "Maximum number of members per team reached"
 
+teamMemberNotFound :: Error
+teamMemberNotFound = Error status404 "no-team-member" "team member not found"
+

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -57,7 +57,7 @@ import Galley.Intra.User
 import Galley.Types
 import Galley.Types.Bot
 import Galley.Types.Clients (Clients)
-import Galley.Types.Teams hiding (EventType (..))
+import Galley.Types.Teams hiding (EventType (..), EventData (..))
 import Galley.Validation
 import Network.HTTP.Types
 import Network.Wai

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -12,6 +12,7 @@ module Galley.Data
 
     -- * Teams
     , addTeamMember
+    , updateTeamMember
     , createTeam
     , removeTeamMember
     , team
@@ -187,6 +188,9 @@ addTeamMember t m =
         setConsistency Quorum
         addPrepQuery Cql.insertTeamMember (t, m^.userId, m^.permissions)
         addPrepQuery Cql.insertUserTeam   (m^.userId, t)
+
+updateTeamMember :: MonadClient m => TeamId -> UserId -> Permissions -> m ()
+updateTeamMember t u p = retry x5 $ write Cql.updatePermissions (params Quorum (p, t, u))
 
 removeTeamMember :: MonadClient m => TeamId -> UserId -> m ()
 removeTeamMember t m =

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -79,6 +79,11 @@ getTeamMembers g usr tid = do
     r <- get (g . paths ["teams", toByteString' tid, "members"] . zUser usr) <!! const 200 === statusCode
     pure (fromJust (decodeBody r))
 
+getTeamMember :: Galley -> UserId -> TeamId -> UserId -> Http TeamMember
+getTeamMember g usr tid mid = do
+    r <- get (g . paths ["teams", toByteString' tid, "members", toByteString' mid] . zUser usr) <!! const 200 === statusCode
+    pure (fromJust (decodeBody r))
+
 addTeamMember :: Galley -> UserId -> TeamId -> TeamMember -> Http ()
 addTeamMember g usr tid mem = do
     let payload = json (newNewTeamMember mem)


### PR DESCRIPTION
- Include team metadata as part of `team.create` event.
- Add support for updating team member permissions.
- Add API endpoint to get a single team conversation.
- Add API endpoint to get a single team member.
- If a team member is removed, remove it from all team conversations.
- Update API documentation.