### PR TITLE
Fix a flaky throttling test

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -368,6 +368,7 @@ executable brig-integration
       , lens-aeson            >= 1.0
       , lifted-async          >= 0.9.3
       , mime                  >= 0.4
+      , monad-control
       , mtl                   >= 2.1
       , network
       , optparse-applicative  >= 0.11


### PR DESCRIPTION
In this PR, I try to fix a flaky throttling test by using 8 threads instead of 1 for logging in. This will probably make logging-in fast enough that throttling will actually kick in.

For an example of test failure, see here: https://bridge-ie-concourse.zinfra.io/teams/main/pipelines/wire-server-pr-integration/jobs/test/builds/111

```
        throttle:                                          FAIL
          Exception: Assertions failed:
           1: 429 =/= 200
          
          Response was:
          
          Response {responseStatus = Status {statusCode = 200, statusMessage = "OK"}, responseVersion = HTTP/1.1, responseHeaders = [("Transfer-Encoding","chunked"),("Date","Tue, 22 May 2018 12:06:50 GMT"),("Server","Warp/3.2.13"),("Content-Encoding","gzip"),("Set-Cookie","zuid=XUcvxEq3LTq9n8-tEAPfHpFuMSzmb1Fuk97AQDV3x6Kmf3an8p8HtUl4e2KyWer7ayWNWny-cW5mNqJVt0XnBw==.v=1.k=1.d=1526990830.t=u.l=s.u=7f8c6cf9-4dcb-4aa5-9672-4698dbcc62a0.r=7c004229; Path=/access; Domain=brig; HttpOnly"),("Content-Type","application/json")], responseBody = Just "{\"expires_in\":30,\"access_token\":\"_t59Mep7Sjt3bdx53ZW2B3XEdUJJ9EC4-ntybyrNSz0crWWqrWWfC-XoXB1uoBtIehnqao3GQRHaptFRTudWBA==.v=1.k=1.d=1526990840.t=a.l=.u=7f8c6cf9-4dcb-4aa5-9672-4698dbcc62a0.c=17217311231157329923\",\"user\":\"7f8c6cf9-4dcb-4aa5-9672-4698dbcc62a0\",\"token_type\":\"Bearer\"}", responseCookieJar = CJ {expose = [Cookie {cookie_name = "zuid", cookie_value = "XUcvxEq3LTq9n8-tEAPfHpFuMSzmb1Fuk97AQDV3x6Kmf3an8p8HtUl4e2KyWer7ayWNWny-cW5mNqJVt0XnBw==.v=1.k=1.d=1526990830.t=u.l=s.u=7f8c6cf9-4dcb-4aa5-9672-4698dbcc62a0.r=7c004229", cookie_expiry_time = 3017-09-22 00:00:00 UTC, cookie_domain = "brig", cookie_path = "/access", cookie_creation_time = 2018-05-22 12:06:50.119124828 UTC, cookie_last_access_time = 2018-05-22 12:06:50.119124828 UTC, cookie_persistent = False, cookie_host_only = True, cookie_secure_only = False, cookie_http_only = True}]}, responseClose' = ResponseClose}
          CallStack (from HasCallStack):
            error, called at src/Bilge/Assert.hs:73:30 in bilge-0.22.0-Le7pb7FqBaSrgj9VniFis:Bilge.Assert
            <!!, called at test/integration/API/User/Auth.hs:232:10 in main:API.User.Auth
```