### PR TITLE
Use dumb-init as the default PID 1 in containers

### DIFF
--- a/build/alpine/Dockerfile
+++ b/build/alpine/Dockerfile
@@ -22,4 +22,4 @@ COPY --from=builder /src/wire-server/services/${service}/dist/${executable} /usr
 # ARGs are not available at runtime, create symlink at build time
 # more info: https://stackoverflow.com/questions/40902445/using-variable-interpolation-in-string-in-docker
 RUN ln -s /usr/bin/${executable} /usr/bin/service
-ENTRYPOINT ["/usr/bin/service"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/bin/service"]

--- a/build/alpine/Dockerfile.deps
+++ b/build/alpine/Dockerfile.deps
@@ -24,4 +24,5 @@ RUN apk add --no-cache \
             icu \
             geoip \
             llvm-libunwind \
-            ca-certificates
+            ca-certificates \
+            dumb-init

--- a/services/brig/Dockerfile
+++ b/services/brig/Dockerfile
@@ -18,4 +18,4 @@ COPY --from=builder /src/wire-server/services/brig/deb/opt/brig/templates/ /usr/
 # ARGs are not available at runtime, create symlink at build time
 # more info: https://stackoverflow.com/questions/40902445/using-variable-interpolation-in-string-in-docker
 RUN ln -s /usr/bin/${executable} /usr/bin/service
-ENTRYPOINT ["/usr/bin/service"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/bin/service"]


### PR DESCRIPTION
Our haskell executables, if used as PID 1 inside containers, don't do signal handling well, don't reap zombie processes, etc. Dumb-init should be a more sane default init process.
See e.g. https://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html