### PR TITLE
Tweak cassandra container settings to get it to work on nixos.

### DIFF
--- a/deploy/dockerephemeral/docker-compose.yaml
+++ b/deploy/dockerephemeral/docker-compose.yaml
@@ -97,10 +97,18 @@ services:
     image: julialongtin/cassandra:0.0.9
     ports:
       - "127.0.0.1:9042:9042"
+    ulimits:
+      memlock: 65536
+      nofile: 100000
+      nproc: 32768
     environment:
-# what's present in the jvm.options file by default.
-#      - "CS_JAVA_OPTIONS=-Xmx1024M -Xms1024M -Xmn200M"
+      # what's present in the jvm.options file by default:
+      #- "CS_JAVA_OPTIONS=-Xmx1024M -Xms1024M -Xmn200M"
       - "CS_JVM_OPTIONS=-Xmx128M -Xms128M -Xmn50M"
+
+      # on nixos, you also may need to run
+      #   sysctl -w vm.max_map_count=1048576
+      # or add that to your `configuration.nix`
     networks:
       - demo_wire
 


### PR DESCRIPTION
cassandra didn't start up any more, and I added this to the `docker-compose.yaml` during debugging.

it turned out that i should have read the logs better, because there was also a database inconsistency that could only be removed by `docker-compose kill`, not by shutting down and restarting.  so these changes may not be entirely necessary for this to work on nixos, but they remove some warnings.