### PR TITLE
Bump http-client

### DIFF
--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -54,6 +54,7 @@ import Data.Time.Clock
 import qualified Data.UUID.V4 as UUID
 import qualified Data.ZAuth.Token as ZAuth
 import Imports
+import Network.HTTP.Client (equivCookie)
 import qualified Network.Wai.Utilities.Error as Error
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -603,7 +604,8 @@ testNewPersistentCookie config b = do
     const 200 === statusCode
     const Nothing =/= getHeader "Set-Cookie"
     const (Just "access_token") =~= responseBody
-  liftIO $ assertEqual "cookie" c' (decodeCookie _rs)
+  -- we got a new cookie value, but the key is the same
+  liftIO $ assertBool "cookie" (c' `equivCookie` decodeCookie _rs)
   -- Refresh with the new cookie should succeed
   -- (without advertising yet another new cookie).
   post (b . path "/access" . cookie c') !!! do

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -615,7 +615,7 @@ endpointToURL endpoint urlpath = either err pure url
 
 shouldRespondWith ::
   forall a.
-  (HasCallStack, Show a, Eq a) =>
+  (HasCallStack, Show a) =>
   Http a ->
   (a -> Bool) ->
   TestSpar ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -133,7 +133,7 @@ extra-deps:
   commit: fe08618e81dee9b7a25f10f5b9d26d1ff1837c79    # master (Mar 25, 2020)
 
 - git: https://github.com/wireapp/http-client
-  commit: a160cef95d9daaff7d9cfe616d95754c2f8202bf    # master (Feb 4, 2020)
+  commit: 9100baeddbd15d93dc58a826ae812dafff29d5fd    # master (Jun 16, 2020)
   subdirs:
   - http-client
   - http-client-openssl

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -316,35 +316,35 @@ packages:
 - completed:
     subdir: http-client
     cabal-file:
-      size: 5320
-      sha256: 940ca1c45282ef0b18ff9e535b086c4a422f3ebc8372183c1a9432b0f38f1a15
+      size: 5350
+      sha256: 868faa3479fa330ac6eb897e6888296a32f10a249d2d91ece5ab2add9f0c24d4
     name: http-client
-    version: 0.6.4
+    version: 0.7.0
     git: https://github.com/wireapp/http-client
     pantry-tree:
-      size: 3127
-      sha256: fc8c48d7bdccaf2f761f3c6216f6a592ba4424735c9a8544cc13fae9e48a563e
-    commit: a160cef95d9daaff7d9cfe616d95754c2f8202bf
+      size: 3129
+      sha256: 355d13d4b018ab32ad3ba1b88d8d183c4f673efb3a8109d3b0260776b2473ec0
+    commit: 9100baeddbd15d93dc58a826ae812dafff29d5fd
   original:
     subdir: http-client
     git: https://github.com/wireapp/http-client
-    commit: a160cef95d9daaff7d9cfe616d95754c2f8202bf
+    commit: 9100baeddbd15d93dc58a826ae812dafff29d5fd
 - completed:
     subdir: http-client-openssl
     cabal-file:
       size: 1494
-      sha256: 36a5a54e4c7effe1e67310d9fc932e6a9d92a3d865ceb29ae38816d8335ae3bc
+      sha256: 423d74b93d5b2a79991340da8d2cd8fccd496fb470483bad8c73857200509e4e
     name: http-client-openssl
-    version: 0.3.0.0
+    version: 0.3.1.0
     git: https://github.com/wireapp/http-client
     pantry-tree:
       size: 387
-      sha256: 0f1784da10763596a76d3bc8a6c5ab86fab24a120de5faa6b6d0db78209a8d1e
-    commit: a160cef95d9daaff7d9cfe616d95754c2f8202bf
+      sha256: c9265105d25badaa471e8d3d0eb493ebcba3ce17b4d430d2db70b6a0a4f90821
+    commit: 9100baeddbd15d93dc58a826ae812dafff29d5fd
   original:
     subdir: http-client-openssl
     git: https://github.com/wireapp/http-client
-    commit: a160cef95d9daaff7d9cfe616d95754c2f8202bf
+    commit: 9100baeddbd15d93dc58a826ae812dafff29d5fd
 - completed:
     subdir: http-client-tls
     cabal-file:
@@ -356,27 +356,27 @@ packages:
     pantry-tree:
       size: 435
       sha256: 13722b74ba7edde9163e5c194af168fc98c4dc419c37fd42fada45f5a89d2042
-    commit: a160cef95d9daaff7d9cfe616d95754c2f8202bf
+    commit: 9100baeddbd15d93dc58a826ae812dafff29d5fd
   original:
     subdir: http-client-tls
     git: https://github.com/wireapp/http-client
-    commit: a160cef95d9daaff7d9cfe616d95754c2f8202bf
+    commit: 9100baeddbd15d93dc58a826ae812dafff29d5fd
 - completed:
     subdir: http-conduit
     cabal-file:
       size: 2910
-      sha256: 22d6108caaf4a661a822462e53e18915b229a9dc75f397a29df666dc9e92e903
+      sha256: 4e0024c25cb1a6c5a20b687201c78a7a2c781a582f669d0f88125d113e65c326
     name: http-conduit
     version: 2.3.7.3
     git: https://github.com/wireapp/http-client
     pantry-tree:
       size: 1074
-      sha256: 03b9ae4a6d67b5fd875f2c898e04fb45d71db92a954180d906c896312fe6dfb9
-    commit: a160cef95d9daaff7d9cfe616d95754c2f8202bf
+      sha256: ec54f41b6997eabc01aa5e65a584bf37a39efb57a9eaad8f1e8005137f32c625
+    commit: 9100baeddbd15d93dc58a826ae812dafff29d5fd
   original:
     subdir: http-conduit
     git: https://github.com/wireapp/http-client
-    commit: a160cef95d9daaff7d9cfe616d95754c2f8202bf
+    commit: 9100baeddbd15d93dc58a826ae812dafff29d5fd
 - completed:
     hackage: template-0.2.0.10@sha256:f822de4d34c45bc84b33a61bc112c15fedee6fa6dc414c62b10456395a868f85,987
     pantry-tree:


### PR DESCRIPTION


Still some issues. The bump breaks `hspec-wai` but I would've expect this break to show up as a version bound conflict. Is this stack being weird?

```
[nix-shell:~/Projects/wire/wire-server]$ stack build
warning: attempt to call something which is not a function but a set, at (string):1:2; will use bash from your environment
galley-0.83.0: unregistering (missing dependencies: zauth)
sodium-crypto-sign-0.1.2: unregistering (local file changes: /nix/store/c1zpndaxjvdzgygz8kzlbz3k53bmnh01-ghc-8.6.5/lib/ghc-8.6.5/include/ghcversion.h /nix/sto...)
zauth-0.10.3: unregistering (missing dependencies: sodium-crypto-sign)
sodium-crypto-sign      > build (lib)
sodium-crypto-sign      > Preprocessing library for sodium-crypto-sign-0.1.2..
sodium-crypto-sign      > Building library for sodium-crypto-sign-0.1.2..
sodium-crypto-sign      > copy/register
sodium-crypto-sign      > Installing library in /home/arian/Projects/wire/wire-server/.stack-work/install/x86_64-linux-nix/0206a7923d0180ed19934bae4360b93c888fb7feebbfafa1df0803cfedfcf5a8/8.6.5/lib/x86_64-linux-ghc-8.6.5/sodium-crypto-sign-0.1.2-FB53I3qGvx2yMlqYcAL3w
sodium-crypto-sign      > Registering library for sodium-crypto-sign-0.1.2..
zauth                   > build (lib + exe)
zauth                   > Preprocessing library for zauth-0.10.3..
zauth                   > Building library for zauth-0.10.3..
zauth                   > [1 of 4] Compiling Data.ZAuth.Token [flags changed]
zauth                   > [2 of 4] Compiling Data.ZAuth.Creation [flags changed]
zauth                   > [3 of 4] Compiling Data.ZAuth.Validation [flags changed]
zauth                   > Preprocessing executable 'zauth' for zauth-0.10.3..
zauth                   > Building executable 'zauth' for zauth-0.10.3..
zauth                   > Linking .stack-work/dist/x86_64-linux-nix/Cabal-2.4.0.1/build/zauth/zauth ...
zauth                   > copy/register
zauth                   > Installing library in /home/arian/Projects/wire/wire-server/.stack-work/install/x86_64-linux-nix/0206a7923d0180ed19934bae4360b93c888fb7feebbfafa1df0803cfedfcf5a8/8.6.5/lib/x86_64-linux-ghc-8.6.5/zauth-0.10.3-KiPnQyXqgVW6hnmpbacbJ4
zauth                   > Installing executable zauth in /home/arian/Projects/wire/wire-server/.stack-work/install/x86_64-linux-nix/0206a7923d0180ed19934bae4360b93c888fb7feebbfafa1df0803cfedfcf5a8/8.6.5/bin
zauth                   > Registering library for zauth-0.10.3..
brig                    > build (lib + internal-lib + exe)
spar                    > build (lib + exe)
galley                  > build (lib + exe)
spar                    > Preprocessing library for spar-0.1..
spar                    > Building library for spar-0.1..
galley                  > Preprocessing executable 'galley-migrate-data' for galley-0.83.0..
galley                  > Building executable 'galley-migrate-data' for galley-0.83.0..
brig                    > Preprocessing executable 'brig-schema' for brig-1.35.0..
brig                    > Building executable 'brig-schema' for brig-1.35.0..
galley                  > Preprocessing library for galley-0.83.0..
galley                  > Building library for galley-0.83.0..
brig                    > Preprocessing library for brig-1.35.0..
brig                    > Building library for brig-1.35.0..
spar                    > Preprocessing executable 'spar-schema' for spar-0.1..
spar                    > Building executable 'spar-schema' for spar-0.1..
galley                  > Preprocessing executable 'galley-schema' for galley-0.83.0..
galley                  > Building executable 'galley-schema' for galley-0.83.0..
spar                    > Preprocessing executable 'spar-integration' for spar-0.1..
spar                    > Building executable 'spar-integration' for spar-0.1..
spar                    > [13 of 14] Compiling Test.Spar.APISpec
galley                  > Preprocessing executable 'galley-integration' for galley-0.83.0..
galley                  > Building executable 'galley-integration' for galley-0.83.0..
brig                    > Preprocessing library 'brig-index-lib' for brig-1.35.0..
brig                    > Building library 'brig-index-lib' for brig-1.35.0..
spar                    >       
spar                    > /home/arian/Projects/wire/wire-server/services/spar/test-integration/Test/Spar/APISpec.hs:513:7: error:
spar                    >     • Could not deduce (Eq ResponseLBS)
spar                    >         arising from a use of ‘shouldRespondWith’
spar                    >       from the context: HasCallStack
spar                    >         bound by the type signature for:
spar                    >                    testGetPutDelete :: HasCallStack =>
spar                    >                                        (SparReq
spar                    >                                         -> Maybe UserId
spar                    >                                         -> IdPId
spar                    >                                         -> IdPMetadataInfo
spar                    >                                         -> Http ResponseLBS)
spar                    >                                        -> SpecWith TestEnv
spar                    >         at test-integration/Test/Spar/APISpec.hs:507:1-129
spar                    >       There are instances for similar types:
spar                    >         instance Eq Data.Swagger.Internal.Response
spar                    >           -- Defined in ‘Data.Swagger.Internal’
spar                    >         instance Eq payload => Eq (SAML.Response payload)
spar                    >           -- Defined in ‘SAML2.WebSSO.Types’
spar                    >     • In a stmt of a 'do' block:
spar                    >         whichone (env ^. teSpar) Nothing (IdPId UUID.nil) idpmeta
spar                    >           `shouldRespondWith` checkErr (== 404) "not-found"
spar                    >       In the second argument of ‘($)’, namely
spar                    >         ‘do env <- ask
spar                    >             (_, _, _, (idpmeta, _)) <- registerTestIdPWithMeta
spar                    >             whichone (env ^. teSpar) Nothing (IdPId UUID.nil) idpmeta
spar                    >               `shouldRespondWith` checkErr (== 404) "not-found"’
spar                    >       In a stmt of a 'do' block:
spar                    >         it "responds with 'not found'"
spar                    >           $ do env <- ask
spar                    >                (_, _, _, (idpmeta, _)) <- registerTestIdPWithMeta
spar                    >                whichone (env ^. teSpar) Nothing (IdPId UUID.nil) idpmeta
spar                    >                  `shouldRespondWith` checkErr (== 404) "not-found"
spar                    >     | 
spar                    > 513 |       whichone (env ^. teSpar) Nothing (IdPId UUID.nil) idpmeta
spar                    >     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
spar                    >       
spar                    > /home/arian/Projects/wire/wire-server/services/spar/test-integration/Test/Spar/APISpec.hs:762:13: error:
spar                    >     • Could not deduce (Eq ResponseLBS)
spar                    >         arising from a use of ‘shouldRespondWith’
spar                    >       from the context: HasCallStack
spar                    >         bound by the type signature for:
spar                    >                    initidp :: HasCallStack =>
spar                    >                               TestSpar (IdP, SignPrivCreds, SignPrivCreds)
spar                    >         at test-integration/Test/Spar/APISpec.hs:756:11-81
spar                    >       There are instances for similar types:
spar                    >         instance Eq Data.Swagger.Internal.Response
spar                    >           -- Defined in ‘Data.Swagger.Internal’
spar                    >         instance Eq payload => Eq (SAML.Response payload)
spar                    >           -- Defined in ‘SAML2.WebSSO.Types’
spar                    >     • In a stmt of a 'do' block:
spar                    >         callIdpUpdate'
spar                    >           (env ^. teSpar)
spar                    >           (Just owner)
spar                    >           (idp ^. idpId)
spar                    >           (IdPMetadataValue (cs $ SAML.encode idpmeta') undefined)
spar                    >           `shouldRespondWith` ((== 200) . statusCode)
spar                    >       In the expression:
spar                    >         do env <- ask
spar                    >            (owner, _, idp,
spar                    >             (IdPMetadataValue _ idpmeta,
spar                    >              oldPrivKey)) <- registerTestIdPWithMeta
spar                    >            (SampleIdP _ newPrivKey _ sampleIdPCert2) <- makeSampleIdPMetadata
spar                    >            let idpmeta'
spar                    >                  = idpmeta & edCertAuthnResponse .~ (sampleIdPCert2 :| ...)
spar                    >            ....
spar                    >       In an equation for ‘initidp’:
spar                    >           initidp
spar                    >             = do env <- ask
spar                    >                  (owner, _, idp,
spar                    >                   (IdPMetadataValue _ idpmeta,
spar                    >                    oldPrivKey)) <- registerTestIdPWithMeta
spar                    >                  (SampleIdP _ newPrivKey _ sampleIdPCert2) <- makeSampleIdPMetadata
spar                    >                  ....
spar                    >     | 
spar                    > 762 |             callIdpUpdate' (env ^. teSpar) (Just owner) (idp ^. idpId) (IdPMetadataValue (cs $ SAML.encode idpmeta') undefined)
spar                    >     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
spar                    >       
spar                    > /home/arian/Projects/wire/wire-server/services/spar/test-integration/Test/Spar/APISpec.hs:1143:7: error:
spar                    >     • No instance for (Eq ResponseLBS)
spar                    >         arising from a use of ‘shouldRespondWith’
spar                    >       There are instances for similar types:
spar                    >         instance Eq Data.Swagger.Internal.Response
spar                    >           -- Defined in ‘Data.Swagger.Internal’
spar                    >         instance Eq payload => Eq (SAML.Response payload)
spar                    >           -- Defined in ‘SAML2.WebSSO.Types’
spar                    >     • In a stmt of a 'do' block:
spar                    >         callSetDefaultSsoCode (env ^. teSpar) nonExisting
spar                    >           `shouldRespondWith` \ resp -> statusCode resp == 404
spar                    >       In the second argument of ‘($)’, namely
spar                    >         ‘do env <- ask
spar                    >             (_userid, _teamid, _idp) <- registerTestIdP
spar                    >             nonExisting <- IdPId <$> liftIO UUID.nextRandom
spar                    >             callSetDefaultSsoCode (env ^. teSpar) nonExisting
spar                    >               `shouldRespondWith` \ resp -> statusCode resp == 404’
spar                    >       In a stmt of a 'do' block:
spar                    >         it "does not allow setting non-existing SSO code"
spar                    >           $ do env <- ask
spar                    >                (_userid, _teamid, _idp) <- registerTestIdP
spar                    >                nonExisting <- IdPId <$> liftIO UUID.nextRandom
spar                    >                callSetDefaultSsoCode (env ^. teSpar) nonExisting
spar                    >                  `shouldRespondWith` \ resp -> statusCode resp == 404
spar                    >      |
spar                    > 1143 |       callSetDefaultSsoCode (env ^. teSpar) nonExisting
spar                    >      |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
spar                    >       
galley                  > Preprocessing executable 'galley' for galley-0.83.0..
galley                  > Building executable 'galley' for galley-0.83.0..
brig                    > Preprocessing executable 'brig-index' for brig-1.35.0..
brig                    > Building executable 'brig-index' for brig-1.35.0..
galley                  > copy/register
galley                  > Installing executable galley-migrate-data in /home/arian/Projects/wire/wire-server/.stack-work/install/x86_64-linux-nix/0206a7923d0180ed19934bae4360b93c888fb7feebbfafa1df0803cfedfcf5a8/8.6.5/bin
galley                  > Installing library in /home/arian/Projects/wire/wire-server/.stack-work/install/x86_64-linux-nix/0206a7923d0180ed19934bae4360b93c888fb7feebbfafa1df0803cfedfcf5a8/8.6.5/lib/x86_64-linux-ghc-8.6.5/galley-0.83.0-FGmtibPG7ZxDQfdRT9X6SJ
galley                  > Installing executable galley-schema in /home/arian/Projects/wire/wire-server/.stack-work/install/x86_64-linux-nix/0206a7923d0180ed19934bae4360b93c888fb7feebbfafa1df0803cfedfcf5a8/8.6.5/bin
galley                  > Installing executable galley-integration in /home/arian/Projects/wire/wire-server/.stack-work/install/x86_64-linux-nix/0206a7923d0180ed19934bae4360b93c888fb7feebbfafa1df0803cfedfcf5a8/8.6.5/bin
brig                    > Preprocessing executable 'brig-integration' for brig-1.35.0..
brig                    > Building executable 'brig-integration' for brig-1.35.0..
galley                  > Installing executable galley in /home/arian/Projects/wire/wire-server/.stack-work/install/x86_64-linux-nix/0206a7923d0180ed19934bae4360b93c888fb7feebbfafa1df0803cfedfcf5a8/8.6.5/bin
brig                    > [11 of 24] Compiling API.User.Auth
galley                  > Registering library for galley-0.83.0..
brig                    > 
brig                    > /home/arian/Projects/wire/wire-server/services/brig/test/integration/API/User/Auth.hs:606:12: error:
brig                    >     • No instance for (Eq Http.Cookie)
brig                    >         arising from a use of ‘assertEqual’
brig                    >       There are instances for similar types:
brig                    >         instance Eq a => Eq (Auth.Cookie a)
brig                    >           -- Defined in ‘Wire.API.User.Auth’
brig                    >     • In the second argument of ‘($)’, namely
brig                    >         ‘assertEqual "cookie" c' (decodeCookie _rs)’
brig                    >       In a stmt of a 'do' block:
brig                    >         liftIO $ assertEqual "cookie" c' (decodeCookie _rs)
brig                    >       In the expression:
brig                    >         do u <- randomUser b
brig                    >            let renewAge = Opts.setUserCookieRenewAge $ Opts.optSettings config
brig                    >            let minAge = fromIntegral $ renewAge * 1000000 + 1
brig                    >                Just email = userEmail u
brig                    >            _rs <- login
brig                    >                     b (emailLogin email defPassword (Just "nexus1")) PersistentCookie
brig                    >                     <!! const 200 === statusCode
brig                    >            ....
brig                    >     |
brig                    > 606 |   liftIO $ assertEqual "cookie" c' (decodeCookie _rs)
brig                    >     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
brig                    > 
                  
--  While building package brig-1.35.0 using:
      /home/arian/.stack/setup-exe-cache/x86_64-linux-nix/Cabal-simple_mPHDZzAJ_2.4.0.1_ghc-8.6.5 --builddir=.stack-work/dist/x86_64-linux-nix/Cabal-2.4.0.1 build lib:brig lib:brig-index-lib exe:brig exe:brig-index exe:brig-integration exe:brig-schema --ghc-options " -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1


--  While building package spar-0.1 using:
      /home/arian/.stack/setup-exe-cache/x86_64-linux-nix/Cabal-simple_mPHDZzAJ_2.4.0.1_ghc-8.6.5 --builddir=.stack-work/dist/x86_64-linux-nix/Cabal-2.4.0.1 build lib:spar exe:spar exe:spar-integration exe:spar-schema --ghc-options " -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1
Progress 5/6

```