### PR TITLE
Upgrade nginx to 1.12.2, use alpine-3.7 and compile with gunzip

### DIFF
--- a/services/nginz/Dockerfile
+++ b/services/nginz/Dockerfile
@@ -1,5 +1,5 @@
 # Requires docker >= 17.05 (requires support for multi-stage builds)
-FROM alpine:3.6 as libzauth-builder
+FROM alpine:3.7 as libzauth-builder
 
 # Compile libzauth
 COPY libs/libzauth /src/libzauth
@@ -9,9 +9,9 @@ RUN cd /src/libzauth/libzauth-c \
     && make install
 
 # Nginz container
-FROM alpine:3.6
+FROM alpine:3.7
 
-ENV NGINX_VERSION 1.12.1
+ENV NGINX_VERSION 1.12.2
 
 # Install libzauth
 COPY --from=libzauth-builder /usr/include/zauth.h /usr/include/zauth.h
@@ -43,6 +43,7 @@ RUN apk add --no-cache inotify-tools dumb-init bash curl && \
         --with-http_ssl_module \
         --with-http_stub_status_module \
         --with-http_realip_module \
+        --with-http_gunzip_module \
         --add-module=/src/third_party/nginx-zauth-module \
         --add-module=/src/third_party/headers-more-nginx-module \
         --add-module=/src/third_party/nginx-module-vts \

--- a/services/nginz/Makefile
+++ b/services/nginz/Makefile
@@ -1,6 +1,6 @@
 SHELL          := /usr/bin/env bash
 NAME           := nginz
-NGINX_VERSION   = 1.12.1
+NGINX_VERSION   = 1.12.2
 NGINZ_VERSION  ?=
 SHELL          := /usr/bin/env bash
 DIST           := build
@@ -29,6 +29,7 @@ ADDITIONAL_MODULES = \
     --with-http_ssl_module \
     --with-http_stub_status_module \
     --with-http_realip_module \
+    --with-http_gunzip_module \
     --add-module=../third_party/nginx-zauth-module \
     --add-module=../third_party/headers-more-nginx-module \
     --add-module=../third_party/nginx-module-vts


### PR DESCRIPTION
It would be nice to allow `nginz` to do the gunzip "heavy lifting", instead of having it at the haskell service level.

Also brings `nginz`'s docker image to `alpine-3.7` to be in sync with the other service. `make docker` worked fine for me.