### PR TITLE
Drop unused types.

### DIFF
--- a/libs/api-bot/src/Network/Wire/Bot/Crypto.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Crypto.hs
@@ -139,7 +139,6 @@ encryptMessage clt cnv msg =
     <$> encrypt clt cnv msg
     <*> pure False -- Native push?
     <*> pure False -- Transient?
-    <*> pure Nothing -- Priority
     <*> pure Nothing -- Extra data distributed to all recipients
     <*> pure Nothing
 

--- a/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
+++ b/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
@@ -33,7 +33,6 @@ module Gundeck.Types.Push.V2
     pushNativeIncludeOrigin,
     pushNativeEncrypt,
     pushNativeAps,
-    pushNativePriority,
     pushPayload,
     singletonRecipient,
     singletonPayload,
@@ -54,9 +53,6 @@ module Gundeck.Types.Push.V2
     apsSound,
     apsPreference,
     apsBadge,
-
-    -- * Priority (re-export)
-    Priority (..),
 
     -- * PushToken (re-export)
     PushTokenList (..),
@@ -84,7 +80,6 @@ import Data.Range
 import qualified Data.Range as Range
 import qualified Data.Set as Set
 import Imports
-import Wire.API.Message (Priority (..))
 import Wire.API.Push.V2.Token
 
 -----------------------------------------------------------------------------
@@ -257,8 +252,6 @@ data Push = Push
     _pushNativeEncrypt :: !Bool,
     -- | APNs-specific metadata.  REFACTOR: can this be removed?
     _pushNativeAps :: !(Maybe ApsData),
-    -- | Native push priority.
-    _pushNativePriority :: !Priority,
     -- | Opaque payload
     _pushPayload :: !(List1 Object)
   }
@@ -277,7 +270,6 @@ newPush from to pload =
       _pushNativeIncludeOrigin = True,
       _pushNativeEncrypt = True,
       _pushNativeAps = Nothing,
-      _pushNativePriority = HighPriority,
       _pushPayload = pload
     }
 
@@ -297,7 +289,6 @@ instance FromJSON Push where
       <*> p .:? "native_include_origin" .!= True
       <*> p .:? "native_encrypt" .!= True
       <*> p .:? "native_aps"
-      <*> p .:? "native_priority" .!= HighPriority
       <*> p .: "payload"
 
 instance ToJSON Push where
@@ -311,7 +302,6 @@ instance ToJSON Push where
         # "native_include_origin" .= ifNot (== True) (_pushNativeIncludeOrigin p)
         # "native_encrypt" .= ifNot (== True) (_pushNativeEncrypt p)
         # "native_aps" .= _pushNativeAps p
-        # "native_priority" .= ifNot (== HighPriority) (_pushNativePriority p)
         # "payload" .= _pushPayload p
         # []
     where

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
@@ -141,7 +141,6 @@ tests =
       testRoundTrip @Event.Conversation.OtrMessage,
       currentlyFailing (testRoundTrip @Event.Team.Event), -- flaky, fails because of TeamUpdateData
       testRoundTrip @Event.Team.EventType,
-      testRoundTrip @Message.Priority,
       testRoundTrip @Message.OtrRecipients,
       testRoundTrip @Message.NewOtrMessage,
       currentlyFailing (testRoundTrip @Message.ClientMismatch), -- because ToJSON is rounding UTCTime

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -627,7 +627,7 @@ postOtrBroadcast zusr zcon val message =
 -- in the filter query than fits the url length limit.  for details, see
 -- https://github.com/zinfra/backend-issues/issues/1248
 allowOtrFilterMissingInBody :: OtrFilterMissing -> NewOtrMessage -> OtrFilterMissing
-allowOtrFilterMissingInBody val (NewOtrMessage _ _ _ _ _ _ mrepmiss) = case mrepmiss of
+allowOtrFilterMissingInBody val (NewOtrMessage _ _ _ _ _ mrepmiss) = case mrepmiss of
   Nothing -> val
   Just uids -> OtrReportMissing $ Set.fromList uids
 
@@ -690,7 +690,6 @@ newMessage usr con cnv msg now (m, c, t) ~(toBots, toUsers) =
           let p =
                 newPush ListComplete (evtFrom e) (ConvEvent e) [r]
                   <&> set pushConn con
-                    . set pushNativePriority (newOtrNativePriority msg)
                     . set pushRoute (bool RouteDirect RouteAny (newOtrNativePush msg))
                     . set pushTransient (newOtrTransient msg)
            in (toBots, p : toUsers)

--- a/services/galley/src/Galley/Intra/Push.hs
+++ b/services/galley/src/Galley/Intra/Push.hs
@@ -31,7 +31,6 @@ module Galley.Intra.Push
     pushConn,
     pushTransient,
     pushRoute,
-    pushNativePriority,
     pushAsync,
 
     -- * Push Recipients
@@ -43,14 +42,13 @@ module Galley.Intra.Push
 
     -- * Re-Exports
     Gundeck.Route (..),
-    Gundeck.Priority (..),
   )
 where
 
 import Bilge hiding (options)
 import Bilge.RPC
 import Bilge.Retry
-import Control.Lens (makeLenses, set, view, (&), (.~), (^.))
+import Control.Lens (makeLenses, view, (&), (.~), (^.))
 import Control.Monad.Catch
 import Control.Retry
 import Data.Aeson (Object)
@@ -109,7 +107,6 @@ data PushTo user = Push
   { _pushConn :: Maybe ConnId,
     _pushTransient :: Bool,
     _pushRoute :: Gundeck.Route,
-    _pushNativePriority :: Maybe Gundeck.Priority,
     _pushAsync :: Bool,
     pushOrigin :: UserId,
     pushRecipients :: List1 (RecipientBy user),
@@ -126,7 +123,6 @@ newPush1 recipientListType from e rr =
     { _pushConn = Nothing,
       _pushTransient = False,
       _pushRoute = Gundeck.RouteAny,
-      _pushNativePriority = Nothing,
       _pushAsync = False,
       pushRecipientListType = recipientListType,
       pushJson = pushEventJson e,
@@ -201,7 +197,6 @@ pushLocal ps = do
        in Gundeck.newPush (pushOrigin p) (unsafeRange (Set.fromList r)) pload
             & Gundeck.pushOriginConnection .~ _pushConn p
             & Gundeck.pushTransient .~ _pushTransient p
-            & maybe id (set Gundeck.pushNativePriority) (_pushNativePriority p)
     toRecipient p r =
       Gundeck.recipient (_recipientUserId r) (_pushRoute p)
         & Gundeck.recipientClients .~ _recipientClients r

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -345,16 +345,14 @@ nativeTargets psh rcps' alreadySent =
     -- same client (currently only APNS vs APNS VoIP). If no explicit
     -- preference is given, the default preference depends on the priority.
     preference as =
-      let pref = psh ^. pushNativeAps >>= view apsPreference
-          defPreference = ApsVoIPPreference
-       in filter (pick (fromMaybe defPreference pref)) as
+      filter pick as
       where
-        pick pr a = case a ^. addrTransport of
+        pick a = case a ^. addrTransport of
           GCM -> True
-          APNS -> pr == ApsStdPreference || notAny a APNSVoIP
-          APNSSandbox -> pr == ApsStdPreference || notAny a APNSVoIPSandbox
-          APNSVoIP -> pr == ApsVoIPPreference || notAny a APNS
-          APNSVoIPSandbox -> pr == ApsVoIPPreference || notAny a APNSSandbox
+          APNS -> notAny a APNSVoIP
+          APNSSandbox -> notAny a APNSVoIPSandbox
+          APNSVoIP -> True
+          APNSVoIPSandbox -> True
         notAny a t =
           not
             ( any

--- a/services/gundeck/src/Gundeck/Push/Native/Types.hs
+++ b/services/gundeck/src/Gundeck/Push/Native/Types.hs
@@ -105,6 +105,5 @@ data Failure
 
 data NativePush = NativePush
   { npNotificationid :: NotificationId,
-    npPriority :: Priority,
     npApsData :: Maybe ApsData
   }

--- a/services/gundeck/test/bench/Main.hs
+++ b/services/gundeck/test/bench/Main.hs
@@ -56,7 +56,7 @@ notice :: IO Text
 notice = do
   i <- randomId
   a <- mkAddress GCM
-  let msg = NativePush i HighPriority Nothing
+  let msg = NativePush i Nothing
   Right txt <- serialise msg a
   return $! LT.toStrict txt
 

--- a/services/gundeck/test/unit/MockGundeck.hs
+++ b/services/gundeck/test/unit/MockGundeck.hs
@@ -597,10 +597,9 @@ mockStreamAdd _ (toList -> targets) pay _ =
 mockPushNative ::
   (HasCallStack, m ~ MockGundeck) =>
   Notification ->
-  Push ->
   [Address] ->
   m ()
-mockPushNative _nid ((^. pushPayload) -> payload) addrs = do
+mockPushNative (ntfPayload -> payload) addrs = do
   env <- ask
   forM_ addrs $ \addr -> do
     when (nativeReachableAddr env addr) $

--- a/services/gundeck/test/unit/Native.hs
+++ b/services/gundeck/test/unit/Native.hs
@@ -152,7 +152,7 @@ randNotif size = do
     Notification i <$> arbitrary <*> pure pload
 
 randMessage :: Notification -> IO NativePush
-randMessage n = pure $ NativePush (ntfId n) HighPriority Nothing
+randMessage n = pure $ NativePush (ntfId n) Nothing
 
 -----------------------------------------------------------------------------
 -- Utilities


### PR DESCRIPTION
I'm a bit nervous about this one.

- The types tell me I'm right, and as the haddocks of the `Priority` type state, the evidene is in favor of this. 
- Worst thing that can happen is that we'll want to send low-priority messages in the future for some reason, and won't be able to (first commit), or that we'll want to change the order of preference between different types (second commit); both seem unlikely to me.

But I have little context in this matter.

I'll open it anyway as a PR, since writing it helped me understand the code better, and what belongs to what; perhaps reading it will help, too.  Happy to have it rejected.  :)