### PR TITLE
Distinguish TURN token/config TTLs

### DIFF
--- a/services/brig/deb/etc/sv/brig/run
+++ b/services/brig/deb/etc/sv/brig/run
@@ -46,6 +46,13 @@ else
     TURN_TOKEN_LIFETIME=""
 fi
 
+if [ -n "$BRIG_TURN_CONFIG_TTL" ]; then
+    TURN_CONFIG_TTL="--turn-config-ttl=$BRIG_TURN_CONFIG_TTL"
+else
+    TURN_CONFIG_TTL=""
+fi
+
+
 cd $HOME
 
 ulimit -n 65536
@@ -104,6 +111,7 @@ exec chpst -u $USER \
     --turn-servers=${BRIG_TURN_SERVERS?'unset'} \
     --turn-secret=${BRIG_TURN_SECRET?'unset'} \
     ${TURN_TOKEN_LIFETIME} \
+    ${TURN_CONFIG_TTL} \
     ${AWS_ACCESS_KEY_ID} \
     ${AWS_SECRET_ACCESS_KEY} \
     ${GEOIP_DB} \

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -130,9 +130,10 @@ data ZAuthOpts = ZAuthOpts
 instance FromJSON ZAuthOpts
 
 data TurnOpts = TurnOpts
-    { servers  :: !FilePath
-    , secret   :: !FilePath
-    , lifetime :: !Word32
+    { servers   :: !FilePath
+    , secret    :: !FilePath
+    , tokenTTL  :: !Word32
+    , configTTL :: !Word32
     } deriving (Show, Generic)
 
 instance FromJSON TurnOpts
@@ -338,8 +339,11 @@ optsParser =
       help "TURN shared secret file path" <>
       action "file") <*>
      (option auto $
-      long "turn-token-lifetime" <> metavar "INT" <> value 3600 <> showDefault <>
-      help "Number of seconds TURN credentials should be valid.")) <*>
+      long "turn-token-lifetime" <> metavar "INT" <> value 21600 <> showDefault <>
+      help "Number of seconds TURN credentials should be valid.") <*>
+     (option auto $
+      long "turn-config-ttl" <> metavar "INT" <> value 3600 <> showDefault <>
+      help "Number of seconds until a new TURN configuration should be fetched.")) <*>
     settingsParser
 
 settingsParser :: Parser Settings

--- a/services/brig/src/Brig/TURN.hs
+++ b/services/brig/src/Brig/TURN.hs
@@ -11,14 +11,15 @@ import OpenSSL.EVP.Digest (Digest)
 import System.Random.MWC (GenIO, createSystemRandom)
 
 data Env = Env
-    { _turnServers :: List1 TurnURI
-    , _turnTTL     :: Word32
-    , _turnSecret  :: ByteString
-    , _turnSHA512  :: Digest
-    , _turnPrng    :: GenIO
+    { _turnServers   :: List1 TurnURI
+    , _turnTokenTTL  :: Word32
+    , _turnConfigTTL :: Word32
+    , _turnSecret    :: ByteString
+    , _turnSHA512    :: Digest
+    , _turnPrng      :: GenIO
     }
 
 makeLenses ''Env
 
-newEnv :: Digest -> List1 TurnURI -> Word32 -> ByteString -> IO Env
-newEnv sha512 srvs ttl secret = Env srvs ttl secret sha512 <$> createSystemRandom
+newEnv :: Digest -> List1 TurnURI -> Word32 -> Word32 -> ByteString -> IO Env
+newEnv sha512 srvs tTTL cTTL secret = Env srvs tTTL cTTL secret sha512 <$> createSystemRandom


### PR DESCRIPTION
Allow TTL values for the TURN config itself (default: 1 hour) to be different from the TURN token lifetime (default: 6 hours).