### PR TITLE
Issue 663

### DIFF
--- a/libs/brig-types/brig-types.cabal
+++ b/libs/brig-types/brig-types.cabal
@@ -44,6 +44,7 @@ library
       , bytestring            >= 0.9
       , bytestring-conversion >= 0.2
       , containers            >= 0.5
+      , currency-codes        >= 2.0
       , galley-types          >= 0.45.7
       , errors                >= 1.4
       , hashable

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -278,9 +278,8 @@ newtype InvitationCode = InvitationCode
 
 data BindingNewUserTeam = BindingNewUserTeam
     { bnuTeam     :: BindingNewTeam
-    -- TODO: Remove Currency selection once billing supports
-    --       currency changes after team creation
     , bnuCurrency :: Maybe Currency.Alpha
+    -- TODO: Remove Currency selection once billing supports currency changes after team creation
     }
 
 instance FromJSON BindingNewUserTeam where
@@ -291,10 +290,10 @@ instance FromJSON BindingNewUserTeam where
     parseJSON _ = fail "parseJSON BindingNewUserTeam: must be an object"
 
 instance ToJSON BindingNewUserTeam where
-    toJSON (BindingNewUserTeam c t) = do
-        let (Object c') = toJSON c
-            (Object t') = toJSON t
-         in Object (HashMap.union c' t')
+    toJSON (BindingNewUserTeam t c) = do
+        let (Object t') = toJSON t
+         in object $ "currency" .= c
+                   # HashMap.toList t'
 
 newtype NewUserTeam = NewUserTeam { nuTeam :: Either InvitationCode BindingNewUserTeam}
 

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -277,8 +277,8 @@ newtype InvitationCode = InvitationCode
     deriving (Eq, Show, FromJSON, ToJSON, ToByteString, FromByteString)
 
 data BindingNewUserTeam = BindingNewUserTeam
-    { bnuTeam     :: BindingNewTeam
-    , bnuCurrency :: Maybe Currency.Alpha
+    { bnuTeam     :: !BindingNewTeam
+    , bnuCurrency :: !(Maybe Currency.Alpha)
     -- TODO: Remove Currency selection once billing supports currency changes after team creation
     }
 

--- a/libs/brig-types/stack.yaml
+++ b/libs/brig-types/stack.yaml
@@ -10,5 +10,6 @@ flags:
     protobuf: True
     arbitrary: True
 
-extra-deps: []
+extra-deps:
+- currency-codes-2.0.0.0
 extra-package-dbs: []

--- a/libs/galley-types/galley-types.cabal
+++ b/libs/galley-types/galley-types.cabal
@@ -34,6 +34,7 @@ library
       , bytestring            >= 0.9
       , bytestring-conversion >= 0.2
       , containers            >= 0.5
+      , currency-codes        >= 2.0
       , data-default          >= 0.5
       , gundeck-types         >= 1.15.13
       , lens                  >= 4.12

--- a/libs/galley-types/src/Galley/Types/Teams/Intra.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Intra.hs
@@ -58,6 +58,7 @@ instance FromJSON TeamData where
 data TeamStatusUpdate = TeamStatusUpdate
     { tuStatus   :: TeamStatus
     , tuCurrency :: Maybe Currency.Alpha
+    -- TODO: Remove Currency selection once billing supports currency changes after team creation
     }
 
 instance FromJSON TeamStatusUpdate where

--- a/libs/galley-types/src/Galley/Types/Teams/Intra.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Intra.hs
@@ -56,8 +56,8 @@ instance FromJSON TeamData where
                  <*> o .:? "status_time"
 
 data TeamStatusUpdate = TeamStatusUpdate
-    { tuStatus   :: TeamStatus
-    , tuCurrency :: Maybe Currency.Alpha
+    { tuStatus   :: !TeamStatus
+    , tuCurrency :: !(Maybe Currency.Alpha)
     -- TODO: Remove Currency selection once billing supports currency changes after team creation
     }
 

--- a/libs/galley-types/src/Galley/Types/Teams/Intra.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Intra.hs
@@ -11,6 +11,8 @@ import Data.Text (Text)
 import Data.Time (UTCTime)
 import Galley.Types.Teams (Team)
 
+import qualified Data.Currency as Currency
+
 data TeamStatus
     = Active
     | PendingDelete
@@ -53,15 +55,20 @@ instance FromJSON TeamData where
                  <*> o .:  "status"
                  <*> o .:? "status_time"
 
-newtype TeamStatusUpdate = TeamStatusUpdate
-    { tuStatus :: TeamStatus }
+data TeamStatusUpdate = TeamStatusUpdate
+    { tuStatus   :: TeamStatus
+    , tuCurrency :: Maybe Currency.Alpha
+    }
 
 instance FromJSON TeamStatusUpdate where
     parseJSON = withObject "team-status-update" $ \o ->
-        TeamStatusUpdate <$> o .: "status"
+        TeamStatusUpdate <$> o .:  "status"
+                         <*> o .:? "currency"
 
 instance ToJSON TeamStatusUpdate where
-    toJSON s = object ["status" .= tuStatus s]
+    toJSON s = object [ "status"   .= tuStatus s
+                      , "currency" .= tuCurrency s
+                      ]
 
 newtype TeamName = TeamName
     { tnName :: Text }

--- a/libs/galley-types/stack.yaml
+++ b/libs/galley-types/stack.yaml
@@ -10,5 +10,6 @@ flags:
     protobuf: True
     arbitrary: True
 
-extra-deps: []
+extra-deps:
+- currency-codes-2.0.0.0
 extra-package-dbs: []

--- a/libs/types-common-journal/proto/TeamEvents.proto
+++ b/libs/types-common-journal/proto/TeamEvents.proto
@@ -10,8 +10,9 @@ message TeamEvent {
     optional EventData event_data = 4;
 
     message EventData {
-        required int32 member_count = 1;
-        repeated bytes billing_user = 2;
+        required int32  member_count = 1;
+        repeated bytes  billing_user = 2;
+        optional string currency     = 3; // ISO_4217
     }
 
     enum EventType {

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -103,6 +103,7 @@ library
       , bytestring                >= 0.10
       , bytestring-conversion     >= 0.2
       , cassandra-util            >= 0.16.2
+      , currency-codes            >= 2.0
       , cookie                    >= 0.4
       , containers                >= 0.5
       , cryptobox-haskell         >= 0.1.1

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1145,7 +1145,7 @@ createUserNoVerify (_ ::: _ ::: req) = do
     forM_ (catMaybes [eac, pac]) $ \adata ->
         let key  = ActivateKey $ activationKey adata
             code = activationCode adata
-        in API.activate key code (Just uid) Nothing !>> actError
+        in API.activate key code (Just uid) !>> actError
     return . setStatus status201
            . addHeader "Location" (toByteString' uid)
            $ json (SelfProfile usr)
@@ -1488,7 +1488,7 @@ activate (Activate tgt code dryrun)
         API.preverify tgt code !>> actError
         return empty
     | otherwise = do
-        result <- API.activate tgt code Nothing Nothing !>> actError
+        result <- API.activate tgt code Nothing !>> actError
         return $ case result of
             ActivationSuccess ident first -> respond ident first
             ActivationPass                -> setStatus status204 empty

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -196,7 +196,7 @@ createUser new@NewUser{..} = do
                     return $ Just edata
                 Just c -> do
                     ak <- liftIO $ Data.mkActivationKey ek
-                    void $ activate (ActivateKey ak) c (Just uid) (join (bnuCurrency <$> newTeam)) !>> EmailActivationError
+                    void $ activate' (ActivateKey ak) c (Just uid) (join (bnuCurrency <$> newTeam)) !>> EmailActivationError
                     return Nothing
 
     -- Handle phone activation
@@ -212,7 +212,7 @@ createUser new@NewUser{..} = do
                     return $ Just pdata
                 Just c -> do
                     ak <- liftIO $ Data.mkActivationKey pk
-                    void $ activate (ActivateKey ak) c (Just uid) (join (bnuCurrency <$> newTeam)) !>> PhoneActivationError
+                    void $ activate' (ActivateKey ak) c (Just uid) (join (bnuCurrency <$> newTeam)) !>> PhoneActivationError
                     return Nothing
 
     return $! CreateUserResult account edata pdata (activatedTeam <|> joinedTeam)
@@ -269,7 +269,7 @@ createUser new@NewUser{..} = do
             throwE TooManyTeamMembers
         lift $ do
             activateUser uid ident
-            void $ onActivated (AccountActivated account) Nothing
+            void $ onActivated (AccountActivated account)
             Log.info $ field "user" (toByteString uid)
                      . field "team" (toByteString $ Team.iiTeam ii)
                      . msg (val "Accepting invitation")
@@ -286,7 +286,7 @@ createUser new@NewUser{..} = do
             throwE $ DuplicateUserKey uk
         lift $ do
             activateUser uid ident
-            void $ onActivated (AccountActivated account) Nothing
+            void $ onActivated (AccountActivated account)
             Log.info $ field "user" (toByteString uid)
                      . field "inviter" (toByteString $ iiInviter ii)
                      . msg (val "Accepting invitation")
@@ -466,19 +466,18 @@ changeAccountStatus usrs status = do
 
 activate :: ActivationTarget
          -> ActivationCode
-         -> Maybe UserId         -- ^ The user for whom to activate the key.
-         -> Maybe Currency.Alpha -- ^ TODO: Potential currency update
+         -> Maybe UserId -- ^ The user for whom to activate the key.
          -> ExceptT ActivationError AppIO ActivationResult
-activate tgt code usr cur = do
-    key <- mkActivationKey tgt
-    activateKey key code usr cur
+activate tgt code usr = activate' tgt code usr Nothing
 
-activateKey :: ActivationKey
-            -> ActivationCode
-            -> Maybe UserId         -- ^ The user for whom to activate the key.
-            -> Maybe Currency.Alpha -- ^ TODO: Potential currency update
-            -> ExceptT ActivationError AppIO ActivationResult
-activateKey key code usr cur = do
+activate' :: ActivationTarget
+         -> ActivationCode
+         -> Maybe UserId         -- ^ The user for whom to activate the key.
+         -> Maybe Currency.Alpha -- ^ Potential currency update.
+         -- ^ TODO: to be removed once billing supports currency changes after team creation
+         -> ExceptT ActivationError AppIO ActivationResult
+activate' tgt code usr cur = do
+    key <- mkActivationKey tgt
     Log.info $ field "activation.key"  (toByteString key)
              . field "activation.code" (toByteString code)
              . msg (val "Activating")
@@ -486,32 +485,32 @@ activateKey key code usr cur = do
     case event of
         Nothing -> return ActivationPass
         Just  e -> do
-            (ident, first) <- lift $ onActivated e cur
+            (uid, ident, first) <- lift $ onActivated e
+            when first $
+                lift $ activateTeam uid
             return $ ActivationSuccess ident first
-
-onActivated :: ActivationEvent -> Maybe Currency.Alpha -> AppIO (Maybe UserIdentity, Bool)
-onActivated (AccountActivated account) cur = do
-    let uid = userId (accountUser account)
-    Log.info $ field "user" (toByteString uid) . msg (val "User activated")
-    Intra.onUserEvent uid Nothing $ UserActivated account
-    activateTeam uid cur
-    return (userIdentity (accountUser account), True)
-onActivated (EmailActivated uid email) _ = do
-    Intra.onUserEvent uid Nothing (emailUpdated uid email)
-    return (Just (EmailIdentity email), False)
-onActivated (PhoneActivated uid phone) _ = do
-    Intra.onUserEvent uid Nothing (phoneUpdated uid phone)
-    return (Just (PhoneIdentity phone), False)
-
-activateTeam :: UserId -> Maybe Currency.Alpha -> AppIO ()
-activateTeam uid cur = do
-    tid <- Intra.getTeamId uid
-    for_ tid $ \t -> Intra.changeTeamStatus t Team.Active cur
+  where
+    activateTeam uid = do
+        tid <- Intra.getTeamId uid
+        for_ tid $ \t -> Intra.changeTeamStatus t Team.Active cur
 
 preverify :: ActivationTarget -> ActivationCode -> ExceptT ActivationError AppIO ()
 preverify tgt code = do
     key <- mkActivationKey tgt
     void $ Data.verifyCode key code
+
+onActivated :: ActivationEvent -> AppIO (UserId, Maybe UserIdentity, Bool)
+onActivated (AccountActivated account) = do
+    let uid = userId (accountUser account)
+    Log.info $ field "user" (toByteString uid) . msg (val "User activated")
+    Intra.onUserEvent uid Nothing $ UserActivated account
+    return (uid, userIdentity (accountUser account), True)
+onActivated (EmailActivated uid email) = do
+    Intra.onUserEvent uid Nothing (emailUpdated uid email)
+    return (uid, Just (EmailIdentity email), False)
+onActivated (PhoneActivated uid phone) = do
+    Intra.onUserEvent uid Nothing (phoneUpdated uid phone)
+    return (uid, Just (PhoneIdentity phone), False)
 
 sendActivationCode :: Either Email Phone -> Maybe Locale -> Bool -> ExceptT SendActivationCodeError AppIO ()
 sendActivationCode emailOrPhone loc call = case emailOrPhone of

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -79,6 +79,7 @@ import System.Logger.Class hiding ((.=), name)
 import qualified Brig.User.Search.Index      as Search
 import qualified Brig.User.Event.Log         as Log
 import qualified Data.ByteString.Lazy        as BL
+import qualified Data.Currency               as Currency
 import qualified Data.HashMap.Strict         as M
 import qualified Data.Set                    as Set
 import qualified Gundeck.Types.Push.V2       as Push
@@ -612,14 +613,13 @@ getTeamName tid = do
     req = paths ["i", "teams", toByteString' tid, "name"]
         . expect2xx
 
-changeTeamStatus :: TeamId -> Team.TeamStatus -> AppIO ()
-changeTeamStatus tid s = do
-    debug $ remote "galley"
-            . msg (val "Change Team status")
+changeTeamStatus :: TeamId -> Team.TeamStatus -> Maybe Currency.Alpha -> AppIO ()
+changeTeamStatus tid s cur = do
+    debug $ remote "galley" . msg (val "Change Team status")
     void $ galleyRequest PUT req
   where
     req = paths ["i", "teams", toByteString' tid, "status"]
         . header "Content-Type" "application/json"
         . expect2xx
-        . lbytes (encode $ Team.TeamStatusUpdate s)
+        . lbytes (encode $ Team.TeamStatusUpdate s cur)
 

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -224,13 +224,13 @@ suspendTeam :: JSON ::: TeamId -> Handler Response
 suspendTeam (_ ::: tid) = do
     changeTeamAccountStatuses tid Suspended
     DB.deleteInvitations tid
-    lift $ Intra.changeTeamStatus tid Team.Suspended
+    lift $ Intra.changeTeamStatus tid Team.Suspended Nothing
     return empty
 
 unsuspendTeam :: JSON ::: TeamId -> Handler Response
 unsuspendTeam (_ ::: tid) = do
     changeTeamAccountStatuses tid Active
-    lift $ Intra.changeTeamStatus tid Team.Active
+    lift $ Intra.changeTeamStatus tid Team.Active Nothing
     return empty
 
 -------------------------------------------------------------------------------

--- a/services/brig/stack.yaml
+++ b/services/brig/stack.yaml
@@ -35,6 +35,7 @@ extra-deps:
 - aws-0.16
 - base58-bytestring-0.1.0
 - bloodhound-0.13.0.0
+- currency-codes-2.0.0.0
 - data-checked-0.3
 - data-textual-0.3.0.2
 - data-timeout-0.3

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -45,7 +45,7 @@ tests m b c g =
     return $ testGroup "team"
         [ testGroup "invitation"
             [ test m "post /teams/:tid/invitations - 201"                  $ testInvitationEmail b g
-            , test m "post /teams/:tid/invitations - 403 no permission"    $ testInvitationNoPermission b
+            , test m "post /teams/:tid/invitations - 403 no permission"    $ testInvitationNoPermission b g
             , test m "post /teams/:tid/invitations - 403 too many pending" $ testInvitationTooManyPending b g
             , test m "post /register - 201 accepted"                       $ testInvitationEmailAccepted b g
             , test m "post /register user & team - 201 accepted"           $ testCreateTeam b g
@@ -74,9 +74,8 @@ tests m b c g =
 
 testUpdateEvents :: Brig -> Galley -> Cannon -> Http ()
 testUpdateEvents brig galley cannon = do
-    inviteeEmail  <- randomEmail
-    alice         <- userId <$> randomUser brig
-    tid           <- createTeam alice galley
+    (alice, tid) <- createUserWithTeam brig galley
+    inviteeEmail <- randomEmail
 
     -- invite and register Bob
     let invite  = InvitationRequest inviteeEmail (Name "Bob") Nothing
@@ -108,17 +107,15 @@ testUpdateEvents brig galley cannon = do
 
 testInvitationEmail :: Brig -> Galley -> Http ()
 testInvitationEmail brig galley = do
+    (inviter, tid) <- createUserWithTeam brig galley
     invitee <- randomEmail
-    inviter <- userId <$> randomUser brig
-    tid     <- createTeam inviter galley
     let invite = InvitationRequest invitee (Name "Bob") Nothing
     void $ postInvitation brig tid inviter invite
 
 -- TODO: Use max team size from options
 testInvitationTooManyPending :: Brig -> Galley -> Http ()
 testInvitationTooManyPending brig galley = do
-    inviter <- userId <$> randomUser brig
-    tid     <- createTeam inviter galley
+    (inviter, tid) <- createUserWithTeam brig galley
     emails  <- replicateConcurrently 128 randomEmail
     let invite e = InvitationRequest e (Name "Bob") Nothing
     mapM_ (mapConcurrently_ $ postInvitation brig tid inviter . invite) (chunksOf 16 emails)
@@ -129,9 +126,8 @@ testInvitationTooManyPending brig galley = do
 
 testInvitationEmailAccepted :: Brig -> Galley -> Http ()
 testInvitationEmailAccepted brig galley = do
+    (inviter, tid) <- createUserWithTeam brig galley
     inviteeEmail <- randomEmail
-    inviter <- userId <$> randomUser brig
-    tid     <- createTeam inviter galley
     let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing
     Just inv <- decodeBody <$> postInvitation brig tid inviter invite
     Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
@@ -201,10 +197,10 @@ testCreateTeamPreverified brig galley = do
             let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing
             postInvitation brig (team^.Team.teamId) uid invite !!! const 201 === statusCode
 
-testInvitationNoPermission :: Brig -> Http ()
-testInvitationNoPermission brig = do
+testInvitationNoPermission :: Brig -> Galley -> Http ()
+testInvitationNoPermission brig galley = do
+    (_, tid) <- createUserWithTeam brig galley
     alice <- userId <$> randomUser brig
-    tid   <- randomTeamId
     email <- randomEmail
     let invite = InvitationRequest email (Name "Bob") Nothing
     postInvitation brig tid alice invite !!! do
@@ -235,8 +231,7 @@ testTeamNoPassword brig = do
 testInvitationCodeExists :: Brig -> Galley -> Http ()
 testInvitationCodeExists brig galley = do
     email <- randomEmail
-    uid   <- userId <$> randomUser brig
-    tid   <- createTeam uid galley
+    (uid, tid) <- createUserWithTeam brig galley
     rsp   <- postInvitation brig tid uid (invite email) <!! const 201 === statusCode
 
     let Just invId = inInvitation <$> decodeBody rsp
@@ -307,13 +302,12 @@ testInvitationMutuallyExclusive brig = do
 
 testInvitationTooManyMembers :: Brig -> Galley -> Http ()
 testInvitationTooManyMembers brig galley = do
-    creator <- userId <$> randomUser brig
-    tid     <- createTeam creator galley
+    (creator, tid) <- createUserWithTeam brig galley
     uids    <- fmap toNewMember <$> replicateConcurrently 127 randomId
     mapM_ (mapConcurrently_ (addTeamMember galley tid)) $ chunksOf 16 uids
 
     em <- randomEmail
-    let invite  = InvitationRequest em (Name "Bob") Nothing
+    let invite = InvitationRequest em (Name "Bob") Nothing
     Just inv <- decodeBody <$> postInvitation brig tid creator invite
     Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
     post (brig . path "/register"
@@ -325,12 +319,11 @@ testInvitationTooManyMembers brig galley = do
     toNewMember u = Team.newNewTeamMember $ Team.newTeamMember u Team.fullPermissions
 
 testInvitationPaging :: Brig -> Galley -> Http ()
-testInvitationPaging b g = do
-    u     <- userId <$> randomUser b
-    tid   <- createTeam u g
+testInvitationPaging brig galley = do
+    (u, tid) <- createUserWithTeam brig galley
     replicateM_ total $ do
         email <- randomEmail
-        postInvitation b tid u (invite email) !!! const 201 === statusCode
+        postInvitation brig tid u (invite email) !!! const 201 === statusCode
     foldM_ (next u tid 2) (0, Nothing) [2,2,1,0]
     foldM_ (next u tid total) (0, Nothing) [total,0]
   where
@@ -340,7 +333,7 @@ testInvitationPaging b g = do
     next u t step (count, start) n = do
         let count' = count + step
         let range = queryRange (toByteString' <$> start) (Just step)
-        r <- get (b . paths ["teams", toByteString' t, "invitations"] . zUser u . range) <!!
+        r <- get (brig . paths ["teams", toByteString' t, "invitations"] . zUser u . range) <!!
             const 200 === statusCode
         let (invs, more) = (fmap ilInvitations &&& fmap ilHasMore) $ decodeBody r
         liftIO $ assertEqual "page size" (Just n) (length <$> invs)
@@ -352,8 +345,7 @@ testInvitationPaging b g = do
 testInvitationInfo :: Brig -> Galley -> Http ()
 testInvitationInfo brig galley = do
     email    <- randomEmail
-    uid      <- userId <$> randomUser brig
-    tid      <- createTeam uid galley
+    (uid, tid) <- createUserWithTeam brig galley
     let invite = InvitationRequest email (Name "Bob") Nothing
     Just inv <- decodeBody <$> postInvitation brig tid uid invite
 
@@ -373,8 +365,7 @@ testSuspendTeam :: Brig -> Galley -> Http ()
 testSuspendTeam brig galley = do
     inviteeEmail  <- randomEmail
     inviteeEmail2 <- randomEmail
-    inviter       <- userId <$> randomUser brig
-    tid           <- createTeam inviter galley
+    (inviter, tid) <- createUserWithTeam brig galley
 
     -- invite and register invitee
     let invite  = InvitationRequest inviteeEmail (Name "Bob") Nothing
@@ -410,8 +401,7 @@ testSuspendTeam brig galley = do
 
 testDeleteTeamUser :: Brig -> Galley -> Http ()
 testDeleteTeamUser brig galley = do
-    creator <- userId <$> randomUser brig
-    tid     <- createTeam creator galley
+    (creator, tid) <- createUserWithTeam brig galley
     -- Cannot delete the user since it will make the team orphan
     deleteUser creator (Just defPassword) brig !!! do
         const 403 === statusCode
@@ -446,8 +436,7 @@ testDeleteTeamUser brig galley = do
 
 testConnectionSameTeam :: Brig -> Galley -> Http ()
 testConnectionSameTeam brig galley = do
-    creatorA <- userId <$> randomUser brig
-    tidA     <- createTeam creatorA galley
+    (creatorA, tidA) <- createUserWithTeam brig galley
     inviteeA <- userId <$> inviteAndRegisterUser creatorA tidA brig
 
     postConnection brig creatorA inviteeA !!! do
@@ -564,9 +553,6 @@ assertNoInvitationCode brig t i =
           const 400 === statusCode
           const (Just "invalid-invitation-code") === fmap Error.label . decodeBody
 
-randomTeamId :: MonadIO m => m TeamId
-randomTeamId = Id <$> liftIO UUID.nextRandom
-
 getTeamMember :: UserId -> TeamId -> Galley -> Http Team.TeamMember
 getTeamMember u tid galley = do
     r <- get ( galley
@@ -575,15 +561,6 @@ getTeamMember u tid galley = do
              . expect2xx
              )
     return $ fromMaybe (error "getTeamMember: failed to parse response") (decodeBody r)
-
-getTeams :: UserId -> Galley -> Http Team.TeamList
-getTeams u galley = do
-    r <- get ( galley
-             . paths ["teams"]
-             . zAuthAccess u "conn"
-             . expect2xx
-             )
-    return $ fromMaybe (error "getTeams: failed to parse response") (decodeBody r)
 
 accept :: Email -> InvitationCode -> RequestBody
 accept email code = RequestBodyLBS . encode $ object

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -187,6 +187,7 @@ executable galley-integration
       , bytestring-conversion
       , cereal
       , containers
+      , currency-codes
       , data-default-class
       , data-timeout
       , errors

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -67,6 +67,7 @@ library
       , cassandra-util          >= 0.16.2
       , cereal                  >= 0.4
       , containers              >= 0.5
+      , currency-codes          >= 2.0
       , enclosed-exceptions     >= 1.0
       , errors                  >= 2.0
       , safe-exceptions         >= 0.1

--- a/services/galley/journaler/src/Journal.hs
+++ b/services/galley/journaler/src/Journal.hs
@@ -61,7 +61,7 @@ runCommand l env c start = void $ C.runClient c $ do
     journalTeamActivate :: TeamId -> Maybe TeamCreationTime -> C.Client ()
     journalTeamActivate tid time = do
         mems <- Data.teamMembers tid
-        let dat = Journal.evData mems
+        let dat = Journal.evData mems Nothing
         publish tid TeamEvent'TEAM_ACTIVATE time (Just dat)
 
     publish :: TeamId -> TeamEvent'EventType -> Maybe TeamCreationTime -> Maybe TeamEvent'EventData -> C.Client ()

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -62,7 +62,6 @@ import Network.Wai
 import Network.Wai.Predicate hiding (setStatus, result, or)
 import Network.Wai.Utilities
 import Prelude hiding (head, mapM)
-import System.Logger.Message
 
 import qualified Data.Set as Set
 import qualified Galley.Data as Data
@@ -71,7 +70,6 @@ import qualified Galley.Queue as Q
 import qualified Galley.Types as Conv
 import qualified Galley.Types.Teams as Teams
 import qualified Galley.Intra.Journal as Journal
-import qualified System.Logger.Class as Log
 
 getTeam :: UserId ::: TeamId ::: JSON -> Galley Response
 getTeam (zusr::: tid ::: _) =
@@ -127,8 +125,6 @@ updateTeamStatus :: TeamId ::: Request ::: JSON ::: JSON -> Galley Response
 updateTeamStatus (tid ::: req ::: _) = do
     TeamStatusUpdate to cur <- fromBody req invalidPayload
     from <- tdStatus <$> (Data.team tid >>= ifNothing teamNotFound)
-    Log.info $ field "team" (toByteString tid)
-             . msg ("Updating from: " ++ show from ++ " to: " ++ show to)
     valid <- validateTransition from to
     when valid $ do
       journal to cur

--- a/services/galley/src/Galley/Intra/Journal.hs
+++ b/services/galley/src/Galley/Intra/Journal.hs
@@ -26,6 +26,7 @@ import Galley.App
 import Prelude hiding (head, mapM)
 import Proto.TeamEvents
 
+import qualified Data.Currency as Currency
 import qualified Data.UUID as UUID
 import qualified Galley.Aws as Aws
 
@@ -33,8 +34,9 @@ import qualified Galley.Aws as Aws
 -- Team journal operations to SQS are a no-op when the service
 -- is started without journaling arguments
 
-teamActivate :: TeamId -> [TeamMember] -> Maybe TeamCreationTime -> Galley ()
-teamActivate tid mems time = journalEvent TeamEvent'TEAM_ACTIVATE tid (Just $ evData mems) time
+-- TODO: Make actual use of the currency
+teamActivate :: TeamId -> [TeamMember] -> Maybe Currency.Alpha -> Maybe TeamCreationTime -> Galley ()
+teamActivate tid mems _ time = journalEvent TeamEvent'TEAM_ACTIVATE tid (Just $ evData mems) time
 
 teamUpdate :: TeamId -> [TeamMember] -> Galley ()
 teamUpdate tid mems = journalEvent TeamEvent'TEAM_UPDATE tid (Just $ evData mems) Nothing

--- a/services/galley/src/Galley/Intra/Journal.hs
+++ b/services/galley/src/Galley/Intra/Journal.hs
@@ -19,6 +19,7 @@ import Data.Foldable (for_)
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy (toStrict)
 import Data.Id
+import Data.Text (pack)
 import Galley.Types.Teams
 import Data.Time.Clock (getCurrentTime)
 import Data.Time.Clock.POSIX
@@ -34,12 +35,11 @@ import qualified Galley.Aws as Aws
 -- Team journal operations to SQS are a no-op when the service
 -- is started without journaling arguments
 
--- TODO: Make actual use of the currency
 teamActivate :: TeamId -> [TeamMember] -> Maybe Currency.Alpha -> Maybe TeamCreationTime -> Galley ()
-teamActivate tid mems _ time = journalEvent TeamEvent'TEAM_ACTIVATE tid (Just $ evData mems) time
+teamActivate tid mems cur time = journalEvent TeamEvent'TEAM_ACTIVATE tid (Just $ evData mems cur) time
 
 teamUpdate :: TeamId -> [TeamMember] -> Galley ()
-teamUpdate tid mems = journalEvent TeamEvent'TEAM_UPDATE tid (Just $ evData mems) Nothing
+teamUpdate tid mems = journalEvent TeamEvent'TEAM_UPDATE tid (Just $ evData mems Nothing) Nothing
 
 teamDelete :: TeamId -> Galley ()
 teamDelete tid = journalEvent TeamEvent'TEAM_DELETE tid Nothing Nothing
@@ -60,8 +60,8 @@ journalEvent typ tid dat tim = view aEnv >>= \mEnv -> for_ mEnv $ \e -> do
 bytes :: Id a -> ByteString
 bytes = toStrict . UUID.toByteString . toUUID
 
-evData :: [TeamMember] -> TeamEvent'EventData
-evData mems = TeamEvent'EventData count (bytes <$> uids)
+evData :: [TeamMember] -> Maybe Currency.Alpha -> TeamEvent'EventData
+evData mems cur = TeamEvent'EventData count (bytes <$> uids) (pack . show <$> cur)
   where
     uids  = view userId <$> filter (`hasPermission` SetBilling) mems
     count = fromIntegral $ length mems

--- a/services/galley/stack.yaml
+++ b/services/galley/stack.yaml
@@ -21,6 +21,7 @@ flags:
     arbitrary: True
 
 extra-deps:
+- currency-codes-2.0.0.0
 - data-timeout-0.3
 - wai-middleware-gunzip-0.0.2
 extra-package-dbs: []

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -715,7 +715,7 @@ testUpdateTeamStatus g b _ a = do
 
     void $ put ( g
                . paths ["i", "teams", toByteString' tid, "status"]
-               . json (TeamStatusUpdate Deleted)
+               . json (TeamStatusUpdate Deleted Nothing)
                ) !!! do
         const 403 === statusCode
         const "invalid-team-status-update" === (Error.label . Util.decodeBody' "error label")

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -27,6 +27,7 @@ import Test.Tasty.HUnit
 import API.SQS
 
 import qualified API.Util as Util
+import qualified Data.Currency as Currency
 import qualified Data.List1 as List1
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -48,6 +49,7 @@ tests :: IO TestSetup -> TestTree
 tests s = testGroup "Teams API"
     [ test s "create team" testCreateTeam
     , test s "create multiple binding teams fail" testCreateMulitpleBindingTeams
+    , test s "create binding team with currency" testCreateBindingTeamWithCurrency
     , test s "create team with members" testCreateTeamWithMembers
     , test s "create 1-1 conversation between binding team members (fail)" testCreateOne2OneFailNonBindingTeamMembers
     , test s "create 1-1 conversation between binding team members" testCreateOne2OneWithMembers
@@ -106,6 +108,18 @@ testCreateMulitpleBindingTeams g b _ a = do
     owner' <- Util.randomUser b
     void $ Util.createTeam g "foo" owner' []
     void $ Util.createTeam g "foo" owner' []
+
+testCreateBindingTeamWithCurrency :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testCreateBindingTeamWithCurrency g b _ a = do
+    _owner <- Util.randomUser b
+    _      <- Util.createTeamInternal g "foo" _owner
+    -- Backwards compatible
+    assertQueue "create team" a (tActivateWithCurrency Nothing)
+
+    -- Ensure currency is properly journaled
+    _owner <- Util.randomUser b
+    _      <- Util.createTeamInternalWithCurrency g "foo" _owner Currency.USD
+    assertQueue "create team" a (tActivateWithCurrency $ Just Currency.USD)
 
 testCreateTeamWithMembers :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
 testCreateTeamWithMembers g b c _ = do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -82,7 +82,7 @@ createTeam g name owner mems = do
 changeTeamStatus :: Galley -> TeamId -> TeamStatus -> Http ()
 changeTeamStatus g tid s = put
         ( g . paths ["i", "teams", toByteString' tid, "status"]
-        . json (TeamStatusUpdate s)
+        . json (TeamStatusUpdate s Nothing)
         ) !!! const 200 === statusCode
 
 createTeamInternal :: Galley -> Text -> UserId -> Http TeamId


### PR DESCRIPTION
This PR (temporarily) introduces the concept of _currency_ in our team events, which get propagated `brig -> galley -> billing` during team creation/activation.

Some considerations:
 * This currency is only propagated in case of team activation during registration, i.e., if there is a pre-verified e-mail address
 * We allow all [ISO_4217 currencies](https://en.wikipedia.org/wiki/ISO_4217) to be specified during creation @dkovacevic 
 * The encoding of the currency in the protobuf is done as an optional string, which is not ideal, but prevents having to map all currencies to a protobuf enum (or a subset, requiring then new builds for any added currency). If someone some better ideas here, please let me know :)
 * The intend is also to revert this PR once we are able to set currencies _after_ team activation

Note that some team tests were also rewritten as [this test](https://github.com/wireapp/wire-server/blob/develop/services/brig/test/integration/API/Team.hs#L62) was failing, due to the fact that the user got activated before the team creation (possible with the usage of internal APIs).