### PR TITLE
Better events for deletion of team conversations

### DIFF
--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -22,6 +22,7 @@ import Network.Wai.Predicate
 import Network.Wai.Utilities
 import UnliftIO (concurrently)
 
+import qualified Data.Set       as Set
 import qualified Data.Text.Lazy as LT
 import qualified Galley.Data    as Data
 
@@ -151,6 +152,12 @@ location = addHeader hLocation . toByteString'
 
 nonTeamMembers :: [Member] -> [TeamMember] -> [Member]
 nonTeamMembers cm tm = filter (not . flip isTeamMember tm . memId) cm
+
+convMembsAndTeamMembs :: [Member] -> [TeamMember] -> [Recipient]
+convMembsAndTeamMembs convMembs teamMembs
+    = fmap userRecipient . setnub $ map memId convMembs <> map (view userId) teamMembs
+  where
+    setnub = Set.toList . Set.fromList
 
 membersToRecipients :: Maybe UserId -> [TeamMember] -> [Recipient]
 membersToRecipients Nothing  = map (userRecipient . view userId)

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -735,9 +735,9 @@ testDeleteTeamConv = do
 
         checkTeamConvDeleteEvent tid cid1 wsOwner
         checkTeamConvDeleteEvent tid cid1 wsMember
-        checkConvDeletevent cid1 wsOwner
-        checkConvDeletevent cid1 wsMember
-        checkConvDeletevent cid1 wsExtern
+        checkConvDeleteEvent cid1 wsOwner
+        checkConvDeleteEvent cid1 wsMember
+        checkConvDeleteEvent cid1 wsExtern
 
         WS.assertNoEvent timeout [wsOwner, wsExtern, wsMember]
 
@@ -747,20 +747,6 @@ testDeleteTeamConv = do
             Util.assertNotConvMember u x
 
     postConvCodeCheck code !!! const 404 === statusCode
-  where
-    checkTeamConvDeleteEvent tid cid w = WS.assertMatch_ timeout w $ \notif -> do
-        ntfTransient notif @?= False
-        let e = List1.head (WS.unpackPayload notif)
-        e^.eventType @?= ConvDelete
-        e^.eventTeam @?= tid
-        e^.eventData @?= Just (EdConvDelete cid)
-
-    checkConvDeletevent cid w = WS.assertMatch_ timeout w $ \notif -> do
-        ntfTransient notif @?= False
-        let e = List1.head (WS.unpackPayload notif)
-        evtType e @?= Conv.ConvDelete
-        evtConv e @?= cid
-        evtData e @?= Nothing
 
 testUpdateTeam :: TestM ()
 testUpdateTeam = do
@@ -929,6 +915,14 @@ checkTeamDeleteEvent tid w = WS.assertMatch_ timeout w $ \notif -> do
     e^.eventType @?= TeamDelete
     e^.eventTeam @?= tid
     e^.eventData @?= Nothing
+
+checkTeamConvDeleteEvent :: HasCallStack => TeamId -> ConvId -> WS.WebSocket -> TestM ()
+checkTeamConvDeleteEvent tid cid w = WS.assertMatch_ timeout w $ \notif -> do
+    ntfTransient notif @?= False
+    let e = List1.head (WS.unpackPayload notif)
+    e^.eventType @?= ConvDelete
+    e^.eventTeam @?= tid
+    e^.eventData @?= Just (EdConvDelete cid)
 
 checkConvDeleteEvent :: HasCallStack => ConvId -> WS.WebSocket -> TestM ()
 checkConvDeleteEvent cid w = WS.assertMatch_ timeout w $ \notif -> do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -600,6 +600,8 @@ testDeleteTeam = do
             const 202 === statusCode
         checkTeamDeleteEvent tid wsOwner
         checkTeamDeleteEvent tid wsMember
+        checkConvDeleteEvent cid1 wsOwner
+        checkConvDeleteEvent cid1 wsMember
         checkConvDeleteEvent cid1 wsExtern
         WS.assertNoEvent timeout [wsOwner, wsExtern, wsMember]
 
@@ -733,6 +735,8 @@ testDeleteTeamConv = do
 
         checkTeamConvDeleteEvent tid cid1 wsOwner
         checkTeamConvDeleteEvent tid cid1 wsMember
+        checkConvDeletevent cid1 wsOwner
+        checkConvDeletevent cid1 wsMember
         checkConvDeletevent cid1 wsExtern
 
         WS.assertNoEvent timeout [wsOwner, wsExtern, wsMember]

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -726,6 +726,9 @@ testDeleteTeamConv = do
 
         checkTeamConvDeleteEvent tid cid2 wsOwner
         checkTeamConvDeleteEvent tid cid2 wsMember
+        checkConvDeleteEvent cid2 wsOwner
+        checkConvDeleteEvent cid2 wsMember
+        WS.assertNoEvent timeout [wsOwner, wsMember]
 
         delete ( g
                . paths ["teams", toByteString' tid, "conversations", toByteString' cid1]
@@ -738,8 +741,7 @@ testDeleteTeamConv = do
         checkConvDeleteEvent cid1 wsOwner
         checkConvDeleteEvent cid1 wsMember
         checkConvDeleteEvent cid1 wsExtern
-
-        WS.assertNoEvent timeout [wsOwner, wsExtern, wsMember]
+        WS.assertNoEvent timeout [wsOwner, wsMember, wsExtern]
 
     for_ [cid1, cid2] $ \x ->
         for_ [owner, member^.userId, extern] $ \u -> do


### PR DESCRIPTION
Start sending `conversation.delete` event also to all team members (whether in the conversation or not).  `team.conversation-delete` will still be sent as before.

This solves the following issue:

> One side effect of getting only one of the team.converation-delete and conversation.delete events is that we can't display who deleted a conversation in a team. The team.converation-delete event doesn't contain the from field.

Also, lots of small refactoring.