### PR TITLE
Refactor: Simplify SRV lookup logic in federation-util

### DIFF
--- a/libs/federation-util/src/Network/Federation/Util/DNS.hs
+++ b/libs/federation-util/src/Network/Federation/Util/DNS.hs
@@ -17,6 +17,7 @@
 
 module Network.Federation.Util.DNS
   ( srvLookup,
+    SrvTarget (..),
   )
 where
 
@@ -37,7 +38,7 @@ import Network.Federation.Util.Internal
 -- > main = do
 -- >   rs <- makeResolvSeed defaultResolvConf
 -- >   x <- srvLookup "staging.zinfra.io" rs
-srvLookup :: Text -> ResolvSeed -> IO (Maybe [(Domain, Word16)])
+srvLookup :: Text -> ResolvSeed -> IO (Maybe [SrvTarget])
 srvLookup = srvLookup' srvDefaultPrefix
 
 srvDefaultPrefix :: Text

--- a/libs/federation-util/test/Test/DNSSpec.hs
+++ b/libs/federation-util/test/Test/DNSSpec.hs
@@ -62,7 +62,7 @@ spec = do
     it "returns the expected result for wire.com" $ do
       rs <- makeResolvSeed defaultResolvConf
       wire <- srvLookup'' mockLookupSRV "_wire-server" "wire.com" rs
-      wire `shouldBe` Just [("wire.com", 443)]
+      wire `shouldBe` Just [SrvTarget "wire.com" 443]
     it "filters out single '.' results" $ do
       rs <- makeResolvSeed defaultResolvConf
       exampleDotCom <- srvLookup'' mockLookupSRV "_wire-server" "example.com" rs

--- a/libs/federation-util/test/Test/DNSSpec.hs
+++ b/libs/federation-util/test/Test/DNSSpec.hs
@@ -27,7 +27,7 @@ spec = do
   describe "order" $ do
     it "orders records according to ascending priority" $ do
       actual <-
-        orderSrvResult
+        orderSrvResult . map toSrvEntry $
           [ -- priority, weight, port, domain
             (0, 0, 443, "offline.com"),
             (15, 10, 443, "main.com"),
@@ -37,16 +37,17 @@ spec = do
             (3, 5, 443, "main.com"),
             (0, 0, 443, "backup.com")
           ]
-      (fst4 <$> actual) `shouldBe` [0, 0, 0, 2, 2, 3, 15]
+      (srvPriority <$> actual) `shouldBe` [0, 0, 0, 2, 2, 3, 15]
     it "orders records with the same priority according to weight with certain probability" $ do
       let raw =
-            [ (2, 10, 443, "server1.com"),
-              (2, 20, 443, "server2.com"),
-              (2, 0, 443, "dontuseoften.com")
-            ]
+            map toSrvEntry $
+              [ (2, 10, 443, "server1.com"),
+                (2, 20, 443, "server2.com"),
+                (2, 0, 443, "dontuseoften.com")
+              ]
       -- order the list 50 times
       actuals <- replicateM 50 (orderSrvResult raw)
-      let weightLists = fmap (fmap snd4) actuals
+      let weightLists = fmap (fmap srvWeight) actuals
       let x = filter ((== 20) . head) weightLists
       let y = filter ((== 10) . head) weightLists
       -- we may have e.g.
@@ -75,12 +76,6 @@ spec = do
       rs <- makeResolvSeed defaultResolvConf
       noRecord <- srvLookup'' mockLookupSRV "_wire-server" "no-record-here" rs
       noRecord `shouldBe` Nothing
-
-fst4 :: (a, b, c, d) -> a
-fst4 (a, _, _, _) = a
-
-snd4 :: (a, b, c, d) -> b
-snd4 (_, b, _, _) = b
 
 -- mock function matching Network.DNS's 'lookupSRV' types
 mockLookupSRV :: Resolver -> Domain -> IO (Either DNSError [(Word16, Word16, Word16, Domain)])


### PR DESCRIPTION
I started with the interface of `srvLookup` to avoid dealing with tuples of primitive types in `federator`, but quickly continued refactoring the actual logic itself after seeing bit tuples of `Word16` and things like `(\(priority', weight', port', domain', _) -> (priority', weight', port', domain'))` and `srvResult''''`.

Probably easiest to convince oneself of the correctness by looking at the commits individually.