### PR TITLE
Some formatting cleanup

### DIFF
--- a/libs/cassandra-util/src/Cassandra/Exec.hs
+++ b/libs/cassandra-util/src/Cassandra/Exec.hs
@@ -33,10 +33,9 @@ where
 import Cassandra.CQL (Consistency, R)
 import Control.Monad.Catch
 import Data.Conduit
--- Things we just import and re-export.
-
 -- We only use these locally.
 import Database.CQL.IO (RetrySettings, RunQ, defRetrySettings, eagerRetrySettings)
+-- Things we just import and re-export.
 import Database.CQL.IO as C (BatchM, Client, ClientState, MonadClient, Page (..), PrepQuery, Row, addPrepQuery, addQuery, adjustConsistency, adjustResponseTimeout, adjustSendTimeout, batch, emptyPage, init, liftClient, localState, paginate, prepared, query, query1, queryString, retry, runClient, schema, setConsistency, setSerialConsistency, setType, shutdown, trans, write)
 import Database.CQL.Protocol (Error, QueryParams (QueryParams), Tuple)
 import Imports hiding (init)

--- a/libs/imports/src/Imports.hs
+++ b/libs/imports/src/Imports.hs
@@ -117,25 +117,8 @@ module Imports
   )
 where
 
--- Explicitly saying what to import because some things from Prelude clash
--- with e.g. UnliftIO modules
-
-import Control.Applicative hiding (empty, many, optional, some) -- common in
--- some libs
-
--- conflicts with Options.Applicative.Option (should we care?)
--- First and Last are going to be deprecated. Use Semigroup instead
-
--- 'insert' and 'delete' are
--- common in database modules
-
--- Handle is hidden
--- because it's common
--- in Brig
--- Permissions is common in Galley
-
--- Lazy and strict versions are the same
-
+-- common in some libs
+import Control.Applicative hiding (empty, many, optional, some)
 import Control.DeepSeq (NFData (..), deepseq)
 import Control.Monad hiding (forM, forM_, mapM, mapM_, msum, sequence, sequence_)
 import Control.Monad.Extra (unlessM, whenM)
@@ -165,11 +148,15 @@ import Data.Functor.Identity
 import Data.HashMap.Strict (HashMap)
 import Data.HashSet (HashSet)
 import Data.Int
+-- 'insert' and 'delete' are common in database modules
 import Data.List hiding (delete, insert)
+-- Lazy and strict versions are the same
 import Data.Map (Map)
 import Data.Maybe
+-- First and Last are going to be deprecated. Use Semigroup instead
 import Data.Monoid hiding (First (..), Last (..))
 import Data.Ord
+-- conflicts with Options.Applicative.Option (should we care?)
 import Data.Semigroup hiding (Option, diff, option)
 import Data.Set (Set)
 import Data.String
@@ -184,13 +171,17 @@ import GHC.Generics (Generic)
 import GHC.Stack (HasCallStack)
 import Text.Read (readEither, readMaybe)
 import UnliftIO.Concurrent
+-- Permissions is common in Galley
 import UnliftIO.Directory hiding (Permissions)
 import UnliftIO.Environment
 import UnliftIO.Exception
+-- Handle is hidden because it's common in Brig
 import UnliftIO.IO hiding (Handle, getMonotonicTime)
 import UnliftIO.IORef
 import UnliftIO.MVar
 import UnliftIO.STM
+-- Explicitly saying what to import because some things from Prelude clash
+-- with e.g. UnliftIO modules
 import Prelude
   ( Bounded (..),
     Double,

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -985,7 +985,7 @@ lookupProfilesOfLocalUsers self others = do
   where
     toMap :: [ConnectionStatus] -> Map UserId Relation
     toMap = Map.fromList . map (csFrom &&& csStatus)
-    --
+
     getSelfInfo :: AppIO (Maybe (TeamId, Team.TeamMember))
     getSelfInfo = do
       -- FUTUREWORK: it is an internal error for the two lookups (for 'User' and 'TeamMember')
@@ -995,7 +995,7 @@ lookupProfilesOfLocalUsers self others = do
       case userTeam =<< mUser of
         Nothing -> pure Nothing
         Just tid -> (tid,) <$$> Intra.getTeamMember self tid
-    --
+
     toProfile :: EmailVisibility' -> Map UserId Relation -> User -> UserProfile
     toProfile emailVisibility'' css u =
       let cs = Map.lookup (userId u) css

--- a/services/brig/src/Brig/Index/Eval.hs
+++ b/services/brig/src/Brig/Index/Eval.hs
@@ -125,7 +125,7 @@ waitForTaskToComplete timeoutSeconds taskNodeId = do
     isTaskComplete :: Either ES.EsError (ES.TaskResponse a) -> m Bool
     isTaskComplete (Left e) = throwM $ ReindexFromAnotherIndexError $ "Error response while getting task: " <> show e
     isTaskComplete (Right taskRes) = pure $ ES.taskResponseCompleted taskRes
-    --
+
     errTaskGet :: MonadThrow m => ES.EsError -> m x
     errTaskGet e = throwM $ ReindexFromAnotherIndexError $ "Error response while getting task: " <> show e
 

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -512,21 +512,20 @@ updateTeamMember zusr zcon tid targetMember = do
   updateJournal team updatedMembers
   updatePeers targetId targetPermissions updatedMembers
   where
-    --
     canDowngradeOwner = canDeleteMember
-    --
+
     downgradesOwner :: TeamMember -> Permissions -> Bool
     downgradesOwner previousMember targetPermissions =
       permissionsRole (previousMember ^. permissions) == Just RoleOwner
         && permissionsRole targetPermissions /= Just RoleOwner
-    --
+
     updateJournal :: Team -> TeamMemberList -> Galley ()
     updateJournal team mems = do
       when (team ^. teamBinding == Binding) $ do
         (TeamSize size) <- BrigTeam.getSize tid
         billingUserIds <- Journal.getBillingUserIds tid $ Just mems
         Journal.teamUpdate tid size billingUserIds
-    --
+
     updatePeers :: UserId -> Permissions -> TeamMemberList -> Galley ()
     updatePeers targetId targetPermissions updatedMembers = do
       -- inform members of the team about the change
@@ -798,14 +797,14 @@ getTeamNotificationsH (zusr ::: sinceRaw ::: size ::: _) = do
   where
     parseSince :: Galley (Maybe Public.NotificationId)
     parseSince = maybe (pure Nothing) (fmap Just . parseUUID) sinceRaw
-    --
+
     parseUUID :: ByteString -> Galley Public.NotificationId
     parseUUID raw =
       maybe
         (throwM invalidTeamNotificationId)
         (pure . Id)
         ((UUID.fromASCIIBytes >=> isV1UUID) raw)
-    --
+
     isV1UUID :: UUID.UUID -> Maybe UUID.UUID
     isV1UUID u = if UUID.version u == 1 then Just u else Nothing
 

--- a/services/galley/src/Galley/Intra/Journal.hs
+++ b/services/galley/src/Galley/Intra/Journal.hs
@@ -102,11 +102,11 @@ getBillingUserIds tid maybeMemberList = do
   where
     fetchFromDB :: Galley [UserId]
     fetchFromDB = Data.listBillingTeamMembers tid
-    --
+
     filterFromMembers :: TeamMemberList -> Galley [UserId]
     filterFromMembers list =
       pure $ map (view userId) $ filter (`hasPermission` SetBilling) (list ^. teamMembers)
-    --
+
     handleList :: Bool -> TeamMemberList -> Galley [UserId]
     handleList enableIndexedBillingTeamMembers list =
       case list ^. teamMemberListType of

--- a/services/galley/src/Galley/Intra/Push.hs
+++ b/services/galley/src/Galley/Intra/Push.hs
@@ -159,12 +159,12 @@ push ps = do
       where
         (localRecipients, remoteRecipients) =
           partitionEithers . fmap localOrRemoteRecipient . toList $ pushRecipients p
-    --
+
     localOrRemoteRecipient :: RecipientBy (MappedOrLocalId Id.U) -> Either (RecipientBy UserId) (RecipientBy (IdMapping Id.U))
     localOrRemoteRecipient rcp = case _recipientUserId rcp of
       Local localId -> Left $ rcp {_recipientUserId = localId}
       Mapped idMapping -> Right $ rcp {_recipientUserId = idMapping}
-    --
+
     mkPushTo :: [RecipientBy a] -> PushTo b -> Maybe (PushTo a)
     mkPushTo recipients p =
       nonEmpty recipients <&> \nonEmptyRecipients ->

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -846,10 +846,10 @@ getTeamQueue zusr msince msize onlyLast = do
         error $ "expected time: Nothing; but found: " <> show (qnl ^. queuedTime)
       | otherwise =
         fmap (_2 %~ parseEvt) . mconcat . fmap parseEvts . view queuedNotifications $ qnl
-    --
+
     parseEvts :: QueuedNotification -> [(NotificationId, Object)]
     parseEvts qn = (qn ^. queuedNotificationId,) <$> (toList . toNonEmpty $ qn ^. queuedNotificationPayload)
-    --
+
     parseEvt :: Object -> UserId
     parseEvt o = case fromJSON (Object o) of
       (Error msg) -> error msg

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -408,14 +408,14 @@ addToken uid cid newtok = mpaRunWithBudget 1 AddTokenNoBudget $ do
           then (Just a, old)
           else (x, a : old)
       | otherwise = (x, old)
-    --
+
     continue ::
       PushToken ->
       Maybe Address ->
       Gundeck (Either AddTokenResponse Address)
     continue t Nothing = create (0 :: Int) t
     continue t (Just a) = update (0 :: Int) t (a ^. addrEndpoint)
-    --
+
     create ::
       Int ->
       PushToken ->
@@ -445,7 +445,7 @@ addToken uid cid newtok = mpaRunWithBudget 1 AddTokenNoBudget $ do
         Right arn -> do
           Data.insert uid trp app tok arn cid (t ^. tokenClient)
           return (Right (mkAddr t arn))
-    --
+
     update ::
       Int ->
       PushToken ->
@@ -481,7 +481,7 @@ addToken uid cid newtok = mpaRunWithBudget 1 AddTokenNoBudget $ do
               Aws.EndpointNotFound {} -> create (n + 1) t
               Aws.InvalidCustomData {} -> return (Left AddTokenMetadataTooLong)
               ex -> throwM ex
-    --
+
     mkAddr ::
       PushToken ->
       EndpointArn ->

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -1189,7 +1189,7 @@ specEmailValidation = do
           let req = put $ galley . paths p . json (Feature.TeamFeatureStatus Feature.TeamFeatureEnabled)
               p = ["/i/teams", toByteString' tid, "features", "validate-saml-emails"]
           call req !!! const 204 === statusCode
-        --
+
         assertEmail :: HasCallStack => UserId -> Maybe Email -> TestSpar ()
         assertEmail uid expectedEmail = do
           brig <- asks (^. teBrig)
@@ -1197,10 +1197,10 @@ specEmailValidation = do
           call req !!! do
             const 200 === statusCode
             const expectedEmail === (userEmail <=< responseJsonMaybe)
-        --
+
         eventually :: HasCallStack => TestSpar a -> TestSpar a
         eventually = recovering (limitRetries 3 <> exponentialBackoff 100000) [] . const
-        --
+
         setup :: HasCallStack => Bool -> TestSpar (UserId, Email)
         setup enabled = do
           (tok, (_ownerid, teamid, idp)) <- registerIdPAndScimToken
@@ -1212,7 +1212,7 @@ specEmailValidation = do
           brig <- asks (^. teBrig)
           call $ activateEmail brig email
           pure (uid, email)
-        --
+
         -- copied from brig integration tests.
         activateEmail ::
           HasCallStack =>
@@ -1228,7 +1228,7 @@ specEmailValidation = do
               activate brig kc !!! do
                 const 200 === statusCode
                 const (Just False) === fmap Activation.activatedFirst . responseJsonMaybe
-        --
+
         -- copied from brig integration tests.
         getActivationCode ::
           HasCallStack =>
@@ -1242,7 +1242,7 @@ specEmailValidation = do
           let akey = Activation.ActivationKey . Ascii.unsafeFromText <$> (lbs ^? key "key" . _String)
           let acode = Activation.ActivationCode . Ascii.unsafeFromText <$> (lbs ^? key "code" . _String)
           return $ (,) <$> akey <*> acode
-        --
+
         -- copied from brig integration tests.
         activate ::
           HasCallStack =>


### PR DESCRIPTION
With Ormolu 0.1.2, we can now stop separating definitions in a where-clause by empty comments. This PR fixes all the places I found using `grep`.
It also fixes some comments that got broken when Ormolu was introduced.