### PR TITLE
Tidy up partner role.

### DIFF
--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -257,6 +257,9 @@ instance Arbitrary NewTeamUser where
         , NewTeamMemberSSO <$> arbitrary
         ]
 
+instance Arbitrary TeamMember where
+    arbitrary = newTeamMember <$> arbitrary <*> arbitrary <*> arbitrary
+
 instance Arbitrary PasswordChange where
     arbitrary = PasswordChange <$> arbitrary <*> arbitrary
 

--- a/libs/brig-types/test/unit/Test/Brig/Types/User.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/User.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE ViewPatterns        #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Test.Brig.Types.User where
 
 import Imports
@@ -18,6 +20,7 @@ import Data.Aeson
 import Data.Aeson.Types
 import Data.Proxy
 import Data.Typeable (typeOf)
+import Galley.Types.Teams
 import Test.Brig.Types.Arbitrary ()
 import Test.QuickCheck
 import Test.Tasty
@@ -88,6 +91,7 @@ roundtripTests =
     , run @PhoneUpdate Proxy
     , run @ReAuthUser Proxy
     , run @SelfProfile Proxy
+    , run @TeamMember Proxy
     , run @UpdateServiceWhitelist Proxy
     , run @UserHandleInfo Proxy
     , run @UserIdentity Proxy

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -582,6 +582,10 @@ instance FromJSON Role where
         "admin"        -> pure RoleAdmin
         "member"       -> pure RoleMember
         "partner"      -> pure RoleExternalPartner
+        "collaborator" -> pure RoleExternalPartner
+          -- 'collaborator' was used for a short period of time on staging.  if you are
+          -- wondering about this, it's probably safe to remove.
+          -- ~fisx, Wed Jan 23 16:38:52 CET 2019
         bad            -> fail $ "not a role: " <> show bad
 
 newTeamJson :: NewTeam a -> [Pair]

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -248,7 +248,7 @@ data Perm =
     -- read Note [team roles] first.
     deriving (Eq, Ord, Show, Enum, Bounded)
 
-data Role = RoleOwner | RoleAdmin | RoleMember | RoleCollaborator
+data Role = RoleOwner | RoleAdmin | RoleMember | RoleExternalPartner
     deriving (Eq, Ord, Show, Enum, Bounded)
 
 defaultRole :: Role
@@ -269,13 +269,13 @@ rolePerms RoleAdmin = rolePerms RoleMember <> Set.fromList
     , SetTeamData
     , SetMemberPermissions
     ]
-rolePerms RoleMember = rolePerms RoleCollaborator <> Set.fromList
+rolePerms RoleMember = rolePerms RoleExternalPartner <> Set.fromList
     [ DeleteConversation
     , AddRemoveConvMember
     , ModifyConvMetadata
     , GetMemberPermissions
     ]
-rolePerms RoleCollaborator = Set.fromList
+rolePerms RoleExternalPartner = Set.fromList
     [ CreateConversation
     , GetTeamConversations
     ]
@@ -574,14 +574,14 @@ instance ToJSON Role where
     toJSON RoleOwner        = "owner"
     toJSON RoleAdmin        = "admin"
     toJSON RoleMember       = "member"
-    toJSON RoleCollaborator = "collaborator"
+    toJSON RoleExternalPartner = "partner"
 
 instance FromJSON Role where
     parseJSON = withText "Role" $ \case
         "owner"        -> pure RoleOwner
         "admin"        -> pure RoleAdmin
         "member"       -> pure RoleMember
-        "collaborator" -> pure RoleCollaborator
+        "partner"      -> pure RoleExternalPartner
         bad            -> fail $ "not a role: " <> show bad
 
 newTeamJson :: NewTeam a -> [Pair]
@@ -739,13 +739,13 @@ instance Cql.Cql Role where
     toCql RoleOwner        = Cql.CqlInt 1
     toCql RoleAdmin        = Cql.CqlInt 2
     toCql RoleMember       = Cql.CqlInt 3
-    toCql RoleCollaborator = Cql.CqlInt 4
+    toCql RoleExternalPartner = Cql.CqlInt 4
 
     fromCql (Cql.CqlInt i) = case i of
         1 -> return RoleOwner
         2 -> return RoleAdmin
         3 -> return RoleMember
-        4 -> return RoleCollaborator
+        4 -> return RoleExternalPartner
         n -> fail $ "Unexpected Role value: " ++ show n
     fromCql _ = fail "Role value: int expected"
 


### PR DESCRIPTION
This changes will mess with staging only, since none of the features touched have seen master yet.  All changes have been agreed on with the other teams.

1. json representation of TeamMember will look more like the one of Invitation, i.e. instead of { invited: { by: <uuid>, at: <timestamp> }, it will contain { created_by: <uuid>, created_at: <timestamp> }.
2. collaborator will disappear from everywhere, and partner will be used instead.  (when you send collaborator, the backend will hear "partner", but when you expect to receive collaborator, you are in trouble.