### PR TITLE
Don't build alpine-builder with --profile

### DIFF
--- a/build/alpine/Dockerfile.builder
+++ b/build/alpine/Dockerfile.builder
@@ -8,12 +8,8 @@ WORKDIR /
 # Download stack indices and compile/cache dependencies to speed up subsequent
 # container creation.
 #
-# We also build profiling versions of all libraries. Due to a bug in Stack,
-# they have to be built in a separate directory. See this issue:
-# https://github.com/commercialhaskell/stack/issues/4032
-#
-# Finally, we build docs for haskell-src-exts without hyperlinking enabled
-# to avoid a Haddock segfault. See https://github.com/haskell/haddock/issues/928
+# We build docs for haskell-src-exts without hyperlinking enabled to avoid
+# a Haddock segfault. See https://github.com/haskell/haddock/issues/928
 #
 # Note: git, ncurses, sed are added here for historical reasons; since
 # roughly 2019-03-28, they are included in prebuilder as well.
@@ -23,9 +19,9 @@ RUN apk add --no-cache git ncurses sed && \
     cd /wire-server && \
     stack update && \
     echo "allow-different-user: true" >> /root/.stack/config.yaml && \
-    stack build --haddock --dependencies-only --profile haskell-src-exts && \
-    stack build --haddock --no-haddock-hyperlink-source --profile haskell-src-exts && \
-    stack build --pedantic --haddock --test --no-run-tests --bench --no-run-benchmarks --dependencies-only --profile && \
+    stack build --haddock --dependencies-only haskell-src-exts && \
+    stack build --haddock --no-haddock-hyperlink-source haskell-src-exts && \
+    stack build --pedantic --haddock --test --no-run-tests --bench --no-run-benchmarks --dependencies-only && \
     cd / && \
     # we run the build only to cache the built source in /root/.stack, we can remove the source code itself
     rm -rf /wire-server


### PR DESCRIPTION
Originally, the plan was to build integration tests with `--profile` and get nice stacktraces without having to add `HasCallStack` everywhere.

However, we ended up adding `HasCallStack` anyway, and half a year later we still don't have tests with profiling.

Furthermore, compiling tests with profiling is not trivial. We would have to build alpine-intermediate both with and without profiling, bringing it from 20m to probably 40m. I'm not sure whether it's avoidable. We also need to make sure that service binaries are built without profiling, which is annoyingly hard thanks to bugs like <https://github.com/commercialhaskell/stack/issues/3827>.

If somebody wants to add stack traces later, it will be easy for them to do. For now we can just merge this PR and enjoy a smaller alpine-builder.