### PR TITLE
Issue 685

### DIFF
--- a/libs/brig-types/brig-types.cabal
+++ b/libs/brig-types/brig-types.cabal
@@ -70,3 +70,35 @@ library
         -O2
         -fwarn-tabs
         -funbox-strict-fields
+
+test-suite brig-types-tests
+    type: exitcode-stdio-1.0
+    hs-source-dirs: test/unit
+    main-is: Main.hs
+
+    exposed-modules:
+        Test.Brig.Types.Arbitrary
+        Test.Brig.Types.TURN
+
+    build-depends:
+        aeson
+      , attoparsec
+      , base
+      , brig-types
+      , bytestring
+      , iproute
+      , lens
+      , QuickCheck
+      , tasty
+      , tasty-quickcheck
+      , text
+      , time
+      , types-common
+      , vector
+
+    ghc-options:
+        -Wall
+        -threaded
+        -with-rtsopts=-N
+
+    default-language: Haskell2010

--- a/libs/brig-types/brig-types.cabal
+++ b/libs/brig-types/brig-types.cabal
@@ -76,7 +76,7 @@ test-suite brig-types-tests
     hs-source-dirs: test/unit
     main-is: Main.hs
 
-    exposed-modules:
+    other-modules:
         Test.Brig.Types.Arbitrary
         Test.Brig.Types.TURN
 

--- a/libs/brig-types/src/Brig/Types/TURN.hs
+++ b/libs/brig-types/src/Brig/Types/TURN.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE StrictData        #-}
 {-# LANGUAGE TemplateHaskell   #-}
 
+-- module Brig.Types.TURN where
 module Brig.Types.TURN
     ( RTCConfiguration
     , rtcConfiguration
@@ -17,8 +18,12 @@ module Brig.Types.TURN
 
     , TurnURI
     , turnURI
+    , turiScheme
+    , Scheme (..)
     , turiHost
     , turiPort
+    , turiTransport
+    , Transport (..)
 
     , TurnHost
     , _TurnHost
@@ -36,23 +41,21 @@ where
 import           Control.Lens               hiding ((.=))
 import           Data.Aeson
 import           Data.Aeson.Encoding        (text)
-import           Data.Aeson.Lens
 import           Data.Attoparsec.Text
+import           Data.ByteString            (ByteString)
 import           Data.ByteString.Builder
 import qualified Data.ByteString.Conversion as BC
 import           Data.List1
 import           Data.Misc                  (IpAddr, Port (portNumber))
 import           Data.Monoid
 import           Data.Text                  (Text)
-import qualified Data.Text                  as T
 import           Data.Text.Ascii
-import qualified Data.Text.Lazy.Builder.Int as TB
-import           Data.Text.Lazy.Lens        (builder)
+import qualified Data.Text.Encoding         as TE
 import           Data.Text.Strict.Lens      (utf8)
 import           Data.Time.Clock.POSIX
 import           Data.Word
+import           GHC.Base                   (Alternative)
 import           GHC.Generics               (Generic)
-import           Safe                       (readMay)
 
 -- | A configuration object resembling \"RTCConfiguration\"
 --
@@ -75,12 +78,28 @@ data RTCIceServer = RTCIceServer
     , _iceCredential :: AsciiBase64
     } deriving (Show, Generic)
 
--- | TURN server URI of the form \"turn:<addr>:<port>\"
+-- | TURN server URI as described in https://tools.ietf.org/html/rfc7065, minus ext
+-- |
+-- | turnURI       = scheme ":" host [ ":" port ]
+-- |                 [ "?transport=" transport ]
+-- | scheme        = "turn" / "turns"
+-- | transport     = "udp" / "tcp" / transport-ext
+-- | transport-ext = 1*unreserved
+--
 data TurnURI = TurnURI
-    { _turiHost :: TurnHost
-    , _turiPort :: Port
-    }
-    deriving (Eq, Show, Generic)
+    { _turiScheme    :: Scheme
+    , _turiHost      :: TurnHost
+    , _turiPort      :: Port
+    , _turiTransport :: Maybe Transport
+    } deriving (Eq, Show, Generic)
+
+data Scheme = SchemeTurn
+            | SchemeTurns
+            deriving (Eq, Show, Generic)
+
+data Transport = TransportTCP
+               | TransportUDP
+               deriving (Eq, Show, Generic)
 
 -- future versions may allow using a hostname
 newtype TurnHost = TurnHost IpAddr
@@ -101,7 +120,7 @@ rtcConfiguration = RTCConfiguration
 rtcIceServer :: List1 TurnURI -> TurnUsername -> AsciiBase64 -> RTCIceServer
 rtcIceServer = RTCIceServer
 
-turnURI :: TurnHost -> Port -> TurnURI
+turnURI :: Scheme -> TurnHost -> Port -> Maybe Transport -> TurnURI
 turnURI = TurnURI
 
 -- turn into a 'Prism'' once hostnames are supported
@@ -145,13 +164,17 @@ instance FromJSON RTCIceServer where
     parseJSON = withObject "RTCIceServer" $ \o ->
         RTCIceServer <$> o .: "urls" <*> o .: "username" <*> o .: "credential"
 
+instance BC.ToByteString TurnURI where
+    builder (TurnURI s (TurnHost h) p tp) =
+           BC.builder s
+        <> byteString ":"
+        <> BC.builder h
+        <> byteString ":"
+        <> BC.builder (portNumber p)
+        <> maybe mempty (\t -> byteString "?transport=" <> BC.builder t) tp
 
 instance ToJSON TurnURI where
-    toEncoding uri = text . view (from builder . strict) $
-          "turn:"^.builder
-       <> view (turiHost . re (_JSON :: Prism' Value TurnHost) . _String . lazy . builder) uri
-       <> ":"^.builder
-       <> TB.decimal (portNumber (view turiPort uri))
+    toJSON = String . TE.decodeUtf8 . BC.toByteString'
 
 instance BC.FromByteString TurnURI where
     parser = BC.parser >>= either fail pure . parseTurnURI
@@ -163,18 +186,24 @@ parseTurnURI :: Text -> Either String TurnURI
 parseTurnURI = parseOnly (parser <* endOfInput)
   where
     parser = TurnURI
-          <$> ((string "turn:" *> takeWhile1 (/=':') <* char ':') >>= parseHost)
-          <*> decimal
+          <$> ((takeWhile1 (/=':') <* char ':' >>= parseScheme)                   <?> "parsingScheme")
+          <*> ((takeWhile1 (/=':') <* char ':' >>= parseHost)                     <?> "parsingHost")
+          <*> (decimal                                                            <?> "parsingPort")
+          <*> ((optional ((string "?transport=" *> takeText) >>= parseTransport)) <?> "parsingTransport")
 
-    parseHost t = case readMay (T.unpack t) of
-        Just h  -> return (TurnHost h)
-        Nothing -> fail ("txtToTurnHost: Could not parse as IpAddr: " ++ show t)
+    parseScheme    = conv "parseScheme"
+    parseHost      = fmap TurnHost . conv "parseHost"
+    parseTransport = conv "parseTransport"
 
+    conv :: (BC.FromByteString b, Monad m) => String -> Text -> m b
+    conv err x = case BC.fromByteString (TE.encodeUtf8 x) of
+        Just ok -> return ok
+        Nothing -> fail (err ++ " failed when parsing: " ++ show x)
 
 instance ToJSON   TurnHost
 instance FromJSON TurnHost
 
-
+ 
 instance ToJSON TurnUsername where
     toEncoding = text . view utf8 . BC.toByteString'
 
@@ -202,3 +231,46 @@ parseTurnUsername = TurnUsername
     <*> (string ".k=" *> decimal)
     <*> (string ".t=" *> anyChar)
     <*> (string ".r=" *> takeWhile1 (inClass "a-z0-9"))
+
+instance BC.FromByteString Scheme where
+    parser = BC.parser >>= \t -> case (t :: ByteString) of
+        "turn"  -> pure SchemeTurn
+        "turns" -> pure SchemeTurns
+        _       -> fail $ "Invalid turn scheme: " ++ show t
+
+instance BC.ToByteString Scheme where
+    builder SchemeTurn  = "turn"
+    builder SchemeTurns = "turns"
+
+instance FromJSON Scheme where
+    parseJSON = withText "Scheme" $
+        either fail pure . BC.runParser BC.parser . TE.encodeUtf8
+
+instance ToJSON Scheme where
+    toJSON = String . TE.decodeUtf8 . BC.toByteString'
+
+instance BC.FromByteString Transport where
+    parser = BC.parser >>= \t -> case (t :: ByteString) of
+        "udp" -> pure TransportUDP
+        "tcp" -> pure TransportTCP
+        _               -> fail $ "Invalid turn transport: " ++ show t
+
+instance BC.ToByteString Transport where
+    builder TransportUDP = "udp"
+    builder TransportTCP = "tcp"
+
+instance FromJSON Transport where
+    parseJSON = withText "Transport" $
+        either fail pure . BC.runParser BC.parser . TE.encodeUtf8
+
+instance ToJSON Transport where
+    toJSON = String . TE.decodeUtf8 . BC.toByteString'
+
+-- Convenience
+optional :: (Alternative f, Functor f) => f a -> f (Maybe a)
+optional x = option Nothing (Just <$> x)
+
+convert :: (BC.FromByteString b, Monad m) => String -> (Text -> Maybe b) -> Text -> m b
+convert err conv x = case BC.fromByteString (TE.encodeUtf8 x) of
+    Just ok -> return ok
+    Nothing -> fail (err ++ " failed when parsing: " ++ show x)

--- a/libs/brig-types/test/unit/Main.hs
+++ b/libs/brig-types/test/unit/Main.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import qualified Test.Brig.Types.TURN as T
+import           Test.Tasty
+
+main :: IO ()
+main = defaultMain $ testGroup "Tests" [ T.tests ]

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -4,7 +4,6 @@
 module Test.Brig.Types.Arbitrary where
 
 import Brig.Types.TURN
-import Control.Applicative
 import Data.IP
 import Data.Misc
 import Data.Word
@@ -23,7 +22,7 @@ instance Arbitrary Scheme where
 
 -- TODO: Add an arbitrary instance for IPv6
 instance Arbitrary IpAddr where
-    arbitrary = ipV4Arbitrary -- <|> ipV4Arbitrary
+    arbitrary = ipV4Arbitrary
       where
         ipV4Arbitrary :: Gen IpAddr
         ipV4Arbitrary = do

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings    #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Brig.Types.Arbitrary where
+
+import Brig.Types.TURN
+import Control.Applicative
+import Data.IP
+import Data.Misc
+import Data.Word
+import Test.QuickCheck
+
+newtype Octet = Octet { octet :: Word16 }
+    deriving (Eq, Show)
+
+instance Arbitrary Octet where
+    arbitrary = Octet <$> arbitrary `suchThat` (<256)
+
+instance Arbitrary Scheme where
+    arbitrary = elements [ SchemeTurn
+                         , SchemeTurns
+                         ]
+
+-- TODO: Add an arbitrary instance for IPv6
+instance Arbitrary IpAddr where
+    arbitrary = ipV4Arbitrary -- <|> ipV4Arbitrary
+      where
+        ipV4Arbitrary :: Gen IpAddr
+        ipV4Arbitrary = do
+            a <- ipV4Part
+            b <- ipV4Part
+            c <- ipV4Part
+            d <- ipV4Part
+            let adr = show a ++ "." ++ show b ++ "." ++ show c ++ "." ++ show d
+            IpAddr . IPv4 <$> return (read adr)
+
+        ipV4Part = octet <$> arbitrary
+
+instance Arbitrary TurnHost where
+    arbitrary = TurnHost <$> arbitrary
+
+instance Arbitrary Port where
+    arbitrary = Port <$> arbitrary
+
+instance Arbitrary Transport where
+    arbitrary = elements [ TransportUDP
+                         , TransportTCP
+                         ]
+
+instance Arbitrary TurnURI where
+    arbitrary = turnURI <$> arbitrary
+                        <*> arbitrary
+                        <*> arbitrary
+                        <*> arbitrary

--- a/libs/brig-types/test/unit/Test/Brig/Types/TURN.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/TURN.hs
@@ -3,10 +3,8 @@
 module Test.Brig.Types.TURN where
 
 import Brig.Types.TURN hiding (turnURI)
-import Control.Monad.IO.Class
 import Data.Aeson
-import Data.Misc
-import Test.Brig.Types.Arbitrary
+import Test.Brig.Types.Arbitrary ()
 import Test.Tasty
 import Test.Tasty.QuickCheck
 

--- a/libs/brig-types/test/unit/Test/Brig/Types/TURN.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/TURN.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Brig.Types.TURN where
+
+import Brig.Types.TURN hiding (turnURI)
+import Control.Monad.IO.Class
+import Data.Aeson
+import Data.Misc
+import Test.Brig.Types.Arbitrary
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "TURN"
+    [ testProperty "TurnURI: decode . encode = id" turnURIid
+    ]
+
+turnURIid :: TurnURI -> Property
+turnURIid t = Just t === (decode . encode) t

--- a/libs/types-common/src/Data/Misc.hs
+++ b/libs/types-common/src/Data/Misc.hs
@@ -37,6 +37,7 @@ import Control.Lens ((^.), makeLenses)
 import Control.Monad (when)
 import Data.Aeson
 import Data.ByteString (ByteString)
+import Data.ByteString.Builder
 import Data.ByteString.Char8 (unpack)
 import Data.ByteString.Conversion
 import Data.Char (isSpace)
@@ -70,6 +71,9 @@ instance FromByteString IpAddr where
         case readMay (unpack s) of
             Nothing -> fail "Failed parsing bytestring as IpAddr."
             Just ip -> return (IpAddr ip)
+
+instance ToByteString IpAddr where
+    builder = string8 . show . ipAddr
 
 instance Read IpAddr where
     readPrec = IpAddr <$> readPrec


### PR DESCRIPTION
This PR adds support for TURN URI's according to https://tools.ietf.org/html/rfc7065, (minus `transport-ext`) which will later allow the introduction of `turns` and different transport types.