### PR TITLE
Federation: Link related issue IDs

### DIFF
--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -443,7 +443,7 @@ deriving instance Show Invite
 
 -- Events -------------------------------------------------------------------
 
--- FUTUREWORK(federation):
+-- FUTUREWORK(federation, #1213):
 -- Conversation and user ID can be remote IDs, but the receiver might be on
 -- another backend, so mapped IDs don't work for them.
 data Event
@@ -473,7 +473,7 @@ data EventType
   | Typing
   deriving (Eq, Show, Generic)
 
--- FUTUREWORK(federation):
+-- FUTUREWORK(federation, #1213):
 -- A lot of information in the events can contain remote IDs, but the
 -- receiver might be on another backend, so mapped IDs don't work for them.
 data EventData

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -1266,9 +1266,9 @@ listUsers self = \case
     getIds :: [OptionallyQualified Handle] -> Handler [MappedOrLocalId Id.U]
     getIds hs = do
       -- we might be able to do something smarter if the domain is our own
-      let (localHandles, _remoteHandles) = partitionEithers (map eitherQualifiedOrNot hs)
+      let (localHandles, _qualifiedHandles) = partitionEithers (map eitherQualifiedOrNot hs)
       localUsers <- catMaybes <$> traverse (lift . API.lookupHandle) localHandles
-      -- FUTUREWORK(federation): resolve remote handles, too
+      -- FUTUREWORK(federation, #1268): resolve qualified handles, too
       pure (Local <$> localUsers)
     filterSameTeamOnly :: [UserProfile] -> Handler [UserProfile]
     filterSameTeamOnly us = do

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -60,7 +60,7 @@ lookupClient mappedOrLocalUserId clientId =
     Local u ->
       lift $ lookupLocalClient u clientId
     Mapped IdMapping {idMappingLocal} ->
-      -- FUTUREWORK(federation): look up remote clients
+      -- FUTUREWORK(federation, #1271): look up remote clients
       throwE $ ClientUserNotFound (makeMappedIdOpaque idMappingLocal)
 
 lookupLocalClient :: UserId -> ClientId -> AppIO (Maybe Client)
@@ -71,7 +71,7 @@ lookupClients = \case
   Local u ->
     lift $ lookupLocalClients u
   Mapped IdMapping {idMappingLocal} ->
-    -- FUTUREWORK(federation): look up remote clients
+    -- FUTUREWORK(federation, #1271): look up remote clients
     throwE $ ClientUserNotFound (makeMappedIdOpaque idMappingLocal)
 
 lookupLocalClients :: UserId -> AppIO [Client]
@@ -129,6 +129,7 @@ claimPrekey u c = case u of
   Local localUser ->
     claimLocalPrekey localUser c
   Mapped _ ->
+    -- FUTUREWORK(federation, #1272): claim key from other backend
     pure Nothing
 
 claimLocalPrekey :: UserId -> ClientId -> AppIO (Maybe ClientPrekey)
@@ -143,6 +144,7 @@ claimPrekeyBundle = \case
   Local localUser ->
     claimLocalPrekeyBundle localUser
   Mapped IdMapping {idMappingLocal} ->
+    -- FUTUREWORK(federation, #1272): claim keys from other backend
     pure $ PrekeyBundle (makeMappedIdOpaque idMappingLocal) []
 
 claimLocalPrekeyBundle :: UserId -> AppIO PrekeyBundle
@@ -156,7 +158,7 @@ claimMultiPrekeyBundles (UserClients clientMap) = do
   let (localUsers, remoteUsers) = partitionEithers $ map localOrRemoteUser resolved
   for_ (nonEmpty remoteUsers) $
     throwStd . federationNotImplemented . fmap fst
-  -- FUTUREWORK(federation): claim keys from other backends, merge maps
+  -- FUTUREWORK(federation, #1272): claim keys from other backends, merge maps
   lift $ UserClientMap . Map.mapKeys makeIdOpaque <$> claimLocalPrekeyBundles localUsers
   where
     localOrRemoteUser :: (MappedOrLocalId Id.U, a) -> Either (UserId, a) (IdMapping Id.U, a)

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -50,7 +50,7 @@ createConnection self req conn = do
     Local u ->
       createConnectionToLocalUser self u req conn
     Mapped IdMapping {idMappingLocal} ->
-      -- FUTUREWORK(federation): allow creating connections to remote users
+      -- FUTUREWORK(federation, #1262): allow creating connections to remote users
       throwE $ InvalidUser (makeMappedIdOpaque idMappingLocal)
 
 createConnectionToLocalUser ::

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -901,7 +901,7 @@ lookupProfiles ::
 lookupProfiles self others = do
   let (localUsers, _remoteUsers) = partitionMappedOrLocalIds others
   localProfiles <- lookupProfilesOfLocalUsers self localUsers
-  -- FUTUREWORK(federation): fetch remote profiles
+  -- FUTUREWORK(federation, #1267): fetch remote profiles
   remoteProfiles <- pure []
   pure (localProfiles <> remoteProfiles)
 

--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -19,7 +19,7 @@ lookupProfilesMaybeFilterSameTeamOnly self us = do
     Just team -> filter (\x -> profileTeam x == Just team) us
     Nothing -> us
 
--- FUTUREWORK(federation): implement function to resolve IDs in batch
+-- FUTUREWORK(federation, #1178): implement function to resolve IDs in batch
 
 -- | this exists as a shim to find and mark places where we need to handle 'OpaqueUserId's.
 resolveOpaqueUserId :: MonadReader Env m => OpaqueUserId -> m (MappedOrLocalId Id.U)
@@ -30,5 +30,5 @@ resolveOpaqueUserId (Id opaque) = do
       -- don't check the ID mapping, just assume it's local
       pure . Local $ Id opaque
     True ->
-      -- FUTUREWORK(federation): implement database lookup
+      -- FUTUREWORK(federation, #1178): implement database lookup
       pure . Local $ Id opaque

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -63,6 +63,9 @@ searchH (_ ::: u ::: q ::: s) = json <$> lift (search u q s)
 
 search :: UserId -> Text -> Range 1 100 Int32 -> AppIO (SearchResult Contact)
 search searcherId searchTerm maxResults = do
+  -- FUTUREWORK(federation, #1269):
+  -- If the query contains a qualified handle, forward the search to the remote
+  -- backend.
   searcherTeamId <- DB.lookupUserTeam searcherId
   sameTeamSearchOnly <- fromMaybe False <$> view (settings . Opts.searchSameTeamOnly)
   let teamSearchInfo =

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -52,7 +52,7 @@ rmUser user conn = do
     leaveConversations :: List1 UserId -> Page OpaqueConvId -> Galley ()
     leaveConversations u ids = do
       (localConvIds, remoteConvIds) <- partitionMappedOrLocalIds <$> traverse resolveOpaqueConvId (result ids)
-      -- FUTUREWORK(federation): leave remote conversations.
+      -- FUTUREWORK(federation, #1275): leave remote conversations.
       -- If we could just get all conversation IDs at once and then leave conversations
       -- in batches, it would make everything much easier.
       for_ (nonEmpty remoteConvIds) $

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -83,7 +83,7 @@ getConversations :: UserId -> Maybe (Either (Range 1 32 (List OpaqueConvId)) Opa
 getConversations zusr range size =
   withConvIds zusr range size $ \more ids -> do
     (localConvIds, _qualifiedConvIds) <- partitionMappedOrLocalIds <$> traverse resolveOpaqueConvId ids
-    -- FUTUREWORK(federation): fetch remote conversations from other backend
+    -- FUTUREWORK(federation, #1273): fetch remote conversations from other backend
     cs <-
       Data.conversations localConvIds
         >>= filterM removeDeleted

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -498,8 +498,11 @@ removeMemberH (zusr ::: zcon ::: cid ::: victim) = do
 removeMember :: UserId -> ConnId -> OpaqueConvId -> OpaqueUserId -> Galley UpdateResult
 removeMember zusr zcon cid victim = do
   resolveOpaqueConvId cid >>= \case
-    Mapped idMapping -> throwM . federationNotImplemented $ pure idMapping
-    Local localConvId -> removeMemberOfLocalConversation localConvId
+    Mapped idMapping ->
+      -- FUTUREWORK(federation, #1274): forward request to conversation's backend.
+      throwM . federationNotImplemented $ pure idMapping
+    Local localConvId ->
+      removeMemberOfLocalConversation localConvId
   where
     removeMemberOfLocalConversation convId = do
       conv <- Data.conversation convId >>= ifNothing convNotFound
@@ -515,7 +518,7 @@ removeMember zusr zcon cid victim = do
           case resolvedVictim of
             Local _ -> pure () -- nothing to do
             Mapped _ -> do
-              -- FUTUREWORK(federation): users can be on other backend, how to notify it?
+              -- FUTUREWORK(federation, #1274): users can be on other backend, how to notify it?
               pure ()
           for_ (newPush (evtFrom event) (ConvEvent event) (recipient <$> users)) $ \p ->
             push1 $ p & pushConn ?~ zcon
@@ -596,7 +599,7 @@ postNewOtrMessage :: UserId -> Maybe ConnId -> OpaqueConvId -> OtrFilterMissing 
 postNewOtrMessage usr con cnv val msg = do
   resolveOpaqueConvId cnv >>= \case
     Mapped idMapping ->
-      -- FUTUREWORK(federation): forward message to backend owning the conversation
+      -- FUTUREWORK(federation, #1261): forward message to backend owning the conversation
       throwM . federationNotImplemented $ pure idMapping
     Local localConvId ->
       postToLocalConv localConvId

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -57,7 +57,7 @@ ensureConnectedOrSameTeam u uids = do
   sameTeamUids <- forM uTeams $ \team ->
     fmap (view userId) <$> Data.teamMembersLimited team uids
   -- Do not check connections for users that are on the same team
-  -- FUTUREWORK(federation): handle remote users (can't be part of the same team, just check connections)
+  -- FUTUREWORK(federation, #1262): handle remote users (can't be part of the same team, just check connections)
   ensureConnected u (Local <$> uids \\ join sameTeamUids)
 
 -- | Check that the user is connected to everybody else.
@@ -69,7 +69,7 @@ ensureConnected :: UserId -> [MappedOrLocalId Id.U] -> Galley ()
 ensureConnected _ [] = pure ()
 ensureConnected u mappedOrLocalUserIds = do
   let (localUserIds, remoteUserIds) = partitionMappedOrLocalIds mappedOrLocalUserIds
-  -- FUTUREWORK(federation): check remote connections
+  -- FUTUREWORK(federation, #1262): check remote connections
   for_ (nonEmpty remoteUserIds) $
     throwM . federationNotImplemented
   ensureConnectedToLocals u localUserIds
@@ -242,7 +242,7 @@ getConversationAndCheckMembershipWithError ex zusr = \case
       throwM ex
     return c
 
--- FUTUREWORK(federation): implement function to resolve IDs in batch
+-- FUTUREWORK(federation, #1178): implement function to resolve IDs in batch
 
 -- | this exists as a shim to find and mark places where we need to handle 'OpaqueUserId's.
 resolveOpaqueUserId :: OpaqueUserId -> Galley (MappedOrLocalId Id.U)
@@ -253,7 +253,7 @@ resolveOpaqueUserId (Id opaque) = do
       -- don't check the ID mapping, just assume it's local
       pure . Local $ Id opaque
     True ->
-      -- FUTUREWORK(federation): implement database lookup
+      -- FUTUREWORK(federation, #1178): implement database lookup
       pure . Local $ Id opaque
 
 -- | this exists as a shim to find and mark places where we need to handle 'OpaqueConvId's.
@@ -265,5 +265,5 @@ resolveOpaqueConvId (Id opaque) = do
       -- don't check the ID mapping, just assume it's local
       pure . Local $ Id opaque
     True ->
-      -- FUTUREWORK(federation): implement database lookup
+      -- FUTUREWORK(federation, #1178): implement database lookup
       pure . Local $ Id opaque

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -681,7 +681,7 @@ removeMembers conv orig victims = do
           pure ()
   return $ Event MemberLeave (convId conv) orig t (Just (EdMembersLeave leavingMembers))
   where
-    -- FUTUREWORK(federation): We need to tell clients about remote members leaving, too.
+    -- FUTUREWORK(federation, #1274): We need to tell clients about remote members leaving, too.
     leavingMembers = UserIdList . mapMaybe localIdOrNothing . toList $ victims
     localIdOrNothing = \case
       Local localId -> Just localId


### PR DESCRIPTION
There's also a small change where in two endpoints the `Z-User` header was marked as opaque user ID.