### PR TITLE
Log warnings only when users are suspended

### DIFF
--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -162,6 +162,7 @@ catchSuspendInactiveUser uid errval = do
   when mustsuspend $ do
     Log.warn $ msg (val "Suspending user due to inactivity")
       ~~ field "user" (toByteString uid)
+      ~~ field "action" "user.suspend"
     lift $ suspendAccount (singleton uid)
     throwE errval
 

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -162,7 +162,7 @@ catchSuspendInactiveUser uid errval = do
   when mustsuspend $ do
     Log.warn $ msg (val "Suspending user due to inactivity")
       ~~ field "user" (toByteString uid)
-      ~~ field "action" "user.suspend"
+      ~~ field "action" ("user.suspend" :: String)
     lift $ suspendAccount (singleton uid)
     throwE errval
 

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -159,10 +159,9 @@ revokeAccess u pw cc ll = do
 catchSuspendInactiveUser :: UserId -> e -> ExceptT e AppIO ()
 catchSuspendInactiveUser uid errval = do
   mustsuspend <- lift $ mustSuspendInactiveUser uid
-  Log.warn $ msg (val "catchSuspendInactiveUser")
-    ~~ field "user" (toByteString uid)
-    ~~ field "mustsuspend" mustsuspend
   when mustsuspend $ do
+    Log.warn $ msg (val "Suspending user due to inactivity")
+        ~~ field "user" (toByteString uid)
     lift $ suspendAccount (singleton uid)
     throwE errval
 

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -161,7 +161,7 @@ catchSuspendInactiveUser uid errval = do
   mustsuspend <- lift $ mustSuspendInactiveUser uid
   when mustsuspend $ do
     Log.warn $ msg (val "Suspending user due to inactivity")
-        ~~ field "user" (toByteString uid)
+      ~~ field "user" (toByteString uid)
     lift $ suspendAccount (singleton uid)
     throwE errval
 


### PR DESCRIPTION
Currently we log this _really_ often, and at the `Warn` log level; the `mustSuspend` value is also redundant.

In addition, I added an extra field named `"action"` (`"type"` sounds more appropriate but I'd generally avoid using such keywords that may be reserved or whatnot): I think we should have a consistent way of tracking and filtering important events. The name of the event tries to follow the convention of [our push formats](https://github.com/wireapp/wire-server/blob/develop/services/brig/src/Brig/IO/Intra.hs#L279-L374).

In general, I'd like to then start a little internal discussion on how we structure logs, etc., and also document this so that it becomes easier to trace logs, etc.