### PR TITLE
New galley internal endpoints to manipulate teams

### DIFF
--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -11,6 +11,7 @@ module Galley.Types.Teams
     , teamName
     , teamIcon
     , teamIconKey
+    , teamBound
 
     , TeamList
     , newTeamList
@@ -56,7 +57,7 @@ module Galley.Types.Teams
     , newTeamIcon
     , newTeamIconKey
     , newTeamMembers
-    , newTeamBindUsr
+    , newTeamBinding
 
     , NewTeamMember
     , newNewTeamMember
@@ -105,6 +106,7 @@ data Team = Team
     , _teamName    :: Text
     , _teamIcon    :: Text
     , _teamIconKey :: Maybe Text
+    , _teamBound   :: Bool
     } deriving (Eq, Show)
 
 data Event = Event
@@ -190,15 +192,15 @@ data NewTeam = NewTeam
     , _newTeamIcon    :: Range 1 256 Text
     , _newTeamIconKey :: Maybe (Range 1 256 Text)
     , _newTeamMembers :: Maybe (Range 1 127 [TeamMember])
-    , _newTeamBindUsr :: Bool
+    , _newTeamBinding :: Bool
     }
 
 newtype NewTeamMember = NewTeamMember
     { _ntmNewTeamMember :: TeamMember
     }
 
-newTeam :: TeamId -> UserId -> Text -> Text -> Team
-newTeam tid uid nme ico = Team tid uid nme ico Nothing
+newTeam :: TeamId -> UserId -> Text -> Text -> Bool -> Team
+newTeam tid uid nme ico bnd = Team tid uid nme ico Nothing bnd
 
 newTeamList :: [Team] -> Bool -> TeamList
 newTeamList = TeamList
@@ -305,6 +307,7 @@ instance FromJSON Team where
              <*> o .:  "name"
              <*> o .:  "icon"
              <*> o .:? "icon_key"
+             <*> o .:? "binding" .!= False
 
 instance ToJSON TeamList where
     toJSON t = object
@@ -371,7 +374,7 @@ instance ToJSON NewTeam where
         # "icon"      .= fromRange (_newTeamIcon t)
         # "icon_key"  .= (fromRange <$> _newTeamIconKey t)
         # "members"   .= (map (teamMemberJson True) . fromRange <$> _newTeamMembers t)
-        # "bind_user" .= _newTeamBindUsr t
+        # "binding"   .= _newTeamBinding t
         # []
 
 instance FromJSON NewTeam where
@@ -380,7 +383,7 @@ instance FromJSON NewTeam where
         icon <- o .:  "icon"
         key  <- o .:? "icon_key"
         mems <- o .:? "members"
-        bind <- o .:? "bind_user" .!= False
+        bind <- o .:? "binding" .!= False
         either fail pure $
             NewTeam <$> checkedEitherMsg "name" name
                     <*> checkedEitherMsg "icon" icon

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -216,7 +216,7 @@ newTeamConversationList :: [TeamConversation] -> TeamConversationList
 newTeamConversationList = TeamConversationList
 
 newNewTeam :: Range 1 256 Text -> Range 1 256 Text -> NewTeam
-newNewTeam nme ico = NewTeam nme ico Nothing Nothing True
+newNewTeam nme ico = NewTeam nme ico Nothing Nothing False
 
 newNewTeamMember :: TeamMember -> NewTeamMember
 newNewTeamMember = NewTeamMember
@@ -380,7 +380,7 @@ instance FromJSON NewTeam where
         icon <- o .:  "icon"
         key  <- o .:? "icon_key"
         mems <- o .:? "members"
-        bind <- o .:? "bind_user" .!= True
+        bind <- o .:? "bind_user" .!= False
         either fail pure $
             NewTeam <$> checkedEitherMsg "name" name
                     <*> checkedEitherMsg "icon" icon

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -10,6 +10,7 @@ import System.Logger hiding (info)
 
 import qualified V20
 import qualified V21
+import qualified V22
 
 main :: IO ()
 main = do
@@ -18,6 +19,7 @@ main = do
     migrateSchema l o
         [ V20.migration
         , V21.migration
+        , V22.migration
         ]
       `finally`
         close l

--- a/services/galley/schema/src/V22.hs
+++ b/services/galley/schema/src/V22.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module V22 (migration) where
+
+import Cassandra.Schema
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 22 "Added bound flag to teams" $ do
+    schema' [r| ALTER TABLE team ADD bound boolean; |]

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -88,6 +88,12 @@ sitemap = do
         response 201 "Team ID as `Location` header value" end
         errorResponse Error.notConnected
 
+    post "/i/teams" (continue createTeamInternal) $
+        zauthUserId
+        .&. request
+        .&. accept "application" "json"
+        .&. contentType "application" "json"
+
     put "/teams/:id" (continue updateTeam) $
         zauthUserId
         .&. zauthConnId

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -633,6 +633,14 @@ sitemap = do
     get "/i/conversations/:cnv/meta" (continue getConversationMeta) $
         capture "cnv"
 
+    post "/i/teams/:id/members" (continue uncheckedAddTeamMember) $
+        zauthUserId
+        .&. zauthConnId
+        .&. capture "id"
+        .&. request
+        .&. contentType "application" "json"
+        .&. accept "application" "json"
+
     get "/i/test/clients" (continue getClients)
         zauthUserId
 

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -633,6 +633,10 @@ sitemap = do
     get "/i/conversations/:cnv/meta" (continue getConversationMeta) $
         capture "cnv"
 
+    get "/i/teams/:tid" (continue uncheckedLookupTeam) $
+        capture "tid"
+        .&. accept "application" "json"
+
     post "/i/teams/:tid/members" (continue uncheckedAddTeamMember) $
         capture "tid"
         .&. request

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -641,6 +641,11 @@ sitemap = do
         .&. contentType "application" "json"
         .&. accept "application" "json"
 
+    get "/i/teams/:tid/members/:uid" (continue uncheckedGetTeamMember) $
+        capture "tid"
+        .&. capture "uid"
+        .&. accept "application" "json"
+
     get "/i/test/clients" (continue getClients)
         zauthUserId
 

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -633,15 +633,8 @@ sitemap = do
     get "/i/conversations/:cnv/meta" (continue getConversationMeta) $
         capture "cnv"
 
-    post "/i/teams" (continue createTeamInternal) $
-        zauthUserId
-        .&. request
-        .&. accept "application" "json"
-        .&. contentType "application" "json"
-
-    post "/i/teams/:id/members" (continue uncheckedAddTeamMember) $
-        zauthUserId
-        .&. capture "id"
+    post "/i/teams/:tid/members" (continue uncheckedAddTeamMember) $
+        capture "tid"
         .&. request
         .&. contentType "application" "json"
         .&. accept "application" "json"

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -88,12 +88,6 @@ sitemap = do
         response 201 "Team ID as `Location` header value" end
         errorResponse Error.notConnected
 
-    post "/i/teams" (continue createTeamInternal) $
-        zauthUserId
-        .&. request
-        .&. accept "application" "json"
-        .&. contentType "application" "json"
-
     put "/teams/:id" (continue updateTeam) $
         zauthUserId
         .&. zauthConnId
@@ -639,9 +633,14 @@ sitemap = do
     get "/i/conversations/:cnv/meta" (continue getConversationMeta) $
         capture "cnv"
 
+    post "/i/teams" (continue createTeamInternal) $
+        zauthUserId
+        .&. request
+        .&. accept "application" "json"
+        .&. contentType "application" "json"
+
     post "/i/teams/:id/members" (continue uncheckedAddTeamMember) $
         zauthUserId
-        .&. zauthConnId
         .&. capture "id"
         .&. request
         .&. contentType "application" "json"

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -633,10 +633,6 @@ sitemap = do
     get "/i/conversations/:cnv/meta" (continue getConversationMeta) $
         capture "cnv"
 
-    get "/i/teams/:tid" (continue uncheckedLookupTeam) $
-        capture "tid"
-        .&. accept "application" "json"
-
     post "/i/teams/:tid/members" (continue uncheckedAddTeamMember) $
         capture "tid"
         .&. request

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -71,5 +71,8 @@ teamMemberNotFound = Error status404 "no-team-member" "team member not found"
 noTeamConv :: Error
 noTeamConv = Error status400 "no-team-conv" "Team conversations are not allowed in this context."
 
+userBindingExists :: Error
+userBindingExists = Error status403 "binding-exists" "The user is already bound to a different team."
+
 deleteQueueFull :: Error
 deleteQueueFull = Error status503 "queue-full" "The delete queue is full. No further delete requests can be processed at the moment."

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -56,6 +56,9 @@ noAddToManaged = Error status403 "no-add-to-managed" "Adding users directly to m
 teamNotFound :: Error
 teamNotFound = Error status404 "no-team" "team not found"
 
+noAddToBound :: Error
+noAddToBound = Error status403 "no-add-to-bound" "Cannot add users to bound teams, invite only."
+
 noBotsInTeamConvs :: Error
 noBotsInTeamConvs = Error status403 "bots-not-allowed" "Adding bots to team conversations is not allowed."
 

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -18,6 +18,7 @@ module Galley.API.Teams
     , deleteTeamConversation
     , updateTeamMember
     , uncheckedAddTeamMember
+    , uncheckedGetTeamMember
     , uncheckedRemoveTeamMember
     ) where
 
@@ -156,6 +157,11 @@ getTeamMember (zusr::: tid ::: uid ::: _) = do
             let withPerm = m `hasPermission` GetMemberPermissions
             let member   = findTeamMember uid mems
             maybe (throwM teamMemberNotFound) (pure . json . teamMemberJson withPerm) member
+
+uncheckedGetTeamMember :: TeamId ::: UserId ::: JSON -> Galley Response
+uncheckedGetTeamMember (tid ::: uid ::: _) = do
+    mems <- Data.teamMembers tid
+    maybe (throwM teamMemberNotFound) (pure . json . teamMemberJson True) (findTeamMember uid mems)
 
 addTeamMember :: UserId ::: ConnId ::: TeamId ::: Request ::: JSON ::: JSON -> Galley Response
 addTeamMember (zusr::: zcon ::: tid ::: req ::: _) = do

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -84,6 +84,7 @@ createTeam (zusr::: zcon ::: req ::: _) = do
     u    <- getUser zusr
     when (body^.newTeamBindUsr && isJust (userTeam u)) $
         throwM userBindingExists
+    -- TODO: Need to check the other users as well as this point
     team <- Data.createTeam zusr (body^.newTeamName) (body^.newTeamIcon) (body^.newTeamIconKey)
     let owner  = newTeamMember zusr fullPermissions
     let others = filter ((zusr /=) . view userId)

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -93,7 +93,7 @@ createTeam (zusr::: zcon ::: req ::: _) = do
     for_ (owner : others) $
         Data.addTeamMember (team^.teamId)
     -- We bind the user at a later stage because of potential failures.
-    -- If we fail at this point, the user can still try to bind to other teams
+    -- If we fail at this point, the user can still try to bind to another team
     when (body^.newTeamBindUsr) $
         bindUser zusr (team^.teamId)
     now <- liftIO getCurrentTime

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -20,6 +20,7 @@ module Galley.API.Teams
     , uncheckedAddTeamMember
     , uncheckedGetTeamMember
     , uncheckedRemoveTeamMember
+    , uncheckedLookupTeam
     ) where
 
 import Brig.Types (userTeam)
@@ -77,6 +78,14 @@ lookupTeam zusr tid = do
         pure (Data.tdTeam <$> t)
     else
         pure Nothing
+
+uncheckedLookupTeam :: TeamId ::: JSON -> Galley Response
+uncheckedLookupTeam (tid ::: _) = do
+    t <- Data.team tid
+    return . json $ if (Just True == (Data.tdDeleted <$> t))
+        then Nothing
+    else
+        Data.tdTeam <$> t
 
 createTeam :: UserId ::: ConnId ::: Request ::: JSON ::: JSON -> Galley Response
 createTeam (zusr::: zcon ::: req ::: _) = do

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -171,9 +171,9 @@ uncheckedGetTeamMember (tid ::: uid ::: _) = do
 
 addTeamMember :: UserId ::: ConnId ::: TeamId ::: Request ::: JSON ::: JSON -> Galley Response
 addTeamMember (zusr::: zcon ::: tid ::: req ::: _) = do
-    body  <- fromBody req invalidPayload
-    mems  <- Data.teamMembers tid
-    tmem  <- permissionCheck zusr AddTeamMember mems
+    body <- fromBody req invalidPayload
+    mems <- Data.teamMembers tid
+    tmem <- permissionCheck zusr AddTeamMember mems
     unless ((body^.ntmNewTeamMember.permissions.self) `Set.isSubsetOf` (tmem^.permissions.copy)) $
         throwM invalidPermissions
     unless (length mems < 128) $

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -20,7 +20,6 @@ module Galley.API.Teams
     , uncheckedAddTeamMember
     , uncheckedGetTeamMember
     , uncheckedRemoveTeamMember
-    , uncheckedLookupTeam
     ) where
 
 import Brig.Types (userTeam)
@@ -78,14 +77,6 @@ lookupTeam zusr tid = do
         pure (Data.tdTeam <$> t)
     else
         pure Nothing
-
-uncheckedLookupTeam :: TeamId ::: JSON -> Galley Response
-uncheckedLookupTeam (tid ::: _) = do
-    t <- Data.team tid
-    return . json $ if (Just True == (Data.tdDeleted <$> t))
-        then Nothing
-    else
-        Data.tdTeam <$> t
 
 createTeam :: UserId ::: ConnId ::: Request ::: JSON ::: JSON -> Galley Response
 createTeam (zusr::: zcon ::: req ::: _) = do

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -180,9 +180,9 @@ uncheckedGetTeamMember (tid ::: uid ::: _) = do
 
 addTeamMember :: UserId ::: ConnId ::: TeamId ::: Request ::: JSON ::: JSON -> Galley Response
 addTeamMember (zusr::: zcon ::: tid ::: req ::: _) = do
-    body <- fromBody req invalidPayload
-    mems <- Data.teamMembers tid
-    tmem <- permissionCheck zusr AddTeamMember mems
+    body  <- fromBody req invalidPayload
+    mems  <- Data.teamMembers tid
+    tmem  <- permissionCheck zusr AddTeamMember mems
     unless ((body^.ntmNewTeamMember.permissions.self) `Set.isSubsetOf` (tmem^.permissions.copy)) $
         throwM invalidPermissions
     unless (length mems < 128) $
@@ -201,7 +201,10 @@ addTeamMember (zusr::: zcon ::: tid ::: req ::: _) = do
 -- Does not check whether users are connected before adding to team
 uncheckedAddTeamMember :: TeamId ::: Request ::: JSON ::: JSON -> Galley Response
 uncheckedAddTeamMember (tid ::: req ::: _) = do
-    body <- fromBody req invalidPayload
+    body  <- fromBody req invalidPayload
+    alive <- Data.isTeamAlive tid
+    unless alive $
+        throwM teamNotFound
     mems <- Data.teamMembers tid
     unless (length mems < 128) $
         throwM tooManyTeamMembers

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -186,7 +186,7 @@ addTeamMember (zusr::: zcon ::: tid ::: req ::: _) = do
     now <- liftIO getCurrentTime
     let e = newEvent MemberJoin tid now & eventData .~ Just (EdMemberJoin (body^.ntmNewTeamMember.userId))
     let r = list1 (userRecipient zusr) (membersToRecipients (Just zusr) ((body^.ntmNewTeamMember) : mems))
-    push1 $ newPush1 zusr (TeamEvent e) r & pushConn .~ (Just zcon)
+    push1 $ newPush1 zusr (TeamEvent e) r & pushConn .~ Just zcon
     pure empty
 
 -- Does not check whether users are connected before adding to team

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -20,8 +20,8 @@ import qualified Data.Text.Lazy as LT
 
 -- Teams --------------------------------------------------------------------
 
-selectTeam :: PrepQuery R (Identity TeamId) (UserId, Text, Text, Maybe Text, Bool)
-selectTeam = "select creator, name, icon, icon_key, deleted from team where team = ?"
+selectTeam :: PrepQuery R (Identity TeamId) (UserId, Text, Text, Maybe Text, Bool, Maybe Bool)
+selectTeam = "select creator, name, icon, icon_key, deleted, bound from team where team = ?"
 
 selectTeamConv :: PrepQuery R (TeamId, ConvId) (Identity Bool)
 selectTeamConv = "select managed from team_conv where team = ? and conv = ?"
@@ -44,8 +44,8 @@ selectUserTeamsIn = "select team from user_team where user = ? and team in ? ord
 selectUserTeamsFrom :: PrepQuery R (UserId, TeamId) (Identity TeamId)
 selectUserTeamsFrom = "select team from user_team where user = ? and team > ? order by team"
 
-insertTeam :: PrepQuery W (TeamId, UserId, Text, Text, Maybe Text) ()
-insertTeam = "insert into team (team, creator, name, icon, icon_key, deleted) values (?, ?, ?, ?, ?, false)"
+insertTeam :: PrepQuery W (TeamId, UserId, Text, Text, Maybe Text, Bool) ()
+insertTeam = "insert into team (team, creator, name, icon, icon_key, deleted, bound) values (?, ?, ?, ?, ?, false, ?)"
 
 insertTeamConv :: PrepQuery W (TeamId, ConvId, Bool) ()
 insertTeamConv = "insert into team_conv (team, conv, managed) values (?, ?, ?)"

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -8,9 +8,10 @@ module Galley.Intra.User
     ) where
 
 import Bilge hiding (options, getHeader)
+import Brig.Types (User(..))
 import Bilge.RPC
 import Bilge.Retry
-import Brig.Types.Intra (ConnectionStatus (..), UserAccount (..))
+import Brig.Types.Intra (ConnectionStatus (..))
 import Brig.Types.Connection (Relation (..))
 import Galley.App
 import Galley.Options
@@ -56,13 +57,14 @@ deleteBot cid bot = do
         . header "Z-Conversation" (toByteString' cid)
         . expect2xx
 
-getUser :: UserId -> Galley UserAccount
+getUser :: UserId -> Galley User
 getUser u = do
     h <- view (options.brigHost)
     p <- view (options.brigPort)
     r <- call "brig"
         $ method GET . host h . port (portNumber p)
-        . paths ["/i/users", toByteString' u]
+        . path "/self"
+        . header "Z-User" (toByteString' u)
         . expect2xx
     parseResponse (Error status502 "server-error") r
 
@@ -72,7 +74,7 @@ bindUser u t = do
     p <- view (options.brigPort)
     void $ call "brig"
         $ method POST . host h . port (portNumber p)
-        . paths ["/i/teams", toByteString' t, "bind", toByteString' u]
+        . paths ["/i/users", toByteString' u, "bind", toByteString' t]
         . expect2xx
 
 -----------------------------------------------------------------------------

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -16,7 +16,7 @@ import Brig.Types.Connection (Relation (..))
 import Galley.App
 import Galley.Options
 import Control.Monad (void)
-import Control.Lens
+import Control.Lens (view)
 import Control.Retry
 import Data.ByteString.Char8 (pack, intercalate)
 import Data.ByteString.Conversion
@@ -25,7 +25,7 @@ import Data.Char (toLower)
 import Data.Id
 import Data.Misc (portNumber)
 import Network.HTTP.Types.Method
-import Network.HTTP.Types.Status
+import Network.HTTP.Types.Status (status502)
 import Network.Wai.Utilities.Error
 
 import qualified Data.Text.Lazy as LT

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -69,7 +69,7 @@ testCreateTeam g b c = do
 testCreateMulitpleBoundTeam :: Galley -> Brig -> Http ()
 testCreateMulitpleBoundTeam g b = do
     owner <- Util.randomUser b
-    let nt = newNewTeam (unsafeRange "owner") (unsafeRange "icon") & newTeamBindUsr .~ True
+    let nt = newNewTeam (unsafeRange "owner") (unsafeRange "icon") & newTeamBinding .~ True
     void $ post (g . path "/teams" . zUser owner . zConn "conn" . json nt) <!! do
         const 201 === statusCode
     void $ post (g . path "/teams" . zUser owner . zConn "conn" . json nt) <!! do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -81,6 +81,7 @@ testCreateMulitpleBoundTeam g b c = do
                 e^.eventData @?= Just (EdTeamCreate team)
             void $ WS.assertSuccess eventChecks
         let nt = newNewTeam (unsafeRange "foo") (unsafeRange "icon")
+        WS.assertNoEvent timeout [wsOwner]
         void $ post (g . path "/teams" . zUser owner . zConn "conn" . zType "access" . json nt) <!! do
             const 403 === statusCode
 

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -2,7 +2,7 @@
 
 module API.Teams (tests) where
 
-import API.Util (Galley, Brig, test, zUser, zConn, zType)
+import API.Util (Galley, Brig, test, zUser, zConn)
 import Bilge hiding (timeout)
 import Bilge.Assert
 import Control.Concurrent.Async (mapConcurrently)
@@ -82,7 +82,7 @@ testCreateMulitpleBoundTeam g b c = do
             void $ WS.assertSuccess eventChecks
         let nt = newNewTeam (unsafeRange "foo") (unsafeRange "icon")
         WS.assertNoEvent timeout [wsOwner]
-        void $ post (g . path "/teams" . zUser owner . zConn "conn" . zType "access" . json nt) <!! do
+        void $ post (g . path "/teams" . zUser owner . zConn "conn" . json nt) <!! do
             const 403 === statusCode
 
 testCreateTeamWithMembers :: Galley -> Brig -> Cannon -> Http ()

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -75,7 +75,7 @@ testCreateMulitpleBoundTeam g b = do
     void $ post (g . path "/teams" . zUser owner . zConn "conn" . json nt) <!! do
         const 403 === statusCode
     -- Can create more teams if not bound
-    let nt' = nt & newTeamBindUsr .~ False
+    let nt' = newNewTeam (unsafeRange "owner") (unsafeRange "icon")
     void $ post (g . path "/teams" . zUser owner . zConn "conn" . json nt') <!! do
         const 201 === statusCode
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -84,10 +84,21 @@ getTeamMember g usr tid mid = do
     r <- get (g . paths ["teams", toByteString' tid, "members", toByteString' mid] . zUser usr) <!! const 200 === statusCode
     pure (fromJust (decodeBody r))
 
+getTeamMemberInternal :: Galley -> TeamId -> UserId -> Http TeamMember
+getTeamMemberInternal g tid mid = do
+    r <- get (g . paths ["i", "teams", toByteString' tid, "members", toByteString' mid]) <!! const 200 === statusCode
+    pure (fromJust (decodeBody r))
+
 addTeamMember :: Galley -> UserId -> TeamId -> TeamMember -> Http ()
 addTeamMember g usr tid mem = do
     let payload = json (newNewTeamMember mem)
     post (g . paths ["teams", toByteString' tid, "members"] . zUser usr . zConn "conn" .payload) !!!
+        const 200 === statusCode
+
+addTeamMemberInternal :: Galley -> TeamId -> TeamMember -> Http ()
+addTeamMemberInternal g tid mem = do
+    let payload = json (newNewTeamMember mem)
+    post (g . paths ["i", "teams", toByteString' tid, "members"] . payload) !!!
         const 200 === statusCode
 
 createTeamConv :: Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Http ConvId


### PR DESCRIPTION
Depends on newer types from brig which would need to be merged in first.
It mostly adds internal endpoints that allow `brig` to manipulate teams, mainly to _bind_ a user to a team (to be explained in brig's PR).