### PR TITLE
Fix metrics.

### DIFF
--- a/services/cannon/package.yaml
+++ b/services/cannon/package.yaml
@@ -36,6 +36,7 @@ library:
   - mwc-random >=0.13
   - prometheus-client
   - retry >=0.7
+  - safe-exceptions
   - singletons >=2.0
   - strict >=0.3.2
   - swagger >=0.2

--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -70,11 +70,15 @@ sitemap = do
     head "/i/status" (continue (const $ return empty)) true
 
 monitoring :: Media "application" "json" -> Cannon Response
-monitoring = const $ do
+monitoring _ = do
+    refreshMetrics
+    json <$> (Metrics.render =<< monitor)
+
+refreshMetrics :: Cannon ()
+refreshMetrics = do
     m <- monitor
     s <- D.size =<< clients
     gaugeSet (fromIntegral s) (path "net.websocket.clients") m
-    json <$> Metrics.render m
 
 docs :: Media "application" "json" ::: Text -> Cannon Response
 docs (_ ::: url) = do

--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -7,7 +7,6 @@ import Cannon.WS hiding (env)
 import Control.Monad.Catch
 import Data.Aeson (encode)
 import Data.Id (ClientId, UserId, ConnId)
-import Data.Metrics.Middleware
 import Data.Swagger.Build.Api hiding (def, Response)
 import Network.HTTP.Types
 import Gundeck.Types
@@ -71,14 +70,7 @@ sitemap = do
 
 monitoring :: Media "application" "json" -> Cannon Response
 monitoring _ = do
-    refreshMetrics
     json <$> (Metrics.render =<< monitor)
-
-refreshMetrics :: Cannon ()
-refreshMetrics = do
-    m <- monitor
-    s <- D.size =<< clients
-    gaugeSet (fromIntegral s) (path "net.websocket.clients") m
 
 docs :: Media "application" "json" ::: Text -> Cannon Response
 docs (_ ::: url) = do

--- a/services/cannon/src/Cannon/API.hs
+++ b/services/cannon/src/Cannon/API.hs
@@ -69,8 +69,7 @@ sitemap = do
     head "/i/status" (continue (const $ return empty)) true
 
 monitoring :: Media "application" "json" -> Cannon Response
-monitoring _ = do
-    json <$> (Metrics.render =<< monitor)
+monitoring _ = json <$> (Metrics.render =<< monitor)
 
 docs :: Media "application" "json" ::: Text -> Cannon Response
 docs (_ ::: url) = do

--- a/services/cannon/src/Cannon/Dict.hs
+++ b/services/cannon/src/Cannon/Dict.hs
@@ -18,45 +18,74 @@ import qualified Data.HashMap.Strict as M
 import qualified Data.Vector         as V
 
 newtype Dict a b = Dict
-    { _map :: Vector (IORef (HashMap a b)) }
+    { _map :: Vector (IORef (SizedHashMap a b)) }
 
 size :: MonadIO m => Dict a b -> m Int
-size d = liftIO $ sum <$> mapM (\r -> M.size <$> readIORef r) (_map d)
+size d = liftIO $ sum <$> mapM (\r -> hmsize <$> readIORef r) (_map d)
 
 empty :: MonadIO m => Int -> m (Dict a b)
 empty w = liftIO $ if w > 0 && w < 8192
-    then Dict <$> V.generateM w (const $ newIORef M.empty)
+    then Dict <$> V.generateM w (const $ newIORef hmempty)
     else error "Dict.empty: slice number out of range [1, 8191]"
 
 insert :: (Eq a, Hashable a, MonadIO m) => a -> b -> Dict a b -> m ()
-insert k v = mutDict (M.insert k v) . getSlice k
+insert k v = mutDict (hminsert k v) . getSlice k
 
 add :: (Eq a, Hashable a, MonadIO m) => a -> b -> Dict a b -> m Bool
 add k v d = liftIO $ atomicModifyIORef' (getSlice k d) $ \m ->
-    if k `elem` M.keys m
+    if k `elem` hmkeys m
         then (m, False)
-        else (M.insert k v m, True)
+        else (hminsert k v m, True)
 
 remove :: (Eq a, Hashable a, MonadIO m) => a -> Dict a b -> m Bool
 remove = removeIf (const True)
 
 removeIf :: (Eq a, Hashable a, MonadIO m) => (Maybe b -> Bool) -> a -> Dict a b -> m Bool
 removeIf f k d = liftIO $ atomicModifyIORef' (getSlice k d) $ \m ->
-    if f (M.lookup k m)
-        then (M.delete k m, True)
+    if f (hmlookup k m)
+        then (hmdelete k m, True)
         else (m, False)
 
 lookup :: (Eq a, Hashable a, MonadIO m) => a -> Dict a b -> m (Maybe b)
-lookup k = liftIO . fmap (M.lookup k) . readIORef . getSlice k
+lookup k = liftIO . fmap (hmlookup k) . readIORef . getSlice k
 
 -----------------------------------------------------------------------------
 -- Internal
 
 mutDict :: MonadIO m
-        => (HashMap a b -> HashMap a b)
-        -> IORef (HashMap a b)
+        => (SizedHashMap a b -> SizedHashMap a b)
+        -> IORef (SizedHashMap a b)
         -> m ()
 mutDict f d = liftIO $ atomicModifyIORef' d $ \m -> (f m, ())
 
-getSlice :: (Hashable a) => a -> Dict a b -> IORef (HashMap a b)
+getSlice :: (Hashable a) => a -> Dict a b -> IORef (SizedHashMap a b)
 getSlice k (Dict m) = m ! (hash k `mod` V.length m)
+
+----------------------------------------------------------------------
+-- hashmap with O(1) size operator
+
+data SizedHashMap a b = SizedHashMap !Int !(HashMap a b)
+
+hmsize :: forall k v. SizedHashMap k v -> Int
+hmsize (SizedHashMap s _) = s
+
+hmempty :: forall k v. SizedHashMap k v
+hmempty = SizedHashMap 0 M.empty
+
+hminsert :: forall k v. (Eq k, Hashable k) => k -> v -> SizedHashMap k v -> SizedHashMap k v
+hminsert k v (SizedHashMap n hm) = SizedHashMap n' hm'
+  where
+    n' = if M.member k hm then n else n + 1
+    hm' = M.insert k v hm
+
+hmkeys :: forall k v. SizedHashMap k v -> [k]
+hmkeys (SizedHashMap _ hm) = M.keys hm
+
+hmlookup :: forall k v. (Eq k, Hashable k) => k -> SizedHashMap k v -> Maybe v
+hmlookup k (SizedHashMap _ hm) = M.lookup k hm
+
+hmdelete :: forall k v. (Eq k, Hashable k) => k -> SizedHashMap k v -> SizedHashMap k v
+hmdelete k (SizedHashMap n hm) = SizedHashMap n' hm'
+  where
+    n' = if M.member k hm then n - 1 else n
+    hm' = M.delete k hm

--- a/services/cannon/src/Cannon/Types.hs
+++ b/services/cannon/src/Cannon/Types.hs
@@ -12,6 +12,7 @@ module Cannon.Types
     , mapConcurrentlyCannon
     , mkEnv
     , runCannon
+    , runCannon'
     , options
     , clients
     , monitor
@@ -87,7 +88,10 @@ mkEnv m external o l d p g t = Env m o l d def $
 
 runCannon :: Env -> Cannon a -> Request -> IO a
 runCannon e c r = let e' = e { reqId = lookupReqId r } in
-    runReaderT (unCannon c) e'
+    runCannon' e' c
+
+runCannon' :: Env -> Cannon a -> IO a
+runCannon' e c = runReaderT (unCannon c) e
 
 lookupReqId :: Request -> RequestId
 lookupReqId = maybe def RequestId . lookup requestIdName . requestHeaders

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -38,7 +38,6 @@ import qualified Galley.API.Error              as Error
 import qualified Galley.API.Internal           as Internal
 import qualified Galley.API.LegalHold          as LegalHold
 import qualified Galley.API.Teams              as Teams
-import qualified Galley.Queue                  as Q
 import qualified Galley.Types.Swagger          as Model
 import qualified Galley.Types.Teams.Swagger    as TeamsModel
 import qualified Network.Wai.Predicate         as P
@@ -1004,14 +1003,7 @@ docs (_ ::: url) = do
 
 monitoring :: JSON -> Galley Response
 monitoring _ = do
-    refreshMetrics
     json <$> (render =<< view monitor)
-
-refreshMetrics :: Galley ()
-refreshMetrics = do
-    m <- view monitor
-    n <- Q.len =<< view deleteQueue
-    gaugeSet (fromIntegral n) (Metrics.path "galley.deletequeue.len") m
 
 filterMissing :: HasQuery r => Predicate r P.Error OtrFilterMissing
 filterMissing = (>>= go) <$> (query "ignore_missing" ||| query "report_missing")

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -1004,10 +1004,14 @@ docs (_ ::: url) = do
 
 monitoring :: JSON -> Galley Response
 monitoring _ = do
+    refreshMetrics
+    json <$> (render =<< view monitor)
+
+refreshMetrics :: Galley ()
+refreshMetrics = do
     m <- view monitor
     n <- Q.len =<< view deleteQueue
     gaugeSet (fromIntegral n) (Metrics.path "galley.deletequeue.len") m
-    json <$> render m
 
 filterMissing :: HasQuery r => Predicate r P.Error OtrFilterMissing
 filterMissing = (>>= go) <$> (query "ignore_missing" ||| query "report_missing")

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -1,6 +1,7 @@
 module Galley.API.Internal
     ( rmUser
     , deleteLoop
+    , refreshMetrics
     ) where
 
 import Imports
@@ -10,6 +11,7 @@ import Control.Lens hiding ((.=))
 import Data.Id
 import Data.List.NonEmpty (nonEmpty)
 import Data.List1
+import Data.Metrics.Middleware as Metrics
 import Data.Range
 import Galley.API.Util (isMember)
 import Galley.API.Teams (uncheckedRemoveTeamMember)
@@ -72,3 +74,12 @@ deleteLoop = do
         unless ok $
             err (msg (val "delete queue is full, dropping item") ~~ "item" .= show i)
         liftIO $ threadDelay 1000000
+
+refreshMetrics :: Galley ()
+refreshMetrics = do
+    m <- view monitor
+    q <- view deleteQueue
+    forever $ do
+        n <- Q.len q
+        gaugeSet (fromIntegral n) (Metrics.path "galley.deletequeue.len") m
+        threadDelay 100000

--- a/services/gundeck/src/Gundeck/API.hs
+++ b/services/gundeck/src/Gundeck/API.hs
@@ -1,7 +1,7 @@
 module Gundeck.API (sitemap) where
 
 import Imports hiding (head)
-import Control.Lens hiding (enum)
+import Control.Lens (view)
 import Data.Metrics.Middleware
 import Data.Range
 import Data.Swagger.Build.Api hiding (def, min, Response)
@@ -179,8 +179,5 @@ docs (url ::: _) =
     let doc = mkSwaggerApi (decodeLatin1 url) Model.gundeckModels sitemap in
     return $ json doc
 
--- REFACTOR: what does this function still do, after the fallback queue is gone?
 monitoring :: JSON -> Gundeck Response
-monitoring = const $ do
-    m  <- view monitor
-    json <$> render m
+monitoring _ = json <$> (render =<< view monitor)


### PR DESCRIPTION
@tiago writes:

> Start cannon and curl localhost:8083/i/metrics
> 
> Notice there is no net_websocket_clients on the output?
> 
> Now try curl localhost:8083/i/monitoring and again curl localhost:8083/i/metrics.
> 
> Look at what happens! :) Anyway... just wanted to share this... so, culprit
> 
> https://github.com/wireapp/wire-server/blob/develop/services/cannon/src/Cannon/API.hs#L72-L77
> https://github.com/wireapp/wire-server/blob/develop/services/galley/src/Galley/API.hs#L1007-L1010
> 
> Can we please move those to a different place? Calling /i/monitoring should only render metrics and not do some extra logic.