### PR TITLE
Allow up to 256 characters as handle, dots and dashes too

### DIFF
--- a/libs/brig-types/src/Brig/Types/Common.hs
+++ b/libs/brig-types/src/Brig/Types/Common.hs
@@ -47,14 +47,17 @@ isValidHandle :: Text -> Bool
 isValidHandle t = either (const False) (const True)
                 $ parseOnly handle t
   where
-    handle = count 2 (satisfy charsFirst)
-          *> count 62 (optional (satisfy charsSecond))
+    handle = count 2 (satisfy chars)
+          *> count 254 (optional (satisfy chars))
           *> endOfInput
     -- NOTE: Ensure that characters such as `@` and `+` should _NOT_
     -- be used so that "phone numbers", "emails", and "handles" remain
     -- disjoint sets.
-    charsFirst = inClass "a-z0-9_"
-    charsSecond = inClass "a-z0-9_.-"
+    -- The rationale behind max size here relates to the max length of
+    -- an email address as defined here:
+    -- http://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
+    -- with the intent that in the enterprise world handle =~ email address
+    chars = inClass "a-z0-9_.-"
 
 --------------------------------------------------------------------------------
 -- Name

--- a/libs/brig-types/src/Brig/Types/Common.hs
+++ b/libs/brig-types/src/Brig/Types/Common.hs
@@ -50,6 +50,9 @@ isValidHandle t = either (const False) (const True)
     handle = count 2 (satisfy charsFirst)
           *> count 62 (optional (satisfy charsSecond))
           *> endOfInput
+    -- NOTE: Ensure that characters such as `@` and `+` should _NOT_
+    -- be used so that "phone numbers", "emails", and "handles" remain
+    -- disjoint sets.
     charsFirst = inClass "a-z0-9_"
     charsSecond = inClass "a-z0-9_-."
 

--- a/libs/brig-types/src/Brig/Types/Common.hs
+++ b/libs/brig-types/src/Brig/Types/Common.hs
@@ -54,7 +54,7 @@ isValidHandle t = either (const False) (const True)
     -- be used so that "phone numbers", "emails", and "handles" remain
     -- disjoint sets.
     charsFirst = inClass "a-z0-9_"
-    charsSecond = inClass "a-z0-9_-."
+    charsSecond = inClass "a-z0-9_.-"
 
 --------------------------------------------------------------------------------
 -- Name

--- a/libs/brig-types/src/Brig/Types/Common.hs
+++ b/libs/brig-types/src/Brig/Types/Common.hs
@@ -47,10 +47,11 @@ isValidHandle :: Text -> Bool
 isValidHandle t = either (const False) (const True)
                 $ parseOnly handle t
   where
-    handle = count 2 (satisfy chars)
-          *> count 19 (optional (satisfy chars))
+    handle = count 2 (satisfy charsFirst)
+          *> count 62 (optional (satisfy charsSecond))
           *> endOfInput
-    chars  = inClass "a-z0-9_"
+    charsFirst = inClass "a-z0-9_"
+    charsSecond = inClass "a-z0-9_-."
 
 --------------------------------------------------------------------------------
 -- Name

--- a/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
+++ b/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
@@ -104,9 +104,8 @@ instance Arbitrary TurnURI where
 
 instance Arbitrary Handle where
   arbitrary = Handle . ST.pack <$> do
-      let manyFirst n = replicateM n (elements $ ['a'..'z'] <> ['0'..'9'] <> ['_'])
-      let manySecond n = replicateM n (elements $ ['a'..'z'] <> ['0'..'9'] <> ['_'] <> ['-'] <> ['.'])
-      ((<>) <$> manyFirst 2 <*> (manySecond =<< choose (0, 62)))
+      let many n = replicateM n (elements $ ['a'..'z'] <> ['0'..'9'] <> ['_'] <> ['-'] <> ['.'])
+      ((<>) <$> many 2 <*> (many =<< choose (0, 254)))
 
 instance Arbitrary Name where
   arbitrary = Name . ST.pack <$>

--- a/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
+++ b/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
@@ -104,8 +104,9 @@ instance Arbitrary TurnURI where
 
 instance Arbitrary Handle where
   arbitrary = Handle . ST.pack <$> do
-      let manyC n = replicateM n (elements $ ['a'..'z'] <> ['0'..'9'] <> ['_'])
-      ((<>) <$> manyC 2 <*> (manyC =<< choose (0, 19)))
+      let manyFirst n = replicateM n (elements $ ['a'..'z'] <> ['0'..'9'] <> ['_'])
+      let manySecond n = replicateM n (elements $ ['a'..'z'] <> ['0'..'9'] <> ['_'] <> ['-'] <> ['.'])
+      ((<>) <$> manyFirst 2 <*> (manySecond =<< choose (0, 62)))
 
 instance Arbitrary Name where
   arbitrary = Name . ST.pack <$>
@@ -512,7 +513,7 @@ instance Arbitrary LegalHoldClientRequest where
 
 instance Arbitrary LegalHoldServiceConfirm where
     arbitrary =
-        LegalHoldServiceConfirm 
+        LegalHoldServiceConfirm
           <$> arbitrary
           <*> arbitrary
           <*> arbitrary


### PR DESCRIPTION
This fits more globally into making users unique and searchable in an enterprise world. 64 characters should be enough for most use cases; I did _not_ run any integration tests, so I will let the CI do that job.

Adding extra `-` and `.` was done so that it supports, more directly, conversions of emails to handles. `@` and `+` should _NOT_ be used so that "phone numbers", "emails", and "handles" remain disjoint sets.