### PR TITLE
Cannon analytics (2)

### DIFF
--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -274,7 +274,7 @@ emitLByteString lbs = do
     -- | Emit the bytestring on the first read, then always return "" on subsequent reads
     return . atomically $ swapTVar tvar mempty
 
--- | Run the 'Applicatino'; check the response status; if >=500, throw a 'Wai.Error' with
+-- | Run the 'Application'; check the response status; if >=500, throw a 'Wai.Error' with
 -- label @"server-error"@ and the body as the error message.
 rethrow5xx :: Logger -> Middleware
 rethrow5xx logger app req k = app req k'

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -283,7 +283,7 @@ rethrow5xx logger app req k = app req k'
         let logMsg = field "canoncalpath" (show $ pathInfo req)
                    . field "rawpath" (rawPathInfo req)
                    . field "request" (fromMaybe "N/A" $ lookupRequestId req)
-                   . msg (val "ResponseRaw - cannot collect metrics and log info on errors")
+                   . msg (val "ResponseRaw - cannot collect metrics or log info on errors")
         Log.log logger Log.Debug logMsg
         k resp
     k' resp = do

--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -6,7 +6,6 @@ import Cannon.Types
 import Cannon.WS hiding (env)
 import Control.Monad.Catch
 import Data.Aeson (encode)
-import Data.String.Conversions (cs)
 import Data.Id (ClientId, UserId, ConnId)
 import Data.Metrics.Middleware
 import Data.Swagger.Build.Api hiding (def, Response)
@@ -18,7 +17,6 @@ import Network.Wai.Predicate hiding (Error, (#))
 import Network.Wai.Routing hiding (route, path)
 import Network.Wai.Utilities hiding (message)
 import Network.Wai.Utilities.Request (parseBody')
-import Network.Wai.Utilities.Server (lazyResponseBody)
 import Network.Wai.Utilities.Swagger
 import Network.Wai.Handler.WebSockets
 import System.Logger (msg, val)
@@ -139,13 +137,7 @@ await (u ::: a ::: c ::: r) = do
     e <- wsenv
     case websocketsApp wsoptions (wsapp (mkKey u a) c l e) r of
         Nothing -> return $ errorRs status426 "request-error" "websocket upgrade required"
-        Just rs -> do
-            let st = responseStatus rs
-            if statusCode st < 500
-                then return rs
-                else do
-                    rsbody :: LText <- liftIO $ cs <$> lazyResponseBody rs
-                    throwM $ Error st "server-error" rsbody
+        Just rs -> return rs
   where
     status426 = mkStatus 426 "Upgrade Required"
     wsoptions = Ws.defaultConnectionOptions

--- a/services/cannon/src/Cannon/App.hs
+++ b/services/cannon/src/Cannon/App.hs
@@ -137,7 +137,7 @@ rejectOnError p x = do
         NotSupported              -> rejectRequest p (f "protocol not supported" "N/A")
         MalformedRequest _ m      -> rejectRequest p (f "malformed-request" (Text.pack m))
         OtherHandshakeException m -> rejectRequest p (f "other-error" (Text.pack m))
-        _                         -> throwM x
+        _                         -> pure ()
     throwM x
 
 ioErrors :: MonadIO m => Logger -> Key -> [Handler m ()]

--- a/services/cannon/src/Cannon/App.hs
+++ b/services/cannon/src/Cannon/App.hs
@@ -65,11 +65,10 @@ continue l ws clock k = liftIO $ do
     case result of
         (Left  (Left x)) ->
             let text = client (key2bytes k) . msg (val "read: " +++ show x) in
-            case fromException x of
-                Just ConnectionClosed -> Logger.debug l text
-                _                     -> Logger.warn  l text
-        (Right (Left x)) -> Logger.warn l $
-            client (key2bytes k) . msg (val "write: " +++ show x)
+            Logger.debug l text
+        (Right (Left x)) ->
+            let text = client (key2bytes k) . msg (val "write: " +++ show x) in
+            Logger.debug l text
         _                -> return ()
 
 terminate :: Key -> Websocket -> WS ()


### PR DESCRIPTION
Second episode after the popular pilot #749

If some application (or inner middleware) responds with status >=500 rather than throwing an exception, turn that into an actual exception so `catchErrors` can do its thing.