### PR TITLE
Upgrade to nginx-1.12.1

### DIFF
--- a/services/nginz/Makefile
+++ b/services/nginz/Makefile
@@ -1,6 +1,6 @@
 SHELL          := /usr/bin/env bash
 NAME           := nginz
-NGINX_VERSION   = 1.12.0
+NGINX_VERSION   = 1.12.1
 NGINZ_VERSION  ?=
 SHELL          := /usr/bin/env bash
 DIST           := build


### PR DESCRIPTION
Upgrading to `1.12.1` due to:

```
2017-07-11 | nginx-1.12.1 stable and nginx-1.13.3 mainline versions have been released with a fix for theinteger overflow in the range filter vulnerability (CVE-2017-7529).
```

 http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7529
