### PR TITLE
Downgrade the warning about last prekey to 'Info'

### DIFF
--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -176,7 +176,7 @@ claimPrekey u c = withOptLock u c $ do
         Just (i, k) -> do
             if i /= lastPrekeyId
                 then retry x1 $ write removePrekey (params Quorum (u, c, i))
-                else Log.warn $ field "user" (toByteString u)
+                else Log.info $ field "user" (toByteString u)
                               . field "client" (toByteString c)
                               . msg (val "last resort prekey used")
             return $ Just (ClientPrekey c (Prekey i k))


### PR DESCRIPTION
It doesn't deserve to be a warning, I guess. Like, it happens all the time and stuff.