### PR TITLE
Delete notifications of deleted users.

### DIFF
--- a/services/gundeck/src/Gundeck/Client.hs
+++ b/services/gundeck/src/Gundeck/Client.hs
@@ -23,8 +23,9 @@ import Network.HTTP.Types
 import Network.Wai (Request, Response)
 import Network.Wai.Utilities
 
-import qualified Gundeck.Client.Data as Clients
-import qualified Gundeck.Push.Data   as Push
+import qualified Gundeck.Client.Data       as Clients
+import qualified Gundeck.Notification.Data as Notifications
+import qualified Gundeck.Push.Data         as Push
 
 register :: UserId ::: ClientId ::: Request ::: JSON ::: JSON -> Gundeck Response
 register (uid ::: cid ::: req ::: _) = do
@@ -54,4 +55,5 @@ removeUser user = do
     deleteTokens toks Nothing
     Push.erase user
     Clients.erase user
+    Notifications.deleteAll user
     return empty

--- a/services/gundeck/src/Gundeck/Notification/Data.hs
+++ b/services/gundeck/src/Gundeck/Notification/Data.hs
@@ -9,6 +9,7 @@ module Gundeck.Notification.Data
     , fetch
     , fetchId
     , fetchLast
+    , deleteAll
     ) where
 
 import Cassandra
@@ -156,6 +157,12 @@ fetch u c since (fromRange -> size) = do
         \FROM notifications \
         \WHERE user = ? AND id >= ? \
         \ORDER BY id ASC"
+
+deleteAll :: MonadClient m => UserId -> m ()
+deleteAll u = write cql (params Quorum (Identity u)) & retry x5
+  where
+    cql :: PrepQuery W (Identity UserId) ()
+    cql = "DELETE FROM notifications WHERE user = ?"
 
 -------------------------------------------------------------------------------
 -- Conversions

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -127,12 +127,15 @@ removeUser s g c = do
     clt  <- randomClient g user
     tok  <- randomGcmToken clt
     _    <- registerPushToken user tok g
+    _    <- sendPush g (buildPush user [(user, [])] (textPayload "data"))
     deleteUser g user
+    ntfs <- listNotifications user Nothing g
     liftIO $ do
         keys   <- Cql.runClient s (Clients.select user clt)
         tokens <- Cql.runClient s (Push.lookup user Push.Quorum)
-        assertBool "clients gone" (isNothing keys)
-        assertBool "tokens gone" (null tokens)
+        isNothing keys @?= True
+        null tokens    @?= True
+        ntfs           @?= []
 
 replacePresence :: Gundeck -> Cannon -> Http ()
 replacePresence gu ca = do


### PR DESCRIPTION
Immediately delete all notifications of deleted users instead of just letting them expire.