### PR TITLE
Feature/gundeck limit parallel connections

### DIFF
--- a/services/gundeck/gundeck.integration.yaml
+++ b/services/gundeck/gundeck.integration.yaml
@@ -24,6 +24,7 @@ settings:
   httpPoolSize: 1024
   notificationTTL: 24192200
   bulkPush: true
+  perNativePushConcurrency: 32
   maxConcurrentNativePushes:
     hard: 30  # more than this number of threads will not be allowed
     soft: 10  # more than this number of threads will be warned about

--- a/services/gundeck/src/Gundeck/Options.hs
+++ b/services/gundeck/src/Gundeck/Options.hs
@@ -38,6 +38,10 @@ data Settings = Settings
     , _setBulkPush        :: !Bool
     -- | Maximum number of concurrent threads calling SNS.
     , _setMaxConcurrentNativePushes :: !(Maybe MaxConcurrentNativePushes)
+    -- | Maximum number of parallel requests to SNS and cassandra
+    -- during native push processing (per incoming push request)
+    -- defaults to unbounded, if unset.
+    , _setPerNativePushConcurrency  :: !(Maybe Int)
     } deriving (Show, Generic)
 
 data MaxConcurrentNativePushes = MaxConcurrentNativePushes

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -193,10 +193,10 @@ pushAll pushes = do
         -- native push
         forM_ resp $ \((notif :: Notification, psh :: Push), alreadySent :: [Presence]) -> do
             let rcps' = nativeTargetsRecipients psh
-                budget = length rcps'
-                  -- this is a rough budget, since there may be more than one device in a
+                budget = min 32 (length rcps')
+                  -- ^ this is a rough budget, since there may be more than one device in a
                   -- 'Presence', so one budget token may trigger at most 8 push notifications
-                  -- to be sent out.
+                  -- to be sent out. We take the min with 32, as native push requests to cassandra and SNS are limited to 32 in parallel.
             unless (psh ^. pushTransient)
                 $ mpaRunWithBudget budget ()
                     $ mpaPushNative notif psh =<< nativeTargets psh rcps' alreadySent

--- a/services/gundeck/src/Gundeck/Push/Native.hs
+++ b/services/gundeck/src/Gundeck/Push/Native.hs
@@ -29,11 +29,16 @@ import qualified Gundeck.Aws               as Aws
 import qualified Gundeck.Notification.Data as Stream
 import qualified Gundeck.Push.Data         as Data
 import qualified System.Logger.Class       as Log
+import qualified Data.List.Extra           as List
 
 push :: NativePush -> [Address] -> Gundeck ()
 push _    [] = pure ()
 push m   [a] = push1 m a
-push m addrs = void $ mapConcurrently (push1 m) addrs
+push m addrs = do
+    -- avoid high amounts of fresh parallel network requests by
+    -- parallelizing only 32 native pushes at a time
+    let chunks = List.chunksOf 32 addrs
+    void $ concat <$> mapM (mapConcurrently (push1 m)) chunks
 
 push1 :: NativePush -> Address -> Gundeck ()
 push1 m a = do

--- a/services/gundeck/test/unit/MockGundeck.hs
+++ b/services/gundeck/test/unit/MockGundeck.hs
@@ -400,6 +400,7 @@ instance MonadNativeTargets MockGundeck where
   mntgtLookupAddresses = mockLookupAddresses
 
 instance MonadMapAsync MockGundeck where
+  mntgtPerPushConcurrency = pure Nothing -- (unbounded)
   mntgtMapAsync f xs = Right <$$> mapM f xs  -- (no concurrency)
 
 instance MonadPushAny MockGundeck where


### PR DESCRIPTION
in connections to cassandra for native push notifications, as well as when connecting to SNS, limit the per-push parallelism to 32 connections at a time.

Update: off by default, made configurable so we can tune as needed.