### PR TITLE
Make team members unsearchable by default

### DIFF
--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -108,8 +108,8 @@ reauthenticate u pw = lift (lookupAuth u) >>= \case
             unless (verifyPassword p pw') $
                 throwE (ReAuthError AuthInvalidCredentials)
 
-insertAccount :: UserAccount -> Maybe Password -> Bool -> AppIO ()
-insertAccount (UserAccount u status) password activated = do
+insertAccount :: UserAccount -> Maybe Password -> Bool -> SearchableStatus -> AppIO ()
+insertAccount (UserAccount u status) password activated searchable = do
     let Locale l c = userLocale u
     retry x5 $ write userInsert $ params Quorum
         ( userId u, userName u, userPict u, userAssets u, userEmail u
@@ -118,7 +118,7 @@ insertAccount (UserAccount u status) password activated = do
         , view serviceRefProvider <$> userService u
         , view serviceRefId <$> userService u
         , userHandle u
-        , SearchableStatus True
+        , searchable
         )
 
 updateLocale :: UserId -> Locale -> AppIO ()

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -18,6 +18,7 @@ import Brig.Types.Intra (UserAccount (..), AccountStatus (..))
 import Brig.Types.Client
 import Brig.Types.User
 import Brig.Types.Provider
+import Brig.Types.Search
 import Control.Lens (view)
 import Control.Exception.Enclosed (handleAny)
 import Control.Monad (join, when, unless, (>=>))
@@ -563,7 +564,7 @@ addBot (zuid ::: zcon ::: cid ::: req) = do
     let newClt = (newClient PermanentClient (Ext.rsNewBotLastPrekey rs) ())
                { newClientPrekeys = Ext.rsNewBotPrekeys rs
                }
-    lift $ User.insertAccount (UserAccount usr Active) Nothing True
+    lift $ User.insertAccount (UserAccount usr Active) Nothing True (SearchableStatus True)
     (clt, _, _) <- User.addClient (botUserId bid) bcl newClt Nothing
                    !>> const (StdError badGateway) -- MalformedPrekeys
 

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -94,4 +94,3 @@ setSearchable (_ ::: u ::: r) = do
     lift $ DB.updateSearchableStatus u s
     lift $ Intra.onUserEvent u Nothing (searchableStatusUpdated u s)
     return (setStatus status200 empty)
-

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -4,7 +4,6 @@ module API.Search (tests) where
 
 import API.Search.Util
 import Bilge
-import Bilge.Assert
 import Brig.Types
 import Control.Concurrent              (threadDelay)
 import Control.Concurrent.Async.Lifted
@@ -36,23 +35,19 @@ testOptInOut brig = do
         uid2 = userId u2
         Just h1 = fromHandle <$> userHandle u1
 
-    assertSearchable uid1 True
+    assertSearchable "default" brig uid1 True
     assertCanFind brig uid2 uid1 h1
 
     updateSearchableStatus brig uid1 optOut
     refreshIndex brig
-    assertSearchable uid1 False
+    assertSearchable "opted out" brig uid1 False
     assertCan'tFind brig uid2 uid1 h1
 
     updateSearchableStatus brig uid1 optIn
     refreshIndex brig
-    assertSearchable uid1 True
+    assertSearchable "opted in" brig uid1 True
     assertCanFind brig uid2 uid1 h1
-  where
-    assertSearchable uid status =
-        get (brig . path "/self/searchable" . zUser uid) !!! do
-            const 200 === statusCode
-            const (Just status) === fmap isSearchable . decodeBody
+
 
 testSearchByName :: Brig -> Http ()
 testSearchByName brig = do


### PR DESCRIPTION
On user creation, set the searchable flag to false for team creators and members.