### PR TITLE
Allow team deletion on stern

### DIFF
--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -1053,6 +1053,8 @@ sitemap = do
     capture "tid"
       .&. capture "uid"
       .&. accept "application" "json"
+  delete "/i/teams/:tid" (continue Teams.internalDeleteBindingTeamWithOneMemberH) $
+    capture "tid"
   get "/i/users/:uid/team/members" (continue Teams.getBindingTeamMembersH) $
     capture "uid"
   get "/i/users/:uid/team" (continue Teams.getBindingTeamIdH) $

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -109,6 +109,12 @@ actionDenied a =
     "action-denied"
     ("Insufficient authorization (missing " <> (pack $ show a) <> ")")
 
+noBindingTeam :: Error
+noBindingTeam = Error status403 "no-binding-team" "Operation allowed only on binding teams."
+
+notAOneMemberTeam :: Error
+notAOneMemberTeam = Error status403 "not-one-member-team" "Can only delete teams with a single member."
+
 notATeamMember :: Error
 notATeamMember = Error status403 "no-team-member" "Requesting user is not a team member."
 

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -51,6 +51,8 @@ module Galley.API.Teams
     withBindingTeam,
     userIsTeamOwnerH,
     canUserJoinTeamH,
+    internalDeleteBindingTeamWithOneMemberH,
+    internalDeleteBindingTeamWithOneMember,
   )
 where
 
@@ -244,22 +246,27 @@ deleteTeam zusr zcon tid mBody = do
     Deleted ->
       throwM teamNotFound
     PendingDelete ->
-      queueDelete
+      queueTeamDeletion tid zusr (Just zcon)
     _ -> do
       checkPermissions team
-      queueDelete
+      queueTeamDeletion tid zusr (Just zcon)
   where
     checkPermissions team = do
       void $ permissionCheck DeleteTeam =<< Data.teamMember tid zusr
       when ((tdTeam team) ^. teamBinding == Binding) $ do
         body <- mBody & ifNothing (invalidPayload "missing request body")
         ensureReAuthorised zusr (body ^. tdAuthPassword)
-    queueDelete = do
-      q <- view deleteQueue
-      ok <- Q.tryPush q (TeamItem tid zusr (Just zcon))
-      if ok
-        then pure ()
-        else throwM deleteQueueFull
+
+-- This can be called by stern
+internalDeleteBindingTeamWithOneMember :: TeamId -> Galley ()
+internalDeleteBindingTeamWithOneMember tid = do
+  team <- Data.team tid
+  unless ((view teamBinding . tdTeam <$> team) == Just Binding) $
+    throwM noBindingTeam
+  mems <- Data.teamMembersWithLimit tid (unsafeRange 2)
+  case mems ^. teamMembers of
+    (mem:[]) -> queueTeamDeletion tid (mem ^. userId) Nothing
+    _        -> throwM notAOneMemberTeam
 
 -- This function is "unchecked" because it does not validate that the user has the `DeleteTeam` permission.
 uncheckedDeleteTeam :: UserId -> Maybe ConnId -> TeamId -> Galley ()
@@ -386,6 +393,11 @@ getTeamMember zusr tid uid = do
       Data.teamMember tid uid >>= \case
         Nothing -> throwM teamMemberNotFound
         Just member -> pure (member, withPerms)
+
+internalDeleteBindingTeamWithOneMemberH :: TeamId -> Galley Response
+internalDeleteBindingTeamWithOneMemberH tid = do
+  internalDeleteBindingTeamWithOneMember tid
+  pure (empty & setStatus status202)
 
 uncheckedGetTeamMemberH :: TeamId ::: UserId ::: JSON -> Galley Response
 uncheckedGetTeamMemberH (tid ::: uid ::: _) = do
@@ -891,3 +903,12 @@ userIsTeamOwner :: TeamId -> UserId -> Galley Bool
 userIsTeamOwner tid uid = do
   let asking = uid
   isTeamOwner . fst <$> getTeamMember asking tid uid
+
+-- Queues a team for async deletion
+queueTeamDeletion :: TeamId -> UserId -> Maybe ConnId -> Galley ()
+queueTeamDeletion tid zusr zcon = do
+      q <- view deleteQueue
+      ok <- Q.tryPush q (TeamItem tid zusr zcon)
+      if ok
+        then pure ()
+        else throwM deleteQueueFull

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -265,8 +265,8 @@ internalDeleteBindingTeamWithOneMember tid = do
     throwM noBindingTeam
   mems <- Data.teamMembersWithLimit tid (unsafeRange 2)
   case mems ^. teamMembers of
-    (mem:[]) -> queueTeamDeletion tid (mem ^. userId) Nothing
-    _        -> throwM notAOneMemberTeam
+    (mem : []) -> queueTeamDeletion tid (mem ^. userId) Nothing
+    _ -> throwM notAOneMemberTeam
 
 -- This function is "unchecked" because it does not validate that the user has the `DeleteTeam` permission.
 uncheckedDeleteTeam :: UserId -> Maybe ConnId -> TeamId -> Galley ()
@@ -907,8 +907,8 @@ userIsTeamOwner tid uid = do
 -- Queues a team for async deletion
 queueTeamDeletion :: TeamId -> UserId -> Maybe ConnId -> Galley ()
 queueTeamDeletion tid zusr zcon = do
-      q <- view deleteQueue
-      ok <- Q.tryPush q (TeamItem tid zusr zcon)
-      if ok
-        then pure ()
-        else throwM deleteQueueFull
+  q <- view deleteQueue
+  ok <- Q.tryPush q (TeamItem tid zusr zcon)
+  if ok
+    then pure ()
+    else throwM deleteQueueFull

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1133,12 +1133,13 @@ ensureDeletedState check from u = do
 getDeletedState :: HasCallStack => UserId -> UserId -> TestM (Maybe Bool)
 getDeletedState from u = do
   b <- view tsBrig
-  fmap profileDeleted . responseJsonMaybe <$> get
-    ( b
-        . paths ["users", toByteString' u]
-        . zUser from
-        . zConn "conn"
-    )
+  fmap profileDeleted . responseJsonMaybe
+    <$> get
+      ( b
+          . paths ["users", toByteString' u]
+          . zUser from
+          . zConn "conn"
+      )
 
 getClients :: UserId -> TestM ResponseLBS
 getClients u = do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1127,16 +1127,18 @@ randomClient uid lk = do
 
 ensureDeletedState :: HasCallStack => Bool -> UserId -> UserId -> TestM ()
 ensureDeletedState check from u = do
+  state <- getDeletedState from u
+  liftIO $ assertEqual "Unxpected deleted state" state (Just check)
+
+getDeletedState :: HasCallStack => UserId -> UserId -> TestM (Maybe Bool)
+getDeletedState from u = do
   b <- view tsBrig
-  get
+  fmap profileDeleted . responseJsonMaybe <$> get
     ( b
         . paths ["users", toByteString' u]
         . zUser from
         . zConn "conn"
     )
-    !!! const (Just check)
-    === fmap profileDeleted
-    . responseJsonMaybe
 
 getClients :: UserId -> TestM ResponseLBS
 getClients u = do

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -503,7 +503,6 @@ deleteTeam (givenTid ::: email) = do
   where
     handleNoUser = ifNothing (Error status404 "no-user" "No such user with that email")
     handleNoTeam = ifNothing (Error status404 "no-binding-team" "No such binding team")
-
     wrongMemberCount = Error status403 "wrong-member-count" "Only teams with 1 user can be deleted"
     bindingTeamMismatch = Error status404 "binding-team-mismatch" "Binding team mismatch"
 

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -232,7 +232,7 @@ sitemap = do
       .&. query "email"
   document "DELETE" "deleteTeam" $ do
     summary "Delete a team (irrevocable!) You can only delete teams with 1 user!"
-    Doc.notes "Email the userId's (to prevent copy/paste mistakes)"
+    Doc.notes "The email address of the user must be provided to prevent copy/paste mistakes"
     Doc.parameter Doc.Path "tid" Doc.bytes' $
       description "Team ID"
     Doc.parameter Doc.Query "email" Doc.string' $ do

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -35,6 +35,7 @@ module Stern.Intra
     changeEmail,
     changePhone,
     deleteAccount,
+    deleteBindingTeam,
     getTeamInfo,
     getUserBindingTeam,
     isBlacklisted,
@@ -262,6 +263,19 @@ deleteAccount uid = do
       b
       ( method DELETE
           . paths ["/i/users", toByteString' uid]
+          . expect2xx
+      )
+
+deleteBindingTeam :: TeamId -> Handler ()
+deleteBindingTeam tid = do
+  info $ msg "Deleting team"
+  g <- view galley
+  void . catchRpcErrors $
+    rpc'
+      "galley"
+      g
+      ( method DELETE
+          . paths ["/i/teams", toByteString' tid]
           . expect2xx
       )
 


### PR DESCRIPTION
Adds an internal endpoint allowing binding teams of 1 member to be unconditionally deleted.

Fixes: https://github.com/zinfra/backend-issues/issues/1387