### PR TITLE
Use URLs for snapshots; switch fork repos

### DIFF
--- a/snapshots/README.md
+++ b/snapshots/README.md
@@ -1,0 +1,23 @@
+This directory contains [custom Stack snapshots][custom] used for Wire code.
+
+[custom]: https://docs.haskellstack.org/en/stable/custom_snapshot/
+
+Snapshot definitions should never be changed (once committed to `develop`), because in other
+repositories we refer to snapshot definitions by URL.
+
+(Rationale: Stack only downloads snapshot definitions once, and never checks whether they have
+changed. If a snapshot changes and you have a repo that depends on it, you will get
+inconsistent results depending on whether you've built that repo before or not.)
+
+To add, modify, or remove packages, a new snapshot should be created. It can be based on the
+previous snapshot version. For major changes, e.g. LTS bumps, it's better to create a snapshot
+from scratch.
+
+Some packages in this snapshot reference tar files instead of Git repos. This is due to
+several issues in Stack that make working with big Git repositories unpleasant:
+
+  * https://github.com/commercialhaskell/stack/issues/4345
+  * https://github.com/commercialhaskell/stack/issues/3551
+
+Unless the fixes to those are released, it's recommended to use GitHub's tar releases for
+packages with big repos.

--- a/snapshots/wire-1.0.yaml
+++ b/snapshots/wire-1.0.yaml
@@ -64,7 +64,7 @@ packages:
 ############################################################
 
 #  Our fork of multihash with relaxed upper bounds
-- git: https://github.com/tiago-loureiro/haskell-multihash.git
+- git: https://github.com/wireapp/haskell-multihash.git
   commit: 300a6f46384bfca33e545c8bab52ef3717452d12
 
 # Our fork of aws with minor fixes

--- a/snapshots/wire-1.0.yaml
+++ b/snapshots/wire-1.0.yaml
@@ -68,7 +68,7 @@ packages:
   commit: 300a6f46384bfca33e545c8bab52ef3717452d12
 
 # Our fork of aws with minor fixes
-- git: https://github.com/tiago-loureiro/aws
+- git: https://github.com/wireapp/aws
   commit: 42695688fc20f80bf89cec845c57403954aab0a2
 
 # https://github.com/hspec/hspec-wai/pull/49
@@ -80,10 +80,10 @@ packages:
 #
 # The important commits for us are:
 #
-#   * https://github.com/snoyberg/http-client/compare/master...neongreen:connection-guts
+#   * https://github.com/snoyberg/http-client/compare/master...wireapp:connection-guts
 #
 # The archive corresponds to commit 6a4ac55edf5e62574210c77a1468fa7accb81670.
-- archive: https://github.com/neongreen/http-client/archive/wire-2019-01-25.tar.gz
+- archive: https://github.com/wireapp/http-client/archive/wire-2019-01-25.tar.gz
   subdirs:
   - http-client
   - http-client-openssl
@@ -103,7 +103,7 @@ packages:
 #   * https://github.com/brendanhay/amazonka/pull/493/files
 #
 # The archive corresponds to commit 52896fd46ef6812708e9e4d7456becc692698f6b.
-- archive: https://github.com/neongreen/amazonka/archive/wire-2019-01-25.tar.gz
+- archive: https://github.com/wireapp/amazonka/archive/wire-2019-01-25.tar.gz
   subdirs:
   - amazonka
   - core

--- a/snapshots/wire-1.0.yaml
+++ b/snapshots/wire-1.0.yaml
@@ -1,23 +1,4 @@
-# A custom Stack snapshot (https://docs.haskellstack.org/en/stable/custom_snapshot/) used for
-# Wire code.
-#
-# Should never be changed once pushed to develop, because in other repositories we refer to
-# snapshot definitions by URL. Stack only downloads snapshot definitions once and never checks
-# whether they have changed. So, when building code from other repositories, people would be
-# getting inconsistent results depending on whether they built that code before or not.
-#
-# To add, modify, or remove packages, a new snapshot should be created. It can be based on the
-# previous snapshot version (please read the docs above to learn what the syntax is). For
-# major changes, e.g. LTS bumps, it's better to create a snapshot from scratch.
-#
-# Some packages in this snapshot reference tar files instead of Git repos. This is due to
-# several issues in Stack that make working with big Git repositories unpleasant:
-#
-#   * https://github.com/commercialhaskell/stack/issues/4345
-#   * https://github.com/commercialhaskell/stack/issues/3551
-#
-# Unless the fixes to those are released, it's recommended to use Github's tar releases for
-# forks of big/old packages.
+# DO NOT MODIFY THIS FILE. See README.md to learn why.
 
 resolver: lts-12.10
 name: wire-1.0
@@ -136,3 +117,5 @@ packages:
 
 - git: https://github.com/wireapp/hsaml2
   commit: 000868849efd85ba82d2bf0ac5757f801d49ad5a    # master (Sep 10, 2018)
+
+# DO NOT MODIFY THIS FILE. See README.md to learn why.

--- a/snapshots/wire-1.1.yaml
+++ b/snapshots/wire-1.1.yaml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY THIS FILE. See README.md to learn why.
+
 resolver: https://raw.githubusercontent.com/wireapp/wire-server/develop/snapshots/wire-1.0.yaml
 name: wire-1.1
 

--- a/snapshots/wire-1.1.yaml
+++ b/snapshots/wire-1.1.yaml
@@ -1,4 +1,4 @@
-resolver: wire-1.0.yaml
+resolver: https://raw.githubusercontent.com/wireapp/wire-server/develop/snapshots/wire-1.0.yaml
 name: wire-1.1
 
 packages:

--- a/snapshots/wire-1.2.yaml
+++ b/snapshots/wire-1.2.yaml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY THIS FILE. See README.md to learn why.
+
 resolver: https://raw.githubusercontent.com/wireapp/wire-server/develop/snapshots/wire-1.1.yaml
 name: wire-1.2
 

--- a/snapshots/wire-1.2.yaml
+++ b/snapshots/wire-1.2.yaml
@@ -1,6 +1,6 @@
-resolver: wire-1.1.yaml
+resolver: https://raw.githubusercontent.com/wireapp/wire-server/develop/snapshots/wire-1.1.yaml
 name: wire-1.2
 
 packages:
-- cql-io-1.1.0  # the MR in wire-1.0.yaml has been  released on hackage.
+- cql-io-1.1.0  # the MR in wire-1.0.yaml has been released on hackage.
 - cql-io-tinylog-0.1.0


### PR DESCRIPTION
Now wire-1.2.yaml contains a link to wire-1.1.yaml, and not just a relative path.

Without this PR we can't use wire-server snapshots in other repos, because Stack is not smart enough to fetch snapshots based on relative paths.

From this point on, the resolver/snapshot files *actually* have to be immutable.

This PR will cause another "copying precompiled package" cascade. @fisx sorry!