### PR TITLE
Fix Makefiles to use the correct dist folder

### DIFF
--- a/services/nginz/Makefile
+++ b/services/nginz/Makefile
@@ -70,7 +70,7 @@ clean:
 
 .PHONY: compile
 compile: $(BIN)
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 	cp src/objs/nginx ../../dist/
 
 .PHONY: dist

--- a/services/spar/Makefile
+++ b/services/spar/Makefile
@@ -22,7 +22,7 @@ guard-%:
 default: fast
 
 init:
-	mkdir -p dist ../../dist
+	mkdir -p ../../dist
 
 .PHONY: install
 install: init


### PR DESCRIPTION
Follow up from https://github.com/wireapp/wire-server/commit/132c700c06baff8bebd725640b99494f35dddc6d