### PR TITLE
Fix: empty objects `{}` are valid TeamMemberDeleteData.

### DIFF
--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -720,7 +720,7 @@ instance FromJSON TeamUpdateData where
 
 instance FromJSON TeamMemberDeleteData where
     parseJSON = withObject "team-member-delete-data" $ \o ->
-        TeamMemberDeleteData <$> o .: "password"
+        TeamMemberDeleteData <$> (o .:? "password")
 
 instance ToJSON TeamMemberDeleteData where
     toJSON tmd = object


### PR DESCRIPTION
This is a production issue, but the web team agreed to provide a work-around and submit `{ "password": null }` rather than `{}`.