### PR TITLE
Qualify all API imports in Galley

### DIFF
--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -9,17 +9,16 @@ import Data.Range
 import qualified Data.Set as Set
 import Data.Swagger.Build.Api hiding (Response, def, min)
 import Data.Text.Encoding (decodeLatin1)
-import Galley.API.Clients
-import Galley.API.Create
+import qualified Galley.API.Clients as Clients
+import qualified Galley.API.Create as Create
 import qualified Galley.API.CustomBackend as CustomBackend
 import qualified Galley.API.Error as Error
 import qualified Galley.API.Internal as Internal
 import qualified Galley.API.LegalHold as LegalHold
-import Galley.API.Query
+import qualified Galley.API.Query as Query
 import Galley.API.Swagger (swagger)
-import Galley.API.Teams
 import qualified Galley.API.Teams as Teams
-import Galley.API.Update
+import qualified Galley.API.Update as Update
 import Galley.App
 import Galley.Types
 import Galley.Types.Bot (AddBot, RemoveBot)
@@ -43,7 +42,7 @@ import Network.Wai.Utilities.ZAuth
 
 sitemap :: Routes ApiBuilder Galley ()
 sitemap = do
-  post "/teams" (continue createNonBindingTeamH) $
+  post "/teams" (continue Teams.createNonBindingTeamH) $
     zauthUserId
       .&. zauthConnId
       .&. jsonRequest @NonBindingNewTeam
@@ -54,7 +53,7 @@ sitemap = do
       description "JSON body"
     response 201 "Team ID as `Location` header value" end
     errorResponse Error.notConnected
-  put "/teams/:tid" (continue updateTeamH) $
+  put "/teams/:tid" (continue Teams.updateTeamH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "tid"
@@ -70,7 +69,7 @@ sitemap = do
     errorResponse (Error.operationDenied SetTeamData)
   --
 
-  get "/teams" (continue getManyTeamsH) $
+  get "/teams" (continue Teams.getManyTeamsH) $
     zauthUserId
       .&. opt (query "ids" ||| query "start")
       .&. def (unsafeRange 100) (query "size")
@@ -81,7 +80,7 @@ sitemap = do
     response 200 "Teams list" end
   --
 
-  get "/teams/:tid" (continue getTeamH) $
+  get "/teams/:tid" (continue Teams.getTeamH) $
     zauthUserId
       .&. capture "tid"
       .&. accept "application" "json"
@@ -94,7 +93,7 @@ sitemap = do
     errorResponse Error.teamNotFound
   --
 
-  delete "/teams/:tid" (continue deleteTeamH) $
+  delete "/teams/:tid" (continue Teams.deleteTeamH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "tid"
@@ -115,7 +114,7 @@ sitemap = do
     errorResponse Error.teamNotFound
   --
 
-  get "/teams/:tid/conversations/roles" (continue getTeamConversationRolesH) $
+  get "/teams/:tid/conversations/roles" (continue Teams.getTeamConversationRolesH) $
     zauthUserId
       .&. capture "tid"
       .&. accept "application" "json"
@@ -129,7 +128,7 @@ sitemap = do
     errorResponse Error.noTeamMember
   --
 
-  get "/teams/:tid/members" (continue getTeamMembersH) $
+  get "/teams/:tid/members" (continue Teams.getTeamMembersH) $
     zauthUserId
       .&. capture "tid"
       .&. accept "application" "json"
@@ -142,7 +141,7 @@ sitemap = do
     errorResponse Error.noTeamMember
   --
 
-  get "/teams/:tid/members/:uid" (continue getTeamMemberH) $
+  get "/teams/:tid/members/:uid" (continue Teams.getTeamMemberH) $
     zauthUserId
       .&. capture "tid"
       .&. capture "uid"
@@ -159,7 +158,7 @@ sitemap = do
     errorResponse Error.teamMemberNotFound
   --
 
-  post "/teams/:tid/members" (continue addTeamMemberH) $
+  post "/teams/:tid/members" (continue Teams.addTeamMemberH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "tid"
@@ -178,7 +177,7 @@ sitemap = do
     errorResponse Error.tooManyTeamMembers
   --
 
-  delete "/teams/:tid/members/:uid" (continue deleteTeamMemberH) $
+  delete "/teams/:tid/members/:uid" (continue Teams.deleteTeamMemberH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "tid"
@@ -200,7 +199,7 @@ sitemap = do
     errorResponse Error.reAuthFailed
   --
 
-  put "/teams/:tid/members" (continue updateTeamMemberH) $
+  put "/teams/:tid/members" (continue Teams.updateTeamMemberH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "tid"
@@ -217,7 +216,7 @@ sitemap = do
     errorResponse (Error.operationDenied SetMemberPermissions)
   --
 
-  get "/teams/:tid/conversations" (continue getTeamConversationsH) $
+  get "/teams/:tid/conversations" (continue Teams.getTeamConversationsH) $
     zauthUserId
       .&. capture "tid"
       .&. accept "application" "json"
@@ -231,7 +230,7 @@ sitemap = do
     errorResponse (Error.operationDenied GetTeamConversations)
   --
 
-  get "/teams/:tid/conversations/:cid" (continue getTeamConversationH) $
+  get "/teams/:tid/conversations/:cid" (continue Teams.getTeamConversationH) $
     zauthUserId
       .&. capture "tid"
       .&. capture "cid"
@@ -249,7 +248,7 @@ sitemap = do
     errorResponse (Error.operationDenied GetTeamConversations)
   --
 
-  delete "/teams/:tid/conversations/:cid" (continue deleteTeamConversationH) $
+  delete "/teams/:tid/conversations/:cid" (continue Teams.deleteTeamConversationH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "tid"
@@ -310,12 +309,12 @@ sitemap = do
       .&. accept "application" "json"
   ---
 
-  get "/bot/conversation" (continue getBotConversationH) $
+  get "/bot/conversation" (continue Query.getBotConversationH) $
     zauth ZAuthBot
       .&> zauthBotId
       .&. zauthConvId
       .&. accept "application" "json"
-  post "/bot/messages" (continue postBotMessageH) $
+  post "/bot/messages" (continue Update.postBotMessageH) $
     zauth ZAuthBot
       .&> zauthBotId
       .&. zauthConvId
@@ -324,7 +323,7 @@ sitemap = do
       .&. accept "application" "json"
   --
 
-  get "/conversations/:cnv" (continue getConversationH) $
+  get "/conversations/:cnv" (continue Query.getConversationH) $
     zauthUserId
       .&. capture "cnv"
       .&. accept "application" "json"
@@ -337,7 +336,7 @@ sitemap = do
     errorResponse Error.convAccessDenied
   --
 
-  get "/conversations/:cnv/roles" (continue getConversationRolesH) $
+  get "/conversations/:cnv/roles" (continue Query.getConversationRolesH) $
     zauthUserId
       .&. capture "cnv"
       .&. accept "application" "json"
@@ -350,7 +349,7 @@ sitemap = do
     errorResponse Error.convNotFound
   ---
 
-  get "/conversations/ids" (continue getConversationIdsH) $
+  get "/conversations/ids" (continue Query.getConversationIdsH) $
     zauthUserId
       .&. opt (query "start")
       .&. def (unsafeRange 1000) (query "size")
@@ -367,7 +366,7 @@ sitemap = do
     returns (ref Model.conversationIds)
   ---
 
-  get "/conversations" (continue getConversationsH) $
+  get "/conversations" (continue Query.getConversationsH) $
     zauthUserId
       .&. opt (query "ids" ||| query "start")
       .&. def (unsafeRange 100) (query "size")
@@ -389,7 +388,7 @@ sitemap = do
       description "Max. number of conversations to return"
   ---
 
-  post "/conversations" (continue createGroupConversationH) $
+  post "/conversations" (continue Create.createGroupConversationH) $
     zauthUserId
       .&. zauthConnId
       .&. jsonRequest @NewConvUnmanaged
@@ -404,7 +403,7 @@ sitemap = do
     errorResponse (Error.operationDenied CreateConversation)
   ---
 
-  post "/conversations/self" (continue createSelfConversationH) $
+  post "/conversations/self" (continue Create.createSelfConversationH) $
     zauthUserId
   document "POST" "createSelfConversation" $ do
     summary "Create a self-conversation"
@@ -412,7 +411,7 @@ sitemap = do
     response 201 "Conversation created" end
   ---
 
-  post "/conversations/one2one" (continue createOne2OneConversationH) $
+  post "/conversations/one2one" (continue Create.createOne2OneConversationH) $
     zauthUserId
       .&. zauthConnId
       .&. jsonRequest @NewConvUnmanaged
@@ -425,7 +424,7 @@ sitemap = do
     errorResponse Error.noManagedTeamConv
   ---
 
-  put "/conversations/:cnv/name" (continue updateConversationNameH) $
+  put "/conversations/:cnv/name" (continue Update.updateConversationNameH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -440,7 +439,7 @@ sitemap = do
     errorResponse Error.convNotFound
   ---
 
-  put "/conversations/:cnv" (continue updateConversationDeprecatedH) $
+  put "/conversations/:cnv" (continue Update.updateConversationDeprecatedH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -455,7 +454,7 @@ sitemap = do
     errorResponse Error.convNotFound
   ---
 
-  post "/conversations/:cnv/join" (continue joinConversationByIdH) $
+  post "/conversations/:cnv/join" (continue Update.joinConversationByIdH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -469,7 +468,7 @@ sitemap = do
     errorResponse Error.convNotFound
   ---
 
-  post "/conversations/code-check" (continue checkReusableCodeH) $
+  post "/conversations/code-check" (continue Update.checkReusableCodeH) $
     jsonRequest @ConversationCode
   document "POST" "checkConversationCode" $ do
     summary "Check validity of a conversation code"
@@ -477,7 +476,7 @@ sitemap = do
     body (ref Model.conversationCode) $
       description "JSON body"
     errorResponse Error.codeNotFound
-  post "/conversations/join" (continue joinConversationByReusableCodeH) $
+  post "/conversations/join" (continue Update.joinConversationByReusableCodeH) $
     zauthUserId
       .&. zauthConnId
       .&. jsonRequest @ConversationCode
@@ -492,7 +491,7 @@ sitemap = do
     errorResponse Error.tooManyMembers
   ---
 
-  post "/conversations/:cnv/code" (continue addCodeH) $
+  post "/conversations/:cnv/code" (continue Update.addCodeH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -508,7 +507,7 @@ sitemap = do
     errorResponse Error.invalidAccessOp
   ---
 
-  delete "/conversations/:cnv/code" (continue rmCodeH) $
+  delete "/conversations/:cnv/code" (continue Update.rmCodeH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -522,7 +521,7 @@ sitemap = do
     errorResponse Error.invalidAccessOp
   ---
 
-  get "/conversations/:cnv/code" (continue getCodeH) $
+  get "/conversations/:cnv/code" (continue Update.getCodeH) $
     zauthUserId
       .&. capture "cnv"
   document "GET" "getConversationCode" $ do
@@ -535,7 +534,7 @@ sitemap = do
     errorResponse Error.invalidAccessOp
   ---
 
-  put "/conversations/:cnv/access" (continue updateConversationAccessH) $
+  put "/conversations/:cnv/access" (continue Update.updateConversationAccessH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -557,7 +556,7 @@ sitemap = do
     errorResponse Error.invalidConnectOp
   ---
 
-  put "/conversations/:cnv/receipt-mode" (continue updateConversationReceiptModeH) $
+  put "/conversations/:cnv/receipt-mode" (continue Update.updateConversationReceiptModeH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -576,7 +575,7 @@ sitemap = do
     errorResponse Error.convAccessDenied
   ---
 
-  put "/conversations/:cnv/message-timer" (continue updateConversationMessageTimerH) $
+  put "/conversations/:cnv/message-timer" (continue Update.updateConversationMessageTimerH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -597,7 +596,7 @@ sitemap = do
     errorResponse Error.invalidConnectOp
   ---
 
-  post "/conversations/:cnv/members" (continue addMembersH) $
+  post "/conversations/:cnv/members" (continue Update.addMembersH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -617,7 +616,7 @@ sitemap = do
     errorResponse Error.convAccessDenied
   ---
 
-  get "/conversations/:cnv/self" (continue getSelfH) $
+  get "/conversations/:cnv/self" (continue Query.getSelfH) $
     zauthUserId
       .&. capture "cnv"
   document "GET" "getSelf" $ do
@@ -628,7 +627,7 @@ sitemap = do
     errorResponse Error.convNotFound
   ---
 
-  put "/conversations/:cnv/self" (continue updateSelfMemberH) $
+  put "/conversations/:cnv/self" (continue Update.updateSelfMemberH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -643,7 +642,7 @@ sitemap = do
     errorResponse Error.convNotFound
   ---
 
-  put "/conversations/:cnv/members/:usr" (continue updateOtherMemberH) $
+  put "/conversations/:cnv/members/:usr" (continue Update.updateOtherMemberH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -663,7 +662,7 @@ sitemap = do
     errorResponse Error.invalidTargetUserOp
   ---
 
-  post "/conversations/:cnv/typing" (continue isTypingH) $
+  post "/conversations/:cnv/typing" (continue Update.isTypingH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -677,7 +676,7 @@ sitemap = do
     errorResponse Error.convNotFound
   ---
 
-  delete "/conversations/:cnv/members/:usr" (continue removeMemberH) $
+  delete "/conversations/:cnv/members/:usr" (continue Update.removeMemberH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -695,7 +694,7 @@ sitemap = do
     errorResponse $ Error.invalidOp "Conversation type does not allow removing members"
   ---
 
-  post "/broadcast/otr/messages" (continue postOtrBroadcastH) $
+  post "/broadcast/otr/messages" (continue Update.postOtrBroadcastH) $
     zauthUserId
       .&. zauthConnId
       .&. def OtrReportAllMissing filterMissing
@@ -714,7 +713,7 @@ sitemap = do
     errorResponse Error.nonBindingTeam
   ---
 
-  post "/broadcast/otr/messages" (continue postProtoOtrBroadcastH) $
+  post "/broadcast/otr/messages" (continue Update.postProtoOtrBroadcastH) $
     zauthUserId
       .&. zauthConnId
       .&. def OtrReportAllMissing filterMissing
@@ -746,7 +745,7 @@ sitemap = do
     errorResponse Error.nonBindingTeam
   ---
 
-  post "/conversations/:cnv/otr/messages" (continue postOtrMessageH) $
+  post "/conversations/:cnv/otr/messages" (continue Update.postOtrMessageH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -779,7 +778,7 @@ sitemap = do
     errorResponse Error.convNotFound
   ---
 
-  post "/conversations/:cnv/otr/messages" (continue postProtoOtrMessageH) $
+  post "/conversations/:cnv/otr/messages" (continue Update.postProtoOtrMessageH) $
     zauthUserId
       .&. zauthConnId
       .&. capture "cnv"
@@ -844,59 +843,59 @@ sitemap = do
       .&. request
   head "/i/status" (continue $ const (return empty)) true
   get "/i/status" (continue $ const (return empty)) true
-  get "/i/conversations/:cnv/members/:usr" (continue internalGetMemberH) $
+  get "/i/conversations/:cnv/members/:usr" (continue Query.internalGetMemberH) $
     capture "cnv"
       .&. capture "usr"
-  post "/i/conversations/managed" (continue internalCreateManagedConversationH) $
+  post "/i/conversations/managed" (continue Create.internalCreateManagedConversationH) $
     zauthUserId
       .&. zauthConnId
       .&. jsonRequest @NewConvManaged
-  post "/i/conversations/connect" (continue createConnectConversationH) $
+  post "/i/conversations/connect" (continue Create.createConnectConversationH) $
     zauthUserId
       .&. opt zauthConnId
       .&. jsonRequest @Connect
-  put "/i/conversations/:cnv/accept/v2" (continue acceptConvH) $
+  put "/i/conversations/:cnv/accept/v2" (continue Update.acceptConvH) $
     zauthUserId
       .&. opt zauthConnId
       .&. capture "cnv"
-  put "/i/conversations/:cnv/block" (continue blockConvH) $
+  put "/i/conversations/:cnv/block" (continue Update.blockConvH) $
     zauthUserId
       .&. capture "cnv"
-  put "/i/conversations/:cnv/unblock" (continue unblockConvH) $
+  put "/i/conversations/:cnv/unblock" (continue Update.unblockConvH) $
     zauthUserId
       .&. opt zauthConnId
       .&. capture "cnv"
-  get "/i/conversations/:cnv/meta" (continue getConversationMetaH) $
+  get "/i/conversations/:cnv/meta" (continue Query.getConversationMetaH) $
     capture "cnv"
-  get "/i/teams/:tid" (continue getTeamInternalH) $
+  get "/i/teams/:tid" (continue Teams.getTeamInternalH) $
     capture "tid"
       .&. accept "application" "json"
-  get "/i/teams/:tid/name" (continue getTeamNameInternalH) $
+  get "/i/teams/:tid/name" (continue Teams.getTeamNameInternalH) $
     capture "tid"
       .&. accept "application" "json"
-  put "/i/teams/:tid" (continue createBindingTeamH) $
+  put "/i/teams/:tid" (continue Teams.createBindingTeamH) $
     zauthUserId
       .&. capture "tid"
       .&. jsonRequest @BindingNewTeam
       .&. accept "application" "json"
-  put "/i/teams/:tid/status" (continue updateTeamStatusH) $
+  put "/i/teams/:tid/status" (continue Teams.updateTeamStatusH) $
     capture "tid"
       .&. jsonRequest @TeamStatusUpdate
       .&. accept "application" "json"
-  post "/i/teams/:tid/members" (continue uncheckedAddTeamMemberH) $
+  post "/i/teams/:tid/members" (continue Teams.uncheckedAddTeamMemberH) $
     capture "tid"
       .&. jsonRequest @NewTeamMember
       .&. accept "application" "json"
-  get "/i/teams/:tid/members" (continue uncheckedGetTeamMembersH) $
+  get "/i/teams/:tid/members" (continue Teams.uncheckedGetTeamMembersH) $
     capture "tid"
       .&. accept "application" "json"
-  get "/i/teams/:tid/members/:uid" (continue uncheckedGetTeamMemberH) $
+  get "/i/teams/:tid/members/:uid" (continue Teams.uncheckedGetTeamMemberH) $
     capture "tid"
       .&. capture "uid"
       .&. accept "application" "json"
-  get "/i/users/:uid/team/members" (continue getBindingTeamMembersH) $
+  get "/i/users/:uid/team/members" (continue Teams.getBindingTeamMembersH) $
     capture "uid"
-  get "/i/users/:uid/team" (continue getBindingTeamIdH) $
+  get "/i/users/:uid/team" (continue Teams.getBindingTeamIdH) $
     capture "uid"
   -- Start of team features (internal); enabling this should only be
   -- possible internally. Viewing the status should be allowed
@@ -918,27 +917,27 @@ sitemap = do
       .&. accept "application" "json"
   -- End of team features
 
-  get "/i/test/clients" (continue getClientsH) $
+  get "/i/test/clients" (continue Clients.getClientsH) $
     zauthUserId
   -- eg. https://github.com/wireapp/wire-server/blob/3bdca5fc8154e324773802a0deb46d884bd09143/services/brig/test/integration/API/User/Client.hs#L319
 
-  post "/i/clients/:client" (continue addClientH) $
+  post "/i/clients/:client" (continue Clients.addClientH) $
     zauthUserId
       .&. capture "client"
-  delete "/i/clients/:client" (continue rmClientH) $
+  delete "/i/clients/:client" (continue Clients.rmClientH) $
     zauthUserId
       .&. capture "client"
   delete "/i/user" (continue Internal.rmUserH) $
     zauthUserId .&. opt zauthConnId
-  post "/i/services" (continue addServiceH) $
+  post "/i/services" (continue Update.addServiceH) $
     jsonRequest @Service
-  delete "/i/services" (continue rmServiceH) $
+  delete "/i/services" (continue Update.rmServiceH) $
     jsonRequest @ServiceRef
-  post "/i/bots" (continue addBotH) $
+  post "/i/bots" (continue Update.addBotH) $
     zauthUserId
       .&. zauthConnId
       .&. jsonRequest @AddBot
-  delete "/i/bots" (continue rmBotH) $
+  delete "/i/bots" (continue Update.rmBotH) $
     zauthUserId
       .&. opt zauthConnId
       .&. jsonRequest @RemoveBot


### PR DESCRIPTION
This way you know which routes are handled in which modules.

Next step is to regroup handlers by resource type instead of by
modification type.