### PR TITLE
Pull brig-index before running the docker ephemeral setup

### DIFF
--- a/deploy/dockerephemeral/run.sh
+++ b/deploy/dockerephemeral/run.sh
@@ -17,7 +17,4 @@ docker pull quay.io/wire/gundeck-schema
 docker pull quay.io/wire/spar-schema
 docker pull quay.io/wire/brig-index
 
-# elasticsearch does not do migrations, so the following line is not needed.
-#docker pull quay.io/wire/brig-index
-
 docker-compose --file "$DOCKER_FILE" up

--- a/deploy/dockerephemeral/run.sh
+++ b/deploy/dockerephemeral/run.sh
@@ -15,6 +15,7 @@ docker pull quay.io/wire/brig-schema
 docker pull quay.io/wire/galley-schema
 docker pull quay.io/wire/gundeck-schema
 docker pull quay.io/wire/spar-schema
+docker pull quay.io/wire/brig-index
 
 # elasticsearch does not do migrations, so the following line is not needed.
 #docker pull quay.io/wire/brig-index


### PR DESCRIPTION
This will ensure brig-index is up to date before running the tests.