### PR TITLE
Gitlab seems to need the `.git` suffix on repo urls.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -42,7 +42,7 @@ extra-deps:
   commit: 68cc331da70c401cae114c24e6ba5373e1b5c190    # master (Apr 4, 2019)
 - git: https://github.com/wireapp/hscim
   commit: 6b98b894c127eed4a5bde646ebf20febcfa656fa    # master (Apr 2, 2019)
-- git: https://gitlab.com/fisx/tinylog
+- git: https://gitlab.com/fisx/tinylog.git
   commit: fd7155aaf6f090f48004a8f7857ce9d3cb4f9417    # https://gitlab.com/twittner/tinylog/merge_requests/6
 
 flags:


### PR DESCRIPTION
discussion: https://github.com/wireapp/wire-server/issues/678,
https://github.com/wireapp/wire-server/issues/727