### PR TITLE
Better defaults

### DIFF
--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -450,10 +450,10 @@ data Settings
   deriving (Show, Generic)
 
 defMaxKeyLen :: Int64
-defMaxKeyLen = 256
+defMaxKeyLen = 1024
 
 defMaxValueLen :: Int64
-defMaxValueLen = 512
+defMaxValueLen = 524288
 
 defDeleteThrottleMillis :: Int
 defDeleteThrottleMillis = 100


### PR DESCRIPTION
especially for the folders feature: https://wire.com/en/blog/folders-feature/

These precise numbers were introduced also here:
https://github.com/wireapp/wire-server-deploy/pull/173