### PR TITLE
parallelize client lookups if ids > 128

### DIFF
--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -41,6 +41,7 @@ import Control.Lens ((&), (.~), (?~), (^.), (<&>), set, view)
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
+import Control.Concurrent.Async.Lifted.Safe (mapConcurrently)
 import Data.Bool (bool)
 import Data.Foldable
 import Data.Id
@@ -49,6 +50,7 @@ import Data.Maybe (fromMaybe, catMaybes)
 import Data.Range hiding ((<|))
 import Data.Text (Text)
 import Data.Time
+import Data.List.Split (chunksOf)
 import Galley.App
 import Galley.API.Error
 import Galley.API.Mapping
@@ -439,9 +441,13 @@ withValidOtrBroadcastRecipients usr clt rcps val now go = Teams.withBindingTeam 
     tMembers <- fmap (view userId) <$> Data.teamMembers tid
     contacts <- getContactList usr
     let users = Set.toList $ Set.union (Set.fromList tMembers) (Set.fromList contacts)
-    clts  <- Data.lookupClients users
+    clts  <- lookupClientsAsync users
     let membs = Data.newMember <$> users
     handleOtrResponse usr clt rcps membs clts val now go
+  where
+    -- do a maximum of 16 parallel lookups of up to 128 users each
+    lookupClientsAsync users = Clients.fromList . concat . concat <$>
+          forM (chunksOf 2048 users) (mapConcurrently Data.lookupClients' . chunksOf 128)
 
 withValidOtrRecipients
     :: UserId

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -59,6 +59,7 @@ module Galley.Data
     -- * Clients
     , eraseClients
     , lookupClients
+    , lookupClients'
     , updateClient
 
     -- * Utilities
@@ -544,7 +545,10 @@ updateClient add usr cls = do
     retry x5 $ write (q cls) (params Quorum (Identity usr))
 
 lookupClients :: MonadClient m => [UserId] -> m Clients
-lookupClients usrs = Clients.fromList . map (second fromSet) <$>
+lookupClients = fmap Clients.fromList . lookupClients'
+
+lookupClients' :: MonadClient m => [UserId] -> m [(UserId, [ClientId])]
+lookupClients' usrs = map (second fromSet) <$>
     retry x1 (query Cql.selectClients (params Quorum (Identity usrs)))
 
 eraseClients :: MonadClient m => UserId -> m ()


### PR DESCRIPTION
`withValidBroadcastRecipients` currently has a theoretical limit of 1127 users. Instead of a single `IN` lookup, this PR instead does multiple smaller lookups in parallel. 