### PR TITLE
Feature/integration test keyspace from config

### DIFF
--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -52,9 +52,10 @@ runTests iConf bConf = do
     turnFile <- optOrEnv (Opts.servers . Opts.turn) bConf id "TURN_SERVERS"
     casHost  <- optOrEnv (\v -> (Opts.cassandra v)^.casEndpoint.epHost) bConf pack "BRIG_CASSANDRA_HOST"
     casPort  <- optOrEnv (\v -> (Opts.cassandra v)^.casEndpoint.epPort) bConf read "BRIG_CASSANDRA_PORT"
+    casKey   <- optOrEnv (\v -> (Opts.cassandra v)^.casKeyspace) bConf pack "BRIG_CASSANDRA_KEYSPACE"
 
     lg <- Logger.new Logger.defSettings
-    db <- defInitCassandra "brig_test" casHost casPort lg
+    db <- defInitCassandra casKey casHost casPort lg
     mg <- newManager tlsManagerSettings
 
     userApi     <- User.tests bConf mg b c g

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -92,7 +92,7 @@ parseConfigPaths = do
   pure $ fromMaybe (defaultIntPath, defaultBrigPath) res
   where
     defaultBrigPath = "/etc/wire/brig/conf/brig.yaml"
-    defaultIntPath = "/etc/wire/brig/conf/integration.yaml"
+    defaultIntPath = "/etc/wire/integration/integration.yaml"
     pathParser :: Parser (String, String)
     pathParser = (,) <$>
                  (strOption $

--- a/services/gundeck/test/integration/Main.hs
+++ b/services/gundeck/test/integration/Main.hs
@@ -83,9 +83,10 @@ main = withOpenSSL $ runTests go
         b <- Brig    . mkRequest <$> optOrEnv brig iConf (local . read) "BRIG_WEB_PORT"
         ch <- optOrEnv (\v -> v^.optCassandra.casEndpoint.epHost) gConf pack "GUNDECK_CASSANDRA_HOST"
         cp <- optOrEnv (\v -> v^.optCassandra.casEndpoint.epPort) gConf read "GUNDECK_CASSANDRA_PORT"
+        ck <- optOrEnv (\v -> v^.optCassandra.casKeyspace) gConf pack "GUNDECK_CASSANDRA_KEYSPACE"
 
         lg <- Logger.new Logger.defSettings
-        db <- defInitCassandra "gundeck_test" ch cp lg
+        db <- defInitCassandra ck ch cp lg
 
         return $ API.TestSetup m g c b db 
 


### PR DESCRIPTION
Read used keyspace from environment variable/config file to ensure that the integration tests use the same DB as the service itself. Also removed some non-exhaustive pattern matches from one of the tests