### PR TITLE
Fix/gitignore config yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,14 @@ services/.env
 tools/api-simulations/mailboxes.json
 tools/api-simulations/reports
 .DS_Store
+
+brig-schema.yaml
+brig.yaml
+cannon.yaml
+cargohold.yaml
+galley-schema.yaml
+galley.yaml
+integration.yaml
+gundeck-schema.yaml
+gundeck.yaml
+proxy.yaml

--- a/services/cannon/Makefile
+++ b/services/cannon/Makefile
@@ -6,6 +6,7 @@ BUILD_LABEL  ?= local
 BUILD        := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
 DEB          := $(NAME)_$(VERSION)+$(BUILD)_amd64.deb
 EXECUTABLES  := $(NAME)
+EXE_IT		 := dist/$(NAME)
 
 guard-%:
 	@ if [ "${${*}}" = "" ]; then \

--- a/services/cannon/Makefile
+++ b/services/cannon/Makefile
@@ -6,7 +6,6 @@ BUILD_LABEL  ?= local
 BUILD        := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
 DEB          := $(NAME)_$(VERSION)+$(BUILD)_amd64.deb
 EXECUTABLES  := $(NAME)
-EXE_IT		 := dist/$(NAME)
 
 guard-%:
 	@ if [ "${${*}}" = "" ]; then \


### PR DESCRIPTION
Git should ignore config yaml files, as these are specific to the deployment and not for distribution. ToDo: .yaml.example files for distribution.