### PR TITLE
[WIP] New feature flags backend (part 2)

### DIFF
--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -948,7 +948,7 @@ sitemap = do
 
     get "/i/test/clients" (continue getClients)
         zauthUserId
-    -- TODO: What is this endpoint? Is this used anywhere?
+        -- eg. https://github.com/wireapp/wire-server/blob/3bdca5fc8154e324773802a0deb46d884bd09143/services/brig/test/integration/API/User/Client.hs#L319
 
     post "/i/clients/:client" (continue addClient) $
         zauthUserId


### PR DESCRIPTION
- Merge only when #813 has landed.
- Note migration plan is still under discussion!

## migration plan

- merge #813.
  - this will create the new team_features table, but not use it for legalhold.
  - all teams with sso configured will continue working normally, but report as "sso disabled".  (weird, yes.  sorry.)
- migrate data:
  - for every team that has an idp, set the "sso enabled" flag in galley, in the new table.
  - we'll let legalhold break on all existing teams that have it enabled (not newly created ones).
- merge #817
  - switch legalhold feature flag lookup and update from old to new table.
  - this also breaks legalhold.
- yet another PR:
  - this will remove the old legalhold feature flag table.

## tasks

- [ ] don't destroy the old LH flag table.  (it's in this PR as of the writing of this comment, but we need to do that in a 3rd PR.)
- [ ] make "put /i/sso-disabled" fail with an explanation why implementing this is hard.
- [ ] write (and run) migration script for SSO flag.  (frontend depends on this to be sound.)
