### PR TITLE
benchmarking for O(n) function, remove expensive call from atomicModifyIORef

### DIFF
--- a/services/gundeck/package.yaml
+++ b/services/gundeck/package.yaml
@@ -224,9 +224,12 @@ benchmarks:
     - gundeck
     - gundeck-types
     - HsOpenSSL
+    - random
     - text
     - types-common
     - unordered-containers
+    - time
+    - uuid
 flags:
   static:
     description: Enable static linking

--- a/services/gundeck/src/Gundeck/ThreadBudget.hs
+++ b/services/gundeck/src/Gundeck/ThreadBudget.hs
@@ -68,7 +68,7 @@ data BudgetMap = BudgetMap
 -- counts all the threads that are successfully running (dropping the ones that are just about
 -- to try to grab a token).
 --
--- WARNING: takes O(n)), use with care.  See '_bench_BudgetSpent''.
+-- WARNING: takes O(n)), use with care.  See 'bench_BudgetSpent''.
 budgetSpent :: ThreadBudgetState -> IO Int
 budgetSpent (ThreadBudgetState _ running) = budgetSpent' <$> readIORef running
 

--- a/services/gundeck/src/Gundeck/ThreadBudget.hs
+++ b/services/gundeck/src/Gundeck/ThreadBudget.hs
@@ -40,6 +40,7 @@ import Data.Time
 import Data.UUID (UUID, toText)
 import Data.UUID.V4 (nextRandom)
 import Gundeck.Options
+import System.Random (randomRIO)
 import UnliftIO.Async
 import UnliftIO.Exception (finally)
 
@@ -64,12 +65,35 @@ data BudgetMap = BudgetMap
 -- counts all the threads that are successfully running (dropping the ones that are just about
 -- to try to grab a token).
 --
--- WARNING: takes O(n)) and should only be used in testing.
+-- WARNING: takes O(n)), use with care.  See '_bench_BudgetSpent''.
 budgetSpent :: ThreadBudgetState -> IO Int
 budgetSpent (ThreadBudgetState _ running) = budgetSpent' <$> readIORef running
 
 budgetSpent' :: BudgetMap -> Int
 budgetSpent' = sum . fmap fst . filter (isJust . snd) . HM.elems . bmap
+
+-- very ad-hoc benchmark in ghci on my laptop:
+--
+-- ThreadBudget> _bench_BudgetSpent' $ 100*1000
+-- 2019-10-24 11:34:08.696000955 UTC
+-- 0
+-- 2019-10-24 11:34:08.862147318 UTC
+-- 0
+-- 2019-10-24 11:34:08.893983895 UTC
+_bench_BudgetSpent' :: Int -> IO ()
+_bench_BudgetSpent' size = do
+  ThreadBudgetState _ ref <- mkThreadBudgetState (MaxConcurrentNativePushes Nothing Nothing)
+  forM_ [1..size] $ \_ -> do
+    key <- nextRandom
+    weight <- randomRIO (1, 1000)
+    allocate ref key weight
+  budgetmap <- readIORef ref
+
+  print =<< getCurrentTime
+  print $ budgetSpent' budgetmap
+  print =<< getCurrentTime
+  print $ budgetSpent' budgetmap
+  print =<< getCurrentTime
 
 cancelAllThreads :: ThreadBudgetState -> IO ()
 cancelAllThreads (ThreadBudgetState _ ref) = readIORef ref

--- a/services/gundeck/test/bench/Main.hs
+++ b/services/gundeck/test/bench/Main.hs
@@ -6,16 +6,25 @@ import Data.Id (randomId, ConnId (..), ClientId (..))
 import Gundeck.Types.Push
 import Gundeck.Push.Native.Serialise
 import Gundeck.Push.Native.Types
+import Gundeck.ThreadBudget
+import Gundeck.Options
 import Network.AWS (Region (Ireland))
 import OpenSSL (withOpenSSL)
+import System.Random (randomRIO)
+import Data.UUID.V4 (nextRandom)
 
 import qualified Data.Text.Lazy      as LT
 
 main :: IO ()
 main = withOpenSSL $ do
+    prepared <- prepareBudgetState (100000)
     defaultMain [
         bgroup "notice"
             [ bench "32"   $ nfIO notice
+            ]
+        , bgroup "ThreadBudget"
+            [ bench "budgetSpent'" $ nfIO (bench_BudgetSpent' prepared)
+            , bench "prepare + budgetSpent'" $ nfIO (bench_BudgetSpent' =<< prepareBudgetState 100000)
             ]
         ]
 
@@ -29,6 +38,11 @@ notice = do
     let msg   = NativePush i HighPriority Nothing
     Right txt <- serialise msg a
     return $! LT.toStrict txt
+
+bench_BudgetSpent' :: IORef BudgetMap -> IO ()
+bench_BudgetSpent' ref = do
+    budgetmap <- readIORef ref
+    void $ return $ budgetSpent' budgetmap
 
 -----------------------------------------------------------------------------
 -- Utilities
@@ -47,3 +61,12 @@ mkEndpoint :: Transport -> AppName -> EndpointArn
 mkEndpoint t a = mkSnsArn Ireland (Account "test") topic
   where
     topic = mkEndpointTopic (ArnEnv "test") t a (EndpointId "test")
+
+prepareBudgetState :: Int -> IO (IORef BudgetMap)
+prepareBudgetState size = do
+    ref <- _threadBudgetRunning <$> mkThreadBudgetState (MaxConcurrentNativePushes Nothing Nothing)
+    forM_ [1..size] $ \_ -> do
+        key <- nextRandom
+        weight <- randomRIO (1, 1000)
+        allocate ref key weight
+    return ref


### PR DESCRIPTION
Just a little experiment to extablish whether we really want to call the more expensive `budgetSpent`, and not just `bsize`, for the metrics.