### PR TITLE
Bump spar dependency

### DIFF
--- a/services/spar/src/Spar/Data/Instances.hs
+++ b/services/spar/src/Spar/Data/Instances.hs
@@ -24,7 +24,7 @@ instance Cql (SignedCertificate) where
     ctype = Tagged BlobColumn
     toCql = CqlBlob . cs . renderKeyInfo
 
-    fromCql (CqlBlob t) = parseKeyInfo (cs t)
+    fromCql (CqlBlob t) = parseKeyInfo False (cs t)
     fromCql _           = fail "SignedCertificate: expected CqlBlob"
 
 instance Cql (URIRef Absolute) where

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,7 +38,7 @@ packages:
 
 extra-deps:
 - git: https://github.com/wireapp/saml2-web-sso
-  commit: 3e04ed8e605733cedfaa68d82808b450b2d4508f    # master (Jan 23, 2019)
+  commit: 08f65c6ee07f5979300189c56e1dacfaeef3290e    # master (Feb 04, 2019)
 - git: https://github.com/wireapp/hscim
   commit: 53db8029e17e7085322e7055f71efb5e7058d4a5    # master (Jan 23, 2019)
 


### PR DESCRIPTION
Changes:

- IdP Metadata parsing implements some corner cases from the standard now.
- Notice and capture more IO exceptions (instead of turning them into impore exceptions).
- Capture noise on stdout / stderr emitted by libxml2 (which is a C library used by hsaml2, which is used by saml2-web-sso, for xml dsigs).

Please take a look at https://github.com/wireapp/saml2-web-sso/pull/44 when you review this.
