### PR TITLE
[WIP] build nginz on nixos

### DIFF
--- a/libs/libzauth/Makefile
+++ b/libs/libzauth/Makefile
@@ -1,7 +1,9 @@
 LANG := en_US.UTF-8
 dist:
 	$(MAKE) -C libzauth-c $@
-	cp libzauth-c/target/release/*.deb .
+
+install:
+	$(MAKE) -C libzauth-c $@
 
 clean:
 	$(MAKE) -C libzauth-c $@

--- a/services/nginz/README.md
+++ b/services/nginz/README.md
@@ -73,3 +73,15 @@ If you are using macOS and you used `brew` to install openssl, the `Makefile` al
 ## How to run it
 
 Have a look at our demo config in [services demo](../../deploy/services-demo/conf/nginz)
+
+
+
+
+## build on nixos
+
+be in this directory
+nix-shell ../../shell.nix
+. ./env.sh
+make -C ../../libs/libzauth install
+make
+

--- a/services/nginz/env.sh
+++ b/services/nginz/env.sh
@@ -1,0 +1,4 @@
+export SODIUM_LIB_DIR=/nix/store/y95hjmcslzmlziv3zllqq3j654gqpqnx-libsodium-1.0.18-dev/lib/pkgconfig/
+export PREFIX_INSTALL=`pwd`/libzauth
+export EXTRA_CC_LIB="-l$PREFIX_INSTALL/lib/libzauth.so"
+export EXTRA_CC_INC="-I$PREFIX_INSTALL/include"

--- a/services/nginz/env.sh
+++ b/services/nginz/env.sh
@@ -1,4 +1,5 @@
 export SODIUM_LIB_DIR=/nix/store/y95hjmcslzmlziv3zllqq3j654gqpqnx-libsodium-1.0.18-dev/lib/pkgconfig/
 export PREFIX_INSTALL=`pwd`/libzauth
-export EXTRA_CC_LIB="-l$PREFIX_INSTALL/lib/libzauth.so"
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PREFIX_INSTALL/lib/
+export EXTRA_CC_LIB="-L$PREFIX_INSTALL/lib/ -lzauth"
 export EXTRA_CC_INC="-I$PREFIX_INSTALL/include"

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,14 @@
 { pkgs ? import <nixpkgs> {}}:
 with pkgs; mkShell {
   name = "shell";
-  buildInputs = [ 
+  buildInputs = [
     docker-compose
     gnumake
     stack
+    cargo
+    libsodium
+    pcre
+    openssl
+    zlib
   ];
 }


### PR DESCRIPTION
This is a convolution of horrible hacks.  I want to get it to work on my machine first, then discuss (probably once @arianvp is back) how to do it properly.

Current status fails here:

```
[...]
 + gcc version: 7.4.0 (GCC) 
checking for gcc -pipe switch ... found
checking for --with-ld-opt="-l/home/mf/src/wire-server/services/nginz/libzauth/lib/libzauth.so" ... not found
./configure: error: the invalid value in --with-ld-opt="-l/home/mf/src/wire-server/services/nginz/libzauth/lib/libzauth.so"
```

This looks to me like `configure` confuses the extra linker options string with the name of an executable?  But I'm probably wrong...