### PR TITLE
Make adding users implicit in CreateConversation permission.

### DIFF
--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -84,6 +84,8 @@ createTeamGroupConv zusr zcon tinfo body = do
             let uu = filter (/= zusr) $ map (view userId) mems
             checkedConvSize uu
         else do
+            when (length mems > 1) $ do
+                void $ permissionCheck zusr AddRemoveConvMember mems
             uu <- checkedConvSize (newConvUsers body)
             ensureConnected zusr (notTeamMember (fromConvSize uu) mems)
             pure uu

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -84,7 +84,6 @@ createTeamGroupConv zusr zcon tinfo body = do
             let uu = filter (/= zusr) $ map (view userId) mems
             checkedConvSize uu
         else do
-            void $ permissionCheck zusr AddRemoveConvMember mems
             uu <- checkedConvSize (newConvUsers body)
             ensureConnected zusr (notTeamMember (fromConvSize uu) mems)
             pure uu


### PR DESCRIPTION
without this, collaborators can only create *empty* conversations, but they need to create 1:1 convs, too.