### PR TITLE
Add minimal smtp/postfix docker image to the demo

### DIFF
--- a/deploy/docker-ephemeral/docker-compose.yaml
+++ b/deploy/docker-ephemeral/docker-compose.yaml
@@ -3,18 +3,18 @@ services:
   fake_dynamodb:
     image: cnadiminti/dynamodb-local:2018-04-11
     ports:
-      - 4567:8000
+      - 127.0.0.1:4567:8000
 
   fake_sqs:
     image: airdock/fake-sqs:0.3.1
     ports:
-      - 4568:4568
+      - 127.0.0.1:4568:4568
 
   fake_localstack:
     image: localstack/localstack:0.8.0  # NB: this is younger than 0.8.6!
     ports:
-      - 4569:4579 # ses # needed for local integration tests
-      - 4575:4575 # sns
+      - 127.0.0.1:4569:4579 # ses # needed for local integration tests
+      - 127.0.0.1:4575:4575 # sns
     environment:
       - DEBUG=1
       - DEFAULT_REGION=eu-west-1
@@ -28,7 +28,7 @@ services:
         # smtp connection handling needs to be made more generic to accept
         # alternative ports. See changes introduced in
         # https://github.com/wireapp/wire-server/pull/405
-      - "25:25"
+      - "127.0.0.1:25:25"
     environment:
       - maildomain=mail.wiredemo.example.com
       - smtp_user=dummy:dummy-smtp-password
@@ -36,7 +36,7 @@ services:
   fake_s3:
     image: minio/minio:RELEASE.2018-05-25T19-49-13Z
     ports:
-     - "4570:9000"
+     - "127.0.0.1:4570:9000"
     environment:
       MINIO_ACCESS_KEY: dummykey
       MINIO_SECRET_KEY: dummysecret # minio requires a secret of at least 8 chars
@@ -50,20 +50,20 @@ services:
   redis:
     image: redis:3.0.7-alpine
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
 
   elasticsearch:
     image: elasticsearch:5.6
     # https://hub.docker.com/_/elastic is deprecated, but 6.2.4 did not work without further changes.
     # image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - "127.0.0.1:9200:9200"
+      - "127.0.0.1:9300:9300"
 
   cassandra:
     image: cassandra:3.11.2
     ports:
-      - "9042:9042"
+      - "127.0.0.1:9042:9042"
 
   db_migrations:
     image: quay.io/wire/migrations

--- a/deploy/docker-ephemeral/docker-compose.yaml
+++ b/deploy/docker-ephemeral/docker-compose.yaml
@@ -13,12 +13,25 @@ services:
   fake_localstack:
     image: localstack/localstack:0.8.0  # NB: this is younger than 0.8.6!
     ports:
-      - 4569:4579 # ses
+      - 4569:4579 # ses # needed for local integration tests
       - 4575:4575 # sns
     environment:
       - DEBUG=1
       - DEFAULT_REGION=eu-west-1
       - SERVICES=ses,sns
+
+  basic_smtp: # needed for demo setup
+    # https://github.com/catatnight/docker-postfix
+    image: catatnight/postfix
+    ports:
+        # if binding to port 25 is a problem,
+        # smtp connection handling needs to be made more generic to accept
+        # alternative ports. See changes introduced in
+        # https://github.com/wireapp/wire-server/pull/405
+      - "25:25"
+    environment:
+      - maildomain=mail.wiredemo.example.com
+      - smtp_user=dummy:dummy-smtp-password
 
   fake_s3:
     image: minio/minio:RELEASE.2018-05-25T19-49-13Z

--- a/deploy/services-demo/README.md
+++ b/deploy/services-demo/README.md
@@ -68,13 +68,8 @@ In order to view the API, you need to create a regular user. For that purpose, y
 
 ### This is fantastic, all services up & running... what now, can I run some kind of smoketests?
 
-Short answer: yes and no. At the moment, you need _one_ AWS service in order to test your cluster with our automated smoketester tool. The `sesEndpoint` in `brig`'s [example configuration](https://github.com/wireapp/wire-server/blob/develop/services/brig/brig.integration.yaml) needs to point to a real AWS SES endpoint.
-
-In your environment, you can configure `AWS_REGION`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for your correct AWS account. Note that there are other ways to specify these credentials (to be detailed later).
-
-Then, have a look at what the configuration for the [api-smoketest](../../tools/api-simulations/README.md) should be. Once you have the correct `mailboxes.json`, this should just work from the top level directory (note the `sender-email` must match brig's [sender-email](https://github.com/wireapp/wire-server/blob/develop/services/brig/brig.integration.yaml#L35))
+Yes. You need to specify an email server that the smoketests can log in to for it to read and act upon registration/activation emails. Have a look at what the configuration for the [api-smoketest](../../tools/api-simulations/README.md) should be. Once you have the correct `mailboxes.json`, this should just work from the top level directory (note the `sender-email` must match brig's [sender-email](https://github.com/wireapp/wire-server/blob/develop/services/brig/brig.integration.yaml#L35))
 
 ```
-# This assumes, for now, that brig is configured to use a real AWS SES endpoint
-../../dist/api-smoketest --api-host=127.0.0.1 --api-port=8080 --api-websocket-host=127.0.0.1 --api-websocket-port=8081 --mailbox-config=<path_to_mailboxes_file> --sender-email=backend-integration@wire.com --enable-asserts
+../../dist/api-smoketest --api-host=127.0.0.1 --api-port=8080 --api-websocket-host=127.0.0.1 --api-websocket-port=8081 --mailbox-config=<path_to_mailboxes_file> --sender-email=backend-demo@mail.wiredemo.example.com --enable-asserts
 ```

--- a/deploy/services-demo/README.md
+++ b/deploy/services-demo/README.md
@@ -75,5 +75,15 @@ Note: This demo setup comes bundled with a postfix email sending docker image; h
 Example:
 
 ```
-../../dist/api-smoketest --api-host=127.0.0.1 --api-port=8080 --api-websocket-host=127.0.0.1 --api-websocket-port=8081 --mailbox-config=<path_to_mailboxes_file> --sender-email=backend-demo@mail.wiredemo.example.com --mailbox-folder INBOX --mailbox-folder '[Gmail]/Spam' --enable-asserts
+# from the wire-server directory, after having compiled everything with 'make install'
+./dist/api-smoketest \
+    --api-host=127.0.0.1 \
+    --api-port=8080 \
+    --api-websocket-host=127.0.0.1 \
+    --api-websocket-port=8081 \
+    --mailbox-config=<path_to_mailboxes_file> \
+    --sender-email=backend-demo@mail.wiredemo.example.com \
+    --mailbox-folder INBOX \
+    --mailbox-folder '[Gmail]/Spam' \
+    --enable-asserts
 ```

--- a/deploy/services-demo/README.md
+++ b/deploy/services-demo/README.md
@@ -68,8 +68,12 @@ In order to view the API, you need to create a regular user. For that purpose, y
 
 ### This is fantastic, all services up & running... what now, can I run some kind of smoketests?
 
-Yes. You need to specify an email server that the smoketests can log in to for it to read and act upon registration/activation emails. Have a look at what the configuration for the [api-smoketest](../../tools/api-simulations/README.md) should be. Once you have the correct `mailboxes.json`, this should just work from the top level directory (note the `sender-email` must match brig's [sender-email](https://github.com/wireapp/wire-server/blob/develop/services/brig/brig.integration.yaml#L35))
+Yes. You need to specify an email address that the smoketests can log in to via IMAP for it to read and act upon registration/activation emails. Have a look at what the configuration for the [api-smoketest](../../tools/api-simulations/README.md) should be. Once you have the correct `mailboxes.json`, this should just work from the top level directory (note the `sender-email` must match brig's [sender-email](https://github.com/wireapp/wire-server/blob/develop/services/brig/brig.integration.yaml#L35))
+
+Note: This demo setup comes bundled with a postfix email sending docker image; however due to the minimal setup, emails will likely land in the Spam/Junk folder of the target email address, if you configure a common email provider. To get the smoketester to check the Spam folder as well, use e.g. (in the case of gmail) `--mailbox-folder INBOX --mailbox-folder '[Gmail]/Spam'`.
+
+Example:
 
 ```
-../../dist/api-smoketest --api-host=127.0.0.1 --api-port=8080 --api-websocket-host=127.0.0.1 --api-websocket-port=8081 --mailbox-config=<path_to_mailboxes_file> --sender-email=backend-demo@mail.wiredemo.example.com --enable-asserts
+../../dist/api-smoketest --api-host=127.0.0.1 --api-port=8080 --api-websocket-host=127.0.0.1 --api-websocket-port=8081 --mailbox-config=<path_to_mailboxes_file> --sender-email=backend-demo@mail.wiredemo.example.com --mailbox-folder INBOX --mailbox-folder '[Gmail]/Spam' --enable-asserts
 ```

--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -35,11 +35,13 @@ internalEvents:
 
 emailSMS:
   email:
-    sesQueue: integration-brig-events
-    sesEndpoint: http://localhost:4569 # https://email.eu-west-1.amazonaws.com
+    smtpEndpoint: 127.0.0.1
+    smtpUsername: dummy
+    smtpPassword: resources/smtp-secret.txt
+    smtpConnType: plain
   general:
     templateDir: resources/templates
-    emailSender: backend-integration@wire.com
+    emailSender: backend-demo@mail.wiredemo.example.com
     smsSender: "<insert-sender-number-here>"
 
   user:

--- a/deploy/services-demo/resources/smtp-secret.txt
+++ b/deploy/services-demo/resources/smtp-secret.txt
@@ -1,0 +1,1 @@
+dummy-smtp-password

--- a/libs/api-bot/src/Network/Wire/Bot/Monad.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Monad.hs
@@ -129,16 +129,17 @@ import qualified System.Random.MWC        as MWC
 -- * BotNetEnv
 
 data BotNetEnv = BotNetEnv
-    { botNetGen       :: MWC.GenIO
-    , botNetMailboxes :: [Mailbox]
-    , botNetSender    :: Email
-    , botNetUsers     :: Cache
-    , botNetServer    :: Server
-    , botNetLogger    :: Logger
-    , botNetAssert    :: !Bool
-    , botNetSettings  :: BotSettings
-    , botNetMetrics   :: Metrics
-    , botNetReportDir :: Maybe FilePath
+    { botNetGen            :: MWC.GenIO
+    , botNetMailboxes      :: [Mailbox]
+    , botNetSender         :: Email
+    , botNetUsers          :: Cache
+    , botNetServer         :: Server
+    , botNetLogger         :: Logger
+    , botNetAssert         :: !Bool
+    , botNetSettings       :: BotSettings
+    , botNetMetrics        :: Metrics
+    , botNetReportDir      :: Maybe FilePath
+    , botNetMailboxFolders :: [String]
     }
 
 newBotNetEnv :: Manager -> Logger -> BotNetSettings -> IO BotNetEnv
@@ -156,16 +157,17 @@ newBotNetEnv manager logger o = do
             , serverManager = manager
             }
     return $! BotNetEnv
-        { botNetGen       = gen
-        , botNetMailboxes = mbx
-        , botNetSender    = setBotNetSender o
-        , botNetUsers     = usr
-        , botNetServer    = srv
-        , botNetLogger    = logger
-        , botNetAssert    = setBotNetAssert o
-        , botNetSettings  = setBotNetBotSettings o
-        , botNetMetrics   = met
-        , botNetReportDir = setBotNetReportDir o
+        { botNetGen            = gen
+        , botNetMailboxes      = mbx
+        , botNetSender         = setBotNetSender o
+        , botNetUsers          = usr
+        , botNetServer         = srv
+        , botNetLogger         = logger
+        , botNetAssert         = setBotNetAssert o
+        , botNetSettings       = setBotNetBotSettings o
+        , botNetMetrics        = met
+        , botNetReportDir      = setBotNetReportDir o
+        , botNetMailboxFolders = setBotNetMailboxFolders o
         }
 
 -- Note: Initializing metrics to avoid race conditions on first access and thus
@@ -400,7 +402,8 @@ newBot tag = liftBotNet $ do
     user <- registerUser new
     log Info $ botLogFields (userId user) tag . msg (val "Await activation mail")
     sndr <- BotNet $ asks botNetSender
-    keys <- liftIO $ awaitActivationMail mbox sndr email
+    folders <- BotNet $ asks botNetMailboxFolders
+    keys <- liftIO $ awaitActivationMail mbox folders sndr email
     log Info $ botLogFields (userId user) tag . msg (val "Activate user")
     forM_ keys (uncurry activateKey >=> flip assertTrue "Activation failed.")
     bot <- mkBot tag user pw

--- a/libs/api-bot/src/Network/Wire/Bot/Settings.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Settings.hs
@@ -30,17 +30,18 @@ import qualified Data.Text as Text
 -- BotNetSettings
 
 data BotNetSettings = BotNetSettings
-    { setBotNetApiHost       :: !ByteString
-    , setBotNetApiPort       :: !Word16
-    , setBotNetApiWsHost     :: !(Maybe ByteString)
-    , setBotNetApiWsPort     :: !(Maybe Word16)
-    , setBotNetApiSSL        :: !Bool
-    , setBotNetAssert        :: !Bool
-    , setBotNetMailboxConfig :: !(Maybe FilePath)
-    , setBotNetSender        :: !Email
-    , setBotNetUsersFile     :: !(Maybe FilePath)
-    , setBotNetReportDir     :: !(Maybe FilePath)
-    , setBotNetBotSettings   :: !BotSettings
+    { setBotNetApiHost        :: !ByteString
+    , setBotNetApiPort        :: !Word16
+    , setBotNetApiWsHost      :: !(Maybe ByteString)
+    , setBotNetApiWsPort      :: !(Maybe Word16)
+    , setBotNetApiSSL         :: !Bool
+    , setBotNetAssert         :: !Bool
+    , setBotNetMailboxConfig  :: !(Maybe FilePath)
+    , setBotNetSender         :: !Email
+    , setBotNetUsersFile      :: !(Maybe FilePath)
+    , setBotNetReportDir      :: !(Maybe FilePath)
+    , setBotNetBotSettings    :: !BotSettings
+    , setBotNetMailboxFolders :: ![String]
     } deriving (Eq, Show)
 
 botNetSettingsParser :: Parser BotNetSettings
@@ -56,6 +57,7 @@ botNetSettingsParser = BotNetSettings
     <*> usersFileOption
     <*> reportDirOption
     <*> botSettingsParser
+    <*> mailboxFoldersOption
 
 apiHostOption :: Parser ByteString
 apiHostOption = bsOption $
@@ -116,6 +118,14 @@ reportDirOption = optional . strOption $
     long "report-dir"
     <> metavar "DIR"
     <> help "Output directory for reports"
+
+mailboxFoldersOption :: Parser [String]
+mailboxFoldersOption = (some . strOption $
+    long "mailbox-folder"
+    <> help "In which mailbox folder to search for emails. \
+    \ Defaults to 'INBOX' if not specified. \
+    \ Can be specified multiple times for multiple folders."
+    ) <|> pure ["INBOX"]
 
 -------------------------------------------------------------------------------
 -- BotSettings


### PR DESCRIPTION
Allows sending real emails when e.g signing up via POST
localhost:8080/register

Note that these emails will most likely land in your spam folder.

WIP note: email sending works, but smoketests don't actually work (when the mailbot is configured to use gmail), since emails land in the spam folder, where the mailbot doesn't find them. Three options:

1. Make the smoketester also look in the spam folder
2. Invest time into using a mail server docker image from which emails are not labelled as spam (might be hard)
3. configure smoketester's mailbox.json to use an account without spam detection (e.g. another docker image running a mail server)

Thoughts?