### PR TITLE
Remove `exposed-modules` sections from all package.yaml files.

### DIFF
--- a/libs/api-bot/package.yaml
+++ b/libs/api-bot/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: api-bot
 version: '0.4.2'
@@ -58,15 +58,4 @@ dependencies:
 - vector >=0.10
 library:
   source-dirs: src
-  exposed-modules:
-  - Network.Wire.Bot
-  - Network.Wire.Bot.Assert
-  - Network.Wire.Bot.Clients
-  - Network.Wire.Bot.Crypto
-  - Network.Wire.Bot.Email
-  - Network.Wire.Bot.Metrics
-  - Network.Wire.Bot.Monad
-  - Network.Wire.Bot.Report
-  - Network.Wire.Bot.Report.Text
-  - Network.Wire.Bot.Settings
 stability: experimental

--- a/libs/api-client/package.yaml
+++ b/libs/api-client/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: api-client
 version: '0.4.2'
@@ -47,16 +47,4 @@ dependencies:
 - websockets >=0.9
 library:
   source-dirs: src
-  exposed-modules:
-  - Network.Wire.Client
-  - Network.Wire.Client.API.Auth
-  - Network.Wire.Client.API.Asset
-  - Network.Wire.Client.API.Conversation
-  - Network.Wire.Client.API.Push
-  - Network.Wire.Client.API.Search
-  - Network.Wire.Client.API.User
-  - Network.Wire.Client.API.Client
-  - Network.Wire.Client.HTTP
-  - Network.Wire.Client.Monad
-  - Network.Wire.Client.Session
 stability: experimental

--- a/libs/bilge/package.yaml
+++ b/libs/bilge/package.yaml
@@ -40,12 +40,4 @@ dependencies:
 - wai-extra
 library:
   source-dirs: src
-  exposed-modules:
-  - Bilge
-  - Bilge.Assert
-  - Bilge.IO
-  - Bilge.Request
-  - Bilge.Response
-  - Bilge.Retry
-  - Bilge.RPC
 stability: experimental

--- a/libs/cargohold-types/package.yaml
+++ b/libs/cargohold-types/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: cargohold-types
 version: '1.5.0'
@@ -31,7 +31,3 @@ dependencies:
 - uuid >=1.2
 library:
   source-dirs: src
-  exposed-modules:
-  - CargoHold.Types
-  - CargoHold.Types.V3
-  - CargoHold.Types.V3.Resumable

--- a/libs/cassandra-util/package.yaml
+++ b/libs/cassandra-util/package.yaml
@@ -35,10 +35,3 @@ dependencies:
 - retry
 library:
   source-dirs: src
-  exposed-modules:
-  - Cassandra
-  - Cassandra.CQL
-  - Cassandra.Exec
-  - Cassandra.Schema
-  - Cassandra.Settings
-  - Cassandra.Util

--- a/libs/gundeck-types/package.yaml
+++ b/libs/gundeck-types/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: gundeck-types
 version: '1.45.0'
@@ -26,13 +26,3 @@ dependencies:
 - unordered-containers >=0.2
 library:
   source-dirs: src
-  exposed-modules:
-  - Gundeck.Types
-  - Gundeck.Types.BulkPush
-  - Gundeck.Types.Common
-  - Gundeck.Types.Event
-  - Gundeck.Types.Notification
-  - Gundeck.Types.Presence
-  - Gundeck.Types.Push
-  - Gundeck.Types.Push.V2
-  - Gundeck.Types.Swagger

--- a/libs/imports/package.yaml
+++ b/libs/imports/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: imports
 version: '0.1.0'
@@ -30,6 +30,4 @@ dependencies:
 - tinylog
 library:
   source-dirs: src
-  exposed-modules:
-  - Imports
 stability: experimental

--- a/libs/metrics-collectd/package.yaml
+++ b/libs/metrics-collectd/package.yaml
@@ -18,12 +18,6 @@ dependencies:
 - transformers >=0.3
 library:
   source-dirs: src
-  exposed-modules:
-  - System.Metrics.Collectd.Collectd
-  - System.Metrics.Collectd.IO
-  - System.Metrics.Collectd.Json
-  - System.Metrics.Collectd.Json.Path
-  - System.Metrics.Collectd.Config
   dependencies:
   - aeson >=0.8
   - async >=2.0

--- a/libs/ropes/package.yaml
+++ b/libs/ropes/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: ropes
 version: '0.4.20'
@@ -16,11 +16,6 @@ dependencies:
 - semigroups >=0.11
 library:
   source-dirs: src
-  exposed-modules:
-  - Ropes.Aws
-  - Ropes.Aws.Ses
-  - Ropes.Nexmo
-  - Ropes.Twilio
   dependencies:
   - aeson >=0.6
   - aws >=0.10.2

--- a/libs/sodium-crypto-sign/package.yaml
+++ b/libs/sodium-crypto-sign/package.yaml
@@ -21,7 +21,5 @@ dependencies:
 - imports
 library:
   source-dirs: src
-  exposed-modules:
-  - Sodium.Crypto.Sign
   pkg-config-dependencies:
   - libsodium >= 0.4.5

--- a/libs/ssl-util/package.yaml
+++ b/libs/ssl-util/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: ssl-util
 version: '0.1.0'
@@ -19,6 +19,4 @@ dependencies:
 - time >=1.5
 library:
   source-dirs: src
-  exposed-modules:
-  - Ssl.Util
 stability: experimental

--- a/libs/tasty-cannon/package.yaml
+++ b/libs/tasty-cannon/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: tasty-cannon
 version: '0.4.0'
@@ -29,5 +29,3 @@ dependencies:
 - websockets >=0.8
 library:
   source-dirs: src
-  exposed-modules:
-  - Test.Tasty.Cannon

--- a/libs/types-common-aws/package.yaml
+++ b/libs/types-common-aws/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: types-common-aws
 version: '0.16.0'
@@ -36,8 +36,6 @@ dependencies:
 library:
   source-dirs: src
   ghc-prof-options: -fprof-auto-exported
-  exposed-modules:
-  - Util.Test.SQS
   when:
   - condition: impl(ghc >=8)
     ghc-options: -fno-warn-redundant-constraints

--- a/libs/types-common-journal/package.yaml
+++ b/libs/types-common-journal/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: types-common-journal
 version: '0.1.0'
@@ -26,13 +26,13 @@ library:
   source-dirs: src
   ghc-prof-options: -fprof-auto-exported
   exposed-modules:
+  # do not remove this list!  stack won't be able to generate it from the protobuf source files!
   - Data.Proto
   - Data.Proto.Id
   - Proto.TeamEvents
   - Proto.TeamEvents_Fields
   - Proto.UserEvents
   - Proto.UserEvents_Fields
-
 build-type: Custom
 verbatim: |
   custom-setup

--- a/libs/types-common/package.yaml
+++ b/libs/types-common/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: types-common
 version: '0.16.0'
@@ -14,21 +14,6 @@ dependencies:
 library:
   source-dirs: src
   ghc-prof-options: -fprof-auto-exported
-  exposed-modules:
-  - Data.Code
-  - Data.ETag
-  - Data.Id
-  - Data.Json.Util
-  - Data.LegalHold
-  - Data.List1
-  - Data.Misc
-  - Data.Range
-  - Data.Swagger
-  - Data.Text.Ascii
-  - Data.UUID.Tagged
-  - Util.Options
-  - Util.Options.Common
-  - Util.Test
   dependencies:
   - attoparsec >=0.11
   - aeson >=1.0

--- a/libs/wai-utilities/package.yaml
+++ b/libs/wai-utilities/package.yaml
@@ -39,11 +39,3 @@ dependencies:
 - warp >=3.0
 library:
   source-dirs: src
-  exposed-modules:
-  - Network.Wai.Utilities
-  - Network.Wai.Utilities.Error
-  - Network.Wai.Utilities.Request
-  - Network.Wai.Utilities.Response
-  - Network.Wai.Utilities.Server
-  - Network.Wai.Utilities.Swagger
-  - Network.Wai.Utilities.ZAuth

--- a/libs/zauth/package.yaml
+++ b/libs/zauth/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: zauth
 version: '0.10.3'
@@ -17,10 +17,6 @@ library:
   source-dirs: src
   ghc-options:
   - -funbox-strict-fields
-  exposed-modules:
-  - Data.ZAuth.Token
-  - Data.ZAuth.Creation
-  - Data.ZAuth.Validation
   dependencies:
   - attoparsec >=0.11
   - base >=4.6 && <5

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -39,20 +39,6 @@ dependencies:
 - yaml >=0.8.22
 library:
   source-dirs: src
-  exposed-modules:
-  - Brig.App
-  - Brig.API
-  - Brig.AWS
-  - Brig.AWS.Types
-  - Brig.Code
-  - Brig.Data.PasswordReset
-  - Brig.Options
-  - Brig.Provider.DB
-  - Brig.RPC
-  - Brig.Run
-  - Brig.User.Auth.Cookie.Limit
-  - Brig.User.Search.Index
-  - Brig.ZAuth
   dependencies:
   - amazonka >=1.3.7
   - amazonka-dynamodb >=1.3.7

--- a/services/cannon/package.yaml
+++ b/services/cannon/package.yaml
@@ -14,13 +14,6 @@ dependencies:
 - extended
 library:
   source-dirs: src
-  exposed-modules:
-  - Cannon.API
-  - Cannon.Dict
-  - Cannon.Options
-  - Cannon.Run
-  - Cannon.Types
-  - Cannon.WS
   dependencies:
   - base >=4.6 && <5
   - aeson >=0.11

--- a/services/cargohold/package.yaml
+++ b/services/cargohold/package.yaml
@@ -34,10 +34,6 @@ dependencies:
 - imports
 library:
   source-dirs: src
-  exposed-modules:
-  - CargoHold.API
-  - CargoHold.Options
-  - CargoHold.Run
   dependencies:
   - base >=4 && <5
   - attoparsec >=0.12

--- a/services/gundeck/package.yaml
+++ b/services/gundeck/package.yaml
@@ -15,32 +15,6 @@ library:
   source-dirs: src
   ghc-options:
   - -fwarn-incomplete-uni-patterns
-  exposed-modules:
-  - Gundeck.API
-  - Gundeck.API.Error
-  - Gundeck.Aws
-  - Gundeck.Aws.Arn
-  - Gundeck.Aws.Sns
-  - Gundeck.Client
-  - Gundeck.Env
-  - Gundeck.Instances
-  - Gundeck.Monad
-  - Gundeck.Notification
-  - Gundeck.Notification.Data
-  - Gundeck.Options
-  - Gundeck.Presence
-  - Gundeck.Presence.Data
-  - Gundeck.Push
-  - Gundeck.Push.Data
-  - Gundeck.Push.Native
-  - Gundeck.Push.Native.Serialise
-  - Gundeck.Push.Native.Types
-  - Gundeck.Push.Websocket
-  - Gundeck.React
-  - Gundeck.Run
-  - Gundeck.Util
-  - Gundeck.Util.DelayQueue
-  - Gundeck.Util.Redis
   dependencies:
   - aeson >=0.11
   - amazonka >=1.3.7

--- a/services/proxy/package.yaml
+++ b/services/proxy/package.yaml
@@ -15,12 +15,6 @@ library:
   source-dirs: src
   ghc-options:
   - -funbox-strict-fields
-  exposed-modules:
-  - Proxy.API
-  - Proxy.Env
-  - Proxy.Options
-  - Proxy.Proxy
-  - Proxy.Run
   dependencies:
   - base >=4.6 && <5
   - aeson >=1.0

--- a/tools/api-simulations/package.yaml
+++ b/tools/api-simulations/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: api-simulations
 version: '0.4.2'
@@ -19,8 +19,6 @@ dependencies:
 - split >=0.2
 library:
   source-dirs: lib/src
-  exposed-modules:
-  - Network.Wire.Simulations
   dependencies:
   - aeson >=0.7
   - base >=4.6

--- a/tools/bonanza/package.yaml
+++ b/tools/bonanza/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: bonanza
 version: '3.6.0'
@@ -19,28 +19,6 @@ library:
   ghc-options:
   - -funbox-small-strict-fields
   - -fno-warn-unused-do-bind
-  exposed-modules:
-  - Bonanza.Anon
-  - Bonanza.App
-  - Bonanza.Geo
-  - Bonanza.Metrics
-  - Bonanza.Parser.CommonLog
-  - Bonanza.Parser.IP
-  - Bonanza.Parser.Internal
-  - Bonanza.Parser.Journald
-  - Bonanza.Parser.Netstrings
-  - Bonanza.Parser.Nginz
-  - Bonanza.Parser.Rkt
-  - Bonanza.Parser.Socklog
-  - Bonanza.Parser.Svlogd
-  - Bonanza.Parser.Time
-  - Bonanza.Parser.Tinylog
-  - Bonanza.Streaming.Binary
-  - Bonanza.Streaming.Kibana
-  - Bonanza.Streaming.Parser
-  - Bonanza.Streaming.Protobuf
-  - Bonanza.Streaming.Snappy
-  - Bonanza.Types
   dependencies:
   - base ==4.*
   - aeson >=1.0

--- a/tools/makedeb/package.yaml
+++ b/tools/makedeb/package.yaml
@@ -1,4 +1,4 @@
-defaults: 
+defaults:
   local: ../../package-defaults.yaml
 name: makedeb
 version: '0.3.0'
@@ -13,8 +13,6 @@ dependencies:
 - imports
 library:
   source-dirs: src
-  exposed-modules:
-  - System.MakeDeb
   dependencies:
   - base >=4.6 && <5.0
   - directory >=1.2

--- a/tools/stern/package.yaml
+++ b/tools/stern/package.yaml
@@ -16,10 +16,6 @@ library:
   source-dirs: src
   ghc-options:
   - -funbox-strict-fields
-  exposed-modules:
-  - Stern.API
-  - Stern.App
-  - Stern.Options
   dependencies:
   - base                      >= 4.5     && < 5
   - aeson                     >= 0.11


### PR DESCRIPTION
(with these sections, we need to manually add new modules to expose them; without, everything gets exposed by default.)

cherry-picked from https://github.com/wireapp/wire-server/pull/826 because controversial.