### PR TITLE
Spar tests: add scim auth token to database in TestEnv.

### DIFF
--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -166,6 +166,7 @@ mkEnv _teTstOpts _teOpts = do
       sparCtxRequestId   = RequestId "<fake request id>"
 
   let _teScimToken = ScimToken "scim-test-token"
+  runClient _teCql $ Data.insertScimToken _teTeamId _teScimToken (Just (_teIdP ^. idpId))
 
   pure TestEnv {..}
 


### PR DESCRIPTION
@neongreen Is this the answer to your question?  If not please try again.  :-)