### PR TITLE
Prune SSO subject identities if they exceed 128 chars.

### DIFF
--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -34,6 +34,7 @@ import Spar.Error
 import Web.Cookie
 
 import qualified SAML2.WebSSO as SAML
+import qualified Data.Text as Text
 
 
 ----------------------------------------------------------------------
@@ -91,7 +92,7 @@ createUser suid (Id buid) teamid mbName = do
       let subject = suid ^. SAML.uidSubject
           badName = throwSpar . SparBadUserName $ SAML.encodeElem subject
           mkName  = Name . fromRange <$>
-                    (SAML.shortShowNameID >=> checked @ST @1 @128) subject
+                    (fmap (Text.take 128) . SAML.shortShowNameID >=> checked @ST @1 @128) subject
       maybe badName pure mkName
 
   let newUser :: NewUser


### PR DESCRIPTION
This avoids ugly errors if a user with a long SAML subject ID wants to have a user created via spar.

We could be even nicer here, and generate some random, user-readable, non-offensive-to-anybody username if using the SSO subject id fails.  Not sure it's worth it, though.

(Note that this is already causing CS noise because some users do not like this default, and are having trouble configuring the subject ID on the IdP side so they like the wire names.  We should really wait for SCIM to provide a more robust solution for these issues.)