### PR TITLE
Update types of some galley endpoints to be federation-aware

### DIFF
--- a/libs/api-bot/src/Network/Wire/Bot/Crypto.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Crypto.hs
@@ -104,7 +104,8 @@ encrypt cl cnv val = fmap (OtrRecipients . UserClientMap)
         ciphertext <- do
           bs <- CBox.encrypt s val >>= unwrap >>= CBox.copyBytes
           return $! decodeUtf8 $! B64.encode bs
-        return $ Map.insertWith Map.union u (Map.singleton c ciphertext) rcps
+        let userId = makeIdOpaque u
+        return $ Map.insertWith Map.union userId (Map.singleton c ciphertext) rcps
 
 -- | Decrypt an OTR message received from a given user and client.
 decrypt :: BotClient -> UserId -> ClientId -> ByteString -> BotSession ByteString

--- a/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
@@ -47,7 +47,7 @@ postOtrMessage cnv msg = sessionRequest req rsc readBody
 -- will be thrown. It's not possible that some users will be added and
 -- others will not.
 addMembers :: (MonadSession m, MonadThrow m) => ConvId -> List1 UserId -> m (Maybe (ConvEvent SimpleMembers))
-addMembers cnv (fmap makeUserIdOpaque -> mems) = do
+addMembers cnv (fmap makeIdOpaque -> mems) = do
   rs <- sessionRequest req rsc consumeBody
   case statusCode rs of
     200 -> Just <$> responseJsonThrow (ParseError . pack) rs
@@ -114,7 +114,7 @@ createConv ::
   -- | Conversation name
   Maybe Text ->
   m Conversation
-createConv (fmap makeUserIdOpaque -> users) name = sessionRequest req rsc readBody
+createConv (fmap makeIdOpaque -> users) name = sessionRequest req rsc readBody
   where
     req =
       method POST

--- a/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
@@ -47,7 +47,7 @@ postOtrMessage cnv msg = sessionRequest req rsc readBody
 -- will be thrown. It's not possible that some users will be added and
 -- others will not.
 addMembers :: (MonadSession m, MonadThrow m) => ConvId -> List1 UserId -> m (Maybe (ConvEvent SimpleMembers))
-addMembers cnv mems = do
+addMembers cnv (fmap makeUserIdOpaque -> mems) = do
   rs <- sessionRequest req rsc consumeBody
   case statusCode rs of
     200 -> Just <$> responseJsonThrow (ParseError . pack) rs
@@ -114,7 +114,7 @@ createConv ::
   -- | Conversation name
   Maybe Text ->
   m Conversation
-createConv users name = sessionRequest req rsc readBody
+createConv (fmap makeUserIdOpaque -> users) name = sessionRequest req rsc readBody
   where
     req =
       method POST

--- a/libs/api-client/src/Network/Wire/Client/API/Push.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Push.hs
@@ -147,6 +147,10 @@ lastNotification = do
 
 -- * Event Data
 
+-- FUTUREWORK(federation):
+-- A lot of information in the events can contain remote IDs (UserConnection,
+-- User, ConvEvent, Conversation, SimpleMembers, UserIdList, Connect), but the
+-- receiver might be on another backend, so mapped IDs don't work for them.
 data Event
   = -- User events
     EConnection UserConnection (Maybe UserInfo)

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -313,10 +313,10 @@ data OtrFilterMissing
     OtrReportAllMissing
   | -- | Complain only about missing
     --      recipients who are /not/ on this list
-    OtrIgnoreMissing (Set UserId) -- TODO (mheinzel)
+    OtrIgnoreMissing (Set OpaqueUserId)
   | -- | Complain only about missing
     --      recipients who /are/ on this list
-    OtrReportMissing (Set UserId) -- TODO (mheinzel)
+    OtrReportMissing (Set OpaqueUserId)
 
 data NewOtrMessage
   = NewOtrMessage

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -215,7 +215,7 @@ data ConvTeamInfo
 
 data NewConv
   = NewConv
-      { newConvUsers :: ![UserId],
+      { newConvUsers :: ![OpaqueUserId],
         newConvName :: !(Maybe Text),
         newConvAccess :: !(Set Access),
         newConvAccessRole :: !(Maybe AccessRole),
@@ -271,7 +271,7 @@ create managed conversations anyway.
 
 newtype UserClientMap a
   = UserClientMap
-      { userClientMap :: Map UserId (Map ClientId a)
+      { userClientMap :: Map OpaqueUserId (Map ClientId a)
       }
   deriving
     ( Eq,
@@ -313,10 +313,10 @@ data OtrFilterMissing
     OtrReportAllMissing
   | -- | Complain only about missing
     --      recipients who are /not/ on this list
-    OtrIgnoreMissing (Set UserId)
+    OtrIgnoreMissing (Set UserId) -- TODO (mheinzel)
   | -- | Complain only about missing
     --      recipients who /are/ on this list
-    OtrReportMissing (Set UserId)
+    OtrReportMissing (Set UserId) -- TODO (mheinzel)
 
 data NewOtrMessage
   = NewOtrMessage
@@ -430,7 +430,7 @@ deriving instance Show OtherMemberUpdate
 
 data Invite
   = Invite
-      { invUsers :: !(List1 UserId),
+      { invUsers :: !(List1 OpaqueUserId),
         invRoleName :: !RoleName -- This role name is to be applied to all users
       }
 

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -330,7 +330,7 @@ data NewOtrMessage
 
 newtype UserClients
   = UserClients
-      { userClients :: Map UserId (Set ClientId)
+      { userClients :: Map OpaqueUserId (Set ClientId)
       }
   deriving (Eq, Show, Semigroup, Monoid, Generic)
 

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -296,7 +296,7 @@ newtype OtrRecipients
       Monoid
     )
 
-foldrOtrRecipients :: (UserId -> ClientId -> Text -> a -> a) -> a -> OtrRecipients -> a
+foldrOtrRecipients :: (OpaqueUserId -> ClientId -> Text -> a -> a) -> a -> OtrRecipients -> a
 foldrOtrRecipients f a =
   Map.foldrWithKey go a
     . userClientMap
@@ -434,7 +434,7 @@ data Invite
         invRoleName :: !RoleName -- This role name is to be applied to all users
       }
 
-newInvite :: List1 UserId -> Invite
+newInvite :: List1 OpaqueUserId -> Invite
 newInvite us = Invite us roleNameWireAdmin
 
 deriving instance Eq Invite

--- a/libs/galley-types/src/Galley/Types/Proto.hs
+++ b/libs/galley-types/src/Galley/Types/Proto.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Galley.Types.Proto
-  ( UserId,
+  ( OpaqueUserId,
     userId,
     fromUserId,
     ClientId,
@@ -48,22 +48,22 @@ import qualified Galley.Types as Galley
 import qualified Gundeck.Types.Push as Gundeck
 import Imports
 
--- UserId -------------------------------------------------------------------
+-- OpaqueUserId -------------------------------------------------------------
 
-newtype UserId
-  = UserId
-      { _user :: Required 1 (Value Id.UserId)
+newtype OpaqueUserId
+  = OpaqueUserId
+      { _user :: Required 1 (Value Id.OpaqueUserId)
       }
   deriving (Eq, Show, Generic)
 
-instance Encode UserId
+instance Encode OpaqueUserId
 
-instance Decode UserId
+instance Decode OpaqueUserId
 
-fromUserId :: Id.UserId -> UserId
-fromUserId u = UserId {_user = putField u}
+fromUserId :: Id.OpaqueUserId -> OpaqueUserId
+fromUserId u = OpaqueUserId {_user = putField u}
 
-userId :: Functor f => (Id.UserId -> f Id.UserId) -> UserId -> f UserId
+userId :: Functor f => (Id.OpaqueUserId -> f Id.OpaqueUserId) -> OpaqueUserId -> f OpaqueUserId
 userId f c = (\x -> c {_user = x}) <$> field f (_user c)
 
 -- ClientId ------------------------------------------------------------------
@@ -124,7 +124,7 @@ clientEntryMessage f c = (\x -> c {_clientVal = x}) <$> field f (_clientVal c)
 
 data UserEntry
   = UserEntry
-      { _userId :: !(Required 1 (Message UserId)),
+      { _userId :: !(Required 1 (Message OpaqueUserId)),
         _userVal :: !(Repeated 2 (Message ClientEntry))
       }
   deriving (Eq, Show, Generic)
@@ -133,14 +133,14 @@ instance Encode UserEntry
 
 instance Decode UserEntry
 
-userEntry :: UserId -> [ClientEntry] -> UserEntry
+userEntry :: OpaqueUserId -> [ClientEntry] -> UserEntry
 userEntry u c =
   UserEntry
     { _userId = putField u,
       _userVal = putField c
     }
 
-userEntryId :: Functor f => (UserId -> f UserId) -> UserEntry -> f UserEntry
+userEntryId :: Functor f => (OpaqueUserId -> f OpaqueUserId) -> UserEntry -> f UserEntry
 userEntryId f c = (\x -> c {_userId = x}) <$> field f (_userId c)
 
 userEntryClients :: Functor f => ([ClientEntry] -> f [ClientEntry]) -> UserEntry -> f UserEntry

--- a/libs/galley-types/src/Galley/Types/Proto.hs
+++ b/libs/galley-types/src/Galley/Types/Proto.hs
@@ -2,8 +2,9 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
+-- FUTUREWORK: generate this file
 module Galley.Types.Proto
-  ( OpaqueUserId,
+  ( UserId,
     userId,
     fromUserId,
     ClientId,
@@ -48,22 +49,22 @@ import qualified Galley.Types as Galley
 import qualified Gundeck.Types.Push as Gundeck
 import Imports
 
--- OpaqueUserId -------------------------------------------------------------
+-- UserId -------------------------------------------------------------------
 
-newtype OpaqueUserId
-  = OpaqueUserId
+newtype UserId
+  = UserId
       { _user :: Required 1 (Value Id.OpaqueUserId)
       }
   deriving (Eq, Show, Generic)
 
-instance Encode OpaqueUserId
+instance Encode UserId
 
-instance Decode OpaqueUserId
+instance Decode UserId
 
-fromUserId :: Id.OpaqueUserId -> OpaqueUserId
-fromUserId u = OpaqueUserId {_user = putField u}
+fromUserId :: Id.OpaqueUserId -> UserId
+fromUserId u = UserId {_user = putField u}
 
-userId :: Functor f => (Id.OpaqueUserId -> f Id.OpaqueUserId) -> OpaqueUserId -> f OpaqueUserId
+userId :: Functor f => (Id.OpaqueUserId -> f Id.OpaqueUserId) -> UserId -> f UserId
 userId f c = (\x -> c {_user = x}) <$> field f (_user c)
 
 -- ClientId ------------------------------------------------------------------
@@ -124,7 +125,7 @@ clientEntryMessage f c = (\x -> c {_clientVal = x}) <$> field f (_clientVal c)
 
 data UserEntry
   = UserEntry
-      { _userId :: !(Required 1 (Message OpaqueUserId)),
+      { _userId :: !(Required 1 (Message UserId)),
         _userVal :: !(Repeated 2 (Message ClientEntry))
       }
   deriving (Eq, Show, Generic)
@@ -133,14 +134,14 @@ instance Encode UserEntry
 
 instance Decode UserEntry
 
-userEntry :: OpaqueUserId -> [ClientEntry] -> UserEntry
+userEntry :: UserId -> [ClientEntry] -> UserEntry
 userEntry u c =
   UserEntry
     { _userId = putField u,
       _userVal = putField c
     }
 
-userEntryId :: Functor f => (OpaqueUserId -> f OpaqueUserId) -> UserEntry -> f UserEntry
+userEntryId :: Functor f => (UserId -> f UserId) -> UserEntry -> f UserEntry
 userEntryId f c = (\x -> c {_userId = x}) <$> field f (_userId c)
 
 userEntryClients :: Functor f => ([ClientEntry] -> f [ClientEntry]) -> UserEntry -> f UserEntry

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -187,7 +187,7 @@ errorHandlers =
     Handler $ \(_ :: InvalidRequest) -> pure $ Wai.Error status400 "client-error" "Invalid Request",
     Handler $ \(_ :: TimeoutThread) -> pure $ Wai.Error status408 "client-error" "Request Timeout",
     Handler $ \(ZlibException (-3)) -> pure $ Wai.Error status400 "client-error" "Invalid request body compression",
-    Handler $ \(_ :: SomeException) -> pure $ Wai.Error status500 "server-error" "Server Error"
+    Handler $ \(e :: SomeException) -> pure $ Wai.Error status500 "server-error" (cs $ show e)
   ]
 {-# INLINE errorHandlers #-}
 

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -187,7 +187,7 @@ errorHandlers =
     Handler $ \(_ :: InvalidRequest) -> pure $ Wai.Error status400 "client-error" "Invalid Request",
     Handler $ \(_ :: TimeoutThread) -> pure $ Wai.Error status408 "client-error" "Request Timeout",
     Handler $ \(ZlibException (-3)) -> pure $ Wai.Error status400 "client-error" "Invalid request body compression",
-    Handler $ \(e :: SomeException) -> pure $ Wai.Error status500 "server-error" (cs $ show e)
+    Handler $ \(_ :: SomeException) -> pure $ Wai.Error status500 "server-error" "Server Error"
   ]
 {-# INLINE errorHandlers #-}
 

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -896,7 +896,7 @@ getMultiPrekeyBundles body = do
   maxSize <- fromIntegral . setMaxConvSize <$> view settings
   when (Map.size (userClients body) > maxSize) $
     throwStd tooManyClients
-  lift (API.claimMultiPrekeyBundles body)
+  API.claimMultiPrekeyBundles body
 
 addClientH :: JsonRequest NewClient ::: UserId ::: ConnId ::: Maybe IpAddr ::: JSON -> Handler Response
 addClientH (req ::: usr ::: con ::: ip ::: _) = do
@@ -960,7 +960,8 @@ internalListClientsH (_ ::: req) = do
 
 internalListClients :: UserSet -> AppIO UserClients
 internalListClients (UserSet usrs) = do
-  UserClients . Map.fromList <$> (API.lookupUsersClientIds $ Set.toList usrs)
+  UserClients . Map.mapKeys makeIdOpaque . Map.fromList
+    <$> (API.lookupUsersClientIds $ Set.toList usrs)
 
 getClientH :: UserId ::: ClientId ::: JSON -> Handler Response
 getClientH (usr ::: clt ::: _) = lift $ do

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -119,7 +119,7 @@ claimMultiPrekeyBundles (UserClients x) = do
   let (localUserIds, remoteUserIds) = partitionWith localOrRemoteClient resolved
   for_ (nonEmpty remoteUserIds) $ \remotes ->
     -- FUTUREWORK(federation): check remote connections
-    throwStd . federationNotImplemented . fmap (idMappingGlobal . fst) $ remotes
+    throwStd . federationNotImplemented . fmap fst $ remotes
   e <- ask
   -- TODO: use traverse
   m <- liftIO $ forM (chunksOf 16 localUserIds) (mapConcurrently $ runAppT e . outer)

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -8,9 +8,10 @@ import Control.Monad.Error.Class hiding (Error)
 import Data.Aeson
 import Data.ByteString.Conversion
 import qualified Data.HashMap.Strict as HashMap
-import Data.Id (Id, idToText)
+import Data.Id (idToText)
+import Data.IdMapping (IdMapping (IdMapping, idMappingGlobal, idMappingLocal))
 import Data.List.NonEmpty (NonEmpty)
-import Data.Qualified (Qualified, renderQualified)
+import Data.Qualified (renderQualified)
 import Data.String.Conversions (cs)
 import qualified Data.Text.Lazy as LT
 import qualified Data.ZAuth.Validation as ZAuth
@@ -452,7 +453,7 @@ can'tAddLegalHoldClient =
 legalHoldNotEnabled :: Wai.Error
 legalHoldNotEnabled = Wai.Error status403 "legalhold-not-enabled" "LegalHold must be enabled and configured on the team first"
 
-federationNotImplemented :: forall a. Typeable a => NonEmpty (Qualified (Id a)) -> Wai.Error
+federationNotImplemented :: forall a. Typeable a => NonEmpty (IdMapping a) -> Wai.Error
 federationNotImplemented qualified =
   Wai.Error
     status501
@@ -460,4 +461,6 @@ federationNotImplemented qualified =
     ("Federation is not implemented, but global qualified IDs (" <> idType <> ") found: " <> rendered)
   where
     idType = cs (show (typeRep @a))
-    rendered = LT.intercalate ", " . toList . fmap (LT.fromStrict . renderQualified idToText) $ qualified
+    rendered = LT.intercalate ", " . toList . fmap (LT.fromStrict . renderMapping) $ qualified
+    renderMapping IdMapping {idMappingLocal, idMappingGlobal} =
+      idToText idMappingLocal <> " -> " <> renderQualified idToText idMappingGlobal

--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -4,7 +4,8 @@ import Brig.API.Handler
 import qualified Brig.Data.User as Data
 import Brig.Types
 import Control.Monad
-import Data.Id
+import Data.Id as Id
+import Data.IdMapping (MappedOrLocalId (Local))
 import Data.Maybe
 import Imports
 
@@ -14,3 +15,9 @@ lookupProfilesMaybeFilterSameTeamOnly self us = do
   return $ case selfTeam of
     Just team -> filter (\x -> profileTeam x == Just team) us
     Nothing -> us
+
+-- | this exists as a shim to find and mark places where we need to handle 'OpaqueUserId's.
+resolveOpaqueUserId :: Monad m => OpaqueUserId -> m (MappedOrLocalId Id.U)
+resolveOpaqueUserId (Id opaque) =
+  -- FUTUREWORK(federation): implement database lookup
+  pure . Local $ Id opaque

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 
@@ -399,7 +400,7 @@ newtype AppT m a
   = AppT
       { unAppT :: ReaderT Env m a
       }
-  deriving
+  deriving newtype
     ( Functor,
       Applicative,
       Monad,
@@ -409,6 +410,11 @@ newtype AppT m a
       MonadMask,
       MonadReader Env
     )
+  deriving
+    ( Semigroup,
+      Monoid
+    )
+    via (Ap (AppT m) a)
 
 type AppIO = AppT IO
 

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -881,7 +881,7 @@ botClaimUsersPrekeys body = do
   maxSize <- fromIntegral . setMaxConvSize <$> view settings
   when (Map.size (userClients body) > maxSize) $
     throwStd tooManyClients
-  lift (Client.claimMultiPrekeyBundles body)
+  Client.claimMultiPrekeyBundles body
 
 botListUserProfilesH :: List UserId -> Handler Response
 botListUserProfilesH uids = do

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -1255,7 +1255,7 @@ createConv g u us =
       . contentJson
       . body (RequestBodyLBS (encode (NewConvUnmanaged conv)))
   where
-    conv = NewConv us Nothing Set.empty Nothing Nothing Nothing Nothing roleNameWireAdmin
+    conv = NewConv (makeIdOpaque <$> us) Nothing Set.empty Nothing Nothing Nothing Nothing roleNameWireAdmin
 
 postMessage ::
   Galley ->

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -117,7 +117,7 @@ createTeamConv g tid u us mtimer = do
   let tinfo = Just $ ConvTeamInfo tid False
   let conv =
         NewConvUnmanaged $
-          NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin
+          NewConv (makeIdOpaque <$> us) Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin
   r <-
     post
       ( g
@@ -139,7 +139,7 @@ createManagedConv g tid u us mtimer = do
   let tinfo = Just $ ConvTeamInfo tid True
   let conv =
         NewConvManaged $
-          NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin
+          NewConv (makeIdOpaque <$> us) Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin
   r <-
     post
       ( g

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -3,7 +3,7 @@ module Galley.API where
 import Brig.Types.Team.LegalHold
 import Data.Aeson (encode)
 import Data.ByteString.Conversion (fromByteString, fromList)
-import Data.Id (ConvId, UserId)
+import Data.Id (ConvId, OpaqueUserId)
 import qualified Data.Predicate as P
 import Data.Range
 import qualified Data.Set as Set
@@ -968,7 +968,7 @@ filterMissing = (>>= go) <$> (query "ignore_missing" ||| query "report_missing")
       Just True -> return OtrReportAllMissing
       Just False -> return OtrIgnoreAllMissing
       Nothing -> OtrReportMissing <$> users "report_missing" rep
-    users :: ByteString -> ByteString -> P.Result P.Error (Set UserId)
+    users :: ByteString -> ByteString -> P.Result P.Error (Set OpaqueUserId)
     users src bs = case fromByteString bs of
       Nothing ->
         P.Fail $ P.setMessage "Boolean or list of user IDs expected."

--- a/services/galley/src/Galley/API/Clients.hs
+++ b/services/galley/src/Galley/API/Clients.hs
@@ -28,7 +28,7 @@ getClients usr = do
     if isInternal
       then fromUserClients <$> Intra.lookupClients [usr]
       else Data.lookupClients [usr]
-  return $ clientIds usr clts
+  return $ clientIds (makeIdOpaque usr) clts
 
 addClientH :: UserId ::: ClientId -> Galley Response
 addClientH (usr ::: clt) = do

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -10,6 +10,7 @@ where
 import Control.Lens hiding ((??))
 import Control.Monad.Catch
 import Data.Id
+import Data.IdMapping (IdMapping (..), MappedOrLocalId (Local, Mapped))
 import Data.List1 (list1)
 import Data.Range
 import qualified Data.Set as Set
@@ -66,7 +67,23 @@ createRegularGroupConv zusr zcon (NewConvUnmanaged body) = do
   name <- rangeCheckedMaybe (newConvName body)
   uids <- checkedConvSize (newConvUsers body)
   ensureConnected zusr (fromConvSize uids)
-  c <- Data.createConversation zusr name (access body) (accessRole body) uids (newConvTeam body) (newConvMessageTimer body) (newConvReceiptMode body) (newConvUsersRole body)
+  (localUserIds, remoteUserIds) <-
+    partitionMappedOrLocalIds <$> traverse resolveOpaqueUserId (newConvUsers body)
+  for_ (listToMaybe remoteUserIds) $ \IdMapping {idMappingGlobal} ->
+    -- FUTUREWORK(federation): notify remote users' backends about new conversation
+    failFederationNotImplemented idMappingGlobal
+  localCheckedUsers <- checkedConvSize localUserIds
+  c <-
+    Data.createConversation
+      zusr
+      name
+      (access body)
+      (accessRole body)
+      localCheckedUsers
+      (newConvTeam body)
+      (newConvMessageTimer body)
+      (newConvReceiptMode body)
+      (newConvUsersRole body)
   notifyCreatedConversation Nothing zusr (Just zcon) c
   conversationCreated zusr c
 
@@ -74,9 +91,15 @@ createRegularGroupConv zusr zcon (NewConvUnmanaged body) = do
 -- handlers above. Allows both unmanaged and managed conversations.
 createTeamGroupConv :: UserId -> ConnId -> ConvTeamInfo -> NewConv -> Galley ConversationResponse
 createTeamGroupConv zusr zcon tinfo body = do
+  (localUserIds, remoteUserIds) <-
+    partitionMappedOrLocalIds <$> traverse resolveOpaqueUserId (newConvUsers body)
+  for_ (listToMaybe remoteUserIds) $ \IdMapping {idMappingGlobal} ->
+    -- for now, teams don't support conversations with remote members
+    -- TODO: change error to something 400?
+    failFederationNotImplemented idMappingGlobal
   name <- rangeCheckedMaybe (newConvName body)
   teamMems <- Data.teamMembers (cnvTeamId tinfo)
-  ensureAccessRole (accessRole body) (newConvUsers body) (Just teamMems)
+  ensureAccessRole (accessRole body) localUserIds (Just teamMems)
   void $ permissionCheck zusr CreateConversation teamMems
   otherConvMems <-
     if cnvManaged tinfo
@@ -84,7 +107,7 @@ createTeamGroupConv zusr zcon tinfo body = do
         let otherConvMems = filter (/= zusr) $ map (view userId) teamMems
         checkedConvSize otherConvMems
       else do
-        otherConvMems <- checkedConvSize (newConvUsers body)
+        otherConvMems <- checkedConvSize localUserIds
         -- In teams we don't have 1:1 conversations, only regular conversations. We want
         -- users without the 'AddRemoveConvMember' permission to still be able to create
         -- regular conversations, therefore we check for 'AddRemoveConvMember' only if
@@ -99,7 +122,7 @@ createTeamGroupConv zusr zcon tinfo body = do
           void $ permissionCheck zusr DoNotUseDeprecatedAddRemoveConvMember teamMems
         -- Team members are always considered to be connected, so we only check
         -- 'ensureConnected' for non-team-members.
-        ensureConnected zusr (notTeamMember (fromConvSize otherConvMems) teamMems)
+        ensureConnected zusr (makeIdOpaque <$> notTeamMember (fromConvSize otherConvMems) teamMems)
         pure otherConvMems
   conv <- Data.createConversation zusr name (access body) (accessRole body) otherConvMems (newConvTeam body) (newConvMessageTimer body) (newConvReceiptMode body) (newConvUsersRole body)
   now <- liftIO getCurrentTime
@@ -130,8 +153,8 @@ createOne2OneConversationH (zusr ::: zcon ::: req) = do
 
 createOne2OneConversation :: UserId -> ConnId -> NewConvUnmanaged -> Galley ConversationResponse
 createOne2OneConversation zusr zcon (NewConvUnmanaged j) = do
-  other <- head . fromRange <$> (rangeChecked (newConvUsers j) :: Galley (Range 1 1 [UserId]))
-  (x, y) <- toUUIDs zusr other
+  other <- head . fromRange <$> (rangeChecked (newConvUsers j) :: Galley (Range 1 1 [OpaqueUserId]))
+  (x, y) <- toUUIDs (makeIdOpaque zusr) other
   when (x == y)
     $ throwM
     $ invalidOp "Cannot create a 1-1 with yourself"
@@ -144,7 +167,10 @@ createOne2OneConversation zusr zcon (NewConvUnmanaged j) = do
   c <- Data.conversation (Data.one2OneConvId x y)
   maybe (create x y n $ newConvTeam j) (conversationExisted zusr) c
   where
-    checkBindingTeamPermissions x y tid = do
+    checkBindingTeamPermissions x other tid = do
+      y <- resolveOpaqueUserId other >>= \case
+        Local l -> pure l
+        Mapped _ -> throwM noBindingTeamMembers -- remote user can't be in local team
       mems <- bindingTeamMembers tid
       void $ permissionCheck zusr CreateConversation mems
       unless (all (flip isTeamMember mems) [x, y]) $
@@ -161,7 +187,7 @@ createConnectConversationH (usr ::: conn ::: req) = do
 
 createConnectConversation :: UserId -> Maybe ConnId -> Connect -> Galley ConversationResponse
 createConnectConversation usr conn j = do
-  (x, y) <- toUUIDs usr (cRecipient j)
+  (x, y) <- toUUIDs (makeIdOpaque usr) (makeIdOpaque (cRecipient j))
   n <- rangeCheckedMaybe (cName j)
   conv <- Data.conversation (Data.one2OneConvId x y)
   maybe (create x y n) (update n) conv
@@ -178,7 +204,7 @@ createConnectConversation usr conn j = do
     update n conv =
       let mems = Data.convMembers conv
        in conversationExisted usr
-            =<< if | usr `isMember` mems -> connect n conv
+            =<< if | makeIdOpaque usr `isMember` mems -> connect n conv
                    | otherwise -> do
                      now <- liftIO getCurrentTime
                      mm <- snd <$> Data.addMember now (Data.convId conv) usr
@@ -244,7 +270,7 @@ notifyCreatedConversation dtime usr conn c = do
           & pushConn .~ conn
           & pushRoute .~ route
 
-toUUIDs :: UserId -> UserId -> Galley (U.UUID U.V4, U.UUID U.V4)
+toUUIDs :: OpaqueUserId -> OpaqueUserId -> Galley (U.UUID U.V4, U.UUID U.V4)
 toUUIDs a b = do
   a' <- U.fromUUID (toUUID a) & ifNothing invalidUUID4
   b' <- U.fromUUID (toUUID b) & ifNothing invalidUUID4

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -8,17 +8,18 @@ where
 import Cassandra
 import Control.Exception.Safe (catchAny)
 import Control.Lens hiding ((.=))
-import Control.Monad.Catch (MonadCatch)
+import Control.Monad.Catch (MonadCatch, throwM)
 import Data.Id
-import Data.IdMapping (IdMapping (..), MappedOrLocalId (Local))
+import Data.IdMapping (MappedOrLocalId (Local))
 import Data.List.NonEmpty (nonEmpty)
 import Data.List1
 import Data.Metrics.Middleware as Metrics
 import Data.Range
 import Data.String.Conversions (cs)
+import Galley.API.Error (federationNotImplemented)
 import Galley.API.Teams (uncheckedRemoveTeamMember)
 import qualified Galley.API.Teams as Teams
-import Galley.API.Util (failFederationNotImplemented, isMember, partitionMappedOrLocalIds, resolveOpaqueConvId)
+import Galley.API.Util (isMember, partitionMappedOrLocalIds, resolveOpaqueConvId)
 import Galley.App
 import qualified Galley.Data as Data
 import qualified Galley.Intra.Push as Intra
@@ -51,11 +52,11 @@ rmUser user conn = do
     leaveConversations :: List1 UserId -> Page OpaqueConvId -> Galley ()
     leaveConversations u ids = do
       (localConvIds, remoteConvIds) <- partitionMappedOrLocalIds <$> traverse resolveOpaqueConvId (result ids)
-      for_ (listToMaybe remoteConvIds) $ \IdMapping {idMappingGlobal} ->
-        -- FUTUREWORK(federation): leave remote conversations.
-        -- If we could just get all conversation IDs at once and then leave conversations
-        -- in batches, it would make everything much easier.
-        failFederationNotImplemented idMappingGlobal
+      -- FUTUREWORK(federation): leave remote conversations.
+      -- If we could just get all conversation IDs at once and then leave conversations
+      -- in batches, it would make everything much easier.
+      for_ (nonEmpty remoteConvIds) $
+        throwM . federationNotImplemented
       cc <- Data.conversations localConvIds
       pp <- for cc $ \c -> case Data.convType c of
         SelfConv -> return Nothing

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -92,7 +92,6 @@ getConversations zusr range size =
       | Data.isConvDeleted c = Data.deleteConversation (Data.convId c) >> pure False
       | otherwise = pure True
 
--- TODO(mheinzel): in minimal API, but not essential
 getSelfH :: UserId ::: ConvId -> Galley Response
 getSelfH (zusr ::: cnv) = do
   json <$> getSelf zusr cnv

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -80,7 +80,7 @@ getConversations :: UserId -> Maybe (Either (Range 1 32 (List OpaqueConvId)) Opa
 getConversations zusr range size =
   withConvIds zusr range size $ \more ids -> do
     -- FUTUREWORK(federation): resolve IDs in batch
-    (localConvIds, _qualifiedConvIds) <- partitionEithers <$> traverse resolveOpaqueConvId ids
+    (localConvIds, _qualifiedConvIds) <- partitionMappedOrLocalIds <$> traverse resolveOpaqueConvId ids
     -- FUTUREWORK(federation): fetch remote conversations from other backend
     cs <-
       Data.conversations localConvIds

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -468,7 +468,7 @@ uncheckedRemoveTeamMember zusr zcon tid remove mems = do
   let edata = Conv.EdMembersLeave (Conv.UserIdList [remove])
   cc <- Data.teamConversations tid
   for_ cc $ \c -> Data.conversation (c ^. conversationId) >>= \conv ->
-    for_ conv $ \dc -> when (remove `isMember` Data.convMembers dc) $ do
+    for_ conv $ \dc -> when (makeIdOpaque remove `isMember` Data.convMembers dc) $ do
       Data.removeMember remove (c ^. conversationId)
       unless (c ^. managedConversation) $
         pushEvent tmids edata now dc

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -130,7 +130,7 @@ createNonBindingTeam zusr zcon (NonBindingNewTeam body) = do
           $ body ^. newTeamMembers
   let zothers = map (view userId) others
   ensureUnboundUsers (zusr : zothers)
-  ensureConnected zusr zothers
+  ensureConnected zusr (makeIdOpaque <$> zothers)
   Log.debug $
     Log.field "targets" (toByteString . show $ toByteString <$> zothers)
       . Log.field "action" (Log.val "Teams.createNonBindingTeam")
@@ -362,7 +362,7 @@ addTeamMember zusr zcon tid nmem = do
   targetPermissions `ensureNotElevated` tmem
   ensureNonBindingTeam tid
   ensureUnboundUsers [uid]
-  ensureConnected zusr [uid]
+  ensureConnected zusr [makeIdOpaque uid]
   addTeamMemberInternal tid (Just zusr) (Just zcon) nmem mems
 
 -- This function is "unchecked" because there is no need to check for user binding (invite only).

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -448,7 +448,6 @@ addMembers zusr zcon cid invite = do
         throwM noAddToManaged
       ensureConnectedOrSameTeam zusr newUsers
 
--- TODO(mheinzel): in minimal API, but not essential
 updateSelfMemberH :: UserId ::: ConnId ::: ConvId ::: JsonRequest MemberUpdate -> Galley Response
 updateSelfMemberH (zusr ::: zcon ::: cid ::: req) = do
   update <- fromJsonBody req
@@ -656,7 +655,6 @@ updateConversationName zusr zcon cnv convRename = do
   void . forkIO $ void $ External.deliver (bots `zip` repeat e)
   return e
 
--- TODO(mheinzel): included in minimal API, but not essential
 isTypingH :: UserId ::: ConnId ::: ConvId ::: JsonRequest TypingData -> Galley Response
 isTypingH (zusr ::: zcon ::: cnv ::: req) = do
   typingData <- fromJsonBody req

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -966,5 +966,5 @@ checkOtrRecipients (makeIdOpaque -> usr) sid prs vms vcs val now
     filterMissing miss = case val of
       OtrReportAllMissing -> miss
       OtrIgnoreAllMissing -> Clients.nil
-      OtrReportMissing us -> Clients.filter (`Set.member` Set.map makeIdOpaque us) miss
-      OtrIgnoreMissing us -> Clients.filter (`Set.notMember` Set.map makeIdOpaque us) miss
+      OtrReportMissing us -> Clients.filter (`Set.member` us) miss
+      OtrIgnoreMissing us -> Clients.filter (`Set.notMember` us) miss

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -934,6 +934,7 @@ checkOtrRecipients usr sid prs vms vcs val now
     next u c t rs
       | Just m <- member u c = (m, c, t) : rs
       | otherwise = rs
+    member :: OpaqueUserId -> ClientId -> Maybe _
     member u c
       | Just m <- Map.lookup u vmembers,
         Clients.contains u c vclients =

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -69,9 +69,9 @@ ensureConnected _ [] = pure ()
 ensureConnected u opaqueIds = do
   (localUserIds, remoteUserIds) <-
     partitionMappedOrLocalIds <$> traverse resolveOpaqueUserId opaqueIds
-  for_ (nonEmpty remoteUserIds) $ \remotes ->
-    -- FUTUREWORK(federation): check remote connections
-    throwM $ federationNotImplemented remotes
+  -- FUTUREWORK(federation): check remote connections
+  for_ (nonEmpty remoteUserIds) $
+    throwM . federationNotImplemented
   ensureConnectedToLocals localUserIds
   where
     ensureConnectedToLocals uids = do

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -663,8 +663,6 @@ removeMembers conv orig victims = do
   return $ Event MemberLeave (convId conv) orig t (Just (EdMembersLeave leavingMembers))
   where
     -- FUTUREWORK(federation): We need to tell clients about remote members leaving, too.
-    -- FUTUREWORK(federation): These IDs don't mean anything to remote conversation members,
-    -- as they don't have the same mapping. Not sure how we should solve this.
     leavingMembers = UserIdList . mapMaybe localIdOrNothing . toList $ victims
     localIdOrNothing = \case
       Local localId -> Just localId

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -185,15 +185,16 @@ deleteCode = "DELETE FROM conversation_codes WHERE key = ? AND scope = ?"
 
 -- User Conversations -------------------------------------------------------
 
-selectUserConvs :: PrepQuery R (Identity UserId) (Identity ConvId)
+selectUserConvs :: PrepQuery R (Identity UserId) (Identity OpaqueConvId)
 selectUserConvs = "select conv from user where user = ? order by conv"
 
-selectUserConvsIn :: PrepQuery R (UserId, [ConvId]) (Identity ConvId)
+selectUserConvsIn :: PrepQuery R (UserId, [OpaqueConvId]) (Identity OpaqueConvId)
 selectUserConvsIn = "select conv from user where user = ? and conv in ? order by conv"
 
-selectUserConvsFrom :: PrepQuery R (UserId, ConvId) (Identity ConvId)
+selectUserConvsFrom :: PrepQuery R (UserId, OpaqueConvId) (Identity OpaqueConvId)
 selectUserConvsFrom = "select conv from user where user = ? and conv > ? order by conv"
 
+-- FUTUREWORK(federation): unify types with queries above
 insertUserConv :: PrepQuery W (UserId, ConvId) ()
 insertUserConv = "insert into user (user, conv) values (?, ?)"
 
@@ -213,7 +214,7 @@ selectMembers = "select conv, user, service, provider, status, otr_muted, otr_mu
 insertMember :: PrepQuery W (ConvId, UserId, Maybe ServiceId, Maybe ProviderId, RoleName) ()
 insertMember = "insert into member (conv, user, service, provider, status, conversation_role) values (?, ?, ?, ?, 0, ?)"
 
-removeMember :: PrepQuery W (ConvId, UserId) ()
+removeMember :: PrepQuery W (ConvId, OpaqueUserId) ()
 removeMember = "delete from member where conv = ? and user = ?"
 
 updateOtrMemberMuted :: PrepQuery W (Bool, Maybe Text, ConvId, UserId) ()

--- a/services/galley/src/Galley/Types/Clients.hs
+++ b/services/galley/src/Galley/Types/Clients.hs
@@ -44,18 +44,18 @@ null = Map.null . (userClients . clients)
 nil :: Clients
 nil = Clients $ UserClients Map.empty
 
-userIds :: Clients -> [UserId]
+userIds :: Clients -> [OpaqueUserId]
 userIds = Map.keys . (userClients . clients)
 
-clientIds :: UserId -> Clients -> [ClientId]
+clientIds :: OpaqueUserId -> Clients -> [ClientId]
 clientIds u c = Set.toList $ fromMaybe Set.empty (Map.lookup u ((userClients . clients) c))
 
-toList :: Clients -> [(UserId, [ClientId])]
+toList :: Clients -> [(OpaqueUserId, [ClientId])]
 toList = Map.foldrWithKey' fn [] . (userClients . clients)
   where
     fn u c a = (u, Set.toList c) : a
 
-fromList :: [(UserId, [ClientId])] -> Clients
+fromList :: [(OpaqueUserId, [ClientId])] -> Clients
 fromList = Clients . UserClients . foldr fn Map.empty
   where
     fn (u, c) = Map.insert u (Set.fromList c)
@@ -63,27 +63,27 @@ fromList = Clients . UserClients . foldr fn Map.empty
 fromUserClients :: UserClients -> Clients
 fromUserClients ucs = Clients ucs
 
-fromMap :: Map UserId (Set ClientId) -> Clients
+fromMap :: Map OpaqueUserId (Set ClientId) -> Clients
 fromMap = Clients . UserClients
 
-toMap :: Clients -> Map UserId (Set ClientId)
+toMap :: Clients -> Map OpaqueUserId (Set ClientId)
 toMap = userClients . clients
 
-singleton :: UserId -> [ClientId] -> Clients
+singleton :: OpaqueUserId -> [ClientId] -> Clients
 singleton u c =
   Clients . UserClients $ Map.singleton u (Set.fromList c)
 
-filter :: (UserId -> Bool) -> Clients -> Clients
+filter :: (OpaqueUserId -> Bool) -> Clients -> Clients
 filter p =
   Clients . UserClients
     . Map.filterWithKey (\u _ -> p u)
     . (userClients . clients)
 
-contains :: UserId -> ClientId -> Clients -> Bool
+contains :: OpaqueUserId -> ClientId -> Clients -> Bool
 contains u c =
   maybe False (Set.member c) . Map.lookup u . (userClients . clients)
 
-insert :: UserId -> ClientId -> Clients -> Clients
+insert :: OpaqueUserId -> ClientId -> Clients -> Clients
 insert u c =
   Clients . UserClients
     . Map.insertWith Set.union u (Set.singleton c)
@@ -97,7 +97,7 @@ diff (Clients (UserClients ca)) (Clients (UserClients cb)) =
       let d = a `Set.difference` b
        in if Set.null d then Nothing else Just d
 
-rmClient :: UserId -> ClientId -> Clients -> Clients
+rmClient :: OpaqueUserId -> ClientId -> Clients -> Clients
 rmClient u c (Clients (UserClients m)) =
   Clients . UserClients $ Map.update f u m
   where

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -256,8 +256,8 @@ postCryptoMessage2 = do
       <!! const 200 === statusCode
   let p = responseJsonUnsafeWithMsg "prekeys" r2 :: UserClientMap (Maybe Prekey)
   liftIO $ do
-    Map.keys (userClientMap p) @=? [eve]
-    Map.keys <$> Map.lookup eve (userClientMap p) @=? Just [ec]
+    Map.keys (userClientMap p) @=? [makeIdOpaque eve]
+    Map.keys <$> Map.lookup (makeIdOpaque eve) (userClientMap p) @=? Just [ec]
 
 postCryptoMessage3 :: TestM ()
 postCryptoMessage3 = do
@@ -281,8 +281,8 @@ postCryptoMessage3 = do
       <!! const 200 === statusCode
   let p = responseJsonUnsafeWithMsg "prekeys" r2 :: UserClientMap (Maybe Prekey)
   liftIO $ do
-    Map.keys (userClientMap p) @=? [eve]
-    Map.keys <$> Map.lookup eve (userClientMap p) @=? Just [ec]
+    Map.keys (userClientMap p) @=? [makeIdOpaque eve]
+    Map.keys <$> Map.lookup (makeIdOpaque eve) (userClientMap p) @=? Just [ec]
 
 postCryptoMessage4 :: TestM ()
 postCryptoMessage4 = do
@@ -633,7 +633,7 @@ postConvO2OFailWithSelf :: TestM ()
 postConvO2OFailWithSelf = do
   g <- view tsGalley
   alice <- randomUser
-  let inv = NewConvUnmanaged (NewConv [alice] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin)
+  let inv = NewConvUnmanaged (NewConv [makeIdOpaque alice] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin)
   post (g . path "/conversations/one2one" . zUser alice . zConn "conn" . zType "access" . json inv) !!! do
     const 403 === statusCode
     const (Just "invalid-op") === fmap label . responseJsonUnsafe

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -521,7 +521,7 @@ testAddManagedConv = do
   let tinfo = ConvTeamInfo tid True
   let conv =
         NewConvManaged $
-          NewConv [owner] (Just "blah") (Set.fromList []) Nothing (Just tinfo) Nothing Nothing roleNameWireAdmin
+          NewConv [makeIdOpaque owner] (Just "blah") (Set.fromList []) Nothing (Just tinfo) Nothing Nothing roleNameWireAdmin
   post
     ( g
         . path "/conversations"

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -201,7 +201,7 @@ testApproveLegalHoldDevice = do
       liftIO $ do
         clients' <- Cql.runClient cassState $ Data.lookupClients [member]
         assertBool "Expect clientId to be saved on the user" $
-          Clients.contains member someClientId clients'
+          Clients.contains (makeIdOpaque member) someClientId clients'
       UserLegalHoldStatusResponse userStatus _ _ <- getUserStatusTyped member tid
       liftIO $
         assertEqual

--- a/tools/api-simulations/lib/src/Network/Wire/Simulations.hs
+++ b/tools/api-simulations/lib/src/Network/Wire/Simulations.hs
@@ -30,7 +30,7 @@ import Control.Lens ((^.))
 import Control.Monad.Catch
 import qualified Data.ByteString as BS
 import Data.ByteString.Conversion
-import Data.Id (ConvId, UserId)
+import Data.Id (ConvId, UserId, makeIdOpaque)
 import qualified Data.Map.Strict as Map
 import Data.Serialize
 import qualified Data.Set as Set
@@ -199,6 +199,6 @@ assertClientMissing ::
   BotSession ()
 assertClientMissing u d cm =
   assertEqual
-    (UserClients (Map.singleton u (Set.singleton $ botClientId d)))
+    (UserClients (Map.singleton (makeIdOpaque u) (Set.singleton $ botClientId d)))
     (missingClients cm)
     "Missing Clients"


### PR DESCRIPTION
This should not change any behaviour, but shows the places where we need to make changes to make this work.