### PR TITLE
Makefile: remove unused docker-migrations target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,13 +115,6 @@ docker-intermediate:
 	docker tag $(DOCKER_USER)/alpine-intermediate:$(DOCKER_TAG) $(DOCKER_USER)/alpine-intermediate:latest;
 	if test -n "$$DOCKER_PUSH"; then docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD); docker push $(DOCKER_USER)/alpine-intermediate:$(DOCKER_TAG); docker push $(DOCKER_USER)/alpine-intermediate:latest; fi;
 
-.PHONY: docker-migrations
-docker-migrations:
-	# `docker-migrations` needs to be built whenever docker-intermediate was rebuilt AND new schema migrations were added.
-	docker build -t $(DOCKER_USER)/migrations:$(DOCKER_TAG) -f build/alpine/Dockerfile.migrations --build-arg intermediate=$(DOCKER_USER)/alpine-intermediate --build-arg deps=$(DOCKER_USER)/alpine-deps .
-	docker tag $(DOCKER_USER)/migrations:$(DOCKER_TAG) $(DOCKER_USER)/migrations:latest
-	if test -n "$$DOCKER_PUSH"; then docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD); docker push $(DOCKER_USER)/migrations:$(DOCKER_TAG); docker push $(DOCKER_USER)/migrations:latest; fi;
-
 .PHONY: docker-exe-%
 docker-exe-%:
 	docker image ls | grep $(DOCKER_USER)/alpine-deps > /dev/null || (echo "'make docker-deps' required.", exit 1)


### PR DESCRIPTION
This was a red herring when I was trying to understand migration
automation, and @jschaul says it is outdated, not used anymore and can
be deleted.