### PR TITLE
Make some IDs in galley events opaque

### DIFF
--- a/libs/api-bot/src/Network/Wire/Bot/Assert.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Assert.hs
@@ -20,7 +20,7 @@
 
 module Network.Wire.Bot.Assert where
 
-import Data.Id (ConvId, UserId)
+import Data.Id (ConvId, UserId, makeIdOpaque)
 import qualified Data.Set as Set
 import Imports
 import Network.Wire.Bot.Monad
@@ -50,8 +50,8 @@ assertConvCreated c b bs = do
          in cnvId cnv == c
               && convEvtFrom e == botId b
               && cnvType cnv == RegularConv
-              && memId (cmSelf mems) == self
-              && omems == others
+              && memId (cmSelf mems) == makeIdOpaque self
+              && omems == (Set.map makeIdOpaque others)
       _ -> False
 
 awaitOtrMessage ::
@@ -129,6 +129,6 @@ connStatus from to rel = \case
 memberJoined :: UserId -> UserId -> Event -> Bool
 memberJoined from other = \case
   EMemberJoin m ->
-    null (toList (fmap smId $ mMembers (convEvtData m)) \\ [other, from])
+    null (toList (fmap smId $ mMembers (convEvtData m)) \\ [makeIdOpaque other, makeIdOpaque from])
       && convEvtFrom m == from
   _ -> False

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -278,6 +278,7 @@ instance DecodeWire ClientId where
 newtype BotId
   = BotId
       {botUserId :: UserId}
+  -- FUTUREWORK: use DerivingStrategies to clarify how the instances are derived
   deriving
     ( Eq,
       Ord,
@@ -290,6 +291,7 @@ newtype BotId
       Generic
     )
 
+-- FUTUREWORK: use GeneralizedNewtypeDeriving for these instances.
 instance Show BotId where
   show = show . botUserId
 

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -789,7 +789,7 @@ addBot zuid zcon cid add = do
   btk <- Text.decodeLatin1 . toByteString' <$> ZAuth.newBotToken pid bid cid
   let bcl = newClientId (fromIntegral (hash bid))
   -- Ask the external service to create a bot
-  let origmem = OtherMember zuid Nothing roleNameWireAdmin
+  let origmem = OtherMember (makeIdOpaque zuid) Nothing roleNameWireAdmin
   let members = origmem : (cmOthers mems)
   let bcnv = Ext.botConvView (cnvId cnv) (cnvName cnv) members
   let busr = mkBotUserView zusr
@@ -838,7 +838,7 @@ removeBot zusr zcon cid bid = do
   unless (cnvType cnv == RegularConv) $
     throwStd invalidConv
   -- Find the bot in the member list and delete it
-  let busr = botUserId bid
+  let busr = makeIdOpaque (botUserId bid)
   let bot = List.find ((== busr) . omId) (cmOthers mems)
   case bot >>= omService of
     Nothing -> return Nothing

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -423,7 +423,7 @@ isMember g usr cnv = do
         . expect2xx
   case responseJsonMaybe res of
     Nothing -> return False
-    Just m -> return (usr == memId m)
+    Just m -> return (makeIdOpaque usr == memId m)
 
 getStatus :: HasCallStack => Brig -> UserId -> HttpT IO AccountStatus
 getStatus brig u =

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -41,7 +41,7 @@ import Galley.App
 import qualified Galley.Data as Data
 import qualified Galley.Intra.Push as Intra
 import qualified Galley.Queue as Q
-import Galley.Types (ConvType (..), evtFrom)
+import Galley.Types (ConvType (..))
 import Imports
 import Network.Wai
 import Network.Wai.Predicate hiding (err, result)
@@ -83,7 +83,8 @@ rmUser user conn = do
           | isMember (makeIdOpaque user) (Data.convMembers c) -> do
             e <- Data.removeMembers c user (Local <$> u)
             return $
-              (Intra.newPush (evtFrom e) (Intra.ConvEvent e) (Intra.recipient <$> Data.convMembers c))
+              -- we rely on the fact that `evtFrom e` is `user` (but opaque)
+              (Intra.newPush (Local user) (Intra.ConvEvent e) (Intra.recipient <$> Data.convMembers c))
                 <&> set Intra.pushConn conn
                 . set Intra.pushRoute Intra.RouteDirect
           | otherwise -> return Nothing

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -32,7 +32,7 @@ import Network.Wai.Utilities.Error
 import qualified System.Logger.Class as Log
 import System.Logger.Message ((+++), msg, val)
 
-conversationView :: UserId -> Data.Conversation -> Galley Conversation
+conversationView :: OpaqueUserId -> Data.Conversation -> Galley Conversation
 conversationView u Data.Conversation {..} = do
   let mm = toList convMembers
   let (me, them) = List.partition ((u ==) . memId) mm

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -60,6 +60,7 @@ import Control.Lens
 import Control.Monad.Catch
 import Data.ByteString.Conversion hiding (fromList)
 import Data.Id
+import Data.IdMapping (MappedOrLocalId (Local))
 import qualified Data.List.Extra as List
 import Data.List1 (list1)
 import Data.Range as Range
@@ -226,8 +227,8 @@ updateTeam zusr zcon tid updateData = do
   now <- liftIO getCurrentTime
   membs <- Data.teamMembersUnsafeForLargeTeams tid
   let e = newEvent TeamUpdate tid now & eventData .~ Just (EdTeamUpdate updateData)
-  let r = list1 (userRecipient zusr) (membersToRecipients (Just zusr) membs)
-  push1 $ newPush1 zusr (TeamEvent e) r & pushConn .~ Just zcon
+  let r = list1 (userRecipient (makeIdOpaque zusr)) (membersToRecipients (Just zusr) membs)
+  push1 $ newPush1 (Local zusr) (TeamEvent e) r & pushConn .~ Just zcon
 
 deleteTeamH :: UserId ::: ConnId ::: TeamId ::: OptionalJsonRequest TeamDeleteData ::: JSON -> Galley Response
 deleteTeamH (zusr ::: zcon ::: tid ::: req ::: _) = do
@@ -284,14 +285,14 @@ uncheckedDeleteTeam zusr zcon tid = do
     pushDeleteEvents :: [TeamMember] -> Event -> [Push] -> Galley ()
     pushDeleteEvents membs e ue = do
       o <- view $ options . optSettings
-      let r = list1 (userRecipient zusr) (membersToRecipients (Just zusr) membs)
+      let r = list1 (userRecipient (makeIdOpaque zusr)) (membersToRecipients (Just zusr) membs)
       -- To avoid DoS on gundeck, send team deletion events in chunks
       let chunkSize = fromMaybe defConcurrentDeletionEvents (o ^. setConcurrentDeletionEvents)
       let chunks = List.chunksOf chunkSize (toList r)
       forM_ chunks $ \chunk -> case chunk of
         [] -> return ()
         -- push TeamDelete events
-        x : xs -> push1 (newPush1 zusr (TeamEvent e) (list1 x xs) & pushConn .~ zcon)
+        x : xs -> push1 (newPush1 (Local zusr) (TeamEvent e) (list1 x xs) & pushConn .~ zcon)
       -- To avoid DoS on gundeck, send conversation deletion events slowly
       let delay = 1000 * (fromMaybe defDeleteConvThrottleMillis (o ^. setDeleteConvThrottleMillis))
       forM_ ue $ \event -> do
@@ -310,8 +311,8 @@ uncheckedDeleteTeam zusr zcon tid = do
       -- all team users are deleted immediately after these events are sent
       -- and will thus never be able to see these events in practice.
       let mm = nonTeamMembers convMembs teamMembs
-      let e = Conv.Event Conv.ConvDelete (c ^. conversationId) zusr now Nothing
-      let p = newPush zusr (ConvEvent e) (map recipient mm)
+      let e = Conv.Event Conv.ConvDelete (makeIdOpaque (c ^. conversationId)) (makeIdOpaque zusr) now Nothing
+      let p = newPush (Local zusr) (ConvEvent e) (map recipient mm)
       let ee' = bots `zip` repeat e
       let pp' = maybe pp (\x -> (x & pushConn .~ zcon) : pp) p
       pure (pp', ee' ++ ee)
@@ -493,7 +494,7 @@ updateTeamMember zusr zcon tid targetMember = do
       now <- liftIO getCurrentTime
       let ePriv = newEvent MemberUpdate tid now & eventData ?~ privilegedUpdate
       -- push to all members (user is privileged)
-      let pushPriv = newPush zusr (TeamEvent ePriv) $ privilegedRecipients
+      let pushPriv = newPush (Local zusr) (TeamEvent ePriv) $ privilegedRecipients
       for_ pushPriv $ \p -> push1 $ p & pushConn .~ Just zcon
 
 deleteTeamMemberH :: UserId ::: ConnId ::: TeamId ::: UserId ::: OptionalJsonRequest TeamMemberDeleteData ::: JSON -> Galley Response
@@ -555,13 +556,13 @@ uncheckedRemoveTeamMember zusr zcon tid remove mems = do
     pushMemberLeaveEvent :: UTCTime -> Galley ()
     pushMemberLeaveEvent now = do
       let e = newEvent MemberLeave tid now & eventData .~ Just (EdMemberLeave remove)
-      let r = list1 (userRecipient zusr) (membersToRecipients (Just zusr) mems)
-      push1 $ newPush1 zusr (TeamEvent e) r & pushConn .~ zcon
+      let r = list1 (userRecipient (makeIdOpaque zusr)) (membersToRecipients (Just zusr) mems)
+      push1 $ newPush1 (Local zusr) (TeamEvent e) r & pushConn .~ zcon
     -- notify all conversation members not in this team.
     pushConvLeaveEvent :: UTCTime -> Galley ()
     pushConvLeaveEvent now = do
-      let tmids = Set.fromList $ map (view userId) mems
-      let edata = Conv.EdMembersLeave (Conv.UserIdList [remove])
+      let tmids = Set.fromList $ map (makeIdOpaque . view userId) mems
+      let edata = Conv.EdMembersLeave (Conv.OpaqueUserIdList [makeIdOpaque remove])
       cc <- Data.teamConversations tid
       for_ cc $ \c -> Data.conversation (c ^. conversationId) >>= \conv ->
         for_ conv $ \dc -> when (makeIdOpaque remove `isMember` Data.convMembers dc) $ do
@@ -569,12 +570,12 @@ uncheckedRemoveTeamMember zusr zcon tid remove mems = do
           unless (c ^. managedConversation) $
             pushEvent tmids edata now dc
     --
-    pushEvent :: Set UserId -> Conv.EventData -> UTCTime -> Conversation -> Galley ()
+    pushEvent :: Set OpaqueUserId -> Conv.EventData -> UTCTime -> Conversation -> Galley ()
     pushEvent exceptTo edata now dc = do
       let (bots, users) = botsAndUsers (Data.convMembers dc)
       let x = filter (\m -> not (Conv.memId m `Set.member` exceptTo)) users
-      let y = Conv.Event Conv.MemberLeave (Data.convId dc) zusr now (Just edata)
-      for_ (newPush zusr (ConvEvent y) (recipient <$> x)) $ \p ->
+      let y = Conv.Event Conv.MemberLeave (makeIdOpaque (Data.convId dc)) (makeIdOpaque zusr) now (Just edata)
+      for_ (newPush (Local zusr) (ConvEvent y) (recipient <$> x)) $ \p ->
         push1 $ p & pushConn .~ zcon
       void . forkIO $ void $ External.deliver (bots `zip` repeat y)
 
@@ -608,12 +609,12 @@ deleteTeamConversationH (zusr ::: zcon ::: tid ::: cid ::: _) = do
 deleteTeamConversation :: UserId -> ConnId -> TeamId -> ConvId -> Galley ()
 deleteTeamConversation zusr zcon tid cid = do
   (bots, cmems) <- botsAndUsers <$> Data.members cid
-  ensureActionAllowed Roles.DeleteConversation =<< getSelfMember zusr cmems
+  ensureActionAllowed Roles.DeleteConversation =<< getSelfMember (makeIdOpaque zusr) cmems
   flip Data.deleteCode ReusableCode =<< mkKey cid
   now <- liftIO getCurrentTime
-  let ce = Conv.Event Conv.ConvDelete cid zusr now Nothing
+  let ce = Conv.Event Conv.ConvDelete (makeIdOpaque cid) (makeIdOpaque zusr) now Nothing
   let recps = fmap recipient cmems
-  let convPush = newPush zusr (ConvEvent ce) recps <&> pushConn .~ Just zcon
+  let convPush = newPush (Local zusr) (ConvEvent ce) recps <&> pushConn .~ Just zcon
   pushSome $ maybeToList convPush
   void . forkIO $ void $ External.deliver (bots `zip` repeat ce)
   -- TODO: we don't delete bots here, but we should do that, since every
@@ -693,10 +694,10 @@ addTeamMemberInternal tid origin originConn newMem mems = do
   for_ cc $ \c ->
     Data.addMember now (c ^. conversationId) (new ^. userId)
   let e = newEvent MemberJoin tid now & eventData .~ Just (EdMemberJoin (new ^. userId))
-  push1 $ newPush1 (new ^. userId) (TeamEvent e) (recipients origin new) & pushConn .~ originConn
+  push1 $ newPush1 (Local (new ^. userId)) (TeamEvent e) (recipients origin new) & pushConn .~ originConn
   where
-    recipients (Just o) n = list1 (userRecipient o) (membersToRecipients (Just o) (n : mems))
-    recipients Nothing n = list1 (userRecipient (n ^. userId)) (membersToRecipients Nothing (n : mems))
+    recipients (Just o) n = list1 (userRecipient (makeIdOpaque o)) (membersToRecipients (Just o) (n : mems))
+    recipients Nothing n = list1 (userRecipient (makeIdOpaque (n ^. userId))) (membersToRecipients Nothing (n : mems))
 
 finishCreateTeam :: Team -> TeamMember -> [TeamMember] -> Maybe ConnId -> Galley TeamId
 finishCreateTeam team owner others zcon = do
@@ -706,7 +707,7 @@ finishCreateTeam team owner others zcon = do
   now <- liftIO getCurrentTime
   let e = newEvent TeamCreate (team ^. teamId) now & eventData .~ Just (EdTeamCreate team)
   let r = membersToRecipients Nothing others
-  push1 $ newPush1 zusr (TeamEvent e) (list1 (userRecipient zusr) r) & pushConn .~ zcon
+  push1 $ newPush1 (Local zusr) (TeamEvent e) (list1 (userRecipient (makeIdOpaque zusr)) r) & pushConn .~ zcon
   pure (team ^. teamId)
 
 withBindingTeam :: UserId -> (TeamId -> Galley b) -> Galley b

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -651,7 +651,7 @@ addMembersUncheckedWithRole t conv (orig, _origRole) usrs = do
   let e = Event MemberJoin conv orig t (Just . EdMembersJoin . SimpleMembers . toSimpleMembers $ toList usrs)
   return (e, fmap (uncurry newMemberWithRole) usrs)
   where
-    toSimpleMembers :: [(UserId, RoleName)] -> [SimpleMember]
+    toSimpleMembers :: [(OpaqueUserId, RoleName)] -> [SimpleMember]
     toSimpleMembers = fmap (uncurry SimpleMember)
 
 updateMember :: MonadClient m => ConvId -> UserId -> MemberUpdate -> m MemberUpdateData

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -223,31 +223,31 @@ deleteUserConv = "delete from user where user = ? and conv = ?"
 
 type MemberStatus = Int32
 
-selectMember :: PrepQuery R (ConvId, UserId) (UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName)
+selectMember :: PrepQuery R (ConvId, OpaqueUserId) (OpaqueUserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName)
 selectMember = "select user, service, provider, status, otr_muted, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role from member where conv = ? and user = ?"
 
-selectMembers :: PrepQuery R (Identity [ConvId]) (ConvId, UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName)
+selectMembers :: PrepQuery R (Identity [ConvId]) (ConvId, OpaqueUserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName)
 selectMembers = "select conv, user, service, provider, status, otr_muted, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role from member where conv in ?"
 
-insertMember :: PrepQuery W (ConvId, UserId, Maybe ServiceId, Maybe ProviderId, RoleName) ()
+insertMember :: PrepQuery W (ConvId, OpaqueUserId, Maybe ServiceId, Maybe ProviderId, RoleName) ()
 insertMember = "insert into member (conv, user, service, provider, status, conversation_role) values (?, ?, ?, ?, 0, ?)"
 
 removeMember :: PrepQuery W (ConvId, OpaqueUserId) ()
 removeMember = "delete from member where conv = ? and user = ?"
 
-updateOtrMemberMuted :: PrepQuery W (Bool, Maybe Text, ConvId, UserId) ()
+updateOtrMemberMuted :: PrepQuery W (Bool, Maybe Text, ConvId, OpaqueUserId) ()
 updateOtrMemberMuted = "update member set otr_muted = ?, otr_muted_ref = ? where conv = ? and user = ?"
 
-updateOtrMemberMutedStatus :: PrepQuery W (MutedStatus, Maybe Text, ConvId, UserId) ()
+updateOtrMemberMutedStatus :: PrepQuery W (MutedStatus, Maybe Text, ConvId, OpaqueUserId) ()
 updateOtrMemberMutedStatus = "update member set otr_muted_status = ?, otr_muted_ref = ? where conv = ? and user = ?"
 
-updateOtrMemberArchived :: PrepQuery W (Bool, Maybe Text, ConvId, UserId) ()
+updateOtrMemberArchived :: PrepQuery W (Bool, Maybe Text, ConvId, OpaqueUserId) ()
 updateOtrMemberArchived = "update member set otr_archived = ?, otr_archived_ref = ? where conv = ? and user = ?"
 
-updateMemberHidden :: PrepQuery W (Bool, Maybe Text, ConvId, UserId) ()
+updateMemberHidden :: PrepQuery W (Bool, Maybe Text, ConvId, OpaqueUserId) ()
 updateMemberHidden = "update member set hidden = ?, hidden_ref = ? where conv = ? and user = ?"
 
-updateMemberConvRoleName :: PrepQuery W (RoleName, ConvId, UserId) ()
+updateMemberConvRoleName :: PrepQuery W (RoleName, ConvId, OpaqueUserId) ()
 updateMemberConvRoleName = "update member set conversation_role = ? where conv = ? and user = ?"
 
 -- Clients ------------------------------------------------------------------

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -1149,17 +1149,17 @@ checkConvDeleteEvent cid w = WS.assertMatch_ timeout w $ \notif -> do
   ntfTransient notif @?= False
   let e = List1.head (WS.unpackPayload notif)
   evtType e @?= Conv.ConvDelete
-  evtConv e @?= cid
+  evtConv e @?= makeIdOpaque cid
   evtData e @?= Nothing
 
 checkConvMemberLeaveEvent :: HasCallStack => ConvId -> UserId -> WS.WebSocket -> TestM ()
 checkConvMemberLeaveEvent cid usr w = WS.assertMatch_ timeout w $ \notif -> do
   ntfTransient notif @?= False
   let e = List1.head (WS.unpackPayload notif)
-  evtConv e @?= cid
+  evtConv e @?= makeIdOpaque cid
   evtType e @?= Conv.MemberLeave
   case evtData e of
-    Just (Conv.EdMembersLeave mm) -> mm @?= Conv.UserIdList [usr]
+    Just (Conv.EdMembersLeave mm) -> mm @?= Conv.OpaqueUserIdList [makeIdOpaque usr]
     other -> assertFailure $ "Unexpected event data: " <> show other
 
 postCryptoBroadcastMessageJson :: TestM ()

--- a/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
+++ b/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
@@ -93,7 +93,7 @@ mainBotNet n = do
   runBotSession bill $ do
     let update =
           MemberUpdateData
-            { misTarget = Just $ botId bill,
+            { misTarget = Just . makeIdOpaque $ botId bill,
               misOtrMuted = Nothing,
               misOtrMutedStatus = Nothing,
               misOtrMutedRef = Nothing,


### PR DESCRIPTION
Still a few things to think about.

Generally, I got the feeling now that I really want to keep the usage of opaque IDs strictly to the API boundaries. This includes storing optional `IdMapping`s in database tables alongside the local ones instead of sticking to storing a single (opaque) ID, but we have to think of the implications regarding migrations and data consistency.