### PR TITLE
Issue 575

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -304,6 +304,7 @@ executable brig-integration
         API.Search
         API.Search.Util
         API.Team
+        API.Team.Util
         API.TURN
         API.User.Auth
         Util
@@ -342,6 +343,7 @@ executable brig-integration
       , options               >= 0.1
       , pem
       , random                >= 1.0
+      , retry                 >= 0.6
       , safe                  >= 0.3
       , semigroups
       , tasty                 >= 0.3.1

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -36,6 +36,7 @@ module Brig.IO.Intra
     , getTeamMember
     , getTeamMembers
     , getTeam
+    , getTeamConv
     , getTeamId
     , getTeamContacts
     , changeTeamStatus
@@ -421,6 +422,20 @@ getConv usr cnv = do
         _   -> return Nothing
   where
     req = paths ["conversations", toByteString' cnv]
+        . zUser usr
+        . expect [status200, status404]
+
+getTeamConv :: UserId -> TeamId -> ConvId -> AppIO (Maybe Team.TeamConversation)
+getTeamConv usr tid cnv = do
+    debug $ remote "galley"
+          . field "conv" (toByteString cnv)
+          . msg (val "Getting team conversation")
+    rs <- galleyRequest GET req
+    case Bilge.statusCode rs of
+        200 -> Just <$> decodeBody "galley" rs
+        _   -> return Nothing
+  where
+    req = paths ["teams", toByteString' tid, "conversations", toByteString' cnv]
         . zUser usr
         . expect [status200, status404]
 

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -11,7 +11,6 @@ import Data.Aeson
 import Data.ByteString.Conversion
 import Data.Id hiding (client)
 import Data.Range
-import Data.Text (Text)
 import Galley.Types (ConvTeamInfo (..), NewConv (..))
 import Util
 
@@ -40,10 +39,10 @@ addTeamMember galley tid mem =
                 . lbytes (encode mem)
                 )
 
-createTeamConv :: Galley -> TeamId -> UserId -> [UserId] -> Maybe Text -> Http ConvId
-createTeamConv g tid u us name = do
-    let tinfo = Just $ ConvTeamInfo tid False
-    let conv = NewConv us name (Set.fromList []) tinfo
+createTeamConv :: Galley -> TeamId -> UserId -> [UserId] -> Bool -> Http ConvId
+createTeamConv g tid u us managed = do
+    let tinfo = Just $ ConvTeamInfo tid managed
+    let conv = NewConv us Nothing (Set.fromList []) tinfo
     r <- post ( g
               . path "/conversations"
               . zUser u

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
+
+module API.Team.Util where
+
+import Bilge hiding (accept, timeout, head)
+import Bilge.Assert
+import Control.Monad
+import Data.Aeson
+import Data.ByteString.Conversion
+import Data.Id hiding (client)
+import Data.Range
+import Data.Text (Text)
+import Galley.Types (ConvTeamInfo (..), NewConv (..))
+import Util
+
+import qualified Data.Set                    as Set
+import qualified Galley.Types.Teams          as Team
+
+createTeam :: UserId -> Galley -> Http TeamId
+createTeam u galley = do
+    tid <- randomId
+    r <- put ( galley
+              . paths ["i", "teams", toByteString' tid]
+              . contentJson
+              . zAuthAccess u "conn"
+              . expect2xx
+              . lbytes (encode newTeam)
+              )
+    maybe (error "invalid team id") return $
+        fromByteString $ getHeader' "Location" r
+
+addTeamMember :: Galley -> TeamId -> Team.NewTeamMember -> Http ()
+addTeamMember galley tid mem =
+    void $ post ( galley
+                . paths ["i", "teams", toByteString' tid, "members"]
+                . contentJson
+                . expect2xx
+                . lbytes (encode mem)
+                )
+
+createTeamConv :: Galley -> TeamId -> UserId -> [UserId] -> Maybe Text -> Http ConvId
+createTeamConv g tid u us name = do
+    let tinfo = Just $ ConvTeamInfo tid False
+    let conv = NewConv us name (Set.fromList []) tinfo
+    r <- post ( g
+              . path "/conversations"
+              . zUser u
+              . zConn "conn"
+              . contentJson
+              . lbytes (encode conv)
+              ) <!! const 201 === statusCode
+    maybe (error "invalid conv id") return $
+        fromByteString $ getHeader' "Location" r
+
+deleteTeamConv :: Galley -> TeamId -> ConvId -> UserId -> Http ()
+deleteTeamConv g tid cid u = do
+    delete ( g
+           . paths ["teams", toByteString' tid, "conversations", toByteString' cid]
+           . zUser u
+           . zConn "conn"
+           ) !!! const 200 === statusCode
+
+deleteTeam :: Galley -> TeamId -> UserId -> Http ()
+deleteTeam g tid u = do
+    delete ( g
+           . paths ["teams", toByteString' tid]
+           . zUser u
+           . zConn "conn"
+           . lbytes (encode $ Team.newTeamDeleteData Util.defPassword)
+           ) !!! const 202 === statusCode
+
+newTeam :: Team.BindingNewTeam
+newTeam = Team.BindingNewTeam $ Team.newNewTeam (unsafeRange "teamName") (unsafeRange "defaultIcon")

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -200,6 +200,7 @@ executable galley-integration
       , http-client-tls
       , http-types
       , lens
+      , lens-aeson
       , mtl
       , network
       , optparse-applicative

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -63,9 +63,6 @@ noAddToManaged = Error status403 "no-add-to-managed" "Adding users directly to m
 teamNotFound :: Error
 teamNotFound = Error status404 "no-team" "team not found"
 
-noBotsInTeamConvs :: Error
-noBotsInTeamConvs = Error status403 "bots-not-allowed" "Adding bots to team conversations is not allowed."
-
 invalidPermissions :: Error
 invalidPermissions = Error status403 "invalid-permissions" "The specified permissions are invalid."
 

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -58,7 +58,7 @@ noOtherOwner = Error status403 "no-other-owner" "You are trying to remove or dow
                             \ an owner. Promote another team member before proceeding."
 
 noAddToManaged :: Error
-noAddToManaged = Error status403 "no-add-to-managed" "Adding users directly to managed conversation is not allowed."
+noAddToManaged = Error status403 "no-add-to-managed" "Adding users/bots directly to managed conversation is not allowed."
 
 teamNotFound :: Error
 teamNotFound = Error status404 "no-team" "team not found"

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -31,6 +31,7 @@ module Galley.API.Teams
 
 import Cassandra (result, hasMore)
 import Control.Concurrent.Async (mapConcurrently)
+import Control.Concurrent.Lifted (fork)
 import Control.Lens hiding (from, to)
 import Control.Monad (unless, when, void)
 import Control.Monad.Catch
@@ -43,12 +44,13 @@ import Data.List1 (list1)
 import Data.List (partition)
 import Data.Maybe (catMaybes, isJust)
 import Data.Range
-import Data.Time.Clock (getCurrentTime)
+import Data.Time.Clock (getCurrentTime, UTCTime (..))
 import Data.Traversable (mapM)
 import Data.Set (fromList, toList)
 import Galley.App
 import Galley.API.Error
 import Galley.API.Util
+import Galley.Data.Services (BotMember)
 import Galley.Intra.Push
 import Galley.Intra.User
 import Galley.Options
@@ -62,6 +64,7 @@ import Prelude hiding (head, mapM)
 
 import qualified Data.Set as Set
 import qualified Galley.Data as Data
+import qualified Galley.External as External
 import qualified Galley.Queue as Q
 import qualified Galley.Types as Conv
 import qualified Galley.Types.Teams as Teams
@@ -174,23 +177,28 @@ uncheckedDeleteTeam :: UserId -> Maybe ConnId -> TeamId -> Galley ()
 uncheckedDeleteTeam zusr zcon tid = do
     team <- Data.team tid
     when (isJust team) $ do
-        membs  <- Data.teamMembers tid
-        now    <- liftIO getCurrentTime
-        convs  <- filter (not . view managedConversation) <$> Data.teamConversations tid
-        events <- foldrM (pushEvents now membs) [] convs
+        membs    <- Data.teamMembers tid
+        now      <- liftIO getCurrentTime
+        convs    <- filter (not . view managedConversation) <$> Data.teamConversations tid
+        (ue, be) <- foldrM (pushEvents now membs) ([],[]) convs
         let e = newEvent TeamDelete tid now
         let r = list1 (userRecipient zusr) (membersToRecipients (Just zusr) membs)
-        pushSome ((newPush1 zusr (TeamEvent e) r & pushConn .~ zcon) : events)
+        pushSome ((newPush1 zusr (TeamEvent e) r & pushConn .~ zcon) : ue)
+        void . fork $ void $ External.deliver be
         when ((view teamBinding . tdTeam <$> team) == Just Binding) $ do
             mapM_ (deleteUser . view userId) membs
             Journal.teamDelete tid
         Data.deleteTeam tid
   where
-    pushEvents now membs c pp = do
-        mm <- flip nonTeamMembers membs <$> Data.members (c^.conversationId)
+    pushEvents :: UTCTime -> [TeamMember] -> TeamConversation -> ([Push],[(BotMember, Conv.Event)]) -> Galley ([Push],[(BotMember, Conv.Event)])
+    pushEvents now membs c (pp, ee) = do
+        (bots, users) <- botsAndUsers <$> Data.members (c^.conversationId)
+        let mm = nonTeamMembers users membs
         let e = Conv.Event Conv.ConvDelete (c^.conversationId) zusr now Nothing
         let p = newPush zusr (ConvEvent e) (map recipient mm)
-        pure (maybe pp (\x -> (x & pushConn .~ zcon) : pp) p)
+        let ee' = bots `zip` repeat e
+        let pp' = maybe pp (\x -> (x & pushConn .~ zcon) : pp) p
+        pure (pp', ee' ++ ee)
 
 getTeamMembers :: UserId ::: TeamId ::: JSON -> Galley Response
 getTeamMembers (zusr::: tid ::: _) = do
@@ -335,10 +343,12 @@ uncheckedRemoveTeamMember zusr zcon tid remove mems = do
                 pushEvent tmids edata now dc
   where
     pushEvent tmids edata now dc = do
-        let x = filter (\m -> not (Conv.memId m `Set.member` tmids)) (Data.convMembers dc)
+        let (bots, users) = botsAndUsers (Data.convMembers dc)
+        let x = filter (\m -> not (Conv.memId m `Set.member` tmids)) users
         let y = Conv.Event Conv.MemberLeave (Data.convId dc) zusr now (Just edata)
         for_ (newPush zusr (ConvEvent y) (recipient <$> x)) $ \p ->
             push1 $ p & pushConn .~ zcon
+        void . fork $ void $ External.deliver (bots `zip` repeat y)
 
 getTeamConversations :: UserId ::: TeamId ::: JSON -> Galley Response
 getTeamConversations (zusr::: tid ::: _) = do
@@ -358,7 +368,7 @@ deleteTeamConversation :: UserId ::: ConnId ::: TeamId ::: ConvId ::: JSON -> Ga
 deleteTeamConversation (zusr::: zcon ::: tid ::: cid ::: _) = do
     tmems <- Data.teamMembers tid
     void $ permissionCheck zusr DeleteConversation tmems
-    cmems <- Data.members cid
+    (bots, cmems) <- botsAndUsers <$> Data.members cid
     now <- liftIO getCurrentTime
     let te = newEvent Teams.ConvDelete tid now & eventData .~ Just (Teams.EdConvDelete cid)
     let ce = Conv.Event Conv.ConvDelete cid zusr now Nothing
@@ -367,6 +377,7 @@ deleteTeamConversation (zusr::: zcon ::: tid ::: cid ::: _) = do
     case map recipient (nonTeamMembers cmems tmems) of
         []     -> push1 p
         (m:mm) -> pushSome [p, newPush1 zusr (ConvEvent ce) (list1 m mm) & pushConn .~ Just zcon]
+    void . fork $ void $ External.deliver (bots `zip` repeat ce)
     Data.removeTeamConv tid cid
     pure empty
 

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -337,8 +337,6 @@ addBot (zusr ::: zcon ::: req ::: _) = do
     when (Data.isConvDeleted c) $ do
         Data.deleteConversation (b^.addBotConv)
         throwM convNotFound
-    when (Data.isTeamConv c) $
-        throwM noBotsInTeamConvs
     let (bots, users) = botsAndUsers (Data.convMembers c)
     unless (zusr `isMember` users) $
         throwM convNotFound

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -146,7 +146,7 @@ addMembers (zusr ::: zcon ::: cid ::: req ::: _) = do
         void $ permissionCheck zusr AddConversationMember tms
         tcv <- Data.teamConversation tid cid
         when (maybe True (view managedConversation) tcv) $
-            throwM (invalidOp "Users can not be added to managed conversations.")
+            throwM noAddToManaged
         ensureMemberLimit (toList $ Data.convMembers conv) new_users
         ensureConnected zusr (notTeamMember (fromRange to_add) tms)
 
@@ -337,12 +337,10 @@ addBot (zusr ::: zcon ::: req ::: _) = do
     when (Data.isConvDeleted c) $ do
         Data.deleteConversation (b^.addBotConv)
         throwM convNotFound
-    let (bots, users) = botsAndUsers (Data.convMembers c)
-    unless (zusr `isMember` users) $
-        throwM convNotFound
-    ensureGroupConv c
-    unless (any ((== b^.addBotId) . botMemId) bots) $
-        ensureMemberLimit (toList $ Data.convMembers c) [botUserId (b^.addBotId)]
+    -- Check some preconditions on adding bots to a conversation
+    for_ (Data.convTeam c) $ teamConvChecks (b^.addBotConv)
+    (bots, users) <- regularConvChecks b c
+
     t <- liftIO getCurrentTime
     Data.updateClient True (botUserId (b^.addBotId)) (b^.addBotClient)
     (e, bm) <- Data.addBotMember zusr (b^.addBotService) (b^.addBotId) (b^.addBotConv) t
@@ -350,6 +348,22 @@ addBot (zusr ::: zcon ::: req ::: _) = do
         push1 $ p & pushConn ?~ zcon
     void . fork $ void $ External.deliver ((bm:bots) `zip` repeat e)
     return (json e)
+  where
+    regularConvChecks b c = do
+        let (bots, users) = botsAndUsers (Data.convMembers c)
+        unless (zusr `isMember` users) $
+            throwM convNotFound
+        ensureGroupConv c
+        unless (any ((== b^.addBotId) . botMemId) bots) $
+            ensureMemberLimit (toList $ Data.convMembers c) [botUserId (b^.addBotId)]
+        return (bots, users)
+
+    teamConvChecks cid tid = do
+        tms <- Data.teamMembers tid
+        void $ permissionCheck zusr AddConversationMember tms
+        tcv <- Data.teamConversation tid cid
+        when (maybe True (view managedConversation) tcv) $
+            throwM noAddToManaged
 
 rmBot :: UserId ::: Maybe ConnId ::: Request ::: JSON -> Galley Response
 rmBot (zusr ::: zcon ::: req ::: _) = do


### PR DESCRIPTION
This PR allows bots to be added to team conversations. It's ready for review, except for:

 * Ensure that bots can be added _only_ to non-managed team conversations
 * Minor test refactor