### PR TITLE
Allow SCIM without saml

### DIFF
--- a/libs/brig-types/src/Brig/Types/Intra.hs
+++ b/libs/brig-types/src/Brig/Types/Intra.hs
@@ -64,7 +64,7 @@ instance ToJSON AccountStatus where
   toJSON Deleted = String "deleted"
   toJSON Ephemeral = String "ephemeral"
 
-data AccountStatusResp = AccountStatusResp AccountStatus
+data AccountStatusResp = AccountStatusResp {fromAccountStatusResp :: AccountStatus}
 
 instance ToJSON AccountStatusResp where
   toJSON (AccountStatusResp s) = object ["status" .= s]

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -593,12 +593,12 @@ instance FromJSON NewUser where
     newUserLabel <- o .:? "label"
     newUserLocale <- o .:? "locale"
     newUserPassword <- o .:? "password"
-    newUserOrigin <- parseNewUserOrigin newUserPassword newUserIdentity ssoid o
+    newUserManagedBy <- o .:? "managed_by"
+    newUserOrigin <- parseNewUserOrigin newUserPassword newUserIdentity ssoid newUserManagedBy o
     newUserExpires <- o .:? "expires_in"
     newUserExpiresIn <- case (newUserExpires, newUserIdentity) of
       (Just _, Just _) -> fail "Only users without an identity can expire"
       _ -> return newUserExpires
-    newUserManagedBy <- o .:? "managed_by"
     return NewUser {..}
 
 -- FUTUREWORK: align more with FromJSON instance?
@@ -681,9 +681,10 @@ parseNewUserOrigin ::
   Maybe PlainTextPassword ->
   Maybe UserIdentity ->
   Maybe UserSSOId ->
+  Maybe ManagedBy ->
   Object ->
   Aeson.Parser (Maybe NewUserOrigin)
-parseNewUserOrigin pass uid ssoid o = do
+parseNewUserOrigin pass uid ssoid managedBy o = do
   invcode <- o .:? "invitation_code"
   teamcode <- o .:? "team_code"
   team <- o .:? "team"
@@ -694,12 +695,15 @@ parseNewUserOrigin pass uid ssoid o = do
     (Nothing, Nothing, Just a, Nothing, Nothing) -> return . Just . NewUserOriginTeamUser $ NewTeamCreator a
     (Nothing, Nothing, Nothing, Just _, Just t) -> return . Just . NewUserOriginTeamUser $ NewTeamMemberSSO t
     (Nothing, Nothing, Nothing, Nothing, Nothing) -> return Nothing
-    (_, _, _, _, _) ->
-      fail $
-        "team_code, team, invitation_code, sso_id are mutually exclusive\
-        \ and sso_id, team_id must be either both present or both absent."
+    (_, _, _, Just _, Nothing) -> fail "sso_id, team_id must be either both present or both absent."
+    (_, _, _, Nothing, Just t) ->
+      if managedBy == Just ManagedByScim
+        then return . Just . NewUserOriginTeamUser $ NewTeamMemberSSO t
+        else fail "sso_id, team_id must be either both present or both absent."
+    _ -> fail "team_code, team, invitation_code, sso_id, and the pair (sso_id, team_id) are mutually exclusive"
   case (result, pass, uid) of
     (_, _, Just SSOIdentity {}) -> pure result
+    (Just (NewUserOriginTeamUser (NewTeamMemberSSO _)), Nothing, Nothing) -> pure result
     (Just (NewUserOriginTeamUser _), Nothing, _) -> fail "all team users must set a password on creation"
     _ -> pure result
 
@@ -729,7 +733,8 @@ data NewTeamUser
   = -- | requires email address
     NewTeamMember InvitationCode
   | NewTeamCreator BindingNewTeamUser
-  | NewTeamMemberSSO TeamId
+  | -- | sso: users with saml credentials and/or created via scim
+    NewTeamMemberSSO TeamId
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform NewTeamUser)
 

--- a/libs/wire-api/src/Wire/API/User/Identity.hs
+++ b/libs/wire-api/src/Wire/API/User/Identity.hs
@@ -251,15 +251,13 @@ isValidPhone = either (const False) (const True) . parseOnly e164
 -- FUTUREWORK: rename the data type to @UserSparId@ (not the two constructors, those are ok).
 data UserSSOId
   = UserSSOId
-      { -- | An XML blob pointing to the identity provider that can confirm
-        -- user's identity.
-        userSSOIdTenant :: Text,
-        -- | An XML blob specifying the user's ID on the identity provider's side.
-        userSSOIdSubject :: Text
-      }
+      -- An XML blob pointing to the identity provider that can confirm
+      -- user's identity.
+      Text
+      -- An XML blob specifying the user's ID on the identity provider's side.
+      Text
   | UserScimExternalId
-      { userScimExternalId :: Text
-      }
+      Text
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform UserSSOId)
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -1096,7 +1096,7 @@ instance ToJSON GetActivationCodeResp where
 updateUserH :: UserId ::: ConnId ::: JsonRequest Public.UserUpdate -> Handler Response
 updateUserH (uid ::: conn ::: req) = do
   uu <- parseJsonBody req
-  lift $ API.updateUser uid conn uu
+  lift $ API.updateUser uid (Just conn) uu
   return empty
 
 changePhoneH :: UserId ::: ConnId ::: JsonRequest Public.PhoneUpdate -> Handler Response
@@ -1177,7 +1177,7 @@ changeHandleH (u ::: conn ::: req) = do
 changeHandle :: UserId -> ConnId -> Public.HandleUpdate -> Handler ()
 changeHandle u conn (Public.HandleUpdate h) = do
   handle <- API.validateHandle h
-  API.changeHandle u conn handle !>> changeHandleError
+  API.changeHandle u (Just conn) handle !>> changeHandleError
 
 beginPasswordResetH :: JSON ::: JsonRequest Public.NewPasswordReset -> Handler Response
 beginPasswordResetH (_ ::: req) = do

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -335,10 +335,10 @@ checkRestrictedUserCreation new = do
 -- FUTUREWORK: this and other functions should refuse to modify a ManagedByScim user. See
 -- {#SparBrainDump}  https://github.com/zinfra/backend-issues/issues/1632
 
-updateUser :: UserId -> ConnId -> UserUpdate -> AppIO ()
-updateUser uid conn uu = do
+updateUser :: UserId -> Maybe ConnId -> UserUpdate -> AppIO ()
+updateUser uid mconn uu = do
   Data.updateUser uid uu
-  Intra.onUserEvent uid (Just conn) (profileUpdated uid uu)
+  Intra.onUserEvent uid mconn (profileUpdated uid uu)
 
 -------------------------------------------------------------------------------
 -- Update Locale
@@ -359,8 +359,8 @@ changeManagedBy uid conn (ManagedByUpdate mb) = do
 --------------------------------------------------------------------------------
 -- Change Handle
 
-changeHandle :: UserId -> ConnId -> Handle -> ExceptT ChangeHandleError AppIO ()
-changeHandle uid conn hdl = do
+changeHandle :: UserId -> Maybe ConnId -> Handle -> ExceptT ChangeHandleError AppIO ()
+changeHandle uid mconn hdl = do
   when (isBlacklistedHandle hdl) $
     throwE ChangeHandleInvalid
   usr <- lift $ Data.lookupUser uid
@@ -374,7 +374,7 @@ changeHandle uid conn hdl = do
       claimed <- lift $ claimHandle (userId u) (userHandle u) hdl
       unless claimed $
         throwE ChangeHandleExists
-      lift $ Intra.onUserEvent uid (Just conn) (handleUpdated uid hdl)
+      lift $ Intra.onUserEvent uid mconn (handleUpdated uid hdl)
 
 --------------------------------------------------------------------------------
 -- Check Handle

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -238,7 +238,7 @@ updateEmail u e = retry x5 $ write userEmailUpdate (params Quorum (e, u))
 updatePhone :: UserId -> Phone -> AppIO ()
 updatePhone u p = retry x5 $ write userPhoneUpdate (params Quorum (p, u))
 
-updateSSOId :: UserId -> UserSSOId -> AppIO Bool
+updateSSOId :: UserId -> Maybe UserSSOId -> AppIO Bool
 updateSSOId u ssoid = do
   mteamid <- lookupUserTeam u
   case mteamid of
@@ -549,7 +549,7 @@ userEmailUpdate = "UPDATE user SET email = ? WHERE id = ?"
 userPhoneUpdate :: PrepQuery W (Phone, UserId) ()
 userPhoneUpdate = "UPDATE user SET phone = ? WHERE id = ?"
 
-userSSOIdUpdate :: PrepQuery W (UserSSOId, UserId) ()
+userSSOIdUpdate :: PrepQuery W (Maybe UserSSOId, UserId) ()
 userSSOIdUpdate = "UPDATE user SET sso_id = ? WHERE id = ?"
 
 userManagedByUpdate :: PrepQuery W (ManagedBy, UserId) ()

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -283,7 +283,7 @@ deleteInvitationH (_ ::: uid ::: tid ::: iid) = do
 deleteInvitation :: UserId -> TeamId -> InvitationId -> Handler ()
 deleteInvitation uid tid iid = do
   ensurePermissions uid tid [Team.AddTeamMember]
-  lift $ DB.deleteInvitation tid iid
+  DB.deleteInvitation tid iid
 
 listInvitationsH :: JSON ::: UserId ::: TeamId ::: Maybe InvitationId ::: Range 1 500 Int32 -> Handler Response
 listInvitationsH (_ ::: uid ::: tid ::: start ::: size) = do

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -143,6 +143,7 @@ executables:
       - silently
       - spar
       - stm
+      - tasty-hunit
       - tinylog
       - wai
       - wai-extra

--- a/services/spar/schema/src/Main.hs
+++ b/services/spar/schema/src/Main.hs
@@ -24,6 +24,7 @@ import qualified System.Logger.Extended as Log
 import Util.Options
 import qualified V0
 import qualified V1
+import qualified V10
 import qualified V2
 import qualified V3
 import qualified V4
@@ -51,7 +52,8 @@ main = do
       V6.migration,
       V7.migration,
       V8.migration,
-      V9.migration
+      V9.migration,
+      V10.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Spar.Data
 

--- a/services/spar/schema/src/V10.hs
+++ b/services/spar/schema/src/V10.hs
@@ -1,0 +1,37 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V10
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 10 "Add table for mapping scim external ids to brig user ids" $ do
+  void $
+    schema'
+      [r|
+        CREATE TABLE if not exists scim_external_ids
+          ( external  text
+          , user      uuid
+          , primary key (external)
+          ) with compaction = {'class': 'LeveledCompactionStrategy'};
+      |]

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9e93f41b1db03ac57d3620035d67548eb7eb9fa62deaeb86a273357442e947c9
+-- hash: 88a250ccd05fb0ad0b42a8b133068a52e559f6b5e00efb0df3098445c92f2a45
 
 name:           spar
 version:        0.1
@@ -308,6 +308,7 @@ executable spar-schema
   other-modules:
       V0
       V1
+      V10
       V2
       V3
       V4

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c4215bccf7e235dad19c5eb68954faf664f92ff0b3d7aeacdfb6ac21b448503b
+-- hash: 9e93f41b1db03ac57d3620035d67548eb7eb9fa62deaeb86a273357442e947c9
 
 name:           spar
 version:        0.1
@@ -207,6 +207,7 @@ executable spar-integration
       Test.Spar.Scim.UserSpec
       Util
       Util.Core
+      Util.Email
       Util.Scim
       Util.Types
       Paths_spar
@@ -277,6 +278,7 @@ executable spar-integration
     , stm
     , string-conversions
     , swagger2
+    , tasty-hunit
     , text
     , text-latin1
     , time

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -192,7 +192,7 @@ createSamlUserWithId :: UserId -> SAML.UserRef -> ManagedBy -> Spar ()
 createSamlUserWithId buid suid managedBy = do
   teamid <- (^. idpExtraInfo . wiTeam) <$> getIdPConfigByIssuer (suid ^. uidTenant)
   uname <- either (throwSpar . SparBadUserName . cs) pure $ Intra.mkUserName Nothing (UrefOnly suid)
-  buid' <- Intra.createBrigUser (Just suid) buid teamid uname managedBy
+  buid' <- Intra.createBrigUser (UrefOnly suid) buid teamid uname managedBy
   assert (buid == buid') $ pure ()
   insertUser suid buid
 

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -246,8 +246,8 @@ validateEmailIfExists uid =
 -- 'UserRef' into the 'UserIdentity'.  Otherwise, throw an error.
 bindUser :: UserId -> SAML.UserRef -> Spar UserId
 bindUser buid userref = do
-  teamid <- (^. idpExtraInfo . wiTeam) <$> getIdPConfigByIssuer (userref ^. uidTenant)
   do
+    teamid <- (^. idpExtraInfo . wiTeam) <$> getIdPConfigByIssuer (userref ^. uidTenant)
     mteamid' <- Intra.getBrigUserTeam buid
     unless (mteamid' == Just teamid) $ do
       throwSpar . SparBindFromWrongOrNoTeam . cs . show $ buid

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -71,7 +71,6 @@ import qualified System.Logger as Log
 import System.Logger.Class (MonadLogger (log))
 import URI.ByteString as URI
 import Web.Cookie (SetCookie, renderSetCookie)
-import qualified Wire.API.User as User
 
 newtype Spar a = Spar {fromSpar :: ReaderT Env (ExceptT SparError IO) a}
   deriving (Functor, Applicative, Monad, MonadIO, MonadReader Env, MonadError SparError)
@@ -247,8 +246,8 @@ bindUser :: UserId -> SAML.UserRef -> Spar UserId
 bindUser buid userref = do
   teamid <- (^. idpExtraInfo . wiTeam) <$> getIdPConfigByIssuer (userref ^. uidTenant)
   do
-    muser <- Intra.getBrigUser buid
-    unless ((User.userTeam =<< muser) == Just teamid) $ do
+    mteamid' <- Intra.getBrigUserTeam buid
+    unless (mteamid' == Just teamid) $ do
       throwSpar . SparBindFromWrongOrNoTeam . cs . show $ buid
   insertUser userref buid
   buid <$ Intra.setBrigUserUserRef buid userref

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -250,7 +250,7 @@ bindUser buid userref = do
     unless (mteamid' == Just teamid) $ do
       throwSpar . SparBindFromWrongOrNoTeam . cs . show $ buid
   insertUser userref buid
-  buid <$ Intra.setBrigUserUserRef buid userref
+  buid <$ Intra.setBrigUserVeid buid (UrefOnly userref)
 
 instance SPHandler SparError Spar where
   type NTCTX Spar = Env
@@ -347,7 +347,7 @@ findUserWithOldIssuer (SAML.UserRef issuer subject) = do
 moveUserToNewIssuer :: SAML.UserRef -> SAML.UserRef -> UserId -> Spar ()
 moveUserToNewIssuer oldUserRef newUserRef uid = do
   wrapMonadClient $ Data.insertSAMLUser newUserRef uid
-  Intra.setBrigUserUserRef uid newUserRef
+  Intra.setBrigUserVeid uid (UrefOnly newUserRef)
   wrapMonadClient $ Data.deleteSAMLUser oldUserRef
 
 verdictHandlerResultCore :: HasCallStack => Maybe BindCookie -> SAML.AccessVerdict -> Spar VerdictHandlerResult

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -235,12 +235,9 @@ validateEmailIfExists uid uref = case (uref ^? veidEmail, uref ^? veidUref) of
     doValidate :: Bool -> SAML.Email -> Spar ()
     doValidate always email = do
       enabled <- do
-        if always
-          then pure True
-          else do
-            tid <- Intra.getBrigUserTeam uid
-            maybe (pure False) Intra.isEmailValidationEnabledTeam tid
-      case enabled of
+        tid <- Intra.getBrigUserTeam uid
+        maybe (pure False) Intra.isEmailValidationEnabledTeam tid
+      case enabled || always of
         True -> Intra.updateEmail uid (Intra.emailFromSAML email)
         False -> pure ()
 

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -75,13 +75,17 @@ module Spar.Data
     deleteScimToken,
     deleteTeamScimTokens,
 
-    -- * SCIM user timestampes
+    -- * SCIM externalids, user timestamps
     writeScimUserTimes,
     readScimUserTimes,
     deleteScimUserTimes,
+    insertScimExternalId,
+    lookupScimExternalId,
+    deleteScimExternalId,
   )
 where
 
+import Brig.Types.Common (Email, fromEmail)
 import Cassandra as Cas
 import Control.Lens
 import Control.Monad.Except
@@ -105,7 +109,7 @@ import Web.Scim.Schema.Meta (Meta (..), WithMeta (..))
 
 -- | A lower bound: @schemaVersion <= whatWeFoundOnCassandra@, not @==@.
 schemaVersion :: Int32
-schemaVersion = 9
+schemaVersion = 10
 
 ----------------------------------------------------------------------
 -- helpers
@@ -735,3 +739,28 @@ deleteScimUserTimes uid = retry x5 . write del $ params Quorum (Identity uid)
   where
     del :: PrepQuery W (Identity UserId) ()
     del = "DELETE FROM scim_user_times WHERE uid = ?"
+
+-- | If a scim externalId does not have an associated saml idp issuer, it cannot be stored in
+-- table @spar.user@.  In those cases, and only in those cases, we store the mapping to
+-- 'UserId' here.  (Note that since there is no associated IdP, the externalId is required to
+-- be an email address, so we enforce that in the type signature, even though we only use it
+-- as a 'Text'.)
+insertScimExternalId :: (HasCallStack, MonadClient m) => Email -> UserId -> m ()
+insertScimExternalId (fromEmail -> email) uid = retry x5 . write ins $ params Quorum (email, uid)
+  where
+    ins :: PrepQuery W (Text, UserId) ()
+    ins = "INSERT INTO scim_external_ids (external, user) VALUES (?, ?)"
+
+-- | The inverse of 'insertScimExternalId'.
+lookupScimExternalId :: (HasCallStack, MonadClient m) => Email -> m (Maybe UserId)
+lookupScimExternalId (fromEmail -> email) = runIdentity <$$> (retry x1 . query1 sel $ params Quorum (Identity email))
+  where
+    sel :: PrepQuery R (Identity Text) (Identity UserId)
+    sel = "SELECT user FROM scim_external_ids WHERE external = ?"
+
+-- | The other inverse of 'insertScimExternalId' :).
+deleteScimExternalId :: (HasCallStack, MonadClient m) => Email -> m ()
+deleteScimExternalId (fromEmail -> email) = retry x5 . write del $ params Quorum (Identity email)
+  where
+    del :: PrepQuery W (Identity Text) ()
+    del = "DELETE FROM scim_external_ids WHERE external = ?"

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -32,6 +32,7 @@ module Spar.Error
     renderSparErrorWithLogging,
     -- FUTUREWORK: we really shouldn't export this, but that requires that we can use our
     -- custom servant monad in the 'MakeCustomError' instances.
+    servantToWaiError,
     sparToServerError,
     renderSparError,
     waiToServant,
@@ -94,7 +95,7 @@ data SparCustomError
   | SparNewIdPWantHttps LT
   | SparIdPHasBoundUsers
   | SparIdPIssuerInUse
-  | SparProvisioningNoSingleIdP LT
+  | SparProvisioningMoreThanOneIdP LT
   | SparProvisioningTokenLimitReached
   | -- | All errors returned from SCIM handlers are wrapped into 'SparScimError'
     SparScimError Scim.ScimError
@@ -179,7 +180,7 @@ renderSparError (SAML.CustomError (SparNewIdPWantHttps msg)) = Right $ Wai.Error
 renderSparError (SAML.CustomError SparIdPHasBoundUsers) = Right $ Wai.Error status412 "idp-has-bound-users" "an idp can only be deleted if it is empty"
 renderSparError (SAML.CustomError SparIdPIssuerInUse) = Right $ Wai.Error status400 "idp-issuer-in-use" "The issuer of your IdP is already in use.  Remove the entry in the team that uses it, or construct a new IdP issuer."
 -- Errors related to provisioning
-renderSparError (SAML.CustomError (SparProvisioningNoSingleIdP msg)) = Right $ Wai.Error status400 "no-single-idp" ("Team should have exactly one IdP configured: " <> msg)
+renderSparError (SAML.CustomError (SparProvisioningMoreThanOneIdP msg)) = Right $ Wai.Error status400 "more-than-one-idp" ("Team can have at most one IdP configured: " <> msg)
 renderSparError (SAML.CustomError SparProvisioningTokenLimitReached) = Right $ Wai.Error status403 "token-limit-reached" "The limit of provisioning tokens per team has been reached"
 -- SCIM errors
 renderSparError (SAML.CustomError (SparScimError err)) = Left $ Scim.scimToServerError err

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -290,7 +290,11 @@ getBrigUserByEmail email = do
         . path "/i/users"
         . queryItem "email" (toByteString' email)
   case statusCode resp of
-    200 -> listToMaybe <$> parseResponse @[UserAccount] resp
+    200 -> do
+      macc <- listToMaybe <$> parseResponse @[UserAccount] resp
+      case userEmail . accountUser =<< macc of
+        Just email' | email' == email -> pure macc
+        _ -> pure Nothing
     404 -> pure Nothing
     _ -> rethrow resp
 

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -21,17 +21,23 @@
 module Spar.Intra.Brig
   ( toUserSSOId,
     fromUserSSOId,
-    toExternalId,
+    urefToExternalId,
+    userToScimExternalId,
     mkUserName,
+    renderValidExternalId,
+    emailFromSAML,
+    emailToSAML,
     getBrigUser,
     getBrigUserTeam,
     getBrigUsers,
     getBrigUserByHandle,
+    getBrigUserByEmail,
     getBrigUserRichInfo,
     setBrigUserName,
     setBrigUserHandle,
     setBrigUserManagedBy,
     setBrigUserUserRef,
+    deleteBrigUserUserRef,
     setBrigUserRichInfo,
     checkHandleAvailable,
     deleteBrigUser,
@@ -42,8 +48,8 @@ module Spar.Intra.Brig
     ssoLogin,
     parseResponse,
     MonadSparToBrig (..),
-    isEmailValidationEnabledUser,
     getStatus,
+    getStatusMaybe,
     setStatus,
     giveDefaultHandle,
   )
@@ -53,6 +59,7 @@ where
 -- master data (first name, last name, ...)
 
 import Bilge
+import qualified Brig.Types.Common
 import Brig.Types.Intra
 import Brig.Types.User
 import Brig.Types.User.Auth (SsoLogin (..))
@@ -65,12 +72,15 @@ import Data.Id (Id (Id), TeamId, UserId)
 import Data.Ix
 import Data.Misc (PlainTextPassword)
 import Data.String.Conversions
+import Data.String.Conversions (cs)
 import Imports
 import Network.HTTP.Types.Method
+import qualified Network.Wai.Utilities.Error as Wai
 import qualified SAML2.WebSSO as SAML
-import qualified Servant.Server as Servant
 import Spar.Error
-import Spar.Intra.Galley as Galley (MonadSparToGalley, assertIsTeamOwner, isEmailValidationEnabledTeam)
+import Spar.Intra.Galley as Galley (MonadSparToGalley, assertIsTeamOwner)
+import Spar.Scim.Types (ValidExternalId (..), runValidExternalId)
+import qualified Text.Email.Parser
 import Web.Cookie
 import Wire.API.User
 import Wire.API.User.RichInfo as RichInfo
@@ -88,19 +98,29 @@ fromUserSSOId (UserSSOId (cs -> tenant) (cs -> subject)) =
     (Left msg, _) -> throwError msg
     (_, Left msg) -> throwError msg
 
--- | Converts a brig User SSO Id into an external id
-toExternalId :: MonadError SparError m => UserSSOId -> m Text
-toExternalId ssoid = do
-  uref <- either (throwSpar . SparCouldNotParseBrigResponse . cs) pure $ fromUserSSOId ssoid
-  let subj = uref ^. SAML.uidSubject
-  pure $ SAML.nameIDToST subj
+urefToExternalId :: SAML.UserRef -> Maybe Text
+urefToExternalId = SAML.shortShowNameID . view SAML.uidSubject
+
+userToScimExternalId :: User -> Either String Text
+userToScimExternalId usr = case (userIdentity >=> ssoIdentity $ usr, userEmail usr) of
+  (Just ssoid, _) -> case fromUserSSOId ssoid of
+    Right (SAML.UserRef _ subj) -> maybe (Left "bad uref from brig") Right $ SAML.shortShowNameID subj
+    Left err -> Left err
+  (Nothing, Just email) -> Right $ fromEmail email
+  (Nothing, Nothing) -> Left "brig user without external id"
 
 -- | Take a maybe text, construct a 'Name' from what we have in a scim user.  If the text
--- isn't present, use the saml subject (usually an email address).  If both are 'Nothing',
--- fail.
-mkUserName :: Maybe Text -> SAML.UserRef -> Either String Name
-mkUserName (Just n) _ = mkName n
-mkUserName Nothing uref = mkName (SAML.unsafeShowNameID $ uref ^. SAML.uidSubject)
+-- isn't present, use an email address or a saml subject (usually also an email address).  If
+-- both are 'Nothing', fail.
+mkUserName :: Maybe Text -> ValidExternalId -> Either String Name
+mkUserName (Just n) = const $ mkName n
+mkUserName Nothing =
+  runValidExternalId
+    (\uref -> mkName (SAML.unsafeShowNameID $ uref ^. SAML.uidSubject))
+    (\email -> mkName (fromEmail email))
+
+renderValidExternalId :: ValidExternalId -> Maybe Text
+renderValidExternalId = runValidExternalId urefToExternalId (Just . fromEmail)
 
 parseResponse :: (FromJSON a, MonadError SparError m) => Response (Maybe LBS) -> m a
 parseResponse resp = do
@@ -118,6 +138,19 @@ respToCookie resp = do
   unless (statusCode resp == 200) crash
   maybe crash (pure . parseSetCookie) $ getHeader "Set-Cookie" resp
 
+emailFromSAML :: HasCallStack => SAML.Email -> Brig.Types.Common.Email
+emailFromSAML =
+  fromJust . Brig.Types.Common.parseEmail . cs
+    . Text.Email.Parser.toByteString
+    . SAML.fromEmail
+
+emailToSAML :: HasCallStack => Brig.Types.Common.Email -> SAML.Email
+emailToSAML brigEmail =
+  SAML.Email $
+    Text.Email.Parser.unsafeEmailAddress
+      (cs $ Brig.Types.Common.emailLocal brigEmail)
+      (cs $ Brig.Types.Common.emailDomain brigEmail)
+
 ----------------------------------------------------------------------
 
 class MonadError SparError m => MonadSparToBrig m where
@@ -130,7 +163,7 @@ instance MonadSparToBrig m => MonadSparToBrig (ReaderT r m) where
 createBrigUser ::
   (HasCallStack, MonadSparToBrig m) =>
   -- | SSO identity
-  SAML.UserRef ->
+  Maybe SAML.UserRef ->
   UserId ->
   TeamId ->
   -- | User name
@@ -138,12 +171,12 @@ createBrigUser ::
   -- | Who should have control over the user
   ManagedBy ->
   m UserId
-createBrigUser suid (Id buid) teamid uname managedBy = do
+createBrigUser mUref (Id buid) teamid uname managedBy = do
   let newUser :: NewUser
       newUser =
         (emptyNewUser uname)
           { newUserUUID = Just buid,
-            newUserIdentity = Just $ SSOIdentity (toUserSSOId suid) Nothing Nothing,
+            newUserIdentity = maybe Nothing (\uref -> Just $ SSOIdentity (toUserSSOId uref) Nothing Nothing) mUref,
             newUserOrigin = Just . NewUserOriginTeamUser . NewTeamMemberSSO $ teamid,
             newUserManagedBy = Just managedBy
           }
@@ -152,14 +185,9 @@ createBrigUser suid (Id buid) teamid uname managedBy = do
       method POST
         . path "/i/users"
         . json newUser
-  let sCode = statusCode resp
-  if
-      | sCode < 300 ->
-        userId . selfUser <$> parseResponse @SelfProfile resp
-      | inRange (400, 499) sCode ->
-        throwSpar . SparBrigErrorWith (responseStatus resp) $ "create user failed"
-      | otherwise ->
-        throwSpar . SparBrigError . cs $ "create user failed with status " <> show sCode
+  if statusCode resp `elem` [200, 201]
+    then userId . selfUser <$> parseResponse @SelfProfile resp
+    else rethrow resp
 
 updateEmail :: (HasCallStack, MonadSparToBrig m) => UserId -> Email -> m ()
 updateEmail buid email = do
@@ -221,25 +249,33 @@ getBrigUserByHandle handle = do
   where
     parse :: [UserAccount] -> Maybe User
     parse (x : []) = Just $ accountUser x
-    parse _ = Nothing -- TODO: What if more accounts get returned?
+    parse _ = Nothing -- more than one account is impossible, since the handle is unique.
+
+getBrigUserByEmail :: (HasCallStack, MonadSparToBrig m) => Email -> m (Maybe User)
+getBrigUserByEmail email = do
+  resp :: ResponseLBS <-
+    call $
+      method GET
+        . path "/i/users"
+        . queryItem "email" (toByteString' email)
+  case statusCode resp of
+    200 -> parse <$> parseResponse @[UserAccount] resp
+    404 -> pure Nothing
+    _ -> throwSpar (SparBrigError "Could not retrieve user")
+  where
+    parse :: [UserAccount] -> Maybe User
+    parse (x : []) = Just $ accountUser x
+    parse _ = Nothing
 
 -- | Set user' name.  Fails with status <500 if brig fails with <500, and with 500 if brig
 -- fails with >= 500.
 setBrigUserName :: (HasCallStack, MonadSparToBrig m) => UserId -> Name -> m ()
-setBrigUserName buid name = do
+setBrigUserName buid (Name name) = do
   resp <-
     call $
       method PUT
-        . path "/self"
-        . header "Z-User" (toByteString' buid)
-        . header "Z-Connection" ""
-        . json
-          UserUpdate
-            { uupName = Just name,
-              uupPict = Nothing,
-              uupAssets = Nothing,
-              uupAccentId = Nothing
-            }
+        . paths ["/i/users", toByteString' buid, "name"]
+        . json (NameUpdate name)
   let sCode = statusCode resp
   if
       | sCode < 300 ->
@@ -251,23 +287,22 @@ setBrigUserName buid name = do
 
 -- | Set user's handle.  Fails with status <500 if brig fails with <500, and with 500 if brig fails
 -- with >= 500.
-setBrigUserHandle :: (HasCallStack, MonadSparToBrig m) => UserId -> Handle -> m ()
+--
+-- NB: that this doesn't take a 'HandleUpdate', since we already construct a valid handle in
+-- 'validateScimUser' to increase the odds that user creation doesn't fail half-way through
+-- the many database write operations.
+setBrigUserHandle :: (HasCallStack, MonadSparToBrig m) => UserId -> Handle {- not 'HandleUpdate'! -} -> m ()
 setBrigUserHandle buid handle = do
   resp <-
     call $
       method PUT
-        . path "/self/handle"
-        . header "Z-User" (toByteString' buid)
-        . header "Z-Connection" ""
+        . paths ["/i/users", toByteString' buid, "handle"]
         . json (HandleUpdate (fromHandle handle))
-  let sCode = statusCode resp
-  if
-      | sCode < 300 ->
-        pure ()
-      | inRange (400, 499) sCode ->
-        throwSpar . SparBrigErrorWith (responseStatus resp) $ "set handle failed"
-      | otherwise ->
-        throwSpar . SparBrigError . cs $ "set handle failed with status " <> show sCode
+  case (statusCode resp, Wai.label <$> responseJsonMaybe @Wai.Error resp) of
+    (200, Nothing) -> do
+      pure ()
+    _ -> do
+      rethrow resp
 
 -- | Set user's managedBy. Fails with status <500 if brig fails with <500, and with 500 if
 -- brig fails with >= 500.
@@ -276,7 +311,7 @@ setBrigUserManagedBy buid managedBy = do
   resp <-
     call $
       method PUT
-        . paths ["i", "users", toByteString' buid, "managed-by"]
+        . paths ["/i/users", toByteString' buid, "managed-by"]
         . json (ManagedByUpdate managedBy)
   let sCode = statusCode resp
   if
@@ -295,14 +330,23 @@ setBrigUserUserRef buid uref = do
       method PUT
         . paths ["i", "users", toByteString' buid, "sso-id"]
         . json (toUserSSOId uref)
-  let sCode = statusCode resp
-  if
-      | sCode < 300 ->
-        pure ()
-      | inRange (400, 499) sCode ->
-        throwSpar . SparBrigErrorWith (responseStatus resp) $ "set UserSSOId failed"
-      | otherwise ->
-        throwSpar . SparBrigError . cs $ "set UserSSOId failed with status " <> show sCode
+  case statusCode resp of
+    200 -> do
+      pure ()
+    _ -> do
+      rethrow resp
+
+deleteBrigUserUserRef :: (HasCallStack, MonadSparToBrig m) => UserId -> m ()
+deleteBrigUserUserRef buid = do
+  resp <-
+    call $
+      method DELETE
+        . paths ["i", "users", toByteString' buid, "sso-id"]
+  case statusCode resp of
+    200 -> do
+      pure ()
+    _ -> do
+      rethrow resp
 
 -- | Set user's richInfo. Fails with status <500 if brig fails with <500, and with 500 if
 -- brig fails with >= 500.
@@ -322,30 +366,23 @@ setBrigUserRichInfo buid richInfo = do
       | otherwise ->
         throwSpar . SparBrigError . cs $ "set richInfo failed with status " <> show sCode
 
--- TODO: We should add an internal endpoint for this instead
 getBrigUserRichInfo :: (HasCallStack, MonadSparToBrig m) => UserId -> m RichInfo
 getBrigUserRichInfo buid =
   RichInfo.RichInfo <$> do
     resp <-
       call $
         method GET
-          . paths ["users", toByteString' buid, "rich-info"]
-          . header "Z-User" (toByteString' buid)
-          . header "Z-Connection" ""
+          . paths ["/i/users", toByteString' buid, "rich-info"]
     case statusCode resp of
       200 -> parseResponse resp
       _ -> throwSpar (SparBrigErrorWith (responseStatus resp) "Could not retrieve rich info")
 
--- | At the time of writing this, @HEAD /users/handles/:uid@ does not use the 'UserId' for
--- anything but authorization.
-checkHandleAvailable :: (HasCallStack, MonadSparToBrig m) => Handle -> UserId -> m Bool
-checkHandleAvailable hnd buid = do
+checkHandleAvailable :: (HasCallStack, MonadSparToBrig m) => Handle -> m Bool
+checkHandleAvailable hnd = do
   resp <-
     call $
       method HEAD
-        . paths ["users", "handles", toByteString' hnd]
-        . header "Z-User" (toByteString' buid)
-        . header "Z-Connection" ""
+        . paths ["/i/users/handles", toByteString' hnd]
   let sCode = statusCode resp
   if
       | sCode == 200 -> -- handle exists
@@ -439,24 +476,23 @@ ssoLogin buid = do
       | otherwise ->
         throwSpar . SparBrigError . cs $ "sso-login failed with status " <> show sCode
 
--- | This is more of a brig thing, but we need to get the team for the user first, so it goes
--- here.  Perhaps we should merge "Spar.Intra.*" into "Spar.Intra"?
-isEmailValidationEnabledUser :: (HasCallStack, MonadSparToGalley m, MonadSparToBrig m) => UserId -> m Bool
-isEmailValidationEnabledUser uid = do
-  user <- getBrigUser uid
-  case user >>= userTeam of
-    Nothing -> pure False
-    Just tid -> isEmailValidationEnabledTeam tid
+getStatus' :: (HasCallStack, MonadSparToBrig m) => UserId -> m ResponseLBS
+getStatus' uid = call $ method GET . paths ["/i/users", toByteString' uid, "status"]
 
 getStatus :: (HasCallStack, MonadSparToBrig m) => UserId -> m AccountStatus
 getStatus uid = do
-  resp <-
-    call $
-      method GET
-        . paths ["/i/users", toByteString' uid, "status"]
+  resp <- getStatus' uid
   case statusCode resp of
-    200 -> (\(AccountStatusResp status) -> status) <$> parseResponse @AccountStatusResp resp
-    _ -> throwSpar (SparBrigErrorWith (responseStatus resp) "Could not retrieve account status")
+    200 -> fromAccountStatusResp <$> parseResponse @AccountStatusResp resp
+    _ -> rethrow resp
+
+getStatusMaybe :: (HasCallStack, MonadSparToBrig m) => UserId -> m (Maybe AccountStatus)
+getStatusMaybe uid = do
+  resp <- getStatus' uid
+  case statusCode resp of
+    200 -> Just . fromAccountStatusResp <$> parseResponse @AccountStatusResp resp
+    404 -> pure Nothing
+    _ -> rethrow resp
 
 setStatus :: (HasCallStack, MonadSparToBrig m) => UserId -> AccountStatus -> m ()
 setStatus uid status = do
@@ -487,27 +523,21 @@ giveDefaultHandle :: (HasCallStack, MonadSparToBrig m) => User -> m Handle
 giveDefaultHandle usr = case userHandle usr of
   Just handle -> pure handle
   Nothing -> do
-    let handle :: Handle = Handle . cs . toByteString' . userId $ usr
-    resp :: Response (Maybe LBS) <-
-      call $
-        method PUT
-          . path "/self/handle"
-          . header "Z-User" (toByteString' . userId $ usr)
-          . header "Z-Connection" ""
-          . (json . HandleUpdate . fromHandle $ handle)
-    if statusCode resp == 200
-      then pure handle
-      else rethrow resp
+    let handle = Handle . cs . toByteString' $ uid
+        uid = userId usr
+    setBrigUserHandle uid handle
+    pure handle
 
 -- | If a call to brig fails, we often just want to respond with whatever brig said.
 --
 -- FUTUREWORK: with servant, there will be a way for the type checker to confirm that we
 -- handle all exceptions that brig can legally throw!
 rethrow :: ResponseLBS -> (HasCallStack, MonadSparToBrig m) => m a
-rethrow resp = throwError $ SAML.CustomServant (withDefault mServantErr)
+rethrow resp = throwError err
   where
-    withDefault :: Maybe Servant.ServerError -> Servant.ServerError
-    withDefault = fromMaybe (Servant.ServerError 500 "unexpected brig response" mempty mempty)
-    --
-    mServantErr :: Maybe Servant.ServerError
-    mServantErr = waiToServant <$> responseJsonMaybe resp
+    err :: SparError
+    err =
+      responseJsonMaybe resp
+        & maybe
+          (SAML.CustomError . SparBrigError . cs . fromMaybe "" . responseBody $ resp)
+          (SAML.CustomServant . waiToServant)

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -60,16 +60,12 @@ module Spar.Intra.Brig
   )
 where
 
--- TODO: when creating user, we need to be able to provide more
--- master data (first name, last name, ...)
-
 import Bilge
 import Brig.Types.Intra
 import Brig.Types.User
 import Brig.Types.User.Auth (SsoLogin (..))
 import Control.Lens
 import Control.Monad.Except
-import Data.Aeson (FromJSON, eitherDecode')
 import Data.ByteString.Conversion
 import Data.Handle (Handle (Handle, fromHandle))
 import Data.Id (Id (Id), TeamId, UserId)
@@ -82,6 +78,7 @@ import Network.HTTP.Types.Method
 import qualified Network.Wai.Utilities.Error as Wai
 import qualified SAML2.WebSSO as SAML
 import Spar.Error
+import Spar.Intra.Galley (parseResponse)
 import Spar.Intra.Galley as Galley (MonadSparToGalley, assertIsTeamOwner)
 import Spar.Scim.Types (ValidExternalId (..), runValidExternalId)
 import qualified Text.Email.Parser
@@ -164,11 +161,6 @@ mkUserName Nothing =
 
 renderValidExternalId :: ValidExternalId -> Maybe Text
 renderValidExternalId = runValidExternalId urefToExternalId (Just . fromEmail)
-
-parseResponse :: (FromJSON a, MonadError SparError m) => Response (Maybe LBS) -> m a
-parseResponse resp = do
-  bdy <- maybe (throwSpar SparNoBodyInBrigResponse) pure $ responseBody resp
-  either (throwSpar . SparCouldNotParseBrigResponse . cs) pure $ eitherDecode' bdy
 
 -- | Similar to 'Network.Wire.Client.API.Auth.tokenResponse', but easier: we just need to set the
 -- cookie in the response, and the redirect will make the client negotiate a fresh auth token.

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -131,6 +131,10 @@ userToExternalId usr =
 -- total function as long as brig obeys the api).  Otherwise, if the user has an email, we can
 -- construct a return value from that (and an optional saml issuer).  If a user only has a
 -- phone number, or no identity at all, throw an error.
+--
+-- Note: the saml issuer is only needed in the case where a user has been invited via team
+-- settings and is now onboarded to saml/scim.  If this case can safely be ruled out, it's ok
+-- to just set it to 'Nothing'.
 veidFromBrigUser :: MonadError String m => User -> Maybe SAML.Issuer -> m ValidExternalId
 veidFromBrigUser usr mIssuer = case (userSSOId usr, userEmail usr, mIssuer) of
   (Just ssoid, _, _) -> veidFromUserSSOId ssoid

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -41,8 +41,7 @@ module Spar.Intra.Brig
     setBrigUserName,
     setBrigUserHandle,
     setBrigUserManagedBy,
-    setBrigUserUserRef,
-    deleteBrigUserUserRef,
+    setBrigUserVeid,
     setBrigUserRichInfo,
     checkHandleAvailable,
     deleteBrigUser,
@@ -351,30 +350,16 @@ setBrigUserManagedBy buid managedBy = do
         throwSpar . SparBrigError . cs $ "set managedBy failed with status " <> show sCode
 
 -- | Set user's UserSSOId.
-setBrigUserUserRef :: (HasCallStack, MonadSparToBrig m) => UserId -> SAML.UserRef -> m ()
-setBrigUserUserRef buid uref = do
+setBrigUserVeid :: (HasCallStack, MonadSparToBrig m) => UserId -> ValidExternalId -> m ()
+setBrigUserVeid buid veid = do
   resp <-
     call $
       method PUT
         . paths ["i", "users", toByteString' buid, "sso-id"]
-        . json (toUserSSOId uref)
+        . json (veidToUserSSOId veid)
   case statusCode resp of
-    200 -> do
-      pure ()
-    _ -> do
-      rethrow resp
-
-deleteBrigUserUserRef :: (HasCallStack, MonadSparToBrig m) => UserId -> m ()
-deleteBrigUserUserRef buid = do
-  resp <-
-    call $
-      method DELETE
-        . paths ["i", "users", toByteString' buid, "sso-id"]
-  case statusCode resp of
-    200 -> do
-      pure ()
-    _ -> do
-      rethrow resp
+    200 -> pure ()
+    _ -> rethrow resp
 
 -- | Set user's richInfo. Fails with status <500 if brig fails with <500, and with 500 if
 -- brig fails with >= 500.

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -30,6 +30,7 @@ module Spar.Intra.Brig
     emailFromSAML,
     emailToSAML,
     emailToSAMLNameID,
+    emailFromSAMLNameID,
     getBrigUser,
     getBrigUserAccount,
     getBrigUserTeam,
@@ -183,6 +184,11 @@ emailToSAML brigEmail =
 -- function total without all that praying and hoping.
 emailToSAMLNameID :: HasCallStack => Email -> SAML.NameID
 emailToSAMLNameID = fromRight (error "impossible") . SAML.emailNameID . fromEmail
+
+emailFromSAMLNameID :: HasCallStack => SAML.NameID -> Maybe Email
+emailFromSAMLNameID nid = case nid ^. SAML.nameID of
+  SAML.UNameIDEmail email -> Just $ emailFromSAML email
+  _ -> Nothing
 
 ----------------------------------------------------------------------
 

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -395,15 +395,14 @@ setBrigUserRichInfo buid richInfo = do
         throwSpar . SparBrigError . cs $ "set richInfo failed with status " <> show sCode
 
 getBrigUserRichInfo :: (HasCallStack, MonadSparToBrig m) => UserId -> m RichInfo
-getBrigUserRichInfo buid =
-  RichInfo.RichInfo <$> do
-    resp <-
-      call $
-        method GET
-          . paths ["/i/users", toByteString' buid, "rich-info"]
-    case statusCode resp of
-      200 -> parseResponse resp
-      _ -> rethrow resp
+getBrigUserRichInfo buid = do
+  resp <-
+    call $
+      method GET
+        . paths ["/i/users", toByteString' buid, "rich-info"]
+  case statusCode resp of
+    200 -> parseResponse resp
+    _ -> rethrow resp
 
 checkHandleAvailable :: (HasCallStack, MonadSparToBrig m) => Handle -> m Bool
 checkHandleAvailable hnd = do

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -104,36 +104,33 @@ createScimToken zusr CreateScimToken {..} = do
   unless (tokenNumber < maxTokens) $
     E.throwSpar E.SparProvisioningTokenLimitReached
   idps <- wrapMonadClient $ Data.getIdPConfigsByTeam teamid
+
+  let caseOneOrNoIdP :: Maybe SAML.IdPId -> Spar CreateScimTokenResponse
+      caseOneOrNoIdP midpid = do
+        token <- ScimToken . cs . ES.encode <$> liftIO (randBytes 32)
+        tokenid <- randomId
+        now <- liftIO getCurrentTime
+        let info =
+              ScimTokenInfo
+                { stiId = tokenid,
+                  stiTeam = teamid,
+                  stiCreatedAt = now,
+                  stiIdP = midpid,
+                  stiDescr = descr
+                }
+        wrapMonadClient $ Data.insertScimToken token info
+        pure $ CreateScimTokenResponse token info
+
   case idps of
-    [idp] -> do
-      -- TODO: sign tokens. Also, we might want to use zauth, if we can / if
-      -- it makes sense semantically
-      token <- ScimToken . cs . ES.encode <$> liftIO (randBytes 32)
-      tokenid <- randomId
-      now <- liftIO getCurrentTime
-      let idpid = idp ^. SAML.idpId
-          info =
-            ScimTokenInfo
-              { stiId = tokenid,
-                stiTeam = teamid,
-                stiCreatedAt = now,
-                stiIdP = Just idpid,
-                stiDescr = descr
-              }
-      wrapMonadClient $ Data.insertScimToken token info
-      pure $ CreateScimTokenResponse token info
-    -- NB: if the two following cases do not result in errors, 'validateScimUser' needs to
-    -- be changed.  currently, it relies on the fact that there is always an IdP.
-    [] ->
-      E.throwSpar $
-        E.SparProvisioningNoSingleIdP
-          "SCIM tokens can only be created for a team with an IdP, \
-          \but none are found"
+    [idp] -> caseOneOrNoIdP . Just $ idp ^. SAML.idpId
+    [] -> caseOneOrNoIdP Nothing
+    -- NB: if the following case does not result in errors, 'validateScimUser' needs to
+    -- be changed.  currently, it relies on the fact that there is never more than one IdP.
+    -- https://github.com/zinfra/backend-issues/issues/1377
     _ ->
       E.throwSpar $
-        E.SparProvisioningNoSingleIdP
-          "SCIM tokens can only be created for a team with exactly one IdP, \
-          \but more are found"
+        E.SparProvisioningMoreThanOneIdP
+          "SCIM tokens can only be created for a team with at most one IdP"
 
 -- | > docs/reference/provisioning/scim-token.md {#RefScimTokenDelete}
 --

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -71,7 +71,6 @@ import qualified Web.Scim.Schema.PatchOp as Scim
 import Web.Scim.Schema.Schema (Schema (CustomSchema))
 import qualified Web.Scim.Schema.Schema as Scim
 import qualified Web.Scim.Schema.User as Scim.User
-import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import qualified Wire.API.User.RichInfo as RI
 
 ----------------------------------------------------------------------------
@@ -214,7 +213,6 @@ data ValidExternalId
   | UrefOnly SAML.UserRef
   | EmailOnly Email
   deriving (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ValidExternalId)
 
 -- | Take apart a 'ValidExternalId', using 'SAML.UserRef' if available, otehrwise 'Email'.
 runValidExternalId :: (SAML.UserRef -> a) -> (Email -> a) -> ValidExternalId -> a

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -53,6 +54,7 @@ import qualified Data.Map as Map
 import Data.Misc (PlainTextPassword)
 import Imports
 import qualified SAML2.WebSSO as SAML
+import SAML2.WebSSO.Test.Arbitrary ()
 import Servant (DeleteNoContent, Get, Header, JSON, NoContent, Post, QueryParam', ReqBody, Required, Strict, (:<|>), (:>))
 import Servant.API.Generic (ToServantApi, (:-))
 import Spar.API.Util (OmitDocs)
@@ -69,6 +71,7 @@ import qualified Web.Scim.Schema.PatchOp as Scim
 import Web.Scim.Schema.Schema (Schema (CustomSchema))
 import qualified Web.Scim.Schema.Schema as Scim
 import qualified Web.Scim.Schema.User as Scim.User
+import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import qualified Wire.API.User.RichInfo as RI
 
 ----------------------------------------------------------------------------
@@ -210,7 +213,8 @@ data ValidExternalId
   = EmailAndUref Email SAML.UserRef
   | UrefOnly SAML.UserRef
   | EmailOnly Email
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform ValidExternalId)
 
 -- | Take apart a 'ValidExternalId', using 'SAML.UserRef' if available, otehrwise 'Email'.
 runValidExternalId :: (SAML.UserRef -> a) -> (Email -> a) -> ValidExternalId -> a

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -40,9 +40,10 @@
 -- * Request and response types for SCIM-related endpoints.
 module Spar.Scim.Types where
 
+import Brig.Types.Common (Email)
 import Brig.Types.Intra (AccountStatus (Active, Deleted, Ephemeral, Suspended))
 import qualified Brig.Types.User as BT
-import Control.Lens (makeLenses)
+import Control.Lens (Prism', makeLenses, prism')
 import Control.Monad.Except (throwError)
 import qualified Data.Aeson as Aeson
 import qualified Data.CaseInsensitive as CI
@@ -196,11 +197,8 @@ instance Scim.Patchable ScimUserExtra where
 -- [here](https://tools.ietf.org/html/rfc7644#section-3.3): "Since the server is free to alter
 -- and/or ignore POSTed content, returning the full representation can be useful to the
 -- client, enabling it to correlate the client's and server's views of the new resource."
---
--- FUTUREWORK: make '_vsuUserRef' a 'Maybe' and allow for SCIM users without a SAML SSO
--- identity.
 data ValidScimUser = ValidScimUser
-  { _vsuUserRef :: SAML.UserRef,
+  { _vsuExternalId :: ValidExternalId,
     _vsuHandle :: Handle,
     _vsuName :: BT.Name,
     _vsuRichInfo :: RI.RichInfo,
@@ -208,7 +206,35 @@ data ValidScimUser = ValidScimUser
   }
   deriving (Eq, Show)
 
+data ValidExternalId
+  = EmailAndUref Email SAML.UserRef
+  | UrefOnly SAML.UserRef
+  | EmailOnly Email
+  deriving (Eq, Show)
+
+-- | Take apart a 'ValidExternalId', using 'SAML.UserRef' if available, otehrwise 'Email'.
+runValidExternalId :: (SAML.UserRef -> a) -> (Email -> a) -> ValidExternalId -> a
+runValidExternalId doUref doEmail = \case
+  EmailAndUref _ uref -> doUref uref
+  UrefOnly uref -> doUref uref
+  EmailOnly email -> doEmail email
+
+veidUref :: Prism' ValidExternalId SAML.UserRef
+veidUref = prism' UrefOnly $
+  \case
+    EmailAndUref _ uref -> Just uref
+    UrefOnly uref -> Just uref
+    EmailOnly _ -> Nothing
+
+veidEmail :: Prism' ValidExternalId Email
+veidEmail = prism' EmailOnly $
+  \case
+    EmailAndUref email _ -> Just email
+    UrefOnly _ -> Nothing
+    EmailOnly email -> Just email
+
 makeLenses ''ValidScimUser
+makeLenses ''ValidExternalId
 
 scimActiveFlagFromAccountStatus :: AccountStatus -> Bool
 scimActiveFlagFromAccountStatus = \case

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -411,6 +411,8 @@ updateVsuUref uid old new = do
 
   Brig.setBrigUserVeid uid new
 
+-- TODO: how do we claim emails before writing them?
+
 toScimStoredUser ::
   UserId ->
   Scim.User ST.SparTag ->
@@ -530,7 +532,7 @@ calculateVersion uid usr = Scim.Weak (Text.pack (show h))
 --
 -- ASSUMPTION: every scim user has a 'SAML.UserRef', and the `SAML.NameID` in it corresponds
 -- to a single `externalId`.
-assertUserRefUnused :: SAML.UserRef -> Scim.ScimHandler Spar ()
+assertUserRefUnused :: SAML.UserRef -> Scim.ScimHandler Spar () -- we could take a veid here and check that scim_external_ids doesn't have an entry either.  very race-conditionie!
 assertUserRefUnused userRef = do
   mExistingUserId <- lift $ getUser userRef
   unless (isNothing mExistingUserId) $

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -411,8 +411,6 @@ updateVsuUref uid old new = do
 
   Brig.setBrigUserVeid uid new
 
--- TODO: how do we claim emails before writing them?
-
 toScimStoredUser ::
   UserId ->
   Scim.User ST.SparTag ->

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -215,6 +215,11 @@ validateScimUser' ::
   Scim.User ST.SparTag ->
   m ST.ValidScimUser
 validateScimUser' midp richInfoLimit user = do
+  unless (isNothing $ Scim.password user) $
+    throwError $
+      Scim.badRequest
+        Scim.InvalidValue
+        (Just "Setting user passwords is not supported for security reasons.")
   veid <- mkUserRef midp (Scim.externalId user)
   handl <- validateHandle . Text.toLower . Scim.userName $ user
   -- FUTUREWORK: 'Scim.userName' should be case insensitive; then the toLower here would

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -633,7 +633,9 @@ synthesizeStoredUser' uid veid dname handle richInfo accStatus createdAt lastUpd
         synthesizeScimUser
           ST.ValidScimUser
             { ST._vsuExternalId = veid,
-              ST._vsuHandle = handle, -- 'Maybe' there is one in @usr@, but we want to type checker to make sure this exists.
+              ST._vsuHandle = handle {- 'Maybe' there is one in @usr@, but we want the type
+                                        checker to make sure this exists, so we add it here
+                                        redundantly, without the 'Maybe'. -},
               ST._vsuName = dname,
               ST._vsuRichInfo = richInfo,
               ST._vsuActive = ST.scimActiveFlagFromAccountStatus accStatus

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -492,8 +492,12 @@ deleteScimUser ScimTokenInfo {stiTeam} uid = do
         throwError $
           Scim.notFound "user" (idToText uid)
       for_ (BT.userSSOId brigUser) $ \ssoId -> do
-        uref <- either logThenServerError pure $ Brig.fromUserSSOId ssoId
-        lift . wrapMonadClient $ Data.deleteSAMLUser uref
+        veid <- either logThenServerError pure $ Brig.veidFromUserSSOId ssoId
+        lift . wrapMonadClient $
+          ST.runValidExternalId
+            Data.deleteSAMLUser
+            Data.deleteScimExternalId
+            veid
       lift . wrapMonadClient $ Data.deleteScimUserTimes uid
       lift $ Brig.deleteBrigUser uid
       return ()

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -270,7 +270,7 @@ mkUserRef Nothing (Just extid) = do
   let err =
         Scim.badRequest
           Scim.InvalidValue
-          (Just "externalId must be a valid email or a valid SAML NameID")
+          (Just "externalId must be a valid email address or (if there is a SAML IdP) a valid SAML NameID")
   maybe (throwError err) (pure . ST.EmailOnly) $ parseEmail extid
 mkUserRef (Just idp) (Just extid) = do
   let issuer = idp ^. SAML.idpMetadata . SAML.edIssuer

--- a/services/spar/src/Spar/Types.hs
+++ b/services/spar/src/Spar/Types.hs
@@ -173,7 +173,7 @@ instance FromJSON ScimTokenInfo where
     stiTeam <- o .: "team"
     stiId <- o .: "id"
     stiCreatedAt <- o .: "created_at"
-    stiIdP <- o .: "idp"
+    stiIdP <- o .:? "idp"
     stiDescr <- o .: "description"
     pure ScimTokenInfo {..}
 

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -1063,7 +1063,7 @@ specScimAndSAML = do
     userid' <- getUserIdViaRef' userref
     liftIO $ ('i', userid') `shouldBe` ('i', Just userid)
     userssoid <- getSsoidViaSelf' userid
-    liftIO $ ('r', Intra.veidFromUserSSOId <$> userssoid) `shouldBe` ('r', Just (Right (UrefOnly userref)))
+    liftIO $ ('r', preview veidUref <$$> (Intra.veidFromUserSSOId <$> userssoid)) `shouldBe` ('r', Just (Right (Just userref)))
     -- login a user for the first time with the scim-supplied credentials
     authnreq <- negotiateAuthnRequest idp
     spmeta <- getTestSPMetadata

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -48,6 +48,7 @@ import SAML2.WebSSO.Test.MockResponse
 import SAML2.WebSSO.Test.Util
 import Spar.API.Types
 import qualified Spar.Intra.Brig as Intra
+import Spar.Scim.Types
 import Spar.Types
 import Text.XML.DSig (SignPrivCreds, mkSignCredsWithCert)
 import URI.ByteString.QQ (uri)
@@ -394,7 +395,7 @@ specBindingUsers = describe "binding existing users to sso identities" $ do
         getSsoidViaAuthResp aresp = do
           parsed :: AuthnResponse <-
             either error pure . parseFromDocument $ fromSignedAuthnResponse aresp
-          either error (pure . Intra.toUserSSOId) $ getUserRef parsed
+          either error (pure . Intra.veidToUserSSOId . UrefOnly) $ getUserRef parsed
         initialBind :: HasCallStack => UserId -> IdP -> SignPrivCreds -> TestSpar (NameID, SignedAuthnResponse, ResponseLBS)
         initialBind = initialBind' Just
         initialBind' ::
@@ -1062,7 +1063,7 @@ specScimAndSAML = do
     userid' <- getUserIdViaRef' userref
     liftIO $ ('i', userid') `shouldBe` ('i', Just userid)
     userssoid <- getSsoidViaSelf' userid
-    liftIO $ ('r', Intra.fromUserSSOId <$> userssoid) `shouldBe` ('r', Just (Right userref))
+    liftIO $ ('r', Intra.veidFromUserSSOId <$> userssoid) `shouldBe` ('r', Just (Right (UrefOnly userref)))
     -- login a user for the first time with the scim-supplied credentials
     authnreq <- negotiateAuthnRequest idp
     spmeta <- getTestSPMetadata

--- a/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
@@ -31,6 +31,7 @@ import Control.Lens
 import Data.Misc (PlainTextPassword (..))
 import qualified Galley.Types.Teams as Galley
 import Imports
+import qualified SAML2.WebSSO.Test.Util as SAML
 import Spar.Scim
 import Spar.Types (ScimTokenInfo (..))
 import Util
@@ -52,7 +53,7 @@ specCreateToken :: SpecWith TestEnv
 specCreateToken = describe "POST /auth-tokens" $ do
   it "works" $ testCreateToken
   it "respects the token limit" $ testTokenLimit
-  it "requires the team to have an IdP" $ testIdPIsNeeded
+  it "requires the team to have no more than one IdP" $ testNumIdPs
   it "authorizes only team owner" $ testCreateTokenAuthorizesOnlyTeamOwner
   it "requires a password" $ testCreateTokenRequiresPassword
 
@@ -114,25 +115,27 @@ testTokenLimit = do
     (env ^. teSpar)
     !!! checkErr 403 (Just "token-limit-reached")
 
--- | Test that a token can't be created for a team without an IdP.
---
--- (We don't support SCIM without SSO.)
-testIdPIsNeeded :: TestSpar ()
-testIdPIsNeeded = do
+testNumIdPs :: TestSpar ()
+testNumIdPs = do
   env <- ask
-  -- Create a new team and don't associate an IdP with it
-  (userid, _teamid) <-
+  (owner, _) <-
     runHttpT (env ^. teMgr) $
       createUserWithTeam (env ^. teBrig) (env ^. teGalley)
-  -- Creating a token should fail now
-  createToken_
-    userid
-    CreateScimToken
-      { createScimTokenDescr = "testIdPIsNeeded",
-        createScimTokenPassword = Just defPassword
-      }
-    (env ^. teSpar)
-    !!! checkErr 400 (Just "no-single-idp")
+
+  let addSomeIdP :: TestSpar ()
+      addSomeIdP = do
+        spar <- asks (view teSpar)
+        SAML.SampleIdP metadata _ _ _ <- SAML.makeSampleIdPMetadata
+        void $ call $ Util.callIdpCreate spar (Just owner) metadata
+
+  createToken owner (CreateScimToken "eins" (Just defPassword))
+    >>= deleteToken owner . stiId . createScimTokenResponseInfo
+  addSomeIdP
+  createToken owner (CreateScimToken "zwei" (Just defPassword))
+    >>= deleteToken owner . stiId . createScimTokenResponseInfo
+  addSomeIdP
+  createToken_ owner (CreateScimToken "drei" (Just defPassword)) (env ^. teSpar)
+    !!! checkErr 400 (Just "more-than-one-idp")
 
 -- | Test that a token can only be created as a team owner
 testCreateTokenAuthorizesOnlyTeamOwner :: TestSpar ()

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -1362,6 +1362,7 @@ specEmailValidation = do
               p = ["/i/teams", toByteString' tid, "features", "validate-saml-emails"]
           call req !!! const 204 === statusCode
 
+        -- (This may be the same as 'Util.Email.checkEmail'.)
         assertEmail :: HasCallStack => UserId -> Maybe Email -> TestSpar ()
         assertEmail uid expectedEmail = do
           brig <- asks (^. teBrig)

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -213,7 +213,7 @@ testCreateUserWithPass = do
     const 400 === statusCode
     -- TODO: write a FAQ entry in wire-docs, reference it in the error description.
     -- TODO: yes, we should just test for error labels consistently, i know...
-    const (Just "setting password via scim is not supported") =~= responseBody
+    const (Just "Setting user passwords is not supported for security reasons.") =~= responseBody
 
 testCreateUserNoIdP :: TestSpar ()
 testCreateUserNoIdP = do

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -648,16 +648,13 @@ testFindNonProvisionedUserNoIdP = do
 -- | Test that deleted users are not listed.
 testListNoDeletedUsers :: TestSpar ()
 testListNoDeletedUsers = do
-  env <- ask
   -- Create a user via SCIM
   user <- randomScimUser
   (tok, _) <- registerIdPAndScimToken
   storedUser <- createUser tok user
   let userid = scimUserId storedUser
   -- Delete the user
-  -- TODO(fisx): use 'Util.Scim.deleteUser' instead of 'Util.Core.deleteUserOnBrig' (in fact,
-  -- we should probably do both)
-  call $ deleteUserOnBrig (env ^. teBrig) userid
+  _ <- deleteUser tok userid
   -- Get all users
   users <- listUsers tok (Just (filterForStoredUser storedUser))
   -- Check that the user is absent

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -277,7 +277,7 @@ testCreateUserNoIdPNoEmail = do
   createUser_ (Just tok) user (env ^. teSpar) !!! do
     const 400 === statusCode
     -- TODO(fisx): test for error labels consistently...
-    const (Just "externalId must be a valid SAML NameID or an email address (or both)") =~= responseBody
+    const (Just "externalId must be a valid email address or (if there is a SAML IdP) a valid SAML NameID") =~= responseBody
 
 testCreateUserWithSamlIdP :: TestSpar ()
 testCreateUserWithSamlIdP = do

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -186,8 +186,6 @@ specCreateUser = describe "POST /Users" $ do
   context "team has one SAML IdP" $ do
     it "creates a user in an existing team" $ do
       testCreateUserWithSamlIdP
-    it "validates email address if feature flag is on" $ do
-      testValidateEmailsInSamlUrefs
   it "adds a Wire scheme to the user record" $ testSchemaIsAdded
   it "requires externalId to be present" $ testExternalIdIsRequired
   it "rejects invalid handle" $ testCreateRejectsInvalidHandle
@@ -300,9 +298,6 @@ testCreateUserWithSamlIdP = do
   accStatus <- aFewTimes (runSpar $ Intra.getStatus (userId brigUser)) (== Active)
   liftIO $ accStatus `shouldBe` Active
   liftIO $ userManagedBy brigUser `shouldBe` ManagedByScim
-
-testValidateEmailsInSamlUrefs :: TestSpar ()
-testValidateEmailsInSamlUrefs = undefined
 
 -- | Test that Wire-specific schemas are added to the SCIM user record, even if the schemas
 -- were not present in the original record during creation.

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -356,7 +356,8 @@ testCreateRejectsTakenExternalId withidp = do
         registerScimToken tid Nothing
 
   -- Create and add a first user: success!
-  user1 <- randomScimUser
+  email <- randomEmail
+  user1 <- randomScimUser <&> \u -> u {Scim.User.externalId = Just $ fromEmail email}
   _ <- createUser tok user1
   -- Try to create different user with same @externalId@ in same team, and fail.
   user2 <- randomScimUser

--- a/services/spar/test-integration/Util.hs
+++ b/services/spar/test-integration/Util.hs
@@ -21,5 +21,6 @@ module Util
 where
 
 import Util.Core as U
+import Util.Email as U
 import Util.Scim as U
 import Util.Types as U

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -174,6 +174,7 @@ import qualified Spar.Data as Data
 import qualified Spar.Intra.Brig as Intra
 import qualified Spar.Options
 import Spar.Run
+import Spar.Scim.Types (runValidExternalId)
 import Spar.Types
 import qualified System.Logger.Extended as Log
 import System.Random (randomRIO)
@@ -1104,8 +1105,12 @@ callDeleteDefaultSsoCode sparreq_ = do
 -- | Look up 'UserId' under 'UserSSOId' on spar's cassandra directly.
 ssoToUidSpar :: (HasCallStack, MonadIO m, MonadReader TestEnv m) => Brig.UserSSOId -> m (Maybe UserId)
 ssoToUidSpar ssoid = do
-  ssoref <- either (error . ("could not parse UserRef: " <>)) pure $ Intra.fromUserSSOId ssoid
-  runSparCass @Client $ Data.getSAMLUser ssoref
+  veid <- either (error . ("could not parse brig sso_id: " <>)) pure $ Intra.veidFromUserSSOId ssoid
+  runSparCass @Client $
+    runValidExternalId
+      Data.getSAMLUser
+      Data.lookupScimExternalId
+      veid
 
 runSparCass ::
   (HasCallStack, m ~ Client, MonadIO m', MonadReader TestEnv m') =>

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -47,6 +47,7 @@ module Util.Core
     endpointToURL,
 
     -- * Other
+    randomEmail,
     defPassword,
     getUserBrig,
     createUserWithTeam,
@@ -741,7 +742,7 @@ registerTestIdPWithMeta ::
   (HasCallStack, MonadRandom m, MonadIO m, MonadReader TestEnv m) =>
   m (UserId, TeamId, IdP, (IdPMetadataInfo, SAML.SignPrivCreds))
 registerTestIdPWithMeta = do
-  (SampleIdP idpmeta privkey _ _) <- makeSampleIdPMetadata
+  SampleIdP idpmeta privkey _ _ <- makeSampleIdPMetadata
   env <- ask
   (uid, tid, idp) <- registerTestIdPFrom idpmeta (env ^. teMgr) (env ^. teBrig) (env ^. teGalley) (env ^. teSpar)
   pure (uid, tid, idp, (IdPMetadataValue (cs $ SAML.encode idpmeta) idpmeta, privkey))

--- a/services/spar/test-integration/Util/Email.hs
+++ b/services/spar/test-integration/Util/Email.hs
@@ -29,6 +29,15 @@ activateEmail brig email = do
         const 200 === statusCode
         const (Just False) === fmap activatedFirst . responseJsonMaybe
 
+failActivatingEmail ::
+  (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) =>
+  BrigReq ->
+  Email ->
+  MonadHttp m => m ()
+failActivatingEmail brig email = do
+  act <- getActivationCode brig (Left email)
+  liftIO $ assertEqual "there should be no pending activation" act Nothing
+
 checkEmail ::
   (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) =>
   BrigReq ->

--- a/services/spar/test-integration/Util/Email.hs
+++ b/services/spar/test-integration/Util/Email.hs
@@ -1,0 +1,66 @@
+-- | Cloned from "/services/brig/test/integration/{Uril.hs,Util/Email.hs}"
+module Util.Email where
+
+import Bilge hiding (accept, timeout)
+import Bilge.Assert
+import Brig.Types
+import Control.Lens ((^?))
+import Control.Monad.Catch (MonadCatch)
+import Data.Aeson.Lens
+import Data.ByteString.Conversion
+import Data.Id hiding (client)
+import qualified Data.Text.Ascii as Ascii
+import Imports
+import Test.Tasty.HUnit
+import Util.Core
+import Util.Types
+
+activateEmail ::
+  (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) =>
+  BrigReq ->
+  Email ->
+  MonadHttp m => m ()
+activateEmail brig email = do
+  act <- getActivationCode brig (Left email)
+  case act of
+    Nothing -> liftIO $ assertFailure "missing activation key/code"
+    Just kc ->
+      activate brig kc !!! do
+        const 200 === statusCode
+        const (Just False) === fmap activatedFirst . responseJsonMaybe
+
+checkEmail ::
+  (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) =>
+  BrigReq ->
+  UserId ->
+  Email ->
+  m ()
+checkEmail brig uid expectedEmail =
+  get (brig . path "/self" . zUser uid) !!! do
+    const 200 === statusCode
+    const (Just expectedEmail) === (userEmail <=< responseJsonMaybe)
+
+activate ::
+  (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) =>
+  BrigReq ->
+  ActivationPair ->
+  m ResponseLBS
+activate brig (k, c) =
+  get $
+    brig
+      . path "activate"
+      . queryItem "key" (toByteString' k)
+      . queryItem "code" (toByteString' c)
+
+getActivationCode ::
+  (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) =>
+  BrigReq ->
+  Either Email Phone ->
+  m (Maybe (ActivationKey, ActivationCode))
+getActivationCode brig ep = do
+  let qry = either (queryItem "email" . toByteString') (queryItem "phone" . toByteString') ep
+  r <- get $ brig . path "/i/users/activation-code" . qry
+  let lbs = fromMaybe "" $ responseBody r
+  let akey = ActivationKey . Ascii.unsafeFromText <$> (lbs ^? key "key" . _String)
+  let acode = ActivationCode . Ascii.unsafeFromText <$> (lbs ^? key "code" . _String)
+  return $ (,) <$> akey <*> acode

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -553,9 +553,12 @@ instance IsUser ValidScimUser where
   maybeUserId = Nothing
   maybeHandle = Just (Just . view vsuHandle)
   maybeName = Just (Just . view vsuName)
-  maybeTenant = Just (Just . view (vsuUserRef . SAML.uidTenant))
-  maybeSubject = Just (Just . view (vsuUserRef . SAML.uidSubject))
-  maybeSubjectRaw = Just (SAML.shortShowNameID . view (vsuUserRef . SAML.uidSubject))
+  maybeTenant = Just (^? (vsuExternalId . veidUref . SAML.uidTenant))
+  maybeSubject = Just (^? (vsuExternalId . veidUref . SAML.uidSubject))
+  maybeSubjectRaw = Just (\vsc -> email vsc <|> uref vsc)
+    where
+      email = fmap fromEmail . (^? (vsuExternalId . veidEmail))
+      uref = SAML.shortShowNameID <=< (^? (vsuExternalId . veidUref . SAML.uidSubject))
 
 instance IsUser (WrappedScimStoredUser SparTag) where
   maybeUserId = Just $ scimUserId . fromWrappedScimStoredUser
@@ -632,4 +635,4 @@ urefFromBrig brigUser = case userIdentity brigUser of
 -- what we expect a user that comes back from spar to look like in terms of what it looked
 -- like when we sent it there.
 whatSparReturnsFor :: HasCallStack => IdP -> Int -> Scim.User.User SparTag -> Either String (Scim.User.User SparTag)
-whatSparReturnsFor idp richInfoSizeLimit = either (Left . show) (Right . synthesizeScimUser) . validateScimUser' idp richInfoSizeLimit
+whatSparReturnsFor idp richInfoSizeLimit = either (Left . show) (Right . synthesizeScimUser) . validateScimUser' (Just idp) richInfoSizeLimit

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -241,7 +241,7 @@ deleteUser tok userid = do
       (Just tok)
       (Just userid)
       (env ^. teSpar)
-      <!! const 200 === statusCode -- status code maybe some other 2xx?
+      <!! const 204 === statusCode
   pure (responseJsonUnsafe r)
 
 -- | List all users.

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -25,7 +25,6 @@ import Brig.Types.User
 import Cassandra
 import Control.Lens
 import Control.Monad.Random
-import qualified Data.Aeson as Aeson
 import Data.ByteString.Conversion
 import Data.Handle (Handle (Handle))
 import Data.Id
@@ -352,7 +351,7 @@ createUser_ auth user spar_ = do
         . paths ["scim", "v2", "Users"]
         . scimAuth auth
         . contentScim
-        . body (RequestBodyLBS . Aeson.encode $ user)
+        . json user
         . acceptScim
     )
 
@@ -374,7 +373,7 @@ updateUser_ auth muid user spar_ = do
         . paths (["scim", "v2", "Users"] <> maybeToList (toByteString' <$> muid))
         . scimAuth auth
         . contentScim
-        . body (RequestBodyLBS . Aeson.encode $ user)
+        . json user
         . acceptScim
     )
 
@@ -386,7 +385,7 @@ patchUser_ auth muid patchop spar_ =
         . paths (["scim", "v2", "Users"] <> maybeToList (toByteString' <$> muid))
         . scimAuth auth
         . contentScim
-        . body (RequestBodyLBS . Aeson.encode $ patchop)
+        . json patchop
         . acceptScim
     )
 
@@ -463,7 +462,7 @@ createToken_ userid payload spar_ = do
         . paths ["scim", "auth-tokens"]
         . zUser userid
         . contentJson
-        . body (RequestBodyLBS . Aeson.encode $ payload)
+        . json payload
         . acceptJson
     )
 

--- a/services/spar/test/Test/Spar/Intra/BrigSpec.hs
+++ b/services/spar/test/Test/Spar/Intra/BrigSpec.hs
@@ -25,6 +25,7 @@ import Data.String.Conversions (ST, cs)
 import Imports
 import SAML2.WebSSO as SAML
 import Spar.Intra.Brig
+import Spar.Scim.Types
 import Test.Hspec
 import Test.QuickCheck
 import URI.ByteString (URI, laxURIParserOptions, parseURI)
@@ -41,29 +42,31 @@ spec = do
 
     it "example" $ do
       let have =
-            UserRef
-              (Issuer $ mkuri "http://wire.com/")
-              ( either (error . show) id $
-                  mkNameID (mkUNameIDTransient "V") (Just "kati") (Just "rolli") (Just "jaan")
-              )
+            UrefOnly $
+              UserRef
+                (Issuer $ mkuri "http://wire.com/")
+                ( either (error . show) id $
+                    mkNameID (mkUNameIDTransient "V") (Just "kati") (Just "rolli") (Just "jaan")
+                )
           want =
             UserSSOId
               "<Issuer xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:samla=\"urn:oasis:names:tc:SAML:2.0:assertion\" xmlns:samlm=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://wire.com/</Issuer>"
               "<NameID xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:samla=\"urn:oasis:names:tc:SAML:2.0:assertion\" xmlns:samlm=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\" NameQualifier=\"kati\" SPNameQualifier=\"rolli\" SPProvidedID=\"jaan\" xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\">V</NameID>"
-      toUserSSOId have `shouldBe` want
-      fromUserSSOId want `shouldBe` Right have
+      veidToUserSSOId have `shouldBe` want
+      veidFromUserSSOId want `shouldBe` Right have
     it "another example" $ do
       let have =
-            UserRef
-              (Issuer $ mkuri "http://wire.com/")
-              ( either (error . show) id $
-                  mkNameID (mkUNameIDPersistent "PWkS") (Just "hendrik") Nothing (Just "marye")
-              )
+            UrefOnly $
+              UserRef
+                (Issuer $ mkuri "http://wire.com/")
+                ( either (error . show) id $
+                    mkNameID (mkUNameIDPersistent "PWkS") (Just "hendrik") Nothing (Just "marye")
+                )
           want =
             UserSSOId
               "<Issuer xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:samla=\"urn:oasis:names:tc:SAML:2.0:assertion\" xmlns:samlm=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://wire.com/</Issuer>"
               "<NameID xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:samla=\"urn:oasis:names:tc:SAML:2.0:assertion\" xmlns:samlm=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\" NameQualifier=\"hendrik\" SPProvidedID=\"marye\" xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\">PWkS</NameID>"
-      toUserSSOId have `shouldBe` want
-      fromUserSSOId want `shouldBe` Right have
+      veidToUserSSOId have `shouldBe` want
+      veidFromUserSSOId want `shouldBe` Right have
     it "roundtrips" . property $
-      \(x :: SAML.UserRef) -> (fromUserSSOId @(Either String) . toUserSSOId) x == Right x
+      \(x :: ValidExternalId) -> (veidFromUserSSOId @(Either String) . veidToUserSSOId) x == Right x


### PR DESCRIPTION
Fixes https://github.com/zinfra/backend-issues/issues/1365, https://github.com/zinfra/backend-issues/issues/1572

### documentation

Before this PR, scim tokens could only be added to teams that already had exactly one SAML IdP.  Now, we also allow SAML-less teams to have SCIM provisioning.  This is an alternative to onboarding via team-settings and produces user accounts that are authenticated with email and password.  (Phone may or may not work, but is not officially supported.)

The way this works is different from team-settings: we don't send invites, but we create active users immediately the moment the SCIM user post is processed.  The new thing is that the created user has neither email nor phone nor a SAML identity, nor a password.

How does this work?

**email:** If no SAML IdP is present, SCIM user posts must contain an externalId that is an email address.  This email address is not added to the newly created user, because it has not been validated.  Instead, the flow for changing an email address is triggered in brig: an email is sent to the address containing a validation key, and once the user completes the flow, brig will add the email address to the user.  We had to add very little code for this in this PR, it's all an old feature.

When SCIM user gets are processed, in order to reconstruct the externalId from the user spar is retrieving from brig, we introduce a new json object for the `sso_id` field that looks like this: `{'scim_external_id': 'me@example.com'}`.

In order to find users that have email addresses pending validation, we introduce a new table in spar's cassandra called `scim_external_ids`, in analogy to `user`.  We have tried to use brig's internal `GET /i/user&email=...`, but that also finds pending email addresses, and there are corner cases when changing email addresses and waiting for the new address to be validated and the old to be removed...  that made this approach seem infeasible.

**password:** once the user has validated their email address, they need to trigger the "forgot password" flow -- also old code.

That's the gist of it!