### PR TITLE
Feature/cassandra prefix search

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -260,6 +260,7 @@ executable brig-schema
         V44
         V45
         V46
+        V47
 
     build-depends:
         base

--- a/services/brig/schema/src/Main.hs
+++ b/services/brig/schema/src/Main.hs
@@ -42,6 +42,7 @@ import qualified V43
 import qualified V44
 import qualified V45
 import qualified V46
+import qualified V47
 
 main :: IO ()
 main = do
@@ -85,4 +86,5 @@ main = do
         , V44.migration
         , V45.migration
         , V46.migration
+        , V47.migration
         ] `finally` close l

--- a/services/brig/schema/src/V47.hs
+++ b/services/brig/schema/src/V47.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module V47 (migration) where
+
+import Cassandra.Schema
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 47 "Create and populate prefix table" $
+    schema' [r|
+        create table if not exists service_prefix
+        ( prefix text
+        , name text
+        , service uuid
+        , provider uuid
+        , primary key (prefix, name)
+        )
+    |]

--- a/services/brig/schema/src/V47.hs
+++ b/services/brig/schema/src/V47.hs
@@ -14,6 +14,7 @@ migration = Migration 47 "Create and populate prefix table" $
         , name text
         , service uuid
         , provider uuid
-        , primary key (prefix, name)
-        )
+        , primary key (prefix, name, service)
+        ) with clustering order by (name asc, service asc)
+          and compaction = {'class': 'LeveledCompactionStrategy'};
     |]

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -361,3 +361,6 @@ internalServerError = Wai.Error status500 "internal-server-error" "Internal Serv
 
 failedQueueEvent :: Wai.Error
 failedQueueEvent = Wai.Error status500 "event-queue-failed" "Failed to queue the event, MD5 mismatch. Try again later"
+
+invalidRange :: Text -> Wai.Error
+invalidRange = Wai.Error status400 "client-error"

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -118,7 +118,7 @@ import qualified System.Logger            as Log
 import qualified System.Logger.Class      as LC
 
 schemaVersion :: Int32
-schemaVersion = 44
+schemaVersion = 47
 
 -------------------------------------------------------------------------------
 -- Environment

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -21,7 +21,7 @@ import Brig.Types.Provider
 import Brig.Types.Search
 import Control.Lens (view)
 import Control.Exception.Enclosed (handleAny)
-import Control.Monad (join, when, unless, (>=>))
+import Control.Monad (join, when, unless, (>=>), liftM2)
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.ByteString.Conversion
@@ -401,15 +401,16 @@ updateService (pid ::: sid ::: req) = do
 
     -- Update service profile
     svc <- DB.lookupService pid sid >>= maybeServiceNotFound
+    let name       = serviceName svc
     let newName    = updateServiceName upd
+    let nameChange = liftM2 (,) (pure name) newName
     let newSummary = fromRange <$> updateServiceSummary upd
     let newDescr   = fromRange <$> updateServiceDescr upd
     let newAssets  = updateServiceAssets upd
     let newTags    = updateServiceTags upd
-    DB.updateService pid sid newName newSummary newDescr newAssets newTags
+    DB.updateService pid sid nameChange newSummary newDescr newAssets newTags
 
     -- Update tag index
-    let name  = serviceName svc
     let tags  = unsafeRange (serviceTags svc)
     let name' = fromMaybe name newName
     let tags' = fromMaybe tags newTags

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -499,7 +499,7 @@ getProviderProfile pid = do
 
 listServiceProfiles :: ProviderId -> Handler Response
 listServiceProfiles pid = do
-    ss <- DB.listServiceProfilesByProvider pid
+    ss <- DB.listServiceProfiles pid
     return (json ss)
 
 getServiceProfile :: ProviderId ::: ServiceId -> Handler Response

--- a/services/brig/src/Brig/Provider/DB/Tag.hs
+++ b/services/brig/src/Brig/Provider/DB/Tag.hs
@@ -34,7 +34,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 
 newtype Bucket = Bucket Int32
-    deriving Cql
+    deriving (Cql, Show)
 
 -- | Bucketing allows us to distribute individual tag bitmasks
 -- across multiple wide rows, if it should become necessary.

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -427,7 +427,6 @@ testListServices config db brig = do
         return _ls
 
     -- 20 names, all using the given unique prefix
-    mkTaggedNames :: Text -> [(Name, [ServiceTag])]
     mkTaggedNames uniq =
         [ (mkName uniq "Alpha",     [SocialTag, QuizTag, BusinessTag])
         , (mkName uniq "Beta",      [SocialTag, MusicTag, LifestyleTag])
@@ -451,24 +450,20 @@ testListServices config db brig = do
         , (mkName uniq "Zulu",      [SocialTag, MusicTag, LifestyleTag])
         ]
 
-mkName :: Text -> Text -> Name
-mkName uniq n = Name (uniq <> n)
+    mkName uniq n = Name (uniq <> n)
 
-mkNew :: NewService -> (Name, [ServiceTag]) -> NewService
-mkNew new (n, t) = new { newServiceName = n
-                       , newServiceTags = unsafeRange (Set.fromList t)
-                       }
-select :: Name -> [Name] -> [Name]
-select (Name prefix) nm = filter (isPrefixOf (toLower prefix) . toLower . fromName) nm
+    mkNew new (n, t) = new { newServiceName = n
+                           , newServiceTags = unsafeRange (Set.fromList t)
+                           }
+    select (Name prefix) nm = filter (isPrefixOf (toLower prefix) . toLower . fromName) nm
 
-emptyUpdateService :: UpdateService
-emptyUpdateService = UpdateService
-    { updateServiceName    = Nothing
-    , updateServiceSummary = Nothing
-    , updateServiceDescr   = Nothing
-    , updateServiceAssets  = Nothing
-    , updateServiceTags    = Nothing
-    }
+    emptyUpdateService = UpdateService
+        { updateServiceName    = Nothing
+        , updateServiceSummary = Nothing
+        , updateServiceDescr   = Nothing
+        , updateServiceAssets  = Nothing
+        , updateServiceTags    = Nothing
+        }
 
 testDeleteService :: Maybe Config -> DB.ClientState -> Brig -> Http ()
 testDeleteService config db brig = do

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -335,6 +335,15 @@ testListServices config db brig = do
     let pid = providerId prv
     uid <- randomId
 
+    -- You need to supply at least one tag or a prefix
+    get ( brig
+        . path "/services"
+        . header "Z-Type" "access"
+        . header "Z-User" (toByteString' uid)) !!! const 400 === statusCode
+
+    -- An empty prefix is not sufficient
+    listServiceProfilesByPrefix brig uid (Name "") 10 !!! const 400 === statusCode
+
     -- nb. We use a random name prefix so tests can run concurrently
     -- (and repeatedly) against a shared database and thus a shared
     -- "name index" per tag.


### PR DESCRIPTION
This PR introduces the possibility of searching for services using only a prefix, i.e., the `start` parameter. For that, we use an index based on the first character of the service name, similarly to how we use `tags` (which can still be used together with `start`).

It also introduces some `batch`ing when updating services vs. the service index; i.e., on `name` and/or `tag` changes, both the `service` and the `indexes` are updated in a batch.