### PR TITLE
Fixed logic related to ephemeral users

### DIFF
--- a/docs/reference/user/registration.md
+++ b/docs/reference/user/registration.md
@@ -185,7 +185,8 @@ During registration, we can take advantage of [NewUserOrigin](https://github.com
 So `/register` should only succeed iff at least one of these conditions is true:
 
 ```
-NewUserIsTeamUser OR newUserIsEphemeral
+import Brig.Types.User
+isNewUserTeamMember || isNewUserEphemeral
 ```
 
 The rest of the unauthorized end-points is safe:

--- a/docs/reference/user/registration.md
+++ b/docs/reference/user/registration.md
@@ -180,14 +180,12 @@ We need an option to block 1, 2, 5 on-prem; 3, 4 should remain available (no blo
  * Allow team members to register (via email/phone or SSO)
  * Allow ephemeral users
 
-During registration, we can take advantage of [NewUserOrigin](https://github.com/wireapp/wire-server/blob/a89b9cd818997e7837e5d0938ecfd90cf8dd9e52/libs/wire-api/src/Wire/API/User.hs#L625); we're particularly interested in `NewUserOriginTeamUser` --> only `NewTeamMember` or `NewTeamMemberSSO` should be accepted. In case this is a `Nothing`, we need to check if the user expires, i.e., `newUserExpiresIn` must be a `Just`.
+During registration, we can take advantage of [NewUserOrigin](https://github.com/wireapp/wire-server/blob/a89b9cd818997e7837e5d0938ecfd90cf8dd9e52/libs/wire-api/src/Wire/API/User.hs#L625); we're particularly interested in `NewUserOriginTeamUser` --> only `NewTeamMember` or `NewTeamMemberSSO` should be accepted. In case this is a `Nothing`, we need to check if the user expires, i.e., if the user has no identity (and thus `Ephemeral`).
 
 So `/register` should only succeed iff at least one of these conditions is true:
 
 ```
-newUserTeam == (Just (NewTeamMember _)) OR
-newUserTeam == (Just (NewTeamMemberSSO _)) OR
-newUserExpiresIn == (Just _)
+NewUserIsTeamUser OR newUserIsEphemeral
 ```
 
 The rest of the unauthorized end-points is safe:

--- a/libs/brig-types/src/Brig/Types/User.hs
+++ b/libs/brig-types/src/Brig/Types/User.hs
@@ -43,6 +43,8 @@ module Brig.Types.User
     newUserEmail,
     newUserPhone,
     newUserSSOId,
+    isNewUserEphemeral,
+    isNewUserTeamMember,
     InvitationCode (..),
     BindingNewTeamUser (..),
     NewTeamUser (..),

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -43,6 +43,8 @@ module Wire.API.User
     newUserEmail,
     newUserPhone,
     newUserSSOId,
+    isNewUserEphemeral,
+    isNewUserTeamMember,
 
     -- * NewUserOrigin
     NewUserOrigin (..),
@@ -491,6 +493,19 @@ validateNewUserPublic nu
     Left "only managed-by-Wire users can be created here."
   | otherwise =
     Right (NewUserPublic nu)
+
+-- | Any user registering without either an email or a phone is Ephemeral,
+-- i.e. can be deleted after expires_in or sessionTokenTimeout
+isNewUserEphemeral :: NewUser -> Bool
+isNewUserEphemeral u = case newUserIdentity u of
+  Nothing -> True
+  Just _ -> False
+
+isNewUserTeamMember :: NewUser -> Bool
+isNewUserTeamMember u = case newUserTeam u of
+  Just (NewTeamMember _) -> True
+  Just (NewTeamMemberSSO _) -> True
+  _ -> False
 
 instance Arbitrary NewUserPublic where
   arbitrary = arbitrary `QC.suchThatMap` (rightMay . validateNewUserPublic)

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -497,9 +497,7 @@ validateNewUserPublic nu
 -- | Any user registering without either an email or a phone is Ephemeral,
 -- i.e. can be deleted after expires_in or sessionTokenTimeout
 isNewUserEphemeral :: NewUser -> Bool
-isNewUserEphemeral u = case newUserIdentity u of
-  Nothing -> True
-  Just _ -> False
+isNewUserEphemeral = isNothing . newUserIdentity
 
 isNewUserTeamMember :: NewUser -> Bool
 isNewUserTeamMember u = case newUserTeam u of

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -503,7 +503,8 @@ isNewUserTeamMember :: NewUser -> Bool
 isNewUserTeamMember u = case newUserTeam u of
   Just (NewTeamMember _) -> True
   Just (NewTeamMemberSSO _) -> True
-  _ -> False
+  Just (NewTeamCreator _) -> False
+  Nothing -> False
 
 instance Arbitrary NewUserPublic where
   arbitrary = arbitrary `QC.suchThatMap` (rightMay . validateNewUserPublic)

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -318,22 +318,13 @@ createUser new@NewUser {..} = do
 -- | docs/reference/user/registration.md {#RefRestrictRegistration}.
 checkRestrictedUserCreation :: NewUser -> ExceptT CreateUserError AppIO ()
 checkRestrictedUserCreation new = do
-  let nTeam = newUserTeam new
-      nExpires = newUserExpiresIn new
-
   restrictPlease <- lift . asks $ fromMaybe False . setRestrictUserCreation . view settings
   when
     ( restrictPlease
-        && not (isTeamMember nTeam)
-        && not (isEphemeral nExpires)
+        && not (isNewUserTeamMember new)
+        && not (isNewUserEphemeral new)
     )
     $ throwE UserCreationRestricted
-  where
-    isTeamMember (Just (NewTeamMember _)) = True
-    isTeamMember (Just (NewTeamMemberSSO _)) = True
-    isTeamMember _ = False
-    isEphemeral (Just _) = True
-    isEphemeral _ = False
 
 -------------------------------------------------------------------------------
 -- Update Profile

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -128,9 +128,10 @@ newAccount u inv tid = do
     name = newUserDisplayName u
     pict = fromMaybe noPict (newUserPict u)
     assets = newUserAssets u
-    status = if isNewUserEphemeral u
-      then Ephemeral
-      else Active
+    status =
+      if isNewUserEphemeral u
+        then Ephemeral
+        else Active
     colour = fromMaybe defaultAccentId (newUserAccentId u)
     locale defLoc = fromMaybe defLoc (newUserLocale u)
     managedBy = fromMaybe defaultManagedBy (newUserManagedBy u)

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -128,12 +128,9 @@ newAccount u inv tid = do
     name = newUserDisplayName u
     pict = fromMaybe noPict (newUserPict u)
     assets = newUserAssets u
-    status = case ident of
-      Nothing ->
-        -- any user registering without either an email or a phone is Ephemeral,
-        -- i.e. can be deleted after expires_in or sessionTokenTimeout
-        Ephemeral
-      Just _ -> Active
+    status = if isNewUserEphemeral u
+      then Ephemeral
+      else Active
     colour = fromMaybe defaultAccentId (newUserAccentId u)
     locale defLoc = fromMaybe defLoc (newUserLocale u)
     managedBy = fromMaybe defaultManagedBy (newUserManagedBy u)


### PR DESCRIPTION
Fixes https://github.com/zinfra/backend-issues/issues/1685

Long story short: the logic that checked whether a user was ephemeral was flawed, causing user creation to fail when it should succeed. This PR fixes that.