### PR TITLE
Fix: saml implicit user creation does not choke on odd but legal names.

### DIFF
--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -101,6 +101,11 @@ createBrigUser suid (Id buid) teamid mbName managedBy = do
   uname :: Name <- case mbName of
     Just n -> pure n
     Nothing -> do
+      -- 1. use 'SAML.unsafeShowNameID' to get a 'Name'.  rationale: it does not need to be
+      --    unique.
+      -- 2. do not throw an error if it is too long, but truncate it.  rationale: it's an
+      --    unlikely scenario, and if it happens user names can be changed manually by the
+      --    user.
       let subject = suid ^. SAML.uidSubject
           uname   = Text.take 128 . SAML.unsafeShowNameID $ subject
       when (Text.null uname) . throwSpar . SparBadUserName $

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,7 +38,7 @@ packages:
 
 extra-deps:
 - git: https://github.com/wireapp/saml2-web-sso
-  commit: e3aa52ac8637c168c122ad3e0eda02a7759dd56b    # master (Mar 20, 2019)
+  commit: 68cc331da70c401cae114c24e6ba5373e1b5c190    # master (Apr 4, 2019)
 - git: https://github.com/wireapp/hscim
   commit: b2ddde040426d332a2eddcddb00e81ffb1144a90    # master (Mar 13, 2019)
 - git: https://gitlab.com/fisx/tinylog


### PR DESCRIPTION
Related: #701