### PR TITLE
stack snapshot 3.0.

### DIFF
--- a/snapshots/README.md
+++ b/snapshots/README.md
@@ -3,7 +3,8 @@ This directory contains [custom Stack snapshots][custom] used for Wire code.
 [custom]: https://docs.haskellstack.org/en/stable/custom_snapshot/
 
 Snapshot definitions should never be changed (once committed to `develop`), because in other
-repositories we refer to snapshot definitions by URL.
+repositories we refer to snapshot definitions by URL.  This goes for *ANY* change!  What
+matters is that the sha256 hash of the file remains intact!
 
 (Rationale: Stack only downloads snapshot definitions once, and never checks whether they have
 changed. If a snapshot changes and you have a repo that depends on it, you will get

--- a/snapshots/wire-3.0.yaml
+++ b/snapshots/wire-3.0.yaml
@@ -1,0 +1,104 @@
+# DO NOT MODIFY THIS FILE. See README.md to learn why.
+
+resolver: lts-14.12
+name: wire-3.0
+
+# compiler: ghc-8.6.5
+
+packages:
+- git: https://github.com/kim/hs-collectd
+  commit: 885da222be2375f78c7be36127620ed772b677c9
+
+- git: https://github.com/kim/snappy-framing
+  commit: d99f702c0086729efd6848dea8a01e5266c3a61c
+
+- git: https://gitlab.com/twittner/wai-routing
+  commit: 7e996a93fec5901767f845a50316b3c18e51a61d
+
+# Includes the changes from <https://gitlab.com/twittner/cql-io/merge_requests/14>
+# - git: https://gitlab.com/twittner/cql-io.git
+#   commit: 8b91d053c469887a427e8c075cef43139fa189c4
+
+#  Our fork of multihash with relaxed upper bounds
+- git: https://github.com/wireapp/haskell-multihash.git
+  commit: 300a6f46384bfca33e545c8bab52ef3717452d12
+
+# Our fork of aws with minor fixes
+- git: https://github.com/wireapp/aws
+  commit: 42695688fc20f80bf89cec845c57403954aab0a2
+
+# https://github.com/hspec/hspec-wai/pull/49
+- git: https://github.com/wireapp/hspec-wai
+  commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25
+
+# amazonka-1.6.1 is buggy: https://github.com/brendanhay/amazonka/issues/466
+# Therefore we pin an unreleased commit directly.
+#
+# More precisely, we pull just some libraries out of it,
+# the other packages weren't changed between 1.6.1 and this commit,
+# so we can use Stackage-supplied versions for them.
+# See https://github.com/brendanhay/amazonka/compare/1.6.1...9cf5b5777b69ac494d23d43a692294882927df34
+#
+# Once there has been made a new hackage release, we can use that instead.
+- archive: https://github.com/brendanhay/amazonka/archive/9cf5b5777b69ac494d23d43a692294882927df34.tar.gz
+  sha256: c3044f803a7652aee88fe600a97321175cdc1443d671246ba7ff78e14bf5b49f
+  size: 11137527
+  subdirs:
+  - amazonka
+  - amazonka-elb
+  - amazonka-redshift
+  - amazonka-route53
+  - core
+
+############################################################
+# Wire packages (only ones that change infrequently)
+############################################################
+
+- git: https://github.com/wireapp/cryptobox-haskell
+  commit: 7546a1a25635ef65183e3d44c1052285e8401608    # master (Jul 21, 2016)
+
+- git: https://github.com/wireapp/hsaml2
+  commit: cc47da1d097b0b26595b8889e40c33c6c0c1c551    # master (Feb 27, 2020)
+
+- git: https://github.com/wireapp/http-client
+  commit: a160cef95d9daaff7d9cfe616d95754c2f8202bf    # master (Feb 4, 2020)
+  subdirs:
+  - http-client
+  - http-client-openssl
+  - http-client-tls
+  - http-conduit
+
+# Dropped from upstream snapshot
+- bloodhound-0.16.0.0
+- template-0.2.0.10
+- HaskellNet-0.5.1
+- HaskellNet-SSL-0.3.4.1
+- snappy-0.2.0.2
+- smtp-mail-0.2.0.0
+- stm-containers-1.1.0.4
+- redis-io-1.0.0
+- redis-resp-1.0.0
+- hedgehog-quickcheck-0.1.1
+
+# Only in nightly
+- stm-hamt-1.2.0.4
+- optics-th-0.2
+- primitive-unlifted-0.1.2.0
+
+# Not on stackage
+- currency-codes-3.0.0.1
+- mime-0.4.0.2
+- data-timeout-0.3.1
+- geoip2-0.4.0.1
+- stomp-queue-0.3.1
+- text-icu-translit-0.1.0.7
+- wai-middleware-gunzip-0.0.2
+- cql-io-tinylog-0.1.0
+- invertible-hxt-0.1
+- network-uri-static-0.1.2.1
+- base58-bytestring-0.1.0
+- stompl-0.5.0
+- pattern-trie-0.1.0
+
+# Not latest as latst one breaks wai-routing
+- wai-route-0.4.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: snapshots/wire-2.2.yaml
+resolver: snapshots/wire-3.0.yaml
 
 packages:
 - libs/api-bot


### PR DESCRIPTION
This does not change any dependencies from 2.2.

I broke 2.* a while ago by editing the files, and thus learned
that even editing typos in comments is a bad idea.  the easiest
way out is to abandon the old snapshot and clone it into a new
one with the same content.