### PR TITLE
Specialize the error cases on conversation lookup.

### DIFF
--- a/services/brig/test/integration/API/User/Connection.hs
+++ b/services/brig/test/integration/API/User/Connection.hs
@@ -163,10 +163,10 @@ testCancelConnection2 brig galley = do
 
     -- A cannot see the conversation (due to cancelling)
     getConversation galley uid1 cnv !!! do
-        const 404 === statusCode
+        const 403 === statusCode
 
     -- B cannot see the conversation
-    getConversation galley uid2 cnv !!! const 404 === statusCode
+    getConversation galley uid2 cnv !!! const 403 === statusCode
 
     -- B initiates a connection request himself
     postConnection brig uid2 uid1 !!! const 200 === statusCode
@@ -182,7 +182,7 @@ testCancelConnection2 brig galley = do
 
     -- A is a past member, cannot see the conversation
     getConversation galley uid1 cnv !!! do
-        const 404 === statusCode
+        const 403 === statusCode
 
     -- A finally accepts
     putConnection brig uid1 uid2 Accepted !!! const 200 === statusCode
@@ -270,7 +270,7 @@ testBlockAndResendConnection brig galley = do
 
     -- B never accepted and thus does not see the conversation
     let Just cnv = ucConvId =<< decodeBody rsp
-    getConversation galley uid2 cnv !!! const 404 === statusCode
+    getConversation galley uid2 cnv !!! const 403 === statusCode
 
     -- A can see the conversation and is a current member
     getConversation galley uid1 cnv !!! do

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -360,6 +360,7 @@ sitemap = do
         parameter Path "cnv" bytes' $
             description "Conversation ID"
         errorResponse Error.convNotFound
+        errorResponse Error.convAccessDenied
 
     ---
 

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -44,7 +44,7 @@ getConversation (zusr ::: cnv ::: _) = do
         Data.deleteConversation cnv
         throwM convNotFound
     unless (zusr `isMember` Data.convMembers c) $
-        throwM convNotFound
+        throwM convAccessDenied
     a <- conversationView zusr c
     return $ json a
 


### PR DESCRIPTION
Fixes https://github.com/wearezeta/backend-issues/issues/870

@tiago-loureiro writes:

> Currently there is no distinction between "there is no conversation with id X" and "you are not a member of the conversation".
> 
> This creates a problem now that we will effectively add "conversation deletion" on the UI and clients need to distinguish between the 2 (i.e., was I kicked or did the conversation get deleted). This is particularly important for new devices or when missing a lot of notifications (note that when deleting conversations clients must delete this locally too but not when getting kicked/leaving conversations).

This PR changes the behavior to return two errors for these two cases:

```haskell
Error status404 "no-conversation" "conversation not found"
Error status403 "access-denied" "Conversation access denied"
```