### PR TITLE
break PREFIX into PREFIX_PACKAGE and PREFIX_INSTALL, to fix the path …

### DIFF
--- a/libs/libzauth/libzauth-c/Makefile
+++ b/libs/libzauth/libzauth-c/Makefile
@@ -6,7 +6,9 @@ BUILD   ?= 1
 OS      := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 # If we can install libzauth globally, we'll install it there, otherwise
 # it'll go into ~/.wire-dev (unless it's overridden)
-PREFIX  ?= $(shell [ -w /usr/local ] && echo /usr/local || echo "$(HOME)/.wire-dev")
+PREFIX_INSTALL  ?= $(shell [ -w /usr/local ] && echo /usr/local || echo "$(HOME)/.wire-dev")
+# If we are building a debian package, just use /usr/local.
+PREFIX_PACKAGE  ?= /usr/local
 
 ifeq ($(OS), darwin)
 LIB_TYPE := dylib
@@ -19,7 +21,7 @@ all: build
 clean:
 	cargo clean
 	rm -rf test/target
-	rm -rf deb$(PREFIX)/
+	rm -rf deb$(PREFIX_PACKAGE)/
 
 build:
 	cargo build
@@ -28,27 +30,27 @@ build-release:
 	cargo build --release
 
 install: build-release
-	mkdir -p $(PREFIX)/include
-	mkdir -p $(PREFIX)/lib/pkgconfig
-	cp src/zauth.h $(PREFIX)/include/
+	mkdir -p $(PREFIX_INSTALL)/include
+	mkdir -p $(PREFIX_INSTALL)/lib/pkgconfig
+	cp src/zauth.h $(PREFIX_INSTALL)/include/
 	sed -e "s~<<VERSION>>~$(VERSION)~" \
-		-e "s~<<PREFIX>>~$(PREFIX)~" \
-		src/libzauth.pc > $(PREFIX)/lib/pkgconfig/libzauth.pc
-	cp target/release/libzauth.$(LIB_TYPE) $(PREFIX)/lib/
+		-e "s~<<PREFIX>>~$(PREFIX_INSTALL)~" \
+		src/libzauth.pc > $(PREFIX_INSTALL)/lib/pkgconfig/libzauth.pc
+	cp target/release/libzauth.$(LIB_TYPE) $(PREFIX_INSTALL)/lib/
 
 uninstall:
-	rm -f $(PREFIX)/include/zauth.h
-	rm -f $(PREFIX)/lib/libzauth.$(LIB_TYPE)
-	rm -f $(PREFIX)/lib/pkgconfig/libzauth.pc
+	rm -f $(PREFIX_INSTALL)/include/zauth.h
+	rm -f $(PREFIX_INSTALL)/lib/libzauth.$(LIB_TYPE)
+	rm -f $(PREFIX_INSTALL)/lib/pkgconfig/libzauth.pc
 
 dist: build-release
-	mkdir -p deb$(PREFIX)/include
-	mkdir -p deb$(PREFIX)/lib/pkgconfig
-	cp src/zauth.h deb$(PREFIX)/include/
+	mkdir -p deb$(PREFIX_PACKAGE)/include
+	mkdir -p deb$(PREFIX_PACKAGE)/lib/pkgconfig
+	cp src/zauth.h deb$(PREFIX_PACKAGE)/include/
 	sed -e "s~<<VERSION>>~$(VERSION)~" \
-		-e "s~<<PREFIX>>~$(PREFIX)~" \
-		src/libzauth.pc > deb$(PREFIX)/lib/pkgconfig/libzauth.pc
-	cp target/release/libzauth.$(LIB_TYPE) deb$(PREFIX)/lib/
+		-e "s~<<PREFIX>>~$(PREFIX_PACKAGE)~" \
+		src/libzauth.pc > deb$(PREFIX_PACKAGE)/lib/pkgconfig/libzauth.pc
+	cp target/release/libzauth.$(LIB_TYPE) deb$(PREFIX_PACKAGE)/lib/
 ifeq ($(OS), linux)
 	makedeb --name=libzauth        \
 			--version=$(VERSION)   \


### PR DESCRIPTION
…when building debian packages as a non-root user.