### PR TITLE
consistency: logLevel/logNetstrings are top-level configuration options

### DIFF
--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -48,10 +48,10 @@ import qualified System.IO.Strict            as Strict
 
 mkLogger :: Opts -> IO Logger
 mkLogger o = Logger.new $ Logger.defSettings
-    & Logger.setLogLevel (o^.cannon.logLevel)
+    & Logger.setLogLevel (o^.logLevel)
     & Logger.setOutput Logger.StdOut
     & Logger.setFormat Nothing
-    & Logger.setNetStrings (o^.cannon.logNetStrings)
+    & Logger.setNetStrings (o^.logNetStrings)
 
 run :: Opts -> IO ()
 run o = do

--- a/services/cannon/src/Cannon/Options.hs
+++ b/services/cannon/src/Cannon/Options.hs
@@ -31,8 +31,6 @@ data Cannon = Cannon
     , _cannonPort             :: !Word16
     , _cannonExternalHost     :: !(Maybe Text)
     , _cannonExternalHostFile :: !(Maybe FilePath)
-    , _cannonLogLevel         :: !Level
-    , _cannonLogNetStrings    :: !Bool
     } deriving (Eq, Show, Generic)
 
 makeFields ''Cannon
@@ -47,8 +45,10 @@ makeFields ''Gundeck
 deriveApiFieldJSON ''Gundeck
 
 data Opts = Opts
-    { _optsCannon   :: !Cannon
-    , _optsGundeck  :: !Gundeck
+    { _optsCannon         :: !Cannon
+    , _optsGundeck        :: !Gundeck
+    , _optsLogLevel       :: !Level
+    , _optsLogNetStrings  :: !Bool
     } deriving (Eq, Show, Generic)
 
 makeFields ''Opts


### PR DESCRIPTION
fixes inconsistency in #555 (code did not match config changes here; this PR makes options consistent with the other services)