### PR TITLE
Ignore dist-newstyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ ID
 Setup.hs
 cabal.sandbox.config
 dist
+dist-newstyle
 gen-hs
 log
 tags


### PR DESCRIPTION
If someone tries to build the project with cabal (either on accident or because they're cool) it will leave these folders around and they might be accidentally commited