### PR TITLE
Containers for integration,schema,etc executables

### DIFF
--- a/build/alpine/Dockerfile
+++ b/build/alpine/Dockerfile
@@ -16,9 +16,10 @@ RUN cd /src/wire-server/services/${service} && make install
 FROM wire-server-deps:alpine
 
 ARG service
-COPY --from=builder /src/wire-server/services/${service}/dist/${service} /usr/local/bin/${service}
+ARG executable
+COPY --from=builder /src/wire-server/services/${service}/dist/${executable} /usr/bin/${exectuable}
 
 # ARGs are not available at runtime, create symlink at build time
 # more info: https://stackoverflow.com/questions/40902445/using-variable-interpolation-in-string-in-docker
-RUN ln -s /usr/local/bin/${service} /usr/local/bin/service
-ENTRYPOINT ["/usr/local/bin/service"]
+RUN ln -s /usr/bin/${executable} /usr/bin/service
+ENTRYPOINT ["/usr/bin/service"]

--- a/services/brig/Makefile
+++ b/services/brig/Makefile
@@ -12,6 +12,7 @@ DEB_IT        := dist/$(NAME)-integration_$(VERSION)+$(BUILD)_amd64.deb
 DEB_SCHEMA    := dist/$(NAME)-schema_$(VERSION)+$(BUILD)_amd64.deb
 DEB_INDEX     := dist/$(NAME)-index_$(VERSION)+$(BUILD)_amd64.deb
 KEIRETSU_ENV  ?= ../.env
+EXECUTABLES   := $(NAME) $(NAME)-integration $(NAME)-schema $(NAME)-index
 
 guard-%:
 	@ if [ "${${*}}" = "" ]; then \
@@ -115,4 +116,11 @@ index-reset: install
 
 .PHONY: docker
 docker:
-	docker build -t $(NAME) -f ../../build/alpine/Dockerfile --build-arg service=$(NAME) ../..
+	$(foreach executable,$(EXECUTABLES),\
+	docker build -t $(executable) \
+	-f ../../build/alpine/Dockerfile \
+	--build-arg service=$(NAME) \
+	--build-arg executable=$(executable) \
+	../.. \
+	;)
+

--- a/services/cannon/Makefile
+++ b/services/cannon/Makefile
@@ -5,6 +5,7 @@ BUILD_NUMBER ?= 0
 BUILD_LABEL  ?= local
 BUILD        := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
 DEB          := $(NAME)_$(VERSION)+$(BUILD)_amd64.deb
+EXECUTABLES  := $(NAME)
 
 guard-%:
 	@ if [ "${${*}}" = "" ]; then \
@@ -59,4 +60,10 @@ integration-%:
 
 .PHONY: docker
 docker:
-	docker build -t $(NAME) -f ../../build/alpine/Dockerfile --build-arg service=$(NAME) ../..
+	$(foreach executable,$(EXECUTABLES),\
+	docker build -t $(executable) \
+	-f ../../build/alpine/Dockerfile \
+	--build-arg service=$(NAME) \
+	--build-arg executable=$(executable) \
+	../.. \
+	;)

--- a/services/cargohold/Makefile
+++ b/services/cargohold/Makefile
@@ -9,6 +9,7 @@ DEB           := dist/$(NAME)_$(VERSION)+$(BUILD)_amd64.deb
 DEB_IT        := dist/$(NAME)-integration_$(VERSION)+$(BUILD)_amd64.deb
 SDIST         := dist/$(NAME)-$(VERSION).tar.gz
 KEIRETSU_ENV  ?= ../.env
+EXECUTABLES   := $(NAME) $(NAME)-integration
 
 guard-%:
 	@ if [ "${${*}}" = "" ]; then \
@@ -66,4 +67,10 @@ integration: install
 
 .PHONY: docker
 docker:
-	docker build -t $(NAME) -f ../../build/alpine/Dockerfile --build-arg service=$(NAME) ../..
+	$(foreach executable,$(EXECUTABLES),\
+	docker build -t $(executable) \
+	-f ../../build/alpine/Dockerfile \
+	--build-arg service=$(NAME) \
+	--build-arg executable=$(executable) \
+	../.. \
+	;)

--- a/services/galley/Makefile
+++ b/services/galley/Makefile
@@ -11,6 +11,7 @@ DEB_IT        := $(NAME)-integration_$(VERSION)+$(BUILD)_amd64.deb
 DEB_SCHEMA    := $(NAME)-schema_$(VERSION)+$(BUILD)_amd64.deb
 DEB_JOURNALER := $(NAME)-journaler_$(VERSION)+$(BUILD)_amd64.deb
 KEIRETSU_ENV  ?= ../.env
+EXECUTABLES   := $(NAME) $(NAME)-integration $(NAME)-schema $(NAME)-journaler
 
 guard-%:
 	@ if [ "${${*}}" = "" ]; then \
@@ -101,4 +102,11 @@ db-migrate: install
 
 .PHONY: docker
 docker:
-	docker build -t $(NAME) -f ../../build/alpine/Dockerfile --build-arg service=$(NAME) ../..
+	$(foreach executable,$(EXECUTABLES),\
+	docker build -t $(executable) \
+	-f ../../build/alpine/Dockerfile \
+	--build-arg service=$(NAME) \
+	--build-arg executable=$(executable) \
+	../.. \
+	;)
+

--- a/services/gundeck/Makefile
+++ b/services/gundeck/Makefile
@@ -13,6 +13,7 @@ DEB_IT        := $(NAME)-integration_$(VERSION)+$(BUILD)_amd64.deb
 DEB_SCHEMA    := $(NAME)-schema_$(VERSION)+$(BUILD)_amd64.deb
 SDIST         := dist/$(NAME)-$(VERSION).tar.gz
 KEIRETSU_ENV  ?= ../.env
+EXECUTABLES   := $(NAME) $(NAME)-integration $(NAME)-schema
 
 guard-%:
 	@ if [ "${${*}}" = "" ]; then \
@@ -106,4 +107,11 @@ db-migrate: install
 
 .PHONY: docker
 docker:
-	docker build -t $(NAME) -f ../../build/alpine/Dockerfile --build-arg service=$(NAME) ../..
+	$(foreach executable,$(EXECUTABLES),\
+	docker build -t $(executable) \
+	-f ../../build/alpine/Dockerfile \
+	--build-arg service=$(NAME) \
+	--build-arg executable=$(executable) \
+	../.. \
+	;)
+

--- a/services/proxy/Makefile
+++ b/services/proxy/Makefile
@@ -5,6 +5,7 @@ BUILD_NUMBER ?= 0
 BUILD_LABEL  ?= local
 BUILD        := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
 DEB          := $(NAME)_$(VERSION)+$(BUILD)_amd64.deb
+EXECUTABLES  := proxy
 
 guard-%:
 	@ if [ "${${*}}" = "" ]; then \
@@ -49,4 +50,10 @@ $(DEB):
 
 .PHONY: docker
 docker:
-	docker build -t $(NAME) -f ../../build/alpine/Dockerfile --build-arg service=$(NAME) ../..
+	$(foreach executable,$(EXECUTABLES),\
+	docker build -t $(executable) \
+	-f ../../build/alpine/Dockerfile \
+	--build-arg service=$(NAME) \
+	--build-arg executable=$(executable) \
+	../.. \
+	;)


### PR DESCRIPTION
Create separate docker images containing other executables like e.g. `brig-schema`, `brig-integration`, etc. Does not need additional recompilation time.