### PR TITLE
Order TurnURI by scheme and transport

### DIFF
--- a/libs/brig-types/brig-types.cabal
+++ b/libs/brig-types/brig-types.cabal
@@ -89,7 +89,9 @@ test-suite brig-types-tests
       , iproute
       , lens
       , QuickCheck
+      , random-shuffle
       , tasty
+      , tasty-hunit
       , tasty-quickcheck
       , text
       , time

--- a/libs/brig-types/src/Brig/Types/TURN.hs
+++ b/libs/brig-types/src/Brig/Types/TURN.hs
@@ -47,6 +47,7 @@ import qualified Data.ByteString.Conversion as BC
 import           Data.List1
 import           Data.Misc                  (IpAddr, Port (..))
 import           Data.Monoid
+import           Data.Ord
 import           Data.Text                  (Text)
 import           Data.Text.Ascii
 import qualified Data.Text.Encoding         as TE
@@ -92,13 +93,18 @@ data TurnURI = TurnURI
     , _turiTransport :: Maybe Transport
     } deriving (Eq, Show, Generic)
 
+-- | Relies on Ord instances for `Scheme` and `Transport`.
+-- | First, prefer `turn` scheme and then prefer UDP.
+instance Ord TurnURI where
+    compare = comparing _turiScheme <> comparing _turiTransport
+
 data Scheme = SchemeTurn
             | SchemeTurns
-            deriving (Eq, Show, Generic)
+            deriving (Eq, Ord, Show, Generic)
 
-data Transport = TransportTCP
-               | TransportUDP
-               deriving (Eq, Show, Generic)
+data Transport = TransportUDP
+               | TransportTCP
+               deriving (Eq, Ord, Show, Generic)
 
 -- future versions may allow using a hostname
 newtype TurnHost = TurnHost IpAddr
@@ -202,7 +208,7 @@ parseTurnURI = parseOnly (parser <* endOfInput)
 instance ToJSON   TurnHost
 instance FromJSON TurnHost
 
- 
+
 instance ToJSON TurnUsername where
     toEncoding = text . view utf8 . BC.toByteString'
 

--- a/libs/brig-types/test/unit/Test/Brig/Types/TURN.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/TURN.hs
@@ -2,16 +2,44 @@
 
 module Test.Brig.Types.TURN where
 
-import Brig.Types.TURN hiding (turnURI)
+import Brig.Types.TURN
 import Data.Aeson
+import Data.List (sort)
+import Data.Misc
+import System.Random.Shuffle
 import Test.Brig.Types.Arbitrary ()
 import Test.Tasty
+import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 
 tests :: TestTree
 tests = testGroup "TURN"
     [ testProperty "TurnURI: decode . encode = id" turnURIid
+    , testGroup "Order"
+        [ testCase "Turn order example" turnURIOrder
+        ]
     ]
 
 turnURIid :: TurnURI -> Property
 turnURIid t = Just t === (decode . encode) t
+
+turnURIOrder :: IO ()
+turnURIOrder = go (100 :: Int)
+  where
+    go 0 = return ()
+    go n = do
+        shuffled <- shuffleM ordered
+        assertEqual "Unexpected shuffle & sorting" (sort shuffled) ordered
+        go (n - 1)
+
+    -- Prefer servers with `SchemeTURN` and then `TransportUDP`
+    ordered = [ turnURI SchemeTurn  host port Nothing
+              , turnURI SchemeTurn  host port (Just TransportUDP)
+              , turnURI SchemeTurn  host port (Just TransportTCP)
+              , turnURI SchemeTurns host port Nothing
+              , turnURI SchemeTurns host port (Just TransportUDP)
+              , turnURI SchemeTurns host port (Just TransportTCP)
+              ]
+
+    host = TurnHost $ IpAddr $ read "127.0.0.1"
+    port = Port 12345

--- a/libs/types-common/src/Data/List1.hs
+++ b/libs/types-common/src/Data/List1.hs
@@ -52,6 +52,10 @@ head :: List1 a -> a
 head = N.head . toNonEmpty
 {-# INLINE head #-}
 
+sort :: (Ord a) => List1 a -> List1 a
+sort = List1 . N.sort . toNonEmpty
+{-# INLINE sort #-}
+
 instance ToJSON a => ToJSON (List1 a) where
     toJSON = toJSON . toList
     toEncoding = toEncoding . toList


### PR DESCRIPTION
Change the order of how TURN servers are advertised: `/calls/config` now advertises all known URIs and orders them in a specific order: first the ones with `turn` scheme and then `UDP`