### PR TITLE
Set brig's logLevel to Warn while running integration-tests

### DIFF
--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -162,6 +162,6 @@ optSettings:
   #   to register, per account. The default value is '7' if the option is unset.
 
 logLevel: Warn
-# ^ NOTE: We log too much in brig, if we set this to Info like other services running tests
+# ^ NOTE: We log too much in brig, if we set this to Info like other services, running tests
 #   produces too many logs, hence this is set to Warn.
 logNetStrings: false

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -161,5 +161,7 @@ optSettings:
   # ^ You can limit the max number of permanent clients that a user is allowed
   #   to register, per account. The default value is '7' if the option is unset.
 
-logLevel: Info
+logLevel: Warn
+# ^ NOTE: We log too much in brig, if we set this to Info like other services running tests
+#   produces too many logs, hence this is set to Warn.
 logNetStrings: false


### PR DESCRIPTION
Info is too noisy