### PR TITLE
Support sharing of push tokens across users.

### DIFF
--- a/services/gundeck/Makefile
+++ b/services/gundeck/Makefile
@@ -91,7 +91,7 @@ integration-list: install
 	LOG_LEVEL=Info keiretsu --run '$(EXE_IT) -l; sleep 1' --env $(KEIRETSU_ENV)
 
 integration-%: install
-	LOG_LEVEL=Info keiretsu --run '$(EXE_IT) --pattern="$*"' --env $(KEIRETSU_ENV)
+	LOG_LEVEL=Info keiretsu --run '$(EXE_IT) --pattern="$*"; sleep 1' --env $(KEIRETSU_ENV)
 
 .PHONY: db
 db: db-reset

--- a/services/gundeck/src/Gundeck/Client.hs
+++ b/services/gundeck/src/Gundeck/Client.hs
@@ -13,19 +13,16 @@ import Control.Concurrent.Async.Lifted.Safe
 import Control.Lens (view, (^.), set)
 import Control.Monad
 import Control.Monad.Catch
-import Data.Foldable (for_)
 import Data.Id
 import Data.Maybe (isNothing)
 import Data.Predicate
-import Gundeck.Env (awsEnv)
 import Gundeck.Monad
-import Gundeck.Push.Native.Types
+import Gundeck.Push.Native
 import Gundeck.Util
 import Network.HTTP.Types
 import Network.Wai (Request, Response)
 import Network.Wai.Utilities
 
-import qualified Gundeck.Aws         as Aws
 import qualified Gundeck.Client.Data as Clients
 import qualified Gundeck.Push.Data   as Push
 
@@ -39,9 +36,8 @@ unregister (uid ::: cid) = do
     keys <- Clients.select uid cid
     when (isNothing keys) $
         throwM (Error status404 "not-found" "Client not found")
-    aa <- filter byClient <$> Push.lookup uid Push.Quorum
-    for_ aa $ \a ->
-        Push.delete (a^.addrUser) (a^.addrTransport) (a^.addrApp) (a^.addrToken)
+    toks <- filter byClient <$> Push.lookup uid Push.Quorum
+    deleteTokens toks Nothing
     Clients.remove uid cid
     return empty
   where
@@ -54,9 +50,8 @@ lookupKeys = mapConcurrently $ \a -> do
 
 removeUser :: UserId -> Gundeck Response
 removeUser user = do
-    env <- view awsEnv
-    let rm a = Aws.execute env (Aws.deleteEndpoint (a^.addrEndpoint))
-    Push.lookup user Push.Quorum >>= mapM_ rm
+    toks <- Push.lookup user Push.Quorum
+    deleteTokens toks Nothing
     Push.erase user
     Clients.erase user
     return empty


### PR DESCRIPTION
## Context

The desire to use multiple accounts from a single device and app
installation simultaneously, i.e. being logged into multiple accounts,
receiving push notifications for each. So far ownership of a push token
was restricted to a single user, mostly to avoid scenarios where push
notifications may end up being shown to an unintended recipient on a
device that is shared by multiple users and if the notifications contain
a payload in plain text.  Plain text payloads are no longer used.

## Changes

  1. Multiple users can have the same push token registered, without
     either being removed on registration of the other.
  2. The mapping from push tokens stored in gundeck (Cassandra) to SNS
     endpoints becomes N to 1. To that effect, `CustomUserData` of an SNS
     endpoint can now contain a list of user IDs, instead of just a single
     ID.
  3. When a push token is removed for any reason, the associated SNS
     endpoint is only deleted if it is not shared with other users,
     otherwise it is updated by removing the owner of the deleted token
     from the endpoints `CustomUserData`.
  4. The user ID of the intended recipient is included in push payloads
     of any type as plain metadata to allow the receiving device to
     associate it with the right account and thus use the correct keys and
     access tokens to decrypt or fetch the notification content,
     respectively.
  5. If a user registers a new token that replaces an old token, then if
     the old token has shared owners, they have their tokens (that are
     referring to the same outdated endpoint) updated as well.