### PR TITLE
Guide `make fast` behavior during development via shell env.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install: init
 
 .PHONY: fast
 fast: init
-	stack install --pedantic --test --local-bin-path=dist --fast
+	stack install --pedantic --test --local-bin-path=dist --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY: clean
 clean:

--- a/services/brig/Makefile
+++ b/services/brig/Makefile
@@ -30,7 +30,7 @@ install: init
 
 .PHONY: fast
 fast: init
-	stack install --pedantic --test --local-bin-path=../../dist --fast
+	stack install --pedantic --test --local-bin-path=../../dist --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY: clean
 clean:

--- a/services/brig/stack.yaml
+++ b/services/brig/stack.yaml
@@ -1,21 +1,36 @@
 extra-package-dbs: []
 packages:
 - .
-- '../../libs/brig-types'
-- '../../libs/types-common'
-- '../../libs/bilge'
-- '../../libs/cargohold-types'
-- '../../libs/cassandra-util'
-- '../../libs/gundeck-types'
-- '../../libs/ropes'
-- '../../libs/tasty-cannon'
-- '../../libs/galley-types'
-- '../../libs/http-client-openssl-ext'
-- '../../libs/metrics-core'
-- '../../libs/metrics-wai'
-- '../../libs/sodium-crypto-sign'
-- '../../libs/wai-utilities'
-- '../../libs/zauth'
+- location: '../../libs/brig-types'
+  extra-dep: true
+- location: '../../libs/types-common'
+  extra-dep: true
+- location: '../../libs/bilge'
+  extra-dep: true
+- location: '../../libs/cargohold-types'
+  extra-dep: true
+- location: '../../libs/cassandra-util'
+  extra-dep: true
+- location: '../../libs/gundeck-types'
+  extra-dep: true
+- location: '../../libs/ropes'
+  extra-dep: true
+- location: '../../libs/tasty-cannon'
+  extra-dep: true
+- location: '../../libs/galley-types'
+  extra-dep: true
+- location: '../../libs/http-client-openssl-ext'
+  extra-dep: true
+- location: '../../libs/metrics-core'
+  extra-dep: true
+- location: '../../libs/metrics-wai'
+  extra-dep: true
+- location: '../../libs/sodium-crypto-sign'
+  extra-dep: true
+- location: '../../libs/wai-utilities'
+  extra-dep: true
+- location: '../../libs/zauth'
+  extra-dep: true
 - location:
     git: https://github.com/tiago-loureiro/haskell-multihash.git
     commit: 7622cfcff97fa1e207ec91bb11495a207e6c0195

--- a/services/cannon/Makefile
+++ b/services/cannon/Makefile
@@ -32,7 +32,7 @@ install: init
 
 .PHONY: fast
 fast: init
-	stack install --pedantic --test --local-bin-path=../../dist --fast
+	stack install --pedantic --test --local-bin-path=../../dist --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY:
 compile:

--- a/services/cannon/stack.yaml
+++ b/services/cannon/stack.yaml
@@ -1,12 +1,18 @@
 resolver: lts-10.3
 packages:
 - '.'
-- '../../libs/bilge'
-- '../../libs/metrics-core'
-- '../../libs/metrics-wai'
-- '../../libs/types-common'
-- '../../libs/gundeck-types'
-- '../../libs/wai-utilities'
+- location: '../../libs/bilge'
+  extra-dep: true
+- location: '../../libs/metrics-core'
+  extra-dep: true
+- location: '../../libs/metrics-wai'
+  extra-dep: true
+- location: '../../libs/types-common'
+  extra-dep: true
+- location: '../../libs/gundeck-types'
+  extra-dep: true
+- location: '../../libs/wai-utilities'
+  extra-dep: true
 flags:
   types-common:
     protobuf: True

--- a/services/cargohold/Makefile
+++ b/services/cargohold/Makefile
@@ -28,7 +28,7 @@ install: init
 
 .PHONY: fast
 fast: init
-	stack install --pedantic --test --fast --local-bin-path=../../dist
+	stack install --pedantic --test --local-bin-path=../../dist --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY: compile
 compile:

--- a/services/cargohold/stack.yaml
+++ b/services/cargohold/stack.yaml
@@ -2,13 +2,20 @@ flags: {}
 extra-package-dbs: []
 packages:
 - .
-- ../../libs/cargohold-types
-- ../../libs/types-common
-- ../../libs/ropes
-- ../../libs/wai-utilities
-- ../../libs/bilge
-- ../../libs/metrics-core
-- ../../libs/metrics-wai
+- location: ../../libs/cargohold-types
+  extra-dep: true
+- location: ../../libs/types-common
+  extra-dep: true
+- location: ../../libs/ropes
+  extra-dep: true
+- location: ../../libs/wai-utilities
+  extra-dep: true
+- location: ../../libs/bilge
+  extra-dep: true
+- location: ../../libs/metrics-core
+  extra-dep: true
+- location: ../../libs/metrics-wai
+  extra-dep: true
 - location:
     git: https://github.com/tiago-loureiro/aws
     commit: 483f4b0c137d6d4bbbe9abb0acab4309e8d3bde9

--- a/services/galley/Makefile
+++ b/services/galley/Makefile
@@ -37,7 +37,7 @@ install: init
 
 .PHONY: fast
 fast: init
-	stack install --pedantic --test --local-bin-path=../../dist --fast
+	stack install --pedantic --test --local-bin-path=../../dist --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY:
 compile:

--- a/services/galley/stack.yaml
+++ b/services/galley/stack.yaml
@@ -1,18 +1,30 @@
 resolver: lts-10.3
 packages:
 - '.'
-- '../../libs/bilge'
-- '../../libs/brig-types'
-- '../../libs/cassandra-util'
-- '../../libs/galley-types'
-- '../../libs/gundeck-types'
-- '../../libs/http-client-openssl-ext'
-- '../../libs/metrics-core'
-- '../../libs/metrics-wai'
-- '../../libs/tasty-cannon'
-- '../../libs/types-common'
-- '../../libs/types-common-journal'
-- '../../libs/wai-utilities'
+- location: '../../libs/bilge'
+  extra-dep: true
+- location: '../../libs/brig-types'
+  extra-dep: true
+- location: '../../libs/cassandra-util'
+  extra-dep: true
+- location: '../../libs/galley-types'
+  extra-dep: true
+- location: '../../libs/gundeck-types'
+  extra-dep: true
+- location: '../../libs/http-client-openssl-ext'
+  extra-dep: true
+- location: '../../libs/metrics-core'
+  extra-dep: true
+- location: '../../libs/metrics-wai'
+  extra-dep: true
+- location: '../../libs/tasty-cannon'
+  extra-dep: true
+- location: '../../libs/types-common'
+  extra-dep: true
+- location: '../../libs/types-common-journal'
+  extra-dep: true
+- location: '../../libs/wai-utilities'
+  extra-dep: true
 
 flags:
   types-common:

--- a/services/gundeck/Makefile
+++ b/services/gundeck/Makefile
@@ -34,7 +34,7 @@ install: init
 
 .PHONY: fast
 fast: init
-	stack install --pedantic --test --local-bin-path=../../dist --fast
+	stack install --pedantic --test --local-bin-path=../../dist --fast $(WIRE_STACK_OPTIONS)
 	cp "$(shell stack path --dist-dir)/build/$(NAME)-tests/$(NAME)-tests" ../../dist/
 
 .PHONY: compile

--- a/services/gundeck/stack.yaml
+++ b/services/gundeck/stack.yaml
@@ -3,16 +3,26 @@ flags: {}
 extra-package-dbs: []
 packages:
 - .
-- ../../libs/bilge
-- ../../libs/brig-types
-- ../../libs/cassandra-util
-- ../../libs/galley-types
-- ../../libs/gundeck-types
-- ../../libs/metrics-core
-- ../../libs/metrics-wai
-- ../../libs/tasty-cannon
-- ../../libs/types-common
-- ../../libs/wai-utilities
+- location: ../../libs/bilge
+  extra-dep: true
+- location: ../../libs/brig-types
+  extra-dep: true
+- location: ../../libs/cassandra-util
+  extra-dep: true
+- location: ../../libs/galley-types
+  extra-dep: true
+- location: ../../libs/gundeck-types
+  extra-dep: true
+- location: ../../libs/metrics-core
+  extra-dep: true
+- location: ../../libs/metrics-wai
+  extra-dep: true
+- location: ../../libs/tasty-cannon
+  extra-dep: true
+- location: ../../libs/types-common
+  extra-dep: true
+- location: ../../libs/wai-utilities
+  extra-dep: true
 
 flags:
   types-common:

--- a/services/proxy/Makefile
+++ b/services/proxy/Makefile
@@ -32,7 +32,7 @@ install: init
 
 .PHONY: fast
 fast: init
-	stack install --pedantic --test --local-bin-path=../../dist --fast
+	stack install --pedantic --test --local-bin-path=../../dist --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY:
 compile:

--- a/services/proxy/stack.yaml
+++ b/services/proxy/stack.yaml
@@ -1,11 +1,16 @@
 resolver: lts-10.3
 packages:
 - '.'
-- '../../libs/bilge'
-- '../../libs/types-common'
-- '../../libs/wai-utilities'
-- '../../libs/metrics-core'
-- '../../libs/metrics-wai'
+- location: '../../libs/bilge'
+  extra-dep: true
+- location: '../../libs/types-common'
+  extra-dep: true
+- location: '../../libs/wai-utilities'
+  extra-dep: true
+- location: '../../libs/metrics-core'
+  extra-dep: true
+- location: '../../libs/metrics-wai'
+  extra-dep: true
 
 flags:
   types-common:

--- a/tools/api-simulations/Makefile
+++ b/tools/api-simulations/Makefile
@@ -27,7 +27,7 @@ clean:
 
 .PHONY: fast
 fast: init
-	stack install --pedantic --test --local-bin-path=../../dist --fast
+	stack install --pedantic --test --local-bin-path=../../dist --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY:
 compile:

--- a/tools/bonanza/Makefile
+++ b/tools/bonanza/Makefile
@@ -28,7 +28,7 @@ install: init
 
 .PHONY: compile
 compile:
-	stack build --fast --pedantic --test --no-copy-bins
+	stack build --pedantic --test --no-copy-bins --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY: dist
 dist: guard-VERSION $(DEB)


### PR DESCRIPTION
Tweak the `make fast` rule such that it lets you ignore warnings during development without risking to accidentally commit your compiler settings:

```shell
$ WIRE_STACK_OPTIONS="--ghc-options=-Wwarn" make fast
```
