### PR TITLE
[brig] Allow region for SQS and DynamoDB to be specified

### DIFF
--- a/services/brig/brig.yaml.example
+++ b/services/brig/brig.yaml.example
@@ -26,6 +26,7 @@ aws:
   internalQueue: integration-brig-events-internal
   blacklistTable: integration-brig-userkey-blacklist
   prekeyTable: integration-brig-prekeys
+  awsRegion: eu-west-1
   # TODO: Check AWS loadCredentialsFromEnv
   awsKeyId: <insert-key-id-here>
   awsSecretKey: <insert-secret-key-here>

--- a/services/brig/brig.yaml.example
+++ b/services/brig/brig.yaml.example
@@ -26,7 +26,7 @@ aws:
   internalQueue: integration-brig-events-internal
   blacklistTable: integration-brig-userkey-blacklist
   prekeyTable: integration-brig-prekeys
-  awsRegion: eu-west-1
+  region: eu-west-1
   # TODO: Check AWS loadCredentialsFromEnv
   awsKeyId: <insert-key-id-here>
   awsSecretKey: <insert-secret-key-here>

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -243,7 +243,7 @@ initAws o l m = do
     -- https://hackage.haskell.org/package/aws-0.17.1/docs/src/Aws-Core.html#loadCredentialsFromFile
     -- which would avoid the need to specify them in a config file when running tests
     e <- Aws.newEnv l m (liftM2 (,) (Opt.awsKeyId a) (Opt.awsSecretKey a))
-    let c = Aws.config (Opt.awsRegion a)
+    let c = Aws.config (Opt.region a)
                        (Aws.Account (Opt.account a))
                        (Aws.SesQueue (Opt.sesQueue a))
                        (Aws.InternalQueue (Opt.internalQueue a))

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -243,7 +243,8 @@ initAws o l m = do
     -- https://hackage.haskell.org/package/aws-0.17.1/docs/src/Aws-Core.html#loadCredentialsFromFile
     -- which would avoid the need to specify them in a config file when running tests
     e <- Aws.newEnv l m (liftM2 (,) (Opt.awsKeyId a) (Opt.awsSecretKey a))
-    let c = Aws.config (Aws.Account (Opt.account a))
+    let c = Aws.config (Opt.awsRegion a)
+                       (Aws.Account (Opt.account a))
                        (Aws.SesQueue (Opt.sesQueue a))
                        (Aws.InternalQueue (Opt.internalQueue a))
                        (Aws.BlacklistTable (Opt.blacklistTable a))

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -59,7 +59,7 @@ data AWSOpts = AWSOpts
     , internalQueue   :: !Text
     , blacklistTable  :: !Text
     , prekeyTable     :: !Text
-    , awsRegion       :: !Region
+    , region          :: !Region
     , awsKeyId        :: !(Maybe Aws.AccessKeyId)
     , awsSecretKey    :: !(Maybe Aws.SecretAccessKey)
     } deriving (Show, Generic)


### PR DESCRIPTION
 * Adds partial support for regions, for SQS/DynamoDB
   * The used [aws library](https://hackage.haskell.org/package/aws-0.17.1) does not have a "higher level" datatype for region so I have defined an internal one, similarly to [amazonka](https://github.com/brendanhay/amazonka/blob/afeb929c758c772fe83692a54978cf7bb05a9de5/amazonka-lightsail/gen/Network/AWS/Lightsail/Types/Sum.hs#L559-L573) to then choose the correct regions depending on the service.
     * At the moment, we support only `eu-west-1` and `eu-central-1`. You can easily add more if needed
     * Since the [AWS SQS library](https://hackage.haskell.org/package/aws-0.17.1/docs/Aws-Sqs-Core.html) does not yet support a specific endpoint for eu-central-1, a "hardcoded" string is used
* As SES is only available in some regions (namely, `eu-west-1`, `us-east-1` and `us-west-2`),  that is still hardcoded to use `eu-west-1` and `us-east-1` as a fallback. One must set up `SES` in one of these regions in order to be able to send out e-mails.