### PR TITLE
Alternatively use SMTP for email

### DIFF
--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -25,14 +25,15 @@ gundeck:
   port: 8086
 
 aws:
-  sesQueue: integration-brig-events
-  internalQueue: integration-brig-events-internal
   blacklistTable: integration-brig-userkey-blacklist
   prekeyTable: integration-brig-prekeys
   sesEndpoint: http://localhost:4569 # https://email.eu-west-1.amazonaws.com
   sqsEndpoint: http://localhost:4568 # https://sqs.eu-west-1.amazonaws.com
   dynamoDBEndpoint: http://localhost:4567 # https://dynamodb.eu-west-1.amazonaws.com
 emailSMS:
+  email:
+    sesQueue: integration-brig-events
+    internalQueue: integration-brig-events-internal
   general:
     templateDir: resources/templates
     emailSender: backend-integration@wire.com

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -62,6 +62,7 @@ library
       , Brig.Provider.RPC
       , Brig.Provider.Template
       , Brig.RPC
+      , Brig.SMTP
       , Brig.Team.API
       , Brig.Team.DB
       , Brig.Team.Email
@@ -157,6 +158,7 @@ library
       , pem                       >= 0.2
       , proto-lens                >= 0.1
       , resourcet                 >= 1.1
+      , resource-pool             >= 0.2
       , ropes                     >= 0.4.20
       , safe                      >= 0.3
       , scientific                >= 0.3.4

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -133,6 +133,8 @@ library
       , http-client               >= 0.5
       , http-client-openssl-ext   >= 0.1
       , http-types                >= 0.8
+      , HaskellNet                >= 0.3
+      , HaskellNet-SSL            >= 0.3
       , HsOpenSSL                 >= 0.10
       , HsOpenSSL-x509-system     >= 0.1
       , iproute                   >= 1.5
@@ -159,6 +161,7 @@ library
       , safe                      >= 0.3
       , scientific                >= 0.3.4
       , scrypt                    >= 0.5
+      , smtp-mail                 >= 0.1
       , split                     >= 0.2
       , semigroups                >= 0.15
       , singletons                >= 2.0

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -30,6 +30,10 @@ aws:
   userJournalQueue: integration-user-events.fifo
   # ^ Comment this out if you don't want to journal user events
   blacklistTable: integration-brig-userkey-blacklist
+  # ^ NOTE: blacklisting of emails (processing of bounces and complaints)  is only done
+  #         automatically IF sesQueue/sesEndpoint are used. If SMTP is used directly, the
+  #         operator must handle these notifications "manually" (there are internal endpoints)
+  #         that may be used for this
   prekeyTable: integration-brig-prekeys
   sqsEndpoint: http://localhost:4568 # https://sqs.eu-west-1.amazonaws.com
   dynamoDBEndpoint: http://localhost:4567 # https://dynamodb.eu-west-1.amazonaws.com

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -38,11 +38,12 @@ emailSMS:
   # or you can use SMTP directly (blacklisting of email/phone must be otherwise handled by
   # the operator).
   email:
-    # sesQueue: integration-brig-events
-    # sesEndpoint: http://localhost:4569 # https://email.eu-west-1.amazonaws.com
-    smtpEndpoint: email-smtp.eu-west-1.amazonaws.com
-    smtpUser: foo
-    smtpPassword: bar
+    sesQueue: integration-brig-events
+    sesEndpoint: http://localhost:4569 # https://email.eu-west-1.amazonaws.com
+    # smtpEndpoint: email-smtp.eu-west-1.amazonaws.com
+    # smtpUsername: <username>
+    # smtpPassword: <password>
+    # smtpConnType: tls
 
   general:
     templateDir: deb/opt/brig/templates

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -41,11 +41,13 @@ emailSMS:
     sesQueue: integration-brig-events
     sesEndpoint: http://localhost:4569 # https://email.eu-west-1.amazonaws.com
     # If you prefer to use SMTP directly, uncomment the following lines
-    # and set the correct credentials
-    # smtpEndpoint: email-smtp.eu-west-1.amazonaws.com
-    # smtpUsername: foo
-    # smtpPassword: <path_to_file_with_password>
-    # smtpConnType: tls | ssl | plain
+    # and set the correct credentials.
+    # NOTE: In case a user tries to supply config values for both SES and SMTP,
+    #       SES takes precedence and gets used instead
+    # smtpEndpoint: <hostname>
+    # smtpUsername: <username>
+    # smtpPassword: test/resources/smtp-secret.txt
+    # smtpConnType: tls
 
   general:
     templateDir: deb/opt/brig/templates

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -26,16 +26,24 @@ gundeck:
 
 # You can set up local SQS/Dynamo running e.g. `../../deploy/docker-ephemeral/run.sh`
 aws:
-  sesQueue: integration-brig-events
   internalQueue: integration-brig-events-internal
   userJournalQueue: integration-user-events.fifo
   # ^ Comment this out if you don't want to journal user events
   blacklistTable: integration-brig-userkey-blacklist
   prekeyTable: integration-brig-prekeys
-  sesEndpoint: http://localhost:4569 # https://email.eu-west-1.amazonaws.com
   sqsEndpoint: http://localhost:4568 # https://sqs.eu-west-1.amazonaws.com
   dynamoDBEndpoint: http://localhost:4567 # https://dynamodb.eu-west-1.amazonaws.com
 emailSMS:
+  # You can either use SES directly (in which case, ensure a feedback queue is configured)
+  # or you can use SMTP directly (blacklisting of email/phone must be otherwise handled by
+  # the operator).
+  email:
+    # sesQueue: integration-brig-events
+    # sesEndpoint: http://localhost:4569 # https://email.eu-west-1.amazonaws.com
+    smtpEndpoint: email-smtp.eu-west-1.amazonaws.com
+    smtpUser: foo
+    smtpPassword: bar
+
   general:
     templateDir: deb/opt/brig/templates
     emailSender: backend-integration@wire.com

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -40,10 +40,12 @@ emailSMS:
   email:
     sesQueue: integration-brig-events
     sesEndpoint: http://localhost:4569 # https://email.eu-west-1.amazonaws.com
+    # If you prefer to use SMTP directly, uncomment the following lines
+    # and set the correct credentials
     # smtpEndpoint: email-smtp.eu-west-1.amazonaws.com
-    # smtpUsername: <username>
-    # smtpPassword: <password>
-    # smtpConnType: tls
+    # smtpUsername: foo
+    # smtpPassword: <path_to_file_with_password>
+    # smtpConnType: tls | ssl | plain
 
   general:
     templateDir: deb/opt/brig/templates

--- a/services/brig/src/Brig/AWS.hs
+++ b/services/brig/src/Brig/AWS.hs
@@ -16,6 +16,7 @@ module Brig.AWS
     , amazonkaEnv
     , execute
     , sesQueue
+    , sesConfigured
     , internalQueue
     , userJournalQueue
     , blacklistTable
@@ -51,6 +52,7 @@ import Control.Monad.Trans.Resource
 import Control.Retry
 import Data.Aeson hiding ((.=))
 import Data.Foldable (for_)
+import Data.Maybe (isJust)
 import Data.Monoid
 import Data.Text (Text, isPrefixOf)
 import Data.Typeable
@@ -79,7 +81,8 @@ import qualified System.Logger           as Logger
 
 data Env = Env
     { _logger           :: !Logger
-    , _sesQueue         :: !Text
+    , _sesQueue         :: !(Maybe Text)
+    , _sesConfigured    :: !Bool
     , _internalQueue    :: !Text
     , _userJournalQueue :: !(Maybe Text)
     , _blacklistTable   :: !Text
@@ -114,23 +117,24 @@ instance MonadBaseControl IO Amazon where
 instance AWS.MonadAWS Amazon where
     liftAWS a = view amazonkaEnv >>= flip AWS.runAWS a
 
-mkEnv :: Logger -> Opt.AWSOpts -> Manager -> IO Env
-mkEnv lgr opts mgr = do
+mkEnv :: Logger -> Opt.AWSOpts -> Maybe Opt.EmailAWSOpts -> Manager -> IO Env
+mkEnv lgr opts emailOpts mgr = do
     let g = Logger.clone (Just "aws.brig") lgr
     let (bl, pk) = (Opt.blacklistTable opts, Opt.prekeyTable opts)
-    e  <- mkAwsEnv g (mkEndpoint SES.ses      (Opt.sesEndpoint opts))
+    let sesEndpoint = maybe Nothing (Just . mkEndpoint SES.ses . Opt.sesEndpoint) emailOpts
+    e  <- mkAwsEnv g sesEndpoint
                      (mkEndpoint SQS.sqs      (Opt.sqsEndpoint opts))
                      (mkEndpoint DDB.dynamoDB (Opt.dynamoDBEndpoint opts))
-    sq <- getQueueUrl e (Opt.sesQueue opts)
+    sq <- maybe (return Nothing) (fmap Just . getQueueUrl e . Opt.sesQueue) emailOpts
     iq <- getQueueUrl e (Opt.internalQueue opts)
     jq <- maybe (return Nothing) (fmap Just . getQueueUrl e) (Opt.userJournalQueue opts)
-    return (Env g sq iq jq bl pk e)
+    return (Env g sq (isJust sq) iq jq bl pk e)
   where
     mkEndpoint svc e = AWS.setEndpoint (e^.awsSecure) (e^.awsHost) (e^.awsPort) svc
 
     mkAwsEnv g ses sqs dyn =  set AWS.envLogger (awsLogger g)
                           <$> AWS.newEnvWith AWS.Discover Nothing mgr
-                          <&> AWS.configure ses
+                          <&> maybe id AWS.configure ses
                           <&> AWS.configure sqs
                           <&> AWS.configure dyn
 

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -215,8 +215,8 @@ newEnv o = do
     emailConn lgr (Opt.EmailSMTP  s) = do
         let host = Opt.smtpEndpoint s
             user = SMTP.Username (Opt.smtpUsername s)
-            pass = SMTP.Password (Opt.smtpPassword s)
-        smtp <- SMTP.initSMTP lgr host user pass (Opt.smtpConnType s)
+        pass <- initCredentials (Opt.smtpPassword s)
+        smtp <- SMTP.initSMTP lgr host user (SMTP.Password pass) (Opt.smtpConnType s)
         return (Nothing, Just smtp)
 
     mkEndpoint service = RPC.host (encodeUtf8 (service^.epHost)) . RPC.port (service^.epPort) $ RPC.empty

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -117,8 +117,8 @@ data EmailOpts = EmailAWS  EmailAWSOpts
                deriving (Show, Generic)
 
 instance FromJSON EmailOpts where
-    parseJSON o = do
-      (return . EmailAWS =<< parseJSON o) <|> (return . EmailSMTP =<< parseJSON o)
+    parseJSON o =  EmailAWS <$> parseJSON o
+               <|> EmailSMTP <$> parseJSON o
 
 data EmailSMSOpts = EmailSMSOpts
     { email    :: !EmailOpts

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -70,7 +70,7 @@ instance FromJSON EmailAWSOpts
 data EmailSMTPOpts = EmailSMTPOpts
     { smtpEndpoint :: !Text
     , smtpUsername :: !Text
-    , smtpPassword :: !Text
+    , smtpPassword :: !FilePathSecrets
     , smtpConnType :: !SMTPConnType
     } deriving (Show, Generic)
 
@@ -383,9 +383,9 @@ emailSMTPOptsParser =
       (textOption $
         long "smtp-username" <> metavar "STRING" <>
         help "Username to authenticate against the SMTP server") <*>
-      (textOption $
-        long "smtp-password" <> metavar "STRING" <>
-        help "Password to authenticate against the SMTP server") <*>
+      (FilePathSecrets <$> (strOption $
+        long "smtp-password" <> metavar "FILE" <>
+        help "File containing password to authenticate against the SMTP server" <> action "file")) <*>
       (smtpConnTypeOption $
         long "smtp-conn-type" <> metavar "STRING" <> value "tls" <> showDefault <>
         help "Which type of connection to use against the SMTP server {tls,ssl,plain}")

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE ViewPatterns      #-}
+
+module Brig.SMTP where
+
+import Control.Lens
+import Control.Monad (unless)
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Control
+import Data.Aeson
+import Data.Aeson.TH
+import Data.Char (toLower)
+import Data.Pool
+import Data.Text (Text, unpack)
+import Network.Mail.Mime
+import System.Logger.Class hiding (create)
+
+import qualified Network.HaskellNet.SMTP     as SMTP
+import qualified Network.HaskellNet.SMTP.SSL as SMTP
+import qualified System.Logger               as Logger
+
+newtype Username = Username Text
+newtype Password = Password Text
+
+data SMTP = SMTP
+    { _pool :: !(Pool SMTP.SMTPConnection)
+    }
+
+data SMTPConnType = Plain
+                  | TLS
+                  | SSL
+                  deriving (Eq, Show)
+
+deriveJSON defaultOptions { constructorTagModifier = map toLower } ''SMTPConnType
+
+makeLenses ''SMTP
+
+initSMTP :: Logger -> Text -> Username -> Password -> SMTPConnType -> IO SMTP
+initSMTP lg host (Username user) (Password pass) connType = do
+    -- Try to initiate a connection and fail badly right away in case of bad auth
+    -- otherwise config errors will be detected "too late"
+    (success, _) <- connect
+    unless success $
+      error "Failed to authenticate against the SMTP server"
+    SMTP <$> createPool create destroy 1 5 5
+  where
+    connect = do
+      conn <- case connType of
+                  Plain -> SMTP.connectSMTP (unpack host)
+                  TLS   -> SMTP.connectSMTPSTARTTLS (unpack host)
+                  SSL   -> SMTP.connectSMTPSSL (unpack host)
+      ok   <- SMTP.authenticate SMTP.LOGIN (unpack user) (unpack pass) conn
+      return (ok, conn)
+
+    create = do
+      (ok, conn) <- connect
+      if ok
+        then Logger.log lg Logger.Debug (msg $ val "Established connection to: " +++ host)
+        else Logger.log lg Logger.Warn (msg $ val "Failed to established connection, check your credentials to connect to: " +++ host )
+      return conn
+
+    destroy _ =
+      Logger.log lg Logger.Debug (msg $ val "Closing connection to: " +++ host)
+
+sendMail :: (MonadBaseControl IO m, MonadIO m) => SMTP -> Mail -> m ()
+sendMail s m = withResource (s^.pool) $ liftIO . SMTP.sendMimeMail2 m

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -61,7 +61,8 @@ initSMTP lg host (Username user) (Password pass) connType = do
         else Logger.log lg Logger.Warn (msg $ val "Failed to established connection, check your credentials to connect to: " +++ host )
       return conn
 
-    destroy _ =
+    destroy c = do
+      SMTP.closeSMTP c
       Logger.log lg Logger.Debug (msg $ val "Closing connection to: " +++ host)
 
 sendMail :: (MonadBaseControl IO m, MonadIO m) => SMTP -> Mail -> m ()

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -306,7 +306,8 @@ testCreateUserBlacklist brig aws =
                         "complaint" -> MailComplaint [em]
                         x           -> error ("Unsupported message type: " ++ show x)
         let queue = env^.AWS.sesQueue
-        void $ AWS.execute env (AWS.enqueueStandard queue bdy)
+        -- Given the startup options, we know that a queue exists iff we use SES
+        for_ queue $ AWS.execute env . flip AWS.enqueueStandard bdy
 
     awaitBlacklist :: Int -> Email -> Http ()
     awaitBlacklist n e = do

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -287,7 +287,7 @@ testCreateUserBlacklist brig aws =
             post (brig . path "/register" . contentJson . body (p e)) !!! const 201 === statusCode
             -- If we are using a local env, we need to fake this bounce
             unless (Util.isRealSESEnv aws) $
-                publishMessage typ e aws
+                forceBlacklist typ e
             -- Typically bounce/complaint messages arrive instantaneously
             awaitBlacklist 30 e
             post (brig . path "/register" . contentJson . body (p e)) !!! do
@@ -299,15 +299,19 @@ testCreateUserBlacklist brig aws =
                                                , "password" .= defPassword
                                                ]
 
-    publishMessage :: Text -> Email -> AWS.Env -> Http ()
-    publishMessage typ em env = do
+    -- If there is no queue available, we need to force it either by publishing an event or using the API
+    forceBlacklist :: Text -> Email -> Http ()
+    forceBlacklist typ em = case aws^.AWS.sesQueue of
+        Just queue -> publishMessage typ em queue
+        Nothing    -> Bilge.post (brig . path "i/users/blacklist" . queryItem "email" (toByteString' em)) !!! const 200 === statusCode
+
+    publishMessage :: Text -> Email -> Text -> Http ()
+    publishMessage typ em queue = do
         let bdy = encode $ case typ of
                         "bounce"    -> MailBounce BouncePermanent [em]
                         "complaint" -> MailComplaint [em]
                         x           -> error ("Unsupported message type: " ++ show x)
-        let queue = env^.AWS.sesQueue
-        -- Given the startup options, we know that a queue exists iff we use SES
-        for_ queue $ AWS.execute env . flip AWS.enqueueStandard bdy
+        void . AWS.execute aws $ AWS.enqueueStandard queue bdy
 
     awaitBlacklist :: Int -> Email -> Http ()
     awaitBlacklist n e = do

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -65,9 +65,9 @@ runTests iConf bConf otherArgs = do
     lg <- Logger.new Logger.defSettings
     db <- defInitCassandra casKey casHost casPort lg
     mg <- newManager tlsManagerSettings
-    let emailAWSOpts = case fmap Opts.email (Opts.emailSMS <$> bConf) of
-                                    Just (Opts.EmailAWS aws) -> Just aws
-                                    _                        -> Nothing
+    let emailAWSOpts = case Opts.email . Opts.emailSMS <$> bConf of
+                                Just (Opts.EmailAWS aws) -> Just aws
+                                _                        -> Nothing
     awsEnv <- AWS.mkEnv lg awsOpts emailAWSOpts mg
 
     userApi     <- User.tests bConf mg b c ch g awsEnv


### PR DESCRIPTION
This PR introduces an optional way to send out emails: by using SMTP instead of forcing SES. The basic functionality works, want to improve a few things namely, we need to ensure that

- [x] - config is backwards compatible (Currently only works if config files are used)
- [x] - SMTP connection can be (re)established (use a pool)
- [x] - integration tests work with both configs
- [x] - general code cleanup

Feedback on how the config file could look easier to read is welcome! 