### PR TITLE
services/brig: pave way for local whitelist

### DIFF
--- a/docs/reference/user/activation.md
+++ b/docs/reference/user/activation.md
@@ -129,7 +129,22 @@ X-Zeta-Code: 123456
 
 ## Phone/email whitelist {#RefActivationWhitelist}
 
-The backend can be configured to only allow specific phone numbers or email addresses to register. The following options have to be set in `brig.yaml`:
+The backend can be configured to only allow specific phone numbers or email addresses to register.
+
+There are two whitelisting methods:
+
+ - contact an external whitelisting service by HTTP
+ - use built-in whitelisting
+
+Both are configured by settings options in `brig.yaml`. If both are configured simultaneously, internal whitelisting is ignored.
+
+If an email address or phone number are rejected by the whitelist, `POST /activate/send` or `POST /register` will return `403 Forbidden`:
+
+### External whitelisting
+
+External whitelisting is **deprecated** and will be removed in a future version of Wire-Server.
+
+The following options have to be set in `brig.yaml`:
 
 ```yaml
 optSettings:
@@ -141,7 +156,20 @@ optSettings:
 
 When those options are present, the backend will do a GET request at `<whitelistUrl>?email=...` or `<whitelistUrl>?mobile=...` for every activation request it receives. It will expect either status code 200 ("everything good") or 404 ("provided email/phone is not on the whitelist").
 
-If an email address or phone number are rejected by the whitelist, `POST /activate/send` or `POST /register` will return `403 Forbidden`:
+### Internal whitelisting
+
+Internal whitelisting currently only supports filtering by email domain. Activations/registrations will only be allowed from emails that are directly specified in a static list of domains.
+
+The following options have to be set in `brig.yaml`:
+
+```yaml
+optSettings:
+  setWhitelist:
+    whitelistDomains:
+     - example.com
+     - contractor.com
+```
+
 
 ```json
 {

--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -88,6 +88,6 @@ checkWhitelist key = do
     wex <- setWhitelist <$> view settings
     win <- setInternalWhitelist <$> view settings
     ok <- case (wex, win) of (Just b, _) -> Whitelist.verifyService b key
-                             (_, Just b) -> Whitelist.verifyInternal b key
+                             (_, Just b) -> pure $ Whitelist.verifyInternal b key
                              _           -> pure True
     unless ok (throwStd whitelistError)

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -8,7 +8,7 @@ import Brig.Queue.Types (Queue (..))
 import Brig.SMTP (SMTPConnType (..))
 import Brig.Types
 import Brig.User.Auth.Cookie.Limit
-import Brig.Whitelist (Whitelist(..))
+import Brig.Whitelist (Whitelist(..), InternalWhitelist(..))
 import qualified Control.Lens as Lens
 import Data.Aeson.Types (typeMismatch)
 import Data.Aeson (withText)
@@ -280,7 +280,8 @@ data Settings = Settings
     , setTwilio                :: !FilePathSecrets  -- ^ Twilio credentials
     , setNexmo                 :: !FilePathSecrets  -- ^ Nexmo credentials
     , setStomp                 :: !(Maybe FilePathSecrets)  -- ^ STOMP broker credentials
-    , setWhitelist             :: !(Maybe Whitelist) -- ^ Whitelist of allowed emails/phones
+    , setWhitelist             :: !(Maybe Whitelist)         -- ^ External whitelist of allowed emails/phones
+    , setInternalWhitelist     :: !(Maybe InternalWhitelist) -- ^ Internal whitelist of allowed emails/phones
     , setUserMaxConnections    :: !Int64    -- ^ Max. number of sent/accepted
                                             --   connections per user
     , setCookieDomain          :: !Text     -- ^ The domain to restrict cookies to

--- a/services/brig/src/Brig/Whitelist.hs
+++ b/services/brig/src/Brig/Whitelist.hs
@@ -44,34 +44,34 @@ deriveJSON toOptionFieldName 'internalWhitelistDomains
 -- consults a statically configured whitelist of allowed email domains..
 verifyInternal :: InternalWhitelist -> Either Email Phone -> Bool
 verifyInternal (InternalWhitelist domains) key =
-  let allowFromDomains (Left e) = (emailDomain e) `elem` domains
-      allowFromDomains _        = False
-  in allowFromDomains key
+    let allowFromDomains (Left e) = (emailDomain e) `elem` domains
+        allowFromDomains _        = False
+    in allowFromDomains key
 
 -- | Do a request to the whitelist service and verify that the provided email/phone address is
 -- whitelisted.
 verifyService :: (MonadIO m, MonadMask m, MonadHttp m) => Whitelist -> Either Email Phone -> m Bool
 verifyService (Whitelist url user pass) key = if isKnownDomain key
-  then return True
-  else recovering x3 httpHandlers . const $ do
-     rq <- parseRequest $ T.unpack url
-     rsp <- get' rq $ req (encodeUtf8 user) (encodeUtf8 pass)
-     case statusCode rsp of
-         200 -> return True
-         404 -> return False
-         _   -> throwM $
-             HttpExceptionRequest rq (StatusCodeException (rsp { responseBody = () }) mempty)
-  where
-    -- Duplicate behaviour from verifyLocal, keeping old behaviour for
-    -- compatibility.
-    isKnownDomain (Left e) = emailDomain e == "wire.com"
-    isKnownDomain _        = False
+    then return True
+    else recovering x3 httpHandlers . const $ do
+        rq <- parseRequest $ T.unpack url
+        rsp <- get' rq $ req (encodeUtf8 user) (encodeUtf8 pass)
+        case statusCode rsp of
+            200 -> return True
+            404 -> return False
+            _   -> throwM $
+                HttpExceptionRequest rq (StatusCodeException (rsp { responseBody = () }) mempty)
+    where
+      -- Duplicate behaviour from verifyLocal, keeping old behaviour for
+      -- compatibility.
+      isKnownDomain (Left e) = emailDomain e == "wire.com"
+      isKnownDomain _        = False
 
-    urlEmail = queryItem "email" . encodeUtf8 . fromEmail
-    urlPhone = queryItem "mobile" . encodeUtf8 . fromPhone
+      urlEmail = queryItem "email" . encodeUtf8 . fromEmail
+      urlPhone = queryItem "mobile" . encodeUtf8 . fromPhone
 
-    req u p = port 443 . secure
-            . either urlEmail urlPhone key
-            . applyBasicAuth u p
+      req u p = port 443 . secure
+              . either urlEmail urlPhone key
+              . applyBasicAuth u p
 
-    x3 = limitRetries 3 <> exponentialBackoff 100000
+      x3 = limitRetries 3 <> exponentialBackoff 100000

--- a/services/brig/src/Brig/Whitelist.hs
+++ b/services/brig/src/Brig/Whitelist.hs
@@ -18,10 +18,11 @@ import Bilge.Retry
 import Brig.Types
 import Control.Monad.Catch (MonadMask, throwM)
 import Control.Retry
-import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), parseRequest)
 import Util.Options.Common (toOptionFieldName)
+
+import qualified Data.Text as T
 
 -- | A service providing a whitelist of allowed email addresses and phone numbers
 -- DEPRECATED: use internal whitelisting instead!
@@ -41,11 +42,11 @@ deriveJSON toOptionFieldName 'internalWhitelistDomains
 
 -- | Check internal whitelist for given email/phone number. Currently this
 -- consults a statically configured whitelist of allowed email domains..
-verifyInternal :: (MonadIO m, MonadMask m, MonadHttp m) => InternalWhitelist -> Either Email Phone -> m Bool
+verifyInternal :: InternalWhitelist -> Either Email Phone -> Bool
 verifyInternal (InternalWhitelist domains) key =
   let allowFromDomains (Left e) = (emailDomain e) `elem` domains
       allowFromDomains _        = False
-  in pure $ allowFromDomains key
+  in allowFromDomains key
 
 -- | Do a request to the whitelist service and verify that the provided email/phone address is
 -- whitelisted.

--- a/services/brig/src/Brig/Whitelist.hs
+++ b/services/brig/src/Brig/Whitelist.hs
@@ -1,10 +1,16 @@
 -- | > docs/reference/user/activation.md {#RefActivationWhitelist}
 --
 -- Email/phone whitelist.
-module Brig.Whitelist (Whitelist (..), verify) where
+module Brig.Whitelist
+    ( Whitelist (..)
+    , InternalWhitelist (..)
+    , verifyInternal
+    , verifyService
+    ) where
 
 import Imports
 import Data.Aeson
+import Data.Aeson.TH (deriveJSON)
 import Bilge.IO
 import Bilge.Request
 import Bilge.Response
@@ -12,33 +18,51 @@ import Bilge.Retry
 import Brig.Types
 import Control.Monad.Catch (MonadMask, throwM)
 import Control.Retry
-import Data.Text
+import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), parseRequest)
+import Util.Options.Common (toOptionFieldName)
 
 -- | A service providing a whitelist of allowed email addresses and phone numbers
+-- DEPRECATED: use internal whitelisting instead!
 data Whitelist = Whitelist
     { whitelistUrl  :: !Text     -- ^ Service URL
-    , whitelistUser :: !Text     -- ^ Username
-    , whitelistPass :: !Text     -- ^ Password
+    , whitelistUser :: !Text     -- ^ Service Username (basic auth)
+    , whitelistPass :: !Text     -- ^ Service Password (basic auth)
+
     } deriving (Show, Generic)
 
 instance FromJSON Whitelist
 
+data InternalWhitelist = InternalWhitelist
+    { internalWhitelistDomains :: ![Text]} deriving (Show, Generic)
+
+deriveJSON toOptionFieldName 'internalWhitelistDomains
+
+-- | Check internal whitelist for given email/phone number. Currently this
+-- consults a statically configured whitelist of allowed email domains..
+verifyInternal :: (MonadIO m, MonadMask m, MonadHttp m) => InternalWhitelist -> Either Email Phone -> m Bool
+verifyInternal (InternalWhitelist domains) key =
+  let allowFromDomains (Left e) = (emailDomain e) `elem` domains
+      allowFromDomains _        = False
+  in pure $ allowFromDomains key
+
 -- | Do a request to the whitelist service and verify that the provided email/phone address is
 -- whitelisted.
-verify :: (MonadIO m, MonadMask m, MonadHttp m) => Whitelist -> Either Email Phone -> m Bool
-verify (Whitelist url user pass) key = if isKnownDomain key
-    then return True
-    else recovering x3 httpHandlers . const $ do
-        rq <- parseRequest $ unpack url
-        rsp <- get' rq $ req (encodeUtf8 user) (encodeUtf8 pass)
-        case statusCode rsp of
-            200 -> return True
-            404 -> return False
-            _   -> throwM $
-                HttpExceptionRequest rq (StatusCodeException (rsp { responseBody = () }) mempty)
+verifyService :: (MonadIO m, MonadMask m, MonadHttp m) => Whitelist -> Either Email Phone -> m Bool
+verifyService (Whitelist url user pass) key = if isKnownDomain key
+  then return True
+  else recovering x3 httpHandlers . const $ do
+     rq <- parseRequest $ T.unpack url
+     rsp <- get' rq $ req (encodeUtf8 user) (encodeUtf8 pass)
+     case statusCode rsp of
+         200 -> return True
+         404 -> return False
+         _   -> throwM $
+             HttpExceptionRequest rq (StatusCodeException (rsp { responseBody = () }) mempty)
   where
+    -- Duplicate behaviour from verifyLocal, keeping old behaviour for
+    -- compatibility.
     isKnownDomain (Left e) = emailDomain e == "wire.com"
     isKnownDomain _        = False
 


### PR DESCRIPTION
Currently whitelisting for account activation is performed via an
external service, if configured.

We would like to move logic from the external service into Wire itself.
As such, this change brings in configuration format changes that will
allow to select either external or internal whitelisting.

For now, internal whitelisting only supports a statically configured
list of allowed email domains. In the future, it will gain extra
features like in-database storage of allowed emails.