### PR TITLE
Use /root/.stack rather than local stack-work files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ docker-services:
 	$(MAKE) -C services/nginz docker
 
 DOCKER_DEV_NETWORK := --net=host
-DOCKER_DEV_VOLUMES := -v `pwd`:/src/wire-server
+DOCKER_DEV_VOLUMES := -v `pwd`:/wire-server
 DOCKER_DEV_IMAGE   := quay.io/wire/alpine-builder:$(DOCKER_TAG)
 .PHONY: run-docker-builder
 run-docker-builder:

--- a/build/alpine/Dockerfile.builder
+++ b/build/alpine/Dockerfile.builder
@@ -3,7 +3,7 @@
 ARG prebuilder=quay.io/wire/alpine-prebuilder
 
 FROM ${prebuilder}
-WORKDIR /src/wire-server
+WORKDIR /
 
 # Download stack indices and compile/cache dependencies to speed up subsequent
 # container creation.
@@ -16,23 +16,13 @@ WORKDIR /src/wire-server
 # to avoid a Haddock segfault. See https://github.com/haskell/haddock/issues/928
 
 RUN apk add --no-cache git ncurses && \
-    mkdir -p /src && cd /src && \
-    git clone -b develop https://github.com/wireapp/wire-server.git && \
-    cd wire-server && \
+    git clone -b develop https://github.com/wireapp/wire-server.git && \ # Clone into /wire-server
+    cd /wire-server && \
     stack update && \
-    echo "allow-different-user: true"                                       >> /root/.stack/config.yaml && \
-    echo                                                                    >> /root/.stack/config.yaml && \
-    echo '# NB: do not touch following line!'                               >> /root/.stack/config.yaml && \
-    echo '# this image is used both for building docker images with the'    >> /root/.stack/config.yaml && \
-    echo '# integration tests (so they can be run on the ci) and for'       >> /root/.stack/config.yaml && \
-    echo '# interactive integration testing (with the working copy of the'  >> /root/.stack/config.yaml && \
-    echo '# host system mounted into the docker container).  in the latter' >> /root/.stack/config.yaml && \
-    echo '# use case, we want the docker container to write to its own'     >> /root/.stack/config.yaml && \
-    echo '# stack-work directory and not pollute the one on the host.'      >> /root/.stack/config.yaml && \
-    echo 'work-dir: .stack-docker'                                          >> /root/.stack/config.yaml && \
-    stack --work-dir .stack-docker-profile build --haddock --dependencies-only --profile haskell-src-exts && \
-    stack --work-dir .stack-docker         build --haddock --dependencies-only           haskell-src-exts && \
-    stack --work-dir .stack-docker-profile build --haddock --no-haddock-hyperlink-source --profile haskell-src-exts && \
-    stack --work-dir .stack-docker         build --haddock --no-haddock-hyperlink-source           haskell-src-exts && \
-    stack --work-dir .stack-docker-profile build --pedantic --haddock --test --no-run-tests --bench --no-run-benchmarks --dependencies-only --profile && \
-    stack --work-dir .stack-docker         build --pedantic --haddock --test --no-run-tests --bench --no-run-benchmarks --dependencies-only
+    echo "allow-different-user: true" >> /root/.stack/config.yaml && \
+    stack build --haddock --dependencies-only --profile haskell-src-exts && \
+    stack build --haddock --no-haddock-hyperlink-source --profile haskell-src-exts && \
+    stack build --pedantic --haddock --test --no-run-tests --bench --no-run-benchmarks --dependencies-only --profile && \
+    cd / && \
+    # we run the build only to cache the built source in /root/.stack, we can remove the source code itself
+    rm -rf /wire-server

--- a/build/alpine/Dockerfile.builder
+++ b/build/alpine/Dockerfile.builder
@@ -16,7 +16,7 @@ WORKDIR /
 # to avoid a Haddock segfault. See https://github.com/haskell/haddock/issues/928
 
 RUN apk add --no-cache git ncurses && \
-    git clone -b develop https://github.com/wireapp/wire-server.git && \ # Clone into /wire-server
+    git clone -b develop https://github.com/wireapp/wire-server.git && \
     cd /wire-server && \
     stack update && \
     echo "allow-different-user: true" >> /root/.stack/config.yaml && \

--- a/build/alpine/Dockerfile.intermediate
+++ b/build/alpine/Dockerfile.intermediate
@@ -12,16 +12,15 @@ ARG deps=quay.io/wire/alpine-deps
 #--- Builder stage ---
 FROM ${builder} as builder
 
-# ensure no stale files remain if they get deleted from the branch.
-RUN find /src/wire-server/ -maxdepth 1 -mindepth 1 | grep -v .stack- | xargs rm -rf
+WORKDIR /wire-server/
 
-COPY . /src/wire-server/
+COPY . /wire-server/
 
-RUN cd /src/wire-server && make clean install
+RUN make clean install
 
 #--- Minified stage ---
 FROM ${deps}
 
-COPY --from=builder /src/wire-server/dist/ /dist/
+COPY --from=builder /wire-server/dist/ /dist/
 # brig also needs some templates.
-COPY --from=builder /src/wire-server/services/brig/deb/opt/brig/templates/ /dist/templates/
+COPY --from=builder /wire-server/services/brig/deb/opt/brig/templates/ /dist/templates/


### PR DESCRIPTION
Remove the wire-server directory after pre-builder so there aren't files polluting the builder image.

We can do this now, because @neongreen has moved our dependencies into a snapshot; meaning they will be cached outside of the project in `/root/.stack`.

He also mentions we only need to [build once](https://github.com/wireapp/wire-server-private/pull/118#issuecomment-462281113):
> We also don't have to build twice (with profiling and without profiling) because custom snapshots play nicely with profiling, unlike local `.stack-work` dependencies.

I'll still need to make the appropriate adjustments to our Ubuntu server cache to not keep those files around, but this was just a start on simplifying things.

Unfortunately this may cause problems with @fisx 's work environment, but I volunteer to help him fix those 😄