### PR TITLE
Add a HEAD request for prechecking of authn requests

### DIFF
--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -145,13 +145,12 @@ redirectURLMaxLength :: Int
 redirectURLMaxLength = 140
 
 validateAuthreqParams :: Maybe URI.URI -> Maybe URI.URI -> Spar VerdictFormat
-validateAuthreqParams msucc merr = do
-  case (msucc, merr) of
-    (Nothing, Nothing) -> pure VerdictFormatWeb
-    (Just ok, Just err) -> do
-      validateRedirectURL `mapM_` [ok, err]
-      pure $ VerdictFormatMobile ok err
-    _ -> throwSpar $ SparBadInitiateLoginQueryParams "need-both-redirect-urls"
+validateAuthreqParams msucc merr = case (msucc, merr) of
+  (Nothing, Nothing) -> pure VerdictFormatWeb
+  (Just ok, Just err) -> do
+    validateRedirectURL `mapM_` [ok, err]
+    pure $ VerdictFormatMobile ok err
+  _ -> throwSpar $ SparBadInitiateLoginQueryParams "need-both-redirect-urls"
 
 validateRedirectURL :: URI.URI -> Spar ()
 validateRedirectURL uri = do

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -23,6 +23,7 @@ module Spar.API
   ( app, api
   , API
   , APIMeta
+  , APIAuthReqPrecheck
   , APIAuthReq
   , APIAuthResp
   , IdpGet
@@ -77,6 +78,7 @@ app ctx = SAML.setHttpCachePolicy
 type API = "i" :> "status" :> Get '[JSON] NoContent
       :<|> "sso" :> "api-docs" :> Get '[JSON] Swagger
       :<|> APIMeta
+      :<|> APIAuthReqPrecheck
       :<|> APIAuthReq
       :<|> APIAuthResp
       :<|> IdpGet
@@ -86,7 +88,15 @@ type API = "i" :> "status" :> Get '[JSON] NoContent
       :<|> "i" :> "integration-tests" :> IntegrationTests
       -- NB. If you add endpoints here, also update Test.Spar.APISpec
 
+type CheckOK = Verb 'HEAD 200
+
 type APIMeta     = "sso" :> "metadata" :> SAML.APIMeta
+type APIAuthReqPrecheck
+                 = "sso" :> "initiate-login"
+                :> QueryParam "success_redirect" URI.URI
+                :> QueryParam "error_redirect" URI.URI
+                :> Capture "idp" SAML.IdPId
+                :> CheckOK '[PlainText] NoContent
 type APIAuthReq  = "sso" :> "initiate-login"
                 :> QueryParam "success_redirect" URI.URI
                 :> QueryParam "error_redirect" URI.URI
@@ -107,6 +117,7 @@ api opts =
        pure NoContent
   :<|> pure (toSwagger (Proxy @OutsideWorldAPI))
   :<|> SAML.meta appName (Proxy @API) (Proxy @APIAuthResp)
+  :<|> authreqPrecheck
   :<|> authreq (maxttlAuthreqDiffTime opts)
   :<|> SAML.authresp (SAML.HandleVerdictRaw verdictHandler)
   :<|> idpGet
@@ -118,21 +129,29 @@ api opts =
 appName :: ST
 appName = "spar"
 
+authreqPrecheck :: Maybe URI.URI -> Maybe URI.URI -> SAML.IdPId -> Spar NoContent
+authreqPrecheck msucc merr idpid = validateAuthreqParams msucc merr
+                                *> SAML.getIdPConfig idpid
+                                *> return NoContent
 
 authreq :: NominalDiffTime -> Maybe URI.URI -> Maybe URI.URI -> SAML.IdPId -> Spar (SAML.FormRedirect SAML.AuthnRequest)
 authreq authreqttl msucc merr idpid = do
-  vformat <- case (msucc, merr) of
-    (Nothing, Nothing) -> pure VerdictFormatWeb
-    (Just ok, Just err) -> do
-      validateRedirectURL `mapM_` [ok, err]
-      pure $ VerdictFormatMobile ok err
-    _ -> throwSpar $ SparBadInitiateLoginQueryParams "need-both-redirect-urls"
+  vformat <- validateAuthreqParams msucc merr
   form@(SAML.FormRedirect _ ((^. SAML.rqID) -> reqid)) <- SAML.authreq authreqttl idpid
   wrapMonadClient $ Data.storeVerdictFormat authreqttl reqid vformat
   pure form
 
 redirectURLMaxLength :: Int
 redirectURLMaxLength = 140
+
+validateAuthreqParams :: Maybe URI.URI -> Maybe URI.URI -> Spar VerdictFormat
+validateAuthreqParams msucc merr = do
+  case (msucc, merr) of
+    (Nothing, Nothing) -> pure VerdictFormatWeb
+    (Just ok, Just err) -> do
+      validateRedirectURL `mapM_` [ok, err]
+      pure $ VerdictFormatMobile ok err
+    _ -> throwSpar $ SparBadInitiateLoginQueryParams "need-both-redirect-urls"
 
 validateRedirectURL :: URI.URI -> Spar ()
 validateRedirectURL uri = do

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -38,6 +38,7 @@ module Util
   , samplePublicKey1
   , samplePublicKey2
   , responseJSON
+  , callAuthnReqPrecheck'
   , callAuthnReq, callAuthnReq'
   , callIdpGet, callIdpGet'
   , callIdpCreate, callIdpCreate'
@@ -69,6 +70,7 @@ import Data.UUID as UUID hiding (null, fromByteString)
 import Data.UUID.V4 as UUID (nextRandom)
 import GHC.Stack (HasCallStack)
 import Lens.Micro
+import Prelude hiding (head)
 import Spar.API ()
 import Spar.Options as Options
 import Spar.Run
@@ -383,6 +385,10 @@ safeHead msg []    = throwError $ msg <> ": []"
 callAuthnReq' :: (MonadIO m, MonadHttp m) => SparReq -> SAML.IdPId -> m ResponseLBS
 callAuthnReq' sparreq_ idpid = do
   get $ sparreq_ . path ("/sso/initiate-login/" <> cs (SAML.idPIdToST idpid))
+
+callAuthnReqPrecheck' :: (MonadIO m, MonadHttp m) => SparReq -> SAML.IdPId -> m ResponseLBS
+callAuthnReqPrecheck' sparreq_ idpid = do
+  head $ sparreq_ . path ("/sso/initiate-login/" <> cs (SAML.idPIdToST idpid))
 
 callIdpGet :: (MonadIO m, MonadHttp m) => SparReq -> Maybe UserId -> SAML.IdPId -> m IdP
 callIdpGet sparreq_ muid idpid = do

--- a/services/spar/test/Test/Spar/APISpec.hs
+++ b/services/spar/test/Test/Spar/APISpec.hs
@@ -18,6 +18,7 @@ import Test.Hspec
 spec :: Spec
 spec = do
   validateEveryToJSON (Proxy :: Proxy API.APIMeta)
+  validateEveryToJSON (Proxy :: Proxy API.APIAuthReqPrecheck)
   validateEveryToJSON (Proxy :: Proxy API.APIAuthReq)
   validateEveryToJSON (Proxy :: Proxy API.APIAuthResp)
   validateEveryToJSON (Proxy :: Proxy API.IdpGet)


### PR DESCRIPTION
A number of things can go wrong during the authreq; at that point, clients have already opened a web session and errors are difficult to handle, unless we wrap all these errors in html, similarly to how we reply in the [verdictHandlerWeb](https://github.com/wireapp/wire-server/blob/develop/services/spar/src/Spar/App.hs#L214-L249).

This shouldn't be part of [saml2-web-sso](https://github.com/wireapp/saml2-web-sso) since it is quite specific to our use case and thus was added only on spar.