### PR TITLE
[docker] make base images configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,7 @@ docker-services:
 	$(MAKE) -C build/alpine
 	$(foreach service,$(SERVICES),$(MAKE) -C services/$(service) docker;)
 
+.PHONY: services
+services:
+	$(foreach service,$(HASKELL_SERVICES),$(MAKE) -C services/$(service) clean install;)
+

--- a/build/alpine/Dockerfile
+++ b/build/alpine/Dockerfile
@@ -4,16 +4,20 @@
 #   (from wire-server root directory)
 #   SERVICE=galley; docker build -f build/alpine/Dockerfile -t $SERVICE --build-arg service=$SERVICE .
 
+ARG builder=wire-server-builder:alpine
+ARG deps=wire-server-deps:alpine
+
 #--- Builder stage ---
-FROM wire-server-builder:alpine as builder
+FROM ${builder} as builder
 
 ARG service
+ARG target=install
 COPY . /src/wire-server/
 
-RUN cd /src/wire-server/services/${service} && make install
+RUN cd /src/wire-server/services/${service} && make ${target}
 
 #--- Minified stage ---
-FROM wire-server-deps:alpine
+FROM ${deps}
 
 ARG service
 ARG executable

--- a/build/alpine/Dockerfile.deps
+++ b/build/alpine/Dockerfile.deps
@@ -2,7 +2,7 @@
 
 FROM alpine:3.6 as cryptobox-builder
 
-# compile cryptobox
+# compile cryptobox-c
 RUN apk add --no-cache cargo libsodium-dev git && \
     cd /tmp && \
     git clone https://github.com/wireapp/cryptobox-c.git && \

--- a/services/brig/Dockerfile
+++ b/services/brig/Dockerfile
@@ -1,15 +1,20 @@
 # Requires docker >= 17.05 (requires support for multi-stage builds)
 # Requires to have created the wire-server-builder and wire-server-deps docker images
 
+ARG builder=wire-server-builder:alpine
+ARG deps=wire-server-deps:alpine
+
 #--- Builder stage ---
-FROM wire-server-builder:alpine as builder
+FROM ${builder} as builder
+
+ARG target=install
 
 COPY . /src/wire-server/
 
-RUN cd /src/wire-server/services/brig && make install
+RUN cd /src/wire-server/services/brig && make ${target}
 
 #--- Minified stage ---
-FROM wire-server-deps:alpine
+FROM ${deps}
 
 ARG executable
 COPY --from=builder /src/wire-server/services/brig/dist/${executable} /usr/bin/${exectuable}


### PR DESCRIPTION
Allows to use different base images via `--build-arg builder=...`