### PR TITLE
Update types of some brig endpoints to be federation-aware

### DIFF
--- a/libs/brig-types/src/Brig/Types/Client/Prekey.hs
+++ b/libs/brig-types/src/Brig/Types/Client/Prekey.hs
@@ -31,7 +31,7 @@ data Prekey
 
 data PrekeyBundle
   = PrekeyBundle
-      { prekeyUser :: !UserId,
+      { prekeyUser :: !OpaqueUserId,
         prekeyClients :: ![ClientPrekey]
       }
   deriving (Eq, Show, Generic)

--- a/libs/brig-types/src/Brig/Types/Connection.hs
+++ b/libs/brig-types/src/Brig/Types/Connection.hs
@@ -64,7 +64,7 @@ data UserConnection
 data ConnectionRequest
   = ConnectionRequest
       { -- | Connection recipient
-        crUser :: !UserId,
+        crUser :: !OpaqueUserId,
         -- | Name of the conversation to be created
         crName :: !Text,
         -- | Initial message

--- a/libs/types-common/package.yaml
+++ b/libs/types-common/package.yaml
@@ -29,7 +29,6 @@ library:
   - data-default >=0.5
   - deepseq >=1.4
   - directory >=1.2
-  - email-validate >=2.3
   - errors >=2.0
   - ghc-prim
   - hashable >=1.2

--- a/libs/types-common/package.yaml
+++ b/libs/types-common/package.yaml
@@ -77,6 +77,7 @@ tests:
     - bytestring-conversion
     - protobuf
     - QuickCheck
+    - string-conversions
     - tasty
     - tasty-hunit
     - tasty-quickcheck

--- a/libs/types-common/src/Data/Domain.hs
+++ b/libs/types-common/src/Data/Domain.hs
@@ -16,8 +16,11 @@ import qualified Test.QuickCheck as QC
 -- | Following [RFC-1035](https://www.ietf.org/rfc/rfc1035.txt), Section 2.3.1,
 -- except for:
 -- * not allowing a space @" "@
--- * accepting digits as the first letter of labels (except for the last label)
--- * not only must labels be 63 characters or less, the whole domain be 255 characters or less
+-- * TODO accepting digits as the first letter of labels (except for the last label)
+-- * TODO requiring at least two labels
+-- * not only must labels be 63 characters or less, the whole domain must be 253 characters or less
+--
+-- TODO: rename to Fqdn
 --
 -- <domain> ::= <label> | <domain> "." <label>
 -- <label> ::= <let-dig> [ [ <ldh-str> ] <let-dig> ]
@@ -28,7 +31,7 @@ import qualified Test.QuickCheck as QC
 -- upper case and a through z in lower case
 -- <digit> ::= any one of the ten digits 0 through 9
 --
--- All letters will be lowercased when parsed.
+-- The domain will be normalized to lowercase when parsed.
 newtype Domain
   = Domain {_domainText :: Text}
   deriving (Eq, Generic, Show)

--- a/libs/types-common/src/Data/Domain.hs
+++ b/libs/types-common/src/Data/Domain.hs
@@ -37,7 +37,7 @@ domainText :: Domain -> Text
 domainText = _domainText
 
 mkDomain :: Text -> Either String Domain
-mkDomain = Atto.parseOnly domainParser . Text.E.encodeUtf8
+mkDomain = Atto.parseOnly (domainParser <* Atto.endOfInput) . Text.E.encodeUtf8
 
 instance FromByteString Domain where
   parser = domainParser

--- a/libs/types-common/src/Data/Domain.hs
+++ b/libs/types-common/src/Data/Domain.hs
@@ -2,13 +2,15 @@ module Data.Domain where
 
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON))
 import qualified Data.Aeson as Aeson
-import qualified Data.Attoparsec.ByteString as Atto
-import Data.Bifunctor (bimap, first)
+import qualified Data.Attoparsec.ByteString.Char8 as Atto
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS.Char8
 import Data.ByteString.Conversion
+import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text.E
 import Imports
-import Test.QuickCheck (Arbitrary (arbitrary), elements)
-import qualified Text.Email.Validate as Email
+import Test.QuickCheck (Arbitrary (arbitrary))
+import qualified Test.QuickCheck as QC
 
 -- | FUTUREWORK: move this type upstream into the email-validate package?
 -- or become independent of email validation.
@@ -20,20 +22,32 @@ domainText :: Domain -> Text
 domainText = _domainText
 
 mkDomain :: Text -> Either String Domain
-mkDomain =
-  bimap show Domain . Text.E.decodeUtf8'
-    <=< validateDomain . Text.E.encodeUtf8
-  where
-    -- this is a slightly hacky way of validating a domain,
-    -- but Text.Email.Validate doesn't expose the parser for the domain.
-    validateDomain = fmap Email.domainPart . Email.validate . ("local-part@" <>)
+mkDomain = Atto.parseOnly domainParser . Text.E.encodeUtf8
 
 instance FromByteString Domain where
-  parser = do
-    bs <- Atto.takeByteString
-    case mkDomain =<< first show (Text.E.decodeUtf8' bs) of
-      Left err -> fail ("Failed parsing ByteString as Domain: " <> err)
-      Right domain -> pure domain
+  parser = domainParser
+
+domainParser :: Atto.Parser Domain
+domainParser = do
+  parts <- domainLabel `Atto.sepBy1` Atto.char '.'
+  let bs = BS.intercalate "." parts
+  when (BS.length bs > 253) $
+    fail "Invalid domain: too long"
+  case Text.E.decodeUtf8' bs of
+    Left err -> fail $ "Invalid UTF-8 in Domain: " <> show err
+    Right txt -> pure $ Domain txt
+  where
+    domainLabel :: Atto.Parser ByteString
+    domainLabel = do
+      match <- matching (Atto.satisfy alphaNum *> Atto.skipWhile alphaNumHyphen)
+      when (BS.length match > 63 || BS.Char8.last match == '-') $
+        fail "Invalid domain label"
+      pure match
+    matching = fmap fst . Atto.match
+    -- TODO: we don't accept capital letters here.
+    -- we probably should, but need to normalize them?
+    alphaNum = Atto.inClass "a-z0-9"
+    alphaNumHyphen = Atto.inClass "a-z0-9-"
 
 instance ToJSON Domain where
   toJSON = Aeson.String . domainText
@@ -43,12 +57,22 @@ instance FromJSON Domain where
 
 instance Arbitrary Domain where
   arbitrary =
-    either (error "arbitrary @Domain") id . mkDomain
-      <$> elements
-        [ "example.com",
-          "beispiel.com"
-          -- unicode domains are not supported, sadly:
-          -- "例.com",
-          -- "مثال.com",
-          -- "dæmi.com"
-        ]
+    either (error . ("arbitrary @Domain: " <>)) id . mkDomain . Text.intercalate "."
+      <$> count 1 4 arbitraryDomainLabel
+    where
+      arbitraryDomainLabel = do
+        a <- alphaNum
+        b <- Text.pack <$> count 0 61 alphaNumHypen
+        c <- alphaNum
+        pure (a `Text.cons` b `Text.snoc` c)
+      -- unicode domains are not supported, sadly:
+      -- "例.com",
+      -- "مثال.com",
+      -- "dæmi.com"
+      alphaNum =
+        QC.elements $ ['a' .. 'z'] <> ['0' .. '9']
+      alphaNumHypen =
+        QC.elements $ ['a' .. 'z'] <> ['0' .. '9'] <> "-"
+      count x y gen = do
+        n <- QC.choose (x, y)
+        replicateM n gen

--- a/libs/types-common/src/Data/Domain.hs
+++ b/libs/types-common/src/Data/Domain.hs
@@ -26,6 +26,8 @@ import qualified Test.QuickCheck as QC
 -- <letter> ::= any one of the 52 alphabetic characters A through Z in
 -- upper case and a through z in lower case
 -- <digit> ::= any one of the ten digits 0 through 9
+--
+-- All letters will be lowercased when parsed.
 newtype Domain
   = Domain {_domainText :: Text}
   deriving (Eq, Generic, Show)
@@ -47,7 +49,7 @@ domainParser = do
     fail "Invalid domain: too long"
   case Text.E.decodeUtf8' bs of
     Left err -> fail $ "Invalid UTF-8 in Domain: " <> show err
-    Right txt -> pure $ Domain txt
+    Right txt -> pure . Domain $ Text.toCaseFold txt
   where
     domainLabel :: Atto.Parser ByteString
     domainLabel = do
@@ -56,10 +58,8 @@ domainParser = do
         fail "Invalid domain label"
       pure match
     matching = fmap fst . Atto.match
-    -- TODO: we don't accept capital letters here.
-    -- we probably should, but need to normalize them?
-    alphaNum = Atto.inClass "a-z0-9"
-    alphaNumHyphen = Atto.inClass "a-z0-9-"
+    alphaNum = Atto.inClass "A-Za-z0-9"
+    alphaNumHyphen = Atto.inClass "A-Za-z0-9-"
 
 instance ToJSON Domain where
   toJSON = Aeson.String . domainText

--- a/libs/types-common/src/Data/Handle.hs
+++ b/libs/types-common/src/Data/Handle.hs
@@ -1,7 +1,13 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Data.Handle where
+module Data.Handle
+  ( Handle (..),
+    parseHandle,
+    parseHandleEither,
+    isValidHandle,
+  )
+where
 
 import Data.Aeson hiding ((<?>))
 import Data.Attoparsec.ByteString ((<?>))

--- a/libs/types-common/src/Data/Handle.hs
+++ b/libs/types-common/src/Data/Handle.hs
@@ -5,12 +5,13 @@ module Data.Handle where
 
 import Control.Applicative (optional)
 import Data.Aeson hiding ((<?>))
-import Data.Attoparsec.Text
+import qualified Data.Attoparsec.ByteString.Char8 as Atto
 import Data.ByteString.Conversion
 import Data.Hashable (Hashable)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text.E
 import Imports
-import Test.QuickCheck (Arbitrary (arbitrary), choose, elements)
+import Test.QuickCheck (Arbitrary (arbitrary), choose, elements, oneof)
 
 --------------------------------------------------------------------------------
 -- Handle
@@ -22,28 +23,29 @@ newtype Handle
   deriving stock (Eq, Show, Generic)
   deriving newtype (ToJSON, ToByteString, Hashable)
 
-instance FromByteString Handle where
-  parser = parser >>= maybe (fail "Invalid handle") return . parseHandle
+parseHandle :: Text -> Maybe Handle
+parseHandle = either (const Nothing) Just . parseHandleEither
+
+parseHandleEither :: Text -> Either String Handle
+parseHandleEither = Atto.parseOnly handleParser . Text.E.encodeUtf8
+
+isValidHandle :: Text -> Bool
+isValidHandle = maybe False (const True) . parseHandle
 
 instance FromJSON Handle where
   parseJSON =
     withText "Handle" $
       maybe (fail "Invalid handle") pure . parseHandle
 
-parseHandle :: Text -> Maybe Handle
-parseHandle t
-  | isValidHandle t = Just (Handle t)
-  | otherwise = Nothing
+instance FromByteString Handle where
+  parser = handleParser
 
-isValidHandle :: Text -> Bool
-isValidHandle t =
-  either (const False) (const True) $
-    parseOnly handle t
+handleParser :: Atto.Parser Handle
+handleParser = do
+  start <- Atto.count 2 handleChar
+  rest <- catMaybes <$> Atto.count 254 (optional handleChar)
+  pure . Handle . Text.pack $ start <> rest
   where
-    handle =
-      count 2 (satisfy chars)
-        *> count 254 (optional (satisfy chars))
-        *> endOfInput
     -- NOTE: Ensure that characters such as `@` and `+` should _NOT_
     -- be used so that "phone numbers", "emails", and "handles" remain
     -- disjoint sets.
@@ -51,9 +53,9 @@ isValidHandle t =
     -- an email address as defined here:
     -- http://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
     -- with the intent that in the enterprise world handle =~ email address
-    chars = inClass "a-z0-9_.-"
+    handleChar = Atto.satisfy (Atto.inClass "a-z0-9_.-")
 
 instance Arbitrary Handle where
   arbitrary = Handle . Text.pack <$> do
-    let many n = replicateM n (elements $ ['a' .. 'z'] <> ['0' .. '9'] <> ['_'] <> ['-'] <> ['.'])
-    ((<>) <$> many 2 <*> (many =<< choose (0, 254)))
+    len <- oneof [choose (2, 10), choose (2, 256)] -- prefer short handles
+    replicateM len (elements $ ['a' .. 'z'] <> ['0' .. '9'] <> "_-.")

--- a/libs/types-common/src/Data/Handle.hs
+++ b/libs/types-common/src/Data/Handle.hs
@@ -30,22 +30,22 @@ newtype Handle
   deriving stock (Eq, Show, Generic)
   deriving newtype (ToJSON, ToByteString, Hashable)
 
-parseHandle :: Text -> Maybe Handle
-parseHandle = either (const Nothing) Just . parseHandleEither
-
-parseHandleEither :: Text -> Either String Handle
-parseHandleEither = Atto.parseOnly (handleParser <* Atto.endOfInput) . Text.E.encodeUtf8
-
-isValidHandle :: Text -> Bool
-isValidHandle = isRight . parseHandleEither
+instance FromByteString Handle where
+  parser = handleParser
 
 instance FromJSON Handle where
   parseJSON =
     withText "Handle" $
-      maybe (fail "Invalid handle") pure . parseHandle
+      either (fail . ("Invalid handle: " <>)) pure . parseHandleEither
 
-instance FromByteString Handle where
-  parser = handleParser
+parseHandle :: Text -> Maybe Handle
+parseHandle = either (const Nothing) Just . parseHandleEither
+
+isValidHandle :: Text -> Bool
+isValidHandle = isRight . parseHandleEither
+
+parseHandleEither :: Text -> Either String Handle
+parseHandleEither = Atto.parseOnly (handleParser <* Atto.endOfInput) . Text.E.encodeUtf8
 
 handleParser :: Atto.Parser Handle
 handleParser = do

--- a/libs/types-common/src/Data/Handle.hs
+++ b/libs/types-common/src/Data/Handle.hs
@@ -34,10 +34,10 @@ parseHandle :: Text -> Maybe Handle
 parseHandle = either (const Nothing) Just . parseHandleEither
 
 parseHandleEither :: Text -> Either String Handle
-parseHandleEither = Atto.parseOnly handleParser . Text.E.encodeUtf8
+parseHandleEither = Atto.parseOnly (handleParser <* Atto.endOfInput) . Text.E.encodeUtf8
 
 isValidHandle :: Text -> Bool
-isValidHandle = maybe False (const True) . parseHandle
+isValidHandle = isRight . parseHandleEither
 
 instance FromJSON Handle where
   parseJSON =

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -8,9 +8,10 @@
 module Data.Id where
 
 import Cassandra hiding (S)
-import Data.Aeson
+import Data.Aeson hiding ((<?>))
 import Data.Aeson.Encoding (text)
 import Data.Aeson.Types (Parser)
+import Data.Attoparsec.ByteString ((<?>))
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
 import Data.ByteString.Builder (byteString)
 import Data.ByteString.Conversion
@@ -123,17 +124,17 @@ instance FromByteString (Id a) where
     x <-
       -- we only want the matching ByteString
       matching $ do
-        () <$ Atto.count 8 hexDigit <* Atto.char '-'
-        () <$ Atto.count 4 hexDigit <* Atto.char '-'
-        () <$ Atto.count 4 hexDigit <* Atto.char '-'
-        () <$ Atto.count 4 hexDigit <* Atto.char '-'
-        () <$ Atto.count 12 hexDigit
+        void $ Atto.count 8 hexDigit <* Atto.char '-'
+        void $ Atto.count 4 hexDigit <* Atto.char '-'
+        void $ Atto.count 4 hexDigit <* Atto.char '-'
+        void $ Atto.count 4 hexDigit <* Atto.char '-'
+        void $ Atto.count 12 hexDigit
     case UUID.fromASCIIBytes x of
       Nothing -> fail "Invalid UUID"
       Just ui -> return (Id ui)
     where
       matching = fmap fst . Atto.match
-      hexDigit = Atto.satisfy Char.isHexDigit
+      hexDigit = Atto.satisfy Char.isHexDigit <?> "hexadecimal digit"
 
 instance ToByteString (Id a) where
   builder = byteString . UUID.toASCIIBytes . toUUID

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -121,15 +121,17 @@ instance Read (Id a) where
 
 instance FromByteString (Id a) where
   parser = do
-    x <-
-      -- we only want the matching ByteString
+    match <-
+      -- we only want the matching part of the ByteString, so the parser doesn't
+      -- consume additional input.
+      -- This allows the parser to be composed.
       matching $ do
         void $ Atto.count 8 hexDigit <* Atto.char '-'
         void $ Atto.count 4 hexDigit <* Atto.char '-'
         void $ Atto.count 4 hexDigit <* Atto.char '-'
         void $ Atto.count 4 hexDigit <* Atto.char '-'
         void $ Atto.count 12 hexDigit
-    case UUID.fromASCIIBytes x of
+    case UUID.fromASCIIBytes match of
       Nothing -> fail "Invalid UUID"
       Just ui -> return (Id ui)
     where

--- a/libs/types-common/src/Data/IdMapping.hs
+++ b/libs/types-common/src/Data/IdMapping.hs
@@ -17,6 +17,11 @@ opaqueIdFromMappedOrLocal = \case
   Local localId -> makeIdOpaque localId
   Mapped IdMapping {idMappingLocal} -> makeMappedIdOpaque idMappingLocal
 
+partitionMappedOrLocalIds :: Foldable f => f (MappedOrLocalId a) -> ([Id a], [IdMapping a])
+partitionMappedOrLocalIds = foldMap $ \case
+  Mapped mapping -> (mempty, [mapping])
+  Local localId -> ([localId], mempty)
+
 data IdMapping a
   = IdMapping
       { idMappingLocal :: Id (Mapped a),

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -21,7 +21,6 @@ import Data.Aeson (FromJSON, ToJSON, withText)
 import qualified Data.Aeson as Aeson
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
 import Data.Bifunctor (first)
-import qualified Data.ByteString.Conversion as BS.C
 import Data.ByteString.Conversion (FromByteString (parser))
 import Data.Domain (Domain, domainText)
 import Data.Handle (Handle (..))
@@ -94,7 +93,7 @@ renderQualifiedId :: Qualified (Id a) -> Text
 renderQualifiedId = renderQualified (cs . UUID.toString . toUUID)
 
 mkQualifiedId :: Text -> Either String (Qualified (Id a))
-mkQualifiedId = Atto.parseOnly (BS.C.parser <* Atto.endOfInput) . Text.E.encodeUtf8
+mkQualifiedId = Atto.parseOnly (parser <* Atto.endOfInput) . Text.E.encodeUtf8
 
 instance ToJSON (Qualified (Id a)) where
   toJSON = Aeson.String . renderQualifiedId
@@ -106,7 +105,7 @@ instance FromHttpApiData (Qualified (Id a)) where
   parseUrlPiece = first cs . mkQualifiedId
 
 instance FromByteString (Qualified (Id a)) where
-  parser = qualifiedParser BS.C.parser
+  parser = qualifiedParser parser
 
 ----------------------------------------------------------------------
 
@@ -114,7 +113,7 @@ renderQualifiedHandle :: Qualified Handle -> Text
 renderQualifiedHandle = renderQualified fromHandle
 
 mkQualifiedHandle :: Text -> Either String (Qualified Handle)
-mkQualifiedHandle = Atto.parseOnly (BS.C.parser <* Atto.endOfInput) . Text.E.encodeUtf8
+mkQualifiedHandle = Atto.parseOnly (parser <* Atto.endOfInput) . Text.E.encodeUtf8
 
 instance ToJSON (Qualified Handle) where
   toJSON = Aeson.String . renderQualifiedHandle
@@ -126,7 +125,7 @@ instance FromHttpApiData (Qualified Handle) where
   parseUrlPiece = first cs . mkQualifiedHandle
 
 instance FromByteString (Qualified Handle) where
-  parser = qualifiedParser BS.C.parser
+  parser = qualifiedParser parser
 
 ----------------------------------------------------------------------
 -- ARBITRARY

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -1,6 +1,20 @@
 {-# LANGUAGE StrictData #-}
 
-module Data.Qualified where
+module Data.Qualified
+  ( -- * Optionally qualified
+    OptionallyQualified (..),
+    unqualified,
+    qualified,
+    eitherQualifiedOrNot,
+
+    -- * Qualified
+    Qualified (..),
+    renderQualifiedId,
+    mkQualifiedId,
+    renderQualifiedHandle,
+    mkQualifiedHandle,
+  )
+where
 
 import Control.Applicative (optional)
 import Data.Aeson (FromJSON, ToJSON, withText)

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -4,17 +4,52 @@ module Data.Qualified where
 
 import Data.Aeson (FromJSON, ToJSON, withText)
 import qualified Data.Aeson as Aeson
+import Data.Attoparsec.ByteString (takeByteString)
 import Data.Bifunctor (first)
 import qualified Data.ByteString.Conversion as BS.C
+import Data.ByteString.Conversion (FromByteString (parser))
 import Data.Domain (Domain, domainText, mkDomain)
 import Data.Handle (Handle (..))
 import Data.Id (Id (toUUID))
 import Data.String.Conversions (cs)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text.E
 import qualified Data.UUID as UUID
 import Imports hiding (local)
 import Servant.API (FromHttpApiData (parseUrlPiece))
 import Test.QuickCheck (Arbitrary (arbitrary))
+
+----------------------------------------------------------------------
+-- OPTIONALLY QUALIFIED
+
+type OptionallyQualified a = Either a (Qualified a)
+
+unqualified :: a -> OptionallyQualified a
+unqualified = Left
+
+qualified :: Qualified a -> OptionallyQualified a
+qualified = Right
+
+{-
+Either is a hack, conceptually we want this:
+
+data OptionallyQualified a
+  = OptionallyQualified
+      { _oqLocalPart :: a,
+        _oqDomain :: Maybe Domain
+      }
+-}
+
+-- OptionallyQualified (Id a)
+instance FromByteString (Either (Id a) (Qualified (Id a))) where
+  parser = asum [Left <$> parser, Right <$> parser]
+
+-- OptionallyQualified Handle
+instance FromByteString (Either Handle (Qualified Handle)) where
+  parser = asum [Left <$> parser, Right <$> parser]
+
+----------------------------------------------------------------------
+-- QUALIFIED
 
 data Qualified a
   = Qualified
@@ -56,6 +91,15 @@ instance FromJSON (Qualified (Id a)) where
 instance FromHttpApiData (Qualified (Id a)) where
   parseUrlPiece = first cs . mkQualifiedId
 
+instance FromByteString (Qualified (Id a)) where
+  parser = do
+    bs <- takeByteString
+    case makeFromByteString bs of
+      Left err -> fail err
+      Right qi -> pure qi
+    where
+      makeFromByteString = mkQualifiedId <=< first show . Text.E.decodeUtf8'
+
 renderQualifiedHandle :: Qualified Handle -> Text
 renderQualifiedHandle = renderQualified fromHandle
 
@@ -70,6 +114,15 @@ instance FromJSON (Qualified Handle) where
 
 instance FromHttpApiData (Qualified Handle) where
   parseUrlPiece = first cs . mkQualifiedHandle
+
+instance FromByteString (Qualified Handle) where
+  parser = do
+    bs <- takeByteString
+    case makeFromByteString bs of
+      Left err -> fail err
+      Right qi -> pure qi
+    where
+      makeFromByteString = mkQualifiedHandle <=< first show . Text.E.decodeUtf8'
 
 ----------------------------------------------------------------------
 -- ARBITRARY

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -94,7 +94,7 @@ renderQualifiedId :: Qualified (Id a) -> Text
 renderQualifiedId = renderQualified (cs . UUID.toString . toUUID)
 
 mkQualifiedId :: Text -> Either String (Qualified (Id a))
-mkQualifiedId = Atto.parseOnly BS.C.parser . Text.E.encodeUtf8
+mkQualifiedId = Atto.parseOnly (BS.C.parser <* Atto.endOfInput) . Text.E.encodeUtf8
 
 instance ToJSON (Qualified (Id a)) where
   toJSON = Aeson.String . renderQualifiedId
@@ -114,7 +114,7 @@ renderQualifiedHandle :: Qualified Handle -> Text
 renderQualifiedHandle = renderQualified fromHandle
 
 mkQualifiedHandle :: Text -> Either String (Qualified Handle)
-mkQualifiedHandle = Atto.parseOnly BS.C.parser . Text.E.encodeUtf8
+mkQualifiedHandle = Atto.parseOnly (BS.C.parser <* Atto.endOfInput) . Text.E.encodeUtf8
 
 instance ToJSON (Qualified Handle) where
   toJSON = Aeson.String . renderQualifiedHandle

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -59,7 +59,6 @@ instance FromByteString (OptionallyQualified Handle) where
 ----------------------------------------------------------------------
 -- QUALIFIED
 
--- TODO: how do we deal with IPs?
 data Qualified a
   = Qualified
       { _qLocalPart :: a,

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -31,6 +31,7 @@ qualified :: Qualified a -> OptionallyQualified a
 qualified = Right
 
 {-
+TODO: do it properly
 Either is a hack, conceptually we want this:
 
 data OptionallyQualified a

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -59,6 +59,7 @@ instance FromByteString (OptionallyQualified Handle) where
 ----------------------------------------------------------------------
 -- QUALIFIED
 
+-- TODO: how do we deal with IPs?
 data Qualified a
   = Qualified
       { _qLocalPart :: a,

--- a/libs/types-common/src/Util/Attoparsec.hs
+++ b/libs/types-common/src/Util/Attoparsec.hs
@@ -1,0 +1,11 @@
+module Util.Attoparsec where
+
+import qualified Data.Attoparsec.ByteString.Char8 as Atto
+import Imports
+
+takeUpToWhile :: Int -> (Char -> Bool) -> Atto.Parser ByteString
+takeUpToWhile maxCount predicate =
+  Atto.scan maxCount $ \count char -> do
+    guard (count > 0)
+    guard (predicate char)
+    Just (count - 1)

--- a/libs/types-common/test/Main.hs
+++ b/libs/types-common/test/Main.hs
@@ -1,6 +1,8 @@
 module Main (main) where
 
 import Imports
+import qualified Test.Domain as Domain
+import qualified Test.Handle as Handle
 import qualified Test.Properties as Properties
 import qualified Test.Qualified as Qualified
 import qualified Test.SizedHashMap as SizedHashMap
@@ -13,5 +15,7 @@ main =
       "Tests"
       [ Properties.tests,
         SizedHashMap.tests,
+        Domain.tests,
+        Handle.tests,
         Qualified.tests
       ]

--- a/libs/types-common/test/Test/Domain.hs
+++ b/libs/types-common/test/Test/Domain.hs
@@ -1,0 +1,27 @@
+module Test.Domain
+  ( tests,
+  )
+where
+
+import Data.Domain (DomainText (DomainText), domainText, mkDomain)
+import qualified Data.Text as Text
+import Imports
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests =
+  testGroup
+    "Domain"
+    [ testGroup "serialization" testDomainSerialization
+    ]
+
+testDomainSerialization :: [TestTree]
+testDomainSerialization =
+  [ testProperty "Arbitrary DomainText generates valid domains" $
+      \(DomainText x) ->
+        isRight $ mkDomain x,
+    testProperty "parsing a domain normalizes it" $
+      \(DomainText x) ->
+        (domainText <$> mkDomain x) === Right (Text.toCaseFold x)
+  ]

--- a/libs/types-common/test/Test/Domain.hs
+++ b/libs/types-common/test/Test/Domain.hs
@@ -7,6 +7,7 @@ import Data.Domain (DomainText (DomainText), domainText, mkDomain)
 import qualified Data.Text as Text
 import Imports
 import Test.Tasty
+import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 
 tests :: TestTree
@@ -18,7 +19,38 @@ tests =
 
 testDomainSerialization :: [TestTree]
 testDomainSerialization =
-  [ testProperty "Arbitrary DomainText generates valid domains" $
+  [ testCase "parses some example domains" $ do
+      let validDomains =
+            [ "wire.com",
+              "some.long.example.with.lots.of.labels.com",
+              "multiple-------dashes.co.uk",
+              "0123456789.abcdefghijklmnopqrstuvwxyz.ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+              "Domain-with-dashes-and-Uppercase.Even-in-TLD",
+              "1.1.1.g1", -- just TLD can't start with digit
+              Text.replicate 63 "x" <> ".foo",
+              Text.intercalate "." (replicate 127 "h") -- 253 chars
+            ]
+      for_ validDomains $ \d ->
+        case mkDomain d of
+          Right _ -> pure ()
+          Left err -> assertFailure $ "valid domain " <> show d <> " not parsed successfully: " <> err,
+    testCase "rejects invalid domains" $ do
+      let invalidDomains =
+            [ "dotless-domain",
+              "label.starting.with.-dash.com",
+              "label.ending.with.dash-.com",
+              "exämple.com",
+              "(comment)domain.com",
+              "[1.1.1.1]", -- bracketed IP
+              "192.168.1.65", -- IP
+              Text.replicate 64 "x" <> ".foo",
+              Text.intercalate "." (replicate 128 "h") -- 255 chars
+            ]
+      for_ invalidDomains $ \h ->
+        case mkDomain h of
+          Left _ -> pure ()
+          Right parsed -> assertFailure $ "invalid domain parsed successfully: " <> show (h, parsed),
+    testProperty "Arbitrary DomainText generates valid domains" $
       \(DomainText x) ->
         isRight $ mkDomain x,
     testProperty "parsing a domain normalizes it" $

--- a/libs/types-common/test/Test/Handle.hs
+++ b/libs/types-common/test/Test/Handle.hs
@@ -1,0 +1,47 @@
+module Test.Handle
+  ( tests,
+  )
+where
+
+import Data.Handle (Handle (fromHandle), parseHandleEither)
+import qualified Data.Text as Text
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests =
+  testGroup
+    "Handle"
+    [ testGroup "serialization" testHandleSerialization
+    ]
+
+testHandleSerialization :: [TestTree]
+testHandleSerialization =
+  [ testCase "parses some example handles" $ do
+      let validHandles = ["handle", "--", "__", "..", "0123456789", Text.replicate 256 "a"]
+      for_ validHandles $ \h ->
+        case parseHandleEither h of
+          Right _ -> pure ()
+          Left err -> assertFailure $ "valid handle " <> show h <> " not parsed successfully: " <> err,
+    testCase "rejects invalid handles" $ do
+      let invalidHandles =
+            [ "h", -- too short
+              Text.replicate 257 "a", -- too long
+              "myhändle",
+              "myhàndle",
+              "myh@ndle",
+              "$pecial",
+              "some+name",
+              "upperCase",
+              "with space"
+            ]
+      for_ invalidHandles $ \h ->
+        case parseHandleEither h of
+          Left _ -> pure ()
+          Right parsed -> assertFailure $ "invalid handle parsed successfully: " <> show (h, parsed),
+    testProperty "roundtrip for Handle" $
+      \(x :: Handle) ->
+        parseHandleEither (fromHandle x) === Right x
+  ]

--- a/libs/types-common/test/Test/Handle.hs
+++ b/libs/types-common/test/Test/Handle.hs
@@ -20,7 +20,14 @@ tests =
 testHandleSerialization :: [TestTree]
 testHandleSerialization =
   [ testCase "parses some example handles" $ do
-      let validHandles = ["handle", "--", "__", "..", "0123456789", Text.replicate 256 "a"]
+      let validHandles =
+            [ "handle",
+              Text.replicate 256 "a",
+              "--",
+              "__",
+              "..",
+              "0123456789"
+            ]
       for_ validHandles $ \h ->
         case parseHandleEither h of
           Right _ -> pure ()

--- a/libs/types-common/test/Test/Qualified.hs
+++ b/libs/types-common/test/Test/Qualified.hs
@@ -6,11 +6,12 @@ where
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON))
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString.Conversion as BS.C
-import Data.Domain (Domain (Domain))
+import Data.Domain (Domain (Domain), DomainText (DomainText), domainText, mkDomain)
 import Data.Handle (Handle (Handle, fromHandle))
 import Data.Id (Id (Id, toUUID), UserId)
 import Data.Qualified (OptionallyQualified, Qualified (Qualified), eitherQualifiedOrNot, mkQualifiedHandle, mkQualifiedId, renderQualifiedHandle, renderQualifiedId)
 import Data.String.Conversions (cs)
+import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text.E
 import qualified Data.UUID as UUID
 import Imports
@@ -23,37 +24,55 @@ tests :: TestTree
 tests =
   testGroup
     "Qualified"
-    [ testGroup
-        "serialization"
-        [ testCase "render foo@bar.com" $ do
-            assertEqual "" "foo@bar.com" $
-              (renderQualifiedHandle (Qualified (Handle "foo") (Domain "bar.com"))),
-          testCase "render 61a73a52-e526-4892-82a9-3d638d77629f@example.com" $ do
-            uuid <-
-              maybe (assertFailure "invalid UUID") pure $
-                UUID.fromString "61a73a52-e526-4892-82a9-3d638d77629f"
-            assertEqual "" "61a73a52-e526-4892-82a9-3d638d77629f@example.com" $
-              (renderQualifiedId (Qualified (Id uuid) (Domain "example.com"))),
-          testProperty "mkQualifiedHandle (renderQualifiedHandle x) == Right x" $
-            \(x :: Qualified Handle) ->
-              mkQualifiedHandle (renderQualifiedHandle x) === Right x,
-          testProperty "mkQualifiedId (renderQualifiedId x) == Right x" $
-            \(x :: Qualified UserId) ->
-              mkQualifiedId (renderQualifiedId x) === Right x,
-          testProperty "roundtrip for OptionallyQualified Handle" $
-            \(x :: OptionallyQualified Handle) -> do
-              let render = Text.E.encodeUtf8 . either fromHandle renderQualifiedHandle . eitherQualifiedOrNot
-              let parse = BS.C.runParser BS.C.parser
-              parse (render x) === Right x,
-          testProperty "roundtrip for OptionallyQualified UserId" $
-            \(x :: OptionallyQualified UserId) -> do
-              let render = Text.E.encodeUtf8 . either (cs . UUID.toString . toUUID) renderQualifiedId . eitherQualifiedOrNot
-              let parse = BS.C.runParser BS.C.parser
-              parse (render x) === Right x,
-          jsonRoundtrip @(Qualified Handle),
-          jsonRoundtrip @(Qualified UserId)
-        ]
+    [ testGroup "Domain" testDomain,
+      testGroup "Qualified" testQualified
     ]
+
+testDomain :: [TestTree]
+testDomain =
+  [ testProperty "Arbitrary DomainText generates valid domains" $
+      \(DomainText x) ->
+        isRight $ mkDomain x,
+    testProperty "parsing a domain normalizes it" $
+      \(DomainText x) ->
+        (domainText <$> mkDomain x) === Right (Text.toCaseFold x)
+  ]
+
+testQualified :: [TestTree]
+testQualified =
+  [ testGroup "serialization" testQualifiedSerialization
+  ]
+
+testQualifiedSerialization :: [TestTree]
+testQualifiedSerialization =
+  [ testCase "render foo@bar.com" $ do
+      assertEqual "" "foo@bar.com" $
+        (renderQualifiedHandle (Qualified (Handle "foo") (Domain "bar.com"))),
+    testCase "render 61a73a52-e526-4892-82a9-3d638d77629f@example.com" $ do
+      uuid <-
+        maybe (assertFailure "invalid UUID") pure $
+          UUID.fromString "61a73a52-e526-4892-82a9-3d638d77629f"
+      assertEqual "" "61a73a52-e526-4892-82a9-3d638d77629f@example.com" $
+        (renderQualifiedId (Qualified (Id uuid) (Domain "example.com"))),
+    testProperty "roundtrip for Qualified Handle" $
+      \(x :: Qualified Handle) ->
+        mkQualifiedHandle (renderQualifiedHandle x) === Right x,
+    testProperty "roundtrip for Qualified UserId" $
+      \(x :: Qualified UserId) ->
+        mkQualifiedId (renderQualifiedId x) === Right x,
+    testProperty "roundtrip for OptionallyQualified Handle" $
+      \(x :: OptionallyQualified Handle) -> do
+        let render = Text.E.encodeUtf8 . either fromHandle renderQualifiedHandle . eitherQualifiedOrNot
+        let parse = BS.C.runParser BS.C.parser
+        parse (render x) === Right x,
+    testProperty "roundtrip for OptionallyQualified UserId" $
+      \(x :: OptionallyQualified UserId) -> do
+        let render = Text.E.encodeUtf8 . either (cs . UUID.toString . toUUID) renderQualifiedId . eitherQualifiedOrNot
+        let parse = BS.C.runParser BS.C.parser
+        parse (render x) === Right x,
+    jsonRoundtrip @(Qualified Handle),
+    jsonRoundtrip @(Qualified UserId)
+  ]
 
 jsonRoundtrip ::
   forall a.

--- a/libs/types-common/test/Test/Qualified.hs
+++ b/libs/types-common/test/Test/Qualified.hs
@@ -9,7 +9,7 @@ import qualified Data.ByteString.Conversion as BS.C
 import Data.Domain (Domain (Domain))
 import Data.Handle (Handle (Handle, fromHandle))
 import Data.Id (Id (Id, toUUID), UserId)
-import Data.Qualified (OptionallyQualified, Qualified (Qualified), mkQualifiedHandle, mkQualifiedId, renderQualifiedHandle, renderQualifiedId)
+import Data.Qualified (OptionallyQualified, Qualified (Qualified), eitherQualifiedOrNot, mkQualifiedHandle, mkQualifiedId, renderQualifiedHandle, renderQualifiedId)
 import Data.String.Conversions (cs)
 import qualified Data.Text.Encoding as Text.E
 import qualified Data.UUID as UUID
@@ -42,12 +42,12 @@ tests =
               mkQualifiedId (renderQualifiedId x) === Right x,
           testProperty "roundtrip for OptionallyQualified Handle" $
             \(x :: OptionallyQualified Handle) -> do
-              let render = Text.E.encodeUtf8 . either fromHandle renderQualifiedHandle
+              let render = Text.E.encodeUtf8 . either fromHandle renderQualifiedHandle . eitherQualifiedOrNot
               let parse = BS.C.runParser BS.C.parser
               parse (render x) === Right x,
           testProperty "roundtrip for OptionallyQualified UserId" $
             \(x :: OptionallyQualified UserId) -> do
-              let render = Text.E.encodeUtf8 . either (cs . UUID.toString . toUUID) renderQualifiedId
+              let render = Text.E.encodeUtf8 . either (cs . UUID.toString . toUUID) renderQualifiedId . eitherQualifiedOrNot
               let parse = BS.C.runParser BS.C.parser
               parse (render x) === Right x,
           jsonRoundtrip @(Qualified Handle),

--- a/libs/types-common/test/Test/Qualified.hs
+++ b/libs/types-common/test/Test/Qualified.hs
@@ -41,9 +41,9 @@ testHandle =
       let invalidHandles =
             [ "h", -- too short
               Text.replicate 257 "a", -- too long
-              "händle",
-              "hàndle",
-              "h@ndle",
+              "myhändle",
+              "myhàndle",
+              "myh@ndle",
               "$pecial",
               "some+name",
               "upperCase",

--- a/libs/types-common/types-common.cabal
+++ b/libs/types-common/types-common.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 484de5870f7e8d34240981855e8f568bb05647325fe2a5fbd26d1912107f0557
+-- hash: 6524c012b9c2b417de7d0c9d6462811a09880449bbac320e48c098532860eb86
 
 name:           types-common
 version:        0.16.0
@@ -35,6 +35,7 @@ library
       Data.SizedHashMap
       Data.Text.Ascii
       Data.UUID.Tagged
+      Util.Attoparsec
       Util.Options
       Util.Options.Common
       Util.Test

--- a/libs/types-common/types-common.cabal
+++ b/libs/types-common/types-common.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.32.0.
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7092aa277e1be77c0621c4f6d0d8f06c53268ae73e283ce08b6033b78e6ab422
+-- hash: 484de5870f7e8d34240981855e8f568bb05647325fe2a5fbd26d1912107f0557
 
 name:           types-common
 version:        0.16.0
@@ -62,7 +62,6 @@ library
     , data-default >=0.5
     , deepseq >=1.4
     , directory >=1.2
-    , email-validate >=2.3
     , errors >=2.0
     , ghc-prim
     , hashable >=1.2
@@ -100,6 +99,8 @@ test-suite tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Test.Domain
+      Test.Handle
       Test.Properties
       Test.Qualified
       Test.SizedHashMap
@@ -119,6 +120,7 @@ test-suite tests
     , cereal
     , imports
     , protobuf
+    , string-conversions
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -43,7 +43,7 @@ import Data.IdMapping (MappedOrLocalId (Local))
 import qualified Data.List1 as List1
 import qualified Data.Map.Strict as Map
 import Data.Misc ((<$$>), IpAddr (..))
-import Data.Qualified (OptionallyQualified)
+import Data.Qualified (OptionallyQualified, eitherQualifiedOrNot)
 import Data.Range
 import qualified Data.Set as Set
 import qualified Data.Swagger.Build.Api as Doc
@@ -1181,7 +1181,7 @@ listUsers self = \case
     getIds :: [OptionallyQualified Handle] -> Handler [MappedOrLocalId Id.U]
     getIds hs = do
       -- we might be able to do something smarter if the domain is our own
-      let (localHandles, _remoteHandles) = partitionEithers hs
+      let (localHandles, _remoteHandles) = partitionEithers (map eitherQualifiedOrNot hs)
       localUsers <- catMaybes <$> traverse (lift . API.lookupHandle) localHandles
       -- FUTUREWORK(federation): resolve remote handles, too
       pure (Local <$> localUsers)

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -129,7 +129,6 @@ claimPrekey u c = case u of
   Local localUser ->
     claimLocalPrekey localUser c
   Mapped _ ->
-    -- TODO: error?
     pure Nothing
 
 claimLocalPrekey :: UserId -> ClientId -> AppIO (Maybe ClientPrekey)
@@ -144,7 +143,6 @@ claimPrekeyBundle = \case
   Local localUser ->
     claimLocalPrekeyBundle localUser
   Mapped IdMapping {idMappingLocal} ->
-    -- TODO: error?
     pure $ PrekeyBundle (makeMappedIdOpaque idMappingLocal) []
 
 claimLocalPrekeyBundle :: UserId -> AppIO PrekeyBundle

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -7,8 +7,8 @@ module Brig.API.Client
     pubClient,
     legalHoldClientRequested,
     removeLegalHoldClient,
-    Data.lookupClient,
-    Data.lookupClients,
+    lookupClient,
+    lookupClients,
     Data.lookupPrekeyIds,
     Data.lookupUsersClientIds,
 
@@ -41,7 +41,7 @@ import Data.Bitraversable (bitraverse)
 import Data.ByteString.Conversion
 import Data.IP (IP)
 import qualified Data.Id as Id
-import Data.Id (ClientId, ConnId, UserId, makeIdOpaque)
+import Data.Id (ClientId, ConnId, UserId, makeIdOpaque, makeMappedIdOpaque)
 import Data.IdMapping
 import Data.List.NonEmpty (nonEmpty)
 import Data.List.Split (chunksOf)
@@ -54,11 +54,34 @@ import System.Logger.Class (field, msg, val, (~~))
 import qualified System.Logger.Class as Log
 import UnliftIO.Async (Concurrently (Concurrently, runConcurrently))
 
+lookupClient :: MappedOrLocalId Id.U -> ClientId -> ExceptT ClientError AppIO (Maybe Client)
+lookupClient mappedOrLocalUserId clientId =
+  case mappedOrLocalUserId of
+    Local u ->
+      lift $ lookupLocalClient u clientId
+    Mapped IdMapping {idMappingLocal} ->
+      -- FUTUREWORK(federation): look up remote clients
+      throwE $ ClientUserNotFound (makeMappedIdOpaque idMappingLocal)
+
+lookupLocalClient :: UserId -> ClientId -> AppIO (Maybe Client)
+lookupLocalClient = Data.lookupClient
+
+lookupClients :: MappedOrLocalId Id.U -> ExceptT ClientError AppIO [Client]
+lookupClients = \case
+  Local u ->
+    lift $ lookupLocalClients u
+  Mapped IdMapping {idMappingLocal} ->
+    -- FUTUREWORK(federation): look up remote clients
+    throwE $ ClientUserNotFound (makeMappedIdOpaque idMappingLocal)
+
+lookupLocalClients :: UserId -> AppIO [Client]
+lookupLocalClients = Data.lookupClients
+
 -- nb. We must ensure that the set of clients known to brig is always
 -- a superset of the clients known to galley.
 addClient :: UserId -> Maybe ConnId -> Maybe IP -> NewClient -> ExceptT ClientError AppIO Client
 addClient u con ip new = do
-  acc <- lift (Data.lookupAccount u) >>= maybe (throwE (ClientUserNotFound u)) return
+  acc <- lift (Data.lookupAccount u) >>= maybe (throwE (ClientUserNotFound (makeIdOpaque u))) return
   loc <- maybe (return Nothing) locationOf ip
   maxPermClients <- fromMaybe Opt.defUserMaxPermClients <$> Opt.setUserMaxPermClients <$> view settings
   (clt, old, count) <- Data.addClient u clientId' new maxPermClients loc !>> ClientDataError
@@ -101,17 +124,33 @@ rmClient u con clt pw =
         _ -> Data.reauthenticate u pw !>> ClientDataError . ClientReAuthError
       lift $ execDelete u (Just con) client
 
-claimPrekey :: UserId -> ClientId -> AppIO (Maybe ClientPrekey)
-claimPrekey u c = do
+claimPrekey :: MappedOrLocalId Id.U -> ClientId -> AppIO (Maybe ClientPrekey)
+claimPrekey u c = case u of
+  Local localUser ->
+    claimLocalPrekey localUser c
+  Mapped _ ->
+    -- TODO: error?
+    pure Nothing
+
+claimLocalPrekey :: UserId -> ClientId -> AppIO (Maybe ClientPrekey)
+claimLocalPrekey u c = do
   prekey <- Data.claimPrekey u c
   case prekey of
     Nothing -> noPrekeys u c >> return Nothing
     pk@(Just _) -> return pk
 
-claimPrekeyBundle :: UserId -> AppIO PrekeyBundle
-claimPrekeyBundle u = do
+claimPrekeyBundle :: MappedOrLocalId Id.U -> AppIO PrekeyBundle
+claimPrekeyBundle = \case
+  Local localUser ->
+    claimLocalPrekeyBundle localUser
+  Mapped IdMapping {idMappingLocal} ->
+    -- TODO: error?
+    pure $ PrekeyBundle (makeMappedIdOpaque idMappingLocal) []
+
+claimLocalPrekeyBundle :: UserId -> AppIO PrekeyBundle
+claimLocalPrekeyBundle u = do
   clients <- map clientId <$> Data.lookupClients u
-  PrekeyBundle u . catMaybes <$> mapM (Data.claimPrekey u) clients
+  PrekeyBundle (makeIdOpaque u) . catMaybes <$> mapM (Data.claimPrekey u) clients
 
 claimMultiPrekeyBundles :: UserClients -> Handler (UserClientMap (Maybe Prekey))
 claimMultiPrekeyBundles (UserClients clientMap) = do

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -51,7 +51,6 @@ createConnection self req conn = do
       createConnectionToLocalUser self u req conn
     Mapped IdMapping {idMappingLocal} ->
       -- FUTUREWORK(federation): allow creating connections to remote users
-      -- TODO: different error?
       throwE $ InvalidUser (makeMappedIdOpaque idMappingLocal)
 
 createConnectionToLocalUser ::

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -18,6 +18,7 @@ module Brig.API.Connection
 where
 
 import Brig.API.Types
+import Brig.API.Util (resolveOpaqueUserId)
 import Brig.App
 import qualified Brig.Data.Connection as Data
 import qualified Brig.Data.User as Data
@@ -29,7 +30,8 @@ import Brig.User.Event
 import qualified Brig.User.Event.Log as Log
 import Control.Error
 import Control.Lens (view)
-import Data.Id
+import Data.Id as Id
+import Data.IdMapping (IdMapping (IdMapping, idMappingLocal), MappedOrLocalId (Local, Mapped))
 import Data.Range
 import qualified Data.Set as Set
 import Galley.Types (ConvType (..), cnvType)
@@ -43,17 +45,32 @@ createConnection ::
   ConnectionRequest ->
   ConnId ->
   ExceptT ConnectionError AppIO ConnectionResult
-createConnection self ConnectionRequest {..} conn = do
+createConnection self req conn = do
+  resolveOpaqueUserId (crUser req) >>= \case
+    Local u ->
+      createConnectionToLocalUser self u req conn
+    Mapped IdMapping {idMappingLocal} ->
+      -- FUTUREWORK(federation): allow creating connections to remote users
+      -- TODO: different error?
+      throwE $ InvalidUser (makeMappedIdOpaque idMappingLocal)
+
+createConnectionToLocalUser ::
+  UserId ->
+  UserId ->
+  ConnectionRequest ->
+  ConnId ->
+  ExceptT ConnectionError AppIO ConnectionResult
+createConnectionToLocalUser self crUser ConnectionRequest {crName, crMessage} conn = do
   when (self == crUser)
     $ throwE
-    $ InvalidUser crUser
+    $ InvalidUser (makeIdOpaque crUser)
   selfActive <- lift $ Data.isActivated self
   unless selfActive $
     throwE ConnectNoIdentity
   otherActive <- lift $ Data.isActivated crUser
   unless otherActive
     $ throwE
-    $ InvalidUser crUser
+    $ InvalidUser (makeIdOpaque crUser)
   -- Users belonging to the same team are always treated as connected, so creating a
   -- connection between them is useless. {#RefConnectionTeam}
   sameTeam <- lift $ belongSameTeam

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -11,7 +11,7 @@ import qualified Data.HashMap.Strict as HashMap
 import Data.Id (idToText)
 import Data.IdMapping (IdMapping (IdMapping, idMappingGlobal, idMappingLocal))
 import Data.List.NonEmpty (NonEmpty)
-import Data.Qualified (renderQualified)
+import Data.Qualified (renderQualifiedId)
 import Data.String.Conversions (cs)
 import qualified Data.Text.Lazy as LT
 import qualified Data.ZAuth.Validation as ZAuth
@@ -463,4 +463,4 @@ federationNotImplemented qualified =
     idType = cs (show (typeRep @a))
     rendered = LT.intercalate ", " . toList . fmap (LT.fromStrict . renderMapping) $ qualified
     renderMapping IdMapping {idMappingLocal, idMappingGlobal} =
-      idToText idMappingLocal <> " -> " <> renderQualified idToText idMappingGlobal
+      idToText idMappingLocal <> " -> " <> renderQualifiedId idMappingGlobal

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -89,7 +89,7 @@ data ConnectionError
   | -- | An invalid connection status change.
     InvalidTransition UserId Relation
   | -- | The target user in an connection attempt is invalid, e.g. not activated.
-    InvalidUser UserId
+    InvalidUser OpaqueUserId
   | -- | An attempt at updating a non-existent connection.
     NotConnected UserId UserId
   | -- | An attempt at creating a connection from an account with

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -155,7 +155,7 @@ data SendLoginCodeError
 data ClientError
   = ClientNotFound
   | ClientDataError !ClientDataError
-  | ClientUserNotFound !UserId
+  | ClientUserNotFound !OpaqueUserId
   | ClientLegalHoldCannotBeRemoved
   | ClientLegalHoldCannotBeAdded
 

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -904,7 +904,6 @@ lookupProfiles self others = do
   let (localUsers, _remoteUsers) = partitionMappedOrLocalIds others
   localProfiles <- lookupProfilesOfLocalUsers self localUsers
   -- FUTUREWORK(federation): fetch remote profiles
-  -- TODO: error?
   remoteProfiles <- pure []
   pure (localProfiles <> remoteProfiles)
 

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -901,7 +901,7 @@ lookupProfiles ::
   [MappedOrLocalId Id.U] ->
   AppIO [UserProfile]
 lookupProfiles self others = do
-  let (localUsers, remoteUsers) = partitionMappedOrLocalIds others
+  let (localUsers, _remoteUsers) = partitionMappedOrLocalIds others
   localProfiles <- lookupProfilesOfLocalUsers self localUsers
   -- FUTUREWORK(federation): fetch remote profiles
   -- TODO: error?

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -104,7 +104,8 @@ import Control.Monad.Catch
 import Data.ByteString.Conversion
 import qualified Data.Currency as Currency
 import Data.Handle (Handle)
-import Data.Id
+import Data.Id as Id
+import Data.IdMapping (MappedOrLocalId, partitionMappedOrLocalIds)
 import Data.Json.Util
 import Data.List1 (List1)
 import qualified Data.Map.Strict as Map
@@ -885,7 +886,7 @@ userGC u = case (userExpire u) of
       deleteUserNoVerify (userId u)
     return u
 
-lookupProfile :: UserId -> UserId -> AppIO (Maybe UserProfile)
+lookupProfile :: UserId -> MappedOrLocalId Id.U -> AppIO (Maybe UserProfile)
 lookupProfile self other = listToMaybe <$> lookupProfiles self [other]
 
 -- | Obtain user profiles for a list of users as they can be seen by
@@ -897,9 +898,23 @@ lookupProfiles ::
   -- | User 'self' on whose behalf the profiles are requested.
   UserId ->
   -- | The users ('others') for which to obtain the profiles.
-  [UserId] ->
+  [MappedOrLocalId Id.U] ->
   AppIO [UserProfile]
 lookupProfiles self others = do
+  let (localUsers, remoteUsers) = partitionMappedOrLocalIds others
+  localProfiles <- lookupProfilesOfLocalUsers self localUsers
+  -- FUTUREWORK(federation): fetch remote profiles
+  -- TODO: error?
+  remoteProfiles <- pure []
+  pure (localProfiles <> remoteProfiles)
+
+lookupProfilesOfLocalUsers ::
+  -- | User 'self' on whose behalf the profiles are requested.
+  UserId ->
+  -- | The users ('others') for which to obtain the profiles.
+  [UserId] ->
+  AppIO [UserProfile]
+lookupProfilesOfLocalUsers self others = do
   users <- Data.lookupUsers others >>= mapM userGC
   css <- toMap <$> Data.lookupConnectionStatus (map userId users) [self]
   emailVisibility' <- view (settings . emailVisibility)

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -151,13 +151,13 @@ testGetUserPrekeys brig = do
   let cpk = ClientPrekey (clientId c) (somePrekeys !! 0)
   get (brig . paths ["users", toByteString' uid, "prekeys"]) !!! do
     const 200 === statusCode
-    const (Just $ PrekeyBundle uid [cpk]) === responseJsonMaybe
+    const (Just $ PrekeyBundle (makeIdOpaque uid) [cpk]) === responseJsonMaybe
   -- prekeys are deleted when retrieved, except the last one
   let lpk = ClientPrekey (clientId c) (unpackLastPrekey (someLastPrekeys !! 0))
   replicateM_ 2 $
     get (brig . paths ["users", toByteString' uid, "prekeys"]) !!! do
       const 200 === statusCode
-      const (Just $ PrekeyBundle uid [lpk]) === responseJsonMaybe
+      const (Just $ PrekeyBundle (makeIdOpaque uid) [lpk]) === responseJsonMaybe
 
 testGetClientPrekey :: Brig -> Http ()
 testGetClientPrekey brig = do

--- a/services/brig/test/integration/API/User/Handles.hs
+++ b/services/brig/test/integration/API/User/Handles.hs
@@ -131,7 +131,10 @@ testHandleQuery opts brig galley = do
   -- Query user profiles by handles
   get (brig . path "/users" . queryItem "handles" (toByteString' hdl) . zUser uid) !!! do
     const 200 === statusCode
-    const (Just (Handle hdl)) === (>>= (listToMaybe >=> userHandle)) . responseJsonMaybe
+    const (Just (Handle hdl)) === (userHandle <=< listToMaybe <=< responseJsonMaybe)
+  -- Qualified handles get accepted, but don't have any matches (federation)
+  get (brig . path "/users" . queryItem "handles" (toByteString' hdl <> "@wire.com") . zUser uid) !!! do
+    const 404 === statusCode
   -- Bulk availability check
   hdl2 <- randomHandle
   hdl3 <- randomHandle

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -321,7 +321,7 @@ postConnection brig from to =
   where
     payload =
       RequestBodyLBS . encode $
-        ConnectionRequest to "some conv name" (Message "some message")
+        ConnectionRequest (makeIdOpaque to) "some conv name" (Message "some message")
 
 putConnection :: Brig -> UserId -> UserId -> Relation -> Http ResponseLBS
 putConnection brig from to r =

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -10,7 +10,7 @@ where
 import Control.Lens hiding ((??))
 import Control.Monad.Catch
 import Data.Id
-import Data.IdMapping (MappedOrLocalId (Local, Mapped))
+import Data.IdMapping (MappedOrLocalId (Local, Mapped), partitionMappedOrLocalIds)
 import Data.List.NonEmpty (nonEmpty)
 import Data.List1 (list1)
 import Data.Range

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -4,7 +4,7 @@ import Data.Domain (Domain, domainText)
 import Data.Id (idToText)
 import Data.IdMapping (IdMapping (IdMapping, idMappingGlobal, idMappingLocal))
 import Data.List.NonEmpty (NonEmpty)
-import Data.Qualified (renderQualified)
+import Data.Qualified (renderQualifiedId)
 import Data.String.Conversions (cs)
 import Data.Text.Lazy as LT (pack)
 import qualified Data.Text.Lazy as LT
@@ -205,4 +205,4 @@ federationNotImplemented qualified =
     idType = cs (show (typeRep @a))
     rendered = LT.intercalate ", " . toList . fmap (LT.fromStrict . renderMapping) $ qualified
     renderMapping IdMapping {idMappingLocal, idMappingGlobal} =
-      idToText idMappingLocal <> " -> " <> renderQualified idToText idMappingGlobal
+      idToText idMappingLocal <> " -> " <> renderQualifiedId idMappingGlobal

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -10,7 +10,7 @@ import Control.Exception.Safe (catchAny)
 import Control.Lens hiding ((.=))
 import Control.Monad.Catch (MonadCatch, throwM)
 import Data.Id
-import Data.IdMapping (MappedOrLocalId (Local))
+import Data.IdMapping (MappedOrLocalId (Local), partitionMappedOrLocalIds)
 import Data.List.NonEmpty (nonEmpty)
 import Data.List1
 import Data.Metrics.Middleware as Metrics
@@ -19,7 +19,7 @@ import Data.String.Conversions (cs)
 import Galley.API.Error (federationNotImplemented)
 import Galley.API.Teams (uncheckedRemoveTeamMember)
 import qualified Galley.API.Teams as Teams
-import Galley.API.Util (isMember, partitionMappedOrLocalIds, resolveOpaqueConvId)
+import Galley.API.Util (isMember, resolveOpaqueConvId)
 import Galley.App
 import qualified Galley.Data as Data
 import qualified Galley.Intra.Push as Intra

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -13,7 +13,7 @@ where
 import Cassandra (hasMore, result)
 import Data.ByteString.Conversion
 import Data.Id
-import Data.IdMapping (MappedOrLocalId (Local))
+import Data.IdMapping (MappedOrLocalId (Local), partitionMappedOrLocalIds)
 import Data.Range
 import Galley.API.Error
 import Galley.API.Mapping

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -6,7 +6,7 @@ import Control.Lens ((.~), view)
 import Control.Monad.Catch
 import Data.ByteString.Conversion
 import Data.Id as Id
-import Data.IdMapping (IdMapping (..), MappedOrLocalId (Local, Mapped))
+import Data.IdMapping (MappedOrLocalId (Local, Mapped), partitionMappedOrLocalIds)
 import Data.List.NonEmpty (nonEmpty)
 import Data.Misc (PlainTextPassword (..))
 import qualified Data.Set as Set
@@ -267,8 +267,3 @@ resolveOpaqueConvId (Id opaque) = do
     True ->
       -- FUTUREWORK(federation): implement database lookup
       pure . Local $ Id opaque
-
-partitionMappedOrLocalIds :: Foldable f => f (MappedOrLocalId a) -> ([Id a], [IdMapping a])
-partitionMappedOrLocalIds = foldMap $ \case
-  Mapped mapping -> (mempty, [mapping])
-  Local localId -> ([localId], mempty)

--- a/services/galley/test/integration/API/CustomBackend.hs
+++ b/services/galley/test/integration/API/CustomBackend.hs
@@ -34,7 +34,7 @@ getByDomainInvalidDomain = do
   -- contains invalid character '+'
   get (galley . path "/custom-backend/by-domain/invalid%2Bdomain") !!! do
     const 400 === statusCode
-    const ("Failed parsing" :: ByteString) =~= (cs . fold . responseBody)
+    const ("client-error" :: ByteString) =~= (cs . fold . responseBody)
 
 getByDomainFound :: TestM ()
 getByDomainFound = do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -852,7 +852,7 @@ connectUsersWith fn u us = mapM connectTo us
               . zUser u
               . zConn "conn"
               . path "/connections"
-              . json (ConnectionRequest v "chat" (Message "Y"))
+              . json (ConnectionRequest (makeIdOpaque v) "chat" (Message "Y"))
               . fn
           )
       r2 <-

--- a/tools/api-simulations/lib/src/Network/Wire/Simulations.hs
+++ b/tools/api-simulations/lib/src/Network/Wire/Simulations.hs
@@ -80,7 +80,7 @@ connectIfNeeded = go 6 -- six turns should be enough
         case s of
           -- If no connection: initiate one
           Nothing -> do
-            void $ connectTo (ConnectionRequest (botId b) (fromMaybe "" (botEmail a)) (Message "Hi there!"))
+            void $ connectTo (ConnectionRequest (makeIdOpaque (botId b)) (fromMaybe "" (botEmail a)) (Message "Hi there!"))
             assertConnectRequested a b
             return False
           -- If there's a pending connection to us: accept it

--- a/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
+++ b/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
@@ -9,7 +9,7 @@ where
 
 import qualified Codec.MIME.Type as MIME
 import qualified Data.ByteString.Lazy as LBS
-import Data.Id (ConvId)
+import Data.Id (ConvId, makeIdOpaque)
 import Data.List1
 import Imports
 import Network.Wire.Bot
@@ -44,7 +44,7 @@ mainBotNet n = do
         conn <-
           connectTo
             ConnectionRequest
-              { crUser = botId user,
+              { crUser = makeIdOpaque (botId user),
                 crName = fromMaybe "" (botEmail ally),
                 crMessage = Message "Hi there!"
               }


### PR DESCRIPTION
One thing I'm still thinking about (and left some TODOs for):

In Galley when encounter a remote ID where we can't handle it yet, we throw a HTTP 501 "federation-not-implemented". Here, it's not as easy since we throw errors into different sum types for different routes (ClientError, UserError, ConnectionError), which we would all have to extend with a case for federation. I'm currently leaning towards just doing that (instead of just treating remote IDs as non-existent ones).