### PR TITLE
Allow writing request types in handler signatures

### DIFF
--- a/libs/wai-utilities/src/Network/Wai/Utilities/Request.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Request.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP               #-}
 
+{-# OPTIONS -Wno-orphans #-}  -- for "instance HasRequest Request" :(
+
 module Network.Wai.Utilities.Request where
 
 import Imports
@@ -9,6 +11,9 @@ import Control.Monad.Catch (MonadThrow, throwM)
 import Data.Aeson
 import Network.HTTP.Types.Status (status400)
 import Network.Wai
+import Network.Wai.Predicate
+import Network.Wai.Predicate.Request
+import Network.Wai.Utilities.ZAuth ((.&>))
 import Pipes
 
 import qualified Data.ByteString      as B
@@ -17,24 +22,45 @@ import qualified Data.Text.Lazy       as Text
 import qualified Pipes.Prelude        as P
 import qualified Network.Wai.Utilities.Error as Wai
 
-readBody :: MonadIO m => Request -> m Lazy.ByteString
+readBody :: (MonadIO m, HasRequest r) => r -> m LByteString
 readBody r = liftIO $ Lazy.fromChunks <$> P.toListM chunks
   where
     chunks = do
-        b <- lift $ requestBody r
+        b <- lift $ requestBody (getRequest r)
         unless (B.null b) $ do
             yield b
             chunks
 
 parseBody :: (MonadIO m, FromJSON a)
-          => Request
+          => JsonRequest a
           -> ExceptT LText m a
 parseBody r = readBody r >>= hoistEither . fmapL Text.pack . eitherDecode'
 
-parseBody' :: (FromJSON a, MonadIO m, MonadThrow m) => Request -> m a
+parseBody' :: (FromJSON a, MonadIO m, MonadThrow m) => JsonRequest a -> m a
 parseBody' r = either thrw pure =<< runExceptT (parseBody r)
   where
     thrw msg = throwM $ Wai.Error status400 "bad-request" msg
 
-lookupRequestId :: Request -> Maybe ByteString
-lookupRequestId = lookup "Request-Id" . requestHeaders
+lookupRequestId :: HasRequest r => r -> Maybe ByteString
+lookupRequestId = lookup "Request-Id" . requestHeaders . getRequest
+
+----------------------------------------------------------------------------
+-- Typed JSON 'Request'
+
+newtype JsonRequest body = JsonRequest { fromJsonRequest :: Request }
+
+jsonRequest
+    :: forall body r. (HasRequest r, HasHeaders r)
+    => Predicate r Error (JsonRequest body)
+jsonRequest =
+    contentType "application" "json"
+    .&> (return . JsonRequest . getRequest)
+
+----------------------------------------------------------------------------
+-- Instances
+
+instance HasRequest (JsonRequest a) where
+    getRequest = fromJsonRequest
+
+instance HasRequest Request where
+    getRequest = id

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -37,6 +37,7 @@ import Network.Wai
 import Network.Wai.Handler.Warp
 import Network.Wai.Handler.Warp.Internal (TimeoutThread)
 import Network.Wai.Predicate hiding (Error, err, status)
+import Network.Wai.Predicate.Request (HasRequest)
 import Network.Wai.Routing.Route (Routes, Tree, App, Continue)
 import Network.Wai.Utilities.Error (Error (Error))
 import Network.Wai.Utilities.Request (lookupRequestId)
@@ -226,7 +227,7 @@ onError g m r k e = liftIO $ do
     k (errorRs' e)
 
 -- | Log an 'Error' response for debugging purposes.
-logError :: MonadIO m => Logger -> Maybe Request -> Error -> m ()
+logError :: (MonadIO m, HasRequest r) => Logger -> Maybe r -> Error -> m ()
 logError g r (Error c l m) = liftIO $ Log.debug g logMsg
   where
     logMsg = field "code" (statusCode c)
@@ -234,7 +235,7 @@ logError g r (Error c l m) = liftIO $ Log.debug g logMsg
            . field "request" (fromMaybe "N/A" (lookupRequestId =<< r))
            . msg (val "\"" +++ m +++ val "\"")
 
-logIO :: ToBytes a => Logger -> Level -> Maybe Request -> a -> IO ()
+logIO :: (ToBytes msg, HasRequest r) => Logger -> Level -> Maybe r -> msg -> IO ()
 logIO lg lv r a =
     let reqId = field "request" . fromMaybe "N/A" . lookupRequestId <$> r
         mesg  = fromMaybe id reqId . msg a

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -26,7 +26,7 @@ import Data.Text.Encoding (decodeLatin1)
 import Data.Text.Lazy (pack)
 import Galley.Types (UserClients (..))
 import Network.HTTP.Types.Status
-import Network.Wai (Request, Response, responseLBS, lazyRequestBody)
+import Network.Wai (Response, responseLBS, lazyRequestBody)
 import Network.Wai.Predicate hiding (setStatus, result)
 import Network.Wai.Routing
 import Network.Wai.Utilities
@@ -75,20 +75,17 @@ sitemap o = do
 
     post "/i/users/:id/auto-connect" (continue autoConnect) $
         accept "application" "json"
-        .&. contentType "application" "json"
         .&. capture "id"
         .&. opt (header "Z-Connection")
-        .&. request
+        .&. jsonRequest @UserSet
 
     post "/i/users" (continue createUserNoVerify) $
         accept "application" "json"
-        .&. contentType "application" "json"
-        .&. request
+        .&. jsonRequest @NewUser
 
     put "/i/self/email" (continue changeSelfEmailNoSend) $
-        contentType "application" "json"
-        .&. header "Z-User"
-        .&. request
+        header "Z-User"
+        .&. jsonRequest @EmailUpdate
 
     delete "/i/users/:id" (continue deleteUserNoVerify) $
         capture "id"
@@ -99,8 +96,7 @@ sitemap o = do
 
     post "/i/users/connections-status" (continue getConnectionsStatus) $
         accept "application" "json"
-        .&. contentType "application" "json"
-        .&. request
+        .&. jsonRequest @ConnectionsStatusRequest
         .&. opt (query "filter")
 
     get "/i/users" (continue listActivatedAccounts) $
@@ -112,9 +108,8 @@ sitemap o = do
         .&. (param "email" ||| param "phone")
 
     put "/i/users/:id/status" (continue changeAccountStatus) $
-        contentType "application" "json"
-        .&. capture "id"
-        .&. request
+        capture "id"
+        .&. jsonRequest @AccountStatusUpdate
 
     get "/i/users/:id/status" (continue getAccountStatus) $
         accept "application" "json"
@@ -154,8 +149,7 @@ sitemap o = do
 
     post "/i/users/phone-prefixes" (continue addPhonePrefix) $
       accept "application" "json"
-      .&. contentType "application" "json"
-      .&. request
+      .&. jsonRequest @ExcludedPrefix
 
     -- is :uid not team owner, or there are other team owners?
     get "/i/users/:uid/can-be-deleted/:tid" (continue canBeDeleted) $
@@ -170,25 +164,21 @@ sitemap o = do
     put "/i/users/:uid/sso-id" (continue updateSSOId) $
       capture "uid"
       .&. accept "application" "json"
-      .&. contentType "application" "json"
-      .&. request
+      .&. jsonRequest @UserSSOId
 
     put "/i/users/:uid/managed-by" (continue updateManagedBy) $
       capture "uid"
       .&. accept "application" "json"
-      .&. contentType "application" "json"
-      .&. request
+      .&. jsonRequest @ManagedByUpdate
 
     put "/i/users/:uid/rich-info" (continue updateRichInfo) $
       capture "uid"
       .&. accept "application" "json"
-      .&. contentType "application" "json"
-      .&. request
+      .&. jsonRequest @RichInfoUpdate
 
     post "/i/clients" (continue internalListClients) $
       accept "application" "json"
-      .&. contentType "application" "json"
-      .&. request
+      .&. jsonRequest @UserSet
 
     -- /users -----------------------------------------------------------------
 
@@ -231,9 +221,8 @@ sitemap o = do
 
     post "/users/handles" (continue checkHandles) $
         accept "application" "json"
-        .&. contentType "application" "json"
         .&. header "Z-User"
-        .&. request
+        .&. jsonRequest @CheckHandles
 
     document "POST" "checkUserHandles" $ do
         Doc.summary "Check availability of user handles"
@@ -289,8 +278,7 @@ sitemap o = do
     ---
 
     post "/users/prekeys" (continue getMultiPrekeyBundles) $
-        request
-        .&. contentType "application" "json"
+        jsonRequest @UserClients
         .&. accept "application" "json"
 
     document "POST" "getMultiPrekeyBundles" $ do
@@ -393,10 +381,9 @@ sitemap o = do
     ---
 
     put "/self" (continue updateUser) $
-        contentType "application" "json"
-        .&. header "Z-User"
+        header "Z-User"
         .&. header "Z-Connection"
-        .&. request
+        .&. jsonRequest @UserUpdate
 
     document "PUT" "updateSelf" $ do
         Doc.summary "Update your profile"
@@ -418,10 +405,9 @@ sitemap o = do
     ---
 
     put "/self/email" (continue changeSelfEmail) $
-        contentType "application" "json"
-        .&. header "Z-User"
+        header "Z-User"
         .&. header "Z-Connection"
-        .&. request
+        .&. jsonRequest @EmailUpdate
 
     document "PUT" "changeEmail" $ do
         Doc.summary "Change your email address"
@@ -437,10 +423,9 @@ sitemap o = do
     ---
 
     put "/self/phone" (continue changePhone) $
-        contentType "application" "json"
-        .&. header "Z-User"
+        header "Z-User"
         .&. header "Z-Connection"
-        .&. request
+        .&. jsonRequest @PhoneUpdate
 
     document "PUT" "changePhone" $ do
         Doc.summary "Change your phone number"
@@ -462,9 +447,8 @@ sitemap o = do
     ---
 
     put "/self/password" (continue changePassword) $
-        contentType "application" "json"
-        .&. header "Z-User"
-        .&. request
+        header "Z-User"
+        .&. jsonRequest @PasswordChange
 
     document "PUT" "changePassword" $ do
         Doc.summary "Change your password"
@@ -477,10 +461,9 @@ sitemap o = do
     --
 
     put "/self/locale" (continue changeLocale) $
-        contentType "application" "json"
-        .&. header "Z-User"
+        header "Z-User"
         .&. header "Z-Connection"
-        .&. request
+        .&. jsonRequest @LocaleUpdate
 
     document "PUT" "changeLocale" $ do
         Doc.summary "Change your locale"
@@ -491,10 +474,9 @@ sitemap o = do
     --
 
     put "/self/handle" (continue changeHandle) $
-        contentType "application" "json"
-        .&. header "Z-User"
+        header "Z-User"
         .&. header "Z-Connection"
-        .&. request
+        .&. jsonRequest @HandleUpdate
 
     document "PUT" "changeHandle" $ do
         Doc.summary "Change your handle"
@@ -537,8 +519,7 @@ sitemap o = do
 
     delete "/self" (continue deleteUser) $
         header "Z-User"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @DeleteUser
         .&. accept "application" "json"
 
     document "DELETE" "deleteUser" $ do
@@ -559,8 +540,7 @@ sitemap o = do
     ---
 
     post "/delete" (continue verifyDeleteUser) $
-        request
-        .&. contentType "application" "json"
+        jsonRequest @VerifyDeleteUser
         .&. accept "application" "json"
 
     document "POST" "verifyDeleteUser" $ do
@@ -574,10 +554,9 @@ sitemap o = do
 
     post "/connections" (continue createConnection) $
         accept "application" "json"
-        .&. contentType "application" "json"
         .&. header "Z-User"
         .&. header "Z-Connection"
-        .&. request
+        .&. jsonRequest @ConnectionRequest
 
     document "POST" "createConnection" $ do
         Doc.summary "Create a connection to another user."
@@ -616,11 +595,10 @@ sitemap o = do
 
     put "/connections/:id" (continue updateConnection) $
         accept "application" "json"
-        .&. contentType "application" "json"
         .&. header "Z-User"
         .&. header "Z-Connection"
         .&. capture "id"
-        .&. request
+        .&. jsonRequest @ConnectionUpdate
 
     document "PUT" "updateConnection" $ do
         Doc.summary "Update a connection."
@@ -653,12 +631,11 @@ sitemap o = do
     --- Clients
 
     post "/clients" (continue addClient) $
-        request
+        jsonRequest @NewClient
         .&. header "Z-User"
         .&. header "Z-Connection"
         .&. opt (header "X-Forwarded-For")
         .&. accept "application" "json"
-        .&. contentType "application" "json"
 
     document "POST" "registerClient" $ do
         Doc.summary "Register a new client."
@@ -673,11 +650,10 @@ sitemap o = do
     ---
 
     put "/clients/:client" (continue updateClient) $
-        request
+        jsonRequest @UpdateClient
         .&. header "Z-User"
         .&. capture "client"
         .&. accept "application" "json"
-        .&. contentType "application" "json"
 
     document "PUT" "updateClient" $ do
         Doc.summary "Update a registered client."
@@ -691,12 +667,11 @@ sitemap o = do
     ---
 
     delete "/clients/:client" (continue rmClient) $
-        request
+        jsonRequest @RmClient
         .&. header "Z-User"
         .&. header "Z-Connection"
         .&. capture "client"
         .&. accept "application" "json"
-        .&. contentType "application" "json"
 
     document "DELETE" "deleteClient" $ do
         Doc.summary "Delete an existing client."
@@ -751,8 +726,7 @@ sitemap o = do
         header "Z-User"
         .&. header "Z-Connection"
         .&. capture "key"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @PropertyValue
 
     document "PUT" "setProperty" $ do
         Doc.summary "Set a user property."
@@ -825,8 +799,7 @@ sitemap o = do
 
     post "/register" (continue createUser) $
         accept "application" "json"
-        .&. contentType "application" "json"
-        .&. request
+        .&. jsonRequest @NewUserPublic
 
     document "POST" "register" $ do
         Doc.summary "Register a new user."
@@ -867,8 +840,7 @@ sitemap o = do
 
     post "/activate" (continue activateKey) $
         accept "application" "json"
-        .&. contentType "application" "json"
-        .&. request
+        .&. jsonRequest @Activate
 
     document "POST" "activate" $ do
         Doc.summary "Activate (i.e. confirm) an email address or phone number."
@@ -884,8 +856,7 @@ sitemap o = do
     ---
 
     post "/activate/send" (continue sendActivationCode) $
-        contentType "application" "json"
-        .&. request
+        jsonRequest @SendActivationCode
 
     document "POST" "sendActivationCode" $ do
         Doc.summary "Send (or resend) an email or phone activation code."
@@ -902,8 +873,7 @@ sitemap o = do
 
     post "/password-reset" (continue beginPasswordReset) $
         accept "application" "json"
-        .&. contentType "application" "json"
-        .&. request
+        .&. jsonRequest @NewPasswordReset
 
     document "POST" "beginPasswordReset" $ do
         Doc.summary "Initiate a password reset."
@@ -917,8 +887,7 @@ sitemap o = do
 
     post "/password-reset/complete" (continue completePasswordReset) $
         accept "application" "json"
-        .&. contentType "application" "json"
-        .&. request
+        .&. jsonRequest @CompletePasswordReset
 
     document "POST" "completePasswordReset" $ do
         Doc.summary "Complete a password reset."
@@ -931,9 +900,8 @@ sitemap o = do
 
     post "/password-reset/:key" (continue deprecatedCompletePasswordReset) $
         accept "application" "json"
-        .&. contentType "application" "json"
         .&. capture "key"
-        .&. request
+        .&. jsonRequest @PasswordReset
 
     document "POST" "deprecatedCompletePasswordReset" $ do
         Doc.deprecated
@@ -944,9 +912,8 @@ sitemap o = do
 
     post "/onboarding/v3" (continue onboarding) $
         accept "application" "json"
-        .&. contentType "application" "json"
         .&. header "Z-User"
-        .&. request
+        .&. jsonRequest @AddressBook
 
     document "POST" "onboardingV3" $ do
         Doc.summary "Upload contacts and invoke matching. Returns the list of Matches"
@@ -965,11 +932,11 @@ sitemap o = do
 ---------------------------------------------------------------------------
 -- Handlers
 
-setProperty :: UserId ::: ConnId ::: PropertyKey ::: Request ::: JSON -> Handler Response
-setProperty (u ::: c ::: k ::: req ::: _) = do
+setProperty :: UserId ::: ConnId ::: PropertyKey ::: JsonRequest PropertyValue -> Handler Response
+setProperty (u ::: c ::: k ::: req) = do
     unless (Text.compareLength (Ascii.toText (propertyKeyName k)) maxKeyLen <= EQ) $
         throwStd propertyKeyTooLarge
-    lbs <- Lazy.take (maxValueLen + 1) <$> liftIO (lazyRequestBody req)
+    lbs <- Lazy.take (maxValueLen + 1) <$> liftIO (lazyRequestBody (fromJsonRequest req))
     unless (Lazy.length lbs <= maxValueLen) $
         throwStd propertyValueTooLarge
     val <- hoistEither $ fmapL (StdError . badRequest . pack) (eitherDecode lbs)
@@ -1008,7 +975,7 @@ getPrekey (u ::: c ::: _) = do
 getPrekeyBundle :: UserId ::: JSON -> Handler Response
 getPrekeyBundle (u ::: _) = json <$> lift (API.claimPrekeyBundle u)
 
-getMultiPrekeyBundles :: Request ::: JSON ::: JSON -> Handler Response
+getMultiPrekeyBundles :: JsonRequest UserClients ::: JSON -> Handler Response
 getMultiPrekeyBundles (req ::: _) = do
     body <- parseJsonBody req
     maxSize <- fromIntegral . setMaxConvSize <$> view settings
@@ -1016,7 +983,7 @@ getMultiPrekeyBundles (req ::: _) = do
         throwStd tooManyClients
     json <$> lift (API.claimMultiPrekeyBundles body)
 
-addClient :: Request ::: UserId ::: ConnId ::: Maybe IpAddr ::: JSON ::: JSON -> Handler Response
+addClient :: JsonRequest NewClient ::: UserId ::: ConnId ::: Maybe IpAddr ::: JSON -> Handler Response
 addClient (req ::: usr ::: con ::: ip ::: _) = do
     new <- parseJsonBody req
     clt <- API.addClient usr con (ipAddr <$> ip) new !>> clientError
@@ -1024,13 +991,13 @@ addClient (req ::: usr ::: con ::: ip ::: _) = do
            . addHeader "Location" (toByteString' $ clientId clt)
            $ json clt
 
-rmClient :: Request ::: UserId ::: ConnId ::: ClientId ::: JSON ::: JSON -> Handler Response
+rmClient :: JsonRequest RmClient ::: UserId ::: ConnId ::: ClientId ::: JSON -> Handler Response
 rmClient (req ::: usr ::: con ::: clt ::: _) = do
     body <- parseJsonBody req
     API.rmClient usr con clt (rmPassword body) !>> clientError
     return empty
 
-updateClient :: Request ::: UserId ::: ClientId ::: JSON ::: JSON -> Handler Response
+updateClient :: JsonRequest UpdateClient ::: UserId ::: ClientId ::: JSON -> Handler Response
 updateClient (req ::: usr ::: clt ::: _) = do
     body <- parseJsonBody req
     API.updateClient usr clt body !>> clientError
@@ -1039,8 +1006,8 @@ updateClient (req ::: usr ::: clt ::: _) = do
 listClients :: UserId ::: JSON -> Handler Response
 listClients (usr ::: _) = json <$> lift (API.lookupClients usr)
 
-internalListClients :: JSON ::: JSON ::: Request -> Handler Response
-internalListClients (_ ::: _ ::: req) = do
+internalListClients :: JSON ::: JsonRequest UserSet -> Handler Response
+internalListClients (_ ::: req) = do
     UserSet usrs <- parseJsonBody req
     ucs <- Map.fromList <$> lift (API.lookupUsersClientIds $ Set.toList usrs)
     return $ json (UserClients ucs)
@@ -1078,8 +1045,8 @@ getRichInfo (self ::: user ::: _) = do
 listPrekeyIds :: UserId ::: ClientId ::: JSON -> Handler Response
 listPrekeyIds (usr ::: clt ::: _) = json <$> lift (API.lookupPrekeyIds usr clt)
 
-autoConnect :: JSON ::: JSON ::: UserId ::: Maybe ConnId ::: Request -> Handler Response
-autoConnect (_ ::: _ ::: uid ::: conn ::: req) = do
+autoConnect :: JSON ::: UserId ::: Maybe ConnId ::: JsonRequest UserSet -> Handler Response
+autoConnect (_ ::: uid ::: conn ::: req) = do
     UserSet to <- parseJsonBody req
     let num = Set.size to
     when (num < 1) $
@@ -1089,8 +1056,8 @@ autoConnect (_ ::: _ ::: uid ::: conn ::: req) = do
     conns <- API.autoConnect uid to conn !>> connError
     return $ json conns
 
-createUser :: JSON ::: JSON ::: Request -> Handler Response
-createUser (_ ::: _ ::: req) = do
+createUser :: JSON ::: JsonRequest NewUserPublic -> Handler Response
+createUser (_ ::: req) = do
     NewUserPublic new <- parseJsonBody req
     for_ (newUserEmail new) $ checkWhitelist . Left
     for_ (newUserPhone new) $ checkWhitelist . Right
@@ -1128,8 +1095,8 @@ createUser (_ ::: _ ::: req) = do
     sendWelcomeEmail e (CreateUserTeam t n) (NewTeamMember  _) l = Team.sendMemberWelcomeMail e t n l
     sendWelcomeEmail e (CreateUserTeam t n) (NewTeamMemberSSO _) l = Team.sendMemberWelcomeMail e t n l
 
-createUserNoVerify :: JSON ::: JSON ::: Request -> Handler Response
-createUserNoVerify (_ ::: _ ::: req) = do
+createUserNoVerify :: JSON ::: JsonRequest NewUser -> Handler Response
+createUserNoVerify (_ ::: req) = do
     (uData :: NewUser)  <- parseJsonBody req
     result <- API.createUser uData !>> newUserError
     let acc = createdAccount result
@@ -1151,8 +1118,8 @@ deleteUserNoVerify uid = do
     lift $ API.deleteUserNoVerify uid
     return $ setStatus status202 empty
 
-changeSelfEmailNoSend :: JSON ::: UserId ::: Request -> Handler Response
-changeSelfEmailNoSend (_ ::: u ::: req) = changeEmail u req False
+changeSelfEmailNoSend :: UserId ::: JsonRequest EmailUpdate -> Handler Response
+changeSelfEmailNoSend (u ::: req) = changeEmail u req False
 
 checkUserExists :: UserId ::: UserId -> Handler Response
 checkUserExists (self ::: uid) = do
@@ -1218,14 +1185,14 @@ getPasswordResetCode (_ ::: emailOrPhone) = do
   where
     found (k, c) = json $ object [ "key" .= k, "code" .= c ]
 
-updateUser :: JSON ::: UserId ::: ConnId ::: Request -> Handler Response
-updateUser (_ ::: uid ::: conn ::: req) = do
+updateUser :: UserId ::: ConnId ::: JsonRequest UserUpdate -> Handler Response
+updateUser (uid ::: conn ::: req) = do
     uu <- parseJsonBody req
     lift $ API.updateUser uid conn uu
     return empty
 
-changeAccountStatus :: JSON ::: UserId ::: Request -> Handler Response
-changeAccountStatus (_ ::: usr ::: req) = do
+changeAccountStatus :: UserId ::: JsonRequest AccountStatusUpdate -> Handler Response
+changeAccountStatus (usr ::: req) = do
     status <- suStatus <$> parseJsonBody req
     API.changeAccountStatus (List1.singleton usr) status !>> accountStatusError
     return empty
@@ -1237,8 +1204,8 @@ getAccountStatus (_ ::: usr) = do
         Just s  -> json $ object ["status" .= s]
         Nothing -> setStatus status404 empty
 
-changePhone :: JSON ::: UserId ::: ConnId ::: Request -> Handler Response
-changePhone (_ ::: u ::: _ ::: req) = do
+changePhone :: UserId ::: ConnId ::: JsonRequest PhoneUpdate -> Handler Response
+changePhone (u ::: _ ::: req) = do
     phone <- puPhone <$> parseJsonBody req
     (adata, pn) <- API.changePhone u phone !>> changePhoneError
     loc   <- lift $ API.lookupLocale u
@@ -1261,14 +1228,14 @@ checkPasswordExists self = do
     exists <- lift $ isJust <$> API.lookupPassword self
     return $ if exists then empty else setStatus status404 empty
 
-changePassword :: JSON ::: UserId ::: Request -> Handler Response
-changePassword (_ ::: u ::: req) = do
+changePassword :: UserId ::: JsonRequest PasswordChange -> Handler Response
+changePassword (u ::: req) = do
     cp <- parseJsonBody req
     API.changePassword u cp !>> changePwError
     return empty
 
-changeLocale :: JSON ::: UserId ::: ConnId ::: Request -> Handler Response
-changeLocale (_ ::: u ::: conn ::: req) = do
+changeLocale :: UserId ::: ConnId ::: JsonRequest LocaleUpdate -> Handler Response
+changeLocale (u ::: conn ::: req) = do
     l <- parseJsonBody req
     lift $ API.changeLocale u conn l
     return empty
@@ -1287,8 +1254,8 @@ checkHandle (_ ::: h) = do
         -- Handle is free and can be taken
         -> return $ setStatus status404 empty
 
-checkHandles :: JSON ::: JSON ::: UserId ::: Request -> Handler Response
-checkHandles (_ ::: _ ::: _ ::: req) = do
+checkHandles :: JSON ::: UserId ::: JsonRequest CheckHandles -> Handler Response
+checkHandles (_ ::: _ ::: req) = do
     CheckHandles hs num <- parseJsonBody req
     let handles = mapMaybe parseHandle (fromRange hs)
     free <- lift $ API.checkHandles handles (fromRange num)
@@ -1301,18 +1268,18 @@ getHandleInfo (_ ::: _ ::: h) = do
         Just  u -> json (UserHandleInfo u)
         Nothing -> setStatus status404 empty
 
-changeHandle :: JSON ::: UserId ::: ConnId ::: Request -> Handler Response
-changeHandle (_ ::: u ::: conn ::: req) = do
+changeHandle :: UserId ::: ConnId ::: JsonRequest HandleUpdate -> Handler Response
+changeHandle (u ::: conn ::: req) = do
     HandleUpdate h <- parseJsonBody req
     handle <- validateHandle h
     API.changeHandle u conn handle !>> changeHandleError
     return empty
 
-activateKey :: JSON ::: JSON ::: Request -> Handler Response
-activateKey (_ ::: _ ::: req) = parseJsonBody req >>= activate
+activateKey :: JSON ::: JsonRequest Activate -> Handler Response
+activateKey (_ ::: req) = parseJsonBody req >>= activate
 
-beginPasswordReset :: JSON ::: JSON ::: Request -> Handler Response
-beginPasswordReset (_ ::: _ ::: req) = do
+beginPasswordReset :: JSON ::: JsonRequest NewPasswordReset -> Handler Response
+beginPasswordReset (_ ::: req) = do
     NewPasswordReset target <- parseJsonBody req
     checkWhitelist target
     (u, pair) <- API.beginPasswordReset target !>> pwResetError
@@ -1322,21 +1289,21 @@ beginPasswordReset (_ ::: _ ::: req) = do
         Right phone -> sendPasswordResetSms  phone pair loc
     return $ setStatus status201 empty
 
-completePasswordReset :: JSON ::: JSON ::: Request -> Handler Response
-completePasswordReset (_ ::: _ ::: req) = do
+completePasswordReset :: JSON ::: JsonRequest CompletePasswordReset -> Handler Response
+completePasswordReset (_ ::: req) = do
     CompletePasswordReset{..} <- parseJsonBody req
     API.completePasswordReset cpwrIdent cpwrCode cpwrPassword !>> pwResetError
     return empty
 
-sendActivationCode :: JSON ::: Request -> Handler Response
-sendActivationCode (_ ::: req) = do
+sendActivationCode :: JsonRequest SendActivationCode -> Handler Response
+sendActivationCode req = do
     SendActivationCode{..} <- parseJsonBody req
     checkWhitelist saUserKey
     API.sendActivationCode saUserKey saLocale saCall !>> sendActCodeError
     return empty
 
-changeSelfEmail :: JSON ::: UserId ::: ConnId ::: Request -> Handler Response
-changeSelfEmail (_ ::: u ::: _ ::: req) = changeEmail u req True
+changeSelfEmail :: UserId ::: ConnId ::: JsonRequest EmailUpdate -> Handler Response
+changeSelfEmail (u ::: _ ::: req) = changeEmail u req True
 
 -- Deprecated and to be removed after new versions of brig and galley are
 -- deployed. Reason for deprecation: it returns N^2 things (which is not
@@ -1350,25 +1317,25 @@ deprecatedGetConnectionsStatus (users ::: flt) = do
     filterByRelation l rel = filter ((==rel) . csStatus) l
 
 getConnectionsStatus
-    :: JSON ::: JSON ::: Request ::: Maybe Relation
+    :: JSON ::: JsonRequest ConnectionsStatusRequest ::: Maybe Relation
     -> Handler Response
-getConnectionsStatus (_ ::: _ ::: req ::: flt) = do
+getConnectionsStatus (_ ::: req ::: flt) = do
     ConnectionsStatusRequest{csrFrom, csrTo} <- parseJsonBody req
     r <- lift $ API.lookupConnectionStatus csrFrom csrTo
     return . json $ maybe r (filterByRelation r) flt
   where
     filterByRelation l rel = filter ((==rel) . csStatus) l
 
-createConnection :: JSON ::: JSON ::: UserId ::: ConnId ::: Request -> Handler Response
-createConnection (_ ::: _ ::: self ::: conn ::: req) = do
+createConnection :: JSON ::: UserId ::: ConnId ::: JsonRequest ConnectionRequest -> Handler Response
+createConnection (_ ::: self ::: conn ::: req) = do
     cr <- parseJsonBody req
     rs <- API.createConnection self cr conn !>> connError
     return $ case rs of
         ConnectionCreated c -> setStatus status201 $ json c
         ConnectionExists  c -> json c
 
-updateConnection :: JSON ::: JSON ::: UserId ::: ConnId ::: UserId ::: Request -> Handler Response
-updateConnection (_ ::: _ ::: self ::: conn ::: other ::: req) = do
+updateConnection :: JSON ::: UserId ::: ConnId ::: UserId ::: JsonRequest ConnectionUpdate -> Handler Response
+updateConnection (_ ::: self ::: conn ::: other ::: req) = do
     newStatus <- cuStatus <$> parseJsonBody req
     mc <- API.updateConnection self other newStatus (Just conn) !>> connError
     return $ case mc of
@@ -1421,8 +1388,8 @@ deleteFromPhonePrefix prefix = do
     void . lift $ API.phonePrefixDelete prefix
     return empty
 
-addPhonePrefix :: JSON ::: JSON ::: Request -> Handler Response
-addPhonePrefix (_ ::: _ ::: req) = do
+addPhonePrefix :: JSON ::: JsonRequest ExcludedPrefix -> Handler Response
+addPhonePrefix (_ ::: req) = do
     prefix :: ExcludedPrefix <- parseJsonBody req
     void . lift $ API.phonePrefixInsert prefix
     return empty
@@ -1449,22 +1416,22 @@ isTeamOwner (uid ::: tid) = do
        Team.NoTeamOwnersAreLeft   -> throwStd insufficientTeamPermissions
     return empty
 
-updateSSOId :: UserId ::: JSON ::: JSON ::: Request -> Handler Response
-updateSSOId (uid ::: _ ::: _ ::: req) = do
+updateSSOId :: UserId ::: JSON ::: JsonRequest UserSSOId -> Handler Response
+updateSSOId (uid ::: _ ::: req) = do
     ssoid :: UserSSOId <- parseJsonBody req
     success <- lift $ Data.updateSSOId uid ssoid
     if success
       then return empty
       else return . setStatus status404 $ plain "User does not exist or has no team."
 
-updateManagedBy :: UserId ::: JSON ::: JSON ::: Request -> Handler Response
-updateManagedBy (uid ::: _ ::: _ ::: req) = do
+updateManagedBy :: UserId ::: JSON ::: JsonRequest ManagedByUpdate -> Handler Response
+updateManagedBy (uid ::: _ ::: req) = do
     ManagedByUpdate managedBy <- parseJsonBody req
     lift $ Data.updateManagedBy uid managedBy
     return empty
 
-updateRichInfo :: UserId ::: JSON ::: JSON ::: Request -> Handler Response
-updateRichInfo (uid ::: _ ::: _ ::: req) = do
+updateRichInfo :: UserId ::: JSON ::: JsonRequest RichInfoUpdate -> Handler Response
+updateRichInfo (uid ::: _ ::: req) = do
     richInfo <- normalizeRichInfo . riuRichInfo <$> parseJsonBody req
     maxSize <- setRichInfoLimit <$> view settings
     when (richInfoSize richInfo > maxSize) $ throwStd tooLargeRichInfo
@@ -1473,22 +1440,22 @@ updateRichInfo (uid ::: _ ::: _ ::: req) = do
     -- Intra.onUserEvent uid (Just conn) (richInfoUpdate uid ri)
     return empty
 
-deleteUser :: UserId ::: Request ::: JSON ::: JSON -> Handler Response
-deleteUser (u ::: r ::: _ ::: _) = do
+deleteUser :: UserId ::: JsonRequest DeleteUser ::: JSON -> Handler Response
+deleteUser (u ::: r ::: _) = do
     body <- parseJsonBody r
     res <- API.deleteUser u (deleteUserPassword body) !>> deleteUserError
     return $ case res of
         Nothing  -> setStatus status200 empty
         Just ttl -> setStatus status202 (json (DeletionCodeTimeout ttl))
 
-verifyDeleteUser :: Request ::: JSON ::: JSON -> Handler Response
+verifyDeleteUser :: JsonRequest VerifyDeleteUser ::: JSON -> Handler Response
 verifyDeleteUser (r ::: _) = do
     body <- parseJsonBody r
     API.verifyDeleteUser body !>> deleteUserError
     return (setStatus status200 empty)
 
-onboarding :: JSON ::: JSON ::: UserId ::: Request -> Handler Response
-onboarding (_ ::: _ ::: uid ::: r) = do
+onboarding :: JSON ::: UserId ::: JsonRequest AddressBook -> Handler Response
+onboarding (_ ::: uid ::: r) = do
     ab <- parseJsonBody r
     json <$> API.onboarding uid ab !>> connError
 
@@ -1499,8 +1466,8 @@ getContactList (_ ::: uid) = do
 
 -- Deprecated
 
-deprecatedCompletePasswordReset :: JSON ::: JSON ::: PasswordResetKey ::: Request -> Handler Response
-deprecatedCompletePasswordReset (_ ::: _ ::: k ::: req) = do
+deprecatedCompletePasswordReset :: JSON ::: PasswordResetKey ::: JsonRequest PasswordReset -> Handler Response
+deprecatedCompletePasswordReset (_ ::: k ::: req) = do
     pwr <- parseJsonBody req
     API.completePasswordReset (PasswordResetIdentityKey k) (pwrCode pwr) (pwrPassword pwr) !>> pwResetError
     return empty
@@ -1524,7 +1491,7 @@ activate (Activate tgt code dryrun)
     respond (Just ident) first = setStatus status200 $ json (ActivationResponse ident first)
     respond Nothing      _     = setStatus status200 empty
 
-changeEmail :: UserId -> Request -> Bool -> Handler Response
+changeEmail :: UserId -> JsonRequest EmailUpdate -> Bool -> Handler Response
 changeEmail u req sendOutEmail = do
     email <- euEmail <$> parseJsonBody req
     API.changeEmail u email !>> changeEmailError >>= \case

--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -25,7 +25,7 @@ import Network.Wai.Predicate (Media)
 import Network.Wai (Request, ResponseReceived)
 import Network.Wai.Routing (Continue)
 import Network.Wai.Utilities.Error ((!>>))
-import Network.Wai.Utilities.Request (lookupRequestId, parseBody)
+import Network.Wai.Utilities.Request (JsonRequest, lookupRequestId, parseBody)
 import Network.Wai.Utilities.Response (setStatus, json, addHeader)
 import System.Logger (Logger)
 
@@ -76,7 +76,7 @@ type JSON = Media "application" "json"
 -- TODO: move to libs/wai-utilities?  there is a parseJson' in "Network.Wai.Utilities.Request",
 -- but adjusting its signature to this here would require to move more code out of brig (at least
 -- badRequest and probably all the other errors).
-parseJsonBody :: FromJSON a => Request -> Handler a
+parseJsonBody :: FromJSON a => JsonRequest a -> Handler a
 parseJsonBody req = parseBody req !>> StdError . badRequest
 
 -- | If a whitelist is configured, consult it, otherwise a no-op.

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -34,16 +34,17 @@ import Data.Misc (Fingerprint (..), Rsa)
 import Data.Predicate
 import Data.Range
 import Galley.Types (Conversation (..), ConvType (..), ConvMembers (..), AccessRole (..))
-import Galley.Types (OtherMember (..))
+import Galley.Types (OtherMember (..), UserClients)
 import Galley.Types (Event, userClients)
 import Galley.Types.Bot (newServiceRef, serviceRefProvider, serviceRefId)
 import Data.Conduit ((.|), runConduit)
 import Network.HTTP.Types.Status
-import Network.Wai (Request, Response)
-import Network.Wai.Predicate (contentType, accept, request, query, def, opt)
+import Network.Wai (Response)
+import Network.Wai.Predicate (contentType, accept, query, def, opt)
 import Network.Wai.Routing
 import Network.Wai.Utilities.Error ((!>>))
 import Network.Wai.Utilities.Response (json, empty, setStatus, addHeader)
+import Network.Wai.Utilities.Request (jsonRequest, JsonRequest)
 import Network.Wai.Utilities.ZAuth
 import OpenSSL.Random (randBytes)
 
@@ -81,9 +82,8 @@ routes = do
     -- Public API --------------------------------------------------------------
 
     post "/provider/register" (continue newAccount) $
-        contentType "application" "json"
-        .&> accept "application" "json"
-        .&> request
+        accept "application" "json"
+        .&> jsonRequest @NewProvider
 
     get "/provider/activate" (continue activateAccountKey) $
         accept "application" "json"
@@ -96,45 +96,38 @@ routes = do
         .&. query "code"
 
     post "/provider/login" (continue login) $
-        contentType "application" "json"
-        .&> request
+        jsonRequest @ProviderLogin
 
     post "/provider/password-reset" (continue beginPasswordReset) $
         accept "application" "json"
-        .&> contentType "application" "json"
-        .&> request
+        .&> jsonRequest @PasswordReset
 
     post "/provider/password-reset/complete" (continue completePasswordReset) $
         accept "application" "json"
-        .&> contentType "application" "json"
-        .&> request
+        .&> jsonRequest @CompletePasswordReset
 
     -- Provider API ------------------------------------------------------------
 
     delete "/provider" (continue deleteAccount) $
-        contentType "application" "json"
-        .&> zauth ZAuthProvider
+        zauth ZAuthProvider
         .&> zauthProviderId
-        .&. request
+        .&. jsonRequest @DeleteProvider
 
     put "/provider" (continue updateAccountProfile) $
-        contentType "application" "json"
-        .&> accept "application" "json"
+        accept "application" "json"
         .&> zauth ZAuthProvider
         .&> zauthProviderId
-        .&. request
+        .&. jsonRequest @UpdateProvider
 
     put "/provider/email" (continue updateAccountEmail) $
-        contentType "application" "json"
-        .&> zauth ZAuthProvider
+        zauth ZAuthProvider
         .&> zauthProviderId
-        .&. request
+        .&. jsonRequest @EmailUpdate
 
     put "/provider/password" (continue updateAccountPassword) $
-        contentType "application" "json"
-        .&> zauth ZAuthProvider
+        zauth ZAuthProvider
         .&> zauthProviderId
-        .&. request
+        .&. jsonRequest @PasswordChange
 
     get "/provider" (continue getAccount) $
         accept "application" "json"
@@ -143,10 +136,9 @@ routes = do
 
     post "/provider/services" (continue addService) $
         accept "application" "json"
-        .&> contentType "application" "json"
         .&> zauth ZAuthProvider
         .&> zauthProviderId
-        .&. request
+        .&. jsonRequest @NewService
 
     get "/provider/services" (continue listServices) $
         accept "application" "json"
@@ -160,18 +152,16 @@ routes = do
         .&. capture "sid"
 
     put "/provider/services/:sid" (continue updateService) $
-        contentType "application" "json"
-        .&> zauth ZAuthProvider
+        zauth ZAuthProvider
         .&> zauthProviderId
         .&. capture "sid"
-        .&. request
+        .&. jsonRequest @UpdateService
 
     put "/provider/services/:sid/connection" (continue updateServiceConn) $
-        contentType "application" "json"
-        .&> zauth ZAuthProvider
+        zauth ZAuthProvider
         .&> zauthProviderId
         .&. capture "sid"
-        .&. request
+        .&. jsonRequest @UpdateServiceConn
 
 -- TODO
 --     post "/provider/services/:sid/token" (continue genServiceToken) $
@@ -179,11 +169,10 @@ routes = do
 --         .&. zauthProvider
 
     delete "/provider/services/:sid" (continue deleteService) $
-        contentType "application" "json"
-        .&> zauth ZAuthProvider
+        zauth ZAuthProvider
         .&> zauthProviderId
         .&. capture "sid"
-        .&. request
+        .&. jsonRequest @DeleteService
 
     -- User API ----------------------------------------------------------------
 
@@ -228,16 +217,15 @@ routes = do
         .&> zauthUserId
         .&. zauthConnId
         .&. capture "tid"
-        .&. request
+        .&. jsonRequest @UpdateServiceWhitelist
 
     post "/conversations/:cnv/bots" (continue addBot) $
-        contentType "application" "json"
-        .&> accept "application" "json"
+        accept "application" "json"
         .&> zauth ZAuthAccess
         .&> zauthUserId
         .&. zauthConnId
         .&. capture "cnv"
-        .&. request
+        .&. jsonRequest @AddBot
 
     delete "/conversations/:cnv/bots/:bot" (continue removeBot) $
         zauth ZAuthAccess
@@ -264,10 +252,9 @@ routes = do
         .&> zauthBotId
 
     post "/bot/client/prekeys" (continue botUpdatePrekeys) $
-        contentType "application" "json"
-        .&> zauth ZAuthBot
+        zauth ZAuthBot
         .&> zauthBotId
-        .&. request
+        .&. jsonRequest @UpdateBotPrekeys
 
     get "/bot/client" (continue botGetClient) $
         contentType "application" "json"
@@ -276,9 +263,8 @@ routes = do
 
     post "/bot/users/prekeys" (continue botClaimUsersPrekeys) $
         accept "application" "json"
-        .&> contentType "application" "json"
         .&> zauth ZAuthBot
-        .&> request
+        .&> jsonRequest @UserClients
 
     get "/bot/users" (continue botListUserProfiles) $
         accept "application" "json"
@@ -299,7 +285,7 @@ routes = do
 --------------------------------------------------------------------------------
 -- Public API (Unauthenticated)
 
-newAccount :: Request -> Handler Response
+newAccount :: JsonRequest NewProvider -> Handler Response
 newAccount req = do
     new <- parseJsonBody req
 
@@ -382,7 +368,7 @@ approveAccountKey (key ::: val) = do
             return empty
         _ -> throwStd invalidCode
 
-login :: Request -> Handler Response
+login :: JsonRequest ProviderLogin -> Handler Response
 login req = do
     l    <- parseJsonBody req
     pid  <- DB.lookupKey (mkEmailKey (providerLoginEmail l)) >>= maybeBadCredentials
@@ -392,7 +378,7 @@ login req = do
     tok <- ZAuth.newProviderToken pid
     setProviderCookie tok empty
 
-beginPasswordReset :: Request -> Handler Response
+beginPasswordReset :: JsonRequest PasswordReset -> Handler Response
 beginPasswordReset req = do
     PasswordReset target <- parseJsonBody req
     pid <- DB.lookupKey (mkEmailKey target) >>= maybeBadCredentials
@@ -410,7 +396,7 @@ beginPasswordReset req = do
     lift $ sendPasswordResetMail target (Code.codeKey code) (Code.codeValue code)
     return $ setStatus status201 empty
 
-completePasswordReset :: Request -> Handler Response
+completePasswordReset :: JsonRequest CompletePasswordReset -> Handler Response
 completePasswordReset req = do
     CompletePasswordReset key val pwd <- parseJsonBody req
     c <- Code.verify key Code.PasswordReset val >>= maybeInvalidCode
@@ -431,7 +417,7 @@ getAccount pid = do
         Just  p -> json p
         Nothing -> setStatus status404 empty
 
-updateAccountProfile :: ProviderId ::: Request -> Handler Response
+updateAccountProfile :: ProviderId ::: JsonRequest UpdateProvider -> Handler Response
 updateAccountProfile (pid ::: req) = do
     _   <- DB.lookupAccount pid >>= maybeInvalidProvider
     upd <- parseJsonBody req
@@ -441,7 +427,7 @@ updateAccountProfile (pid ::: req) = do
         (updateProviderDescr upd)
     return empty
 
-updateAccountEmail :: ProviderId ::: Request -> Handler Response
+updateAccountEmail :: ProviderId ::: JsonRequest EmailUpdate -> Handler Response
 updateAccountEmail (pid ::: req) = do
     EmailUpdate new <- parseJsonBody req
     email <- case validateEmail new of
@@ -461,7 +447,7 @@ updateAccountEmail (pid ::: req) = do
     lift $ sendActivationMail (Name "name") email (Code.codeKey code) (Code.codeValue code) True
     return $ setStatus status202 empty
 
-updateAccountPassword :: ProviderId ::: Request -> Handler Response
+updateAccountPassword :: ProviderId ::: JsonRequest PasswordChange -> Handler Response
 updateAccountPassword (pid ::: req) = do
     upd  <- parseJsonBody req
     pass <- DB.lookupPassword pid >>= maybeBadCredentials
@@ -470,7 +456,7 @@ updateAccountPassword (pid ::: req) = do
     DB.updateAccountPassword pid (cpNewPassword upd)
     return empty
 
-addService :: ProviderId ::: Request -> Handler Response
+addService :: ProviderId ::: JsonRequest NewService -> Handler Response
 addService (pid ::: req) = do
     new <- parseJsonBody req
     _   <- DB.lookupAccount pid >>= maybeInvalidProvider
@@ -499,7 +485,7 @@ getService (pid ::: sid) = do
     s <- DB.lookupService pid sid >>= maybeServiceNotFound
     return (json s)
 
-updateService :: ProviderId ::: ServiceId ::: Request -> Handler Response
+updateService :: ProviderId ::: ServiceId ::: JsonRequest UpdateService -> Handler Response
 updateService (pid ::: sid ::: req) = do
     upd <- parseJsonBody req
     _   <- DB.lookupAccount pid >>= maybeInvalidProvider
@@ -520,7 +506,7 @@ updateService (pid ::: sid ::: req) = do
 
     return empty
 
-updateServiceConn :: ProviderId ::: ServiceId ::: Request -> Handler Response
+updateServiceConn :: ProviderId ::: ServiceId ::: JsonRequest UpdateServiceConn -> Handler Response
 updateServiceConn (pid ::: sid ::: req) = do
     upd <- parseJsonBody req
 
@@ -568,7 +554,7 @@ updateServiceConn (pid ::: sid ::: req) = do
 -- Since deleting a service can be costly, it just marks the service as
 -- disabled and then creates an event that will, when processed, actually
 -- delete the service. See 'finishDeleteService'.
-deleteService :: ProviderId ::: ServiceId ::: Request -> Handler Response
+deleteService :: ProviderId ::: ServiceId ::: JsonRequest DeleteService -> Handler Response
 deleteService (pid ::: sid ::: req) = do
     del  <- parseJsonBody req
     pass <- DB.lookupPassword pid >>= maybeBadCredentials
@@ -595,7 +581,7 @@ finishDeleteService pid sid = do
   where
     kick (bid, cid, _) = deleteBot (botUserId bid) Nothing bid cid
 
-deleteAccount :: ProviderId ::: Request -> Handler Response
+deleteAccount :: ProviderId ::: JsonRequest DeleteProvider -> Handler Response
 deleteAccount (pid ::: req) = do
     del  <- parseJsonBody req
     prov <- DB.lookupAccount pid >>= maybeInvalidProvider
@@ -665,7 +651,7 @@ getServiceTagList _ = return (json (ServiceTagList allTags))
   where
     allTags = [(minBound :: ServiceTag) ..]
 
-updateServiceWhitelist :: UserId ::: ConnId ::: TeamId ::: Request -> Handler Response
+updateServiceWhitelist :: UserId ::: ConnId ::: TeamId ::: JsonRequest UpdateServiceWhitelist -> Handler Response
 updateServiceWhitelist (uid ::: con ::: tid ::: req) = do
     upd :: UpdateServiceWhitelist <- parseJsonBody req
     let pid = updateServiceWhitelistProvider upd
@@ -694,7 +680,7 @@ updateServiceWhitelist (uid ::: con ::: tid ::: req) = do
             DB.deleteServiceWhitelist (Just tid) pid sid
             return (setStatus status200 empty)
 
-addBot :: UserId ::: ConnId ::: ConvId ::: Request -> Handler Response
+addBot :: UserId ::: ConnId ::: ConvId ::: JsonRequest AddBot -> Handler Response
 addBot (zuid ::: zcon ::: cid ::: req) = do
     add  <- parseJsonBody req
     zusr <- lift (User.lookupUser zuid) >>= maybeInvalidUser
@@ -810,7 +796,7 @@ botListPrekeys bot = do
         Nothing -> return $ json ([] :: [PrekeyId])
         Just ci -> json <$> lift (User.lookupPrekeyIds (botUserId bot) ci)
 
-botUpdatePrekeys :: BotId ::: Request -> Handler Response
+botUpdatePrekeys :: BotId ::: JsonRequest UpdateBotPrekeys -> Handler Response
 botUpdatePrekeys (bot ::: req) = do
     upd <- parseJsonBody req
     clt <- lift $ listToMaybe <$> User.lookupClients (botUserId bot)
@@ -821,7 +807,7 @@ botUpdatePrekeys (bot ::: req) = do
             User.updatePrekeys (botUserId bot) (clientId c) pks !>> clientDataError
     return empty
 
-botClaimUsersPrekeys :: Request -> Handler Response
+botClaimUsersPrekeys :: JsonRequest UserClients -> Handler Response
 botClaimUsersPrekeys req = do
     body <- parseJsonBody req
     maxSize <- fromIntegral . setMaxConvSize <$> view settings

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -19,7 +19,7 @@ import Data.ByteString.Conversion
 import Data.Id
 import Data.Range
 import Network.HTTP.Types.Status
-import Network.Wai (Request, Response)
+import Network.Wai (Response)
 import Network.Wai.Predicate hiding (setStatus, result, and)
 import Network.Wai.Routing hiding (head)
 import Network.Wai.Utilities hiding (message, code)
@@ -44,7 +44,7 @@ routes = do
         accept "application" "json"
         .&. header "Z-User"
         .&. capture "tid"
-        .&. request
+        .&. jsonRequest @InvitationRequest
 
     document "POST" "sendTeamInvitation" $ do
         Doc.summary "Create and send a new team invitation."
@@ -153,7 +153,7 @@ getInvitationCode (_ ::: t ::: r) = do
   where
     found c = json $ object [ "code" .= c ]
 
-createInvitation :: JSON ::: UserId ::: TeamId ::: Request -> Handler Response
+createInvitation :: JSON ::: UserId ::: TeamId ::: JsonRequest InvitationRequest -> Handler Response
 createInvitation (_ ::: uid ::: tid ::: req) = do
     body :: InvitationRequest <- parseJsonBody req
     idt  <- maybe (throwStd noIdentity) return =<< lift (fetchUserIdentity uid)

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -4,13 +4,15 @@ import Imports
 import Brig.API.Handler
 import Brig.User.Event
 import Brig.User.Search.Index
+import Brig.Types.Search (SearchableStatus)
 import Data.Id
 import Data.Range
 import Data.Predicate
 import Network.HTTP.Types.Status
-import Network.Wai (Request, Response)
+import Network.Wai (Response)
 import Network.Wai.Predicate hiding (setStatus)
 import Network.Wai.Routing
+import Network.Wai.Utilities.Request (jsonRequest, JsonRequest)
 import Network.Wai.Utilities.Response (json, empty, setStatus)
 import Network.Wai.Utilities.Swagger (document)
 
@@ -51,9 +53,8 @@ routes = do
     --
 
     put "/self/searchable" (continue setSearchable) $
-        contentType "application" "json"
-        .&. header "Z-User"
-        .&. request
+        header "Z-User"
+        .&. jsonRequest @SearchableStatus
 
     document "PUT" "updateSearchableStatus" $ do
         Doc.summary "Opt in or out of being included in search results."
@@ -82,8 +83,8 @@ search (_ ::: u ::: q ::: s) = json <$> lift (searchIndex u q s)
 isSearchable :: JSON ::: UserId -> Handler Response
 isSearchable (_ ::: u) = json <$> lift (checkIndex u)
 
-setSearchable :: JSON ::: UserId ::: Request-> Handler Response
-setSearchable (_ ::: u ::: r) = do
+setSearchable :: UserId ::: JsonRequest SearchableStatus -> Handler Response
+setSearchable (u ::: r) = do
     s <- parseJsonBody r
     lift $ DB.updateSearchableStatus u s
     lift $ Intra.onUserEvent u Nothing (searchableStatusUpdated u s)

--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -55,7 +55,7 @@ sitemap = do
         capture "user" .&. capture "conn" .&. request
 
     post "/i/bulkpush" (continue bulkpush) $
-        jsonRequest @BulkPushRequest
+        request
 
     head "/i/presences/:user/:conn" (continue checkPresence) $
         param "user" .&. param "conn"
@@ -87,8 +87,8 @@ push (user ::: conn ::: req) =
 
 -- | Parse the entire list of notifcations and targets, then call 'singlePush' on the each of them
 -- in order.
-bulkpush :: JsonRequest BulkPushRequest -> Cannon Response
-bulkpush req = json <$> (parseBody' req >>= bulkpush')
+bulkpush :: Request -> Cannon Response
+bulkpush req = json <$> (parseBody' (JsonRequest req) >>= bulkpush')
 
 -- | The typed part of 'bulkpush'.
 bulkpush' :: BulkPushRequest -> Cannon BulkPushResponse

--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -54,8 +54,8 @@ sitemap = do
     post "/i/push/:user/:conn" (continue push) $
         capture "user" .&. capture "conn" .&. request
 
-    post "/i/bulkpush" (continue bulkpush)
-        request
+    post "/i/bulkpush" (continue bulkpush) $
+        jsonRequest @BulkPushRequest
 
     head "/i/presences/:user/:conn" (continue checkPresence) $
         param "user" .&. param "conn"
@@ -87,7 +87,7 @@ push (user ::: conn ::: req) =
 
 -- | Parse the entire list of notifcations and targets, then call 'singlePush' on the each of them
 -- in order.
-bulkpush :: Request -> Cannon Response
+bulkpush :: JsonRequest BulkPushRequest -> Cannon Response
 bulkpush req = json <$> (parseBody' req >>= bulkpush')
 
 -- | The typed part of 'bulkpush'.

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -15,8 +15,11 @@ import Galley.API.Create
 import Galley.API.Update
 import Galley.API.Teams
 import Galley.API.Query
-import Galley.Types (OtrFilterMissing (..))
-import Galley.Types.Teams (Perm (..))
+import Galley.Types
+import Galley.Types.Teams
+import Galley.Types.Teams.Intra
+import Galley.Types.Bot.Service
+import Galley.Types.Bot (AddBot, RemoveBot)
 import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Predicate
@@ -40,9 +43,8 @@ sitemap = do
     post "/teams" (continue createNonBindingTeam) $
         zauthUserId
         .&. zauthConnId
-        .&. request
+        .&. jsonRequest @NonBindingNewTeam
         .&. accept "application" "json"
-        .&. contentType "application" "json"
 
     document "POST" "createNonBindingTeam" $ do
         summary "Create a new non binding team"
@@ -55,9 +57,8 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. capture "id"
-        .&. request
+        .&. jsonRequest @TeamUpdateData
         .&. accept "application" "json"
-        .&. contentType "application" "json"
 
     document "PUT" "updateTeam" $ do
         summary "Update team properties"
@@ -160,8 +161,7 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. capture "id"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @NewTeamMember
         .&. accept "application" "json"
 
     document "POST" "addTeamMember" $ do
@@ -206,9 +206,8 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. capture "id"
-        .&. request
+        .&. jsonRequest @NewTeamMember
         .&. accept "application" "json"
-        .&. contentType "application" "json"
 
     document "PUT" "updateTeamMember" $ do
         summary "Update an existing team member"
@@ -287,8 +286,7 @@ sitemap = do
         .&> zauthBotId
         .&. zauthConvId
         .&. def OtrReportAllMissing filterMissing
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @NewOtrMessage
         .&. accept "application" "json"
 
     --
@@ -352,8 +350,7 @@ sitemap = do
     post "/conversations" (continue createGroupConversation) $
         zauthUserId
         .&. zauthConnId
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @NewConvUnmanaged
 
     document "POST" "createGroupConversation" $ do
         summary "Create a new conversation"
@@ -380,8 +377,7 @@ sitemap = do
     post "/conversations/one2one" (continue createOne2OneConversation) $
         zauthUserId
         .&. zauthConnId
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @NewConvUnmanaged
 
     document "POST" "createOne2OneConversation" $ do
         summary "Create a 1:1-conversation"
@@ -397,8 +393,7 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. capture "cnv"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @ConversationRename
 
     document "PUT" "updateConversation" $ do
         summary "Update conversation properties"
@@ -428,8 +423,7 @@ sitemap = do
     ---
 
     post "/conversations/code-check" (continue checkReusableCode) $
-        request
-        .&. contentType "application" "json"
+        jsonRequest @ConversationCode
 
     document "POST" "checkConversationCode" $ do
         summary "Check validity of a conversation code"
@@ -442,8 +436,7 @@ sitemap = do
     post "/conversations/join" (continue joinConversationByReusableCode) $
         zauthUserId
         .&. zauthConnId
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @ConversationCode
 
     document "POST" "joinConversationByCode" $ do
         summary "Join a conversation using a reusable code"
@@ -510,8 +503,7 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. capture "cnv"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @ConversationAccessUpdate
 
     document "PUT" "updateConversationAccess" $ do
         summary "Update access modes for a conversation"
@@ -535,8 +527,7 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. capture "cnv"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @ConversationReceiptModeUpdate
         .&. accept "application" "json"
 
     document "PUT" "updateConversationReceiptMode" $ do
@@ -557,8 +548,7 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. capture "cnv"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @ConversationMessageTimerUpdate
 
     document "PUT" "updateConversationMessageTimer" $ do
         summary "Update the message timer for a conversation"
@@ -581,8 +571,7 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. capture "cnv"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @Invite
 
     document "POST" "addMembers" $ do
         summary "Add users to an existing conversation"
@@ -617,8 +606,7 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. capture "cnv"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @MemberUpdate
 
     document "PUT" "updateSelf" $ do
         summary "Update self membership properties"
@@ -635,8 +623,7 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. capture "cnv"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @TypingData
 
     document "POST" "isTyping" $ do
         summary "Sending typing notifications"
@@ -672,8 +659,7 @@ sitemap = do
         zauthUserId
         .&. zauthConnId
         .&. def OtrReportAllMissing filterMissing
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @NewOtrMessage
 
     document "POST" "postOtrBroadcast" $ do
         summary "Broadcast an encrypted message to all team members and all contacts (accepts JSON)"
@@ -727,8 +713,7 @@ sitemap = do
         .&. zauthConnId
         .&. capture "cnv"
         .&. def OtrReportAllMissing filterMissing
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @NewOtrMessage
 
     document "POST" "postOtrMessage" $ do
         summary "Post an encrypted message to a conversation (accepts JSON)"
@@ -806,14 +791,12 @@ sitemap = do
     post "/i/conversations/managed" (continue internalCreateManagedConversation) $
         zauthUserId
         .&. zauthConnId
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @NewConvManaged
 
     post "/i/conversations/connect" (continue createConnectConversation) $
         zauthUserId
         .&. opt zauthConnId
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @Connect
 
     put "/i/conversations/:cnv/accept/v2" (continue acceptConv) $
         zauthUserId
@@ -843,20 +826,17 @@ sitemap = do
     put "/i/teams/:tid" (continue createBindingTeam) $
         zauthUserId
         .&. capture "tid"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @BindingNewTeam
         .&. accept "application" "json"
 
     put "/i/teams/:tid/status" (continue updateTeamStatus) $
         capture "tid"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @TeamStatusUpdate
         .&. accept "application" "json"
 
     post "/i/teams/:tid/members" (continue uncheckedAddTeamMember) $
         capture "tid"
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @NewTeamMember
         .&. accept "application" "json"
 
     get "/i/teams/:tid/members" (continue uncheckedGetTeamMembers) $
@@ -889,24 +869,20 @@ sitemap = do
         zauthUserId .&. opt zauthConnId
 
     post "/i/services" (continue addService) $
-        request
-        .&. contentType "application" "json"
+        jsonRequest @Service
 
     delete "/i/services" (continue rmService) $
-        request
-        .&. contentType "application" "json"
+        jsonRequest @ServiceRef
 
     post "/i/bots" (continue addBot) $
         zauthUserId
         .&. zauthConnId
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @AddBot
 
     delete "/i/bots" (continue rmBot) $
         zauthUserId
         .&. opt zauthConnId
-        .&. request
-        .&. contentType "application" "json"
+        .&. jsonRequest @RemoveBot
 
 type JSON = Media "application" "json"
 

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -40,7 +40,7 @@ import qualified Galley.Types.Teams as Teams
 -- See Note [managed conversations].
 createGroupConversation :: UserId ::: ConnId ::: JsonRequest NewConvUnmanaged -> Galley Response
 createGroupConversation (zusr ::: zcon ::: req) = do
-    wrapped@(NewConvUnmanaged body) <- fromBody req invalidPayload
+    wrapped@(NewConvUnmanaged body) <- fromJsonBody req
     case newConvTeam body of
         Nothing    -> createRegularGroupConv zusr zcon wrapped
         Just tinfo -> createTeamGroupConv zusr zcon tinfo body
@@ -50,7 +50,7 @@ createGroupConversation (zusr ::: zcon ::: req) = do
 internalCreateManagedConversation
     :: UserId ::: ConnId ::: JsonRequest NewConvManaged -> Galley Response
 internalCreateManagedConversation (zusr ::: zcon ::: req) = do
-    NewConvManaged body <- fromBody req invalidPayload
+    NewConvManaged body <- fromJsonBody req
     case newConvTeam body of
         Nothing -> throwM internalError
         Just tinfo -> createTeamGroupConv zusr zcon tinfo body
@@ -111,7 +111,7 @@ createSelfConversation zusr = do
 
 createOne2OneConversation :: UserId ::: ConnId ::: JsonRequest NewConvUnmanaged -> Galley Response
 createOne2OneConversation (zusr ::: zcon ::: req) = do
-    NewConvUnmanaged j <- fromBody req invalidPayload
+    NewConvUnmanaged j <- fromJsonBody req
     other  <- head . fromRange <$> (rangeChecked (newConvUsers j) :: Galley (Range 1 1 [UserId]))
     (x, y) <- toUUIDs zusr other
     when (x == y) $
@@ -137,7 +137,7 @@ createOne2OneConversation (zusr ::: zcon ::: req) = do
 
 createConnectConversation :: UserId ::: Maybe ConnId ::: JsonRequest Connect -> Galley Response
 createConnectConversation (usr ::: conn ::: req) = do
-    j      <- fromBody req invalidPayload
+    j      <- fromJsonBody req
     (x, y) <- toUUIDs usr (cRecipient j)
     n      <- rangeCheckedMaybe (cName j)
     conv   <- Data.conversation (Data.one2OneConvId x y)

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -38,8 +38,8 @@ import qualified Galley.Types.Teams as Teams
 -- | The public-facing endpoint for creating group conversations.
 --
 -- See Note [managed conversations].
-createGroupConversation :: UserId ::: ConnId ::: Request ::: JSON -> Galley Response
-createGroupConversation (zusr ::: zcon ::: req ::: _) = do
+createGroupConversation :: UserId ::: ConnId ::: JsonRequest NewConvUnmanaged -> Galley Response
+createGroupConversation (zusr ::: zcon ::: req) = do
     wrapped@(NewConvUnmanaged body) <- fromBody req invalidPayload
     case newConvTeam body of
         Nothing    -> createRegularGroupConv zusr zcon wrapped
@@ -48,8 +48,8 @@ createGroupConversation (zusr ::: zcon ::: req ::: _) = do
 -- | An internal endpoint for creating managed group conversations. Will
 -- throw an error for everything else.
 internalCreateManagedConversation
-    :: UserId ::: ConnId ::: Request ::: JSON -> Galley Response
-internalCreateManagedConversation (zusr ::: zcon ::: req ::: _) = do
+    :: UserId ::: ConnId ::: JsonRequest NewConvManaged -> Galley Response
+internalCreateManagedConversation (zusr ::: zcon ::: req) = do
     NewConvManaged body <- fromBody req invalidPayload
     case newConvTeam body of
         Nothing -> throwM internalError
@@ -109,8 +109,8 @@ createSelfConversation zusr = do
         c <- Data.createSelfConversation zusr Nothing
         conversationResponse status201 zusr c
 
-createOne2OneConversation :: UserId ::: ConnId ::: Request ::: JSON -> Galley Response
-createOne2OneConversation (zusr ::: zcon ::: req ::: _) = do
+createOne2OneConversation :: UserId ::: ConnId ::: JsonRequest NewConvUnmanaged -> Galley Response
+createOne2OneConversation (zusr ::: zcon ::: req) = do
     NewConvUnmanaged j <- fromBody req invalidPayload
     other  <- head . fromRange <$> (rangeChecked (newConvUsers j) :: Galley (Range 1 1 [UserId]))
     (x, y) <- toUUIDs zusr other
@@ -135,8 +135,8 @@ createOne2OneConversation (zusr ::: zcon ::: req ::: _) = do
         notifyCreatedConversation Nothing zusr (Just zcon) c
         conversationResponse status201 zusr c
 
-createConnectConversation :: UserId ::: Maybe ConnId ::: Request ::: JSON -> Galley Response
-createConnectConversation (usr ::: conn ::: req ::: _) = do
+createConnectConversation :: UserId ::: Maybe ConnId ::: JsonRequest Connect -> Galley Response
+createConnectConversation (usr ::: conn ::: req) = do
     j      <- fromBody req invalidPayload
     (x, y) <- toUUIDs usr (cRecipient j)
     n      <- rangeCheckedMaybe (cName j)

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -28,7 +28,7 @@ module Galley.App
 
       -- * Utilities
     , ifNothing
-    , fromBody
+    , fromJsonBody
     , fromProtoBody
     ) where
 
@@ -48,6 +48,7 @@ import Data.Misc (Fingerprint, Rsa)
 import Data.Serialize.Get (runGetLazy)
 import Data.Text (unpack)
 import Galley.Options
+import Galley.API.Error
 import Network.HTTP.Client (responseTimeoutMicro)
 import Network.HTTP.Client.OpenSSL
 import Network.Wai
@@ -62,7 +63,6 @@ import qualified Cassandra                as C
 import qualified Cassandra.Settings       as C
 import qualified Data.List.NonEmpty       as NE
 import qualified Data.ProtocolBuffers     as Proto
-import qualified Data.Text.Lazy           as Lazy
 import qualified Galley.Aws               as Aws
 import qualified Galley.Queue             as Q
 import qualified OpenSSL.X509.SystemStore as Ssl
@@ -202,14 +202,14 @@ reqIdMsg :: RequestId -> Msg -> Msg
 reqIdMsg = ("request" .=) . unRequestId
 {-# INLINE reqIdMsg #-}
 
-fromBody :: FromJSON a => JsonRequest a -> (Lazy.Text -> Error) -> Galley a
-fromBody r f = exceptT (throwM . f) return (parseBody r)
-{-# INLINE fromBody #-}
+fromJsonBody :: FromJSON a => JsonRequest a -> Galley a
+fromJsonBody r = exceptT (throwM . invalidPayload) return (parseBody r)
+{-# INLINE fromJsonBody #-}
 
-fromProtoBody :: Proto.Decode a => Request -> (Lazy.Text -> Error) -> Galley a
-fromProtoBody r f = do
+fromProtoBody :: Proto.Decode a => Request -> Galley a
+fromProtoBody r = do
     b <- readBody r
-    either (throwM . f . fromString) return (runGetLazy Proto.decodeMessage b)
+    either (throwM . invalidPayload . fromString) return (runGetLazy Proto.decodeMessage b)
 {-# INLINE fromProtoBody #-}
 
 ifNothing :: Error -> Maybe a -> Galley a

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -202,7 +202,7 @@ reqIdMsg :: RequestId -> Msg -> Msg
 reqIdMsg = ("request" .=) . unRequestId
 {-# INLINE reqIdMsg #-}
 
-fromBody :: FromJSON a => Request -> (Lazy.Text -> Error) -> Galley a
+fromBody :: FromJSON a => JsonRequest a -> (Lazy.Text -> Error) -> Galley a
 fromBody r f = exceptT (throwM . f) return (parseBody r)
 {-# INLINE fromBody #-}
 

--- a/services/gundeck/src/Gundeck/API.hs
+++ b/services/gundeck/src/Gundeck/API.hs
@@ -66,12 +66,12 @@ sitemap = do
         response 200 "Object containing list of push tokens" end
 
     post "/i/push" (continue Push.push) $
-        jsonRequest @[Push] .&. accept "application" "json"
+        request .&. accept "application" "json"
         -- TODO: REFACTOR: this end-point is probably noise, and should be dropped.  @/i/push/v2@ does exactly
         -- the same thing.
 
     post "/i/push/v2" (continue Push.push) $
-        jsonRequest @[Push] .&. accept "application" "json"
+        request .&. accept "application" "json"
 
     -- Notification API --------------------------------------------------------
 
@@ -137,7 +137,7 @@ sitemap = do
         param "ids" .&. accept "application" "json"
 
     post "/i/presences" (continue Presence.add) $
-        jsonRequest @Presence .&. accept "application" "json"
+        request .&. accept "application" "json"
 
     delete "/i/presences/:uid/devices/:did/cannons/:cannon" (continue Presence.remove) $
         param "uid" .&. param "did" .&. param "cannon"

--- a/services/gundeck/src/Gundeck/API.hs
+++ b/services/gundeck/src/Gundeck/API.hs
@@ -10,6 +10,7 @@ import Data.Text.Encoding (decodeLatin1)
 import Gundeck.API.Error
 import Gundeck.Env
 import Gundeck.Monad
+import Gundeck.Types
 import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Predicate hiding (setStatus)
@@ -32,9 +33,8 @@ sitemap = do
     post "/push/tokens" (continue Push.addToken) $
         header "Z-User"
         .&. header "Z-Connection"
-        .&. request
+        .&. jsonRequest @PushToken
         .&. accept "application" "json"
-        .&. contentType "application" "json"
 
     document "POST" "registerPushToken" $ do
         summary "Register a native push token"
@@ -66,12 +66,12 @@ sitemap = do
         response 200 "Object containing list of push tokens" end
 
     post "/i/push" (continue Push.push) $
-        request .&. accept "application" "json"
+        jsonRequest @[Push] .&. accept "application" "json"
         -- TODO: REFACTOR: this end-point is probably noise, and should be dropped.  @/i/push/v2@ does exactly
         -- the same thing.
 
     post "/i/push/v2" (continue Push.push) $
-        request .&. accept "application" "json"
+        jsonRequest @[Push] .&. accept "application" "json"
 
     -- Notification API --------------------------------------------------------
 
@@ -137,7 +137,7 @@ sitemap = do
         param "ids" .&. accept "application" "json"
 
     post "/i/presences" (continue Presence.add) $
-        request .&. accept "application" "json"
+        jsonRequest @Presence .&. accept "application" "json"
 
     delete "/i/presences/:uid/devices/:did/cannons/:cannon" (continue Presence.remove) $
         param "uid" .&. param "did" .&. param "cannon"

--- a/services/gundeck/src/Gundeck/Monad.hs
+++ b/services/gundeck/src/Gundeck/Monad.hs
@@ -15,7 +15,7 @@ module Gundeck.Monad
     , Gundeck
     , runDirect
     , runGundeck
-    , fromBody
+    , fromJsonBody
     , ifNothing
     , posixTime
     ) where
@@ -33,6 +33,7 @@ import Data.Misc (Milliseconds (..))
 import Gundeck.Env
 import Network.Wai
 import Network.Wai.Utilities
+import Network.HTTP.Types
 import System.Logger.Class hiding (Error, info)
 
 import qualified Database.Redis.IO as Redis
@@ -83,9 +84,9 @@ lookupReqId :: Request -> RequestId
 lookupReqId = maybe def RequestId . lookup requestIdName . requestHeaders
 {-# INLINE lookupReqId #-}
 
-fromBody :: FromJSON a => JsonRequest a -> (LText -> Error) -> Gundeck a
-fromBody r f = exceptT (throwM . f) return (parseBody r)
-{-# INLINE fromBody #-}
+fromJsonBody :: FromJSON a => JsonRequest a -> Gundeck a
+fromJsonBody r = exceptT (throwM . Error status400 "bad-request") return (parseBody r)
+{-# INLINE fromJsonBody #-}
 
 ifNothing :: Error -> Maybe a -> Gundeck a
 ifNothing e = maybe (throwM e) return

--- a/services/gundeck/src/Gundeck/Monad.hs
+++ b/services/gundeck/src/Gundeck/Monad.hs
@@ -83,7 +83,7 @@ lookupReqId :: Request -> RequestId
 lookupReqId = maybe def RequestId . lookup requestIdName . requestHeaders
 {-# INLINE lookupReqId #-}
 
-fromBody :: FromJSON a => Request -> (LText -> Error) -> Gundeck a
+fromBody :: FromJSON a => JsonRequest a -> (LText -> Error) -> Gundeck a
 fromBody r f = exceptT (throwM . f) return (parseBody r)
 {-# INLINE fromBody #-}
 

--- a/services/gundeck/src/Gundeck/Presence.hs
+++ b/services/gundeck/src/Gundeck/Presence.hs
@@ -27,7 +27,7 @@ listAll (uids ::: _) = setStatus status200 . json . concat
 
 add :: JsonRequest Presence ::: JSON -> Gundeck Response
 add (req ::: _) = do
-    p <- fromBody req (Error status400 "bad-request")
+    p <- fromJsonBody req
     Data.add p
     return $ ( setStatus status201
              . addHeader hLocation (toByteString' (resource p))

--- a/services/gundeck/src/Gundeck/Presence.hs
+++ b/services/gundeck/src/Gundeck/Presence.hs
@@ -13,7 +13,7 @@ import Gundeck.Monad
 import Gundeck.Types
 import Gundeck.Util
 import Network.HTTP.Types
-import Network.Wai (Request, Response)
+import Network.Wai (Response)
 import Network.Wai.Utilities
 
 import qualified Gundeck.Presence.Data as Data
@@ -25,7 +25,7 @@ listAll :: List UserId ::: JSON -> Gundeck Response
 listAll (uids ::: _) = setStatus status200 . json . concat
                     <$> Data.listAll (fromList uids)
 
-add :: Request ::: JSON -> Gundeck Response
+add :: JsonRequest Presence ::: JSON -> Gundeck Response
 add (req ::: _) = do
     p <- fromBody req (Error status400 "bad-request")
     Data.add p

--- a/services/gundeck/src/Gundeck/Presence.hs
+++ b/services/gundeck/src/Gundeck/Presence.hs
@@ -13,7 +13,7 @@ import Gundeck.Monad
 import Gundeck.Types
 import Gundeck.Util
 import Network.HTTP.Types
-import Network.Wai (Response)
+import Network.Wai (Request, Response)
 import Network.Wai.Utilities
 
 import qualified Gundeck.Presence.Data as Data
@@ -25,9 +25,9 @@ listAll :: List UserId ::: JSON -> Gundeck Response
 listAll (uids ::: _) = setStatus status200 . json . concat
                     <$> Data.listAll (fromList uids)
 
-add :: JsonRequest Presence ::: JSON -> Gundeck Response
+add :: Request ::: JSON -> Gundeck Response
 add (req ::: _) = do
-    p <- fromJsonBody req
+    p <- fromJsonBody (JsonRequest req)
     Data.add p
     return $ ( setStatus status201
              . addHeader hLocation (toByteString' (resource p))

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -31,7 +31,7 @@ import Gundeck.Options
 import Gundeck.Types
 import Gundeck.Util
 import Network.HTTP.Types
-import Network.Wai (Response)
+import Network.Wai (Request, Response)
 import Network.Wai.Utilities
 import System.Logger.Class (msg, (.=), (~~), val, (+++))
 import UnliftIO.Concurrent (forkIO)
@@ -52,9 +52,9 @@ import qualified Gundeck.Push.Websocket       as Web
 import qualified Gundeck.Types.Presence       as Presence
 import qualified System.Logger.Class          as Log
 
-push :: JsonRequest [Push] ::: JSON -> Gundeck Response
+push :: Request ::: JSON -> Gundeck Response
 push (req ::: _) = do
-    ps   :: [Push] <- fromJsonBody req
+    ps   :: [Push] <- fromJsonBody (JsonRequest req)
     bulk :: Bool   <- view (options . optSettings . setBulkPush)
     rs             <- if bulk
                       then (Right <$> pushAll ps) `catch` (pure . Left . Seq.singleton)

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -54,7 +54,7 @@ import qualified System.Logger.Class          as Log
 
 push :: JsonRequest [Push] ::: JSON -> Gundeck Response
 push (req ::: _) = do
-    ps   :: [Push] <- fromBody req (Error status400 "bad-request")
+    ps   :: [Push] <- fromJsonBody req
     bulk :: Bool   <- view (options . optSettings . setBulkPush)
     rs             <- if bulk
                       then (Right <$> pushAll ps) `catch` (pure . Left . Seq.singleton)
@@ -313,7 +313,7 @@ nativeTargets p pres =
 
 addToken :: UserId ::: ConnId ::: JsonRequest PushToken ::: JSON -> Gundeck Response
 addToken (uid ::: cid ::: req ::: _) = do
-    new <- fromBody req (Error status400 "bad-request")
+    new <- fromJsonBody req
     (cur, old) <- foldl' (matching new) (Nothing, []) <$> Data.lookup uid Data.Quorum
     Log.info $ "user"  .= UUID.toASCIIBytes (toUUID uid)
             ~~ "token" .= Text.take 16 (tokenText (new^.token))

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -31,7 +31,7 @@ import Gundeck.Options
 import Gundeck.Types
 import Gundeck.Util
 import Network.HTTP.Types
-import Network.Wai (Request, Response)
+import Network.Wai (Response)
 import Network.Wai.Utilities
 import System.Logger.Class (msg, (.=), (~~), val, (+++))
 import UnliftIO.Concurrent (forkIO)
@@ -52,7 +52,7 @@ import qualified Gundeck.Push.Websocket       as Web
 import qualified Gundeck.Types.Presence       as Presence
 import qualified System.Logger.Class          as Log
 
-push :: Request ::: JSON -> Gundeck Response
+push :: JsonRequest [Push] ::: JSON -> Gundeck Response
 push (req ::: _) = do
     ps   :: [Push] <- fromBody req (Error status400 "bad-request")
     bulk :: Bool   <- view (options . optSettings . setBulkPush)
@@ -311,7 +311,7 @@ nativeTargets p pres =
     check (Left  e) = mntgtLogErr e >> return []
     check (Right r) = return r
 
-addToken :: UserId ::: ConnId ::: Request ::: JSON ::: JSON -> Gundeck Response
+addToken :: UserId ::: ConnId ::: JsonRequest PushToken ::: JSON -> Gundeck Response
 addToken (uid ::: cid ::: req ::: _) = do
     new <- fromBody req (Error status400 "bad-request")
     (cur, old) <- foldl' (matching new) (Nothing, []) <$> Data.lookup uid Data.Quorum


### PR DESCRIPTION
Figuring out "which request body type does this handler take" is a constant annoyance for me. Should be easier with this change.

If you think it's worth it, I'll migrate the rest.