### PR TITLE
Turn hostnames

### DIFF
--- a/libs/brig-types/brig-types.cabal
+++ b/libs/brig-types/brig-types.cabal
@@ -31,6 +31,7 @@ library
         Brig.Types.Swagger
         Brig.Types.Team.Invitation
         Brig.Types.TURN
+        Brig.Types.TURN.Internal
         Brig.Types.User
         Brig.Types.User.Auth
 

--- a/libs/brig-types/brig-types.cabal
+++ b/libs/brig-types/brig-types.cabal
@@ -48,6 +48,7 @@ library
       , galley-types          >= 0.45.7
       , errors                >= 1.4
       , hashable
+      , hostname-validate
       , iproute               >= 1.5
       , iso3166-country-codes >= 0.2
       , iso639                >= 0.1
@@ -90,6 +91,7 @@ test-suite brig-types-tests
       , bytestring
       , currency-codes
       , galley-types
+      , hostname-validate
       , iproute
       , iso639
       , lens

--- a/libs/brig-types/src/Brig/Types/TURN.hs
+++ b/libs/brig-types/src/Brig/Types/TURN.hs
@@ -25,8 +25,7 @@ module Brig.Types.TURN
     , Transport (..)
 
     , TurnHost (..)
-    , _TurnHost
-
+    , isHostName
     , TurnUsername
     , turnUsername
     , tuExpiresAt
@@ -45,7 +44,7 @@ import           Data.ByteString            (ByteString)
 import           Data.ByteString.Builder
 import qualified Data.ByteString.Conversion as BC
 import           Data.List1
-import           Data.Misc                  (IpAddr, Port (..))
+import           Data.Misc                  (IpAddr (..), Port (..))
 import           Data.Monoid
 import           Data.Text                  (Text)
 import           Data.Text.Ascii
@@ -55,6 +54,7 @@ import           Data.Time.Clock.POSIX
 import           Data.Word
 import           GHC.Base                   (Alternative)
 import           GHC.Generics               (Generic)
+import           Text.Hostname
 
 -- | A configuration object resembling \"RTCConfiguration\"
 --
@@ -100,9 +100,13 @@ data Transport = TransportUDP
                | TransportTCP
                deriving (Eq, Show, Generic, Enum, Bounded)
 
--- future versions may allow using a hostname
-newtype TurnHost = TurnHost IpAddr
+data TurnHost = TurnHostIp IpAddr
+              | TurnHostName Text
     deriving (Eq, Show, Generic)
+
+isHostName :: TurnHost -> Bool
+isHostName (TurnHostIp   _) = False
+isHostName (TurnHostName _) = True
 
 data TurnUsername = TurnUsername
     { _tuExpiresAt :: POSIXTime
@@ -121,10 +125,6 @@ rtcIceServer = RTCIceServer
 
 turnURI :: Scheme -> TurnHost -> Port -> Maybe Transport -> TurnURI
 turnURI = TurnURI
-
--- turn into a 'Prism'' once hostnames are supported
-_TurnHost :: Iso' TurnHost IpAddr
-_TurnHost = iso (\(TurnHost ip) -> ip) TurnHost
 
 -- note that the random value is not checked for well-formedness
 turnUsername :: POSIXTime -> Text -> TurnUsername
@@ -163,8 +163,23 @@ instance FromJSON RTCIceServer where
     parseJSON = withObject "RTCIceServer" $ \o ->
         RTCIceServer <$> o .: "urls" <*> o .: "username" <*> o .: "credential"
 
+parseTurnHost :: Text -> Maybe TurnHost
+parseTurnHost h = case BC.fromByteString host of
+    Just ip@(IpAddr _)           -> Just $ TurnHostIp ip
+    Nothing | validHostname host -> Just $ TurnHostName h -- NOTE: IPv4 addresses are also valid hostnames...
+    _                            -> Nothing
+  where
+    host = TE.encodeUtf8 h
+
+instance BC.FromByteString TurnHost where
+    parser = BC.parser >>= maybe (fail "Invalid turn host") return . parseTurnHost
+
+instance BC.ToByteString TurnHost where
+    builder (TurnHostIp ip)  = BC.builder ip
+    builder (TurnHostName n) = BC.builder n
+
 instance BC.ToByteString TurnURI where
-    builder (TurnURI s (TurnHost h) (Port p) tp) =
+    builder (TurnURI s h (Port p) tp) =
            BC.builder s
         <> byteString ":"
         <> BC.builder h
@@ -191,7 +206,7 @@ parseTurnURI = parseOnly (parser <* endOfInput)
           <*> ((optional ((string "?transport=" *> takeText) >>= parseTransport)) <?> "parsingTransport")
 
     parseScheme    = parse "parseScheme"
-    parseHost      = fmap TurnHost . parse "parseHost"
+    parseHost      = parse "parseHost"
     parseTransport = parse "parseTransport"
 
     parse :: (BC.FromByteString b, Monad m) => String -> Text -> m b

--- a/libs/brig-types/src/Brig/Types/TURN.hs
+++ b/libs/brig-types/src/Brig/Types/TURN.hs
@@ -24,8 +24,10 @@ module Brig.Types.TURN
     , turiTransport
     , Transport (..)
 
-    , TurnHost (..)
+    , TurnHost -- Re-export
     , isHostName
+    , parseTurnHost
+
     , TurnUsername
     , turnUsername
     , tuExpiresAt
@@ -36,6 +38,7 @@ module Brig.Types.TURN
     )
 where
 
+import           Brig.Types.TURN.Internal
 import           Control.Lens               hiding ((.=))
 import           Data.Aeson
 import           Data.Aeson.Encoding        (text)
@@ -44,7 +47,7 @@ import           Data.ByteString            (ByteString)
 import           Data.ByteString.Builder
 import qualified Data.ByteString.Conversion as BC
 import           Data.List1
-import           Data.Misc                  (IpAddr (..), Port (..))
+import           Data.Misc                  (Port (..))
 import           Data.Monoid
 import           Data.Text                  (Text)
 import           Data.Text.Ascii
@@ -54,7 +57,6 @@ import           Data.Time.Clock.POSIX
 import           Data.Word
 import           GHC.Base                   (Alternative)
 import           GHC.Generics               (Generic)
-import           Text.Hostname
 
 -- | A configuration object resembling \"RTCConfiguration\"
 --
@@ -99,14 +101,6 @@ data Scheme = SchemeTurn
 data Transport = TransportUDP
                | TransportTCP
                deriving (Eq, Show, Generic, Enum, Bounded)
-
-data TurnHost = TurnHostIp IpAddr
-              | TurnHostName Text
-    deriving (Eq, Show, Generic)
-
-isHostName :: TurnHost -> Bool
-isHostName (TurnHostIp   _) = False
-isHostName (TurnHostName _) = True
 
 data TurnUsername = TurnUsername
     { _tuExpiresAt :: POSIXTime
@@ -163,21 +157,6 @@ instance FromJSON RTCIceServer where
     parseJSON = withObject "RTCIceServer" $ \o ->
         RTCIceServer <$> o .: "urls" <*> o .: "username" <*> o .: "credential"
 
-parseTurnHost :: Text -> Maybe TurnHost
-parseTurnHost h = case BC.fromByteString host of
-    Just ip@(IpAddr _)           -> Just $ TurnHostIp ip
-    Nothing | validHostname host -> Just $ TurnHostName h -- NOTE: IPv4 addresses are also valid hostnames...
-    _                            -> Nothing
-  where
-    host = TE.encodeUtf8 h
-
-instance BC.FromByteString TurnHost where
-    parser = BC.parser >>= maybe (fail "Invalid turn host") return . parseTurnHost
-
-instance BC.ToByteString TurnHost where
-    builder (TurnHostIp ip)  = BC.builder ip
-    builder (TurnHostName n) = BC.builder n
-
 instance BC.ToByteString TurnURI where
     builder (TurnURI s h (Port p) tp) =
            BC.builder s
@@ -213,10 +192,6 @@ parseTurnURI = parseOnly (parser <* endOfInput)
     parse err x = case BC.fromByteString (TE.encodeUtf8 x) of
         Just ok -> return ok
         Nothing -> fail (err ++ " failed when parsing: " ++ show x)
-
-instance ToJSON   TurnHost
-instance FromJSON TurnHost
-
 
 instance ToJSON TurnUsername where
     toEncoding = text . view utf8 . BC.toByteString'

--- a/libs/brig-types/src/Brig/Types/TURN/Internal.hs
+++ b/libs/brig-types/src/Brig/Types/TURN/Internal.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Brig.Types.TURN.Internal where
+
+import Data.Aeson
+import Data.Misc (IpAddr (..))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import qualified Data.ByteString.Conversion as BC
+import qualified Data.Text.Encoding         as TE
+import           Text.Hostname
+
+data TurnHost = TurnHostIp IpAddr
+              | TurnHostName Text
+    deriving (Eq, Show, Generic)
+
+isHostName :: TurnHost -> Bool
+isHostName (TurnHostIp   _) = False
+isHostName (TurnHostName _) = True
+
+parseTurnHost :: Text -> Maybe TurnHost
+parseTurnHost h = case BC.fromByteString host of
+    Just ip@(IpAddr _)           -> Just $ TurnHostIp ip
+    Nothing | validHostname host -> Just $ TurnHostName h -- NOTE: IP addresses are also valid hostnames
+    _                            -> Nothing
+  where
+    host = TE.encodeUtf8 h
+
+instance BC.FromByteString TurnHost where
+    parser = BC.parser >>= maybe (fail "Invalid turn host") return . parseTurnHost
+
+instance BC.ToByteString TurnHost where
+    builder (TurnHostIp ip)  = BC.builder ip
+    builder (TurnHostName n) = BC.builder n
+
+instance ToJSON   TurnHost
+instance FromJSON TurnHost

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -32,6 +32,7 @@ import Data.Misc
 import Data.Monoid
 import Data.Range
 import Data.Text.Ascii
+import Data.Text.Encoding (encodeUtf8)
 import Data.Typeable
 import Data.Word
 import Galley.Types.Bot.Service.Internal
@@ -41,6 +42,8 @@ import GHC.Stack
 import GHC.TypeLits
 import Test.QuickCheck
 import Test.QuickCheck.Instances ()
+import Text.Hostname
+
 
 import qualified Data.Text as ST
 import qualified System.Random
@@ -71,7 +74,10 @@ instance Arbitrary IpAddr where
         ipV4Part = octet <$> arbitrary
 
 instance Arbitrary TurnHost where
-    arbitrary = TurnHost <$> arbitrary
+    arbitrary = oneof
+              [ TurnHostIp   <$> arbitrary
+              , TurnHostName <$> arbitrary `suchThat` (validHostname . encodeUtf8)
+              ]
 
 instance Arbitrary Port where
     arbitrary = Port <$> arbitrary

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -17,6 +17,7 @@ module Test.Brig.Types.Arbitrary where
 import Brig.Types.Activation
 import Brig.Types.Code
 import Brig.Types.TURN
+import Brig.Types.TURN.Internal
 import Brig.Types.User
 import Brig.Types.User.Auth
 import Control.Lens hiding (elements)

--- a/services/brig/src/Brig/TURN/API.hs
+++ b/services/brig/src/Brig/TURN/API.hs
@@ -9,7 +9,7 @@ module Brig.TURN.API (routes) where
 
 import Brig.App
 import Brig.TURN hiding (Env)
-import Brig.Types.TURN 
+import Brig.Types.TURN
 import Brig.API.Error (badTURNconfig)
 import Brig.API.Handler
 import Control.Lens
@@ -51,8 +51,8 @@ routes = do
         .&. header "Z-Connection"
 
     document "GET" "getCallsConfig" $ do
-        Doc.summary "Retrieve TURN server addresses and credentials \
-                    \ for scheme `turn` and transport `udp` "
+        Doc.summary "Retrieve TURN server addresses and credentials for \
+                    \ IPv4 addresses, scheme `turn` and transport `udp` only "
         Doc.returns (Doc.ref Doc.rtcConfiguration)
         Doc.response 200 "RTCConfiguration" Doc.end
 
@@ -62,35 +62,43 @@ routes = do
         .&. header "Z-Connection"
 
     document "GET" "getCallsConfigV2" $ do
-        Doc.summary "Retrieve all TURN server addresses and credentials."
+        Doc.summary "Retrieve all TURN server addresses and credentials. \
+                    \Clients are expected to do a DNS lookup to resolve \
+                    \the IP addresses of the given hostnames "
         Doc.returns (Doc.ref Doc.rtcConfiguration)
         Doc.response 200 "RTCConfiguration" Doc.end
 
 getCallsConfigV2 :: JSON ::: UserId ::: ConnId -> Handler Response
-getCallsConfigV2 (_ ::: _ ::: _) = json <$> lift (newConfig Nothing)
+getCallsConfigV2 (_ ::: _ ::: _) = json <$> lift (newConfig fn)
+  where
+    fn = isHostName . view turiHost
 
 getCallsConfig :: JSON ::: UserId ::: ConnId -> Handler Response
-getCallsConfig (_ ::: _ ::: _) = json . dropTransport <$> lift (newConfig (Just ([SchemeTurn], [Just TransportUDP, Nothing])))
+getCallsConfig (_ ::: _ ::: _) = json . dropTransport <$> lift (newConfig fn)
   where
+    fn uri =  uri^.turiScheme == SchemeTurn
+           && not (isHostName (uri^.turiHost))
+           && uri^.turiTransport `elem` [Just TransportUDP, Nothing]
     -- In order to avoid being backwards incompatible, remove the `transport` query param from the URIs
     dropTransport :: RTCConfiguration -> RTCConfiguration
     dropTransport = set (rtcConfIceServers . traverse . iceURLs . traverse . turiTransport) Nothing
 
 newConfig :: (MonadThrow m, MonadIO m, MonadReader Env m)
-          => Maybe ([Scheme], [Maybe Transport])
+          => (TurnURI -> Bool)
+          -- ^ Predicate that given a TurnURI returns True if
+          --   that TurnURI is supported for the given configuration
           -> m RTCConfiguration
 newConfig fn = do
     env  <- liftIO =<< readIORef <$> view turnEnv
     let (sha, secret, tTTL, cTTL, prng) = (env^.turnSHA512, env^.turnSecret, env^.turnTokenTTL, env^.turnConfigTTL, env^.turnPrng)
-    uris <- filterSuitableURIs fn =<< (liftIO $ randomize (env^.turnServers))
+    uris <- liftIO . randomize =<< filterSuitableURIs (env^.turnServers)
     srvs <- for uris $ \uri -> do
                 u <- liftIO $ genUsername tTTL prng
                 pure $ rtcIceServer (List1.singleton uri) u (computeCred sha secret u)
     pure $ rtcConfiguration srvs cTTL
   where
-    filterSuitableURIs :: MonadThrow m => Maybe ([Scheme], [Maybe Transport]) -> List1 TurnURI -> m (List1 TurnURI)
-    filterSuitableURIs Nothing       uris = return uris
-    filterSuitableURIs (Just (s, t)) uris = case filter (\x -> view turiScheme x `elem` s && view turiTransport x `elem` t) (toList uris) of
+    filterSuitableURIs :: MonadThrow m => List1 TurnURI -> m (List1 TurnURI)
+    filterSuitableURIs uris = case filter fn (toList uris) of
         []     -> throwM badTURNconfig
         (x:xs) -> return $ List1.list1 x xs
 

--- a/services/brig/src/Brig/TURN/API.hs
+++ b/services/brig/src/Brig/TURN/API.hs
@@ -52,7 +52,7 @@ routes = do
 
     document "GET" "getCallsConfig" $ do
         Doc.summary "Retrieve TURN server addresses and credentials for \
-                    \ IPv4 addresses, scheme `turn` and transport `udp` only "
+                    \ IP addresses, scheme `turn` and transport `udp` only "
         Doc.returns (Doc.ref Doc.rtcConfiguration)
         Doc.response 200 "RTCConfiguration" Doc.end
 


### PR DESCRIPTION
This PR adds support for hostnames in TURN URIs by allowing hostnames in the form of either `IPv4` addresses or _valid hostnames_. To be noted that _valid hostnames_ also _include_ `IPv4` addresses.

`TurnHost` can only be constructed using `parseTurnHost` (unless you import an `Internal` module) and it tries to first parse a given TURN address as an IP address; if that fails, the fallback is to parse it as a [valid hostname](https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_hostnames).

`/calls/config` remains as-(is/was); `/calls/config/v2` was not used until now so we have changed that endpoint to advertise turn uri that have a valid hostname.

The turn file then may contain both plain IP address and hostnames; at the application level, we filter `TurnHost` based on `isHostName`