### PR TITLE
http-client: bump to wire-20191104

### DIFF
--- a/snapshots/wire-1.4.yaml
+++ b/snapshots/wire-1.4.yaml
@@ -11,7 +11,7 @@ packages:
   #  - 64ebec4fe7b48c131b7d6f0f8d7a6c6cacae70e6
   #  - 78ebeead1a2efb17c55fb72d2d0041295d1271b8
   #  - 032b6503ab0c47f8f85bf48e0beb1f895a95bb27
-  # These provide a hacky way to implement TLS ceritifcate pinning.
+  # These provide a hacky way to implement TLS certificate pinning.
 - archive: https://github.com/wireapp/http-client/archive/wire-2019-11-04.tar.gz
   subdirs:
   - http-client

--- a/snapshots/wire-1.4.yaml
+++ b/snapshots/wire-1.4.yaml
@@ -4,6 +4,14 @@ resolver: https://raw.githubusercontent.com/wireapp/wire-server/develop/snapshot
 name: wire-1.4
 
 packages:
+  # http-client forked by wire, commit 032b6503ab0c47f8f85bf48e0beb1f895a95bb27
+  # Contains patches on top of http-client-openssl-0.2.2.0:
+  #  - 89136497b8e0fa0624c1451883eb011347203532
+  #  - 916b04313c6864e02ebed4278b43b971189c61cd
+  #  - 64ebec4fe7b48c131b7d6f0f8d7a6c6cacae70e6
+  #  - 78ebeead1a2efb17c55fb72d2d0041295d1271b8
+  #  - 032b6503ab0c47f8f85bf48e0beb1f895a95bb27
+  # These provide a hacky way to implement TLS ceritifcate pinning.
 - archive: https://github.com/wireapp/http-client/archive/wire-2019-11-04.tar.gz
   subdirs:
   - http-client

--- a/snapshots/wire-1.4.yaml
+++ b/snapshots/wire-1.4.yaml
@@ -1,0 +1,12 @@
+# DO NOT MODIFY THIS FILE. See README.md to learn why.
+
+resolver: https://raw.githubusercontent.com/wireapp/wire-server/develop/snapshots/wire-1.3.yaml
+name: wire-1.4
+
+packages:
+- archive: https://github.com/wireapp/http-client/archive/wire-2019-11-04.tar.gz
+  subdirs:
+  - http-client
+  - http-client-openssl
+  - http-client-tls
+  - http-conduit

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: snapshots/wire-1.3.yaml
+resolver: snapshots/wire-1.4.yaml
 
 packages:
 - libs/api-bot


### PR DESCRIPTION
We have updated https://github.com/wireapp/http-client to [wire-20191104](https://github.com/wireapp/http-client/tree/wire-2019-11-04), which includes http-client-openssl-0.2.2.0, and as such should include SNI support when initiating HTTPS connections.