### PR TITLE
Fix licenses of db tools

### DIFF
--- a/tools/db/auto-whitelist/auto-whitelist.cabal
+++ b/tools/db/auto-whitelist/auto-whitelist.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9f5daffbdfdfad8ece7e59b59a05ece9aaec09bd2efbd317782e0179455afb91
+-- hash: 85c7cbfdf08baf6437e3da2f82fe7862311336420ea8f4825dec40ec753daa23
 
 name:           auto-whitelist
 version:        1.0.0
@@ -13,7 +13,7 @@ category:       Network
 author:         Wire Swiss GmbH
 maintainer:     Wire Swiss GmbH <backend@wire.com>
 copyright:      (c) 2018 Wire Swiss GmbH
-license:        UnspecifiedLicense
+license:        AGPL-3
 build-type:     Simple
 
 executable auto-whitelist

--- a/tools/db/auto-whitelist/package.yaml
+++ b/tools/db/auto-whitelist/package.yaml
@@ -7,7 +7,7 @@ category: Network
 author: Wire Swiss GmbH
 maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2018 Wire Swiss GmbH
-license: UnspecifiedLicense
+license: AGPL-3
 ghc-options:
 - -funbox-strict-fields
 - -threaded

--- a/tools/db/migrate-sso-feature-flag/migrate-sso-feature-flag.cabal
+++ b/tools/db/migrate-sso-feature-flag/migrate-sso-feature-flag.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bc78f413cc738aaa6ef5e3e9caa52fecaec3fd60c832b3f5d7eb5d1a4ae88ff6
+-- hash: b23ff3a5117d9703a8b229f72618083015c92bf83b6a79de67c339b275def085
 
 name:           migrate-sso-feature-flag
 version:        1.0.0
@@ -13,7 +13,7 @@ category:       Network
 author:         Wire Swiss GmbH
 maintainer:     Wire Swiss GmbH <backend@wire.com>
 copyright:      (c) 2018 Wire Swiss GmbH
-license:        UnspecifiedLicense
+license:        AGPL-3
 build-type:     Simple
 
 executable migrate-sso-feature-flag

--- a/tools/db/migrate-sso-feature-flag/package.yaml
+++ b/tools/db/migrate-sso-feature-flag/package.yaml
@@ -7,7 +7,7 @@ category: Network
 author: Wire Swiss GmbH
 maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2018 Wire Swiss GmbH
-license: UnspecifiedLicense
+license: AGPL-3
 ghc-options:
 - -funbox-strict-fields
 - -threaded

--- a/tools/db/service-backfill/package.yaml
+++ b/tools/db/service-backfill/package.yaml
@@ -7,7 +7,7 @@ category: Network
 author: Wire Swiss GmbH
 maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2018 Wire Swiss GmbH
-license: UnspecifiedLicense
+license: AGPL-3
 ghc-options:
 - -funbox-strict-fields
 - -threaded

--- a/tools/db/service-backfill/service-backfill.cabal
+++ b/tools/db/service-backfill/service-backfill.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d01bdc5a7ff5214b1a392af08efefb347b77b002bfb0e35de03043e7fd5911b3
+-- hash: 0b53449632293250f29c5b217594390fe59e99c14f4a315c0e59edb64800ff82
 
 name:           service-backfill
 version:        1.0.0
@@ -13,7 +13,7 @@ category:       Network
 author:         Wire Swiss GmbH
 maintainer:     Wire Swiss GmbH <backend@wire.com>
 copyright:      (c) 2018 Wire Swiss GmbH
-license:        UnspecifiedLicense
+license:        AGPL-3
 build-type:     Simple
 
 executable service-backfill


### PR DESCRIPTION
It looks like we made a mistake in the past while moving from cabal to hpack.