### PR TITLE
Try loading AWS keys and secrets from sensible defaults

### DIFF
--- a/libs/ropes/src/Ropes/Aws.hs
+++ b/libs/ropes/src/Ropes/Aws.hs
@@ -86,6 +86,9 @@ data Env = Env
         -- ^ Get the HTTP 'Manager' used by an 'Env'ironment.
     }
 
+-- | If credentials are supplied to this function, they are used to create the 'Env'
+-- | Otherwise, it tries to discover AWS credentials by calling the underlying
+-- | loadCredentialsDefault. If that does not succeed, if fallsback to instance metadata
 newEnv :: Logger -> Manager -> Maybe (AccessKeyId, SecretAccessKey) -> IO Env
 newEnv lgr mgr ks = do
     auth <- case ks of


### PR DESCRIPTION
Currently, services (`brig` and `cargohold`) using the `ropes` (and thus using the underlying aws library) library can only read AWS credentials in 2 ways: either by supplying key/secret directly in a config file (`PermAuth`) or using the ec2 metadata (`TempAuth`).

It would be useful to have this done in a similar way as [amazonka's discovery](https://hackage.haskell.org/package/amazonka-1.5.0/docs/src/Network-AWS-Auth.html#Credentials)