### PR TITLE
Revert "allow non-amd64 architecture, and work around 32 bit portability issue."

### DIFF
--- a/libs/libzauth/libzauth-c/Makefile
+++ b/libs/libzauth/libzauth-c/Makefile
@@ -1,7 +1,7 @@
 LANG := en_US.UTF-8
 SHELL   := /usr/bin/env bash
 VERSION := "3.0.0"
-ARCH    := $(shell if [ -f "`which dpkg-architecture`" ]; then dpkg-architecture -qDEB_HOST_ARCH; else [ -f "`which dpkg`" ] && dpkg --print-architecture; fi )
+ARCH    := amd64
 BUILD   ?= 1
 OS      := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 # If we can install libzauth globally, we'll install it there, otherwise

--- a/libs/libzauth/libzauth-c/deb/DEBIAN/control
+++ b/libs/libzauth/libzauth-c/deb/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: libzauth
 Version: <<VERSION_NUMBER>>+<<BUILD_NUMBER>>
 Maintainer: Wire Swiss GmbH <backend@wire.com>
-Architecture: <<ARCHITECTURE>>
+Architecture: amd64
 Description: zauth token parsing and verification

--- a/libs/libzauth/libzauth-c/src/lib.rs
+++ b/libs/libzauth/libzauth-c/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate libc;
 extern crate zauth;
 
-use libc::{size_t, uint8_t};
+use libc::{c_long, size_t, uint8_t};
 use std::char;
 use std::fs::File;
 use std::io::{self, BufReader, Read};
@@ -130,11 +130,10 @@ pub extern fn zauth_token_type(t: &ZauthToken) -> ZauthTokenType {
     From::from(t.0.token_type)
 }
 
-// Commented out, looks unused, and causing portability issues with ia32.
-//#[no_mangle]
-//pub extern fn zauth_token_time(t: &ZauthToken) -> c_long {
-//    t.0.timestamp
-//}
+#[no_mangle]
+pub extern fn zauth_token_time(t: &ZauthToken) -> c_long {
+    t.0.timestamp
+}
 
 #[no_mangle]
 pub extern fn zauth_token_version(t: &ZauthToken) -> uint8_t {


### PR DESCRIPTION
Reverts wireapp/wire-server#587