### PR TITLE
Use proper payload when sending out update events

### DIFF
--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -377,7 +377,7 @@ data EventType
 data EventData
     = EdMembers             !Members
     | EdConnect             !Connect
-    | EdConvReceiptModeUpdate  !ReceiptMode
+    | EdConvReceiptModeUpdate  !ConversationReceiptModeUpdate
     | EdConvRename          !ConversationRename
     | EdConvAccessUpdate    !ConversationAccessUpdate
     | EdConvMessageTimerUpdate !ConversationMessageTimerUpdate

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -229,7 +229,7 @@ updateConversationReceiptMode (usr ::: zcon ::: cnv ::: req ::: _ ::: _) = do
         -- Update Cassandra & send an event
         Data.updateConversationReceiptMode cnv mode
         now <- liftIO getCurrentTime
-        let receiptEvent = Event ConvReceiptModeUpdate cnv usr now (Just $ EdConvReceiptModeUpdate mode)
+        let receiptEvent = Event ConvReceiptModeUpdate cnv usr now (Just $ EdConvReceiptModeUpdate (ConversationReceiptModeUpdate mode))
         pushEvent receiptEvent users bots zcon
         return $ json receiptEvent & setStatus status200
 

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1084,8 +1084,9 @@ putReceiptModeOk g b c _ = do
         evtType e @?= ConvReceiptModeUpdate
         evtFrom e @?= alice
         case evtData e of
-            Just (EdConvReceiptModeUpdate (ReceiptMode mode)) -> assertEqual "modes should match" mode 0
-            _                                                 -> assertFailure "Unexpected event data"
+            Just (EdConvReceiptModeUpdate (ConversationReceiptModeUpdate (ReceiptMode mode)))
+                -> assertEqual "modes should match" mode 0
+            _   -> assertFailure "Unexpected event data"
 
 postTypingIndicators :: Galley -> Brig -> Cannon -> TestSetup -> Http ()
 postTypingIndicators g b _ _ = do


### PR DESCRIPTION
Current implementation sends out the update event as a plain int; the desired behaviour is that it's wrapped in a JSON object of type `ConversationReceiptModeUpdate` (as indicated on swagger)