### PR TITLE
Script for registering IdPs in wire teams.

### DIFF
--- a/deploy/services-demo/register_idp.sh
+++ b/deploy/services-demo/register_idp.sh
@@ -8,7 +8,7 @@ set -e
 #
 # Usage:
 #   register_idp.sh idp-metadata.xml
-#   WIRE_TRACE=1 WIRE_BACKEND=prod-nginz-https.wire.com register_idp.sh idp-metadata.xml
+#   WIRE_TRACE=1 WIRE_BACKEND=our-wire-backend.example.com register_idp.sh idp-metadata.xml
 #
 # the script will prompt you for your wire login and password.  your
 # user needs to be a team admin, and the idp will be registered with
@@ -24,7 +24,7 @@ fi
 if [ -n "$WIRE_BACKEND" ]; then
     backend="$WIRE_BACKEND"
 else
-    backend="prod-nginz-https.wire.com"
+    backend="localhost:8080"
 fi
 
 if [ "$WIRE_TRACE" == "1" ]; then

--- a/deploy/services-demo/register_idp.sh
+++ b/deploy/services-demo/register_idp.sh
@@ -54,7 +54,7 @@ fi
 
 payload="{\"email\":\"$login\",\"password\":\"$password\"}"
 test -n "$trace" && echo "$curl_exe -is --show-error -XPOST https://$backend/login -H'Content-type: application/json' -d$payload"
-access_token=$($curl_exe -s --show-error -XPOST https://$backend/login -H'Content-type: application/json' -d$payload | jq -r .access_token)
+access_token=$($curl_exe -s --show-error -XPOST https://$backend/login -H'Content-type: application/json' -d$payload | $jq_exe -r .access_token)
 
 # register idp
 test -n "$trace" && echo "$curl_exe -is --show-error -XPOST https://$backend/identity-providers -H\"Authorization: Bearer $access_token\" -H'Content-type: application/xml' -d@\"$metadata_file\""

--- a/deploy/services-demo/register_idp.sh
+++ b/deploy/services-demo/register_idp.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -e
+
+#
+# This bash script can be used to register an idp service with a team
+# over the public backend API.
+#
+# Usage:
+#   register_idp.sh idp-metadata.xml
+#   WIRE_TRACE=1 WIRE_BACKEND=prod-nginz-https.wire.com register_idp.sh idp-metadata.xml
+#
+# the script will prompt you for your wire login and password.  your
+# user needs to be a team admin, and the idp will be registered with
+# that team.
+#
+
+metadata_file=$1
+if [ ! -e "$metadata_file" ]; then
+    echo "*** no metadata: '$1'"
+    exit 80
+fi
+
+if [ -n "$WIRE_BACKEND" ]; then
+    backend="$WIRE_BACKEND"
+else
+    backend="prod-nginz-https.wire.com"
+fi
+
+if [ "$WIRE_TRACE" == "1" ]; then
+    trace="1"
+fi
+
+which curl >/dev/null || ( echo "*** please install https://curl.haxx.se/ in your path."; exit 81 )
+curl_exe=`which curl`
+
+which jq >/dev/null || ( echo "*** please install https://stedolan.github.io/jq/ in your path."; exit 82 )
+jq_exe=`which jq`
+
+# login
+if [ -n "$WIRE_LOGIN" ]; then
+    login="$WIRE_LOGIN"
+else
+    echo -n "login email: "
+    read login
+fi
+
+if [ -n "$WIRE_PASSWORD" ]; then
+    password="$WIRE_PASSWORD"
+else
+    echo -n "password: "
+    stty -echo; read password; stty echo; echo
+fi
+
+payload="{\"email\":\"$login\",\"password\":\"$password\"}"
+test -n "$trace" && echo "$curl_exe -is --show-error -XPOST https://$backend/login -H'Content-type: application/json' -d$payload"
+access_token=$($curl_exe -s --show-error -XPOST https://$backend/login -H'Content-type: application/json' -d$payload | jq -r .access_token)
+
+# register idp
+test -n "$trace" && echo "$curl_exe -is --show-error -XPOST https://$backend/identity-providers -H\"Authorization: Bearer $access_token\" -H'Content-type: application/xml' -d@\"$metadata_file\""
+$curl_exe -is --show-error -XPOST https://$backend/identity-providers -H"Authorization: Bearer $access_token" -H'Content-type: application/xml' -d@"$metadata_file"


### PR DESCRIPTION
We can give this to customers until the admin settings pages support registering IdPs.

Tested on staging to the point where I got an expected error for the bad metadata I sent, and I have tested the rest in swagger successfully, so I'm assuming this will work.
