### PR TITLE
Email changes

### DIFF
--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE MultiWayIf        #-}
@@ -130,6 +131,11 @@ sitemap o = do
     post "/i/users" (continue createUserNoVerify) $
         accept "application" "json"
         .&. contentType "application" "json"
+        .&. request
+
+    put "/i/self/email" (continue changeSelfEmailNoSend) $
+        contentType "application" "json"
+        .&. header "Z-User"
         .&. request
 
     delete "/i/users/:id" (continue deleteUserNoVerify) $
@@ -411,7 +417,7 @@ sitemap o = do
 
     ---
 
-    put "/self/email" (continue changeEmail) $
+    put "/self/email" (continue changeSelfEmail) $
         contentType "application" "json"
         .&. header "Z-User"
         .&. header "Z-Connection"
@@ -1200,6 +1206,9 @@ deleteUserNoVerify uid = do
     lift $ API.deleteUserNoVerify uid
     return $ setStatus status202 empty
 
+changeSelfEmailNoSend :: JSON ::: UserId ::: Request -> Handler Response
+changeSelfEmailNoSend (_ ::: u ::: req) = changeEmail u req False
+
 checkUserExists :: UserId ::: UserId -> Handler Response
 checkUserExists (self ::: uid) = do
     exists <- lift $ isJust <$> API.lookupProfile self uid
@@ -1388,17 +1397,8 @@ sendActivationCode (_ ::: req) = do
     API.sendActivationCode saUserKey saLocale saCall !>> sendActCodeError
     return empty
 
-changeEmail :: JSON ::: UserId ::: ConnId ::: Request -> Handler Response
-changeEmail (_ ::: u ::: _ ::: req) = do
-    email  <- euEmail <$> parseJsonBody req
-    (adata, en) <- API.changeEmail u email !>> changeEmailError
-    usr <- maybe (throwStd invalidUser) return =<< lift (API.lookupUser u)
-    let apair = (activationKey adata, activationCode adata)
-    let name  = userName usr
-    let ident = userIdentity usr
-    let lang  = userLocale usr
-    lift $ sendActivationMail en name apair (Just lang) ident
-    return $ setStatus status202 empty
+changeSelfEmail :: JSON ::: UserId ::: ConnId ::: Request -> Handler Response
+changeSelfEmail (_ ::: u ::: _ ::: req) = changeEmail u req True
 
 -- Deprecated and to be removed after new versions of brig and galley are
 -- deployed. Reason for deprecation: it returns N^2 things (which is not
@@ -1563,6 +1563,23 @@ activate (Activate tgt code dryrun)
   where
     respond (Just ident) first = setStatus status200 $ json (ActivationResponse ident first)
     respond Nothing      _     = setStatus status200 empty
+
+changeEmail :: UserId -> Request -> Bool -> Handler Response
+changeEmail u req sendOutEmail = do
+    email <- euEmail <$> parseJsonBody req
+    API.changeEmail u email !>> changeEmailError >>= \case
+        ChangeEmailIdempotent                       -> respond status204
+        ChangeEmailNeedsActivation (usr, adata, en) -> handleActivation usr adata en
+  where
+    respond = return . flip setStatus empty
+    handleActivation usr adata en = do
+        when sendOutEmail $ do
+            let apair = (activationKey adata, activationCode adata)
+            let name  = userName usr
+            let ident = userIdentity usr
+            let lang  = userLocale usr
+            lift $ sendActivationMail en name apair (Just lang) ident
+        respond status202
 
 validateHandle :: Text -> Handler Handle
 validateHandle = maybe (throwE (StdError invalidHandle)) return . parseHandle

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -428,6 +428,7 @@ sitemap o = do
         Doc.body (Doc.ref Doc.emailUpdate) $
             Doc.description "JSON body"
         Doc.response 202 "Update accepted and pending activation of the new email." Doc.end
+        Doc.response 204 "No update, current and new email address are the same." Doc.end
         Doc.errorResponse invalidEmail
         Doc.errorResponse userKeyExists
         Doc.errorResponse blacklistedEmail

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -55,6 +55,12 @@ data ActivationResult
     | ActivationPass
         -- ^ The key/code was valid but already recently activated.
 
+data ChangeEmailResult
+    = ChangeEmailNeedsActivation !(User, Activation, Email)
+        -- ^ The request was successful, user needs to verify the new email address
+    | ChangeEmailIdempotent
+        -- ^ The user asked to change the email address to the one already owned
+
 -------------------------------------------------------------------------------
 -- Failures
 

--- a/services/brig/src/Brig/Data/Activation.hs
+++ b/services/brig/src/Brig/Data/Activation.hs
@@ -85,18 +85,28 @@ activateKey k c u = verifyCode k c >>= pickUser >>= activate
                 lift $ activateUser uid ident
                 let a' = a { accountUser = (accountUser a) { userIdentity = Just ident } }
                 return . Just $ AccountActivated a'
-            Just _ ->
-                let oldKey = foldKey (\(_ :: Email) -> fmap userEmailKey . userEmail)
-                                     (\(_ :: Phone) -> fmap userPhoneKey . userPhone)
-                                     key
-                           $ accountUser a
-                in if oldKey == Just key then return Nothing else do
-                    -- ensure no password reset codes remain on activation of new email
-                    mkPasswordResetKey uid >>= lift . deletePasswordResetCode
-                    claim key uid
-                    lift $ foldKey (updateEmail uid) (updatePhone uid) key
-                    for_ oldKey $ lift . deleteKey
-                    return . Just $ foldKey (EmailActivated uid) (PhoneActivated uid) key
+            Just _ -> do
+                let usr = accountUser a
+                    (profileNeedsUpdate, oldKey) = foldKey (\(e :: Email) -> (Just e /= userEmail usr,) . fmap userEmailKey . userEmail)
+                                                       (\(p :: Phone) -> (Just p /= userPhone usr,) . fmap userPhoneKey . userPhone)
+                                                       key
+                                            $ usr
+                 in handleExistingIdentity uid profileNeedsUpdate oldKey key
+
+    handleExistingIdentity uid profileNeedsUpdate oldKey key
+        | oldKey == Just key && (not profileNeedsUpdate) = return Nothing
+        -- ^ activating existing key and exactly same profile
+        --   (can happen when a user clicks on activation links more than once)
+        | oldKey == Just key && profileNeedsUpdate       = do
+            lift $ foldKey (updateEmail uid) (updatePhone uid) key
+            return . Just $ foldKey (EmailActivated uid) (PhoneActivated uid) key
+        -- ^ if the key is the same, we only want to update our profile
+        | otherwise                    = do
+            mkPasswordResetKey uid >>= lift . deletePasswordResetCode
+            claim key uid
+            lift $ foldKey (updateEmail uid) (updatePhone uid) key
+            for_ oldKey $ lift . deleteKey
+            return . Just $ foldKey (EmailActivated uid) (PhoneActivated uid) key
 
     claim key uid = do
         ok <- lift $ claimKey key uid

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -93,7 +93,7 @@ tests conf p db b c g = do
             , test p "update"         $ testUpdateProvider db b
             , test p "delete"         $ testDeleteProvider db b
             , test p "password-reset" $ testPasswordResetProvider db b
-            , test p "email/password update with password reset" 
+            , test p "email/password update with password reset"
                                       $ testPasswordResetAfterEmailUpdateProvider db b
             ]
         , testGroup "service"
@@ -123,7 +123,7 @@ tests conf p db b c g = do
 -- of pre- and post-conditions.
 testRegisterProvider :: DB.ClientState -> Brig -> Http ()
 testRegisterProvider db brig = do
-    email <- mkEmail "success@simulator.amazonses.com"
+    email <- mkSimulatorEmail "simulator.amazonses.com"
     gen   <- Code.mkGen (Code.ForEmail email)
 
     let new = defNewProvider email
@@ -225,11 +225,11 @@ testPasswordResetProvider db brig = do
     let email = providerEmail prv
     initiatePasswordResetProvider brig (PasswordReset email) !!! const 201 === statusCode
     let newPw = PlainTextPassword "newsupersecret"
-    
+
     -- Get the code directly from the DB
     gen <- Code.mkGen (Code.ForEmail email)
     Just vcode <- lookupCode db gen Code.PasswordReset
-    
+
     let passwordResetData = CompletePasswordReset (Code.codeKey vcode)
                                                   (Code.codeValue vcode)
                                                   newPw
@@ -242,7 +242,7 @@ testPasswordResetProvider db brig = do
 
 testPasswordResetAfterEmailUpdateProvider :: DB.ClientState -> Brig -> Http ()
 testPasswordResetAfterEmailUpdateProvider db brig = do
-    newEmail <- mkEmail "success@simulator.amazonses.com"
+    newEmail <- mkSimulatorEmail "success"
     prv <- randomProvider db brig
     let pid = providerId prv
     let origEmail = providerEmail prv
@@ -252,7 +252,7 @@ testPasswordResetAfterEmailUpdateProvider db brig = do
     -- Get password reset code directly from the DB
     genOrig <- Code.mkGen (Code.ForEmail origEmail)
     Just vcodePw <- lookupCode db genOrig Code.PasswordReset
-    
+
     let passwordResetData = CompletePasswordReset (Code.codeKey vcodePw)
                                                   (Code.codeValue vcodePw)
                                                   (PlainTextPassword "doesnotmatter")
@@ -990,7 +990,7 @@ lookupCode db gen = liftIO . DB.runClient db . Code.lookup (Code.genKey gen)
 
 randomProvider :: HasCallStack => DB.ClientState -> Brig -> Http Provider
 randomProvider db brig = do
-    email <- mkEmail "success@simulator.amazonses.com"
+    email <- mkSimulatorEmail "success"
     gen   <- Code.mkGen (Code.ForEmail email)
     -- Register
     let new = defNewProvider email

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -123,7 +123,7 @@ tests conf p db b c g = do
 -- of pre- and post-conditions.
 testRegisterProvider :: DB.ClientState -> Brig -> Http ()
 testRegisterProvider db brig = do
-    email <- mkSimulatorEmail "simulator.amazonses.com"
+    email <- mkSimulatorEmail "success"
     gen   <- Code.mkGen (Code.ForEmail email)
 
     let new = defNewProvider email

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -346,7 +346,6 @@ testActivateWithExpiry brig timeout = do
                 const 200 === statusCode
                 const (Just (userIdentity u, True)) === actualBody
             -- Note: This value must be larger than the option passed as `activation-timeout`
-            liftIO $ print timeout
             awaitExpiry (round timeout + 5) kc
             activate brig kc !!! const 404 === statusCode
   where
@@ -357,9 +356,7 @@ testActivateWithExpiry brig timeout = do
     awaitExpiry :: Int -> ActivationPair -> Http ()
     awaitExpiry n kc = do
         liftIO $ threadDelay 1000000
-        liftIO $ print ("Going..." :: String)
         r <- activate brig kc
-        liftIO $ print (statusCode r)
         when (statusCode r == 204 && n > 0) $
             awaitExpiry (n-1) kc
 

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -55,7 +55,7 @@ checkHandles brig uid hs num =
 -- TODO: register
 registerUser :: Text -> Text -> Brig -> Http ResponseLBS
 registerUser name email brig = do
-    e <- mkEmail email
+    e <- mkEmailRandomLocalSuffix email
     let p = RequestBodyLBS . encode $ object
             [ "name"     .= name
             , "email"    .= fromEmail e
@@ -111,6 +111,11 @@ initiateEmailUpdate :: Brig -> Email -> UserId -> Http ResponseLBS
 initiateEmailUpdate brig email uid =
     let emailUpdate = RequestBodyLBS . encode $ EmailUpdate email in
     put (brig . path "/self/email" . contentJson . zUser uid . zConn "c" . body emailUpdate)
+
+initiateEmailUpdateNoSend :: Brig -> Email -> UserId -> Http ResponseLBS
+initiateEmailUpdateNoSend brig email uid =
+    let emailUpdate = RequestBodyLBS . encode $ EmailUpdate email in
+    put (brig . path "/i/self/email" . contentJson . zUser uid . body emailUpdate)
 
 preparePasswordReset :: Brig -> Email -> UserId -> PlainTextPassword -> Http CompletePasswordReset
 preparePasswordReset brig email uid newpw = do

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -147,7 +147,7 @@ getConnection brig from to = get $ brig
 -- more flexible variant of 'createUser' (see above).
 postUser :: Text -> Maybe Text -> Maybe InvitationCode -> Maybe UserSSOId -> Maybe TeamId -> Brig -> Http ResponseLBS
 postUser name email invCode ssoid teamid brig = do
-    email' <- maybe (pure Nothing) (fmap (Just . fromEmail) . mkEmail) email
+    email' <- maybe (pure Nothing) (fmap (Just . fromEmail) . mkEmailRandomLocalSuffix) email
     let p = RequestBodyLBS . encode $ object
             [ "name"            .= name
             , "email"           .= email'
@@ -345,9 +345,8 @@ decodeBody = responseBody >=> decode'
 asValue :: Response (Maybe Lazy.ByteString) -> Maybe Value
 asValue = decodeBody
 
--- TODO: randomiseEmail
-mkEmail :: MonadIO m => Text -> m Email
-mkEmail e = do
+mkEmailRandomLocalSuffix :: MonadIO m => Text -> m Email
+mkEmailRandomLocalSuffix e = do
     uid <- liftIO UUID.nextRandom
     case parseEmail e of
         Just (Email loc dom) -> return $ Email (loc <> "+" <> UUID.toText uid) dom
@@ -357,7 +356,7 @@ randomEmail :: MonadIO m => m Email
 randomEmail = mkSimulatorEmail "success"
 
 mkSimulatorEmail :: MonadIO m => Text -> m Email
-mkSimulatorEmail loc = mkEmail (loc <> "@simulator.amazonses.com")
+mkSimulatorEmail loc = mkEmailRandomLocalSuffix (loc <> "@simulator.amazonses.com")
 
 randomPhone :: MonadIO m => m Phone
 randomPhone = liftIO $ do


### PR DESCRIPTION
This PR includes the following changes:
   * if a user tries to change the email to the exact same address, a 204 is returned
   * if a user tries to change the local address of a verified email address, the change can now be seen also on the user's profile

Due to the fact that we need to test out non-trusted addresses ([meaning from domains not listed here](https://github.com/wireapp/wire-server/blob/fe39c4435fa87b2ff993886b47c9da8e7819c689/services/brig/src/Brig/Email.hs#L110)), a new internal endpoint was added so that an _actual email_ is not sent out (that could potentially give us problems with bounces)