### PR TITLE
Overly static cors policy.

### DIFF
--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -52,6 +52,7 @@ dependencies:
   - types-common
   - uri-bytestring
   - uuid
+  - wai-cors
   - wai-utilities
   - warp
   - x509

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -36,14 +36,13 @@ import qualified Spar.Intra.Brig as Intra
 spec :: SpecWith TestEnv
 spec = do
     describe "CORS" $ do
-      it "is disabled" $ do
-        -- I put this there because I was playing with a CORS middleware to make swagger browsing more
-        -- convenient, but went for a simpler work flow that didn't require that in the end.  I left
-        -- it in so if we ever start adding CORS headers, whether by accident or intentionally, we
-        -- will fall over this test and will have to extend it to document the new behavior.
+      it "works" $ do
+        let corsPolicy = "https://wire-webapp-staging.zinfra.io"
         env <- ask
-        get ((env ^. teSpar) . path "/i/status" . expect2xx)
-          `shouldRespondWith` (\(responseHeaders -> hdrs) -> isNothing $ lookup "Access-Control-Allow-Origin" hdrs)
+        resp <- call $ get ((env ^. teSpar) . path "/i/status" . header "Origin" "https://wire-webapp-staging.zinfra.io" . expect2xx)
+        liftIO $ do
+          lookup "Access-Control-Allow-Origin" (responseHeaders resp)
+            `shouldBe` Just corsPolicy
 
     describe "status, metadata" $ do
       it "brig /i/status" $ do


### PR DESCRIPTION
This is not the final solution, but we're blocking the web team.  The
next-fancier solution I can think of would be to add this to the yaml
config file:

```yaml
cors-allow:
  - "https://wire-webapp-edge.zinfra.io/"
  - "https://wire-webapp-qa.zinfra.io/"
  - "https://wire-webapp-dev.zinfra.io/"
  - "https://wire-webapp-staging.zinfra.io/"
  - "https://wire-webapp-edge.wire.com/"
  - "https://wire-webapp-qa.wire.com/"
  - "https://wire-webapp-dev.wire.com/"
  - "https://wire-webapp-staging.wire.com/"
  - "https://wire-webapp-prod-next.wire.com/"
  - "https://app.wire.com/"
```

I could do that today I guess.
