### PR TITLE
Team id user profile

### DIFF
--- a/libs/api-bot/src/Network/Wire/Bot/Cache.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Cache.hs
@@ -67,6 +67,7 @@ toUser _ acc [i, e, p] = do
         , userService  = Nothing
         , userHandle   = Nothing
         , userExpire   = Nothing
+        , userTeam     = Nothing
         }
 toUser g acc entry = do
     warn g $ msg (val "invalid entry: " +++ show entry)

--- a/libs/brig-types/src/Brig/Types/Provider/External.hs
+++ b/libs/brig-types/src/Brig/Types/Provider/External.hs
@@ -99,6 +99,7 @@ data BotUserView = BotUserView
     , botUserViewName   :: !Name
     , botUserViewColour :: !ColourId
     , botUserViewHandle :: !(Maybe Handle)
+    , botUserViewTeam   :: !(Maybe TeamId)
     } deriving (Eq, Show)
 
 instance FromJSON BotUserView where
@@ -107,6 +108,7 @@ instance FromJSON BotUserView where
                     <*> o .:  "name"
                     <*> o .:  "accent_id"
                     <*> o .:? "handle"
+                    <*> o .:? "team"
 
 instance ToJSON BotUserView where
     toJSON u = object
@@ -114,5 +116,6 @@ instance ToJSON BotUserView where
         , "name"      .= botUserViewName u
         , "accent_id" .= botUserViewColour u
         , "handle"    .= botUserViewHandle u
+        , "team"      .= botUserViewTeam u
         ]
 

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -98,6 +98,7 @@ connectedProfile u = UserProfile
     , profileLocale   = Just (userLocale u)
     , profileDeleted  = userDeleted u
     , profileExpire   = userExpire u
+    , profileTeam     = userTeam u
     }
 
 publicProfile :: User -> UserProfile
@@ -121,6 +122,8 @@ data User = User
     , userHandle   :: !(Maybe Handle)
     , userExpire   :: !(Maybe UTCTime)
         -- ^ Set if the user is ephemeral
+    , userTeam     :: !(Maybe TeamId)
+        -- ^ Set if the user is part of a binding team
     }
 
 userEmail :: User -> Maybe Email
@@ -144,6 +147,7 @@ data UserProfile = UserProfile
     , profileHandle   :: !(Maybe Handle)
     , profileLocale   :: !(Maybe Locale)
     , profileExpire   :: !(Maybe UTCTime)
+    , profileTeam     :: !(Maybe TeamId)
     }
 
 instance ToJSON User where
@@ -160,6 +164,7 @@ instance ToJSON User where
         # "service"    .= userService u
         # "handle"     .= userHandle u
         # "expires_at" .= (UTCTimeMillis <$> userExpire u)
+        # "team"       .= userTeam u    
         # []
 
 instance FromJSON User where
@@ -175,6 +180,7 @@ instance FromJSON User where
              <*> o .:? "service"
              <*> o .:? "handle"
              <*> o .:? "expires_at"
+             <*> o .:? "team"
 
 instance FromJSON UserProfile where
     parseJSON = withObject "UserProfile" $ \o ->
@@ -188,6 +194,7 @@ instance FromJSON UserProfile where
                     <*> o .:? "handle"
                     <*> o .:? "locale"
                     <*> o .:? "expires_at"
+                    <*> o .:? "team"
 
 instance ToJSON UserProfile where
     toJSON u = object
@@ -201,6 +208,7 @@ instance ToJSON UserProfile where
         # "handle"     .= profileHandle u
         # "locale"     .= profileLocale u
         # "expires_at" .= (UTCTimeMillis <$> profileExpire u)
+        # "team"       .= profileTeam u
         # []
 
 instance FromJSON SelfProfile where

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -263,6 +263,7 @@ executable brig-schema
         V46
         V47
         V48
+        V49
 
     build-depends:
         base

--- a/services/brig/schema/src/Main.hs
+++ b/services/brig/schema/src/Main.hs
@@ -44,6 +44,7 @@ import qualified V45
 import qualified V46
 import qualified V47
 import qualified V48
+import qualified V49
 
 main :: IO ()
 main = do
@@ -89,4 +90,5 @@ main = do
         , V46.migration
         , V47.migration
         , V48.migration
+        , V49.migration
         ] `finally` close l

--- a/services/brig/schema/src/V49.hs
+++ b/services/brig/schema/src/V49.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module V49 (migration) where
+
+import Cassandra.Schema
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 49 "Add binding team to user table" $
+    schema' [r| ALTER TABLE user ADD team uuid; |]

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -95,6 +95,7 @@ import Data.List1 (List1)
 import Data.Misc (PlainTextPassword (..))
 import Data.Time.Clock (diffUTCTime)
 import Data.Traversable (for)
+import Data.UUID.V4 (nextRandom)
 import Network.Wai.Utilities
 import System.Logger.Message
 
@@ -151,7 +152,7 @@ createUser new@NewUser{..} = do
 
     -- Look for an invitation, if a code is given
     invitation <- maybe (return Nothing) (findInvitation emKey phKey) newUserInvitationCode
-    (newTeam, teamInvitation) <- handleTeam newUserTeam emKey
+    (newTeam, teamInvitation, tid) <- handleTeam newUserTeam emKey
 
     -- team members are by default not searchable
     let searchable = SearchableStatus $ case (newTeam, teamInvitation) of
@@ -159,7 +160,7 @@ createUser new@NewUser{..} = do
             _                  -> False
 
     -- Create account
-    (account, pw) <- lift $ newAccount new { newUserIdentity = ident } (Team.inInvitation . fst <$> teamInvitation)
+    (account, pw) <- lift $ newAccount new { newUserIdentity = ident } (Team.inInvitation . fst <$> teamInvitation) tid
     let uid = userId (accountUser account)
 
     Log.info $ field "user" (toByteString uid) . msg (val "Creating user")
@@ -168,8 +169,9 @@ createUser new@NewUser{..} = do
         Intra.createSelfConv uid
         Intra.onUserEvent uid Nothing (UserCreated account)
         -- If newUserEmailCode is set, team gets activated _now_ else createUser fails
-        fmap join . for newTeam $ createTeam uid (isJust newUserEmailCode) . bnuTeam
-
+        case (tid, newTeam) of
+            (Just t, Just nt) -> createTeam uid (isJust newUserEmailCode) (bnuTeam nt) t
+            _                 -> return Nothing
     (emailInvited, phoneInvited) <- case invitation of
         Just (inv, invInfo) -> case inIdentity inv of
             Left em -> do
@@ -227,15 +229,21 @@ createUser new@NewUser{..} = do
         unless av $
             throwE $ DuplicateUserKey k
 
-    createTeam uid activating t = do
-        created <- Intra.createTeam uid t
+    createTeam uid activating t tid = do
+        created <- Intra.createTeam uid t tid
         return $ if activating
                     then Just created
                     else Nothing
 
-    handleTeam (Just (NewTeamMember i))  e = (Nothing, ) <$> findTeamInvitation e i
-    handleTeam (Just (NewTeamCreator t)) _ = return (Just t, Nothing)
-    handleTeam Nothing                   _ = return (Nothing, Nothing)
+    handleTeam :: Maybe NewTeamUser 
+               -> Maybe UserKey
+               -> ExceptT CreateUserError AppIO ( Maybe BindingNewTeamUser
+                                                , Maybe (Team.Invitation, Team.InvitationInfo)
+                                                , Maybe TeamId
+                                                )
+    handleTeam (Just (NewTeamMember i))  e = findTeamInvitation e i
+    handleTeam (Just (NewTeamCreator t)) _ = (Just t, Nothing, ) <$> (Just . Id <$> liftIO nextRandom)
+    handleTeam Nothing                   _ = return (Nothing, Nothing, Nothing)
 
     findInvitation :: Maybe UserKey -> Maybe UserKey -> InvitationCode -> ExceptT CreateUserError AppIO (Maybe (Invitation, InvitationInfo))
     findInvitation Nothing Nothing _ = throwE MissingIdentity
@@ -248,14 +256,14 @@ createUser new@NewUser{..} = do
                 _                                                        -> throwE InvalidInvitationCode
         Nothing -> throwE InvalidInvitationCode
 
-    findTeamInvitation :: Maybe UserKey -> InvitationCode -> ExceptT CreateUserError AppIO (Maybe (Team.Invitation, Team.InvitationInfo))
+    findTeamInvitation :: Maybe UserKey -> InvitationCode -> ExceptT CreateUserError AppIO (Maybe BindingNewTeamUser, Maybe (Team.Invitation, Team.InvitationInfo), Maybe TeamId)
     findTeamInvitation Nothing  _ = throwE MissingIdentity
     findTeamInvitation (Just e) c = lift (Team.lookupInvitationInfo c) >>= \case
         Just ii -> do
             inv <- lift $ Team.lookupInvitation (Team.iiTeam ii) (Team.iiInvId ii)
             case (inv, Team.inIdentity <$> inv) of
                 (Just invite, Just em) | e == userEmailKey em -> ensureMemberCanJoin (Team.iiTeam ii) >>
-                                                                 (return $ Just (invite, ii))
+                                                                 return (Nothing, Just (invite, ii), Just $ Team.iiTeam ii)
                 _                                             -> throwE InvalidInvitationCode
         Nothing -> throwE InvalidInvitationCode
 

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -118,7 +118,7 @@ import qualified System.Logger            as Log
 import qualified System.Logger.Class      as LC
 
 schemaVersion :: Int32
-schemaVersion = 48
+schemaVersion = 49
 
 -------------------------------------------------------------------------------
 -- Environment

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -539,11 +539,11 @@ addTeamMember u tid = do
           . expect [status200, status403]
           . lbytes (encode $ t p)
 
-createTeam :: UserId -> Team.BindingNewTeam -> AppIO CreateUserTeam
-createTeam u t@(Team.BindingNewTeam bt) = do
+createTeam :: UserId -> Team.BindingNewTeam -> TeamId -> AppIO CreateUserTeam
+createTeam u t@(Team.BindingNewTeam bt) teamid = do
     debug $ remote "galley"
             . msg (val "Creating Team")
-    r   <- galleyRequest PUT . req =<< randomId
+    r   <- galleyRequest PUT $ req teamid
     tid <- maybe (error "invalid team id") return $
             fromByteString $ getHeader' "Location" r
     return (CreateUserTeam tid $ fromRange (bt^.Team.newTeamName))

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -795,6 +795,7 @@ mkBotUserView u = Ext.BotUserView
     , Ext.botUserViewName   = userName u
     , Ext.botUserViewColour = userAccentId u
     , Ext.botUserViewHandle = userHandle u
+    , Ext.botUserViewTeam   = userTeam u
     }
 
 setProviderCookie :: ZAuth.ProviderToken -> Response -> Handler Response

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -644,7 +644,7 @@ addBot (zuid ::: zcon ::: cid ::: req) = do
     let colour = fromMaybe defaultAccentId            (Ext.rsNewBotColour rs)
     let pict   = Pict [] -- Legacy
     let sref   = newServiceRef sid pid
-    let usr    = User (botUserId bid) Nothing name pict assets colour False locale (Just sref) Nothing Nothing
+    let usr    = User (botUserId bid) Nothing name pict assets colour False locale (Just sref) Nothing Nothing Nothing
     let newClt = (newClient PermanentClient (Ext.rsNewBotLastPrekey rs) ())
                { newClientPrekeys = Ext.rsNewBotPrekeys rs
                }

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -635,6 +635,9 @@ inviteAndRegisterUser u tid brig = do
                              . body (accept inviteeEmail inviteeCode)) <!! const 201 === statusCode
 
     let Just invitee = decodeBody rspInvitee
+    liftIO $ assertBool "Team ID in registration and team table do not match" (Just tid == userTeam invitee)
+    selfTeam <- userTeam . selfUser <$> getSelfProfile brig (userId invitee)
+    liftIO $ assertBool "Team ID in self profile and team table do not match" (selfTeam == Just tid)
     return invitee
 
 updatePermissions :: UserId -> TeamId -> (UserId, Team.Permissions) -> Galley -> HttpT IO ()

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -165,6 +165,11 @@ activate brig (k, c) = get $ brig
     . queryItem "key" (toByteString' k)
     . queryItem "code" (toByteString' c)
 
+getSelfProfile :: Brig -> UserId -> Http SelfProfile
+getSelfProfile brig usr = do
+    rsp <- get $ brig . path "/self" . zUser usr
+    return $ fromMaybe (error $ "getSelfProfile: failed to decode: " ++ show rsp) (decodeBody rsp)
+
 getUser :: Brig -> UserId -> UserId -> Http ResponseLBS
 getUser brig zusr usr = get $ brig
     . paths ["users", toByteString' usr]


### PR DESCRIPTION
This PR adds a field in the `user`'s table for the binding `team_id` of that user; it exposes it over the `/users` and `/self` endpoints as part of the user's public profile.

A migration to backfill `team_id`s for existing users will be done after.