### PR TITLE
gundeck: fix incorrect boolean logic

### DIFF
--- a/services/gundeck/src/Gundeck/ThreadBudget.hs
+++ b/services/gundeck/src/Gundeck/ThreadBudget.hs
@@ -221,8 +221,8 @@ removeStaleHandles ref = do
       mapM_ waitCatch . join . fmap snd =<< HM.lookup key . bmap <$> readIORef ref
       unregister ref key
 
-  isUnsanitary <- atomicModifyIORef' ref sanitize
-  when isUnsanitary . LC.warn . LC.msg . LC.val $
+  isSanitary <- atomicModifyIORef' ref sanitize
+  unless isSanitary . LC.warn . LC.msg . LC.val $
     "watchThreadBudgetState: total overall thread budget diverged from async weights (repaired)."
 
   where


### PR DESCRIPTION
Currently, we get spammed with these warnings before any traffic
happens, due to an incorrect handling of booleans introduced in #869 .
```
[gundeck] W, request=N/A, watchThreadBudgetState: total overall thread budget diverged from async weights (repaired).
[gundeck] W, request=N/A, watchThreadBudgetState: total overall thread budget diverged from async weights (repaired).
[gundeck] W, request=N/A, watchThreadBudgetState: total overall thread budget diverged from async weights (repaired).
```

It's questionable whether this "sanitization" is necessary and should be used at all, as [a comment](https://github.com/wireapp/wire-server/blob/develop/services/gundeck/src/Gundeck/ThreadBudget.hs#L63-L72) indicates this should only be used in testing (but it's used in the "prod" watcher thread here).