### PR TITLE
Add missing options to services-demo config files

### DIFF
--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -86,7 +86,7 @@ zauth:
     providerTokenTimeout: 604800 # 7 days
     legalHoldUserTokenTimeout: 4838400    # 56 days
     legalHoldSessionTokenTimeout: 604800  # 7 days
-    legalHoldAccessTokenTimeout: 30
+    legalHoldAccessTokenTimeout: 900 # 15 minutes
 
 turn:
   serversV2: resources/turn/servers-v2.txt

--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -86,6 +86,7 @@ zauth:
     providerTokenTimeout: 604800 # 7 days
     legalHoldUserTokenTimeout: 4838400    # 56 days
     legalHoldSessionTokenTimeout: 604800  # 7 days
+    legalHoldAccessTokenTimeout: 30
 
 turn:
   serversV2: resources/turn/servers-v2.txt

--- a/deploy/services-demo/conf/galley.demo.yaml
+++ b/deploy/services-demo/conf/galley.demo.yaml
@@ -26,6 +26,12 @@ settings:
   maxConvSize: 128
   intraListing: false
   conversationCodeURI: https://127.0.0.1/join/
+  concurrentDeletionEvents: 1024
+  deleteConvThrottleMillis: 0
+
+  featureFlags:  # see #RefConfigOptions in `/docs/reference`
+    sso: disabled-by-default
+    legalhold: disabled-by-default
 
 logLevel: Info
 logNetStrings: false


### PR DESCRIPTION
With the current config files, brig and galley refused to start with errors like

```
brig: user error (AesonException "Error in $.zauth.authSettings: key \"legalHoldAccessTokenTimeout\" not present")
```

Not sure if the given values are the right ones for the demo, though. Is there something we should change?