### PR TITLE
Fix alpine builder path

### DIFF
--- a/build/alpine/Dockerfile
+++ b/build/alpine/Dockerfile
@@ -8,15 +8,15 @@
 FROM wire-server-builder:alpine as builder
 
 ARG service
-COPY . /src
+COPY . /src/wire-server/
 
-RUN cd /src/services/${service} && make install
+RUN cd /src/wire-server/services/${service} && make install
 
 #--- Minified stage ---
 FROM wire-server-deps:alpine
 
 ARG service
-COPY --from=builder /src/services/${service}/dist/${service} /usr/local/bin/${service}
+COPY --from=builder /src/wire-server/services/${service}/dist/${service} /usr/local/bin/${service}
 
 # ARGs are not available at runtime, create symlink at build time
 # more info: https://stackoverflow.com/questions/40902445/using-variable-interpolation-in-string-in-docker


### PR DESCRIPTION
Fix the COPY destination path so it matches the absolute source path. This means we get the registered packages under .stack-work for the build, reducing build time significantly.