### PR TITLE
consistent default integration test file path

### DIFF
--- a/services/spar/test-integration/Spec.hs
+++ b/services/spar/test-integration/Spec.hs
@@ -46,5 +46,5 @@ cliOptsParser = (,) <$>
     <> showDefault
     <> value defaultSparPath)
   where
-    defaultIntPath = "/etc/wire/spar/conf/integration.yaml"
+    defaultIntPath = "/etc/wire/integration/integration.yaml"
     defaultSparPath = "/etc/wire/spar/conf/spar.yaml"


### PR DESCRIPTION
(background: kubernetes volume mounting is made easier if config and integration config are put in different directories; also: paths are now consistent with brig/galley/gundeck)