### PR TITLE
Small fix for services-demo/demo.sh: mkdir zauth

### DIFF
--- a/deploy/services-demo/demo.sh
+++ b/deploy/services-demo/demo.sh
@@ -60,6 +60,7 @@ function check_secrets() {
     fi
     if [[ ! -f ${SCRIPT_DIR}/resources/zauth/privkeys.txt || ! -f ${SCRIPT_DIR}/resources/zauth/pubkeys.txt ]]; then
         echo "Generate private and public keys (used both by brig and nginz)..."
+        mkdir -p ${SCRIPT_DIR}/resources/zauth/
         TMP_KEYS=$(mktemp "/tmp/demo.keys.XXXXXXXXXXX")
         run_zauth -m gen-keypair -i 1 > $TMP_KEYS
         cat $TMP_KEYS | sed -n 's/public: \(.*\)/\1/p' > ${SCRIPT_DIR}/resources/zauth/pubkeys.txt


### PR DESCRIPTION
The script failed for me when trying to run the services demo.

After checking out this repository, the directory `deploy/services-demo/resource/zauth` doesn't exist.
Because of that, demo.sh failed writing the public and private keys to `resource/zauth/{pub,priv}keys.txt`.