### PR TITLE
Add a per-conversation message timer

### DIFF
--- a/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
@@ -106,6 +106,6 @@ createConv users name = sessionRequest req rsc readBody
     req = method POST
         . path "conversations"
         . acceptJson
-        . json (NewConv users name mempty Nothing Nothing)
+        . json (NewConv users name mempty Nothing Nothing Nothing)
         $ empty
     rsc = status201 :| []

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -718,7 +718,7 @@ instance ToJSON ConversationMessageTimerUpdate where
 
 instance FromJSON ConversationMessageTimerUpdate where
    parseJSON = withObject "conversation-message-timer-update" $ \o ->
-       ConversationMessageTimerUpdate <$> o .: "message_timer"
+       ConversationMessageTimerUpdate <$> o .:? "message_timer"
 
 instance FromJSON ConversationRename where
     parseJSON = withObject "conversation-rename object" $ \c ->

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -77,6 +77,11 @@ import qualified Data.Text.Encoding  as T
 
 -- Conversations ------------------------------------------------------------
 
+-- | Public-facing conversation type. Represents information that a
+-- particular user is allowed to see.
+--
+-- Can be produced from the internal one ('Galley.Data.Types.Conversation')
+-- by using 'Galley.API.Mapping.conversationView'.
 data Conversation = Conversation
     { cnvId         :: !ConvId
     , cnvType       :: !ConvType
@@ -86,6 +91,7 @@ data Conversation = Conversation
     , cnvName       :: !(Maybe Text)
     , cnvMembers    :: !ConvMembers
     , cnvTeam       :: !(Maybe TeamId)
+    , cnvMessageTimer :: !(Maybe Milliseconds)
     } deriving (Eq, Show)
 
 data ConvType
@@ -126,6 +132,7 @@ data ConversationMeta = ConversationMeta
     , cmAccessRole  :: !AccessRole
     , cmName        :: !(Maybe Text)
     , cmTeam        :: !(Maybe TeamId)
+    , cmMessageTimer :: !(Maybe Milliseconds)
     } deriving (Eq, Show)
 
 data ConversationList a = ConversationList
@@ -156,6 +163,7 @@ data NewConv = NewConv
     , newConvAccess :: !(Set Access)
     , newConvAccessRole :: !(Maybe AccessRole)
     , newConvTeam   :: !(Maybe ConvTeamInfo)
+    , newConvMessageTimer :: !(Maybe Milliseconds)
     }
 
 deriving instance Eq   NewConv
@@ -521,6 +529,7 @@ instance ToJSON Conversation where
         , "last_event"          .= ("0.0" :: Text)
         , "last_event_time"     .= ("1970-01-01T00:00:00.000Z" :: Text)
         , "team"                .= cnvTeam c
+        , "message_timer"       .= cnvMessageTimer c
         ]
 
 instance FromJSON Conversation where
@@ -533,6 +542,7 @@ instance FromJSON Conversation where
                     <*> o .:? "name"
                     <*> o .:  "members"
                     <*> o .:? "team"
+                    <*> o .:? "message_timer"
 
 instance ToJSON ConvMembers where
    toJSON mm = object
@@ -627,6 +637,7 @@ instance FromJSON NewConv where
                 <*> i .:? "access" .!= mempty
                 <*> i .:? "access_role"
                 <*> i .:? "team"
+                <*> i .:? "message_timer"
 
 instance ToJSON NewConv where
     toJSON i = object
@@ -635,6 +646,7 @@ instance ToJSON NewConv where
         # "access" .= newConvAccess i
         # "access_role" .= newConvAccessRole i
         # "team"   .= newConvTeam i
+        # "message_timer" .= newConvMessageTimer i
         # []
 
 instance ToJSON ConvTeamInfo where
@@ -663,6 +675,7 @@ instance FromJSON ConversationMeta where
                          <*> o .:  "access_role"
                          <*> o .:  "name"
                          <*> o .:? "team"
+                         <*> o .:? "message_timer"
 
 instance ToJSON ConversationMeta where
     toJSON c = object
@@ -673,6 +686,7 @@ instance ToJSON ConversationMeta where
         # "access_role" .= cmAccessRole c
         # "name"        .= cmName c
         # "team"        .= cmTeam c
+        # "message_timer" .= cmMessageTimer c
         # []
 
 instance ToJSON ConversationAccessUpdate where

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -713,8 +713,8 @@ instance FromJSON ConversationAccessUpdate where
 
 instance ToJSON ConversationMessageTimerUpdate where
     toJSON c = object
-        $ "message_timer" .= cupMessageTimer c
-        # []
+        [ "message_timer" .= cupMessageTimer c
+        ]
 
 instance FromJSON ConversationMessageTimerUpdate where
    parseJSON = withObject "conversation-message-timer-update" $ \o ->

--- a/libs/galley-types/src/Galley/Types/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Swagger.hs
@@ -2,7 +2,7 @@
 
 module Galley.Types.Swagger where
 
-import Data.Swagger.Build.Api
+import Data.Swagger.Build.Api as Swagger
 import qualified Data.Swagger as Swagger
 
 galleyModels :: [Model]
@@ -139,11 +139,17 @@ conversation = defineModel "Conversation" $ do
         description "The conversation type of this object (0 = regular, 1 = self, 2 = 1:1, 3 = connect)"
     property "creator" bytes' $
         description "The creator's user ID."
+    -- TODO: property "access"
+    -- property "access_role"
     property "name" string' $ do
         description "The conversation name"
         optional
     property "members" (ref conversationMembers) $
         description "The current set of conversation members"
+    -- property "team"
+    property "message_timer" (int64 (Swagger.min 0)) $ do
+        description "Per-conversation message timer"
+        optional
 
 conversationType :: DataType
 conversationType = int32 $ enum [0, 1, 2, 3]
@@ -304,6 +310,11 @@ newConversation = defineModel "NewConversation" $ do
         optional
     property "team" (ref teamInfo) $ do
         description "Team information of this conversation"
+        optional
+    -- TODO: property "access"
+    -- property "access_role"
+    property "message_timer" (int64 (Swagger.min 0)) $ do
+        description "Per-conversation message timer"
         optional
 
 teamInfo :: Model

--- a/libs/galley-types/src/Galley/Types/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Swagger.hs
@@ -15,6 +15,7 @@ galleyModels =
     , conversationMembers
     , conversationUpdate
     , conversationAccessUpdate
+    , conversationMessageTimerUpdate
     , conversationCode
     , conversationUpdateEvent
     , errorObj
@@ -58,6 +59,7 @@ event = defineModel "Event" $ do
                     , typingEvent
                     , otrMessageEvent
                     , conversationAccessUpdateEvent
+                    , conversationMessageTimerUpdateEvent
                     , conversationCodeUpdateEvent
                     , conversationCodeDeleteEvent
                     ]
@@ -69,6 +71,7 @@ eventType = string $ enum
     , "conversation.member-update"
     , "conversation.rename"
     , "conversation.access-update"
+    , "conversation.message-timer-update"
     , "conversation.code-update"
     , "conversation.code-delete"
     , "conversation.create"
@@ -102,6 +105,11 @@ conversationAccessUpdateEvent :: Model
 conversationAccessUpdateEvent = defineModel "ConversationAccessUpdateEvent" $ do
     description "conversation access update event"
     property "data" (ref conversationAccessUpdate) $ description "conversation access data"
+
+conversationMessageTimerUpdateEvent :: Model
+conversationMessageTimerUpdateEvent = defineModel "ConversationMessageTimerUpdateEvent" $ do
+    description "conversation message timer update event"
+    property "data" (ref conversationMessageTimerUpdate) $ description "conversation message timer data"
 
 conversationCodeUpdateEvent :: Model
 conversationCodeUpdateEvent = defineModel "ConversationCodeUpdateEvent" $ do
@@ -226,6 +234,12 @@ conversationAccessUpdate = defineModel "ConversationAccessUpdate" $ do
     description "Contains conversation properties to update"
     property "access" (unique $ array bytes') $
         description "List of conversation access modes: []|[invite]|[invite,code]"
+
+conversationMessageTimerUpdate :: Model
+conversationMessageTimerUpdate = defineModel "ConversationMessageTimerUpdate" $ do
+    description "Contains conversation properties to update"
+    property "message_timer" int64' $
+        description "Conversation message timer (in milliseconds)"
 
 conversationCode :: Model
 conversationCode = defineModel "ConversationCode" $ do

--- a/libs/galley-types/src/Galley/Types/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Swagger.hs
@@ -245,7 +245,7 @@ conversationMessageTimerUpdate :: Model
 conversationMessageTimerUpdate = defineModel "ConversationMessageTimerUpdate" $ do
     description "Contains conversation properties to update"
     property "message_timer" int64' $
-        description "Conversation message timer (in milliseconds)"
+        description "Conversation message timer (in milliseconds); can be null"
 
 conversationCode :: Model
 conversationCode = defineModel "ConversationCode" $ do

--- a/libs/gundeck-types/src/Gundeck/Types/Presence.hs
+++ b/libs/gundeck-types/src/Gundeck/Types/Presence.hs
@@ -8,14 +8,10 @@ module Gundeck.Types.Presence
 
 import Data.Aeson
 import Data.Id
-import Data.Word
+import Data.Misc (Milliseconds)
 import Gundeck.Types.Common as Common
 
 import qualified Data.ByteString.Lazy as Lazy
-
-newtype Milliseconds = Ms
-    { ms :: Word64
-    } deriving (Eq, Ord, Show, Num, ToJSON, FromJSON)
 
 data Presence = Presence
     { userId    :: !UserId

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -43,6 +43,8 @@ append p         pp = p:pp
 
 infixr 5 #
 
+-- | An operator for building JSON in cases where you want @null@ fields to
+-- disappear from the result instead of being present as @null@s.
 (#) :: Pair -> [Pair] -> [Pair]
 (#) = append
 {-# INLINE (#) #-}

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -604,7 +604,7 @@ testAddRemoveBotTeam config crt db brig galley cannon = withTestService config c
     (u1, u2, h, tid, cid, pid, sid) <- prepareBotUsersTeam brig galley sref
     let (uid1, uid2) = (userId u1, userId u2)
     -- Ensure cannot add bots to managed conversations
-    cidFail <- Team.createTeamConv galley tid uid1 [uid2] True
+    cidFail <- Team.createTeamConv galley tid uid1 [uid2] True Nothing
     addBot brig uid1 pid sid cidFail !!! do
         const 403 === statusCode
         const (Just "invalid-conversation") === fmap Error.label . decodeBody
@@ -625,7 +625,7 @@ testMessageBotTeam config crt db brig galley cannon = withTestService config crt
     tid <- Team.createTeam uid galley
 
     -- Create conversation
-    cid <- Team.createTeamConv galley tid uid [] False
+    cid <- Team.createTeamConv galley tid uid [] False Nothing
 
     testMessageBotUtil uid uc cid pid sid sref buf brig galley cannon
 
@@ -935,7 +935,7 @@ createConv g u us = post $ g
     . header "Z-Type" "access"
     . header "Z-Connection" "conn"
     . contentJson
-    . body (RequestBodyLBS (encode (NewConv us Nothing Set.empty Nothing Nothing)))
+    . body (RequestBodyLBS (encode (NewConv us Nothing Set.empty Nothing Nothing Nothing)))
 
 postMessage
     :: Galley
@@ -1484,7 +1484,7 @@ prepareBotUsersTeam brig galley sref = do
     Team.addTeamMember galley tid $ Team.newNewTeamMember $ Team.newTeamMember uid2 Team.fullPermissions
 
     -- Create conversation
-    cid <- Team.createTeamConv galley tid uid1 [uid2] False
+    cid <- Team.createTeamConv galley tid uid1 [uid2] False Nothing
 
     return (u1, u2, h, tid, cid, pid, sid)
 

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -14,6 +14,7 @@ import Data.Aeson
 import Data.ByteString.Conversion
 import Data.Id hiding (client)
 import Data.Maybe (fromMaybe)
+import Data.Misc (Milliseconds)
 import Data.Range
 import Galley.Types (ConvTeamInfo (..), NewConv (..))
 import GHC.Stack (HasCallStack)
@@ -63,10 +64,10 @@ addTeamMember galley tid mem =
                 . lbytes (encode mem)
                 )
 
-createTeamConv :: HasCallStack => Galley -> TeamId -> UserId -> [UserId] -> Bool -> Http ConvId
-createTeamConv g tid u us managed = do
+createTeamConv :: HasCallStack => Galley -> TeamId -> UserId -> [UserId] -> Bool -> Maybe Milliseconds -> Http ConvId
+createTeamConv g tid u us managed mtimer = do
     let tinfo = Just $ ConvTeamInfo tid managed
-    let conv = NewConv us Nothing (Set.fromList []) Nothing tinfo
+    let conv = NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer
     r <- post ( g
               . path "/conversations"
               . zUser u

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -176,6 +176,7 @@ executable galley-integration
     other-modules:
         API
         API.Teams
+        API.MessageTimer
         API.Util
         API.SQS
 

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -154,6 +154,7 @@ executable galley-schema
         V24
         V25
         V26
+        V27
 
     build-depends:
         base

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -15,6 +15,7 @@ import qualified V23
 import qualified V24
 import qualified V25
 import qualified V26
+import qualified V27
 
 main :: IO ()
 main = do
@@ -28,6 +29,9 @@ main = do
         , V24.migration
         , V25.migration
         , V26.migration
+        , V27.migration
+        -- When adding migrations here, don't forget to update
+        -- 'schemaVersion' in Galley.Data
         ]
       `finally`
         close l

--- a/services/galley/schema/src/V27.hs
+++ b/services/galley/schema/src/V27.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module V27 (migration) where
+
+import Cassandra.Schema
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 27 "Add conversation message_timer" $
+    schema' [r| ALTER TABLE conversation ADD message_timer bigint; |]

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -553,6 +553,7 @@ sitemap = do
         summary "Update access modes for a conversation"
         returns (ref Model.event)
         response 200 "Conversation access updated." end
+        response 204 "Conversation access unchanged." end
         body (ref Model.conversationAccessUpdate) $
             description "JSON body"
         errorResponse Error.convNotFound
@@ -561,7 +562,28 @@ sitemap = do
         errorResponse Error.invalidSelfOp
         errorResponse Error.invalidOne2OneOp
         errorResponse Error.invalidConnectOp
-        errorResponse Error.invalidTargetAccess
+
+    ---
+
+    put "/conversations/:cnv/message-timer" (continue updateConversationMessageTimer) $
+        zauthUserId
+        .&. zauthConnId
+        .&. capture "cnv"
+        .&. request
+        .&. contentType "application" "json"
+
+    document "PUT" "updateConversationMessageTimer" $ do
+        summary "Update the message timer for a conversation"
+        returns (ref Model.event)
+        response 200 "Message timer updated." end
+        response 204 "Message timer unchanged." end
+        body (ref Model.conversationMessageTimerUpdate) $
+            description "JSON body"
+        errorResponse Error.convNotFound
+        errorResponse Error.accessDenied
+        errorResponse Error.invalidSelfOp
+        errorResponse Error.invalidOne2OneOp
+        errorResponse Error.invalidConnectOp
 
     ---
 

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -24,7 +24,7 @@ conversationView u Data.Conversation{..} = do
     let (me, them) = List.partition ((u ==) . memId) mm
     m <- maybe memberNotFound return (listToMaybe me)
     let (name, mems) = (convName, ConvMembers m (map toOther them))
-    return $! Conversation convId convType convCreator convAccess convAccessRole name mems convTeam
+    return $! Conversation convId convType convCreator convAccess convAccessRole name mems convTeam convMessageTimer
   where
     toOther x = OtherMember (memId x) (memService x)
 

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -95,6 +95,7 @@ import Data.List.Split (chunksOf)
 import Data.List1 (List1, list1, singleton)
 import Data.Int
 import Data.Maybe (fromMaybe)
+import Data.Misc (Milliseconds)
 import Data.Text (Text)
 import Data.Time.Clock
 import Data.UUID.V4 (nextRandom)
@@ -324,7 +325,7 @@ conversations ids = do
   where
     fetchConvs = do
         cs <- retry x1 $ query Cql.selectConvs (params Quorum (Identity ids))
-        let m = Map.fromList $ map (\(c,t,u,n,a,r,i,d) -> (c, (t,u,n,a,r,i,d))) cs
+        let m = Map.fromList $ map (\(c,t,u,n,a,r,i,d,mt) -> (c, (t,u,n,a,r,i,d,mt))) cs
         return $ map (`Map.lookup` m) ids
 
     flatten (i, c) cc = case c of
@@ -335,18 +336,18 @@ conversations ids = do
 
 toConv :: ConvId
        -> [Member]
-       -> Maybe (ConvType, UserId, Maybe (Set Access), Maybe AccessRole, Maybe Text, Maybe TeamId, Maybe Bool)
+       -> Maybe (ConvType, UserId, Maybe (Set Access), Maybe AccessRole, Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds)
        -> Maybe Conversation
 toConv cid mms conv =
     f mms <$> conv
   where
-    f ms (cty, uid, acc, role, nme, ti, del) = Conversation cid cty uid nme (defAccess cty acc) (maybeRole cty role) ms ti del
+    f ms (cty, uid, acc, role, nme, ti, del, timer) = Conversation cid cty uid nme (defAccess cty acc) (maybeRole cty role) ms ti del timer
 
 conversationMeta :: MonadClient m => ConvId -> m (Maybe ConversationMeta)
 conversationMeta conv = fmap toConvMeta <$>
     retry x1 (query1 Cql.selectConv (params Quorum (Identity conv)))
   where
-    toConvMeta (t, c, a, r, n, i, _) = ConversationMeta conv t c (defAccess t a) (maybeRole t r) n i
+    toConvMeta (t, c, a, r, n, i, _, mt) = ConversationMeta conv t c (defAccess t a) (maybeRole t r) n i mt
 
 conversationIdsFrom :: MonadClient m => UserId -> Maybe ConvId -> Range 1 1000 Int32 -> m (ResultSet ConvId)
 conversationIdsFrom usr range (fromRange -> max) =
@@ -366,28 +367,29 @@ createConversation :: UserId
                    -> AccessRole
                    -> ConvAndTeamSizeChecked [UserId]
                    -> Maybe ConvTeamInfo
+                   -> Maybe Milliseconds                  -- ^ Message timer
                    -> Galley Conversation
-createConversation usr name acc role others tinfo = do
+createConversation usr name acc role others tinfo mtimer = do
     conv <- Id <$> liftIO nextRandom
     now  <- liftIO getCurrentTime
     retry x5 $ case tinfo of
-        Nothing -> write Cql.insertConv (params Quorum (conv, RegularConv, usr, Set (toList acc), role, fromRange <$> name, Nothing))
+        Nothing -> write Cql.insertConv (params Quorum (conv, RegularConv, usr, Set (toList acc), role, fromRange <$> name, Nothing, mtimer))
         Just ti -> batch $ do
             setType BatchLogged
             setConsistency Quorum
-            addPrepQuery Cql.insertConv (conv, RegularConv, usr, Set (toList acc), role, fromRange <$> name, Just (cnvTeamId ti))
+            addPrepQuery Cql.insertConv (conv, RegularConv, usr, Set (toList acc), role, fromRange <$> name, Just (cnvTeamId ti), mtimer)
             addPrepQuery Cql.insertTeamConv (cnvTeamId ti, conv, cnvManaged ti)
     mems <- snd <$> addMembersUnchecked now conv usr (list1 usr $ fromConvTeamSize others)
-    return $ newConv conv RegularConv usr (toList mems) acc role name (cnvTeamId <$> tinfo)
+    return $ newConv conv RegularConv usr (toList mems) acc role name (cnvTeamId <$> tinfo) mtimer
 
 createSelfConversation :: MonadClient m => UserId -> Maybe (Range 1 256 Text) -> m Conversation
 createSelfConversation usr name = do
     let conv = selfConv usr
     now <- liftIO getCurrentTime
     retry x5 $
-        write Cql.insertConv (params Quorum (conv, SelfConv, usr, privateOnly, privateRole, fromRange <$> name, Nothing))
+        write Cql.insertConv (params Quorum (conv, SelfConv, usr, privateOnly, privateRole, fromRange <$> name, Nothing, Nothing))
     mems <- snd <$> addMembersUnchecked now conv usr (singleton usr)
-    return $ newConv conv SelfConv usr (toList mems) [PrivateAccess] privateRole name Nothing
+    return $ newConv conv SelfConv usr (toList mems) [PrivateAccess] privateRole name Nothing Nothing
 
 createConnectConversation :: MonadClient m
                           => U.UUID U.V4
@@ -400,12 +402,12 @@ createConnectConversation a b name conn = do
         a'   = Id . U.unpack $ a
     now <- liftIO getCurrentTime
     retry x5 $
-        write Cql.insertConv (params Quorum (conv, ConnectConv, a', privateOnly, privateRole, fromRange <$> name, Nothing))
+        write Cql.insertConv (params Quorum (conv, ConnectConv, a', privateOnly, privateRole, fromRange <$> name, Nothing, Nothing))
     -- We add only one member, second one gets added later,
     -- when the other user accepts the connection request.
     mems <- snd <$> addMembersUnchecked now conv a' (singleton a')
     let e = Event ConvConnect conv a' now (Just $ EdConnect conn)
-    return (newConv conv ConnectConv a' (toList mems) [PrivateAccess] privateRole name Nothing, e)
+    return (newConv conv ConnectConv a' (toList mems) [PrivateAccess] privateRole name Nothing Nothing, e)
 
 createOne2OneConversation :: U.UUID U.V4
                           -> U.UUID U.V4
@@ -418,14 +420,14 @@ createOne2OneConversation a b name ti = do
         b'   = Id (U.unpack b)
     now <- liftIO getCurrentTime
     retry x5 $ case ti of
-        Nothing  -> write Cql.insertConv (params Quorum (conv, One2OneConv, a', privateOnly, privateRole, fromRange <$> name, Nothing))
+        Nothing  -> write Cql.insertConv (params Quorum (conv, One2OneConv, a', privateOnly, privateRole, fromRange <$> name, Nothing, Nothing))
         Just tid -> batch $ do
             setType BatchLogged
             setConsistency Quorum
-            addPrepQuery Cql.insertConv (conv, One2OneConv, a', privateOnly, privateRole, fromRange <$> name, Just tid)
+            addPrepQuery Cql.insertConv (conv, One2OneConv, a', privateOnly, privateRole, fromRange <$> name, Just tid, Nothing)
             addPrepQuery Cql.insertTeamConv (tid, conv, False)
     mems <- snd <$> addMembersUnchecked now conv a' (list1 a' [b'])
-    return $ newConv conv One2OneConv a' (toList mems) [PrivateAccess] privateRole name ti
+    return $ newConv conv One2OneConv a' (toList mems) [PrivateAccess] privateRole name ti Nothing
 
 updateConversation :: MonadClient m => ConvId -> Range 1 256 Text -> m ()
 updateConversation cid name = retry x5 $ write Cql.updateConvName (params Quorum (fromRange name, cid))
@@ -454,8 +456,9 @@ newConv :: ConvId
         -> AccessRole
         -> Maybe (Range 1 256 Text)
         -> Maybe TeamId
+        -> Maybe Milliseconds
         -> Conversation
-newConv cid ct usr mems acc role name tid = Conversation
+newConv cid ct usr mems acc role name tid mtimer = Conversation
     { convId      = cid
     , convType    = ct
     , convCreator = usr
@@ -465,6 +468,7 @@ newConv cid ct usr mems acc role name tid = Conversation
     , convMembers = mems
     , convTeam    = tid
     , convDeleted = Nothing
+    , convMessageTimer = mtimer
     }
 
 defAccess :: ConvType -> Maybe (Set Access) -> [Access]

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -47,6 +47,7 @@ module Galley.Data
     , isConvAlive
     , updateConversation
     , updateConversationAccess
+    , updateConversationMessageTimer
     , deleteConversation
 
     -- * Conversation Members
@@ -434,6 +435,9 @@ updateConversation cid name = retry x5 $ write Cql.updateConvName (params Quorum
 
 updateConversationAccess :: MonadClient m => ConvId -> [Access] -> AccessRole -> m ()
 updateConversationAccess cid acc role = retry x5 $ write Cql.updateConvAccess (params Quorum (Set acc, role, cid))
+
+updateConversationMessageTimer :: MonadClient m => ConvId -> Maybe Milliseconds -> m ()
+updateConversationMessageTimer cid mtimer = retry x5 $ write Cql.updateConvMessageTimer (params Quorum (mtimer, cid))
 
 deleteConversation :: MonadClient m => ConvId -> m ()
 deleteConversation cid = do

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -128,7 +128,7 @@ import qualified System.Logger.Class  as Log
 newtype ResultSet a = ResultSet { page :: Page a }
 
 schemaVersion :: Int32
-schemaVersion = 25
+schemaVersion = 27
 
 -- | Insert a conversation code
 insertCode :: MonadClient m => Code -> m ()

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -104,17 +104,17 @@ updateTeamStatus = "update team set status = ? where team = ?"
 
 -- Conversations ------------------------------------------------------------
 
-selectConv :: PrepQuery R (Identity ConvId) (ConvType, UserId, Maybe (Set Access), Maybe AccessRole, Maybe Text, Maybe TeamId, Maybe Bool)
-selectConv = "select type, creator, access, access_role, name, team, deleted from conversation where conv = ?"
+selectConv :: PrepQuery R (Identity ConvId) (ConvType, UserId, Maybe (Set Access), Maybe AccessRole, Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds)
+selectConv = "select type, creator, access, access_role, name, team, deleted, message_timer from conversation where conv = ?"
 
-selectConvs :: PrepQuery R (Identity [ConvId]) (ConvId, ConvType, UserId, Maybe (Set Access), Maybe AccessRole, Maybe Text, Maybe TeamId, Maybe Bool)
-selectConvs = "select conv, type, creator, access, access_role, name, team, deleted from conversation where conv in ?"
+selectConvs :: PrepQuery R (Identity [ConvId]) (ConvId, ConvType, UserId, Maybe (Set Access), Maybe AccessRole, Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds)
+selectConvs = "select conv, type, creator, access, access_role, name, team, deleted, message_timer from conversation where conv in ?"
 
 isConvDeleted :: PrepQuery R (Identity ConvId) (Identity (Maybe Bool))
 isConvDeleted = "select deleted from conversation where conv = ?"
 
-insertConv :: PrepQuery W (ConvId, ConvType, UserId, Set Access, AccessRole, Maybe Text, Maybe TeamId) ()
-insertConv = "insert into conversation (conv, type, creator, access, access_role, name, team) values (?, ?, ?, ?, ?, ?, ?)"
+insertConv :: PrepQuery W (ConvId, ConvType, UserId, Set Access, AccessRole, Maybe Text, Maybe TeamId, Maybe Milliseconds) ()
+insertConv = "insert into conversation (conv, type, creator, access, access_role, name, team, message_timer) values (?, ?, ?, ?, ?, ?, ?, ?)"
 
 updateConvAccess :: PrepQuery W (Set Access, AccessRole, ConvId) ()
 updateConvAccess = "update conversation set access = ?, access_role = ? where conv = ?"

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -119,6 +119,9 @@ insertConv = "insert into conversation (conv, type, creator, access, access_role
 updateConvAccess :: PrepQuery W (Set Access, AccessRole, ConvId) ()
 updateConvAccess = "update conversation set access = ?, access_role = ? where conv = ?"
 
+updateConvMessageTimer :: PrepQuery W (Maybe Milliseconds, ConvId) ()
+updateConvMessageTimer = "update conversation set message_timer = ? where conv = ?"
+
 updateConvName :: PrepQuery W (Text, ConvId) ()
 updateConvName = "update conversation set name = ? where conv = ?"
 

--- a/services/galley/src/Galley/Data/Types.hs
+++ b/services/galley/src/Galley/Data/Types.hs
@@ -24,6 +24,7 @@ import Data.Id
 import Data.Range
 import Data.Text
 import Data.Maybe (fromMaybe, isJust)
+import Data.Misc (Milliseconds)
 import Galley.Types (ConvType (..), Access, Member (..), AccessRole)
 import OpenSSL.Random (randBytes)
 import OpenSSL.EVP.Digest (getDigestByName, digestBS)
@@ -31,6 +32,9 @@ import OpenSSL.EVP.Digest (getDigestByName, digestBS)
 import qualified Data.Text.Ascii as Ascii
 import qualified Data.ByteString as BS
 
+-- | Internal conversation type, corresponding directly to database schema.
+-- Should never be sent to users (and therefore doesn't have 'FromJSON' or
+-- 'ToJSON' instances).
 data Conversation = Conversation
     { convId      :: ConvId
     , convType    :: ConvType
@@ -41,6 +45,7 @@ data Conversation = Conversation
     , convMembers :: [Member]
     , convTeam    :: Maybe TeamId
     , convDeleted :: Maybe Bool
+    , convMessageTimer :: Maybe Milliseconds      -- ^ Global message timer
     } deriving (Eq, Show)
 
 isSelfConv :: Conversation -> Bool

--- a/services/galley/src/Galley/External.hs
+++ b/services/galley/src/Galley/External.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Galley.External (deliver) where
 
@@ -37,9 +38,8 @@ deliver :: [(BotMember, Event)] -> Galley [BotMember]
 deliver pp = mapM (async . exec) pp >>= foldM eval [] . zip (map fst pp)
   where
     exec :: (BotMember, Event) -> Galley Bool
-    exec (b, e) = do
-        ms <- Data.lookupService (botMemService b)
-        case ms of
+    exec (b, e) =
+        Data.lookupService (botMemService b) >>= \case
             Nothing -> return False
             Just  s -> do
                 deliver1 s b e

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -35,6 +35,7 @@ import API.SQS
 import qualified Data.Text.Ascii          as Ascii
 import qualified Galley.Types.Teams       as Teams
 import qualified API.Teams                as Teams
+import qualified API.MessageTimer         as MessageTimer
 import qualified Control.Concurrent.Async as Async
 import qualified Data.List1               as List1
 import qualified Data.Map.Strict          as Map
@@ -53,7 +54,8 @@ test s n t = testCase n runTest
         (void $ runHttpT (manager setup) (t (galley setup) (brig setup) (cannon setup) setup))
 
 tests :: IO TestSetup -> TestTree
-tests s = testGroup "Galley integration tests" [ mainTests, Teams.tests s ]
+tests s = testGroup "Galley integration tests"
+    [ mainTests, Teams.tests s, MessageTimer.tests s ]
   where
     mainTests = testGroup "Main API"
         [ test s "status" status

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -6,42 +6,20 @@ module API.MessageTimer (tests) where
 import API.Util
 import Bilge hiding (timeout)
 import Bilge.Assert
-import Brig.Types
-import Control.Applicative hiding (empty)
-import Control.Error
-import Control.Lens ((^.))
 import Control.Monad hiding (mapM_)
 import Control.Monad.IO.Class
-import Data.Aeson hiding (json)
-import Data.ByteString.Conversion
-import Data.Foldable (mapM_)
-import Data.Id
-import Data.Int
-import Data.List ((\\), find)
 import Data.List1
 import Data.Misc
 import Data.Maybe
-import Data.Monoid
-import Data.Range
 import Galley.Types
-import Gundeck.Types.Notification
 import Network.Wai.Utilities.Error
 import Prelude hiding (head, mapM_)
 import Test.Tasty
 import Test.Tasty.Cannon (Cannon, TimeoutUnit (..), (#))
 import Test.Tasty.HUnit
-import API.SQS
 
-import qualified Data.Text.Ascii          as Ascii
 import qualified Galley.Types.Teams       as Teams
-import qualified API.Teams                as Teams
-import qualified Control.Concurrent.Async as Async
-import qualified Data.List1               as List1
-import qualified Data.Map.Strict          as Map
-import qualified Data.Set                 as Set
-import qualified Data.Text                as T
 import qualified Test.Tasty.Cannon        as WS
-import qualified Data.Code                as Code
 
 type TestSignature a = Galley -> Brig -> Cannon -> TestSetup -> Http a
 
@@ -66,7 +44,7 @@ tests s = testGroup "Per-conversation message timer"
 messageTimerInit
     :: Maybe Milliseconds    -- ^ Timer value
     -> Galley -> Brig -> Cannon -> TestSetup -> Http ()
-messageTimerInit mtimer g b ca _ = do
+messageTimerInit mtimer g b _ca _ = do
     -- Create a conversation with a timer
     [alice, bob, jane] <- randomUsers b 3
     connectUsers b alice (list1 bob [jane])
@@ -78,7 +56,7 @@ messageTimerInit mtimer g b ca _ = do
         const mtimer === (cnvMessageTimer <=< decodeBody)
 
 messageTimerChange :: Galley -> Brig -> Cannon -> TestSetup -> Http ()
-messageTimerChange g b ca _ = do
+messageTimerChange g b _ca _ = do
     -- Create a conversation without a timer
     [alice, bob, jane] <- randomUsers b 3
     connectUsers b alice (list1 bob [jane])
@@ -105,7 +83,7 @@ messageTimerChange g b ca _ = do
         const timer1year === (cnvMessageTimer <=< decodeBody)
 
 messageTimerChangeGuest :: Galley -> Brig -> Cannon -> TestSetup -> Http ()
-messageTimerChangeGuest g b ca _ = do
+messageTimerChangeGuest g b _ca _ = do
     -- Create a team and a guest user
     [owner, member, guest] <- randomUsers b 3
     connectUsers b owner (list1 member [guest])
@@ -125,7 +103,7 @@ messageTimerChangeGuest g b ca _ = do
         const timer1sec === (cnvMessageTimer <=< decodeBody)
 
 messageTimerChangeO2O :: Galley -> Brig -> Cannon -> TestSetup -> Http ()
-messageTimerChangeO2O g b ca _ = do
+messageTimerChangeO2O g b _ca _ = do
     -- Create a 1:1 conversation
     [alice, bob] <- randomUsers b 2
     connectUsers b alice (singleton bob)

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module API.MessageTimer (tests) where
+
+import API.Util
+import Bilge hiding (timeout)
+import Bilge.Assert
+import Brig.Types
+import Control.Applicative hiding (empty)
+import Control.Error
+import Control.Lens ((^.))
+import Control.Monad hiding (mapM_)
+import Control.Monad.IO.Class
+import Data.Aeson hiding (json)
+import Data.ByteString.Conversion
+import Data.Foldable (mapM_)
+import Data.Id
+import Data.Int
+import Data.List ((\\), find)
+import Data.List1
+import Data.Misc
+import Data.Maybe
+import Data.Monoid
+import Data.Range
+import Galley.Types
+import Gundeck.Types.Notification
+import Network.Wai.Utilities.Error
+import Prelude hiding (head, mapM_)
+import Test.Tasty
+import Test.Tasty.Cannon (Cannon, TimeoutUnit (..), (#))
+import Test.Tasty.HUnit
+import API.SQS
+
+import qualified Data.Text.Ascii          as Ascii
+import qualified Galley.Types.Teams       as Teams
+import qualified API.Teams                as Teams
+import qualified Control.Concurrent.Async as Async
+import qualified Data.List1               as List1
+import qualified Data.Map.Strict          as Map
+import qualified Data.Set                 as Set
+import qualified Data.Text                as T
+import qualified Test.Tasty.Cannon        as WS
+import qualified Data.Code                as Code
+
+type TestSignature a = Galley -> Brig -> Cannon -> TestSetup -> Http a
+
+test :: IO TestSetup -> TestName -> TestSignature a -> TestTree
+test s n t = testCase n runTest
+  where
+    runTest = do
+        setup <- s
+        (void $ runHttpT (manager setup) (t (galley setup) (brig setup) (cannon setup) setup))
+
+tests :: IO TestSetup -> TestTree
+tests s = testGroup "Per-conversation message timer"
+    [ test s "timer can be set at creation time" messageTimerInit
+    , test s "timer can be changed" messageTimerChange
+    , test s "timer can't be set by guests" messageTimerChangeGuest
+    , test s "timer can't be set in 1:1 conversations" messageTimerChange1to1
+    , test s "setting the timer generates an event" messageTimerEvent
+    ]
+
+messageTimerInit :: Galley -> Brig -> Cannon -> TestSetup -> Http ()
+messageTimerInit g b ca _ = do
+    pure ()
+    -- create a conversation
+    -- check that the timer is whatever
+    -- create a conversation without timer
+    -- check that the timer is nothing
+
+messageTimerChange :: Galley -> Brig -> Cannon -> TestSetup -> Http ()
+messageTimerChange g b ca _ = do
+    pure ()
+    -- create a conversation without timer
+    -- set timer to something
+    -- set timer to null
+    -- set timer to something else
+
+messageTimerChangeGuest :: Galley -> Brig -> Cannon -> TestSetup -> Http ()
+messageTimerChangeGuest g b ca _ = do
+    pure ()
+    -- create a conversation with a guest user
+    -- try to change the timer (as the guest user) and observe failure
+
+messageTimerChange1to1 :: Galley -> Brig -> Cannon -> TestSetup -> Http ()
+messageTimerChange1to1 g b ca _ = do
+    pure ()
+    -- create a 1:1 conversation
+    -- try to change the timer and observe failure
+
+messageTimerEvent :: Galley -> Brig -> Cannon -> TestSetup -> Http ()
+messageTimerEvent g b ca _ = do
+    pure ()
+    -- create a conversation
+    -- change the timer
+    -- check that the returned event is correct
+    -- check that other participants have also got the event

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -273,13 +273,13 @@ testRemoveTeamMember g b c _ = do
     tid <- Util.createTeam g "foo" owner [mem1, mem2]
 
     -- Managed conversation:
-    void $ Util.createTeamConv g owner (ConvTeamInfo tid True) [] (Just "gossip") Nothing
+    void $ Util.createTeamConv g owner (ConvTeamInfo tid True) [] (Just "gossip") Nothing Nothing
     -- Regular conversation:
-    cid2 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [mem1^.userId, mem2^.userId, mext1] (Just "blaa") Nothing
+    cid2 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [mem1^.userId, mem2^.userId, mext1] (Just "blaa") Nothing Nothing
     -- Member external 2 is a guest and not a part of any conversation that mem1 is a part of
-    void $ Util.createTeamConv g owner (ConvTeamInfo tid False) [mem2^.userId, mext2] (Just "blaa") Nothing
+    void $ Util.createTeamConv g owner (ConvTeamInfo tid False) [mem2^.userId, mext2] (Just "blaa") Nothing Nothing
     -- Member external 3 is a guest and part of a conversation that mem1 is a part of
-    cid3 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [mem1^.userId, mext3] (Just "blaa") Nothing
+    cid3 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [mem1^.userId, mext3] (Just "blaa") Nothing Nothing
 
     WS.bracketRN c [owner, mem1^.userId, mem2^.userId, mext1, mext2, mext3] $ \ws@[wsOwner, wsMem1, wsMem2, wsMext1, _wsMext2, wsMext3] -> do
         -- `mem1` lacks permission to remove team members
@@ -315,7 +315,7 @@ testRemoveBindingTeamMember g b c a = do
     Util.addTeamMemberInternal g tid mem1
     assertQueue "team member join" a $ tUpdate 2 [owner]
     Util.connectUsers b owner (singleton mext)
-    cid1 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [(mem1^.userId), mext] (Just "blaa") Nothing
+    cid1 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [(mem1^.userId), mext] (Just "blaa") Nothing Nothing
 
     -- Deleting from a binding team without a password is a bad request
     delete ( g
@@ -366,12 +366,12 @@ testAddTeamConv g b c _ = do
 
     WS.bracketRN c [owner, extern, mem1^.userId, mem2^.userId]  $ \ws@[wsOwner, wsExtern, wsMem1, wsMem2] -> do
         -- Managed conversation:
-        cid1 <- Util.createTeamConv g owner (ConvTeamInfo tid True) [] (Just "gossip") Nothing
+        cid1 <- Util.createTeamConv g owner (ConvTeamInfo tid True) [] (Just "gossip") Nothing Nothing
         checkConvCreateEvent cid1 wsOwner
         checkConvCreateEvent cid1 wsMem2
 
         -- Regular conversation:
-        cid2 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [extern] (Just "blaa") Nothing
+        cid2 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [extern] (Just "blaa") Nothing Nothing
         checkConvCreateEvent cid2 wsOwner
         checkConvCreateEvent cid2 wsExtern
         -- mem2 is not a conversation member but still receives an event that
@@ -390,7 +390,7 @@ testAddTeamConv g b c _ = do
         Util.assertNotConvMember g (mem1^.userId) cid2
 
         -- Managed team conversations get all team members added implicitly.
-        cid3 <- Util.createTeamConv g owner (ConvTeamInfo tid True) [] (Just "blup") Nothing
+        cid3 <- Util.createTeamConv g owner (ConvTeamInfo tid True) [] (Just "blup") Nothing Nothing
         for_ [owner, mem1^.userId, mem2^.userId] $ \u ->
             Util.assertConvMember g u cid3
 
@@ -426,7 +426,7 @@ testAddTeamConvWithUsers g b _ _ = do
     Util.connectUsers b owner (list1 extern [])
     tid <- Util.createTeam g "foo" owner []
     -- Create managed team conversation and erroneously specify external users.
-    cid <- Util.createTeamConv g owner (ConvTeamInfo tid True) [extern] (Just "gossip") Nothing
+    cid <- Util.createTeamConv g owner (ConvTeamInfo tid True) [extern] (Just "gossip") Nothing Nothing
     -- External users have been ignored.
     Util.assertNotConvMember g extern cid
     -- Team members are present.
@@ -444,7 +444,7 @@ testAddTeamMemberToConv g b _ _ = do
     tid <- Util.createTeam g "foo" owner [mem1, mem2, mem3]
 
     -- Team owner creates new regular team conversation:
-    cid <- Util.createTeamConv g owner (ConvTeamInfo tid False) [] (Just "blaa") Nothing
+    cid <- Util.createTeamConv g owner (ConvTeamInfo tid False) [] (Just "blaa") Nothing Nothing
 
     -- Team member 1 (who is *not* a member of the new conversation)
     -- can add other team members without requiring a user connection
@@ -470,8 +470,8 @@ testDeleteTeam g b c a = do
     Util.connectUsers b owner (list1 (member^.userId) [extern])
 
     tid  <- Util.createTeam g "foo" owner [member]
-    cid1 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [] (Just "blaa") Nothing
-    cid2 <- Util.createTeamConv g owner (ConvTeamInfo tid True) [] (Just "blup") Nothing
+    cid1 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [] (Just "blaa") Nothing Nothing
+    cid2 <- Util.createTeamConv g owner (ConvTeamInfo tid True) [] (Just "blup") Nothing Nothing
 
     Util.assertConvMember g owner cid2
     Util.assertConvMember g (member^.userId) cid2
@@ -583,11 +583,11 @@ testDeleteTeamConv g b c _ = do
     Util.connectUsers b owner (list1 (member^.userId) [extern])
 
     tid  <- Util.createTeam g "foo" owner [member]
-    cid1 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [] (Just "blaa") Nothing
+    cid1 <- Util.createTeamConv g owner (ConvTeamInfo tid False) [] (Just "blaa") Nothing Nothing
     let access = ConversationAccessUpdate [InviteAccess, CodeAccess] ActivatedAccessRole
     putAccessUpdate g owner cid1 access !!! const 200 === statusCode
     code <- decodeConvCodeEvent <$> (postConvCode g owner cid1 <!! const 201 === statusCode)
-    cid2 <- Util.createTeamConv g owner (ConvTeamInfo tid True) [] (Just "blup") Nothing
+    cid2 <- Util.createTeamConv g owner (ConvTeamInfo tid True) [] (Just "blup") Nothing Nothing
 
     Util.postMembers g owner (list1 extern [member^.userId]) cid1 !!! const 200 === statusCode
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -462,6 +462,15 @@ wsAssertConvAccessUpdate conv usr new n = do
     evtFrom      e @?= usr
     evtData      e @?= Just (EdConvAccessUpdate new)
 
+wsAssertConvMessageTimerUpdate :: ConvId -> UserId -> ConversationMessageTimerUpdate -> Notification -> IO ()
+wsAssertConvMessageTimerUpdate conv usr new n = do
+    let e = List1.head (WS.unpackPayload n)
+    ntfTransient n @?= False
+    evtConv      e @?= conv
+    evtType      e @?= ConvMessageTimerUpdate
+    evtFrom      e @?= usr
+    evtData      e @?= Just (EdConvMessageTimerUpdate new)
+
 wsAssertMemberLeave :: ConvId -> UserId -> [UserId] -> Notification -> IO ()
 wsAssertMemberLeave conv usr old n = do
     let e = List1.head (WS.unpackPayload n)

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -144,17 +144,17 @@ addTeamMemberInternal g tid mem = do
     post (g . paths ["i", "teams", toByteString' tid, "members"] . payload) !!!
         const 200 === statusCode
 
-createTeamConv :: HasCallStack => Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Http ConvId
-createTeamConv g u tinfo us name acc = createTeamConvAccess g u tinfo us name acc Nothing
+createTeamConv :: HasCallStack => Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe Milliseconds -> Http ConvId
+createTeamConv g u tinfo us name acc mtimer = createTeamConvAccess g u tinfo us name acc Nothing mtimer
 
-createTeamConvAccess :: HasCallStack => Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe AccessRole -> Http ConvId
-createTeamConvAccess g u tinfo us name acc role = do
-    r <- createTeamConvAccessRaw g u tinfo us name acc role <!! const 201 === statusCode
+createTeamConvAccess :: HasCallStack => Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe AccessRole -> Maybe Milliseconds -> Http ConvId
+createTeamConvAccess g u tinfo us name acc role mtimer = do
+    r <- createTeamConvAccessRaw g u tinfo us name acc role mtimer <!! const 201 === statusCode
     fromBS (getHeader' "Location" r)
 
-createTeamConvAccessRaw :: Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe AccessRole -> Http ResponseLBS
-createTeamConvAccessRaw g u tinfo us name acc role = do
-    let conv = NewConv us name (fromMaybe (Set.fromList []) acc) role (Just tinfo)
+createTeamConvAccessRaw :: Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe AccessRole -> Maybe Milliseconds -> Http ResponseLBS
+createTeamConvAccessRaw g u tinfo us name acc role mtimer = do
+    let conv = NewConv us name (fromMaybe (Set.fromList []) acc) role (Just tinfo) mtimer
     post ( g
           . path "/conversations"
           . zUser u
@@ -165,12 +165,12 @@ createTeamConvAccessRaw g u tinfo us name acc role = do
 
 createOne2OneTeamConv :: Galley -> UserId -> UserId -> Maybe Text -> TeamId -> Http ResponseLBS
 createOne2OneTeamConv g u1 u2 n tid = do
-    let conv = NewConv [u2] n mempty Nothing (Just $ ConvTeamInfo tid False)
+    let conv = NewConv [u2] n mempty Nothing (Just $ ConvTeamInfo tid False) Nothing
     post $ g . path "/conversations/one2one" . zUser u1 . zConn "conn" . zType "access" . json conv
 
-postConv :: Galley -> UserId -> [UserId] -> Maybe Text -> [Access] -> Maybe AccessRole -> Http ResponseLBS
-postConv g u us name a r = do
-    let conv = NewConv us name (Set.fromList a) r  Nothing
+postConv :: Galley -> UserId -> [UserId] -> Maybe Text -> [Access] -> Maybe AccessRole -> Maybe Milliseconds -> Http ResponseLBS
+postConv g u us name a r mtimer = do
+    let conv = NewConv us name (Set.fromList a) r Nothing mtimer
     post $ g . path "/conversations" . zUser u . zConn "conn" . zType "access" . json conv
 
 postSelfConv :: Galley -> UserId -> Http ResponseLBS
@@ -178,7 +178,7 @@ postSelfConv g u = post $ g . path "/conversations/self" . zUser u . zConn "conn
 
 postO2OConv :: Galley -> UserId -> UserId -> Maybe Text -> Http ResponseLBS
 postO2OConv g u1 u2 n = do
-    let conv = NewConv [u2] n mempty Nothing Nothing
+    let conv = NewConv [u2] n mempty Nothing Nothing Nothing
     post $ g . path "/conversations/one2one" . zUser u1 . zConn "conn" . zType "access" . json conv
 
 postConnectConv :: Galley -> UserId -> UserId -> Text -> Text -> Maybe Text -> Http ResponseLBS

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -325,6 +325,15 @@ putAccessUpdate g u c acc = put $ g
     . zType "access"
     . json acc
 
+putMessageTimerUpdate
+    :: Galley -> UserId -> ConvId -> ConversationMessageTimerUpdate -> Http ResponseLBS
+putMessageTimerUpdate g u c acc = put $ g
+    . paths ["/conversations", toByteString' c, "message-timer"]
+    . zUser u
+    . zConn "conn"
+    . zType "access"
+    . json acc
+
 postConvCode :: Galley -> UserId -> ConvId -> Http ResponseLBS
 postConvCode g u c = post $ g
     . paths ["/conversations", toByteString' c, "code"]

--- a/services/gundeck/src/Gundeck/Env.hs
+++ b/services/gundeck/src/Gundeck/Env.hs
@@ -9,11 +9,11 @@ import Control.AutoUpdate
 import Control.Lens ((^.), makeLenses)
 import Data.Int (Int32)
 import Data.Metrics.Middleware (Metrics)
+import Data.Misc (Milliseconds (..))
 import Data.Text (unpack)
 import Data.Time.Clock.POSIX
 import Util.Options
 import Gundeck.Options as Opt
-import Gundeck.Types.Presence (Milliseconds (..))
 import Network.HTTP.Client (responseTimeoutMicro)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import OpenSSL.EVP.Cipher (Cipher, getCipherByName)

--- a/services/gundeck/src/Gundeck/Monad.hs
+++ b/services/gundeck/src/Gundeck/Monad.hs
@@ -38,8 +38,8 @@ import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Control.Monad.Trans.Control
 import Data.Aeson (FromJSON)
+import Data.Misc (Milliseconds (..))
 import Gundeck.Env
-import Gundeck.Types.Presence (Milliseconds (..))
 import Network.Wai
 import Network.Wai.Utilities
 import System.Logger.Class hiding (Error, info)

--- a/services/gundeck/src/Gundeck/Notification.hs
+++ b/services/gundeck/src/Gundeck/Notification.hs
@@ -13,13 +13,13 @@ import Data.ByteString (ByteString)
 import Data.Foldable (for_, toList)
 import Data.Id
 import Data.Int
+import Data.Misc (Milliseconds (..))
 import Data.Predicate
 import Data.Range
 import Data.Time.Clock.POSIX
 import Gundeck.API.Error
 import Gundeck.Monad
 import Gundeck.Types.Notification
-import Gundeck.Types.Presence (Milliseconds (..))
 import Gundeck.Util
 import Network.HTTP.Types.Status
 import Network.Wai (Response)

--- a/services/gundeck/src/Gundeck/Presence/Data.hs
+++ b/services/gundeck/src/Gundeck/Presence/Data.hs
@@ -16,6 +16,7 @@ import Data.ByteString (ByteString, isPrefixOf)
 import Data.Foldable (for_)
 import Data.Id
 import Data.Maybe (mapMaybe)
+import Data.Misc (Milliseconds)
 import Data.Monoid
 import Database.Redis.IO hiding (Milliseconds)
 import Gundeck.Monad (Gundeck, posixTime)

--- a/services/gundeck/src/Gundeck/Push/Websocket.hs
+++ b/services/gundeck/src/Gundeck/Push/Websocket.hs
@@ -30,6 +30,7 @@ import Data.Function (on)
 import Data.Id
 import Data.List (groupBy, sortBy, foldl')
 import Data.List1
+import Data.Misc (Milliseconds (..))
 import Data.Monoid ((<>))
 import Data.Set (Set)
 import Data.Time.Clock.POSIX


### PR DESCRIPTION
### Features

* [x] Add the `message_timer` field to the database
* [x] Allow providing an initial `message_timer` for a conversation
* [x] Add an endpoint for setting `message_timer`
* [x] Add an endpoint for getting `message_timer` or make sure it's provided as a part of some other endpoint
* [x] Send out an event when the timer is changed
* [x] Round negative values of the timer to zero

### Documentation

* [x] Make sure that the GET endpoint is documented in Swagger
* [x] Make sure that the PUT endpoint is documented in Swagger
* [x] Make sure that the event is documented in Swagger

### Testing

* [x] Test that providing an initial `message_timer` works
* [x] Test that setting and getting `message_timer` works
* [x] Test that the event is sent out when the timer is changed
* [x] Test that a guest can not change the timer
* [x] Test that a timer can not be set for a 1-to-1 conversation
* [x] Test that a timer can be unset

### Open questions

* [x] Should the backend check the range of the timer? (No.)
* [x] Should the `message-timer-update` event be renamed? (No.)

### Bureaucracy

* [x] Introduce bureaucracy