### PR TITLE
Remove subv4

### DIFF
--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -505,6 +505,10 @@ deleteConversation cid = do
 acceptConnect :: MonadClient m => ConvId -> m ()
 acceptConnect cid = retry x5 $ write Cql.updateConvType (params Quorum (One2OneConv, cid))
 
+-- | We deduce the conversation ID by adding the 4 components of the V4 UUID
+-- together pairwise, and then setting the version bits (v4) and variant bits
+-- (variant 2). This means that we always know what the UUID is for a
+-- one-to-one conversation which hopefully makes them unique.
 one2OneConvId :: U.UUID U.V4 -> U.UUID U.V4 -> ConvId
 one2OneConvId a b = Id . U.unpack $ U.addv4 a b
 


### PR DESCRIPTION
It's not being used and doesn't seem to have any of the desirable
properties (being the inverse of addv4)

I'm also not sure if addv4 is functionally correct, as addition is not a
local operation like bitwise XOR. There might be some bias in how we
allocate conversation ids due to the fact that we add the numbers
together before bitwise-AND'ing in the version and variant. This is all a
bit naughty but we can't change it retroactively I think.

λ> quickCheck $ \x y -> subv4 (addv4 x y) x === y
*** Failed! Falsified (after 26 tests):
UUID 0000035e-0000-47d5-8000-0a7e00000d9b
UUID 00000b1c-0000-4d8f-8000-04f600000565
UUID 00000b1c-ffff-4d8f-8000-04f600000565 /= UUID 00000b1c-0000-4d8f-8000-04f600000565

λ> quickCheck $ \x y -> subv4 (addv4 y x) y === x
*** Failed! Falsified (after 26 tests):
UUID 00000513-0000-4beb-8000-01e10000022a
UUID 000009f2-0000-4ec8-8000-054b000003fb
UUID 00000513-ffff-4beb-8000-01e10000022a /= UUID 00000513-0000-4beb-8000-01e10000022a