### PR TITLE
Manage invited user by SCIM when SSO is enabled

### DIFF
--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -656,6 +656,12 @@ scimFindUserByHandle mIdpConfig stiTeam hndl = do
     Right veid -> lift $ synthesizeStoredUser brigUser veid
     Left _ -> Applicative.empty
 
+-- | Construct a 'ValidExternalid'.  If it an 'Email', find the non-SAML SCIM user in spar; if
+-- that fails, find the user by email in brig.  If it is a 'UserRef', find the SAML user.
+-- Return the result as a SCIM user.
+--
+-- Note the user won't get an entry in `spar.user`.  That will only happen on their first
+-- successful authentication with their SAML credentials.
 scimFindUserByEmail :: Maybe IdP -> TeamId -> Text -> MaybeT (Scim.ScimHandler Spar) (Scim.StoredUser ST.SparTag)
 scimFindUserByEmail mIdpConfig stiTeam email = do
   veid <- mkUserRef mIdpConfig (pure email)

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -36,7 +36,7 @@ module Spar.Scim.User
   ( validateScimUser',
     synthesizeScimUser,
     toScimStoredUser',
-    mkUserRef,
+    mkValidExternalId,
     scimFindUserByEmail,
   )
 where
@@ -203,7 +203,7 @@ validateScimUser' midp richInfoLimit user = do
       Scim.badRequest
         Scim.InvalidValue
         (Just "Setting user passwords is not supported for security reasons.")
-  veid <- mkUserRef midp (Scim.externalId user)
+  veid <- mkValidExternalId midp (Scim.externalId user)
   handl <- validateHandle . Text.toLower . Scim.userName $ user
   -- FUTUREWORK: 'Scim.userName' should be case insensitive; then the toLower here would
   -- be a little less brittle.
@@ -234,28 +234,28 @@ validateScimUser' midp richInfoLimit user = do
             }
       pure richInfo
 
--- | Given an 'externalId' and an 'IdP', construct a 'SAML.UserRef'.
+-- | Given an 'externalId' and an 'IdP', construct a 'ST.ValidExternalId'.
 --
 -- This is needed primarily in 'validateScimUser', but also in 'updateValidScimUser' to
 -- recover the 'SAML.UserRef' of the scim user before the update from the database.
-mkUserRef ::
+mkValidExternalId ::
   forall m.
   (MonadError Scim.ScimError m) =>
   Maybe IdP ->
   Maybe Text ->
   m ST.ValidExternalId
-mkUserRef _ Nothing = do
+mkValidExternalId _ Nothing = do
   throwError $
     Scim.badRequest
       Scim.InvalidValue
       (Just "externalId is required for SAML users")
-mkUserRef Nothing (Just extid) = do
+mkValidExternalId Nothing (Just extid) = do
   let err =
         Scim.badRequest
           Scim.InvalidValue
           (Just "externalId must be a valid email address or (if there is a SAML IdP) a valid SAML NameID")
   maybe (throwError err) (pure . ST.EmailOnly) $ parseEmail extid
-mkUserRef (Just idp) (Just extid) = do
+mkValidExternalId (Just idp) (Just extid) = do
   let issuer = idp ^. SAML.idpMetadata . SAML.edIssuer
   subject <- validateSubject extid
   let uref = SAML.UserRef issuer subject
@@ -664,7 +664,7 @@ scimFindUserByHandle mIdpConfig stiTeam hndl = do
 -- successful authentication with their SAML credentials.
 scimFindUserByEmail :: Maybe IdP -> TeamId -> Text -> MaybeT (Scim.ScimHandler Spar) (Scim.StoredUser ST.SparTag)
 scimFindUserByEmail mIdpConfig stiTeam email = do
-  veid <- mkUserRef mIdpConfig (pure email)
+  veid <- mkValidExternalId mIdpConfig (pure email)
   uid <- MaybeT . lift $ ST.runValidExternalId withUref withEmailOnly veid
   brigUser <- MaybeT . lift . Brig.getBrigUserAccount $ uid
   guard $ userTeam (accountUser brigUser) == Just stiTeam
@@ -679,6 +679,8 @@ scimFindUserByEmail mIdpConfig stiTeam email = do
     withEmailOnly :: BT.Email -> Spar (Maybe UserId)
     withEmailOnly eml = maybe inbrig (pure . Just) =<< inspar
       where
+        -- FUTUREWORK: we could also always lookup brig, that's simpler and possibly faster,
+        -- and it never should be visible in spar, but not in brig.
         inspar, inbrig :: Spar (Maybe UserId)
         inspar = wrapMonadClient $ Data.lookupScimExternalId eml
         inbrig = userId . accountUser <$$> Brig.getBrigUserByEmail eml

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -671,7 +671,10 @@ scimFindUserByEmail mIdpConfig stiTeam email = do
   lift $ synthesizeStoredUser brigUser veid
   where
     withUref :: SAML.UserRef -> Spar (Maybe UserId)
-    withUref = wrapMonadClient . Data.getSAMLUser
+    withUref uref = do
+      wrapMonadClient (Data.getSAMLUser uref) >>= \case
+        Nothing -> maybe (pure Nothing) withEmailOnly $ Brig.urefToEmail uref
+        Just uid -> pure (Just uid)
 
     withEmailOnly :: BT.Email -> Spar (Maybe UserId)
     withEmailOnly eml = maybe inbrig (pure . Just) =<< inspar

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -1067,7 +1067,7 @@ testUpdateExternalId withidp = do
         storedUser <- createUser tok user
         let userid = scimUserId storedUser
         veid :: ValidExternalId <-
-          either (error . show) pure $ mkUserRef midp (Scim.User.externalId user)
+          either (error . show) pure $ mkValidExternalId midp (Scim.User.externalId user)
         -- Overwrite the user with another randomly-generated user (only controlling externalId)
         user' <- do
           otherEmail <- randomEmail
@@ -1079,7 +1079,7 @@ testUpdateExternalId withidp = do
                         else Scim.User.externalId user
                   }
           randomScimUser <&> upd
-        let veid' = either (error . show) id $ mkUserRef midp (Scim.User.externalId user')
+        let veid' = either (error . show) id $ mkValidExternalId midp (Scim.User.externalId user')
 
         _ <- updateUser tok userid user'
 
@@ -1426,7 +1426,7 @@ specEmailValidation = do
           scimStoredUser <- createUser tok user
           uref :: SAML.UserRef <-
             either (error . show) (pure . (^?! veidUref)) $
-              mkUserRef (Just idp) (Scim.User.externalId . Scim.value . Scim.thing $ scimStoredUser)
+              mkValidExternalId (Just idp) (Scim.User.externalId . Scim.value . Scim.thing $ scimStoredUser)
           uid :: UserId <-
             getUserIdViaRef uref
           brig <- asks (^. teBrig)

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -564,10 +564,14 @@ specListUsers = describe "GET /Users" $ do
   it "lists all SCIM users in a team" $ testListProvisionedUsers
   context "1 SAML IdP" $ do
     it "finds a SCIM-provisioned user by userName or externalId" $ testFindProvisionedUser
-    it "finds a non-SCIM-provisioned user by userName or externalId" $ testFindNonProvisionedUser
+    it "finds a user autoprovisioned via saml by externalId via email" $ testFindSamlAutoProvisionedUserMigratedWithEmailInTeamWithSSO
+    it "finds a user invited via team settings by externalId via email" $ testFindTeamSettingsInvitedUserMigratedWithEmailInTeamWithSSO
+    it "finds a user invited via team settings by UserId" $ testFindTeamSettingsInvitedUserMigratedWithEmailInTeamWithSSOViaUserId
   context "0 SAML IdP" $ do
     it "finds a SCIM-provisioned user by userName or externalId" $ testFindProvisionedUserNoIdP
-    it "finds a non-SCIM-provisioned user by userName or externalId" $ testFindNonProvisionedUserNoIdP
+    it "finds a non-SCIM-provisioned user by userName" $ testFindNonProvisionedUserNoIdP FindByHandle
+    it "finds a non-SCIM-provisioned user by externalId" $ testFindNonProvisionedUserNoIdP FindByExternalId
+    it "finds a non-SCIM-provisioned user by UserId" $ testFindNonProvisionedUserNoIdP GetByUserId
   it "doesn't list deleted users" $ testListNoDeletedUsers
   it "doesnt't find deleted users by userName or externalId" $ testFindNoDeletedUsers
   it "doesn't list users from other teams" $ testUserListFailsWithNotFoundIfOutsideTeam
@@ -594,33 +598,66 @@ testFindProvisionedUser = do
   users' <- listUsers tok (Just (filterBy "externalId" externalId))
   liftIO $ users' `shouldBe` [storedUser]
 
--- When explicitly filtering, we should be able to find non-SCIM-provisioned users
-testFindNonProvisionedUser :: HasCallStack => TestSpar ()
-testFindNonProvisionedUser = do
-  (_, teamid, idp, (_, privCreds)) <- registerTestIdPWithMeta
-  member <- loginSsoUserFirstTime idp privCreds
-  -- NOTE: once SCIM is enabled SSO Auto-provisioning is disabled
+-- The user is migrated by using the email as the externalId
+testFindSamlAutoProvisionedUserMigratedWithEmailInTeamWithSSO :: TestSpar ()
+testFindSamlAutoProvisionedUserMigratedWithEmailInTeamWithSSO = do
+  (_owner, teamid, idp, (_, privCreds)) <- registerTestIdPWithMeta
+
+  -- auto-provision user via saml
+  memberWithSSO <- do
+    uid <- loginSsoUserFirstTime idp privCreds
+    Just usr <- runSpar $ Intra.getBrigUser uid
+    handle <- nextHandle
+    runSpar $ Intra.setBrigUserHandle uid handle
+    pure usr
+  let memberIdWithSSO = userId memberWithSSO
+      externalId = either error id $ Intra.userToExternalId memberWithSSO
+
+  -- NOTE: once SCIM is enabled, SSO auto-provisioning is disabled
   tok <- registerScimToken teamid (Just (idp ^. SAML.idpId))
-  handle <- nextHandle
-  runSpar $ Intra.setBrigUserHandle member handle
-  Just brigUser <- runSpar $ Intra.getBrigUser member
-  liftIO $ userManagedBy brigUser `shouldBe` ManagedByWire
-  users <- listUsers tok (Just (filterBy "userName" (fromHandle handle)))
-  liftIO $ (scimUserId <$> users) `shouldContain` [member]
-  Just brigUser' <- runSpar $ Intra.getBrigUser member
+
+  liftIO $ userManagedBy memberWithSSO `shouldBe` ManagedByWire
+  users <- listUsers tok (Just (filterBy "externalId" externalId))
+  liftIO $ (scimUserId <$> users) `shouldContain` [memberIdWithSSO]
+  Just brigUser' <- runSpar $ Intra.getBrigUser memberIdWithSSO
   liftIO $ userManagedBy brigUser' `shouldBe` ManagedByScim
-  _ <- getUser tok member
-  let externalId = either error id $ Intra.userToExternalId brigUser'
-  users' <- listUsers tok (Just (filterBy "externalId" externalId))
-  liftIO $ (scimUserId <$> users') `shouldContain` [member]
+
+testFindTeamSettingsInvitedUserMigratedWithEmailInTeamWithSSO :: TestSpar ()
+testFindTeamSettingsInvitedUserMigratedWithEmailInTeamWithSSO = do
+  env <- ask
+  (tok, (owner, teamid, _idp)) <- registerIdPAndScimToken
+
+  memberInvited <- call (inviteAndRegisterUser (env ^. teBrig) owner teamid)
+  let emailInvited = maybe (error "must have email") fromEmail (userEmail memberInvited)
+      memberIdInvited = userId memberInvited
+
+  users' <- listUsers tok (Just (filterBy "externalId" emailInvited))
+  liftIO $ (scimUserId <$> users') `shouldContain` [memberIdInvited]
+  Just brigUserInvited' <- runSpar $ Intra.getBrigUser (memberIdInvited)
+  liftIO $ userManagedBy brigUserInvited' `shouldBe` ManagedByScim
+
+testFindTeamSettingsInvitedUserMigratedWithEmailInTeamWithSSOViaUserId :: TestSpar ()
+testFindTeamSettingsInvitedUserMigratedWithEmailInTeamWithSSOViaUserId = do
+  env <- ask
+  (tok, (owner, teamid, _idp)) <- registerIdPAndScimToken
+
+  memberInvited <- call (inviteAndRegisterUser (env ^. teBrig) owner teamid)
+  let memberIdInvited = userId memberInvited
+
+  _ <- getUser tok memberIdInvited
+  Just brigUserInvited' <- runSpar $ Intra.getBrigUser (memberIdInvited)
+  liftIO $ userManagedBy brigUserInvited' `shouldBe` ManagedByScim
 
 testFindProvisionedUserNoIdP :: TestSpar ()
 testFindProvisionedUserNoIdP = do
   -- covered in 'testCreateUserNoIdP' (as of Mon 31 Aug 2020 08:37:05 PM CEST)
   pure ()
 
-testFindNonProvisionedUserNoIdP :: TestSpar ()
-testFindNonProvisionedUserNoIdP = do
+data FindBy = FindByExternalId | FindByHandle | GetByUserId
+  deriving (Eq, Show)
+
+testFindNonProvisionedUserNoIdP :: FindBy -> TestSpar ()
+testFindNonProvisionedUserNoIdP findBy = do
   env <- ask
   (owner, teamid) <- call $ createUserWithTeam (env ^. teBrig) (env ^. teGalley)
   tok <- registerScimToken teamid Nothing
@@ -636,11 +673,13 @@ testFindNonProvisionedUserNoIdP = do
     liftIO $ userManagedBy brigUser `shouldBe` ManagedByWire
     liftIO $ userEmail brigUser `shouldSatisfy` isJust
 
-  byHandle <- listUsers tok (Just (filterBy "userName" (fromHandle handle)))
-  byExternalId <- listUsers tok (Just (filterBy "externalId" (fromEmail email)))
+  users <- case findBy of
+    FindByExternalId -> scimUserId <$$> listUsers tok (Just (filterBy "externalId" (fromEmail email)))
+    FindByHandle -> scimUserId <$$> listUsers tok (Just (filterBy "userName" (fromHandle handle)))
+    GetByUserId -> (: []) . scimUserId <$> getUser tok uid
 
-  for_ [byHandle, byExternalId] $ \users -> do
-    liftIO $ (scimUserId <$> users) `shouldBe` [uid]
+  do
+    liftIO $ users `shouldBe` [uid]
     Just brigUser' <- runSpar $ Intra.getBrigUser uid
     liftIO $ userManagedBy brigUser' `shouldBe` ManagedByScim
     liftIO $ brigUser' `shouldBe` brigUser {userManagedBy = ManagedByScim}


### PR DESCRIPTION
When a user has been invited to a team with SAML IdP via team settings, and then is searched via SCIM, the user won't be found and bound.  This is most likely because spar doesn't treat the email address that is the `externalId`  as an email, but as a SAML `NameID`.

This PR will fix this.

Fixes https://github.com/zinfra/backend-issues/issues/1572