### PR TITLE
legalhold cancel pending

### DIFF
--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -168,4 +168,7 @@ removeLegalHoldClient uid = do
     clients <- Data.lookupClients uid
     -- Should only be one; but just in case we'll treat it as a list
     let legalHoldClients = filter ((== LegalHoldClientType) . clientType) clients
+    -- maybe log if this isn't the case
     forM_ legalHoldClients  (execDelete uid Nothing)
+    Intra.onUserEvent uid Nothing (UserLegalHoldDisabled uid)
+

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -158,7 +158,7 @@ dispatchNotifications orig conn e = case e of
     UserCreated{}         -> return ()
     UserSuspended{}       -> return ()
     UserResumed{}         -> return ()
-    UserLegalHoldDisabled{} -> return ()
+    UserLegalHoldDisabled{} -> notifyContacts event orig Push.RouteAny conn
 
     UserUpdated{..}
         | isJust eupLocale -> notifySelf     event orig Push.RouteDirect conn

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -131,7 +131,8 @@ updateSearchIndex orig e = case e of
     UserActivated{}       -> Search.reindex orig
     UserDeleted{}         -> Search.reindex orig
     UserUpdated{..}       -> do
-        let interesting = or [ isJust eupName , isJust eupAccentId
+        let interesting = or [ isJust eupName 
+                             , isJust eupAccentId
                              , isJust eupHandle
                              , isJust eupSearchable
                              ]

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -124,14 +124,14 @@ updateSearchIndex orig e = case e of
     UserCreated{}         -> return ()
     UserIdentityUpdated{} -> return ()
     UserIdentityRemoved{} -> return ()
+    UserLegalHoldDisabled{} -> return ()
 
     UserSuspended{}       -> Search.reindex orig
     UserResumed{}         -> Search.reindex orig
     UserActivated{}       -> Search.reindex orig
     UserDeleted{}         -> Search.reindex orig
     UserUpdated{..}       -> do
-        let interesting = or [ isJust eupName
-                             , isJust eupAccentId
+        let interesting = or [ isJust eupName , isJust eupAccentId
                              , isJust eupHandle
                              , isJust eupSearchable
                              ]
@@ -158,6 +158,7 @@ dispatchNotifications orig conn e = case e of
     UserCreated{}         -> return ()
     UserSuspended{}       -> return ()
     UserResumed{}         -> return ()
+    UserLegalHoldDisabled{} -> return ()
 
     UserUpdated{..}
         | isJust eupLocale -> notifySelf     event orig Push.RouteDirect conn
@@ -326,6 +327,10 @@ toPushFormat (UserEvent (UserResumed i)) = Just $ M.fromList
     ]
 toPushFormat (UserEvent (UserDeleted i)) = Just $ M.fromList
     [ "type" .= ("user.delete" :: Text)
+    , "id"   .= i
+    ]
+toPushFormat (UserEvent (UserLegalHoldDisabled  i)) = Just $ M.fromList
+    [ "type" .= ("user.legalhold-disabled" :: Text)
     , "id"   .= i
     ]
 toPushFormat (PropertyEvent (PropertySet _ k v)) = Just $ M.fromList

--- a/services/brig/src/Brig/User/Event.hs
+++ b/services/brig/src/Brig/User/Event.hs
@@ -46,6 +46,10 @@ data UserEvent
         , eirEmail :: !(Maybe Email)
         , eirPhone :: !(Maybe Phone)
         }
+    | UserLegalHoldDisabled
+        { elhdId :: !UserId
+        }
+        -- ^ Legal hold was disabled by admin
 
 data ConnectionEvent
     = ConnectionUpdated
@@ -114,6 +118,7 @@ userEventUserId (UserDeleted u)         = u
 userEventUserId UserUpdated{..}         = eupId
 userEventUserId UserIdentityUpdated{..} = eiuId
 userEventUserId UserIdentityRemoved{..} = eirId
+userEventUserId UserLegalHoldDisabled{..} = elhdId
 
 propEventUserId :: PropertyEvent -> UserId
 propEventUserId (PropertySet       u _ _) = u

--- a/services/brig/src/Brig/User/Event/Log.hs
+++ b/services/brig/src/Brig/User/Event/Log.hs
@@ -28,6 +28,7 @@ instance ToBytes UserEvent where
     bytes e@UserSuspended{}       = val "user.suspend: " +++ toByteString (userEventUserId e)
     bytes e@UserResumed{}         = val "user.resume: " +++ toByteString (userEventUserId e)
     bytes e@UserDeleted{}         = val "user.delete: " +++ toByteString (userEventUserId e)
+    bytes e@UserLegalHoldDisabled{} = val "user.legalhold-disabled: " +++ toByteString (userEventUserId e)
 
 instance ToBytes ConnectionEvent where
     bytes e@ConnectionUpdated{} = val "user.connection: " +++ toByteString (connEventUserId e)

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -391,6 +391,12 @@ testDeleteLegalHoldClient brig cannon = do
             let eClientId = j ^? key "client" . key "id" .  _String
             eType @?= Just "user.client-remove"
             eClientId @?= Just (client lhClientId)
+        void . liftIO $ WS.assertMatch (5 # Second) ws $ \n -> do
+            let j = Object $ List1.head (ntfPayload n)
+            let eType = j ^? key "type" . _String
+            let euid = j ^?  key "id" .  _JSON
+            eType @?= Just "user.legalhold-disabled"
+            euid @?= Just uid
 
 testCan'tDeleteLegalHoldClient :: Brig -> Http ()
 testCan'tDeleteLegalHoldClient brig = do


### PR DESCRIPTION
Before, devices did not know when legalhold would go from pending to disabled. Even when legalhold was disabled before the user approved it, the notification to approve would still show up. We now make sure that we send a notification when legalhold gets disabled, such that the client can react appropriately.