### PR TITLE
Cleanup stern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 2019-09-16 #858
+
+## Relevant for self-hosters
+
+- Documentation changes for Twilio configurations and TURN setup. (#775)
+
+## Relevant for client developers
+
+- Better events for deletion of team conversations (also send `conversation.delete` to team members) (#849)
+- Add a new type of authorization tokens for legalhold (for details on legalhold, see https://github.com/wireapp/wire-server/blob/develop/docs/reference/team/legalhold.md) (#761)
+
+## Bug fixes
+
+- Fix swagger docs. (#852)
+- Fix intra call in stern (aka customer support, aka backoffice) (#844)
+
+## Internal Changes
+
+- Change feature flags from boolean to custom enum types. (#850)
+- Fix flaky integration test. (#848)
+- Cleanup: incoherent functions for response body parsing. (#847)
+- add route for consistency (#851)
+
+
 # 2019-09-03 #843
 
 ## Relevant for self-hosters

--- a/deploy/services-demo/README.md
+++ b/deploy/services-demo/README.md
@@ -75,16 +75,24 @@ If you wish to send verification SMS/calls (to support registration using phone 
 
 Note: This demo setup comes bundled with a postfix email sending docker image; however due to the minimal setup, emails will likely land in the Spam/Junk folder of the target email address, if you configure a common email provider. To get the smoketester to check the Spam folder as well, use e.g. (in the case of gmail) `--mailbox-folder INBOX --mailbox-folder '[Gmail]/Spam'`.
 
-Example:
+Configure an email inbox for the smoketester:
 
 ```
-# from the wire-server directory, after having compiled everything with 'make install'
+# from the root of wire-server directory
+cp tools/api-simulations/mailboxes.example.json mailboxes.json
+```
+
+Now adjust `mailboxes.json` and use credentials for an email account you own.
+
+Next, from the wire-server directory, after having compiled everything with 'make install':
+
+```bash
 ./dist/api-smoketest \
     --api-host=127.0.0.1 \
     --api-port=8080 \
     --api-websocket-host=127.0.0.1 \
     --api-websocket-port=8081 \
-    --mailbox-config=<path_to_mailboxes_file> \
+    --mailbox-config=mailboxes.json \
     --sender-email=backend-demo@mail.wiredemo.example.com \
     --mailbox-folder INBOX \
     --mailbox-folder '[Gmail]/Spam' \

--- a/deploy/services-demo/conf/nginz/zauth_acl.txt
+++ b/deploy/services-demo/conf/nginz/zauth_acl.txt
@@ -13,4 +13,5 @@ p (whitelist (path "/provider")
 # LegalHold Access Tokens
 la (whitelist (path "/notifications")
               (path "/assets/v3/**")
+              (path "/users")
               (path "/users/**"))

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -1,0 +1,50 @@
+# Config Options {#RefConfigOptions}
+
+Fragment.
+
+This page is about the yaml files that determine the configuration of
+the Wire backend services.
+
+
+## Feature flags
+
+Feature flags can be used to turn features on or off, or determine the
+behavior of the features.  Example:
+
+```
+# [galley.yaml]
+settings:
+  featureFlags:
+    sso: disabled-by-default
+    legalhold: disabled-by-default
+```
+
+The `featureFlags` field in the galley settings is mandatory, and all
+features must be listed.  Each feature defines its own set of allowed
+flag values.  (The reason for that is that as we will see, the
+semantics is slightly different (or more specific) than boolean.)
+
+### SSO
+
+This sets the default setting for all teams, and can be overridden by
+customer support / backoffice.  [Allowed
+values](https://github.com/wireapp/wire-server/blob/46713382a1a6544de3936eb03e987b9f76df3faa/libs/galley-types/src/Galley/Types/Teams.hs#L327-L329):
+`disabled-by-default`, `enabled-by-default`.
+
+IMPORTANT: if you change this from 'enabled-by-default' to
+'disabled-by-default' in production, you need to run [this migration
+script](https://github.com/wireapp/wire-server/tree/master/tools/db/migrate-sso-feature-flag)
+to fix all teams that have registered an idp.  (if you don't, the idp
+will keep working, but the admin won't be able to register new idps.)
+
+### LegalHold
+
+Optionally block customer support / backoffice from enabling legal
+hold for individual teams.  [Allowed
+values](https://github.com/wireapp/wire-server/blob/46713382a1a6544de3936eb03e987b9f76df3faa/libs/galley-types/src/Galley/Types/Teams.hs#L332-L334):
+'disabled-permanently', 'disabled-by-default'.
+
+IMPORTANT: If you switch this back to `disabled-permanently` from
+`disabled-by-default`, LegalHold devices may still be active in teams
+that have created them while it was allowed.  This may change in the
+future.

--- a/libs/bilge/src/Bilge/Request.hs
+++ b/libs/bilge/src/Bilge/Request.hs
@@ -28,7 +28,7 @@ module Bilge.Request
     , showRequest
     , noRedirect
     , timeout
-    , expect2xx, expect3xx, expect4xx
+    , expect2xx, expect3xx, expect4xx, expectStatus
     , checkStatus
     , cookie
     , cookieRaw

--- a/libs/brig-types/test/unit/Test/Brig/Types/Common.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Common.hs
@@ -85,8 +85,6 @@ instance Arbitrary SSOTeamConfig where
   arbitrary = SSOTeamConfig <$> arbitrary
 
 instance Arbitrary FeatureFlags where
-  arbitrary = FeatureFlags <$> arbitrary
-  shrink (FeatureFlags ls) = FeatureFlags <$> shrink ls
-
-instance Arbitrary FeatureFlag where
-  arbitrary = Test.Tasty.QuickCheck.elements [minBound..]
+  arbitrary = FeatureFlags
+      <$> Test.Tasty.QuickCheck.elements [minBound..]
+      <*> Test.Tasty.QuickCheck.elements [minBound..]

--- a/libs/galley-types/package.yaml
+++ b/libs/galley-types/package.yaml
@@ -27,6 +27,7 @@ library:
   - exceptions >=0.10.0
   - lens >=4.12
   - protobuf >=0.2
+  - string-conversions
   - swagger >=0.1
   - text >=0.11
   - time >=1.4

--- a/mailboxes.json
+++ b/mailboxes.json
@@ -1,0 +1,7 @@
+[
+    { "host": "imap.bar.com"
+    , "user": "foo@bar.com"
+    , "pass": "secret"
+    , "conn": 1
+    }
+]

--- a/mailboxes.json
+++ b/mailboxes.json
@@ -1,7 +1,0 @@
-[
-    { "host": "imap.bar.com"
-    , "user": "foo@bar.com"
-    , "pass": "secret"
-    , "conn": 1
-    }
-]

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -214,7 +214,7 @@ sitemap o = do
 
     document "HEAD" "userExists" $ do
         Doc.summary "Check if a user ID exists"
-        Doc.parameter Doc.Path "id" Doc.bytes' $
+        Doc.parameter Doc.Path "uid" Doc.bytes' $
             Doc.description "User ID"
         Doc.response 200 "User exists" Doc.end
         Doc.errorResponse userNotFound
@@ -228,7 +228,7 @@ sitemap o = do
 
     document "GET" "user" $ do
         Doc.summary "Get a user by ID"
-        Doc.parameter Doc.Path "id" Doc.bytes' $
+        Doc.parameter Doc.Path "uid" Doc.bytes' $
             Doc.description "User ID"
         Doc.returns (Doc.ref Doc.user)
         Doc.response 200 "User" Doc.end
@@ -317,7 +317,7 @@ sitemap o = do
 
     document "GET" "getPrekeyBundle" $ do
         Doc.summary "Get a prekey for each client of a user."
-        Doc.parameter Doc.Path "user" Doc.bytes' $
+        Doc.parameter Doc.Path "uid" Doc.bytes' $
             Doc.description "User ID"
         Doc.returns (Doc.ref Doc.prekeyBundle)
         Doc.response 200 "Prekey Bundle" Doc.end
@@ -331,7 +331,7 @@ sitemap o = do
 
     document "GET" "getPrekey" $ do
         Doc.summary "Get a prekey for a specific client of a user."
-        Doc.parameter Doc.Path "user" Doc.bytes' $
+        Doc.parameter Doc.Path "uid" Doc.bytes' $
             Doc.description "User ID"
         Doc.parameter Doc.Path "client" Doc.bytes' $
             Doc.description "Client ID"
@@ -346,7 +346,7 @@ sitemap o = do
 
     document "GET" "getUserClients" $ do
         Doc.summary "Get all of a user's clients."
-        Doc.parameter Doc.Path "user" Doc.bytes' $
+        Doc.parameter Doc.Path "uid" Doc.bytes' $
             Doc.description "User ID"
         Doc.returns (Doc.array (Doc.ref Doc.pubClient))
         Doc.response 200 "List of clients" Doc.end
@@ -360,7 +360,7 @@ sitemap o = do
 
     document "GET" "getUserClient" $ do
         Doc.summary "Get a specific client of a user."
-        Doc.parameter Doc.Path "user" Doc.bytes' $
+        Doc.parameter Doc.Path "uid" Doc.bytes' $
             Doc.description "User ID"
         Doc.parameter Doc.Path "client" Doc.bytes' $
             Doc.description "Client ID"
@@ -376,7 +376,7 @@ sitemap o = do
 
     document "GET" "getRichInfo" $ do
         Doc.summary "Get user's rich info"
-        Doc.parameter Doc.Path "user" Doc.bytes' $
+        Doc.parameter Doc.Path "uid" Doc.bytes' $
             Doc.description "User ID"
         Doc.returns (Doc.ref Doc.richInfo)
         Doc.response 200 "RichInfo" Doc.end

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -26,24 +26,9 @@ settings:
   maxConvSize: 16
   intraListing: false
   conversationCodeURI: https://app.wire.com/join/
-  featureFlags:
-    # SSO: this sets the default setting for each time, which can
-    # always be overridden by customer support / backoffice.
-    # IMPORTANT: if you change sso from 'enabled' to 'disabled' after
-    # running 'enabled' in production, you need to run this migration
-    # script to fix all teams that have registered an idp:
-    # https://github.com/wireapp/wire-server/tree/master/tools/db/migrate-sso-feature-flag
-    # if you don't, the idp will keep working, but the admin won't be
-    # able to register new idps.
-    # disabled for integration tests (the ones who need it on will
-    # turn it on themselves).
-    sso: false
-
-    # Legal Hold: this decides whether customer support / backoffice
-    # is allowed to turn the feature on for individual teams.  the
-    # default for new teams is always "false", no matter what the
-    # feature flag is set to.
-    legalhold: true
+  featureFlags:  # see #RefConfigOptions in `/docs/reference`
+    sso: disabled-by-default
+    legalhold: disabled-by-default
 
 logLevel: Info
 logNetStrings: false

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -67,7 +67,7 @@ sitemap = do
 
     document "PUT" "updateTeam" $ do
         summary "Update team properties"
-        parameter Path "id" bytes' $
+        parameter Path "tid" bytes' $
             description "Team ID"
         body (ref TeamsModel.update) $
             description "JSON body"
@@ -96,7 +96,7 @@ sitemap = do
 
     document "GET" "getTeam" $ do
         summary "Get a team by ID"
-        parameter Path "id" bytes' $
+        parameter Path "tid" bytes' $
             description "Team ID"
         returns (ref TeamsModel.team)
         response 200 "Team data" end
@@ -114,7 +114,7 @@ sitemap = do
 
     document "DELETE" "deleteTeam" $ do
         summary "Delete a team"
-        parameter Path "id" bytes' $
+        parameter Path "tid" bytes' $
             description "Team ID"
         body (ref TeamsModel.teamDelete) $ do
             optional
@@ -135,7 +135,7 @@ sitemap = do
 
     document "GET" "getTeamMembers" $ do
         summary "Get team members"
-        parameter Path "id" bytes' $
+        parameter Path "tid" bytes' $
             description "Team ID"
         returns (ref TeamsModel.teamMemberList)
         response 200 "Team members" end
@@ -171,7 +171,7 @@ sitemap = do
 
     document "POST" "addTeamMember" $ do
         summary "Add a new team member"
-        parameter Path "id" bytes' $
+        parameter Path "tid" bytes' $
             description "Team ID"
         body (ref TeamsModel.newTeamMember) $
             description "JSON body"
@@ -216,7 +216,7 @@ sitemap = do
 
     document "PUT" "updateTeamMember" $ do
         summary "Update an existing team member"
-        parameter Path "id" bytes' $
+        parameter Path "tid" bytes' $
             description "Team ID"
         body (ref TeamsModel.newTeamMember) $
             description "JSON body"
@@ -233,7 +233,7 @@ sitemap = do
 
     document "GET" "getTeamConversations" $ do
         summary "Get team conversations"
-        parameter Path "id" bytes' $
+        parameter Path "tid" bytes' $
             description "Team ID"
         returns (ref TeamsModel.teamConversationList)
         response 200 "Team conversations" end

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -532,18 +532,18 @@ getLegalholdStatus (uid ::: tid ::: ct) = do
 -- | Get SSO status for a team.
 getSSOStatusInternal :: TeamId ::: JSON -> Galley Response
 getSSOStatusInternal (tid ::: _) = do
-    defConfig <- do
+    defConfig :: SSOTeamConfig <- do
         featureSSO <- view (options . optSettings . featureEnabled FeatureSSO)
         pure $ if featureSSO
             then SSOTeamConfig SSOEnabled
             else SSOTeamConfig SSODisabled
-    ssoTeamConfig <- SSOData.getSSOTeamConfig tid
+    ssoTeamConfig :: Maybe SSOTeamConfig <- SSOData.getSSOTeamConfig tid
     pure . json . fromMaybe defConfig $ ssoTeamConfig
 
 -- | Enable or disable SSO for a team.
 setSSOStatusInternal :: TeamId ::: JsonRequest SSOTeamConfig ::: JSON -> Galley Response
 setSSOStatusInternal (tid ::: req ::: _) = do
-    ssoTeamConfig <- fromJsonBody req
+    ssoTeamConfig :: SSOTeamConfig <- fromJsonBody req
     case ssoTeamConfigStatus ssoTeamConfig of
         SSODisabled -> throwM disableSsoNotImplemented
         SSOEnabled  -> pure () -- this one is easy to implement :)

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -7,7 +7,7 @@ import Util.Options
 import Util.Options.Common
 import System.Logger.Extended (Level, LogFormat)
 import Data.Misc
-import Galley.Types.Teams (FeatureFlags(..), FeatureFlag)
+import Galley.Types.Teams (FeatureFlags(..))
 
 data Settings = Settings
     {
@@ -21,18 +21,11 @@ data Settings = Settings
     , _setIntraListing          :: !Bool
     -- | URI prefix for conversations with access mode @code@
     , _setConversationCodeURI   :: !HttpsUrl
-    , _setFeatureFlags          :: !(Maybe FeatureFlags)
+    , _setFeatureFlags          :: !FeatureFlags
     } deriving (Show, Generic)
 
 deriveFromJSON toOptionFieldName ''Settings
 makeLenses ''Settings
-
-featureEnabled :: FeatureFlag -> Getter Settings Bool
-featureEnabled flag
-    = setFeatureFlags
-    . to (\case
-             Nothing -> False
-             Just (FeatureFlags flags) -> flag `elem` flags)
 
 data JournalOpts = JournalOpts
     { _awsQueueName :: !Text         -- ^ SQS queue name to send team events

--- a/services/restund/README.md
+++ b/services/restund/README.md
@@ -66,30 +66,38 @@ Makefile.
 
 ## Running restund on a server
 
-You need a restund config and pem file (for the following assumed to be under /etc/restund), and can then run the aci image with rkt.
+You need
 
-A config file could look like the following (with the ansible-style variables filled in accordingly):
+* the aci image built in the section above, or, alternatively, a natively compiled `restund` binary with all the shared libraries available.
+* an adapted restund config (see below)
+* (optionally) a TLS certificate chain in PEM format, including the private key
 
-```
+Example config file:
+
+```conf
+# /etc/restund/restund.conf
+
 # core
 daemon                  no
 debug                   no
 realm                   dummy.io
 syncinterval            600
-udp_listen              {{ ansible_default_ipv4.address }}:{{ restund_udp_listen_port }}
+udp_listen              {{ ansible_default_ipv4.address }}:3478
 udp_sockbuf_size        524288
-tcp_listen              {{ ansible_default_ipv4.address }}:{{ restund_tcp_listen_port }}
-tls_listen              {{ ansible_default_ipv4.address }}:{{ restund_tls_listen_port }},/usr/local/etc/restund/restund.pem
+tcp_listen              {{ ansible_default_ipv4.address }}:3478
+# tls_listen is optional, you can comment that line out. If set, you must provide a valid TLS certificate for the domain name you're advertising.
+# tls_listen              {{ ansible_default_ipv4.address }}:5349,/usr/local/etc/restund/restund.pem
 
 # modules
 module_path             /usr/local/lib/restund/modules
 module                  stat.so
 module                  drain.so
 module                  binding.so
-module                  auth.so
 module                  turn.so
-module                  zrest.so
 module                  status.so
+# The auth and zrest modules are optional. If enabled, ensure the zrest_secret below is set to a value shared with the configuration in brig.
+module                  zrest.so
+module                  auth.so
 
 # auth
 auth_nonce_expiry       3600
@@ -98,24 +106,40 @@ auth_nonce_expiry       3600
 turn_max_allocations    64000
 turn_max_lifetime       3600
 turn_relay_addr         {{ ansible_default_ipv4.address }}
-{% if ansible_default_ipv4.address != public_ipv4 %}
-turn_public_addr        {{ public_ipv4 }}
-{% endif %}
+
+# You generally don't need to set this (only if your server is on a private network and must be reachable from other restund servers that are on another network):
+# turn_public_addr is an IP which must be reachable for UDP traffic from other restund servers (and from this server itself). If unset, defaults to 'turn_relay_addr'
+#turn_public_addr        {{ public_ipv4 }}
 
 # syslog
 syslog_facility         24
 
 # status
 status_udp_addr         127.0.0.1
-status_udp_port         {{ restund_udp_status_port }}
+status_udp_port         33000
 status_http_addr        127.0.0.1
-status_http_port        {{ restund_http_status_port }}
+status_http_port        8080
 
-# zrest (shared secret shared with brig)
+# zrest (shared secret shared with brig, optional)
 zrest_secret            {{ restund_zrest_secret }}
 ```
 
-Example rkt command:
+Adjust the above configuration:
+
+* Replace the `{{ variables }}` with real values (without `{{`)):
+    * Put your private IP of the server in place of: `{{ ansible_default_ipv4.address }}`.
+* You may comment these out in case you don't want to use authentication:
+```
+module                  zrest.so
+module                  auth.so
+zrest_secret            {{ restund_zrest_secret }}
+```
+
+Next, list out TURN IP and port in `deploy/services-demo/resources/turn/servers.txt`, and `deploy/services-demo/resources/turn/servers-v2.txt`, as given below:
+`turn:<private-ip>:3478`
+Then run the command restund command and you'll get the live stun log in your terminal.
+
+Running restund with `rkt`:
 
 ```
 /usr/bin/rkt run \
@@ -127,17 +151,3 @@ Example rkt command:
     --user=restund \
     --group=restund
 ```
-
-In case You have set up restund without docker, you just need to make some of these changes:
-
-Put your private IP of the server in place of: `{{ ansible_default_ipv4.address }}`. And replace restund listen ports with `3478`, for both UDP and TCP.
-
-You may comment these out in case you don't want to use:
-```
-module                  zrest.so
-module                  auth.so
-zrest_secret            {{ restund_zrest_secret }}
-```
-It'll help in running the TURN server without interuption or further configuration for testing purpose. List out TURN IP and port in `deploy/services-demo/resources/turn/servers.txt`, and `deploy/services-demo/resources/turn/servers-v2.txt`, as given below:
-`turn:<private-ip>:3478`
-Then run the command restund command and You'll get the live stun log in your terminal.

--- a/services/restund/README.md
+++ b/services/restund/README.md
@@ -127,3 +127,17 @@ Example rkt command:
     --user=restund \
     --group=restund
 ```
+
+In case You have set up restund without docker, you just need to make some of these changes:
+
+Put your private IP of the server in place of: `{{ ansible_default_ipv4.address }}`. And replace restund listen ports with `3478`, for both UDP and TCP.
+
+You may comment these out in case you don't want to use:
+```
+module                  zrest.so
+module                  auth.so
+zrest_secret            {{ restund_zrest_secret }}
+```
+It'll help in running the TURN server without interuption or further configuration for testing purpose. List out TURN IP and port in `deploy/services-demo/resources/turn/servers.txt`, and `deploy/services-demo/resources/turn/servers-v2.txt`, as given below:
+`turn:<private-ip>:3478`
+Then run the command restund command and You'll get the live stun log in your terminal.

--- a/tools/stern/package.yaml
+++ b/tools/stern/package.yaml
@@ -42,7 +42,6 @@ library:
   - semigroups                >= 0.16
   - split                     >= 0.2
   - swagger                   >= 0.3
-  - tagged
   - text                      >= 1.1
   - text-format               >= 0.3
   - time                      >= 1.4

--- a/tools/stern/package.yaml
+++ b/tools/stern/package.yaml
@@ -42,6 +42,7 @@ library:
   - semigroups                >= 0.16
   - split                     >= 0.2
   - swagger                   >= 0.3
+  - tagged
   - text                      >= 1.1
   - text-format               >= 0.3
   - time                      >= 1.4

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -11,7 +11,6 @@ import Imports hiding (head)
 
 import Brig.Types
 import Brig.Types.Intra
-import Brig.Types.Team.LegalHold (LegalHoldStatus(..))
 import Control.Applicative ((<|>))
 import Control.Error
 import Control.Lens (view, (^.))
@@ -28,7 +27,6 @@ import Data.Range
 import Data.Swagger.Build.Api hiding (def, min, Response, response)
 import Data.Text.Encoding (decodeLatin1)
 import Data.Text (Text, unpack)
-import Galley.Types.Teams.SSO
 import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Handler.Warp
@@ -304,20 +302,20 @@ sitemap = do
         summary "Shows whether legalhold feature is enabled for team"
         Doc.parameter Doc.Path "tid" Doc.bytes' $
             description "Team ID"
-        Doc.returns Doc.docLegalHoldStatus
+        Doc.returns Doc.docSetLegalHoldStatus
         Doc.response 200 "Legalhold status" Doc.end
         Doc.returns Doc.bool'
 
     put "/teams/:tid/features/legalhold" (continue setLegalholdStatus) $
         contentType "application" "json"
         .&. capture "tid"
-        .&. jsonRequest @LegalHoldStatus
+        .&. jsonRequest @SetLegalHoldStatus
 
     document "PUT" "setLegalholdStatus" $ do
         summary "Disable / enable legalhold feature for team"
         Doc.parameter Doc.Path "tid" Doc.bytes' $
             description "Team ID"
-        Doc.body Doc.docLegalHoldStatus $
+        Doc.body Doc.docSetLegalHoldStatus $
             Doc.description "JSON body"
         Doc.response 200 "Legalhold status" Doc.end
 
@@ -328,19 +326,19 @@ sitemap = do
         summary "Shows whether SSO feature is enabled for team"
         Doc.parameter Doc.Path "tid" Doc.bytes' $
             description "Team ID"
-        Doc.returns Doc.docSSOStatus
+        Doc.returns Doc.docSetSSOStatus
         Doc.response 200 "SSO status" Doc.end
 
     put "/teams/:tid/features/sso" (continue setSSOStatus) $
         contentType "application" "json"
         .&. capture "tid"
-        .&. jsonRequest @SSOStatus
+        .&. jsonRequest @SetSSOStatus
 
     document "PUT" "setSSOStatus" $ do
         summary "Disable / enable SSO feature for team"
         Doc.parameter Doc.Path "tid" Doc.bytes' $
             description "Team ID"
-        Doc.body Doc.docSSOStatus $
+        Doc.body Doc.docSetSSOStatus $
             Doc.description "JSON body"
         Doc.response 200 "SSO status" Doc.end
 
@@ -536,14 +534,14 @@ getTeamInfo :: TeamId -> Handler Response
 getTeamInfo = liftM json . Intra.getTeamInfo
 
 
-setLegalholdStatus :: JSON ::: TeamId ::: JsonRequest LegalHoldStatus -> Handler Response
+setLegalholdStatus :: JSON ::: TeamId ::: JsonRequest SetLegalHoldStatus -> Handler Response
 setLegalholdStatus (_ ::: tid ::: req) = do
     status <- parseBody req !>> Error status400 "client-error"
     liftM json $ Intra.setLegalholdStatus tid status
 
-setSSOStatus :: JSON ::: TeamId ::: JsonRequest SSOStatus -> Handler Response
+setSSOStatus :: JSON ::: TeamId ::: JsonRequest SetSSOStatus -> Handler Response
 setSSOStatus (_ ::: tid ::: req) = do
-    status :: SSOStatus <- parseBody req !>> Error status400 "client-error"
+    status :: SetSSOStatus <- parseBody req !>> Error status400 "client-error"
     liftM json $ Intra.setSSOStatus tid status
 
 getTeamBillingInfo :: TeamId -> Handler Response

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -520,8 +520,8 @@ setLegalholdStatus (_ ::: tid ::: req) = do
 
 setSSOStatus :: JSON ::: TeamId ::: JsonRequest (Tagged "sso" Bool) -> Handler Response
 setSSOStatus (_ ::: tid ::: req) = do
-  status :: Tagged "sso" Bool <- parseBody req !>> Error status400 "client-error"
-  liftM json $ Intra.setSSOStatus tid status
+    status :: Tagged "sso" Bool <- parseBody req !>> Error status400 "client-error"
+    liftM json $ Intra.setSSOStatus tid status
 
 getTeamBillingInfo :: TeamId -> Handler Response
 getTeamBillingInfo tid = do

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -5,8 +5,6 @@
 {-# LANGUAGE ViewPatterns      #-}
 {-# LANGUAGE LambdaCase        #-}
 
-{-# OPTIONS_GHC -Wno-unused-binds #-}
-
 module Stern.API (start) where
 
 import Imports hiding (head)
@@ -298,6 +296,30 @@ sitemap = do
         Doc.response 200 "Team Information" Doc.end
 
     -- feature flags
+
+    get "/teams/:tid/features/legalhold" (continue (liftM json . Intra.getLegalholdStatus)) $
+        capture "tid"
+
+    document "GET" "getLegalholdStatus" $ do
+        summary "Shows whether legalhold feature is enabled for team"
+        Doc.parameter Doc.Path "tid" Doc.bytes' $
+            description "Team ID"
+        Doc.returns Doc.docLegalHoldStatus
+        Doc.response 200 "Legalhold status" Doc.end
+        Doc.returns Doc.bool'
+
+    put "/teams/:tid/features/legalhold" (continue setLegalholdStatus) $
+        contentType "application" "json"
+        .&. capture "tid"
+        .&. jsonRequest @LegalHoldStatus
+
+    document "PUT" "setLegalholdStatus" $ do
+        summary "Disable / enable legalhold feature for team"
+        Doc.parameter Doc.Path "tid" Doc.bytes' $
+            description "Team ID"
+        Doc.body Doc.docLegalHoldStatus $
+            Doc.description "JSON body"
+        Doc.response 200 "Legalhold status" Doc.end
 
     get "/teams/:tid/features/sso" (continue (liftM json . Intra.getSSOStatus)) $
         capture "tid"

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -358,6 +358,7 @@ getLegalholdStatus tid = do
     (>>= fromResponseBody) . catchRpcErrors $ rpc' "galley" gly
          ( method GET
          . paths ["/i/teams", toByteString' tid, "features", "legalhold"]
+         . expect2xx
          )
   where
     fromResponseBody :: Response (Maybe LByteString) -> Handler SetLegalHoldStatus
@@ -375,6 +376,7 @@ setLegalholdStatus tid status = do
          . paths ["/i/teams", toByteString' tid, "features", "legalhold"]
          . lbytes (encode $ toRequestBody status)
          . contentJson
+         . expect2xx
          )
   where
     toRequestBody SetLegalHoldDisabled = LegalHoldTeamConfig LegalHoldDisabled
@@ -387,6 +389,7 @@ getSSOStatus tid = do
     (>>= fromResponseBody) . catchRpcErrors $ rpc' "galley" gly
          ( method GET
          . paths ["/i/teams", toByteString' tid, "features", "sso"]
+         . expect2xx
          )
   where
     fromResponseBody :: Response (Maybe LByteString) -> Handler SetSSOStatus
@@ -404,6 +407,7 @@ setSSOStatus tid status = do
          . paths ["/i/teams", toByteString' tid, "features", "sso"]
          . lbytes (encode $ toRequestBody status)
          . contentJson
+         . expect2xx
          )
   where
     toRequestBody SetSSODisabled = SSOTeamConfig SSODisabled

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -371,13 +371,15 @@ setLegalholdStatus :: TeamId -> SetLegalHoldStatus -> Handler ()
 setLegalholdStatus tid status = do
     info $ msg "Setting legalhold status"
     gly <- view galley
-    void . catchRpcErrors $ rpc' "galley" gly
+    resp <- catchRpcErrors $ rpc' "galley" gly
          ( method PUT
          . paths ["/i/teams", toByteString' tid, "features", "legalhold"]
          . lbytes (encode $ toRequestBody status)
          . contentJson
-         . expect2xx
          )
+    case statusCode resp of
+      204 -> pure ()
+      _   -> throwE $ responseJsonUnsafe resp
   where
     toRequestBody SetLegalHoldDisabled = LegalHoldTeamConfig LegalHoldDisabled
     toRequestBody SetLegalHoldEnabled  = LegalHoldTeamConfig LegalHoldEnabled
@@ -402,13 +404,15 @@ setSSOStatus :: TeamId -> SetSSOStatus -> Handler ()
 setSSOStatus tid status = do
     info $ msg "Setting SSO status"
     gly <- view galley
-    void . catchRpcErrors $ rpc' "galley" gly
+    resp <- catchRpcErrors $ rpc' "galley" gly
          ( method PUT
          . paths ["/i/teams", toByteString' tid, "features", "sso"]
          . lbytes (encode $ toRequestBody status)
          . contentJson
-         . expect2xx
          )
+    case statusCode resp of
+      204 -> pure ()
+      _   -> throwE $ responseJsonUnsafe resp
   where
     toRequestBody SetSSODisabled = SSOTeamConfig SSODisabled
     toRequestBody SetSSOEnabled  = SSOTeamConfig SSOEnabled

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -58,6 +58,7 @@ import Data.ByteString.Conversion
 import Data.Id
 import Data.Int
 import Data.List.Split (chunksOf)
+import Data.Tagged
 import Data.Text (Text, strip)
 import Data.Text.Lazy (pack)
 import Data.Text.Encoding (encodeUtf8, decodeUtf8)
@@ -351,8 +352,8 @@ setBlacklistStatus status emailOrPhone = do
     statusToMethod False = DELETE
     statusToMethod True  = POST
 
-getLegalholdStatus :: TeamId -> Handler Bool
-getLegalholdStatus tid = do
+getLegalholdStatus :: TeamId -> Handler (Tagged "legalhold" Bool)
+getLegalholdStatus tid = Tagged <$> do
     info $ msg "Getting legalhold status"
     gly <- view galley
     (>>= fromResponseBody) . catchRpcErrors $ rpc' "galley" gly
@@ -367,8 +368,8 @@ getLegalholdStatus tid = do
       Right (LegalHoldTeamConfig LegalHoldEnabled) -> pure True
       Left errmsg -> throwE (Error status502 "bad-upstream" ("bad response; error message: " <> pack errmsg))
 
-setLegalholdStatus :: TeamId -> Bool -> Handler ()
-setLegalholdStatus tid status = do
+setLegalholdStatus :: TeamId -> Tagged "legalhold" Bool -> Handler ()
+setLegalholdStatus tid (Tagged status) = do
     info $ msg "Setting legalhold status"
     gly <- view galley
     void . catchRpcErrors $ rpc' "galley" gly
@@ -382,8 +383,8 @@ setLegalholdStatus tid status = do
     toRequestBody False = LegalHoldTeamConfig LegalHoldDisabled
     toRequestBody True  = LegalHoldTeamConfig LegalHoldEnabled
 
-getSSOStatus :: TeamId -> Handler Bool
-getSSOStatus tid = do
+getSSOStatus :: TeamId -> Handler (Tagged "sso" Bool)
+getSSOStatus tid = Tagged <$> do
     info $ msg "Getting SSO status"
     gly <- view galley
     (>>= fromResponseBody) . catchRpcErrors $ rpc' "galley" gly
@@ -398,8 +399,8 @@ getSSOStatus tid = do
       Right (SSOTeamConfig SSOEnabled) -> pure True
       Left errmsg -> throwE (Error status502 "bad-upstream" ("bad response; error message: " <> pack errmsg))
 
-setSSOStatus :: TeamId -> Bool -> Handler ()
-setSSOStatus tid status = do
+setSSOStatus :: TeamId -> Tagged "sso" Bool -> Handler ()
+setSSOStatus tid (Tagged status) = do
     info $ msg "Setting SSO status"
     gly <- view galley
     void . catchRpcErrors $ rpc' "galley" gly

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -441,7 +441,7 @@ catchRpcErrors action = ExceptT $ catch (Right <$> action) catchRPCException
     catchRPCException :: RPCException -> App (Either Error a)
     catchRPCException rpcE = do
       Log.err $ rpcExceptionMsg rpcE
-      pure . Left $ Error status500 "io-error" "I/O Error"
+      pure . Left $ Error status500 "io-error" (pack $ show rpcE)
 
 getTeamData :: TeamId -> Handler TeamData
 getTeamData tid = do

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -358,7 +358,6 @@ getLegalholdStatus tid = do
     (>>= fromResponseBody) . catchRpcErrors $ rpc' "galley" gly
          ( method GET
          . paths ["/i/teams", toByteString' tid, "features", "legalhold"]
-         . expect2xx
          )
   where
     fromResponseBody :: Response (Maybe LByteString) -> Handler SetLegalHoldStatus
@@ -376,7 +375,6 @@ setLegalholdStatus tid status = do
          . paths ["/i/teams", toByteString' tid, "features", "legalhold"]
          . lbytes (encode $ toRequestBody status)
          . contentJson
-         . expect2xx
          )
   where
     toRequestBody SetLegalHoldDisabled = LegalHoldTeamConfig LegalHoldDisabled
@@ -389,7 +387,6 @@ getSSOStatus tid = do
     (>>= fromResponseBody) . catchRpcErrors $ rpc' "galley" gly
          ( method GET
          . paths ["/i/teams", toByteString' tid, "features", "sso"]
-         . expect2xx
          )
   where
     fromResponseBody :: Response (Maybe LByteString) -> Handler SetSSOStatus
@@ -407,7 +404,6 @@ setSSOStatus tid status = do
          . paths ["/i/teams", toByteString' tid, "features", "sso"]
          . lbytes (encode $ toRequestBody status)
          . contentJson
-         . expect2xx
          )
   where
     toRequestBody SetSSODisabled = SSOTeamConfig SSODisabled

--- a/tools/stern/src/Stern/Swagger.hs
+++ b/tools/stern/src/Stern/Swagger.hs
@@ -3,6 +3,7 @@
 module Stern.Swagger where
 
 import Data.Swagger.Build.Api
+import Stern.Types
 import Imports
 
 sternModels :: [Model]
@@ -73,7 +74,13 @@ teamBillingInfoUpdate = defineModel "teamBillingInfoUpdate" $ do
         optional
 
 docSetSSOStatus :: DataType
-docSetSSOStatus = string $ enum ["\"SetSSODisabled\"","\"SetSSOEnabled\""]
+docSetSSOStatus = docBoundedEnum @SetSSOStatus
 
 docSetLegalHoldStatus :: DataType
-docSetLegalHoldStatus = string $ enum ["\"SetLegalHoldDisabled\"","\"SetLegalHoldEnabled\""]
+docSetLegalHoldStatus = docBoundedEnum @SetLegalHoldStatus
+
+-- (the double-call to show is to add extra double-quotes to the string.  this is important
+-- because the json instances also render this into a json string, and json string are wrapped
+-- in double-quotes.)
+docBoundedEnum :: forall a. (Bounded a, Enum a, Show a) => DataType
+docBoundedEnum = string . enum $ show . show <$> [(minBound :: a)..]

--- a/tools/stern/src/Stern/Swagger.hs
+++ b/tools/stern/src/Stern/Swagger.hs
@@ -71,3 +71,9 @@ teamBillingInfoUpdate = defineModel "teamBillingInfoUpdate" $ do
     property "state" string' $ do
         description "State of the company address (1 - 256 characters)"
         optional
+
+docSSOStatus :: DataType
+docSSOStatus = string $ enum ["enabled", "disabled"]
+
+docLegalHoldStatus :: DataType
+docLegalHoldStatus = string $ enum ["enabled", "disabled"]

--- a/tools/stern/src/Stern/Swagger.hs
+++ b/tools/stern/src/Stern/Swagger.hs
@@ -72,8 +72,8 @@ teamBillingInfoUpdate = defineModel "teamBillingInfoUpdate" $ do
         description "State of the company address (1 - 256 characters)"
         optional
 
-docSSOStatus :: DataType
-docSSOStatus = string $ enum ["enabled", "disabled"]
+docSetSSOStatus :: DataType
+docSetSSOStatus = string $ enum ["\"SetSSODisabled\"","\"SetSSOEnabled\""]
 
-docLegalHoldStatus :: DataType
-docLegalHoldStatus = string $ enum ["enabled", "disabled"]
+docSetLegalHoldStatus :: DataType
+docSetLegalHoldStatus = string $ enum ["\"SetLegalHoldDisabled\"","\"SetLegalHoldEnabled\""]

--- a/tools/stern/src/Stern/Types.hs
+++ b/tools/stern/src/Stern/Types.hs
@@ -94,3 +94,13 @@ data TeamBillingInfoUpdate = TeamBillingInfoUpdate
     } deriving (Eq, Show)
 
 deriveJSON toJSONFieldName ''TeamBillingInfoUpdate
+
+data SetLegalHoldStatus = SetLegalHoldDisabled | SetLegalHoldEnabled
+  deriving (Eq, Show, Ord, Enum, Bounded, Generic)
+
+deriveJSON toJSONFieldName ''SetLegalHoldStatus
+
+data SetSSOStatus = SetSSODisabled | SetSSOEnabled
+  deriving (Eq, Show, Ord, Enum, Bounded, Generic)
+
+deriveJSON toJSONFieldName ''SetSSOStatus


### PR DESCRIPTION
This should not change behavior in any observable way except for better error messages.  But it does add more type information to the code that should make mistakes like [this one](https://github.com/wireapp/wire-server/pull/844) harder in this particular place.  We should do that more in general!.

Fixes https://github.com/wearezeta/backend-issues/issues/877 (mostly with ed28786)