### PR TITLE
Fix: wait for dynamo to come up before attempting to delete stale tables.

### DIFF
--- a/deploy/docker-ephemeral/init.sh
+++ b/deploy/docker-ephemeral/init.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 exec_until_ready() {
         until $1; do echo 'service not ready yet'; sleep 1; done
@@ -11,6 +11,11 @@ aws configure set aws_secret_access_key dummysecret
 aws configure set region eu-west-1
 
 # Potentially delete pre-existing tables
+echo -n "waiting for dynamo: "
+while (! aws --endpoint-url=http://dynamodb:8000 --cli-connect-timeout=1 dynamodb list-tables); do
+    sleep 1;
+done
+echo " [ok!]"
 aws --endpoint-url=http://dynamodb:8000 dynamodb delete-table --table-name integration-brig-userkey-blacklist || true
 aws --endpoint-url=http://dynamodb:8000 dynamodb delete-table --table-name integration-brig-prekeys || true
 


### PR DESCRIPTION
rebased and tested on two machines.  it seems to work at least as good as before, and i could not reproduce the race condition that motivated this.