### PR TITLE
[WIP] Cleanup Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 SHELL            := /usr/bin/env bash
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 LANG             := en_US.UTF-8
 DOCKER_USER      ?= quay.io/wire
 DOCKER_TAG       ?= local
@@ -11,12 +15,12 @@ init:
 # Build all Haskell services and executables, run unit tests
 .PHONY: install
 install: init
-	stack install --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
+	stack install $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 # Build all Haskell services and executables with -O0, run unit tests
 .PHONY: fast
 fast: init
-	stack install --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist --fast $(WIRE_STACK_OPTIONS)
+	stack install $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)
 
 # Build everything (Haskell services and nginz)
 .PHONY: services
@@ -26,20 +30,20 @@ services: init install
 # Build haddocks
 .PHONY: haddock
 haddock:
-	WIRE_STACK_OPTIONS="--haddock --haddock-internal" make fast
+	WIRE_STACK_OPTIONS="--haddock --haddock-internal $(WIRE_STACK_OPTIONS)" make fast
 
 # Build haddocks only for wire-server
 .PHONY: haddock-shallow
 haddock-shallow:
-	WIRE_STACK_OPTIONS="--haddock --haddock-internal --no-haddock-deps" make fast
+	WIRE_STACK_OPTIONS="--haddock --haddock-internal --no-haddock-deps $(WIRE_STACK_OPTIONS)" make fast
 
 # Clean
 .PHONY: clean
 clean:
-	stack clean
+	stack clean $(STACK_OPTIONS)
 	$(MAKE) -C services/nginz clean
-	-rm -rf dist
-	-rm -f .metadata
+	rm -rf dist
+	rm -f .metadata
 
 #################################
 ## running integration tests

--- a/libs/metrics-collectd/Makefile
+++ b/libs/metrics-collectd/Makefile
@@ -1,5 +1,9 @@
 LANG := en_US.UTF-8
 SHELL        := /usr/bin/env bash
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 NAME         := $(lastword $(subst /, ,$(CURDIR)))
 VERSION       = $(shell sed -n 's/^version: *\(.*\)$$/\1/p' $(NAME).cabal)
 BUILD_NUMBER ?= 0
@@ -12,26 +16,24 @@ default: all
 all: clean install
 
 init:
-	mkdir -p dist
+	mkdir -p ../../dist
 
 .PHONY: clean
 clean:
-	stack clean metrics-collectd
-	-rm -rf dist
-	-rm -f .metadata
+	stack clean . $(STACK_OPTIONS)
+	rm -f .metadata
 
 .PHONY: install
 install: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY:
 compile:
-	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
+	stack build . $(STACK_OPTIONS) --no-copy-bins $(WIRE_STACK_OPTIONS)
 
 .PHONY: sdist
 sdist: init
-	stack sdist .
-	cp "$(shell stack path --dist-dir)/$(NAME)-$(VERSION).tar.gz" dist/
+	stack sdist . $(STACK_OPTIONS)
 
 .PHONY: dist
 dist: sdist install $(DEB) .metadata

--- a/services/brig/Makefile
+++ b/services/brig/Makefile
@@ -1,6 +1,10 @@
 LANG := en_US.UTF-8
 SHELL         := /usr/bin/env bash
 NAME          := brig
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 VERSION       ?=
 BUILD_NUMBER  ?= 0
 BUILD_LABEL   ?= local
@@ -25,25 +29,24 @@ guard-%:
 default: fast
 
 init:
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 
 .PHONY: install
 install: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: fast
 fast: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist --fast $(WIRE_STACK_OPTIONS)
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY: clean
 clean:
-	stack clean $(NAME)
-	-rm -rf dist
-	-rm -f .metadata
+	stack clean . $(STACK_OPTIONS)
+	rm -f .metadata
 
 .PHONY: compile
 compile:
-	stack build . --fast --test --bench --no-run-benchmarks --no-copy-bins
+	stack build . $(STACK_OPTIONS) --no-copy-bins $(WIRE_STACK_OPTIONS)
 
 .PHONY: dist
 dist: guard-VERSION install $(DEB) $(DEB_IT) $(DEB_SCHEMA) $(DEB_INDEX) .metadata
@@ -139,7 +142,7 @@ docker:
 
 .PHONY: time
 time: clean
-	-rm -f .stack-work/logs/*
-	stack build . --pedantic --no-run-benchmarks --no-copy-bins --ghc-options="-j +RTS -s -RTS"
+	rm -f $(shell stack path --project-root)/.stack-work/logs/*
+	stack build . $(STACK_OPTIONS) --no-copy-bins --ghc-options="-j +RTS -s -RTS"
 	@echo -e "\nTotal wall-clock times taken to compile each module (see logs for more detail):"
 	@grep Total .stack-work/logs/* | tr -s ' ' | awk -F' ' '{gsub(/s$$/, "", $$6); a[$$1] += $$6}END{for (i in a) {m=gensub(/^.*\/logs\//,"",1,i); m=gensub(/-[0-9].*\.log/,"",1,m); print m, a[i] ++ "s"}}' | sort -grk2

--- a/services/cannon/Makefile
+++ b/services/cannon/Makefile
@@ -1,6 +1,10 @@
 LANG := en_US.UTF-8
 SHELL        := /usr/bin/env bash
 NAME         := cannon
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 VERSION      ?=
 BUILD_NUMBER ?= 0
 BUILD_LABEL  ?= local
@@ -21,25 +25,24 @@ default: fast
 all: clean install
 
 init:
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 
 .PHONY: clean
 clean:
-	stack clean $(NAME)
-	-rm -rf dist
-	-rm -f .metadata
+	stack clean . $(STACK_OPTIONS)
+	rm -f .metadata
 
 .PHONY: install
 install: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: fast
 fast: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist --fast $(WIRE_STACK_OPTIONS)
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY:
 compile:
-	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
+	stack build . $(STACK_OPTIONS) --no-copy-bins $(WIRE_STACK_OPTIONS)
 
 .PHONY: dist
 dist: guard-VERSION install $(DEB) .metadata
@@ -68,7 +71,7 @@ docker:
 
 .PHONY: time
 time: clean
-	-rm -f .stack-work/logs/*
-	stack build . --pedantic --no-run-benchmarks --no-copy-bins --ghc-options="-j +RTS -s -RTS"
+	rm -f $(shell stack path --project-root)/.stack-work/logs/*
+	stack build . $(STACK_OPTIONS) --no-copy-bins --ghc-options="-j +RTS -s -RTS"
 	@echo -e "\nTotal wall-clock times taken to compile each module (see logs for more detail):"
 	@grep Total .stack-work/logs/* | tr -s ' ' | awk -F' ' '{gsub(/s$$/, "", $$6); a[$$1] += $$6}END{for (i in a) {m=gensub(/^.*\/logs\//,"",1,i); m=gensub(/-[0-9].*\.log/,"",1,m); print m, a[i] ++ "s"}}' | sort -grk2

--- a/services/cargohold/Makefile
+++ b/services/cargohold/Makefile
@@ -1,6 +1,10 @@
 LANG := en_US.UTF-8
 SHELL         := /usr/bin/env bash
 NAME          := cargohold
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 VERSION       ?=
 BUILD_NUMBER  ?= 0
 BUILD_LABEL   ?= local
@@ -23,25 +27,24 @@ default: fast
 
 .PHONY: init
 init:
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 
 .PHONY: install
 install: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: fast
 fast: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist --fast $(WIRE_STACK_OPTIONS)
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY: compile
 compile:
-	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
+	stack build . $(STACK_OPTIONS) --no-copy-bins $(WIRE_STACK_OPTIONS)
 
 .PHONY: clean
 clean: init
-	stack clean $(NAME)
-	-rm -rf dist
-	-rm -f .metadata
+	stack clean . $(STACK_OPTIONS)
+	rm -f .metadata
 
 .PHONY: dist
 dist: guard-VERSION install $(DEB) $(DEB_IT) .metadata
@@ -103,7 +106,7 @@ docker:
 
 .PHONY: time
 time: clean
-	-rm -f .stack-work/logs/*
-	stack build . --pedantic --no-run-benchmarks --no-copy-bins --ghc-options="-j +RTS -s -RTS"
+	rm -f $(shell stack path --project-root)/.stack-work/logs/*
+	stack build . $(STACK_OPTIONS) --no-copy-bins --ghc-options="-j +RTS -s -RTS"
 	@echo -e "\nTotal wall-clock times taken to compile each module (see logs for more detail):"
 	@grep Total .stack-work/logs/* | tr -s ' ' | awk -F' ' '{gsub(/s$$/, "", $$6); a[$$1] += $$6}END{for (i in a) {m=gensub(/^.*\/logs\//,"",1,i); m=gensub(/-[0-9].*\.log/,"",1,m); print m, a[i] ++ "s"}}' | sort -grk2

--- a/services/galley/Makefile
+++ b/services/galley/Makefile
@@ -1,7 +1,11 @@
-LANG := en_US.UTF-8
+LANG          := en_US.UTF-8
 SHELL         := /usr/bin/env bash
 NAME          := galley
 VERSION       ?=
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 BUILD_NUMBER  ?= 0
 BUILD_LABEL   ?= local
 BUILD         := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
@@ -12,8 +16,8 @@ DEB_IT        := $(NAME)-integration_$(VERSION)+$(BUILD)_amd64.deb
 DEB_SCHEMA    := $(NAME)-schema_$(VERSION)+$(BUILD)_amd64.deb
 DEB_JOURNALER := $(NAME)-journaler_$(VERSION)+$(BUILD)_amd64.deb
 EXECUTABLES   := $(NAME) $(NAME)-integration $(NAME)-schema $(NAME)-journaler
-DOCKER_USER    ?= quay.io/wire
-DOCKER_TAG     ?= local
+DOCKER_USER   ?= quay.io/wire
+DOCKER_TAG    ?= local
 
 guard-%:
 	@ if [ "${${*}}" = "" ]; then \
@@ -26,25 +30,24 @@ default: fast
 all: clean install
 
 init:
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 
 .PHONY: clean
 clean:
-	stack clean $(NAME)
-	-rm -rf dist
-	-rm -f .metadata
+	stack clean . $(STACK_OPTIONS)
+	rm -f .metadata
 
 .PHONY: install
 install: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: fast
 fast: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist --fast $(WIRE_STACK_OPTIONS)
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY:
 compile:
-	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
+	stack build . $(STACK_OPTIONS) --no-copy-bins $(WIRE_STACK_OPTIONS)
 
 .PHONY: dist
 dist: guard-VERSION install $(DEB) $(DEB_IT) $(DEB_SCHEMA) $(DEB_JOURNALER) .metadata
@@ -132,7 +135,7 @@ docker:
 
 .PHONY: time
 time: clean
-	-rm -f .stack-work/logs/*
-	stack build . --pedantic --no-run-benchmarks --no-copy-bins --ghc-options="-j +RTS -s -RTS"
+	rm -f $(shell stack path --project-root)/.stack-work/logs/*
+	stack build . $(STACK_OPTIONS) --no-copy-bins --ghc-options="-j +RTS -s -RTS"
 	@echo -e "\nTotal wall-clock times taken to compile each module (see logs for more detail):"
 	@grep Total .stack-work/logs/* | tr -s ' ' | awk -F' ' '{gsub(/s$$/, "", $$6); a[$$1] += $$6}END{for (i in a) {m=gensub(/^.*\/logs\//,"",1,i); m=gensub(/-[0-9].*\.log/,"",1,m); print m, a[i] ++ "s"}}' | sort -grk2

--- a/services/gundeck/Makefile
+++ b/services/gundeck/Makefile
@@ -1,6 +1,10 @@
 LANG := en_US.UTF-8
 SHELL         := /usr/bin/env bash
 NAME          := gundeck
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 VERSION       ?=
 BUILD_NUMBER  ?= 0
 BUILD_LABEL   ?= local
@@ -27,28 +31,24 @@ default: fast
 
 .PHONY: init
 init:
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 
 .PHONY: install
 install: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
-	cp "$(shell stack path --dist-dir)/build/$(NAME)-tests/$(NAME)-tests" ../../dist/
-	cp "$(shell stack path --dist-dir)/build/$(NAME)-bench/$(NAME)-bench" ../../dist/
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: fast
 fast: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist --fast $(WIRE_STACK_OPTIONS)
-	cp "$(shell stack path --dist-dir)/build/$(NAME)-tests/$(NAME)-tests" ../../dist/
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY: compile
 compile:
-	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
+	stack build . $(STACK_OPTIONS) --no-copy-bins $(WIRE_STACK_OPTIONS)
 
 .PHONY: clean
 clean:
-	stack clean $(NAME)
-	-rm -rf dist
-	-rm -f .metadata
+	stack clean . $(STACK_OPTIONS)
+	rm -f .metadata
 
 .PHONY: dist
 dist: guard-VERSION install $(DEB) $(DEB_IT) $(DEB_SCHEMA) .metadata
@@ -137,7 +137,7 @@ docker:
 
 .PHONY: time
 time: clean
-	-rm -f .stack-work/logs/*
-	stack build . --pedantic --no-run-benchmarks --no-copy-bins --ghc-options="-j +RTS -s -RTS"
+	rm -f $(shell stack path --project-root)/.stack-work/logs/*
+	stack build . $(STACK_OPTIONS) --no-copy-bins --ghc-options="-j +RTS -s -RTS"
 	@echo -e "\nTotal wall-clock times taken to compile each module (see logs for more detail):"
 	@grep Total .stack-work/logs/* | tr -s ' ' | awk -F' ' '{gsub(/s$$/, "", $$6); a[$$1] += $$6}END{for (i in a) {m=gensub(/^.*\/logs\//,"",1,i); m=gensub(/-[0-9].*\.log/,"",1,m); print m, a[i] ++ "s"}}' | sort -grk2

--- a/services/nginz/Makefile
+++ b/services/nginz/Makefile
@@ -66,11 +66,11 @@ default: compile
 
 .PHONY: clean
 clean:
-	-rm -rf src $(DIST) .metadata zwagger-ui/swagger-ui
+	rm -rf src $(DIST) .metadata zwagger-ui/swagger-ui
 
 .PHONY: compile
 compile: $(BIN)
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 	cp src/objs/nginx ../../dist/
 
 .PHONY: dist

--- a/services/proxy/Makefile
+++ b/services/proxy/Makefile
@@ -1,6 +1,10 @@
 LANG := en_US.UTF-8
 SHELL        := /usr/bin/env bash
 NAME         := proxy
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 VERSION      ?=
 BUILD_NUMBER ?= 0
 BUILD_LABEL  ?= local
@@ -21,25 +25,24 @@ default: fast
 all: clean install
 
 init:
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 
 .PHONY: clean
 clean:
-	stack clean $(NAME)
-	-rm -rf dist
-	-rm -f .metadata
+	stack clean . $(STACK_OPTIONS)
+	rm -f .metadata
 
 .PHONY: install
 install: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: fast
 fast: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist --fast $(WIRE_STACK_OPTIONS)
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY:
 compile:
-	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
+	stack build . $(STACK_OPTIONS) --no-copy-bins $(WIRE_STACK_OPTIONS)
 
 .PHONY: dist
 dist: guard-VERSION install $(DEB) $(DEB_IT) .metadata
@@ -68,7 +71,7 @@ docker:
 
 .PHONY: time
 time: clean
-	-rm -f .stack-work/logs/*
-	stack build . --pedantic --no-run-benchmarks --no-copy-bins --ghc-options="-j +RTS -s -RTS"
+	rm -f $(shell stack path --project-root)/.stack-work/logs/*
+	stack build . $(STACK_OPTIONS) --no-copy-bins --ghc-options="-j +RTS -s -RTS"
 	@echo -e "\nTotal wall-clock times taken to compile each module (see logs for more detail):"
 	@grep Total .stack-work/logs/* | tr -s ' ' | awk -F' ' '{gsub(/s$$/, "", $$6); a[$$1] += $$6}END{for (i in a) {m=gensub(/^.*\/logs\//,"",1,i); m=gensub(/-[0-9].*\.log/,"",1,m); print m, a[i] ++ "s"}}' | sort -grk2

--- a/services/spar/Makefile
+++ b/services/spar/Makefile
@@ -1,6 +1,10 @@
 LANG := en_US.UTF-8
 SHELL         := /usr/bin/env bash
 NAME          := spar
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 VERSION       ?=
 BUILD_NUMBER  ?= 0
 BUILD_LABEL   ?= local
@@ -22,24 +26,24 @@ guard-%:
 default: fast
 
 init:
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 
 .PHONY: install
 install: init
-	stack install --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist spar
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: fast
 fast: init
-	stack install --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist --fast $(WIRE_STACK_OPTIONS) spar
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY: clean
 clean:
-	stack clean $(NAME)
+	stack clean . $(STACK_OPTIONS)
 	rm -f .metadata
 
 .PHONY: compile
 compile:
-	stack build --fast --test --bench --no-run-benchmarks --no-copy-bins spar
+	stack build . $(STACK_OPTIONS) --no-copy-bins $(WIRE_STACK_OPTIONS)
 
 .PHONY: dist
 dist: guard-VERSION install $(DEB) $(DEB_SCHEMA) .metadata
@@ -112,7 +116,7 @@ docker:
 
 .PHONY: time
 time: clean
-	-rm -f .stack-work/logs/*
-	stack build --pedantic --no-run-benchmarks --no-copy-bins --ghc-options="-j +RTS -s -RTS"
+	rm -f $(shell stack path --project-root)/.stack-work/logs/*
+	stack build $(STACK_OPTIONS) --no-copy-bins --ghc-options="-j +RTS -s -RTS"
 	@echo -e "\nTotal wall-clock times taken to compile each module (see logs for more detail):"
 	@grep Total .stack-work/logs/* | tr -s ' ' | awk -F' ' '{gsub(/s$$/, "", $$6); a[$$1] += $$6}END{for (i in a) {m=gensub(/^.*\/logs\//,"",1,i); m=gensub(/-[0-9].*\.log/,"",1,m); print m, a[i] ++ "s"}}' | sort -grk2

--- a/tools/api-simulations/Makefile
+++ b/tools/api-simulations/Makefile
@@ -1,6 +1,10 @@
 LANG := en_US.UTF-8
 SHELL        := /usr/bin/env bash
 NAME         := api-simulations
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 VERSION      ?=
 BUILD_NUMBER ?= 0
 BUILD_LABEL  ?= local
@@ -18,25 +22,24 @@ default: fast
 all: clean install
 
 init:
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 
 .PHONY: clean
 clean:
-	stack clean api-simulations
-	-rm -rf dist
-	-rm -f .metadata
+	stack clean . $(STACK_OPTIONS)
+	rm -f .metadata
 
 .PHONY: fast
 fast: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist --fast $(WIRE_STACK_OPTIONS)
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY:
 compile:
-	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
+	stack build . $(STACK_OPTIONS) --no-copy-bins $(WIRE_STACK_OPTIONS)
 
 .PHONY: install
 install: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: dist
 dist: guard-VERSION install $(DEB) .metadata

--- a/tools/bonanza/Makefile
+++ b/tools/bonanza/Makefile
@@ -1,6 +1,10 @@
 LANG := en_US.UTF-8
 SHELL        := /usr/bin/env bash
 NAME         := bonanza
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 VERSION      ?=
 BUILD_NUMBER ?= 0
 DEB          := dist/$(NAME)_$(VERSION)+$(BUILD_NUMBER)_amd64.deb
@@ -16,21 +20,19 @@ default: all
 all: clean install
 
 init:
-	mkdir -p dist
 	mkdir -p ../../dist
 
 .PHONY: clean
 clean:
-	stack clean bonanza
-	-rm -rf dist
+	stack clean . $(STACK_OPTIONS)
 
 .PHONY: install
 install: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: compile
 compile:
-	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins --fast $(WIRE_STACK_OPTIONS)
+	stack build . $(STACK_OPTIONS) --no-copy-bins --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY: dist
 dist: guard-VERSION $(DEB)

--- a/tools/db/auto-whitelist/Makefile
+++ b/tools/db/auto-whitelist/Makefile
@@ -1,5 +1,9 @@
 LANG := en_US.UTF-8
 
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 SHELL := /usr/bin/env bash
 
 default: all
@@ -8,20 +12,20 @@ all: clean install
 
 .PHONY: init
 init:
-	mkdir -p dist
+	mkdir -p ../../../dist
 
 .PHONY: clean
 clean:
-	stack clean
+	stack clean . $(STACK_OPTIONS)
 
 .PHONY: compile
 compile:
-	stack build
+	stack build . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: install
 install: init
-	stack install --pedantic --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: fast
 fast: init
-	stack install --fast --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)

--- a/tools/db/migrate-sso-feature-flag/Makefile
+++ b/tools/db/migrate-sso-feature-flag/Makefile
@@ -1,6 +1,10 @@
 LANG := en_US.UTF-8
 
 SHELL := /usr/bin/env bash
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 
 default: all
 
@@ -8,20 +12,20 @@ all: install
 
 .PHONY: init
 init:
-	mkdir -p dist
+	mkdir -p ../../../dist
 
 .PHONY: clean
 clean:
-	stack clean
+	stack clean . $(STACK_OPTIONS)
 
 .PHONY: compile
 compile:
-	stack build
+	stack build . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: install
 install: init
-	stack install --pedantic --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: fast
 fast: init
-	stack install --fast --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)

--- a/tools/db/service-backfill/Makefile
+++ b/tools/db/service-backfill/Makefile
@@ -1,5 +1,9 @@
 LANG := en_US.UTF-8
 
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 SHELL := /usr/bin/env bash
 
 default: all
@@ -8,20 +12,20 @@ all: install
 
 .PHONY: init
 init:
-	mkdir -p dist
+	mkdir -p ../../../dist
 
 .PHONY: clean
 clean:
-	stack clean
+	stack clean . $(STACK_OPTIONS)
 
 .PHONY: compile
 compile:
-	stack build
+	stack build . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: install
 install: init
-	stack install --pedantic --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: fast
 fast: init
-	stack install --fast --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)

--- a/tools/makedeb/Makefile
+++ b/tools/makedeb/Makefile
@@ -1,6 +1,10 @@
 LANG := en_US.UTF-8
 SHELL        := /usr/bin/env bash
 NAME         := makedeb
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 VERSION      ?=
 ARCH  	     := $(shell if [ -f "`which dpkg-architecture`" ]; then dpkg-architecture -qDEB_HOST_ARCH; else [ -f "`which dpkg`" ] && dpkg --print-architecture; fi )
 BUILD_NUMBER ?= 0
@@ -19,22 +23,20 @@ default: all
 all: clean install
 
 init:
-	mkdir -p dist
 	mkdir -p ../../dist
 
 .PHONY: clean
 clean:
-	stack clean makedeb
-	-rm -rf dist
-	-rm -f .metadata
+	stack clean . $(STACK_OPTIONS)
+	rm -f .metadata
 
 .PHONY: install
 install: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: compile
 compile:
-	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
+	stack build . $(STACK_OPTIONS) --no-copy-bins $(WIRE_STACK_OPTIONS)
 
 .PHONY: dist
 dist: guard-VERSION install $(DEB) .metadata

--- a/tools/stern/Makefile
+++ b/tools/stern/Makefile
@@ -1,6 +1,10 @@
 LANG         := en_US.UTF-8
 SHELL        := /usr/bin/env bash
 NAME         := stern
+# STACK_OPTIONS are the options used for most stack calls in this
+# Makefile; WIRE_STACK_OPTIONS is the place for the user to override
+# things.
+STACK_OPTIONS := --pedantic --test --bench --no-run-benchmarks --local-bin-path=$(shell stack path --project-root)/dist
 VERSION      ?=
 BUILD_NUMBER ?= 0
 BUILD_LABEL  ?= local
@@ -21,25 +25,24 @@ default: fast
 all: clean install
 
 init:
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 
 .PHONY: clean
 clean:
-	stack clean $(NAME)
-	-rm -rf dist
-	-rm -f .metadata
+	stack clean . $(STACK_OPTIONS)
+	rm -f .metadata
 
 .PHONY: install
 install: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
+	stack install . $(STACK_OPTIONS) $(WIRE_STACK_OPTIONS)
 
 .PHONY: fast
 fast: init
-	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist --fast $(WIRE_STACK_OPTIONS)
+	stack install . $(STACK_OPTIONS) --fast $(WIRE_STACK_OPTIONS)
 
 .PHONY:
 compile:
-	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
+	stack build . $(STACK_OPTIONS) --no-copy-bins $(WIRE_STACK_OPTIONS)
 
 .PHONY: dist
 dist: guard-VERSION install $(DEB) $(DEB_IT) .metadata
@@ -68,7 +71,7 @@ docker:
 
 .PHONY: time
 time: clean
-	-rm -f .stack-work/logs/*
-	stack build . --pedantic --no-run-benchmarks --no-copy-bins --ghc-options="-j +RTS -s -RTS"
+	rm -f $(shell stack path --project-root)/.stack-work/logs/*
+	stack build . $(STACK_OPTIONS) --no-copy-bins --ghc-options="-j +RTS -s -RTS"
 	@echo -e "\nTotal wall-clock times taken to compile each module (see logs for more detail):"
 	@grep Total .stack-work/logs/* | tr -s ' ' | awk -F' ' '{gsub(/s$$/, "", $$6); a[$$1] += $$6}END{for (i in a) {m=gensub(/^.*\/logs\//,"",1,i); m=gensub(/-[0-9].*\.log/,"",1,m); print m, a[i] ++ "s"}}' | sort -grk2


### PR DESCRIPTION
- install executables into project-root/dist right away
- do not copy it to project root only *sometimes* (fixes https://github.com/wireapp/wire-server/issues/821)
- extract common stack arguments into makefile-local shell variable
- pass $WIRE_STACK_OPTIONS everywhere where applicable
- keep $WIRE_STACK_OPTIONS intact in haddock goals
- `compile` goal in brig, spar: drop the unexpected `--fast` (everybody else doesn't have it).
- make sure calls to stack in sub-Makefiles do not build the entire project (add the `.` argument to build).

after merging this and if you like tidy working copies, you can run:

```shell
cd `stack path --project-root`
mv .stack-work .stack-work-backup
find . -name dist -exec rm -rf {} \;
find . -name .stack-work -exec rm -rf {} \;
mv .stack-work-backup .stack-work
```

after that, you shouldn't see any of those folders in the sub-directories any more.