### PR TITLE
Store asset meta info in a specific file, use minio instead of fake-s3

### DIFF
--- a/deploy/docker-ephemeral/docker-compose.yaml
+++ b/deploy/docker-ephemeral/docker-compose.yaml
@@ -21,9 +21,13 @@ services:
       - SERVICES=ses,sns
 
   fake_s3:
-      image: tiagoloureiro/fake-s3:0.2.5
-      ports:
-        - 4570:4570
+    image: minio/minio:RELEASE.2018-04-27T23-33-52Z
+    ports:
+     - "4570:9000"
+    environment:
+      MINIO_ACCESS_KEY: dummykey
+      MINIO_SECRET_KEY: dummysecret # minio requires a secret of at least 8 chars
+    command: server /tmp
 
   redis:
     image: redis:3.0.7-alpine

--- a/deploy/services-demo/conf/cargohold.demo.yaml
+++ b/deploy/services-demo/conf/cargohold.demo.yaml
@@ -3,8 +3,8 @@ cargohold:
   port: 8084
 
 aws:
-  keyId: dummy
-  secretKey: dummy
+  keyId: dummykey
+  secretKey: dummysecret
   s3Bucket: dummy-bucket
   s3Endpoint: http://localhost:4570 # https://s3-eu-west-1.amazonaws.com:443
 

--- a/services/cargohold/cargohold.integration.yaml
+++ b/services/cargohold/cargohold.integration.yaml
@@ -4,8 +4,8 @@ cargohold:
 
 aws:
   # TODO: Check AWS loadCredentialsFromEnv
-  keyId: dummy # <-- insert-key-id-here
-  secretKey: dummy # <-- insert-secret-key-here
+  keyId: dummykey # <-- insert-key-id-here
+  secretKey: dummysecret # <-- insert-secret-key-here
   s3Bucket: dummy-bucket # <-- insert-bucket-name-here
   s3Endpoint: http://localhost:4570 # https://s3-eu-west-1.amazonaws.com:443
   # If you want to use cloudfront for asset downloads

--- a/services/cargohold/src/CargoHold/S3.hs
+++ b/services/cargohold/src/CargoHold/S3.hs
@@ -302,7 +302,8 @@ minBigSize = 5 * 1024 * 1024 -- 5 MiB
 
 getResumable :: V3.AssetKey -> ExceptT Error App (Maybe S3Resumable)
 getResumable k = do
-    let (rk, mk) = (mkResumableKey k, mkResumableKeyMeta k)
+    let rk = mkResumableKey k
+        mk = mkResumableKeyMeta k
     Log.debug $ "remote" .= val "S3"
         ~~ "asset"          .= toByteString k
         ~~ "asset.key"      .= toByteString rk

--- a/services/cargohold/stack.yaml
+++ b/services/cargohold/stack.yaml
@@ -11,7 +11,7 @@ packages:
 - ../../libs/metrics-wai
 - location:
     git: https://github.com/tiago-loureiro/aws
-    commit: 9c79c78b018825c70515baf0f9dd7a08776e5848
+    commit: 483f4b0c137d6d4bbbe9abb0acab4309e8d3bde9
   extra-dep: true
 resolver: lts-10.3
 extra-deps:

--- a/services/integration.sh
+++ b/services/integration.sh
@@ -63,8 +63,8 @@ function run() {
 # brig,gundeck,galley use the amazonka library's 'Discover', which expects AWS credentials
 # even if those are not used/can be dummy values with the fake sqs/ses/etc containers used (see deploy/docker-ephemeral/docker-compose.yaml )
 export AWS_REGION=eu-west-1
-export AWS_ACCESS_KEY_ID=dummy
-export AWS_SECRET_ACCESS_KEY=dummy
+export AWS_ACCESS_KEY_ID=dummykey
+export AWS_SECRET_ACCESS_KEY=dummysecret
 
 check_prerequisites
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,7 +47,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/tiago-loureiro/aws
-    commit: 9c79c78b018825c70515baf0f9dd7a08776e5848
+    commit: 483f4b0c137d6d4bbbe9abb0acab4309e8d3bde9
   extra-dep: true
 
 extra-deps:


### PR DESCRIPTION
This PR introduces 2 changes:
1. Migrate to use [minio](https://minio.io/) instead of fake-s3; one of the many advantages is that all tests now also pass locally (resumable uploads work against minio).
2. The meta information about an upload is now stored in a different file, i.e., it was stored under `v3/resumable/<asset_id>` and it is now stored under `v3/resumable/<asset_id>/meta`. The reason for this change is that parts are then stored under `v3/resumable/<asset_id>/<part_nr>`, which is fine for S3 but not very portable since it is not possible, when using your local filesystem, to have a file and a folder with the same name.