### PR TITLE
limit list of SFT servers to 5 (configurable), independent of the amount of servers …

### DIFF
--- a/libs/dns-util/src/Wire/Network/DNS/SRV.hs
+++ b/libs/dns-util/src/Wire/Network/DNS/SRV.hs
@@ -68,7 +68,7 @@ data SrvEntry = SrvEntry
     srvWeight :: !Word16,
     srvTarget :: !SrvTarget
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Ord)
 
 data SrvTarget = SrvTarget
   { -- | the hostname on which the service is offered
@@ -76,7 +76,7 @@ data SrvTarget = SrvTarget
     -- | the port on which the service is offered
     srvTargetPort :: !Word16
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Ord)
 
 data SrvResponse
   = SrvNotAvailable

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0efba75abb2e931761d20c36d7c690eb2cf9711711c4b002dfd2cd5ff7bd60ee
+-- hash: 7c9aee98315a9a56aa48fcb0af9a9e82954d9913fc94cafa512a0811f40b2ad3
 
 name:           brig
 version:        1.35.0
@@ -450,6 +450,7 @@ test-suite brig-tests
     , bloodhound
     , brig
     , brig-types
+    , containers
     , dns
     , dns-util
     , imports

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -144,10 +144,11 @@ tests:
     - bloodhound
     - brig
     - brig-types
+    - containers
     - dns
     - dns-util
-    - polysemy
     - imports
+    - polysemy
     - retry
     - tasty
     - tasty-hunit

--- a/services/brig/src/Brig/Calling.hs
+++ b/services/brig/src/Brig/Calling.hs
@@ -17,14 +17,38 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Brig.Calling where
+module Brig.Calling
+  ( getRandomSFTServers,
+    mkSFTDomain,
+    SFTServers, -- See NOTE SFTServers
+    mkSFTServers,
+    SFTEnv (..),
+    Discovery (..),
+    Env (..),
+    mkSFTEnv,
+    newEnv,
+    sftDiscoveryLoop,
+    discoverSFTServers,
+    discoveryToMaybe,
+    randomize,
+    startSFTServiceDiscovery,
+    turnServers,
+    turnTokenTTL,
+    turnConfigTTL,
+    turnSecret,
+    turnSHA512,
+    turnPrng,
+  )
+where
 
 import Brig.Options (SFTOptions (..), defSftDiscoveryIntervalSeconds, defSftListLength, defSftServiceName)
 import qualified Brig.Options as Opts
 import Brig.PolyLog
 import Brig.Types (TurnURI)
 import Control.Lens
-import Data.List.NonEmpty
+import Control.Monad.Random.Class (MonadRandom)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.List1
 import Data.Range
 import Data.Time.Clock (DiffTime, diffTimeToPicoseconds)
@@ -34,14 +58,52 @@ import OpenSSL.EVP.Digest (Digest)
 import Polysemy
 import qualified System.Logger as Log
 import System.Random.MWC (GenIO, createSystemRandom)
+import System.Random.Shuffle
 import Wire.Network.DNS.Effect
 import Wire.Network.DNS.SRV
+
+-- | NOTE SFTServers:
+-- Retrieving SFTServers should give a 1) randomized and 2) limited list of servers.
+-- Random as a (poor) way of "load balancing" for clients
+-- And limited since client currently try contacting all servers returned
+-- (and we don't want them to open 100 parallel connections unnecessarily)
+-- Therefore, we hide the constructor from the module export.
+newtype SFTServers = SFTServers (NonEmpty SrvEntry)
+  deriving (Eq, Show)
+
+mkSFTServers :: NonEmpty SrvEntry -> SFTServers
+mkSFTServers = SFTServers
+
+type MaximumSFTServers = 100
+
+-- | According to RFC2782, the SRV Entries are supposed to be tried in order of
+-- priority and weight, but we internally agreed to randomize the list of
+-- available servers for poor man's "load balancing" purposes.
+-- FUTUREWORK: be smarter about list orderding depending on how much capacity SFT servers have.
+-- randomizedSftEntries <- liftIO $ mapM randomize sftSrvEntries
+--
+-- Currently (Sept 2020) the client initiating an SFT call will try all
+-- servers in this list. Limit this list to a smaller subset in case many
+-- SFT servers are advertised in a given environment.
+getRandomSFTServers :: MonadRandom m => Range 1 MaximumSFTServers Int -> SFTServers -> m (NonEmpty SrvEntry)
+getRandomSFTServers limit (SFTServers list) = subsetSft limit <$> randomize list
+
+subsetSft :: Range 1 100 Int -> NonEmpty a -> NonEmpty a
+subsetSft l entries = do
+  let entry1 = NonEmpty.head entries
+  let entryTail = take (fromRange l - 1) (NonEmpty.tail entries)
+  entry1 :| entryTail
+
+-- | Note: Even though 'shuffleM' works only for [a], input is NonEmpty so it's
+-- safe to NonEmpty.fromList; ideally, we'd have 'shuffleM' for 'NonEmpty'
+randomize :: (MonadRandom m) => NonEmpty a -> m (NonEmpty a)
+randomize xs = NonEmpty.fromList <$> shuffleM (NonEmpty.toList xs)
 
 data SFTEnv = SFTEnv
   { -- | Starts off as `NotDiscoveredYet`, once it has servers, it should never
     -- go back to `NotDiscoveredYet` and continue having stale values if
-    -- subsequent discovries fail
-    sftServers :: IORef (Discovery (NonEmpty SrvEntry)),
+    -- subsequent discoveries fail
+    sftServers :: IORef (Discovery SFTServers),
     sftDomain :: DNS.Domain,
     -- | Microseconds, as expected by 'threadDelay'
     sftDiscoveryInterval :: Int,
@@ -81,7 +143,7 @@ sftDiscoveryLoop SFTEnv {..} = forever $ do
   servers <- discoverSFTServers sftDomain
   case servers of
     Nothing -> pure ()
-    Just es -> atomicWriteIORef sftServers (Discovered es)
+    Just es -> atomicWriteIORef sftServers (Discovered (SFTServers es))
   threadDelay sftDiscoveryInterval
 
 mkSFTEnv :: SFTOptions -> IO SFTEnv

--- a/services/brig/src/Brig/Calling.hs
+++ b/services/brig/src/Brig/Calling.hs
@@ -19,9 +19,10 @@
 
 module Brig.Calling where
 
-import Brig.Options (SFTOptions (..), defSftDiscoveryIntervalSeconds, defSftServiceName, defSftListLength)
+import Brig.Options (SFTOptions (..), defSftDiscoveryIntervalSeconds, defSftListLength, defSftServiceName)
 import qualified Brig.Options as Opts
 import Brig.PolyLog
+import Data.Range
 import Brig.Types (TurnURI)
 import Control.Lens
 import Data.List.NonEmpty
@@ -46,7 +47,7 @@ data SFTEnv = SFTEnv
     sftDiscoveryInterval :: Int,
     -- | maximum amount of servers to give out,
     -- even if more are in the SRV record
-    sftListLength :: Int
+    sftListLength :: Range 1 100 Int
   }
 
 data Discovery a

--- a/services/brig/src/Brig/Calling.hs
+++ b/services/brig/src/Brig/Calling.hs
@@ -19,7 +19,7 @@
 
 module Brig.Calling where
 
-import Brig.Options (SFTOptions (..), defSftDiscoveryIntervalSeconds, defSftServiceName)
+import Brig.Options (SFTOptions (..), defSftDiscoveryIntervalSeconds, defSftServiceName, defSftListLength)
 import qualified Brig.Options as Opts
 import Brig.PolyLog
 import Brig.Types (TurnURI)
@@ -43,7 +43,10 @@ data SFTEnv = SFTEnv
     sftServers :: IORef (Discovery (NonEmpty SrvEntry)),
     sftDomain :: DNS.Domain,
     -- | Microseconds, as expected by 'threadDelay'
-    sftDiscoveryInterval :: Int
+    sftDiscoveryInterval :: Int,
+    -- | maximum amount of servers to give out,
+    -- even if more are in the SRV record
+    sftListLength :: Int
   }
 
 data Discovery a
@@ -86,6 +89,7 @@ mkSFTEnv opts =
     <$> newIORef NotDiscoveredYet
     <*> pure (mkSFTDomain opts)
     <*> pure (diffTimeToMicroseconds (fromMaybe defSftDiscoveryIntervalSeconds (Opts.sftDiscoveryIntervalSeconds opts)))
+    <*> pure (fromMaybe defSftListLength (Opts.sftListLength opts))
 
 startSFTServiceDiscovery :: Log.Logger -> SFTEnv -> IO ()
 startSFTServiceDiscovery logger =

--- a/services/brig/src/Brig/Calling.hs
+++ b/services/brig/src/Brig/Calling.hs
@@ -22,11 +22,11 @@ module Brig.Calling where
 import Brig.Options (SFTOptions (..), defSftDiscoveryIntervalSeconds, defSftListLength, defSftServiceName)
 import qualified Brig.Options as Opts
 import Brig.PolyLog
-import Data.Range
 import Brig.Types (TurnURI)
 import Control.Lens
 import Data.List.NonEmpty
 import Data.List1
+import Data.Range
 import Data.Time.Clock (DiffTime, diffTimeToPicoseconds)
 import Imports
 import qualified Network.DNS as DNS

--- a/services/brig/src/Brig/Calling/API.hs
+++ b/services/brig/src/Brig/Calling/API.hs
@@ -132,14 +132,15 @@ newConfig env mSftEnv limit = do
   -- Currently (Sept 2020) the client initiating an SFT call will try all servers
   -- in this list. Limit this list to a smaller subset (here: 6) in case many SFT
   -- servers are advertised in a given environment.
-  let subsetSftEntries = subsetSft <$> randomizedSftEntries
+  let subsetLength = Calling.sftListLength <$> mSftEnv
+  let subsetSftEntries = subsetSft subsetLength <$> randomizedSftEntries
 
   pure $ Public.rtcConfiguration srvs (sftServerFromSrvTarget . srvTarget <$$> subsetSftEntries) cTTL
   where
-    subsetSft :: NonEmpty a -> NonEmpty a
-    subsetSft entries = do
+    subsetSft :: Int -> NonEmpty a -> NonEmpty a
+    subsetSft l entries = do
       let entry1 = NonEmpty.head entries
-      let entryTail = take 5 (NonEmpty.tail entries)
+      let entryTail = take (l - 1) (NonEmpty.tail entries)
       entry1 :| entryTail
 
     -- NOTE: even though `shuffleM` works only for [a], input is List1 so it's

--- a/services/brig/src/Brig/Calling/API.hs
+++ b/services/brig/src/Brig/Calling/API.hs
@@ -134,9 +134,9 @@ newConfig env mSftEnv limit = do
       -- FUTUREWORK: be smarter about list orderding depending on how much capacity SFT servers have.
       randomizedSftEntries <- liftIO $ mapM randomize sftSrvEntries
 
-      -- Currently (Sept 2020) the client initiating an SFT call will try all servers
-      -- in this list. Limit this list to a smaller subset (here: 6) in case many SFT
-      -- servers are advertised in a given environment.
+      -- Currently (Sept 2020) the client initiating an SFT call will try all
+      -- servers in this list. Limit this list to a smaller subset in case many
+      -- SFT servers are advertised in a given environment.
       let subsetLength = Calling.sftListLength actualSftEnv
       return $ subsetSft subsetLength <$> randomizedSftEntries
 

--- a/services/brig/src/Brig/Calling/Internal.hs
+++ b/services/brig/src/Brig/Calling/Internal.hs
@@ -18,9 +18,9 @@
 module Brig.Calling.Internal where
 
 import Control.Lens ((?~))
-import Imports
 import qualified Data.ByteString.Char8 as BS
 import Data.Misc (ensureHttpsUrl)
+import Imports
 import qualified URI.ByteString as URI
 import qualified URI.ByteString.QQ as URI
 import qualified Wire.API.Call.Config as Public

--- a/services/brig/src/Brig/Calling/Internal.hs
+++ b/services/brig/src/Brig/Calling/Internal.hs
@@ -18,9 +18,9 @@
 module Brig.Calling.Internal where
 
 import Control.Lens ((?~))
+import Imports
 import qualified Data.ByteString.Char8 as BS
 import Data.Misc (ensureHttpsUrl)
-import Imports
 import qualified URI.ByteString as URI
 import qualified URI.ByteString.QQ as URI
 import qualified Wire.API.Call.Config as Public

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -33,11 +33,12 @@ import Data.Aeson.Types (typeMismatch)
 import qualified Data.Char as Char
 import Data.Domain (Domain)
 import Data.Id
+import Data.Range
 import Data.Scientific (toBoundedInteger)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Data.Time.Clock (DiffTime, NominalDiffTime, secondsToDiffTime)
-import Data.Yaml (FromJSON (..), ToJSON (..), (.:), (.:?))
+import Data.Yaml ((.:), (.:?), FromJSON (..), ToJSON (..))
 import qualified Data.Yaml as Y
 import Imports
 import qualified Network.DNS as DNS
@@ -525,7 +526,7 @@ data SFTOptions = SFTOptions
   { sftBaseDomain :: !DNS.Domain,
     sftSRVServiceName :: !(Maybe ByteString), -- defaults to defSftServiceName if unset
     sftDiscoveryIntervalSeconds :: !(Maybe DiffTime), -- defaults to defSftDiscoveryIntervalSeconds
-    sftListLength :: !(Maybe Int) -- defaults to defSftListLength
+    sftListLength :: !(Maybe (Range 1 100 Int)) -- defaults to defSftListLength
   }
   deriving (Show, Generic)
 
@@ -564,17 +565,17 @@ defSftServiceName = "_sft"
 defSftDiscoveryIntervalSeconds :: DiffTime
 defSftDiscoveryIntervalSeconds = secondsToDiffTime 10
 
-defSftListLength :: Int
-defSftListLength = 5
+defSftListLength :: Range 1 100 Int
+defSftListLength = unsafeRange 5
 
 instance FromJSON Timeout where
   parseJSON (Y.Number n) =
     let defaultV = 3600
         bounded = toBoundedInteger n :: Maybe Int64
-     in pure $
-          Timeout $
-            fromIntegral @Int $
-              maybe defaultV fromIntegral bounded
+     in pure
+          $ Timeout
+          $ fromIntegral @Int
+          $ maybe defaultV fromIntegral bounded
   parseJSON v = typeMismatch "activationTimeout" v
 
 instance FromJSON Settings

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -524,7 +524,8 @@ newtype DomainsBlockedForRegistration = DomainsBlockedForRegistration [Domain]
 data SFTOptions = SFTOptions
   { sftBaseDomain :: !DNS.Domain,
     sftSRVServiceName :: !(Maybe ByteString), -- defaults to defSftServiceName if unset
-    sftDiscoveryIntervalSeconds :: !(Maybe DiffTime) -- defaults to defSftDiscoveryIntervalSeconds
+    sftDiscoveryIntervalSeconds :: !(Maybe DiffTime), -- defaults to defSftDiscoveryIntervalSeconds
+    sftListLength :: !(Maybe Int) -- defaults to defSftListLength
   }
   deriving (Show, Generic)
 
@@ -534,6 +535,7 @@ instance FromJSON SFTOptions where
       <$> (asciiOnly =<< o .: "sftBaseDomain")
       <*> (mapM asciiOnly =<< o .:? "sftSRVServiceName")
       <*> (secondsToDiffTime <$$> o .:? "sftDiscoveryIntervalSeconds")
+      <*> (o .:? "sftListLength")
     where
       asciiOnly :: Text -> Y.Parser ByteString
       asciiOnly t =
@@ -561,6 +563,9 @@ defSftServiceName = "_sft"
 
 defSftDiscoveryIntervalSeconds :: DiffTime
 defSftDiscoveryIntervalSeconds = secondsToDiffTime 10
+
+defSftListLength :: Int
+defSftListLength = 5
 
 instance FromJSON Timeout where
   parseJSON (Y.Number n) =

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -38,7 +38,7 @@ import Data.Scientific (toBoundedInteger)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Data.Time.Clock (DiffTime, NominalDiffTime, secondsToDiffTime)
-import Data.Yaml ((.:), (.:?), FromJSON (..), ToJSON (..))
+import Data.Yaml (FromJSON (..), ToJSON (..), (.:), (.:?))
 import qualified Data.Yaml as Y
 import Imports
 import qualified Network.DNS as DNS
@@ -572,10 +572,10 @@ instance FromJSON Timeout where
   parseJSON (Y.Number n) =
     let defaultV = 3600
         bounded = toBoundedInteger n :: Maybe Int64
-     in pure
-          $ Timeout
-          $ fromIntegral @Int
-          $ maybe defaultV fromIntegral bounded
+     in pure $
+          Timeout $
+            fromIntegral @Int $
+              maybe defaultV fromIntegral bounded
   parseJSON v = typeMismatch "activationTimeout" v
 
 instance FromJSON Settings

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -93,7 +93,7 @@ testSFT b opts = do
       "when SFT discovery is not enabled, sft_servers shouldn't be returned"
       Nothing
       (cfg ^. rtcConfSftServers)
-  withSettingsOverrides (opts & Opts.sftL ?~ Opts.SFTOptions "integration-tests.zinfra.io" Nothing (Just 0.001)) $ do
+  withSettingsOverrides (opts & Opts.sftL ?~ Opts.SFTOptions "integration-tests.zinfra.io" Nothing (Just 0.001) Nothing) $ do
     cfg1 <- retryWhileN 10 (isNothing . view rtcConfSftServers) (getTurnConfigurationV2 uid b)
     -- These values are controlled by https://github.com/zinfra/cailleach/tree/77ca2d23cf2959aa183dd945d0a0b13537a8950d/environments/dns-integration-tests
     let Right server1 = mkHttpsUrl =<< first show (parseURI laxURIParserOptions "https://sft01.integration-tests.zinfra.io:443")

--- a/services/brig/test/unit/Test/Brig/Calling.hs
+++ b/services/brig/test/unit/Test/Brig/Calling.hs
@@ -69,12 +69,12 @@ tests =
             assertEqual
               "should use the service name to form domain"
               "_foo._tcp.example.com."
-              (mkSFTDomain (SFTOptions "example.com" (Just "foo") Nothing)),
+              (mkSFTDomain (SFTOptions "example.com" (Just "foo") Nothing Nothing)),
           testCase "when service name is not provided" $
             assertEqual
               "should assume service name to be 'sft'"
               "_sft._tcp.example.com."
-              (mkSFTDomain (SFTOptions "example.com" Nothing Nothing))
+              (mkSFTDomain (SFTOptions "example.com" Nothing Nothing Nothing))
         ],
       testGroup "sftDiscoveryLoop" $
         [ testCase "when service can be discovered" $ void testDiscoveryLoopWhenSuccessful,
@@ -96,7 +96,7 @@ testDiscoveryLoopWhenSuccessful = do
       entry3 = SrvEntry 0 0 (SrvTarget "sft3.foo.example.com." 443)
       returnedEntries = (entry1 :| [entry2, entry3])
   fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvAvailable returnedEntries)
-  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001))
+  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001) Nothing)
 
   discoveryLoop <- Async.async $ runM . ignoreLogs . runFakeDNSLookup fakeDNSEnv $ sftDiscoveryLoop sftEnv
   void $ retryEvery10MicrosWhileN 2000 (== 0) (length <$> readIORef (fakeLookupCalls fakeDNSEnv))
@@ -111,7 +111,7 @@ testDiscoveryLoopWhenSuccessful = do
 testDiscoveryLoopWhenUnsuccessful :: IO ()
 testDiscoveryLoopWhenUnsuccessful = do
   fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvNotAvailable)
-  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001))
+  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001) Nothing)
 
   discoveryLoop <- Async.async $ runM . ignoreLogs . runFakeDNSLookup fakeDNSEnv $ sftDiscoveryLoop sftEnv
   -- We wait for at least two lookups to be sure that the lookup loop looped at

--- a/services/brig/test/unit/Test/Brig/Calling.hs
+++ b/services/brig/test/unit/Test/Brig/Calling.hs
@@ -24,6 +24,9 @@ import Brig.Options
 import Brig.PolyLog
 import Control.Retry
 import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Range
+import qualified Data.Set as Set
 import Imports
 import Network.DNS
 import Polysemy
@@ -40,7 +43,7 @@ data FakeDNSEnv = FakeDNSEnv
   }
 
 newFakeDNSEnv :: (Domain -> SrvResponse) -> IO FakeDNSEnv
-newFakeDNSEnv lookupFn = do
+newFakeDNSEnv lookupFn =
   FakeDNSEnv lookupFn <$> newIORef []
 
 runFakeDNSLookup :: Member (Embed IO) r => FakeDNSEnv -> Sem (DNSLookup ': r) a -> Sem r a
@@ -61,6 +64,7 @@ recordLogs LogRecorder {..} = interpret $ \(PolyLog lvl msg) ->
 ignoreLogs :: Sem (PolyLog ': r) a -> Sem r a
 ignoreLogs = interpret $ \(PolyLog _ _) -> pure ()
 
+{-# ANN tests ("HLint: ignore" :: String) #-}
 tests :: TestTree
 tests =
   testGroup "Calling" $
@@ -86,6 +90,11 @@ tests =
         [ testCase "when service is available" testSFTDiscoverWhenAvailable,
           testCase "when service is not available" testSFTDiscoverWhenNotAvailable,
           testCase "when dns lookup fails" testSFTDiscoverWhenDNSFails
+        ],
+      testGroup "getRandomSFTServers" $
+        [ testCase "more servers in SRV than limit" testSFTManyServers,
+          testCase "fewer servers in SRV than limit" testSFTFewerServers
+          -- the randomization part is not (yet?) tested here.
         ]
     ]
 
@@ -94,7 +103,7 @@ testDiscoveryLoopWhenSuccessful = do
   let entry1 = SrvEntry 0 0 (SrvTarget "sft1.foo.example.com." 443)
       entry2 = SrvEntry 0 0 (SrvTarget "sft2.foo.example.com." 443)
       entry3 = SrvEntry 0 0 (SrvTarget "sft3.foo.example.com." 443)
-      returnedEntries = (entry1 :| [entry2, entry3])
+      returnedEntries = entry1 :| [entry2, entry3]
   fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvAvailable returnedEntries)
   sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001) Nothing)
 
@@ -105,7 +114,7 @@ testDiscoveryLoopWhenSuccessful = do
   Async.cancel discoveryLoop
 
   actualServers <- readIORef (sftServers sftEnv)
-  assertEqual "servers should be the ones read from DNS" (Discovered returnedEntries) actualServers
+  assertEqual "servers should be the ones read from DNS" (Discovered (mkSFTServers returnedEntries)) actualServers
   pure sftEnv
 
 testDiscoveryLoopWhenUnsuccessful :: IO ()
@@ -153,11 +162,11 @@ testDiscoveryLoopWhenURLsChange = do
   discoveryLoop <- Async.async $ runM . ignoreLogs . runFakeDNSLookup fakeDNSEnv $ sftDiscoveryLoop sftEnv
   void $ retryEvery10MicrosWhileN 2000 (== 0) (length <$> readIORef (fakeLookupCalls fakeDNSEnv))
   -- We don't want to stop the loop before it has written to the sftServers IORef
-  void $ retryEvery10MicrosWhileN 2000 (== Discovered newEntries) (readIORef (sftServers sftEnv))
+  void $ retryEvery10MicrosWhileN 2000 (== Discovered (mkSFTServers newEntries)) (readIORef (sftServers sftEnv))
   Async.cancel discoveryLoop
 
   actualServers <- readIORef (sftServers sftEnv)
-  assertEqual "servers should get overwritten" (Discovered newEntries) actualServers
+  assertEqual "servers should get overwritten" (Discovered (mkSFTServers newEntries)) actualServers
 
 testSFTDiscoverWhenAvailable :: IO ()
 testSFTDiscoverWhenAvailable = do
@@ -197,6 +206,32 @@ testSFTDiscoverWhenDNSFails = do
         )
   assertEqual "should warn about it in the logs" [(Log.Error, "DNS Lookup failed for SFT Discovery, Error=IllegalDomain\n")]
     =<< readIORef (recordedLogs logRecorder)
+
+testSFTManyServers :: IO ()
+testSFTManyServers = do
+  let entry1 = SrvEntry 0 0 (SrvTarget "sft1.foo.example.com." 443)
+      entry2 = SrvEntry 0 0 (SrvTarget "sft2.foo.example.com." 443)
+      entry3 = SrvEntry 0 0 (SrvTarget "sft3.foo.example.com." 443)
+      entry4 = SrvEntry 0 0 (SrvTarget "sft4.foo.example.com." 443)
+      entry5 = SrvEntry 0 0 (SrvTarget "sft5.foo.example.com." 443)
+      entry6 = SrvEntry 0 0 (SrvTarget "sft6.foo.example.com." 443)
+      entry7 = SrvEntry 0 0 (SrvTarget "sft7.foo.example.com." 443)
+      entries = entry1 :| [entry2, entry3, entry4, entry5, entry6, entry7]
+      sftServers = mkSFTServers entries
+  someServers <- getRandomSFTServers (unsafeRange 3) sftServers
+  assertEqual "should return only 3 servers" 3 (length someServers)
+
+testSFTFewerServers :: IO ()
+testSFTFewerServers = do
+  let entry1 = SrvEntry 0 0 (SrvTarget "sft1.foo.example.com." 443)
+      entry2 = SrvEntry 0 0 (SrvTarget "sft2.foo.example.com." 443)
+      entry3 = SrvEntry 0 0 (SrvTarget "sft3.foo.example.com." 443)
+      entry4 = SrvEntry 0 0 (SrvTarget "sft4.foo.example.com." 443)
+      entries = entry1 :| [entry2, entry3, entry4]
+      sftServers = mkSFTServers entries
+
+  allServers <- getRandomSFTServers (unsafeRange 10) sftServers
+  assertEqual "should return all of them" (Set.fromList $ NonEmpty.toList allServers) (Set.fromList $ NonEmpty.toList entries)
 
 retryEvery10MicrosWhileN :: (MonadIO m) => Int -> (a -> Bool) -> m a -> m a
 retryEvery10MicrosWhileN n f m =


### PR DESCRIPTION
…in the SRV record

Can be configured with

```yaml
sft:
  sftListLength: 17 # an integer outside the range 1,100 will throw an error at startup time
```