### PR TITLE
Allow setting specific ports for SMTP and use different image for SMTP

### DIFF
--- a/deploy/docker-ephemeral/docker-compose.yaml
+++ b/deploy/docker-ephemeral/docker-compose.yaml
@@ -21,17 +21,10 @@ services:
       - SERVICES=ses,sns
 
   basic_smtp: # needed for demo setup
-    # https://github.com/catatnight/docker-postfix
-    image: catatnight/postfix
+    # https://github.com/namshi/docker-smtp
+    image: namshi/smtp
     ports:
-        # if binding to port 25 is a problem,
-        # smtp connection handling needs to be made more generic to accept
-        # alternative ports. See changes introduced in
-        # https://github.com/wireapp/wire-server/pull/405
-      - "127.0.0.1:25:25"
-    environment:
-      - maildomain=mail.wiredemo.example.com
-      - smtp_user=dummy:dummy-smtp-password
+        - 127.0.0.1:2500:25
 
   fake_s3:
     image: minio/minio:RELEASE.2018-05-25T19-49-13Z

--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -35,9 +35,9 @@ internalEvents:
 
 emailSMS:
   email:
-    smtpEndpoint: 127.0.0.1
-    smtpUsername: dummy
-    smtpPassword: resources/smtp-secret.txt
+    smtpEndpoint:
+      host: 127.0.0.1
+      port: 2500
     smtpConnType: plain
   general:
     templateDir: resources/templates

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -57,10 +57,13 @@ emailSMS:
     # and set the correct credentials.
     # NOTE: In case a user tries to supply config values for both SES and SMTP,
     #       SES takes precedence and gets used instead
-    # smtpEndpoint: <hostname>
-    # smtpUsername: <username>
-    # smtpPassword: test/resources/smtp-secret.txt
-    # smtpConnType: tls
+    # smtpEndpoint:
+    #   host: localhost
+    #   port: 2500
+    # smtpCredentials:
+    #   username: <username>
+    #   password: test/resources/smtp-secret.txt
+    # smtpConnType: plain
     # ^ NOTE: blacklisting of emails (processing of bounces and complaints)  is only done
     #         automatically IF sesQueue/sesEndpoint are used. If SMTP is used directly, the
     #         operator must handle these notifications "manually" (there are internal endpoints)


### PR DESCRIPTION
This PR introduces 2 changes:

1. Addresses an old comment, namely:
>     # if binding to port 25 is a problem,
>     # connection handling needs to be made more generic to accept
>     # alternative ports. See changes introduced in
>     # https://github.com/wireapp/wire-server/pull/405

Indeed it's a bit inconvenient to have to use privileged ports so it's always good to allow some flexibility here.

2. It changes the SMTP docker image which seems to work better than the current one; at least, I have been able to deliver emails without a problem with this solution. Note though that the communication between brig and this SMTP container should be done using `plain` protocol and then configure the container for the [desired scenario](https://github.com/namshi/docker-smtp#below-are-scenarios-for-using-this-container) - which is basically no arguments in our typical test-like use case.