### PR TITLE
Service whitelisting, for real this time

### DIFF
--- a/libs/brig-types/src/Brig/Types/Provider.hs
+++ b/libs/brig-types/src/Brig/Types/Provider.hs
@@ -475,7 +475,7 @@ data ServiceProfile = ServiceProfile
     , serviceProfileAssets   :: ![Asset]
     , serviceProfileTags     :: !(Set ServiceTag)
     , serviceProfileEnabled  :: !Bool
-    }
+    } deriving (Eq, Show)
 
 instance FromJSON ServiceProfile where
     parseJSON = withObject "ServiceProfile" $ \o ->
@@ -506,7 +506,7 @@ instance ToJSON ServiceProfile where
 data ServiceProfilePage = ServiceProfilePage
     { serviceProfilePageHasMore :: !Bool
     , serviceProfilePageResults :: ![ServiceProfile]
-    }
+    } deriving (Eq, Show)
 
 instance FromJSON ServiceProfilePage where
     parseJSON = withObject "ServiceProfilePage" $ \o ->
@@ -598,6 +598,28 @@ instance ToJSON DeleteService where
         ]
 
 --------------------------------------------------------------------------------
+-- UpdateServiceWhitelist
+
+data UpdateServiceWhitelist = UpdateServiceWhitelist
+    { updateServiceWhitelistProvider :: !ProviderId
+    , updateServiceWhitelistService  :: !ServiceId
+    , updateServiceWhitelistStatus   :: !Bool
+    } deriving (Eq, Show)
+
+instance FromJSON UpdateServiceWhitelist where
+    parseJSON = withObject "UpdateServiceWhitelist" $ \o ->
+        UpdateServiceWhitelist <$> o .: "provider"
+                               <*> o .: "id"
+                               <*> o .: "whitelisted"
+
+instance ToJSON UpdateServiceWhitelist where
+    toJSON u = object
+        [ "provider"    .= updateServiceWhitelistProvider u
+        , "id"          .= updateServiceWhitelistService u
+        , "whitelisted" .= updateServiceWhitelistStatus u
+        ]
+
+--------------------------------------------------------------------------------
 -- AddBot
 
 -- | Input data for adding a bot to a conversation.
@@ -681,4 +703,3 @@ instance ToJSON UpdateBotPrekeys where
     toJSON u = object
         [ "prekeys" .= updateBotPrekeyList u
         ]
-

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -16,6 +16,7 @@ module Test.Brig.Types.Arbitrary where
 
 import Brig.Types.Activation
 import Brig.Types.Code
+import Brig.Types.Provider (UpdateServiceWhitelist(..))
 import Brig.Types.TURN
 import Brig.Types.TURN.Internal
 import Brig.Types.User
@@ -329,6 +330,9 @@ deriving instance Bounded ISO639_1
 
 instance Arbitrary Country where
     arbitrary = Country <$> genEnumBounded
+
+instance Arbitrary UpdateServiceWhitelist where
+    arbitrary = UpdateServiceWhitelist <$> arbitrary <*> arbitrary <*> arbitrary
 
 
 ----------------------------------------------------------------------

--- a/libs/brig-types/test/unit/Test/Brig/Types/User.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/User.hs
@@ -9,6 +9,7 @@
 module Test.Brig.Types.User where
 
 import Brig.Types.Activation
+import Brig.Types.Provider (UpdateServiceWhitelist)
 import Brig.Types.User
 import Data.Aeson
 import Data.Aeson.Types
@@ -81,10 +82,11 @@ roundtripTests =
     , run @PhoneRemove Proxy
     , run @PhoneUpdate Proxy
     , run @SelfProfile Proxy
+    , run @UpdateServiceWhitelist Proxy
     , run @UserHandleInfo Proxy
     , run @UserProfile Proxy
-    , run @UserUpdate Proxy
     , run @User Proxy
+    , run @UserUpdate Proxy
     , run @VerifyDeleteUser Proxy
     ]
   where

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -155,6 +155,13 @@ data Event = Event
 --      presumably only they care about it. However, we can't do this
 --      either, because adding new permissions is tricky.
 --      See Note [team roles] again.
+--
+-- So, we don't send these events at all. An implementation was done, but
+-- then removed in commit b4d777ede1c7f73e42b2e1bc356ce7346e0355bc.
+--
+-- It's also unclear whether these event types belong in Brig or in Galley;
+-- arguably the code would be simpler if they were in Brig, so we should
+-- think about that if we want to get them in.
 
 data EventType =
       TeamCreate

--- a/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
@@ -146,8 +146,6 @@ eventType = string $ enum
     , "team.member-leave"
     , "team.conversation-create"
     , "team.conversation-delete"
-    , "team.service-whitelist-add"
-    , "team.service-whitelist-remove"
     ]
 
 memberEvent :: Model

--- a/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
@@ -146,6 +146,8 @@ eventType = string $ enum
     , "team.member-leave"
     , "team.conversation-create"
     , "team.conversation-delete"
+    , "team.service-whitelist-add"
+    , "team.service-whitelist-remove"
     ]
 
 memberEvent :: Model

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -22,6 +22,7 @@ library
         Brig.Data.PasswordReset
         Brig.Options
         Brig.Provider.DB
+        Brig.RPC
         Brig.User.Auth.Cookie.Limit
         Brig.User.Search.Index
         Brig.ZAuth
@@ -60,7 +61,6 @@ library
       , Brig.Provider.Email
       , Brig.Provider.RPC
       , Brig.Provider.Template
-      , Brig.RPC
       , Brig.SMTP
       , Brig.Team.API
       , Brig.Team.DB
@@ -274,6 +274,7 @@ executable brig-schema
         V49
         V50
         V51
+        V52
 
     build-depends:
         base

--- a/services/brig/schema/src/Main.hs
+++ b/services/brig/schema/src/Main.hs
@@ -47,6 +47,7 @@ import qualified V48
 import qualified V49
 import qualified V50
 import qualified V51
+import qualified V52
 
 main :: IO ()
 main = do
@@ -95,4 +96,5 @@ main = do
         , V49.migration
         , V50.migration
         , V51.migration
+        , V52.migration
         ] `finally` close l

--- a/services/brig/schema/src/V17.hs
+++ b/services/brig/schema/src/V17.hs
@@ -9,6 +9,7 @@ import Text.RawString.QQ
 
 migration :: Migration
 migration = Migration 17 "Drop user_push column family" $ do
+    -- 'user_push' has been moved to gundeck
     void $ schema' [r|
        drop columnfamily if exists user_push;
        |]

--- a/services/brig/schema/src/V52.hs
+++ b/services/brig/schema/src/V52.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module V52 (migration) where
+
+import Data.Functor (void)
+import Cassandra.Schema
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 52 "Add service whitelist table" $ do
+    -- NB. It's expected that for every team there'll only be a few
+    -- whitelisted services (tens? maybe less).
+    void $ schema' [r|
+        create table if not exists service_whitelist
+            ( team     uuid
+            , provider uuid
+            , service  uuid
+            , primary key (team, provider, service)
+            ) with clustering order by (provider asc, service asc)
+    |]
+
+    -- When a service is deleted, we have to remove it from the whitelist.
+    -- Since 'service_whitelist' has 'team' as the partition key, Cassandra
+    -- won't allow a naive "delete ... where service = X" query. Hence, we
+    -- will create and maintain a reverse index for the whitelist.
+    void $ schema' [r|
+        create table if not exists service_whitelist_rev
+            ( team     uuid
+            , provider uuid
+            , service  uuid
+            , primary key ((provider, service), team)
+            )
+    |]

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -122,7 +122,7 @@ import qualified System.Logger            as Log
 import qualified System.Logger.Class      as LC
 
 schemaVersion :: Int32
-schemaVersion = 51
+schemaVersion = 52
 
 -------------------------------------------------------------------------------
 -- Environment

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -22,6 +22,7 @@ module Brig.Data.User
     , lookupLocale
     , lookupPassword
     , lookupStatus
+    , lookupUserTeam
     , insertAccount
     , updateUser
     , updateEmail
@@ -232,6 +233,10 @@ lookupStatus :: UserId -> AppIO (Maybe AccountStatus)
 lookupStatus u = join . fmap runIdentity <$>
     retry x1 (query1 statusSelect (params Quorum (Identity u)))
 
+lookupUserTeam :: UserId -> AppIO (Maybe TeamId)
+lookupUserTeam u = join . fmap runIdentity <$>
+    retry x1 (query1 teamSelect (params Quorum (Identity u)))
+
 lookupAuth :: (MonadClient m) => UserId -> m (Maybe (Maybe Password, AccountStatus))
 lookupAuth u = fmap f <$> retry x1 (query1 authSelect (params Quorum (Identity u)))
   where
@@ -294,6 +299,9 @@ accountStateSelectAll = "SELECT id, activated, status FROM user WHERE id IN ?"
 
 statusSelect :: PrepQuery R (Identity UserId) (Identity (Maybe AccountStatus))
 statusSelect = "SELECT status FROM user WHERE id = ?"
+
+teamSelect :: PrepQuery R (Identity UserId) (Identity (Maybe TeamId))
+teamSelect = "SELECT team FROM user WHERE id = ?"
 
 accountsSelect :: PrepQuery R (Identity [UserId]) AccountRow
 accountsSelect = "SELECT id, name, picture, email, phone, sso_id, accent_id, assets, \

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -13,8 +13,6 @@ module Brig.IO.Intra
     , onConnectionEvent
     , onPropertyEvent
     , onClientEvent
-    , push
-    , rawPush
 
       -- * Conversations
     , createSelfConv
@@ -213,6 +211,8 @@ rawPush
     -> Push.Route   -- ^ The push routing strategy.
     -> Maybe ConnId -- ^ The originating device connection.
     -> AppIO ()
+-- TODO: if we decide to have service whitelist events in Brig instead of
+-- Galley, let's merge 'push' and 'rawPush' back. See Note [whitelist events].
 rawPush (toList -> events) usrs orig route conn = do
     for_ events $ \e -> debug $ remote "gundeck" . msg (fst e)
     g <- view gundeck

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -13,6 +13,8 @@ module Brig.IO.Intra
     , onConnectionEvent
     , onPropertyEvent
     , onClientEvent
+    , push
+    , rawPush
 
       -- * Conversations
     , createSelfConv
@@ -41,6 +43,7 @@ module Brig.IO.Intra
     , getTeamId
     , getTeamContacts
     , getTeamOwners
+    , getTeamOwnersWithEmail
     , changeTeamStatus
     ) where
 
@@ -76,7 +79,7 @@ import Galley.Types (Connect (..), Conversation)
 import Gundeck.Types.Push.V2
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status
-import System.Logger.Class hiding ((.=), name)
+import System.Logger.Class as Log hiding ((.=), name)
 
 import qualified Brig.User.Search.Index      as Search
 import qualified Brig.User.Event.Log         as Log
@@ -191,25 +194,37 @@ push :: List1 Event  -- ^ The events to push.
      -> Push.Route   -- ^ The push routing strategy.
      -> Maybe ConnId -- ^ The originating device connection.
      -> AppIO ()
-push (toList -> evts) usrs orig route conn = do
-    let events = mapMaybe toPushData evts
-    unless (null events) $ do
-      for_ events $ \e -> debug $ remote "gundeck" . msg (fst e)
-      g <- view gundeck
-      forM_ recipients $ \rcps ->
-        void . recovering x3 rpcHandlers $ const $ rpc' "gundeck" g
-            ( method POST
-            . path "/i/push/v2"
-            . zUser orig
-            . json (map (mkPush rcps . snd) events)
-            . expect2xx
-            )
+push (toList -> events) usrs orig route conn =
+    case mapMaybe toPushData events of
+        []   -> pure ()
+        x:xs -> rawPush (list1 x xs) usrs orig route conn
   where
-    toPushData :: Event -> Maybe (Event, (Object, Maybe ApsData))
+    toPushData :: Event -> Maybe (Builder, (Object, Maybe ApsData))
     toPushData e = case toPushFormat e of
-          Just o  -> Just (e, (o, toApsData e))
+          Just o  -> Just (Log.bytes e, (o, toApsData e))
           Nothing -> Nothing
 
+-- | Push encoded events to other users. Useful if you want to push
+-- something that's not defined in Brig.
+rawPush
+    :: List1 (Builder, (Object, Maybe ApsData)) -- ^ The events to push.
+    -> List1 UserId -- ^ The users to push to.
+    -> UserId       -- ^ The originator of the events.
+    -> Push.Route   -- ^ The push routing strategy.
+    -> Maybe ConnId -- ^ The originating device connection.
+    -> AppIO ()
+rawPush (toList -> events) usrs orig route conn = do
+    for_ events $ \e -> debug $ remote "gundeck" . msg (fst e)
+    g <- view gundeck
+    forM_ recipients $ \rcps ->
+      void . recovering x3 rpcHandlers $ const $ rpc' "gundeck" g
+          ( method POST
+          . path "/i/push/v2"
+          . zUser orig
+          . json (map (mkPush rcps . snd) events)
+          . expect2xx
+          )
+  where
     recipients :: [Range 1 1024 (Set.Set Recipient)]
     recipients = map (unsafeRange . Set.fromList)
                $ chunksOf 512
@@ -612,7 +627,7 @@ getTeamContacts u = do
         . expect [status200, status404]
 
 -- | 'Nothing' means no team could be found.  'Just' contains all members of the team that have full
--- permissions and email address.
+-- permissions.
 --
 -- TODO: This could arguably also live in galley, since it is about teams.  But it also needs emails
 -- of users, so no matter whether it lives in galley or brig, one has to call the other for this to
@@ -623,26 +638,24 @@ getTeamContacts u = do
 -- body.  When brig wants to know, it can call both parts.  These thoughts may all become obsolete
 -- if we introduce a deletion service in the future.
 getTeamOwners :: TeamId -> AppIO [Team.TeamMember]
-getTeamOwners tid = filterByEmail . filterByPerms =<< getTeamMembers tid
-  where
-    filterByPerms :: Team.TeamMemberList -> [Team.TeamMember]
-    filterByPerms mems =
-        filter ((== Team.fullPermissions) . (^. Team.permissions)) (mems ^. Team.teamMembers)
+getTeamOwners tid = filter Team.isTeamOwner . view Team.teamMembers <$> getTeamMembers tid
 
-    filterByEmail :: [Team.TeamMember] -> AppIO [Team.TeamMember]
-    filterByEmail mems = do
-        usrList :: [User] <- lookupUsers ((^. Team.userId) <$> mems)
+-- | Like 'getTeamOwners', but only returns owners with an email address.
+getTeamOwnersWithEmail :: TeamId -> AppIO [Team.TeamMember]
+getTeamOwnersWithEmail tid = do
+    mems <- getTeamOwners tid
+    usrList :: [User] <- lookupUsers ((^. Team.userId) <$> mems)
 
-        let usrMap :: Map.Map UserId Bool
-            usrMap = Map.fromList $ mkListItem <$> usrList
+    let usrMap :: Map.Map UserId Bool
+        usrMap = Map.fromList $ mkListItem <$> usrList
 
-            mkListItem :: User -> (UserId, Bool)
-            mkListItem usr = (userId usr, isJust $ userEmail usr)
+        mkListItem :: User -> (UserId, Bool)
+        mkListItem usr = (userId usr, isJust $ userEmail usr)
 
-            hasEmail :: Team.TeamMember -> Bool
-            hasEmail mem = maybe False id $ Map.lookup (mem ^. Team.userId) usrMap
+        hasEmail :: Team.TeamMember -> Bool
+        hasEmail mem = maybe False id $ Map.lookup (mem ^. Team.userId) usrMap
 
-        pure $ filter hasEmail mems
+    pure $ filter hasEmail mems
 
 getTeamId :: UserId -> AppIO (Maybe TeamId)
 getTeamId u = do

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -15,6 +15,7 @@ import Brig.Data.UserKey (userEmailKey)
 import Brig.Email
 import Brig.Options (setMaxTeamSize, setTeamInvitationTimeout)
 import Brig.Team.Email
+import Brig.Team.Util (ensurePermissions)
 import Brig.Types.Team.Invitation
 import Brig.Types.User (InvitationCode, emailIdentity)
 import Brig.Types.Intra (AccountStatus (..))
@@ -246,13 +247,3 @@ changeTeamAccountStatuses tid s = do
   where
     toList1 (x:xs) = return $ List1.list1 x xs
     toList1 []     = throwStd (notFound "Team not found or no members")
-
-ensurePermissions :: UserId -> TeamId -> [Team.Perm] -> Handler ()
-ensurePermissions u t perms = do
-    m <- lift $ Intra.getTeamMember u t
-    unless (check m) $
-        throwStd insufficientTeamPermissions
-  where
-    check :: Maybe Team.TeamMember -> Bool
-    check (Just m) = and $ Team.hasPermission m <$> perms
-    check Nothing  = False

--- a/services/brig/test/integration/API/TURN.hs
+++ b/services/brig/test/integration/API/TURN.hs
@@ -140,9 +140,8 @@ getTurnConfiguration suffix u b = get ( b
                                 )
 
 getAndValidateTurnConfiguration :: HasCallStack => ByteString -> UserId -> Brig -> Http RTCConfiguration
-getAndValidateTurnConfiguration suffix u b = do
-    r <- getTurnConfiguration suffix u b <!! const 200 === statusCode
-    return $ fromMaybe (error "getTurnConfiguration: failed to parse response") (decodeBody r)
+getAndValidateTurnConfiguration suffix u b =
+    decodeBody =<< (getTurnConfiguration suffix u b <!! const 200 === statusCode)
 
 toTurnURILegacy :: ByteString -> Port -> TurnURI
 toTurnURILegacy h p = toTurnURI SchemeTurn h p Nothing

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -16,21 +16,19 @@ import Brig.Types.User.Auth
 import Brig.Types.Intra
 import Control.Arrow ((&&&))
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async.Lifted.Safe (mapConcurrently_, replicateConcurrently)
-import Control.Lens ((^.), (^?), view)
+import Control.Concurrent.Async.Lifted.Safe.Extended
+    (mapConcurrently_, replicateConcurrently, forPooled, replicatePooled)
+import Control.Lens ((^.), view)
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Aeson
-import Data.Aeson.Lens
 import Data.ByteString.Conversion
 import Data.ByteString.Lazy.Internal (ByteString)
 import Data.Id hiding (client)
-import Data.List.Extra (chunksOf)
 import Data.Maybe
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import Data.Word (Word16)
-import GHC.Stack (HasCallStack)
 import Network.HTTP.Client             (Manager)
 import Test.Tasty hiding (Timeout)
 import Test.Tasty.HUnit
@@ -42,7 +40,6 @@ import Util.Options.Common
 import qualified Brig.AWS                    as AWS
 import qualified Brig.Options                as Opt
 import qualified Data.Text.Ascii             as Ascii
-import qualified Data.Text.Encoding          as T
 import qualified Data.UUID.V4                as UUID
 import qualified Network.Wai.Utilities.Error as Error
 import qualified Galley.Types.Teams          as Team
@@ -98,7 +95,7 @@ testUpdateEvents brig galley cannon = do
 
     -- invite and register Bob
     let invite  = InvitationRequest inviteeEmail (Name "Bob") Nothing
-    Just inv <- decodeBody <$> postInvitation brig tid alice invite
+    inv <- decodeBody =<< postInvitation brig tid alice invite
     Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
     rsp2 <- post (brig . path "/register"
                        . contentJson
@@ -136,7 +133,8 @@ testInvitationTooManyPending brig galley (TeamSizeLimit limit) = do
     (inviter, tid) <- createUserWithTeam brig galley
     emails <- replicateConcurrently (fromIntegral limit) randomEmail
     let invite e = InvitationRequest e (Name "Bob") Nothing
-    mapM_ (mapConcurrently_ $ postInvitation brig tid inviter . invite) (chunksOf 16 emails)
+    void $ forPooled 16 emails $ \email ->
+        postInvitation brig tid inviter (invite email)
     e <- randomEmail
     -- TODO: If this test takes longer to run than `team-invitation-timeout`, then some of the
     --       invitations have likely expired already and this test will actually _fail_
@@ -149,7 +147,7 @@ testInvitationEmailAccepted brig galley = do
     (inviter, tid) <- createUserWithTeam brig galley
     inviteeEmail <- randomEmail
     let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing
-    Just inv <- decodeBody <$> postInvitation brig tid inviter invite
+    inv <- decodeBody =<< postInvitation brig tid inviter invite
     Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
     rsp2 <- post (brig . path "/register"
                        . contentJson
@@ -325,20 +323,18 @@ testInvitationMutuallyExclusive brig = do
 testInvitationTooManyMembers :: Brig -> Galley -> TeamSizeLimit -> Http ()
 testInvitationTooManyMembers brig galley (TeamSizeLimit limit) = do
     (creator, tid) <- createUserWithTeam brig galley
-    uids <- fmap toNewMember <$> replicateConcurrently (fromIntegral limit - 1) randomId
-    mapM_ (mapConcurrently_ (addTeamMember galley tid)) $ chunksOf 16 uids
+    void $ replicatePooled 16 (fromIntegral limit - 1) $
+        createTeamMember brig galley creator tid Team.fullPermissions
 
     em <- randomEmail
     let invite = InvitationRequest em (Name "Bob") Nothing
-    Just inv <- decodeBody <$> postInvitation brig tid creator invite
+    inv <- decodeBody =<< postInvitation brig tid creator invite
     Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
     post (brig . path "/register"
                . contentJson
                . body (accept em inviteeCode)) !!! do
         const 403 === statusCode
         const (Just "too-many-team-members") === fmap Error.label . decodeBody
-  where
-    toNewMember u = Team.newNewTeamMember $ Team.newTeamMember u Team.fullPermissions
 
 testInvitationPaging :: Brig -> Galley -> Http ()
 testInvitationPaging brig galley = do
@@ -369,7 +365,7 @@ testInvitationInfo brig galley = do
     email    <- randomEmail
     (uid, tid) <- createUserWithTeam brig galley
     let invite = InvitationRequest email (Name "Bob") Nothing
-    Just inv <- decodeBody <$> postInvitation brig tid uid invite
+    inv <- decodeBody =<< postInvitation brig tid uid invite
 
     Just invCode    <- getInvitationCode brig tid (inInvitation inv)
     Just invitation <- getInvitation brig invCode
@@ -388,7 +384,7 @@ testInvitationInfoExpired brig galley timeout = do
     email      <- randomEmail
     (uid, tid) <- createUserWithTeam brig galley
     let invite = InvitationRequest email (Name "Bob") Nothing
-    Just inv <- decodeBody <$> postInvitation brig tid uid invite
+    inv <- decodeBody =<< postInvitation brig tid uid invite
     -- Note: This value must be larger than the option passed as `team-invitation-timeout`
     awaitExpiry (round timeout + 5) tid (inInvitation inv)
     getCode tid (inInvitation inv) !!! const 400 === statusCode
@@ -415,7 +411,7 @@ testSuspendTeam brig galley = do
 
     -- invite and register invitee
     let invite  = InvitationRequest inviteeEmail (Name "Bob") Nothing
-    Just inv <- decodeBody <$> postInvitation brig tid inviter invite
+    inv <- decodeBody =<< postInvitation brig tid inviter invite
     Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
     rsp2 <- post (brig . path "/register"
                        . contentJson
@@ -425,7 +421,7 @@ testSuspendTeam brig galley = do
 
     -- invite invitee2 (don't register)
     let invite2 = InvitationRequest inviteeEmail2 (Name "Bob") Nothing
-    Just inv2 <- decodeBody <$> postInvitation brig tid inviter invite2
+    inv2 <- decodeBody =<< postInvitation brig tid inviter invite2
     Just _ <- getInvitationCode brig tid (inInvitation inv2)
 
     -- suspend team
@@ -591,7 +587,7 @@ testCreateUserInternalSSO brig galley = do
     let Just teamid' = userTeam $ selfUser profile
     liftIO $ assertEqual "bad team_id" teamid teamid'
 
-    -- does gally know about this?  is user active?
+    -- does galley know about this?  is user active?
     _ <- getTeamMember uid teamid galley
     isact <- isActivatedUser uid brig
     liftIO $ assertBool "user not activated" isact
@@ -629,128 +625,3 @@ testDeleteUserSSO brig galley = do
     -- if the mock sso service disagrees with the deletion: 403 "sso-not-allowed" or something
     -- if user is last remaining owner: 403 "no-other-owner" (as above).
     -- otherwise: 2xx.
-
--------------------------------------------------------------------------------
--- Utilities
-
-listConnections :: HasCallStack => UserId -> Brig -> Http UserConnectionList
-listConnections u brig = do
-    r <- get $ brig
-             . path "connections"
-             . zUser u
-    return $ fromMaybe (error "listConnections: failed to parse response") (decodeBody r)
-
-getInvitation :: Brig -> InvitationCode -> Http (Maybe Invitation)
-getInvitation brig c = do
-    r <- get $ brig
-             . path "/teams/invitations/info"
-             . queryItem "code" (toByteString' c)
-    return . decode . fromMaybe "" $ responseBody r
-
-postInvitation :: Brig -> TeamId -> UserId -> InvitationRequest -> Http ResponseLBS
-postInvitation brig t u i = post $ brig
-    . paths ["teams", toByteString' t, "invitations"]
-    . contentJson
-    . body (RequestBodyLBS $ encode i)
-    . zAuthAccess u "conn"
-
-suspendTeam :: Brig -> TeamId -> HttpT IO (Response (Maybe ByteString))
-suspendTeam brig t = post $ brig
-    . paths ["i", "teams", toByteString' t, "suspend"]
-    . contentJson
-
-unsuspendTeam :: Brig -> TeamId -> Http ResponseLBS
-unsuspendTeam brig t = post $ brig
-    . paths ["i", "teams", toByteString' t, "unsuspend"]
-    . contentJson
-
-getTeam :: HasCallStack => Galley -> TeamId -> Http Team.TeamData
-getTeam galley t = do
-    r <- get $ galley . paths ["i", "teams", toByteString' t]
-    return $ fromMaybe (error "getTeam: failed to parse response") (decodeBody r)
-
-getInvitationCode :: HasCallStack => Brig -> TeamId -> InvitationId -> Http (Maybe InvitationCode)
-getInvitationCode brig t ref = do
-    r <- get ( brig
-             . path "/i/teams/invitation-code"
-             . queryItem "team" (toByteString' t)
-             . queryItem "invitation_id" (toByteString' ref)
-             )
-    let lbs   = fromMaybe "" $ responseBody r
-    return $ fromByteString . fromMaybe (error "No code?") $ T.encodeUtf8 <$> (lbs ^? key "code"  . _String)
-
-assertNoInvitationCode :: HasCallStack => Brig -> TeamId -> InvitationId -> Http ()
-assertNoInvitationCode brig t i =
-    get ( brig
-        . path "/i/teams/invitation-code"
-        . queryItem "team" (toByteString' t)
-        . queryItem "invitation_id" (toByteString' i)
-        ) !!! do
-          const 400 === statusCode
-          const (Just "invalid-invitation-code") === fmap Error.label . decodeBody
-
-accept :: Email -> InvitationCode -> RequestBody
-accept email code = RequestBodyLBS . encode $ object
-    [ "name"      .= ("Bob" :: Text)
-    , "email"     .= fromEmail email
-    , "password"  .= defPassword
-    , "team_code" .= code
-    ]
-
-register :: Email -> Team.BindingNewTeam -> Brig -> HttpT IO (Response (Maybe ByteString))
-register e t brig = post (brig . path "/register" . contentJson . body (
-    RequestBodyLBS . encode  $ object
-        [ "name"            .= ("Bob" :: Text)
-        , "email"           .= fromEmail e
-        , "password"        .= defPassword
-        , "team"            .= t
-        ]
-    ))
-
-register' :: Email -> Team.BindingNewTeam -> ActivationCode -> Brig -> HttpT IO (Response (Maybe ByteString))
-register' e t c brig = post (brig . path "/register" . contentJson . body (
-    RequestBodyLBS . encode  $ object
-        [ "name"            .= ("Bob" :: Text)
-        , "email"           .= fromEmail e
-        , "email_code"      .= c
-        , "password"        .= defPassword
-        , "team"            .= t
-        ]
-    ))
-
-decodeBody' :: FromJSON a => Response (Maybe ByteString) -> Http a
-decodeBody' x = maybe (error $ "Failed to decodeBody: " ++ show x) return $ decodeBody x
-
-inviteAndRegisterUser :: UserId -> TeamId -> Brig -> HttpT IO User
-inviteAndRegisterUser u tid brig = do
-    inviteeEmail <- randomEmail
-    let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing
-    Just inv <- decodeBody <$> postInvitation brig tid u invite
-    Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
-    rspInvitee <- post (brig . path "/register"
-                             . contentJson
-                             . body (accept inviteeEmail inviteeCode)) <!! const 201 === statusCode
-
-    let Just invitee = decodeBody rspInvitee
-    liftIO $ assertBool "Team ID in registration and team table do not match" (Just tid == userTeam invitee)
-    selfTeam <- userTeam . selfUser <$> getSelfProfile brig (userId invitee)
-    liftIO $ assertBool "Team ID in self profile and team table do not match" (selfTeam == Just tid)
-    return invitee
-
-updatePermissions :: UserId -> TeamId -> (UserId, Team.Permissions) -> Galley -> HttpT IO ()
-updatePermissions from tid (to, perm) galley =
-    put ( galley
-        . paths ["teams", toByteString' tid, "members"]
-        . zUser from
-        . zConn "conn"
-        . Bilge.json changeMember
-        ) !!! const 200 === statusCode
-  where
-    changeMember = Team.newNewTeamMember $ Team.newTeamMember to perm
-
-isActivatedUser :: UserId -> Brig -> Http Bool
-isActivatedUser uid brig = do
-    resp <- get (brig . path "/i/users" . queryItem "ids" (toByteString' uid) . expect2xx)
-    pure $ case decodeBody @[User] resp of
-        Just (_:_) -> True
-        _ -> False

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -337,7 +337,7 @@ testCreateUserExternalSSO brig = do
 
 testActivateWithExpiry :: Brig -> Opt.Timeout -> Http ()
 testActivateWithExpiry brig timeout = do
-    Just u <- decodeBody <$> registerUser "dilbert" "success@simulator.amazonses.com" brig
+    u <- decodeBody =<< registerUser "dilbert" "success@simulator.amazonses.com" brig
     let email = fromMaybe (error "missing email") (userEmail u)
     act <- getActivationCode brig (Left email)
     case act of
@@ -523,7 +523,8 @@ testEmailUpdate brig aws = do
     flip initiateUpdateAndActivate uid =<< mkEmailRandomLocalSuffix "test@example.com"
   where
     ensureNoOtherUserWithEmail eml = do
-        tk <- decodeBody <$> login brig (defEmailLogin eml) SessionCookie
+        tk :: Maybe AccessToken <-
+            decodeBody <$> login brig (defEmailLogin eml) SessionCookie
         for_ tk $ \t -> do
             deleteUser (Auth.user t) (Just defPassword) brig !!! const 200 === statusCode
             liftIO $ Util.assertUserJournalQueue "user deletion" aws (userDeleteJournaled $ Auth.user t)
@@ -818,7 +819,7 @@ testDeleteUserByPassword brig cannon aws = do
     con23 <- getConnection brig uid2 uid3 <!! const 200 === statusCode
 
     -- Register a client
-    addClient brig u (defNewClient PermanentClient [somePrekeys !! 0] (someLastPrekeys !! 0))
+    addClient brig uid1 (defNewClient PermanentClient [somePrekeys !! 0] (someLastPrekeys !! 0))
         !!! const 201 === statusCode
 
     -- Initial login

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -201,7 +201,7 @@ testLoginFailure brig = do
                 ]
     res <- post (brig . path "/i/users" . contentJson . Http.body newUser) <!!
         const 201 === statusCode
-    let uid = fromMaybe (error "Failed to parse user") (userId <$> decodeBody res)
+    uid <- userId <$> decodeBody res
     eml <- randomEmail
 
     -- Add email

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -51,11 +51,11 @@ tests _cl _at _conf p b c g = testGroup "client"
 
 testAddGetClient :: Brig -> Cannon -> Http ()
 testAddGetClient brig cannon = do
-    u <- randomUser brig
-    let rq = addClientReq brig u (defNewClient TemporaryClient [somePrekeys !! 0] (someLastPrekeys !! 0))
+    uid <- userId <$> randomUser brig
+    let rq = addClientReq brig uid (defNewClient TemporaryClient [somePrekeys !! 0] (someLastPrekeys !! 0))
            . header "X-Forwarded-For" "127.0.0.1" -- Fake IP to test IpAddr parsing.
-    c <- WS.bracketR cannon (userId u) $ \ws -> do
-        Just c <- decodeBody <$> (post rq <!! do
+    c <- WS.bracketR cannon uid $ \ws -> do
+        c <- decodeBody =<< (post rq <!! do
             const 201  === statusCode
             const True === isJust . getHeader "Location")
         void . liftIO $ WS.assertMatch (5 # Second) ws $ \n -> do
@@ -65,7 +65,7 @@ testAddGetClient brig cannon = do
             etype @?= Just "user.client-add"
             fmap fromJSON eclient @?= Just (Success c)
         return c
-    getClient brig (userId u) (clientId c) !!! do
+    getClient brig uid (clientId c) !!! do
         const 200      === statusCode
         const (Just c) === decodeBody
 
@@ -83,122 +83,123 @@ testClientReauthentication brig = do
                  { newClientPassword = Nothing }
 
     -- User with password
-    u <- randomUser brig
+    uid <- userId <$> randomUser brig
     -- The first client never requires authentication
-    Just c <- decodeBody <$> (addClient brig u payload1 <!! const 201 === statusCode)
+    c <- decodeBody =<< (addClient brig uid payload1 <!! const 201 === statusCode)
     -- Adding a second client requires reauthentication, if a password is set.
-    addClient brig u payload2 !!! do
+    addClient brig uid payload2 !!! do
         const 403 === statusCode
         const (Just "missing-auth") === (fmap Error.label . decodeBody)
     -- Removing a client requires reauthentication, if a password is set.
-    deleteClient brig (userId u) (clientId c) Nothing !!! const 403 === statusCode
+    deleteClient brig uid (clientId c) Nothing !!! const 403 === statusCode
 
     -- User without a password
-    u2 <- createAnonUser "Mr. X" brig
-    Just c2 <- decodeBody <$> (addClient brig u2 payload1 <!! const 201 === statusCode)
-    Just c3 <- decodeBody <$> (addClient brig u2 payload2 <!! const 201 === statusCode)
-    deleteClient brig (userId u2) (clientId c2) Nothing !!! const 200 === statusCode
-    deleteClient brig (userId u2) (clientId c3) Nothing !!! const 200 === statusCode
+    uid2 <- userId <$> createAnonUser "Mr. X" brig
+    c2 <- decodeBody =<< (addClient brig uid2 payload1 <!! const 201 === statusCode)
+    c3 <- decodeBody =<< (addClient brig uid2 payload2 <!! const 201 === statusCode)
+    deleteClient brig uid2 (clientId c2) Nothing !!! const 200 === statusCode
+    deleteClient brig uid2 (clientId c3) Nothing !!! const 200 === statusCode
 
     -- Temporary client can always be deleted without a password
-    Just c4 <- decodeBody <$> addClient brig u payload3
-    deleteClient brig (userId u) (clientId c4) Nothing !!! const 200 === statusCode
-    Just c5 <- decodeBody <$> addClient brig u2 payload3
-    deleteClient brig (userId u2) (clientId c5) Nothing !!! const 200 === statusCode
+    c4 <- decodeBody =<< addClient brig uid payload3
+    deleteClient brig uid (clientId c4) Nothing !!! const 200 === statusCode
+    c5 <- decodeBody =<< addClient brig uid2 payload3
+    deleteClient brig uid2 (clientId c5) Nothing !!! const 200 === statusCode
 
 testListClients :: Brig -> Http ()
 testListClients brig = do
-    u  <- randomUser brig
+    uid <- userId <$> randomUser brig
     let (pk1, lk1) = (somePrekeys !! 0, (someLastPrekeys !! 0))
     let (pk2, lk2) = (somePrekeys !! 1, (someLastPrekeys !! 1))
     let (pk3, lk3) = (somePrekeys !! 2, (someLastPrekeys !! 2))
-    c1 <- decodeBody <$> addClient brig u (defNewClient PermanentClient [pk1] lk1)
-    c2 <- decodeBody <$> addClient brig u (defNewClient PermanentClient [pk2] lk2)
-    c3 <- decodeBody <$> addClient brig u (defNewClient TemporaryClient [pk3] lk3)
+    c1 <- decodeBody <$> addClient brig uid (defNewClient PermanentClient [pk1] lk1)
+    c2 <- decodeBody <$> addClient brig uid (defNewClient PermanentClient [pk2] lk2)
+    c3 <- decodeBody <$> addClient brig uid (defNewClient TemporaryClient [pk3] lk3)
     let cs = sortBy (compare `on` clientId) $ catMaybes [c1, c2, c3]
     get ( brig
         . path "clients"
-        . zUser (userId u)
+        . zUser uid
         ) !!! do
             const 200       === statusCode
             const (Just cs) === decodeBody
 
 testListPrekeyIds :: Brig -> Http ()
 testListPrekeyIds brig = do
-    u <- randomUser brig
+    uid <- userId <$> randomUser brig
     let new = defNewClient PermanentClient [somePrekeys !! 0] (someLastPrekeys !! 0)
-    Just c <- decodeBody <$> addClient brig u new
+    c <- decodeBody =<< addClient brig uid new
     let pks = [PrekeyId 1, lastPrekeyId]
     get ( brig
         . paths ["clients", toByteString' (clientId c), "prekeys"]
-        . zUser (userId u)
+        . zUser uid
         ) !!! do
             const 200        === statusCode
             const (Just pks) === fmap sort . decodeBody
 
 testGetUserPrekeys :: Brig -> Http ()
 testGetUserPrekeys brig = do
-    u <- randomUser brig
+    uid <- userId <$> randomUser brig
     let new = defNewClient TemporaryClient [somePrekeys !! 0] (someLastPrekeys !! 0)
-    Just c <- decodeBody <$> addClient brig u new
+    c <- decodeBody =<< addClient brig uid new
     let cpk = ClientPrekey (clientId c) (somePrekeys !! 0)
-    get (brig . paths ["users", toByteString' (userId u), "prekeys"]) !!! do
+    get (brig . paths ["users", toByteString' uid, "prekeys"]) !!! do
         const 200 === statusCode
-        const (Just $ PrekeyBundle (userId u) [cpk]) === decodeBody
+        const (Just $ PrekeyBundle uid [cpk]) === decodeBody
 
     -- prekeys are deleted when retrieved, except the last one
     let lpk = ClientPrekey (clientId c) (unpackLastPrekey (someLastPrekeys !! 0))
-    replicateM_ 2 $ get (brig . paths ["users", toByteString' (userId u), "prekeys"]) !!! do
+    replicateM_ 2 $ get (brig . paths ["users", toByteString' uid, "prekeys"]) !!! do
         const 200 === statusCode
-        const (Just $ PrekeyBundle (userId u) [lpk]) === decodeBody
+        const (Just $ PrekeyBundle uid [lpk]) === decodeBody
 
 testGetClientPrekey :: Brig -> Http ()
 testGetClientPrekey brig = do
-    u <- randomUser brig
+    uid <- userId <$> randomUser brig
     let new = defNewClient TemporaryClient [somePrekeys !! 0] (someLastPrekeys !! 0)
-    Just c <- decodeBody <$> addClient brig u new
-    get (brig . paths ["users", toByteString' (userId u), "prekeys", toByteString' (clientId c)]) !!! do
+    c <- decodeBody =<< addClient brig uid new
+    get (brig . paths ["users", toByteString' uid, "prekeys", toByteString' (clientId c)]) !!! do
         const 200 === statusCode
         const (Just $ ClientPrekey (clientId c) (somePrekeys !! 0)) === decodeBody
 
 testTooManyClients :: Brig -> Http ()
 testTooManyClients brig = do
-    u <- randomUser brig
+    uid <- userId <$> randomUser brig
 
     -- There is only one temporary client, adding a new one
     -- replaces the previous one.
     forM_ [0..(9 :: Int)] $ \i ->
         let pk = somePrekeys !! i
             lk = someLastPrekeys !! i
-        in addClient brig u (defNewClient TemporaryClient [pk] lk) !!! const 201 === statusCode
+        in addClient brig uid (defNewClient TemporaryClient [pk] lk) !!! const 201 === statusCode
 
     -- But there can be only up to 7 permanent clients
     forM_ [10..(16 :: Int)] $ \i ->
         let pk = somePrekeys !! i
             lk = someLastPrekeys !! i
-        in addClient brig u (defNewClient PermanentClient [pk] lk) !!! const 201 === statusCode
+        in addClient brig uid (defNewClient PermanentClient [pk] lk) !!! const 201 === statusCode
 
-    addClient brig u (defNewClient PermanentClient [somePrekeys !! 17] (someLastPrekeys !! 17)) !!! do
+    addClient brig uid (defNewClient PermanentClient [somePrekeys !! 17] (someLastPrekeys !! 17)) !!! do
         const 403 === statusCode
         const (Just "too-many-clients") === fmap Error.label . decodeBody
 
 testRemoveClient :: Brig -> Cannon -> Http ()
 testRemoveClient brig cannon = do
     u <- randomUser brig
+    let uid = userId u
     let Just email = userEmail u
 
     -- Permanent client with attached cookie
     login brig (defEmailLogin email) PersistentCookie
         !!! const 200 === statusCode
-    numCookies <- countCookies brig (userId u) defCookieLabel
+    numCookies <- countCookies brig uid defCookieLabel
     liftIO $ Just 1 @=? numCookies
-    Just c <- decodeBody <$> addClient brig u (client PermanentClient (someLastPrekeys !! 10))
+    c <- decodeBody =<< addClient brig uid (client PermanentClient (someLastPrekeys !! 10))
     -- Missing password
-    deleteClient brig (userId u) (clientId c) Nothing !!! const 403 === statusCode
+    deleteClient brig uid (clientId c) Nothing !!! const 403 === statusCode
 
     -- Success
-    WS.bracketR cannon (userId u) $ \ws -> do
-        deleteClient brig (userId u) (clientId c) (Just defPassword)
+    WS.bracketR cannon uid $ \ws -> do
+        deleteClient brig uid (clientId c) (Just defPassword)
             !!! const 200 === statusCode
         void . liftIO $ WS.assertMatch (5 # Second) ws $ \n -> do
             let j = Object $ List1.head (ntfPayload n)
@@ -208,10 +209,10 @@ testRemoveClient brig cannon = do
             fmap ClientId eclient @?= Just (clientId c)
 
     -- Not found on retry
-    deleteClient brig (userId u) (clientId c) Nothing !!! const 404 === statusCode
+    deleteClient brig uid (clientId c) Nothing !!! const 404 === statusCode
 
     -- Prekeys are gone
-    getPreKey brig (userId u) (clientId c) !!! const 404 === statusCode
+    getPreKey brig uid (clientId c) !!! const 404 === statusCode
 
     -- Cookies are gone
     numCookies' <- countCookies brig (userId u) defCookieLabel
@@ -224,17 +225,17 @@ testRemoveClient brig cannon = do
 
 testUpdateClient :: Brig -> Http ()
 testUpdateClient brig = do
-    u <- randomUser brig
+    uid <- userId <$> randomUser brig
     let clt = (defNewClient TemporaryClient [somePrekeys !! 0] (someLastPrekeys !! 0))
                 { newClientClass = Just PhoneClient
                 , newClientModel = Just "featurephone"
                 }
-    Just c <- decodeBody <$> addClient brig u clt
-    get (brig . paths ["users", toByteString' (userId u), "prekeys", toByteString' (clientId c)]) !!! do
+    c <- decodeBody =<< addClient brig uid clt
+    get (brig . paths ["users", toByteString' uid, "prekeys", toByteString' (clientId c)]) !!! do
         const 200 === statusCode
         const (Just $ ClientPrekey (clientId c) (somePrekeys !! 0)) === decodeBody
 
-    getClient brig (userId u) (clientId c) !!! do
+    getClient brig uid (clientId c) !!! do
         const 200                   === statusCode
         const (Just "Test Device")  === (clientLabel <=< decodeBody)
         const (Just PhoneClient)    === (clientClass <=< decodeBody)
@@ -245,22 +246,22 @@ testUpdateClient brig = do
 
     put ( brig
         . paths ["clients", toByteString' (clientId c)]
-        . zUser (userId u)
+        . zUser uid
         . contentJson
         . body (RequestBodyLBS $ encode update)
         ) !!! const 200 === statusCode
 
-    get (brig . paths ["users", toByteString' (userId u), "prekeys", toByteString' (clientId c)]) !!! do
+    get (brig . paths ["users", toByteString' uid, "prekeys", toByteString' (clientId c)]) !!! do
         const 200 === statusCode
         const (Just $ ClientPrekey (clientId c) newPrekey) === decodeBody
 
     -- check if label has been updated
-    getClient brig (userId u) (clientId c) !!! do
+    getClient brig uid (clientId c) !!! do
         const 200            === statusCode
         const (Just "label") === (clientLabel <=< decodeBody)
 
     -- via `/users/:user/clients/:client`, only `id` and `class` are visible:
-    get (brig . paths ["users", toByteString' (userId u), "clients", toByteString' (clientId c)]) !!! do
+    get (brig . paths ["users", toByteString' uid, "clients", toByteString' (clientId c)]) !!! do
         const 200                 === statusCode
         const (Just $ clientId c) === (fmap pubClientId . decodeBody)
         const (Just PhoneClient)  === (pubClientClass <=< decodeBody)
@@ -271,28 +272,28 @@ testUpdateClient brig = do
     -- empty update should be a no-op
     put ( brig
         . paths ["clients", toByteString' (clientId c)]
-        . zUser (userId u)
+        . zUser uid
         . contentJson
         . body (RequestBodyLBS $ encode update')
         ) !!! const 200 === statusCode
 
     -- check if label is still present
-    getClient brig (userId u) (clientId c) !!! do
+    getClient brig uid (clientId c) !!! do
         const 200            === statusCode
         const (Just "label") === (clientLabel <=< decodeBody)
 
 -- Legacy (galley)
 testAddMultipleTemporary :: Brig -> Galley -> Http ()
 testAddMultipleTemporary brig galley = do
-    u <- randomUser brig
+    uid <- userId <$> randomUser brig
 
     let clt1 = (defNewClient TemporaryClient [somePrekeys !! 0] (someLastPrekeys !! 0))
                 { newClientClass = Just PhoneClient
                 , newClientModel = Just "featurephone1"
                 }
-    _ <- addClient brig u clt1
-    brigClients1   <- numOfBrigClients (userId u)
-    galleyClients1 <- numOfGalleyClients (userId u)
+    _ <- addClient brig uid clt1
+    brigClients1   <- numOfBrigClients uid
+    galleyClients1 <- numOfGalleyClients uid
     liftIO $ assertEqual "Too many clients found" (Just 1) brigClients1
     liftIO $ assertEqual "Too many clients found" (Just 1) galleyClients1
 
@@ -300,10 +301,10 @@ testAddMultipleTemporary brig galley = do
                 { newClientClass = Just PhoneClient
                 , newClientModel = Just "featurephone2"
                 }
-    _ <- addClient brig u clt2
+    _ <- addClient brig uid clt2
 
-    brigClients2   <- numOfBrigClients (userId u)
-    galleyClients2 <- numOfGalleyClients (userId u)
+    brigClients2   <- numOfBrigClients uid
+    galleyClients2 <- numOfGalleyClients uid
     liftIO $ assertEqual "Too many clients found" (Just 1) brigClients2
     liftIO $ assertEqual "Too many clients found" (Just 1) galleyClients2
   where
@@ -321,15 +322,15 @@ testAddMultipleTemporary brig galley = do
 
 testPreKeyRace :: Brig -> Http ()
 testPreKeyRace brig = do
-    u <- randomUser brig
+    uid <- userId <$> randomUser brig
     let pks = map (\i -> somePrekeys !! i) [1..10]
-    Just c <- decodeBody <$> addClient brig u (defNewClient PermanentClient pks (someLastPrekeys !! 0))
+    c <- decodeBody =<< addClient brig uid (defNewClient PermanentClient pks (someLastPrekeys !! 0))
     pks' <- flip mapConcurrently pks $ \_ -> do
-        rs <- getPreKey brig (userId u) (clientId c) <!! const 200 === statusCode
+        rs <- getPreKey brig uid (clientId c) <!! const 200 === statusCode
         return $ prekeyId . prekeyData <$> decodeBody rs
     -- We should not hand out regular prekeys more than once (i.e. at most once).
     let actual = catMaybes pks'
     liftIO $ assertEqual "insufficient prekeys" (length pks) (length actual)
     let regular = filter (/= lastPrekeyId) actual
     liftIO $ assertEqual "duplicate prekeys" (length regular) (length (nub regular))
-    deleteClient brig (userId u) (clientId c) (Just defPassword) !!! const 200 === statusCode
+    deleteClient brig uid (clientId c) (Just defPassword) !!! const 200 === statusCode

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -226,7 +226,7 @@ uploadAsset c usr dat = do
                 . content "multipart/mixed"
                 . lbytes (toLazyByteString mpb)
                 ) <!! const 201 === statusCode
-    return $ fromMaybe (error "Failed to decode asset body") (decodeBody rsp)
+    decodeBody rsp
 
 downloadAsset :: CargoHold -> UserId -> ByteString -> Http (Response (Maybe LB.ByteString))
 downloadAsset c usr ast =

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -216,7 +216,7 @@ getTeamMembers (zusr::: tid ::: _) = do
             pure (json $ teamMemberListJson withPerm (newTeamMemberList mems))
 
 getTeamMember :: UserId ::: TeamId ::: UserId ::: JSON -> Galley Response
-getTeamMember (zusr::: tid ::: uid ::: _) = do
+getTeamMember (zusr ::: tid ::: uid ::: _) = do
     mems <- Data.teamMembers tid
     case findTeamMember zusr mems of
         Nothing -> throwM noTeamMember
@@ -236,7 +236,7 @@ uncheckedGetTeamMembers (tid ::: _) = do
     return . json $ teamMemberListJson True (newTeamMemberList mems)
 
 addTeamMember :: UserId ::: ConnId ::: TeamId ::: Request ::: JSON ::: JSON -> Galley Response
-addTeamMember (zusr::: zcon ::: tid ::: req ::: _) = do
+addTeamMember (zusr ::: zcon ::: tid ::: req ::: _) = do
     nmem <- fromBody req invalidPayload
     mems <- Data.teamMembers tid
 
@@ -261,7 +261,7 @@ uncheckedAddTeamMember (tid ::: req ::: _) = do
 
 updateTeamMember :: UserId ::: ConnId ::: TeamId ::: Request ::: JSON ::: JSON
                  -> Galley Response
-updateTeamMember (zusr::: zcon ::: tid ::: req ::: _) = do
+updateTeamMember (zusr ::: zcon ::: tid ::: req ::: _) = do
     -- the team member to be updated
     targetMember <- view ntmNewTeamMember <$> fromBody req invalidPayload
     let targetId          = targetMember^.userId

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -242,6 +242,7 @@ deleteTeam tid = do
     cc <- teamConversations tid
     for_ cc $ removeTeamConv tid . view conversationId
     retry x5 $ write Cql.deleteTeam (params Quorum (Deleted, tid))
+    -- TODO: delete service_whitelist records that mention this team
 
 addTeamMember :: MonadClient m => TeamId -> TeamMember -> m ()
 addTeamMember t m =

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -112,7 +112,7 @@ canBeDeleted members uid tid = if askGalley then pure True else askBrig
   where
     -- team members without full permissions can always be deleted.
     askGalley = case filter ((== uid) . (^. userId)) members of
-        (mem:_) -> mem ^. permissions /= fullPermissions
+        (mem:_) -> not (isTeamOwner mem)
         _ -> False  -- e.g., if caller has no members and passes an empty list.
 
     -- only if still in doubt, ask brig.


### PR DESCRIPTION
### Code

* [x] Add a `service_whitelist` table.
* [x] Update the `service_whitelist` table when a service is disabled.
* [x] Using `service_whitelist` in `/teams/:tid/search/whitelisted`.
* [x] An endpoint for whitelisting/unwhitelisting a service.
* [x] A disabled service can be whitelisted/unwhitelisted by team admins or higher.
* [x] Disabled services don't show up in `.../search/whitelisted` unless you pass `?filter_disabled=false`.
* [x] Throw an error when a client tries to add a non-whitelisted service to the conversation.
* ~Send out events when service whitelist status changes~
  * ~through the endpoint~
  * ~because of being deleted~ won't get done in this PR

### Questions

* [x] Figure out if the event has to be returned from the brig endpoint or not.
* [x] Figure out if I should filter out `uid` from `owners` when pushing the event, or not. Currently the initiator does an event, but I don't know how the tests work and whether it's wrong behavior.
* [x] `WS.assertNoEvent (2 # Second) [wsMember]` – is 2s too much of a timeout? or not enough?
* [x] Unrelated, but: we have code that touches the `user_push` table, which doesn't exist anymore, and I don't know why we do this.

### Tests

* [x] Whitelisting/unwhitelisting a service.
* [x] Whitelisted services search:
  * [x] Works for users on the team, doesn't work for users off the team.
  * [x] Search works without a prefix.
  * [x] Enabling/disabling is honored re/ `filter_disabled=false`.
  * [x] Whitelisting/unwhitelisting is honored.
  * [x] Prefix search (steal from that other test).
  * [x] `searchAndAssertNameChange`.
  * [x] Search by exact name.
  * [x] Search for a fresh team produces no results by default.
* [x] A disabled service can be whitelisted/unwhitelisted.
* [x] A non-whitelisted service can't be added to the conversation.
* [x] Team admins can whitelist a service.
* ~Events are sent out when whitelist status changes:~
  * ~through the endpoint~
  * ~because of being deleted~ won't get done in this PR
* ~No events when the status doesn't change (code 204).~


### Future work

~**Lowercase `service_prefix` in production.** (or else search will break)~ done.

~Create a new permission for service handling. Or something.~ the permission system is broken anyway.

Cleanup whitelists when a team is deleted.

When a service is de-whitelisted, we want to:
* Kick the service out of all team conversations it's in.

When a service is deleted, we want to:
* Send events about de-whitelisting (tricky because event originates from a provider in this case and not from a user).
* ~Kick the service out of all conversations it's in, across all teams.~ This already happens in a lazy way (look for `deliver`).