### PR TITLE
LH: disable by default; tests.

### DIFF
--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -154,13 +154,13 @@ pubClient c = PubClient
     }
 
 legalHoldClientRequested :: UserId -> LegalHoldClientRequest -> AppIO ()
-legalHoldClientRequested targetUser (LegalHoldClientRequest requester lastPrekey') =
+legalHoldClientRequested targetUser (LegalHoldClientRequest _requester lastPrekey') =
     Intra.onUserEvent targetUser Nothing lhClientEvent
   where
     clientId :: ClientId
     clientId = clientIdFromPrekey $ unpackLastPrekey lastPrekey'
     eventData :: LegalHoldClientRequestedData
-    eventData = LegalHoldClientRequestedData requester targetUser lastPrekey' clientId
+    eventData = LegalHoldClientRequestedData targetUser lastPrekey' clientId
     lhClientEvent :: UserEvent
     lhClientEvent = LegalHoldClientRequested eventData
 

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -363,7 +363,7 @@ toPushFormat (ClientEvent (ClientRemoved _ c)) = Just $ M.fromList
     , "client" .= object ["id" .= clientId c]
     ]
 toPushFormat (UserEvent (LegalHoldClientRequested payload)) =
-    let LegalHoldClientRequestedData _ targetUser lastPrekey' clientId = payload
+    let LegalHoldClientRequestedData targetUser lastPrekey' clientId = payload
     in Just
        $ M.fromList [ "type" .= ("user.legalhold-request" :: Text)
                     , "id" .= targetUser

--- a/services/brig/src/Brig/User/Event.hs
+++ b/services/brig/src/Brig/User/Event.hs
@@ -68,8 +68,7 @@ data ClientEvent
 
 data LegalHoldClientRequestedData =
     LegalHoldClientRequestedData
-    { lhcRequester  :: !UserId
-    , lhcTargetUser :: !UserId
+    { lhcTargetUser :: !UserId
     , lhcLastPrekey :: !LastPrekey
     , lhcClientId   :: !ClientId
     } deriving stock (Show)

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -116,7 +116,7 @@ legalHoldServiceInvalidKey :: Error
 legalHoldServiceInvalidKey = Error status400 "legalhold-invalid-key" "legal hold service pubkey is invalid"
 
 legalHoldServiceUnavailable :: Error
-legalHoldServiceUnavailable = Error status412 "legalhold-unavailable" "legal hold service does not respond"
+legalHoldServiceUnavailable = Error status412 "legalhold-unavailable" "legal hold service does not respond or tls handshake could not be completed (did you pin the wrong public key?)"
 
 legalHoldServiceNotRegistered :: Error
 legalHoldServiceNotRegistered = Error status400 "legalhold-not-registered" "legal hold service has not been registered for this team"

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -121,8 +121,6 @@ removeSettings' tid mMembers = do
 -- Note that this is accessible to ANY authenticated user, even ones outside the team
 getUserStatus :: UserId ::: TeamId ::: UserId ::: JSON -> Galley Response
 getUserStatus (_zusr ::: tid ::: uid ::: _) = do
-    -- TODO: Should we really verify this here? I am not sure it makes sense.
-    -- assertLegalHoldEnabled tid
     mTeamMember <- Data.teamMember tid uid
     teamMember <- maybe (throwM teamMemberNotFound) pure mTeamMember
     statusResponse <- case (view legalHoldStatus teamMember) of

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -73,6 +73,7 @@ createSettings (zusr ::: tid ::: req ::: _) = do
 
     let service = legalHoldService tid fpr newService key
     LegalHoldData.createSettings service
+    -- TODO: Refactor and use `json` function instead which ensures correct content-type is set, etc.
     pure $ responseLBS status201 [] (encode . viewLegalHoldService $ service)
 
 getSettings :: UserId ::: TeamId ::: JSON -> Galley Response

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -116,6 +116,7 @@ removeSettings' tid mMembers = do
     removeLHForUser member = do
         let uid = member ^. Team.userId
         Client.removeLegalHoldClientFromUser uid
+        LHService.removeLegalHold tid uid
         LegalHoldData.setUserLegalHoldStatus tid uid UserLegalHoldDisabled
 
 -- | Learn whether a user has LH enabled and fetch pre-keys.

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -36,7 +36,7 @@ isLegalHoldEnabled tid = do
     return $ case legalHoldTeamConfigStatus <$> lhConfig of
         Just LegalHoldEnabled  -> True
         Just LegalHoldDisabled -> False
-        Nothing                -> True  -- TODO: must be false. this behaviour is only here for testing.
+        Nothing                -> False
 
 -- | Get legal hold status for a team.
 getEnabled :: TeamId ::: JSON -> Galley Response
@@ -44,8 +44,7 @@ getEnabled (tid ::: _) = do
     legalHoldTeamConfig <- LegalHoldData.getLegalHoldTeamConfig tid
     pure . json . fromMaybe defConfig $ legalHoldTeamConfig
   where
-    defConfig = LegalHoldTeamConfig LegalHoldEnabled
-    -- ^ TODO: must be false. this behaviour is only here for testing.
+    defConfig = LegalHoldTeamConfig LegalHoldDisabled
 
 -- | Enable or disable legal hold for a team.
 setEnabled :: TeamId ::: JsonRequest LegalHoldTeamConfig ::: JSON -> Galley Response

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -33,12 +33,10 @@ assertLegalHoldEnabled tid = unlessM (isLegalHoldEnabled tid) $ throwM legalHold
 isLegalHoldEnabled :: TeamId -> Galley Bool
 isLegalHoldEnabled tid = do
     lhConfig <- LegalHoldData.getLegalHoldTeamConfig tid
-    case lhConfig of
-        Just LegalHoldTeamConfig{legalHoldTeamConfigStatus=LegalHoldEnabled}
-          -> return True
-        Just LegalHoldTeamConfig{legalHoldTeamConfigStatus=LegalHoldDisabled}
-          -> return False
-        _ -> return True  -- TODO: must be false. this behaviour is only here for testing.
+    return $ case legalHoldTeamConfigStatus <$> lhConfig of
+        Just LegalHoldEnabled  -> True
+        Just LegalHoldDisabled -> False
+        Nothing                -> True  -- TODO: must be false. this behaviour is only here for testing.
 
 -- | Get legal hold status for a team.
 getEnabled :: TeamId ::: JSON -> Galley Response

--- a/services/galley/src/Galley/API/Swagger.hs
+++ b/services/galley/src/Galley/API/Swagger.hs
@@ -334,6 +334,7 @@ instance ToSchema PrekeyId where
         tweak = fmap $ schema . description ?~ descr
           where
             descr = "in the range [0..65535]."
+              -- TODO: can this be also expressed in swagger, not just in the description?
 
 instance ToSchema Prekey where
     declareNamedSchema = genericDeclareNamedSchema opts

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -854,7 +854,6 @@ publicKeyNotMatchingService =
               ]
     in k
 -- TODO: adding two new legal hold settings on one team is not possible (409)
--- TODO: deleting or disabling lh settings deletes all lh devices
 -- TODO: PATCH lh settings for updating URL or pubkey.
 
 

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -744,15 +744,6 @@ jsonBody resp = either (error . show . (, bdy)) id . Aeson.eitherDecode $ bdy
 ---------------------------------------------------------------------
 --- Device helpers
 
--- data NewLegalHoldDevice = NewLegalHoldDevice
---     { newLegalHoldDeviceTeam  :: TeamId
---     , newLegalHoldDeviceUser  :: UserId
---     }
---   deriving (Eq, Show, Generic)
-
--- getDevice :: HasCallStack => TeamId -> UserId -> TestM ResponseLBS
--- getDevice = undefined
-
 requestDevice :: HasCallStack => UserId -> UserId -> TeamId -> TestM ResponseLBS
 requestDevice zusr uid tid = do
     g <- view tsGalley

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -545,10 +545,8 @@ testEnablePerTeam = do
         LegalHoldTeamConfig isEnabledAfterUnset <- jsonBody <$> (getEnabled tid <!! testResponse 200 Nothing)
         liftIO $ assertEqual "Calling 'putEnabled False' should disable LegalHold" isEnabledAfterUnset LegalHoldDisabled
 
-        -- TODO: This test needs to be re-thought, so I will keep a TODO here; what should really happen when disabling?
-        ignore $ do
-            UserLegalHoldStatusResponse status _ _ <- getUserStatusTyped member tid
-            liftIO $ assertEqual "User legal hold status should be disabled after disabling for team" UserLegalHoldDisabled status
+        UserLegalHoldStatusResponse status _ _ <- getUserStatusTyped member tid
+        liftIO $ assertEqual "User legal hold status should be disabled after disabling for team" UserLegalHoldDisabled status
 
         viewLHS <- getSettingsTyped owner tid
         -- liftIO $ assertEqual "LH Service settings should be cleared"

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -393,14 +393,14 @@ testCreateLegalHoldTeamSettings = do
             let badServiceValidKey = newService { newLegalHoldServiceKey = ServiceKeyPEM publicKeyNotMatchingService }
             postSettings owner tid badServiceValidKey !!! testResponse 412 (Just "legalhold-unavailable")
 
+    -- We do not use the higher level withDummyTestServiceForTeam here because we want to make
+    -- legalhold service misbehave on purpose in certain cases
     -- if no valid service response can be obtained, responds with 400
     withTestService (lhapp False) (lhtest False)
 
     -- if valid service response can be obtained, writes a pending entry to cassandra
     -- synchronously and respond with 201
     withTestService (lhapp True) (lhtest True)
-
-    -- TODO: can we use withDummyTestServiceForTeam here instead?  if not, explain why.
 
     -- TODO: expect event TeamEvent'TEAM_UPDATE as a reaction to this POST.
     -- TODO: should we expect any other events?

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -490,7 +490,7 @@ testRemoveLegalHoldFromTeam = do
         let delete'' = do 
               deleteSettings (Just defPassword) owner tid !!! testResponse 204 Nothing
               liftIO $ assertMatchChan chan $ \(req, _) -> do
-                assertEqual "method" "DELETE" (requestMethod req) 
+                assertEqual "method" "POST" (requestMethod req) 
                 assertEqual "path" (pathInfo req) ["legalhold", "remove"]
               resp <- getSettings owner tid
               liftIO $ assertEqual "bad body" ViewLegalHoldServiceNotConfigured (jsonBody resp)
@@ -931,7 +931,7 @@ instance FromJSON UserEvent where
       "user.legalhold-disable" -> UserLegalHoldDisabled' <$> o .: "id"
       "user.legalhold-request" ->
         LegalHoldClientRequested <$> (LegalHoldClientRequestedData
-          <*> o .: "id" -- this is the target user
+          <$> o .: "id" -- this is the target user
           <*> o .: "last_prekey"
           <*> (o .: "client" >>= Aeson.withObject "id" (.: "id")))
       x -> fail $ "unspported event type: " ++ show x

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -402,10 +402,7 @@ testCreateLegalHoldTeamSettings = do
 
             -- The pubkey is different... if a connection would be reused
             -- this request would actually return a 201
-            let badServiceValidKey = newService { newLegalHoldServiceKey = ServiceKeyPEM randomButValidPublicKey }
-            ignore $ postSettings owner tid badServiceValidKey !!! testResponse 400 (Just "legalhold-invalid-key")
-            -- TODO: request gets a 412 (unavialable) instead of 400.  it should work as the
-            -- test says: the above line should work, and the line below should fail.
+            let badServiceValidKey = newService { newLegalHoldServiceKey = ServiceKeyPEM publicKeyNotMatchingService }
             postSettings owner tid badServiceValidKey !!! testResponse 412 (Just "legalhold-unavailable")
 
     -- if no valid service response can be obtained, responds with 400
@@ -852,8 +849,8 @@ withTestService mkApp go = do
             mkApp buf
     go buf `finally` liftIO (Async.cancel srv)
 
-randomButValidPublicKey :: PEM
-randomButValidPublicKey =
+publicKeyNotMatchingService :: PEM
+publicKeyNotMatchingService =
     let Right [k] = pemParseBS . BS.unlines $
               [ "-----BEGIN PUBLIC KEY-----"
               , "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu+Kg/PHHU3atXrUbKnw0"

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -244,13 +244,18 @@ testApproveLegalHoldDevice = do
         let pluck' = \case
               UserLegalHoldEnabled' eUser -> eUser @?= member
               _ -> assertBool "Unexpected event" False
+
         assertNotification ows pluck'
+        -- We send to all members of a team. which includes the team-settings
         assertNotification member2Ws pluck'
-        when False {- TODO: seems like this is another bug?  or perhaps i set up the conversation wrong? -} $
-          assertNotification outsideContactWs pluck'
+
+        -- People outside of the team should not be notified. However they'll
+        -- for sure discover that the user is under legalhold because they
+        -- discover the legalhold device as soon as they try to send the
+        -- message.
+        assertNoNotification outsideContactWs
         assertNoNotification strangerWs
 
-        -- TODO: sends an event to team settings (however that works; it's a client-independent event i think)
 
 
 testGetLegalHoldDeviceStatus :: TestM ()

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -565,6 +565,9 @@ testCreateLegalHoldDeviceOldAPI = do
 
     -- team owner can't add LH device
     tryout owner
+
+    -- in this one case, we actually don't care about these events and just flush them
+    ensureQueueEmpty
   where
     tryout :: UserId -> TestM ()
     tryout uid = do

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -487,10 +487,6 @@ testRemoveLegalHoldFromTeam = do
         -- returns 204 if legal hold is successfully removed from team
         deleteSettings (Just defPassword) owner tid !!! testResponse 204 Nothing
 
-
-        -- TODO make sure to flush or to move the withService to just here. Because now
-        -- it's hard to decide when the "DELETE" we expect actually shows up
-
         let delete'' = do 
               deleteSettings (Just defPassword) owner tid !!! testResponse 204 Nothing
               liftIO $ assertMatchChan chan $ \(req, _) -> do
@@ -502,8 +498,6 @@ testRemoveLegalHoldFromTeam = do
         -- is idempotent (deleting twice in a row works)
         delete''
         delete''
-
-        -- TODO
 
         -- deletion of settings should disable for all team members and remove their clients
         do UserLegalHoldStatusResponse userStatus _ _ <- getUserStatusTyped member tid
@@ -916,8 +910,7 @@ data ClientEvent
 
 data LegalHoldClientRequestedData =
   LegalHoldClientRequestedData
-  { lhcRequester  :: !UserId
-  , lhcTargetUser :: !UserId
+  { lhcTargetUser :: !UserId
   , lhcLastPrekey :: !LastPrekey
   , lhcClientId   :: !ClientId
   } deriving stock (Show)
@@ -938,7 +931,6 @@ instance FromJSON UserEvent where
       "user.legalhold-disable" -> UserLegalHoldDisabled' <$> o .: "id"
       "user.legalhold-request" ->
         LegalHoldClientRequested <$> (LegalHoldClientRequestedData
-          <$> o .: "id" -- TODO: should be requester. but we dont expose that in the event anymore?
           <*> o .: "id" -- this is the target user
           <*> o .: "last_prekey"
           <*> (o .: "client" >>= Aeson.withObject "id" (.: "id")))

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -66,7 +66,6 @@ tests s = testGroup "Teams LegalHold API"
 
       -- device handling (CRUD)
     , test s "POST /teams/{tid}/legalhold/{uid}" testRequestLegalHoldDevice
-    , test s "POST /teams/{tid}/legalhold/{uid} - twice" testCreateTwoLegalHoldDevices
     , test s "PUT /teams/{tid}/legalhold/approve" testApproveLegalHoldDevice
     , test s "(user denies approval: nothing needs to be done in backend)" (pure ())
     , test s "GET /teams/{tid}/legalhold/{uid}" testGetLegalHoldDeviceStatus

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -102,11 +102,6 @@ tests s = testGroup "Teams LegalHold API"
     ]
 
 
--- TODO: delete this function when we're done fixing all the test cases.
-ignore :: Monad m => m () -> m ()
-ignore _ = trace "\n*** ignored test case!!\n" $ pure ()
-
-
 -- | Make sure the ToSchema and ToJSON instances are in sync for all of the swagger docs.
 -- (this is more of a unit test, but galley doesn't have any, and it seems not worth it to
 -- start another test suite just for this one line.)

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -380,6 +380,7 @@ testCreateLegalHoldTeamSettings = do
             let badServiceBadKey = newService { newLegalHoldServiceKey = ServiceKeyPEM k }
             postSettings owner tid badServiceBadKey !!! testResponse 400 (Just "legalhold-invalid-key")
             postSettings owner tid newService !!! testResponse 201 Nothing
+            postSettings owner tid newService !!! testResponse 201 Nothing  -- it's idempotent
             ViewLegalHoldService service <- getSettingsTyped owner tid
             liftIO $ do
                 Just (_, fpr) <- validateServiceKey (newLegalHoldServiceKey newService)
@@ -853,7 +854,8 @@ publicKeyNotMatchingService =
               , "-----END PUBLIC KEY-----"
               ]
     in k
--- TODO: adding two new legal hold settings on one team is not possible (409)
+
+
 -- TODO: PATCH lh settings for updating URL or pubkey.
 
 

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -175,14 +175,6 @@ testRequestLegalHoldDevice = do
     -- requests approval from monitored user asynchronously; request contains pre-keys
 
 
-testCreateTwoLegalHoldDevices :: TestM ()
-testCreateTwoLegalHoldDevices = do
-    pure ()
-
-    -- creating a second valid a legal hold device is rejected.
-    -- also when the legal hold status of a user is 'pending".
-
-
 testApproveLegalHoldDevice :: TestM ()
 testApproveLegalHoldDevice = do
     (owner, tid) <- createTeam
@@ -295,6 +287,7 @@ testGetLegalHoldDeviceStatus = do
                 assertEqual "last_prekey should be set when LH is pending" (Just (head someLastPrekeys)) lastPrekey'
                 assertEqual "client.id should be set when LH is pending" (Just someClientId) clientId'
 
+        requestDevice owner member tid !!! testResponse 409 (Just "legalhold-already-enabled")
     ensureQueueEmpty
 
 testDisableLegalHoldForUser :: TestM ()

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -193,8 +193,7 @@ testApproveLegalHoldDevice = do
     let lhapp :: Chan () -> Application
         lhapp _ch _req res = res $ responseLBS status200 mempty mempty
     withTestService lhapp $ \_ -> do
-        -- TODO: this returns the wrong label.
-        ignore $ approveLegalHoldDevice (Just defPassword) owner member tid !!! testResponse 403 (Just "legalhold-not-enabled")
+        approveLegalHoldDevice (Just defPassword) owner member tid !!! testResponse 403 (Just "legalhold-not-enabled")
 
     cannon <- view tsCannon
 
@@ -349,13 +348,13 @@ testCreateLegalHoldTeamSettings = do
     newService <- newLegalHoldService
     -- TODO: not allowed if feature is disabled globally in galley config yaml
 
-    -- not allowed for users with corresp. permission bit missing
-    postSettings member tid newService !!! testResponse 403 (Just "operation-denied")
-
     -- not allowed to create if team setting is disabled
     postSettings owner tid newService !!! testResponse 403 (Just "legalhold-not-enabled")
 
     putEnabled tid LegalHoldEnabled -- enable it for this team
+
+    -- not allowed for users with corresp. permission bit missing
+    postSettings member tid newService !!! testResponse 403 (Just "operation-denied")
 
     -- rejected if service is not available
     postSettings owner tid newService !!! testResponse 412 (Just "legalhold-unavailable")

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -676,10 +676,7 @@ ephemeralUser = do
     return $ Brig.Types.userId user
 
 randomClient :: HasCallStack => UserId -> LastPrekey -> TestM ClientId
-randomClient = randomClientWithType PermanentClientType 201
-
-randomClientWithType :: HasCallStack => ClientType -> Int -> UserId -> LastPrekey -> TestM ClientId
-randomClientWithType cType rStatus uid lk = do
+randomClient uid lk = do
     b <- view tsBrig
     resp <- post (b . paths ["i", "clients", toByteString' uid] . json newClientBody)
             <!! const rStatus === statusCode
@@ -687,6 +684,8 @@ randomClientWithType cType rStatus uid lk = do
                            (decodeBody resp)
     return (clientId client)
   where
+    cType = PermanentClientType
+    rStatus = 201
     newClientBody = (newClient cType lk)
         { newClientPassword = Just defPassword
         }


### PR DESCRIPTION
better tests, plus:

- make LH disabled by default in all teams.
- do not allow to create LH devices via `POST /clients` any more.
- always test that LH is enabled first when performing LH operations.
