### PR TITLE
HTML-encode all input of HTML templates.

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -119,6 +119,7 @@ library
       , fsnotify                  >= 0.2
       , iso639                    >= 0.1
       , hashable                  >= 1.2
+      , html-entities             >= 1.1
       , http-client               >= 0.5
       , http-client-openssl-ext   >= 0.1
       , http-types                >= 0.8

--- a/services/brig/src/Brig/Provider/Email.hs
+++ b/services/brig/src/Brig/Provider/Email.hs
@@ -15,7 +15,6 @@ import Brig.Types.Provider
 import Data.ByteString.Conversion
 import Data.Range
 import Data.Text (Text)
-import Data.Text.Template
 
 import qualified Brig.Types.Code    as Code
 import qualified Data.Text.Ascii    as Ascii
@@ -54,9 +53,9 @@ renderActivationMail ActivationEmail{..} ActivationEmailTemplate{..} =
 
     from = Address (Just "Wire") (fromEmail activationEmailSender)
     to   = mkMimeAddress acmName acmTo
-    txt  = render activationEmailBodyText replace
-    html = render activationEmailBodyHtml replace
-    subj = render activationEmailSubject  replace
+    txt  = renderText activationEmailBodyText replace
+    html = renderHtml activationEmailBodyHtml replace
+    subj = renderText activationEmailSubject  replace
 
     replace "url"   = renderActivationUrl activationEmailUrl acmKey acmCode
     replace "email" = fromEmail acmTo
@@ -65,7 +64,7 @@ renderActivationMail ActivationEmail{..} ActivationEmailTemplate{..} =
 
 renderActivationUrl :: Template -> Code.Key -> Code.Value -> Text
 renderActivationUrl t (Code.Key k) (Code.Value v) =
-    LT.toStrict $ render t replace
+    LT.toStrict $ renderText t replace
   where
     replace "key"  = Ascii.toText (fromRange k)
     replace "code" = Ascii.toText (fromRange v)
@@ -101,9 +100,9 @@ renderApprovalRequestMail ApprovalRequestEmail{..} ApprovalRequestEmailTemplate{
   where
     from = Address (Just "Wire")       (fromEmail approvalRequestEmailSender)
     to   = Address (Just "Wire Staff") (fromEmail approvalRequestEmailTo)
-    txt  = render approvalRequestEmailBodyText replace
-    html = render approvalRequestEmailBodyHtml replace
-    subj = render approvalRequestEmailSubject  replace
+    txt  = renderText approvalRequestEmailBodyText replace
+    html = renderHtml approvalRequestEmailBodyHtml replace
+    subj = renderText approvalRequestEmailSubject  replace
 
     replace "email"       = fromEmail aprTo
     replace "name"        = fromName aprName
@@ -115,7 +114,7 @@ renderApprovalRequestMail ApprovalRequestEmail{..} ApprovalRequestEmailTemplate{
 -- TODO: Unify with renderActivationUrl
 renderApprovalUrl :: Template -> Code.Key -> Code.Value -> Text
 renderApprovalUrl t (Code.Key k) (Code.Value v) =
-    LT.toStrict $ render t replace
+    LT.toStrict $ renderText t replace
   where
     replace "key"  = Ascii.toText (fromRange k)
     replace "code" = Ascii.toText (fromRange v)
@@ -147,9 +146,9 @@ renderApprovalConfirmMail ApprovalConfirmEmail{..} ApprovalConfirmEmailTemplate{
   where
     from = Address (Just "Wire") (fromEmail approvalConfirmEmailSender)
     to   = mkMimeAddress apcName apcTo
-    txt  = render approvalConfirmEmailBodyText replace
-    html = render approvalConfirmEmailBodyHtml replace
-    subj = render approvalConfirmEmailSubject  replace
+    txt  = renderText approvalConfirmEmailBodyText replace
+    html = renderHtml approvalConfirmEmailBodyHtml replace
+    subj = renderText approvalConfirmEmailSubject  replace
 
     replace "homeUrl" = Text.decodeUtf8 (toByteString' approvalConfirmEmailHomeUrl)
     replace "email"   = fromEmail apcTo

--- a/services/brig/src/Brig/Provider/Template.hs
+++ b/services/brig/src/Brig/Provider/Template.hs
@@ -8,6 +8,11 @@ module Brig.Provider.Template
     , ApprovalConfirmEmailTemplate (..)
     -- , TODO: NewServiceEmailTemplate   (..)
     , loadProviderTemplates
+
+      -- * Re-exports
+    , Template
+    , renderText
+    , renderHtml
     ) where
 
 import Brig.Options

--- a/services/brig/src/Brig/Team/Email.hs
+++ b/services/brig/src/Brig/Team/Email.hs
@@ -13,7 +13,6 @@ import Brig.Types
 import Data.Id (idToText, TeamId)
 import Data.Text (Text)
 import Data.Text.Lazy (toStrict)
-import Data.Text.Template
 
 import qualified Brig.Aws        as Aws
 import qualified Data.Text.Ascii as Ascii
@@ -49,9 +48,9 @@ renderInvitationEmail InvitationEmail{..} InvitationEmailTemplate{..} =
 
     from = Address (Just invitationEmailSenderName) (fromEmail invitationEmailSender)
     to   = mkMimeAddress invInviterName invTo
-    txt  = render invitationEmailBodyText replace
-    html = render invitationEmailBodyHtml replace
-    subj = render invitationEmailSubject  replace
+    txt  = renderText invitationEmailBodyText replace
+    html = renderHtml invitationEmailBodyHtml replace
+    subj = renderText invitationEmailSubject  replace
 
     replace "url"      = renderInvitationUrl invitationEmailUrl invTeamId invInvCode
     replace "email"    = fromEmail invTo
@@ -61,7 +60,7 @@ renderInvitationEmail InvitationEmail{..} InvitationEmailTemplate{..} =
 
 renderInvitationUrl :: Template -> TeamId -> InvitationCode -> Text
 renderInvitationUrl t tid (InvitationCode c) =
-    toStrict $ render t replace
+    toStrict $ renderText t replace
   where
     replace "team" = idToText tid
     replace "code" = Ascii.toText c

--- a/services/brig/src/Brig/Team/Template.hs
+++ b/services/brig/src/Brig/Team/Template.hs
@@ -5,6 +5,11 @@ module Brig.Team.Template
     ( TeamTemplates              (..)
     , InvitationEmailTemplate    (..)
     , loadTeamTemplates
+
+      -- * Re-exports
+    , Template
+    , renderText
+    , renderHtml
     ) where
 
 import Brig.Options

--- a/services/brig/src/Brig/Template.hs
+++ b/services/brig/src/Brig/Template.hs
@@ -3,14 +3,16 @@
 
 -- | Common templating utilities.
 module Brig.Template
-    ( -- * Localised templates
+    ( -- * Reading templates
       Localised
     , forLocale
     , readLocalesDir
-
-      -- * Reading files
     , readTemplate
     , readText
+
+      -- * Rendering templates
+    , renderText
+    , renderHtml
 
       -- * Re-exports
     , Template
@@ -24,7 +26,7 @@ import Data.Map.Strict (Map)
 import Data.Maybe
 import Data.Monoid
 import Data.Text (Text, pack, unpack)
-import Data.Text.Template
+import Data.Text.Template (Template, template)
 import System.Directory (getDirectoryContents)
 import System.IO.Error (isDoesNotExistError)
 import Prelude hiding (readFile)
@@ -32,6 +34,9 @@ import Prelude hiding (readFile)
 import qualified Data.ByteString    as BS
 import qualified Data.Map.Strict    as Map
 import qualified Data.Text.Encoding as T
+import qualified Data.Text.Lazy     as Lazy
+import qualified Data.Text.Template as Template
+import qualified HTMLEntities.Text  as HTML
 
 -- | Localised templates.
 data Localised a = Localised
@@ -91,4 +96,10 @@ readText :: FilePath -> IO Text
 readText f = catchJust (\e -> if isDoesNotExistError e then Just () else Nothing)
                        (readFile f)
                        (\_ -> error $ "Missing file: '" ++ f)
+
+renderText :: Template -> (Text -> Text) -> Lazy.Text
+renderText = Template.render
+
+renderHtml :: Template -> (Text -> Text) -> Lazy.Text
+renderHtml tpl f = renderText tpl (HTML.text . f)
 

--- a/services/brig/src/Brig/User/Email.hs
+++ b/services/brig/src/Brig/User/Email.hs
@@ -30,7 +30,6 @@ import Data.Maybe (fromMaybe, isNothing)
 import Data.Range
 import Data.Text (Text)
 import Data.Text.Lazy (toStrict)
-import Data.Text.Template
 
 import qualified Brig.Aws        as Aws
 import qualified Brig.Types.Code as Code
@@ -91,9 +90,9 @@ renderNewClientEmail NewClientEmailTemplate{..} NewClientEmail{..} =
   where
     from = Address (Just newClientEmailSenderName) (fromEmail newClientEmailSender)
     to   = mkMimeAddress nclName nclTo
-    txt  = render newClientEmailBodyText replace
-    html = render newClientEmailBodyHtml replace
-    subj = render newClientEmailSubject  replace
+    txt  = renderText newClientEmailBodyText replace
+    html = renderHtml newClientEmailBodyHtml replace
+    subj = renderText newClientEmailSubject  replace
 
     replace "name"  = fromName nclName
     replace "label" = fromMaybe "N/A" (clientLabel nclClient)
@@ -128,14 +127,14 @@ renderDeletionEmail DeletionEmailTemplate{..} DeletionEmail{..} =
     from = Address (Just deletionEmailSenderName) (fromEmail deletionEmailSender)
     to   = mkMimeAddress delName delTo
 
-    txt  = render deletionEmailBodyText replace1
-    html = render deletionEmailBodyHtml replace1
-    subj = render deletionEmailSubject  replace1
+    txt  = renderText deletionEmailBodyText replace1
+    html = renderHtml deletionEmailBodyHtml replace1
+    subj = renderText deletionEmailSubject  replace1
 
     key  = Ascii.toText (fromRange (Code.asciiKey delKey))
     code = Ascii.toText (fromRange (Code.asciiValue delCode))
 
-    replace1 "url"   = toStrict (render deletionEmailUrl replace2)
+    replace1 "url"   = toStrict (renderText deletionEmailUrl replace2)
     replace1 "email" = fromEmail delTo
     replace1 "name"  = fromName delName
     replace1 x       = x
@@ -169,9 +168,9 @@ renderActivationMail ActivationEmail{..} ActivationEmailTemplate{..} =
 
     from = Address (Just activationEmailSenderName) (fromEmail activationEmailSender)
     to   = mkMimeAddress acmName acmTo
-    txt  = render activationEmailBodyText replace
-    html = render activationEmailBodyHtml replace
-    subj = render activationEmailSubject  replace
+    txt  = renderText activationEmailBodyText replace
+    html = renderHtml activationEmailBodyHtml replace
+    subj = renderText activationEmailSubject  replace
 
     replace "url"   = renderActivationUrl activationEmailUrl acmPair
     replace "email" = fromEmail acmTo
@@ -180,7 +179,7 @@ renderActivationMail ActivationEmail{..} ActivationEmailTemplate{..} =
 
 renderActivationUrl :: Template -> ActivationPair -> Text
 renderActivationUrl t (ActivationKey k, ActivationCode c) =
-    toStrict $ render t replace
+    toStrict $ renderText t replace
   where
     replace "key"  = Ascii.toText k
     replace "code" = Ascii.toText c
@@ -210,16 +209,16 @@ renderPwResetMail PasswordResetEmail{..} PasswordResetEmailTemplate{..} =
 
     from = Address (Just passwordResetEmailSenderName) (fromEmail passwordResetEmailSender)
     to   = Address Nothing (fromEmail pwrTo)
-    txt  = render passwordResetEmailBodyText replace
-    html = render passwordResetEmailBodyHtml replace
-    subj = render passwordResetEmailSubject  replace
+    txt  = renderText passwordResetEmailBodyText replace
+    html = renderHtml passwordResetEmailBodyHtml replace
+    subj = renderText passwordResetEmailSubject  replace
 
     replace "url" = renderPwResetUrl passwordResetEmailUrl pwrPair
     replace x     = x
 
 renderPwResetUrl :: Template -> PasswordResetPair -> Text
 renderPwResetUrl t (PasswordResetKey k, PasswordResetCode c) =
-    toStrict $ render t replace
+    toStrict $ renderText t replace
   where
     replace "key"  = Ascii.toText k
     replace "code" = Ascii.toText c
@@ -251,9 +250,9 @@ renderInvitationEmail InvitationEmail{..} InvitationEmailTemplate{..} =
 
     from = Address (Just invitationEmailSenderName) (fromEmail invitationEmailSender)
     to   = mkMimeAddress invInviteeName invTo
-    txt  = render invitationEmailBodyText replace
-    html = render invitationEmailBodyHtml replace
-    subj = render invitationEmailSubject  replace
+    txt  = renderText invitationEmailBodyText replace
+    html = renderHtml invitationEmailBodyHtml replace
+    subj = renderText invitationEmailSubject  replace
 
     replace "url"      = renderInvitationUrl invitationEmailUrl invInvCode
     replace "email"    = fromEmail invTo
@@ -264,7 +263,7 @@ renderInvitationEmail InvitationEmail{..} InvitationEmailTemplate{..} =
 
 renderInvitationUrl :: Template -> InvitationCode -> Text
 renderInvitationUrl t (InvitationCode c) =
-    toStrict $ render t replace
+    toStrict $ renderText t replace
   where
     replace "code" = Ascii.toText c
     replace x      = x

--- a/services/brig/src/Brig/User/Phone.hs
+++ b/services/brig/src/Brig/User/Phone.hs
@@ -34,7 +34,6 @@ import Brig.Types.User.Auth (LoginCode (..))
 import Data.Range
 import Data.Text (Text, chunksOf, intercalate, toLower)
 import Data.Text.Lazy (toStrict)
-import Data.Text.Template
 
 import qualified Brig.Types.Code as Code
 import qualified Data.Text.Ascii as Ascii
@@ -80,7 +79,7 @@ data ActivationSms = ActivationSms
 
 renderActivationSms :: ActivationSms -> ActivationSmsTemplate -> SMSMessage
 renderActivationSms ActivationSms{..} (ActivationSmsTemplate url t from) =
-    SMSMessage from (fromPhone actSmsTo) (toStrict $ render t replace)
+    SMSMessage from (fromPhone actSmsTo) (toStrict $ renderText t replace)
   where
     replace "code" = codeText
     replace "url"  = renderSmsActivationUrl url codeText
@@ -98,7 +97,7 @@ data PasswordResetSms = PasswordResetSms
 
 renderPasswordResetSms :: PasswordResetSms -> PasswordResetSmsTemplate -> SMSMessage
 renderPasswordResetSms PasswordResetSms{..} (PasswordResetSmsTemplate t from) =
-    SMSMessage from (fromPhone pwrSmsTo) (toStrict $ render t replace)
+    SMSMessage from (fromPhone pwrSmsTo) (toStrict $ renderText t replace)
   where
     replace "code" = Ascii.toText (fromPasswordResetCode pwrSmsCode)
     replace x      = x
@@ -113,7 +112,7 @@ data LoginSms = LoginSms
 
 renderLoginSms :: LoginSms -> LoginSmsTemplate -> SMSMessage
 renderLoginSms LoginSms{..} (LoginSmsTemplate url t from) =
-    SMSMessage from (fromPhone loginSmsTo) (toStrict $ render t replace)
+    SMSMessage from (fromPhone loginSmsTo) (toStrict $ renderText t replace)
   where
     replace "code" = fromLoginCode loginSmsCode
     replace "url"  = renderSmsActivationUrl url (fromLoginCode loginSmsCode)
@@ -130,10 +129,10 @@ data DeletionSms = DeletionSms
 
 renderDeletionSms :: DeletionSms -> DeletionSmsTemplate -> SMSMessage
 renderDeletionSms DeletionSms{..} (DeletionSmsTemplate url txt from) =
-    SMSMessage from (fromPhone delSmsTo) (toStrict $ render txt replace1)
+    SMSMessage from (fromPhone delSmsTo) (toStrict $ renderText txt replace1)
   where
     replace1 "code" = Ascii.toText (fromRange (Code.asciiValue delSmsCode))
-    replace1 "url"  = toStrict (render url replace2)
+    replace1 "url"  = toStrict (renderText url replace2)
     replace1 x      = x
 
     replace2 "key"  = Ascii.toText (fromRange (Code.asciiKey delSmsKey))
@@ -152,7 +151,7 @@ renderActivationCall :: ActivationCall -> ActivationCallTemplate -> Locale -> Ne
 renderActivationCall ActivationCall{..} (ActivationCallTemplate t) loc =
     Nexmo.Call Nothing
                (fromPhone actCallTo)
-               (toStrict $ render t replace)
+               (toStrict $ renderText t replace)
                (Just . toLower $ locToText loc)
                (Just 1)
   where
@@ -171,7 +170,7 @@ renderLoginCall :: LoginCall -> LoginCallTemplate -> Locale -> Nexmo.Call
 renderLoginCall LoginCall{..} (LoginCallTemplate t) loc =
     Nexmo.Call Nothing
                (fromPhone loginCallTo)
-               (toStrict $ render t replace)
+               (toStrict $ renderText t replace)
                (Just . toLower $ locToText loc)
                (Just 1)
   where
@@ -187,7 +186,7 @@ toPinPrompt = intercalate "<break time=\"750ms\"/>" . chunksOf 1
 
 renderSmsActivationUrl :: Template -> Text -> Text
 renderSmsActivationUrl t c =
-    toStrict $ render t replace
+    toStrict $ renderText t replace
   where
     replace "code" = c
     replace x      = x

--- a/services/brig/src/Brig/User/Template.hs
+++ b/services/brig/src/Brig/User/Template.hs
@@ -16,6 +16,11 @@ module Brig.User.Template
     , DeletionEmailTemplate      (..)
     , NewClientEmailTemplate     (..)
     , loadUserTemplates
+
+      -- * Re-exports
+    , Template
+    , renderText
+    , renderHtml
     ) where
 
 import Brig.Options

--- a/services/brig/stack.yaml
+++ b/services/brig/stack.yaml
@@ -39,6 +39,7 @@ extra-deps:
 - data-textual-0.3.0.2
 - data-timeout-0.3
 - geoip2-0.2.2.0
+- html-entities-1.1.4.1
 - raw-strings-qq-1.0.2
 - text-icu-translit-0.1.0.7
 - text-latin1-0.3


### PR DESCRIPTION
To prevent / disallow arbitrary HTML injection in scenarios where input to templates directly or indirectly originates from user input (e.g. primarily current invitation emails).