### PR TITLE
[WIP] [PAUSED] team-configurable token expiry

### DIFF
--- a/deploy/services-demo/conf/galley.demo-docker.yaml
+++ b/deploy/services-demo/conf/galley.demo-docker.yaml
@@ -26,6 +26,15 @@ settings:
   maxConvSize: 128
   intraListing: false
   conversationCodeURI: https://cannon/join/
+  defaultTeamTokenSettings:
+    # 28 days
+    user_token_timeout_seconds: 2419200
+    # 1 day
+    session_token_timeout_seconds: 86400
+    # 15 minutes
+    access_token_timeout_seconds: 900
+    # 7 days
+    provider_token_timeout_seconds: 604800
 
 logLevel: Info
 logNetStrings: false

--- a/deploy/services-demo/conf/galley.demo.yaml
+++ b/deploy/services-demo/conf/galley.demo.yaml
@@ -26,6 +26,15 @@ settings:
   maxConvSize: 128
   intraListing: false
   conversationCodeURI: https://127.0.0.1/join/
+  defaultTeamTokenSettings:
+    # 28 days
+    user_token_timeout_seconds: 2419200
+    # 1 day
+    session_token_timeout_seconds: 86400
+    # 15 minutes
+    access_token_timeout_seconds: 900
+    # 7 days
+    provider_token_timeout_seconds: 604800
 
 logLevel: Info
 logNetStrings: false

--- a/libs/galley-types/package.yaml
+++ b/libs/galley-types/package.yaml
@@ -46,6 +46,7 @@ library:
   - unordered-containers >=0.2
   - uri-bytestring >=0.2
   - uuid >=1.3
+  - zauth
   when:
   - condition: flag(cql)
     cpp-options: -DWITH_CQL

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -102,6 +102,13 @@ module Galley.Types.Teams
     , iconUpdate
     , iconKeyUpdate
 
+    , TeamSettingsUpdateData
+    , newTeamSettingsUpdateData
+    , tsUserTokenTimeout
+    , tsSessionTokenTimeout
+    , tsAccessTokenTimeout
+    , tsProviderTokenTimeout
+
     , TeamMemberDeleteData
     , tmdAuthPassword
     , newTeamMemberDeleteData
@@ -124,6 +131,7 @@ import Data.Range
 import Data.Time (UTCTime)
 import Galley.Types.Teams.Internal
 
+import qualified Data.ZAuth.Settings as ZAuth
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Set as Set
 #ifdef WITH_CQL
@@ -197,6 +205,13 @@ data TeamUpdateData = TeamUpdateData
     { _nameUpdate    :: Maybe (Range 1 256 Text)
     , _iconUpdate    :: Maybe (Range 1 256 Text)
     , _iconKeyUpdate :: Maybe (Range 1 256 Text)
+    } deriving (Eq, Show)
+
+data TeamSettingsUpdateData = TeamSettingsUpdateData
+    { _tsUserTokenTimeout     :: ZAuth.UserTokenTimeout
+    , _tsSessionTokenTimeout  :: ZAuth.SessionTokenTimeout
+    , _tsAccessTokenTimeout   :: ZAuth.AccessTokenTimeout
+    , _tsProviderTokenTimeout :: ZAuth.ProviderTokenTimeout
     } deriving (Eq, Show)
 
 data TeamList = TeamList
@@ -341,6 +356,20 @@ newEvent typ tid tme = Event typ tid tme Nothing
 newTeamUpdateData :: TeamUpdateData
 newTeamUpdateData = TeamUpdateData Nothing Nothing Nothing
 
+newTeamSettingsUpdateData
+  :: ZAuth.UserTokenTimeout
+  -> ZAuth.SessionTokenTimeout
+  -> ZAuth.AccessTokenTimeout
+  -> ZAuth.ProviderTokenTimeout
+  -> TeamSettingsUpdateData
+newTeamSettingsUpdateData utt stt att ptt =
+  TeamSettingsUpdateData
+  { _tsUserTokenTimeout     = utt
+  , _tsSessionTokenTimeout  = stt
+  , _tsAccessTokenTimeout   = att
+  , _tsProviderTokenTimeout = ptt
+  }
+
 newTeamMemberDeleteData :: Maybe PlainTextPassword -> TeamMemberDeleteData
 newTeamMemberDeleteData = TeamMemberDeleteData
 
@@ -358,6 +387,7 @@ makeLenses ''NewTeam
 makeLenses ''NewTeamMember
 makeLenses ''Event
 makeLenses ''TeamUpdateData
+makeLenses ''TeamSettingsUpdateData
 makeLenses ''TeamMemberDeleteData
 makeLenses ''TeamDeleteData
 makeLenses ''TeamCreationTime

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -104,10 +104,10 @@ module Galley.Types.Teams
 
     , TeamSettings
     , newTeamSettings
-    , tsUserTokenTimeout
-    , tsSessionTokenTimeout
-    , tsAccessTokenTimeout
-    , tsProviderTokenTimeout
+    , tsUserTokenTimeoutSeconds
+    , tsSessionTokenTimeoutSeconds
+    , tsAccessTokenTimeoutSeconds
+    , tsProviderTokenTimeoutSeconds
 
     , TeamMemberDeleteData
     , tmdAuthPassword
@@ -209,10 +209,10 @@ data TeamUpdateData = TeamUpdateData
     } deriving (Eq, Show)
 
 data TeamSettings = TeamSettings
-    { _tsUserTokenTimeout     :: ZAuth.UserTokenTimeout
-    , _tsSessionTokenTimeout  :: ZAuth.SessionTokenTimeout
-    , _tsAccessTokenTimeout   :: ZAuth.AccessTokenTimeout
-    , _tsProviderTokenTimeout :: ZAuth.ProviderTokenTimeout
+    { _tsUserTokenTimeoutSeconds     :: ZAuth.UserTokenTimeout
+    , _tsSessionTokenTimeoutSeconds  :: ZAuth.SessionTokenTimeout
+    , _tsAccessTokenTimeoutSeconds   :: ZAuth.AccessTokenTimeout
+    , _tsProviderTokenTimeoutSeconds :: ZAuth.ProviderTokenTimeout
     } deriving (Eq, Show)
 
 data TeamList = TeamList
@@ -365,10 +365,10 @@ newTeamSettings
   -> TeamSettings
 newTeamSettings utt stt att ptt =
   TeamSettings
-  { _tsUserTokenTimeout     = utt
-  , _tsSessionTokenTimeout  = stt
-  , _tsAccessTokenTimeout   = att
-  , _tsProviderTokenTimeout = ptt
+  { _tsUserTokenTimeoutSeconds     = utt
+  , _tsSessionTokenTimeoutSeconds  = stt
+  , _tsAccessTokenTimeoutSeconds   = att
+  , _tsProviderTokenTimeoutSeconds = ptt
   }
 
 newTeamMemberDeleteData :: Maybe PlainTextPassword -> TeamMemberDeleteData
@@ -514,10 +514,10 @@ permsToInt = Set.foldr' (\p n -> n .|. permToInt p) 0
 
 instance ToJSON TeamSettings where
     toJSON ts = object
-        $ "user_token_timeout_seconds"     .= (asInteger $ _tsUserTokenTimeout ts)
-        # "session_token_timeout_seconds"  .= (asInteger $ _tsSessionTokenTimeout ts)
-        # "access_token_timeout_seconds"   .= (asInteger $ _tsAccessTokenTimeout ts)
-        # "provider_token_timeout_seconds" .= (asInteger $ _tsProviderTokenTimeout ts)
+        $ "user_token_timeout_seconds"     .= (asInteger $ _tsUserTokenTimeoutSeconds ts)
+        # "session_token_timeout_seconds"  .= (asInteger $ _tsSessionTokenTimeoutSeconds ts)
+        # "access_token_timeout_seconds"   .= (asInteger $ _tsAccessTokenTimeoutSeconds ts)
+        # "provider_token_timeout_seconds" .= (asInteger $ _tsProviderTokenTimeoutSeconds ts)
         # []
       where
         asInteger :: Coercible a Integer => a -> Integer

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -509,13 +509,13 @@ instance ToJSON TeamTokenSettings where
         asInteger = coerce
 
 instance FromJSON TeamTokenSettings where
-    parseJSON = withObject "team_settings" $ \o -> do
+    parseJSON = withObject "team_token_settings" $ \o -> do
       -- Expect an integer in the JSON then coerce it into the proper newtype from zauth
       utt <- coerce @Integer <$> o .: "user_token_timeout_seconds"
       stt <- coerce @Integer <$> o .: "session_token_timeout_seconds"
       att <- coerce @Integer <$> o .: "access_token_timeout_seconds"
       ptt <- coerce @Integer <$> o .: "provider_token_timeout_seconds"
-      return $ TeamTokenSettings 
+      return $ TeamTokenSettings
         { _ttsUserTokenTimeoutSeconds     = utt
         , _ttsSessionTokenTimeoutSeconds  = stt
         , _ttsAccessTokenTimeoutSeconds   = att

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -102,12 +102,12 @@ module Galley.Types.Teams
     , iconUpdate
     , iconKeyUpdate
 
-    , TeamSettings
-    , newTeamSettings
-    , tsUserTokenTimeoutSeconds
-    , tsSessionTokenTimeoutSeconds
-    , tsAccessTokenTimeoutSeconds
-    , tsProviderTokenTimeoutSeconds
+    , TeamTokenSettings
+    , newTeamTokenSettings
+    , ttsUserTokenTimeoutSeconds
+    , ttsSessionTokenTimeoutSeconds
+    , ttsAccessTokenTimeoutSeconds
+    , ttsProviderTokenTimeoutSeconds
 
     , TeamMemberDeleteData
     , tmdAuthPassword
@@ -208,11 +208,11 @@ data TeamUpdateData = TeamUpdateData
     , _iconKeyUpdate :: Maybe (Range 1 256 Text)
     } deriving (Eq, Show)
 
-data TeamSettings = TeamSettings
-    { _tsUserTokenTimeoutSeconds     :: ZAuth.UserTokenTimeout
-    , _tsSessionTokenTimeoutSeconds  :: ZAuth.SessionTokenTimeout
-    , _tsAccessTokenTimeoutSeconds   :: ZAuth.AccessTokenTimeout
-    , _tsProviderTokenTimeoutSeconds :: ZAuth.ProviderTokenTimeout
+data TeamTokenSettings = TeamTokenSettings
+    { _ttsUserTokenTimeoutSeconds     :: ZAuth.UserTokenTimeout
+    , _ttsSessionTokenTimeoutSeconds  :: ZAuth.SessionTokenTimeout
+    , _ttsAccessTokenTimeoutSeconds   :: ZAuth.AccessTokenTimeout
+    , _ttsProviderTokenTimeoutSeconds :: ZAuth.ProviderTokenTimeout
     } deriving (Eq, Show)
 
 data TeamList = TeamList
@@ -357,18 +357,18 @@ newEvent typ tid tme = Event typ tid tme Nothing
 newTeamUpdateData :: TeamUpdateData
 newTeamUpdateData = TeamUpdateData Nothing Nothing Nothing
 
-newTeamSettings
+newTeamTokenSettings
   :: ZAuth.UserTokenTimeout
   -> ZAuth.SessionTokenTimeout
   -> ZAuth.AccessTokenTimeout
   -> ZAuth.ProviderTokenTimeout
-  -> TeamSettings
-newTeamSettings utt stt att ptt =
-  TeamSettings
-  { _tsUserTokenTimeoutSeconds     = utt
-  , _tsSessionTokenTimeoutSeconds  = stt
-  , _tsAccessTokenTimeoutSeconds   = att
-  , _tsProviderTokenTimeoutSeconds = ptt
+  -> TeamTokenSettings
+newTeamTokenSettings utt stt att ptt =
+  TeamTokenSettings
+  { _ttsUserTokenTimeoutSeconds     = utt
+  , _ttsSessionTokenTimeoutSeconds  = stt
+  , _ttsAccessTokenTimeoutSeconds   = att
+  , _ttsProviderTokenTimeoutSeconds = ptt
   }
 
 newTeamMemberDeleteData :: Maybe PlainTextPassword -> TeamMemberDeleteData
@@ -388,7 +388,7 @@ makeLenses ''NewTeam
 makeLenses ''NewTeamMember
 makeLenses ''Event
 makeLenses ''TeamUpdateData
-makeLenses ''TeamSettings
+makeLenses ''TeamTokenSettings
 makeLenses ''TeamMemberDeleteData
 makeLenses ''TeamDeleteData
 makeLenses ''TeamCreationTime
@@ -512,24 +512,24 @@ intToPerms n =
 permsToInt :: Set Perm -> Word64
 permsToInt = Set.foldr' (\p n -> n .|. permToInt p) 0
 
-instance ToJSON TeamSettings where
+instance ToJSON TeamTokenSettings where
     toJSON ts = object
-        $ "user_token_timeout_seconds"     .= (asInteger $ _tsUserTokenTimeoutSeconds ts)
-        # "session_token_timeout_seconds"  .= (asInteger $ _tsSessionTokenTimeoutSeconds ts)
-        # "access_token_timeout_seconds"   .= (asInteger $ _tsAccessTokenTimeoutSeconds ts)
-        # "provider_token_timeout_seconds" .= (asInteger $ _tsProviderTokenTimeoutSeconds ts)
+        $ "user_token_timeout_seconds"     .= (asInteger $ _ttsUserTokenTimeoutSeconds ts)
+        # "session_token_timeout_seconds"  .= (asInteger $ _ttsSessionTokenTimeoutSeconds ts)
+        # "access_token_timeout_seconds"   .= (asInteger $ _ttsAccessTokenTimeoutSeconds ts)
+        # "provider_token_timeout_seconds" .= (asInteger $ _ttsProviderTokenTimeoutSeconds ts)
         # []
       where
         asInteger :: Coercible a Integer => a -> Integer
         asInteger = coerce
 
-instance FromJSON TeamSettings where
+instance FromJSON TeamTokenSettings where
     parseJSON = withObject "team_settings" $ \o -> do
       utt <- o .: "user_token_timeout_seconds"
       stt <- o .: "session_token_timeout_seconds"
       att <- o .: "access_token_timeout_seconds"
       ptt <- o .: "provider_token_timeout_seconds"
-      return $ newTeamSettings utt stt att ptt
+      return $ newTeamTokenSettings utt stt att ptt
 
 
 instance ToJSON TeamList where

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -102,8 +102,7 @@ module Galley.Types.Teams
     , iconUpdate
     , iconKeyUpdate
 
-    , TeamTokenSettings
-    , newTeamTokenSettings
+    , TeamTokenSettings(..)
     , ttsUserTokenTimeoutSeconds
     , ttsSessionTokenTimeoutSeconds
     , ttsAccessTokenTimeoutSeconds
@@ -357,20 +356,6 @@ newEvent typ tid tme = Event typ tid tme Nothing
 newTeamUpdateData :: TeamUpdateData
 newTeamUpdateData = TeamUpdateData Nothing Nothing Nothing
 
-newTeamTokenSettings
-  :: ZAuth.UserTokenTimeout
-  -> ZAuth.SessionTokenTimeout
-  -> ZAuth.AccessTokenTimeout
-  -> ZAuth.ProviderTokenTimeout
-  -> TeamTokenSettings
-newTeamTokenSettings utt stt att ptt =
-  TeamTokenSettings
-  { _ttsUserTokenTimeoutSeconds     = utt
-  , _ttsSessionTokenTimeoutSeconds  = stt
-  , _ttsAccessTokenTimeoutSeconds   = att
-  , _ttsProviderTokenTimeoutSeconds = ptt
-  }
-
 newTeamMemberDeleteData :: Maybe PlainTextPassword -> TeamMemberDeleteData
 newTeamMemberDeleteData = TeamMemberDeleteData
 
@@ -525,12 +510,17 @@ instance ToJSON TeamTokenSettings where
 
 instance FromJSON TeamTokenSettings where
     parseJSON = withObject "team_settings" $ \o -> do
-      utt <- o .: "user_token_timeout_seconds"
-      stt <- o .: "session_token_timeout_seconds"
-      att <- o .: "access_token_timeout_seconds"
-      ptt <- o .: "provider_token_timeout_seconds"
-      return $ newTeamTokenSettings utt stt att ptt
-
+      -- Expect an integer in the JSON then coerce it into the proper newtype from zauth
+      utt <- coerce @Integer <$> o .: "user_token_timeout_seconds"
+      stt <- coerce @Integer <$> o .: "session_token_timeout_seconds"
+      att <- coerce @Integer <$> o .: "access_token_timeout_seconds"
+      ptt <- coerce @Integer <$> o .: "provider_token_timeout_seconds"
+      return $ TeamTokenSettings 
+        { _ttsUserTokenTimeoutSeconds     = utt
+        , _ttsSessionTokenTimeoutSeconds  = stt
+        , _ttsAccessTokenTimeoutSeconds   = att
+        , _ttsProviderTokenTimeoutSeconds = ptt
+        }
 
 instance ToJSON TeamList where
     toJSON t = object

--- a/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
@@ -21,8 +21,8 @@ module Galley.Types.Teams.Swagger
   , teamMemberDelete
   , teamMemberList
   , teamSettings
-  , updateTeam
-  , updateTeamEvent
+  , teamUpdate
+  , teamUpdateEvent
   ) where
 
 import Imports hiding (min, max)
@@ -43,10 +43,10 @@ teamsModels =
     , event
     , memberEvent
     , convEvent
-    , updateTeamEvent
+    , teamUpdateEvent
     , member
     , conversation
-    , updateTeam
+    , teamUpdate
     , teamMemberDelete
     , teamDelete
     ]
@@ -183,7 +183,7 @@ event = defineModel "TeamEvent" $ do
         description "date and time this event occurred"
     children "type" [ memberEvent
                     , convEvent
-                    , updateTeamEvent
+                    , teamUpdateEvent
                     ]
 
 eventType :: DataType
@@ -207,10 +207,10 @@ convEvent = defineModel "TeamConversationEvent" $ do
     description "team conversation event"
     property "data" (ref conversation) $ description "conversation data"
 
-updateTeamEvent :: Model
-updateTeamEvent = defineModel "TeamUpdateEvent" $ do
+teamUpdateEvent :: Model
+teamUpdateEvent = defineModel "TeamUpdateEvent" $ do
     description "team update event"
-    property "data" (ref updateTeam) $ description "update data"
+    property "data" (ref teamUpdate) $ description "update data"
 
 member :: Model
 member = defineModel "MemberData" $
@@ -220,8 +220,8 @@ conversation :: Model
 conversation = defineModel "ConversationData" $
     property "conv" bytes' $ description "conversation ID"
 
-updateTeam :: Model
-updateTeam = defineModel "TeamUpdateData" $ do
+teamUpdate :: Model
+teamUpdate = defineModel "TeamUpdateData" $ do
     description "team update data"
     property "name" string' $ do
         description "new team name"

--- a/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
@@ -131,16 +131,12 @@ teamSettings = defineModel "TeamSettings" $ do
     description "team settings"
     property "user_token_timeout_seconds" int64' $ do
         description "Time in seconds until user tokens expire"
-        optional
     property "session_token_timeout_seconds" int64' $ do
         description "Time in seconds until session tokens expire"
-        optional
     property "access_token_timeout_seconds" int64' $ do
         description "Time in seconds until access tokens expire"
-        optional
     property "provider_token_timeout_seconds" int64' $ do
         description "Time in seconds until provider tokens expire"
-        optional
 
 permissions :: Model
 permissions = defineModel "Permissions" $ do

--- a/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
@@ -20,7 +20,7 @@ module Galley.Types.Teams.Swagger
   , teamMember
   , teamMemberDelete
   , teamMemberList
-  , teamSettings
+  , teamTokenSettings
   , teamUpdate
   , teamUpdateEvent
   ) where
@@ -126,9 +126,9 @@ teamMember = defineModel "TeamMember" $ do
         description "ID of the inviting user.  Requires created_at."
         optional
 
-teamSettings :: Model
-teamSettings = defineModel "TeamSettings" $ do
-    description "team settings"
+teamTokenSettings :: Model
+teamTokenSettings = defineModel "teamTokenSettings" $ do
+    description "team token settings"
     property "user_token_timeout_seconds" int64' $ do
         description "Time in seconds until user tokens expire"
     property "session_token_timeout_seconds" int64' $ do

--- a/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
@@ -21,8 +21,8 @@ module Galley.Types.Teams.Swagger
   , teamMemberDelete
   , teamMemberList
   , teamSettings
-  , update
-  , updateEvent
+  , updateTeam
+  , updateTeamEvent
   ) where
 
 import Imports hiding (min, max)
@@ -43,10 +43,10 @@ teamsModels =
     , event
     , memberEvent
     , convEvent
-    , updateEvent
+    , updateTeamEvent
     , member
     , conversation
-    , update
+    , updateTeam
     , teamMemberDelete
     , teamDelete
     ]
@@ -183,7 +183,7 @@ event = defineModel "TeamEvent" $ do
         description "date and time this event occurred"
     children "type" [ memberEvent
                     , convEvent
-                    , updateEvent
+                    , updateTeamEvent
                     ]
 
 eventType :: DataType
@@ -207,10 +207,10 @@ convEvent = defineModel "TeamConversationEvent" $ do
     description "team conversation event"
     property "data" (ref conversation) $ description "conversation data"
 
-updateEvent :: Model
-updateEvent = defineModel "TeamUpdateEvent" $ do
+updateTeamEvent :: Model
+updateTeamEvent = defineModel "TeamUpdateEvent" $ do
     description "team update event"
-    property "data" (ref update) $ description "update data"
+    property "data" (ref updateTeam) $ description "update data"
 
 member :: Model
 member = defineModel "MemberData" $
@@ -220,8 +220,8 @@ conversation :: Model
 conversation = defineModel "ConversationData" $
     property "conv" bytes' $ description "conversation ID"
 
-update :: Model
-update = defineModel "TeamUpdateData" $ do
+updateTeam :: Model
+updateTeam = defineModel "TeamUpdateData" $ do
     description "team update data"
     property "name" string' $ do
         description "new team name"

--- a/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Swagger.hs
@@ -1,6 +1,29 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Galley.Types.Teams.Swagger where
+module Galley.Types.Teams.Swagger
+  ( teamsModels
+  , convEvent
+  , conversation
+  , event
+  , eventType
+  , member
+  , memberEvent
+  , newBindingTeam
+  , newNonBindingTeam
+  , newTeamMember
+  , permissions
+  , team
+  , teamConversation
+  , teamConversationList
+  , teamDelete
+  , teamList
+  , teamMember
+  , teamMemberDelete
+  , teamMemberList
+  , teamSettings
+  , update
+  , updateEvent
+  ) where
 
 import Imports hiding (min, max)
 import Data.Swagger.Build.Api
@@ -101,6 +124,22 @@ teamMember = defineModel "TeamMember" $ do
         optional
     property "created_by" bytes' $ do
         description "ID of the inviting user.  Requires created_at."
+        optional
+
+teamSettings :: Model
+teamSettings = defineModel "TeamSettings" $ do
+    description "team settings"
+    property "user_token_timeout_seconds" int64' $ do
+        description "Time in seconds until user tokens expire"
+        optional
+    property "session_token_timeout_seconds" int64' $ do
+        description "Time in seconds until session tokens expire"
+        optional
+    property "access_token_timeout_seconds" int64' $ do
+        description "Time in seconds until access tokens expire"
+        optional
+    property "provider_token_timeout_seconds" int64' $ do
+        description "Time in seconds until provider tokens expire"
         optional
 
 permissions :: Model

--- a/libs/zauth/package.yaml
+++ b/libs/zauth/package.yaml
@@ -81,3 +81,8 @@ tests:
     - uuid
     - zauth
 stability: experimental
+flags:
+  cql:
+    description: Enable cql instances
+    manual: false
+    default: false

--- a/libs/zauth/package.yaml
+++ b/libs/zauth/package.yaml
@@ -21,7 +21,9 @@ library:
   - Data.ZAuth.Token
   - Data.ZAuth.Creation
   - Data.ZAuth.Validation
+  - Data.ZAuth.Settings
   dependencies:
+  - aeson
   - attoparsec >=0.11
   - base >=4.6 && <5
   - base64-bytestring >=1.0
@@ -29,12 +31,14 @@ library:
   - bytestring-conversion >=0.1.1
   - errors >=2.0
   - exceptions >=0.4
+  - HsOpenSSL
   - lens >=4.4
   - mtl >=2.2
   - mwc-random >=0.12
   - sodium-crypto-sign >=0.1
   - time >=1.4
   - transformers >=0.4
+  - types-common
   - vector >=0.10
   - uuid >=1.3
 executables:

--- a/libs/zauth/package.yaml
+++ b/libs/zauth/package.yaml
@@ -41,6 +41,11 @@ library:
   - types-common
   - vector >=0.10
   - uuid >=1.3
+  when:
+  - condition: flag(cql)
+    cpp-options: -DWITH_CQL
+    dependencies:
+    - cql
 executables:
   zauth:
     main: Main.hs

--- a/libs/zauth/src/Data/ZAuth/Settings.hs
+++ b/libs/zauth/src/Data/ZAuth/Settings.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE CPP #-}
 
 -- | 'zauth' token signing and verification.
 module Data.ZAuth.Settings

--- a/libs/zauth/src/Data/ZAuth/Settings.hs
+++ b/libs/zauth/src/Data/ZAuth/Settings.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- | 'zauth' token signing and verification.
---
--- REFACTOR: should this be moved to @/libs/zauth@?
-module Brig.ZAuth
+module Data.ZAuth.Settings
     ( -- * Monad
       ZAuth
     , MonadZAuth (..)

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -49,7 +49,6 @@ library:
   - Brig.RPC
   - Brig.User.Auth.Cookie.Limit
   - Brig.User.Search.Index
-  - Brig.ZAuth
   dependencies:
   - amazonka >=1.3.7
   - amazonka-dynamodb >=1.3.7

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -56,7 +56,7 @@ import Brig.Team.Template
 import Brig.User.Search.Index (runIndexIO, IndexEnv (..), MonadIndexIO (..))
 import Brig.User.Template
 import Brig.Types (Locale (..), TurnURI)
-import Brig.ZAuth (MonadZAuth (..), runZAuth)
+import Data.ZAuth.Settings (MonadZAuth (..), runZAuth)
 import Cassandra (MonadClient (..), Keyspace (..), runClient)
 import Cassandra.Schema (versionCheck)
 import Control.AutoUpdate
@@ -90,7 +90,7 @@ import qualified Brig.Queue.Stomp         as Stomp
 import qualified Brig.Options             as Opt
 import qualified Brig.SMTP                as SMTP
 import qualified Brig.TURN                as TURN
-import qualified Brig.ZAuth               as ZAuth
+import qualified Data.ZAuth.Settings      as ZAuth
 import qualified Cassandra                as Cas
 import qualified Cassandra.Settings       as Cas
 import qualified Data.GeoIP2              as GeoIp

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -68,7 +68,7 @@ import Data.Conduit (ConduitM)
 import Data.UUID.V4
 import Galley.Types.Bot
 
-import qualified Brig.ZAuth as ZAuth
+import qualified Data.ZAuth.Settings as ZAuth
 
 -- | Authentication errors.
 data AuthError

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -16,7 +16,7 @@ import Data.Yaml (FromJSON(..))
 import Util.Options
 import System.Logger (Level)
 
-import qualified Brig.ZAuth  as ZAuth
+import qualified Data.ZAuth.Settings  as ZAuth
 import qualified Data.Yaml   as Y
 
 newtype Timeout = Timeout

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -72,7 +72,7 @@ import qualified OpenSSL.EVP.PKey             as SSL
 import qualified Ssl.Util                     as SSL
 import qualified Data.Text.Encoding           as Text
 import qualified Network.Wai.Utilities.Error  as Wai
-import qualified Brig.ZAuth                   as ZAuth
+import qualified Data.ZAuth.Settings          as ZAuth
 import qualified Galley.Types.Teams           as Teams
 
 routes :: Routes Doc.ApiBuilder Handler ()

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -25,7 +25,7 @@ import qualified Data.ByteString               as BS
 import qualified Brig.Types.Swagger            as Doc
 import qualified Data.Swagger.Build.Api        as Doc
 import qualified Network.Wai.Utilities.Swagger as Doc
-import qualified Brig.ZAuth                    as ZAuth
+import qualified Data.ZAuth.Settings           as ZAuth
 import qualified Network.Wai.Predicate         as P
 
 routes :: Routes Doc.ApiBuilder Handler ()

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -36,7 +36,7 @@ import qualified Brig.Data.Activation as Data
 import qualified Brig.Data.LoginCode as Data
 import qualified Brig.Data.User as Data
 import qualified Brig.Data.UserKey as Data
-import qualified Brig.ZAuth as ZAuth
+import qualified Data.ZAuth.Settings as ZAuth
 
 data Access = Access
     { accessToken  :: !AccessToken

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -41,7 +41,7 @@ import qualified Data.List                as List
 import qualified System.Logger.Class      as Log
 import qualified Data.Metrics             as Metrics
 import qualified Web.Cookie               as WebCookie
-import qualified Brig.ZAuth               as ZAuth
+import qualified Data.ZAuth.Settings      as ZAuth
 
 --------------------------------------------------------------------------------
 -- Basic Cookie Management

--- a/services/brig/src/Brig/ZAuth.hs
+++ b/services/brig/src/Brig/ZAuth.hs
@@ -17,7 +17,6 @@ module Brig.ZAuth
       -- * Settings
     , settings
     , Settings (..)
-    , defSettings
     , localSettings
     , keyIndex
     , UserTokenTimeout (..)
@@ -95,15 +94,8 @@ data Settings = Settings
     , _userTokenTimeout     :: !UserTokenTimeout      -- ^ User token validity timeout
     , _sessionTokenTimeout  :: !SessionTokenTimeout   -- ^ Session token validity timeout
     , _accessTokenTimeout   :: !AccessTokenTimeout    -- ^ Access token validity timeout
-    , _providerTokenTimeout :: !ProviderTokenTimeout  -- ^ Access token validity timeout
+    , _providerTokenTimeout :: !ProviderTokenTimeout  -- ^ Provider token validity timeout
     } deriving (Show, Generic)
-
-defSettings :: Settings
-defSettings = Settings 1
-    (UserTokenTimeout (60 * 60 * 24 * 28))    -- 28 days
-    (SessionTokenTimeout (60 * 60 * 24))      -- 1 day
-    (AccessTokenTimeout 900)                  -- 15 minutes
-    (ProviderTokenTimeout (60 * 60 * 24 * 7)) -- 7 days
 
 data Env = Env
     { _private  :: !ZC.Env

--- a/services/brig/test/integration/API/User.hs
+++ b/services/brig/test/integration/API/User.hs
@@ -18,9 +18,9 @@ import qualified API.User.PasswordReset
 import qualified API.User.Property
 import qualified API.User.RichInfo
 
-import qualified Brig.AWS     as AWS
-import qualified Brig.Options as Opt
-import qualified Brig.ZAuth   as ZAuth
+import qualified Brig.AWS            as AWS
+import qualified Brig.Options        as Opt
+import qualified Data.ZAuth.Settings as ZAuth
 
 tests :: Maybe Opt.Opts -> Manager -> Brig -> Cannon -> CargoHold -> Galley -> AWS.Env -> IO TestTree
 tests conf p b c ch g aws = do

--- a/services/brig/test/integration/API/User.hs
+++ b/services/brig/test/integration/API/User.hs
@@ -39,8 +39,15 @@ tests conf p b c ch g aws = do
         , API.User.RichInfo.tests      cl at conf p b c g
         ]
 
+zAuthTestSettings :: ZAuth.Settings
+zAuthTestSettings = ZAuth.Settings 1
+    (ZAuth.UserTokenTimeout (60 * 60 * 24 * 28))    -- 28 days
+    (ZAuth.SessionTokenTimeout (60 * 60 * 24))      -- 1 day
+    (ZAuth.AccessTokenTimeout 900)                  -- 15 minutes
+    (ZAuth.ProviderTokenTimeout (60 * 60 * 24 * 7)) -- 7 days
+
 mkZAuthEnv :: Maybe Opt.Opts -> IO ZAuth.Env
 mkZAuthEnv config = do
     Just (sk :| sks) <- join $ optOrEnv (ZAuth.readKeys . Opt.privateKeys . Opt.zauth) config ZAuth.readKeys "ZAUTH_PRIVKEYS"
     Just (pk :| pks) <- join $ optOrEnv (ZAuth.readKeys . Opt.privateKeys . Opt.zauth) config ZAuth.readKeys "ZAUTH_PUBKEYS"
-    ZAuth.mkEnv (sk :| sks) (pk :| pks) ZAuth.defSettings
+    ZAuth.mkEnv (sk :| sks) (pk :| pks) zAuthTestSettings

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -6,7 +6,7 @@ import Bilge.Assert hiding (assert)
 import Brig.Types.Intra
 import Brig.Types.User
 import Brig.Types.User.Auth
-import Brig.ZAuth (ZAuth, runZAuth)
+import Data.ZAuth.Settings (ZAuth, runZAuth)
 import UnliftIO.Async hiding (wait)
 import Control.Lens ((^?), set)
 import Data.Aeson
@@ -28,7 +28,7 @@ import qualified Bilge                as Http
 import qualified Data.ByteString      as BS
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text.Lazy       as Lazy
-import qualified Brig.ZAuth           as ZAuth
+import qualified Data.ZAuth.Settings  as ZAuth
 import qualified Data.Text            as Text
 import qualified Data.UUID.V4         as UUID
 

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -26,8 +26,17 @@ settings:
   maxConvSize: 16
   intraListing: false
   conversationCodeURI: https://app.wire.com/join/
+  defaultTeamTokenSettings:
+    # 28 days
+    user_token_timeout_seconds: 2419200
+    # 1 day
+    session_token_timeout_seconds: 86400
+    # 15 minutes
+    access_token_timeout_seconds: 900
+    # 7 days
+    provider_token_timeout_seconds: 604800
 
-logLevel: Info
+logLevel: Warn
 logNetStrings: false
 
 journal: # if set, journals; if not set, disables journaling

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -13,6 +13,7 @@ dependencies:
 - extended
 - safe >=0.3
 - ssl-util
+- raw-strings-qq
 library:
   source-dirs: src
   exposed-modules:
@@ -92,6 +93,7 @@ library:
   - wai-routing >=0.12
   - wai-utilities >=0.16
   - warp >=3.0
+  - zauth
 executables:
   galley:
     main: src/Main.hs

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -14,6 +14,7 @@ dependencies:
 - safe >=0.3
 - ssl-util
 - raw-strings-qq
+- zauth
 library:
   source-dirs: src
   exposed-modules:
@@ -93,7 +94,6 @@ library:
   - wai-routing >=0.12
   - wai-utilities >=0.16
   - warp >=3.0
-  - zauth
 executables:
   galley:
     main: src/Main.hs

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -19,6 +19,7 @@ import qualified V27
 import qualified V28
 import qualified V29
 import qualified V30
+import qualified V31
 
 main :: IO ()
 main = do
@@ -36,6 +37,7 @@ main = do
         , V28.migration
         , V29.migration
         , V30.migration
+        , V31.migration
         -- When adding migrations here, don't forget to update
         -- 'schemaVersion' in Galley.Data
         ]

--- a/services/galley/schema/src/V31.hs
+++ b/services/galley/schema/src/V31.hs
@@ -5,9 +5,9 @@ import Cassandra.Schema
 import Text.RawString.QQ
 
 migration :: Migration
-migration = Migration 31 "Add team_settings table" $ do
+migration = Migration 31 "Add team_token_settings table" $ do
   schema' [r|
-      CREATE TABLE team_settings 
+      CREATE TABLE team_token_settings 
         (  team                            uuid    PRIMARY KEY
         ,  user_token_timeout_seconds      bigint
         ,  session_token_timeout_seconds   bigint

--- a/services/galley/schema/src/V31.hs
+++ b/services/galley/schema/src/V31.hs
@@ -1,0 +1,18 @@
+module V31 (migration) where
+
+import Imports
+import Cassandra.Schema
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 31 "Add team_settings table" $ do
+  schema' [r|
+      CREATE TABLE team_settings 
+        (  team                            uuid    PRIMARY KEY
+        ,  user_token_timeout_seconds      bigint
+        ,  session_token_timeout_seconds   bigint
+        ,  access_token_timeout_seconds    bigint
+        ,  provider_token_timeout_seconds  bigint
+        ) WITH compaction = {'class': 'LeveledCompactionStrategy'}
+          AND gc_grace_seconds = 864000;
+    |]

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -312,23 +312,23 @@ sitemap = do
 
    --
 
-    get "/teams/:tid/settings" (continue getTeamTokenSettings) $
+    get "/teams/:tid/settings/tokens" (continue getTeamTokenSettings) $
         zauthUserId
         .&. capture "tid"
         .&. accept "application" "json"
 
     document "GET" "getTeamTokenSettings" $ do
-        summary "Get team settings"
+        summary "Get token settings for a team"
         parameter Path "tid" bytes' $
             description "Team ID"
         returns (ref TeamsModel.teamTokenSettings)
-        response 200 "Team settings" end
+        response 200 "Team token settings" end
         errorResponse Error.teamMemberNotFound
         errorResponse Error.invalidPermissions
 
    --
 
-    put "/teams/:tid/settings" (continue putTeamTokenSettings) $
+    put "/teams/:tid/settings/tokens" (continue putTeamTokenSettings) $
         zauthUserId
         .&. capture "tid"
         .&. request
@@ -336,7 +336,7 @@ sitemap = do
 
 
     document "PUT" "updateTeamTokenSettings" $ do
-        summary "Update team settings"
+        summary "Update token settings for a team"
         parameter Path "tid" bytes' $
             description "Team ID"
         body (ref TeamsModel.teamTokenSettings) $

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -312,34 +312,34 @@ sitemap = do
 
    --
 
-    get "/teams/:tid/settings" (continue getTeamSettings) $
+    get "/teams/:tid/settings" (continue getTeamTokenSettings) $
         zauthUserId
         .&. capture "tid"
         .&. accept "application" "json"
 
-    document "GET" "getTeamSettings" $ do
+    document "GET" "getTeamTokenSettings" $ do
         summary "Get team settings"
         parameter Path "tid" bytes' $
             description "Team ID"
-        returns (ref TeamsModel.teamSettings)
+        returns (ref TeamsModel.teamTokenSettings)
         response 200 "Team settings" end
         errorResponse Error.teamMemberNotFound
         errorResponse Error.invalidPermissions
 
    --
 
-    put "/teams/:tid/settings" (continue putTeamSettings) $
+    put "/teams/:tid/settings" (continue putTeamTokenSettings) $
         zauthUserId
         .&. capture "tid"
         .&. request
         .&. accept "application" "json"
 
 
-    document "PUT" "updateTeamSettings" $ do
+    document "PUT" "updateTeamTokenSettings" $ do
         summary "Update team settings"
         parameter Path "tid" bytes' $
             description "Team ID"
-        body (ref TeamsModel.teamSettings) $
+        body (ref TeamsModel.teamTokenSettings) $
             description "JSON body"
         -- TODO(ChrisPenner) update errors after implementing
    --
@@ -908,7 +908,7 @@ sitemap = do
         capture "tid"
         .&. accept "application" "json"
 
-    get "/i/teams/:tid/settings" (continue getTeamSettingsUnauthed) $
+    get "/i/teams/:tid/settings" (continue getTeamTokenSettingsInternal) $
         capture "tid"
         .&. accept "application" "json"
 

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -99,7 +99,7 @@ sitemap = do
         summary "Update team properties"
         parameter Path "id" bytes' $
             description "Team ID"
-        body (ref TeamsModel.update) $
+        body (ref TeamsModel.teamUpdate) $
             description "JSON body"
         errorResponse Error.noTeamMember
         errorResponse (Error.operationDenied SetTeamData)
@@ -310,6 +310,38 @@ sitemap = do
         errorResponse Error.noTeamMember
         errorResponse (Error.operationDenied DeleteConversation)
 
+   --
+
+    get "/teams/:tid/settings" (continue getTeamSettings) $
+        zauthUserId
+        .&. capture "tid"
+        .&. accept "application" "json"
+
+    document "GET" "getTeamSettings" $ do
+        summary "Get team settings"
+        parameter Path "tid" bytes' $
+            description "Team ID"
+        returns (ref TeamsModel.teamSettings)
+        response 200 "Team settings" end
+        errorResponse Error.teamMemberNotFound
+        errorResponse Error.invalidPermissions
+
+   --
+
+    put "/teams/:tid/settings" (continue putTeamSettings) $
+        zauthUserId
+        .&. capture "tid"
+        .&. request
+        .&. accept "application" "json"
+
+
+    document "PUT" "updateTeamSettings" $ do
+        summary "Update team settings"
+        parameter Path "tid" bytes' $
+            description "Team ID"
+        body (ref TeamsModel.teamSettings) $
+            description "JSON body"
+        -- TODO(ChrisPenner) update errors after implementing
    --
 
     get "/bot/conversation" (continue getBotConversation) $
@@ -876,7 +908,7 @@ sitemap = do
         capture "tid"
         .&. accept "application" "json"
 
-    get "/i/teams/:tid/settings" (continue getTeamSettingsInternal) $
+    get "/i/teams/:tid/settings" (continue getTeamSettingsUnauthed) $
         capture "tid"
         .&. accept "application" "json"
 

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -876,6 +876,10 @@ sitemap = do
         capture "tid"
         .&. accept "application" "json"
 
+    get "/i/teams/:tid/settings" (continue getTeamSettingsInternal) $
+        capture "tid"
+        .&. accept "application" "json"
+
     put "/i/teams/:tid" (continue createBindingTeam) $
         zauthUserId
         .&. capture "tid"

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -6,6 +6,7 @@ module Galley.API.Teams
     , getTeam
     , getTeamInternal
     , getTeamNameInternal
+    , getTeamSettingsInternal
     , getBindingTeamId
     , getBindingTeamMembers
     , getManyTeams
@@ -72,6 +73,11 @@ getTeamInternal (tid ::: _) =
 getTeamNameInternal :: TeamId ::: JSON -> Galley Response
 getTeamNameInternal (tid ::: _) =
     maybe (throwM teamNotFound) (pure . json . TeamName) =<< Data.teamName tid
+
+getTeamSettingsInternal :: TeamId ::: JSON -> Galley Response
+getTeamSettingsInternal (tid ::: _) = do
+    defaultTeamSettings <- view (options . optSettings . setDefaultTeamSettings)
+    json . fromMaybe defaultTeamSettings <$> Data.getTeamSettings tid
 
 getManyTeams :: UserId ::: Maybe (Either (Range 1 32 (List TeamId)) TeamId) ::: Range 1 100 Int32 ::: JSON -> Galley Response
 getManyTeams (zusr ::: range ::: size ::: _) =

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -6,8 +6,8 @@ module Galley.API.Teams
     , getTeam
     , getTeamInternal
     , getTeamNameInternal
-    , getTeamSettings, getTeamSettingsInternal
-    , putTeamSettings
+    , getTeamTokenSettings, getTeamTokenSettingsInternal
+    , putTeamTokenSettings
     , getBindingTeamId
     , getBindingTeamMembers
     , getManyTeams
@@ -75,30 +75,30 @@ getTeamNameInternal :: TeamId ::: JSON -> Galley Response
 getTeamNameInternal (tid ::: _) =
     maybe (throwM teamNotFound) (pure . json . TeamName) =<< Data.teamName tid
 
-getTeamSettingsInternal :: TeamId ::: JSON -> Galley Response
-getTeamSettingsInternal (tid ::: _) = getTeamSettings' tid
+getTeamTokenSettingsInternal :: TeamId ::: JSON -> Galley Response
+getTeamTokenSettingsInternal (tid ::: _) = getTeamTokenSettings' tid
 
-getTeamSettings :: UserId ::: TeamId ::: JSON -> Galley Response
-getTeamSettings (zusr ::: tid ::: _) = do
+getTeamTokenSettings :: UserId ::: TeamId ::: JSON -> Galley Response
+getTeamTokenSettings (zusr ::: tid ::: _) = do
     Data.teamMember tid zusr >>= \case
         Nothing         -> throwM teamMemberNotFound
         Just teamMember -> unless (isTeamOwner teamMember) $ throwM invalidPermissions
-    getTeamSettings' tid
+    getTeamTokenSettings' tid
 
--- | Helper for getTeamSettings handlers; does not perform any authorization checks
-getTeamSettings' :: TeamId -> Galley Response
-getTeamSettings' tid = do
-    defaultTeamSettings <- view (options . optSettings . setDefaultTeamSettings)
-    json . fromMaybe defaultTeamSettings <$> Data.fetchTeamSettings tid
+-- | Helper for getTeamTokenSettings handlers; does not perform any authorization checks
+getTeamTokenSettings' :: TeamId -> Galley Response
+getTeamTokenSettings' tid = do
+    defaultTeamTokenSettings <- view (options . optSettings . setDefaultTeamTokenSettings)
+    json . fromMaybe defaultTeamTokenSettings <$> Data.fetchTeamTokenSettings tid
 
-putTeamSettings :: UserId ::: TeamId ::: Request ::: JSON -> Galley Response
-putTeamSettings (zusr ::: tid ::: req ::: _) = do
+putTeamTokenSettings :: UserId ::: TeamId ::: Request ::: JSON -> Galley Response
+putTeamTokenSettings (zusr ::: tid ::: req ::: _) = do
     Data.teamMember tid zusr
       >>= \case
         Nothing         -> throwM teamMemberNotFound
         Just teamMember -> unless (isTeamOwner teamMember) $ throwM invalidPermissions
-    teamSettings <- fromBody req invalidPayload
-    Data.updateTeamSettings tid teamSettings
+    teamTokenSettings <- fromBody req invalidPayload
+    Data.updateTeamTokenSettings tid teamTokenSettings
     return empty
 
 getManyTeams :: UserId ::: Maybe (Either (Range 1 32 (List TeamId)) TeamId) ::: Range 1 100 Int32 ::: JSON -> Galley Response

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -166,6 +166,7 @@ fetchTeamSettings tid = do
     where
       toTeamSettings (utt, stt, att, ptt) = newTeamSettings utt stt att ptt
 
+
 teamIdsOf :: MonadClient m => UserId -> Range 1 32 (List TeamId) -> m [TeamId]
 teamIdsOf usr (fromList . fromRange -> tids) =
     map runIdentity <$> retry x1 (query Cql.selectUserTeamsIn (params Quorum (usr, tids)))
@@ -303,10 +304,10 @@ updateTeamSettings :: MonadClient m => TeamId -> TeamSettings -> m ()
 updateTeamSettings tid tsud =
   retry x5 $ write Cql.updateTeamSettings
           (params Quorum
-                  ( tsud ^. tsUserTokenTimeout
-                  , tsud ^. tsSessionTokenTimeout
-                  , tsud ^. tsAccessTokenTimeout
-                  , tsud ^. tsProviderTokenTimeout
+                  ( tsud ^. tsUserTokenTimeoutSeconds
+                  , tsud ^. tsSessionTokenTimeoutSeconds
+                  , tsud ^. tsAccessTokenTimeoutSeconds
+                  , tsud ^. tsProviderTokenTimeoutSeconds
                   , tid
                   ))
 

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -164,7 +164,13 @@ fetchTeamTokenSettings tid = do
   let q = query1 Cql.selectTeamTokenSettings (params Quorum $ Identity tid)
   fmap toTeamTokenSettings <$> retry x5 q
     where
-      toTeamTokenSettings (utt, stt, att, ptt) = newTeamTokenSettings utt stt att ptt
+      toTeamTokenSettings (utt, stt, att, ptt) =
+          TeamTokenSettings
+            { _ttsUserTokenTimeoutSeconds     = utt
+            , _ttsSessionTokenTimeoutSeconds  = stt
+            , _ttsAccessTokenTimeoutSeconds   = att
+            , _ttsProviderTokenTimeoutSeconds = ptt
+            }
 
 
 teamIdsOf :: MonadClient m => UserId -> Range 1 32 (List TeamId) -> m [TeamId]

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -123,7 +123,7 @@ import qualified System.Logger.Class  as Log
 newtype ResultSet a = ResultSet { page :: Page a }
 
 schemaVersion :: Int32
-schemaVersion = 30
+schemaVersion = 31
 
 -- | Insert a conversation code
 insertCode :: MonadClient m => Code -> m ()
@@ -304,10 +304,10 @@ updateTeamTokenSettings :: MonadClient m => TeamId -> TeamTokenSettings -> m ()
 updateTeamTokenSettings tid tsud =
   retry x5 $ write Cql.updateTeamTokenSettings
           (params Quorum
-                  ( tsud ^. tsUserTokenTimeoutSeconds
-                  , tsud ^. tsSessionTokenTimeoutSeconds
-                  , tsud ^. tsAccessTokenTimeoutSeconds
-                  , tsud ^. tsProviderTokenTimeoutSeconds
+                  ( tsud ^. ttsUserTokenTimeoutSeconds
+                  , tsud ^. ttsSessionTokenTimeoutSeconds
+                  , tsud ^. ttsAccessTokenTimeoutSeconds
+                  , tsud ^. ttsProviderTokenTimeoutSeconds
                   , tid
                   ))
 

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -24,6 +24,7 @@ module Galley.Data
     , deleteTeam
     , removeTeamConv
     , updateTeam
+    , newUpdateTeamSettings
     , updateTeamStatus
 
     -- * Conversations
@@ -289,6 +290,17 @@ updateTeam tid u = retry x5 $ batch $ do
         addPrepQuery Cql.updateTeamIcon (fromRange i, tid)
     for_ (u^.iconKeyUpdate) $ \k ->
         addPrepQuery Cql.updateTeamIconKey (fromRange k, tid)
+
+newUpdateTeamSettings :: MonadClient m => TeamId -> TeamSettingsUpdateData -> m ()
+newUpdateTeamSettings tid tsud =
+  retry x5 $ write Cql.updateTeamSettings
+          (params Quorum
+                  ( tsud ^. tsUserTokenTimeout
+                  , tsud ^. tsSessionTokenTimeout
+                  , tsud ^. tsAccessTokenTimeout
+                  , tsud ^. tsProviderTokenTimeout
+                  , tid
+                  ))
 
 -- Conversations ------------------------------------------------------------
 

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -11,7 +11,7 @@ module Galley.Data
     , removeTeamMember
     , team
     , Galley.Data.teamName
-    , fetchTeamSettings
+    , fetchTeamTokenSettings
     , teamConversation
     , teamConversations
     , teamIdsFrom
@@ -25,7 +25,7 @@ module Galley.Data
     , deleteTeam
     , removeTeamConv
     , updateTeam
-    , updateTeamSettings
+    , updateTeamTokenSettings
     , updateTeamStatus
 
     -- * Conversations
@@ -159,12 +159,12 @@ teamName :: MonadClient m => TeamId -> m (Maybe Text)
 teamName tid = fmap runIdentity <$>
     retry x1 (query1 Cql.selectTeamName (params Quorum (Identity tid)))
 
-fetchTeamSettings :: MonadClient m => TeamId -> m (Maybe TeamSettings)
-fetchTeamSettings tid = do
-  let q = query1 Cql.selectTeamSettings (params Quorum $ Identity tid)
-  fmap toTeamSettings <$> retry x5 q
+fetchTeamTokenSettings :: MonadClient m => TeamId -> m (Maybe TeamTokenSettings)
+fetchTeamTokenSettings tid = do
+  let q = query1 Cql.selectTeamTokenSettings (params Quorum $ Identity tid)
+  fmap toTeamTokenSettings <$> retry x5 q
     where
-      toTeamSettings (utt, stt, att, ptt) = newTeamSettings utt stt att ptt
+      toTeamTokenSettings (utt, stt, att, ptt) = newTeamTokenSettings utt stt att ptt
 
 
 teamIdsOf :: MonadClient m => UserId -> Range 1 32 (List TeamId) -> m [TeamId]
@@ -300,9 +300,9 @@ updateTeam tid u = retry x5 $ batch $ do
     for_ (u^.iconKeyUpdate) $ \k ->
         addPrepQuery Cql.updateTeamIconKey (fromRange k, tid)
 
-updateTeamSettings :: MonadClient m => TeamId -> TeamSettings -> m ()
-updateTeamSettings tid tsud =
-  retry x5 $ write Cql.updateTeamSettings
+updateTeamTokenSettings :: MonadClient m => TeamId -> TeamTokenSettings -> m ()
+updateTeamTokenSettings tid tsud =
+  retry x5 $ write Cql.updateTeamTokenSettings
           (params Quorum
                   ( tsud ^. tsUserTokenTimeoutSeconds
                   , tsud ^. tsSessionTokenTimeoutSeconds

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -11,7 +11,7 @@ module Galley.Data
     , removeTeamMember
     , team
     , Galley.Data.teamName
-    , getTeamSettings
+    , fetchTeamSettings
     , teamConversation
     , teamConversations
     , teamIdsFrom
@@ -159,8 +159,8 @@ teamName :: MonadClient m => TeamId -> m (Maybe Text)
 teamName tid = fmap runIdentity <$>
     retry x1 (query1 Cql.selectTeamName (params Quorum (Identity tid)))
 
-getTeamSettings :: MonadClient m => TeamId -> m (Maybe TeamSettings)
-getTeamSettings tid = do
+fetchTeamSettings :: MonadClient m => TeamId -> m (Maybe TeamSettings)
+fetchTeamSettings tid = do
   let q = query1 Cql.selectTeamSettings (params Quorum $ Identity tid)
   fmap toTeamSettings <$> retry x5 q
     where

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -226,13 +226,13 @@ insertBot :: PrepQuery W (ConvId, BotId, ServiceId, ProviderId) ()
 insertBot = "insert into member (conv, user, service, provider, status) values (?, ?, ?, ?, 0)"
 
 -- Team Settings ---------------------------------------------------------------------
-selectTeamSettings :: PrepQuery R (Identity TeamId)
+selectTeamTokenSettings :: PrepQuery R (Identity TeamId)
                                   ( ZAuth.UserTokenTimeout
                                   , ZAuth.SessionTokenTimeout
                                   , ZAuth.AccessTokenTimeout
                                   , ZAuth.ProviderTokenTimeout
                                   )
-selectTeamSettings = [r|
+selectTeamTokenSettings = [r|
   select
       user_token_timeout_seconds
     , session_token_timeout_seconds
@@ -242,13 +242,13 @@ selectTeamSettings = [r|
   where team = ?
   |]
 
-updateTeamSettings :: PrepQuery W ( ZAuth.UserTokenTimeout
+updateTeamTokenSettings :: PrepQuery W ( ZAuth.UserTokenTimeout
                                   , ZAuth.SessionTokenTimeout
                                   , ZAuth.AccessTokenTimeout
                                   , ZAuth.ProviderTokenTimeout
                                   , TeamId
                                   ) ()
-updateTeamSettings = [r|
+updateTeamTokenSettings = [r|
   update team_settings
     set user_token_timeout_seconds = ?
       , session_token_timeout_seconds = ?

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -238,7 +238,7 @@ selectTeamSettings = [r|
     , session_token_timeout_seconds
     , access_token_timeout_seconds
     , provider_token_timeout_seconds
-  from team_settings
+  from team_token_settings
   where team = ?
   |]
 

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -12,7 +12,9 @@ import Galley.Types hiding (Conversation)
 import Galley.Types.Bot
 import Galley.Types.Teams
 import Galley.Types.Teams.Intra
+import qualified Data.ZAuth.Settings as ZAuth
 
+import Text.RawString.QQ
 import qualified Data.Text.Lazy as LT
 
 -- Teams --------------------------------------------------------------------
@@ -222,3 +224,19 @@ selectSrv = "select base_url, auth_token, fingerprints, enabled from service whe
 
 insertBot :: PrepQuery W (ConvId, BotId, ServiceId, ProviderId) ()
 insertBot = "insert into member (conv, user, service, provider, status) values (?, ?, ?, ?, 0)"
+
+-- Team Settings ---------------------------------------------------------------------
+updateTeamSettings :: PrepQuery W ( ZAuth.UserTokenTimeout
+                                  , ZAuth.SessionTokenTimeout
+                                  , ZAuth.AccessTokenTimeout
+                                  , ZAuth.ProviderTokenTimeout
+                                  , TeamId
+                                  ) ()
+updateTeamSettings = [r|
+  update team_settings
+     set user_token_timeout_seconds = ?
+       , session_token_timeout_seconds = ?
+       , access_token_timeout_seconds = ?
+       , provider_token_timeout_seconds = ?
+     where team = ?
+  |]

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -249,7 +249,7 @@ updateTeamTokenSettings :: PrepQuery W ( ZAuth.UserTokenTimeout
                                   , TeamId
                                   ) ()
 updateTeamTokenSettings = [r|
-  update team_settings
+  update team_token_settings
     set user_token_timeout_seconds = ?
       , session_token_timeout_seconds = ?
       , access_token_timeout_seconds = ?

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -234,9 +234,9 @@ updateTeamSettings :: PrepQuery W ( ZAuth.UserTokenTimeout
                                   ) ()
 updateTeamSettings = [r|
   update team_settings
-     set user_token_timeout_seconds = ?
-       , session_token_timeout_seconds = ?
-       , access_token_timeout_seconds = ?
-       , provider_token_timeout_seconds = ?
-     where team = ?
+    set user_token_timeout_seconds = ?
+      , session_token_timeout_seconds = ?
+      , access_token_timeout_seconds = ?
+      , provider_token_timeout_seconds = ?
+    where team = ?
   |]

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -226,6 +226,22 @@ insertBot :: PrepQuery W (ConvId, BotId, ServiceId, ProviderId) ()
 insertBot = "insert into member (conv, user, service, provider, status) values (?, ?, ?, ?, 0)"
 
 -- Team Settings ---------------------------------------------------------------------
+selectTeamSettings :: PrepQuery R (Identity TeamId)
+                                  ( ZAuth.UserTokenTimeout
+                                  , ZAuth.SessionTokenTimeout
+                                  , ZAuth.AccessTokenTimeout
+                                  , ZAuth.ProviderTokenTimeout
+                                  )
+selectTeamSettings = [r|
+  select
+      user_token_timeout_seconds
+    , session_token_timeout_seconds
+    , access_token_timeout_seconds
+    , provider_token_timeout_seconds
+  from team_settings
+  where team = ?
+  |]
+
 updateTeamSettings :: PrepQuery W ( ZAuth.UserTokenTimeout
                                   , ZAuth.SessionTokenTimeout
                                   , ZAuth.AccessTokenTimeout

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StrictData #-}
 module Galley.Options where
 
 import Imports
@@ -11,15 +12,15 @@ import Data.Misc
 data Settings = Settings
     {
     -- | Number of connections for the HTTP client pool
-      _setHttpPoolSize          :: !Int
+      _setHttpPoolSize          :: Int
     -- | Max number of members in a team. NOTE: This must be in sync with Brig
-    , _setMaxTeamSize           :: !Word16
+    , _setMaxTeamSize           :: Word16
     -- | Max number of members in a conversation. NOTE: This must be in sync with Brig
-    , _setMaxConvSize           :: !Word16
+    , _setMaxConvSize           :: Word16
     -- | Whether to call Brig for device listing
-    , _setIntraListing          :: !Bool
+    , _setIntraListing          :: Bool
     -- | URI prefix for conversations with access mode @code@
-    , _setConversationCodeURI   :: !HttpsUrl
+    , _setConversationCodeURI   :: HttpsUrl
     } deriving (Show, Generic)
 
 deriveFromJSON toOptionFieldName ''Settings
@@ -34,18 +35,18 @@ deriveFromJSON toOptionFieldName ''JournalOpts
 makeLenses ''JournalOpts
 
 data Opts = Opts
-    { _optGalley    :: !Endpoint             -- ^ Host and port to bind to
-    , _optCassandra :: !CassandraOpts        -- ^ Cassandra settings
-    , _optBrig      :: !Endpoint             -- ^ Brig endpoint
-    , _optGundeck   :: !Endpoint             -- ^ Gundeck endpoint
-    , _optSpar      :: !Endpoint             -- ^ Spar endpoint
-    , _optDiscoUrl  :: !(Maybe Text)         -- ^ Disco URL
-    , _optSettings  :: !Settings             -- ^ Other settings
-    , _optJournal   :: !(Maybe JournalOpts)  -- ^ Journaling options ('Nothing'
+    { _optGalley    :: Endpoint             -- ^ Host and port to bind to
+    , _optCassandra :: CassandraOpts        -- ^ Cassandra settings
+    , _optBrig      :: Endpoint             -- ^ Brig endpoint
+    , _optGundeck   :: Endpoint             -- ^ Gundeck endpoint
+    , _optSpar      :: Endpoint             -- ^ Spar endpoint
+    , _optDiscoUrl  :: (Maybe Text)         -- ^ Disco URL
+    , _optSettings  :: Settings             -- ^ Other settings
+    , _optJournal   :: (Maybe JournalOpts)  -- ^ Journaling options ('Nothing'
                                              --   disables journaling)
     -- Logging
-    , _optLogLevel      :: !Level            -- ^ Log level (Debug, Info, etc)
-    , _optLogNetStrings :: !Bool             -- ^ Use netstrings encoding:
+    , _optLogLevel      :: Level            -- ^ Log level (Debug, Info, etc)
+    , _optLogNetStrings :: Bool             -- ^ Use netstrings encoding:
                                              --   <http://cr.yp.to/proto/netstrings.txt>
     }
 

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -9,6 +9,8 @@ import Util.Options.Common
 import System.Logger (Level)
 import Data.Misc
 
+import Galley.Types.Teams
+
 data Settings = Settings
     {
     -- | Number of connections for the HTTP client pool
@@ -21,6 +23,9 @@ data Settings = Settings
     , _setIntraListing          :: Bool
     -- | URI prefix for conversations with access mode @code@
     , _setConversationCodeURI   :: HttpsUrl
+    -- | Defaults for team settings.
+    --   These are potentially overridden by values stored per-team.
+    , _setDefaultTeamSettings      :: TeamSettings
     } deriving (Show, Generic)
 
 deriveFromJSON toOptionFieldName ''Settings

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -25,7 +25,7 @@ data Settings = Settings
     , _setConversationCodeURI   :: HttpsUrl
     -- | Defaults for team settings.
     --   These are potentially overridden by values stored per-team.
-    , _setDefaultTeamSettings      :: TeamSettings
+    , _setDefaultTeamTokenSettings      :: TeamTokenSettings
     } deriving (Show, Generic)
 
 deriveFromJSON toOptionFieldName ''Settings

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-unused-imports -fno-warn-unused-top-binds -fno-warn-unused-local-binds #-}
 module API (tests) where
 
 import Imports
@@ -43,7 +44,9 @@ test s n t = testCase n runTest
 
 tests :: IO TestSetup -> TestTree
 tests s = testGroup "Galley integration tests"
-    [ mainTests, Teams.tests s, MessageTimer.tests s ]
+    [ --mainTests
+     Teams.tests s
+    , MessageTimer.tests s ]
   where
     mainTests = testGroup "Main API"
         [ test s "status" status

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -82,7 +82,7 @@ tests s = testGroup "Teams API"
     -- , test s "post crypto broadcast message 100 (or max cons)" postCryptoBroadcastMessage100OrMaxConns
     , testGroup "Token Settings"
        [ test s "getTeamTokenSettings returns default settings if unset" testGetDefaultTokenSettings
-       , test s "getTeamTokenSettings returns default settings if unset" testSetAndGetTokenSettings
+       , test s "getting after settings should return the set values" testSetAndGetTokenSettings
        ]
     ]
 
@@ -1077,7 +1077,16 @@ testGetDefaultTokenSettings g b _ _ = do
 testSetAndGetTokenSettings :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()
 testSetAndGetTokenSettings g b _ _ = do
     (tid, ownerId) <- teamFixture g b
+    callPutTeamTokenSettings g ownerId tid newTeamTokenSettings
     tts <- callGetTeamTokenSettings g ownerId tid
-    liftIO $ assertEqual "team token settings" tts undefined
+    liftIO $ assertEqual "team token settings" tts newTeamTokenSettings
+      where
+        newTeamTokenSettings =
+          TeamTokenSettings
+            { _ttsUserTokenTimeoutSeconds = coerce @Integer 10
+            , _ttsSessionTokenTimeoutSeconds = coerce @Integer 20
+            , _ttsAccessTokenTimeoutSeconds = coerce @Integer 30
+            , _ttsProviderTokenTimeoutSeconds = coerce @Integer 40
+            }
 
 --------------------------------------------------------------------------------------------

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -762,3 +762,7 @@ callGetTeamTokenSettings :: HasCallStack => Galley -> UserId -> TeamId -> Http T
 callGetTeamTokenSettings g usr tid = do
     r <- get (g . paths ["teams", toByteString' tid, "settings", "tokens"] . zUser usr) <!! const 200 === statusCode
     pure (fromJust (decodeBody r))
+
+callPutTeamTokenSettings :: HasCallStack => Galley -> UserId -> TeamId -> TeamTokenSettings -> Http ()
+callPutTeamTokenSettings g usr tid tts = do
+    put (g . paths ["teams", toByteString' tid, "settings", "tokens"] . zUser usr . json tts) !!! const 200 === statusCode

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -757,3 +757,8 @@ retryWhileN :: (MonadIO m) => Int -> (a -> Bool) -> m a -> m a
 retryWhileN n f m = retrying (constantDelay 1000000 <> limitRetries n)
                              (const (return . f))
                              (const m)
+
+callGetTeamTokenSettings :: HasCallStack => Galley -> UserId -> TeamId -> Http TeamTokenSettings
+callGetTeamTokenSettings g usr tid = do
+    r <- get (g . paths ["teams", toByteString' tid, "settings", "tokens"] . zUser usr) <!! const 200 === statusCode
+    pure (fromJust (decodeBody r))

--- a/stack.yaml
+++ b/stack.yaml
@@ -53,4 +53,7 @@ flags:
   galley-types:
     cql: True
 
+  zauth:
+    cql: True
+
 allow-newer: False


### PR DESCRIPTION
In progress;

- [x] Add `team_settings` table to Cassandra
- [x] Add `/i/teams/:tid/settings` endpoint for brig and friends to fetch settings for team
  - [x] GET
- [x] Add `/teams/:tid/settings` endpoint to allow team admins to get/set settings for team (via curl)
  - [x] GET
  - [x] PUT
- [x] Add team settings to Galley Env and Options
- [ ] Update all yaml configs to contain new required values

I plan to make a separate PR for:

- [ ] Use team settings from Galley when issuing tokens