### PR TITLE
[WIP] New cassandra

### DIFF
--- a/libs/cassandra-util/src/Cassandra/Exec.hs
+++ b/libs/cassandra-util/src/Cassandra/Exec.hs
@@ -53,9 +53,7 @@ import Control.Exception (IOException)
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
-import Control.Monad.IO.Unlift
 import Control.Monad.Reader
-import Control.Monad.Trans.Class
 import Control.Retry
 import Data.Conduit
 import Data.Int

--- a/libs/cassandra-util/src/Cassandra/Exec.hs
+++ b/libs/cassandra-util/src/Cassandra/Exec.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-{-# OPTIONS_GHC -Wno-orphans #-} -- for MonadUnliftIO Client
-
 module Cassandra.Exec
     ( Client
     , MonadClient    (..)
@@ -111,8 +109,3 @@ paginateC q p r = go =<< lift (retry r (paginate q p))
             yield (result page)
         when (hasMore page) $
             go =<< lift (retry r (liftClient (nextPage page)))
-
-instance MonadUnliftIO Client where
-    askUnliftIO = do
-        env <- ask
-        pure $ UnliftIO (runClient env)

--- a/libs/cassandra-util/src/Cassandra/Schema.hs
+++ b/libs/cassandra-util/src/Cassandra/Schema.hs
@@ -40,7 +40,7 @@ import Data.Time.Clock
 import Data.UUID (UUID)
 import Data.Word
 import Database.CQL.IO
-import Database.CQL.Protocol (Request (..), Query (..), Response(..), Result (..))
+import Database.CQL.Protocol (Request (..), Query (..))
 import GHC.Generics hiding (to, from, S, R)
 import Options.Applicative hiding (info)
 import Prelude hiding (log)
@@ -141,8 +141,7 @@ useKeyspace (Keyspace k) = void . getResult =<< qry
 
 migrateSchema :: Logger -> MigrationOpts -> [Migration] -> IO ()
 migrateSchema l o ms = do
-    -- if migHost is a DNS name, resolve it and connect to all nodes
-    hosts <- initialContactsDNS $ pack (migHost o)
+    hosts <- initialContactsPlain $ pack (migHost o)
     p <- Database.CQL.IO.init l $
             setContacts (NonEmpty.head hosts) (NonEmpty.tail hosts)
           . setPortNumber (fromIntegral $ migPort o)

--- a/libs/cassandra-util/src/Cassandra/Schema.hs
+++ b/libs/cassandra-util/src/Cassandra/Schema.hs
@@ -133,16 +133,11 @@ createKeyspace (Keyspace k) rs = void $ schema (cql rs) (params All ())
     pair (dc, ReplicationFactor n) = "'" <> dc <> "': " <> pack (show n)
 
 useKeyspace :: Keyspace -> Client ()
-useKeyspace (Keyspace k) = do
-    r <- qry
-    case r of
-        RsResult _ (SetKeyspaceResult _) -> return ()
-        RsError _ e                      -> throwM e
-        _                                -> throwM (UnexpectedResponse' r)
+useKeyspace (Keyspace k) = void . getResult =<< qry
   where
-    qry  = request (RqQuery (Query cql prms)) :: Client (Response () () ())
-    prms = QueryParams One False () Nothing Nothing Nothing
-    cql  = QueryString $ "use \"" <> fromStrict k <> "\""
+    qry  = request (RqQuery (Query cql prms)) :: Client (HostResponse () () ())
+    prms = QueryParams One False () Nothing Nothing Nothing Nothing
+    cql = QueryString $ "use \"" <> fromStrict k <> "\""
 
 migrateSchema :: Logger -> MigrationOpts -> [Migration] -> IO ()
 migrateSchema l o ms = do

--- a/libs/cassandra-util/src/Cassandra/Settings.hs
+++ b/libs/cassandra-util/src/Cassandra/Settings.hs
@@ -33,7 +33,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.Monoid
 import Data.Text (pack, stripSuffix, unpack, Text)
 import Data.Text.Encoding (encodeUtf8)
-import Database.CQL.IO
+import Database.CQL.IO hiding (values)
 import Network.DNS.Lookup
 import Network.DNS.Resolver
 import Network.Wreq
@@ -75,4 +75,4 @@ initialContactsDNS address = liftIO $ do
 
 -- | Puts the address into a list using the same signature as the other initalContacts
 initialContactsPlain :: MonadIO m => Text -> m (NonEmpty String)
-initialContactsPlain address = liftIO $ unpack address :| []
+initialContactsPlain address = pure $ unpack address :| []

--- a/libs/cassandra-util/src/Cassandra/Settings.hs
+++ b/libs/cassandra-util/src/Cassandra/Settings.hs
@@ -73,6 +73,6 @@ initialContactsDNS address = liftIO $ do
   where
     fallback = unpack address :| [] -- If it's not a valid DNS name, just try using it anyway
 
--- | Puts the address into a list using the same signature as the other initalContacts
+-- | Puts the address into a list using the same signature as the other initialContacts
 initialContactsPlain :: MonadIO m => Text -> m (NonEmpty String)
 initialContactsPlain address = pure $ unpack address :| []

--- a/libs/cassandra-util/src/Cassandra/Settings.hs
+++ b/libs/cassandra-util/src/Cassandra/Settings.hs
@@ -39,6 +39,10 @@ import Network.Wreq
 
 import qualified Data.List.NonEmpty as NE
 
+-- | This function is likely only useful at Wire, as it is AWS/describe-instances specific.
+-- Given a server name and a url returning a wire-custom "disco" json (AWS describe-instances-like json), e.g.
+-- { "roles" : { "server_name": [ {...}, {...} ] } },
+-- return a list of IP addresses.
 initialContactsDisco :: MonadIO m => String -> String -> m (NonEmpty String)
 initialContactsDisco (pack -> srv) url = liftIO $ do
     rs <- asValue =<< get url
@@ -57,6 +61,7 @@ initialContactsDisco (pack -> srv) url = liftIO $ do
         i:ii -> return (i :| ii)
         _    -> error "initial-contacts: no IP addresses found."
 
+-- | Given a DNS name or single IP, return a list of IP addresses.
 initialContactsDNS :: MonadIO m => Text -> m (NonEmpty String)
 initialContactsDNS address = liftIO $ do
     rs  <- makeResolvSeed defaultResolvConf

--- a/libs/extended/extended.cabal
+++ b/libs/extended/extended.cabal
@@ -21,14 +21,13 @@ library
     ghc-options:      -Wall -O2 -fwarn-tabs
 
     exposed-modules:
-        Control.Concurrent.Async.Lifted.Safe.Extended
+        UnliftIO.Async.Extended
         Options.Applicative.Extended
 
     build-depends:
         base
       , base-prelude
       , async-pool
-      , lifted-async
-      , unliftio-core
+      , unliftio
       , optparse-applicative
       , extra

--- a/libs/extended/src/UnliftIO/Async/Extended.hs
+++ b/libs/extended/src/UnliftIO/Async/Extended.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
--- | A version of "Control.Concurrent.Async.Lifted.Safe" with extra utilities.
-module Control.Concurrent.Async.Lifted.Safe.Extended
-    ( module Control.Concurrent.Async.Lifted.Safe
+-- | A version of "UnliftIO.Async" with extra utilities.
+module UnliftIO.Async.Extended
+    ( module UnliftIO.Async
     -- * Pooled functions (using at most T threads)
     , forPooled
     , mapMPooled
@@ -12,8 +12,8 @@ module Control.Concurrent.Async.Lifted.Safe.Extended
     , sequencePooled
     ) where
 
-import Control.Monad.IO.Unlift
-import Control.Concurrent.Async.Lifted.Safe
+import UnliftIO
+import UnliftIO.Async
 
 import qualified Control.Concurrent.Async.Pool as Pool
 

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -421,3 +421,4 @@ executable brig-integration
       , warp-tls              >= 3.2
       , zauth
       , yaml                  >= 0.8.22
+      , unliftio

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -275,9 +275,9 @@ turnSetup lgr w dig o = do
 startWatching :: FS.WatchManager -> FilePath -> FS.Action -> IO ()
 startWatching w p = void . FS.watchDir w (Path.dropFileName p) predicate
   where
-    predicate (FS.Added f _)    = Path.equalFilePath f p
-    predicate (FS.Modified f _) = Path.equalFilePath f p
-    predicate (FS.Removed _ _)  = False
+    predicate (FS.Added f _ _)    = Path.equalFilePath f p
+    predicate (FS.Modified f _ _) = Path.equalFilePath f p
+    predicate (FS.Removed _ _ _)  = False
 
 replaceGeoDb :: Logger -> IORef GeoIp.GeoDB -> FS.Event -> IO ()
 replaceGeoDb g ref e = do

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -278,6 +278,7 @@ startWatching w p = void . FS.watchDir w (Path.dropFileName p) predicate
     predicate (FS.Added f _ _)    = Path.equalFilePath f p
     predicate (FS.Modified f _ _) = Path.equalFilePath f p
     predicate (FS.Removed _ _ _)  = False
+    predicate (FS.Unknown _ _ _)  = False
 
 replaceGeoDb :: Logger -> IORef GeoIp.GeoDB -> FS.Event -> IO ()
 replaceGeoDb g ref e = do
@@ -360,7 +361,7 @@ initExtGetManager = do
 
 initCassandra :: Opts -> Logger -> IO Cas.ClientState
 initCassandra o g = do
-    c <- maybe (Cas.initialContactsDNS ((Opt.cassandra o)^.casEndpoint.epHost))
+    c <- maybe (Cas.initialContactsPlain ((Opt.cassandra o)^.casEndpoint.epHost))
                (Cas.initialContactsDisco "cassandra_brig")
                (unpack <$> Opt.discoUrl o)
     p <- Cas.init (Log.clone (Just "cassandra.brig") g)

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -35,7 +35,6 @@ import Brig.Data.User (AuthError (..), ReAuthError (..))
 import Brig.Types
 import Brig.Types.User.Auth (CookieLabel)
 import Cassandra hiding (Client)
-import Control.Concurrent.Async.Lifted.Safe (mapConcurrently)
 import Control.Error
 import Control.Lens
 import Control.Monad
@@ -56,6 +55,7 @@ import Data.Word
 import Safe (readMay)
 import System.CryptoBox (Result (Success))
 import System.Logger.Class (field, msg, val)
+import UnliftIO (mapConcurrently)
 
 import qualified Brig.Data.User         as User
 import qualified Control.Exception.Lens as EL

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -24,7 +24,7 @@ import Brig.Types.Intra
 import Cassandra
 import Control.Monad
 import Control.Monad.IO.Class
-import Control.Concurrent.Async.Lifted.Safe.Extended (mapMPooled)
+import UnliftIO.Async.Extended (mapMPooled)
 import Data.Conduit ((.|), runConduit)
 import Data.Functor.Identity
 import Data.Id

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -30,7 +30,7 @@ import Brig.Types.Client
 import Brig.Types.User (publicProfile, User (..), Pict (..))
 import Brig.Types.Provider
 import Brig.Types.Search
-import Control.Concurrent.Async.Lifted.Safe.Extended (mapMPooled)
+import UnliftIO.Async.Extended (mapMPooled)
 import Control.Lens (view, (^.))
 import Control.Error (throwE)
 import Control.Exception.Enclosed (handleAny)

--- a/services/brig/src/Brig/Provider/DB.hs
+++ b/services/brig/src/Brig/Provider/DB.hs
@@ -12,7 +12,6 @@ import Brig.Types.Common
 import Brig.Types.Provider hiding (updateServiceTags)
 import Cassandra
 import Control.Arrow ((&&&))
-import Control.Concurrent.Async.Lifted.Safe (mapConcurrently)
 import Control.Monad (when)
 import Control.Monad.IO.Class
 import Data.Foldable (for_, toList)
@@ -26,6 +25,7 @@ import Data.Maybe (isJust, catMaybes, fromMaybe, mapMaybe)
 import Data.Misc
 import Data.Range (Range, fromRange, rnil, rcast)
 import Data.Text (Text, toLower, isPrefixOf)
+import UnliftIO (mapConcurrently)
 
 import qualified Data.Set as Set
 import qualified Data.Text as Text

--- a/services/brig/src/Brig/Team/DB.hs
+++ b/services/brig/src/Brig/Team/DB.hs
@@ -29,7 +29,7 @@ import Brig.Types.Common
 import Brig.Types.User
 import Brig.Types.Team.Invitation
 import Cassandra
-import Control.Concurrent.Async.Lifted.Safe.Extended (mapMPooled)
+import UnliftIO.Async.Extended (mapMPooled)
 import Control.Lens
 import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -6,7 +6,6 @@ import API.Search.Util
 import Bilge
 import Brig.Types
 import Control.Concurrent              (threadDelay)
-import Control.Concurrent.Async.Lifted.Safe
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Foldable
@@ -15,6 +14,7 @@ import Network.HTTP.Client             (Manager)
 import Test.Tasty
 import Test.Tasty.HUnit
 import Util
+import UnliftIO (Concurrently(..), runConcurrently)
 
 tests :: Manager -> Brig -> IO TestTree
 tests mgr brig =

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -16,7 +16,7 @@ import Brig.Types.User.Auth
 import Brig.Types.Intra
 import Control.Arrow ((&&&))
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async.Lifted.Safe.Extended
+import UnliftIO.Async.Extended
     (mapConcurrently_, replicateConcurrently, forPooled, replicatePooled)
 import Control.Lens ((^.), view)
 import Control.Monad

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -17,7 +17,6 @@ import Brig.Types.Intra
 import Brig.Types.User.Auth hiding (user)
 import Control.Arrow ((&&&))
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async.Lifted.Safe (mapConcurrently_)
 import Control.Lens ((^?), (^.))
 import Control.Monad
 import Control.Monad.Catch
@@ -45,6 +44,7 @@ import Test.Tasty.HUnit
 import Web.Cookie (parseSetCookie)
 import Util as Util
 import Util.AWS as Util
+import UnliftIO (mapConcurrently_)
 
 import qualified API.Search.Util             as Search
 import qualified Brig.AWS                    as AWS

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -10,7 +10,7 @@ import Brig.Types.User
 import Brig.Types.User.Auth
 import Brig.ZAuth (ZAuth, runZAuth)
 import Control.Concurrent
-import Control.Concurrent.Async.Lifted.Safe.Extended hiding (wait)
+import UnliftIO.Async.Extended hiding (wait)
 import Control.Lens ((^?), set)
 import Control.Monad
 import Control.Monad.IO.Class

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -10,7 +10,6 @@ import Bilge hiding (accept, timeout)
 import Bilge.Assert
 import Brig.Types
 import Brig.Types.User.Auth hiding (user)
-import Control.Concurrent.Async.Lifted.Safe (mapConcurrently)
 import Control.Lens ((^?), preview)
 import Control.Monad
 import Control.Monad.IO.Class
@@ -27,6 +26,7 @@ import Test.Tasty hiding (Timeout)
 import Test.Tasty.Cannon hiding (Cannon)
 import Test.Tasty.HUnit
 import Util
+import UnliftIO (mapConcurrently)
 
 import qualified Brig.Options                as Opt
 import qualified Data.List1                  as List1

--- a/services/brig/test/integration/API/User/Handles.hs
+++ b/services/brig/test/integration/API/User/Handles.hs
@@ -9,7 +9,6 @@ import API.User.Util
 import Bilge hiding (accept, timeout)
 import Bilge.Assert
 import Brig.Types
-import Control.Concurrent.Async.Lifted.Safe (mapConcurrently)
 import Control.Lens ((^?), (^?!))
 import Control.Monad
 import Control.Monad.IO.Class
@@ -23,6 +22,7 @@ import Test.Tasty hiding (Timeout)
 import Test.Tasty.Cannon hiding (Cannon)
 import Test.Tasty.HUnit
 import Util
+import UnliftIO (mapConcurrently)
 
 import qualified API.Search.Util             as Search
 import qualified Brig.Options                as Opt

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -244,6 +244,7 @@ executable galley-integration
       , wai-utilities
       , warp
       , yaml
+      , unliftio
 
 executable galley-journaler
     main-is:            Main.hs
@@ -279,6 +280,7 @@ executable galley-journaler
       , bytestring
       , uuid
       , ssl-util
+      , unliftio
 
     other-modules:
         Journal

--- a/services/galley/journaler/src/Journal.hs
+++ b/services/galley/journaler/src/Journal.hs
@@ -6,7 +6,6 @@
 module Journal where
 
 import Cassandra as C
-import Control.Concurrent.Async.Lifted.Safe (mapConcurrently)
 import Control.Lens
 import Control.Monad.Except
 import Data.Id
@@ -20,6 +19,7 @@ import Proto.TeamEvents
 import Galley.Types.Teams (TeamCreationTime (..), tcTime)
 import Galley.Types.Teams.Intra
 import System.Logger (Logger)
+import UnliftIO (mapConcurrently)
 
 import qualified System.Logger        as Log
 import qualified Galley.Data          as Data

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -11,7 +11,6 @@ import Control.Lens (view, (&), (.~))
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
-import Control.Concurrent.Async.Lifted.Safe
 import Data.ByteString.Conversion
 import Data.Id
 import Data.Foldable (find, for_, toList)
@@ -30,6 +29,7 @@ import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Predicate
 import Network.Wai.Utilities
+import UnliftIO (concurrently)
 
 import qualified Data.Text.Lazy as LT
 import qualified Galley.Data    as Data

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -141,7 +141,7 @@ createEnv m o = do
 
 initCassandra :: Opts -> Logger -> IO ClientState
 initCassandra o l = do
-    c <- maybe (C.initialContactsDNS (o^.optCassandra.casEndpoint.epHost))
+    c <- maybe (C.initialContactsPlain (o^.optCassandra.casEndpoint.epHost))
                (C.initialContactsDisco "cassandra_galley")
                (unpack <$> o^.optDiscoUrl)
     C.init (Logger.clone (Just "cassandra.galley") l) $

--- a/services/galley/src/Galley/External.hs
+++ b/services/galley/src/Galley/External.hs
@@ -6,7 +6,6 @@ module Galley.External (deliver) where
 
 import Bilge.Request
 import Bilge.Retry (httpHandlers)
-import Control.Concurrent.Async.Lifted.Safe
 import Control.Exception (fromException)
 import Control.Lens
 import Control.Monad
@@ -26,6 +25,7 @@ import Network.HTTP.Types.Status (status410)
 import Ssl.Util (withVerifiedSslConnection)
 import System.Logger.Message (msg, val, field, (~~))
 import URI.ByteString
+import UnliftIO (async, Async, waitCatch)
 
 import qualified Network.HTTP.Client          as Http
 import qualified Galley.Data.Services         as Data

--- a/services/galley/src/Galley/Intra/Push.hs
+++ b/services/galley/src/Galley/Intra/Push.hs
@@ -42,8 +42,6 @@ import Galley.App
 import Galley.Options
 import Galley.Types
 import Control.Applicative
-import Control.Concurrent.Async.Lifted.Safe (mapConcurrently)
-import Control.Concurrent.Lifted (fork)
 import Control.Lens (makeLenses, set, view, (.~), (&), (^.))
 import Control.Monad.Catch
 import Control.Monad (void, (>=>))
@@ -63,8 +61,10 @@ import Data.Text.Encoding (encodeUtf8)
 import Network.HTTP.Types.Method
 import Safe (headDef, tailDef)
 import System.Logger.Class hiding (new)
-import Prelude hiding (mapM_, foldr)
+import Prelude hiding (foldr)
 import Util.Options
+import UnliftIO (mapConcurrently)
+import UnliftIO.Concurrent (forkIO)
 
 import qualified Data.Set               as Set
 import qualified Data.Text.Lazy         as LT
@@ -190,7 +190,7 @@ gundeckReq ps = do
         . expect2xx
 
 callAsync :: LT.Text -> (Request -> Request) -> Galley ()
-callAsync n r = void . fork $ void (call n r) `catches` handlers
+callAsync n r = void . forkIO $ void (call n r) `catches` handlers
   where
     handlers =
         [ Handler $ \(x :: RPCException)  -> err (rpcExceptionMsg x)
@@ -202,4 +202,3 @@ call n r = recovering x3 rpcHandlers (const (rpc n r))
 
 x3 :: RetryPolicy
 x3 = limitRetries 3 <> exponentialBackoff 100000
-

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -27,9 +27,9 @@ import Test.Tasty
 import Test.Tasty.Cannon (Cannon, TimeoutUnit (..), (#))
 import Test.Tasty.HUnit
 import API.SQS
+import UnliftIO (mapConcurrently_)
 
 import qualified API.Util as Util
-import qualified Control.Concurrent.Async.Lifted.Safe as AsyncSafe
 import qualified Data.Currency as Currency
 import qualified Data.List1 as List1
 import qualified Data.Set as Set
@@ -220,7 +220,7 @@ testAddTeamMember g b c _ = do
     WS.bracketRN c [owner, (mem1^.userId), (mem2^.userId), (mem3^.userId)] $ \[wsOwner, wsMem1, wsMem2, wsMem3] -> do
         -- `mem2` has `AddTeamMember` permission
         Util.addTeamMember g (mem2^.userId) tid mem3
-        AsyncSafe.mapConcurrently_ (checkTeamMemberJoin tid (mem3^.userId)) [wsOwner, wsMem1, wsMem2, wsMem3]
+        mapConcurrently_ (checkTeamMemberJoin tid (mem3^.userId)) [wsOwner, wsMem1, wsMem2, wsMem3]
 
 testAddTeamMemberCheckBound :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
 testAddTeamMemberCheckBound g b _ a = do
@@ -300,7 +300,7 @@ testRemoveTeamMember g b c _ = do
         -- Ensure that `mem1` is still a user (tid is not a binding team)
         Util.ensureDeletedState b False owner (mem1^.userId)
 
-        AsyncSafe.mapConcurrently_ (checkTeamMemberLeave tid (mem1^.userId)) [wsOwner, wsMem1, wsMem2]
+        mapConcurrently_ (checkTeamMemberLeave tid (mem1^.userId)) [wsOwner, wsMem1, wsMem2]
         checkConvMemberLeaveEvent cid2 (mem1^.userId) wsMext1
         checkConvMemberLeaveEvent cid3 (mem1^.userId) wsMext3
         WS.assertNoEvent timeout ws

--- a/services/gundeck/src/Gundeck/Client.hs
+++ b/services/gundeck/src/Gundeck/Client.hs
@@ -10,7 +10,6 @@ module Gundeck.Client
     ) where
 
 import Imports
-import Control.Concurrent.Async.Lifted.Safe
 import Control.Lens (view, (^.), set)
 import Control.Monad.Catch
 import Data.Id
@@ -21,6 +20,7 @@ import Gundeck.Util
 import Network.HTTP.Types
 import Network.Wai (Request, Response)
 import Network.Wai.Utilities
+import UnliftIO (mapConcurrently)
 
 import qualified Gundeck.Client.Data       as Clients
 import qualified Gundeck.Notification.Data as Notifications

--- a/services/gundeck/src/Gundeck/Env.hs
+++ b/services/gundeck/src/Gundeck/Env.hs
@@ -51,7 +51,7 @@ schemaVersion = 7
 createEnv :: Metrics -> Opts -> IO Env
 createEnv m o = do
     l <- new $ setOutput StdOut . setFormat Nothing $ defSettings
-    c <- maybe (C.initialContactsDNS (o^.optCassandra.casEndpoint.epHost))
+    c <- maybe (C.initialContactsPlain (o^.optCassandra.casEndpoint.epHost))
                (C.initialContactsDisco "cassandra_gundeck")
                (unpack <$> o^.optDiscoUrl)
     n <- newManager tlsManagerSettings

--- a/services/gundeck/src/Gundeck/Notification/Data.hs
+++ b/services/gundeck/src/Gundeck/Notification/Data.hs
@@ -14,15 +14,14 @@ module Gundeck.Notification.Data
 
 import Imports hiding (Set)
 import Cassandra
-import Control.Concurrent.Async.Lifted.Safe (mapConcurrently, Forall, Pure)
 import Control.Lens ((^.), _1)
-import Control.Monad.Trans.Control
 import Data.Id
 import Data.List1 (List1)
 import Data.Range (Range, fromRange)
 import Data.Sequence (Seq, (><), (<|), ViewL (..), ViewR (..))
 import Gundeck.Types.Notification
 import Gundeck.Options (NotificationTTL (..))
+import UnliftIO (mapConcurrently)
 
 import qualified Data.Aeson      as JSON
 import qualified Data.List.Extra as List
@@ -40,7 +39,7 @@ data ResultPage = ResultPage
         -- iff a start ID ('since') has been given which could not be found.
     }
 
-add :: (MonadClient m, MonadBaseControl IO m, Forall (Pure m))
+add :: (MonadClient m, MonadUnliftIO m)
     => NotificationId
     -> List1 NotificationTarget
     -> List1 JSON.Object

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -17,8 +17,6 @@ module Gundeck.Push
 
 import Imports
 import Control.Arrow ((&&&))
-import Control.Concurrent.Async.Lifted.Safe (async, wait)
-import Control.Concurrent.Lifted (fork)
 import Control.Error
 import Control.Exception (ErrorCall(ErrorCall))
 import Control.Lens ((^.), (.~), (%~), _2, view, set)
@@ -39,6 +37,8 @@ import Network.HTTP.Types
 import Network.Wai (Request, Response)
 import Network.Wai.Utilities
 import System.Logger.Class (msg, (.=), (~~), val, (+++))
+import UnliftIO (async, wait)
+import UnliftIO.Concurrent (forkIO)
 
 import qualified Data.List.Extra              as List
 import qualified Data.Sequence                as Seq
@@ -90,7 +90,7 @@ pushAny' p = do
     let tgts  = mkTarget <$> uniq
     unless (p^.pushTransient) $
         Stream.add i tgts pload =<< view (options.optSettings.setNotificationTTL)
-    void . fork $ do
+    void . forkIO $ do
         prs <- Web.push notif tgts (p^.pushOrigin) (p^.pushOriginConnection) (p^.pushConnections)
         pushNative sendNotice notif p =<< nativeTargets p prs
   where

--- a/services/gundeck/src/Gundeck/Push/Native.hs
+++ b/services/gundeck/src/Gundeck/Push/Native.hs
@@ -8,8 +8,6 @@ module Gundeck.Push.Native
     ) where
 
 import Imports
-import Control.Concurrent.Async.Lifted.Safe
-import Control.Exception.Enclosed (handleAny)
 import Control.Lens ((^.), view, (.~))
 import Control.Monad.Catch
 import Data.ByteString.Conversion.To
@@ -25,6 +23,7 @@ import Gundeck.Types
 import Gundeck.Util
 import Network.AWS.Data (toText)
 import System.Logger.Class (MonadLogger, (~~), msg, val, field)
+import UnliftIO (mapConcurrently, handleAny)
 
 import qualified Data.Set                  as Set
 import qualified Data.Text                 as Text

--- a/services/gundeck/src/Gundeck/Util.hs
+++ b/services/gundeck/src/Gundeck/Util.hs
@@ -4,22 +4,16 @@
 
 module Gundeck.Util where
 
-import Control.Concurrent.Async.Lifted.Safe
-import Control.Monad ((<=<))
+import Imports
 import Control.Monad.Catch
-import Control.Monad.IO.Class
-import Control.Monad.Trans.Control
 import Control.Retry
 import Data.Id
-import Data.Maybe (isNothing)
-import Data.Monoid ((<>))
-import Data.Traversable (mapM)
 import Data.UUID.V1
 import Gundeck.Types.Notification
 import Network.HTTP.Types.Status
 import Network.Wai.Predicate.MediaType (Media)
 import Network.Wai.Utilities
-import Prelude hiding (mapM)
+import UnliftIO (async, waitCatch)
 
 type JSON = Media "application" "json"
 
@@ -32,7 +26,7 @@ mkNotificationId = do
     fun = const (return . isNothing)
     err = Error status500 "internal-error" "unable to generate notification ID"
 
-mapAsync :: (MonadBaseControl IO m, Traversable t, Forall (Pure m))
+mapAsync :: (MonadUnliftIO m, Traversable t)
          => (a -> m b)
          -> t a
          -> m (t (Either SomeException b))

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -54,7 +54,7 @@ import qualified System.Logger as Log
 initCassandra :: Opts -> Logger -> IO ClientState
 initCassandra opts lgr = do
     connectString <- maybe
-               (Cas.initialContactsDNS (Types.cassandra opts ^. casEndpoint . epHost))
+               (Cas.initialContactsPlain (Types.cassandra opts ^. casEndpoint . epHost))
                (Cas.initialContactsDisco "cassandra_spar")
                (cs <$> Types.discoUrl opts)
     cas <- Cas.init (Log.clone (Just "cassandra.spar") lgr) $ Cas.defSettings

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,6 +36,12 @@ packages:
 - tools/db/service-backfill
 - tools/db/auto-whitelist
 
+  # For the changes from https://gitlab.com/twittner/cql-io/merge_requests/14
+- location:
+    git: https://gitlab.com/twittner/cql-io.git
+    commit: 736ed643858e8301943ecfab7fdb00c3626e4c31
+  extra-dep: true
+
 - location:
     git: https://github.com/tiago-loureiro/haskell-multihash.git
     commit: 7622cfcff97fa1e207ec91bb11495a207e6c0195
@@ -124,8 +130,13 @@ packages:
   extra-dep: true
 
 extra-deps:
+- async-2.2.1
+- lifted-async-0.10.0.3
+- hinotify-0.4
+- fsnotify-0.3.0.1
 - base-prelude-1.3
 - base58-bytestring-0.1.0
+- cql-4.0.1
 - currency-codes-2.0.0.0
 - data-timeout-0.3
 - geoip2-0.3.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,11 +36,11 @@ packages:
 - tools/db/service-backfill
 - tools/db/auto-whitelist
 
-  # cql-io 1.0.1 plus the changes from
+  # cql-io 1.1.0 (unreleased), includes the changes from
   # https://gitlab.com/twittner/cql-io/merge_requests/14
 - location:
     git: https://gitlab.com/twittner/cql-io.git
-    commit: 736ed643858e8301943ecfab7fdb00c3626e4c31
+    commit: 8b91d053c469887a427e8c075cef43139fa189c4
   extra-dep: true
 
 - location:

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,7 +36,8 @@ packages:
 - tools/db/service-backfill
 - tools/db/auto-whitelist
 
-  # For the changes from https://gitlab.com/twittner/cql-io/merge_requests/14
+  # cql-io 1.0.1 plus the changes from
+  # https://gitlab.com/twittner/cql-io/merge_requests/14
 - location:
     git: https://gitlab.com/twittner/cql-io.git
     commit: 736ed643858e8301943ecfab7fdb00c3626e4c31

--- a/tools/api-simulations/api-simulations.cabal
+++ b/tools/api-simulations/api-simulations.cabal
@@ -75,6 +75,7 @@ executable api-smoketest
       , types-common         >= 0.11
       , unordered-containers >= 0.2
       , uuid                 >= 1.3
+      , unliftio
 
 executable api-loadtest
     default-language:   Haskell2010

--- a/tools/api-simulations/loadtest/src/Network/Wire/Simulations/LoadTest.hs
+++ b/tools/api-simulations/loadtest/src/Network/Wire/Simulations/LoadTest.hs
@@ -5,7 +5,7 @@
 module Network.Wire.Simulations.LoadTest where
 
 import Control.Concurrent
-import Control.Concurrent.Async.Lifted.Safe.Extended as Async
+import UnliftIO.Async.Extended as Async
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Id (ConvId)
@@ -250,4 +250,3 @@ postAssetTime = Metrics.path "post-asset.time"
 
 between :: MonadBotNet m => Int -> Int -> m Int
 between x y = getGen >>= liftIO . MWC.uniformR (max 0 x, max x y)
-

--- a/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
+++ b/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
@@ -5,7 +5,6 @@
 
 module Network.Wire.Simulations.SmokeTest (mainBotNet) where
 
-import Control.Concurrent.Async.Lifted.Safe
 import Control.Monad (void)
 import Data.ByteString (ByteString)
 import Data.Foldable (for_)
@@ -26,6 +25,7 @@ import Network.Wire.Client.API.Push
 import Network.Wire.Client.API.Search
 import Network.Wire.Client.API.User
 import System.Logger.Class
+import UnliftIO (mapConcurrently)
 
 import qualified Codec.MIME.Type          as MIME
 import qualified Data.ByteString.Lazy     as LBS
@@ -262,4 +262,3 @@ awaitOtrMsg cnv from to = do
 
 decryptTextMsg :: BotClient -> ConvEvent OtrMessage -> BotSession Text
 decryptTextMsg cl bs = decryptMessage cl bs >>= requireTextMsg
-

--- a/tools/db/auto-whitelist/src/Work.hs
+++ b/tools/db/auto-whitelist/src/Work.hs
@@ -15,7 +15,7 @@ import Data.Id
 import Data.Maybe
 import System.Logger (Logger)
 import Data.Functor.Identity
-import Control.Concurrent.Async.Lifted.Safe.Extended (mapMPooled)
+import UnliftIO.Async.Extended (mapMPooled)
 import Data.List.Extra (nubOrd)
 
 import qualified System.Logger as Log

--- a/tools/db/service-backfill/src/Work.hs
+++ b/tools/db/service-backfill/src/Work.hs
@@ -15,7 +15,7 @@ import Data.Id
 import Data.Int
 import System.Logger (Logger)
 import Data.Functor.Identity
-import Control.Concurrent.Async.Lifted.Safe.Extended (mapMPooled)
+import UnliftIO.Async.Extended (mapMPooled)
 import Data.Conduit
 import Data.Conduit.Internal (zipSources)
 import qualified Data.Conduit.List as C


### PR DESCRIPTION
Upgrade to the lastest `cql-io`. There are multiple reasons for upgrading, see [the changelog](https://gitlab.com/twittner/cql-io/blob/develop/CHANGELOG#L1-23). 

One reason is to try out the changes from [this MR](https://gitlab.com/twittner/cql-io/merge_requests/14) relating to the problem described [here](https://gitlab.com/twittner/cql-io/issues/21). To this end, `initialContactsDNS` is no longer used, so that cql-io can re-resolve the DNS upon losing a control connection.

TODO: This PR is marked as WIP since the changes to [the retry policies](https://gitlab.com/twittner/cql-io/issues/13) should get another look. Instead of our `x1` and `x5` retry policies used everywhere, perhaps we should switch to `defRetrySettings` and `eagerRetrySettings`. `eagerRetryHandlers`, however:
> -- are only safe to use for idempotent
> -- queries, or if a duplicate write has no severe consequences in
> -- the context of the application's data model.

Side-effects:

* switch from `MonadBaseControl` and `Control.Concurrent.*` to `UnliftIO.*` everywhere (thanks @neongreen).