### PR TITLE
Fix gundeck and cannon links in brig readme

### DIFF
--- a/services/brig/README.md
+++ b/services/brig/README.md
@@ -1,7 +1,7 @@
 ## Brig
 
-The main vessel of the server fleet with a dedicated [gundeck](https://github.com/wire-server/services/gundeck/)
-carrying the [cannons](https://github.com/wire-server/services/cannon/).
+The main vessel of the server fleet with a dedicated [gundeck](https://github.com/wireapp/wire-server/blob/develop/services/gundeck/)
+carrying the [cannons](https://github.com/wireapp/wire-server/blob/develop/services/cannon/).
 
 ## Table of Contents
 


### PR DESCRIPTION
Both links were broken.