### PR TITLE
Upgrade to tasty-1.0.0.1

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -347,7 +347,7 @@ executable brig-integration
       , retry                 >= 0.6
       , safe                  >= 0.3
       , semigroups
-      , tasty                 >= 0.3.1
+      , tasty                 >= 1.0
       , tasty-cannon          >= 0.3.4
       , tasty-hunit           >= 0.2
       , time                  >= 1.5

--- a/services/brig/stack.yaml
+++ b/services/brig/stack.yaml
@@ -17,7 +17,7 @@ packages:
 - '../../libs/zauth'
 - location:
     git: https://github.com/tiago-loureiro/haskell-multihash.git
-    commit: ad23c413571f78e58a217a52eda1da4f87fe7084
+    commit: 2a23fae359e90e15bafa29f4dbb5131008e21a7c
   extra-dep: true
 - location:
     git: https://github.com/wireapp/cryptobox-haskell
@@ -41,7 +41,9 @@ extra-deps:
 - geoip2-0.2.2.0
 - html-entities-1.1.4.1
 - lifted-async-0.9.3
+- optparse-applicative-0.14.0.0
 - raw-strings-qq-1.0.2
+- tasty-1.0.0.1
 - temporary-1.2.1.1
 - text-icu-translit-0.1.0.7
 - text-latin1-0.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -31,7 +31,7 @@ packages:
 - tools/api-simulations
 - location:
     git: https://github.com/tiago-loureiro/haskell-multihash.git
-    commit: 10a0d7d765d87fa937fafa42ee7a45f871c9758e
+    commit: 2a23fae359e90e15bafa29f4dbb5131008e21a7c
   extra-dep: true
 - location:
     git: https://github.com/wireapp/cryptobox-haskell
@@ -51,8 +51,10 @@ extra-deps:
 - html-entities-1.1.4.1
 - lifted-async-0.9.3
 - mime-0.4.0.2
+- optparse-applicative-0.14.0.0
 - snappy-0.2.0.2
 - snappy-framing-0.1.1
+- tasty-1.0.0.1
 - temporary-1.2.1.1
 - text-icu-translit-0.1.0.7
 - wai-middleware-gunzip-0.0.2


### PR DESCRIPTION
The latest version of tasty is pretty useful as it allows using [pattern tests](https://github.com/feuerbach/tasty#patterns) as _awk expressions_.

Unfortunately it's pretty bleeding edge so not present in any LTS.