### PR TITLE
Make UTCTimeMillis abstract and fix Eq, Show instances.

### DIFF
--- a/libs/brig-types/src/Brig/Types/Client.hs
+++ b/libs/brig-types/src/Brig/Types/Client.hs
@@ -16,7 +16,8 @@ import Data.Id
 import Data.Json.Util
 import Data.Misc (Location, PlainTextPassword (..))
 import Data.Text (Text)
-import Data.Time (UTCTime)
+
+
 -- * Data Types:
 
 data ClientType
@@ -58,7 +59,7 @@ newClient t k a = NewClient
 data Client = Client
     { clientId       :: !ClientId
     , clientType     :: !ClientType
-    , clientTime     :: !UTCTime
+    , clientTime     :: !UTCTimeMillis
     , clientClass    :: !(Maybe ClientClass)
     , clientLabel    :: !(Maybe Text)
     , clientCookie   :: !(Maybe CookieLabel)
@@ -90,7 +91,7 @@ instance ToJSON Client where
         # "type"     .= clientType c
         # "label"    .= clientLabel c
         # "class"    .= clientClass c
-        # "time"     .= toUTCTimeMillis (clientTime c)
+        # "time"     .= clientTime c
         # "cookie"   .= clientCookie c
         # "location" .= clientLocation c
         # "model"    .= clientModel c

--- a/libs/brig-types/src/Brig/Types/Client.hs
+++ b/libs/brig-types/src/Brig/Types/Client.hs
@@ -90,7 +90,7 @@ instance ToJSON Client where
         # "type"     .= clientType c
         # "label"    .= clientLabel c
         # "class"    .= clientClass c
-        # "time"     .= UTCTimeMillis (clientTime c)
+        # "time"     .= toUTCTimeMillis (clientTime c)
         # "cookie"   .= clientCookie c
         # "location" .= clientLocation c
         # "model"    .= clientModel c

--- a/libs/brig-types/src/Brig/Types/Connection.hs
+++ b/libs/brig-types/src/Brig/Types/Connection.hs
@@ -129,7 +129,7 @@ instance ToJSON UserConnection where
         [ "from"         .= ucFrom uc
         , "to"           .= ucTo uc
         , "status"       .= ucStatus uc
-        , "last_update"  .= UTCTimeMillis (ucLastUpdate uc)
+        , "last_update"  .= toUTCTimeMillis (ucLastUpdate uc)
         , "message"      .= ucMessage uc
         , "conversation" .= ucConvId uc
         ]
@@ -179,7 +179,7 @@ instance ToJSON Invitation where
     toJSON i = object [ "inviter"       .= inInviter i
                       , "id"            .= inInvitation i
                       , either ("email" .=) ("phone" .=) (inIdentity i)
-                      , "created_at"    .= UTCTimeMillis (inCreatedAt i)
+                      , "created_at"    .= toUTCTimeMillis (inCreatedAt i)
                       , "name"          .= inName i
                       ]
 

--- a/libs/brig-types/src/Brig/Types/Connection.hs
+++ b/libs/brig-types/src/Brig/Types/Connection.hs
@@ -39,7 +39,7 @@ data UserConnection = UserConnection
     { ucFrom       :: !UserId
     , ucTo         :: !UserId
     , ucStatus     :: !Relation
-    , ucLastUpdate :: !UTCTime
+    , ucLastUpdate :: !UTCTimeMillis
     , ucMessage    :: !(Maybe Message)
     , ucConvId     :: !(Maybe ConvId)
     } deriving (Eq, Show)
@@ -129,7 +129,7 @@ instance ToJSON UserConnection where
         [ "from"         .= ucFrom uc
         , "to"           .= ucTo uc
         , "status"       .= ucStatus uc
-        , "last_update"  .= toUTCTimeMillis (ucLastUpdate uc)
+        , "last_update"  .= ucLastUpdate uc
         , "message"      .= ucMessage uc
         , "conversation" .= ucConvId uc
         ]

--- a/libs/brig-types/src/Brig/Types/Team/Invitation.hs
+++ b/libs/brig-types/src/Brig/Types/Team/Invitation.hs
@@ -49,7 +49,7 @@ instance ToJSON Invitation where
     toJSON i = object [ "team"       .= inTeam i
                       , "id"            .= inInvitation i
                       , "email"         .= inIdentity i
-                      , "created_at"    .= UTCTimeMillis (inCreatedAt i)
+                      , "created_at"    .= toUTCTimeMillis (inCreatedAt i)
                       ]
 
 instance ToJSON InvitationList where

--- a/libs/brig-types/src/Brig/Types/Team/Invitation.hs
+++ b/libs/brig-types/src/Brig/Types/Team/Invitation.hs
@@ -6,7 +6,6 @@ import Brig.Types.Common
 import Data.Aeson
 import Data.Id
 import Data.Json.Util
-import Data.Time.Clock (UTCTime)
 
 data InvitationRequest = InvitationRequest
     { irEmail    :: !Email
@@ -18,7 +17,7 @@ data Invitation = Invitation
     { inTeam       :: !TeamId
     , inInvitation :: !InvitationId
     , inIdentity   :: !Email
-    , inCreatedAt  :: !UTCTime
+    , inCreatedAt  :: !UTCTimeMillis
     } deriving (Eq, Show)
 
 data InvitationList = InvitationList
@@ -49,7 +48,7 @@ instance ToJSON Invitation where
     toJSON i = object [ "team"       .= inTeam i
                       , "id"            .= inInvitation i
                       , "email"         .= inIdentity i
-                      , "created_at"    .= toUTCTimeMillis (inCreatedAt i)
+                      , "created_at"    .= inCreatedAt i
                       ]
 
 instance ToJSON InvitationList where

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -21,7 +21,7 @@ import Data.Aeson
 import Data.Aeson.Types (Parser, Pair)
 import Data.ByteString.Conversion
 import Data.Id
-import Data.Json.Util ((#), UTCTimeMillis (..))
+import Data.Json.Util ((#), toUTCTimeMillis)
 import Data.Maybe (isJust)
 import Data.Misc (PlainTextPassword (..))
 import Data.Range
@@ -175,7 +175,7 @@ instance ToJSON User where
         # "locale"     .= userLocale u
         # "service"    .= userService u
         # "handle"     .= userHandle u
-        # "expires_at" .= (UTCTimeMillis <$> userExpire u)
+        # "expires_at" .= (toUTCTimeMillis <$> userExpire u)
         # "team"       .= userTeam u
         # "sso_id"     .= userSSOId u
         # []
@@ -221,7 +221,7 @@ instance ToJSON UserProfile where
         # "service"    .= profileService u
         # "handle"     .= profileHandle u
         # "locale"     .= profileLocale u
-        # "expires_at" .= (UTCTimeMillis <$> profileExpire u)
+        # "expires_at" .= (toUTCTimeMillis <$> profileExpire u)
         # "team"       .= profileTeam u
         # []
 

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -21,13 +21,12 @@ import Data.Aeson
 import Data.Aeson.Types (Parser, Pair)
 import Data.ByteString.Conversion
 import Data.Id
-import Data.Json.Util ((#), toUTCTimeMillis)
+import Data.Json.Util ((#), UTCTimeMillis)
 import Data.Maybe (isJust)
 import Data.Misc (PlainTextPassword (..))
 import Data.Range
 import Data.Text.Ascii
 import Data.Text (Text)
-import Data.Time (UTCTime)
 import Galley.Types.Bot (ServiceRef)
 import Galley.Types.Teams hiding (userId)
 
@@ -126,7 +125,7 @@ data User = User
         -- ^ Set if the user represents an external service,
         -- i.e. it is a "bot".
     , userHandle   :: !(Maybe Handle)
-    , userExpire   :: !(Maybe UTCTime)
+    , userExpire   :: !(Maybe UTCTimeMillis)
         -- ^ Set if the user is ephemeral
     , userTeam     :: !(Maybe TeamId)
         -- ^ Set if the user is part of a binding team
@@ -156,7 +155,7 @@ data UserProfile = UserProfile
         -- i.e. it is a "bot".
     , profileHandle   :: !(Maybe Handle)
     , profileLocale   :: !(Maybe Locale)
-    , profileExpire   :: !(Maybe UTCTime)
+    , profileExpire   :: !(Maybe UTCTimeMillis)
     , profileTeam     :: !(Maybe TeamId)
     }
     deriving (Eq, Show)
@@ -175,7 +174,7 @@ instance ToJSON User where
         # "locale"     .= userLocale u
         # "service"    .= userService u
         # "handle"     .= userHandle u
-        # "expires_at" .= (toUTCTimeMillis <$> userExpire u)
+        # "expires_at" .= userExpire u
         # "team"       .= userTeam u
         # "sso_id"     .= userSSOId u
         # []
@@ -221,7 +220,7 @@ instance ToJSON UserProfile where
         # "service"    .= profileService u
         # "handle"     .= profileHandle u
         # "locale"     .= profileLocale u
-        # "expires_at" .= (toUTCTimeMillis <$> profileExpire u)
+        # "expires_at" .= profileExpire u
         # "team"       .= profileTeam u
         # []
 

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -25,7 +25,7 @@ import Data.Currency
 import Data.Aeson
 import Data.Either
 import Data.IP
-import Data.Json.Util (UTCTimeMillis (..))
+import Data.Json.Util (UTCTimeMillis (..), toUTCTimeMillis)
 import Data.LanguageCodes
 import Data.Maybe
 import Data.Misc
@@ -219,7 +219,7 @@ instance Arbitrary NewUser where
 
 instance Arbitrary UTCTimeMillis where
     arbitrary = fromRight (error "instance Arbitrary UTCTimeMillis")
-              . eitherDecode . encode . UTCTimeMillis
+              . eitherDecode . encode . toUTCTimeMillis
             <$> arbitrary
 
 instance Arbitrary NewUserOrigin where

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -22,7 +22,10 @@ import Brig.Types.User.Auth
 import Control.Lens hiding (elements)
 import Control.Monad
 import Data.Currency
+import Data.Aeson
+import Data.Either
 import Data.IP
+import Data.Json.Util (UTCTimeMillis (..), toUTCTimeMillis)
 import Data.LanguageCodes
 import Data.Maybe
 import Data.Misc
@@ -214,6 +217,11 @@ instance Arbitrary NewUser where
         newUserExpiresIn  <- if isJust newUserIdentity then pure Nothing else arbitrary
         pure NewUser{..}
 
+instance Arbitrary UTCTimeMillis where
+    arbitrary = fromRight (error "instance Arbitrary UTCTimeMillis")
+              . eitherDecode . encode . toUTCTimeMillis
+            <$> arbitrary
+
 instance Arbitrary NewUserOrigin where
     arbitrary = oneof
         [ NewUserOriginInvitationCode <$> arbitrary
@@ -268,7 +276,7 @@ instance Arbitrary UserProfile where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
-        <*> arbitrary
+        <*> (fromUTCTimeMillis <$$> arbitrary)
         <*> arbitrary
 
 instance Arbitrary ServiceRef where
@@ -293,7 +301,7 @@ instance Arbitrary User where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
-        <*> arbitrary
+        <*> (fromUTCTimeMillis <$$> arbitrary)
         <*> arbitrary
 
 instance Arbitrary VerifyDeleteUser where

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -218,9 +218,7 @@ instance Arbitrary NewUser where
         pure NewUser{..}
 
 instance Arbitrary UTCTimeMillis where
-    arbitrary = fromRight (error "instance Arbitrary UTCTimeMillis")
-              . eitherDecode . encode . toUTCTimeMillis
-            <$> arbitrary
+    arbitrary = toUTCTimeMillis <$> arbitrary
 
 instance Arbitrary NewUserOrigin where
     arbitrary = oneof

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -276,7 +276,7 @@ instance Arbitrary UserProfile where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
-        <*> (fromUTCTimeMillis <$$> arbitrary)
+        <*> arbitrary
         <*> arbitrary
 
 instance Arbitrary ServiceRef where
@@ -301,7 +301,7 @@ instance Arbitrary User where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
-        <*> (fromUTCTimeMillis <$$> arbitrary)
+        <*> arbitrary
         <*> arbitrary
 
 instance Arbitrary VerifyDeleteUser where

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -22,8 +22,6 @@ import Brig.Types.User.Auth
 import Control.Lens hiding (elements)
 import Control.Monad
 import Data.Currency
-import Data.Aeson
-import Data.Either
 import Data.IP
 import Data.Json.Util (UTCTimeMillis (..), toUTCTimeMillis)
 import Data.LanguageCodes

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -22,10 +22,7 @@ import Brig.Types.User.Auth
 import Control.Lens hiding (elements)
 import Control.Monad
 import Data.Currency
-import Data.Aeson
-import Data.Either
 import Data.IP
-import Data.Json.Util (UTCTimeMillis (..), toUTCTimeMillis)
 import Data.LanguageCodes
 import Data.Maybe
 import Data.Misc
@@ -217,11 +214,6 @@ instance Arbitrary NewUser where
         newUserExpiresIn  <- if isJust newUserIdentity then pure Nothing else arbitrary
         pure NewUser{..}
 
-instance Arbitrary UTCTimeMillis where
-    arbitrary = fromRight (error "instance Arbitrary UTCTimeMillis")
-              . eitherDecode . encode . toUTCTimeMillis
-            <$> arbitrary
-
 instance Arbitrary NewUserOrigin where
     arbitrary = oneof
         [ NewUserOriginInvitationCode <$> arbitrary
@@ -276,7 +268,7 @@ instance Arbitrary UserProfile where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
-        <*> (fromUTCTimeMillis <$$> arbitrary)
+        <*> arbitrary
         <*> arbitrary
 
 instance Arbitrary ServiceRef where
@@ -301,7 +293,7 @@ instance Arbitrary User where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
-        <*> (fromUTCTimeMillis <$$> arbitrary)
+        <*> arbitrary
         <*> arbitrary
 
 instance Arbitrary VerifyDeleteUser where

--- a/libs/cargohold-types/src/CargoHold/Types/V3.hs
+++ b/libs/cargohold-types/src/CargoHold/Types/V3.hs
@@ -50,7 +50,7 @@ import Data.ByteString.Lazy (ByteString)
 import Data.ByteString.Builder
 import Data.ByteString.Conversion
 import Data.Id
-import Data.Json.Util ((#), UTCTimeMillis (..))
+import Data.Json.Util ((#), toUTCTimeMillis)
 import Data.Monoid
 import Data.Time.Clock
 import Data.Text (Text)
@@ -280,7 +280,7 @@ mkAsset k = Asset k Nothing Nothing
 instance ToJSON Asset where
     toJSON a = object
         $ "key"     .= _assetKey a
-        # "expires" .= fmap UTCTimeMillis (_assetExpires a)
+        # "expires" .= fmap toUTCTimeMillis (_assetExpires a)
         # "token"   .= _assetToken a
         # []
 
@@ -306,4 +306,3 @@ instance ToByteString Principal where
     builder (UserPrincipal     u) = builder u
     builder (BotPrincipal      b) = builder b
     builder (ProviderPrincipal p) = builder p
-

--- a/libs/cargohold-types/src/CargoHold/Types/V3/Resumable.hs
+++ b/libs/cargohold-types/src/CargoHold/Types/V3/Resumable.hs
@@ -24,7 +24,7 @@ import Control.Lens (makeLenses)
 import Data.Aeson
 import Data.Aeson.Types
 import Data.ByteString.Conversion
-import Data.Json.Util ((#), UTCTimeMillis (..))
+import Data.Json.Util ((#), toUTCTimeMillis)
 import Data.Text (Text)
 import Data.Time.Clock
 import CargoHold.Types.V3
@@ -103,7 +103,6 @@ instance FromJSON ResumableAsset where
 instance ToJSON ResumableAsset where
     toJSON r = object
         $ "asset"      .= _resumableAsset r
-        # "expires"    .= UTCTimeMillis (_resumableExpires r)
+        # "expires"    .= toUTCTimeMillis (_resumableExpires r)
         # "chunk_size" .= _resumableChunkSize r
         # []
-

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -406,7 +406,7 @@ instance FromJSON UserClients where
 
 instance ToJSON ClientMismatch where
     toJSON m = object
-        [ "time"      .= UTCTimeMillis (cmismatchTime m)
+        [ "time"      .= toUTCTimeMillis (cmismatchTime m)
         , "missing"   .= missingClients m
         , "redundant" .= redundantClients m
         , "deleted"   .= deletedClients m
@@ -584,7 +584,7 @@ instance ToJSONObject Event where
         [ "type"         .= evtType e
         , "conversation" .= evtConv e
         , "from"         .= evtFrom e
-        , "time"         .= UTCTimeMillis (evtTime e)
+        , "time"         .= toUTCTimeMillis (evtTime e)
         , "data"         .= evtData e
         ]
 

--- a/libs/galley-types/src/Galley/Types/Teams/Intra.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Intra.hs
@@ -46,7 +46,7 @@ instance ToJSON TeamData where
     toJSON (TeamData t s st) = object
         $ "team"        .= t
         # "status"      .= s
-        # "status_time" .= (UTCTimeMillis <$> st)
+        # "status_time" .= (toUTCTimeMillis <$> st)
         # []
 
 instance FromJSON TeamData where

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -34,7 +34,6 @@ import Data.Text (pack)
 import qualified Data.Text.Encoding
 import qualified Data.Text.Encoding.Error
 import GHC.Generics
-import GHC.Prim
 import GHC.Stack
 
 append :: Pair -> [Pair] -> [Pair]

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -20,7 +20,6 @@ import qualified Data.ByteString.Lazy.Char8 as L8
 import qualified Data.ByteString.Base64.Lazy as EL
 import Data.Char (isUpper)
 import Data.Fixed
-import Data.Maybe (fromMaybe)
 import Data.String
 import Data.Time.Clock
 import Data.Time.Format (formatTime, parseTimeM)
@@ -55,7 +54,10 @@ newtype UTCTimeMillis = UTCTimeMillis { fromUTCTimeMillis :: UTCTime }
 
 {-# INLINE toUTCTimeMillis #-}
 toUTCTimeMillis :: HasCallStack => UTCTime -> UTCTimeMillis
-toUTCTimeMillis = UTCTimeMillis . (TL.seconds %~ MkFixed . (* (10^9)) . (`div` (10^9)) . coerce @Pico @Integer)
+toUTCTimeMillis = UTCTimeMillis . (TL.seconds %~ MkFixed . roundit . coerce @Pico @Integer)
+  where
+    roundit = (* onebillion) . (`div` onebillion)
+    onebillion = 10 ^ (9 :: Integer)
 
 {-# INLINE showUTCTimeMillis #-}
 showUTCTimeMillis :: UTCTimeMillis -> String

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE NumDecimals          #-}
 {-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 module Data.Json.Util
     ( append
@@ -54,10 +55,7 @@ newtype UTCTimeMillis = UTCTimeMillis { fromUTCTimeMillis :: UTCTime }
 
 {-# INLINE toUTCTimeMillis #-}
 toUTCTimeMillis :: HasCallStack => UTCTime -> UTCTimeMillis
-toUTCTimeMillis = UTCTimeMillis . (TL.seconds %~ MkFixed . roundit . coerce @Pico @Integer)
-  where
-    roundit = (* onebillion) . (`div` onebillion)
-    onebillion = 10 ^ (9 :: Integer)
+toUTCTimeMillis = UTCTimeMillis . (TL.seconds %~ MkFixed . (* 1e9) . (`div` 1e9) . coerce @Pico @Integer)
 
 {-# INLINE showUTCTimeMillis #-}
 showUTCTimeMillis :: UTCTimeMillis -> String

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -51,6 +51,10 @@ infixr 5 #
 -- millisecond precision instead of the default picosecond precision.
 -- Construct values using 'toUTCTimeMillis'; deconstruct with 'fromUTCTimeMillis'.
 -- Unlike with 'UTCTime', 'Show' renders ISO string.
+--
+-- It would be nice to have a Cql instance for this type to make storing slightly more
+-- straight-forward.  This would require cassandra-utils as a dependency here, as both brig and
+-- cassandra (and possibly others in the future) are using this type.
 newtype UTCTimeMillis = UTCTimeMillis { fromUTCTimeMillis :: UTCTime }
   deriving (Eq)
 

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -52,6 +52,7 @@ infixr 5 #
 -- Construct values using 'toUTCTimeMillis'; deconstruct with 'fromUTCTimeMillis'.
 -- Unlike with 'UTCTime', 'Show' renders ISO string.
 newtype UTCTimeMillis = UTCTimeMillis { fromUTCTimeMillis :: UTCTime }
+  deriving (Eq)
 
 {-# INLINE toUTCTimeMillis #-}
 toUTCTimeMillis :: HasCallStack => UTCTime -> UTCTimeMillis
@@ -67,16 +68,8 @@ readUTCTimeMillis = fmap toUTCTimeMillis . parseTimeM True defaultTimeLocale for
 formatUTCTimeMillis :: String
 formatUTCTimeMillis = "%FT%T%QZ"
 
-{-# INLINE eqUTCTimeMillis #-}
--- (this implementation is not very fast)
-eqUTCTimeMillis :: UTCTimeMillis -> UTCTimeMillis -> Bool
-eqUTCTimeMillis t t' = show t == show t'
-
 instance Show UTCTimeMillis where
     showsPrec d = showParen (d > 10) . showString . showUTCTimeMillis
-
-instance Eq UTCTimeMillis where
-    (==) = eqUTCTimeMillis
 
 instance ToJSON UTCTimeMillis where
     toJSON = String . pack . showUTCTimeMillis

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -6,7 +6,7 @@ module Data.Json.Util
     ( append
     , toJSONFieldName
     , (#)
-    , UTCTimeMillis (..)
+    , UTCTimeMillis, toUTCTimeMillis, fromUTCTimeMillis, showUTCTimeMillis, readUTCTimeMillis
     , ToJSONObject  (..)
     , Base64ByteString (..)
     ) where
@@ -19,7 +19,7 @@ import qualified Data.ByteString.Base64.Lazy as EL
 import Data.Char (isUpper)
 import Data.String
 import Data.Time.Clock
-import Data.Time.Format (formatTime)
+import Data.Time.Format (formatTime, parseTimeM)
 import Data.Time.Locale.Compat (defaultTimeLocale)
 import Data.Text (pack)
 import qualified Data.Text.Encoding
@@ -42,11 +42,15 @@ infixr 5 #
 
 -- | A newtype wrapper for 'UTCTime' that formats timestamps in JSON with
 -- millisecond precision instead of the default picosecond precision.
+--
+-- 'Show', 'Eq' behave as expected, ignoring picoseconds.  Construct values
+-- using 'toUTCTimeMillis'.  NB: 'fromUTCTimeMillis' will give you a
+-- 'UTCTime' that may have a fractional milisecond count.
 newtype UTCTimeMillis = UTCTimeMillis { fromUTCTimeMillis :: UTCTime }
-  deriving (Eq)
 
-instance Show UTCTimeMillis where
-    showsPrec d = showParen (d > 10) . showString . showUTCTimeMillis
+{-# INLINE toUTCTimeMillis #-}
+toUTCTimeMillis :: UTCTime -> UTCTimeMillis
+toUTCTimeMillis = UTCTimeMillis
 
 {-# INLINE showUTCTimeMillis #-}
 showUTCTimeMillis :: UTCTimeMillis -> String
@@ -54,6 +58,22 @@ showUTCTimeMillis (UTCTimeMillis t) = formatTime defaultTimeLocale format t
   where
     format = "%FT%T." ++ formatMillis t ++ "Z"
     formatMillis = take 3 . formatTime defaultTimeLocale "%q"
+
+readUTCTimeMillis :: String -> Maybe UTCTimeMillis
+readUTCTimeMillis = fmap UTCTimeMillis . parseTimeM True defaultTimeLocale format
+  where
+    format = "%FT%T%QZ"
+
+{-# INLINE eqUTCTimeMillis #-}
+-- (this implementation is not very fast)
+eqUTCTimeMillis :: UTCTimeMillis -> UTCTimeMillis -> Bool
+eqUTCTimeMillis t t' = show t == show t'
+
+instance Show UTCTimeMillis where
+    showsPrec d = showParen (d > 10) . showString . showUTCTimeMillis
+
+instance Eq UTCTimeMillis where
+    (==) = eqUTCTimeMillis
 
 instance ToJSON UTCTimeMillis where
     toJSON = String . pack . showUTCTimeMillis

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -13,7 +13,7 @@ module Data.Json.Util
     , Base64ByteString (..)
     ) where
 
-import Control.Lens ((%~))
+import Control.Lens ((%~), coerced)
 import Data.Aeson
 import Data.Aeson.Types
 import qualified Data.ByteString.Lazy as L
@@ -60,11 +60,7 @@ newtype UTCTimeMillis = UTCTimeMillis { fromUTCTimeMillis :: UTCTime }
 
 {-# INLINE toUTCTimeMillis #-}
 toUTCTimeMillis :: HasCallStack => UTCTime -> UTCTimeMillis
-toUTCTimeMillis = UTCTimeMillis . (TL.seconds %~ MkFixed . roundToMillis . coerce @Pico @Integer)
-
-{-# INLINE roundToMillis #-}
-roundToMillis :: Integer -> Integer
-roundToMillis = (* 1e9) . (`div` 1e9)
+toUTCTimeMillis = UTCTimeMillis . (TL.seconds . coerced @Pico @_ @Integer %~ (* 1e9) . (`div` 1e9))
 
 {-# INLINE showUTCTimeMillis #-}
 showUTCTimeMillis :: UTCTimeMillis -> String

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -6,7 +6,7 @@ module Data.Json.Util
     ( append
     , toJSONFieldName
     , (#)
-    , toUTCTimeMillis
+    , UTCTimeMillis, toUTCTimeMillis, fromUTCTimeMillis, showUTCTimeMillis, readUTCTimeMillis
     , ToJSONObject  (..)
     , Base64ByteString (..)
     ) where
@@ -19,7 +19,7 @@ import qualified Data.ByteString.Base64.Lazy as EL
 import Data.Char (isUpper)
 import Data.String
 import Data.Time.Clock
-import Data.Time.Format (formatTime)
+import Data.Time.Format (formatTime, parseTimeM)
 import Data.Time.Locale.Compat (defaultTimeLocale)
 import Data.Text (pack)
 import qualified Data.Text.Encoding
@@ -40,13 +40,46 @@ infixr 5 #
 -----------------------------------------------------------------------------
 -- UTCTimeMillis
 
--- | 'UTCTime' JSON with millisecond precision instead of the default picosecond precision.
+-- | A newtype wrapper for 'UTCTime' that formats timestamps in JSON with
+-- millisecond precision instead of the default picosecond precision.
+--
+-- 'Show', 'Eq' behave as expected, ignoring picoseconds.  Construct values
+-- using 'toUTCTimeMillis'.  NB: 'fromUTCTimeMillis' will give you a
+-- 'UTCTime' that may have a fractional milisecond count.
+newtype UTCTimeMillis = UTCTimeMillis { fromUTCTimeMillis :: UTCTime }
+
 {-# INLINE toUTCTimeMillis #-}
-toUTCTimeMillis :: UTCTime -> Value
-toUTCTimeMillis t = String . pack $ formatTime defaultTimeLocale format t
+toUTCTimeMillis :: UTCTime -> UTCTimeMillis
+toUTCTimeMillis = UTCTimeMillis
+
+{-# INLINE showUTCTimeMillis #-}
+showUTCTimeMillis :: UTCTimeMillis -> String
+showUTCTimeMillis (UTCTimeMillis t) = formatTime defaultTimeLocale format t
   where
     format = "%FT%T." ++ formatMillis t ++ "Z"
     formatMillis = take 3 . formatTime defaultTimeLocale "%q"
+
+readUTCTimeMillis :: String -> Maybe UTCTimeMillis
+readUTCTimeMillis = fmap UTCTimeMillis . parseTimeM True defaultTimeLocale format
+  where
+    format = "%FT%T%QZ"
+
+{-# INLINE eqUTCTimeMillis #-}
+-- (this implementation is not very fast)
+eqUTCTimeMillis :: UTCTimeMillis -> UTCTimeMillis -> Bool
+eqUTCTimeMillis t t' = show t == show t'
+
+instance Show UTCTimeMillis where
+    showsPrec d = showParen (d > 10) . showString . showUTCTimeMillis
+
+instance Eq UTCTimeMillis where
+    (==) = eqUTCTimeMillis
+
+instance ToJSON UTCTimeMillis where
+    toJSON = String . pack . showUTCTimeMillis
+
+instance FromJSON UTCTimeMillis where
+    parseJSON = fmap UTCTimeMillis . parseJSON
 
 -----------------------------------------------------------------------------
 -- ToJSONObject

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -58,6 +58,7 @@ newtype UTCTimeMillis = UTCTimeMillis { fromUTCTimeMillis :: UTCTime }
 toUTCTimeMillis :: HasCallStack => UTCTime -> UTCTimeMillis
 toUTCTimeMillis = UTCTimeMillis . (TL.seconds %~ MkFixed . roundToMillis . coerce @Pico @Integer)
 
+{-# INLINE roundToMillis #-}
 roundToMillis :: Integer -> Integer
 roundToMillis = (* 1e9) . (`div` 1e9)
 

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -56,7 +56,10 @@ newtype UTCTimeMillis = UTCTimeMillis { fromUTCTimeMillis :: UTCTime }
 
 {-# INLINE toUTCTimeMillis #-}
 toUTCTimeMillis :: HasCallStack => UTCTime -> UTCTimeMillis
-toUTCTimeMillis = UTCTimeMillis . (TL.seconds %~ MkFixed . (* 1e9) . (`div` 1e9) . coerce @Pico @Integer)
+toUTCTimeMillis = UTCTimeMillis . (TL.seconds %~ MkFixed . roundToMillis . coerce @Pico @Integer)
+
+roundToMillis :: Integer -> Integer
+roundToMillis = (* 1e9) . (`div` 1e9)
 
 {-# INLINE showUTCTimeMillis #-}
 showUTCTimeMillis :: UTCTimeMillis -> String

--- a/libs/types-common/test/Test/Properties.hs
+++ b/libs/types-common/test/Test/Properties.hs
@@ -99,6 +99,16 @@ tests = testGroup "Properties"
         [ testProperty "validate (Aeson.decode . Aeson.encode) == pure . id" $
             \(t :: Util.UTCTimeMillis) ->
                 (Aeson.eitherDecode . Aeson.encode) t == Right t
+
+          -- (we could test @show x == show y ==> x == y@, but that kind of follows from the above.)
+
+        , let testcase (t1, t2) = testCase (show (t1, t2)) $ make t1 @=? make t2
+              make = Util.readUTCTimeMillis
+          in testGroup "validate Eq" $ testcase <$>
+            [ ("1918-04-14T09:58:58.457Z",  "1918-04-14T09:58:58.457Z")
+            , ("1918-04-14T09:58:58.4574Z", "1918-04-14T09:58:58.457Z")
+            , ("1918-04-14T09:58:58.4579Z", "1918-04-14T09:58:58.457Z")
+            ]
         ]
 
     , testGroup "UUID"
@@ -141,4 +151,4 @@ instance Arbitrary Tag' where
     arbitrary = Tag' <$> choose (0, 536870912)
 
 instance Arbitrary Util.UTCTimeMillis where
-    arbitrary = Util.UTCTimeMillis . posixSecondsToUTCTime . fromInteger <$> arbitrary
+    arbitrary = Util.toUTCTimeMillis . posixSecondsToUTCTime . fromInteger <$> arbitrary

--- a/libs/types-common/test/Test/Properties.hs
+++ b/libs/types-common/test/Test/Properties.hs
@@ -9,12 +9,13 @@ module Test.Properties (tests) where
 import Data.Aeson as Aeson
 import Data.ByteString.Conversion
 import Data.ByteString.Lazy as L
+import Data.Maybe (fromJust)
 import Data.Monoid
 import Data.Text.Ascii
 import Data.Id
 import Data.ProtocolBuffers.Internal
 import Data.Serialize
-import Data.Time.Clock.POSIX
+import Data.Time
 import Data.UUID
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -95,19 +96,14 @@ tests = testGroup "Properties"
             go "foo" "\"Zm9v\""
         ]
 
-    , testGroup "UTCTimeMillis"
-        [ testProperty "validate (Aeson.decode . Aeson.encode) == pure . id" $
-            \(t :: Util.UTCTimeMillis) ->
-                (Aeson.eitherDecode . Aeson.encode) t == Right t
-
-          -- (we could test @show x == show y ==> x == y@, but that kind of follows from the above.)
-
-        , let testcase (t1, t2) = testCase (show (t1, t2)) $ make t1 @=? make t2
-              make = Util.readUTCTimeMillis
+    , testGroup "toUTCTimeMillis"
+        [ let testcase (t1, t2) = testCase (show (t1, t2)) $ timeval t1 @=? timeval t2
+              timeval = Util.toUTCTimeMillis . fromJust . parseTimeM True defaultTimeLocale "%FT%T%QZ"
           in testGroup "validate Eq" $ testcase <$>
-            [ ("1918-04-14T09:58:58.457Z",  "1918-04-14T09:58:58.457Z")
-            , ("1918-04-14T09:58:58.4574Z", "1918-04-14T09:58:58.457Z")
-            , ("1918-04-14T09:58:58.4579Z", "1918-04-14T09:58:58.457Z")
+            [ ("1918-04-14T09:58:58.457Z",      "1918-04-14T09:58:58.457Z")
+            , ("1918-04-14T09:58:58.4574Z",     "1918-04-14T09:58:58.457Z")
+            , ("1918-04-14T09:58:58.4579Z",     "1918-04-14T09:58:58.457Z")
+            , ("1918-04-14T09:58:58.45799817Z", "1918-04-14T09:58:58.457Z")
             ]
         ]
 
@@ -149,6 +145,3 @@ newtype Tag' = Tag' Tag
 
 instance Arbitrary Tag' where
     arbitrary = Tag' <$> choose (0, 536870912)
-
-instance Arbitrary Util.UTCTimeMillis where
-    arbitrary = Util.toUTCTimeMillis . posixSecondsToUTCTime . fromInteger <$> arbitrary

--- a/libs/types-common/types-common.cabal
+++ b/libs/types-common/types-common.cabal
@@ -60,10 +60,12 @@ library
         , deepseq               >= 1.4
         , directory             >= 1.2
         , errors                >= 2.0
+        , ghc-prim
         , hashable              >= 1.2
         , iproute               >= 1.5
         , optparse-applicative  >= 0.10
         , lens                  >= 4.10
+        , lens-datetime         >= 0.3
         , semigroups            >= 0.12
         , safe                  >= 0.3
         , scientific            >= 0.3.4

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -91,6 +91,7 @@ import Control.Monad.Reader
 import Data.ByteString.Conversion
 import Data.Foldable
 import Data.Id
+import Data.Json.Util
 import Data.List (nub)
 import Data.List1 (List1)
 import Data.Misc (PlainTextPassword (..))
@@ -842,7 +843,7 @@ deleteUserNoVerify uid = do
 userGC :: User -> AppIO User
 userGC u = case (userExpire u) of
         Nothing  -> return u
-        (Just e) -> do
+        (Just (fromUTCTimeMillis -> e)) -> do
             now <- liftIO =<< view currentTime
             -- ephemeral users past their expiry date are deleted
             when (diffUTCTime e now < 0) $

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -51,7 +51,6 @@ import Data.Json.Util (UTCTimeMillis, toUTCTimeMillis)
 import Data.Misc
 import Data.Monoid ((<>))
 import Data.Text (Text)
-import Data.Time.Clock
 import Data.Typeable
 import Data.Word
 import Safe (readMay)

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module Brig.Data.Client
     ( -- * Clients
@@ -46,6 +47,7 @@ import Data.ByteString.Conversion (toByteString, toByteString')
 import Data.Foldable (for_)
 import Data.Id
 import Data.List.Split (chunksOf)
+import Data.Json.Util (toUTCTimeMillis)
 import Data.Misc
 import Data.Monoid ((<>))
 import Data.Text (Text)
@@ -115,7 +117,7 @@ addClient u newId c loc = do
             mdl = newClientModel c
             prm = (u, newId, now, newClientType c, newClientLabel c, newClientClass c, newClientCookie c, lat, lon, mdl)
         retry x5 $ write insertClient (params Quorum prm)
-        return $! Client newId (newClientType c) now (newClientClass c) (newClientLabel c) (newClientCookie c) loc mdl
+        return $! Client newId (newClientType c) (toUTCTimeMillis now) (newClientClass c) (newClientLabel c) (newClientCookie c) loc mdl
 
 lookupClient :: MonadClient m => UserId -> ClientId -> m (Maybe Client)
 lookupClient u c = fmap toClient <$>
@@ -225,7 +227,7 @@ checkClient = "SELECT client from clients where user = ? and client = ?"
 -- Conversions
 
 toClient :: (ClientId, ClientType, UTCTime, Maybe Text, Maybe ClientClass, Maybe CookieLabel, Maybe Latitude, Maybe Longitude, Maybe Text) -> Client
-toClient (cid, cty, tme, lbl, cls, cok, lat, lon, mdl) = Client
+toClient (cid, cty, toUTCTimeMillis -> tme, lbl, cls, cok, lat, lon, mdl) = Client
     { clientId       = cid
     , clientType     = cty
     , clientTime     = tme

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -30,7 +30,7 @@ import Data.Int
 import Data.Json.Util (UTCTimeMillis, toUTCTimeMillis)
 import Data.List (foldl')
 import Data.Range
-import Data.Time (UTCTime, getCurrentTime)
+import Data.Time (getCurrentTime)
 
 connectUsers :: UserId -> [(UserId, ConvId)] -> AppIO [UserConnection]
 connectUsers from to = do

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -55,7 +55,7 @@ import Data.Id
 import Data.Json.Util (UTCTimeMillis, toUTCTimeMillis)
 import Data.Misc (PlainTextPassword (..))
 import Data.Range (fromRange)
-import Data.Time (UTCTime, addUTCTime)
+import Data.Time (addUTCTime)
 import Data.UUID.V4
 import Galley.Types.Bot
 

--- a/services/brig/src/Brig/Team/DB.hs
+++ b/services/brig/src/Brig/Team/DB.hs
@@ -35,7 +35,7 @@ import Control.Monad.IO.Class
 import Control.Monad (when)
 import Data.Id
 import Data.Int
-import Data.Json.Util (toUTCTimeMillis, fromUTCTimeMillis)
+import Data.Json.Util (UTCTimeMillis, toUTCTimeMillis)
 import Data.Maybe (fromMaybe)
 import Data.Range
 import Data.Text.Ascii (encodeBase64Url)
@@ -68,14 +68,14 @@ insertInvitation t email (toUTCTimeMillis -> now) timeout = do
     retry x5 $ batch $ do
         setType BatchLogged
         setConsistency Quorum
-        addPrepQuery cqlInvitation (t, iid, code, email, fromUTCTimeMillis now, round timeout)
+        addPrepQuery cqlInvitation (t, iid, code, email, now, round timeout)
         addPrepQuery cqlInvitationInfo (code, t, iid, round timeout)
     return (inv, code)
   where
     cqlInvitationInfo :: PrepQuery W (InvitationCode, TeamId, InvitationId, Int32) ()
     cqlInvitationInfo = "INSERT INTO team_invitation_info (code, team, id) VALUES (?, ?, ?) USING TTL ?"
 
-    cqlInvitation :: PrepQuery W (TeamId, InvitationId, InvitationCode, Email, UTCTime, Int32) ()
+    cqlInvitation :: PrepQuery W (TeamId, InvitationId, InvitationCode, Email, UTCTimeMillis, Int32) ()
     cqlInvitation = "INSERT INTO team_invitation (team, id, code, email, created_at) VALUES (?, ?, ?, ?, ?) USING TTL ?"
 
 lookupInvitation :: MonadClient m => TeamId -> InvitationId -> m (Maybe Invitation)

--- a/services/brig/src/Brig/Team/DB.hs
+++ b/services/brig/src/Brig/Team/DB.hs
@@ -35,10 +35,11 @@ import Control.Monad.IO.Class
 import Control.Monad (when)
 import Data.Id
 import Data.Int
+import Data.Json.Util (toUTCTimeMillis)
 import Data.Maybe (fromMaybe)
 import Data.Range
-import Data.UUID.V4
 import Data.Text.Ascii (encodeBase64Url)
+import Data.UUID.V4
 import Data.Time.Clock
 import OpenSSL.Random (randBytes)
 
@@ -63,7 +64,7 @@ insertInvitation :: MonadClient m
 insertInvitation t email now timeout = do
     iid  <- liftIO mkInvitationId
     code <- liftIO mkInvitationCode
-    let inv = Invitation t iid email now
+    let inv = Invitation t iid email (toUTCTimeMillis now)
     retry x5 $ batch $ do
         setType BatchLogged
         setConsistency Quorum
@@ -164,4 +165,4 @@ countInvitations t = fromMaybe 0 . fmap runIdentity <$>
 
 -- Helper
 toInvitation :: (TeamId, InvitationId, Email, UTCTime) -> Invitation
-toInvitation (t, i, e, tm) = Invitation t i e tm
+toInvitation (t, i, e, tm) = Invitation t i e (toUTCTimeMillis tm)

--- a/services/brig/src/Brig/Team/DB.hs
+++ b/services/brig/src/Brig/Team/DB.hs
@@ -165,4 +165,4 @@ countInvitations t = fromMaybe 0 . fmap runIdentity <$>
 
 -- Helper
 toInvitation :: (TeamId, InvitationId, Email, UTCTime) -> Invitation
-toInvitation (t, i, e, tm) = Invitation t i e (toUTCTimeMillis tm)
+toInvitation (t, i, e, toUTCTimeMillis -> tm) = Invitation t i e tm

--- a/services/brig/src/Brig/User/Email.hs
+++ b/services/brig/src/Brig/User/Email.hs
@@ -19,6 +19,7 @@ import Brig.Email
 import Brig.Locale (formatDateTime, timeLocale)
 import Brig.User.Template
 import Brig.Types
+import Data.Json.Util (fromUTCTimeMillis)
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Range
 import Data.Text (Text)
@@ -104,7 +105,7 @@ renderNewClientEmail NewClientEmailTemplate{..} NewClientEmail{..} =
     replace "model" = fromMaybe "N/A" (clientModel nclClient)
     replace "date"  = formatDateTime "%A %e %B %Y, %H:%M - %Z"
                                      (timeLocale nclLocale)
-                                     (clientTime nclClient)
+                                     (fromUTCTimeMillis $ clientTime nclClient)
     replace x       = x
 
 -------------------------------------------------------------------------------
@@ -339,4 +340,3 @@ renderInvitationUrl t (InvitationCode c) =
   where
     replace "code" = Ascii.toText c
     replace x      = x
-

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -26,6 +26,7 @@ import Data.Aeson.Lens
 import Data.ByteString.Char8 (pack, intercalate)
 import Data.ByteString.Conversion
 import Data.Id hiding (client)
+import Data.Json.Util (fromUTCTimeMillis)
 import Data.Foldable (for_)
 import Data.List1 (singleton)
 import Data.Maybe
@@ -405,7 +406,7 @@ testCreateUserAnonExpiry b = do
     alice <- randomUser b
     bob <- createAnonUserExpiry (Just 2) "bob" b
     liftIO $ assertBool "expiry not set on regular creation" (not $ isJust $ userExpire alice)
-    ensureExpiry (userExpire bob) "bob/register"
+    ensureExpiry (fromUTCTimeMillis <$> userExpire bob) "bob/register"
     resAlice <- getProfile (userId u1) (userId alice)
     resBob <- getProfile (userId u1) (userId bob)
     selfBob <- get (b . zUser (userId bob) . path "self") <!! const 200 === statusCode


### PR DESCRIPTION
`UTCTimeMillis` is currently used like this:

```haskell
data User = User { ..., timestamp :: UTCTime, ... }

instance ToJSON User where
    toJSON u = object [ ..., "timestamp" .= UTCTimeMillis (timestamp u), ... ]
```

This makes sure that the client will never see more than 3 decimal digits in time stamps.  The representation on the server side is not ideal, though:

1. The roundtrip-property `decode . encode === id` will fail on all timestamps with more digits.
2. The law that if `show x == show y` then `x == y` is broken.

This PR makes the data type opaque and adds a smart constructor and `Eq`, `Show`, `{To,From}JSON` instances that satisfy the above laws.

The implementation of `(==)` is not very fast, but I'm not sure it's worth optimizing?  I think we are using this only for serialization anyway.