### PR TITLE
Latest HsOpenSSL is compatible with openssl 1.1.x

### DIFF
--- a/services/brig/stack.yaml
+++ b/services/brig/stack.yaml
@@ -39,4 +39,5 @@ extra-deps:
 - tasty-1.0.0.1
 - text-icu-translit-0.1.0.7
 - wai-middleware-gunzip-0.0.2
+- HsOpenSSL-0.11.4.12
 resolver: lts-10.3

--- a/services/galley/stack.yaml
+++ b/services/galley/stack.yaml
@@ -24,4 +24,4 @@ extra-deps:
 - currency-codes-2.0.0.0
 - data-timeout-0.3
 - wai-middleware-gunzip-0.0.2
-extra-package-dbs: []
+- HsOpenSSL-0.11.4.12

--- a/services/gundeck/stack.yaml
+++ b/services/gundeck/stack.yaml
@@ -24,3 +24,4 @@ extra-deps:
 - currency-codes-2.0.0.0
 - data-timeout-0.3
 - wai-middleware-gunzip-0.0.2
+- HsOpenSSL-0.11.4.12

--- a/stack.yaml
+++ b/stack.yaml
@@ -55,6 +55,7 @@ extra-deps:
 - tasty-1.0.0.1
 - text-icu-translit-0.1.0.7
 - wai-middleware-gunzip-0.0.2
+- HsOpenSSL-0.11.4.12
 
 flags:
   types-common:


### PR DESCRIPTION
Currently, brig, galley, gundeck, cargohold don't compile/link with openssl 1.1.x. (#203 already removes that dependency for cargohold). The latest HsOpenSSL fixes that, and works with both the 1.0.x and 1.1.x branches. 1.1.x tested with:

```
OpenSSL 1.1.0g-fips  2 Nov 2017
```

```
ldd ~/.local/bin/brig
(...)
	libssl.so.1.1 => /lib64/libssl.so.1.1 (0x0000783c4913a000)
(...)
```
Integration tests work, too.

Whenever we upgrade the resolver to `lts-10.6` or later, that will also upgrade HsOpenSSL, so at that point it doesn't need to be specified as extra-dep.