### PR TITLE
Remove unnecessary endpoint and rename info to settings

### DIFF
--- a/libs/brig-types/src/Brig/Types/Team/LegalHold.hs
+++ b/libs/brig-types/src/Brig/Types/Team/LegalHold.hs
@@ -94,9 +94,9 @@ data ViewLegalHoldService
 
 instance ToJSON ViewLegalHoldService where
     toJSON s = case s of
-        ViewLegalHoldService info -> object
-            $ "status" .= String "configured"
-            # "info"   .= info
+        ViewLegalHoldService settings -> object
+            $ "status"   .= String "configured"
+            # "settings" .= settings
             # []
         ViewLegalHoldServiceNotConfigured -> object
             $ "status" .= String "not_configured"
@@ -109,7 +109,7 @@ instance FromJSON ViewLegalHoldService where
     parseJSON = withObject "LegalHoldService" $ \o -> do
         status :: Text <- o .: "status"
         case status of
-            "configured"     -> ViewLegalHoldService <$> (o .: "info")
+            "configured"     -> ViewLegalHoldService <$> (o .: "settings")
             "not_configured" -> pure ViewLegalHoldServiceNotConfigured
             "disabled"       -> pure ViewLegalHoldServiceDisabled
             _ -> fail "status (one of configured, not_configured, disabled)"

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -285,11 +285,6 @@ sitemap = do
     get "/teams/api-docs" (continue . const . pure . json $ swagger) $
         accept "application" "json"
 
-    get "/teams/:tid/legalhold" (continue LegalHold.getEnabled) $
-        zauthUserId
-        .&. capture "tid"
-        .&. accept "application" "json"
-
     post "/teams/:tid/legalhold/settings" (continue LegalHold.createSettings) $
         zauthUserId
         .&. capture "tid"
@@ -909,11 +904,11 @@ sitemap = do
         .&. capture "uid"
         .&. accept "application" "json"
 
-    get "/i/teams/:tid/legalhold" (continue LegalHold.getEnabledInternal) $
+    get "/i/teams/:tid/legalhold" (continue LegalHold.getEnabled) $
         capture "tid"
         .&. accept "application" "json"
 
-    put "/i/teams/:tid/legalhold" (continue LegalHold.setEnabledInternal) $
+    put "/i/teams/:tid/legalhold" (continue LegalHold.setEnabled) $
         capture "tid"
         .&. jsonRequest @LegalHoldTeamConfig
         .&. accept "application" "json"

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -491,14 +491,10 @@ testEnablePerTeam = do
     ignore $ do
         LegalHoldTeamConfig isInitiallyEnabled <- jsonBody <$> (getEnabled tid <!! const 200 === statusCode)
         liftIO $ assertEqual "Teams should start with LegalHold disabled" isInitiallyEnabled LegalHoldDisabled
-        LegalHoldTeamConfig isInitiallyEnabledPublic <- jsonBody <$> (getEnabledPublic owner tid <!! const 200 === statusCode)
-        liftIO $ assertEqual "Teams should start with LegalHold disabled (public)" isInitiallyEnabledPublic LegalHoldDisabled
 
-    -- TODO: Remove these 2 tests once we change the default value
+    -- TODO: Remove this test once we change the default value
     LegalHoldTeamConfig isInitiallyEnabled <- jsonBody <$> (getEnabled tid <!! const 200 === statusCode)
     liftIO $ assertEqual "Teams should start with LegalHold enabled" isInitiallyEnabled LegalHoldEnabled
-    LegalHoldTeamConfig isInitiallyEnabledPublic <- jsonBody <$> (getEnabledPublic owner tid <!! const 200 === statusCode)
-    liftIO $ assertEqual "Teams should start with LegalHold enabled (public)" isInitiallyEnabledPublic LegalHoldEnabled
 
     putEnabled tid LegalHoldEnabled -- enable it for this team
     LegalHoldTeamConfig isEnabledAfter <- jsonBody <$> (getEnabled tid <!! const 200 === statusCode)
@@ -589,14 +585,6 @@ createTeam = do
     teamid <- Util.createTeamInternal tname ownerid
     assertQueue "create team" tActivate
     pure (ownerid, teamid)
-
-getEnabledPublic :: HasCallStack => UserId -> TeamId -> TestM ResponseLBS
-getEnabledPublic uid tid = do
-    g <- view tsGalley
-    get $ g
-        . paths ["teams", toByteString' tid, "legalhold"]
-        . zUser uid . zConn "conn"
-        . zType "access"
 
 getEnabled :: HasCallStack => TeamId -> TestM ResponseLBS
 getEnabled tid = do


### PR DESCRIPTION
`GET "/teams/:tid/legalhold"` was not needed; renamed `"info"` to `"settings"`