### PR TITLE
Add alpine-based nginz Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 HASKELL_SERVICES := proxy cannon cargohold brig galley gundeck
+SERVICES         := $(HASKELL_SERVICES) nginz
 
 .PHONY: docker-services
 docker-services:
 	$(MAKE) -C build/alpine
-	$(foreach service,$(HASKELL_SERVICES),$(MAKE) -C services/$(service) docker;)
+	$(foreach service,$(SERVICES),$(MAKE) -C services/$(service) docker;)
 

--- a/services/nginz/Dockerfile
+++ b/services/nginz/Dockerfile
@@ -41,34 +41,6 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
         --group=nginx \
         --with-http_ssl_module \
         --with-http_stub_status_module \
-        --with-http_ssl_module \
-        --with-http_realip_module \
-        --with-http_addition_module \
-        --with-http_sub_module \
-        --with-http_dav_module \
-        --with-http_flv_module \
-        --with-http_mp4_module \
-        --with-http_gunzip_module \
-        --with-http_gzip_static_module \
-        --with-http_random_index_module \
-        --with-http_secure_link_module \
-        --with-http_stub_status_module \
-        --with-http_auth_request_module \
-        --with-http_xslt_module=dynamic \
-        --with-http_image_filter_module=dynamic \
-        --with-http_geoip_module=dynamic \
-        --with-threads \
-        --with-stream \
-        --with-stream_ssl_module \
-        --with-stream_ssl_preread_module \
-        --with-stream_realip_module \
-        --with-stream_geoip_module=dynamic \
-        --with-http_slice_module \
-        --with-mail \
-        --with-mail_ssl_module \
-        --with-compat \
-        --with-file-aio \
-        --with-http_v2_module \
         --add-module=/src/third_party/nginx-zauth-module \
         --add-module=/src/third_party/headers-more-nginx-module \
         --add-module=/src/third_party/nginx-module-vts \
@@ -111,10 +83,6 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
     && ./configure $CONFIG --with-debug \
     && make -j$(getconf _NPROCESSORS_ONLN) \
     && mv objs/nginx objs/nginx-debug \
-    && mv objs/ngx_http_xslt_filter_module.so objs/ngx_http_xslt_filter_module-debug.so \
-    && mv objs/ngx_http_image_filter_module.so objs/ngx_http_image_filter_module-debug.so \
-    && mv objs/ngx_http_geoip_module.so objs/ngx_http_geoip_module-debug.so \
-    && mv objs/ngx_stream_geoip_module.so objs/ngx_stream_geoip_module-debug.so \
     && ./configure $CONFIG \
     && make -j$(getconf _NPROCESSORS_ONLN) \
     && make install \
@@ -124,13 +92,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
     && install -m644 html/index.html /usr/share/nginx/html/ \
     && install -m644 html/50x.html /usr/share/nginx/html/ \
     && install -m755 objs/nginx-debug /usr/sbin/nginx-debug \
-    && install -m755 objs/ngx_http_xslt_filter_module-debug.so /usr/lib/nginx/modules/ngx_http_xslt_filter_module-debug.so \
-    && install -m755 objs/ngx_http_image_filter_module-debug.so /usr/lib/nginx/modules/ngx_http_image_filter_module-debug.so \
-    && install -m755 objs/ngx_http_geoip_module-debug.so /usr/lib/nginx/modules/ngx_http_geoip_module-debug.so \
-    && install -m755 objs/ngx_stream_geoip_module-debug.so /usr/lib/nginx/modules/ngx_stream_geoip_module-debug.so \
     && ln -s ../../usr/lib/nginx/modules /etc/nginx/modules \
     && strip /usr/sbin/nginx* \
-    && strip /usr/lib/nginx/modules/*.so \
     && rm -rf /usr/src/nginx-$NGINX_VERSION \
     \
     # Bring in gettext so we can get `envsubst`, then throw

--- a/services/nginz/Dockerfile
+++ b/services/nginz/Dockerfile
@@ -1,0 +1,162 @@
+# Requires docker >= 17.05 (requires support for multi-stage builds)
+FROM alpine:3.6 as libzauth-builder
+
+# Compile libzauth
+COPY libs/libzauth /src/libzauth
+RUN cd /src/libzauth/libzauth-c \
+    && export PREFIX=/usr \
+    && apk add --no-cache make bash cargo libsodium-dev \
+    && make install
+
+# Nginz container
+FROM alpine:3.6
+
+ENV NGINX_VERSION 1.12.1
+
+# Install libzauth
+COPY --from=libzauth-builder /usr/include/zauth.h /usr/include/zauth.h
+COPY --from=libzauth-builder /usr/lib/libzauth.so /usr/lib/libzauth.so
+COPY --from=libzauth-builder /usr/lib/pkgconfig/libzauth.pc /usr/lib/pkgconfig/libzauth.pc
+
+COPY services/nginz/third_party /src/third_party
+
+# Install nginz (nginx including the zauth module)
+# (taken mostly from https://github.com/nginxinc/docker-nginx/blob/master/stable/alpine/Dockerfile)
+RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
+    && CONFIG="\
+        --prefix=/etc/nginx \
+        --sbin-path=/usr/sbin/nginx \
+        --modules-path=/usr/lib/nginx/modules \
+        --conf-path=/etc/nginx/nginx.conf \
+        --error-log-path=/var/log/nginx/error.log \
+        --http-log-path=/var/log/nginx/access.log \
+        --pid-path=/var/run/nginx.pid \
+        --lock-path=/var/run/nginx.lock \
+        --http-client-body-temp-path=/var/cache/nginx/client_temp \
+        --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+        --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
+        --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+        --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
+        --user=nginx \
+        --group=nginx \
+        --with-http_ssl_module \
+        --with-http_stub_status_module \
+        --with-http_ssl_module \
+        --with-http_realip_module \
+        --with-http_addition_module \
+        --with-http_sub_module \
+        --with-http_dav_module \
+        --with-http_flv_module \
+        --with-http_mp4_module \
+        --with-http_gunzip_module \
+        --with-http_gzip_static_module \
+        --with-http_random_index_module \
+        --with-http_secure_link_module \
+        --with-http_stub_status_module \
+        --with-http_auth_request_module \
+        --with-http_xslt_module=dynamic \
+        --with-http_image_filter_module=dynamic \
+        --with-http_geoip_module=dynamic \
+        --with-threads \
+        --with-stream \
+        --with-stream_ssl_module \
+        --with-stream_ssl_preread_module \
+        --with-stream_realip_module \
+        --with-stream_geoip_module=dynamic \
+        --with-http_slice_module \
+        --with-mail \
+        --with-mail_ssl_module \
+        --with-compat \
+        --with-file-aio \
+        --with-http_v2_module \
+        --add-module=/src/third_party/nginx-zauth-module \
+        --add-module=/src/third_party/headers-more-nginx-module \
+        --add-module=/src/third_party/nginx-module-vts \
+    " \
+    && addgroup -g 666 -S nginx \
+    && adduser -u 666 -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
+    && apk add --no-cache --virtual .build-deps \
+        libsodium-dev \
+        llvm-libunwind-dev \
+        gcc \
+        libc-dev \
+        make \
+        openssl-dev \
+        pcre-dev \
+        zlib-dev \
+        linux-headers \
+        curl \
+        gnupg \
+        libxslt-dev \
+        gd-dev \
+        geoip-dev \
+    && curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
+    && curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
+    && found=''; \
+    for server in \
+        ha.pool.sks-keyservers.net \
+        hkp://keyserver.ubuntu.com:80 \
+        hkp://p80.pool.sks-keyservers.net:80 \
+        pgp.mit.edu \
+    ; do \
+        echo "Fetching GPG key $GPG_KEYS from $server"; \
+        gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$GPG_KEYS" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch GPG key $GPG_KEYS" && exit 1; \
+    gpg --batch --verify nginx.tar.gz.asc nginx.tar.gz \
+    && mkdir -p /usr/src \
+    && tar -zxC /usr/src -f nginx.tar.gz \
+    && rm nginx.tar.gz \
+    && cd /usr/src/nginx-$NGINX_VERSION \
+    && ./configure $CONFIG --with-debug \
+    && make -j$(getconf _NPROCESSORS_ONLN) \
+    && mv objs/nginx objs/nginx-debug \
+    && mv objs/ngx_http_xslt_filter_module.so objs/ngx_http_xslt_filter_module-debug.so \
+    && mv objs/ngx_http_image_filter_module.so objs/ngx_http_image_filter_module-debug.so \
+    && mv objs/ngx_http_geoip_module.so objs/ngx_http_geoip_module-debug.so \
+    && mv objs/ngx_stream_geoip_module.so objs/ngx_stream_geoip_module-debug.so \
+    && ./configure $CONFIG \
+    && make -j$(getconf _NPROCESSORS_ONLN) \
+    && make install \
+    && rm -rf /etc/nginx/html/ \
+    && mkdir /etc/nginx/conf.d/ \
+    && mkdir -p /usr/share/nginx/html/ \
+    && install -m644 html/index.html /usr/share/nginx/html/ \
+    && install -m644 html/50x.html /usr/share/nginx/html/ \
+    && install -m755 objs/nginx-debug /usr/sbin/nginx-debug \
+    && install -m755 objs/ngx_http_xslt_filter_module-debug.so /usr/lib/nginx/modules/ngx_http_xslt_filter_module-debug.so \
+    && install -m755 objs/ngx_http_image_filter_module-debug.so /usr/lib/nginx/modules/ngx_http_image_filter_module-debug.so \
+    && install -m755 objs/ngx_http_geoip_module-debug.so /usr/lib/nginx/modules/ngx_http_geoip_module-debug.so \
+    && install -m755 objs/ngx_stream_geoip_module-debug.so /usr/lib/nginx/modules/ngx_stream_geoip_module-debug.so \
+    && ln -s ../../usr/lib/nginx/modules /etc/nginx/modules \
+    && strip /usr/sbin/nginx* \
+    && strip /usr/lib/nginx/modules/*.so \
+    && rm -rf /usr/src/nginx-$NGINX_VERSION \
+    \
+    # Bring in gettext so we can get `envsubst`, then throw
+    # the rest away. To do this, we need to install `gettext`
+    # then move `envsubst` out of the way so `gettext` can
+    # be deleted completely, then move `envsubst` back.
+    && apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /usr/sbin/nginx /usr/lib/nginx/modules/*.so /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache --virtual .nginx-rundeps $runDeps \
+    && apk del .build-deps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/ \
+    \
+    # add libzauth runtime dependencies back in
+    && apk add --no-cache libsodium llvm-libunwind \
+    \
+    # forward request and error logs to docker log collector
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/services/nginz/Makefile
+++ b/services/nginz/Makefile
@@ -78,3 +78,8 @@ src: $(TMPDIR)/$(BUNDLE)
 $(TMPDIR)/$(BUNDLE):
 	(cd $(TMPDIR); curl -O https://nginx.org/download/$(BUNDLE).asc)
 	(cd $(TMPDIR); curl -O https://nginx.org/download/$(BUNDLE))
+
+.PHONY: docker
+docker:
+	git submodule update --init
+	docker build -f ../../services/nginz/Dockerfile -t nginz ../..

--- a/services/nginz/Makefile
+++ b/services/nginz/Makefile
@@ -82,4 +82,4 @@ $(TMPDIR)/$(BUNDLE):
 .PHONY: docker
 docker:
 	git submodule update --init
-	docker build -f ../../services/nginz/Dockerfile -t nginz ../..
+	docker build -f Dockerfile -t nginz ../..


### PR DESCRIPTION
Based on the official nginx alpine Dockerfile (but includes the zauth module). Does not contain any configuration (needs to be provided at run-time). Results in a ~15MB container uncompressed.