### PR TITLE
Bump ghc to 8.4.4.

### DIFF
--- a/build/alpine/Dockerfile.builder
+++ b/build/alpine/Dockerfile.builder
@@ -10,11 +10,8 @@ WORKDIR /
 #
 # We build docs for haskell-src-exts without hyperlinking enabled to avoid
 # a Haddock segfault. See https://github.com/haskell/haddock/issues/928
-#
-# Note: git, ncurses, sed are added here for historical reasons; since
-# roughly 2019-03-28, they are included in prebuilder as well.
 
-RUN apk add --no-cache git ncurses sed && \
+RUN apk add --no-cache && \
     git clone -b develop https://github.com/wireapp/wire-server.git && \
     cd /wire-server && \
     stack update && \

--- a/build/alpine/Dockerfile.builder
+++ b/build/alpine/Dockerfile.builder
@@ -11,8 +11,7 @@ WORKDIR /
 # We build docs for haskell-src-exts without hyperlinking enabled to avoid
 # a Haddock segfault. See https://github.com/haskell/haddock/issues/928
 
-RUN apk add --no-cache && \
-    git clone -b develop https://github.com/wireapp/wire-server.git && \
+RUN git clone -b develop https://github.com/wireapp/wire-server.git && \
     cd /wire-server && \
     stack update && \
     echo "allow-different-user: true" >> /root/.stack/config.yaml && \

--- a/build/alpine/Dockerfile.deps
+++ b/build/alpine/Dockerfile.deps
@@ -1,9 +1,13 @@
 # Requires docker >= 17.05 (requires support for multi-stage builds)
 
-FROM alpine:3.11 as cryptobox-builder
+ARG UBUNTU_VERSION=2.1.3
+
+FROM ubuntu:${UBUNTU_VERSION} as cryptobox-builder
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y ubuntu-server
 
 # compile cryptobox-c
-RUN apk add --no-cache cargo file libsodium-dev git && \
+RUN apt-get install -y cargo file libsodium-dev git && \
     cd /tmp && \
     git clone https://github.com/wireapp/cryptobox-c.git && \
     cd cryptobox-c && \
@@ -11,11 +15,12 @@ RUN apk add --no-cache cargo file libsodium-dev git && \
     cargo build --release
 
 # Minimal dependencies for alpine-compiled, dynamically linked wire-server Haskell services
-FROM alpine:3.11
+FROM ubuntu:${UBUNTU_VERSION}
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y ubuntu-server
 
 COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib
-
-RUN apk add --no-cache \
+RUN apt-get install -y \
             libsodium \
             openssl \
             gmp \

--- a/build/alpine/Dockerfile.deps
+++ b/build/alpine/Dockerfile.deps
@@ -3,10 +3,11 @@
 FROM alpine:3.11 as cryptobox-builder
 
 # compile cryptobox-c
-RUN apk add --no-cache cargo libsodium-dev git && \
+RUN apk add --no-cache cargo file libsodium-dev git && \
     cd /tmp && \
     git clone https://github.com/wireapp/cryptobox-c.git && \
     cd cryptobox-c && \
+    export SODIUM_USE_PKG_CONFIG=1 && \
     cargo build --release
 
 # Minimal dependencies for alpine-compiled, dynamically linked wire-server Haskell services

--- a/build/alpine/Dockerfile.deps
+++ b/build/alpine/Dockerfile.deps
@@ -1,6 +1,6 @@
 # Requires docker >= 17.05 (requires support for multi-stage builds)
 
-FROM alpine:3.8 as cryptobox-builder
+FROM alpine:3.11 as cryptobox-builder
 
 # compile cryptobox-c
 RUN apk add --no-cache cargo libsodium-dev git && \
@@ -10,7 +10,7 @@ RUN apk add --no-cache cargo libsodium-dev git && \
     cargo build --release
 
 # Minimal dependencies for alpine-compiled, dynamically linked wire-server Haskell services
-FROM alpine:3.8
+FROM alpine:3.11
 
 COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib
 

--- a/build/alpine/Dockerfile.prebuilder
+++ b/build/alpine/Dockerfile.prebuilder
@@ -39,17 +39,7 @@ RUN apk add --no-cache \
         sed
 
 # get static version of Haskell Stack and use system ghc by default
-ARG STACK_ALPINE_VERSION=1.9.1
+ARG STACK_ALPINE_VERSION=2.1.3
 RUN curl -sSfL https://github.com/commercialhaskell/stack/releases/download/v${STACK_ALPINE_VERSION}/stack-${STACK_ALPINE_VERSION}-linux-x86_64-static.tar.gz \
     | tar --wildcards -C /usr/local/bin --strip-components=1 -xzvf - '*/stack' && chmod 755 /usr/local/bin/stack && \
     stack config set system-ghc --global true
-
-# upgrade stack to current master (2019-03-28).  this fixes an issue
-# with building internal libraries as used in cql-io-1.1.0.
-# details: https://github.com/commercialhaskell/stack/pull/4596
-RUN git clone https://github.com/commercialhaskell/stack && \
-    cd stack && \
-    git checkout f0b66a1ab60fb5be85f6cb60491915bf53d3cd3c && \
-    sed -i -e 's/lts-12.20/lts-12.14/' snapshot-lts-12.yaml && \
-    stack install --system-ghc --stack-yaml=stack-lts-12.yaml --system-ghc && \
-    cp /root/.local/bin/stack /usr/local/bin/stack

--- a/build/alpine/Dockerfile.prebuilder
+++ b/build/alpine/Dockerfile.prebuilder
@@ -1,6 +1,6 @@
 # Requires docker >= 17.05 (requires support for multi-stage builds)
 
-FROM alpine:3.8 as cryptobox-builder
+FROM alpine:3.11 as cryptobox-builder
 
 # compile cryptobox-c
 RUN apk add --no-cache cargo libsodium-dev git && \
@@ -9,7 +9,7 @@ RUN apk add --no-cache cargo libsodium-dev git && \
     cd cryptobox-c && \
     cargo build --release
 
-FROM alpine:3.8
+FROM alpine:3.11
 
 # install cryptobox-c in the new container
 COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib/libcryptobox.so

--- a/build/alpine/Dockerfile.prebuilder
+++ b/build/alpine/Dockerfile.prebuilder
@@ -3,10 +3,11 @@
 FROM alpine:3.11 as cryptobox-builder
 
 # compile cryptobox-c
-RUN apk add --no-cache cargo libsodium-dev git && \
+RUN apk add --no-cache cargo file libsodium-dev git && \
     cd /tmp && \
     git clone https://github.com/wireapp/cryptobox-c.git && \
     cd cryptobox-c && \
+    export SODIUM_USE_PKG_CONFIG=1 && \
     cargo build --release
 
 FROM alpine:3.11

--- a/build/alpine/Dockerfile.prebuilder
+++ b/build/alpine/Dockerfile.prebuilder
@@ -1,43 +1,45 @@
 # Requires docker >= 17.05 (requires support for multi-stage builds)
 
-FROM alpine:3.11 as cryptobox-builder
+ARG UBUNTU_VERSION=19.10
+
+FROM ubuntu:${UBUNTU_VERSION} as cryptobox-builder
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y ubuntu-server
 
 # compile cryptobox-c
-RUN apk add --no-cache cargo file libsodium-dev git && \
+RUN apt-get install -y pkg-config file cargo libsodium-dev git && \
     cd /tmp && \
     git clone https://github.com/wireapp/cryptobox-c.git && \
     cd cryptobox-c && \
     export SODIUM_USE_PKG_CONFIG=1 && \
     cargo build --release
 
-FROM alpine:3.11
+FROM ubuntu:${UBUNTU_VERSION}
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y ubuntu-server
 
 # install cryptobox-c in the new container
 COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib/libcryptobox.so
 COPY --from=cryptobox-builder /tmp/cryptobox-c/src/cbox.h /usr/include/cbox.h
 
 # development packages required for wire-server Haskell services
-RUN apk add --no-cache \
-        alpine-sdk \
-        ca-certificates \
-        linux-headers \
-        zlib-dev \
-        ghc \
-        ghc-dev \
-        ghc-doc \
-        libsodium-dev \
-        openssl-dev \
-        protobuf \
-        icu-dev \
-        geoip-dev \
-        snappy-dev \
-        llvm-libunwind-dev \
+RUN apt-get install -y \
         bash \
-        xz \
-        libxml2-dev \
+        ca-certificates \
+        curl \
+        ghc \
+        ghc-doc \
+        ghc-prof \
         git \
-        ncurses \
-        sed
+        hdevtools \
+        icu-devtools libicu-dev \
+        libsodium-dev \
+        libxml2-dev \
+        openssl \
+        protobuf-compiler \
+        sed \
+        zlib1g-dev
+
 
 # get static version of Haskell Stack and use system ghc by default
 ARG STACK_ALPINE_VERSION=2.1.3

--- a/snapshots/wire-1.5.yaml
+++ b/snapshots/wire-1.5.yaml
@@ -1,0 +1,6 @@
+# DO NOT MODIFY THIS FILE. See README.md to learn why.
+
+resolver: https://raw.githubusercontent.com/wireapp/wire-server/develop/snapshots/wire-1.4.yaml
+name: wire-1.5
+
+compiler: ghc-8.4.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
-resolver: snapshots/wire-1.4.yaml
+resolver: snapshots/wire-1.5.yaml
+compiler: ghc-8.4.4
 
 packages:
 - libs/api-bot


### PR DESCRIPTION
Lots of bugs in ghc-8.4.3...

This change requires re-building over 400 packages.