### PR TITLE
Fix compilation in fisx's weird dev env.

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7c9aee98315a9a56aa48fcb0af9a9e82954d9913fc94cafa512a0811f40b2ad3
+-- hash: 82d006499cc245f9cd8ca75f3293023302984a4172a6252daf0e471b8d8af304
 
 name:           brig
 version:        1.35.0
@@ -310,6 +310,7 @@ executable brig-integration
     , containers
     , cookie
     , data-timeout
+    , dns
     , exceptions
     , extra
     , filepath >=1.4

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -193,6 +193,7 @@ executables:
     - containers
     - cookie
     - data-timeout
+    - dns
     - extra
     - exceptions
     - filepath >=1.4


### PR DESCRIPTION
Without this change, I can't compile brig integration tests in my repl any more.  One hypothesis is that this is because I'm loading modules from `/services/brig/src` directly, rather than loading the compiled package, but I haven't confirmed that.

This seems safe to me: it only affects the integration test executable, and that should already have this dependency transitively anyway.