### PR TITLE
Use status 403 for 'not implemented'

### DIFF
--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -459,7 +459,7 @@ legalHoldNotEnabled = Wai.Error status403 "legalhold-not-enabled" "LegalHold mus
 federationNotImplemented :: forall a. Typeable a => NonEmpty (IdMapping a) -> Wai.Error
 federationNotImplemented qualified =
   Wai.Error
-    status501
+    status403
     "federation-not-implemented"
     ("Federation is not implemented, but global qualified IDs (" <> idType <> ") found: " <> rendered)
   where

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -198,7 +198,7 @@ customBackendNotFound domain =
 federationNotImplemented :: forall a. Typeable a => NonEmpty (IdMapping a) -> Error
 federationNotImplemented qualified =
   Error
-    status501
+    status403
     "federation-not-implemented"
     ("Federation is not implemented, but global qualified IDs (" <> idType <> ") found: " <> rendered)
   where


### PR DESCRIPTION
1) For consistency of other "not implemented uses" (e.g. in
   services/galley/src/Galley/API/Error.hs:178)
2) To avoid 5xx metrics/logs and unactionable alarms to go off by accident.

It's known that 501 would be the semantically correct code to use. This
change is a pragmatic one in our deployment context.