### PR TITLE
Upgrade to ormolu 0.1.2.0

### DIFF
--- a/libs/api-bot/src/Network/Wire/Bot/Cache.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Cache.hs
@@ -62,7 +62,7 @@ empty :: IO Cache
 empty = Cache <$> newIORef []
 
 get :: (MonadIO m, HasCallStack) => Cache -> m CachedUser
-get c = liftIO $ atomicModifyIORef (cache c) $ \u ->
+get c = liftIO . atomicModifyIORef (cache c) $ \u ->
   case u of
     [] ->
       error
@@ -71,7 +71,7 @@ get c = liftIO $ atomicModifyIORef (cache c) $ \u ->
     (x : xs) -> (xs, x)
 
 put :: MonadIO m => Cache -> CachedUser -> m ()
-put c a = liftIO $ atomicModifyIORef (cache c) $ \u -> (a : u, ())
+put c a = liftIO . atomicModifyIORef (cache c) $ \u -> (a : u, ())
 
 toUser :: HasCallStack => Logger -> [CachedUser] -> [LText] -> IO [CachedUser]
 toUser _ acc [i, e, p] = do

--- a/libs/api-bot/src/Network/Wire/Bot/Crypto.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Crypto.hs
@@ -181,9 +181,9 @@ decryptSymmetric _ (SymmetricKeys ekey mkey) msg = liftIO $ do
   let (dgst, ciphertext) = BS.splitAt 32 msg
   sha256 <- requireMaybe (digestFromByteString dgst) "Bad MAC"
   let mac = hmac (toByteString' mkey) ciphertext :: HMAC SHA256
-  unless (HMAC sha256 == mac)
-    $ throwM
-    $ RequirementFailed "Bad MAC"
+  unless (HMAC sha256 == mac) $
+    throwM $
+      RequirementFailed "Bad MAC"
   let (iv, dat) = BS.splitAt 16 ciphertext
   return $ unpadPKCS7 $ cbcDecrypt aes (aesIV iv) dat
 

--- a/libs/api-bot/src/Network/Wire/Bot/Crypto/Glue.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Crypto/Glue.hs
@@ -50,7 +50,7 @@ deleteBox :: UserId -> Maybe Text -> IO ()
 deleteBox uid label = do
   dir <- getBoxDir uid label
   removePathForcibly dir -- using "forcibly" so that it wouldn't fail
-    -- if the directory doesn't exist
+  -- if the directory doesn't exist
 
 genPrekeys :: Box -> Word16 -> IO [C.Prekey]
 genPrekeys box n = mapM (genPrekey box) [1 .. n - 1]

--- a/libs/api-bot/src/Network/Wire/Bot/Monad.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Monad.hs
@@ -615,7 +615,7 @@ scheduleAssert bot typ f out = whenAsserts $ do
         writeTQueue (botAsserts bot) (EventAssertion typ t f out callStack)
         writeTVar (botAssertCount bot) (n + 1)
         return True
-  unless r $ liftBotNet $ do
+  unless r . liftBotNet $ do
     incrAssertFailed
     runBotSession bot . log Error . msg $
       "Too many event assertions. Dropped: " <> eventTypeText typ
@@ -698,7 +698,7 @@ mkBot tag user pw = do
   return bot
 
 connectPush :: Bot -> BotNetEnv -> IO (Async ())
-connectPush bot e = runBotNet e $ runBotSession bot $ do
+connectPush bot e = runBotNet e . runBotSession bot $ do
   log Info $ msg (val "Establishing push channel")
   awaitNotifications (consume bot e)
 

--- a/libs/bilge/src/Bilge/Assert.hs
+++ b/libs/bilge/src/Bilge/Assert.hs
@@ -85,9 +85,11 @@ io <!! aa = do
   r <- io `catch` printErr
   let results = map ($ r) (execWriter . _assertions $ aa)
   let failures = filter (isJust . snd) $ zip [1 ..] results
-  unless (null failures) $ error . concat $
-    title "Assertions failed:\n" : intersperse "\n" (map msg failures)
-      ++ ["\n\nResponse was:\n\n" ++ show r]
+  unless (null failures) $
+    error . concat $
+      title "Assertions failed:\n" :
+      intersperse "\n" (map msg failures)
+        ++ ["\n\nResponse was:\n\n" ++ show r]
   return r
   where
     msg :: (Int, Maybe String) -> String

--- a/libs/bilge/src/Bilge/IO.hs
+++ b/libs/bilge/src/Bilge/IO.hs
@@ -205,7 +205,7 @@ instance MonadBaseControl IO (HttpT IO) where
 
 instance MonadUnliftIO m => MonadUnliftIO (HttpT m) where
   withRunInIO inner =
-    HttpT $ ReaderT $ \r ->
+    HttpT . ReaderT $ \r ->
       withRunInIO $ \run ->
         inner (run . runHttpT r)
 

--- a/libs/bilge/src/Bilge/RPC.hs
+++ b/libs/bilge/src/Bilge/RPC.hs
@@ -109,9 +109,9 @@ statusCheck ::
   Response (Maybe LByteString) ->
   m ()
 statusCheck c f r =
-  unless (statusCode r == c)
-    $ throwError
-    $ f ("unexpected status code: " <> pack (show $ statusCode r))
+  unless (statusCode r == c) $
+    throwError $
+      f ("unexpected status code: " <> pack (show $ statusCode r))
 
 parseResponse ::
   (Exception e, MonadThrow m, Monad m, FromJSON a) =>

--- a/libs/bilge/src/Bilge/Response.hs
+++ b/libs/bilge/src/Bilge/Response.hs
@@ -80,12 +80,12 @@ getCookieValue :: ByteString -> Response a -> Maybe ByteString
 getCookieValue cookieName resp =
   resp
     ^? to responseHeaders
-    . traversed -- Over each header
-    . filtered ((== "Set-Cookie") . fst) -- Select the cookie headers by name
-    . _2 -- Select Set-Cookie values
-    . to parseSetCookie
-    . filtered ((== cookieName) . setCookieName) -- Select only the cookie we want
-    . to setCookieValue -- extract the cookie value
+      . traversed -- Over each header
+      . filtered ((== "Set-Cookie") . fst) -- Select the cookie headers by name
+      . _2 -- Select Set-Cookie values
+      . to parseSetCookie
+      . filtered ((== cookieName) . setCookieName) -- Select only the cookie we want
+      . to setCookieValue -- extract the cookie value
 
 type ResponseLBS = Response (Maybe LByteString)
 

--- a/libs/brig-types/test/unit/Test/Brig/Roundtrip.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Roundtrip.hs
@@ -21,7 +21,7 @@ import Data.Aeson (FromJSON, ToJSON, parseJSON, toJSON)
 import Data.Aeson.Types (parseEither)
 import Imports
 import Test.Tasty (TestTree)
-import Test.Tasty.QuickCheck ((===), Arbitrary, counterexample, testProperty)
+import Test.Tasty.QuickCheck (Arbitrary, counterexample, testProperty, (===))
 import Type.Reflection (typeRep)
 
 testRoundTrip ::

--- a/libs/cassandra-util/src/Cassandra/Exec.hs
+++ b/libs/cassandra-util/src/Cassandra/Exec.hs
@@ -34,9 +34,10 @@ import Cassandra.CQL (Consistency, R)
 import Control.Monad.Catch
 import Data.Conduit
 -- Things we just import and re-export.
-import Database.CQL.IO as C (BatchM, Client, ClientState, MonadClient, Page (..), PrepQuery, Row, addPrepQuery, addQuery, adjustConsistency, adjustResponseTimeout, adjustSendTimeout, batch, emptyPage, init, liftClient, localState, paginate, prepared, query, query1, queryString, retry, runClient, schema, setConsistency, setSerialConsistency, setType, shutdown, trans, write)
+
 -- We only use these locally.
 import Database.CQL.IO (RetrySettings, RunQ, defRetrySettings, eagerRetrySettings)
+import Database.CQL.IO as C (BatchM, Client, ClientState, MonadClient, Page (..), PrepQuery, Row, addPrepQuery, addQuery, adjustConsistency, adjustResponseTimeout, adjustSendTimeout, batch, emptyPage, init, liftClient, localState, paginate, prepared, query, query1, queryString, retry, runClient, schema, setConsistency, setSerialConsistency, setType, shutdown, trans, write)
 import Database.CQL.Protocol (Error, QueryParams (QueryParams), Tuple)
 import Imports hiding (init)
 

--- a/libs/cassandra-util/src/Cassandra/Schema.hs
+++ b/libs/cassandra-util/src/Cassandra/Schema.hs
@@ -125,12 +125,12 @@ schemaVersion = catch (fmap runIdentity <$> qry) h
 versionCheck :: Int32 -> Client ()
 versionCheck v = do
   v' <- schemaVersion
-  unless (Just v <= v')
-    $ error
-    $ "Schema Version too old! Expecting at least: "
-      <> show v
-      <> ", but got: "
-      <> fromMaybe "" (show <$> v')
+  unless (Just v <= v') $
+    error $
+      "Schema Version too old! Expecting at least: "
+        <> show v
+        <> ", but got: "
+        <> fromMaybe "" (show <$> v')
 
 createKeyspace :: Keyspace -> ReplicationStrategy -> Client ()
 createKeyspace (Keyspace k) rs = void $ schema (cql rs) (params All ())
@@ -165,8 +165,8 @@ migrateSchema :: Log.Logger -> MigrationOpts -> [Migration] -> IO ()
 migrateSchema l o ms = do
   hosts <- initialContactsPlain $ pack (migHost o)
   p <-
-    CQL.init
-      $ setLogger (CT.mkLogger l)
+    CQL.init $
+      setLogger (CT.mkLogger l)
         . setContacts (NonEmpty.head hosts) (NonEmpty.tail hosts)
         . setPortNumber (fromIntegral $ migPort o)
         . setMaxConnections 1
@@ -183,7 +183,7 @@ migrateSchema l o ms = do
         . setSendTimeout 20
         . setResponseTimeout 50
         . setProtocolVersion V4
-      $ defSettings
+        $ defSettings
   runClient p $ do
     let keyspace = Keyspace . migKeyspace $ o
     when (migReset o) $ do

--- a/libs/cassandra-util/src/Cassandra/Settings.hs
+++ b/libs/cassandra-util/src/Cassandra/Settings.hs
@@ -46,13 +46,14 @@ initialContactsDisco (pack -> srv) url = liftIO $ do
         Nothing -> [srv, srv <> "_seed"]
         Just _ -> [srv] -- requesting only seeds is a valid use-case
   let ip =
-        rs ^.. responseBody
-          . key "roles"
-          . members
-          . indices (`elem` srvs)
-          . values
-          . key "privateIpAddress"
-          . _String
+        rs
+          ^.. responseBody
+            . key "roles"
+            . members
+            . indices (`elem` srvs)
+            . values
+            . key "privateIpAddress"
+            . _String
           & map unpack
   case ip of
     i : ii -> return (i :| ii)

--- a/libs/cassandra-util/src/Cassandra/Util.hs
+++ b/libs/cassandra-util/src/Cassandra/Util.hs
@@ -38,9 +38,9 @@ writeTimeToUTC = posixSecondsToUTCTime . fromIntegral . (`div` 1000000)
 
 defInitCassandra :: Text -> Text -> Word16 -> Log.Logger -> IO ClientState
 defInitCassandra ks h p lg =
-  init
-    $ setLogger (CT.mkLogger lg)
+  init $
+    setLogger (CT.mkLogger lg)
       . setPortNumber (fromIntegral p)
       . setContacts (unpack h) []
       . setKeyspace (Keyspace ks)
-    $ defSettings
+      $ defSettings

--- a/libs/extended/src/Servant/API/Extended.hs
+++ b/libs/extended/src/Servant/API/Extended.hs
@@ -92,9 +92,9 @@ instance
         -- See also "W3C Internet Media Type registration, consistency of use"
         -- http://www.w3.org/2001/tag/2002/0129-mime
         let contentTypeH =
-              fromMaybe "application/octet-stream"
-                $ lookup hContentType
-                $ requestHeaders request
+              fromMaybe "application/octet-stream" $
+                lookup hContentType $
+                  requestHeaders request
         case canHandleCTypeH (Proxy :: Proxy list) (cs contentTypeH) :: Maybe (BL.ByteString -> Either String a) of
           Nothing -> delayedFail err415
           Just f -> return f

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -126,7 +126,7 @@ module Galley.Types.Teams
 where
 
 import Control.Exception (ErrorCall (ErrorCall))
-import Control.Lens ((^.), makeLenses, view)
+import Control.Lens (makeLenses, view, (^.))
 import Control.Monad.Catch
 import Data.Aeson
 import Data.Id (UserId)
@@ -137,8 +137,8 @@ import qualified Data.Set as Set
 import Data.String.Conversions (cs)
 import Imports
 import Wire.API.Event.Team
-import Wire.API.Team (NewTeam (..), Team (..), TeamBinding (..))
 import Wire.API.Team
+import Wire.API.Team (NewTeam (..), Team (..), TeamBinding (..))
 import Wire.API.Team.Conversation
 import Wire.API.Team.Feature
 import Wire.API.Team.Member

--- a/libs/galley-types/test/unit/Test/Galley/Roundtrip.hs
+++ b/libs/galley-types/test/unit/Test/Galley/Roundtrip.hs
@@ -21,7 +21,7 @@ import Data.Aeson (FromJSON, ToJSON, parseJSON, toJSON)
 import Data.Aeson.Types (parseEither)
 import Imports
 import Test.Tasty (TestTree)
-import Test.Tasty.QuickCheck ((===), Arbitrary, counterexample, testProperty)
+import Test.Tasty.QuickCheck (Arbitrary, counterexample, testProperty, (===))
 import Type.Reflection (typeRep)
 
 testRoundTrip ::

--- a/libs/galley-types/test/unit/Test/Galley/Types.hs
+++ b/libs/galley-types/test/unit/Test/Galley/Types.hs
@@ -38,14 +38,13 @@ tests =
     "Tests"
     [ testCase "owner has all permissions" $
         rolePermissions RoleOwner @=? fullPermissions,
-      testCase "smaller roles (further to the left/top in the type def) are strictly more powerful"
-        $
+      testCase "smaller roles (further to the left/top in the type def) are strictly more powerful" $
         -- we may not want to maintain this property in the future when adding more roles, but for
         -- now it's true, and it's nice to have that written down somewhere.
-        forM_ [(r1, r2) | r1 <- [minBound ..], r2 <- drop 1 [r1 ..]]
-        $ \(r1, r2) -> do
-          assertBool "owner.self" ((rolePermissions r2 ^. self) `isSubsetOf` (rolePermissions r1 ^. self))
-          assertBool "owner.copy" ((rolePermissions r2 ^. copy) `isSubsetOf` (rolePermissions r1 ^. copy)),
+        forM_ [(r1, r2) | r1 <- [minBound ..], r2 <- drop 1 [r1 ..]] $
+          \(r1, r2) -> do
+            assertBool "owner.self" ((rolePermissions r2 ^. self) `isSubsetOf` (rolePermissions r1 ^. self))
+            assertBool "owner.copy" ((rolePermissions r2 ^. copy) `isSubsetOf` (rolePermissions r1 ^. copy)),
       testCase "permissions for viewing feature flags" $
         -- We currently (at the time of writing this test) grant view permissions for all
         -- 'TeamFeatureName's to all roles.  If we add more features in the future and forget to

--- a/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
+++ b/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
@@ -155,14 +155,16 @@ instance ToJSON Recipient where
 
 -- "All clients" is encoded in the API as an empty list.
 instance FromJSON RecipientClients where
-  parseJSON x = parseJSON @[ClientId] x >>= \case
-    [] -> pure RecipientClientsAll
-    c : cs -> pure (RecipientClientsSome (list1 c cs))
+  parseJSON x =
+    parseJSON @[ClientId] x >>= \case
+      [] -> pure RecipientClientsAll
+      c : cs -> pure (RecipientClientsSome (list1 c cs))
 
 instance ToJSON RecipientClients where
-  toJSON = toJSON . \case
-    RecipientClientsAll -> []
-    RecipientClientsSome cs -> toList cs
+  toJSON =
+    toJSON . \case
+      RecipientClientsAll -> []
+      RecipientClientsSome cs -> toList cs
 
 -----------------------------------------------------------------------------
 -- ApsData

--- a/libs/hscim/src/Web/Scim/ContentType.hs
+++ b/libs/hscim/src/Web/Scim/ContentType.hs
@@ -38,10 +38,10 @@ data SCIM
 instance Accept SCIM where
   contentTypes _ =
     "application" // "scim+json" /: ("charset", "utf-8")
-      :| "application" // "scim+json"
-      : "application" // "json" /: ("charset", "utf-8")
-      : "application" // "json"
-      : []
+      :| "application" // "scim+json" :
+    "application" // "json" /: ("charset", "utf-8") :
+    "application" // "json" :
+    []
 
 instance ToJSON a => MimeRender SCIM a where
   mimeRender _ = mimeRender (Proxy @JSON)

--- a/libs/hscim/src/Web/Scim/Filter.hs
+++ b/libs/hscim/src/Web/Scim/Filter.hs
@@ -56,7 +56,7 @@ module Web.Scim.Filter
   )
 where
 
-import Control.Applicative ((<|>), optional)
+import Control.Applicative (optional, (<|>))
 import Data.Aeson as Aeson
 import Data.Aeson.Parser as Aeson
 import Data.Aeson.Text as Aeson

--- a/libs/hscim/src/Web/Scim/Schema/PatchOp.hs
+++ b/libs/hscim/src/Web/Scim/Schema/PatchOp.hs
@@ -20,12 +20,12 @@ module Web.Scim.Schema.PatchOp where
 import Control.Applicative
 import Control.Monad (guard)
 import Control.Monad.Except
-import Data.Aeson.Types ((.:), (.:?), (.=), FromJSON (parseJSON), ToJSON (toJSON), Value (String), object, withObject, withText)
+import Data.Aeson.Types (FromJSON (parseJSON), ToJSON (toJSON), Value (String), object, withObject, withText, (.:), (.:?), (.=))
 import qualified Data.Aeson.Types as Aeson
 import Data.Attoparsec.ByteString (Parser, endOfInput, parseOnly)
 import Data.Bifunctor (first)
-import qualified Data.HashMap.Strict as HashMap
 import qualified Data.HashMap.Strict as HM
+import qualified Data.HashMap.Strict as HashMap
 import Data.Text (Text, toCaseFold, toLower)
 import Data.Text.Encoding (encodeUtf8)
 import Web.Scim.AttrName (AttrName (..))

--- a/libs/hscim/src/Web/Scim/Schema/User.hs
+++ b/libs/hscim/src/Web/Scim/Schema/User.hs
@@ -182,9 +182,10 @@ instance FromJSON (UserExtra tag) => FromJSON (User tag) where
   parseJSON = withObject "User" $ \obj -> do
     -- Lowercase all fields
     let o = HM.fromList . map (over _1 toLower) . HM.toList $ obj
-    schemas <- o .:? "schemas" <&> \case
-      Nothing -> [User20]
-      Just xs -> if User20 `elem` xs then xs else User20 : xs
+    schemas <-
+      o .:? "schemas" <&> \case
+        Nothing -> [User20]
+        Just xs -> if User20 `elem` xs then xs else User20 : xs
     userName <- o .: "username"
     externalId <- o .:? "externalid"
     name <- o .:? "name"

--- a/libs/hscim/src/Web/Scim/Test/Util.hs
+++ b/libs/hscim/src/Web/Scim/Test/Util.hs
@@ -52,7 +52,7 @@ where
 
 import qualified Control.Retry as Retry
 import Data.Aeson
-import Data.Aeson.Internal ((<?>), JSONPathElement (Key))
+import Data.Aeson.Internal (JSONPathElement (Key), (<?>))
 import Data.Aeson.QQ
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -71,8 +71,7 @@ import Network.Wai (Application)
 import Network.Wai.Test (SResponse)
 import Test.Hspec.Expectations (expectationFailure)
 import Test.Hspec.Wai hiding (patch, post, put, shouldRespondWith)
-import Test.Hspec.Wai.Matcher (bodyEquals)
-import Test.Hspec.Wai.Matcher (match)
+import Test.Hspec.Wai.Matcher (bodyEquals, match)
 import Web.Scim.Class.Auth (AuthTypes (..))
 import Web.Scim.Class.Group (GroupTypes (..))
 import Web.Scim.Schema.Schema (Schema (CustomSchema, User20))

--- a/libs/hscim/test/Test/Schema/PatchOpSpec.hs
+++ b/libs/hscim/test/Test/Schema/PatchOpSpec.hs
@@ -21,8 +21,8 @@
 module Test.Schema.PatchOpSpec where
 
 import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Types as Aeson
 import Data.Aeson.Types (Result (Error, Success), Value (String), fromJSON, toJSON)
+import qualified Data.Aeson.Types as Aeson
 import Data.Attoparsec.ByteString (parseOnly)
 import Data.Either (isLeft)
 import Data.Foldable (for_)

--- a/libs/imports/src/Imports.hs
+++ b/libs/imports/src/Imports.hs
@@ -121,7 +121,7 @@ where
 -- with e.g. UnliftIO modules
 
 import Control.Applicative hiding (empty, many, optional, some) -- common in
-  -- some libs
+-- some libs
 
 -- conflicts with Options.Applicative.Option (should we care?)
 -- First and Last are going to be deprecated. Use Semigroup instead
@@ -191,10 +191,8 @@ import UnliftIO.IO hiding (Handle, getMonotonicTime)
 import UnliftIO.IORef
 import UnliftIO.MVar
 import UnliftIO.STM
-import qualified Prelude as P
 import Prelude
-  ( ($!),
-    Bounded (..),
+  ( Bounded (..),
     Double,
     Enum (..),
     Eq (..),
@@ -215,8 +213,6 @@ import Prelude
     RealFrac (..),
     Show (..),
     ShowS,
-    (^),
-    (^^),
     error,
     even,
     fromIntegral,
@@ -235,7 +231,11 @@ import Prelude
     shows,
     subtract,
     undefined,
+    ($!),
+    (^),
+    (^^),
   )
+import qualified Prelude as P
 
 ----------------------------------------------------------------------------
 -- Type aliases

--- a/libs/metrics-wai/src/Data/Metrics/Middleware/Prometheus.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Middleware/Prometheus.hs
@@ -21,8 +21,7 @@ module Data.Metrics.Middleware.Prometheus
 where
 
 import Data.Maybe (fromMaybe)
-import Data.Metrics.Types (Paths)
-import Data.Metrics.Types (treeLookup)
+import Data.Metrics.Types (Paths, treeLookup)
 import Data.Metrics.WaiRoute (treeToPaths)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as T

--- a/libs/ropes/src/Ropes/Nexmo.hs
+++ b/libs/ropes/src/Ropes/Nexmo.hs
@@ -319,9 +319,9 @@ sendFeedback cr mgr fb = httpLbs req mgr >>= parseResponse
     -- You must _always_ specify a timestamp
     nexmoTimeFormat = formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S"
     parseResponse res =
-      unless (responseStatus res == status200)
-        $ throwIO
-        $ FeedbackErrorResponse (decodeUtf8 . toStrict . responseBody $ res)
+      unless (responseStatus res == status200) $
+        throwIO $
+          FeedbackErrorResponse (decodeUtf8 . toStrict . responseBody $ res)
 
 sendMessage :: Credentials -> Manager -> Message -> IO MessageResponse
 sendMessage cr mgr msg = N.head <$> sendMessages cr mgr (msg :| [])

--- a/libs/tasty-cannon/src/Test/Tasty/Cannon.hs
+++ b/libs/tasty-cannon/src/Test/Tasty/Cannon.hs
@@ -75,7 +75,7 @@ import Data.ByteString.Conversion
 import Data.Id
 import Data.List1
 import Data.Misc ((<$$>))
-import Data.Timeout ((#), Timeout, TimeoutUnit (..))
+import Data.Timeout (Timeout, TimeoutUnit (..), (#))
 import Gundeck.Types
 import Imports
 import Network.HTTP.Client
@@ -240,15 +240,16 @@ awaitMatch t ws match = go [] []
     go buf errs = do
       mn <- await t ws
       case mn of
-        Just n -> do
-          liftIO (match n)
-          refill buf
-          return (Right n)
-          `catchAll` \e -> case asyncExceptionFromException e of
-            Just x -> throwM (x :: SomeAsyncException)
-            Nothing ->
-              let e' = MatchFailure e
-               in go (n : buf) (e' : errs)
+        Just n ->
+          do
+            liftIO (match n)
+            refill buf
+            return (Right n)
+            `catchAll` \e -> case asyncExceptionFromException e of
+              Just x -> throwM (x :: SomeAsyncException)
+              Nothing ->
+                let e' = MatchFailure e
+                 in go (n : buf) (e' : errs)
         Nothing -> do
           refill buf
           return (Left (MatchTimeout errs))

--- a/libs/types-common-aws/src/Util/Test/SQS.hs
+++ b/libs/types-common-aws/src/Util/Test/SQS.hs
@@ -91,8 +91,8 @@ receive :: Int -> Text -> SQS.ReceiveMessage
 receive n url =
   SQS.receiveMessage url
     & set SQS.rmWaitTimeSeconds (Just 1)
-    . set SQS.rmMaxNumberOfMessages (Just n)
-    . set SQS.rmVisibilityTimeout (Just 1)
+      . set SQS.rmMaxNumberOfMessages (Just n)
+      . set SQS.rmVisibilityTimeout (Just 1)
 
 fetchMessage :: (MonadIO m, AWS.MonadAWS m, Message a) => Text -> String -> (String -> Maybe a -> IO ()) -> m ()
 fetchMessage url label callback = do
@@ -140,9 +140,10 @@ tryMatch label tries url callback = go tries
       when (null ok) $ do
         liftIO $ threadDelay (10 ^ (6 :: Int))
         go (n - 1)
-    check e = do
-      liftIO $ callback label e
-      return (Right $ show e)
-      `catchAll` \ex -> case asyncExceptionFromException ex of
-        Just x -> throwM (x :: SomeAsyncException)
-        Nothing -> return . Left $ MatchFailure (e, ex)
+    check e =
+      do
+        liftIO $ callback label e
+        return (Right $ show e)
+        `catchAll` \ex -> case asyncExceptionFromException ex of
+          Just x -> throwM (x :: SomeAsyncException)
+          Nothing -> return . Left $ MatchFailure (e, ex)

--- a/libs/types-common/src/Data/Handle.hs
+++ b/libs/types-common/src/Data/Handle.hs
@@ -83,6 +83,7 @@ handleParser = do
     isHandleChar = Atto.inClass "a-z0-9_.-"
 
 instance Arbitrary Handle where
-  arbitrary = Handle . Text.pack <$> do
-    len <- oneof [choose (2, 10), choose (2, 256)] -- prefer short handles
-    replicateM len (elements $ ['a' .. 'z'] <> ['0' .. '9'] <> "_-.")
+  arbitrary =
+    Handle . Text.pack <$> do
+      len <- oneof [choose (2, 10), choose (2, 256)] -- prefer short handles
+      replicateM len (elements $ ['a' .. 'z'] <> ['0' .. '9'] <> "_-.")

--- a/libs/types-common/src/Data/IdMapping.hs
+++ b/libs/types-common/src/Data/IdMapping.hs
@@ -19,7 +19,7 @@
 
 module Data.IdMapping where
 
-import Data.Aeson ((.=), ToJSON (toJSON))
+import Data.Aeson (ToJSON (toJSON), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import Data.Domain (domainText)

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -36,7 +36,7 @@ module Data.Json.Util
 where
 
 import qualified Cassandra as CQL
-import Control.Lens ((%~), coerced)
+import Control.Lens (coerced, (%~))
 import Data.Aeson
 import Data.Aeson.Types
 import qualified Data.ByteString.Base64.Lazy as EL

--- a/libs/types-common/src/Data/Misc.hs
+++ b/libs/types-common/src/Data/Misc.hs
@@ -61,7 +61,7 @@ module Data.Misc
 where
 
 import Cassandra
-import Control.Lens ((.~), (^.), makeLenses)
+import Control.Lens (makeLenses, (.~), (^.))
 import Data.Aeson
 import qualified Data.Aeson.Types as Json
 import qualified Data.Attoparsec.ByteString.Char8 as Chars

--- a/libs/types-common/src/Data/Text/Ascii.hs
+++ b/libs/types-common/src/Data/Text/Ascii.hs
@@ -371,12 +371,13 @@ check m f t
   | otherwise = Left m
 
 parseBytes :: (Text -> Either String a) -> Parser a
-parseBytes f = parser >>= \bs ->
-  case decodeUtf8' bs of
-    Left _ -> fail $ "Invalid ASCII characters in: " ++ C8.unpack bs
-    Right t -> case f t of
-      Left e -> fail $ e ++ ": " ++ Text.unpack t
-      Right a -> pure a
+parseBytes f =
+  parser >>= \bs ->
+    case decodeUtf8' bs of
+      Left _ -> fail $ "Invalid ASCII characters in: " ++ C8.unpack bs
+      Right t -> case f t of
+        Left e -> fail $ e ++ ": " ++ Text.unpack t
+        Right a -> pure a
 
 unsafeString :: (Text -> Either String a) -> String -> a
 unsafeString f s = case f (Text.pack s) of

--- a/libs/types-common/src/Util/Test.hs
+++ b/libs/types-common/src/Util/Test.hs
@@ -35,11 +35,12 @@ instance IsOption IntegrationConfigFile where
   optionName = return "integration-config"
   optionHelp = return "Integration config file to read from"
   optionCLParser =
-    fmap IntegrationConfigFile $ strOption $
-      ( short (untag (return 'i' :: Tagged IntegrationConfigFile Char))
-          <> long (untag (optionName :: Tagged IntegrationConfigFile String))
-          <> help (untag (optionHelp :: Tagged IntegrationConfigFile String))
-      )
+    fmap IntegrationConfigFile $
+      strOption $
+        ( short (untag (return 'i' :: Tagged IntegrationConfigFile Char))
+            <> long (untag (optionName :: Tagged IntegrationConfigFile String))
+            <> help (untag (optionHelp :: Tagged IntegrationConfigFile String))
+        )
 
 handleParseError :: (Show a) => Either a b -> IO (Maybe b)
 handleParseError (Left err) = do

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -99,14 +99,14 @@ newSettings (Server h p l m t) = do
   -- (Atomically) initialise the standard metrics, to avoid races.
   void $ gaugeGet (path "net.connections") m
   void $ counterGet (path "net.errors") m
-  return
-    $ setHost (fromString h)
+  return $
+    setHost (fromString h)
       . setPort (fromIntegral p)
       . setBeforeMainLoop logStart
       . setOnOpen (const $ connStart >> return True)
       . setOnClose (const connEnd)
       . setTimeout (fromMaybe 300 t)
-    $ defaultSettings
+      $ defaultSettings
   where
     connStart = gaugeIncr (path "net.connections") m
     connEnd = gaugeDecr (path "net.connections") m
@@ -357,10 +357,11 @@ runHandlers e [] = throw e
 runHandlers e (Handler h : hs) = maybe (runHandlers e hs) h (fromException e)
 
 restrict :: Int -> Int -> Predicate r P.Error Int -> Predicate r P.Error Int
-restrict l u = fmap $ \x -> x >>= \v ->
-  if v >= l && v <= u
-    then x
-    else Fail (setMessage (emsg v) . setReason TypeError $ e400)
+restrict l u = fmap $ \x ->
+  x >>= \v ->
+    if v >= l && v <= u
+      then x
+      else Fail (setMessage (emsg v) . setReason TypeError $ e400)
   where
     emsg v =
       LBS.toStrict . toLazyByteString $

--- a/libs/wire-api/src/Wire/API/Arbitrary.hs
+++ b/libs/wire-api/src/Wire/API/Arbitrary.hs
@@ -43,8 +43,8 @@ import Data.List1 (List1, list1)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import GHC.Generics (Rep)
+import Generic.Random (listOf', (:+) ((:+)))
 import qualified Generic.Random as Generic
-import Generic.Random ((:+) ((:+)), listOf')
 import Imports
 import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary))
 import qualified Test.QuickCheck.Arbitrary as QC

--- a/libs/wire-api/src/Wire/API/Asset/V3.hs
+++ b/libs/wire-api/src/Wire/API/Asset/V3.hs
@@ -68,7 +68,7 @@ import Data.ByteString.Builder
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as LBS
 import Data.Id
-import Data.Json.Util ((#), toUTCTimeMillis)
+import Data.Json.Util (toUTCTimeMillis, (#))
 import Data.Text.Ascii (AsciiBase64Url)
 import qualified Data.Text.Encoding as T
 import Data.Time.Clock
@@ -303,13 +303,14 @@ instance ToByteString AssetRetention where
 
 -- | ByteString representation is used in AssetKey
 instance FromByteString AssetRetention where
-  parser = decimal >>= \d -> case (d :: Word) of
-    1 -> return AssetEternal
-    2 -> return AssetPersistent
-    3 -> return AssetVolatile
-    4 -> return AssetEternalInfrequentAccess
-    5 -> return AssetExpiring
-    _ -> fail $ "Invalid asset retention: " ++ show d
+  parser =
+    decimal >>= \d -> case (d :: Word) of
+      1 -> return AssetEternal
+      2 -> return AssetPersistent
+      3 -> return AssetVolatile
+      4 -> return AssetEternalInfrequentAccess
+      5 -> return AssetExpiring
+      _ -> fail $ "Invalid asset retention: " ++ show d
 
 instance ToJSON AssetRetention where
   toJSON = String . retentionToTextRep

--- a/libs/wire-api/src/Wire/API/Asset/V3/Resumable.hs
+++ b/libs/wire-api/src/Wire/API/Asset/V3/Resumable.hs
@@ -46,7 +46,7 @@ import Control.Lens (makeLenses)
 import Data.Aeson
 import Data.Aeson.Types
 import Data.ByteString.Conversion
-import Data.Json.Util ((#), toUTCTimeMillis)
+import Data.Json.Util (toUTCTimeMillis, (#))
 import Data.Time.Clock
 import Imports
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))

--- a/libs/wire-api/src/Wire/API/Call/Config.hs
+++ b/libs/wire-api/src/Wire/API/Call/Config.hs
@@ -282,10 +282,11 @@ instance BC.ToByteString Scheme where
   builder SchemeTurns = "turns"
 
 instance BC.FromByteString Scheme where
-  parser = BC.parser >>= \t -> case (t :: ByteString) of
-    "turn" -> pure SchemeTurn
-    "turns" -> pure SchemeTurns
-    _ -> fail $ "Invalid turn scheme: " ++ show t
+  parser =
+    BC.parser >>= \t -> case (t :: ByteString) of
+      "turn" -> pure SchemeTurn
+      "turns" -> pure SchemeTurns
+      _ -> fail $ "Invalid turn scheme: " ++ show t
 
 instance ToJSON Scheme where
   toJSON = String . TE.decodeUtf8 . BC.toByteString'
@@ -348,10 +349,11 @@ instance BC.ToByteString Transport where
   builder TransportTCP = "tcp"
 
 instance BC.FromByteString Transport where
-  parser = BC.parser >>= \t -> case (t :: ByteString) of
-    "udp" -> pure TransportUDP
-    "tcp" -> pure TransportTCP
-    _ -> fail $ "Invalid turn transport: " ++ show t
+  parser =
+    BC.parser >>= \t -> case (t :: ByteString) of
+      "udp" -> pure TransportUDP
+      "tcp" -> pure TransportTCP
+      _ -> fail $ "Invalid turn transport: " ++ show t
 
 instance ToJSON Transport where
   toJSON = String . TE.decodeUtf8 . BC.toByteString'

--- a/libs/wire-api/src/Wire/API/Connection.hs
+++ b/libs/wire-api/src/Wire/API/Connection.hs
@@ -186,14 +186,15 @@ instance FromJSON Relation where
   parseJSON _ = mzero
 
 instance FromByteString Relation where
-  parser = takeByteString >>= \b -> case b of
-    "accepted" -> return Accepted
-    "blocked" -> return Blocked
-    "pending" -> return Pending
-    "ignored" -> return Ignored
-    "sent" -> return Sent
-    "cancelled" -> return Cancelled
-    x -> fail $ "Invalid relation-type " <> show x
+  parser =
+    takeByteString >>= \b -> case b of
+      "accepted" -> return Accepted
+      "blocked" -> return Blocked
+      "pending" -> return Pending
+      "ignored" -> return Ignored
+      "sent" -> return Sent
+      "cancelled" -> return Cancelled
+      x -> fail $ "Invalid relation-type " <> show x
 
 --------------------------------------------------------------------------------
 -- Message

--- a/libs/wire-api/src/Wire/API/Conversation/Code.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Code.hs
@@ -34,7 +34,7 @@ module Wire.API.Conversation.Code
 where
 
 import Control.Lens ((.~))
-import Data.Aeson ((.:), (.:?), (.=), FromJSON (parseJSON), ToJSON (toJSON))
+import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), (.:), (.:?), (.=))
 import qualified Data.Aeson as JSON
 import Data.ByteString.Conversion (toByteString')
 -- FUTUREWORK: move content of Data.Code here?

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -67,19 +67,18 @@ import Data.Aeson
 import Data.Aeson.Types (Parser)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Id
-import Data.Json.Util ((#), ToJSONObject (toJSONObject), toUTCTimeMillis)
+import Data.Json.Util (ToJSONObject (toJSONObject), toUTCTimeMillis, (#))
 import qualified Data.Swagger.Build.Api as Doc
 import Data.Time
 import Imports
 import qualified Test.QuickCheck as QC
 import URI.ByteString ()
 import Wire.API.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
-import Wire.API.Conversation (modelConversationAccessUpdate, modelConversationMessageTimerUpdate, modelConversationReceiptModeUpdate, modelConversationUpdateName)
 import Wire.API.Conversation
+import Wire.API.Conversation (modelConversationAccessUpdate, modelConversationMessageTimerUpdate, modelConversationReceiptModeUpdate, modelConversationUpdateName)
 import Wire.API.Conversation.Code (ConversationCode (..), modelConversationCode)
 import Wire.API.Conversation.Role
-import Wire.API.Conversation.Typing (modelTyping)
-import Wire.API.Conversation.Typing (TypingData (..))
+import Wire.API.Conversation.Typing (TypingData (..), modelTyping)
 import Wire.API.User (UserIdList (..))
 
 --------------------------------------------------------------------------------
@@ -359,9 +358,9 @@ newtype SimpleMembers = SimpleMembers
 -- | Used both for 'SimpleMembers' and 'UserIdList'.
 modelMembers :: Doc.Model
 modelMembers =
-  Doc.defineModel "Members"
-    $ Doc.property "users" (Doc.unique $ Doc.array Doc.bytes')
-    $ Doc.description "List of user IDs"
+  Doc.defineModel "Members" $
+    Doc.property "users" (Doc.unique $ Doc.array Doc.bytes') $
+      Doc.description "List of user IDs"
 
 instance ToJSON SimpleMembers where
   toJSON e =

--- a/libs/wire-api/src/Wire/API/Event/Team.hs
+++ b/libs/wire-api/src/Wire/API/Event/Team.hs
@@ -98,9 +98,9 @@ modelMemberEvent = Doc.defineModel "TeamMemberEvent" $ do
 
 modelMemberData :: Doc.Model
 modelMemberData =
-  Doc.defineModel "MemberData"
-    $ Doc.property "user" Doc.bytes'
-    $ Doc.description "user ID"
+  Doc.defineModel "MemberData" $
+    Doc.property "user" Doc.bytes' $
+      Doc.description "user ID"
 
 modelConvEvent :: Doc.Model
 modelConvEvent = Doc.defineModel "TeamConversationEvent" $ do
@@ -109,9 +109,9 @@ modelConvEvent = Doc.defineModel "TeamConversationEvent" $ do
 
 modelConversationData :: Doc.Model
 modelConversationData =
-  Doc.defineModel "ConversationData"
-    $ Doc.property "conv" Doc.bytes'
-    $ Doc.description "conversation ID"
+  Doc.defineModel "ConversationData" $
+    Doc.property "conv" Doc.bytes' $
+      Doc.description "conversation ID"
 
 modelUpdateEvent :: Doc.Model
 modelUpdateEvent = Doc.defineModel "TeamUpdateEvent" $ do

--- a/libs/wire-api/src/Wire/API/Notification.hs
+++ b/libs/wire-api/src/Wire/API/Notification.hs
@@ -42,8 +42,8 @@ module Wire.API.Notification
 where
 
 import Control.Lens (makeLenses)
+import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), (.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as JSON
-import Data.Aeson ((.!=), (.:), (.:?), (.=), FromJSON (parseJSON), ToJSON (toJSON))
 import Data.Id
 import Data.Json.Util ((#))
 import Data.List1

--- a/libs/wire-api/src/Wire/API/Provider/Service/Tag.hs
+++ b/libs/wire-api/src/Wire/API/Provider/Service/Tag.hs
@@ -45,8 +45,8 @@ import qualified Data.Aeson as JSON
 import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Char8 as C8
 import Data.ByteString.Conversion
-import qualified Data.Range as Range
 import Data.Range (LTE, Range, fromRange)
+import qualified Data.Range as Range
 import qualified Data.Set as Set
 import qualified Data.Text.Encoding as Text
 import GHC.TypeLits (KnownNat, Nat)
@@ -97,39 +97,40 @@ data ServiceTag
   deriving (Arbitrary) via (GenericUniform ServiceTag)
 
 instance FromByteString ServiceTag where
-  parser = parser >>= \t -> case (t :: ByteString) of
-    "audio" -> pure AudioTag
-    "books" -> pure BooksTag
-    "business" -> pure BusinessTag
-    "design" -> pure DesignTag
-    "education" -> pure EducationTag
-    "entertainment" -> pure EntertainmentTag
-    "finance" -> pure FinanceTag
-    "fitness" -> pure FitnessTag
-    "food-drink" -> pure FoodDrinkTag
-    "games" -> pure GamesTag
-    "graphics" -> pure GraphicsTag
-    "health" -> pure HealthTag
-    "integration" -> pure IntegrationTag
-    "lifestyle" -> pure LifestyleTag
-    "media" -> pure MediaTag
-    "medical" -> pure MedicalTag
-    "movies" -> pure MoviesTag
-    "music" -> pure MusicTag
-    "news" -> pure NewsTag
-    "photography" -> pure PhotographyTag
-    "poll" -> pure PollTag
-    "productivity" -> pure ProductivityTag
-    "quiz" -> pure QuizTag
-    "rating" -> pure RatingTag
-    "shopping" -> pure ShoppingTag
-    "social" -> pure SocialTag
-    "sports" -> pure SportsTag
-    "travel" -> pure TravelTag
-    "tutorial" -> pure TutorialTag
-    "video" -> pure VideoTag
-    "weather" -> pure WeatherTag
-    _ -> fail $ "Invalid tag: " ++ show t
+  parser =
+    parser >>= \t -> case (t :: ByteString) of
+      "audio" -> pure AudioTag
+      "books" -> pure BooksTag
+      "business" -> pure BusinessTag
+      "design" -> pure DesignTag
+      "education" -> pure EducationTag
+      "entertainment" -> pure EntertainmentTag
+      "finance" -> pure FinanceTag
+      "fitness" -> pure FitnessTag
+      "food-drink" -> pure FoodDrinkTag
+      "games" -> pure GamesTag
+      "graphics" -> pure GraphicsTag
+      "health" -> pure HealthTag
+      "integration" -> pure IntegrationTag
+      "lifestyle" -> pure LifestyleTag
+      "media" -> pure MediaTag
+      "medical" -> pure MedicalTag
+      "movies" -> pure MoviesTag
+      "music" -> pure MusicTag
+      "news" -> pure NewsTag
+      "photography" -> pure PhotographyTag
+      "poll" -> pure PollTag
+      "productivity" -> pure ProductivityTag
+      "quiz" -> pure QuizTag
+      "rating" -> pure RatingTag
+      "shopping" -> pure ShoppingTag
+      "social" -> pure SocialTag
+      "sports" -> pure SportsTag
+      "travel" -> pure TravelTag
+      "tutorial" -> pure TutorialTag
+      "video" -> pure VideoTag
+      "weather" -> pure WeatherTag
+      _ -> fail $ "Invalid tag: " ++ show t
 
 instance ToByteString ServiceTag where
   builder AudioTag = "audio"

--- a/libs/wire-api/src/Wire/API/Push/V2/Token.hs
+++ b/libs/wire-api/src/Wire/API/Push/V2/Token.hs
@@ -156,13 +156,14 @@ instance FromJSON Transport where
     x -> fail $ "Invalid push transport: " ++ show x
 
 instance FromByteString Transport where
-  parser = takeByteString >>= \case
-    "GCM" -> return GCM
-    "APNS" -> return APNS
-    "APNS_SANDBOX" -> return APNSSandbox
-    "APNS_VOIP" -> return APNSVoIP
-    "APNS_VOIP_SANDBOX" -> return APNSVoIPSandbox
-    x -> fail $ "Invalid push transport: " <> show x
+  parser =
+    takeByteString >>= \case
+      "GCM" -> return GCM
+      "APNS" -> return APNS
+      "APNS_SANDBOX" -> return APNSSandbox
+      "APNS_VOIP" -> return APNSVoIP
+      "APNS_VOIP_SANDBOX" -> return APNSVoIPSandbox
+      x -> fail $ "Invalid push transport: " <> show x
 
 newtype Token = Token
   { tokenText :: Text

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -51,15 +51,16 @@ data TeamFeatureName
   deriving (Arbitrary) via (GenericUniform TeamFeatureName)
 
 instance FromByteString TeamFeatureName where
-  parser = Parser.takeByteString >>= \b ->
-    case T.decodeUtf8' b of
-      Left e -> fail $ "Invalid TeamFeatureName: " <> show e
-      Right "legalhold" -> pure TeamFeatureLegalHold
-      Right "sso" -> pure TeamFeatureSSO
-      Right "search-visibility" -> pure TeamFeatureSearchVisibility
-      Right "validate-saml-emails" -> pure TeamFeatureValidateSAMLEmails
-      Right "digital-signatures" -> pure TeamFeatureDigitalSignatures
-      Right t -> fail $ "Invalid TeamFeatureName: " <> T.unpack t
+  parser =
+    Parser.takeByteString >>= \b ->
+      case T.decodeUtf8' b of
+        Left e -> fail $ "Invalid TeamFeatureName: " <> show e
+        Right "legalhold" -> pure TeamFeatureLegalHold
+        Right "sso" -> pure TeamFeatureSSO
+        Right "search-visibility" -> pure TeamFeatureSearchVisibility
+        Right "validate-saml-emails" -> pure TeamFeatureValidateSAMLEmails
+        Right "digital-signatures" -> pure TeamFeatureDigitalSignatures
+        Right t -> fail $ "Invalid TeamFeatureName: " <> T.unpack t
 
 instance ToByteString TeamFeatureName where
   builder TeamFeatureLegalHold = "legalhold"
@@ -121,9 +122,10 @@ instance ToByteString TeamFeatureStatusValue where
   builder TeamFeatureDisabled = "disabled"
 
 instance FromByteString TeamFeatureStatusValue where
-  parser = Parser.takeByteString >>= \b ->
-    case T.decodeUtf8' b of
-      Right "enabled" -> pure TeamFeatureEnabled
-      Right "disabled" -> pure TeamFeatureDisabled
-      Right t -> fail $ "Invalid TeamFeatureStatusValue: " <> T.unpack t
-      Left e -> fail $ "Invalid TeamFeatureStatusValue: " <> show e
+  parser =
+    Parser.takeByteString >>= \b ->
+      case T.decodeUtf8' b of
+        Right "enabled" -> pure TeamFeatureEnabled
+        Right "disabled" -> pure TeamFeatureDisabled
+        Right t -> fail $ "Invalid TeamFeatureStatusValue: " <> T.unpack t
+        Left e -> fail $ "Invalid TeamFeatureStatusValue: " <> show e

--- a/libs/wire-api/src/Wire/API/Team/Permission.hs
+++ b/libs/wire-api/src/Wire/API/Team/Permission.hs
@@ -44,9 +44,9 @@ where
 
 import qualified Cassandra as Cql
 import qualified Control.Error.Util as Err
-import Control.Lens ((^.), makeLenses)
+import Control.Lens (makeLenses, (^.))
 import Data.Aeson
-import Data.Bits ((.|.), testBit)
+import Data.Bits (testBit, (.|.))
 import Data.Json.Util
 import qualified Data.Set as Set
 import qualified Data.Swagger.Build.Api as Doc
@@ -89,10 +89,11 @@ instance FromJSON Permissions where
       Just ps -> pure ps
 
 instance Arbitrary Permissions where
-  arbitrary = maybe (error "instance Arbitrary Permissions") pure =<< do
-    selfperms <- arbitrary
-    copyperms <- Set.intersection selfperms <$> arbitrary
-    pure $ newPermissions selfperms copyperms
+  arbitrary =
+    maybe (error "instance Arbitrary Permissions") pure =<< do
+      selfperms <- arbitrary
+      copyperms <- Set.intersection selfperms <$> arbitrary
+      pure $ newPermissions selfperms copyperms
 
 newPermissions ::
   -- | User's permissions

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -96,7 +96,7 @@ import qualified Data.Currency as Currency
 import Data.Handle (Handle)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Id
-import Data.Json.Util ((#), UTCTimeMillis)
+import Data.Json.Util (UTCTimeMillis, (#))
 import Data.Misc (PlainTextPassword (..))
 import Data.Range
 import qualified Data.Swagger.Build.Api as Doc

--- a/libs/wire-api/src/Wire/API/User/Client.hs
+++ b/libs/wire-api/src/Wire/API/User/Client.hs
@@ -124,9 +124,9 @@ newtype UserClients = UserClients
 
 modelUserClients :: Doc.Model
 modelUserClients =
-  Doc.defineModel "UserClients"
-    $ Doc.property "" (Doc.unique $ Doc.array Doc.bytes')
-    $ Doc.description "Map of user IDs to sets of client IDs ({ UserId: [ClientId] })."
+  Doc.defineModel "UserClients" $
+    Doc.property "" (Doc.unique $ Doc.array Doc.bytes') $
+      Doc.description "Map of user IDs to sets of client IDs ({ UserId: [ClientId] })."
 
 instance ToJSON UserClients where
   toJSON =
@@ -256,12 +256,15 @@ instance FromJSON PubClient where
 -- team on a per-user basis
 
 -- * A LegalHoldClient is a client outside that user's control (but under the
+
 --   control of that team's business)
 
 -- * Users need to click "accept" before a LegalHoldClient is added to their
+
 --   account.
 
 -- * Any user interacting with a user which has a LegalHoldClient will upon
+
 --   first interaction receive a warning, have the option of cancelling the
 --   interaction, and on an ongoing basis see a visual indication in all
 --   conversations where such a device is active.

--- a/libs/wire-api/src/Wire/API/User/Identity.hs
+++ b/libs/wire-api/src/Wire/API/User/Identity.hs
@@ -219,11 +219,12 @@ instance FromByteString Phone where
   parser = parser >>= maybe (fail "Invalid phone") return . parsePhone
 
 instance Arbitrary Phone where
-  arbitrary = Phone . Text.pack <$> do
-    let mkdigits n = replicateM n (QC.elements ['0' .. '9'])
-    mini <- mkdigits 8
-    maxi <- mkdigits =<< QC.chooseInt (0, 7)
-    pure $ '+' : mini <> maxi
+  arbitrary =
+    Phone . Text.pack <$> do
+      let mkdigits n = replicateM n (QC.elements ['0' .. '9'])
+      mini <- mkdigits 8
+      maxi <- mkdigits =<< QC.chooseInt (0, 7)
+      pure $ '+' : mini <> maxi
 
 -- | Parses a phone number in E.164 format with a mandatory leading '+'.
 parsePhone :: Text -> Maybe Phone

--- a/libs/wire-api/src/Wire/API/User/Profile.hs
+++ b/libs/wire-api/src/Wire/API/User/Profile.hs
@@ -271,9 +271,10 @@ typeManagedBy =
       ]
 
 instance ToJSON ManagedBy where
-  toJSON = String . \case
-    ManagedByWire -> "wire"
-    ManagedByScim -> "scim"
+  toJSON =
+    String . \case
+      ManagedByWire -> "wire"
+      ManagedByScim -> "scim"
 
 instance FromJSON ManagedBy where
   parseJSON = withText "ManagedBy" $ \case

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
@@ -23,7 +23,7 @@ import Data.Id (ConvId)
 import Imports
 import qualified Test.Tasty as T
 import Test.Tasty.ExpectedFailure (ignoreTest)
-import Test.Tasty.QuickCheck ((===), Arbitrary, counterexample, testProperty)
+import Test.Tasty.QuickCheck (Arbitrary, counterexample, testProperty, (===))
 import Type.Reflection (typeRep)
 import qualified Wire.API.Asset as Asset
 import qualified Wire.API.Asset.V3.Resumable as Asset.Resumable

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/ByteString.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/ByteString.hs
@@ -20,7 +20,7 @@ module Test.Wire.API.Roundtrip.ByteString (tests) where
 import Data.ByteString.Conversion
 import Imports
 import qualified Test.Tasty as T
-import Test.Tasty.QuickCheck ((===), Arbitrary, counterexample, testProperty)
+import Test.Tasty.QuickCheck (Arbitrary, counterexample, testProperty, (===))
 import Type.Reflection (typeRep)
 import qualified Wire.API.Arbitrary as Arbitrary ()
 import qualified Wire.API.Asset.V3 as Asset.V3

--- a/libs/zauth/main/Main.hs
+++ b/libs/zauth/main/Main.hs
@@ -179,15 +179,16 @@ options =
         long "data"
           <> metavar "STRING"
           <> help "token data"
-    toMode = readerAsk >>= \s -> case s of
-      "create-user" -> return CreateUser
-      "create-session" -> return CreateSession
-      "create-access" -> return CreateAccess
-      "create-bot" -> return CreateBot
-      "create-provider" -> return CreateProvider
-      "verify-user" -> return VerifyUser
-      "verify-access" -> return VerifyAccess
-      "verify-bot" -> return VerifyBot
-      "verify-provider" -> return VerifyProvider
-      "gen-keypair" -> return GenKeyPair
-      other -> readerError $ "invalid mode: " <> other
+    toMode =
+      readerAsk >>= \s -> case s of
+        "create-user" -> return CreateUser
+        "create-session" -> return CreateSession
+        "create-access" -> return CreateAccess
+        "create-bot" -> return CreateBot
+        "create-provider" -> return CreateProvider
+        "verify-user" -> return VerifyUser
+        "verify-access" -> return VerifyAccess
+        "verify-bot" -> return VerifyBot
+        "verify-provider" -> return VerifyProvider
+        "gen-keypair" -> return GenKeyPair
+        other -> readerError $ "invalid mode: " <> other

--- a/libs/zauth/src/Data/ZAuth/Creation.hs
+++ b/libs/zauth/src/Data/ZAuth/Creation.hs
@@ -53,7 +53,7 @@ import Data.ByteString.Conversion
 import Data.ByteString.Lazy (toStrict)
 import Data.Time.Clock.POSIX
 import Data.UUID
-import Data.Vector ((!), Vector)
+import Data.Vector (Vector, (!))
 import qualified Data.Vector as Vec
 import Data.ZAuth.Token hiding (signature)
 import Imports

--- a/libs/zauth/src/Data/ZAuth/Token.hs
+++ b/libs/zauth/src/Data/ZAuth/Token.hs
@@ -185,40 +185,46 @@ makeLenses ''LegalHoldUser
 makeLenses ''LegalHoldAccess
 
 instance FromByteString (Token Access) where
-  parser = takeLazyByteString >>= \b ->
-    case readToken A readAccessBody b of
-      Nothing -> fail "Invalid access token"
-      Just t -> return t
+  parser =
+    takeLazyByteString >>= \b ->
+      case readToken A readAccessBody b of
+        Nothing -> fail "Invalid access token"
+        Just t -> return t
 
 instance FromByteString (Token User) where
-  parser = takeLazyByteString >>= \b ->
-    case readToken U readUserBody b of
-      Nothing -> fail "Invalid user token"
-      Just t -> return t
+  parser =
+    takeLazyByteString >>= \b ->
+      case readToken U readUserBody b of
+        Nothing -> fail "Invalid user token"
+        Just t -> return t
 
 instance FromByteString (Token Bot) where
-  parser = takeLazyByteString >>= \b ->
-    case readToken B readBotBody b of
-      Nothing -> fail "Invalid bot token"
-      Just t -> return t
+  parser =
+    takeLazyByteString >>= \b ->
+      case readToken B readBotBody b of
+        Nothing -> fail "Invalid bot token"
+        Just t -> return t
 
 instance FromByteString (Token Provider) where
-  parser = takeLazyByteString >>= \b ->
-    case readToken P readProviderBody b of
-      Nothing -> fail "Invalid provider token"
-      Just t -> return t
+  parser =
+    takeLazyByteString >>= \b ->
+      case readToken P readProviderBody b of
+        Nothing -> fail "Invalid provider token"
+        Just t -> return t
 
 instance FromByteString (Token LegalHoldAccess) where
-  parser = takeLazyByteString >>= \b ->
-    case readToken LA readLegalHoldAccessBody b of
-      Nothing -> fail "Invalid access token"
-      Just t -> return t
+  parser =
+    takeLazyByteString >>= \b ->
+      case readToken LA readLegalHoldAccessBody b of
+        Nothing -> fail "Invalid access token"
+        Just t -> return t
 
 instance FromByteString (Token LegalHoldUser) where
-  parser = takeLazyByteString >>= \b ->
-    case readToken LU readLegalHoldUserBody b of
-      Nothing -> fail "Invalid user token"
-      Just t -> return t
+  parser =
+    takeLazyByteString >>= \b ->
+      case readToken LU readLegalHoldUserBody b of
+        Nothing -> fail "Invalid user token"
+        Just t -> return t
 
 instance ToByteString a => ToByteString (Token a) where
   builder = writeToken

--- a/libs/zauth/src/Data/ZAuth/Validation.hs
+++ b/libs/zauth/src/Data/ZAuth/Validation.hs
@@ -37,7 +37,7 @@ import Control.Monad.Except
 import qualified Data.ByteString as Strict
 import Data.ByteString.Conversion
 import Data.Time.Clock.POSIX
-import Data.Vector ((!), Vector)
+import Data.Vector (Vector, (!))
 import qualified Data.Vector as Vec
 import Data.ZAuth.Token
 import Imports

--- a/services/brig/schema/src/V42.hs
+++ b/services/brig/schema/src/V42.hs
@@ -26,9 +26,9 @@ import Text.RawString.QQ
 
 migration :: Migration
 migration =
-  Migration 42 "Remove user.tracking_id"
-    $ void
-    $ schema'
-      [r|
+  Migration 42 "Remove user.tracking_id" $
+    void $
+      schema'
+        [r|
        alter columnfamily user drop tracking_id;
        |]

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -57,8 +57,8 @@ import Control.Lens (view)
 import Data.Bitraversable (bitraverse)
 import Data.ByteString.Conversion
 import Data.IP (IP)
-import qualified Data.Id as Id
 import Data.Id (ClientId, ConnId, UserId, makeIdOpaque, makeMappedIdOpaque)
+import qualified Data.Id as Id
 import Data.IdMapping
 import Data.List.NonEmpty (nonEmpty)
 import Data.List.Split (chunksOf)
@@ -108,10 +108,10 @@ addClient u con ip new = do
     Intra.newClient u (clientId clt)
     Intra.onClientEvent u con (ClientAdded u clt)
     when (clientType clt == LegalHoldClientType) $ Intra.onUserEvent u con (UserLegalHoldEnabled u)
-    when (count > 1)
-      $ for_ (userEmail usr)
-      $ \email ->
-        sendNewClientEmail (userDisplayName usr) email clt (userLocale usr)
+    when (count > 1) $
+      for_ (userEmail usr) $
+        \email ->
+          sendNewClientEmail (userDisplayName usr) email clt (userLocale usr)
   return clt
   where
     clientId' = clientIdFromPrekey (unpackLastPrekey $ newClientLastKey new)

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -209,7 +209,7 @@ updateConnection self other newStatus conn = do
     (old, _, new)
       | old == new -> return Nothing
     _ -> throwE $ InvalidTransition self newStatus
-  lift $ for_ s2o' $ \c ->
+  lift . for_ s2o' $ \c ->
     let e2s = ConnectionUpdated c (Just $ ucStatus s2o) Nothing
      in Intra.onConnectionEvent self conn e2s
   return s2o'
@@ -219,12 +219,12 @@ updateConnection self other newStatus conn = do
       Log.info $
         Log.connection self (ucTo s2o)
           . msg (val "Accepting connection")
-      cnv <- lift $ for (ucConvId s2o) $ Intra.acceptConnectConv self conn
+      cnv <- lift . for (ucConvId s2o) $ Intra.acceptConnectConv self conn
       -- Note: The check for @Pending@ accounts for situations in which both
       --       sides are pending, which can occur due to rare race conditions
       --       when sending mutual connection requests, combined with untimely
       --       crashes.
-      when (ucStatus o2s `elem` [Sent, Pending]) $ lift $ do
+      when (ucStatus o2s `elem` [Sent, Pending]) . lift $ do
         o2s' <-
           if (cnvType <$> cnv) /= Just ConnectConv
             then Data.updateConnection o2s Accepted
@@ -244,8 +244,8 @@ updateConnection self other newStatus conn = do
       Log.info $
         Log.connection self (ucTo s2o)
           . msg (val "Unblocking connection")
-      cnv <- lift $ for (ucConvId s2o) $ Intra.unblockConv (ucFrom s2o) conn
-      when (ucStatus o2s == Sent && new == Accepted) $ lift $ do
+      cnv <- lift . for (ucConvId s2o) $ Intra.unblockConv (ucFrom s2o) conn
+      when (ucStatus o2s == Sent && new == Accepted) . lift $ do
         o2s' <-
           if (cnvType <$> cnv) /= Just ConnectConv
             then Data.updateConnection o2s Accepted
@@ -257,7 +257,7 @@ updateConnection self other newStatus conn = do
       Log.info $
         Log.connection self (ucTo s2o)
           . msg (val "Cancelling connection")
-      lift $ for_ (ucConvId s2o) $ Intra.blockConv (ucFrom s2o) conn
+      lift . for_ (ucConvId s2o) $ Intra.blockConv (ucFrom s2o) conn
       o2s' <- lift $ Data.updateConnection o2s Cancelled
       let e2o = ConnectionUpdated o2s' (Just $ ucStatus o2s) Nothing
       lift $ Intra.onConnectionEvent self conn e2o

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -77,16 +77,16 @@ createConnectionToLocalUser ::
   ConnId ->
   ExceptT ConnectionError AppIO ConnectionResult
 createConnectionToLocalUser self crUser ConnectionRequest {crName, crMessage} conn = do
-  when (self == crUser)
-    $ throwE
-    $ InvalidUser (makeIdOpaque crUser)
+  when (self == crUser) $
+    throwE $
+      InvalidUser (makeIdOpaque crUser)
   selfActive <- lift $ Data.isActivated self
   unless selfActive $
     throwE ConnectNoIdentity
   otherActive <- lift $ Data.isActivated crUser
-  unless otherActive
-    $ throwE
-    $ InvalidUser (makeIdOpaque crUser)
+  unless otherActive $
+    throwE $
+      InvalidUser (makeIdOpaque crUser)
   -- Users belonging to the same team are always treated as connected, so creating a
   -- connection between them is useless. {#RefConnectionTeam}
   sameTeam <- lift $ belongSameTeam
@@ -321,6 +321,6 @@ checkLimit :: UserId -> ExceptT ConnectionError AppIO ()
 checkLimit u = do
   n <- lift $ Data.countConnections u [Accepted, Sent]
   l <- setUserMaxConnections <$> view settings
-  unless (n < l)
-    $ throwE
-    $ TooManyConnections u
+  unless (n < l) $
+    throwE $
+      TooManyConnections u

--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -79,10 +79,10 @@ onError :: Logger -> Request -> Continue IO -> Error -> IO ResponseReceived
 onError g r k e = do
   Server.logError g (Just r) we
   Server.flushRequestBody r
-  k
-    $ setStatus (WaiError.code we)
+  k $
+    setStatus (WaiError.code we)
       . appEndo (foldMap (Endo . uncurry addHeader) hs)
-    $ json e
+      $ json e
   where
     (we, hs) = case e of
       StdError x -> (x, [])

--- a/services/brig/src/Brig/API/IdMapping.hs
+++ b/services/brig/src/Brig/API/IdMapping.hs
@@ -32,15 +32,15 @@ import Brig.App (AppIO)
 import qualified Brig.Data.IdMapping as Data (getIdMapping, insertIdMapping)
 import qualified Brig.IO.Intra.IdMapping as Intra
 import Control.Monad.Catch (throwM)
-import qualified Data.Id as Id
 import Data.Id (Id (Id, toUUID), OpaqueUserId, idToText)
+import qualified Data.Id as Id
 import Data.IdMapping (IdMapping (IdMapping, _imQualifiedId), MappedOrLocalId (Local, Mapped), hashQualifiedId)
 import Data.Qualified (Qualified, renderQualifiedId)
 import Galley.Types.IdMapping (PostIdMappingRequest (PostIdMappingRequest), PostIdMappingResponse (PostIdMappingResponse), mkPostIdMappingRequest)
 import Imports
 import Network.HTTP.Types (forbidden403, notFound404)
 import Network.Wai (Response)
-import Network.Wai.Predicate ((.&.), (:::) ((:::)), accept)
+import Network.Wai.Predicate (accept, (.&.), (:::) ((:::)))
 import Network.Wai.Routing (Routes, capture, continue, get, post)
 import Network.Wai.Utilities (JsonRequest, empty, json, jsonRequest, setStatus)
 import qualified System.Logger.Class as Log
@@ -147,12 +147,12 @@ createIdMapping qualifiedId = do
       let idMapping = IdMapping mappedId qualifiedId
       Data.getIdMapping mappedId >>= \case
         Just existingMapping ->
-          when (_imQualifiedId existingMapping /= qualifiedId)
-            $ Log.err
-            $ Log.msg @Text "Conflict when creating IdMapping"
-              . Log.field "mapped_id" (idToText mappedId)
-              . Log.field "existing_qualified_id" (renderQualifiedId qualifiedId)
-              . Log.field "new_qualified_id" (renderQualifiedId (_imQualifiedId existingMapping))
+          when (_imQualifiedId existingMapping /= qualifiedId) $
+            Log.err $
+              Log.msg @Text "Conflict when creating IdMapping"
+                . Log.field "mapped_id" (idToText mappedId)
+                . Log.field "existing_qualified_id" (renderQualifiedId qualifiedId)
+                . Log.field "new_qualified_id" (renderQualifiedId (_imQualifiedId existingMapping))
         Nothing -> do
           Data.insertIdMapping idMapping
           Intra.createIdMappingInGalley (mkPostIdMappingRequest qualifiedId)

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -257,12 +257,12 @@ autoConnectH (_ ::: uid ::: conn ::: req) = do
 autoConnect :: UserId -> Maybe ConnId -> UserSet -> Handler [UserConnection]
 autoConnect uid conn (UserSet to) = do
   let num = Set.size to
-  when (num < 1)
-    $ throwStd
-    $ badRequest "No users given for auto-connect."
-  when (num > 25)
-    $ throwStd
-    $ badRequest "Too many users given for auto-connect (> 25)."
+  when (num < 1) $
+    throwStd $
+      badRequest "No users given for auto-connect."
+  when (num > 25) $
+    throwStd $
+      badRequest "Too many users given for auto-connect (> 25)."
   API.autoConnect uid to conn !>> connError
 
 createUserNoVerifyH :: JSON ::: JsonRequest NewUser -> Handler Response

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -45,7 +45,7 @@ import qualified Brig.User.Auth.Cookie as Auth
 import Brig.User.Email
 import Brig.User.Phone
 import Control.Error hiding (bool)
-import Control.Lens ((^.), view)
+import Control.Lens (view, (^.))
 import Control.Monad.Catch (throwM)
 import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
@@ -55,7 +55,7 @@ import Data.Handle (Handle, parseHandle)
 import Data.Id as Id
 import Data.IdMapping (MappedOrLocalId (Local))
 import qualified Data.Map.Strict as Map
-import Data.Misc ((<$$>), IpAddr (..))
+import Data.Misc (IpAddr (..), (<$$>))
 import Data.Qualified (OptionallyQualified, eitherQualifiedOrNot)
 import Data.Range
 import qualified Data.Swagger.Build.Api as Doc
@@ -1152,7 +1152,8 @@ checkHandle :: UserId -> Text -> Handler CheckHandleResp
 checkHandle _ uhandle = do
   handle <- validateHandle uhandle
   owner <- lift $ API.lookupHandle handle
-  if  | isJust owner ->
+  if
+      | isJust owner ->
         -- Handle is taken (=> getHandleInfo will return 200)
         return CheckHandleFound
       | API.isBlacklistedHandle handle ->

--- a/services/brig/src/Brig/AWS.hs
+++ b/services/brig/src/Brig/AWS.hs
@@ -182,7 +182,7 @@ listen throttleMillis url callback = forever . handleAny unexpectedError $ do
     receive =
       SQS.receiveMessage url
         & set SQS.rmWaitTimeSeconds (Just 20)
-        . set SQS.rmMaxNumberOfMessages (Just 10)
+          . set SQS.rmMaxNumberOfMessages (Just 10)
     onMessage m =
       case decodeStrict =<< Text.encodeUtf8 <$> m ^. mBody of
         Nothing -> err $ msg ("Failed to parse SQS event: " ++ show m)
@@ -252,9 +252,9 @@ execCatch ::
   a ->
   m (Either AWS.Error (Rs a))
 execCatch e cmd =
-  runResourceT . AWST.runAWST e
-    $ AWST.trying AWS._Error
-    $ AWST.send cmd
+  runResourceT . AWST.runAWST e $
+    AWST.trying AWS._Error $
+      AWST.send cmd
 
 exec ::
   (AWSRequest a, AWS.HasEnv r, MonadUnliftIO m, MonadCatch m, MonadThrow m, MonadIO m) =>

--- a/services/brig/src/Brig/AWS.hs
+++ b/services/brig/src/Brig/AWS.hs
@@ -102,7 +102,7 @@ newtype Amazon a = Amazon
     )
 
 instance MonadUnliftIO Amazon where
-  askUnliftIO = Amazon $ ReaderT $ \r ->
+  askUnliftIO = Amazon . ReaderT $ \r ->
     withUnliftIO $ \u ->
       return (UnliftIO (unliftIO u . flip runReaderT r . unAmazon))
 
@@ -173,7 +173,7 @@ instance Exception Error
 -- SQS
 
 listen :: (FromJSON a, Show a) => Int -> Text -> (a -> IO ()) -> Amazon ()
-listen throttleMillis url callback = forever $ handleAny unexpectedError $ do
+listen throttleMillis url callback = forever . handleAny unexpectedError $ do
   msgs <- view rmrsMessages <$> send receive
   void $ mapConcurrently onMessage msgs
   when (null msgs) $

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -474,7 +474,7 @@ instance Monad m => HasRequestId (AppT m) where
 
 instance MonadUnliftIO m => MonadUnliftIO (AppT m) where
   withRunInIO inner =
-    AppT $ ReaderT $ \r ->
+    AppT . ReaderT $ \r ->
       withRunInIO $ \run ->
         inner (run . flip runReaderT r . unAppT)
 

--- a/services/brig/src/Brig/Calling/API.hs
+++ b/services/brig/src/Brig/Calling/API.hs
@@ -42,7 +42,7 @@ import Data.Text.Strict.Lens
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Imports hiding (head)
 import Network.Wai (Response)
-import Network.Wai.Predicate hiding ((#), and, result, setStatus)
+import Network.Wai.Predicate hiding (and, result, setStatus, (#))
 import Network.Wai.Routing hiding (toList)
 import Network.Wai.Utilities hiding (code, message)
 import Network.Wai.Utilities.Swagger (document)

--- a/services/brig/src/Brig/Data/Activation.hs
+++ b/services/brig/src/Brig/Data/Activation.hs
@@ -118,9 +118,9 @@ activateKey k c u = verifyCode k c >>= pickUser >>= activate
         return . Just $ foldKey (EmailActivated uid) (PhoneActivated uid) key
     claim key uid = do
       ok <- lift $ claimKey key uid
-      unless ok
-        $ throwE . UserKeyExists . LT.fromStrict
-        $ foldKey fromEmail fromPhone key
+      unless ok $
+        throwE . UserKeyExists . LT.fromStrict $
+          foldKey fromEmail fromPhone key
 
 -- | Create a new pending activation for a given 'UserKey'.
 newActivation ::
@@ -162,7 +162,8 @@ verifyCode key code = do
   s <- lift . retry x1 . query1 keySelect $ params Quorum (Identity key)
   case s of
     Just (ttl, Ascii t, k, c, u, r) ->
-      if  | c == code -> mkScope t k u
+      if
+          | c == code -> mkScope t k u
           | r >= 1 -> countdown (key, t, k, c, u, r -1, ttl) >> throwE invalidCode
           | otherwise -> revoke >> throwE invalidCode
     Nothing -> throwE invalidCode

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -91,9 +91,9 @@ addClient u newId c maxPermClients loc = do
   let typed = filter ((== newClientType c) . clientType) clients
   let count = length typed
   let upsert = any exists typed
-  unless (count == 0 || upsert)
-    $ fmapLT ClientReAuthError
-    $ User.reauthenticate u (newClientPassword c)
+  unless (count == 0 || upsert) $
+    fmapLT ClientReAuthError $
+      User.reauthenticate u (newClientPassword c)
   let capacity = fmap (+ (- count)) limit
   unless (maybe True (> 0) capacity || upsert) $
     throwE TooManyClients

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -37,7 +37,7 @@ import Brig.Data.Types as T
 import Brig.Types
 import Brig.Types.Intra
 import Cassandra
-import Data.Conduit ((.|), runConduit)
+import Data.Conduit (runConduit, (.|))
 import qualified Data.Conduit.List as C
 import Data.Id
 import Data.Json.Util (UTCTimeMillis, toUTCTimeMillis)
@@ -97,9 +97,10 @@ lookupConnection from to =
 
 -- | For a given user 'A', lookup his outgoing connections (A -> X) to other users.
 lookupConnections :: UserId -> Maybe UserId -> Range 1 500 Int32 -> AppIO (ResultPage UserConnection)
-lookupConnections from start (fromRange -> size) = toResult <$> case start of
-  Just u -> retry x1 $ paginate connectionsSelectFrom (paramsP Quorum (from, u) (size + 1))
-  Nothing -> retry x1 $ paginate connectionsSelect (paramsP Quorum (Identity from) (size + 1))
+lookupConnections from start (fromRange -> size) =
+  toResult <$> case start of
+    Just u -> retry x1 $ paginate connectionsSelectFrom (paramsP Quorum (from, u) (size + 1))
+    Nothing -> retry x1 $ paginate connectionsSelect (paramsP Quorum (Identity from) (size + 1))
   where
     toResult = cassandraResultPage . fmap toUserConnection . trim
     trim p = p {result = take (fromIntegral size) (result p)}

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -49,13 +49,13 @@ import UnliftIO.Async (pooledMapConcurrentlyN_)
 connectUsers :: UserId -> [(UserId, ConvId)] -> AppIO [UserConnection]
 connectUsers from to = do
   now <- toUTCTimeMillis <$> liftIO getCurrentTime
-  retry x5 $ batch $ do
+  retry x5 . batch $ do
     setType BatchLogged
     setConsistency Quorum
     forM_ to $ \(u, c) -> do
       addPrepQuery connectionInsert (from, u, Accepted, now, Nothing, c)
       addPrepQuery connectionInsert (u, from, Accepted, now, Nothing, c)
-  return $ concat $ (`map` to) $ \(u, c) ->
+  return . concat . (`map` to) $ \(u, c) ->
     [ UserConnection from u Accepted now Nothing (Just c),
       UserConnection u from Accepted now Nothing (Just c)
     ]

--- a/services/brig/src/Brig/Data/IdMapping.hs
+++ b/services/brig/src/Brig/Data/IdMapping.hs
@@ -33,8 +33,9 @@ import Imports
 -- | Only a single namespace/table is used for for potentially multiple different types of
 -- mapped IDs.
 getIdMapping :: Id (Mapped a) -> AppIO (Maybe (IdMapping a))
-getIdMapping mappedId = fmap toIdMapping <$> do
-  retry x1 $ query1 idMappingSelect (params Quorum (Identity mappedId))
+getIdMapping mappedId =
+  fmap toIdMapping <$> do
+    retry x1 $ query1 idMappingSelect (params Quorum (Identity mappedId))
   where
     toIdMapping (remoteId, domain) =
       IdMapping mappedId (Qualified remoteId domain)

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -177,7 +177,7 @@ insertAccount ::
   -- | Whether the user is activated
   Bool ->
   AppIO ()
-insertAccount (UserAccount u status) mbConv password activated = retry x5 $ batch $ do
+insertAccount (UserAccount u status) mbConv password activated = retry x5 . batch $ do
   setType BatchLogged
   setConsistency Quorum
   let Locale l c = userLocale u
@@ -223,7 +223,7 @@ updateLocale :: UserId -> Locale -> AppIO ()
 updateLocale u (Locale l c) = write userLocaleUpdate (params Quorum (l, c, u))
 
 updateUser :: UserId -> UserUpdate -> AppIO ()
-updateUser u UserUpdate {..} = retry x5 $ batch $ do
+updateUser u UserUpdate {..} = retry x5 . batch $ do
   setType BatchLogged
   setConsistency Quorum
   for_ uupName $ \n -> addPrepQuery userDisplayNameUpdate (n, u)
@@ -270,7 +270,7 @@ deleteServiceUser :: ProviderId -> ServiceId -> BotId -> AppIO ()
 deleteServiceUser pid sid bid = do
   lookupServiceUser pid sid bid >>= \case
     Nothing -> pure ()
-    Just (_, mbTid) -> retry x5 $ batch $ do
+    Just (_, mbTid) -> retry x5 . batch $ do
       setType BatchLogged
       setConsistency Quorum
       addPrepQuery cql (pid, sid, bid)

--- a/services/brig/src/Brig/Email.hs
+++ b/services/brig/src/Brig/Email.hs
@@ -50,9 +50,10 @@ import Network.Mail.Mime
 
 -------------------------------------------------------------------------------
 sendMail :: Mail -> AppIO ()
-sendMail m = view smtpEnv >>= \case
-  Just smtp -> SMTP.sendMail smtp m
-  Nothing -> view awsEnv >>= \e -> AWS.execute e $ AWS.sendMail m
+sendMail m =
+  view smtpEnv >>= \case
+    Just smtp -> SMTP.sendMail smtp m
+    Nothing -> view awsEnv >>= \e -> AWS.execute e $ AWS.sendMail m
 
 -------------------------------------------------------------------------------
 -- Unique Keys

--- a/services/brig/src/Brig/IO/Journal.hs
+++ b/services/brig/src/Brig/IO/Journal.hs
@@ -60,17 +60,18 @@ userDelete :: UserId -> AppIO ()
 userDelete uid = journalEvent UserEvent'USER_DELETE uid Nothing Nothing Nothing Nothing
 
 journalEvent :: UserEvent'EventType -> UserId -> Maybe Email -> Maybe Locale -> Maybe TeamId -> Maybe Name -> AppIO ()
-journalEvent typ uid em loc tid nm = view awsEnv >>= \env -> for_ (view AWS.userJournalQueue env) $ \queue -> do
-  ts <- now
-  rnd <- liftIO nextRandom
-  let userEvent :: UserEvent =
-        defMessage
-          & U.eventType .~ typ
-          & U.userId .~ (toBytes uid)
-          & U.utcTime .~ ts
-          & U.maybe'email .~ (toByteString' <$> em)
-          & U.maybe'locale .~ (pack . show <$> loc)
-          & U.maybe'teamId .~ (toBytes <$> tid)
-          & U.maybe'name .~ (toByteString' <$> nm) -- []
-      encoded = fromStrict $ B64.encode $ encodeMessage userEvent
-  AWS.execute env (AWS.enqueueFIFO queue "user.events" rnd encoded)
+journalEvent typ uid em loc tid nm =
+  view awsEnv >>= \env -> for_ (view AWS.userJournalQueue env) $ \queue -> do
+    ts <- now
+    rnd <- liftIO nextRandom
+    let userEvent :: UserEvent =
+          defMessage
+            & U.eventType .~ typ
+            & U.userId .~ (toBytes uid)
+            & U.utcTime .~ ts
+            & U.maybe'email .~ (toByteString' <$> em)
+            & U.maybe'locale .~ (pack . show <$> loc)
+            & U.maybe'teamId .~ (toBytes <$> tid)
+            & U.maybe'name .~ (toByteString' <$> nm) -- []
+        encoded = fromStrict $ B64.encode $ encodeMessage userEvent
+    AWS.execute env (AWS.enqueueFIFO queue "user.events" rnd encoded)

--- a/services/brig/src/Brig/Index/Eval.hs
+++ b/services/brig/src/Brig/Index/Eval.hs
@@ -99,13 +99,13 @@ runCommand l = \case
       ES.mkBHEnv (toESServer esURI)
         <$> newManager defaultManagerSettings
     initDb cas =
-      C.init
-        $ C.setLogger (C.mkLogger l)
+      C.init $
+        C.setLogger (C.mkLogger l)
           . C.setContacts (view cHost cas) []
           . C.setPortNumber (fromIntegral (view cPort cas))
           . C.setKeyspace (view cKeyspace cas)
           . C.setProtocolVersion C.V4
-        $ C.defSettings
+          $ C.defSettings
 
 waitForTaskToComplete :: forall a m. (ES.MonadBH m, MonadIO m, MonadThrow m, FromJSON a) => Int -> ES.TaskNodeId -> m ()
 waitForTaskToComplete timeoutSeconds taskNodeId = do
@@ -117,9 +117,10 @@ waitForTaskToComplete timeoutSeconds taskNodeId = do
   unless (ES.taskResponseCompleted task) $ do
     throwM $ ReindexFromAnotherIndexError $ "Timed out waiting for task: " <> show taskNodeId
   when (isJust $ ES.taskResponseError task) $ do
-    throwM $ ReindexFromAnotherIndexError $
-      "Task failed with error: "
-        <> LensBS.unpackLazy8 (Aeson.encode $ ES.taskResponseError task)
+    throwM $
+      ReindexFromAnotherIndexError $
+        "Task failed with error: "
+          <> LensBS.unpackLazy8 (Aeson.encode $ ES.taskResponseError task)
   where
     isTaskComplete :: Either ES.EsError (ES.TaskResponse a) -> m Bool
     isTaskComplete (Left e) = throwM $ ReindexFromAnotherIndexError $ "Error response while getting task: " <> show e

--- a/services/brig/src/Brig/Index/Migrations.hs
+++ b/services/brig/src/Brig/Index/Migrations.hs
@@ -25,9 +25,9 @@ import qualified Brig.Index.Options as Opts
 import qualified Brig.User.Search.Index as Search
 import qualified Cassandra as C
 import qualified Cassandra.Settings as C
-import Control.Lens ((^.), view)
+import Control.Lens (view, (^.))
 import Control.Monad.Catch (Exception, MonadThrow, finally, throwM)
-import Data.Aeson ((.=), Value, object)
+import Data.Aeson (Value, object, (.=))
 import qualified Data.Metrics as Metrics
 import qualified Data.Text as Text
 import qualified Database.Bloodhound as ES
@@ -79,13 +79,13 @@ mkEnv l es cas =
         (Opts.toESServer (es ^. Opts.esServer))
         <$> HTTP.newManager HTTP.defaultManagerSettings
     initCassandra =
-      C.init
-        $ C.setLogger (C.mkLogger l)
+      C.init $
+        C.setLogger (C.mkLogger l)
           . C.setContacts (view Opts.cHost cas) []
           . C.setPortNumber (fromIntegral (view Opts.cPort cas))
           . C.setKeyspace (view Opts.cKeyspace cas)
           . C.setProtocolVersion C.V4
-        $ C.defSettings
+          $ C.defSettings
     initLogger = pure l
 
 createMigrationsIndexIfNotPresent :: (MonadThrow m, MonadIO m, ES.MonadBH m) => m ()
@@ -98,9 +98,9 @@ createMigrationsIndexIfNotPresent =
       >>= throwIfNotCreated PutMappingFailed
   where
     throwIfNotCreated err response =
-      unless (ES.isSuccess response)
-        $ throwM
-        $ err (show response)
+      unless (ES.isSuccess response) $
+        throwM $
+          err (show response)
 
 failIfIndexAbsent :: (MonadThrow m, MonadIO m, ES.MonadBH m) => ES.IndexName -> m ()
 failIfIndexAbsent targetIndex =

--- a/services/brig/src/Brig/Index/Migrations/Types.hs
+++ b/services/brig/src/Brig/Index/Migrations/Types.hs
@@ -24,7 +24,7 @@ import qualified Brig.User.Search.Index as Search
 import qualified Cassandra as C
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Reader (MonadReader (..), ReaderT, lift, runReaderT)
-import Data.Aeson ((.:), (.=), FromJSON (..), ToJSON (..), object, withObject)
+import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
 import Data.Metrics (Metrics)
 import qualified Database.Bloodhound as ES
 import Imports

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -55,9 +55,10 @@ onEvent n = handleTimeout $ case n of
         ~~ field "service" (toByteString sid)
     API.finishDeleteService pid sid
   where
-    handleTimeout act = timeout 60000000 act >>= \case
-      Just x -> pure x
-      Nothing -> throwM (InternalEventTimeout n)
+    handleTimeout act =
+      timeout 60000000 act >>= \case
+        Just x -> pure x
+        Nothing -> throwM (InternalEventTimeout n)
 
 data InternalEventException
   = -- | 'onEvent' has timed out

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -38,7 +38,7 @@ import Data.Scientific (toBoundedInteger)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Data.Time.Clock (DiffTime, NominalDiffTime, secondsToDiffTime)
-import Data.Yaml ((.:), (.:?), FromJSON (..), ToJSON (..))
+import Data.Yaml (FromJSON (..), ToJSON (..), (.:), (.:?))
 import qualified Data.Yaml as Y
 import Imports
 import qualified Network.DNS as DNS
@@ -569,10 +569,10 @@ instance FromJSON Timeout where
   parseJSON (Y.Number n) =
     let defaultV = 3600
         bounded = toBoundedInteger n :: Maybe Int64
-     in pure
-          $ Timeout
-          $ fromIntegral @Int
-          $ maybe defaultV fromIntegral bounded
+     in pure $
+          Timeout $
+            fromIntegral @Int $
+              maybe defaultV fromIntegral bounded
   parseJSON v = typeMismatch "activationTimeout" v
 
 instance FromJSON Settings

--- a/services/brig/src/Brig/Provider/DB.hs
+++ b/services/brig/src/Brig/Provider/DB.hs
@@ -110,10 +110,10 @@ lookupPassword ::
   ProviderId ->
   m (Maybe Password)
 lookupPassword p =
-  fmap (fmap runIdentity)
-    $ retry x1
-    $ query1 cql
-    $ params Quorum (Identity p)
+  fmap (fmap runIdentity) $
+    retry x1 $
+      query1 cql $
+        params Quorum (Identity p)
   where
     cql :: PrepQuery R (Identity ProviderId) (Identity Password)
     cql = "SELECT password FROM provider WHERE id = ?"
@@ -167,10 +167,10 @@ lookupKey ::
   EmailKey ->
   m (Maybe ProviderId)
 lookupKey k =
-  fmap (fmap runIdentity)
-    $ retry x1
-    $ query1 cql
-    $ params Quorum (Identity (emailKeyUniq k))
+  fmap (fmap runIdentity) $
+    retry x1 $
+      query1 cql $
+        params Quorum (Identity (emailKeyUniq k))
   where
     cql :: PrepQuery R (Identity Text) (Identity ProviderId)
     cql = "SELECT provider FROM provider_keys WHERE key = ?"
@@ -200,10 +200,11 @@ insertService ::
 insertService pid name summary descr url token key fprint assets tags = do
   sid <- randomId
   let tagSet = C.Set (Set.toList tags)
-  retry x5 $ write cql $
-    params
-      Quorum
-      (pid, sid, name, summary, descr, url, [token], [key], [fprint], assets, tagSet, False)
+  retry x5 $
+    write cql $
+      params
+        Quorum
+        (pid, sid, name, summary, descr, url, [token], [key], [fprint], assets, tagSet, False)
   return sid
   where
     cql ::
@@ -234,10 +235,10 @@ lookupService ::
   ServiceId ->
   m (Maybe Service)
 lookupService pid sid =
-  fmap (fmap mk)
-    $ retry x1
-    $ query1 cql
-    $ params Quorum (pid, sid)
+  fmap (fmap mk) $
+    retry x1 $
+      query1 cql $
+        params Quorum (pid, sid)
   where
     cql ::
       PrepQuery
@@ -255,10 +256,10 @@ listServices ::
   ProviderId ->
   m [Service]
 listServices p =
-  fmap (map mk)
-    $ retry x1
-    $ query cql
-    $ params Quorum (Identity p)
+  fmap (map mk) $
+    retry x1 $
+      query cql $
+        params Quorum (Identity p)
   where
     cql ::
       PrepQuery
@@ -350,10 +351,10 @@ lookupServiceProfile ::
   ServiceId ->
   m (Maybe ServiceProfile)
 lookupServiceProfile p s =
-  fmap (fmap mk)
-    $ retry x1
-    $ query1 cql
-    $ params One (p, s)
+  fmap (fmap mk) $
+    retry x1 $
+      query1 cql $
+        params One (p, s)
   where
     cql :: PrepQuery R (ProviderId, ServiceId) (Name, Maybe Text, Text, [Asset], C.Set ServiceTag, Bool)
     cql =
@@ -369,10 +370,10 @@ listServiceProfiles ::
   ProviderId ->
   m [ServiceProfile]
 listServiceProfiles p =
-  fmap (map mk)
-    $ retry x1
-    $ query cql
-    $ params One (Identity p)
+  fmap (map mk) $
+    retry x1 $
+      query cql $
+        params One (Identity p)
   where
     cql ::
       PrepQuery
@@ -405,10 +406,10 @@ lookupServiceConn ::
   ServiceId ->
   m (Maybe ServiceConn)
 lookupServiceConn pid sid =
-  fmap (fmap mk)
-    $ retry x1
-    $ query1 cql
-    $ params Quorum (pid, sid)
+  fmap (fmap mk) $
+    retry x1 $
+      query1 cql $
+        params Quorum (pid, sid)
   where
     cql :: PrepQuery R (ProviderId, ServiceId) (HttpsUrl, List1 ServiceToken, List1 (Fingerprint Rsa), Bool)
     cql =
@@ -686,8 +687,9 @@ paginateServiceNames mbPrefix size providerFilter = liftClient $ do
             \FROM service_prefix \
             \WHERE prefix = ? AND name >= ?"
       p <-
-        retry x1 $ paginate cql $
-          paramsP One (mkPrefixIndex (Name prefix), prefix) len
+        retry x1 $
+          paginate cql $
+            paramsP One (mkPrefixIndex (Name prefix), prefix) len
       return $! p {result = trim size (result p)}
 
 -- Pagination utilities

--- a/services/brig/src/Brig/Queue.hs
+++ b/services/brig/src/Brig/Queue.hs
@@ -29,7 +29,7 @@ import Brig.Options
 import qualified Brig.Queue.Stomp as Stomp
 import Brig.Queue.Types
 import Control.Exception (ErrorCall (..))
-import Control.Lens ((^.), view)
+import Control.Lens (view, (^.))
 import Control.Monad.Catch
 import Data.Aeson
 import qualified Data.ByteString.Base16 as B16

--- a/services/brig/src/Brig/Queue/Stomp.hs
+++ b/services/brig/src/Brig/Queue/Stomp.hs
@@ -94,19 +94,20 @@ enqueue b q m =
     retryPredicate _ res = pure (isLeft res)
     retryPolicy = limitRetries 5 <> exponentialBackoff 50000
     enqueueAction =
-      liftIO $ try @StomplException
-        $ stompTimeout "enqueue" 500000
-        $ withConnection' b
-        $ \conn ->
-          withWriter
-            conn
-            (unpack q)
-            (unpack q)
-            [OWithReceipt, OWaitReceipt]
-            []
-            oconv
-            $ \w ->
-              writeQ w jsonType [("persistent", "true")] m
+      liftIO $
+        try @StomplException $
+          stompTimeout "enqueue" 500000 $
+            withConnection' b $
+              \conn ->
+                withWriter
+                  conn
+                  (unpack q)
+                  (unpack q)
+                  [OWithReceipt, OWaitReceipt]
+                  []
+                  oconv
+                  $ \w ->
+                    writeQ w jsonType [("persistent", "true")] m
 
 -- Note [receipts]
 -- ~~~
@@ -204,8 +205,10 @@ withConnection' b =
 -- | Like 'timeout', but throws an 'AppException' instead of returning a
 -- 'Maybe'. Not very composable, but kinda convenient here.
 stompTimeout :: String -> Int -> IO a -> IO a
-stompTimeout location t act = timeout t act >>= \case
-  Just x -> pure x
-  Nothing ->
-    throwIO $ AppException $
-      location <> ": STOMP request took more than " <> show t <> "mcs and has timed out"
+stompTimeout location t act =
+  timeout t act >>= \case
+    Just x -> pure x
+    Nothing ->
+      throwIO $
+        AppException $
+          location <> ": STOMP request took more than " <> show t <> "mcs and has timed out"

--- a/services/brig/src/Brig/Queue/Stomp.hs
+++ b/services/brig/src/Brig/Queue/Stomp.hs
@@ -159,7 +159,7 @@ listen b q callback =
                 runInIO $ callback (msgContent m)
                 stompTimeout "listen/ack" 1000000 $ ack conn m
     handlers = skipAsyncExceptions ++ [logError]
-    logError = const $ Handler $ \(e :: SomeException) -> do
+    logError = const . Handler $ \(e :: SomeException) -> do
       Log.err $
         msg (val "Exception when listening to a STOMP queue")
           ~~ field "queue" (show q)

--- a/services/brig/src/Brig/RPC.hs
+++ b/services/brig/src/Brig/RPC.hs
@@ -35,7 +35,7 @@ import Imports
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), checkResponse)
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status
-import System.Logger.Class hiding ((.=), name)
+import System.Logger.Class hiding (name, (.=))
 
 x3 :: RetryPolicy
 x3 = limitRetries 3 <> exponentialBackoff 100000
@@ -55,9 +55,9 @@ expect ss rq = rq {checkResponse = check}
     check rq' rs = do
       let s = responseStatus rs
           rs' = rs {responseBody = ()}
-      when (statusIsServerError s || s `notElem` ss)
-        $ throwM
-        $ HttpExceptionRequest rq' (StatusCodeException rs' mempty)
+      when (statusIsServerError s || s `notElem` ss) $
+        throwM $
+          HttpExceptionRequest rq' (StatusCodeException rs' mempty)
 
 cargoholdRequest ::
   StdMethod ->
@@ -85,8 +85,9 @@ serviceRequest ::
   AppIO (Response (Maybe BL.ByteString))
 serviceRequest nm svc m r = do
   service <- view svc
-  recovering x3 rpcHandlers $ const $
-    rpc' nm service (method m . r)
+  recovering x3 rpcHandlers $
+    const $
+      rpc' nm service (method m . r)
 
 -- | Failed to parse a response from another service.
 data ParseException = ParseException

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -41,7 +41,7 @@ import Brig.Types.Team (TeamSize)
 import Brig.Types.Team.Invitation
 import Brig.Types.User (Email, InvitationCode, emailIdentity)
 import qualified Brig.User.Search.Index as ESIndex
-import Control.Lens ((^.), view)
+import Control.Lens (view, (^.))
 import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
 import Data.Id

--- a/services/brig/src/Brig/Team/DB.hs
+++ b/services/brig/src/Brig/Team/DB.hs
@@ -93,7 +93,7 @@ insertInvitation t role email (toUTCTimeMillis -> now) minviter inviteeName phon
   iid <- liftIO mkInvitationId
   code <- liftIO mkInvitationCode
   let inv = Invitation t role iid email now minviter inviteeName phone
-  retry x5 $ batch $ do
+  retry x5 . batch $ do
     setType BatchLogged
     setConsistency Quorum
     addPrepQuery cqlInvitation (t, role, iid, code, email, now, minviter, inviteeName, phone, round timeout)
@@ -159,7 +159,7 @@ deleteInvitation :: MonadClient m => TeamId -> InvitationId -> m ()
 deleteInvitation t i = do
   codeEmail <- lookupInvitationCodeEmail t i
   case codeEmail of
-    Just (invCode, invEmail) -> retry x5 $ batch $ do
+    Just (invCode, invEmail) -> retry x5 . batch $ do
       setType BatchLogged
       setConsistency Quorum
       addPrepQuery cqlInvitation (t, i)

--- a/services/brig/src/Brig/Template.hs
+++ b/services/brig/src/Brig/Template.hs
@@ -79,7 +79,8 @@ readLocalesDir defLocale base typ load = do
     -- Ignore locales if no such directory exist for the locale
     ls <-
       filterM (doesDirectoryExist . basePath)
-        . filter (/= defLocaleDir) =<< listDirectory base
+        . filter (/= defLocaleDir)
+        =<< listDirectory base
     Map.fromList . zip (map readLocale ls) <$> mapM (load . basePath) ls
   where
     basePath :: FilePath -> FilePath

--- a/services/brig/src/Brig/Unique.hs
+++ b/services/brig/src/Brig/Unique.hs
@@ -96,10 +96,10 @@ deleteClaim u v t = do
 -- | Lookup the current claims on a value.
 lookupClaims :: MonadClient m => Text -> m [Id a]
 lookupClaims v =
-  fmap (maybe [] (fromSet . runIdentity))
-    $ retry x1
-    $ query1 cql
-    $ params Quorum (Identity v)
+  fmap (maybe [] (fromSet . runIdentity)) $
+    retry x1 $
+      query1 cql $
+        params Quorum (Identity v)
   where
     cql :: PrepQuery R (Identity Text) (Identity (C.Set (Id a)))
     cql = "SELECT claims FROM unique_claims WHERE value = ?"

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -99,11 +99,12 @@ sendLoginCode phone call force = do
         return c
 
 lookupLoginCode :: Phone -> AppIO (Maybe PendingLoginCode)
-lookupLoginCode phone = Data.lookupKey (userPhoneKey phone) >>= \case
-  Nothing -> return Nothing
-  Just u -> do
-    Log.debug $ field "user" (toByteString u) . field "action" (Log.val "User.lookupLoginCode")
-    Data.lookupLoginCode u
+lookupLoginCode phone =
+  Data.lookupKey (userPhoneKey phone) >>= \case
+    Nothing -> return Nothing
+    Just u -> do
+      Log.debug $ field "user" (toByteString u) . field "action" (Log.val "User.lookupLoginCode")
+      Data.lookupLoginCode u
 
 login :: Login -> CookieType -> ExceptT LoginError AppIO (Access ZAuth.User)
 login (PasswordLogin li pw label) typ = do

--- a/services/brig/src/Brig/User/Auth/DB/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/DB/Cookie.hs
@@ -88,7 +88,7 @@ listCookies u =
         }
 
 deleteCookies :: MonadClient m => UserId -> [Cookie a] -> m ()
-deleteCookies u cs = retry x5 $ batch $ do
+deleteCookies u cs = retry x5 . batch $ do
   setType BatchUnLogged
   setConsistency Quorum
   for_ cs $ \c -> addPrepQuery cql (u, cookieExpires c, cookieId c)

--- a/services/brig/src/Brig/User/Handle.hs
+++ b/services/brig/src/Brig/User/Handle.hs
@@ -42,16 +42,16 @@ claimHandle u h = do
     _ -> do
       env <- ask
       let key = "@" <> fromHandle h
-      claimed <- withClaim (userId u) key (30 # Minute)
-        $ runAppT env
-        $ do
-          -- Record ownership
-          retry x5 $ write handleInsert (params Quorum (h, userId u))
-          -- Update profile
-          User.updateHandle (userId u) h
-          -- Free old handle (if it changed)
-          for_ (mfilter (/= h) (userHandle u)) $
-            freeHandle u
+      claimed <- withClaim (userId u) key (30 # Minute) $
+        runAppT env $
+          do
+            -- Record ownership
+            retry x5 $ write handleInsert (params Quorum (h, userId u))
+            -- Update profile
+            User.updateHandle (userId u) h
+            -- Free old handle (if it changed)
+            for_ (mfilter (/= h) (userHandle u)) $
+              freeHandle u
       return (isJust claimed)
 
 -- | Free a 'Handle', making it available to be claimed again.

--- a/services/brig/src/Brig/ZAuth.hs
+++ b/services/brig/src/Brig/ZAuth.hs
@@ -88,7 +88,7 @@ module Brig.ZAuth
   )
 where
 
-import Control.Lens (Lens', (^.), makeLenses, over)
+import Control.Lens (Lens', makeLenses, over, (^.))
 import Control.Monad.Catch
 import Data.Aeson
 import Data.Bits
@@ -292,51 +292,58 @@ instance UserTokenLike LegalHoldUser where
 mkUserToken' :: MonadZAuth m => UserId -> Word32 -> UTCTime -> m UserToken
 mkUserToken' u r t = liftZAuth $ do
   z <- ask
-  liftIO $ ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
-    ZC.newToken (utcTimeToPOSIXSeconds t) U Nothing (mkUser (toUUID u) r)
+  liftIO $
+    ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
+      ZC.newToken (utcTimeToPOSIXSeconds t) U Nothing (mkUser (toUUID u) r)
 
 newUserToken' :: MonadZAuth m => UserId -> m UserToken
 newUserToken' u = liftZAuth $ do
   z <- ask
   r <- liftIO randomValue
-  liftIO $ ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
-    let UserTokenTimeout ttl = z ^. settings . userTokenTimeout
-     in ZC.userToken ttl (toUUID u) r
+  liftIO $
+    ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
+      let UserTokenTimeout ttl = z ^. settings . userTokenTimeout
+       in ZC.userToken ttl (toUUID u) r
 
 newSessionToken' :: MonadZAuth m => UserId -> m UserToken
 newSessionToken' u = liftZAuth $ do
   z <- ask
   r <- liftIO randomValue
-  liftIO $ ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
-    let SessionTokenTimeout ttl = z ^. settings . sessionTokenTimeout
-     in ZC.sessionToken ttl (toUUID u) r
+  liftIO $
+    ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
+      let SessionTokenTimeout ttl = z ^. settings . sessionTokenTimeout
+       in ZC.sessionToken ttl (toUUID u) r
 
 newAccessToken' :: MonadZAuth m => UserToken -> m AccessToken
 newAccessToken' xt = liftZAuth $ do
   z <- ask
-  liftIO $ ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
-    let AccessTokenTimeout ttl = z ^. settings . accessTokenTimeout
-     in ZC.accessToken1 ttl (xt ^. body . user)
+  liftIO $
+    ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
+      let AccessTokenTimeout ttl = z ^. settings . accessTokenTimeout
+       in ZC.accessToken1 ttl (xt ^. body . user)
 
 renewAccessToken' :: MonadZAuth m => AccessToken -> m AccessToken
 renewAccessToken' old = liftZAuth $ do
   z <- ask
-  liftIO $ ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
-    let AccessTokenTimeout ttl = z ^. settings . accessTokenTimeout
-     in ZC.renewToken ttl old
+  liftIO $
+    ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
+      let AccessTokenTimeout ttl = z ^. settings . accessTokenTimeout
+       in ZC.renewToken ttl old
 
 newBotToken :: MonadZAuth m => ProviderId -> BotId -> ConvId -> m BotToken
 newBotToken pid bid cid = liftZAuth $ do
   z <- ask
-  liftIO $ ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
-    ZC.botToken (toUUID pid) (toUUID (botUserId bid)) (toUUID cid)
+  liftIO $
+    ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
+      ZC.botToken (toUUID pid) (toUUID (botUserId bid)) (toUUID cid)
 
 newProviderToken :: MonadZAuth m => ProviderId -> m ProviderToken
 newProviderToken pid = liftZAuth $ do
   z <- ask
-  liftIO $ ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
-    let ProviderTokenTimeout ttl = z ^. settings . providerTokenTimeout
-     in ZC.providerToken ttl (toUUID pid)
+  liftIO $
+    ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
+      let ProviderTokenTimeout ttl = z ^. settings . providerTokenTimeout
+       in ZC.providerToken ttl (toUUID pid)
 
 -- FUTUREWORK: this function is very similar to mkUserToken',
 -- the differences are
@@ -347,30 +354,34 @@ newProviderToken pid = liftZAuth $ do
 mkLegalHoldUserToken :: MonadZAuth m => UserId -> Word32 -> UTCTime -> m LegalHoldUserToken
 mkLegalHoldUserToken u r t = liftZAuth $ do
   z <- ask
-  liftIO $ ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
-    ZC.newToken (utcTimeToPOSIXSeconds t) LU Nothing (mkLegalHoldUser (toUUID u) r)
+  liftIO $
+    ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
+      ZC.newToken (utcTimeToPOSIXSeconds t) LU Nothing (mkLegalHoldUser (toUUID u) r)
 
 newLegalHoldUserToken :: MonadZAuth m => UserId -> m LegalHoldUserToken
 newLegalHoldUserToken u = liftZAuth $ do
   z <- ask
   r <- liftIO randomValue
-  liftIO $ ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
-    let LegalHoldUserTokenTimeout ttl = z ^. settings . legalHoldUserTokenTimeout
-     in ZC.legalHoldUserToken ttl (toUUID u) r
+  liftIO $
+    ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
+      let LegalHoldUserTokenTimeout ttl = z ^. settings . legalHoldUserTokenTimeout
+       in ZC.legalHoldUserToken ttl (toUUID u) r
 
 newLegalHoldAccessToken :: MonadZAuth m => LegalHoldUserToken -> m LegalHoldAccessToken
 newLegalHoldAccessToken xt = liftZAuth $ do
   z <- ask
-  liftIO $ ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
-    let LegalHoldAccessTokenTimeout ttl = z ^. settings . legalHoldAccessTokenTimeout
-     in ZC.legalHoldAccessToken1 ttl (xt ^. body . legalHoldUser . user)
+  liftIO $
+    ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
+      let LegalHoldAccessTokenTimeout ttl = z ^. settings . legalHoldAccessTokenTimeout
+       in ZC.legalHoldAccessToken1 ttl (xt ^. body . legalHoldUser . user)
 
 renewLegalHoldAccessToken :: MonadZAuth m => LegalHoldAccessToken -> m LegalHoldAccessToken
 renewLegalHoldAccessToken old = liftZAuth $ do
   z <- ask
-  liftIO $ ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
-    let LegalHoldAccessTokenTimeout ttl = z ^. settings . legalHoldAccessTokenTimeout
-     in ZC.renewToken ttl old
+  liftIO $
+    ZC.runCreate (z ^. private) (z ^. settings . keyIndex) $
+      let LegalHoldAccessTokenTimeout ttl = z ^. settings . legalHoldAccessTokenTimeout
+       in ZC.renewToken ttl old
 
 validateToken ::
   (MonadZAuth m, ToByteString a) =>

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -23,7 +23,7 @@ import Bilge
 import Bilge.Assert
 import qualified Brig.Options as Opts
 import Brig.Types
-import Control.Lens ((?~), (^.), view)
+import Control.Lens (view, (?~), (^.))
 import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Data.Bifunctor (Bifunctor (first))
 import Data.ByteString.Conversion
@@ -48,15 +48,16 @@ import Wire.API.Call.Config
 
 tests :: Manager -> Brig -> Opts.Opts -> FilePath -> FilePath -> IO TestTree
 tests m b opts turn turnV2 = do
-  return $ testGroup "calling" $
-    [ testGroup "turn" $
-        [ test m "basic /calls/config - 200" $ testCallsConfig b,
-          -- FIXME: requires tests to run on same host as brig
-          test m "multiple servers /calls/config - 200" . withTurnFile turn $ testCallsConfigMultiple b,
-          test m "multiple servers /calls/config/v2 - 200" . withTurnFile turnV2 $ testCallsConfigMultipleV2 b
-        ],
-      testGroup "sft" $ [test m "SFT servers /calls/config/v2 - 200" $ testSFT b opts]
-    ]
+  return $
+    testGroup "calling" $
+      [ testGroup "turn" $
+          [ test m "basic /calls/config - 200" $ testCallsConfig b,
+            -- FIXME: requires tests to run on same host as brig
+            test m "multiple servers /calls/config - 200" . withTurnFile turn $ testCallsConfigMultiple b,
+            test m "multiple servers /calls/config/v2 - 200" . withTurnFile turnV2 $ testCallsConfigMultipleV2 b
+          ],
+        testGroup "sft" $ [test m "SFT servers /calls/config/v2 - 200" $ testSFT b opts]
+      ]
 
 testCallsConfig :: Brig -> Http ()
 testCallsConfig b = do

--- a/services/brig/test/integration/API/IdMapping.hs
+++ b/services/brig/test/integration/API/IdMapping.hs
@@ -27,8 +27,8 @@ import Control.Lens ((?~))
 import Data.ByteString.Conversion (toByteString')
 import Data.Coerce (coerce)
 import Data.Domain (Domain, mkDomain)
-import qualified Data.Id as Id
 import Data.Id (Id)
+import qualified Data.Id as Id
 import Data.Qualified (Qualified (Qualified))
 import Galley.Types.IdMapping (PostIdMappingRequest (PostIdMappingRequest), PostIdMappingResponse (PostIdMappingResponse))
 import Imports

--- a/services/brig/test/integration/API/RichInfo/Util.hs
+++ b/services/brig/test/integration/API/RichInfo/Util.hs
@@ -40,7 +40,8 @@ getRichInfo brig self uid = do
           . paths ["users", toByteString' uid, "rich-info"]
           . zUser self
       )
-  if  | statusCode r == 200 -> Right <$> responseJsonError r
+  if
+      | statusCode r == 200 -> Right <$> responseJsonError r
       | statusCode r `elem` [403, 404] -> pure . Left . statusCode $ r
       | otherwise ->
         error $

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -32,7 +32,7 @@ import Control.Lens ((.~), (?~), (^.))
 import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Monad.Fail (MonadFail)
 import Control.Retry
-import Data.Aeson ((.=), FromJSON, Value)
+import Data.Aeson (FromJSON, Value, (.=))
 import qualified Data.Aeson as Aeson
 import Data.Handle (fromHandle)
 import Data.Id
@@ -41,8 +41,8 @@ import qualified Data.Text as Text
 import qualified Database.Bloodhound as ES
 import qualified Galley.Types.Teams.SearchVisibility as Team
 import Imports
-import qualified Network.HTTP.Client as HTTP
 import Network.HTTP.Client (Manager)
+import qualified Network.HTTP.Client as HTTP
 import qualified Network.Wai.Test as WaiTest
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -53,9 +53,9 @@ import Wire.API.Team.Feature (TeamFeatureStatusValue (..))
 tests :: Opt.Opts -> Manager -> Galley -> Brig -> IO TestTree
 tests opts mgr galley brig = do
   testSetupOutboundOnly <- runHttpT mgr prepareUsersForSearchVisibilityNoNameOutsideTeamTests
-  return
-    $ testGroup "search"
-    $ [ testWithBothIndices opts mgr "by-name" $ testSearchByName brig,
+  return $
+    testGroup "search" $
+      [ testWithBothIndices opts mgr "by-name" $ testSearchByName brig,
         testWithBothIndices opts mgr "by-handle" $ testSearchByHandle brig,
         test mgr "reindex" $ testReindex brig,
         testWithBothIndices opts mgr "no match" $ testSearchNoMatch brig,

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -118,10 +118,11 @@ testTeamSize brig = do
   assertSize tid expectedSize
   where
     assertSize :: HasCallStack => TeamId -> Natural -> Http ()
-    assertSize tid expectedSize = void $
-      get (brig . paths ["i", "teams", toByteString' tid, "size"]) <!! do
-        const 200 === statusCode
-        (const . Right $ TeamSize expectedSize) === responseJsonEither
+    assertSize tid expectedSize =
+      void $
+        get (brig . paths ["i", "teams", toByteString' tid, "size"]) <!! do
+          const 200 === statusCode
+          (const . Right $ TeamSize expectedSize) === responseJsonEither
 
 -------------------------------------------------------------------------------
 -- Invitation Tests
@@ -765,9 +766,10 @@ testCreateUserInternalSSO brig galley = do
   postUser' True False "dummy" True False Nothing (Just teamid) brig
     !!! const 400 === statusCode
   -- creating user with sso_id, team_id is ok
-  resp <- postUser "dummy" True False (Just ssoid) (Just teamid) brig <!! do
-    const 201 === statusCode
-    const (Just ssoid) === (userSSOId . selfUser <=< responseJsonMaybe)
+  resp <-
+    postUser "dummy" True False (Just ssoid) (Just teamid) brig <!! do
+      const 201 === statusCode
+      const (Just ssoid) === (userSSOId . selfUser <=< responseJsonMaybe)
   -- self profile contains sso id
   let Just uid = userId <$> responseJsonMaybe resp
   profile <- getSelfProfile brig uid

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -113,9 +113,9 @@ createTeam u galley = do
           . expect2xx
           . lbytes (encode newTeam)
       )
-  maybe (error "invalid team id") return
-    $ fromByteString
-    $ getHeader' "Location" r
+  maybe (error "invalid team id") return $
+    fromByteString $
+      getHeader' "Location" r
 
 -- | Create user and binding team.
 --
@@ -218,9 +218,9 @@ createTeamConv g tid u us mtimer = do
       )
       <!! const 201
       === statusCode
-  maybe (error "invalid conv id") return
-    $ fromByteString
-    $ getHeader' "Location" r
+  maybe (error "invalid conv id") return $
+    fromByteString $
+      getHeader' "Location" r
 
 -- See Note [managed conversations]
 createManagedConv :: HasCallStack => Galley -> TeamId -> UserId -> [UserId] -> Maybe Milliseconds -> Http ConvId
@@ -240,9 +240,9 @@ createManagedConv g tid u us mtimer = do
       )
       <!! const 201
       === statusCode
-  maybe (error "invalid conv id") return
-    $ fromByteString
-    $ getHeader' "Location" r
+  maybe (error "invalid conv id") return $
+    fromByteString $
+      getHeader' "Location" r
 
 deleteTeamConv :: HasCallStack => Galley -> TeamId -> ConvId -> UserId -> Http ()
 deleteTeamConv g tid cid u = do

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -530,7 +530,7 @@ testUserUpdate brig cannon aws = do
                 fmap userAssets u
               )
           )
-      . responseJsonMaybe
+        . responseJsonMaybe
   -- get only the new name
   get (brig . path "/self/name" . zUser alice) !!! do
     const 200 === statusCode
@@ -921,9 +921,10 @@ testDeleteUserByPassword brig cannon aws = do
   act <- getActivationCode brig (Left eml)
   case act of
     Nothing -> liftIO $ assertFailure "missing activation key/code"
-    Just kc -> activate brig kc !!! do
-      const 404 === statusCode
-      const (Just "invalid-code") === fmap Error.label . responseJsonMaybe
+    Just kc ->
+      activate brig kc !!! do
+        const 404 === statusCode
+        const (Just "invalid-code") === fmap Error.label . responseJsonMaybe
   -- Connections involving uid1 are gone (uid2 <-> uid3 remains)
   let u1Conns = UserConnectionList [] False
   let u2Conns = UserConnectionList (maybeToList (responseJsonMaybe con23)) False
@@ -1207,7 +1208,7 @@ setHandleAndDeleteUser brig cannon u others aws execDelete = do
                   userHandle =<< u'
                 )
             )
-        . responseJsonMaybe
+          . responseJsonMaybe
     assertDeletedProfilePublic = do
       const 200 === statusCode
       const (Just noPict, Just True, Nothing)
@@ -1217,4 +1218,4 @@ setHandleAndDeleteUser brig cannon u others aws execDelete = do
                   profileHandle =<< u'
                 )
             )
-        . responseJsonMaybe
+          . responseJsonMaybe

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -842,7 +842,7 @@ testEmailPhoneDelete brig cannon = do
   WS.bracketR cannon uid $ \ws -> do
     delete (brig . path "/self/email" . zUser uid . zConn "c")
       !!! (const 200 === statusCode)
-    void . liftIO $ WS.assertMatch (5 # Second) ws $ \n -> do
+    void . liftIO . WS.assertMatch (5 # Second) ws $ \n -> do
       let j = Object $ List1.head (ntfPayload n)
       let etype = j ^? key "type" . _String
       let euser = j ^? key "user" . key "id" . _String
@@ -869,7 +869,7 @@ testEmailPhoneDelete brig cannon = do
   WS.bracketR cannon uid $ \ws -> do
     delete (brig . path "/self/phone" . zUser uid . zConn "c")
       !!! const 200 === statusCode
-    void . liftIO $ WS.assertMatch (5 # Second) ws $ \n -> do
+    void . liftIO . WS.assertMatch (5 # Second) ws $ \n -> do
       let j = Object $ List1.head (ntfPayload n)
       let etype = j ^? key "type" . _String
       let euser = j ^? key "user" . key "id" . _String
@@ -1156,7 +1156,7 @@ setHandleAndDeleteUser brig cannon u others aws execDelete = do
   -- Delete the user
   WS.bracketRN cannon (uid : others) $ \wss -> do
     execDelete uid
-    void . liftIO $ WS.assertMatchN (5 # Second) wss $ \n -> do
+    void . liftIO . WS.assertMatchN (5 # Second) wss $ \n -> do
       let j = Object $ List1.head (ntfPayload n)
       let etype = j ^? key "type" . _String
       let euser = j ^? key "id" . _String

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -81,7 +81,7 @@ testAddGetClient hasPwd brig cannon = do
                 const 201 === statusCode
                 const True === isJust . getHeader "Location"
             )
-    void . liftIO $ WS.assertMatch (5 # Second) ws $ \n -> do
+    void . liftIO . WS.assertMatch (5 # Second) ws $ \n -> do
       let j = Object $ List1.head (ntfPayload n)
       let etype = j ^? key "type" . _String
       let eclient = j ^? key "client"
@@ -228,7 +228,7 @@ testRemoveClient hasPwd brig cannon = do
   WS.bracketR cannon uid $ \ws -> do
     deleteClient brig uid (clientId c) (if hasPwd then Just defPassword else Nothing)
       !!! const 200 === statusCode
-    void . liftIO $ WS.assertMatch (5 # Second) ws $ \n -> do
+    void . liftIO . WS.assertMatch (5 # Second) ws $ \n -> do
       let j = Object $ List1.head (ntfPayload n)
       let etype = j ^? key "type" . _String
       let eclient = j ^? key "client" . key "id" . _String

--- a/services/brig/test/integration/API/User/Connection.hs
+++ b/services/brig/test/integration/API/User/Connection.hs
@@ -305,9 +305,10 @@ testBadUpdateConnection brig = do
   assertBadUpdate uid1 uid2 Accepted
   assertBadUpdate uid2 uid1 Sent
   where
-    assertBadUpdate u1 u2 s = putConnection brig u1 u2 s !!! do
-      const 403 === statusCode
-      const (Just "bad-conn-update") === fmap Error.label . responseJsonMaybe
+    assertBadUpdate u1 u2 s =
+      putConnection brig u1 u2 s !!! do
+        const 403 === statusCode
+        const (Just "bad-conn-update") === fmap Error.label . responseJsonMaybe
 
 testConnectionPaging :: Brig -> Http ()
 testConnectionPaging b = do
@@ -357,11 +358,12 @@ testAutoConnectionOK :: Brig -> Galley -> Http ()
 testAutoConnectionOK brig galley = do
   uid1 <- userId <$> randomUser brig
   uid2 <- userId <$> randomUser brig
-  bdy <- postAutoConnection brig uid1 [uid2] <!! do
-    const 200 === statusCode
-    const (Just 2) === \r -> do
-      b <- responseBody r
-      Vec.length <$> (decode b :: Maybe (Vector UserConnection))
+  bdy <-
+    postAutoConnection brig uid1 [uid2] <!! do
+      const 200 === statusCode
+      const (Just 2) === \r -> do
+        b <- responseBody r
+        Vec.length <$> (decode b :: Maybe (Vector UserConnection))
   assertConnections brig uid1 [ConnectionStatus uid1 uid2 Accepted]
   assertConnections brig uid2 [ConnectionStatus uid2 uid1 Accepted]
   case responseJsonMaybe bdy >>= headMay >>= ucConvId of

--- a/services/brig/test/integration/API/User/Handles.hs
+++ b/services/brig/test/integration/API/User/Handles.hs
@@ -27,7 +27,7 @@ import Bilge hiding (accept, timeout)
 import Bilge.Assert
 import qualified Brig.Options as Opt
 import Brig.Types
-import Control.Lens hiding ((#), from)
+import Control.Lens hiding (from, (#))
 import Control.Monad.Catch (MonadCatch)
 import Data.Aeson
 import Data.Aeson.Lens

--- a/services/brig/test/integration/API/User/RichInfo.hs
+++ b/services/brig/test/integration/API/User/RichInfo.hs
@@ -116,9 +116,10 @@ testRichInfoSizeLimit brig conf = do
         RichInfoAssocList
           [ RichField "department" (Text.replicate (fromIntegral maxSize) "#")
           ]
-      bad2 = RichInfoAssocList $
-        [0 .. ((maxSize `div` 2))]
-          <&> \i -> RichField (CI.mk $ Text.pack $ show i) "#"
+      bad2 =
+        RichInfoAssocList $
+          [0 .. ((maxSize `div` 2))]
+            <&> \i -> RichField (CI.mk $ Text.pack $ show i) "#"
   putRichInfo brig owner bad1 !!! const 413 === statusCode
   putRichInfo brig owner bad2 !!! const 413 === statusCode
 

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -28,7 +28,7 @@ import Brig.Types.Team.LegalHold (LegalHoldClientRequest (..))
 import Brig.Types.User.Auth hiding (user)
 import qualified CargoHold.Types.V3 as CHV3
 import qualified Codec.MIME.Type as MIME
-import Control.Lens ((^?), preview)
+import Control.Lens (preview, (^?))
 import Control.Monad.Catch (MonadCatch)
 import Data.Aeson
 import Data.Aeson.Lens
@@ -131,9 +131,10 @@ activateEmail brig email = do
   act <- getActivationCode brig (Left email)
   case act of
     Nothing -> liftIO $ assertFailure "missing activation key/code"
-    Just kc -> activate brig kc !!! do
-      const 200 === statusCode
-      const (Just False) === fmap activatedFirst . responseJsonMaybe
+    Just kc ->
+      activate brig kc !!! do
+        const 200 === statusCode
+        const (Just False) === fmap activatedFirst . responseJsonMaybe
 
 checkEmail :: HasCallStack => Brig -> UserId -> Email -> HttpT IO ()
 checkEmail brig uid expectedEmail =
@@ -254,9 +255,10 @@ countCookies brig u label = do
   return $ Vec.length <$> (preview (key "cookies" . _Array) =<< responseJsonMaybe @Value r)
 
 assertConnections :: HasCallStack => Brig -> UserId -> [ConnectionStatus] -> Http ()
-assertConnections brig u cs = listConnections brig u !!! do
-  const 200 === statusCode
-  const (Just True) === fmap (check . map status . clConnections) . responseJsonMaybe
+assertConnections brig u cs =
+  listConnections brig u !!! do
+    const 200 === statusCode
+    const (Just True) === fmap (check . map status . clConnections) . responseJsonMaybe
   where
     check xs = all (`elem` xs) cs
     status c = ConnectionStatus (ucFrom c) (ucTo c) (ucStatus c)

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -40,7 +40,7 @@ import Control.Monad.Catch (MonadCatch)
 import Control.Monad.Fail (MonadFail)
 import Control.Retry
 import Data.Aeson
-import Data.Aeson.Lens (_Integral, _JSON, _String, key)
+import Data.Aeson.Lens (key, _Integral, _JSON, _String)
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString as BS
 import Data.ByteString.Char8 (pack)
@@ -574,9 +574,10 @@ updatePhone brig uid phn = do
   act <- getActivationCode brig (Right phn)
   case act of
     Nothing -> liftIO $ assertFailure "missing activation key/code"
-    Just kc -> activate brig kc !!! do
-      const 200 === statusCode
-      const (Just False) === fmap activatedFirst . responseJsonMaybe
+    Just kc ->
+      activate brig kc !!! do
+        const 200 === statusCode
+        const (Just False) === fmap activatedFirst . responseJsonMaybe
 
 defEmailLogin :: Email -> Login
 defEmailLogin e = emailLogin e defPassword (Just defCookieLabel)

--- a/services/cannon/src/Cannon/App.hs
+++ b/services/cannon/src/Cannon/App.hs
@@ -26,7 +26,7 @@ import Cannon.WS
 import Control.Concurrent.Async
 import Control.Concurrent.Timeout
 import Control.Monad.Catch
-import Data.Aeson hiding ((.=), Error)
+import Data.Aeson hiding (Error, (.=))
 import Data.ByteString.Conversion
 import Data.ByteString.Lazy (toStrict)
 import Data.Id (ClientId)
@@ -106,7 +106,8 @@ writeLoop ws clock (TTL ttl) st = loop
   where
     loop = do
       s <- readIORef st
-      if  | s ^. counter == 0 -> do
+      if
+          | s ^. counter == 0 -> do
             set counter st succ
             threadDelay $ s ^. pingFreq
             keepAlive

--- a/services/cannon/src/Cannon/Dict.hs
+++ b/services/cannon/src/Cannon/Dict.hs
@@ -30,7 +30,7 @@ where
 import Data.Hashable (Hashable, hash)
 import Data.SizedHashMap (SizedHashMap)
 import qualified Data.SizedHashMap as SHM
-import Data.Vector ((!), Vector)
+import Data.Vector (Vector, (!))
 import qualified Data.Vector as V
 import Imports hiding (lookup)
 

--- a/services/cannon/src/Cannon/Dict.hs
+++ b/services/cannon/src/Cannon/Dict.hs
@@ -51,7 +51,7 @@ insert :: (Eq a, Hashable a, MonadIO m) => a -> b -> Dict a b -> m ()
 insert k v = mutDict (SHM.insert k v) . getSlice k
 
 add :: (Eq a, Hashable a, MonadIO m) => a -> b -> Dict a b -> m Bool
-add k v d = liftIO $ atomicModifyIORef' (getSlice k d) $ \m ->
+add k v d = liftIO . atomicModifyIORef' (getSlice k d) $ \m ->
   if k `elem` SHM.keys m
     then (m, False)
     else (SHM.insert k v m, True)
@@ -60,7 +60,7 @@ remove :: (Eq a, Hashable a, MonadIO m) => a -> Dict a b -> m Bool
 remove = removeIf (const True)
 
 removeIf :: (Eq a, Hashable a, MonadIO m) => (Maybe b -> Bool) -> a -> Dict a b -> m Bool
-removeIf f k d = liftIO $ atomicModifyIORef' (getSlice k d) $ \m ->
+removeIf f k d = liftIO . atomicModifyIORef' (getSlice k d) $ \m ->
   if f (SHM.lookup k m)
     then (SHM.delete k m, True)
     else (m, False)
@@ -76,7 +76,7 @@ mutDict ::
   (SizedHashMap a b -> SizedHashMap a b) ->
   IORef (SizedHashMap a b) ->
   m ()
-mutDict f d = liftIO $ atomicModifyIORef' d $ \m -> (f m, ())
+mutDict f d = liftIO . atomicModifyIORef' d $ \m -> (f m, ())
 
 getSlice :: (Hashable a) => a -> Dict a b -> IORef (SizedHashMap a b)
 getSlice k (Dict m) = m ! (hash k `mod` V.length m)

--- a/services/cannon/src/Cannon/Run.hs
+++ b/services/cannon/src/Cannon/Run.hs
@@ -30,8 +30,7 @@ import Cannon.WS hiding (env)
 import qualified Control.Concurrent.Async as Async
 import Control.Exception.Safe (catchAny)
 import Control.Lens ((^.))
-import Control.Monad.Catch (MonadCatch)
-import Control.Monad.Catch (finally)
+import Control.Monad.Catch (MonadCatch, finally)
 import Data.Metrics.Middleware (gaugeSet, path)
 import qualified Data.Metrics.Middleware as Middleware
 import Data.Metrics.Middleware.Prometheus (waiPrometheusMiddleware)
@@ -95,7 +94,8 @@ refreshMetrics = do
     threadDelay 1000000
   where
     safeForever :: (MonadIO m, LC.MonadLogger m, MonadCatch m) => m () -> m ()
-    safeForever action = forever $
-      action `catchAny` \exc -> do
-        LC.err $ "error" LC..= show exc LC.~~ LC.msg (LC.val "refreshMetrics failed")
-        threadDelay 60000000 -- pause to keep worst-case noise in logs manageable
+    safeForever action =
+      forever $
+        action `catchAny` \exc -> do
+          LC.err $ "error" LC..= show exc LC.~~ LC.msg (LC.val "refreshMetrics failed")
+          threadDelay 60000000 -- pause to keep worst-case noise in logs manageable

--- a/services/cannon/src/Cannon/Types.hs
+++ b/services/cannon/src/Cannon/Types.hs
@@ -81,9 +81,10 @@ newtype Cannon a = Cannon
     )
 
 mapConcurrentlyCannon :: Traversable t => (a -> Cannon b) -> t a -> Cannon (t b)
-mapConcurrentlyCannon action inputs = Cannon $
-  ask >>= \e ->
-    liftIO $ mapConcurrently ((`runReaderT` e) . unCannon . action) inputs
+mapConcurrentlyCannon action inputs =
+  Cannon $
+    ask >>= \e ->
+      liftIO $ mapConcurrently ((`runReaderT` e) . unCannon . action) inputs
 
 instance MonadLogger Cannon where
   log l m = Cannon $ do

--- a/services/cannon/src/Cannon/WS.hs
+++ b/services/cannon/src/Cannon/WS.hs
@@ -115,7 +115,7 @@ newtype Clock = Clock (IORef Word64)
 mkClock :: IO Clock
 mkClock = do
   r <- newIORef 0
-  void . forkIO $ forever $ do
+  void . forkIO . forever $ do
     threadDelay (1 # Second)
     modifyIORef' r (+ 1)
   return $ Clock r

--- a/services/cannon/src/Cannon/WS.hs
+++ b/services/cannon/src/Cannon/WS.hs
@@ -61,7 +61,7 @@ import Data.Default (def)
 import Data.Hashable
 import Data.Id (ClientId, ConnId (..), UserId)
 import Data.Text.Encoding (decodeUtf8)
-import Data.Timeout ((#), TimeoutUnit (..))
+import Data.Timeout (TimeoutUnit (..), (#))
 import Gundeck.Types
 import Imports hiding (threadDelay)
 import Network.HTTP.Types.Method
@@ -69,7 +69,7 @@ import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
 import Network.WebSockets hiding (Request)
 import qualified System.Logger as Logger
-import System.Logger.Class hiding ((.=), Error, Settings, close)
+import System.Logger.Class hiding (Error, Settings, close, (.=))
 import System.Random.MWC (GenIO, uniform)
 
 -----------------------------------------------------------------------------
@@ -208,16 +208,19 @@ registerRemote k c = do
   debug $ client kb . msg (val "register-remote")
   e <- WS ask
   i <- regInfo k c
-  void $ recovering retry3x rpcHandlers $ const $
-    rpc' "gundeck" (upstream e) (method POST . path "/i/presences" . i . expect2xx)
+  void $
+    recovering retry3x rpcHandlers $
+      const $
+        rpc' "gundeck" (upstream e) (method POST . path "/i/presences" . i . expect2xx)
   debug $ client kb . msg (val "registered")
 
 isRemoteRegistered :: UserId -> ConnId -> WS Bool
 isRemoteRegistered u c = do
   e <- WS ask
   rs <-
-    recovering retry3x rpcHandlers $ const $
-      rpc' "gundeck" (upstream e) (method GET . paths ["/i/presences", toByteString' u] . expect2xx)
+    recovering retry3x rpcHandlers $
+      const $
+        rpc' "gundeck" (upstream e) (method GET . paths ["/i/presences", toByteString' u] . expect2xx)
   cs <- map connId <$> parseResponse (Error status502 "server-error") rs
   return $ c `elem` cs
 

--- a/services/cannon/test/Test/Cannon/Dict.hs
+++ b/services/cannon/test/Test/Cannon/Dict.hs
@@ -98,10 +98,11 @@ insertLookup = do
     action d k = do
       v <- toByteString <$> nextRandom
       added <- D.add k v d
-      when added $ replicateM_ 361 $ do
-        threadDelay 3571
-        x <- D.lookup k d
-        Just v @=? x
+      when added $
+        replicateM_ 361 $ do
+          threadDelay 3571
+          x <- D.lookup k d
+          Just v @=? x
 
 assertEq :: (Show a, Eq a, Monad m) => String -> a -> a -> PropertyM m ()
 assertEq m a b

--- a/services/cargohold/src/CargoHold/API/Error.hs
+++ b/services/cargohold/src/CargoHold/API/Error.hs
@@ -50,14 +50,15 @@ requestTimeout =
 
 invalidOffset :: Offset -> Offset -> Error
 invalidOffset expected given =
-  Error status409 "invalid-offset" $ toLazyText $
-    "Invalid offset: "
-      <> "expected: "
-      <> decimal expected
-      <> ", "
-      <> "given: "
-      <> decimal given
-      <> "."
+  Error status409 "invalid-offset" $
+    toLazyText $
+      "Invalid offset: "
+        <> "expected: "
+        <> decimal expected
+        <> ", "
+        <> "given: "
+        <> decimal given
+        <> "."
 
 uploadTooSmall :: Error
 uploadTooSmall =
@@ -77,14 +78,15 @@ uploadTooLarge =
 
 uploadIncomplete :: TotalSize -> TotalSize -> Error
 uploadIncomplete expected actual =
-  Error status403 "client-error" $ toLazyText $
-    "The upload is incomplete: "
-      <> "expected size: "
-      <> decimal expected
-      <> ", "
-      <> "current size: "
-      <> decimal actual
-      <> "."
+  Error status403 "client-error" $
+    toLazyText $
+      "The upload is incomplete: "
+        <> "expected size: "
+        <> decimal expected
+        <> ", "
+        <> "current size: "
+        <> decimal actual
+        <> "."
 
 clientError :: LText -> Error
 clientError = Error status400 "client-error"

--- a/services/cargohold/src/CargoHold/API/Public.hs
+++ b/services/cargohold/src/CargoHold/API/Public.hs
@@ -30,7 +30,7 @@ import CargoHold.Options
 import qualified CargoHold.TUS as TUS
 import qualified CargoHold.Types.V3 as V3 (Principal (..))
 import Control.Error
-import Control.Lens ((^.), view)
+import Control.Lens (view, (^.))
 import Data.ByteString.Conversion
 import Data.Id
 import Data.Predicate

--- a/services/cargohold/src/CargoHold/API/V3.hs
+++ b/services/cargohold/src/CargoHold/API/V3.hs
@@ -38,7 +38,7 @@ import qualified Codec.MIME.Type as MIME
 import qualified Conduit as Conduit
 import Control.Applicative (optional)
 import Control.Error
-import Control.Lens ((^.), set, view)
+import Control.Lens (set, view, (^.))
 import Control.Monad.Trans.Resource
 import Crypto.Hash
 import Crypto.Random (getRandomBytes)
@@ -214,9 +214,9 @@ headers names = count (length names) (header names)
 header :: [HeaderName] -> Parser (HeaderName, ByteString)
 header names = do
   name <- CI.mk <$> takeTill (== ':') <?> "header name"
-  unless (name `elem` names)
-    $ fail
-    $ "Unexpected header: " ++ show (CI.original name)
+  unless (name `elem` names) $
+    fail $
+      "Unexpected header: " ++ show (CI.original name)
   _ <- char ':'
   skipSpace
   value <- takeTill isEOL <?> "header value"

--- a/services/cargohold/src/CargoHold/API/V3/Resumable.hs
+++ b/services/cargohold/src/CargoHold/API/V3/Resumable.hs
@@ -119,7 +119,7 @@ upload own key off len src = do
       let totalBytes = V3.totalSizeBytes (S3.resumableTotalSize r)
       let numBytes = min (chunkSize r) remaining
       if numBytes < chunkSize r && coerce offset + remaining < totalBytes
-        then-- Remaining input that is not a full chunk size and does
+        then -- Remaining input that is not a full chunk size and does
         -- not constitute the last chunk is ignored, i.e. all chunks
         -- except the last must have the same size (the chunk size).
           return (r, offset)

--- a/services/cargohold/src/CargoHold/AWS.hs
+++ b/services/cargohold/src/CargoHold/AWS.hs
@@ -53,8 +53,8 @@ import qualified Network.AWS.Env as AWS
 import qualified Network.AWS.S3 as S3
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), Manager)
 import qualified System.Logger as Logger
-import qualified System.Logger.Class as Log
 import System.Logger.Class (Logger, MonadLogger (log), (~~))
+import qualified System.Logger.Class as Log
 import Util.Options (AWSEndpoint (..))
 
 data Env = Env

--- a/services/cargohold/src/CargoHold/AWS.hs
+++ b/services/cargohold/src/CargoHold/AWS.hs
@@ -97,7 +97,7 @@ instance MonadLogger Amazon where
   log l m = view logger >>= \g -> Logger.log g l m
 
 instance MonadUnliftIO Amazon where
-  askUnliftIO = Amazon $ ReaderT $ \r ->
+  askUnliftIO = Amazon . ReaderT $ \r ->
     withUnliftIO $ \u ->
       return (UnliftIO (unliftIO u . flip runReaderT r . unAmazon))
 

--- a/services/cargohold/src/CargoHold/App.hs
+++ b/services/cargohold/src/CargoHold/App.hs
@@ -49,7 +49,7 @@ import Bilge.RPC (HasRequestId (..))
 import qualified CargoHold.AWS as AWS
 import CargoHold.Options as Opt
 import Control.Error (ExceptT, exceptT)
-import Control.Lens ((^.), makeLenses, set, view)
+import Control.Lens (makeLenses, set, view, (^.))
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Trans.Resource (ResourceT, runResourceT, transResourceT)
 import Data.Default (def)

--- a/services/cargohold/src/CargoHold/Run.hs
+++ b/services/cargohold/src/CargoHold/Run.hs
@@ -30,8 +30,8 @@ import Data.Text (unpack)
 import Imports
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Middleware.Gzip as GZip
-import qualified Network.Wai.Utilities.Server as Server
 import Network.Wai.Utilities.Server
+import qualified Network.Wai.Utilities.Server as Server
 import Util.Options
 
 run :: Opts -> IO ()

--- a/services/cargohold/src/CargoHold/Util.hs
+++ b/services/cargohold/src/CargoHold/Util.hs
@@ -28,7 +28,8 @@ import URI.ByteString hiding (urlEncode)
 
 genSignedURL :: (ToByteString p) => p -> Handler URI
 genSignedURL path = do
-  uri <- view (aws . cloudFront) >>= \case
-    Nothing -> S3.signedURL path
-    Just cf -> CloudFront.signedURL cf path
+  uri <-
+    view (aws . cloudFront) >>= \case
+      Nothing -> S3.signedURL path
+      Just cf -> CloudFront.signedURL cf path
   return $! uri

--- a/services/cargohold/test/integration/API/V3.hs
+++ b/services/cargohold/test/integration/API/V3.hs
@@ -98,9 +98,10 @@ testSimpleRoundtrip c = do
       when (isJust $ join (V3.assetRetentionSeconds <$> (sets ^. V3.setAssetRetention))) $ do
         liftIO $ assertBool "invalid expiration" (Just utc < view V3.assetExpires ast)
       -- Lookup with token and download via redirect.
-      r2 <- get (c . path loc . zUser uid . header "Asset-Token" (toByteString' tok) . noRedirect) <!! do
-        const 302 === statusCode
-        const Nothing === responseBody
+      r2 <-
+        get (c . path loc . zUser uid . header "Asset-Token" (toByteString' tok) . noRedirect) <!! do
+          const 302 === statusCode
+          const Nothing === responseBody
       r3 <- flip get' id =<< parseUrlThrow (C8.unpack (getHeader' "Location" r2))
       liftIO $ do
         assertEqual "status" status200 (responseStatus r3)
@@ -150,9 +151,10 @@ testSimpleTokens c = do
   let Just tok' = V3.newAssetToken <$> responseJsonMaybe r2
   liftIO $ assertBool "token unchanged" (tok /= tok')
   -- Download by owner with new token.
-  r3 <- get (c . path loc . zUser uid . header "Asset-Token" (toByteString' tok') . noRedirect) <!! do
-    const 302 === statusCode
-    const Nothing === responseBody
+  r3 <-
+    get (c . path loc . zUser uid . header "Asset-Token" (toByteString' tok') . noRedirect) <!! do
+      const 302 === statusCode
+      const Nothing === responseBody
   r4 <- flip get' id =<< parseUrlThrow (C8.unpack (getHeader' "Location" r3))
   liftIO $ do
     assertEqual "status" status200 (responseStatus r4)
@@ -347,9 +349,10 @@ getAsset c u k t =
 
 downloadAsset :: HasCallStack => CargoHold -> UserId -> V3.AssetKey -> Maybe V3.AssetToken -> Http (Response (Maybe Lazy.ByteString))
 downloadAsset c u k t = do
-  r <- getAsset c u k t <!! do
-    const 302 === statusCode
-    const Nothing === responseBody
+  r <-
+    getAsset c u k t <!! do
+      const 302 === statusCode
+      const Nothing === responseBody
   l <- parseUrlThrow (C8.unpack (getHeader' "Location" r))
   get' l id
 

--- a/services/cargohold/test/integration/Main.hs
+++ b/services/cargohold/test/integration/Main.hs
@@ -60,24 +60,25 @@ instance IsOption ServiceConfigFile where
   optionName = return "service-config"
   optionHelp = return "Service config file to read from"
   optionCLParser =
-    fmap ServiceConfigFile $ strOption $
-      ( short (untag (return 's' :: Tagged ServiceConfigFile Char))
-          <> long (untag (optionName :: Tagged ServiceConfigFile String))
-          <> help (untag (optionHelp :: Tagged ServiceConfigFile String))
-      )
+    fmap ServiceConfigFile $
+      strOption $
+        ( short (untag (return 's' :: Tagged ServiceConfigFile Char))
+            <> long (untag (optionName :: Tagged ServiceConfigFile String))
+            <> help (untag (optionHelp :: Tagged ServiceConfigFile String))
+        )
 
 runTests :: (String -> String -> TestTree) -> IO ()
-runTests run = defaultMainWithIngredients ings
-  $ askOption
-  $ \(ServiceConfigFile c) ->
-    askOption $ \(IntegrationConfigFile i) -> run c i
+runTests run = defaultMainWithIngredients ings $
+  askOption $
+    \(ServiceConfigFile c) ->
+      askOption $ \(IntegrationConfigFile i) -> run c i
   where
     ings =
       includingOptions
         [ Option (Proxy :: Proxy ServiceConfigFile),
           Option (Proxy :: Proxy IntegrationConfigFile)
-        ]
-        : defaultIngredients
+        ] :
+      defaultIngredients
 
 main :: IO ()
 main = runTests go

--- a/services/cargohold/test/integration/TestSetup.hs
+++ b/services/cargohold/test/integration/TestSetup.hs
@@ -27,7 +27,7 @@ where
 
 import Bilge (Request)
 import Bilge.IO (Http, Manager, runHttpT)
-import Control.Lens ((^.), makeLenses)
+import Control.Lens (makeLenses, (^.))
 import Imports
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/services/federator/src/Federator/Run.hs
+++ b/services/federator/src/Federator/Run.hs
@@ -118,7 +118,7 @@ instance Monad m => HasRequestId (AppT m) where
 
 instance MonadUnliftIO m => MonadUnliftIO (AppT m) where
   withRunInIO inner =
-    AppT $ ReaderT $ \r ->
+    AppT . ReaderT $ \r ->
       withRunInIO $ \runner ->
         inner (runner . flip runReaderT r . unAppT)
 

--- a/services/federator/src/Federator/Run.hs
+++ b/services/federator/src/Federator/Run.hs
@@ -37,7 +37,7 @@ where
 import Bilge (RequestId (unRequestId))
 import Bilge.RPC (HasRequestId (..))
 import Control.Error
-import Control.Lens ((^.), view)
+import Control.Lens (view, (^.))
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Trans.Resource
 import Data.Default (def)

--- a/services/galley/migrate-data/src/Galley/DataMigration.hs
+++ b/services/galley/migrate-data/src/Galley/DataMigration.hs
@@ -70,13 +70,13 @@ mkEnv l cas =
     <*> initLogger
   where
     initCassandra =
-      C.init
-        $ C.setLogger (C.mkLogger l)
+      C.init $
+        C.setLogger (C.mkLogger l)
           . C.setContacts (cHost cas) []
           . C.setPortNumber (fromIntegral (cPort cas))
           . C.setKeyspace (cKeyspace cas)
           . C.setProtocolVersion C.V4
-        $ C.defSettings
+          $ C.defSettings
     initLogger = pure l
 
 -- | Runs only the migrations which need to run

--- a/services/galley/src/Galley/API/IdMapping.hs
+++ b/services/galley/src/Galley/API/IdMapping.hs
@@ -29,8 +29,8 @@ module Galley.API.IdMapping
 where
 
 import Control.Monad.Catch (throwM)
-import qualified Data.Id as Id
 import Data.Id (Id (Id, toUUID), OpaqueConvId, OpaqueUserId, idToText)
+import qualified Data.Id as Id
 import Data.IdMapping (IdMapping (IdMapping, _imQualifiedId), MappedOrLocalId (Local, Mapped), hashQualifiedId)
 import Data.Qualified (Qualified, renderQualifiedId)
 import Galley.API.Error (federationNotEnabled)
@@ -146,12 +146,12 @@ createIdMapping qualifiedId = do
       let idMapping = IdMapping mappedId qualifiedId
       Data.getIdMapping mappedId >>= \case
         Just existingMapping ->
-          when (_imQualifiedId existingMapping /= qualifiedId)
-            $ Log.err
-            $ Log.msg @Text "Conflict when creating IdMapping"
-              . Log.field "mapped_id" (idToText mappedId)
-              . Log.field "existing_qualified_id" (renderQualifiedId qualifiedId)
-              . Log.field "new_qualified_id" (renderQualifiedId (_imQualifiedId existingMapping))
+          when (_imQualifiedId existingMapping /= qualifiedId) $
+            Log.err $
+              Log.msg @Text "Conflict when creating IdMapping"
+                . Log.field "mapped_id" (idToText mappedId)
+                . Log.field "existing_qualified_id" (renderQualifiedId qualifiedId)
+                . Log.field "new_qualified_id" (renderQualifiedId (_imQualifiedId existingMapping))
         Nothing -> do
           Data.insertIdMapping idMapping
           Intra.createIdMappingInBrig (mkPostIdMappingRequest qualifiedId)

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -292,7 +292,7 @@ rmUser user conn = do
             return $
               (Intra.newPush ListComplete (evtFrom e) (Intra.ConvEvent e) (Intra.recipient <$> Data.convMembers c))
                 <&> set Intra.pushConn conn
-                . set Intra.pushRoute Intra.RouteDirect
+                  . set Intra.pushRoute Intra.RouteDirect
           | otherwise -> return Nothing
       for_
         (maybeList1 (catMaybes pp))
@@ -315,7 +315,8 @@ deleteLoop = do
       liftIO $ threadDelay 1000000
 
 safeForever :: (MonadIO m, MonadLogger m, MonadCatch m) => String -> m () -> m ()
-safeForever funName action = forever $
-  action `catchAny` \exc -> do
-    err $ "error" .= show exc ~~ msg (val $ cs funName <> " failed")
-    threadDelay 60000000 -- pause to keep worst-case noise in logs manageable
+safeForever funName action =
+  forever $
+    action `catchAny` \exc -> do
+      err $ "error" .= show exc ~~ msg (val $ cs funName <> " failed")
+      threadDelay 60000000 -- pause to keep worst-case noise in logs manageable

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -31,7 +31,7 @@ where
 import Brig.Types.Client.Prekey
 import Brig.Types.Provider
 import Brig.Types.Team.LegalHold hiding (userId)
-import Control.Lens ((^.), view)
+import Control.Lens (view, (^.))
 import Control.Monad.Catch
 import Data.ByteString.Conversion (toByteString, toByteString')
 import Data.Id

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -32,7 +32,7 @@ import Imports
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
 import qualified System.Logger.Class as Log
-import System.Logger.Message ((+++), msg, val)
+import System.Logger.Message (msg, val, (+++))
 import qualified Wire.API.Conversation as Public
 
 conversationView :: MappedOrLocalId Id.U -> Data.Conversation -> Galley Public.Conversation

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -1071,10 +1071,11 @@ filterMissing = (>>= go) <$> (query "ignore_missing" ||| query "report_missing")
     users :: ByteString -> ByteString -> P.Result P.Error (Set OpaqueUserId)
     users src bs = case fromByteString bs of
       Nothing ->
-        P.Fail $ P.setMessage "Boolean or list of user IDs expected."
-          $ P.setReason P.TypeError
-          $ P.setSource src
-          $ P.err status400
+        P.Fail $
+          P.setMessage "Boolean or list of user IDs expected." $
+            P.setReason P.TypeError $
+              P.setSource src $
+                P.err status400
       -- NB. 'fromByteString' parses a comma-separated list ('List') of
       -- user IDs, and then 'fromList' unwraps it; took me a while to
       -- understand this

--- a/services/galley/src/Galley/API/Swagger.hs
+++ b/services/galley/src/Galley/API/Swagger.hs
@@ -33,8 +33,7 @@ import Brig.Types.Client.Prekey (LastPrekey, Prekey, PrekeyId)
 import Brig.Types.Provider
 import Brig.Types.Team.LegalHold
 import Control.Lens
-import Data.Aeson (toJSON)
-import Data.Aeson (Value (..))
+import Data.Aeson (Value (..), toJSON)
 import Data.HashMap.Strict.InsOrd
 import Data.Id
 import Data.LegalHold
@@ -157,14 +156,15 @@ instance ToSchema NewLegalHoldService where
 
 instance ToSchema ViewLegalHoldService where
   declareNamedSchema _ =
-    pure $ NamedSchema (Just "ViewLegalHoldService") $
-      mempty
-        & properties .~ properties_
-        & example .~ Just (toJSON example_)
-        & required .~ ["status"]
-        & minProperties .~ Just 1
-        & maxProperties .~ Just 2
-        & type_ .~ Just SwaggerObject
+    pure $
+      NamedSchema (Just "ViewLegalHoldService") $
+        mempty
+          & properties .~ properties_
+          & example .~ Just (toJSON example_)
+          & required .~ ["status"]
+          & minProperties .~ Just 1
+          & maxProperties .~ Just 2
+          & type_ .~ Just SwaggerObject
     where
       properties_ :: InsOrdHashMap Text (Referenced Schema)
       properties_ =
@@ -204,12 +204,13 @@ instance ToSchema ViewLegalHoldServiceInfo where
         }
   -}
   declareNamedSchema _ =
-    pure $ NamedSchema (Just "ViewLegalHoldServiceInfo") $
-      mempty
-        & properties .~ properties_
-        & example .~ Just (toJSON example_)
-        & required .~ ["team_id", "base_url", "fingerprint", "auth_token", "public_key"]
-        & type_ .~ Just SwaggerObject
+    pure $
+      NamedSchema (Just "ViewLegalHoldServiceInfo") $
+        mempty
+          & properties .~ properties_
+          & example .~ Just (toJSON example_)
+          & required .~ ["team_id", "base_url", "fingerprint", "auth_token", "public_key"]
+          & type_ .~ Just SwaggerObject
     where
       properties_ :: InsOrdHashMap Text (Referenced Schema)
       properties_ =
@@ -226,12 +227,13 @@ instance ToSchema ViewLegalHoldServiceInfo where
 
 instance ToSchema TeamFeatureStatus where
   declareNamedSchema _ =
-    pure $ NamedSchema (Just "TeamFeatureStatus") $
-      mempty
-        & properties .~ (fromList [("status", Inline statusValue)])
-        & required .~ ["status"]
-        & type_ ?~ SwaggerObject
-        & description ?~ "whether a given team feature is enabled"
+    pure $
+      NamedSchema (Just "TeamFeatureStatus") $
+        mempty
+          & properties .~ (fromList [("status", Inline statusValue)])
+          & required .~ ["status"]
+          & type_ ?~ SwaggerObject
+          & description ?~ "whether a given team feature is enabled"
     where
       statusValue =
         mempty
@@ -259,13 +261,14 @@ instance ToSchema NewLegalHoldClient where
 
 instance ToSchema UserLegalHoldStatusResponse where
   declareNamedSchema _ =
-    pure $ NamedSchema (Just "UserLegalHoldStatusResponse") $
-      mempty
-        & properties .~ properties_
-        & required .~ ["status"]
-        & minProperties .~ Just 1
-        & maxProperties .~ Just 3
-        & type_ .~ Just SwaggerObject
+    pure $
+      NamedSchema (Just "UserLegalHoldStatusResponse") $
+        mempty
+          & properties .~ properties_
+          & required .~ ["status"]
+          & minProperties .~ Just 1
+          & maxProperties .~ Just 3
+          & type_ .~ Just SwaggerObject
     where
       properties_ :: InsOrdHashMap Text (Referenced Schema)
       properties_ =
@@ -277,11 +280,12 @@ instance ToSchema UserLegalHoldStatusResponse where
 
 instance ToSchema a => ToSchema (IdObject a) where
   declareNamedSchema _ =
-    pure $ NamedSchema (Just "IdObject a") $
-      mempty
-        & properties .~ properties_
-        & required .~ ["id"]
-        & type_ .~ Just SwaggerObject
+    pure $
+      NamedSchema (Just "IdObject a") $
+        mempty
+          & properties .~ properties_
+          & required .~ ["id"]
+          & type_ .~ Just SwaggerObject
     where
       properties_ :: InsOrdHashMap Text (Referenced Schema)
       properties_ =

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -19,7 +19,7 @@ module Galley.API.Util where
 
 import Brig.Types (Relation (..))
 import Brig.Types.Intra (ReAuthUser (..))
-import Control.Lens ((.~), (^.), view)
+import Control.Lens (view, (.~), (^.))
 import Control.Monad.Catch
 import Data.ByteString.Conversion
 import Data.Domain (Domain)
@@ -154,11 +154,12 @@ assertOnTeam uid tid = do
 -- | If the conversation is in a team, throw iff zusr is a team member and does not have named
 -- permission.  If the conversation is not in a team, do nothing (no error).
 permissionCheckTeamConv :: UserId -> ConvId -> Perm -> Galley ()
-permissionCheckTeamConv zusr cnv perm = Data.conversation cnv >>= \case
-  Just cnv' -> case Data.convTeam cnv' of
-    Just tid -> void $ permissionCheck perm =<< Data.teamMember tid zusr
-    Nothing -> pure ()
-  Nothing -> throwM convNotFound
+permissionCheckTeamConv zusr cnv perm =
+  Data.conversation cnv >>= \case
+    Just cnv' -> case Data.convTeam cnv' of
+      Just tid -> void $ permissionCheck perm =<< Data.teamMember tid zusr
+      Nothing -> pure ()
+    Nothing -> throwM convNotFound
 
 -- | Try to accept a 1-1 conversation, promoting connect conversations as appropriate.
 acceptOne2One :: UserId -> Data.Conversation -> Maybe ConnId -> Galley Data.Conversation

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -164,7 +164,7 @@ validateOptions l o = do
 
 instance MonadUnliftIO Galley where
   askUnliftIO =
-    Galley $ ReaderT $ \r ->
+    Galley . ReaderT $ \r ->
       withUnliftIO $ \u ->
         return (UnliftIO (unliftIO u . flip runReaderT r . unGalley))
 

--- a/services/galley/src/Galley/Aws.hs
+++ b/services/galley/src/Galley/Aws.hs
@@ -150,9 +150,9 @@ mkEnv lgr mgr opts = do
     getQueueUrl :: AWS.Env -> Text -> IO QueueUrl
     getQueueUrl e q = do
       x <-
-        runResourceT . AWST.runAWST e
-          $ AWST.trying AWS._Error
-          $ AWST.send (SQS.getQueueURL q)
+        runResourceT . AWST.runAWST e $
+          AWST.trying AWS._Error $
+            AWST.send (SQS.getQueueURL q)
       either
         (throwM . GeneralError)
         (return . QueueUrl . view SQS.gqursQueueURL)

--- a/services/galley/src/Galley/Aws.hs
+++ b/services/galley/src/Galley/Aws.hs
@@ -95,7 +95,7 @@ newtype Amazon a = Amazon
     )
 
 instance MonadUnliftIO Amazon where
-  askUnliftIO = Amazon $ ReaderT $ \r ->
+  askUnliftIO = Amazon . ReaderT $ \r ->
     withUnliftIO $ \u ->
       return (UnliftIO (unliftIO u . flip runReaderT r . unAmazon))
 

--- a/services/galley/src/Galley/Data/CustomBackend.hs
+++ b/services/galley/src/Galley/Data/CustomBackend.hs
@@ -32,8 +32,9 @@ import Galley.Types
 import Imports
 
 getCustomBackend :: MonadClient m => Domain -> m (Maybe CustomBackend)
-getCustomBackend domain = fmap toCustomBackend <$> do
-  retry x1 $ query1 Cql.selectCustomBackend (params Quorum (Identity domain))
+getCustomBackend domain =
+  fmap toCustomBackend <$> do
+    retry x1 $ query1 Cql.selectCustomBackend (params Quorum (Identity domain))
   where
     toCustomBackend (backendConfigJsonUrl, backendWebappWelcomeUrl) =
       CustomBackend {..}

--- a/services/galley/src/Galley/Data/IdMapping.hs
+++ b/services/galley/src/Galley/Data/IdMapping.hs
@@ -32,8 +32,9 @@ import Imports
 -- | Only a single namespace/table is used for for potentially multiple different types of
 -- mapped IDs.
 getIdMapping :: MonadClient m => Id (Mapped a) -> m (Maybe (IdMapping a))
-getIdMapping mappedId = fmap toIdMapping <$> do
-  retry x1 $ query1 Cql.selectIdMapping (params Quorum (Identity mappedId))
+getIdMapping mappedId =
+  fmap toIdMapping <$> do
+    retry x1 $ query1 Cql.selectIdMapping (params Quorum (Identity mappedId))
   where
     toIdMapping (remoteId, domain) =
       IdMapping mappedId (Qualified remoteId domain)

--- a/services/galley/src/Galley/Data/LegalHold.hs
+++ b/services/galley/src/Galley/Data/LegalHold.hs
@@ -48,8 +48,9 @@ createSettings (LegalHoldService tid url fpr tok key) = do
 -- | Returns 'Nothing' if no settings are saved
 -- The Caller is responsible for checking whether legal hold is enabled for this team
 getSettings :: MonadClient m => TeamId -> m (Maybe LegalHoldService)
-getSettings tid = fmap toLegalHoldService <$> do
-  retry x1 $ query1 selectLegalHoldSettings (params Quorum (Identity tid))
+getSettings tid =
+  fmap toLegalHoldService <$> do
+    retry x1 $ query1 selectLegalHoldSettings (params Quorum (Identity tid))
   where
     toLegalHoldService (httpsUrl, fingerprint, tok, key) = LegalHoldService tid httpsUrl fingerprint tok key
 
@@ -57,10 +58,10 @@ removeSettings :: MonadClient m => TeamId -> m ()
 removeSettings tid = retry x5 (write removeLegalHoldSettings (params Quorum (Identity tid)))
 
 insertPendingPrekeys :: MonadClient m => UserId -> [Prekey] -> m ()
-insertPendingPrekeys uid keys = retry x5 . batch
-  $ forM_ keys
-  $ \key ->
-    addPrepQuery Q.insertPendingPrekeys (toTuple key)
+insertPendingPrekeys uid keys = retry x5 . batch $
+  forM_ keys $
+    \key ->
+      addPrepQuery Q.insertPendingPrekeys (toTuple key)
   where
     toTuple (Prekey keyId key) = (uid, keyId, key)
 

--- a/services/galley/src/Galley/Data/SearchVisibility.hs
+++ b/services/galley/src/Galley/Data/SearchVisibility.hs
@@ -33,8 +33,9 @@ import Imports
 
 -- | Return whether a given team is allowed to enable/disable sso
 getSearchVisibility :: MonadClient m => TeamId -> m TeamSearchVisibility
-getSearchVisibility tid = toSearchVisibility <$> do
-  retry x1 $ query1 selectSearchVisibility (params Quorum (Identity tid))
+getSearchVisibility tid =
+  toSearchVisibility <$> do
+    retry x1 $ query1 selectSearchVisibility (params Quorum (Identity tid))
   where
     -- The value is either set or we return the default
     toSearchVisibility :: (Maybe (Identity (Maybe TeamSearchVisibility))) -> TeamSearchVisibility

--- a/services/galley/src/Galley/Data/Services.hs
+++ b/services/galley/src/Galley/Data/Services.hs
@@ -64,7 +64,7 @@ addBotMember :: UserId -> ServiceRef -> BotId -> ConvId -> UTCTime -> Galley (Ev
 addBotMember orig s bot cnv now = do
   let pid = s ^. serviceRefProvider
   let sid = s ^. serviceRefId
-  retry x5 $ batch $ do
+  retry x5 . batch $ do
     setType BatchLogged
     setConsistency Quorum
     addPrepQuery insertUserConv (botUserId bot, makeIdOpaque cnv, Nothing, Nothing)

--- a/services/galley/src/Galley/Data/TeamNotifications.hs
+++ b/services/galley/src/Galley/Data/TeamNotifications.hs
@@ -35,7 +35,7 @@ import qualified Data.Aeson as JSON
 import Data.Id
 import Data.List1 (List1)
 import Data.Range (Range, fromRange)
-import Data.Sequence ((<|), (><), Seq, ViewL (..), ViewR (..))
+import Data.Sequence (Seq, ViewL (..), ViewR (..), (<|), (><))
 import qualified Data.Sequence as Seq
 import Gundeck.Types.Notification
 import Imports
@@ -128,9 +128,9 @@ toNotif (i, b) ns =
     ns
     (\p1 -> queuedNotification notifId p1 : ns)
     ( JSON.decode' (fromBlob b)
-      -- FUTUREWORK: this is from the database, so it's slightly more ok to ignore parse
-      -- errors than if it's data provided by a client.  it would still be better to have an
-      -- error entry in the log file and crash, rather than ignore the error and continue.
+    -- FUTUREWORK: this is from the database, so it's slightly more ok to ignore parse
+    -- errors than if it's data provided by a client.  it would still be better to have an
+    -- error entry in the log file and crash, rather than ignore the error and continue.
     )
   where
     notifId = Id (fromTimeUuid i)

--- a/services/galley/src/Galley/External.hs
+++ b/services/galley/src/Galley/External.hs
@@ -128,7 +128,7 @@ urlPort (HttpsUrl u) = do
 sendMessage :: [Fingerprint Rsa] -> (Request -> Request) -> Galley ()
 sendMessage fprs reqBuilder = do
   (man, verifyFingerprints) <- view (extEnv . extGetManager)
-  liftIO $ withVerifiedSslConnection (verifyFingerprints fprs) man reqBuilder $ \req ->
+  liftIO . withVerifiedSslConnection (verifyFingerprints fprs) man reqBuilder $ \req ->
     Http.withResponse req man (const $ return ())
 
 x3 :: RetryPolicy

--- a/services/galley/src/Galley/External.hs
+++ b/services/galley/src/Galley/External.hs
@@ -103,17 +103,18 @@ deliver1 s bm e
     let u = s ^. serviceUrl
     let b = botMemId bm
     let HttpsUrl url = u
-    recovering x3 httpHandlers $ const
-      $ sendMessage (s ^. serviceFingerprints)
-      $ method POST
-        . maybe id host (urlHost u)
-        . maybe (port 443) port (urlPort u)
-        . paths [url ^. pathL, "bots", toByteString' b, "messages"]
-        . header "Authorization" ("Bearer " <> t)
-        . json e
-        . timeout 5000
-        . secure
-        . expect2xx
+    recovering x3 httpHandlers $
+      const $
+        sendMessage (s ^. serviceFingerprints) $
+          method POST
+            . maybe id host (urlHost u)
+            . maybe (port 443) port (urlPort u)
+            . paths [url ^. pathL, "bots", toByteString' b, "messages"]
+            . header "Authorization" ("Bearer " <> t)
+            . json e
+            . timeout 5000
+            . secure
+            . expect2xx
   | otherwise = return ()
 
 urlHost :: HttpsUrl -> Maybe ByteString

--- a/services/galley/src/Galley/Intra/Journal.hs
+++ b/services/galley/src/Galley/Intra/Journal.hs
@@ -65,16 +65,17 @@ teamSuspend :: TeamId -> Galley ()
 teamSuspend tid = journalEvent TeamEvent'TEAM_SUSPEND tid Nothing Nothing
 
 journalEvent :: TeamEvent'EventType -> TeamId -> Maybe TeamEvent'EventData -> Maybe TeamCreationTime -> Galley ()
-journalEvent typ tid dat tim = view aEnv >>= \mEnv -> for_ mEnv $ \e -> do
-  -- writetime is in microseconds in cassandra 3.11
-  ts <- maybe now (return . (`div` 1000000) . view tcTime) tim
-  let ev =
-        defMessage
-          & T.eventType .~ typ
-          & T.teamId .~ toBytes tid
-          & T.utcTime .~ ts
-          & T.maybe'eventData .~ dat
-  Aws.execute e (Aws.enqueue ev)
+journalEvent typ tid dat tim =
+  view aEnv >>= \mEnv -> for_ mEnv $ \e -> do
+    -- writetime is in microseconds in cassandra 3.11
+    ts <- maybe now (return . (`div` 1000000) . view tcTime) tim
+    let ev =
+          defMessage
+            & T.eventType .~ typ
+            & T.teamId .~ toBytes tid
+            & T.utcTime .~ ts
+            & T.maybe'eventData .~ dat
+    Aws.execute e (Aws.enqueue ev)
 
 ----------------------------------------------------------------------------
 -- utils

--- a/services/galley/src/Galley/Intra/Push.hs
+++ b/services/galley/src/Galley/Intra/Push.hs
@@ -50,7 +50,7 @@ where
 import Bilge hiding (options)
 import Bilge.RPC
 import Bilge.Retry
-import Control.Lens ((&), (.~), (^.), makeLenses, set, view)
+import Control.Lens (makeLenses, set, view, (&), (.~), (^.))
 import Control.Monad.Catch
 import Control.Retry
 import Data.Aeson (Object)

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -28,10 +28,9 @@ where
 
 import Bilge hiding (getHeader, options, statusCode)
 import Bilge.RPC
-import Brig.Types.Connection (UserIds (..))
-import Brig.Types.Connection (ConnectionsStatusRequest (..), Relation (..))
-import Brig.Types.Intra (ConnectionStatus (..), ReAuthUser (..))
+import Brig.Types.Connection (ConnectionsStatusRequest (..), Relation (..), UserIds (..))
 import Brig.Types.Intra
+import Brig.Types.Intra (ConnectionStatus (..), ReAuthUser (..))
 import Brig.Types.User (User)
 import Control.Monad.Catch (throwM)
 import Data.ByteString.Char8 (pack)
@@ -71,13 +70,14 @@ getConnections uFrom uTo rlt = do
 deleteBot :: ConvId -> BotId -> Galley ()
 deleteBot cid bot = do
   (h, p) <- brigReq
-  void $ call "brig" $
-    method DELETE . host h . port p
-      . path "/bot/self"
-      . header "Z-Type" "bot"
-      . header "Z-Bot" (toByteString' bot)
-      . header "Z-Conversation" (toByteString' cid)
-      . expect2xx
+  void $
+    call "brig" $
+      method DELETE . host h . port p
+        . path "/bot/self"
+        . header "Z-Type" "bot"
+        . header "Z-Bot" (toByteString' bot)
+        . header "Z-Conversation" (toByteString' cid)
+        . expect2xx
 
 -- | Calls 'Brig.User.API.Auth.reAuthUserH'.
 reAuthUser :: UserId -> ReAuthUser -> Galley Bool
@@ -129,10 +129,11 @@ getUser uid = do
 deleteUser :: UserId -> Galley ()
 deleteUser uid = do
   (h, p) <- brigReq
-  void $ call "brig" $
-    method DELETE . host h . port p
-      . paths ["/i/users", toByteString' uid]
-      . expect2xx
+  void $
+    call "brig" $
+      method DELETE . host h . port p
+        . paths ["/i/users", toByteString' uid]
+        . expect2xx
 
 -- | Calls 'Brig.API.getContactListH'.
 getContactList :: UserId -> Galley [UserId]

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -17,7 +17,7 @@
 
 module Galley.Options where
 
-import Control.Lens hiding ((.=), Level)
+import Control.Lens hiding (Level, (.=))
 import Data.Aeson.TH (deriveFromJSON)
 import Data.Domain (Domain)
 import Data.Misc

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -25,15 +25,15 @@ import Cassandra (runClient, shutdown)
 import Cassandra.Schema (versionCheck)
 import qualified Control.Concurrent.Async as Async
 import Control.Exception (finally)
-import Control.Lens ((^.), view)
+import Control.Lens (view, (^.))
 import qualified Data.Metrics.Middleware as M
 import Data.Metrics.Middleware.Prometheus (waiPrometheusMiddleware)
 import Data.Misc (portNumber)
 import Data.Text (unpack)
 import Galley.API (sitemap)
 import qualified Galley.API.Internal as Internal
-import qualified Galley.App as App
 import Galley.App
+import qualified Galley.App as App
 import qualified Galley.Data as Data
 import Galley.Options (Opts, optGalley)
 import qualified Galley.Queue as Q

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -54,7 +54,7 @@ import Gundeck.Types.Notification
 import Imports
 import Network.Wai.Utilities.Error
 import Test.Tasty
-import Test.Tasty.Cannon ((#), TimeoutUnit (..))
+import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
 import TestHelpers
@@ -384,8 +384,9 @@ postJoinConvOk = do
   WS.bracketR2 c alice bob $ \(wsA, wsB) -> do
     postJoinConv bob conv !!! const 200 === statusCode
     postJoinConv bob conv !!! const 204 === statusCode
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB] $
-      wsAssertMemberJoinWithRole conv bob [bob] roleNameWireMember
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA, wsB] $
+        wsAssertMemberJoinWithRole conv bob [bob] roleNameWireMember
 
 postJoinCodeConvOk :: TestM ()
 postJoinCodeConvOk = do
@@ -412,8 +413,9 @@ postJoinCodeConvOk = do
     postJoinCodeConv bob payload !!! const 204 === statusCode
     -- eve cannot join
     postJoinCodeConv eve payload !!! const 403 === statusCode
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB] $
-      wsAssertMemberJoinWithRole conv bob [bob] roleNameWireMember
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA, wsB] $
+        wsAssertMemberJoinWithRole conv bob [bob] roleNameWireMember
     -- changing access to non-activated should give eve access
     let nonActivatedAccess = ConversationAccessUpdate [CodeAccess] NonActivatedAccessRole
     putAccessUpdate alice conv nonActivatedAccess !!! const 200 === statusCode
@@ -441,8 +443,9 @@ postConvertCodeConv = do
     putAccessUpdate alice conv nonActivatedAccess !!! const 200 === statusCode
     -- test no-op
     putAccessUpdate alice conv nonActivatedAccess !!! const 204 === statusCode
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA] $
-      wsAssertConvAccessUpdate conv alice nonActivatedAccess
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA] $
+        wsAssertConvAccessUpdate conv alice nonActivatedAccess
   -- Create/get/update/delete codes
   getConvCode alice conv !!! const 404 === statusCode
   c1 <- decodeConvCodeEvent <$> (postConvCode alice conv <!! const 201 === statusCode)
@@ -485,16 +488,19 @@ postConvertTeamConv = do
   j <- decodeConvCodeEvent <$> postConvCode alice conv
   WS.bracketR3 c alice bob eve $ \(wsA, wsB, wsE) -> do
     postJoinCodeConv mallory j !!! const 200 === statusCode
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsE] $
-      wsAssertMemberJoinWithRole conv mallory [mallory] roleNameWireMember
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA, wsB, wsE] $
+        wsAssertMemberJoinWithRole conv mallory [mallory] roleNameWireMember
   WS.bracketRN c [alice, bob, eve, mallory] $ \[wsA, wsB, wsE, wsM] -> do
     let teamAccess = ConversationAccessUpdate [InviteAccess, CodeAccess] TeamAccessRole
     putAccessUpdate alice conv teamAccess !!! const 200 === statusCode
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsE, wsM] $
-      wsAssertConvAccessUpdate conv alice teamAccess
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA, wsB, wsE, wsM] $
+        wsAssertConvAccessUpdate conv alice teamAccess
     -- non-team members get kicked out
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsE, wsM] $
-      wsAssertMemberLeave conv alice [eve, mallory]
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA, wsB, wsE, wsM] $
+        wsAssertMemberLeave conv alice [eve, mallory]
     -- joining (for mallory) is no longer possible
     postJoinCodeConv mallory j !!! const 403 === statusCode
     -- team members (dave) can still join
@@ -1141,10 +1147,12 @@ removeUser = do
   conv3 <- decodeConvId <$> postConv alice [carl] (Just "gossip3") [] Nothing Nothing
   WS.bracketR3 c alice bob carl $ \(wsA, wsB, wsC) -> do
     deleteUser bob
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB] $
-      matchMemberLeave conv1 bob
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
-      matchMemberLeave conv2 bob
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA, wsB] $
+        matchMemberLeave conv1 bob
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
+        matchMemberLeave conv2 bob
   -- Check memberships
   mems1 <- fmap cnvMembers . responseJsonUnsafe <$> getConv alice conv1
   mems2 <- fmap cnvMembers . responseJsonUnsafe <$> getConv alice conv2

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -535,7 +535,7 @@ getConvsOk2 = do
   let cs = convList <$> responseJsonUnsafe rs
   let c1 = cs >>= find ((== cnvId cnv1) . cnvId)
   let c2 = cs >>= find ((== cnvId cnv2) . cnvId)
-  liftIO $ forM_ [(cnv1, c1), (cnv2, c2)] $ \(expected, actual) -> do
+  liftIO . forM_ [(cnv1, c1), (cnv2, c2)] $ \(expected, actual) -> do
     assertEqual
       "name mismatch"
       (Just $ cnvName expected)
@@ -968,7 +968,7 @@ putConvRenameOk = do
   -- This endpoint should be deprecated but clients still use it
   WS.bracketR2 c alice bob $ \(wsA, wsB) -> do
     void $ putConversationName bob conv "gossip++" !!! const 200 === statusCode
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB] $ \n -> do
+    void . liftIO . WS.assertMatchN (5 # Second) [wsA, wsB] $ \n -> do
       let e = List1.head (WS.unpackPayload n)
       ntfTransient n @?= False
       evtConv e @?= conv
@@ -1030,7 +1030,7 @@ putMemberOk update = do
   -- Update member state & verify push notification
   WS.bracketR c bob $ \ws -> do
     putMember bob update conv !!! const 200 === statusCode
-    void . liftIO $ WS.assertMatch (5 # Second) ws $ \n -> do
+    void . liftIO . WS.assertMatch (5 # Second) ws $ \n -> do
       let e = List1.head (WS.unpackPayload n)
       ntfTransient n @?= False
       evtConv e @?= conv

--- a/services/galley/test/integration/API/IdMapping.hs
+++ b/services/galley/test/integration/API/IdMapping.hs
@@ -22,12 +22,12 @@ module API.IdMapping where
 import API.Util (withSettingsOverrides)
 import Bilge hiding (timeout)
 import Bilge.Assert
-import Control.Lens ((?~), view)
+import Control.Lens (view, (?~))
 import Data.ByteString.Conversion (toByteString')
 import Data.Coerce (coerce)
 import Data.Domain (Domain, mkDomain)
-import qualified Data.Id as Id
 import Data.Id (Id)
+import qualified Data.Id as Id
 import Data.Qualified (Qualified (Qualified))
 import Galley.Options (optSettings, setEnableFederationWithDomain)
 import Galley.Types.IdMapping (PostIdMappingRequest (PostIdMappingRequest), PostIdMappingResponse (PostIdMappingResponse))

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -32,7 +32,7 @@ import qualified Galley.Types.Teams as Teams
 import Imports hiding (head)
 import Network.Wai.Utilities.Error
 import Test.Tasty
-import Test.Tasty.Cannon ((#), TimeoutUnit (..))
+import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import qualified Test.Tasty.Cannon as WS
 import TestHelpers
 import TestSetup
@@ -151,8 +151,9 @@ messageTimerEvent = do
     let update = ConversationMessageTimerUpdate timer1sec
     putMessageTimerUpdate alice cid update
       !!! const 200 === statusCode
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB] $
-      wsAssertConvMessageTimerUpdate cid alice update
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA, wsB] $
+        wsAssertConvMessageTimerUpdate cid alice update
 
 ----------------------------------------------------------------------------
 -- Utilities

--- a/services/galley/test/integration/API/Roles.hs
+++ b/services/galley/test/integration/API/Roles.hs
@@ -72,7 +72,7 @@ handleConversationRoleAdmin = do
   WS.bracketR3 c alice bob chuck $ \(wsA, wsB, wsC) -> do
     let updateDown = OtherMemberUpdate (Just roleNameWireMember)
     putOtherMember alice bob updateDown cid !!! assertActionSucceeded
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $ do
+    void . liftIO . WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $ do
       wsAssertMemberUpdateWithRole cid alice bob roleNameWireMember
   wireMemberChecks cid bob alice jack
 
@@ -105,7 +105,7 @@ handleConversationRoleMember = do
     -- Chuck cannot update, member only
     putOtherMember chuck bob updateUp cid !!! assertActionDenied
     putOtherMember alice bob updateUp cid !!! assertActionSucceeded
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $ do
+    void . liftIO . WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $ do
       wsAssertMemberUpdateWithRole cid alice bob roleNameWireAdmin
   wireAdminChecks cid bob alice chuck
 

--- a/services/galley/test/integration/API/Roles.hs
+++ b/services/galley/test/integration/API/Roles.hs
@@ -28,7 +28,7 @@ import Galley.Types.Conversations.Roles
 import Imports
 import Network.Wai.Utilities.Error
 import Test.Tasty
-import Test.Tasty.Cannon ((#), TimeoutUnit (..))
+import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import qualified Test.Tasty.Cannon as WS
 import TestHelpers
 import TestSetup
@@ -59,12 +59,14 @@ handleConversationRoleAdmin = do
     let cid = decodeConvId rsp
     -- Make sure everyone gets the correct event
     postMembersWithRole alice (singleton eve) cid role !!! const 200 === statusCode
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
-      wsAssertMemberJoinWithRole cid alice [eve] role
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
+        wsAssertMemberJoinWithRole cid alice [eve] role
     -- Add a member to help out with testing
     postMembersWithRole alice (singleton jack) cid roleNameWireMember !!! const 200 === statusCode
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
-      wsAssertMemberJoinWithRole cid alice [jack] roleNameWireMember
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
+        wsAssertMemberJoinWithRole cid alice [jack] roleNameWireMember
     return cid
   -- Added bob as a wire_admin and do the checks
   wireAdminChecks cid alice bob jack
@@ -94,8 +96,9 @@ handleConversationRoleMember = do
     let cid = decodeConvId rsp
     -- Make sure everyone gets the correct event
     postMembersWithRole alice (singleton eve) cid role !!! const 200 === statusCode
-    void . liftIO $ WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
-      wsAssertMemberJoinWithRole cid alice [eve] role
+    void . liftIO $
+      WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
+        wsAssertMemberJoinWithRole cid alice [eve] role
     return cid
   -- Added bob as a wire_member and do the checks
   wireMemberChecks cid bob alice chuck

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -63,7 +63,7 @@ import qualified Network.Wai.Utilities.Error as Wai
 import qualified Proto.TeamEvents as E
 import qualified Proto.TeamEvents_Fields as E
 import Test.Tasty
-import Test.Tasty.Cannon ((#), TimeoutUnit (..))
+import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
 import TestHelpers (test)
@@ -330,9 +330,10 @@ testEnableTeamSearchVisibilityPerTeam = do
           assertEqual "bad status" status403 status
           assertEqual "bad label" "team-search-visibility-not-enabled" label
   let getSearchVisibilityCheck :: (HasCallStack, MonadCatch m, MonadIO m, MonadHttp m) => TeamSearchVisibility -> m ()
-      getSearchVisibilityCheck vis = getSearchVisibility g owner tid !!! do
-        const 200 === statusCode
-        const (Just (TeamSearchVisibilityView vis)) === responseJsonUnsafe
+      getSearchVisibilityCheck vis =
+        getSearchVisibility g owner tid !!! do
+          const 200 === statusCode
+          const (Just (TeamSearchVisibilityView vis)) === responseJsonUnsafe
 
   Util.withCustomSearchFeature FeatureTeamSearchVisibilityEnabledByDefault $ do
     check "Teams should start with Custom Search Visibility enabled" Public.TeamFeatureEnabled
@@ -1769,7 +1770,7 @@ postCryptoBroadcastMessageJson2 = do
   cc <- Util.randomClient charlie (someLastPrekeys !! 2)
   connectUsers alice (list1 charlie [])
   let t = 3 # Second -- WS receive timeout
-      -- Missing charlie
+  -- Missing charlie
   let m1 = [(bob, bc, "ciphertext1")]
   Util.postOtrBroadcastMessage id alice ac m1 !!! do
     const 412 === statusCode

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -941,7 +941,7 @@ testDeleteTeam = do
   Util.assertConvMember owner cid1
   Util.assertConvMember extern cid1
   Util.assertNotConvMember (member ^. userId) cid1
-  void $ WS.bracketR3 c owner extern (member ^. userId) $ \(wsOwner, wsExtern, wsMember) -> do
+  void . WS.bracketR3 c owner extern (member ^. userId) $ \(wsOwner, wsExtern, wsMember) -> do
     delete (g . paths ["teams", toByteString' tid] . zUser owner . zConn "conn")
       !!! const 202 === statusCode
     checkTeamDeleteEvent tid wsOwner
@@ -1004,7 +1004,7 @@ testDeleteBindingTeamSingleMember = do
       (/= Just True)
       (getDeletedState extern (other ^. userId))
 
-  void $ WS.bracketRN c [owner, extern] $ \[wsOwner, wsExtern] -> do
+  void . WS.bracketRN c [owner, extern] $ \[wsOwner, wsExtern] -> do
     delete
       ( g
           . paths ["/i/teams", toByteString' tid]
@@ -1075,7 +1075,7 @@ testDeleteBindingTeam ownerHasPassword = do
     !!! const 202
     === statusCode
   assertQueue "team member leave 1" $ tUpdate 4 [ownerWithPassword, owner]
-  void $ WS.bracketRN c [owner, (mem1 ^. userId), (mem2 ^. userId), extern] $ \[wsOwner, wsMember1, wsMember2, wsExtern] -> do
+  void . WS.bracketRN c [owner, (mem1 ^. userId), (mem2 ^. userId), extern] $ \[wsOwner, wsMember1, wsMember2, wsExtern] -> do
     delete
       ( g
           . paths ["teams", toByteString' tid]
@@ -1327,7 +1327,7 @@ testTeamAddRemoveMemberAboveThresholdNoEvents = do
     deleteTeam tid owner otherRealUsersInTeam teamCidsThatExternBelongsTo extern = do
       c <- view tsCannon
       g <- view tsGalley
-      void $ WS.bracketRN c (owner : extern : otherRealUsersInTeam) $ \(_wsOwner : wsExtern : _wsotherRealUsersInTeam) -> do
+      void . WS.bracketRN c (owner : extern : otherRealUsersInTeam) $ \(_wsOwner : wsExtern : _wsotherRealUsersInTeam) -> do
         delete
           ( g
               . paths ["teams", toByteString' tid]

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -121,18 +121,20 @@ testSearchVisibility = do
         TeamId ->
         Public.TeamFeatureStatusValue ->
         m ()
-      getTeamSearchVisibility teamid expected = Util.getTeamSearchVisibilityAvailable g owner teamid !!! do
-        statusCode === const 200
-        responseJsonEither === const (Right (Public.TeamFeatureStatus expected))
+      getTeamSearchVisibility teamid expected =
+        Util.getTeamSearchVisibilityAvailable g owner teamid !!! do
+          statusCode === const 200
+          responseJsonEither === const (Right (Public.TeamFeatureStatus expected))
 
   let getTeamSearchVisibilityInternal ::
         (Monad m, MonadHttp m, MonadIO m, MonadCatch m, HasCallStack) =>
         TeamId ->
         Public.TeamFeatureStatusValue ->
         m ()
-      getTeamSearchVisibilityInternal teamid expected = Util.getTeamSearchVisibilityAvailableInternal g teamid !!! do
-        statusCode === const 200
-        responseJsonEither === const (Right (Public.TeamFeatureStatus expected))
+      getTeamSearchVisibilityInternal teamid expected =
+        Util.getTeamSearchVisibilityAvailableInternal g teamid !!! do
+          statusCode === const 200
+          responseJsonEither === const (Right (Public.TeamFeatureStatus expected))
 
   let setTeamSearchVisibilityInternal ::
         (Monad m, MonadHttp m, MonadIO m, HasCallStack) =>
@@ -187,6 +189,7 @@ testSimpleFlag feature = do
   getFlagInternal feature Public.TeamFeatureEnabled
 
 assertFlag :: HasCallStack => TestM ResponseLBS -> Public.TeamFeatureStatusValue -> TestM ()
-assertFlag res expected = res !!! do
-  statusCode === const 200
-  responseJsonEither === const (Right (Public.TeamFeatureStatus expected))
+assertFlag res expected =
+  res !!! do
+    statusCode === const 200
+    responseJsonEither === const (Right (Public.TeamFeatureStatus expected))

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -321,7 +321,7 @@ testDisableLegalHoldForUser = do
     disableLegalHoldForUser Nothing tid owner member !!! const 403 === statusCode
     assertExactlyOneLegalHoldDevice member
     disableLegalHoldForUser (Just defPassword) tid owner member !!! testResponse 200 Nothing
-    liftIO $ assertMatchChan chan $ \(req, _) -> do
+    liftIO . assertMatchChan chan $ \(req, _) -> do
       assertEqual "method" "POST" (requestMethod req)
       assertEqual "path" (pathInfo req) ["legalhold", "remove"]
     assertNotification mws $ \case
@@ -468,7 +468,7 @@ testRemoveLegalHoldFromTeam = do
     deleteSettings Nothing owner tid !!! testResponse 403 (Just "access-denied")
     let delete'' expectRemoteLHCall = do
           deleteSettings (Just defPassword) owner tid !!! testResponse 204 Nothing
-          when expectRemoteLHCall $ liftIO $ assertMatchChan chan $ \(req, _) -> do
+          when expectRemoteLHCall . liftIO . assertMatchChan chan $ \(req, _) -> do
             putStrLn (show (pathInfo req, pathInfo req == ["legalhold", "remove"]))
             putStrLn (show (requestMethod req, requestMethod req == "POST"))
             assertEqual "path" ["legalhold", "remove"] (pathInfo req)

--- a/services/galley/test/integration/API/Util/TeamFeature.hs
+++ b/services/galley/test/integration/API/Util/TeamFeature.hs
@@ -17,10 +17,10 @@
 
 module API.Util.TeamFeature where
 
-import qualified API.Util as Util
 import API.Util (zUser)
+import qualified API.Util as Util
 import Bilge
-import Control.Lens ((.~), view)
+import Control.Lens (view, (.~))
 import Data.ByteString.Conversion (toByteString')
 import Data.Id (TeamId, UserId)
 import Galley.Options (optSettings, setFeatureFlags)

--- a/services/galley/test/integration/Main.hs
+++ b/services/galley/test/integration/Main.hs
@@ -60,24 +60,25 @@ instance IsOption ServiceConfigFile where
   optionName = return "service-config"
   optionHelp = return "Service config file to read from"
   optionCLParser =
-    fmap ServiceConfigFile $ strOption $
-      ( short (untag (return 's' :: Tagged ServiceConfigFile Char))
-          <> long (untag (optionName :: Tagged ServiceConfigFile String))
-          <> help (untag (optionHelp :: Tagged ServiceConfigFile String))
-      )
+    fmap ServiceConfigFile $
+      strOption $
+        ( short (untag (return 's' :: Tagged ServiceConfigFile Char))
+            <> long (untag (optionName :: Tagged ServiceConfigFile String))
+            <> help (untag (optionHelp :: Tagged ServiceConfigFile String))
+        )
 
 runTests :: (String -> String -> TestTree) -> IO ()
-runTests run = defaultMainWithIngredients ings
-  $ askOption
-  $ \(ServiceConfigFile c) ->
-    askOption $ \(IntegrationConfigFile i) -> run c i
+runTests run = defaultMainWithIngredients ings $
+  askOption $
+    \(ServiceConfigFile c) ->
+      askOption $ \(IntegrationConfigFile i) -> run c i
   where
     ings =
       includingOptions
         [ Option (Proxy :: Proxy ServiceConfigFile),
           Option (Proxy :: Proxy IntegrationConfigFile)
-        ]
-        : defaultIngredients
+        ] :
+      defaultIngredients
 
 main :: IO ()
 main = withOpenSSL $ runTests go

--- a/services/gundeck/src/Gundeck/Aws.hs
+++ b/services/gundeck/src/Gundeck/Aws.hs
@@ -72,8 +72,7 @@ import Gundeck.Options
 import Gundeck.Types.Push (AppName (..), Token, Transport (..))
 import qualified Gundeck.Types.Push as Push
 import Imports
-import Network.AWS (AWSRequest, Rs)
-import Network.AWS (serviceAbbrev, serviceCode, serviceMessage, serviceStatus)
+import Network.AWS (AWSRequest, Rs, serviceAbbrev, serviceCode, serviceMessage, serviceStatus)
 import qualified Network.AWS as AWS
 import qualified Network.AWS.Data as AWS
 import qualified Network.AWS.Env as AWS
@@ -202,9 +201,9 @@ mkEnv lgr opts mgr = do
     getQueueUrl :: AWS.Env -> Text -> IO QueueUrl
     getQueueUrl e q = do
       x <-
-        runResourceT . AWST.runAWST e
-          $ AWST.trying AWS._Error
-          $ AWST.send (SQS.getQueueURL q)
+        runResourceT . AWST.runAWST e $
+          AWST.trying AWS._Error $
+            AWST.send (SQS.getQueueURL q)
       either
         (throwM . GeneralError)
         (return . QueueUrl . view SQS.gqursQueueURL)
@@ -447,7 +446,7 @@ listen throttleMillis callback = do
     receive url =
       SQS.receiveMessage url
         & set SQS.rmWaitTimeSeconds (Just 20)
-        . set SQS.rmMaxNumberOfMessages (Just 10)
+          . set SQS.rmMaxNumberOfMessages (Just 10)
     onMessage url m =
       case decodeStrict =<< Text.encodeUtf8 <$> m ^. mBody of
         Nothing ->

--- a/services/gundeck/src/Gundeck/Aws.hs
+++ b/services/gundeck/src/Gundeck/Aws.hs
@@ -141,7 +141,7 @@ newtype Amazon a = Amazon
     )
 
 instance MonadUnliftIO Amazon where
-  askUnliftIO = Amazon $ ReaderT $ \r ->
+  askUnliftIO = Amazon . ReaderT $ \r ->
     withUnliftIO $ \u ->
       return (UnliftIO (unliftIO u . flip runReaderT r . unAmazon))
 
@@ -438,7 +438,7 @@ publish arn txt attrs = do
 listen :: Int -> (Event -> IO ()) -> Amazon ()
 listen throttleMillis callback = do
   QueueUrl url <- view eventQueue
-  forever $ handleAny unexpectedError $ do
+  forever . handleAny unexpectedError $ do
     msgs <- view rmrsMessages <$> send (receive url)
     void $ mapConcurrently (onMessage url) msgs
     when (null msgs) $

--- a/services/gundeck/src/Gundeck/Env.hs
+++ b/services/gundeck/src/Gundeck/Env.hs
@@ -22,7 +22,7 @@ import Cassandra (ClientState, Keyspace (..))
 import qualified Cassandra as C
 import qualified Cassandra.Settings as C
 import Control.AutoUpdate
-import Control.Lens ((^.), makeLenses)
+import Control.Lens (makeLenses, (^.))
 import Data.Default (def)
 import qualified Data.List.NonEmpty as NE
 import Data.Metrics.Middleware (Metrics)
@@ -73,17 +73,17 @@ createEnv m o = do
           managerResponseTimeout = responseTimeoutMicro 5000000
         }
   r <-
-    Redis.mkPool (Logger.clone (Just "redis.gundeck") l)
-      $ Redis.setHost (unpack $ o ^. optRedis . epHost)
+    Redis.mkPool (Logger.clone (Just "redis.gundeck") l) $
+      Redis.setHost (unpack $ o ^. optRedis . epHost)
         . Redis.setPort (o ^. optRedis . epPort)
         . Redis.setMaxConnections 100
         . Redis.setPoolStripes 4
         . Redis.setConnectTimeout 3
         . Redis.setSendRecvTimeout 5
-      $ Redis.defSettings
+        $ Redis.defSettings
   p <-
-    C.init
-      $ C.setLogger (C.mkLogger (Logger.clone (Just "cassandra.gundeck") l))
+    C.init $
+      C.setLogger (C.mkLogger (Logger.clone (Just "cassandra.gundeck") l))
         . C.setContacts (NE.head c) (NE.tail c)
         . C.setPortNumber (fromIntegral $ o ^. optCassandra . casEndpoint . epPort)
         . C.setKeyspace (Keyspace (o ^. optCassandra . casKeyspace))
@@ -93,7 +93,7 @@ createEnv m o = do
         . C.setSendTimeout 3
         . C.setResponseTimeout 10
         . C.setProtocolVersion C.V4
-      $ C.defSettings
+        $ C.defSettings
   a <- Aws.mkEnv l o n
   io <-
     mkAutoUpdate

--- a/services/gundeck/src/Gundeck/Instances.hs
+++ b/services/gundeck/src/Gundeck/Instances.hs
@@ -83,7 +83,8 @@ instance ToText (Id a) where
   toText = Text.decodeUtf8 . Uuid.toASCIIBytes . toUUID
 
 instance FromText (Id a) where
-  parser = Parser.take 36 >>= \txt ->
-    txt & Text.encodeUtf8
-      & Uuid.fromASCIIBytes
-      & maybe (fail "Invalid UUID") (return . Id)
+  parser =
+    Parser.take 36 >>= \txt ->
+      txt & Text.encodeUtf8
+        & Uuid.fromASCIIBytes
+        & maybe (fail "Invalid UUID") (return . Id)

--- a/services/gundeck/src/Gundeck/Monad.hs
+++ b/services/gundeck/src/Gundeck/Monad.hs
@@ -75,7 +75,7 @@ newtype Gundeck a = Gundeck
 
 instance MonadUnliftIO Gundeck where
   askUnliftIO =
-    Gundeck $ ReaderT $ \r ->
+    Gundeck . ReaderT $ \r ->
       withUnliftIO $ \u ->
         return (UnliftIO (unliftIO u . flip runReaderT r . unGundeck))
 

--- a/services/gundeck/src/Gundeck/Notification/Data.hs
+++ b/services/gundeck/src/Gundeck/Notification/Data.hs
@@ -31,7 +31,7 @@ import qualified Data.Aeson as JSON
 import Data.Id
 import Data.List1 (List1)
 import Data.Range (Range, fromRange)
-import Data.Sequence ((<|), (><), Seq, ViewL (..), ViewR (..))
+import Data.Sequence (Seq, ViewL (..), ViewR (..), (<|), (><))
 import qualified Data.Sequence as Seq
 import Gundeck.Options (NotificationTTL (..))
 import Gundeck.Types.Notification
@@ -87,9 +87,10 @@ fetchLast u c = do
   ls <- query cqlLast (params Quorum (Identity u)) & retry x1
   case ls of
     [] -> return Nothing
-    ns@(n : _) -> ns `getFirstOrElse` do
-      p <- paginate cqlSeek (paramsP Quorum (u, n ^. _1) 100) & retry x1
-      seek p
+    ns@(n : _) ->
+      ns `getFirstOrElse` do
+        p <- paginate cqlSeek (paramsP Quorum (u, n ^. _1) 100) & retry x1
+        seek p
   where
     seek p =
       result p

--- a/services/gundeck/src/Gundeck/Presence/Data.hs
+++ b/services/gundeck/src/Gundeck/Presence/Data.hs
@@ -60,7 +60,7 @@ add p = do
   let k = toKey (userId p)
   let v = toField (connId p)
   let d = encode $ PresenceData (resource p) (clientId p) now
-  retry x3 $ commands $ do
+  retry x3 . commands $ do
     multi
     void $ hset k v d
     -- nb. All presences of a user are expired 'maxIdleTime' after the
@@ -77,7 +77,7 @@ deleteAll [] = return ()
 deleteAll pp = for_ pp $ \p -> do
   let k = toKey (userId p)
   let f = __field p
-  retry x3 $ commands $ do
+  retry x3 . commands $ do
     watch (pure k)
     value <- hget k f
     multi

--- a/services/gundeck/src/Gundeck/Push/Native.hs
+++ b/services/gundeck/src/Gundeck/Push/Native.hs
@@ -22,7 +22,7 @@ module Gundeck.Push.Native
   )
 where
 
-import Control.Lens ((.~), (^.), view)
+import Control.Lens (view, (.~), (^.))
 import Control.Monad.Catch
 import Data.ByteString.Conversion.To
 import Data.Id

--- a/services/gundeck/src/Gundeck/Push/Native/Serialise.hs
+++ b/services/gundeck/src/Gundeck/Push/Native/Serialise.hs
@@ -22,7 +22,7 @@ module Gundeck.Push.Native.Serialise
 where
 
 import Control.Lens ((^.), (^?), _Just)
-import Data.Aeson ((.=), Value, object)
+import Data.Aeson (Value, object, (.=))
 import Data.Aeson.Text (encodeToTextBuilder)
 import qualified Data.ByteString as BS
 import Data.Json.Util
@@ -85,8 +85,10 @@ renderText t aps prio x = case t of
                 # "loc-args" .= (aps ^? _Just . apsLocArgs)
                 # []
             )
-          # "sound" .= (aps ^? _Just . apsSound)
-          # "content-available" .= '1'
+          # "sound"
+          .= (aps ^? _Just . apsSound)
+          # "content-available"
+          .= '1'
           # []
     apsDict LowPriority =
       object $

--- a/services/gundeck/src/Gundeck/Push/Native/Types.hs
+++ b/services/gundeck/src/Gundeck/Push/Native/Types.hs
@@ -40,7 +40,7 @@ module Gundeck.Push.Native.Types
   )
 where
 
-import Control.Lens (Lens', (^.), makeLenses, view)
+import Control.Lens (Lens', makeLenses, view, (^.))
 import Data.Id (ClientId, ConnId, UserId)
 import Gundeck.Aws.Arn
 import Gundeck.Types

--- a/services/gundeck/src/Gundeck/Push/Websocket.hs
+++ b/services/gundeck/src/Gundeck/Push/Websocket.hs
@@ -27,7 +27,7 @@ import Bilge.RPC
 import Bilge.Retry (rpcHandlers)
 import Control.Arrow ((&&&))
 import Control.Exception (ErrorCall (ErrorCall))
-import Control.Lens ((%~), (^.), _2, view)
+import Control.Lens (view, (%~), (^.), _2)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow, catch, throwM, try)
 import Control.Retry
 import Data.Aeson (eitherDecode, encode)
@@ -51,7 +51,7 @@ import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..))
 import qualified Network.HTTP.Client.Internal as Http
 import Network.HTTP.Types (StdMethod (POST), status200, status410)
 import qualified Network.URI as URI
-import System.Logger.Class ((+++), val, (~~))
+import System.Logger.Class (val, (+++), (~~))
 import qualified System.Logger.Class as Log
 import UnliftIO (handleAny, mapConcurrently)
 
@@ -368,12 +368,13 @@ send n pp =
   where
     fn js p = do
       req <- Http.setUri empty (fromURI (resource p))
-      recovering x1 rpcHandlers $ const
-        $ rpc' "cannon" (check req)
-        $ method POST
-          . contentJson
-          . lbytes js
-          . timeout 3000 -- ms
+      recovering x1 rpcHandlers $
+        const $
+          rpc' "cannon" (check req) $
+            method POST
+              . contentJson
+              . lbytes js
+              . timeout 3000 -- ms
     check r =
       r
         { Http.checkResponse = \rq rs ->

--- a/services/gundeck/src/Gundeck/React.hs
+++ b/services/gundeck/src/Gundeck/React.hs
@@ -22,7 +22,7 @@ module Gundeck.React
   )
 where
 
-import Control.Lens ((.~), (^.), view)
+import Control.Lens (view, (.~), (^.))
 import Data.ByteString.Conversion
 import Data.Id (ClientId, UserId)
 import qualified Data.List as List
@@ -44,7 +44,7 @@ import qualified Gundeck.Push.Websocket as Web
 import Gundeck.Types
 import Gundeck.Util
 import Imports
-import System.Logger.Class ((+++), (.=), Msg, msg, val, (~~))
+import System.Logger.Class (Msg, msg, val, (+++), (.=), (~~))
 import qualified System.Logger.Class as Log
 
 onEvent :: Event -> Gundeck ()
@@ -76,7 +76,8 @@ onUpdated ev = withEndpoint ev $ \e as ->
       forM_ sup $ \a -> do
         logUserEvent (a ^. addrUser) ev $ msg (val "Removing superseded token")
         deleteToken (a ^. addrUser) ev (a ^. addrToken) (a ^. addrClient)
-      if  | null sup -> return ()
+      if
+          | null sup -> return ()
           | null cur -> deleteEndpoint ev
           | otherwise -> updateEndpoint ev e (map (view addrUser) cur)
 

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -322,7 +322,7 @@ sendMultipleUsers = do
   -- 'uid1' and 'uid2' should each have 1 notification
   ntfs1 <- listNotifications uid1 Nothing
   ntfs2 <- listNotifications uid2 Nothing
-  liftIO $ forM_ [ntfs1, ntfs2] $ \ntfs -> do
+  liftIO . forM_ [ntfs1, ntfs2] $ \ntfs -> do
     assertEqual "Not exactly 1 notification" 1 (length ntfs)
     let p = view queuedNotificationPayload (Prelude.head ntfs)
     assertEqual "Wrong events in notification" pload p
@@ -390,7 +390,7 @@ targetClientPush = do
   -- Check the notification stream
   ns1 <- listNotifications uid (Just cid1)
   ns2 <- listNotifications uid (Just cid2)
-  liftIO $ forM_ [(ns1, cid1), (ns2, cid2)] $ \(ns, c) -> do
+  liftIO . forM_ [(ns1, cid1), (ns2, cid2)] $ \(ns, c) -> do
     assertEqual "Not exactly 1 notification" 1 (length ns)
     let p = view queuedNotificationPayload (Prelude.head ns)
     assertEqual "Wrong events in notification" (pload c) p

--- a/services/gundeck/test/integration/Main.hs
+++ b/services/gundeck/test/integration/Main.hs
@@ -65,24 +65,25 @@ instance IsOption ServiceConfigFile where
   optionName = return "service-config"
   optionHelp = return "Service config file to read from"
   optionCLParser =
-    fmap ServiceConfigFile $ strOption $
-      ( short (untag (return 's' :: Tagged ServiceConfigFile Char))
-          <> long (untag (optionName :: Tagged ServiceConfigFile String))
-          <> help (untag (optionHelp :: Tagged ServiceConfigFile String))
-      )
+    fmap ServiceConfigFile $
+      strOption $
+        ( short (untag (return 's' :: Tagged ServiceConfigFile Char))
+            <> long (untag (optionName :: Tagged ServiceConfigFile String))
+            <> help (untag (optionHelp :: Tagged ServiceConfigFile String))
+        )
 
 runTests :: (String -> String -> TestTree) -> IO ()
-runTests run = defaultMainWithIngredients ings
-  $ askOption
-  $ \(ServiceConfigFile c) ->
-    askOption $ \(IntegrationConfigFile i) -> run c i
+runTests run = defaultMainWithIngredients ings $
+  askOption $
+    \(ServiceConfigFile c) ->
+      askOption $ \(IntegrationConfigFile i) -> run c i
   where
     ings =
       includingOptions
         [ Option (Proxy :: Proxy ServiceConfigFile),
           Option (Proxy :: Proxy IntegrationConfigFile)
-        ]
-        : defaultIngredients
+        ] :
+      defaultIngredients
 
 main :: IO ()
 main = withOpenSSL $ runTests go

--- a/services/gundeck/test/integration/TestSetup.hs
+++ b/services/gundeck/test/integration/TestSetup.hs
@@ -37,7 +37,7 @@ where
 
 import Bilge (HttpT (..), Manager, MonadHttp, Request, runHttpT)
 import qualified Cassandra as Cql
-import Control.Lens ((^.), makeLenses)
+import Control.Lens (makeLenses, (^.))
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Fail (MonadFail)
 import Imports

--- a/services/gundeck/test/unit/ThreadBudget.hs
+++ b/services/gundeck/test/unit/ThreadBudget.hs
@@ -154,8 +154,8 @@ testThreadBudgets :: Assertion
 testThreadBudgets = do
   let timeUnits n = MilliSeconds $ lengthOfTimeUnit * n
       lengthOfTimeUnit = 5 -- if you make this larger, the test will run more slowly, and be
-        -- less likely to have timing issues.  if you make it too small, some of the calls to
-        -- 'delayms' may return too fast and some things may not be ready yet.
+      -- less likely to have timing issues.  if you make it too small, some of the calls to
+      -- 'delayms' may return too fast and some things may not be ready yet.
   tbs <- mkThreadBudgetState (MaxConcurrentNativePushes (Just 5) (Just 5))
   logHistory :: LogHistory <- newMVar []
   watcher <- mkWatcher tbs logHistory

--- a/services/proxy/src/Proxy/API/Public.hs
+++ b/services/proxy/src/Proxy/API/Public.hs
@@ -184,7 +184,7 @@ x2 :: RetryPolicy
 x2 = exponentialBackoff 5000 <> limitRetries 2
 
 handler :: (MonadIO m, MonadMask m) => RetryStatus -> Handler m Bool
-handler = const $ Handler $ \case
+handler = const . Handler $ \case
   Client.HttpExceptionRequest _ Client.NoResponseDataReceived -> return True
   Client.HttpExceptionRequest _ Client.IncompleteHeaders -> return True
   Client.HttpExceptionRequest _ (Client.ConnectionTimeout) -> return True

--- a/services/proxy/src/Proxy/API/Public.hs
+++ b/services/proxy/src/Proxy/API/Public.hs
@@ -117,16 +117,16 @@ spotifyToken rq = do
       req = baseReq {Client.requestHeaders = hdr}
   mgr <- view manager
   res <- liftIO $ recovering x2 [handler] $ const (Client.httpLbs (Req.lbytes b req) mgr)
-  when (isError (Client.responseStatus res))
-    $ debug
-    $ msg (val "unexpected upstream response")
-      ~~ "upstream" .= val "spotify::token"
-      ~~ "status" .= S (Client.responseStatus res)
-      ~~ "body" .= B.take 256 (Client.responseBody res)
+  when (isError (Client.responseStatus res)) $
+    debug $
+      msg (val "unexpected upstream response")
+        ~~ "upstream" .= val "spotify::token"
+        ~~ "status" .= S (Client.responseStatus res)
+        ~~ "body" .= B.take 256 (Client.responseBody res)
   return $
     plain (Client.responseBody res)
       & setStatus (Client.responseStatus res)
-      . maybeHeader hContentType res
+        . maybeHeader hContentType res
   where
     baseReq =
       Req.method POST
@@ -142,16 +142,16 @@ soundcloudResolve url = do
   let req = Req.queryItem "client_id" s . Req.queryItem "url" url $ baseReq
   mgr <- view manager
   res <- liftIO $ recovering x2 [handler] $ const (Client.httpLbs req mgr)
-  when (isError (Client.responseStatus res))
-    $ debug
-    $ msg (val "unexpected upstream response")
-      ~~ "upstream" .= val "soundcloud::resolve"
-      ~~ "status" .= S (Client.responseStatus res)
-      ~~ "body" .= B.take 256 (Client.responseBody res)
+  when (isError (Client.responseStatus res)) $
+    debug $
+      msg (val "unexpected upstream response")
+        ~~ "upstream" .= val "soundcloud::resolve"
+        ~~ "status" .= S (Client.responseStatus res)
+        ~~ "body" .= B.take 256 (Client.responseBody res)
   return $
     plain (Client.responseBody res)
       & setStatus (Client.responseStatus res)
-      . maybeHeader hContentType res
+        . maybeHeader hContentType res
   where
     baseReq =
       Req.method GET

--- a/services/proxy/src/Proxy/Env.hs
+++ b/services/proxy/src/Proxy/Env.hs
@@ -28,7 +28,7 @@ module Proxy.Env
   )
 where
 
-import Control.Lens ((^.), makeLenses)
+import Control.Lens (makeLenses, (^.))
 import Data.Configurator
 import Data.Configurator.Types
 import Data.Default (def)

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -367,9 +367,10 @@ validateIdPUpdate ::
   SAML.IdPId ->
   m (TeamId, IdP)
 validateIdPUpdate zusr _idpMetadata _idpId = do
-  previousIdP <- wrapMonadClient (Data.getIdPConfig _idpId) >>= \case
-    Nothing -> throwError errUnknownIdPId
-    Just idp -> pure idp
+  previousIdP <-
+    wrapMonadClient (Data.getIdPConfig _idpId) >>= \case
+      Nothing -> throwError errUnknownIdPId
+      Just idp -> pure idp
   teamId <- authorizeIdP zusr previousIdP
   unless (previousIdP ^. SAML.idpExtraInfo . wiTeam == teamId) $ do
     throwError errUnknownIdP

--- a/services/spar/src/Spar/API/Swagger.hs
+++ b/services/spar/src/Spar/API/Swagger.hs
@@ -131,12 +131,13 @@ instance ToSchema SAML.IdPMetadata where
 
 instance ToSchema IdPMetadataInfo where
   declareNamedSchema _ =
-    pure $ NamedSchema (Just "IdPMetadataInfo") $
-      mempty
-        & properties .~ properties_
-        & minProperties ?~ 1
-        & maxProperties ?~ 1
-        & type_ .~ Just SwaggerObject
+    pure $
+      NamedSchema (Just "IdPMetadataInfo") $
+        mempty
+          & properties .~ properties_
+          & minProperties ?~ 1
+          & maxProperties ?~ 1
+          & type_ .~ Just SwaggerObject
     where
       properties_ :: InsOrdHashMap Text (Referenced Schema)
       properties_ =

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -43,7 +43,7 @@ import Control.Exception (assert)
 import Control.Lens hiding ((.=))
 import qualified Control.Monad.Catch as Catch
 import Control.Monad.Except
-import Data.Aeson as Aeson ((.=), encode, object)
+import Data.Aeson as Aeson (encode, object, (.=))
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Id
@@ -401,10 +401,11 @@ verdictHandlerResultCore bindCky = \case
 --   not be the title of any page sent by the IdP while it negotiates with the user.
 -- - The page broadcasts a message to '*', to be picked up by the app.
 verdictHandlerWeb :: HasCallStack => VerdictHandlerResult -> Spar SAML.ResponseVerdict
-verdictHandlerWeb = pure . \case
-  VerifyHandlerGranted cky _uid -> successPage cky
-  VerifyHandlerDenied reasons -> forbiddenPage "forbidden" (explainDeniedReason <$> reasons)
-  VerifyHandlerError lbl msg -> forbiddenPage lbl [msg]
+verdictHandlerWeb =
+  pure . \case
+    VerifyHandlerGranted cky _uid -> successPage cky
+    VerifyHandlerDenied reasons -> forbiddenPage "forbidden" (explainDeniedReason <$> reasons)
+    VerifyHandlerError lbl msg -> forbiddenPage lbl [msg]
   where
     forbiddenPage :: ST -> [ST] -> SAML.ResponseVerdict
     forbiddenPage errlbl reasons =

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -142,7 +142,8 @@ mkTTL now maxttl endOfLife = mkTTLNDT maxttl $ endOfLife `diffUTCTime` now
 
 mkTTLNDT :: (MonadError TTLError m, KnownSymbol a) => TTL a -> NominalDiffTime -> m (TTL a)
 mkTTLNDT maxttl ttlNDT =
-  if  | actualttl > maxttl -> throwError $ TTLTooLong (showTTL actualttl) (showTTL maxttl)
+  if
+      | actualttl > maxttl -> throwError $ TTLTooLong (showTTL actualttl) (showTTL maxttl)
       | actualttl <= 0 -> throwError $ TTLNegative (showTTL actualttl)
       | otherwise -> pure actualttl
   where
@@ -320,8 +321,9 @@ insertBindCookie cky uid ttlNDT = do
 
 -- | The counter-part of 'insertBindCookie'.
 lookupBindCookie :: (HasCallStack, MonadClient m) => BindCookie -> m (Maybe UserId)
-lookupBindCookie (cs . fromBindCookie -> ckyval :: ST) = runIdentity <$$> do
-  (retry x1 . query1 sel $ params Quorum (Identity ckyval))
+lookupBindCookie (cs . fromBindCookie -> ckyval :: ST) =
+  runIdentity <$$> do
+    (retry x1 . query1 sel $ params Quorum (Identity ckyval))
   where
     sel :: PrepQuery R (Identity ST) (Identity UserId)
     sel = "SELECT session_owner FROM bind_cookie WHERE cookie = ?"

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -465,7 +465,7 @@ deleteIdPConfig ::
   SAML.Issuer ->
   TeamId ->
   m ()
-deleteIdPConfig idp issuer team = retry x5 $ batch $ do
+deleteIdPConfig idp issuer team = retry x5 . batch $ do
   setType BatchLogged
   setConsistency Quorum
   addPrepQuery delDefaultIdp (Identity idp)
@@ -587,7 +587,7 @@ insertScimToken ::
   ScimToken ->
   ScimTokenInfo ->
   m ()
-insertScimToken token ScimTokenInfo {..} = retry x5 $ batch $ do
+insertScimToken token ScimTokenInfo {..} = retry x5 . batch $ do
   setType BatchLogged
   setConsistency Quorum
   addPrepQuery insByToken (token, stiTeam, stiId, stiCreatedAt, stiIdP, stiDescr)
@@ -650,7 +650,7 @@ deleteScimToken ::
   m ()
 deleteScimToken team tokenid = do
   mbToken <- retry x1 . query1 selById $ params Quorum (team, tokenid)
-  retry x5 $ batch $ do
+  retry x5 . batch $ do
     setType BatchLogged
     setConsistency Quorum
     addPrepQuery delById (team, tokenid)
@@ -683,7 +683,7 @@ deleteTeamScimTokens ::
   m ()
 deleteTeamScimTokens team = do
   tokens <- retry x5 $ query sel $ params Quorum (Identity team)
-  retry x5 $ batch $ do
+  retry x5 . batch $ do
     setType BatchLogged
     setConsistency Quorum
     addPrepQuery delByTeam (Identity team)

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -169,7 +169,8 @@ createBrigUser suid (Id buid) teamid mbName managedBy = do
         . path "/i/users"
         . json newUser
   let sCode = statusCode resp
-  if  | sCode < 300 ->
+  if
+      | sCode < 300 ->
         userId . selfUser <$> parseResponse @SelfProfile resp
       | inRange (400, 499) sCode ->
         throwSpar . SparBrigErrorWith (responseStatus resp) $ "create user failed"
@@ -256,7 +257,8 @@ setBrigUserName buid name = do
               uupAccentId = Nothing
             }
   let sCode = statusCode resp
-  if  | sCode < 300 ->
+  if
+      | sCode < 300 ->
         pure ()
       | inRange (400, 499) sCode ->
         throwSpar . SparBrigErrorWith (responseStatus resp) $ "set name failed"
@@ -275,7 +277,8 @@ setBrigUserHandle buid handle = do
         . header "Z-Connection" ""
         . json (HandleUpdate (fromHandle handle))
   let sCode = statusCode resp
-  if  | sCode < 300 ->
+  if
+      | sCode < 300 ->
         pure ()
       | inRange (400, 499) sCode ->
         throwSpar . SparBrigErrorWith (responseStatus resp) $ "set handle failed"
@@ -292,7 +295,8 @@ setBrigUserManagedBy buid managedBy = do
         . paths ["i", "users", toByteString' buid, "managed-by"]
         . json (ManagedByUpdate managedBy)
   let sCode = statusCode resp
-  if  | sCode < 300 ->
+  if
+      | sCode < 300 ->
         pure ()
       | inRange (400, 499) sCode ->
         throwSpar . SparBrigErrorWith (responseStatus resp) $ "set managedBy failed"
@@ -308,7 +312,8 @@ setBrigUserUserRef buid uref = do
         . paths ["i", "users", toByteString' buid, "sso-id"]
         . json (toUserSSOId uref)
   let sCode = statusCode resp
-  if  | sCode < 300 ->
+  if
+      | sCode < 300 ->
         pure ()
       | inRange (400, 499) sCode ->
         throwSpar . SparBrigErrorWith (responseStatus resp) $ "set UserSSOId failed"
@@ -325,7 +330,8 @@ setBrigUserRichInfo buid richInfo = do
         . paths ["i", "users", toByteString' buid, "rich-info"]
         . json (RichInfoUpdate $ unRichInfo richInfo)
   let sCode = statusCode resp
-  if  | sCode < 300 ->
+  if
+      | sCode < 300 ->
         pure ()
       | inRange (400, 499) sCode ->
         throwSpar . SparBrigErrorWith (responseStatus resp) $ "set richInfo failed"
@@ -334,16 +340,17 @@ setBrigUserRichInfo buid richInfo = do
 
 -- TODO: We should add an internal endpoint for this instead
 getBrigUserRichInfo :: (HasCallStack, MonadSparToBrig m) => UserId -> m RichInfo
-getBrigUserRichInfo buid = RichInfo.RichInfo <$> do
-  resp <-
-    call $
-      method GET
-        . paths ["users", toByteString' buid, "rich-info"]
-        . header "Z-User" (toByteString' buid)
-        . header "Z-Connection" ""
-  case statusCode resp of
-    200 -> parseResponse resp
-    _ -> throwSpar (SparBrigErrorWith (responseStatus resp) "Could not retrieve rich info")
+getBrigUserRichInfo buid =
+  RichInfo.RichInfo <$> do
+    resp <-
+      call $
+        method GET
+          . paths ["users", toByteString' buid, "rich-info"]
+          . header "Z-User" (toByteString' buid)
+          . header "Z-Connection" ""
+    case statusCode resp of
+      200 -> parseResponse resp
+      _ -> throwSpar (SparBrigErrorWith (responseStatus resp) "Could not retrieve rich info")
 
 -- | At the time of writing this, @HEAD /users/handles/:uid@ does not use the 'UserId' for
 -- anything but authorization.
@@ -356,7 +363,8 @@ checkHandleAvailable hnd buid = do
         . header "Z-User" (toByteString' buid)
         . header "Z-Connection" ""
   let sCode = statusCode resp
-  if  | sCode == 200 -> -- handle exists
+  if
+      | sCode == 200 -> -- handle exists
         pure False
       | sCode == 404 -> -- handle not found
         pure True
@@ -386,7 +394,8 @@ deleteBrigUser buid = do
       method DELETE
         . paths ["/i/users", toByteString' buid]
   let sCode = statusCode resp
-  if  | sCode < 300 -> pure ()
+  if
+      | sCode < 300 -> pure ()
       | inRange (400, 499) sCode ->
         throwSpar $ SparBrigErrorWith (responseStatus resp) "failed to delete user"
       | otherwise ->
@@ -430,7 +439,8 @@ ensureReAuthorised (Just uid) secret = do
         . paths ["/i/users", toByteString' uid, "reauthenticate"]
         . json (ReAuthUser secret)
   let sCode = statusCode resp
-  if  | sCode == 200 ->
+  if
+      | sCode == 200 ->
         pure ()
       | sCode == 403 ->
         throwSpar SparReAuthRequired
@@ -454,7 +464,8 @@ ssoLogin buid = do
         . json (SsoLogin buid Nothing)
         . queryItem "persist" "true"
   let sCode = statusCode resp
-  if  | sCode < 300 ->
+  if
+      | sCode < 300 ->
         Just <$> respToCookie resp
       | inRange (400, 499) sCode ->
         pure Nothing

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -119,8 +119,9 @@ apiScim =
         -- We caught an exception that's not a Spar exception at all. It is wrapped into
         -- Scim.serverError.
         Left someException ->
-          pure $ Left . SAML.CustomError . SparScimError $
-            Scim.serverError (cs (displayException someException))
+          pure $
+            Left . SAML.CustomError . SparScimError $
+              Scim.serverError (cs (displayException someException))
         -- We caught a 'SparScimError' exception. It is left as-is.
         Right err@(Left (SAML.CustomError (SparScimError _))) ->
           pure err
@@ -129,8 +130,9 @@ apiScim =
         -- TODO: does it have to be logged?
         Right (Left sparError) -> do
           err <- sparToServerErrorWithLogging (sparCtxLogger env) sparError
-          pure $ Left . SAML.CustomError . SparScimError $
-            Scim.serverError (cs (errBody err))
+          pure $
+            Left . SAML.CustomError . SparScimError $
+              Scim.serverError (cs (errBody err))
         -- No exceptions! Good.
         Right (Right x) -> pure $ Right x
 

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -34,7 +34,7 @@ module Spar.Scim.Auth
   )
 where
 
-import Control.Lens hiding ((.=), Strict)
+import Control.Lens hiding (Strict, (.=))
 import qualified Data.ByteString.Base64 as ES
 import Data.Id (ScimTokenId, UserId, randomId)
 import Data.String.Conversions (cs)
@@ -42,8 +42,8 @@ import Data.Time (getCurrentTime)
 import Imports
 import OpenSSL.Random (randBytes)
 import qualified SAML2.WebSSO as SAML
-import Servant ((:<|>) ((:<|>)), NoContent (NoContent), ServerT)
-import Spar.App (Spar, sparCtxOpts, wrapMonadClient, wrapMonadClient)
+import Servant (NoContent (NoContent), ServerT, (:<|>) ((:<|>)))
+import Spar.App (Spar, sparCtxOpts, wrapMonadClient)
 import qualified Spar.Data as Data
 import qualified Spar.Error as E
 import qualified Spar.Intra.Brig as Intra.Brig
@@ -51,7 +51,6 @@ import Spar.Scim.Types
   ( APIScimToken,
     CreateScimToken (CreateScimToken),
     CreateScimTokenResponse (..),
-    ScimTokenList,
     ScimTokenList (..),
     SparTag,
     createScimTokenDescr,

--- a/services/spar/src/Spar/Scim/Swagger.hs
+++ b/services/spar/src/Spar/Scim/Swagger.hs
@@ -30,7 +30,7 @@ module Spar.Scim.Swagger
   )
 where
 
-import Control.Lens ((&), (.~), (?~), mapped)
+import Control.Lens (mapped, (&), (.~), (?~))
 import Data.Id (ScimTokenId, TeamId)
 import Data.Proxy (Proxy (Proxy))
 import Data.Swagger hiding (Header (..))
@@ -56,50 +56,54 @@ instance ToSchema ScimTokenInfo where
     createdAtSchema <- declareSchemaRef (Proxy @UTCTime)
     idpSchema <- declareSchemaRef (Proxy @SAML.IdPId)
     descrSchema <- declareSchemaRef (Proxy @Text)
-    return $ NamedSchema (Just "ScimTokenInfo") $
-      mempty
-        & type_ .~ Just SwaggerObject
-        & properties
-          .~ [ ("team", teamSchema),
-               ("id", idSchema),
-               ("created_at", createdAtSchema),
-               ("idp", idpSchema),
-               ("description", descrSchema)
-             ]
-        & required .~ ["team", "id", "created_at", "description"]
+    return $
+      NamedSchema (Just "ScimTokenInfo") $
+        mempty
+          & type_ .~ Just SwaggerObject
+          & properties
+            .~ [ ("team", teamSchema),
+                 ("id", idSchema),
+                 ("created_at", createdAtSchema),
+                 ("idp", idpSchema),
+                 ("description", descrSchema)
+               ]
+          & required .~ ["team", "id", "created_at", "description"]
 
 instance ToSchema CreateScimToken where
   declareNamedSchema _ = do
     textSchema <- declareSchemaRef (Proxy @Text)
-    return $ NamedSchema (Just "CreateScimToken") $
-      mempty
-        & type_ .~ Just SwaggerObject
-        & properties
-          .~ [ ("description", textSchema),
-               ("password", textSchema)
-             ]
-        & required .~ ["description"]
+    return $
+      NamedSchema (Just "CreateScimToken") $
+        mempty
+          & type_ .~ Just SwaggerObject
+          & properties
+            .~ [ ("description", textSchema),
+                 ("password", textSchema)
+               ]
+          & required .~ ["description"]
 
 instance ToSchema CreateScimTokenResponse where
   declareNamedSchema _ = do
     tokenSchema <- declareSchemaRef (Proxy @ScimToken)
     infoSchema <- declareSchemaRef (Proxy @ScimTokenInfo)
-    return $ NamedSchema (Just "CreateScimTokenResponse") $
-      mempty
-        & type_ .~ Just SwaggerObject
-        & properties
-          .~ [ ("token", tokenSchema),
-               ("info", infoSchema)
-             ]
-        & required .~ ["token", "info"]
+    return $
+      NamedSchema (Just "CreateScimTokenResponse") $
+        mempty
+          & type_ .~ Just SwaggerObject
+          & properties
+            .~ [ ("token", tokenSchema),
+                 ("info", infoSchema)
+               ]
+          & required .~ ["token", "info"]
 
 instance ToSchema ScimTokenList where
   declareNamedSchema _ = do
     infoListSchema <- declareSchemaRef (Proxy @[ScimTokenInfo])
-    return $ NamedSchema (Just "ScimTokenList") $
-      mempty
-        & type_ .~ Just SwaggerObject
-        & properties
-          .~ [ ("tokens", infoListSchema)
-             ]
-        & required .~ ["tokens"]
+    return $
+      NamedSchema (Just "ScimTokenList") $
+        mempty
+          & type_ .~ Just SwaggerObject
+          & properties
+            .~ [ ("tokens", infoListSchema)
+               ]
+          & required .~ ["tokens"]

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -52,8 +52,8 @@ import qualified Data.Map as Map
 import Data.Misc (PlainTextPassword)
 import Imports
 import qualified SAML2.WebSSO as SAML
-import Servant ((:<|>), (:>), DeleteNoContent, Get, Header, JSON, NoContent, Post, QueryParam', ReqBody, Required, Strict)
-import Servant.API.Generic ((:-), ToServantApi)
+import Servant (DeleteNoContent, Get, Header, JSON, NoContent, Post, QueryParam', ReqBody, Required, Strict, (:<|>), (:>))
+import Servant.API.Generic (ToServantApi, (:-))
 import Spar.API.Util (OmitDocs)
 import Spar.Types (ScimToken, ScimTokenInfo)
 import Web.Scim.AttrName (AttrName (..))

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -237,8 +237,8 @@ specFinalizeLogin = do
                   . expect2xx
               )
             liftIO $ threadDelay 100000 -- make sure deletion is done.  if we don't want to take
-                -- the time, we should find another way to robustly
-                -- confirm that deletion has compelted in the background.
+            -- the time, we should find another way to robustly
+            -- confirm that deletion has compelted in the background.
 
           -- second login
           do
@@ -1012,10 +1012,10 @@ specDeleteCornerCases = describe "delete corner cases" $ do
     samlUserShouldSatisfy uref isJust
     deleteViaBrig uid
     samlUserShouldSatisfy uref isJust -- brig doesn't talk to spar right now when users
-      -- are deleted there.  we need to work around this
-      -- fact for now.  (if the test fails here, this may
-      -- mean that you fixed the behavior and can
-      -- change this to 'isNothing'.)
+    -- are deleted there.  we need to work around this
+    -- fact for now.  (if the test fails here, this may
+    -- mean that you fixed the behavior and can
+    -- change this to 'isNothing'.)
     (Just _) <- createViaSaml idp privcreds uref
     samlUserShouldSatisfy uref isJust
   where

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -34,12 +34,11 @@ import Control.Lens
 import Control.Monad.Catch (MonadCatch)
 import Control.Retry (exponentialBackoff, limitRetries, recovering)
 import qualified Data.Aeson as Aeson
-import Data.Aeson.Lens (_String, key)
+import Data.Aeson.Lens (key, _String)
 import Data.Aeson.QQ (aesonQQ)
 import Data.Aeson.Types (fromJSON, toJSON)
 import Data.ByteString.Conversion
-import Data.Handle (Handle (Handle))
-import Data.Handle (fromHandle)
+import Data.Handle (Handle (Handle), fromHandle)
 import Data.Id (TeamId, UserId, randomId)
 import Data.Ix (inRange)
 import Data.String.Conversions (cs)
@@ -50,8 +49,8 @@ import qualified SAML2.WebSSO.Types as SAML
 import qualified Spar.Data as Data
 import qualified Spar.Intra.Brig as Intra
 import Spar.Scim
-import qualified Spar.Types
 import Spar.Types (IdP)
+import qualified Spar.Types
 import qualified Text.XML.DSig as SAML
 import Util
 import qualified Web.Scim.Class.User as Scim.UserC
@@ -416,10 +415,10 @@ testScimCreateVsUserRef = do
   samlUserShouldSatisfy uref isJust
   deleteViaBrig uid
   samlUserShouldSatisfy uref isJust -- brig doesn't talk to spar right now when users
-    -- are deleted there.  we need to work around this
-    -- fact for now.  (if the test fails here, this may
-    -- mean that you fixed the behavior and can
-    -- change this to 'isNothing'.)
+  -- are deleted there.  we need to work around this
+  -- fact for now.  (if the test fails here, this may
+  -- mean that you fixed the behavior and can
+  -- change this to 'isNothing'.)
   tok <- registerScimToken teamid (Just (idp ^. SAML.idpId))
   storedusr :: Scim.UserC.StoredUser SparTag <-
     do
@@ -844,11 +843,12 @@ testUpdateSameHandle = do
   let userid = scimUserId storedUser
   -- Overwrite the user with another randomly-generated user who has the same name and
   -- handle
-  user' <- randomScimUser <&> \u ->
-    u
-      { Scim.User.userName = Scim.User.userName user,
-        Scim.User.displayName = Scim.User.displayName user
-      }
+  user' <-
+    randomScimUser <&> \u ->
+      u
+        { Scim.User.userName = Scim.User.userName user,
+          Scim.User.displayName = Scim.User.displayName user
+        }
   updatedUser <- updateUser tok userid user'
   -- Get the updated user and check that it matches the user returned by 'updateUser'
   storedUser' <- getUser tok userid
@@ -1223,10 +1223,11 @@ specEmailValidation = do
           act <- getActivationCode brig (Left email)
           case act of
             Nothing -> pure () -- missing activation key/code; this happens if the feature is
-                -- disabled (second test case below)
-            Just kc -> activate brig kc !!! do
-              const 200 === statusCode
-              const (Just False) === fmap Activation.activatedFirst . responseJsonMaybe
+            -- disabled (second test case below)
+            Just kc ->
+              activate brig kc !!! do
+                const 200 === statusCode
+                const (Just False) === fmap Activation.activatedFirst . responseJsonMaybe
         --
         -- copied from brig integration tests.
         getActivationCode ::

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -129,7 +129,7 @@ specSuspend = do
             void $ aFewTimes (runSpar $ Intra.getStatus uid) (== Active)
 
     it "PUT will change state from active to inactive and back" $ do
-      void $ activeInactiveAndBack $ \tok uid user active ->
+      void . activeInactiveAndBack $ \tok uid user active ->
         updateUser tok uid user {Scim.User.active = Just active}
 
     it "PATCH will change state from active to inactive and back" $ do
@@ -138,7 +138,7 @@ specSuspend = do
               PatchOp.Replace
               (Just (PatchOp.NormalPath (Filter.topLevelAttrPath name)))
               (Just (toJSON value))
-      void $ activeInactiveAndBack $ \tok uid _user active ->
+      void . activeInactiveAndBack $ \tok uid _user active ->
         patchUser tok uid $ PatchOp.PatchOp [replaceAttrib "active" active]
 
     -- Consider the following series of events:

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -123,7 +123,7 @@ module Util.Core
 where
 
 import Bilge hiding (getCookie) -- we use Web.Cookie instead of the http-client type
-import Bilge.Assert ((!!!), (<!!), (===), Assertions)
+import Bilge.Assert (Assertions, (!!!), (<!!), (===))
 import qualified Brig.Types.Activation as Brig
 import Brig.Types.Common (UserIdentity (..), UserSSOId (..))
 import Brig.Types.User (User (..), selfUser, userIdentity)
@@ -506,10 +506,11 @@ nextHandle = liftIO $ Handle . cs . show <$> randomRIO (0 :: Int, 13371137)
 -- | Generate a 'SAML.UserRef' subject.
 nextSubject :: (HasCallStack, MonadIO m) => m NameID
 nextSubject = liftIO $ do
-  unameId <- randomRIO (0, 1 :: Int) >>= \case
-    0 -> either (error . show) id . SAML.mkUNameIDEmail . Brig.fromEmail <$> randomEmail
-    1 -> SAML.mkUNameIDUnspecified . UUID.toText <$> UUID.nextRandom
-    _ -> error "nextSubject: impossible"
+  unameId <-
+    randomRIO (0, 1 :: Int) >>= \case
+      0 -> either (error . show) id . SAML.mkUNameIDEmail . Brig.fromEmail <$> randomEmail
+      1 -> SAML.mkUNameIDUnspecified . UUID.toText <$> UUID.nextRandom
+      _ -> error "nextSubject: impossible"
   either (error . show) pure $ SAML.mkNameID unameId Nothing Nothing Nothing
 
 nextUserRef :: MonadIO m => m SAML.UserRef
@@ -776,9 +777,9 @@ getCookie proxy rsp = do
 hasPersistentCookieHeader :: ResponseLBS -> Either String ()
 hasPersistentCookieHeader rsp = do
   cky <- getCookie (Proxy @"zuid") rsp
-  when (isNothing . Web.setCookieExpires $ fromSimpleSetCookie cky)
-    $ Left
-    $ "expiration date should NOT empty: " <> show cky
+  when (isNothing . Web.setCookieExpires $ fromSimpleSetCookie cky) $
+    Left $
+      "expiration date should NOT empty: " <> show cky
 
 -- | A bind cookie is always sent, but if we do not want to send one, it looks like this:
 -- "wire.com=; Path=/sso/finalize-login; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=-1; Secure"
@@ -835,10 +836,11 @@ negotiateAuthnRequest ::
   (HasCallStack, MonadIO m, MonadReader TestEnv m) =>
   IdP ->
   m SAML.AuthnRequest
-negotiateAuthnRequest idp = negotiateAuthnRequest' DoInitiateLogin idp id >>= \case
-  (req, cky) -> case maybe (Left "missing") isDeleteBindCookie cky of
-    Right () -> pure req
-    Left msg -> error $ "unexpected bind cookie: " <> show (cky, msg)
+negotiateAuthnRequest idp =
+  negotiateAuthnRequest' DoInitiateLogin idp id >>= \case
+    (req, cky) -> case maybe (Left "missing") isDeleteBindCookie cky of
+      Right () -> pure req
+      Left msg -> error $ "unexpected bind cookie: " <> show (cky, msg)
 
 doInitiatePath :: DoInitiate -> [ST]
 doInitiatePath DoInitiateLogin = ["sso", "initiate-login"]

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -78,9 +78,10 @@ registerIdPAndScimTokenWithMeta = do
 registerScimToken :: HasCallStack => TeamId -> Maybe IdPId -> TestSpar ScimToken
 registerScimToken teamid midpid = do
   env <- ask
-  tok <- ScimToken <$> do
-    code <- liftIO UUID.nextRandom
-    pure $ "scim-test-token/" <> "team=" <> idToText teamid <> "/code=" <> UUID.toText code
+  tok <-
+    ScimToken <$> do
+      code <- liftIO UUID.nextRandom
+      pure $ "scim-test-token/" <> "team=" <> idToText teamid <> "/code=" <> UUID.toText code
   scimTokenId <- randomId
   now <- liftIO getCurrentTime
   runClient (env ^. teCql) $
@@ -121,17 +122,18 @@ randomScimUserWithSubjectAndRichInfo richInfo = do
   emails <- getRandomR (0, 3) >>= \n -> replicateM n randomScimEmail
   phones <- getRandomR (0, 3) >>= \n -> replicateM n randomScimPhone
   -- Related, but non-trivial to re-use here: 'nextSubject'
-  (externalId, subj) <- getRandomR (0, 1 :: Int) <&> \case
-    0 ->
-      ( "scimuser_extid_" <> suffix <> "@example.com",
-        either (error . show) id $
-          SAML.mkUNameIDEmail ("scimuser_extid_" <> suffix <> "@example.com")
-      )
-    1 ->
-      ( "scimuser_extid_" <> suffix,
-        SAML.mkUNameIDUnspecified ("scimuser_extid_" <> suffix)
-      )
-    _ -> error "randomScimUserWithSubject: impossible"
+  (externalId, subj) <-
+    getRandomR (0, 1 :: Int) <&> \case
+      0 ->
+        ( "scimuser_extid_" <> suffix <> "@example.com",
+          either (error . show) id $
+            SAML.mkUNameIDEmail ("scimuser_extid_" <> suffix <> "@example.com")
+        )
+      1 ->
+        ( "scimuser_extid_" <> suffix,
+          SAML.mkUNameIDUnspecified ("scimuser_extid_" <> suffix)
+        )
+      _ -> error "randomScimUserWithSubject: impossible"
   pure
     ( (Scim.User.empty userSchemas ("scimuser_" <> suffix) (ScimUserExtra richInfo))
         { Scim.User.displayName = Just ("Scim User #" <> suffix),
@@ -159,7 +161,7 @@ randomScimEmail :: MonadRandom m => m Email.Email
 randomScimEmail = do
   let typ :: Maybe Text = Nothing
       primary :: Maybe Bool = Nothing -- TODO: where should we catch users with more than one
-        -- primary email?
+      -- primary email?
   value :: Email.EmailAddress2 <- do
     localpart <- cs <$> replicateM 15 (getRandomR ('a', 'z'))
     domainpart <- (<> ".com") . cs <$> replicateM 15 (getRandomR ('a', 'z'))

--- a/services/spar/test-integration/Util/Types.hs
+++ b/services/spar/test-integration/Util/Types.hs
@@ -104,6 +104,6 @@ _unitTestTestErrorLabel :: IO ()
 _unitTestTestErrorLabel = do
   let val :: Either String TestErrorLabel
       val = Aeson.eitherDecode "{\"code\":404,\"message\":\"Not found.\",\"label\":\"not-found\"}"
-  unless (val == Right "not-found")
-    $ throwIO . ErrorCall . show
-    $ val
+  unless (val == Right "not-found") $
+    throwIO . ErrorCall . show $
+      val

--- a/services/spar/test/Test/Spar/APISpec.hs
+++ b/services/spar/test/Test/Spar/APISpec.hs
@@ -45,12 +45,12 @@ spec = do
     let withoutRaw (IdPMetadataValue _ x) = x
     (withoutRaw <$> (Aeson.eitherDecode . Aeson.encode) val) `shouldBe` Right (withoutRaw val)
   describe "SsoSettings JSON instance" $ do
-    it "always has and requires the field default_sso_code"
-      $ property
-      $ \(ssoSettings :: SsoSettings) -> do
-        let object = Aeson.toJSON ssoSettings
-        let objectWithoutKey = Lens.over Aeson._Object (HM.delete "default_sso_code") $ object
-        (HM.lookup "default_sso_code" =<< Lens.preview Aeson._Object object)
-          `shouldSatisfy` isJust
-        Aeson.parseMaybe (Aeson.parseJSON @SsoSettings) objectWithoutKey
-          `shouldSatisfy` isNothing
+    it "always has and requires the field default_sso_code" $
+      property $
+        \(ssoSettings :: SsoSettings) -> do
+          let object = Aeson.toJSON ssoSettings
+          let objectWithoutKey = Lens.over Aeson._Object (HM.delete "default_sso_code") $ object
+          (HM.lookup "default_sso_code" =<< Lens.preview Aeson._Object object)
+            `shouldSatisfy` isJust
+          Aeson.parseMaybe (Aeson.parseJSON @SsoSettings) objectWithoutKey
+            `shouldSatisfy` isNothing

--- a/stack.yaml
+++ b/stack.yaml
@@ -177,7 +177,7 @@ extra-deps:
 # Development tools
 ############################################################
 
-- ormolu-0.0.5.0
-- ghc-lib-parser-8.10.1.20200412@sha256:b0517bb150a02957d7180f131f5b94abd2a7f58a7d1532a012e71618282339c2,8751  # for ormolu-0.0.5.0
+- ormolu-0.1.2.0
+- ghc-lib-parser-8.10.1.20200412@sha256:b0517bb150a02957d7180f131f5b94abd2a7f58a7d1532a012e71618282339c2,8751  # for ormolu-0.1.2.0
 
 - headroom-0.2.1.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -506,12 +506,12 @@ packages:
   original:
     hackage: polysemy-1.3.0.0
 - completed:
-    hackage: ormolu-0.0.5.0@sha256:e5f49c51c6ebd8b3cd16113e585312de7315c1e1561fbb599988cebc61c14f4e,7956
+    hackage: ormolu-0.1.2.0@sha256:24e6512750576978b6f045c1e53a7aad28ab61960f738a3c74fb0bc2beaf4030,6237
     pantry-tree:
-      size: 66187
-      sha256: fd591a96bb129610f89d23d2986b1b11dad8c1c41e23ea1c6f03340b7265b617
+      size: 71915
+      sha256: 5a857d9bf0e9579ee4daacfb63b4665cdf9e0a0de31d8e0715a27836007e9c42
   original:
-    hackage: ormolu-0.0.5.0
+    hackage: ormolu-0.1.2.0
 - completed:
     hackage: ghc-lib-parser-8.10.1.20200412@sha256:b0517bb150a02957d7180f131f5b94abd2a7f58a7d1532a012e71618282339c2,8751
     pantry-tree:

--- a/tools/api-simulations/loadtest/src/Main.hs
+++ b/tools/api-simulations/loadtest/src/Main.hs
@@ -92,14 +92,16 @@ ltsSettingsParser = do
   conversationRamp <-
     optional $
       asum
-        [ fmap RampStep $ option auto $
-            long "ramp-step"
-              <> metavar "INT"
-              <> help "delay in microseconds between conversations start",
-          fmap RampTotal $ option auto $
-            long "ramp-total"
-              <> metavar "INT"
-              <> help "time in microseconds until full load"
+        [ fmap RampStep $
+            option auto $
+              long "ramp-step"
+                <> metavar "INT"
+                <> help "delay in microseconds between conversations start",
+          fmap RampTotal $
+            option auto $
+              long "ramp-total"
+                <> metavar "INT"
+                <> help "time in microseconds until full load"
         ]
   conversationsTotal <-
     option auto $

--- a/tools/api-simulations/loadtest/src/Network/Wire/Simulations/LoadTest.hs
+++ b/tools/api-simulations/loadtest/src/Network/Wire/Simulations/LoadTest.hs
@@ -113,7 +113,7 @@ runConv s g = do
         Clients.addMembers (botClientSessions client) conv (map botId bots)
   let removeClients (b, st) =
         mapM_ (removeBotClient b) (botClient st : botOtherClients st)
-  void $ flip mapConcurrently (zip bots states) $ \(b, st) ->
+  void . flip mapConcurrently (zip bots states) $ \(b, st) ->
     runBotSession b $ do
       log Info $ msg $ val "Starting bot"
       runBot s st `Ex.onException` removeClients (b, st)

--- a/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
+++ b/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
@@ -128,15 +128,17 @@ mainBotNet n = do
   let carlWithTablet = (carl, carlTablet)
   let people :: [(Bot, ConvId, BotClient)] -- everyone except for Ally
       people =
-        (bill, a2b, billPC) : (carl, a2c, carlTablet)
-          : zip3 goons a2goons goonClients
+        (bill, a2b, billPC) :
+        (carl, a2c, carlTablet) :
+        zip3 goons a2goons goonClients
   info $ msg (val "OTR 1-1 greetings")
   -- Ally greets everyone in 1-1
-  runBotSession ally $ for_ people $ \(user, conv, _client) -> do
-    botInitSession (botId user)
-    Clients.addMembers (botClientSessions allyPhone) conv [botId user]
-    let message = "Hey " <> unTag (botTag user) <> ", Everything secure?"
-    postOtrTextMsg allyPhone conv message >>= assertNoClientMismatch
+  runBotSession ally $
+    for_ people $ \(user, conv, _client) -> do
+      botInitSession (botId user)
+      Clients.addMembers (botClientSessions allyPhone) conv [botId user]
+      let message = "Hey " <> unTag (botTag user) <> ", Everything secure?"
+      postOtrTextMsg allyPhone conv message >>= assertNoClientMismatch
   -- Everyone answers
   for_ people $ \(user, conv, client) -> runBotSession user $ do
     pkm <- awaitOtrMsg conv allyWithPhone (user, client)
@@ -148,14 +150,15 @@ mainBotNet n = do
     Clients.addMembers (botClientSessions client) conv [botId ally]
     postOtrTextMsg client conv "Thanks Ally, All good." >>= assertNoClientMismatch
   -- Ally confirms the answers
-  runBotSession ally $ for_ people $ \(user, conv, client) -> do
-    message <- awaitOtrMsg conv (user, client) allyWithPhone
-    plain <- decryptTextMsg allyPhone message
-    assertEqual
-      plain
-      "Thanks Ally, All good."
-      ("Ally (from " <> unTag (botTag user) <> "): Plaintext /= CipherText")
-    postOtrTextMsg allyPhone conv "Glad to hear that." >>= assertNoClientMismatch
+  runBotSession ally $
+    for_ people $ \(user, conv, client) -> do
+      message <- awaitOtrMsg conv (user, client) allyWithPhone
+      plain <- decryptTextMsg allyPhone message
+      assertEqual
+        plain
+        "Thanks Ally, All good."
+        ("Ally (from " <> unTag (botTag user) <> "): Plaintext /= CipherText")
+      postOtrTextMsg allyPhone conv "Glad to hear that." >>= assertNoClientMismatch
   -- Everyone checks Ally's response
   for_ people $ \(user, conv, client) -> runBotSession user $ do
     message <- awaitOtrMsg conv allyWithPhone (user, client)

--- a/tools/bonanza/src/Bonanza/Anon.hs
+++ b/tools/bonanza/src/Bonanza/Anon.hs
@@ -21,7 +21,7 @@ module Bonanza.Anon
 where
 
 import Bonanza.Types
-import Control.Lens ((%~), _Wrapped', over)
+import Control.Lens (over, (%~), _Wrapped')
 import Data.HashMap.Strict (filterWithKey)
 import Imports
 

--- a/tools/bonanza/src/Bonanza/Parser/CommonLog.hs
+++ b/tools/bonanza/src/Bonanza/Parser/CommonLog.hs
@@ -85,9 +85,9 @@ instance ToLogEvent CommonLogRecord where
 
 commonLogFields :: [Text]
 commonLogFields =
-  "remote_addr"
-    : "remote_user"
-    : map fst fieldParsers
+  "remote_addr" :
+  "remote_user" :
+  map fst fieldParsers
 
 fieldParsers :: [(Text, Parser CommonLogField)]
 fieldParsers =
@@ -112,9 +112,9 @@ commonLogRecord moreFieldParsers = do
                 (_, CEmpty) -> Nothing
                 (k, CField v) -> Just (k, v)
             )
-            $ ("remote_addr", raddr)
-              : ("remote_user", ruser)
-              : flds,
+            $ ("remote_addr", raddr) :
+            ("remote_user", ruser) :
+            flds,
         cRequest = req
       }
   where

--- a/tools/bonanza/src/Bonanza/Parser/Tinylog.hs
+++ b/tools/bonanza/src/Bonanza/Parser/Tinylog.hs
@@ -53,8 +53,8 @@ instance ToLogEvent TinyLogRecord where
     where
       tgs =
         Tags . fromList . map (second String) $
-          ("level", T.singleton tLevel)
-            : tFields
+          ("level", T.singleton tLevel) :
+          tFields
             ++ maybeToList ((,) "time" <$> tDate)
 
 tinyLogRecord :: Parser TinyLogRecord

--- a/tools/bonanza/test/unit/Test/Bonanza/Arbitrary.hs
+++ b/tools/bonanza/test/unit/Test/Bonanza/Arbitrary.hs
@@ -281,8 +281,8 @@ instance Arbitrary (ParseInput TinyLogRecord) where
           encodeUtf8 . mconcat $
             [ maybe "" (\d -> decodeUtf8 $ df d <> ", ") date,
               T.intercalate ", " $
-                T.singleton level
-                  : map (\(k, v) -> alnum k <> "=" <> fieldValue v) fields
+                T.singleton level :
+                map (\(k, v) -> alnum k <> "=" <> fieldValue v) fields
                   ++ [message]
             ]
     return $ ParseInput (rec, inp)
@@ -351,9 +351,9 @@ instance Arbitrary (ParseInput (NginzLogRecord)) where
             { cTime = date,
               cFields =
                 mapMaybe (\(k, v) -> (,) k <$> fromField v) $
-                  ("remote_addr", raddr)
-                    : ("remote_user", ruser)
-                    : fields,
+                  ("remote_addr", raddr) :
+                  ("remote_user", ruser) :
+                  fields,
               cRequest = req
             }
         inp =

--- a/tools/bonanza/test/unit/Test/Bonanza/Streaming.hs
+++ b/tools/bonanza/test/unit/Test/Bonanza/Streaming.hs
@@ -31,7 +31,7 @@ import Bonanza.Types
 import Data.Attoparsec.ByteString.Char8
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy as BL
-import Data.Conduit ((.|), runConduit)
+import Data.Conduit (runConduit, (.|))
 import qualified Data.Conduit.Binary as Conduit
 import qualified Data.Conduit.List as Conduit
 import Imports
@@ -110,12 +110,12 @@ run_prop ::
   [ParseInput a] ->
   Property
 run_prop p i =
-  ioProperty
-    $ runConduit
-    $ Conduit.sourceLbs inp
-      .| P.stream (P.MkParser p)
-      .| Conduit.consume
-      >>= pure . (=== out) . map secs
+  ioProperty $
+    runConduit $
+      Conduit.sourceLbs inp
+        .| P.stream (P.MkParser p)
+        .| Conduit.consume
+        >>= pure . (=== out) . map secs
   where
     inp = BL.fromStrict . B.intercalate "\n" $ map (snd . parseInput) i
     out = map (secs . toLogEvent . fst . parseInput) i

--- a/tools/db/auto-whitelist/src/Work.hs
+++ b/tools/db/auto-whitelist/src/Work.hs
@@ -72,7 +72,7 @@ whitelistService l (pid, sid, tid) = do
       . Log.field "provider" (show pid)
       . Log.field "service" (show sid)
       . Log.field "team" (show tid)
-  retry x5 $ batch $ do
+  retry x5 . batch $ do
     setConsistency Quorum
     setType BatchLogged
     addPrepQuery insert1 (tid, pid, sid)

--- a/tools/db/billing-team-member-backfill/src/Work.hs
+++ b/tools/db/billing-team-member-backfill/src/Work.hs
@@ -68,7 +68,7 @@ getTeamMembers = paginateC cql (paramsP Quorum () pageSize) x5
 
 createBillingTeamMembers :: [(TeamId, UserId)] -> Client ()
 createBillingTeamMembers pairs =
-  retry x5 $ batch $ do
+  retry x5 . batch $ do
     setType BatchLogged
     setConsistency Quorum
     mapM_ (addPrepQuery cql) pairs

--- a/tools/db/find-undead/src/Work.hs
+++ b/tools/db/find-undead/src/Work.hs
@@ -25,8 +25,8 @@ import Brig.Types.Intra (AccountStatus (..))
 import Cassandra
 import Cassandra.Util (Writetime, writeTimeToUTC)
 import Conduit
-import Control.Lens (_1, _2, view)
-import Data.Aeson ((.:), FromJSON)
+import Control.Lens (view, _1, _2)
+import Data.Aeson (FromJSON, (.:))
 import qualified Data.Aeson as Aeson
 import qualified Data.Conduit.List as C
 import qualified Data.Set as Set
@@ -41,16 +41,16 @@ runCommand :: Logger -> ClientState -> ES.BHEnv -> String -> String -> IO ()
 runCommand l cas es indexStr mappingStr = do
   let index = ES.IndexName $ Text.pack indexStr
       mapping = ES.MappingName $ Text.pack mappingStr
-  runConduit
-    $ transPipe (ES.runBH es)
-    $ getScrolled index mapping
-      .| C.iterM (logProgress l)
-      .| C.mapM
-        ( \uuids -> do
-            fromCas <- runClient cas $ usersInCassandra uuids
-            pure (uuids, fromCas)
-        )
-      .| C.mapM_ (logDifference l)
+  runConduit $
+    transPipe (ES.runBH es) $
+      getScrolled index mapping
+        .| C.iterM (logProgress l)
+        .| C.mapM
+          ( \uuids -> do
+              fromCas <- runClient cas $ usersInCassandra uuids
+              pure (uuids, fromCas)
+          )
+        .| C.mapM_ (logDifference l)
 
 ----------------------------------------------------------------------------
 -- Queries

--- a/tools/db/service-backfill/src/Work.hs
+++ b/tools/db/service-backfill/src/Work.hs
@@ -84,7 +84,7 @@ writeBots ::
   [(ProviderId, ServiceId, BotId, ConvId, Maybe TeamId)] ->
   Client ()
 writeBots [] = pure ()
-writeBots xs = retry x5 $ batch $ do
+writeBots xs = retry x5 . batch $ do
   setConsistency Quorum
   setType BatchLogged
   forM_ xs $ \(pid, sid, bid, cid, mbTid) -> do

--- a/tools/ormolu.sh
+++ b/tools/ormolu.sh
@@ -74,7 +74,7 @@ FAILURES=0
 
 for hsfile in $(git ls-files | grep '\.hsc\?$'); do
     FAILED=0
-    ormolu --mode $ARG_ORMOLU_MODE --check-idempotency $LANGUAGE_EXTS "$hsfile" || FAILED=1
+    ormolu --mode $ARG_ORMOLU_MODE --check-idempotence $LANGUAGE_EXTS "$hsfile" || FAILED=1
     if [ "$FAILED" == "1" ]; then
         ((++FAILURES))
         echo "$hsfile...  *** FAILED"

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -65,7 +65,7 @@ import qualified Stern.Intra as Intra
 import Stern.Options
 import qualified Stern.Swagger as Doc
 import Stern.Types
-import System.Logger.Class hiding ((.=), Error, name, trace)
+import System.Logger.Class hiding (Error, name, trace, (.=))
 import Util.Options
 import qualified Wire.API.Team.Feature as Public
 import qualified Wire.API.Team.SearchVisibility as Public
@@ -649,9 +649,9 @@ getTeamInvoice (tid ::: iid ::: _) = do
 getConsentLog :: Email -> Handler Response
 getConsentLog e = do
   acc <- (listToMaybe <$> Intra.getUserProfilesByIdentity (Left e))
-  when (isJust acc)
-    $ throwE
-    $ Error status403 "user-exists" "Trying to access consent log of existing user!"
+  when (isJust acc) $
+    throwE $
+      Error status403 "user-exists" "Trying to access consent log of existing user!"
   consentLog <- Intra.getEmailConsentLog e
   marketo <- Intra.getMarketoResult e
   return . json $

--- a/tools/stern/src/Stern/App.hs
+++ b/tools/stern/src/Stern/App.hs
@@ -27,7 +27,7 @@ import qualified Bilge
 import qualified Bilge.IO as Bilge (withResponse)
 import Bilge.RPC (HasRequestId (..))
 import Control.Error
-import Control.Lens ((^.), makeLenses, set, view)
+import Control.Lens (makeLenses, set, view, (^.))
 import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Monad.IO.Class
 import Control.Monad.Reader.Class

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -63,7 +63,7 @@ import Brig.Types
 import Brig.Types.Intra
 import Brig.Types.User.Auth
 import Control.Error
-import Control.Lens ((^.), view)
+import Control.Lens (view, (^.))
 import Control.Monad.Reader
 import Data.Aeson hiding (Error)
 import Data.Aeson.Types (emptyArray)
@@ -89,7 +89,7 @@ import Network.HTTP.Types.Status hiding (statusCode)
 import Network.Wai.Utilities (Error (..))
 import Stern.App
 import Stern.Types
-import System.Logger.Class hiding ((.=), Error, name)
+import System.Logger.Class hiding (Error, name, (.=))
 import qualified System.Logger.Class as Log
 import UnliftIO.Exception hiding (Handler)
 import qualified Wire.API.Team.Feature as Public
@@ -100,33 +100,35 @@ putUser :: UserId -> UserUpdate -> Handler ()
 putUser uid upd = do
   info $ userMsg uid . msg "Changing user state"
   b <- view brig
-  void $ catchRpcErrors $
-    rpc'
-      "brig"
-      b
-      ( method PUT
-          . path "/self"
-          . header "Z-User" (toByteString' uid)
-          . header "Z-Connection" (toByteString' "")
-          . lbytes (encode upd)
-          . contentJson
-          . expect2xx
-      )
+  void $
+    catchRpcErrors $
+      rpc'
+        "brig"
+        b
+        ( method PUT
+            . path "/self"
+            . header "Z-User" (toByteString' uid)
+            . header "Z-Connection" (toByteString' "")
+            . lbytes (encode upd)
+            . contentJson
+            . expect2xx
+        )
 
 putUserStatus :: AccountStatus -> UserId -> Handler ()
 putUserStatus status uid = do
   info $ userMsg uid . msg "Changing user status"
   b <- view brig
-  void $ catchRpcErrors $
-    rpc'
-      "brig"
-      b
-      ( method PUT
-          . paths ["/i/users", toByteString' uid, "status"]
-          . lbytes (encode payload)
-          . contentJson
-          . expect2xx
-      )
+  void $
+    catchRpcErrors $
+      rpc'
+        "brig"
+        b
+        ( method PUT
+            . paths ["/i/users", toByteString' uid, "status"]
+            . lbytes (encode payload)
+            . contentJson
+            . expect2xx
+        )
   where
     payload = AccountStatusUpdate status
 
@@ -335,10 +337,11 @@ getUserBindingTeam u = do
             . expect2xx
         )
   teams <- parseResponse (Error status502 "bad-upstream") r
-  return $ listToMaybe
-    $ fmap (view teamId)
-    $ filter ((== Binding) . view teamBinding)
-    $ teams ^. teamListTeams
+  return $
+    listToMaybe $
+      fmap (view teamId) $
+        filter ((== Binding) . view teamBinding) $
+          teams ^. teamListTeams
 
 getInvoiceUrl :: TeamId -> InvoiceId -> Handler ByteString
 getInvoiceUrl tid iid = do

--- a/tools/stern/src/Stern/Types.hs
+++ b/tools/stern/src/Stern/Types.hs
@@ -42,10 +42,10 @@ instance ToJSON TeamMemberInfo where
   toJSON (TeamMemberInfo m) =
     case teamMemberJson (const True) m of
       Object o ->
-        Object
-          $ M.insert "can_update_billing" (Bool (hasPermission m SetBilling))
-          $ M.insert "can_view_billing" (Bool (hasPermission m GetBilling))
-          $ o
+        Object $
+          M.insert "can_update_billing" (Bool (hasPermission m SetBilling)) $
+            M.insert "can_view_billing" (Bool (hasPermission m GetBilling)) $
+              o
       other ->
         error $ "toJSON TeamMemberInfo: not an object: " <> show (encode other)
 


### PR DESCRIPTION
See https://github.com/zinfra/backend-issues/issues/1623

Don't merge yet. We'll wait for a good moment where we don't have many PRs with Haskell changes in progress.
It should not take much time to rebase this PR then (if we just re-create the `run ormolu` commit instead of rebasing it).

Main [Ormolu changes since 0.0.5.0](https://github.com/tweag/ormolu/blob/master/CHANGELOG.md#ormolu-0120) we care about:
  - Blank lines between definitions in let and while bindings are now preserved. [Issue 554](https://github.com/tweag/ormolu/issues/554).
  - Fixed rendering of comments around if expressions. [Issue 458](https://github.com/tweag/ormolu/issues/458).
  - A bunch of idempotence fixes we occasionally ran into.

Changes that cause most diffs:
   - Improved sorting of operators in imports. [Issue 602](https://github.com/tweag/ormolu/issues/602).
   - Added support for formatting linked lists with (:) as line terminator. [Issue 478](https://github.com/tweag/ormolu/issues/478).
   - Renamed the --check-idempotency flag to --check-idempotence. *(this needed fixing in our script as well)*