### PR TITLE
Leave domain empty in cookies.

### DIFF
--- a/deploy/services-demo/conf/brig.demo-docker.yaml
+++ b/deploy/services-demo/conf/brig.demo-docker.yaml
@@ -99,7 +99,6 @@ optSettings:
   setActivationTimeout: 1209600     # 1 day
   setTeamInvitationTimeout: 1814400 # 21 days
   setUserMaxConnections: 1000
-  setCookieDomain: brig
   setCookieInsecure: false
   setUserCookieRenewAge: 1209600 # 14 days
   setUserCookieLimit: 32

--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -102,7 +102,6 @@ optSettings:
   setActivationTimeout: 1209600     # 1 day
   setTeamInvitationTimeout: 1814400 # 21 days
   setUserMaxConnections: 1000
-  setCookieDomain: localhost
   setCookieInsecure: false
   setUserCookieRenewAge: 1209600 # 14 days
   setUserCookieLimit: 32

--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -281,6 +281,11 @@ http {
       proxy_pass http://galley;
     }
 
+    location ~* ^/teams/([^/]*)/legalhold(.*) {
+      include common_response_with_zauth.conf;
+      proxy_pass http://galley;
+    }
+
     # Gundeck Endpoints
 
     rewrite ^/api-docs/push  /push/api-docs?base_url=http://127.0.0.1:8080/ break;

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -131,7 +131,6 @@ optSettings:
   setNexmo: test/resources/nexmo-credentials.yaml
   # setStomp: test/resources/stomp-credentials.yaml
   setUserMaxConnections: 16
-  setCookieDomain: 127.0.0.1
   setCookieInsecure: true
   setUserCookieRenewAge: 2
   setUserCookieLimit: 5

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -393,9 +393,6 @@ data Settings = Settings
     -- | Max. number of permanent clients per user
     setUserMaxPermClients :: !(Maybe Int),
     -- | The domain to restrict cookies to
-    setCookieDomain :: !Text,
-    -- | Whether to allow plain HTTP transmission
-    --   of cookies (for testing purposes only)
     setCookieInsecure :: !Bool,
     -- | Minimum age of a user cookie before
     --   it is renewed during token refresh

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -1036,7 +1036,7 @@ setProviderCookie t r = do
       Cookie.def
         { Cookie.setCookieName = "zprovider",
           Cookie.setCookieValue = toByteString' t,
-          Cookie.setCookieDomain = Just $ Text.encodeUtf8 . setCookieDomain $ s,
+          Cookie.setCookieDomain = Nothing,
           Cookie.setCookiePath = Just "/provider",
           Cookie.setCookieExpires = Just (ZAuth.tokenExpiresUTC t),
           Cookie.setCookieSecure = not (setCookieInsecure s),

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -52,7 +52,6 @@ import Data.Id
 import qualified Data.List as List
 import qualified Data.Metrics as Metrics
 import Data.Proxy
-import Data.Text.Encoding (encodeUtf8)
 import Data.Time.Clock
 import Imports
 import Network.Wai (Response)
@@ -234,7 +233,7 @@ setResponseCookie c r = do
       WebCookie.def
         { WebCookie.setCookieName = "zuid",
           WebCookie.setCookieValue = toByteString' (cookieValue c),
-          WebCookie.setCookieDomain = Just $ encodeUtf8 . setCookieDomain $ s,
+          WebCookie.setCookieDomain = Nothing,
           WebCookie.setCookiePath = Just "/access",
           WebCookie.setCookieExpires =
             if cookieType c == PersistentCookie

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -36,10 +36,9 @@ import Brig.Types.User.Auth
 import qualified Brig.Types.User.Auth as Auth
 import Brig.ZAuth (ZAuth, runZAuth)
 import qualified Brig.ZAuth as ZAuth
-import Control.Lens ((^.), (^?), set)
+import Control.Lens ((^.), set)
 import Control.Retry
 import Data.Aeson
-import Data.Aeson.Lens
 import qualified Data.ByteString as BS
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
@@ -48,7 +47,6 @@ import Data.Id
 import Data.Misc (PlainTextPassword (..))
 import Data.Proxy
 import qualified Data.Text as Text
-import Data.Text.Encoding (encodeUtf8)
 import qualified Data.Text.Lazy as Lazy
 import Data.Time.Clock
 import qualified Data.UUID.V4 as UUID
@@ -856,18 +854,6 @@ prepareLegalHoldUser brig galley = do
   -- enable it for this team - without that, legalhold login will fail.
   putLegalHoldEnabled tid LegalHoldEnabled galley
   return uid
-
-decodeCookie :: HasCallStack => Response a -> Http.Cookie
-decodeCookie = fromMaybe (error "missing zuid cookie") . getCookie "zuid"
-
-decodeToken :: HasCallStack => Response (Maybe Lazy.ByteString) -> ZAuth.AccessToken
-decodeToken = decodeToken' @ZAuth.Access
-
-decodeToken' :: (HasCallStack, ZAuth.AccessTokenLike a) => Response (Maybe Lazy.ByteString) -> ZAuth.Token a
-decodeToken' r = fromMaybe (error "invalid access_token") $ do
-  x <- responseBody r
-  t <- x ^? key "access_token" . _String
-  fromByteString (encodeUtf8 t)
 
 getCookieId :: forall u. (HasCallStack, ZAuth.UserTokenLike u) => Http.Cookie -> CookieId
 getCookieId c =

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -268,6 +268,9 @@ getUser brig zusr usr =
       . paths ["users", toByteString' usr]
       . zUser zusr
 
+-- | NB: you can also use nginz as the first argument here.  The type aliases are compatible,
+-- and so are the end-points.  This is important in tests where the cookie must come from the
+-- nginz domain, so it can be passed back to it.
 login :: Brig -> Login -> CookieType -> Http ResponseLBS
 login b l t =
   let js = RequestBodyLBS (encode l)

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -214,8 +214,9 @@ requestDevice zusr tid uid = do
       let NewLegalHoldClient prekeys lastKey = lhDevice
       return (lastKey, prekeys)
 
--- | Approve the adding of a Legal Hold device to the user
--- we don't delete pending prekeys during this flow just in case
+-- | Approve the adding of a Legal Hold device to the user.
+--
+-- We don't delete pending prekeys during this flow just in case
 -- it gets interupted. There's really no reason to delete them anyways
 -- since they are replaced if needed when registering new LH devices.
 approveDeviceH ::

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -69,7 +69,6 @@ import Spar.Scim
 import Spar.Scim.Swagger ()
 import Spar.Types
 import qualified URI.ByteString as URI
-import qualified Web.Cookie as Cky
 
 app :: Env -> Application
 app ctx =
@@ -144,23 +143,12 @@ authreq authreqttl _ zusr msucc merr idpid = do
 -- value that deletes any bind cookies on the client.
 initializeBindCookie :: Maybe UserId -> NominalDiffTime -> Spar SetBindCookie
 initializeBindCookie zusr authreqttl = do
-  DerivedOpts {derivedOptsBindCookiePath, derivedOptsBindCookieDomain} <-
-    asks (derivedOpts . sparCtxOpts)
+  DerivedOpts {derivedOptsBindCookiePath} <- asks (derivedOpts . sparCtxOpts)
   msecret <-
     if isJust zusr
       then liftIO $ Just . cs . ES.encode <$> randBytes 32
       else pure Nothing
-  let updSetCkyDom (SAML.SimpleSetCookie raw) =
-        SAML.SimpleSetCookie
-          raw
-            { Cky.setCookieDomain = Just derivedOptsBindCookieDomain
-            }
-  cky <-
-    updSetCkyDom
-      <$> ( SAML.toggleCookie derivedOptsBindCookiePath $
-              (,authreqttl) <$> msecret ::
-              Spar SetBindCookie
-          )
+  cky <- SAML.toggleCookie derivedOptsBindCookiePath $ (,authreqttl) <$> msecret
   forM_ zusr $ \userid -> wrapMonadClientWithEnv $ Data.insertBindCookie cky userid authreqttl
   pure cky
 

--- a/services/spar/src/Spar/Options.hs
+++ b/services/spar/src/Spar/Options.hs
@@ -30,7 +30,6 @@ where
 
 import Control.Exception
 import Control.Lens
-import Control.Monad.Catch
 import qualified Data.ByteString as SBS
 import qualified Data.Yaml as Yaml
 import Imports
@@ -56,8 +55,6 @@ deriveOpts raw = do
   derived <- do
     let respuri = runWithConfig raw sparResponseURI
         derivedOptsBindCookiePath = URI.uriPath respuri
-        unwrap = maybe (throwM $ ErrorCall "Bad server config: no domain in response URI") pure
-    derivedOptsBindCookieDomain <- URI.hostBS . URI.authorityHost <$> unwrap (URI.uriAuthority respuri)
     -- We could also make this selectable in the config file, but it seems easier to derive it from
     -- the SAML base uri.
     let derivedOptsScimBaseURI = (saml raw ^. SAML.cfgSPSsoURI) & pathL %~ derive

--- a/services/spar/src/Spar/Types.hs
+++ b/services/spar/src/Spar/Types.hs
@@ -253,7 +253,6 @@ instance FromJSON (Opts' (Maybe ()))
 
 data DerivedOpts = DerivedOpts
   { derivedOptsBindCookiePath :: !SBS,
-    derivedOptsBindCookieDomain :: !SBS,
     derivedOptsScimBaseURI :: !URI
   }
   deriving (Show, Generic)


### PR DESCRIPTION
This makes UAs default to server host (plus sub-domains).

Fixes https://github.com/zinfra/backend-issues/issues/953