### PR TITLE
Log this message only at debug level

### DIFF
--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -161,9 +161,9 @@ claimPrekey u c = withOptLock u c $ do
         Just (i, k) -> do
             if i /= lastPrekeyId
                 then retry x1 $ write removePrekey (params Quorum (u, c, i))
-                else Log.info $ field "user" (toByteString u)
-                              . field "client" (toByteString c)
-                              . msg (val "last resort prekey used")
+                else Log.debug $ field "user" (toByteString u)
+                               . field "client" (toByteString c)
+                               . msg (val "last resort prekey used")
             return $ Just (ClientPrekey c (Prekey i k))
         Nothing -> return Nothing
 


### PR DESCRIPTION
This line accounts for > 90% of our log lines and does not really provide any interesting info besides the fact that these users should probably publish prekeys more often.