### PR TITLE
Confirm WS registration before returning

### DIFF
--- a/libs/tasty-cannon/src/Test/Tasty/Cannon.hs
+++ b/libs/tasty-cannon/src/Test/Tasty/Cannon.hs
@@ -46,9 +46,9 @@ module Test.Tasty.Cannon
 import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Concurrent.STM
-import Control.Concurrent.Timeout
+import Control.Concurrent.Timeout hiding (threadDelay)
 import Control.Exception (SomeAsyncException, asyncExceptionFromException, throwIO)
-import Control.Monad (void, forever)
+import Control.Monad (void, forever, unless)
 import Control.Monad.Catch hiding (bracket)
 import Control.Monad.IO.Class
 import Data.Aeson (decodeStrict', FromJSON, fromJSON, Value (..))
@@ -58,10 +58,13 @@ import Data.Foldable (mapM_, for_)
 import Data.Id
 import Data.List1
 import Data.Maybe
+import Data.Monoid
 import Data.Timeout (Timeout, TimeoutUnit (..), (#))
 import Data.Typeable
 import Data.Word
 import Gundeck.Types
+import Network.HTTP.Client
+import Network.HTTP.Types.Status
 import Prelude hiding (mapM_)
 import System.Random (randomIO)
 import Test.Tasty.HUnit
@@ -184,6 +187,15 @@ instance Show MatchTimeout where
                             . showString "\n"
                             . showFailures es
 
+newtype RegistrationTimeout = RegistrationTimeout Int
+    deriving (Typeable)
+
+instance Exception RegistrationTimeout
+
+instance Show RegistrationTimeout where
+    show (RegistrationTimeout s) =
+        "Failed to find a registration after " ++ show s ++ " retries.\n"
+
 await :: MonadIO m => Timeout -> WebSocket -> m (Maybe Notification)
 await t = liftIO . timeout t . atomically . readTChan . wsChan
 
@@ -282,13 +294,24 @@ run (($ Http.defaultRequest) -> ca) uid cid app = liftIO $ do
     stat <- poll wsapp
     case stat of
         Just (Left ex) -> throwIO ex
-        _              -> return wsapp
+        _              -> waitForRegistry numRetries >> return wsapp
   where
     caHost = C.unpack (Http.host ca)
     caPort = Http.port ca
     caPath = "/await" ++ C.unpack (Http.queryString ca)
     caOpts = WS.defaultConnectionOptions
     caHdrs = [ ("Z-User", toByteString' uid), ("Z-Connection", toByteString' cid) ]
+
+    numRetries = 30
+
+    waitForRegistry 0          = throwIO $ RegistrationTimeout numRetries
+    waitForRegistry (n :: Int) = do
+      man <- newManager defaultManagerSettings
+      let ca' = ca { path = "/i/presences/" <> toByteString' uid <> "/" <> toByteString' cid }
+      res <- httpLbs ca' man
+      unless (responseStatus res == status200) $ do
+          threadDelay $ 100 * 1000
+          waitForRegistry (n - 1)
 
 clientApp :: TChan Notification -> MVar () -> WS.ClientApp ()
 clientApp nchan latch conn = do

--- a/libs/tasty-cannon/tasty-cannon.cabal
+++ b/libs/tasty-cannon/tasty-cannon.cabal
@@ -29,6 +29,7 @@ library
       , gundeck-types
       , exceptions
       , http-client           >= 0.5
+      , http-types
       , random
       , stm
       , transformers

--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -20,13 +20,14 @@ import Data.Aeson (encode)
 import Data.ByteString (ByteString)
 import Data.Id (ClientId, UserId, ConnId)
 import Data.Metrics.Middleware
+import Data.Monoid
 import Data.Swagger.Build.Api hiding (def, Response)
 import Data.Text (Text, strip, pack)
 import Data.Text.Encoding (encodeUtf8)
 import Network.HTTP.Types
 import Data.Maybe
+import Gundeck.Types
 import Gundeck.Types.BulkPush
-import Gundeck.Types.Notification
 import Network.Wai
 import Network.Wai.Predicate hiding (Error, (#))
 import Network.Wai.Routing hiding (route, path)
@@ -111,6 +112,9 @@ sitemap = do
     post "/i/bulkpush" (continue bulkpush)
         request
 
+    get "/i/presences/:user/:conn" (continue checkPresence) $
+        param "user" .&. param "conn"
+
     get "/i/monitoring" (continue monitoring) $
         accept "application" "json"
 
@@ -173,6 +177,13 @@ singlePush notification (PushTarget usrid conid) = do
                 `catchAll`
                 const (terminate k x >> return PushStatusGone)
 
+checkPresence :: UserId ::: ConnId -> Cannon Response
+checkPresence (u ::: c) = do
+    e <- wsenv
+    registered <- runWS e $ isRemoteRegistered u c
+    if registered
+        then return empty
+        else return $ errorRs status404 "not-found" "presence not registered"
 
 await :: UserId ::: ConnId ::: Maybe ClientId ::: Request -> Cannon Response
 await (u ::: a ::: c ::: r) = do

--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -112,7 +112,7 @@ sitemap = do
     post "/i/bulkpush" (continue bulkpush)
         request
 
-    get "/i/presences/:user/:conn" (continue checkPresence) $
+    head "/i/presences/:user/:conn" (continue checkPresence) $
         param "user" .&. param "conn"
 
     get "/i/monitoring" (continue monitoring) $


### PR DESCRIPTION
Some of our integration tests seem to "ramdomly" fail, which hinted at a race condition somewhere as sometimes notifications did not arrive.

This PR changes the way our tests establish connections with cannon by waiting until it has a confirmation that this presence has been registered (i.e., that `gundeck` has confirmed the presence) before it returns the websocket connection back to the caller.

Even though it could have been fixed by passing around a reference to gundeck everywhere in the tests, it seemed easier and cleaner to add an internal endpoint in `cannon` which queries that presence from `gundeck`.