### PR TITLE
Expose legalhold status and check if it is really disabled

### DIFF
--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -285,6 +285,11 @@ sitemap = do
     get "/teams/api-docs" (continue . const . pure . json $ swagger) $
         accept "application" "json"
 
+    get "/teams/:tid/legalhold" (continue LegalHold.getEnabled) $
+        zauthUserId
+        .&. capture "tid"
+        .&. accept "application" "json"
+
     post "/teams/:tid/legalhold/settings" (continue LegalHold.createSettings) $
         zauthUserId
         .&. capture "tid"
@@ -904,11 +909,11 @@ sitemap = do
         .&. capture "uid"
         .&. accept "application" "json"
 
-    get "/i/teams/:tid/legalhold" (continue LegalHold.getEnabled) $
+    get "/i/teams/:tid/legalhold" (continue LegalHold.getEnabledInternal) $
         capture "tid"
         .&. accept "application" "json"
 
-    put "/i/teams/:tid/legalhold" (continue LegalHold.setEnabled) $
+    put "/i/teams/:tid/legalhold" (continue LegalHold.setEnabledInternal) $
         capture "tid"
         .&. jsonRequest @LegalHoldTeamConfig
         .&. accept "application" "json"


### PR DESCRIPTION
Exposes the GET LH status so that admins can view this information. In addition, it _actually_ checks for LH disabled at the DB level so that we can manually disable LH using the internal endpoint.