### PR TITLE
Legalhold remove settings on disable

### DIFF
--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -130,5 +130,8 @@ legalHoldNotEnabled = Error status403 "legalhold-not-enabled" "legal hold is not
 userLegalHoldAlreadyEnabled :: Error
 userLegalHoldAlreadyEnabled = Error status409 "legalhold-already-enabled" "legal hold is already enabled for this user"
 
+userLegalHoldNotPending :: Error
+userLegalHoldNotPending = Error status412 "legalhold-not-pending" "legal hold cannot be approved without being in a pending state"
+
 noLegalHoldDeviceAllocated :: Error
 noLegalHoldDeviceAllocated = Error status404 "legalhold-no-device-allocated" "no legal hold device is registered for this user. POST /teams/:tid/legalhold/:uid/ to start the flow."

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -51,9 +51,10 @@ getEnabled (tid ::: _) = do
 setEnabled :: TeamId ::: JsonRequest LegalHoldTeamConfig ::: JSON -> Galley Response
 setEnabled (tid ::: req ::: _) = do
     legalHoldTeamConfig <- fromJsonBody req
+    case legalHoldTeamConfigStatus legalHoldTeamConfig of
+        LegalHoldDisabled -> LegalHoldData.removeSettings tid
+        LegalHoldEnabled -> pure ()
     LegalHoldData.setLegalHoldTeamConfig tid legalHoldTeamConfig
-    -- TODO: How do we remove all devices from all users?
-    -- Do we also delete the settings from the table?
     pure $ responseLBS status204 [] mempty
 
 createSettings :: UserId ::: TeamId ::: JsonRequest NewLegalHoldService ::: JSON -> Galley Response

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -195,9 +195,9 @@ approveDevice (zusr ::: tid ::: uid ::: connId ::: _) = do
     assertUserLHPending = do
         userLHStatus <- fmap (view legalHoldStatus) <$> Data.teamMember tid uid
         case userLHStatus of
-            UserLegalHoldDisabled -> throwM userLegalHoldNotPending
-            UserLegalHoldEnabled -> throwM userLegalHoldAlreadyEnabled
-            UserLegalHoldPending -> pure ()
+            Just UserLegalHoldEnabled -> throwM userLegalHoldAlreadyEnabled
+            Just UserLegalHoldPending -> pure ()
+            _ -> throwM userLegalHoldNotPending
 
 disableForUser :: UserId ::: TeamId ::: UserId ::: JSON -> Galley Response
 disableForUser (zusr ::: tid ::: uid ::: _) = do

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -197,12 +197,6 @@ testApproveLegalHoldDevice = do
         putEnabled tid LegalHoldEnabled
         requestDevice owner member tid !!! const 204 === statusCode
 
-        putEnabled tid LegalHoldDisabled
-        -- Can't approve device when in disabled state
-        -- TODO: remove the following 'ignore' once 'disabled' is the default
-        ignore $ approveLegalHoldDevice member member tid !!! const 403 === statusCode
-        putEnabled tid LegalHoldEnabled
-
         -- Only the user themself can approve adding a LH device
         approveLegalHoldDevice owner member tid !!! const 403 === statusCode
         approveLegalHoldDevice member member tid !!! const 200 === statusCode
@@ -506,10 +500,10 @@ testEnablePerTeam = do
            liftIO $ assertEqual "User legal hold status should be disabled after disabling for team" UserLegalHoldDisabled status
 
         viewLHS <- getSettingsTyped owner tid
-        liftIO $ assertEqual "LH Service should be disabled" ViewLegalHoldServiceDisabled viewLHS
+        liftIO $ assertEqual "LH Service settings should be cleared"
+                   ViewLegalHoldServiceNotConfigured viewLHS
 
-    -- TODO: Check that disabling legalhold for a team removes the LH device from all team
-    -- members
+    ensureQueueEmpty
 
 testCreateLegalHoldDeviceOldAPI :: TestM ()
 testCreateLegalHoldDeviceOldAPI = do

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -198,12 +198,6 @@ testApproveLegalHoldDevice = do
         putEnabled tid LegalHoldEnabled
         requestDevice owner member tid !!! const 204 === statusCode
 
-        putEnabled tid LegalHoldDisabled
-        -- Can't approve device when in disabled state
-        -- TODO: remove the following 'ignore' once 'disabled' is the default
-        ignore $ approveLegalHoldDevice (Just defPassword) member member tid !!! const 403 === statusCode
-        putEnabled tid LegalHoldEnabled
-
         -- Only the user themself can approve adding a LH device
         approveLegalHoldDevice (Just defPassword) owner member tid !!! const 403 === statusCode
         -- Requires password
@@ -502,7 +496,7 @@ testEnablePerTeam = do
 
     withDummyTestServiceForTeam owner tid $ do
         requestDevice owner member tid !!! const 204 === statusCode
-        approveLegalHoldDevice member member tid !!! const 200 === statusCode
+        approveLegalHoldDevice (Just defPassword) member member tid !!! const 200 === statusCode
         do UserLegalHoldStatusResponse status _ _ <- getUserStatusTyped member tid
            liftIO $ assertEqual "User legal hold status should be enabled" UserLegalHoldEnabled status
 


### PR DESCRIPTION
- [x] Delete LH settings AND disable for all users when disabling at the team level
- [x] Ensure Users can only approve LH from a pending state, not disabled (or Weird Things™ occur)