### PR TITLE
Use remotely generated notification id

### DIFF
--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -371,8 +371,10 @@ testNoNewNotifs gu _ _ _ = do
 
 testMissingNotifs :: TestSignature ()
 testMissingNotifs gu _ _ _ = do
-    ally <- randomId
-    old <- nextNotificationId
+    other   <- randomId
+    sendPush gu (buildPush other [(other, [])] (textPayload "hello"))
+    (old:_) <- map (view queuedNotificationId) <$> listNotifications other Nothing gu
+    ally    <- randomId
     sendPush gu (buildPush ally [(ally, [])] (textPayload "hello"))
     ns <- listNotifications ally Nothing gu
     get ( runGundeck gu


### PR DESCRIPTION
Running this test locally against a remote server (or cluster of) "often" fails due to clock drift; this PR fixes that by using a notification ID remotely generated (for another user, to keep the semantics of the test) instead of a local one.