### PR TITLE
Put OpenSSL paths for macOS into the nginz makefile

### DIFF
--- a/services/nginz/Makefile
+++ b/services/nginz/Makefile
@@ -18,9 +18,18 @@ DEST_PATH      ?= /opt/nginz
 LOG_PATH       ?= /var/log/nginz
 CONF_PATH      ?= /etc/nginz
 PID_PATH       ?= /var/run
-# You may need to use this if you have some dependencies in non-standard locations
-EXTRA_CC_INC   ?=
-EXTRA_CC_LIB   ?=
+
+# You may need to use this if you have some dependencies in non-standard
+# locations. For macOS, we use Brew default directories for OpenSSL (if they
+# exist). These variables can be always overridden when running the
+# Makefile, though.
+ifeq ($(wildcard /usr/local/opt/openssl/.),)
+    EXTRA_CC_INC ?=
+    EXTRA_CC_LIB ?=
+else
+    EXTRA_CC_INC ?= -I/usr/local/opt/openssl/include
+    EXTRA_CC_LIB ?= -L/usr/local/opt/openssl/lib
+endif
 
 # Where should we look for packages, locally or globally?
 EXTRA_PKG_PATH := $(shell [ -w /usr/local ] && echo /usr/local || echo "$(HOME)/.wire-dev")/lib/pkgconfig

--- a/services/nginz/README.md
+++ b/services/nginz/README.md
@@ -7,7 +7,7 @@ To build nginz natively, ensure to have the usual C compiler toolchains installe
 * gpg (needed to verify nginx's signatures)
 * openssl
 * libossp-uuid
-* [libzauth](../../libs/libzauth) 
+* [libzauth](../../libs/libzauth)
     * depends on the rust compiler, libsodium, [makedeb](../../tools/makedeb)
 
 If you're on alpine, see the [Dockerfile](Dockerfile) for the precise dependency names. If you're on another platform, their names might differ slightly.
@@ -41,11 +41,7 @@ with nginx by using --with-openssl=<path> option.
 
 openssl is required to compile nginx and it may be installed in a "non-standard" path in your system. Once you are sure you have installed it, look for `EXTRA_CC_INC` and `EXTRA_CC_LIB` in the `Makefile` and point them to the correct location in your system.
 
-For instance, if you are using OSX and used `brew` to install openssl, you most likely need to change the `Makefile` to:
-```
-EXTRA_CC_INC ?= -I/usr/local/opt/openssl/include
-EXTRA_CC_LIB ?= -L/usr/local/opt/openssl/lib
-```
+If you are using macOS and you used `brew` to install openssl, the `Makefile` already contains the right paths so you should not be seeing that error.
 
 ## Compile with docker
 


### PR DESCRIPTION
This should work on Linux as well and it should not harm anything if OpenSSL paths change on macOS in the future. However, I'd like somebody familiar with Makefile syntax to take a closer look.