### PR TITLE
ormolu.sh: make queries for options more robust

### DIFF
--- a/tools/ormolu.sh
+++ b/tools/ormolu.sh
@@ -2,7 +2,7 @@
 
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
-ORMOLU_VERSION=$(perl -ne '/^- ormolu-([^\s]+)(\s|$)/ && print $1' stack.yaml)
+ORMOLU_VERSION=$(yq read stack.yaml 'extra-deps[*]' | sed -n 's/ormolu-//p')
 ( ormolu -v 2>/dev/null | grep -q $ORMOLU_VERSION ) || ( echo "please install ormolu $ORMOLU_VERSION (eg., run 'stack install ormolu' and ensure ormolu is on your PATH.)"; exit 1 )
 
 ARG_ALLOW_DIRTY_WC="0"
@@ -58,7 +58,7 @@ if [ "$(git status -s | grep -v \?\?)" != "" ]; then
     fi
 fi
 
-LANGUAGE_EXTS=$(perl -ne '$x=1 if /default-extensions:/?1:(/^[^-]/?0:$x); print "--ghc-opt -X$1 " if ($x && /^- (.+)/);' package-defaults.yaml)
+LANGUAGE_EXTS=$(yq read package-defaults.yaml 'default-extensions[*]' | awk '{print "--ghc-opt -X" $0}' ORS=' ')
 echo "ormolu mode: $ARG_ORMOLU_MODE"
 
 FAILURES=0

--- a/tools/ormolu.sh
+++ b/tools/ormolu.sh
@@ -2,6 +2,11 @@
 
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
+command -v grep >/dev/null 2>&1 || { echo >&2 "grep is not installed, aborting."; exit 1; }
+command -v awk  >/dev/null 2>&1 || { echo >&2 "awk is not installed, aborting."; exit 1; }
+command -v sed  >/dev/null 2>&1 || { echo >&2 "sed is not installed, aborting."; exit 1; }
+command -v yq   >/dev/null 2>&1 || { echo >&2 "yq is not installed, aborting. See https://github.com/mikefarah/yq"; exit 1; }
+
 ORMOLU_VERSION=$(yq read stack.yaml 'extra-deps[*]' | sed -n 's/ormolu-//p')
 ( ormolu -v 2>/dev/null | grep -q $ORMOLU_VERSION ) || ( echo "please install ormolu $ORMOLU_VERSION (eg., run 'stack install ormolu' and ensure ormolu is on your PATH.)"; exit 1 )
 echo "ormolu version: $ORMOLU_VERSION"

--- a/tools/ormolu.sh
+++ b/tools/ormolu.sh
@@ -4,6 +4,7 @@ cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
 ORMOLU_VERSION=$(yq read stack.yaml 'extra-deps[*]' | sed -n 's/ormolu-//p')
 ( ormolu -v 2>/dev/null | grep -q $ORMOLU_VERSION ) || ( echo "please install ormolu $ORMOLU_VERSION (eg., run 'stack install ormolu' and ensure ormolu is on your PATH.)"; exit 1 )
+echo "ormolu version: $ORMOLU_VERSION"
 
 ARG_ALLOW_DIRTY_WC="0"
 ARG_ORMOLU_MODE="inplace"
@@ -60,6 +61,7 @@ fi
 
 LANGUAGE_EXTS=$(yq read package-defaults.yaml 'default-extensions[*]' | awk '{print "--ghc-opt -X" $0}' ORS=' ')
 echo "ormolu mode: $ARG_ORMOLU_MODE"
+echo "language extensions: $LANGUAGE_EXTS"
 
 FAILURES=0
 


### PR DESCRIPTION
By using `yq` we don't rely on formatting and ordering of the `package.yaml` and `package-default.yaml` files anymore.

I needed these changes to [make the script work in `saml-web-sso`](https://github.com/wireapp/saml2-web-sso/pull/59), now I'm just backporting them.