### PR TITLE
Decouple debian package version from cabal version

### DIFF
--- a/services/cannon/Makefile
+++ b/services/cannon/Makefile
@@ -1,10 +1,16 @@
 SHELL        := /usr/bin/env bash
 NAME         := cannon
-VERSION      := $(shell sed -n 's/^version: *\(.*\)$$/\1/p' $(NAME).cabal)
+VERSION      ?=
 BUILD_NUMBER ?= 0
 BUILD_LABEL  ?= local
 BUILD        := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
 DEB          := $(NAME)_$(VERSION)+$(BUILD)_amd64.deb
+
+guard-%:
+	@ if [ "${${*}}" = "" ]; then \
+	      echo "Environment variable $* not set"; \
+	    exit 1; \
+	fi
 
 default: all
 
@@ -28,7 +34,7 @@ compile:
 	stack build --pedantic --test --no-copy-bins
 
 .PHONY: dist
-dist: install $(DEB) .metadata
+dist: guard-VERSION install $(DEB) .metadata
 
 $(DEB):
 	makedeb --name=$(NAME) \

--- a/services/cargohold/Makefile
+++ b/services/cargohold/Makefile
@@ -1,6 +1,6 @@
 SHELL         := /usr/bin/env bash
 NAME          := cargohold
-VERSION       := $(shell sed -n 's/^version: *\(.*\)$$/\1/p' $(NAME).cabal)
+VERSION       ?=
 BUILD_NUMBER  ?= 0
 BUILD_LABEL   ?= local
 BUILD         := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
@@ -9,6 +9,12 @@ DEB           := dist/$(NAME)_$(VERSION)+$(BUILD)_amd64.deb
 DEB_IT        := dist/$(NAME)-integration_$(VERSION)+$(BUILD)_amd64.deb
 SDIST         := dist/$(NAME)-$(VERSION).tar.gz
 KEIRETSU_ENV  ?= ../.env
+
+guard-%:
+	@ if [ "${${*}}" = "" ]; then \
+	      echo "Environment variable $* not set"; \
+	    exit 1; \
+	fi
 
 default: clean install
 
@@ -32,7 +38,7 @@ clean: init
 	-rm -f .metadata
 
 .PHONY: dist
-dist: install $(DEB) $(DEB_IT) .metadata
+dist: guard-VERSION install $(DEB) $(DEB_IT) .metadata
 
 $(DEB):
 	makedeb --name=$(NAME) \

--- a/services/galley/Makefile
+++ b/services/galley/Makefile
@@ -1,6 +1,6 @@
 SHELL        := /usr/bin/env bash
 NAME         := galley
-VERSION      := $(shell sed -n 's/^version: *\(.*\)$$/\1/p' $(NAME).cabal)
+VERSION      ?=
 BUILD_NUMBER ?= 0
 BUILD_LABEL  ?= local
 BUILD        := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
@@ -10,6 +10,12 @@ DEB          := $(NAME)_$(VERSION)+$(BUILD)_amd64.deb
 DEB_IT       := $(NAME)-integration_$(VERSION)+$(BUILD)_amd64.deb
 DEB_SCHEMA   := $(NAME)-schema_$(VERSION)+$(BUILD)_amd64.deb
 KEIRETSU_ENV ?= ../.env
+
+guard-%:
+	@ if [ "${${*}}" = "" ]; then \
+	      echo "Environment variable $* not set"; \
+	    exit 1; \
+	fi
 
 default: all
 
@@ -34,7 +40,7 @@ compile:
 	stack build --pedantic --test --no-copy-bins
 
 .PHONY: dist
-dist: install $(DEB) $(DEB_IT) $(DEB_SCHEMA) .metadata
+dist: guard-VERSION install $(DEB) $(DEB_IT) $(DEB_SCHEMA) .metadata
 
 $(DEB):
 	makedeb --name=$(NAME) \

--- a/services/gundeck/Makefile
+++ b/services/gundeck/Makefile
@@ -1,6 +1,6 @@
 SHELL         := /usr/bin/env bash
 NAME          := gundeck
-VERSION       := $(shell sed -n 's/^version: *\(.*\)$$/\1/p' $(NAME).cabal)
+VERSION       ?=
 BUILD_NUMBER  ?= 0
 BUILD_LABEL   ?= local
 BUILD         := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
@@ -13,6 +13,12 @@ DEB_IT        := $(NAME)-integration_$(VERSION)+$(BUILD)_amd64.deb
 DEB_SCHEMA    := $(NAME)-schema_$(VERSION)+$(BUILD)_amd64.deb
 SDIST         := dist/$(NAME)-$(VERSION).tar.gz
 KEIRETSU_ENV  ?= ../.env
+
+guard-%:
+	@ if [ "${${*}}" = "" ]; then \
+	      echo "Environment variable $* not set"; \
+	    exit 1; \
+	fi
 
 default: clean install
 
@@ -38,7 +44,7 @@ clean:
 	-rm -f .metadata
 
 .PHONY: dist
-dist: install $(DEB) $(DEB_IT) $(DEB_SCHEMA) .metadata
+dist: guard-VERSION install $(DEB) $(DEB_IT) $(DEB_SCHEMA) .metadata
 
 $(DEB):
 	makedeb --name=$(NAME) \

--- a/services/proxy/Makefile
+++ b/services/proxy/Makefile
@@ -1,10 +1,16 @@
 SHELL        := /usr/bin/env bash
 NAME         := proxy
-VERSION      := $(shell sed -n 's/^version: *\(.*\)$$/\1/p' $(NAME).cabal)
+VERSION      ?=
 BUILD_NUMBER ?= 0
 BUILD_LABEL  ?= local
 BUILD        := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
 DEB          := $(NAME)_$(VERSION)+$(BUILD)_amd64.deb
+
+guard-%:
+	@ if [ "${${*}}" = "" ]; then \
+	      echo "Environment variable $* not set"; \
+	    exit 1; \
+	fi
 
 default: all
 
@@ -28,7 +34,7 @@ compile:
 	stack build --pedantic --test --no-copy-bins
 
 .PHONY: dist
-dist: install $(DEB) $(DEB_IT) .metadata
+dist: guard-VERSION install $(DEB) $(DEB_IT) .metadata
 
 $(DEB):
 	makedeb --name=$(NAME) \

--- a/tools/bonanza/Makefile
+++ b/tools/bonanza/Makefile
@@ -1,10 +1,14 @@
 SHELL        := /usr/bin/env bash
 NAME         := bonanza
-VERSION      := $(shell sed -n 's/^version: *\(.*\)$$/\1/p' $(NAME).cabal)
+VERSION      ?=
 BUILD_NUMBER ?= 0
 DEB          := dist/$(NAME)_$(VERSION)+$(BUILD_NUMBER)_amd64.deb
-SDIST        := dist/$(NAME)-$(VERSION).tar.gz
 
+guard-%:
+	@ if [ "${${*}}" = "" ]; then \
+	      echo "Environment variable $* not set"; \
+	    exit 1; \
+	fi
 
 default: all
 
@@ -27,11 +31,7 @@ compile:
 	stack build --fast --pedantic --test --no-copy-bins
 
 .PHONY: dist
-dist: $(DEB) $(SDIST)
-
-$(SDIST): init
-	stack sdist
-	cp "$(shell stack path --dist-dir)/$(NAME)-$(VERSION).tar.gz" dist/
+dist: guard-VERSION $(DEB)
 
 $(DEB): install
 	makedeb --name=$(NAME) \

--- a/tools/makedeb/Makefile
+++ b/tools/makedeb/Makefile
@@ -1,10 +1,16 @@
 SHELL        := /usr/bin/env bash
 NAME         := makedeb
-VERSION      := $(shell sed -n 's/^version: *\(.*\)$$/\1/p' $(NAME).cabal)
+VERSION      ?=
 BUILD_NUMBER ?= 0
 BUILD_LABEL  ?= local
 BUILD        := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
 DEB          := $(NAME)_$(VERSION)+$(BUILD)_amd64.deb
+
+guard-%:
+	@ if [ "${${*}}" = "" ]; then \
+	      echo "Environment variable $* not set"; \
+	    exit 1; \
+	fi
 
 default: all
 
@@ -27,13 +33,8 @@ install: init
 compile:
 	stack build --pedantic --test --no-copy-bins
 
-.PHONY: sdist
-sdist: init
-	stack sdist
-	cp "$(shell stack path --dist-dir)/$(NAME)-$(VERSION).tar.gz" dist/
-
 .PHONY: dist
-dist: sdist install $(DEB) .metadata
+dist: guard-VERSION install $(DEB) .metadata
 
 $(DEB):
 	$(eval $@_DIR := $(shell mktemp -d -t makedeb.XXXXXXXXXX))


### PR DESCRIPTION
`make dist` now depends on the `VERSION` environment variable.

Motivation: creating new build artifacts from a service should not depend on a developer bumping versions in the cabal file manually; build artifact versioning can be automated by CI jobs.