### PR TITLE
Add generics instances to common, brig, galley types.

### DIFF
--- a/libs/brig-types/src/Brig/Types/Activation.hs
+++ b/libs/brig-types/src/Brig/Types/Activation.hs
@@ -16,13 +16,13 @@ import Data.Text.Ascii
 -- | An opaque identifier of a 'UserKey' awaiting activation.
 newtype ActivationKey = ActivationKey
     { fromActivationKey :: AsciiBase64Url }
-    deriving (Eq, Show, FromByteString, ToByteString, FromJSON, ToJSON)
+    deriving (Eq, Show, FromByteString, ToByteString, FromJSON, ToJSON, Generic)
 
 -- | A random code for use with an 'ActivationKey' that is usually transmitted
 -- out-of-band, e.g. via email or sms.
 newtype ActivationCode = ActivationCode
     { fromActivationCode :: AsciiBase64Url }
-    deriving (Eq, Show, FromByteString, ToByteString, FromJSON, ToJSON)
+    deriving (Eq, Show, FromByteString, ToByteString, FromJSON, ToJSON, Generic)
 
 -- | A pair of 'ActivationKey' and 'ActivationCode' as required for activation.
 type ActivationPair = (ActivationKey, ActivationCode)

--- a/libs/brig-types/src/Brig/Types/Common.hs
+++ b/libs/brig-types/src/Brig/Types/Common.hs
@@ -29,7 +29,7 @@ import qualified Data.Text        as Text
 
 newtype Handle = Handle
     { fromHandle :: Text }
-    deriving (Eq, Show, ToJSON, ToByteString, Hashable)
+    deriving (Eq, Show, ToJSON, ToByteString, Hashable, Generic)
 
 instance FromByteString Handle where
     parser = parser >>= maybe (fail "Invalid handle") return . parseHandle
@@ -57,7 +57,7 @@ isValidHandle t = either (const False) (const True)
 
 newtype Name = Name
     { fromName :: Text }
-    deriving (Eq, Ord, Show, ToJSON, FromByteString, ToByteString)
+    deriving (Eq, Ord, Show, ToJSON, FromByteString, ToByteString, Generic)
 
 instance FromJSON Name where
     parseJSON x = Name . fromRange
@@ -67,7 +67,7 @@ instance FromJSON Name where
 -- Colour
 
 newtype ColourId = ColourId { fromColourId :: Int32 }
-    deriving (Eq, Num, Ord, Show, FromJSON, ToJSON)
+    deriving (Eq, Num, Ord, Show, FromJSON, ToJSON, Generic)
 
 defaultAccentId :: ColourId
 defaultAccentId = ColourId 0
@@ -78,7 +78,7 @@ defaultAccentId = ColourId 0
 data Email = Email
     { emailLocal  :: !Text
     , emailDomain :: !Text
-    } deriving (Eq, Ord)
+    } deriving (Eq, Ord, Generic)
 
 instance Show Email where
     show = Text.unpack . fromEmail
@@ -109,7 +109,7 @@ parseEmail t = case Text.split (=='@') t of
 -----------------------------------------------------------------------------
 -- Phone
 
-newtype Phone = Phone { fromPhone :: Text } deriving (Eq, Show, ToJSON)
+newtype Phone = Phone { fromPhone :: Text } deriving (Eq, Show, ToJSON, Generic)
 
 -- | Parses a phone number in E.164 format with a mandatory leading '+'.
 parsePhone :: Text -> Maybe Phone
@@ -141,7 +141,7 @@ instance ToByteString Phone where
 -- indicates in seconds when another attempt may be made.
 newtype PhoneBudgetTimeout = PhoneBudgetTimeout
     { phoneBudgetTimeout :: NominalDiffTime }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance FromJSON PhoneBudgetTimeout where
     parseJSON = withObject "PhoneBudgetTimeout" $ \o ->
@@ -153,7 +153,7 @@ instance ToJSON PhoneBudgetTimeout where
 -----------------------------------------------------------------------------
 -- PhonePrefix (for excluding from SMS/calling)
 
-newtype PhonePrefix = PhonePrefix { fromPhonePrefix :: Text } deriving (Eq, Show, ToJSON)
+newtype PhonePrefix = PhonePrefix { fromPhonePrefix :: Text } deriving (Eq, Show, ToJSON, Generic)
 
 -- | Parses a phone number prefix with a mandatory leading '+'.
 parsePhonePrefix :: Text -> Maybe PhonePrefix
@@ -189,7 +189,7 @@ instance ToByteString PhonePrefix where
 
 data ExcludedPrefix = ExcludedPrefix { phonePrefix :: PhonePrefix
                                      , comment :: Text
-                                     } deriving (Eq, Show)
+                                     } deriving (Eq, Show, Generic)
 
 instance FromJSON ExcludedPrefix where
     parseJSON = withObject "ExcludedPrefix" $ \o -> ExcludedPrefix
@@ -209,7 +209,7 @@ data UserIdentity
     | EmailIdentity !Email
     | PhoneIdentity        !Phone
     | SSOIdentity !UserSSOId !(Maybe Email) !(Maybe Phone)
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance FromJSON UserIdentity where
     parseJSON = withObject "UserIdentity" $ \o -> do
@@ -270,7 +270,7 @@ data UserSSOId = UserSSOId
       userSSOIdTenant :: Text
     -- | An XML blob specifying the user's ID on the identity provider's side.
     , userSSOIdSubject :: Text
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 instance FromJSON UserSSOId where
     parseJSON = withObject "UserSSOId" $ \obj -> UserSSOId
@@ -284,13 +284,13 @@ instance ToJSON UserSSOId where
 -- Asset
 
 data AssetSize = AssetComplete | AssetPreview
-    deriving (Eq, Show, Enum, Bounded)
+    deriving (Eq, Show, Enum, Bounded, Generic)
 
 -- Note: Intended to be turned into a sum type to add further asset types.
 data Asset = ImageAsset
     { assetKey  :: !Text
     , assetSize :: !(Maybe AssetSize)
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 instance FromJSON AssetSize where
     parseJSON = withText "AssetSize" $ \s ->
@@ -322,7 +322,7 @@ instance ToJSON Asset where
 -----------------------------------------------------------------------------
 -- Language
 
-newtype Language = Language { fromLanguage :: ISO639_1 } deriving (Ord, Eq, Show)
+newtype Language = Language { fromLanguage :: ISO639_1 } deriving (Ord, Eq, Show, Generic)
 
 languageParser :: Parser Language
 languageParser = codeParser "language" $ fmap Language . checkAndConvert isLower
@@ -336,7 +336,7 @@ parseLanguage = hush . parseOnly languageParser
 -----------------------------------------------------------------------------
 -- Country
 
-newtype Country = Country { fromCountry :: CountryCode } deriving (Ord, Eq, Show)
+newtype Country = Country { fromCountry :: CountryCode } deriving (Ord, Eq, Show, Generic)
 
 countryParser :: Parser Country
 countryParser = codeParser "country" $ fmap Country . checkAndConvert isUpper
@@ -353,7 +353,7 @@ parseCountry = hush . parseOnly countryParser
 data Locale = Locale
     { lLanguage :: !Language
     , lCountry  :: !(Maybe Country)
-    } deriving (Eq, Ord)
+    } deriving (Eq, Ord, Generic)
 
 locToText :: Locale -> Text
 locToText (Locale l c) = lan2Text l <> maybe mempty (("-"<>) . con2Text) c
@@ -410,7 +410,7 @@ data ManagedBy
       -- There are some other things that SCIM can't do yet, like setting accent IDs, but they
       -- are not essential, unlike e.g. passwords.
     | ManagedByScim
-    deriving (Eq, Show, Bounded, Enum)
+    deriving (Eq, Show, Bounded, Enum, Generic)
 
 instance FromJSON ManagedBy where
     parseJSON = withText "ManagedBy" $ \case

--- a/libs/brig-types/src/Brig/Types/Connection.hs
+++ b/libs/brig-types/src/Brig/Types/Connection.hs
@@ -28,7 +28,7 @@ import Data.Text as Text
 -- /Note 2019-03-28:/ some clients send it, but we have hidden it anyway in the UI since it
 -- works as a nice source of spam. TODO deprecate and remove.
 newtype Message = Message { messageText :: Text }
-    deriving (Eq, Ord, Show, ToJSON)
+    deriving (Eq, Ord, Show, ToJSON, Generic)
 
 -- | Possible relations between two users. For detailed descriptions of these states, see:
 --
@@ -40,7 +40,7 @@ data Relation
     | Ignored
     | Sent
     | Cancelled
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic)
 
 -- | Exact state of the connection between two users, stored in Brig database (see
 -- 'Brig.Data.Connection.lookupConnections').
@@ -54,25 +54,25 @@ data UserConnection = UserConnection
     , ucLastUpdate :: !UTCTimeMillis     -- ^ When 'ucStatus' was last changed
     , ucMessage    :: !(Maybe Message)
     , ucConvId     :: !(Maybe ConvId)
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 -- | Payload type for a connection request from one user to another.
 data ConnectionRequest = ConnectionRequest
     { crUser    :: !UserId    -- ^ Connection recipient
     , crName    :: !Text      -- ^ Name of the conversation to be created
     , crMessage :: !Message   -- ^ Initial message
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 -- | Payload type for "please change the status of this connection".
 data ConnectionUpdate = ConnectionUpdate
     { cuStatus :: !Relation
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 -- | Response type for endpoints returning lists of connections.
 data UserConnectionList = UserConnectionList
     { clConnections :: [UserConnection]
     , clHasMore     :: !Bool     -- ^ Pagination flag ("we have more results")
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 -- | Response type for endpoints returning lists of users with a specific connection state.
 -- E.g. 'getContactList' returns a 'UserIds' containing the list of connections in an
@@ -84,7 +84,7 @@ data UserIds = UserIds
 data ConnectionsStatusRequest = ConnectionsStatusRequest
     { csrFrom :: ![UserId]
     , csrTo   :: ![UserId]
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 ----------------------------------------------------------------------------
 -- JSON instances

--- a/libs/brig-types/src/Brig/Types/Intra.hs
+++ b/libs/brig-types/src/Brig/Types/Intra.hs
@@ -24,7 +24,7 @@ data AccountStatus
     | Suspended
     | Deleted
     | Ephemeral
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance FromJSON AccountStatus where
     parseJSON = withText "account-status" $ \s -> case Text.toLower s of
@@ -57,7 +57,7 @@ data ConnectionStatus = ConnectionStatus
     { csFrom       :: !UserId
     , csTo         :: !UserId
     , csStatus     :: !Relation
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 instance FromJSON ConnectionStatus where
     parseJSON = withObject "connection-status" $ \o ->
@@ -82,7 +82,7 @@ data UserAccount = UserAccount
     { accountUser       :: !User
     , accountStatus     :: !AccountStatus
     }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance FromJSON UserAccount where
     parseJSON j@(Object o) = do
@@ -103,7 +103,7 @@ instance ToJSON UserAccount where
 -- APIs for auto-connections, listing user's clients)
 data UserSet = UserSet
     { usUsrs :: !(Set UserId)
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 instance FromJSON UserSet where
     parseJSON = withObject "user-set" $ \o ->
@@ -121,7 +121,7 @@ instance ToJSON UserSet where
 -- only for users that have already set a password.
 newtype ReAuthUser = ReAuthUser
     { reAuthPassword :: Maybe PlainTextPassword }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 instance FromJSON ReAuthUser where
     parseJSON = withObject "reauth-user" $ \o ->

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -38,7 +38,7 @@ import qualified Data.Text           as Text
 
 -- DEPRECATED
 newtype Pict = Pict { fromPict :: [Object] }
-    deriving (Eq, Show, ToJSON)
+    deriving (Eq, Show, ToJSON, Generic)
 
 instance FromJSON Pict where
     parseJSON x = Pict . fromRange @0 @10 <$> parseJSON x
@@ -50,7 +50,7 @@ noPict = Pict []
 -- UserHandleInfo
 
 newtype UserHandleInfo = UserHandleInfo { userHandleId :: UserId }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance ToJSON UserHandleInfo where
     toJSON (UserHandleInfo u) = object
@@ -69,7 +69,7 @@ data CheckHandles = CheckHandles
         -- ^ Handles to check for availability, in ascending order of preference.
     , checkHandlesNum  :: Range 1 10 Word
         -- ^ Number of free handles to return. Default 1.
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 instance ToJSON CheckHandles where
     toJSON (CheckHandles l n) = object
@@ -88,7 +88,7 @@ instance FromJSON CheckHandles where
 -- | A self profile.
 data SelfProfile = SelfProfile
     { selfUser       :: !User }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 connectedProfile :: User -> UserProfile
 connectedProfile u = UserProfile
@@ -164,7 +164,7 @@ data User = User
         -- ^ How is the user profile managed (e.g. if it's via SCIM then the user profile
         -- can't be edited via normal means)
     }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 userEmail :: User -> Maybe Email
 userEmail = emailIdentity <=< userIdentity
@@ -194,7 +194,7 @@ data UserProfile = UserProfile
     , profileTeam     :: !(Maybe TeamId)
     , profileEmail    :: !(Maybe Email)
     }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 -- TODO: disentangle json serializations for 'User', 'NewUser', 'UserIdentity', 'NewUserOrigin'.
 instance ToJSON User where
@@ -277,7 +277,7 @@ instance ToJSON SelfProfile where
 data RichInfo = RichInfo
     { richInfoFields :: ![RichField]  -- ^ An ordered list of fields
     }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance ToJSON RichInfo where
     toJSON u = object
@@ -305,7 +305,7 @@ data RichField = RichField
     { richFieldType  :: !Text
     , richFieldValue :: !Text
     }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance ToJSON RichField where
     -- NB: "name" would be a better name for 'richFieldType', but "type" is used because we
@@ -363,7 +363,7 @@ data NewUser = NewUser
     , newUserExpiresIn      :: !(Maybe ExpiresIn)
     , newUserManagedBy      :: !(Maybe ManagedBy)
     }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 -- | 1 second - 1 week
 type ExpiresIn = Range 1 604800 Integer
@@ -371,7 +371,7 @@ type ExpiresIn = Range 1 604800 Integer
 data NewUserOrigin =
     NewUserOriginInvitationCode !InvitationCode
   | NewUserOriginTeamUser !NewTeamUser
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 parseNewUserOrigin :: Maybe PlainTextPassword -> Maybe UserIdentity -> Maybe UserSSOId
                    -> Object -> Aeson.Parser (Maybe NewUserOrigin)
@@ -470,14 +470,14 @@ parseIdentity ssoid o = if isJust (HashMap.lookup "email" o <|> HashMap.lookup "
 -- | A random invitation code for use during registration
 newtype InvitationCode = InvitationCode
     { fromInvitationCode :: AsciiBase64Url }
-    deriving (Eq, Show, FromJSON, ToJSON, ToByteString, FromByteString)
+    deriving (Eq, Show, FromJSON, ToJSON, ToByteString, FromByteString, Generic)
 
 data BindingNewTeamUser = BindingNewTeamUser
     { bnuTeam     :: !BindingNewTeam
     , bnuCurrency :: !(Maybe Currency.Alpha)
     -- TODO: Remove Currency selection once billing supports currency changes after team creation
     }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance FromJSON BindingNewTeamUser where
     parseJSON j@(Object o) = do
@@ -495,7 +495,7 @@ instance ToJSON BindingNewTeamUser where
 data NewTeamUser = NewTeamMember    !InvitationCode      -- ^ requires email address
                  | NewTeamCreator   !BindingNewTeamUser
                  | NewTeamMemberSSO !TeamId
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 -- | We use the same 'NewUser' type for the @\/register@ and @\/i\/users@ endpoints. This
 -- newtype is used as request body type for the public @\/register@ endpoint, where only a
@@ -511,7 +511,7 @@ data NewTeamUser = NewTeamMember    !InvitationCode      -- ^ requires email add
 --   * Setting 'ManagedBy' (it should be the default in all cases unless Spar creates a
 --     SCIM-managed user)
 newtype NewUserPublic = NewUserPublic NewUser
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance FromJSON NewUserPublic where
     parseJSON val = do
@@ -533,17 +533,17 @@ data UserUpdate = UserUpdate
     , uupPict     :: !(Maybe Pict) -- DEPRECATED
     , uupAssets   :: !(Maybe [Asset])
     , uupAccentId :: !(Maybe ColourId)
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
-newtype LocaleUpdate = LocaleUpdate { luLocale :: Locale } deriving (Eq, Show)
-newtype EmailUpdate = EmailUpdate { euEmail :: Email } deriving (Eq, Show)
-newtype PhoneUpdate = PhoneUpdate { puPhone :: Phone } deriving (Eq, Show)
-newtype HandleUpdate = HandleUpdate { huHandle :: Text } deriving (Eq, Show)
-newtype ManagedByUpdate = ManagedByUpdate { mbuManagedBy :: ManagedBy } deriving (Eq, Show)
-newtype RichInfoUpdate = RichInfoUpdate { riuRichInfo :: RichInfo } deriving (Eq, Show)
+newtype LocaleUpdate = LocaleUpdate { luLocale :: Locale } deriving (Eq, Show, Generic)
+newtype EmailUpdate = EmailUpdate { euEmail :: Email } deriving (Eq, Show, Generic)
+newtype PhoneUpdate = PhoneUpdate { puPhone :: Phone } deriving (Eq, Show, Generic)
+newtype HandleUpdate = HandleUpdate { huHandle :: Text } deriving (Eq, Show, Generic)
+newtype ManagedByUpdate = ManagedByUpdate { mbuManagedBy :: ManagedBy } deriving (Eq, Show, Generic)
+newtype RichInfoUpdate = RichInfoUpdate { riuRichInfo :: RichInfo } deriving (Eq, Show, Generic)
 
-newtype EmailRemove = EmailRemove { erEmail :: Email } deriving (Eq, Show)
-newtype PhoneRemove = PhoneRemove { prPhone :: Phone } deriving (Eq, Show)
+newtype EmailRemove = EmailRemove { erEmail :: Email } deriving (Eq, Show, Generic)
+newtype PhoneRemove = PhoneRemove { prPhone :: Phone } deriving (Eq, Show, Generic)
 
 -- NB: when adding new types, please also add roundtrip tests to
 -- 'Test.Brig.Types.User.roundtripTests'
@@ -626,7 +626,7 @@ instance ToJSON PhoneRemove where
 newtype DeleteUser = DeleteUser
     { deleteUserPassword :: Maybe PlainTextPassword
     }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 mkDeleteUser :: Maybe PlainTextPassword -> DeleteUser
 mkDeleteUser = DeleteUser
@@ -635,7 +635,7 @@ mkDeleteUser = DeleteUser
 data VerifyDeleteUser = VerifyDeleteUser
     { verifyDeleteUserKey  :: !Code.Key
     , verifyDeleteUserCode :: !Code.Value
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 mkVerifyDeleteUser :: Code.Key -> Code.Value -> VerifyDeleteUser
 mkVerifyDeleteUser = VerifyDeleteUser
@@ -643,7 +643,7 @@ mkVerifyDeleteUser = VerifyDeleteUser
 -- | A response for a pending deletion code.
 newtype DeletionCodeTimeout = DeletionCodeTimeout
     { fromDeletionCodeTimeout :: Code.Timeout }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance ToJSON DeleteUser where
     toJSON d = object
@@ -677,17 +677,17 @@ instance ToJSON DeletionCodeTimeout where
 
 -- | The payload for initiating a password reset.
 newtype NewPasswordReset = NewPasswordReset (Either Email Phone)
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 -- | Opaque identifier per user (SHA256 of the user ID).
 newtype PasswordResetKey = PasswordResetKey
     { fromPasswordResetKey :: AsciiBase64Url }
-    deriving (Eq, Show, FromByteString, ToByteString, FromJSON, ToJSON)
+    deriving (Eq, Show, FromByteString, ToByteString, FromJSON, ToJSON, Generic)
 
 -- | Random code, acting as a very short-lived, single-use password.
 newtype PasswordResetCode = PasswordResetCode
     { fromPasswordResetCode :: AsciiBase64Url }
-    deriving (Eq, Show, FromByteString, ToByteString, FromJSON, ToJSON)
+    deriving (Eq, Show, FromByteString, ToByteString, FromJSON, ToJSON, Generic)
 
 type PasswordResetPair = (PasswordResetKey, PasswordResetCode)
 
@@ -699,7 +699,7 @@ data PasswordResetIdentity
         -- ^ A known email address with a pending password reset.
     | PasswordResetPhoneIdentity !Phone
         -- ^ A known phone number with a pending password reset.
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 -- | The payload for completing a password reset.
 data CompletePasswordReset = CompletePasswordReset
@@ -707,14 +707,14 @@ data CompletePasswordReset = CompletePasswordReset
     , cpwrCode     :: !PasswordResetCode
     , cpwrPassword :: !PlainTextPassword
     }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 -- | The payload for setting or changing a password.
 data PasswordChange = PasswordChange
     { cpOldPassword :: !(Maybe PlainTextPassword)
     , cpNewPassword :: !PlainTextPassword
     }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance FromJSON NewPasswordReset where
     parseJSON = withObject "NewPasswordReset" $ \o ->

--- a/libs/brig-types/src/Brig/Types/User/Auth.hs
+++ b/libs/brig-types/src/Brig/Types/User/Auth.hs
@@ -162,11 +162,11 @@ data RemoveCookies = RemoveCookies
 -- Cookies can be listed and deleted based on their labels.
 newtype CookieLabel = CookieLabel
     { cookieLabelText :: Text }
-    deriving (Eq, Show, Ord, FromJSON, ToJSON, FromByteString, ToByteString, IsString)
+    deriving (Eq, Show, Ord, FromJSON, ToJSON, FromByteString, ToByteString, IsString, Generic)
 
 newtype CookieId = CookieId
     { cookieIdNum :: Word32 }
-    deriving (Eq, Show, FromJSON, ToJSON)
+    deriving (Eq, Show, FromJSON, ToJSON, Generic)
 
 -- | A (long-lived) cookie scoped to a specific user for obtaining new
 -- 'AccessToken's.
@@ -178,7 +178,7 @@ data Cookie a = Cookie
     , cookieLabel   :: !(Maybe CookieLabel)
     , cookieSucc    :: !(Maybe CookieId)
     , cookieValue   :: !a
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 data CookieList = CookieList
     { cookieList :: [Cookie ()]
@@ -195,7 +195,7 @@ data CookieType
         -- ^ A regular persistent cookie that expires at a specific date.
         -- These cookies are regularly renewed as part of an access token
         -- refresh.
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 instance ToJSON AccessToken where
     toJSON (AccessToken u t tt e) =

--- a/libs/galley-types/src/Galley/Types/Bot/Service/Internal.hs
+++ b/libs/galley-types/src/Galley/Types/Bot/Service/Internal.hs
@@ -18,7 +18,7 @@ import Data.Text.Ascii
 data ServiceRef = ServiceRef
     { _serviceRefId       :: !ServiceId
     , _serviceRefProvider :: !ProviderId
-    } deriving (Ord, Eq, Show)
+    } deriving (Ord, Eq, Show, Generic)
 
 makeLenses ''ServiceRef
 
@@ -40,7 +40,7 @@ instance ToJSON ServiceRef where
 -- | A /secret/ bearer token used to authenticate and authorise requests @towards@
 -- a 'Service' via inclusion in the HTTP 'Authorization' header.
 newtype ServiceToken = ServiceToken AsciiBase64Url
-    deriving (Eq, Show, ToByteString, FromByteString, FromJSON, ToJSON)
+    deriving (Eq, Show, ToByteString, FromByteString, FromJSON, ToJSON, Generic)
 
 -- | Service connection information that is needed by galley.
 data Service = Service

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -136,7 +136,7 @@ data Event = Event
     , _eventTeam :: TeamId
     , _eventTime :: UTCTime
     , _eventData :: Maybe EventData
-    } deriving Eq
+    } deriving (Eq, Generic)
 
 -- Note [whitelist events]
 -- ~~~~~~~~~~~~~~~
@@ -181,7 +181,7 @@ data EventType =
     | MemberUpdate
     | ConvCreate
     | ConvDelete
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 data EventData =
       EdTeamCreate   Team
@@ -191,28 +191,28 @@ data EventData =
     | EdMemberUpdate UserId (Maybe Permissions)
     | EdConvCreate   ConvId
     | EdConvDelete   ConvId
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 data TeamUpdateData = TeamUpdateData
     { _nameUpdate    :: Maybe (Range 1 256 Text)
     , _iconUpdate    :: Maybe (Range 1 256 Text)
     , _iconKeyUpdate :: Maybe (Range 1 256 Text)
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 data TeamList = TeamList
     { _teamListTeams   :: [Team]
     , _teamListHasMore :: Bool
-    } deriving Show
+    } deriving (Show, Generic)
 
 data TeamMember = TeamMember
     { _userId      :: UserId
     , _permissions :: Permissions
     , _invitation  :: Maybe (UserId, UTCTimeMillis)
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Ord, Show, Generic)
 
 newtype TeamMemberList = TeamMemberList
     { _teamMembers :: [TeamMember]
-    } deriving (Semigroup, Monoid)
+    } deriving (Semigroup, Monoid, Generic)
 
 data TeamConversation = TeamConversation
     { _conversationId      :: ConvId
@@ -226,7 +226,7 @@ newtype TeamConversationList = TeamConversationList
 data Permissions = Permissions
     { _self :: Set Perm
     , _copy :: Set Perm
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Ord, Show, Generic)
 
 data Perm =
       CreateConversation
@@ -246,10 +246,10 @@ data Perm =
     -- (CRUD vs. Add,Remove vs; Get,Set vs. Create,Delete etc).
     -- If you ever think about adding a new permission flag,
     -- read Note [team roles] first.
-    deriving (Eq, Ord, Show, Enum, Bounded)
+    deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 data Role = RoleOwner | RoleAdmin | RoleMember | RoleExternalPartner
-    deriving (Eq, Ord, Show, Enum, Bounded)
+    deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 defaultRole :: Role
 defaultRole = RoleMember
@@ -281,10 +281,10 @@ rolePerms RoleExternalPartner = Set.fromList
     ]
 
 newtype BindingNewTeam = BindingNewTeam (NewTeam ())
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 newtype NonBindingNewTeam = NonBindingNewTeam (NewTeam (Range 1 127 [TeamMember]))
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 newtype NewTeamMember = NewTeamMember
     { _ntmNewTeamMember :: TeamMember

--- a/libs/galley-types/src/Galley/Types/Teams/Internal.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Internal.hs
@@ -18,7 +18,7 @@ import Data.Range
 data TeamBinding =
       Binding
     | NonBinding
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 data Team = Team
     { _teamId      :: TeamId
@@ -27,7 +27,7 @@ data Team = Team
     , _teamIcon    :: Text
     , _teamIconKey :: Maybe Text
     , _teamBinding :: TeamBinding
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 data NewTeam a = NewTeam
     { _newTeamName    :: Range 1 256 Text
@@ -35,7 +35,7 @@ data NewTeam a = NewTeam
     , _newTeamIconKey :: Maybe (Range 1 256 Text)
     , _newTeamMembers :: Maybe a
     }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 
 instance ToJSON TeamBinding where

--- a/libs/metrics-core/src/Data/Metrics.hs
+++ b/libs/metrics-core/src/Data/Metrics.hs
@@ -87,6 +87,7 @@ data Metrics =
         , gauges     :: IORef (HashMap Path Gauge)
         , histograms :: IORef (HashMap Path Histogram)
         }
+  deriving (Generic)
 
 -- Initialize an empty set of metrics
 metrics :: MonadIO m => m Metrics

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -54,7 +54,7 @@ infixr 5 #
 -- Construct values using 'toUTCTimeMillis'; deconstruct with 'fromUTCTimeMillis'.
 -- Unlike with 'UTCTime', 'Show' renders ISO string.
 newtype UTCTimeMillis = UTCTimeMillis { fromUTCTimeMillis :: UTCTime }
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Generic)
 
 {-# INLINE toUTCTimeMillis #-}
 toUTCTimeMillis :: HasCallStack => UTCTime -> UTCTimeMillis

--- a/libs/types-common/src/Data/Misc.hs
+++ b/libs/types-common/src/Data/Misc.hs
@@ -65,7 +65,7 @@ import qualified Data.Text                        as Text
 --------------------------------------------------------------------------------
 -- IpAddr / Port
 
-newtype IpAddr = IpAddr { ipAddr :: IP } deriving (Eq, Ord, Show)
+newtype IpAddr = IpAddr { ipAddr :: IP } deriving (Eq, Ord, Show, Generic)
 
 instance FromByteString IpAddr where
     parser = do
@@ -84,7 +84,7 @@ instance NFData IpAddr where rnf (IpAddr a) = seq a ()
 
 newtype Port = Port
     { portNumber :: Word16
-    } deriving (Eq, Ord, Show, Real, Enum, Num, Integral, NFData)
+    } deriving (Eq, Ord, Show, Real, Enum, Num, Integral, NFData, Generic)
 
 instance Read Port where
     readsPrec n = map (\x -> (Port (fst x), snd x)) . readsPrec n
@@ -123,8 +123,8 @@ instance NFData Location
 
 makeLenses ''Location
 
-newtype Latitude  = Latitude  Double deriving NFData
-newtype Longitude = Longitude Double deriving NFData
+newtype Latitude  = Latitude  Double deriving (NFData, Generic)
+newtype Longitude = Longitude Double deriving (NFData, Generic)
 
 location :: Latitude -> Longitude -> Location
 location (Latitude lat) (Longitude lon) =
@@ -161,7 +161,7 @@ instance Cql Longitude where
 
 newtype Milliseconds = Ms
     { ms :: Word64
-    } deriving (Eq, Ord, Show, Num)
+    } deriving (Eq, Ord, Show, Num, Generic)
 
 -- | Convert milliseconds to 'Int64', with clipping if it doesn't fit.
 msToInt64 :: Milliseconds -> Int64
@@ -191,7 +191,7 @@ instance Cql Milliseconds where
 
 newtype HttpsUrl = HttpsUrl
     { httpsUrl :: URIRef Absolute
-    } deriving Eq
+    } deriving (Eq, Generic)
 
 mkHttpsUrl :: URIRef Absolute -> Either String HttpsUrl
 mkHttpsUrl uri = if uri ^. uriSchemeL . schemeBSL == "https"
@@ -230,7 +230,7 @@ data Rsa
 
 newtype Fingerprint a = Fingerprint
     { fingerprintBytes :: ByteString
-    } deriving (Eq, Show, FromByteString, ToByteString, NFData)
+    } deriving (Eq, Show, FromByteString, ToByteString, NFData, Generic)
 
 instance FromJSON (Fingerprint a) where
     parseJSON = withText "Fingerprint" $
@@ -253,7 +253,7 @@ instance Cql (Fingerprint a) where
 
 newtype PlainTextPassword = PlainTextPassword
     { fromPlainTextPassword :: Text }
-    deriving (Eq, ToJSON)
+    deriving (Eq, ToJSON, Generic)
 
 instance Show PlainTextPassword where
     show _ = "PlainTextPassword <hidden>"


### PR DESCRIPTION
This is needed for the servant-swagger / swagger2 business.  It's not an
exhaustive change set, just what I needed when playing with this.