### PR TITLE
More robust integration tests

### DIFF
--- a/deploy/docker-ephemeral/init.sh
+++ b/deploy/docker-ephemeral/init.sh
@@ -18,11 +18,15 @@ aws --endpoint-url=http://dynamodb:8000 dynamodb delete-table --table-name integ
 exec_until_ready "aws --endpoint-url=http://dynamodb:8000 dynamodb create-table --table-name integration-brig-userkey-blacklist --attribute-definitions AttributeName=key,AttributeType=S --key-schema AttributeName=key,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5"
 exec_until_ready "aws --endpoint-url=http://dynamodb:8000 dynamodb create-table --table-name integration-brig-prekeys --attribute-definitions AttributeName=client,AttributeType=S --key-schema AttributeName=client,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5"
 exec_until_ready "aws --endpoint-url=http://sqs:4568 sqs create-queue --queue-name integration-brig-events"
+exec_until_ready "aws --endpoint-url=http://sqs:4568 sqs set-queue-attributes --queue-url http://sqs:4568/integration-brig-events --attributes VisibilityTimeout=1"
 exec_until_ready "aws --endpoint-url=http://sqs:4568 sqs create-queue --queue-name integration-brig-events-internal"
+exec_until_ready "aws --endpoint-url=http://sqs:4568 sqs set-queue-attributes --queue-url http://sqs:4568/integration-brig-events-internal --attributes VisibilityTimeout=1"
 # Gundeck's feedback queue
 exec_until_ready "aws --endpoint-url=http://sqs:4568 sqs create-queue --queue-name integration-gundeck-events"
+exec_until_ready "aws --endpoint-url=http://sqs:4568 sqs set-queue-attributes --queue-url http://sqs:4568/integration-gundeck-events --attributes VisibilityTimeout=1"
 # Galley's team event queue
 exec_until_ready "aws --endpoint-url=http://sqs:4568 sqs create-queue --queue-name integration-team-events.fifo"
+exec_until_ready "aws --endpoint-url=http://sqs:4568 sqs set-queue-attributes --queue-url http://sqs:4568/integration-team-events.fifo --attributes VisibilityTimeout=1"
 # # Verify sender's email address (ensure the sender address is in sync with the config in brig)
 exec_until_ready "aws --endpoint-url=http://ses:4579 ses verify-email-identity --email-address backend-integration@wire.com"
 

--- a/services/galley/.env
+++ b/services/galley/.env
@@ -5,4 +5,4 @@ GALLEY_CASSANDRA_KEYSPACE=galley_test
 INTEGRATION_TEST=1
 GALLEY_CONVERSATION_CODE_PREFIX=https://app.wire.com/join/
 GALLEY_SQS_TEAM_EVENTS=integration-team-events.fifo
-GALLEY_SQS_ENDPOINT=http://localhost:4568
+GALLEY_SQS_ENDPOINT=https://sqs.eu-west-1.amazonaws.com:443

--- a/services/galley/.env
+++ b/services/galley/.env
@@ -5,4 +5,4 @@ GALLEY_CASSANDRA_KEYSPACE=galley_test
 INTEGRATION_TEST=1
 GALLEY_CONVERSATION_CODE_PREFIX=https://app.wire.com/join/
 GALLEY_SQS_TEAM_EVENTS=integration-team-events.fifo
-GALLEY_SQS_ENDPOINT=https://sqs.eu-west-1.amazonaws.com:443
+GALLEY_SQS_ENDPOINT=http://localhost:4568

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -207,7 +207,7 @@ executable galley-integration
       , http-types
       , lens
       , lens-aeson
-      , lifted-async         >= 0.2
+      , lifted-async
       , mtl
       , network
       , optparse-applicative

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -207,6 +207,7 @@ executable galley-integration
       , http-types
       , lens
       , lens-aeson
+      , lifted-async         >= 0.2
       , mtl
       , network
       , optparse-applicative

--- a/services/galley/test/integration/API/SQS.hs
+++ b/services/galley/test/integration/API/SQS.hs
@@ -7,7 +7,10 @@
 
 module API.SQS where
 
+import Control.Concurrent (threadDelay)
+import Control.Exception (SomeAsyncException, asyncExceptionFromException)
 import Control.Lens hiding ((.=))
+import Control.Monad.Catch hiding (bracket)
 import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Data.Foldable (for_)
@@ -38,13 +41,21 @@ import qualified OpenSSL.X509.SystemStore as Ssl
 import qualified Proto.TeamEvents as E
 import qualified System.Logger as L
 
+ensureQueueEmpty :: MonadIO m => Maybe Aws.Env -> m ()
+ensureQueueEmpty (Just env) = liftIO $ Aws.execute env purgeQueue
+ensureQueueEmpty Nothing    = return ()
+
 assertQueue :: MonadIO m => String -> Maybe Aws.Env -> (String -> Maybe E.TeamEvent -> IO ()) -> m ()
 assertQueue label (Just env) check = liftIO $ Aws.execute env $ fetchMessage label check
-assertQueue _ Nothing _ = return ()
+assertQueue _     Nothing    _     = return ()
+
+assertQueue' :: MonadIO m => String -> Int -> Maybe Aws.Env -> (String -> Maybe E.TeamEvent -> IO ()) -> m ()
+assertQueue' label timeout (Just env) check = liftIO $ Aws.execute env $ awaitMessage label timeout check
+assertQueue' _     _       Nothing    _     = return ()
 
 assertQueueEmpty :: MonadIO m => Maybe Aws.Env -> m ()
 assertQueueEmpty (Just env) = liftIO $ Aws.execute env ensureNoMessages
-assertQueueEmpty Nothing = return ()
+assertQueueEmpty Nothing    = return ()
 
 tActivateWithCurrency :: Maybe Currency.Alpha -> String -> Maybe E.TeamEvent -> IO ()
 tActivateWithCurrency c l (Just e) = do
@@ -53,21 +64,21 @@ tActivateWithCurrency c l (Just e) = do
     -- NOTE: protobuf decodes absent, optional fields as (Just "")
     let cur = maybe "" (pack . show) c
     assertEqual "currency" (Just cur) (e^.E.eventData^?E.currency)
-tActivateWithCurrency _ l Nothing = assertFailure $ l <> ": Expected 1 TeamActivate, got nothing"
+tActivateWithCurrency _ l Nothing  = assertFailure $ l <> ": Expected 1 TeamActivate, got nothing"
 
 tActivate :: String -> Maybe E.TeamEvent -> IO ()
 tActivate l (Just e) = do
     assertEqual (l <> ": eventType") E.TeamEvent'TEAM_ACTIVATE (e^.E.eventType)
     assertEqual "count" 1 (e^.E.eventData^.E.memberCount)
-tActivate l Nothing = assertFailure $ l <> ": Expected 1 TeamActivate, got nothing"
+tActivate l Nothing  = assertFailure $ l <> ": Expected 1 TeamActivate, got nothing"
 
 tDelete :: String -> Maybe E.TeamEvent -> IO ()
 tDelete l (Just e) = assertEqual (l <> ": eventType") E.TeamEvent'TEAM_DELETE (e^.E.eventType)
-tDelete l Nothing = assertFailure $ l <> ": Expected 1 TeamDelete, got nothing"
+tDelete l Nothing  = assertFailure $ l <> ": Expected 1 TeamDelete, got nothing"
 
 tSuspend :: String -> Maybe E.TeamEvent -> IO ()
 tSuspend l (Just e) = assertEqual (l  <> "eventType") E.TeamEvent'TEAM_SUSPEND (e^.E.eventType)
-tSuspend l Nothing = assertFailure $ l <> ": Expected 1 TeamSuspend, got nothing"
+tSuspend l Nothing  = assertFailure $ l <> ": Expected 1 TeamSuspend, got nothing"
 
 tUpdate :: Int32 -> [UserId] -> String -> Maybe E.TeamEvent -> IO ()
 tUpdate c uids l (Just e) = do
@@ -79,36 +90,93 @@ tUpdate _ _ l Nothing = assertFailure $ l <> ": Expected 1 TeamUpdate, got nothi
 ensureNoMessages :: Amazon ()
 ensureNoMessages = do
     QueueUrl url <- view eventQueue
-    msgs <- view SQS.rmrsMessages <$> AWS.send (receive url)
-    liftIO $ assertEqual "length" 0 (length msgs)
+    msgs <- view SQS.rmrsMessages <$> AWS.send (receive 1 url)
+    liftIO $ assertEqual "ensureNoMessages: length" 0 (length msgs)
 
 fetchMessage :: String -> (String -> Maybe E.TeamEvent -> IO()) -> Amazon ()
 fetchMessage label callback = do
     QueueUrl url <- view eventQueue
-    msgs <- view SQS.rmrsMessages <$> AWS.send (receive url)
+    msgs <- view SQS.rmrsMessages <$> AWS.send (receive 1 url)
     events <- mapM (parseDeleteMessage url) msgs
     liftIO $ callback label (headDef Nothing events)
+
+awaitMessage :: String -> Int -> (String -> Maybe E.TeamEvent -> IO()) -> Amazon ()
+awaitMessage label timeout callback = do
+    QueueUrl url <- view eventQueue
+    -- TODO: Read all messages
+    tryMatch label timeout url callback -- (headDef Nothing events)
+
+type Err = String
+type Success = String
+
+-- tryMatch :: (MonadIO m, MonadCatch m, AWS.MonadAWS m)
+--          => Text
+--          -> (String -> Maybe E.TeamEvent -> IO())
+--          -> m (Either Err Success)    
+tryMatch :: String
+         -> Int
+         -> Text
+         -> (String -> Maybe E.TeamEvent -> IO())
+         -> Amazon ()    
+tryMatch label tries url callback = go tries
+  where
+    go 0 = error "no journaled notification found fail!"
+    go n = do
+        msgs   <- view SQS.rmrsMessages <$> AWS.send (receive 10 url)
+        events <- mapM parseMessage msgs
+        liftIO $ print ("Callback with: " ++ show events)
+        anyOK <- checkAnyOK . zip msgs <$> mapM check events
+        liftIO $ print anyOK
+        case anyOK of
+            [] -> go (n - 1)
+            xs -> do
+                forM_ xs $ \(m,evt) -> do
+                    for_ (m ^. SQS.mReceiptHandle) (void . AWS.send . SQS.deleteMessage url)
+                    liftIO $ print ("deleted: " ++ show evt)
+                -- go (n - 1)
+        liftIO $ threadDelay (1 * 10^(6 :: Int))
+
+    check :: Maybe E.TeamEvent -> Amazon (Either Err Success)
+    check e = do
+        liftIO $ callback label e
+        liftIO $ print ("Successfully checked: " ++ show e)
+        return (Right $ show e)
+      `catchAll` \ex -> case asyncExceptionFromException ex of
+        Just  x -> throwM (x :: SomeAsyncException)
+        Nothing -> return (Left $ show ex)
+
+    checkAnyOK :: [(SQS.Message, Either Err Success)] -> [(SQS.Message, Success)]
+    checkAnyOK []     = []
+    checkAnyOK (x:xs) = case x of
+                            (m, Right r) -> (m, r) : checkAnyOK xs
+                            _            -> checkAnyOK xs
 
 purgeQueue :: Amazon ()
 purgeQueue = do
     QueueUrl url <- view eventQueue
     void $ AWS.send (SQS.purgeQueue url)
 
-receive :: Text -> SQS.ReceiveMessage
-receive url = SQS.receiveMessage url
-                & set SQS.rmWaitTimeSeconds (Just 5)
-                . set SQS.rmMaxNumberOfMessages (Just 1)
+receive :: Int -> Text -> SQS.ReceiveMessage
+receive n url = SQS.receiveMessage url
+              & set SQS.rmWaitTimeSeconds (Just 1)
+              . set SQS.rmMaxNumberOfMessages (Just n)
+              . set SQS.rmVisibilityTimeout (Just 1)
 
 parseDeleteMessage :: Text -> SQS.Message -> Amazon (Maybe E.TeamEvent)
-parseDeleteMessage url m =
-  case (>>= decodeMessage) . B64.decode . Text.encodeUtf8 <$> (m^.SQS.mBody) of
-      Just (Right e) -> do
-          trace $ msg $ val "SQS event received"
-          for_ (m ^. SQS.mReceiptHandle) (void . AWS.send . SQS.deleteMessage url)
-          return (Just e)
-      _ -> do
-          err . msg $ val "Failed to parse SQS event"
-          return Nothing
+parseDeleteMessage url m = do
+    evt <- parseMessage m
+    for_ (m ^. SQS.mReceiptHandle) (void . AWS.send . SQS.deleteMessage url)
+    return evt
+    
+parseMessage :: SQS.Message -> Amazon (Maybe E.TeamEvent)
+parseMessage m =
+    case (>>= decodeMessage) . B64.decode . Text.encodeUtf8 <$> (m^.SQS.mBody) of
+        Just (Right e) -> do
+            trace $ msg $ val "SQS event received"
+            return (Just e)
+        _ -> do
+            err . msg $ val "Failed to parse SQS event"
+            return Nothing
 
 initHttpManager :: IO Manager
 initHttpManager = do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -10,6 +10,7 @@ import Control.Lens hiding ((#), (.=))
 import Control.Monad (void)
 import Control.Monad.IO.Class
 import Data.Aeson hiding (json)
+import Data.Aeson.Lens
 import Data.ByteString.Conversion
 import Data.Foldable (forM_, for_)
 import Data.Id
@@ -27,10 +28,12 @@ import Test.Tasty.HUnit
 import API.SQS
 
 import qualified API.Util as Util
+import qualified Control.Concurrent.Async.Lifted.Safe as AsyncSafe
 import qualified Data.Currency as Currency
 import qualified Data.List1 as List1
 import qualified Data.Set as Set
 import qualified Data.Text as T
+import qualified Data.UUID as UUID
 import qualified Galley.Types as Conv
 import qualified Network.Wai.Utilities.Error as Error
 import qualified Test.Tasty.Cannon as WS
@@ -62,7 +65,7 @@ tests s = testGroup "Teams API"
     , test s "add managed team conversation ignores given users" testAddTeamConvWithUsers
     , test s "add team member to conversation without connection" testAddTeamMemberToConv
     , test s "delete non-binding team" testDeleteTeam
-    , test s "delete binding team" testDeleteBindingTeam
+    , test s "delete (binding) team" testDeleteBindingTeam
     , test s "delete team conversation" testDeleteTeamConv
     , test s "update team data" testUpdateTeam
     , test s "update team member" testUpdateTeamMember
@@ -216,14 +219,7 @@ testAddTeamMember g b c _ = do
     WS.bracketRN c [owner, (mem1^.userId), (mem2^.userId), (mem3^.userId)] $ \[wsOwner, wsMem1, wsMem2, wsMem3] -> do
         -- `mem2` has `AddTeamMember` permission
         Util.addTeamMember g (mem2^.userId) tid mem3
-        liftIO . void $ mapConcurrently (checkJoinEvent tid (mem3^.userId)) [wsOwner, wsMem1, wsMem2, wsMem3]
-  where
-    checkJoinEvent tid usr w = WS.assertMatch_ timeout w $ \notif -> do
-        ntfTransient notif @?= False
-        let e = List1.head (WS.unpackPayload notif)
-        e^.eventType @?= MemberJoin
-        e^.eventTeam @?= tid
-        e^.eventData @?= Just (EdMemberJoin usr)
+        AsyncSafe.mapConcurrently_ (checkTeamMemberJoin tid (mem3^.userId)) [wsOwner, wsMem1, wsMem2, wsMem3]
 
 testAddTeamMemberCheckBound :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
 testAddTeamMemberCheckBound g b _ a = do
@@ -303,17 +299,10 @@ testRemoveTeamMember g b c _ = do
         -- Ensure that `mem1` is still a user (tid is not a binding team)
         Util.ensureDeletedState b False owner (mem1^.userId)
 
-        liftIO . void $ mapConcurrently (checkLeaveEvent tid (mem1^.userId)) [wsOwner, wsMem1, wsMem2]
+        AsyncSafe.mapConcurrently_ (checkTeamMemberLeave tid (mem1^.userId)) [wsOwner, wsMem1, wsMem2]
         checkConvMemberLeaveEvent cid2 (mem1^.userId) wsMext1
         checkConvMemberLeaveEvent cid3 (mem1^.userId) wsMext3
         WS.assertNoEvent timeout ws
-  where
-    checkLeaveEvent tid usr w = WS.assertMatch_ timeout w $ \notif -> do
-        ntfTransient notif @?= False
-        let e = List1.head (WS.unpackPayload notif)
-        e^.eventType @?= MemberLeave
-        e^.eventTeam @?= tid
-        e^.eventData @?= Just (EdMemberLeave usr)
 
 testRemoveBindingTeamMember :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
 testRemoveBindingTeamMember g b c a = do
@@ -347,7 +336,7 @@ testRemoveBindingTeamMember g b c a = do
     -- Mem1 is still part of Wire
     Util.ensureDeletedState b False owner (mem1^.userId)
 
-    WS.bracketR c mext $ \wsMext -> do
+    WS.bracketR2 c owner mext $ \(wsOwner, wsMext) -> do
         delete ( g
                . paths ["teams", toByteString' tid, "members", toByteString' (mem1^.userId)]
                . zUser owner
@@ -355,7 +344,9 @@ testRemoveBindingTeamMember g b c a = do
                . json (newTeamMemberDeleteData (PlainTextPassword Util.defPassword))
                ) !!! const 202 === statusCode
 
+        checkTeamMemberLeave tid (mem1^.userId) wsOwner
         checkConvMemberLeaveEvent cid1 (mem1^.userId) wsMext
+
         assertQueue "team member leave" a $ tUpdate 1 [owner]
         WS.assertNoEvent timeout [wsMext]
         -- Mem1 is now gone from Wire
@@ -527,10 +518,14 @@ testDeleteBindingTeam g b c a = do
     mem1 <- flip newTeamMember p1 <$> Util.randomUser b
     let p2 = Util.symmPermissions [AddConversationMember]
     mem2 <- flip newTeamMember p2 <$> Util.randomUser b
+    let p3 = Util.symmPermissions [AddConversationMember]
+    mem3 <- flip newTeamMember p3 <$> Util.randomUser b
     Util.addTeamMemberInternal g tid mem1
-    assertQueue "team member join" a $ tUpdate 2 [owner]
+    assertQueue "team member join 2" a $ tUpdate 2 [owner]
     Util.addTeamMemberInternal g tid mem2
-    assertQueue "team member join" a $ tUpdate 3 [owner]
+    assertQueue "team member join 3" a $ tUpdate 3 [owner]
+    Util.addTeamMemberInternal g tid mem3
+    assertQueue "team member join 4" a $ tUpdate 4 [owner]
     extern <- Util.randomUser b
 
     delete ( g
@@ -542,6 +537,14 @@ testDeleteBindingTeam g b c a = do
         const 403 === statusCode
         const "access-denied" === (Error.label . Util.decodeBody' "error label")
 
+    -- Let's delete a member just to fill up the journaling queue (when in use)
+    delete ( g
+           . paths ["teams", toByteString' tid, "members", toByteString' (mem3^.userId)]
+           . zUser owner
+           . zConn "conn"
+           . json (newTeamMemberDeleteData (PlainTextPassword Util.defPassword))
+           ) !!! const 202 === statusCode
+
     void $ WS.bracketRN c [owner, (mem1^.userId), (mem2^.userId), extern] $ \[wsOwner, wsMember1, wsMember2, wsExtern] -> do
         delete ( g
                . paths ["teams", toByteString' tid]
@@ -549,13 +552,21 @@ testDeleteBindingTeam g b c a = do
                . zConn "conn"
                . json (newTeamDeleteData (PlainTextPassword Util.defPassword))
                ) !!! const 202 === statusCode
+        
+        checkUserDeleteEvent owner wsOwner
+        checkUserDeleteEvent (mem1^.userId) wsMember1
+        checkUserDeleteEvent (mem2^.userId) wsMember2
+
         checkTeamDeleteEvent tid wsOwner
         checkTeamDeleteEvent tid wsMember1
         checkTeamDeleteEvent tid wsMember2
-        -- TODO: Due to the async nature of the deletion, we should actually check for
-        --       the user deletion event to avoid race conditions at this point
+
         WS.assertNoEvent timeout [wsExtern]
-        assertQueue "team delete" a tDelete
+        -- TODO: Again, depending on the timing, a user _could_ be deleted before the
+        --       the team gets deleted
+        let jt = 5 -- 5 second timeout
+        assertQueue' "team delete, eventually" jt a tDelete
+        assertQueue' "team joined, should be there long time" jt a $ tUpdate 3 [owner]
 
     forM_ [owner, (mem1^.userId), (mem2^.userId)] $ \uid -> do
         -- Wait until the users are marked as deleted
@@ -734,6 +745,14 @@ testUpdateTeamStatus g b _ a = do
         const 403 === statusCode
         const "invalid-team-status-update" === (Error.label . Util.decodeBody' "error label")
 
+checkUserDeleteEvent :: UserId -> WS.WebSocket -> Http ()
+checkUserDeleteEvent uid w = WS.assertMatch_ timeout w $ \notif -> do
+    let j = Object $ List1.head (ntfPayload notif)
+    let etype = j ^? key "type" . _String
+    let euser = j ^? key "id" . _String
+    etype @?= Just "user.delete"
+    euser @?= Just (UUID.toText (toUUID uid))
+
 checkTeamMemberJoin :: TeamId -> UserId -> WS.WebSocket -> Http ()
 checkTeamMemberJoin tid uid w = WS.assertMatch_ timeout w $ \notif -> do
     ntfTransient notif @?= False
@@ -741,6 +760,14 @@ checkTeamMemberJoin tid uid w = WS.assertMatch_ timeout w $ \notif -> do
     e^.eventType @?= MemberJoin
     e^.eventTeam @?= tid
     e^.eventData @?= Just (EdMemberJoin uid)
+
+checkTeamMemberLeave :: TeamId -> UserId -> WS.WebSocket -> Http ()
+checkTeamMemberLeave tid usr w = WS.assertMatch_ timeout w $ \notif -> do
+    ntfTransient notif @?= False
+    let e = List1.head (WS.unpackPayload notif)
+    e^.eventType @?= MemberLeave
+    e^.eventTeam @?= tid
+    e^.eventData @?= Just (EdMemberLeave usr)
 
 checkTeamDeleteEvent :: TeamId -> WS.WebSocket -> Http ()
 checkTeamDeleteEvent tid w = WS.assertMatch_ timeout w $ \notif -> do

--- a/services/galley/test/integration/Main.hs
+++ b/services/galley/test/integration/Main.hs
@@ -86,7 +86,7 @@ main = withOpenSSL $ runTests go
         e <- join <$> optOrEnvSafe endpoint gConf (fromByteString . BS.pack) "GALLEY_SQS_ENDPOINT"
         convTeamMaxSize <- optOrEnv maxSize gConf read "CONV_AND_TEAM_MAX_SIZE"
         awsEnv <- initAwsEnv e q
-        -- SQS.ensureQueueEmpty awsEnv
+        SQS.ensureQueueEmpty awsEnv
         return $ Util.TestSetup m g b c awsEnv convTeamMaxSize
 
     queueName = fmap (view awsQueueName) . view optJournal

--- a/services/galley/test/integration/Main.hs
+++ b/services/galley/test/integration/Main.hs
@@ -85,7 +85,9 @@ main = withOpenSSL $ runTests go
         q <- join <$> optOrEnvSafe queueName gConf (Just . pack) "GALLEY_SQS_TEAM_EVENTS"
         e <- join <$> optOrEnvSafe endpoint gConf (fromByteString . BS.pack) "GALLEY_SQS_ENDPOINT"
         convTeamMaxSize <- optOrEnv maxSize gConf read "CONV_AND_TEAM_MAX_SIZE"
-        Util.TestSetup m g b c <$> initAwsEnv e q <*> pure convTeamMaxSize
+        awsEnv <- initAwsEnv e q
+        -- SQS.ensureQueueEmpty awsEnv
+        return $ Util.TestSetup m g b c awsEnv convTeamMaxSize
 
     queueName = fmap (view awsQueueName) . view optJournal
     endpoint = fmap (view awsEndpoint) . view optJournal


### PR DESCRIPTION
This PR tries to make testing of journaling events more reliable and caters for some differences between the real AWS queues behaviour and fake SQS (e.g., visibility timeout does not work properly with the fake queue).

If order is not relevant for some journaling events (or cannot be reliably determined, for instance, when deleting a team), `tryMatch` makes no assumptions on the order of such events in the queue and can just check that the desired event is in fact in the queue. It also ensures that the SQS queue is cleared before starting the test suite making it easier to re-run the tests.