### PR TITLE
Extended team invitations

### DIFF
--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -417,11 +417,11 @@ teamInvitationRequest = defineModel "TeamInvitationRequest" $ do
   property "role" role $ do
     description "Role of the invited user"
     optional
-  property "invitee_name" string' $ do
+  property "name" string' $ do
     description "Name of the invitee (1 - 128 characters)"
     optional
   property "phone" string' $ do
-    description "E.164 Phone number of the invitee"
+    description "Phone number of the invitee, in the E.164 format"
     optional
 
 -- | This is *not* the swagger model for the 'TeamInvitation' type (which does not exist), but
@@ -446,11 +446,11 @@ teamInvitation = defineModel "TeamInvitation" $ do
   property "created_by" bytes' $ do
     description "ID of the inviting user"
     optional
-  property "invitee_name" string' $ do
-    description "Name of the invitee"
+  property "name" string' $ do
+    description "Name of the invitee (1 - 128 characters)"
     optional
   property "phone" string' $ do
-    description "E.164 Phone number of the invitee"
+    description "Phone number of the invitee, in the E.164 format"
     optional
 
 teamInvitationList :: Model

--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -417,6 +417,12 @@ teamInvitationRequest = defineModel "TeamInvitationRequest" $ do
   property "role" role $ do
     description "Role of the invited user"
     optional
+  property "invitee_name" string' $ do
+    description "Name of the invitee (1 - 128 characters)"
+    optional
+  property "phone" string' $ do
+    description "E.164 Phone number of the invitee"
+    optional
 
 -- | This is *not* the swagger model for the 'TeamInvitation' type (which does not exist), but
 -- for the use of 'Invitation' under @/teams/{tid}/invitations@.
@@ -440,8 +446,12 @@ teamInvitation = defineModel "TeamInvitation" $ do
   property "created_by" bytes' $ do
     description "ID of the inviting user"
     optional
-  property "name" string' $
+  property "invitee_name" string' $ do
     description "Name of the invitee"
+    optional
+  property "phone" string' $ do
+    description "E.164 Phone number of the invitee"
+    optional
 
 teamInvitationList :: Model
 teamInvitationList = defineModel "TeamInvitationList" $ do

--- a/libs/brig-types/src/Brig/Types/Team/Invitation.hs
+++ b/libs/brig-types/src/Brig/Types/Team/Invitation.hs
@@ -48,7 +48,7 @@ instance FromJSON InvitationRequest where
       <*> o .: "inviter_name"
       <*> o .:? "locale"
       <*> o .:? "role"
-      <*> o .:? "invitee_name"
+      <*> o .:? "name"
       <*> o .:? "phone"
 
 instance ToJSON InvitationRequest where
@@ -58,7 +58,7 @@ instance ToJSON InvitationRequest where
         "inviter_name" .= irName i,
         "locale" .= irLocale i,
         "role" .= irRole i,
-        "invitee_name" .= irInviteeName i,
+        "name" .= irInviteeName i,
         "phone" .= irPhone i
       ]
 
@@ -71,7 +71,7 @@ instance FromJSON Invitation where
       <*> o .: "email"
       <*> o .: "created_at"
       <*> o .:? "created_by"
-      <*> o .:? "invitee_name"
+      <*> o .:? "name"
       <*> o .:? "phone"
 
 instance ToJSON Invitation where
@@ -83,7 +83,7 @@ instance ToJSON Invitation where
         "email" .= inIdentity i,
         "created_at" .= inCreatedAt i,
         "created_by" .= inCreatedBy i,
-        "invitee_name" .= inInviteeName i,
+        "name" .= inInviteeName i,
         "phone" .= inPhone i
       ]
 

--- a/libs/brig-types/src/Brig/Types/Team/Invitation.hs
+++ b/libs/brig-types/src/Brig/Types/Team/Invitation.hs
@@ -14,7 +14,9 @@ data InvitationRequest
       { irEmail :: !Email,
         irName :: !Name,
         irLocale :: !(Maybe Locale),
-        irRole :: !(Maybe Role)
+        irRole :: !(Maybe Role),
+        irInviteeName :: !(Maybe Name),
+        irPhone :: !(Maybe Phone)
       }
   deriving (Eq, Show)
 
@@ -27,7 +29,9 @@ data Invitation
         inCreatedAt :: !UTCTimeMillis,
         -- | this is always 'Just' for new invitations, but for
         -- migration it is allowed to be 'Nothing'.
-        inCreatedBy :: !(Maybe UserId)
+        inCreatedBy :: !(Maybe UserId),
+        inInviteeName :: !(Maybe Name),
+        inPhone :: !(Maybe Phone)
       }
   deriving (Eq, Show)
 
@@ -44,6 +48,8 @@ instance FromJSON InvitationRequest where
       <*> o .: "inviter_name"
       <*> o .:? "locale"
       <*> o .:? "role"
+      <*> o .:? "invitee_name"
+      <*> o .:? "phone"
 
 instance ToJSON InvitationRequest where
   toJSON i =
@@ -51,7 +57,9 @@ instance ToJSON InvitationRequest where
       [ "email" .= irEmail i,
         "inviter_name" .= irName i,
         "locale" .= irLocale i,
-        "role" .= irRole i
+        "role" .= irRole i,
+        "invitee_name" .= irInviteeName i,
+        "phone" .= irPhone i
       ]
 
 instance FromJSON Invitation where
@@ -63,6 +71,8 @@ instance FromJSON Invitation where
       <*> o .: "email"
       <*> o .: "created_at"
       <*> o .:? "created_by"
+      <*> o .:? "invitee_name"
+      <*> o .:? "phone"
 
 instance ToJSON Invitation where
   toJSON i =
@@ -72,7 +82,9 @@ instance ToJSON Invitation where
         "id" .= inInvitation i,
         "email" .= inIdentity i,
         "created_at" .= inCreatedAt i,
-        "created_by" .= inCreatedBy i
+        "created_by" .= inCreatedBy i,
+        "invitee_name" .= inInviteeName i,
+        "phone" .= inPhone i
       ]
 
 instance ToJSON InvitationList where

--- a/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
+++ b/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
@@ -381,7 +381,7 @@ instance Arbitrary InvitationList where
   arbitrary = InvitationList <$> listOf arbitrary <*> arbitrary
 
 instance Arbitrary Invitation where
-  arbitrary = Invitation <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary = Invitation <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary Permissions where
   arbitrary = maybe (error "instance Arbitrary Permissions") pure =<< do
@@ -393,7 +393,7 @@ instance Arbitrary Perm where
   arbitrary = elements [minBound ..]
 
 instance Arbitrary InvitationRequest where
-  arbitrary = InvitationRequest <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary = InvitationRequest <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary Role where
   arbitrary = elements [minBound ..]

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -494,6 +494,7 @@ executable brig-schema
       V56
       V57
       V58
+      V59
       V9
       Paths_brig
   hs-source-dirs:

--- a/services/brig/schema/src/Main.hs
+++ b/services/brig/schema/src/Main.hs
@@ -51,6 +51,7 @@ import qualified V55
 import qualified V56
 import qualified V57
 import qualified V58
+import qualified V59
 import qualified V9
 
 main :: IO ()
@@ -108,6 +109,7 @@ main = do
       V55.migration,
       V56.migration,
       V57.migration,
-      V58.migration
+      V58.migration,
+      V59.migration
     ]
     `finally` Log.close l

--- a/services/brig/schema/src/V59.hs
+++ b/services/brig/schema/src/V59.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module V59
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 59 "Add invitee_name and phone to the team invitations table" $ do
+  schema' [r| ALTER TABLE team_invitation ADD (invitee_name text, phone text); |]

--- a/services/brig/schema/src/V59.hs
+++ b/services/brig/schema/src/V59.hs
@@ -11,5 +11,5 @@ import Imports
 import Text.RawString.QQ
 
 migration :: Migration
-migration = Migration 59 "Add invitee_name and phone to the team invitations table" $ do
-  schema' [r| ALTER TABLE team_invitation ADD (invitee_name text, phone text); |]
+migration = Migration 59 "Add name and phone to the team invitations table" $ do
+  schema' [r| ALTER TABLE team_invitation ADD (name text, phone text); |]

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -265,6 +265,9 @@ userKeyExists = Wai.Error status409 "key-exists" "The given e-mail address or ph
 emailExists :: Wai.Error
 emailExists = Wai.Error status409 "email-exists" "The given e-mail address is in use."
 
+phoneExists :: Wai.Error
+phoneExists = Wai.Error status409 "phone-exists" "The given phone number is in use."
+
 handleExists :: Wai.Error
 handleExists = Wai.Error status409 "handle-exists" "The given handle is already taken."
 

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -8,10 +8,10 @@ import Brig.App (currentTime, settings)
 import qualified Brig.Data.Blacklist as Blacklist
 import Brig.Data.UserKey
 import qualified Brig.Data.UserKey as Data
-import Brig.Email
+import qualified Brig.Email as Email
 import qualified Brig.IO.Intra as Intra
 import Brig.Options (setMaxTeamSize, setTeamInvitationTimeout)
-import Brig.Phone
+import qualified Brig.Phone as Phone
 import qualified Brig.Team.DB as DB
 import Brig.Team.Email
 import Brig.Team.Util (ensurePermissionToAddUser, ensurePermissions)
@@ -171,7 +171,7 @@ createInvitation uid tid body = do
   --             sendActivationCode. Refactor this to a single place
 
   -- Validate e-mail
-  email <- either (const $ throwStd invalidEmail) return (validateEmail (irEmail body))
+  email <- either (const $ throwStd invalidEmail) return (Email.validateEmail (irEmail body))
   let uke = userEmailKey email
   blacklistedEm <- lift $ Blacklist.exists uke
   when blacklistedEm $
@@ -182,7 +182,7 @@ createInvitation uid tid body = do
 
   -- Validate phone
   phone <- for (irPhone body) $ \p -> do
-      validatedPhone <- maybe (throwStd invalidPhone) return =<< lift (validatePhone p)
+      validatedPhone <- maybe (throwStd invalidPhone) return =<< lift (Phone.validatePhone p)
       let ukp = userPhoneKey validatedPhone
       blacklistedPh <- lift $ Blacklist.exists ukp
       when blacklistedPh $

--- a/services/brig/src/Brig/Team/DB.hs
+++ b/services/brig/src/Brig/Team/DB.hs
@@ -78,7 +78,7 @@ insertInvitation t role email (toUTCTimeMillis -> now) minviter inviteeName phon
     cqlInvitationInfo :: PrepQuery W (InvitationCode, TeamId, InvitationId, Int32) ()
     cqlInvitationInfo = "INSERT INTO team_invitation_info (code, team, id) VALUES (?, ?, ?) USING TTL ?"
     cqlInvitation :: PrepQuery W (TeamId, Role, InvitationId, InvitationCode, Email, UTCTimeMillis, Maybe UserId, Maybe Name, Maybe Phone, Int32) ()
-    cqlInvitation = "INSERT INTO team_invitation (team, role, id, code, email, created_at, created_by, invitee_name, phone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) USING TTL ?"
+    cqlInvitation = "INSERT INTO team_invitation (team, role, id, code, email, created_at, created_by, name, phone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) USING TTL ?"
 
 lookupInvitation :: MonadClient m => TeamId -> InvitationId -> m (Maybe Invitation)
 lookupInvitation t r =
@@ -86,7 +86,7 @@ lookupInvitation t r =
     <$> retry x1 (query1 cqlInvitation (params Quorum (t, r)))
   where
     cqlInvitation :: PrepQuery R (TeamId, InvitationId) (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId, Maybe Name, Maybe Phone)
-    cqlInvitation = "SELECT team, role, id, email, created_at, created_by, invitee_name, phone FROM team_invitation WHERE team = ? AND id = ?"
+    cqlInvitation = "SELECT team, role, id, email, created_at, created_by, name, phone FROM team_invitation WHERE team = ? AND id = ?"
 
 lookupInvitationByCode :: MonadClient m => InvitationCode -> m (Maybe Invitation)
 lookupInvitationByCode i = lookupInvitationInfo i >>= \case
@@ -116,9 +116,9 @@ lookupInvitations team start (fromRange -> size) = do
             hasMore = more
           }
     cqlSelect :: PrepQuery R (Identity TeamId) (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId, Maybe Name, Maybe Phone)
-    cqlSelect = "SELECT team, role, id, email, created_at, created_by, invitee_name, phone FROM team_invitation WHERE team = ? ORDER BY id ASC"
+    cqlSelect = "SELECT team, role, id, email, created_at, created_by, name, phone FROM team_invitation WHERE team = ? ORDER BY id ASC"
     cqlSelectFrom :: PrepQuery R (TeamId, InvitationId) (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId, Maybe Name, Maybe Phone)
-    cqlSelectFrom = "SELECT team, role, id, email, created_at, created_by, invitee_name, phone FROM team_invitation WHERE team = ? AND id > ? ORDER BY id ASC"
+    cqlSelectFrom = "SELECT team, role, id, email, created_at, created_by, name, phone FROM team_invitation WHERE team = ? AND id > ? ORDER BY id ASC"
 
 deleteInvitation :: MonadClient m => TeamId -> InvitationId -> m ()
 deleteInvitation t i = do

--- a/services/brig/src/Brig/Team/DB.hs
+++ b/services/brig/src/Brig/Team/DB.hs
@@ -59,32 +59,34 @@ insertInvitation ::
   Email ->
   UTCTime ->
   Maybe UserId ->
+  Maybe Name ->
+  Maybe Phone ->
   -- | The timeout for the invitation code.
   Timeout ->
   m (Invitation, InvitationCode)
-insertInvitation t role email (toUTCTimeMillis -> now) minviter timeout = do
+insertInvitation t role email (toUTCTimeMillis -> now) minviter inviteeName phone timeout = do
   iid <- liftIO mkInvitationId
   code <- liftIO mkInvitationCode
-  let inv = Invitation t role iid email now minviter
+  let inv = Invitation t role iid email now minviter inviteeName phone
   retry x5 $ batch $ do
     setType BatchLogged
     setConsistency Quorum
-    addPrepQuery cqlInvitation (t, role, iid, code, email, now, minviter, round timeout)
+    addPrepQuery cqlInvitation (t, role, iid, code, email, now, minviter, inviteeName, phone, round timeout)
     addPrepQuery cqlInvitationInfo (code, t, iid, round timeout)
   return (inv, code)
   where
     cqlInvitationInfo :: PrepQuery W (InvitationCode, TeamId, InvitationId, Int32) ()
     cqlInvitationInfo = "INSERT INTO team_invitation_info (code, team, id) VALUES (?, ?, ?) USING TTL ?"
-    cqlInvitation :: PrepQuery W (TeamId, Role, InvitationId, InvitationCode, Email, UTCTimeMillis, Maybe UserId, Int32) ()
-    cqlInvitation = "INSERT INTO team_invitation (team, role, id, code, email, created_at, created_by) VALUES (?, ?, ?, ?, ?, ?, ?) USING TTL ?"
+    cqlInvitation :: PrepQuery W (TeamId, Role, InvitationId, InvitationCode, Email, UTCTimeMillis, Maybe UserId, Maybe Name, Maybe Phone, Int32) ()
+    cqlInvitation = "INSERT INTO team_invitation (team, role, id, code, email, created_at, created_by, invitee_name, phone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) USING TTL ?"
 
 lookupInvitation :: MonadClient m => TeamId -> InvitationId -> m (Maybe Invitation)
 lookupInvitation t r =
   fmap toInvitation
     <$> retry x1 (query1 cqlInvitation (params Quorum (t, r)))
   where
-    cqlInvitation :: PrepQuery R (TeamId, InvitationId) (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId)
-    cqlInvitation = "SELECT team, role, id, email, created_at, created_by FROM team_invitation WHERE team = ? AND id = ?"
+    cqlInvitation :: PrepQuery R (TeamId, InvitationId) (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId, Maybe Name, Maybe Phone)
+    cqlInvitation = "SELECT team, role, id, email, created_at, created_by, invitee_name, phone FROM team_invitation WHERE team = ? AND id = ?"
 
 lookupInvitationByCode :: MonadClient m => InvitationCode -> m (Maybe Invitation)
 lookupInvitationByCode i = lookupInvitationInfo i >>= \case
@@ -113,10 +115,10 @@ lookupInvitations team start (fromRange -> size) = do
           { result = invs,
             hasMore = more
           }
-    cqlSelect :: PrepQuery R (Identity TeamId) (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId)
-    cqlSelect = "SELECT team, role, id, email, created_at, created_by FROM team_invitation WHERE team = ? ORDER BY id ASC"
-    cqlSelectFrom :: PrepQuery R (TeamId, InvitationId) (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId)
-    cqlSelectFrom = "SELECT team, role, id, email, created_at, created_by FROM team_invitation WHERE team = ? AND id > ? ORDER BY id ASC"
+    cqlSelect :: PrepQuery R (Identity TeamId) (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId, Maybe Name, Maybe Phone)
+    cqlSelect = "SELECT team, role, id, email, created_at, created_by, invitee_name, phone FROM team_invitation WHERE team = ? ORDER BY id ASC"
+    cqlSelectFrom :: PrepQuery R (TeamId, InvitationId) (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId, Maybe Name, Maybe Phone)
+    cqlSelectFrom = "SELECT team, role, id, email, created_at, created_by, invitee_name, phone FROM team_invitation WHERE team = ? AND id > ? ORDER BY id ASC"
 
 deleteInvitation :: MonadClient m => TeamId -> InvitationId -> m ()
 deleteInvitation t i = do
@@ -166,5 +168,5 @@ countInvitations t =
 
 -- | brig used to not store the role, so for migration we allow this to be empty and fill in the
 -- default here.
-toInvitation :: (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId) -> Invitation
-toInvitation (t, r, i, e, tm, minviter) = Invitation t (fromMaybe Team.defaultRole r) i e tm minviter
+toInvitation :: (TeamId, Maybe Role, InvitationId, Email, UTCTimeMillis, Maybe UserId, Maybe Name, Maybe Phone) -> Invitation
+toInvitation (t, r, i, e, tm, minviter, inviteeName, p) = Invitation t (fromMaybe Team.defaultRole r) i e tm minviter inviteeName p

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -49,6 +49,7 @@ tests conf m b c g aws = do
             test m "post /teams/:tid/invitations - 403 too many pending" $ testInvitationTooManyPending b g tl,
             test m "post /teams/:tid/invitations - roles" $ testInvitationRoles b g,
             test' aws m "post /register - 201 accepted" $ testInvitationEmailAccepted b g,
+            test' aws m "post /register - 201 extended accepted" $ testInvitationEmailAndPhoneAccepted b g,
             test' aws m "post /register user & team - 201 accepted" $ testCreateTeam b g aws,
             test' aws m "post /register user & team - 201 preverified" $ testCreateTeamPreverified b g aws,
             test m "post /register - 400 no passwordless" $ testTeamNoPassword b,
@@ -87,7 +88,7 @@ testUpdateEvents brig galley cannon = do
   (alice, tid) <- createUserWithTeam brig galley
   inviteeEmail <- randomEmail
   -- invite and register Bob
-  let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
+  let invite = stdInvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
   inv <- responseJsonError =<< postInvitation brig tid alice invite
   Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
   rsp2 <-
@@ -118,14 +119,14 @@ testInvitationEmail :: Brig -> Galley -> Http ()
 testInvitationEmail brig galley = do
   (inviter, tid) <- createUserWithTeam brig galley
   invitee <- randomEmail
-  let invite = InvitationRequest invitee (Name "Bob") Nothing Nothing
+  let invite = stdInvitationRequest invitee (Name "Bob") Nothing Nothing
   void $ postInvitation brig tid inviter invite
 
 testInvitationTooManyPending :: Brig -> Galley -> TeamSizeLimit -> Http ()
 testInvitationTooManyPending brig galley (TeamSizeLimit limit) = do
   (inviter, tid) <- createUserWithTeam brig galley
   emails <- replicateConcurrently (fromIntegral limit) randomEmail
-  let invite e = InvitationRequest e (Name "Bob") Nothing Nothing
+  let invite e = stdInvitationRequest e (Name "Bob") Nothing Nothing
   pooledForConcurrentlyN_ 16 emails $ \email ->
     postInvitation brig tid inviter (invite email)
   e <- randomEmail
@@ -154,13 +155,13 @@ testInvitationRoles brig galley = do
   -- owner creates a member alice.
   alice :: UserId <- do
     aliceEmail <- randomEmail
-    let invite = InvitationRequest aliceEmail (Name "Alice") Nothing (Just Team.RoleAdmin)
+    let invite = stdInvitationRequest aliceEmail (Name "Alice") Nothing (Just Team.RoleAdmin)
     inv :: Invitation <- responseJsonError =<< postInvitation brig tid owner invite
     registerInvite inv aliceEmail
   -- alice creates a external partner bob.  success!  bob only has externalPartner perms.
   do
     bobEmail <- randomEmail
-    let invite = InvitationRequest bobEmail (Name "Bob") Nothing (Just Team.RoleExternalPartner)
+    let invite = stdInvitationRequest bobEmail (Name "Bob") Nothing (Just Team.RoleExternalPartner)
     inv :: Invitation <-
       responseJsonError
         =<< ( postInvitation brig tid alice invite <!! do
@@ -175,24 +176,50 @@ testInvitationRoles brig galley = do
   -- alice creates an owner charly.  failure!
   do
     charlyEmail <- randomEmail
-    let invite = InvitationRequest charlyEmail (Name "Charly") Nothing (Just Team.RoleOwner)
+    let invite = stdInvitationRequest charlyEmail (Name "Charly") Nothing (Just Team.RoleOwner)
     postInvitation brig tid alice invite !!! do
       const 403 === statusCode
       const (Just "insufficient-permissions") === fmap Error.label . responseJsonMaybe
 
 testInvitationEmailAccepted :: Brig -> Galley -> Http ()
 testInvitationEmailAccepted brig galley = do
-  (inviter, tid) <- createUserWithTeam brig galley
   inviteeEmail <- randomEmail
-  let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
+  let invite = stdInvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
+  void $ createAndVerifyInvitation (accept (irEmail invite)) invite brig galley
+
+testInvitationEmailAndPhoneAccepted :: Brig -> Galley -> Http ()
+testInvitationEmailAndPhoneAccepted brig galley = do
+  inviteeEmail <- randomEmail
+  inviteePhone <- randomPhone
+  -- Prepare the extended invitation
+  let stdInvite = stdInvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
+      inviteeName = Name "Invited Member"
+      extInvite = stdInvite { irPhone = Just inviteePhone, irInviteeName = Just inviteeName }
+
+  -- Register the same (pre verified) phone number
+  let phoneReq = RequestBodyLBS . encode $ object ["phone" .= fromPhone inviteePhone]
+  post (brig . path "/activate/send" . contentJson . body phoneReq) !!! (const 200 === statusCode)
+  Just (_, phoneCode) <- getActivationCode brig (Right inviteePhone)
+
+  -- Register the user with the extra supplied information
+  (profile, invitation) <- createAndVerifyInvitation (extAccept inviteeEmail inviteeName inviteePhone phoneCode) extInvite brig galley
+  liftIO $ assertEqual "Wrong name in profile" (Just inviteeName) (userName . selfUser <$> profile)
+  liftIO $ assertEqual "Wrong name in invitation" (Just inviteeName) (inInviteeName invitation)
+  liftIO $ assertEqual "Wrong phone number in profile" (Just inviteePhone) (join (userPhone . selfUser <$> profile))
+  liftIO $ assertEqual "Wrong phone number in invitation" (Just inviteePhone) (inPhone invitation)
+
+createAndVerifyInvitation :: (InvitationCode -> RequestBody) -> InvitationRequest -> Brig -> Galley -> HttpT IO ((Maybe SelfProfile), Invitation)
+createAndVerifyInvitation acceptFn invite brig galley = do
+  (inviter, tid) <- createUserWithTeam brig galley
   inv <- responseJsonError =<< postInvitation brig tid inviter invite
   let invmeta = Just (inviter, inCreatedAt inv)
   Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
+  Just invitation  <- getInvitation brig inviteeCode
   rsp2 <-
     post
       ( brig . path "/register"
           . contentJson
-          . body (accept inviteeEmail inviteeCode)
+          . body (acceptFn inviteeCode)
       )
       <!! const 201 === statusCode
   let Just (invitee, Just email2) = (userId &&& userEmail) <$> responseJsonMaybe rsp2
@@ -206,6 +233,7 @@ testInvitationEmailAccepted brig galley = do
   liftIO $ assertEqual "Member has no/wrong invitation metadata" invmeta (mem ^. Team.invitation)
   conns <- listConnections invitee brig
   liftIO $ assertBool "User should have no connections" (null (clConnections conns) && not (clHasMore conns))
+  return (responseJsonMaybe rsp2, invitation)
 
 testCreateTeam :: Brig -> Galley -> AWS.Env -> Http ()
 testCreateTeam brig galley aws = do
@@ -221,7 +249,7 @@ testCreateTeam brig galley aws = do
   liftIO $ assertBool "Member not part of the team" (uid == mem ^. Team.userId)
   -- Verify that the user cannot send invitations before activating their account
   inviteeEmail <- randomEmail
-  let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
+  let invite = stdInvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
   postInvitation brig (team ^. Team.teamId) uid invite !!! const 403 === statusCode
   -- Verify that the team is still in status "pending"
   team2 <- getTeam galley (team ^. Team.teamId)
@@ -257,7 +285,7 @@ testCreateTeamPreverified brig galley aws = do
       liftIO $ assertEqual "Team should already be active" Team.Active (Team.tdStatus team2)
       -- Verify that the user can already send invitations before activating their account
       inviteeEmail <- randomEmail
-      let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
+      let invite = stdInvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
       postInvitation brig (team ^. Team.teamId) uid invite !!! const 201 === statusCode
 
 testInvitationNoPermission :: Brig -> Galley -> Http ()
@@ -265,7 +293,7 @@ testInvitationNoPermission brig galley = do
   (_, tid) <- createUserWithTeam brig galley
   alice <- userId <$> randomUser brig
   email <- randomEmail
-  let invite = InvitationRequest email (Name "Bob") Nothing Nothing
+  let invite = stdInvitationRequest email (Name "Bob") Nothing Nothing
   postInvitation brig tid alice invite !!! do
     const 403 === statusCode
     const (Just "insufficient-permissions") === fmap Error.label . responseJsonMaybe
@@ -307,7 +335,7 @@ testInvitationCodeExists :: Brig -> Galley -> Http ()
 testInvitationCodeExists brig galley = do
   email <- randomEmail
   (uid, tid) <- createUserWithTeam brig galley
-  let invite email_ = InvitationRequest email_ (Name "Bob") Nothing Nothing
+  let invite email_ = stdInvitationRequest email_ (Name "Bob") Nothing Nothing
   rsp <- postInvitation brig tid uid (invite email) <!! const 201 === statusCode
   let Just invId = inInvitation <$> responseJsonMaybe rsp
   Just invCode <- getInvitationCode brig tid invId
@@ -387,7 +415,7 @@ testInvitationTooManyMembers brig galley (TeamSizeLimit limit) = do
   pooledForConcurrentlyN_ 16 [1 .. limit -1] $ \_ ->
     createTeamMember brig galley creator tid Team.fullPermissions
   em <- randomEmail
-  let invite = InvitationRequest em (Name "Bob") Nothing Nothing
+  let invite = stdInvitationRequest em (Name "Bob") Nothing Nothing
   inv <- responseJsonError =<< postInvitation brig tid creator invite
   Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
   post
@@ -404,7 +432,7 @@ testInvitationPaging brig galley = do
   before <- liftIO $ toUTCTimeMillis . addUTCTime (-1) <$> getCurrentTime
   (uid, tid) <- createUserWithTeam brig galley
   let total = 5
-      invite email = InvitationRequest email (Name "Bob") Nothing Nothing
+      invite email = stdInvitationRequest email (Name "Bob") Nothing Nothing
   emails <- replicateM total $ do
     email <- randomEmail
     postInvitation brig tid uid (invite email) !!! const 201 === statusCode
@@ -440,7 +468,7 @@ testInvitationInfo :: Brig -> Galley -> Http ()
 testInvitationInfo brig galley = do
   email <- randomEmail
   (uid, tid) <- createUserWithTeam brig galley
-  let invite = InvitationRequest email (Name "Bob") Nothing Nothing
+  let invite = stdInvitationRequest email (Name "Bob") Nothing Nothing
   inv <- responseJsonError =<< postInvitation brig tid uid invite
   Just invCode <- getInvitationCode brig tid (inInvitation inv)
   Just invitation <- getInvitation brig invCode
@@ -457,7 +485,7 @@ testInvitationInfoExpired :: Brig -> Galley -> Opt.Timeout -> Http ()
 testInvitationInfoExpired brig galley timeout = do
   email <- randomEmail
   (uid, tid) <- createUserWithTeam brig galley
-  let invite = InvitationRequest email (Name "Bob") Nothing Nothing
+  let invite = stdInvitationRequest email (Name "Bob") Nothing Nothing
   inv <- responseJsonError =<< postInvitation brig tid uid invite
   -- Note: This value must be larger than the option passed as `team-invitation-timeout`
   awaitExpiry (round timeout + 5) tid (inInvitation inv)
@@ -483,7 +511,7 @@ testSuspendTeam brig galley = do
   inviteeEmail2 <- randomEmail
   (inviter, tid) <- createUserWithTeam brig galley
   -- invite and register invitee
-  let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
+  let invite = stdInvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
   inv <- responseJsonError =<< postInvitation brig tid inviter invite
   Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
   rsp2 <-
@@ -495,7 +523,7 @@ testSuspendTeam brig galley = do
       <!! const 201 === statusCode
   let Just (invitee, Just email) = (userId &&& userEmail) <$> responseJsonMaybe rsp2
   -- invite invitee2 (don't register)
-  let invite2 = InvitationRequest inviteeEmail2 (Name "Bob") Nothing Nothing
+  let invite2 = stdInvitationRequest inviteeEmail2 (Name "Bob") Nothing Nothing
   inv2 <- responseJsonError =<< postInvitation brig tid inviter invite2
   Just _ <- getInvitationCode brig tid (inInvitation inv2)
   -- suspend team

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -81,7 +81,7 @@ createTeamMember brig galley owner tid perm = do
 inviteAndRegisterUser :: UserId -> TeamId -> Brig -> Http User
 inviteAndRegisterUser u tid brig = do
   inviteeEmail <- randomEmail
-  let invite = InvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
+  let invite = stdInvitationRequest inviteeEmail (Name "Bob") Nothing Nothing
   inv <- responseJsonError =<< postInvitation brig tid u invite
   Just inviteeCode <- getInvitationCode brig tid (inInvitation inv)
   rspInvitee <-
@@ -210,6 +210,19 @@ accept email code =
         "team_code" .= code
       ]
 
+extAccept :: Email -> Name -> Phone -> ActivationCode -> InvitationCode -> RequestBody
+extAccept email name phone phoneCode code =
+  RequestBodyLBS . encode $
+    object
+      [ "name" .= name,
+        "email" .= fromEmail email,
+        "password" .= defPassword,
+        "team_code" .= code,
+        "phone" .= phone,
+        "phone_code" .= phoneCode,
+        "team_code" .= code
+      ]
+
 register :: Email -> Team.BindingNewTeam -> Brig -> Http (Response (Maybe LByteString))
 register e t brig =
   post
@@ -316,3 +329,7 @@ isActivatedUser uid brig = do
   pure $ case responseJsonMaybe @[User] resp of
     Just (_ : _) -> True
     _ -> False
+
+stdInvitationRequest :: Email -> Name -> Maybe Locale -> Maybe Team.Role -> InvitationRequest
+stdInvitationRequest e inviterName loc role =
+  InvitationRequest e inviterName loc role Nothing Nothing


### PR DESCRIPTION
There are certain on-boarding flows where the inviter wants to provide more information about the invitee, particularly information about the invitee's name and phone number.

These values can be picked up during the registration process and clients (web) can pull that extra information from the invitation and add it to the `/register` call.

The new integration test shows how this can be used by our webapp in order to enhance the invitation process.