### PR TITLE
Ignore flaky cookie limit test

### DIFF
--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -177,6 +177,7 @@ executables:
     - tasty >=1.0
     - tasty-cannon >=0.3.4
     - tasty-hunit >=0.2
+    - tasty-expected-failure
     - temporary >=1.2.1
     - time >=1.5
     - tinylog

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -23,6 +23,7 @@ import Data.Text.Encoding (encodeUtf8)
 import Data.Time.Clock
 import Test.Tasty
 import Test.Tasty.HUnit
+import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Util
 import API.Team.Util
 import Brig.Types.Team.LegalHold (LegalHoldStatus (..))
@@ -88,7 +89,7 @@ tests conf m z b g n = testGroup "auth"
             [ test m "list" (testListCookies b)
             , test m "remove-by-label" (testRemoveCookiesByLabel b)
             , test m "remove-by-label-id" (testRemoveCookiesByLabelAndId b)
-            , test m "limit" (testTooManyCookies conf b)
+            , ignoreTestBecause "it is flaky on K8s" $ test m "limit" (testTooManyCookies conf b)
             , test m "logout" (testLogout b)
             ]
         , testGroup "reauth"


### PR DESCRIPTION
The test hardly ever passes on K8s, specially after GHC 8.6.5 upgrade. This PR marks it ignored. I have created another issue to track it: https://github.com/zinfra/backend-issues/issues/1150