### PR TITLE
Activate team on account activation only

### DIFF
--- a/libs/galley-types/src/Galley/Types/Teams/Intra.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Intra.hs
@@ -13,6 +13,7 @@ data TeamStatus
     | PendingDelete
     | Deleted
     | Suspended
+    | PendingActive
     deriving (Eq, Show)
 
 instance ToJSON TeamStatus where
@@ -20,12 +21,14 @@ instance ToJSON TeamStatus where
     toJSON PendingDelete = String "pending_delete"
     toJSON Deleted       = String "deleted"
     toJSON Suspended     = String "suspended"
+    toJSON PendingActive = String "pending_active"
 
 instance FromJSON TeamStatus where
     parseJSON (String "active")         = pure Active
     parseJSON (String "pending_delete") = pure PendingDelete
     parseJSON (String "deleted")        = pure Deleted
     parseJSON (String "suspended")      = pure Suspended
+    parseJSON (String "pending_active") = pure PendingActive
     parseJSON other                     = fail $ "Unknown TeamStatus: " <> show other
 
 data TeamData = TeamData
@@ -56,3 +59,4 @@ instance FromJSON TeamStatusUpdate where
 
 instance ToJSON TeamStatusUpdate where
     toJSON s = object ["status" .= tuStatus s]
+

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -111,6 +111,7 @@ import qualified Brig.Types.Team.Invitation as Team
 import qualified Brig.Team.DB               as Team
 import qualified Data.Map.Strict            as Map
 import qualified Galley.Types.Teams         as Team
+import qualified Galley.Types.Teams.Intra   as Team
 import qualified System.Logger.Class        as Log
 
 -------------------------------------------------------------------------------
@@ -469,6 +470,7 @@ onActivated (AccountActivated account) = do
     let uid = userId (accountUser account)
     Log.info $ field "user" (toByteString uid) . msg (val "User activated")
     Intra.onUserEvent uid Nothing $ UserActivated account
+    activateTeam uid
     return (userIdentity (accountUser account), True)
 onActivated (EmailActivated uid email) = do
     Intra.onUserEvent uid Nothing (emailUpdated uid email)
@@ -476,6 +478,11 @@ onActivated (EmailActivated uid email) = do
 onActivated (PhoneActivated uid phone) = do
     Intra.onUserEvent uid Nothing (phoneUpdated uid phone)
     return (Just (PhoneIdentity phone), False)
+
+activateTeam :: UserId -> AppIO ()
+activateTeam uid = do
+    tid <- Intra.getTeamId uid
+    for_ tid $ flip Intra.changeTeamStatus Team.Active
 
 sendActivationCode :: Either Email Phone -> Maybe Locale -> Bool -> ExceptT SendActivationCodeError AppIO ()
 sendActivationCode emailOrPhone loc call = case emailOrPhone of
@@ -774,3 +781,4 @@ fetchUserIdentity :: UserId -> AppIO (Maybe UserIdentity)
 fetchUserIdentity uid = lookupSelfProfile uid >>= maybe
     (throwM $ UserProfileNotFound uid)
     (return . userIdentity . selfUser)
+

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -36,6 +36,7 @@ module Brig.IO.Intra
     , getTeamMember
     , getTeamMembers
     , getTeam
+    , getTeamId
     , getTeamContacts
     , changeTeamStatus
     ) where
@@ -564,6 +565,17 @@ getTeamContacts u = do
     req = paths ["i", "users", toByteString' u, "team", "members"]
         . expect [status200, status404]
 
+getTeamId :: UserId -> AppIO (Maybe TeamId)
+getTeamId u = do
+    debug $ remote "galley" . msg (val "Get team from user")
+    rs <- galleyRequest GET req
+    case Bilge.statusCode rs of
+        200 -> Just <$> decodeBody "galley" rs
+        _   -> return Nothing
+  where
+    req = paths ["i", "users", toByteString' u, "team"]
+        . expect [status200, status404]
+
 getTeam :: TeamId -> AppIO Team.TeamData
 getTeam tid = do
     debug $ remote "galley" . msg (val "Get team info")
@@ -582,3 +594,4 @@ changeTeamStatus tid s = do
         . header "Content-Type" "application/json"
         . expect2xx
         . lbytes (encode $ Team.TeamStatusUpdate s)
+

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -681,6 +681,9 @@ sitemap = do
     get "/i/users/:uid/team/members" (continue getBindingTeamMembers) $
         capture "uid"
 
+    get "/i/users/:uid/team" (continue getBindingTeamId) $
+        capture "uid"
+
     get "/i/test/clients" (continue getClients)
         zauthUserId
 

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -181,8 +181,11 @@ createTeam :: MonadClient m
            -> m Team
 createTeam t uid (fromRange -> n) (fromRange -> i) k b = do
     tid <- maybe (Id <$> liftIO nextRandom) return t
-    retry x5 $ write Cql.insertTeam (params Quorum (tid, uid, n, i, fromRange <$> k, Active, b))
+    retry x5 $ write Cql.insertTeam (params Quorum (tid, uid, n, i, fromRange <$> k, initialStatus b, b))
     pure (newTeam tid uid n i b & teamIconKey .~ (fromRange <$> k))
+  where
+    initialStatus Binding = PendingActive -- Team becomes Active after User account activation
+    initialStatus NonBinding = Active
 
 deleteTeam :: MonadClient m => TeamId -> m ()
 deleteTeam tid = do

--- a/services/galley/src/Galley/Data/Instances.hs
+++ b/services/galley/src/Galley/Data/Instances.hs
@@ -100,11 +100,14 @@ instance Cql TeamStatus where
     toCql PendingDelete   = CqlInt 1
     toCql Deleted         = CqlInt 2
     toCql Suspended       = CqlInt 3
+    toCql PendingActive   = CqlInt 4
 
     fromCql (CqlInt i) = case i of
         0 -> return Active
         1 -> return PendingDelete
         2 -> return Deleted
         3 -> return Suspended
+        4 -> return PendingActive
         n -> fail $ "unexpected team-status: " ++ show n
     fromCql _ = fail "team-status: int expected"
+

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -81,8 +81,7 @@ testCreateMulitpleBindingTeams g b a = do
     assertQueue a tCreate
     -- Cannot create more teams if bound (used internal API)
     let nt = NonBindingNewTeam $ newNewTeam (unsafeRange "owner") (unsafeRange "icon")
-    void $ post (g . path "/teams" . zUser owner . zConn "conn" . json nt) <!! do
-        const 403 === statusCode
+    void $ post (g . path "/teams" . zUser owner . zConn "conn" . json nt) !!! const 403 === statusCode
 
     -- If never used the internal API, can create multiple teams
     owner' <- Util.randomUser b
@@ -249,7 +248,7 @@ testRemoveBindingTeamMember g b c a = do
     assertQueue a $ tUpdate 2 [owner]
     Util.connectUsers b owner (singleton mext)
     cid1 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [(mem1^.userId), mext] (Just "blaa")
-    
+
     -- Deleting from a binding team without a password is a bad request
     delete ( g
            . paths ["teams", toByteString' tid, "members", toByteString' (mem1^.userId)]
@@ -656,3 +655,4 @@ checkConvMemberLeaveEvent cid usr w = WS.assertMatch_ timeout w $ \notif -> do
         case evtData e of
             Just (Conv.EdMembers mm) -> mm @?= Conv.Members [usr]
             other                    -> assertFailure $ "Unexpected event data: " <> show other
+


### PR DESCRIPTION
Add `Pending` state to Teams, which is their initial state. Upon the first user account activation, an associated team also becomes active.