### PR TITLE
More debug logging for native push notifications.

### DIFF
--- a/services/gundeck/src/Gundeck/Push/Native.hs
+++ b/services/gundeck/src/Gundeck/Push/Native.hs
@@ -24,6 +24,7 @@ where
 
 import Control.Lens (view, (.~), (^.))
 import Control.Monad.Catch
+import Data.Aeson (encode)
 import Data.ByteString.Conversion.To
 import Data.Id
 import Data.List1
@@ -68,6 +69,9 @@ push1 m a = do
       Log.debug $
         field "user" (toByteString (a ^. addrUser))
           ~~ field "arn" (toText (a ^. addrEndpoint))
+          ~~ field "notification_id" (toText (npNotificationid m))
+          ~~ field "prio" (show (npPriority m))
+          ~~ field "payload" (encode (npApsData m))
           ~~ Log.msg (val "Native push success")
       view monitor >>= counterIncr (path "push.native.success")
     Failure EndpointDisabled _ -> onDisabled


### PR DESCRIPTION
Needed to debug native push notifications on staging.

This will make the logs contain user-identifying information, but not content.  I think we're already at that point, and anyway it's log level `DEBUG`, so I think this is fine.