### PR TITLE
Expose push tokens over the public API

### DIFF
--- a/services/gundeck/src/Gundeck/API.hs
+++ b/services/gundeck/src/Gundeck/API.hs
@@ -112,8 +112,14 @@ sitemap = do
             description "The notification ID"
         response 200 "Pending fallback notification cancelled" end
 
-    get "/i/push/tokens" (continue Push.listTokens) $
-        header "Z-User" .&. accept "application" "json"
+    get "/push/tokens" (continue Push.listTokens) $
+        header "Z-User"
+        .&. accept "application" "json"
+
+    document "GET" "getPushTokens" $ do
+        summary "List the user's registered push tokens."
+        returns (ref Model.push)
+        response 200 "List of push tokens" end
 
     post "/i/push" (continue Push.push) $
         request .&. accept "application" "json"

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -890,7 +890,7 @@ unregisterPushToken u t g = do
 listPushTokens :: UserId -> Gundeck -> Http [PushToken]
 listPushTokens u g = do
     rs <- get ( runGundeck g
-              . path "/i/push/tokens"
+              . path "push/tokens"
               . zUser u
               . zConn "random"
               )

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -890,7 +890,7 @@ unregisterPushToken u t g = do
 listPushTokens :: UserId -> Gundeck -> Http [PushToken]
 listPushTokens u g = do
     rs <- get ( runGundeck g
-              . path "push/tokens"
+              . path "/push/tokens"
               . zUser u
               . zConn "random"
               )


### PR DESCRIPTION
This PR simply exposes a previously internal only endpoint (was not needed by clients but useful for debugging purposes on the client side)