### PR TITLE
Allow 1to1 conversations inside a binding team

### DIFF
--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -554,7 +554,7 @@ instance ToJSON ConvTeamInfo where
 
 instance FromJSON ConvTeamInfo where
     parseJSON = withObject "conversation team info" $ \o ->
-        ConvTeamInfo <$> o .: "teamid" <*> o .: "managed"
+        ConvTeamInfo <$> o .: "teamid" <*> o .:? "managed" .!= False
 
 instance FromJSON Invite where
     parseJSON = withObject "invite object"

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -423,7 +423,7 @@ sitemap = do
         body (ref Model.newConversation) $
             description "JSON body"
         response 201 "Conversation created" end
-        errorResponse Error.noTeamConv
+        errorResponse Error.noManagedTeamConv
 
     ---
 

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -11,13 +11,12 @@ module Galley.API.Create
     ) where
 
 import Control.Lens hiding ((??))
-import Control.Monad (when, void)
+import Control.Monad (when, void, unless)
 import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Data.Foldable (for_, toList)
 import Data.Id
 import Data.List1
-import Data.Maybe (isJust)
 import Data.Monoid ((<>))
 import Data.Range
 import Data.Set ((\\))
@@ -94,20 +93,28 @@ createSelfConversation zusr = do
 
 createOne2OneConversation :: UserId ::: ConnId ::: Request ::: JSON -> Galley Response
 createOne2OneConversation (zusr ::: zcon ::: req ::: _) = do
-    j <- fromBody req invalidPayload
-    when (isJust (newConvTeam j)) $
-        throwM noTeamConv
-    u <- rangeChecked (newConvUsers j) :: Galley (Range 1 1 [UserId])
-    (x, y) <- toUUIDs zusr (List.head $ fromRange u)
+    j      <- fromBody req invalidPayload
+    other  <- List.head . fromRange <$> (rangeChecked (newConvUsers j) :: Galley (Range 1 1 [UserId]))
+    (x, y) <- toUUIDs zusr other
     when (x == y) $
         throwM $ invalidOp "Cannot create a 1-1 with yourself"
-    ensureConnected zusr (fromRange u)
+    case newConvTeam j of
+        Just ti | cnvManaged ti -> throwM noManagedTeamConv
+                | otherwise     -> checkBindingTeamPermissions zusr other (cnvTeamId ti)
+        Nothing -> ensureConnected zusr [other]
     n <- rangeCheckedMaybe (newConvName j)
     c <- Data.conversation (Data.one2OneConvId x y)
-    maybe (create x y n) (conversationResponse status200 zusr) c
+    maybe (create x y n $ newConvTeam j) (conversationResponse status200 zusr) c
   where
-    create x y n = do
-        c <- Data.createOne2OneConversation x y n
+    checkBindingTeamPermissions x y tid = do
+        mems <- bindingTeamMembers tid
+        void $ permissionCheck zusr CreateConversation mems
+        let users = x : [y]
+        unless (sameTeam users mems == users) $
+            throwM noBindingTeamMembers
+
+    create x y n tinfo = do
+        c <- Data.createOne2OneConversation x y n (cnvTeamId <$> tinfo)
         notifyCreatedConversation Nothing zusr (Just zcon) c
         conversationResponse status201 zusr c
 

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -75,8 +75,8 @@ tooManyTeamMembers = Error status403 "too-many-team-members" "Maximum number of 
 teamMemberNotFound :: Error
 teamMemberNotFound = Error status404 "no-team-member" "team member not found"
 
-noTeamConv :: Error
-noTeamConv = Error status400 "no-team-conv" "Team conversations are not allowed in this context."
+noManagedTeamConv :: Error
+noManagedTeamConv = Error status400 "no-managed-team-conv" "Managed team conversations are not allowed in this context."
 
 userBindingExists :: Error
 userBindingExists = Error status403 "binding-exists" "User already bound to a different team."
@@ -89,3 +89,6 @@ deleteQueueFull = Error status503 "queue-full" "The delete queue is full. No fur
 
 nonBindingTeam :: Error
 nonBindingTeam = Error status404 "non-binding-team" "not member of a binding team"
+
+noBindingTeamMembers :: Error
+noBindingTeamMembers = Error status403 "non-binding-team-members" "Both users must be members of the same binding team."

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -393,10 +393,6 @@ finishCreateTeam team owner others zcon = do
 
 getBindingTeamMembers :: UserId -> Galley Response
 getBindingTeamMembers zusr = do
-    tid <- Data.oneUserTeam zusr >>= ifNothing teamNotFound
-    binding <- Data.teamBinding tid >>= ifNothing teamNotFound
-    case binding of
-        Binding -> do
-            members <- Data.teamMembers tid
-            pure $ json $ teamMemberListJson True (newTeamMemberList members)
-        NonBinding -> throwM nonBindingTeam
+    tid  <- Data.oneUserTeam zusr >>= ifNothing teamNotFound
+    mems <- bindingTeamMembers tid
+    pure $ json $ teamMemberListJson True (newTeamMemberList mems)

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -60,6 +60,13 @@ ensureReAuthorised u secret = do
     unless reAuthed $
         throwM reAuthFailed
 
+bindingTeamMembers :: TeamId -> Galley [TeamMember]
+bindingTeamMembers tid = do
+    binding <- Data.teamBinding tid >>= ifNothing teamNotFound
+    case binding of
+        Binding -> Data.teamMembers tid
+        NonBinding -> throwM nonBindingTeam
+
 sameTeam :: [UserId] -> [TeamMember] -> [UserId]
 sameTeam uids tmms = Set.toList $
     Set.fromList uids `Set.intersection` Set.fromList (map (view userId) tmms)

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -347,16 +347,22 @@ createConnectConversation a b name conn = do
 createOne2OneConversation :: U.UUID U.V4
                           -> U.UUID U.V4
                           -> Maybe (Range 1 256 Text)
+                          -> Maybe TeamId
                           -> Galley Conversation
-createOne2OneConversation a b name = do
+createOne2OneConversation a b name ti = do
     let conv = one2OneConvId a b
         a'   = Id (U.unpack a)
         b'   = Id (U.unpack b)
     now <- liftIO getCurrentTime
-    retry x5 $
-        write Cql.insertConv (params Quorum (conv, One2OneConv, a', privateOnly, fromRange <$> name, Nothing))
+    retry x5 $ case ti of
+        Nothing  -> write Cql.insertConv (params Quorum (conv, One2OneConv, a', privateOnly, fromRange <$> name, Nothing))
+        Just tid -> batch $ do
+            setType BatchLogged
+            setConsistency Quorum
+            addPrepQuery Cql.insertConv (conv, One2OneConv, a', privateOnly, fromRange <$> name, Just tid)
+            addPrepQuery Cql.insertTeamConv (tid, conv, False)
     mems <- snd <$> addMembers now conv a' (rcast $ a' <| rsingleton b')
-    return $ newConv conv One2OneConv a' (toList mems) (singleton PrivateAccess) name Nothing
+    return $ newConv conv One2OneConv a' (toList mems) (singleton PrivateAccess) name ti
 
 updateConversation :: MonadClient m => ConvId -> Range 1 256 Text -> m ()
 updateConversation cid name = retry x5 $ write Cql.updateConvName (params Quorum (fromRange name, cid))

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -39,6 +39,7 @@ tests g b c m a = testGroup "Teams API"
     [ test m "create team" (testCreateTeam g b c a)
     , test m "create multiple binding teams fail" (testCreateMulitpleBindingTeams g b a)
     , test m "create team with members" (testCreateTeamWithMembers g b c)
+    , test m "create 1-1 conversation between binding team members" (testCreateOne2OneWithMembers g b c a)
     , test m "add new team member" (testAddTeamMember g b c)
     , test m "add new team member binding teams" (testAddTeamMemberCheckBound g b a)
     , test m "add new team member internal" (testAddTeamMemberInternal g b c a)
@@ -81,7 +82,7 @@ testCreateMulitpleBindingTeams g b a = do
     assertQueue a tCreate
     -- Cannot create more teams if bound (used internal API)
     let nt = NonBindingNewTeam $ newNewTeam (unsafeRange "owner") (unsafeRange "icon")
-    void $ post (g . path "/teams" . zUser owner . zConn "conn" . json nt) <!! do
+    post (g . path "/teams" . zUser owner . zConn "conn" . json nt) !!!
         const 403 === statusCode
 
     -- If never used the internal API, can create multiple teams
@@ -114,6 +115,48 @@ testCreateTeamWithMembers g b c = do
         e^.eventType @?= TeamCreate
         e^.eventTeam @?= (team^.teamId)
         e^.eventData @?= Just (EdTeamCreate team)
+
+testCreateOne2OneWithMembers :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testCreateOne2OneWithMembers g b c a = do
+    -- Negative tests first
+    ensureNoOne2OneUnlessSameBindingTeam
+    
+    -- Test with binding teams
+    owner <- Util.randomUser b
+    tid   <- Util.createTeamInternal g "foo" owner
+    assertQueue a tCreate
+    let p1 = Util.symmPermissions [CreateConversation]
+    mem1 <- flip newTeamMember p1 <$> Util.randomUser b
+
+    WS.bracketR c (mem1^.userId) $ \wsMem1 -> do
+        Util.addTeamMemberInternal g tid mem1
+        checkTeamMemberJoin tid (mem1^.userId) wsMem1
+        WS.assertNoEvent timeout [wsMem1]
+
+    Util.createO2OTeamConv g owner (mem1^.userId) Nothing tid !!! const 201 === statusCode
+  where
+    ensureNoOne2OneUnlessSameBindingTeam = do
+        owner <- Util.randomUser b
+        let p1 = Util.symmPermissions [CreateConversation, AddConversationMember]
+        let p2 = Util.symmPermissions [CreateConversation, AddConversationMember, AddTeamMember]
+        mem1 <- flip newTeamMember p1 <$> Util.randomUser b
+        mem2 <- flip newTeamMember p2 <$> Util.randomUser b
+        Util.connectUsers b owner (list1 (mem1^.userId) [mem2^.userId])
+        tid <- Util.createTeam g "foo" owner [mem1, mem2]
+        -- Cannot create a 1-1 conversation, not connected and in the same team but not binding
+        Util.createO2OTeamConv g (mem1^.userId) (mem2^.userId) Nothing tid !!! do
+            const 404 === statusCode
+            const "non-binding-team" === (Error.label . Util.decodeBody' "error label")
+        -- Both have a binding team but not the same team
+        owner1 <- Util.randomUser b
+        tid1 <- Util.createTeamInternal g "foo" owner1
+        assertQueue a tCreate
+        owner2 <- Util.randomUser b
+        void $ Util.createTeamInternal g "foo" owner2
+        assertQueue a tCreate
+        Util.createO2OTeamConv g owner1 owner2 Nothing tid1 !!! do
+            const 403 === statusCode
+            const "non-binding-team-members" === (Error.label . Util.decodeBody' "error label")
 
 testAddTeamMember :: Galley -> Brig -> Cannon -> Http ()
 testAddTeamMember g b c = do
@@ -349,14 +392,6 @@ testAddTeamConv g b c = do
         case evtData e of
             Just (Conv.EdConversation x) -> cnvId x @?= cid
             other                        -> assertFailure $ "Unexpected event data: " <> show other
-
-    checkTeamMemberJoin tid uid w = WS.assertMatch_ timeout w $ \notif -> do
-        ntfTransient notif @?= False
-        let e = List1.head (WS.unpackPayload notif)
-        e^.eventType @?= MemberJoin
-        e^.eventTeam @?= tid
-        e^.eventData @?= Just (EdMemberJoin uid)
-
 
 testAddTeamConvWithUsers :: Galley -> Brig -> Http ()
 testAddTeamConvWithUsers g b = do
@@ -630,6 +665,14 @@ testUpdateTeamMember g b c a = do
         e^.eventType @?= MemberUpdate
         e^.eventTeam @?= tid
         e^.eventData @?= Just (EdMemberUpdate uid)
+
+checkTeamMemberJoin :: TeamId -> UserId -> WS.WebSocket -> Http ()
+checkTeamMemberJoin tid uid w = WS.assertMatch_ timeout w $ \notif -> do
+    ntfTransient notif @?= False
+    let e = List1.head (WS.unpackPayload notif)
+    e^.eventType @?= MemberJoin
+    e^.eventTeam @?= tid
+    e^.eventData @?= Just (EdMemberJoin uid)
 
 checkTeamDeleteEvent :: TeamId -> WS.WebSocket -> Http ()
 checkTeamDeleteEvent tid w = WS.assertMatch_ timeout w $ \notif -> do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -123,6 +123,11 @@ createTeamConv g u tinfo us name = do
               ) <!! const 201 === statusCode
     fromBS (getHeader' "Location" r)
 
+createO2OTeamConv :: Galley -> UserId -> UserId -> Maybe Text -> TeamId -> Http ResponseLBS
+createO2OTeamConv g u1 u2 n tid = do
+    let conv = NewConv [u2] n mempty (Just $ ConvTeamInfo tid False)
+    post $ g . path "/conversations/one2one" . zUser u1 . zConn "conn" . zType "access" . json conv
+
 postConv :: Galley -> UserId -> [UserId] -> Maybe Text -> [Access] -> Http ResponseLBS
 postConv g u us name a = do
     let conv = NewConv us name (Set.fromList a) Nothing

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -123,8 +123,8 @@ createTeamConv g u tinfo us name = do
               ) <!! const 201 === statusCode
     fromBS (getHeader' "Location" r)
 
-createO2OTeamConv :: Galley -> UserId -> UserId -> Maybe Text -> TeamId -> Http ResponseLBS
-createO2OTeamConv g u1 u2 n tid = do
+createOne2OneTeamConv :: Galley -> UserId -> UserId -> Maybe Text -> TeamId -> Http ResponseLBS
+createOne2OneTeamConv g u1 u2 n tid = do
     let conv = NewConv [u2] n mempty (Just $ ConvTeamInfo tid False)
     post $ g . path "/conversations/one2one" . zUser u1 . zConn "conn" . zType "access" . json conv
 


### PR DESCRIPTION
These type of conversations _can_ be created within a team, but only in case this is a binding team.