### PR TITLE
[archived] Don't parse CLI options

### DIFF
--- a/services/brig/deb/etc/sv/brig/run
+++ b/services/brig/deb/etc/sv/brig/run
@@ -6,136 +6,17 @@ exec 2>&1
 # defaults
 USER=${USER:-www-data}
 APP=brig
-CONFIG=${CONFIG:-/etc/$APP/.env}
+CONFIG=${CONFIG:-/etc/${APP}/${APP}.yaml}
 HOME=${APP_HOME:-/opt/$APP}
 BIN=$HOME/bin/$APP
-TEMPLATE_DIR=$HOME/templates
 
 if [ ! -f $CONFIG ]; then exec chpst -u $USER get_config; fi
-source $CONFIG
-
-source <(khan --silent metadata --multiline)
-
-DISCO_URL="http://${KHAN_ENV}-${KHAN_REGION_ABBREV}-klabautermann.${KHAN_DOMAIN}/describe-instances"
-
-AWS_ACCESS_KEY_ID=${BRIG_AWS_ACCESS_KEY_ID:+--aws-access-key-id=$BRIG_AWS_ACCESS_KEY_ID}
-AWS_SECRET_ACCESS_KEY=${BRIG_AWS_SECRET_ACCESS_KEY:+--aws-secret-access-key=$BRIG_AWS_SECRET_ACCESS_KEY}
 
 export LOG_LEVEL=${BRIG_LOG_LEVEL:-Info}
 export LOG_NETSTR=${BRIG_LOG_NETSTR:-True}
-
-if [ -n "$BRIG_WHITELIST_URL" ]; then
-    WHITELIST_URL="--whitelist-url=$BRIG_WHITELIST_URL"
-    WHITELIST_USER="--whitelist-user=$BRIG_WHITELIST_USER"
-    WHITELIST_PASS="--whitelist-pass=$BRIG_WHITELIST_PASS"
-else
-    WHITELIST_URL=""
-    WHITELIST_USER=""
-    WHITELIST_PASS=""
-fi
-
-if [ -n "$BRIG_GEOIP_DATABASE" ]; then
-    GEOIP_DB="--geodb=\"$BRIG_GEOIP_DATABASE\""
-else
-    GEOIP_DB=""
-fi
-
-if [ -n "$BRIG_TURN_TOKEN_LIFETIME" ]; then
-    TURN_TOKEN_LIFETIME="--turn-token-lifetime=$BRIG_TURN_TOKEN_LIFETIME"
-else
-    TURN_TOKEN_LIFETIME=""
-fi
-
-if [ -n "$BRIG_TURN_CONFIG_TTL" ]; then
-    TURN_CONFIG_TTL="--turn-config-ttl=$BRIG_TURN_CONFIG_TTL"
-else
-    TURN_CONFIG_TTL=""
-fi
-
-if [ -n "$BRIG_PROVIDER_ID_SEARCH_FILTER" ]; then
-    PROVIDER_ID_SEARCH_FILTER="--provider-id-search-filter=$BRIG_PROVIDER_ID_SEARCH_FILTER"
-else
-    PROVIDER_ID_SEARCH_FILTER=""
-fi
-
-if [ -n "$BRIG_AWS_USER_JOURNAL_QUEUE" ]; then
-    USER_QUEUE_JOURNAL="--aws-user-journal-queue=$BRIG_AWS_USER_JOURNAL_QUEUE"
-else
-    USER_QUEUE_JOURNAL=""
-fi
 
 cd $HOME
 
 ulimit -n 65536
 
-exec chpst -u $USER \
-    $BIN \
-    --host=${BRIG_HOST:-'127.0.0.1'} \
-    --port=${BRIG_PORT?'unset'} \
-    --galley-host=${BRIG_GALLEY_HOST?'unset'} \
-    --galley-port=${BRIG_GALLEY_PORT?'unset'} \
-    --gundeck-host=${BRIG_GUNDECK_HOST?'unset'} \
-    --gundeck-port=${BRIG_GUNDECK_PORT?'unset'} \
-    --cargohold-host=${BRIG_CARGOHOLD_HOST?'unset'} \
-    --cargohold-port=${BRIG_CARGOHOLD_PORT?'unset'} \
-    --cassandra-host=${BRIG_CASSANDRA_HOST?'unset'} \
-    --cassandra-port=${BRIG_CASSANDRA_PORT?'unset'} \
-    --cassandra-keyspace=${BRIG_CASSANDRA_KEYSPACE?'unset'} \
-    --activation-url=${BRIG_ACTIVATION_URL?'unset'} \
-    --team-activation-url=${BRIG_TEAM_ACTIVATION_URL?'unset'} \
-    --activation-timeout=${BRIG_ACTIVATION_TIMEOUT?'unset'} \
-    --team-invitation-timeout=${BRIG_TEAM_INVITATION_TIMEOUT?'unset'} \
-    --sms-activation-url=${BRIG_SMS_ACTIVATION_URL?'unset'} \
-    --password-reset-url=${BRIG_PASSWORD_RESET_URL?'unset'} \
-    --deletion-url=${BRIG_DELETION_URL?'unset'} \
-    --team-invitation-url=${BRIG_TEAM_INVITATION_URL?'unset'} \
-    --team-creator-welcome-url=${BRIG_TEAM_CREATOR_WELCOME_URL?'unset'} \
-    --team-member-welcome-url=${BRIG_TEAM_MEMBER_WELCOME_URL?'unset'} \
-    --aws-ses-queue=${BRIG_AWS_SES_QUEUE?'unset'} \
-    --internal-events-queue=${BRIG_INTERNAL_EVENTS_QUEUE?'unset'} \
-    --aws-dynamo-prekeys=${BRIG_AWS_DYNAMO_PREKEYS?'unset'} \
-    --aws-ses-endpoint=${BRIG_SES_ENDPOINT?'unset'} \
-    --aws-sqs-endpoint=${BRIG_SQS_ENDPOINT?'unset'} \
-    --aws-dynamodb-endpoint=${BRIG_DYNAMODB_ENDPOINT?'unset'} \
-    --twilio-credentials=${BRIG_TWILIO_CREDENTIALS?'unset'} \
-    --twilio-sender=${BRIG_TWILIO_SENDER?'unset'} \
-    --nexmo-credentials=${BRIG_NEXMO_CREDENTIALS?'unset'} \
-    `# --stomp-credentials=${BRIG_STOMP_CREDENTIALS}` \
-    --template-dir=${TEMPLATE_DIR?'unset'} \
-    --email-sender=${BRIG_EMAIL_SENDER?'unset'} \
-    --disco-url=${DISCO_URL?'unset'} \
-    --default-locale=${BRIG_DEFAULT_LOCALE?'unset'} \
-    --cookie-domain=${BRIG_COOKIE_DOMAIN?'unset'} \
-    --provider-home-url=${BRIG_PROVIDER_HOME_URL?'unset'} \
-    --provider-activation-url=${BRIG_PROVIDER_ACTIVATION_URL?'unset'} \
-    --provider-approval-url=${BRIG_PROVIDER_APPROVAL_URL?'unset'} \
-    --provider-approval-to=${BRIG_PROVIDER_APPROVAL_TO?'unset'} \
-    --provider-password-reset-url=${BRIG_PROVIDER_PASSWORD_RESET_URL?'unset'} \
-    --user-cookie-limit=${BRIG_USER_COOKIE_LIMIT?'unset'} \
-    --user-cookie-renew-age=${BRIG_USER_COOKIE_RENEW_AGE?'unset'} \
-    --user-cookie-min-deviation=${BRIG_USER_COOKIE_MIN_DEVIATION?'unset'} \
-    --user-cookie-retry-after=${BRIG_USER_COOKIE_RETRY_AFTER?'unset'} \
-    --zauth-private-keys=${BRIG_ZAUTH_PRIVKEYS?'unset'} \
-    --zauth-public-keys=${BRIG_ZAUTH_PUBKEYS?'unset'} \
-    --zauth-key-index=${BRIG_ZAUTH_KEY_INDEX?'unset'} \
-    --zauth-user-token-timeout=${BRIG_ZAUTH_USER_TOKEN_TIMEOUT?'unset'} \
-    --zauth-access-token-timeout=${BRIG_ZAUTH_ACCESS_TOKEN_TIMEOUT?'unset'} \
-    --zauth-session-token-timeout=${BRIG_ZAUTH_SESSION_TOKEN_TIMEOUT?'unset'} \
-    --zauth-provider-token-timeout=${BRIG_ZAUTH_PROVIDER_TOKEN_TIMEOUT?'unset'} \
-    --elasticsearch-url=${BRIG_ELASTICSEARCH_URL?'unset'} \
-    --elasticsearch-user-index=${BRIG_ELASTICSEARCH_USER_INDEX?'unset'} \
-    --turn-servers=${BRIG_TURN_SERVERS?'unset'} \
-    --turn-servers-v2=${BRIG_TURN_SERVERS_V2?'unset'} \
-    --turn-secret=${BRIG_TURN_SECRET?'unset'} \
-    --team-max-size=${BRIG_TEAM_MAX_SIZE?'unset'} \
-    --conv-max-size=${BRIG_CONV_MAX_SIZE?'unset'} \
-    ${TURN_TOKEN_LIFETIME} \
-    ${TURN_CONFIG_TTL} \
-    ${AWS_ACCESS_KEY_ID} \
-    ${AWS_SECRET_ACCESS_KEY} \
-    ${GEOIP_DB} \
-    ${WHITELIST_URL} \
-    ${WHITELIST_USER} \
-    ${WHITELIST_PASS} \
-    ${PROVIDER_ID_SEARCH_FILTER} \
-    ${USER_QUEUE_JOURNAL}
+exec chpst -u $USER $BIN --config-file=${CONFIG}

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeOperators     #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 
-module Brig.API (runServer, parseOptions) where
+module Brig.API (runServer) where
 
 import Brig.App
 import Brig.AWS (sesQueue)

--- a/services/brig/src/Brig/User/Auth/Cookie/Limit.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie/Limit.hs
@@ -49,6 +49,12 @@ limitCookies lim now cs
 --------------------------------------------------------------------------------
 -- Temporal Throttling
 
+-- | The fields are:
+--
+-- * Min. standard deviation cookie creation
+-- * Wait time when the min deviation is violated
+--
+-- Both fields are in seconds.
 data CookieThrottle
     = StdDevThrottle StdDev RetryAfter
     deriving (Show)

--- a/services/brig/src/Brig/Whitelist.hs
+++ b/services/brig/src/Brig/Whitelist.hs
@@ -18,10 +18,11 @@ import Data.Text.Encoding (encodeUtf8)
 import GHC.Generics
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), parseRequest)
 
+-- | A service providing a whitelist of allowed email addresses and phone numbers
 data Whitelist = Whitelist
-    { whitelistUrl  :: !Text
-    , whitelistUser :: !Text
-    , whitelistPass :: !Text
+    { whitelistUrl  :: !Text     -- ^ Service URL
+    , whitelistUser :: !Text     -- ^ Username
+    , whitelistPass :: !Text     -- ^ Password
     } deriving (Show, Generic)
 
 instance FromJSON Whitelist

--- a/services/brig/src/Brig/ZAuth.hs
+++ b/services/brig/src/Brig/ZAuth.hs
@@ -95,11 +95,12 @@ runZAuth :: MonadIO m => Env -> ZAuth a -> m a
 runZAuth e za = liftIO $ runReaderT (unZAuth za) e
 
 data Settings = Settings
-    { _keyIndex             :: !Int
-    , _userTokenTimeout     :: !UserTokenTimeout
-    , _sessionTokenTimeout  :: !SessionTokenTimeout
-    , _accessTokenTimeout   :: !AccessTokenTimeout
-    , _providerTokenTimeout :: !ProviderTokenTimeout
+    { _keyIndex             :: !Int                   -- ^ Secret key index to use
+                                                      --   for token creation
+    , _userTokenTimeout     :: !UserTokenTimeout      -- ^ User token validity timeout
+    , _sessionTokenTimeout  :: !SessionTokenTimeout   -- ^ Session token validity timeout
+    , _accessTokenTimeout   :: !AccessTokenTimeout    -- ^ Access token validity timeout
+    , _providerTokenTimeout :: !ProviderTokenTimeout  -- ^ Access token validity timeout
     } deriving (Show, Generic)
 
 defSettings :: Settings

--- a/services/brig/src/Main.hs
+++ b/services/brig/src/Main.hs
@@ -3,12 +3,11 @@ module Main (main) where
 import Brig.API
 import OpenSSL (withOpenSSL)
 
-import Brig.Options
 import Util.Options
 
 main :: IO ()
 main = withOpenSSL $ do
   let desc = "Brig - User Service"
       defaultPath = "/etc/wire/brig/conf/brig.yaml"
-  options <- getOptions desc (Just optsParser) defaultPath
+  options <- getOptions desc Nothing defaultPath
   runServer options

--- a/services/cannon/deb/etc/sv/cannon/run
+++ b/services/cannon/deb/etc/sv/cannon/run
@@ -7,13 +7,12 @@ APP=cannon
 
 # defaults
 USER=${USER:-www-data}
-CONFIG=${CONFIG:-/etc/$APP/.env}
+CONFIG=${CONFIG:-/etc/${APP}/${APP}.yaml}
 HOME=${APP_HOME:-/opt/$APP}
 BIN=$HOME/bin/$APP
 
 if [ ! -f $CONFIG ]; then exec chpst -u $USER get_config; fi
 echo $CONFIG
-source $CONFIG
 
 export LOG_LEVEL=${CANNON_LOG_LEVEL:-Info}
 export LOG_BUFFER=${CANNON_LOG_BUFFER:-4096}
@@ -24,10 +23,4 @@ cd $HOME
 
 ulimit -n 131072
 
-exec chpst -u $USER \
-    $BIN \
-    -p ${CANNON_PORT?'unset'} \
-    --host ${CANNON_HOST?'unset'} \
-    --external-host ${CANNON_EXTERNAL_HOST:-127.0.0.1} \
-    --gundeck-host=${CANNON_GUNDECK_HOST?'unset'} \
-    --gundeck-port=${CANNON_GUNDECK_PORT?'unset'}
+exec chpst -u $USER $BIN --config-file=${CONFIG}

--- a/services/cannon/src/Cannon/Options.hs
+++ b/services/cannon/src/Cannon/Options.hs
@@ -8,8 +8,7 @@
 {-# LANGUAGE FlexibleInstances          #-}
 
 module Cannon.Options
-    ( optsParser
-    , host
+    ( host
     , port
     , cannon
     , gundeck
@@ -21,18 +20,17 @@ where
 
 import Control.Lens (makeFields)
 import Data.Aeson.APIFieldJsonTH
-import Data.Monoid ((<>))
-import Data.Text (Text, pack)
+import Data.Text (Text)
 import Data.Word
 import GHC.Generics
-import Options.Applicative
 
 
 data Cannon = Cannon
-    { _cannonHost             :: !String
-    , _cannonPort             :: !Word16
-    , _cannonExternalHost     :: !(Maybe Text)
-    , _cannonExternalHostFile :: !(Maybe FilePath)
+    { _cannonHost             :: !String            -- ^ Host to listen on
+    , _cannonPort             :: !Word16            -- ^ Port to listen on
+    , _cannonExternalHost     :: !(Maybe Text)      -- ^ Host to report to other services
+    , _cannonExternalHostFile :: !(Maybe FilePath)  -- ^ File containing host address to
+                                                    --   report to other services
     } deriving (Eq, Show, Generic)
 
 makeFields ''Cannon
@@ -47,52 +45,9 @@ makeFields ''Gundeck
 deriveApiFieldJSON ''Gundeck
 
 data Opts = Opts
-    { _optsCannon   :: !Cannon
-    , _optsGundeck  :: !Gundeck
+    { _optsCannon   :: !Cannon   -- ^ Our options
+    , _optsGundeck  :: !Gundeck  -- ^ Gundeck endpoint
     } deriving (Eq, Show, Generic)
 
 makeFields ''Opts
 deriveApiFieldJSON ''Opts
-
-optsParser :: Parser Opts
-optsParser = Opts <$> cParser <*> gParser
-
-gParser :: Parser Gundeck
-gParser = Gundeck
-    <$> (textOption $
-            long "gundeck-host"
-            <> metavar "HOSTNAME"
-            <> help "Gundeck host")
-
-    <*> (option auto $
-            long "gundeck-port"
-            <> metavar "PORT"
-            <> help "Gundeck port")
-
-
-cParser :: Parser Cannon
-cParser = Cannon
-    <$> (strOption $
-            long "host"
-            <> metavar "HOSTNAME"
-            <> help "host to listen on")
-
-    <*> (option auto $
-            long "port"
-            <> short 'p'
-            <> metavar "PORT"
-            <> help "port to listen on")
-
-    <*> (optional $ (textOption $
-            long "external-host"
-            <> metavar "HOSTNAME"
-            <> help "host address to report to other services"))
-
-    <*> (optional $ (strOption $
-            long "external-host-file"
-            <> metavar "HOSTNAME_FILE"
-            <> help "file containing host address to report to other services"))
-
-
-textOption :: Mod OptionFields String -> Parser Text
-textOption = fmap pack . strOption

--- a/services/cannon/src/Main.hs
+++ b/services/cannon/src/Main.hs
@@ -1,11 +1,10 @@
 module Main (main) where
 
 import Cannon.API
-import Cannon.Options
 import Util.Options
 
 main :: IO ()
-main = getOptions desc (Just optsParser) defaultPath >>= run
+main = getOptions desc Nothing defaultPath >>= run
   where
     desc = "Cannon - Websocket Push Service"
     defaultPath = "/etc/wire/cannon/conf/cannon.yaml"

--- a/services/cargohold/deb/etc/sv/cargohold/run
+++ b/services/cargohold/deb/etc/sv/cargohold/run
@@ -7,18 +7,11 @@ APP=cargohold
 
 # defaults
 USER=${USER:-www-data}
-CONFIG=${CONFIG:-/etc/$APP/.env}
+CONFIG=${CONFIG:-/etc/${APP}/${APP}.yaml}
 HOME=${APP_HOME:-/opt/$APP}
 BIN=$HOME/bin/$APP
 
-# we need KHAN_DOMAIN before sourcing $CONFIG
-source <(khan --silent metadata --multiline)
-
 if [ ! -f $CONFIG ]; then exec chpst -u $USER get_config; fi
-source $CONFIG
-
-AWS_ACCESS_KEY_ID=${CARGOHOLD_AWS_ACCESS_KEY_ID:+--aws-key-id=$CARGOHOLD_AWS_ACCESS_KEY_ID}
-AWS_SECRET_ACCESS_KEY=${CARGOHOLD_AWS_SECRET_ACCESS_KEY:+--aws-secret-key=$CARGOHOLD_AWS_SECRET_ACCESS_KEY}
 
 export LOG_LEVEL=${CARGOHOLD_LOG_LEVEL:-Info}
 export LOG_BUFFER=${CARGOHOLD_LOG_BUFFER:-4096}
@@ -28,16 +21,4 @@ cd $HOME
 
 ulimit -n 65536
 
-exec chpst -u $USER \
-    $BIN \
-    --host=${CARGOHOLD_HOST:-'127.0.0.1'} \
-    --port=${CARGOHOLD_PORT?'unset'} \
-    ${AWS_ACCESS_KEY_ID} \
-    ${AWS_SECRET_ACCESS_KEY} \
-    --aws-s3-endpoint=${CARGOHOLD_AWS_S3_ENDPOINT:-'https://s3.eu-west-1.amazonaws.com'} \
-    --aws-s3-bucket=${CARGOHOLD_AWS_S3_BUCKET?'unset'} \
-    --aws-cloudfront-domain=${CARGOHOLD_AWS_CLOUDFRONT_DOMAIN?'unset'} \
-    --aws-cloudfront-keypair-id=${CARGOHOLD_AWS_CLOUDFRONT_KEYPAIR_ID?'unset'} \
-    --aws-cloudfront-private-key=${CARGOHOLD_AWS_CLOUDFRONT_PRIVATEKEY?'unset'} \
-    --max-total-bytes=${CARGOHOLD_MAX_TOTAL_BYTES?'unset'} \
-    --download-link-ttl=${CARGOHOLD_DOWNLOAD_LINK_TTL:-300}
+exec chpst -u $USER $BIN --config-file=${CONFIG}

--- a/services/cargohold/src/CargoHold/API.hs
+++ b/services/cargohold/src/CargoHold/API.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators     #-}
 
-module CargoHold.API (runServer, parseOptions) where
+module CargoHold.API (runServer) where
 
 import Imports hiding (head)
 import CargoHold.App

--- a/services/cargohold/src/Main.hs
+++ b/services/cargohold/src/Main.hs
@@ -4,12 +4,11 @@ import Imports
 import CargoHold.API
 import OpenSSL (withOpenSSL)
 
-import CargoHold.Options
 import Util.Options
 
 main :: IO ()
 main = withOpenSSL $ do
-    options <- getOptions desc (Just optsParser) defaultPath
+    options <- getOptions desc Nothing defaultPath
     runServer options
   where
     desc = "Cargohold - Asset Storage"

--- a/services/galley/deb/etc/sv/galley/run
+++ b/services/galley/deb/etc/sv/galley/run
@@ -6,47 +6,18 @@ exec 2>&1
 # defaults
 USER=${USER:-www-data}
 APP=galley
-CONFIG=${CONFIG:-/etc/$APP/.env}
+CONFIG=${CONFIG:-/etc/${APP}/${APP}.yaml}
 HOME=${APP_HOME:-/opt/$APP}
 BIN=$HOME/bin/$APP
 
 if [ ! -f $CONFIG ]; then exec chpst -u $USER get_config; fi
-source $CONFIG
-
-source <(khan --silent metadata --multiline)
-
-GALLEY_DISCO_URL="http://${KHAN_ENV}-${KHAN_REGION_ABBREV}-klabautermann.${KHAN_DOMAIN}/describe-instances"
 
 export LOG_LEVEL=${GALLEY_LOG_LEVEL:-Debug}
 export LOG_BUFFER=${GALLEY_LOG_BUFFER:-4096}
 export LOG_NETSTR=${GALLEY_LOG_NETSTR:-True}
 
-if [ -n "$GALLEY_INTRA_DEVICE_LISTING" ]; then
-    GALLEY_INTRA_DEVICE_LISTING="--intra-device-listing"
-else
-    GALLEY_INTRA_DEVICE_LISTING=""
-fi
-
 cd $HOME
 
 ulimit -n 65536
 
-exec chpst -u $USER \
-    $BIN \
-    --host=${GALLEY_HOST:-'127.0.0.1'} \
-    --port=${GALLEY_PORT?'unset'} \
-    --brig-host=${GALLEY_BRIG_HOST?'unset'} \
-    --brig-port=${GALLEY_BRIG_PORT?'unset'} \
-    --gundeck-host=${GALLEY_GUNDECK_HOST?'unset'} \
-    --gundeck-port=${GALLEY_GUNDECK_PORT?'unset'} \
-    --cassandra-host=${GALLEY_CASSANDRA_HOST?'unset'} \
-    --cassandra-port=${GALLEY_CASSANDRA_PORT?'unset'} \
-    --cassandra-keyspace=${GALLEY_CASSANDRA_KEYSPACE?'unset'} \
-    --disco-url=${GALLEY_DISCO_URL?'unset'} \
-    --http-pool-size=${GALLEY_HTTP_POOL_SIZE:-128} \
-    --team-events-queue-name=${GALLEY_SQS_TEAM_EVENTS?'unset'} \
-    --aws-sqs-endpoint=${GALLEY_SQS_ENDPOINT?'unset'} \
-    --team-max-size=${TEAM_MAX_SIZE?'unset'} \
-    --conv-max-size=${CONV_MAX_SIZE?'unset'} \
-    --conversation-code-prefix=${GALLEY_CONVERSATION_CODE_PREFIX?'unset'} \
-    ${GALLEY_INTRA_DEVICE_LISTING}
+exec chpst -u $USER $BIN --config-file=${CONFIG}

--- a/services/galley/src/Main.hs
+++ b/services/galley/src/Main.hs
@@ -1,7 +1,6 @@
 module Main (main) where
 
 import Galley.API
-import Galley.Options
 import OpenSSL (withOpenSSL)
 import Util.Options
 
@@ -9,5 +8,5 @@ main :: IO ()
 main = withOpenSSL $ do
   let desc = "Galley - Conversation service"
       defaultPath = "/etc/wire/galley/conf/galley.yaml"
-  options <- getOptions desc (Just optsParser) defaultPath
+  options <- getOptions desc Nothing defaultPath
   run options

--- a/services/gundeck/deb/etc/sv/gundeck/run
+++ b/services/gundeck/deb/etc/sv/gundeck/run
@@ -6,55 +6,18 @@ exec 2>&1
 # defaults
 USER=${USER:=www-data}
 APP=gundeck
-CONFIG=${CONFIG:=/etc/$APP/.env}
+CONFIG=${CONFIG:=/etc/${APP}/${APP}.yaml}
 HOME=${APP_HOME:=/opt/$APP}
 BIN=$HOME/bin/$APP
 
 chpst -u $USER get_config
-source $CONFIG
-
-source <(khan --silent metadata --multiline)
-
-GUNDECK_DISCO_URL="http://${KHAN_ENV}-${KHAN_REGION_ABBREV}-klabautermann.${KHAN_DOMAIN}/describe-instances"
 
 export LOG_LEVEL=${GUNDECK_LOG_LEVEL:-Debug}
 export LOG_BUFFER=${GUNDECK_LOG_BUFFER:-4096}
 export LOG_NETSTR=${GUNDECK_LOG_NETSTR:-True}
 
-if [ -n "$GUNDECK_PREFER_NOTICE" ]; then
-    GUNDECK_PREFER_NOTICE="--prefer-notice"
-else
-    GUNDECK_PREFER_NOTICE=""
-fi
-
-if [ -n "$GUNDECK_CANNON_BULK_PUSH" ]; then
-    GUNDECK_CANNON_BULK_PUSH="--bulk-push"
-else
-    GUNDECK_CANNON_BULK_PUSH=""
-fi
-
 cd $HOME
 
 ulimit -n 65536
 
-exec chpst -u $USER \
-    $BIN \
-    --host=${GUNDECK_HOST:-'127.0.0.1'} \
-    --port=${GUNDECK_PORT?'unset'} \
-    --cassandra-host=${GUNDECK_CASSANDRA_HOST?'unset'} \
-    --cassandra-port=${GUNDECK_CASSANDRA_PORT?'unset'} \
-    --cassandra-keyspace=${GUNDECK_CASSANDRA_KEYSPACE?'unset'} \
-    --disco-url=${GUNDECK_DISCO_URL?'unset'} \
-    --redis-host=${GUNDECK_REDIS_HOST?'unset'} \
-    --redis-port=${GUNDECK_REDIS_PORT?'unset'} \
-    --http-pool-size=${GUNDECK_HTTP_POOL_SIZE:-128} \
-    --event-queue-name=${GUNDECK_EVENT_QUEUE_NAME?'unset'} \
-    --notification-ttl=${GUNDECK_NOTIFICATION_TTL?'unset'} \
-    --aws-region=${KHAN_REGION?'unset'} \
-    --aws-account=${AWS_ACCOUNT_ID?'unset'} \
-    --aws-arn-env=${KHAN_ENV?'unset'} \
-    --aws-sqs-endpoint=${GUNDECK_AWS_SQS_ENDPOINT:-'https://sqs.eu-west-1.amazonaws.com'} \
-    --aws-sns-endpoint=${GUNDECK_AWS_SNS_ENDPOINT:-'https://sns.eu-west-1.amazonaws.com'} \
-    --skip-fallbacks \
-    ${GUNDECK_PREFER_NOTICE} \
-    ${GUNDECK_CANNON_BULK_PUSH}
+exec chpst -u $USER $BIN --config-file=${CONFIG}

--- a/services/gundeck/src/Gundeck/Options.hs
+++ b/services/gundeck/src/Gundeck/Options.hs
@@ -10,8 +10,6 @@ import Control.Lens
 import Data.Aeson.TH
 import Data.Yaml (FromJSON)
 import Gundeck.Aws.Arn
-import Options.Applicative
-import Options.Applicative.Types
 import Util.Options
 import Util.Options.Common
 
@@ -19,185 +17,55 @@ newtype NotificationTTL = NotificationTTL
     { notificationTTLSeconds :: Word32 }
     deriving (Eq, Ord, Show, Generic, FromJSON)
 
+-- | AWS options
 data AWSOpts = AWSOpts
-    { _awsAccount     :: !Account
-    , _awsRegion      :: !Region
-    , _awsArnEnv      :: !ArnEnv
-    , _awsQueueName   :: !Text
-    , _awsSqsEndpoint :: !AWSEndpoint
-    , _awsSnsEndpoint :: !AWSEndpoint
+    { _awsAccount     :: !Account      -- ^ Account
+    , _awsRegion      :: !Region       -- ^ Region
+    , _awsArnEnv      :: !ArnEnv       -- ^ Environment name to scope ARNs to
+    , _awsQueueName   :: !Text         -- ^ SQS event queue name
+    , _awsSqsEndpoint :: !AWSEndpoint  -- ^ SQS endpoint
+    , _awsSnsEndpoint :: !AWSEndpoint  -- ^ SNS endpoint
     } deriving (Show, Generic)
 
 deriveFromJSON toOptionFieldName ''AWSOpts
 makeLenses ''AWSOpts
 
 data FallbackOpts = FallbackOpts
-    { _fbSkipFallbacks :: !Bool
-    , _fbPreferNotice  :: !Bool
-    , _fbQueueDelay    :: !Word64
-    , _fbQueueLimit    :: !Int
-    , _fbQueueBurst    :: !Word16
+    { _fbSkipFallbacks :: !Bool    -- ^ Never send delayed fallback notifications
+    , _fbPreferNotice  :: !Bool    -- ^ Send notifications of type @notice@
+    , _fbQueueDelay    :: !Word64  -- ^ Delay of notifications before sending a
+                                   --   fallback, in seconds. MUST be 30s or higher
+    , _fbQueueLimit    :: !Int     -- ^ Max size of the notification fallback queue
+    , _fbQueueBurst    :: !Word16  -- ^ Max number of delayed notifications
+                                   --   to fire in a row, per second
     } deriving (Show, Generic)
 
 deriveFromJSON toOptionFieldName ''FallbackOpts
 makeLenses ''FallbackOpts
 
 data Settings = Settings
-    { _setHttpPoolSize    :: !Int
-    , _setNotificationTTL :: !NotificationTTL
-    , _setBulkPush        :: !Bool
+    { _setHttpPoolSize    :: !Int              -- ^ Number of connections
+                                               --   for the HTTP client pool
+    , _setNotificationTTL :: !NotificationTTL  -- ^ TTL for stored notifications,
+                                               --   in seconds
+    , _setBulkPush        :: !Bool             -- ^ Group push notifications and
+                                               --   send them to Cannon in bulk,
+                                               --   instead of doing individual
+                                               --   requests
     } deriving (Show, Generic)
 
 deriveFromJSON toOptionFieldName ''Settings
 makeLenses ''Settings
 
 data Opts = Opts
-    { _optGundeck   :: !Endpoint
-    , _optCassandra :: !CassandraOpts
-    , _optRedis     :: !Endpoint
-    , _optAws       :: !AWSOpts
-    , _optDiscoUrl  :: !(Maybe Text)
-    , _optFallback  :: !FallbackOpts
-    , _optSettings  :: !Settings
+    { _optGundeck   :: !Endpoint        -- ^ Hostname and port to listen on
+    , _optCassandra :: !CassandraOpts   -- ^ Cassandra settings
+    , _optRedis     :: !Endpoint        -- ^ Redis endpoint
+    , _optAws       :: !AWSOpts         -- ^ AWS settings
+    , _optDiscoUrl  :: !(Maybe Text)    -- ^ Disco URL (klabautermann)
+    , _optFallback  :: !FallbackOpts    -- ^ Settings for fallback notifications
+    , _optSettings  :: !Settings        -- ^ Other settings
     } deriving (Show, Generic)
 
 deriveFromJSON toOptionFieldName ''Opts
 makeLenses ''Opts
-
-parseOptions :: IO Opts
-parseOptions = execParser (info (helper <*> optsParser) desc)
-  where
-    desc = header "Gundeck - Push Notifications" <> fullDesc
-
-optsParser :: Parser Opts
-optsParser = Opts <$>
-    (Endpoint <$>
-        (textOption $
-            long "host"
-            <> value "*4"
-            <> showDefault
-            <> metavar "HOSTNAME"
-            <> help "Hostname or address to bind to")
-        <*>
-        (option auto $
-            long "port"
-            <> short 'p'
-            <> metavar "PORT"
-            <> help "Port to listen on"))
-  <*> cassandraParser
-  <*> redisParser
-  <*> awsParser
-  <*> optional discoUrlParser
-  <*> fallbackParser
-  <*> settingsParser
-  where
-    redisParser :: Parser Endpoint
-    redisParser = Endpoint <$>
-        (textOption $
-            long "redis-host"
-            <> metavar "HOSTNAME"
-            <> help "Redis hostname")
-        <*>
-        (option auto $
-            long "redis-port"
-            <> metavar "PORT"
-            <> help "Redis port")
-
-    awsParser :: Parser AWSOpts
-    awsParser = AWSOpts <$>
-        (fmap Account . textOption $
-            long "aws-account"
-            <> metavar "STRING"
-            <> help "aws account")
-        <*>
-        (option parseRegion $
-            long "aws-region"
-            <> metavar "STRING"
-            <> help "aws region name")
-        <*>
-        (fmap ArnEnv . textOption $
-            long "aws-arn-env"
-            <> metavar "STRING"
-            <> help "environment name to scope ARNs to")
-        <*>
-        (textOption $
-            long "event-queue-name"
-            <> metavar "STRING"
-            <> help "sqs queue name")
-        <*>
-        (option parseAWSEndpoint $
-            long "aws-sqs-endpoint"
-            <> metavar "STRING"
-            <> value (AWSEndpoint "sqs.eu-west-1.amazonaws.com" True 443)
-            <> showDefault
-            <> help "aws SQS endpoint")
-        <*>
-        (option parseAWSEndpoint $
-            long "aws-sns-endpoint"
-            <> metavar "STRING"
-            <> value (AWSEndpoint "sns.eu-west-1.amazonaws.com" True 443)
-            <> showDefault
-            <> help "aws SNS endpoint")
-
-    fallbackParser :: Parser FallbackOpts
-    fallbackParser = FallbackOpts <$>
-        -- NOTE: If set, notifications are still queued to be sent, etc. but never actually
-        -- end up getting sent out. This allows us to still keep track of how successful
-        -- we are with cancelling the fallback notifications and thus get a feeling of
-        --  where we stand today.
-        (switch $
-            long "skip-fallbacks"
-            <> help "Use this option if you wish to never send delayed fallback notifications.")
-
-        <*> (switch $
-                long "prefer-notice"
-                <> help "Use this option if you always wish to send notifications of type notice.")
-
-        <*> (delayOption $
-                long "fallback-queue-delay"
-                <> metavar "SIZE"
-                <> showDefault
-                <> help "Delay (seconds) of notifications before sending a fallback. \
-                   \MUST be higher than 30 seconds."
-                <> value 300)
-
-        <*> (option auto $
-                long "fallback-queue-limit"
-                <> metavar "SIZE"
-                <> showDefault
-                <> help "Max. size of the notification fallback queue."
-                <> value 30000)
-
-        <*> (option auto $
-                long "fallback-queue-burst"
-                <> metavar "SIZE"
-                <> showDefault
-                <> help "Max. number of delayed notifications to fire in a row (i.e. per second)."
-                <> value 100)
-
-    delayOption = fmap check . option auto
-      where
-        check x = if x < 30 then error "Delay must > 30" else x
-
-    settingsParser :: Parser Settings
-    settingsParser = Settings <$>
-        (option auto $
-            long "http-pool-size"
-            <> metavar "SIZE"
-            <> showDefault
-            <> help "number of connections for the http client pool"
-            <> value 128)
-        <*>
-        (fmap NotificationTTL . option auto $
-            long "notification-ttl"
-            <> metavar "SIZE"
-            <> showDefault
-            <> help "TTL (seconds) of stored notifications"
-            <> value 86400)
-        <*>
-        (switch $
-            long "bulk-push"
-            <> help ("Use this option to group push notifications and send them " <>
-                     "in bulk to Cannon, instead of in individual requests."))
-
-    parseRegion = readerAsk >>= either readerError return . fromText . fromString

--- a/services/gundeck/src/Main.hs
+++ b/services/gundeck/src/Main.hs
@@ -2,6 +2,8 @@ module Main (main) where
 
 import Imports
 import Gundeck.API
+import Control.Monad (when)
+import Control.Lens ((^.))
 import OpenSSL (withOpenSSL)
 
 import Gundeck.Options
@@ -9,7 +11,9 @@ import Util.Options
 
 main :: IO ()
 main = withOpenSSL $ do
-    options <- getOptions desc (Just optsParser) defaultPath
+    options <- getOptions desc Nothing defaultPath
+    when (options^.optFallback.fbQueueDelay < 30) $
+        error "fbQueueDelay must be 30s or higher"
     runServer options
   where
     desc = "Gundeck - Push Notification Hub Service"

--- a/services/proxy/deb/etc/sv/proxy/run
+++ b/services/proxy/deb/etc/sv/proxy/run
@@ -7,12 +7,11 @@ APP=proxy
 
 # defaults
 USER=${USER:-www-data}
-CONFIG=${CONFIG:-/etc/$APP/.env}
+CONFIG=${CONFIG:-/etc/${APP}/${APP}.yaml}
 HOME=${APP_HOME:-/opt/$APP}
 BIN=$HOME/bin/$APP
 
 if [ ! -f $CONFIG ]; then exec chpst -u $USER get_config; fi
-source $CONFIG
 
 export LOG_LEVEL=${PROXY_LOG_LEVEL:-Debug}
 export LOG_BUFFER=${PROXY_LOG_BUFFER:-4096}
@@ -22,10 +21,4 @@ cd $HOME
 
 ulimit -n 65536
 
-exec chpst -u $USER \
-    $BIN \
-    --host=${PROXY_WEB_HOST?'unset'} \
-    --port=${PROXY_WEB_PORT?'unset'} \
-    --config=${PROXY_CONFIG?'unset'} \
-    --http-pool-size=${PROXY_HTTP_POOL_SIZE:-256} \
-    --max-connections=${PROXY_MAX_CONNECTIONS?'unset'}
+exec chpst -u $USER $BIN --config-file=${CONFIG}

--- a/services/proxy/src/Main.hs
+++ b/services/proxy/src/Main.hs
@@ -2,12 +2,11 @@ module Main (main) where
 
 import Imports
 import Proxy.API
-import Proxy.Options
 import Util.Options
 
 main :: IO ()
 main = do
-    opts <- getOptions desc (Just optsParser) defaultPath
+    opts <- getOptions desc Nothing defaultPath
     run opts
   where
     desc = "Proxy - 3rd party proxy"

--- a/services/proxy/src/Proxy/Options.hs
+++ b/services/proxy/src/Proxy/Options.hs
@@ -9,56 +9,21 @@ module Proxy.Options
     , secretsConfig
     , httpPoolSize
     , maxConns
-    , optsParser
     ) where
 
 import Imports
 import Control.Lens
-import Options.Applicative
 import Data.Aeson
 import Data.Aeson.TH
 
 data Opts = Opts
-    { _host          :: !String
-    , _port          :: !Word16
-    , _secretsConfig :: !FilePath
-    , _httpPoolSize  :: !Int
-    , _maxConns      :: !Int
+    { _host          :: !String        -- ^ Host to listen on
+    , _port          :: !Word16        -- ^ Post to listen on
+    , _secretsConfig :: !FilePath      -- ^ File containing upstream secrets
+    , _httpPoolSize  :: !Int           -- ^ Number of connections for the HTTP pool
+    , _maxConns      :: !Int           -- ^ Maximum number of incoming connections
     } deriving (Show, Generic)
 
 makeLenses ''Opts
 
 deriveJSON defaultOptions{fieldLabelModifier = drop 1} ''Opts
-
-optsParser :: Parser Opts
-optsParser = Opts
-    <$> (strOption $
-            long "host"
-            <> value "*4"
-            <> showDefault
-            <> metavar "HOSTNAME"
-            <> help "host to listen on")
-
-    <*> (option auto $
-            long "port"
-            <> short 'p'
-            <> metavar "PORT"
-            <> help "listen port")
-
-    <*> (strOption $
-            long "config"
-            <> metavar "FILE"
-            <> help "File containing upstream secrets"
-            <> action "file")
-
-    <*> (option auto $
-            long "http-pool-size"
-            <> metavar "SIZE"
-            <> showDefault
-            <> help "number of connections for the http pool"
-            <> value 256)
-
-    <*> (option auto $
-            long "max-connections"
-            <> metavar "SIZE"
-            <> help "maximum number of incoming connections")


### PR DESCRIPTION
Instead of using CLI options and env variables, we'd like to switch to YAML configs everywhere (if only to avoid having to change many different places whenever a single new option is added). The first step is to banish option-parsing code from wire-server.

Problems (I'm writing them down here so that I won't forget):

* The Cannon config uses `$(hostname -i)`, we'll have to switch to "external host file". Look at the diff for `run`.

* The Cargohold config uses `KHAN_DOMAIN` (that comes from `khan metadata`) and neither me nor Tiago know why. Same for Gundeck and Galley and Brig. Again, look at the diffs for `run`.

* I'm not sure if I should do the same for `galley/journaler` or not.

Also, I'm not going to rid of `LOG_LEVEL` here. It can be done later, or perhaps never.