### PR TITLE
fix nginx permissions in docker image

### DIFF
--- a/services/nginz/Dockerfile
+++ b/services/nginz/Dockerfile
@@ -137,6 +137,9 @@ RUN set -x \
 
 ################# wire/nginz specific ######################
 
+# Fix file permissions
+RUN mkdir -p /var/cache/nginx/client_temp && chown -R nginx:nginx /var/cache/nginx
+
 RUN apk add --no-cache inotify-tools dumb-init bash curl && \
     # add libzauth runtime dependencies back in
     apk add --no-cache libsodium llvm-libunwind libgcc

--- a/services/nginz/Makefile
+++ b/services/nginz/Makefile
@@ -12,6 +12,7 @@ DEB            := $(NAME)_$(NGINZ_VERSION)_$(ARCH).deb
 ifeq ($(DEBUG), 1)
 WITH_DEBUG      = --with-debug
 endif
+DOCKER_REGISTRY ?= quay.io
 DOCKER_USER    ?= quay.io/wire
 DOCKER_TAG     ?= local
 
@@ -124,7 +125,7 @@ docker:
 	git submodule update --init
 	docker build -t $(DOCKER_USER)/nginz:$(DOCKER_TAG) -f Dockerfile ../..
 	docker tag $(DOCKER_USER)/nginz:$(DOCKER_TAG) $(DOCKER_USER)/nginz:latest
-	if test -n "$$DOCKER_PUSH"; then docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD); docker push $(DOCKER_USER)/nginz:$(DOCKER_TAG); docker push $(DOCKER_USER)/nginz:latest; fi;
+	if test -n "$$DOCKER_PUSH"; then docker login $(DOCKER_REGISTRY); docker push $(DOCKER_USER)/nginz:$(DOCKER_TAG); docker push $(DOCKER_USER)/nginz:latest; fi;
 
 .PHONY: libzauth
 libzauth:


### PR DESCRIPTION
This fixes the error seen on our kubernetes deployments:

```
Starting nginx
Setting up watches for /etc/wire/nginz/upstreams
nginx PID: 9
Setting up watches.
Watches established.
2020/02/19 08:22:55 [emerg] 10#0: mkdir() "/var/cache/nginx/client_temp" failed (2: No such file or directory)
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (2: No such file or directory)
```