### PR TITLE
Remove unnecessary fanout team events

### DIFF
--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -93,8 +93,6 @@ createTeamGroupConv zusr zcon tinfo body = do
     now  <- liftIO getCurrentTime
     let d = Teams.EdConvCreate (Data.convId conv)
     let e = newEvent Teams.ConvCreate (cnvTeamId tinfo) now & eventData .~ Just d
-    let notInConv = Set.fromList (map (view userId) teamMems) \\ Set.fromList (zusr : fromConvSize otherConvMems)
-    for_ (newPush zusr (TeamEvent e) (map userRecipient (Set.toList notInConv))) push1
     notifyCreatedConversation (Just now) zusr (Just zcon) conv
     conversationResponse status201 zusr conv
 

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -12,7 +12,6 @@ import Control.Monad.Catch
 import Data.Id
 import Data.List1 (list1)
 import Data.Range
--- import Data.Set ((\\))
 import Data.Time
 import Galley.App
 import Galley.API.Error
@@ -30,7 +29,6 @@ import Network.Wai.Utilities
 import qualified Data.Set           as Set
 import qualified Data.UUID.Tagged   as U
 import qualified Galley.Data        as Data
--- import qualified Galley.Types.Teams as Teams
 
 ----------------------------------------------------------------------------
 -- Group conversations
@@ -91,11 +89,7 @@ createTeamGroupConv zusr zcon tinfo body = do
             pure otherConvMems
     conv <- Data.createConversation zusr name (access body) (accessRole body) otherConvMems (newConvTeam body) (newConvMessageTimer body) (newConvReceiptMode body)
     now  <- liftIO getCurrentTime
-    -- let d = Teams.EdConvCreate (Data.convId conv)
-    -- let e = newEvent Teams.ConvCreate (cnvTeamId tinfo) now & eventData .~ Just d
-    -- NOTE: Do we still need to send team.conversation-create?
-    -- let notInConv = Set.fromList (map (view userId) teamMems) \\ Set.fromList (zusr : fromConvSize otherConvMems)
-    -- for_ (newPush zusr (TeamEvent e) (map userRecipient (Set.toList notInConv))) push1
+    -- NOTE: We only send (conversation) events to members of the conversation
     notifyCreatedConversation (Just now) zusr (Just zcon) conv
     conversationResponse status201 zusr conv
 

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -12,7 +12,7 @@ import Control.Monad.Catch
 import Data.Id
 import Data.List1 (list1)
 import Data.Range
-import Data.Set ((\\))
+-- import Data.Set ((\\))
 import Data.Time
 import Galley.App
 import Galley.API.Error
@@ -30,7 +30,7 @@ import Network.Wai.Utilities
 import qualified Data.Set           as Set
 import qualified Data.UUID.Tagged   as U
 import qualified Galley.Data        as Data
-import qualified Galley.Types.Teams as Teams
+-- import qualified Galley.Types.Teams as Teams
 
 ----------------------------------------------------------------------------
 -- Group conversations
@@ -91,8 +91,11 @@ createTeamGroupConv zusr zcon tinfo body = do
             pure otherConvMems
     conv <- Data.createConversation zusr name (access body) (accessRole body) otherConvMems (newConvTeam body) (newConvMessageTimer body) (newConvReceiptMode body)
     now  <- liftIO getCurrentTime
-    let d = Teams.EdConvCreate (Data.convId conv)
-    let e = newEvent Teams.ConvCreate (cnvTeamId tinfo) now & eventData .~ Just d
+    -- let d = Teams.EdConvCreate (Data.convId conv)
+    -- let e = newEvent Teams.ConvCreate (cnvTeamId tinfo) now & eventData .~ Just d
+    -- NOTE: Do we still need to send team.conversation-create?
+    -- let notInConv = Set.fromList (map (view userId) teamMems) \\ Set.fromList (zusr : fromConvSize otherConvMems)
+    -- for_ (newPush zusr (TeamEvent e) (map userRecipient (Set.toList notInConv))) push1
     notifyCreatedConversation (Just now) zusr (Just zcon) conv
     conversationResponse status201 zusr conv
 

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -419,7 +419,7 @@ deleteTeamConversation (zusr::: zcon ::: tid ::: cid ::: _) = do
     let convPush = case convMembsAndTeamMembs cmems tmems of
             []     -> []
             (m:mm) -> [newPush1 zusr (ConvEvent ce) (list1 m mm) & pushConn .~ Just zcon]
-    pushSome $ convPush
+    pushSome convPush
     void . forkIO $ void $ External.deliver (bots `zip` repeat ce)
     -- TODO: we don't delete bots here, but we should do that, since every
     -- bot user can only be in a single conversation

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -419,11 +419,10 @@ deleteTeamConversation (zusr::: zcon ::: tid ::: cid ::: _) = do
     let te = newEvent Teams.ConvDelete tid now & eventData .~ Just (Teams.EdConvDelete cid)
     let ce = Conv.Event Conv.ConvDelete cid zusr now Nothing
     let tr = list1 (userRecipient zusr) (membersToRecipients (Just zusr) tmems)
-    let teamPush = [newPush1 zusr (TeamEvent te) tr & pushConn .~ Just zcon]
-        convPush = case convMembsAndTeamMembs cmems tmems of
+    let convPush = case convMembsAndTeamMembs cmems tmems of
             []     -> []
             (m:mm) -> [newPush1 zusr (ConvEvent ce) (list1 m mm) & pushConn .~ Just zcon]
-    pushSome $ teamPush <> convPush
+    pushSome convPush
     void . forkIO $ void $ External.deliver (bots `zip` repeat ce)
     -- TODO: we don't delete bots here, but we should do that, since every
     -- bot user can only be in a single conversation

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -902,13 +902,13 @@ checkConvCreateEvent cid w = WS.assertMatch_ timeout w $ \notif -> do
         Just (Conv.EdConversation x) -> cnvId x @?= cid
         other                        -> assertFailure $ "Unexpected event data: " <> show other
 
-checkTeamConvDeleteEvent :: HasCallStack => TeamId -> ConvId -> WS.WebSocket -> TestM ()
-checkTeamConvDeleteEvent tid cid w = WS.assertMatch_ timeout w $ \notif -> do
+checkTeamDeleteEvent :: HasCallStack => TeamId -> WS.WebSocket -> TestM ()
+checkTeamDeleteEvent tid w = WS.assertMatch_ timeout w $ \notif -> do
     ntfTransient notif @?= False
     let e = List1.head (WS.unpackPayload notif)
-    e^.eventType @?= ConvDelete
+    e^.eventType @?= TeamDelete
     e^.eventTeam @?= tid
-    e^.eventData @?= Just (EdConvDelete cid)
+    e^.eventData @?= Nothing
 
 checkConvDeleteEvent :: HasCallStack => ConvId -> WS.WebSocket -> TestM ()
 checkConvDeleteEvent cid w = WS.assertMatch_ timeout w $ \notif -> do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -444,9 +444,8 @@ testAddTeamConv = do
         cid2 <- Util.createTeamConv owner tid [extern] (Just "blaa") Nothing Nothing
         checkConvCreateEvent cid2 wsOwner
         checkConvCreateEvent cid2 wsExtern
-        -- mem2 is not a conversation member but still receives an event that
-        -- a new team conversation has been created:
-        checkTeamConvCreateEvent tid cid2 wsMem2
+        -- mem2 is not a conversation member and no longer receives
+        -- an event that a new team conversation has been created
 
         Util.addTeamMember owner tid mem1
 
@@ -721,8 +720,10 @@ testDeleteTeamConv = do
                . zConn "conn"
                ) !!!  const 200 === statusCode
 
-        checkTeamConvDeleteEvent tid cid2 wsOwner
-        checkTeamConvDeleteEvent tid cid2 wsMember
+        -- We no longer send duplicate conv deletion events
+        -- i.e., as both a regular "conversation.delete" to all
+        -- conversation members and as "team.conversation-delete"
+        -- to all team members not part of the conversation
         checkConvDeleteEvent cid2 wsOwner
         checkConvDeleteEvent cid2 wsMember
         WS.assertNoEvent timeout [wsOwner, wsMember]
@@ -733,8 +734,10 @@ testDeleteTeamConv = do
                . zConn "conn"
                ) !!!  const 200 === statusCode
 
-        checkTeamConvDeleteEvent tid cid1 wsOwner
-        checkTeamConvDeleteEvent tid cid1 wsMember
+        -- We no longer send duplicate conv deletion events
+        -- i.e., as both a regular "conversation.delete" to all
+        -- conversation members and as "team.conversation-delete"
+        -- to all team members not part of the conversation
         checkConvDeleteEvent cid1 wsOwner
         checkConvDeleteEvent cid1 wsMember
         checkConvDeleteEvent cid1 wsExtern
@@ -890,14 +893,6 @@ checkTeamMemberLeave tid usr w = WS.assertMatch_ timeout w $ \notif -> do
     e^.eventTeam @?= tid
     e^.eventData @?= Just (EdMemberLeave usr)
 
-checkTeamConvCreateEvent :: HasCallStack => TeamId -> ConvId -> WS.WebSocket -> TestM ()
-checkTeamConvCreateEvent tid cid w = WS.assertMatch_ timeout w $ \notif -> do
-    ntfTransient notif @?= False
-    let e = List1.head (WS.unpackPayload notif)
-    e^.eventType @?= ConvCreate
-    e^.eventTeam @?= tid
-    e^.eventData @?= Just (EdConvCreate cid)
-
 checkConvCreateEvent :: HasCallStack => ConvId -> WS.WebSocket -> TestM ()
 checkConvCreateEvent cid w = WS.assertMatch_ timeout w $ \notif -> do
     ntfTransient notif @?= False
@@ -906,14 +901,6 @@ checkConvCreateEvent cid w = WS.assertMatch_ timeout w $ \notif -> do
     case evtData e of
         Just (Conv.EdConversation x) -> cnvId x @?= cid
         other                        -> assertFailure $ "Unexpected event data: " <> show other
-
-checkTeamDeleteEvent :: HasCallStack => TeamId -> WS.WebSocket -> TestM ()
-checkTeamDeleteEvent tid w = WS.assertMatch_ timeout w $ \notif -> do
-    ntfTransient notif @?= False
-    let e = List1.head (WS.unpackPayload notif)
-    e^.eventType @?= TeamDelete
-    e^.eventTeam @?= tid
-    e^.eventData @?= Nothing
 
 checkTeamConvDeleteEvent :: HasCallStack => TeamId -> ConvId -> WS.WebSocket -> TestM ()
 checkTeamConvDeleteEvent tid cid w = WS.assertMatch_ timeout w $ \notif -> do


### PR DESCRIPTION
Currently, `team.conversation-create` and `team.conversation-delete` events are sent to _all_ team members that are _not_ part of the conversation.

While this may theoretically be useful for conversation discovery in case of teams (e.g., you may be interested in joining these conversations) there's currently no UI nor a use case for it so we're better off avoiding unnecessary fan outs. In case this does become relevant again, one could simply undo (redo?) this PR.