### PR TITLE
Use custom snapshots

### DIFF
--- a/snapshots/wire-1.0.yaml
+++ b/snapshots/wire-1.0.yaml
@@ -1,0 +1,120 @@
+# A custom Stack snapshot (https://docs.haskellstack.org/en/stable/custom_snapshot/) used for
+# Wire code. Should be never changed once pushed to develop.
+
+resolver: lts-12.10
+name: wire-1.0
+
+packages:
+
+############################################################
+# Packages where we need specific lower/upper bounds
+############################################################
+
+- async-2.2.1
+- hinotify-0.4
+- fsnotify-0.3.0.1
+- base-prelude-1.3
+- base58-bytestring-0.1.0
+- cql-4.0.1
+- currency-codes-2.0.0.0
+- data-timeout-0.3
+- geoip2-0.3.1.0
+- mime-0.4.0.2
+- multiset-0.3.4.1
+- text-icu-translit-0.1.0.7
+- wai-middleware-gunzip-0.0.2
+- network-uri-static-0.1.1.0  # includes 'relativeReference'
+- list-t-1.0.1  # v1.0.0.1 doesn't build
+- unliftio-0.2.10  # for pooled concurrency utils in UnliftIO.Async
+- network-2.7.0.2  # to get nicer errors when connections fail
+- HaskellNet-SSL-0.3.4.1  # first version to support network-2.7
+
+- git: https://github.com/kim/hs-collectd
+  commit: 885da222be2375f78c7be36127620ed772b677c9
+
+- git: https://github.com/kim/snappy-framing
+  commit: d99f702c0086729efd6848dea8a01e5266c3a61c
+
+- git: https://gitlab.com/twittner/wai-routing
+  commit: 7e996a93fec5901767f845a50316b3c18e51a61d
+
+# Includes the changes from <https://gitlab.com/twittner/cql-io/merge_requests/14>
+- git: https://gitlab.com/twittner/cql-io.git
+  commit: 8b91d053c469887a427e8c075cef43139fa189c4
+
+############################################################
+# Packages that are not on Stackage
+############################################################
+
+- bloodhound-0.16.0.0
+- template-0.2.0.10
+- wai-route-0.4.0
+- text-format-0.3.2
+- redis-io-1.0.0
+- redis-resp-1.0.0
+- servant-multipart-0.11.2
+- wai-middleware-prometheus-1.0.0
+- prometheus-client-1.0.0
+- hedgehog-quickcheck-0.1
+- invertible-hxt-0.1
+- stomp-queue-0.3.1
+- stompl-0.5.0
+
+############################################################
+# Forks
+############################################################
+
+#  Our fork of multihash with relaxed upper bounds
+- git: https://github.com/tiago-loureiro/haskell-multihash.git
+  commit: 300a6f46384bfca33e545c8bab52ef3717452d12
+
+# Our fork of aws with minor fixes
+- git: https://github.com/tiago-loureiro/aws
+  commit: 42695688fc20f80bf89cec845c57403954aab0a2
+
+# https://github.com/hspec/hspec-wai/pull/49
+- git: https://github.com/wireapp/hspec-wai
+  commit: ca10d13deab929f1cc3a569abea2e7fbe35fdbe3
+
+# Our fork of http-client gives us access to some guts that the upstream http-client doesn't
+# expose; see <https://github.com/wireapp/wire-server/pull/373#issuecomment-400251467>
+#
+# The important commits for us are:
+#
+#   * https://github.com/snoyberg/http-client/compare/master...neongreen:connection-guts
+#
+# The archive corresponds to commit 6a4ac55edf5e62574210c77a1468fa7accb81670.
+- archive: https://github.com/neongreen/http-client/archive/wire-2019-01-25.tar.gz
+  subdirs:
+  - http-client
+  - http-client-openssl
+  - http-client-tls
+  - http-conduit
+
+# amazonka-1.6.0 is buggy: https://github.com/brendanhay/amazonka/issues/466
+# amazonka-HEAD is also buggy: https://github.com/brendanhay/amazonka/issues/490
+#
+# Therefore we use our own fork of amazonka here. More precisely, we pull two libraries out of
+# it: amazonka and amazonka-core. Other packages weren't changed between 1.6.0 and this
+# commit, so we can use Stackage-supplied versions for them.
+#
+# The important commits for us are:
+#
+#   * https://github.com/brendanhay/amazonka/commit/2688190f
+#   * https://github.com/brendanhay/amazonka/pull/493/files
+#
+# The archive corresponds to commit 52896fd46ef6812708e9e4d7456becc692698f6b.
+- archive: https://github.com/neongreen/amazonka/archive/wire-2019-01-25.tar.gz
+  subdirs:
+  - amazonka
+  - core
+
+############################################################
+# Wire packages (only ones that change infrequently)
+############################################################
+
+- git: https://github.com/wireapp/cryptobox-haskell
+  commit: 7546a1a25635ef65183e3d44c1052285e8401608    # master (Jul 21, 2016)
+
+- git: https://github.com/wireapp/hsaml2
+  commit: 000868849efd85ba82d2bf0ac5757f801d49ad5a    # master (Sep 10, 2018)

--- a/snapshots/wire-1.0.yaml
+++ b/snapshots/wire-1.0.yaml
@@ -1,5 +1,23 @@
 # A custom Stack snapshot (https://docs.haskellstack.org/en/stable/custom_snapshot/) used for
-# Wire code. Should be never changed once pushed to develop.
+# Wire code.
+#
+# Should never be changed once pushed to develop, because in other repositories we refer to
+# snapshot definitions by URL. Stack only downloads snapshot definitions once and never checks
+# whether they have changed. So, when building code from other repositories, people would be
+# getting inconsistent results depending on whether they built that code before or not.
+#
+# To add, modify, or remove packages, a new snapshot should be created. It can be based on the
+# previous snapshot version (please read the docs above to learn what the syntax is). For
+# major changes, e.g. LTS bumps, it's better to create a snapshot from scratch.
+#
+# Some packages in this snapshot reference tar files instead of Git repos. This is due to
+# several issues in Stack that make working with big Git repositories unpleasant:
+#
+#   * https://github.com/commercialhaskell/stack/issues/4345
+#   * https://github.com/commercialhaskell/stack/issues/3551
+#
+# Unless the fixes to those are released, it's recommended to use Github's tar releases for
+# forks of big/old packages.
 
 resolver: lts-12.10
 name: wire-1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.10
+resolver: snapshots/wire-1.0.yaml
 
 packages:
 - libs/api-bot
@@ -36,134 +36,11 @@ packages:
 - tools/db/service-backfill
 - tools/db/auto-whitelist
 
-  # cql-io 1.1.0 (unreleased), includes the changes from
-  # https://gitlab.com/twittner/cql-io/merge_requests/14
-- location:
-    git: https://gitlab.com/twittner/cql-io.git
-    commit: 8b91d053c469887a427e8c075cef43139fa189c4
-  extra-dep: true
-
-- location:
-    git: https://github.com/tiago-loureiro/haskell-multihash.git
-    commit: 300a6f46384bfca33e545c8bab52ef3717452d12
-  extra-dep: true
-
-- location:
-    git: https://github.com/wireapp/cryptobox-haskell
-    commit: 7546a1a25635ef65183e3d44c1052285e8401608
-  extra-dep: true
-
-- location:
-    git: https://github.com/kim/hs-collectd
-    commit: '0.0.0.2'
-  extra-dep: true
-
-- location:
-    git: https://github.com/kim/snappy-framing
-    commit: d99f702c0086729efd6848dea8a01e5266c3a61c
-  extra-dep: true
-
-- location:
-    git: https://github.com/tiago-loureiro/aws
-    commit: 42695688fc20f80bf89cec845c57403954aab0a2
-  extra-dep: true
-
-- location:
-    git: https://gitlab.com/twittner/wai-routing
-    commit: 7e996a93fec5901767f845a50316b3c18e51a61d
-  extra-dep: true
-
-# Our fork gives us access to some guts that the upstream 'http-client'
-# doesn't expose; see https://github.com/wireapp/wire-server/pull/373#issuecomment-400251467
-#
-# The important commits for us are:
-#
-#   * https://github.com/snoyberg/http-client/compare/master...neongreen:connection-guts
-- location:
-    git: https://github.com/neongreen/http-client
-    commit: 6a4ac55edf5e62574210c77a1468fa7accb81670
-  subdirs:
-  - http-client
-  - http-client-openssl
-  - http-client-tls
-  - http-conduit
-  extra-dep: true
-
-# amazonka-1.6.0 is buggy: https://github.com/brendanhay/amazonka/issues/466
-# amazonka-HEAD is also buggy: https://github.com/brendanhay/amazonka/issues/490
-#
-# Therefore we use our own fork of amazonka here. More precisely, we pull
-# two libraries out of it: amazonka and amazonka-core. Other packages
-# weren't changed between 1.6.0 and this commit, so we can use
-# Stackage-supplied versions for them.
-#
-# The important commits for us are:
-#
-#   * https://github.com/brendanhay/amazonka/commit/2688190f659e4d87fd6862b52b04be706b17d251
-#   * https://github.com/brendanhay/amazonka/pull/493/files
-- location:
-    git: https://github.com/neongreen/amazonka
-    commit: 52896fd46ef6812708e9e4d7456becc692698f6b
-  subdirs:
-  - amazonka
-  - core
-  extra-dep: true
-
-# services/spar:
-- location:
-    git: https://github.com/wireapp/saml2-web-sso
-    commit: 3e04ed8e605733cedfaa68d82808b450b2d4508f  # master (Jan 23, 2019)
-  extra-dep: true
-- location:
-    git: https://github.com/wireapp/hsaml2
-    commit: 000868849efd85ba82d2bf0ac5757f801d49ad5a
-  extra-dep: true
-- location:
-    git: https://github.com/wireapp/hspec-wai
-    # https://github.com/hspec/hspec-wai/pull/49
-    commit: ca10d13deab929f1cc3a569abea2e7fbe35fdbe3
-  extra-dep: true
-- location:
-    git: https://github.com/wireapp/hscim
-    commit: 53db8029e17e7085322e7055f71efb5e7058d4a5  # master (Jan 23, 2019)
-  extra-dep: true
-
 extra-deps:
-- async-2.2.1
-- hinotify-0.4
-- fsnotify-0.3.0.1
-- base-prelude-1.3
-- base58-bytestring-0.1.0
-- cql-4.0.1
-- currency-codes-2.0.0.0
-- data-timeout-0.3
-- geoip2-0.3.1.0
-- mime-0.4.0.2
-- multiset-0.3.4.1
-- text-icu-translit-0.1.0.7
-- wai-middleware-gunzip-0.0.2
-- invertible-hxt-0.1  # for hsaml2 / spar
-- stomp-queue-0.3.1  # for Brig.Queue.Stomp
-- stompl-0.5.0
-# for hscim
-- network-uri-static-0.1.1.0
-- list-t-1.0.1  # 1.0.0.1 doesn't build
-- unliftio-0.2.10  # for pooled concurrency utils in UnliftIO.Async
-- network-2.7.0.2  # to get nicer errors when connections fail
-- HaskellNet-SSL-0.3.4.1  # first version to support network-2.7
-
-# the following are just not on Stackage (and most of these were present in
-# LTS-11 but got evicted in LTS-12)
-- bloodhound-0.16.0.0
-- template-0.2.0.10
-- wai-route-0.4.0
-- text-format-0.3.2
-- redis-io-1.0.0
-- redis-resp-1.0.0
-- servant-multipart-0.11.2
-- wai-middleware-prometheus-1.0.0
-- prometheus-client-1.0.0
-- hedgehog-quickcheck-0.1
+- git: https://github.com/wireapp/saml2-web-sso
+  commit: 3e04ed8e605733cedfaa68d82808b450b2d4508f    # master (Jan 23, 2019)
+- git: https://github.com/wireapp/hscim
+  commit: 53db8029e17e7085322e7055f71efb5e7058d4a5    # master (Jan 23, 2019)
 
 flags:
   types-common:
@@ -173,7 +50,5 @@ flags:
 
   galley-types:
     cql: True
-
-extra-package-dbs: []
 
 allow-newer: False


### PR DESCRIPTION
This uses Stack's custom snapshot feature (<https://docs.haskellstack.org/en/stable/custom_snapshot/>). A custom snapshot extends the set of packages in the resolver and can be used from any other project (including other Wire repos). No more copying parts of stack.yaml from one project to another.

Custom snapshots are stored in `~/.stack`. This has several benefits:

* They survive `stack clean`. (Well, Git deps have to be cloned anyway because of a bug in Stack, but they won't be recompiled, only recloned, and for the biggest deps I've switched to using tarballs so that should be faster.)

* They survive branch switches (i.e. if different package versions are used in different branches, no recompiling is necessary when switching between the two).

* We no longer need to cache both `.stack` and `.stack-work` on CI.

A thing to keep in mind is that snapshots are immutable. A snapshot can be based on the previous version of the snapshot, but Stack takes a bit of time to symlink everything from the older snapshot to the newer one, so having a new snapshot every day would be inadvisable. For that reason packages that change frequently (like hscim) should remain in `stack.yaml`.