### PR TITLE
Issue 637

### DIFF
--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -196,6 +196,9 @@ newUser = defineModel "NewUser" $ do
     property "accent_id" int32' $ do
         description "Accent colour ID"
         optional
+    property "email_code" bytes' $ do
+        description "Email activation code"
+        optional
     property "phone_code" bytes' $ do
         description "Phone activation code"
         optional

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -209,6 +209,7 @@ data NewUser = NewUser
     , newUserPict           :: !(Maybe Pict) -- ^ DEPRECATED
     , newUserAssets         :: [Asset]
     , newUserAccentId       :: !(Maybe ColourId)
+    , newUserEmailCode      :: !(Maybe ActivationCode)
     , newUserPhoneCode      :: !(Maybe ActivationCode)
     , newUserInvitationCode :: !(Maybe InvitationCode)
     , newUserLabel          :: !(Maybe CookieLabel)
@@ -230,6 +231,7 @@ instance FromJSON NewUser where
           newUserPict           <- o .:? "picture"
           newUserAssets         <- o .:? "assets" .!= []
           newUserAccentId       <- o .:? "accent_id"
+          newUserEmailCode      <- o .:? "email_code"
           newUserPhoneCode      <- o .:? "phone_code"
           newUserInvitationCode <- o .:? "invitation_code"
           newUserLabel          <- o .:? "label"
@@ -249,6 +251,7 @@ instance ToJSON NewUser where
     toJSON u = object
         $ "name"            .= newUserName u
         # "email"           .= newUserEmail u
+        # "email_code"      .= newUserEmailCode u
         # "password"        .= newUserPassword u
         # "picture"         .= newUserPict u
         # "assets"          .= newUserAssets u

--- a/services/brig/deb/opt/brig/templates/user/ar/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/ar/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/ar/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/ar/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/ar/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/ar/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/de/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/de/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/de/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/de/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/de/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/de/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/en/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/en/email/verification-subject.txt
@@ -1,0 +1,1 @@
+Wire verification code: ${code}

--- a/services/brig/deb/opt/brig/templates/user/en/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/en/email/verification.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+</head>
+<body style="
+font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+margin: 0;
+padding: 0;
+font-size: 16px;
+font-weight: 400;
+line-height: 1.5em;
+color: #42474A;
+-webkit-font-smoothing: antialiased;
+-moz-osx-font-smoothing: grayscale;
+  ">
+<br>
+<table width="100%" cellpadding="0" cellspacing="0">
+    <tr>
+        <td>
+            <center>
+                <table cellpadding="0" cellspacing="10" style="
+              max-width: 500px;
+              margin: 12px auto 0 auto;
+              font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            ">
+                    <thead>
+                    <tr>
+                        <td style="padding-bottom: 0px;">
+                            <a href="https://wire.com"><img src="https://wire.com/p/img/email/logo-email-black.png"
+                                                            width="57" height="18"
+                                                            alt="Wire"></a>
+                        </td>
+                        <td style="text-align: right; text-transform: uppercase; font-size: 12px; font-weight: 500;">
+                            <a href="https://wire.com" style="text-decoration: none; color: #42474A;">wire.com</a>
+                        </td>
+                    </tr>
+                    </thead>
+<tbody style="font-size: 16px;">
+<tr>
+    <td width="500" colspan="2" style="padding-top: 48px;padding-bottom: 0px;">
+    <p style="font-size: 32px; font-weight: 300; text-align: center; line-height: 1.3;">
+    Verify your email
+    </p>
+    <br/>
+    <p>
+    <strong>${email}</strong> was used to register on Wire. Enter this code to verify your
+    email and create your account.
+    </p>
+          <p style="font-size: 24px; font-weight: 300; text-align: center;">
+          	${code}
+          </p>
+          <p style="font-size: 10pt; font-weight: 300; line-height: 1.5em; color: #000;">
+            If you didn&#8217;t create a Wire account using this email address, please
+            <a href="http://support.wire.com/hc/en-us/requests/new" style="color: #3898DD; font-weight: 400; text-decoration:none!important;">
+              contact us
+            </a>.
+          </p>
+    </td>
+</tr>
+</tbody>
+<tfoot style="text-align: center;">
+<tr>
+    <td width="500" colspan="2"
+        style="font-size: 12px; font-weight: 500; line-height: 2em; color: #42474A; text-transform: uppercase; padding-top: 40px; padding-bottom: 40px; border-top: 1px solid #E9EDF0;">
+        <a href="https://wire.com/legal/" style="
+                  color: #B9BCBD;
+                  font-weight: 500;
+                  text-decoration:none !important;
+                ">Privacy</a><span style="margin-left: 8px; margin-right: 8px; color: #B9BCBD;">&middot;</span>
+        <a href="mailto:misuse@wire.com" style="color: #B9BCBD;font-weight: 500;text-decoration:none
+                             !important;">Report Misuse</a><br>Wire Swiss GmbH. All Rights Reserved.
+    </td>
+</tr>
+</tfoot>
+</table>
+</center>
+</td>
+</tr>
+</table>
+</body>
+</html>

--- a/services/brig/deb/opt/brig/templates/user/en/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/en/email/verification.txt
@@ -1,0 +1,18 @@
+Wire
+
+
+Hello,
+
+${email} was used to register on Wire. Enter this code to verify your email and create your account.
+
+${code}
+
+Please don't reply to this message.
+
+If you didn't create a Wire account using this email address, please visit https://support.wire.com
+
+
+
+(c) Wire Swiss GmbH
+
+Privacy Policy  |  Report misuse

--- a/services/brig/deb/opt/brig/templates/user/es-ES/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/es-ES/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/es-ES/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/es-ES/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/es-ES/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/es-ES/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/et/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/et/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/et/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/et/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/et/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/et/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/fa/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/fa/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/fa/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/fa/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/fa/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/fa/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/fr/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/fr/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/fr/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/fr/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/fr/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/fr/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/it/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/it/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/it/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/it/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/it/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/it/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/pt-BR/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/pt-BR/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/pt-BR/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/pt-BR/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/pt-BR/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/pt-BR/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/ru/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/ru/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/ru/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/ru/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/ru/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/ru/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/sv-SE/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/sv-SE/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/sv-SE/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/sv-SE/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/sv-SE/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/sv-SE/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/tr/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/tr/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/tr/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/tr/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/tr/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/tr/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/uk/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/uk/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/uk/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/uk/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/uk/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/uk/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/deb/opt/brig/templates/user/zh-TW/email/verification-subject.txt
+++ b/services/brig/deb/opt/brig/templates/user/zh-TW/email/verification-subject.txt
@@ -1,0 +1,1 @@
+../../en/email/verification-subject.txt

--- a/services/brig/deb/opt/brig/templates/user/zh-TW/email/verification.html
+++ b/services/brig/deb/opt/brig/templates/user/zh-TW/email/verification.html
@@ -1,0 +1,1 @@
+../../en/email/verification.html

--- a/services/brig/deb/opt/brig/templates/user/zh-TW/email/verification.txt
+++ b/services/brig/deb/opt/brig/templates/user/zh-TW/email/verification.txt
@@ -1,0 +1,1 @@
+../../en/email/verification.txt

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -70,6 +70,7 @@ newUserError MissingIdentity          = StdError missingIdentity
 newUserError (InvalidEmail _)         = StdError invalidEmail
 newUserError (InvalidPhone _)         = StdError invalidPhone
 newUserError (DuplicateUserKey _)     = StdError userKeyExists
+newUserError (EmailActivationError e) = actError e
 newUserError (PhoneActivationError e) = actError e
 newUserError (BlacklistedUserKey k)   = StdError $ foldKey (const blacklistedEmail) (const blacklistedPhone) k
 newUserError TooManyTeamMembers       = StdError tooManyTeamMembers

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -53,6 +53,7 @@ data ActivationResult
 data CreateUserError
     = InvalidInvitationCode
     | MissingIdentity
+    | EmailActivationError ActivationError
     | PhoneActivationError ActivationError
     | InvalidEmail Email
     | InvalidPhone Phone

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -182,7 +182,6 @@ createUser new@NewUser{..} = do
                     edata   <- lift $ Data.newActivation ek timeout (Just uid)
                     Log.info $ field "user"            (toByteString uid)
                              . field "activation.key"  (toByteString $ activationKey edata)
-                             . field "activation.code" (toByteString $ activationCode edata)
                              . msg (val "Created email activation key/code pair")
                     return $ Just edata
                 Just c -> do
@@ -199,7 +198,6 @@ createUser new@NewUser{..} = do
                     pdata   <- lift $ Data.newActivation pk timeout (Just uid)
                     Log.info $ field "user"            (toByteString uid)
                              . field "activation.key"  (toByteString $ activationKey pdata)
-                             . field "activation.code" (toByteString $ activationCode pdata)
                              . msg (val "Created phone activation key/code pair")
                     return $ Just pdata
                 Just c -> do

--- a/services/brig/src/Brig/Data/Activation.hs
+++ b/services/brig/src/Brig/Data/Activation.hs
@@ -65,7 +65,7 @@ data ActivationEvent
 
 -- | Max. number of activation attempts per 'ActivationKey'.
 maxAttempts :: Int32
-maxAttempts = 5
+maxAttempts = 3
 
 activateKey :: ActivationKey
             -> ActivationCode

--- a/services/brig/src/Brig/User/Email.hs
+++ b/services/brig/src/Brig/User/Email.hs
@@ -21,7 +21,7 @@ import Brig.User.Template
 import Brig.Types
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Range
-import Data.Text (Text)
+import Data.Text (Text, chunksOf, intercalate)
 import Data.Text.Lazy (toStrict)
 
 import qualified Brig.Aws        as Aws
@@ -176,17 +176,10 @@ renderVerificationMail VerificationEmail{..} VerificationEmailTemplate{..} =
     html = renderHtml verificationEmailBodyHtml replace
     subj = renderText verificationEmailSubject  replace
 
-    replace "url"   = renderVerificationUrl verificationEmailUrl vfPair
+    -- Digits can be better read in groups of 3
+    replace "code"  = intercalate " " . chunksOf 3 $ Ascii.toText code
     replace "email" = fromEmail vfTo
     replace x       = x
-
-renderVerificationUrl :: Template -> ActivationPair -> Text
-renderVerificationUrl t (ActivationKey k, ActivationCode c) =
-    toStrict $ renderText t replace
-  where
-    replace "key"  = Ascii.toText k
-    replace "code" = Ascii.toText c
-    replace x      = x
 
 -------------------------------------------------------------------------------
 -- Activation Email

--- a/services/brig/src/Brig/User/Email.hs
+++ b/services/brig/src/Brig/User/Email.hs
@@ -2,21 +2,12 @@
 {-# LANGUAGE RecordWildCards   #-}
 
 module Brig.User.Email
-    ( ActivationEmail (..)
-    , sendActivationMail
-
+    ( sendActivationMail
+    , sendVerificationMail
     , sendTeamActivationMail
-
-    , PasswordResetEmail (..)
     , sendPasswordResetMail
-
-    , InvitationEmail (..)
     , sendInvitationMail
-
-    , DeletionEmail (..)
     , sendDeletionEmail
-
-    , NewClientEmail (..)
     , sendNewClientEmail
 
       -- * Re-exports
@@ -36,6 +27,12 @@ import Data.Text.Lazy (toStrict)
 import qualified Brig.Aws        as Aws
 import qualified Brig.Types.Code as Code
 import qualified Data.Text.Ascii as Ascii
+
+sendVerificationMail :: Email -> ActivationPair -> Maybe Locale -> AppIO ()
+sendVerificationMail to pair loc = do
+    tpl <- verificationEmail . snd <$> userTemplates loc
+    let mail = VerificationEmail to pair
+    Aws.sendMail $ renderVerificationMail mail tpl
 
 sendActivationMail :: Email -> Name -> ActivationPair -> Maybe Locale -> Maybe UserIdentity -> AppIO ()
 sendActivationMail to name pair loc ident = do
@@ -150,6 +147,46 @@ renderDeletionEmail DeletionEmailTemplate{..} DeletionEmail{..} =
     replace2 "key"  = key
     replace2 "code" = code
     replace2 x      = x
+
+-------------------------------------------------------------------------------
+-- Verification Email
+
+data VerificationEmail = VerificationEmail
+    { vfTo   :: !Email
+    , vfPair :: !ActivationPair
+    }
+
+renderVerificationMail :: VerificationEmail -> VerificationEmailTemplate -> Mail
+renderVerificationMail VerificationEmail{..} VerificationEmailTemplate{..} =
+    (emptyMail from)
+        { mailTo      = [ to ]
+        , mailHeaders = [ ("Subject", toStrict subj)
+                        , ("X-Zeta-Purpose", "Verification")
+                        , ("X-Zeta-Key", Ascii.toText key)
+                        , ("X-Zeta-Code", Ascii.toText code)
+                        ]
+        , mailParts   = [ [ plainPart txt, htmlPart html ] ]
+        }
+  where
+    (ActivationKey key, ActivationCode code) = vfPair
+
+    from = Address (Just verificationEmailSenderName) (fromEmail verificationEmailSender)
+    to   = Address Nothing (fromEmail vfTo)
+    txt  = renderText verificationEmailBodyText replace
+    html = renderHtml verificationEmailBodyHtml replace
+    subj = renderText verificationEmailSubject  replace
+
+    replace "url"   = renderVerificationUrl verificationEmailUrl vfPair
+    replace "email" = fromEmail vfTo
+    replace x       = x
+
+renderVerificationUrl :: Template -> ActivationPair -> Text
+renderVerificationUrl t (ActivationKey k, ActivationCode c) =
+    toStrict $ renderText t replace
+  where
+    replace "key"  = Ascii.toText k
+    replace "code" = Ascii.toText c
+    replace x      = x
 
 -------------------------------------------------------------------------------
 -- Activation Email

--- a/services/brig/src/Brig/User/Email.hs
+++ b/services/brig/src/Brig/User/Email.hs
@@ -162,13 +162,12 @@ renderVerificationMail VerificationEmail{..} VerificationEmailTemplate{..} =
         { mailTo      = [ to ]
         , mailHeaders = [ ("Subject", toStrict subj)
                         , ("X-Zeta-Purpose", "Verification")
-                        , ("X-Zeta-Key", Ascii.toText key)
                         , ("X-Zeta-Code", Ascii.toText code)
                         ]
         , mailParts   = [ [ plainPart txt, htmlPart html ] ]
         }
   where
-    (ActivationKey key, ActivationCode code) = vfPair
+    (ActivationKey _, ActivationCode code) = vfPair
 
     from = Address (Just verificationEmailSenderName) (fromEmail verificationEmailSender)
     to   = Address Nothing (fromEmail vfTo)

--- a/services/brig/src/Brig/User/Email.hs
+++ b/services/brig/src/Brig/User/Email.hs
@@ -21,7 +21,7 @@ import Brig.User.Template
 import Brig.Types
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Range
-import Data.Text (Text, chunksOf, intercalate)
+import Data.Text (Text)
 import Data.Text.Lazy (toStrict)
 
 import qualified Brig.Aws        as Aws
@@ -176,8 +176,7 @@ renderVerificationMail VerificationEmail{..} VerificationEmailTemplate{..} =
     html = renderHtml verificationEmailBodyHtml replace
     subj = renderText verificationEmailSubject  replace
 
-    -- Digits can be better read in groups of 3
-    replace "code"  = intercalate " " . chunksOf 3 $ Ascii.toText code
+    replace "code"  = Ascii.toText code
     replace "email" = fromEmail vfTo
     replace x       = x
 

--- a/services/brig/src/Brig/User/Template.hs
+++ b/services/brig/src/Brig/User/Template.hs
@@ -4,6 +4,7 @@
 module Brig.User.Template
     ( UserTemplates              (..)
     , ActivationSmsTemplate      (..)
+    , VerificationEmailTemplate  (..)
     , ActivationEmailTemplate    (..)
     , TeamActivationEmailTemplate(..)
     , ActivationCallTemplate     (..)
@@ -34,6 +35,7 @@ import qualified Brig.Options       as Opt
 data UserTemplates = UserTemplates
     { activationSms         :: !ActivationSmsTemplate
     , activationCall        :: !ActivationCallTemplate
+    , verificationEmail     :: !VerificationEmailTemplate
     , activationEmail       :: !ActivationEmailTemplate
     , activationEmailUpdate :: !ActivationEmailTemplate
     , teamActivationEmail   :: !TeamActivationEmailTemplate
@@ -56,6 +58,15 @@ data ActivationSmsTemplate = ActivationSmsTemplate
 
 data ActivationCallTemplate = ActivationCallTemplate
     { activationCallText  :: !Template
+    }
+
+data VerificationEmailTemplate = VerificationEmailTemplate
+    { verificationEmailUrl        :: !Template
+    , verificationEmailSubject    :: !Template
+    , verificationEmailBodyText   :: !Template
+    , verificationEmailBodyHtml   :: !Template
+    , verificationEmailSender     :: !Email
+    , verificationEmailSenderName :: !Text
     }
 
 data ActivationEmailTemplate = ActivationEmailTemplate
@@ -146,6 +157,12 @@ loadUserTemplates o = readLocalesDir defLocale templateDir $ \fp ->
                 <*> pure smsSender)
         <*> (ActivationCallTemplate
                 <$> readTemplate (fp <> "/call/activation.txt"))
+        <*> (VerificationEmailTemplate activationUrl
+                <$> readTemplate (fp <> "/email/verification-subject.txt")
+                <*> readTemplate (fp <> "/email/verification.txt")
+                <*> readTemplate (fp <> "/email/verification.html")
+                <*> pure emailSender
+                <*> readText (fp <> "/email/sender.txt"))
         <*> (ActivationEmailTemplate activationUrl
                 <$> readTemplate (fp <> "/email/activation-subject.txt")
                 <*> readTemplate (fp <> "/email/activation.txt")

--- a/services/brig/test/integration/API.hs
+++ b/services/brig/test/integration/API.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 
 module API (tests, ConnectionLimit (..)) where
 
@@ -66,7 +67,8 @@ tests conf p b c g = do
     l <- optOrEnv (ConnectionLimit . Opt.setUserMaxConnections . Opt.optSettings) conf (ConnectionLimit . read) "USER_CONNECTION_LIMIT"
     return $ testGroup "user"
         [ testGroup "account"
-            [ test p "post /register - 201"                     $ testCreateUser b g
+            [ test p "post /register - 201 (with preverified)"  $ testCreateUserWithPreverified b
+            , test p "post /register - 201"                     $ testCreateUser b g
             , test p "post /register - 201 + no email"          $ testCreateUserNoEmailNoPassword b
             , test p "post /register - 201 anonymous"           $ testCreateUserAnon b g
             , test p "post /register - 201 pending"             $ testCreateUserPending b
@@ -158,6 +160,48 @@ tests conf p b c g = do
 
 -------------------------------------------------------------------------------
 -- User Account/Profile Tests
+
+testCreateUserWithPreverified :: Brig -> Http ()
+testCreateUserWithPreverified brig = do
+    -- Register (pre verified) user with phone
+    p <- randomPhone
+    let phoneReq = RequestBodyLBS . encode $ object [ "phone" .= fromPhone p ]
+    post (brig . path "/activate/send" . contentJson . body phoneReq) !!!
+        (const 200 === statusCode)
+    getActivationCode brig (Right p) >>= \case
+        Nothing     -> liftIO $ assertFailure "missing activation key/code"
+        Just (_, c) -> do
+            let reg = RequestBodyLBS . encode $ object
+                    [ "name"       .= Name "Alice"
+                    , "phone"      .= fromPhone p
+                    , "phone_code" .= c
+                    ]
+            rs <- post (brig . path "/register" . contentJson . body reg) <!!
+                const 201 === statusCode
+            let Just uid = userId <$> decodeBody rs
+            get (brig . path "/self" . zUser uid) !!! do
+                const 200 === statusCode
+                const (Just p) === (userPhone <=< decodeBody)
+
+    -- Register (pre verified) user with email
+    e <- randomEmail
+    let emailReq = RequestBodyLBS . encode $ object [ "email" .= fromEmail e ]
+    post (brig . path "/activate/send" . contentJson . body emailReq) !!!
+        (const 200 === statusCode)
+    getActivationCode brig (Left e) >>= \case
+        Nothing     -> liftIO $ assertFailure "missing activation key/code"
+        Just (_, c) -> do
+            let reg = RequestBodyLBS . encode $ object
+                    [ "name"       .= Name "Alice"
+                    , "email"      .= fromEmail e
+                    , "email_code" .= c
+                    ]
+            rs <- post (brig . path "/register" . contentJson . body reg) <!!
+                const 201 === statusCode
+            let Just uid = userId <$> decodeBody rs
+            get (brig . path "/self" . zUser uid) !!! do
+                const 200 === statusCode
+                const (Just e) === (userEmail <=< decodeBody)
 
 testCreateUser :: Brig -> Galley -> Http ()
 testCreateUser brig galley = do
@@ -598,9 +642,14 @@ testPasswordChange brig = do
 testSendActivationCode :: Brig -> Http ()
 testSendActivationCode brig = do
     p <- randomPhone
+    -- Code for pre-verification
     send $ RequestBodyLBS . encode $ object ["phone" .= fromPhone p]
+    e <- randomEmail
+    -- Code for pre-verification
+    send $ RequestBodyLBS . encode $ object ["email" .= fromEmail e]
     r <- registerUser "Alice" "success@simulator.amazonses.com" brig <!! const 201 === statusCode
     let Just email = userEmail =<< decodeBody r
+    -- Re-request existing activation code
     send $ RequestBodyLBS . encode $ object ["email" .= fromEmail email]
   where
     send p = post (brig . path "/activate/send" . contentJson . body p) !!!

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -47,6 +47,7 @@ tests m b c g =
             , test m "post /teams/:tid/invitations - 403 no permission"  $ testInvitationNoPermission b
             , test m "post /register - 201 accepted"                     $ testInvitationEmailAccepted b g
             , test m "post /register user & team - 201 accepted"         $ testCreateTeam b g
+            , test m "post /register user & team - 201 preverified"      $ testCreateTeamPreverified b g
             , test m "post /register - 400 no passwordless"              $ testTeamNoPassword b
             , test m "post /register - 400 code already used"            $ testInvitationCodeExists b g
             , test m "post /register - 400 bad code"                     $ testInvitationInvalidCode b
@@ -158,6 +159,30 @@ testCreateTeam brig galley = do
     -- Verify that Team has status Active now
     team3 <- getTeam galley (team^.Team.teamId)
     liftIO $ assertEqual "status" Team.Active (Team.tdStatus team3)
+
+testCreateTeamPreverified :: Brig -> Galley -> Http ()
+testCreateTeamPreverified brig galley = do
+    email <- randomEmail
+    requestActivationCode brig (Left email)
+    act <- getActivationCode brig (Left email)
+    case act of
+        Nothing     -> liftIO $ assertFailure "activation key/code not found"
+        Just (_, c) -> do
+            rsp <- register' email newTeam c brig <!! const 201 === statusCode
+            let Just uid = userId <$> decodeBody rsp
+            teams <- view Team.teamListTeams <$> getTeams uid galley
+            liftIO $ assertBool "User not part of exactly one team" (length teams == 1)
+            let team = fromMaybe (error "No team??") $ listToMaybe teams
+            liftIO $ assertBool "Team not binding" (team^.Team.teamBinding == Team.Binding)
+            mem <- getTeamMember uid (team^.Team.teamId) galley
+            liftIO $ assertBool "Member not part of the team" (uid == mem ^. Team.userId)
+            team2 <- getTeam galley (team^.Team.teamId)
+            -- Team should already be active
+            liftIO $ assertEqual "status" Team.Active (Team.tdStatus team2)
+            -- Verify that the user can already send invitations before activating their account
+            inviteeEmail <- randomEmail
+            let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing
+            postInvitation brig (team^.Team.teamId) uid invite !!! const 201 === statusCode
 
 testInvitationNoPermission :: Brig -> Http ()
 testInvitationNoPermission brig = do
@@ -533,6 +558,17 @@ register e t brig = post (brig . path "/register" . contentJson . body (
     RequestBodyLBS . encode  $ object
         [ "name"            .= ("Bob" :: Text)
         , "email"           .= fromEmail e
+        , "password"        .= defPassword
+        , "team"            .= t
+        ]
+    ))
+
+register' :: Email -> Team.BindingNewTeam -> ActivationCode -> Brig -> HttpT IO (Response (Maybe ByteString))
+register' e t c brig = post (brig . path "/register" . contentJson . body (
+    RequestBodyLBS . encode  $ object
+        [ "name"            .= ("Bob" :: Text)
+        , "email"           .= fromEmail e
+        , "email_code"      .= c
         , "password"        .= defPassword
         , "team"            .= t
         ]

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -177,8 +177,7 @@ testCreateTeamPreverified brig galley = do
             mem <- getTeamMember uid (team^.Team.teamId) galley
             liftIO $ assertBool "Member not part of the team" (uid == mem ^. Team.userId)
             team2 <- getTeam galley (team^.Team.teamId)
-            -- Team should already be active
-            liftIO $ assertEqual "status" Team.Active (Team.tdStatus team2)
+            liftIO $ assertEqual "Team should already be active" Team.Active (Team.tdStatus team2)
             -- Verify that the user can already send invitations before activating their account
             inviteeEmail <- randomEmail
             let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -68,6 +68,14 @@ createAnonUser name brig = do
     r <- post (brig . path "/register" . contentJson . body p) <!! const 201 === statusCode
     return $ fromMaybe (error "createAnonUser: failed to parse response") (decodeBody r)
 
+requestActivationCode :: Brig -> Either Email Phone -> Http ()
+requestActivationCode brig ep =
+    post (brig . path "/activate/send" . contentJson . body (RequestBodyLBS . encode $ bdy ep)) !!!
+        const 200 === statusCode
+  where
+    bdy (Left e)  = object [ "email" .= fromEmail e ]
+    bdy (Right p) = object [ "phone" .= fromPhone p ]
+
 getActivationCode :: Brig -> Either Email Phone -> Http (Maybe (ActivationKey, ActivationCode))
 getActivationCode brig ep = do
     let qry = either (queryItem "email" . toByteString') (queryItem "phone" . toByteString') ep


### PR DESCRIPTION
This PR introduces the following changes:
 * Allow pre verification of emails (the same way we do for phone numbers)
 * Reduce activation attempts to 3 (previously we allowed up to 5)
 * All verification codes are now 6 digits codes