### PR TITLE
Fix: log multi-line error messages on one line.

### DIFF
--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -195,7 +195,7 @@ catchErrors l m app req k =
     errorResponse ex = do
         er <- runHandlers ex errorHandlers
         when (statusCode (Error.code er) >= 500) $
-            logIO l Log.Error (Just req) (show ex)
+            logIO l Log.Error (Just req) (filter (/= '\n') $ show ex)
         onError l m req k er
 {-# INLINEABLE catchErrors #-}
 

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -195,8 +195,9 @@ catchErrors l m app req k =
     errorResponse ex = do
         er <- runHandlers ex errorHandlers
         when (statusCode (Error.code er) >= 500) $
-            logIO l Log.Error (Just req) (filter (/= '\n') $ show ex)
+            logIO l Log.Error (Just req) (oneline <$> show ex)
         onError l m req k er
+    oneline c = if isSpace c then ' ' else c
 {-# INLINEABLE catchErrors #-}
 
 -- | Standard handlers for turning exceptions into appropriate


### PR DESCRIPTION
The proposed fix is very simple, and arguably not the most readable, but it solve the problem of two error messages interleaving each other by dropping all newlines.

Alternatives:

- replace newline with space, or `--`, or something else.
- use netstrings
- ?
