### PR TITLE
 Add hard-wired 60 sec tolerance to all time bounds checks.

### DIFF
--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -12,7 +12,6 @@ module Spar.API
     -- * API types
   , API, OutsideWorldAPI
     -- ** Individual API pieces
-  , APIMeta
   , APIAuthReqPrecheck
   , APIAuthReq
   , APIAuthResp

--- a/services/spar/src/Spar/API/Types.hs
+++ b/services/spar/src/Spar/API/Types.hs
@@ -40,15 +40,12 @@ type OutsideWorldAPI = OutsideWorld API
 
 type APISSO
      = OmitDocs :> "api-docs" :> Get '[JSON] Swagger
-  :<|> APIMeta
+  :<|> "metadata" :> SAML.APIMeta
   :<|> "initiate-login" :> APIAuthReqPrecheck
   :<|> "initiate-login" :> APIAuthReq
   :<|> APIAuthResp
 
 type CheckOK = Verb 'HEAD 200
-
-type APIMeta
-     = "metadata" :> SAML.APIMeta
 
 type APIAuthReqPrecheck
      = QueryParam "success_redirect" URI.URI

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -282,10 +282,7 @@ catchVerdictErrors = (`catchError` hndlr)
         Left (serr :: ServantErr) -> VerifyHandlerError "unknown-error" (cs (errReasonPhrase serr) <> " " <> cs (errBody serr))
 
 verdictHandlerResult :: HasCallStack => Maybe BindCookie -> SAML.AccessVerdict -> Spar VerdictHandlerResult
-verdictHandlerResult bindCky verdict = do
-  result <- catchVerdictErrors $ verdictHandlerResultCore bindCky verdict
-  SAML.logger SAML.Debug (show result)
-  pure result
+verdictHandlerResult bindCky verdict = catchVerdictErrors $ verdictHandlerResultCore bindCky verdict
 
 verdictHandlerResultCore :: HasCallStack => Maybe BindCookie -> SAML.AccessVerdict -> Spar VerdictHandlerResult
 verdictHandlerResultCore bindCky = \case

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -283,9 +283,9 @@ catchVerdictErrors = (`catchError` hndlr)
 
 verdictHandlerResult :: HasCallStack => Maybe BindCookie -> SAML.AccessVerdict -> Spar VerdictHandlerResult
 verdictHandlerResult bindCky verdict = do
-  result <- catchVerdictErrors $ verdictHandlerResult' bindCky verdict
-  SAML.logger SAML.Debug (show hres)
-  pure results
+  result <- catchVerdictErrors $ verdictHandlerResultCore bindCky verdict
+  SAML.logger SAML.Debug (show result)
+  pure result
 
 verdictHandlerResultCore :: HasCallStack => Maybe BindCookie -> SAML.AccessVerdict -> Spar VerdictHandlerResult
 verdictHandlerResultCore bindCky = \case

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,7 @@ packages:
 
 extra-deps:
 - git: https://github.com/wireapp/saml2-web-sso
-  commit: 68cc331da70c401cae114c24e6ba5373e1b5c190    # master (Apr 4, 2019)
+  commit: c0bcbe8ae5bb6fdc0b5b94f640f63a615c068cbf    # master (Apr 25, 2019)
 - git: https://github.com/wireapp/hscim
   commit: 6b98b894c127eed4a5bde646ebf20febcfa656fa    # master (Apr 2, 2019)
 - git: https://gitlab.com/fisx/tinylog


### PR DESCRIPTION
This is mostly to pull in https://github.com/wireapp/saml2-web-sso/pull/52, which helps with drifting IdP clocks.  During investigating this, I did some refactorings that I would like to keep that are the only thing you can see in this PR.