### PR TITLE
Always carry a Role in the Invitation type.

### DIFF
--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -391,10 +391,10 @@ invitation = defineModel "Invitation" $ do
     property "inviter" bytes' $
         description "User ID of the inviter"
     property "role" role $ do
-        description "User ID of the inviter"
+        description "Role of the invited user"
         optional
     property "id" bytes' $
-        description "UUID used to refer the invitation"
+        description "UUID used to refer to the invitation"
     property "email" string' $ do
         description "Email of the invitee"
         optional

--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -2,10 +2,11 @@
 
 module Brig.Types.Swagger where
 
-import Imports
 import Data.Swagger
 import Data.Swagger.Build.Api
+import Galley.Types.Teams (defaultRole)
 
+import qualified Data.Swagger.Model.Api     as Model
 import qualified Galley.Types.Swagger       as Galley
 import qualified Galley.Types.Teams.Swagger as Galley
 
@@ -375,11 +376,23 @@ invitationRequest = defineModel "InvitationRequest" $ do
         description "Locale to use for the invitation."
         optional
 
+role :: DataType
+role = Model.Prim $ Model.Primitive
+    { Model.primType     = Model.PrimString
+    , Model.defaultValue = Just defaultRole
+    , Model.enum         = Just [minBound..]
+    , Model.minVal       = Just minBound
+    , Model.maxVal       = Just maxBound
+    }
+
 invitation :: Model
 invitation = defineModel "Invitation" $ do
     description "An invitation to join Wire"
     property "inviter" bytes' $
         description "User ID of the inviter"
+    property "role" role $ do
+        description "User ID of the inviter"
+        optional
     property "id" bytes' $
         description "UUID used to refer the invitation"
     property "email" string' $ do

--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -2,6 +2,7 @@
 
 module Brig.Types.Swagger where
 
+import Imports
 import Data.Swagger
 import Data.Swagger.Build.Api
 import Galley.Types.Teams (defaultRole)

--- a/libs/brig-types/src/Brig/Types/Team/Invitation.hs
+++ b/libs/brig-types/src/Brig/Types/Team/Invitation.hs
@@ -7,7 +7,7 @@ import Brig.Types.Common
 import Data.Aeson
 import Data.Id
 import Data.Json.Util
-import Galley.Types.Teams (Role)
+import Galley.Types.Teams
 
 data InvitationRequest = InvitationRequest
     { irEmail    :: !Email

--- a/libs/brig-types/src/Brig/Types/Team/Invitation.hs
+++ b/libs/brig-types/src/Brig/Types/Team/Invitation.hs
@@ -50,7 +50,7 @@ instance FromJSON Invitation where
     parseJSON = withObject "invitation" $ \o ->
         Invitation <$> o .: "team"
                        -- clients, when leaving "role" empty, can leave the default role choice to us
-                   <*> (fromMaybe defaultRole <$> (o .:? "role"))
+                   <*> o .:? "role" .!= defaultRole
                    <*> o .: "id"
                    <*> o .: "email"
                    <*> o .: "created_at"

--- a/libs/brig-types/src/Brig/Types/Team/Invitation.hs
+++ b/libs/brig-types/src/Brig/Types/Team/Invitation.hs
@@ -49,7 +49,8 @@ instance ToJSON InvitationRequest where
 instance FromJSON Invitation where
     parseJSON = withObject "invitation" $ \o ->
         Invitation <$> o .: "team"
-                   <*> o .: "role"
+                       -- clients don't can leave the default role choice to us:
+                   <*> (fromMaybe defaultRole <$> (o .:? "role"))
                    <*> o .: "id"
                    <*> o .: "email"
                    <*> o .: "created_at"

--- a/libs/brig-types/src/Brig/Types/Team/Invitation.hs
+++ b/libs/brig-types/src/Brig/Types/Team/Invitation.hs
@@ -49,7 +49,7 @@ instance ToJSON InvitationRequest where
 instance FromJSON Invitation where
     parseJSON = withObject "invitation" $ \o ->
         Invitation <$> o .: "team"
-                       -- clients don't can leave the default role choice to us:
+                       -- clients, when leaving "role" empty, can leave the default role choice to us
                    <*> (fromMaybe defaultRole <$> (o .:? "role"))
                    <*> o .: "id"
                    <*> o .: "email"

--- a/libs/brig-types/src/Brig/Types/Team/Invitation.hs
+++ b/libs/brig-types/src/Brig/Types/Team/Invitation.hs
@@ -18,7 +18,7 @@ data InvitationRequest = InvitationRequest
 
 data Invitation = Invitation
     { inTeam       :: !TeamId
-    , inRole       :: !(Maybe Role)
+    , inRole       :: !Role
     , inInvitation :: !InvitationId
     , inIdentity   :: !Email
     , inCreatedAt  :: !UTCTimeMillis
@@ -49,7 +49,7 @@ instance ToJSON InvitationRequest where
 instance FromJSON Invitation where
     parseJSON = withObject "invitation" $ \o ->
         Invitation <$> o .: "team"
-                   <*> o .:? "role"
+                   <*> o .: "role"
                    <*> o .: "id"
                    <*> o .: "email"
                    <*> o .: "created_at"

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -70,6 +70,7 @@ module Galley.Types.Teams
     , intToPerms
 
     , Role (..)
+    , defaultRole
     , rolePermissions
 
     , BindingNewTeam (..)
@@ -249,6 +250,9 @@ data Perm =
 
 data Role = RoleOwner | RoleAdmin | RoleMember | RoleCollaborator
     deriving (Eq, Ord, Show, Enum, Bounded)
+
+defaultRole :: Role
+defaultRole = RoleMember
 
 rolePermissions :: Role -> Permissions
 rolePermissions role = Permissions p p  where p = rolePerms role

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -257,7 +257,7 @@ createUser new@NewUser{..} = do
         ok <- lift $ Data.claimKey uk uid
         unless ok $
             throwE $ DuplicateUserKey uk
-        let minvmeta :: (Maybe (UserId, UTCTimeMillis), Maybe Team.Role)
+        let minvmeta :: (Maybe (UserId, UTCTimeMillis), Team.Role)
             minvmeta = ((, inCreatedAt inv) <$> inCreatedBy inv, Team.inRole inv)
         added <- lift $ Intra.addTeamMember uid (Team.iiTeam ii) minvmeta
         unless added $
@@ -273,7 +273,7 @@ createUser new@NewUser{..} = do
     addUserToTeamSSO :: UserAccount -> TeamId -> UserIdentity -> ExceptT CreateUserError AppIO CreateUserTeam
     addUserToTeamSSO account tid ident = do
         let uid = userId (accountUser account)
-        added <- lift $ Intra.addTeamMember uid tid (Nothing, Nothing)
+        added <- lift $ Intra.addTeamMember uid tid (Nothing, Team.defaultRole)
         unless added $
             throwE TooManyTeamMembers
         lift $ do

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -529,8 +529,8 @@ rmClient u c = do
 -------------------------------------------------------------------------------
 -- Team Management
 
-addTeamMember :: UserId -> TeamId -> (Maybe (UserId, UTCTimeMillis), Maybe Team.Role) -> AppIO Bool
-addTeamMember u tid (minvmeta, mrole) = do
+addTeamMember :: UserId -> TeamId -> (Maybe (UserId, UTCTimeMillis), Team.Role) -> AppIO Bool
+addTeamMember u tid (minvmeta, role) = do
     debug $ remote "galley"
             . msg (val "Adding member to team")
     rs <- galleyRequest POST req
@@ -538,7 +538,7 @@ addTeamMember u tid (minvmeta, mrole) = do
         200 -> True
         _   -> False
   where
-    prm   = Team.rolePermissions $ fromMaybe Team.RoleMember mrole
+    prm   = Team.rolePermissions role
     bdy   = Team.newNewTeamMember $ Team.newTeamMember u prm minvmeta
     req   = paths ["i", "teams", toByteString' tid, "members"]
           . header "Content-Type" "application/json"

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -167,7 +167,7 @@ createInvitation (_ ::: uid ::: tid ::: req) = do
     idt  <- maybe (throwStd noIdentity) return =<< lift (fetchUserIdentity uid)
     from <- maybe (throwStd noEmail)    return (emailIdentity idt)
     let inviteePerms = Team.rolePermissions inviteeRole
-        inviteeRole  = fromMaybe Team.RoleMember . irRole $ body
+        inviteeRole  = fromMaybe Team.defaultRole . irRole $ body
     ensurePermissionToAddUser uid tid inviteePerms
     email <- either (const $ throwStd invalidEmail) return (validateEmail (irEmail body))
     let uk = userEmailKey email

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -166,7 +166,8 @@ createInvitation (_ ::: uid ::: tid ::: req) = do
     body :: InvitationRequest <- parseJsonBody req
     idt  <- maybe (throwStd noIdentity) return =<< lift (fetchUserIdentity uid)
     from <- maybe (throwStd noEmail)    return (emailIdentity idt)
-    let inviteePerms = Team.rolePermissions . fromMaybe Team.RoleMember . irRole $ body
+    let inviteePerms = Team.rolePermissions inviteeRole
+        inviteeRole  = fromMaybe Team.RoleMember . irRole $ body
     ensurePermissionToAddUser uid tid inviteePerms
     email <- either (const $ throwStd invalidEmail) return (validateEmail (irEmail body))
     let uk = userEmailKey email
@@ -180,7 +181,7 @@ createInvitation (_ ::: uid ::: tid ::: req) = do
     user <- lift $ Data.lookupKey uk
     case user of
         Just _  -> throwStd emailExists
-        Nothing -> doInvite (irRole body) email from (irLocale body)
+        Nothing -> doInvite inviteeRole email from (irLocale body)
   where
     doInvite role to from lc = lift $ do
         now     <- liftIO =<< view currentTime

--- a/services/brig/src/Brig/Team/DB.hs
+++ b/services/brig/src/Brig/Team/DB.hs
@@ -163,8 +163,7 @@ countInvitations t = fromMaybe 0 . fmap runIdentity <$>
     cqlSelect :: PrepQuery R (Identity TeamId) (Identity Int64)
     cqlSelect = "SELECT count(*) FROM team_invitation WHERE team = ?"
 
--- | FUTUREWORK: two weeks after https://github.com/wearezeta/backend-issues/issues/775 has been
--- deployed, we won't find any `Nothing` role values any more; then it will be safe to change the
--- type here from @Maybe Role@ into @Role@.
+-- | brig used to not store the role, so for migration we allow this to be empty and fill in the
+-- default here.
 toInvitation :: (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId) -> Invitation
 toInvitation (t, r, i, e, tm, minviter) = Invitation t (fromMaybe Team.defaultRole r) i e tm minviter


### PR DESCRIPTION
Without this, the default role would have to be picked twice: once in the backend, and once in team settings.  This is both extra work and poses the risk of running out of sync.

With these changes, the backend stores all future `Invitation`s in the DB with a default role that is defined near the type.  For migration, we allow for database entries with missing `Role`, and fill in the default there again.  This is marked in the code as `FUTUREWORK: remove`.
