### PR TITLE
Change feature flags from boolean to custom enum types.

### DIFF
--- a/libs/brig-types/test/unit/Test/Brig/Types/Common.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/Common.hs
@@ -85,8 +85,6 @@ instance Arbitrary SSOTeamConfig where
   arbitrary = SSOTeamConfig <$> arbitrary
 
 instance Arbitrary FeatureFlags where
-  arbitrary = FeatureFlags <$> arbitrary
-  shrink (FeatureFlags ls) = FeatureFlags <$> shrink ls
-
-instance Arbitrary FeatureFlag where
-  arbitrary = Test.Tasty.QuickCheck.elements [minBound..]
+  arbitrary = FeatureFlags
+      <$> Test.Tasty.QuickCheck.elements [minBound..]
+      <*> Test.Tasty.QuickCheck.elements [minBound..]

--- a/libs/galley-types/package.yaml
+++ b/libs/galley-types/package.yaml
@@ -27,6 +27,7 @@ library:
   - exceptions >=0.10.0
   - lens >=4.12
   - protobuf >=0.2
+  - string-conversions
   - swagger >=0.1
   - text >=0.11
   - time >=1.4

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -21,8 +21,9 @@ module Galley.Types.Teams
     , TeamCreationTime (..)
     , tcTime
 
-    , FeatureFlags(..)
-    , FeatureFlag(..)
+    , FeatureFlags(..), flagSSO, flagLegalHold
+    , FeatureSSO(..)
+    , FeatureLegalHold(..)
 
     , TeamList
     , newTeamList
@@ -128,6 +129,7 @@ import Data.Id (TeamId, ConvId, UserId)
 import Data.Json.Util
 import Data.Misc (PlainTextPassword (..))
 import Data.Range
+import Data.String.Conversions (cs)
 import Data.Time (UTCTime)
 import Data.LegalHold (UserLegalHoldStatus(..))
 import Galley.Types.Teams.Internal
@@ -316,24 +318,50 @@ newtype TeamCreationTime = TeamCreationTime
     { _tcTime :: Int64
     }
 
-newtype FeatureFlags = FeatureFlags (Set FeatureFlag)
+data FeatureFlags = FeatureFlags
+    { _flagSSO       :: !FeatureSSO
+    , _flagLegalHold :: !FeatureLegalHold
+    }
     deriving (Eq, Show, Generic)
 
-data FeatureFlag = FeatureSSO | FeatureLegalHold
+data FeatureSSO
+    = FeatureSSOEnabledByDefault
+    | FeatureSSODisabledByDefault
+    deriving (Eq, Ord, Show, Enum, Bounded, Generic)
+
+data FeatureLegalHold
+    = FeatureLegalHoldDisabledPermantently
+    | FeatureLegalHoldDisabledByDefault
     deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 instance FromJSON FeatureFlags where
-    parseJSON = withObject "FeatureFlags" $ \obj -> do
-        sso       <- fromMaybe False <$> obj .:? "sso"
-        legalhold <- fromMaybe False <$> obj .:? "legalhold"
-        pure . FeatureFlags . Set.fromList $
-            [ FeatureSSO       | sso ] <>
-            [ FeatureLegalHold | legalhold ]
+    parseJSON = withObject "FeatureFlags" $ \obj -> FeatureFlags
+        <$> (obj .: "sso")
+        <*> (obj .: "legalhold")
 
 instance ToJSON FeatureFlags where
-    toJSON (FeatureFlags flags) = object $
-        [ "sso"       .= (FeatureSSO       `elem` flags) ] <>
-        [ "legalhold" .= (FeatureLegalHold `elem` flags) ]
+    toJSON (FeatureFlags sso legalhold) = object $
+        [ "sso"       .= sso
+        , "legalhold" .= legalhold
+        ]
+
+instance FromJSON FeatureSSO where
+    parseJSON (String "enabled-by-default")  = pure FeatureSSOEnabledByDefault
+    parseJSON (String "disabled-by-default") = pure FeatureSSODisabledByDefault
+    parseJSON bad = fail $ "FeatureSSO: " <> cs (encode bad)
+
+instance ToJSON FeatureSSO where
+    toJSON FeatureSSOEnabledByDefault = String "enabled-by-default"
+    toJSON FeatureSSODisabledByDefault = String "disabled-by-default"
+
+instance FromJSON FeatureLegalHold where
+    parseJSON (String "disabled-permanently") = pure $ FeatureLegalHoldDisabledPermantently
+    parseJSON (String "disabled-by-default")  = pure $ FeatureLegalHoldDisabledByDefault
+    parseJSON bad = fail $ "FeatureLegalHold: " <> cs (encode bad)
+
+instance ToJSON FeatureLegalHold where
+    toJSON FeatureLegalHoldDisabledPermantently = String "disabled-permanently"
+    toJSON FeatureLegalHoldDisabledByDefault = String "disabled-by-default"
 
 newTeam :: TeamId -> UserId -> Text -> Text -> TeamBinding -> Team
 newTeam tid uid nme ico bnd = Team tid uid nme ico Nothing bnd
@@ -404,6 +432,7 @@ makeLenses ''TeamUpdateData
 makeLenses ''TeamMemberDeleteData
 makeLenses ''TeamDeleteData
 makeLenses ''TeamCreationTime
+makeLenses ''FeatureFlags
 
 
 -- Note [hidden team roles]

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -37,13 +37,11 @@ settings:
     # able to register new idps.
     # disabled for integration tests (the ones who need it on will
     # turn it on themselves).
-    sso: false
+    sso: disabled-by-default
 
     # Legal Hold: this decides whether customer support / backoffice
-    # is allowed to turn the feature on for individual teams.  the
-    # default for new teams is always "false", no matter what the
-    # feature flag is set to.
-    legalhold: true
+    # is allowed to turn the feature on for individual teams.
+    legalhold: disabled-by-default
 
 logLevel: Info
 logNetStrings: false

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -533,10 +533,10 @@ getLegalholdStatus (uid ::: tid ::: ct) = do
 getSSOStatusInternal :: TeamId ::: JSON -> Galley Response
 getSSOStatusInternal (tid ::: _) = do
     defConfig <- do
-        featureSSO <- view (options . optSettings . featureEnabled FeatureSSO)
-        pure $ if featureSSO
-            then SSOTeamConfig SSOEnabled
-            else SSOTeamConfig SSODisabled
+        featureSSO <- view (options . optSettings . setFeatureFlags . flagSSO)
+        pure . SSOTeamConfig $ case featureSSO of
+            FeatureSSOEnabledByDefault  -> SSOEnabled
+            FeatureSSODisabledByDefault -> SSODisabled
     ssoTeamConfig <- SSOData.getSSOTeamConfig tid
     pure . json . fromMaybe defConfig $ ssoTeamConfig
 
@@ -553,12 +553,12 @@ setSSOStatusInternal (tid ::: req ::: _) = do
 -- | Get legal hold status for a team.
 getLegalholdStatusInternal :: TeamId ::: JSON -> Galley Response
 getLegalholdStatusInternal (tid ::: _) = do
-    legalholdEnabled <- view (options . optSettings . featureEnabled FeatureLegalHold)
-    if legalholdEnabled
-      then do
+    featureLegalHold <- view (options . optSettings . setFeatureFlags . flagLegalHold)
+    case featureLegalHold of
+      FeatureLegalHoldDisabledByDefault -> do
         legalHoldTeamConfig <- LegalHoldData.getLegalHoldTeamConfig tid
         pure . json . fromMaybe disabledConfig $ legalHoldTeamConfig
-      else do
+      FeatureLegalHoldDisabledPermantently -> do
         pure . json $ disabledConfig
   where
     disabledConfig = LegalHoldTeamConfig LegalHoldDisabled
@@ -566,8 +566,12 @@ getLegalholdStatusInternal (tid ::: _) = do
 -- | Enable or disable legal hold for a team.
 setLegalholdStatusInternal :: TeamId ::: JsonRequest LegalHoldTeamConfig ::: JSON -> Galley Response
 setLegalholdStatusInternal (tid ::: req ::: _) = do
-    do  featureLegalHold <- view (options . optSettings . featureEnabled FeatureLegalHold)
-        unless featureLegalHold $ throwM legalHoldFeatureFlagNotEnabled
+    do  featureLegalHold <- view (options . optSettings . setFeatureFlags . flagLegalHold)
+        case featureLegalHold of
+          FeatureLegalHoldDisabledByDefault -> do
+            pure ()
+          FeatureLegalHoldDisabledPermantently -> do
+            throwM legalHoldFeatureFlagNotEnabled
 
     legalHoldTeamConfig <- fromJsonBody req
     case legalHoldTeamConfigStatus legalHoldTeamConfig of

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -7,7 +7,7 @@ import Util.Options
 import Util.Options.Common
 import System.Logger.Extended (Level, LogFormat)
 import Data.Misc
-import Galley.Types.Teams (FeatureFlags(..), FeatureFlag)
+import Galley.Types.Teams (FeatureFlags(..))
 
 data Settings = Settings
     {
@@ -21,18 +21,11 @@ data Settings = Settings
     , _setIntraListing          :: !Bool
     -- | URI prefix for conversations with access mode @code@
     , _setConversationCodeURI   :: !HttpsUrl
-    , _setFeatureFlags          :: !(Maybe FeatureFlags)
+    , _setFeatureFlags          :: !FeatureFlags
     } deriving (Show, Generic)
 
 deriveFromJSON toOptionFieldName ''Settings
 makeLenses ''Settings
-
-featureEnabled :: FeatureFlag -> Getter Settings Bool
-featureEnabled flag
-    = setFeatureFlags
-    . to (\case
-             Nothing -> False
-             Just (FeatureFlags flags) -> flag `elem` flags)
 
 data JournalOpts = JournalOpts
     { _awsQueueName :: !Text         -- ^ SQS queue name to send team events

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -15,7 +15,7 @@ import Data.Id
 import Data.List1
 import Data.Misc (PlainTextPassword (..))
 import Data.Range
-import Galley.Options (optSettings, featureEnabled)
+import Galley.Options (optSettings, setFeatureFlags)
 import Galley.Types hiding (EventType (..), EventData (..), MemberUpdate (..))
 import Galley.Types.Teams
 import Galley.Types.Teams.Intra
@@ -176,12 +176,10 @@ testEnableSSOPerTeam = do
             assertEqual "bad status" status403 status
             assertEqual "bad label" "not-implemented" label
 
-    featureSSO <- view (tsGConf . optSettings . featureEnabled FeatureSSO)
-    if not featureSSO
-      then do
-        check "Teams should start with SSO disabled" SSODisabled
-      else do
-        check "Teams should start with SSO enabled" SSOEnabled
+    featureSSO <- view (tsGConf . optSettings . setFeatureFlags . flagSSO)
+    case featureSSO of
+        FeatureSSOEnabledByDefault  -> check "Teams should start with SSO enabled" SSOEnabled
+        FeatureSSODisabledByDefault -> check "Teams should start with SSO disabled" SSODisabled
 
     putSSOEnabledInternal tid SSOEnabled
     check "Calling 'putEnabled True' should enable SSO" SSOEnabled
@@ -1175,17 +1173,16 @@ testFeatureFlags = do
         setSSOInternal :: HasCallStack => SSOStatus -> TestM ()
         setSSOInternal = putSSOEnabledInternal tid
 
-    featureSSO <- view (tsGConf . optSettings . featureEnabled FeatureSSO)
-    if not featureSSO
-      then do -- disabled
+    featureSSO <- view (tsGConf . optSettings . setFeatureFlags . flagSSO)
+    case featureSSO of
+      FeatureSSODisabledByDefault -> do
         getSSO SSODisabled
         getSSOInternal SSODisabled
 
         setSSOInternal SSOEnabled
         getSSO SSOEnabled
         getSSOInternal SSOEnabled
-
-      else do -- enabled
+      FeatureSSOEnabledByDefault -> do
         -- since we don't allow to disable (see 'disableSsoNotImplemented'), we can't test
         -- much here.  (disable failure is covered in "enable/disable SSO" above.)
         getSSO SSOEnabled
@@ -1209,11 +1206,11 @@ testFeatureFlags = do
     getLegalHold LegalHoldDisabled
     getLegalHoldInternal LegalHoldDisabled
 
-    featureLegalHold <- view (tsGConf . optSettings . featureEnabled FeatureLegalHold)
-    if featureLegalHold
-      then do
+    featureLegalHold <- view (tsGConf . optSettings . setFeatureFlags . flagLegalHold)
+    case featureLegalHold of
+      FeatureLegalHoldDisabledByDefault -> do
         setLegalHoldInternal LegalHoldEnabled
         getLegalHold LegalHoldEnabled
         getLegalHoldInternal LegalHoldEnabled
-      else do
+      FeatureLegalHoldDisabledPermantently -> do
         putLegalHoldEnabledInternal' expect4xx tid LegalHoldEnabled

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -31,7 +31,7 @@ import Data.Text.Encoding (encodeUtf8)
 import Galley.API.Swagger (GalleyRoutes)
 import Galley.External.LegalHoldService (validateServiceKey)
 import Galley.Types.Teams
-import Galley.Options (optSettings, featureEnabled)
+import Galley.Options (optSettings, setFeatureFlags)
 import GHC.Generics hiding (to)
 import GHC.TypeLits
 import Gundeck.Types.Notification (ntfPayload)
@@ -69,10 +69,12 @@ import qualified Test.Tasty.Cannon                 as WS
 
 onlyIfLhEnabled :: TestM () -> TestM ()
 onlyIfLhEnabled action = do
-    featureLegalHold <- view (tsGConf . optSettings . featureEnabled FeatureLegalHold)
-    if featureLegalHold
-        then action
-        else liftIO $ hPutStrLn stderr "*** legalhold feature flag disabled, not running integration tests"
+    featureLegalHold <- view (tsGConf . optSettings . setFeatureFlags . flagLegalHold)
+    case featureLegalHold of
+        FeatureLegalHoldDisabledPermantently
+            -> liftIO $ hPutStrLn stderr "*** legalhold feature flag disabled, not running integration tests"
+        FeatureLegalHoldDisabledByDefault
+            -> action
 
 tests :: IO TestSetup -> TestTree
 tests s = testGroup "Teams LegalHold API"


### PR DESCRIPTION
Different feature flags have subtly different semantics, and `Bool` is not a good type to represent everything we want to say.  Here is a better way.

Related: 
https://github.com/wireapp/wire-server/pull/845#issuecomment-529586511
https://github.com/wearezeta/backend-issues/issues/877#issuecomment-529573103
