### PR TITLE
Canonicalize capture names

### DIFF
--- a/docs/reference/user/rich-info.md
+++ b/docs/reference/user/rich-info.md
@@ -18,7 +18,7 @@ Only team members and partners can see the user's rich info.
 
 ### Querying rich info {#RefRichInfoGet}
 
-`GET /users/:user/rich-info`. Sample output:
+`GET /users/:uid/rich-info`. Sample output:
 
 ```json
 {

--- a/libs/metrics-wai/package.yaml
+++ b/libs/metrics-wai/package.yaml
@@ -12,14 +12,16 @@ dependencies:
 - base ==4.*
 - bytestring >=0.10
 - clock >=0.6
+- containers
 - exceptions >=0.6
 - http-types >=0.8
 - imports
 - metrics-core >=0.3
-- containers
 - prometheus-client
 - servant
 - string-conversions
+- tasty
+- tasty-hunit
 - text >=0.11
 - transformers >=0.3
 - wai >=3

--- a/libs/metrics-wai/src/Data/Metrics/Middleware/Prometheus.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Middleware/Prometheus.hs
@@ -44,7 +44,7 @@ normalizeWaiRequestRoute paths req = pathInfo
     -- Use the normalized path info if available; otherwise dump the raw path info for
     -- debugging purposes
     pathInfo :: Text
-    pathInfo  = T.decodeUtf8 $ fromMaybe (Wai.rawPathInfo req) mPathInfo
+    pathInfo  = T.decodeUtf8 $ fromMaybe "N/A" mPathInfo
 
 -- | This can be refactored away once https://github.com/fimad/prometheus-haskell/pull/45 has
 -- been released on hackage.

--- a/libs/metrics-wai/src/Data/Metrics/Servant.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Servant.hs
@@ -19,7 +19,7 @@ import Servant.API
 
 
 routesToPaths :: forall routes. RoutesToPaths routes => Paths
-routesToPaths = Paths (getRoutes @routes)
+routesToPaths = Paths (meltTree (getRoutes @routes))
 
 class RoutesToPaths routes where
   getRoutes :: Forest PathSegment

--- a/libs/metrics-wai/src/Data/Metrics/Servant.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Servant.hs
@@ -30,14 +30,14 @@ instance {-# OVERLAPPING #-}
          ( KnownSymbol seg
          , RoutesToPaths segs
          ) => RoutesToPaths (seg :> segs) where
-  getRoutes = [Node (Right . cs $ symbolVal (Proxy @seg)) (getRoutes @segs)]
+  getRoutes = [Node (ConstantSeg . cs $ symbolVal (Proxy @seg)) (getRoutes @segs)]
 
 -- <capture> <:> routes
 instance {-# OVERLAPPING #-}
          ( KnownSymbol capture
          , RoutesToPaths segs
          ) => RoutesToPaths (Capture' mods capture a :> segs) where
-  getRoutes = [Node (Left ":_") (getRoutes @segs)]
+  getRoutes = [Node CaptureSeg (getRoutes @segs)]
 
 -- route <:> routes
 instance {-# OVERLAPPING #-}

--- a/libs/metrics-wai/src/Data/Metrics/Servant.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Servant.hs
@@ -30,14 +30,14 @@ instance {-# OVERLAPPING #-}
          ( KnownSymbol seg
          , RoutesToPaths segs
          ) => RoutesToPaths (seg :> segs) where
-  getRoutes = [Node (ConstantSeg . cs $ symbolVal (Proxy @seg)) (getRoutes @segs)]
+  getRoutes = [Node (Right . cs $ symbolVal (Proxy @seg)) (getRoutes @segs)]
 
 -- <capture> <:> routes
 instance {-# OVERLAPPING #-}
          ( KnownSymbol capture
          , RoutesToPaths segs
          ) => RoutesToPaths (Capture' mods capture a :> segs) where
-  getRoutes = [Node CaptureSeg (getRoutes @segs)]
+  getRoutes = [Node (Left ":_") (getRoutes @segs)]
 
 -- route <:> routes
 instance {-# OVERLAPPING #-}

--- a/libs/metrics-wai/src/Data/Metrics/Test.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Test.hs
@@ -50,11 +50,11 @@ pathsConsistencyCheck (Paths forest) = mconcat $ go [] <$> forest
     findSiteConsistencyError prefix subtrees = case catMaybes $ captureVars <$> subtrees of
           []          -> Nothing
           [_]         -> Nothing
-          bad@(_:_:_) -> Just $ SiteConsistencyError (either cs cs <$> prefix) bad
+          bad@(_:_:_) -> Just $ SiteConsistencyError (cs . pathSegmentToString <$> prefix) bad
 
-    captureVars :: Tree.Tree (Either ByteString any) -> Maybe (Text, Int)
-    captureVars (Tree.Node (Left root) trees) = Just (cs root, weight trees)
-    captureVars (Tree.Node (Right _) _) = Nothing
+    captureVars :: Tree.Tree PathSegment -> Maybe (Text, Int)
+    captureVars (Tree.Node CaptureSeg trees) = Just ("_", weight trees)
+    captureVars (Tree.Node (ConstantSeg _) _) = Nothing
 
     weight :: Tree.Forest a -> Int
     weight = sum . fmap (length . Tree.flatten)

--- a/libs/metrics-wai/src/Data/Metrics/Test.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Test.hs
@@ -50,11 +50,11 @@ pathsConsistencyCheck (Paths forest) = mconcat $ go [] <$> forest
     findSiteConsistencyError prefix subtrees = case catMaybes $ captureVars <$> subtrees of
           []          -> Nothing
           [_]         -> Nothing
-          bad@(_:_:_) -> Just $ SiteConsistencyError (cs . pathSegmentToString <$> prefix) bad
+          bad@(_:_:_) -> Just $ SiteConsistencyError (either cs cs <$> prefix) bad
 
-    captureVars :: Tree.Tree PathSegment -> Maybe (Text, Int)
-    captureVars (Tree.Node CaptureSeg trees) = Just ("_", weight trees)
-    captureVars (Tree.Node (ConstantSeg _) _) = Nothing
+    captureVars :: Tree.Tree (Either ByteString any) -> Maybe (Text, Int)
+    captureVars (Tree.Node (Left root) trees) = Just (cs root, weight trees)
+    captureVars (Tree.Node (Right _) _) = Nothing
 
     weight :: Tree.Forest a -> Int
     weight = sum . fmap (length . Tree.flatten)

--- a/libs/metrics-wai/src/Data/Metrics/Test.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Test.hs
@@ -1,0 +1,57 @@
+module Data.Metrics.Test where
+
+import Imports
+
+import Data.Metrics.Types
+import Data.Metrics.WaiRoute (treeToPaths)
+import Data.String.Conversions (cs)
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (testCase, assertEqual)
+
+import qualified Data.Text as Text
+import qualified Data.Tree as Tree
+import qualified Network.Wai.Routing.Route     as Route
+
+
+sitemapConsistency :: Route.Tree a -> TestTree
+sitemapConsistency smap = testCase "" $ assertEqual "inconcistent sitemap" mempty (siteConsistencyCheck smap)
+
+-- | It is an error for one prefix to end in two different capture variables.  eg., these two
+-- routes constitute a confict: "/user/:uid", "/user/:id".  There is a show instance that
+-- explains this better.
+data SiteConsistencyError = SiteConsistencyError
+    { _siteConsistencyPrefix      :: [Text]
+    , _siteConsistencyCaptureVars :: [(Text, Int)]
+    }
+  deriving (Eq)
+
+instance Show SiteConsistencyError where
+  show (SiteConsistencyError prefix conflicts) =
+    "bad routing tables: the prefix " <>
+    show ("/" <> Text.intercalate "/" prefix) <> " " <>
+    "contains these variables with (very roughly) the resp. numbers of routes under them: " <>
+    show conflicts
+
+siteConsistencyCheck :: Route.Tree any -> [SiteConsistencyError]
+siteConsistencyCheck = pathsConsistencyCheck . treeToPaths
+
+pathsConsistencyCheck :: Paths -> [SiteConsistencyError]
+pathsConsistencyCheck (Paths forest) = mconcat $ go [] <$> forest
+  where
+    go :: [PathSegment] -> Tree.Tree PathSegment -> [SiteConsistencyError]
+    go prefix (Tree.Node root trees) = maybeToList here <> (mconcat $ go (root : prefix) <$> trees)
+      where
+        here = findSiteConsistencyError (reverse $ root : prefix) trees
+
+    findSiteConsistencyError :: [PathSegment] -> Tree.Forest PathSegment -> Maybe SiteConsistencyError
+    findSiteConsistencyError prefix subtrees = case catMaybes $ captureVars <$> subtrees of
+          []          -> Nothing
+          [_]         -> Nothing
+          bad@(_:_:_) -> Just $ SiteConsistencyError (either cs cs <$> prefix) bad
+
+    captureVars :: Tree.Tree (Either ByteString any) -> Maybe (Text, Int)
+    captureVars (Tree.Node (Left root) trees) = Just (cs root, weight trees)
+    captureVars (Tree.Node (Right _) _) = Nothing
+
+    weight :: Tree.Forest a -> Int
+    weight = sum . fmap (length . Tree.flatten)

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -12,31 +12,121 @@ ghc-options:
 - -funbox-strict-fields
 dependencies:
 - aeson >=0.11
+- amazonka >=1.3.7
+- amazonka-dynamodb >=1.3.7
+- amazonka-ses >=1.3.7
+- amazonka-sns >=1.3.7
+- amazonka-sqs >=1.3.7
+- async >=2.1
+- attoparsec >=0.12
+- auto-update >=0.1
+- base16-bytestring >=0.1
 - base ==4.*
 - base64-bytestring >=1.0
+- base-prelude
+- bilge >=0.21.1
+- blaze-builder >=0.3
 - bloodhound >=0.13
+- brig-types >=0.91.1
+- bytestring >=0.10
 - bytestring-conversion >=0.2
-- cookie >=0.4
+- cassandra-util >=0.16.2
+- conduit >=1.2.8
 - containers >=0.5
+- cookie >=0.4
+- cryptobox-haskell >=0.1.1
+- currency-codes >=2.0
+- data-default >=0.5
+- data-timeout >=0.3
 - directory >=1.2
+- either >=4.3
+- email-validate >=2.0
+- enclosed-exceptions >=1.0
 - errors >=1.4
 - exceptions >=0.5
 - extended
-- imports
-- http-types >=0.8
+- extra >=1.3
+- filepath >=1.3
+- fsnotify >=0.2
+- galley-types >=0.75.3
+- geoip2 >=0.3.1.0
+- gundeck-types >=1.32.1
+- hashable >=1.2
+- HaskellNet >=0.3
+- HaskellNet-SSL >=0.3
 - HsOpenSSL >=0.10
+- HsOpenSSL-x509-system >=0.1
+- html-entities >=1.1
+- http-client >=0.5
+- http-client-openssl >=0.2
+- http-types >=0.8
+- imports
+- iproute >=1.5
+- iso639 >=0.1
+- lens >=3.8
 - lens-aeson >=1.0
+- lifted-base >=0.2
+- metrics-core >=0.3
+- metrics-wai >=0.3
+- mime
+- mime-mail >=0.4
+- monad-control >=1.0
+- MonadRandom >=0.5
 - mtl >=2.1
+- multihash >=0.1.3
+- mwc-random
+- network >=2.4
+- network-conduit-tls
+- network-uri >=2.6
 - optparse-applicative >=0.11
+- pem >=0.2
 - prometheus-client
+- proto-lens >=0.1
+- random-shuffle >=0.0.3
+- resource-pool >=0.2
+- resourcet >=1.1
+- retry >=0.7
+- ropes >=0.4.20
 - safe >=0.3
+- scientific >=0.3.4
+- scrypt >=0.5
+- semigroups >=0.15
+- singletons >=2.0
+- smtp-mail >=0.1
+- sodium-crypto-sign >=0.1
+- split >=0.2
+- ssl-util
+- statistics >=0.13
+- stomp-queue >=0.3
+- string-conversions
+- swagger >=0.1
+- tagged >=0.7
+- template >=0.2
 - text >=0.11
-- transformers >=0.3
+- text-icu-translit >=0.1
+- time >=1.1
 - tinylog >=0.10
+- tls >=1.3.4
+- transformers >=0.3
+- transformers-base >=0.4
+- types-common >=0.16
 - types-common-journal >=0.1
+- unliftio >=0.2
+- unliftio-core >=0.1
+- unordered-containers >=0.2
+- uri-bytestring >=0.2
 - uuid >=1.3.5
+- vault >=0.3
+- vector >=0.11
+- wai >=3.0
 - wai-extra >=3.0
+- wai-middleware-gunzip >=0.0.2
+- wai-predicates >=0.8
+- wai-routing >=0.12
+- wai-utilities >=0.16
+- warp >=3.0.12.1
 - yaml >=0.8.22
+- zauth >=0.10.3
 library:
   source-dirs: src
   exposed-modules:
@@ -53,97 +143,6 @@ library:
   - Brig.User.Auth.Cookie.Limit
   - Brig.User.Search.Index
   - Brig.ZAuth
-  dependencies:
-  - amazonka >=1.3.7
-  - amazonka-dynamodb >=1.3.7
-  - amazonka-ses >=1.3.7
-  - amazonka-sns >=1.3.7
-  - amazonka-sqs >=1.3.7
-  - attoparsec >=0.12
-  - async >=2.1
-  - auto-update >=0.1
-  - base-prelude
-  - base16-bytestring >=0.1
-  - bilge >=0.21.1
-  - blaze-builder >=0.3
-  - brig-types >=0.91.1
-  - bytestring >=0.10
-  - cassandra-util >=0.16.2
-  - currency-codes >=2.0
-  - conduit >=1.2.8
-  - cryptobox-haskell >=0.1.1
-  - data-default >=0.5
-  - data-timeout >=0.3
-  - either >=4.3
-  - email-validate >=2.0
-  - enclosed-exceptions >=1.0
-  - extra >=1.3
-  - geoip2 >=0.3.1.0
-  - galley-types >=0.75.3
-  - gundeck-types >=1.32.1
-  - filepath >=1.3
-  - fsnotify >=0.2
-  - iso639 >=0.1
-  - hashable >=1.2
-  - html-entities >=1.1
-  - http-client >=0.5
-  - http-client-openssl >=0.2
-  - HaskellNet >=0.3
-  - HaskellNet-SSL >=0.3
-  - HsOpenSSL-x509-system >=0.1
-  - iproute >=1.5
-  - lens >=3.8
-  - lifted-base >=0.2
-  - mime
-  - mime-mail >=0.4
-  - metrics-core >=0.3
-  - metrics-wai >=0.3
-  - monad-control >=1.0
-  - MonadRandom >=0.5
-  - multihash >=0.1.3
-  - mwc-random
-  - network >=2.4
-  - network-conduit-tls
-  - network-uri >=2.6
-  - pem >=0.2
-  - proto-lens >=0.1
-  - resourcet >=1.1
-  - resource-pool >=0.2
-  - ropes >=0.4.20
-  - scientific >=0.3.4
-  - scrypt >=0.5
-  - smtp-mail >=0.1
-  - split >=0.2
-  - semigroups >=0.15
-  - singletons >=2.0
-  - stomp-queue >=0.3
-  - string-conversions
-  - ssl-util
-  - random-shuffle >=0.0.3
-  - sodium-crypto-sign >=0.1
-  - statistics >=0.13
-  - swagger >=0.1
-  - tagged >=0.7
-  - template >=0.2
-  - text-icu-translit >=0.1
-  - time >=1.1
-  - tls >=1.3.4
-  - transformers-base >=0.4
-  - types-common >=0.16
-  - retry >=0.7
-  - unliftio >=0.2
-  - unliftio-core >=0.1
-  - unordered-containers >=0.2
-  - uri-bytestring >=0.2
-  - vault >=0.3
-  - vector >=0.11
-  - wai >=3.0
-  - wai-middleware-gunzip >=0.0.2
-  - wai-predicates >=0.8
-  - wai-routing >=0.12
-  - wai-utilities >=0.16
-  - warp >=3.0.12.1
-  - zauth >=0.10.3
 executables:
   brig-schema:
     main: Main.hs

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -75,9 +75,9 @@ sitemap o = do
     get "/i/monitoring" (continue $ const $ view metrics >>= fmap json . render) $
         accept "application" "json"
 
-    post "/i/users/:id/auto-connect" (continue autoConnect) $
+    post "/i/users/:uid/auto-connect" (continue autoConnect) $
         accept "application" "json"
-        .&. capture "id"
+        .&. capture "uid"
         .&. opt (header "Z-Connection")
         .&. jsonRequest @UserSet
 
@@ -89,8 +89,8 @@ sitemap o = do
         header "Z-User"
         .&. jsonRequest @EmailUpdate
 
-    delete "/i/users/:id" (continue deleteUserNoVerify) $
-        capture "id"
+    delete "/i/users/:uid" (continue deleteUserNoVerify) $
+        capture "uid"
 
     get "/i/users/connections-status" (continue deprecatedGetConnectionsStatus) $
         query "users"
@@ -109,17 +109,17 @@ sitemap o = do
         accept "application" "json"
         .&. (param "email" ||| param "phone")
 
-    put "/i/users/:id/status" (continue changeAccountStatus) $
-        capture "id"
+    put "/i/users/:uid/status" (continue changeAccountStatus) $
+        capture "uid"
         .&. jsonRequest @AccountStatusUpdate
 
-    get "/i/users/:id/status" (continue getAccountStatus) $
+    get "/i/users/:uid/status" (continue getAccountStatus) $
         accept "application" "json"
-        .&. capture "id"
+        .&. capture "uid"
 
-    get "/i/users/:id/contacts" (continue getContactList) $
+    get "/i/users/:uid/contacts" (continue getContactList) $
         accept "application" "json"
-        .&. capture "id"
+        .&. capture "uid"
 
     get "/i/users/activation-code" (continue getActivationCode) $
         accept "application" "json"
@@ -208,9 +208,9 @@ sitemap o = do
 
     ---
 
-    head "/users/:id" (continue checkUserExists) $
+    head "/users/:uid" (continue checkUserExists) $
         header "Z-User"
-        .&. capture "id"
+        .&. capture "uid"
 
     document "HEAD" "userExists" $ do
         Doc.summary "Check if a user ID exists"
@@ -221,10 +221,10 @@ sitemap o = do
 
     ---
 
-    get "/users/:id" (continue getUser) $
+    get "/users/:uid" (continue getUser) $
         accept "application" "json"
         .&. header "Z-User"
-        .&. capture "id"
+        .&. capture "uid"
 
     document "GET" "user" $ do
         Doc.summary "Get a user by ID"
@@ -311,8 +311,8 @@ sitemap o = do
 
     ---
 
-    get "/users/:user/prekeys" (continue getPrekeyBundle) $
-        capture "user"
+    get "/users/:uid/prekeys" (continue getPrekeyBundle) $
+        capture "uid"
         .&. accept "application" "json"
 
     document "GET" "getPrekeyBundle" $ do
@@ -324,8 +324,8 @@ sitemap o = do
 
     ---
 
-    get "/users/:user/prekeys/:client" (continue getPrekey) $
-        capture "user"
+    get "/users/:uid/prekeys/:client" (continue getPrekey) $
+        capture "uid"
         .&. capture "client"
         .&. accept "application" "json"
 
@@ -340,8 +340,8 @@ sitemap o = do
 
     --
 
-    get "/users/:user/clients" (continue getUserClients) $
-        capture "user"
+    get "/users/:uid/clients" (continue getUserClients) $
+        capture "uid"
         .&. accept "application" "json"
 
     document "GET" "getUserClients" $ do
@@ -353,8 +353,8 @@ sitemap o = do
 
     --
 
-    get "/users/:user/clients/:client" (continue getUserClient) $
-        capture "user"
+    get "/users/:uid/clients/:client" (continue getUserClient) $
+        capture "uid"
         .&. capture "client"
         .&. accept "application" "json"
 
@@ -369,9 +369,9 @@ sitemap o = do
 
     --
 
-    get "/users/:user/rich-info" (continue getRichInfo) $
+    get "/users/:uid/rich-info" (continue getRichInfo) $
         header "Z-User"
-        .&. capture "user"
+        .&. capture "uid"
         .&. accept "application" "json"
 
     document "GET" "getRichInfo" $ do

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -765,7 +765,7 @@ verifyDeleteUser d = do
     for_ account $ lift . deleteAccount
     lift $ Code.delete key Code.AccountDeletion
 
--- | Internal deletion without validation.  Called via @delete /i/user/:id@.  Team users can be
+-- | Internal deletion without validation.  Called via @delete /i/user/:uid@.  Team users can be
 -- deleted iff the team is not orphaned, i.e. there is at least one user with an email address left
 -- in the team.
 deleteAccount :: UserAccount -> AppIO ()

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -147,8 +147,8 @@ routes = do
         accept "application" "json"
         .&. param "phone"
 
-    get "/i/users/:id/reauthenticate" (continue reAuthUser) $
-        capture "id"
+    get "/i/users/:uid/reauthenticate" (continue reAuthUser) $
+        capture "uid"
         .&. jsonRequest @ReAuthUser
 
 -- Handlers

--- a/services/brig/test/integration/API/Metrics.hs
+++ b/services/brig/test/integration/API/Metrics.hs
@@ -49,7 +49,7 @@ testMonitoringEndpoint brig = do
 
     resp :: Value <- jsonBody <$> get (brig . path "i/monitoring")
     let have :: Set Text = Set.fromList $ fst <$> (resp ^@.. key "net" . key "resources" . members)
-        want :: Set Text = Set.fromList $ cs <$> [p1, p2 ":user"]
+        want :: Set Text = Set.fromList $ cs <$> [p1, p2 ":uid"]
         errmsg = "some of " <> show want <> " missing in metrics: " <> show have
     liftIO $ assertBool errmsg (want `Set.isSubsetOf` have)
 

--- a/services/brig/test/integration/API/Settings.hs
+++ b/services/brig/test/integration/API/Settings.hs
@@ -44,7 +44,7 @@ tests defOpts manager brig galley = return $ do
                 . runHttpT manager
                 $ testUsersEmailVisibleIffExpected defOpts brig galley Opt.EmailVisibleToSelf
                 ]
-            , testGroup "/users/:id"
+            , testGroup "/users/:uid"
                 [ testCase "EmailVisibleIfOnTeam"
                 . runHttpT manager
                 $ testGetUserEmailShowsEmailsIffExpected defOpts brig galley Opt.EmailVisibleIfOnTeam

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -70,7 +70,7 @@ tests conf m b c g aws = do
             ]
         , testGroup "sso"
             [ test m "post /i/users  - 201 internal-SSO" $ testCreateUserInternalSSO b g
-            , test m "delete /i/users/:id - 202 internal-SSO (ensure no orphan teams)" $ testDeleteUserSSO b g
+            , test m "delete /i/users/:uid - 202 internal-SSO (ensure no orphan teams)" $ testDeleteUserSSO b g
             , test m "get /i/users/:uid/is-team-owner/:tid" $ testSSOIsTeamOwner b g
             ]
         ]

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -64,8 +64,8 @@ tests _ at _ p b c ch g aws = testGroup "account"
     , test' aws p "post /register - 403 blacklist"           $ testCreateUserBlacklist b aws
     , test' aws p "post /register - 400 external-SSO"        $ testCreateUserExternalSSO b
     , test' aws p "post /activate - 200/204 + expiry"        $ testActivateWithExpiry b at
-    , test' aws p "get /users/:id - 404"                     $ testNonExistingUser b
-    , test' aws p "get /users/:id - 200"                     $ testExistingUser b
+    , test' aws p "get /users/:uid - 404"                    $ testNonExistingUser b
+    , test' aws p "get /users/:uid - 200"                    $ testExistingUser b
     , test' aws p "get /users?:id=.... - 200"                $ testMultipleUsers b
     , test' aws p "put /self - 200"                          $ testUserUpdate b c aws
     , test' aws p "put /self/email - 2xx"                    $ testEmailUpdate b aws
@@ -76,14 +76,14 @@ tests _ at _ p b c ch g aws = testGroup "account"
     , test' aws p "post /activate/send - 200"                $ testSendActivationCode b
     , test' aws p "post /activate/send - 403"                $ testSendActivationCodePrefixExcluded b
     , test' aws p "post /i/users/phone-prefix"               $ testInternalPhonePrefixes b
-    , test' aws p "put /i/users/:id/status (suspend)"        $ testSuspendUser b
+    , test' aws p "put /i/users/:uid/status (suspend)"       $ testSuspendUser b
     , test' aws p "get /i/users?:(email|phone) - 200"        $ testGetByIdentity b
     , test' aws p "delete/phone-email"                       $ testEmailPhoneDelete b c
     , test' aws p "delete/by-password"                       $ testDeleteUserByPassword b c aws
     , test' aws p "delete/with-legalhold"                    $ testDeleteUserWithLegalHold b c aws
     , test' aws p "delete/by-code"                           $ testDeleteUserByCode b
     , test' aws p "delete/anonymous"                         $ testDeleteAnonUser b
-    , test' aws p "delete /i/users/:id - 202"                $ testDeleteInternal b c aws
+    , test' aws p "delete /i/users/:uid - 202"               $ testDeleteInternal b c aws
     , test' aws p "delete with profile pic"                  $ testDeleteWithProfilePic b ch
     , test' aws p "put /i/users/:uid/sso-id"                 $ testUpdateSSOId b g
     ]

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -30,8 +30,8 @@ tests _cl _at _conf p b c g = testGroup "client"
                $ testCan'tDeleteLegalHoldClient b
     , test p "post /clients 400 - can't add legalhold clients manually"
                $ testCan'tAddLegalHoldClient b
-    , test p "get /users/:user/prekeys - 200"         $ testGetUserPrekeys b
-    , test p "get /users/:user/prekeys/:client - 200" $ testGetClientPrekey b
+    , test p "get /users/:uid/prekeys - 200"          $ testGetUserPrekeys b
+    , test p "get /users/:uid/prekeys/:client - 200"  $ testGetClientPrekey b
     , test p "post /clients - 201 (pwd)"              $ testAddGetClient True b c
     , test p "post /clients - 201 (no pwd)"           $ testAddGetClient False b c
     , test p "post /clients - 403"                    $ testClientReauthentication b
@@ -260,7 +260,7 @@ testUpdateClient brig = do
         const 200            === statusCode
         const (Just "label") === (clientLabel <=< decodeBody)
 
-    -- via `/users/:user/clients/:client`, only `id` and `class` are visible:
+    -- via `/users/:uid/clients/:client`, only `id` and `class` are visible:
     get (brig . paths ["users", toByteString' uid, "clients", toByteString' (clientId c)]) !!! do
         const 200                 === statusCode
         const (Just $ clientId c) === (fmap pubClientId . decodeBody)

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -2,14 +2,17 @@ module Main (main) where
 
 import Imports hiding (local)
 import Bilge hiding (header)
+import Brig.API (sitemap)
 import Cassandra.Util (defInitCassandra)
 import Control.Lens
 import Data.Aeson
 import Data.ByteString.Conversion
-import Data.Text (pack)
+import Data.Metrics.Test (sitemapConsistency)
 import Data.Text.Encoding (encodeUtf8)
+import Data.Text (pack)
 import Data.Yaml (decodeFileEither)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.Wai.Utilities.Server (compile)
 import OpenSSL (withOpenSSL)
 import Options.Applicative
 import System.Environment (withArgs)
@@ -75,7 +78,8 @@ runTests iConf bConf otherArgs = do
     settingsApi <- Settings.tests brigOpts mg b g
 
     withArgs otherArgs . defaultMain $ testGroup "Brig API Integration"
-        [ userApi
+        [ sitemapConsistency . compile . Brig.API.sitemap $ brigOpts
+        , userApi
         , providerApi
         , searchApis
         , teamApis

--- a/services/cannon/package.yaml
+++ b/services/cannon/package.yaml
@@ -10,8 +10,48 @@ maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
 dependencies:
-- imports
+- aeson >=0.11
+- api-field-json-th >=0.1.0.2
+- async >=2.0
+- base >=4.6 && <5
+- bilge >=0.12
+- bytestring >=0.10
+- bytestring-conversion >=0.2
+- case-insensitive >=1.2
+- data-default >=0.5
+- data-timeout >=0.3
+- exceptions >=0.6
 - extended
+- gundeck-types
+- hashable >=1.2
+- http-types >=0.8
+- imports
+- lens >=4.4
+- lens-family-core >=1.1
+- metrics-wai >=0.4
+- mtl >=2.2
+- mwc-random >=0.13
+- prometheus-client
+- retry >=0.7
+- singletons >=2.0
+- strict >=0.3.2
+- swagger >=0.2
+- text >=1.1
+- tinylog >=0.10
+- transformers >=0.3
+- types-common >=0.16
+- unordered-containers >=0.2
+- uuid >=1.3
+- vault >=0.3
+- vector >=0.10
+- wai >=3.0
+- wai-extra >=3.0
+- wai-predicates >=0.8
+- wai-routing >=0.12
+- wai-utilities >=0.11
+- wai-websockets >=3.0
+- warp >=3.0
+- websockets >=0.11.2
 library:
   source-dirs: src
   exposed-modules:
@@ -21,47 +61,6 @@ library:
   - Cannon.Run
   - Cannon.Types
   - Cannon.WS
-  dependencies:
-  - base >=4.6 && <5
-  - aeson >=0.11
-  - api-field-json-th >=0.1.0.2
-  - async >=2.0
-  - bilge >=0.12
-  - bytestring >=0.10
-  - bytestring-conversion >=0.2
-  - case-insensitive >=1.2
-  - data-default >=0.5
-  - data-timeout >=0.3
-  - exceptions >=0.6
-  - gundeck-types
-  - hashable >=1.2
-  - http-types >=0.8
-  - lens >=4.4
-  - lens-family-core >=1.1
-  - metrics-wai >=0.4
-  - mtl >=2.2
-  - mwc-random >=0.13
-  - prometheus-client
-  - retry >=0.7
-  - singletons >=2.0
-  - strict >=0.3.2
-  - swagger >=0.2
-  - text >=1.1
-  - tinylog >=0.10
-  - transformers >=0.3
-  - types-common >=0.16
-  - unordered-containers >=0.2
-  - uuid >=1.3
-  - vault >=0.3
-  - vector >=0.10
-  - wai >=3.0
-  - wai-extra >=3.0
-  - wai-predicates >=0.8
-  - wai-routing >=0.12
-  - wai-utilities >=0.11
-  - wai-websockets >=3.0
-  - warp >=3.0
-  - websockets >=0.11.2
 executables:
   cannon:
     main: src/Main.hs

--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -59,8 +59,8 @@ sitemap = do
     post "/i/bulkpush" (continue bulkpush) $
         request
 
-    head "/i/presences/:user/:conn" (continue checkPresence) $
-        param "user" .&. param "conn"
+    head "/i/presences/:uid/:conn" (continue checkPresence) $
+        param "uid" .&. param "conn"
 
     get "/i/monitoring" (continue monitoring) $
         accept "application" "json"

--- a/services/cannon/test/Main.hs
+++ b/services/cannon/test/Main.hs
@@ -1,12 +1,19 @@
 module Main where
 
 import Imports
+
+import Data.Metrics.Test (sitemapConsistency)
+import Network.Wai.Utilities.Server (compile)
 import Test.Tasty
 
 import qualified Bench            as B
+import qualified Cannon.API
 import qualified Test.Cannon.Dict as D
 
 main :: IO ()
 main = do
     B.benchmark
-    defaultMain $ testGroup "Tests" [ D.tests ]
+    defaultMain $ testGroup "Tests"
+        [ sitemapConsistency . compile $ Cannon.API.sitemap
+        , D.tests
+        ]

--- a/services/cargohold/package.yaml
+++ b/services/cargohold/package.yaml
@@ -11,72 +11,71 @@ copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
 dependencies:
 - aeson >=0.11
+- attoparsec >=0.12
+- auto-update >=0.1.4
+- aws >=0.18
+- base16-bytestring >=0.1
+- base >=4 && <5
+- base64-bytestring >=1.0
 - bilge >=0.21
+- byteable >=0.1
 - bytestring >=0.10
 - bytestring-conversion >=0.2
-- base64-bytestring >=1.0
+- cargohold-types >=0.5
+- case-insensitive >=1.0
 - cereal >=0.4
+- conduit >=1.2
+- conduit-extra >=1.1.5
 - containers >=0.5
+- cryptonite >=0.20
 - data-default >=0.5
+- either >=4.3
 - errors >=1.4
 - exceptions >=0.6
 - extended
 - HsOpenSSL >=0.11
+- HsOpenSSL-x509-system >=0.1
 - http-client >=0.4
+- http-client-openssl >=0.2
+- http-conduit >=2.1
 - http-types >=0.8
+- imports
+- lens >=4.1
+- metrics-wai >=0.4
 - mime >=0.4
 - mtl >=2.1
+- network >=2.4
+- optparse-applicative >=0.10
 - prometheus-client
+- random >=1.1
+- resourcet >=1.1
+- retry >=0.5
+- ropes >=0.3
 - safe >=0.3
+- split >=0.2
+- swagger >=0.2
 - text >=1.1
+- time >=1.4
+- tinylog >=0.10
 - transformers >=0.3
+- types-common >=0.16
+- uri-bytestring >=0.2
+- uuid >=1.3.5
+- wai >=3.0
+- wai-conduit >=3.0
+- wai-extra >=3.0
+- wai-predicates >=0.8
+- wai-routing >=0.12
+- wai-utilities >=0.16.1
+- warp >=3.0
+- xml-conduit >=1.3
 - yaml >=0.8
-- imports
 library:
   source-dirs: src
   exposed-modules:
   - CargoHold.API
   - CargoHold.Options
   - CargoHold.Run
-  dependencies:
-  - base >=4 && <5
-  - attoparsec >=0.12
-  - auto-update >=0.1.4
-  - aws >=0.18
-  - byteable >=0.1
-  - base16-bytestring >=0.1
-  - cargohold-types >=0.5
-  - case-insensitive >=1.0
-  - conduit >=1.2
-  - conduit-extra >=1.1.5
-  - cryptonite >=0.20
-  - either >=4.3
-  - HsOpenSSL-x509-system >=0.1
-  - http-client-openssl >=0.2
-  - http-conduit >=2.1
-  - lens >=4.1
-  - metrics-wai >=0.4
-  - network >=2.4
-  - optparse-applicative >=0.10
-  - random >=1.1
-  - retry >=0.5
-  - resourcet >=1.1
-  - ropes >=0.3
-  - swagger >=0.2
-  - time >=1.4
-  - tinylog >=0.10
-  - types-common >=0.16
-  - split >=0.2
-  - uri-bytestring >=0.2
-  - uuid >=1.3.5
-  - wai >=3.0
-  - wai-conduit >=3.0
-  - wai-extra >=3.0
-  - wai-predicates >=0.8
-  - wai-routing >=0.12
-  - wai-utilities >=0.16.1
-  - warp >=3.0
-  - xml-conduit >=1.3
 executables:
   cargohold-integration:
     main: Main.hs

--- a/services/cargohold/test/integration/Main.hs
+++ b/services/cargohold/test/integration/Main.hs
@@ -1,24 +1,29 @@
 module Main (main) where
 
 import Imports hiding (local)
+
 import Bilge hiding (header, body)
+import Data.Metrics.Test (sitemapConsistency)
 import Data.Proxy
 import Data.Tagged
 import Data.Text.Encoding (encodeUtf8)
 import Data.Yaml hiding (Parser)
 import Network.HTTP.Client (responseTimeoutMicro)
 import Network.HTTP.Client.TLS
+import Network.Wai.Utilities.Server (compile)
 import OpenSSL
 import Options.Applicative
+import Test.Tasty
+import Test.Tasty.Options
 import Util.Options
 import Util.Options.Common
 import Util.Test
-import Test.Tasty
-import Test.Tasty.Options
 
 import TestSetup
 import qualified API.V3
 import qualified Metrics
+import qualified CargoHold.API (sitemap)
+
 
 data IntegrationConfig = IntegrationConfig
   -- internal endpoint
@@ -58,7 +63,8 @@ main :: IO ()
 main = withOpenSSL $ runTests go
   where
     go c i = withResource (getOpts c i) releaseOpts $ \opts ->
-        testGroup "Cargohold" [ API.V3.tests opts
+        testGroup "Cargohold" [ sitemapConsistency . compile $ CargoHold.API.sitemap
+                              , API.V3.tests opts
                               , Metrics.tests opts
                               ]
 

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -9,91 +9,90 @@ maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
 dependencies:
-- imports
+- aeson >=0.11
+- amazonka >=1.4.5
+- amazonka-sqs >=1.4.5
+- async >=2.0
+- attoparsec >=0.10
+- base >=4.6 && <5
+- base64-bytestring >=1.0
+- bilge >=0.21.1
+- blaze-builder >=0.3
+- brig-types >=0.73.1
+- bytestring >=0.9
+- bytestring-conversion >=0.2
+- case-insensitive >=1.0
+- cassandra-util >=0.16.2
+- cereal >=0.4
+- containers >=0.5
+- currency-codes >=2.0
+- data-default >=0.5
+- enclosed-exceptions >=1.0
+- errors >=2.0
+- exceptions >=0.4
 - extended
-- safe >=0.3
-- ssl-util
+- extra >=1.3
+- galley-types >=0.65.0
+- gundeck-types >=1.35.2
+- HsOpenSSL >=0.11
+- HsOpenSSL-x509-system >=0.1
+- http-client >=0.4
+- http-client-openssl >=0.2
+- http-client-tls >=0.2.2
+- http-types >=0.8
+- imports
+- insert-ordered-containers
+- lens >=4.4
+- lifted-base >=0.2
+- metrics-wai >=0.4
+- monad-control >=1.0
+- mtl >=2.2
+- optparse-applicative >=0.10
+- pem
+- prometheus-client
+- protobuf >=0.2
+- proto-lens >=0.2
 - raw-strings-qq >=1.0
+- resourcet >=1.1
+- retry >=0.5
+- safe >=0.3
+- safe-exceptions >=0.1
+- semigroups >=0.12
+- servant
+- servant-swagger
+- singletons >=1.0
+- split >=0.2
+- ssl-util
+- ssl-util >=0.1
+- stm >=2.4
+- string-conversions
+- swagger >=0.1
+- swagger2
+- text >=0.11
+- text-format >=0.3
+- time >=1.4
+- tinylog >=0.10
+- tls >=1.3.10
+- transformers >=0.3
+- transformers-base >=0.4
+- types-common >=0.16
+- types-common-journal >=0.1
+- unliftio >=0.2
+- unliftio-core >=0.1
+- unordered-containers >=0.2
+- uri-bytestring >=0.2
+- uuid >=1.3
+- vector >=0.10
+- wai >=3.0
+- wai-extra >=3.0
+- wai-middleware-gunzip >=0.0.2
+- wai-predicates >=0.8
+- wai-routing >=0.12
+- wai-utilities >=0.16
+- warp >=3.0
+- zauth
 library:
   source-dirs: src
-  dependencies:
-  - aeson >=0.11
-  - amazonka >=1.4.5
-  - amazonka-sqs >=1.4.5
-  - async >=2.0
-  - attoparsec >=0.10
-  - base >=4.6 && <5
-  - base64-bytestring >=1.0
-  - bilge >=0.21.1
-  - blaze-builder >=0.3
-  - brig-types >=0.73.1
-  - bytestring >=0.9
-  - bytestring-conversion >=0.2
-  - case-insensitive >=1.0
-  - cassandra-util >=0.16.2
-  - cereal >=0.4
-  - containers >=0.5
-  - currency-codes >=2.0
-  - data-default >=0.5
-  - enclosed-exceptions >=1.0
-  - errors >=2.0
-  - exceptions >=0.4
-  - extra >=1.3
-  - galley-types >=0.65.0
-  - gundeck-types >=1.35.2
-  - HsOpenSSL >=0.11
-  - HsOpenSSL-x509-system >=0.1
-  - http-client >=0.4
-  - http-client-openssl >=0.2
-  - http-client-tls >=0.2.2
-  - http-types >=0.8
-  - insert-ordered-containers
-  - lens >=4.4
-  - lifted-base >=0.2
-  - metrics-wai >=0.4
-  - monad-control >=1.0
-  - mtl >=2.2
-  - optparse-applicative >=0.10
-  - pem
-  - prometheus-client
-  - protobuf >=0.2
-  - proto-lens >=0.2
-  - resourcet >=1.1
-  - retry >=0.5
-  - safe-exceptions >=0.1
-  - semigroups >=0.12
-  - servant
-  - servant-swagger
-  - singletons >=1.0
-  - split >=0.2
-  - ssl-util >=0.1
-  - stm >=2.4
-  - string-conversions
-  - swagger >=0.1
-  - swagger2
-  - text >=0.11
-  - text-format >=0.3
-  - time >=1.4
-  - tinylog >=0.10
-  - tls >=1.3.10
-  - transformers >=0.3
-  - transformers-base >=0.4
-  - types-common >=0.16
-  - types-common-journal >=0.1
-  - unliftio >=0.2
-  - unliftio-core >=0.1
-  - unordered-containers >=0.2
-  - uri-bytestring >=0.2
-  - uuid >=1.3
-  - vector >=0.10
-  - wai >=3.0
-  - wai-extra >=3.0
-  - wai-middleware-gunzip >=0.0.2
-  - wai-predicates >=0.8
-  - wai-routing >=0.12
-  - wai-utilities >=0.16
-  - warp >=3.0
-  - zauth
 executables:
   galley:
     main: src/Main.hs

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -56,10 +56,10 @@ sitemap = do
         response 201 "Team ID as `Location` header value" end
         errorResponse Error.notConnected
 
-    put "/teams/:id" (continue updateTeam) $
+    put "/teams/:tid" (continue updateTeam) $
         zauthUserId
         .&. zauthConnId
-        .&. capture "id"
+        .&. capture "tid"
         .&. jsonRequest @TeamUpdateData
         .&. accept "application" "json"
 
@@ -87,9 +87,9 @@ sitemap = do
 
     --
 
-    get "/teams/:id" (continue getTeam) $
+    get "/teams/:tid" (continue getTeam) $
         zauthUserId
-        .&. capture "id"
+        .&. capture "tid"
         .&. accept "application" "json"
 
     document "GET" "getTeam" $ do
@@ -102,10 +102,10 @@ sitemap = do
 
     --
 
-    delete "/teams/:id" (continue deleteTeam) $
+    delete "/teams/:tid" (continue deleteTeam) $
         zauthUserId
         .&. zauthConnId
-        .&. capture "id"
+        .&. capture "tid"
         .&. request
         .&. opt (contentType "application" "json")
         .&. accept "application" "json"
@@ -126,9 +126,9 @@ sitemap = do
 
     --
 
-    get "/teams/:id/members" (continue getTeamMembers) $
+    get "/teams/:tid/members" (continue getTeamMembers) $
         zauthUserId
-        .&. capture "id"
+        .&. capture "tid"
         .&. accept "application" "json"
 
     document "GET" "getTeamMembers" $ do
@@ -160,10 +160,10 @@ sitemap = do
 
     --
 
-    post "/teams/:id/members" (continue addTeamMember) $
+    post "/teams/:tid/members" (continue addTeamMember) $
         zauthUserId
         .&. zauthConnId
-        .&. capture "id"
+        .&. capture "tid"
         .&. jsonRequest @NewTeamMember
         .&. accept "application" "json"
 
@@ -205,10 +205,10 @@ sitemap = do
 
     --
 
-    put "/teams/:id/members" (continue updateTeamMember) $
+    put "/teams/:tid/members" (continue updateTeamMember) $
         zauthUserId
         .&. zauthConnId
-        .&. capture "id"
+        .&. capture "tid"
         .&. jsonRequest @NewTeamMember
         .&. accept "application" "json"
 
@@ -224,9 +224,9 @@ sitemap = do
 
     --
 
-    get "/teams/:id/conversations" (continue getTeamConversations) $
+    get "/teams/:tid/conversations" (continue getTeamConversations) $
         zauthUserId
-        .&. capture "id"
+        .&. capture "tid"
         .&. accept "application" "json"
 
     document "GET" "getTeamConversations" $ do

--- a/services/gundeck/package.yaml
+++ b/services/gundeck/package.yaml
@@ -9,8 +9,74 @@ maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
 dependencies:
-- imports
+- aeson >=0.11
+- amazonka >=1.3.7
+- amazonka-sns >=1.3.7
+- amazonka-sqs >=1.3.7
+- async >=2.0
+- attoparsec >=0.10
+- auto-update >=0.1
+- base >=4.7 && <5
+- base64-bytestring >=1.0
+- bilge >=0.21
+- blaze-builder >=0.3
+- bytestring >=0.9
+- bytestring-conversion >=0.2
+- case-insensitive >=1.0
+- cassandra-util >=0.16.2
+- conduit >=1.1
+- containers >=0.5
+- data-default >=0.5
+- enclosed-exceptions >=1.0
+- errors >=2.0
+- exceptions >=0.4
 - extended
+- extra >=1.1
+- gundeck-types >=1.0
+- HsOpenSSL >=0.11
+- http-client >=0.4
+- http-client-tls >=0.2.2
+- http-types >=0.8
+- imports
+- lens >=4.4
+- lens-aeson >=1.0
+- lifted-base >=0.2
+- metrics-core >=0.2.1
+- metrics-wai >=0.5.7
+- monad-control >=1.0
+- mtl >=2.2
+- network-uri >=2.6
+- optparse-applicative >=0.10
+- prometheus-client
+- psqueues >=0.2.2
+- redis-io >=0.4
+- resourcet >=1.1
+- retry >=0.5
+- semigroups >=0.12
+- singletons >=1.0
+- split >=0.2
+- swagger >=0.1
+- text >=1.1
+- text-format >=0.3
+- time >=1.4
+- tinylog >=0.10
+- tls >=1.3.4
+- transformers >=0.3
+- transformers-base >=0.4
+- types-common >=0.16
+- unliftio >=0.2
+- unliftio-core >=0.1
+- unordered-containers >=0.2
+- uuid >=1.3
+- vector >=0.10
+- wai >=3.2
+- wai-extra >=3.0
+- wai-middleware-gunzip >=0.0.2
+- wai-predicates >=0.8
+- wai-routing >=0.12
+- wai-utilities >=0.16
+- warp >=3.2
+- yaml >=0.8
 library:
   source-dirs: src
   ghc-options:
@@ -41,73 +107,6 @@ library:
   - Gundeck.Util
   - Gundeck.Util.DelayQueue
   - Gundeck.Util.Redis
-  dependencies:
-  - aeson >=0.11
-  - amazonka >=1.3.7
-  - amazonka-sns >=1.3.7
-  - amazonka-sqs >=1.3.7
-  - async >=2.0
-  - attoparsec >=0.10
-  - auto-update >=0.1
-  - base >=4.7 && <5
-  - bilge >=0.21
-  - blaze-builder >=0.3
-  - bytestring >=0.9
-  - bytestring-conversion >=0.2
-  - base64-bytestring >=1.0
-  - case-insensitive >=1.0
-  - cassandra-util >=0.16.2
-  - conduit >=1.1
-  - containers >=0.5
-  - data-default >=0.5
-  - enclosed-exceptions >=1.0
-  - errors >=2.0
-  - exceptions >=0.4
-  - extra >=1.1
-  - gundeck-types >=1.0
-  - HsOpenSSL >=0.11
-  - http-client >=0.4
-  - http-client-tls >=0.2.2
-  - http-types >=0.8
-  - lens >=4.4
-  - lens-aeson >=1.0
-  - lifted-base >=0.2
-  - metrics-core >=0.2.1
-  - metrics-wai >=0.5.7
-  - monad-control >=1.0
-  - mtl >=2.2
-  - network-uri >=2.6
-  - optparse-applicative >=0.10
-  - prometheus-client
-  - psqueues >=0.2.2
-  - redis-io >=0.4
-  - resourcet >=1.1
-  - retry >=0.5
-  - semigroups >=0.12
-  - singletons >=1.0
-  - split >=0.2
-  - swagger >=0.1
-  - text >=1.1
-  - text-format >=0.3
-  - time >=1.4
-  - tinylog >=0.10
-  - tls >=1.3.4
-  - transformers >=0.3
-  - transformers-base >=0.4
-  - types-common >=0.16
-  - unliftio >=0.2
-  - unliftio-core >=0.1
-  - unordered-containers >=0.2
-  - uuid >=1.3
-  - vector >=0.10
-  - wai >=3.2
-  - wai-extra >=3.0
-  - wai-middleware-gunzip >=0.0.2
-  - wai-predicates >=0.8
-  - wai-routing >=0.12
-  - wai-utilities >=0.16
-  - warp >=3.2
-  - yaml >=0.8
 executables:
   gundeck-integration:
     main: Main.hs

--- a/services/gundeck/test/unit/Main.hs
+++ b/services/gundeck/test/unit/Main.hs
@@ -1,10 +1,14 @@
 module Main (main) where
 
 import Imports
+
+import Data.Metrics.Test (sitemapConsistency)
+import Network.Wai.Utilities.Server (compile)
 import OpenSSL (withOpenSSL)
 import Test.Tasty
 
 import qualified DelayQueue
+import qualified Gundeck.API
 import qualified Json
 import qualified Native
 import qualified Push
@@ -12,7 +16,8 @@ import qualified Push
 main :: IO ()
 main = withOpenSSL . defaultMain $
     testGroup "Main"
-        [ DelayQueue.tests
+        [ sitemapConsistency . compile $ Gundeck.API.sitemap
+        , DelayQueue.tests
         , Json.tests
         , Native.tests
         , Push.tests

--- a/services/proxy/package.yaml
+++ b/services/proxy/package.yaml
@@ -8,9 +8,41 @@ author: Wire Swiss GmbH
 maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
+
 dependencies:
-- imports
+- aeson >=1.0
+- base >=4.6 && <5
+- bilge >=0.21
+- bytestring >=0.10
+- case-insensitive >=1.2
+- configurator >=0.3
+- data-default >=0.5
+- exceptions >=0.8
 - extended
+- http-client >=0.4
+- http-client-tls >=0.2
+- http-reverse-proxy >=0.4
+- http-types >=0.9
+- imports
+- lens >=4.11
+- metrics-wai >=0.5
+- mtl >=2.2
+- network >=2.6
+- optparse-applicative >=0.12
+- prometheus-client
+- retry >=0.7
+- text >=1.2
+- tinylog >=0.12
+- tls >=1.3
+- transformers >=0.4
+- types-common >=0.8
+- wai >=3.2
+- wai-predicates >=0.8
+- wai-routing >=0.12
+- wai-utilities >=0.14.3
+- warp >=3.0
+- yaml >=0.8.22
+
 library:
   source-dirs: src
   ghc-options:
@@ -21,37 +53,18 @@ library:
   - Proxy.Options
   - Proxy.Proxy
   - Proxy.Run
-  dependencies:
-  - base >=4.6 && <5
-  - aeson >=1.0
-  - bilge >=0.21
-  - bytestring >=0.10
-  - case-insensitive >=1.2
-  - configurator >=0.3
-  - data-default >=0.5
-  - http-reverse-proxy >=0.4
-  - http-client >=0.4
-  - http-client-tls >=0.2
-  - http-types >=0.9
-  - exceptions >=0.8
-  - lens >=4.11
-  - metrics-wai >=0.5
-  - mtl >=2.2
-  - network >=2.6
-  - optparse-applicative >=0.12
-  - prometheus-client
-  - retry >=0.7
-  - text >=1.2
-  - tinylog >=0.12
-  - tls >=1.3
-  - transformers >=0.4
-  - types-common >=0.8
-  - wai >=3.2
-  - wai-predicates >=0.8
-  - wai-routing >=0.12
-  - wai-utilities >=0.14.3
-  - warp >=3.0
-  - yaml >=0.8.22
+
+tests:
+  spec:
+    main: Main.hs
+    source-dirs:
+    - test/unit
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N
+    dependencies:
+    - metrics-core
+    - proxy
+    - tasty
+
 executables:
   proxy:
     main: src/Main.hs

--- a/services/proxy/src/Proxy/Options.hs
+++ b/services/proxy/src/Proxy/Options.hs
@@ -7,13 +7,14 @@ module Proxy.Options
     , maxConns
     , logLevel
     , logNetStrings
+    , mockOpts
     ) where
 
 import Imports
 import Control.Lens hiding (Level)
 import Data.Aeson
 import Data.Aeson.TH
-import System.Logger (Level)
+import System.Logger (Level(Debug))
 
 data Opts = Opts
     { _host          :: !String     -- ^ Host to listen on
@@ -30,3 +31,15 @@ data Opts = Opts
 makeLenses ''Opts
 
 deriveJSON defaultOptions{fieldLabelModifier = drop 1} ''Opts
+
+-- | for testing.
+mockOpts :: FilePath -> Opts
+mockOpts secrets = Opts
+    { _host          = mempty
+    , _port          = 0
+    , _secretsConfig = secrets
+    , _httpPoolSize  = 0
+    , _maxConns      = 0
+    , _logLevel      = Debug
+    , _logNetStrings = True
+    }

--- a/services/proxy/test/unit/Main.hs
+++ b/services/proxy/test/unit/Main.hs
@@ -1,0 +1,22 @@
+module Main (main) where
+
+import Imports
+
+import Data.Metrics (Metrics, metrics)
+import Data.Metrics.Test (sitemapConsistency)
+import Network.Wai.Utilities.Server (compile)
+import Proxy.API (sitemap)
+import Proxy.Env (Env, createEnv)
+import Proxy.Options (mockOpts)
+import Test.Tasty
+
+
+main :: IO ()
+main = do
+    mockEnv <- mkMockEnv =<< metrics
+    defaultMain $ testGroup "Main"
+        [ sitemapConsistency . compile $ sitemap mockEnv
+        ]
+
+mkMockEnv :: Metrics -> IO Env
+mkMockEnv mtrx = createEnv mtrx (mockOpts "doc/example.config")

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -95,6 +95,8 @@ tests:
     dependencies:
       - hspec
       - hspec-discover
+      - tasty
+      - tasty-hspec
       - QuickCheck
       - spar
       - uri-bytestring

--- a/services/spar/test/Test/Spar/APISpec.hs
+++ b/services/spar/test/Test/Spar/APISpec.hs
@@ -2,13 +2,20 @@
 
 module Test.Spar.APISpec where
 
-import Data.Proxy
+import Imports
+
 import Arbitrary ()
+import Data.Metrics.Test (servantApiConsistency)
+import Data.Proxy
 import Servant.Swagger (validateEveryToJSON)
 import Spar.API as API
 import Test.Hspec
+
+import qualified Test.Tasty
+
 
 spec :: Spec
 spec = do
   -- Note: SCIM types are not validated because their content-type is 'SCIM'.
   validateEveryToJSON (Proxy @API.OutsideWorldAPI)
+  it "..." $ Test.Tasty.defaultMain (servantApiConsistency (Proxy @API.API))

--- a/services/spar/test/Test/Spar/APISpec.hs
+++ b/services/spar/test/Test/Spar/APISpec.hs
@@ -5,10 +5,12 @@ module Test.Spar.APISpec where
 import Imports
 
 import Arbitrary ()
+import Control.Exception
 import Data.Metrics.Test (servantApiConsistency)
 import Data.Proxy
 import Servant.Swagger (validateEveryToJSON)
 import Spar.API as API
+import System.Exit
 import Test.Hspec
 
 import qualified Test.Tasty
@@ -18,4 +20,9 @@ spec :: Spec
 spec = do
   -- Note: SCIM types are not validated because their content-type is 'SCIM'.
   validateEveryToJSON (Proxy @API.OutsideWorldAPI)
-  it "..." $ Test.Tasty.defaultMain (servantApiConsistency (Proxy @API.API))
+  tastyToHspec (servantApiConsistency (Proxy @API.API))
+
+
+tastyToHspec :: Test.Tasty.TestTree -> Spec
+tastyToHspec tasty = it "tasty" $ do
+  Test.Tasty.defaultMain tasty `catch` (`shouldBe` ExitSuccess)


### PR DESCRIPTION
Since some servant- and prometheus-related refactorings earlier this year (I think), capturing metrics only worked under the assumption that all capture variables names (the path segments like `:uid`) were had the same name when in the same node in the routing tree.

This PR adds tests that enforces this assumption.  I will try to fix the unnecessary assumption independently, but even though not technically necessary, I think it's really quite unnecessary to allow for different names for the same thing.

If we have different capture variables for the same node in the routing table, we get errors like this in the future;

```
FAIL
    src/Data/Metrics/Test.hs:17:
    inconcistent sitemap
    expected: []
     but got: [bad routing tables: the prefix "/teams" contains these variables with resp. numbers of routes under them: [(":tid",8),(":id",2)]]
[...]
```

This happens in all services; and has been fixed for existing routing tables so the tests pass now.

Consequently, some alerts and graphana dashboards will not work, since they have the old paths hard-coded in their rules.  Consider fixing this before deploying this PR (either in staging or in production).
