### PR TITLE
Fix: URI path for initiate-bind.

### DIFF
--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -329,6 +329,11 @@ http {
       proxy_pass http://spar;
     }
 
+    location /sso-initiate-bind {
+      include common_response_with_zauth.conf;
+      proxy_pass http://spar;
+    }
+
     location /identity-providers {
       include common_response_with_zauth.conf;
       proxy_pass http://spar;

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -67,7 +67,11 @@ app ctx = SAML.setHttpCachePolicy
         $ serve (Proxy @API) (hoistServer (Proxy @API) (SAML.nt @SparError @Spar ctx) (api $ sparCtxOpts ctx) :: Server API)
 
 api :: Opts -> ServerT API Spar
-api opts = apiSSO opts :<|> apiIDP :<|> apiINTERNAL
+api opts
+     = apiSSO opts
+  :<|> authreq (maxttlAuthreqDiffTime opts) DoInitiateBind
+  :<|> apiIDP
+  :<|> apiINTERNAL
 
 apiSSO :: Opts -> ServerT APISSO Spar
 apiSSO opts
@@ -75,7 +79,6 @@ apiSSO opts
   :<|> SAML.meta appName sparSPIssuer sparResponseURI
   :<|> authreqPrecheck
   :<|> authreq (maxttlAuthreqDiffTime opts) DoInitiateLogin
-  :<|> authreq (maxttlAuthreqDiffTime opts) DoInitiateBind
   :<|> authresp
 
 apiIDP :: ServerT APIIDP Spar

--- a/services/spar/src/Spar/API/Types.hs
+++ b/services/spar/src/Spar/API/Types.hs
@@ -41,6 +41,7 @@ import "swagger2" Data.Swagger hiding (Header(..))
 
 type API
      = "sso" :> APISSO
+  :<|> "sso-initiate-bind"  :> APIAuthReq  -- (see comment on 'APIAuthReq')
   :<|> "identity-providers" :> APIIDP
   :<|> "i" :> APIINTERNAL
   -- NB. If you add endpoints here, also update Test.Spar.APISpec
@@ -50,7 +51,6 @@ type APISSO
   :<|> APIMeta
   :<|> "initiate-login" :> APIAuthReqPrecheck
   :<|> "initiate-login" :> APIAuthReq
-  :<|> "initiate-bind"  :> APIAuthReq          -- (see comment on 'APIAuthReq')
   :<|> APIAuthResp
 
 type CheckOK = Verb 'HEAD 200
@@ -79,9 +79,9 @@ type APIAuthReq
 data DoInitiate = DoInitiateLogin | DoInitiateBind
   deriving (Eq, Show, Bounded, Enum)
 
-doInitiatePath :: DoInitiate -> ST
-doInitiatePath DoInitiateLogin = "initiate-login"
-doInitiatePath DoInitiateBind  = "initiate-bind"
+doInitiatePath :: DoInitiate -> [ST]
+doInitiatePath DoInitiateLogin = ["sso", "initiate-login"]
+doInitiatePath DoInitiateBind  = ["sso-initiate-bind"]
 
 type WithBindCookie = Headers '[Servant.Header "Set-Cookie" BindCookie]
 

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -211,7 +211,7 @@ specBindingUsers = describe "binding existing users to sso identities" $ do
           env <- ask
           let idp = idPIdToST $ env ^. teIdP . idpId
           void . call $ head ( (env ^. teSpar)
-                             . path (cs $ "/sso/initiate-bind/" -/ idp)
+                             . path (cs $ "/sso-initiate-bind/" -/ idp)
                              . header "Z-User" (toByteString' $ env ^. teUserId)
                              . expect2xx
                              )
@@ -223,7 +223,7 @@ specBindingUsers = describe "binding existing users to sso identities" $ do
           let idp = idPIdToST $ env ^. teIdP . idpId
           void . call $ head ( (env ^. teSpar)
                              . header "Z-User" (toByteString' uid)
-                             . path (cs $ "/sso/initiate-bind/" -/ idp)
+                             . path (cs $ "/sso-initiate-bind/" -/ idp)
                              . expect2xx
                              )
 
@@ -242,12 +242,12 @@ specBindingUsers = describe "binding existing users to sso identities" $ do
           uid <- createUser
           get ( (env ^. teSpar)
               . header "Z-User" (toByteString' uid)
-              . path (cs $ "/sso/initiate-bind/" -/ idp)
+              . path (cs $ "/sso-initiate-bind/" -/ idp)
               . expect2xx
               )
             `shouldRespondWith` (\resp -> checkRespBody resp && hasSetBindCookieHeader resp)
 
-    describe "GET /sso/initiate-bind/:idp" $ do
+    describe "GET /sso-initiate-bind/:idp" $ do
       context "known IdP, running session with non-sso user" $ do
         it "responds with 200 and a bind cookie" $ do
           checkInitiateLogin (fmap fst . call . createRandomPhoneUser =<< asks (^. teBrig))

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -478,7 +478,7 @@ negotiateAuthnRequest' (doInitiatePath -> doInit) midp modreq = do
     <- call $ get
            ( modreq
            . (env ^. teSpar)
-           . paths (cs <$> (doInit) <> [idPIdToST $ idp ^. SAML.idpId])
+           . paths (cs <$> (doInit <> [idPIdToST $ idp ^. SAML.idpId]))
            . expect2xx
            )
   (_, authnreq) <- either error pure . parseAuthnReqResp $ cs <$> responseBody resp

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -478,7 +478,7 @@ negotiateAuthnRequest' (doInitiatePath -> doInit) midp modreq = do
     <- call $ get
            ( modreq
            . (env ^. teSpar)
-           . paths ["sso", cs doInit, cs . idPIdToST $ idp ^. SAML.idpId]
+           . paths (cs <$> (doInit) <> [idPIdToST $ idp ^. SAML.idpId])
            . expect2xx
            )
   (_, authnreq) <- either error pure . parseAuthnReqResp $ cs <$> responseBody resp


### PR DESCRIPTION
nginz exposes the `/sso/` prefix without authentication, but the bind end-point needs to be authenticated.  so we give it its own prefix `/sso-initiate-bind/` prefix.