### PR TITLE
Add travis file that builds & pushes docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ services:
 env:
   global:
     - DOCKER_TAG=0.1.${TRAVIS_BUILD_NUMBER}
-    - DOCKER_PUSH=1
+    - DOCKER_PUSH=1 # if DOCKER_PUSH is defined, `make docker-*` uploads images to dockerhub.
   matrix:
-    # - TARGETS="docker-builder" # currently takes ~ 2h (needs to compile GHC) which is more than travis permits.
+    # - TARGETS="docker-builder" # currently takes ~ 2h (needs to compile GHC) which is more than travis permits. This image will, until a more recent ghc is available as an alpine package, be uploaded manually/through wire-internal CI"
     - TARGETS="docker-deps"
     - TARGETS="docker-intermediate docker-migrations"
     - TARGETS="docker-intermediate
@@ -46,6 +46,6 @@ script:
 notifications:
   email: false
 
-#branches:
-#only:
-#  - develop
+branches:
+  only:
+    - develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,6 @@ script:
 notifications:
   email: false
 
-branches:
-  only:
-    - develop
+#branches:
+#only:
+#  - develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+sudo: 'required'
+
+services:
+- 'docker'
+
+env:
+  global:
+    - DOCKER_TAG=0.1.${TRAVIS_BUILD_NUMBER}
+    - DOCKER_PUSH=1
+  matrix:
+    # - TARGETS="docker-builder" # currently takes ~ 2h (needs to compile GHC) which is more than travis permits.
+    - TARGETS="docker-deps"
+    - TARGETS="docker-intermediate docker-migrations"
+    - TARGETS="docker-intermediate
+               docker-exe-api-loadtest
+               docker-exe-api-smoketest
+               docker-exe-bonanza
+               docker-exe-brig
+               docker-exe-brig-index
+               docker-exe-brig-integration
+               docker-exe-brig-schema
+               docker-exe-cannon
+               docker-exe-cargohold
+               docker-exe-cargohold-integration
+               docker-exe-galley
+               docker-exe-galley-integration
+               docker-exe-galley-journaler
+               docker-exe-galley-schema
+               docker-exe-gundeck
+               docker-exe-gundeck-integration
+               docker-exe-gundeck-schema
+               docker-exe-kibana-raw
+               docker-exe-kibanana
+               docker-exe-makedeb
+               docker-exe-metrics-collector
+               docker-exe-proxy
+               docker-exe-ropes-aws-auth-test
+               docker-exe-ropes-aws-test
+               docker-exe-zauth
+              "
+
+script:
+  - docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+  - make ${TARGETS[@]}
+
+notifications:
+  email: false
+
+branches:
+  only:
+    - develop

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,62 @@
 HASKELL_SERVICES := proxy cannon cargohold brig galley gundeck
 SERVICES         := $(HASKELL_SERVICES) nginz
+DOCKER_USER      ?= wireserver
+DOCKER_TAG       ?= local
+
+default: clean install
+
+init:
+	mkdir -p dist
+
+.PHONY: install
+install: init
+	stack install --pedantic --test --local-bin-path=dist
+
+.PHONY: clean
+clean:
+	stack clean
+	-rm -rf dist
+	-rm -f .metadata
+
+
+.PHONY: services
+services:
+	$(foreach service,$(HASKELL_SERVICES),$(MAKE) -C services/$(service) clean install;)
+
+#################################
+## docker targets
 
 .PHONY: docker-services
 docker-services:
 	$(MAKE) -C build/alpine
 	$(foreach service,$(SERVICES),$(MAKE) -C services/$(service) docker;)
 
-.PHONY: services
-services:
-	$(foreach service,$(HASKELL_SERVICES),$(MAKE) -C services/$(service) clean install;)
+.PHONY: docker-deps
+docker-deps:
+	$(MAKE) -C build/alpine deps
 
+.PHONY: docker-builder
+docker-builder:
+	$(MAKE) -C build/alpine builder
+
+.PHONY: docker-intermediate
+docker-intermediate:
+	docker build -t $(DOCKER_USER)/intermediate:$(DOCKER_TAG) -f build/alpine/Dockerfile.intermediate .;
+	docker tag $(DOCKER_USER)/intermediate:$(DOCKER_TAG) $(DOCKER_USER)/intermediate:latest;
+	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/intermediate:$(DOCKER_TAG); docker push $(DOCKER_USER)/intermediate:latest; fi;
+
+.PHONY: docker-migrations
+docker-migrations:
+	docker build -t $(DOCKER_USER)/migrations:$(DOCKER_TAG) -f build/alpine/Dockerfile.migrations .
+	docker tag $(DOCKER_USER)/migrations:$(DOCKER_TAG) $(DOCKER_USER)/migrations:latest
+	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/migrations:$(DOCKER_TAG); docker push $(DOCKER_USER)/migrations:latest; fi;
+
+.PHONY: docker-exe-%
+docker-exe-%:
+	docker build -t $(DOCKER_USER)/"$*":$(DOCKER_TAG) -f build/alpine/Dockerfile.executable --build-arg executable="$*" .
+	docker tag $(DOCKER_USER)/"$*":$(DOCKER_TAG) $(DOCKER_USER)/"$*":latest
+	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/"$*":$(DOCKER_TAG); docker push $(DOCKER_USER)/"$*":latest; fi;
+
+.PHONY: docker-service-%
+docker-service-%:
+	$(MAKE) -C services/"$*" docker

--- a/Makefile
+++ b/Makefile
@@ -43,19 +43,19 @@ docker-builder:
 docker-intermediate:
 	docker build -t $(DOCKER_USER)/intermediate:$(DOCKER_TAG) -f build/alpine/Dockerfile.intermediate .;
 	docker tag $(DOCKER_USER)/intermediate:$(DOCKER_TAG) $(DOCKER_USER)/intermediate:latest;
-	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/intermediate:$(DOCKER_TAG); docker push $(DOCKER_USER)/intermediate:latest; fi;
+	if test -n "$$DOCKER_PUSH"; then docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD); docker push $(DOCKER_USER)/intermediate:$(DOCKER_TAG); docker push $(DOCKER_USER)/intermediate:latest; fi;
 
 .PHONY: docker-migrations
 docker-migrations:
 	docker build -t $(DOCKER_USER)/migrations:$(DOCKER_TAG) -f build/alpine/Dockerfile.migrations .
 	docker tag $(DOCKER_USER)/migrations:$(DOCKER_TAG) $(DOCKER_USER)/migrations:latest
-	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/migrations:$(DOCKER_TAG); docker push $(DOCKER_USER)/migrations:latest; fi;
+	if test -n "$$DOCKER_PUSH"; then docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD); docker push $(DOCKER_USER)/migrations:$(DOCKER_TAG); docker push $(DOCKER_USER)/migrations:latest; fi;
 
 .PHONY: docker-exe-%
 docker-exe-%:
 	docker build -t $(DOCKER_USER)/"$*":$(DOCKER_TAG) -f build/alpine/Dockerfile.executable --build-arg executable="$*" .
 	docker tag $(DOCKER_USER)/"$*":$(DOCKER_TAG) $(DOCKER_USER)/"$*":latest
-	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/"$*":$(DOCKER_TAG); docker push $(DOCKER_USER)/"$*":latest; fi;
+	if test -n "$$DOCKER_PUSH"; then docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD); docker push $(DOCKER_USER)/"$*":$(DOCKER_TAG); docker push $(DOCKER_USER)/"$*":latest; fi;
 
 .PHONY: docker-service-%
 docker-service-%:

--- a/build/alpine/Dockerfile
+++ b/build/alpine/Dockerfile
@@ -4,8 +4,8 @@
 #   (from wire-server root directory)
 #   SERVICE=galley; docker build -f build/alpine/Dockerfile -t $SERVICE --build-arg service=$SERVICE .
 
-ARG builder=wire-server-builder:alpine
-ARG deps=wire-server-deps:alpine
+ARG builder=wireserver/alpine-builder
+ARG deps=wireserver/alpine-deps
 
 #--- Builder stage ---
 FROM ${builder} as builder

--- a/build/alpine/Dockerfile.builder
+++ b/build/alpine/Dockerfile.builder
@@ -89,8 +89,9 @@ RUN cd /tmp && \
 RUN cd /tmp/ghc && \
     ./boot && \
     SPHINXBUILD=/usr/bin/sphinx-build-3 ./configure --prefix=/root/.stack/programs/x86_64-linux/$GHC_VER --disable-ld-override && \
-    make -j4 && \
-    make install && \
+    echo "compiling GHC, may take an hour. Log output sent to /dev/null due to travis log length restrictions." && \
+    make -j4 &> /dev/null && \
+    make install &> /dev/null && \
     mv /tmp/config.yaml /root/.stack/
 
 # download stack indices and compile/cache dependencies to speed up subsequent container creation

--- a/build/alpine/Dockerfile.executable
+++ b/build/alpine/Dockerfile.executable
@@ -1,0 +1,30 @@
+# Produces final docker image with a single executable $executable
+
+# Requires docker version >= 17.05 (requires support for multi-stage builds)
+# Requires to have created the wire-server-builder and wire-server-deps docker images (run `make` in this directory)
+# Usage example:
+#   (from wire-server root directory)
+#   export EXECUTABLE=galley-schema; docker build -t $EXECUTABLE -f build/alpine/Dockerfile.executable --build-arg executable=$EXECUTABLE .
+
+ARG intermediate=wireserver/intermediate
+ARG deps=wireserver/alpine-deps
+
+#--- Intermediate stage ---
+FROM ${intermediate} as intermediate
+
+#--- Minified stage ---
+FROM ${deps}
+
+ARG executable
+
+COPY --from=intermediate /dist/${executable} /dist/${executable}
+
+# TODO: only if executable=brig, also copy templates. Docker image conditionals seem hacky:
+# https://stackoverflow.com/questions/31528384/conditional-copy-add-in-dockerfile
+# For now, adds ~2 MB of additional files into every container
+COPY --from=intermediate /dist/templates/ /usr/share/wire/templates/
+
+# ARGs are not available at runtime, create symlink at build time
+# more info: https://stackoverflow.com/questions/40902445/using-variable-interpolation-in-string-in-docker
+RUN ln -s /usr/bin/${executable} /usr/bin/service
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/bin/service"]

--- a/build/alpine/Dockerfile.intermediate
+++ b/build/alpine/Dockerfile.intermediate
@@ -1,0 +1,24 @@
+# Produces intermediate docker image with all executables under /dist
+
+# Requires docker version >= 17.05 (requires support for multi-stage builds)
+# Requires to have created the wire-server-builder and wire-server-deps docker images (run `make` in this directory)
+# Usage example:
+#   (from wire-server root directory)
+#   docker build -f build/alpine/Dockerfile.intermediate .
+
+ARG builder=wireserver/alpine-builder
+ARG deps=wireserver/alpine-deps
+
+#--- Builder stage ---
+FROM ${builder} as builder
+
+COPY . /src/wire-server/
+
+RUN cd /src/wire-server && make clean install
+
+#--- Minified stage ---
+FROM ${deps}
+
+COPY --from=builder /src/wire-server/dist/ /dist/
+# brig also needs some templates.
+COPY --from=builder /src/wire-server/services/brig/deb/opt/brig/templates/ /dist/templates/

--- a/build/alpine/Dockerfile.migrations
+++ b/build/alpine/Dockerfile.migrations
@@ -1,0 +1,23 @@
+# Produces docker image with migration executables (brig-schema, brig-index, etc)
+
+# Requires docker version >= 17.05 (requires support for multi-stage builds)
+# Requires to have created the wire-server-builder and wire-server-deps docker images (run `make` in this directory)
+# Usage example:
+#   (from wire-server root directory)
+#   docker build -f build/alpine/Dockerfile.migrations .
+
+ARG intermediate=wireserver/intermediate
+ARG deps=wireserver/alpine-deps
+
+#--- Intermediate stage ---
+FROM ${intermediate} as intermediate
+
+#--- Minified stage ---
+FROM ${deps}
+
+COPY --from=intermediate /dist/brig-index /usr/bin/brig-index
+COPY --from=intermediate /dist/brig-schema /usr/bin/brig-schema
+COPY --from=intermediate /dist/galley-schema /usr/bin/galley-schema
+COPY --from=intermediate /dist/gundeck-schema /usr/bin/gundeck-schema
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/build/alpine/Makefile
+++ b/build/alpine/Makefile
@@ -1,10 +1,16 @@
+DOCKER_USER   ?= wireserver
+DOCKER_TAG    ?= local
 
 default: deps builder
 
 .PHONY: deps
 deps:
-	docker build -t wire-server-deps:alpine -f Dockerfile.deps .
+	docker build -t $(DOCKER_USER)/alpine-deps:$(DOCKER_TAG) -f Dockerfile.deps .
+	docker tag $(DOCKER_USER)/alpine-deps:$(DOCKER_TAG) $(DOCKER_USER)/alpine-deps:latest
+	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/alpine-deps:$(DOCKER_TAG); docker push $(DOCKER_USER)/alpine-deps:latest; fi;
 
 .PHONY: builder
 builder:
-	docker build -t wire-server-builder:alpine -f Dockerfile.builder .
+	docker build -t $(DOCKER_USER)/alpine-builder:$(DOCKER_TAG) -f Dockerfile.builder .
+	docker tag $(DOCKER_USER)/alpine-builder:$(DOCKER_TAG) $(DOCKER_USER)/alpine-builder:latest
+	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/alpine-builder:$(DOCKER_TAG); docker push $(DOCKER_USER)/alpine-builder:latest; fi;

--- a/build/alpine/README.md
+++ b/build/alpine/README.md
@@ -1,4 +1,4 @@
-## Overview
+# Overview
 
 To create docker images, you need to install [docker version >= 17.05](https://www.docker.com/) and [`make`](https://www.gnu.org/software/make/).
 
@@ -20,3 +20,9 @@ cd build/alpine && make
 ```bash
 cd services/brig && make docker
 ```
+
+## Other dockerfiles
+
+* `Dockerfile.intermediate` - based on `Dockerfile.deps`/`Dockerfile.builder`, this is an intermediate image compiling all dynamically linked binaries (obtained when running `make install` in the top-level directory).
+* `Dockerfile.executable` - based on `Dockerfile.deps`/`Dockerfile.intermediate`, this extracts a single executable from the intermediate image, yielding a small image with a single dynamically linked binary.
+* `Dockerfile.migrations` - same as Dockerfile.executable, with a fixed set of database migration binaries.

--- a/services/brig/Dockerfile
+++ b/services/brig/Dockerfile
@@ -1,8 +1,8 @@
 # Requires docker >= 17.05 (requires support for multi-stage builds)
 # Requires to have created the wire-server-builder and wire-server-deps docker images
 
-ARG builder=wire-server-builder:alpine
-ARG deps=wire-server-deps:alpine
+ARG builder=wireserver/alpine-builder
+ARG deps=wireserver/alpine-deps
 
 #--- Builder stage ---
 FROM ${builder} as builder


### PR DESCRIPTION
Adds a few docker images and Makefile targets. 'wireserver' on dockerhub becomes the default namespace (I'll convert this shortly to an organization).

`docker-builder` is currently uploaded manually due to it taking >50 minutes (which is the travis hard limit)

Example build: https://travis-ci.org/wireapp/wire-server/builds/346911997
Resulting docker images: https://hub.docker.com/r/wireserver/