### PR TITLE
New field in NewUser for storing a UUID pre-fabricated.

### DIFF
--- a/libs/api-bot/src/Network/Wire/Bot/Monad.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Monad.hs
@@ -889,6 +889,7 @@ randUser (Email loc dom) (BotTag tag) = do
     let passw = PlainTextPassword (pack (toString pwdUuid))
     return (NewUser
         { newUserName           = Name (tag <> "-Wirebot-" <> pack (toString uuid))
+        , newUserUUID           = Nothing
         , newUserIdentity       = Just (EmailIdentity email)
         , newUserPassword       = Just passw
         , newUserPict           = Nothing

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -31,6 +31,7 @@ import Data.Monoid
 import Data.Range
 import Data.Text.Ascii
 import Data.Typeable
+import Data.UUID (nil)
 import Data.Word
 import Galley.Types.Bot.Service.Internal
 import Galley.Types.Teams
@@ -204,6 +205,7 @@ instance Arbitrary NewUser where
                 Just (NewUserOriginTeamUser _) -> True
                 _ -> False
         newUserName       <- arbitrary
+        newUserUUID       <- elements [Just nil, Nothing]
         newUserPict       <- arbitrary
         newUserAssets     <- arbitrary
         newUserAccentId   <- arbitrary


### PR DESCRIPTION
In spar, we will need to be able to pick a UUID for a user we want to create.
Otherwise we would not be able to find dangling users after crashed creation
attempts.

Adding an optional field for this to the `NewUser` type is a small, reasonably
safe change: the two place where they are pulled from the network are here:

```
$ git grep -Hn NewUser
[...]
services/brig/src/Brig/API.hs:1150:    NewUserNoSSO new <- parseJsonBody req
services/brig/src/Brig/API.hs:1189:    (uData :: NewUser)  <- parseJsonBody req
[...]
```

We only allow the 'UUID' to be chosen by the creator in the 'NewUser' case;
the 'NewUserNoSSO' case fails to parse if anybody tries.