### PR TITLE
Ensure 'Just Range' is within Range

### DIFF
--- a/services/galley/src/Galley/Validation.hs
+++ b/services/galley/src/Galley/Validation.hs
@@ -32,7 +32,7 @@ rangeChecked = either throwErr return . checkedEither
 
 rangeCheckedMaybe :: Within a n m => Maybe a -> Galley (Maybe (Range n m a))
 rangeCheckedMaybe Nothing  = return Nothing
-rangeCheckedMaybe (Just a) = return (checked a)
+rangeCheckedMaybe (Just a) = Just <$> rangeChecked a
 {-# INLINE rangeCheckedMaybe #-}
 
 -- Between 0 and (setMaxConvAndTeamSize - 1)

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -124,10 +124,13 @@ postConvOk g b c _ = do
     bob   <- randomUser b
     jane  <- randomUser b
     connectUsers b alice (list1 bob [jane])
+    -- Ensure name is within range, max size is 256
+    postConv g alice [bob, jane] (Just (T.replicate 257 "a")) [] !!! const 400 === statusCode
+    let nameMaxSize = T.replicate 256 "a"
     WS.bracketR3 c alice bob jane $ \(wsA, wsB, wsJ) -> do
-        rsp <- postConv g alice [bob, jane] (Just "gossip") [] Nothing <!!
+        rsp <- postConv g alice [bob, jane] (Just nameMaxSize) [] Nothing <!!
             const 201 === statusCode
-        cid <- assertConv rsp RegularConv alice alice [bob, jane] (Just "gossip")
+        cid <- assertConv rsp RegularConv alice alice [bob, jane] (Just nameMaxSize)
         cvs <- mapM (convView cid) [alice, bob, jane]
         liftIO $ mapM_ WS.assertSuccess =<< Async.mapConcurrently (checkWs alice) (zip cvs [wsA, wsB, wsJ])
   where

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -125,7 +125,7 @@ postConvOk g b c _ = do
     jane  <- randomUser b
     connectUsers b alice (list1 bob [jane])
     -- Ensure name is within range, max size is 256
-    postConv g alice [bob, jane] (Just (T.replicate 257 "a")) [] !!! const 400 === statusCode
+    postConv g alice [bob, jane] (Just (T.replicate 257 "a")) [] Nothing !!! const 400 === statusCode
     let nameMaxSize = T.replicate 256 "a"
     WS.bracketR3 c alice bob jane $ \(wsA, wsB, wsJ) -> do
         rsp <- postConv g alice [bob, jane] (Just nameMaxSize) [] Nothing <!!

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -7,7 +7,7 @@ import Bilge hiding (timeout)
 import Bilge.Assert
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Lens hiding ((#), (.=))
-import Control.Monad (void, replicateM)
+import Control.Monad (void)
 import Control.Monad.IO.Class
 import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
@@ -71,7 +71,7 @@ tests s = testGroup "Teams API"
     , test s "post crypto broadcast message protobuf" postCryptoBroadcastMessageProto
     , test s "post crypto broadcast message redundant/missing" postCryptoBroadcastMessageJson2
     , test s "post crypto broadcast message no-team" postCryptoBroadcastMessageNoTeam
-    , test s "post crypto broadcast message (max conns)" postCryptoBroadcastMessageMaxConns
+    , test s "post crypto broadcast message 100 (or max conns)" postCryptoBroadcastMessage100OrMaxConns
     ]
 
 timeout :: WS.Timeout
@@ -896,14 +896,12 @@ postCryptoBroadcastMessageNoTeam g b _ _ _ = do
     let msg = [(bob, bc, "ciphertext1")]
     Util.postOtrBroadcastMessage id g alice ac msg !!! const 404 === statusCode
 
-postCryptoBroadcastMessageMaxConns :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-postCryptoBroadcastMessageMaxConns g b c a s = do
-    let maxConns = fromIntegral (maxConvTeamSize s)
+postCryptoBroadcastMessage100OrMaxConns :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
+postCryptoBroadcastMessage100OrMaxConns g b c a _ = do
     (alice, ac) <- randomUserWithClient b (someLastPrekeys !! 0)
     _ <- createTeamInternal g "foo" alice
     assertQueue "" a tActivate
-    (bob, bc):others <- replicateM maxConns (randomUserWithClient b (someLastPrekeys !! 1))
-    connectUsers b alice (list1 bob (fst <$> others))
+    ((bob, bc), others) <- createAndConnectUserWhileLimitNotReached alice (100 :: Int) [] (someLastPrekeys !! 1)
     let t = 3 # Second -- WS receive timeout
     WS.bracketRN c (bob : (fst <$> others)) $ \ws -> do
         let f (u, clt) = (u, clt, "ciphertext")
@@ -914,3 +912,14 @@ postCryptoBroadcastMessageMaxConns g b c a s = do
         void . liftIO $ WS.assertMatch t (Prelude.head ws) (wsAssertOtr (selfConv bob) alice ac bc "ciphertext")
         for_ (zip (tail ws) others) $ \(wsU, (u, clt)) ->
             liftIO $ WS.assertMatch t wsU (wsAssertOtr (selfConv u) alice ac clt "ciphertext")
+  where
+    createAndConnectUserWhileLimitNotReached alice remaining acc pk = do
+        (uid, cid) <- randomUserWithClient b pk
+        (r1, r2)   <- List1.head <$> connectUsersUnchecked b alice (singleton uid)
+        case (statusCode r1, statusCode r2, remaining, acc) of
+            (201, 200, 0, []    ) -> error "Need to connect with at least 1 user"
+            (201, 200, 0, (x:xs)) -> return (x, xs)
+            (201, 200, _, _     ) -> createAndConnectUserWhileLimitNotReached alice (remaining-1) ((uid ,cid):acc) pk
+            (403, 403, _, []    ) -> error "Need to connect with at least 1 user"
+            (403, 403, _, (x:xs)) -> return (x, xs)
+            (xxx, yyy, _, _     ) -> error ("Unexpected while connecting users: " ++ show xxx ++ " and " ++ show yyy)

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -36,14 +36,14 @@ import qualified Network.Wai.Utilities.Error as Error
 import qualified Test.Tasty.Cannon as WS
 import qualified Galley.Aws as Aws
 
-type TestSignature a = Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http a
+type TestSignature a = Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http a
 
 test :: IO TestSetup -> TestName -> TestSignature a -> TestTree
 test s n h = testCase n runTest
   where
     runTest = do
         setup <- s
-        void $ runHttpT (manager setup) (h (galley setup) (brig setup) (cannon setup) (awsEnv setup) setup)
+        void $ runHttpT (manager setup) (h (galley setup) (brig setup) (cannon setup) (awsEnv setup))
 
 tests :: IO TestSetup -> TestTree
 tests s = testGroup "Teams API"
@@ -77,8 +77,8 @@ tests s = testGroup "Teams API"
 timeout :: WS.Timeout
 timeout = 3 # Second
 
-testCreateTeam :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testCreateTeam g b c a _ = do
+testCreateTeam :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testCreateTeam g b c a = do
     owner <- Util.randomUser b
     WS.bracketR c owner $ \wsOwner -> do
         tid   <- Util.createTeam g "foo" owner []
@@ -94,8 +94,8 @@ testCreateTeam g b c a _ = do
                 e^.eventData @?= Just (EdTeamCreate team)
             void $ WS.assertSuccess eventChecks
 
-testCreateMulitpleBindingTeams :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testCreateMulitpleBindingTeams g b _ a _ = do
+testCreateMulitpleBindingTeams :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testCreateMulitpleBindingTeams g b _ a = do
     owner <- Util.randomUser b
     _     <- Util.createTeamInternal g "foo" owner
     assertQueue "create team" a tActivate
@@ -109,8 +109,8 @@ testCreateMulitpleBindingTeams g b _ a _ = do
     void $ Util.createTeam g "foo" owner' []
     void $ Util.createTeam g "foo" owner' []
 
-testCreateBindingTeamWithCurrency :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testCreateBindingTeamWithCurrency g b _ a _ = do
+testCreateBindingTeamWithCurrency :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testCreateBindingTeamWithCurrency g b _ a = do
     _owner <- Util.randomUser b
     _      <- Util.createTeamInternal g "foo" _owner
     -- Backwards compatible
@@ -121,8 +121,8 @@ testCreateBindingTeamWithCurrency g b _ a _ = do
     _      <- Util.createTeamInternalWithCurrency g "foo" _owner Currency.USD
     assertQueue "create team" a (tActivateWithCurrency $ Just Currency.USD)
 
-testCreateTeamWithMembers :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testCreateTeamWithMembers g b c _ _ = do
+testCreateTeamWithMembers :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testCreateTeamWithMembers g b c _ = do
     owner <- Util.randomUser b
     user1 <- Util.randomUser b
     user2 <- Util.randomUser b
@@ -147,8 +147,8 @@ testCreateTeamWithMembers g b c _ _ = do
         e^.eventTeam @?= (team^.teamId)
         e^.eventData @?= Just (EdTeamCreate team)
 
-testCreateOne2OneFailNonBindingTeamMembers :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testCreateOne2OneFailNonBindingTeamMembers g b _ a _ = do
+testCreateOne2OneFailNonBindingTeamMembers :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testCreateOne2OneFailNonBindingTeamMembers g b _ a = do
     owner <- Util.randomUser b
     let p1 = Util.symmPermissions [CreateConversation, AddConversationMember]
     let p2 = Util.symmPermissions [CreateConversation, AddConversationMember, AddTeamMember]
@@ -171,8 +171,8 @@ testCreateOne2OneFailNonBindingTeamMembers g b _ a _ = do
         const 403 === statusCode
         const "non-binding-team-members" === (Error.label . Util.decodeBody' "error label")
 
-testCreateOne2OneWithMembers :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testCreateOne2OneWithMembers g b c a _ = do
+testCreateOne2OneWithMembers :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testCreateOne2OneWithMembers g b c a = do
     owner <- Util.randomUser b
     tid   <- Util.createTeamInternal g "foo" owner
     assertQueue "create team" a tActivate
@@ -193,8 +193,8 @@ testCreateOne2OneWithMembers g b c a _ = do
     repeatIf :: Util.ResponseLBS -> Bool
     repeatIf r = statusCode r /= 201
 
-testAddTeamMember :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testAddTeamMember g b c _ _ = do
+testAddTeamMember :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testAddTeamMember g b c _ = do
     owner <- Util.randomUser b
     let p1 = Util.symmPermissions [CreateConversation, AddConversationMember]
     let p2 = Util.symmPermissions [CreateConversation, AddConversationMember, AddTeamMember]
@@ -225,8 +225,8 @@ testAddTeamMember g b c _ _ = do
         e^.eventTeam @?= tid
         e^.eventData @?= Just (EdMemberJoin usr)
 
-testAddTeamMemberCheckBound :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testAddTeamMemberCheckBound g b _ a _ = do
+testAddTeamMemberCheckBound :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testAddTeamMemberCheckBound g b _ a = do
     ownerBound <- Util.randomUser b
     tidBound   <- Util.createTeamInternal g "foo" ownerBound
     assertQueue "create team" a tActivate
@@ -243,8 +243,8 @@ testAddTeamMemberCheckBound g b _ a _ = do
     post (g . paths ["teams", toByteString' tid, "members"] . zUser owner . zConn "conn" . json (newNewTeamMember boundMem)) !!!
         const 403 === statusCode
 
-testAddTeamMemberInternal :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testAddTeamMemberInternal g b c a _ = do
+testAddTeamMemberInternal :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testAddTeamMemberInternal g b c a = do
     owner <- Util.randomUser b
     tid <- Util.createTeam g "foo" owner []
     let p1 = Util.symmPermissions [GetBilling] -- permissions are irrelevant on internal endpoint
@@ -263,8 +263,8 @@ testAddTeamMemberInternal g b c a _ = do
         e^.eventTeam @?= tid
         e^.eventData @?= Just (EdMemberJoin usr)
 
-testRemoveTeamMember :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testRemoveTeamMember g b c _ _ = do
+testRemoveTeamMember :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testRemoveTeamMember g b c _ = do
     owner <- Util.randomUser b
     let p1 = Util.symmPermissions [AddConversationMember]
     let p2 = Util.symmPermissions [AddConversationMember, RemoveTeamMember]
@@ -315,8 +315,8 @@ testRemoveTeamMember g b c _ _ = do
         e^.eventTeam @?= tid
         e^.eventData @?= Just (EdMemberLeave usr)
 
-testRemoveBindingTeamMember :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testRemoveBindingTeamMember g b c a _ = do
+testRemoveBindingTeamMember :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testRemoveBindingTeamMember g b c a = do
     owner <- Util.randomUser b
     tid   <- Util.createTeamInternal g "foo" owner
     assertQueue "create team" a tActivate
@@ -361,8 +361,8 @@ testRemoveBindingTeamMember g b c a _ = do
         -- Mem1 is now gone from Wire
         Util.ensureDeletedState b True owner (mem1^.userId)
 
-testAddTeamConv :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testAddTeamConv g b c _ _ = do
+testAddTeamConv :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testAddTeamConv g b c _ = do
     owner  <- Util.randomUser b
     extern <- Util.randomUser b
 
@@ -428,8 +428,8 @@ testAddTeamConv g b c _ _ = do
             Just (Conv.EdConversation x) -> cnvId x @?= cid
             other                        -> assertFailure $ "Unexpected event data: " <> show other
 
-testAddTeamConvWithUsers :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testAddTeamConvWithUsers g b _ _ _ = do
+testAddTeamConvWithUsers :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testAddTeamConvWithUsers g b _ _ = do
     owner  <- Util.randomUser b
     extern <- Util.randomUser b
     Util.connectUsers b owner (list1 extern [])
@@ -441,8 +441,8 @@ testAddTeamConvWithUsers g b _ _ _ = do
     -- Team members are present.
     Util.assertConvMember g owner cid
 
-testAddTeamMemberToConv :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testAddTeamMemberToConv g b _ _ _ = do
+testAddTeamMemberToConv :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testAddTeamMemberToConv g b _ _ = do
     owner <- Util.randomUser b
     let p = Util.symmPermissions [AddConversationMember]
     mem1 <- flip newTeamMember p <$> Util.randomUser b
@@ -470,8 +470,8 @@ testAddTeamMemberToConv g b _ _ _ = do
         const 403                === statusCode
         const "operation-denied" === (Error.label . Util.decodeBody' "error label")
 
-testDeleteTeam :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testDeleteTeam g b c a _ = do
+testDeleteTeam :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testDeleteTeam g b c a = do
     owner <- Util.randomUser b
     let p = Util.symmPermissions [AddConversationMember]
     member <- flip newTeamMember p <$> Util.randomUser b
@@ -518,8 +518,8 @@ testDeleteTeam g b c a _ = do
                 const (Just Null) === Util.decodeBody
     assertQueueEmpty a
 
-testDeleteBindingTeam :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testDeleteBindingTeam g b c a _ = do
+testDeleteBindingTeam :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testDeleteBindingTeam g b c a = do
     owner  <- Util.randomUser b
     tid    <- Util.createTeamInternal g "foo" owner
     assertQueue "create team" a tActivate
@@ -562,8 +562,8 @@ testDeleteBindingTeam g b c a _ = do
         void $ retryWhileN 20 (not . id) $ isUserDeleted b uid
         Util.ensureDeletedState b True extern uid
 
-testDeleteTeamConv :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testDeleteTeamConv g b c _ _ = do
+testDeleteTeamConv :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testDeleteTeamConv g b c _ = do
     owner <- Util.randomUser b
     let p = Util.symmPermissions [DeleteConversation]
     member <- flip newTeamMember p <$> Util.randomUser b
@@ -620,8 +620,8 @@ testDeleteTeamConv g b c _ _ = do
         evtConv e @?= cid
         evtData e @?= Nothing
 
-testUpdateTeam :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testUpdateTeam g b c _ _ = do
+testUpdateTeam :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testUpdateTeam g b c _ = do
     owner <- Util.randomUser b
     let p = Util.symmPermissions [DeleteConversation]
     member <- flip newTeamMember p <$> Util.randomUser b
@@ -657,8 +657,8 @@ testUpdateTeam g b c _ _ = do
         e^.eventTeam @?= tid
         e^.eventData @?= Just (EdTeamUpdate upd)
 
-testUpdateTeamMember :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testUpdateTeamMember g b c a _ = do
+testUpdateTeamMember :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testUpdateTeamMember g b c a = do
     owner <- Util.randomUser b
     let p = Util.symmPermissions [SetMemberPermissions]
     member <- flip newTeamMember p <$> Util.randomUser b
@@ -710,8 +710,8 @@ testUpdateTeamMember g b c a _ = do
         e^.eventTeam @?= tid
         e^.eventData @?= Just (EdMemberUpdate uid mPerm)
 
-testUpdateTeamStatus :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-testUpdateTeamStatus g b _ a _ = do
+testUpdateTeamStatus :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+testUpdateTeamStatus g b _ a = do
     owner <- Util.randomUser b
     tid   <- Util.createTeamInternal g "foo" owner
     assertQueue "create team" a tActivate
@@ -768,8 +768,8 @@ checkConvMemberLeaveEvent cid usr w = WS.assertMatch_ timeout w $ \notif -> do
             Just (Conv.EdMembers mm) -> mm @?= Conv.Members [usr]
             other                    -> assertFailure $ "Unexpected event data: " <> show other
 
-postCryptoBroadcastMessageJson :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-postCryptoBroadcastMessageJson g b c a _ = do
+postCryptoBroadcastMessageJson :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+postCryptoBroadcastMessageJson g b c a = do
     -- Team1: Alice, Bob. Team2: Charlie. Regular user: Dan. Connect Alice,Charlie,Dan
     (alice,  ac) <- randomUserWithClient b (someLastPrekeys !! 0)
     (bob,    bc) <- randomUserWithClient b (someLastPrekeys !! 1)
@@ -805,8 +805,8 @@ postCryptoBroadcastMessageJson g b c a _ = do
                 -- Alice's second client should get the broadcast
                 void . liftIO $ WS.assertMatch t wsA2 (wsAssertOtr (selfConv alice) alice ac ac2 "ciphertext0")
 
-postCryptoBroadcastMessageJson2 :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-postCryptoBroadcastMessageJson2 g b c a _ = do
+postCryptoBroadcastMessageJson2 :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+postCryptoBroadcastMessageJson2 g b c a = do
     -- Team1: Alice, Bob. Team2: Charlie. Connect Alice,Charlie
     (alice,  ac) <- randomUserWithClient b (someLastPrekeys !! 0)
     (bob,    bc) <- randomUserWithClient b (someLastPrekeys !! 1)
@@ -855,8 +855,8 @@ postCryptoBroadcastMessageJson2 g b c a _ = do
         -- charlie should not get it
         assertNoMsg wsE (wsAssertOtr (selfConv charlie) alice ac cc "ciphertext4")
 
-postCryptoBroadcastMessageProto :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-postCryptoBroadcastMessageProto g b c a _ = do
+postCryptoBroadcastMessageProto :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+postCryptoBroadcastMessageProto g b c a = do
     -- similar to postCryptoBroadcastMessageJson except uses protobuf
 
     -- Team1: Alice, Bob. Team2: Charlie. Regular user: Dan. Connect Alice,Charlie,Dan
@@ -888,20 +888,21 @@ postCryptoBroadcastMessageProto g b c a _ = do
         -- Alice should not get her own broadcast
         WS.assertNoEvent timeout ws
 
-postCryptoBroadcastMessageNoTeam :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-postCryptoBroadcastMessageNoTeam g b _ _ _ = do
+postCryptoBroadcastMessageNoTeam :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+postCryptoBroadcastMessageNoTeam g b _ _ = do
     (alice, ac) <- randomUserWithClient b (someLastPrekeys !! 0)
     (bob,   bc) <- randomUserWithClient b (someLastPrekeys !! 1)
     connectUsers b alice (list1 bob [])
     let msg = [(bob, bc, "ciphertext1")]
     Util.postOtrBroadcastMessage id g alice ac msg !!! const 404 === statusCode
 
-postCryptoBroadcastMessage100OrMaxConns :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> TestSetup -> Http ()
-postCryptoBroadcastMessage100OrMaxConns g b c a _ = do
+postCryptoBroadcastMessage100OrMaxConns :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
+postCryptoBroadcastMessage100OrMaxConns g b c a = do
     (alice, ac) <- randomUserWithClient b (someLastPrekeys !! 0)
     _ <- createTeamInternal g "foo" alice
     assertQueue "" a tActivate
     ((bob, bc), others) <- createAndConnectUserWhileLimitNotReached alice (100 :: Int) [] (someLastPrekeys !! 1)
+    connectUsers b alice (list1 bob (fst <$> others))
     let t = 3 # Second -- WS receive timeout
     WS.bracketRN c (bob : (fst <$> others)) $ \ws -> do
         let f (u, clt) = (u, clt, "ciphertext")

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -15,7 +15,7 @@ import Data.Aeson hiding (json)
 import Data.Aeson.Lens (key)
 import Data.ByteString.Char8 (pack, ByteString, intercalate)
 import Data.ByteString.Conversion
-import Data.Foldable (toList, mapM_)
+import Data.Foldable (toList)
 import Data.Id
 import Data.Int
 import Data.List (sort)
@@ -499,21 +499,37 @@ zType :: ByteString -> Request -> Request
 zType = header "Z-Type"
 
 connectUsers :: Brig -> UserId -> List1 UserId -> Http ()
-connectUsers b u = mapM_ connectTo
+connectUsers b u us = void $ connectUsersWith expect2xx b u us
+
+connectUsersUnchecked :: Brig
+                      -> UserId
+                      -> List1 UserId
+                      -> Http (List1 (Response (Maybe Lazy.ByteString), Response (Maybe Lazy.ByteString)))
+connectUsersUnchecked = connectUsersWith id
+
+connectUsersWith :: (Request -> Request)
+                 -> Brig
+                 -> UserId
+                 -> List1 UserId
+                 -> Http (List1 (Response (Maybe Lazy.ByteString), Response (Maybe Lazy.ByteString)))
+connectUsersWith fn b u us = mapM connectTo us
   where
     connectTo v = do
-        post ( b
+        r1 <- post ( b
              . zUser u
              . zConn "conn"
              . path "/connections"
              . json (ConnectionRequest v "chat" (Message "Y"))
-             ) !!! const 201 === statusCode
-        put ( b
+             . fn
+             )
+        r2 <- put ( b
             . zUser v
             . zConn "conn"
             . paths ["connections", toByteString' u]
             . json (ConnectionUpdate Accepted)
-            ) !!! const 200 === statusCode
+            . fn
+            )
+        return (r1, r2)
 
 randomUsers :: Brig -> Int -> Http [UserId]
 randomUsers b n = replicateM n (randomUser b)


### PR DESCRIPTION
This PR changes the behaviour of `rangeCheckedMaybe` (which is used in the creation of every type of conversation) to verify that if we have a `Just`, then this `Just` is within the required `Range`.
Thus, when creating conversations, if `Name` is specified, then it must be within the `[1, 256]` range.

Also fixed one test which was failing after the configurable options for max connections was introduced.