### PR TITLE
Build profiling versions of libraries in alpine-builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tags
 TAGS
 .stack-work
 .stack-docker
+.stack-docker-profile
 .metadata
 *.tix
 *.pem

--- a/build/alpine/Dockerfile.builder
+++ b/build/alpine/Dockerfile.builder
@@ -5,18 +5,25 @@ ARG prebuilder=quay.io/wire/alpine-prebuilder
 FROM ${prebuilder}
 WORKDIR /src/wire-server
 
+# Get newer Stack
+
+# later versions don't have static binaries (temporarily)
+ARG STACK_VERSION=1.6.5
+RUN curl -sSfL https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/stack-${STACK_VERSION}-linux-x86_64-static.tar.gz \
+    | tar --wildcards -C /usr/local/bin --strip-components=1 -xzvf - '*/stack' && chmod 755 /usr/local/bin/stack
+
 # Download stack indices and compile/cache dependencies to speed up subsequent
 # container creation.
 #
-# We do a full 'stack build' to get dependencies like 'aws' to build, but then
-# we do a 'stack clean' so that packages in the repo wouldn't get into the final
-# image – that's because Stack sometimes doesn't realize that local packages
-# should be recompiled, and we really don't want that to happen during CI.
+# We also build profiling versions of all libraries. Due to a bug in Stack,
+# they have to be built in a separate directory. See this issue:
+# https://github.com/commercialhaskell/stack/issues/4032
+
 RUN apk add --no-cache git ncurses && \
     mkdir -p /src && cd /src && \
-    git clone https://github.com/wireapp/wire-server.git && \
+    git clone -b develop https://github.com/wireapp/wire-server.git && \
     cd wire-server && \
     stack update && \
-    stack upgrade && \
-    echo -e "allow-different-user: true\nwork-dir: .stack-docker" >> /root/.stack/config.yaml && \
-    stack build --pedantic --haddock --test --dependencies-only --no-run-tests
+    echo -e "allow-different-user: true\n" >> /root/.stack/config.yaml && \
+    stack --work-dir .stack-docker-profile build --pedantic --haddock --test --dependencies-only --no-run-tests --profile && \
+    stack --work-dir .stack-docker         build --pedantic --haddock --test --dependencies-only --no-run-tests


### PR DESCRIPTION
This is the first step towards having automatic stack traces in integration tests. (The second step will be enabling `-xc` when running integration tests, and the third step will be just fixing makefiles/etc so that locally we would get stack traces as well.)

I checked locally and the image builds successfully; I can also upload it to Quay if nobody objects.