### PR TITLE
SSO permissions

### DIFF
--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -695,13 +695,10 @@ deleteUser uid pwd = do
         Just tid -> do
             ownerSituation <- lift $ Team.teamOwnershipStatus uid tid
             case ownerSituation of
-               Team.IsOnlyTeamOwner       -> throwE DeleteUserOnlyOwner
-               Team.IsOneOfManyTeamOwners -> pure ()
-               Team.IsNotTeamOwner        -> pure ()
-               Team.NoTeamOwnersAreLeft   -> do
-                   Log.warn $ field "user" (toByteString uid)
-                            . field "team" (toByteString tid)
-                            . msg (val "Team.NoTeamOwnersAreLeft")
+               Team.IsOnlyTeamOwnerWithEmail       -> throwE DeleteUserOnlyOwner
+               Team.IsOneOfManyTeamOwnersWithEmail -> pure ()
+               Team.IsTeamOwnerWithoutEmail        -> pure ()
+               Team.IsNotTeamOwner                 -> pure ()
 
     go a = maybe (byIdentity a) (byPassword a) pwd
 

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -619,8 +619,9 @@ getTeamContacts u = do
 getTeamOwners :: TeamId -> AppIO [Team.TeamMember]
 getTeamOwners tid = filter Team.isTeamOwner . view Team.teamMembers <$> getTeamMembers tid
 
--- | Like 'getTeamOwners', but only returns owners with an email address.
-getTeamOwnersWithEmail :: TeamId -> AppIO [Team.TeamMember]
+-- | Like 'getTeamOwners', but only returns owners with an flag indicating whether they have
+-- an email address.
+getTeamOwnersWithEmail :: TeamId -> AppIO [(Team.TeamMember, Bool)]
 getTeamOwnersWithEmail tid = do
     mems <- getTeamOwners tid
     usrList :: [User] <- lookupUsers ((^. Team.userId) <$> mems)
@@ -634,7 +635,7 @@ getTeamOwnersWithEmail tid = do
         hasEmail :: Team.TeamMember -> Bool
         hasEmail mem = maybe False id $ Map.lookup (mem ^. Team.userId) usrMap
 
-    pure $ filter hasEmail mems
+    pure $ (\mem -> (mem, hasEmail mem)) <$> mems
 
 getTeamId :: UserId -> AppIO (Maybe TeamId)
 getTeamId u = do

--- a/services/brig/src/Brig/Team/Util.hs
+++ b/services/brig/src/Brig/Team/Util.hs
@@ -11,19 +11,34 @@ import Control.Error
 import qualified Brig.IO.Intra as Intra
 import qualified Data.Set as Set
 
-data TeamOwnershipStatus = IsOnlyTeamOwner | IsOneOfManyTeamOwners | IsNotTeamOwner | NoTeamOwnersAreLeft
+-- | Every team must have at least one owner with an email address for billing and
+-- administration.  'TeamOwnershipStatus' distinguishes all the relevant cases.
+data TeamOwnershipStatus
+  = IsOnlyTeamOwnerWithEmail
+  | IsOneOfManyTeamOwnersWithEmail
+  | IsTeamOwnerWithoutEmail
+  | IsNotTeamOwner
   deriving (Eq, Show, Bounded, Enum)
 
 -- | A team owner is a team member with full permissions *and* an email address.
 teamOwnershipStatus :: UserId -> TeamId -> AppIO TeamOwnershipStatus
-teamOwnershipStatus uid tid = teamOwnershipStatus' uid . fmap (^. userId) <$> Intra.getTeamOwnersWithEmail tid
+teamOwnershipStatus uid tid = compute <$> Intra.getTeamOwnersWithEmail tid
+  where
+    compute :: [(TeamMember, Bool)] -> TeamOwnershipStatus
+    compute owners = search (getuid <$> owners) (getuid <$> ownersWithEmail)
+      where
+        ownersWithEmail = filter (^. _2) owners
+        getuid = (^. _1 . userId)
 
-teamOwnershipStatus' :: UserId -> [UserId] -> TeamOwnershipStatus
-teamOwnershipStatus' _ [] = NoTeamOwnersAreLeft
-teamOwnershipStatus' uid (Set.fromList -> owners)
-    | uid `Set.notMember` owners       = IsNotTeamOwner
-    | Set.null (Set.delete uid owners) = IsOnlyTeamOwner
-    | otherwise                        = IsOneOfManyTeamOwners
+    search :: [UserId] -> [UserId] -> TeamOwnershipStatus
+    search [] [] = IsNotTeamOwner  -- this shouldn't happen, but we don't handle that here.
+    search (Set.fromList -> owners) (Set.fromList -> ownersWithEmail)
+        = case (uid `Set.member` owners, uid `Set.member` ownersWithEmail) of
+            (False, _)     -> IsNotTeamOwner
+            (True,  False) -> IsTeamOwnerWithoutEmail
+            (True,  True)  -> if Set.null (Set.delete uid ownersWithEmail)
+                then IsOnlyTeamOwnerWithEmail
+                else IsOneOfManyTeamOwnersWithEmail
 
 ensurePermissions :: UserId -> TeamId -> [Perm] -> ExceptT Error AppIO ()
 ensurePermissions u t perms = do

--- a/services/brig/src/Brig/Team/Util.hs
+++ b/services/brig/src/Brig/Team/Util.hs
@@ -20,7 +20,6 @@ data TeamOwnershipStatus
   | IsNotTeamOwner
   deriving (Eq, Show, Bounded, Enum)
 
--- | A team owner is a team member with full permissions *and* an email address.
 teamOwnershipStatus :: UserId -> TeamId -> AppIO TeamOwnershipStatus
 teamOwnershipStatus uid tid = compute <$> Intra.getTeamOwnersWithEmail tid
   where

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -262,7 +262,7 @@ testLimitRetries (Just conf) brig = do
             retryTimeout = Opts.Timeout $ fromIntegral retryAfterSecs
         liftIO $ do
             assertEqual "throttle delay (1)" retryTimeout (Opts.timeout opts)
-            threadDelay (1000000 * (retryAfterSecs - 1))  -- wait almost long enough.
+            threadDelay (1000000 * (retryAfterSecs - 2))  -- wait almost long enough.
 
     -- fail again later into the block time window
     rsp <- login brig (defEmailLogin email) SessionCookie <!! const 403 === statusCode

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -33,6 +33,8 @@ module Util.Core
   , createTeamMember
   , deleteUserOnBrig
   , getTeams
+  , getTeamMembers
+  , promoteTeamMember
   , getSelfProfile
   , nextWireId
   , nextSAMLID
@@ -370,6 +372,23 @@ getTeams u gly = do
              . expect2xx
              )
     return $ decodeBody' r
+
+getTeamMembers :: HasCallStack => UserId -> TeamId -> TestSpar [UserId]
+getTeamMembers usr tid = do
+  gly <- view teGalley
+  resp <- call $ get (gly . paths ["teams", toByteString' tid, "members"] . zUser usr)
+            <!! const 200 === statusCode
+  let mems :: Galley.TeamMemberList
+      Right mems = responseJson resp
+  pure $ (^. Galley.userId) <$> (mems ^. Galley.teamMembers)
+
+promoteTeamMember :: HasCallStack => UserId -> TeamId -> UserId -> TestSpar ()
+promoteTeamMember usr tid memid = do
+  gly <- view teGalley
+  let bdy :: Galley.NewTeamMember
+      bdy = Galley.newNewTeamMember $ Galley.newTeamMember memid Galley.fullPermissions Nothing
+  call $ put (gly . paths ["teams", toByteString' tid, "members"] . zAuthAccess usr "conn" . json bdy)
+    !!! const 200 === statusCode
 
 getSelfProfile :: (HasCallStack, MonadHttp m, MonadIO m) => BrigReq -> UserId -> m Brig.SelfProfile
 getSelfProfile brg usr = do


### PR DESCRIPTION
galley has an end-point only used by spar for deciding team ownership.  so far this end-point has not acknowledged owners if they didn't have an email address.

this constraint is relaxed here, the code for membership status is cleaned up, and tests are added.