### PR TITLE
Refactor Makefiles to support $DOCKER_USER through all docker build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ docker-builder:
 .PHONY: docker-intermediate
 docker-intermediate:
 	# `docker-intermediate` needs to be built whenever code changes - this essentially runs `stack clean && stack install` on the whole repo
-	docker build -t $(DOCKER_USER)/alpine-intermediate:$(DOCKER_TAG) -f build/alpine/Dockerfile.intermediate --build-arg intermediate=$(DOCKER_USER)/alpine-intermediate --build-arg deps=$(DOCKER_USER)/alpine-deps .;
+	docker build -t $(DOCKER_USER)/alpine-intermediate:$(DOCKER_TAG) -f build/alpine/Dockerfile.intermediate --build-arg builder=$(DOCKER_USER)/alpine-builder --build-arg deps=$(DOCKER_USER)/alpine-deps .;
 	docker tag $(DOCKER_USER)/alpine-intermediate:$(DOCKER_TAG) $(DOCKER_USER)/alpine-intermediate:latest;
 	if test -n "$$DOCKER_PUSH"; then docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD); docker push $(DOCKER_USER)/alpine-intermediate:$(DOCKER_TAG); docker push $(DOCKER_USER)/alpine-intermediate:latest; fi;
 

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,11 @@ i-%:
 #################################
 ## docker targets
 
+.PHONY: docker-prebuilder
+docker-prebuilder:
+	# `docker-prebuilder` needs to be built or pulled only once (unless native dependencies change)
+	$(MAKE) -C build/alpine prebuilder
+
 .PHONY: docker-deps
 docker-deps:
 	# `docker-deps` needs to be built or pulled only once (unless native dependencies change)

--- a/build/alpine/Makefile
+++ b/build/alpine/Makefile
@@ -18,6 +18,6 @@ prebuilder:
 
 .PHONY: builder
 builder:
-	docker build -t $(DOCKER_USER)/alpine-builder:$(DOCKER_TAG) -f Dockerfile.builder .
+	docker build --build-arg prebuilder=$(DOCKER_USER)/alpine-prebuilder -t $(DOCKER_USER)/alpine-builder:$(DOCKER_TAG) -f Dockerfile.builder .
 	docker tag $(DOCKER_USER)/alpine-builder:$(DOCKER_TAG) $(DOCKER_USER)/alpine-builder:latest
 	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/alpine-builder:$(DOCKER_TAG); docker push $(DOCKER_USER)/alpine-builder:latest; fi;


### PR DESCRIPTION
These changes add the ability to run custom builds using the `$DOCKER_USER` variables starting at the prebuilder stage, while retaining original functionality of course. 

For example
```shell
DOCKER_USER='james.brink' make docker-prebuilder docker-builder docker-deps docker-intermediate
```