### PR TITLE
Speed up test for too many tokens

### DIFF
--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -13,7 +13,7 @@ import Bilge
 import Bilge.Assert
 import Control.Arrow ((&&&))
 import Control.Concurrent
-import Control.Concurrent.Async       (Async, async, wait, replicateConcurrently)
+import Control.Concurrent.Async       (Async, async, wait)
 import Control.Concurrent.STM.TChan
 import Control.Lens                   ((&), (.~), (^.), (^?), view)
 import Control.Monad.IO.Class         (MonadIO)
@@ -617,7 +617,7 @@ testRegisterTooManyTokens :: TestSignature ()
 testRegisterTooManyTokens g _ _ _ = do
     -- create tokens for reuse with multiple users
     gcmTok <- Token . T.decodeUtf8 . toByteString' <$> randomId
-    uids   <- liftIO $ replicateConcurrently 55 randomId
+    uids   <- liftIO $ replicateM 55 randomId
     -- create 55 users with these tokens, which should succeed
     mapM_ (registerToken 201 gcmTok) uids
     -- should run out of space in endpoint metadata and fail with a 413 on number 56

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -13,7 +13,7 @@ import Bilge
 import Bilge.Assert
 import Control.Arrow ((&&&))
 import Control.Concurrent
-import Control.Concurrent.Async       (Async, async, wait)
+import Control.Concurrent.Async       (Async, async, wait, replicateConcurrently)
 import Control.Concurrent.STM.TChan
 import Control.Lens                   ((&), (.~), (^.), (^?), view)
 import Control.Monad.IO.Class         (MonadIO)
@@ -614,33 +614,19 @@ testRegisterPushToken g _ b _ = do
 
 -- TODO: Try to make this test more performant, this test takes too long right now
 testRegisterTooManyTokens :: TestSignature ()
-testRegisterTooManyTokens g _ b _ = do
+testRegisterTooManyTokens g _ _ _ = do
     -- create tokens for reuse with multiple users
-    apsTok <- Token . T.decodeUtf8 . B16.encode <$> randomBytes 32
     gcmTok <- Token . T.decodeUtf8 . toByteString' <$> randomId
-    
+    uids   <- liftIO $ replicateConcurrently 55 randomId
     -- create 55 users with these tokens, which should succeed
-    userClients <- replicateM 55 $ registerToken 201 apsTok gcmTok
-
+    mapM_ (registerToken 201 gcmTok) uids
     -- should run out of space in endpoint metadata and fail with a 413 on number 56
-    _           <- registerToken 413 apsTok gcmTok
-
-    -- clean up by deleting clients and their tokens
-    forM_ userClients (\(uid, c) -> unregisterClient g uid c !!! const 200 === statusCode)
-    forM_ userClients (\(uid, c) -> unregisterClient g uid c !!! const 404 === statusCode)
-    tokens <- forM (map fst userClients) (\uid -> listPushTokens uid g)
-    liftIO $ assertEqual "unexpected tokens" [] (concat tokens)
+    registerToken 413 gcmTok =<< randomId
   where
-    registerToken status apsTok gcmTok = do
-        let tka = pushToken APNS "com.wire.int.ent" apsTok
-        let tkg = pushToken GCM "test" gcmTok
-        uid <- randomUser b
-        c   <- randomClient g uid
-        let ta = tka c
-        let tg = tkg c
-        registerPushTokenRequest uid ta g !!! const status === statusCode
-        registerPushTokenRequest uid tg g !!! const status === statusCode
-        return (uid, c)
+    registerToken status gcmTok uid = do
+        con <- randomClientId
+        let tkg = pushToken GCM "test" gcmTok con
+        registerPushTokenRequest uid tkg g !!! const status === statusCode
 
 testUnregisterPushToken :: TestSignature ()
 testUnregisterPushToken g _ b _ = do


### PR DESCRIPTION
With this change we no longer use `brig` for user/client creation and create only 1 push token per user, halving the number of token creation requests to SNS. In addition, we also do not clean up SNS/cassandra.

Locally, the test now runs in ~25 secs (vs. the previous 120)