### PR TITLE
legalhold swagger updates

### DIFF
--- a/libs/brig-types/src/Brig/Types/Team/LegalHold.hs
+++ b/libs/brig-types/src/Brig/Types/Team/LegalHold.hs
@@ -141,7 +141,6 @@ viewLegalHoldService :: LegalHoldService -> ViewLegalHoldService
 viewLegalHoldService (LegalHoldService tid u fpr _) =
     ViewLegalHoldService $ ViewLegalHoldServiceInfo tid u fpr
 
--- TODO: Do we need a Client ID?
 data NewLegalHoldClient = NewLegalHoldClient
     { newLegalHoldClientPrekeys  :: [Prekey]
     , newLegalHoldClientLastKey  :: !LastPrekey

--- a/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
+++ b/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
@@ -498,9 +498,9 @@ instance Arbitrary UserLegalHoldStatus where
     arbitrary = elements [minBound..]
 
 instance Arbitrary LegalHoldClientRequest where
-    arbitrary = 
-        LegalHoldClientRequest 
-            <$> arbitrary 
+    arbitrary =
+        LegalHoldClientRequest
+            <$> arbitrary
             <*> arbitrary
             <*> arbitrary
             <*> arbitrary

--- a/services/galley/src/Galley/API/Swagger.hs
+++ b/services/galley/src/Galley/API/Swagger.hs
@@ -51,7 +51,7 @@ main = do
 
 -- TODO: document exceptions properly.
 
--- TODO: document zusr authentication thingy somehow.
+-- TODO: document zusr, zconn
 
 -- TODO: factor out the servant handlers from the functions in Gally.API.LegalHold, and build
 --       them together to an Application.  don't run it yet, but that would give us some extra

--- a/services/galley/src/Galley/API/Swagger.hs
+++ b/services/galley/src/Galley/API/Swagger.hs
@@ -74,9 +74,8 @@ type GalleyRoutesPublic
           :> Verb 'DELETE 204 '[] NoContent
 
   :<|> "teams" :> Capture "tid" TeamId :> "legalhold" :> Capture "uid" UserId
-          :> ReqBody '[JSON] RequestNewLegalHoldClient
-          :> Post '[JSON] NewLegalHoldClient
-  :<|> "teams" :> Capture "tid" TeamId :> "legalhold" :> "approve"
+          :> Post '[] NoContent
+  :<|> "teams" :> Capture "tid" TeamId :> "legalhold" :> Capture "uid" UserId :> "approve"
           :> Verb 'PUT 204 '[] NoContent
   :<|> "teams" :> Capture "tid" TeamId :> "legalhold" :> Capture "uid" UserId
           :> Get '[JSON] UserLegalHoldStatus
@@ -224,24 +223,6 @@ instance ToSchema LegalHoldStatus where
           where
             descr = "determines whether admins of a team " <>
                     "are allowed to enable LH for their users."
-
-instance ToSchema RequestNewLegalHoldClient where
-    declareNamedSchema = genericDeclareNamedSchema opts
-      where
-        opts = defaultSchemaOptions
-          { fieldLabelModifier = \case
-              "userId" -> "user_id"
-              "teamId" -> "team_id"
-          }
-
-instance ToSchema NewLegalHoldClient where
-    declareNamedSchema = genericDeclareNamedSchema opts
-      where
-        opts = defaultSchemaOptions
-          { fieldLabelModifier = \case
-              "newLegalHoldClientPrekeys" -> "prekeys"
-              "newLegalHoldClientLastKey" -> "last_prekey"
-          }
 
 instance ToSchema UserLegalHoldStatus where
     declareNamedSchema = tweak . genericDeclareNamedSchema opts


### PR DESCRIPTION
a minor sync of the swagger docs with the actual interface.

one more thing i noticed: `UserLegalHoldStatus` is returned in a response body as a string, but json is sometimes required to be wrapped in an object.  Not sure if that's outdated or still a requirement.  if so, we can just write a newtype `UserLegalHoldStatusObject` that wraps the json string into a `{ "status": ... }`.