### PR TITLE
Fixed logic with connection checks

### DIFF
--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -347,7 +347,7 @@ addMembers (zusr ::: zcon ::: cid ::: req) = do
     case Data.convTeam conv of
         Nothing -> do
             ensureAccessRole (Data.convAccessRole conv) newUsers Nothing
-            ensureConnected zusr newUsers
+            ensureConnectedOrSameTeam zusr newUsers
         Just ti -> teamConvChecks ti newUsers conv
     addToConversation mems (zusr, memConvRoleName self) zcon ((, invRoleName body) <$> newUsers) conv
   where
@@ -359,8 +359,7 @@ addMembers (zusr ::: zcon ::: cid ::: req) = do
             throwM noAddToManaged
         -- Team members are always considered connected, so we only check 'ensureConnected'
         -- for non-team-members.
-        let guests = notTeamMember newUsers tms
-        ensureConnected zusr guests
+        ensureConnectedOrSameTeam zusr newUsers
 
 updateSelfMember :: UserId ::: ConnId ::: ConvId ::: JsonRequest MemberUpdate -> Galley Response
 updateSelfMember (zusr ::: zcon ::: cid ::: req) = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -357,8 +357,6 @@ addMembers (zusr ::: zcon ::: cid ::: req) = do
         tcv <- Data.teamConversation tid cid
         when (maybe True (view managedConversation) tcv) $
             throwM noAddToManaged
-        -- Team members are always considered connected, so we only check 'ensureConnected'
-        -- for non-team-members.
         ensureConnectedOrSameTeam zusr newUsers
 
 updateSelfMember :: UserId ::: ConnId ::: ConvId ::: JsonRequest MemberUpdate -> Galley Response

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -43,6 +43,16 @@ ensureAccessRole role users mbTms = case role of
         when (length activated /= length users) $ throwM convAccessDenied
     NonActivatedAccessRole -> return ()
 
+ensureConnectedOrSameTeam :: UserId -> [UserId] -> Galley ()
+ensureConnectedOrSameTeam _ []   = pure ()
+ensureConnectedOrSameTeam u uids = do
+    uTeams <- Data.userTeams u
+    -- We collect all the relevant uids from same teams as the origin user
+    sameTeamUids <- forM uTeams $ \team ->
+        fmap (view userId) <$> Data.teamMembersLimited team uids
+    -- Do not check connections for users that are on the same team
+    ensureConnected u (uids \\ (join sameTeamUids))
+
 -- | Check that the user is connected to everybody else.
 --
 -- The connection has to be bidirectional (e.g. if A connects to B and later

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -56,7 +56,7 @@ ensureConnectedOrSameTeam u uids = do
     sameTeamUids <- forM uTeams $ \team ->
         fmap (view userId) <$> Data.teamMembersLimited team uids
     -- Do not check connections for users that are on the same team
-    ensureConnected u (uids \\ (join sameTeamUids))
+    ensureConnected u (uids \\ join sameTeamUids)
 
 -- | Check that the user is connected to everybody else.
 --

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -43,6 +43,11 @@ ensureAccessRole role users mbTms = case role of
         when (length activated /= length users) $ throwM convAccessDenied
     NonActivatedAccessRole -> return ()
 
+-- | Check that the given user is either part of the same team(s) as the other
+-- users OR that there is a connection.
+--
+-- Team members are always considered connected, so we only check 'ensureConnected'
+-- for non-team-members of the _given_ user
 ensureConnectedOrSameTeam :: UserId -> [UserId] -> Galley ()
 ensureConnectedOrSameTeam _ []   = pure ()
 ensureConnectedOrSameTeam u uids = do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -62,6 +62,7 @@ tests s = testGroup "Teams API"
     , test s "add team conversation as partner (fail)" testAddTeamConvAsExternalPartner
     , test s "add managed conversation through public endpoint (fail)" testAddManagedConv
     , test s "add managed team conversation ignores given users" testAddTeamConvWithUsers
+    -- Queue is emptied here to ensure that lingering events do not affect other tests
     , test s "add team member to conversation without connection" (testAddTeamMemberToConv >> ensureQueueEmpty)
     , test s "update conversation as member" (testUpdateTeamConv RoleMember roleNameWireAdmin)
     , test s "update conversation as partner" (testUpdateTeamConv RoleExternalPartner roleNameWireMember)
@@ -641,9 +642,6 @@ testAddTeamMemberToConv = do
     -- Users *can* add across teams if *connected*
     Util.postMembers ownerT1 (list1 ownerT2 []) cidPersonal !!! const 200 === statusCode
     Util.assertConvMember ownerT2 cidPersonal
-
-    -- We don't care about these events now, we just empty the queue
-    ensureQueueEmpty
 
 testUpdateTeamConv
     :: Role     -- ^ Team role of the user who creates the conversation

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -593,7 +593,7 @@ testAddTeamMemberToConv = do
     Util.postMembers ownerT1 (list1 (mem2T1^.userId) []) cidT1 !!! const 200 === statusCode
     Util.assertConvMember (mem2T1^.userId) cidT1
 
-    -- The following tests check the logic: users can add other users to a conversatio
+    -- The following tests check the logic: users can add other users to a conversation
     -- iff:
     --    - *the adding user is connected to the users being added*
     --    OR


### PR DESCRIPTION
This is actually an existing bug with the current permission check that surfaced with the latest conversation role PR. The _actual_ logic should be:

```
    -- users can add other users to a conversation iff:
    --    - *the adding user is connected to the users being added*
    --    OR
    --    - *the adding user is part of the team of the users being added*
``` 