### PR TITLE
don't poll from SQS as often

### DIFF
--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -151,6 +151,7 @@ optSettings:
   setPropertyMaxKeyLen: 1024
   setPropertyMaxValueLen: 4096
   setDeleteThrottleMillis: 0
+  setSqsThrottleMillis: 1000
   # setSearchSameTeamOnly: false
   # ^ NOTE: this filters out search results for team users,
   #   i.e., if you are a team user the search endpoints will

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -442,7 +442,11 @@ data Settings = Settings
     -- | When false, assume there are no other backends and IDs are always local.
     -- This means we don't run any queries on federation-related tables and don't
     -- make any calls to the federator service.
-    setEnableFederation :: !(Maybe Bool)
+    setEnableFederation :: !(Maybe Bool),
+    -- | The amount of time in milliseconds to wait after reading from an SQS queue
+    -- returns no message, before asking for messages from SQS again.
+    -- defaults to 'defSqsThrottleMillis'.
+    setSqsThrottleMillis :: !(Maybe Int)
   }
   deriving (Show, Generic)
 
@@ -454,6 +458,9 @@ defMaxValueLen = 524288
 
 defDeleteThrottleMillis :: Int
 defDeleteThrottleMillis = 100
+
+defSqsThrottleMillis :: Int
+defSqsThrottleMillis = 500
 
 defUserMaxPermClients :: Int
 defUserMaxPermClients = 7
@@ -489,3 +496,5 @@ Lens.makeLensesFor [("setSearchSameTeamOnly", "searchSameTeamOnly")] ''Settings
 Lens.makeLensesFor [("setUserMaxPermClients", "userMaxPermClients")] ''Settings
 
 Lens.makeLensesFor [("setEnableFederation", "enableFederation")] ''Settings
+
+Lens.makeLensesFor [("setSqsThrottleMillis", "sqsThrottleMillis")] ''Settings

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -446,6 +446,11 @@ data Settings = Settings
     -- | The amount of time in milliseconds to wait after reading from an SQS queue
     -- returns no message, before asking for messages from SQS again.
     -- defaults to 'defSqsThrottleMillis'.
+    -- When using real SQS from AWS, throttling isn't needed as much, since using
+    --   SQS.rmWaitTimeSeconds (Just 20) in Brig.AWS.listen
+    -- ensures that there is only one request every 20 seconds.
+    -- However, that parameter is not honoured when using fake-sqs
+    -- (where throttling can thus make sense)
     setSqsThrottleMillis :: !(Maybe Int)
   }
   deriving (Show, Generic)

--- a/services/gundeck/gundeck.integration.yaml
+++ b/services/gundeck/gundeck.integration.yaml
@@ -25,6 +25,7 @@ settings:
   notificationTTL: 24192200
   bulkPush: true
   perNativePushConcurrency: 32
+  sqsThrottleMillis: 1000
   maxConcurrentNativePushes:
     hard: 30  # more than this number of threads will not be allowed
     soft: 10  # more than this number of threads will be warned about

--- a/services/gundeck/src/Gundeck/Aws.hs
+++ b/services/gundeck/src/Gundeck/Aws.hs
@@ -441,6 +441,7 @@ listen callback = do
   forever $ handleAny unexpectedError $ do
     msgs <- view rmrsMessages <$> send (receive url)
     void $ mapConcurrently (onMessage url) msgs
+    threadDelay 1000000
   where
     receive url =
       SQS.receiveMessage url

--- a/services/gundeck/src/Gundeck/Options.hs
+++ b/services/gundeck/src/Gundeck/Options.hs
@@ -63,7 +63,16 @@ data Settings = Settings
     -- | Maximum number of parallel requests to SNS and cassandra
     -- during native push processing (per incoming push request)
     -- defaults to unbounded, if unset.
-    _setPerNativePushConcurrency :: !(Maybe Int)
+    _setPerNativePushConcurrency :: !(Maybe Int),
+    -- | The amount of time in milliseconds to wait after reading from an SQS queue
+    -- returns no message, before asking for messages from SQS again.
+    -- defaults to 'defSqsThrottleMillis'.
+    -- When using real SQS from AWS, throttling isn't needed as much, since using
+    --   SQS.rmWaitTimeSeconds (Just 20) in Gundeck.Aws.listen
+    -- ensures that there is only one request every 20 seconds.
+    -- However, that parameter is not honoured when using fake-sqs
+    -- (where throttling can thus make sense)
+    _setSqsThrottleMillis :: !(Maybe Int)
   }
   deriving (Show, Generic)
 
@@ -105,3 +114,6 @@ data Opts = Opts
 deriveFromJSON toOptionFieldName ''Opts
 
 makeLenses ''Opts
+
+defSqsThrottleMillis :: Int
+defSqsThrottleMillis = 500


### PR DESCRIPTION
Relates to https://github.com/zinfra/backend-issues/issues/891

We currently poll SQS as fast as possible for three queues: two in brig and one in gundeck. For local development / integration tests, this creates a lot of unnecessary logs and high CPU usage for the fake-sqs container. On my machine, I get about 65 polling requests to fake SQS per second. This PR takes that down to 3 requests per second.

I'd like to 
* get a CI run though to see whether tests fail or not (whether any tests are time-critical when it comes to queing).
* get a review here to see whether the approach makes any sense: can we afford to be slower at querying SQS? I think we can, as neither the internal nor the email feedback or push notification feedback events need to be processed in the same split second. But I'd like to get a second opinion on this.

This PR is WIP, as the times are hardcoded to one second at the moment. I plan to make this threaddelay configurable. But what would be a good default for production (and for local/testing?)?