### PR TITLE
sed compat

### DIFF
--- a/deploy/services-demo/create_test_user.sh
+++ b/deploy/services-demo/create_test_user.sh
@@ -47,7 +47,7 @@ do
         -H'Content-type: application/json' \
         -d'{"email":"'$EMAIL'","password":"'$PASSWORD'","name":"demo"}')
 
-    UUID=$(echo "$CURL_OUT" | tail -1 | sed 's/.*"id":"\([0-9a-z-]\+\)".*/\1/')
+    UUID=$(echo "$CURL_OUT" | tail -1 | sed 's/.*\"id\":\"\([a-z0-9-]*\)\".*/\1/')
 
     if [ "$CSV" == "false" ]
         then echo -e "Succesfully created a user with email: "$EMAIL" and password: "$PASSWORD

--- a/deploy/services-demo/create_test_user.sh
+++ b/deploy/services-demo/create_test_user.sh
@@ -3,14 +3,14 @@
 set -e
 
 #
-# This bash script can be used to create an active user by using an internal 
+# This bash script can be used to create an active user by using an internal
 # brig endpoint. Note that this is not exposed over nginz and can only be used
 # if you have direct access to brig
 #
 
 # Usage:
-#   --csv			Output users in CSV format
-#   --count=INT		Generate several users (by default it's just one)
+#   --csv                      Output users in CSV format
+#   --count=INT                Generate several users (by default it's just one)
 
 CSV=false
 COUNT=1


### PR DESCRIPTION
On Linux, both variants have the same output, but on mac, allegedly only the second one works:

```sh
$ echo '{"email":"l8TVlbK0@example.com","locale":"en","accent_id":0,"picture":[],"name":"demo","id":"29740ea6-c54a-4a92-8fd5-3f8c5b05cdc3","assets":[]}' | sed 's/.*"id":"\([0-9a-z-]\+\)".*/\1/'
$ echo '{"email":"l8TVlbK0@example.com","locale":"en","accent_id":0,"picture":[],"name":"demo","id":"29740ea6-c54a-4a92-8fd5-3f8c5b05cdc3","assets":[]}' | sed 's/.*\"id\":\"\([a-z0-9-]*\)\".*/\1/'
```

See https://github.com/wireapp/wire-server/issues/712 (thanks @limengyu1990!)
