### PR TITLE
Limit login retries

### DIFF
--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -104,10 +104,6 @@ emailSMS:
     tCreatorWelcomeUrl: http://127.0.0.1:8080/creator-welcome-website
     tMemberWelcomeUrl: http://127.0.0.1:8080/member-welcome-website
 
-loginRetry:
-  loginRetryTimeout: 5
-  loginRetryLimit: 5
-
 zauth:
   privateKeys: test/resources/zauth/privkeys.txt
   publicKeys: test/resources/zauth/pubkeys.txt
@@ -141,6 +137,9 @@ optSettings:
   setUserCookieThrottle:
     stdDev: 5
     retryAfter: 1
+  limitFailedLogins:
+    timeout: 5  # seconds.  if you reach the limit, how long do you have to wait to try again.
+    retryLimit: 5  # how many times can you have a failed login in that timeframe.
   setRichInfoLimit: 5000  # should be in sync with Spar
   setDefaultLocale: en
   setMaxTeamSize: 32

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -104,6 +104,10 @@ emailSMS:
     tCreatorWelcomeUrl: http://127.0.0.1:8080/creator-welcome-website
     tMemberWelcomeUrl: http://127.0.0.1:8080/member-welcome-website
 
+loginRetry:
+  loginRetryTimeout: 5
+  loginRetryLimit: 5
+
 zauth:
   privateKeys: test/resources/zauth/privkeys.txt
   publicKeys: test/resources/zauth/pubkeys.txt

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -137,7 +137,7 @@ optSettings:
   setUserCookieThrottle:
     stdDev: 5
     retryAfter: 1
-  limitFailedLogins:
+  setLimitFailedLogins:
     timeout: 5  # seconds.  if you reach the limit, how long do you have to wait to try again.
     retryLimit: 5  # how many times can you have a failed login in that timeframe.
   setRichInfoLimit: 5000  # should be in sync with Spar

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -109,6 +109,8 @@ loginError LoginEphemeral         = StdError accountEphemeral
 loginError LoginPendingActivation = StdError accountPending
 loginError (LoginThrottled wait)  = RichError loginsTooFrequent ()
     [("Retry-After", toByteString' (retryAfterSeconds wait))]
+loginError (LoginBlocked wait)    = RichError tooManyFailedLogins ()
+    [("Retry-After", toByteString' (retryAfterSeconds wait))]
 
 authError :: AuthError -> Error
 authError AuthInvalidUser        = StdError badCredentials
@@ -377,8 +379,12 @@ tooManyTeamInvitations = Wai.Error status403 "too-many-team-invitations" "Too ma
 tooManyTeamMembers :: Wai.Error
 tooManyTeamMembers = Wai.Error status403 "too-many-team-members" "Too many members in this team."
 
+-- | In contrast to 'tooManyFailedLogins', this is about too many *successful* logins.
 loginsTooFrequent :: Wai.Error
 loginsTooFrequent = Wai.Error status429 "client-error" "Logins too frequent"
+
+tooManyFailedLogins :: Wai.Error
+tooManyFailedLogins = Wai.Error status403 "client-error" "Too many failed logins"
 
 tooLargeRichInfo :: Wai.Error
 tooLargeRichInfo = Wai.Error status413 "too-large-rich-info" "Rich info has exceeded the limit"

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -112,6 +112,7 @@ data LoginError
     | LoginEphemeral
     | LoginPendingActivation
     | LoginThrottled RetryAfter
+    | LoginBlocked RetryAfter
 
 data ChangePasswordError
     = InvalidCurrentPassword

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -26,6 +26,7 @@ module Brig.App
     , settings
     , currentTime
     , geoDb
+    , loginRetry
     , zauthEnv
     , digestSHA256
     , digestMD5
@@ -48,7 +49,7 @@ module Brig.App
 import Imports
 import Bilge (MonadHttp, Manager, newManager, RequestId (..), withResponse)
 import Bilge.RPC (HasRequestId (..))
-import Brig.Options (Opts, Settings)
+import Brig.Options (Opts, LoginRetryOpts, Settings)
 import Brig.Queue.Types (Queue (..))
 import Brig.Template (Localised, forLocale, genTemplateBranding, TemplateBranding)
 import Brig.Provider.Template
@@ -141,6 +142,7 @@ data Env = Env
     , _turnEnv       :: IORef TURN.Env
     , _turnEnvV2     :: IORef TURN.Env
     , _currentTime   :: IO UTCTime
+    , _loginRetry    :: Maybe LoginRetryOpts
     , _zauthEnv      :: ZAuth.Env
     , _digestSHA256  :: Digest
     , _digestMD5     :: Digest
@@ -210,6 +212,7 @@ newEnv o = do
         , _turnEnvV2         = turnV2
         , _fsWatcher         = w
         , _currentTime       = clock
+        , _loginRetry        = Opt.loginRetry o
         , _zauthEnv          = zau
         , _digestMD5         = md5
         , _digestSHA256      = sha256

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -26,7 +26,6 @@ module Brig.App
     , settings
     , currentTime
     , geoDb
-    , loginRetry
     , zauthEnv
     , digestSHA256
     , digestMD5
@@ -49,7 +48,7 @@ module Brig.App
 import Imports
 import Bilge (MonadHttp, Manager, newManager, RequestId (..), withResponse)
 import Bilge.RPC (HasRequestId (..))
-import Brig.Options (Opts, LoginRetryOpts, Settings)
+import Brig.Options (Opts, Settings)
 import Brig.Queue.Types (Queue (..))
 import Brig.Template (Localised, forLocale, genTemplateBranding, TemplateBranding)
 import Brig.Provider.Template
@@ -142,7 +141,6 @@ data Env = Env
     , _turnEnv       :: IORef TURN.Env
     , _turnEnvV2     :: IORef TURN.Env
     , _currentTime   :: IO UTCTime
-    , _loginRetry    :: Maybe LoginRetryOpts
     , _zauthEnv      :: ZAuth.Env
     , _digestSHA256  :: Digest
     , _digestMD5     :: Digest
@@ -212,7 +210,6 @@ newEnv o = do
         , _turnEnvV2         = turnV2
         , _fsWatcher         = w
         , _currentTime       = clock
-        , _loginRetry        = Opt.loginRetry o
         , _zauthEnv          = zau
         , _digestMD5         = md5
         , _digestSHA256      = sha256

--- a/services/brig/src/Brig/Budget.hs
+++ b/services/brig/src/Brig/Budget.hs
@@ -5,6 +5,7 @@ module Brig.Budget
     , BudgetKey (..)
     , Budgeted (..)
     , withBudget
+    , checkBudget
     , lookupBudget
     , insertBudget
     ) where
@@ -18,14 +19,26 @@ data Budget = Budget
     { budgetTimeout :: !NominalDiffTime
     , budgetValue   :: !Int32
     }
+  deriving (Eq, Show, Generic)
 
 data Budgeted a
     = BudgetExhausted NominalDiffTime
     | BudgetedValue a Int32
+  deriving (Eq, Show, Generic)
 
 newtype BudgetKey = BudgetKey Text
     deriving (Eq, Show, Cql)
 
+-- | @withBudget (BudgetKey "k") (Budget 30 5) action@ runs @action@ at most 5 times every 30
+-- seconds.  @"k"@ is used for keeping different calls to 'withBudget' apart; use something
+-- there that's unique to your context, like @"login#" <> uid@.
+--
+-- FUTUREWORK: encourage caller to define their own type for budget keys (rather than using an
+-- untyped text), and represent the types in a way that guarantees that if i'm using a local
+-- type that i don't export, then nobody will be able to use my namespace.
+--
+-- FUTUREWORK: exceptions are not handled very nicely, but it's not clear what it would mean
+-- to improve this.
 withBudget :: MonadClient m => BudgetKey -> Budget -> m a -> m (Budgeted a)
 withBudget k b ma = do
     Budget ttl val <- fromMaybe b <$> lookupBudget k
@@ -36,6 +49,15 @@ withBudget k b ma = do
             a <- ma
             insertBudget k (Budget ttl remaining)
             return (BudgetedValue a remaining)
+
+-- | Like 'withBudget', but does not decrease budget, only takes a look.
+checkBudget :: MonadClient m => BudgetKey -> Budget -> m (Budgeted ())
+checkBudget k b = do
+    Budget ttl val <- fromMaybe b <$> lookupBudget k
+    let remaining = val - 1
+    return $ if remaining < 0
+        then BudgetExhausted ttl
+        else BudgetedValue () remaining
 
 lookupBudget :: MonadClient m => BudgetKey -> m (Maybe Budget)
 lookupBudget k = fmap mk <$> query1 budgetSelect (params One (Identity k))

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -171,14 +171,14 @@ instance FromJSON EmailSMSOpts
 --
 -- If in doubt, do not ues retry options and worry about encouraging / enforcing a good
 -- password policy.
-data LoginRetryOpts = LoginRetryOpts
-    { loginRetryTimeout :: !Int   -- ^ Time the user is blocked when retry limit is reached
-                                  -- (in seconds mostly for making it easier to write a
-                                  -- fast-ish integration test.)
-    , loginRetryLimit   :: !Int   -- ^ Maximum number of failed login attempts for one user.
+data LimitFailedLogins = LimitFailedLogins
+    { timeout    :: !Int   -- ^ Time the user is blocked when retry limit is reached (in
+                           -- seconds mostly for making it easier to write a fast-ish
+                           -- integration test.)
+    , retryLimit :: !Int   -- ^ Maximum number of failed login attempts for one user.
     } deriving (Eq, Show, Generic)
 
-instance FromJSON LoginRetryOpts
+instance FromJSON LimitFailedLogins
 
 -- | ZAuth options
 data ZAuthOpts = ZAuthOpts
@@ -245,10 +245,6 @@ data Opts = Opts
     -- Email & SMS
     , emailSMS      :: !EmailSMSOpts           -- ^ Email and SMS settings
 
-    -- Login
-    , loginRetry    :: !(Maybe LoginRetryOpts) -- ^ Block user from logging in for m minutes
-                                               -- after n failed logins
-
     -- ZAuth
     , zauth         :: !ZAuthOpts              -- ^ ZAuth settings
 
@@ -289,6 +285,9 @@ data Settings = Settings
     , setUserCookieLimit       :: !Int      -- ^ Max. # of cookies per user and cookie type
     , setUserCookieThrottle    :: !CookieThrottle -- ^ Throttling settings (not to be confused
                                                   -- with 'LoginRetryOpts')
+    , limitFailedLogins        :: !(Maybe LimitFailedLogins) -- ^ Block user from logging in
+                                                             -- for m minutes after n failed
+                                                             -- logins
     , setRichInfoLimit         :: !Int     -- ^ Max size of rich info (number of chars in
                                            --   field names and values), should be in sync
                                            --   with Spar

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -285,7 +285,7 @@ data Settings = Settings
     , setUserCookieLimit       :: !Int      -- ^ Max. # of cookies per user and cookie type
     , setUserCookieThrottle    :: !CookieThrottle -- ^ Throttling settings (not to be confused
                                                   -- with 'LoginRetryOpts')
-    , limitFailedLogins        :: !(Maybe LimitFailedLogins) -- ^ Block user from logging in
+    , setLimitFailedLogins     :: !(Maybe LimitFailedLogins) -- ^ Block user from logging in
                                                              -- for m minutes after n failed
                                                              -- logins
     , setRichInfoLimit         :: !Int     -- ^ Max size of rich info (number of chars in

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -104,7 +104,7 @@ withRetryLimit
     -> UserId
     -> ExceptT LoginError AppIO ()
 withRetryLimit action uid = do
-    mLimitFailedLogins <- view (settings . to Opt.limitFailedLogins)
+    mLimitFailedLogins <- view (settings . to Opt.setLimitFailedLogins)
     forM_ mLimitFailedLogins $ \opts -> do
         let bkey = BudgetKey ("login#" <> idToText uid)
             budget = Budget

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -108,7 +108,7 @@ withRetryLimit action uid = do
     forM_ mLimitFailedLogins $ \opts -> do
         let bkey = BudgetKey ("login#" <> idToText uid)
             budget = Budget
-                (fromIntegral $ Opt.timeout opts)
+                (Opt.timeoutDiff $ Opt.timeout opts)
                 (fromIntegral $ Opt.retryLimit opts)
         bresult <- action bkey budget
         case bresult of

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -16,8 +16,11 @@ module Brig.User.Auth
     ) where
 
 import Imports
+
+import Control.Lens (view)
 import Brig.App
 import Brig.API.Types
+import Brig.Budget
 import Brig.Email
 import Brig.Data.UserKey
 import Brig.Phone
@@ -36,6 +39,7 @@ import qualified Brig.Data.Activation as Data
 import qualified Brig.Data.LoginCode as Data
 import qualified Brig.Data.User as Data
 import qualified Brig.Data.UserKey as Data
+import qualified Brig.Options as Opt
 import qualified Brig.ZAuth as ZAuth
 
 data Access = Access
@@ -71,18 +75,49 @@ lookupLoginCode phone = Data.lookupKey (userPhoneKey phone) >>= \case
 login :: Login -> CookieType -> ExceptT LoginError AppIO Access
 login (PasswordLogin li pw label) typ = do
     uid <- resolveLoginId li
+    checkRetryLimit uid
     Data.authenticate uid pw `catchE` \case
         AuthSuspended          -> throwE LoginSuspended
         AuthEphemeral          -> throwE LoginEphemeral
-        AuthInvalidCredentials -> throwE LoginFailed
-        AuthInvalidUser        -> throwE LoginFailed
+        AuthInvalidCredentials -> loginFailed uid
+        AuthInvalidUser        -> loginFailed uid
     newAccess uid typ label
 login (SmsLogin phone code label) typ = do
     uid <- resolveLoginId (LoginByPhone phone)
+    checkRetryLimit uid
     ok <- lift $ Data.verifyLoginCode uid code
     unless ok $
-        throwE LoginFailed
+        loginFailed uid
     newAccess uid typ label
+
+loginFailed :: UserId -> ExceptT LoginError AppIO ()
+loginFailed uid = decrRetryLimit uid >> throwE LoginFailed
+
+decrRetryLimit :: UserId -> ExceptT LoginError AppIO ()
+decrRetryLimit = withRetryLimit (\k b -> withBudget k b $ pure ())
+
+checkRetryLimit :: UserId -> ExceptT LoginError AppIO ()
+checkRetryLimit = withRetryLimit checkBudget
+
+withRetryLimit
+    :: (BudgetKey -> Budget -> ExceptT LoginError AppIO (Budgeted ()))
+    -> UserId
+    -> ExceptT LoginError AppIO ()
+withRetryLimit action uid = do
+    () <- traceShow 'a' $ pure ()
+    mLoginRetryOpts <- view loginRetry
+    () <- traceShow mLoginRetryOpts $ pure ()
+    forM_ mLoginRetryOpts $ \opts -> do
+        let bkey = BudgetKey ("login#" <> idToText uid)
+            budget = Budget
+                (fromIntegral $ Opt.loginRetryTimeout opts)
+                (fromIntegral $ Opt.loginRetryLimit opts)
+        () <- traceShow (bkey, budget) $ pure ()
+        bresult <- action bkey budget
+        () <- traceShow bresult $ pure ()
+        case bresult of
+            BudgetExhausted ttl -> throwE . LoginBlocked . RetryAfter . floor $ ttl
+            BudgetedValue () _ -> pure ()
 
 logout :: ZAuth.UserToken -> ZAuth.AccessToken -> ExceptT ZAuth.Failure AppIO ()
 logout ut at = do

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -590,7 +590,7 @@ testSuspendUser brig = do
     u <- randomUser brig
     let uid        = userId u
         Just email = userEmail u
-    setStatus uid Suspended
+    setStatus brig uid Suspended
     -- login fails
     login brig (defEmailLogin email) PersistentCookie !!! do
         const 403 === statusCode
@@ -603,17 +603,11 @@ testSuspendUser brig = do
     Search.assertCan'tFind brig suid uid (fromName (userName u))
 
     -- re-activate
-    setStatus uid Active
+    setStatus brig uid Active
     chkStatus brig uid Active
     -- should appear in search again
     Search.refreshIndex brig
     Search.assertCanFind brig suid uid (fromName (userName u))
-  where
-    setStatus u s =
-        let js = RequestBodyLBS . encode $ AccountStatusUpdate s
-        in put ( brig . paths ["i", "users", toByteString' u, "status"]
-               . contentJson . body js
-               ) !!! const 200 === statusCode
 
 testGetByIdentity :: Brig -> Http ()
 testGetByIdentity brig = do

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -234,7 +234,7 @@ testThrottleLogins conf b = do
 
 testLimitRetries :: HasCallStack => Maybe Opts.Opts -> Brig -> Http ()
 testLimitRetries (Just conf) brig = do
-    let Just opts = Opts.limitFailedLogins . Opts.optSettings $ conf
+    let Just opts = Opts.setLimitFailedLogins . Opts.optSettings $ conf
     unless (Opts.timeout opts <= 30) $
         error "`loginRetryTimeout` is the number of seconds this test is running.  Please pick a value < 30."
 

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -626,14 +626,6 @@ assertSaneAccessToken now uid tk = do
     assertEqual "user" uid (ZAuth.accessTokenOf tk)
     assertBool "expiry" (ZAuth.tokenExpiresUTC tk > now)
 
--- | Set user's status to something (e.g. 'Suspended').
-setStatus :: Brig -> UserId -> AccountStatus -> HttpT IO ()
-setStatus brig u s =
-    let js = RequestBodyLBS . encode $ AccountStatusUpdate s
-    in put ( brig . paths ["i", "users", toByteString' u, "status"]
-           . contentJson . Http.body js
-           ) !!! const 200 === statusCode
-
 -- | Get error label from the response (for use in assertions).
 errorLabel :: Response (Maybe Lazy.ByteString) -> Maybe Lazy.Text
 errorLabel = fmap Error.label . decodeBody

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
 module API.User.Auth (tests) where
 
 import Imports
@@ -231,8 +233,8 @@ testThrottleLogins conf b = do
     login b (defEmailLogin e) SessionCookie !!! const 200 === statusCode
 
 testLimitRetries :: HasCallStack => Maybe Opts.Opts -> Brig -> Http ()
-testLimitRetries conf brig = do
-    let Just opts = Opts.limitFailedLogins . Opts.optSettings =<< conf
+testLimitRetries (Just conf) brig = do
+    let Just opts = Opts.limitFailedLogins . Opts.optSettings $ conf
     unless (Opts.timeout opts <= 30) $
         error "`loginRetryTimeout` is the number of seconds this test is running.  Please pick a value < 30."
 

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -228,7 +228,7 @@ testThrottleLogins conf b = do
     liftIO $ do
         assertBool "throttle delay" (n > 0)
         threadDelay (1000000 * (n + 1))
-    void $ login b (defEmailLogin e) SessionCookie
+    login b (defEmailLogin e) SessionCookie !!! const 200 === statusCode
 
 testLimitRetries :: HasCallStack => Maybe Opts.Opts -> Brig -> Http ()
 testLimitRetries conf brig = do

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -262,14 +262,14 @@ testLimitRetries (Just conf) brig = do
             retryTimeout = Opts.Timeout $ fromIntegral retryAfterSecs
         liftIO $ do
             assertEqual "throttle delay (1)" retryTimeout (Opts.timeout opts)
-            threadDelay (1000000 * (retryAfterSecs - 1))
+            threadDelay (1000000 * (retryAfterSecs - 1))  -- wait almost long enough.
 
     -- fail again later into the block time window
     rsp <- login brig (defEmailLogin email) SessionCookie <!! const 403 === statusCode
     do  let Just retryAfterSecs = fromByteString =<< getHeader "Retry-After" rsp
         liftIO $ do
             assertBool ("throttle delay (2): " <> show retryAfterSecs) (retryAfterSecs <= 2)
-            threadDelay (1000000 * (retryAfterSecs - 2))
+            threadDelay (1000000 * (retryAfterSecs + 1))  -- wait one more second, just to be safe.
 
     -- wait long enough and login successfully!
     liftIO $ threadDelay (1000000 * 2)

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -515,6 +515,9 @@ someLastPrekeys =
 defPassword :: PlainTextPassword
 defPassword = PlainTextPassword "secret"
 
+defWrongPassword :: PlainTextPassword
+defWrongPassword = PlainTextPassword "not secret"
+
 defCookieLabel :: CookieLabel
 defCookieLabel = CookieLabel "auth"
 


### PR DESCRIPTION
Implements https://github.com/wearezeta/backend-issues/issues/841#issuecomment-518033685 .

Open questions:

1. I use `forM_` instead of `pooledForConcurrentlyN_` [here](https://github.com/wireapp/wire-server/blob/33a66e5732404bc8de91d9329dd3347d8d5be622/services/brig/test/integration/API/User/Auth.hs#L246).  The latter will fail because `Bridge.Budget` is not concurrency-proof: if two threads / services request a budget coin concurrently, only one of them will decrement the budget value in cassandra.  We could use [counters](https://cassandra.apache.org/doc/latest/cql/types.html#counters) instead of `int` in the [schema](https://github.com/wireapp/wire-server/blob/33a66e5732404bc8de91d9329dd3347d8d5be622/services/brig/schema/src/V37.hs), but it is unclear what that will mean for the other use case.  (cases?  i think there is only one.)
2. Should I move [LoginRetryOpts](https://github.com/wireapp/wire-server/blob/33a66e5732404bc8de91d9329dd3347d8d5be622/services/brig/src/Brig/Options.hs#L174) to [Settings](https://github.com/wireapp/wire-server/blob/33a66e5732404bc8de91d9329dd3347d8d5be622/services/brig/src/Brig/Options.hs#L274)?  It's not clear to me what the difference is, except perhaps that `Settings` can be changed at run-time, in which case `LoginRetryOpts` shouldn't go there (I think).
