### PR TITLE
nginz-container: Reload process on upstreams.conf change.

### DIFF
--- a/services/nginz/Dockerfile
+++ b/services/nginz/Dockerfile
@@ -20,9 +20,10 @@ COPY --from=libzauth-builder /usr/lib/pkgconfig/libzauth.pc /usr/lib/pkgconfig/l
 
 COPY services/nginz/third_party /src/third_party
 
-# Install nginz (nginx including the zauth module)
-# (taken mostly from https://github.com/nginxinc/docker-nginx/blob/master/stable/alpine/Dockerfile)
-RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
+RUN apk add --no-cache inotify-tools dumb-init bash curl && \
+    # Install nginz (nginx including the zauth module)
+    # (taken mostly from https://github.com/nginxinc/docker-nginx/blob/master/stable/alpine/Dockerfile)
+    export GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
     && CONFIG="\
         --prefix=/etc/nginx \
         --sbin-path=/usr/sbin/nginx \
@@ -122,4 +123,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
-CMD ["nginx", "-g", "daemon off;"]
+COPY services/nginz/nginz_reload.sh /usr/bin/nginz_reload.sh
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/usr/bin/nginz_reload.sh", "-g", "daemon off;", "-c", "/etc/wire/nginz/conf/nginx.conf"]

--- a/services/nginz/nginz_reload.sh
+++ b/services/nginz/nginz_reload.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+{
+  echo "Starting nginx"
+  nginx "$@" && exit 1
+} &
+
+nginx_pid=$!
+
+watches=${WATCH_PATHS:-"/etc/wire/nginz/upstreams"}
+
+# only react on changes to upstreams.conf
+cfg=upstreams.conf
+
+echo "Setting up watches for ${watches[@]}"
+
+{
+  echo "nginx PID: $nginx_pid"
+  inotifywait -m -e moved_to -e modify,move,create,delete -m --format '%f' \
+  ${watches[@]} | while read file; do \
+    if [ $file == $cfg ]; then \
+        echo "Config file update detected"; \
+        nginx -t "$@"; \
+        if [ $? -ne 0 ]; then \
+            echo "ERROR: New configuration is invalid!!"; \
+        else \
+            echo "New configuration is valid, reloading nginx"; \
+            nginx -s reload "$@" ; \
+        fi; \
+    fi; \
+  done
+
+  echo "inotifywait failed, killing nginx"
+
+  kill -TERM $nginx_pid
+} &
+
+wait $nginx_pid || exit 1


### PR DESCRIPTION
Uses [dumb-init](https://github.com/Yelp/dumb-init) as PID 1 and `inotifywait` to reload nginz if upstreams
change. Change only affects docker image.