### PR TITLE
debug spar prod

### DIFF
--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -216,7 +216,7 @@ heavyDebugLogging
     :: ((Request, LByteString) -> Maybe (Request, LByteString))
     -> Level -> Logger -> Middleware
 heavyDebugLogging sanitizeReq lvl lgr app = \req cont -> do
-    (bdy, req') <- if lvl <= Debug  -- or (`elem` [Trace, Debug])
+    (bdy, req') <- if lvl `elem` [Trace, Debug]
         then cloneBody req
         else pure ("body omitted because log level was less sensitive than Debug", req)
     app req' $ \resp -> do

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -162,7 +162,7 @@ authresp ckyraw arbody = logErrors $ SAML.authresp sparSPIssuer sparResponseURI 
     logErrors = flip catchError $ \case
       e@(SAML.CustomServant _) -> throwError e
       e -> do
-        throwError . SAML.CustomError $ SparFinalizeLoginError
+        throwError . SAML.CustomServant $ errorPage
             e
             (Multipart.inputs (SAML.authnResponseBodyRaw arbody))
             ckyraw

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -162,8 +162,10 @@ authresp ckyraw arbody = logErrors $ SAML.authresp sparSPIssuer sparResponseURI 
     logErrors = flip catchError $ \case
       e@(SAML.CustomServant _) -> throwError e
       e -> do
-        SAML.logger SAML.Info (show (e, Multipart.inputs (SAML.authnResponseBodyRaw arbody)))
-        throwError e
+        throwError . SAML.CustomError $ SparFinalizeLoginError
+            e
+            (Multipart.inputs (SAML.authnResponseBodyRaw arbody))
+            ckyraw
 
 ssoSettings :: Spar SsoSettings
 ssoSettings = do

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -43,6 +43,7 @@ import Spar.Types
 import qualified Data.ByteString as SBS
 import qualified Data.ByteString.Base64 as ES
 import qualified SAML2.WebSSO as SAML
+import qualified Servant.Multipart as Multipart
 import qualified Spar.Data as Data
 import qualified Spar.Intra.Brig as Intra
 import qualified Spar.Intra.Galley as Galley
@@ -147,7 +148,7 @@ validateRedirectURL uri = do
 
 
 authresp :: Maybe ST -> SAML.AuthnResponseBody -> Spar Void
-authresp ckyraw = SAML.authresp sparSPIssuer sparResponseURI go
+authresp ckyraw arbody = logErrors $ SAML.authresp sparSPIssuer sparResponseURI go arbody
   where
     cky :: Maybe BindCookie
     cky = ckyraw >>= bindCookieFromHeader
@@ -156,6 +157,13 @@ authresp ckyraw = SAML.authresp sparSPIssuer sparResponseURI go
     go resp verdict = do
       result :: SAML.ResponseVerdict <- verdictHandler cky resp verdict
       throwError $ SAML.CustomServant result
+
+    logErrors :: Spar Void -> Spar Void
+    logErrors = flip catchError $ \case
+      e@(SAML.CustomServant _) -> throwError e
+      e -> do
+        SAML.logger SAML.Info (show (e, Multipart.inputs (SAML.authnResponseBodyRaw arbody)))
+        throwError e
 
 ssoSettings :: Spar SsoSettings
 ssoSettings = do

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- | The 'Spar' monad and a set of actions (e.g. 'createUser') that can be performed in it.
 module Spar.App
@@ -12,6 +13,7 @@ module Spar.App
   , insertUser
   , autoprovisionSamlUser
   , autoprovisionSamlUserWithId
+  , errorPage
   ) where
 
 import Imports hiding (log)
@@ -32,20 +34,23 @@ import Spar.Orphans ()
 import Spar.API.Swagger ()
 import Spar.Error
 import Spar.Types
+import System.Logger.Class (MonadLogger(log))
 import URI.ByteString as URI
 import Web.Cookie (SetCookie, renderSetCookie)
 
 import qualified Cassandra as Cas
 import qualified Control.Monad.Catch as Catch
 import qualified Data.ByteString.Builder as Builder
+import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.UUID.V4 as UUID
+import qualified Network.HTTP.Types.Status as Http
 import qualified Network.Wai.Utilities.Error as Wai
 import qualified SAML2.WebSSO as SAML
+import qualified Servant.Multipart as Multipart
 import qualified Spar.Data as Data
 import qualified Spar.Intra.Brig as Intra
 import qualified Spar.Intra.Galley as Intra
 import qualified System.Logger as Log
-import System.Logger.Class (MonadLogger(log))
 
 
 newtype Spar a = Spar { fromSpar :: ReaderT Env (ExceptT SparError IO) a }
@@ -410,3 +415,29 @@ verdictHandlerMobile granted denied = \case
                      , ("Set-Cookie", cs . Builder.toLazyByteString . renderSetCookie $ cky)
                      ]
       }
+
+
+-- | When getting stuck during login finalization, show a nice HTML error rather than the json
+-- blob.  Show lots of debugging info for the customer to paste in any issue they might open.
+errorPage :: SparError -> [Multipart.Input] -> Maybe Text -> ServerError
+errorPage err inputs mcky = ServerError
+  { errHTTPCode     = Http.statusCode $ Wai.code werr
+  , errReasonPhrase = cs $ Wai.label werr
+  , errBody         = easyHtml $ LBS.intercalate "\n" errbody
+  , errHeaders      = [("Content-Type", "text/html")]
+  }
+  where
+    werr = either forceWai id $ renderSparError err
+    forceWai ServerError{..} = Wai.Error (Http.Status errHTTPCode "") (cs errReasonPhrase) (cs errBody)
+
+    errbody :: [LByteString]
+    errbody =
+      [ "<head>"
+      , "  <title>wire:sso:error:" <> cs (Wai.label werr) <> "</title>"
+      , "</head>"
+      , "</body>"
+      , "  sorry, something went wrong :(<br>"
+      , "  please copy this page to your clipboard and provide it when opening an issue in our customer support.<br><br>"
+      , "  <pre>" <> cs (show (err, inputs, mcky)) <> "</pre>"
+      , "</body>"
+      ]

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -351,7 +351,7 @@ verdictHandlerWeb = pure . \case
                           "       window.opener.postMessage(" <> Aeson.encode errval <> ", receiverOrigin);" <>
                           "   </script>" <>
                           "</head>"
-      , errHeaders      = []
+      , errHeaders      = [("Content-Type", "text/html")]
       }
       where
         errval = object [ "type" .= ("AUTH_ERROR" :: ST)

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -31,6 +31,7 @@ import qualified Network.Wai as Wai
 import qualified Network.Wai.Utilities.Error as Wai
 import qualified Network.Wai.Utilities.Server as Wai
 import qualified SAML2.WebSSO as SAML
+import qualified Servant.Multipart as Multipart
 import qualified System.Logger.Class as Log
 import qualified Web.Scim.Schema.Error as Scim
 
@@ -82,6 +83,9 @@ data SparCustomError
 
   | SparProvisioningNoSingleIdP LT
   | SparProvisioningTokenLimitReached
+
+  -- | When login fails with a real error, return extra info.
+  | SparFinalizeLoginError SparError [Multipart.Input] (Maybe ST)
 
   -- | All errors returned from SCIM handlers are wrapped into 'SparScimError'
   | SparScimError Scim.ScimError
@@ -167,6 +171,7 @@ renderSparError (SAML.CustomError SparIdPHasBoundUsers)                    = Rig
 -- Errors related to provisioning
 renderSparError (SAML.CustomError (SparProvisioningNoSingleIdP msg))       = Right $ Wai.Error status400 "no-single-idp" ("Team should have exactly one IdP configured: " <> msg)
 renderSparError (SAML.CustomError SparProvisioningTokenLimitReached)       = Right $ Wai.Error status403 "token-limit-reached" "The limit of provisioning tokens per team has been reached"
+renderSparError (SAML.CustomError (SparFinalizeLoginError err inps mcky))  = renderSparError err <&> \werr -> werr { Wai.message = Wai.message werr <> "  request details: " <> cs (show (inps, mcky)) }
 -- SCIM errors
 renderSparError (SAML.CustomError (SparScimError err))                     = Left $ Scim.scimToServerError err
 -- Other

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -267,7 +267,7 @@ specFinalizeLogin = do
           sparresp <- submitAuthnResponse authnresp
           liftIO $ do
             statusCode sparresp `shouldBe` 404
-            responseJsonEither sparresp `shouldBe` Right (TestErrorLabel "not-found")
+            (cs . fromJust . responseBody $ sparresp) `shouldContain` "wire:sso:error:not-found"
 
       -- TODO(arianvp): Ask Matthias what this even means
       context "AuthnResponse does not match any request" $ do

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -267,7 +267,10 @@ specFinalizeLogin = do
           sparresp <- submitAuthnResponse authnresp
           liftIO $ do
             statusCode sparresp `shouldBe` 404
-            (cs . fromJust . responseBody $ sparresp) `shouldContain` "wire:sso:error:not-found"
+            -- body should contain the error label in the title, the verbatim haskell error, and the request:
+            (cs . fromJust . responseBody $ sparresp) `shouldContain` "<title>wire:sso:error:not-found</title>"
+            (cs . fromJust . responseBody $ sparresp) `shouldContain` "CustomError SparNotFound"
+            (cs . fromJust . responseBody $ sparresp) `shouldContain` "Input {iName = \"SAMLResponse\""
 
       -- TODO(arianvp): Ask Matthias what this even means
       context "AuthnResponse does not match any request" $ do

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ extra-deps:
   # a version > 1.0.0 of wai-middleware-prometheus is available
   # (required: https://github.com/fimad/prometheus-haskell/pull/45)
 - git: https://github.com/wireapp/saml2-web-sso
-  commit: 36f10c5a4e5795bb10a671b7a2987c76883688ca  # master (Feb 4, 2020)
+  commit: 7a83e300ba1e142bd4c020b728994fdfc9cb08d3
 - git: https://github.com/wireapp/hscim
   commit: af22d89e7723d0f1a264fb4dbd0b4bbb4097c7a1  # master (Feb 4, 2020)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ extra-deps:
   # a version > 1.0.0 of wai-middleware-prometheus is available
   # (required: https://github.com/fimad/prometheus-haskell/pull/45)
 - git: https://github.com/wireapp/saml2-web-sso
-  commit: 7a83e300ba1e142bd4c020b728994fdfc9cb08d3
+  commit: 1a1b313092beb685a9bb15685c83a3162c1e220f  # master (Feb 17, 2020)
 - git: https://github.com/wireapp/hscim
   commit: af22d89e7723d0f1a264fb4dbd0b4bbb4097c7a1  # master (Feb 4, 2020)
 


### PR DESCRIPTION
We need to collect more information from `/sso/finalize-login` for cases where customers complain about errors.  Currently, customers can only show us a json blob containing some info about the error, but not the original request, which would be required for reproducing it.

Depends on https://github.com/wireapp/saml2-web-sso/pull/57

Couple things to decide:
1. we could not log this with level `Info`, but make the json blob that customers get really big.  gives us the information in cases where customers are able to cut&paste, but logs will have less potentially sensitive data.
2.  we could add an end-point to spar for whitelisting teams that we log.
3.  we could just log the data and decide it's not sensitive.  (it is only logged in case of real errors, not "login rejected".)

answer: 1.