### PR TITLE
Minimize dependencies of all brig binaries

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 824497871484175c7f832e5e32d20687f9bad1ad0835054aa6cc42dd7cb68c25
+-- hash: 2d75605e990ced662e68a90ee59831680ff15d186c31a1e37c95f7783cb96b1b
 
 name:           brig
 version:        1.35.0
@@ -233,123 +233,23 @@ library brig-index-lib
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -O2 -Wall -fwarn-tabs -optP-Wno-nonportable-include-path -funbox-strict-fields
   build-depends:
-      HaskellNet >=0.3
-    , HaskellNet-SSL >=0.3
-    , HsOpenSSL >=0.10
-    , HsOpenSSL-x509-system >=0.1
-    , MonadRandom >=0.5
-    , aeson >=0.11
-    , amazonka >=1.3.7
-    , amazonka-dynamodb >=1.3.7
-    , amazonka-ses >=1.3.7
-    , amazonka-sns >=1.3.7
-    , amazonka-sqs >=1.3.7
-    , async >=2.1
-    , attoparsec >=0.12
-    , auto-update >=0.1
+      aeson
     , base
-    , base-prelude
-    , base16-bytestring >=0.1
-    , base64-bytestring >=1.0
-    , bilge >=0.21.1
-    , blaze-builder >=0.3
-    , bloodhound >=0.13
+    , bloodhound
     , brig
-    , brig-types >=0.91.1
-    , bytestring >=0.10
-    , bytestring-conversion >=0.2
     , cassandra-util >=0.12
-    , conduit >=1.2.8
-    , containers >=0.5
-    , cookie >=0.4
-    , cryptobox-haskell >=0.1.1
-    , currency-codes >=2.0
-    , data-default >=0.5
-    , data-timeout >=0.3
-    , directory >=1.2
-    , either >=4.3
-    , email-validate >=2.0
-    , enclosed-exceptions >=1.0
-    , errors >=1.4
     , exceptions
-    , extended
-    , extra >=1.3
-    , filepath >=1.3
-    , fsnotify >=0.2
-    , galley-types >=0.75.3
-    , geoip2 >=0.3.1.0
-    , gundeck-types >=1.32.1
-    , hashable >=1.2
-    , html-entities >=1.1
     , http-client
-    , http-client-openssl >=0.2
-    , http-types >=0.8
     , imports
-    , iproute >=1.5
-    , iso639 >=0.1
     , lens
-    , lens-aeson >=1.0
-    , lifted-base >=0.2
     , metrics-core
-    , metrics-wai >=0.3
-    , mime
-    , mime-mail >=0.4
-    , monad-control >=1.0
     , mtl
-    , multihash >=0.1.3
-    , mwc-random
-    , network >=2.4
-    , network-conduit-tls
-    , network-uri >=2.6
     , optparse-applicative >=0.13
-    , pem >=0.2
-    , prometheus-client
-    , proto-lens >=0.1
-    , random-shuffle >=0.0.3
-    , resource-pool >=0.2
-    , resourcet >=1.1
-    , retry >=0.7
-    , ropes >=0.4.20
-    , safe >=0.3
-    , scientific >=0.3.4
-    , scrypt >=0.5
-    , semigroups >=0.15
-    , singletons >=2.0
-    , smtp-mail >=0.1
-    , sodium-crypto-sign >=0.1
-    , split >=0.2
-    , ssl-util
-    , statistics >=0.13
-    , stomp-queue >=0.3
-    , string-conversions
-    , swagger >=0.1
-    , tagged >=0.7
-    , template >=0.2
     , text
-    , text-icu-translit >=0.1
     , time
-    , tinylog >=0.10
-    , tls >=1.3.4
-    , transformers >=0.3
-    , transformers-base >=0.4
+    , tinylog
     , types-common
-    , types-common-journal >=0.1
-    , unliftio >=0.2
-    , unliftio-core >=0.1
-    , unordered-containers >=0.2
     , uri-bytestring
-    , uuid >=1.3.5
-    , vault >=0.3
-    , vector >=0.11
-    , wai >=3.0
-    , wai-extra >=3.0
-    , wai-middleware-gunzip >=0.0.2
-    , wai-predicates >=0.8
-    , wai-routing >=0.12
-    , wai-utilities >=0.16
-    , warp >=3.0.12.1
-    , yaml >=0.8.22
-    , zauth >=0.10.3
   default-language: Haskell2010
 
 executable brig
@@ -359,123 +259,13 @@ executable brig
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -O2 -Wall -fwarn-tabs -optP-Wno-nonportable-include-path -funbox-strict-fields -threaded -with-rtsopts=-N1 -with-rtsopts=-T -rtsopts
   build-depends:
-      HaskellNet >=0.3
-    , HaskellNet-SSL >=0.3
-    , HsOpenSSL >=0.10
-    , HsOpenSSL-x509-system >=0.1
-    , MonadRandom >=0.5
-    , aeson >=0.11
-    , amazonka >=1.3.7
-    , amazonka-dynamodb >=1.3.7
-    , amazonka-ses >=1.3.7
-    , amazonka-sns >=1.3.7
-    , amazonka-sqs >=1.3.7
-    , async >=2.1
-    , attoparsec >=0.12
-    , auto-update >=0.1
+      HsOpenSSL
     , base
-    , base-prelude
-    , base16-bytestring >=0.1
-    , base64-bytestring >=1.0
-    , bilge >=0.21.1
-    , blaze-builder >=0.3
-    , bloodhound >=0.13
     , brig
-    , brig-types >=0.91.1
-    , bytestring >=0.10
-    , bytestring-conversion >=0.2
-    , cassandra-util >=0.16.2
-    , conduit >=1.2.8
-    , containers >=0.5
-    , cookie >=0.4
-    , cryptobox-haskell >=0.1.1
-    , currency-codes >=2.0
-    , data-default >=0.5
-    , data-timeout >=0.3
     , directory >=1.3
-    , either >=4.3
-    , email-validate >=2.0
-    , enclosed-exceptions >=1.0
-    , errors >=1.4
-    , exceptions >=0.5
-    , extended
-    , extra >=1.3
-    , filepath >=1.3
-    , fsnotify >=0.2
-    , galley-types >=0.75.3
-    , geoip2 >=0.3.1.0
-    , gundeck-types >=1.32.1
-    , hashable >=1.2
-    , html-entities >=1.1
-    , http-client >=0.5
-    , http-client-openssl >=0.2
-    , http-types >=0.8
     , imports
-    , iproute >=1.5
-    , iso639 >=0.1
-    , lens >=3.8
-    , lens-aeson >=1.0
-    , lifted-base >=0.2
-    , metrics-core >=0.3
-    , metrics-wai >=0.3
-    , mime
-    , mime-mail >=0.4
-    , monad-control >=1.0
-    , mtl >=2.1
-    , multihash >=0.1.3
-    , mwc-random
-    , network >=2.4
-    , network-conduit-tls
-    , network-uri >=2.6
     , optparse-applicative >=0.10
-    , pem >=0.2
-    , prometheus-client
-    , proto-lens >=0.1
-    , random-shuffle >=0.0.3
-    , resource-pool >=0.2
-    , resourcet >=1.1
-    , retry >=0.7
-    , ropes >=0.4.20
-    , safe >=0.3
-    , scientific >=0.3.4
-    , scrypt >=0.5
-    , semigroups >=0.15
-    , singletons >=2.0
-    , smtp-mail >=0.1
-    , sodium-crypto-sign >=0.1
-    , split >=0.2
-    , ssl-util
-    , statistics >=0.13
-    , stomp-queue >=0.3
-    , string-conversions
-    , swagger >=0.1
-    , tagged >=0.7
-    , template >=0.2
-    , text >=0.11
-    , text-icu-translit >=0.1
-    , time >=1.1
-    , tinylog >=0.10
-    , tls >=1.3.4
-    , transformers >=0.3
-    , transformers-base >=0.4
     , types-common
-    , types-common-journal >=0.1
-    , unliftio >=0.2
-    , unliftio-core >=0.1
-    , unordered-containers >=0.2
-    , uri-bytestring >=0.2
-    , uuid >=1.3.5
-    , vault >=0.3
-    , vector >=0.11
-    , wai >=3.0
-    , wai-extra >=3.0
-    , wai-middleware-gunzip >=0.0.2
-    , wai-predicates >=0.8
-    , wai-routing >=0.12
-    , wai-utilities >=0.16
-    , warp >=3.0.12.1
-    , yaml >=0.8.22
-    , zauth >=0.10.3
   default-language: Haskell2010
 
 executable brig-index
@@ -485,123 +275,11 @@ executable brig-index
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -O2 -Wall -fwarn-tabs -optP-Wno-nonportable-include-path -funbox-strict-fields -threaded -with-rtsopts=-N
   build-depends:
-      HaskellNet >=0.3
-    , HaskellNet-SSL >=0.3
-    , HsOpenSSL >=0.10
-    , HsOpenSSL-x509-system >=0.1
-    , MonadRandom >=0.5
-    , aeson >=0.11
-    , amazonka >=1.3.7
-    , amazonka-dynamodb >=1.3.7
-    , amazonka-ses >=1.3.7
-    , amazonka-sns >=1.3.7
-    , amazonka-sqs >=1.3.7
-    , async >=2.1
-    , attoparsec >=0.12
-    , auto-update >=0.1
-    , base
-    , base-prelude
-    , base16-bytestring >=0.1
-    , base64-bytestring >=1.0
-    , bilge >=0.21.1
-    , blaze-builder >=0.3
-    , bloodhound >=0.13
+      base
     , brig-index-lib
-    , brig-types >=0.91.1
-    , bytestring >=0.10
-    , bytestring-conversion >=0.2
-    , cassandra-util >=0.16.2
-    , conduit >=1.2.8
-    , containers >=0.5
-    , cookie >=0.4
-    , cryptobox-haskell >=0.1.1
-    , currency-codes >=2.0
-    , data-default >=0.5
-    , data-timeout >=0.3
-    , directory >=1.2
-    , either >=4.3
-    , email-validate >=2.0
-    , enclosed-exceptions >=1.0
-    , errors >=1.4
-    , exceptions >=0.5
-    , extended
-    , extra >=1.3
-    , filepath >=1.3
-    , fsnotify >=0.2
-    , galley-types >=0.75.3
-    , geoip2 >=0.3.1.0
-    , gundeck-types >=1.32.1
-    , hashable >=1.2
-    , html-entities >=1.1
-    , http-client >=0.5
-    , http-client-openssl >=0.2
-    , http-types >=0.8
     , imports
-    , iproute >=1.5
-    , iso639 >=0.1
-    , lens >=3.8
-    , lens-aeson >=1.0
-    , lifted-base >=0.2
-    , metrics-core >=0.3
-    , metrics-wai >=0.3
-    , mime
-    , mime-mail >=0.4
-    , monad-control >=1.0
-    , mtl >=2.1
-    , multihash >=0.1.3
-    , mwc-random
-    , network >=2.4
-    , network-conduit-tls
-    , network-uri >=2.6
-    , optparse-applicative >=0.11
-    , pem >=0.2
-    , prometheus-client
-    , proto-lens >=0.1
-    , random-shuffle >=0.0.3
-    , resource-pool >=0.2
-    , resourcet >=1.1
-    , retry >=0.7
-    , ropes >=0.4.20
-    , safe >=0.3
-    , scientific >=0.3.4
-    , scrypt >=0.5
-    , semigroups >=0.15
-    , singletons >=2.0
-    , smtp-mail >=0.1
-    , sodium-crypto-sign >=0.1
-    , split >=0.2
-    , ssl-util
-    , statistics >=0.13
-    , stomp-queue >=0.3
-    , string-conversions
-    , swagger >=0.1
-    , tagged >=0.7
-    , template >=0.2
-    , text >=0.11
-    , text-icu-translit >=0.1
-    , time >=1.1
-    , tinylog >=0.10
-    , tls >=1.3.4
-    , transformers >=0.3
-    , transformers-base >=0.4
-    , types-common >=0.16
-    , types-common-journal >=0.1
-    , unliftio >=0.2
-    , unliftio-core >=0.1
-    , unordered-containers >=0.2
-    , uri-bytestring >=0.2
-    , uuid >=1.3.5
-    , vault >=0.3
-    , vector >=0.11
-    , wai >=3.0
-    , wai-extra >=3.0
-    , wai-middleware-gunzip >=0.0.2
-    , wai-predicates >=0.8
-    , wai-routing >=0.12
-    , wai-utilities >=0.16
-    , warp >=3.0.12.1
-    , yaml >=0.8.22
-    , zauth >=0.10.3
+    , optparse-applicative
+    , tinylog
   default-language: Haskell2010
 
 executable brig-integration
@@ -635,136 +313,70 @@ executable brig-integration
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -O2 -Wall -fwarn-tabs -optP-Wno-nonportable-include-path -funbox-strict-fields
   build-depends:
-      HaskellNet >=0.3
-    , HaskellNet-SSL >=0.3
-    , HsOpenSSL
-    , HsOpenSSL-x509-system >=0.1
-    , MonadRandom >=0.5
-    , aeson >=0.11
-    , amazonka >=1.3.7
-    , amazonka-dynamodb >=1.3.7
-    , amazonka-ses >=1.3.7
-    , amazonka-sns >=1.3.7
-    , amazonka-sqs >=1.3.7
+      HsOpenSSL
+    , aeson
     , async
     , attoparsec
-    , auto-update >=0.1
-    , base ==4.*
-    , base-prelude
-    , base16-bytestring >=0.1
-    , base64-bytestring >=1.0
+    , base
     , bilge
-    , blaze-builder >=0.3
-    , bloodhound >=0.13
+    , bloodhound
     , brig
     , brig-index-lib
     , brig-types
     , bytestring >=0.9
-    , bytestring-conversion >=0.2
+    , bytestring-conversion
     , cargohold-types
     , case-insensitive
     , cassandra-util
-    , conduit >=1.2.8
-    , containers >=0.5
-    , cookie >=0.4
-    , cryptobox-haskell >=0.1.1
-    , currency-codes >=2.0
-    , data-default >=0.5
+    , containers
+    , cookie
     , data-timeout
-    , directory >=1.2
-    , either >=4.3
-    , email-validate >=2.0
-    , enclosed-exceptions >=1.0
-    , errors >=1.4
-    , exceptions >=0.5
-    , extended
+    , exceptions
     , extra
     , filepath >=1.4
-    , fsnotify >=0.2
     , galley-types
-    , geoip2 >=0.3.1.0
     , gundeck-types
-    , hashable >=1.2
-    , html-entities >=1.1
     , http-client
-    , http-client-openssl >=0.2
     , http-client-tls >=0.2
-    , http-types >=0.8
+    , http-types
     , imports
-    , iproute >=1.5
-    , iso639 >=0.1
     , lens >=3.9
-    , lens-aeson >=1.0
-    , lifted-base >=0.2
-    , metrics-core >=0.3
+    , lens-aeson
     , metrics-wai
     , mime >=0.4
-    , mime-mail >=0.4
-    , monad-control >=1.0
-    , mtl >=2.1
-    , multihash >=0.1.3
-    , mwc-random
     , network
-    , network-conduit-tls
-    , network-uri >=2.6
     , options >=0.1
-    , optparse-applicative >=0.11
+    , optparse-applicative
     , pem
-    , prometheus-client
     , proto-lens
     , random >=1.0
-    , random-shuffle >=0.0.3
-    , resource-pool >=0.2
-    , resourcet >=1.1
     , retry >=0.6
-    , ropes >=0.4.20
-    , safe >=0.3
-    , scientific >=0.3.4
-    , scrypt >=0.5
+    , safe
     , semigroups
-    , singletons >=2.0
-    , smtp-mail >=0.1
-    , sodium-crypto-sign >=0.1
-    , split >=0.2
-    , ssl-util
-    , statistics >=0.13
-    , stomp-queue >=0.3
     , string-conversions
-    , swagger >=0.1
-    , tagged >=0.7
     , tasty >=1.0
     , tasty-cannon >=0.3.4
     , tasty-hunit >=0.2
-    , template >=0.2
     , temporary >=1.2.1
-    , text >=0.11
-    , text-icu-translit >=0.1
+    , text
     , time >=1.5
     , tinylog
-    , tls >=1.3.4
-    , transformers >=0.3
-    , transformers-base >=0.4
     , types-common >=0.3
     , types-common-aws >=0.1
-    , types-common-journal >=0.1
+    , types-common-journal
     , unix >=2.5
     , unliftio
-    , unliftio-core >=0.1
     , unordered-containers
     , uri-bytestring >=0.2
-    , uuid >=1.3.5
-    , vault >=0.3
+    , uuid
     , vector >=0.10
     , wai
-    , wai-extra >=3.0
-    , wai-middleware-gunzip >=0.0.2
-    , wai-predicates >=0.8
+    , wai-extra
     , wai-route
-    , wai-routing >=0.12
     , wai-utilities >=0.9
     , warp
     , warp-tls >=3.2
-    , yaml >=0.8.22
+    , yaml
     , zauth
   default-language: Haskell2010
 
@@ -826,126 +438,19 @@ executable brig-schema
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -O2 -Wall -fwarn-tabs -optP-Wno-nonportable-include-path -funbox-strict-fields
   build-depends:
-      HaskellNet >=0.3
-    , HaskellNet-SSL >=0.3
-    , HsOpenSSL >=0.10
-    , HsOpenSSL-x509-system >=0.1
-    , MonadRandom >=0.5
-    , aeson >=0.11
-    , amazonka >=1.3.7
-    , amazonka-dynamodb >=1.3.7
-    , amazonka-ses >=1.3.7
-    , amazonka-sns >=1.3.7
-    , amazonka-sqs >=1.3.7
-    , async >=2.1
-    , attoparsec >=0.12
-    , auto-update >=0.1
-    , base
-    , base-prelude
-    , base16-bytestring >=0.1
-    , base64-bytestring >=1.0
-    , bilge >=0.21.1
-    , blaze-builder >=0.3
-    , bloodhound >=0.13
-    , brig-types >=0.91.1
-    , bytestring >=0.10
-    , bytestring-conversion >=0.2
+      base
     , cassandra-util >=0.12
-    , conduit >=1.2.8
-    , containers >=0.5
-    , cookie >=0.4
-    , cryptobox-haskell >=0.1.1
-    , currency-codes >=2.0
-    , data-default >=0.5
-    , data-timeout >=0.3
     , directory >=1.3
-    , either >=4.3
-    , email-validate >=2.0
-    , enclosed-exceptions >=1.0
-    , errors >=1.4
-    , exceptions >=0.5
     , extended
-    , extra >=1.3
-    , filepath >=1.3
-    , fsnotify >=0.2
-    , galley-types >=0.75.3
-    , geoip2 >=0.3.1.0
-    , gundeck-types >=1.32.1
-    , hashable >=1.2
-    , html-entities >=1.1
-    , http-client >=0.5
-    , http-client-openssl >=0.2
-    , http-types >=0.8
     , imports
-    , iproute >=1.5
-    , iso639 >=0.1
-    , lens >=3.8
-    , lens-aeson >=1.0
-    , lifted-base >=0.2
-    , metrics-core >=0.3
-    , metrics-wai >=0.3
-    , mime
-    , mime-mail >=0.4
-    , monad-control >=1.0
-    , mtl >=2.1
-    , multihash >=0.1.3
-    , mwc-random
-    , network >=2.4
-    , network-conduit-tls
-    , network-uri >=2.6
     , optparse-applicative >=0.10
-    , pem >=0.2
-    , prometheus-client
-    , proto-lens >=0.1
-    , random-shuffle >=0.0.3
     , raw-strings-qq >=1.0
-    , resource-pool >=0.2
-    , resourcet >=1.1
-    , retry >=0.7
-    , ropes >=0.4.20
-    , safe >=0.3
-    , scientific >=0.3.4
-    , scrypt >=0.5
-    , semigroups >=0.15
-    , singletons >=2.0
-    , smtp-mail >=0.1
-    , sodium-crypto-sign >=0.1
-    , split >=0.2
-    , ssl-util
-    , statistics >=0.13
-    , stomp-queue >=0.3
-    , string-conversions
-    , swagger >=0.1
-    , tagged >=0.7
-    , template >=0.2
     , text
-    , text-icu-translit >=0.1
-    , time >=1.1
-    , tinylog >=0.10
-    , tls >=1.3.4
-    , transformers >=0.3
-    , transformers-base >=0.4
+    , tinylog
     , types-common
-    , types-common-journal >=0.1
-    , unliftio >=0.2
-    , unliftio-core >=0.1
-    , unordered-containers >=0.2
-    , uri-bytestring >=0.2
-    , uuid >=1.3.5
-    , vault >=0.3
-    , vector >=0.11
-    , wai >=3.0
-    , wai-extra >=3.0
-    , wai-middleware-gunzip >=0.0.2
-    , wai-predicates >=0.8
-    , wai-routing >=0.12
-    , wai-utilities >=0.16
-    , warp >=3.0.12.1
-    , yaml >=0.8.22
-    , zauth >=0.10.3
   default-language: Haskell2010
 
-test-suite brig-types-tests
+test-suite brig-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
@@ -956,123 +461,14 @@ test-suite brig-types-tests
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -O2 -Wall -fwarn-tabs -optP-Wno-nonportable-include-path -funbox-strict-fields -threaded -with-rtsopts=-N
   build-depends:
-      HaskellNet >=0.3
-    , HaskellNet-SSL >=0.3
-    , HsOpenSSL >=0.10
-    , HsOpenSSL-x509-system >=0.1
-    , MonadRandom >=0.5
-    , aeson >=0.11
-    , amazonka >=1.3.7
-    , amazonka-dynamodb >=1.3.7
-    , amazonka-ses >=1.3.7
-    , amazonka-sns >=1.3.7
-    , amazonka-sqs >=1.3.7
-    , async >=2.1
-    , attoparsec >=0.12
-    , auto-update >=0.1
-    , base ==4.*
-    , base-prelude
-    , base16-bytestring >=0.1
-    , base64-bytestring >=1.0
-    , bilge >=0.21.1
-    , blaze-builder >=0.3
-    , bloodhound >=0.13
+      aeson
+    , base
+    , bloodhound
     , brig
-    , brig-types >=0.91.1
-    , bytestring >=0.10
-    , bytestring-conversion >=0.2
-    , cassandra-util >=0.16.2
-    , conduit >=1.2.8
-    , containers >=0.5
-    , cookie >=0.4
-    , cryptobox-haskell >=0.1.1
-    , currency-codes >=2.0
-    , data-default >=0.5
-    , data-timeout >=0.3
-    , directory >=1.2
-    , either >=4.3
-    , email-validate >=2.0
-    , enclosed-exceptions >=1.0
-    , errors >=1.4
-    , exceptions >=0.5
-    , extended
-    , extra >=1.3
-    , filepath >=1.3
-    , fsnotify >=0.2
-    , galley-types >=0.75.3
-    , geoip2 >=0.3.1.0
-    , gundeck-types >=1.32.1
-    , hashable >=1.2
-    , html-entities >=1.1
-    , http-client >=0.5
-    , http-client-openssl >=0.2
-    , http-types >=0.8
+    , brig-types
     , imports
-    , iproute >=1.5
-    , iso639 >=0.1
-    , lens >=3.8
-    , lens-aeson >=1.0
-    , lifted-base >=0.2
-    , metrics-core >=0.3
-    , metrics-wai >=0.3
-    , mime
-    , mime-mail >=0.4
-    , monad-control >=1.0
-    , mtl >=2.1
-    , multihash >=0.1.3
-    , mwc-random
-    , network >=2.4
-    , network-conduit-tls
-    , network-uri >=2.6
-    , optparse-applicative >=0.11
-    , pem >=0.2
-    , prometheus-client
-    , proto-lens >=0.1
-    , random-shuffle >=0.0.3
-    , resource-pool >=0.2
-    , resourcet >=1.1
-    , retry >=0.7
-    , ropes >=0.4.20
-    , safe >=0.3
-    , scientific >=0.3.4
-    , scrypt >=0.5
-    , semigroups >=0.15
-    , singletons >=2.0
-    , smtp-mail >=0.1
-    , sodium-crypto-sign >=0.1
-    , split >=0.2
-    , ssl-util
-    , statistics >=0.13
-    , stomp-queue >=0.3
-    , string-conversions
-    , swagger >=0.1
-    , tagged >=0.7
     , tasty
     , tasty-hunit
-    , template >=0.2
-    , text >=0.11
-    , text-icu-translit >=0.1
-    , time >=1.1
-    , tinylog >=0.10
-    , tls >=1.3.4
-    , transformers >=0.3
-    , transformers-base >=0.4
-    , types-common >=0.16
-    , types-common-journal >=0.1
-    , unliftio >=0.2
-    , unliftio-core >=0.1
-    , unordered-containers >=0.2
-    , uri-bytestring >=0.2
-    , uuid >=1.3.5
-    , vault >=0.3
-    , vector >=0.11
-    , wai >=3.0
-    , wai-extra >=3.0
-    , wai-middleware-gunzip >=0.0.2
-    , wai-predicates >=0.8
-    , wai-routing >=0.12
-    , wai-utilities >=0.16
-    , warp >=3.0.12.1
-    , yaml >=0.8.22
-    , zauth >=0.10.3
+    , types-common
+    , uuid
   default-language: Haskell2010

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -10,126 +10,10 @@ copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
 ghc-options:
 - -funbox-strict-fields
-dependencies:
-- aeson >=0.11
-- amazonka >=1.3.7
-- amazonka-dynamodb >=1.3.7
-- amazonka-ses >=1.3.7
-- amazonka-sns >=1.3.7
-- amazonka-sqs >=1.3.7
-- async >=2.1
-- attoparsec >=0.12
-- auto-update >=0.1
-- base16-bytestring >=0.1
-- base ==4.*
-- base64-bytestring >=1.0
-- base-prelude
-- bilge >=0.21.1
-- blaze-builder >=0.3
-- bloodhound >=0.13
-- brig-types >=0.91.1
-- bytestring >=0.10
-- bytestring-conversion >=0.2
-- cassandra-util >=0.16.2
-- conduit >=1.2.8
-- containers >=0.5
-- cookie >=0.4
-- cryptobox-haskell >=0.1.1
-- currency-codes >=2.0
-- data-default >=0.5
-- data-timeout >=0.3
-- directory >=1.2
-- either >=4.3
-- email-validate >=2.0
-- enclosed-exceptions >=1.0
-- errors >=1.4
-- exceptions >=0.5
-- extended
-- extra >=1.3
-- filepath >=1.3
-- fsnotify >=0.2
-- galley-types >=0.75.3
-- geoip2 >=0.3.1.0
-- gundeck-types >=1.32.1
-- hashable >=1.2
-- HaskellNet >=0.3
-- HaskellNet-SSL >=0.3
-- HsOpenSSL >=0.10
-- HsOpenSSL-x509-system >=0.1
-- html-entities >=1.1
-- http-client >=0.5
-- http-client-openssl >=0.2
-- http-types >=0.8
-- imports
-- iproute >=1.5
-- iso639 >=0.1
-- lens >=3.8
-- lens-aeson >=1.0
-- lifted-base >=0.2
-- metrics-core >=0.3
-- metrics-wai >=0.3
-- mime
-- mime-mail >=0.4
-- monad-control >=1.0
-- MonadRandom >=0.5
-- mtl >=2.1
-- multihash >=0.1.3
-- mwc-random
-- network >=2.4
-- network-conduit-tls
-- network-uri >=2.6
-- optparse-applicative >=0.11
-- pem >=0.2
-- prometheus-client
-- proto-lens >=0.1
-- random-shuffle >=0.0.3
-- resource-pool >=0.2
-- resourcet >=1.1
-- retry >=0.7
-- ropes >=0.4.20
-- safe >=0.3
-- scientific >=0.3.4
-- scrypt >=0.5
-- semigroups >=0.15
-- singletons >=2.0
-- smtp-mail >=0.1
-- sodium-crypto-sign >=0.1
-- split >=0.2
-- ssl-util
-- statistics >=0.13
-- stomp-queue >=0.3
-- string-conversions
-- swagger >=0.1
-- tagged >=0.7
-- template >=0.2
-- text >=0.11
-- text-icu-translit >=0.1
-- time >=1.1
-- tinylog >=0.10
-- tls >=1.3.4
-- transformers >=0.3
-- transformers-base >=0.4
-- types-common >=0.16
-- types-common-journal >=0.1
-- unliftio >=0.2
-- unliftio-core >=0.1
-- unordered-containers >=0.2
-- uri-bytestring >=0.2
-- uuid >=1.3.5
-- vault >=0.3
-- vector >=0.11
-- wai >=3.0
-- wai-extra >=3.0
-- wai-middleware-gunzip >=0.0.2
-- wai-predicates >=0.8
-- wai-routing >=0.12
-- wai-utilities >=0.16
-- warp >=3.0.12.1
-- yaml >=0.8.22
-- zauth >=0.10.3
 library:
   source-dirs: src
   dependencies:
+  - aeson >=0.11
   - amazonka >=1.3.7
   - amazonka-dynamodb >=1.3.7
   - amazonka-ses >=1.3.7
@@ -138,37 +22,51 @@ library:
   - attoparsec >=0.12
   - async >=2.1
   - auto-update >=0.1
+  - base ==4.*
   - base-prelude
   - base16-bytestring >=0.1
+  - base64-bytestring >=1.0
   - bilge >=0.21.1
   - blaze-builder >=0.3
+  - bloodhound >=0.13
   - brig-types >=0.91.1
   - bytestring >=0.10
+  - bytestring-conversion >=0.2
   - cassandra-util >=0.16.2
   - currency-codes >=2.0
   - conduit >=1.2.8
+  - containers >=0.5
+  - cookie >=0.4
   - cryptobox-haskell >=0.1.1
   - data-default >=0.5
   - data-timeout >=0.3
+  - directory >=1.2
   - either >=4.3
   - email-validate >=2.0
   - enclosed-exceptions >=1.0
+  - errors >=1.4
   - extra >=1.3
+  - exceptions >=0.5
+  - extended
   - geoip2 >=0.3.1.0
   - galley-types >=0.75.3
   - gundeck-types >=1.32.1
+  - imports
   - filepath >=1.3
   - fsnotify >=0.2
   - iso639 >=0.1
   - hashable >=1.2
   - html-entities >=1.1
   - http-client >=0.5
+  - http-types >=0.8
   - http-client-openssl >=0.2
   - HaskellNet >=0.3
   - HaskellNet-SSL >=0.3
+  - HsOpenSSL >=0.10
   - HsOpenSSL-x509-system >=0.1
   - iproute >=1.5
   - lens >=3.8
+  - lens-aeson >=1.0
   - lifted-base >=0.2
   - mime
   - mime-mail >=0.4
@@ -177,15 +75,19 @@ library:
   - monad-control >=1.0
   - MonadRandom >=0.5
   - multihash >=0.1.3
+  - mtl >=2.1
   - mwc-random
   - network >=2.4
   - network-conduit-tls
   - network-uri >=2.6
+  - optparse-applicative >=0.11
   - pem >=0.2
   - proto-lens >=0.1
+  - prometheus-client
   - resourcet >=1.1
   - resource-pool >=0.2
   - ropes >=0.4.20
+  - safe >=0.3
   - scientific >=0.3.4
   - scrypt >=0.5
   - smtp-mail >=0.1
@@ -201,40 +103,51 @@ library:
   - swagger >=0.1
   - tagged >=0.7
   - template >=0.2
+  - text >=0.11
   - text-icu-translit >=0.1
   - time >=1.1
+  - tinylog >=0.10
   - tls >=1.3.4
+  - transformers >=0.3
   - transformers-base >=0.4
   - types-common >=0.16
+  - types-common-journal >=0.1
   - retry >=0.7
   - unliftio >=0.2
   - unliftio-core >=0.1
   - unordered-containers >=0.2
   - uri-bytestring >=0.2
+  - uuid >=1.3.5
   - vault >=0.3
   - vector >=0.11
   - wai >=3.0
+  - wai-extra >=3.0
   - wai-middleware-gunzip >=0.0.2
   - wai-predicates >=0.8
   - wai-routing >=0.12
   - wai-utilities >=0.16
   - warp >=3.0.12.1
+  - yaml >=0.8.22
   - zauth >=0.10.3
 internal-libraries:
   brig-index-lib:
     source-dirs: index/src
     dependencies:
+    - aeson
     - base
+    - bloodhound
     - brig
     - cassandra-util >=0.12
     - exceptions
     - http-client
+    - imports
     - lens
     - metrics-core
     - mtl
     - optparse-applicative >=0.13
     - text
     - time
+    - tinylog
     - types-common
     - uri-bytestring
 tests:
@@ -245,9 +158,16 @@ tests:
     - -threaded
     - -with-rtsopts=-N
     dependencies:
+    - aeson
+    - base
+    - bloodhound
     - brig
+    - brig-types
+    - imports
     - tasty
     - tasty-hunit
+    - types-common
+    - uuid
 executables:
   brig-schema:
     main: Main.hs
@@ -256,61 +176,81 @@ executables:
     - base
     - cassandra-util >=0.12
     - directory >=1.3
+    - extended
     - optparse-applicative >=0.10
     - raw-strings-qq >=1.0
+    - imports
     - text
+    - tinylog
     - types-common
   brig-integration:
     main: Main.hs
     source-dirs: test/integration
     dependencies:
+    - aeson
     - async
     - attoparsec
     - bilge
+    - bloodhound
+    - base
     - brig
     - brig-index-lib
     - brig-types
     - bytestring >=0.9
+    - bytestring-conversion
     - cargohold-types
     - case-insensitive
     - cassandra-util
+    - containers
+    - cookie
     - data-timeout
     - extra
+    - exceptions
     - filepath >=1.4
     - galley-types
     - gundeck-types
     - HsOpenSSL
     - http-client
     - http-client-tls >=0.2
+    - http-types
+    - imports
     - lens >=3.9
+    - lens-aeson
     - metrics-wai
     - mime >=0.4
     - network
     - options >=0.1
+    - optparse-applicative
     - pem
     - proto-lens
     - random >=1.0
     - retry >=0.6
+    - safe
     - semigroups
     - string-conversions
     - tasty >=1.0
     - tasty-cannon >=0.3.4
     - tasty-hunit >=0.2
     - temporary >=1.2.1
+    - text
     - time >=1.5
     - tinylog
     - types-common >=0.3
     - types-common-aws >=0.1
+    - types-common-journal
     - unix >=2.5
     - unliftio
     - unordered-containers
     - uri-bytestring >=0.2
+    - uuid
     - vector >=0.10
     - wai
+    - wai-extra
     - wai-route
     - wai-utilities >=0.9
     - warp
     - warp-tls >=3.2
+    - yaml
     - zauth
   brig-index:
     main: index/src/Main.hs
@@ -320,6 +260,9 @@ executables:
     dependencies:
     - base
     - brig-index-lib
+    - imports
+    - optparse-applicative
+    - tinylog
   brig:
     main: src/Main.hs
     ghc-options:
@@ -331,5 +274,7 @@ executables:
     - base
     - brig
     - directory >=1.3
+    - HsOpenSSL
+    - imports
     - optparse-applicative >=0.10
     - types-common


### PR DESCRIPTION
Changes in #964 were causing brig-schema to depend on cryptobox, libsodium, etc, which failed the build in staging. This PR reverts that.