### PR TITLE
Change end-point name from /i/backdoor-login to /i/sso-login.

### DIFF
--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -565,8 +565,8 @@ login = defineModel "Login" $ do
                     \specific client."
         optional
 
-backdoorLogin :: Model
-backdoorLogin = defineModel "BackdoorLogin" $ do
+ssoLogin :: Model
+ssoLogin = defineModel "SsoLogin" $ do
     description "Payload for performing a credential-less login."
     property "user" bytes' $
         description "User ID"

--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -565,18 +565,6 @@ login = defineModel "Login" $ do
                     \specific client."
         optional
 
-ssoLogin :: Model
-ssoLogin = defineModel "SsoLogin" $ do
-    description "Payload for performing a credential-less login."
-    property "user" bytes' $
-        description "User ID"
-    property "label" string' $ do
-        description "A label to associate with the returned cookie. \
-                    \Every client should have a unique and stable (persistent) label \
-                    \to allow targeted revocation of all cookies granted to that \
-                    \specific client."
-        optional
-
 accessToken :: Model
 accessToken = defineModel "AccessToken" $ do
     description "An API access token."

--- a/libs/brig-types/src/Brig/Types/User/Auth.hs
+++ b/libs/brig-types/src/Brig/Types/User/Auth.hs
@@ -52,8 +52,8 @@ data Login
     | SmsLogin !Phone !LoginCode !(Maybe CookieLabel)
 
 -- | A special kind of login that is only used for an internal endpoint.
-data BackdoorLogin
-    = BackdoorLogin !UserId !(Maybe CookieLabel)
+data SsoLogin
+    = SsoLogin !UserId !(Maybe CookieLabel)
 
 loginLabel :: Login -> Maybe CookieLabel
 loginLabel (PasswordLogin _ _ l) = l
@@ -103,12 +103,12 @@ instance ToJSON Login where
     toJSON (PasswordLogin login password label) =
         object [ "password" .= password, "label" .= label, loginIdPair login ]
 
-instance FromJSON BackdoorLogin where
-    parseJSON = withObject "BackdoorLogin" $ \o ->
-        BackdoorLogin <$> o .: "user" <*> o .:? "label"
+instance FromJSON SsoLogin where
+    parseJSON = withObject "SsoLogin" $ \o ->
+        SsoLogin <$> o .: "user" <*> o .:? "label"
 
-instance ToJSON BackdoorLogin where
-    toJSON (BackdoorLogin uid label) =
+instance ToJSON SsoLogin where
+    toJSON (SsoLogin uid label) =
         object [ "user" .= uid, "label" .= label ]
 
 instance FromJSON PendingLoginCode where

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -151,22 +151,6 @@ routes = do
         .&. accept "application" "json"
         .&. contentType "application" "json"
 
-    document "POST" "ssoLogin" $ do
-        Doc.summary "Login as any user, without credentials."
-        Doc.notes "This is an internal version of the /login endpoint. It does not \
-                  \require any credentials, and it is supposed to be used for \
-                  \single sign-on primarily."
-        Doc.body (Doc.ref Doc.ssoLogin) $
-            Doc.description "The optional label can later be used to delete all \
-                            \cookies matching this label (cf. /cookies/remove)."
-        Doc.parameter Doc.Query "persist" (Doc.bool $ Doc.def False) $ do
-            Doc.description "Request a persistent cookie instead of a session cookie."
-            Doc.optional
-        Doc.errorResponse badCredentials
-        Doc.errorResponse accountSuspended
-        Doc.errorResponse accountPending
-        Doc.errorResponse loginsTooFrequent
-
     get "/i/users/login-code" (continue getLoginCode) $
         accept "application" "json"
         .&. param "phone"

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -145,18 +145,18 @@ routes = do
 
     -- Internal
 
-    post "/i/backdoor-login" (continue backdoorLogin) $
+    post "/i/sso-login" (continue ssoLogin) $
         request
         .&. def False (query "persist")
         .&. accept "application" "json"
         .&. contentType "application" "json"
 
-    document "POST" "backdoorLogin" $ do
+    document "POST" "ssoLogin" $ do
         Doc.summary "Login as any user, without credentials."
         Doc.notes "This is an internal version of the /login endpoint. It does not \
                   \require any credentials, and it is supposed to be used for \
                   \single sign-on primarily."
-        Doc.body (Doc.ref Doc.backdoorLogin) $
+        Doc.body (Doc.ref Doc.ssoLogin) $
             Doc.description "The optional label can later be used to delete all \
                             \cookies matching this label (cf. /cookies/remove)."
         Doc.parameter Doc.Query "persist" (Doc.bool $ Doc.def False) $ do
@@ -203,11 +203,11 @@ login (req ::: persist ::: _) = do
     a <- Auth.login l typ !>> loginError
     tokenResponse a
 
-backdoorLogin :: Request ::: Bool ::: JSON ::: JSON -> Handler Response
-backdoorLogin (req ::: persist ::: _) = do
+ssoLogin :: Request ::: Bool ::: JSON ::: JSON -> Handler Response
+ssoLogin (req ::: persist ::: _) = do
     l <- parseJsonBody req
     let typ = if persist then PersistentCookie else SessionCookie
-    a <- Auth.backdoorLogin l typ !>> loginError
+    a <- Auth.ssoLogin l typ !>> loginError
     tokenResponse a
 
 logout :: JSON ::: Maybe ZAuth.UserToken ::: Maybe ZAuth.AccessToken -> Handler Response
@@ -271,4 +271,3 @@ tokenRequest = opt userToken .&. opt accessToken
 tokenResponse :: Auth.Access -> Handler Response
 tokenResponse (Auth.Access t  Nothing) = return (json t)
 tokenResponse (Auth.Access t (Just c)) = lift $ Auth.setResponseCookie c (json t)
-

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -12,7 +12,7 @@ module Brig.User.Auth
 
       -- * Internal
     , lookupLoginCode
-    , backdoorLogin
+    , ssoLogin
 
       -- * Re-exports
     , listCookies
@@ -186,8 +186,8 @@ validateTokens ut at = do
     return (ZAuth.userTokenOf ut, ck)
 
 -- | Allow to login as any user without having the credentials.
-backdoorLogin :: BackdoorLogin -> CookieType -> ExceptT LoginError AppIO Access
-backdoorLogin (BackdoorLogin uid label) typ = do
+ssoLogin :: SsoLogin -> CookieType -> ExceptT LoginError AppIO Access
+ssoLogin (SsoLogin uid label) typ = do
     Data.reauthenticate uid Nothing `catchE` \case
         ReAuthMissingPassword -> pure ()
         ReAuthError e -> case e of

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -202,9 +202,9 @@ login b l t = let js = RequestBodyLBS (encode l) in post $ b
     . (if t == PersistentCookie then queryItem "persist" "true" else id)
     . body js
 
-backdoorLogin :: Brig -> BackdoorLogin -> CookieType -> Http ResponseLBS
-backdoorLogin b l t = let js = RequestBodyLBS (encode l) in post $ b
-    . path "/i/backdoor-login"
+ssoLogin :: Brig -> SsoLogin -> CookieType -> Http ResponseLBS
+ssoLogin b l t = let js = RequestBodyLBS (encode l) in post $ b
+    . path "/i/sso-login"
     . contentJson
     . (if t == PersistentCookie then queryItem "persist" "true" else id)
     . body js


### PR DESCRIPTION
The old name introduced in https://github.com/wireapp/wire-server/pull/329 was confusing and prone to create misunderstandings.

This end-point will be used for SSO login.  Neither does it violate our attack model, nor is security deteriorated in any way.  Without it, admins with access to the cassandra nodes on the server would still be able to impersonate any user by temporarily replacing their password.