### PR TITLE
Federation DB changes

### DIFF
--- a/docs/reference/cassandra-schema.cql
+++ b/docs/reference/cassandra-schema.cql
@@ -103,6 +103,7 @@ CREATE TABLE galley_test.data_migration (
 
 CREATE TABLE galley_test.team_features (
     team_id uuid PRIMARY KEY,
+    digital_signatures int,
     legalhold_status int,
     search_visibility_status int,
     sso_status int,

--- a/docs/reference/cassandra-schema.cql
+++ b/docs/reference/cassandra-schema.cql
@@ -175,6 +175,8 @@ CREATE TABLE galley_test.member (
     provider uuid,
     service uuid,
     status int,
+    user_remote_domain text,
+    user_remote_id uuid,
     PRIMARY KEY (conv, user)
 ) WITH CLUSTERING ORDER BY (user ASC)
     AND bloom_filter_fp_chance = 0.1
@@ -262,6 +264,8 @@ CREATE TABLE galley_test.meta (
 CREATE TABLE galley_test.user (
     user uuid,
     conv uuid,
+    conv_remote_domain text,
+    conv_remote_id uuid,
     PRIMARY KEY (user, conv)
 ) WITH CLUSTERING ORDER BY (conv ASC)
     AND bloom_filter_fp_chance = 0.1

--- a/libs/api-bot/src/Network/Wire/Bot/Assert.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Assert.hs
@@ -20,7 +20,7 @@
 
 module Network.Wire.Bot.Assert where
 
-import Data.Id (ConvId, UserId)
+import Data.Id (ConvId, UserId, makeIdOpaque)
 import qualified Data.Set as Set
 import Imports
 import Network.Wire.Bot.Monad
@@ -39,7 +39,7 @@ assertConvCreated ::
 assertConvCreated c b bs = do
   let everyone = b : bs
   forM_ bs $ \u ->
-    let others = Set.fromList . filter (/= botId u) . map botId $ everyone
+    let others = Set.fromList . map makeIdOpaque . filter (/= botId u) . map botId $ everyone
      in assertEvent u TConvCreate (convCreate (botId u) others)
   where
     convCreate self others = \case
@@ -50,7 +50,7 @@ assertConvCreated c b bs = do
          in cnvId cnv == c
               && convEvtFrom e == botId b
               && cnvType cnv == RegularConv
-              && memId (cmSelf mems) == self
+              && memId (cmSelf mems) == makeIdOpaque self
               && omems == others
       _ -> False
 

--- a/libs/galley-types/galley-types.cabal
+++ b/libs/galley-types/galley-types.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fb74da023d3b1f2a3ad91fca661ee239b7010e42ec219bec603378749aafabea
+-- hash: 73ad5a5126cffda9d353014c94e6f72b68f8dfbe7ecad75a7f03f55f13e06d7b
 
 name:           galley-types
 version:        0.81.0
@@ -22,6 +22,7 @@ library
       Galley.Types
       Galley.Types.Bot
       Galley.Types.Bot.Service
+      Galley.Types.Conversations.Members
       Galley.Types.Conversations.Roles
       Galley.Types.Teams
       Galley.Types.Teams.Intra

--- a/libs/galley-types/src/Galley/Types/Conversations/Members.hs
+++ b/libs/galley-types/src/Galley/Types/Conversations/Members.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE StrictData #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Types.Conversations.Members
+  ( LocalMember,
+    Member,
+    InternalMember (..),
+  )
+where
+
+import Data.Id as Id
+import Data.IdMapping (MappedOrLocalId)
+import Imports
+import Wire.API.Conversation.Member (MutedStatus)
+import Wire.API.Conversation.Role (RoleName)
+import Wire.API.Provider.Service (ServiceRef)
+
+type LocalMember = InternalMember Id.UserId
+
+type Member = InternalMember (MappedOrLocalId Id.U)
+
+-- | Internal representation of a conversation member.
+data InternalMember id = Member
+  { memId :: id,
+    memService :: Maybe ServiceRef,
+    -- | DEPRECATED, remove it once enough clients use `memOtrMutedStatus`
+    memOtrMuted :: Bool,
+    memOtrMutedStatus :: Maybe MutedStatus,
+    memOtrMutedRef :: Maybe Text,
+    memOtrArchived :: Bool,
+    memOtrArchivedRef :: Maybe Text,
+    memHidden :: Bool,
+    memHiddenRef :: Maybe Text,
+    memConvRoleName :: RoleName
+  }
+  deriving stock (Functor, Show)

--- a/libs/types-common/src/Data/Domain.hs
+++ b/libs/types-common/src/Data/Domain.hs
@@ -52,7 +52,7 @@ import Util.Attoparsec (takeUpToWhile)
 --
 -- The domain will be normalized to lowercase when parsed.
 newtype Domain = Domain {_domainText :: Text}
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Ord, Generic, Show)
 
 domainText :: Domain -> Text
 domainText = _domainText

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -70,12 +70,17 @@ data Mapped a
 
 data Opaque a
 
+data Remote a
+
 type AssetId = Id A
 
 type InvitationId = Id I
 
 -- | A local conversation ID
 type ConvId = Id C
+
+-- | A UUID local to another backend, only meaningful together with its domain.
+type RemoteConvId = Id (Remote C)
 
 -- | A UUID local to this backend, for which we know a mapping to a
 -- remote qualified conversation ID exists.
@@ -90,6 +95,9 @@ type OpaqueConvId = Id (Opaque C)
 
 -- | A local user ID
 type UserId = Id U
+
+-- | A UUID local to another backend, only meaningful together with its domain.
+type RemoteUserId = Id (Remote U)
 
 -- | A UUID local to this backend, for which we know a mapping to a
 -- remote qualified user ID exists.

--- a/libs/types-common/src/Data/IdMapping.hs
+++ b/libs/types-common/src/Data/IdMapping.hs
@@ -27,7 +27,7 @@ import Test.QuickCheck (Arbitrary (arbitrary), oneof)
 data MappedOrLocalId a
   = Mapped (IdMapping a)
   | Local (Id a)
-  deriving (Show)
+  deriving stock (Eq, Ord, Show)
 
 opaqueIdFromMappedOrLocal :: MappedOrLocalId a -> Id (Opaque a)
 opaqueIdFromMappedOrLocal = \case
@@ -43,7 +43,7 @@ data IdMapping a = IdMapping
   { idMappingLocal :: Id (Mapped a),
     idMappingGlobal :: Qualified (Id (Remote a))
   }
-  deriving (Show)
+  deriving stock (Eq, Ord, Show)
 
 ----------------------------------------------------------------------
 -- ARBITRARY

--- a/libs/types-common/src/Data/IdMapping.hs
+++ b/libs/types-common/src/Data/IdMapping.hs
@@ -41,7 +41,7 @@ partitionMappedOrLocalIds = foldMap $ \case
 
 data IdMapping a = IdMapping
   { idMappingLocal :: Id (Mapped a),
-    idMappingGlobal :: Qualified (Id a)
+    idMappingGlobal :: Qualified (Id (Remote a))
   }
   deriving (Show)
 

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -92,7 +92,7 @@ data Qualified a = Qualified
   { _qLocalPart :: a,
     _qDomain :: Domain
   }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Ord, Show, Generic)
 
 renderQualified :: (a -> Text) -> Qualified a -> Text
 renderQualified renderLocal (Qualified localPart domain) =

--- a/libs/wire-api/src/Wire/API/Conversation/Member.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Member.hs
@@ -83,7 +83,7 @@ instance FromJSON ConvMembers where
 -- Members
 
 data Member = Member
-  { memId :: UserId,
+  { memId :: OpaqueUserId,
     memService :: Maybe ServiceRef,
     -- | DEPRECATED, remove it once enough clients use `memOtrMutedStatus`
     memOtrMuted :: Bool,
@@ -165,7 +165,7 @@ newtype MutedStatus = MutedStatus {fromMutedStatus :: Int32}
   deriving newtype (Num, FromJSON, ToJSON, Arbitrary)
 
 data OtherMember = OtherMember
-  { omId :: UserId,
+  { omId :: OpaqueUserId,
     omService :: Maybe ServiceRef,
     omConvRoleName :: RoleName
   }

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -835,7 +835,7 @@ addBot zuid zcon cid add = do
   btk <- Text.decodeLatin1 . toByteString' <$> ZAuth.newBotToken pid bid cid
   let bcl = newClientId (fromIntegral (hash bid))
   -- Ask the external service to create a bot
-  let origmem = OtherMember zuid Nothing roleNameWireAdmin
+  let origmem = OtherMember (makeIdOpaque zuid) Nothing roleNameWireAdmin
   let members = origmem : (cmOthers mems)
   let bcnv = Ext.botConvView (cnvId cnv) (cnvName cnv) members
   let busr = mkBotUserView zusr
@@ -885,7 +885,7 @@ removeBot zusr zcon cid bid = do
     throwStd invalidConv
   -- Find the bot in the member list and delete it
   let busr = botUserId bid
-  let bot = List.find ((== busr) . omId) (cmOthers mems)
+  let bot = List.find ((== makeIdOpaque busr) . omId) (cmOthers mems)
   case bot >>= omService of
     Nothing -> return Nothing
     Just _ -> do

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -1938,12 +1938,12 @@ testMessageBotUtil uid uc cid pid sid sref buf brig galley cannon = do
   let Just bcnv = responseJsonMaybe _rs
   liftIO $ do
     assertEqual "id" cid (bcnv ^. Ext.botConvId)
-    assertEqual "members" [OtherMember uid Nothing roleNameWireAdmin] (bcnv ^. Ext.botConvMembers)
+    assertEqual "members" [OtherMember (makeIdOpaque uid) Nothing roleNameWireAdmin] (bcnv ^. Ext.botConvMembers)
   -- The user can identify the bot in the member list
   mems <- fmap cnvMembers . responseJsonError =<< getConversation galley uid cid
   let other = listToMaybe (cmOthers mems)
   liftIO $ do
-    assertEqual "id" (Just buid) (omId <$> other)
+    assertEqual "id" (Just (makeIdOpaque buid)) (omId <$> other)
     assertEqual "service" (Just sref) (omService =<< other)
   -- The bot greets the user
   WS.bracketR cannon uid $ \ws -> do

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -53,7 +53,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Ascii as Ascii
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID
-import Galley.Types (Member (..))
 import qualified Galley.Types.Teams as Team
 import Gundeck.Types.Notification
 import Imports
@@ -64,6 +63,7 @@ import Test.Tasty.Cannon
 import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
 import Util.AWS
+import Wire.API.Conversation.Member (Member (..))
 
 type Brig = Request -> Request
 
@@ -475,7 +475,7 @@ isMember g usr cnv = do
         . expect2xx
   case responseJsonMaybe res of
     Nothing -> return False
-    Just m -> return (usr == memId m)
+    Just m -> return (makeIdOpaque usr == memId m)
 
 getStatus :: HasCallStack => Brig -> UserId -> (MonadIO m, MonadHttp m) => m AccountStatus
 getStatus brig u =

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 95344a909a53f5c4aedff6805c8679acf34708259b5949d1b5f580509e8f1d58
+-- hash: 0078da3c962467f70b278c32cbc35b9daca407ca541f11862b2262160c86c27b
 
 name:           galley
 version:        0.83.0
@@ -339,6 +339,7 @@ executable galley-schema
       V41_TeamNotificationQueue
       V42_TeamFeatureValidateSamlEmails
       V43_TeamFeatureDigitalSignatures
+      V44_AddRemoteIdentifiers
       Paths_galley
   hs-source-dirs:
       schema/src

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -46,6 +46,7 @@ import qualified V40_CreateTableDataMigration
 import qualified V41_TeamNotificationQueue
 import qualified V42_TeamFeatureValidateSamlEmails
 import qualified V43_TeamFeatureDigitalSignatures
+import qualified V44_AddRemoteIdentifiers
 
 main :: IO ()
 main = do
@@ -77,7 +78,8 @@ main = do
       V40_CreateTableDataMigration.migration,
       V41_TeamNotificationQueue.migration,
       V42_TeamFeatureValidateSamlEmails.migration,
-      V43_TeamFeatureDigitalSignatures.migration
+      V43_TeamFeatureDigitalSignatures.migration,
+      V44_AddRemoteIdentifiers.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Galley.Data
     ]

--- a/services/galley/schema/src/V44_AddRemoteIdentifiers.hs
+++ b/services/galley/schema/src/V44_AddRemoteIdentifiers.hs
@@ -1,0 +1,43 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V44_AddRemoteIdentifiers (migration) where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 43 "Add remote identifiers to conversation related tables" $ do
+  -- The user table answers the question: Which conversations am I a member of?
+  -- With federation one now also needs to know: Where are these conversations located?
+  schema'
+    [r|
+      ALTER TABLE user ADD (
+        conv_remote_id uuid,
+        conv_remote_domain text
+      );
+    |]
+  -- The member table is used to answer the question: Which users are part of a conversation?
+  -- With federation one now also needs to know: Where are these users located?
+  schema'
+    [r|
+      ALTER TABLE member ADD (
+        user_remote_id uuid,
+        user_remote_domain text
+      );
+    |]

--- a/services/galley/schema/src/V44_AddRemoteIdentifiers.hs
+++ b/services/galley/schema/src/V44_AddRemoteIdentifiers.hs
@@ -22,7 +22,7 @@ import Imports
 import Text.RawString.QQ
 
 migration :: Migration
-migration = Migration 43 "Add remote identifiers to conversation related tables" $ do
+migration = Migration 44 "Add remote identifiers to conversation related tables" $ do
   -- The user table answers the question: Which conversations am I a member of?
   -- With federation one now also needs to know: Where are these conversations located?
   schema'

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -235,7 +235,7 @@ createConnectConversation usr conn j = do
     update n conv =
       let mems = Data.convMembers conv
        in conversationExisted usr
-            =<< if | makeIdOpaque usr `isMember` mems ->
+            =<< if | Local usr `isMember` mems ->
                      -- we already were in the conversation, maybe also other
                      connect n conv
                    | otherwise -> do
@@ -280,10 +280,10 @@ data ConversationResponse
   | ConversationExisted !Public.Conversation
 
 conversationCreated :: UserId -> Data.Conversation -> Galley ConversationResponse
-conversationCreated usr cnv = ConversationCreated <$> conversationView usr cnv
+conversationCreated usr cnv = ConversationCreated <$> conversationView (Local usr) cnv
 
 conversationExisted :: UserId -> Data.Conversation -> Galley ConversationResponse
-conversationExisted usr cnv = ConversationExisted <$> conversationView usr cnv
+conversationExisted usr cnv = ConversationExisted <$> conversationView (Local usr) cnv
 
 handleConversationResponse :: ConversationResponse -> Response
 handleConversationResponse = \case

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -33,7 +33,10 @@ import Network.Wai.Utilities.Error
 import Type.Reflection (Typeable, typeRep)
 
 internalError :: Error
-internalError = Error status500 "internal-error" "internal error"
+internalError = internalErrorWithDescription "internal error"
+
+internalErrorWithDescription :: LText -> Error
+internalErrorWithDescription = Error status500 "internal-error"
 
 convNotFound :: Error
 convNotFound = Error status404 "no-conversation" "conversation not found"

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -251,7 +251,7 @@ rmUser user conn = do
   let n = unsafeRange 100 :: Range 1 100 Int32
   tids <- Data.teamIdsForPagination user Nothing (rcast n)
   leaveTeams tids
-  cids <- Data.conversationIdsForPagination user Nothing (rcast n)
+  cids <- Data.conversationIdRowsForPagination user Nothing (rcast n)
   let u = list1 user []
   leaveConversations u cids
   Data.eraseClients user

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -26,7 +26,7 @@ import qualified Cassandra as Cql
 import Control.Exception.Safe (catchAny)
 import Control.Lens hiding ((.=))
 import Control.Monad.Catch (MonadCatch, throwM)
-import Data.Id
+import Data.Id as Id
 import Data.IdMapping (MappedOrLocalId (Local), partitionMappedOrLocalIds)
 import Data.List.NonEmpty (nonEmpty)
 import Data.List1 (List1, list1, maybeList1)
@@ -40,7 +40,7 @@ import qualified Galley.API.Query as Query
 import Galley.API.Teams (uncheckedDeleteTeamMember)
 import qualified Galley.API.Teams as Teams
 import qualified Galley.API.Update as Update
-import Galley.API.Util (isMember, resolveOpaqueConvId)
+import Galley.API.Util (isMember)
 import Galley.App
 import qualified Galley.Data as Data
 import qualified Galley.Intra.Push as Intra
@@ -260,9 +260,9 @@ rmUser user conn = do
       mems <- Data.teamMembersForFanout tid
       uncheckedDeleteTeamMember user conn tid user mems
       leaveTeams =<< Cql.liftClient (Cql.nextPage tids)
-    leaveConversations :: List1 UserId -> Cql.Page OpaqueConvId -> Galley ()
+    leaveConversations :: List1 UserId -> Cql.Page (MappedOrLocalId Id.C) -> Galley ()
     leaveConversations u ids = do
-      (localConvIds, remoteConvIds) <- partitionMappedOrLocalIds <$> traverse resolveOpaqueConvId (Cql.result ids)
+      let (localConvIds, remoteConvIds) = partitionMappedOrLocalIds (Cql.result ids)
       -- FUTUREWORK(federation, #1275): leave remote conversations.
       -- If we could just get all conversation IDs at once and then leave conversations
       -- in batches, it would make everything much easier.
@@ -271,10 +271,10 @@ rmUser user conn = do
       cc <- Data.conversations localConvIds
       pp <- for cc $ \c -> case Data.convType c of
         SelfConv -> return Nothing
-        One2OneConv -> Data.removeMember user (Data.convId c) >> return Nothing
-        ConnectConv -> Data.removeMember user (Data.convId c) >> return Nothing
+        One2OneConv -> Data.removeMember (Local user) (Data.convId c) >> return Nothing
+        ConnectConv -> Data.removeMember (Local user) (Data.convId c) >> return Nothing
         RegularConv
-          | isMember (makeIdOpaque user) (Data.convMembers c) -> do
+          | Local user `isMember` Data.convMembers c -> do
             e <- Data.removeMembers c user (Local <$> u)
             return $
               (Intra.newPush ListComplete (evtFrom e) (Intra.ConvEvent e) (Intra.recipient <$> Data.convMembers c))

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -260,9 +260,10 @@ rmUser user conn = do
       mems <- Data.teamMembersForFanout tid
       uncheckedDeleteTeamMember user conn tid user mems
       leaveTeams =<< Cql.liftClient (Cql.nextPage tids)
-    leaveConversations :: List1 UserId -> Cql.Page (MappedOrLocalId Id.C) -> Galley ()
+    leaveConversations :: List1 UserId -> Cql.Page (Data.MappedOrLocalIdRow Id.C) -> Galley ()
     leaveConversations u ids = do
-      let (localConvIds, remoteConvIds) = partitionMappedOrLocalIds (Cql.result ids)
+      (localConvIds, remoteConvIds) <-
+        partitionMappedOrLocalIds <$> traverse Data.toMappedOrLocalId (Cql.result ids)
       -- FUTUREWORK(federation, #1275): leave remote conversations.
       -- If we could just get all conversation IDs at once and then leave conversations
       -- in batches, it would make everything much easier.

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -56,7 +56,6 @@ conversationView u Data.Conversation {..} = do
           +++ showUserId u
           +++ val " is not a member of conv "
           +++ idToText convId
-          +++ show (showUserId . Internal.memId <$> toList convMembers)
       throwM badState
     showUserId = \case
       Local localId ->

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -56,6 +56,7 @@ conversationView u Data.Conversation {..} = do
           +++ showUserId u
           +++ val " is not a member of conv "
           +++ idToText convId
+          +++ show (showUserId . Internal.memId <$> toList convMembers)
       throwM badState
     showUserId = \case
       Local localId ->

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -21,10 +21,12 @@ module Galley.API.Mapping where
 
 import Control.Monad.Catch
 import Data.ByteString.Conversion
-import Data.Id
+import qualified Data.Id as Id
+import Data.IdMapping (MappedOrLocalId, opaqueIdFromMappedOrLocal)
 import qualified Data.List as List
 import Galley.App
 import qualified Galley.Data as Data
+import qualified Galley.Types.Conversations.Members as Internal
 import Imports
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
@@ -32,25 +34,30 @@ import qualified System.Logger.Class as Log
 import System.Logger.Message ((+++), msg, val)
 import qualified Wire.API.Conversation as Public
 
-conversationView :: UserId -> Data.Conversation -> Galley Public.Conversation
+conversationView :: MappedOrLocalId Id.U -> Data.Conversation -> Galley Public.Conversation
 conversationView u Data.Conversation {..} = do
   let mm = toList convMembers
-  let (me, them) = List.partition ((u ==) . Public.memId) mm
+  let (me, them) = List.partition ((u ==) . Internal.memId) mm
   m <- maybe memberNotFound return (listToMaybe me)
-  let (name, mems) = (convName, Public.ConvMembers m (map toOther them))
-  return $! Public.Conversation convId convType convCreator convAccess convAccessRole name mems convTeam convMessageTimer convReceiptMode
+  let mems = Public.ConvMembers (toMember m) (toOther <$> them)
+  return $! Public.Conversation convId convType convCreator convAccess convAccessRole convName mems convTeam convMessageTimer convReceiptMode
   where
+    toOther :: Internal.Member -> Public.OtherMember
     toOther x =
       Public.OtherMember
-        { omId = Public.memId x,
-          omService = Public.memService x,
-          omConvRoleName = Public.memConvRoleName x
+        { Public.omId = opaqueIdFromMappedOrLocal (Internal.memId x),
+          Public.omService = Internal.memService x,
+          Public.omConvRoleName = Internal.memConvRoleName x
         }
     memberNotFound = do
       Log.err . msg $
         val "User "
-          +++ toByteString u
+          +++ toByteString (opaqueIdFromMappedOrLocal u)
           +++ val " is not a member of conv "
           +++ toByteString convId
       throwM badState
     badState = Error status500 "bad-state" "Bad internal member state."
+
+toMember :: Internal.Member -> Public.Member
+toMember x@(Internal.Member {..}) =
+  Public.Member {memId = opaqueIdFromMappedOrLocal (Internal.memId x), ..}

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -92,10 +92,10 @@ getConversationIdsH (zusr ::: start ::: size ::: _) = do
 
 getConversationIds :: UserId -> Maybe OpaqueConvId -> Range 1 1000 Int32 -> Galley (Public.ConversationList OpaqueConvId)
 getConversationIds zusr start size = do
-  ids <- Data.conversationIdsFrom zusr start size
+  ids <- Data.conversationIdRowsFrom zusr start size
   pure $
     Public.ConversationList
-      (opaqueIdFromMappedOrLocal <$> Data.resultSetResult ids)
+      ((\(i, _, _) -> i) <$> Data.resultSetResult ids)
       (Data.resultSetType ids == Data.ResultSetTruncated)
 
 getConversationsH :: UserId ::: Maybe (Either (Range 1 32 (List OpaqueConvId)) OpaqueConvId) ::: Range 1 500 Int32 ::: JSON -> Galley Response

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -62,7 +62,9 @@ import Brig.Types.Team (TeamSize (..))
 import Control.Lens
 import Control.Monad.Catch
 import Data.ByteString.Conversion hiding (fromList)
+import qualified Data.Id as Id
 import Data.Id
+import Data.IdMapping (MappedOrLocalId (Local))
 import qualified Data.List.Extra as List
 import Data.List1 (list1)
 import Data.Range as Range
@@ -241,7 +243,7 @@ updateTeam zusr zcon tid updateData = do
   now <- liftIO getCurrentTime
   memList <- Data.teamMembersForFanout tid
   let e = newEvent TeamUpdate tid now & eventData .~ Just (EdTeamUpdate updateData)
-  let r = list1 (userRecipient zusr) (membersToRecipients (Just zusr) (memList ^. teamMembers))
+  let r = list1 (userRecipient (Local zusr)) (membersToRecipients (Just zusr) (memList ^. teamMembers))
   push1 $ newPush1 (memList ^. teamMemberListType) zusr (TeamEvent e) r & pushConn .~ Just zcon
 
 deleteTeamH :: UserId ::: ConnId ::: TeamId ::: OptionalJsonRequest Public.TeamDeleteData ::: JSON -> Galley Response
@@ -309,7 +311,7 @@ uncheckedDeleteTeam zusr zcon tid = do
     pushDeleteEvents :: [TeamMember] -> Event -> [Push] -> Galley ()
     pushDeleteEvents membs e ue = do
       o <- view $ options . optSettings
-      let r = list1 (userRecipient zusr) (membersToRecipients (Just zusr) membs)
+      let r = list1 (userRecipient (Local zusr)) (membersToRecipients (Just zusr) membs)
       -- To avoid DoS on gundeck, send team deletion events in chunks
       let chunkSize = fromMaybe defConcurrentDeletionEvents (o ^. setConcurrentDeletionEvents)
       let chunks = List.chunksOf chunkSize (toList r)
@@ -596,7 +598,7 @@ uncheckedDeleteTeamMember zusr zcon tid remove mems = do
     pushMemberLeaveEvent :: UTCTime -> Galley ()
     pushMemberLeaveEvent now = do
       let e = newEvent MemberLeave tid now & eventData .~ Just (EdMemberLeave remove)
-      let r = list1 (userRecipient zusr) (membersToRecipients (Just zusr) (mems ^. teamMembers))
+      let r = list1 (userRecipient (Local zusr)) (membersToRecipients (Just zusr) (mems ^. teamMembers))
       push1 $ newPush1 (mems ^. teamMemberListType) zusr (TeamEvent e) r & pushConn .~ zcon
     -- notify all conversation members not in this team.
     removeFromConvsAndPushConvLeaveEvent :: UTCTime -> Galley ()
@@ -604,16 +606,16 @@ uncheckedDeleteTeamMember zusr zcon tid remove mems = do
       -- This may not make sense if that list has been truncated. In such cases, we still want to
       -- remove the user from conversations but never send out any events. We assume that clients
       -- handle nicely these missing events, regardless of whether they are in the same team or not
-      let tmids = Set.fromList $ map (view userId) (mems ^. teamMembers)
+      let tmids = Set.fromList $ map (Local . view userId) (mems ^. teamMembers)
       let edata = Conv.EdMembersLeave (Conv.UserIdList [remove])
       cc <- Data.teamConversations tid
       for_ cc $ \c -> Data.conversation (c ^. conversationId) >>= \conv ->
-        for_ conv $ \dc -> when (makeIdOpaque remove `isMember` Data.convMembers dc) $ do
-          Data.removeMember remove (c ^. conversationId)
+        for_ conv $ \dc -> when (Local remove `isMember` Data.convMembers dc) $ do
+          Data.removeMember (Local remove) (c ^. conversationId)
           -- If the list was truncated, then the tmids list is incomplete so we simply drop these events
           unless (c ^. managedConversation || mems ^. teamMemberListType == ListTruncated) $
             pushEvent tmids edata now dc
-    pushEvent :: Set UserId -> Conv.EventData -> UTCTime -> Data.Conversation -> Galley ()
+    pushEvent :: Set (MappedOrLocalId Id.U) -> Conv.EventData -> UTCTime -> Data.Conversation -> Galley ()
     pushEvent exceptTo edata now dc = do
       let (bots, users) = botsAndUsers (Data.convMembers dc)
       let x = filter (\m -> not (Conv.memId m `Set.member` exceptTo)) users
@@ -769,8 +771,14 @@ addTeamMemberInternal tid origin originConn newMem memList = do
   APITeamQueue.pushTeamEvent tid e
   return sizeBeforeAdd
   where
-    recipients (Just o) n = list1 (userRecipient o) (membersToRecipients (Just o) (n : memList ^. teamMembers))
-    recipients Nothing n = list1 (userRecipient (n ^. userId)) (membersToRecipients Nothing (memList ^. teamMembers))
+    recipients (Just o) n =
+      list1
+        (userRecipient (Local o))
+        (membersToRecipients (Just o) (n : memList ^. teamMembers))
+    recipients Nothing n =
+      list1
+        (userRecipient (Local (n ^. userId)))
+        (membersToRecipients Nothing (memList ^. teamMembers))
 
 -- | See also: 'Gundeck.API.Public.paginateH', but the semantics of this end-point is slightly
 -- less warped.  This is a work-around because we cannot send events to all of a large team.
@@ -807,7 +815,7 @@ finishCreateTeam team owner others zcon = do
   now <- liftIO getCurrentTime
   let e = newEvent TeamCreate (team ^. teamId) now & eventData ?~ EdTeamCreate team
   let r = membersToRecipients Nothing others
-  push1 $ newPush1 ListComplete zusr (TeamEvent e) (list1 (userRecipient zusr) r) & pushConn .~ zcon
+  push1 $ newPush1 ListComplete zusr (TeamEvent e) (list1 (userRecipient (Local zusr)) r) & pushConn .~ zcon
 
 withBindingTeam :: UserId -> (TeamId -> Galley b) -> Galley b
 withBindingTeam zusr callback = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -677,8 +677,9 @@ newMessage usr con cnv msg now (m, c, t) ~(toBots, toUsers) =
             otrCiphertext = t,
             otrData = newOtrData msg
           }
-      -- TODO(mheinzel)
-      conv = fromMaybe (selfConv $ undefined memId m) cnv -- use recipient's client's self conversation on broadcast
+      -- use recipient's client's self conversation on broadcast
+      -- (with federation, this might not work for remote members)
+      conv = fromMaybe (selfConv $ memId m) cnv
       e = Event OtrMessageAdd conv usr now (Just $ EdOtrMessage o)
       r = recipient (Local <$> m) & recipientClients .~ (RecipientClientsSome $ singleton c)
    in case newBotMember m of

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -111,7 +111,7 @@ ensureReAuthorised u secret = do
 -- is permitted.
 -- If not, throw 'Member'; if the user is found and does not have the given permission, throw
 -- 'operationDenied'.  Otherwise, return the found user.
-ensureActionAllowed :: Action -> Member -> Galley ()
+ensureActionAllowed :: Action -> InternalMember a -> Galley ()
 ensureActionAllowed action mem = case isActionAllowed action (memConvRoleName mem) of
   Just True -> return ()
   Just False -> throwM (actionDenied action)
@@ -124,7 +124,7 @@ ensureActionAllowed action mem = case isActionAllowed action (memConvRoleName me
 --   own. This is used to ensure users cannot "elevate" allowed actions
 --   This function needs to be review when custom roles are introduced since only
 --   custom roles can cause `roleNameToActions` to return a Nothing
-ensureConvRoleNotElevated :: Member -> RoleName -> Galley ()
+ensureConvRoleNotElevated :: InternalMember a -> RoleName -> Galley ()
 ensureConvRoleNotElevated origMember targetRole = do
   case (roleNameToActions targetRole, roleNameToActions (memConvRoleName origMember)) of
     (Just targetActions, Just memberActions) ->
@@ -163,21 +163,21 @@ permissionCheckTeamConv zusr cnv perm = Data.conversation cnv >>= \case
 acceptOne2One :: UserId -> Data.Conversation -> Maybe ConnId -> Galley Data.Conversation
 acceptOne2One usr conv conn = case Data.convType conv of
   One2OneConv ->
-    if makeIdOpaque usr `isMember` mems
+    if Local usr `isMember` mems
       then return conv
       else do
         now <- liftIO getCurrentTime
         mm <- snd <$> Data.addMember now cid usr
         return $ conv {Data.convMembers = mems <> toList mm}
   ConnectConv -> case mems of
-    [_, _] | makeIdOpaque usr `isMember` mems -> promote
+    [_, _] | Local usr `isMember` mems -> promote
     [_, _] -> throwM convNotFound
     _ -> do
       when (length mems > 2) $
         throwM badConvState
       now <- liftIO getCurrentTime
       (e, mm) <- Data.addMember now cid usr
-      conv' <- if isJust (find ((usr /=) . memId) mems) then promote else pure conv
+      conv' <- if isJust (find ((Local usr /=) . memId) mems) then promote else pure conv
       let mems' = mems <> toList mm
       for_ (newPush ListComplete (evtFrom e) (ConvEvent e) (recipient <$> mems')) $ \p ->
         push1 $ p & pushConn .~ conn & pushRoute .~ RouteDirect
@@ -194,53 +194,64 @@ acceptOne2One usr conv conn = case Data.convType conv of
         "Connect conversation with more than 2 members: "
           <> LT.pack (show cid)
 
-isBot :: Member -> Bool
+isBot :: InternalMember a -> Bool
 isBot = isJust . memService
 
-isMember :: Foldable m => OpaqueUserId -> m Member -> Bool
-isMember u = isJust . find ((u ==) . makeIdOpaque . memId)
+isMember :: (Eq a, Foldable m) => a -> m (InternalMember a) -> Bool
+isMember u = isJust . find ((u ==) . memId)
 
-findMember :: Data.Conversation -> UserId -> Maybe Member
+findMember :: Data.Conversation -> MappedOrLocalId Id.U -> Maybe Member
 findMember c u = find ((u ==) . memId) (Data.convMembers c)
 
 botsAndUsers :: Foldable t => t Member -> ([BotMember], [Member])
-botsAndUsers = foldr fn ([], [])
+botsAndUsers = foldMap fn
   where
-    fn m ~(bb, mm) = case newBotMember m of
-      Nothing -> (bb, m : mm)
-      Just b -> (b : bb, mm)
+    fn m = case memService m of
+      Just _ -> (toList (mkBotMember m), []) -- TODO: we drop invalid bots here, which shouldn't happen
+      Nothing -> ([], [m])
+    mkBotMember :: Member -> Maybe BotMember
+    mkBotMember m = case memId m of
+      Mapped _ -> Nothing -- remote members can't be bots
+      Local localMemId ->
+        let m' = m {memId = localMemId} :: LocalMember
+         in newBotMember m'
 
 location :: ToByteString a => a -> Response -> Response
 location = addHeader hLocation . toByteString'
 
 nonTeamMembers :: [Member] -> [TeamMember] -> [Member]
-nonTeamMembers cm tm = filter (not . flip isTeamMember tm . memId) cm
+nonTeamMembers cm tm = filter (not . isMemberOfTeam . memId) cm
+  where
+    isMemberOfTeam = \case
+      Local uid -> isTeamMember uid tm
+      Mapped _ -> False -- teams and their members are always on the same backend
 
 convMembsAndTeamMembs :: [Member] -> [TeamMember] -> [Recipient]
 convMembsAndTeamMembs convMembs teamMembs =
-  fmap userRecipient . setnub $ map memId convMembs <> map (view userId) teamMembs
+  fmap userRecipient . setnub $ map memId convMembs <> map (Local . view userId) teamMembs
   where
     setnub = Set.toList . Set.fromList
 
 membersToRecipients :: Maybe UserId -> [TeamMember] -> [Recipient]
-membersToRecipients Nothing = map (userRecipient . view userId)
-membersToRecipients (Just u) = map userRecipient . filter (/= u) . map (view userId)
+membersToRecipients Nothing = map (userRecipient . Local . view userId)
+membersToRecipients (Just u) = map (userRecipient . Local) . filter (/= u) . map (view userId)
 
--- Note that we use 2 nearly identical functions but slightly different
+-- | Note that we use 2 nearly identical functions but slightly different
 -- semantics; when using `getSelfMember`, if that user is _not_ part of
 -- the conversation, we don't want to disclose that such a conversation
 -- with that id exists.
-getSelfMember :: Foldable t => UserId -> t Member -> Galley Member
+getSelfMember :: Foldable t => UserId -> t Member -> Galley LocalMember
 getSelfMember = getMember convNotFound
 
-getOtherMember :: Foldable t => UserId -> t Member -> Galley Member
+getOtherMember :: Foldable t => UserId -> t Member -> Galley LocalMember
 getOtherMember = getMember convMemberNotFound
 
-getMember :: Foldable t => Error -> UserId -> t Member -> Galley Member
+-- | Since we search by local user ID, we know that the member must be local.
+getMember :: Foldable t => Error -> UserId -> t Member -> Galley LocalMember
 getMember ex u ms = do
-  let member = find ((u ==) . memId) ms
+  let member = find ((Local u ==) . memId) ms
   case member of
-    Just m -> return m
+    Just m -> return (m {memId = u})
     Nothing -> throwM ex
 
 getConversationAndCheckMembership :: UserId -> MappedOrLocalId Id.C -> Galley Data.Conversation
@@ -256,7 +267,7 @@ getConversationAndCheckMembershipWithError ex zusr = \case
     when (DataTypes.isConvDeleted c) $ do
       Data.deleteConversation convId
       throwM convNotFound
-    unless (makeIdOpaque zusr `isMember` Data.convMembers c) $
+    unless (Local zusr `isMember` Data.convMembers c) $
       throwM ex
     return c
 

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -207,14 +207,17 @@ botsAndUsers :: Foldable t => t Member -> ([BotMember], [Member])
 botsAndUsers = foldMap fn
   where
     fn m = case memService m of
-      Just _ -> (toList (mkBotMember m), []) -- TODO: we drop invalid bots here, which shouldn't happen
-      Nothing -> ([], [m])
+      Just _ ->
+        -- TODO(mheinzel): we drop invalid bots here, which shouldn't happen
+        (toList (mkBotMember m), [])
+      Nothing ->
+        ([], [m])
     mkBotMember :: Member -> Maybe BotMember
     mkBotMember m = case memId m of
-      Mapped _ -> Nothing -- remote members can't be bots
+      Mapped _ ->
+        Nothing -- remote members can't be bots
       Local localMemId ->
-        let m' = m {memId = localMemId} :: LocalMember
-         in newBotMember m'
+        newBotMember (m {memId = localMemId} :: LocalMember)
 
 location :: ToByteString a => a -> Response -> Response
 location = addHeader hLocation . toByteString'

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -208,7 +208,8 @@ botsAndUsers = foldMap fn
   where
     fn m = case memService m of
       Just _ ->
-        -- TODO(mheinzel): we drop invalid bots here, which shouldn't happen
+        -- TODO(mheinzel): log error!
+        -- we drop invalid bots here, which shouldn't happen
         (toList (mkBotMember m), [])
       Nothing ->
         ([], [m])

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -696,7 +696,7 @@ toMappedOrLocalId = \case
   (Id localId, Nothing, Nothing) ->
     Local (Id localId)
   (Id localId, _, _) ->
-    -- TODO: this should be an error
+    -- TODO(mheinzel): this should be an error
     Local (Id localId)
 
 fromMappedOrLocalId :: MappedOrLocalId a -> (Id (Opaque a), Maybe (Id (Remote a)), Maybe Domain)

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -519,6 +519,8 @@ conversationIdsForPagination usr start (fromRange -> max) =
     Just c -> paginate Cql.selectUserConvsFrom (paramsP Quorum (usr, c) max)
     Nothing -> paginate Cql.selectUserConvs (paramsP Quorum (Identity usr) max)
 
+-- TODO(mheinzel): do any consumers of this function only need the opaque ID?
+-- if so, should we create a separate function that can't fail on toMappedOrLocalId?
 conversationIdsOf :: MonadClient m => UserId -> Range 1 32 (List OpaqueConvId) -> m [MappedOrLocalId Id.C]
 conversationIdsOf usr (fromList . fromRange -> cids) =
   map toMappedOrLocalId <$> retry x1 (query Cql.selectUserConvsIn (params Quorum (usr, cids)))
@@ -696,7 +698,7 @@ toMappedOrLocalId = \case
   (Id localId, Nothing, Nothing) ->
     Local (Id localId)
   (Id localId, _, _) ->
-    -- TODO(mheinzel): this should be an error
+    -- TODO(mheinzel): return either, raise error
     Local (Id localId)
 
 fromMappedOrLocalId :: MappedOrLocalId a -> (Id (Opaque a), Maybe (Id (Remote a)), Maybe Domain)

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -172,7 +172,7 @@ resultSetResult :: ResultSet a -> [a]
 resultSetResult = result . page
 
 schemaVersion :: Int32
-schemaVersion = 43
+schemaVersion = 44
 
 -- | Insert a conversation code
 insertCode :: MonadClient m => Code -> m ()

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -263,7 +263,7 @@ selectMembers :: PrepQuery R (Identity [ConvId]) (ConvId, OpaqueUserId, Maybe Re
 selectMembers = "select conv, user, user_remote_id, user_remote_domain, service, provider, status, otr_muted, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role from member where conv in ?"
 
 insertMember :: PrepQuery W (ConvId, OpaqueUserId, Maybe RemoteUserId, Maybe Domain, Maybe ServiceId, Maybe ProviderId, RoleName) ()
-insertMember = "insert into member (conv, user, user_remote_id, user_remote_domain, service, provider, status, conversation_role) values (?, ?, ?, ?, 0, ?)"
+insertMember = "insert into member (conv, user, user_remote_id, user_remote_domain, service, provider, status, conversation_role) values (?, ?, ?, ?, ?, ?, 0, ?)"
 
 removeMember :: PrepQuery W (ConvId, OpaqueUserId) ()
 removeMember = "delete from member where conv = ? and user = ?"

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -237,51 +237,50 @@ deleteCode = "DELETE FROM conversation_codes WHERE key = ? AND scope = ?"
 
 -- User Conversations -------------------------------------------------------
 
-selectUserConvs :: PrepQuery R (Identity UserId) (Identity OpaqueConvId)
-selectUserConvs = "select conv from user where user = ? order by conv"
+selectUserConvs :: PrepQuery R (Identity UserId) (OpaqueConvId, Maybe RemoteConvId, Maybe Domain)
+selectUserConvs = "select conv, conv_remote_id, conv_remote_domain from user where user = ? order by conv"
 
-selectUserConvsIn :: PrepQuery R (UserId, [OpaqueConvId]) (Identity OpaqueConvId)
-selectUserConvsIn = "select conv from user where user = ? and conv in ? order by conv"
+selectUserConvsIn :: PrepQuery R (UserId, [OpaqueConvId]) (OpaqueConvId, Maybe RemoteConvId, Maybe Domain)
+selectUserConvsIn = "select conv, conv_remote_id, conv_remote_domain from user where user = ? and conv in ? order by conv"
 
-selectUserConvsFrom :: PrepQuery R (UserId, OpaqueConvId) (Identity OpaqueConvId)
-selectUserConvsFrom = "select conv from user where user = ? and conv > ? order by conv"
+selectUserConvsFrom :: PrepQuery R (UserId, OpaqueConvId) (OpaqueConvId, Maybe RemoteConvId, Maybe Domain)
+selectUserConvsFrom = "select conv, conv_remote_id, conv_remote_domain from user where user = ? and conv > ? order by conv"
 
--- FUTUREWORK(federation): unify types with queries above
-insertUserConv :: PrepQuery W (UserId, ConvId) ()
-insertUserConv = "insert into user (user, conv) values (?, ?)"
+insertUserConv :: PrepQuery W (UserId, OpaqueConvId, Maybe RemoteConvId, Maybe Domain) ()
+insertUserConv = "insert into user (user, conv) values (?, ?, ?, ?)"
 
-deleteUserConv :: PrepQuery W (UserId, ConvId) ()
+deleteUserConv :: PrepQuery W (UserId, OpaqueConvId) ()
 deleteUserConv = "delete from user where user = ? and conv = ?"
 
 -- Members ------------------------------------------------------------------
 
 type MemberStatus = Int32
 
-selectMember :: PrepQuery R (ConvId, UserId) (UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName)
-selectMember = "select user, service, provider, status, otr_muted, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role from member where conv = ? and user = ?"
+selectMember :: PrepQuery R (ConvId, OpaqueUserId) (OpaqueUserId, Maybe RemoteUserId, Maybe Domain, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName)
+selectMember = "select user, user_remote_id, user_remote_domain, service, provider, status, otr_muted, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role from member where conv = ? and user = ?"
 
-selectMembers :: PrepQuery R (Identity [ConvId]) (ConvId, UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName)
-selectMembers = "select conv, user, service, provider, status, otr_muted, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role from member where conv in ?"
+selectMembers :: PrepQuery R (Identity [ConvId]) (ConvId, OpaqueUserId, Maybe RemoteUserId, Maybe Domain, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe Bool, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName)
+selectMembers = "select conv, user, user_remote_id, user_remote_domain, service, provider, status, otr_muted, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role from member where conv in ?"
 
-insertMember :: PrepQuery W (ConvId, UserId, Maybe ServiceId, Maybe ProviderId, RoleName) ()
-insertMember = "insert into member (conv, user, service, provider, status, conversation_role) values (?, ?, ?, ?, 0, ?)"
+insertMember :: PrepQuery W (ConvId, OpaqueUserId, Maybe RemoteUserId, Maybe Domain, Maybe ServiceId, Maybe ProviderId, RoleName) ()
+insertMember = "insert into member (conv, user, user_remote_id, user_remote_domain, service, provider, status, conversation_role) values (?, ?, ?, ?, 0, ?)"
 
 removeMember :: PrepQuery W (ConvId, OpaqueUserId) ()
 removeMember = "delete from member where conv = ? and user = ?"
 
-updateOtrMemberMuted :: PrepQuery W (Bool, Maybe Text, ConvId, UserId) ()
+updateOtrMemberMuted :: PrepQuery W (Bool, Maybe Text, ConvId, OpaqueUserId) ()
 updateOtrMemberMuted = "update member set otr_muted = ?, otr_muted_ref = ? where conv = ? and user = ?"
 
-updateOtrMemberMutedStatus :: PrepQuery W (MutedStatus, Maybe Text, ConvId, UserId) ()
+updateOtrMemberMutedStatus :: PrepQuery W (MutedStatus, Maybe Text, ConvId, OpaqueUserId) ()
 updateOtrMemberMutedStatus = "update member set otr_muted_status = ?, otr_muted_ref = ? where conv = ? and user = ?"
 
-updateOtrMemberArchived :: PrepQuery W (Bool, Maybe Text, ConvId, UserId) ()
+updateOtrMemberArchived :: PrepQuery W (Bool, Maybe Text, ConvId, OpaqueUserId) ()
 updateOtrMemberArchived = "update member set otr_archived = ?, otr_archived_ref = ? where conv = ? and user = ?"
 
-updateMemberHidden :: PrepQuery W (Bool, Maybe Text, ConvId, UserId) ()
+updateMemberHidden :: PrepQuery W (Bool, Maybe Text, ConvId, OpaqueUserId) ()
 updateMemberHidden = "update member set hidden = ?, hidden_ref = ? where conv = ? and user = ?"
 
-updateMemberConvRoleName :: PrepQuery W (RoleName, ConvId, UserId) ()
+updateMemberConvRoleName :: PrepQuery W (RoleName, ConvId, OpaqueUserId) ()
 updateMemberConvRoleName = "update member set conversation_role = ? where conv = ? and user = ?"
 
 -- Clients ------------------------------------------------------------------

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -247,7 +247,7 @@ selectUserConvsFrom :: PrepQuery R (UserId, OpaqueConvId) (OpaqueConvId, Maybe R
 selectUserConvsFrom = "select conv, conv_remote_id, conv_remote_domain from user where user = ? and conv > ? order by conv"
 
 insertUserConv :: PrepQuery W (UserId, OpaqueConvId, Maybe RemoteConvId, Maybe Domain) ()
-insertUserConv = "insert into user (user, conv) values (?, ?, ?, ?)"
+insertUserConv = "insert into user (user, conv, conv_remote_id, conv_remote_domain) values (?, ?, ?, ?)"
 
 deleteUserConv :: PrepQuery W (UserId, OpaqueConvId) ()
 deleteUserConv = "delete from user where user = ? and conv = ?"

--- a/services/galley/src/Galley/Data/Services.hs
+++ b/services/galley/src/Galley/Data/Services.hs
@@ -46,9 +46,12 @@ import Imports
 
 -- BotMember ------------------------------------------------------------------
 
-newtype BotMember = BotMember {fromBotMember :: Member}
+-- | For now we assume bots to always be local
+--
+-- FUTUREWORK(federation): allow remote bots
+newtype BotMember = BotMember {fromBotMember :: LocalMember}
 
-newBotMember :: Member -> Maybe BotMember
+newBotMember :: LocalMember -> Maybe BotMember
 newBotMember m = const (BotMember m) <$> memService m
 
 botMemId :: BotMember -> BotId
@@ -64,7 +67,7 @@ addBotMember orig s bot cnv now = do
   retry x5 $ batch $ do
     setType BatchLogged
     setConsistency Quorum
-    addPrepQuery insertUserConv (botUserId bot, cnv)
+    addPrepQuery insertUserConv (botUserId bot, makeIdOpaque cnv, Nothing, Nothing)
     addPrepQuery insertBot (cnv, bot, sid, pid)
   let e = Event MemberJoin cnv orig now (Just . EdMembersJoin . SimpleMembers $ (fmap toSimpleMember [botUserId bot]))
   let mem = (newMember (botUserId bot)) {memService = Just s}

--- a/services/galley/src/Galley/Data/Types.hs
+++ b/services/galley/src/Galley/Data/Types.hs
@@ -40,7 +40,7 @@ import Data.Id
 import Data.Misc (Milliseconds)
 import Data.Range
 import qualified Data.Text.Ascii as Ascii
-import Galley.Types (Access, AccessRole, ConvType (..), Member (..), ReceiptMode)
+import Galley.Types (Access, AccessRole, ConvType (..), Member, ReceiptMode)
 import Imports
 import OpenSSL.EVP.Digest (digestBS, getDigestByName)
 import OpenSSL.Random (randBytes)
@@ -62,7 +62,7 @@ data Conversation = Conversation
     convMessageTimer :: Maybe Milliseconds,
     convReceiptMode :: Maybe ReceiptMode
   }
-  deriving (Eq, Show, Generic)
+  deriving (Show)
 
 isSelfConv :: Conversation -> Bool
 isSelfConv = (SelfConv ==) . convType

--- a/services/galley/src/Galley/Intra/Push.hs
+++ b/services/galley/src/Galley/Intra/Push.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
 
 -- This file is part of the Wire Server implementation.

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -46,7 +46,7 @@ import Data.Range
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Ascii as Ascii
-import Galley.Types
+import Galley.Types hiding (InternalMember (..), Member)
 import Galley.Types.Conversations.Roles
 import qualified Galley.Types.Teams as Teams
 import Gundeck.Types.Notification
@@ -58,6 +58,7 @@ import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
 import TestHelpers
 import TestSetup
+import Wire.API.Conversation.Member (Member (..))
 
 tests :: IO TestSetup -> TestTree
 tests s =
@@ -873,7 +874,7 @@ postMembersOk2 = do
   postMembers bob (singleton chuck) conv !!! const 204 === statusCode
   chuck' <- responseJsonUnsafe <$> (getSelfMember chuck conv <!! const 200 === statusCode)
   liftIO $
-    assertEqual "wrong self member" (memId <$> chuck') (Just chuck)
+    assertEqual "wrong self member" (Just (makeIdOpaque chuck)) (memId <$> chuck')
 
 postMembersOk3 :: TestM ()
 postMembersOk3 = do
@@ -1013,7 +1014,7 @@ putMemberOk update = do
   -- Expected member state
   let memberBob =
         Member
-          { memId = bob,
+          { memId = makeIdOpaque bob,
             memService = Nothing,
             memOtrMuted = fromMaybe False (mupOtrMute update),
             memOtrMutedStatus = mupOtrMuteStatus update,
@@ -1146,13 +1147,13 @@ removeUser = do
   mems1 <- fmap cnvMembers . responseJsonUnsafe <$> getConv alice conv1
   mems2 <- fmap cnvMembers . responseJsonUnsafe <$> getConv alice conv2
   mems3 <- fmap cnvMembers . responseJsonUnsafe <$> getConv alice conv3
-  let other u = find ((== u) . omId) . cmOthers
+  let other u = find ((== makeIdOpaque u) . omId) . cmOthers
   liftIO $ do
     (mems1 >>= other bob) @?= Nothing
     (mems2 >>= other bob) @?= Nothing
-    (mems2 >>= other carl) @?= Just (OtherMember carl Nothing roleNameWireAdmin)
+    (mems2 >>= other carl) @?= Just (OtherMember (makeIdOpaque carl) Nothing roleNameWireAdmin)
     (mems3 >>= other bob) @?= Nothing
-    (mems3 >>= other carl) @?= Just (OtherMember carl Nothing roleNameWireAdmin)
+    (mems3 >>= other carl) @?= Just (OtherMember (makeIdOpaque carl) Nothing roleNameWireAdmin)
   where
     matchMemberLeave conv u n = do
       let e = List1.head (WS.unpackPayload n)


### PR DESCRIPTION
Just to show what it would look like if done this way.

*edit: I'm now working on this for real*

The best places to start reviewing this are probably
- the change to the schema (migration in [`services/galley/schema/src/V42_AddRemoteIdentifiers.hs`](https://github.com/wireapp/wire-server/pull/1070/files#diff-fbc8ff3f06af03cf12d756e13ffb62e1)),
- the change to the Cassandra queries ([`services/galley/src/Galley/Data/Queries.hs`](https://github.com/wireapp/wire-server/pull/1070/files#diff-4da299bc3b32ddfd89f129cb028537ef))
and (de)serialization ([`services/galley/src/Galley/Data.hs`](https://github.com/wireapp/wire-server/pull/1070/files#diff-15dea71d1934d99c4d13aeaa66bb4917R692))

- the new `InternalMember` type ([`libs/galley-types/src/Galley/Types/Conversations/Members.hs` ](https://github.com/wireapp/wire-server/pull/1070/files#diff-371cb31453e069048a1df3b3d16437c0))
- the change to make a bit more of the API work with opaque IDs ([`libs/wire-api/src/Wire/API/Conversation/Member.hs`](https://github.com/wireapp/wire-server/pull/1070/files#diff-f989e55d6fc76241821cf85ff308f971)).

The rest pretty much follows from theses changes to make it type-check.