### PR TITLE
Add module descriptions for all Spar modules

### DIFF
--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -18,11 +18,17 @@
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE ViewPatterns               #-}
 
-{-# OPTIONS_GHC -Wno-orphans #-}
-
+-- | The API types, handlers, and WAI 'Application' for whole Spar.
+--
+-- Note: handlers are defined here, but API types are reexported from "Spar.API.Types". The
+-- SCIM branch of the API is fully defined in "Spar.Scim".
 module Spar.API
-  ( app, api
+  ( -- * Server
+    app, api
+
+    -- * API types
   , API, OutsideWorldAPI
+    -- ** Individual API pieces
   , APIMeta
   , APIAuthReqPrecheck
   , APIAuthReq

--- a/services/spar/src/Spar/API/Swagger.hs
+++ b/services/spar/src/Spar/API/Swagger.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE PackageImports             #-}
 {-# LANGUAGE QuasiQuotes                #-}
-{-# LANGUAGE QuasiQuotes                #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
@@ -17,7 +16,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Spar.API.Swagger where
+-- | Swagger instances for Spar types (as well as some types that are used in Spar but not
+-- defined in Spar).
+module Spar.API.Swagger () where
 
 import Imports
 import Control.Lens

--- a/services/spar/src/Spar/API/Types.hs
+++ b/services/spar/src/Spar/API/Types.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE ViewPatterns               #-}
 
+-- | Servant-based API description types for Spar.
 module Spar.API.Types where
 
 import Imports

--- a/services/spar/src/Spar/API/Util.hs
+++ b/services/spar/src/Spar/API/Util.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE PolyKinds             #-}
 
+-- | Swagger utilities.
 module Spar.API.Util where
 
 import Imports

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE ViewPatterns               #-}
 
+-- | The 'Spar' monad and a set of actions (e.g. 'createUser') that can be performed in it.
 module Spar.App
   ( Spar(..)
   , Env(..)

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE ViewPatterns               #-}
 
+-- | Manipulating Spar records in the database.
 module Spar.Data
   ( schemaVersion
   , Env(..)

--- a/services/spar/src/Spar/Data/Instances.hs
+++ b/services/spar/src/Spar/Data/Instances.hs
@@ -4,7 +4,17 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Spar.Data.Instances where
+-- | 'Cql' instances for Spar types, as well as conversion functions used in "Spar.Data"
+-- (which does the actual database work).
+module Spar.Data.Instances
+    (
+      -- * Raw database types
+      VerdictFormatRow
+    , VerdictFormatCon(..)
+      -- ** Conversions
+    , fromVerdictFormat
+    , toVerdictFormat
+    ) where
 
 import Imports
 import Cassandra as Cas

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -3,6 +3,13 @@
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
+-- | Error reporting in Spar.
+--
+-- All errors we throw are 'SparError's.
+--
+-- FUTUREWORK: since SCIM errors have their own format, the whole SCIM API subtree just wraps
+-- errors into 'SAML.CustomServant'. This could be reworked by creating a new branch in
+-- 'SparCustomError'.
 module Spar.Error
   ( SparError
   , SparCustomError(..)

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -12,7 +12,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE ViewPatterns               #-}
 
--- | Spar talking to Brig.
+-- | Client functions for interacting with the Brig API.
 module Spar.Intra.Brig where
 
 -- TODO: when creating user, we need to be able to provide more

--- a/services/spar/src/Spar/Intra/Galley.hs
+++ b/services/spar/src/Spar/Intra/Galley.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE ViewPatterns               #-}
 
--- | Spar talking to Galley.
+-- | Client functions for interacting with the Galley API.
 module Spar.Intra.Galley where
 
 import Imports

--- a/services/spar/src/Spar/Options.hs
+++ b/services/spar/src/Spar/Options.hs
@@ -10,6 +10,9 @@
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 
+-- | Reading the Spar config.
+--
+-- The config type itself, 'Opts', is defined in "Spar.Types".
 module Spar.Options
   ( getOpts
   , deriveOpts

--- a/services/spar/src/Spar/Orphans.hs
+++ b/services/spar/src/Spar/Orphans.hs
@@ -11,7 +11,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Spar.Orphans where
+-- | Miscellaneous orphan instances needed for Spar.
+module Spar.Orphans () where
 
 import Imports
 import Data.Id

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -13,8 +13,10 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 
-{-# OPTIONS_GHC -Wno-orphans #-}
-
+-- | The entry point for Spar.
+--
+-- (Well, as close to the entry point as we can get. The executable is produced by
+-- @exec/Main.hs@, but it's just a wrapper over 'runServer'.)
 module Spar.Run
   ( initCassandra
   , mkLogger

--- a/services/spar/src/Spar/Scim/Swagger.hs
+++ b/services/spar/src/Spar/Scim/Swagger.hs
@@ -17,7 +17,12 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Spar.Scim.Swagger where
+-- | Swagger instances for SCIM-related types that are defined in Spar.
+--
+-- /Note 2019-02-06:/ SCIM schema types from @hscim@ ('User', 'Group', etc) don't have Swagger
+-- instances yet and are unlikely to get them soon. For more details see
+-- <https://github.com/wireapp/hscim/pull/16>.
+module Spar.Scim.Swagger () where
 
 import Imports
 import Control.Lens

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -16,6 +16,11 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 
+-- | This module contains several categories of SCIM-related types:
+--
+-- * Our wrappers over @hscim@ types (like 'ValidScimUser').
+-- * Servant-based API types.
+-- * Request and response types for SCIM-related endpoints.
 module Spar.Scim.Types where
 
 import Imports

--- a/services/spar/src/Spar/Types.hs
+++ b/services/spar/src/Spar/Types.hs
@@ -13,6 +13,8 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 
+-- | A "default" module for types used in Spar, unless there's a better / more specific place
+-- for them.
 module Spar.Types where
 
 import Imports


### PR DESCRIPTION
I'm very often bitten by "should X go to this module or to some other module?", so I thought spending a bit of time on adding module descriptions would be a good idea.

I would also love it if CI barked at PRs that introduce modules without documentation. Thoughts?