### PR TITLE
Rename brig's userName to userDisplayName to avoid confusion

### DIFF
--- a/libs/api-bot/src/Network/Wire/Bot/Cache.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Cache.hs
@@ -68,7 +68,7 @@ toUser _ acc [i, e, p] = do
       pw
       User
         { userId = ui,
-          userName = Name $ "Fakebot-" <> Text.toStrict (Text.strip i),
+          userDisplayName = Name $ "Fakebot-" <> Text.toStrict (Text.strip i),
           userPict = Pict [],
           userAssets = [],
           userIdentity = Just (EmailIdentity em),

--- a/libs/api-bot/src/Network/Wire/Bot/Monad.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Monad.hs
@@ -354,7 +354,7 @@ botId :: Bot -> UserId
 botId = userId . botUser
 
 botName :: Bot -> Text
-botName = fromName . userName . botUser
+botName = fromName . userDisplayName . botUser
 
 botEmail :: Bot -> Maybe Text
 botEmail = fmap fromEmail . userEmail . botUser
@@ -949,7 +949,7 @@ randUser (Email loc dom) (BotTag tag) = do
   let passw = PlainTextPassword (pack (toString pwdUuid))
   return
     ( NewUser
-        { newUserName = Name (tag <> "-Wirebot-" <> pack (toString uuid)),
+        { newUserDisplayName = Name (tag <> "-Wirebot-" <> pack (toString uuid)),
           newUserUUID = Nothing,
           newUserIdentity = Just (EmailIdentity email),
           newUserPassword = Just passw,
@@ -974,4 +974,4 @@ randMailbox = do
   return $ botNetMailboxes e !! i
 
 tagged :: BotTag -> User -> User
-tagged t u = u {userName = Name $ unTag t <> "-" <> fromName (userName u)}
+tagged t u = u {userDisplayName = Name $ unTag t <> "-" <> fromName (userDisplayName u)}

--- a/libs/brig-types/src/Brig/Types/Swagger.hs
+++ b/libs/brig-types/src/Brig/Types/Swagger.hs
@@ -15,7 +15,7 @@ brigModels =
   [ -- User
     self,
     user,
-    userName,
+    userDisplayName,
     newUser,
     userUpdate,
     emailUpdate,
@@ -197,8 +197,8 @@ richInfo = defineModel "RichInfo" $ do
   property "version" int32' $
     description "Format version (the current version is 0)"
 
-userName :: Model
-userName = defineModel "UserName" $ do
+userDisplayName :: Model
+userDisplayName = defineModel "UserDisplayName" $ do
   description "User name"
   property "name" string' $
     description "User name"

--- a/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
+++ b/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
@@ -226,7 +226,7 @@ instance Arbitrary NewUser where
     let isTeamUser = case newUserOrigin of
           Just (NewUserOriginTeamUser _) -> True
           _ -> False
-    newUserName <- arbitrary
+    newUserDisplayName <- arbitrary
     newUserUUID <- elements [Just nil, Nothing]
     newUserPict <- arbitrary
     newUserAssets <- arbitrary

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -107,7 +107,7 @@ connectedProfile u =
   UserProfile
     { profileId = userId u,
       profileHandle = userHandle u,
-      profileName = userName u,
+      profileName = userDisplayName u,
       profilePict = userPict u,
       profileAssets = userAssets u,
       profileAccentId = userAccentId u,
@@ -162,7 +162,7 @@ data User
         -- verified. {#RefActivation}
         userIdentity :: !(Maybe UserIdentity),
         -- | required; non-unique
-        userName :: !Name,
+        userDisplayName :: !Name,
         -- | DEPRECATED
         userPict :: !Pict,
         userAssets :: [Asset],
@@ -221,7 +221,7 @@ instance ToJSON User where
   toJSON u =
     object $
       "id" .= userId u
-        # "name" .= userName u
+        # "name" .= userDisplayName u
         # "picture" .= userPict u
         # "assets" .= userAssets u
         # "email" .= userEmail u
@@ -454,7 +454,7 @@ emptyRichInfoAssocList = RichInfoAssocList []
 
 data NewUser
   = NewUser
-      { newUserName :: !Name,
+      { newUserDisplayName :: !Name,
         -- | use this as 'UserId' (if 'Nothing', call 'Data.UUID.nextRandom').
         newUserUUID :: !(Maybe UUID),
         newUserIdentity :: !(Maybe UserIdentity),
@@ -536,7 +536,7 @@ newUserSSOId = ssoIdentity <=< newUserIdentity
 instance FromJSON NewUser where
   parseJSON = withObject "new-user" $ \o -> do
     ssoid <- o .:? "sso_id"
-    newUserName <- o .: "name"
+    newUserDisplayName <- o .: "name"
     newUserUUID <- o .:? "uuid"
     newUserIdentity <- parseIdentity ssoid o
     newUserPict <- o .:? "picture"
@@ -558,7 +558,7 @@ instance FromJSON NewUser where
 instance ToJSON NewUser where
   toJSON u =
     object $
-      "name" .= newUserName u
+      "name" .= newUserDisplayName u
         # "uuid" .= newUserUUID u
         # "email" .= newUserEmail u
         # "email_code" .= newUserEmailCode u

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -395,12 +395,12 @@ sitemap o = do
     Doc.response 200 "Update successful." Doc.end
   ---
 
-  get "/self/name" (continue getUserNameH) $
+  get "/self/name" (continue getUserDisplayNameH) $
     accept "application" "json"
       .&. header "Z-User"
   document "GET" "selfName" $ do
     Doc.summary "Get your profile name"
-    Doc.returns (Doc.ref Doc.userName)
+    Doc.returns (Doc.ref Doc.userDisplayName)
     Doc.response 200 "Profile name found." Doc.end
   ---
 
@@ -1155,7 +1155,7 @@ createUser (NewUserPublic new) = do
   let lang = userLocale usr
   lift $ do
     for_ (liftM2 (,) (userEmail usr) epair) $ \(e, p) ->
-      sendActivationEmail e (userName usr) p (Just lang) (newUserTeam new)
+      sendActivationEmail e (userDisplayName usr) p (Just lang) (newUserTeam new)
     for_ (liftM2 (,) (userPhone usr) ppair) $ \(p, c) ->
       sendActivationSms p c (Just lang)
     for_ (liftM3 (,,) (userEmail usr) (createdUserTeam result) (newUserTeam new)) $ \(e, ct, ut) ->
@@ -1236,8 +1236,8 @@ getUser self opaqueUserId = do
   resolvedUserId <- resolveOpaqueUserId opaqueUserId
   lift $ API.lookupProfile self resolvedUserId
 
-getUserNameH :: JSON ::: UserId -> Handler Response
-getUserNameH (_ ::: self) = do
+getUserDisplayNameH :: JSON ::: UserId -> Handler Response
+getUserDisplayNameH (_ ::: self) = do
   name :: Maybe Name <- lift $ API.lookupName self
   return $ case name of
     Just n -> json $ object ["name" .= n]
@@ -1706,7 +1706,7 @@ changeEmail u req sendOutEmail = do
     handleActivation usr adata en = do
       when sendOutEmail $ do
         let apair = (activationKey adata, activationCode adata)
-        let name = userName usr
+        let name = userDisplayName usr
         let ident = userIdentity usr
         let lang = userLocale usr
         lift $ sendActivationMail en name apair (Just lang) ident

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -94,7 +94,7 @@ addClient u con ip new = do
     when (count > 1)
       $ for_ (userEmail usr)
       $ \email ->
-        sendNewClientEmail (userName usr) email clt (userLocale usr)
+        sendNewClientEmail (userDisplayName usr) email clt (userLocale usr)
   return clt
   where
     clientId' = clientIdFromPrekey (unpackLastPrekey $ newClientLastKey new)

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -179,13 +179,13 @@ data AccountStatusError
 -- Exceptions
 
 -- | A user name was unexpectedly not found for an existing user ID.
-data UserNameNotFound = UserNameNotFound !UserId
+data UserDisplayNameNotFound = UserDisplayNameNotFound !UserId
   deriving (Typeable)
 
-instance Exception UserNameNotFound
+instance Exception UserDisplayNameNotFound
 
-instance Show UserNameNotFound where
-  show (UserNameNotFound uid) = "User name not found for user: " ++ show uid
+instance Show UserDisplayNameNotFound where
+  show (UserDisplayNameNotFound uid) = "User name not found for user: " ++ show uid
 
 data UserProfileNotFound = UserProfileNotFound !UserId
   deriving (Typeable)

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -599,7 +599,7 @@ sendActivationCode emailOrPhone loc call = case emailOrPhone of
           then sendActivationCall ph p loc
           else sendActivationSms ph p loc
   where
-    notFound = throwM . UserNameNotFound
+    notFound = throwM . UserDisplayNameNotFound
     mkPair k c u = do
       timeout <- setActivationTimeout <$> view settings
       case c of
@@ -616,7 +616,7 @@ sendActivationCode emailOrPhone loc call = case emailOrPhone of
       u <- maybe (notFound uid) return =<< lift (Data.lookupUser uid)
       p <- mkPair ek (Just uc) (Just uid)
       let ident = userIdentity u
-          name = userName u
+          name = userDisplayName u
           loc' = loc <|> Just (userLocale u)
       void . forEmailKey ek $ \em -> lift $ do
         -- Get user's team, if any.
@@ -786,7 +786,7 @@ deleteUser uid pwd = do
           let k = Code.codeKey c
           let v = Code.codeValue c
           let l = userLocale (accountUser a)
-          let n = userName (accountUser a)
+          let n = userDisplayName (accountUser a)
           either
             (\e -> lift $ sendDeletionEmail n e k v l)
             (\p -> lift $ sendDeletionSms p k v l)
@@ -836,7 +836,7 @@ deleteAccount account@(accountUser -> user) = do
           { accountStatus = Deleted,
             accountUser =
               user
-                { userName = Name "default",
+                { userDisplayName = Name "default",
                   userAccentId = defaultAccentId,
                   userPict = noPict,
                   userAssets = [],

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -106,7 +106,7 @@ newAccount u inv tid = do
   where
     ident = newUserIdentity u
     pass = newUserPassword u
-    name = newUserName u
+    name = newUserDisplayName u
     pict = fromMaybe noPict (newUserPict u)
     assets = newUserAssets u
     status = case ident of
@@ -166,7 +166,7 @@ insertAccount (UserAccount u status) mbConv password activated = retry x5 $ batc
   addPrepQuery
     userInsert
     ( userId u,
-      userName u,
+      userDisplayName u,
       userPict u,
       userAssets u,
       userEmail u,
@@ -208,7 +208,7 @@ updateUser :: UserId -> UserUpdate -> AppIO ()
 updateUser u UserUpdate {..} = retry x5 $ batch $ do
   setType BatchLogged
   setConsistency Quorum
-  for_ uupName $ \n -> addPrepQuery userNameUpdate (n, u)
+  for_ uupName $ \n -> addPrepQuery userDisplayNameUpdate (n, u)
   for_ uupPict $ \p -> addPrepQuery userPictUpdate (p, u)
   for_ uupAssets $ \a -> addPrepQuery userAssetsUpdate (a, u)
   for_ uupAccentId $ \c -> addPrepQuery userAccentIdUpdate (c, u)
@@ -512,8 +512,8 @@ userInsert =
   \country, provider, service, handle, team, managed_by) \
   \VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
-userNameUpdate :: PrepQuery W (Name, UserId) ()
-userNameUpdate = "UPDATE user SET name = ? WHERE id = ?"
+userDisplayNameUpdate :: PrepQuery W (Name, UserId) ()
+userDisplayNameUpdate = "UPDATE user SET name = ? WHERE id = ?"
 
 userPictUpdate :: PrepQuery W (Pict, UserId) ()
 userPictUpdate = "UPDATE user SET picture = ? WHERE id = ?"

--- a/services/brig/src/Brig/IO/Journal.hs
+++ b/services/brig/src/Brig/IO/Journal.hs
@@ -31,7 +31,7 @@ import qualified Proto.UserEvents_Fields as U
 -- without journaling arguments for user updates
 
 userActivate :: User -> AppIO ()
-userActivate u@User {..} = journalEvent UserEvent'USER_ACTIVATE userId (userEmail u) (Just userLocale) userTeam (Just userName)
+userActivate u@User {..} = journalEvent UserEvent'USER_ACTIVATE userId (userEmail u) (Just userLocale) userTeam (Just userDisplayName)
 
 userUpdate :: UserId -> Maybe Email -> Maybe Locale -> Maybe Name -> AppIO ()
 userUpdate uid em loc nm = journalEvent UserEvent'USER_UPDATE uid em loc Nothing nm

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -968,7 +968,7 @@ mkBotUserView :: User -> Ext.BotUserView
 mkBotUserView u =
   Ext.BotUserView
     { Ext.botUserViewId = userId u,
-      Ext.botUserViewName = userName u,
+      Ext.botUserViewName = userDisplayName u,
       Ext.botUserViewColour = userAccentId u,
       Ext.botUserViewHandle = userHandle u,
       Ext.botUserViewTeam = userTeam u

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -40,11 +40,11 @@ testSearchByName brig = do
   refreshIndex brig
   let uid1 = userId u1
       uid2 = userId u2
-  assertCanFind brig uid1 uid2 (fromName (userName u2))
-  assertCanFind brig uid2 uid1 (fromName (userName u1))
+  assertCanFind brig uid1 uid2 (fromName (userDisplayName u2))
+  assertCanFind brig uid2 uid1 (fromName (userDisplayName u1))
   -- Users cannot find themselves
-  assertCan'tFind brig uid1 uid1 (fromName (userName u1))
-  assertCan'tFind brig uid2 uid2 (fromName (userName u2))
+  assertCan'tFind brig uid1 uid1 (fromName (userDisplayName u1))
+  assertCan'tFind brig uid2 uid2 (fromName (userDisplayName u2))
 
 testSearchByHandle :: Brig -> Http ()
 testSearchByHandle brig = do
@@ -71,7 +71,7 @@ testReindex brig = do
     Just (found : _) <- fmap searchResults <$> executeSearch brig (userId u) h
     liftIO $ do
       assertEqual "Unexpected UserId" (contactUserId found) (userId u')
-      assertEqual "Unexpected Name" (contactName found) (fromName $ userName u')
+      assertEqual "Unexpected Name" (contactName found) (fromName $ userDisplayName u')
       assertEqual "Unexpected Colour" (contactColorId found) (Just . fromIntegral . fromColourId $ userAccentId u')
       assertEqual "Unexpected Handle" (contactHandle found) (fromHandle <$> userHandle u')
   where
@@ -85,27 +85,27 @@ testSearchTeamMemberAsNonMember galley brig = do
   nonTeamMember <- randomUser brig
   (_, _, [teamMember]) <- createPopulatedBindingTeam brig galley 1
   refreshIndex brig
-  assertCan'tFind brig (userId nonTeamMember) (userId teamMember) (fromName (userName teamMember))
+  assertCan'tFind brig (userId nonTeamMember) (userId teamMember) (fromName (userDisplayName teamMember))
 
 testSearchTeamMemberAsOtherMember :: Galley -> Brig -> Http ()
 testSearchTeamMemberAsOtherMember galley brig = do
   (_, _, [teamAMember]) <- createPopulatedBindingTeam brig galley 1
   (_, _, [teamBMember]) <- createPopulatedBindingTeam brig galley 1
   refreshIndex brig
-  assertCan'tFind brig (userId teamAMember) (userId teamBMember) (fromName (userName teamBMember))
+  assertCan'tFind brig (userId teamAMember) (userId teamBMember) (fromName (userDisplayName teamBMember))
 
 testSearchTeamMemberAsSameMember :: Galley -> Brig -> Http ()
 testSearchTeamMemberAsSameMember galley brig = do
   (_, _, [teamAMember, teamAMember']) <- createPopulatedBindingTeam brig galley 2
   refreshIndex brig
-  assertCanFind brig (userId teamAMember) (userId teamAMember') (fromName (userName teamAMember'))
+  assertCanFind brig (userId teamAMember) (userId teamAMember') (fromName (userDisplayName teamAMember'))
 
 testSeachNonMemberAsTeamMember :: Galley -> Brig -> Http ()
 testSeachNonMemberAsTeamMember galley brig = do
   nonTeamMember <- randomUser brig
   (_, _, [teamMember]) <- createPopulatedBindingTeam brig galley 1
   refreshIndex brig
-  assertCanFind brig (userId teamMember) (userId nonTeamMember) (fromName (userName nonTeamMember))
+  assertCanFind brig (userId teamMember) (userId nonTeamMember) (fromName (userDisplayName nonTeamMember))
 
 testSearchOrderingAsTeamMemeber :: Galley -> Brig -> Http ()
 testSearchOrderingAsTeamMemeber galley brig = do
@@ -126,4 +126,4 @@ testSearchSameTeamOnly opts galley brig = do
   refreshIndex brig
   let newOpts = opts & Opt.optionSettings . Opt.searchSameTeamOnly .~ Just True
   withSettingsOverrides newOpts $ do
-    assertCan'tFind brig (userId teamMember) (userId nonTeamMember) (fromName (userName nonTeamMember))
+    assertCan'tFind brig (userId teamMember) (userId nonTeamMember) (fromName (userDisplayName nonTeamMember))

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -194,7 +194,7 @@ testInvitationEmailAndPhoneAccepted brig galley = do
   Just (_, phoneCode) <- getActivationCode brig (Right inviteePhone)
   -- Register the user with the extra supplied information
   (profile, invitation) <- createAndVerifyInvitation (extAccept inviteeEmail inviteeName inviteePhone phoneCode) extInvite brig galley
-  liftIO $ assertEqual "Wrong name in profile" (Just inviteeName) (userName . selfUser <$> profile)
+  liftIO $ assertEqual "Wrong name in profile" (Just inviteeName) (userDisplayName . selfUser <$> profile)
   liftIO $ assertEqual "Wrong name in invitation" (Just inviteeName) (inInviteeName invitation)
   liftIO $ assertEqual "Wrong phone number in profile" (Just inviteePhone) (join (userPhone . selfUser <$> profile))
   liftIO $ assertEqual "Wrong phone number in invitation" (Just inviteePhone) (inPhone invitation)

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -384,9 +384,9 @@ testMultipleUsers brig = do
       -- on this endpoint, only from the self profile (/self).
       expected =
         Set.fromList
-          [ (Just $ userName u1, Nothing :: Maybe Email),
-            (Just $ userName u2, Nothing),
-            (Just $ userName u3, Nothing)
+          [ (Just $ userDisplayName u1, Nothing :: Maybe Email),
+            (Just $ userDisplayName u2, Nothing),
+            (Just $ userDisplayName u3, Nothing)
           ]
   get (brig . zUser (userId u1) . path "users" . queryItem "ids" uids) !!! do
     const 200 === statusCode
@@ -470,7 +470,7 @@ testUserUpdate brig cannon aws = do
     const 200 === statusCode
     const (newName, newColId, newAssets)
       === ( \u ->
-              ( fmap userName u,
+              ( fmap userDisplayName u,
                 fmap userAccentId u,
                 fmap userAssets u
               )
@@ -598,13 +598,13 @@ testSuspendUser brig = do
   -- should not appear in search
   suid <- userId <$> randomUser brig
   Search.refreshIndex brig
-  Search.assertCan'tFind brig suid uid (fromName (userName u))
+  Search.assertCan'tFind brig suid uid (fromName (userDisplayName u))
   -- re-activate
   setStatus brig uid Active
   chkStatus brig uid Active
   -- should appear in search again
   Search.refreshIndex brig
-  Search.assertCanFind brig suid uid (fromName (userName u))
+  Search.assertCanFind brig suid uid (fromName (userDisplayName u))
 
 testGetByIdentity :: Brig -> Http ()
 testGetByIdentity brig = do
@@ -1020,7 +1020,7 @@ setHandleAndDeleteUser brig cannon u others aws execDelete = do
   -- Does not appear in search; public profile shows the user as deleted
   forM_ others $ \usr -> do
     get (brig . paths ["users", toByteString' uid] . zUser usr) !!! assertDeletedProfilePublic
-    Search.assertCan'tFind brig usr uid (fromName (userName u))
+    Search.assertCan'tFind brig usr uid (fromName (userDisplayName u))
     Search.assertCan'tFind brig usr uid hdl
   -- Email address is available again
   let Object o =

--- a/services/brig/test/integration/Util/AWS.hs
+++ b/services/brig/test/integration/Util/AWS.hs
@@ -51,7 +51,7 @@ userActivateJournaled u l (Just ev) = do
   assertEventType l PU.UserEvent'USER_ACTIVATE ev
   assertUserId l (userId u) ev
   assertTeamId l (userTeam u) ev
-  assertName l (Just $ userName u) ev
+  assertName l (Just $ userDisplayName u) ev
   assertEmail l (userEmail u) ev
   assertLocale l (Just $ userLocale u) ev
 userActivateJournaled _ l Nothing = assertFailure $ l <> ": Expected 1 UserActivate, got nothing"

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -122,7 +122,7 @@ createBrigUser suid (Id buid) teamid mbName managedBy = do
   let newUser :: NewUser
       newUser =
         NewUser
-          { newUserName = uname,
+          { newUserDisplayName = uname,
             newUserUUID = Just buid,
             newUserIdentity = Just $ SSOIdentity (toUserSSOId suid) Nothing Nothing,
             newUserPict = Nothing,

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -184,7 +184,7 @@ validateHandle txt = case parseHandle txt of
 --
 --   * @userName@ is mapped to our 'userHandle'.
 --
---   * @displayName@ is mapped to our 'userName'. We don't use the @name@ field, as it
+--   * @displayName@ is mapped to our 'userDisplayName'. We don't use the @name@ field, as it
 --     provides a rather poor model for names.
 --
 --   * The @externalId@ is used to construct a 'SAML.UserRef'. If it looks like an email
@@ -589,7 +589,7 @@ getOrCreateScimUser stiTeam brigUser = do
     createScimUser' brigUser' = do
       let uid = BrigTypes.userId brigUser'
       handle <- getUserHandle' brigUser'
-      let name = userName brigUser'
+      let name = userDisplayName brigUser'
       richInfo <- getRichInfo' uid
       -- NOTE: If user is not an SSO User; this returns Nothing
       -- Hence; we should only set managedByScim if this _succeeds_

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -532,7 +532,7 @@ instance IsUser (WrappedScimUser SparTag) where
 instance IsUser User where
   maybeUserId = Just userId
   maybeHandle = Just userHandle
-  maybeName = Just (Just . userName)
+  maybeName = Just (Just . userDisplayName)
   maybeTenant = Just (fmap (view SAML.uidTenant) . urefFromBrig)
   maybeSubject = Just (fmap (view SAML.uidSubject) . urefFromBrig)
   maybeSubjectRaw = Just (SAML.shortShowNameID . view SAML.uidSubject <=< urefFromBrig)


### PR DESCRIPTION
To avoid current and future confusions with the variable `userName`, this renames all (of brig's) usages to `userDisplayName`. To keep backwards compatibility, json instances have not been touched.

Spar still uses `userName` (for a different meaning than what brig used it for), which can stay as is.