### PR TITLE
Add Wire-specific schemas to SCIM user records

### DIFF
--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -58,7 +58,7 @@ import qualified Web.Scim.Schema.ListResponse     as Scim
 import qualified Web.Scim.Schema.Meta             as Scim
 import qualified Web.Scim.Schema.ResourceType     as Scim
 import qualified Web.Scim.Schema.User             as Scim
-
+import qualified Web.Scim.Schema.User             as Scim.User (schemas)
 
 ----------------------------------------------------------------------------
 -- UserDB instance
@@ -349,7 +349,9 @@ toScimStoredUser'
   -> Scim.User SparTag
   -> Scim.StoredUser SparTag
 toScimStoredUser' (SAML.Time now) baseuri uid usr =
-    Scim.WithMeta meta (Scim.WithId uid usr)
+    Scim.WithMeta meta $
+    Scim.WithId uid $
+    usr { Scim.User.schemas = userSchemas }
   where
     mkLocation :: String -> URI
     mkLocation pathSuffix = convURI $ baseuri SAML.=/ cs pathSuffix


### PR DESCRIPTION
This is a minor bug that manifests when a user is provisioned via SCIM.

When a user is provisioned via SCIM, our backend receives a user record that includes the `"schemas"` field. It might include `"urn:wire:scim:schemas:profile:1.0"`, or it might not.

Before this PR, we just wrote the received user record into the database. After this PR, we also make sure to overwrite the list of schemas with schemas we actually support. (Even if the received record doesn't have `"richInfo"`, we still return it – so we have to signal `"richInfo"` support in the schema.)

This is a freshly created SCIM user record in Spar database, before and after this PR:

```diff
{
-   "schemas": [ "urn:ietf:params:scim:schemas:core:2.0:User" ],
+   "schemas": [
+        "urn:ietf:params:scim:schemas:core:2.0:User",
+        "urn:wire:scim:schemas:profile:1.0"
+   ],
    "id": "ef4bafda-5be8-46e3-bed2-5bcce55cff01",
    "externalId": "lana@example.com",
    "userName": "lana_d",
    "displayName": "Lana Donohue",
    "urn:wire:scim:schemas:profile:1.0": {
        "richInfo": {
            "version": 0,
            "fields": [
                { "type": "Title", "value": "Chief Backup Officer" },
                { "type": "Favorite quote", "value": "Monads are just giant burritos" }
            ]
        }
    },
    "meta": {
        "resourceType": "User",
        "location": "https://staging-nginz-https.zinfra.io/scim/v2/Users/ef4bafda-5be8-46e3-bed2-5bcce55cff01",
        "created": "2019-04-21T04:15:12.535509602Z",
        "lastModified": "2019-04-21T04:15:18.185055531Z",
        "version": "W/\"e051bc17f7e07dec815f4b9314f76f88e2949a62b6aad8c816086cff85de4783\""
    }
}
```