### PR TITLE
Use network-2.7 for more informative "connection failed" errors

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -149,6 +149,8 @@ extra-deps:
 - network-uri-static-0.1.1.0
 - list-t-1.0.1  # 1.0.0.1 doesn't build
 - unliftio-0.2.10  # for pooled concurrency utils in UnliftIO.Async
+- network-2.7.0.2  # to get nicer errors when connections fail
+- HaskellNet-SSL-0.3.4.1  # first version to support network-2.7
 
 # the following are just not on Stackage (and most of these were present in
 # LTS-11 but got evicted in LTS-12)

--- a/tools/bonanza/src/Bonanza/Metrics.hs
+++ b/tools/bonanza/src/Bonanza/Metrics.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 
-{-# OPTIONS_GHC -Wno-deprecations #-}  -- for Network.BSD
+-- Network.BSD got deprecated in network-2.7; this line won't be needed once we
+-- move to network-3.0 because then we can use the network-bsd package
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Bonanza.Metrics
     ( Stats (..)

--- a/tools/bonanza/src/Bonanza/Metrics.hs
+++ b/tools/bonanza/src/Bonanza/Metrics.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 
+{-# OPTIONS_GHC -Wno-deprecations #-}  -- for Network.BSD
+
 module Bonanza.Metrics
     ( Stats (..)
     , debugCollectd

--- a/tools/bonanza/src/Bonanza/Streaming/Kibana.hs
+++ b/tools/bonanza/src/Bonanza/Streaming/Kibana.hs
@@ -6,7 +6,10 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 
 -- necessary because of missing 'Eq ZonedTime' instance
-{-# OPTIONS_GHC -fno-warn-orphans       #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+-- Network.BSD got deprecated in network-2.7; this line won't be needed once we
+-- move to network-3.0 because then we can use the network-bsd package
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Bonanza.Streaming.Kibana
     ( KibanaEvent


### PR DESCRIPTION
```
service: Network.Socket.getAddrInfo: does not exist (Name does not resolve)
```

Starting from network-2.7, `getAddrInfo` also prints the host that it was trying to connect to.