### PR TITLE
federation: resolve opaque IDs at the edges of galley

### DIFF
--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -16,6 +16,8 @@ lookupProfilesMaybeFilterSameTeamOnly self us = do
     Just team -> filter (\x -> profileTeam x == Just team) us
     Nothing -> us
 
+-- FUTUREWORK(federation): implement function to resolve IDs in batch
+
 -- | this exists as a shim to find and mark places where we need to handle 'OpaqueUserId's.
 resolveOpaqueUserId :: Monad m => OpaqueUserId -> m (MappedOrLocalId Id.U)
 resolveOpaqueUserId (Id opaque) =

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -13,6 +13,7 @@ where
 import Cassandra (hasMore, result)
 import Data.ByteString.Conversion
 import Data.Id
+import Data.IdMapping (MappedOrLocalId (Local))
 import Data.Range
 import Galley.API.Error
 import Galley.API.Mapping
@@ -35,7 +36,7 @@ getBotConversationH (zbot ::: zcnv ::: _) = do
 
 getBotConversation :: BotId -> ConvId -> Galley BotConvView
 getBotConversation zbot zcnv = do
-  c <- getConversationAndCheckMembershipWithError convNotFound (botUserId zbot) (makeIdOpaque zcnv)
+  c <- getConversationAndCheckMembershipWithError convNotFound (botUserId zbot) (Local zcnv)
   let cmems = mapMaybe mkMember (toList (Data.convMembers c))
   pure $ botConvView zcnv (Data.convName c) cmems
   where
@@ -48,7 +49,8 @@ getConversationH (zusr ::: cnv ::: _) = do
   json <$> getConversation zusr cnv
 
 getConversation :: UserId -> OpaqueConvId -> Galley Conversation
-getConversation zusr cnv = do
+getConversation zusr opaqueCnv = do
+  cnv <- resolveOpaqueConvId opaqueCnv
   c <- getConversationAndCheckMembership zusr cnv
   conversationView zusr c
 
@@ -57,7 +59,8 @@ getConversationRolesH (zusr ::: cnv ::: _) = do
   json <$> getConversationRoles zusr cnv
 
 getConversationRoles :: UserId -> OpaqueConvId -> Galley ConversationRolesList
-getConversationRoles zusr cnv = do
+getConversationRoles zusr opaqueCnv = do
+  cnv <- resolveOpaqueConvId opaqueCnv
   void $ getConversationAndCheckMembership zusr cnv
   -- NOTE: If/when custom roles are added, these roles should
   --       be merged with the team roles (if they exist)

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -82,7 +82,6 @@ getConversationsH (zusr ::: range ::: size ::: _) =
 getConversations :: UserId -> Maybe (Either (Range 1 32 (List OpaqueConvId)) OpaqueConvId) -> Range 1 500 Int32 -> Galley (ConversationList Conversation)
 getConversations zusr range size =
   withConvIds zusr range size $ \more ids -> do
-    -- FUTUREWORK(federation): resolve IDs in batch
     (localConvIds, _qualifiedConvIds) <- partitionMappedOrLocalIds <$> traverse resolveOpaqueConvId ids
     -- FUTUREWORK(federation): fetch remote conversations from other backend
     cs <-

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -130,7 +130,7 @@ createNonBindingTeam zusr zcon (NonBindingNewTeam body) = do
           $ body ^. newTeamMembers
   let zothers = map (view userId) others
   ensureUnboundUsers (zusr : zothers)
-  ensureConnected zusr (makeIdOpaque <$> zothers)
+  ensureConnectedToLocals zusr zothers
   Log.debug $
     Log.field "targets" (toByteString . show $ toByteString <$> zothers)
       . Log.field "action" (Log.val "Teams.createNonBindingTeam")
@@ -362,7 +362,7 @@ addTeamMember zusr zcon tid nmem = do
   targetPermissions `ensureNotElevated` tmem
   ensureNonBindingTeam tid
   ensureUnboundUsers [uid]
-  ensureConnected zusr [makeIdOpaque uid]
+  ensureConnectedToLocals zusr [uid]
   addTeamMemberInternal tid (Just zusr) (Just zcon) nmem mems
 
 -- This function is "unchecked" because there is no need to check for user binding (invite only).

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -415,8 +415,14 @@ addMembersH (zusr ::: zcon ::: cid ::: req) = do
 addMembers :: UserId -> ConnId -> OpaqueConvId -> Invite -> Galley UpdateResult
 addMembers zusr zcon cid invite = do
   resolveOpaqueConvId cid >>= \case
-    Mapped idMapping -> throwM . federationNotImplemented $ pure idMapping
-    Local localConvId -> addMembersToLocalConv localConvId
+    Mapped idMapping ->
+      -- FUTUREWORK(federation): if the conversation is on another backend, send request there.
+      -- in the case of a non-team conversation, we need to think about `ensureConnectedOrSameTeam`,
+      -- specifically whether teams from another backend than the conversation should have any
+      -- relevance here.
+      throwM . federationNotImplemented $ pure idMapping
+    Local localConvId ->
+      addMembersToLocalConv localConvId
   where
     addMembersToLocalConv convId = do
       conv <- Data.conversation convId >>= ifNothing convNotFound

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -425,15 +425,15 @@ addMembers zusr zcon cid invite = do
       ensureActionAllowed AddConversationMember self
       toAdd <- fromMemberSize <$> checkedMemberAddSize (toList $ invUsers invite)
       let newOpaqueUsers = filter (notIsMember conv) (toList toAdd)
+      ensureMemberLimit (toList $ Data.convMembers conv) newOpaqueUsers
+      ensureAccess conv InviteAccess
+      ensureConvRoleNotElevated self (invRoleName invite)
       (newUsers, newQualifiedUsers) <- partitionMappedOrLocalIds <$> traverse resolveOpaqueUserId newOpaqueUsers
       -- FUTUREWORK(federation): allow adding remote members
       -- this one is a bit tricky because all of the checks that need to be done,
       -- some of them on remote backends.
       for_ (nonEmpty newQualifiedUsers) $
         throwM . federationNotImplemented
-      ensureMemberLimit (toList $ Data.convMembers conv) newOpaqueUsers
-      ensureAccess conv InviteAccess
-      ensureConvRoleNotElevated self (invRoleName invite)
       case Data.convTeam conv of
         Nothing -> do
           ensureAccessRole (Data.convAccessRole conv) newUsers Nothing

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -456,7 +456,7 @@ updateSelfMemberH (zusr ::: zcon ::: cid ::: req) = do
 
 updateSelfMember :: UserId -> ConnId -> ConvId -> MemberUpdate -> Galley ()
 updateSelfMember zusr zcon cid update = do
-  conv <- getConversationAndCheckMembership zusr (makeIdOpaque cid)
+  conv <- getConversationAndCheckMembership zusr (Local cid)
   m <- getSelfMember zusr (Data.convMembers conv)
   -- Ensure no self role upgrades
   for_ (mupConvRoleName update) $ ensureConvRoleNotElevated m
@@ -472,7 +472,7 @@ updateOtherMember :: UserId -> ConnId -> ConvId -> UserId -> OtherMemberUpdate -
 updateOtherMember zusr zcon cid victim update = do
   when (zusr == victim) $
     throwM invalidTargetUserOp
-  conv <- getConversationAndCheckMembership zusr (makeIdOpaque cid)
+  conv <- getConversationAndCheckMembership zusr (Local cid)
   let (bots, users) = botsAndUsers (Data.convMembers conv)
   ensureActionAllowed ModifyOtherConversationMember =<< getSelfMember zusr users
   memTarget <- getOtherMember victim users

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -252,6 +252,8 @@ getConversationAndCheckMembershipWithError ex zusr = \case
       throwM ex
     return c
 
+-- FUTUREWORK(federation): implement function to resolve IDs in batch
+
 -- | this exists as a shim to find and mark places where we need to handle 'OpaqueUserId's.
 resolveOpaqueUserId :: OpaqueUserId -> Galley (MappedOrLocalId Id.U)
 resolveOpaqueUserId (Id opaque) =

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -57,7 +57,8 @@ ensureConnectedOrSameTeam u uids = do
   sameTeamUids <- forM uTeams $ \team ->
     fmap (view userId) <$> Data.teamMembersLimited team uids
   -- Do not check connections for users that are on the same team
-  ensureConnectedToLocals u (uids \\ join sameTeamUids)
+  -- FUTUREWORK(federation): handle remote users (can't be part of the same team, just check connections)
+  ensureConnected u (Local <$> uids \\ join sameTeamUids)
 
 -- | Check that the user is connected to everybody else.
 --


### PR DESCRIPTION
This saves us some unnecessary ID resolution lookups.

Probably easiest to review each commit individually.