### PR TITLE
Release 2019 05 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 2019-04-09 #756
+
+## Documentation changes
+
+* Group provisioning (#724)
+* Instructions for running load tests (#738)
+* Twilio configuration (#733)
+
+## Bug fixes
+
+Cannon no longer reports 500s in the prometheus metrics when establishing websocket connections. (#751, #754)
+
+## Features
+
+Per-installation flag: Allow displaying emails of users in a team (code from #724, see description in #719)
+
+## Internal Changes
+
+Docker image building improvements (#755)
+
+## Changes (potentially) requiring action for self-hosters
+
+Config value `setEmailVisibility` must be set in brig's config file (if you're not sure, `visible_to_self` is the preferred default)
+
 # 2019-04-09 #746
 
 ## Documentation changes

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,11 @@ i-%:
 #################################
 ## docker targets
 
+.PHONY: docker-prebuilder
+docker-prebuilder:
+	# `docker-prebuilder` needs to be built or pulled only once (unless native dependencies change)
+	$(MAKE) -C build/alpine prebuilder
+
 .PHONY: docker-deps
 docker-deps:
 	# `docker-deps` needs to be built or pulled only once (unless native dependencies change)
@@ -106,7 +111,7 @@ docker-builder:
 .PHONY: docker-intermediate
 docker-intermediate:
 	# `docker-intermediate` needs to be built whenever code changes - this essentially runs `stack clean && stack install` on the whole repo
-	docker build -t $(DOCKER_USER)/alpine-intermediate:$(DOCKER_TAG) -f build/alpine/Dockerfile.intermediate --build-arg intermediate=$(DOCKER_USER)/alpine-intermediate --build-arg deps=$(DOCKER_USER)/alpine-deps .;
+	docker build -t $(DOCKER_USER)/alpine-intermediate:$(DOCKER_TAG) -f build/alpine/Dockerfile.intermediate --build-arg builder=$(DOCKER_USER)/alpine-builder --build-arg deps=$(DOCKER_USER)/alpine-deps .;
 	docker tag $(DOCKER_USER)/alpine-intermediate:$(DOCKER_TAG) $(DOCKER_USER)/alpine-intermediate:latest;
 	if test -n "$$DOCKER_PUSH"; then docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD); docker push $(DOCKER_USER)/alpine-intermediate:$(DOCKER_TAG); docker push $(DOCKER_USER)/alpine-intermediate:latest; fi;
 

--- a/build/alpine/Makefile
+++ b/build/alpine/Makefile
@@ -18,6 +18,6 @@ prebuilder:
 
 .PHONY: builder
 builder:
-	docker build -t $(DOCKER_USER)/alpine-builder:$(DOCKER_TAG) -f Dockerfile.builder .
+	docker build --build-arg prebuilder=$(DOCKER_USER)/alpine-prebuilder -t $(DOCKER_USER)/alpine-builder:$(DOCKER_TAG) -f Dockerfile.builder .
 	docker tag $(DOCKER_USER)/alpine-builder:$(DOCKER_TAG) $(DOCKER_USER)/alpine-builder:latest
 	if test -n "$$DOCKER_PUSH"; then docker push $(DOCKER_USER)/alpine-builder:$(DOCKER_TAG); docker push $(DOCKER_USER)/alpine-builder:latest; fi;

--- a/deploy/services-demo/README.md
+++ b/deploy/services-demo/README.md
@@ -69,7 +69,9 @@ In order to view the API, you need to create a regular user. For that purpose, y
 
 ### This is fantastic, all services up & running... what now, can I run some kind of smoketests?
 
-Yes. You need to specify an email address that the smoketests can log in to via IMAP for it to read and act upon registration/activation emails. Have a look at what the configuration for the [api-smoketest](../../tools/api-simulations/README.md) should be. Once you have the correct `mailboxes.json`, this should just work from the top level directory (note the `sender-email` must match brig's [sender-email](https://github.com/wireapp/wire-server/blob/develop/services/brig/brig.integration.yaml#L35))
+Yes. You need to specify an email address that the smoketests can log in to via IMAP for it to read and act upon registration/activation emails. Have a look at what the configuration for the [api-smoketest](../../tools/api-simulations/README.md) should be. Once you have the correct `mailboxes.json`, this should just work from the top level directory (note the `sender-email` must match brig's [sender-email](https://github.com/wireapp/wire-server/blob/develop/services/brig/brig.integration.yaml#L35)).
+
+If you wish to send verification SMS/calls (to support registration using phone numbers), you need to create an account and configure Twilio: you need to specify the sid and token from the Twilio account in the "wire-server/blob/develop/deploy/services-demo/resources/twilio-credentials.yaml". And specify your Twilio number in smsSender in file "wire-server/deploy/services-demo/conf/brig.demo.yaml" at `emailSMS.general.smsSender`. 
 
 Note: This demo setup comes bundled with a postfix email sending docker image; however due to the minimal setup, emails will likely land in the Spam/Junk folder of the target email address, if you configure a common email provider. To get the smoketester to check the Spam folder as well, use e.g. (in the case of gmail) `--mailbox-folder INBOX --mailbox-folder '[Gmail]/Spam'`.
 

--- a/deploy/services-demo/conf/brig.demo-docker.yaml
+++ b/deploy/services-demo/conf/brig.demo-docker.yaml
@@ -43,6 +43,17 @@ emailSMS:
     templateDir: resources/templates
     emailSender: backend-demo@mail.wiredemo.example.com
     smsSender: "<insert-sender-number-here>"
+    templateBranding:
+      brand: Wire
+      brandUrl: https://wire.com
+      brandLabelUrl: wire.com # This is the text in the label for the above URL
+      brandLogoUrl: https://wire.com/p/img/email/logo-email-black.png
+      brandService: Wire Service Provider
+      copyright: © WIRE SWISS GmbH
+      misuse: misuse@wire.com
+      legal: https://wire.com/legal/
+      forgot: https://wire.com/forgot/
+      support: https://support.wire.com/
 
   user:
     activationUrl: http://brig:8080/activate?key=${key}&code=${code}

--- a/deploy/services-demo/conf/brig.demo-docker.yaml
+++ b/deploy/services-demo/conf/brig.demo-docker.yaml
@@ -110,6 +110,7 @@ optSettings:
   setDefaultLocale: en
   setMaxTeamSize: 128
   setMaxConvSize: 128
+  setEmailVisibility: visible_to_self
 
 logLevel: Debug
 logNetStrings: false

--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -54,6 +54,7 @@ emailSMS:
       legal: https://wire.com/legal/
       forgot: https://wire.com/forgot/
       support: https://support.wire.com/
+
   user:
     activationUrl: http://127.0.0.1:8080/activate?key=${key}&code=${code}
     smsActivationUrl: http://127.0.0.1:8080/v/${code}
@@ -98,7 +99,7 @@ optSettings:
   setActivationTimeout: 1209600     # 1 day
   setTeamInvitationTimeout: 1814400 # 21 days
   setUserMaxConnections: 1000
-  setCookieDomain: 127.0.0.1
+  setCookieDomain: localhost
   setCookieInsecure: false
   setUserCookieRenewAge: 1209600 # 14 days
   setUserCookieLimit: 32

--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -110,6 +110,7 @@ optSettings:
   setDefaultLocale: en
   setMaxTeamSize: 128
   setMaxConvSize: 128
+  setEmailVisibility: visible_to_self
 
 logLevel: Debug
 logNetStrings: false

--- a/docs/reference/conversation.md
+++ b/docs/reference/conversation.md
@@ -1,0 +1,142 @@
+# Creating and populating conversations {#RefCreateAndPopulateConvs}
+
+_Author: Matthias Fischmann_
+
+---
+
+This will walk you through creating and populating a conversation
+using [curl](https://curl.haxx.se/) commands and the credentials of an
+ordinary user (member role).
+
+If you have a system for identity management like a SAML IdP, you may
+be able to use that as a source of user and group information, and
+write a script or a program based on this document to keep your wire
+conversations in sync with your groups.
+
+Sidenote: in the future we may implement groups in our [SCIM
+API](http://www.simplecloud.info/) to handle conversations.  For the
+time being, we hope you consider the approach explained here a decent
+work-around.
+
+
+## Prerequisites
+
+We will talk to the backend using the API that the clients use, so we
+need a pseudo-user that we can authenticate as.  We assume this user
+has been created by other means.  For the sake of testing, you could
+just use the team admin (but you don't need admin privileges for this
+user).
+
+So here is some shell environment we will need:
+
+```bash
+export WIRE_BACKEND=https://prod-nginz-https.wire.com
+export WIRE_USER=...
+export WIRE_PASSWD=...
+export WIRE_TEAMID=...
+```
+
+Now you can login and get a wire token to authenticate all further
+requests:
+
+```bash
+export BEARER=$(curl -X POST \
+  --header 'Content-Type: application/json' \
+  --header 'Accept: application/json' \
+  -d '{"email":"'"$WIRE_USER"'","password":"'"$WIRE_PASSWD"'"}' \
+  $WIRE_BACKEND/login'?persist=false' | jq -r .access_token)
+```
+
+This token will be good for 15 minutes; after that, just repeat.
+
+If you don't want to install [jq](https://stedolan.github.io/jq/), you
+can just call the `curl` command and copy the access token into the
+shell variable manually.
+
+Here is a quick test that you're logged in:
+
+```bash
+curl -X GET --header "Authorization: Bearer $BEARER" \
+  $WIRE_BACKEND/self
+```
+
+
+## Contact requests
+
+If `$WIRE_USER` is in a team, all other team members are implicitly
+connected to it.  So for the users in your team, you don't have to do
+anything here.
+
+TODO: contact requests to users not on the team.
+
+
+## Conversations
+
+To create a converation with no users (except the pseudo-user creating it):
+
+```bash
+export WIRE_CONV_NAME="The B-Team"
+export WIRE_CONV='{
+  "users": [],
+  "name": "'${WIRE_CONV_NAME}'",
+  "team": {
+    "managed": false,
+    "teamid": "'${WIRE_TEAMID}'"
+  },
+  "receipt_mode": 0,
+  "message_timer": 0
+}'
+
+export CONV_ID=$(curl -X POST --header "Authorization: Bearer $BEARER" \
+  -H "Content-Type: application/json" \
+  -d "$WIRE_CONV" \
+  $WIRE_BACKEND/conversations | jq -r .id)
+```
+
+The `users` field can contain UUIDs that need to point to existing
+wire users (in your team or not), and `$WIRE_USER` needs to have an
+accepted connection with them.  You can extract these ids from the
+corresponding SCIM user records.  If in doubt, leave empty.
+
+You can also add and remove users once the converation has been
+created:
+
+```bash
+curl -X POST --header "Authorization: Bearer $BEARER" \
+  -H "Content-Type: application/json" \
+  -d '{ "users": ["b4b6a96c-70c8-11e9-99e6-f3ea044b132c", "b7293854-70c8-11e9-b620-97ff1eba6324"] }' \
+  $WIRE_BACKEND/conversations/$CONV_ID/members
+
+curl -X DELETE --header "Authorization: Bearer $BEARER" \
+  $WIRE_BACKEND/conversations/$CONV_ID/members/b9f1c786-70c8-11e9-91a6-fbeb48cdcdd1
+```
+
+You can also look at one or all conversations:
+
+```bash
+curl -X GET --header "Authorization: Bearer $BEARER" \
+  $WIRE_BACKEND/conversations/ids
+
+curl -X GET --header "Authorization: Bearer $BEARER" \
+  $WIRE_BACKEND/conversations/
+
+curl -X GET --header "Authorization: Bearer $BEARER" \
+  $WIRE_BACKEND/conversations/$CONV_ID/
+```
+
+Finally, conversations can be renamed or deleted:
+
+```bash
+curl -X PUT --header "Authorization: Bearer $BEARER" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "The C-Team" }' \
+  $WIRE_BACKEND/conversations/$CONV_ID
+
+curl -X DELETE --header "Authorization: Bearer $BEARER" \
+  $WIRE_BACKEND/teams/$WIRE_TEAMID/conversations/$CONV_ID
+```
+
+
+## Advanced topics
+
+TODO: pseudo-user leaving the conv, and being added by admin for changes later.

--- a/libs/api-bot/src/Network/Wire/Bot/Monad.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Monad.hs
@@ -71,7 +71,7 @@ module Network.Wire.Bot.Monad
     ) where
 
 import Imports hiding (log, rem)
-import Bilge (MonadHttp (..), Manager)
+import Bilge (MonadHttp (..), Manager, withResponse)
 import Control.Concurrent (myThreadId)
 import Control.Concurrent.Async
 import Control.Concurrent.STM (retry)
@@ -204,7 +204,9 @@ instance MonadBaseControl IO BotNet where
     restoreM       = BotNet . restoreM
 
 instance MonadHttp BotNet where
-    getManager = serverManager <$> getServer
+    handleRequestWithCont req handler = do
+        manager <- serverManager <$> getServer
+        liftIO $ withResponse req manager handler
 
 instance MonadClient BotNet where
     getServer = BotNet $ asks botNetServer
@@ -232,7 +234,7 @@ runBotNet s (BotNet b) = liftIO $ runReaderT b s
 
 newtype BotSession a = BotSession { unBotSession :: ReaderT Bot BotNet a }
     deriving (Functor, Applicative, Monad, MonadIO,
-              MonadThrow, MonadCatch, MonadMask, MonadBase IO)
+              MonadThrow, MonadCatch, MonadMask, MonadBase IO, MonadUnliftIO)
 
 instance MonadBotNet BotSession where
     liftBotNet = BotSession . lift
@@ -243,7 +245,9 @@ instance MonadBaseControl IO BotSession where
     restoreM       = BotSession . restoreM
 
 instance MonadHttp BotSession where
-    getManager = serverManager <$> getServer
+    handleRequestWithCont req handler = do
+        manager <- serverManager <$> getServer
+        liftIO $ withResponse req manager handler
 
 instance MonadClient BotSession where
     getServer = liftBotNet getServer

--- a/libs/api-bot/src/Network/Wire/Bot/Settings.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Settings.hs
@@ -109,7 +109,9 @@ usersFileOption :: Parser (Maybe FilePath)
 usersFileOption = optional . strOption $
     long "users-file"
     <> metavar "FILE"
-    <> help "Path to users file"
+    <> help "Path to users file; which is a headerless csv \
+    \ containing a list of ALREADY EXISTING users with the columns: \
+    \ User-Id,Email,Password"
 
 reportDirOption :: Parser (Maybe FilePath)
 reportDirOption = optional . strOption $

--- a/libs/api-client/package.yaml
+++ b/libs/api-client/package.yaml
@@ -42,6 +42,7 @@ dependencies:
 - transformers >=0.3
 - types-common >=0.16
 - unordered-containers >=0.2
+- unliftio
 - uuid >=1.3
 - websockets >=0.9
 library:

--- a/libs/api-client/src/Network/Wire/Client/API/Auth.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Auth.hs
@@ -13,6 +13,7 @@ module Network.Wire.Client.API.Auth
 import Imports
 import Bilge
 import Brig.Types.User.Auth as Auth hiding (Cookie, user)
+import Control.Monad.Catch (MonadMask)
 import Data.List.NonEmpty
 import Data.Time (getCurrentTime)
 import Network.HTTP.Client (generateCookie)
@@ -36,7 +37,7 @@ data Auth = Auth
 -------------------------------------------------------------------------------
 -- Unauthenticated
 
-login :: MonadClient m => Login -> m (Maybe Auth)
+login :: (MonadClient m, MonadUnliftIO m, MonadMask m) => Login -> m (Maybe Auth)
 login l = do
     rs <- clientRequest req rsc consumeBody
     sv <- getServer
@@ -52,7 +53,7 @@ login l = do
 -------------------------------------------------------------------------------
 -- Authenticated
 
-refreshAuth :: MonadClient m => Auth -> m (Maybe Auth)
+refreshAuth :: (MonadClient m, MonadMask m, MonadUnliftIO m) => Auth -> m (Maybe Auth)
 refreshAuth (Auth ac@(AuthCookie c) t) = do
     sv <- getServer
     rs <- clientRequest (req sv) rsc consumeBody

--- a/libs/api-client/src/Network/Wire/Client/API/Search.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Search.hs
@@ -11,6 +11,7 @@ module Network.Wire.Client.API.Search
 import Imports
 import Bilge
 import Brig.Types
+import Control.Monad.Catch (MonadMask)
 import Data.Default.Class
 import Data.List.NonEmpty
 import Data.Text.Encoding (encodeUtf8)
@@ -32,7 +33,7 @@ instance Default SearchParams where
     def = SearchParams "" 2 10 True
 
 -- | Search for already connected and/or potential contacts.
-search :: MonadSession m => SearchParams -> m (SearchResult Contact)
+search :: (MonadSession m, MonadUnliftIO m, MonadMask m) => SearchParams -> m (SearchResult Contact)
 search SearchParams{..} = sessionRequest req rsc readBody
   where
     req = method GET

--- a/libs/api-client/src/Network/Wire/Client/API/User.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/User.hs
@@ -14,6 +14,7 @@ module Network.Wire.Client.API.User
 import Imports
 import Bilge
 import Brig.Types as M
+import Control.Monad.Catch (MonadMask)
 import Data.ByteString.Conversion
 import Data.Id
 import Data.List.NonEmpty
@@ -28,7 +29,7 @@ import qualified Data.ByteString.Char8 as C
 -------------------------------------------------------------------------------
 -- Unauthenticated
 
-registerUser :: MonadClient m => NewUser -> m User
+registerUser :: (MonadClient m, MonadUnliftIO m, MonadMask m) => NewUser -> m User
 registerUser u = clientRequest req rsc readBody
   where
     req = method POST
@@ -38,7 +39,7 @@ registerUser u = clientRequest req rsc readBody
         $ empty
     rsc = status201 :| []
 
-activateKey :: MonadClient m => ActivationKey -> ActivationCode -> m Bool
+activateKey :: (MonadClient m, MonadUnliftIO m, MonadMask m) => ActivationKey -> ActivationCode -> m Bool
 activateKey (ActivationKey key) (ActivationCode code) = do
     status <- clientRequest req rsc (return . statusCode)
     return $ status /= 404
@@ -52,7 +53,7 @@ activateKey (ActivationKey key) (ActivationCode code) = do
 -------------------------------------------------------------------------------
 -- Authenticated
 
-getSelfProfile :: MonadSession m => m User
+getSelfProfile :: (MonadSession m, MonadUnliftIO m, MonadMask m) => m User
 getSelfProfile = sessionRequest req rsc readBody
   where
     req = method GET
@@ -61,7 +62,7 @@ getSelfProfile = sessionRequest req rsc readBody
         $ empty
     rsc = status200 :| []
 
-getProfile :: MonadSession m => UserId -> m UserProfile
+getProfile :: (MonadSession m, MonadUnliftIO m, MonadMask m) => UserId -> m UserProfile
 getProfile uid = sessionRequest req rsc readBody
   where
     req = method GET
@@ -70,7 +71,7 @@ getProfile uid = sessionRequest req rsc readBody
         $ empty
     rsc = status200 :| []
 
-connectTo :: MonadSession m => ConnectionRequest -> m UserConnection
+connectTo :: (MonadSession m, MonadUnliftIO m, MonadMask m) => ConnectionRequest -> m UserConnection
 connectTo cr = sessionRequest req rsc readBody
   where
     req = method POST
@@ -80,7 +81,7 @@ connectTo cr = sessionRequest req rsc readBody
         $ empty
     rsc = status201 :| [status200]
 
-updateConnection :: MonadSession m => UserId -> ConnectionUpdate -> m UserConnection
+updateConnection :: (MonadSession m, MonadUnliftIO m, MonadMask m) => UserId -> ConnectionUpdate -> m UserConnection
 updateConnection u cu = sessionRequest req rsc readBody
   where
     req = method PUT
@@ -90,7 +91,7 @@ updateConnection u cu = sessionRequest req rsc readBody
         $ empty
     rsc = status200 :| []
 
-getConnection :: MonadSession m => UserId -> m (Maybe UserConnection)
+getConnection :: (MonadSession m, MonadUnliftIO m, MonadMask m) => UserId -> m (Maybe UserConnection)
 getConnection u = do
     rs <- sessionRequest req rsc consumeBody
     case statusCode rs of

--- a/libs/api-client/src/Network/Wire/Client/Monad.hs
+++ b/libs/api-client/src/Network/Wire/Client/Monad.hs
@@ -7,6 +7,7 @@ module Network.Wire.Client.Monad
     , setServer
     , Client
     , MonadClient (..)
+    , liftClient
     , asyncClient
     , runClient
     , ClientException (..)
@@ -14,6 +15,7 @@ module Network.Wire.Client.Monad
 
 import Imports hiding (log)
 import Bilge
+import Control.Monad.Catch (MonadThrow, MonadCatch, MonadMask)
 import Control.Concurrent.Async
 import Network.HTTP.Types
 import System.Logger.Class
@@ -26,7 +28,16 @@ data Env = Env
     }
 
 newtype Client a = Client (ReaderT Env IO a)
-    deriving (Functor, Applicative, Monad, MonadIO)
+    deriving ( Functor
+             , Applicative
+             , Monad
+             , MonadIO
+             , MonadReader Env
+             , MonadUnliftIO
+             , MonadThrow
+             , MonadCatch
+             , MonadMask
+             )
 
 data Server = Server
     { serverHost    :: ByteString
@@ -41,8 +52,19 @@ class (MonadHttp m, MonadLogger m, MonadIO m) => MonadClient m where
     getServer :: m Server
     getLogger :: m Logger
 
+-- | Allows running a 'Client' inside a 'MonadClient'.
+-- This is sometimes useful to regain a MonadUnliftIO instance
+-- which is invalid for the 'MonadClient' itself.
+liftClient :: MonadClient m => Client a -> m a
+liftClient m = do
+    s <- getServer
+    l <- getLogger
+    liftIO $ runClient s l m
+
 instance MonadHttp Client where
-    getManager = Client $ asks (serverManager . clientServer)
+    handleRequestWithCont req handler = do
+        manager <- asks (serverManager . clientServer)
+        liftIO $ withResponse req manager handler
 
 instance MonadClient Client where
     getServer = Client $ asks clientServer

--- a/libs/api-client/src/Network/Wire/Client/Session.hs
+++ b/libs/api-client/src/Network/Wire/Client/Session.hs
@@ -32,7 +32,7 @@ class (Functor m, MonadClient m) => MonadSession m where
     setAuth :: Auth -> m ()
 
 instance MonadHttp Session where
-    getManager = Session $ lift getManager
+    handleRequestWithCont req cont = Session . lift $ handleRequestWithCont req cont
 
 instance MonadClient Session where
     getServer = Session $ lift getServer
@@ -62,11 +62,11 @@ sessionRequest rq expected f =
     exec :: (Response BodyReader -> IO b) -> m b
     exec h = do
         Auth _ t <- getAuth
-        clientRequest (token t rq) (status401 <| expected) h
+        liftClient $ clientRequest (token t rq) (status401 <| expected) h
 
     retry :: ClientException -> m a
     retry e = do
-        a  <- getAuth >>= refreshAuth
+        a  <- getAuth >>= liftClient . refreshAuth
         maybe (liftIO $ throwIO e) setAuth a
         exec f
 

--- a/libs/bilge/package.yaml
+++ b/libs/bilge/package.yaml
@@ -33,6 +33,9 @@ dependencies:
 - transformers-base >=0.4
 - types-common >=0.7
 - unliftio-core >=0.1
+- unliftio
+- wai
+- wai-extra
 library:
   source-dirs: src
   exposed-modules:

--- a/libs/bilge/src/Bilge/IO.hs
+++ b/libs/bilge/src/Bilge/IO.hs
@@ -11,6 +11,7 @@ module Bilge.IO
       HttpT        (..)
     , Http
     , MonadHttp    (..)
+    , handleRequest
     , Debug        (..)
     , runHttpT
     , http
@@ -51,10 +52,19 @@ import Imports hiding (head, trace)
 import Control.Monad.Base
 import Control.Monad.Catch
 import Control.Monad.Trans.Control
-import Network.HTTP.Client hiding (method, httpLbs)
+import Network.HTTP.Client as Client hiding (method, httpLbs)
+import qualified Network.HTTP.Client as Client (method)
+import qualified Data.ByteString.Lazy as LB
+
+-- It's impossible to create a Response body without using internals :'(
+import qualified Network.HTTP.Client.Internal as Client (Response(..), ResponseClose(..))
 import Network.HTTP.Types
 import Bilge.Request
 import Bilge.Response
+import Data.CaseInsensitive (CI)
+
+import qualified Network.Wai.Test as Wai
+import qualified Network.Wai      as Wai
 
 import qualified Data.ByteString.Lazy as Lazy
 
@@ -80,13 +90,69 @@ newtype HttpT m a = HttpT
                )
 
 class MonadHttp m where
-    getManager :: m Manager
+    handleRequestWithCont :: Request -> (Response BodyReader -> IO a) -> m a
+    {-# MINIMAL handleRequestWithCont #-}
 
-instance {-# OVERLAPPING #-} Monad m => MonadHttp (HttpT m) where
-    getManager = HttpT ask
+handleRequest :: MonadHttp m => Request -> m (Response (Maybe LByteString))
+handleRequest req = handleRequestWithCont req consumeBody
+
+instance MonadIO m => MonadHttp (HttpT m) where
+  handleRequestWithCont req h = do
+      m <- ask
+      liftIO $ withResponse req m h
+
+-- | Returns the entire ByteString immediately on first read
+-- then empty ByteString on all subsequent reads.
+-- This is used for back-compatability on MonadHttp so that we can write an instance for
+-- MonadHttp of Wai.Session while maintaining compatability with the previous interface.
+trivialBodyReader :: ByteString -> IO BodyReader
+trivialBodyReader bodyBytes = do
+    bodyVar <- newTVarIO bodyBytes
+    return $ mkBodyReader bodyVar
+      where
+        mkBodyReader :: TVar ByteString -> BodyReader
+        mkBodyReader bodyVar = do
+            atomically $ swapTVar bodyVar ""
+
+
+instance MonadHttp Wai.Session where
+  handleRequestWithCont req cont = do
+      wResponse :: Wai.SResponse <- Wai.request wRequest
+      bodyReader <- liftIO $ trivialBodyReader $ LB.toStrict $ Wai.simpleBody wResponse
+      let bilgeResponse :: Response BodyReader
+          bilgeResponse = toBilgeResponse bodyReader wResponse
+      liftIO $ cont bilgeResponse
+    where
+      wRequest :: Wai.Request
+      wRequest =
+          flip Wai.setPath (Client.path req <> Client.queryString req)
+          $ Wai.defaultRequest
+          { Wai.requestMethod = Client.method req
+          , Wai.httpVersion = Client.requestVersion req
+          , Wai.requestHeaders = Client.requestHeaders req
+          , Wai.isSecure = Client.secure req
+          , Wai.remoteHost = error "no remote host"
+          , Wai.requestHeaderHost = lookupHeader "HOST" req
+          , Wai.requestHeaderRange = lookupHeader "RANGE" req
+          , Wai.requestHeaderReferer = lookupHeader "REFERER" req
+          , Wai.requestHeaderUserAgent = lookupHeader "USER-AGENT" req
+          }
+      toBilgeResponse :: BodyReader -> Wai.SResponse -> Response BodyReader
+      toBilgeResponse bodyReader Wai.SResponse {Wai.simpleStatus, Wai.simpleHeaders} =
+          Client.Response
+          { responseStatus        = simpleStatus
+            -- I just picked an arbitrary version; shouldn't matter.
+          , responseVersion       = http11
+          , responseHeaders       = simpleHeaders
+          , responseBody          = bodyReader
+          , responseCookieJar     = mempty
+          , Client.responseClose' = Client.ResponseClose $ pure ()
+          }
+      lookupHeader :: CI ByteString -> Client.Request -> Maybe ByteString
+      lookupHeader headerName r = lookup headerName (Client.requestHeaders r)
 
 instance {-# OVERLAPPABLE #-} (MonadTrans t, MonadHttp m, Monad m) => MonadHttp (t m) where
-  getManager = lift getManager
+  handleRequestWithCont req cont = lift $ handleRequestWithCont req cont
 
 instance MonadBase IO (HttpT IO) where
     liftBase = liftIO
@@ -151,9 +217,7 @@ http :: (MonadIO m, MonadHttp m)
      -> (Request -> Request)
      -> (Response BodyReader -> IO a)
      -> m a
-http r f h = do
-    m <- getManager
-    liftIO $ withResponse (f r) m h
+http r f h = handleRequestWithCont (f r) h
 
 httpDebug :: (MonadIO m, MonadHttp m)
           => Debug
@@ -162,19 +226,17 @@ httpDebug :: (MonadIO m, MonadHttp m)
           -> (Response (Maybe Lazy.ByteString) -> IO a)
           -> m a
 httpDebug debug r f h = do
-    m <- getManager
     let rq = f r
-    liftIO $ do
+    if debug > Head
+        then putStrLn (showRequest rq)
+        else putStrLn (showRequest (rq { requestBody = RequestBodyLBS "" }))
+    putStrLn "-"
+    handleRequestWithCont rq $ consumeBody >=> \rsp -> do
         if debug > Head
-            then putStrLn (showRequest rq)
-            else putStrLn (showRequest (rq { requestBody = RequestBodyLBS "" }))
-        putStrLn "-"
-        withResponse rq m $ consumeBody >=> \rsp -> do
-            if debug > Head
-                then putStrLn (showResponse rsp)
-                else putStrLn (showResponse $ rsp { responseBody = ("" :: String) })
-            putStrLn "--"
-            h rsp
+            then putStrLn (showResponse rsp)
+            else putStrLn (showResponse $ rsp { responseBody = ("" :: String) })
+        putStrLn "--"
+        h rsp
 
 consumeBody :: Response BodyReader -> IO (Response (Maybe Lazy.ByteString))
 consumeBody r = do

--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -141,6 +141,9 @@ user = defineModel "User" $ do
         description "User ID"
     property "name" string' $
         description "Name"
+    property "email" string' $ do
+        description "Email"
+        optional
     property "assets" (array (ref asset)) $
         description "Profile assets"
     property "accent_id" int32' $ do

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -103,12 +103,41 @@ connectedProfile u = UserProfile
     , profileDeleted  = userDeleted u
     , profileExpire   = userExpire u
     , profileTeam     = userTeam u
+    -- We don't want to show the email by default;
+    -- However we do allow adding it back in intentionally later.
+    , profileEmail    = Nothing
     }
 
 publicProfile :: User -> UserProfile
-publicProfile u = (connectedProfile u)
-    { profileLocale = Nothing
-    }
+publicProfile u =
+    -- Note that we explicitly unpack and repack the types here rather than using
+    -- RecordWildCards or something similar because we want changes to the public profile
+    -- to be EXPLICIT and INTENTIONAL so we don't accidentally leak sensitive data.
+    let UserProfile { profileId
+                    , profileHandle
+                    , profileName
+                    , profilePict
+                    , profileAssets
+                    , profileAccentId
+                    , profileService
+                    , profileDeleted
+                    , profileExpire
+                    , profileTeam
+                    } = connectedProfile u
+    in UserProfile
+       { profileLocale   = Nothing
+       , profileEmail    = Nothing
+       , profileId
+       , profileHandle
+       , profileName
+       , profilePict
+       , profileAssets
+       , profileAccentId
+       , profileService
+       , profileDeleted
+       , profileExpire
+       , profileTeam
+       }
 
 -- | The data of an existing user.
 data User = User
@@ -163,6 +192,7 @@ data UserProfile = UserProfile
     , profileLocale   :: !(Maybe Locale)
     , profileExpire   :: !(Maybe UTCTimeMillis)
     , profileTeam     :: !(Maybe TeamId)
+    , profileEmail    :: !(Maybe Email)
     }
     deriving (Eq, Show)
 
@@ -216,6 +246,7 @@ instance FromJSON UserProfile where
                     <*> o .:? "locale"
                     <*> o .:? "expires_at"
                     <*> o .:? "team"
+                    <*> o .:? "email"
 
 instance ToJSON UserProfile where
     toJSON u = object
@@ -230,6 +261,7 @@ instance ToJSON UserProfile where
         # "locale"     .= profileLocale u
         # "expires_at" .= profileExpire u
         # "team"       .= profileTeam u
+        # "email"      .= profileEmail u
         # []
 
 instance FromJSON SelfProfile where

--- a/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Arbitrary.hs
@@ -300,6 +300,7 @@ instance Arbitrary UserProfile where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
+        <*> arbitrary
 
 instance Arbitrary RichField where
     arbitrary = RichField <$> arbitrary <*> arbitrary

--- a/libs/brig-types/test/unit/Test/Brig/Types/User.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/User.hs
@@ -16,7 +16,6 @@ import Brig.Types.Team.Invitation
 import Brig.Types.User
 import Data.Aeson
 import Data.Aeson.Types
-import Data.Proxy
 import Data.Typeable (typeOf)
 import Galley.Types.Teams
 import Test.Brig.Types.Arbitrary ()
@@ -70,41 +69,41 @@ unitTests =
 
 roundtripTests :: [TestTree]
 roundtripTests =
-    [ run @BindingNewTeamUser Proxy
-    , run @CheckHandles Proxy
-    , run @CompletePasswordReset Proxy
-    , run @DeleteUser Proxy
-    , run @DeletionCodeTimeout Proxy
-    , run @EmailRemove Proxy
-    , run @EmailUpdate Proxy
-    , run @HandleUpdate Proxy
-    , run @InvitationList Proxy
-    , run @Invitation Proxy
-    , run @InvitationRequest Proxy
-    , run @LocaleUpdate Proxy
-    , run @NewPasswordReset Proxy
-    , run @NewUser Proxy
-    , run @PasswordChange Proxy
-    , run @PhoneRemove Proxy
-    , run @PhoneUpdate Proxy
-    , run @ManagedByUpdate Proxy
-    , run @ReAuthUser Proxy
-    , run @SelfProfile Proxy
-    , run @TeamMember Proxy
-    , run @UpdateServiceWhitelist Proxy
-    , run @UserHandleInfo Proxy
-    , run @UserIdentity Proxy
-    , run @UserProfile Proxy
-    , run @User Proxy
-    , run @RichInfo Proxy
-    , run @UserUpdate Proxy
-    , run @RichInfoUpdate Proxy
-    , run @VerifyDeleteUser Proxy
+    [ run @BindingNewTeamUser
+    , run @CheckHandles
+    , run @CompletePasswordReset
+    , run @DeleteUser
+    , run @DeletionCodeTimeout
+    , run @EmailRemove
+    , run @EmailUpdate
+    , run @HandleUpdate
+    , run @InvitationList
+    , run @Invitation
+    , run @InvitationRequest
+    , run @LocaleUpdate
+    , run @NewPasswordReset
+    , run @NewUser
+    , run @PasswordChange
+    , run @PhoneRemove
+    , run @PhoneUpdate
+    , run @ManagedByUpdate
+    , run @ReAuthUser
+    , run @SelfProfile
+    , run @TeamMember
+    , run @UpdateServiceWhitelist
+    , run @UserHandleInfo
+    , run @UserIdentity
+    , run @UserProfile
+    , run @User
+    , run @RichInfo
+    , run @UserUpdate
+    , run @RichInfoUpdate
+    , run @VerifyDeleteUser
     ]
   where
     run :: forall a. (Arbitrary a, Typeable a, ToJSON a, FromJSON a, Eq a, Show a)
-        => Proxy a -> TestTree
-    run Proxy = testProperty msg trip
+        => TestTree
+    run = testProperty msg trip
       where
         msg = show $ typeOf (undefined :: a)
         trip (v :: a) = counterexample (show $ toJSON v)

--- a/libs/metrics-wai/package.yaml
+++ b/libs/metrics-wai/package.yaml
@@ -17,6 +17,7 @@ dependencies:
 - imports
 - metrics-core >=0.3
 - containers
+- prometheus-client
 - servant
 - string-conversions
 - text >=0.11

--- a/libs/metrics-wai/src/Data/Metrics/Middleware/Prometheus.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Middleware/Prometheus.hs
@@ -2,20 +2,30 @@ module Data.Metrics.Middleware.Prometheus (waiPrometheusMiddleware) where
 
 import           Imports
 import qualified Network.Wai                       as Wai
+import           Network.Wai.Internal
 import           Network.Wai.Routing.Route         (Routes, prepare)
 import qualified Network.Wai.Middleware.Prometheus as Promth
+import qualified Data.Text                         as T
 import qualified Data.Text.Encoding                as T
+import           Data.Maybe (fromMaybe)
+import           Data.Ratio ((%))
+import           Data.Text (Text)
+import           Data.Text.Encoding (decodeUtf8)
+import qualified Network.HTTP.Types as HTTP
+import qualified Prometheus as Prom
+import           System.Clock
 
 import Data.Metrics.WaiRoute (treeToPaths)
 import Data.Metrics.Types (Paths)
 import Data.Metrics.Types (treeLookup)
+
 
 -- | Adds a prometheus metrics endpoint at @/i/metrics@
 -- This middleware requires your servers 'Routes' because it does some normalization
 -- (e.g. removing params from calls)
 waiPrometheusMiddleware :: Monad m => Routes a m b -> Wai.Middleware
 waiPrometheusMiddleware routes =
-    Promth.prometheus conf . Promth.instrumentHandlerValue (normalizeWaiRequestRoute paths)
+    Promth.prometheus conf . instrumentHandlerValue (normalizeWaiRequestRoute paths)
   where
     paths = treeToPaths $ prepare routes
     conf = Promth.def
@@ -37,3 +47,36 @@ normalizeWaiRequestRoute paths req = pathInfo
     -- debugging purposes
     pathInfo :: Text
     pathInfo  = T.decodeUtf8 $ fromMaybe (Wai.rawPathInfo req) mPathInfo
+
+
+-- the following code is copied and mutated from wai-middleware-prometheus.  something like
+-- this should be moved there.
+
+instrumentHandlerValue ::
+     (Wai.Request -> Text) -- ^ The function used to derive the "handler" value in Prometheus
+  -> Wai.Application -- ^ The app to instrument
+  -> Wai.Application -- ^ The instrumented app
+instrumentHandlerValue f app req respond = do
+  start <- getTime Monotonic
+  app req $ \case
+    res@(ResponseRaw {}) -> respond res  -- See Note [Raw Response]
+    res -> do
+      end <- getTime Monotonic
+      let method = Just $ decodeUtf8 (Wai.requestMethod req)
+      let status = Just $ T.pack (show (HTTP.statusCode (Wai.responseStatus res)))
+      observeSeconds (f req) method status start end
+      respond res
+
+observeSeconds :: Text -> Maybe Text -> Maybe Text -> TimeSpec -> TimeSpec -> IO ()
+observeSeconds handler method status start end = do
+    let latency = fromRational $ toRational (toNanoSecs (end `diffTimeSpec` start) % 1000000000)
+    Prom.withLabel requestLatency
+                   (handler, fromMaybe "" method, fromMaybe "" status)
+                   (flip Prom.observe latency)
+
+{-# NOINLINE requestLatency #-}
+requestLatency :: Prom.Vector Prom.Label3 Prom.Histogram
+requestLatency = Prom.unsafeRegister $ Prom.vector ("handler", "method", "status_code")
+                                     $ Prom.histogram info Prom.defaultBuckets
+    where info = Prom.Info "http_request_duration_seconds"
+                           "The HTTP request latencies in seconds."

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -141,6 +141,7 @@ optSettings:
   setDefaultLocale: en
   setMaxTeamSize: 32
   setMaxConvSize: 16
+  setEmailVisibility: visible_to_self
 
 logLevel: Warn
 logNetStrings: false

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -35,6 +35,7 @@ dependencies:
 - tinylog >=0.10
 - types-common-journal >=0.1
 - uuid >=1.3.5
+- wai-extra >=3.0
 - yaml >=0.8.22
 library:
   source-dirs: src
@@ -137,7 +138,6 @@ library:
   - vault >=0.3
   - vector >=0.11
   - wai >=3.0
-  - wai-extra >=3.0
   - wai-middleware-gunzip >=0.0.2
   - wai-predicates >=0.8
   - wai-routing >=0.12

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -855,14 +855,29 @@ lookupProfiles :: UserId   -- ^ User 'A' on whose behalf the profiles are reques
 lookupProfiles self others = do
     users <- Data.lookupUsers others >>= mapM userGC
     css   <- toMap <$> Data.lookupConnectionStatus (map userId users) [self]
-    return $ map (toProfile css) users
+    emailVisibility' <- view (settings . emailVisibility)
+    return $ map (toProfile emailVisibility' css) users
   where
+    toMap :: [ConnectionStatus] -> Map UserId Relation
     toMap = Map.fromList . map (csFrom &&& csStatus)
-    toProfile css u =
+    toProfile :: EmailVisibility -> Map UserId Relation -> User -> UserProfile
+    toProfile emailVisibility' css u =
         let cs = Map.lookup (userId u) css
-        in if userId u == self || cs == Just Accepted || cs == Just Sent
-            then connectedProfile u
-            else publicProfile u
+            profileEmail' = getEmailForProfile u emailVisibility'
+            baseProfile = if userId u == self || cs == Just Accepted || cs == Just Sent
+                            then connectedProfile u
+                            else publicProfile u
+         in baseProfile{ profileEmail = profileEmail'}
+
+-- | Gets the email if it's visible to the requester according to configured settings
+getEmailForProfile :: User -- ^ The user who's profile is being requested
+                   -> EmailVisibility
+                   -> Maybe Email
+getEmailForProfile _ EmailVisibleToSelf = Nothing
+getEmailForProfile u EmailVisibleIfOnTeam =
+    if isJust (userTeam u)
+        then userEmail u
+        else Nothing
 
 -- | Obtain a profile for a user as he can see himself.
 lookupSelfProfile :: UserId -> AppIO (Maybe SelfProfile)

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -46,7 +46,7 @@ module Brig.App
     ) where
 
 import Imports
-import Bilge (MonadHttp, Manager, newManager, RequestId (..))
+import Bilge (MonadHttp, Manager, newManager, RequestId (..), withResponse)
 import Bilge.RPC (HasRequestId (..))
 import Brig.Options (Opts, Settings)
 import Brig.Queue.Types (Queue (..))
@@ -185,35 +185,35 @@ newEnv o = do
         StompQueue q -> pure (StompQueue q)
         SqsQueue q -> SqsQueue <$> AWS.getQueueUrl (aws ^. AWS.amazonkaEnv) q
     return $! Env
-        { _cargohold     = mkEndpoint $ Opt.cargohold o
-        , _galley        = mkEndpoint $ Opt.galley o
-        , _gundeck       = mkEndpoint $ Opt.gundeck o
-        , _casClient     = cas
-        , _smtpEnv       = emailSMTP
-        , _awsEnv        = aws
-        , _stompEnv      = stomp
-        , _metrics       = mtr
-        , _applog        = lgr
-        , _internalEvents = eventsQueue
-        , _requestId     = def
-        , _usrTemplates  = utp
-        , _provTemplates = ptp
-        , _tmTemplates   = ttp
-        , _templateBranding = branding
-        , _httpManager   = mgr
-        , _extGetManager = ext
-        , _settings      = sett
-        , _nexmoCreds    = nxm
-        , _twilioCreds   = twl
-        , _geoDb         = g
-        , _turnEnv       = turn
-        , _turnEnvV2     = turnV2
-        , _fsWatcher     = w
-        , _currentTime   = clock
-        , _zauthEnv      = zau
-        , _digestMD5     = md5
-        , _digestSHA256  = sha256
-        , _indexEnv      = mkIndexEnv o lgr mgr mtr
+        { _cargohold         = mkEndpoint $ Opt.cargohold o
+        , _galley            = mkEndpoint $ Opt.galley o
+        , _gundeck           = mkEndpoint $ Opt.gundeck o
+        , _casClient         = cas
+        , _smtpEnv           = emailSMTP
+        , _awsEnv            = aws
+        , _stompEnv          = stomp
+        , _metrics           = mtr
+        , _applog            = lgr
+        , _internalEvents    = eventsQueue
+        , _requestId         = def
+        , _usrTemplates      = utp
+        , _provTemplates     = ptp
+        , _tmTemplates       = ttp
+        , _templateBranding  = branding
+        , _httpManager       = mgr
+        , _extGetManager     = ext
+        , _settings          = sett
+        , _nexmoCreds        = nxm
+        , _twilioCreds       = twl
+        , _geoDb             = g
+        , _turnEnv           = turn
+        , _turnEnvV2         = turnV2
+        , _fsWatcher         = w
+        , _currentTime       = clock
+        , _zauthEnv          = zau
+        , _digestMD5         = md5
+        , _digestSHA256      = sha256
+        , _indexEnv          = mkIndexEnv o lgr mgr mtr
         }
   where
     emailConn _   (Opt.EmailAWS aws) = return (Just aws, Nothing)
@@ -411,8 +411,10 @@ instance MonadIO m => MonadLogger (AppT m) where
 instance MonadIO m => MonadLogger (ExceptT err (AppT m)) where
     log l m = lift (LC.log l m)
 
-instance Monad m => MonadHttp (AppT m) where
-    getManager = view httpManager
+instance (Monad m, MonadIO m) => MonadHttp (AppT m) where
+    handleRequestWithCont req handler = do
+        manager <- view httpManager
+        liftIO $ withResponse req manager handler
 
 instance MonadIO m => MonadZAuth (AppT m) where
     liftZAuth za = view zauthEnv >>= \e -> runZAuth e za

--- a/services/brig/test/integration/API/Settings.hs
+++ b/services/brig/test/integration/API/Settings.hs
@@ -1,0 +1,134 @@
+module API.Settings  where
+
+import           Imports
+import           Bilge              hiding (accept, timeout)
+import           Brig.Options (Opts)
+import           Brig.Run (mkApp)
+import           Test.Tasty         hiding (Timeout)
+import           Util
+import           API.Team.Util
+import qualified Galley.Types.Teams as Team
+
+import Data.Id
+import qualified Brig.Options as Opt
+
+import Bilge.Assert
+import Brig.Types
+import Control.Arrow ((&&&))
+import Data.Aeson
+import Data.Aeson.Lens
+import Control.Lens
+import Data.ByteString.Conversion
+import Test.Tasty.HUnit
+
+import qualified Network.Wai.Test as WaiTest
+
+import qualified Data.ByteString.Char8       as C8
+import qualified Data.Set                    as Set
+
+withCustomOptions :: Opts -> WaiTest.Session a -> IO a
+withCustomOptions opts sess = do
+    (app, _) <- mkApp opts
+    WaiTest.runSession sess app
+
+tests :: Opts -> Manager -> Brig -> Galley -> IO TestTree
+tests defOpts manager brig galley = return $ do
+    testGroup "settings"
+        [ testGroup "setEmailVisibility"
+            [ testGroup "/users/"
+                [
+                testCase "EmailVisibleIfOnTeam"
+                . runHttpT manager
+                $ testUsersEmailVisibleIffExpected defOpts brig galley Opt.EmailVisibleIfOnTeam
+                , testCase "EmailVisibleToSelf"
+                . runHttpT manager
+                $ testUsersEmailVisibleIffExpected defOpts brig galley Opt.EmailVisibleToSelf
+                ]
+            , testGroup "/users/:id"
+                [ testCase "EmailVisibleIfOnTeam"
+                . runHttpT manager
+                $ testGetUserEmailShowsEmailsIffExpected defOpts brig galley Opt.EmailVisibleIfOnTeam
+
+                , testCase "EmailVisibleToSelf"
+                . runHttpT manager
+                $ testGetUserEmailShowsEmailsIffExpected defOpts brig galley Opt.EmailVisibleToSelf
+                ]
+            ]
+        ]
+
+data UserRelationship = SameTeam | DifferentTeam | NoTeam
+
+expectEmailVisible :: Opt.EmailVisibility -> UserRelationship -> Bool
+expectEmailVisible Opt.EmailVisibleIfOnTeam SameTeam = True
+expectEmailVisible Opt.EmailVisibleIfOnTeam DifferentTeam = True
+expectEmailVisible Opt.EmailVisibleIfOnTeam NoTeam = False
+
+expectEmailVisible Opt.EmailVisibleToSelf SameTeam = False
+expectEmailVisible Opt.EmailVisibleToSelf DifferentTeam = False
+expectEmailVisible Opt.EmailVisibleToSelf NoTeam = False
+
+jsonField :: FromJSON a => Text -> Value -> Maybe a
+jsonField f u = u ^? key f >>= maybeFromJSON
+
+testUsersEmailVisibleIffExpected :: Opts -> Brig -> Galley -> Opt.EmailVisibility -> Http ()
+testUsersEmailVisibleIffExpected opts brig galley visibilitySetting = do
+    (creatorId, tid) <- createUserWithTeam brig galley
+    (otherTeamCreatorId, otherTid) <- createUserWithTeam brig galley
+    userA <- createTeamMember brig galley creatorId tid Team.fullPermissions
+    userB <- createTeamMember brig galley otherTeamCreatorId otherTid Team.fullPermissions
+    nonTeamUser <- createUser "joe" brig
+    let uids =
+            C8.intercalate ","
+            $ toByteString' <$> [userId userA, userId userB, userId nonTeamUser]
+        expected :: Set (Maybe UserId, Maybe Email)
+        expected =
+            Set.fromList [ ( Just $ userId userA
+                           , if expectEmailVisible visibilitySetting SameTeam
+                                 then userEmail userA
+                                 else Nothing
+                           )
+                         , ( Just $ userId userB
+                           , if expectEmailVisible visibilitySetting DifferentTeam
+                                 then userEmail userB
+                                 else Nothing
+                           )
+                         , ( Just $ userId nonTeamUser
+                           , if expectEmailVisible visibilitySetting NoTeam
+                                 then userEmail nonTeamUser
+                                 else Nothing
+                           )
+                         ]
+    let newOpts = opts & Opt.optionSettings . Opt.emailVisibility .~ visibilitySetting
+    withSettingsOverrides newOpts $ do
+        get (brig . zUser creatorId . path "users" . queryItem "ids" uids) !!! do
+            const 200 === statusCode
+            const (Just expected) === result
+  where
+    result r = Set.fromList . map (jsonField "id" &&& jsonField "email") <$> decodeBody r
+
+testGetUserEmailShowsEmailsIffExpected :: Opts -> Brig -> Galley -> Opt.EmailVisibility -> Http ()
+testGetUserEmailShowsEmailsIffExpected opts brig galley visibilitySetting = do
+    (creatorId, tid) <- createUserWithTeam brig galley
+    (otherTeamCreatorId, otherTid) <- createUserWithTeam brig galley
+    userA <- createTeamMember brig galley creatorId tid Team.fullPermissions
+    userB <- createTeamMember brig galley otherTeamCreatorId otherTid Team.fullPermissions
+    nonTeamUser <- createUser "joe" brig
+    let expectations :: [(UserId, Maybe Email)]
+        expectations =
+            [ (userId userA, if expectEmailVisible visibilitySetting SameTeam then userEmail userA
+                                                         else Nothing)
+            , (userId userB, if expectEmailVisible visibilitySetting DifferentTeam then userEmail userB
+                                                              else Nothing)
+            , (userId nonTeamUser, if expectEmailVisible visibilitySetting NoTeam then userEmail nonTeamUser
+                                                             else Nothing)
+            ]
+
+    let newOpts = opts & Opt.optionSettings . Opt.emailVisibility .~ visibilitySetting
+    withSettingsOverrides newOpts $ do
+        forM_ expectations $ \(uid, expectedEmail) ->
+            get (brig . zUser creatorId . paths ["users", toByteString' uid]) !!! do
+                const 200 === statusCode
+                const expectedEmail === emailResult
+  where
+    emailResult :: Response (Maybe LByteString) -> Maybe Email
+    emailResult r = decodeBody r >>= jsonField "email"

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -24,6 +24,7 @@ import qualified API.Team              as Team
 import qualified API.TURN              as TURN
 import qualified API.User              as User
 import qualified API.Metrics           as Metrics
+import qualified API.Settings          as Settings
 import qualified Brig.AWS              as AWS
 import qualified Brig.Options          as Opts
 import qualified Data.ByteString.Char8 as BS
@@ -43,6 +44,10 @@ instance FromJSON Config
 
 runTests :: Maybe Config -> Maybe Opts.Opts -> [String] -> IO ()
 runTests iConf bConf otherArgs = do
+    -- TODO: Pass Opts instead of Maybe Opts through tests now that we no longer use ENV vars
+    -- for config.
+    -- Involves removing a bunch of 'optOrEnv' calls
+    brigOpts <- maybe (fail "failed to parse options file") pure bConf
     let local p = Endpoint { _epHost = "127.0.0.1", _epPort = p }
     b  <- mkRequest <$> optOrEnv brig iConf (local . read) "BRIG_WEB_PORT"
     c  <- mkRequest <$> optOrEnv cannon iConf (local . read) "CANNON_WEB_PORT"
@@ -67,6 +72,7 @@ runTests iConf bConf otherArgs = do
     teamApis    <- Team.tests bConf mg b c g awsEnv
     turnApi     <- TURN.tests mg b turnFile turnFileV2
     metricsApi  <- Metrics.tests mg b
+    settingsApi <- Settings.tests brigOpts mg b g
 
     withArgs otherArgs . defaultMain $ testGroup "Brig API Integration"
         [ userApi
@@ -75,6 +81,7 @@ runTests iConf bConf otherArgs = do
         , teamApis
         , turnApi
         , metricsApi
+        , settingsApi
         ]
   where
     mkRequest (Endpoint h p) = host (encodeUtf8 h) . port p

--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -137,7 +137,7 @@ await (u ::: a ::: c ::: r) = do
     e <- wsenv
     case websocketsApp wsoptions (wsapp (mkKey u a) c l e) r of
         Nothing -> return $ errorRs status426 "request-error" "websocket upgrade required"
-        Just rs -> return rs
+        Just rs -> return rs -- ensure all middlewares ignore RawResponse - see Note [Raw Response]
   where
     status426 = mkStatus 426 "Upgrade Required"
     wsoptions = Ws.defaultConnectionOptions

--- a/services/cannon/src/Cannon/WS.hs
+++ b/services/cannon/src/Cannon/WS.hs
@@ -139,6 +139,8 @@ newtype WS a = WS
                , MonadThrow
                , MonadCatch
                , MonadMask
+               , MonadReader Env
+               , MonadUnliftIO
                )
 
 instance MonadLogger WS where
@@ -148,7 +150,9 @@ instance MonadLogger WS where
         liftIO $ Logger.log g l (r . m)
 
 instance MonadHttp WS where
-    getManager = WS $ asks manager
+    handleRequestWithCont req handler = do
+        manager <- asks manager
+        liftIO $ withResponse req manager handler
 
 instance HasRequestId WS where
     getRequestId = WS $ asks reqId

--- a/services/cargohold/src/CargoHold/App.hs
+++ b/services/cargohold/src/CargoHold/App.hs
@@ -27,7 +27,7 @@ module CargoHold.App
     ) where
 
 import Imports hiding (log)
-import Bilge (MonadHttp, Manager, newManager, RequestId (..))
+import Bilge (Manager, MonadHttp, RequestId(..), newManager, withResponse)
 import Bilge.RPC (HasRequestId (..))
 import CargoHold.CloudFront
 import CargoHold.Options as Opt
@@ -165,13 +165,15 @@ instance MonadLogger (ExceptT e App) where
     log l = lift . log l
 
 instance MonadHttp App where
-    getManager = view httpManager
+    handleRequestWithCont req handler = do
+        manager <- view httpManager
+        liftIO $ withResponse req manager handler
 
 instance HasRequestId App where
     getRequestId = view requestId
 
 instance MonadHttp (ExceptT e App) where
-    getManager = lift Bilge.getManager
+    handleRequestWithCont req handler = lift $ Bilge.handleRequestWithCont req handler
 
 instance HasRequestId (ExceptT e App) where
     getRequestId = lift getRequestId

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -98,6 +98,7 @@ executables:
     ghc-options:
     - -threaded
     - -with-rtsopts=-T
+    - -rtsopts
     dependencies:
     - base
     - galley

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -118,7 +118,9 @@ instance MonadLogger Galley where
         Logger.log (e^.applog) l (reqIdMsg (e^.reqId) . m)
 
 instance MonadHttp Galley where
-    getManager = view manager
+    handleRequestWithCont req handler = do
+        httpManager <- view manager
+        liftIO $ withResponse req httpManager handler
 
 instance HasRequestId Galley where
     getRequestId = view reqId

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -17,7 +17,7 @@ import Test.Tasty          (TestName, TestTree)
 import Test.Tasty.HUnit    (Assertion, testCase)
 import Control.Lens        (makeLenses, view)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
-import Bilge (Manager, MonadHttp(..), Request)
+import Bilge (Manager, MonadHttp(..), Request, withResponse)
 
 import qualified Galley.Aws          as Aws
 
@@ -50,7 +50,9 @@ newtype TestM a =
              )
 
 instance MonadHttp TestM where
-    getManager = view tsManager
+    handleRequestWithCont req handler = do
+        manager <- view tsManager
+        liftIO $ withResponse req manager handler
 
 test :: IO TestSetup -> TestName -> TestM a -> TestTree
 test s n h = testCase n runTest

--- a/services/gundeck/src/Gundeck/Monad.hs
+++ b/services/gundeck/src/Gundeck/Monad.hs
@@ -69,7 +69,9 @@ instance MonadLogger Gundeck where
         Logger.log (e^.applog) l (reqIdMsg (e^.reqId) . m)
 
 instance MonadHttp Gundeck where
-    getManager = view manager
+    handleRequestWithCont req handler = do
+        httpManager <- view manager
+        liftIO $ withResponse req httpManager handler
 
 instance HasRequestId Gundeck where
     getRequestId = view reqId

--- a/services/gundeck/src/Gundeck/Push/Websocket.hs
+++ b/services/gundeck/src/Gundeck/Push/Websocket.hs
@@ -129,14 +129,30 @@ fanOut
     pullUri :: (notif, [Presence]) -> [(notif, (URI, Presence))]
     pullUri (notif, prcs) = (notif,) . (bulkresource &&& id) <$> prcs
 
-bulkSend
-  :: forall m. (MonadIO m, MonadThrow m, MonadCatch m, MonadMask m, HasRequestId m, MonadHttp m)
+bulkSend :: forall m.
+         ( MonadIO m
+         , MonadThrow m
+         , MonadCatch m
+         , MonadMask m
+         , HasRequestId m
+         , MonadHttp m
+         , MonadUnliftIO m
+         )
   => URI -> BulkPushRequest -> m (URI, Either SomeException BulkPushResponse)
 bulkSend uri req = (uri,) <$> ((Right <$> bulkSend' uri req) `catch` (pure . Left))
 
-bulkSend'
-  :: forall m. (MonadIO m, MonadThrow m, MonadCatch m, MonadMask m, HasRequestId m, MonadHttp m)
-  => URI -> BulkPushRequest -> m BulkPushResponse
+bulkSend' :: forall m.
+          ( MonadIO m
+          , MonadThrow m
+          , MonadCatch m
+          , MonadMask m
+          , HasRequestId m
+          , MonadHttp m
+          , MonadUnliftIO m
+          )
+          => URI
+          -> BulkPushRequest
+          -> m BulkPushResponse
 bulkSend' uri (encode -> jsbody) = do
     req <- ( check
            . method POST

--- a/services/nginz/README.md
+++ b/services/nginz/README.md
@@ -45,9 +45,9 @@ Once you have all necessary dependencies, `make` in this directory should work.
 gpg: Can't check signature: public key not found
 ```
 
-This means that you haven't imported the public key that was used to sign nginx. Look for the keys at https://nginx.org/en/pgp_keys.html and make sure to import them after with:
+This means that you haven't imported the public key that was used to sign nginx. Look for the keys at https://nginx.org/en/pgp_keys.html and make sure to import ALL of them with:
 
-`gpg --import <path_to_key>`
+`gpg --import <paths_to_keys>`
 
 Alternatively, you can ask GPG to find the key by its ID (printed in the error message):
 

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -227,7 +227,9 @@ instance SPHandler SparError Spar where
       throwErrorAsHandlerException (Right a) = pure a
 
 instance MonadHttp Spar where
-  getManager = asks sparCtxHttpManager
+  handleRequestWithCont req handler = do
+    manager <- asks sparCtxHttpManager
+    liftIO $ withResponse req manager handler
 
 instance Intra.MonadSparToBrig Spar where
   call modreq = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,6 +38,10 @@ packages:
 - tools/db/auto-whitelist
 
 extra-deps:
+- git: https://github.com/wireapp/prometheus-haskell
+  commit: 9bcd5423e0e33a6db8b1e69b50d74e8b47daa737
+  subdirs:
+  - wai-middleware-prometheus
 - git: https://github.com/wireapp/saml2-web-sso
   commit: c0bcbe8ae5bb6fdc0b5b94f640f63a615c068cbf    # master (Apr 25, 2019)
 - git: https://github.com/wireapp/hscim

--- a/tools/api-simulations/loadtest/README.md
+++ b/tools/api-simulations/loadtest/README.md
@@ -1,0 +1,85 @@
+# Load Testing
+
+This package includes the `api-loadtest` executable which will run a loadtest against
+a running instance of wire-server.
+
+Example usage: 
+
+```
+api-loadtest --api-host=test.api --api-port=8080 --conversations-total=40 --conversation-passive-bots=20  --conversation-bots=30  --bot-messages=50  --report-dir=. --message-length=50 --max-events=2000  --enable-asserts --users-file=users.csv
+```
+
+See [Creating Users for Load Test](#creating-users-for-load-test) for details on creating a `users.csv` file.
+
+
+## Available Options
+
+Run `api-loadtest -h` to get the most up to date documentation.
+
+```
+  --api-host HOSTNAME      HTTP(S) API hostname or address to connect to
+  --api-port PORT          HTTP(S) API port to connect to
+  --api-websocket-host HOSTNAME
+                           Websocket API hostname or address to connect to
+  --api-websocket-port PORT
+                           Websocket API port to connect to
+  --api-ssl                Use TLS (HTTPS)
+  --enable-asserts         Enable assertions
+  --mailbox-config FILE    Path to mailbox config
+  --sender-email EMAIL     Expected sender email address
+                           (FROM) (default: accounts@wire.com)
+  --users-file FILE        Path to users file; which is a headerless csv
+                           containing a list of ALREADY EXISTING users with the columns:
+                           User-Id,Email,Password
+  --report-dir DIR         Output directory for reports
+  --max-events NUM         Max. event inbox size per bot
+  --event-timeout SECONDS  Timeout for unmatched events when assertions are
+                           enabled
+  --max-asserts NUM        Max. assert queue size per bot
+  --assert-timeout SECONDS Timeout for assertions
+  --mailbox-folder ARG     In which mailbox folder to search for emails.
+                           Defaults to 'INBOX' if not specified. Can be
+                           specified multiple times for multiple folders.
+  --ramp-step INT          delay in microseconds between conversations start
+  --ramp-total INT         time in microseconds until full load
+  --conversations-total INT
+                           total number of conversations
+  --conversation-bots INT|INT..INT
+                           number of bots in a conversation (default: (2,5))
+  --conversation-passive-bots INT|INT..INT
+                           number of passive bots (that don't send anything) to
+                           be added along with usual bots (default: (0,0))
+  --clients INT|INT..INT   number of clients per bot (default: (1,1))
+  --bot-messages INT|INT..INT
+                           number of text messages to post per
+                           bot (default: (0,0))
+  --message-length INT|INT..INT
+                           length of text messages posted (default: (1,100))
+  --bot-assets INT|INT..INT
+                           number of assets to post per bot (default: (0,0))
+  --asset-size INT|INT..INT
+                           size (bytes) of assets posted (default: (10,1000))
+  --step-delay INT         delay in microseconds between actions taken by a
+                           single bot (default: 1000000)
+  --parallel-requests INT  maximum number of parallel requests (for bots in a
+                           single conversation); applies to everything except
+                           sending or receiving messages (default: 10)
+```
+
+# Creating Users for Load Test
+
+You can create test users against a given `brig` by running the following
+command from the root of `wire-server`:
+
+```bash
+./deploy/services-demo/create_test_user.sh 
+```
+
+By default the script creates users on a `brig` running at `localhost:8082`;
+but you may edit the script to point elsewhere if required.
+
+E.g. to create 100 users on a brig running at `localhost:8082` and generate a valid users file:
+
+```shell
+./deploy/services-demo/create_test_user.sh -c -n 100 -h http://localhost:8082 > users.csv
+```

--- a/tools/stern/package.yaml
+++ b/tools/stern/package.yaml
@@ -11,6 +11,7 @@ license: AGPL-3
 dependencies:
 - imports
 - extended
+- unliftio
 library:
   source-dirs: src
   ghc-options:

--- a/tools/stern/src/Stern/App.hs
+++ b/tools/stern/src/Stern/App.hs
@@ -30,6 +30,7 @@ import           System.Logger.Class            hiding (Error, info)
 import           Util.Options
 
 import qualified Bilge
+import qualified Bilge.IO as Bilge (withResponse)
 import qualified Data.Metrics.Middleware        as Metrics
 import qualified System.Logger                  as Log
 import qualified System.Logger.Extended         as Log
@@ -72,6 +73,7 @@ newtype AppT m a = AppT (ReaderT Env m a)
              , MonadCatch
              , MonadReader Env
              )
+deriving instance MonadUnliftIO App
 
 type App = AppT IO
 
@@ -84,8 +86,10 @@ instance (Functor m, MonadIO m) => MonadLogger (AppT m) where
 instance MonadLogger (ExceptT e App) where
     log l m = lift (LC.log l m)
 
-instance Monad m => Bilge.MonadHttp (AppT m) where
-    getManager = view httpManager
+instance MonadIO m => Bilge.MonadHttp (AppT m) where
+    handleRequestWithCont req h = do
+        m <- view httpManager
+        liftIO $ Bilge.withResponse req m h
 
 instance Monad m => HasRequestId (AppT m) where
     getRequestId = view requestId
@@ -94,7 +98,9 @@ instance HasRequestId (ExceptT e App) where
     getRequestId = view requestId
 
 instance Bilge.MonadHttp (ExceptT e App) where
-    getManager = view httpManager
+    handleRequestWithCont req h = do
+        m <- view httpManager
+        liftIO $ Bilge.withResponse req m h
 
 runAppT :: Env -> AppT m a -> m a
 runAppT e (AppT ma) = runReaderT ma e


### PR DESCRIPTION
# 2019-04-09 #756

## Documentation changes

* Group provisioning (#724)
* Instructions for running load tests (#738)
* Twilio configuration (#733)

## Bug fixes

Cannon no longer reports 500s in the prometheus metrics when establishing websocket connections. (#751, #754)

## Features

Per-installation flag: Allow displaying emails of users in a team (code from #724, see description in #719)

## Internal Changes

Docker image building improvements (#755)

## Changes (potentially) requiring action for self-hosters

Config value `setEmailVisibility` must be set in brig's config file (if you're not sure, `visible_to_self` is the preferred default)
