### PR TITLE
Feature/legalhold fixes

### DIFF
--- a/libs/wai-utilities/src/Network/Wai/Utilities/Response.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Response.hs
@@ -14,6 +14,9 @@ import qualified Data.ByteString.Lazy as Lazy
 empty :: Response
 empty = plain ""
 
+noContent :: Response
+noContent = empty & setStatus status204
+
 plain :: Lazy.ByteString -> Response
 plain = responseLBS status200 [plainContent]
 

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -133,7 +133,7 @@ updateSearchIndex orig e = case e of
     UserActivated{}       -> Search.reindex orig
     UserDeleted{}         -> Search.reindex orig
     UserUpdated{..}       -> do
-        let interesting = or [ isJust eupName 
+        let interesting = or [ isJust eupName
                              , isJust eupAccentId
                              , isJust eupHandle
                              , isJust eupSearchable
@@ -363,10 +363,9 @@ toPushFormat (ClientEvent (ClientRemoved _ c)) = Just $ M.fromList
     , "client" .= object ["id" .= clientId c]
     ]
 toPushFormat (UserEvent (LegalHoldClientRequested payload)) =
-    let LegalHoldClientRequestedData requester targetUser lastPrekey' clientId = payload
+    let LegalHoldClientRequestedData _ targetUser lastPrekey' clientId = payload
     in Just
        $ M.fromList [ "type" .= ("user.legalhold-request" :: Text)
-                    , "requester" .= requester
                     , "id" .= targetUser
                     , "last_prekey" .= lastPrekey'
                     , "client" .= object ["id" .= clientId ]

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -200,7 +200,7 @@ approveDevice (zusr ::: tid ::: uid ::: connId ::: req ::: _) = do
     legalHoldAuthToken <- Client.getLegalHoldAuthToken uid
     LHService.confirmLegalHold clientId tid uid legalHoldAuthToken
     LegalHoldData.setUserLegalHoldStatus tid uid UserLegalHoldEnabled
-    -- send event at this point
+    -- TODO: send event at this point
     pure empty
   where
     assertUserLHPending :: Galley ()
@@ -225,9 +225,10 @@ disableForUser (zusr ::: tid ::: uid ::: req ::: _) = do
     userLHNotDisabled mems = do
         let target = findTeamMember uid mems
         case fmap (view legalHoldStatus) target of
-            Just UserLegalHoldEnabled -> True
-            Just UserLegalHoldPending -> True
-            _                         -> False
+            Just UserLegalHoldEnabled  -> True
+            Just UserLegalHoldPending  -> True
+            Just UserLegalHoldDisabled -> False
+            Nothing                    -> False -- Never been set
 
     disableLH = do
         DisableLegalHoldForUserRequest mPassword <- fromJsonBody req
@@ -235,4 +236,4 @@ disableForUser (zusr ::: tid ::: uid ::: req ::: _) = do
         Client.removeLegalHoldClientFromUser uid
         LHService.removeLegalHold tid uid
         LegalHoldData.setUserLegalHoldStatus tid uid UserLegalHoldDisabled
-        -- send event at this point
+        -- TODO: send event at this point

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -15,7 +15,7 @@ module Galley.App
     , extEnv
     , aEnv
 
-    , ExtEnv
+    , ExtEnv (..)
     , extGetManager
 
       -- * Galley monad
@@ -30,6 +30,7 @@ module Galley.App
     , ifNothing
     , fromJsonBody
     , fromProtoBody
+    , initExtEnv
     ) where
 
 import Imports

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -72,7 +72,7 @@ tests s = testGroup "Teams LegalHold API"
     , test s "DELETE /teams/{tid}/legalhold/{uid}" testDisableLegalHoldForUser
 
       -- legal hold settings
-    , test s "XXX POST /teams/{tid}/legalhold/settings" testCreateLegalHoldTeamSettings
+    , test s "POST /teams/{tid}/legalhold/settings" testCreateLegalHoldTeamSettings
     , test s "GET /teams/{tid}/legalhold/settings" testGetLegalHoldTeamSettings
     , test s "DELETE /teams/{tid}/legalhold/settings" testRemoveLegalHoldFromTeam
     , test s "GET, PUT [/i]?/teams/{tid}/legalhold" testEnablePerTeam

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -47,6 +47,7 @@ import qualified Control.Concurrent.Async          as Async
 import qualified Cassandra.Exec                    as Cql
 import qualified Data.Aeson                        as Aeson
 import qualified Data.ByteString                   as BS
+import qualified Data.ByteString.Char8             as BS
 import qualified Data.List1                        as List1
 import qualified Network.Wai.Handler.Warp          as Warp
 import qualified Network.Wai.Handler.Warp.Internal as Warp
@@ -71,7 +72,7 @@ tests s = testGroup "Teams LegalHold API"
     , test s "DELETE /teams/{tid}/legalhold/{uid}" testDisableLegalHoldForUser
 
       -- legal hold settings
-    , test s "POST /teams/{tid}/legalhold/settings" testCreateLegalHoldTeamSettings
+    , test s "XXX POST /teams/{tid}/legalhold/settings" testCreateLegalHoldTeamSettings
     , test s "GET /teams/{tid}/legalhold/settings" testGetLegalHoldTeamSettings
     , test s "DELETE /teams/{tid}/legalhold/settings" testRemoveLegalHoldFromTeam
     , test s "GET, PUT [/i]?/teams/{tid}/legalhold" testEnablePerTeam
@@ -155,12 +156,10 @@ testRequestLegalHoldDevice = do
             void . liftIO $ WS.assertMatch (5 WS.# WS.Second) ws $ \n -> do
                 let j = Aeson.Object $ List1.head (ntfPayload n)
                 let etype = j ^? key "type" . _String
-                let eRequester = j ^? key "requester" . _String
                 let eTargetUser = j ^? key "id" . _String
                 let eLastPrekey = j ^? key "last_prekey" . _JSON
                 let eClientId = j ^? key "client" . key "id" . _JSON
                 etype @?= Just "user.legalhold-request"
-                eRequester @?= Just (idToText owner)
                 eTargetUser @?= Just (idToText member)
                 eClientId @?= Just someClientId
                 -- These need to match the values provided by the 'dummy service'
@@ -344,10 +343,6 @@ testCreateLegalHoldTeamSettings = do
     member <- randomUser
     addTeamMemberInternal tid $ newTeamMember member (rolePermissions RoleMember) Nothing
     newService <- newLegalHoldService
-    let Right [k] = pemParseBS "-----BEGIN PUBLIC KEY-----\n\n-----END PUBLIC KEY-----"
-        badService = newService { newLegalHoldServiceKey = ServiceKeyPEM k }
-        -- TODO: make a bad service with a syntactically valid, but wrong certificate.
-
     -- TODO: not allowed if feature is disabled globally in galley config yaml
 
     -- not allowed for users with corresp. permission bit missing
@@ -383,7 +378,9 @@ testCreateLegalHoldTeamSettings = do
             postSettings owner tid newService !!! const 412 === statusCode  -- TODO: test err label
 
         lhtest _isworking@True _ = do
-            postSettings owner tid badService !!! const 400 === statusCode  -- TODO: test err label
+            let Right [k] = pemParseBS "-----BEGIN PUBLIC KEY-----\n\n-----END PUBLIC KEY-----"
+            let badServiceBadKey = newService { newLegalHoldServiceKey = ServiceKeyPEM k }
+            postSettings owner tid badServiceBadKey !!! const 400 === statusCode  -- TODO: test err label
             postSettings owner tid newService !!! const 201 === statusCode
             ViewLegalHoldService service <- getSettingsTyped owner tid
             liftIO $ do
@@ -391,7 +388,11 @@ testCreateLegalHoldTeamSettings = do
                 assertEqual "viewLegalHoldTeam" tid (viewLegalHoldServiceTeam service)
                 assertEqual "viewLegalHoldServiceUrl" (newLegalHoldServiceUrl newService) (viewLegalHoldServiceUrl service)
                 assertEqual "viewLegalHoldServiceFingerprint" fpr (viewLegalHoldServiceFingerprint service)
-            -- TODO: check cassandra as well?
+
+            -- The pubkey is different... if a connection would be reused
+            -- this request would actually return a 201
+            let badServiceValidKey = newService { newLegalHoldServiceKey = ServiceKeyPEM randomButValidPublicKey }
+            postSettings owner tid badServiceValidKey !!! const 412 === statusCode
 
     -- if no valid service response can be obtained, responds with 400
     withTestService (lhapp False) (lhtest False)
@@ -846,7 +847,20 @@ withTestService mkApp go = do
             mkApp buf
     go buf `finally` liftIO (Async.cancel srv)
 
-
+randomButValidPublicKey :: PEM
+randomButValidPublicKey =
+    let Right [k] = pemParseBS . BS.unlines $
+              [ "-----BEGIN PUBLIC KEY-----"
+              , "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu+Kg/PHHU3atXrUbKnw0"
+              , "G06FliXcNt3lMwl2os5twEDcPPFw/feGiAKymxp+7JqZDrseS5D9THGrW+OQRIPH"
+              , "WvUBdiLfGrZqJO223DB6D8K2Su/odmnjZJ2z23rhXoEArTplu+Dg9K+c2LVeXTKV"
+              , "VPOaOzgtAB21XKRiQ4ermqgi3/njr03rXyq/qNkuNd6tNcg+HAfGxfGvvCSYBfiS"
+              , "bUKr/BeArYRcjzr/h5m1In6fG/if9GEI6m8dxHT9JbY53wiksowy6ajCuqskIFg8"
+              , "7X883H+LA/d6X5CTiPv1VMxXdBUiGPuC9IT/6CNQ1/LFt0P37ax58+LGYlaFo7la"
+              , "nQIDAQAZ"
+              , "-----END PUBLIC KEY-----"
+              ]
+    in k
 -- TODO: adding two new legal hold settings on one team is not possible (409)
 -- TODO: deleting or disabling lh settings deletes all lh devices
 -- TODO: PATCH lh settings for updating URL or pubkey.


### PR DESCRIPTION
In this PR:
 - [x] - _It looks like the "approve" endpoint for legal hold does not return a "Content-Type" in its response, so Firefox thinks that it is XML._
 - [x] - ~~_the teams/team_id/legalhold/user_id response does not contain the requester field_~~ removed from the event too
 - [x] - _I register legal hold service and send the pending request to a user. This user sees the popup on the client but waits now. In this moment, i update the legal hold service settings via backend to a new public key. Then i accept the pending legal hold request by the user. Result: It is activated. Should the backend not throw an error because of the wrong public key?_
 - [x] - _If i use the backend call to deactivate LH for a user on a user that was never under LH and never in pending state. The backend sends out events to the clients and the clients show system messages._