### PR TITLE
Enable journaling locally and fix integration tests

### DIFF
--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -30,14 +30,7 @@ settings:
 logLevel: Info
 logNetStrings: false
 
-### Journaling of team events
-#
-# If you want to use journaling but journal to a fake sqs service
-# such as "fake-sqs" or "localstack",
-# run e.g. `../../deploy/docker-ephemeral/run.sh`
-# and use a localhost endpoint
-#
-#journal: # if set, journals; if not set, disables journaling
-#  queueName: integration-team-events.fifo
-#  endpoint: http://localhost:4568 # https://sqs.eu-west-1.amazonaws.com
-#  region: eu-west-1
+journal: # if set, journals; if not set, disables journaling
+  queueName: integration-team-events.fifo
+  endpoint: http://localhost:4568 # https://sqs.eu-west-1.amazonaws.com
+  region: eu-west-1

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -432,7 +432,7 @@ testAddTeamConv g b c _ = do
         WS.assertNoEvent timeout ws
 
 testAddTeamConvAsExternalPartner :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
-testAddTeamConvAsExternalPartner g b _ _ = do
+testAddTeamConvAsExternalPartner g b _ a = do
     owner <- Util.randomUser b
     memMember1 <- newTeamMember' (rolePermissions RoleMember) <$> Util.randomUser b
     memMember2 <- newTeamMember' (rolePermissions RoleMember) <$> Util.randomUser b
@@ -440,8 +440,10 @@ testAddTeamConvAsExternalPartner g b _ _ = do
     Util.connectUsers b owner
         (list1 (memMember1^.userId) [memExternalPartner^.userId, memMember2^.userId])
     tid <- Util.createTeamInternal g "foo" owner
-    forM_ [memMember1, memMember2, memExternalPartner] $ \mem ->
+    assertQueue "create team" a tActivate
+    forM_ [(2, memMember1), (3, memMember2), (4, memExternalPartner)] $ \(i, mem) -> do
         Util.addTeamMemberInternal g tid mem
+        assertQueue ("team member join #" ++ show i) a $ tUpdate i [owner]
     let acc = Just $ Set.fromList [InviteAccess, CodeAccess]
     Util.createTeamConvAccessRaw g
         (memExternalPartner^.userId)


### PR DESCRIPTION
The tests got broken when a commit was introduced where one of the tests used `addTeamMemberInternal` and `addTeamMemberInternal` but didn't follow them up with a corresponding `assertQueue`.