### PR TITLE
Add a new, more efficient connections-status endpoint

### DIFF
--- a/libs/brig-types/src/Brig/Types/Connection.hs
+++ b/libs/brig-types/src/Brig/Types/Connection.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE RecordWildCards            #-}
 
 module Brig.Types.Connection
     ( module Brig.Types.Connection
@@ -23,6 +25,7 @@ import Data.Time.Clock (UTCTime)
 newtype Message = Message { messageText :: Text }
     deriving (Eq, Ord, Show, ToJSON)
 
+-- | Look at @services\/brig\/doc@ for descriptions of these states.
 data Relation
     = Accepted
     | Blocked
@@ -78,6 +81,12 @@ data InvitationList = InvitationList
 
 data UserIds = UserIds
     { cUsers :: [UserId] }
+
+-- | Data that is passed to the @\/i\/users\/connections-status@ endpoint.
+data ConnectionsStatusRequest = ConnectionsStatusRequest
+    { csrFrom :: ![UserId]
+    , csrTo   :: ![UserId]
+    } deriving (Eq, Show)
 
 -- * JSON Instances:
 
@@ -212,3 +221,15 @@ instance FromJSON UserIds where
 instance ToJSON UserIds where
     toJSON (UserIds us) = object
         [ "ids" .= us ]
+
+instance FromJSON ConnectionsStatusRequest where
+    parseJSON = withObject "ConnectionsStatusRequest" $ \o -> do
+        csrFrom <- o .: "from"
+        csrTo   <- o .: "to"
+        pure ConnectionsStatusRequest{..}
+
+instance ToJSON ConnectionsStatusRequest where
+    toJSON ConnectionsStatusRequest{csrFrom, csrTo} = object
+        [ "from" .= csrFrom
+        , "to"   .= csrTo
+        ]

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 
 module Brig.API (runServer, parseOptions) where
 
@@ -130,8 +131,14 @@ sitemap o = do
     delete "/i/users/:id" (continue deleteUserNoVerify) $
         capture "id"
 
-    get "/i/users/connections-status" (continue getConnectionStatus) $
+    get "/i/users/connections-status" (continue deprecatedGetConnectionsStatus) $
         query "users"
+        .&. opt (query "filter")
+
+    post "/i/users/connections-status" (continue getConnectionsStatus) $
+        accept "application" "json"
+        .&. contentType "application" "json"
+        .&. request
         .&. opt (query "filter")
 
     get "/i/users" (continue listActivatedAccounts) $
@@ -1385,9 +1392,23 @@ changeEmail (_ ::: u ::: _ ::: req) = do
     lift $ sendActivationMail en name apair (Just lang) ident
     return $ setStatus status202 empty
 
-getConnectionStatus :: List UserId ::: Maybe Relation -> Handler Response
-getConnectionStatus (users ::: flt) = do
+-- Deprecated and to be removed after new versions of brig and galley are
+-- deployed. Reason for deprecation: it returns N^2 things (which is not
+-- needed), it doesn't scale, and it accepts everything in URL parameters,
+-- which doesn't work when the list of users is long.
+deprecatedGetConnectionsStatus :: List UserId ::: Maybe Relation -> Handler Response
+deprecatedGetConnectionsStatus (users ::: flt) = do
     r <- lift $ API.lookupConnectionStatus (fromList users) (fromList users)
+    return . json $ maybe r (filterByRelation r) flt
+  where
+    filterByRelation l rel = filter ((==rel) . csStatus) l
+
+getConnectionsStatus
+    :: JSON ::: JSON ::: Request ::: Maybe Relation
+    -> Handler Response
+getConnectionsStatus (_ ::: _ ::: req ::: flt) = do
+    ConnectionsStatusRequest{csrFrom, csrTo} <- parseJsonBody req
+    r <- lift $ API.lookupConnectionStatus csrFrom csrTo
     return . json $ maybe r (filterByRelation r) flt
   where
     filterByRelation l rel = filter ((==rel) . csStatus) l

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -6,7 +6,7 @@
 module Galley.API.Util where
 
 import Brig.Types (Relation (..))
-import Brig.Types.Intra (ConnectionStatus (..), ReAuthUser (..))
+import Brig.Types.Intra (ReAuthUser (..))
 import Control.Lens (view, (&), (.~))
 import Control.Monad
 import Control.Monad.Catch
@@ -52,18 +52,8 @@ ensureConnected :: UserId -> [UserId] -> Galley ()
 ensureConnected _ []   = pure ()
 ensureConnected u uids = do
     conns <- getConnections u uids (Just Accepted)
-    unless (all (isConnected u conns) uids) $
+    unless (length conns == length uids) $
         throwM notConnected
-  where
-    isConnected u1 conns u2 =
-        let c1 = find (connection u1 u2) conns
-            c2 = find (connection u2 u1) conns
-        in isJust c1 && isJust c2
-
-    connection u1 u2 cs =
-           csFrom   cs == u1
-        && csTo     cs == u2
-        && csStatus cs == Accepted
 
 ensureReAuthorised :: UserId -> PlainTextPassword -> Galley ()
 ensureReAuthorised u secret = do

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -30,16 +30,19 @@ import Network.Wai.Utilities.Error
 
 import qualified Network.HTTP.Client.Internal as Http
 
--- | Get statuses of all connections between one user and the rest of them.
+-- | Get statuses of all connections between two groups of users (the usual
+-- pattern is to check all connections from one user to several, or from
+-- several users to one).
+--
 -- When a connection does not exist, it is skipped.
-getConnections :: UserId -> [UserId] -> Maybe Relation -> Galley [ConnectionStatus]
-getConnections u uids rlt = do
+getConnections :: [UserId] -> [UserId] -> Maybe Relation -> Galley [ConnectionStatus]
+getConnections from to rlt = do
     (h, p) <- brigReq
     r <- call "brig"
         $ method POST . host h . port p
         . path "/i/users/connections-status"
         . maybe id rfilter rlt
-        . json ConnectionsStatusRequest{csrFrom = [u], csrTo = uids}
+        . json ConnectionsStatusRequest{csrFrom = from, csrTo = to}
         . expect2xx
     parseResponse (Error status502 "server-error") r
   where

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -543,6 +543,17 @@ connectUsersWith fn b u us = mapM connectTo us
             )
         return (r1, r2)
 
+-- | A copy of 'putConnection' from Brig integration tests.
+putConnection :: Brig -> UserId -> UserId -> Relation -> Http ResponseLBS
+putConnection b from to r = put $ b
+    . paths ["/connections", toByteString' to]
+    . contentJson
+    . body payload
+    . zUser from
+    . zConn "conn"
+  where
+    payload = RequestBodyLBS . encode $ object [ "status" .= r ]
+
 randomUsers :: Brig -> Int -> Http [UserId]
 randomUsers b n = replicateM n (randomUser b)
 


### PR DESCRIPTION
The old endpoint (`GET /i/users/connections-status`) sinned in two ways:

  * It took the list of users as a query parameter. This doesn't fly for
    256 users.

  * It gave N^2 responses (connections between all users), while most of the
    time we only need to know connection status for connections from one
    user to a bunch of other users.

The new `POST /i/users/connections-status` endpoint is pure as snow
in comparison.