### PR TITLE
Add script to rebase branch onto formatting changes (like Ormolu upgrades)

### DIFF
--- a/tools/rebase-onto-formatter.sh
+++ b/tools/rebase-onto-formatter.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "INSTRUCTIONS:"
+echo "1. Make a copy of your branch (or be prepared to salvage it from reflog)."
+echo "2. Find out the what the base commit is (in our case ...)"
+echo "3. Rebase onto the base commit yourself."
+echo "4. Make sure the formatting tool is installed with the correct version and settings (i.e. stack install ormolu)."
+echo "5. Run this script."
+echo ""
+echo "Running the script now. This will take a while."
+[[ "$(read -e -p 'Continue? [y/N]> '; echo $REPLY)" == [Yy]* ]] || exit 0
+
+set -x
+
+# TODO: check existence of tools
+
+# TODO: just show usage/instructions if arguments are not supplied?
+BASE_COMMIT=$1
+TARGET_COMMIT=$2
+FORMATTING_COMMAND='make formatf'
+
+# edit every commit Ci, adding f(Ci) and r(F(Ci))
+git rebase $BASE_COMMIT~1 --exec "$FORMATTING_COMMAND && git commit -am "format" && git revert HEAD --no-edit"
+
+# drop last commit
+git reset HEAD~1 --hard
+
+# now for every Ci, squash with the previous and next commit (i.e. r(f(C(i-1))) and f(Ci))
+# in sequence editor, squash lines 3, 6, 9, ... and fixup lines 4, 7, 10, ...
+# in commit message editor, drop drop first 9 lines
+GIT_SEQUENCE_EDITOR='sed -i -e "3~3s/pick/squash/" -e "4~3s/pick/fixup/"' \
+  GIT_EDITOR='sed -i "1,9d"' \
+  git rebase --interactive $BASE_COMMIT
+
+# rebase onto TARGET_COMMIT.
+# Annoyingly, we still have this first "format" commit that should already be
+# part of the TARGET_COMMIT. So we drop it.
+GIT_SEQUENCE_EDITOR='sed -i "1s/pick/drop/"' \
+  git rebase --interactive $BASE_COMMIT --onto $TARGET_COMMIT
+
+echo "Done."
+echo "Please check that the history looks as it should and all expected commits are there."

--- a/tools/rebase-onto-formatter.sh
+++ b/tools/rebase-onto-formatter.sh
@@ -20,7 +20,7 @@ TODO: explain base commit etc.
 
 INSTRUCTIONS:
 1. Make a copy of your branch (or be prepared to salvage it from reflog).
-2. Find out the what the base commit is.
+2. Find out what the base commit is.
 3. Rebase onto the base commit yourself.
 4. Make sure the formatting tool is installed with the correct version and settings (i.e. stack install ormolu).
 5. Run this script.
@@ -47,7 +47,7 @@ git reset HEAD~1 --hard
 
 # now for every Ci, squash with the previous and next commit (i.e. r(f(C(i-1))) and f(Ci))
 # - in sequence editor, squash lines 3, 6, 9, ... and fixup lines 4, 7, 10, ...
-# - in commit message editor, drop drop first 9 lines (removing the commit message of the revert commit)
+# - in commit message editor, drop first 9 lines (removing the commit message of the revert commit)
 GIT_SEQUENCE_EDITOR='sed -i -e "3~3s/pick/squash/" -e "4~3s/pick/fixup/"' \
   GIT_EDITOR='sed -i "1,9d"' \
   git rebase --interactive $BASE_COMMIT

--- a/tools/rebase-onto-formatter.sh
+++ b/tools/rebase-onto-formatter.sh
@@ -44,7 +44,7 @@ echo "Running the script now. This might take a while..."
 # The general idea is the following:
 #
 # We have a branch consisting of commits C1, C2, ... on top of our BASE_COMMIT C0.
-# Also, from C0 a formatting change f(C0) was made on some branch (e.g. develop).
+# Also, from C0 an automated formatting change f was made on some branch (e.g. develop).
 #
 #  C0 ----> C1 ----> C2 ----> ... ----> Cn
 #  |
@@ -63,28 +63,45 @@ echo "Running the script now. This might take a while..."
 #  C0' ---> C1' ---> C2' ---> ... ----> Cn'
 #
 # One useful thing is that since f is defined by an automated tool,
-# we know f(Ci) on every commit Ci.
+# we know f applied at every commit Ci, resulting in a hypothetical Ci'.
 #
 #  C0 ----> C1 ----> C2 ----> ... ----> Cn
 #  |        |        |                  |
 #  f        f        f                  f
 #  |        |        |                  |
 #  v        v        v                  v
+#  C0'      C1'      C2'                Cn'
+#
+# And we can also get its inverse g (applied at Ci') by reverting the commit.
+#
+#  C0 ----> C1 ----> C2 ----> ... ----> Cn
+#  |^       |^       |^                 |^
+#  f|       f|       f|                 f|
+#  |g       |g       |g                 |g
+#  v|       v|       v|                 v|
+#  C0'      C1'      C2'                Cn'
+#
+# Finally, we can get from C(i-1)' to Ci' by composing three arrows:
+# - g at C(i-1)
+# - Ci
+# - f at C1
+#
+#  C0 ----> C1 ----> C2 ----> ... ----> Cn
+#  |^       |^       |^                 |^
+#  f|       f|       f|                 f|
+#  |g       |g       |g                 |g
+#  v|       v|       v|                 v|
 #  C0' ---> C1' ---> C2' ---> ... ----> Cn'
-#
-# And we can also get its inverse r(f(Ci)) by reverting the commit.
-#
-# So we can obtain Ci' by composing r(f(C(i-1))), Ci and f(Ci).
 
 set -x
 
-# edit every commit Ci, adding f(Ci) and r(f(Ci))
+# edit every commit Ci, adding new commits representing f at Ci and it's inverse g
 git rebase $BASE_COMMIT~1 --exec "$FORMATTING_COMMAND && git commit -am "format" && git revert HEAD --no-edit"
 
 # drop last commit
 git reset HEAD~1 --hard
 
-# now for every Ci, squash with the previous and next commit (i.e. r(f(C(i-1))) and f(Ci))
+# now for every Ci, squash with the previous and next commit (i.e. g at C(i-1) and f at Ci)
 # - in sequence editor, squash lines 3, 6, 9, ... and fixup lines 4, 7, 10, ...
 # - in commit message editor, drop first 9 lines (removing the commit message of the revert commit)
 GIT_SEQUENCE_EDITOR='sed -i -e "3~3s/pick/squash/" -e "4~3s/pick/fixup/"' \

--- a/tools/rebase-onto-formatter.sh
+++ b/tools/rebase-onto-formatter.sh
@@ -44,43 +44,37 @@ echo "Running the script now. This might take a while..."
 # The general idea is the following:
 #
 # We have a branch consisting of commits C1, C2, ... on top of our BASE_COMMIT C0.
-# Also, from C0 a formatting change `f(C0)` was made on some branch (e.g. develop).
+# Also, from C0 a formatting change f(C0) was made on some branch (e.g. develop).
 #
-# ```
 #  C0 ----> C1 ----> C2 ----> ... ----> Cn
 #  |
 #  f
 #  |
 #  v
 #  C0'
-# ```
 #
 # Now, how do we obtain versions of our commits operating on the formatted code (let's call them Ci')?
 #
-# ```
 #  C0 ----> C1 ----> C2 ----> ... ----> Cn
 #  |
 #  f
 #  |
 #  v
 #  C0' ---> C1' ---> C2' ---> ... ----> Cn'
-# ```
 #
-# One useful thing is that since `f` is defined by an automated tool,
-# we know `f(Ci)` on every commit `Ci`.
+# One useful thing is that since f is defined by an automated tool,
+# we know f(Ci) on every commit Ci.
 #
-# ```
 #  C0 ----> C1 ----> C2 ----> ... ----> Cn
 #  |        |        |                  |
 #  f        f        f                  f
 #  |        |        |                  |
 #  v        v        v                  v
 #  C0' ---> C1' ---> C2' ---> ... ----> Cn'
-# ```
 #
-# And we can also get its inverse `r(f(Ci))` by reverting the commit.
+# And we can also get its inverse r(f(Ci)) by reverting the commit.
 #
-# So we can obtain `Ci'` by composing `r(f(C(i-1))), `Ci` and `f(Ci)`.
+# So we can obtain Ci' by composing r(f(C(i-1))), Ci and f(Ci).
 
 set -x
 

--- a/tools/rebase-onto-formatter.sh
+++ b/tools/rebase-onto-formatter.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 command -v sed  >/dev/null 2>&1 || { echo >&2 "sed is not installed, aborting."; exit 1; }
 
-BASE_COMMIT=$1
-TARGET_COMMIT=$2
+BASE_COMMIT=${1:-}
+TARGET_COMMIT=${2:-}
 FORMATTING_COMMAND='make formatf'
 USAGE="
 USAGE: $0 BASE_COMMIT TARGET_COMMIT
@@ -27,7 +27,7 @@ INSTRUCTIONS:
 
 "
 
-if [ -z "$BASE_COMMIT" || -z "$TARGET_COMMIT" || -z "$FORMATTING_COMMAND" ]
+if [ -n "$BASE_COMMIT" ] || [ -n "$TARGET_COMMIT" ] || [ -n "$FORMATTING_COMMAND" ]
 then
   echo "$USAGE" 1>&2
   exit 1

--- a/tools/rebase-onto-formatter.sh
+++ b/tools/rebase-onto-formatter.sh
@@ -8,15 +8,17 @@ BASE_COMMIT=${1:-}
 TARGET_COMMIT=${2:-}
 FORMATTING_COMMAND='make formatf'
 USAGE="
-USAGE: $0 BASE_COMMIT TARGET_COMMIT
-    BASE_COMMIT:
+USAGE: $0 TARGET_COMMIT BASE_COMMIT
+
     TARGET_COMMIT:
+        The commit introducing the formatting that you want to rebase onto.
+    BASE_COMMIT:
+        A commit very similar to TARGET_COMMIT, just that the automated formatting changes are not applied yet.
+        It has to include changes to formatting version and config already.
 
 Rebase a branch onto changes created by an automated formatter. The script
 will keep the (linear) history of the branch intact and make the commits appear
 as if the changes had been applied onto the newly-formatted version all along.
-
-TODO: explain base commit etc.
 
 INSTRUCTIONS:
 1. Make a copy of your branch (or be prepared to salvage it from reflog).

--- a/tools/rebase-onto-formatter.sh
+++ b/tools/rebase-onto-formatter.sh
@@ -43,54 +43,54 @@ echo "Running the script now. This might take a while..."
 
 # The general idea is the following:
 #
-# We have a branch consisting of changes C1, C2, ... on top of our BASE_COMMIT 0.
-# Also, from the base commit, a formatting change `f(0)` was made.
+# We have a branch consisting of commits C1, C2, ... on top of our BASE_COMMIT C0.
+# Also, from C0 a formatting change `f(C0)` was made on some branch (e.g. develop).
 #
 # ```
-#  0 --- C1 ---> 1 --- C2 ---> 2 --- C3 ---> ... --- Cn ---> n
+#  C0 ----> C1 ----> C2 ----> ... ----> Cn
 #  |
 #  f
 #  |
 #  v
-#  0'
+#  C0'
 # ```
 #
-# Now, how do we obtain versions of our changes operating on the formatted code (let's call them Ci')?
+# Now, how do we obtain versions of our commits operating on the formatted code (let's call them Ci')?
 #
 # ```
-#  0 --- C1 ---> 1 --- C2 ---> 2 --- C3 ---> ... --- Cn ---> n
+#  C0 ----> C1 ----> C2 ----> ... ----> Cn
 #  |
 #  f
 #  |
 #  v
-#  0' -- C1' --> 1' -- C2' --> 2' -- C3' --> ... --- Cn' --> n'
+#  C0' ---> C1' ---> C2' ---> ... ----> Cn'
 # ```
 #
 # One useful thing is that since `f` is defined by an automated tool,
-# we know `f(i)` on every commit `i`.
+# we know `f(Ci)` on every commit `Ci`.
 #
 # ```
-#  0 --- C1 ---> 1 --- C2 ---> 2 --- C3 ---> ... --- Cn ---> n
-#  |             |             |                             |
-#  f             f             f                             f
-#  |             |             |                             |
-#  v             v             v                             v
-#  0' -- C1' --> 1' -- C2' --> 2' -- C3' --> ... --- Cn' --> n'
+#  C0 ----> C1 ----> C2 ----> ... ----> Cn
+#  |        |        |                  |
+#  f        f        f                  f
+#  |        |        |                  |
+#  v        v        v                  v
+#  C0' ---> C1' ---> C2' ---> ... ----> Cn'
 # ```
 #
-# And we can also get its inverse `r(f(i))` by reverting the commit.
+# And we can also get its inverse `r(f(Ci))` by reverting the commit.
 #
-# So we can obtain `Ci' by composing `r(f(i-1)), `Ci` and `f(i)`.
+# So we can obtain `Ci'` by composing `r(f(C(i-1))), `Ci` and `f(Ci)`.
 
 set -x
 
-# edit every commit i, adding f(i) and r(f(i))
+# edit every commit Ci, adding f(Ci) and r(f(Ci))
 git rebase $BASE_COMMIT~1 --exec "$FORMATTING_COMMAND && git commit -am "format" && git revert HEAD --no-edit"
 
 # drop last commit
 git reset HEAD~1 --hard
 
-# now for every i, squash with the previous and next commit (i.e. r(f(i-1)) and f(i))
+# now for every Ci, squash with the previous and next commit (i.e. r(f(C(i-1))) and f(Ci))
 # - in sequence editor, squash lines 3, 6, 9, ... and fixup lines 4, 7, 10, ...
 # - in commit message editor, drop first 9 lines (removing the commit message of the revert commit)
 GIT_SEQUENCE_EDITOR='sed -i -e "3~3s/pick/squash/" -e "4~3s/pick/fixup/"' \

--- a/tools/rebase-onto-formatter.sh
+++ b/tools/rebase-onto-formatter.sh
@@ -22,10 +22,14 @@ as if the changes had been applied onto the newly-formatted version all along.
 
 INSTRUCTIONS:
 1. Make a copy of your branch (or be prepared to salvage it from reflog).
+   $ git branch mybranch-backup
 2. Find out what the base commit is.
 3. Rebase onto the base commit yourself.
-4. Make sure the formatting tool is installed with the correct version and settings (i.e. stack install ormolu).
+   $ git rebase \$BASE_COMMIT
+4. Make sure the formatting tool is installed with the correct version and settings.
+   $ stack install ormolu
 5. Run this script.
+   $ $0 \$TARGET_COMMIT \$BASE_COMMIT
 
 "
 

--- a/tools/rebase-onto-formatter.sh
+++ b/tools/rebase-onto-formatter.sh
@@ -33,7 +33,7 @@ INSTRUCTIONS:
 
 "
 
-if [ -n "$BASE_COMMIT" ] || [ -n "$TARGET_COMMIT" ] || [ -n "$FORMATTING_COMMAND" ]
+if [ -z "$BASE_COMMIT" ] || [ -z "$TARGET_COMMIT" ] || [ -z "$FORMATTING_COMMAND" ]
 then
   echo "$USAGE" 1>&2
   exit 1


### PR DESCRIPTION
Related to https://github.com/zinfra/backend-issues/issues/1623.

Upgrading Ormolu can be painful, because the style will often change in a lot of places (see for example #1145). Any active branches/PRs will then have to rebase onto these changes and resolve the resulting conflicts. It becomes a bit less cumbersome after first squashing all commits of the branch into a single one, but that's often not desirable.

This script will automate the rebasing process, keeping the (linear) history of intact and making the commits appear as if the changes had been applied onto the newly-formatted version all along.

For example, I rebased #1179 onto #1145, resulting in [this branch](https://github.com/wireapp/wire-server/compare/mheinzel/upgrade-ormolu-squashed...fisx/cleanup-rebased-onto-ormolu-0.1.2?expand=1)

You can compare the old and new commits, e.g. [this pre-#1145 change](https://github.com/wireapp/wire-server/commit/0c4d0b898b35c9c103a5d8e36c6924a4271c9d50#diff-9f592dc55a5aee3a8eb533599379916eR411-R419) with [this one post-#1145](https://github.com/wireapp/wire-server/commit/b39cc6fead76dcfc10f58b8c4a33741a35dc7f28#diff-9f592dc55a5aee3a8eb533599379916eR412-R420).


I still want to clean up the script a bit and add instructions and explanations of the idea, but as you see it already works. It was invoked using `./tools/rebase-onto-formatter.sh 178b754c3ba72c5a78745330d53d79b4fc5e34e0 mheinzel/upgrade-ormolu-squashed`, which you can also try on other branches.