### PR TITLE
Add missing re-exports to other swagger models

### DIFF
--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -91,6 +91,10 @@ brigModels =
       -- TURN
     , rtcConfiguration
     , rtcIceServer
+
+      -- Re-Exports
+    , Galley.newBindingTeam
+    , Galley.serviceRef
     ]
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
If we don't re-export the swagger models (and thus return them from the API endpoint), then the swagger client cannot display them properly