### PR TITLE
Don't warn about team size when indexedBillingTeamMembers is true

### DIFF
--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -144,8 +144,12 @@ validateOptions :: Logger.Logger -> Opts -> IO ()
 validateOptions l o = do
   let settings = view optSettings o
       optFanoutLimit = fromIntegral . fromRange $ currentFanoutLimit o
-  when ((isJust $ o ^. optJournal) && (settings ^. setMaxTeamSize > optFanoutLimit)) $
-    Logger.warn
+  when
+    ( isJust (o ^. optJournal)
+        && settings ^. setMaxTeamSize > optFanoutLimit
+        && not (settings ^. setEnableIndexedBillingTeamMembers . to (fromMaybe False))
+    )
+    $ Logger.warn
       l
       ( msg
           . val


### PR DESCRIPTION
Fixes https://github.com/zinfra/backend-issues/issues/1296

This warning is false for users using indexedBillingTeamMembers.