### PR TITLE
Use consistency 'One' for (native) push key lookups.

### DIFF
--- a/services/gundeck/src/Gundeck/Client/Data.hs
+++ b/services/gundeck/src/Gundeck/Client/Data.hs
@@ -15,8 +15,9 @@ import Gundeck.Instances ()
 import Gundeck.Types
 import Prelude hiding (max)
 
+-- | Note: Consistency: 'One'
 select :: MonadClient m => UserId -> ClientId -> m (Maybe SignalingKeys)
-select u c = fmap (uncurry SignalingKeys) <$> query1 q (params Quorum (u, c))
+select u c = fmap (uncurry SignalingKeys) <$> query1 q (params One (u, c))
   where
     q :: QueryString R (UserId, ClientId) (EncKey, MacKey)
     q = "select enckey, mackey from clients where user = ? and client = ?"


### PR DESCRIPTION
The same motivation as in https://github.com/wireapp/wire-server/pull/25. Since these keys are updated comparatively rarely by clients but read all the time.

Upsides:

  * Increased chances of delivery of (native) push notifications in case of database-related network issues.
  * (Slightly?) improved latency.

Downsides:

  * Outdated keys may be used temporarily, e.g. for keys that have been changed shortly before a network partition occurs and for as long as the partition is not resolved.