### PR TITLE
Cleanup hspec-wai dependency

### DIFF
--- a/libs/wai-utilities/package.yaml
+++ b/libs/wai-utilities/package.yaml
@@ -36,6 +36,8 @@ dependencies:
 - wai >=3.0
 - wai-predicates >=0.8
 - wai-routing >=0.12
+- wai-extra
+- hspec-wai
 - warp >=3.0
 library:
   source-dirs: src

--- a/libs/wai-utilities/src/Test/Hspec/Wai/Extra.hs
+++ b/libs/wai-utilities/src/Test/Hspec/Wai/Extra.hs
@@ -1,0 +1,49 @@
+-- | <https://github.com/hspec/hspec-wai/pull/49>, <https://github.com/hspec/hspec-wai/pull/41>
+module Test.Hspec.Wai.Extra (
+  bodyContains
+, bodySatisfies
+) where
+
+import           Prelude
+import           Control.Monad
+import           Data.Char
+import qualified Data.Text as TS
+import qualified Data.Text.Encoding as TS
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as SB
+import qualified Data.ByteString.Lazy as LB
+import           Test.Hspec.Wai.Matcher
+
+bodyContains :: Body -> MatchBody
+bodyContains body = bodySatisfies body SB.isInfixOf
+
+bodySatisfies :: Body -> (ByteString -> ByteString -> Bool) -> MatchBody
+bodySatisfies body prop = MatchBody (\_ actual -> bodyMatcher actual body)
+  where
+    bodyMatcher :: Body -> Body -> Maybe String
+    bodyMatcher (toStrict -> actual) (toStrict -> expected) = actualExpected "body mismatch:" actual_ expected_ <$ guard (not $ expected `prop` actual)
+      where
+        (actual_, expected_) = case (safeToString actual, safeToString expected) of
+          (Just x, Just y) -> (x, y)
+          _ -> (show actual, show expected)
+
+actualExpected :: String -> String -> String -> String
+actualExpected message actual expected = unlines [
+    message
+  , "  expected: " ++ expected
+  , "  but got:  " ++ actual
+  ]
+
+----------------------------------------------------------------------
+-- from "Test.Hspec.Wai.Util"
+
+toStrict :: LB.ByteString -> ByteString
+toStrict = mconcat . LB.toChunks
+
+safeToString :: ByteString -> Maybe String
+safeToString bs = do
+  str <- either (const Nothing) (Just . TS.unpack) (TS.decodeUtf8' bs)
+  let isSafe = not $ case str of
+        [] -> True
+        _  -> isSpace (last str) || any (not . isPrint) str
+  guard isSafe >> return str

--- a/libs/wai-utilities/wai-utilities.cabal
+++ b/libs/wai-utilities/wai-utilities.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 03b270072cba482a38b85bce9aa85fba04e5bd4a10561c7e636d64b797c9989a
+-- hash: 6cebd33b352df1c2bf4f33553facf68fb2437ced7defa185e4a240e50f759983
 
 name:           wai-utilities
 version:        0.16.1
@@ -27,6 +27,7 @@ library
       Network.Wai.Utilities.Server
       Network.Wai.Utilities.Swagger
       Network.Wai.Utilities.ZAuth
+      Test.Hspec.Wai.Extra
   other-modules:
       Paths_wai_utilities
   hs-source-dirs:
@@ -42,6 +43,7 @@ library
     , containers >=0.5
     , errors >=2.0
     , exceptions >=0.6
+    , hspec-wai
     , http-types >=0.8
     , imports
     , metrics-core >=0.1
@@ -58,6 +60,7 @@ library
     , types-common >=0.12
     , unix >=2.7
     , wai >=3.0
+    , wai-extra
     , wai-predicates >=0.8
     , wai-routing >=0.12
     , warp >=3.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -87,9 +87,8 @@ extra-deps:
 - git: https://github.com/wireapp/aws
   commit: 42695688fc20f80bf89cec845c57403954aab0a2
 
-# https://github.com/hspec/hspec-wai/pull/49
 - git: https://github.com/wireapp/hspec-wai
-  commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25
+  commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25 # (2020-01-30) branch: body-contains (https://github.com/hspec/hspec-wai/pull/49)
 
 - git: https://github.com/wireapp/bloodhound
   commit: 7d3ccf8039912829b26b8e47cc4eaabc98cb571a # (2020-05-25) branch: feature/reindex

--- a/stack.yaml
+++ b/stack.yaml
@@ -87,9 +87,6 @@ extra-deps:
 - git: https://github.com/wireapp/aws
   commit: 42695688fc20f80bf89cec845c57403954aab0a2
 
-- git: https://github.com/wireapp/hspec-wai
-  commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25 # (2020-01-30) branch: body-contains (https://github.com/hspec/hspec-wai/pull/49)
-
 - git: https://github.com/wireapp/bloodhound
   commit: 7d3ccf8039912829b26b8e47cc4eaabc98cb571a # (2020-05-25) branch: feature/reindex
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -127,20 +127,6 @@ packages:
     commit: 42695688fc20f80bf89cec845c57403954aab0a2
 - completed:
     cabal-file:
-      size: 2289
-      sha256: 07c1e684acf4ba1c097fe5dd2525cb887269f7d3335c42783c1f4d2bfdc01283
-    name: hspec-wai
-    version: 0.9.2
-    git: https://github.com/wireapp/hspec-wai
-    pantry-tree:
-      size: 1829
-      sha256: 1da15bc431ded925782e30d299556f7c33ab89fa74e5a519061081616fb9f4d7
-    commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25
-  original:
-    git: https://github.com/wireapp/hspec-wai
-    commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25
-- completed:
-    cabal-file:
       size: 3403
       sha256: 2fd9aef25802bf62848b7087a9476264b50bc7d9f195c7f0012e52d19ed2ebe3
     name: bloodhound


### PR DESCRIPTION
we could either go with the first commit, or entirely get rid of the for, taking our changes into (a bit arbitrarily) wai-utilities.

third option (not implemented here): set up a tiny package hspec-wai-extra that contains the changes.

oops, and if we go for the second option, we probably need to change some places in which we use the code that has moved.

@arianvp you triggered this, please make a call how to proceed.  my personal favorite is keep fe934bd and revert 26e4f33