### PR TITLE
Work on integration tests

### DIFF
--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -188,7 +188,6 @@ testCreateOne2OneWithMembers g b c a = do
         Util.addTeamMemberInternal g tid mem1
         checkTeamMemberJoin tid (mem1^.userId) wsMem1
         assertQueue "team member join" a $ tUpdate 2 [owner]
-        WS.assertNoEvent timeout [wsMem1]
 
     void $ retryWhileN 10 repeatIf (Util.createOne2OneTeamConv g owner (mem1^.userId) Nothing tid)
 
@@ -763,7 +762,7 @@ checkUserDeleteEvent uid w = WS.assertMatch_ timeout w $ \notif -> do
     euser @?= Just (UUID.toText (toUUID uid))
 
 checkTeamMemberJoin :: HasCallStack => TeamId -> UserId -> WS.WebSocket -> Http ()
-checkTeamMemberJoin tid uid w = WS.assertMatch_ timeout w $ \notif -> do
+checkTeamMemberJoin tid uid w = WS.awaitMatch_ timeout w $ \notif -> do
     ntfTransient notif @?= False
     let e = List1.head (WS.unpackPayload notif)
     e^.eventType @?= MemberJoin

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -10,7 +10,7 @@ import Control.Error
 import Control.Lens hiding ((.=), from, to, (#))
 import Control.Monad hiding (mapM_)
 import Control.Monad.IO.Class
-import Control.Retry
+import Control.Retry (retrying, constantDelay, limitRetries)
 import Data.Aeson hiding (json)
 import Data.Aeson.Lens (key)
 import Data.ByteString.Char8 (pack, ByteString, intercalate)

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -704,9 +704,9 @@ testUnregisterPushToken g _ b _ = do
     clt <- randomClient g uid
     tkn <- randomToken clt gcmToken
     void $ registerPushToken uid tkn g
-    void $ retryWhileN 12 (not . null) (listPushTokens uid g)
-    unregisterPushToken uid (tkn^.token) g !!! const 204 === statusCode
     void $ retryWhileN 12 null (listPushTokens uid g)
+    unregisterPushToken uid (tkn^.token) g !!! const 204 === statusCode
+    void $ retryWhileN 12 (not . null) (listPushTokens uid g)
     unregisterPushToken uid (tkn^.token) g !!! const 404 === statusCode
 
 testSharePushToken :: TestSignature ()

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -657,6 +657,7 @@ testRegisterPushToken g _ b _ = do
     _ <- registerPushToken uid t22 g
 
     -- Check tokens
+    void $ retryWhileN 12 ((/= 5) . length) (listPushTokens uid g)
     _tokens <- sortPushTokens <$> listPushTokens uid g
     let _expected = sortPushTokens [t11, t12, t13, t21, t22]
     liftIO $ assertEqual "unexpected tokens" _expected _tokens
@@ -667,6 +668,7 @@ testRegisterPushToken g _ b _ = do
     _ <- registerPushToken uid t22' g
 
     -- Check tokens
+    void $ retryWhileN 12 ((/= 5) . length) (listPushTokens uid g)
     _tokens <- sortPushTokens <$> listPushTokens uid g
     let _expected = sortPushTokens [t11', t12, t13, t21, t22']
     liftIO $ assertEqual "unexpected tokens" _expected _tokens
@@ -676,6 +678,7 @@ testRegisterPushToken g _ b _ = do
     unregisterClient g uid c1 !!! const 404 === statusCode
     unregisterClient g uid c2 !!! const 200 === statusCode
     unregisterClient g uid c2 !!! const 404 === statusCode
+    void $ retryWhileN 12 (not . null) (listPushTokens uid g)
     _tokens <- listPushTokens uid g
     liftIO $ assertEqual "unexpected tokens" [] _tokens
 

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -657,7 +657,6 @@ testRegisterPushToken g _ b _ = do
     _ <- registerPushToken uid t22 g
 
     -- Check tokens
-    void $ retryWhileN 12 ((/= 5) . length) (listPushTokens uid g)
     _tokens <- sortPushTokens <$> listPushTokens uid g
     let _expected = sortPushTokens [t11, t12, t13, t21, t22]
     liftIO $ assertEqual "unexpected tokens" _expected _tokens
@@ -668,7 +667,6 @@ testRegisterPushToken g _ b _ = do
     _ <- registerPushToken uid t22' g
 
     -- Check tokens
-    void $ retryWhileN 12 ((/= 5) . length) (listPushTokens uid g)
     _tokens <- sortPushTokens <$> listPushTokens uid g
     let _expected = sortPushTokens [t11', t12, t13, t21, t22']
     liftIO $ assertEqual "unexpected tokens" _expected _tokens
@@ -678,7 +676,6 @@ testRegisterPushToken g _ b _ = do
     unregisterClient g uid c1 !!! const 404 === statusCode
     unregisterClient g uid c2 !!! const 200 === statusCode
     unregisterClient g uid c2 !!! const 404 === statusCode
-    void $ retryWhileN 12 (not . null) (listPushTokens uid g)
     _tokens <- listPushTokens uid g
     liftIO $ assertEqual "unexpected tokens" [] _tokens
 

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -18,8 +18,8 @@ import Control.Concurrent.STM.TChan
 import Control.Lens                   ((&), (.~), (^.), (^?), view)
 import Control.Monad.IO.Class         (MonadIO)
 import Control.Monad.Reader
-import Control.Monad.STM       hiding (retry)
-import Control.Retry
+import Control.Monad.STM
+import Control.Retry (retrying, constantDelay, limitRetries)
 import Data.Aeson              hiding (json)
 import Data.Aeson.Lens
 import Data.ByteString.Char8          (ByteString)
@@ -701,7 +701,9 @@ testUnregisterPushToken g _ b _ = do
     clt <- randomClient g uid
     tkn <- randomToken clt gcmToken
     void $ registerPushToken uid tkn g
+    void $ retryWhileN 12 (not . null) (listPushTokens uid g)
     unregisterPushToken uid (tkn^.token) g !!! const 204 === statusCode
+    void $ retryWhileN 12 null (listPushTokens uid g)
     unregisterPushToken uid (tkn^.token) g !!! const 404 === statusCode
 
 testSharePushToken :: TestSignature ()

--- a/services/integration.yaml
+++ b/services/integration.yaml
@@ -37,9 +37,9 @@ provider:
 
 # Used by spar-integration
 newIdp:
-  metadata: http://localhost:9001/meta
-  issuer: http://localhost:9001/
-  requestUri: http://localhost:9001/resp
+  metadata: https://localhost:9001/meta
+  issuer: https://localhost:9001/
+  requestUri: https://localhost:9001/resp
   publicKey: '<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIB/zCCASigAwIBAgIOEyBZjWrTHqmgBPAVkAUwDQYJKoZIhvcNAQELBQAwADAeFw0xODA4MTYxMjQzNTdaFw0zODA4MTExMjQzNTdaMAAwgd0wDQYJKoZIhvcNAQEBBQADgcsAMIHHAoHBAMHb4Ne1z2cQD1TXcVmYBy0Q1EnmQl5IncCfC6/eGrp0qpa5sqaQPlRtvS3UEczpAgf9ml+kL6aK56xEBH2Zv/mlkvBEbxASxVha3LhcIg9TNAg0vm2KJBG1pZvHx8OIKhpDCfabkSJF+MxXvtTrp0JTRfQr2BHkegZNX3hCaF5JGyGIMBinTRwEi5duDfNUsJoG5MwNq/hrd7pLdjOWgs4CLlNV6L+3rvhhYt+e0QUeh9QrZFUfhXxezlfYfP36WQIBETANBgkqhkiG9w0BAQsFAAOBwQBtZqvROSfV1znZws9h6M749g1HRpm3vub3RKAZOWfqP2Qag2ML+BjAqEIH1SAaQSZlFbKRsKM2Bp/QpG5ByshwrxoS9ausPNynulMA7dEPvWOExfqYO9Vj/0ejxwAmilseKrVfv333yvcgVRNRqP/LMxqe/8Hw3Ax+Ul83usIZLQ5m4sW9/IUVwlDLk31ddIkPVpx2USKL9eVDXjVhIl7itgJxPyG0wc0I9Ad/ZWy/Dbbilwz1tHcZSZsxSdNFW+k=</ds:X509Certificate></ds:X509Data></ds:KeyInfo>'
 
 # Used by spar-integration
@@ -53,3 +53,6 @@ mockIdp:
   connect:  # where should integration tests send their requests?
     host: 127.0.0.1
     port: 9001
+  privateKey: test-integration/resources/key.pem
+  publicKey: test-integration/resources/pubkey.pem
+  cert: test-integration/resources/cert.pem

--- a/services/integration.yaml
+++ b/services/integration.yaml
@@ -47,5 +47,9 @@ newIdp:
 # case in production, but according to the standard it is technically
 # legal.
 mockIdp:
-  host: 127.0.0.1
-  port: 9001
+  bind:  # what should the mock idp bind to?  (usually 0.0.0.0 or 127.0.0.1)
+    host: 127.0.0.1
+    port: 9001
+  connect:  # where should integration tests send their requests?
+    host: 127.0.0.1
+    port: 9001

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -106,6 +106,7 @@ executables:
       - hspec-discover
       - lens-aeson
       - random
+      - retry
       - servant-client
       - spar
       - stm

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -23,6 +23,7 @@ dependencies:
   - bytestring-conversion
   - case-insensitive
   - cassandra-util
+  - connection
   - containers
   - cookie
   - cryptonite

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -111,6 +111,7 @@ executables:
       - spar
       - stm
       - wai
+      - warp-tls
       - xml-conduit
       - xml-hamlet
       - xml-lens

--- a/services/spar/spar.integration.yaml
+++ b/services/spar/spar.integration.yaml
@@ -35,3 +35,5 @@ maxttlAuthreq: 5  # seconds.  don't set this too large, it is also the run time 
 maxttlAuthresp: 7200  # seconds.  do not set this to 1h or less, as that is what the mock idp wants.
 
 logNetStrings: False # log using netstrings encoding (see http://cr.yp.to/proto/netstrings.txt)
+
+tlsDisableCertValidation: True  # only for testing!  in production, this must be set to 'False'!

--- a/services/spar/src/Spar/Options.hs
+++ b/services/spar/src/Spar/Options.hs
@@ -38,6 +38,7 @@ data Opts = Opts
     , maxttlAuthresp :: !(TTL "authresp")
     , discoUrl       :: !(Maybe Text) -- Wire/AWS specific; optional; used to discover cassandra instance IPs using describe-instances
     , logNetStrings  :: !Bool
+    , tlsDisableCertValidation :: !Bool -- always set to 'False' in production!  see 'sparManager'.
     -- , optSettings   :: !Settings  -- (nothing yet; see other services for what belongs in here.)
     }
   deriving (Show, Generic)

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -26,7 +26,6 @@ import Data.String.Conversions
 import Data.String (fromString)
 import Lens.Micro
 import Network.HTTP.Client (responseTimeoutMicro)
-import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.Wai (Application)
 import Network.Wai.Utilities.Request (lookupRequestId)
 import Spar.API
@@ -42,6 +41,8 @@ import Util.Options (epHost, epPort)
 
 import qualified Cassandra.Schema as Cas
 import qualified Cassandra.Settings as Cas
+import qualified Network.Connection as TLS
+import qualified Network.HTTP.Client.TLS as TLS
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Utilities.Server as WU
 import qualified SAML2.WebSSO as SAML
@@ -97,9 +98,7 @@ runServer sparCtxOpts = do
   let settings = Warp.defaultSettings
         & Warp.setHost (fromString $ sparCtxOpts ^. to saml . SAML.cfgSPHost)
         . Warp.setPort (sparCtxOpts ^. to saml . SAML.cfgSPPort)
-  sparCtxHttpManager <- newManager tlsManagerSettings
-      { managerResponseTimeout = responseTimeoutMicro (10 * 1000 * 1000)
-      }
+  sparCtxHttpManager <- sparManager (tlsDisableCertValidation sparCtxOpts)
   let sparCtxHttpBrig = Bilge.host (sparCtxOpts ^. to brig . epHost . to cs)
                       . Bilge.port (sparCtxOpts ^. to brig . epPort)
                       $ Bilge.empty
@@ -113,6 +112,24 @@ runServer sparCtxOpts = do
         $ \sparCtxRequestId -> app Env {..}
   WU.runSettingsWithShutdown settings wrappedApp 5
 
+-- | Create a TLS-capabable manager for fetching metadata from IdPs.
+--
+-- NB: In integration tests, we turn certificate validation off.  This is not ideal, but the
+-- alternative would be to register a mock certificate with the production spar service, which is
+-- not trivial and thus not risk-free either:
+--
+-- * https://stackoverflow.com/questions/25833305/accepting-specific-certificate-with-http-client-tls-or-tls
+-- * https://stackoverflow.com/questions/40081508/how-to-provide-a-client-certificate-to-http-client-tls#40082394
+sparManager :: Bool -> IO Manager
+sparManager disableCertificateValidation = newManager (TLS.mkManagerSettings tlss Nothing)
+  { managerResponseTimeout = responseTimeoutMicro (10 * 1000 * 1000)
+  }
+  where
+    tlss = TLS.TLSSettingsSimple
+      { TLS.settingDisableCertificateValidation = disableCertificateValidation
+      , TLS.settingDisableSession = False
+      , TLS.settingUseServerName = False
+      }
 
 lookupRequestIdMiddleware :: (RequestId -> Application) -> Application
 lookupRequestIdMiddleware mkapp req cont = do

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -55,6 +55,7 @@ module Util
 import Bilge
 import Bilge.Assert ((!!!), (===), (<!!))
 import Cassandra as Cas
+import Control.Concurrent (threadDelay)
 import Control.Exception
 import Control.Monad
 import Control.Monad.Catch
@@ -125,7 +126,9 @@ mkEnv _teTstOpts _teOpts = do
   let srv = Warp.runSettings (endpointToSettings _teIdPEndpoint) app
   _teIdPHandle <- Async.async srv
 
-  (_teUserId, _teTeamId, _teIdP) <- createTestIdPFrom _teNewIdP _teMgr _teBrig _teGalley _teSpar
+  (_teUserId, _teTeamId, _teIdP) <- do
+    threadDelay 3000000
+    createTestIdPFrom _teNewIdP _teMgr _teBrig _teGalley _teSpar
 
   pure TestEnv {..}
 

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -99,7 +99,7 @@ import qualified Control.Concurrent.Async as Async
 import qualified Data.ByteString.Base64.Lazy as EL
 import qualified Data.Text.Ascii as Ascii
 import qualified Galley.Types.Teams as Galley
-import qualified Network.Wai.Handler.Warp as Warp
+import qualified Network.Wai.Handler.WarpTLS as Warp
 import qualified SAML2.WebSSO as SAML
 import qualified Test.Hspec
 import qualified Text.XML as XML
@@ -118,7 +118,11 @@ mkEnv _teTstOpts _teOpts = do
       _teNewIdP  = cfgNewIdp _teTstOpts
 
   (app, _teIdPChan) <- serveSampleIdP _teNewIdP
-  let srv = Warp.runSettings (endpointToSettings . mockidpBind . cfgMockIdp $ _teTstOpts) app
+  let srv     = Warp.runTLS tlss defs app
+      tlss    = Warp.tlsSettings (mockidpCert mocktls) (mockidpPrivateKey mocktls)
+      mocktls = cfgMockIdp _teTstOpts
+      defs    = endpointToSettings . mockidpBind . cfgMockIdp $ _teTstOpts
+
   _teIdPHandle <- Async.async srv
   assertServiceIsUp _teIdPHandle _teMgr (endpointToReq . mockidpConnect . cfgMockIdp $ _teTstOpts)
 

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -21,7 +21,7 @@
 module Util
   ( TestEnv(..)
   , teMgr, teCql, teBrig, teGalley, teSpar
-  , teNewIdP, teIdPEndpoint, teUserId, teTeamId, teIdP, teIdPHandle, teIdPChan
+  , teNewIdP, teUserId, teTeamId, teIdP, teIdPHandle, teIdPChan
   , teOpts, teTstOpts
   , Select, mkEnv, destroyEnv, passes, it, pending, pendingWith
   , IntegrationConfig(..)
@@ -115,21 +115,19 @@ mkEnv _teTstOpts _teOpts = do
   let _teBrig    = endpointToReq (cfgBrig   _teTstOpts)
       _teGalley  = endpointToReq (cfgGalley _teTstOpts)
       _teSpar    = endpointToReq (cfgSpar   _teTstOpts)
-
       _teNewIdP  = cfgNewIdp _teTstOpts
-      _teIdPEndpoint = cfgMockIdp _teTstOpts
 
   (app, _teIdPChan) <- serveSampleIdP _teNewIdP
-  let srv = Warp.runSettings (endpointToSettings _teIdPEndpoint) app
+  let srv = Warp.runSettings (endpointToSettings . mockidpBind . cfgMockIdp $ _teTstOpts) app
   _teIdPHandle <- Async.async srv
-  assertServiceIsUp _teIdPHandle _teMgr (endpointToReq _teIdPEndpoint)
+  assertServiceIsUp _teIdPHandle _teMgr (endpointToReq . mockidpConnect . cfgMockIdp $ _teTstOpts)
 
   (_teUserId, _teTeamId, _teIdP) <- do
     createTestIdPFrom _teNewIdP _teMgr _teBrig _teGalley _teSpar
 
   pure TestEnv {..}
 
-assertServiceIsUp :: Show a => Async.Async a -> Manager -> (Request -> Request) -> IO ()
+assertServiceIsUp :: (HasCallStack, Show a) => Async.Async a -> Manager -> (Request -> Request) -> IO ()
 assertServiceIsUp async mgr req = waitForService mgr req >>= \case
   True  -> pure ()
   False -> Async.poll async >>= \case
@@ -361,7 +359,7 @@ makeTestNewIdP :: (HasCallStack, MonadReader TestEnv m, MonadIO m) => m NewIdP
 makeTestNewIdP = do
   env <- ask
   issuerid <- liftIO $ UUID.nextRandom
-  let Endpoint ephost (cs . show -> epport) = env ^. teTstOpts . to cfgMockIdp
+  let Endpoint ephost (cs . show -> epport) = env ^. teTstOpts . to cfgMockIdp . to mockidpConnect
       mkurl = either (error . show) id . SAML.parseURI' . (("http://" <> ephost <> ":" <> epport) <>)
   pure $ (env ^. teNewIdP) & nidpIssuer .~ Issuer (mkurl $ "/_" <> UUID.toText issuerid)
 

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -55,7 +55,6 @@ module Util
 import Bilge
 import Bilge.Assert ((!!!), (===), (<!!))
 import Cassandra as Cas
-import Control.Concurrent (threadDelay)
 import Control.Exception
 import Control.Monad
 import Control.Monad.Catch

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -134,7 +134,7 @@ mkEnv _teTstOpts _teOpts = do
 
 waitForService :: Manager -> (Request -> Request) -> IO Bool
 waitForService mgr req =
-  retrying (constantDelay 100000 <> limitRetries 50) (\_ b -> pure b) (\_ -> serviceIsUp mgr req)
+  retrying (constantDelay 100000 <> limitRetries 50) (\_ -> pure . not) (\_ -> serviceIsUp mgr req)
 
 serviceIsUp :: Manager -> (Request -> Request) -> IO Bool
 serviceIsUp mgr req = (runHttpT mgr (Bilge.get req) >> pure True)

--- a/services/spar/test-integration/Util/MockIdP.hs
+++ b/services/spar/test-integration/Util/MockIdP.hs
@@ -37,6 +37,7 @@ import URI.ByteString
 import Util.Options
 import Util.Types
 
+import qualified Bilge
 import qualified Control.Concurrent.Async          as Async
 import qualified Data.X509                         as X509
 import qualified Network.Wai.Handler.Warp          as Warp
@@ -91,6 +92,9 @@ sampleIdPMetadata' privKey cert newidp = signElementIO privKey [xml|
 
 
 -- auxiliaries
+
+endpointToReq :: Endpoint -> (Bilge.Request -> Bilge.Request)
+endpointToReq ep = Bilge.host (ep ^. epHost . to cs) . Bilge.port (ep ^. epPort)
 
 endpointToSettings :: Endpoint -> Warp.Settings
 endpointToSettings endpoint = Warp.defaultSettings { Warp.settingsHost = host, Warp.settingsPort = port }

--- a/services/spar/test-integration/Util/Types.hs
+++ b/services/spar/test-integration/Util/Types.hs
@@ -22,7 +22,6 @@ module Util.Types
   , teGalley
   , teSpar
   , teNewIdP
-  , teIdPEndpoint
   , teUserId
   , teTeamId
   , teIdP
@@ -33,6 +32,7 @@ module Util.Types
   , Select
   , ResponseLBS
   , IntegrationConfig(..)
+  , MockIdPConfig(..)
   , TestErrorLabel(..)
   ) where
 
@@ -71,7 +71,6 @@ data TestEnv = TestEnv
   , _teGalley      :: GalleyReq
   , _teSpar        :: SparReq
   , _teNewIdP      :: SAML.NewIdP
-  , _teIdPEndpoint :: Endpoint
   , _teUserId      :: UserId
   , _teTeamId      :: TeamId
   , _teIdP         :: IdP
@@ -90,10 +89,16 @@ data IntegrationConfig = IntegrationConfig
   , cfgGalley  :: Endpoint
   , cfgSpar    :: Endpoint
   , cfgNewIdp  :: SAML.NewIdP
-  , cfgMockIdp :: Endpoint
+  , cfgMockIdp :: MockIdPConfig
+  } deriving (Show, Generic)
+
+data MockIdPConfig = MockIdPConfig
+  { mockidpBind    :: Endpoint
+  , mockidpConnect :: Endpoint
   } deriving (Show, Generic)
 
 deriveFromJSON deriveJSONOptions ''IntegrationConfig
+deriveFromJSON deriveJSONOptions ''MockIdPConfig
 makeLenses ''TestEnv
 
 

--- a/services/spar/test-integration/Util/Types.hs
+++ b/services/spar/test-integration/Util/Types.hs
@@ -93,8 +93,11 @@ data IntegrationConfig = IntegrationConfig
   } deriving (Show, Generic)
 
 data MockIdPConfig = MockIdPConfig
-  { mockidpBind    :: Endpoint
-  , mockidpConnect :: Endpoint
+  { mockidpBind       :: Endpoint
+  , mockidpConnect    :: Endpoint
+  , mockidpPrivateKey :: FilePath
+  , mockidpPublicKey  :: FilePath
+  , mockidpCert       :: FilePath
   } deriving (Show, Generic)
 
 deriveFromJSON deriveJSONOptions ''IntegrationConfig

--- a/services/spar/test-integration/resources/cert.pem
+++ b/services/spar/test-integration/resources/cert.pem
@@ -1,0 +1,1 @@
+../../../brig/test/resources/cert.pem

--- a/services/spar/test-integration/resources/key.pem
+++ b/services/spar/test-integration/resources/key.pem
@@ -1,0 +1,1 @@
+../../../brig/test/resources/key.pem

--- a/services/spar/test-integration/resources/pubkey.pem
+++ b/services/spar/test-integration/resources/pubkey.pem
@@ -1,0 +1,1 @@
+../../../brig/test/resources/pubkey.pem


### PR DESCRIPTION
- make some flaky integration tests less flaky (hopefully...)
- spar integration tests:
    - fix behavior on concourse
    - better error messages
    - assert availability of mock idp
    - make mock idp in spar integration tests serve via SSL