### PR TITLE
Change order in which user data is created in spar

### DIFF
--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -169,8 +169,8 @@ createSamlUser suid mbName managedBy = do
 createSamlUserWithId :: UserId -> SAML.UserRef -> Maybe Name -> ManagedBy -> Spar ()
 createSamlUserWithId buid suid mbName managedBy = do
   teamid <- (^. idpExtraInfo) <$> getIdPConfigByIssuer (suid ^. uidTenant)
-  insertUser suid buid
   buid' <- Intra.createBrigUser suid buid teamid mbName managedBy
+  insertUser suid buid
   assert (buid == buid') $ pure ()
 
 -- | If the team has no scim token, call 'createSamlUser'.  Otherwise, raise "invalid

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -248,10 +248,6 @@ createValidScimUser (ValidScimUser user uref handl mbName richInfo) = do
     assertUserRefUnused uref
     assertHandleUnused handl buid
 
-    -- Create SCIM user here in spar.
-    storedUser <- lift $ toScimStoredUser buid user
-    lift . wrapMonadClient $ Data.insertScimUser buid storedUser
-
     -- Create SAML user here in spar, which in turn creates a brig user. The user is created
     -- with 'ManagedByScim', which signals to client apps that the user should not be editable
     -- from the app (and ideally brig should also enforce this). See {#DevScimOneWaySync}.
@@ -263,6 +259,10 @@ createValidScimUser (ValidScimUser user uref handl mbName richInfo) = do
 
     -- Set rich info on brig
     lift $ Intra.Brig.setBrigUserRichInfo buid richInfo
+
+    -- Create SCIM user here in spar.
+    storedUser <- lift $ toScimStoredUser buid user
+    lift . wrapMonadClient $ Data.insertScimUser buid storedUser
 
     pure storedUser
 

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -22,7 +22,6 @@ import qualified SAML2.WebSSO.Test.MockResponse   as SAML
 import qualified Spar.Data                        as Data
 import qualified Spar.Intra.Brig                  as Intra
 import qualified Web.Scim.Class.User              as ScimC.User
-import qualified Web.Scim.Class.User              as Scim.UserC
 import qualified Web.Scim.Schema.Common           as Scim
 import qualified Web.Scim.Schema.Meta             as Scim
 import qualified Web.Scim.Schema.User             as Scim.User
@@ -198,7 +197,7 @@ testRichInfo = do
     let -- validate response
         checkStoredUser
             :: HasCallStack
-            => Scim.UserC.StoredUser SparTag -> RichInfo -> TestSpar ()
+            => ScimC.User.StoredUser SparTag -> RichInfo -> TestSpar ()
         checkStoredUser storedUser rinf = liftIO $ do
             (Scim.User.extra . Scim.value . Scim.thing) storedUser
                 `shouldBe` (ScimUserExtra rinf)
@@ -258,7 +257,7 @@ testScimCreateVsUserRef = do
                                        -- change this to 'isNothing'.)
 
     tok <- registerScimToken teamid (Just (idp ^. SAML.idpId))
-    storedusr :: Scim.UserC.StoredUser SparTag
+    storedusr :: ScimC.User.StoredUser SparTag
         <- do
           resp <- aFewTimes (createUser_ (Just tok) usr =<< view teSpar) ((== 201) . statusCode)
               <!! const 201 === statusCode


### PR DESCRIPTION
before: `[ scim -> ] saml -> brig`
now: `brig -> saml [ -> scim ]`

Rationale: creation of users via scim (or implicitly via saml) is
idempotent; dealing with zombie users in brig is easier than handling
all errors correctly that can happen in brig during creating a user.