### PR TITLE
Add metrics middleware to spar.

### DIFF
--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -57,6 +57,7 @@ dependencies:
   - uri-bytestring
   - uuid
   - wai
+  - wai-middleware-prometheus
   - wai-utilities
   - warp
   - x509

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -100,7 +100,7 @@ runServer sparCtxOpts = do
                       $ Bilge.empty
   let wrappedApp
         = WU.catchErrors sparCtxLogger mx
-        . Promth.prometheus Promth.def
+        . Promth.prometheus Promth.def { Promth.prometheusEndPoint = ["i", "monitoring"] }
         . SAML.setHttpCachePolicy
         . lookupRequestIdMiddleware
         $ \sparCtxRequestId -> app Env {..}

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -42,6 +42,7 @@ import Util.Options (casEndpoint, casKeyspace, epHost, epPort)
 import qualified Cassandra.Schema as Cas
 import qualified Cassandra.Settings as Cas
 import qualified Network.Wai.Handler.Warp as Warp
+import qualified Network.Wai.Middleware.Prometheus as Promth
 import qualified Network.Wai.Utilities.Server as WU
 import qualified SAML2.WebSSO as SAML
 import qualified Spar.Data as Data
@@ -98,10 +99,8 @@ runServer sparCtxOpts = do
                       . Bilge.port (sparCtxOpts ^. to brig . epPort)
                       $ Bilge.empty
   let wrappedApp
-    -- . WU.measureRequests mx _
-        -- TODO: we need the swagger sitemap from servant for this.  we also want this to be
-        -- prometheus-compatible.  not sure about the order in which to do these.
         = WU.catchErrors sparCtxLogger mx
+        . Promth.prometheus Promth.def
         . SAML.setHttpCachePolicy
         . lookupRequestIdMiddleware
         $ \sparCtxRequestId -> app Env {..}

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -70,6 +70,19 @@ specMisc = do
         ping (env ^. teSpar) `shouldRespondWith` (== ())
 
 
+    describe "metrics" $ do
+      it "spar /i/monitoring" $ do
+        env <- ask
+        get ((env ^. teSpar) . path "/i/monitoring")
+          `shouldRespondWith` (\(responseBody -> Just (cs -> bdy)) -> all (`isInfixOf` bdy)
+                                [ "http_request_duration_seconds_bucket"
+                                , "handler="
+                                , "method="
+                                , "status_code="
+                                , "le="
+                                ])
+
+
 specMetadata :: SpecWith TestEnv
 specMetadata = do
     describe "metadata" $ do


### PR DESCRIPTION
tasks:

- [x] make sure `/metrics` is the right URI path, or change it.
- [x] add integration test that checks that metrics are generated?
- [x] see if we have all the generate all any data at all, or all the data we want.
