### PR TITLE
Fix package deps

### DIFF
--- a/libs/brig-types/package.yaml
+++ b/libs/brig-types/package.yaml
@@ -92,7 +92,7 @@ tests:
 flags:
   cql:
     description: Enable cql instances
-    manual: false
+    manual: true
     default: false
   arbitrary:
     description: Enable quickcheck arbitrary instances

--- a/libs/galley-types/package.yaml
+++ b/libs/galley-types/package.yaml
@@ -69,5 +69,5 @@ tests:
 flags:
   cql:
     description: Enable cql instances
-    manual: false
+    manual: true
     default: false

--- a/libs/metrics-wai/package.yaml
+++ b/libs/metrics-wai/package.yaml
@@ -12,16 +12,14 @@ dependencies:
 - base ==4.*
 - bytestring >=0.10
 - clock >=0.6
-- containers
 - exceptions >=0.6
 - http-types >=0.8
 - imports
 - metrics-core >=0.3
+- containers
 - prometheus-client
 - servant
 - string-conversions
-- tasty
-- tasty-hunit
 - text >=0.11
 - transformers >=0.3
 - wai >=3

--- a/libs/metrics-wai/src/Data/Metrics/Test.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Test.hs
@@ -3,24 +3,11 @@ module Data.Metrics.Test where
 import Imports
 
 import Data.Metrics.Types
-import Data.Metrics.WaiRoute (treeToPaths)
-import Data.Metrics.Servant (RoutesToPaths, routesToPaths)
 import Data.String.Conversions (cs)
-import Test.Tasty (TestTree)
-import Test.Tasty.HUnit (testCase, assertEqual)
 
 import qualified Data.Text as Text
 import qualified Data.Tree as Tree
-import qualified Network.Wai.Routing.Route as Route
 
-
-servantApiConsistency :: forall proxy routes. RoutesToPaths routes => proxy routes -> TestTree
-servantApiConsistency _ = testCase "servant api" $
-    assertEqual "inconcistent servant api" mempty (pathsConsistencyCheck (routesToPaths @routes))
-
-sitemapConsistency :: Route.Tree a -> TestTree
-sitemapConsistency smap = testCase "sitemap" $
-    assertEqual "inconcistent sitemap" mempty (pathsConsistencyCheck $ treeToPaths smap)
 
 -- | It is an error for one prefix to end in two different capture variables.  eg., these two
 -- routes constitute a confict: "/user/:uid", "/user/:id".  There is a show instance that

--- a/libs/types-common-aws/package.yaml
+++ b/libs/types-common-aws/package.yaml
@@ -52,9 +52,9 @@ library:
 flags:
   arbitrary:
     description: Enable quickcheck's arbitrary instances
-    manual: false
+    manual: true
     default: false
   protobuf:
     description: Enable protocol buffers instances
-    manual: false
+    manual: true
     default: false

--- a/libs/types-common/package.yaml
+++ b/libs/types-common/package.yaml
@@ -110,13 +110,13 @@ tests:
 flags:
   arbitrary:
     description: Enable quickcheck's arbitrary instances
-    manual: false
+    manual: true
     default: false
   protobuf:
     description: Enable protocol buffers instances
-    manual: false
+    manual: true
     default: false
   cql:
     description: Enable cql instances
-    manual: false
+    manual: true
     default: false

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -12,121 +12,31 @@ ghc-options:
 - -funbox-strict-fields
 dependencies:
 - aeson >=0.11
-- amazonka >=1.3.7
-- amazonka-dynamodb >=1.3.7
-- amazonka-ses >=1.3.7
-- amazonka-sns >=1.3.7
-- amazonka-sqs >=1.3.7
-- async >=2.1
-- attoparsec >=0.12
-- auto-update >=0.1
-- base16-bytestring >=0.1
 - base ==4.*
 - base64-bytestring >=1.0
-- base-prelude
-- bilge >=0.21.1
-- blaze-builder >=0.3
 - bloodhound >=0.13
-- brig-types >=0.91.1
-- bytestring >=0.10
 - bytestring-conversion >=0.2
-- cassandra-util >=0.16.2
-- conduit >=1.2.8
-- containers >=0.5
 - cookie >=0.4
-- cryptobox-haskell >=0.1.1
-- currency-codes >=2.0
-- data-default >=0.5
-- data-timeout >=0.3
+- containers >=0.5
 - directory >=1.2
-- either >=4.3
-- email-validate >=2.0
-- enclosed-exceptions >=1.0
 - errors >=1.4
 - exceptions >=0.5
 - extended
-- extra >=1.3
-- filepath >=1.3
-- fsnotify >=0.2
-- galley-types >=0.75.3
-- geoip2 >=0.3.1.0
-- gundeck-types >=1.32.1
-- hashable >=1.2
-- HaskellNet >=0.3
-- HaskellNet-SSL >=0.3
-- HsOpenSSL >=0.10
-- HsOpenSSL-x509-system >=0.1
-- html-entities >=1.1
-- http-client >=0.5
-- http-client-openssl >=0.2
-- http-types >=0.8
 - imports
-- iproute >=1.5
-- iso639 >=0.1
-- lens >=3.8
+- http-types >=0.8
+- HsOpenSSL >=0.10
 - lens-aeson >=1.0
-- lifted-base >=0.2
-- metrics-core >=0.3
-- metrics-wai >=0.3
-- mime
-- mime-mail >=0.4
-- monad-control >=1.0
-- MonadRandom >=0.5
 - mtl >=2.1
-- multihash >=0.1.3
-- mwc-random
-- network >=2.4
-- network-conduit-tls
-- network-uri >=2.6
 - optparse-applicative >=0.11
-- pem >=0.2
 - prometheus-client
-- proto-lens >=0.1
-- random-shuffle >=0.0.3
-- resource-pool >=0.2
-- resourcet >=1.1
-- retry >=0.7
-- ropes >=0.4.20
 - safe >=0.3
-- scientific >=0.3.4
-- scrypt >=0.5
-- semigroups >=0.15
-- singletons >=2.0
-- smtp-mail >=0.1
-- sodium-crypto-sign >=0.1
-- split >=0.2
-- ssl-util
-- statistics >=0.13
-- stomp-queue >=0.3
-- string-conversions
-- swagger >=0.1
-- tagged >=0.7
-- template >=0.2
 - text >=0.11
-- text-icu-translit >=0.1
-- time >=1.1
-- tinylog >=0.10
-- tls >=1.3.4
 - transformers >=0.3
-- transformers-base >=0.4
-- types-common >=0.16
+- tinylog >=0.10
 - types-common-journal >=0.1
-- unliftio >=0.2
-- unliftio-core >=0.1
-- unordered-containers >=0.2
-- uri-bytestring >=0.2
 - uuid >=1.3.5
-- vault >=0.3
-- vector >=0.11
-- wai >=3.0
 - wai-extra >=3.0
-- wai-middleware-gunzip >=0.0.2
-- wai-predicates >=0.8
-- wai-routing >=0.12
-- wai-utilities >=0.16
-- warp >=3.0.12.1
 - yaml >=0.8.22
-- zauth >=0.10.3
 library:
   source-dirs: src
   exposed-modules:
@@ -143,6 +53,97 @@ library:
   - Brig.User.Auth.Cookie.Limit
   - Brig.User.Search.Index
   - Brig.ZAuth
+  dependencies:
+  - amazonka >=1.3.7
+  - amazonka-dynamodb >=1.3.7
+  - amazonka-ses >=1.3.7
+  - amazonka-sns >=1.3.7
+  - amazonka-sqs >=1.3.7
+  - attoparsec >=0.12
+  - async >=2.1
+  - auto-update >=0.1
+  - base-prelude
+  - base16-bytestring >=0.1
+  - bilge >=0.21.1
+  - blaze-builder >=0.3
+  - brig-types >=0.91.1
+  - bytestring >=0.10
+  - cassandra-util >=0.16.2
+  - currency-codes >=2.0
+  - conduit >=1.2.8
+  - cryptobox-haskell >=0.1.1
+  - data-default >=0.5
+  - data-timeout >=0.3
+  - either >=4.3
+  - email-validate >=2.0
+  - enclosed-exceptions >=1.0
+  - extra >=1.3
+  - geoip2 >=0.3.1.0
+  - galley-types >=0.75.3
+  - gundeck-types >=1.32.1
+  - filepath >=1.3
+  - fsnotify >=0.2
+  - iso639 >=0.1
+  - hashable >=1.2
+  - html-entities >=1.1
+  - http-client >=0.5
+  - http-client-openssl >=0.2
+  - HaskellNet >=0.3
+  - HaskellNet-SSL >=0.3
+  - HsOpenSSL-x509-system >=0.1
+  - iproute >=1.5
+  - lens >=3.8
+  - lifted-base >=0.2
+  - mime
+  - mime-mail >=0.4
+  - metrics-core >=0.3
+  - metrics-wai >=0.3
+  - monad-control >=1.0
+  - MonadRandom >=0.5
+  - multihash >=0.1.3
+  - mwc-random
+  - network >=2.4
+  - network-conduit-tls
+  - network-uri >=2.6
+  - pem >=0.2
+  - proto-lens >=0.1
+  - resourcet >=1.1
+  - resource-pool >=0.2
+  - ropes >=0.4.20
+  - scientific >=0.3.4
+  - scrypt >=0.5
+  - smtp-mail >=0.1
+  - split >=0.2
+  - semigroups >=0.15
+  - singletons >=2.0
+  - stomp-queue >=0.3
+  - string-conversions
+  - ssl-util
+  - random-shuffle >=0.0.3
+  - sodium-crypto-sign >=0.1
+  - statistics >=0.13
+  - swagger >=0.1
+  - tagged >=0.7
+  - template >=0.2
+  - text-icu-translit >=0.1
+  - time >=1.1
+  - tls >=1.3.4
+  - transformers-base >=0.4
+  - types-common >=0.16
+  - retry >=0.7
+  - unliftio >=0.2
+  - unliftio-core >=0.1
+  - unordered-containers >=0.2
+  - uri-bytestring >=0.2
+  - vault >=0.3
+  - vector >=0.11
+  - wai >=3.0
+  - wai-middleware-gunzip >=0.0.2
+  - wai-predicates >=0.8
+  - wai-routing >=0.12
+  - wai-utilities >=0.16
+  - warp >=3.0.12.1
+  - zauth >=0.10.3
 executables:
   brig-schema:
     main: Main.hs

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -161,10 +161,10 @@ executables:
     source-dirs: test/integration
     dependencies:
     - async
-    - brig
-    - bytestring >=0.9
     - bilge
+    - brig
     - brig-types
+    - bytestring >=0.9
     - cargohold-types
     - cassandra-util
     - data-timeout
@@ -172,10 +172,11 @@ executables:
     - filepath >=1.4
     - galley-types
     - gundeck-types
+    - HsOpenSSL
     - http-client
     - http-client-tls >=0.2
-    - HsOpenSSL
     - lens >=3.9
+    - metrics-wai
     - mime >=0.4
     - network
     - options >=0.1
@@ -188,12 +189,13 @@ executables:
     - tasty >=1.0
     - tasty-cannon >=0.3.4
     - tasty-hunit >=0.2
-    - time >=1.5
     - temporary >=1.2.1
+    - time >=1.5
     - tinylog
     - types-common >=0.3
     - types-common-aws >=0.1
     - unix >=2.5
+    - unliftio
     - unordered-containers
     - vector >=0.10
     - wai
@@ -202,7 +204,6 @@ executables:
     - warp
     - warp-tls >=3.2
     - zauth
-    - unliftio
   brig-index:
     main: Main.hs
     source-dirs: index/src

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -1,13 +1,15 @@
 module Main (main) where
 
 import Imports hiding (local)
+
 import Bilge hiding (header)
 import Brig.API (sitemap)
 import Cassandra.Util (defInitCassandra)
 import Control.Lens
 import Data.Aeson
 import Data.ByteString.Conversion
-import Data.Metrics.Test (sitemapConsistency)
+import Data.Metrics.Test (pathsConsistencyCheck)
+import Data.Metrics.WaiRoute (treeToPaths)
 import Data.Text.Encoding (encodeUtf8)
 import Data.Text (pack)
 import Data.Yaml (decodeFileEither)
@@ -17,6 +19,7 @@ import OpenSSL (withOpenSSL)
 import Options.Applicative
 import System.Environment (withArgs)
 import Test.Tasty
+import Test.Tasty.HUnit
 import Util.Options
 import Util.Options.Common
 import Util.Test
@@ -78,7 +81,9 @@ runTests iConf bConf otherArgs = do
     settingsApi <- Settings.tests brigOpts mg b g
 
     withArgs otherArgs . defaultMain $ testGroup "Brig API Integration"
-        [ sitemapConsistency . compile . Brig.API.sitemap $ brigOpts
+        [ testCase "sitemap" $ assertEqual "inconcistent sitemap"
+            mempty
+            (pathsConsistencyCheck . treeToPaths . compile $ Brig.API.sitemap brigOpts)
         , userApi
         , providerApi
         , searchApis

--- a/services/cannon/package.yaml
+++ b/services/cannon/package.yaml
@@ -10,48 +10,8 @@ maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
 dependencies:
-- aeson >=0.11
-- api-field-json-th >=0.1.0.2
-- async >=2.0
-- base >=4.6 && <5
-- bilge >=0.12
-- bytestring >=0.10
-- bytestring-conversion >=0.2
-- case-insensitive >=1.2
-- data-default >=0.5
-- data-timeout >=0.3
-- exceptions >=0.6
-- extended
-- gundeck-types
-- hashable >=1.2
-- http-types >=0.8
 - imports
-- lens >=4.4
-- lens-family-core >=1.1
-- metrics-wai >=0.4
-- mtl >=2.2
-- mwc-random >=0.13
-- prometheus-client
-- retry >=0.7
-- singletons >=2.0
-- strict >=0.3.2
-- swagger >=0.2
-- text >=1.1
-- tinylog >=0.10
-- transformers >=0.3
-- types-common >=0.16
-- unordered-containers >=0.2
-- uuid >=1.3
-- vault >=0.3
-- vector >=0.10
-- wai >=3.0
-- wai-extra >=3.0
-- wai-predicates >=0.8
-- wai-routing >=0.12
-- wai-utilities >=0.11
-- wai-websockets >=3.0
-- warp >=3.0
-- websockets >=0.11.2
+- extended
 library:
   source-dirs: src
   exposed-modules:
@@ -61,6 +21,47 @@ library:
   - Cannon.Run
   - Cannon.Types
   - Cannon.WS
+  dependencies:
+  - base >=4.6 && <5
+  - aeson >=0.11
+  - api-field-json-th >=0.1.0.2
+  - async >=2.0
+  - bilge >=0.12
+  - bytestring >=0.10
+  - bytestring-conversion >=0.2
+  - case-insensitive >=1.2
+  - data-default >=0.5
+  - data-timeout >=0.3
+  - exceptions >=0.6
+  - gundeck-types
+  - hashable >=1.2
+  - http-types >=0.8
+  - lens >=4.4
+  - lens-family-core >=1.1
+  - metrics-wai >=0.4
+  - mtl >=2.2
+  - mwc-random >=0.13
+  - prometheus-client
+  - retry >=0.7
+  - singletons >=2.0
+  - strict >=0.3.2
+  - swagger >=0.2
+  - text >=1.1
+  - tinylog >=0.10
+  - transformers >=0.3
+  - types-common >=0.16
+  - unordered-containers >=0.2
+  - uuid >=1.3
+  - vault >=0.3
+  - vector >=0.10
+  - wai >=3.0
+  - wai-extra >=3.0
+  - wai-predicates >=0.8
+  - wai-routing >=0.12
+  - wai-utilities >=0.11
+  - wai-websockets >=3.0
+  - warp >=3.0
+  - websockets >=0.11.2
 executables:
   cannon:
     main: src/Main.hs

--- a/services/cannon/package.yaml
+++ b/services/cannon/package.yaml
@@ -88,17 +88,19 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - async
-    - QuickCheck >=2.7 && <2.12
     - base
     - bytestring
     - cannon
     - criterion >=1.0
+    - metrics-wai
+    - QuickCheck >=2.7 && <2.12
     - random >=1.0
     - tasty >=0.8
     - tasty-hunit >=0.8
     - tasty-quickcheck >=0.8
     - types-common
     - uuid
+    - wai-utilities
 flags:
   static:
     description: Enable static linking

--- a/services/cannon/package.yaml
+++ b/services/cannon/package.yaml
@@ -102,5 +102,5 @@ tests:
 flags:
   static:
     description: Enable static linking
-    manual: false
+    manual: true
     default: false

--- a/services/cannon/test/Main.hs
+++ b/services/cannon/test/Main.hs
@@ -2,9 +2,11 @@ module Main where
 
 import Imports
 
-import Data.Metrics.Test (sitemapConsistency)
+import Data.Metrics.Test (pathsConsistencyCheck)
+import Data.Metrics.WaiRoute (treeToPaths)
 import Network.Wai.Utilities.Server (compile)
 import Test.Tasty
+import Test.Tasty.HUnit
 
 import qualified Bench            as B
 import qualified Cannon.API
@@ -14,6 +16,8 @@ main :: IO ()
 main = do
     B.benchmark
     defaultMain $ testGroup "Tests"
-        [ sitemapConsistency . compile $ Cannon.API.sitemap
+        [ testCase "sitemap" $ assertEqual "inconcistent sitemap"
+            mempty
+            (pathsConsistencyCheck . treeToPaths . compile $ Cannon.API.sitemap)
         , D.tests
         ]

--- a/services/cargohold/package.yaml
+++ b/services/cargohold/package.yaml
@@ -11,71 +11,72 @@ copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
 dependencies:
 - aeson >=0.11
-- attoparsec >=0.12
-- auto-update >=0.1.4
-- aws >=0.18
-- base16-bytestring >=0.1
-- base >=4 && <5
-- base64-bytestring >=1.0
 - bilge >=0.21
-- byteable >=0.1
 - bytestring >=0.10
 - bytestring-conversion >=0.2
-- cargohold-types >=0.5
-- case-insensitive >=1.0
+- base64-bytestring >=1.0
 - cereal >=0.4
-- conduit >=1.2
-- conduit-extra >=1.1.5
 - containers >=0.5
-- cryptonite >=0.20
 - data-default >=0.5
-- either >=4.3
 - errors >=1.4
 - exceptions >=0.6
 - extended
 - HsOpenSSL >=0.11
-- HsOpenSSL-x509-system >=0.1
 - http-client >=0.4
-- http-client-openssl >=0.2
-- http-conduit >=2.1
 - http-types >=0.8
-- imports
-- lens >=4.1
-- metrics-wai >=0.4
 - mime >=0.4
 - mtl >=2.1
-- network >=2.4
-- optparse-applicative >=0.10
 - prometheus-client
-- random >=1.1
-- resourcet >=1.1
-- retry >=0.5
-- ropes >=0.3
 - safe >=0.3
-- split >=0.2
-- swagger >=0.2
 - text >=1.1
-- time >=1.4
-- tinylog >=0.10
 - transformers >=0.3
-- types-common >=0.16
-- uri-bytestring >=0.2
-- uuid >=1.3.5
-- wai >=3.0
-- wai-conduit >=3.0
-- wai-extra >=3.0
-- wai-predicates >=0.8
-- wai-routing >=0.12
-- wai-utilities >=0.16.1
-- warp >=3.0
-- xml-conduit >=1.3
 - yaml >=0.8
+- imports
 library:
   source-dirs: src
   exposed-modules:
   - CargoHold.API
   - CargoHold.Options
   - CargoHold.Run
+  dependencies:
+  - base >=4 && <5
+  - attoparsec >=0.12
+  - auto-update >=0.1.4
+  - aws >=0.18
+  - byteable >=0.1
+  - base16-bytestring >=0.1
+  - cargohold-types >=0.5
+  - case-insensitive >=1.0
+  - conduit >=1.2
+  - conduit-extra >=1.1.5
+  - cryptonite >=0.20
+  - either >=4.3
+  - HsOpenSSL-x509-system >=0.1
+  - http-client-openssl >=0.2
+  - http-conduit >=2.1
+  - lens >=4.1
+  - metrics-wai >=0.4
+  - network >=2.4
+  - optparse-applicative >=0.10
+  - random >=1.1
+  - retry >=0.5
+  - resourcet >=1.1
+  - ropes >=0.3
+  - swagger >=0.2
+  - time >=1.4
+  - tinylog >=0.10
+  - types-common >=0.16
+  - split >=0.2
+  - uri-bytestring >=0.2
+  - uuid >=1.3.5
+  - wai >=3.0
+  - wai-conduit >=3.0
+  - wai-extra >=3.0
+  - wai-predicates >=0.8
+  - wai-routing >=0.12
+  - wai-utilities >=0.16.1
+  - warp >=3.0
+  - xml-conduit >=1.3
 executables:
   cargohold-integration:
     main: Main.hs

--- a/services/cargohold/package.yaml
+++ b/services/cargohold/package.yaml
@@ -82,12 +82,13 @@ executables:
     main: Main.hs
     source-dirs: test/integration
     dependencies:
+    - base ==4.*
     - cargohold
     - cargohold-types
-    - base ==4.*
     - cryptohash-md5 >=0.11.7.2
     - http-client-tls >=0.2
     - lens >=3.8
+    - metrics-wai
     - optparse-applicative
     - tagged >=0.8
     - tasty >=1.0

--- a/services/cargohold/package.yaml
+++ b/services/cargohold/package.yaml
@@ -112,5 +112,5 @@ executables:
 flags:
   static:
     description: Enable static linking
-    manual: false
+    manual: true
     default: false

--- a/services/cargohold/test/integration/Main.hs
+++ b/services/cargohold/test/integration/Main.hs
@@ -3,7 +3,8 @@ module Main (main) where
 import Imports hiding (local)
 
 import Bilge hiding (header, body)
-import Data.Metrics.Test (sitemapConsistency)
+import Data.Metrics.Test (pathsConsistencyCheck)
+import Data.Metrics.WaiRoute (treeToPaths)
 import Data.Proxy
 import Data.Tagged
 import Data.Text.Encoding (encodeUtf8)
@@ -14,6 +15,7 @@ import Network.Wai.Utilities.Server (compile)
 import OpenSSL
 import Options.Applicative
 import Test.Tasty
+import Test.Tasty.HUnit
 import Test.Tasty.Options
 import Util.Options
 import Util.Options.Common
@@ -63,10 +65,13 @@ main :: IO ()
 main = withOpenSSL $ runTests go
   where
     go c i = withResource (getOpts c i) releaseOpts $ \opts ->
-        testGroup "Cargohold" [ sitemapConsistency . compile $ CargoHold.API.sitemap
-                              , API.V3.tests opts
-                              , Metrics.tests opts
-                              ]
+        testGroup "Cargohold"
+            [ testCase "sitemap" $ assertEqual "inconcistent sitemap"
+                mempty
+                (pathsConsistencyCheck . treeToPaths . compile $ CargoHold.API.sitemap)
+            , API.V3.tests opts
+            , Metrics.tests opts
+            ]
 
     getOpts _ i = do
         -- TODO: It would actually be useful to read some

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -166,6 +166,7 @@ executables:
     - cereal
     - containers
     - currency-codes
+    - metrics-wai
     - data-default-class
     - data-timeout
     - errors

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -230,5 +230,5 @@ executables:
 flags:
   static:
     description: Enable static linking
-    manual: false
+    manual: true
     default: false

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -9,90 +9,91 @@ maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
 dependencies:
-- aeson >=0.11
-- amazonka >=1.4.5
-- amazonka-sqs >=1.4.5
-- async >=2.0
-- attoparsec >=0.10
-- base >=4.6 && <5
-- base64-bytestring >=1.0
-- bilge >=0.21.1
-- blaze-builder >=0.3
-- brig-types >=0.73.1
-- bytestring >=0.9
-- bytestring-conversion >=0.2
-- case-insensitive >=1.0
-- cassandra-util >=0.16.2
-- cereal >=0.4
-- containers >=0.5
-- currency-codes >=2.0
-- data-default >=0.5
-- enclosed-exceptions >=1.0
-- errors >=2.0
-- exceptions >=0.4
-- extended
-- extra >=1.3
-- galley-types >=0.65.0
-- gundeck-types >=1.35.2
-- HsOpenSSL >=0.11
-- HsOpenSSL-x509-system >=0.1
-- http-client >=0.4
-- http-client-openssl >=0.2
-- http-client-tls >=0.2.2
-- http-types >=0.8
 - imports
-- insert-ordered-containers
-- lens >=4.4
-- lifted-base >=0.2
-- metrics-wai >=0.4
-- monad-control >=1.0
-- mtl >=2.2
-- optparse-applicative >=0.10
-- pem
-- prometheus-client
-- protobuf >=0.2
-- proto-lens >=0.2
-- raw-strings-qq >=1.0
-- resourcet >=1.1
-- retry >=0.5
+- extended
 - safe >=0.3
-- safe-exceptions >=0.1
-- semigroups >=0.12
-- servant
-- servant-swagger
-- singletons >=1.0
-- split >=0.2
 - ssl-util
-- ssl-util >=0.1
-- stm >=2.4
-- string-conversions
-- swagger >=0.1
-- swagger2
-- text >=0.11
-- text-format >=0.3
-- time >=1.4
-- tinylog >=0.10
-- tls >=1.3.10
-- transformers >=0.3
-- transformers-base >=0.4
-- types-common >=0.16
-- types-common-journal >=0.1
-- unliftio >=0.2
-- unliftio-core >=0.1
-- unordered-containers >=0.2
-- uri-bytestring >=0.2
-- uuid >=1.3
-- vector >=0.10
-- wai >=3.0
-- wai-extra >=3.0
-- wai-middleware-gunzip >=0.0.2
-- wai-predicates >=0.8
-- wai-routing >=0.12
-- wai-utilities >=0.16
-- warp >=3.0
-- zauth
+- raw-strings-qq >=1.0
 library:
   source-dirs: src
+  dependencies:
+  - aeson >=0.11
+  - amazonka >=1.4.5
+  - amazonka-sqs >=1.4.5
+  - async >=2.0
+  - attoparsec >=0.10
+  - base >=4.6 && <5
+  - base64-bytestring >=1.0
+  - bilge >=0.21.1
+  - blaze-builder >=0.3
+  - brig-types >=0.73.1
+  - bytestring >=0.9
+  - bytestring-conversion >=0.2
+  - case-insensitive >=1.0
+  - cassandra-util >=0.16.2
+  - cereal >=0.4
+  - containers >=0.5
+  - currency-codes >=2.0
+  - data-default >=0.5
+  - enclosed-exceptions >=1.0
+  - errors >=2.0
+  - exceptions >=0.4
+  - extra >=1.3
+  - galley-types >=0.65.0
+  - gundeck-types >=1.35.2
+  - HsOpenSSL >=0.11
+  - HsOpenSSL-x509-system >=0.1
+  - http-client >=0.4
+  - http-client-openssl >=0.2
+  - http-client-tls >=0.2.2
+  - http-types >=0.8
+  - insert-ordered-containers
+  - lens >=4.4
+  - lifted-base >=0.2
+  - metrics-wai >=0.4
+  - monad-control >=1.0
+  - mtl >=2.2
+  - optparse-applicative >=0.10
+  - pem
+  - prometheus-client
+  - protobuf >=0.2
+  - proto-lens >=0.2
+  - resourcet >=1.1
+  - retry >=0.5
+  - safe-exceptions >=0.1
+  - semigroups >=0.12
+  - servant
+  - servant-swagger
+  - singletons >=1.0
+  - split >=0.2
+  - ssl-util >=0.1
+  - stm >=2.4
+  - string-conversions
+  - swagger >=0.1
+  - swagger2
+  - text >=0.11
+  - text-format >=0.3
+  - time >=1.4
+  - tinylog >=0.10
+  - tls >=1.3.10
+  - transformers >=0.3
+  - transformers-base >=0.4
+  - types-common >=0.16
+  - types-common-journal >=0.1
+  - unliftio >=0.2
+  - unliftio-core >=0.1
+  - unordered-containers >=0.2
+  - uri-bytestring >=0.2
+  - uuid >=1.3
+  - vector >=0.10
+  - wai >=3.0
+  - wai-extra >=3.0
+  - wai-middleware-gunzip >=0.0.2
+  - wai-predicates >=0.8
+  - wai-routing >=0.12
+  - wai-utilities >=0.16
+  - warp >=3.0
+  - zauth
 executables:
   galley:
     main: src/Main.hs

--- a/services/galley/test/integration/Main.hs
+++ b/services/galley/test/integration/Main.hs
@@ -6,14 +6,15 @@ import Bilge hiding (header, body)
 import Cassandra.Util
 import Control.Lens
 import Data.ByteString.Conversion
-import Data.Metrics.Test (sitemapConsistency)
+import Data.Metrics.Test (pathsConsistencyCheck)
+import Data.Metrics.WaiRoute (treeToPaths)
 import Data.Proxy
 import Data.Tagged
 import Data.Text.Encoding (encodeUtf8)
 import Data.Text (pack)
 import Data.Yaml (decodeFileEither)
-import Galley.Options
 import Galley.API (sitemap)
+import Galley.Options
 import Network.HTTP.Client (responseTimeoutMicro)
 import Network.HTTP.Client.TLS
 import Network.Wai.Utilities.Server (compile)
@@ -21,6 +22,7 @@ import OpenSSL (withOpenSSL)
 import Options.Applicative
 import TestSetup
 import Test.Tasty
+import Test.Tasty.HUnit
 import Test.Tasty.Options
 import Util.Options
 import Util.Options.Common
@@ -62,7 +64,9 @@ main :: IO ()
 main = withOpenSSL $ runTests go
   where
     go g i = withResource (getOpts g i) releaseOpts $ \setup -> testGroup "galley"
-        [ sitemapConsistency . compile $ Galley.API.sitemap
+        [ testCase "sitemap" $ assertEqual "inconcistent sitemap"
+            mempty
+            (pathsConsistencyCheck . treeToPaths . compile $ Galley.API.sitemap)
         , API.tests setup
         ]
 

--- a/services/gundeck/package.yaml
+++ b/services/gundeck/package.yaml
@@ -211,6 +211,7 @@ tests:
     - gundeck-types
     - HsOpenSSL
     - lens
+    - metrics-wai
     - MonadRandom
     - mtl
     - multiset
@@ -230,6 +231,7 @@ tests:
     - unordered-containers
     - uuid
     - vector
+    - wai-utilities
 benchmarks:
   gundeck-bench:
     main: Main.hs

--- a/services/gundeck/package.yaml
+++ b/services/gundeck/package.yaml
@@ -9,74 +9,8 @@ maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
 dependencies:
-- aeson >=0.11
-- amazonka >=1.3.7
-- amazonka-sns >=1.3.7
-- amazonka-sqs >=1.3.7
-- async >=2.0
-- attoparsec >=0.10
-- auto-update >=0.1
-- base >=4.7 && <5
-- base64-bytestring >=1.0
-- bilge >=0.21
-- blaze-builder >=0.3
-- bytestring >=0.9
-- bytestring-conversion >=0.2
-- case-insensitive >=1.0
-- cassandra-util >=0.16.2
-- conduit >=1.1
-- containers >=0.5
-- data-default >=0.5
-- enclosed-exceptions >=1.0
-- errors >=2.0
-- exceptions >=0.4
-- extended
-- extra >=1.1
-- gundeck-types >=1.0
-- HsOpenSSL >=0.11
-- http-client >=0.4
-- http-client-tls >=0.2.2
-- http-types >=0.8
 - imports
-- lens >=4.4
-- lens-aeson >=1.0
-- lifted-base >=0.2
-- metrics-core >=0.2.1
-- metrics-wai >=0.5.7
-- monad-control >=1.0
-- mtl >=2.2
-- network-uri >=2.6
-- optparse-applicative >=0.10
-- prometheus-client
-- psqueues >=0.2.2
-- redis-io >=0.4
-- resourcet >=1.1
-- retry >=0.5
-- semigroups >=0.12
-- singletons >=1.0
-- split >=0.2
-- swagger >=0.1
-- text >=1.1
-- text-format >=0.3
-- time >=1.4
-- tinylog >=0.10
-- tls >=1.3.4
-- transformers >=0.3
-- transformers-base >=0.4
-- types-common >=0.16
-- unliftio >=0.2
-- unliftio-core >=0.1
-- unordered-containers >=0.2
-- uuid >=1.3
-- vector >=0.10
-- wai >=3.2
-- wai-extra >=3.0
-- wai-middleware-gunzip >=0.0.2
-- wai-predicates >=0.8
-- wai-routing >=0.12
-- wai-utilities >=0.16
-- warp >=3.2
-- yaml >=0.8
+- extended
 library:
   source-dirs: src
   ghc-options:
@@ -107,6 +41,73 @@ library:
   - Gundeck.Util
   - Gundeck.Util.DelayQueue
   - Gundeck.Util.Redis
+  dependencies:
+  - aeson >=0.11
+  - amazonka >=1.3.7
+  - amazonka-sns >=1.3.7
+  - amazonka-sqs >=1.3.7
+  - async >=2.0
+  - attoparsec >=0.10
+  - auto-update >=0.1
+  - base >=4.7 && <5
+  - bilge >=0.21
+  - blaze-builder >=0.3
+  - bytestring >=0.9
+  - bytestring-conversion >=0.2
+  - base64-bytestring >=1.0
+  - case-insensitive >=1.0
+  - cassandra-util >=0.16.2
+  - conduit >=1.1
+  - containers >=0.5
+  - data-default >=0.5
+  - enclosed-exceptions >=1.0
+  - errors >=2.0
+  - exceptions >=0.4
+  - extra >=1.1
+  - gundeck-types >=1.0
+  - HsOpenSSL >=0.11
+  - http-client >=0.4
+  - http-client-tls >=0.2.2
+  - http-types >=0.8
+  - lens >=4.4
+  - lens-aeson >=1.0
+  - lifted-base >=0.2
+  - metrics-core >=0.2.1
+  - metrics-wai >=0.5.7
+  - monad-control >=1.0
+  - mtl >=2.2
+  - network-uri >=2.6
+  - optparse-applicative >=0.10
+  - prometheus-client
+  - psqueues >=0.2.2
+  - redis-io >=0.4
+  - resourcet >=1.1
+  - retry >=0.5
+  - semigroups >=0.12
+  - singletons >=1.0
+  - split >=0.2
+  - swagger >=0.1
+  - text >=1.1
+  - text-format >=0.3
+  - time >=1.4
+  - tinylog >=0.10
+  - tls >=1.3.4
+  - transformers >=0.3
+  - transformers-base >=0.4
+  - types-common >=0.16
+  - unliftio >=0.2
+  - unliftio-core >=0.1
+  - unordered-containers >=0.2
+  - uuid >=1.3
+  - vector >=0.10
+  - wai >=3.2
+  - wai-extra >=3.0
+  - wai-middleware-gunzip >=0.0.2
+  - wai-predicates >=0.8
+  - wai-routing >=0.12
+  - wai-utilities >=0.16
+  - warp >=3.2
+  - yaml >=0.8
 executables:
   gundeck-integration:
     main: Main.hs

--- a/services/gundeck/package.yaml
+++ b/services/gundeck/package.yaml
@@ -249,5 +249,5 @@ benchmarks:
 flags:
   static:
     description: Enable static linking
-    manual: false
+    manual: true
     default: false

--- a/services/gundeck/test/unit/Main.hs
+++ b/services/gundeck/test/unit/Main.hs
@@ -2,10 +2,12 @@ module Main (main) where
 
 import Imports
 
-import Data.Metrics.Test (sitemapConsistency)
+import Data.Metrics.Test (pathsConsistencyCheck)
+import Data.Metrics.WaiRoute (treeToPaths)
 import Network.Wai.Utilities.Server (compile)
 import OpenSSL (withOpenSSL)
 import Test.Tasty
+import Test.Tasty.HUnit
 
 import qualified DelayQueue
 import qualified Gundeck.API
@@ -16,7 +18,9 @@ import qualified Push
 main :: IO ()
 main = withOpenSSL . defaultMain $
     testGroup "Main"
-        [ sitemapConsistency . compile $ Gundeck.API.sitemap
+        [ testCase "sitemap" $ assertEqual "inconcistent sitemap"
+            mempty
+            (pathsConsistencyCheck . treeToPaths . compile $ Gundeck.API.sitemap)
         , DelayQueue.tests
         , Json.tests
         , Native.tests

--- a/services/proxy/package.yaml
+++ b/services/proxy/package.yaml
@@ -8,41 +8,9 @@ author: Wire Swiss GmbH
 maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
-
 dependencies:
-- aeson >=1.0
-- base >=4.6 && <5
-- bilge >=0.21
-- bytestring >=0.10
-- case-insensitive >=1.2
-- configurator >=0.3
-- data-default >=0.5
-- exceptions >=0.8
-- extended
-- http-client >=0.4
-- http-client-tls >=0.2
-- http-reverse-proxy >=0.4
-- http-types >=0.9
 - imports
-- lens >=4.11
-- metrics-wai >=0.5
-- mtl >=2.2
-- network >=2.6
-- optparse-applicative >=0.12
-- prometheus-client
-- retry >=0.7
-- text >=1.2
-- tinylog >=0.12
-- tls >=1.3
-- transformers >=0.4
-- types-common >=0.8
-- wai >=3.2
-- wai-predicates >=0.8
-- wai-routing >=0.12
-- wai-utilities >=0.14.3
-- warp >=3.0
-- yaml >=0.8.22
-
+- extended
 library:
   source-dirs: src
   ghc-options:
@@ -53,18 +21,37 @@ library:
   - Proxy.Options
   - Proxy.Proxy
   - Proxy.Run
-
-tests:
-  spec:
-    main: Main.hs
-    source-dirs:
-    - test/unit
-    ghc-options: -threaded -rtsopts -with-rtsopts=-N
-    dependencies:
-    - metrics-core
-    - proxy
-    - tasty
-
+  dependencies:
+  - base >=4.6 && <5
+  - aeson >=1.0
+  - bilge >=0.21
+  - bytestring >=0.10
+  - case-insensitive >=1.2
+  - configurator >=0.3
+  - data-default >=0.5
+  - http-reverse-proxy >=0.4
+  - http-client >=0.4
+  - http-client-tls >=0.2
+  - http-types >=0.9
+  - exceptions >=0.8
+  - lens >=4.11
+  - metrics-wai >=0.5
+  - mtl >=2.2
+  - network >=2.6
+  - optparse-applicative >=0.12
+  - prometheus-client
+  - retry >=0.7
+  - text >=1.2
+  - tinylog >=0.12
+  - tls >=1.3
+  - transformers >=0.4
+  - types-common >=0.8
+  - wai >=3.2
+  - wai-predicates >=0.8
+  - wai-routing >=0.12
+  - wai-utilities >=0.14.3
+  - warp >=3.0
+  - yaml >=0.8.22
 executables:
   proxy:
     main: src/Main.hs

--- a/services/proxy/package.yaml
+++ b/services/proxy/package.yaml
@@ -69,5 +69,5 @@ executables:
 flags:
   static:
     description: Enable static linking
-    manual: false
+    manual: true
     default: false

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -95,8 +95,6 @@ tests:
     dependencies:
       - hspec
       - hspec-discover
-      - tasty
-      - tasty-hspec
       - QuickCheck
       - spar
       - uri-bytestring

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -95,6 +95,7 @@ tests:
     dependencies:
       - hspec
       - hspec-discover
+      - metrics-wai
       - QuickCheck
       - spar
       - uri-bytestring

--- a/services/spar/test/Test/Spar/APISpec.hs
+++ b/services/spar/test/Test/Spar/APISpec.hs
@@ -5,24 +5,17 @@ module Test.Spar.APISpec where
 import Imports
 
 import Arbitrary ()
-import Control.Exception
-import Data.Metrics.Test (servantApiConsistency)
+import Data.Metrics.Test (pathsConsistencyCheck)
+import Data.Metrics.Servant (routesToPaths)
 import Data.Proxy
 import Servant.Swagger (validateEveryToJSON)
 import Spar.API as API
-import System.Exit
 import Test.Hspec
-
-import qualified Test.Tasty
 
 
 spec :: Spec
 spec = do
   -- Note: SCIM types are not validated because their content-type is 'SCIM'.
   validateEveryToJSON (Proxy @API.OutsideWorldAPI)
-  tastyToHspec (servantApiConsistency (Proxy @API.API))
-
-
-tastyToHspec :: Test.Tasty.TestTree -> Spec
-tastyToHspec tasty = it "tasty" $ do
-  Test.Tasty.defaultMain tasty `catch` (`shouldBe` ExitSuccess)
+  it "api consistency" $ do
+    pathsConsistencyCheck (routesToPaths @API.API) `shouldBe` mempty

--- a/stack.yaml
+++ b/stack.yaml
@@ -60,17 +60,17 @@ extra-deps:
 
 flags:
   types-common:
-    cql: True
-    protobuf: True
-    arbitrary: True
+    cql: true
+    protobuf: true
+    arbitrary: true
 
   galley-types:
-    cql: True
+    cql: true
 
   brig-types:
-    cql: True
+    cql: true
 
-allow-newer: False
+allow-newer: false
 
 nix:
   shell-file: shell.nix

--- a/tools/stern/package.yaml
+++ b/tools/stern/package.yaml
@@ -78,5 +78,5 @@ executables:
 flags:
   static:
     description: Enable static linking
-    manual: false
+    manual: true
     default: false


### PR DESCRIPTION
Develop contains some changes in `package.yaml` files that make some executables depend on packages they don't need, which can trigger dynamic linker errors in our ~~docker~~ ops setup.

This PR reverts these changes and adds some more conservative ones to get the tests added in #808 to build again.