### PR TITLE
Handle search within team

### DIFF
--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -151,6 +151,11 @@ optSettings:
   setPropertyMaxKeyLen: 1024
   setPropertyMaxValueLen: 4096
   setDeleteThrottleMillis: 0
+  # NOTE: this filters out search results for team users,
+  # i.e., if you are a team user the search endpoints will
+  # return only users part of the same team. For name search,
+  # this is slightly more inefficient as it requires 2 extra DB lookups
+  # setSearchSameTeamOnly: false
 
 logLevel: Warn
 logNetStrings: false

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1189,7 +1189,7 @@ listUsers (_ ::: self ::: qry) = case qry of
     Left  us -> toResponse =<< byIds (fromList us)
     Right hs -> do
         us <- catMaybes <$> mapM (lift . API.lookupHandle) (fromList hs)
-        sameTeamSearchOnly <- fromMaybe False <$> view (settings . handleSearchSameTeamOnly)
+        sameTeamSearchOnly <- fromMaybe False <$> view (settings . searchSameTeamOnly)
         toResponse =<< if sameTeamSearchOnly
             then sameTeamOnly =<< byIds us
             else byIds us

--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -1,0 +1,17 @@
+module Brig.API.Util where
+
+import Brig.API.Handler
+import Brig.Types
+import Control.Monad
+import Data.Id
+import Data.Maybe
+import Imports
+
+import qualified Brig.Data.User as Data
+
+lookupProfilesMaybeFilterSameTeamOnly :: UserId -> [UserProfile] -> Handler [UserProfile]
+lookupProfilesMaybeFilterSameTeamOnly self us = do
+    selfTeam <- lift $ Data.lookupUserTeam self
+    return $ case selfTeam of
+        Just team -> filter (\x -> profileTeam x == Just team) us
+        Nothing   -> us

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -24,6 +24,7 @@ module Brig.Data.User
     , lookupStatus
     , lookupRichInfo
     , lookupUserTeam
+    , lookupUsersTeam
     , lookupServiceUsers
     , lookupServiceUsersForTeam
 
@@ -308,6 +309,10 @@ lookupUserTeam :: UserId -> AppIO (Maybe TeamId)
 lookupUserTeam u = join . fmap runIdentity <$>
     retry x1 (query1 teamSelect (params Quorum (Identity u)))
 
+lookupUsersTeam :: [UserId] -> AppIO [(UserId, Maybe TeamId)]
+lookupUsersTeam us =
+    retry x1 (query usersTeamSelect (params Quorum (Identity us)))
+
 lookupAuth :: (MonadClient m) => UserId -> m (Maybe (Maybe Password, AccountStatus))
 lookupAuth u = fmap f <$> retry x1 (query1 authSelect (params Quorum (Identity u)))
   where
@@ -415,6 +420,9 @@ richInfoSelect = "SELECT json FROM rich_info WHERE user = ?"
 
 teamSelect :: PrepQuery R (Identity UserId) (Identity (Maybe TeamId))
 teamSelect = "SELECT team FROM user WHERE id = ?"
+
+usersTeamSelect :: PrepQuery R (Identity [UserId]) (UserId, Maybe TeamId)
+usersTeamSelect = "SELECT id, team FROM user WHERE id IN ?"
 
 accountsSelect :: PrepQuery R (Identity [UserId]) AccountRow
 accountsSelect = "SELECT id, name, picture, email, phone, sso_id, accent_id, assets, \

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -312,10 +312,11 @@ data Settings = Settings
 
     , setPropertyMaxKeyLen     :: !(Maybe Int64)
     , setPropertyMaxValueLen   :: !(Maybe Int64)
-    , setDeleteThrottleMillis  :: !(Maybe Int) -- ^ How long, in milliseconds, to wait
-                                               -- in between processing delete events
-                                               -- from the internal delete queue
-
+    , setDeleteThrottleMillis  :: !(Maybe Int)  -- ^ How long, in milliseconds, to wait
+                                                -- in between processing delete events
+                                                -- from the internal delete queue
+    , setHandleSearchSameTeamOnly :: !(Maybe Bool) -- ^ When true, handle search only
+                                                   -- returns users from the same team
     } deriving (Show, Generic)
 
 defMaxKeyLen :: Int64
@@ -344,3 +345,4 @@ Lens.makeLensesFor [("optSettings", "optionSettings")] ''Opts
 Lens.makeLensesFor [("setEmailVisibility", "emailVisibility")] ''Settings
 Lens.makeLensesFor [("setPropertyMaxKeyLen", "propertyMaxKeyLen")] ''Settings
 Lens.makeLensesFor [("setPropertyMaxValueLen", "propertyMaxValueLen")] ''Settings
+Lens.makeLensesFor [("setHandleSearchSameTeamOnly", "handleSearchSameTeamOnly")] ''Settings

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -315,8 +315,8 @@ data Settings = Settings
     , setDeleteThrottleMillis  :: !(Maybe Int)  -- ^ How long, in milliseconds, to wait
                                                 -- in between processing delete events
                                                 -- from the internal delete queue
-    , setHandleSearchSameTeamOnly :: !(Maybe Bool) -- ^ When true, handle search only
-                                                   -- returns users from the same team
+    , setSearchSameTeamOnly :: !(Maybe Bool) -- ^ When true, search only
+                                             -- returns users from the same team
     } deriving (Show, Generic)
 
 defMaxKeyLen :: Int64
@@ -345,4 +345,4 @@ Lens.makeLensesFor [("optSettings", "optionSettings")] ''Opts
 Lens.makeLensesFor [("setEmailVisibility", "emailVisibility")] ''Settings
 Lens.makeLensesFor [("setPropertyMaxKeyLen", "propertyMaxKeyLen")] ''Settings
 Lens.makeLensesFor [("setPropertyMaxValueLen", "propertyMaxValueLen")] ''Settings
-Lens.makeLensesFor [("setHandleSearchSameTeamOnly", "handleSearchSameTeamOnly")] ''Settings
+Lens.makeLensesFor [("setSearchSameTeamOnly", "searchSameTeamOnly")] ''Settings

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -41,7 +41,6 @@ testOptInOut brig = do
     refreshIndex brig
     assertSearchable "opted in" brig uid1 True
     assertCanFind brig uid2 uid1 h1
-    -- Even if users opt in, team users in other teams should not be found
 
 testSearchByName :: Brig -> Http ()
 testSearchByName brig = do

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -41,7 +41,7 @@ testOptInOut brig = do
     refreshIndex brig
     assertSearchable "opted in" brig uid1 True
     assertCanFind brig uid2 uid1 h1
-
+    -- Even if users opt in, team users in other teams should not be found
 
 testSearchByName :: Brig -> Http ()
 testSearchByName brig = do

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -641,12 +641,20 @@ testNonSearchableAcrossTeam opts brig galley = do
         cName = fromName $ userName creatorWithHandle
         Just iHandle = fromHandle <$> userHandle inviteeWithHandle
         Just oHandle = fromHandle <$> userHandle creatorOtherWithHandle
+        oName = fromName $ userName creatorOtherWithHandle
 
     -- users are searchable by default
     assertSearchable "user is searchable" brig uid1 True
     assertCanFind brig uid2 uid1 uHandle
     -- users are also searcheable by name
-    assertCanFind brig uid2 uid1 uName
+    assertCanFind brig uid3 uid1 uName
+
+    -- team users can also be made searchable
+    updateSearchableStatus brig uid4 optIn
+    assertSearchable "user is searchable" brig uid4 True
+    refreshIndex brig
+    assertCanFind brig uid2 uid4 oHandle
+    assertCanFind brig uid3 uid4 oName
 
     -- team owners are not searchable by default
     assertSearchable "owner isn't searchable" brig uid2 False
@@ -660,10 +668,13 @@ testNonSearchableAcrossTeam opts brig galley = do
     updateSearchableStatus brig uid2 optIn
     refreshIndex brig
 
-    -- he is searchable for uid1, uid3 and uid4 now
+    -- uid2 is searchable for uid1, uid3 and uid4 now
     assertCanFind brig uid1 uid2 cHandle
+    assertCanFind brig uid1 uid2 cName
     assertCanFind brig uid3 uid2 cHandle
+    assertCanFind brig uid3 uid2 cName
     assertCanFind brig uid4 uid2 cHandle
+    assertCanFind brig uid4 uid2 cName
 
     let newOpts = opts & Opt.optionSettings . Opt.searchSameTeamOnly .~ Just True
     withSettingsOverrides newOpts $ do
@@ -672,7 +683,8 @@ testNonSearchableAcrossTeam opts brig galley = do
         assertCan'tFind brig uid2 uid1 uName
         -- and also not across
         assertCan'tFind brig uid3 uid4 oHandle
-        -- uid3 can find uid2 because they are on the same team
+        assertCan'tFind brig uid3 uid4 oName
+        -- uid3 can find uid2 because uid2 is visible and they are on the same team
         assertCanFind brig uid3 uid2 cHandle
         assertCanFind brig uid3 uid2 cName
 

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -11,7 +11,7 @@ import Brig.Types.User.Auth
 import Brig.Types.Intra
 import Control.Arrow ((&&&))
 import UnliftIO.Async (mapConcurrently_, replicateConcurrently, pooledForConcurrentlyN_)
-import Control.Lens ((^.), view)
+import Control.Lens hiding ((.=))
 import Data.Aeson
 import Data.ByteString.Conversion
 import Data.Id hiding (client)
@@ -23,7 +23,6 @@ import Test.Tasty.HUnit
 import Web.Cookie (parseSetCookie, setCookieName)
 import Util
 import Util.AWS as Util
-import Util.Options.Common
 
 import qualified Brig.AWS                    as AWS
 import qualified Brig.Options                as Opt
@@ -36,10 +35,10 @@ import qualified Test.Tasty.Cannon           as WS
 
 newtype TeamSizeLimit = TeamSizeLimit Word16
 
-tests :: Maybe Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> AWS.Env -> IO TestTree
+tests :: Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> AWS.Env -> IO TestTree
 tests conf m b c g aws = do
-    tl <- optOrEnv (TeamSizeLimit . Opt.setMaxTeamSize . Opt.optSettings) conf (TeamSizeLimit . read) "TEAM_MAX_SIZE"
-    it <- optOrEnv (Opt.setTeamInvitationTimeout . Opt.optSettings) conf read "TEAM_INVITATION_TIMEOUT"
+    let tl = TeamSizeLimit . Opt.setMaxTeamSize . Opt.optSettings $ conf
+    let it = Opt.setTeamInvitationTimeout . Opt.optSettings $ conf
     return $ testGroup "team"
         [ testGroup "invitation"
             [ test m "post /teams/:tid/invitations - 201"                  $ testInvitationEmail b g
@@ -66,6 +65,7 @@ tests conf m b c g aws = do
             ]
         , testGroup "search"
             [ test m "post /register members are unsearchable" $ testNonSearchableDefault b g
+            , test m "team members may only search within team if set" $ testNonSearchableAcrossTeam conf b g
             ]
         , testGroup "sso"
             [ test m "post /i/users  - 201 internal-SSO" $ testCreateUserInternalSSO b g
@@ -600,6 +600,81 @@ testNonSearchableDefault brig galley = do
     -- team members are not searchable by default
     assertSearchable "member isn't searchable" brig uid3 False
     assertCan'tFind brig uid1 uid3 iHandle
+
+testNonSearchableAcrossTeam :: Opt.Opts -> Brig -> Galley -> Http ()
+testNonSearchableAcrossTeam opts brig galley = do
+    nonMember <- randomUserWithHandle brig
+    email     <- randomEmail
+    rsp       <- register email newTeam brig
+
+    act <- getActivationCode brig (Left email)
+    case act of
+      Nothing -> liftIO $ assertFailure "activation key/code not found"
+      Just kc -> activate brig kc !!! const 200 === statusCode
+
+    let Just creator = responseJsonMaybe rsp
+    [team]  <- view Team.teamListTeams <$> getTeams (userId creator) galley
+    let tid = view Team.teamId team
+    invitee <- inviteAndRegisterUser (userId creator) tid brig
+    creatorWithHandle <- setRandomHandle brig creator
+    inviteeWithHandle <- setRandomHandle brig invitee
+    -- Separate team creator
+    emailOther <- randomEmail
+    rspOther <- register emailOther newTeam brig
+    actOther <- getActivationCode brig (Left emailOther)
+    case actOther of
+      Nothing -> liftIO $ assertFailure "activation key/code not found"
+      Just kc -> activate brig kc !!! const 200 === statusCode
+
+    let Just creatorOther = responseJsonMaybe rspOther
+    creatorOtherWithHandle <- setRandomHandle brig creatorOther
+
+    refreshIndex brig
+
+    let uid1 = userId nonMember
+        uid2 = userId creatorWithHandle
+        uid3 = userId inviteeWithHandle
+        uid4 = userId creatorOtherWithHandle
+        Just uHandle = fromHandle <$> userHandle nonMember
+        uName = fromName $ userName nonMember
+        Just cHandle = fromHandle <$> userHandle creatorWithHandle
+        cName = fromName $ userName creatorWithHandle
+        Just iHandle = fromHandle <$> userHandle inviteeWithHandle
+        Just oHandle = fromHandle <$> userHandle creatorOtherWithHandle
+
+    -- users are searchable by default
+    assertSearchable "user is searchable" brig uid1 True
+    assertCanFind brig uid2 uid1 uHandle
+    -- users are also searcheable by name
+    assertCanFind brig uid2 uid1 uName
+
+    -- team owners are not searchable by default
+    assertSearchable "owner isn't searchable" brig uid2 False
+    assertCan'tFind brig uid1 uid2 cHandle
+
+    -- team members are not searchable by default
+    assertSearchable "member isn't searchable" brig uid3 False
+    assertCan'tFind brig uid1 uid3 iHandle
+
+    -- make the creator searchable
+    updateSearchableStatus brig uid2 optIn
+    refreshIndex brig
+
+    -- he is searchable for uid1, uid3 and uid4 now
+    assertCanFind brig uid1 uid2 cHandle
+    assertCanFind brig uid3 uid2 cHandle
+    assertCanFind brig uid4 uid2 cHandle
+
+    let newOpts = opts & Opt.optionSettings . Opt.searchSameTeamOnly .~ Just True
+    withSettingsOverrides newOpts $ do
+        -- team users cannot search by name nor handle if not a team user
+        assertCan'tFind brig uid2 uid1 uHandle
+        assertCan'tFind brig uid2 uid1 uName
+        -- and also not across
+        assertCan'tFind brig uid3 uid4 oHandle
+        -- uid3 can find uid2 because they are on the same team
+        assertCanFind brig uid3 uid2 cHandle
+        assertCanFind brig uid3 uid2 cName
 
 ----------------------------------------------------------------------
 -- SSO

--- a/services/brig/test/integration/API/User.hs
+++ b/services/brig/test/integration/API/User.hs
@@ -22,11 +22,11 @@ import qualified Brig.AWS     as AWS
 import qualified Brig.Options as Opt
 import qualified Brig.ZAuth   as ZAuth
 
-tests :: Maybe Opt.Opts -> Manager -> Brig -> Cannon -> CargoHold -> Galley -> Nginz -> AWS.Env -> IO TestTree
+tests :: Opt.Opts -> Manager -> Brig -> Cannon -> CargoHold -> Galley -> Nginz -> AWS.Env -> IO TestTree
 tests conf p b c ch g n aws = do
-    cl <- optOrEnv (ConnectionLimit . Opt.setUserMaxConnections . Opt.optSettings) conf (ConnectionLimit . read) "USER_CONNECTION_LIMIT"
-    at <- optOrEnv (Opt.setActivationTimeout . Opt.optSettings)                    conf read                     "USER_ACTIVATION_TIMEOUT"
-    z  <- mkZAuthEnv conf
+    let cl = ConnectionLimit $ Opt.setUserMaxConnections (Opt.optSettings conf)
+    let at = Opt.setActivationTimeout (Opt.optSettings conf)
+    z  <- mkZAuthEnv (Just conf)
     return $ testGroup "user"
         [ API.User.Client.tests        cl at conf p b c g
         , API.User.Account.tests       cl at conf p b c ch g aws

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -50,7 +50,7 @@ import qualified Data.Vector                 as Vec
 import qualified Network.Wai.Utilities.Error as Error
 import qualified Test.Tasty.Cannon           as WS
 
-tests :: ConnectionLimit -> Opt.Timeout -> Maybe Opt.Opts -> Manager -> Brig -> Cannon -> CargoHold -> Galley -> AWS.Env -> TestTree
+tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> CargoHold -> Galley -> AWS.Env -> TestTree
 tests _ at _ p b c ch g aws = testGroup "account"
     [ test' aws p "post /register - 201 (with preverified)"  $ testCreateUserWithPreverified b aws
     , test' aws p "post /register - 201"                     $ testCreateUser b g

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -24,7 +24,7 @@ import qualified Data.Vector                 as Vec
 import qualified Network.Wai.Utilities.Error as Error
 import qualified Test.Tasty.Cannon           as WS
 
-tests :: ConnectionLimit -> Opt.Timeout -> Maybe Opt.Opts -> Manager -> Brig -> Cannon -> Galley-> TestTree
+tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> Galley-> TestTree
 tests _cl _at _conf p b c g = testGroup "client"
     [ test p "delete /clients/:client 403 - can't delete legalhold clients"
                $ testCan'tDeleteLegalHoldClient b

--- a/services/brig/test/integration/API/User/Connection.hs
+++ b/services/brig/test/integration/API/User/Connection.hs
@@ -22,7 +22,7 @@ import qualified Data.UUID.V4                as UUID
 import qualified Data.Vector                 as Vec
 import qualified Network.Wai.Utilities.Error as Error
 
-tests :: ConnectionLimit -> Opt.Timeout -> Maybe Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
+tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
 tests cl _at _conf p b _c g = testGroup "connection"
     [ test p "post /connections"                    $ testCreateManualConnections b
     , test p "post /connections mutual"             $ testCreateMutualConnections b g

--- a/services/brig/test/integration/API/User/Handles.hs
+++ b/services/brig/test/integration/API/User/Handles.hs
@@ -165,8 +165,8 @@ testHandleQuery opts brig galley = do
         const 200 === statusCode
         const (Just (Handle h4)) === (>>= (listToMaybe >=> profileHandle)) . responseJsonMaybe
 
-    let newOpts = opts & Opt.optionSettings . Opt.handleSearchSameTeamOnly .~ Just True
+    let newOpts = opts & Opt.optionSettings . Opt.searchSameTeamOnly .~ Just True
     withSettingsOverrides newOpts $ do
-        -- Usually, you can search outside your team
+        -- Usually, you can search outside your team but not if this config option is set
         get (brig . path "/users" . queryItem "handles" (toByteString' h4) . zUser uid3) !!! do
             const 404 === statusCode

--- a/services/brig/test/integration/API/User/Handles.hs
+++ b/services/brig/test/integration/API/User/Handles.hs
@@ -6,7 +6,7 @@ import API.User.Util
 import Bilge hiding (accept, timeout)
 import Bilge.Assert
 import Brig.Types
-import Control.Lens ((^?), (^?!))
+import Control.Lens hiding ((#))
 import Data.Aeson
 import Data.Aeson.Lens
 import Data.ByteString.Conversion
@@ -22,11 +22,10 @@ import qualified API.Search.Util             as Search
 import qualified Brig.Options                as Opt
 import qualified Data.List1                  as List1
 import qualified Data.UUID                   as UUID
-import qualified Galley.Types.Teams          as Team
 import qualified Network.Wai.Utilities.Error as Error
 import qualified Test.Tasty.Cannon           as WS
 
-tests :: ConnectionLimit -> Opt.Timeout -> Maybe Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
+tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
 tests _cl _at conf p b c g = testGroup "handles"
     [ test p "handles/update" $ testHandleUpdate b c
     , test p "handles/race"   $ testHandleRace b
@@ -118,8 +117,8 @@ testHandleRace brig = do
         let owners = catMaybes $ filter (maybe False ((== Just (Handle hdl)) . userHandle)) ps
         liftIO $ assertBool "More than one owner of a handle" (length owners <= 1)
 
-testHandleQuery :: Maybe Opt.Opts -> Brig -> Galley -> Http ()
-testHandleQuery _opts brig galley = do
+testHandleQuery :: Opt.Opts -> Brig -> Galley -> Http ()
+testHandleQuery opts brig galley = do
     uid <- userId <$> randomUser brig
     hdl <- randomHandle
 
@@ -157,15 +156,17 @@ testHandleQuery _opts brig galley = do
         const (Just [hdl2, hdl3]) === responseJsonMaybe
 
     -- Let's check for availability outside the team when an option is given
-    (uid3,tid1) <- createUserWithTeam brig galley
-    u4 <- createTeamMember brig galley uid3 tid1 Team.noPermissions
+    uid3 <- fst <$> createUserWithTeam brig galley
+    uid4 <- fst <$> createUserWithTeam brig galley
     h4 <- randomHandle
-    putHandle brig (userId u4) h4 !!! statusCode === const 200
-    -- Query the updated profile
-    get (brig . path "/self" . zUser (userId u4)) !!! do
-        const 200 === statusCode
-        const (Just (Handle h4)) === (>>= userHandle) . responseJsonMaybe
-
+    putHandle brig uid4 h4 !!! statusCode === const 200
+    -- Usually, you can search outside your team
     get (brig . path "/users" . queryItem "handles" (toByteString' h4) . zUser uid3) !!! do
         const 200 === statusCode
-        const (Just (Handle h4)) === (>>= (listToMaybe >=> userHandle)) . responseJsonMaybe
+        const (Just (Handle h4)) === (>>= (listToMaybe >=> profileHandle)) . responseJsonMaybe
+
+    let newOpts = opts & Opt.optionSettings . Opt.handleSearchSameTeamOnly .~ Just True
+    withSettingsOverrides newOpts $ do
+        -- Usually, you can search outside your team
+        get (brig . path "/users" . queryItem "handles" (toByteString' h4) . zUser uid3) !!! do
+            const 404 === statusCode

--- a/services/brig/test/integration/API/User/Onboarding.hs
+++ b/services/brig/test/integration/API/User/Onboarding.hs
@@ -10,7 +10,7 @@ import Util
 
 import qualified Brig.Options                as Opt
 
-tests :: ConnectionLimit -> Opt.Timeout -> Maybe Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
+tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
 tests _cl _at _conf p b _c _g = testGroup "onboarding"
     [ test p "post /onboarding/v3 - 200" $ testOnboarding b
     ]

--- a/services/brig/test/integration/API/User/PasswordReset.hs
+++ b/services/brig/test/integration/API/User/PasswordReset.hs
@@ -12,7 +12,7 @@ import Util
 
 import qualified Brig.Options as Opt
 
-tests :: ConnectionLimit -> Opt.Timeout -> Maybe Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
+tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
 tests _cl _at _conf p b _c _g = testGroup "password-reset"
     [ test p "post /password-reset[/complete] - 201[/200]"  $ testPasswordReset b
     , test p "post /password-reset & put /self/email - 400" $ testPasswordResetAfterEmailUpdate b

--- a/services/brig/test/integration/API/User/Property.hs
+++ b/services/brig/test/integration/API/User/Property.hs
@@ -16,7 +16,7 @@ import qualified Data.ByteString.Char8       as C
 import qualified Data.Text                   as T
 import qualified Network.Wai.Utilities.Error as Error
 
-tests :: ConnectionLimit -> Opt.Timeout -> Maybe Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
+tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
 tests _cl _at opts p b _c _g = testGroup "property"
     [ test p "put/get /properties/:key - 200" $ testSetGetProperty b
     , test p "delete /properties/:key - 200"  $ testDeleteProperty b
@@ -123,9 +123,8 @@ testPropertyLimits brig = do
         const 403 === statusCode
         const (Just "too-many-properties") === fmap Error.label . responseJsonMaybe
 
-testSizeLimits :: HasCallStack => Maybe Opt.Opts -> Brig -> Http ()
-testSizeLimits Nothing _ = error "no config!"
-testSizeLimits (Just opts) brig = do
+testSizeLimits :: HasCallStack => Opt.Opts -> Brig -> Http ()
+testSizeLimits opts brig = do
     let maxKeyLen = fromIntegral $ fromMaybe defMaxKeyLen . setPropertyMaxKeyLen $ optSettings opts
         maxValueLen = fromIntegral $ fromMaybe defMaxValueLen . setPropertyMaxValueLen $ optSettings opts
 

--- a/services/brig/test/integration/API/User/RichInfo.hs
+++ b/services/brig/test/integration/API/User/RichInfo.hs
@@ -17,7 +17,7 @@ import qualified Data.List1                  as List1
 import qualified Data.Text                   as Text
 import qualified Galley.Types.Teams          as Team
 
-tests :: ConnectionLimit -> Opt.Timeout -> Maybe Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
+tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
 tests _cl _at conf p b _c g = testGroup "rich info"
     [ test p "there is default empty rich info" $ testDefaultRichInfo b g
     , test p "missing fields in an update are deleted" $ testDeleteMissingFieldsInUpdates b g
@@ -79,9 +79,8 @@ testForbidDuplicateFieldNames brig galley = do
             ]
     putRichInfo brig owner bad !!! const 400 === statusCode
 
-testRichInfoSizeLimit :: HasCallStack => Brig -> Galley -> Maybe Opt.Opts -> Http ()
-testRichInfoSizeLimit _ _ Nothing = error "this test needs a config file"
-testRichInfoSizeLimit brig galley (Just conf) = do
+testRichInfoSizeLimit :: HasCallStack => Brig -> Galley -> Opt.Opts -> Http ()
+testRichInfoSizeLimit brig galley conf = do
     let maxSize :: Int = setRichInfoLimit $ optSettings conf
     (owner, _) <- createUserWithTeam brig galley
     let bad1 = RichInfo

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -77,7 +77,7 @@ runTests iConf bConf otherArgs = do
     userApi     <- User.tests brigOpts mg b c ch g n awsEnv
     providerApi <- Provider.tests (provider <$> iConf) mg db b c g
     searchApis  <- Search.tests mg b
-    teamApis    <- Team.tests bConf mg b c g awsEnv
+    teamApis    <- Team.tests brigOpts mg b c g awsEnv
     turnApi     <- TURN.tests mg b turnFile turnFileV2
     metricsApi  <- Metrics.tests mg b
     settingsApi <- Settings.tests brigOpts mg b g

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -74,7 +74,7 @@ runTests iConf bConf otherArgs = do
     emailAWSOpts <- parseEmailAWSOpts
     awsEnv <- AWS.mkEnv lg awsOpts emailAWSOpts mg
 
-    userApi     <- User.tests bConf mg b c ch g n awsEnv
+    userApi     <- User.tests brigOpts mg b c ch g n awsEnv
     providerApi <- Provider.tests (provider <$> iConf) mg db b c g
     searchApis  <- Search.tests mg b
     teamApis    <- Team.tests bConf mg b c g awsEnv

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -78,6 +78,14 @@ test' e m n h = testCase n $ void $ runHttpT m (liftIO (purgeJournalQueue e) >> 
 randomUser :: HasCallStack => Brig -> Http User
 randomUser = randomUser' True
 
+randomUserWithTeam :: HasCallStack => Brig -> Http User
+randomUserWithTeam brig = do
+    name <- fromName <$> randomName
+    tid <- Id <$> liftIO UUID.nextRandom
+    r <- postUser' False True name True False Nothing (Just tid) brig <!!
+       const 201 === statusCode
+    responseJsonError r
+
 randomUser' :: HasCallStack => Bool -> Brig -> Http User
 randomUser' hasPwd brig = do
     n <- fromName <$> randomName


### PR DESCRIPTION
This solves the problem for on premise deployments where it is not desirable have team members connecting outside their team