### PR TITLE
Reduce consistency requirement for token lookup.

### DIFF
--- a/services/gundeck/src/Gundeck/Client.hs
+++ b/services/gundeck/src/Gundeck/Client.hs
@@ -39,7 +39,7 @@ unregister (uid ::: cid) = do
     keys <- Clients.select uid cid
     when (isNothing keys) $
         throwM (Error status404 "not-found" "Client not found")
-    aa <- filter byClient <$> Push.lookup uid
+    aa <- filter byClient <$> Push.lookup uid Push.Quorum
     for_ aa $ \a ->
         Push.delete (a^.addrUser) (a^.addrTransport) (a^.addrApp) (a^.addrToken)
     Clients.remove uid cid
@@ -56,7 +56,7 @@ removeUser :: UserId -> Gundeck Response
 removeUser user = do
     env <- view awsEnv
     let rm a = Aws.execute env (Aws.deleteEndpoint (a^.addrEndpoint))
-    Push.lookup user >>= mapM_ rm
+    Push.lookup user Push.Quorum >>= mapM_ rm
     Push.erase user
     Clients.erase user
     return empty

--- a/services/gundeck/src/Gundeck/Push/Native/Fallback.hs
+++ b/services/gundeck/src/Gundeck/Push/Native/Fallback.hs
@@ -79,7 +79,7 @@ execute nid prio (Candidates now queue) = do
             -- TODO: We could avoid looking up the addresses here again, if we
             --       retain the fallback addresses in `Gundeck.Push.nativeTargets`.
             addr <- List.find (fallbackAddress clt app trp)
-                <$> Push.lookup usr
+                <$> Push.lookup usr Push.One
             for_ addr $ \a -> do
                 Log.debug $ logMsg usr clt app trp "Sending fallback notification"
                     ~~ "arn" .= toText (a^.addrEndpoint)

--- a/services/gundeck/src/Gundeck/React.hs
+++ b/services/gundeck/src/Gundeck/React.hs
@@ -31,7 +31,7 @@ import qualified Data.Set                  as Set
 import qualified Data.Text                 as Text
 import qualified Gundeck.Aws               as Aws
 import qualified Gundeck.Notification.Data as Stream
-import qualified Gundeck.Push.Data         as Data
+import qualified Gundeck.Push.Data         as Push
 import qualified Gundeck.Push.Websocket    as Web
 import qualified System.Logger.Class       as Log
 
@@ -86,7 +86,7 @@ withToken ev f = do
     e <- Aws.execute v (Aws.lookupEndpoint (ev^.evEndpoint))
     for_ e $ \ep -> do
         u  <- Aws.readEndpointData invalidData ep
-        as <- Data.lookup u
+        as <- Push.lookup u Push.Quorum
         case List.find ((== (ev^.evEndpoint)) . view addrEndpoint) as of
             Nothing -> do
                 logEvent u ev $ "token" .= Text.take 16 (tokenText (ep^.endpointToken))
@@ -111,7 +111,7 @@ deleteToken u ev tk cl = do
         r = singleton (target u & targetClients .~ [cl])
     void $ Web.push n r u Nothing Set.empty
     Stream.add i r p =<< view (options.notificationTTL)
-    Data.delete u (t^.tokenTransport) (t^.tokenApp) tk
+    Push.delete u (t^.tokenTransport) (t^.tokenApp) tk
 
 mkPushToken :: Event -> Token -> ClientId -> PushToken
 mkPushToken ev tk cl = let t = ev^.evEndpoint.snsTopic in

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -129,7 +129,7 @@ removeUser s g c = do
     deleteUser g user
     liftIO $ do
         keys   <- Cql.runClient s (Clients.select user clt)
-        tokens <- Cql.runClient s (Push.lookup user)
+        tokens <- Cql.runClient s (Push.lookup user Push.Quorum)
         assertBool "clients gone" (isNothing keys)
         assertBool "tokens gone" (null tokens)
 


### PR DESCRIPTION
Reduce the consistency requirement from `Quorum` to `One` for push token lookups in the main async code path for sending (native) push notifications to increase chances of delivery in the presence of
network problems (and possibly slightly reduced latency).

Note: Other code paths for push token lookups still need to use `Quorum` consistency as the
lookups happen in the context of possible token updates or removal, i.e. a (strongly) consistent read is typically necessary for correct operation and / or to fulfill the API contract.