### PR TITLE
Add databases & migrations to docker-compose

### DIFF
--- a/deploy/docker-ephemeral/db-migrate.sh
+++ b/deploy/docker-ephemeral/db-migrate.sh
@@ -4,7 +4,7 @@ until_ready() {
     until $1; do echo 'service not ready yet'; sleep 5; done
 }
 
-until_ready "brig-index create --elasticsearch-server http://elasticsearch:9200"
+until_ready "brig-index reset --elasticsearch-server http://elasticsearch:9200"
 
 until_ready "brig-schema --host cassandra --keyspace brig_test --replication-factor 1"
 until_ready "galley-schema --host cassandra --keyspace galley_test --replication-factor 1"

--- a/deploy/docker-ephemeral/db-migrate.sh
+++ b/deploy/docker-ephemeral/db-migrate.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+until_ready() {
+    until $1; do echo 'service not ready yet'; sleep 5; done
+}
+
+
+# TODO: brig-index needs to allow hosts other than localhost
+# until_ready "brig-index reset"
+
+until_ready "brig-schema --host cassandra --keyspace brig_test --replication-factor 1"
+until_ready "galley-schema --host cassandra --keyspace galley_test --replication-factor 1"
+until_ready "gundeck-schema --host cassandra --keyspace gundeck_test --replication-factor 1"

--- a/deploy/docker-ephemeral/db-migrate.sh
+++ b/deploy/docker-ephemeral/db-migrate.sh
@@ -4,9 +4,7 @@ until_ready() {
     until $1; do echo 'service not ready yet'; sleep 5; done
 }
 
-
-# TODO: brig-index needs to allow hosts other than localhost
-# until_ready "brig-index reset"
+until_ready "brig-index create --elasticsearch-server http://elasticsearch:9200"
 
 until_ready "brig-schema --host cassandra --keyspace brig_test --replication-factor 1"
 until_ready "galley-schema --host cassandra --keyspace galley_test --replication-factor 1"

--- a/deploy/docker-ephemeral/docker-compose.yaml
+++ b/deploy/docker-ephemeral/docker-compose.yaml
@@ -25,6 +25,29 @@ services:
     ports:
       - "6379:6379"
 
+  elasticsearch:
+    image: elasticsearch:5.6
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+
+  cassandra:
+    image: cassandra:3.11.1
+    ports:
+      - "9042:9042"
+
+  db_migrations:
+    image: wireserver/migrations
+    depends_on:
+      - elasticsearch
+      - cassandra
+    command: /scripts/db-migrate.sh
+    volumes:
+      - ./:/scripts
+    links:
+      - elasticsearch
+      - cassandra
+
   aws_cli:
     image: mesosphere/aws-cli:1.14.5
     depends_on:
@@ -39,4 +62,3 @@ services:
     entrypoint: /scripts/init.sh
     volumes:
       - ./:/scripts
-


### PR DESCRIPTION
#217 shows how `wireserver/migrations` is created.

Depends on #219 and #217 being merged.