### PR TITLE
Expose 'expires_at' json field for ephemeral users

### DIFF
--- a/libs/brig-types/src/Brig/Types/Intra.hs
+++ b/libs/brig-types/src/Brig/Types/Intra.hs
@@ -24,6 +24,7 @@ data AccountStatus
     = Active
     | Suspended
     | Deleted
+    | Ephemeral
     deriving Eq
 
 instance FromJSON AccountStatus where
@@ -31,12 +32,14 @@ instance FromJSON AccountStatus where
         "active"    -> pure Active
         "suspended" -> pure Suspended
         "deleted"   -> pure Deleted
+        "ephemeral" -> pure Ephemeral
         _           -> fail $ "Invalid account status: " ++ Text.unpack s
 
 instance ToJSON AccountStatus where
     toJSON Active    = String "active"
     toJSON Suspended = String "suspended"
     toJSON Deleted   = String "deleted"
+    toJSON Ephemeral = String "ephemeral"
 
 newtype AccountStatusUpdate = AccountStatusUpdate
     { suStatus :: AccountStatus }

--- a/services/brig/Makefile
+++ b/services/brig/Makefile
@@ -90,18 +90,18 @@ integration-list: install
 integration-%: db-migrate index-reset
 	LOG_LEVEL=Info keiretsu --run '$(EXE_IT) --pattern="$*"' --env $(KEIRETSU_ENV)
 
+
+.PHONY: fast
+fast:
+	stack install --fast --local-bin-path=dist
+
 .PHONY: test
-test:
-	stack install --fast --test --local-bin-path=dist
-	LOG_LEVEL=Info keiretsu --run '$(EXE_IT)' --env $(KEIRETSU_ENV)
+test: fast
+	LOG_LEVEL=Info keiretsu --run '$(EXE_IT)' --env $(KEIRETSU_ENV) --delay 3000
 
-test-%:
-	stack install --fast --test --local-bin-path=dist
-	LOG_LEVEL=Info keiretsu --run '$(EXE_IT) --pattern="$*"' --env $(KEIRETSU_ENV)
+test-%: fast
+	LOG_LEVEL=Info keiretsu --run '$(EXE_IT) --pattern="$*"' --env $(KEIRETSU_ENV) --delay 3000
 
-test-fast:
-	stack install --fast --test --local-bin-path=dist
-	LOG_LEVEL=Info keiretsu --run '$(EXE_IT)' --env $(KEIRETSU_ENV)
 
 .PHONY: db
 db: db-reset

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1133,7 +1133,9 @@ createUser (_ ::: _ ::: req) = do
             sendActivationSms p c (Just lang)
         for_ (liftM3 (,,) (userEmail usr) (createdUserTeam result) (newUserTeam new)) $ \(e, ct, ut) ->
             sendWelcomeEmail e ct ut (Just lang)
-    cok <- lift $ Auth.newCookie (userId usr) PersistentCookie (newUserLabel new)
+    cok <- case acc of
+        UserAccount _ Ephemeral -> lift $ Auth.newCookie (userId usr) SessionCookie (newUserLabel new)
+        UserAccount _ _         -> lift $ Auth.newCookie (userId usr) PersistentCookie (newUserLabel new)
     lift $ Auth.setResponseCookie cok
         $ setStatus status201
         . addHeader "Location" (toByteString' (userId usr))

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -107,6 +107,7 @@ changeHandleError ChangeHandleInvalid     = StdError invalidHandle
 loginError :: LoginError -> Error
 loginError LoginFailed            = StdError badCredentials
 loginError LoginSuspended         = StdError accountSuspended
+loginError LoginEphemeral         = StdError accountEphemeral
 loginError LoginPendingActivation = StdError accountPending
 loginError (LoginThrottled wait)  = RichError loginsTooFrequent ()
     [("Retry-After", toByteString' (retryAfterSeconds wait))]
@@ -115,6 +116,7 @@ authError :: AuthError -> Error
 authError AuthInvalidUser        = StdError badCredentials
 authError AuthInvalidCredentials = StdError badCredentials
 authError AuthSuspended          = StdError accountSuspended
+authError AuthEphemeral          = StdError accountEphemeral
 
 reauthError :: ReAuthError -> Error
 reauthError ReAuthMissingPassword = StdError missingAuthError
@@ -254,6 +256,9 @@ accountPending = Wai.Error status403 "pending-activation" "Account pending activ
 
 accountSuspended :: Wai.Error
 accountSuspended = Wai.Error status403 "suspended" "Account suspended."
+
+accountEphemeral :: Wai.Error
+accountEphemeral = Wai.Error status403 "ephemeral" "Account is ephemeral."
 
 badCredentials :: Wai.Error
 badCredentials = Wai.Error status403 "invalid-credentials" "Authentication failed."

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -104,6 +104,7 @@ data PasswordResetError
 data LoginError
     = LoginFailed
     | LoginSuspended
+    | LoginEphemeral
     | LoginPendingActivation
     | LoginThrottled RetryAfter
 

--- a/services/brig/src/Brig/Data/Instances.hs
+++ b/services/brig/src/Brig/Data/Instances.hs
@@ -125,11 +125,13 @@ instance Cql AccountStatus where
     toCql Active    = CqlInt 0
     toCql Suspended = CqlInt 1
     toCql Deleted   = CqlInt 2
+    toCql Ephemeral = CqlInt 3
 
     fromCql (CqlInt i) = case i of
         0 -> return Active
         1 -> return Suspended
         2 -> return Deleted
+        3 -> return Ephemeral
         n -> fail $ "unexpected account status: " ++ show n
     fromCql _ = fail "account status: int expected"
 

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -644,7 +644,7 @@ addBot (zuid ::: zcon ::: cid ::: req) = do
     let colour = fromMaybe defaultAccentId            (Ext.rsNewBotColour rs)
     let pict   = Pict [] -- Legacy
     let sref   = newServiceRef sid pid
-    let usr    = User (botUserId bid) Nothing name pict assets colour False locale (Just sref) Nothing
+    let usr    = User (botUserId bid) Nothing name pict assets colour False locale (Just sref) Nothing Nothing
     let newClt = (newClient PermanentClient (Ext.rsNewBotLastPrekey rs) ())
                { newClientPrekeys = Ext.rsNewBotPrekeys rs
                }

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -75,6 +75,7 @@ login (PasswordLogin li pw label) typ = do
     uid <- resolveLoginId li
     Data.authenticate uid pw `catchE` \case
         AuthSuspended          -> throwE LoginSuspended
+        AuthEphemeral          -> throwE LoginEphemeral
         AuthInvalidCredentials -> throwE LoginFailed
         AuthInvalidUser        -> throwE LoginFailed
     newAccess uid typ label


### PR DESCRIPTION
Ephemeral users are defined as users created with neither email nor phone
The optional field 'expires_at' is available for these users on
  - /register
  - /self (SelfProfile)
  - /users/:Id (public UserProfile)
expiry time is creation time + SessionTokenTimeout (default: 1 day). JSON example of user profile: 
```
{
   (... other user fields)
   "expires_at" : "2018-03-06T20:36:12.000Z"
}
```