### PR TITLE
Optionally filter services by provider

### DIFF
--- a/services/brig/deb/etc/sv/brig/run
+++ b/services/brig/deb/etc/sv/brig/run
@@ -52,6 +52,11 @@ else
     TURN_CONFIG_TTL=""
 fi
 
+if [ -n "$BRIG_PROVIDER_ID_SEARCH_FILTER" ]; then
+    PROVIDER_ID_SEARCH_FILTER="--provider-id-search-filter=$BRIG_PROVIDER_ID_SEARCH_FILTER"
+else
+    PROVIDER_ID_SEARCH_FILTER=""
+fi
 
 cd $HOME
 
@@ -120,5 +125,5 @@ exec chpst -u $USER \
     ${GEOIP_DB} \
     ${WHITELIST_URL} \
     ${WHITELIST_USER} \
-    ${WHITELIST_PASS}
-
+    ${WHITELIST_PASS} \
+    ${BRIG_PROVIDER_ID_SEARCH_FILTER}

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -511,8 +511,7 @@ getServiceProfile (pid ::: sid) = do
 
 listServiceProfilesByTag :: QueryAnyTags 1 3 ::: Maybe Name ::: Range 10 100 Int32 -> Handler Response
 listServiceProfilesByTag (tags ::: start ::: size) = do
-    let size' = fromRange size
-    ss <- DB.paginateServiceTags tags start size'
+    ss <- DB.paginateServiceTags tags start (fromRange size) =<< setProviderSearchFilter <$> view settings
     return (json ss)
 
 getServiceTagList :: () -> Handler Response


### PR DESCRIPTION
Add an option when starting `brig` to list only services from a specific providerID on the `GET "/services"` endpoint.

Adding tests for this is tricky but I ran them without the option (and all tests succeed) and then added `--provider-id-search-filter <random uuid_v4>` on the Procfile which causes the provider/service search test to fail (which is what you'd expect - no services are returned).
The happy path was checked locally by launching brig with `--provider-id-search-filter=<known_providerid>` and verified that only services for that provider were returned from `GET /services`. Clearly room for improvement...