### PR TITLE
Fix: bump schemaVersion for Brig and Galley

### DIFF
--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -127,7 +127,7 @@ import qualified System.Logger.Extended as Log
 import Util.Options
 
 schemaVersion :: Int32
-schemaVersion = 58
+schemaVersion = 59
 
 -------------------------------------------------------------------------------
 -- Environment

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -172,7 +172,7 @@ resultSetResult :: ResultSet a -> [a]
 resultSetResult = result . page
 
 schemaVersion :: Int32
-schemaVersion = 40
+schemaVersion = 41
 
 -- | Insert a conversation code
 insertCode :: MonadClient m => Code -> m ()


### PR DESCRIPTION
Both of these were behind by 1, with migrations 59 and 41 respectively already existing.