### PR TITLE
Endpoint that allows checking for set password

### DIFF
--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -430,6 +430,16 @@ sitemap o = do
 
     ---
 
+    head "/self/password" (continue checkPasswordExists) $
+        header "Z-User"
+
+    document "HEAD" "checkPassword" $ do
+        Doc.summary "Check that your passowrd is set"
+        Doc.response 200 "Password is set." Doc.end
+        Doc.response 404 "Password is not set." Doc.end
+
+    ---
+
     put "/self/password" (continue changePassword) $
         contentType "application" "json"
         .&. header "Z-User"
@@ -1282,6 +1292,11 @@ removeEmail :: UserId ::: ConnId -> Handler Response
 removeEmail (self ::: conn) = do
     API.removeEmail self conn !>> idtError
     return empty
+
+checkPasswordExists :: UserId -> Handler Response
+checkPasswordExists self = do
+    exists <- lift $ isJust <$> API.lookupPassword self
+    return $ if exists then empty else setStatus status404 empty
 
 changePassword :: JSON ::: UserId ::: Request -> Handler Response
 changePassword (_ ::: u ::: req) = do

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -51,6 +51,7 @@ module Brig.API.User
     , beginPasswordReset
     , completePasswordReset
     , lookupPasswordResetCode
+    , Data.lookupPassword
 
       -- * Blacklisting
     , isBlacklisted


### PR DESCRIPTION
Depending on the user's state, our clients may end up in a situation where they need to ask the user to either "Enter a password" or "Set a password";

In such occasions, it would be convenient for clients to be able to check if the _self_ user has a password registered with the backend.

@deanrobertcook 