### PR TITLE
Bump saml2-web-sso, hsaml2 deps.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -66,11 +66,11 @@ packages:
 # services/spar:
 - location:
     git: https://github.com/wireapp/saml2-web-sso
-    commit: 80d6728ef29a2bba3a322f339e1644c80ba744d4
+    commit: 4d6e1af27c81fbaea97e4bcc5c2959c6935d77ec
   extra-dep: true
 - location:
     git: https://github.com/wireapp/hsaml2
-    commit: 8a91c880740232dbd52ff73efb99ea179c2338c7
+    commit: aa6fd1365a62d5e937033f28f548cc53379a0227
   extra-dep: true
 - location:
     git: https://github.com/wireapp/hspec-wai

--- a/stack.yaml
+++ b/stack.yaml
@@ -66,7 +66,7 @@ packages:
 # services/spar:
 - location:
     git: https://github.com/wireapp/saml2-web-sso
-    commit: 4d6e1af27c81fbaea97e4bcc5c2959c6935d77ec
+    commit: 2d3ce018677256f6c9be856a46265846a762b472
   extra-dep: true
 - location:
     git: https://github.com/wireapp/hsaml2


### PR DESCRIPTION
the hsaml2 commit referenced before was destroyed when i merged a branch.  saml2-web-sso is just in here because i was already at it.

from here on, i will only merge PRs that have depencies pointing to commits that have already landed stable branches.
