### PR TITLE
Fix ToJSON and arbitrary instance for PlainTextPassword

### DIFF
--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -165,7 +165,7 @@ instance Arbitrary AsciiBase64Url where
     arbitrary = encodeBase64Url <$> arbitrary
 
 instance Arbitrary PlainTextPassword where
-    arbitrary = pure $ PlainTextPassword "<hidden>"
+    arbitrary = PlainTextPassword . fromRange <$> genRangeText @6 @1024 arbitrary
 
 instance Arbitrary DeleteUser where
     arbitrary = DeleteUser <$> arbitrary

--- a/libs/types-common/src/Data/Misc.hs
+++ b/libs/types-common/src/Data/Misc.hs
@@ -221,13 +221,10 @@ instance Cql (Fingerprint a) where
 
 newtype PlainTextPassword = PlainTextPassword
     { fromPlainTextPassword :: Text }
-    deriving (Eq)
+    deriving (Eq, ToJSON)
 
 instance Show PlainTextPassword where
     show _ = "PlainTextPassword <hidden>"
-
-instance ToJSON PlainTextPassword where
-    toJSON _ = toJSON @Text "PlainTextPassword <hidden>"
 
 instance FromJSON PlainTextPassword where
     parseJSON x = PlainTextPassword . fromRange


### PR DESCRIPTION
Fix for https://github.com/wireapp/wire-server/issues/339