### PR TITLE
Split alpine-builder

### DIFF
--- a/build/alpine/Dockerfile.builder
+++ b/build/alpine/Dockerfile.builder
@@ -2,10 +2,17 @@
 
 FROM wireserver/alpine-prebuilder
 
-# download stack indices and compile/cache dependencies to speed up subsequent container creation
+# Download stack indices and compile/cache dependencies to speed up subsequent
+# container creation.
+#
+# We do a full 'stack build' to get dependencies like 'aws' to build, but then
+# we do a 'stack clean' so that packages in the repo wouldn't get into the final
+# image – that's because Stack sometimes doesn't realize that local packages
+# should be recompiled, and we really don't want that to happen during CI.
 RUN apk add --no-cache git && \
     mkdir -p /src && cd /src && \
     git clone https://github.com/wireapp/wire-server.git && \
     cd wire-server && \
     stack update && \
-    stack build --pedantic --haddock --test --no-run-tests
+    stack build --pedantic --haddock --test --no-run-tests && \
+    stack clean

--- a/build/alpine/Dockerfile.builder
+++ b/build/alpine/Dockerfile.builder
@@ -1,104 +1,11 @@
 # Requires docker >= 17.05 (requires support for multi-stage builds)
 
-FROM alpine:3.7 as cryptobox-builder
-
-# compile cryptobox-c
-RUN apk add --no-cache cargo libsodium-dev git && \
-    cd /tmp && \
-    git clone https://github.com/wireapp/cryptobox-c.git && \
-    cd cryptobox-c && \
-    cargo build --release
-
-FROM alpine:3.7
-
-# install cryptobox-c in the new container
-COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib/libcryptobox.so
-COPY --from=cryptobox-builder /tmp/cryptobox-c/src/cbox.h /usr/include/cbox.h
-
-# development packages required for wire-server Haskell services
-RUN apk add --no-cache \
-        alpine-sdk \
-        ca-certificates \
-        linux-headers \
-        zlib-dev \
-        ghc \
-        libsodium-dev \
-        openssl-dev \
-        protobuf \
-        icu-dev \
-        geoip-dev \
-        snappy-dev \
-        llvm-libunwind-dev \
-        bash \
-        xz
-
-# get static version of Haskell Stack and use system ghc by default
-ARG STACK_VERSION=1.6.3
-RUN curl -sSfL https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/stack-${STACK_VERSION}-linux-x86_64-static.tar.gz \
-    | tar --wildcards -C /usr/local/bin --strip-components=1 -xzvf - '*/stack' && chmod 755 /usr/local/bin/stack && \
-    stack config set system-ghc --global true
-
-# As done by https://github.com/TerrorJack/meikyu,
-# Install packages needed for newer version of GHC
-WORKDIR /root
-ENV LANG en_US.UTF-8
-ENV GHC_REV ghc-8.2.2-release
-ENV GHC_VER ghc-8.2.2
-ENV PATH /root/.local/bin:/root/.cabal/bin:/root/.stack/programs/x86_64-linux/$GHC_VER/bin:$PATH
-ADD ghc/build.mk ghc/config.yaml /tmp/
-RUN stack --no-terminal --resolver lts-9 --system-ghc install \
-        alex \
-        happy \
-        hscolour && \
-    apk add --no-cache --no-progress \
-    autoconf \
-    automake \
-    binutils-gold \
-    bzip2 \
-    ca-certificates \
-    coreutils \
-    file \
-    findutils \
-    g++ \
-    gawk \
-    gcc \
-    ghc \
-    git \
-    gmp-dev \
-    gzip \
-    libffi-dev \
-    make \
-    musl-dev \
-    ncurses-dev \
-    openssh \
-    patch \
-    perl \
-    py3-sphinx \
-    sed \
-    tar \
-    zlib-dev
-
-# Install newer version of GHC
-RUN cd /tmp && \
-    git clone git://git.haskell.org/ghc.git && \
-    cd ghc && \
-    git checkout $GHC_REV && \
-    git submodule update --init --recursive && \
-    mv /tmp/build.mk mk/
-
-RUN cd /tmp/ghc && \
-    ./boot && \
-    SPHINXBUILD=/usr/bin/sphinx-build-3 ./configure --prefix=/root/.stack/programs/x86_64-linux/$GHC_VER --disable-ld-override && \
-    echo "compiling GHC, may take an hour. Log output sent to /dev/null due to travis log length restrictions." && \
-    make -j4 &> /dev/null && \
-    make install &> /dev/null && \
-    mv /tmp/config.yaml /root/.stack/
+FROM wireserver/alpine-prebuilder
 
 # download stack indices and compile/cache dependencies to speed up subsequent container creation
-# TODO: make this caching step optional?
 RUN apk add --no-cache git && \
     mkdir -p /src && cd /src && \
     git clone https://github.com/wireapp/wire-server.git && \
     cd wire-server && \
     stack update && \
-    stack build --pedantic --haddock --test --dependencies-only
+    stack build --pedantic --haddock --test --no-run-tests

--- a/build/alpine/Dockerfile.prebuilder
+++ b/build/alpine/Dockerfile.prebuilder
@@ -1,0 +1,96 @@
+# Requires docker >= 17.05 (requires support for multi-stage builds)
+
+FROM alpine:3.7 as cryptobox-builder
+
+# compile cryptobox-c
+RUN apk add --no-cache cargo libsodium-dev git && \
+    cd /tmp && \
+    git clone https://github.com/wireapp/cryptobox-c.git && \
+    cd cryptobox-c && \
+    cargo build --release
+
+FROM alpine:3.7
+
+# install cryptobox-c in the new container
+COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib/libcryptobox.so
+COPY --from=cryptobox-builder /tmp/cryptobox-c/src/cbox.h /usr/include/cbox.h
+
+# development packages required for wire-server Haskell services
+RUN apk add --no-cache \
+        alpine-sdk \
+        ca-certificates \
+        linux-headers \
+        zlib-dev \
+        ghc \
+        libsodium-dev \
+        openssl-dev \
+        protobuf \
+        icu-dev \
+        geoip-dev \
+        snappy-dev \
+        llvm-libunwind-dev \
+        bash \
+        xz
+
+# get static version of Haskell Stack and use system ghc by default
+ARG STACK_VERSION=1.6.3
+RUN curl -sSfL https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/stack-${STACK_VERSION}-linux-x86_64-static.tar.gz \
+    | tar --wildcards -C /usr/local/bin --strip-components=1 -xzvf - '*/stack' && chmod 755 /usr/local/bin/stack && \
+    stack config set system-ghc --global true
+
+# As done by https://github.com/TerrorJack/meikyu,
+# Install packages needed for newer version of GHC
+WORKDIR /root
+ENV LANG en_US.UTF-8
+ENV GHC_REV ghc-8.2.2-release
+ENV GHC_VER ghc-8.2.2
+ENV PATH /root/.local/bin:/root/.cabal/bin:/root/.stack/programs/x86_64-linux/$GHC_VER/bin:$PATH
+ADD ghc/build.mk ghc/config.yaml /tmp/
+RUN stack --no-terminal --resolver lts-9 --system-ghc install \
+        alex \
+        happy \
+        hscolour && \
+    apk add --no-cache --no-progress \
+    autoconf \
+    automake \
+    binutils-gold \
+    bzip2 \
+    ca-certificates \
+    coreutils \
+    file \
+    findutils \
+    g++ \
+    gawk \
+    gcc \
+    ghc \
+    git \
+    gmp-dev \
+    gzip \
+    libffi-dev \
+    make \
+    musl-dev \
+    ncurses-dev \
+    openssh \
+    patch \
+    perl \
+    py3-sphinx \
+    sed \
+    tar \
+    zlib-dev
+
+# Install newer version of GHC
+RUN cd /tmp && \
+    git clone git://git.haskell.org/ghc.git && \
+    cd ghc && \
+    git checkout $GHC_REV && \
+    git submodule update --init --recursive && \
+    mv /tmp/build.mk mk/
+
+RUN cd /tmp/ghc && \
+    ./boot && \
+    SPHINXBUILD=/usr/bin/sphinx-build-3 ./configure --prefix=/root/.stack/programs/x86_64-linux/$GHC_VER --disable-ld-override && \
+    echo "compiling GHC, may take an hour. Log output sent to /dev/null due to travis log length restrictions." && \
+    make -j4 &> /dev/null && \
+    make install &> /dev/null && \
+    mv /tmp/config.yaml /root/.stack/ && \
+    rm -rf /tmp/ghc

--- a/build/alpine/Makefile
+++ b/build/alpine/Makefile
@@ -1,13 +1,19 @@
 DOCKER_USER   ?= wireserver
 DOCKER_TAG    ?= local
 
-default: deps builder
+default: deps prebuilder builder
 
 .PHONY: deps
 deps:
 	docker build -t $(DOCKER_USER)/alpine-deps:$(DOCKER_TAG) -f Dockerfile.deps .
 	docker tag $(DOCKER_USER)/alpine-deps:$(DOCKER_TAG) $(DOCKER_USER)/alpine-deps:latest
 	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/alpine-deps:$(DOCKER_TAG); docker push $(DOCKER_USER)/alpine-deps:latest; fi;
+
+.PHONY: prebuilder
+prebuilder:
+	docker build -t $(DOCKER_USER)/alpine-prebuilder:$(DOCKER_TAG) -f Dockerfile.prebuilder .
+	docker tag $(DOCKER_USER)/alpine-prebuilder:$(DOCKER_TAG) $(DOCKER_USER)/alpine-prebuilder:latest
+	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/alpine-prebuilder:$(DOCKER_TAG); docker push $(DOCKER_USER)/alpine-prebuilder:latest; fi;
 
 .PHONY: builder
 builder:

--- a/build/alpine/README.md
+++ b/build/alpine/README.md
@@ -2,7 +2,7 @@
 
 To create docker images, you need to install [docker version >= 17.05](https://www.docker.com/) and [`make`](https://www.gnu.org/software/make/).
 
-* `Dockerfile.builder` contains all the compile-time dependencies necessary to compile any of the haskell services (it also downloads, builds and caches some haskell libraries). This image is fairly large, ~4GB uncompressed.
+* `Dockerfile.builder` contains all the compile-time dependencies necessary to compile any of the Haskell services (it also downloads, builds and caches some Haskell libraries). This image is fairly large, ~4GB uncompressed.
 * `Dockerfile.deps` contains all the run-time dependencies e.g. shared libraries, at a total size of ~18MB compressed.
 
 Both of the above need to be built first (only once) to be able to actually build a service docker image.
@@ -25,4 +25,5 @@ cd services/brig && make docker
 
 * `Dockerfile.intermediate` - based on `Dockerfile.deps`/`Dockerfile.builder`, this is an intermediate image compiling all dynamically linked binaries (obtained when running `make install` in the top-level directory).
 * `Dockerfile.executable` - based on `Dockerfile.deps`/`Dockerfile.intermediate`, this extracts a single executable from the intermediate image, yielding a small image with a single dynamically linked binary.
-* `Dockerfile.migrations` - same as Dockerfile.executable, with a fixed set of database migration binaries.
+* `Dockerfile.migrations` - same as `Dockerfile.executable`, with a fixed set of database migration binaries.
+* `Dockerfile.prebuilder` - dependencies of `Dockerfile.builder` that are expected to change very rarely (GHC, system libraries).


### PR DESCRIPTION
Pros:
* The next time we want to change something about the way we build Haskell stuff, we won't have to wait for the GHC build every. single. time.

Cons:
* A split based on components (e.g. GHC in a separate docker image) would be nicer conceptually.