### PR TITLE
Cleanup logging

### DIFF
--- a/libs/api-client/src/Network/Wire/Client/API/Push.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Push.hs
@@ -51,6 +51,7 @@ import qualified Data.HashMap.Strict       as M
 import qualified Data.Text                 as T
 import qualified Network.WebSockets        as WS
 import qualified Network.WebSockets.Stream as WS
+-- FUTUREWORK: We can probably monadunliftio the Session monad somehow?
 import qualified System.Logger             as Log
 
 -------------------------------------------------------------------------------

--- a/libs/api-client/src/Network/Wire/Client/HTTP.hs
+++ b/libs/api-client/src/Network/Wire/Client/HTTP.hs
@@ -25,7 +25,7 @@ import Network.Wire.Client.Monad
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text.Encoding   as T
 import qualified Network.HTTP.Client  as Rq
-import qualified System.Logger.Class        as Log
+import qualified System.Logger.Class  as Log
 
 data Error = Error
     { code    :: Int

--- a/libs/cassandra-util/src/Cassandra/Schema.hs
+++ b/libs/cassandra-util/src/Cassandra/Schema.hs
@@ -40,6 +40,7 @@ import Options.Applicative hiding (info)
 import qualified Database.CQL.IO.Tinylog as CT
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text.Lazy as LT
+-- FUTUREWORK: We could use the System.Logger.Class here in the future, but we don't have a ReaderT IO here (yet)
 import qualified System.Logger as Log
 
 data Migration = Migration

--- a/libs/imports/src/Orphans.hs
+++ b/libs/imports/src/Orphans.hs
@@ -8,7 +8,7 @@ module Orphans () where
 
 import Data.Aeson
 import GHC.Generics
-import System.Logger as Logger
+import System.Logger.Class as Logger
 
 deriving instance Generic Logger.Level
 instance FromJSON Logger.Level

--- a/services/brig/index/src/Main.hs
+++ b/services/brig/index/src/Main.hs
@@ -5,7 +5,7 @@ import           Eval
 import           Options
 import           Options.Applicative
 import           System.Exit
-import qualified System.Logger.Class       as Log
+import qualified System.Logger.Class as Log
 
 main :: IO ()
 main = do

--- a/services/brig/index/src/Main.hs
+++ b/services/brig/index/src/Main.hs
@@ -5,7 +5,7 @@ import           Eval
 import           Options
 import           Options.Applicative
 import           System.Exit
-import qualified System.Logger       as Log
+import qualified System.Logger.Class       as Log
 
 main :: IO ()
 main = do

--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -27,7 +27,7 @@ import Network.Wai.Routing (Continue)
 import Network.Wai.Utilities.Error ((!>>))
 import Network.Wai.Utilities.Request (JsonRequest, lookupRequestId, parseBody)
 import Network.Wai.Utilities.Response (setStatus, json, addHeader)
-import System.Logger (Logger)
+import System.Logger.Class (Logger)
 
 import qualified Brig.AWS                     as AWS
 import qualified Brig.Whitelist               as Whitelist

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -17,7 +17,7 @@ import Data.Scientific (toBoundedInteger)
 import Data.Time.Clock (DiffTime, secondsToDiffTime)
 import Data.Yaml (FromJSON(..), ToJSON(..))
 import Util.Options
-import System.Logger (Level)
+import System.Logger.Class (Level)
 
 import qualified Brig.ZAuth  as ZAuth
 import qualified Data.Yaml   as Y

--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -20,7 +20,7 @@ import Network.Wai.Utilities.Request (parseBody')
 import Network.Wai.Utilities.Response (json)
 import Network.Wai.Utilities.Swagger
 import Network.Wai.Handler.WebSockets
-import System.Logger (msg, val)
+import System.Logger.Class (msg, val)
 
 import qualified Cannon.Dict                 as D
 import qualified Data.ByteString.Lazy        as L
@@ -134,9 +134,8 @@ checkPresence (u ::: c) = do
 
 await :: UserId ::: ConnId ::: Maybe ClientId ::: Request -> Cannon Response
 await (u ::: a ::: c ::: r) = do
-    l <- logger
     e <- wsenv
-    case websocketsApp wsoptions (wsapp (mkKey u a) c l e) r of
+    case websocketsApp wsoptions (wsapp (mkKey u a) c e) r of
         Nothing -> return $ errorRs status426 "request-error" "websocket upgrade required"
         Just rs -> return rs -- ensure all middlewares ignore RawResponse - see Note [Raw Response]
   where

--- a/services/cannon/src/Cannon/App.hs
+++ b/services/cannon/src/Cannon/App.hs
@@ -16,9 +16,8 @@ import Network.Wai.Utilities.Error
 import Network.WebSockets hiding (Request, Response, requestHeaders)
 import System.Logger.Class hiding (Error, close)
 
-import qualified Data.Text.Lazy as Text
--- TODO(arianvp): Make this Classy. we can utilise UnliftIO here
-import qualified System.Logger.Class  as Logger
+import qualified Data.Text.Lazy      as Text
+import qualified System.Logger.Class as Logger
 
 -- | Connection state, updated by {read, write}Loop.
 data State = State !Int !Timeout

--- a/services/cannon/src/Cannon/Options.hs
+++ b/services/cannon/src/Cannon/Options.hs
@@ -17,7 +17,7 @@ where
 import Imports
 import Control.Lens (makeFields)
 import Data.Aeson.APIFieldJsonTH
-import System.Logger (Level)
+import System.Logger.Class (Level)
 
 
 data Cannon = Cannon

--- a/services/galley/journaler/src/Journal.hs
+++ b/services/galley/journaler/src/Journal.hs
@@ -10,7 +10,7 @@ import Data.Proto.Id as Proto
 import Proto.TeamEvents
 import Galley.Types.Teams (TeamCreationTime (..), tcTime)
 import Galley.Types.Teams.Intra
-import System.Logger (Logger)
+import System.Logger.Class (Logger)
 import UnliftIO (mapConcurrently)
 
 import qualified System.Logger        as Log

--- a/services/galley/journaler/src/Main.hs
+++ b/services/galley/journaler/src/Main.hs
@@ -16,7 +16,7 @@ import Options.Applicative
 
 import qualified Galley.Aws as Aws
 import qualified OpenSSL.X509.SystemStore as Ssl
-import qualified System.Logger as Log
+import qualified System.Logger.Class as Log
 
 
 main :: IO ()

--- a/services/galley/src/Galley/Intra/Client.hs
+++ b/services/galley/src/Galley/Intra/Client.hs
@@ -28,7 +28,7 @@ import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
 
-import qualified System.Logger as Logger
+import qualified System.Logger.Class as Logger
 import qualified Data.Set as Set
 
 lookupClients :: [UserId] -> Galley UserClients
@@ -64,10 +64,9 @@ getLegalHoldAuthToken uid = do
             . queryItem "persist" "true"
             . json (SsoLogin uid Nothing)
             . expect2xx
-    lg <- view applog
     case getCookieValue "zuid" r of
         Nothing -> do
-            Logger.warn lg $ Logger.msg @Text "Response from login missing auth cookie"
+            Logger.warn $ Logger.msg @Text "Response from login missing auth cookie"
             throwM internalError
         Just c -> pure . OpaqueAuthToken . decodeUtf8 $ c
 

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -5,7 +5,7 @@ import Control.Lens hiding ((.=), Level)
 import Data.Aeson.TH (deriveFromJSON)
 import Util.Options
 import Util.Options.Common
-import System.Logger (Level)
+import System.Logger.Class (Level)
 import Data.Misc
 
 data Settings = Settings

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -17,7 +17,7 @@ import qualified Control.Concurrent.Async           as Async
 import qualified Data.Metrics.Middleware            as M
 import qualified Network.Wai.Middleware.Gunzip      as GZip
 import qualified Network.Wai.Middleware.Gzip        as GZip
-import qualified System.Logger.Class                      as Log
+import qualified System.Logger.Class                 as Log
 
 import           Galley.API          (sitemap)
 import qualified Galley.API.Internal as Internal

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -17,7 +17,7 @@ import qualified Control.Concurrent.Async           as Async
 import qualified Data.Metrics.Middleware            as M
 import qualified Network.Wai.Middleware.Gunzip      as GZip
 import qualified Network.Wai.Middleware.Gzip        as GZip
-import qualified System.Logger                      as Log
+import qualified System.Logger.Class                      as Log
 
 import           Galley.API          (sitemap)
 import qualified Galley.API.Internal as Internal

--- a/services/galley/test/integration/API/SQS.hs
+++ b/services/galley/test/integration/API/SQS.hs
@@ -32,7 +32,7 @@ import qualified Galley.Aws as Aws
 import qualified Network.AWS as AWS
 import qualified Network.AWS.SQS as SQS
 import qualified OpenSSL.X509.SystemStore as Ssl
-import qualified System.Logger as L
+import qualified System.Logger.Class as L
 
 ensureQueueEmpty :: TestM ()
 ensureQueueEmpty  = view tsAwsEnv >>= ensureQueueEmptyIO

--- a/services/galley/test/integration/Main.hs
+++ b/services/galley/test/integration/Main.hs
@@ -31,7 +31,7 @@ import Util.Test
 import qualified API
 import qualified API.SQS                as SQS
 import qualified Data.ByteString.Char8  as BS
-import qualified System.Logger.Class   as Logger
+import qualified System.Logger.Class    as Logger
 
 newtype ServiceConfigFile = ServiceConfigFile String
     deriving (Eq, Ord, Typeable)

--- a/services/galley/test/integration/Main.hs
+++ b/services/galley/test/integration/Main.hs
@@ -31,7 +31,7 @@ import Util.Test
 import qualified API
 import qualified API.SQS                as SQS
 import qualified Data.ByteString.Char8  as BS
-import qualified System.Logger   as Logger
+import qualified System.Logger.Class   as Logger
 
 newtype ServiceConfigFile = ServiceConfigFile String
     deriving (Eq, Ord, Typeable)

--- a/services/proxy/package.yaml
+++ b/services/proxy/package.yaml
@@ -52,6 +52,7 @@ library:
   - wai-utilities >=0.14.3
   - warp >=3.0
   - yaml >=0.8.22
+  - unliftio-core
 executables:
   proxy:
     main: src/Main.hs

--- a/services/proxy/src/Proxy/API.hs
+++ b/services/proxy/src/Proxy/API.hs
@@ -27,7 +27,7 @@ import qualified Data.List as List
 import qualified Data.Text as Text
 import qualified Network.HTTP.Client as Client
 import qualified Network.Wai.Internal as I
-import qualified System.Logger as Logger
+import qualified System.Logger.Class as Logger
 
 sitemap :: Env -> Routes a Proxy ()
 sitemap e = do
@@ -73,8 +73,8 @@ googleMaps = ProxyDest "maps.googleapis.com" 443
 giphy      = ProxyDest "api.giphy.com" 443
 
 proxy :: Env -> ByteString -> Text -> Rerouting -> ByteString -> ProxyDest -> App Proxy
-proxy e qparam keyname reroute path phost rq k = liftIO $ do
-    s <- Config.require (e^.secrets) keyname
+proxy e qparam keyname reroute path phost rq k = do
+    s <- liftIO $ Config.require (e^.secrets) keyname
     let r  = getRequest rq
     let q  = renderQuery True ((qparam, Just s) : safeQuery (I.queryString r))
     let r' = defaultRequest
@@ -85,18 +85,19 @@ proxy e qparam keyname reroute path phost rq k = liftIO $ do
                 Prefix -> snd $ breakSubstring path (I.rawPathInfo r)
            , I.rawQueryString = q
            }
-    loop (2 :: Int) r (WPRModifiedRequestSecure r' phost)
+    runInIO <- askRunInIO
+    liftIO $ loop runInIO (2 :: Int) r (WPRModifiedRequestSecure r' phost)
   where
-    loop !n waiReq req =
-        waiProxyTo (const $ return req) onUpstreamError (e^.manager) waiReq $ \res ->
+    loop runInIO !n waiReq req =
+        waiProxyTo (const $ return req) (onUpstreamError runInIO) (e^.manager) waiReq $ \res ->
             if responseStatus res == status502 && n > 0 then do
                 threadDelay 5000
-                loop (n - 1) waiReq req
+                loop runInIO (n - 1) waiReq req
             else
                 runProxy e waiReq (k res)
 
-    onUpstreamError x _ next = do
-        Logger.warn (e^.applog) (msg (val "gateway error") ~~ field "error" (show x))
+    onUpstreamError runInIO x _ next = do
+        runInIO $ Logger.warn (msg (val "gateway error") ~~ field "error" (show x))
         next (errorRs' error502)
 
 spotifyToken :: Request -> Proxy Response

--- a/services/proxy/src/Proxy/Options.hs
+++ b/services/proxy/src/Proxy/Options.hs
@@ -14,7 +14,7 @@ import Imports
 import Control.Lens hiding (Level)
 import Data.Aeson
 import Data.Aeson.TH
-import System.Logger (Level(Debug))
+import System.Logger.Class (Level(Debug))
 
 data Opts = Opts
     { _host          :: !String     -- ^ Host to listen on

--- a/services/proxy/src/Proxy/Proxy.hs
+++ b/services/proxy/src/Proxy/Proxy.hs
@@ -11,6 +11,7 @@ import Data.Id (RequestId (..))
 import Proxy.Env
 import Network.Wai
 import System.Logger.Class hiding (Error, info)
+import Control.Monad.IO.Unlift()
 
 import qualified System.Logger as Logger
 
@@ -24,6 +25,7 @@ newtype Proxy a = Proxy
                , MonadCatch
                , MonadMask
                , MonadReader Env
+               , MonadUnliftIO
                )
 
 instance MonadLogger Proxy where

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -17,7 +17,7 @@ module Spar.App
   , autoprovisionSamlUserWithId
   ) where
 
-import Imports
+import Imports hiding (log)
 import Bilge
 import Brig.Types (Name, ManagedBy(..))
 import Cassandra
@@ -49,6 +49,7 @@ import qualified Spar.Data as Data
 import qualified Spar.Intra.Brig as Intra
 import qualified Spar.Intra.Galley as Intra
 import qualified System.Logger as Log
+import System.Logger.Class (MonadLogger(log))
 
 
 newtype Spar a = Spar { fromSpar :: ReaderT Env (ExceptT SparError IO) a }
@@ -72,12 +73,15 @@ instance HasCreateUUID Spar where
 instance HasLogger Spar where
   -- FUTUREWORK: optionally use 'field' to index user or idp ids for easier logfile processing.
   logger (toLevel -> lv) mg = do
+    let mg'    = Log.msg . condenseLogMsg . cs $ mg
+    log lv mg'
+
+instance MonadLogger Spar where
+  log level mg = do
     lg <- asks sparCtxLogger
     reqid <- asks sparCtxRequestId
-    let fields, mg' :: Log.Msg -> Log.Msg
-        fields = Log.field "request" (unRequestId reqid)
-        mg'    = Log.msg . condenseLogMsg . cs $ mg
-    Spar . Log.log lg lv $ fields Log.~~ mg'
+    let fields = Log.field "request" (unRequestId reqid)
+    Spar . Log.log lg level $ fields Log.~~ mg
 
 condenseLogMsg :: ST -> ST
 condenseLogMsg = ST.intercalate " " . filter (not . ST.null) . ST.split isSpace

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -72,9 +72,7 @@ instance HasNow Spar where
 instance HasCreateUUID Spar where
 instance HasLogger Spar where
   -- FUTUREWORK: optionally use 'field' to index user or idp ids for easier logfile processing.
-  logger (toLevel -> lv) mg = do
-    let mg'    = Log.msg . condenseLogMsg . cs $ mg
-    log lv mg'
+  logge lv = logger lv = log (toLevel lv) . Log.msg . cs
 
 instance MonadLogger Spar where
   log level mg = do

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -31,7 +31,7 @@ import qualified Network.Wai as Wai
 import qualified Network.Wai.Utilities.Error as Wai
 import qualified Network.Wai.Utilities.Server as Wai
 import qualified SAML2.WebSSO as SAML
-import qualified System.Logger as Log
+import qualified System.Logger.Class as Log
 import qualified Web.Scim.Schema.Error as Scim
 
 

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -26,7 +26,7 @@ import Spar.App
 import Spar.Data.Instances ()
 import Spar.Orphans ()
 import Spar.Types as Types
-import System.Logger (Logger)
+import System.Logger.Class (Logger)
 import Util.Options (casEndpoint, casKeyspace, epHost, epPort)
 
 import qualified Cassandra.Schema as Cas

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -35,7 +35,7 @@ import Data.String.Conversions
 import Galley.Types.Teams    as Galley
 import Network.URI
 
-import Spar.App (Spar, Env, wrapMonadClient, sparCtxOpts, sparCtxLogger, createSamlUserWithId, wrapMonadClient, getUser)
+import Spar.App (Spar, Env, wrapMonadClient, sparCtxOpts, createSamlUserWithId, wrapMonadClient, getUser)
 import Spar.Intra.Galley
 import Spar.Scim.Types
 import Spar.Scim.Auth ()
@@ -47,7 +47,7 @@ import qualified SAML2.WebSSO as SAML
 import qualified Spar.Data    as Data
 import qualified Spar.Intra.Brig as Intra.Brig
 import qualified URI.ByteString as URIBS
-import qualified System.Logger as Log
+import qualified System.Logger.Class as Log
 
 import qualified Web.Scim.Class.User              as Scim
 import qualified Web.Scim.Filter                  as Scim
@@ -420,8 +420,7 @@ deleteScimUser ScimTokenInfo{stiTeam} uid = do
   where
     logThenServerError :: String -> Scim.ScimHandler Spar b
     logThenServerError err = do
-      logger <- asks sparCtxLogger
-      Log.err logger $ Log.msg err
+      lift $ Log.err (Log.msg err)
       throwError $ Scim.serverError "Server Error"
 
 


### PR DESCRIPTION
We want to make sure that we were using the `MonadLogger` typeclass everywhere, as this will make it easy to consistently inject metadata into the logs throughout the project. 

Turns out,  most places where already fine.

I made this PR by using `sed` and then making stuff compile. So maybe some places we could have left untouched. We should go over the diff and decide what things do not need to be changed, such that the diff becomes a bit smaller