### PR TITLE
SCIM fixes Phase 0: User creation in correct order

### DIFF
--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -168,9 +168,9 @@ createSamlUser suid mbName managedBy = do
 createSamlUserWithId :: UserId -> SAML.UserRef -> Maybe Name -> ManagedBy -> Spar ()
 createSamlUserWithId buid suid mbName managedBy = do
   teamid <- (^. idpExtraInfo) <$> getIdPConfigByIssuer (suid ^. uidTenant)
-  insertUser suid buid
   buid' <- Intra.createBrigUser suid buid teamid mbName managedBy
   assert (buid == buid') $ pure ()
+  insertUser suid buid
 
 -- | If the team has no scim token, call 'createSamlUser'.  Otherwise, raise "invalid
 -- credentials".

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -10,8 +10,6 @@ module Spar.App
   , verdictHandler
   , getUser
   , insertUser
-  , createSamlUser
-  , createSamlUserWithId
   , autoprovisionSamlUser
   , autoprovisionSamlUserWithId
   ) where
@@ -139,6 +137,7 @@ getUser uref = do
   muid <- wrapMonadClient $ Data.getSAMLUser uref
   case muid of
     Nothing -> pure Nothing
+    -- TODO(arianvp): Why does it check if it is a team user? Ask Tiago
     Just uid -> do
       itis <- Intra.isTeamUser uid
       pure $ if itis then Just uid else Nothing
@@ -159,11 +158,11 @@ getUser uref = do
 -- FUTUREWORK: once we support <https://github.com/wireapp/hscim scim>, brig will refuse to delete
 -- users that have an sso id, unless the request comes from spar.  then we can make users
 -- undeletable in the team admin page, and ask admins to go talk to their IdP system.
-createSamlUser :: SAML.UserRef -> Maybe Name -> ManagedBy -> Spar UserId
+{-createSamlUser :: SAML.UserRef -> Maybe Name -> ManagedBy -> Spar UserId
 createSamlUser suid mbName managedBy = do
   buid <- Id <$> liftIO UUID.nextRandom
   createSamlUserWithId buid suid mbName managedBy
-  pure buid
+  pure buid-}
 
 -- | Like 'createSamlUser', but for an already existing 'UserId'.
 createSamlUserWithId :: UserId -> SAML.UserRef -> Maybe Name -> ManagedBy -> Spar ()

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -27,6 +27,7 @@ import Brig.Types.User as BrigTypes
 import Spar.Intra.Brig as Brig
 import Control.Lens hiding ((.=), Strict)
 import Control.Monad.Except
+import Control.Exception (assert)
 import Crypto.Hash
 import Data.Aeson as Aeson
 import Data.Id
@@ -35,7 +36,7 @@ import Data.String.Conversions
 import Galley.Types.Teams    as Galley
 import Network.URI
 
-import Spar.App (Spar, Env, wrapMonadClient, sparCtxOpts, createSamlUserWithId, wrapMonadClient, getUser)
+import Spar.App (Spar, Env, wrapMonadClient, sparCtxOpts,  wrapMonadClient, getUser)
 import Spar.Intra.Galley
 import Spar.Scim.Types
 import Spar.Scim.Auth ()
@@ -245,31 +246,22 @@ createValidScimUser
 createValidScimUser (ValidScimUser user uref handl mbName richInfo) = do
     -- Generate a UserId will be used both for scim user in spar and for brig.
     buid <- Id <$> liftIO UUID.nextRandom
-
     -- ensure uniqueness constraints of all affected identifiers.
     assertUserRefUnused uref
     assertHandleUnused handl buid
-
-    -- Create SCIM user here in spar.
+    -- TODO(arianvp): Get rid of manual lifting. Needs to be SCIM instances for ExceptT
+    -- This is the pain and the price you pay for the horribleness called MTL
     storedUser <- lift $ toScimStoredUser buid user
-    lift . wrapMonadClient $ Data.insertScimUser buid storedUser
-
-    -- Create SAML user here in spar, which in turn creates a brig user. The user is created
-    -- with 'ManagedByScim', which signals to client apps that the user should not be editable
-    -- from the app (and ideally brig should also enforce this). See {#DevScimOneWaySync}.
-    lift $ createSamlUserWithId buid uref mbName ManagedByScim
-
-    -- Set user handle on brig (which can't be done during user creation yet).
-    -- TODO: handle errors better here?
+    idpConfig <-  lift $ SAML.getIdPConfigByIssuer (uref ^. SAML.uidTenant)
+    let teamid = view SAML.idpExtraInfo idpConfig
+    lift . wrapMonadClient $ Data.insertSAMLUser uref buid
+    buid' <- lift $ Intra.Brig.createBrigUser uref buid teamid mbName ManagedByScim
+    assert (buid == buid') $ pure ()
     lift $ Intra.Brig.setBrigUserHandle buid handl
-
-    -- Set rich info on brig
     lift $ Intra.Brig.setBrigUserRichInfo buid richInfo
-
+    lift . wrapMonadClient $ Data.insertScimUser buid storedUser
+    lift . wrapMonadClient $ Data.insertSAMLUser uref buid
     pure storedUser
-
-    -- FUTUREWORK: think about potential failure points in this function (SCIM can succeed but
-    -- SAML can fail, Brig user creation can succeed but handle-setting can fail).
 
 updateValidScimUser
   :: forall m. (m ~ Scim.ScimHandler Spar)

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -179,8 +179,10 @@ validateScimUser' idp richInfoLimit user = do
     pure $ ValidScimUser user uref handl mbName richInfo
   where
     -- Validate a handle (@userName@).
+    -- We should lowercase the wire handle here first, as SCIM says it's case insensitive.
+    -- TODO(arianvp): We should do this at the hscim level. but for now I do it here
     validateHandle :: Text -> m Handle
-    validateHandle txt = case parseHandle txt of
+    validateHandle txt = case parseHandle (Text.toLower txt) of
         Just h -> pure h
         Nothing -> throwError $ Scim.badRequest Scim.InvalidValue
             (Just "userName must be a valid Wire handle")

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -243,6 +243,7 @@ specFinalizeLogin = do
           it "logs out user B, logs in user A" $ do
             pending
 
+        -- TODO(arianvp): Ask Matthias what this even means
         context "more than one dsig cert" $ do
           it "accepts the first of two certs for signatures" $ do
             pending
@@ -266,10 +267,12 @@ specFinalizeLogin = do
             statusCode sparresp `shouldBe` 404
             responseJsonEither sparresp `shouldBe` Right (TestErrorLabel "not-found")
 
+      -- TODO(arianvp): Ask Matthias what this even means
       context "AuthnResponse does not match any request" $ do
         it "rejects" $ do
           pending
 
+      -- TODO(arianvp): Ask Matthias what this even means
       context "AuthnResponse contains assertions that have been offered before" $ do
         it "rejects" $ do
           pending


### PR DESCRIPTION
This should make us more robust against partial failures, especially after we implement `PATCH` for SCIM.

I have no idea how to test this properly as we don't seem to have a good story in our test framework for testing components that fail on purpose.  I would love us to be able to programmatically call into other components, instead of having them as fixed processes. This would allow us to write an intricate test for this. Alternative ideas are welcome; as we probably don't have time to refactor our test suite to allow this :P (Though we should definitely discuss this at some time in the future).