### PR TITLE
add libtinfo/ncurses to docs and nix deps

### DIFF
--- a/docs/developer/dependencies.md
+++ b/docs/developer/dependencies.md
@@ -178,8 +178,3 @@ Using Stack's [Nix integration](https://docs.haskellstack.org/en/stable/nix_inte
 dependencies automatically - including `cryptobox-c`. If new system dependencies are needed, add them to the `stack-deps.nix` file in the project root.
 Just type `$ nix-shell` and you will automatically have `make`, `docker-compose` and `stack` in `PATH`.
 You can then run all the builds, and the native dependencies will be automatically present.
-
-Nix might only ship a more recent minor version of GHC than the current Stackage snapshot specifies. The releases should be totally compatible, but we need to convince stack that this is true. Hence, we can add the following to our global stack config in `~/.stack/config.yaml`
-```bash
-skip-ghc-check: true
-```

--- a/docs/developer/dependencies.md
+++ b/docs/developer/dependencies.md
@@ -175,11 +175,11 @@ docker login --username=<MY_DOCKER_USERNAME>
 ## Nix
 
 Using Stack's [Nix integration](https://docs.haskellstack.org/en/stable/nix_integration/), Stack will take care of installing any system
-dependencies automatically - including `cryptobox-c`. If new system dependencies are needed, add them to the `shell.nix` file in the project root.
+dependencies automatically - including `cryptobox-c`. If new system dependencies are needed, add them to the `stack-deps.nix` file in the project root.
 Just type `$ nix-shell` and you will automatically have `make`, `docker-compose` and `stack` in `PATH`.
 You can then run all the builds, and the native dependencies will be automatically present.
 
-We are currently on a snapshot that uses `ghc863` but Nix only ships `ghc864` as `ghc863` is officially deprecated. The releases should be totally compatible, but we need to convince stack that this is true. Hence, we can add the following to our global stack config in `~/.stack/config.yaml`
+Nix might only ship a more recent minor version of GHC than the current Stackage snapshot specifies. The releases should be totally compatible, but we need to convince stack that this is true. Hence, we can add the following to our global stack config in `~/.stack/config.yaml`
 ```bash
 skip-ghc-check: true
 ```

--- a/docs/developer/dependencies.md
+++ b/docs/developer/dependencies.md
@@ -20,7 +20,7 @@ sudo dnf install -y pkgconfig haskell-platform libstdc++-devel libstdc++-static 
 _Note_: Debian is not recommended due to this issue when running local integration tests: [#327](https://github.com/wireapp/wire-server/issues/327). This issue does not occur with Ubuntu.
 
 ```bash
-sudo apt install pkg-config libsodium-dev openssl-dev libtool automake build-essential libicu-dev libsnappy-dev libgeoip-dev protobuf-compiler libxml2-dev zlib1g-dev -y
+sudo apt install pkg-config libsodium-dev openssl-dev libtool automake build-essential libicu-dev libsnappy-dev libgeoip-dev protobuf-compiler libxml2-dev zlib1g-dev libtinfo-dev -y
 ```
 
 If `openssl-dev` does not work for you, try `libssl-dev`.
@@ -30,7 +30,7 @@ If `openssl-dev` does not work for you, try `libssl-dev`.
 ```
 # You might also need 'sudo pacman -S base-devel' if you haven't
 # installed the base-devel group already.
-sudo pacman -S geoip snappy icu openssl
+sudo pacman -S geoip snappy icu openssl ncurses-compat-libs
 ```
 
 ### macOS:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -16,7 +16,7 @@
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
-        "repo": "nixpkgs-channels",
+        "repo": "nixpkgs",
         "rev": "502845c3e31ef3de0e424f3fcb09217df2ce6df6",
         "sha256": "0fcqpsy6y7dgn0y0wgpa56gsg0b0p8avlpjrd79fp4mp9bl18nda",
         "type": "tarball",

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "ab9cc41caf44d1f1d465d8028e4bc0096fd73238",
-        "sha256": "17k52n8zwp832cqifsc4458mhy4044wmk22f807171hf6p7l4xvr",
+        "rev": "9d35b9e4837ab88517210b1701127612c260eccf",
+        "sha256": "0q50xhnm8g2yfyakrh0nly4swyygxpi0a8cb9gp65wcakcgvzvdh",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/ab9cc41caf44d1f1d465d8028e4bc0096fd73238.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/9d35b9e4837ab88517210b1701127612c260eccf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "6d4b93323e7f78121f8d6db6c59f3889aa1dd931",
-        "sha256": "0g2j41cx2w2an5d9kkqvgmada7ssdxqz1zvjd7hi5vif8ag0v5la",
+        "rev": "502845c3e31ef3de0e424f3fcb09217df2ce6df6",
+        "sha256": "0fcqpsy6y7dgn0y0wgpa56gsg0b0p8avlpjrd79fp4mp9bl18nda",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/6d4b93323e7f78121f8d6db6c59f3889aa1dd931.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/502845c3e31ef3de0e424f3fcb09217df2ce6df6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/stack-deps.nix
+++ b/stack-deps.nix
@@ -10,6 +10,7 @@ pkgs.haskell.lib.buildStackProject {
     icu
     libsodium
     libxml2
+    ncurses
     openssl
     pkgconfig
     protobuf


### PR DESCRIPTION
proto-lens-protoc switched to ghc-source-gen, which requires libtinfo.

Don't know what the equivalent on macOS is and if it's even needed. Didn't find it with some googling.
Also not sure if the Nix dependency is the right one. Please tell me if it's not right.