### PR TITLE
Fix: user deletion via scim

### DIFF
--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -757,7 +757,7 @@ deleteAccount account@(accountUser -> user) = do
     -- Free unique keys
     for_ (userEmail  user) $ deleteKey . userEmailKey
     for_ (userPhone  user) $ deleteKey . userPhoneKey
-    for_ (userHandle user) freeHandle
+    for_ (userHandle user) $ freeHandle user
     -- Wipe data
     Data.clearProperties uid
     tombstone <- mkTombstone

--- a/services/brig/src/Brig/Unique.hs
+++ b/services/brig/src/Brig/Unique.hs
@@ -52,9 +52,12 @@ withClaim u v t io = do
     cql = "UPDATE unique_claims USING TTL ? SET claims = claims + ? WHERE value = ?"
 
 deleteClaim :: MonadClient m
-    => Id a
-    -> Text
-    -> Timeout
+    => Id a     -- ^ The 'Id' associated with the claim.
+    -> Text     -- ^ The value on which to acquire the claim.
+    -> Timeout  -- ^ The minimum timeout (i.e. duration) of the rest of the claim.  (Each
+                --   claim can have more than one claimer (even though this is a feature we
+                --   never use), so removing a claim is an update operation on the database.
+                --   Therefore, we reset the TTL the same way we reset it in 'withClaim'.)
     -> m ()
 deleteClaim u v t = do
     let ttl = max minTtl (fromIntegral (t #> Second))

--- a/services/brig/test/integration/API/User/Handles.hs
+++ b/services/brig/test/integration/API/User/Handles.hs
@@ -85,18 +85,20 @@ testHandleUpdate brig cannon = do
     Search.assertCan'tFind brig uid2 uid hdl
     Search.assertCanFind   brig uid2 uid hdl2
 
-    -- Other users can immediately claim the old handle (the claim is removed with the old
-    -- handle).
+    -- Other users can immediately claim the old handle (the claim of the old handle is
+    -- removed).
     put (brig . path "/self/handle" . contentJson . zUser uid2 . zConn "c" . body update) !!! do
         const 200 === statusCode
 
     -- The old handle can be claimed again immediately by the user who previously
     -- owned it (since the claim is either still active but his own, or expired).
+    -- make sure 'hdl' is not used by 'uid2' already.
     hdl3 <- randomHandle
     let update3 = RequestBodyLBS . encode $ HandleUpdate hdl3
     put (brig . path "/self/handle" . contentJson . zUser uid2 . zConn "c" . body update3) !!! do
         const 200 === statusCode
-    put (brig . path "/self/handle" . contentJson . zUser uid . zConn "c" . body update) !!!
+    -- now 'uid2' takes 'hld' back.
+    put (brig . path "/self/handle" . contentJson . zUser uid2 . zConn "c" . body update) !!!
         const 200 === statusCode
 
 testHandleRace :: Brig -> Http ()

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -9,6 +9,7 @@ module Spar.App
   , wrapMonadClientWithEnv
   , wrapMonadClient
   , verdictHandler
+  , getUser
   , insertUser
   , createUser, createUser_
   ) where

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -273,9 +273,9 @@ deleteBrigUser buid = do
   if
     | sCode < 300 -> pure ()
     | inRange (400, 499) sCode
-      -> throwSpar . SparBrigErrorWith (responseStatus resp) $ "failed to delete user"
-    | otherwise -> throwSpar . SparBrigError . cs
-      $ "delete user failed with status " <> show sCode
+      -> throwSpar $ SparBrigErrorWith (responseStatus resp) "failed to delete user"
+    | otherwise
+      -> throwSpar $ SparBrigError ("delete user failed with status " <> cs (show sCode))
 
 -- | Check that a user id exists on brig and has a team id.
 isTeamUser :: (HasCallStack, MonadSparToBrig m) => UserId -> m Bool

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -255,6 +255,8 @@ setBrigUserRichInfo buid richInfo = do
      | otherwise
        -> throwSpar . SparBrigError . cs $ "set richInfo failed with status " <> show sCode
 
+-- | At the time of writing this, @HEAD /users/handles/:uid@ does not use the 'UserId' for
+-- anything but authorization.
 checkHandleAvailable :: (HasCallStack, MonadSparToBrig m) => Handle -> UserId -> m Bool
 checkHandleAvailable hnd buid = do
   resp <- call

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -263,9 +263,9 @@ checkHandle hnd buid = do
     . header "Z-User" (toByteString' buid)
     . header "Z-Connection" ""
   let sCode = statusCode resp
-  if | sCode < 300
+  if | sCode == 404
        -> pure ()
-     | inRange (400, 499) sCode
+     | sCode < 500
        -> throwSpar . SparBrigErrorWith (responseStatus resp) $ "check handle failed"
      | otherwise
        -> throwSpar . SparBrigError . cs $ "check handle failed with status " <> show sCode

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -58,7 +58,6 @@ import Spar.App (Spar)
 import Spar.Scim.Types
 import Spar.Scim.Auth
 import Spar.Scim.User
-import Spar.Types
 
 import qualified SAML2.WebSSO as SAML
 
@@ -80,9 +79,9 @@ apiScim :: ServerT APIScim Spar
 apiScim = hoistScim (toServant (Scim.siteServer configuration))
      :<|> apiScimToken
   where
-    hoistScim = hoistServer (Proxy @(Scim.SiteAPI ScimToken ScimUserExtra))
+    hoistScim = hoistServer (Proxy @(Scim.SiteAPI SparTag))
                             (Scim.fromScimHandler fromError)
     fromError = throwError . SAML.CustomServant . Scim.scimToServantErr
 
-instance Scim.Group.GroupDB Spar where
+instance Scim.Group.GroupDB SparTag Spar where
   -- TODO

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -38,12 +38,7 @@ import qualified Web.Scim.Handler                 as Scim
 import qualified Web.Scim.Schema.Error            as Scim
 
 -- | An instance that tells @hscim@ how authentication should be done for SCIM routes.
-instance Scim.Class.Auth.AuthDB Spar where
-    -- To authenticate, you need to provide a 'ScimToken'
-    type AuthData Spar = ScimToken
-    -- The result of authentication (passed to our handlers) is 'ScimTokenInfo'
-    type AuthInfo Spar = ScimTokenInfo
-
+instance Scim.Class.Auth.AuthDB SparTag Spar where
     -- Validate and resolve a given token
     authCheck :: Maybe ScimToken -> Scim.ScimHandler Spar ScimTokenInfo
     authCheck Nothing =

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -38,8 +38,11 @@ import Spar.Types
 import qualified Data.HashMap.Strict              as HM
 import qualified Data.Text                        as T
 import qualified SAML2.WebSSO                     as SAML
-import qualified Web.Scim.Schema.User             as Scim.User
+import qualified Web.Scim.Class.Auth              as Scim.Auth
+import qualified Web.Scim.Class.Group             as Scim.Group
+import qualified Web.Scim.Class.User              as Scim.User
 import qualified Web.Scim.Schema.Schema           as Scim
+import qualified Web.Scim.Schema.User             as Scim.User
 import qualified Web.Scim.Server                  as Scim
 
 
@@ -55,6 +58,59 @@ userExtraURN = "urn:wire:scim:schemas:profile:1.0"
 
 ----------------------------------------------------------------------------
 -- @hscim@ extensions and wrappers
+
+data SparTag
+
+instance Scim.User.UserTypes SparTag where
+  type UserId SparTag = UserId
+  type UserExtra SparTag = ScimUserExtra
+
+instance Scim.Group.GroupTypes SparTag where
+  type GroupId SparTag = ()
+
+instance Scim.Auth.AuthTypes SparTag where
+  type AuthData SparTag = ScimToken
+  type AuthInfo SparTag = ScimTokenInfo
+
+
+-- | Wrapper to work around complications with type synonym family application in instances.
+--
+-- Background: 'SparTag' is used to instantiate the open type families in the classes
+-- @Scim.UserTypes@, @Scim.GroupTypes@, @Scim.AuthTypes@.  Those type families are not
+-- injective, and in general they shouldn't be: it should be possible to map two tags to
+-- different user ids, but the same extra user info.  This makes the type of the 'Cql'
+-- instance for @'Scim.StoredUser' tag@ undecidable: if the type checker encounters a
+-- constraint that gives it the user id and extra info, it can't compute the tag from that to
+-- look up the instance.
+--
+-- Possible solutions:
+--
+-- * what we're doing here: wrap the type synonyms we can't instantiate into newtypes in the
+--   code using hscim.
+
+-- * do not instantiate the type synonym, but its value (in this case
+--   @Web.Scim.Schema.Meta.WithMeta (Web.Scim.Schema.Common.WithId (Id U) (Scim.User tag))@
+--
+-- * Use newtypes instead type in hscim.  This will carry around the tag as a data type rather
+--   than applying it, which in turn will enable ghc to type-check instances like @Cql
+--   (Scim.StoredUser tag)@.
+--
+-- * make the type classes parametric in not only the tag, but also all the values of the type
+--   families, and add functional dependencies, like this: @class UserInfo tag uid extrainfo |
+--   (uid, extrainfo) -> tag, tag -> (uid, extrainfo)@.  this will make writing the instances
+--   only a little more awkward, but the rest of the code should change very little, as long
+--   as we just apply the type families rather than explicitly imposing the class constraints.
+--
+-- * given a lot of time: extend ghc with something vaguely similar to @AllowAmbigiousTypes@,
+--   where the instance typechecks, and non-injectivity errors are raised when checking the
+--   constraint that "calls" the instance.  :)
+newtype WrappedScimStoredUser tag = WrappedScimStoredUser
+  { fromWrappedScimStoredUser :: Scim.User.StoredUser tag }
+
+-- | See 'WrappedScimStoredUser'.
+newtype WrappedScimUser tag = WrappedScimUser
+  { fromWrappedScimUser :: Scim.User.User tag }
+
 
 -- | Extra Wire-specific data contained in a SCIM user profile.
 data ScimUserExtra = ScimUserExtra
@@ -105,7 +161,7 @@ parseRichInfo v =
 -- the 'Scim.User.User' and b) be valid in regard to our own user schema requirements (only
 -- certain characters allowed in handles, etc).
 data ValidScimUser = ValidScimUser
-  { _vsuUser          :: Scim.User.User ScimUserExtra
+  { _vsuUser          :: Scim.User.User SparTag
 
     -- SAML SSO
   , _vsuSAMLUserRef   :: SAML.UserRef
@@ -189,7 +245,7 @@ instance ToJSON ScimTokenList where
 -- Servant APIs
 
 type APIScim
-     = OmitDocs :> "v2" :> Scim.SiteAPI ScimToken ScimUserExtra
+     = OmitDocs :> "v2" :> Scim.SiteAPI SparTag
   :<|> "auth-tokens" :> APIScimToken
 
 type APIScimToken

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -447,7 +447,8 @@ assertUserRefUnused userRef = do
     throwError Scim.conflict {Scim.detail = Just "externalId is already taken"}
 
 {-|
-Check that the UserRef is not taken *by another user*.
+Check that the UserRef is not taken any user other than the passed 'UserId'
+(it is also acceptable if it is not taken by anybody).
 
 ASSUMPTION: every scim user has a 'SAML.UserRef', and the `SAML.NameID` in it corresponds
 to a single `externalId`.
@@ -459,7 +460,7 @@ assertUserRefNotUsedElsewhere userRef wireUserId = do
     throwError Scim.conflict {Scim.detail = Just "externalId does not match UserId"}
 
 assertHandleUnused :: Handle -> UserId -> Scim.ScimHandler Spar ()
-assertHandleUnused = assertHandleUnused' "externalId is already taken"
+assertHandleUnused = assertHandleUnused' "userName is already taken"
 
 assertHandleUnused' :: Text -> Handle -> UserId -> Scim.ScimHandler Spar ()
 assertHandleUnused' msg hndl uid = lift (Brig.checkHandleAvailable hndl uid) >>= \case
@@ -470,7 +471,7 @@ assertHandleNotUsedElsewhere :: Handle -> UserId -> Scim.ScimHandler Spar ()
 assertHandleNotUsedElsewhere hndl uid = do
   musr <- lift $ Brig.getBrigUser uid
   unless ((userHandle =<< musr) == Just hndl) $
-    assertHandleUnused' "externalId does not match UserId" hndl uid
+    assertHandleUnused' "userName does not match UserId" hndl uid
 
 {- TODO: might be useful later.
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -335,7 +335,7 @@ toScimStoredUser' (SAML.Time now) baseuri uid usr =
       { Scim.resourceType = Scim.UserResource
       , Scim.created = now
       , Scim.lastModified = now
-      , Scim.version = calculateVersion (idToText uid) usr
+      , Scim.version = calculateVersion uid usr
         -- TODO: it looks like we need to add this to the HTTP header.
         -- https://tools.ietf.org/html/rfc7644#section-3.14
       , Scim.location = Scim.URI . mkLocation $ "/Users/" <> cs (idToText uid)
@@ -360,7 +360,7 @@ updScimStoredUser' (SAML.Time moddate) usr (Scim.WithMeta meta (Scim.WithId scim
   where
     meta' = meta
       { Scim.lastModified = moddate
-      , Scim.version = calculateVersion (idToText scimuid) usr
+      , Scim.version = calculateVersion scimuid usr
       }
 
 
@@ -409,13 +409,13 @@ deleteScimUser ScimTokenInfo{stiTeam} uid = do
 -- JSON rendering will remain stable between releases, and therefore we can't satisfy the
 -- requirements of strong ETags ("same resources have the same version").
 calculateVersion
-  :: Text               -- ^ User ID
+  :: UserId
   -> Scim.User SparTag
   -> Scim.ETag
-calculateVersion uidText usr = Scim.Weak (Text.pack (show h))
+calculateVersion uid usr = Scim.Weak (Text.pack (show h))
   where
     h :: Digest SHA256
-    h = hashlazy (Aeson.encode (Scim.WithId uidText usr))
+    h = hashlazy (Aeson.encode (Scim.WithId uid usr))
 
 {-|
 Check that the UserRef is not taken.

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -115,34 +115,8 @@ instance Scim.UserDB SparTag Spar where
   patchUser = error "not implemented"
 
   deleteUser :: ScimTokenInfo -> UserId -> Scim.ScimHandler Spar ()
-  deleteUser ScimTokenInfo{stiTeam} uid = do
-    let uidtxt = idToText uid
-    mbBrigUser <- lift (Intra.Brig.getBrigUser uid)
-    case mbBrigUser of
-      Nothing -> do
-        -- double-deletion gets you a 404.
-        throwError $ Scim.notFound "user" uidtxt
-      Just brigUser -> do
-        -- FUTUREWORK: currently it's impossible to delete the last available team owner via SCIM
-        -- (because that owner won't be managed by SCIM in the first place), but if it ever becomes
-        -- possible, we should do a check here and prohibit it.
-        unless (userTeam brigUser == Just stiTeam) $
-        -- users from other teams get you a 404.
-          throwError $ Scim.notFound "user" uidtxt
-        ssoId <- maybe (logThenServerError $ "no userSSOId for user " <> cs uidtxt)
-                       pure
-                       $ Brig.userSSOId brigUser
-        uref <- either logThenServerError pure $ Intra.Brig.fromUserSSOId ssoId
-        lift . wrapMonadClient $ Data.deleteSAMLUser uref
-        lift . wrapMonadClient $ Data.deleteScimUser uid
-        lift $ Intra.Brig.deleteBrigUser uid
-        return ()
-          where
-            logThenServerError :: String -> Scim.ScimHandler Spar b
-            logThenServerError err = do
-              logger <- asks sparCtxLogger
-              Log.err logger $ Log.msg err
-              throwError $ Scim.serverError "Server Error"
+  deleteUser = deleteScimUser
+
 
 ----------------------------------------------------------------------------
 -- User creation and validation
@@ -396,6 +370,38 @@ updScimStoredUser' (SAML.Time moddate) usr (Scim.WithMeta meta (Scim.WithId scim
       { Scim.lastModified = moddate
       , Scim.version = calculateVersion (idToText scimuid) usr
       }
+
+
+deleteScimUser
+  :: ScimTokenInfo -> UserId -> ExceptT Scim.ScimError Spar ()
+deleteScimUser ScimTokenInfo{stiTeam} uid = do
+    mbBrigUser <- lift (Intra.Brig.getBrigUser uid)
+    case mbBrigUser of
+      Nothing -> do
+        -- double-deletion gets you a 404.
+        throwError $ Scim.notFound "user" (idToText uid)
+      Just brigUser -> do
+        -- FUTUREWORK: currently it's impossible to delete the last available team owner via SCIM
+        -- (because that owner won't be managed by SCIM in the first place), but if it ever becomes
+        -- possible, we should do a check here and prohibit it.
+        unless (userTeam brigUser == Just stiTeam) $
+        -- users from other teams get you a 404.
+          throwError $ Scim.notFound "user" (idToText uid)
+        ssoId <- maybe (logThenServerError $ "no userSSOId for user " <> cs (idToText uid))
+                       pure
+                       $ Brig.userSSOId brigUser
+        uref <- either logThenServerError pure $ Intra.Brig.fromUserSSOId ssoId
+        lift . wrapMonadClient $ Data.deleteSAMLUser uref
+        lift . wrapMonadClient $ Data.deleteScimUser uid
+        lift $ Intra.Brig.deleteBrigUser uid
+        return ()
+  where
+    logThenServerError :: String -> Scim.ScimHandler Spar b
+    logThenServerError err = do
+      logger <- asks sparCtxLogger
+      Log.err logger $ Log.msg err
+      throwError $ Scim.serverError "Server Error"
+
 
 ----------------------------------------------------------------------------
 -- Utilities

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -34,7 +34,7 @@ import Data.String.Conversions
 import Galley.Types.Teams    as Galley
 import Network.URI
 
-import Spar.App (Spar, Env, wrapMonadClient, sparCtxOpts, sparCtxLogger, createUser_, wrapMonadClient)
+import Spar.App (Spar, Env, wrapMonadClient, sparCtxOpts, sparCtxLogger, createUser_, wrapMonadClient, getUser)
 import Spar.Intra.Galley
 import Spar.Scim.Types
 import Spar.Scim.Auth ()
@@ -442,7 +442,7 @@ to a single `externalId`.
 -}
 assertUserRefUnused :: SAML.UserRef -> Scim.ScimHandler Spar ()
 assertUserRefUnused userRef = do
-  mExistingUserId <- lift $ wrapMonadClient (Data.getSAMLUser userRef)
+  mExistingUserId <- lift $ getUser userRef
   unless (isNothing mExistingUserId) $
     throwError Scim.conflict {Scim.detail = Just "externalId is already taken"}
 
@@ -454,7 +454,7 @@ to a single `externalId`.
 -}
 assertUserRefNotUsedElsewhere :: SAML.UserRef -> UserId -> Scim.ScimHandler Spar ()
 assertUserRefNotUsedElsewhere userRef wireUserId = do
-  mExistingUserId <- lift $ wrapMonadClient (Data.getSAMLUser userRef)
+  mExistingUserId <- lift $ getUser userRef
   unless (mExistingUserId `elem` [Nothing, Just wireUserId]) $ do
     throwError Scim.conflict {Scim.detail = Just "externalId does not match UserId"}
 

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -112,7 +112,7 @@ instance Scim.UserDB SparTag Spar where
             -> Scim.UserId SparTag
             -> Value
             -> Scim.ScimHandler Spar (Scim.StoredUser SparTag)
-  patchUser = error "not implemented"
+  patchUser _ _ _ = throwError $ Scim.notFound "patch user" "not implemented"
 
   deleteUser :: ScimTokenInfo -> UserId -> Scim.ScimHandler Spar ()
   deleteUser = deleteScimUser

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -209,12 +209,12 @@ mkUserRef
   -> Maybe Text
   -> m SAML.UserRef
 mkUserRef idp extid  = case extid of
-        Just subjectTxt -> do
-            let issuer = idp ^. SAML.idpMetadata . SAML.edIssuer
-            subject <- validateSubject subjectTxt
-            pure $ SAML.UserRef issuer subject
-        Nothing -> throwError $ Scim.badRequest Scim.InvalidValue
-            (Just "externalId is required for SAML users")
+    Just subjectTxt -> do
+        let issuer = idp ^. SAML.idpMetadata . SAML.edIssuer
+        subject <- validateSubject subjectTxt
+        pure $ SAML.UserRef issuer subject
+    Nothing -> throwError $ Scim.badRequest Scim.InvalidValue
+        (Just "externalId is required for SAML users")
   where
     -- Validate a subject ID (@externalId@).
     validateSubject :: Text -> m SAML.NameID

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -19,6 +19,7 @@ module Spar.Scim.User
     ( -- * Internals (for testing)
       validateScimUser'
     , toScimStoredUser'
+    , mkUserRef
     ) where
 
 import Imports

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -365,7 +365,7 @@ updScimStoredUser' (SAML.Time moddate) usr (Scim.WithMeta meta (Scim.WithId scim
 
 
 deleteScimUser
-  :: ScimTokenInfo -> UserId -> ExceptT Scim.ScimError Spar ()
+  :: ScimTokenInfo -> UserId -> Scim.ScimHandler Spar ()
 deleteScimUser ScimTokenInfo{stiTeam} uid = do
     mbBrigUser <- lift (Intra.Brig.getBrigUser uid)
     case mbBrigUser of

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -7,7 +7,6 @@ import Cassandra
 import Control.Lens
 import Control.Monad.Except
 import Data.Kind (Type)
-import Data.Text (unpack)
 import Data.Typeable
 import Data.UUID as UUID
 import Data.UUID.V4 as UUID
@@ -241,7 +240,7 @@ testDeleteTeam = it "cleans up all the right tables after deletion" $ do
     storedUser1 <- createUser tok user1
     storedUser2 <- createUser tok user2
     -- Resolve the users' SSO ids
-    let getUid = read . unpack . Scim.Common.id . Scim.Meta.thing
+    let getUid = Scim.Common.id . Scim.Meta.thing
     ssoid1 <- getSsoidViaSelf (getUid storedUser1)
     ssoid2 <- getSsoidViaSelf (getUid storedUser2)
     -- Delete the team

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -123,11 +123,11 @@ spec = do
           uid  <- nextWireId
           do
             ()   <- runSparCass $ Data.insertSAMLUser uref uid
-            muid <- runSparCass (Data.getSAMLUser uref) `eventually` isJust
+            muid <- runSparCass (Data.getSAMLUser uref) `aFewTimes` isJust
             liftIO $ muid `shouldBe` Just uid
           do
             ()   <- runSparCass $ Data.deleteSAMLUser uref
-            muid <- runSparCass (Data.getSAMLUser uref) `eventually` isNothing
+            muid <- runSparCass (Data.getSAMLUser uref) `aFewTimes` isNothing
             liftIO $ muid `shouldBe` Nothing
 
 

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -123,7 +123,7 @@ spec = do
           uid  <- nextWireId
           do
             ()   <- runSparCass $ Data.insertSAMLUser uref uid
-            muid <- runSparCass (Data.getSAMLUser uref) `aFewTimes` isJust
+            muid <- runSparCass (Data.getSAMLUser uref)
             liftIO $ muid `shouldBe` Just uid
           do
             ()   <- runSparCass $ Data.deleteSAMLUser uref

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -117,6 +117,19 @@ spec = do
           muid <- runSparCass $ Data.getSAMLUser uref
           liftIO $ muid `shouldBe` Just uid'
 
+      describe "DELETE" $ do
+        it "works" $ do
+          uref <- nextUserRef
+          uid  <- nextWireId
+          do
+            ()   <- runSparCass $ Data.insertSAMLUser uref uid
+            muid <- runSparCass (Data.getSAMLUser uref) `eventually` isJust
+            liftIO $ muid `shouldBe` Just uid
+          do
+            ()   <- runSparCass $ Data.deleteSAMLUser uref
+            muid <- runSparCass (Data.getSAMLUser uref) `eventually` isNothing
+            liftIO $ muid `shouldBe` Nothing
+
 
     describe "BindCookie" $ do
       let mkcky :: TestSpar SetBindCookie

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -222,7 +222,7 @@ testRichInfo = do
     probeUser (scimUserId scimStoredUser) richInfo'
 
 -- | Create a user implicitly via saml login; remove it via brig leaving a dangling entry in
--- @spar.user@; create it via scim.  This should to work despite the dangling database entry.
+-- @spar.user@; create it via scim.  This should work despite the dangling database entry.
 testScimCreateVsUserRef :: HasCallStack => TestSpar ()
 testScimCreateVsUserRef = do
     (tok, (_ownerid, _teamid, idp)) <- registerIdPAndScimToken

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -532,14 +532,14 @@ testUpdateSameHandle = do
 testUpdateUserRefIndex :: HasCallStack => TestSpar ()
 testUpdateUserRefIndex = do
     (tok, (_, _, idp)) <- registerIdPAndScimToken
-    -- Create a user via SCIM
-    user <- randomScimUser
-    storedUser <- createUser tok user
-    let userid = scimUserId storedUser
-    uref <- either (error . show) pure $ mkUserRef idp (Scim.User.externalId user)
-
     let checkUpdateUserRef :: Bool -> TestSpar ()
         checkUpdateUserRef changeUserRef = do
+            -- Create a user via SCIM
+            user <- randomScimUser
+            storedUser <- createUser tok user
+            let userid = scimUserId storedUser
+            uref <- either (error . show) pure $ mkUserRef idp (Scim.User.externalId user)
+
             -- Overwrite the user with another randomly-generated user
             user' <- let upd u = if changeUserRef
                            then u

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -535,11 +535,11 @@ specDeleteUser = do
                 !!! const 204 === statusCode
 
             brigUser :: Maybe User
-              <- aFewTimes (runSpar $ Intra.getBrigUser uid) isNothing
+              <- aFewTimes (runSpar $ Intra.getBrigUser uid) isJust
             samlUser :: Maybe UserId
-              <- aFewTimes (getUserIdViaRef' uref) isNothing
+              <- aFewTimes (getUserIdViaRef' uref) isJust
             scimUser :: Maybe (ScimC.User.StoredUser SparTag)
-              <- aFewTimes (getScimUser uid) isNothing
+              <- aFewTimes (getScimUser uid) isJust
 
             liftIO $ (brigUser, samlUser, scimUser)
               `shouldBe` (Nothing, Nothing, Nothing)
@@ -554,7 +554,7 @@ specDeleteUser = do
             -- Expect first call to succeed
             deleteUser_ (Just tok) (Just uid) spar
                 !!! const 204 === statusCode
-            -- Subsequent calls will return 404 aFewTimes
+            -- Subsequent calls will return 404 eventually
             aFewTimes (deleteUser_ (Just tok) (Just uid) spar) ((== 404) . statusCode)
                 !!! const 404 === statusCode
 

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -535,11 +535,11 @@ specDeleteUser = do
                 !!! const 204 === statusCode
 
             brigUser :: Maybe User
-              <- eventually (runSpar $ Intra.getBrigUser uid) isNothing
+              <- aFewTimes (runSpar $ Intra.getBrigUser uid) isNothing
             samlUser :: Maybe UserId
-              <- eventually (getUserIdViaRef' uref) isNothing
+              <- aFewTimes (getUserIdViaRef' uref) isNothing
             scimUser :: Maybe (ScimC.User.StoredUser SparTag)
-              <- eventually (getScimUser uid) isNothing
+              <- aFewTimes (getScimUser uid) isNothing
 
             liftIO $ (brigUser, samlUser, scimUser)
               `shouldBe` (Nothing, Nothing, Nothing)
@@ -554,8 +554,8 @@ specDeleteUser = do
             -- Expect first call to succeed
             deleteUser_ (Just tok) (Just uid) spar
                 !!! const 204 === statusCode
-            -- Subsequent calls will return 404 eventually
-            eventually (deleteUser_ (Just tok) (Just uid) spar) ((== 404) . statusCode)
+            -- Subsequent calls will return 404 aFewTimes
+            aFewTimes (deleteUser_ (Just tok) (Just uid) spar) ((== 404) . statusCode)
                 !!! const 404 === statusCode
 
         it "should free externalId and everything else in the scim user for re-use" $ do
@@ -566,7 +566,7 @@ specDeleteUser = do
             spar <- view teSpar
             deleteUser_ (Just tok) (Just uid) spar
                 !!! const 204 === statusCode
-            eventually (createUser_ (Just tok) user spar) ((== 201) . statusCode)
+            aFewTimes (createUser_ (Just tok) user spar) ((== 201) . statusCode)
                 !!! const 201 === statusCode
 
         -- FUTUREWORK: hscim has the the following test.  we should probably go through all

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -77,7 +77,7 @@ testCreateUser = do
         . path "/self"
         . expect2xx
         )
-    brigUser `userShouldMatch` scimStoredUser
+    brigUser `userShouldMatch` WrappedScimStoredUser scimStoredUser
 
 -- | Test that @externalId@ (for SSO login) is required when creating a user.
 testExternalIdIsRequired :: TestSpar ()
@@ -181,7 +181,7 @@ testRichInfo = do
     let -- validate response
         checkStoredUser
             :: HasCallStack
-            => Scim.UserC.StoredUser ScimUserExtra -> RichInfo -> TestSpar ()
+            => Scim.UserC.StoredUser SparTag -> RichInfo -> TestSpar ()
         checkStoredUser storedUser rinf = liftIO $ do
             (Scim.User.extra . Scim.value . Scim.thing) storedUser
                 `shouldBe` (ScimUserExtra rinf)
@@ -538,7 +538,7 @@ specDeleteUser = do
               <- eventually (runSpar $ Intra.getBrigUser uid) isNothing
             samlUser :: Maybe UserId
               <- eventually (getUserIdViaRef' uref) isNothing
-            scimUser :: Maybe (ScimC.User.StoredUser ScimUserExtra)
+            scimUser :: Maybe (ScimC.User.StoredUser SparTag)
               <- eventually (getScimUser uid) isNothing
 
             liftIO $ (brigUser, samlUser, scimUser)

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -535,11 +535,11 @@ specDeleteUser = do
                 !!! const 204 === statusCode
 
             brigUser :: Maybe User
-              <- aFewTimes (runSpar $ Intra.getBrigUser uid) isJust
+              <- aFewTimes (runSpar $ Intra.getBrigUser uid) isNothing
             samlUser :: Maybe UserId
-              <- aFewTimes (getUserIdViaRef' uref) isJust
+              <- aFewTimes (getUserIdViaRef' uref) isNothing
             scimUser :: Maybe (ScimC.User.StoredUser SparTag)
-              <- aFewTimes (getScimUser uid) isJust
+              <- aFewTimes (getScimUser uid) isNothing
 
             liftIO $ (brigUser, samlUser, scimUser)
               `shouldBe` (Nothing, Nothing, Nothing)

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -240,7 +240,7 @@ testScimCreateVsUserRef = do
                                            -- are deleted there.  we need to work around this
                                            -- fact for now.  (if the test fails here, this may
                                            -- mean that you fixed the behavior and can
-                                           -- simplify this test.)
+                                           -- change this to 'isNothing'.)
 
     storedusr :: Scim.UserC.StoredUser SparTag
         <- do

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -783,6 +783,6 @@ getUserIdViaRef' uref = do
 -- | FUTUREWORK: arguably this function should move to Util.Scim, but it also is related to
 -- the other lookups above into the various user tables in the various cassandras.  we should
 -- probably clean this up a little, and also pick better names for everything.
-getScimUser :: HasCallStack => UserId -> TestSpar (Maybe (ScimC.User.StoredUser ScimUserExtra))
+getScimUser :: HasCallStack => UserId -> TestSpar (Maybe (ScimC.User.StoredUser SparTag))
 getScimUser uid = do
   eventually (view teCql >>= \cql -> runClient cql $ Data.getScimUser uid) isNothing

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -765,7 +765,7 @@ getSsoidViaSelf uid = maybe (error "not found") pure =<< getSsoidViaSelf' uid
 
 getSsoidViaSelf' :: HasCallStack => UserId -> TestSpar (Maybe UserSSOId)
 getSsoidViaSelf' uid = do
-  musr <- runSpar $ Intra.getBrigUser uid
+  musr <- aFewTimes (runSpar $ Intra.getBrigUser uid) isJust
   pure $ case userIdentity =<< musr of
             Just (SSOIdentity ssoid _ _) -> Just ssoid
             Just (FullIdentity _ _)  -> Nothing
@@ -778,11 +778,11 @@ getUserIdViaRef uref = maybe (error "not found") pure =<< getUserIdViaRef' uref
 
 getUserIdViaRef' :: HasCallStack => UserRef -> TestSpar (Maybe UserId)
 getUserIdViaRef' uref = do
-  aFewTimes (view teCql >>= \cql -> runClient cql $ Data.getSAMLUser uref) isNothing
+  aFewTimes (view teCql >>= \cql -> runClient cql $ Data.getSAMLUser uref) isJust
 
 -- | FUTUREWORK: arguably this function should move to Util.Scim, but it also is related to
 -- the other lookups above into the various user tables in the various cassandras.  we should
 -- probably clean this up a little, and also pick better names for everything.
 getScimUser :: HasCallStack => UserId -> TestSpar (Maybe (ScimC.User.StoredUser SparTag))
 getScimUser uid = do
-  aFewTimes (view teCql >>= \cql -> runClient cql $ Data.getScimUser uid) isNothing
+  aFewTimes (view teCql >>= \cql -> runClient cql $ Data.getScimUser uid) isJust

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -215,7 +215,7 @@ aFewTimes :: TestSpar a -> (a -> Bool) -> TestSpar a
 aFewTimes action good = do
     env <- ask
     liftIO $ retrying
-        (exponentialBackoff 50 <> limitRetries 15)
+        (exponentialBackoff 1000 <> limitRetries 10)
         (\_ -> pure . not . good)
         (\_ -> action `runReaderT` env)
 

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -210,7 +210,8 @@ pendingWith = liftIO . Test.Hspec.pendingWith
 
 
 -- | Run a probe several times, until a "good" value materializes or until patience runs out.
--- The result may be good or not, depending on whether we run out of time.
+-- If all retries were unsuccessful, 'aFewTimes' will return the last obtained value, even
+-- if it does not satisfy the predicate.
 aFewTimes :: TestSpar a -> (a -> Bool) -> TestSpar a
 aFewTimes action good = do
     env <- ask

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -209,8 +209,8 @@ pendingWith :: (HasCallStack, MonadIO m) => String -> m ()
 pendingWith = liftIO . Test.Hspec.pendingWith
 
 
--- | Run a probe a couple of times, until a "good" value materializes or until patience runs
--- out.  The result may be good or not, depending on whether we run out of time.
+-- | Run a probe several times, until a "good" value materializes or until patience runs out.
+-- The result may be good or not, depending on whether we run out of time.
 aFewTimes :: TestSpar a -> (a -> Bool) -> TestSpar a
 aFewTimes action good = do
     env <- ask

--- a/services/spar/test/Test/Spar/ScimSpec.hs
+++ b/services/spar/test/Test/Spar/ScimSpec.hs
@@ -32,7 +32,7 @@ import qualified Web.Scim.Schema.User.Name as ScimN
 spec :: Spec
 spec = describe "toScimStoredUser'" $ do
   it "works" $ do
-    let usr :: Scim.User ScimUserExtra
+    let usr :: Scim.User SparTag
         usr = Scim.User
           { Scim.schemas = [Scim.User20,
                             Scim.CustomSchema "urn:wire:scim:schemas:profile:1.0"]
@@ -80,7 +80,7 @@ spec = describe "toScimStoredUser'" $ do
           URI.ByteString.parseURI laxURIParserOptions "https://127.0.0.1/scim/v2/"
         uid = Id . fromJust . UUID.fromText $ "90b5ee1c-088e-11e9-9a16-73f80f483813"
 
-        result :: ScimC.StoredUser ScimUserExtra
+        result :: ScimC.StoredUser SparTag
         result = toScimStoredUser' now' baseuri uid usr
 
     Scim.meta result `shouldBe` meta

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,7 @@ extra-deps:
 - git: https://github.com/wireapp/saml2-web-sso
   commit: e3aa52ac8637c168c122ad3e0eda02a7759dd56b    # master (Mar 20, 2019)
 - git: https://github.com/wireapp/hscim
-  commit: b2ddde040426d332a2eddcddb00e81ffb1144a90    # master (Mar 13, 2019)
+  commit: 6b98b894c127eed4a5bde646ebf20febcfa656fa    # master (Apr 2, 2019)
 - git: https://gitlab.com/fisx/tinylog
   commit: fd7155aaf6f090f48004a8f7857ce9d3cb4f9417    # https://gitlab.com/twittner/tinylog/merge_requests/6
 


### PR DESCRIPTION
The new tests fail thusly:

```
Failures:

  test-integration/Test/Spar/Scim/UserSpec.hs:543:22: 
  1) Spar.Scim.User, DELETE /Users/:id, should delete user from brig, spar.scim_user, spar.user
       expected: (Nothing,Nothing,Nothing)
        but got: (Just (User {userId = 3eb69525-b292-44a7-bba3-b33af69733a2, userIdentity = Just (SSOIdentity (UserSSOId {userSSOIdTenant = "<Issuer xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:samla=\"urn:oasis:names:tc:SAML:2.0:assertion\" xmlns:samlm=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\">https://issuer.net/_802b24ec-0542-4ff5-bd82-b688478b4272</Issuer>", userSSOIdSubject = "<NameID xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:samla=\"urn:oasis:names:tc:SAML:2.0:assertion\" xmlns:samlm=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\">scimuser_extid_8974660</NameID>"}) Nothing Nothing), userName = Name {fromName = "Scim User #8974660"}, userPict = Pict {fromPict = []}, userAssets = [], userAccentId = ColourId {fromColourId = 0}, userDeleted = False, userLocale = en, userService = Nothing, userHandle = Just (Handle {fromHandle = "scimuser_8974660"}), userExpire = Nothing, userTeam = Just 189f6570-3ef1-4a91-b3e1-a57e71f4453e, userManagedBy = ManagedByScim}),Nothing,Nothing)

  To rerun use: --match "/Spar.Scim.User/DELETE /Users/:id/should delete user from brig, spar.scim_user, spar.user/"

  test-integration/Test/Spar/Scim/UserSpec.hs:568:13: 
  2) Spar.Scim.User, DELETE /Users/:id, should free externalId and everything else in the scim user for re-use
       uncaught exception: ErrorCall
       Assertions failed:
        1: 201 =/= 409

       Response was:

       Response {responseStatus = Status {statusCode = 409, statusMessage = "bad-upstream"}, responseVersion = HTTP/1.1, responseHeaders = [("Transfer-Encoding","chunked"),("Date","Mon, 01 Apr 2019 11:00:55 GMT"),("Server","Warp/3.2.25"),("Cache-Control","no-cache, no-store"),("Pragma","no-cache")], responseBody = Just "{\"code\":409,\"message\":\"set handle failed\",\"label\":\"bad-upstream\"}", responseCookieJar = CJ {expose = []}, responseClose' = ResponseClose}
       CallStack (from HasCallStack):
         error, called at src/Bilge/Assert.hs:69:30 in bilge-0.22.0-6BuG2eVEmcLDQI4T1WJLQ7:Bilge.Assert
         <!!, called at src/Bilge/Assert.hs:86:19 in bilge-0.22.0-6BuG2eVEmcLDQI4T1WJLQ7:Bilge.Assert
         !!!, called at test-integration/Test/Spar/Scim/UserSpec.hs:568:13 in main:Test.Spar.Scim.UserSpec

  To rerun use: --match "/Spar.Scim.User/DELETE /Users/:id/should free externalId and everything else in the scim user for re-use/"

Randomized with seed 437206805

Finished in 35.6825 seconds
153 examples, 2 failures, 31 pending
```