### PR TITLE
Fix compilation for api-bot and api-client

### DIFF
--- a/libs/api-bot/src/Network/Wire/Bot/Cache.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Cache.hs
@@ -16,6 +16,7 @@ import Data.ByteString.Conversion
 import Data.IORef
 import Data.LanguageCodes
 import Data.Maybe (fromMaybe)
+import Data.Misc
 import Data.Monoid
 import Data.Text.Encoding
 import Data.Text.Lazy hiding (length, map)

--- a/libs/api-bot/src/Network/Wire/Bot/Monad.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Monad.hs
@@ -84,6 +84,7 @@ import Data.Id
 import Data.IORef
 import Data.List (foldl', partition)
 import Data.Maybe (fromMaybe, isNothing)
+import Data.Misc
 import Data.Metrics (Metrics)
 import Data.Monoid ((<>))
 import Data.String (IsString)
@@ -861,6 +862,7 @@ randUser (Email loc dom) (BotTag tag) = do
         , newUserInvitationCode = Nothing
         , newUserLabel          = Nothing
         , newUserLocale         = Nothing
+        , newUserTeam           = Nothing
         }, passw)
 
 randMailbox :: BotNet Mailbox

--- a/libs/api-bot/stack.yaml
+++ b/libs/api-bot/stack.yaml
@@ -20,3 +20,4 @@ extra-deps:
 flags:
   types-common:
     protobuf: True
+    arbitrary: True

--- a/libs/api-client/stack.yaml
+++ b/libs/api-client/stack.yaml
@@ -18,3 +18,4 @@ extra-deps:
 flags:
   types-common:
     protobuf: True
+    arbitrary: True


### PR DESCRIPTION
`PlainTextPassword` was moved to types-common and `newUserTeam` introduced at some point; api-client/bot libs were not updated.