### PR TITLE
Rich profiles

### DIFF
--- a/deploy/services-demo/conf/brig.demo-docker.yaml
+++ b/deploy/services-demo/conf/brig.demo-docker.yaml
@@ -95,7 +95,7 @@ optSettings:
   setUserCookieThrottle:
     stdDev: 3000      # 50 minutes
     retryAfter: 86400 # 1 day
-  setRichInfoLimit: 5000
+  setRichInfoLimit: 5000  # should be in sync with Spar
   setDefaultLocale: en
   setMaxTeamSize: 128
   setMaxConvSize: 128

--- a/deploy/services-demo/conf/brig.demo-docker.yaml
+++ b/deploy/services-demo/conf/brig.demo-docker.yaml
@@ -95,6 +95,7 @@ optSettings:
   setUserCookieThrottle:
     stdDev: 3000      # 50 minutes
     retryAfter: 86400 # 1 day
+  setRichInfoLimit: 5000
   setDefaultLocale: en
   setMaxTeamSize: 128
   setMaxConvSize: 128

--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -95,7 +95,7 @@ optSettings:
   setUserCookieThrottle:
     stdDev: 3000      # 50 minutes
     retryAfter: 86400 # 1 day
-  setRichInfoLimit: 5000
+  setRichInfoLimit: 5000  # should be in sync with Spar
   setDefaultLocale: en
   setMaxTeamSize: 128
   setMaxConvSize: 128

--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -95,6 +95,7 @@ optSettings:
   setUserCookieThrottle:
     stdDev: 3000      # 50 minutes
     retryAfter: 86400 # 1 day
+  setRichInfoLimit: 5000
   setDefaultLocale: en
   setMaxTeamSize: 128
   setMaxConvSize: 128

--- a/deploy/services-demo/conf/spar.demo-docker.yaml
+++ b/deploy/services-demo/conf/spar.demo-docker.yaml
@@ -32,5 +32,6 @@ maxttlAuthreq: 28800 # 8h
 maxttlAuthresp: 28800 # 8h
 
 maxScimTokens: 16
+richInfoLimit: 5000  # should be in sync with Brig
 
 logNetStrings: False # log using netstrings encoding (see http://cr.yp.to/proto/netstrings.txt)

--- a/deploy/services-demo/conf/spar.demo.yaml
+++ b/deploy/services-demo/conf/spar.demo.yaml
@@ -32,5 +32,6 @@ maxttlAuthreq: 28800 # 8h
 maxttlAuthresp: 28800 # 8h
 
 maxScimTokens: 16
+richInfoLimit: 5000  # should be in sync with Brig
 
 logNetStrings: False # log using netstrings encoding (see http://cr.yp.to/proto/netstrings.txt)

--- a/docs/reference/user/rich-info.md
+++ b/docs/reference/user/rich-info.md
@@ -100,4 +100,4 @@ Rich info can not be pulled from Wire and will not show up in SCIM queries.
 
 ## Limitations {#RefRichInfoLimitations}
 
-* JSON-encoded rich info cannot exceed 5000 characters in length. There are no limitations on the number of fields, or the length of field names or values.
+* The whole of user-submitted information (field names and values) cannot exceed 5000 characters in length. There are no limitations on the number of fields, or the length of field names or values.

--- a/docs/reference/user/rich-info.md
+++ b/docs/reference/user/rich-info.md
@@ -102,4 +102,6 @@ Rich info can not be pulled from Wire and will not show up in SCIM queries.
 
 ## Limitations {#RefRichInfoLimitations}
 
-* The whole of user-submitted information (field names and values) cannot exceed 5000 characters in length. There are no limitations on the number of fields, or the length of field names or values.
+* The whole of user-submitted information (field names and values) cannot exceed 5000 characters in length. There are no limitations on the number of fields, or the maximum of field names or values.
+
+* Field values can not be empty (`""`). If they are empty, the corresponding field will be removed.

--- a/docs/reference/user/rich-info.md
+++ b/docs/reference/user/rich-info.md
@@ -10,7 +10,7 @@ This page describes a part of the user profile called "Rich info". The correspon
 
 For every team user we can store a list of key-value pairs that are displayed in the user profile. This is similar to "custom profile fields" in Slack and other enterprise messengers.
 
-Different users can have different sets of fields; there is no team-wide schema for fields. All fields are strings.
+Different users can have different sets of fields; there is no team-wide schema for fields. All field values are strings. Fields are passed as an ordered list, and the order information is preserved when displaying fields in client apps.
 
 Only team members and partners can see the user's rich info.
 
@@ -38,7 +38,7 @@ Only team members and partners can see the user's rich info.
 
 If the requesting user is not allowed to see rich info, error code 403 is returned with the `"insufficient-permissions"` error label.
 
-If the rich info is missing, an empty field list is returned:
+Otherwise, if the rich info is missing, an empty field list is returned:
 
 ```json
 {
@@ -49,7 +49,7 @@ If the rich info is missing, an empty field list is returned:
 
 ### Setting rich info {#RefRichInfoPut}
 
-Not implemented yet.
+**Not implemented yet.** Currently the only way to set rich info is via SCIM.
 
 ### Events {#RefRichInfoEvents}
 
@@ -70,7 +70,7 @@ Connected users who are not members of user's team will not receive an event (no
 
 ## SCIM support {#RefRichInfoScim}
 
-Rich info can be pushed to Wire by setting the `"richInfo"` field belonging to the `"urn:wire:scim:schemas:profile:1.0"` extension. Both `PUT /scim/v2/Users/:id` and `PUT /scim/v2/Users/:id` are supported.
+Rich info can be pushed to Wire by setting the `"richInfo"` field belonging to the `"urn:wire:scim:schemas:profile:1.0"` extension. Both `PUT /scim/v2/Users/:id` and `POST /scim/v2/Users/:id` can contain rich info. Here is an example for `PUT`:
 
 ```javascript
 PUT /scim/v2/Users/:id

--- a/docs/reference/user/rich-info.md
+++ b/docs/reference/user/rich-info.md
@@ -1,0 +1,103 @@
+# Rich info {#RefRichInfo}
+
+_Author: Artyom Kazak_
+
+---
+
+This page describes a part of the user profile called "Rich info". The corresponding feature is called "Rich profiles".
+
+## Summary {#RefRichInfoSummary}
+
+For every team user we can store a list of key-value pairs that are displayed in the user profile. This is similar to "custom profile fields" in Slack and other enterprise messengers.
+
+Different users can have different sets of fields; there is no team-wide schema for fields. All fields are strings.
+
+Only team members and partners can see the user's rich info.
+
+## API {#RefRichInfoApi}
+
+### Querying rich info {#RefRichInfoGet}
+
+`GET /users/:user/rich-info`. Sample output:
+
+```json
+{
+    "fields": [
+        {
+            "type": "Department",
+            "value": "Sales & Marketing"
+        },
+        {
+            "type": "Favorite color",
+            "value": "Blue"
+        }
+    ]
+}
+```
+
+If the requesting user is not allowed to see rich info, error code 403 is returned with the `"insufficient-permissions"` error label.
+
+If the rich info is missing, an empty field list is returned:
+
+```json
+{
+    "fields": []
+}
+```
+
+### Setting rich info {#RefRichInfoPut}
+
+Not implemented yet.
+
+### Events {#RefRichInfoEvents}
+
+**Not implemented yet.**
+
+When user's rich info changes, the backend sends out an event to all team members:
+
+```json
+{
+    "type": "user.rich-info-update",
+    "user": {
+        "id": "<user ID>"
+    }
+}
+```
+
+Connected users who are not members of user's team will not receive an event (nor can they query user's rich info by other means).
+
+## SCIM support {#RefRichInfoScim}
+
+Rich info can be pushed to Wire by setting the `"richInfo"` field belonging to the `"urn:wire:scim:schemas:profile:1.0"` extension. Both `PUT /scim/v2/Users/:id` and `PUT /scim/v2/Users/:id` are supported.
+
+```javascript
+PUT /scim/v2/Users/:id
+
+{
+    ...,
+    "urn:wire:scim:schemas:profile:1.0": {
+        "richInfo": [
+            {
+                "type": "Department",
+                "value": "Sales & Marketing"
+            },
+            {
+                "type": "Favorite color",
+                "value": "Blue"
+            }
+        ]
+    }
+}
+```
+
+Rich info can not be pulled from Wire and will not show up in SCIM queries.
+
+### SCIM provisioning agent support {#RefRichInfoScimAgents}
+
+* Okta: unable to push fields in the format we require (checked on 2019-02-21).
+
+* OneLogin: likely able to push fields.
+
+## Limitations {#RefRichInfoLimitations}
+
+* JSON-encoded rich info cannot exceed 5000 characters in length. There are no limitations on the number of fields, or the length of field names or values.

--- a/docs/reference/user/rich-info.md
+++ b/docs/reference/user/rich-info.md
@@ -22,6 +22,7 @@ Only team members and partners can see the user's rich info.
 
 ```json
 {
+    "version": 0,
     "fields": [
         {
             "type": "Department",
@@ -41,6 +42,7 @@ If the rich info is missing, an empty field list is returned:
 
 ```json
 {
+    "version": 0,
     "fields": []
 }
 ```

--- a/docs/reference/user/rich-info.md
+++ b/docs/reference/user/rich-info.md
@@ -102,6 +102,6 @@ Rich info set via SCIM can be queried by doing a `GET /scim/v2/Users` or `GET /s
 
 ## Limitations {#RefRichInfoLimitations}
 
-* The whole of user-submitted information (field names and values) cannot exceed 5000 characters in length. There are no limitations on the number of fields, or the maximum of field names or values.
+* The whole of user-submitted information (field names and values) cannot exceed 5000 characters in length. There are no limitations on the number of fields, or the maximum of individual field names or values.
 
 * Field values can not be empty (`""`). If they are empty, the corresponding field will be removed.

--- a/docs/reference/user/rich-info.md
+++ b/docs/reference/user/rich-info.md
@@ -92,7 +92,7 @@ PUT /scim/v2/Users/:id
 }
 ```
 
-Rich info can not be pulled from Wire and will not show up in SCIM queries.
+Rich info set via SCIM can be queried by doing a `GET /scim/v2/Users` or `GET /scim/v2/Users/:id` query.
 
 ### SCIM provisioning agent support {#RefRichInfoScimAgents}
 

--- a/libs/brig-types/package.yaml
+++ b/libs/brig-types/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: brig-types
 version: '1.35.0'
@@ -46,8 +46,8 @@ library:
   - bytestring-conversion >=0.2
   - containers >=0.5
   - currency-codes >=2.0
-  - galley-types >=0.45.7
   - errors >=1.4
+  - galley-types >=0.45.7
   - hashable
   - iproute >=1.5
   - iso3166-country-codes >=0.2
@@ -79,6 +79,7 @@ tests:
     - bytestring
     - containers
     - currency-codes
+    - extra
     - galley-types
     - iproute
     - iso639

--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -29,6 +29,8 @@ brigModels =
     , asset
     , userHandleInfo
     , checkHandles
+    , richInfo
+    , richField
 
       -- User Connections / Invitations
     , connection
@@ -180,6 +182,20 @@ asset = defineModel "UserAsset" $ do
         description "The asset type"
     property "size" assetSize $
         description "The asset size / format"
+
+richField :: Model
+richField = defineModel "RichField" $ do
+    description "RichInfo field"
+    property "type" string' $
+        description "Field name"
+    property "value" string' $
+        description "Field value"
+
+richInfo :: Model
+richInfo = defineModel "RichInfo" $ do
+    description "Rich info about the user"
+    property "fields" (array (ref richField)) $
+        description "List of fields"
 
 userName :: Model
 userName = defineModel "UserName" $ do

--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -196,6 +196,8 @@ richInfo = defineModel "RichInfo" $ do
     description "Rich info about the user"
     property "fields" (array (ref richField)) $
         description "List of fields"
+    property "version" int32' $
+        description "Format version (the current version is 0)"
 
 userName :: Model
 userName = defineModel "UserName" $ do

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -274,6 +274,12 @@ instance FromJSON RichField where
             <$> o .: "type"
             <*> o .: "value"
 
+-- | Empty rich info, returned for users who don't have rich info set.
+emptyRichInfo :: RichInfo
+emptyRichInfo = RichInfo
+    { richInfoFields = []
+    }
+
 -----------------------------------------------------------------------------
 -- New Users
 
@@ -470,6 +476,7 @@ newtype EmailUpdate = EmailUpdate { euEmail :: Email } deriving (Eq, Show)
 newtype PhoneUpdate = PhoneUpdate { puPhone :: Phone } deriving (Eq, Show)
 newtype HandleUpdate = HandleUpdate { huHandle :: Text } deriving (Eq, Show)
 newtype ManagedByUpdate = ManagedByUpdate { mbuManagedBy :: ManagedBy } deriving (Eq, Show)
+newtype RichInfoUpdate = RichInfoUpdate { riuRichInfo :: RichInfo } deriving (Eq, Show)
 
 newtype EmailRemove = EmailRemove { erEmail :: Email } deriving (Eq, Show)
 newtype PhoneRemove = PhoneRemove { prPhone :: Phone } deriving (Eq, Show)
@@ -526,6 +533,13 @@ instance FromJSON ManagedByUpdate where
 
 instance ToJSON ManagedByUpdate where
     toJSON m = object ["managed_by" .= mbuManagedBy m]
+
+instance FromJSON RichInfoUpdate where
+    parseJSON = withObject "rich-info-update" $ \o ->
+        RichInfoUpdate <$> o .: "rich_info"
+
+instance ToJSON RichInfoUpdate where
+    toJSON m = object ["rich_info" .= riuRichInfo m]
 
 instance FromJSON EmailRemove where
     parseJSON = withObject "email-remove" $ \o ->

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -235,6 +235,45 @@ instance FromJSON SelfProfile where
 instance ToJSON SelfProfile where
     toJSON (SelfProfile u) = toJSON u
 
+----------------------------------------------------------------------------
+-- Rich info
+
+data RichInfo = RichInfo
+    { richInfoFields :: ![RichField]
+    }
+    deriving (Eq, Show)
+
+instance ToJSON RichInfo where
+    toJSON u = object
+        [ "fields" .= richInfoFields u
+        , "version" .= (0 :: Int)
+        ]
+
+instance FromJSON RichInfo where
+    parseJSON = withObject "RichInfo" $ \o -> do
+        o .:? "version" >>= \case
+            Nothing -> RichInfo <$> o .: "fields"
+            Just (0 :: Int) -> RichInfo <$> o .: "fields"
+            Just v -> fail ("unknown version: " <> show v)
+
+data RichField = RichField
+    { richFieldType  :: !Text
+    , richFieldValue :: !Text
+    }
+    deriving (Eq, Show)
+
+instance ToJSON RichField where
+    toJSON u = object
+        [ "type" .= richFieldType u
+        , "value" .= richFieldValue u
+        ]
+
+instance FromJSON RichField where
+    parseJSON = withObject "RichField" $ \o -> do
+        RichField
+            <$> o .: "type"
+            <*> o .: "value"
+
 -----------------------------------------------------------------------------
 -- New Users
 

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -303,6 +303,12 @@ richInfoSize :: RichInfo -> Int
 richInfoSize (RichInfo fields) =
     sum [Text.length t + Text.length v | RichField t v <- fields]
 
+-- | Remove fields with @""@ values.
+normalizeRichInfo :: RichInfo -> RichInfo
+normalizeRichInfo RichInfo{..} = RichInfo
+    { richInfoFields = filter (not . Text.null . richFieldValue) richInfoFields
+    }
+
 -----------------------------------------------------------------------------
 -- New Users
 

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -264,6 +264,10 @@ data RichField = RichField
     deriving (Eq, Show)
 
 instance ToJSON RichField where
+    -- NB: "name" would be a better name for 'richFieldType', but "type" is used because we
+    -- also have "type" in SCIM; and the reason we use "type" for SCIM is that @{"type": ...,
+    -- "value": ...}@ is how all other SCIM payloads are formatted, so it's quite possible
+    -- that some provisioning agent would support "type" but not "name".
     toJSON u = object
         [ "type" .= richFieldType u
         , "value" .= richFieldValue u

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -240,7 +240,7 @@ instance ToJSON SelfProfile where
 -- Rich info
 
 data RichInfo = RichInfo
-    { richInfoFields :: ![RichField]
+    { richInfoFields :: ![RichField]  -- ^ An ordered list of fields
     }
     deriving (Eq, Show)
 
@@ -252,10 +252,10 @@ instance ToJSON RichInfo where
 
 instance FromJSON RichInfo where
     parseJSON = withObject "RichInfo" $ \o -> do
-        o .:? "version" >>= \case
-            Nothing -> RichInfo <$> o .: "fields"
-            Just (0 :: Int) -> RichInfo <$> o .: "fields"
-            Just v -> fail ("unknown version: " <> show v)
+        version :: Int <- o .: "version"
+        case version of
+            0 -> RichInfo <$> o .: "fields"
+            _ -> fail ("unknown version: " <> show version)
 
 data RichField = RichField
     { richFieldType  :: !Text

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -31,6 +31,7 @@ import Galley.Types.Teams hiding (userId)
 import qualified Brig.Types.Code     as Code
 import qualified Data.Currency       as Currency
 import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Text           as Text
 
 -----------------------------------------------------------------------------
 -- User Attributes
@@ -279,6 +280,15 @@ emptyRichInfo :: RichInfo
 emptyRichInfo = RichInfo
     { richInfoFields = []
     }
+
+-- | Calculate the length of user-supplied data in 'RichInfo'. Used for enforcing
+-- 'setRichInfoLimit'
+--
+-- NB: we could just calculate the length of JSON-encoded payload, but it is fragile because
+-- if our JSON encoding changes, existing payloads might become unacceptable.
+richInfoSize :: RichInfo -> Int
+richInfoSize (RichInfo fields) =
+    sum [Text.length t + Text.length v | RichField t v <- fields]
 
 -----------------------------------------------------------------------------
 -- New Users

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -303,6 +303,15 @@ instance Arbitrary UserProfile where
         <*> arbitrary
         <*> arbitrary
 
+instance Arbitrary RichField where
+    arbitrary = RichField <$> arbitrary <*> arbitrary
+
+instance Arbitrary RichInfo where
+    arbitrary = RichInfo <$> arbitrary
+
+instance Arbitrary RichInfoUpdate where
+    arbitrary = RichInfoUpdate <$> arbitrary
+
 instance Arbitrary ServiceRef where
     arbitrary = ServiceRef <$> arbitrary <*> arbitrary
 

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -29,6 +29,7 @@ import Data.Currency
 import Data.IP
 import Data.Json.Util (UTCTimeMillis (..), toUTCTimeMillis)
 import Data.LanguageCodes
+import Data.List.Extra (nubOn)
 import Data.Misc
 import Data.Proxy
 import Data.Range
@@ -307,7 +308,9 @@ instance Arbitrary RichField where
     arbitrary = RichField <$> arbitrary <*> arbitrary
 
 instance Arbitrary RichInfo where
-    arbitrary = RichInfo <$> arbitrary
+    arbitrary = do
+        richInfoFields <- nubOn richFieldType <$> arbitrary
+        pure RichInfo{..}
 
 instance Arbitrary RichInfoUpdate where
     arbitrary = RichInfoUpdate <$> arbitrary

--- a/libs/brig-types/test/unit/Test/Brig/Types/User.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/User.hs
@@ -96,6 +96,7 @@ roundtripTests =
     , run @UserIdentity Proxy
     , run @UserProfile Proxy
     , run @User Proxy
+    , run @RichInfo Proxy
     , run @UserUpdate Proxy
     , run @VerifyDeleteUser Proxy
     ]

--- a/libs/brig-types/test/unit/Test/Brig/Types/User.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/User.hs
@@ -98,6 +98,7 @@ roundtripTests =
     , run @User Proxy
     , run @RichInfo Proxy
     , run @UserUpdate Proxy
+    , run @RichInfoUpdate Proxy
     , run @VerifyDeleteUser Proxy
     ]
   where

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -127,6 +127,7 @@ optSettings:
   setUserCookieThrottle:
     stdDev: 5
     retryAfter: 1
+  setRichInfoLimit: 5000
   setDefaultLocale: en
   setMaxTeamSize: 32
   setMaxConvSize: 16

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -127,7 +127,7 @@ optSettings:
   setUserCookieThrottle:
     stdDev: 5
     retryAfter: 1
-  setRichInfoLimit: 5000
+  setRichInfoLimit: 5000  # should be in sync with Spar
   setDefaultLocale: en
   setMaxTeamSize: 32
   setMaxConvSize: 16

--- a/services/brig/schema/src/Main.hs
+++ b/services/brig/schema/src/Main.hs
@@ -52,6 +52,7 @@ import qualified V54
 import qualified V55
 import qualified V56
 import qualified V57
+import qualified V58
 
 main :: IO ()
 main = do
@@ -106,4 +107,5 @@ main = do
         , V55.migration
         , V56.migration
         , V57.migration
+        , V58.migration
         ] `finally` close l

--- a/services/brig/schema/src/V58.hs
+++ b/services/brig/schema/src/V58.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module V58 (migration) where
+
+import Imports
+import Cassandra.Schema
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 58 "Add table for storing rich info" $ do
+    void $ schema' [r|
+        create table if not exists rich_info
+            ( user uuid
+            , json blob
+            , primary key (user)
+            )
+    |]

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1085,7 +1085,7 @@ listPrekeyIds :: UserId ::: ClientId ::: JSON -> Handler Response
 listPrekeyIds (usr ::: clt ::: _) = json <$> lift (API.lookupPrekeyIds usr clt)
 
 autoConnect :: JSON ::: JSON ::: UserId ::: Maybe ConnId ::: Request -> Handler Response
-autoConnect(_ ::: _ ::: uid ::: conn ::: req) = do
+autoConnect (_ ::: _ ::: uid ::: conn ::: req) = do
     UserSet to <- parseJsonBody req
     let num = Set.size to
     when (num < 1) $

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -218,6 +218,12 @@ sitemap o = do
       .&. contentType "application" "json"
       .&. request
 
+    put "/i/users/:uid/rich-info" (continue updateRichInfo) $
+      capture "uid"
+      .&. accept "application" "json"
+      .&. contentType "application" "json"
+      .&. request
+
     post "/i/clients" (continue internalListClients) $
       accept "application" "json"
       .&. contentType "application" "json"
@@ -394,6 +400,21 @@ sitemap o = do
             Doc.description "Client ID"
         Doc.returns (Doc.ref Doc.pubClient)
         Doc.response 200 "Client" Doc.end
+
+    --
+
+    get "/users/:user/rich-info" (continue getRichInfo) $
+        header "Z-User"
+        .&. capture "user"
+        .&. accept "application" "json"
+
+    document "GET" "getRichInfo" $ do
+        Doc.summary "Get user's rich info"
+        Doc.parameter Doc.Path "user" Doc.bytes' $
+            Doc.description "User ID"
+        Doc.returns (Doc.ref Doc.richInfo)
+        Doc.response 200 "RichInfo" Doc.end
+        Doc.errorResponse insufficientTeamPermissions
 
     -- /self ------------------------------------------------------------------
 
@@ -1081,6 +1102,18 @@ getUserClient (user ::: cid ::: _) = lift $ do
         Just c  -> json c
         Nothing -> setStatus status404 empty
 
+getRichInfo :: UserId ::: UserId ::: JSON -> Handler Response
+getRichInfo (self ::: user ::: _) = do
+    -- Check that both users exist and the requesting user is allowed to see rich info of the
+    -- other user
+    selfUser  <- ifNothing userNotFound =<< lift (Data.lookupUser self)
+    otherUser <- ifNothing userNotFound =<< lift (Data.lookupUser user)
+    case (userTeam selfUser, userTeam otherUser) of
+        (Just t1, Just t2) | t1 == t2 -> pure ()
+        _ -> throwStd insufficientTeamPermissions
+    -- Query rich info
+    json . fromMaybe emptyRichInfo <$> lift (API.lookupRichInfo user)
+
 listPrekeyIds :: UserId ::: ClientId ::: JSON -> Handler Response
 listPrekeyIds (usr ::: clt ::: _) = json <$> lift (API.lookupPrekeyIds usr clt)
 
@@ -1467,6 +1500,12 @@ updateManagedBy :: UserId ::: JSON ::: JSON ::: Request -> Handler Response
 updateManagedBy (uid ::: _ ::: _ ::: req) = do
     ManagedByUpdate managedBy <- parseJsonBody req
     lift $ Data.updateManagedBy uid managedBy
+    return empty
+
+updateRichInfo :: UserId ::: JSON ::: JSON ::: Request -> Handler Response
+updateRichInfo (uid ::: _ ::: _ ::: req) = do
+    RichInfoUpdate richInfo <- parseJsonBody req
+    lift $ Data.updateRichInfo uid richInfo
     return empty
 
 deleteUser :: UserId ::: Request ::: JSON ::: JSON -> Handler Response

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1504,10 +1504,12 @@ updateManagedBy (uid ::: _ ::: _ ::: req) = do
 
 updateRichInfo :: UserId ::: JSON ::: JSON ::: Request -> Handler Response
 updateRichInfo (uid ::: _ ::: _ ::: req) = do
-    RichInfoUpdate richInfo <- parseJsonBody req
+    richInfo <- normalizeRichInfo . riuRichInfo <$> parseJsonBody req
     maxSize <- setRichInfoLimit <$> view settings
     when (richInfoSize richInfo > maxSize) $ throwStd tooLargeRichInfo
     lift $ Data.updateRichInfo uid richInfo
+    -- FUTUREWORK: send an event
+    -- Intra.onUserEvent uid (Just conn) (richInfoUpdate uid ri)
     return empty
 
 deleteUser :: UserId ::: Request ::: JSON ::: JSON -> Handler Response

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1505,6 +1505,8 @@ updateManagedBy (uid ::: _ ::: _ ::: req) = do
 updateRichInfo :: UserId ::: JSON ::: JSON ::: Request -> Handler Response
 updateRichInfo (uid ::: _ ::: _ ::: req) = do
     RichInfoUpdate richInfo <- parseJsonBody req
+    maxSize <- setRichInfoLimit <$> view settings
+    when (richInfoSize richInfo > maxSize) $ throwStd tooLargeRichInfo
     lift $ Data.updateRichInfo uid richInfo
     return empty
 

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -337,6 +337,14 @@ authTokenInvalid = Wai.Error status403 "invalid-credentials" "Invalid token"
 incorrectPermissions :: Wai.Error
 incorrectPermissions = Wai.Error status403 "invalid-permissions" "Copy permissions must be a subset of self permissions"
 
+-- | User's relation to the team is not what we expect it to be. Examples:
+--
+-- * Requested action requires the user to be a team member, but the user doesn't belong to
+--   the team.
+--
+-- * Requested action requires the user to be a team owner.
+--
+-- * Requested action can't be performed if the user is the only team owner left in the team.
 insufficientTeamPermissions :: Wai.Error
 insufficientTeamPermissions = Wai.Error status403 "insufficient-permissions" "Insufficient team permissions"
 

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -367,6 +367,9 @@ tooManyTeamMembers = Wai.Error status403 "too-many-team-members" "Too many membe
 loginsTooFrequent :: Wai.Error
 loginsTooFrequent = Wai.Error status429 "client-error" "Logins too frequent"
 
+tooLargeRichInfo :: Wai.Error
+tooLargeRichInfo = Wai.Error status413 "too-large-rich-info" "Rich info has exceeded the limit"
+
 internalServerError :: Wai.Error
 internalServerError = Wai.Error status500 "internal-server-error" "Internal Server Error"
 

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -12,6 +12,7 @@ module Brig.API.User
     , lookupHandle
     , changeManagedBy
     , changeAccountStatus
+    , changeRichInfo
     , Data.lookupAccounts
     , Data.lookupAccount
     , Data.lookupStatus
@@ -22,6 +23,7 @@ module Brig.API.User
     , Data.lookupName
     , Data.lookupLocale
     , Data.lookupUser
+    , Data.lookupRichInfo
     , removeEmail
     , removePhone
     , revokeIdentity
@@ -327,6 +329,15 @@ changeHandle uid conn hdl = do
         unless claimed $
             throwE ChangeHandleExists
         lift $ Intra.onUserEvent uid (Just conn) (handleUpdated uid hdl)
+
+----------------------------------------------------------------------------
+-- Change Rich Info
+
+changeRichInfo :: UserId -> ConnId -> RichInfoUpdate -> AppIO ()
+changeRichInfo uid _conn (RichInfoUpdate ri) = do
+    Data.updateRichInfo uid ri
+    -- FUTUREWORK: send an event
+    -- Intra.onUserEvent uid (Just conn) (richInfoUpdate uid ri)
 
 --------------------------------------------------------------------------------
 -- Check Handles

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -12,7 +12,6 @@ module Brig.API.User
     , lookupHandle
     , changeManagedBy
     , changeAccountStatus
-    , changeRichInfo
     , Data.lookupAccounts
     , Data.lookupAccount
     , Data.lookupStatus
@@ -329,15 +328,6 @@ changeHandle uid conn hdl = do
         unless claimed $
             throwE ChangeHandleExists
         lift $ Intra.onUserEvent uid (Just conn) (handleUpdated uid hdl)
-
-----------------------------------------------------------------------------
--- Change Rich Info
-
-changeRichInfo :: UserId -> ConnId -> RichInfoUpdate -> AppIO ()
-changeRichInfo uid _conn (RichInfoUpdate ri) = do
-    Data.updateRichInfo uid ri
-    -- FUTUREWORK: send an event
-    -- Intra.onUserEvent uid (Just conn) (richInfoUpdate uid ri)
 
 --------------------------------------------------------------------------------
 -- Check Handles

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -109,7 +109,7 @@ import qualified System.Logger            as Log
 import qualified System.Logger.Class      as LC
 
 schemaVersion :: Int32
-schemaVersion = 57
+schemaVersion = 58
 
 -------------------------------------------------------------------------------
 -- Environment

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -313,6 +313,9 @@ lookupAuth u = fmap f <$> retry x1 (query1 authSelect (params Quorum (Identity u
   where
     f (pw, st) = (pw, fromMaybe Active st)
 
+-- | Return users with given IDs.
+--
+-- Skips nonexistent users. /Does not/ skip users who have been deleted.
 lookupUsers :: [UserId] -> AppIO [User]
 lookupUsers usrs = do
     loc <- setDefaultLocale  <$> view settings

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -7,10 +7,13 @@ module Brig.Data.User
     ( AuthError (..)
     , ReAuthError (..)
     , newAccount
+    , insertAccount
     , authenticate
     , reauthenticate
     , filterActive
     , isActivated
+
+    -- * Lookups
     , lookupAccount
     , lookupAccounts
     , lookupUser
@@ -19,8 +22,12 @@ module Brig.Data.User
     , lookupLocale
     , lookupPassword
     , lookupStatus
+    , lookupRichInfo
     , lookupUserTeam
-    , insertAccount
+    , lookupServiceUsers
+    , lookupServiceUsersForTeam
+
+    -- * Updates
     , updateUser
     , updateEmail
     , updatePhone
@@ -32,12 +39,13 @@ module Brig.Data.User
     , updatePassword
     , updateStatus
     , updateSearchableStatus
+    , updateHandle
+    , updateRichInfo
+
+    -- * Deletions
     , deleteEmail
     , deletePhone
     , deleteServiceUser
-    , lookupServiceUsers
-    , lookupServiceUsersForTeam
-    , updateHandle
     ) where
 
 import Imports
@@ -214,6 +222,9 @@ updatePassword u t = do
     p <- liftIO $ mkSafePassword t
     retry x5 $ write userPasswordUpdate (params Quorum (p, u))
 
+updateRichInfo :: UserId -> RichInfo -> AppIO ()
+updateRichInfo u ri = retry x5 $ write userRichInfoUpdate (params Quorum (ri, u))
+
 deleteEmail :: UserId -> AppIO ()
 deleteEmail u = retry x5 $ write userEmailDelete (params Quorum (Identity u))
 
@@ -288,6 +299,10 @@ lookupPassword u = join . fmap runIdentity <$>
 lookupStatus :: UserId -> AppIO (Maybe AccountStatus)
 lookupStatus u = join . fmap runIdentity <$>
     retry x1 (query1 statusSelect (params Quorum (Identity u)))
+
+lookupRichInfo :: UserId -> AppIO (Maybe RichInfo)
+lookupRichInfo u = fmap runIdentity <$>
+    retry x1 (query1 richInfoSelect (params Quorum (Identity u)))
 
 lookupUserTeam :: UserId -> AppIO (Maybe TeamId)
 lookupUserTeam u = join . fmap runIdentity <$>
@@ -392,6 +407,9 @@ accountStateSelectAll = "SELECT id, activated, status FROM user WHERE id IN ?"
 statusSelect :: PrepQuery R (Identity UserId) (Identity (Maybe AccountStatus))
 statusSelect = "SELECT status FROM user WHERE id = ?"
 
+richInfoSelect :: PrepQuery R (Identity UserId) (Identity RichInfo)
+richInfoSelect = "SELECT json FROM rich_info WHERE user = ?"
+
 teamSelect :: PrepQuery R (Identity UserId) (Identity (Maybe TeamId))
 teamSelect = "SELECT team FROM user WHERE id = ?"
 
@@ -457,6 +475,9 @@ userEmailDelete = "UPDATE user SET email = null WHERE id = ?"
 
 userPhoneDelete :: PrepQuery W (Identity UserId) ()
 userPhoneDelete = "UPDATE user SET phone = null WHERE id = ?"
+
+userRichInfoUpdate :: PrepQuery W (RichInfo, UserId) ()
+userRichInfoUpdate = "UPDATE rich_info SET json = ? WHERE user = ?"
 
 -------------------------------------------------------------------------------
 -- Conversions

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -225,7 +225,8 @@ data Settings = Settings
                                             --   it is renewed during token refresh
     , setUserCookieLimit       :: !Int      -- ^ Max. # of cookies per user and cookie type
     , setUserCookieThrottle    :: !CookieThrottle -- ^ Throttling settings
-    , setRichInfoLimit         :: !Int     -- ^ Max size of rich info, field names+values
+    , setRichInfoLimit         :: !Int     -- ^ Max size of rich info (field names and
+                                           --   values), should be in sync with Spar
     , setDefaultLocale         :: !Locale  -- ^ Default locale to use
                                            --   (e.g. when selecting templates)
     , setMaxTeamSize           :: !Word16  -- ^ Max. # of members in a team.

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -225,8 +225,9 @@ data Settings = Settings
                                             --   it is renewed during token refresh
     , setUserCookieLimit       :: !Int      -- ^ Max. # of cookies per user and cookie type
     , setUserCookieThrottle    :: !CookieThrottle -- ^ Throttling settings
-    , setRichInfoLimit         :: !Int     -- ^ Max size of rich info (field names and
-                                           --   values), should be in sync with Spar
+    , setRichInfoLimit         :: !Int     -- ^ Max size of rich info (number of chars in
+                                           --   field names and values), should be in sync
+                                           --   with Spar
     , setDefaultLocale         :: !Locale  -- ^ Default locale to use
                                            --   (e.g. when selecting templates)
     , setMaxTeamSize           :: !Word16  -- ^ Max. # of members in a team.

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -225,6 +225,7 @@ data Settings = Settings
                                             --   it is renewed during token refresh
     , setUserCookieLimit       :: !Int      -- ^ Max. # of cookies per user and cookie type
     , setUserCookieThrottle    :: !CookieThrottle -- ^ Throttling settings
+    , setRichInfoLimit         :: !Int     -- ^ Max size of rich info, field names+values
     , setDefaultLocale         :: !Locale  -- ^ Default locale to use
                                            --   (e.g. when selecting templates)
     , setMaxTeamSize           :: !Word16  -- ^ Max. # of members in a team.

--- a/services/brig/test/integration/API/RichInfo/Util.hs
+++ b/services/brig/test/integration/API/RichInfo/Util.hs
@@ -14,11 +14,20 @@ getRichInfo
     -> UserId            -- ^ The users whose rich info is being queried
     -> Http (Maybe RichInfo)
 getRichInfo brig self uid = do
+    getRichInfo_ brig self uid <&> either (const Nothing) Just
+
+getRichInfo_
+    :: HasCallStack
+    => Brig
+    -> UserId            -- ^ The user who is performing the query
+    -> UserId            -- ^ The users whose rich info is being queried
+    -> Http (Either Int RichInfo)
+getRichInfo_ brig self uid = do
     r <- get ( brig
              . paths ["users", toByteString' uid, "rich-info"]
              . zUser self
              )
-    if | statusCode r == 200 -> Just <$> decodeBody r
-       | statusCode r `elem` [403, 404] -> pure Nothing
+    if | statusCode r == 200 -> Right <$> decodeBody r
+       | statusCode r `elem` [403, 404] -> pure . Left . statusCode $ r
        | otherwise -> error $
            "expected status code 200, 403, or 404, got: " <> show (statusCode r)

--- a/services/brig/test/integration/API/RichInfo/Util.hs
+++ b/services/brig/test/integration/API/RichInfo/Util.hs
@@ -3,6 +3,7 @@ module API.RichInfo.Util where
 import Imports
 import Bilge
 import Brig.Types
+import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
 import Data.Id
 import Util
@@ -23,6 +24,9 @@ getRichInfo brig self uid = do
        | otherwise -> error $
            "expected status code 200, 403, or 404, got: " <> show (statusCode r)
 
+-- | This contacts an internal end-point.  Note the assymetry between this and the external
+-- GET end-point in the body: here we need to wrap the 'RichInfo' encoding in another object
+-- with one attribute named `rich_info`.
 putRichInfo
     :: HasCallStack
     => Brig
@@ -32,5 +36,5 @@ putRichInfo
 putRichInfo brig uid rinfo = do
     put ( brig
         . paths ["i", "users", toByteString' uid, "rich-info"]
-        . json rinfo
+        . json (object ["rich_info" .= rinfo])
         )

--- a/services/brig/test/integration/API/RichInfo/Util.hs
+++ b/services/brig/test/integration/API/RichInfo/Util.hs
@@ -1,0 +1,24 @@
+module API.RichInfo.Util where
+
+import Imports
+import Bilge
+import Brig.Types
+import Data.ByteString.Conversion
+import Data.Id
+import Util
+
+getRichInfo
+    :: HasCallStack
+    => Brig
+    -> UserId            -- ^ The user who is performing the query
+    -> UserId            -- ^ The users whose rich info is being queried
+    -> Http (Maybe RichInfo)
+getRichInfo brig self uid = do
+    r <- get ( brig
+             . paths ["users", toByteString' uid, "rich-info"]
+             . zUser self
+             )
+    if | statusCode r == 200 -> Just <$> decodeBody r
+       | statusCode r `elem` [403, 404] -> pure Nothing
+       | otherwise -> error $
+           "expected status code 200, 403, or 404, got: " <> show (statusCode r)

--- a/services/brig/test/integration/API/RichInfo/Util.hs
+++ b/services/brig/test/integration/API/RichInfo/Util.hs
@@ -31,3 +31,16 @@ getRichInfo_ brig self uid = do
        | statusCode r `elem` [403, 404] -> pure . Left . statusCode $ r
        | otherwise -> error $
            "expected status code 200, 403, or 404, got: " <> show (statusCode r)
+
+putRichInfo
+    :: HasCallStack
+    => Brig
+    -> UserId            -- ^ The users whose rich info is being updated
+    -> RichInfo
+    -> Http ResponseLBS
+putRichInfo brig uid rinfo = undefined
+    put ( brig
+        . paths ["i", "users", toByteString' uid, "rich-info"]
+        . json rinfo
+        . expect2xx
+        )

--- a/services/brig/test/integration/API/RichInfo/Util.hs
+++ b/services/brig/test/integration/API/RichInfo/Util.hs
@@ -12,17 +12,8 @@ getRichInfo
     => Brig
     -> UserId            -- ^ The user who is performing the query
     -> UserId            -- ^ The users whose rich info is being queried
-    -> Http (Maybe RichInfo)
-getRichInfo brig self uid = do
-    getRichInfo_ brig self uid <&> either (const Nothing) Just
-
-getRichInfo_
-    :: HasCallStack
-    => Brig
-    -> UserId            -- ^ The user who is performing the query
-    -> UserId            -- ^ The users whose rich info is being queried
     -> Http (Either Int RichInfo)
-getRichInfo_ brig self uid = do
+getRichInfo brig self uid = do
     r <- get ( brig
              . paths ["users", toByteString' uid, "rich-info"]
              . zUser self

--- a/services/brig/test/integration/API/RichInfo/Util.hs
+++ b/services/brig/test/integration/API/RichInfo/Util.hs
@@ -38,9 +38,8 @@ putRichInfo
     -> UserId            -- ^ The users whose rich info is being updated
     -> RichInfo
     -> Http ResponseLBS
-putRichInfo brig uid rinfo = undefined
+putRichInfo brig uid rinfo = do
     put ( brig
         . paths ["i", "users", toByteString' uid, "rich-info"]
         . json rinfo
-        . expect2xx
         )

--- a/services/brig/test/integration/API/RichInfo/Util.hs
+++ b/services/brig/test/integration/API/RichInfo/Util.hs
@@ -3,7 +3,6 @@ module API.RichInfo.Util where
 import Imports
 import Bilge
 import Brig.Types
-import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
 import Data.Id
 import Util
@@ -25,8 +24,7 @@ getRichInfo brig self uid = do
            "expected status code 200, 403, or 404, got: " <> show (statusCode r)
 
 -- | This contacts an internal end-point.  Note the assymetry between this and the external
--- GET end-point in the body: here we need to wrap the 'RichInfo' encoding in another object
--- with one attribute named `rich_info`.
+-- GET end-point in the body: here we need to wrap the 'RichInfo' in a 'RichInfoUpdate'.
 putRichInfo
     :: HasCallStack
     => Brig
@@ -36,5 +34,5 @@ putRichInfo
 putRichInfo brig uid rinfo = do
     put ( brig
         . paths ["i", "users", toByteString' uid, "rich-info"]
-        . json (object ["rich_info" .= rinfo])
+        . json (RichInfoUpdate rinfo)
         )

--- a/services/brig/test/integration/API/RichInfo/Util.hs
+++ b/services/brig/test/integration/API/RichInfo/Util.hs
@@ -23,12 +23,12 @@ getRichInfo brig self uid = do
        | otherwise -> error $
            "expected status code 200, 403, or 404, got: " <> show (statusCode r)
 
--- | This contacts an internal end-point.  Note the assymetry between this and the external
+-- | This contacts an internal end-point.  Note the asymmetry between this and the external
 -- GET end-point in the body: here we need to wrap the 'RichInfo' in a 'RichInfoUpdate'.
 putRichInfo
     :: HasCallStack
     => Brig
-    -> UserId            -- ^ The users whose rich info is being updated
+    -> UserId            -- ^ The user whose rich info is being updated
     -> RichInfo
     -> Http ResponseLBS
 putRichInfo brig uid rinfo = do

--- a/services/brig/test/integration/API/User.hs
+++ b/services/brig/test/integration/API/User.hs
@@ -16,6 +16,7 @@ import qualified API.User.Handles
 import qualified API.User.Onboarding
 import qualified API.User.PasswordReset
 import qualified API.User.Property
+import qualified API.User.RichInfo
 
 import qualified Brig.AWS     as AWS
 import qualified Brig.Options as Opt
@@ -35,6 +36,7 @@ tests conf p b c ch g aws = do
         , API.User.Onboarding.tests    cl at conf p b c g
         , API.User.PasswordReset.tests cl at conf p b c g
         , API.User.Property.tests      cl at conf p b c g
+        , API.User.RichInfo.tests      cl at conf p b c g
         ]
 
 mkZAuthEnv :: Maybe Opt.Opts -> IO ZAuth.Env

--- a/services/brig/test/integration/API/User/RichInfo.hs
+++ b/services/brig/test/integration/API/User/RichInfo.hs
@@ -89,8 +89,8 @@ testRichInfoSizeLimit brig galley (Just conf) = do
             ]
         bad2 = RichInfo $ [0 .. ((maxSize `div` 2))] <&>
             \i -> RichField (Text.pack $ show i) "#"
-    putRichInfo brig owner bad1 !!! const 400 === statusCode
-    putRichInfo brig owner bad2 !!! const 400 === statusCode
+    putRichInfo brig owner bad1 !!! const 413 === statusCode
+    putRichInfo brig owner bad2 !!! const 413 === statusCode
 
 -- | Test that rich info of non-team members can not be queried.
 --

--- a/services/brig/test/integration/API/User/RichInfo.hs
+++ b/services/brig/test/integration/API/User/RichInfo.hs
@@ -111,10 +111,10 @@ testNonTeamMembersDoNotHaveRichInfo brig galley = do
 
 testGuestsCannotSeeRichInfo :: Brig -> Galley -> Http ()
 testGuestsCannotSeeRichInfo brig galley = do
-    -- Create a team with two users
+    -- Create a team
     (owner, _) <- createUserWithTeam brig galley
 
-    -- A non-team user should get 'forbidden' when querying rich info for team user.
+    -- A non-team user should get "forbidden" when querying rich info for team user.
     do nonTeamUser <- userId <$> randomUser brig
        richInfo <- getRichInfo brig nonTeamUser owner
        liftIO $ assertEqual "rich info status /= 403" (Left 403) richInfo

--- a/services/brig/test/integration/API/User/RichInfo.hs
+++ b/services/brig/test/integration/API/User/RichInfo.hs
@@ -103,11 +103,11 @@ testNonTeamMembersDoNotHaveRichInfo brig galley = do
     -- Another user should get a 'Nothing' when querying their info
     do nonTeamUser <- userId <$> randomUser brig
        richInfo <- getRichInfo brig nonTeamUser targetUser
-       liftIO $ assertEqual "rich info is present" richInfo (Left 404)
+       liftIO $ assertEqual "rich info is present" richInfo (Left 403)
     -- A team member should also get a 'Nothing' when querying their info
     do (teamUser, _) <- createUserWithTeam brig galley
        richInfo <- getRichInfo brig teamUser targetUser
-       liftIO $ assertEqual "rich info is present" richInfo (Left 404)
+       liftIO $ assertEqual "rich info is present" richInfo (Left 403)
 
 testGuestsCannotSeeRichInfo :: Brig -> Galley -> Http ()
 testGuestsCannotSeeRichInfo brig galley = do

--- a/services/brig/test/integration/API/User/RichInfo.hs
+++ b/services/brig/test/integration/API/User/RichInfo.hs
@@ -1,0 +1,38 @@
+module API.User.RichInfo (tests) where
+
+import Imports
+import API.Team.Util (createUserWithTeam, createTeamMember)
+import API.User.Util
+import API.RichInfo.Util
+import Bilge hiding (accept, timeout)
+import Brig.Types
+import Test.Tasty hiding (Timeout)
+import Test.Tasty.HUnit
+import Util
+
+import qualified Brig.Options                as Opt
+import qualified Galley.Types.Teams          as Team
+
+tests :: ConnectionLimit -> Opt.Timeout -> Maybe Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
+tests _cl _at _conf p b _c g = testGroup "rich info"
+    [ test p "there is default empty rich info" $ testDefaultRichInfo b g
+    ]
+
+-- TODO Team members can see other team members' rich info
+-- TODO Non-team-members don't have rich info at all
+-- TODO Guests can't see rich info
+-- TODO Members of other teams can't see rich info
+-- TODO Empty fields are deleted
+
+-- | Test that for team members there is some rich info set by default, but it's empty.
+testDefaultRichInfo :: Brig -> Galley -> Http ()
+testDefaultRichInfo brig galley = do
+    -- Create a team with two users
+    (owner, tid) <- createUserWithTeam brig galley
+    member1 <- userId <$> createTeamMember brig galley owner tid Team.noPermissions
+    member2 <- userId <$> createTeamMember brig galley owner tid Team.noPermissions
+    -- The first user should see the second user's rich info and it should be empty
+    richInfo <- getRichInfo brig member1 member2
+    liftIO $ assertEqual "rich info is not empty, or not present"
+        richInfo
+        (Just (RichInfo {richInfoFields = []}))

--- a/services/brig/test/integration/API/User/RichInfo.hs
+++ b/services/brig/test/integration/API/User/RichInfo.hs
@@ -16,15 +16,14 @@ import qualified Galley.Types.Teams          as Team
 tests :: ConnectionLimit -> Opt.Timeout -> Maybe Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
 tests _cl _at _conf p b _c g = testGroup "rich info"
     [ test p "there is default empty rich info" $ testDefaultRichInfo b g
+    , test p "non-team members don't have rich info" $ testNonTeamMembersDoNotHaveRichInfo b g
     ]
 
--- TODO Team members can see other team members' rich info
--- TODO Non-team-members don't have rich info at all
 -- TODO Guests can't see rich info
 -- TODO Members of other teams can't see rich info
 -- TODO Empty fields are deleted
 
--- | Test that for team members there is some rich info set by default, but it's empty.
+-- | Test that for team members there is rich info set by default, and that it's empty.
 testDefaultRichInfo :: Brig -> Galley -> Http ()
 testDefaultRichInfo brig galley = do
     -- Create a team with two users
@@ -36,3 +35,20 @@ testDefaultRichInfo brig galley = do
     liftIO $ assertEqual "rich info is not empty, or not present"
         richInfo
         (Just (RichInfo {richInfoFields = []}))
+
+-- | Test that rich info of non-team members can not be queried.
+--
+-- Note: it would be nice to also test that non-team members can not set rich info, but for
+-- now there's no public endpoint for setting it in Brig, so we can't do anything.
+testNonTeamMembersDoNotHaveRichInfo :: Brig -> Galley -> Http ()
+testNonTeamMembersDoNotHaveRichInfo brig galley = do
+    -- Create a user
+    targetUser <- userId <$> randomUser brig
+    -- Another user should get a 'Nothing' when querying their info
+    do nonTeamUser <- userId <$> randomUser brig
+       richInfo <- getRichInfo brig nonTeamUser targetUser
+       liftIO $ assertEqual "rich info is present" richInfo Nothing
+    -- A team member should also get a 'Nothing' when querying their info
+    do (teamUser, _) <- createUserWithTeam brig galley
+       richInfo <- getRichInfo brig teamUser targetUser
+       liftIO $ assertEqual "rich info is present" richInfo Nothing

--- a/services/brig/test/integration/API/User/RichInfo.hs
+++ b/services/brig/test/integration/API/User/RichInfo.hs
@@ -53,8 +53,8 @@ testDeleteMissingFieldsInUpdates brig galley = do
         subset = RichInfo
             [ RichField "relevance" "meh"
             ]
-    putRichInfo brig member2 superset !!! const 201 === statusCode
-    putRichInfo brig member2 subset   !!! const 201 === statusCode
+    putRichInfo brig member2 superset !!! const 200 === statusCode
+    putRichInfo brig member2 subset   !!! const 200 === statusCode
     subset' <- getRichInfo brig member1 member2
     liftIO $ assertEqual "dangling rich info fields" (Right subset) subset'
 
@@ -66,7 +66,7 @@ testDeleteEmptyFields brig galley = do
     let withEmpty = RichInfo
             [ RichField "department" ""
             ]
-    putRichInfo brig member2 withEmpty !!! const 201 === statusCode
+    putRichInfo brig member2 withEmpty !!! const 200 === statusCode
     withoutEmpty <- getRichInfo brig member1 member2
     liftIO $ assertEqual "dangling rich info fields" (Right $ RichInfo []) withoutEmpty
 

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -33,12 +33,15 @@ dependencies:
   - cookie
   - cryptonite
   - data-default
+  - email-validate
   - errors
   - exceptions  # (for MonadClient, which in turn needs MonadCatch)
   - extra
   - galley-types
   - ghc-prim
+  - hscim
   - HsOpenSSL
+  - http-api-data
   - http-client
   - http-client-tls
   - http-types
@@ -66,6 +69,7 @@ dependencies:
   - tinylog
   - transformers
   - types-common
+  - unordered-containers
   - uri-bytestring
   - uuid
   - wai
@@ -75,9 +79,6 @@ dependencies:
   - x509
   - xml-conduit
   - yaml
-  - hscim
-  - email-validate
-  - http-api-data
 
 library:
   source-dirs:

--- a/services/spar/spar.integration.yaml
+++ b/services/spar/spar.integration.yaml
@@ -35,5 +35,6 @@ maxttlAuthreq: 5  # seconds.  don't set this too large, it is also the run time 
 maxttlAuthresp: 7200  # seconds.  do not set this to 1h or less, as that is what the mock idp wants.
 
 maxScimTokens: 2
+richInfoLimit: 5000  # should be in sync with Brig
 
 logNetStrings: False # log using netstrings encoding (see http://cr.yp.to/proto/netstrings.txt)

--- a/services/spar/src/Spar/Data/Instances.hs
+++ b/services/spar/src/Spar/Data/Instances.hs
@@ -16,6 +16,7 @@ module Spar.Data.Instances
 
 import Imports
 import Cassandra as Cas
+import Data.Aeson (FromJSON, ToJSON)
 import Data.String.Conversions
 import Data.X509 (SignedCertificate)
 import SAML2.Util (parseURI')
@@ -78,7 +79,7 @@ toVerdictFormat (VerdictFormatConMobile, Just succredir, Just errredir) = Just $
 toVerdictFormat _                                                       = Nothing
 
 deriving instance Cql ScimToken
-instance Cql Scim.StoredUser where
+instance (FromJSON extra, ToJSON extra) => Cql (Scim.StoredUser extra) where
     ctype = Tagged BlobColumn
     toCql = CqlBlob . Aeson.encode
 

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -80,7 +80,7 @@ apiScim :: ServerT APIScim Spar
 apiScim = hoistScim (toServant (Scim.siteServer configuration))
      :<|> apiScimToken
   where
-    hoistScim = hoistServer (Proxy @(Scim.SiteAPI ScimToken))
+    hoistScim = hoistServer (Proxy @(Scim.SiteAPI ScimToken ScimUserExtra))
                             (Scim.fromScimHandler fromError)
     fromError = throwError . SAML.CustomServant . Scim.scimToServantErr
 

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -83,7 +83,8 @@ instance ToJSON ScimUserExtra where
 -- formats, because not all provisioning agents can send us information in the canonical
 -- @ToJSON RichInfo@ format.
 --
--- FUTUREWORK: allow strings as well
+-- FUTUREWORK: allow more formats. In particular, something needs to be figured out for Okta,
+-- which can not send objects or lists of objects (as of Feb 26, 2019).
 parseRichInfo :: Aeson.Value -> Aeson.Parser RichInfo
 parseRichInfo v =
   normalizeRichInfo <$>

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -74,7 +74,9 @@ instance FromJSON ScimUserExtra where
 
 instance ToJSON ScimUserExtra where
   toJSON v = object
-    [ userExtraURN .= _sueRichInfo v
+    [ userExtraURN .= object
+        [ "richInfo" .= _sueRichInfo v
+        ]
     ]
 
 -- | Parse 'RichInfo', trying several formats in a row. We have to know how to parse different

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -86,6 +86,7 @@ instance ToJSON ScimUserExtra where
 -- FUTUREWORK: allow strings as well
 parseRichInfo :: Aeson.Value -> Aeson.Parser RichInfo
 parseRichInfo v =
+  normalizeRichInfo <$>
   asum [
     -- Canonical format
       parseJSON @RichInfo v

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -18,6 +17,7 @@
 
 -- | This module contains several categories of SCIM-related types:
 --
+-- * Extensions for @hscim@ types (like 'ScimUserExtra').
 -- * Our wrappers over @hscim@ types (like 'ValidScimUser').
 -- * Servant-based API types.
 -- * Request and response types for SCIM-related endpoints.
@@ -27,15 +27,71 @@ import Imports
 import Brig.Types.User       as Brig
 import Control.Lens hiding ((.=), Strict)
 import Data.Aeson as Aeson
+import Data.Aeson.Types as Aeson
 import Data.Id
 import Servant
 import Spar.API.Util
 import Spar.Types
 
-import qualified SAML2.WebSSO as SAML
+import qualified Data.HashMap.Strict              as HM
+import qualified Data.Text                        as T
+import qualified SAML2.WebSSO                     as SAML
 import qualified Web.Scim.Schema.User             as Scim.User
+import qualified Web.Scim.Schema.Schema           as Scim
 import qualified Web.Scim.Server                  as Scim
 
+
+----------------------------------------------------------------------------
+-- Schemas
+
+userSchemas :: [Scim.Schema]
+userSchemas = [Scim.User20, Scim.CustomSchema userExtraURN]
+
+-- | Schema identifier for extra Wire data.
+userExtraURN :: Text
+userExtraURN = "urn:wire:scim:schemas:profile:1.0"
+
+----------------------------------------------------------------------------
+-- @hscim@ extensions and wrappers
+
+-- | Extra Wire-specific data contained in a SCIM user profile.
+data ScimUserExtra = ScimUserExtra
+  { _sueRichInfo :: RichInfo
+  }
+  deriving (Eq, Show)
+
+makeLenses ''ScimUserExtra
+
+instance FromJSON ScimUserExtra where
+  parseJSON = withObject "ScimUserExtra" $ \(lowercase -> o) -> do
+    o .:? T.toLower userExtraURN >>= \case
+      Nothing -> pure (ScimUserExtra emptyRichInfo)
+      Just (lowercase -> o2) -> do
+        _sueRichInfo <- parseRichInfo =<< o2 .: "richinfo"
+        pure ScimUserExtra{..}
+    where
+      lowercase = HM.fromList . map (over _1 T.toLower) . HM.toList
+
+instance ToJSON ScimUserExtra where
+  toJSON v = object
+    [ userExtraURN .= _sueRichInfo v
+    ]
+
+-- | Parse 'RichInfo', trying several formats in a row. We have to know how to parse different
+-- formats, because not all provisioning agents can send us information in the canonical
+-- @ToJSON RichInfo@ format.
+--
+-- FUTUREWORK: allow strings as well
+parseRichInfo :: Aeson.Value -> Aeson.Parser RichInfo
+parseRichInfo v =
+  asum [
+    -- Canonical format
+      parseJSON @RichInfo v
+    -- A list of {type, value} 'RichField's
+    , parseJSON @[RichField] v <&> \xs -> RichInfo { richInfoFields = xs }
+    -- Otherwise we fail
+    , fail "couldn't parse RichInfo"
+    ]
 
 -- | SCIM user with 'SAML.UserRef' and mapping to 'Brig.User'.  Constructed by 'validateScimUser'.
 --
@@ -43,7 +99,7 @@ import qualified Web.Scim.Server                  as Scim
 -- the 'Scim.User.User' and b) be valid in regard to our own user schema requirements (only
 -- certain characters allowed in handles, etc).
 data ValidScimUser = ValidScimUser
-  { _vsuUser          :: Scim.User.User
+  { _vsuUser          :: Scim.User.User ScimUserExtra
 
     -- SAML SSO
   , _vsuSAMLUserRef   :: SAML.UserRef
@@ -119,7 +175,7 @@ instance ToJSON ScimTokenList where
 -- Servant APIs
 
 type APIScim
-     = OmitDocs :> "v2" :> Scim.SiteAPI ScimToken
+     = OmitDocs :> "v2" :> Scim.SiteAPI ScimToken ScimUserExtra
   :<|> "auth-tokens" :> APIScimToken
 
 type APIScimToken

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -111,6 +111,7 @@ data ValidScimUser = ValidScimUser
     -- mapping to 'Brig.User'
   , _vsuHandle        :: Handle
   , _vsuName          :: Maybe Name
+  , _vsuRichInfo      :: RichInfo
   }
   deriving (Eq, Show)
 

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -25,7 +25,7 @@ import Imports
 import Brig.Types.User       as Brig
 import Control.Lens hiding ((.=), Strict)
 import Control.Monad.Except
-import Control.Monad.Extra (whenM, whenJust)
+import Control.Monad.Extra (whenM)
 import Crypto.Hash
 import Data.Aeson as Aeson
 import Data.Id

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -297,6 +297,7 @@ updateValidScimUser tokinfo uidText newScimUser = do
 
         maybe (pure ()) (lift . Intra.Brig.setName uid) $ newScimUser ^. vsuName
         lift . Intra.Brig.setHandle uid $ newScimUser ^. vsuHandle
+        lift . Intra.Brig.setRichInfo uid $ newScimUser ^. vsuRichInfo
 
         -- store new user value to scim_user table (spar). (this must happen last, so in case
         -- of crash the client can repeat the operation and it won't be considered a noop.)

--- a/services/spar/src/Spar/Types.hs
+++ b/services/spar/src/Spar/Types.hs
@@ -155,6 +155,8 @@ data Opts' a = Opts
     , maxttlAuthresp :: !(TTL "authresp")
     -- | The maximum number of SCIM tokens that we will allow teams to have.
     , maxScimTokens  :: !Int
+    -- | The maximum size of rich info. Should be in sync with 'Brig.Types.richInfoLimit'.
+    , richInfoLimit  :: !Int
     -- | Wire/AWS specific; optional; used to discover Cassandra instance
     -- IPs using describe-instances.
     , discoUrl       :: !(Maybe Text)

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -26,7 +26,6 @@ import qualified Galley.Types.Teams as Galley
 import qualified Spar.Intra.Brig as Intra
 import qualified Util.Scim as ScimT
 import qualified Web.Cookie as Cky
-import qualified Web.Scim.Class.User as Scim
 
 
 spec :: SpecWith TestEnv
@@ -663,13 +662,13 @@ specScimAndSAML = do
       env <- ask
 
       -- create a user via scim
-      (tok, (_, _, idp))                <- ScimT.registerIdPAndScimToken
-      (usr, subj)                       <- ScimT.randomScimUserWithSubject
-      scimStoredUser :: Scim.StoredUser <- ScimT.createUser tok usr
-      let userid     :: UserId           = ScimT.scimUserId scimStoredUser
-          userref    :: UserRef          = UserRef tenant subject
-          tenant     :: Issuer           = idp ^. idpMetadata . edIssuer
-          subject    :: NameID           = NameID subj Nothing Nothing Nothing
+      (tok, (_, _, idp))         <- ScimT.registerIdPAndScimToken
+      (usr, subj)                <- ScimT.randomScimUserWithSubject
+      scimStoredUser             <- ScimT.createUser tok usr
+      let userid     :: UserId    = ScimT.scimUserId scimStoredUser
+          userref    :: UserRef   = UserRef tenant subject
+          tenant     :: Issuer    = idp ^. idpMetadata . edIssuer
+          subject    :: NameID    = NameID subj Nothing Nothing Nothing
 
       -- UserRef maps onto correct UserId in spar (and back).
       userid' <- getUserIdViaRef' userref

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -460,7 +460,8 @@ testUpdateUserRefIndex = do
     -- Overwrite the user with another randomly-generated user
     user' <- randomScimUser
     _ <- updateUser tok userid user'
-    vuser' <- either (error . show) pure $ validateScimUser' idp 50000 user'
+    vuser' <- either (error . show) pure $
+        validateScimUser' idp 999999 user'  -- 999999 = some big number
     muserid' <- runSparCass $ Data.getUser (vuser' ^. vsuSAMLUserRef)
     liftIO $ do
         muserid' `shouldBe` Just userid
@@ -474,7 +475,8 @@ testBrigSideIsUpdated = do
     user' <- randomScimUser
     let userid = scimUserId storedUser
     _ <- updateUser tok userid user'
-    validScimUser <- either (error . show) pure $ validateScimUser' idp 50000 user'
+    validScimUser <- either (error . show) pure $
+        validateScimUser' idp 999999 user'
     brigUser      <- maybe (error "no brig user") pure =<< getSelf userid
     brigUser `userShouldMatch` validScimUser
 

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -410,7 +410,7 @@ testUpdateUserRefIndex = do
     -- Overwrite the user with another randomly-generated user
     user' <- randomScimUser
     _ <- updateUser tok userid user'
-    vuser' <- either (error . show) pure $ validateScimUser' (Just idp) user'
+    vuser' <- either (error . show) pure $ validateScimUser' (Just idp) Nothing user'
     muserid' <- runSparCass $ Data.getUser (vuser' ^. vsuSAMLUserRef)
     liftIO $ do
         muserid' `shouldBe` Just userid
@@ -424,6 +424,7 @@ testBrigSideIsUpdated = do
     user' <- randomScimUser
     let userid = scimUserId storedUser
     _ <- updateUser tok userid user'
-    validScimUser <- either (error . show) pure $ validateScimUser' (Just idp) user'
+    validScimUser <- either (error . show) pure $
+        validateScimUser' (Just idp) Nothing user'
     brigUser      <- maybe (error "no brig user") pure =<< getSelf userid
     brigUser `userShouldMatch` validScimUser

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -173,8 +173,8 @@ testRichInfo = do
     brig <- asks (view teBrig)
 
     -- set things up
-    let richInfo  = RichInfo [RichField "platforms" "OpenBSD; Plan9"]
-        richInfo' = RichInfo [RichField "platforms" "Windows10"]
+    let richInfo  = RichInfo [RichField "Platforms" "OpenBSD; Plan9"]
+        richInfo' = RichInfo [RichField "Platforms" "Windows10"]
     (user, _)  <- randomScimUserWithSubjectAndRichInfo richInfo
     (user', _) <- randomScimUserWithSubjectAndRichInfo richInfo'
     (tok, (owner, _, _)) <- registerIdPAndScimToken

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -460,7 +460,7 @@ testUpdateUserRefIndex = do
     -- Overwrite the user with another randomly-generated user
     user' <- randomScimUser
     _ <- updateUser tok userid user'
-    vuser' <- either (error . show) pure $ validateScimUser' idp Nothing user'
+    vuser' <- either (error . show) pure $ validateScimUser' idp 50000 user'
     muserid' <- runSparCass $ Data.getUser (vuser' ^. vsuSAMLUserRef)
     liftIO $ do
         muserid' `shouldBe` Just userid
@@ -474,7 +474,7 @@ testBrigSideIsUpdated = do
     user' <- randomScimUser
     let userid = scimUserId storedUser
     _ <- updateUser tok userid user'
-    validScimUser <- either (error . show) pure $ validateScimUser' idp Nothing user'
+    validScimUser <- either (error . show) pure $ validateScimUser' idp 50000 user'
     brigUser      <- maybe (error "no brig user") pure =<< getSelf userid
     brigUser `userShouldMatch` validScimUser
 

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -78,8 +78,8 @@ randomScimUserWithSubject
     :: (HasCallStack, MonadRandom m)
     => m (Scim.User.User ScimUserExtra, SAML.UnqualifiedNameID)
 randomScimUserWithSubject = do
-    fieldNumber <- getRandomR (0, 3)
-    fields <- replicateM fieldNumber $
+    fieldCount <- getRandomR (0, 3)
+    fields <- replicateM fieldCount $
         RichField <$> (cs <$> replicateM 10 (getRandomR ('A', 'z')))
                   <*> (cs <$> replicateM 3 (getRandomR ('A', 'z')))
     randomScimUserWithSubjectAndRichInfo (RichInfo fields)
@@ -89,7 +89,7 @@ randomScimUserWithSubjectAndRichInfo
     :: MonadRandom m
     => RichInfo -> m (Scim.User.User ScimUserExtra, SAML.UnqualifiedNameID)
 randomScimUserWithSubjectAndRichInfo richInfo = do
-    suffix <- cs <$> replicateM 5 (getRandomR ('0', '9'))
+    suffix <- cs <$> replicateM 7 (getRandomR ('0', '9'))
     emails <- getRandomR (0, 3) >>= \n -> replicateM n randomScimEmail
     phones <- getRandomR (0, 3) >>= \n -> replicateM n randomScimPhone
     -- Related, but non-trivial to re-use here: 'nextSubject'

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -390,6 +390,9 @@ scimUserId storedUser = either err id (readEither id_)
 -- In cases like 'maybeUserId' the accessor returns a raw value, because a user always has a
 -- 'UserId'. In cases like 'maybeHandle' the accessor returns a 'Maybe', because a user may or
 -- may not have a handle.
+--
+-- Note: we don't compare rich info here, because 'User' doesn't contain it. However, we have
+-- separate tests for rich info that cover that.
 class IsUser u where
     maybeUserId :: Maybe (u -> UserId)
     maybeHandle :: Maybe (u -> Maybe Handle)

--- a/services/spar/test/Test/Spar/ScimSpec.hs
+++ b/services/spar/test/Test/Spar/ScimSpec.hs
@@ -11,6 +11,7 @@
 module Test.Spar.ScimSpec where
 
 import Imports
+import Brig.Types.User (emptyRichInfo)
 import Data.Id
 import Network.URI (parseURI)
 import Spar.Scim
@@ -22,6 +23,7 @@ import qualified SAML2.WebSSO as SAML
 import qualified Web.Scim.Class.User as ScimC
 import qualified Web.Scim.Schema.Common as Scim
 import qualified Web.Scim.Schema.Meta as Scim
+import qualified Web.Scim.Schema.Schema as Scim
 import qualified Web.Scim.Schema.ResourceType as ScimR
 import qualified Web.Scim.Schema.User as Scim
 import qualified Web.Scim.Schema.User.Name as ScimN
@@ -30,9 +32,11 @@ import qualified Web.Scim.Schema.User.Name as ScimN
 spec :: Spec
 spec = describe "toScimStoredUser'" $ do
   it "works" $ do
-    let usr :: Scim.User
+    let usr :: Scim.User ScimUserExtra
         usr = Scim.User
-          { Scim.userName = "02b35298-088f-11e9-b4a4-478635dd0d2b"
+          { Scim.schemas = [Scim.User20,
+                            Scim.CustomSchema "urn:wire:scim:schemas:profile:1.0"]
+          , Scim.userName = "02b35298-088f-11e9-b4a4-478635dd0d2b"
           , Scim.externalId = Just "c1704a48-0a1e-11e9-9186-9b185fe892e8"
           , Scim.name = Just (ScimN.Name { ScimN.formatted = Nothing
                                          , ScimN.familyName = Just ""
@@ -58,6 +62,7 @@ spec = describe "toScimStoredUser'" $ do
           , Scim.entitlements = []
           , Scim.roles = []
           , Scim.x509Certificates = []
+          , Scim.extra = ScimUserExtra emptyRichInfo
           }
 
         meta :: Scim.Meta
@@ -65,7 +70,7 @@ spec = describe "toScimStoredUser'" $ do
           { Scim.resourceType = ScimR.UserResource
           , Scim.created = now
           , Scim.lastModified = now
-          , Scim.version = Scim.Weak "e5442c575adce7a7affbb2f744ab0825c553c9e6ce5dafdee8789364d824614e"
+          , Scim.version = Scim.Weak "3acf6d0951b82b1b076db23207262ca5b3c0652aef8c8fc422ead02a44188617"
           , Scim.location = Scim.URI . fromJust $ Network.URI.parseURI
                             "https://127.0.0.1/scim/v2/Users/90b5ee1c-088e-11e9-9a16-73f80f483813"
           }
@@ -75,7 +80,7 @@ spec = describe "toScimStoredUser'" $ do
           URI.ByteString.parseURI laxURIParserOptions "https://127.0.0.1/scim/v2/"
         uid = Id . fromJust . UUID.fromText $ "90b5ee1c-088e-11e9-9a16-73f80f483813"
 
-        result :: ScimC.StoredUser
+        result :: ScimC.StoredUser ScimUserExtra
         result = toScimStoredUser' now' baseuri uid usr
 
     Scim.meta result `shouldBe` meta

--- a/services/spar/test/Test/Spar/ScimSpec.hs
+++ b/services/spar/test/Test/Spar/ScimSpec.hs
@@ -70,7 +70,7 @@ spec = describe "toScimStoredUser'" $ do
           { Scim.resourceType = ScimR.UserResource
           , Scim.created = now
           , Scim.lastModified = now
-          , Scim.version = Scim.Weak "3acf6d0951b82b1b076db23207262ca5b3c0652aef8c8fc422ead02a44188617"
+          , Scim.version = Scim.Weak "cd79ccdd2cff3eeb01bce976f586b086547325907e0a3a7303ecaa61a04635da"
           , Scim.location = Scim.URI . fromJust $ Network.URI.parseURI
                             "https://127.0.0.1/scim/v2/Users/90b5ee1c-088e-11e9-9a16-73f80f483813"
           }

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,7 @@ extra-deps:
 - git: https://github.com/wireapp/saml2-web-sso
   commit: 04e0bef9e87853567b8e063f1dcf91e0dd097593    # master (Feb 13, 2019)
 - git: https://github.com/wireapp/hscim
-  commit: 53db8029e17e7085322e7055f71efb5e7058d4a5    # master (Jan 23, 2019)
+  commit: 42f6018812bf0f04741231b67b1f5e790ce0d489    # master (Feb 25, 2019)
 
 flags:
   types-common:


### PR DESCRIPTION
## Implementation

* [x] Types
* [x] Public GET rich info endpoint
* [x] Private PUT rich info endpoint
* [x] Support extra fields in hscim
* [x] Add a rich info limit
* [x] Allow setting rich info via SCIM
* [x] Prohibit duplicate fields
* [x] Delete fields with values ""

## Documentation

* [x] Reference documentation

## Tests

* [x] Roundtrip for types
* [x] There is a default empty rich info
* [x] Team members can see other team members' rich info
* [x] Non-team-members don't have rich info
* [x] Guests can't see rich info
* [x] Members of other teams can't see rich info
* [x] Writing a smaller list erases fields that are not present in it
* [x] Empty fields ("") are deleted
* [x] SCIM is actually doing the setting
* [x] SCIM should also be doing the querying
* [x] Duplicate fields are forbidden
* [x] There is a rich info limit

## Questions

* [x] Should `userDeleted` users be handled separately? Tiago's answer: no, as long as DB invariants aren't broken it's fine.

## In a separate PR

* [ ] Delete rich info from the database when the user is deleted (and test)
* [ ] Don't update rich info when it's unchanged (and test)
* [ ] Events (and test)
* [ ] Internal documentation

## The estimation game for this PR 🆕 🌟 

Estimated: 4 days.

So far: 5.5 days (Artyom, Chris, Matthias).