### PR TITLE
Fix collectd dependency

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -34,12 +34,15 @@ packages:
     git: https://github.com/wireapp/cryptobox-haskell
     commit: 7546a1a25635ef65183e3d44c1052285e8401608
   extra-dep: true
+- location:
+    git: https://github.com/kim/hs-collectd
+    commit: '0.0.0.2'
+  extra-dep: true
 
 extra-deps:
 - aws-0.16
 - base58-bytestring-0.1.0
 - bloodhound-0.13.0.0
-- collectd-0.0.0.1
 - data-timeout-0.3
 - geoip2-0.2.2.0
 - html-entities-1.1.4.1


### PR DESCRIPTION
The collectd dependency is not on stackage, so this adds the github dependency. Uses the latest version, 0.0.0.2.