### PR TITLE
Upgrade CQL protocol version to V4

### DIFF
--- a/libs/cassandra-util/src/Cassandra.hs
+++ b/libs/cassandra-util/src/Cassandra.hs
@@ -15,7 +15,7 @@ import Cassandra.CQL as C (
   BatchType(BatchLogged, BatchUnLogged),
   Value(CqlInt, CqlBlob, CqlText, CqlUdt, CqlBigInt, CqlList, CqlAscii, CqlDouble, CqlBoolean),
   ColumnType(IntColumn, BlobColumn, TextColumn, BigIntColumn, UdtColumn, TimestampColumn, ListColumn, AsciiColumn, DoubleColumn, MaybeColumn, UuidColumn, BooleanColumn),
-  Version(V3),
+  Version(V4),
   R,
   W,
   S,

--- a/libs/cassandra-util/src/Cassandra/CQL.hs
+++ b/libs/cassandra-util/src/Cassandra/CQL.hs
@@ -15,7 +15,7 @@ import Database.CQL.Protocol as C (
   BatchType(BatchLogged, BatchUnLogged),
   Value(CqlInt, CqlBlob, CqlText, CqlUdt, CqlBigInt, CqlList, CqlAscii, CqlDouble, CqlBoolean),
   ColumnType(IntColumn, BlobColumn, TextColumn, BigIntColumn, UdtColumn, TimestampColumn, ListColumn, AsciiColumn, DoubleColumn, MaybeColumn, UuidColumn, BooleanColumn),
-  Version(V3),
+  Version(V4),
   R,
   W,
   S,

--- a/libs/cassandra-util/src/Cassandra/Schema.hs
+++ b/libs/cassandra-util/src/Cassandra/Schema.hs
@@ -21,7 +21,7 @@ module Cassandra.Schema
     ) where
 
 import Imports hiding (intercalate, fromString, log, All, init)
-import Cassandra (Keyspace(Keyspace), Version(V3), PrepQuery, Client, Consistency(One, All), R, W, S, QueryString(QueryString), QueryParams(QueryParams), write, query, query1, retry, params, x1, x5, runClient)
+import Cassandra (Keyspace(Keyspace), Version(V4), PrepQuery, Client, Consistency(One, All), R, W, S, QueryString(QueryString), QueryParams(QueryParams), write, query, query1, retry, params, x1, x5, runClient)
 import Cassandra.Settings (initialContactsPlain, Policy, defSettings, setLogger, setPolicy, setPoolStripes, setMaxConnections, setPortNumber, setContacts, setProtocolVersion, setResponseTimeout, setSendTimeout, setConnectTimeout)
 import qualified Cassandra as CQL (init)
 import Control.Monad.Catch
@@ -152,7 +152,7 @@ migrateSchema l o ms = do
           . setConnectTimeout 20
           . setSendTimeout 20
           . setResponseTimeout 50
-          . setProtocolVersion V3
+          . setProtocolVersion V4
           $ defSettings
     runClient p $ do
         let keyspace = Keyspace . migKeyspace $ o

--- a/services/brig/index/src/Eval.hs
+++ b/services/brig/index/src/Eval.hs
@@ -47,7 +47,7 @@ runCommand l = \case
         . C.setContacts        (view cHost cas) []
         . C.setPortNumber      (fromIntegral (view cPort cas))
         . C.setKeyspace        (view cKeyspace cas)
-        . C.setProtocolVersion C.V3
+        . C.setProtocolVersion C.V4
         $ C.defSettings
 
 _ESServer :: Prism' ES.Server (URIRef Absolute)

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -360,7 +360,7 @@ initCassandra o g = do
             . Cas.setPoolStripes 4
             . Cas.setSendTimeout 3
             . Cas.setResponseTimeout 10
-            . Cas.setProtocolVersion Cas.V3
+            . Cas.setProtocolVersion Cas.V4
             $ Cas.defSettings
     runClient p $ versionCheck schemaVersion
     return p

--- a/services/galley/journaler/src/Main.hs
+++ b/services/galley/journaler/src/Main.hs
@@ -65,5 +65,5 @@ main = withOpenSSL $ do
         . C.setContacts        (cas^.cHosts) []
         . C.setPortNumber      (fromIntegral $ cas^.cPort)
         . C.setKeyspace        (cas^.cKeyspace)
-        . C.setProtocolVersion C.V3
+        . C.setProtocolVersion C.V4
         $ C.defSettings

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -149,7 +149,7 @@ initCassandra o l = do
             . C.setPoolStripes 4
             . C.setSendTimeout 3
             . C.setResponseTimeout 10
-            . C.setProtocolVersion C.V3
+            . C.setProtocolVersion C.V4
             $ C.defSettings
 
 initHttpManager :: Opts -> IO Manager

--- a/services/gundeck/src/Gundeck/Env.hs
+++ b/services/gundeck/src/Gundeck/Env.hs
@@ -68,7 +68,7 @@ createEnv m o = do
             . C.setPoolStripes 4
             . C.setSendTimeout 3
             . C.setResponseTimeout 10
-            . C.setProtocolVersion C.V3
+            . C.setProtocolVersion C.V4
             $ C.defSettings
     a <- Aws.mkEnv l o n
     io <- mkAutoUpdate defaultUpdateSettings {

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -60,7 +60,7 @@ initCassandra opts lgr = do
       & Cas.setPoolStripes 4
       & Cas.setSendTimeout 3
       & Cas.setResponseTimeout 10
-      & Cas.setProtocolVersion V3
+      & Cas.setProtocolVersion V4
     runClient cas $ Cas.versionCheck Data.schemaVersion
     pure cas
 

--- a/tools/db/auto-whitelist/src/Main.hs
+++ b/tools/db/auto-whitelist/src/Main.hs
@@ -37,5 +37,5 @@ main = do
         . C.setContacts        (cas^.cHosts) []
         . C.setPortNumber      (fromIntegral $ cas^.cPort)
         . C.setKeyspace        (cas^.cKeyspace)
-        . C.setProtocolVersion C.V3
+        . C.setProtocolVersion C.V4
         $ C.defSettings

--- a/tools/db/service-backfill/src/Main.hs
+++ b/tools/db/service-backfill/src/Main.hs
@@ -38,5 +38,5 @@ main = do
         . C.setContacts        (cas^.cHosts) []
         . C.setPortNumber      (fromIntegral $ cas^.cPort)
         . C.setKeyspace        (cas^.cKeyspace)
-        . C.setProtocolVersion C.V3
+        . C.setProtocolVersion C.V4
         $ C.defSettings


### PR DESCRIPTION
We're running cassandra 3.11+ across the board so this operation should be safe. Relevant changes [from V3](https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L1171-L1187)