### PR TITLE
Fix .gitignore shenanigans in Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 target
-Cargo.lock
+./libs/libzauth/libzauth/Cargo.lock
 *.aux*
 *.chi
 *.chs.h

--- a/nix/overlays/wire-server.nix
+++ b/nix/overlays/wire-server.nix
@@ -26,8 +26,7 @@ self: super: {
         name = "libzauth-${version}";
         version = "3.0.0";
         buildInputs = [ libsodium pkgconfig ];
-        src = self.nix-gitignore.gitignoreSource [] ../../libs/libzauth;
-
+        src = self.nix-gitignore.gitignoreSourcePure [ ../../.gitignore ] ../../libs/libzauth;
         sourceRoot = "libzauth/libzauth-c";
 
         cargoSha256 = "01yj1rchqmjnpj5cb9wl7vdzrycjwjhm60xh1jghw02n8jhl51p2"; # self.lib.fakeSha256;


### PR DESCRIPTION
Before, for building libzauth we were only considering the .gitignore
in the ./lib/libzauth directory, (ignoring the toplevel one) which
didn't contain a Cargo.lock ignore (and shouldn't! lockfiles should be
comitted so builds are reproducible!).  Then we deleted the local
gitignore
which tripped up the nix build as the gitignore didn't exist anymore.
We now use the toplevel .gitignore, but remove the global Cargo.lock
ignore as Cargo.lock's are important to be comitted (and were already!).
For some reason we do not have a Cargo.lock for ./libs/libzauth/libzauth
but only ./libs/libzauth/libzauth-c so I kept it like that.  libzauth-c
is the thing we directly build, and then pulls in libzauth as a
dependency, so  locking at just libzauth-c is sufficient and is also the
lockfile we had in source control already anyway.