### PR TITLE
Let Galley read client list form Brig

### DIFF
--- a/libs/brig-types/src/Brig/Types/Intra.hs
+++ b/libs/brig-types/src/Brig/Types/Intra.hs
@@ -94,20 +94,21 @@ instance ToJSON UserAccount where
         in Object $ M.insert "status" (toJSON s) o
 
 -------------------------------------------------------------------------------
--- AutoConnect
+-- UserList
 
--- | List of users to establish a 2-way accepted connection for a given user
-data AutoConnect = AutoConnect
-    { acUsrs :: !(Set UserId)
+-- | Set of user ids, can be used for different purposes (e.g., used on the internal
+-- APIs for auto-connections, listing user's clients)
+data UserSet = UserSet
+    { usUsrs :: !(Set UserId)
     } deriving (Eq, Show)
 
-instance FromJSON AutoConnect where
-    parseJSON = withObject "auto-connect" $ \o ->
-        AutoConnect <$> o .: "users"
+instance FromJSON UserSet where
+    parseJSON = withObject "user-set" $ \o ->
+        UserSet <$> o .: "users"
 
-instance ToJSON AutoConnect where
+instance ToJSON UserSet where
     toJSON ac = object
-        [ "users" .= acUsrs ac
+        [ "users" .= usUsrs ac
         ]
 
 -------------------------------------------------------------------------------

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -175,7 +175,7 @@ data NewOtrMessage = NewOtrMessage
 
 newtype UserClients = UserClients
     { userClients :: Map UserId (Set ClientId)
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Monoid)
 
 data ClientMismatch = ClientMismatch
     { cmismatchTime    :: !UTCTime

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -150,6 +150,7 @@ library
       , safe                      >= 0.3
       , scientific                >= 0.3.4
       , scrypt                    >= 0.5
+      , split                     >= 0.2
       , semigroups                >= 0.15
       , singletons                >= 2.0
       , random-shuffle            >= 0.0.3

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1074,10 +1074,8 @@ listClients (usr ::: _) = json <$> lift (API.lookupClients usr)
 internalListClients :: JSON ::: JSON ::: Request -> Handler Response
 internalListClients (_ ::: _ ::: req) = do
     UserSet usrs <- parseJsonBody req
-    json <$> lift (userClients usrs)
-  where
-    userClient user  = liftM2 (,) (return user) (Set.fromList <$> API.lookupClientIds user)
-    userClients usrs = UserClients . Map.fromList <$> mapM userClient (Set.toList usrs)
+    ucs <- Map.fromList <$> lift (API.lookupUsersClientIds $ Set.toList usrs)
+    return $ json (UserClients ucs)
 
 getClient :: UserId ::: ClientId ::: JSON -> Handler Response
 getClient (usr ::: clt ::: _) = lift $ do

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -10,6 +10,7 @@ module Brig.API.Client
     , Data.lookupClient
     , Data.lookupClients
     , Data.lookupPrekeyIds
+    , Data.lookupUsersClientIds
 
       -- * Prekeys
     , claimPrekey
@@ -35,7 +36,7 @@ import Data.Foldable
 import Data.Hashable (hash)
 import Data.Id (UserId, ClientId, newClientId, ConnId)
 import Data.IP (IP)
-import Data.List.Extra (chunksOf)
+import Data.List.Split (chunksOf)
 import Data.Misc (PlainTextPassword (..))
 import Galley.Types (UserClients (..), UserClientMap (..))
 import Gundeck.Types.Push.V2 (SignalingKeys)

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -47,7 +47,7 @@ import Data.ByteString (ByteString)
 import Data.Id
 import Data.Int (Int32)
 import Data.Foldable (for_)
-import Data.List.Extra (chunksOf)
+import Data.List.Split (chunksOf)
 import Data.Range
 import Data.Set (Set, fromList)
 import Data.Traversable (for)

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -66,7 +66,7 @@ import Data.Foldable (toList, for_)
 import Data.Id
 import Data.Json.Util ((#))
 import Data.List1 (List1, list1, singleton)
-import Data.List.Extra (chunksOf)
+import Data.List.Split (chunksOf)
 import Data.Maybe (isJust, mapMaybe)
 import Data.Range
 import Data.Text (Text)

--- a/services/brig/test/integration/API.hs
+++ b/services/brig/test/integration/API.hs
@@ -2106,7 +2106,7 @@ postAutoConnection brig from to = post $ brig
     . body payload
     . zConn "conn"
   where
-    payload = RequestBodyLBS . encode $ AutoConnect (Set.fromList to)
+    payload = RequestBodyLBS . encode $ UserSet (Set.fromList to)
 
 setProperty :: Brig -> UserId -> ByteString -> Value -> Http ResponseLBS
 setProperty brig u k v = put $ brig

--- a/services/galley/deb/etc/sv/galley/run
+++ b/services/galley/deb/etc/sv/galley/run
@@ -21,6 +21,12 @@ export LOG_LEVEL=${GALLEY_LOG_LEVEL:-Debug}
 export LOG_BUFFER=${GALLEY_LOG_BUFFER:-4096}
 export LOG_NETSTR=${GALLEY_LOG_NETSTR:-True}
 
+if [ -n "$GALLEY_INTRA_DEVICE_LISTING" ]; then
+    GALLEY_INTRA_DEVICE_LISTING="--intra-device-listing"
+else
+    GALLEY_INTRA_DEVICE_LISTING=""
+fi
+
 cd $HOME
 
 ulimit -n 65536
@@ -39,4 +45,5 @@ exec chpst -u $USER \
     --disco-url=${GALLEY_DISCO_URL?'unset'} \
     --http-pool-size=${GALLEY_HTTP_POOL_SIZE:-128} \
     --team-events-queue-name=${GALLEY_SQS_TEAM_EVENTS?'unset'} \
-    --aws-region=${KHAN_REGION?'unset'}
+    --aws-region=${KHAN_REGION?'unset'} \
+    ${GALLEY_INTRA_DEVICE_LISTING}

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -42,6 +42,8 @@ library
         Galley.External
         Galley.Intra.Push
         Galley.Intra.User
+        Galley.Intra.Util
+        Galley.Intra.Client
         Galley.Queue
         Galley.Validation
         Galley.Types.Clients

--- a/services/galley/src/Galley/API/Clients.hs
+++ b/services/galley/src/Galley/API/Clients.hs
@@ -24,9 +24,9 @@ getClients :: UserId -> Galley Response
 getClients usr = do
     isInternal <- view $ options . optSettings . setIntraListing
     clts <- if isInternal then
-              fromUserClients <$> Intra.lookupClients [usr]
+                fromUserClients <$> Intra.lookupClients [usr]
             else
-              Data.lookupClients [usr]
+                Data.lookupClients [usr]
     return . json $ clientIds usr clts
 
 addClient :: UserId ::: ClientId -> Galley Response

--- a/services/galley/src/Galley/API/Clients.hs
+++ b/services/galley/src/Galley/API/Clients.hs
@@ -8,18 +8,25 @@ module Galley.API.Clients
     , rmClient
     ) where
 
+import Control.Lens (view)
 import Data.Id
 import Galley.App
-import Galley.Types.Clients (clientIds)
+import Galley.Options
+import Galley.Types.Clients (clientIds, fromUserClients)
 import Network.Wai
 import Network.Wai.Predicate hiding (setStatus)
 import Network.Wai.Utilities
 
-import qualified Galley.Data as Data
+import qualified Galley.Data         as Data
+import qualified Galley.Intra.Client as Intra
 
 getClients :: UserId -> Galley Response
 getClients usr = do
-    clts <- Data.lookupClients [usr]
+    isInternal <- view $ options . optSettings . setIntraListing
+    clts <- if isInternal then
+              fromUserClients <$> Intra.lookupClients [usr]
+            else
+              Data.lookupClients [usr]
     return . json $ clientIds usr clts
 
 addClient :: UserId ::: ClientId -> Galley Response

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -57,6 +57,7 @@ import Galley.Data.Services as Data
 import Galley.Data.Types
 import Galley.Intra.Push
 import Galley.Intra.User
+import Galley.Options
 import Galley.Types
 import Galley.Types.Bot
 import Galley.Types.Clients (Clients)
@@ -73,6 +74,7 @@ import qualified Data.Set             as Set
 import qualified Galley.Data          as Data
 import qualified Galley.Data.Types    as Data
 import qualified Galley.External      as External
+import qualified Galley.Intra.Client  as Intra
 import qualified Galley.Types.Clients as Clients
 import qualified Galley.Types.Proto   as Proto
 import qualified Galley.API.Teams     as Teams
@@ -451,7 +453,11 @@ withValidOtrBroadcastRecipients usr clt rcps val now go = Teams.withBindingTeam 
     tMembers <- fmap (view userId) <$> Data.teamMembers tid
     contacts <- getContactList usr
     let users = Set.toList $ Set.union (Set.fromList tMembers) (Set.fromList contacts)
-    clts <- Data.lookupClients users
+    isInternal <- view $ options . optSettings . setIntraListing
+    clts <- if isInternal then
+              Clients.fromUserClients <$> Intra.lookupClients users
+            else
+              Data.lookupClients users
     let membs = Data.newMember <$> users
     handleOtrResponse usr clt rcps membs clts val now go
 

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -455,9 +455,9 @@ withValidOtrBroadcastRecipients usr clt rcps val now go = Teams.withBindingTeam 
     let users = Set.toList $ Set.union (Set.fromList tMembers) (Set.fromList contacts)
     isInternal <- view $ options . optSettings . setIntraListing
     clts <- if isInternal then
-              Clients.fromUserClients <$> Intra.lookupClients users
+                Clients.fromUserClients <$> Intra.lookupClients users
             else
-              Data.lookupClients users
+                Data.lookupClients users
     let membs = Data.newMember <$> users
     handleOtrResponse usr clt rcps membs clts val now go
 
@@ -476,7 +476,12 @@ withValidOtrRecipients usr clt cnv rcps val now go = do
         Data.deleteConversation cnv
         throwM convNotFound
     membs <- Data.members cnv
-    clts  <- Data.lookupClients (map memId membs)
+    let memIds = (memId <$> membs)
+    isInternal <- view $ options . optSettings . setIntraListing
+    clts <- if isInternal then
+                Clients.fromUserClients <$> Intra.lookupClients memIds
+            else
+                Data.lookupClients memIds
     handleOtrResponse usr clt rcps membs clts val now go
 
 handleOtrResponse

--- a/services/galley/src/Galley/Intra/Client.hs
+++ b/services/galley/src/Galley/Intra/Client.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Galley.Intra.Client
+    ( lookupClients
+    ) where
+
+import Bilge hiding (options, getHeader, statusCode)
+import Bilge.RPC
+import Galley.App
+import Galley.Intra.Util
+import Galley.Types (UserClients)
+import Data.Id
+import Network.HTTP.Types.Method
+import Network.HTTP.Types.Status
+import Network.Wai.Utilities.Error
+
+lookupClients :: [UserId] -> Galley UserClients
+lookupClients uids = do
+    (h, p) <- brigReq
+    r <- call "brig"
+        $ method POST . host h . port p
+        . path "/i/clients"
+        . json uids
+        . expect2xx
+    parseResponse (Error status502 "server-error") r

--- a/services/galley/src/Galley/Intra/Client.hs
+++ b/services/galley/src/Galley/Intra/Client.hs
@@ -6,10 +6,12 @@ module Galley.Intra.Client
 
 import Bilge hiding (options, getHeader, statusCode)
 import Bilge.RPC
+import Brig.Types.Intra
 import Galley.App
 import Galley.Intra.Util
 import Galley.Types (UserClients)
 import Data.Id
+import Data.Set (fromList)
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
@@ -20,6 +22,6 @@ lookupClients uids = do
     r <- call "brig"
         $ method POST . host h . port p
         . path "/i/clients"
-        . json uids
+        . json (UserSet $ fromList uids)
         . expect2xx
     parseResponse (Error status502 "server-error") r

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -11,31 +11,21 @@ module Galley.Intra.User
 import Bilge hiding (options, getHeader, statusCode)
 import Brig.Types.Connection (UserIds (..))
 import Bilge.RPC
-import Bilge.Retry
 import Brig.Types.Intra (ConnectionStatus (..), ReAuthUser (..))
 import Brig.Types.Connection (Relation (..))
 import Galley.App
-import Galley.Options
+import Galley.Intra.Util
 import Control.Monad (void, when)
 import Control.Monad.Catch (throwM)
-import Control.Lens (view)
-import Control.Retry
-import Data.ByteString (ByteString)
 import Data.ByteString.Char8 (pack, intercalate)
 import Data.ByteString.Conversion
 import Data.Char (toLower)
 import Data.Id
-import Data.Misc (portNumber)
-import Data.Text.Encoding (encodeUtf8)
-import Data.Word (Word16)
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..))
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
-import Util.Options
 
-import qualified Data.ByteString.Lazy as LB
-import qualified Data.Text.Lazy as LT
 import qualified Network.HTTP.Client.Internal as Http
 
 getConnections :: UserId -> [UserId] -> Maybe Relation -> Galley [ConnectionStatus]
@@ -96,17 +86,3 @@ getContactList uid = do
         . paths ["/i/users", toByteString' uid, "contacts"]
         . expect2xx
     cUsers <$> parseResponse (Error status502 "server-error") r
-
------------------------------------------------------------------------------
--- Helpers
-brigReq :: Galley (ByteString, Word16)
-brigReq = do
-    h <- encodeUtf8 <$> view (options.optBrig.epHost)
-    p <- portNumber . fromIntegral <$> view (options.optBrig.epPort)
-    return (h, p)
-
-call :: LT.Text -> (Request -> Request) -> Galley (Response (Maybe LB.ByteString))
-call n r = recovering x1 rpcHandlers (const (rpc n r))
-
-x1 :: RetryPolicy
-x1 = limitRetries 1

--- a/services/galley/src/Galley/Intra/Util.hs
+++ b/services/galley/src/Galley/Intra/Util.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Galley.Intra.Util
+    ( brigReq
+    , call
+    , x1
+    ) where
+
+import Bilge hiding (options, getHeader, statusCode)
+import Bilge.RPC
+import Bilge.Retry
+import Galley.App
+import Galley.Options
+import Control.Lens (view)
+import Control.Retry
+import Data.ByteString (ByteString)
+import Data.Misc (portNumber)
+import Data.Text.Encoding (encodeUtf8)
+import Data.Word (Word16)
+import Util.Options
+
+import qualified Data.ByteString.Lazy as LB
+import qualified Data.Text.Lazy as LT
+
+
+brigReq :: Galley (ByteString, Word16)
+brigReq = do
+    h <- encodeUtf8 <$> view (options.optBrig.epHost)
+    p <- portNumber . fromIntegral <$> view (options.optBrig.epPort)
+    return (h, p)
+
+call :: LT.Text -> (Request -> Request) -> Galley (Response (Maybe LB.ByteString))
+call n r = recovering x1 rpcHandlers (const (rpc n r))
+
+x1 :: RetryPolicy
+x1 = limitRetries 1

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -19,7 +19,8 @@ import Util.Options.Common
 
 data Settings = Settings
     { _setHttpPoolSize :: !Int
-    , _setMaxTeamSize  :: !Int -- NOTE: This must be in sync with brig
+    , _setMaxTeamSize  :: !Int  -- NOTE: This must be in sync with brig
+    , _setIntraListing :: !Bool -- call Brig for device listing
     } deriving (Show, Generic)
 
 deriveFromJSON toOptionFieldName ''Settings
@@ -113,6 +114,13 @@ optsParser = Opts <$>
                 <> showDefault
                 <> help "Max. # of members in a team."
                 <> value 128)
+        <*>
+            (option auto $
+                long "intra-listing"
+                <> metavar "BOOL"
+                <> showDefault
+                <> help "Fetch client list through Brig."
+                <> value False)
 
 journalOptsParser :: Parser JournalOpts
 journalOptsParser = JournalOpts

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -115,12 +115,9 @@ optsParser = Opts <$>
                 <> help "Max. # of members in a team."
                 <> value 128)
         <*>
-            (option auto $
-                long "intra-listing"
-                <> metavar "BOOL"
-                <> showDefault
-                <> help "Fetch client list through Brig."
-                <> value False)
+            (switch $
+                long "intra-device-listing"
+                <> help "Use this option if you want to fetch the device list from brig instead.")
 
 journalOptsParser :: Parser JournalOpts
 journalOptsParser = JournalOpts

--- a/services/galley/src/Galley/Types/Clients.hs
+++ b/services/galley/src/Galley/Types/Clients.hs
@@ -6,6 +6,7 @@ module Galley.Types.Clients
     , clientIds
     , toList
     , fromList
+    , fromUserClients
     , toMap
     , fromMap
     , singleton
@@ -24,68 +25,78 @@ import Data.Id
 import Data.Maybe (fromMaybe)
 import Data.Monoid
 import Data.Range
+import Galley.Types (UserClients (..))
 import Prelude hiding (filter)
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Set        as Set
 
 newtype Clients = Clients
-    { clients :: Map UserId (Set ClientId)
+    { clients :: UserClients
     } deriving (Eq, Show, Monoid)
 
 instance Bounds Clients where
     within c x y =
-        let n = Map.size (clients c) in
+        let n = Map.size ((userClients . clients) c) in
         n >= fromIntegral x && n <= fromIntegral y
 
 null :: Clients -> Bool
-null = Map.null . clients
+null = Map.null . (userClients . clients)
 
 nil :: Clients
-nil = Clients Map.empty
+nil = Clients $ UserClients Map.empty
 
 userIds :: Clients -> [UserId]
-userIds = Map.keys . clients
+userIds = Map.keys . (userClients . clients)
 
 clientIds :: UserId -> Clients -> [ClientId]
-clientIds u c = Set.toList $ fromMaybe Set.empty (Map.lookup u (clients c))
+clientIds u c = Set.toList $ fromMaybe Set.empty (Map.lookup u ((userClients . clients) c))
 
 toList :: Clients -> [(UserId, [ClientId])]
-toList = Map.foldrWithKey' fn [] . clients
+toList = Map.foldrWithKey' fn [] . (userClients . clients)
   where
     fn u c a = (u, Set.toList c) : a
 
 fromList :: [(UserId, [ClientId])] -> Clients
-fromList = Clients . foldr fn Map.empty
+fromList = Clients . UserClients . foldr fn Map.empty
   where
     fn (u, c) = Map.insert u (Set.fromList c)
 
+fromUserClients :: UserClients -> Clients
+fromUserClients ucs = Clients ucs
+
 fromMap :: Map UserId (Set ClientId) -> Clients
-fromMap = Clients
+fromMap = Clients . UserClients
 
 toMap :: Clients -> Map UserId (Set ClientId)
-toMap = clients
+toMap = userClients . clients
 
 singleton :: UserId -> [ClientId] -> Clients
-singleton u c = Clients $ Map.singleton u (Set.fromList c)
+singleton u c =
+  Clients . UserClients $ Map.singleton u (Set.fromList c)
 
 filter :: (UserId -> Bool) -> Clients -> Clients
-filter p = Clients . Map.filterWithKey (\u _ -> p u) . clients
+filter p = Clients . UserClients .
+  Map.filterWithKey (\u _ -> p u) . (userClients . clients)
 
 contains :: UserId -> ClientId -> Clients -> Bool
-contains u c = maybe False (Set.member c) . Map.lookup u . clients
+contains u c =
+  maybe False (Set.member c) . Map.lookup u . (userClients . clients)
 
 insert :: UserId -> ClientId -> Clients -> Clients
-insert u c = Clients . Map.insertWith Set.union u (Set.singleton c) . clients
+insert u c = Clients . UserClients .
+  Map.insertWith Set.union u (Set.singleton c) . (userClients . clients)
 
 diff :: Clients -> Clients -> Clients
-diff (Clients ca) (Clients cb) = Clients $ Map.differenceWith fn ca cb
+diff (Clients (UserClients ca)) (Clients (UserClients cb)) =
+  Clients . UserClients $ Map.differenceWith fn ca cb
   where
     fn a b =
         let d = a `Set.difference` b in
         if Set.null d then Nothing else Just d
 
 rmClient :: UserId -> ClientId -> Clients -> Clients
-rmClient u c (Clients m) = Clients $ Map.update f u m
+rmClient u c (Clients (UserClients m)) =
+  Clients . UserClients $ Map.update f u m
   where
     f x = let s = Set.delete c x in if Set.null s then Nothing else Just s

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -18,6 +18,7 @@ import Data.Id
 import Data.Int
 import Data.List ((\\), find)
 import Data.List1
+import Data.Misc
 import Data.Maybe
 import Data.Monoid
 import Galley.Types
@@ -174,7 +175,7 @@ postCryptoMessage1 g b c = do
 
     -- Deleted eve
     WS.bracketR2 c bob eve $ \(wsB, wsE) -> do
-        deleteClient g eve ec !!! const 200 === statusCode
+        deleteClient b eve ec (Just $ PlainTextPassword defPassword) !!! const 200 === statusCode
         let m4 = [(bob, bc, "ciphertext4"), (eve, ec, "ciphertext4")]
         postOtrMessage id g alice ac conv m4 !!! do
             const 201 === statusCode

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -822,14 +822,14 @@ postCryptoBroadcastMessageJson2 g b c a = do
     let m1 = [(bob, bc, "ciphertext1")]
     Util.postOtrBroadcastMessage id g alice ac m1 !!! do
         const 412 === statusCode
-        assertTrue_ (eqMismatch [(charlie, Set.singleton cc)] [] [] . decodeBody)
+        assertTrue "1: Only Charlie and his device" (eqMismatch [(charlie, Set.singleton cc)] [] [] . decodeBody)
 
     -- Complete
     WS.bracketR2 c bob charlie $ \(wsB, wsE) -> do
         let m2 = [(bob, bc, "ciphertext2"), (charlie, cc, "ciphertext2")]
         Util.postOtrBroadcastMessage id g alice ac m2 !!! do
             const 201 === statusCode
-            assertTrue_ (eqMismatch [] [] [] . decodeBody)
+            assertTrue "No devices expected" (eqMismatch [] [] [] . decodeBody)
         void . liftIO $ WS.assertMatch t wsB (wsAssertOtr (selfConv bob) alice ac bc "ciphertext2")
         void . liftIO $ WS.assertMatch t wsE (wsAssertOtr (selfConv charlie) alice ac cc "ciphertext2")
 
@@ -838,7 +838,7 @@ postCryptoBroadcastMessageJson2 g b c a = do
         let m3 = [(alice, ac, "ciphertext3"), (bob, bc, "ciphertext3"), (charlie, cc, "ciphertext3")]
         Util.postOtrBroadcastMessage id g alice ac m3 !!! do
             const 201 === statusCode
-            assertTrue_ (eqMismatch [] [(alice, Set.singleton ac)] [] . decodeBody)
+            assertTrue "2: Only Alice and her device" (eqMismatch [] [(alice, Set.singleton ac)] [] . decodeBody)
         void . liftIO $ WS.assertMatch t wsB (wsAssertOtr (selfConv bob) alice ac bc "ciphertext3")
         void . liftIO $ WS.assertMatch t wsE (wsAssertOtr (selfConv charlie) alice ac cc "ciphertext3")
         -- Alice should not get it
@@ -846,11 +846,11 @@ postCryptoBroadcastMessageJson2 g b c a = do
 
     -- Deleted charlie
     WS.bracketR2 c bob charlie $ \(wsB, wsE) -> do
-        deleteClient g charlie cc !!! const 200 === statusCode
+        deleteClient b charlie cc (Just $ PlainTextPassword defPassword) !!! const 200 === statusCode
         let m4 = [(bob, bc, "ciphertext4"), (charlie, cc, "ciphertext4")]
         Util.postOtrBroadcastMessage id g alice ac m4 !!! do
             const 201 === statusCode
-            assertTrue_ (eqMismatch [] [] [(charlie, Set.singleton cc)] . decodeBody)
+            assertTrue "3: Only Charlie and his device" (eqMismatch [] [] [(charlie, Set.singleton cc)] . decodeBody)
         void . liftIO $ WS.assertMatch t wsB (wsAssertOtr (selfConv bob) alice ac bc "ciphertext4")
         -- charlie should not get it
         assertNoMsg wsE (wsAssertOtr (selfConv charlie) alice ac cc "ciphertext4")

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -297,8 +297,8 @@ postJoinConv g u c = post $ g
     . zConn "conn"
     . zType "access"
 
-deleteClient :: Galley -> UserId -> ClientId -> Http ResponseLBS
-deleteClient g u c = delete $ g
+deleteClientInternal :: Galley -> UserId -> ClientId -> Http ResponseLBS
+deleteClientInternal g u c = delete $ g
     . zUser u
     . zConn "conn"
     . paths ["i", "clients", toByteString' c]
@@ -479,6 +479,19 @@ ensureDeletedState b check from u =
         . zUser from
         . zConn "conn"
         ) !!! const (Just check) === fmap profileDeleted . decodeBody
+
+-- TODO: Refactor, as used also in brig
+deleteClient :: Brig -> UserId -> ClientId -> Maybe PlainTextPassword -> Http ResponseLBS
+deleteClient b u c pw = delete $ b
+    . paths ["clients", toByteString' c]
+    . zUser u
+    . zConn "conn"
+    . contentJson
+    . body payload
+  where
+    payload = RequestBodyLBS . encode $ object
+        [ "password" .= pw
+        ]
 
 -- TODO: Refactor, as used also in brig
 isUserDeleted :: Brig -> UserId -> Http Bool


### PR DESCRIPTION
Change the Galley read path for client lookup to go through Brig. The write path is still the same, i.e. Galley still writes its own client mapping to Cassandra. This way we can we test the implications of the higher read latency before making a (potential) full switch.

The current code has two identical definitions for userid to client mappings, one for internal use in Galley and one for serialization. This is changed slightly so that the external representation is wrapped in the internal one (it's not pretty but it works).