### PR TITLE
throttle galley->gundeck on team deletion

### DIFF
--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -150,6 +150,7 @@ optSettings:
   setEmailVisibility: visible_to_self
   setPropertyMaxKeyLen: 1024
   setPropertyMaxValueLen: 4096
+  setDeleteThrottleMillis: 0
 
 logLevel: Warn
 logNetStrings: false

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -23,6 +23,10 @@ onEvent n = handleTimeout $ case n of
         Log.info $ msg (val "Processing user delete event")
                 ~~ field "user" (toByteString uid)
         API.lookupAccount uid >>= mapM_ API.deleteAccount
+        -- As user deletions are expensive resource-wise in the context of
+        -- bulk user deletions (e.g. during team deletions),
+        -- wait 50ms before processing the next event
+        liftIO $ threadDelay 50000
     DeleteService pid sid -> do
         Log.info $ msg (val "Processing service delete event")
                 ~~ field "provider" (toByteString pid)

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -4,7 +4,9 @@ module Brig.InternalEvent.Process
 
 import Imports
 import Brig.App
+import Brig.Options (setDeleteThrottleMillis, defDeleteThrottleMillis)
 import Brig.InternalEvent.Types
+import Control.Lens (view)
 import Control.Monad.Catch
 import Data.ByteString.Conversion
 import System.Logger.Class (field, msg, (~~), val)
@@ -25,8 +27,9 @@ onEvent n = handleTimeout $ case n of
         API.lookupAccount uid >>= mapM_ API.deleteAccount
         -- As user deletions are expensive resource-wise in the context of
         -- bulk user deletions (e.g. during team deletions),
-        -- wait 50ms before processing the next event
-        liftIO $ threadDelay 50000
+        -- wait 'delay' ms before processing the next event
+        delay <- fromMaybe defDeleteThrottleMillis . setDeleteThrottleMillis <$> view settings
+        liftIO $ threadDelay (1000 * delay)
     DeleteService pid sid -> do
         Log.info $ msg (val "Processing service delete event")
                 ~~ field "provider" (toByteString pid)

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -312,6 +312,9 @@ data Settings = Settings
 
     , setPropertyMaxKeyLen     :: !(Maybe Int64)
     , setPropertyMaxValueLen   :: !(Maybe Int64)
+    , setDeleteThrottleMillis  :: !(Maybe Int) -- ^ How long, in milliseconds, to wait
+                                               -- in between processing delete events
+                                               -- from the internal delete queue
 
     } deriving (Show, Generic)
 
@@ -320,6 +323,9 @@ defMaxKeyLen = 256
 
 defMaxValueLen :: Int64
 defMaxValueLen = 512
+
+defDeleteThrottleMillis :: Int
+defDeleteThrottleMillis = 50
 
 instance FromJSON Timeout where
     parseJSON (Y.Number n) =

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -325,7 +325,7 @@ defMaxValueLen :: Int64
 defMaxValueLen = 512
 
 defDeleteThrottleMillis :: Int
-defDeleteThrottleMillis = 50
+defDeleteThrottleMillis = 100
 
 instance FromJSON Timeout where
     parseJSON (Y.Number n) =

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -26,6 +26,9 @@ settings:
   maxConvSize: 16
   intraListing: false
   conversationCodeURI: https://app.wire.com/join/
+  concurrentDeletionEvents: 1024
+  deleteConvThrottleMillis: 0
+
   featureFlags:  # see #RefConfigOptions in `/docs/reference`
     sso: disabled-by-default
     legalhold: disabled-by-default

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -191,24 +191,12 @@ uncheckedDeleteTeam zusr zcon tid = do
     team <- Data.team tid
     when (isJust team) $ do
         Spar.deleteTeam tid
-        o        <- view $ options . optSettings
         membs    <- Data.teamMembers tid
         now      <- liftIO getCurrentTime
         convs    <- filter (not . view managedConversation) <$> Data.teamConversations tid
-        (ue, be) <- foldrM (pushConvDeleteEvents now membs) ([],[]) convs
+        (ue, be) <- foldrM (createConvDeleteEvents now membs) ([],[]) convs
         let e = newEvent TeamDelete tid now
-        let r = list1 (userRecipient zusr) (membersToRecipients (Just zusr) membs)
-        -- To avoid DoS on gundeck, send team deletion events in chunks
-        let chunkSize = fromMaybe defConcurrentDeletionEvents (o^.setConcurrentDeletionEvents)
-        let chunks = List.chunksOf chunkSize (toList r)
-        forM_ chunks $ \chunk -> case chunk of
-            [] -> return ()
-            x:xs -> push1 (newPush1 zusr (TeamEvent e) (list1 x xs) & pushConn .~ zcon)
-        -- To avoid DoS on gundeck, send conversation deletion events slowly
-        let delay = 1000 * (fromMaybe defDeleteConvThrottleMillis (o^.setDeleteConvThrottleMillis))
-        forM_ ue $ \event -> do
-            push1 event
-            threadDelay delay
+        pushDeleteEvents membs e ue
         void . forkIO $ void $ External.deliver be
         -- TODO: we don't delete bots here, but we should do that, since
         -- every bot user can only be in a single conversation. Just
@@ -218,13 +206,32 @@ uncheckedDeleteTeam zusr zcon tid = do
             Journal.teamDelete tid
         Data.deleteTeam tid
   where
-    pushConvDeleteEvents
+    pushDeleteEvents :: [TeamMember] -> Event -> [Push] -> Galley ()
+    pushDeleteEvents membs e ue = do
+        o <- view $ options . optSettings
+        let r = list1 (userRecipient zusr) (membersToRecipients (Just zusr) membs)
+        -- To avoid DoS on gundeck, send team deletion events in chunks
+        let chunkSize = fromMaybe defConcurrentDeletionEvents (o^.setConcurrentDeletionEvents)
+        let chunks = List.chunksOf chunkSize (toList r)
+        forM_ chunks $ \chunk -> case chunk of
+            [] -> return ()
+            -- push TeamDelete events
+            x:xs -> push1 (newPush1 zusr (TeamEvent e) (list1 x xs) & pushConn .~ zcon)
+
+        -- To avoid DoS on gundeck, send conversation deletion events slowly
+        let delay = 1000 * (fromMaybe defDeleteConvThrottleMillis (o^.setDeleteConvThrottleMillis))
+        forM_ ue $ \event -> do
+            -- push ConversationDelete events
+            push1 event
+            threadDelay delay
+
+    createConvDeleteEvents
         :: UTCTime
         -> [TeamMember]
         -> TeamConversation
         -> ([Push],[(BotMember, Conv.Event)])
         -> Galley ([Push],[(BotMember, Conv.Event)])
-    pushConvDeleteEvents now teamMembs c (pp, ee) = do
+    createConvDeleteEvents now teamMembs c (pp, ee) = do
         (bots, convMembs) <- botsAndUsers <$> Data.members (c ^. conversationId)
         -- Only nonTeamMembers need to get any events, since on team deletion,
         -- all team users are deleted immediately after these events are sent

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -12,20 +12,30 @@ import Galley.Types.Teams (FeatureFlags(..))
 data Settings = Settings
     {
     -- | Number of connections for the HTTP client pool
-      _setHttpPoolSize          :: !Int
+      _setHttpPoolSize              :: !Int
     -- | Max number of members in a team. NOTE: This must be in sync with Brig
-    , _setMaxTeamSize           :: !Word16
+    , _setMaxTeamSize               :: !Word16
     -- | Max number of members in a conversation. NOTE: This must be in sync with Brig
-    , _setMaxConvSize           :: !Word16
+    , _setMaxConvSize               :: !Word16
     -- | Whether to call Brig for device listing
-    , _setIntraListing          :: !Bool
+    , _setIntraListing              :: !Bool
     -- | URI prefix for conversations with access mode @code@
-    , _setConversationCodeURI   :: !HttpsUrl
-    , _setFeatureFlags          :: !FeatureFlags
+    , _setConversationCodeURI       :: !HttpsUrl
+    -- | Throttling: limits to concurrent deletion events
+    , _setConcurrentDeletionEvents  :: !(Maybe Int)
+    -- | Throttling: delay between sending events upon team deletion
+    , _setDeleteConvThrottleMillis  :: !(Maybe Int)
+    , _setFeatureFlags              :: !FeatureFlags
     } deriving (Show, Generic)
 
 deriveFromJSON toOptionFieldName ''Settings
 makeLenses ''Settings
+
+defConcurrentDeletionEvents :: Int
+defConcurrentDeletionEvents = 128
+
+defDeleteConvThrottleMillis :: Int
+defDeleteConvThrottleMillis = 20
 
 data JournalOpts = JournalOpts
     { _awsQueueName :: !Text         -- ^ SQS queue name to send team events


### PR DESCRIPTION
Even though #897 already reduces the amount of events sent on team deletions, the function logic on team deletions is unbounded in the number of events sent in parallel: Every non-team member of every team conversation gets an event for each conversation that is deleted (N=unbounded), and every team member gets an event that their team has been deleted (M=MAX_TEAM_SIZE).
This PR thus reduces the events sent in parallel from M+N=unbounded at once to `N=MAX_CONV_SIZE - 1` and `M=128` during team deletion, irrespective of team size.

Note that these constraints apply only to team deletions, not other events.

Also adds a delay when processing user deletions.