### PR TITLE
Try to do a DNS lookup to provide an initial list of contacts

### DIFF
--- a/libs/cassandra-util/cassandra-util.cabal
+++ b/libs/cassandra-util/cassandra-util.cabal
@@ -28,6 +28,7 @@ library
       , base                 >= 4.6     && < 5.0
       , cql                  >= 3.0.0
       , cql-io               >= 0.14
+      , dns                  >= 3.0
       , errors               >= 1.4
       , exceptions           >= 0.6
       , lens                 >= 4.4

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -326,8 +326,8 @@ initExtGetManager = do
 
 initCassandra :: Opts -> Logger -> IO Cas.ClientState
 initCassandra o g = do
-    c <- maybe (return $ NE.fromList [unpack ((Opt.cassandra o)^.casEndpoint.epHost)])
-               (Cas.initialContacts "cassandra_brig")
+    c <- maybe (Cas.initialContactsDNS ((Opt.cassandra o)^.casEndpoint.epHost))
+               (Cas.initialContactsDisco "cassandra_brig")
                (unpack <$> Opt.discoUrl o)
     p <- Cas.init (Log.clone (Just "cassandra.brig") g)
             $ Cas.setContacts (NE.head c) (NE.tail c)

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -143,8 +143,8 @@ createEnv m o = do
 
 initCassandra :: Opts -> Logger -> IO ClientState
 initCassandra o l = do
-    c <- maybe (return $ NE.fromList [unpack $ o^.optCassandra.casEndpoint.epHost])
-               (C.initialContacts "cassandra_galley")
+    c <- maybe (C.initialContactsDNS (o^.optCassandra.casEndpoint.epHost))
+               (C.initialContactsDisco "cassandra_galley")
                (unpack <$> o^.optDiscoUrl)
     C.init (Logger.clone (Just "cassandra.galley") l) $
               C.setContacts (NE.head c) (NE.tail c)

--- a/services/gundeck/src/Gundeck/Env.hs
+++ b/services/gundeck/src/Gundeck/Env.hs
@@ -51,8 +51,8 @@ schemaVersion = 7
 createEnv :: Metrics -> Opts -> IO Env
 createEnv m o = do
     l <- new $ setOutput StdOut . setFormat Nothing $ defSettings
-    c <- maybe (return $ NE.fromList [unpack (o^.optCassandra.casEndpoint.epHost)])
-               (C.initialContacts "cassandra_gundeck")
+    c <- maybe (C.initialContactsDNS (o^.optCassandra.casEndpoint.epHost))
+               (C.initialContactsDisco "cassandra_gundeck")
                (unpack <$> o^.optDiscoUrl)
     n <- newManager tlsManagerSettings
             { managerConnCount           = (o^.optSettings.setHttpPoolSize)

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -54,8 +54,9 @@ schemaVersion = 0
 
 initCassandra :: Opts.Opts -> Logger -> IO ClientState
 initCassandra opts lgr = do
-    connectString <- maybe (return $ NE.fromList [cs $ Opts.cassandra opts ^. casEndpoint . epHost])
-               (Cas.initialContacts "cassandra_spar")
+    connectString <- maybe
+               (Cas.initialContactsDNS (Opts.cassandra opts ^. casEndpoint . epHost))
+               (Cas.initialContactsDisco "cassandra_spar")
                (cs <$> Opts.discoUrl opts)
     cas <- Cas.init (Log.clone (Just "cassandra.spar") lgr) $ Cas.defSettings
       & Cas.setContacts (NE.head connectString) (NE.tail connectString)


### PR DESCRIPTION
When initialising a connection to a cassandra cluster, we currently do this in 2 different ways:
1. connect to that hostname directly (be it an IP address or a DNS name)
2. use our internal `disco`, which expects a list of cassandra nodes and parses them in a "proprietary" 

Using 1. has a small problem when the C* cluster is behind a load balancer: it resolves the name once and keeps retrying connections to that same address. This PR aims to improve that behaviour, making connections to a DNS name behave a little more like when we use our `disco`.