### PR TITLE
Further sanitize metric names in prometheus

### DIFF
--- a/libs/metrics-core/src/Data/Metrics.hs
+++ b/libs/metrics-core/src/Data/Metrics.hs
@@ -99,6 +99,9 @@ metrics = liftIO $ Metrics
 --   This is to provide back compatibility with the previous collect-d metric names
 --   which often had paths and dot-separated names.
 --
+-- See the spec for valid prometheus names:
+-- https://prometheus.io/docs/concepts/data_model/
+--
 -- E.g. we sanitize a metric name like "net.resources._conversations_:cnv-members_:usr.DELETE.time.960"
 -- into: "net_resources_conversations_:cnv_members_:usr_delete_time_960"
 toInfo :: Path -> P.Info
@@ -115,7 +118,7 @@ toInfo (Path p) =
 
     -- | prometheus metric names must start with an alphabetic char or a ':'
     validStartingChar :: Char -> Bool
-    validStartingChar c = isAlpha c || c == ':'
+    validStartingChar c = isAlpha c || c `elem` ['_', ':']
 
     -- | Clean up paths which might end up with superfluous underscores
     -- e.g. a path like "path./user" might convert to "path__user"

--- a/libs/metrics-core/src/Data/Metrics.hs
+++ b/libs/metrics-core/src/Data/Metrics.hs
@@ -98,6 +98,9 @@ metrics = liftIO $ Metrics
 -- | Converts a CollectD style 'path' to a Metric name usable by prometheus
 --   This is to provide back compatibility with the previous collect-d metric names
 --   which often had paths and dot-separated names.
+--
+-- E.g. we sanitize a metric name like "net.resources._conversations_:cnv-members_:usr.DELETE.time.960"
+-- into: "net_resources_conversations_:cnv_members_:usr_delete_time_960"
 toInfo :: Path -> P.Info
 toInfo (Path p) =
     P.Info (p


### PR DESCRIPTION
Looks like a few metrics use `-` in them and I missed it the first time; this should solve that (and catch anything else I missed) 👍 

Example:

Sanitize the metric name 

```
net.resources._conversations_:cnv-members_:usr.DELETE.time.960
```

 into the valid name 
```
net_resources_conversations_:cnv_members_:usr_delete_time_960
```
