### PR TITLE
stack:  Split nix stuff into build deps and runtime deps.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,37 +1,9 @@
-{ pkgs ? import <nixpkgs> {} }:
-let 
-  cryptobox-c = pkgs.callPackage ({fetchFromGitHub, rustPlatform,  pkgconfig, libsodium}:
-    rustPlatform.buildRustPackage rec {
-      name = "cryptobox-c-${version}";
-      version = "2019-06-17";
-      buildInputs = [ pkgconfig libsodium ];
-      src = fetchFromGitHub {
-        owner = "wireapp";
-        repo = "cryptobox-c";
-        rev = "4067ad96b125942545dbdec8c1a89f1e1b65d013";
-        sha256 = "1i9dlhw0xk1viglyhail9fb36v1awrypps8jmhrkz8k1bhx98ci3";
-      };
-      cargoSha256 = "1373rpy0fi3cpacv06x1cv4cv0brwdri2680ymdkq8w44syp20ym";
-      postInstall = ''
-        mkdir -p $out/include
-        cp src/cbox.h $out/include
-      '';
-    }) {};
-in
-  pkgs.haskell.lib.buildStackProject {
-    name = "wire-server";
-    buildInputs = with pkgs; [ 
-      docker-compose
-      pkgconfig
-      cryptobox-c 
-      libsodium
-      geoip
-      protobuf
-      openssl
-      snappy
-      icu
-      zlib
-      libxml2
-    ];
-    ghc = pkgs.haskell.compiler.ghc844;
-  }
+{ pkgs ? import <nixpkgs> {}}:
+with pkgs; mkShell {
+  name = "shell";
+  buildInputs = [ 
+    docker-compose
+    gnumake
+    stack
+  ];
+}

--- a/stack-deps.nix
+++ b/stack-deps.nix
@@ -1,0 +1,36 @@
+{ pkgs ? import <nixpkgs> {} }:
+let 
+  cryptobox-c = pkgs.callPackage ({fetchFromGitHub, rustPlatform,  pkgconfig, libsodium}:
+    rustPlatform.buildRustPackage rec {
+      name = "cryptobox-c-${version}";
+      version = "2019-06-17";
+      buildInputs = [ pkgconfig libsodium ];
+      src = fetchFromGitHub {
+        owner = "wireapp";
+        repo = "cryptobox-c";
+        rev = "4067ad96b125942545dbdec8c1a89f1e1b65d013";
+        sha256 = "1i9dlhw0xk1viglyhail9fb36v1awrypps8jmhrkz8k1bhx98ci3";
+      };
+      cargoSha256 = "1373rpy0fi3cpacv06x1cv4cv0brwdri2680ymdkq8w44syp20ym";
+      postInstall = ''
+        mkdir -p $out/include
+        cp src/cbox.h $out/include
+      '';
+    }) {};
+in
+  pkgs.haskell.lib.buildStackProject {
+    name = "wire-server";
+    buildInputs = with pkgs; [ 
+      pkgconfig
+      cryptobox-c 
+      libsodium
+      geoip
+      protobuf
+      openssl
+      snappy
+      icu
+      zlib
+      libxml2
+    ];
+    ghc = pkgs.haskell.compiler.ghc844;
+  }

--- a/stack.yaml
+++ b/stack.yaml
@@ -74,4 +74,4 @@ flags:
 allow-newer: false
 
 nix:
-  shell-file: shell.nix
+  shell-file: stack-deps.nix


### PR DESCRIPTION
Stack started not liking being called from a nix-shell anymore, because
stack wants to create the nix-shell itself so it does some
auto-detection and crashes.  To trick it into doing the right thing
again, we only use the nix-shell for non-build-deps and just for dev
tools, then stack itself will call another nix-shell file that just
handles build deps for the stack project.

(just opening this PR for arian since he's budy :))