### PR TITLE
Use ++FAILURES as it will not evaluate to 0

### DIFF
--- a/tools/ormolu.sh
+++ b/tools/ormolu.sh
@@ -76,7 +76,7 @@ for hsfile in $(git ls-files | grep '\.hsc\?$'); do
     FAILED=0
     ormolu --mode $ARG_ORMOLU_MODE --check-idempotency $LANGUAGE_EXTS "$hsfile" || FAILED=1
     if [ "$FAILED" == "1" ]; then
-        ((FAILURES++))
+        ((++FAILURES))
         echo "$hsfile...  *** FAILED"
     else
         echo "$hsfile...  ok"


### PR DESCRIPTION
When an expression evaluates to 0, its exit code is set to 1. Life is always
interesting when you write bash.
More information:
https://unix.stackexchange.com/questions/32250/why-does-a-0-let-a-return-exit-code-1/32251