### PR TITLE
SSO binding users

### DIFF
--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1419,7 +1419,7 @@ updateSSOId :: UserId ::: JSON ::: JSON ::: Request -> Handler Response
 updateSSOId (uid ::: _ ::: _ ::: req) = do
     ssoid :: UserSSOId <- parseJsonBody req
     lift $ Data.updateSSOId uid ssoid
-    return (setStatus status200 empty)
+    return empty
 
 deleteUser :: UserId ::: Request ::: JSON ::: JSON -> Handler Response
 deleteUser (u ::: r ::: _ ::: _) = do

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1418,8 +1418,10 @@ isTeamOwner (uid ::: tid) = do
 updateSSOId :: UserId ::: JSON ::: JSON ::: Request -> Handler Response
 updateSSOId (uid ::: _ ::: _ ::: req) = do
     ssoid :: UserSSOId <- parseJsonBody req
-    lift $ Data.updateSSOId uid ssoid
-    return empty
+    status <- lift $ Data.updateSSOId uid ssoid
+    if status
+      then return empty
+      else return $ setStatus status404 empty
 
 deleteUser :: UserId ::: Request ::: JSON ::: JSON -> Handler Response
 deleteUser (u ::: r ::: _ ::: _) = do

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -209,6 +209,8 @@ sitemap o = do
 
     put "/i/users/:uid/sso-id" (continue updateSSOId) $
       capture "uid"
+      .&. accept "application" "json"
+      .&. contentType "application" "json"
       .&. request
 
     post "/i/clients" (continue internalListClients) $

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1418,10 +1418,10 @@ isTeamOwner (uid ::: tid) = do
 updateSSOId :: UserId ::: JSON ::: JSON ::: Request -> Handler Response
 updateSSOId (uid ::: _ ::: _ ::: req) = do
     ssoid :: UserSSOId <- parseJsonBody req
-    status <- lift $ Data.updateSSOId uid ssoid
-    if status
+    success <- lift $ Data.updateSSOId uid ssoid
+    if success
       then return empty
-      else return $ setStatus status404 empty
+      else return . setStatus status404 $ plain "User does not exist or has no team."
 
 deleteUser :: UserId ::: Request ::: JSON ::: JSON -> Handler Response
 deleteUser (u ::: r ::: _ ::: _) = do

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -59,6 +59,7 @@ import qualified Brig.API.Client               as API
 import qualified Brig.API.Connection           as API
 import qualified Brig.API.Properties           as API
 import qualified Brig.API.User                 as API
+import qualified Brig.Data.User                as Data
 import qualified Brig.Queue                    as Queue
 import qualified Brig.Team.Util                as Team
 import qualified Brig.User.API.Auth            as Auth
@@ -205,6 +206,10 @@ sitemap o = do
     get "/i/users/:uid/is-team-owner/:tid" (continue isTeamOwner) $
       capture "uid"
       .&. capture "tid"
+
+    put "/i/users/:uid/sso-id" (continue updateSSOId) $
+      capture "uid"
+      .&. request
 
     post "/i/clients" (continue internalListClients) $
       accept "application" "json"
@@ -1407,6 +1412,11 @@ isTeamOwner (uid ::: tid) = do
        Team.IsNotTeamOwner        -> throwStd insufficientTeamPermissions
        Team.NoTeamOwnersAreLeft   -> throwStd insufficientTeamPermissions
     return empty
+
+updateSSOId :: UserId ::: Request -> Handler Response
+updateSSOId (uid ::: req) = do
+    ssoid :: UserSSOId <- parseJsonBody req
+    API.updateSSOId uid ssoid
 
 deleteUser :: UserId ::: Request ::: JSON ::: JSON -> Handler Response
 deleteUser (u ::: r ::: _ ::: _) = do

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1415,10 +1415,11 @@ isTeamOwner (uid ::: tid) = do
        Team.NoTeamOwnersAreLeft   -> throwStd insufficientTeamPermissions
     return empty
 
-updateSSOId :: UserId ::: Request -> Handler Response
-updateSSOId (uid ::: req) = do
+updateSSOId :: UserId ::: JSON ::: JSON ::: Request -> Handler Response
+updateSSOId (uid ::: _ ::: _ ::: req) = do
     ssoid :: UserSSOId <- parseJsonBody req
-    API.updateSSOId uid ssoid
+    lift $ Data.updateSSOId uid ssoid
+    return (setStatus status200 empty)
 
 deleteUser :: UserId ::: Request ::: JSON ::: JSON -> Handler Response
 deleteUser (u ::: r ::: _ ::: _) = do

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -151,6 +151,10 @@ data RemoveIdentityError
     | NoPassword
     | NoIdentity
 
+data UpdateSSOIdError
+    = UpdateSSOIdErrorNoSuchUser
+    | UpdateSSOIdErrorInternal
+
 data DeleteUserError
     = DeleteUserInvalid
     | DeleteUserInvalidCode

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -151,10 +151,6 @@ data RemoveIdentityError
     | NoPassword
     | NoIdentity
 
-data UpdateSSOIdError
-    = UpdateSSOIdErrorNoSuchUser
-    | UpdateSSOIdErrorInternal
-
 data DeleteUserError
     = DeleteUserInvalid
     | DeleteUserInvalidCode

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -638,9 +638,6 @@ mkPasswordResetKey ident = case ident of
   where
     user uk = lift (Data.lookupKey uk) >>= maybe (throwE InvalidPasswordResetKey) return
 
-updateSSOId :: UserId -> UserSSOId -> ExceptT UpdateSSOIdError AppIO ()
-updateSSOId uid ssoid = lift $ Data.updateSSOId uid ssoid
-
 
 -------------------------------------------------------------------------------
 -- User Deletion

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -638,6 +638,10 @@ mkPasswordResetKey ident = case ident of
   where
     user uk = lift (Data.lookupKey uk) >>= maybe (throwE InvalidPasswordResetKey) return
 
+updateSSOId :: UserId -> UserSSOId -> ExceptT UpdateSSOIdError AppIO ()
+updateSSOId uid ssoid = lift $ Data.updateSSOId uid ssoid
+
+
 -------------------------------------------------------------------------------
 -- User Deletion
 

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -201,8 +201,14 @@ updateEmail u e = retry x5 $ write userEmailUpdate (params Quorum (e, u))
 updatePhone :: UserId -> Phone -> AppIO ()
 updatePhone u p = retry x5 $ write userPhoneUpdate (params Quorum (p, u))
 
-updateSSOId :: UserId -> UserSSOId -> AppIO ()
-updateSSOId u ssoid = retry x5 $ write userSSOIdUpdate (params Quorum (ssoid, u))
+updateSSOId :: UserId -> UserSSOId -> AppIO Bool
+updateSSOId u ssoid = do
+  mteamid <- lookupUserTeam u
+  case mteamid of
+    Just _ -> do
+      retry x5 $ write userSSOIdUpdate (params Quorum (ssoid, u))
+      pure True
+    Nothing -> pure False
 
 updateHandle :: UserId -> Handle -> AppIO ()
 updateHandle u h = retry x5 $ write userHandleUpdate (params Quorum (h, u))

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -31,6 +31,7 @@ module Brig.Data.User
     , updateUser
     , updateEmail
     , updatePhone
+    , updateSSOId
     , activateUser
     , deactivateUser
     , updateLocale
@@ -199,6 +200,9 @@ updateEmail u e = retry x5 $ write userEmailUpdate (params Quorum (e, u))
 
 updatePhone :: UserId -> Phone -> AppIO ()
 updatePhone u p = retry x5 $ write userPhoneUpdate (params Quorum (p, u))
+
+updateSSOId :: UserId -> UserSSOId -> AppIO ()
+updateSSOId u ssoid = retry x5 $ write userSSOIdUpdate (params Quorum (ssoid, u))
 
 updateHandle :: UserId -> Handle -> AppIO ()
 updateHandle u h = retry x5 $ write userHandleUpdate (params Quorum (h, u))
@@ -415,6 +419,9 @@ userEmailUpdate = "UPDATE user SET email = ? WHERE id = ?"
 
 userPhoneUpdate :: PrepQuery W (Phone, UserId) ()
 userPhoneUpdate = "UPDATE user SET phone = ? WHERE id = ?"
+
+userSSOIdUpdate :: PrepQuery W (UserSSOId, UserId) ()
+userSSOIdUpdate = "UPDATE user SET ssoid = ? WHERE id = ?"
 
 userHandleUpdate :: PrepQuery W (Handle, UserId) ()
 userHandleUpdate = "UPDATE user SET handle = ? WHERE id = ?"

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -421,7 +421,7 @@ userPhoneUpdate :: PrepQuery W (Phone, UserId) ()
 userPhoneUpdate = "UPDATE user SET phone = ? WHERE id = ?"
 
 userSSOIdUpdate :: PrepQuery W (UserSSOId, UserId) ()
-userSSOIdUpdate = "UPDATE user SET ssoid = ? WHERE id = ?"
+userSSOIdUpdate = "UPDATE user SET sso_id = ? WHERE id = ?"
 
 userHandleUpdate :: PrepQuery W (Handle, UserId) ()
 userHandleUpdate = "UPDATE user SET handle = ? WHERE id = ?"

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -566,13 +566,13 @@ testCreateUserInternalSSO brig galley = do
         getUserSSOId _ = Nothing
 
     -- creating users requires both sso_id and team_id
-    postUser "dummy" (Just "success@simulator.amazonses.com") (Just ssoid) Nothing brig
+    postUser "dummy" (Just "success@simulator.amazonses.com") Nothing (Just ssoid) Nothing brig
         !!! const 400 === statusCode
-    postUser "dummy" (Just "success@simulator.amazonses.com") Nothing (Just teamid) brig
+    postUser "dummy" (Just "success@simulator.amazonses.com") Nothing Nothing (Just teamid) brig
         !!! const 400 === statusCode
 
     -- creating user with sso_id, team_id is ok
-    resp <- postUser "dummy" (Just "success@simulator.amazonses.com") (Just ssoid) (Just teamid) brig <!! do
+    resp <- postUser "dummy" (Just "success@simulator.amazonses.com") Nothing (Just ssoid) (Just teamid) brig <!! do
         const 201 === statusCode
         const (Just ssoid) === (getUserSSOId <=< userIdentity . selfUser <=< decodeBody)
 
@@ -599,7 +599,7 @@ testDeleteUserSSO brig galley = do
     let ssoid = UserSSOId "nil" "nil"
         mkuser :: Bool -> Http (Maybe User)
         mkuser withemail = decodeBody <$>
-            (postUser "dummy" email (Just ssoid) (Just tid) brig
+            (postUser "dummy" email Nothing (Just ssoid) (Just tid) brig
              <!! const 201 === statusCode)
           where
             email = if withemail then Just "success@simulator.amazonses.com" else Nothing

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -7,6 +7,7 @@
 module API.User.Account (tests) where
 
 import API.Search.Util (assertSearchable)
+import API.Team.Util (createUserWithTeam, createTeamMember)
 import API.User.Util
 import Bilge hiding (accept, timeout)
 import Bilge.Assert
@@ -36,6 +37,7 @@ import Data.Time (UTCTime, getCurrentTime)
 import Data.Time.Clock (diffUTCTime)
 import Data.Text (Text)
 import Data.Vector (Vector)
+import Galley.Types.Teams (noPermissions)
 import Gundeck.Types.Notification
 import Test.Tasty hiding (Timeout)
 import Test.Tasty.Cannon hiding (Cannon)
@@ -92,7 +94,7 @@ tests _ at _ p b c ch g aws = testGroup "account"
     , test' aws p "delete/anonymous"                         $ testDeleteAnonUser b
     , test' aws p "delete /i/users/:id - 202"                $ testDeleteInternal b c aws
     , test' aws p "delete with profile pic"                  $ testDeleteWithProfilePic b ch
-    , test' aws p "put /i/users/:uid/sso-id"                 $ testUpdateSSOId b
+    , test' aws p "put /i/users/:uid/sso-id"                 $ testUpdateSSOId b g
     ]
 
 testCreateUserWithPreverified :: Brig -> AWS.Env -> Http ()
@@ -543,17 +545,7 @@ testPhoneUpdate :: Brig -> Http ()
 testPhoneUpdate brig = do
     uid <- userId <$> randomUser brig
     phn <- randomPhone
-    -- update phone
-    let phoneUpdate = RequestBodyLBS . encode $ PhoneUpdate phn
-    put (brig . path "/self/phone" . contentJson . zUser uid . zConn "c" . body phoneUpdate) !!!
-        (const 202 === statusCode)
-    -- activate
-    act <- getActivationCode brig (Right phn)
-    case act of
-        Nothing -> liftIO $ assertFailure "missing activation key/code"
-        Just kc -> activate brig kc !!! do
-            const 200 === statusCode
-            const (Just False) === fmap activatedFirst . decodeBody
+    updatePhone brig uid phn
     -- check new phone
     get (brig . path "/self" . zUser uid) !!! do
         const 200 === statusCode
@@ -913,39 +905,22 @@ testDeleteWithProfilePic brig cargohold = do
     -- Check that the asset gets deleted
     downloadAsset cargohold uid (toByteString' (ast^.CHV3.assetKey)) !!! const 404 === statusCode
 
--- | Users with phone, or email, or both, or combinations thereof plus ssoid, will all be updated
--- correctly, and hpone and email are not changed.
-testUpdateSSOId :: Brig -> Http ()
-testUpdateSSOId brig = do
-    let ssoids =
-            [ UserSSOId "1" "1"
-            , UserSSOId "1" "2"
-            , UserSSOId "2" "1"
-            ]
+testUpdateSSOId :: Brig -> Galley -> Http ()
+testUpdateSSOId brig galley = do
+    noSuchUserId <- Id <$> liftIO UUID.nextRandom
+    put ( brig
+        . paths ["i", "users", toByteString' noSuchUserId, "sso-id"]
+        . Bilge.json (UserSSOId "1" "1")
+        )
+        !!! const 404 === statusCode
 
-        mkUser :: Bool -> Bool -> Http User
-        mkUser hasEmail hasPhone = do
-            name <- UUID.toText <$> liftIO UUID.nextRandom
-            let email = if hasEmail
-                     then Just "success@simulator.amazonses.com"
-                     else Nothing
-            phone <- if hasPhone
-                     then Just . fromPhone <$> randomPhone
-                     else pure Nothing
-            resp <- postUser name email phone Nothing Nothing brig <!!
-                      const 201 === statusCode
-            decodeBody resp
-
-    users <- sequence
-        [ mkUser True  False
-        , mkUser False True
-        , mkUser True  True
-        ]
-
-    let go, goTwice :: User -> UserSSOId -> Http ()
+    let go :: HasCallStack => User -> UserSSOId -> Http ()
         go user ssoid = do
             let uid = userId user
-            put (brig . paths ["i", "users", toByteString' uid, "sso-id"] . Bilge.json ssoid)
+            put ( brig
+                . paths ["i", "users", toByteString' uid, "sso-id"]
+                . Bilge.json ssoid
+                )
                 !!! const 200 === statusCode
             profile :: SelfProfile <- decodeBody =<< get (brig . path "/self" . zUser uid)
             let Just (SSOIdentity ssoid' mEmail mPhone) = userIdentity . selfUser $ profile
@@ -954,9 +929,30 @@ testUpdateSSOId brig = do
                 assertEqual "updateSSOId/email" (userEmail user) mEmail
                 assertEqual "updateSSOId/phone" (userPhone user) mPhone
 
-        goTwice user ssoid = go user ssoid >> go user ssoid
+    (owner, teamid) <- createUserWithTeam brig galley
 
-    sequence_ $ zipWith goTwice users ssoids
+    let mkMember :: Bool -> Bool -> Http User
+        mkMember hasEmail hasPhone = do
+            member <- createTeamMember brig galley owner teamid noPermissions
+            when hasPhone $ do
+                updatePhone brig (userId member) =<< randomPhone
+            when (not hasEmail) $ do
+                error "not implemented"
+            selfUser <$> (decodeBody =<< get (brig . path "/self" . zUser (userId member)))
+
+    let ssoids1 = [ UserSSOId "1" "1", UserSSOId "1" "2" ]
+        ssoids2 = [ UserSSOId "2" "1", UserSSOId "2" "2" ]
+
+    users <- sequence
+        [ mkMember True  False
+        , mkMember True  True
+        -- the following two could be implemented by creating the user implicitly via SSO login.
+        -- , mkMember False  False
+        -- , mkMember False  True
+        ]
+
+    sequence_ $ zipWith go users ssoids1
+    sequence_ $ zipWith go users ssoids2
 
 
 -- helpers

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -61,7 +61,7 @@ import qualified Network.Wai.Utilities.Error as Error
 import qualified Test.Tasty.Cannon           as WS
 
 tests :: ConnectionLimit -> Opt.Timeout -> Maybe Opt.Opts -> Manager -> Brig -> Cannon -> CargoHold -> Galley -> AWS.Env -> TestTree
-tests _cl at _conf p b c ch g aws = testGroup "account"
+tests _ at _ p b c ch g aws = testGroup "account"
     [ test' aws p "post /register - 201 (with preverified)"  $ testCreateUserWithPreverified b aws
     , test' aws p "post /register - 201"                     $ testCreateUser b g
     , test' aws p "post /register - 201 + no email"          $ testCreateUserNoEmailNoPassword b
@@ -911,6 +911,9 @@ testDeleteWithProfilePic brig cargohold = do
 
     -- Check that the asset gets deleted
     downloadAsset cargohold uid (toByteString' (ast^.CHV3.assetKey)) !!! const 404 === statusCode
+
+
+-- helpers
 
 setHandleAndDeleteUser :: Brig -> Cannon -> User -> [UserId] -> AWS.Env -> (UserId -> HttpT IO ()) -> Http ()
 setHandleAndDeleteUser brig cannon u others aws execDelete = do

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -43,6 +43,7 @@ import Test.Tasty.HUnit
 import Test.Tasty.Cannon
 import Util.AWS
 
+import qualified Data.Aeson.Types as Aeson
 import qualified Galley.Types.Teams as Team
 import qualified Brig.AWS as AWS
 import qualified Brig.RPC as RPC
@@ -154,7 +155,7 @@ getConnection brig from to = get $ brig
 postUser :: Text -> Maybe Text -> Maybe Text -> Maybe UserSSOId -> Maybe TeamId -> Brig -> Http ResponseLBS
 postUser name email phone ssoid teamid brig = do
     email' <- maybe (pure Nothing) (fmap (Just . fromEmail) . mkEmailRandomLocalSuffix) email
-    let p = object
+    let Aeson.Success (p :: NewUser) = Aeson.parse parseJSON $ object
             [ "name"            .= name
             , "email"           .= email'
             , "phone"           .= phone
@@ -163,7 +164,6 @@ postUser name email phone ssoid teamid brig = do
             , "sso_id"          .= ssoid
             , "team_id"         .= teamid
             ]
-    -- liftIO $ print (eitherDecode @NewUser (encode p))
     post (brig . path "/i/users" . Bilge.json p)
 
 postUserInternal :: Object -> Brig -> Http User

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -163,6 +163,7 @@ postUser name email phone ssoid teamid brig = do
             , "sso_id"          .= ssoid
             , "team_id"         .= teamid
             ]
+    -- liftIO $ print (eitherDecode @NewUser (encode p))
     post (brig . path "/i/users" . Bilge.json p)
 
 postUserInternal :: Object -> Brig -> Http User

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -154,7 +154,7 @@ getConnection brig from to = get $ brig
 postUser :: Text -> Maybe Text -> Maybe Text -> Maybe UserSSOId -> Maybe TeamId -> Brig -> Http ResponseLBS
 postUser name email phone ssoid teamid brig = do
     email' <- maybe (pure Nothing) (fmap (Just . fromEmail) . mkEmailRandomLocalSuffix) email
-    let p = RequestBodyLBS . encode $ object
+    let p = object
             [ "name"            .= name
             , "email"           .= email'
             , "phone"           .= phone
@@ -163,7 +163,7 @@ postUser name email phone ssoid teamid brig = do
             , "sso_id"          .= ssoid
             , "team_id"         .= teamid
             ]
-    post (brig . path "/i/users" . contentJson . body p)
+    post (brig . path "/i/users" . Bilge.json p)
 
 postUserInternal :: Object -> Brig -> Http User
 postUserInternal payload brig = do

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -95,7 +95,7 @@ randomUser brig = do
 
 createUser :: HasCallStack => Text -> Text -> Brig -> Http User
 createUser name email brig = do
-    r <- postUser name (Just email) Nothing Nothing brig <!!
+    r <- postUser name (Just email) Nothing Nothing Nothing brig <!!
            const 201 === statusCode
     decodeBody r
 
@@ -151,12 +151,13 @@ getConnection brig from to = get $ brig
     . zConn "conn"
 
 -- more flexible variant of 'createUser' (see above).
-postUser :: Text -> Maybe Text -> Maybe UserSSOId -> Maybe TeamId -> Brig -> Http ResponseLBS
-postUser name email ssoid teamid brig = do
+postUser :: Text -> Maybe Text -> Maybe Text -> Maybe UserSSOId -> Maybe TeamId -> Brig -> Http ResponseLBS
+postUser name email phone ssoid teamid brig = do
     email' <- maybe (pure Nothing) (fmap (Just . fromEmail) . mkEmailRandomLocalSuffix) email
     let p = RequestBodyLBS . encode $ object
             [ "name"            .= name
             , "email"           .= email'
+            , "phone"           .= phone
             , "password"        .= defPassword
             , "cookie"          .= defCookieLabel
             , "sso_id"          .= ssoid

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -41,6 +41,7 @@ dependencies:
   - mtl
   - optparse-applicative
   - raw-strings-qq
+  - retry
   - saml2-web-sso >= 0.17
   - scientific
   - servant
@@ -107,7 +108,6 @@ executables:
       - hspec-discover
       - lens-aeson
       - random
-      - retry
       - servant-client
       - spar
       - stm

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -16,6 +16,7 @@ dependencies:
   - aeson-pretty
   - aeson-qq
   - base
+  - base64-bytestring
   - bilge
   - binary
   - brig-types
@@ -101,7 +102,6 @@ executables:
     ghc-options: -threaded -rtsopts -with-rtsopts=-N
     dependencies:
       - async
-      - base64-bytestring
       - galley-types
       - hspec
       - hspec-discover

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -29,6 +29,7 @@ dependencies:
   - errors
   - exceptions  # (for MonadClient, which in turn needs MonadCatch)
   - ghc-prim
+  - HsOpenSSL
   - http-client
   - http-client-tls
   - http-types

--- a/services/spar/schema/src/Main.hs
+++ b/services/spar/schema/src/Main.hs
@@ -10,6 +10,7 @@ import Util.Options
 import qualified V0
 import qualified V1
 import qualified V2
+import qualified V3
 
 main :: IO ()
 main = do
@@ -21,10 +22,13 @@ main = do
         [ V0.migration
         , V1.migration
         , V2.migration
-        -- TODO: Add a V3 migration that removes unused fields
-        -- (we don't want to risk running a migration which would
-        -- effectively break the currently deployed spar service)
-
+        , V3.migration
         -- When adding migrations here, don't forget to update
         -- 'schemaVersion' in Spar.Data
+
+        -- TODO: Add a migration that removes unused fields
+        -- (we don't want to risk running a migration which would
+        -- effectively break the currently deployed spar service)
+        -- see https://github.com/wireapp/wire-server/pull/476.
+
         ] `finally` close l

--- a/services/spar/schema/src/V3.hs
+++ b/services/spar/schema/src/V3.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module V3 (migration) where
+
+import Cassandra.Schema
+import Control.Monad (void)
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 3 "Add cookie stash for binding existing users to sso identities" $ do
+
+    void $ schema' [r|
+        CREATE TABLE if not exists bind_cookie
+            ( cookie          text
+            , session_owner   uuid
+            , primary key (cookie)
+            )
+    |]

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -38,9 +38,6 @@ import Data.Id
 import Data.Maybe (isJust, fromJust)
 import Data.Proxy
 import Data.String.Conversions
-import "swagger2" Data.Swagger hiding (Header(..))
-  -- NB: this package depends on both types-common, swagger2, so there is no away around this name
-  -- clash other than -XPackageImports.
 import Data.Time
 import GHC.Stack
 import Lens.Micro
@@ -49,6 +46,7 @@ import Servant.Swagger
 import Spar.API.Instances ()
 import Spar.API.Swagger ()
 import Spar.API.Test
+import Spar.API.Types
 import Spar.App
 import Spar.Error
 import Spar.Options
@@ -61,66 +59,9 @@ import qualified Spar.Intra.Brig as Intra
 import qualified URI.ByteString as URI
 
 
--- FUTUREWORK: use servant-generic?
-
 app :: Env -> Application
 app ctx = SAML.setHttpCachePolicy
         $ serve (Proxy @API) (hoistServer (Proxy @API) (SAML.nt @SparError @Spar ctx) (api $ sparCtxOpts ctx) :: Server API)
-
-type API
-     = "sso" :> APISSO
-  :<|> "identity-providers" :> APIIDP
-  :<|> "i" :> APIINTERNAL
-  -- NB. If you add endpoints here, also update Test.Spar.APISpec
-
-type APISSO
-     = "api-docs" :> Get '[JSON] Swagger
-  :<|> APIMeta
-  :<|> APIAuthReqPrecheck
-  :<|> APIAuthReq
-  :<|> APIAuthResp
-
-type CheckOK = Verb 'HEAD 200
-
-type APIMeta
-     = "metadata" :> SAML.APIMeta
-
-type APIAuthReqPrecheck
-     = "initiate-login"
-    :> QueryParam "success_redirect" URI.URI
-    :> QueryParam "error_redirect" URI.URI
-    :> Capture "idp" SAML.IdPId
-    :> CheckOK '[PlainText] NoContent
-
-type APIAuthReq
-     = "initiate-login"
-    :> QueryParam "success_redirect" URI.URI
-    :> QueryParam "error_redirect" URI.URI
-    :> SAML.APIAuthReq
-
-type APIAuthResp
-     = "finalize-login"
-    :> SAML.APIAuthResp
-
-type APIIDP
-     = Header "Z-User" UserId :> IdpGet
-  :<|> Header "Z-User" UserId :> IdpGetAll
-  :<|> Header "Z-User" UserId :> IdpCreate
-  :<|> Header "Z-User" UserId :> IdpDelete
-
-type IdpGet     = Capture "id" SAML.IdPId :> Get '[JSON] IdP
-type IdpGetAll  = Get '[JSON] IdPList
-type IdpCreate  = ReqBody '[SAML.XML] SAML.IdPMetadata :> PostCreated '[JSON] IdP
-type IdpDelete  = Capture "id" SAML.IdPId :> DeleteNoContent '[JSON] NoContent
-
-type APIINTERNAL
-     = "status" :> Get '[JSON] NoContent
-  :<|> "integration-tests" :> IntegrationTests
-
--- FUTUREWORK (thanks jschaul): In a more recent version of servant, using Header '[Strict] becomes
--- an option, removing the need for the Maybe and the extra checks. Probably once
--- https://github.com/wireapp/wire-server/pull/373 is merged this can be done.
-
 
 api :: Opts -> ServerT API Spar
 api opts = apiSSO opts :<|> apiIDP :<|> apiINTERNAL
@@ -267,29 +208,3 @@ validateNewIdP _idpMetadata _idpExtraInfo = do
     -- creating users in victim teams.
 
   pure SAML.IdPConfig {..}
-
-
--- | Type families to convert spar's 'API' type into an "outside-world-view" API type
--- to expose as swagger docs intended to be used by client developers.
--- Here we assume the 'spar' service is only accessible from behind the 'nginz' proxy, which
---   * does not expose routes prefixed with /i/
---   * handles authorization (adding a Z-User header if requests are authorized)
---   * does not show the swagger end-point itself
-type OutsideWorldAPI = StripSwagger (StripInternal (StripAuth API))
-
--- | Strip the nginz-set, internal-only Z-User header
-type family StripAuth api where
-    StripAuth (Header "Z-User" a :> b) = b
-    StripAuth (a :<|> b) = (StripAuth a) :<|> (StripAuth b)
-    StripAuth x = x
-
--- | Strip internal endpoints (prefixed with /i/)
-type family StripInternal api where
-    StripInternal ("i" :> b) = EmptyAPI
-    StripInternal (a :<|> b) = (StripInternal a) :<|> (StripInternal b)
-    StripInternal x = x
-
-type family StripSwagger api where
-    StripSwagger ("sso" :> "api-docs" :> Get '[JSON] Swagger :<|> b) = StripSwagger b
-    StripSwagger (a :<|> b) = StripSwagger a :<|> StripSwagger b
-    StripSwagger x = x

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -54,6 +54,7 @@ import Spar.Options
 import Spar.Types
 
 import qualified Data.ByteString as SBS
+import qualified Data.ByteString.Base64 as ES
 import qualified SAML2.WebSSO as SAML
 import qualified Spar.Data as Data
 import qualified Spar.Intra.Brig as Intra
@@ -112,7 +113,7 @@ authreq authreqttl zusr msucc merr idpid = do
 initializeBindCookie :: ZUsr -> SAML.IdPId -> NominalDiffTime -> Spar BindCookie
 initializeBindCookie zusr idpid authreqttl = do
   path <- sparResponseURI idpid <&> URI.uriPath
-  secret <- liftIO $ cs <$> randBytes 32
+  secret <- liftIO $ cs . ES.encode <$> randBytes 32
   let msecret = if isJust zusr then Just secret else Nothing
       cky = SAML.toggleCookie path msecret
   forM_ zusr $ \userid -> wrapMonadClientWithEnv $ Data.insertBindCookie cky userid authreqttl

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -102,7 +102,9 @@ authreq authreqttl zusr msucc merr idpid = do
   vformat <- validateAuthreqParams msucc merr
   form@(SAML.FormRedirect _ ((^. SAML.rqID) -> reqid)) <- SAML.authreq authreqttl sparRequestIssuer idpid
   wrapMonadClient $ Data.storeVerdictFormat authreqttl reqid vformat
-  initializeBindCookie zusr idpid authreqttl <&> (`addHeader` form)
+  cky <- initializeBindCookie zusr idpid authreqttl
+  SAML.logger SAML.Debug $ "setting bind cookie: " <> show cky
+  pure $ addHeader cky form
 
 -- | Create bind cookie with 60 minutes life expectancy; *iff* the user is already authenticated,
 -- store it with the bind cookies.  If user already has a 'UserSSOId' (need to ask brig for that),

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -138,7 +138,7 @@ validateRedirectURL uri = do
     throwSpar $ SparBadInitiateLoginQueryParams "url-too-long"
 
 
-authresp :: Maybe (SAML.SimpleSetCookie "wire.com") -> SAML.IdPId -> SAML.AuthnResponseBody -> Spar Void
+authresp :: Maybe BindCookie -> SAML.IdPId -> SAML.AuthnResponseBody -> Spar Void
 authresp cky = SAML.authresp sparRequestIssuer sparResponseURI $
   \resp verdict -> throwError . SAML.CustomServant =<< verdictHandler cky resp verdict
 

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
@@ -118,7 +119,7 @@ initializeBindCookie zusr authreqttl = do
   path <- sparResponseURI <&> URI.uriPath
   secret <- liftIO $ cs . ES.encode <$> randBytes 32
   let msecret = if isJust zusr then Just secret else Nothing
-      cky = SAML.toggleCookie path msecret
+      cky = SAML.toggleCookie path $ (, authreqttl) <$> msecret
   forM_ zusr $ \userid -> wrapMonadClientWithEnv $ Data.insertBindCookie cky userid authreqttl
   pure cky
 

--- a/services/spar/src/Spar/API/Instances.hs
+++ b/services/spar/src/Spar/API/Instances.hs
@@ -25,8 +25,12 @@ import SAML2.Util (parseURI')
 import SAML2.WebSSO.Types
 import SAML2.WebSSO.XML as SAML
 import Servant hiding (URI)
+import Spar.Types
 import URI.ByteString
 
+
+instance MimeRender PlainText Void where
+  mimeRender _ = error "instance MimeRender HTML Void: impossible"
 
 instance FromHttpApiData URI where
   parseUrlPiece = either (fail . show) pure . parseURI' <=< parseUrlPiece

--- a/services/spar/src/Spar/API/Swagger.hs
+++ b/services/spar/src/Spar/API/Swagger.hs
@@ -150,5 +150,8 @@ instance ToSchema URI.URI where
 instance ToParamSchema URI.URI where
   toParamSchema _ = toParamSchema (Proxy @String)
 
-instance ToParamSchema SAML.SetSAMLCookie where
-  toParamSchema _ = toParamSchema (Proxy @Bool)
+instance ToParamSchema BindCookie where
+  toParamSchema _ = toParamSchema (Proxy @String)
+
+instance ToSchema Void where
+  declareNamedSchema _ = declareNamedSchema (Proxy @String)

--- a/services/spar/src/Spar/API/Test.hs
+++ b/services/spar/src/Spar/API/Test.hs
@@ -42,4 +42,4 @@ integrationTests
  :<|> (\assid endoflife -> wrapMonadClientWithEnv $ Data.storeAssertion assid endoflife)
  :<|> (\uref uid -> wrapMonadClient $ Data.insertUser uref uid)
  :<|> wrapMonadClient . Data.getUser
- :<|> uncurry verdictHandler
+ :<|> uncurry (verdictHandler Nothing)

--- a/services/spar/src/Spar/API/Types.hs
+++ b/services/spar/src/Spar/API/Types.hs
@@ -35,9 +35,8 @@ import "swagger2" Data.Swagger hiding (Header(..))
   -- clash other than -XPackageImports.
 
 
--- FUTUREWORK (thanks jschaul): In a more recent version of servant, using Header '[Strict] becomes
--- an option, removing the need for the Maybe and the extra checks. Probably once
--- https://github.com/wireapp/wire-server/pull/373 is merged this can be done.
+-- FUTUREWORK (thanks jschaul): Use @Header' '[Strict]@ to avoid the need for the 'Maybe' and the
+-- extra checks.
 
 -- FUTUREWORK: use servant-generic?
 

--- a/services/spar/src/Spar/API/Types.hs
+++ b/services/spar/src/Spar/API/Types.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PackageImports             #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE ViewPatterns               #-}
+
+module Spar.API.Types where
+
+import Data.Id
+import Servant
+import Spar.API.Test
+import Spar.Types
+
+import qualified SAML2.WebSSO as SAML
+import qualified URI.ByteString as URI
+
+import "swagger2" Data.Swagger hiding (Header(..))
+  -- NB: this package depends on both types-common, swagger2, so there is no away around this name
+  -- clash other than -XPackageImports.
+
+
+-- FUTUREWORK (thanks jschaul): In a more recent version of servant, using Header '[Strict] becomes
+-- an option, removing the need for the Maybe and the extra checks. Probably once
+-- https://github.com/wireapp/wire-server/pull/373 is merged this can be done.
+
+-- FUTUREWORK: use servant-generic?
+
+type API
+     = "sso" :> APISSO
+  :<|> "identity-providers" :> APIIDP
+  :<|> "i" :> APIINTERNAL
+  -- NB. If you add endpoints here, also update Test.Spar.APISpec
+
+type APISSO
+     = "api-docs" :> Get '[JSON] Swagger
+  :<|> APIMeta
+  :<|> APIAuthReqPrecheck
+  :<|> APIAuthReq
+  :<|> APIAuthResp
+
+type CheckOK = Verb 'HEAD 200
+
+type APIMeta
+     = "metadata" :> SAML.APIMeta
+
+type APIAuthReqPrecheck
+     = "initiate-login"
+    :> QueryParam "success_redirect" URI.URI
+    :> QueryParam "error_redirect" URI.URI
+    :> Capture "idp" SAML.IdPId
+    :> CheckOK '[PlainText] NoContent
+
+type APIAuthReq
+     = "initiate-login"
+    :> QueryParam "success_redirect" URI.URI
+    :> QueryParam "error_redirect" URI.URI
+    :> SAML.APIAuthReq
+
+type APIAuthResp
+     = "finalize-login"
+    :> SAML.APIAuthResp
+
+type APIIDP
+     = Header "Z-User" UserId :> IdpGet
+  :<|> Header "Z-User" UserId :> IdpGetAll
+  :<|> Header "Z-User" UserId :> IdpCreate
+  :<|> Header "Z-User" UserId :> IdpDelete
+
+type IdpGet     = Capture "id" SAML.IdPId :> Get '[JSON] IdP
+type IdpGetAll  = Get '[JSON] IdPList
+type IdpCreate  = ReqBody '[SAML.XML] SAML.IdPMetadata :> PostCreated '[JSON] IdP
+type IdpDelete  = Capture "id" SAML.IdPId :> DeleteNoContent '[JSON] NoContent
+
+type APIINTERNAL
+     = "status" :> Get '[JSON] NoContent
+  :<|> "integration-tests" :> IntegrationTests
+
+
+-- | Type families to convert spar's 'API' type into an "outside-world-view" API type
+-- to expose as swagger docs intended to be used by client developers.
+-- Here we assume the 'spar' service is only accessible from behind the 'nginz' proxy, which
+--   * does not expose routes prefixed with /i/
+--   * handles authorization (adding a Z-User header if requests are authorized)
+--   * does not show the swagger end-point itself
+type OutsideWorldAPI = StripSwagger (StripInternal (StripAuth API))
+
+-- | Strip the nginz-set, internal-only Z-User header
+type family StripAuth api where
+    StripAuth (Header "Z-User" a :> b) = b
+    StripAuth (a :<|> b) = (StripAuth a) :<|> (StripAuth b)
+    StripAuth x = x
+
+-- | Strip internal endpoints (prefixed with /i/)
+type family StripInternal api where
+    StripInternal ("i" :> b) = EmptyAPI
+    StripInternal (a :<|> b) = (StripInternal a) :<|> (StripInternal b)
+    StripInternal x = x
+
+type family StripSwagger api where
+    StripSwagger ("sso" :> "api-docs" :> Get '[JSON] Swagger :<|> b) = StripSwagger b
+    StripSwagger (a :<|> b) = StripSwagger a :<|> StripSwagger b
+    StripSwagger x = x

--- a/services/spar/src/Spar/API/Types.hs
+++ b/services/spar/src/Spar/API/Types.hs
@@ -90,7 +90,6 @@ type APIAuthResp
      = "finalize-login"
     :> Header "Cookie" BindCookie
        -- (SAML.APIAuthResp from here on, except for response)
-    :> Capture "idp" SAML.IdPId
     :> MultipartForm Mem SAML.AuthnResponseBody
     :> Post '[PlainText] Void
 
@@ -110,15 +109,11 @@ type APIINTERNAL
   :<|> "integration-tests" :> IntegrationTests
 
 
-sparRequestIssuer :: SAML.HasConfig m => SAML.IdPId -> m SAML.Issuer
-sparRequestIssuer = fmap SAML.Issuer <$> SAML.getSsoURI' p p
-  where
-    p = Proxy @("initiate-login" :> SAML.APIAuthReq)
-      -- we can't use the 'APIAuthReq' route here because it has extra query params that translate
-      -- into function arguments to 'safeLink', but 'SAML.getSsoURI'' does not support that.
+sparSPIssuer :: SAML.HasConfig m => m SAML.Issuer
+sparSPIssuer = SAML.Issuer <$> SAML.getSsoURI (Proxy @APISSO) (Proxy @APIAuthResp)
 
-sparResponseURI :: SAML.HasConfig m => SAML.IdPId -> m URI.URI
-sparResponseURI = SAML.getSsoURI' (Proxy @APISSO) (Proxy @APIAuthResp)
+sparResponseURI :: SAML.HasConfig m => m URI.URI
+sparResponseURI = SAML.getSsoURI (Proxy @APISSO) (Proxy @APIAuthResp)
 
 
 -- | Type families to convert spar's 'API' type into an "outside-world-view" API type

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -186,8 +186,8 @@ instance Intra.MonadSparToBrig Spar where
 -- signed in-response-to info in the assertions matches the unsigned in-response-to field in the
 -- 'SAML.Response', and fills in the response id in the header if missing, we can just go for the
 -- latter.
-verdictHandler :: HasCallStack => SAML.AuthnResponse -> SAML.AccessVerdict -> Spar SAML.ResponseVerdict
-verdictHandler aresp verdict = do
+verdictHandler :: HasCallStack => Maybe BindCookie -> SAML.AuthnResponse -> SAML.AccessVerdict -> Spar SAML.ResponseVerdict
+verdictHandler _ aresp verdict = do
   -- [3/4.1.4.2]
   -- <SubjectConfirmation> [...] If the containing message is in response to an <AuthnRequest>, then
   -- the InResponseTo attribute MUST match the request's ID.

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -36,7 +36,6 @@ import Servant
 import Spar.API.Instances ()
 import Spar.API.Swagger ()
 import Spar.Error
-import Spar.Options as Options
 import Spar.Types
 import URI.ByteString as URI
 import Web.Cookie (SetCookie, renderSetCookie)

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -137,7 +137,9 @@ getUser uref = do
   muid <- wrapMonadClient $ Data.getUser uref
   case muid of
     Nothing -> pure Nothing
-    Just uid -> Intra.confirmUserId uid
+    Just uid -> do
+      itis <- Intra.isTeamUser uid
+      pure $ if itis then Just uid else Nothing
 
 -- | Create a fresh 'Data.Id.UserId', store it on C* locally together with 'SAML.UserRef', then
 -- create user on brig with that 'UserId'.  See also: 'Spar.App.getUser'.

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -9,7 +9,15 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE ViewPatterns               #-}
 
-module Spar.App where
+module Spar.App
+  ( Spar(..)
+  , Env(..)
+  , condenseLogMsg
+  , toLevel
+  , wrapMonadClientWithEnv
+  , wrapMonadClient
+  , verdictHandler
+  ) where
 
 import Bilge
 import Cassandra
@@ -84,15 +92,6 @@ toLevel = \case
   SAML.Info  -> Log.Info
   SAML.Debug -> Log.Debug
   SAML.Trace -> Log.Trace
-
-fromLevel :: Log.Level -> SAML.Level
-fromLevel = \case
-  Log.Fatal -> SAML.Fatal
-  Log.Error -> SAML.Error
-  Log.Warn  -> SAML.Warn
-  Log.Info  -> SAML.Info
-  Log.Debug -> SAML.Debug
-  Log.Trace -> SAML.Trace
 
 instance SPStore Spar where
   storeRequest i r      = wrapMonadClientWithEnv $ Data.storeRequest i r

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -172,8 +172,9 @@ bindUser buid userref = do
   unless (uteamid == Just teamid)
     (throwSpar . SparBindFromWrongOrNoTeam . cs . show $ uteamid)
   insertUser userref buid
-  Intra.bindUser buid userref
-  pure buid
+  Intra.bindUser buid userref >>= \case
+    True  -> pure buid
+    False -> throwSpar SparBindUserDisappearedFromBrig
 
 
 instance SPHandler SparError Spar where

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -174,7 +174,9 @@ bindUser buid userref = do
   insertUser userref buid
   Intra.bindUser buid userref >>= \case
     True  -> pure buid
-    False -> throwSpar SparBindUserDisappearedFromBrig
+    False -> do
+      SAML.logger SAML.Warn $ "SparBindUserDisappearedFromBrig: " <> show buid
+      throwSpar SparBindUserDisappearedFromBrig
 
 
 instance SPHandler SparError Spar where

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -250,11 +250,10 @@ verdictHandlerResult bindCky = \case
 retrySparAction :: Spar a -> Spar a
 retrySparAction action = do
   env <- ask
-  result <- liftIO $ retrying
+  either throwError pure =<< liftIO (retrying
     (exponentialBackoff 50 <> limitRetries 5)
     (\_ -> pure . either (const True) (const False))
-    (\_ -> runExceptT $ fromSpar action `runReaderT` env)
-  either throwError pure result
+    (\_ -> runExceptT $ fromSpar action `runReaderT` env))
 
 -- | If the client is web, it will be served with an HTML page that it can process to decide whether
 -- to log the user in or show an error.

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -234,12 +234,12 @@ verdictHandlerResult bindCky = \case
         -- idempotent.
 
       case (fromBindCookie, fromSparCass) of
-        (Nothing,  Nothing)   -> createUser userref    -- first sso authentication
-        (Nothing,  Just uid)  -> pure uid              -- sso re-authentication
-        (Just uid, Nothing)   -> bindUser uid userref  -- bind existing user (non-sso or sso) to ssoid
+        (Nothing,  Nothing)   -> createUser userref      -- first sso authentication
+        (Nothing,  Just uid)  -> pure uid                -- sso re-authentication
+        (Just uid, Nothing)   -> bindUser uid userref    -- bind existing user (non-sso or sso) to ssoid
         (Just uid, Just uid')
-          | uid == uid'       -> pure uid              -- redundant binding (no change to brig or spar)
-          | otherwise         -> error "TODO: what now?"  -- attempt to use ssoid for a second wire user
+          | uid == uid' -> pure uid                      -- redundant binding (no change to brig or spar)
+          | otherwise -> throwSpar SparBindUserRefTaken  -- attempt to use ssoid for a second wire user
 
     cky :: SetCookie <- Intra.ssoLogin uid  -- TODO: can this be a race condition?  (user is not
                                             -- quite created yet when we ask for a cookie?  do we do

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -12,7 +12,27 @@
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE ViewPatterns               #-}
 
-module Spar.Data where
+module Spar.Data
+  ( schemaVersion
+  , Env(..)
+  , mkEnv
+  , mkTTLAssertions
+  , storeRequest
+  , checkAgainstRequest
+  , storeAssertion
+  , storeVerdictFormat
+  , getVerdictFormat
+  , insertUser
+  , getUser
+  , insertBindCookie
+  , lookupBindCookie
+  , storeIdPConfig
+  , getIdPConfig
+  , getIdPConfigByIssuer
+  , getIdPIdByIssuer
+  , getIdPConfigsByTeam
+  , deleteIdPConfig
+  ) where
 
 import Cassandra as Cas
 import Control.Monad.Except

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -49,7 +49,6 @@ import GHC.Stack
 import GHC.TypeLits (KnownSymbol)
 import Lens.Micro
 import Spar.Data.Instances (VerdictFormatRow, VerdictFormatCon, fromVerdictFormat, toVerdictFormat)
-import Spar.Options as Options
 import Spar.Types
 import URI.ByteString
 
@@ -73,11 +72,11 @@ data Env = Env
   }
   deriving (Eq, Show)
 
-mkEnv :: Options.Opts -> UTCTime -> Env
+mkEnv :: Opts -> UTCTime -> Env
 mkEnv opts now =
   Env { dataEnvNow                = now
-      , dataEnvMaxTTLAuthRequests = Options.maxttlAuthreq opts
-      , dataEnvMaxTTLAssertions   = Options.maxttlAuthresp opts
+      , dataEnvMaxTTLAuthRequests = maxttlAuthreq opts
+      , dataEnvMaxTTLAssertions   = maxttlAuthresp opts
       }
 
 mkTTLAuthnRequests :: MonadError TTLError m => Env -> UTCTime -> m (TTL "authreq")

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -39,7 +39,7 @@ import qualified SAML2.WebSSO as SAML
 
 -- | NB: this is a lower bound (@<=@, not @==@).
 schemaVersion :: Int32
-schemaVersion = 2
+schemaVersion = 3
 
 
 ----------------------------------------------------------------------

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -158,6 +158,16 @@ getUser (SAML.UserRef tenant subject) = fmap runIdentity <$>
 
 
 ----------------------------------------------------------------------
+-- bind cookies
+
+insertBindCookie :: (HasCallStack, MonadClient m) => BindCookie -> UserId -> m ()
+insertBindCookie = undefined
+
+lookupBindCookie :: (HasCallStack, MonadClient m) => BindCookie -> m UserId
+lookupBindCookie = undefined
+
+
+----------------------------------------------------------------------
 -- idp
 
 type IdPConfigRow = (SAML.IdPId, SAML.Issuer, URI, SignedCertificate, [SignedCertificate], TeamId)

--- a/services/spar/src/Spar/Data/Instances.hs
+++ b/services/spar/src/Spar/Data/Instances.hs
@@ -13,9 +13,16 @@ import SAML2.Util (parseURI')
 import Spar.Types
 import Text.XML.DSig (renderKeyInfo, parseKeyInfo)
 import URI.ByteString
+import Servant.API (toUrlPiece, parseUrlPiece)
 
 import qualified SAML2.WebSSO as SAML
 
+
+instance Cql BindCookie where
+    ctype = Tagged TextColumn
+    toCql = CqlText . toUrlPiece
+    fromCql (CqlText t) = either (Left . cs) Right $ parseUrlPiece t
+    fromCql _           = fail "BindCookie: expected CqlText"
 
 instance Cql (SignedCertificate) where
     ctype = Tagged BlobColumn

--- a/services/spar/src/Spar/Data/Instances.hs
+++ b/services/spar/src/Spar/Data/Instances.hs
@@ -26,7 +26,7 @@ instance Cql BindCookie where
 
 instance Cql (SignedCertificate) where
     ctype = Tagged BlobColumn
-    toCql = CqlText . cs . renderKeyInfo
+    toCql = CqlBlob . cs . renderKeyInfo
 
     fromCql (CqlBlob t) = parseKeyInfo (cs t)
     fromCql _           = fail "SignedCertificate: expected CqlBlob"

--- a/services/spar/src/Spar/Data/Instances.hs
+++ b/services/spar/src/Spar/Data/Instances.hs
@@ -13,16 +13,9 @@ import SAML2.Util (parseURI')
 import Spar.Types
 import Text.XML.DSig (renderKeyInfo, parseKeyInfo)
 import URI.ByteString
-import Servant.API (toUrlPiece, parseUrlPiece)
 
 import qualified SAML2.WebSSO as SAML
 
-
-instance Cql BindCookie where
-    ctype = Tagged TextColumn
-    toCql = CqlText . toUrlPiece
-    fromCql (CqlText t) = either (Left . cs) Right $ parseUrlPiece t
-    fromCql _           = fail "BindCookie: expected CqlText"
 
 instance Cql (SignedCertificate) where
     ctype = Tagged BlobColumn

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -33,6 +33,7 @@ data SparCustomError
   | SparNotTeamOwner
   | SparInitLoginWithAuth
   | SparInitBindWithoutAuth
+  | SparBindUserDisappearedFromBrig
 
   | SparNoRequestRefInResponse LT
   | SparCouldNotSubstituteSuccessURI LT
@@ -89,6 +90,7 @@ sparToWaiError (SAML.CustomError SparNotInTeam)                           = Righ
 sparToWaiError (SAML.CustomError SparNotTeamOwner)                        = Right $ Wai.Error status403 "insufficient-permissions" "You need to be team owner to create an IdP."
 sparToWaiError (SAML.CustomError SparInitLoginWithAuth)                   = Right $ Wai.Error status403 "login-with-auth" "This end-point is only for login, not binding."
 sparToWaiError (SAML.CustomError SparInitBindWithoutAuth)                 = Right $ Wai.Error status403 "bind-without-auth" "This end-point is only for binding, not login."
+sparToWaiError (SAML.CustomError SparBindUserDisappearedFromBrig)         = Right $ Wai.Error status404 "bind-user-disappeared" "Your user appears to have been deleted?"
 sparToWaiError SAML.UnknownError                                          = Right $ Wai.Error status500 "server-error" "Unknown server error."
 sparToWaiError (SAML.BadServerConfig msg)                                 = Right $ Wai.Error status500 "server-error" ("Error in server config: " <> msg)
 -- Errors related to IdP creation

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -38,6 +38,7 @@ data SparCustomError
   | SparCouldNotSubstituteSuccessURI LT
   | SparCouldNotSubstituteFailureURI LT
   | SparBadInitiateLoginQueryParams LT
+  | SparBindFromWrongOrNoTeam LT
 
   | SparBadUserName LT
   | SparNoBodyInBrigResponse
@@ -69,6 +70,8 @@ sparToWaiError (SAML.CustomError (SparNoRequestRefInResponse msg))        = Righ
 sparToWaiError (SAML.CustomError (SparCouldNotSubstituteSuccessURI msg))  = Right $ Wai.Error status400 "bad-success-redirect" ("re-parsing the substituted URI failed: " <> msg)
 sparToWaiError (SAML.CustomError (SparCouldNotSubstituteFailureURI msg))  = Right $ Wai.Error status400 "bad-failure-redirect" ("re-parsing the substituted URI failed: " <> msg)
 sparToWaiError (SAML.CustomError (SparBadInitiateLoginQueryParams label)) = Right $ Wai.Error status400 label label
+sparToWaiError (SAML.CustomError (SparBindFromWrongOrNoTeam msg))         = Right $ Wai.Error status400 "forbidden" ("Forbidden: wrong user team " <> msg)
+
 sparToWaiError (SAML.CustomError (SparBadUserName msg))                   = Right $ Wai.Error status400 "bad-username" ("Bad UserName in SAML response, except len [1, 128]: " <> msg)
 sparToWaiError (SAML.CustomError SparNoBodyInBrigResponse)                = Right $ Wai.Error status502 "bad-upstream" "Failed to get a response from an upstream server."
 sparToWaiError (SAML.CustomError (SparCouldNotParseBrigResponse msg))     = Right $ Wai.Error status502 "bad-upstream" ("Could not parse response body: " <> msg)

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -39,6 +39,7 @@ data SparCustomError
   | SparCouldNotSubstituteFailureURI LT
   | SparBadInitiateLoginQueryParams LT
   | SparBindFromWrongOrNoTeam LT
+  | SparBindUserRefTaken
 
   | SparBadUserName LT
   | SparNoBodyInBrigResponse
@@ -70,7 +71,8 @@ sparToWaiError (SAML.CustomError (SparNoRequestRefInResponse msg))        = Righ
 sparToWaiError (SAML.CustomError (SparCouldNotSubstituteSuccessURI msg))  = Right $ Wai.Error status400 "bad-success-redirect" ("re-parsing the substituted URI failed: " <> msg)
 sparToWaiError (SAML.CustomError (SparCouldNotSubstituteFailureURI msg))  = Right $ Wai.Error status400 "bad-failure-redirect" ("re-parsing the substituted URI failed: " <> msg)
 sparToWaiError (SAML.CustomError (SparBadInitiateLoginQueryParams label)) = Right $ Wai.Error status400 label label
-sparToWaiError (SAML.CustomError (SparBindFromWrongOrNoTeam msg))         = Right $ Wai.Error status400 "forbidden" ("Forbidden: wrong user team " <> msg)
+sparToWaiError (SAML.CustomError (SparBindFromWrongOrNoTeam msg))         = Right $ Wai.Error status403 "bad-team" ("Forbidden: wrong user team " <> msg)
+sparToWaiError (SAML.CustomError SparBindUserRefTaken)                    = Right $ Wai.Error status403 "subject-id-taken" "Forbidden: SubjectID is used by another wire user.  If you have an old user bound to this IdP, unbind or delete that user."
 
 sparToWaiError (SAML.CustomError (SparBadUserName msg))                   = Right $ Wai.Error status400 "bad-username" ("Bad UserName in SAML response, except len [1, 128]: " <> msg)
 sparToWaiError (SAML.CustomError SparNoBodyInBrigResponse)                = Right $ Wai.Error status502 "bad-upstream" "Failed to get a response from an upstream server."

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -31,6 +31,8 @@ data SparCustomError
   | SparMissingZUsr
   | SparNotInTeam
   | SparNotTeamOwner
+  | SparInitLoginWithAuth
+  | SparInitBindWithoutAuth
 
   | SparNoRequestRefInResponse LT
   | SparCouldNotSubstituteSuccessURI LT
@@ -80,6 +82,8 @@ sparToWaiError (SAML.CustomError SparNotFound)                            = Righ
 sparToWaiError (SAML.CustomError SparMissingZUsr)                         = Right $ Wai.Error status400 "client-error" "[header] 'Z-User' required"
 sparToWaiError (SAML.CustomError SparNotInTeam)                           = Right $ Wai.Error status403 "no-team-member" "Requesting user is not a team member or not a member of this team."
 sparToWaiError (SAML.CustomError SparNotTeamOwner)                        = Right $ Wai.Error status403 "insufficient-permissions" "You need to be team owner to create an IdP."
+sparToWaiError (SAML.CustomError SparInitLoginWithAuth)                   = Right $ Wai.Error status403 "login-with-auth" "This end-point is only for login, not binding."
+sparToWaiError (SAML.CustomError SparInitBindWithoutAuth)                 = Right $ Wai.Error status403 "bind-without-auth" "This end-point is only for binding, not login."
 sparToWaiError SAML.UnknownError                                          = Right $ Wai.Error status500 "server-error" "Unknown server error."
 sparToWaiError (SAML.BadServerConfig msg)                                 = Right $ Wai.Error status500 "server-error" ("Error in server config: " <> msg)
 -- Errors related to IdP creation

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -15,7 +15,7 @@ import Data.Aeson
 import Data.String.Conversions
 import Network.HTTP.Types.Status
 import Servant
-import Spar.Options (TTLError)
+import Spar.Types (TTLError)
 
 import qualified Network.Wai.Utilities.Error as Wai
 import qualified SAML2.WebSSO as SAML

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -115,6 +115,10 @@ getUser buid = do
     else Just . selfUser <$> parseResponse @SelfProfile resp
 
 
+bindUser :: (HasCallStack, MonadError SparError m, MonadSparToBrig m) => UserId -> SAML.UserRef -> m ()
+bindUser = undefined
+
+
 -- | Check that a user locally created on spar exists on brig and has a team id.
 confirmUserId :: (HasCallStack, MonadError SparError m, MonadSparToBrig m) => UserId -> m (Maybe UserId)
 confirmUserId buid = do

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -116,7 +116,11 @@ getUser buid = do
 
 
 bindUser :: (HasCallStack, MonadError SparError m, MonadSparToBrig m) => UserId -> SAML.UserRef -> m ()
-bindUser = undefined
+bindUser uid (toUserSSOId -> ussoid) = void . call
+  $ method PUT
+  . paths ["/i/users", toByteString' uid, "ssoid"]
+  . json ussoid
+  . expect2xx
 
 
 -- | Check that a user locally created on spar exists on brig and has a team id.

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -24,6 +24,7 @@ import Control.Monad.Except
 import Data.Aeson (FromJSON, eitherDecode')
 import Data.ByteString.Conversion
 import Data.Id (Id(Id), UserId, TeamId)
+import Data.Maybe (isJust)
 import Data.Range
 import Data.String.Conversions
 import GHC.Stack
@@ -123,11 +124,11 @@ bindUser uid (toUserSSOId -> ussoid) = void . call
   . expect2xx
 
 
--- | Check that a user locally created on spar exists on brig and has a team id.
-confirmUserId :: (HasCallStack, MonadError SparError m, MonadSparToBrig m) => UserId -> m (Maybe UserId)
-confirmUserId buid = do
+-- | Check that a user id exists on brig and has a team id.
+isTeamUser :: (HasCallStack, MonadError SparError m, MonadSparToBrig m) => UserId -> m Bool
+isTeamUser buid = do
   usr <- getUser buid
-  maybe (pure Nothing) (const . pure . Just $ buid) (userTeam =<< usr)
+  pure $ isJust (userTeam =<< usr)
 
 
 -- | If user is not in team, throw 'SparNotInTeam'; if user is in team but not owner, throw

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -118,7 +118,7 @@ getUser buid = do
 bindUser :: (HasCallStack, MonadError SparError m, MonadSparToBrig m) => UserId -> SAML.UserRef -> m ()
 bindUser uid (toUserSSOId -> ussoid) = void . call
   $ method PUT
-  . paths ["/i/users", toByteString' uid, "ssoid"]
+  . paths ["/i/users", toByteString' uid, "sso-id"]
   . json ussoid
   . expect2xx
 

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -126,9 +126,13 @@ bindUser uid (toUserSSOId -> ussoid) = void . call
 
 -- | Check that a user id exists on brig and has a team id.
 isTeamUser :: (HasCallStack, MonadError SparError m, MonadSparToBrig m) => UserId -> m Bool
-isTeamUser buid = do
+isTeamUser buid = isJust <$> getUserTeam buid
+
+-- | Check that a user id exists on brig and has a team id.
+getUserTeam :: (HasCallStack, MonadError SparError m, MonadSparToBrig m) => UserId -> m (Maybe TeamId)
+getUserTeam buid = do
   usr <- getUser buid
-  pure $ isJust (userTeam =<< usr)
+  pure $ userTeam =<< usr
 
 
 -- | If user is not in team, throw 'SparNotInTeam'; if user is in team but not owner, throw

--- a/services/spar/src/Spar/Options.hs
+++ b/services/spar/src/Spar/Options.hs
@@ -1,77 +1,67 @@
 {-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 module Spar.Options
-  ( Opts(..)
-  , TTL(..), TTLError(..), showTTL
-  , getOpts
+  ( getOpts
+  , deriveOpts
   , readOptsFile
-  , ttlToNominalDiffTime
-  , maxttlAuthreqDiffTime
   ) where
 
 import Control.Exception
-import Data.Aeson
-import Data.Id (TeamId)
-import Data.Int
+import Control.Monad.Catch
+import Control.Monad.Reader
+import Data.Id
 import Data.Monoid
-import Data.Proxy (Proxy(Proxy))
-import Data.Text (Text)
-import Data.Time
-import GHC.Generics (Generic)
-import GHC.TypeLits (KnownSymbol, symbolVal)
-import GHC.Types (Symbol)
 import Lens.Micro
 import Options.Applicative
-import Util.Options
+import Spar.API.Types
+import Spar.Types
+import URI.ByteString as URI
 
 import qualified Data.Yaml as Yaml
-import qualified SAML2.WebSSO.Config as SAML
+import qualified SAML2.WebSSO as SAML
 
 
-data Opts = Opts
-    { saml           :: !(SAML.Config TeamId)
-    , brig           :: !Endpoint
-    , cassandra      :: !CassandraOpts
-    , maxttlAuthreq  :: !(TTL "authreq")
-    , maxttlAuthresp :: !(TTL "authresp")
-    , discoUrl       :: !(Maybe Text) -- Wire/AWS specific; optional; used to discover cassandra instance IPs using describe-instances
-    , logNetStrings  :: !Bool
-    -- , optSettings   :: !Settings  -- (nothing yet; see other services for what belongs in here.)
-    }
-  deriving (Show, Generic)
-
-instance FromJSON Opts
-
--- | (seconds)
-newtype TTL (tablename :: Symbol) = TTL { fromTTL :: Int32 }
-  deriving (Eq, Ord, Show, Num)
-
-showTTL :: KnownSymbol a => TTL a -> String
-showTTL (TTL i :: TTL a) = "TTL:" <> (symbolVal (Proxy @a)) <> ":" <> show i
-
-instance FromJSON (TTL a) where
-  parseJSON = withScientific "TTL value (seconds)" (pure . TTL . round)
-
-data TTLError = TTLTooLong String String | TTLNegative String
-  deriving (Eq, Show)
-
-ttlToNominalDiffTime :: TTL a -> NominalDiffTime
-ttlToNominalDiffTime (TTL i32) = fromIntegral i32
-
-maxttlAuthreqDiffTime :: Opts -> NominalDiffTime
-maxttlAuthreqDiffTime = ttlToNominalDiffTime . maxttlAuthreq
-
+type OptsRaw = Opts' (Maybe ())
 
 -- | Throws an exception if no config file is found.
 getOpts :: IO Opts
 getOpts = do
   let desc = "Spar - SSO Service"
-  readOptsFile =<< execParser (info (helper <*> cliOptsParser) (header desc <> fullDesc))
+  deriveOpts
+    =<< readOptsFile
+    =<< execParser (info (helper <*> cliOptsParser) (header desc <> fullDesc))
+
+deriveOpts :: OptsRaw -> IO Opts
+deriveOpts raw = do
+  derived <- do
+    let respuri = runWithConfig raw sparResponseURI
+        derivedOptsBindCookiePath = URI.uriPath respuri
+        unwrap = maybe (throwM $ ErrorCall "Bad server config: no domain in response URI") pure
+    derivedOptsBindCookieDomain <- URI.hostBS . URI.authorityHost <$> unwrap (URI.uriAuthority respuri)
+    pure DerivedOpts {..}
+  pure $ derived <$ raw
+
+-- | This should not leave this module.  It is only for callling 'sparResponseURI' before the 'Spar'
+-- monad is fully initialized.
+newtype WithConfig a = WithConfig (Reader OptsRaw a)
+  deriving (Functor, Applicative, Monad)
+
+instance SAML.HasConfig WithConfig where
+  type ConfigExtra WithConfig = TeamId
+  getConfig = WithConfig $ asks saml
+
+runWithConfig :: OptsRaw -> WithConfig a -> a
+runWithConfig opts (WithConfig act) = act `runReader` opts
+
 
 -- | Accept config file location as cli option.
 --
@@ -87,7 +77,7 @@ cliOptsParser = strOption $
   where
     defaultSparPath = "/etc/wire/spar/conf/spar.yaml"
 
-readOptsFile :: FilePath -> IO Opts
+readOptsFile :: FilePath -> IO OptsRaw
 readOptsFile path =
   either err1 (\opts -> if hasNoIdPs opts then pure opts else err2)
     =<< Yaml.decodeFileEither path
@@ -95,5 +85,5 @@ readOptsFile path =
     err1 = throwIO . ErrorCall . ("no or bad config file: " <>) . show
     err2 = throwIO $ ErrorCall "idps field is not supported by spar."
 
-    hasNoIdPs :: Opts -> Bool
+    hasNoIdPs :: OptsRaw -> Bool
     hasNoIdPs = null . (^. to saml . SAML.cfgIdps)

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -15,7 +15,11 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Spar.Run (initCassandra, mkLogger, runServer) where
+module Spar.Run
+  ( initCassandra
+  , mkLogger
+  , runServer
+  ) where
 
 import Bilge
 import Cassandra as Cas

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -35,11 +35,9 @@ import Spar.API.Instances ()
 import Spar.API.Swagger ()
 import Spar.App
 import Spar.Data.Instances ()
-import Spar.Options
-import Spar.Options as Options
+import Spar.Types as Types
 import System.Logger (Logger)
-import Util.Options (casEndpoint, casKeyspace)
-import Util.Options (epHost, epPort)
+import Util.Options (casEndpoint, casKeyspace, epHost, epPort)
 
 import qualified Cassandra.Schema as Cas
 import qualified Cassandra.Settings as Cas
@@ -47,23 +45,22 @@ import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Utilities.Server as WU
 import qualified SAML2.WebSSO as SAML
 import qualified Spar.Data as Data
-import qualified Spar.Options as Opts
 import qualified System.Logger as Log
 
 
 ----------------------------------------------------------------------
 -- cassandra
 
-initCassandra :: Opts.Opts -> Logger -> IO ClientState
+initCassandra :: Opts -> Logger -> IO ClientState
 initCassandra opts lgr = do
     connectString <- maybe
-               (Cas.initialContactsDNS (Opts.cassandra opts ^. casEndpoint . epHost))
+               (Cas.initialContactsDNS (Types.cassandra opts ^. casEndpoint . epHost))
                (Cas.initialContactsDisco "cassandra_spar")
-               (cs <$> Opts.discoUrl opts)
+               (cs <$> Types.discoUrl opts)
     cas <- Cas.init (Log.clone (Just "cassandra.spar") lgr) $ Cas.defSettings
       & Cas.setContacts (NE.head connectString) (NE.tail connectString)
-      & Cas.setPortNumber (fromIntegral $ Options.cassandra opts ^. casEndpoint . epPort)
-      & Cas.setKeyspace (Keyspace $ Options.cassandra opts ^. casKeyspace)
+      & Cas.setPortNumber (fromIntegral $ Types.cassandra opts ^. casEndpoint . epPort)
+      & Cas.setKeyspace (Keyspace $ Types.cassandra opts ^. casKeyspace)
       & Cas.setMaxConnections 4
       & Cas.setMaxStreams 128
       & Cas.setPoolStripes 4

--- a/services/spar/src/Spar/Types.hs
+++ b/services/spar/src/Spar/Types.hs
@@ -20,7 +20,7 @@ import Data.String.Conversions
 import GHC.Generics
 import Lens.Micro.TH (makeLenses)
 import SAML2.Util (renderURI, parseURI')
-import SAML2.WebSSO (IdPConfig, ID, AuthnRequest)
+import SAML2.WebSSO (IdPConfig, ID, AuthnRequest, SimpleSetCookie)
 import SAML2.WebSSO.Types.TH (deriveJSONOptions)
 import URI.ByteString
 import Web.Cookie
@@ -28,6 +28,12 @@ import Web.Cookie
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.Text as ST
 
+
+data Void
+
+type ZUsr = Maybe UserId
+
+type BindCookie = SimpleSetCookie "wire.com"
 
 -- | The identity provider type used in Spar.
 type IdP = IdPConfig TeamId

--- a/services/spar/src/Spar/Types.hs
+++ b/services/spar/src/Spar/Types.hs
@@ -31,7 +31,7 @@ import qualified Data.Text as ST
 
 data Void
 
-type BindCookie = SimpleSetCookie "wire.com"
+type BindCookie = SimpleSetCookie "zbind"
 
 -- | The identity provider type used in Spar.
 type IdP = IdPConfig TeamId

--- a/services/spar/src/Spar/Types.hs
+++ b/services/spar/src/Spar/Types.hs
@@ -31,8 +31,6 @@ import qualified Data.Text as ST
 
 data Void
 
-type ZUsr = Maybe UserId
-
 type BindCookie = SimpleSetCookie "wire.com"
 
 -- | The identity provider type used in Spar.

--- a/services/spar/test-integration/Spec.hs
+++ b/services/spar/test-integration/Spec.hs
@@ -2,9 +2,11 @@
 
 module Main where
 
+import Control.Exception
 import Data.Monoid
 import Options.Applicative
 import Spar.Options
+import Spar.Types
 import System.Environment
 import Test.Hspec
 import Util
@@ -22,7 +24,7 @@ mkspec = do
   let desc = "Spar - SSO Service Integration Test Suite"
   (integrationConfigFilePath, configFilePath) <- execParser (info (helper <*> cliOptsParser) (header desc <> fullDesc))
   integrationOpts :: IntegrationConfig <- Yaml.decodeFileEither integrationConfigFilePath >>= either (error . show) pure
-  serviceOpts :: Opts <- Yaml.decodeFileEither configFilePath >>= either (error . show) pure
+  serviceOpts :: Opts <- Yaml.decodeFileEither configFilePath >>= either (throwIO . ErrorCall . show) deriveOpts
 
   pure . beforeAll (mkEnv integrationOpts serviceOpts) . afterAll destroyEnv $ do
     describe "Test.Spar.Data" Test.Spar.DataSpec.spec

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -225,7 +225,7 @@ specBindingUsers = describe "binding existing users to sso identities" $ do
                              . expect2xx
                              )
 
-    let checkInitiateLogin :: forall m. m ~ ReaderT TestEnv IO => m UserId -> m ()
+    let checkInitiateLogin :: forall m. m ~ TestSpar => m UserId -> m ()
         checkInitiateLogin createUser = do
           let checkRespBody :: HasCallStack => ResponseLBS -> Bool
               checkRespBody (responseBody -> Just (cs -> bdy)) = all (`isInfixOf` bdy)
@@ -254,7 +254,7 @@ specBindingUsers = describe "binding existing users to sso identities" $ do
         it "responds with 2xx and bind cookie" $ do
           checkInitiateLogin loginSsoUserFirstTime
 
-    let checkFinalizeLogin :: forall m. m ~ ReaderT TestEnv IO => m UserId -> m ()
+    let checkFinalizeLogin :: forall m. m ~ TestSpar => m UserId -> m ()
         checkFinalizeLogin createUser = do
           env <- ask
           uid <- createUser

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -315,12 +315,12 @@ specBindingUsers = describe "binding existing users to sso identities" $ do
 
           reBindSame :: UserId -> IdP -> NameID -> TestSpar (SignedAuthnResponse, ResponseLBS)
           reBindSame uid idp subj = do
-            (_, privCreds, authnReq, Just bindCookie) <- do
+            (_, privCreds, authnReq, Just bindCky) <- do
               negotiateAuthnRequest' DoInitiateBind (Just idp) (header "Z-User" $ toByteString' uid)
             spmeta <- getTestSPMetadata
             authnResp <- liftIO $ mkAuthnResponseWithSubj subj privCreds idp spmeta authnReq True
             sparAuthnResp :: ResponseLBS
-              <- submitAuthnResponse' (header "Cookie" bindCookie) authnResp
+              <- submitAuthnResponse' (header "Cookie" bindCky) authnResp
             pure (authnResp, sparAuthnResp)
 
           reBindDifferent :: UserId -> TestSpar (SignedAuthnResponse, ResponseLBS)

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -29,7 +29,7 @@ import Spar.API.Types
 import Spar.API.Instances ()
 import Spar.API.Test (IntegrationTests)
 import Spar.Data as Data
-import Spar.Options as Options
+import Spar.Types
 import URI.ByteString as URI
 import URI.ByteString.QQ (uri)
 import Util

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -303,14 +303,14 @@ runPostVerdict :: HasCallStack => TestEnv -> (SAML.AuthnResponse, SAML.AccessVer
 runPostVerdict env = runServantClient env . clientPostVerdict
 
 
-mkAuthnReqWeb :: SAML.IdPId -> ReaderT TestEnv IO ResponseLBS
+mkAuthnReqWeb :: SAML.IdPId -> TestSpar ResponseLBS
 mkAuthnReqWeb idpid = do
   env <- ask
   -- TODO: the following fails, i think there is something wrong with query encoding.
   -- runServantClient env $ clientGetAuthnRequest Nothing Nothing idpid
   call $ get ((env ^. teSpar) . path (cs $ "/sso/initiate-login/" -/ SAML.idPIdToST idpid) . expect2xx)
 
-mkAuthnReqMobile :: SAML.IdPId -> ReaderT TestEnv IO ResponseLBS
+mkAuthnReqMobile :: SAML.IdPId -> TestSpar ResponseLBS
 mkAuthnReqMobile idpid = do
   env <- ask
   -- (see the TODO under "web" above)
@@ -323,13 +323,13 @@ mkAuthnReqMobile idpid = do
   call $ get ((env ^. teSpar) . path arPath . expect2xx)
 
 requestAccessVerdict :: HasCallStack
-                     => Bool                                             -- ^ is the verdict granted?
-                     -> (SAML.IdPId -> ReaderT TestEnv IO ResponseLBS)   -- ^ raw authnreq
-                     -> ReaderT TestEnv IO ( UserId
-                                           , SAML.ResponseVerdict
-                                           , URI                         -- ^ location header
-                                           , [(SBS, SBS)]                -- ^ query params
-                                           )
+                     => Bool                                   -- ^ is the verdict granted?
+                     -> (SAML.IdPId -> TestSpar ResponseLBS)   -- ^ raw authnreq
+                     -> TestSpar ( UserId
+                                 , SAML.ResponseVerdict
+                                 , URI                         -- ^ location header
+                                 , [(SBS, SBS)]                -- ^ query params
+                                 )
 requestAccessVerdict isGranted mkAuthnReq = do
   env <- ask
   let uid     = env ^. teUserId

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -343,7 +343,7 @@ requestAccessVerdict isGranted mkAuthnReq = do
     raw <- mkAuthnReq idpid
     bdy <- maybe (error "authreq") pure $ responseBody raw
     either (error . show) pure $ Servant.mimeUnrender (Servant.Proxy @SAML.HTML) bdy
-  spmeta <- getTestSPMetadata idpid
+  spmeta <- getTestSPMetadata
   authnresp <- liftIO $ do
     let mk :: SAML.FormRedirect SAML.AuthnRequest -> IO SAML.AuthnResponse
         mk (SAML.FormRedirect _ req) = do

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -25,6 +25,7 @@ import Data.UUID.V4 as UUID
 import Lens.Micro
 import SAML2.Util ((-/))
 import Spar.API
+import Spar.API.Types
 import Spar.API.Instances ()
 import Spar.API.Test (IntegrationTests)
 import Spar.Data as Data
@@ -279,8 +280,9 @@ clientPostRequest     Servant.:<|>
   clientPostVerdict
   = Servant.client (Servant.Proxy @IntegrationTests)
 
-clientGetAuthnRequest :: Maybe URI -> Maybe URI -> SAML.IdPId -> Servant.ClientM (SAML.FormRedirect SAML.AuthnRequest)
-clientGetAuthnRequest = Servant.client (Servant.Proxy @APIAuthReq)
+clientGetAuthnRequest :: Maybe URI -> Maybe URI -> SAML.IdPId
+                      -> Servant.ClientM (WithBindCookie (SAML.FormRedirect SAML.AuthnRequest))
+clientGetAuthnRequest = Servant.client (Servant.Proxy @APIAuthReq) Nothing
 
 
 runInsertUser :: TestEnv -> SAML.UserRef -> UserId -> Http ()

--- a/services/spar/test-integration/Test/Spar/Intra/BrigSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Intra/BrigSpec.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE QuasiQuotes         #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE ViewPatterns        #-}
+
+module Test.Spar.Intra.BrigSpec where
+
+import Prelude hiding (head)
+import Util
+
+
+spec :: SpecWith TestEnv
+spec = do
+  describe "user deletion between brig and spar" $ do
+    it "if a user gets deleted on brig, it will be deleted on spar as well." $ do
+      pending
+
+    it "if a user gets deleted on spar, it will be deleted on spar as well." $ do
+      pendingWith "or deactivated?  we should decide what we want here."

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -400,7 +400,7 @@ negotiateAuthnRequest = do
   resp :: ResponseLBS
     <- call $ get
            ( (env ^. teSpar)
-           . path (cs $ "/sso/initiate-login/" -/ (UUID.toText . fromIdPId . (^. SAML.idpId) $ idp))
+           . path (cs $ "/sso/initiate-login/" -/ (idPIdToST $ idp ^. SAML.idpId))
            . expect2xx
            )
   (_, authnreq) <- either error pure . parseAuthnReqResp $ cs <$> responseBody resp

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -401,8 +401,7 @@ getTestSPMetadata idpid = do
 createTestIdP :: (HasCallStack, MonadIO m, MonadReader TestEnv m)
               => m (UserId, TeamId, IdP)
 createTestIdP = do
-  issuer <- makeIssuer
-  let idpmeta = sampleIdPMetadata issuer [uri|http://requri.net/|]
+  idpmeta <- makeTestIdPMetadata
   env <- ask
   createTestIdPFrom idpmeta (env ^. teMgr) (env ^. teBrig) (env ^. teGalley) (env ^. teSpar)
 

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -419,7 +419,7 @@ negotiateAuthnRequest = negotiateAuthnRequest' id >>= \case
 isDeleteBindCookieHeader :: HasCallStack => Maybe SBS -> Bool
 isDeleteBindCookieHeader Nothing = True  -- we don't expect this, but it's ok if the implementation changes to it.
 isDeleteBindCookieHeader (Just txt)
-  | "Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=-1; Secure" `SBS.isSuffixOf` txt = True
+  | "Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=-1; Secure" `SBS.isInfixOf` txt = True
   | otherwise = error $ "unexpected bind cookie: " <> show txt
 
 hasDeleteBindCookieHeader :: HasCallStack => Bilge.Response a -> Bool
@@ -429,7 +429,7 @@ isSetBindCookieHeader :: HasCallStack => Maybe SBS -> Bool
 isSetBindCookieHeader Nothing = False
 isSetBindCookieHeader (Just (Web.parseSetCookie -> cky)) = and
   [ Web.setCookieName cky == "wire.com"
-  , maybe False ("/sso/finalize-login/" `SBS.isPrefixOf`) $ Web.setCookiePath cky
+  , maybe False ("/sso/finalize-login" `SBS.isPrefixOf`) $ Web.setCookiePath cky
   , Web.setCookieSecure cky
   , Web.setCookieSameSite cky == Just Web.sameSiteStrict
   ]
@@ -592,9 +592,9 @@ callIdpDelete' sparreq_ muid idpid = do
 
 -- | Look up 'UserId' under 'UserSSOId' on spar's cassandra directly.
 ssoToUidSpar :: (HasCallStack, MonadIO m, MonadReader TestEnv m) => Brig.UserSSOId -> m (Maybe UserId)
-ssoToUidSpar ssoref = do
-  ssoid <- either (error . ("could not parse UserRef: " <>)) pure $ Intra.fromUserSSOId ssoref
-  runSparCass $ Data.getUser ssoid
+ssoToUidSpar ssoid = do
+  ssoref <- either (error . ("could not parse UserRef: " <>)) pure $ Intra.fromUserSSOId ssoid
+  runSparCass $ Data.getUser ssoref
 
 runSparCass :: (HasCallStack, MonadIO m, MonadReader TestEnv m) => Client a -> m a
 runSparCass action = do

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -419,7 +419,7 @@ createTestIdPFrom metadata mgr brig galley spar = do
 isDeleteBindCookieHeader :: HasCallStack => Maybe SBS -> Bool
 isDeleteBindCookieHeader Nothing = True  -- we don't expect this, but it's ok if the implementation changes to it.
 isDeleteBindCookieHeader (Just txt)
-  | "Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=-1; Secure" `SBS.isInfixOf` txt = True
+  | "Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=-1" `SBS.isInfixOf` txt = True
   | otherwise = error $ "unexpected bind cookie: " <> show txt
 
 hasDeleteBindCookieHeader :: HasCallStack => Bilge.Response a -> Bool
@@ -428,7 +428,7 @@ hasDeleteBindCookieHeader = isDeleteBindCookieHeader . lookup "Set-Cookie" . res
 isSetBindCookieHeader :: HasCallStack => Maybe SBS -> Bool
 isSetBindCookieHeader Nothing = False
 isSetBindCookieHeader (Just (Web.parseSetCookie -> cky)) = and
-  [ Web.setCookieName cky == "wire.com"
+  [ Web.setCookieName cky == "zbind"
   , maybe False ("/sso/finalize-login" `SBS.isPrefixOf`) $ Web.setCookiePath cky
   , Web.setCookieSecure cky
   , Web.setCookieSameSite cky == Just Web.sameSiteStrict

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -86,7 +86,6 @@ import SAML2.WebSSO
 import SAML2.WebSSO.Test.Credentials
 import SAML2.WebSSO.Test.MockResponse
 import Spar.API.Types
-import Spar.Options as Options
 import Spar.Run
 import Spar.Types
 import System.Random (randomRIO)

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -152,10 +152,10 @@ destroyEnv _ = pure ()
 passes :: MonadIO m => m ()
 passes = liftIO $ True `shouldBe` True
 
-it :: (HasCallStack, m ~ IO)
+it :: HasCallStack
        -- or, more generally:
        -- MonadIO m, Example (TestEnv -> m ()), Arg (TestEnv -> m ()) ~ TestEnv
-   => String -> ReaderT TestEnv m () -> SpecWith TestEnv
+   => String -> TestSpar () -> SpecWith TestEnv
 it msg bdy = Test.Hspec.it msg $ runReaderT bdy
 
 pending :: (HasCallStack, MonadIO m) => m ()
@@ -355,7 +355,7 @@ endpointToURL endpoint urlpath = either err pure url
 -- spar specifics
 
 shouldRespondWith :: forall a. (HasCallStack, Show a, Eq a)
-                  => Http a -> (a -> Bool) -> ReaderT TestEnv IO ()
+                  => Http a -> (a -> Bool) -> TestSpar ()
 shouldRespondWith action proper = do
   resp <- call action
   liftIO $ resp `shouldSatisfy` proper

--- a/services/spar/test-integration/Util/Types.hs
+++ b/services/spar/test-integration/Util/Types.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TupleSections              #-}
@@ -21,6 +22,7 @@ module Util.Types
   , teBrig
   , teGalley
   , teSpar
+  , teSparCass
   , teUserId
   , teTeamId
   , teIdP
@@ -63,6 +65,7 @@ data TestEnv = TestEnv
   , _teBrig        :: BrigReq
   , _teGalley      :: GalleyReq
   , _teSpar        :: SparReq
+  , _teSparCass    :: ClientState
   , _teOpts        :: Opts               -- ^ spar config
   , _teTstOpts     :: IntegrationConfig  -- ^ integration test config
 

--- a/services/spar/test-integration/Util/Types.hs
+++ b/services/spar/test-integration/Util/Types.hs
@@ -16,6 +16,7 @@ module Util.Types
   ( BrigReq
   , GalleyReq
   , SparReq
+  , TestSpar
   , TestEnv(..)
   , teMgr
   , teCql
@@ -38,6 +39,7 @@ import Bilge
 import Cassandra as Cas
 import Control.Exception
 import Control.Monad
+import Control.Monad.Reader
 import Data.Aeson
 import Data.Aeson.TH
 import Data.Id
@@ -57,6 +59,8 @@ import qualified Data.Aeson as Aeson
 type BrigReq   = Request -> Request
 type GalleyReq = Request -> Request
 type SparReq   = Request -> Request
+
+type TestSpar = ReaderT TestEnv IO
 
 -- | See 'mkEnv' about what's in here.
 data TestEnv = TestEnv

--- a/services/spar/test-integration/Util/Types.hs
+++ b/services/spar/test-integration/Util/Types.hs
@@ -49,7 +49,6 @@ import GHC.Generics (Generic)
 import Lens.Micro.TH
 import SAML2.WebSSO.Types.TH (deriveJSONOptions)
 import Spar.API ()
-import Spar.Options as Options
 import Spar.Types
 import Util.Options
 

--- a/services/spar/test/Test/Spar/DataSpec.hs
+++ b/services/spar/test/Test/Spar/DataSpec.hs
@@ -14,7 +14,7 @@ module Test.Spar.DataSpec where
 import Data.Maybe
 import Data.Time
 import Spar.Data
-import Spar.Options
+import Spar.Types
 import Test.Hspec
 import SAML2.WebSSO (Time(Time), addTime)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -112,7 +112,7 @@ packages:
 # services/spar:
 - location:
     git: https://github.com/wireapp/saml2-web-sso
-    commit: f49da74e4a8792d8af450b9003624237f488a7ac
+    commit: 37c4bbe411b80afd4e0e07a30674263a5324f987
   extra-dep: true
 - location:
     git: https://github.com/wireapp/hsaml2

--- a/stack.yaml
+++ b/stack.yaml
@@ -112,7 +112,7 @@ packages:
 # services/spar:
 - location:
     git: https://github.com/wireapp/saml2-web-sso
-    commit: 37c4bbe411b80afd4e0e07a30674263a5324f987
+    commit: 2f12c737d8eb93574cb1fe311af27e96860f07f2
   extra-dep: true
 - location:
     git: https://github.com/wireapp/hsaml2

--- a/stack.yaml
+++ b/stack.yaml
@@ -112,7 +112,7 @@ packages:
 # services/spar:
 - location:
     git: https://github.com/wireapp/saml2-web-sso
-    commit: 2f12c737d8eb93574cb1fe311af27e96860f07f2
+    commit: 89901fd0cfb0ff1107fc811c2d4bcca0a2d21381
   extra-dep: true
 - location:
     git: https://github.com/wireapp/hsaml2

--- a/stack.yaml
+++ b/stack.yaml
@@ -112,7 +112,7 @@ packages:
 # services/spar:
 - location:
     git: https://github.com/wireapp/saml2-web-sso
-    commit: e4b1799f3cdd3942eb41d59b1db4610f60dbe7f3
+    commit: 36603c07c0a0e0c0e1bfb543869f051e814397c3
   extra-dep: true
 - location:
     git: https://github.com/wireapp/hsaml2

--- a/stack.yaml
+++ b/stack.yaml
@@ -112,7 +112,7 @@ packages:
 # services/spar:
 - location:
     git: https://github.com/wireapp/saml2-web-sso
-    commit: 89901fd0cfb0ff1107fc811c2d4bcca0a2d21381
+    commit: e4b1799f3cdd3942eb41d59b1db4610f60dbe7f3
   extra-dep: true
 - location:
     git: https://github.com/wireapp/hsaml2

--- a/stack.yaml
+++ b/stack.yaml
@@ -112,7 +112,7 @@ packages:
 # services/spar:
 - location:
     git: https://github.com/wireapp/saml2-web-sso
-    commit: 36603c07c0a0e0c0e1bfb543869f051e814397c3
+    commit: cb146eb14dadcf7016c83d0b4a849fb26cf0b3b9
   extra-dep: true
 - location:
     git: https://github.com/wireapp/hsaml2

--- a/stack.yaml
+++ b/stack.yaml
@@ -112,7 +112,7 @@ packages:
 # services/spar:
 - location:
     git: https://github.com/wireapp/saml2-web-sso
-    commit: cb146eb14dadcf7016c83d0b4a849fb26cf0b3b9
+    commit: 5758cb355a1a9956bb5d3ab2402f82b003a5a961
   extra-dep: true
 - location:
     git: https://github.com/wireapp/hsaml2


### PR DESCRIPTION
Also, some other improvements:

- new module Spar.API.Types
- fight potential race conditions with `Control.Retry`.
- improve integration tests
- fixes & cleanup

questions to the reviewer:

- Should brig worry about `UserSSOId` being unique?  Spar certainly does, perhaps that's enough?  If not, is there a thing we can do to the cassandra schema that'll do this?
- What happens if the user that gets its `UserSSOId` updated in brig does not exist?  What *should* happen?
