### PR TITLE
[demo]: bind haskell services to localhost by default, only expose nginz

### DIFF
--- a/deploy/services-demo/README.md
+++ b/deploy/services-demo/README.md
@@ -39,13 +39,12 @@ resources                            <- folder which contains secrets or other r
 
 * **no optimal performance; not highly-available**: The way that the data stores used are set up is done in a simple way that is not advisable for a production environment (e.g., cassandra uses a single node and Docker will manage the storage of your database data by writing the database files to disk on the host system using its own internal volume management). 
 * **missing functionality**: Some other dependencies (such as the "fake" AWS services) do not provide the full functionality of the real AWS services (for instance, the fake SES doesn't actually send emails) nor do they have the same reliability and availability.
-* :warning: **insecure by default** :warning: : 
-    * **all services are exposed**: If your laptop or server is reachable from the outside, it means not only is `nginz` reachable on port 8080, but other services and databases are also directly reachable from outside on other ports. This allows anyone on the internet to
+* :warning: **insecure by default** :warning: :
+    * **no private network**: Not only is `nginz` reachable on port 8080 from the outside world, but all other services and databases are also reachable from localhost, which, if you run this from e.g. your laptop, allows any other concurrently running process (or exploits thereof) to
         * query any user's information,
         * make use of internal endpoints not requiring additional authorization,
         * impersonate other users by making HTTP requests directly to services (such as brig) using a Z-User: <other user's uuid> header,
         * talk directly to the databases and modifying information there, giving arbitrary control over accounts, conversation membership, allows deleting messages for recipients that are offline, etc.
-    * **no private network**: similar to the previous point, if running the demo on e.g. your laptop, chances are other processes are active (e.g. a browser, etc), extending any vulnerabilities to the vulnerabilities of these other processes. 
     * **no HTTPS by default**: The demo setup exposes nginz on plain http, so if you don't have your own ssl termination server in front or configure nginz with an SSL certificate, that allows all kinds of metadata (who, with which device/browser accessed which endpoint with which content at what time) to be read by all routers and people in the networks in between a user and the server.
     * **inadequate process isolation**: Running different services on the same physical or virtual machine is NOT recommended for security. Example: Even in a modified demo setup (in which only nginz is reachable from outside; and SSL/HTTPS in enforced), a temporary bug in nginz could allow an attacker to gain access to that machine, therefore also to the disk and RAM in use by other services (allowing to steal e.g. the private key used by the brig service to sign access tokens; allowing user impersonation even after the nginx bug is fixed (if keys are not rotated)).
     * **dependence on insecurely-downloaded docker images**

--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -1,5 +1,5 @@
 brig:
-  host: 0.0.0.0
+  host: 127.0.0.1
   port: 8082
 
 cassandra:

--- a/deploy/services-demo/conf/cargohold.demo.yaml
+++ b/deploy/services-demo/conf/cargohold.demo.yaml
@@ -1,5 +1,5 @@
 cargohold:
-  host: 0.0.0.0
+  host: 127.0.0.1
   port: 8084
 
 aws:

--- a/deploy/services-demo/conf/galley.demo.yaml
+++ b/deploy/services-demo/conf/galley.demo.yaml
@@ -9,7 +9,7 @@ cassandra:
   keyspace: galley_test
 
 brig:
-  host: 0.0.0.0
+  host: 127.0.0.1
   port: 8082
 
 gundeck:

--- a/deploy/services-demo/conf/gundeck.demo.yaml
+++ b/deploy/services-demo/conf/gundeck.demo.yaml
@@ -1,5 +1,5 @@
 gundeck:
-  host: 0.0.0.0
+  host: 127.0.0.1
   port: 8086
 
 cassandra:

--- a/deploy/services-demo/conf/proxy.demo.yaml
+++ b/deploy/services-demo/conf/proxy.demo.yaml
@@ -1,4 +1,4 @@
-host: 0.0.0.0
+host: 127.0.0.1
 port: 8087
 
 httpPoolSize: 1000

--- a/deploy/services-demo/conf/spar.demo.yaml
+++ b/deploy/services-demo/conf/spar.demo.yaml
@@ -2,7 +2,7 @@ saml:
   version:   SAML2.0
   logLevel:  Debug
 
-  spHost:    0.0.0.0
+  spHost:    127.0.0.1
   spPort:    8088
   spAppUri:  http://localhost:8080/ # <--- change this to point to a reachable web app
   spSsoUri:  http://localhost:8080/
@@ -32,4 +32,3 @@ logNetStrings: False # log using netstrings encoding (see http://cr.yp.to/proto/
 spInfo:
   metaURI:  http://localhost:8088/sso/metadata
   loginURI: http://localhost:8088/sso/initiate-login/
-


### PR DESCRIPTION
For the demo setup: Along with ce342b4fd5ab2aebb305d20dfd37ed598eaf6999 (which also restricts docker images to localhost), restrict all services other than nginz to bind to localhost only.