### PR TITLE
Fix some inaccuracies in Swagger docs

### DIFF
--- a/libs/galley-types/src/Galley/Types/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Swagger.hs
@@ -142,14 +142,12 @@ conversation = defineModel "Conversation" $ do
     -- TODO: property "access"
     -- property "access_role"
     property "name" string' $ do
-        description "The conversation name"
-        optional
+        description "The conversation name (can be null)"
     property "members" (ref conversationMembers) $
         description "The current set of conversation members"
     -- property "team"
     property "message_timer" (int64 (Swagger.min 0)) $ do
-        description "Per-conversation message timer"
-        optional
+        description "Per-conversation message timer (can be null)"
 
 conversationType :: DataType
 conversationType = int32 $ enum [0, 1, 2, 3]

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -506,6 +506,8 @@ sitemap = do
 
     document "POST" "createConversationCode" $ do
         summary "Create or recreate a conversation code"
+        parameter Path "cnv" bytes' $
+            description "Conversation ID"
         returns (ref Model.event)
         returns (ref Model.conversationCode)
         response 201 "Conversation code created." (model Model.event)
@@ -522,6 +524,8 @@ sitemap = do
 
     document "DELETE" "deleteConversationCode" $ do
         summary "Delete conversation code"
+        parameter Path "cnv" bytes' $
+            description "Conversation ID"
         returns (ref Model.event)
         response 200 "Conversation code deleted." end
         errorResponse Error.convNotFound
@@ -535,6 +539,8 @@ sitemap = do
 
     document "GET" "getConversationCode" $ do
         summary "Get existing conversation code"
+        parameter Path "cnv" bytes' $
+            description "Conversation ID"
         returns (ref Model.conversationCode)
         response 200 "Conversation Code" end
         errorResponse Error.convNotFound
@@ -551,6 +557,8 @@ sitemap = do
 
     document "PUT" "updateConversationAccess" $ do
         summary "Update access modes for a conversation"
+        parameter Path "cnv" bytes' $
+            description "Conversation ID"
         returns (ref Model.event)
         response 200 "Conversation access updated." end
         response 204 "Conversation access unchanged." end
@@ -574,6 +582,8 @@ sitemap = do
 
     document "PUT" "updateConversationMessageTimer" $ do
         summary "Update the message timer for a conversation"
+        parameter Path "cnv" bytes' $
+            description "Conversation ID"
         returns (ref Model.event)
         response 200 "Message timer updated." end
         response 204 "Message timer unchanged." end


### PR DESCRIPTION
* `:cnv` was missing sometimes
* In some places `message_timer` is not optional, but nullable