### PR TITLE
New feature flags backend

### DIFF
--- a/libs/bilge/src/Bilge/Response.hs
+++ b/libs/bilge/src/Bilge/Response.hs
@@ -16,10 +16,12 @@ module Bilge.Response
     , responseHeaders
     , responseVersion
     , responseBody
+    , responseJson
     ) where
 
 import Imports
 import Control.Lens
+import Data.Aeson (FromJSON, eitherDecode)
 import Data.CaseInsensitive (original)
 import Network.HTTP.Client
 import Network.HTTP.Types (HeaderName, httpMajor, httpMinor)
@@ -75,3 +77,9 @@ showResponse r = showString "HTTP/"
   where
     showHeaders = foldl' (.) (showString "") (map showHdr (responseHeaders r))
     showHdr (k, v) = showString . C.unpack $ original k <> ": " <> v <> "\n"
+
+
+responseJson :: FromJSON a => Response (Maybe LByteString) -> Either String a
+responseJson resp = case responseBody resp of
+    Nothing  -> Left "no body"
+    Just raw -> eitherDecode raw

--- a/libs/brig-types/test/unit/Test/Brig/Types/Common.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Common.hs
@@ -9,15 +9,17 @@
 module Test.Brig.Types.Common where
 
 import Imports
+
 import Brig.Types.Common
 import Brig.Types.Team.LegalHold
+import Brig.Types.Test.Arbitrary ()
 import Control.Lens
 import Data.Aeson
 import Data.Aeson.Types
 import Data.Proxy
 import Data.Typeable (typeOf)
 import Galley.Types.Teams
-import Brig.Types.Test.Arbitrary ()
+import Galley.Types.Teams.SSO
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
@@ -52,6 +54,8 @@ tests = testGroup "Common (types vs. aeson)"
     , run @RemoveLegalHoldSettingsRequest Proxy
     , run @DisableLegalHoldForUserRequest Proxy
     , run @ApproveLegalHoldForUserRequest Proxy
+    , run @SSOStatus Proxy
+    , run @SSOTeamConfig Proxy
     , testCase "{} is a valid TeamMemberDeleteData" $ do
         assertEqual "{}" (Right $ newTeamMemberDeleteData Nothing) (eitherDecode "{}")
     ]
@@ -73,3 +77,9 @@ instance Eq TeamMemberDeleteData where
 
 instance Show TeamMemberDeleteData where
   show a = "(TeamMemberDeleteData " <> show (a ^. tmdAuthPassword) <> ")"
+
+instance Arbitrary SSOStatus where
+  arbitrary = Test.Tasty.QuickCheck.elements [minBound..]
+
+instance Arbitrary SSOTeamConfig where
+  arbitrary = SSOTeamConfig <$> arbitrary

--- a/libs/galley-types/package.yaml
+++ b/libs/galley-types/package.yaml
@@ -12,18 +12,6 @@ dependencies:
 - imports
 library:
   source-dirs: src
-  exposed-modules:
-  - Galley.Types
-  - Galley.Types.Bot
-  - Galley.Types.Bot.Service
-  - Galley.Types.Bot.Service.Internal
-  - Galley.Types.Proto
-  - Galley.Types.Swagger
-  - Galley.Types.Teams
-  - Galley.Types.Teams.Internal
-  - Galley.Types.Teams.Intra
-  - Galley.Types.Teams.Feature
-  - Galley.Types.Teams.Swagger
   dependencies:
   - aeson >=0.6
   - attoparsec >=0.10

--- a/libs/galley-types/package.yaml
+++ b/libs/galley-types/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: galley-types
 version: '0.81.0'
@@ -22,6 +22,7 @@ library:
   - Galley.Types.Teams
   - Galley.Types.Teams.Internal
   - Galley.Types.Teams.Intra
+  - Galley.Types.Teams.Feature
   - Galley.Types.Teams.Swagger
   dependencies:
   - aeson >=0.6

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -400,6 +400,7 @@ data HiddenPerm
     | ViewLegalHoldTeamSettings
     | ChangeLegalHoldUserSettings
     | ViewLegalHoldUserSettings
+    | ViewSSOTeamSettings  -- (change is only allowed via customer support backoffice)
     deriving (Eq, Ord, Show, Enum, Bounded)
 
 -- | See Note [hidden team roles]
@@ -439,6 +440,7 @@ hiddenPermissionsFromPermissions =
         roleHiddenPerms RoleExternalPartner =
             Set.fromList [ ViewLegalHoldTeamSettings
                          , ViewLegalHoldUserSettings
+                         , ViewSSOTeamSettings
                          ]
 
 -- | See Note [hidden team roles]

--- a/libs/galley-types/src/Galley/Types/Teams/Feature.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/Feature.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Galley.Types.Teams.Feature where
+
+import Imports
+import Data.Aeson
+import Data.Json.Util
+
+import qualified Data.Text as T
+
+data SSOStatus = SSODisabled | SSOEnabled
+   deriving stock (Eq, Show, Ord, Enum, Bounded, Generic)
+
+instance ToJSON SSOStatus where
+    toJSON SSOEnabled  = "enabled"
+    toJSON SSODisabled = "disabled"
+
+instance FromJSON SSOStatus where
+    parseJSON = withText "SSOStatus" $ \case
+      "enabled"  -> pure SSOEnabled
+      "disabled" -> pure SSODisabled
+      x -> fail $ "unexpected status type: " <> T.unpack x
+
+data SSOTeamConfig = SSOTeamConfig
+    { ssoTeamConfigStatus :: !SSOStatus
+    }
+  deriving stock (Eq, Show, Generic)
+
+instance ToJSON SSOTeamConfig where
+    toJSON s = object
+        $ "status" .= ssoTeamConfigStatus s
+        # []
+
+instance FromJSON SSOTeamConfig where
+    parseJSON = withObject "SSOTeamConfig" $ \o ->
+        SSOTeamConfig <$> o .: "status"

--- a/libs/galley-types/src/Galley/Types/Teams/SSO.hs
+++ b/libs/galley-types/src/Galley/Types/Teams/SSO.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 
-module Galley.Types.Teams.Feature where
+module Galley.Types.Teams.SSO where
 
 import Imports
 import Data.Aeson

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -21,6 +21,7 @@ import qualified V30
 import qualified V31
 import qualified V32
 import qualified V33
+import qualified V34
 
 main :: IO ()
 main = do

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -42,6 +42,7 @@ main = do
         , V31.migration
         , V32.migration
         , V33.migration
+        , V34.migration
         -- When adding migrations here, don't forget to update
         -- 'schemaVersion' in Galley.Data
         ]

--- a/services/galley/schema/src/V33.hs
+++ b/services/galley/schema/src/V33.hs
@@ -6,7 +6,7 @@ import Cassandra.Schema
 import Text.RawString.QQ
 
 migration :: Migration
-migration = Migration 33 "xxx" $ do
+migration = Migration 33 "Add storage for pubkey for LH services" $ do
     schema' [r|
         create type if not exists pubkey
             ( typ  int

--- a/services/galley/schema/src/V34.hs
+++ b/services/galley/schema/src/V34.hs
@@ -1,0 +1,19 @@
+module V34 (migration) where
+
+import Imports
+import Cassandra.Schema
+import Text.RawString.QQ
+
+-- TODO: After we've migrated legalhold to a separate feature table,
+--       delete `legalhold_team_config`
+migration :: Migration
+migration = Migration 34 "Add team features table" $ do
+    schema' [r|
+        CREATE TABLE team_features (
+            team_id          uuid,
+            legalhold_status int,
+            sso_status       int,
+            PRIMARY KEY (team_id)
+        ) WITH compaction = {'class': 'LeveledCompactionStrategy'}
+          AND gc_grace_seconds = 864000;
+    |]

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -921,20 +921,20 @@ sitemap = do
     -- possible internally. Viewing the status should be allowed
     -- for any admin
 
-    get "/i/teams/:tid/legalhold" (continue Teams.getLegalholdStatusInternal) $
+    get "/i/teams/:tid/features/legalhold" (continue Teams.getLegalholdStatusInternal) $
         capture "tid"
         .&. accept "application" "json"
 
-    put "/i/teams/:tid/legalhold" (continue Teams.setLegalholdStatusInternal) $
+    put "/i/teams/:tid/features/legalhold" (continue Teams.setLegalholdStatusInternal) $
         capture "tid"
         .&. jsonRequest @LegalHoldTeamConfig
         .&. accept "application" "json"
 
-    get "/i/teams/:tid/sso" (continue Teams.getSSOStatusInternal) $
+    get "/i/teams/:tid/features/sso" (continue Teams.getSSOStatusInternal) $
         capture "tid"
         .&. accept "application" "json"
 
-    put "/i/teams/:tid/sso" (continue Teams.setSSOStatusInternal) $
+    put "/i/teams/:tid/features/sso" (continue Teams.setSSOStatusInternal) $
         capture "tid"
         .&. jsonRequest @SSOTeamConfig
         .&. accept "application" "json"

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -287,11 +287,6 @@ sitemap = do
     get "/teams/api-docs" (continue . const . pure . json $ swagger) $
         accept "application" "json"
 
-    get "/teams/:tid/legalhold" (continue Teams.getLegalholdStatus) $
-        zauthUserId
-        .&. capture "tid"
-        .&. accept "application" "json"
-
     post "/teams/:tid/legalhold/settings" (continue LegalHold.createSettings) $
         zauthUserId
         .&. capture "tid"
@@ -920,6 +915,16 @@ sitemap = do
     -- Start of team features; enabling this should only be
     -- possible internally. Viewing the status should be allowed
     -- for any admin
+
+    get "/teams/:tid/features/legalhold" (continue Teams.getLegalholdStatus) $
+        zauthUserId
+        .&. capture "tid"
+        .&. accept "application" "json"
+
+    get "/teams/:tid/features/sso" (continue Teams.getSSOStatus) $
+        zauthUserId
+        .&. capture "tid"
+        .&. accept "application" "json"
 
     get "/i/teams/:tid/features/legalhold" (continue Teams.getLegalholdStatusInternal) $
         capture "tid"

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -19,6 +19,7 @@ import Galley.API.Query
 import Galley.API.Swagger (swagger)
 import Galley.Types
 import Galley.Types.Teams
+import Galley.Types.Teams.Feature
 import Galley.Types.Teams.Intra
 import Galley.Types.Bot.Service
 import Galley.Types.Bot (AddBot, RemoveBot)
@@ -36,6 +37,7 @@ import qualified Data.Set                      as Set
 import qualified Galley.API.Error              as Error
 import qualified Galley.API.Internal           as Internal
 import qualified Galley.API.LegalHold          as LegalHold
+import qualified Galley.API.Teams              as Teams
 import qualified Galley.Queue                  as Q
 import qualified Galley.Types.Swagger          as Model
 import qualified Galley.Types.Teams.Swagger    as TeamsModel
@@ -904,23 +906,37 @@ sitemap = do
         .&. capture "uid"
         .&. accept "application" "json"
 
-    get "/i/teams/:tid/legalhold" (continue LegalHold.getEnabled) $
-        capture "tid"
-        .&. accept "application" "json"
-
-    put "/i/teams/:tid/legalhold" (continue LegalHold.setEnabled) $
-        capture "tid"
-        .&. jsonRequest @LegalHoldTeamConfig
-        .&. accept "application" "json"
-
     get "/i/users/:uid/team/members" (continue getBindingTeamMembers) $
         capture "uid"
 
     get "/i/users/:uid/team" (continue getBindingTeamId) $
         capture "uid"
 
+    -- Start of team features
+
+    get "/i/teams/:tid/legalhold" (continue Teams.getLegalHoldEnabled) $
+        capture "tid"
+        .&. accept "application" "json"
+
+    put "/i/teams/:tid/legalhold" (continue Teams.setLegalHoldEnabled) $
+        capture "tid"
+        .&. jsonRequest @LegalHoldTeamConfig
+        .&. accept "application" "json"
+
+    get "/i/teams/:tid/sso" (continue Teams.getSSOEnabled) $
+        capture "tid"
+        .&. accept "application" "json"
+
+    put "/i/teams/:tid/sso" (continue Teams.setSSOEnabled) $
+        capture "tid"
+        .&. jsonRequest @SSOTeamConfig
+        .&. accept "application" "json"
+
+    -- End of team features
+
     get "/i/test/clients" (continue getClients)
         zauthUserId
+    -- TODO: What is this endpoint? Is this used anywhere?
 
     post "/i/clients/:client" (continue addClient) $
         zauthUserId

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -287,6 +287,11 @@ sitemap = do
     get "/teams/api-docs" (continue . const . pure . json $ swagger) $
         accept "application" "json"
 
+    get "/teams/:tid/legalhold" (continue Teams.getLegalholdStatus) $
+        zauthUserId
+        .&. capture "tid"
+        .&. accept "application" "json"
+
     post "/teams/:tid/legalhold/settings" (continue LegalHold.createSettings) $
         zauthUserId
         .&. capture "tid"
@@ -912,22 +917,24 @@ sitemap = do
     get "/i/users/:uid/team" (continue getBindingTeamId) $
         capture "uid"
 
-    -- Start of team features
+    -- Start of team features; enabling this should only be
+    -- possible internally. Viewing the status should be allowed
+    -- for any admin
 
-    get "/i/teams/:tid/legalhold" (continue Teams.getLegalHoldEnabled) $
+    get "/i/teams/:tid/legalhold" (continue Teams.getLegalholdStatusInternal) $
         capture "tid"
         .&. accept "application" "json"
 
-    put "/i/teams/:tid/legalhold" (continue Teams.setLegalHoldEnabled) $
+    put "/i/teams/:tid/legalhold" (continue Teams.setLegalholdStatusInternal) $
         capture "tid"
         .&. jsonRequest @LegalHoldTeamConfig
         .&. accept "application" "json"
 
-    get "/i/teams/:tid/sso" (continue Teams.getSSOEnabled) $
+    get "/i/teams/:tid/sso" (continue Teams.getSSOStatusInternal) $
         capture "tid"
         .&. accept "application" "json"
 
-    put "/i/teams/:tid/sso" (continue Teams.setSSOEnabled) $
+    put "/i/teams/:tid/sso" (continue Teams.setSSOStatusInternal) $
         capture "tid"
         .&. jsonRequest @SSOTeamConfig
         .&. accept "application" "json"

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -19,8 +19,8 @@ import Galley.API.Query
 import Galley.API.Swagger (swagger)
 import Galley.Types
 import Galley.Types.Teams
-import Galley.Types.Teams.Feature
 import Galley.Types.Teams.Intra
+import Galley.Types.Teams.SSO
 import Galley.Types.Bot.Service
 import Galley.Types.Bot (AddBot, RemoveBot)
 import Network.HTTP.Types

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -37,24 +37,6 @@ isLegalHoldEnabled tid = do
         Just LegalHoldDisabled -> False
         Nothing                -> False
 
--- | Get legal hold status for a team.
-getEnabled :: TeamId ::: JSON -> Galley Response
-getEnabled (tid ::: _) = do
-    legalHoldTeamConfig <- LegalHoldData.getLegalHoldTeamConfig tid
-    pure . json . fromMaybe defConfig $ legalHoldTeamConfig
-  where
-    defConfig = LegalHoldTeamConfig LegalHoldDisabled
-
--- | Enable or disable legal hold for a team.
-setEnabled :: TeamId ::: JsonRequest LegalHoldTeamConfig ::: JSON -> Galley Response
-setEnabled (tid ::: req ::: _) = do
-    legalHoldTeamConfig <- fromJsonBody req
-    case legalHoldTeamConfigStatus legalHoldTeamConfig of
-        LegalHoldDisabled -> removeSettings' tid Nothing
-        LegalHoldEnabled -> pure ()
-    LegalHoldData.setLegalHoldTeamConfig tid legalHoldTeamConfig
-    pure noContent
-
 createSettings :: UserId ::: TeamId ::: JsonRequest NewLegalHoldService ::: JSON -> Galley Response
 createSettings (zusr ::: tid ::: req ::: _) = do
     assertLegalHoldEnabled tid

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -520,7 +520,8 @@ setSSOStatusInternal :: TeamId ::: JsonRequest SSOTeamConfig ::: JSON -> Galley 
 setSSOStatusInternal (tid ::: req ::: _) = do
     ssoTeamConfig <- fromJsonBody req
     case ssoTeamConfigStatus ssoTeamConfig of
-        SSODisabled -> undefined -- What to do when it's disabled, notify spar?
+        -- TODO: What to do when it's disabled, notify spar?
+        SSODisabled -> pure ()
         SSOEnabled  -> pure ()
     Data.setSSOTeamConfig tid ssoTeamConfig
     pure noContent

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -491,11 +491,12 @@ getBindingTeamMembers zusr = withBindingTeam zusr $ \tid -> do
     pure . json $ newTeamMemberList members
 
 -- Public endpoints for feature checks
-getSSOStatus :: TeamId ::: UserId ::: JSON -> Galley Response
-getSSOStatus (tid ::: uid ::: ct) = do
+
+getSSOStatus :: UserId ::: TeamId ::: JSON -> Galley Response
+getSSOStatus (uid ::: tid ::: ct) = do
     membs <- Data.teamMembers tid
-    void $ permissionCheck uid ViewLegalHoldTeamSettings membs
-    getLegalholdStatusInternal (tid ::: ct)
+    void $ permissionCheck uid ViewSSOTeamSettings membs
+    getSSOStatusInternal (tid ::: ct)
 
 getLegalholdStatus :: UserId ::: TeamId ::: JSON -> Galley Response
 getLegalholdStatus (uid ::: tid ::: ct) = do

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -53,8 +53,8 @@ import Galley.Intra.Push
 import Galley.Intra.User
 import Galley.Options
 import Galley.Types.Teams
-import Galley.Types.Teams.Feature
 import Galley.Types.Teams.Intra
+import Galley.Types.Teams.SSO
 import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Predicate hiding (setStatus, result, or)
@@ -64,7 +64,7 @@ import UnliftIO (mapConcurrently)
 import qualified Data.Set as Set
 import qualified Galley.Data as Data
 import qualified Galley.Data.LegalHold as LegalHoldData
-import qualified Galley.Data.Teams as Data
+import qualified Galley.Data.SSO as SSOData
 import qualified Galley.External as External
 import qualified Galley.Queue as Q
 import qualified Galley.Types as Conv
@@ -510,7 +510,7 @@ getLegalholdStatus (uid ::: tid ::: ct) = do
 -- | Get legal SSO status for a team.
 getSSOStatusInternal :: TeamId ::: JSON -> Galley Response
 getSSOStatusInternal (tid ::: _) = do
-    ssoTeamConfig <- Data.getSSOTeamConfig tid
+    ssoTeamConfig <- SSOData.getSSOTeamConfig tid
     pure . json . fromMaybe defConfig $ ssoTeamConfig
   where
     defConfig = SSOTeamConfig SSODisabled
@@ -523,7 +523,7 @@ setSSOStatusInternal (tid ::: req ::: _) = do
         -- TODO: What to do when it's disabled, notify spar?
         SSODisabled -> pure ()
         SSOEnabled  -> pure ()
-    Data.setSSOTeamConfig tid ssoTeamConfig
+    SSOData.setSSOTeamConfig tid ssoTeamConfig
     pure noContent
 
 -- | Get legal hold status for a team.

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -513,7 +513,7 @@ getSSOStatusInternal (tid ::: _) = do
     ssoTeamConfig <- Data.getSSOTeamConfig tid
     pure . json . fromMaybe defConfig $ ssoTeamConfig
   where
-    defConfig = SSOTeamConfig SSOEnabled
+    defConfig = SSOTeamConfig SSODisabled
 
 -- | Enable or disable SSO for a team.
 setSSOStatusInternal :: TeamId ::: JsonRequest SSOTeamConfig ::: JSON -> Galley Response

--- a/services/galley/src/Galley/Data/Instances.hs
+++ b/services/galley/src/Galley/Data/Instances.hs
@@ -10,6 +10,7 @@ import Control.Error (note)
 import Galley.Types
 import Galley.Types.Bot()
 import Galley.Types.Teams
+import Galley.Types.Teams.Feature
 import Galley.Types.Teams.Intra
 
 deriving instance Cql MutedStatus
@@ -107,3 +108,16 @@ instance Cql TeamStatus where
         4 -> return PendingActive
         n -> fail $ "unexpected team-status: " ++ show n
     fromCql _ = fail "team-status: int expected"
+
+
+instance Cql SSOStatus where
+    ctype = Tagged IntColumn
+
+    fromCql (CqlInt n) = case n of
+        0 -> pure $ SSODisabled
+        1 -> pure $ SSOEnabled
+        _ -> fail "fromCql: Invalid SSOStatus"
+    fromCql _ = fail "fromCql: SSOStatus: CqlInt expected"
+
+    toCql SSODisabled = CqlInt 0
+    toCql SSOEnabled = CqlInt 1

--- a/services/galley/src/Galley/Data/Instances.hs
+++ b/services/galley/src/Galley/Data/Instances.hs
@@ -10,8 +10,8 @@ import Control.Error (note)
 import Galley.Types
 import Galley.Types.Bot()
 import Galley.Types.Teams
-import Galley.Types.Teams.Feature
 import Galley.Types.Teams.Intra
+import Galley.Types.Teams.SSO
 
 deriving instance Cql MutedStatus
 deriving instance Cql ReceiptMode

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -245,11 +245,11 @@ insertBot = "insert into member (conv, user, service, provider, status) values (
 
 selectLegalHoldTeamConfig :: PrepQuery R (Identity TeamId) (Identity LegalHoldStatus)
 selectLegalHoldTeamConfig =
-  "select legalhold_status from team_config where team_id = ?"
+  "select legalhold_status from team_features where team_id = ?"
 
 updateLegalHoldTeamConfig :: PrepQuery W (LegalHoldStatus, TeamId) ()
 updateLegalHoldTeamConfig =
-  "update team_config set legalhold_status = ? where team_id = ?"
+  "update team_features set legalhold_status = ? where team_id = ?"
 
 insertLegalHoldSettings :: PrepQuery W (HttpsUrl, Fingerprint Rsa, ServiceToken, ServiceKey, TeamId) ()
 insertLegalHoldSettings =

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -245,11 +245,11 @@ insertBot = "insert into member (conv, user, service, provider, status) values (
 
 selectLegalHoldTeamConfig :: PrepQuery R (Identity TeamId) (Identity LegalHoldStatus)
 selectLegalHoldTeamConfig =
-  "select status from legalhold_team_config where team_id = ?"
+  "select legalhold_status from team_config where team_id = ?"
 
 updateLegalHoldTeamConfig :: PrepQuery W (LegalHoldStatus, TeamId) ()
 updateLegalHoldTeamConfig =
-  "update legalhold_team_config set status = ? where team_id = ?"
+  "update team_config set legalhold_status = ? where team_id = ?"
 
 insertLegalHoldSettings :: PrepQuery W (HttpsUrl, Fingerprint Rsa, ServiceToken, ServiceKey, TeamId) ()
 insertLegalHoldSettings =

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -1,10 +1,11 @@
 module Galley.Data.Queries where
 
 import Imports
-import Brig.Types.Code
-import Brig.Types.Team.LegalHold (LegalHoldStatus)
+
 import Brig.Types.Client.Prekey
+import Brig.Types.Code
 import Brig.Types.Provider
+import Brig.Types.Team.LegalHold (LegalHoldStatus)
 import Cassandra as C hiding (Value)
 import Cassandra.Util (Writetime)
 import Data.Id
@@ -13,9 +14,9 @@ import Data.LegalHold
 import Data.Misc
 import Galley.Data.Types
 import Galley.Types hiding (Conversation)
--- import Galley.Types.Bot
 import Galley.Types.Teams
 import Galley.Types.Teams.Intra
+import Galley.Types.Teams.SSO
 import Text.RawString.QQ
 
 import qualified Data.Text.Lazy as LT
@@ -298,3 +299,11 @@ updateUserLegalHoldStatus = [r|
           set legalhold_status = ?
           where team = ? and user = ?
     |]
+
+selectSSOTeamConfig :: PrepQuery R (Identity TeamId) (Identity SSOStatus)
+selectSSOTeamConfig =
+  "select sso_status from team_features where team_id = ?"
+
+updateSSOTeamConfig :: PrepQuery W (SSOStatus, TeamId) ()
+updateSSOTeamConfig =
+  "update team_features set sso_status = ? where team_id = ?"

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -245,12 +245,16 @@ insertBot = "insert into member (conv, user, service, provider, status) values (
 -- LegalHold ----------------------------------------------------------------
 
 selectLegalHoldTeamConfig :: PrepQuery R (Identity TeamId) (Identity LegalHoldStatus)
-selectLegalHoldTeamConfig =
-  "select legalhold_status from team_features where team_id = ?"
+selectLegalHoldTeamConfig = if True then _old else _new  -- TODO: get rid of _old
+  where
+    _new = "select legalhold_status from team_features where team_id = ?"
+    _old = "select status from legalhold_team_config where team_id = ?"
 
 updateLegalHoldTeamConfig :: PrepQuery W (LegalHoldStatus, TeamId) ()
-updateLegalHoldTeamConfig =
-  "update team_features set legalhold_status = ? where team_id = ?"
+updateLegalHoldTeamConfig = if True then _old else _new  -- TODO: get rid of _old
+  where
+    _new = "update team_features set legalhold_status = ? where team_id = ?"
+    _old = "update legalhold_team_config set status = ? where team_id = ?"
 
 insertLegalHoldSettings :: PrepQuery W (HttpsUrl, Fingerprint Rsa, ServiceToken, ServiceKey, TeamId) ()
 insertLegalHoldSettings =

--- a/services/galley/src/Galley/Data/SSO.hs
+++ b/services/galley/src/Galley/Data/SSO.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE ViewPatterns #-}
-module Galley.Data.Teams
+module Galley.Data.SSO
     ( setSSOTeamConfig
     , getSSOTeamConfig
     ) where
@@ -8,7 +8,7 @@ import Imports
 import Cassandra
 import Data.Id
 import Galley.Data.Instances ()
-import Galley.Types.Teams.Feature
+import Galley.Types.Teams.SSO
 
 -- | Return whether a given team is allowed to enable/disable sso
 getSSOTeamConfig :: MonadClient m => TeamId -> m (Maybe SSOTeamConfig)

--- a/services/galley/src/Galley/Data/SSO.hs
+++ b/services/galley/src/Galley/Data/SSO.hs
@@ -9,6 +9,7 @@ import Cassandra
 import Data.Id
 import Galley.Data.Instances ()
 import Galley.Types.Teams.SSO
+import Galley.Data.Queries
 
 -- | Return whether a given team is allowed to enable/disable sso
 getSSOTeamConfig :: MonadClient m => TeamId -> m (Maybe SSOTeamConfig)
@@ -21,11 +22,3 @@ getSSOTeamConfig tid = fmap toLegalHoldTeamConfig <$> do
 setSSOTeamConfig :: MonadClient m => TeamId -> SSOTeamConfig -> m ()
 setSSOTeamConfig tid SSOTeamConfig{ssoTeamConfigStatus} = do
     retry x5 $ write updateSSOTeamConfig (params Quorum (ssoTeamConfigStatus, tid))
-
-selectSSOTeamConfig :: PrepQuery R (Identity TeamId) (Identity SSOStatus)
-selectSSOTeamConfig =
-  "select sso_status from team_features where team_id = ?"
-
-updateSSOTeamConfig :: PrepQuery W (SSOStatus, TeamId) ()
-updateSSOTeamConfig =
-  "update team_features set sso_status = ? where team_id = ?"

--- a/services/galley/src/Galley/Data/Teams.hs
+++ b/services/galley/src/Galley/Data/Teams.hs
@@ -24,8 +24,8 @@ setSSOTeamConfig tid SSOTeamConfig{ssoTeamConfigStatus} = do
 
 selectSSOTeamConfig :: PrepQuery R (Identity TeamId) (Identity SSOStatus)
 selectSSOTeamConfig =
-  "select sso_status from team_config where team_id = ?"
+  "select sso_status from team_features where team_id = ?"
 
 updateSSOTeamConfig :: PrepQuery W (SSOStatus, TeamId) ()
 updateSSOTeamConfig =
-  "update team_config set sso_status = ? where team_id = ?"
+  "update team_features set sso_status = ? where team_id = ?"

--- a/services/galley/src/Galley/Data/Teams.hs
+++ b/services/galley/src/Galley/Data/Teams.hs
@@ -6,11 +6,7 @@ module Galley.Data.Teams
 
 import Imports
 import Cassandra
-import Control.Lens (unsnoc)
 import Data.Id
-import Data.LegalHold
-import Brig.Types.Client.Prekey
-import Galley.Data.Queries as Q
 import Galley.Data.Instances ()
 import Galley.Types.Teams.Feature
 

--- a/services/galley/src/Galley/Data/Teams.hs
+++ b/services/galley/src/Galley/Data/Teams.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE ViewPatterns #-}
+module Galley.Data.Teams
+    ( setSSOTeamConfig
+    , getSSOTeamConfig
+    ) where
+
+import Imports
+import Cassandra
+import Control.Lens (unsnoc)
+import Data.Id
+import Data.LegalHold
+import Brig.Types.Client.Prekey
+import Galley.Data.Queries as Q
+import Galley.Data.Instances ()
+import Galley.Types.Teams.Feature
+
+-- | Return whether a given team is allowed to enable/disable sso
+getSSOTeamConfig :: MonadClient m => TeamId -> m (Maybe SSOTeamConfig)
+getSSOTeamConfig tid = fmap toLegalHoldTeamConfig <$> do
+    retry x1 $ query1 selectSSOTeamConfig (params Quorum (Identity tid))
+  where
+    toLegalHoldTeamConfig (Identity status) = SSOTeamConfig status
+
+-- | Determines whether a given team is allowed to enable/disable sso
+setSSOTeamConfig :: MonadClient m => TeamId -> SSOTeamConfig -> m ()
+setSSOTeamConfig tid SSOTeamConfig{ssoTeamConfigStatus} = do
+    retry x5 $ write updateSSOTeamConfig (params Quorum (ssoTeamConfigStatus, tid))
+
+selectSSOTeamConfig :: PrepQuery R (Identity TeamId) (Identity SSOStatus)
+selectSSOTeamConfig =
+  "select sso_status from team_config where team_id = ?"
+
+updateSSOTeamConfig :: PrepQuery W (SSOStatus, TeamId) ()
+updateSSOTeamConfig =
+  "update team_config set sso_status = ? where team_id = ?"

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -151,21 +151,22 @@ testCreateTeamWithMembers = do
 
 testEnableSSOPerTeam :: TestM ()
 testEnableSSOPerTeam = do
-    -- g <- view tsGalley
     owner <- Util.randomUser
     tid   <- Util.createTeamInternal "foo" owner
     assertQueue "create team" tActivate
 
-    do SSOTeamConfig status <- jsonBody <$> (getSSOEnabledInternal tid <!! testResponse 200 Nothing)
-       liftIO $ assertEqual "Teams should start with SSO disabled" SSODisabled status
+    let check :: HasCallStack => String -> SSOStatus -> TestM ()
+        check msg enabledness = do
+          SSOTeamConfig status <- jsonBody <$> (getSSOEnabledInternal tid <!! testResponse 200 Nothing)
+          liftIO $ assertEqual msg enabledness status
+
+    check "Teams should start with SSO disabled" SSODisabled
 
     putSSOEnabledInternal tid SSOEnabled
-    do SSOTeamConfig status <- jsonBody <$> (getSSOEnabledInternal tid <!! testResponse 200 Nothing)
-       liftIO $ assertEqual "Calling 'putEnabled True' should enable SSO" SSOEnabled status
+    check "Calling 'putEnabled True' should enable SSO" SSOEnabled
 
     putSSOEnabledInternal tid SSODisabled
-    do SSOTeamConfig status <- jsonBody <$> (getSSOEnabledInternal tid <!! testResponse 200 Nothing)
-       liftIO $ assertEqual "Calling 'putEnabled False' should disable SSO" SSODisabled status
+    check  "Calling 'putEnabled False' should disable SSO" SSODisabled
 
 
 testCreateOne2OneFailNonBindingTeamMembers :: TestM ()

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -14,8 +14,8 @@ import Data.Misc (PlainTextPassword (..))
 import Data.Range
 import Galley.Types hiding (EventType (..), EventData (..), MemberUpdate (..))
 import Galley.Types.Teams
-import Galley.Types.Teams.Feature
 import Galley.Types.Teams.Intra
+import Galley.Types.Teams.SSO
 import Gundeck.Types.Notification
 import Test.Tasty
 import Test.Tasty.Cannon (TimeoutUnit (..), (#))

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -1106,12 +1106,12 @@ getSSOEnabledInternal :: HasCallStack => TeamId -> TestM ResponseLBS
 getSSOEnabledInternal tid = do
     g <- view tsGalley
     get $ g
-         . paths ["i", "teams", toByteString' tid, "legalhold"]
+        . paths ["i", "teams", toByteString' tid, "features", "sso"]
 
-_putSSOEnabledInternal :: HasCallStack => TeamId -> SSOStatus -> TestM ()
-_putSSOEnabledInternal tid enabled = do
+putSSOEnabledInternal :: HasCallStack => TeamId -> SSOStatus -> TestM ()
+putSSOEnabledInternal tid enabled = do
     g <- view tsGalley
     void . put $ g
-         . paths ["i", "teams", toByteString' tid, "sso"]
-         . json (SSOTeamConfig enabled)
-         . expect2xx
+        . paths ["i", "teams", toByteString' tid, "features", "sso"]
+        . json (SSOTeamConfig enabled)
+        . expect2xx

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -157,30 +157,15 @@ testEnableSSOPerTeam = do
     assertQueue "create team" tActivate
 
     do SSOTeamConfig status <- jsonBody <$> (getSSOEnabledInternal tid <!! testResponse 200 Nothing)
-       liftIO $ assertEqual "Teams should start with SSO enabled" status SSODisabled
+       liftIO $ assertEqual "Teams should start with SSO disabled" SSODisabled status
 
-    -- putEnabled tid LegalHoldEnabled -- enable it for this team
-    -- do LegalHoldTeamConfig status <- jsonBody <$> (getEnabled tid <!! testResponse 200 Nothing)
-    --    liftIO $ assertEqual "Calling 'putEnabled True' should enable LegalHold" status LegalHoldEnabled
+    putSSOEnabledInternal tid SSOEnabled
+    do SSOTeamConfig status <- jsonBody <$> (getSSOEnabledInternal tid <!! testResponse 200 Nothing)
+       liftIO $ assertEqual "Calling 'putEnabled True' should enable SSO" SSOEnabled status
 
-    -- withDummyTestServiceForTeam owner tid $ \_chan -> do
-    --     requestLegalHoldDevice owner member tid !!! const 201 === statusCode
-    --     approveLegalHoldDevice (Just defPassword) member member tid !!! testResponse 200 Nothing
-    --     do UserLegalHoldStatusResponse status _ _ <- getUserStatusTyped member tid
-    --        liftIO $ assertEqual "User legal hold status should be enabled" UserLegalHoldEnabled status
-
-    --     do
-    --       putEnabled tid LegalHoldDisabled -- disable again
-    --       LegalHoldTeamConfig status <- jsonBody <$> (getEnabled tid <!! testResponse 200 Nothing)
-    --       liftIO $ assertEqual "Calling 'putEnabled False' should disable LegalHold" status LegalHoldDisabled
-
-    --     do
-    --       UserLegalHoldStatusResponse status _ _ <- getUserStatusTyped member tid
-    --       liftIO $ assertEqual "User legal hold status should be disabled after disabling for team" UserLegalHoldDisabled status
-
-    --     viewLHS <- getSettingsTyped owner tid
-    --     liftIO $ assertEqual "LH Service settings should be disabled"
-    --                ViewLegalHoldServiceDisabled viewLHS
+    putSSOEnabledInternal tid SSODisabled
+    do SSOTeamConfig status <- jsonBody <$> (getSSOEnabledInternal tid <!! testResponse 200 Nothing)
+       liftIO $ assertEqual "Calling 'putEnabled False' should disable SSO" SSODisabled status
 
 
 testCreateOne2OneFailNonBindingTeamMembers :: TestM ()

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -1,9 +1,11 @@
 module API.Teams (tests) where
 
 import Imports
+import API.SQS
 import API.Util
-import Bilge hiding (timeout)
 import Bilge.Assert
+import Bilge hiding (timeout)
+import Brig.Types.Team.LegalHold (LegalHoldTeamConfig(..), LegalHoldStatus(..))
 import Control.Lens hiding ((#), (.=))
 import Data.Aeson hiding (json)
 import Data.Aeson.Lens
@@ -17,12 +19,11 @@ import Galley.Types.Teams
 import Galley.Types.Teams.Intra
 import Galley.Types.Teams.SSO
 import Gundeck.Types.Notification
+import TestHelpers (test)
+import TestSetup (TestSetup, TestM, tsCannon, tsGalley)
 import Test.Tasty
 import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import Test.Tasty.HUnit
-import TestHelpers (test)
-import TestSetup (TestSetup, TestM, tsCannon, tsGalley)
-import API.SQS
 import UnliftIO (mapConcurrently, mapConcurrently_)
 
 import qualified API.Util as Util
@@ -70,6 +71,7 @@ tests s = testGroup "Teams API"
     , test s "post crypto broadcast message redundant/missing" postCryptoBroadcastMessageJson2
     , test s "post crypto broadcast message no-team" postCryptoBroadcastMessageNoTeam
     , test s "post crypto broadcast message 100 (or max conns)" postCryptoBroadcastMessage100OrMaxConns
+    , test s "feature flags" testFeatureFlags
     ]
 
 timeout :: WS.Timeout
@@ -1088,6 +1090,14 @@ postCryptoBroadcastMessage100OrMaxConns = do
 newTeamMember' :: Permissions -> UserId -> TeamMember
 newTeamMember' perms uid = newTeamMember uid perms Nothing
 
+
+getSSOEnabled :: HasCallStack => UserId -> TeamId -> TestM ResponseLBS
+getSSOEnabled uid tid = do
+    g <- view tsGalley
+    get $ g
+        . paths ["teams", toByteString' tid, "features", "sso"]
+        . zUser uid
+
 getSSOEnabledInternal :: HasCallStack => TeamId -> TestM ResponseLBS
 getSSOEnabledInternal tid = do
     g <- view tsGalley
@@ -1101,3 +1111,74 @@ putSSOEnabledInternal tid enabled = do
         . paths ["i", "teams", toByteString' tid, "features", "sso"]
         . json (SSOTeamConfig enabled)
         . expect2xx
+
+getLegalHoldEnabled :: HasCallStack => UserId -> TeamId -> TestM ResponseLBS
+getLegalHoldEnabled uid tid = do
+    g <- view tsGalley
+    get $ g
+        . paths ["teams", toByteString' tid, "features", "legalhold"]
+        . zUser uid
+
+getLegalHoldEnabledInternal :: HasCallStack => TeamId -> TestM ResponseLBS
+getLegalHoldEnabledInternal tid = do
+    g <- view tsGalley
+    get $ g
+        . paths ["i", "teams", toByteString' tid, "features", "legalhold"]
+
+putLegalHoldEnabledInternal :: HasCallStack => TeamId -> LegalHoldStatus -> TestM ()
+putLegalHoldEnabledInternal tid enabled = do
+    g <- view tsGalley
+    void . put $ g
+        . paths ["i", "teams", toByteString' tid, "features", "legalhold"]
+        . json (LegalHoldTeamConfig enabled)
+        . expect2xx
+
+
+testFeatureFlags :: TestM ()
+testFeatureFlags = do
+    owner <- Util.randomUser
+    tid <- Util.createTeam "foo" owner []
+
+    -- sso
+
+    let getSSO :: HasCallStack => SSOStatus -> TestM ()
+        getSSO expected = getSSOEnabled owner tid !!! do
+          statusCode === const 200
+          responseJson === const (Right (SSOTeamConfig expected))
+
+        getSSOInternal :: HasCallStack => SSOStatus -> TestM ()
+        getSSOInternal expected = getSSOEnabledInternal tid !!! do
+          statusCode === const 200
+          responseJson === const (Right (SSOTeamConfig expected))
+
+        setSSOInternal :: HasCallStack => SSOStatus -> TestM ()
+        setSSOInternal = putSSOEnabledInternal tid
+
+    getSSO SSODisabled
+    getSSOInternal SSODisabled
+
+    setSSOInternal SSOEnabled
+    getSSO SSOEnabled
+    getSSOInternal SSOEnabled
+
+    -- legalhold
+
+    let getLegalHold :: HasCallStack => LegalHoldStatus -> TestM ()
+        getLegalHold expected = getLegalHoldEnabled owner tid !!! do
+          statusCode === const 200
+          responseJson === const (Right (LegalHoldTeamConfig expected))
+
+        getLegalHoldInternal :: HasCallStack => LegalHoldStatus -> TestM ()
+        getLegalHoldInternal expected = getLegalHoldEnabledInternal tid !!! do
+          statusCode === const 200
+          responseJson === const (Right (LegalHoldTeamConfig expected))
+
+        setLegalHoldInternal :: HasCallStack => LegalHoldStatus -> TestM ()
+        setLegalHoldInternal = putLegalHoldEnabledInternal tid
+
+    getLegalHold LegalHoldDisabled
+    getLegalHoldInternal LegalHoldDisabled
+
+    setLegalHoldInternal LegalHoldEnabled
+    getLegalHold LegalHoldEnabled
+    getLegalHoldInternal LegalHoldEnabled

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -600,7 +600,7 @@ getEnabled :: HasCallStack => TeamId -> TestM ResponseLBS
 getEnabled tid = do
     g <- view tsGalley
     get $ g
-         . paths ["i", "teams", toByteString' tid, "legalhold"]
+         . paths ["i", "teams", toByteString' tid, "features", "legalhold"]
 
 renewToken :: HasCallStack => Text -> TestM ()
 renewToken tok = do
@@ -614,7 +614,7 @@ putEnabled :: HasCallStack => TeamId -> LegalHoldStatus -> TestM ()
 putEnabled tid enabled = do
     g <- view tsGalley
     void . put $ g
-         . paths ["i", "teams", toByteString' tid, "legalhold"]
+         . paths ["i", "teams", toByteString' tid, "features", "legalhold"]
          . json (LegalHoldTeamConfig enabled)
          . expect2xx
 

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -45,6 +45,7 @@ import qualified Data.ByteString.Base64 as ES
 import qualified SAML2.WebSSO as SAML
 import qualified Spar.Data as Data
 import qualified Spar.Intra.Brig as Intra
+import qualified Spar.Intra.Galley as Galley
 import qualified URI.ByteString as URI
 import qualified Web.Cookie as Cky
 
@@ -189,10 +190,13 @@ idpDelete zusr idpid = withDebugLog "idpDelete" (const Nothing) $ do
 idpCreateXML :: Maybe UserId -> SAML.IdPMetadata -> Spar IdP
 idpCreateXML zusr idpmeta = withDebugLog "idpCreate" (Just . show . (^. SAML.idpId)) $ do
   teamid <- Intra.getZUsrOwnedTeam zusr
+  Galley.assertSSOEnabled teamid
   idp <- validateNewIdP idpmeta teamid
   SAML.storeIdPConfig idp
   pure idp
 
+-- | This handler only does the json parsing, and leaves all authorization checks and
+-- application logic to 'idpCreateXML'.
 idpCreate :: Maybe UserId -> IdPMetadataInfo -> Spar IdP
 idpCreate zusr (IdPMetadataValue xml) = idpCreateXML zusr xml
 

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -48,6 +48,7 @@ data SparCustomError
   | SparMissingZUsr
   | SparNotInTeam
   | SparNotTeamOwner
+  | SparSSODisabled
   | SparInitLoginWithAuth
   | SparInitBindWithoutAuth
   | SparBindUserDisappearedFromBrig
@@ -149,6 +150,7 @@ renderSparError (SAML.CustomError SparNotFound)                            = Rig
 renderSparError (SAML.CustomError SparMissingZUsr)                         = Right $ Wai.Error status400 "client-error" "[header] 'Z-User' required"
 renderSparError (SAML.CustomError SparNotInTeam)                           = Right $ Wai.Error status403 "no-team-member" "Requesting user is not a team member or not a member of this team."
 renderSparError (SAML.CustomError SparNotTeamOwner)                        = Right $ Wai.Error status403 "insufficient-permissions" "You need to be a team owner."
+renderSparError (SAML.CustomError SparSSODisabled)                         = Right $ Wai.Error status403 "sso-disabled" "Please ask customer support to enable this feature for you."
 renderSparError (SAML.CustomError SparInitLoginWithAuth)                   = Right $ Wai.Error status403 "login-with-auth" "This end-point is only for login, not binding."
 renderSparError (SAML.CustomError SparInitBindWithoutAuth)                 = Right $ Wai.Error status403 "bind-without-auth" "This end-point is only for binding, not login."
 renderSparError (SAML.CustomError SparBindUserDisappearedFromBrig)         = Right $ Wai.Error status404 "bind-user-disappeared" "Your user appears to have been deleted?"

--- a/services/spar/src/Spar/Intra/Galley.hs
+++ b/services/spar/src/Spar/Intra/Galley.hs
@@ -6,6 +6,7 @@ module Spar.Intra.Galley where
 import Imports
 import Bilge
 import Galley.Types.Teams
+import Galley.Types.Teams.Feature
 import Control.Monad.Except
 import Control.Lens
 import Data.Aeson (FromJSON, eitherDecode')
@@ -42,3 +43,16 @@ getTeamMembers tid = do
   unless (statusCode resp == 200) $
     throwSpar (SparGalleyError "Could not retrieve team members")
   (^. teamMembers) <$> parseResponse @TeamMemberList resp
+
+assertSSOEnabled
+  :: (HasCallStack, MonadError SparError m, MonadSparToGalley m)
+  => TeamId -> m ()
+assertSSOEnabled tid = do
+  resp :: Response (Maybe LBS) <- call
+    $ method GET
+    . paths ["i", "teams", toByteString' tid, "features", "sso"]
+  unless (statusCode resp == 200) $
+    throwSpar (SparGalleyError "Could not retrieve SSO config")
+  SSOTeamConfig status <- parseResponse resp
+  unless (status == SSOEnabled) $
+    throwSpar SparSSODisabled

--- a/services/spar/src/Spar/Intra/Galley.hs
+++ b/services/spar/src/Spar/Intra/Galley.hs
@@ -6,7 +6,7 @@ module Spar.Intra.Galley where
 import Imports
 import Bilge
 import Galley.Types.Teams
-import Galley.Types.Teams.Feature
+import Galley.Types.Teams.SSO
 import Control.Monad.Except
 import Control.Lens
 import Data.Aeson (FromJSON, eitherDecode')

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -24,6 +24,7 @@ import Util.Types
 import qualified Data.ByteString.Builder as LB
 import qualified Data.ZAuth.Token as ZAuth
 import qualified Galley.Types.Teams as Galley
+import qualified Galley.Types.Teams.Feature as Galley
 import qualified Spar.Intra.Brig as Intra
 import qualified Util.Scim as ScimT
 import qualified Web.Cookie as Cky
@@ -604,6 +605,14 @@ specCRUDIdentityProvider = do
 
 
     describe "POST /identity-providers" $ do
+      context "sso disabled for team" $ do
+        it "responds with 403 forbidden" $ do
+          env <- ask
+          (uid, tid) <- call $ createUserWithTeam (env ^. teBrig) (env ^. teGalley)
+          call $ putSSOEnabledInternal (env ^. teGalley) tid Galley.SSODisabled
+          (callIdpCreate' (env ^. teSpar) (Just uid) =<< makeTestIdPMetadata)
+            `shouldRespondWith` checkErr (== 403) "sso-disabled"
+
       context "bad xml" $ do
         it "responds with a 'client error'" $ do
           env <- ask

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -24,7 +24,7 @@ import Util.Types
 import qualified Data.ByteString.Builder as LB
 import qualified Data.ZAuth.Token as ZAuth
 import qualified Galley.Types.Teams as Galley
-import qualified Galley.Types.Teams.Feature as Galley
+import qualified Galley.Types.Teams.SSO as Galley
 import qualified Spar.Intra.Brig as Intra
 import qualified Util.Scim as ScimT
 import qualified Web.Cookie as Cky

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -119,7 +119,7 @@ import qualified Data.ByteString.Base64.Lazy as EL
 import qualified Data.Text.Ascii as Ascii
 import qualified Data.Yaml as Yaml
 import qualified Galley.Types.Teams as Galley
-import qualified Galley.Types.Teams.Feature as Galley
+import qualified Galley.Types.Teams.SSO as Galley
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.Warp.Internal as Warp
 import qualified Options.Applicative as OPA

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -316,7 +316,7 @@ sitemap = do
             description "Team ID"
         Doc.response 200 "Legalhold status" Doc.end
 
-    get "/teams/:tid/features/SSO" (continue getSSOStatus) $
+    get "/teams/:tid/features/sso" (continue getSSOStatus) $
         capture "tid"
 
     document "GET" "getSSOStatus" $ do
@@ -324,7 +324,7 @@ sitemap = do
         Doc.parameter Doc.Path "tid" Doc.bytes' $
             description "Team ID"
         Doc.returns Doc.bool'
-        Doc.response 200 "Legalhold status" Doc.end
+        Doc.response 200 "SSO status" Doc.end
 
     put "/teams/:tid/features/sso" (continue setSSOStatus) $
         contentType "application" "json"
@@ -335,7 +335,7 @@ sitemap = do
         summary "Disable / enable SSO feature for team"
         Doc.parameter Doc.Path "tid" Doc.bytes' $
             description "Team ID"
-        Doc.response 200 "Legalhold status" Doc.end
+        Doc.response 200 "SSO status" Doc.end
 
     --- Swagger ---
     get "/stern/api-docs"


### PR DESCRIPTION
This PR intends to add an extra value to enable/disable SSO per team: current default is enabled. In addition, it moves all "flags" under a single CF since it's easier to manage and helps keeping all these "flags" in one place. Feel free to keep it as-is if you find that isolation is preferable.

TODO:
 - [x] Add integration tests for the new feature/endpoint
 - [x] Make spar check this endpoint
 - [x] Add endpoint in stern to check/set this value
 - ~~[ ] There's a TODO in the code, have a look at that too: separate PR~~