### PR TITLE
Leave domain empty in cookies, but account for clients with old cookies.

### DIFF
--- a/deploy/services-demo/conf/brig.demo-docker.yaml
+++ b/deploy/services-demo/conf/brig.demo-docker.yaml
@@ -102,7 +102,6 @@ optSettings:
   setActivationTimeout: 1209600     # 1 day
   setTeamInvitationTimeout: 1814400 # 21 days
   setUserMaxConnections: 1000
-  setCookieDomain: brig
   setCookieInsecure: false
   setUserCookieRenewAge: 1209600 # 14 days
   setUserCookieLimit: 32

--- a/deploy/services-demo/conf/brig.demo.yaml
+++ b/deploy/services-demo/conf/brig.demo.yaml
@@ -102,7 +102,6 @@ optSettings:
   setActivationTimeout: 1209600     # 1 day
   setTeamInvitationTimeout: 1814400 # 21 days
   setUserMaxConnections: 1000
-  setCookieDomain: localhost
   setCookieInsecure: false
   setUserCookieRenewAge: 1209600 # 14 days
   setUserCookieLimit: 32

--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -290,6 +290,11 @@ http {
       proxy_pass http://galley;
     }
 
+    location ~* ^/teams/([^/]*)/legalhold(.*) {
+      include common_response_with_zauth.conf;
+      proxy_pass http://galley;
+    }
+
     # Gundeck Endpoints
 
     rewrite ^/api-docs/push  /push/api-docs?base_url=http://127.0.0.1:8080/ break;

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -135,7 +135,6 @@ optSettings:
   setNexmo: test/resources/nexmo-credentials.yaml
   # setStomp: test/resources/stomp-credentials.yaml
   setUserMaxConnections: 16
-  setCookieDomain: 127.0.0.1
   setCookieInsecure: true
   setUserCookieRenewAge: 2
   setUserCookieLimit: 5

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -411,9 +411,6 @@ data Settings = Settings
     -- | Max. number of permanent clients per user
     setUserMaxPermClients :: !(Maybe Int),
     -- | The domain to restrict cookies to
-    setCookieDomain :: !Text,
-    -- | Whether to allow plain HTTP transmission
-    --   of cookies (for testing purposes only)
     setCookieInsecure :: !Bool,
     -- | Minimum age of a user cookie before
     --   it is renewed during token refresh

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -410,7 +410,8 @@ data Settings = Settings
     setUserMaxConnections :: !Int64,
     -- | Max. number of permanent clients per user
     setUserMaxPermClients :: !(Maybe Int),
-    -- | The domain to restrict cookies to
+    -- | Whether to allow plain HTTP transmission
+    --   of cookies (for testing purposes only)
     setCookieInsecure :: !Bool,
     -- | Minimum age of a user cookie before
     --   it is renewed during token refresh

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -1045,7 +1045,6 @@ setProviderCookie t r = do
       Cookie.def
         { Cookie.setCookieName = "zprovider",
           Cookie.setCookieValue = toByteString' t,
-          Cookie.setCookieDomain = Nothing,
           Cookie.setCookiePath = Just "/provider",
           Cookie.setCookieExpires = Just (ZAuth.tokenExpiresUTC t),
           Cookie.setCookieSecure = not (setCookieInsecure s),

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -1045,7 +1045,7 @@ setProviderCookie t r = do
       Cookie.def
         { Cookie.setCookieName = "zprovider",
           Cookie.setCookieValue = toByteString' t,
-          Cookie.setCookieDomain = Just $ Text.encodeUtf8 . setCookieDomain $ s,
+          Cookie.setCookieDomain = Nothing,
           Cookie.setCookiePath = Just "/provider",
           Cookie.setCookieExpires = Just (ZAuth.tokenExpiresUTC t),
           Cookie.setCookieSecure = not (setCookieInsecure s),

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -305,11 +305,17 @@ tokenRequest = opt (userToken ||| legalHoldUserToken) .&. opt (accessToken ||| l
     legalHoldUserToken = cookieErr @ZAuth.LegalHoldUser <$> cookie "zuid"
     accessToken = parse @ZAuth.Access <$> (tokenHeader .|. tokenQuery)
     legalHoldAccessToken = parse @ZAuth.LegalHoldAccess <$> (tokenHeader .|. tokenQuery)
+    --
+    tokenHeader :: r -> Result P.Error ByteString
     tokenHeader = bearer <$> header "authorization"
+    --
+    tokenQuery :: r -> Result P.Error ByteString
     tokenQuery = query "access_token"
+    --
     cookieErr :: ZAuth.UserTokenLike u => Result P.Error (ZAuth.Token u) -> Result P.Error (ZAuth.Token u)
     cookieErr x@Okay {} = x
     cookieErr (Fail x) = Fail (setMessage "Invalid user token" (P.setStatus status403 x))
+    --
     -- Extract the access token from the Authorization header.
     bearer :: Result P.Error ByteString -> Result P.Error ByteString
     bearer (Fail x) = Fail x
@@ -323,6 +329,7 @@ tokenRequest = opt (userToken ||| legalHoldUserToken) .&. opt (accessToken ||| l
                     TypeError
                     (setMessage "Invalid authorization scheme" (err status403))
                 )
+    --
     -- Parse the access token
     parse :: ZAuth.AccessTokenLike a => Result P.Error ByteString -> Result P.Error (ZAuth.Token a)
     parse (Fail x) = Fail x

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -34,9 +34,9 @@ import qualified Brig.ZAuth as ZAuth
 import qualified Data.ByteString as BS
 import Data.ByteString.Conversion
 import Data.Either.Combinators (leftToMaybe, rightToMaybe)
+import Data.Id
 import Data.List1 (List1)
 import qualified Data.List1 as List1
-import Data.Id
 import Data.Predicate
 import qualified Data.Swagger.Build.Api as Doc
 import qualified Data.ZAuth.Token as ZAuth
@@ -360,8 +360,8 @@ cookies k r =
     [] -> Fail . addLabel "cookie" $ notAvailable k
     cc ->
       case mapMaybe fromByteString cc of
-        []     -> (Fail . addLabel "cookie" . typeError k $ "Failed to get zuid cookies")
-        (x:xs) -> return $ List1.list1 x xs
+        [] -> (Fail . addLabel "cookie" . typeError k $ "Failed to get zuid cookies")
+        (x : xs) -> return $ List1.list1 x xs
 
 notAvailable :: ByteString -> P.Error
 notAvailable k = e400 & setReason NotAvailable . setSource k

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -301,6 +301,7 @@ tokenRequest ::
     )
 tokenRequest = opt (userToken ||| legalHoldUserToken) .&. opt (accessToken ||| legalHoldAccessToken)
   where
+    -- cookie -> lookupCookie: returns **multiple** values -> readValues: returns first that satisfies
     userToken = cookieErr @ZAuth.User <$> cookie "zuid"
     legalHoldUserToken = cookieErr @ZAuth.LegalHoldUser <$> cookie "zuid"
     accessToken = parse @ZAuth.Access <$> (tokenHeader .|. tokenQuery)

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -355,11 +355,13 @@ tokenResponse (Auth.Access t (Just c)) = Auth.setResponseCookie c (json t)
 -- We should also be dropping this in favor of servant which will make this redundant
 cookies :: (R.HasCookies r, FromByteString a) => ByteString -> Predicate r P.Error [a]
 cookies k r =
-    case R.lookupCookie k r of
-        [] -> Fail . addLabel "cookie" $ notAvailable k
-        cc -> maybe (Fail . addLabel "cookie" . typeError k $ "Failed to get zuid cookies")
-                    return
-                    (traverse fromByteString cc)
+  case R.lookupCookie k r of
+    [] -> Fail . addLabel "cookie" $ notAvailable k
+    cc ->
+      maybe
+        (Fail . addLabel "cookie" . typeError k $ "Failed to get zuid cookies")
+        return
+        (traverse fromByteString cc)
 
 notAvailable :: ByteString -> P.Error
 notAvailable k = e400 & setReason NotAvailable . setSource k

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -346,11 +346,13 @@ tokenResponse :: ZAuth.UserTokenLike u => Auth.Access u -> AppIO Response
 tokenResponse (Auth.Access t Nothing) = pure $ json t
 tokenResponse (Auth.Access t (Just c)) = Auth.setResponseCookie c (json t)
 
+-- Utilities
 -- Internal: These functions are nearly copies verbatim from the original
 -- project: https://gitlab.com/twittner/wai-predicates/-/blob/develop/src/Network/Wai/Predicate.hs#L106-112
 -- I will still make an upstream PR but would not like to block this PR because of
 -- it. Main difference: the original stops after finding the first valid cookie which
 -- is a problem if clients send more than 1 cookie and one of them happens to be invalid
+-- We should also be dropping this in favor of servant which will make this redundant
 cookies :: (R.HasCookies r, FromByteString a) => ByteString -> Predicate r P.Error [a]
 cookies k r =
     case R.lookupCookie k r of

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -346,8 +346,7 @@ tokenResponse :: ZAuth.UserTokenLike u => Auth.Access u -> AppIO Response
 tokenResponse (Auth.Access t Nothing) = pure $ json t
 tokenResponse (Auth.Access t (Just c)) = Auth.setResponseCookie c (json t)
 
--- Utilities
--- Internal: These functions are nearly copies verbatim from the original
+-- | Internal utilities: These functions are nearly copies verbatim from the original
 -- project: https://gitlab.com/twittner/wai-predicates/-/blob/develop/src/Network/Wai/Predicate.hs#L106-112
 -- I will still make an upstream PR but would not like to block this PR because of
 -- it. Main difference: the original stops after finding the first valid cookie which
@@ -358,10 +357,9 @@ cookies k r =
   case R.lookupCookie k r of
     [] -> Fail . addLabel "cookie" $ notAvailable k
     cc ->
-      maybe
-        (Fail . addLabel "cookie" . typeError k $ "Failed to get zuid cookies")
-        return
-        (traverse fromByteString cc)
+      case mapMaybe fromByteString cc of
+        []  -> (Fail . addLabel "cookie" . typeError k $ "Failed to get zuid cookies")
+        cks -> return cks
 
 notAvailable :: ByteString -> P.Error
 notAvailable k = e400 & setReason NotAvailable . setSource k

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -60,9 +60,9 @@ import Control.Lens (to, view)
 import Data.ByteString.Conversion (toByteString)
 import Data.Handle (Handle)
 import Data.Id
-import qualified Data.List1 as List1
-import Data.List1 (List1)
 import qualified Data.List.NonEmpty as NE
+import Data.List1 (List1)
+import qualified Data.List1 as List1
 import Data.Misc (PlainTextPassword (..))
 import qualified Data.ZAuth.Token as ZAuth
 import Imports

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -262,7 +262,7 @@ validateTokens ::
   Maybe (ZAuth.Token a) ->
   ExceptT ZAuth.Failure AppIO (UserId, Cookie (ZAuth.Token u))
 validateTokens [] _ = throwE ZAuth.Invalid
-validateTokens (ut:[]) at = validateToken ut at
+validateTokens (ut : []) at = validateToken ut at
 validateTokens uts at = do
   tokens <- forM uts $ \ut -> lift $ runExceptT (validateToken ut at)
   parseResults tokens
@@ -270,9 +270,9 @@ validateTokens uts at = do
     -- FUTUREWORK: There is surely a better way to do this
     parseResults :: [Either ZAuth.Failure (UserId, Cookie (ZAuth.Token u))] -> ExceptT ZAuth.Failure AppIO (UserId, Cookie (ZAuth.Token u))
     parseResults res = case (lefts res, rights res) of
-      (_  , (suc:_)) -> return suc
-      ((e:_), _    ) -> throwE e
-      _              -> throwE ZAuth.Invalid -- Impossible with NonEmpty
+      (_, (suc : _)) -> return suc
+      ((e : _), _) -> throwE e
+      _ -> throwE ZAuth.Invalid -- Impossible with NonEmpty
 
 validateToken ::
   ZAuth.TokenPair u a =>

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -234,7 +234,6 @@ setResponseCookie c r = do
       WebCookie.def
         { WebCookie.setCookieName = "zuid",
           WebCookie.setCookieValue = toByteString' (cookieValue c),
-          WebCookie.setCookieDomain = Nothing,
           WebCookie.setCookiePath = Just "/access",
           WebCookie.setCookieExpires =
             if cookieType c == PersistentCookie

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -52,7 +52,6 @@ import Data.Id
 import qualified Data.List as List
 import qualified Data.Metrics as Metrics
 import Data.Proxy
-import Data.Text.Encoding (encodeUtf8)
 import Data.Time.Clock
 import Imports
 import Network.Wai (Response)
@@ -235,7 +234,7 @@ setResponseCookie c r = do
       WebCookie.def
         { WebCookie.setCookieName = "zuid",
           WebCookie.setCookieValue = toByteString' (cookieValue c),
-          WebCookie.setCookieDomain = Just $ encodeUtf8 . setCookieDomain $ s,
+          WebCookie.setCookieDomain = Nothing,
           WebCookie.setCookiePath = Just "/access",
           WebCookie.setCookieExpires =
             if cookieType c == PersistentCookie

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -36,10 +36,9 @@ import Brig.Types.User.Auth
 import qualified Brig.Types.User.Auth as Auth
 import Brig.ZAuth (ZAuth, runZAuth)
 import qualified Brig.ZAuth as ZAuth
-import Control.Lens (set, (^.), (^?))
+import Control.Lens (set, (^.))
 import Control.Retry
 import Data.Aeson
-import Data.Aeson.Lens
 import qualified Data.ByteString as BS
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
@@ -48,7 +47,6 @@ import Data.Id
 import Data.Misc (PlainTextPassword (..))
 import Data.Proxy
 import qualified Data.Text as Text
-import Data.Text.Encoding (encodeUtf8)
 import qualified Data.Text.Lazy as Lazy
 import Data.Time.Clock
 import qualified Data.UUID.V4 as UUID
@@ -146,7 +144,7 @@ testNginz b n = do
   let Just email = userEmail u
   -- Login with email
   rs <-
-    login b (defEmailLogin email) PersistentCookie
+    login n (defEmailLogin email) PersistentCookie
       <!! const 200 === statusCode
   let c = decodeCookie rs
       t = decodeToken rs
@@ -167,13 +165,27 @@ testNginz b n = do
 testNginzLegalHold :: Brig -> Galley -> Nginz -> Http ()
 testNginzLegalHold b g n = do
   -- create team user Alice
-  (alice, tid) <- createUserWithTeam b
+  (alice, tid) <- createUserWithTeam' b
   putLegalHoldEnabled tid TeamFeatureEnabled g -- enable it for this team
-  rs <-
-    legalHoldLogin b (LegalHoldLogin alice (Just defPassword) Nothing) PersistentCookie
-      <!! const 200 === statusCode
-  let c = decodeCookie rs
-      t = decodeToken' @ZAuth.LegalHoldAccess rs
+  (c, t) <- do
+    -- we need to get the cookie domain from a login through nginz.  otherwise, if brig and
+    -- nginz are running on different hosts, no cookie will be presented in the later requests
+    -- to nginz in this test.  for simplicity, we use the internal end-point for
+    -- authenticating an LH dev, and then steal the domain from a cookie obtained via user
+    -- login.
+    rsUsr <- do
+      let Just email = userEmail alice
+      login n (defEmailLogin email) PersistentCookie
+        <!! const 200 === statusCode
+    rsLhDev <-
+      legalHoldLogin b (LegalHoldLogin (userId alice) (Just defPassword) Nothing) PersistentCookie
+        <!! const 200 === statusCode
+    let t = decodeToken' @ZAuth.LegalHoldAccess rsLhDev
+        c = cLhDev {cookie_domain = cookie_domain cUsr}
+        cLhDev = decodeCookie rsLhDev
+        cUsr = decodeCookie rsUsr
+    pure (c, t)
+
   -- ensure nginz allows passing legalhold cookies / tokens through to /access
   post (n . path "/access" . cookie c . header "Authorization" ("Bearer " <> (toByteString' t))) !!! do
     const 200 === statusCode
@@ -848,18 +860,6 @@ prepareLegalHoldUser brig galley = do
   -- enable it for this team - without that, legalhold login will fail.
   putLegalHoldEnabled tid TeamFeatureEnabled galley
   return uid
-
-decodeCookie :: HasCallStack => Response a -> Http.Cookie
-decodeCookie = fromMaybe (error "missing zuid cookie") . getCookie "zuid"
-
-decodeToken :: HasCallStack => Response (Maybe Lazy.ByteString) -> ZAuth.AccessToken
-decodeToken = decodeToken' @ZAuth.Access
-
-decodeToken' :: (HasCallStack, ZAuth.AccessTokenLike a) => Response (Maybe Lazy.ByteString) -> ZAuth.Token a
-decodeToken' r = fromMaybe (error "invalid access_token") $ do
-  x <- responseBody r
-  t <- x ^? key "access_token" . _String
-  fromByteString (encodeUtf8 t)
 
 getCookieId :: forall u. (HasCallStack, ZAuth.UserTokenLike u) => Http.Cookie -> CookieId
 getCookieId c =

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -241,6 +241,7 @@ testNginzMultipleCookies o b n = do
   (deleted, valid) <- getAndTestDBSupersededCookieAndItsValidSuccessor o b
   now <- liftIO getCurrentTime
   liftIO $ assertBool "cookie should not be expired" (cookie_expiry_time deleted > now)
+  liftIO $ assertBool "cookie should not be expired" (cookie_expiry_time valid > now)
   post (n . path "/access" . cookie deleted) !!! const 403 === statusCode
   post (n . path "/access" . cookie valid) !!! const 200 === statusCode
   post (n . path "/access" . cookie deleted . cookie valid) !!! const 200 === statusCode

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -35,6 +35,7 @@ import Brig.Types.Connection
 import Brig.Types.Intra
 import Brig.Types.User
 import Brig.Types.User.Auth
+import qualified Brig.ZAuth as ZAuth
 import Control.Lens ((^.), (^?), (^?!))
 import Control.Monad.Catch (MonadCatch)
 import Control.Monad.Fail (MonadFail)
@@ -53,6 +54,7 @@ import qualified Data.List1 as List1
 import Data.Misc (PlainTextPassword (..))
 import qualified Data.Text as Text
 import qualified Data.Text.Ascii as Ascii
+import Data.Text.Encoding (encodeUtf8)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID
 import qualified Galley.Types.Teams as Team
@@ -316,6 +318,9 @@ getUser brig zusr usr =
       . paths ["users", toByteString' usr]
       . zUser zusr
 
+-- | NB: you can also use nginz as the first argument here.  The type aliases are compatible,
+-- and so are the end-points.  This is important in tests where the cookie must come from the
+-- nginz domain, so it can be passed back to it.
 login :: Brig -> Login -> CookieType -> (MonadIO m, MonadHttp m) => m ResponseLBS
 login b l t =
   let js = RequestBodyLBS (encode l)
@@ -345,6 +350,18 @@ legalHoldLogin b l t =
           . contentJson
           . (if t == PersistentCookie then queryItem "persist" "true" else id)
           . body js
+
+decodeCookie :: HasCallStack => Response a -> Bilge.Cookie
+decodeCookie = fromMaybe (error "missing zuid cookie") . getCookie "zuid"
+
+decodeToken :: HasCallStack => Response (Maybe LByteString) -> ZAuth.AccessToken
+decodeToken = decodeToken'
+
+decodeToken' :: (HasCallStack, ZAuth.AccessTokenLike a) => Response (Maybe LByteString) -> ZAuth.Token a
+decodeToken' r = fromMaybe (error "invalid access_token") $ do
+  x <- responseBody r
+  t <- x ^? key "access_token" . _String
+  fromByteString (encodeUtf8 t)
 
 data LoginCodeType = LoginCodeSMS | LoginCodeVoice
   deriving (Eq)

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -217,8 +217,9 @@ requestDevice zusr tid uid = do
       let NewLegalHoldClient prekeys lastKey = lhDevice
       return (lastKey, prekeys)
 
--- | Approve the adding of a Legal Hold device to the user
--- we don't delete pending prekeys during this flow just in case
+-- | Approve the adding of a Legal Hold device to the user.
+--
+-- We don't delete pending prekeys during this flow just in case
 -- it gets interupted. There's really no reason to delete them anyways
 -- since they are replaced if needed when registering new LH devices.
 approveDeviceH ::

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -69,7 +69,6 @@ import Spar.Scim
 import Spar.Scim.Swagger ()
 import Spar.Types
 import qualified URI.ByteString as URI
-import qualified Web.Cookie as Cky
 
 app :: Env -> Application
 app ctx =
@@ -144,23 +143,12 @@ authreq authreqttl _ zusr msucc merr idpid = do
 -- value that deletes any bind cookies on the client.
 initializeBindCookie :: Maybe UserId -> NominalDiffTime -> Spar SetBindCookie
 initializeBindCookie zusr authreqttl = do
-  DerivedOpts {derivedOptsBindCookiePath, derivedOptsBindCookieDomain} <-
-    asks (derivedOpts . sparCtxOpts)
+  DerivedOpts {derivedOptsBindCookiePath} <- asks (derivedOpts . sparCtxOpts)
   msecret <-
     if isJust zusr
       then liftIO $ Just . cs . ES.encode <$> randBytes 32
       else pure Nothing
-  let updSetCkyDom (SAML.SimpleSetCookie raw) =
-        SAML.SimpleSetCookie
-          raw
-            { Cky.setCookieDomain = Just derivedOptsBindCookieDomain
-            }
-  cky <-
-    updSetCkyDom
-      <$> ( SAML.toggleCookie derivedOptsBindCookiePath $
-              (,authreqttl) <$> msecret ::
-              Spar SetBindCookie
-          )
+  cky <- SAML.toggleCookie derivedOptsBindCookiePath $ (,authreqttl) <$> msecret
   forM_ zusr $ \userid -> wrapMonadClientWithEnv $ Data.insertBindCookie cky userid authreqttl
   pure cky
 

--- a/services/spar/src/Spar/Options.hs
+++ b/services/spar/src/Spar/Options.hs
@@ -30,7 +30,6 @@ where
 
 import Control.Exception
 import Control.Lens
-import Control.Monad.Catch
 import qualified Data.ByteString as SBS
 import qualified Data.Yaml as Yaml
 import Imports
@@ -56,8 +55,6 @@ deriveOpts raw = do
   derived <- do
     let respuri = runWithConfig raw sparResponseURI
         derivedOptsBindCookiePath = URI.uriPath respuri
-        unwrap = maybe (throwM $ ErrorCall "Bad server config: no domain in response URI") pure
-    derivedOptsBindCookieDomain <- URI.hostBS . URI.authorityHost <$> unwrap (URI.uriAuthority respuri)
     -- We could also make this selectable in the config file, but it seems easier to derive it from
     -- the SAML base uri.
     let derivedOptsScimBaseURI = (saml raw ^. SAML.cfgSPSsoURI) & pathL %~ derive

--- a/services/spar/src/Spar/Types.hs
+++ b/services/spar/src/Spar/Types.hs
@@ -253,7 +253,6 @@ instance FromJSON (Opts' (Maybe ()))
 
 data DerivedOpts = DerivedOpts
   { derivedOptsBindCookiePath :: !SBS,
-    derivedOptsBindCookieDomain :: !SBS,
     derivedOptsScimBaseURI :: !URI
   }
   deriving (Show, Generic)


### PR DESCRIPTION
Fixes https://github.com/zinfra/backend-issues/issues/953

#1076 breaks UX: clients attempting to get new tokens from `/access` with cookies they got before this change will receive an error, and will have to login again.

This PR does it right.

When multiple cookies are presented to the backend, _all of them_ will be tested against the database. If any of them is valid, then we pick the "first" one and use that for auth purposes.