### PR TITLE
Add realip module to nginz

### DIFF
--- a/services/nginz/Dockerfile
+++ b/services/nginz/Dockerfile
@@ -42,6 +42,7 @@ RUN apk add --no-cache inotify-tools dumb-init bash curl && \
         --group=nginx \
         --with-http_ssl_module \
         --with-http_stub_status_module \
+        --with-http_realip_module \
         --add-module=/src/third_party/nginx-zauth-module \
         --add-module=/src/third_party/headers-more-nginx-module \
         --add-module=/src/third_party/nginx-module-vts \

--- a/services/nginz/Makefile
+++ b/services/nginz/Makefile
@@ -28,6 +28,7 @@ CONFIG_OPTIONS = \
 ADDITIONAL_MODULES = \
     --with-http_ssl_module \
     --with-http_stub_status_module \
+    --with-http_realip_module \
     --add-module=../third_party/nginx-zauth-module \
     --add-module=../third_party/headers-more-nginx-module \
     --add-module=../third_party/nginx-module-vts


### PR DESCRIPTION
Adds `realip_module` which _is used to change the client address and optional port to those sent in the specified header field_ (useful when running `nginz` as a proxy).