### PR TITLE
Sneak up on flaky test.

### DIFF
--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -7,7 +7,7 @@ import Bilge.Assert
 import Control.Arrow ((&&&))
 import Control.Concurrent.Async       (Async, async, wait, concurrently_, forConcurrently_)
 import Control.Lens                   ((.~), (^.), (^?), view, (<&>), _2, (%~))
-import Control.Retry                  (retrying, constantDelay, limitRetries)
+import Control.Retry                  (retrying, recoverAll, constantDelay, limitRetries)
 import Data.Aeson              hiding (json)
 import Data.Aeson.Lens
 import Data.ByteString.Conversion

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -159,7 +159,7 @@ removeStalePresence = do
     w <- wsRun ca uid con (wsCloser m)
     wsAssertPresences uid 1
     liftIO $ void $ putMVar m () >> wait w
-    threadDelay 200000  -- sometimes the last line fails with @1 =/= 0@.  does this line help?
+    threadDelay 10000000  -- sometimes the last line fails with @0 =/= 1@.  does this line help?
     sendPush (push uid [uid])
     ensurePresent uid 0
   where


### PR DESCRIPTION
The recoverAll was not needed because the test itself is already running inside `retryWhile`.