### PR TITLE
[WIP][DO NOT MERGE]Add temporary tool to check sanity of user data

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2d75605e990ced662e68a90ee59831680ff15d186c31a1e37c95f7783cb96b1b
+-- hash: 44e248395f7481555f32ca65a3b6eb87688e963d7aecb87ad3416d717f0dd308
 
 name:           brig
 version:        1.35.0
@@ -437,6 +437,25 @@ executable brig-schema
       schema/src
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -O2 -Wall -fwarn-tabs -optP-Wno-nonportable-include-path -funbox-strict-fields
+  build-depends:
+      base
+    , cassandra-util >=0.12
+    , directory >=1.3
+    , extended
+    , imports
+    , optparse-applicative >=0.10
+    , raw-strings-qq >=1.0
+    , text
+    , tinylog
+    , types-common
+  default-language: Haskell2010
+
+executable brig-schema-check
+  main-is: schema-check/Main.hs
+  other-modules:
+      Paths_brig
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
+  ghc-options: -O2 -Wall -fwarn-tabs -optP-Wno-nonportable-include-path -funbox-strict-fields -threaded -with-rtsopts=-N1 -with-rtsopts=-T -rtsopts
   build-depends:
       base
     , cassandra-util >=0.12

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -278,3 +278,21 @@ executables:
     - imports
     - optparse-applicative >=0.10
     - types-common
+  brig-schema-check:
+    main: schema-check/Main.hs
+    ghc-options:
+    - -threaded
+    - -with-rtsopts=-N1
+    - -with-rtsopts=-T
+    - -rtsopts
+    dependencies:
+    - base
+    - cassandra-util >=0.12
+    - directory >=1.3
+    - extended
+    - optparse-applicative >=0.10
+    - raw-strings-qq >=1.0
+    - imports
+    - text
+    - tinylog
+    - types-common

--- a/services/brig/schema-check/Main.hs
+++ b/services/brig/schema-check/Main.hs
@@ -1,0 +1,87 @@
+module Main where
+
+import qualified Cassandra as C
+import qualified Cassandra.Settings as C
+import qualified Cassandra.Util as C
+import Data.Id
+import Imports
+import qualified System.Logger.Extended as Log
+
+main :: IO ()
+main = do
+  [host, portString] <- getArgs
+  let port :: Int32 = read portString
+  l <- Log.mkLogger'
+  casClient <- initCassandra l host port
+  C.runClient casClient $ do
+    page1 <- scanForIndex 500
+    go 0 page1
+  where
+    go n page = do
+      let result = C.result page
+          newCount = n + length result
+      mapM_ printIfErrorSome result
+      putStrLn $ "Scanned " ++ show newCount
+      when (C.hasMore page) $ do
+        nextPage <- C.liftClient (C.nextPage page)
+        go newCount nextPage
+
+printIfErrorSome :: MonadIO m => ReindexRow -> m ()
+printIfErrorSome row@(userId, mName, mNameWT, mColour, mColourWT, mActivated, mActivatedWT) =
+  if or
+    [ any isNothing [mNameWT, mColourWT, mActivatedWT],
+      isNothing mName,
+      isNothing mColour,
+      isNothing mActivated
+    ]
+    then do
+      putStrLn $ "Found unexpected null for: " <> show userId
+      print row
+    else pure ()
+
+initCassandra ::
+  (MonadIO m, Integral a) =>
+  Log.Logger ->
+  String ->
+  a ->
+  m C.ClientState
+initCassandra l host port =
+  C.init
+    $ C.setLogger (C.mkLogger l)
+      . C.setContacts host []
+      . C.setPortNumber (fromIntegral port)
+      . C.setKeyspace (C.Keyspace "brig")
+      . C.setProtocolVersion C.V4
+    $ C.defSettings
+
+type Name = Text
+
+type Activated = Bool
+
+type ColourId = Int32
+
+type ReindexRow =
+  ( UserId,
+    Maybe Name,
+    Maybe (C.Writetime Name),
+    Maybe ColourId,
+    Maybe (C.Writetime ColourId),
+    Maybe Activated,
+    Maybe (C.Writetime Activated)
+  )
+
+scanForIndex :: Int32 -> C.Client (C.Page ReindexRow)
+scanForIndex num =
+  C.paginate cql (C.paramsP C.One () (num + 1))
+  where
+    cql :: C.PrepQuery C.R () ReindexRow
+    cql =
+      "SELECT \
+      \id, \
+      \name, \
+      \writetime(name), \
+      \accent_id, \
+      \writetime(accent_id), \
+      \activated, \
+      \writetime(activated) \
+      \FROM user"


### PR DESCRIPTION
This PR exists solely so this temporary code gets shown to the team before I run it in production.

Recommended way to run it, make sure it is run in an empty directory:

```
CASSANDRA_IP=<IP Address of one of the nodes>
./brig-schema-check $CASSANDRA_IP 9042 | split --unbuffered --verbose -l 1000 -d --suffix-length=10 --filter 'tee >(gzip > $FILE.gz)'
```

This will output a lot of lines saying `Scanning <number>`, but will also store all the output in gzipped files. To see if any errors exists run this command:

```
zgrep null *.gz
```

As a bonus, last line of the output shows total number of users. 
It takes about 15 minutes in staging with less than 15 million users.