### PR TITLE
Change SCIM documentation to actually use SAML Ids

### DIFF
--- a/docs/reference/provisioning/scim-via-curl.md
+++ b/docs/reference/provisioning/scim-via-curl.md
@@ -97,10 +97,19 @@ export SCIM_USER='{
   "displayName" : "The Nick"
 }'
 ```
-The `externalId` is used to construct a 'SAML.UserRef'. If it looks like an email
-address, the constructed 'SAML.UserRef' will have `nameid-format:emailAddress`,
-otherwise the format will be `unspecified`.
-*It is important to configure your SAML provider to use `nameid-format:emailAddress` or `unspecified`. Other
+
+The `externalId` is used to construct a saml identity.  Two cases are
+currently supported:
+
+1. `externalId` contains a valid email address.  The SAML `NameID` has
+the form `<NameID
+Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">me@example.com</NameID>`.
+2. `externalId` contains anything that is *not* an email address.  The
+SAML `NameID` has the form `<NameID
+Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">...</NameID>`.
+
+*NOTE: It is important to configure your SAML provider to use
+`nameid-format:emailAddress` or `nameid-format:unspecified`.  Other
 nameid formats are not supported at this moment*.
 
 

--- a/docs/reference/provisioning/scim-via-curl.md
+++ b/docs/reference/provisioning/scim-via-curl.md
@@ -111,7 +111,7 @@ Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">...</NameID>`.
 *NOTE: It is important to configure your SAML provider to use
 `nameid-format:emailAddress` or `nameid-format:unspecified`.  Other
 nameid formats are not supported at this moment*.
-
+See also: https://github.com/wireapp/wire-server/blob/c507ed64a7d4f0af2bffe2f9c3eb4b5f89a477c0/services/spar/src/Spar/Scim/User.hs#L149-L158
 
 We also support custom fields that are used in rich profiles in this
 form [see {#RefRichInfo}](../user/rich-info.md):

--- a/docs/reference/provisioning/scim-via-curl.md
+++ b/docs/reference/provisioning/scim-via-curl.md
@@ -92,11 +92,17 @@ A minimal definition of a user looks like this:
 ```bash
 export SCIM_USER='{
   "schemas"     : ["urn:ietf:params:scim:schemas:core:2.0:User"],
-  "externalId"  : "f8c4ffde-4592-11e9-8600-afe11dc7d07b",
+  "externalId"  : "nick@example.com",
   "userName"    : "nick",
   "displayName" : "The Nick"
 }'
 ```
+The `externalId` is used to construct a 'SAML.UserRef'. If it looks like an email
+address, the constructed 'SAML.UserRef' will have `nameid-format:emailAddress`,
+otherwise the format will be `unspecified`.
+*It is important to configure your SAML provider to use `nameid-format:emailAddress` or `unspecified`. Other
+nameid formats are not supported at this moment*.
+
 
 We also support custom fields that are used in rich profiles in this
 form [see {#RefRichInfo}](../user/rich-info.md):
@@ -104,7 +110,7 @@ form [see {#RefRichInfo}](../user/rich-info.md):
 ```bash
 export SCIM_USER='{
   "schemas"     : ["urn:ietf:params:scim:schemas:core:2.0:User", "urn:wire:scim:schemas:profile:1.0"],
-  "externalId"  : "f8c4ffde-4592-11e9-8600-afe11dc7d07b",
+  "externalId"  : "rnick@example.com",
   "userName"    : "rnick",
   "displayName" : "The Rich Nick",
   "urn:wire:scim:schemas:profile:1.0": {
@@ -160,7 +166,7 @@ up-to-date user present, just `GET` one right before the `PUT`.)
 ```bash
 export SCIM_USER='{
   "schemas"     : ["urn:ietf:params:scim:schemas:core:2.0:User"],
-  "externalId"  : "updated-user-id",
+  "externalId"  : "rnick@example.com",
   "userName"    : "newnick",
   "displayName" : "The New Nick"
 }'


### PR DESCRIPTION
UUIDs are a bit confusing here. It is more common that your SAML provider is configured to have email addresses isntead