### PR TITLE
The adding member is not always an admin

### DIFF
--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -330,7 +330,7 @@ joinConversation zusr zcon cnv access = do
     -- NOTE: When joining conversations, all users become members
     -- as this is our desired behavior for these types of conversations
     -- where there is no way to control who joins, etc.
-    addToConversation (botsAndUsers (Data.convMembers conv)) zusr zcon newUsers conv roleNameWireMember
+    addToConversation (botsAndUsers (Data.convMembers conv)) (zusr, roleNameWireMember) zcon (newUsers, roleNameWireMember) conv
 
 addMembers :: UserId ::: ConnId ::: ConvId ::: JsonRequest Invite -> Galley Response
 addMembers (zusr ::: zcon ::: cid ::: req) = do
@@ -349,7 +349,7 @@ addMembers (zusr ::: zcon ::: cid ::: req) = do
             ensureAccessRole (Data.convAccessRole conv) newUsers Nothing
             ensureConnected zusr newUsers
         Just ti -> teamConvChecks ti newUsers conv
-    addToConversation mems zusr zcon newUsers conv (invRoleName body)
+    addToConversation mems (zusr, memConvRoleName self) zcon (newUsers, invRoleName body) conv
   where
     teamConvChecks tid newUsers conv = do
         tms <- Data.teamMembersLimited tid newUsers
@@ -587,13 +587,13 @@ rmBot (zusr ::: zcon ::: req) = do
 -------------------------------------------------------------------------------
 -- Helpers
 
-addToConversation :: ([BotMember], [Member]) -> UserId -> ConnId -> [UserId] -> Data.Conversation -> RoleName -> Galley Response
-addToConversation _              _   _    [] _ _    = return $ empty & setStatus status204
-addToConversation (bots, others) usr conn xs c role = do
+addToConversation :: ([BotMember], [Member]) -> (UserId, RoleName) -> ConnId -> ([UserId], RoleName) -> Data.Conversation -> Galley Response
+addToConversation _              _             _    ([], _     ) _ = return $ empty & setStatus status204
+addToConversation (bots, others) (usr,usrRole) conn (xs, xsRole) c = do
     ensureGroupConv c
     mems    <- checkedMemberAddSize xs
     now     <- liftIO getCurrentTime
-    (e, mm) <- Data.addMembersWithRole now (Data.convId c) usr mems role
+    (e, mm) <- Data.addMembersWithRole now (Data.convId c) (usr, usrRole) (mems, xsRole)
     for_ (newPush (evtFrom e) (ConvEvent e) (recipient <$> allMembers (toList mm))) $ \p ->
         push1 $ p & pushConn ?~ conn
     void . forkIO $ void $ External.deliver (bots `zip` repeat e)

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -351,7 +351,7 @@ postJoinConvOk = do
         postJoinConv bob conv !!! const 200 === statusCode
         postJoinConv bob conv !!! const 204 === statusCode
         void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB] $
-            wsAssertMemberJoin conv bob [bob]
+            wsAssertMemberJoinWithRole conv bob [bob] roleNameWireMember
 
 postJoinCodeConvOk :: TestM ()
 postJoinCodeConvOk = do
@@ -380,7 +380,7 @@ postJoinCodeConvOk = do
         -- eve cannot join
         postJoinCodeConv eve payload !!! const 403 === statusCode
         void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB] $
-            wsAssertMemberJoin conv bob [bob]
+            wsAssertMemberJoinWithRole conv bob [bob] roleNameWireMember
         -- changing access to non-activated should give eve access
         let nonActivatedAccess = ConversationAccessUpdate [CodeAccess] NonActivatedAccessRole
         putAccessUpdate alice conv nonActivatedAccess !!! const 200 === statusCode
@@ -459,7 +459,7 @@ postConvertTeamConv = do
     WS.bracketR3 c alice bob eve $ \(wsA, wsB, wsE) -> do
         postJoinCodeConv mallory j !!! const 200 === statusCode
         void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsE] $
-            wsAssertMemberJoin conv mallory [mallory]
+            wsAssertMemberJoinWithRole conv mallory [mallory] roleNameWireMember
 
     WS.bracketRN c [alice, bob, eve, mallory] $ \[wsA, wsB, wsE, wsM] -> do
         let teamAccess = ConversationAccessUpdate [InviteAccess, CodeAccess] TeamAccessRole


### PR DESCRIPTION
This _actually_ fixes https://github.com/wireapp/wire-server/pull/924 - the fact that tests did not break before is a sign that nothing got changed.

Background: previously it was assumed that the user _adding_ others to a conversation was a `wire_admin` - this is not always true: when adding to a conversation, a user adds itself. Also, it's conceivable that in the future there will be more roles able to add users to conversations so this PR also takes that into account making this more forwards compatible.