### PR TITLE
Forbid managed conversations

### DIFF
--- a/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
@@ -106,6 +106,6 @@ createConv users name = sessionRequest req rsc readBody
     req = method POST
         . path "conversations"
         . acceptJson
-        . json (NewConv users name mempty Nothing Nothing Nothing)
+        . json (NewConvUnmanaged (NewConv users name mempty Nothing Nothing Nothing))
         $ empty
     rsc = status201 :| []

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -604,7 +604,7 @@ testAddRemoveBotTeam config crt db brig galley cannon = withTestService config c
     (u1, u2, h, tid, cid, pid, sid) <- prepareBotUsersTeam brig galley sref
     let (uid1, uid2) = (userId u1, userId u2)
     -- Ensure cannot add bots to managed conversations
-    cidFail <- Team.createTeamConv galley tid uid1 [uid2] True Nothing
+    cidFail <- Team.createManagedConv galley tid uid1 [uid2] Nothing
     addBot brig uid1 pid sid cidFail !!! do
         const 403 === statusCode
         const (Just "invalid-conversation") === fmap Error.label . decodeBody
@@ -625,7 +625,7 @@ testMessageBotTeam config crt db brig galley cannon = withTestService config crt
     tid <- Team.createTeam uid galley
 
     -- Create conversation
-    cid <- Team.createTeamConv galley tid uid [] False Nothing
+    cid <- Team.createTeamConv galley tid uid [] Nothing
 
     testMessageBotUtil uid uc cid pid sid sref buf brig galley cannon
 
@@ -1484,7 +1484,7 @@ prepareBotUsersTeam brig galley sref = do
     Team.addTeamMember galley tid $ Team.newNewTeamMember $ Team.newTeamMember uid2 Team.fullPermissions
 
     -- Create conversation
-    cid <- Team.createTeamConv galley tid uid1 [uid2] False Nothing
+    cid <- Team.createTeamConv galley tid uid1 [uid2] Nothing
 
     return (u1, u2, h, tid, cid, pid, sid)
 

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -32,7 +32,7 @@ import Data.Text (Text, isPrefixOf, toLower)
 import Data.Text.Encoding (encodeUtf8)
 import Data.Time.Clock
 import Data.Timeout (Timeout, TimeoutUnit (..), (#), TimedOut (..))
-import Galley.Types (NewConv (..), Conversation (..), Members (..))
+import Galley.Types (NewConv (..), NewConvUnmanaged (..), Conversation (..), Members (..))
 import Galley.Types (ConvMembers (..), OtherMember (..))
 import Galley.Types (Event (..), EventType (..), EventData (..), OtrMessage (..))
 import Galley.Types.Bot (ServiceRef, newServiceRef, serviceRefId, serviceRefProvider)
@@ -935,7 +935,9 @@ createConv g u us = post $ g
     . header "Z-Type" "access"
     . header "Z-Connection" "conn"
     . contentJson
-    . body (RequestBodyLBS (encode (NewConv us Nothing Set.empty Nothing Nothing Nothing)))
+    . body (RequestBodyLBS (encode (NewConvUnmanaged conv)))
+  where
+    conv = NewConv us Nothing Set.empty Nothing Nothing Nothing
 
 postMessage
     :: Galley

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -16,7 +16,7 @@ import Data.Id hiding (client)
 import Data.Maybe (fromMaybe)
 import Data.Misc (Milliseconds)
 import Data.Range
-import Galley.Types (ConvTeamInfo (..), NewConv (..))
+import Galley.Types (ConvTeamInfo (..), NewConv (..), NewConvUnmanaged (..), NewConvManaged (..))
 import GHC.Stack (HasCallStack)
 import Test.Tasty.HUnit
 import Util
@@ -67,7 +67,8 @@ addTeamMember galley tid mem =
 createTeamConv :: HasCallStack => Galley -> TeamId -> UserId -> [UserId] -> Maybe Milliseconds -> Http ConvId
 createTeamConv g tid u us mtimer = do
     let tinfo = Just $ ConvTeamInfo tid False
-    let conv = NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer
+    let conv = NewConvUnmanaged $
+               NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer
     r <- post ( g
               . path "/conversations"
               . zUser u
@@ -78,10 +79,12 @@ createTeamConv g tid u us mtimer = do
     maybe (error "invalid conv id") return $
         fromByteString $ getHeader' "Location" r
 
+-- See Note [managed conversations]
 createManagedConv :: HasCallStack => Galley -> TeamId -> UserId -> [UserId] -> Maybe Milliseconds -> Http ConvId
 createManagedConv g tid u us mtimer = do
     let tinfo = Just $ ConvTeamInfo tid True
-    let conv = NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer
+    let conv = NewConvManaged $
+               NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer
     r <- post ( g
               . path "/i/conversations/managed"
               . zUser u

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -823,6 +823,12 @@ sitemap = do
         capture "cnv"
         .&. capture "usr"
 
+    post "/i/conversations/managed" (continue internalCreateManagedConversation) $
+        zauthUserId
+        .&. zauthConnId
+        .&. request
+        .&. contentType "application" "json"
+
     post "/i/conversations/connect" (continue createConnectConversation) $
         zauthUserId
         .&. opt zauthConnId

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -6,6 +6,7 @@
 
 module Galley.API.Create
     ( createGroupConversation
+    , internalCreateManagedConversation
     , createSelfConversation
     , createOne2OneConversation
     , createConnectConversation
@@ -44,49 +45,76 @@ import qualified Data.UUID.Tagged   as U
 import qualified Galley.Data        as Data
 import qualified Galley.Types.Teams as Teams
 
+----------------------------------------------------------------------------
+-- Group conversations
+
+-- | The public-facing endpoint for creating group conversations.
+--
+-- 'createGroupConversation' doesn't allow managed conversations because
+-- we've decided to deprecate them (as they prevent us from decoupling
+-- conversation size from team size). However, we're not sure that they're
+-- gone forever, so we don't want to remove the code just yet. Instead, we
+-- simply forbid them in the public-facing endpoint, but keep them available
+-- through an internal endpoint which is only used for tests.
 createGroupConversation :: UserId ::: ConnId ::: Request ::: JSON -> Galley Response
-createGroupConversation (zusr::: zcon ::: req ::: _) = do
+createGroupConversation (zusr ::: zcon ::: req ::: _) = do
     body :: NewConv <- fromBody req invalidPayload
     case newConvTeam body of
-        Nothing -> createRegularConv body
-        Just tm -> createTeamConv tm body
-  where
-    createTeamConv tinfo body = do
-        name <- rangeCheckedMaybe (newConvName body)
-        mems <- Data.teamMembers (cnvTeamId tinfo)
-        ensureAccessRole (accessRole body) (newConvUsers body) (Just mems)
-        void $ permissionCheck zusr CreateConversation mems
-        uids <-
-            if cnvManaged tinfo then do
-                let uu = filter (/= zusr) $ map (view userId) mems
-                checkedConvAndTeamSize uu
-            else do
-                void $ permissionCheck zusr AddConversationMember mems
-                uu <- checkedConvAndTeamSize (newConvUsers body)
-                ensureConnected zusr (notTeamMember (fromConvTeamSize uu) mems)
-                pure uu
-        conv <- Data.createConversation zusr name (access body) (accessRole body) uids (newConvTeam body) (newConvMessageTimer body)
-        now  <- liftIO getCurrentTime
-        let d = Teams.EdConvCreate (Data.convId conv)
-        let e = newEvent Teams.ConvCreate (cnvTeamId tinfo) now & eventData .~ Just d
-        let notInConv = Set.fromList (map (view userId) mems) \\ Set.fromList (zusr : fromConvTeamSize uids)
-        for_ (newPush zusr (TeamEvent e) (map userRecipient (Set.toList notInConv))) push1
-        notifyCreatedConversation (Just now) zusr (Just zcon) conv
-        conversationResponse status201 zusr conv
+        Nothing    -> createRegularGroupConv zusr zcon body
+        Just tinfo -> do
+            when (cnvManaged tinfo) $ throwM noManagedTeamConv
+            createTeamGroupConv zusr zcon tinfo body
 
-    createRegularConv body = do
-        name <- rangeCheckedMaybe (newConvName body)
-        uids <- checkedConvAndTeamSize (newConvUsers body)
-        ensureConnected zusr (fromConvTeamSize uids)
-        c <- Data.createConversation zusr name (access body) (accessRole body) uids (newConvTeam body) (newConvMessageTimer body)
-        notifyCreatedConversation Nothing zusr (Just zcon) c
-        conversationResponse status201 zusr c
+-- | An internal endpoint for creating managed group conversations. Will
+-- throw an error for everything else.
+internalCreateManagedConversation
+    :: UserId ::: ConnId ::: Request ::: JSON -> Galley Response
+internalCreateManagedConversation (zusr ::: zcon ::: req ::: _) = do
+    body :: NewConv <- fromBody req invalidPayload
+    case newConvTeam body of
+        Nothing -> throwM internalError
+        Just tinfo -> do
+            unless (cnvManaged tinfo) $ throwM internalError
+            createTeamGroupConv zusr zcon tinfo body
 
-    accessRole b = fromMaybe Data.defRole (newConvAccessRole b)
+-- | A helper for creating a regular (non-team) group conversation.
+createRegularGroupConv :: UserId -> ConnId -> NewConv -> Galley Response
+createRegularGroupConv zusr zcon body = do
+    name <- rangeCheckedMaybe (newConvName body)
+    uids <- checkedConvAndTeamSize (newConvUsers body)
+    ensureConnected zusr (fromConvTeamSize uids)
+    c <- Data.createConversation zusr name (access body) (accessRole body) uids (newConvTeam body) (newConvMessageTimer body)
+    notifyCreatedConversation Nothing zusr (Just zcon) c
+    conversationResponse status201 zusr c
 
-    access a = case Set.toList (newConvAccess a) of
-        []     -> Data.defRegularConvAccess
-        (x:xs) -> x:xs
+-- | A helper for creating a team group conversation. Both normal and
+-- managed conversations are allowed here.
+createTeamGroupConv :: UserId -> ConnId -> ConvTeamInfo -> NewConv -> Galley Response
+createTeamGroupConv zusr zcon tinfo body = do
+    name <- rangeCheckedMaybe (newConvName body)
+    mems <- Data.teamMembers (cnvTeamId tinfo)
+    ensureAccessRole (accessRole body) (newConvUsers body) (Just mems)
+    void $ permissionCheck zusr CreateConversation mems
+    uids <-
+        if cnvManaged tinfo then do
+            let uu = filter (/= zusr) $ map (view userId) mems
+            checkedConvAndTeamSize uu
+        else do
+            void $ permissionCheck zusr AddConversationMember mems
+            uu <- checkedConvAndTeamSize (newConvUsers body)
+            ensureConnected zusr (notTeamMember (fromConvTeamSize uu) mems)
+            pure uu
+    conv <- Data.createConversation zusr name (access body) (accessRole body) uids (newConvTeam body) (newConvMessageTimer body)
+    now  <- liftIO getCurrentTime
+    let d = Teams.EdConvCreate (Data.convId conv)
+    let e = newEvent Teams.ConvCreate (cnvTeamId tinfo) now & eventData .~ Just d
+    let notInConv = Set.fromList (map (view userId) mems) \\ Set.fromList (zusr : fromConvTeamSize uids)
+    for_ (newPush zusr (TeamEvent e) (map userRecipient (Set.toList notInConv))) push1
+    notifyCreatedConversation (Just now) zusr (Just zcon) conv
+    conversationResponse status201 zusr conv
+
+----------------------------------------------------------------------------
+-- Other kinds of conversations
 
 createSelfConversation :: UserId -> Galley Response
 createSelfConversation zusr = do
@@ -201,3 +229,11 @@ toUUIDs a b = do
     a' <- U.fromUUID (toUUID a) & ifNothing invalidUUID4
     b' <- U.fromUUID (toUUID b) & ifNothing invalidUUID4
     return (a', b')
+
+accessRole :: NewConv -> AccessRole
+accessRole b = fromMaybe Data.defRole (newConvAccessRole b)
+
+access :: NewConv -> [Access]
+access a = case Set.toList (newConvAccess a) of
+    []     -> Data.defRegularConvAccess
+    (x:xs) -> x:xs

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -88,7 +88,7 @@ teamMemberNotFound :: Error
 teamMemberNotFound = Error status404 "no-team-member" "team member not found"
 
 noManagedTeamConv :: Error
-noManagedTeamConv = Error status400 "no-managed-team-conv" "Managed team conversations are not allowed in this context."
+noManagedTeamConv = Error status400 "no-managed-team-conv" "Managed team conversations have been deprecated."
 
 userBindingExists :: Error
 userBindingExists = Error status403 "binding-exists" "User already bound to a different team."

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -440,10 +440,10 @@ postConvertTeamConv g b c setup = do
     connectUsers b alice (singleton eve)
     let acc = Just $ Set.fromList [InviteAccess, CodeAccess]
     -- creating a team-only conversation containing eve should fail
-    createTeamConvAccessRaw g alice (ConvTeamInfo tid False) [bob, eve] (Just "blaa") acc (Just TeamAccessRole) Nothing !!!
+    createTeamConvAccessRaw g alice tid [bob, eve] (Just "blaa") acc (Just TeamAccessRole) Nothing !!!
         const 403 === statusCode
     -- create conversation allowing any type of guest
-    conv <- createTeamConvAccess g alice (ConvTeamInfo tid False) [bob, eve] (Just "blaa") acc (Just NonActivatedAccessRole) Nothing
+    conv <- createTeamConvAccess g alice tid [bob, eve] (Just "blaa") acc (Just NonActivatedAccessRole) Nothing
     -- mallory joins by herself
     mallory  <- ephemeralUser b
     j <- decodeConvCodeEvent <$> postConvCode g alice conv
@@ -631,7 +631,7 @@ postO2OConvOk g b _ _ = do
 postConvO2OFailWithSelf :: Galley -> Brig -> Cannon -> TestSetup -> Http ()
 postConvO2OFailWithSelf g b _ _ = do
     alice <- randomUser b
-    let inv = NewConv [alice] Nothing mempty Nothing Nothing Nothing
+    let inv = NewConvUnmanaged (NewConv [alice] Nothing mempty Nothing Nothing Nothing)
     post (g . path "/conversations/one2one" . zUser alice . zConn "conn" . zType "access" . json inv) !!! do
         const 403 === statusCode
         const (Just "invalid-op") === fmap label . decodeBody

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -89,7 +89,7 @@ messageTimerChangeGuest g b _ca _ = do
     connectUsers b owner (list1 member [guest])
     tid <- createTeam g "team" owner [Teams.newTeamMember member Teams.fullPermissions]
     -- Create a conversation
-    cid <- createTeamConv g owner (ConvTeamInfo tid False) [member, guest] Nothing Nothing Nothing
+    cid <- createTeamConv g owner tid [member, guest] Nothing Nothing Nothing
     -- Try to change the timer (as the guest user) and observe failure
     putMessageTimerUpdate g guest cid (ConversationMessageTimerUpdate timer1sec) !!! do
         const 403 === statusCode

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -403,21 +403,6 @@ testAddTeamConv g b c _ = do
             Util.assertNotConvMember g extern
 
         WS.assertNoEvent timeout ws
-  where
-    checkTeamConvCreateEvent tid cid w = WS.assertMatch_ timeout w $ \notif -> do
-        ntfTransient notif @?= False
-        let e = List1.head (WS.unpackPayload notif)
-        e^.eventType @?= ConvCreate
-        e^.eventTeam @?= tid
-        e^.eventData @?= Just (EdConvCreate cid)
-
-    checkConvCreateEvent cid w = WS.assertMatch_ timeout w $ \notif -> do
-        ntfTransient notif @?= False
-        let e = List1.head (WS.unpackPayload notif)
-        evtType e @?= Conv.ConvCreate
-        case evtData e of
-            Just (Conv.EdConversation x) -> cnvId x @?= cid
-            other                        -> assertFailure $ "Unexpected event data: " <> show other
 
 testAddTeamConvWithUsers :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
 testAddTeamConvWithUsers g b _ _ = do
@@ -774,6 +759,23 @@ checkTeamMemberLeave tid usr w = WS.assertMatch_ timeout w $ \notif -> do
     e^.eventType @?= MemberLeave
     e^.eventTeam @?= tid
     e^.eventData @?= Just (EdMemberLeave usr)
+
+checkTeamConvCreateEvent :: TeamId -> ConvId -> WS.WebSocket -> Http ()
+checkTeamConvCreateEvent tid cid w = WS.assertMatch_ timeout w $ \notif -> do
+    ntfTransient notif @?= False
+    let e = List1.head (WS.unpackPayload notif)
+    e^.eventType @?= ConvCreate
+    e^.eventTeam @?= tid
+    e^.eventData @?= Just (EdConvCreate cid)
+
+checkConvCreateEvent :: ConvId -> WS.WebSocket -> Http ()
+checkConvCreateEvent cid w = WS.assertMatch_ timeout w $ \notif -> do
+    ntfTransient notif @?= False
+    let e = List1.head (WS.unpackPayload notif)
+    evtType e @?= Conv.ConvCreate
+    case evtData e of
+        Just (Conv.EdConversation x) -> cnvId x @?= cid
+        other                        -> assertFailure $ "Unexpected event data: " <> show other
 
 checkTeamDeleteEvent :: TeamId -> WS.WebSocket -> Http ()
 checkTeamDeleteEvent tid w = WS.assertMatch_ timeout w $ \notif -> do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -163,6 +163,19 @@ createTeamConvAccessRaw g u tinfo us name acc role mtimer = do
           . json conv
           )
 
+createManagedConv :: HasCallStack => Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe Milliseconds -> Http ConvId
+createManagedConv g u tinfo us name acc mtimer = do
+    let conv = NewConv us name (fromMaybe (Set.fromList []) acc) Nothing (Just tinfo) mtimer
+    r <- post ( g
+              . path "i/conversations/managed"
+              . zUser u
+              . zConn "conn"
+              . zType "access"
+              . json conv
+              )
+         <!! const 201 === statusCode
+    fromBS (getHeader' "Location" r)
+
 createOne2OneTeamConv :: Galley -> UserId -> UserId -> Maybe Text -> TeamId -> Http ResponseLBS
 createOne2OneTeamConv g u1 u2 n tid = do
     let conv = NewConv [u2] n mempty Nothing (Just $ ConvTeamInfo tid False) Nothing

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -144,17 +144,19 @@ addTeamMemberInternal g tid mem = do
     post (g . paths ["i", "teams", toByteString' tid, "members"] . payload) !!!
         const 200 === statusCode
 
-createTeamConv :: HasCallStack => Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe Milliseconds -> Http ConvId
-createTeamConv g u tinfo us name acc mtimer = createTeamConvAccess g u tinfo us name acc Nothing mtimer
+createTeamConv :: HasCallStack => Galley -> UserId -> TeamId -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe Milliseconds -> Http ConvId
+createTeamConv g u tid us name acc mtimer = createTeamConvAccess g u tid us name acc Nothing mtimer
 
-createTeamConvAccess :: HasCallStack => Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe AccessRole -> Maybe Milliseconds -> Http ConvId
-createTeamConvAccess g u tinfo us name acc role mtimer = do
-    r <- createTeamConvAccessRaw g u tinfo us name acc role mtimer <!! const 201 === statusCode
+createTeamConvAccess :: HasCallStack => Galley -> UserId -> TeamId -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe AccessRole -> Maybe Milliseconds -> Http ConvId
+createTeamConvAccess g u tid us name acc role mtimer = do
+    r <- createTeamConvAccessRaw g u tid us name acc role mtimer <!! const 201 === statusCode
     fromBS (getHeader' "Location" r)
 
-createTeamConvAccessRaw :: Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe AccessRole -> Maybe Milliseconds -> Http ResponseLBS
-createTeamConvAccessRaw g u tinfo us name acc role mtimer = do
-    let conv = NewConv us name (fromMaybe (Set.fromList []) acc) role (Just tinfo) mtimer
+createTeamConvAccessRaw :: Galley -> UserId -> TeamId -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe AccessRole -> Maybe Milliseconds -> Http ResponseLBS
+createTeamConvAccessRaw g u tid us name acc role mtimer = do
+    let tinfo = ConvTeamInfo tid False
+    let conv = NewConvUnmanaged $
+               NewConv us name (fromMaybe (Set.fromList []) acc) role (Just tinfo) mtimer
     post ( g
           . path "/conversations"
           . zUser u
@@ -163,9 +165,11 @@ createTeamConvAccessRaw g u tinfo us name acc role mtimer = do
           . json conv
           )
 
-createManagedConv :: HasCallStack => Galley -> UserId -> ConvTeamInfo -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe Milliseconds -> Http ConvId
-createManagedConv g u tinfo us name acc mtimer = do
-    let conv = NewConv us name (fromMaybe (Set.fromList []) acc) Nothing (Just tinfo) mtimer
+createManagedConv :: HasCallStack => Galley -> UserId -> TeamId -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe Milliseconds -> Http ConvId
+createManagedConv g u tid us name acc mtimer = do
+    let tinfo = ConvTeamInfo tid True
+    let conv = NewConvManaged $
+               NewConv us name (fromMaybe (Set.fromList []) acc) Nothing (Just tinfo) mtimer
     r <- post ( g
               . path "i/conversations/managed"
               . zUser u
@@ -178,12 +182,13 @@ createManagedConv g u tinfo us name acc mtimer = do
 
 createOne2OneTeamConv :: Galley -> UserId -> UserId -> Maybe Text -> TeamId -> Http ResponseLBS
 createOne2OneTeamConv g u1 u2 n tid = do
-    let conv = NewConv [u2] n mempty Nothing (Just $ ConvTeamInfo tid False) Nothing
+    let conv = NewConvUnmanaged $
+               NewConv [u2] n mempty Nothing (Just $ ConvTeamInfo tid False) Nothing
     post $ g . path "/conversations/one2one" . zUser u1 . zConn "conn" . zType "access" . json conv
 
 postConv :: Galley -> UserId -> [UserId] -> Maybe Text -> [Access] -> Maybe AccessRole -> Maybe Milliseconds -> Http ResponseLBS
 postConv g u us name a r mtimer = do
-    let conv = NewConv us name (Set.fromList a) r Nothing mtimer
+    let conv = NewConvUnmanaged $ NewConv us name (Set.fromList a) r Nothing mtimer
     post $ g . path "/conversations" . zUser u . zConn "conn" . zType "access" . json conv
 
 postSelfConv :: Galley -> UserId -> Http ResponseLBS
@@ -191,7 +196,7 @@ postSelfConv g u = post $ g . path "/conversations/self" . zUser u . zConn "conn
 
 postO2OConv :: Galley -> UserId -> UserId -> Maybe Text -> Http ResponseLBS
 postO2OConv g u1 u2 n = do
-    let conv = NewConv [u2] n mempty Nothing Nothing Nothing
+    let conv = NewConvUnmanaged $ NewConv [u2] n mempty Nothing Nothing Nothing
     post $ g . path "/conversations/one2one" . zUser u1 . zConn "conn" . zType "access" . json conv
 
 postConnectConv :: Galley -> UserId -> UserId -> Text -> Text -> Maybe Text -> Http ResponseLBS


### PR DESCRIPTION
Now we have an internal endpoint for creating them, and that endpoint is still used for tests. The public endpoint forbids creating them.