### PR TITLE
wire-api: extend generic Arbitrary instances with implementation for 'shrink'

### DIFF
--- a/libs/types-common/src/Data/Misc.hs
+++ b/libs/types-common/src/Data/Misc.hs
@@ -109,7 +109,7 @@ instance Arbitrary IpAddr where
     where
       genIPv4 = toIPv4 <$> replicateM 4 genByte
       genIPv6 = toIPv6b <$> replicateM 16 genByte
-      genByte = QC.choose @Int (0, 255)
+      genByte = QC.chooseInt (0, 255)
 
 newtype Port = Port
   {portNumber :: Word16}

--- a/libs/types-common/src/Data/Range.hs
+++ b/libs/types-common/src/Data/Range.hs
@@ -360,7 +360,7 @@ genRange pack_ gc =
       (fromKnownNat (Proxy @m))
       gc
   where
-    grange mi ma gelem = (`replicateM` gelem) =<< QC.choose (mi, ma)
+    grange mi ma gelem = (`replicateM` gelem) =<< QC.chooseInt (mi, ma)
 
 instance (KnownNat n, KnownNat m, LTE n m) => Arbitrary (Range n m Integer) where
   arbitrary = genIntegral

--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -17,7 +17,7 @@ library:
   source-dirs: src
   dependencies:
   - base >=4 && <5
-  - QuickCheck >=2.9
+  - QuickCheck >=2.14
   - attoparsec >=0.10
   - base64-bytestring >=1.0
   - bytestring >=0.9

--- a/libs/wire-api/src/Wire/API/User/Identity.hs
+++ b/libs/wire-api/src/Wire/API/User/Identity.hs
@@ -178,7 +178,7 @@ instance Arbitrary Phone where
   arbitrary = Phone . Text.pack <$> do
     let mkdigits n = replicateM n (QC.elements ['0' .. '9'])
     mini <- mkdigits 8
-    maxi <- mkdigits =<< QC.choose (0, 7)
+    maxi <- mkdigits =<< QC.chooseInt (0, 7)
     pure $ '+' : mini <> maxi
 
 -- | Parses a phone number in E.164 format with a mandatory leading '+'.

--- a/libs/wire-api/test/unit/Test/Wire/API/Call/TURN.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Call/TURN.hs
@@ -68,4 +68,4 @@ newtype ZeroToTen = ZeroToTen Int
   deriving (Eq, Show)
 
 instance Arbitrary ZeroToTen where
-  arbitrary = ZeroToTen <$> choose (0, 10)
+  arbitrary = ZeroToTen <$> chooseInt (0, 10)

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip.hs
@@ -23,7 +23,7 @@ import Data.Id (ConvId)
 import Imports
 import qualified Test.Tasty as T
 import Test.Tasty.ExpectedFailure (ignoreTest)
-import Test.Tasty.QuickCheck ((===), Arbitrary, counterexample, testProperty)
+import Test.Tasty.QuickCheck ((===), Arbitrary, QuickCheckMaxSize (..), counterexample, testProperty)
 import Type.Reflection (typeRep)
 import qualified Wire.API.Asset as Asset
 import qualified Wire.API.Asset.V3.Resumable as Asset.Resumable
@@ -98,9 +98,9 @@ tests =
       testRoundTrip @Connection.UserConnection,
       testRoundTrip @Connection.UserConnectionList,
       testRoundTrip @Connection.ConnectionUpdate,
-      currentlyFailing (testRoundTrip @Conversation.Conversation),
-      currentlyFailing (testRoundTrip @Conversation.NewConvUnmanaged),
-      currentlyFailing (testRoundTrip @Conversation.NewConvManaged),
+      T.localOption (QuickCheckMaxSize 2000) (testRoundTrip @Conversation.Conversation), -- PASS?
+      T.localOption (QuickCheckMaxSize 2000) (testRoundTrip @Conversation.NewConvUnmanaged), -- PASS?
+      T.localOption (QuickCheckMaxSize 2000) (testRoundTrip @Conversation.NewConvManaged), -- PASS?
       testRoundTrip @(Conversation.ConversationList ConvId),
       testRoundTrip @(Conversation.ConversationList Conversation.Conversation),
       testRoundTrip @Conversation.Access,

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip.hs
@@ -23,7 +23,7 @@ import Data.Id (ConvId)
 import Imports
 import qualified Test.Tasty as T
 import Test.Tasty.ExpectedFailure (ignoreTest)
-import Test.Tasty.QuickCheck ((===), Arbitrary, QuickCheckMaxSize (..), counterexample, testProperty)
+import Test.Tasty.QuickCheck ((===), Arbitrary, counterexample, testProperty)
 import Type.Reflection (typeRep)
 import qualified Wire.API.Asset as Asset
 import qualified Wire.API.Asset.V3.Resumable as Asset.Resumable
@@ -98,9 +98,9 @@ tests =
       testRoundTrip @Connection.UserConnection,
       testRoundTrip @Connection.UserConnectionList,
       testRoundTrip @Connection.ConnectionUpdate,
-      T.localOption (QuickCheckMaxSize 2000) (testRoundTrip @Conversation.Conversation), -- PASS?
-      T.localOption (QuickCheckMaxSize 2000) (testRoundTrip @Conversation.NewConvUnmanaged), -- PASS?
-      T.localOption (QuickCheckMaxSize 2000) (testRoundTrip @Conversation.NewConvManaged), -- PASS?
+      currentlyFailing (testRoundTrip @Conversation.Conversation), -- flaky, fails for large sizes because of rounding error in cnvMessageTimer
+      currentlyFailing (testRoundTrip @Conversation.NewConvUnmanaged),
+      currentlyFailing (testRoundTrip @Conversation.NewConvManaged),
       testRoundTrip @(Conversation.ConversationList ConvId),
       testRoundTrip @(Conversation.ConversationList Conversation.Conversation),
       testRoundTrip @Conversation.Access,

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 059ce33d49685e681d9e0937116fde3f1637ccfa3d73ac4a92816b714a1cc995
+-- hash: e86154ca496caaeb488bd2810630f53757421d25b05d746b86024ee7224c49ff
 
 name:           wire-api
 version:        0.1.0
@@ -74,7 +74,7 @@ library
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -O2 -Wall -fwarn-tabs -optP-Wno-nonportable-include-path
   build-depends:
-      QuickCheck >=2.9
+      QuickCheck >=2.14
     , aeson >=0.6
     , attoparsec >=0.10
     , base >=4 && <5

--- a/stack.yaml
+++ b/stack.yaml
@@ -170,6 +170,10 @@ extra-deps:
 # Not latest as latst one breaks wai-routing
 - wai-route-0.4.0
 
+# Not updated on Stackage yet
+- QuickCheck-2.14
+- splitmix-0.0.4 # needed for QuickCheck
+
 ############################################################
 # Development tools
 ############################################################

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -539,6 +539,20 @@ packages:
   original:
     hackage: wai-route-0.4.0
 - completed:
+    hackage: QuickCheck-2.14@sha256:a1bac79e48b36d5bccd771e981058c44707f440156a0a411ebdcfec8cfccfda9,6982
+    pantry-tree:
+      size: 2203
+      sha256: 1c8b0f1ff061117c78ddb69cbed242faf313a427c03e5c84233aa33e7e58a5cb
+  original:
+    hackage: QuickCheck-2.14
+- completed:
+    hackage: splitmix-0.0.4@sha256:fb9bb8b54a2e76c8a021fe5c4c3798047e1f60e168379a1f80693047fe00ad0e,4813
+    pantry-tree:
+      size: 872
+      sha256: e58892088b95190bfb59a7c0803f7ef65338e57fc9b938d7c166563605003902
+  original:
+    hackage: splitmix-0.0.4
+- completed:
     hackage: ormolu-0.0.5.0@sha256:e5f49c51c6ebd8b3cd16113e585312de7315c1e1561fbb599988cebc61c14f4e,7956
     pantry-tree:
       size: 66187


### PR DESCRIPTION
~This builds on top of #1098, so I'll have to rebase once that is merged. The diff should be quite small then.~

The instance for shrink makes it much easier to find the reason for failing test cases, for example the roundtrip tests still marked as failing (see #https://github.com/zinfra/backend-issues/issues/1446). To write the generic instance, we need QuickCheck 2.14.

Another benefit with QuickCheck 2.14 is that many generators became significantly faster.