### PR TITLE
Host galley endpoints via Servant.Raw

### DIFF
--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f9b73dc91aaa155bf8b00144f15d626fe9b79885c56a796a1171182756d06366
+-- hash: 18586f67f515873a79fe475566800f7eeb40fbba695e5c2c6b3cd23062400772
 
 name:           galley
 version:        0.83.0
@@ -119,6 +119,7 @@ library
     , safe-exceptions >=0.1
     , semigroups >=0.12
     , servant
+    , servant-server
     , servant-swagger
     , singletons >=1.0
     , split >=0.2

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -63,6 +63,7 @@ library:
   - safe-exceptions >=0.1
   - semigroups >=0.12
   - servant
+  - servant-server
   - servant-swagger
   - singletons >=1.0
   - split >=0.2

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -216,7 +216,7 @@ initExtEnv = do
       let pinset = map toByteString' fprs
        in verifyRsaFingerprint sha pinset
 
-runGalley :: Env -> Request -> Galley ResponseReceived -> IO ResponseReceived
+runGalley :: Env -> Request -> Galley a -> IO a
 runGalley e r m =
   let e' = reqId .~ lookupReqId r $ e
    in evalGalley e' m


### PR DESCRIPTION
This wraps the existing galley `Application` into a Servant API.
Extracted from #1015, as I wanted people to be able to review and discuss it separately.