### PR TITLE
Remove Debug.Trace from Imports.

### DIFF
--- a/libs/bilge/src/Bilge/IO.hs
+++ b/libs/bilge/src/Bilge/IO.hs
@@ -48,7 +48,7 @@ module Bilge.IO
     , HttpException (..)
     ) where
 
-import Imports hiding (head, trace)
+import Imports hiding (head)
 import Control.Monad.Base
 import Control.Monad.Catch
 import Control.Monad.Trans.Control

--- a/libs/imports/src/Imports.hs
+++ b/libs/imports/src/Imports.hs
@@ -24,7 +24,6 @@ module Imports
     , module Data.Tuple
     , module Data.String
     , module Data.List
-    , module Debug.Trace
     , Generic
     , Typeable
     , HasCallStack
@@ -112,7 +111,6 @@ import Data.List hiding (insert, delete)  -- 'insert' and 'delete' are
 import Data.String
 import Control.Monad hiding (mapM_, sequence_, forM_, msum, mapM, sequence, forM)
 import Control.Monad.Extra (whenM, unlessM)
-import Debug.Trace
 import GHC.Generics (Generic)
 import Data.Typeable (Typeable)
 import GHC.Stack (HasCallStack)

--- a/services/cannon/src/Cannon/WS.hs
+++ b/services/cannon/src/Cannon/WS.hs
@@ -30,7 +30,7 @@ module Cannon.WS
     )
 where
 
-import Imports hiding (threadDelay, trace)
+import Imports hiding (threadDelay)
 import Bilge hiding (trace)
 import Bilge.Retry
 import Bilge.RPC

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -141,7 +141,7 @@ postConvOk = do
         cvs <- mapM (convView cid) [alice, bob, jane]
         liftIO $ mapM_ WS.assertSuccess =<< Async.mapConcurrently (checkWs alice) (zip cvs [wsA, wsB, wsJ])
   where
-    convView cnv usr = decodeBody' "conversation" <$> getConv usr cnv
+    convView cnv usr = decodeBodyMsg "conversation" <$> getConv usr cnv
     checkWs alice (cnv, ws) = WS.awaitMatch (5 # Second) ws $ \n -> do
         ntfTransient n @?= False
         let e = List1.head (WS.unpackPayload n)
@@ -251,12 +251,12 @@ postCryptoMessage2 = do
     let m = [(bob, bc, "hello bob")]
     r1 <- postOtrMessage id alice ac conv m <!!
         const 412 === statusCode
-    let x = decodeBody' "ClientMismatch" r1
+    let x = decodeBodyMsg "ClientMismatch" r1
     liftIO $ assertBool "client mismatch" (eqMismatch [(eve, Set.singleton ec)] [] [] (Just x))
     -- Fetch all missing clients prekeys
     r2 <- post (b . path "/users/prekeys" . json (missingClients x)) <!!
         const 200 === statusCode
-    let p = decodeBody' "prekeys" r2 :: UserClientMap (Maybe Prekey)
+    let p = decodeBodyMsg "prekeys" r2 :: UserClientMap (Maybe Prekey)
     liftIO $ do
         Map.keys (userClientMap p) @=? [eve]
         Map.keys <$> Map.lookup eve (userClientMap p) @=? Just [ec]
@@ -274,12 +274,12 @@ postCryptoMessage3 = do
     let m = otrRecipients [(bob, [(bc, ciphertext)])]
     r1 <- postProtoOtrMessage alice ac conv m <!!
         const 412 === statusCode
-    let x = decodeBody' "ClientMismatch" r1
+    let x = decodeBodyMsg "ClientMismatch" r1
     liftIO $ assertBool "client mismatch" (eqMismatch [(eve, Set.singleton ec)] [] [] (Just x))
     -- Fetch all missing clients prekeys
     r2 <- post (b . path "/users/prekeys" . json (missingClients x)) <!!
         const 200 === statusCode
-    let p = decodeBody' "prekeys" r2 :: UserClientMap (Maybe Prekey)
+    let p = decodeBodyMsg "prekeys" r2 :: UserClientMap (Maybe Prekey)
     liftIO $ do
         Map.keys (userClientMap p) @=? [eve]
         Map.keys <$> Map.lookup eve (userClientMap p) @=? Just [ec]
@@ -327,7 +327,7 @@ postCryptoMessage5 = do
         const 201 === statusCode
     _rs <- postOtrMessage (queryItem "report_missing" (toByteString' eve)) alice ac conv [] <!!
         const 412 === statusCode
-    let _mm = decodeBody' "ClientMismatch" _rs
+    let _mm = decodeBodyMsg "ClientMismatch" _rs
     liftIO $ assertBool "client mismatch" (eqMismatch [(eve, Set.singleton ec)] [] [] (Just _mm))
 
     -- Ignore missing clients of a specific user only
@@ -335,7 +335,7 @@ postCryptoMessage5 = do
         const 201 === statusCode
     _rs <- postOtrMessage (queryItem "ignore_missing" (toByteString' eve)) alice ac conv [] <!!
         const 412 === statusCode
-    let _mm = decodeBody' "ClientMismatch" _rs
+    let _mm = decodeBodyMsg "ClientMismatch" _rs
     liftIO $ assertBool "client mismatch" (eqMismatch [(bob, Set.singleton bc)] [] [] (Just _mm))
 
 postJoinConvOk :: TestM ()
@@ -490,14 +490,14 @@ getConvsOk2 = do
     [alice, bob] <- randomUsers 2
     connectUsers alice (singleton bob)
     -- create & get one2one conv
-    cnv1 <- decodeBody' "conversation" <$> postO2OConv alice bob (Just "gossip1")
+    cnv1 <- decodeBodyMsg "conversation" <$> postO2OConv alice bob (Just "gossip1")
     getConvs alice (Just $ Left [cnvId cnv1]) Nothing !!! do
         const 200 === statusCode
         const (Just [cnvId cnv1]) === fmap (map cnvId . convList) . decodeBody
     -- create & get group conv
     carl <- randomUser
     connectUsers alice (singleton carl)
-    cnv2 <- decodeBody' "conversation" <$> postConv alice [bob, carl] (Just "gossip2") [] Nothing Nothing
+    cnv2 <- decodeBodyMsg "conversation" <$> postConv alice [bob, carl] (Just "gossip2") [] Nothing Nothing
     getConvs alice (Just $ Left [cnvId cnv2]) Nothing !!! do
         const 200 === statusCode
         const (Just [cnvId cnv2]) === fmap (map cnvId . convList) . decodeBody
@@ -709,7 +709,7 @@ postRepeatConnectConvCancel = do
 
     -- Alice wants to connect
     rsp1 <- postConnectConv alice bob "A" "a" Nothing <!! const 201 === statusCode
-    let cnv = decodeBody' "conversation" rsp1
+    let cnv = decodeBodyMsg "conversation" rsp1
     liftIO $ do
         ConnectConv   @=? cnvType cnv
         (Just "A")    @=? cnvName cnv
@@ -721,7 +721,7 @@ postRepeatConnectConvCancel = do
 
     -- Alice makes another connect attempt
     rsp2 <- postConnectConv alice bob "A2" "a2" Nothing <!! const 200 === statusCode
-    let cnv2 = decodeBody' "conversation" rsp2
+    let cnv2 = decodeBodyMsg "conversation" rsp2
     liftIO $ do
         ConnectConv   @=? cnvType cnv2
         (Just "A2")   @=? cnvName cnv2
@@ -733,7 +733,7 @@ postRepeatConnectConvCancel = do
 
     -- Now Bob attempts to connect
     rsp3 <- postConnectConv bob alice "B" "b" Nothing <!! const 200 === statusCode
-    let cnv3 = decodeBody' "conversation" rsp3
+    let cnv3 = decodeBodyMsg "conversation" rsp3
     liftIO $ do
         ConnectConv   @=? cnvType cnv3
         (Just "B")    @=? cnvName cnv3
@@ -741,7 +741,7 @@ postRepeatConnectConvCancel = do
 
     -- Bob accepting is a no-op, since he is already a member
     putConvAccept bob (cnvId cnv) !!! const 200 === statusCode
-    cnvX <- decodeBody' "conversation" <$> getConv bob (cnvId cnv)
+    cnvX <- decodeBodyMsg "conversation" <$> getConv bob (cnvId cnv)
     liftIO $ do
         ConnectConv   @=? cnvType cnvX
         (Just "B")    @=? cnvName cnvX
@@ -749,7 +749,7 @@ postRepeatConnectConvCancel = do
 
     -- Alice accepts, finally turning it into a 1-1
     putConvAccept alice (cnvId cnv) !!! const 200 === statusCode
-    cnv4 <- decodeBody' "conversation" <$> getConv alice (cnvId cnv)
+    cnv4 <- decodeBodyMsg "conversation" <$> getConv alice (cnvId cnv)
     liftIO $ do
         One2OneConv     @=? cnvType cnv4
         (Just "B")      @=? cnvName cnv4
@@ -766,7 +766,7 @@ putBlockConvOk = do
     g <- view tsGalley
     alice <- randomUser
     bob   <- randomUser
-    conv  <- decodeBody' "conversation" <$> postConnectConv alice bob "Alice" "connect with me!" (Just "me@me.com")
+    conv  <- decodeBodyMsg "conversation" <$> postConnectConv alice bob "Alice" "connect with me!" (Just "me@me.com")
 
     getConv alice (cnvId conv) !!! const 200 === statusCode
     getConv bob (cnvId conv)   !!! const 404 === statusCode
@@ -777,7 +777,7 @@ putBlockConvOk = do
     -- A is still the only member of the 1-1
     getConv alice (cnvId conv) !!! do
         const 200 === statusCode
-        const (cnvMembers conv) === cnvMembers . decodeBody' "conversation"
+        const (cnvMembers conv) === cnvMembers . decodeBodyMsg "conversation"
 
     -- B accepts the conversation by unblocking
     put (g . paths ["/i/conversations", toByteString' (cnvId conv), "unblock"] . zUser bob) !!!

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -80,7 +80,7 @@ messageTimerChangeGuest = do
     -- Try to change the timer (as the guest user) and observe failure
     putMessageTimerUpdate guest cid (ConversationMessageTimerUpdate timer1sec) !!! do
         const 403 === statusCode
-        const "access-denied" === (label . decodeBody' "error label")
+        const "access-denied" === (label . decodeBodyMsg "error label")
     getConv guest cid !!!
         const Nothing === (cnvMessageTimer <=< decodeBody)
     -- Try to change the timer (as a team member) and observe success
@@ -100,9 +100,9 @@ messageTimerChangeO2O = do
     -- Try to change the timer and observe failure
     putMessageTimerUpdate alice cid (ConversationMessageTimerUpdate timer1sec) !!! do
         const 403 === statusCode
-        const "invalid-op" === (label . decodeBody' "error label")
+        const "invalid-op" === (label . decodeBodyMsg "error label")
     getConv alice cid !!!
-        const Nothing === (cnvMessageTimer <=< decodeBody)
+        const Nothing === (cnvMessageTimer <=< decodeBodyM)
 
 messageTimerEvent :: TestM ()
 messageTimerEvent = do

--- a/services/galley/test/integration/API/SQS.hs
+++ b/services/galley/test/integration/API/SQS.hs
@@ -2,7 +2,7 @@
 -- instead.
 module API.SQS where
 
-import Imports hiding (trace)
+import Imports
 import Control.Exception (SomeAsyncException, asyncExceptionFromException)
 import Control.Lens hiding ((.=))
 import Control.Monad.Catch hiding (bracket)

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -195,7 +195,7 @@ testCreateOne2OneFailNonBindingTeamMembers = do
     -- Cannot create a 1-1 conversation, not connected and in the same team but not binding
     Util.createOne2OneTeamConv (mem1^.userId) (mem2^.userId) Nothing tid !!! do
         const 404 === statusCode
-        const "non-binding-team" === (Error.label . Util.decodeBody' "error label")
+        const "non-binding-team" === (Error.label . Util.decodeBodyMsg "error label")
     -- Both have a binding team but not the same team
     owner1 <- Util.randomUser
     tid1 <- Util.createTeamInternal "foo" owner1
@@ -205,7 +205,7 @@ testCreateOne2OneFailNonBindingTeamMembers = do
     assertQueue "create another team" tActivate
     Util.createOne2OneTeamConv owner1 owner2 Nothing tid1 !!! do
         const 403 === statusCode
-        const "non-binding-team-members" === (Error.label . Util.decodeBody' "error label")
+        const "non-binding-team-members" === (Error.label . Util.decodeBodyMsg "error label")
 
 testCreateOne2OneWithMembers
     :: HasCallStack
@@ -384,7 +384,7 @@ testRemoveBindingTeamMember ownerHasPassword = do
            . json (newTeamMemberDeleteData (Just $ PlainTextPassword "wrong passwd"))
            ) !!! do
         const 403 === statusCode
-        const "access-denied" === (Error.label . Util.decodeBody' "error label")
+        const "access-denied" === (Error.label . Util.decodeBodyMsg "error label")
 
     -- Mem1 is still part of Wire
     Util.ensureDeletedState False owner (mem1^.userId)
@@ -491,7 +491,7 @@ testAddTeamConvAsExternalPartner = do
         (Just "blaa") acc (Just TeamAccessRole) Nothing
       !!! do
         const 403 === statusCode
-        const "operation-denied" === (Error.label . Util.decodeBody' "error label")
+        const "operation-denied" === (Error.label . Util.decodeBodyMsg "error label")
 
 testAddManagedConv :: TestM ()
 testAddManagedConv = do
@@ -550,7 +550,7 @@ testAddTeamMemberToConv = do
     Util.assertNotConvMember (mem3^.userId) cid
     Util.postMembers (mem3^.userId) (list1 (mem1^.userId) []) cid !!! do
         const 403                === statusCode
-        const "operation-denied" === (Error.label . Util.decodeBody' "error label")
+        const "operation-denied" === (Error.label . Util.decodeBodyMsg "error label")
 
 testUpdateTeamConv
     :: Role  -- ^ Role of the user who creates the conversation
@@ -644,7 +644,7 @@ testDeleteBindingTeam ownerHasPassword = do
            . json (newTeamDeleteData (Just $ PlainTextPassword "wrong passwd"))
            ) !!! do
         const 403 === statusCode
-        const "access-denied" === (Error.label . Util.decodeBody' "error label")
+        const "access-denied" === (Error.label . Util.decodeBodyMsg "error label")
 
     delete ( g
            . paths ["teams", toByteString' tid, "members", toByteString' (mem3^.userId)]
@@ -809,7 +809,7 @@ testUpdateTeamMember = do
         . json changeOwner
         ) !!! do
         const 403 === statusCode
-        const "no-other-owner" === (Error.label . Util.decodeBody' "error label")
+        const "no-other-owner" === (Error.label . Util.decodeBodyMsg "error label")
     let changeMember = newNewTeamMember (member & permissions .~ fullPermissions)
     WS.bracketR2 c owner (member^.userId) $ \(wsOwner, wsMember) -> do
         put ( g
@@ -869,7 +869,7 @@ testUpdateTeamStatus = do
                . json (TeamStatusUpdate Deleted Nothing)
                ) !!! do
         const 403 === statusCode
-        const "invalid-team-status-update" === (Error.label . Util.decodeBody' "error label")
+        const "invalid-team-status-update" === (Error.label . Util.decodeBodyMsg "error label")
 
 checkUserDeleteEvent :: HasCallStack => UserId -> WS.WebSocket -> TestM ()
 checkUserDeleteEvent uid w = WS.assertMatch_ timeout w $ \notif -> do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -613,7 +613,7 @@ testDeleteTeam = do
             Util.getConv u x !!! const 404 === statusCode
             Util.getSelfMember u x !!! do
                 const 200         === statusCode
-                const (Just Null) === Util.decodeBody
+                const (Just Null) === Util.decodeBodyM
     assertQueueEmpty
 
 testDeleteBindingTeam :: Bool -> TestM ()

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -345,7 +345,7 @@ testCreateLegalHoldTeamSettings = do
     -- behaving or not)
     let lhapp :: HasCallStack => IsWorking -> Chan Void -> Application
         lhapp NotWorking _ _   cont = cont respondBad
-        lhapp Working  _ req cont = trace "APP" $ do
+        lhapp Working  _ req cont = do
             if | pathInfo req /= ["legalhold", "status"] -> cont respondBad
                | requestMethod req /= "GET" -> cont respondBad
                | otherwise -> cont respondOk


### PR DESCRIPTION
Debug.Trace should not be used in production code, but it's easy to miss a trace statement in a PR.  It's much easier to see that `Debug.Trace` is still imported somewhere.  Also, not providing it implicitly makes it clearer that it shouldn't be used in production code.