### PR TITLE
Refactor Galley Tests to use Reader Pattern

### DIFF
--- a/libs/bilge/src/Bilge/IO.hs
+++ b/libs/bilge/src/Bilge/IO.hs
@@ -82,8 +82,11 @@ newtype HttpT m a = HttpT
 class MonadHttp m where
     getManager :: m Manager
 
-instance Monad m => MonadHttp (HttpT m) where
+instance {-# OVERLAPPING #-} Monad m => MonadHttp (HttpT m) where
     getManager = HttpT ask
+
+instance {-# OVERLAPPABLE #-} (MonadTrans t, MonadHttp m, Monad m) => MonadHttp (t m) where
+  getManager = lift getManager
 
 instance MonadBase IO (HttpT IO) where
     liftBase = liftIO

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -97,20 +97,20 @@ tests s = testGroup "Galley integration tests"
 
 status :: TestM ()
 status = do
-    g <- view galley
+    g <- view tsGalley
     get (g . path "/i/status") !!!
       const 200 === statusCode
 
 monitor :: TestM ()
 monitor = do
-    g <- view galley
+    g <- view tsGalley
     get (g . path "/i/monitoring") !!! do
         const 200 === statusCode
         const (Just "application/json") =~= getHeader "Content-Type"
 
 postConvOk :: TestM ()
 postConvOk = do
-    c <- view cannon
+    c <- view tsCannon
     alice <- randomUser
     bob   <- randomUser
     jane  <- randomUser
@@ -139,7 +139,7 @@ postConvOk = do
 
 postCryptoMessage1 :: TestM ()
 postCryptoMessage1 = do
-    c <- view cannon
+    c <- view tsCannon
     (alice, ac) <- randomUserWithClient (someLastPrekeys !! 0)
     (bob,   bc) <- randomUserWithClient (someLastPrekeys !! 1)
     (eve,   ec) <- randomUserWithClient (someLastPrekeys !! 2)
@@ -226,7 +226,7 @@ postCryptoMessage1 = do
 
 postCryptoMessage2 :: TestM ()
 postCryptoMessage2 = do
-    b <- view brig
+    b <- view tsBrig
     (alice, ac) <- randomUserWithClient (someLastPrekeys !! 0)
     (bob,   bc) <- randomUserWithClient (someLastPrekeys !! 1)
     (eve,   ec) <- randomUserWithClient (someLastPrekeys !! 2)
@@ -248,7 +248,7 @@ postCryptoMessage2 = do
 
 postCryptoMessage3 :: TestM ()
 postCryptoMessage3 = do
-    b <- view brig
+    b <- view tsBrig
     (alice, ac) <- randomUserWithClient (someLastPrekeys !! 0)
     (bob,   bc) <- randomUserWithClient (someLastPrekeys !! 1)
     (eve,   ec) <- randomUserWithClient (someLastPrekeys !! 2)
@@ -325,7 +325,7 @@ postCryptoMessage5 = do
 
 postJoinConvOk :: TestM ()
 postJoinConvOk = do
-    c <- view cannon
+    c <- view tsCannon
     alice <- randomUser
     bob   <- randomUser
     conv  <- decodeConvId <$> postConv alice [] (Just "gossip") [InviteAccess, LinkAccess] Nothing Nothing
@@ -337,7 +337,7 @@ postJoinConvOk = do
 
 postJoinCodeConvOk :: TestM ()
 postJoinCodeConvOk = do
-    c <- view cannon
+    c <- view tsCannon
     alice <- randomUser
     bob   <- randomUser
     eve   <- ephemeralUser
@@ -374,7 +374,7 @@ postJoinCodeConvOk = do
 
 postConvertCodeConv :: TestM ()
 postConvertCodeConv = do
-    c <- view cannon
+    c <- view tsCannon
     alice <- randomUser
     conv  <- decodeConvId <$> postConv alice [] (Just "gossip") [InviteAccess] Nothing Nothing
     -- Cannot do code operations if conversation not in code access
@@ -412,7 +412,7 @@ postConvertCodeConv = do
 
 postConvertTeamConv :: TestM ()
 postConvertTeamConv = do
-    c <- view cannon
+    c <- view tsCannon
     -- Create a team conversation with team-alice, team-bob, activated-eve
     -- Non-activated mallory can join
     alice <- randomUser
@@ -577,7 +577,7 @@ postConvFailNotConnected = do
 
 postConvFailNumMembers :: TestM ()
 postConvFailNumMembers = do
-    n <- fromIntegral <$> view maxConvSize
+    n <- fromIntegral <$> view tsMaxConvSize
     alice <- randomUser
     bob:others <- replicateM n (randomUser)
     connectUsers alice (list1 bob others)
@@ -621,7 +621,7 @@ postO2OConvOk = do
 
 postConvO2OFailWithSelf :: TestM ()
 postConvO2OFailWithSelf = do
-    g <- view galley
+    g <- view tsGalley
     alice <- randomUser
     let inv = NewConvUnmanaged (NewConv [alice] Nothing mempty Nothing Nothing Nothing Nothing)
     post (g . path "/conversations/one2one" . zUser alice . zConn "conn" . zType "access" . json inv) !!! do
@@ -741,14 +741,14 @@ postRepeatConnectConvCancel = do
         privateAccess   @=? cnvAccess cnv4
   where
     cancel u c = do
-        g <- view galley
+        g <- view tsGalley
         put (g . paths ["/i/conversations", toByteString' (cnvId c), "block"] . zUser u) !!!
             const 200 === statusCode
         getConv u (cnvId c) !!! const 404 === statusCode
 
 putBlockConvOk :: TestM ()
 putBlockConvOk = do
-    g <- view galley
+    g <- view tsGalley
     alice <- randomUser
     bob   <- randomUser
     conv  <- decodeBody' "conversation" <$> postConnectConv alice bob "Alice" "connect with me!" (Just "me@me.com")
@@ -797,7 +797,7 @@ getConvOk = do
 
 accessConvMeta :: TestM ()
 accessConvMeta = do
-    g <- view galley
+    g <- view tsGalley
     alice <- randomUser
     bob   <- randomUser
     chuck <- randomUser
@@ -887,7 +887,7 @@ postMembersFail = do
 
 postTooManyMembersFail :: TestM ()
 postTooManyMembersFail = do
-    n <- fromIntegral <$> view maxConvSize
+    n <- fromIntegral <$> view tsMaxConvSize
     alice <- randomUser
     bob   <- randomUser
     chuck <- randomUser
@@ -928,8 +928,8 @@ deleteMembersFailO2O = do
 
 putConvRenameOk :: TestM ()
 putConvRenameOk = do
-    g <- view galley
-    c <- view cannon
+    g <- view tsGalley
+    c <- view tsCannon
     alice <- randomUser
     bob   <- randomUser
     connectUsers alice (singleton bob)
@@ -980,7 +980,7 @@ putMemberAllOk = putMemberOk
 
 putMemberOk :: MemberUpdate ->  TestM ()
 putMemberOk update = do
-    c <- view cannon
+    c <- view tsCannon
     alice <- randomUser
     bob   <- randomUser
     connectUsers alice (singleton bob)
@@ -1035,8 +1035,8 @@ putMemberOk update = do
 
 putReceiptModeOk :: TestM ()
 putReceiptModeOk = do
-    g <- view galley
-    c <- view cannon
+    g <- view tsGalley
+    c <- view tsCannon
     alice <- randomUser
     bob   <- randomUser
     jane  <- randomUser
@@ -1098,7 +1098,7 @@ putReceiptModeOk = do
 
 postTypingIndicators :: TestM ()
 postTypingIndicators = do
-    g <- view galley
+    g <- view tsGalley
     alice <- randomUser
     bob   <- randomUser
     connectUsers alice (singleton bob)
@@ -1122,7 +1122,7 @@ postTypingIndicators = do
 
 removeUser :: TestM ()
 removeUser = do
-    c <- view cannon
+    c <- view tsCannon
     alice <- randomUser
     bob   <- randomUser
     carl  <- randomUser

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -105,7 +105,7 @@ messageTimerChangeO2O = do
 
 messageTimerEvent :: TestM ()
 messageTimerEvent = do
-    ca <- view cannon
+    ca <- view tsCannon
     -- Create a conversation
     [alice, bob] <- randomUsers 2
     connectUsers alice (singleton bob)

--- a/services/galley/test/integration/API/SQS.hs
+++ b/services/galley/test/integration/API/SQS.hs
@@ -44,19 +44,19 @@ ensureQueueEmptyIO Nothing    = return ()
 
 assertQueue :: String -> (String -> Maybe E.TeamEvent -> IO ()) -> TestM ()
 assertQueue label check = view TS.awsEnv >>= \case
-  Just env -> liftIO $ Aws.execute env $ fetchMessage label check
-  Nothing -> return ()
+    Just env -> liftIO $ Aws.execute env $ fetchMessage label check
+    Nothing -> return ()
 
 -- Try to assert an event in the queue for a `timeout` amount of seconds
 tryAssertQueue :: Int -> String -> (String -> Maybe E.TeamEvent -> IO ()) -> TestM ()
 tryAssertQueue timeout label check = view TS.awsEnv >>= \case
-  Just env -> liftIO $ Aws.execute env $ awaitMessage label timeout check
-  Nothing -> return ()
+    Just env -> liftIO $ Aws.execute env $ awaitMessage label timeout check
+    Nothing -> return ()
 
 assertQueueEmpty :: (HasCallStack) => TestM ()
 assertQueueEmpty = view TS.awsEnv >>= \case
-  Just env -> liftIO $ Aws.execute env ensureNoMessages
-  Nothing -> return ()
+    Just env -> liftIO $ Aws.execute env ensureNoMessages
+    Nothing -> return ()
 
 tActivateWithCurrency :: HasCallStack => Maybe Currency.Alpha -> String -> Maybe E.TeamEvent -> IO ()
 tActivateWithCurrency c l (Just e) = do

--- a/services/galley/test/integration/API/SQS.hs
+++ b/services/galley/test/integration/API/SQS.hs
@@ -36,9 +36,11 @@ import qualified OpenSSL.X509.SystemStore as Ssl
 import qualified System.Logger as L
 
 ensureQueueEmpty :: TestM ()
-ensureQueueEmpty  = view TS.awsEnv >>= \case
-  Just env -> liftIO $ Aws.execute env purgeQueue
-  Nothing -> return ()
+ensureQueueEmpty  = view TS.awsEnv >>= ensureQueueEmptyIO
+
+ensureQueueEmptyIO :: MonadIO m => Maybe Aws.Env -> m ()
+ensureQueueEmptyIO (Just env) = liftIO $ Aws.execute env purgeQueue
+ensureQueueEmptyIO Nothing    = return ()
 
 assertQueue :: String -> (String -> Maybe E.TeamEvent -> IO ()) -> TestM ()
 assertQueue label check = view TS.awsEnv >>= \case

--- a/services/galley/test/integration/API/SQS.hs
+++ b/services/galley/test/integration/API/SQS.hs
@@ -22,8 +22,7 @@ import Proto.TeamEvents as E
 import Proto.TeamEvents_Fields as E
 import System.Logger.Class
 import Test.Tasty.HUnit
-import TestSetup hiding (awsEnv)
-import TestSetup as TS (awsEnv)
+import TestSetup
 
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.Currency as Currency
@@ -36,25 +35,25 @@ import qualified OpenSSL.X509.SystemStore as Ssl
 import qualified System.Logger as L
 
 ensureQueueEmpty :: TestM ()
-ensureQueueEmpty  = view TS.awsEnv >>= ensureQueueEmptyIO
+ensureQueueEmpty  = view tsAwsEnv >>= ensureQueueEmptyIO
 
 ensureQueueEmptyIO :: MonadIO m => Maybe Aws.Env -> m ()
 ensureQueueEmptyIO (Just env) = liftIO $ Aws.execute env purgeQueue
 ensureQueueEmptyIO Nothing    = return ()
 
 assertQueue :: String -> (String -> Maybe E.TeamEvent -> IO ()) -> TestM ()
-assertQueue label check = view TS.awsEnv >>= \case
+assertQueue label check = view tsAwsEnv >>= \case
     Just env -> liftIO $ Aws.execute env $ fetchMessage label check
     Nothing -> return ()
 
 -- Try to assert an event in the queue for a `timeout` amount of seconds
 tryAssertQueue :: Int -> String -> (String -> Maybe E.TeamEvent -> IO ()) -> TestM ()
-tryAssertQueue timeout label check = view TS.awsEnv >>= \case
+tryAssertQueue timeout label check = view tsAwsEnv >>= \case
     Just env -> liftIO $ Aws.execute env $ awaitMessage label timeout check
     Nothing -> return ()
 
 assertQueueEmpty :: (HasCallStack) => TestM ()
-assertQueueEmpty = view TS.awsEnv >>= \case
+assertQueueEmpty = view tsAwsEnv >>= \case
     Just env -> liftIO $ Aws.execute env ensureNoMessages
     Nothing -> return ()
 

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -19,7 +19,7 @@ import Gundeck.Types.Notification
 import Test.Tasty
 import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import Test.Tasty.HUnit
-import TestSetup (test,  TestSetup,  ResponseLBS, TestM)
+import TestSetup (test,  TestSetup,  ResponseLBS, TestM, cannon, galley)
 import API.SQS
 import UnliftIO (mapConcurrently, mapConcurrently_)
 
@@ -74,11 +74,12 @@ timeout = 3 # Second
 
 testCreateTeam :: TestM ()
 testCreateTeam = do
-    owner <- Util.randomUser b
+    c <- view cannon
+    owner <- Util.randomUser
     WS.bracketR c owner $ \wsOwner -> do
-        tid   <- Util.createTeam g "foo" owner []
-        team  <- Util.getTeam g owner tid
-        assertQueueEmpty a
+        tid   <- Util.createTeam "foo" owner []
+        team  <- Util.getTeam owner tid
+        assertQueueEmpty
         liftIO $ do
             assertEqual "owner" owner (team^.teamCreator)
             eventChecks <- WS.awaitMatch timeout wsOwner $ \notif -> do
@@ -91,44 +92,46 @@ testCreateTeam = do
 
 testCreateMulitpleBindingTeams :: TestM ()
 testCreateMulitpleBindingTeams = do
-    owner <- Util.randomUser b
-    _     <- Util.createTeamInternal g "foo" owner
-    assertQueue "create team" a tActivate
+    g <- view galley
+    owner <- Util.randomUser
+    _     <- Util.createTeamInternal "foo" owner
+    assertQueue "create team" tActivate
     -- Cannot create more teams if bound (used internal API)
     let nt = NonBindingNewTeam $ newNewTeam (unsafeRange "owner") (unsafeRange "icon")
     post (g . path "/teams" . zUser owner . zConn "conn" . json nt) !!!
         const 403 === statusCode
 
     -- If never used the internal API, can create multiple teams
-    owner' <- Util.randomUser b
-    void $ Util.createTeam g "foo" owner' []
-    void $ Util.createTeam g "foo" owner' []
+    owner' <- Util.randomUser
+    void $ Util.createTeam "foo" owner' []
+    void $ Util.createTeam "foo" owner' []
 
 testCreateBindingTeamWithCurrency :: TestM ()
 testCreateBindingTeamWithCurrency = do
-    _owner <- Util.randomUser b
-    _      <- Util.createTeamInternal g "foo" _owner
+    _owner <- Util.randomUser
+    _      <- Util.createTeamInternal "foo" _owner
     -- Backwards compatible
-    assertQueue "create team" a (tActivateWithCurrency Nothing)
+    assertQueue "create team" (tActivateWithCurrency Nothing)
 
     -- Ensure currency is properly journaled
-    _owner <- Util.randomUser b
-    _      <- Util.createTeamInternalWithCurrency g "foo" _owner Currency.USD
-    assertQueue "create team" a (tActivateWithCurrency $ Just Currency.USD)
+    _owner <- Util.randomUser
+    _      <- Util.createTeamInternalWithCurrency "foo" _owner Currency.USD
+    assertQueue "create team" (tActivateWithCurrency $ Just Currency.USD)
 
 testCreateTeamWithMembers :: TestM ()
 testCreateTeamWithMembers = do
-    owner <- Util.randomUser b
-    user1 <- Util.randomUser b
-    user2 <- Util.randomUser b
+    c <- view cannon
+    owner <- Util.randomUser
+    user1 <- Util.randomUser
+    user2 <- Util.randomUser
     let pp = Util.symmPermissions [CreateConversation, AddRemoveConvMember]
     let m1 = newTeamMember' pp user1
     let m2 = newTeamMember' pp user2
     Util.connectUsers owner (list1 user1 [user2])
     WS.bracketR3 c owner user1 user2 $ \(wsOwner, wsUser1, wsUser2) -> do
-        tid  <- Util.createTeam g "foo" owner [m1, m2]
-        team <- Util.getTeam g owner tid
-        mem  <- Util.getTeamMembers g owner tid
+        tid  <- Util.createTeam "foo" owner [m1, m2]
+        team <- Util.getTeam owner tid
+        mem  <- Util.getTeamMembers owner tid
         liftIO $ do
             assertEqual "members"
                 (Set.fromList [newTeamMember' fullPermissions owner, m1, m2])
@@ -144,25 +147,25 @@ testCreateTeamWithMembers = do
 
 testCreateOne2OneFailNonBindingTeamMembers :: TestM ()
 testCreateOne2OneFailNonBindingTeamMembers = do
-    owner <- Util.randomUser b
+    owner <- Util.randomUser
     let p1 = Util.symmPermissions [CreateConversation, AddRemoveConvMember]
     let p2 = Util.symmPermissions [CreateConversation, AddRemoveConvMember, AddTeamMember]
-    mem1 <- newTeamMember' p1 <$> Util.randomUser b
-    mem2 <- newTeamMember' p2 <$> Util.randomUser b
+    mem1 <- newTeamMember' p1 <$> Util.randomUser
+    mem2 <- newTeamMember' p2 <$> Util.randomUser
     Util.connectUsers owner (list1 (mem1^.userId) [mem2^.userId])
-    tid <- Util.createTeam g "foo" owner [mem1, mem2]
+    tid <- Util.createTeam "foo" owner [mem1, mem2]
     -- Cannot create a 1-1 conversation, not connected and in the same team but not binding
-    Util.createOne2OneTeamConv g (mem1^.userId) (mem2^.userId) Nothing tid !!! do
+    Util.createOne2OneTeamConv (mem1^.userId) (mem2^.userId) Nothing tid !!! do
         const 404 === statusCode
         const "non-binding-team" === (Error.label . Util.decodeBody' "error label")
     -- Both have a binding team but not the same team
-    owner1 <- Util.randomUser b
-    tid1 <- Util.createTeamInternal g "foo" owner1
-    assertQueue "create team" a tActivate
-    owner2 <- Util.randomUser b
-    void $ Util.createTeamInternal g "foo" owner2
-    assertQueue "create another team" a tActivate
-    Util.createOne2OneTeamConv g owner1 owner2 Nothing tid1 !!! do
+    owner1 <- Util.randomUser
+    tid1 <- Util.createTeamInternal "foo" owner1
+    assertQueue "create team" tActivate
+    owner2 <- Util.randomUser
+    void $ Util.createTeamInternal "foo" owner2
+    assertQueue "create another team" tActivate
+    Util.createOne2OneTeamConv owner1 owner2 Nothing tid1 !!! do
         const 403 === statusCode
         const "non-binding-team-members" === (Error.label . Util.decodeBody' "error label")
 
@@ -171,36 +174,39 @@ testCreateOne2OneWithMembers
     => Role  -- ^ Role of the user who creates the conversation
     -> TestM ()
 testCreateOne2OneWithMembers (rolePermissions -> perms) = do
-    owner <- Util.randomUser b
-    tid   <- Util.createTeamInternal g "foo" owner
-    assertQueue "create team" a tActivate
-    mem1 <- newTeamMember' perms <$> Util.randomUser b
+    c <- view cannon
+    owner <- Util.randomUser
+    tid   <- Util.createTeamInternal "foo" owner
+    assertQueue "create team" tActivate
+    mem1 <- newTeamMember' perms <$> Util.randomUser
 
     WS.bracketR c (mem1^.userId) $ \wsMem1 -> do
-        Util.addTeamMemberInternal g tid mem1
+        Util.addTeamMemberInternal tid mem1
         checkTeamMemberJoin tid (mem1^.userId) wsMem1
-        assertQueue "team member join" a $ tUpdate 2 [owner]
+        assertQueue "team member join" $ tUpdate 2 [owner]
 
-    void $ retryWhileN 10 repeatIf (Util.createOne2OneTeamConv g owner (mem1^.userId) Nothing tid)
+    void $ retryWhileN 10 repeatIf (Util.createOne2OneTeamConv owner (mem1^.userId) Nothing tid)
 
     -- Recreating a One2One is a no-op, returns a 200
-    Util.createOne2OneTeamConv g owner (mem1^.userId) Nothing tid !!! const 200 === statusCode
+    Util.createOne2OneTeamConv owner (mem1^.userId) Nothing tid !!! const 200 === statusCode
   where
     repeatIf :: ResponseLBS -> Bool
     repeatIf r = statusCode r /= 201
 
 testAddTeamMember :: TestM ()
 testAddTeamMember = do
-    owner <- Util.randomUser b
+    c <- view cannon
+    g <- view galley
+    owner <- Util.randomUser
     let p1 = Util.symmPermissions [CreateConversation, AddRemoveConvMember]
     let p2 = Util.symmPermissions [CreateConversation, AddRemoveConvMember, AddTeamMember]
-    mem1 <- newTeamMember' p1 <$> Util.randomUser b
-    mem2 <- newTeamMember' p2 <$> Util.randomUser b
+    mem1 <- newTeamMember' p1 <$> Util.randomUser
+    mem2 <- newTeamMember' p2 <$> Util.randomUser
     Util.connectUsers owner (list1 (mem1^.userId) [mem2^.userId])
     Util.connectUsers (mem1^.userId) (list1 (mem2^.userId) [])
-    tid <- Util.createTeam g "foo" owner [mem1, mem2]
+    tid <- Util.createTeam "foo" owner [mem1, mem2]
 
-    mem3 <- newTeamMember' p1 <$> Util.randomUser b
+    mem3 <- newTeamMember' p1 <$> Util.randomUser
     let payload = json (newNewTeamMember mem3)
     Util.connectUsers (mem1^.userId) (list1 (mem3^.userId) [])
     Util.connectUsers (mem2^.userId) (list1 (mem3^.userId) [])
@@ -211,22 +217,23 @@ testAddTeamMember = do
 
     WS.bracketRN c [owner, (mem1^.userId), (mem2^.userId), (mem3^.userId)] $ \[wsOwner, wsMem1, wsMem2, wsMem3] -> do
         -- `mem2` has `AddTeamMember` permission
-        Util.addTeamMember g (mem2^.userId) tid mem3
+        Util.addTeamMember (mem2^.userId) tid mem3
         mapConcurrently_ (checkTeamMemberJoin tid (mem3^.userId)) [wsOwner, wsMem1, wsMem2, wsMem3]
 
 testAddTeamMemberCheckBound :: TestM ()
 testAddTeamMemberCheckBound = do
-    ownerBound <- Util.randomUser b
-    tidBound   <- Util.createTeamInternal g "foo" ownerBound
-    assertQueue "create team" a tActivate
+    g <- view galley
+    ownerBound <- Util.randomUser
+    tidBound   <- Util.createTeamInternal "foo" ownerBound
+    assertQueue "create team" tActivate
 
-    rndMem <- newTeamMember' (Util.symmPermissions []) <$> Util.randomUser b
+    rndMem <- newTeamMember' (Util.symmPermissions []) <$> Util.randomUser
     -- Cannot add any users to bound teams
     post (g . paths ["teams", toByteString' tidBound, "members"] . zUser ownerBound . zConn "conn" . json (newNewTeamMember rndMem)) !!!
         const 403 === statusCode
 
-    owner <- Util.randomUser b
-    tid   <- Util.createTeam g "foo" owner []
+    owner <- Util.randomUser
+    tid   <- Util.createTeam "foo" owner []
     -- Cannot add bound users to any teams
     let boundMem = newTeamMember' (Util.symmPermissions []) ownerBound
     post (g . paths ["teams", toByteString' tid, "members"] . zUser owner . zConn "conn" . json (newNewTeamMember boundMem)) !!!
@@ -234,16 +241,17 @@ testAddTeamMemberCheckBound = do
 
 testAddTeamMemberInternal :: TestM ()
 testAddTeamMemberInternal = do
-    owner <- Util.randomUser b
-    tid <- Util.createTeam g "foo" owner []
+    c <- view cannon
+    owner <- Util.randomUser
+    tid <- Util.createTeam "foo" owner []
     let p1 = Util.symmPermissions [GetBilling] -- permissions are irrelevant on internal endpoint
-    mem1 <- newTeamMember' p1 <$> Util.randomUser b
+    mem1 <- newTeamMember' p1 <$> Util.randomUser
 
     WS.bracketRN c [owner, mem1^.userId] $ \[wsOwner, wsMem1] -> do
-        Util.addTeamMemberInternal g tid mem1
+        Util.addTeamMemberInternal tid mem1
         liftIO . void $ mapConcurrently (checkJoinEvent tid (mem1^.userId)) [wsOwner, wsMem1]
-        assertQueue "tem member join" a $ tUpdate 2 [owner]
-    void $ Util.getTeamMemberInternal g tid (mem1^.userId)
+        assertQueue "tem member join" $ tUpdate 2 [owner]
+    void $ Util.getTeamMemberInternal tid (mem1^.userId)
   where
     checkJoinEvent tid usr w = WS.assertMatch_ timeout w $ \notif -> do
         ntfTransient notif @?= False
@@ -254,25 +262,27 @@ testAddTeamMemberInternal = do
 
 testRemoveTeamMember :: TestM ()
 testRemoveTeamMember = do
-    owner <- Util.randomUser b
+    c <- view cannon
+    g <- view galley
+    owner <- Util.randomUser
     let p1 = Util.symmPermissions [AddRemoveConvMember]
     let p2 = Util.symmPermissions [AddRemoveConvMember, RemoveTeamMember]
-    mem1 <- newTeamMember' p1 <$> Util.randomUser b
-    mem2 <- newTeamMember' p2 <$> Util.randomUser b
-    mext1 <- Util.randomUser b
-    mext2 <- Util.randomUser b
-    mext3 <- Util.randomUser b
+    mem1 <- newTeamMember' p1 <$> Util.randomUser
+    mem2 <- newTeamMember' p2 <$> Util.randomUser
+    mext1 <- Util.randomUser
+    mext2 <- Util.randomUser
+    mext3 <- Util.randomUser
     Util.connectUsers owner (list1 (mem1^.userId) [mem2^.userId, mext1, mext2, mext3])
-    tid <- Util.createTeam g "foo" owner [mem1, mem2]
+    tid <- Util.createTeam "foo" owner [mem1, mem2]
 
     -- Managed conversation:
-    void $ Util.createManagedConv g owner tid [] (Just "gossip") Nothing Nothing
+    void $ Util.createManagedConv owner tid [] (Just "gossip") Nothing Nothing
     -- Regular conversation:
-    cid2 <- Util.createTeamConv g owner tid [mem1^.userId, mem2^.userId, mext1] (Just "blaa") Nothing Nothing
+    cid2 <- Util.createTeamConv owner tid [mem1^.userId, mem2^.userId, mext1] (Just "blaa") Nothing Nothing
     -- Member external 2 is a guest and not a part of any conversation that mem1 is a part of
-    void $ Util.createTeamConv g owner tid [mem2^.userId, mext2] (Just "blaa") Nothing Nothing
+    void $ Util.createTeamConv owner tid [mem2^.userId, mext2] (Just "blaa") Nothing Nothing
     -- Member external 3 is a guest and part of a conversation that mem1 is a part of
-    cid3 <- Util.createTeamConv g owner tid [mem1^.userId, mext3] (Just "blaa") Nothing Nothing
+    cid3 <- Util.createTeamConv owner tid [mem1^.userId, mext3] (Just "blaa") Nothing Nothing
 
     WS.bracketRN c [owner, mem1^.userId, mem2^.userId, mext1, mext2, mext3] $ \ws@[wsOwner, wsMem1, wsMem2, wsMext1, _wsMext2, wsMext3] -> do
         -- `mem1` lacks permission to remove team members
@@ -299,16 +309,18 @@ testRemoveTeamMember = do
 
 testRemoveBindingTeamMember :: Bool -> TestM ()
 testRemoveBindingTeamMember ownerHasPassword = do
-    owner <- Util.randomUser' ownerHasPassword b
-    tid   <- Util.createTeamInternal g "foo" owner
-    assertQueue "create team" a tActivate
-    mext  <- Util.randomUser b
+    g <- view galley
+    c <- view cannon
+    owner <- Util.randomUser' ownerHasPassword
+    tid   <- Util.createTeamInternal "foo" owner
+    assertQueue "create team" tActivate
+    mext  <- Util.randomUser
     let p1 = Util.symmPermissions [AddRemoveConvMember]
-    mem1 <- newTeamMember' p1 <$> Util.randomUser b
-    Util.addTeamMemberInternal g tid mem1
-    assertQueue "team member join" a $ tUpdate 2 [owner]
+    mem1 <- newTeamMember' p1 <$> Util.randomUser
+    Util.addTeamMemberInternal tid mem1
+    assertQueue "team member join" $ tUpdate 2 [owner]
     Util.connectUsers owner (singleton mext)
-    cid1 <- Util.createTeamConv g owner tid [(mem1^.userId), mext] (Just "blaa") Nothing Nothing
+    cid1 <- Util.createTeamConv owner tid [(mem1^.userId), mext] (Just "blaa") Nothing Nothing
 
     when ownerHasPassword $ do
         -- Deleting from a binding team with empty body is invalid
@@ -362,52 +374,53 @@ testRemoveBindingTeamMember ownerHasPassword = do
         checkTeamMemberLeave tid (mem1^.userId) wsOwner
         checkConvMemberLeaveEvent cid1 (mem1^.userId) wsMext
 
-        assertQueue "team member leave" a $ tUpdate 1 [owner]
+        assertQueue "team member leave" $ tUpdate 1 [owner]
         WS.assertNoEvent timeout [wsMext]
         -- Mem1 is now gone from Wire
         Util.ensureDeletedState True owner (mem1^.userId)
 
 testAddTeamConv :: TestM ()
 testAddTeamConv = do
-    owner  <- Util.randomUser b
-    extern <- Util.randomUser b
+    c <- view cannon
+    owner  <- Util.randomUser
+    extern <- Util.randomUser
 
     let p = Util.symmPermissions [CreateConversation, AddRemoveConvMember]
-    mem1 <- newTeamMember' p <$> Util.randomUser b
-    mem2 <- newTeamMember' p <$> Util.randomUser b
+    mem1 <- newTeamMember' p <$> Util.randomUser
+    mem2 <- newTeamMember' p <$> Util.randomUser
 
     Util.connectUsers owner (list1 (mem1^.userId) [extern, mem2^.userId])
-    tid <- Util.createTeam g "foo" owner [mem2]
+    tid <- Util.createTeam "foo" owner [mem2]
 
     WS.bracketRN c [owner, extern, mem1^.userId, mem2^.userId]  $ \ws@[wsOwner, wsExtern, wsMem1, wsMem2] -> do
         -- Managed conversation:
-        cid1 <- Util.createManagedConv g owner tid [] (Just "gossip") Nothing Nothing
+        cid1 <- Util.createManagedConv owner tid [] (Just "gossip") Nothing Nothing
         checkConvCreateEvent cid1 wsOwner
         checkConvCreateEvent cid1 wsMem2
 
         -- Regular conversation:
-        cid2 <- Util.createTeamConv g owner tid [extern] (Just "blaa") Nothing Nothing
+        cid2 <- Util.createTeamConv owner tid [extern] (Just "blaa") Nothing Nothing
         checkConvCreateEvent cid2 wsOwner
         checkConvCreateEvent cid2 wsExtern
         -- mem2 is not a conversation member but still receives an event that
         -- a new team conversation has been created:
         checkTeamConvCreateEvent tid cid2 wsMem2
 
-        Util.addTeamMember g owner tid mem1
+        Util.addTeamMember owner tid mem1
 
         checkTeamMemberJoin tid (mem1^.userId) wsOwner
         checkTeamMemberJoin tid (mem1^.userId) wsMem1
         checkTeamMemberJoin tid (mem1^.userId) wsMem2
 
         -- New team members are added automatically to managed conversations ...
-        Util.assertConvMember g (mem1^.userId) cid1
+        Util.assertConvMember (mem1^.userId) cid1
         -- ... but not to regular ones.
-        Util.assertNotConvMember g (mem1^.userId) cid2
+        Util.assertNotConvMember (mem1^.userId) cid2
 
         -- Managed team conversations get all team members added implicitly.
-        cid3 <- Util.createManagedConv g owner tid [] (Just "blup") Nothing Nothing
+        cid3 <- Util.createManagedConv owner tid [] (Just "blup") Nothing Nothing
         for_ [owner, mem1^.userId, mem2^.userId] $ \u ->
-            Util.assertConvMember g u cid3
+            Util.assertConvMember u cid3
 
         checkConvCreateEvent cid3 wsOwner
         checkConvCreateEvent cid3 wsMem1
@@ -415,25 +428,25 @@ testAddTeamConv = do
 
         -- Non team members are never added implicitly.
         for_ [cid1, cid3] $
-            Util.assertNotConvMember g extern
+            Util.assertNotConvMember extern
 
         WS.assertNoEvent timeout ws
 
 testAddTeamConvAsExternalPartner :: TestM ()
 testAddTeamConvAsExternalPartner = do
-    owner <- Util.randomUser b
-    memMember1 <- newTeamMember' (rolePermissions RoleMember) <$> Util.randomUser b
-    memMember2 <- newTeamMember' (rolePermissions RoleMember) <$> Util.randomUser b
-    memExternalPartner <- newTeamMember' (rolePermissions RoleExternalPartner) <$> Util.randomUser b
+    owner <- Util.randomUser
+    memMember1 <- newTeamMember' (rolePermissions RoleMember) <$> Util.randomUser
+    memMember2 <- newTeamMember' (rolePermissions RoleMember) <$> Util.randomUser
+    memExternalPartner <- newTeamMember' (rolePermissions RoleExternalPartner) <$> Util.randomUser
     Util.connectUsers owner
         (list1 (memMember1^.userId) [memExternalPartner^.userId, memMember2^.userId])
-    tid <- Util.createTeamInternal g "foo" owner
-    assertQueue "create team" a tActivate
+    tid <- Util.createTeamInternal "foo" owner
+    assertQueue "create team" tActivate
     forM_ [(2, memMember1), (3, memMember2), (4, memExternalPartner)] $ \(i, mem) -> do
-        Util.addTeamMemberInternal g tid mem
-        assertQueue ("team member join #" ++ show i) a $ tUpdate i [owner]
+        Util.addTeamMemberInternal tid mem
+        assertQueue ("team member join #" ++ show i) $ tUpdate i [owner]
     let acc = Just $ Set.fromList [InviteAccess, CodeAccess]
-    Util.createTeamConvAccessRaw g
+    Util.createTeamConvAccessRaw
         (memExternalPartner^.userId)
         tid
         [memMember1^.userId, memMember2^.userId]
@@ -443,9 +456,10 @@ testAddTeamConvAsExternalPartner = do
         const "operation-denied" === (Error.label . Util.decodeBody' "error label")
 
 testAddManagedConv :: TestM ()
-testAddManagedConv _ = do
-    owner <- Util.randomUser b
-    tid <- Util.createTeam g "foo" owner []
+testAddManagedConv = do
+    g <- view galley
+    owner <- Util.randomUser
+    tid <- Util.createTeam "foo" owner []
     let tinfo = ConvTeamInfo tid True
     let conv = NewConvManaged $
                NewConv [owner] (Just "blah") (Set.fromList []) Nothing (Just tinfo) Nothing Nothing
@@ -460,43 +474,43 @@ testAddManagedConv _ = do
 
 testAddTeamConvWithUsers :: TestM ()
 testAddTeamConvWithUsers = do
-    owner  <- Util.randomUser b
-    extern <- Util.randomUser b
+    owner  <- Util.randomUser
+    extern <- Util.randomUser
     Util.connectUsers owner (list1 extern [])
-    tid <- Util.createTeam g "foo" owner []
+    tid <- Util.createTeam "foo" owner []
     -- Create managed team conversation and erroneously specify external users.
-    cid <- Util.createManagedConv g owner tid [extern] (Just "gossip") Nothing Nothing
+    cid <- Util.createManagedConv owner tid [extern] (Just "gossip") Nothing Nothing
     -- External users have been ignored.
-    Util.assertNotConvMember g extern cid
+    Util.assertNotConvMember extern cid
     -- Team members are present.
-    Util.assertConvMember g owner cid
+    Util.assertConvMember owner cid
 
 testAddTeamMemberToConv :: TestM ()
 testAddTeamMemberToConv = do
-    owner <- Util.randomUser b
+    owner <- Util.randomUser
     let p = Util.symmPermissions [AddRemoveConvMember]
-    mem1 <- newTeamMember' p <$> Util.randomUser b
-    mem2 <- newTeamMember' p <$> Util.randomUser b
-    mem3 <- newTeamMember' (Util.symmPermissions []) <$> Util.randomUser b
+    mem1 <- newTeamMember' p <$> Util.randomUser
+    mem2 <- newTeamMember' p <$> Util.randomUser
+    mem3 <- newTeamMember' (Util.symmPermissions []) <$> Util.randomUser
 
     Util.connectUsers owner (list1 (mem1^.userId) [mem2^.userId, mem3^.userId])
-    tid <- Util.createTeam g "foo" owner [mem1, mem2, mem3]
+    tid <- Util.createTeam "foo" owner [mem1, mem2, mem3]
 
     -- Team owner creates new regular team conversation:
-    cid <- Util.createTeamConv g owner tid [] (Just "blaa") Nothing Nothing
+    cid <- Util.createTeamConv owner tid [] (Just "blaa") Nothing Nothing
 
     -- Team member 1 (who is *not* a member of the new conversation)
     -- can add other team members without requiring a user connection
     -- thanks to both being team members and member 1 having the permission
     -- `AddRemoveConvMember`.
-    Util.assertNotConvMember g (mem1^.userId) cid
-    Util.postMembers g (mem1^.userId) (list1 (mem2^.userId) []) cid !!! const 200 === statusCode
-    Util.assertConvMember g (mem2^.userId) cid
+    Util.assertNotConvMember (mem1^.userId) cid
+    Util.postMembers (mem1^.userId) (list1 (mem2^.userId) []) cid !!! const 200 === statusCode
+    Util.assertConvMember (mem2^.userId) cid
 
     -- OTOH, team member 3 can not add another team member since it
     -- lacks the required permission
-    Util.assertNotConvMember g (mem3^.userId) cid
-    Util.postMembers g (mem3^.userId) (list1 (mem1^.userId) []) cid !!! do
+    Util.assertNotConvMember (mem3^.userId) cid
+    Util.postMembers (mem3^.userId) (list1 (mem1^.userId) []) cid !!! do
         const 403                === statusCode
         const "operation-denied" === (Error.label . Util.decodeBody' "error label")
 
@@ -504,36 +518,38 @@ testUpdateTeamConv
     :: Role  -- ^ Role of the user who creates the conversation
     -> TestM ()
 testUpdateTeamConv (rolePermissions -> perms) = do
-    owner  <- Util.randomUser b
-    member <- Util.randomUser b
+    owner  <- Util.randomUser
+    member <- Util.randomUser
     Util.connectUsers owner (list1 member [])
-    tid <- Util.createTeam g "foo" owner [newTeamMember member perms Nothing]
-    cid <- Util.createTeamConv g owner tid [member] (Just "gossip") Nothing Nothing
-    resp <- updateTeamConv g member cid (ConversationRename "not gossip")
+    tid <- Util.createTeam "foo" owner [newTeamMember member perms Nothing]
+    cid <- Util.createTeamConv owner tid [member] (Just "gossip") Nothing Nothing
+    resp <- updateTeamConv member cid (ConversationRename "not gossip")
     liftIO $ assertEqual "status"
         (if ModifyConvMetadata `elem` (perms ^. self) then 200 else 403)
         (statusCode resp)
 
 testDeleteTeam :: TestM ()
 testDeleteTeam = do
-    owner <- Util.randomUser b
+    g <- view galley
+    c <- view cannon
+    owner <- Util.randomUser
     let p = Util.symmPermissions [AddRemoveConvMember]
-    member <- newTeamMember' p <$> Util.randomUser b
-    extern <- Util.randomUser b
+    member <- newTeamMember' p <$> Util.randomUser
+    extern <- Util.randomUser
     Util.connectUsers owner (list1 (member^.userId) [extern])
 
-    tid  <- Util.createTeam g "foo" owner [member]
-    cid1 <- Util.createTeamConv g owner tid [] (Just "blaa") Nothing Nothing
-    cid2 <- Util.createManagedConv g owner tid [] (Just "blup") Nothing Nothing
+    tid  <- Util.createTeam "foo" owner [member]
+    cid1 <- Util.createTeamConv owner tid [] (Just "blaa") Nothing Nothing
+    cid2 <- Util.createManagedConv owner tid [] (Just "blup") Nothing Nothing
 
-    Util.assertConvMember g owner cid2
-    Util.assertConvMember g (member^.userId) cid2
-    Util.assertNotConvMember g extern cid2
+    Util.assertConvMember owner cid2
+    Util.assertConvMember (member^.userId) cid2
+    Util.assertNotConvMember extern cid2
 
-    Util.postMembers g owner (list1 extern []) cid1 !!! const 200 === statusCode
-    Util.assertConvMember g owner cid1
-    Util.assertConvMember g extern cid1
-    Util.assertNotConvMember g (member^.userId) cid1
+    Util.postMembers owner (list1 extern []) cid1 !!! const 200 === statusCode
+    Util.assertConvMember owner cid1
+    Util.assertConvMember extern cid1
+    Util.assertNotConvMember (member^.userId) cid1
 
     void $ WS.bracketR3 c owner extern (member^.userId) $ \(wsOwner, wsExtern, wsMember) -> do
         delete (g . paths ["teams", toByteString' tid] . zUser owner . zConn "conn") !!!
@@ -556,30 +572,32 @@ testDeleteTeam = do
         -- Ensure no user got deleted
         Util.ensureDeletedState False owner u
         for_ [cid1, cid2] $ \x -> do
-            Util.getConv g u x !!! const 404 === statusCode
-            Util.getSelfMember g u x !!! do
+            Util.getConv u x !!! const 404 === statusCode
+            Util.getSelfMember u x !!! do
                 const 200         === statusCode
                 const (Just Null) === Util.decodeBody
-    assertQueueEmpty a
+    assertQueueEmpty
 
 testDeleteBindingTeam :: Bool -> TestM ()
 testDeleteBindingTeam ownerHasPassword = do
-    owner  <- Util.randomUser' ownerHasPassword b
-    tid    <- Util.createTeamInternal g "foo" owner
-    assertQueue "create team" a tActivate
+    g <- view galley
+    c <- view cannon
+    owner  <- Util.randomUser' ownerHasPassword
+    tid    <- Util.createTeamInternal "foo" owner
+    assertQueue "create team" tActivate
     let p1 = Util.symmPermissions [AddRemoveConvMember]
-    mem1 <- newTeamMember' p1 <$> Util.randomUser b
+    mem1 <- newTeamMember' p1 <$> Util.randomUser
     let p2 = Util.symmPermissions [AddRemoveConvMember]
-    mem2 <- newTeamMember' p2 <$> Util.randomUser b
+    mem2 <- newTeamMember' p2 <$> Util.randomUser
     let p3 = Util.symmPermissions [AddRemoveConvMember]
-    mem3 <- newTeamMember' p3 <$> Util.randomUser b
-    Util.addTeamMemberInternal g tid mem1
-    assertQueue "team member join 2" a $ tUpdate 2 [owner]
-    Util.addTeamMemberInternal g tid mem2
-    assertQueue "team member join 3" a $ tUpdate 3 [owner]
-    Util.addTeamMemberInternal g tid mem3
-    assertQueue "team member join 4" a $ tUpdate 4 [owner]
-    extern <- Util.randomUser b
+    mem3 <- newTeamMember' p3 <$> Util.randomUser
+    Util.addTeamMemberInternal tid mem1
+    assertQueue "team member join 2" $ tUpdate 2 [owner]
+    Util.addTeamMemberInternal tid mem2
+    assertQueue "team member join 3" $ tUpdate 3 [owner]
+    Util.addTeamMemberInternal tid mem3
+    assertQueue "team member join 4" $ tUpdate 4 [owner]
+    extern <- Util.randomUser
 
     delete ( g
            . paths ["teams", toByteString' tid]
@@ -598,7 +616,7 @@ testDeleteBindingTeam ownerHasPassword = do
                                             then Just $ PlainTextPassword Util.defPassword
                                             else Nothing))
            ) !!! const 202 === statusCode
-    assertQueue "team member leave 1" a $ tUpdate 3 [owner]
+    assertQueue "team member leave 1" $ tUpdate 3 [owner]
 
     void $ WS.bracketRN c [owner, (mem1^.userId), (mem2^.userId), extern] $ \[wsOwner, wsMember1, wsMember2, wsExtern] -> do
         delete ( g
@@ -621,7 +639,7 @@ testDeleteBindingTeam ownerHasPassword = do
         WS.assertNoEvent (1 # Second) [wsExtern]
         -- Note that given the async nature of team deletion, we may
         -- have other events in the queue (such as TEAM_UPDATE)
-        tryAssertQueue 10 "team delete, should be there" a tDelete
+        tryAssertQueue 10 "team delete, should be there" tDelete
 
     forM_ [owner, (mem1^.userId), (mem2^.userId)] $
         -- Ensure users are marked as deleted; since we already
@@ -629,27 +647,29 @@ testDeleteBindingTeam ownerHasPassword = do
         Util.ensureDeletedState True extern
 
     -- Let's clean it up, just in case
-    ensureQueueEmpty a
+    ensureQueueEmpty
 
 testDeleteTeamConv :: TestM ()
 testDeleteTeamConv = do
-    owner <- Util.randomUser b
+    g <- view galley
+    c <- view cannon
+    owner <- Util.randomUser
     let p = Util.symmPermissions [DeleteConversation]
-    member <- newTeamMember' p <$> Util.randomUser b
-    extern <- Util.randomUser b
+    member <- newTeamMember' p <$> Util.randomUser
+    extern <- Util.randomUser
     Util.connectUsers owner (list1 (member^.userId) [extern])
 
-    tid  <- Util.createTeam g "foo" owner [member]
-    cid1 <- Util.createTeamConv g owner tid [] (Just "blaa") Nothing Nothing
+    tid  <- Util.createTeam "foo" owner [member]
+    cid1 <- Util.createTeamConv owner tid [] (Just "blaa") Nothing Nothing
     let access = ConversationAccessUpdate [InviteAccess, CodeAccess] ActivatedAccessRole
-    putAccessUpdate g owner cid1 access !!! const 200 === statusCode
-    code <- decodeConvCodeEvent <$> (postConvCode g owner cid1 <!! const 201 === statusCode)
-    cid2 <- Util.createManagedConv g owner tid [] (Just "blup") Nothing Nothing
+    putAccessUpdate owner cid1 access !!! const 200 === statusCode
+    code <- decodeConvCodeEvent <$> (postConvCode owner cid1 <!! const 201 === statusCode)
+    cid2 <- Util.createManagedConv owner tid [] (Just "blup") Nothing Nothing
 
-    Util.postMembers g owner (list1 extern [member^.userId]) cid1 !!! const 200 === statusCode
+    Util.postMembers owner (list1 extern [member^.userId]) cid1 !!! const 200 === statusCode
 
-    for_ [owner, member^.userId, extern] $ \u -> Util.assertConvMember g u cid1
-    for_ [owner, member^.userId]         $ \u -> Util.assertConvMember g u cid2
+    for_ [owner, member^.userId, extern] $ \u -> Util.assertConvMember u cid1
+    for_ [owner, member^.userId]         $ \u -> Util.assertConvMember u cid2
 
     WS.bracketR3 c owner extern (member^.userId) $ \(wsOwner, wsExtern, wsMember) -> do
         delete ( g
@@ -675,10 +695,10 @@ testDeleteTeamConv = do
 
     for_ [cid1, cid2] $ \x ->
         for_ [owner, member^.userId, extern] $ \u -> do
-            Util.getConv g u x !!! const 404 === statusCode
-            Util.assertNotConvMember g u x
+            Util.getConv u x !!! const 404 === statusCode
+            Util.assertNotConvMember u x
 
-    postConvCodeCheck g code !!! const 404 === statusCode
+    postConvCodeCheck code !!! const 404 === statusCode
   where
     checkTeamConvDeleteEvent tid cid w = WS.assertMatch_ timeout w $ \notif -> do
         ntfTransient notif @?= False
@@ -696,11 +716,13 @@ testDeleteTeamConv = do
 
 testUpdateTeam :: TestM ()
 testUpdateTeam = do
-    owner <- Util.randomUser b
+    g <- view galley
+    c <- view cannon
+    owner <- Util.randomUser
     let p = Util.symmPermissions [DeleteConversation]
-    member <- newTeamMember' p <$> Util.randomUser b
+    member <- newTeamMember' p <$> Util.randomUser
     Util.connectUsers owner (list1 (member^.userId) [])
-    tid <- Util.createTeam g "foo" owner [member]
+    tid <- Util.createTeam "foo" owner [member]
     let bad = object ["name" .= T.replicate 100 "too large"]
     put ( g
         . paths ["teams", toByteString' tid]
@@ -733,11 +755,13 @@ testUpdateTeam = do
 
 testUpdateTeamMember :: TestM ()
 testUpdateTeamMember = do
-    owner <- Util.randomUser b
+    g <- view galley
+    c <- view cannon
+    owner <- Util.randomUser
     let p = Util.symmPermissions [SetMemberPermissions]
-    member <- newTeamMember' p <$> Util.randomUser b
+    member <- newTeamMember' p <$> Util.randomUser
     Util.connectUsers owner (list1 (member^.userId) [])
-    tid <- Util.createTeam g "foo" owner [member]
+    tid <- Util.createTeam "foo" owner [member]
     -- Must have at least 1 member with full permissions
     let changeOwner = newNewTeamMember (newTeamMember' p owner)
     put ( g
@@ -756,7 +780,7 @@ testUpdateTeamMember = do
             . zConn "conn"
             . json changeMember
             ) !!! const 200 === statusCode
-        member' <- Util.getTeamMember g owner tid (member^.userId)
+        member' <- Util.getTeamMember owner tid (member^.userId)
         liftIO $ assertEqual "permissions" (member'^.permissions) (changeMember^.ntmNewTeamMember.permissions)
         checkTeamMemberUpdateEvent tid (member^.userId) wsOwner (pure fullPermissions)
         checkTeamMemberUpdateEvent tid (member^.userId) wsMember (pure fullPermissions)
@@ -769,13 +793,13 @@ testUpdateTeamMember = do
             . zConn "conn"
             . json changeOwner
             ) !!! const 200 === statusCode
-        owner' <- Util.getTeamMember g (member^.userId) tid owner
+        owner' <- Util.getTeamMember (member^.userId) tid owner
         liftIO $ assertEqual "permissions" (owner'^.permissions) (changeOwner^.ntmNewTeamMember.permissions)
         -- owner no longer has GetPermissions, but she can still see the update because it's about her!
         checkTeamMemberUpdateEvent tid owner wsOwner (pure p)
         checkTeamMemberUpdateEvent tid owner wsMember (pure p)
         WS.assertNoEvent timeout [wsOwner, wsMember]
-    assertQueueEmpty a
+    assertQueueEmpty
   where
     checkTeamMemberUpdateEvent tid uid w mPerm = WS.assertMatch_ timeout w $ \notif -> do
         ntfTransient notif @?= False
@@ -786,20 +810,21 @@ testUpdateTeamMember = do
 
 testUpdateTeamStatus :: TestM ()
 testUpdateTeamStatus = do
-    owner <- Util.randomUser b
-    tid   <- Util.createTeamInternal g "foo" owner
-    assertQueue "create team" a tActivate
+    g <- view galley
+    owner <- Util.randomUser
+    tid   <- Util.createTeamInternal "foo" owner
+    assertQueue "create team" tActivate
     -- Check for idempotency
-    Util.changeTeamStatus g tid Active
-    assertQueueEmpty a
-    Util.changeTeamStatus g tid Suspended
-    assertQueue "suspend first time" a tSuspend
-    Util.changeTeamStatus g tid Suspended
-    assertQueueEmpty a
-    Util.changeTeamStatus g tid Suspended
-    assertQueueEmpty a
-    Util.changeTeamStatus g tid Active
-    assertQueue "activate again" a tActivate
+    Util.changeTeamStatus tid Active
+    assertQueueEmpty
+    Util.changeTeamStatus tid Suspended
+    assertQueue "suspend first time" tSuspend
+    Util.changeTeamStatus tid Suspended
+    assertQueueEmpty
+    Util.changeTeamStatus tid Suspended
+    assertQueueEmpty
+    Util.changeTeamStatus tid Active
+    assertQueue "activate again" tActivate
 
     void $ put ( g
                . paths ["i", "teams", toByteString' tid, "status"]
@@ -877,18 +902,19 @@ checkConvMemberLeaveEvent cid usr w = WS.assertMatch_ timeout w $ \notif -> do
 
 postCryptoBroadcastMessageJson :: TestM ()
 postCryptoBroadcastMessageJson = do
+    c <- view cannon
     -- Team1: Alice, Bob. Team2: Charlie. Regular user: Dan. Connect Alice,Charlie,Dan
     (alice,  ac) <- randomUserWithClient (someLastPrekeys !! 0)
     (bob,    bc) <- randomUserWithClient (someLastPrekeys !! 1)
     (charlie,cc) <- randomUserWithClient (someLastPrekeys !! 2)
     (dan,    dc) <- randomUserWithClient (someLastPrekeys !! 3)
     connectUsers alice (list1 charlie [dan])
-    tid1 <- createTeamInternal g "foo" alice
-    assertQueue "" a tActivate
-    addTeamMemberInternal g tid1 $ newTeamMember' (symmPermissions []) bob
-    assertQueue "" a $ tUpdate 2 [alice]
-    _ <- createTeamInternal g "foo" charlie
-    assertQueue "" a tActivate
+    tid1 <- createTeamInternal "foo" alice
+    assertQueue "" tActivate
+    addTeamMemberInternal tid1 $ newTeamMember' (symmPermissions []) bob
+    assertQueue "" $ tUpdate 2 [alice]
+    _ <- createTeamInternal "foo" charlie
+    assertQueue "" tActivate
     -- A second client for Alice
     ac2 <- randomClient alice (someLastPrekeys !! 4)
     -- Complete: Alice broadcasts a message to Bob,Charlie,Dan and herself
@@ -898,7 +924,7 @@ postCryptoBroadcastMessageJson = do
         -- Alice's clients 1 and 2 listen to their own messages only
         WS.bracketR (c . queryItem "client" (toByteString' ac2)) alice $ \wsA2 ->
             WS.bracketR (c . queryItem "client" (toByteString' ac)) alice $ \wsA1 -> do
-                Util.postOtrBroadcastMessage id g alice ac msg !!! do
+                Util.postOtrBroadcastMessage id alice ac msg !!! do
                     const 201 === statusCode
                     assertTrue_ (eqMismatch [] [] [] . decodeBody)
                 -- Bob should get the broadcast (team member of alice)
@@ -914,27 +940,28 @@ postCryptoBroadcastMessageJson = do
 
 postCryptoBroadcastMessageJson2 :: TestM ()
 postCryptoBroadcastMessageJson2 = do
+    c <- view cannon
     -- Team1: Alice, Bob. Team2: Charlie. Connect Alice,Charlie
     (alice,  ac) <- randomUserWithClient (someLastPrekeys !! 0)
     (bob,    bc) <- randomUserWithClient (someLastPrekeys !! 1)
     (charlie,cc) <- randomUserWithClient (someLastPrekeys !! 2)
     connectUsers alice (list1 charlie [])
-    tid1 <- createTeamInternal g "foo" alice
-    assertQueue "" a tActivate
-    addTeamMemberInternal g tid1 $ newTeamMember' (symmPermissions []) bob
-    assertQueue "" a $ tUpdate 2 [alice]
+    tid1 <- createTeamInternal "foo" alice
+    assertQueue "" tActivate
+    addTeamMemberInternal tid1 $ newTeamMember' (symmPermissions []) bob
+    assertQueue "" $ tUpdate 2 [alice]
 
     let t = 3 # Second -- WS receive timeout
     -- Missing charlie
     let m1 = [(bob, bc, "ciphertext1")]
-    Util.postOtrBroadcastMessage id g alice ac m1 !!! do
+    Util.postOtrBroadcastMessage id alice ac m1 !!! do
         const 412 === statusCode
         assertTrue "1: Only Charlie and his device" (eqMismatch [(charlie, Set.singleton cc)] [] [] . decodeBody)
 
     -- Complete
     WS.bracketR2 c bob charlie $ \(wsB, wsE) -> do
         let m2 = [(bob, bc, "ciphertext2"), (charlie, cc, "ciphertext2")]
-        Util.postOtrBroadcastMessage id g alice ac m2 !!! do
+        Util.postOtrBroadcastMessage id alice ac m2 !!! do
             const 201 === statusCode
             assertTrue "No devices expected" (eqMismatch [] [] [] . decodeBody)
         void . liftIO $ WS.assertMatch t wsB (wsAssertOtr (selfConv bob) alice ac bc "ciphertext2")
@@ -943,7 +970,7 @@ postCryptoBroadcastMessageJson2 = do
     -- Redundant self
     WS.bracketR3 c alice bob charlie $ \(wsA, wsB, wsE) -> do
         let m3 = [(alice, ac, "ciphertext3"), (bob, bc, "ciphertext3"), (charlie, cc, "ciphertext3")]
-        Util.postOtrBroadcastMessage id g alice ac m3 !!! do
+        Util.postOtrBroadcastMessage id alice ac m3 !!! do
             const 201 === statusCode
             assertTrue "2: Only Alice and her device" (eqMismatch [] [(alice, Set.singleton ac)] [] . decodeBody)
         void . liftIO $ WS.assertMatch t wsB (wsAssertOtr (selfConv bob) alice ac bc "ciphertext3")
@@ -955,7 +982,7 @@ postCryptoBroadcastMessageJson2 = do
     WS.bracketR2 c bob charlie $ \(wsB, wsE) -> do
         deleteClient charlie cc (Just $ PlainTextPassword defPassword) !!! const 200 === statusCode
         let m4 = [(bob, bc, "ciphertext4"), (charlie, cc, "ciphertext4")]
-        Util.postOtrBroadcastMessage id g alice ac m4 !!! do
+        Util.postOtrBroadcastMessage id alice ac m4 !!! do
             const 201 === statusCode
             assertTrue "3: Only Charlie and his device" (eqMismatch [] [] [(charlie, Set.singleton cc)] . decodeBody)
         void . liftIO $ WS.assertMatch t wsB (wsAssertOtr (selfConv bob) alice ac bc "ciphertext4")
@@ -967,23 +994,24 @@ postCryptoBroadcastMessageProto = do
     -- similar to postCryptoBroadcastMessageJson except uses protobuf
 
     -- Team1: Alice, Bob. Team2: Charlie. Regular user: Dan. Connect Alice,Charlie,Dan
+    c <- view cannon
     (alice,  ac) <- randomUserWithClient (someLastPrekeys !! 0)
     (bob,    bc) <- randomUserWithClient (someLastPrekeys !! 1)
     (charlie,cc) <- randomUserWithClient (someLastPrekeys !! 2)
     (dan,    dc) <- randomUserWithClient (someLastPrekeys !! 3)
     connectUsers alice (list1 charlie [dan])
-    tid1 <- createTeamInternal g "foo" alice
-    assertQueue "" a tActivate
-    addTeamMemberInternal g tid1 $ newTeamMember' (symmPermissions []) bob
-    assertQueue "" a $ tUpdate 2 [alice]
-    _ <- createTeamInternal g "foo" charlie
-    assertQueue "" a tActivate
+    tid1 <- createTeamInternal "foo" alice
+    assertQueue "" tActivate
+    addTeamMemberInternal tid1 $ newTeamMember' (symmPermissions []) bob
+    assertQueue "" $ tUpdate 2 [alice]
+    _ <- createTeamInternal "foo" charlie
+    assertQueue "" tActivate
     -- Complete: Alice broadcasts a message to Bob,Charlie,Dan
     let t = 1 # Second -- WS receive timeout
     let ciphertext = encodeCiphertext "hello bob"
     WS.bracketRN c [alice, bob, charlie, dan] $ \ws@[_, wsB, wsC, wsD] -> do
         let msg = otrRecipients [(bob, [(bc, ciphertext)]), (charlie, [(cc, ciphertext)]), (dan, [(dc, ciphertext)])]
-        Util.postProtoOtrBroadcast g alice ac msg !!! do
+        Util.postProtoOtrBroadcast alice ac msg !!! do
             const 201 === statusCode
             assertTrue_ (eqMismatch [] [] [] . decodeBody)
         -- Bob should get the broadcast (team member of alice)

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -19,7 +19,7 @@ import Gundeck.Types.Notification
 import Test.Tasty
 import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import Test.Tasty.HUnit
-import TestSetup (test,  TestSetup,  ResponseLBS, TestM, cannon, galley)
+import TestSetup (test,  TestSetup, TestM, cannon, galley)
 import API.SQS
 import UnliftIO (mapConcurrently, mapConcurrently_)
 

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -19,6 +19,7 @@ import Gundeck.Types.Notification
 import Test.Tasty
 import Test.Tasty.Cannon (Cannon, TimeoutUnit (..), (#))
 import Test.Tasty.HUnit
+import TestSetup (test, TestSignature)
 import API.SQS
 import UnliftIO (mapConcurrently, mapConcurrently_)
 
@@ -32,15 +33,6 @@ import qualified Galley.Types as Conv
 import qualified Network.Wai.Utilities.Error as Error
 import qualified Test.Tasty.Cannon as WS
 import qualified Galley.Aws as Aws
-
-type TestSignature a = Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http a
-
-test :: IO TestSetup -> TestName -> TestSignature a -> TestTree
-test s n h = testCase n runTest
-  where
-    runTest = do
-        setup <- s
-        void $ runHttpT (manager setup) (h (galley setup) (brig setup) (cannon setup) (awsEnv setup))
 
 tests :: IO TestSetup -> TestTree
 tests s = testGroup "Teams API"

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -17,9 +17,9 @@ import Galley.Types.Teams
 import Galley.Types.Teams.Intra
 import Gundeck.Types.Notification
 import Test.Tasty
-import Test.Tasty.Cannon (Cannon, TimeoutUnit (..), (#))
+import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import Test.Tasty.HUnit
-import TestSetup (test, TestSignature)
+import TestSetup (test, Galley, Cannon, TestSetup, Brig, ResponseLBS)
 import API.SQS
 import UnliftIO (mapConcurrently, mapConcurrently_)
 
@@ -187,7 +187,7 @@ testCreateOne2OneWithMembers (rolePermissions -> perms) g b c a = do
     -- Recreating a One2One is a no-op, returns a 200
     Util.createOne2OneTeamConv g owner (mem1^.userId) Nothing tid !!! const 200 === statusCode
   where
-    repeatIf :: Util.ResponseLBS -> Bool
+    repeatIf :: ResponseLBS -> Bool
     repeatIf r = statusCode r /= 201
 
 testAddTeamMember :: Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http ()

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -19,7 +19,7 @@ import Gundeck.Types.Notification
 import Test.Tasty
 import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import Test.Tasty.HUnit
-import TestSetup (test,  TestSetup, TestM, cannon, galley)
+import TestSetup (test,  TestSetup, TestM, tsCannon, tsGalley)
 import API.SQS
 import UnliftIO (mapConcurrently, mapConcurrently_)
 
@@ -74,7 +74,7 @@ timeout = 3 # Second
 
 testCreateTeam :: TestM ()
 testCreateTeam = do
-    c <- view cannon
+    c <- view tsCannon
     owner <- Util.randomUser
     WS.bracketR c owner $ \wsOwner -> do
         tid   <- Util.createTeam "foo" owner []
@@ -92,7 +92,7 @@ testCreateTeam = do
 
 testCreateMulitpleBindingTeams :: TestM ()
 testCreateMulitpleBindingTeams = do
-    g <- view galley
+    g <- view tsGalley
     owner <- Util.randomUser
     _     <- Util.createTeamInternal "foo" owner
     assertQueue "create team" tActivate
@@ -120,7 +120,7 @@ testCreateBindingTeamWithCurrency = do
 
 testCreateTeamWithMembers :: TestM ()
 testCreateTeamWithMembers = do
-    c <- view cannon
+    c <- view tsCannon
     owner <- Util.randomUser
     user1 <- Util.randomUser
     user2 <- Util.randomUser
@@ -174,7 +174,7 @@ testCreateOne2OneWithMembers
     => Role  -- ^ Role of the user who creates the conversation
     -> TestM ()
 testCreateOne2OneWithMembers (rolePermissions -> perms) = do
-    c <- view cannon
+    c <- view tsCannon
     owner <- Util.randomUser
     tid   <- Util.createTeamInternal "foo" owner
     assertQueue "create team" tActivate
@@ -195,8 +195,8 @@ testCreateOne2OneWithMembers (rolePermissions -> perms) = do
 
 testAddTeamMember :: TestM ()
 testAddTeamMember = do
-    c <- view cannon
-    g <- view galley
+    c <- view tsCannon
+    g <- view tsGalley
     owner <- Util.randomUser
     let p1 = Util.symmPermissions [CreateConversation, AddRemoveConvMember]
     let p2 = Util.symmPermissions [CreateConversation, AddRemoveConvMember, AddTeamMember]
@@ -222,7 +222,7 @@ testAddTeamMember = do
 
 testAddTeamMemberCheckBound :: TestM ()
 testAddTeamMemberCheckBound = do
-    g <- view galley
+    g <- view tsGalley
     ownerBound <- Util.randomUser
     tidBound   <- Util.createTeamInternal "foo" ownerBound
     assertQueue "create team" tActivate
@@ -241,7 +241,7 @@ testAddTeamMemberCheckBound = do
 
 testAddTeamMemberInternal :: TestM ()
 testAddTeamMemberInternal = do
-    c <- view cannon
+    c <- view tsCannon
     owner <- Util.randomUser
     tid <- Util.createTeam "foo" owner []
     let p1 = Util.symmPermissions [GetBilling] -- permissions are irrelevant on internal endpoint
@@ -262,8 +262,8 @@ testAddTeamMemberInternal = do
 
 testRemoveTeamMember :: TestM ()
 testRemoveTeamMember = do
-    c <- view cannon
-    g <- view galley
+    c <- view tsCannon
+    g <- view tsGalley
     owner <- Util.randomUser
     let p1 = Util.symmPermissions [AddRemoveConvMember]
     let p2 = Util.symmPermissions [AddRemoveConvMember, RemoveTeamMember]
@@ -309,8 +309,8 @@ testRemoveTeamMember = do
 
 testRemoveBindingTeamMember :: Bool -> TestM ()
 testRemoveBindingTeamMember ownerHasPassword = do
-    g <- view galley
-    c <- view cannon
+    g <- view tsGalley
+    c <- view tsCannon
     owner <- Util.randomUser' ownerHasPassword
     tid   <- Util.createTeamInternal "foo" owner
     assertQueue "create team" tActivate
@@ -381,7 +381,7 @@ testRemoveBindingTeamMember ownerHasPassword = do
 
 testAddTeamConv :: TestM ()
 testAddTeamConv = do
-    c <- view cannon
+    c <- view tsCannon
     owner  <- Util.randomUser
     extern <- Util.randomUser
 
@@ -457,7 +457,7 @@ testAddTeamConvAsExternalPartner = do
 
 testAddManagedConv :: TestM ()
 testAddManagedConv = do
-    g <- view galley
+    g <- view tsGalley
     owner <- Util.randomUser
     tid <- Util.createTeam "foo" owner []
     let tinfo = ConvTeamInfo tid True
@@ -530,8 +530,8 @@ testUpdateTeamConv (rolePermissions -> perms) = do
 
 testDeleteTeam :: TestM ()
 testDeleteTeam = do
-    g <- view galley
-    c <- view cannon
+    g <- view tsGalley
+    c <- view tsCannon
     owner <- Util.randomUser
     let p = Util.symmPermissions [AddRemoveConvMember]
     member <- newTeamMember' p <$> Util.randomUser
@@ -580,8 +580,8 @@ testDeleteTeam = do
 
 testDeleteBindingTeam :: Bool -> TestM ()
 testDeleteBindingTeam ownerHasPassword = do
-    g <- view galley
-    c <- view cannon
+    g <- view tsGalley
+    c <- view tsCannon
     owner  <- Util.randomUser' ownerHasPassword
     tid    <- Util.createTeamInternal "foo" owner
     assertQueue "create team" tActivate
@@ -651,8 +651,8 @@ testDeleteBindingTeam ownerHasPassword = do
 
 testDeleteTeamConv :: TestM ()
 testDeleteTeamConv = do
-    g <- view galley
-    c <- view cannon
+    g <- view tsGalley
+    c <- view tsCannon
     owner <- Util.randomUser
     let p = Util.symmPermissions [DeleteConversation]
     member <- newTeamMember' p <$> Util.randomUser
@@ -716,8 +716,8 @@ testDeleteTeamConv = do
 
 testUpdateTeam :: TestM ()
 testUpdateTeam = do
-    g <- view galley
-    c <- view cannon
+    g <- view tsGalley
+    c <- view tsCannon
     owner <- Util.randomUser
     let p = Util.symmPermissions [DeleteConversation]
     member <- newTeamMember' p <$> Util.randomUser
@@ -755,8 +755,8 @@ testUpdateTeam = do
 
 testUpdateTeamMember :: TestM ()
 testUpdateTeamMember = do
-    g <- view galley
-    c <- view cannon
+    g <- view tsGalley
+    c <- view tsCannon
     owner <- Util.randomUser
     let p = Util.symmPermissions [SetMemberPermissions]
     member <- newTeamMember' p <$> Util.randomUser
@@ -810,7 +810,7 @@ testUpdateTeamMember = do
 
 testUpdateTeamStatus :: TestM ()
 testUpdateTeamStatus = do
-    g <- view galley
+    g <- view tsGalley
     owner <- Util.randomUser
     tid   <- Util.createTeamInternal "foo" owner
     assertQueue "create team" tActivate
@@ -902,7 +902,7 @@ checkConvMemberLeaveEvent cid usr w = WS.assertMatch_ timeout w $ \notif -> do
 
 postCryptoBroadcastMessageJson :: TestM ()
 postCryptoBroadcastMessageJson = do
-    c <- view cannon
+    c <- view tsCannon
     -- Team1: Alice, Bob. Team2: Charlie. Regular user: Dan. Connect Alice,Charlie,Dan
     (alice,  ac) <- randomUserWithClient (someLastPrekeys !! 0)
     (bob,    bc) <- randomUserWithClient (someLastPrekeys !! 1)
@@ -940,7 +940,7 @@ postCryptoBroadcastMessageJson = do
 
 postCryptoBroadcastMessageJson2 :: TestM ()
 postCryptoBroadcastMessageJson2 = do
-    c <- view cannon
+    c <- view tsCannon
     -- Team1: Alice, Bob. Team2: Charlie. Connect Alice,Charlie
     (alice,  ac) <- randomUserWithClient (someLastPrekeys !! 0)
     (bob,    bc) <- randomUserWithClient (someLastPrekeys !! 1)
@@ -994,7 +994,7 @@ postCryptoBroadcastMessageProto = do
     -- similar to postCryptoBroadcastMessageJson except uses protobuf
 
     -- Team1: Alice, Bob. Team2: Charlie. Regular user: Dan. Connect Alice,Charlie,Dan
-    c <- view cannon
+    c <- view tsCannon
     (alice,  ac) <- randomUserWithClient (someLastPrekeys !! 0)
     (bob,    bc) <- randomUserWithClient (someLastPrekeys !! 1)
     (charlie,cc) <- randomUserWithClient (someLastPrekeys !! 2)
@@ -1033,7 +1033,7 @@ postCryptoBroadcastMessageNoTeam = do
 
 postCryptoBroadcastMessage100OrMaxConns :: TestM ()
 postCryptoBroadcastMessage100OrMaxConns = do
-    c <- view cannon
+    c <- view tsCannon
     (alice, ac) <- randomUserWithClient (someLastPrekeys !! 0)
     _ <- createTeamInternal "foo" alice
     assertQueue "" tActivate

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -37,6 +37,7 @@ import qualified Galley.Types.Proto     as Proto
 import qualified Test.QuickCheck        as Q
 import qualified Test.Tasty.Cannon      as WS
 
+type ResponseLBS = Response (Maybe LByteString)
 -------------------------------------------------------------------------------
 -- API Operations
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -21,8 +21,9 @@ import Galley.Types
 import Galley.Types.Teams hiding (EventType (..))
 import Galley.Types.Teams.Intra
 import Gundeck.Types.Notification
-import Test.Tasty.Cannon (Cannon, TimeoutUnit (..), (#))
+import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import Test.Tasty.HUnit
+import TestSetup
 
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Char8  as C
@@ -32,23 +33,9 @@ import qualified Data.HashMap.Strict    as HashMap
 import qualified Data.Map.Strict        as Map
 import qualified Data.Set               as Set
 import qualified Data.UUID              as UUID
-import qualified Galley.Aws             as Aws
 import qualified Galley.Types.Proto     as Proto
 import qualified Test.QuickCheck        as Q
 import qualified Test.Tasty.Cannon      as WS
-
-type Galley      = Request -> Request
-type Brig        = Request -> Request
-type ResponseLBS = Response (Maybe Lazy.ByteString)
-
-data TestSetup = TestSetup
-  { manager         :: Manager
-  , galley          :: Galley
-  , brig            :: Brig
-  , cannon          :: Cannon
-  , awsEnv          :: Maybe Aws.Env
-  , maxConvSize     :: Word16
-  }
 
 -------------------------------------------------------------------------------
 -- API Operations

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -223,7 +223,12 @@ putConvAccept invited cid = do
       . zType "access"
       . zConn "conn"
 
-postOtrMessage :: (Request -> Request) -> UserId -> ClientId -> ConvId -> [(UserId, ClientId, Text)] -> TestM ResponseLBS
+postOtrMessage :: (Request -> Request)
+               -> UserId
+               -> ClientId
+               -> ConvId
+               -> [(UserId, ClientId, Text)]
+               -> TestM ResponseLBS
 postOtrMessage f u d c rec = do
     g <- view galley
     post $ g

--- a/services/galley/test/integration/Main.hs
+++ b/services/galley/test/integration/Main.hs
@@ -20,9 +20,9 @@ import Test.Tasty.Options
 import Util.Options
 import Util.Options.Common
 import Util.Test
+import TestSetup (TestSetup(..))
 
 import qualified API
-import qualified API.Util               as Util
 import qualified API.SQS                as SQS
 import qualified Data.ByteString.Char8  as BS
 
@@ -79,8 +79,8 @@ main = withOpenSSL $ runTests go
         e <- join <$> optOrEnvSafe endpoint gConf (fromByteString . BS.pack) "GALLEY_SQS_ENDPOINT"
         convMaxSize <- optOrEnv maxSize gConf read "CONV_MAX_SIZE"
         awsEnv <- initAwsEnv e q
-        SQS.ensureQueueEmpty awsEnv
-        return $ Util.TestSetup m g b c awsEnv convMaxSize
+        SQS.ensureQueueEmptyIO awsEnv
+        return $ TestSetup m g b c awsEnv convMaxSize
 
     queueName = fmap (view awsQueueName) . view optJournal
     endpoint = fmap (view awsEndpoint) . view optJournal

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -1,26 +1,26 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -fprint-potential-instances #-}
 module TestSetup
-  ( test
-  , manager
-  , galley
-  , brig
-  , cannon
-  , awsEnv
-  , maxConvSize
-  , Galley
-  , Brig
-  , Cannon
-  , TestM(..)
-  , TestSetup(..)
-  ) where
+    ( test
+    , manager
+    , galley
+    , brig
+    , cannon
+    , awsEnv
+    , maxConvSize
+    , Galley
+    , Brig
+    , Cannon
+    , TestM(..)
+    , TestSetup(..)
+    ) where
 
 import Imports
 import Test.Tasty          (TestName, TestTree)
 import Test.Tasty.HUnit    (Assertion, testCase)
 import Control.Lens        ((^.), makeLenses)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
-import Bilge (Http, HttpT(..), Manager, MonadHttp, Request, runHttpT)
+import Bilge (HttpT(..), Manager, MonadHttp, Request, runHttpT)
 
 import qualified Galley.Aws          as Aws
 
@@ -44,13 +44,13 @@ newtype TestM a =
              )
 
 data TestSetup = TestSetup
-  { _manager         :: Manager
-  , _galley          :: Galley
-  , _brig            :: Brig
-  , _cannon          :: Cannon
-  , _awsEnv          :: Maybe Aws.Env
-  , _maxConvSize     :: Word16
-  }
+    { _manager     :: Manager
+    , _galley      :: Galley
+    , _brig        :: Brig
+    , _cannon      :: Cannon
+    , _awsEnv      :: Maybe Aws.Env
+    , _maxConvSize :: Word16
+    }
 
 makeLenses ''TestSetup
 

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -2,12 +2,12 @@
 {-# OPTIONS_GHC -fprint-potential-instances #-}
 module TestSetup
     ( test
-    , manager
-    , galley
-    , brig
-    , cannon
-    , awsEnv
-    , maxConvSize
+    , tsManager
+    , tsGalley
+    , tsBrig
+    , tsCannon
+    , tsAwsEnv
+    , tsMaxConvSize
     , Galley
     , Brig
     , Cannon
@@ -44,12 +44,12 @@ newtype TestM a =
              )
 
 data TestSetup = TestSetup
-    { _manager     :: Manager
-    , _galley      :: Galley
-    , _brig        :: Brig
-    , _cannon      :: Cannon
-    , _awsEnv      :: Maybe Aws.Env
-    , _maxConvSize :: Word16
+    { _tsManager     :: Manager
+    , _tsGalley      :: Galley
+    , _tsBrig        :: Brig
+    , _tsCannon      :: Cannon
+    , _tsAwsEnv      :: Maybe Aws.Env
+    , _tsMaxConvSize :: Word16
     }
 
 makeLenses ''TestSetup
@@ -61,5 +61,5 @@ test s n h = testCase n runTest
     runTest :: Assertion
     runTest = do
         setup <- s
-        void . runHttpT (setup ^. manager) . flip runReaderT setup . runTestM $ h
+        void . runHttpT (setup ^. tsManager) . flip runReaderT setup . runTestM $ h
 

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -2,8 +2,6 @@
 {-# OPTIONS_GHC -fprint-potential-instances #-}
 module TestSetup
   ( test
-  , TestSignature
-  , TestSetup(..)
   , manager
   , galley
   , brig
@@ -13,30 +11,37 @@ module TestSetup
   , Galley
   , Brig
   , Cannon
-  , ResponseLBS
-  , TestM
+  , TestM(..)
+  , TestSetup(..)
   ) where
 
 import Imports
-import Test.Tasty
-import Test.Tasty.HUnit
-import Control.Lens
-import Control.Monad.Catch
+import Test.Tasty          (TestName, TestTree)
+import Test.Tasty.HUnit    (Assertion, testCase)
+import Control.Lens        ((^.), makeLenses)
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import Bilge (Http, HttpT(..), Manager, MonadHttp, Request, runHttpT)
 
-import Bilge (Request, HttpT(..), Http, Manager, Response, runHttpT, MonadHttp)
-import qualified Galley.Aws             as Aws
+import qualified Galley.Aws          as Aws
 
 type Galley      = Request -> Request
 type Brig        = Request -> Request
 type Cannon      = Request -> Request
-type ResponseLBS = Response (Maybe LByteString)
 
-
-type TestSignature a = Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http a
-
-newtype TestM a = TestM {runTestM :: ReaderT TestSetup (HttpT IO) a}
-    deriving (Functor, Applicative, Monad, MonadReader TestSetup, MonadIO, MonadCatch
-            , MonadThrow, MonadMask,  MonadHttp, MonadUnliftIO)
+newtype TestM a =
+  TestM { runTestM :: ReaderT TestSetup (HttpT IO) a
+        }
+    deriving ( Functor
+             , Applicative
+             , Monad
+             , MonadReader TestSetup
+             , MonadIO
+             , MonadCatch
+             , MonadThrow
+             , MonadMask
+             , MonadHttp
+             , MonadUnliftIO
+             )
 
 data TestSetup = TestSetup
   { _manager         :: Manager

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -1,0 +1,51 @@
+module TestSetup
+  ( test
+  , TestSignature
+  , TestSetup
+  , manager
+  , galley
+  , brig
+  , cannon
+  , awsEnv
+  , maxConvSize
+  , Galley
+  , Brig
+  , Cannon
+  , ResponseLBS
+  ) where
+
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+import Control.Lens
+
+import Bilge (Request, Http, Manager, Response)
+import qualified Galley.Aws             as Aws
+
+type Galley      = Request -> Request
+type Brig        = Request -> Request
+type Cannon      = Request -> Request
+type ResponseLBS = Response (Maybe LByteString)
+
+
+type TestSignature a = Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http a
+
+data TestSetup = TestSetup
+  { _manager         :: Manager
+  , _galley          :: Galley
+  , _brig            :: Brig
+  , _cannon          :: Cannon
+  , _awsEnv          :: Maybe Aws.Env
+  , _maxConvSize     :: Word16
+  }
+
+makeLenses ''TestSetup
+
+
+test :: IO TestSetup -> TestName -> TestSignature a -> TestTree
+test s n h = testCase n runTest
+  where
+    runTest = do
+        setup <- s
+        void $ runHttpT (manager setup) (h (galley setup) (brig setup) (cannon setup) (awsEnv setup))
+

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -3,7 +3,7 @@
 module TestSetup
   ( test
   , TestSignature
-  , TestSetup
+  , TestSetup(..)
   , manager
   , galley
   , brig

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -8,9 +8,6 @@ module TestSetup
     , tsCannon
     , tsAwsEnv
     , tsMaxConvSize
-    , Galley
-    , Brig
-    , Cannon
     , TestM(..)
     , TestSetup(..)
     ) where
@@ -23,10 +20,6 @@ import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Bilge (HttpT(..), Manager, MonadHttp, Request, runHttpT)
 
 import qualified Galley.Aws          as Aws
-
-type Galley      = Request -> Request
-type Brig        = Request -> Request
-type Cannon      = Request -> Request
 
 newtype TestM a =
   TestM { runTestM :: ReaderT TestSetup (HttpT IO) a
@@ -43,11 +36,15 @@ newtype TestM a =
              , MonadUnliftIO
              )
 
+type GalleyR      = Request -> Request
+type BrigR        = Request -> Request
+type CannonR      = Request -> Request
+
 data TestSetup = TestSetup
     { _tsManager     :: Manager
-    , _tsGalley      :: Galley
-    , _tsBrig        :: Brig
-    , _tsCannon      :: Cannon
+    , _tsGalley      :: GalleyR
+    , _tsBrig        :: BrigR
+    , _tsCannon      :: CannonR
     , _tsAwsEnv      :: Maybe Aws.Env
     , _tsMaxConvSize :: Word16
     }

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -23,7 +23,7 @@ import Test.Tasty.HUnit
 import Control.Lens
 import Control.Monad.Catch
 
-import Bilge (Request, HttpT, Http, Manager, Response, runHttpT, MonadHttp)
+import Bilge (Request, HttpT(..), Http, Manager, Response, runHttpT, MonadHttp)
 import qualified Galley.Aws             as Aws
 
 type Galley      = Request -> Request
@@ -36,11 +36,7 @@ type TestSignature a = Galley -> Brig -> Cannon -> Maybe Aws.Env -> Http a
 
 newtype TestM a = TestM {runTestM :: ReaderT TestSetup (HttpT IO) a}
     deriving (Functor, Applicative, Monad, MonadReader TestSetup, MonadIO, MonadCatch
-            , MonadThrow, MonadMask,  MonadHttp)
-
-instance MonadUnliftIO TestM where
-  askUnliftIO = TestM askUnliftIO
-  withRunInIO = _
+            , MonadThrow, MonadMask,  MonadHttp, MonadUnliftIO)
 
 data TestSetup = TestSetup
   { _manager         :: Manager


### PR DESCRIPTION
I was having some trouble writing easily re-usable test fixtures for a few reasons:

- Explicit arg passing makes writing higher-order helpers tricky, e.g. passing a test into a helper to run some transformation on it (e.g. modifying one of the arguments before running a test, passing a fixture in to a list of tests, etc.)
- explicit passing added a lot of noise; there were unused arguments everywhere.
- Previously, adding a new dependency on some service would mean changing EVERY test signature

Turns out this is pretty much exactly what reader monad is meant to solve;

Also by switching to an explicit TestM we can make changes there and gain the benefits in all tests; e.g. if we lift assertion functions we can gain the benefits everywhere.

This is strictly a refactoring; no behaviour changes.