### PR TITLE
Differentiate between "expected" and "unexpected" 404

### DIFF
--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -176,7 +176,10 @@ compile routes = Route.prepare (Route.renderer predicateError >> routes)
     messageStr Nothing  = mempty
 
 route :: (MonadCatch m, MonadIO m) => Tree (App m) -> Request -> Continue IO -> m ResponseReceived
-route rt rq k = Route.route rt rq (liftIO . k)
+route rt rq k = Route.routeWithCustomNotFoundResponse (errorRs' notFound) rt rq (liftIO . k)
+  where
+    notFound :: Error
+    notFound = Error status404 "no-such-endpoint" "The requested endpoint does not exist"
 {-# INLINEABLE route #-}
 
 --------------------------------------------------------------------------------

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -176,10 +176,9 @@ compile routes = Route.prepare (Route.renderer predicateError >> routes)
     messageStr Nothing  = mempty
 
 route :: (MonadCatch m, MonadIO m) => Tree (App m) -> Request -> Continue IO -> m ResponseReceived
-route rt rq k = Route.routeWithCustomNotFoundResponse (errorRs' notFound) rt rq (liftIO . k)
+route rt rq k = Route.routeWith (Route.Config $ errorRs' noEndpoint) rt rq (liftIO . k)
   where
-    notFound :: Error
-    notFound = Error status404 "no-such-endpoint" "The requested endpoint does not exist"
+    noEndpoint = Error status404 "no-endpoint" "The requested endpoint does not exist"
 {-# INLINEABLE route #-}
 
 --------------------------------------------------------------------------------

--- a/stack.yaml
+++ b/stack.yaml
@@ -50,6 +50,10 @@ packages:
     git: https://github.com/tiago-loureiro/aws
     commit: bade13d1f73ed82c2b3eafda0bcb16d283da909e
   extra-dep: true
+- location:
+    git: https://gitlab.com/twittner/wai-routing
+    commit: 7e996a93fec5901767f845a50316b3c18e51a61d
+  extra-dep: true
 
 extra-deps:
 - base58-bytestring-0.1.0


### PR DESCRIPTION
We want to treat
```
HTTP/1.1 404 Not Found
Date: Tue, 12 Sep 2017 12:15:37 GMT
Server: Warp/3.2.11.2
Transfer-Encoding: chunked
```

differently from

```
HTTP/1.1 404 Not Found
Content-Type: application/json
Date: Tue, 12 Sep 2017 12:15:18 GMT
Server: Warp/3.2.11.2
Transfer-Encoding: chunked

{
    "code": 404, 
    "label": "...", 
    "message": "..."
}
```

i.e., the first one is an endpoint that does not exist while the second is an endpoint that _does_ exist and a `404` is an expected code from the APIs PoV (e.g., when calling `/notifications`)