### PR TITLE
Issue 625

### DIFF
--- a/services/brig/.ghci
+++ b/services/brig/.ghci
@@ -1,2 +1,1 @@
-:set -isrc
 :set -XOverloadedStrings

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -317,6 +317,7 @@ test-suite brig-integration
       , directory             >= 1.2
       , errors                >= 1.4
       , exceptions            >= 0.5
+      , extra
       , filepath              >= 1.4
       , galley-types
       , gundeck-types

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -130,7 +130,7 @@ library
       , iproute                   >= 1.5
       , lens                      >= 3.8
       , lens-aeson                >= 1.0
-      , lifted-async              >= 0.8
+      , lifted-async              >= 0.9.3
       , mime-mail                 >= 0.4
       , metrics-core              >= 0.3
       , metrics-wai               >= 0.3
@@ -326,7 +326,7 @@ test-suite brig-integration
       , HsOpenSSL
       , lens                  >= 3.9
       , lens-aeson            >= 1.0
-      , lifted-async          >= 0.7
+      , lifted-async          >= 0.9.3
       , mtl                   >= 2.1
       , network
       , options               >= 0.1

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -71,6 +71,7 @@ newUserError (InvalidPhone _)         = StdError invalidPhone
 newUserError (DuplicateUserKey _)     = StdError userKeyExists
 newUserError (PhoneActivationError e) = actError e
 newUserError (BlacklistedUserKey k)   = StdError $ foldKey (const blacklistedEmail) (const blacklistedPhone) k
+newUserError TooManyTeamMembers       = StdError tooManyTeamMembers
 
 sendLoginCodeError :: SendLoginCodeError -> Error
 sendLoginCodeError (SendLoginInvalidPhone _) = StdError invalidPhone
@@ -337,6 +338,9 @@ noBindingTeam = Wai.Error status403 "no-binding-team" "Operation allowed only on
 noOtherOwner :: Wai.Error
 noOtherOwner = Wai.Error status403 "no-other-owner" "You are trying to remove or downgrade\
                                 \ an owner. Promote another team member before proceeding."
+
+tooManyTeamMembers :: Wai.Error
+tooManyTeamMembers = Wai.Error status403 "too-many-team-members" "Too many members in this team."
 
 loginsTooFrequent :: Wai.Error
 loginsTooFrequent = Wai.Error status429 "client-error" "Logins too frequent"

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -58,6 +58,7 @@ data CreateUserError
     | InvalidPhone Phone
     | DuplicateUserKey UserKey
     | BlacklistedUserKey UserKey
+    | TooManyTeamMembers
 
 data InvitationError
     = InviteeEmailExists UserId

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -238,8 +238,10 @@ createUser new@NewUser{..} = do
         ok <- lift $ Data.claimKey uk uid
         unless ok $
             throwE $ DuplicateUserKey uk
+        added <- lift $ Intra.addTeamMember uid (Team.iiTeam ii)
+        unless added $
+            throwE TooManyTeamMembers
         lift $ do
-            Intra.addTeamMember uid (Team.iiTeam ii)
             activateUser uid ident
             void $ onActivated (AccountActivated account)
             Log.info $ field "user" (toByteString uid)

--- a/services/brig/stack.yaml
+++ b/services/brig/stack.yaml
@@ -40,6 +40,7 @@ extra-deps:
 - data-timeout-0.3
 - geoip2-0.2.2.0
 - html-entities-1.1.4.1
+- lifted-async-0.9.3
 - raw-strings-qq-1.0.2
 - temporary-1.2.1.1
 - text-icu-translit-0.1.0.7


### PR DESCRIPTION
Return proper error response in case a team has reached its size limit and a user tries to join. We check this in 2 places because:

 * We want to fail as early as possible and avoid adding users to the user table that will not be able to verify their account.
 * There is always a potential race condition when 2 users register so we must assume that `addTeamMember` can potentially fail.