### PR TITLE
Do not send events to team members to be deleted

### DIFF
--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -598,8 +598,7 @@ testDeleteTeam = do
             const 202 === statusCode
         checkTeamDeleteEvent tid wsOwner
         checkTeamDeleteEvent tid wsMember
-        checkConvDeleteEvent cid1 wsOwner
-        checkConvDeleteEvent cid1 wsMember
+        -- team members should not receive conversation delete events
         checkConvDeleteEvent cid1 wsExtern
         WS.assertNoEvent timeout [wsOwner, wsExtern, wsMember]
 


### PR DESCRIPTION
Events about deleted conversations do not need to be sent to everyone
when a team is deleted. Indeed, it is harmful in that it leads to performance problems:
For large teams with many conversations, notifying
every team member about that fact that every conversation has been
deleted creates a lot of events.
None of these events are useful, since on a team deletion, the accounts
of every user are deleted, i.e. in practice these events cannot be read.

This PR fixes the bug that was introduced in #849