### PR TITLE
Allow stack to use haskell.org instead of fpcomplete.com

### DIFF
--- a/build/alpine/ghc/config.yaml
+++ b/build/alpine/ghc/config.yaml
@@ -4,3 +4,7 @@ ghc-build: standard
 system-ghc: true
 ghc-options:
   "$everything": -split-sections
+package-indices:
+  - name: HackageOrig
+    download-prefix: https://hackage.haskell.org/package/
+    http: https://hackage.haskell.org/01-index.tar.gz


### PR DESCRIPTION
See https://github.com/commercialhaskell/stack/issues/2509

Resolves https://github.com/wireapp/wire-server/issues/236