### PR TITLE
Internal user deletion endpoint should not cause orphan teams

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -64,6 +64,7 @@ library
       , Brig.Team.DB
       , Brig.Team.Email
       , Brig.Team.Template
+      , Brig.Team.Util
       , Brig.Template
       , Brig.TURN
       , Brig.TURN.API

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -73,6 +73,7 @@ import qualified Data.Set                      as Set
 import qualified Data.Text                     as Text
 import qualified Brig.Provider.API             as Provider
 import qualified Brig.Team.API                 as Team
+import qualified Brig.Team.Util                as Team
 import qualified Brig.Team.Email               as Team
 import qualified Brig.TURN.API                 as TURN
 
@@ -1154,6 +1155,9 @@ deleteUserNoVerify uid = do
     acc <- lift $ API.lookupAccount uid
     unless (isJust acc) $
         throwStd userNotFound
+    onlyTeamOwner <- lift $ Team.isOnlyTeamOwner uid
+    when onlyTeamOwner $
+        throwStd noOtherOwner
     ok <- lift $ InternalNotification.publish (Aws.DeleteUser uid)
     unless ok $
         throwStd failedQueueEvent

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -109,6 +109,7 @@ import qualified Brig.Data.UserKey          as Data
 import qualified Brig.IO.Intra              as Intra
 import qualified Brig.Types.Team.Invitation as Team
 import qualified Brig.Team.DB               as Team
+import qualified Brig.Team.Util             as Team
 import qualified Data.Map.Strict            as Map
 import qualified Galley.Types.Teams         as Team
 import qualified Galley.Types.Teams.Intra   as Team
@@ -642,10 +643,10 @@ deleteUser uid pwd = do
             Suspended -> ensureNotOnlyOwner >> go a
             Active    -> ensureNotOnlyOwner >> go a
   where
-    ensureNotOnlyOwner = lift (Intra.getTeamContacts uid) >>= \case
-        Just mems | Team.isOnlyOwner uid (mems^.Team.teamMembers) ->
+    ensureNotOnlyOwner = do
+        onlyOwner <- lift $ Team.isOnlyTeamOwner uid
+        when onlyOwner $
             throwE DeleteUserOnlyOwner
-        _ -> return ()
 
     go a = maybe (byIdentity a) (byPassword a) pwd
 

--- a/services/brig/src/Brig/Team/Util.hs
+++ b/services/brig/src/Brig/Team/Util.hs
@@ -1,0 +1,15 @@
+module Brig.Team.Util where
+
+import Brig.App
+import Control.Lens
+import Data.Id
+import Galley.Types.Teams
+
+import qualified Brig.IO.Intra as Intra
+
+isOnlyTeamOwner :: UserId -> AppIO Bool
+isOnlyTeamOwner uid = do
+    contacts <- Intra.getTeamContacts uid
+    return $ case contacts of
+        Just mems | isOnlyOwner uid (mems^.teamMembers) -> True
+        _                                               -> False

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -61,7 +61,7 @@ tests m b c g =
             , test m "get /teams/:tid/invitations/info - 400"              $ testInvitationInfoBadCode b
             , test m "post /i/teams/:tid/suspend - 200"                    $ testSuspendTeam b g
             , test m "put /self - 200 update events"                       $ testUpdateEvents b g c
-            , test m "delete /self - 200 (ensure no orphan teams)"         $ testDeleteTeamUser b g
+            , test m "delete {/self,/i/users/:id} - 200 (no orphan teams)" $ testDeleteTeamUser b g
             , test m "post /connections - 403 (same binding team)"         $ testConnectionSameTeam b g
             ]
         , testGroup "search"
@@ -414,6 +414,10 @@ testDeleteTeamUser brig galley = do
     tid     <- createTeam creator galley
     -- Cannot delete the user since it will make the team orphan
     deleteUser creator (Just defPassword) brig !!! do
+        const 403 === statusCode
+        const (Just "no-other-owner") === fmap Error.label . decodeBody
+    -- Ensure internal endpoints are also exercised
+    deleteUserInternal creator brig !!! do
         const 403 === statusCode
         const (Just "no-other-owner") === fmap Error.label . decodeBody
     -- We need to invite another user to a full permission member

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -131,6 +131,10 @@ deleteUser u p brig = delete $ brig
     . zUser u
     . body (RequestBodyLBS (encode (mkDeleteUser p)))
 
+deleteUserInternal :: UserId -> Brig -> Http ResponseLBS
+deleteUserInternal u brig = delete $ brig
+    . paths ["/i/users", toByteString' u]
+
 activate :: Brig -> ActivationPair -> Http ResponseLBS
 activate brig (k, c) = get $ brig
     . path "activate"


### PR DESCRIPTION
Similarly to the public endpoint, this PR ensures that using the internal deletion endpoint to delete users will not cause teams to become "orphan" (i.e., without a full permission user)