### PR TITLE
Allow displaying emails of users

### DIFF
--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -141,6 +141,9 @@ user = defineModel "User" $ do
         description "User ID"
     property "name" string' $
         description "Name"
+    property "email" string' $ do
+        description "Email"
+        optional
     property "assets" (array (ref asset)) $
         description "Profile assets"
     property "accent_id" int32' $ do

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -163,30 +163,6 @@ data User = User
     }
     deriving (Eq, Show)
 
-
--- | Configurations for whether to show a user's email to others.
-data EmailVisibility
-    = EmailVisibleIfOnTeam
-    {- ^ Anyone can see the email of someone who is on ANY team.
-         This may sound strange; but certain on-premise hosters have many different teams
-         and still want them to see each-other's emails.
-    -}
-    | EmailVisibleToSelf
-    -- ^ Show your email only to yourself
-    deriving (Eq, Show)
-
-instance FromJSON EmailVisibility where
-    parseJSON = withText "EmailVisibility" $ \case
-        "visible_if_on_team" -> pure EmailVisibleIfOnTeam
-        "visible_to_self"      -> pure EmailVisibleToSelf
-        _ -> fail
-            $  "unexpected value for EmailVisibility settings: "
-            <> "expected one of [visible_if_on_team, visible_to_self]"
-
-instance ToJSON EmailVisibility where
-    toJSON EmailVisibleIfOnTeam = "visible_if_on_team"
-    toJSON EmailVisibleToSelf     = "visible_to_self"
-
 userEmail :: User -> Maybe Email
 userEmail = emailIdentity <=< userIdentity
 

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -167,13 +167,12 @@ data User = User
 -- | Configurations for whether to show a user's email to others.
 data EmailVisibility
     = EmailVisibleIfOnTeam
-    {- ^ Anyone on a team can see the email of anyone else who is on a team.
-         Regardless of if they're on the SAME team.
+    {- ^ Anyone can see the email of someone who is on ANY team.
          This may sound strange; but certain on-premise hosters have many different teams
          and still want them to see each-other's emails.
     -}
     | EmailVisibleToSelf
-    -- ^ Never show emails to anyone other than yourself
+    -- ^ Show your email only to yourself
     deriving (Eq, Show)
 
 instance FromJSON EmailVisibility where
@@ -182,7 +181,7 @@ instance FromJSON EmailVisibility where
         "visible_to_self"      -> pure EmailVisibleToSelf
         _ -> fail
             $  "unexpected value for EmailVisibility settings: "
-            <> "expected one of [visible_if_on_team, visible_to_same_team, visible_to_self]"
+            <> "expected one of [visible_if_on_team, visible_to_self]"
 
 instance ToJSON EmailVisibility where
     toJSON EmailVisibleIfOnTeam = "visible_if_on_team"

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -178,8 +178,19 @@ data EmailVisibility
     -- ^ Never show emails to anyone other than yourself
     deriving (Eq, Show)
 
-instance ToJSON EmailVisibility where
+instance FromJSON EmailVisibility where
+    parseJSON = withText "EmailVisibility" $ \case
+        "visible_to_all_teams" -> pure EmailVisibleToAllTeams
+        "visible_to_same_team" -> pure EmailVisibleToSameTeam
+        "visible_to_self"      -> pure EmailVisibleToSelf
+        _ -> fail
+            $  "unexpected value for EmailVisibility settings: "
+            <> "expected one of [visible_to_all_teams, visible_to_same_team, visible_to_self]"
 
+instance ToJSON EmailVisibility where
+    toJSON EmailVisibleToAllTeams = "visible_to_all_teams"
+    toJSON EmailVisibleToSameTeam = "visible_to_same_team"
+    toJSON EmailVisibleToSelf     = "visible_to_self"
 
 userEmail :: User -> Maybe Email
 userEmail = emailIdentity <=< userIdentity

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -166,30 +166,26 @@ data User = User
 
 -- | Configurations for whether to show a user's email to others.
 data EmailVisibility
-    = EmailVisibleToAllTeams
+    = EmailVisibleIfOnTeam
     {- ^ Anyone on a team can see the email of anyone else who is on a team.
          Regardless of if they're on the SAME team.
          This may sound strange; but certain on-premise hosters have many different teams
          and still want them to see each-other's emails.
     -}
-    | EmailVisibleToSameTeam
-    -- ^ If users are on the same team it's okay to show each-other's emails
     | EmailVisibleToSelf
     -- ^ Never show emails to anyone other than yourself
     deriving (Eq, Show)
 
 instance FromJSON EmailVisibility where
     parseJSON = withText "EmailVisibility" $ \case
-        "visible_to_all_teams" -> pure EmailVisibleToAllTeams
-        "visible_to_same_team" -> pure EmailVisibleToSameTeam
+        "visible_if_on_team" -> pure EmailVisibleIfOnTeam
         "visible_to_self"      -> pure EmailVisibleToSelf
         _ -> fail
             $  "unexpected value for EmailVisibility settings: "
-            <> "expected one of [visible_to_all_teams, visible_to_same_team, visible_to_self]"
+            <> "expected one of [visible_if_on_team, visible_to_same_team, visible_to_self]"
 
 instance ToJSON EmailVisibility where
-    toJSON EmailVisibleToAllTeams = "visible_to_all_teams"
-    toJSON EmailVisibleToSameTeam = "visible_to_same_team"
+    toJSON EmailVisibleIfOnTeam = "visible_if_on_team"
     toJSON EmailVisibleToSelf     = "visible_to_self"
 
 userEmail :: User -> Maybe Email

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -300,6 +300,7 @@ instance Arbitrary UserProfile where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
+        <*> arbitrary
 
 instance Arbitrary RichField where
     arbitrary = RichField <$> arbitrary <*> arbitrary

--- a/libs/brig-types/test/unit/Test/Brig/Types/User.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/User.hs
@@ -16,7 +16,6 @@ import Brig.Types.Team.Invitation
 import Brig.Types.User
 import Data.Aeson
 import Data.Aeson.Types
-import Data.Proxy
 import Data.Typeable (typeOf)
 import Galley.Types.Teams
 import Test.Brig.Types.Arbitrary ()
@@ -70,41 +69,41 @@ unitTests =
 
 roundtripTests :: [TestTree]
 roundtripTests =
-    [ run @BindingNewTeamUser Proxy
-    , run @CheckHandles Proxy
-    , run @CompletePasswordReset Proxy
-    , run @DeleteUser Proxy
-    , run @DeletionCodeTimeout Proxy
-    , run @EmailRemove Proxy
-    , run @EmailUpdate Proxy
-    , run @HandleUpdate Proxy
-    , run @InvitationList Proxy
-    , run @Invitation Proxy
-    , run @InvitationRequest Proxy
-    , run @LocaleUpdate Proxy
-    , run @NewPasswordReset Proxy
-    , run @NewUser Proxy
-    , run @PasswordChange Proxy
-    , run @PhoneRemove Proxy
-    , run @PhoneUpdate Proxy
-    , run @ManagedByUpdate Proxy
-    , run @ReAuthUser Proxy
-    , run @SelfProfile Proxy
-    , run @TeamMember Proxy
-    , run @UpdateServiceWhitelist Proxy
-    , run @UserHandleInfo Proxy
-    , run @UserIdentity Proxy
-    , run @UserProfile Proxy
-    , run @User Proxy
-    , run @RichInfo Proxy
-    , run @UserUpdate Proxy
-    , run @RichInfoUpdate Proxy
-    , run @VerifyDeleteUser Proxy
+    [ run @BindingNewTeamUser
+    , run @CheckHandles
+    , run @CompletePasswordReset
+    , run @DeleteUser
+    , run @DeletionCodeTimeout
+    , run @EmailRemove
+    , run @EmailUpdate
+    , run @HandleUpdate
+    , run @InvitationList
+    , run @Invitation
+    , run @InvitationRequest
+    , run @LocaleUpdate
+    , run @NewPasswordReset
+    , run @NewUser
+    , run @PasswordChange
+    , run @PhoneRemove
+    , run @PhoneUpdate
+    , run @ManagedByUpdate
+    , run @ReAuthUser
+    , run @SelfProfile
+    , run @TeamMember
+    , run @UpdateServiceWhitelist
+    , run @UserHandleInfo
+    , run @UserIdentity
+    , run @UserProfile
+    , run @User
+    , run @RichInfo
+    , run @UserUpdate
+    , run @RichInfoUpdate
+    , run @VerifyDeleteUser
     ]
   where
     run :: forall a. (Arbitrary a, Typeable a, ToJSON a, FromJSON a, Eq a, Show a)
-        => Proxy a -> TestTree
-    run Proxy = testProperty msg trip
+        => TestTree
+    run = testProperty msg trip
       where
         msg = show $ typeOf (undefined :: a)
         trip (v :: a) = counterexample (show $ toJSON v)

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -141,6 +141,8 @@ optSettings:
   setDefaultLocale: en
   setMaxTeamSize: 32
   setMaxConvSize: 16
+optMutableSettings:
+  setEmailVisibility: visible_to_self
 
 logLevel: Warn
 logNetStrings: false

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -12,6 +12,7 @@ ghc-options:
 - -funbox-strict-fields
 dependencies:
 - aeson >=0.11
+- barbies
 - base ==4.*
 - base64-bytestring >=1.0
 - bloodhound >=0.13
@@ -63,7 +64,6 @@ library:
   - auto-update >=0.1
   - base-prelude
   - base16-bytestring >=0.1
-  - barbies
   - bilge >=0.21.1
   - blaze-builder >=0.3
   - brig-types >=0.91.1

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -63,6 +63,7 @@ library:
   - auto-update >=0.1
   - base-prelude
   - base16-bytestring >=0.1
+  - barbies
   - bilge >=0.21.1
   - blaze-builder >=0.3
   - brig-types >=0.91.1

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -74,6 +74,9 @@ sitemap o = do
     get "/i/monitoring" (continue $ const $ view metrics >>= fmap json . render) $
         accept "application" "json"
 
+    get "/i/settings" (continue $ API.getSettings) $
+        accept "application" "json"
+
     put "/i/settings" (continue $ API.putSettings) $
          jsonRequest @(MutableSettings' Maybe)
 

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -38,6 +38,7 @@ import qualified Brig.API.Client               as API
 import qualified Brig.API.Connection           as API
 import qualified Brig.API.Properties           as API
 import qualified Brig.API.User                 as API
+import qualified Brig.API.Settings             as API
 import qualified Brig.Data.User                as Data
 import qualified Brig.Team.Util                as Team
 import qualified Brig.User.API.Auth            as Auth
@@ -72,6 +73,9 @@ sitemap o = do
 
     get "/i/monitoring" (continue $ const $ view metrics >>= fmap json . render) $
         accept "application" "json"
+
+    put "/i/settings" (continue $ API.putSettings) $
+         jsonRequest @(MutableSettings' Maybe)
 
     post "/i/users/:id/auto-connect" (continue autoConnect) $
         accept "application" "json"

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -77,7 +77,7 @@ sitemap o = do
     get "/i/settings" (continue $ API.getSettings) $
         accept "application" "json"
 
-    put "/i/settings" (continue $ API.putSettings) $
+    patch "/i/settings" (continue $ API.patchSettings) $
          jsonRequest @(MutableSettings' Maybe)
 
     post "/i/users/:id/auto-connect" (continue autoConnect) $

--- a/services/brig/src/Brig/API/Settings.hs
+++ b/services/brig/src/Brig/API/Settings.hs
@@ -1,5 +1,5 @@
 module Brig.API.Settings
-    ( putSettings
+    ( patchSettings
     , getSettings
     ) where
 
@@ -15,8 +15,8 @@ import           Network.Wai               (Response)
 import           Network.Wai.Utilities     (JsonRequest, empty, json, parseBody', setStatus)
 
 -- | Update the provided settings accordingly
-putSettings :: JsonRequest (MutableSettings' Maybe) -> Handler Response
-putSettings body = do
+patchSettings :: JsonRequest (MutableSettings' Maybe) -> Handler Response
+patchSettings body = do
     newSettings <- parseBody' body
     mSettingsVar <- view mutableSettings
     atomically $ do
@@ -30,7 +30,7 @@ putSettings body = do
     fromMaybe' a ma = maybe a Identity ma
 
 
--- | Update the provided settings accordingly
+-- | Get the current settings
 getSettings :: JSON -> Handler Response
 getSettings _ = do
     mSet <- view mutableSettings >>= readTVarIO

--- a/services/brig/src/Brig/API/Settings.hs
+++ b/services/brig/src/Brig/API/Settings.hs
@@ -1,0 +1,27 @@
+module Brig.API.Settings (putSettings) where
+
+import Imports
+
+import           Brig.API.Handler          (Handler)
+import           Brig.App                  (mutableSettings)
+import           Brig.Options              (MutableSettings, MutableSettings')
+import           Control.Lens
+import           Data.Barbie               (bzipWith)
+import           Network.HTTP.Types.Status (status200)
+import           Network.Wai               (Response)
+import           Network.Wai.Utilities     (JsonRequest, empty, parseBody', setStatus)
+
+-- | Update the provided settings accordingly
+putSettings :: JsonRequest (MutableSettings' Maybe) -> Handler Response
+putSettings body = do
+    newSettings <- parseBody' body
+    mSettingsVar <- view mutableSettings
+    atomically $ do
+        mSettings <- readTVar mSettingsVar
+        let mergedSettings :: MutableSettings
+            mergedSettings = bzipWith fromMaybe' mSettings newSettings
+        writeTVar mSettingsVar mergedSettings
+    return $ (setStatus status200 empty)
+  where
+    fromMaybe' :: Identity a -> Maybe a -> Identity a
+    fromMaybe' a ma = maybe a Identity ma

--- a/services/brig/src/Brig/API/Settings.hs
+++ b/services/brig/src/Brig/API/Settings.hs
@@ -35,4 +35,4 @@ getSettings :: JSON -> Handler Response
 getSettings _ = do
     mSet <- view mutableSettings >>= readTVarIO
     return . setStatus status200
-           $ json (mSet)
+           $ json mSet

--- a/services/brig/src/Brig/API/Settings.hs
+++ b/services/brig/src/Brig/API/Settings.hs
@@ -1,15 +1,18 @@
-module Brig.API.Settings (putSettings) where
+module Brig.API.Settings
+    ( putSettings
+    , getSettings
+    ) where
 
 import Imports
 
-import           Brig.API.Handler          (Handler)
+import           Brig.API.Handler          (Handler, JSON)
 import           Brig.App                  (mutableSettings)
 import           Brig.Options              (MutableSettings, MutableSettings')
 import           Control.Lens
 import           Data.Barbie               (bzipWith)
 import           Network.HTTP.Types.Status (status200)
 import           Network.Wai               (Response)
-import           Network.Wai.Utilities     (JsonRequest, empty, parseBody', setStatus)
+import           Network.Wai.Utilities     (JsonRequest, empty, json, parseBody', setStatus)
 
 -- | Update the provided settings accordingly
 putSettings :: JsonRequest (MutableSettings' Maybe) -> Handler Response
@@ -25,3 +28,11 @@ putSettings body = do
   where
     fromMaybe' :: Identity a -> Maybe a -> Identity a
     fromMaybe' a ma = maybe a Identity ma
+
+
+-- | Update the provided settings accordingly
+getSettings :: JSON -> Handler Response
+getSettings _ = do
+    mSet <- view mutableSettings >>= readTVarIO
+    return . setStatus status200
+           $ json (mSet)

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -839,7 +839,9 @@ lookupProfiles self others = do
     css   <- toMap <$> Data.lookupConnectionStatus (map userId users) [self]
     return $ map (toProfile css) users
   where
+    toMap :: [ConnectionStatus] -> Map UserId Relation
     toMap = Map.fromList . map (csFrom &&& csStatus)
+    toProfile :: Map UserId Relation -> User -> UserProfile
     toProfile css u =
         let cs = Map.lookup (userId u) css
         in if userId u == self || cs == Just Accepted || cs == Just Sent

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -837,16 +837,29 @@ lookupProfiles :: UserId   -- ^ User 'A' on whose behalf the profiles are reques
 lookupProfiles self others = do
     users <- Data.lookupUsers others >>= mapM userGC
     css   <- toMap <$> Data.lookupConnectionStatus (map userId users) [self]
-    return $ map (toProfile css) users
+    Identity emailVisibility <- view mutableSettings >>= readTVarIO >>= pure . setEmailVisibility
+    return $ map (toProfile emailVisibility css) users
   where
     toMap :: [ConnectionStatus] -> Map UserId Relation
     toMap = Map.fromList . map (csFrom &&& csStatus)
-    toProfile :: Map UserId Relation -> User -> UserProfile
-    toProfile css u =
+    toProfile :: EmailVisibility -> Map UserId Relation -> User -> UserProfile
+    toProfile emailVisibility css u =
         let cs = Map.lookup (userId u) css
-        in if userId u == self || cs == Just Accepted || cs == Just Sent
-            then connectedProfile u
-            else publicProfile u
+            profileEmail' = getEmailForProfile u emailVisibility
+            baseProfile = if userId u == self || cs == Just Accepted || cs == Just Sent
+                            then connectedProfile u
+                            else publicProfile u
+         in baseProfile{ profileEmail = profileEmail'}
+
+-- | Gets the email if it's visible to the requester according to configured settings
+getEmailForProfile :: User -- ^ The user who's profile is being requested
+                   -> EmailVisibility
+                   -> Maybe Email
+getEmailForProfile _ EmailVisibleToSelf = Nothing
+getEmailForProfile u EmailVisibleIfOnTeam =
+    if isJust (userTeam u)
+        then userEmail u
+        else Nothing
 
 -- | Obtain a profile for a user as he can see himself.
 lookupSelfProfile :: UserId -> AppIO (Maybe SelfProfile)

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -10,6 +10,7 @@ import Brig.Types
 import Brig.User.Auth.Cookie.Limit
 import Brig.Whitelist (Whitelist(..))
 import Data.Aeson.Types (typeMismatch)
+import Data.Aeson (withText)
 import Data.Barbie
 import Data.Id
 import Data.Scientific (toBoundedInteger)
@@ -187,6 +188,29 @@ data TurnOpts = TurnOpts
     } deriving (Show, Generic)
 
 instance FromJSON TurnOpts
+
+-- | Configurations for whether to show a user's email to others.
+data EmailVisibility
+    = EmailVisibleIfOnTeam
+    {- ^ Anyone can see the email of someone who is on ANY team.
+         This may sound strange; but certain on-premise hosters have many different teams
+         and still want them to see each-other's emails.
+    -}
+    | EmailVisibleToSelf
+    -- ^ Show your email only to yourself
+    deriving (Eq, Show)
+
+instance FromJSON EmailVisibility where
+    parseJSON = withText "EmailVisibility" $ \case
+        "visible_if_on_team" -> pure EmailVisibleIfOnTeam
+        "visible_to_self"      -> pure EmailVisibleToSelf
+        _ -> fail
+            $  "unexpected value for EmailVisibility settings: "
+            <> "expected one of [visible_if_on_team, visible_to_self]"
+
+instance ToJSON EmailVisibility where
+    toJSON EmailVisibleIfOnTeam = "visible_if_on_team"
+    toJSON EmailVisibleToSelf     = "visible_to_self"
 
 -- | Options that are consumed on startup
 data Opts = Opts

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -189,41 +189,46 @@ instance FromJSON TurnOpts
 -- | Options that are consumed on startup
 data Opts = Opts
     -- services
-    { brig          :: !Endpoint           -- ^ Host and port to bind to
-    , cargohold     :: !Endpoint           -- ^ Cargohold address
-    , galley        :: !Endpoint           -- ^ Galley address
-    , gundeck       :: !Endpoint           -- ^ Gundeck address
+    { brig          :: !Endpoint               -- ^ Host and port to bind to
+    , cargohold     :: !Endpoint               -- ^ Cargohold address
+    , galley        :: !Endpoint               -- ^ Galley address
+    , gundeck       :: !Endpoint               -- ^ Gundeck address
 
     -- external
-    , cassandra     :: !CassandraOpts      -- ^ Cassandra settings
-    , elasticsearch :: !ElasticSearchOpts  -- ^ ElasticSearch settings
-    , aws           :: !AWSOpts            -- ^ AWS settings
-    , stomp         :: !(Maybe StompOpts)  -- ^ STOMP broker settings
+    , cassandra     :: !CassandraOpts          -- ^ Cassandra settings
+    , elasticsearch :: !ElasticSearchOpts      -- ^ ElasticSearch settings
+    , aws           :: !AWSOpts                -- ^ AWS settings
+    , stomp         :: !(Maybe StompOpts)      -- ^ STOMP broker settings
 
     -- Email & SMS
-    , emailSMS      :: !EmailSMSOpts       -- ^ Email and SMS settings
+    , emailSMS      :: !EmailSMSOpts           -- ^ Email and SMS settings
 
     -- ZAuth
-    , zauth         :: !ZAuthOpts          -- ^ ZAuth settings
+    , zauth         :: !ZAuthOpts              -- ^ ZAuth settings
 
     -- Misc.
-    , discoUrl      :: !(Maybe Text)       -- ^ Disco URL
-    , geoDb         :: !(Maybe FilePath)   -- ^ GeoDB file path
-    , internalEvents :: !InternalEventsOpts -- ^ Event queue for
-                                            --   Brig-generated events (e.g.
-                                            --   user deletion)
+    , discoUrl      :: !(Maybe Text)           -- ^ Disco URL
+    , geoDb         :: !(Maybe FilePath)       -- ^ GeoDB file path
+    , internalEvents :: !InternalEventsOpts     -- ^ Event queue for
+                                                --   Brig-generated events (e.g.
+                                                --   user deletion)
 
     -- Logging
-    , logLevel      :: !Level              -- ^ Log level (Debug, Info, etc)
-    , logNetStrings :: !Bool               -- ^ Use netstrings encoding (see
-                                           --   <http://cr.yp.to/proto/netstrings.txt>)
+    , logLevel      :: !Level                  -- ^ Log level (Debug, Info, etc)
+    , logNetStrings :: !Bool                   -- ^ Use netstrings encoding (see
+                                               --   <http://cr.yp.to/proto/netstrings.txt>)
 
     -- TURN
-    , turn          :: !TurnOpts           -- ^ TURN server settings
+    , turn          :: !TurnOpts               -- ^ TURN server settings
 
     -- Runtime settings
-    , optSettings :: !Settings             -- ^ Runtime settings
+    , optSettings :: !Settings                 -- ^ Runtime settings
+    , optMutableSettings :: !MutableSettings   -- ^ Mutable runtime settings
     } deriving (Show, Generic)
+
+data MutableSettings = MutableSettings
+    { msEmailVisibility :: !EmailVisibility
+    } deriving (Eq, Show, Generic)
 
 -- | Options that persist as runtime settings.
 data Settings = Settings
@@ -265,5 +270,6 @@ instance FromJSON Timeout where
     parseJSON v = typeMismatch "activationTimeout" v
 
 instance FromJSON Settings
+instance FromJSON MutableSettings
 
 instance FromJSON Opts

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -229,7 +229,7 @@ data Opts = Opts
     } deriving (Show, Generic)
 
 -- | We use the Higher Kinded Data pattern here because it's very useful for handling
---   partial 'PUT' payloads in the API layer as @MutableSettings Maybe@
+--   partial 'PATCH' payloads in the API layer as @MutableSettings' Maybe@
 data MutableSettings' f = MutableSettings
     { setEmailVisibility :: !(f EmailVisibility)
     } deriving stock (Generic)

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -232,7 +232,7 @@ data Opts = Opts
 --   partial 'PUT' payloads in the API layer as @MutableSettings Maybe@
 data MutableSettings' f = MutableSettings
     { setEmailVisibility :: !(f EmailVisibility)
-    } deriving (Generic)
+    } deriving stock (Generic)
       deriving anyclass (FunctorB, ProductB, TraversableB, ConstraintsB, ProductBC)
 type MutableSettings = MutableSettings' Identity
 deriving instance AllBF Show f MutableSettings' => Show (MutableSettings' f)

--- a/services/brig/test/integration/API/Settings.hs
+++ b/services/brig/test/integration/API/Settings.hs
@@ -10,7 +10,6 @@ import qualified Galley.Types.Teams          as Team
 
 import Data.Id
 import qualified Brig.Options as Opt
-import           Brig.Types.User (EmailVisibility(..))
 
 import Test.Tasty.HUnit
 
@@ -32,24 +31,24 @@ tests manager brig galley = return $ do
             [ testGroup "/users/"
                 [ testCase "EmailVisibleIfOnTeam"
                 . runHttpT manager
-                . withEmailVisibility EmailVisibleIfOnTeam brig
-                $ testUsersEmailShowsEmailsIfExpected brig galley (expectEmailVisible EmailVisibleIfOnTeam)
+                . withEmailVisibility Opt.EmailVisibleIfOnTeam brig
+                $ testUsersEmailShowsEmailsIfExpected brig galley (expectEmailVisible Opt.EmailVisibleIfOnTeam)
 
                 , testCase "EmailVisibleToSelf"
                 . runHttpT manager
-                . withEmailVisibility EmailVisibleToSelf brig
-                $ testUsersEmailShowsEmailsIfExpected brig galley (expectEmailVisible EmailVisibleToSelf)
+                . withEmailVisibility Opt.EmailVisibleToSelf brig
+                $ testUsersEmailShowsEmailsIfExpected brig galley (expectEmailVisible Opt.EmailVisibleToSelf)
                 ]
             , testGroup "/users/:id"
                 [ testCase "EmailVisibleIfOnTeam"
                 . runHttpT manager
-                . withEmailVisibility EmailVisibleIfOnTeam brig
-                $ testGetUserEmailShowsEmailsIfExpected brig galley (expectEmailVisible EmailVisibleIfOnTeam)
+                . withEmailVisibility Opt.EmailVisibleIfOnTeam brig
+                $ testGetUserEmailShowsEmailsIfExpected brig galley (expectEmailVisible Opt.EmailVisibleIfOnTeam)
 
                 , testCase "EmailVisibleToSelf"
                 . runHttpT manager
-                . withEmailVisibility EmailVisibleToSelf brig
-                $ testGetUserEmailShowsEmailsIfExpected brig galley (expectEmailVisible EmailVisibleToSelf)
+                . withEmailVisibility Opt.EmailVisibleToSelf brig
+                $ testGetUserEmailShowsEmailsIfExpected brig galley (expectEmailVisible Opt.EmailVisibleToSelf)
                 ]
             ]
         ]
@@ -59,14 +58,14 @@ data UserRelationship = SameTeam | DifferentTeam | NoTeam
 -- Should we show the email for this user type?
 type EmailVisibilityAssertion = UserRelationship -> Bool
 
-expectEmailVisible :: EmailVisibility -> UserRelationship -> Bool
-expectEmailVisible EmailVisibleIfOnTeam SameTeam = True
-expectEmailVisible EmailVisibleIfOnTeam DifferentTeam = True
-expectEmailVisible EmailVisibleIfOnTeam NoTeam = False
+expectEmailVisible :: Opt.EmailVisibility -> UserRelationship -> Bool
+expectEmailVisible Opt.EmailVisibleIfOnTeam SameTeam = True
+expectEmailVisible Opt.EmailVisibleIfOnTeam DifferentTeam = True
+expectEmailVisible Opt.EmailVisibleIfOnTeam NoTeam = False
 
-expectEmailVisible EmailVisibleToSelf SameTeam = False
-expectEmailVisible EmailVisibleToSelf DifferentTeam = False
-expectEmailVisible EmailVisibleToSelf NoTeam = False
+expectEmailVisible Opt.EmailVisibleToSelf SameTeam = False
+expectEmailVisible Opt.EmailVisibleToSelf DifferentTeam = False
+expectEmailVisible Opt.EmailVisibleToSelf NoTeam = False
 
 jsonField :: FromJSON a => Text -> Value -> Maybe a
 jsonField f u = u ^? key f >>= maybeFromJSON
@@ -124,7 +123,7 @@ testGetUserEmailShowsEmailsIfExpected brig galley shouldShowEmail = do
     emailResult r = decodeBody r >>= jsonField "email"
 
 
-withEmailVisibility :: EmailVisibility -> Brig -> Http () -> Http ()
+withEmailVisibility :: Opt.EmailVisibility -> Brig -> Http () -> Http ()
 withEmailVisibility emailVisibilityOverride brig t =
     withSettingsOverrides brig newSettings t
   where

--- a/services/brig/test/integration/API/Settings.hs
+++ b/services/brig/test/integration/API/Settings.hs
@@ -1,0 +1,74 @@
+module API.Settings (tests) where
+
+import           Imports
+import           Bilge               hiding (accept, timeout)
+import           Data.Barbie         (buniq)
+import           Test.Tasty          hiding (Timeout)
+import           Util
+import API.Team.Util
+import qualified Galley.Types.Teams          as Team
+
+import Data.Id
+import qualified Brig.Options as Opt
+import           Brig.Types.User (EmailVisibility(..))
+
+import Test.Tasty.HUnit
+
+import Bilge.Assert
+import Brig.Types
+import Control.Arrow ((&&&))
+import Data.Aeson
+import Data.Aeson.Lens
+import Control.Lens
+import Data.ByteString.Conversion
+
+import qualified Data.ByteString.Char8       as C8
+import qualified Data.Set                    as Set
+
+tests :: Manager -> Brig -> Galley -> IO TestTree
+tests manager brig galley = do
+    return
+        $ testGroup "settings"
+        $ [ testGroup "EmailVisibleToAllTeams"
+                      [ testCase "" . void
+                            $ runHttpT manager
+                                       (withEmailVisibility EmailVisibleToAllTeams
+                                                            brig
+                                                            (testEmailVisibleTeam brig galley))
+                      ]
+          , testGroup "EmailVisibleToSameTeam" []
+          , testGroup "EmailVisibleToSelf" []
+          ]
+
+testEmailVisibleTeam :: Brig -> Galley -> Http ()
+testEmailVisibleTeam brig galley = do
+    (creatorId, tid) <- createUserWithTeam brig galley
+    userA <- createTeamMember brig galley creatorId tid Team.fullPermissions
+    userB <- createTeamMember brig galley creatorId tid Team.fullPermissions
+    let uids = C8.intercalate "," $ toByteString' <$> [userId userA, userId userB]
+        expected :: Set (Maybe UserId, Maybe Email)
+        expected = Set.fromList
+                   [ (Just $ userId userA, userEmail userA)
+                   , (Just $ userId userB, userEmail userB)
+                   ]
+    get (brig . zUser (userId userB) . path "users" . queryItem "ids" uids) !!! do
+        const 200 === statusCode
+        const (Just expected) === result
+  where
+    result r =  Set.fromList
+             .  map (field "id" &&& field "email")
+            <$> decodeBody r
+
+    field :: FromJSON a => Text -> Value -> Maybe a
+    field f u = u ^? key f >>= maybeFromJSON
+
+
+withEmailVisibility :: EmailVisibility -> Brig -> Http () -> Http ()
+withEmailVisibility emailVisibilityOverride brig t =
+    withSettingsOverrides brig newSettings t
+  where
+    newSettings :: Opt.MutableSettings' Maybe
+    newSettings =
+        (buniq Nothing)
+        { Opt.setEmailVisibility = Just emailVisibilityOverride
+        }

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -71,13 +71,13 @@ runTests iConf bConf otherArgs = do
     settingsApi <- Settings.tests mg b g
 
     withArgs otherArgs . defaultMain $ testGroup "Brig API Integration"
-        [ settingsApi
-        , userApi
+        [ userApi
         , providerApi
         , searchApis
         , teamApis
         , turnApi
         , metricsApi
+        , settingsApi
         ]
   where
     mkRequest (Endpoint h p) = host (encodeUtf8 h) . port p

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -24,6 +24,7 @@ import qualified API.Team              as Team
 import qualified API.TURN              as TURN
 import qualified API.User              as User
 import qualified API.Metrics           as Metrics
+import qualified API.Settings          as Settings
 import qualified Brig.AWS              as AWS
 import qualified Brig.Options          as Opts
 import qualified Data.ByteString.Char8 as BS
@@ -67,9 +68,11 @@ runTests iConf bConf otherArgs = do
     teamApis    <- Team.tests bConf mg b c g awsEnv
     turnApi     <- TURN.tests mg b turnFile turnFileV2
     metricsApi  <- Metrics.tests mg b
+    settingsApi <- Settings.tests mg b g
 
     withArgs otherArgs . defaultMain $ testGroup "Brig API Integration"
-        [ userApi
+        [ settingsApi
+        , userApi
         , providerApi
         , searchApis
         , teamApis

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -560,10 +560,12 @@ withSettingsOverrides brig overrides action  = bracket setup teardown (const act
   where
     setup :: Http MutableSettings
     setup = do
-        existingSettings <- get (brig . paths ["i", "settings"] . Bilge.json overrides) 
+        existingSettings <- get (brig . paths ["i", "settings"] . Bilge.json overrides)
             <!! const 200 === statusCode
+        put (brig . paths ["i", "settings"] . Bilge.json overrides)
+            !!! const 200 === statusCode
         decodeBody existingSettings
 
     teardown :: MutableSettings -> Http ()
-    teardown existingSettings = put (brig . paths ["i", "settings"] . Bilge.json existingSettings) 
+    teardown existingSettings = put (brig . paths ["i", "settings"] . Bilge.json existingSettings)
                 !!! const 200 === statusCode

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -562,10 +562,10 @@ withSettingsOverrides brig overrides action  = bracket setup teardown (const act
     setup = do
         existingSettings <- get (brig . paths ["i", "settings"] . Bilge.json overrides)
             <!! const 200 === statusCode
-        put (brig . paths ["i", "settings"] . Bilge.json overrides)
+        patch (brig . paths ["i", "settings"] . Bilge.json overrides)
             !!! const 200 === statusCode
         decodeBody existingSettings
 
     teardown :: MutableSettings -> Http ()
-    teardown existingSettings = put (brig . paths ["i", "settings"] . Bilge.json existingSettings)
+    teardown existingSettings = patch (brig . paths ["i", "settings"] . Bilge.json existingSettings)
                 !!! const 200 === statusCode

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,6 +43,7 @@ extra-deps:
   commit: 6b98b894c127eed4a5bde646ebf20febcfa656fa    # master (Apr 2, 2019)
 - git: https://gitlab.com/fisx/tinylog
   commit: fd7155aaf6f090f48004a8f7857ce9d3cb4f9417    # https://gitlab.com/twittner/tinylog/merge_requests/6
+- barbies-1.1.1.0@sha256:3071a4d58871729a35b3d494be3491f5f552fc4cb81dcbebbe76f0269d92a423
 
 flags:
   types-common:


### PR DESCRIPTION
The behaviour of this setting is as such; there is a new config called `setEmailVisibility`.
It has two valid settings:

- `visible_if_on_team`: Will display a users email to EVERYONE if they are on a Team
- `visible_to_self`: The current behaviour; only expose email on the `/self` endpoint

Yes this behaviour seems a bit strange, but after chatting with Tiago several times it seems this is all that we currently need for EY. It's certainly possible to add an additional option `visible_within_teams` or something in the future but it adds non-trivial complexity to the code so we'll leave it until necessary.

Note that this PR adds a '/i/settings' endpoint currently used only for testing; and indeed shouldn't be used for anything else because it allows the settings of a server to differ from its config file which is BAD. It adds a test helper which allow mutating the config for the scope of a single test.

Note that this PR also uses the [`barbies`](http://hackage.haskell.org/package/barbies-1.1.2.1) lib for working with 'partial' structures; specifically it allows us to define the structure once and use it in cases where the JSON may be missing fields; this makes endpoints like `PUT /i/settings` much easier to write, at the expense of making other uses slightly less clear. Another option would be to write `PUT /i/settings` in terms of untyped JSON, i.e. `Value` which would also work but which would be less clean in that particular case. I'm open to opinions on this.

`mutableSettings` is currently no different from `settings` except that they are able to be changed. Open to thoughts on this as well.

TODO:

- [ ] add EmailVisibility setting to all required config-maps