### PR TITLE
Allow servant request body parsers that throw json errors.

### DIFF
--- a/libs/extended/package.yaml
+++ b/libs/extended/package.yaml
@@ -23,6 +23,18 @@ dependencies:
 - unliftio
 - cql-io
 - exceptions
+
+# for servant's 'ReqBodyCustomError' type defined here.
+- errors
+- http-types
+- mtl
+- servant
+- servant-client
+- servant-server
+- servant-swagger
+- string-conversions
+- transformers
+- wai
 library:
   source-dirs: src
 stability: experimental

--- a/libs/extended/src/Servant/API/Extended.hs
+++ b/libs/extended/src/Servant/API/Extended.hs
@@ -42,6 +42,8 @@ import qualified Data.ByteString.Lazy as BL
 -- that inspects the response and logs conditionally what it finds in the body (bad for
 -- streaming and performance!), or re-wire more of the servant internals (unclear how hard
 -- that'll be).
+--
+-- See also: https://github.com/haskell-servant/servant/issues/353
 data ReqBodyCustomError' (mods :: [*]) (list :: [ct]) (tag :: Symbol) (a :: *)
 
 type ReqBodyCustomError = ReqBodyCustomError' '[Required, Strict]

--- a/libs/extended/src/Servant/API/Extended.hs
+++ b/libs/extended/src/Servant/API/Extended.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE CPP #-}
+
+-- | Code from "Servant.Server.Internal", modified very slightly to allow for returning json
+-- errors instead of plaintext.
+module Servant.API.Extended where
+
+import Imports
+
+import Control.Monad.Trans        (liftIO)
+import Data.EitherR               (fmapL)
+import Data.Maybe                 (fromMaybe)
+import Data.String.Conversions    (cs)
+import Data.Typeable
+import Network.HTTP.Types         hiding (Header, ResponseHeaders)
+import Network.Wai
+import Prelude                    ()
+import Servant.API
+import Servant.Swagger
+import Servant.API.Modifiers
+import Servant.API.ContentTypes
+import Servant.Server.Internal
+import GHC.TypeLits
+
+import qualified Data.ByteString.Lazy as BL
+
+
+-- | Like 'ReqBody'', but takes parsers that throw 'ServantErr', not 'String'.  @tag@ is used
+-- to select a 'MakeCustomError' instance.
+data ReqBodyCustomError' (mods :: [*]) (list :: [ct]) (tag :: Symbol) (a :: *)
+
+type ReqBodyCustomError = ReqBodyCustomError' '[Required, Strict]
+
+-- | Custom parse error for bad request bodies.
+class MakeCustomError (tag :: Symbol) (a :: *) where
+  makeCustomError :: String -> ServantErr
+
+-- | Variant of the 'ReqBody'' instance that takes a 'ServantErr' as argument instead of a
+-- 'String'.  This gives the caller more control over error responses.
+instance ( MakeCustomError tag a
+         , AllCTUnrender list a
+         , HasServer api context
+         , SBoolI (FoldLenient mods)
+         ) => HasServer (ReqBodyCustomError' mods list tag a :> api) context where
+
+  type ServerT (ReqBodyCustomError' mods list tag a :> api) m =
+    If (FoldLenient mods) (Either ServantErr a) a -> ServerT api m
+
+  hoistServerWithContext _ pc nt s = hoistServerWithContext (Proxy :: Proxy api) pc nt . s
+
+  route Proxy context subserver
+      = route (Proxy :: Proxy api) context $
+          addBodyCheck subserver ctCheck bodyCheck
+    where
+      -- Content-Type check, we only lookup we can try to parse the request body
+      ctCheck = withRequest $ \ request -> do
+        -- See HTTP RFC 2616, section 7.2.1
+        -- http://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7.2.1
+        -- See also "W3C Internet Media Type registration, consistency of use"
+        -- http://www.w3.org/2001/tag/2002/0129-mime
+        let contentTypeH = fromMaybe "application/octet-stream"
+                         $ lookup hContentType $ requestHeaders request
+        case canHandleCTypeH (Proxy :: Proxy list) (cs contentTypeH) :: Maybe (BL.ByteString -> Either String a) of
+          Nothing -> delayedFail err415
+          Just f  -> return f
+
+      -- Body check, we get a body parsing functions as the first argument.
+      bodyCheck :: (BL.ByteString -> Either String a)
+                -> DelayedIO (If (FoldLenient mods) (Either ServantErr a) a)
+      bodyCheck f = withRequest $ \ request -> do
+        mrqbody <- fmapL (makeCustomError @tag @a) . f <$> liftIO (lazyRequestBody request)
+        case sbool :: SBool (FoldLenient mods) of
+          STrue -> return mrqbody
+          SFalse -> case mrqbody of
+            Left e  -> delayedFailFatal e
+            Right v -> return v
+
+-- | TODO: this is not entirely accurate any more either...
+instance
+     ( HasSwagger (ReqBody' '[Required, Strict] cts a :> api)
+     , MakeCustomError tag a
+     ) => HasSwagger (ReqBodyCustomError cts tag a :> api) where
+    toSwagger Proxy = toSwagger (Proxy @(ReqBody' '[Required, Strict] cts a :> api))

--- a/libs/extended/src/Servant/API/Extended.hs
+++ b/libs/extended/src/Servant/API/Extended.hs
@@ -32,6 +32,8 @@ data ReqBodyCustomError' (mods :: [*]) (list :: [ct]) (tag :: Symbol) (a :: *)
 type ReqBodyCustomError = ReqBodyCustomError' '[Required, Strict]
 
 -- | Custom parse error for bad request bodies.
+--
+-- FUTUREWORK: this approach is not ideal because it makes it hard to avoid orphan instances.
 class MakeCustomError (tag :: Symbol) (a :: *) where
   makeCustomError :: String -> ServantErr
 

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -14,8 +14,8 @@ module Spar.Error
   , sparToServantErrWithLogging
   , renderSparErrorWithLogging
 
-    -- TODO: we really shouldn't export this, but that requires that we can use our custom
-    -- servant monad in the 'MakeCustomError' instances.
+    -- FUTUREWORK: we really shouldn't export this, but that requires that we can use our
+    -- custom servant monad in the 'MakeCustomError' instances.
   , sparToServantErr
   ) where
 
@@ -157,7 +157,7 @@ renderSparError SAML.UnknownError                                          = Rig
 renderSparError (SAML.BadServerConfig msg)                                 = Right $ Wai.Error status500 "server-error" ("Error in server config: " <> msg)
 renderSparError (SAML.InvalidCert msg)                                     = Right $ Wai.Error status500 "invalid-certificate" ("Error in idp certificate: " <> msg)
 -- Errors related to IdP creation
-renderSparError (SAML.CustomError (SparNewIdPBadMetadata msg))         = Right $ Wai.Error status400 "invalid-metadata" msg
+renderSparError (SAML.CustomError (SparNewIdPBadMetadata msg))             = Right $ Wai.Error status400 "invalid-metadata" msg
 renderSparError (SAML.CustomError (SparNewIdPBadReqUrl msg))               = Right $ Wai.Error status400 "invalid-req-url" ("bad request url: " <> msg)
 renderSparError (SAML.CustomError SparNewIdPPubkeyMismatch)                = Right $ Wai.Error status400 "key-mismatch" "public keys in body, metadata do not match"
 renderSparError (SAML.CustomError SparNewIdPAlreadyInUse)                  = Right $ Wai.Error status400 "idp-already-in-use" "an idp issuer can only be used within one team"

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -13,6 +13,10 @@ module Spar.Error
   , throwSpar
   , sparToServantErrWithLogging
   , renderSparErrorWithLogging
+
+    -- TODO: we really shouldn't export this, but that requires that we can use our custom
+    -- servant monad in the 'MakeCustomError' instances.
+  , sparToServantErr
   ) where
 
 import Imports
@@ -69,8 +73,7 @@ data SparCustomError
   | SparCassandraError LT
   | SparCassandraTTLError TTLError
 
-  | SparNewIdPBadMetadataJSON LT
-  | SparNewIdPBadMetadataXML LT
+  | SparNewIdPBadMetadata LT
   | SparNewIdPBadReqUrl LT
   | SparNewIdPPubkeyMismatch
   | SparNewIdPAlreadyInUse
@@ -154,8 +157,7 @@ renderSparError SAML.UnknownError                                          = Rig
 renderSparError (SAML.BadServerConfig msg)                                 = Right $ Wai.Error status500 "server-error" ("Error in server config: " <> msg)
 renderSparError (SAML.InvalidCert msg)                                     = Right $ Wai.Error status500 "invalid-certificate" ("Error in idp certificate: " <> msg)
 -- Errors related to IdP creation
-renderSparError (SAML.CustomError (SparNewIdPBadMetadataJSON msg))         = Right $ Wai.Error status400 "invalid-metadata" ("json parser: " <> msg)
-renderSparError (SAML.CustomError (SparNewIdPBadMetadataXML msg))          = Right $ Wai.Error status400 "invalid-metadata" ("xml parser: " <> msg)
+renderSparError (SAML.CustomError (SparNewIdPBadMetadata msg))         = Right $ Wai.Error status400 "invalid-metadata" msg
 renderSparError (SAML.CustomError (SparNewIdPBadReqUrl msg))               = Right $ Wai.Error status400 "invalid-req-url" ("bad request url: " <> msg)
 renderSparError (SAML.CustomError SparNewIdPPubkeyMismatch)                = Right $ Wai.Error status400 "key-mismatch" "public keys in body, metadata do not match"
 renderSparError (SAML.CustomError SparNewIdPAlreadyInUse)                  = Right $ Wai.Error status400 "idp-already-in-use" "an idp issuer can only be used within one team"

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -606,7 +606,6 @@ specCRUDIdentityProvider = do
     describe "POST /identity-providers" $ do
       context "bad xml" $ do
         it "responds with a 'client error'" $ do
-          pendingWith "we need to touch @HasServer ReqBody'@ to fix this..."
           env <- ask
           callIdpCreateRaw' (env ^. teSpar) Nothing "application/xml" "@@ bad xml ###"
             `shouldRespondWith` checkErr (== 400) "invalid-metadata"
@@ -667,7 +666,6 @@ specCRUDIdentityProvider = do
       describe "with json body" $ do
         context "bad json" $ do
           it "responds with a 'client error'" $ do
-            pendingWith "we need to touch @HasServer ReqBody'@ to fix this..."
             env <- ask
             callIdpCreateRaw' (env ^. teSpar) Nothing "application/json" "@@ bad json ###"
               `shouldRespondWith` checkErr (== 400) "invalid-metadata"


### PR DESCRIPTION
We introduce a variant of `ReqBody` that allows us to pick a function that wraps the parser error (`String`) into a `ServantErr`.

Fixes #703

Future work (also noted in the code):

- fix swagger2 instance for new body type
- error construction should be in the custom monad (so we can log)
- move everything upstream into github://haskell-servant/servant/