### PR TITLE
release_2019_12_20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 2019-12-20
+
+## Relevant for self-hosters
+
+- Access tokens are now sanitized on nginz logs (#920)
+
+## Relevant for client developers
+
+- Conversation roles (#911)
+  - Users joining by link are always members (#924) and (#927)
+
+## Bug fixes
+
+- Limit batch size when adding users to conversations (#923)
+- Fixed user property integration test (#922)
+
+
+
 # 2019-11-28
 
 ## Relevant for client developers
@@ -8,7 +26,7 @@
 ## Bug fixes
 
 - SCIM fixes Phase 0: User creation in correct order (#905)
-    
+
 ## Internal changes
 
 - Gundeck: Use polledMapConcurrently (#914)

--- a/deploy/services-demo/conf/nginz/common_response.conf
+++ b/deploy/services-demo/conf/nginz/common_response.conf
@@ -1,3 +1,9 @@
+      # remove access_token from logs, see 'Note sanitized_request'.
+      set $sanitized_request $request;
+      if ($sanitized_request ~ (.*)access_token=[^&]*(.*)) {
+          set $sanitized_request $1access_token=****$2;
+      }
+
       # Should be overriden when using websockets
       proxy_set_header   Connection     "";
       proxy_set_header   Z-Type         $zauth_type;

--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -57,8 +57,12 @@ http {
   #
   # Logging
   #
+  # Note sanitized_request:
+  # We allow passing access_token as query parameter for e.g. websockets
+  # However we do not want to log access tokens.
+  #
 
-  log_format custom_zeta '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" - $connection $request_time $upstream_response_time $upstream_cache_status $zauth_user $zauth_connection $request_id $proxy_protocol_addr';
+  log_format custom_zeta '$remote_addr - $remote_user [$time_local] "$sanitized_request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" - $connection $request_time $upstream_response_time $upstream_cache_status $zauth_user $zauth_connection $request_id $proxy_protocol_addr';
   access_log /dev/stdout custom_zeta;
 
   #

--- a/libs/api-bot/src/Network/Wire/Bot/Assert.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Assert.hs
@@ -8,7 +8,7 @@ import Data.Id (ConvId, UserId)
 import Network.Wire.Bot.Monad
 import Network.Wire.Client.API.Conversation
 import Network.Wire.Client.API.Push
-import Network.Wire.Client.API.User
+import Network.Wire.Client.API.User hiding (UserIds)
 
 import qualified Data.Set as Set
 
@@ -59,7 +59,7 @@ awaitOtrMessage c (from, fc) (to, tc) =
 assertMembersJoined
     :: (HasCallStack, MonadBotNet m)
     => [Bot]                          -- ^ Who should've received the event
-    -> Maybe (ConvEvent Members)      -- ^ Users who have (presumably) joined
+    -> Maybe (ConvEvent SimpleMembers)-- ^ Users who have (presumably) joined
     -> m ()
 assertMembersJoined _  Nothing  = return ()
 assertMembersJoined bs (Just e) = forM_ bs $ \b ->
@@ -73,7 +73,7 @@ assertMembersJoined bs (Just e) = forM_ bs $ \b ->
 assertMembersLeft
     :: (HasCallStack, MonadBotNet m)
     => [Bot]                          -- ^ Who should've received the event
-    -> Maybe (ConvEvent Members)      -- ^ Users who have (presumably) left
+    -> Maybe (ConvEvent UserIdList)   -- ^ Users who have (presumably) left
     -> m ()
 assertMembersLeft _  Nothing  = return ()
 assertMembersLeft bs (Just e) = forM_ bs $ \b ->
@@ -103,6 +103,6 @@ connStatus from to rel = \case
 
 memberJoined :: UserId -> UserId -> Event -> Bool
 memberJoined from other = \case
-    EMemberJoin m -> null (toList (mUsers (convEvtData m)) \\ [other, from]) &&
+    EMemberJoin m -> null (toList (fmap smId $ mMembers (convEvtData m)) \\ [other, from]) &&
                      convEvtFrom m == from
     _             -> False

--- a/libs/api-client/src/Network/Wire/Client/API/Push.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Push.hs
@@ -11,7 +11,8 @@ module Network.Wire.Client.API.Push
       -- * Event Data
     , Event        (..)
     , ConvEvent    (..)
-    , Members      (..)
+    , SimpleMembers(..)
+    , UserIdList   (..)
     , OtrMessage   (..)
     , NoData
     , UserInfo     (..)
@@ -146,9 +147,9 @@ data Event
     -- TODO: EUserUpdate UserUpdate
     -- Conversation events
     | EConvCreate             (ConvEvent Conversation)
-    | EMemberJoin             (ConvEvent Members)
+    | EMemberJoin             (ConvEvent SimpleMembers)
+    | EMemberLeave            (ConvEvent UserIdList)
     | EConnect                (ConvEvent Connect)
-    | EMemberLeave            (ConvEvent Members)
     | EConvRename             (ConvEvent ConversationRename)
     | EMemberStateUpdate      (ConvEvent MemberUpdate)
     | EOtrMessage             (ConvEvent OtrMessage)

--- a/libs/galley-types/package.yaml
+++ b/libs/galley-types/package.yaml
@@ -23,6 +23,7 @@ library:
   - currency-codes >=2.0
   - data-default >=0.5
   - gundeck-types >=1.15.13
+  - hashable
   - errors
   - exceptions >=0.10.0
   - lens >=4.12

--- a/libs/galley-types/src/Galley/Types/Bot/Service/Internal.hs
+++ b/libs/galley-types/src/Galley/Types/Bot/Service/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TemplateHaskell            #-}
@@ -11,7 +12,9 @@ import Data.ByteString.Conversion
 import Data.Id
 import Data.Misc (Fingerprint, Rsa, HttpsUrl)
 import Data.Text.Ascii
+#ifdef WITH_CQL
 import Cassandra.CQL
+#endif
 
 -- ServiceRef -----------------------------------------------------------------
 
@@ -41,7 +44,11 @@ instance ToJSON ServiceRef where
 -- | A /secret/ bearer token used to authenticate and authorise requests @towards@
 -- a 'Service' via inclusion in the HTTP 'Authorization' header.
 newtype ServiceToken = ServiceToken AsciiBase64Url
-    deriving (Eq, Show, ToByteString, Cql, FromByteString, FromJSON, ToJSON, Generic)
+    deriving (Eq, Show, ToByteString, FromByteString, FromJSON, ToJSON, Generic)
+
+#ifdef WITH_CQL
+deriving instance Cql ServiceToken
+#endif
 
 -- | Service connection information that is needed by galley.
 data Service = Service

--- a/libs/galley-types/src/Galley/Types/Conversations/Roles.hs
+++ b/libs/galley-types/src/Galley/Types/Conversations/Roles.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TemplateHaskell            #-}
+
+module Galley.Types.Conversations.Roles
+    ( ConversationRole
+    , convRoleWireAdmin
+    , convRoleWireMember
+    , wireConvRoles
+
+    , RoleName
+    , roleNameWireAdmin
+    , roleNameWireMember
+    , wireConvRoleNames
+
+    , Action (..)
+    , Actions (..)
+    , ConversationRolesList (..)
+
+    , isActionAllowed
+    , roleNameToActions
+    )
+where
+
+import Imports
+#ifdef WITH_CQL
+import Cassandra.CQL hiding (Set)
+#endif
+import Control.Applicative (optional)
+import Data.Aeson
+import Data.Aeson.TH
+import Data.Attoparsec.Text
+import Data.ByteString.Conversion
+import Data.Hashable
+import qualified Data.Set  as Set
+import qualified Data.Text as T
+
+data Action =
+      AddConversationMember
+    | RemoveConversationMember
+    | ModifyConversationName
+    | ModifyConversationMessageTimer
+    | ModifyConversationReceiptMode
+    | ModifyConversationAccess
+    | ModifyOtherConversationMember
+    | LeaveConversation
+    | DeleteConversation
+    deriving (Eq, Ord, Show, Enum, Bounded, Generic)
+
+deriveJSON defaultOptions{ constructorTagModifier = camelTo2 '_' } ''Action
+
+newtype Actions = Actions
+    { allowedActions :: Set Action
+    } deriving (Eq, Ord, Show, Generic)
+
+-- Do not expose the constructors directly, use smart
+-- constructors instead to ensure that all validation
+-- is performed
+data ConversationRole = ConvRoleWireAdmin
+                      | ConvRoleWireMember
+                      | ConvRoleCustom RoleName Actions
+                      deriving (Eq, Show)
+
+-- Given an action and a RoleName, three possible outcomes:
+-- Just True:  Yes, the action is allowed
+-- Just False: No, the action is not allowed
+-- Nothing:    Not enough information, this is a custom role
+isActionAllowed :: Action -> RoleName -> Maybe Bool
+isActionAllowed action rn
+    | isCustomRoleName rn = Nothing
+    | otherwise           = pure $ maybe False (action `elem`) (roleNameToActions rn)
+
+instance ToJSON ConversationRole where
+    toJSON cr = object
+        [ "conversation_role" .= roleToRoleName cr
+        , "actions"           .= roleActions cr
+        ]
+
+instance FromJSON ConversationRole where
+    parseJSON = withObject "conversationRole" $ \o -> do
+        role    <- o .: "conversation_role"
+        actions <- o .: "actions"
+        case (toConvRole role (Just $ Actions actions)) of
+            Just cr -> return cr
+            Nothing -> fail ("Failed to parse: " ++ show o)
+
+data ConversationRolesList = ConversationRolesList
+    { convRolesList :: [ConversationRole]
+    } deriving (Eq, Show)
+
+instance ToJSON ConversationRolesList where
+    toJSON (ConversationRolesList r) = object
+        [ "conversation_roles" .= r
+        ]
+
+instance FromJSON ConversationRolesList where
+    parseJSON = withObject "conversation-roles-list" $ \o ->
+        ConversationRolesList <$> o .: "convesation_roles"
+
+-- RoleNames with `wire_` prefix are reserved
+-- and cannot be created by externals. Therefore, never
+-- expose this constructor outside of this module.
+newtype RoleName = RoleName { fromRoleName :: Text }
+    deriving (Eq, Show, ToJSON, ToByteString, Hashable, Generic)
+
+#ifdef WITH_CQL
+deriving instance Cql RoleName
+#endif
+
+instance FromByteString RoleName where
+    parser = parser >>= maybe (fail "Invalid RoleName") return . parseRoleName
+
+instance FromJSON RoleName where
+    parseJSON = withText "RoleName" $
+        maybe (fail "Invalid RoleName") pure . parseRoleName
+
+wireConvRoles :: [ConversationRole]
+wireConvRoles = [ ConvRoleWireAdmin
+                , ConvRoleWireMember
+                ]
+
+wireConvRoleNames :: [RoleName]
+wireConvRoleNames = [roleNameWireAdmin, roleNameWireMember]
+
+roleNameWireAdmin :: RoleName
+roleNameWireAdmin = RoleName "wire_admin"
+
+roleNameWireMember :: RoleName
+roleNameWireMember = RoleName "wire_member"
+
+convRoleWireAdmin :: ConversationRole
+convRoleWireAdmin = ConvRoleWireAdmin
+
+convRoleWireMember :: ConversationRole
+convRoleWireMember = ConvRoleWireMember
+
+-- | This is how the definition of the convRoleCustom constructor
+--   should look like. We comment this out due to the fact that we
+--   do not want to use this yet and want to avoid `Defined but not
+--   used warnings`
+-- convRoleCustom :: RoleName -> Actions -> Maybe ConversationRole
+-- convRoleCustom r a
+--     | isCustomRoleName r = Just (ConvRoleCustom r a)
+--     | otherwise          = Nothing
+
+parseRoleName :: Text -> Maybe RoleName
+parseRoleName t
+    | isValidRoleName t = Just (RoleName t)
+    | otherwise         = Nothing
+
+-- All RoleNames should have 2-128 chars
+isValidRoleName :: Text -> Bool
+isValidRoleName = either (const False) (const True)
+                . parseOnly customRoleName
+  where
+    customRoleName = count 2 (satisfy chars)
+                  *> count 126 (optional (satisfy chars))
+                  *> endOfInput
+    chars = inClass "a-z0-9_"
+
+--  * Custom RoleNames _must not_ start with `wire_`
+isCustomRoleName :: RoleName -> Bool
+isCustomRoleName (RoleName r) = isValidRoleName r && (not $ "wire_" `T.isPrefixOf` r)
+
+roleToRoleName :: ConversationRole -> RoleName
+roleToRoleName ConvRoleWireAdmin    = roleNameWireAdmin
+roleToRoleName ConvRoleWireMember   = roleNameWireMember
+roleToRoleName (ConvRoleCustom l _) = l
+
+toConvRole :: RoleName -> Maybe Actions -> Maybe ConversationRole
+toConvRole (RoleName "wire_admin")  _        = Just ConvRoleWireAdmin
+toConvRole (RoleName "wire_member") _        = Just ConvRoleWireMember
+toConvRole x                       (Just as) = Just (ConvRoleCustom x as)
+toConvRole _                        _        = Nothing
+
+roleNameToActions :: RoleName -> Maybe (Set Action)
+roleNameToActions r = roleActions <$> toConvRole r Nothing
+
+allActions :: Actions
+allActions = Actions $ Set.fromList [ minBound..maxBound ]
+
+roleActions :: ConversationRole -> Set Action
+roleActions ConvRoleWireAdmin  = allowedActions allActions
+roleActions ConvRoleWireMember = Set.fromList
+    [ LeaveConversation
+    ]
+roleActions (ConvRoleCustom _ (Actions actions)) = actions

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -242,11 +242,11 @@ data Permissions = Permissions
 
 data Perm =
       CreateConversation
-    | DeleteConversation
+    | DoNotUseDeprecatedDeleteConversation  -- NOTE: This gets now overruled by conv level checks
     | AddTeamMember
     | RemoveTeamMember
-    | AddRemoveConvMember
-    | ModifyConvMetadata
+    | DoNotUseDeprecatedAddRemoveConvMember -- NOTE: This gets now overruled by conv level checks
+    | DoNotUseDeprecatedModifyConvName      -- NOTE: This gets now overruled by conv level checks
     | GetBilling
     | SetBilling
     | SetTeamData
@@ -284,9 +284,9 @@ rolePerms RoleAdmin = rolePerms RoleMember <> Set.fromList
     , SetMemberPermissions
     ]
 rolePerms RoleMember = rolePerms RoleExternalPartner <> Set.fromList
-    [ DeleteConversation
-    , AddRemoveConvMember
-    , ModifyConvMetadata
+    [ DoNotUseDeprecatedDeleteConversation
+    , DoNotUseDeprecatedAddRemoveConvMember
+    , DoNotUseDeprecatedModifyConvName
     , GetMemberPermissions
     ]
 rolePerms RoleExternalPartner = Set.fromList
@@ -540,7 +540,7 @@ noPermissions = Permissions mempty mempty
 serviceWhitelistPermissions :: Set Perm
 serviceWhitelistPermissions = Set.fromList
     [ AddTeamMember, RemoveTeamMember
-    , AddRemoveConvMember
+    , DoNotUseDeprecatedAddRemoveConvMember
     , SetTeamData
     ]
 
@@ -586,27 +586,27 @@ isTeamOwner :: TeamMember -> Bool
 isTeamOwner tm = fullPermissions == (tm^.permissions)
 
 permToInt :: Perm -> Word64
-permToInt CreateConversation       = 0x0001
-permToInt DeleteConversation       = 0x0002
-permToInt AddTeamMember            = 0x0004
-permToInt RemoveTeamMember         = 0x0008
-permToInt AddRemoveConvMember      = 0x0010
-permToInt ModifyConvMetadata       = 0x0020
-permToInt GetBilling               = 0x0040
-permToInt SetBilling               = 0x0080
-permToInt SetTeamData              = 0x0100
-permToInt GetMemberPermissions     = 0x0200
-permToInt GetTeamConversations     = 0x0400
-permToInt DeleteTeam               = 0x0800
-permToInt SetMemberPermissions     = 0x1000
+permToInt CreateConversation                    = 0x0001
+permToInt DoNotUseDeprecatedDeleteConversation  = 0x0002
+permToInt AddTeamMember                         = 0x0004
+permToInt RemoveTeamMember                      = 0x0008
+permToInt DoNotUseDeprecatedAddRemoveConvMember = 0x0010
+permToInt DoNotUseDeprecatedModifyConvName      = 0x0020
+permToInt GetBilling                            = 0x0040
+permToInt SetBilling                            = 0x0080
+permToInt SetTeamData                           = 0x0100
+permToInt GetMemberPermissions                  = 0x0200
+permToInt GetTeamConversations                  = 0x0400
+permToInt DeleteTeam                            = 0x0800
+permToInt SetMemberPermissions                  = 0x1000
 
 intToPerm :: Word64 -> Maybe Perm
 intToPerm 0x0001 = Just CreateConversation
-intToPerm 0x0002 = Just DeleteConversation
+intToPerm 0x0002 = Just DoNotUseDeprecatedDeleteConversation
 intToPerm 0x0004 = Just AddTeamMember
 intToPerm 0x0008 = Just RemoveTeamMember
-intToPerm 0x0010 = Just AddRemoveConvMember
-intToPerm 0x0020 = Just ModifyConvMetadata
+intToPerm 0x0010 = Just DoNotUseDeprecatedAddRemoveConvMember
+intToPerm 0x0020 = Just DoNotUseDeprecatedModifyConvName
 intToPerm 0x0040 = Just GetBilling
 intToPerm 0x0080 = Just SetBilling
 intToPerm 0x0100 = Just SetTeamData

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -37,6 +37,7 @@ import Galley.Types (Conversation (..), ConvType (..), ConvMembers (..), AccessR
 import Galley.Types (OtherMember (..), UserClients)
 import Galley.Types (Event, userClients)
 import Galley.Types.Bot (newServiceRef, serviceRefProvider, serviceRefId)
+import Galley.Types.Conversations.Roles
 import Data.Conduit ((.|), runConduit)
 import Network.HTTP.Types.Status
 import Network.Wai (Response)
@@ -727,7 +728,7 @@ addBot (zuid ::: zcon ::: cid ::: req) = do
     let bcl = newClientId (fromIntegral (hash bid))
 
     -- Ask the external service to create a bot
-    let origmem = OtherMember zuid Nothing
+    let origmem = OtherMember zuid Nothing roleNameWireAdmin
     let members = origmem : (cmOthers mems)
     let bcnv    = Ext.botConvView (cnvId cnv) (cnvName cnv) members
     let busr    = mkBotUserView zusr

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -16,6 +16,7 @@ import Data.Id hiding (client)
 import Data.Misc (Milliseconds)
 import Data.Range
 import Galley.Types (ConvTeamInfo (..), NewConv (..), NewConvUnmanaged (..), NewConvManaged (..))
+import Galley.Types.Conversations.Roles (roleNameWireAdmin)
 import Test.Tasty.HUnit
 import Util
 
@@ -101,7 +102,7 @@ createTeamConv :: HasCallStack => Galley -> TeamId -> UserId -> [UserId] -> Mayb
 createTeamConv g tid u us mtimer = do
     let tinfo = Just $ ConvTeamInfo tid False
     let conv = NewConvUnmanaged $
-               NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer Nothing
+               NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin
     r <- post ( g
               . path "/conversations"
               . zUser u
@@ -117,7 +118,7 @@ createManagedConv :: HasCallStack => Galley -> TeamId -> UserId -> [UserId] -> M
 createManagedConv g tid u us mtimer = do
     let tinfo = Just $ ConvTeamInfo tid True
     let conv = NewConvManaged $
-               NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer Nothing
+               NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin
     r <- post ( g
               . path "/i/conversations/managed"
               . zUser u

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -22,6 +22,8 @@ import qualified V31
 import qualified V32
 import qualified V33
 import qualified V34
+import qualified V35
+import qualified V36
 
 main :: IO ()
 main = do
@@ -43,6 +45,8 @@ main = do
         , V32.migration
         , V33.migration
         , V34.migration
+        , V35.migration -- This should safe to do now
+        , V36.migration
         -- When adding migrations here, don't forget to update
         -- 'schemaVersion' in Galley.Data
         ]

--- a/services/galley/schema/src/V36.hs
+++ b/services/galley/schema/src/V36.hs
@@ -1,0 +1,9 @@
+module V36 (migration) where
+
+import Imports
+import Cassandra.Schema
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 36 "Add extra `conversation_role` field in the member table" $ do
+    schema' [r| ALTER TABLE member ADD conversation_role text; |]

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -12,7 +12,6 @@ import Control.Monad.Catch
 import Data.Id
 import Data.List1 (list1)
 import Data.Range
-import Data.Set ((\\))
 import Data.Time
 import Galley.App
 import Galley.API.Error
@@ -30,7 +29,6 @@ import Network.Wai.Utilities
 import qualified Data.Set           as Set
 import qualified Data.UUID.Tagged   as U
 import qualified Galley.Data        as Data
-import qualified Galley.Types.Teams as Teams
 
 ----------------------------------------------------------------------------
 -- Group conversations
@@ -91,10 +89,7 @@ createTeamGroupConv zusr zcon tinfo body = do
             pure otherConvMems
     conv <- Data.createConversation zusr name (access body) (accessRole body) otherConvMems (newConvTeam body) (newConvMessageTimer body) (newConvReceiptMode body)
     now  <- liftIO getCurrentTime
-    let d = Teams.EdConvCreate (Data.convId conv)
-    let e = newEvent Teams.ConvCreate (cnvTeamId tinfo) now & eventData .~ Just d
-    let notInConv = Set.fromList (map (view userId) teamMems) \\ Set.fromList (zusr : fromConvSize otherConvMems)
-    for_ (newPush zusr (TeamEvent e) (map userRecipient (Set.toList notInConv))) push1
+    -- NOTE: We only send (conversation) events to members of the conversation
     notifyCreatedConversation (Just now) zusr (Just zcon) conv
     conversationResponse status201 zusr conv
 

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -3,6 +3,7 @@ module Galley.API.Error where
 import Imports
 import Data.Text.Lazy as LT (pack)
 import Galley.Types.Teams (IsPerm)
+import Galley.Types.Conversations.Roles (Action)
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
 
@@ -11,6 +12,9 @@ internalError = Error status500 "internal-error" "internal error"
 
 convNotFound :: Error
 convNotFound = Error status404 "no-conversation" "conversation not found"
+
+convMemberNotFound :: Error
+convMemberNotFound = Error status404 "no-conversation-member" "conversation member not found"
 
 invalidSelfOp :: Error
 invalidSelfOp = invalidOp "invalid operation for self conversation"
@@ -30,11 +34,17 @@ invalidManagedConvOp = invalidOp "invalid operation for managed conversation"
 invalidTargetAccess :: Error
 invalidTargetAccess = invalidOp "invalid target access"
 
+invalidTargetUserOp :: Error
+invalidTargetUserOp = invalidOp "invalid target user for the given operation"
+
 invalidOp :: LText -> Error
 invalidOp = Error status403 "invalid-op"
 
 invalidPayload :: LText -> Error
 invalidPayload = Error status400 "invalid-payload"
+
+badRequest :: LText -> Error
+badRequest = Error status400 "bad-request"
 
 notConnected :: Error
 notConnected = Error status403 "not-connected" "Users are not connected"
@@ -66,6 +76,12 @@ operationDenied p = Error
     "operation-denied"
     ("Insufficient permissions (missing " <> (pack $ show p) <> ")")
 
+actionDenied :: Action -> Error
+actionDenied a = Error
+    status403
+    "action-denied"
+    ("Insufficient authorization (missing " <> (pack $ show a) <> ")")
+
 noTeamMember :: Error
 noTeamMember = Error status403 "no-team-member" "Requesting user is not a team member."
 
@@ -81,6 +97,9 @@ teamNotFound = Error status404 "no-team" "team not found"
 
 invalidPermissions :: Error
 invalidPermissions = Error status403 "invalid-permissions" "The specified permissions are invalid."
+
+invalidActions :: Error
+invalidActions = Error status403 "invalid-actions" "The specified actions are invalid."
 
 tooManyTeamMembers :: Error
 tooManyTeamMembers = Error status403 "too-many-team-members" "Maximum number of members per team reached"

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -24,7 +24,7 @@ conversationView u Data.Conversation{..} = do
     let (name, mems) = (convName, ConvMembers m (map toOther them))
     return $! Conversation convId convType convCreator convAccess convAccessRole name mems convTeam convMessageTimer convReceiptMode
   where
-    toOther x = OtherMember (memId x) (memService x)
+    toOther x = OtherMember (memId x) (memService x) (memConvRoleName x)
 
     memberNotFound = do
         Log.err . msg $ val "User "

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -69,7 +69,6 @@ import qualified Galley.Data.SSO as SSOData
 import qualified Galley.External as External
 import qualified Galley.Queue as Q
 import qualified Galley.Types as Conv
-import qualified Galley.Types.Teams as Teams
 import qualified Galley.Intra.Journal as Journal
 import qualified Galley.Intra.Spar as Spar
 import qualified System.Logger.Class as Log
@@ -416,14 +415,11 @@ deleteTeamConversation (zusr::: zcon ::: tid ::: cid ::: _) = do
     (bots, cmems) <- botsAndUsers <$> Data.members cid
     flip Data.deleteCode ReusableCode =<< mkKey cid
     now <- liftIO getCurrentTime
-    let te = newEvent Teams.ConvDelete tid now & eventData .~ Just (Teams.EdConvDelete cid)
     let ce = Conv.Event Conv.ConvDelete cid zusr now Nothing
-    let tr = list1 (userRecipient zusr) (membersToRecipients (Just zusr) tmems)
-    let teamPush = [newPush1 zusr (TeamEvent te) tr & pushConn .~ Just zcon]
-        convPush = case convMembsAndTeamMembs cmems tmems of
+    let convPush = case convMembsAndTeamMembs cmems tmems of
             []     -> []
             (m:mm) -> [newPush1 zusr (ConvEvent ce) (list1 m mm) & pushConn .~ Just zcon]
-    pushSome $ teamPush <> convPush
+    pushSome convPush
     void . forkIO $ void $ External.deliver (bots `zip` repeat ce)
     -- TODO: we don't delete bots here, but we should do that, since every
     -- bot user can only be in a single conversation

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1,7 +1,6 @@
 module Galley.API.Update
     ( -- * Managing Conversations
-      updateConversation
-    , acceptConv
+      acceptConv
     , blockConv
     , unblockConv
     , checkReusableCode
@@ -10,13 +9,16 @@ module Galley.API.Update
     , addCode
     , rmCode
     , getCode
+    , updateConversationDeprecated
+    , updateConversationName
     , updateConversationAccess
     , updateConversationReceiptMode
     , updateConversationMessageTimer
 
       -- * Managing Members
     , Galley.API.Update.addMembers
-    , updateMember
+    , updateSelfMember
+    , updateOtherMember
     , removeMember
 
       -- * Talking
@@ -41,6 +43,7 @@ import Control.Monad.Catch
 import Control.Monad.State
 import Data.Code
 import Data.Id
+import Data.List (delete)
 import Data.List1
 import Data.Time
 import Galley.App
@@ -55,7 +58,8 @@ import Galley.Options
 import Galley.Types
 import Galley.Types.Bot
 import Galley.Types.Clients (Clients)
-import Galley.Types.Teams hiding (EventType (..), EventData (..), Event)
+import Galley.Types.Conversations.Roles (RoleName, Action(..), roleNameWireAdmin)
+import Galley.Types.Teams hiding (EventType (..), EventData (..), Event, self)
 import Galley.Validation
 import Gundeck.Types.Push.V2 (RecipientClients(..))
 import Network.HTTP.Types
@@ -109,13 +113,14 @@ updateConversationAccess (usr ::: zcon ::: cnv ::: req) = do
     -- The user who initiated access change has to be a conversation member
     (bots, users) <- botsAndUsers <$> Data.members cnv
     ensureConvMember users usr
-    -- The conversation has to be a group conversation
     conv <- Data.conversation cnv >>= ifNothing convNotFound
+    -- The conversation has to be a group conversation
     ensureGroupConv conv
+    self <- getSelfMember usr users
+    ensureActionAllowed ModifyConversationAccess self
     -- Team conversations incur another round of checks
     case Data.convTeam conv of
-        Just tid -> checkTeamConv tid >>
-                    permissionCheckTeamConv usr cnv ModifyConvMetadata
+        Just tid -> checkTeamConv tid self
         Nothing  -> when (targetRole == TeamAccessRole) $ throwM invalidTargetAccess
     -- When there is no update to be done, we return 204; otherwise we go
     -- with 'uncheckedUpdateConversationAccess', which will potentially kick
@@ -129,18 +134,14 @@ updateConversationAccess (usr ::: zcon ::: cnv ::: req) = do
                  (currentRole,   targetRole)
                  users bots
   where
-    checkTeamConv tid = do
-        tMembers <- Data.teamMembers tid
-        -- Only team members can change access mode
-        unless (usr `elem` (view userId <$> tMembers)) $
-            throwM convAccessDenied
+    checkTeamConv tid self = do
         -- Access mode change for managed conversation is not allowed
         tcv <- Data.teamConversation tid cnv
         when (maybe False (view managedConversation) tcv) $
             throwM invalidManagedConvOp
         -- Access mode change might result in members being removed from the
         -- conversation, so the user must have the necessary permission flag
-        void $ permissionCheck usr AddRemoveConvMember tMembers
+        ensureActionAllowed RemoveConversationMember self
 
 uncheckedUpdateConversationAccess
     :: ConversationAccessUpdate -> UserId -> ConnId -> Data.Conversation
@@ -201,8 +202,8 @@ uncheckedUpdateConversationAccess body usr zcon conv (currentAccess, targetAcces
 updateConversationReceiptMode :: UserId ::: ConnId ::: ConvId ::: JsonRequest ConversationReceiptModeUpdate ::: JSON -> Galley Response
 updateConversationReceiptMode (usr ::: zcon ::: cnv ::: req ::: _) = do
     ConversationReceiptModeUpdate target <- fromJsonBody req
-    permissionCheckTeamConv usr cnv ModifyConvMetadata
     (bots, users) <- botsAndUsers <$> Data.members cnv
+    ensureActionAllowed ModifyConversationReceiptMode =<< getSelfMember usr users
     current <- Data.lookupReceiptMode cnv
     if current == Just target
         then return $ empty & setStatus status204
@@ -222,11 +223,9 @@ updateConversationMessageTimer (usr ::: zcon ::: cnv ::: req) = do
     let messageTimer = cupMessageTimer body
     -- checks and balances
     (bots, users) <- botsAndUsers <$> Data.members cnv
-    ensureConvMember users usr
+    ensureActionAllowed ModifyConversationMessageTimer =<< getSelfMember usr users
     conv <- Data.conversation cnv >>= ifNothing convNotFound
     ensureGroupConv conv
-    traverse_ ensureTeamMember $ Data.convTeam conv -- only team members can change the timer
-    permissionCheckTeamConv usr cnv ModifyConvMetadata
     let currentTimer = Data.convMessageTimer conv
     if currentTimer == messageTimer then
         return $ empty & setStatus status204
@@ -237,11 +236,6 @@ updateConversationMessageTimer (usr ::: zcon ::: cnv ::: req) = do
         Data.updateConversationMessageTimer cnv messageTimer
         pushEvent e users bots zcon
         return $ json e & setStatus status200
-  where
-    ensureTeamMember tid = do
-        tMembers <- Data.teamMembers tid
-        unless (usr `elem` (view userId <$> tMembers)) $
-            throwM convAccessDenied
 
 pushEvent :: Event -> [Member] -> [BotMember] -> ConnId -> Galley ()
 pushEvent e users bots zcon = do
@@ -333,73 +327,71 @@ joinConversation zusr zcon cnv access = do
     ensureAccessRole (Data.convAccessRole conv) [zusr] mbTms
     let newUsers = filter (notIsMember conv) [zusr]
     ensureMemberLimit (toList $ Data.convMembers conv) newUsers
-    addToConversation (botsAndUsers (Data.convMembers conv)) zusr zcon newUsers conv
+    -- NOTE: When joining conversations, all users become admins
+    -- as this is anyway our default.
+    addToConversation (botsAndUsers (Data.convMembers conv)) zusr zcon newUsers conv roleNameWireAdmin
 
 addMembers :: UserId ::: ConnId ::: ConvId ::: JsonRequest Invite -> Galley Response
 addMembers (zusr ::: zcon ::: cid ::: req) = do
     body <- fromJsonBody req
     conv <- Data.conversation cid >>= ifNothing convNotFound
     let mems = botsAndUsers (Data.convMembers conv)
+    self <- getSelfMember zusr (snd mems)
+    ensureActionAllowed AddConversationMember self
     toAdd <- fromMemberSize <$> checkedMemberAddSize (toList $ invUsers body)
     let newUsers = filter (notIsMember conv) (toList toAdd)
     ensureMemberLimit (toList $ Data.convMembers conv) newUsers
     ensureAccess conv InviteAccess
+    ensureConvRoleNotElevated self (invRoleName body)
     case Data.convTeam conv of
         Nothing -> do
-            ensureConvMember (snd mems) zusr
             ensureAccessRole (Data.convAccessRole conv) newUsers Nothing
             ensureConnected zusr newUsers
         Just ti -> teamConvChecks ti newUsers conv
-    addToConversation mems zusr zcon newUsers conv
+    addToConversation mems zusr zcon newUsers conv (invRoleName body)
   where
     teamConvChecks tid newUsers conv = do
-        tms <- Data.teamMembers tid
+        tms <- Data.teamMembersLimited tid newUsers
         ensureAccessRole (Data.convAccessRole conv) newUsers (Just tms)
-        void $ permissionCheck zusr AddRemoveConvMember tms
         tcv <- Data.teamConversation tid cid
         when (maybe True (view managedConversation) tcv) $
             throwM noAddToManaged
-        -- Team members are alwasy considered connected, so we only check 'ensureConnected'
+        -- Team members are always considered connected, so we only check 'ensureConnected'
         -- for non-team-members.
         let guests = notTeamMember newUsers tms
         ensureConnected zusr guests
 
-updateMember :: UserId ::: ConnId ::: ConvId ::: JsonRequest MemberUpdate -> Galley Response
-updateMember (zusr ::: zcon ::: cid ::: req) = do
-    alive <- Data.isConvAlive cid
-    unless alive $ do
-        Data.deleteConversation cid
-        throwM convNotFound
+updateSelfMember :: UserId ::: ConnId ::: ConvId ::: JsonRequest MemberUpdate -> Galley Response
+updateSelfMember (zusr ::: zcon ::: cid ::: req) = do
+    conv <- getConversationAndCheckMembership zusr cid
     body <- fromJsonBody req
-    m    <- Data.member cid zusr >>= ifNothing convNotFound
-    up   <- Data.updateMember cid zusr body
-    now  <- liftIO getCurrentTime
-    let e = Event MemberStateUpdate cid zusr now (Just $ EdMemberUpdate up)
-    let ms = applyChanges m up
-    for_ (newPush (evtFrom e) (ConvEvent e) [recipient ms]) $ \p ->
-        push1 $ p
-              & pushConn  ?~ zcon
-              & pushRoute .~ RouteDirect
+    m    <- getSelfMember zusr (Data.convMembers conv)
+    -- Ensure no self role upgrades
+    for_ (mupConvRoleName body) $ ensureConvRoleNotElevated m
+    void $ processUpdateMemberEvent zusr zcon cid [m] m body
     return empty
-  where
-    applyChanges :: Member -> MemberUpdateData -> Member
-    applyChanges m u = m
-        { memOtrMuted       = fromMaybe (memOtrMuted m) (misOtrMuted u)
-        , memOtrMutedRef    = misOtrMutedRef u <|> memOtrMutedRef m
-        , memOtrArchived    = fromMaybe (memOtrArchived m) (misOtrArchived u)
-        , memOtrArchivedRef = misOtrArchivedRef u <|> memOtrArchivedRef m
-        , memHidden         = fromMaybe (memHidden m) (misHidden u)
-        , memHiddenRef      = misHiddenRef u <|> memHiddenRef m
-        }
+
+updateOtherMember :: UserId ::: ConnId ::: ConvId ::: UserId ::: JsonRequest OtherMemberUpdate -> Galley Response
+updateOtherMember (zusr ::: zcon ::: cid ::: victim ::: req) = do
+    when (zusr == victim) $
+        throwM invalidTargetUserOp
+    conv <- getConversationAndCheckMembership zusr cid
+    let (bots, users) = botsAndUsers (Data.convMembers conv)
+    body <- fromJsonBody req
+    ensureActionAllowed ModifyOtherConversationMember =<< getSelfMember zusr users
+    memTarget <- getOtherMember victim users
+    e <- processUpdateMemberEvent zusr zcon cid users memTarget (memberUpdate { mupConvRoleName = omuConvRoleName body })
+    void . forkIO $ void $ External.deliver (bots `zip` repeat e)
+    return empty
 
 removeMember :: UserId ::: ConnId ::: ConvId ::: UserId -> Galley Response
 removeMember (zusr ::: zcon ::: cid ::: victim) = do
     conv <- Data.conversation cid >>= ifNothing convNotFound
     let (bots, users) = botsAndUsers (Data.convMembers conv)
+    genConvChecks conv users
     case Data.convTeam conv of
-        Nothing -> regularConvChecks users
+        Nothing -> pure ()
         Just ti -> teamConvChecks ti
-    ensureGroupConv conv
     if victim `isMember` users then do
         e <- Data.removeMembers conv zusr (singleton victim)
         for_ (newPush (evtFrom e) (ConvEvent e) (recipient <$> users)) $ \p ->
@@ -409,12 +401,13 @@ removeMember (zusr ::: zcon ::: cid ::: victim) = do
     else
         return $ empty & setStatus status204
   where
-    regularConvChecks users =
-        unless (zusr `isMember` users) $ throwM convNotFound
+    genConvChecks conv usrs = do
+        ensureGroupConv conv
+        if zusr == victim
+            then ensureActionAllowed LeaveConversation =<< getSelfMember zusr usrs
+            else ensureActionAllowed RemoveConversationMember =<< getSelfMember zusr usrs
 
     teamConvChecks tid = do
-        unless (zusr == victim) $
-            void $ permissionCheck zusr AddRemoveConvMember =<< Data.teamMembers tid
         tcv <- Data.teamConversation tid cid
         when (maybe False (view managedConversation) tcv) $
             throwM (invalidOp "Users can not be removed from managed conversations.")
@@ -493,17 +486,18 @@ newMessage usr con cnv msg now (m, c, t) ~(toBots, toUsers) =
                   . set pushTransient      (newOtrTransient msg)
             in (toBots, p:toUsers)
 
-updateConversation :: UserId ::: ConnId ::: ConvId ::: JsonRequest ConversationRename -> Galley Response
-updateConversation (zusr ::: zcon ::: cnv ::: req) = do
+updateConversationDeprecated :: UserId ::: ConnId ::: ConvId ::: JsonRequest ConversationRename -> Galley Response
+updateConversationDeprecated (zusr ::: zcon ::: cnv ::: req) = updateConversationName (zusr ::: zcon ::: cnv ::: req)
+
+updateConversationName :: UserId ::: ConnId ::: ConvId ::: JsonRequest ConversationRename -> Galley Response
+updateConversationName (zusr ::: zcon ::: cnv ::: req) = do
     body <- fromJsonBody req
-    permissionCheckTeamConv zusr cnv ModifyConvMetadata
     alive <- Data.isConvAlive cnv
     unless alive $ do
         Data.deleteConversation cnv
         throwM convNotFound
     (bots, users) <- botsAndUsers <$> Data.members cnv
-    unless (zusr `isMember` users) $
-        throwM convNotFound
+    ensureActionAllowed ModifyConversationName =<< getSelfMember zusr users
     now <- liftIO getCurrentTime
     cn  <- rangeChecked (cupName body)
     Data.updateConversation cnv cn
@@ -559,13 +553,12 @@ addBot (zusr ::: zcon ::: req) = do
         unless (zusr `isMember` users) $
             throwM convNotFound
         ensureGroupConv c
+        ensureActionAllowed AddConversationMember =<< getSelfMember zusr users
         unless (any ((== b^.addBotId) . botMemId) bots) $
             ensureMemberLimit (toList $ Data.convMembers c) [botUserId (b^.addBotId)]
         return (bots, users)
 
     teamConvChecks cid tid = do
-        tms <- Data.teamMembers tid
-        void $ permissionCheck zusr AddRemoveConvMember tms
         tcv <- Data.teamConversation tid cid
         when (maybe True (view managedConversation) tcv) $
             throwM noAddToManaged
@@ -581,7 +574,7 @@ rmBot (zusr ::: zcon ::: req) = do
         then return $ setStatus status204 empty
         else do
             t <- liftIO getCurrentTime
-            let evd = Just (EdMembers (Members [botUserId (b^.rmBotId)]))
+            let evd = Just (EdMembersLeave (UserIdList [botUserId (b^.rmBotId)]))
             let e = Event MemberLeave (Data.convId c) zusr t evd
             for_ (newPush (evtFrom e) (ConvEvent e) (recipient <$> users)) $ \p ->
                 push1 $ p & pushConn .~ zcon
@@ -593,13 +586,13 @@ rmBot (zusr ::: zcon ::: req) = do
 -------------------------------------------------------------------------------
 -- Helpers
 
-addToConversation :: ([BotMember], [Member]) -> UserId -> ConnId -> [UserId] -> Data.Conversation -> Galley Response
-addToConversation _              _   _    [] _ = return $ empty & setStatus status204
-addToConversation (bots, others) usr conn xs c = do
+addToConversation :: ([BotMember], [Member]) -> UserId -> ConnId -> [UserId] -> Data.Conversation -> RoleName -> Galley Response
+addToConversation _              _   _    [] _ _    = return $ empty & setStatus status204
+addToConversation (bots, others) usr conn xs c role = do
     ensureGroupConv c
     mems    <- checkedMemberAddSize xs
     now     <- liftIO getCurrentTime
-    (e, mm) <- Data.addMembers now (Data.convId c) usr mems
+    (e, mm) <- Data.addMembersWithRole now (Data.convId c) usr mems role
     for_ (newPush (evtFrom e) (ConvEvent e) (recipient <$> allMembers (toList mm))) $ \p ->
         push1 $ p & pushConn ?~ conn
     void . forkIO $ void $ External.deliver (bots `zip` repeat e)
@@ -638,6 +631,34 @@ ensureAccess conv access =
     unless (access `elem` Data.convAccess conv) $
         throwM convAccessDenied
 
+applyMemUpdateChanges :: Member -> MemberUpdateData -> Member
+applyMemUpdateChanges m u = m
+    { memOtrMuted       = fromMaybe (memOtrMuted m) (misOtrMuted u)
+    , memOtrMutedRef    = misOtrMutedRef u <|> memOtrMutedRef m
+    , memOtrArchived    = fromMaybe (memOtrArchived m) (misOtrArchived u)
+    , memOtrArchivedRef = misOtrArchivedRef u <|> memOtrArchivedRef m
+    , memHidden         = fromMaybe (memHidden m) (misHidden u)
+    , memHiddenRef      = misHiddenRef u <|> memHiddenRef m
+    , memConvRoleName   = fromMaybe (memConvRoleName m) (misConvRoleName u)
+    }
+
+processUpdateMemberEvent :: UserId
+                         -> ConnId
+                         -> ConvId
+                         -> [Member]
+                         -> Member
+                         -> MemberUpdate
+                         -> Galley Event
+processUpdateMemberEvent zusr zcon cid users target update = do
+    up   <- Data.updateMember cid (memId target) update
+    now  <- liftIO getCurrentTime
+    let e = Event MemberStateUpdate cid zusr now (Just $ EdMemberUpdate up)
+    let ms = applyMemUpdateChanges target up
+    for_ (newPush (evtFrom e) (ConvEvent e) (recipient ms : fmap recipient (delete target users))) $ \p ->
+        push1 $ p
+              & pushConn  ?~ zcon
+              & pushRoute .~ RouteDirect
+    return e
 -------------------------------------------------------------------------------
 -- OtrRecipients Validation
 

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -330,7 +330,7 @@ joinConversation zusr zcon cnv access = do
     -- NOTE: When joining conversations, all users become members
     -- as this is our desired behavior for these types of conversations
     -- where there is no way to control who joins, etc.
-    addToConversation (botsAndUsers (Data.convMembers conv)) zusr zcon newUsers conv roleNameWireMember
+    addToConversation (botsAndUsers (Data.convMembers conv)) (zusr, roleNameWireMember) zcon ((, roleNameWireMember) <$> newUsers) conv
 
 addMembers :: UserId ::: ConnId ::: ConvId ::: JsonRequest Invite -> Galley Response
 addMembers (zusr ::: zcon ::: cid ::: req) = do
@@ -349,7 +349,7 @@ addMembers (zusr ::: zcon ::: cid ::: req) = do
             ensureAccessRole (Data.convAccessRole conv) newUsers Nothing
             ensureConnected zusr newUsers
         Just ti -> teamConvChecks ti newUsers conv
-    addToConversation mems zusr zcon newUsers conv (invRoleName body)
+    addToConversation mems (zusr, memConvRoleName self) zcon ((, invRoleName body) <$> newUsers) conv
   where
     teamConvChecks tid newUsers conv = do
         tms <- Data.teamMembersLimited tid newUsers
@@ -587,13 +587,13 @@ rmBot (zusr ::: zcon ::: req) = do
 -------------------------------------------------------------------------------
 -- Helpers
 
-addToConversation :: ([BotMember], [Member]) -> UserId -> ConnId -> [UserId] -> Data.Conversation -> RoleName -> Galley Response
-addToConversation _              _   _    [] _ _    = return $ empty & setStatus status204
-addToConversation (bots, others) usr conn xs c role = do
+addToConversation :: ([BotMember], [Member]) -> (UserId, RoleName) -> ConnId -> [(UserId, RoleName)] -> Data.Conversation -> Galley Response
+addToConversation _              _             _    [] _ = return $ empty & setStatus status204
+addToConversation (bots, others) (usr,usrRole) conn xs c = do
     ensureGroupConv c
     mems    <- checkedMemberAddSize xs
     now     <- liftIO getCurrentTime
-    (e, mm) <- Data.addMembersWithRole now (Data.convId c) usr mems role
+    (e, mm) <- Data.addMembersWithRole now (Data.convId c) (usr, usrRole) mems
     for_ (newPush (evtFrom e) (ConvEvent e) (recipient <$> allMembers (toList mm))) $ \p ->
         push1 $ p & pushConn ?~ conn
     void . forkIO $ void $ External.deliver (bots `zip` repeat e)

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -58,7 +58,7 @@ import Galley.Options
 import Galley.Types
 import Galley.Types.Bot
 import Galley.Types.Clients (Clients)
-import Galley.Types.Conversations.Roles (RoleName, Action(..), roleNameWireAdmin)
+import Galley.Types.Conversations.Roles (RoleName, Action(..), roleNameWireMember)
 import Galley.Types.Teams hiding (EventType (..), EventData (..), Event, self)
 import Galley.Validation
 import Gundeck.Types.Push.V2 (RecipientClients(..))
@@ -327,9 +327,10 @@ joinConversation zusr zcon cnv access = do
     ensureAccessRole (Data.convAccessRole conv) [zusr] mbTms
     let newUsers = filter (notIsMember conv) [zusr]
     ensureMemberLimit (toList $ Data.convMembers conv) newUsers
-    -- NOTE: When joining conversations, all users become admins
-    -- as this is anyway our default.
-    addToConversation (botsAndUsers (Data.convMembers conv)) zusr zcon newUsers conv roleNameWireAdmin
+    -- NOTE: When joining conversations, all users become members
+    -- as this is our desired behavior for these types of conversations
+    -- where there is no way to control who joins, etc.
+    addToConversation (botsAndUsers (Data.convMembers conv)) zusr zcon newUsers conv roleNameWireMember
 
 addMembers :: UserId ::: ConnId ::: ConvId ::: JsonRequest Invite -> Galley Response
 addMembers (zusr ::: zcon ::: cid ::: req) = do

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -409,7 +409,7 @@ createConversation usr name acc role others tinfo mtimer recpt othersConversatio
             setConsistency Quorum
             addPrepQuery Cql.insertConv (conv, RegularConv, usr, Set (toList acc), role, fromRange <$> name, Just (cnvTeamId ti), mtimer, recpt)
             addPrepQuery Cql.insertTeamConv (cnvTeamId ti, conv, cnvManaged ti)
-    mems <- snd <$> addMembersUnchecked now conv usr (list1 usr $ fromConvSize others) othersConversationRole
+    mems <- snd <$> addMembersUncheckedWithRole now conv (usr, roleNameWireAdmin) (list1 (usr, roleNameWireAdmin) ((, othersConversationRole) <$> fromConvSize others))
     return $ newConv conv RegularConv usr (toList mems) acc role name (cnvTeamId <$> tinfo) mtimer recpt
 
 createSelfConversation :: MonadClient m => UserId -> Maybe (Range 1 256 Text) -> m Conversation
@@ -418,7 +418,7 @@ createSelfConversation usr name = do
     now <- liftIO getCurrentTime
     retry x5 $
         write Cql.insertConv (params Quorum (conv, SelfConv, usr, privateOnly, privateRole, fromRange <$> name, Nothing, Nothing, Nothing))
-    mems <- snd <$> addMembersUnchecked now conv usr (singleton usr) roleNameWireAdmin
+    mems <- snd <$> addMembersUnchecked now conv usr (singleton usr)
     return $ newConv conv SelfConv usr (toList mems) [PrivateAccess] privateRole name Nothing Nothing Nothing
 
 createConnectConversation :: MonadClient m
@@ -435,7 +435,7 @@ createConnectConversation a b name conn = do
         write Cql.insertConv (params Quorum (conv, ConnectConv, a', privateOnly, privateRole, fromRange <$> name, Nothing, Nothing, Nothing))
     -- We add only one member, second one gets added later,
     -- when the other user accepts the connection request.
-    mems <- snd <$> addMembersUnchecked now conv a' (singleton a') roleNameWireAdmin
+    mems <- snd <$> addMembersUnchecked now conv a' (singleton a')
     let e = Event ConvConnect conv a' now (Just $ EdConnect conn)
     return (newConv conv ConnectConv a' (toList mems) [PrivateAccess] privateRole name Nothing Nothing Nothing, e)
 
@@ -456,7 +456,7 @@ createOne2OneConversation a b name ti = do
             setConsistency Quorum
             addPrepQuery Cql.insertConv (conv, One2OneConv, a', privateOnly, privateRole, fromRange <$> name, Just tid, Nothing, Nothing)
             addPrepQuery Cql.insertTeamConv (tid, conv, False)
-    mems <- snd <$> addMembersUnchecked now conv a' (list1 a' [b']) roleNameWireAdmin
+    mems <- snd <$> addMembersUnchecked now conv a' (list1 a' [b'])
     return $ newConv conv One2OneConv a' (toList mems) [PrivateAccess] privateRole name ti Nothing Nothing
 
 updateConversation :: MonadClient m => ConvId -> Range 1 256 Text -> m ()
@@ -566,13 +566,16 @@ members :: MonadClient m => ConvId -> m [Member]
 members conv = join <$> memberLists [conv]
 
 addMember :: MonadClient m => UTCTime -> ConvId -> UserId -> m (Event, List1 Member)
-addMember t c u = addMembersUnchecked t c u (singleton u) roleNameWireAdmin
+addMember t c u = addMembersUnchecked t c u (singleton u)
 
-addMembersWithRole :: MonadClient m => UTCTime -> ConvId -> UserId -> ConvMemberAddSizeChecked (List1 UserId) -> RoleName -> m (Event, List1 Member)
-addMembersWithRole t c u ms r = addMembersUnchecked t c u (fromMemberSize ms) r
+addMembersWithRole :: MonadClient m => UTCTime -> ConvId -> (UserId, RoleName) -> ConvMemberAddSizeChecked (List1 (UserId, RoleName)) -> m (Event, List1 Member)
+addMembersWithRole t c orig mems = addMembersUncheckedWithRole t c orig (fromMemberSize mems)
 
-addMembersUnchecked :: MonadClient m => UTCTime -> ConvId -> UserId -> List1 UserId -> RoleName -> m (Event, List1 Member)
-addMembersUnchecked t conv orig usrs othersRole = do
+addMembersUnchecked :: MonadClient m => UTCTime -> ConvId -> UserId -> List1 UserId -> m (Event, List1 Member)
+addMembersUnchecked t conv orig usrs = addMembersUncheckedWithRole t conv (orig, roleNameWireAdmin) ((, roleNameWireAdmin) <$> usrs)
+
+addMembersUncheckedWithRole :: MonadClient m => UTCTime -> ConvId -> (UserId, RoleName) -> List1 (UserId, RoleName) -> m (Event, List1 Member)
+addMembersUncheckedWithRole t conv (orig, _origRole) usrs = do
     -- batch statement with 500 users are known to be above the batch size limit
     -- and throw "Batch too large" errors. Therefor we chunk requests and insert
     -- sequentially. (parallelizing would not aid performance as the partition
@@ -585,18 +588,14 @@ addMembersUnchecked t conv orig usrs othersRole = do
         retry x5 $ batch $ do
             setType BatchLogged
             setConsistency Quorum
-            for_ chunk $ \u -> do
+            for_ chunk $ \(u, r) -> do
                 addPrepQuery Cql.insertUserConv (u, conv)
-                addPrepQuery Cql.insertMember   (conv, u, Nothing, Nothing, userRole u)
+                addPrepQuery Cql.insertMember   (conv, u, Nothing, Nothing, r)
     let e = Event MemberJoin conv orig t (Just . EdMembersJoin . SimpleMembers . toSimpleMembers $ toList usrs)
-    return (e, fmap (\u -> newMemberWithRole u (userRole u)) usrs)
+    return (e, fmap (uncurry newMemberWithRole  ) usrs)
   where
-    toSimpleMembers :: [UserId] -> [SimpleMember]
-    toSimpleMembers = fmap $ (\u -> SimpleMember u (userRole u))
-
-    userRole u
-       | u == orig = roleNameWireAdmin
-       | otherwise = othersRole
+    toSimpleMembers :: [(UserId, RoleName)] -> [SimpleMember]
+    toSimpleMembers = fmap (uncurry SimpleMember)
 
 updateMember :: MonadClient m => ConvId -> UserId -> MemberUpdate -> m MemberUpdateData
 updateMember cid uid mup = do

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -14,6 +14,7 @@ import Data.LegalHold
 import Data.Misc
 import Galley.Data.Types
 import Galley.Types hiding (Conversation)
+import Galley.Types.Conversations.Roles
 import Galley.Types.Teams
 import Galley.Types.Teams.Intra
 import Galley.Types.Teams.SSO
@@ -58,6 +59,18 @@ selectTeamMembers = [r|
     select user, perms, invited_by, invited_at, legalhold_status
       from team_member
     where team = ? order by user
+    |]
+
+selectTeamMembers' :: PrepQuery R (TeamId, [UserId]) ( UserId
+                                                     , Permissions
+                                                     , Maybe UserId
+                                                     , Maybe UTCTimeMillis
+                                                     , Maybe UserLegalHoldStatus
+                                                   )
+selectTeamMembers' = [r|
+    select user, perms, invited_by, invited_at, legalhold_status
+      from team_member
+    where team = ? and user in ? order by user
     |]
 
 selectUserTeams :: PrepQuery R (Identity UserId) (Identity TeamId)
@@ -184,14 +197,14 @@ deleteUserConv = "delete from user where user = ? and conv = ?"
 
 type MemberStatus = Int32
 
-selectMember :: PrepQuery R (ConvId, UserId) (UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text)
-selectMember = "select user, service, provider, status, otr_muted, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref from member where conv = ? and user = ?"
+selectMember :: PrepQuery R (ConvId, UserId) (UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName)
+selectMember = "select user, service, provider, status, otr_muted, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role from member where conv = ? and user = ?"
 
-selectMembers :: PrepQuery R (Identity [ConvId]) (ConvId, UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text)
-selectMembers = "select conv, user, service, provider, status, otr_muted, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref from member where conv in ?"
+selectMembers :: PrepQuery R (Identity [ConvId]) (ConvId, UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName)
+selectMembers = "select conv, user, service, provider, status, otr_muted, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role from member where conv in ?"
 
-insertMember :: PrepQuery W (ConvId, UserId, Maybe ServiceId, Maybe ProviderId) ()
-insertMember = "insert into member (conv, user, service, provider, status) values (?, ?, ?, ?, 0)"
+insertMember :: PrepQuery W (ConvId, UserId, Maybe ServiceId, Maybe ProviderId, RoleName) ()
+insertMember = "insert into member (conv, user, service, provider, status, conversation_role) values (?, ?, ?, ?, 0, ?)"
 
 removeMember :: PrepQuery W (ConvId, UserId) ()
 removeMember = "delete from member where conv = ? and user = ?"
@@ -207,6 +220,9 @@ updateOtrMemberArchived = "update member set otr_archived = ?, otr_archived_ref 
 
 updateMemberHidden :: PrepQuery W (Bool, Maybe Text, ConvId, UserId) ()
 updateMemberHidden = "update member set hidden = ?, hidden_ref = ? where conv = ? and user = ?"
+
+updateMemberConvRoleName :: PrepQuery W (RoleName, ConvId, UserId) ()
+updateMemberConvRoleName = "update member set conversation_role = ? where conv = ? and user = ?"
 
 -- Clients ------------------------------------------------------------------
 

--- a/services/galley/src/Galley/Data/Services.hs
+++ b/services/galley/src/Galley/Data/Services.hs
@@ -23,6 +23,7 @@ import Galley.Data (newMember)
 import Galley.Data.Queries
 import Galley.Data.Instances ()
 import Galley.Types.Bot
+import Galley.Types.Conversations.Roles
 import Galley.Types hiding (Conversation)
 
 -- BotMember ------------------------------------------------------------------
@@ -47,9 +48,12 @@ addBotMember orig s bot cnv now = do
         setConsistency Quorum
         addPrepQuery insertUserConv (botUserId bot, cnv)
         addPrepQuery insertBot (cnv, bot, sid, pid)
-    let e = Event MemberJoin cnv orig now (Just . EdMembers $ Members [botUserId bot])
+    let e = Event MemberJoin cnv orig now (Just . EdMembersJoin . SimpleMembers $ (fmap toSimpleMember [botUserId bot]))
     let mem = (newMember (botUserId bot)) { memService = Just s }
     return (e, BotMember mem)
+  where
+    toSimpleMember :: UserId -> SimpleMember
+    toSimpleMember u = SimpleMember u roleNameWireAdmin
 
 -- Service --------------------------------------------------------------------
 

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -351,7 +351,7 @@ postJoinConvOk = do
         postJoinConv bob conv !!! const 200 === statusCode
         postJoinConv bob conv !!! const 204 === statusCode
         void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB] $
-            wsAssertMemberJoin conv bob [bob]
+            wsAssertMemberJoinWithRole conv bob [bob] roleNameWireMember
 
 postJoinCodeConvOk :: TestM ()
 postJoinCodeConvOk = do
@@ -380,7 +380,7 @@ postJoinCodeConvOk = do
         -- eve cannot join
         postJoinCodeConv eve payload !!! const 403 === statusCode
         void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB] $
-            wsAssertMemberJoin conv bob [bob]
+            wsAssertMemberJoinWithRole conv bob [bob] roleNameWireMember
         -- changing access to non-activated should give eve access
         let nonActivatedAccess = ConversationAccessUpdate [CodeAccess] NonActivatedAccessRole
         putAccessUpdate alice conv nonActivatedAccess !!! const 200 === statusCode
@@ -459,7 +459,7 @@ postConvertTeamConv = do
     WS.bracketR3 c alice bob eve $ \(wsA, wsB, wsE) -> do
         postJoinCodeConv mallory j !!! const 200 === statusCode
         void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsE] $
-            wsAssertMemberJoin conv mallory [mallory]
+            wsAssertMemberJoinWithRole conv mallory [mallory] roleNameWireMember
 
     WS.bracketRN c [alice, bob, eve, mallory] $ \[wsA, wsB, wsE, wsM] -> do
         let teamAccess = ConversationAccessUpdate [InviteAccess, CodeAccess] TeamAccessRole

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -12,6 +12,7 @@ import Data.Id
 import Data.List1
 import Data.Range
 import Galley.Types
+import Galley.Types.Conversations.Roles
 import Gundeck.Types.Notification
 import Network.Wai.Utilities.Error
 import Test.Tasty
@@ -26,6 +27,7 @@ import qualified Galley.Types.Teams       as Teams
 import qualified API.Teams                as Teams
 import qualified API.Teams.LegalHold      as Teams.LegalHold
 import qualified API.MessageTimer         as MessageTimer
+import qualified API.Roles                as Roles
 import qualified Control.Concurrent.Async as Async
 import qualified Data.List1               as List1
 import qualified Data.Map.Strict          as Map
@@ -40,6 +42,7 @@ tests s = testGroup "Galley integration tests"
     , mainTests
     , Teams.tests s
     , MessageTimer.tests s
+    , Roles.tests s
     ]
   where
     mainTests = testGroup "Main API"
@@ -433,7 +436,7 @@ postConvertTeamConv = do
     alice <- randomUser
     tid   <- createTeamInternal "foo" alice
     assertQueue "create team" tActivate
-    let p1 = symmPermissions [Teams.AddRemoveConvMember]
+    let p1 = symmPermissions [Teams.DoNotUseDeprecatedAddRemoveConvMember]
     bobMem <- (\u -> Teams.newTeamMember u p1 Nothing) <$> randomUser
     addTeamMemberInternal tid bobMem
     let bob = bobMem^.Teams.userId
@@ -446,10 +449,10 @@ postConvertTeamConv = do
     connectUsers alice (singleton eve)
     let acc = Just $ Set.fromList [InviteAccess, CodeAccess]
     -- creating a team-only conversation containing eve should fail
-    createTeamConvAccessRaw alice tid [bob, eve] (Just "blaa") acc (Just TeamAccessRole) Nothing !!!
+    createTeamConvAccessRaw alice tid [bob, eve] (Just "blaa") acc (Just TeamAccessRole) Nothing Nothing !!!
         const 403 === statusCode
     -- create conversation allowing any type of guest
-    conv <- createTeamConvAccess alice tid [bob, eve] (Just "blaa") acc (Just NonActivatedAccessRole) Nothing
+    conv <- createTeamConvAccess alice tid [bob, eve] (Just "blaa") acc (Just NonActivatedAccessRole) Nothing Nothing
     -- mallory joins by herself
     mallory  <- ephemeralUser
     j <- decodeConvCodeEvent <$> postConvCode alice conv
@@ -638,7 +641,7 @@ postConvO2OFailWithSelf :: TestM ()
 postConvO2OFailWithSelf = do
     g <- view tsGalley
     alice <- randomUser
-    let inv = NewConvUnmanaged (NewConv [alice] Nothing mempty Nothing Nothing Nothing Nothing)
+    let inv = NewConvUnmanaged (NewConv [alice] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin)
     post (g . path "/conversations/one2one" . zUser alice . zConn "conn" . zType "access" . json inv) !!! do
         const 403 === statusCode
         const (Just "invalid-op") === fmap label . responseJsonUnsafe
@@ -947,22 +950,15 @@ deleteMembersFailO2O = do
 
 putConvRenameOk :: TestM ()
 putConvRenameOk = do
-    g <- view tsGalley
     c <- view tsCannon
     alice <- randomUser
     bob   <- randomUser
     connectUsers alice (singleton bob)
     conv  <- decodeConvId <$> postO2OConv alice bob (Just "gossip")
+    -- This endpoint should be deprecated but clients still use it
     WS.bracketR2 c alice bob $ \(wsA, wsB) -> do
-        let update = ConversationRename "gossip++"
-        put ( g
-            . paths ["conversations", toByteString' conv]
-            . zUser bob
-            . zConn "conn"
-            . zType "access"
-            . json update
-            ) !!! const 200 === statusCode
-        void. liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB] $ \n -> do
+        void $ putConversationName bob conv "gossip++" !!! const 200 === statusCode
+        void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB] $ \n -> do
             let e = List1.head (WS.unpackPayload n)
             ntfTransient n @?= False
             evtConv      e @?= conv
@@ -1017,6 +1013,7 @@ putMemberOk update = do
                   , memOtrArchivedRef = mupOtrArchiveRef update
                   , memHidden = fromMaybe False (mupHidden update)
                   , memHiddenRef = mupHiddenRef update
+                  , memConvRoleName = fromMaybe roleNameWireAdmin (mupConvRoleName update)
                   }
 
     -- Update member state & verify push notification
@@ -1054,7 +1051,6 @@ putMemberOk update = do
 
 putReceiptModeOk :: TestM ()
 putReceiptModeOk = do
-    g <- view tsGalley
     c <- view tsCannon
     alice <- randomUser
     bob   <- randomUser
@@ -1068,13 +1064,7 @@ putReceiptModeOk = do
             const (Just Nothing) === fmap cnvReceiptMode . responseJsonUnsafe
 
         -- Set receipt mode
-        put ( g
-         . paths ["conversations", toByteString' cnv, "receipt-mode"]
-         . zUser alice
-         . zConn "conn"
-         . zType "access"
-         . json (ConversationReceiptModeUpdate $ ReceiptMode 0)
-         ) !!! const 200 === statusCode
+        putReceiptMode alice cnv (ReceiptMode 0) !!! const 200 === statusCode
 
         -- Ensure the field is properly set
         getConv alice cnv !!! do
@@ -1084,13 +1074,7 @@ putReceiptModeOk = do
         void . liftIO $ checkWs alice (cnv, wsB)
 
         -- No changes
-        put ( g
-         . paths ["conversations", toByteString' cnv, "receipt-mode"]
-         . zUser alice
-         . zConn "conn"
-         . zType "access"
-         . json (ConversationReceiptModeUpdate $ ReceiptMode 0)
-         ) !!! const 204 === statusCode
+        putReceiptMode alice cnv (ReceiptMode 0) !!! const 204 === statusCode
         -- No event should have been generated
         WS.assertNoEvent (1 # Second) [wsB]
 
@@ -1163,9 +1147,9 @@ removeUser = do
     liftIO $ do
         (mems1 >>= other bob)  @?= Nothing
         (mems2 >>= other bob)  @?= Nothing
-        (mems2 >>= other carl) @?= Just (OtherMember carl Nothing)
+        (mems2 >>= other carl) @?= Just (OtherMember carl Nothing roleNameWireAdmin)
         (mems3 >>= other bob)  @?= Nothing
-        (mems3 >>= other carl) @?= Just (OtherMember carl Nothing)
+        (mems3 >>= other carl) @?= Just (OtherMember carl Nothing roleNameWireAdmin)
   where
     matchMemberLeave conv u n = do
         let e = List1.head (WS.unpackPayload n)
@@ -1173,4 +1157,4 @@ removeUser = do
         evtConv      e @?= conv
         evtType      e @?= MemberLeave
         evtFrom      e @?= u
-        evtData      e @?= Just (EdMembers (Members [u]))
+        evtData      e @?= Just (EdMembersLeave (UserIdList [u]))

--- a/services/galley/test/integration/API/Roles.hs
+++ b/services/galley/test/integration/API/Roles.hs
@@ -1,0 +1,213 @@
+module API.Roles where
+
+import Imports
+import API.Util
+import Bilge hiding (timeout)
+import Bilge.Assert
+import Control.Lens (view)
+import Data.Id
+import Data.List1
+import Galley.Types
+import Galley.Types.Conversations.Roles
+import Network.Wai.Utilities.Error
+import Test.Tasty
+import Test.Tasty.Cannon (TimeoutUnit (..), (#))
+import TestHelpers
+import TestSetup
+
+import qualified Test.Tasty.Cannon        as WS
+
+tests :: IO TestSetup -> TestTree
+tests s = testGroup "Conversation roles"
+        [ test s "conversation roles admin (and downgrade)" handleConversationRoleAdmin
+        , test s "conversation roles member (and upgrade)" handleConversationRoleMember
+        ]
+
+handleConversationRoleAdmin :: TestM ()
+handleConversationRoleAdmin = do
+    c     <- view tsCannon
+    alice <- randomUser
+    bob   <- randomUser
+    chuck <- randomUser
+    eve   <- randomUser
+    jack  <- randomUser
+    connectUsers alice (list1 bob [chuck, eve, jack])
+    connectUsers eve (singleton bob)
+    connectUsers bob (singleton jack)
+
+    let role = roleNameWireAdmin
+    cid <- WS.bracketR3 c alice bob chuck $ \(wsA, wsB, wsC) -> do
+        rsp <- postConvWithRole alice [bob, chuck] (Just "gossip") [] Nothing Nothing role
+        void $ assertConvWithRole rsp RegularConv alice alice [bob,chuck] (Just "gossip") Nothing role
+        let cid = decodeConvId rsp
+        -- Make sure everyone gets the correct event
+        postMembersWithRole alice (singleton eve) cid role !!! const 200 === statusCode
+        void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
+            wsAssertMemberJoinWithRole cid alice [eve] role
+        -- Add a member to help out with testing
+        postMembersWithRole alice (singleton jack) cid roleNameWireMember !!! const 200 === statusCode
+        void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
+            wsAssertMemberJoinWithRole cid alice [jack] roleNameWireMember
+
+        return cid
+
+    -- Added bob as a wire_admin and do the checks
+    wireAdminChecks cid alice bob jack
+    -- Demote bob and run the member checks
+    WS.bracketR3 c alice bob chuck $ \(wsA, wsB, wsC) -> do
+        let updateDown = OtherMemberUpdate (Just roleNameWireMember)
+        putOtherMember alice bob updateDown cid !!! assertActionSucceeded
+        void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $ do
+            wsAssertMemberUpdateWithRole cid alice bob roleNameWireMember
+
+    wireMemberChecks cid bob alice jack
+
+handleConversationRoleMember :: TestM ()
+handleConversationRoleMember = do
+    c     <- view tsCannon
+    alice <- randomUser
+    bob   <- randomUser
+    chuck <- randomUser
+    eve   <- randomUser
+    jack  <- randomUser
+    connectUsers alice (list1 bob [chuck, eve])
+    connectUsers bob (singleton chuck)
+    connectUsers eve (list1 bob [jack])
+    let role = roleNameWireMember
+
+    cid <- WS.bracketR3 c alice bob chuck $ \(wsA, wsB, wsC) -> do
+        rsp <- postConvWithRole alice [bob, chuck] (Just "gossip") [] Nothing Nothing role
+        void $ assertConvWithRole rsp RegularConv alice alice [bob,chuck] (Just "gossip") Nothing role
+        let cid = decodeConvId rsp
+
+        -- Make sure everyone gets the correct event
+        postMembersWithRole alice (singleton eve) cid role !!! const 200 === statusCode
+        void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
+            wsAssertMemberJoinWithRole cid alice [eve] role
+
+        return cid
+
+    -- Added bob as a wire_member and do the checks
+    wireMemberChecks cid bob alice chuck
+
+    -- Let's promote bob
+    WS.bracketR3 c alice bob chuck $ \(wsA, wsB, wsC) -> do
+        let updateUp = OtherMemberUpdate (Just roleNameWireAdmin)
+        -- Chuck cannot update, member only
+        putOtherMember chuck bob updateUp cid !!! assertActionDenied
+        putOtherMember alice bob updateUp cid !!! assertActionSucceeded
+        void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $ do
+            wsAssertMemberUpdateWithRole cid alice bob roleNameWireAdmin
+
+    wireAdminChecks cid bob alice chuck
+
+-- | Given an admin, another admin and a member run all
+--   the necessary checks targeting the admin
+wireAdminChecks :: ConvId
+                -> UserId
+                -> UserId
+                -> UserId
+                -> TestM ()
+wireAdminChecks cid admin otherAdmin mem = do
+        let role = roleNameWireAdmin
+        other <- randomUser
+        connectUsers admin (singleton other)
+        -- Admins can perform all operations on the conversation; creator is not relevant
+
+        -- Add members
+        postMembers admin (singleton other) cid !!! assertActionSucceeded
+
+        -- Remove members, regardless of who they are
+        forM_ [otherAdmin, mem] $ \victim -> do
+            deleteMember admin victim cid !!! assertActionSucceeded
+            postMembersWithRole admin (singleton victim) cid role !!! assertActionSucceeded
+
+        -- Modify the conversation name
+        void $ putConversationName admin cid "gossip++" !!! assertActionSucceeded
+        -- Modify other members roles
+        forM_ [otherAdmin, mem] $ \victim -> do
+            let updateDown = OtherMemberUpdate (Just roleNameWireMember)
+            putOtherMember admin victim updateDown cid !!! assertActionSucceeded
+            let updateUp = OtherMemberUpdate (Just roleNameWireAdmin)
+            putOtherMember admin victim updateUp cid !!! assertActionSucceeded
+        -- Updates for message timer, receipt mode or access
+        putMessageTimerUpdate admin cid (ConversationMessageTimerUpdate $ Just 1000) !!! assertActionSucceeded
+        putMessageTimerUpdate admin cid (ConversationMessageTimerUpdate $ Just 2000) !!! assertActionSucceeded
+
+        putReceiptMode admin cid (ReceiptMode 0) !!! assertActionSucceeded
+        putReceiptMode admin cid (ReceiptMode 1) !!! assertActionSucceeded
+
+        let nonActivatedAccess = ConversationAccessUpdate [CodeAccess] NonActivatedAccessRole
+        putAccessUpdate admin cid nonActivatedAccess !!! assertActionSucceeded
+        let activatedAccess = ConversationAccessUpdate [InviteAccess] NonActivatedAccessRole
+        putAccessUpdate admin cid activatedAccess !!! assertActionSucceeded
+
+        -- Update your own member state
+        let memUpdate = memberUpdate { mupOtrMute = Just True }
+        putMember admin memUpdate cid !!! assertActionSucceeded
+        -- You can also leave a conversation
+        deleteMember admin admin cid !!! assertActionSucceeded
+        -- Readding the user
+        postMembersWithRole otherAdmin (singleton admin) cid role !!! const 200 === statusCode
+
+
+-- | Given a member, admin and otherMem, run all the necessary checks
+--   targeting mem
+wireMemberChecks :: ConvId
+                 -> UserId
+                 -> UserId
+                 -> UserId
+                 -> TestM ()
+wireMemberChecks cid mem admin otherMem = do
+    let role = roleNameWireMember
+    other <- randomUser
+    connectUsers mem (singleton other)
+
+    -- Members cannot perform pretty much any action on the conversation
+
+    -- Cannot add members, regardless of their role
+    postMembers mem (singleton other) cid !!! assertActionDenied
+
+    -- Cannot remove members, regardless of who they are
+    forM_ [admin, otherMem] $ \victim -> deleteMember mem victim cid !!! assertActionDenied
+    -- Cannot modify the conversation name
+    void $ putConversationName mem cid "gossip++" !!! assertActionDenied
+    -- Cannot modify other members roles
+    forM_ [admin, otherMem] $ \victim -> do
+        let update = OtherMemberUpdate (Just roleNameWireMember)
+        putOtherMember mem victim update cid !!! assertActionDenied
+    -- Make sure you cannot elevate your own role
+    let sneakyOtherMemberUpdate = OtherMemberUpdate (Just roleNameWireAdmin)
+    putOtherMember mem mem sneakyOtherMemberUpdate cid !!! do
+        const 403 === statusCode
+        const (Just "invalid-op") === fmap label . responseJsonUnsafe
+
+    let selfMemberUpdate = memberUpdate { mupConvRoleName = Just roleNameWireAdmin }
+    putMember mem selfMemberUpdate cid !!! do
+        const 403 === statusCode
+        const (Just "invalid-actions") === fmap label . responseJsonUnsafe
+    -- No updates for message timer, receipt mode or access
+    putMessageTimerUpdate mem cid (ConversationMessageTimerUpdate Nothing) !!! assertActionDenied
+
+    putReceiptMode mem cid (ReceiptMode 0) !!! assertActionDenied
+
+    let nonActivatedAccess = ConversationAccessUpdate [CodeAccess] NonActivatedAccessRole
+    putAccessUpdate mem cid nonActivatedAccess !!! assertActionDenied
+
+    -- Finally, you can still do the following actions:
+
+    -- Update your own member state
+    let memUpdate = memberUpdate { mupOtrMute = Just True }
+    putMember mem memUpdate cid !!! assertActionSucceeded
+    -- Last option is to leave a conversation
+    deleteMember mem mem cid !!! assertActionSucceeded
+    -- Let's readd the user to make tests easier
+    postMembersWithRole admin (singleton mem) cid role !!! const 200 === statusCode
+
+assertActionSucceeded :: HasCallStack => Assertions ()
+assertActionSucceeded = const 200 === statusCode
+
+assertActionDenied :: HasCallStack => Assertions ()
+assertActionDenied = do
+    const 403 === statusCode
+    const (Just "action-denied") === fmap label . responseJsonUnsafe

--- a/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
+++ b/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
@@ -80,13 +80,15 @@ mainBotNet n = do
 
     runBotSession bill $ do
         let update = MemberUpdateData
-                   { misOtrMuted       = Nothing
+                   { misTarget         = Just $ botId bill
+                   , misOtrMuted       = Nothing
                    , misOtrMutedStatus = Nothing
                    , misOtrMutedRef    = Nothing
                    , misOtrArchived    = Just True
                    , misOtrArchivedRef = Nothing
                    , misHidden         = Nothing
                    , misHiddenRef      = Nothing
+                   , misConvRoleName   = Nothing
                    }
         memberUpdate meetup update
         c <- getConv meetup


### PR DESCRIPTION
# 2019-12-20

## Relevant for self-hosters

- Access tokens are now sanitized on nginz logs (#920)

## Relevant for client developers

- Conversation roles (#911)
  - Users joining by link are always members (#924) and (#927)

## Bug fixes

- Limit batch size when adding users to conversations (#923)
- Fixed user property integration test (#922)