### PR TITLE
Allow internal endpoint to always delete a user

### DIFF
--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -73,7 +73,6 @@ import qualified Data.Set                      as Set
 import qualified Data.Text                     as Text
 import qualified Brig.Provider.API             as Provider
 import qualified Brig.Team.API                 as Team
-import qualified Brig.Team.Util                as Team
 import qualified Brig.Team.Email               as Team
 import qualified Brig.TURN.API                 as TURN
 
@@ -1155,9 +1154,6 @@ deleteUserNoVerify uid = do
     acc <- lift $ API.lookupAccount uid
     unless (isJust acc) $
         throwStd userNotFound
-    onlyTeamOwner <- lift $ Team.isOnlyTeamOwner uid
-    when onlyTeamOwner $
-        throwStd noOtherOwner
     ok <- lift $ InternalNotification.publish (Aws.DeleteUser uid)
     unless ok $
         throwStd failedQueueEvent


### PR DESCRIPTION
This PR basically reverts a [previous one](https://github.com/wireapp/wire-server/pull/159) that introduced a problem when deleting teams.

When a team is [deleted](https://github.com/wireapp/wire-server/blob/develop/services/galley/src/Galley/API/Teams.hs#L194), we delete all the users of that team before we delete the team. Thus, this creates a bit of a chicken-egg problem and prevents a team from ever getting properly deleted (not sure how this was missed in the galley tests but I retried them and they failed).

The main driver for this is to avoid backoffice users accidentally causing orphan teams so I'd suggest fixing the backoffice tool itself. The other option would be to add a query parameter like `force` that galley would use in the case of team deletion but the backdoor to create orphan teams would be there anyway in this case so this would just make it more explicit.