### PR TITLE
Licenses

### DIFF
--- a/.licensure.yml
+++ b/.licensure.yml
@@ -34,14 +34,15 @@ licenses:
 
     auto_template: false
     template: |
-      Copyright (C) [year] [name of author].
-      
-      This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of  the License, or (at your option) any later version.
-      
-      This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-      
-      You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+      This file is part of the Wire Server implementation.
 
+      Copyright (C) [year] Wire Swiss GmbH <opensource@wire.com>
+
+      This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+      This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+      You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 # Define type of comment characters to apply based on file extensions.
 comments:

--- a/.licensure.yml
+++ b/.licensure.yml
@@ -23,7 +23,7 @@ licenses:
   # based on their file paths.
   #
   # If "any" is provided all files will match this license.
-  - files: .*\.(hs|rs)
+  - files: .*\.(hs|hsc|rs)
     ident: AGPL-3.0
     authors:
       - name: Wire Swiss GmbH
@@ -50,6 +50,7 @@ comments:
   - columns: 80
     extensions:
       - hs
+      - hsc
     commenter:
       type: line
       comment_char: "--"

--- a/.licensure.yml
+++ b/.licensure.yml
@@ -33,16 +33,14 @@ licenses:
     name of author: Wire
 
     auto_template: false
-    template: >
-      Copyright (C) 2020 Wire Swiss GmbH. This program is free software: you can
-      redistribute it and/or modify it under the terms of the GNU Affero General
-      Public License as published by the Free Software Foundation, either version
-      3 of  the License, or (at your option) any later version. This
-      program is distributed in the hope that it will be useful, but WITHOUT ANY
-      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-      A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
-      details. You should have received a copy of the GNU Affero General Public
-      License along with this program. If not, see <https://www.gnu.org/licenses/>
+    template: |
+      Copyright (C) [year] [name of author].
+      
+      This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of  the License, or (at your option) any later version.
+      
+      This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+      
+      You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 
 # Define type of comment characters to apply based on file extensions.

--- a/.licensure.yml
+++ b/.licensure.yml
@@ -1,0 +1,65 @@
+# See https://github.com/chasinglogic/licensure
+# (As of 2020-02-17, version 0.2.0 (96d7fad9201e19e5193bf7435ab5fdf4a6ad4685) is used)
+
+change_in_place: true
+# Regexes which if matched by a file path will always be excluded from
+# getting a license header
+excludes:
+  - \.gitignore
+  - .*lock
+  - \.git/.*
+  - \.licensure\.yml
+  - README.*
+  - LICENSE.*
+  - .*\.(md|rst|txt|yml|yaml)
+  - Cargo.toml
+# Definition of the licenses used on this project and to what files
+# they should apply.
+licenses:
+  # Either a regex or the string "any" to determine to what files this
+  # license should apply. It is common for projects to have files
+  # under multiple licenses or with multiple copyright holders. This
+  # provides the ability to automatically license files correctly
+  # based on their file paths.
+  #
+  # If "any" is provided all files will match this license.
+  - files: .*\.(hs|rs)
+    ident: AGPL-3.0
+    authors:
+      - name: Wire Swiss GmbH
+        email: opensource@wire.com
+        year: 2020
+    year: 2020
+    name of author: Wire
+
+    auto_template: false
+    template: >
+      Copyright (C) 2020 Wire Swiss GmbH. This program is free software: you can
+      redistribute it and/or modify it under the terms of the GNU Affero General
+      Public License as published by the Free Software Foundation, either version
+      3 of  the License, or (at your option) any later version. This
+      program is distributed in the hope that it will be useful, but WITHOUT ANY
+      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+      A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+      details. You should have received a copy of the GNU Affero General Public
+      License along with this program. If not, see <https://www.gnu.org/licenses/>
+
+
+# Define type of comment characters to apply based on file extensions.
+comments:
+  # The extensions (or singular extension) field defines which file
+  # extensions to apply the commenter to.
+  - columns: 80
+    extensions:
+      - hs
+    commenter:
+      type: line
+      comment_char: "--"
+      trailing_lines: 1
+  - columns: 80
+    extensions:
+      - rs
+    commenter:
+      type: line
+      comment_char: "//"
+      trailing_lines: 1

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,10 @@ formatf:
 formatc:
 	./tools/ormolu.sh -c
 
+# For any Haskell or Rust file that doesn't mention AGPL yet, add a license header.
+# It's your own reponsibility to keep ormolu happy.
 .PHONY: add-license
 add-license:
-	# For any Haskell or Rust file that doesn't mention AGPL yet,
-	#   add a license header.
-	# It's your own reponsibility to keep ormolu happy.
 	for file in $$(git grep -L "GNU Affero General Public License" | grep '\.hs$$\|\.hsc$$\|\.rs$$'); do \
 		echo "Adding license to $${file}."; \
 		licensure -i $${file}; \

--- a/Makefile
+++ b/Makefile
@@ -36,19 +36,29 @@ haddock-shallow:
 # formats all Haskell files (which don't contain CPP)
 .PHONY: format
 format:
-	licensure -p
 	./tools/ormolu.sh
 
 # formats all Haskell files even if local changes are not committed to git
 .PHONY: formatf
 formatf:
-	licensure -p
 	./tools/ormolu.sh -f
 
 # checks that all Haskell files are formatted; fail if a `make format` run is needed.
 .PHONY: formatc
 formatc:
 	./tools/ormolu.sh -c
+
+.PHONY: add-license
+add-license:
+	# For any Haskell or Rust file that doesn't mention AGPL yet,
+	#   add a license header.
+	# It's your own reponsibility to keep ormolu happy.
+	for file in $$(git grep -L "GNU Affero General Public License" | grep '\.hs$$\|\.rs$$'); do \
+		echo "Adding license to $${file}."; \
+		licensure -i $${file}; \
+	done;
+	@echo ""
+	@echo "you most probably want to run 'make formatf' now to keep ormolu happy"
 
 # Clean
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,13 @@ haddock-shallow:
 # formats all Haskell files (which don't contain CPP)
 .PHONY: format
 format:
+	licensure -p
 	./tools/ormolu.sh
 
 # formats all Haskell files even if local changes are not committed to git
 .PHONY: formatf
 formatf:
+	licensure -p
 	./tools/ormolu.sh -f
 
 # checks that all Haskell files are formatted; fail if a `make format` run is needed.

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ add-license:
 	# For any Haskell or Rust file that doesn't mention AGPL yet,
 	#   add a license header.
 	# It's your own reponsibility to keep ormolu happy.
-	for file in $$(git grep -L "GNU Affero General Public License" | grep '\.hs$$\|\.rs$$'); do \
+	for file in $$(git grep -L "GNU Affero General Public License" | grep '\.hs$$\|\.hsc$$\|\.rs$$'); do \
 		echo "Adding license to $${file}."; \
 		licensure -i $${file}; \
 	done;

--- a/docs/developer/dependencies.md
+++ b/docs/developer/dependencies.md
@@ -95,6 +95,24 @@ sudo apt install rustc cargo -y
 curl https://sh.rustup.rs -sSf | sh
 source $HOME/.cargo/env
 ```
+
+## Formatting Haskell files
+
+You need `ormolu` on your PATH, get it with `stack install ormolu`
+
+## Generating license headers
+
+We use [`licensure`](https://github.com/chasinglogic/licensure).
+
+To get it:
+
+```
+git clone https://github.com/chasinglogic/licensure
+cd licensure
+git checkout 96d7fad9201e19e5193bf7435ab5fdf4a6ad4685  # master as of 2020-02-18
+cargo install --path .
+```
+
 ## makedeb
 
 This is a tool to create debian-style binary packages. It is optional, and is only used if you want to install debian-style packages on your debian or ubuntu system.


### PR DESCRIPTION
Adds automation to generate license headers in haskell/rust source files. See https://github.com/zinfra/backend-issues/issues/1154 for details.

A separate PR will be made that applies this change to all files if this is approved.

See also #981 