### PR TITLE
[skip ci] SCIM Test Suite

### DIFF
--- a/services/integration.sh
+++ b/services/integration.sh
@@ -163,10 +163,6 @@ while [ "$all_services_are_up" == "" ]; do
 done
 echo "all services are up!"
 
-if [[ ! $INTEGRATION_SKIP_SCIM_SUITE -eq 1 ]]; then
-    make local -C "$TOP_LEVEL/ervices/spar/test-scim-suite" || (kill_gracefully && wait && exit 1)
-fi
-
 ( ${EXE} "${@:2}" && echo 0 > "${EXIT_STATUS_LOCATION}" && kill_gracefully ) || kill_gracefully &
 
 wait

--- a/services/integration.sh
+++ b/services/integration.sh
@@ -163,6 +163,10 @@ while [ "$all_services_are_up" == "" ]; do
 done
 echo "all services are up!"
 
+if [[ ! $INTEGRATION_SKIP_SCIM_SUITE -eq 1 ]]; then
+    make local -C "$TOP_LEVEL/ervices/spar/test-scim-suite" || (kill_gracefully && wait && exit 1)
+fi
+
 ( ${EXE} "${@:2}" && echo 0 > "${EXIT_STATUS_LOCATION}" && kill_gracefully ) || kill_gracefully &
 
 wait

--- a/services/spar/Makefile
+++ b/services/spar/Makefile
@@ -66,7 +66,10 @@ $(DEB_SCHEMA): install
 
 .PHONY: i
 i:
-	../integration.sh $(EXE_IT) -s $(NAME).integration.yaml -i ../integration.yaml $(WIRE_INTEGRATION_TEST_OPTIONS)
+	../integration.sh bash -c "\
+	./test-scim-suite/runsuite.sh && \
+	$(EXE_IT) -s $(NAME).integration.yaml -i ../integration.yaml $(WIRE_INTEGRATION_TEST_OPTIONS) \
+	"
 
 .PHONY: i-aws
 i-aws:

--- a/services/spar/Makefile
+++ b/services/spar/Makefile
@@ -77,7 +77,7 @@ i-list:
 	$(EXE_IT) -s $(NAME).integration.yaml -i ../integration.yaml -l
 
 i-%:
-	../integration.sh $(EXE_IT) -s $(NAME).integration.yaml -i ../integration.yaml --match="$*" $(WIRE_INTEGRATION_TEST_OPTIONS)
+	INTEGRATION_SKIP_SCIM_SUITE=1 ../integration.sh $(EXE_IT) -s $(NAME).integration.yaml -i ../integration.yaml --match="$*" $(WIRE_INTEGRATION_TEST_OPTIONS)
 
 .PHONY: integration
 integration: fast i

--- a/services/spar/test-scim-suite/Makefile
+++ b/services/spar/test-scim-suite/Makefile
@@ -1,0 +1,20 @@
+.DEFAULT_GOAL := local
+
+.PHONY: clean
+clean:
+	rm -f /tmp/scim_test_suite.json
+
+/tmp/3b5c4b838ec66cacd53b.json:
+	wget --no-check-certificate https://www.getpostman.com/collections/3b5c4b838ec66cacd53b -O /tmp/3b5c4b838ec66cacd53b.json
+
+/tmp/scim_test_suite.json: /tmp/3b5c4b838ec66cacd53b.json setup.js update.jq
+	./mk_collection.sh /tmp/3b5c4b838ec66cacd53b.json > /tmp/scim_test_suite.json
+
+local: /tmp/scim_test_suite.json
+	SCIM_TEST_SUITE_SPAR_HOST=localhost \
+	SCIM_TEST_SUITE_SPAR_PORT=8088 \
+	SCIM_TEST_SUITE_BRIG_HOST=localhost \
+	SCIM_TEST_SUITE_BRIG_PORT=8082 \
+	./run.sh /tmp/scim_test_suite.json --folder "User tests" --folder "User tests with garbage"
+
+collection: /tmp/scim_test_suite.json

--- a/services/spar/test-scim-suite/Makefile
+++ b/services/spar/test-scim-suite/Makefile
@@ -1,4 +1,4 @@
-.DEFAULT_GOAL := local
+collection: /tmp/scim_test_suite.json
 
 .PHONY: clean
 clean:
@@ -9,12 +9,3 @@ clean:
 
 /tmp/scim_test_suite.json: /tmp/3b5c4b838ec66cacd53b.json setup.js update.jq
 	./mk_collection.sh /tmp/3b5c4b838ec66cacd53b.json > /tmp/scim_test_suite.json
-
-local: /tmp/scim_test_suite.json
-	SCIM_TEST_SUITE_SPAR_HOST=localhost \
-	SCIM_TEST_SUITE_SPAR_PORT=8088 \
-	SCIM_TEST_SUITE_BRIG_HOST=localhost \
-	SCIM_TEST_SUITE_BRIG_PORT=8082 \
-	./run.sh /tmp/scim_test_suite.json --folder "User tests" --folder "User tests with garbage"
-
-collection: /tmp/scim_test_suite.json

--- a/services/spar/test-scim-suite/README.md
+++ b/services/spar/test-scim-suite/README.md
@@ -5,18 +5,17 @@ The scripts in this directory allow to run the [SCIM Test Suite](https://github.
 How to run:
 ```sh
 ./services/start-services-only.sh
-cd services/spar/test-scim-suite/
-nix-shell
-make
+./services/spar/test-scim-suite/runsuite.sh
 ```
 
 This will download the Postman collection, patch it and then call `newman` (the cli tool from Postman) to run the tests.
 
 It is also possible to run the tests from the test suite manually:
 
-1. Run `make collection`.
-2. In Postman "Import" the collection `/tmp/scim_test_suite.json`
-3. Create an environment in Postman with these variables
+1. Run `nix-shell`.
+2. Run `make collection`.
+3. In Postman "Import" the collection `/tmp/scim_test_suite.json`
+4. Create an environment in Postman with these variables
 
 ```
 Server: "localhost"

--- a/services/spar/test-scim-suite/README.md
+++ b/services/spar/test-scim-suite/README.md
@@ -1,7 +1,6 @@
 ## Scim Test Suite
 
-The scripts in this directory allow to run the [SCIM Test Suite](https://github.com/AzureAD/SCIMReferenceCode/wiki/Test-Your-SCIM-Endpoint) provided by Microsoft (a [Postman](https://www.postman.com/) collection) provided here
-against the SCIM implementation in spar.
+The scripts in this directory allow to run the [SCIM Test Suite](https://github.com/AzureAD/SCIMReferenceCode/wiki/Test-Your-SCIM-Endpoint) provided by Microsoft (a [Postman](https://www.postman.com/) collection) against the SCIM implementation in spar.
 
 How to run:
 ```sh

--- a/services/spar/test-scim-suite/README.md
+++ b/services/spar/test-scim-suite/README.md
@@ -1,5 +1,6 @@
-The scripts in this directory allow to run the SCIM Test Suite (a [Postman](https://www.postman.com/) collection) provided here
-https://github.com/AzureAD/SCIMReferenceCode/wiki/Test-Your-SCIM-Endpoint
+## Scim Test Suite
+
+The scripts in this directory allow to run the [SCIM Test Suite](https://github.com/AzureAD/SCIMReferenceCode/wiki/Test-Your-SCIM-Endpoint) provided by Microsoft (a [Postman](https://www.postman.com/) collection) provided here
 against the SCIM implementation in spar.
 
 How to run:
@@ -10,13 +11,13 @@ nix-shell
 make
 ```
 
-This will download the Postman collection, patch it and use `newman` to run.
+This will download the Postman collection, patch it and then call `newman` (the cli tool from Postman) to run the tests.
 
-It's also possible to run the tests from the suite manually in Postman:
+It is also possible to run the tests from the test suite manually:
 
 1. Run `make collection`.
 2. In Postman "Import" the collection `/tmp/scim_test_suite.json`
-3. Create an environment with these varibles
+3. Create an environment in Postman with these variables
 
 ```
 Server: "localhost"
@@ -30,4 +31,4 @@ When running tests multiple times you have to manually reset the variable `wire_
 
 Note:
 When running test manually be aware of timeout settings in the services config, which are typically set to only a few seconds.
-If you are not fast enough manully you might get different results than running the suite with `newman`.
+If you are not fast enough you might get different results than running the suite with `newman`.

--- a/services/spar/test-scim-suite/README.md
+++ b/services/spar/test-scim-suite/README.md
@@ -1,0 +1,33 @@
+The scripts in this directory allow to run the SCIM Test Suite (a [Postman](https://www.postman.com/) collection) provided here
+https://github.com/AzureAD/SCIMReferenceCode/wiki/Test-Your-SCIM-Endpoint
+against the SCIM implementation in spar.
+
+How to run:
+```sh
+./services/start-services-only.sh
+cd services/spar/test-scim-suite/
+nix-shell
+make
+```
+
+This will download the Postman collection, patch it and use `newman` to run.
+
+It's also possible to run the tests from the suite manually in Postman:
+
+1. Run `make collection`.
+2. In Postman "Import" the collection `/tmp/scim_test_suite.json`
+3. Create an environment with these varibles
+
+```
+Server: "localhost"
+Port:   ":8088"
+Api:    "scim/v2"
+```
+
+4. Run the steps from the suite
+
+When running tests multiple times you have to manually reset the variable `wire_setup_complete` (See `setup.js`).
+
+Note:
+When running test manually be aware of timeout settings in the services config, which are typically set to only a few seconds.
+If you are not fast enough manully you might get different results than running the suite with `newman`.

--- a/services/spar/test-scim-suite/mk_collection.sh
+++ b/services/spar/test-scim-suite/mk_collection.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+setup_js_jsonlines=$(mktemp /tmp/setup_inline_XXXXXXX.json)
+cat ./setup.js | python3 -c '
+import sys, json;
+print(json.dumps(sys.stdin.read().splitlines()))
+' > $setup_js_jsonlines
+
+jq --slurpfile setup_inline "$setup_js_jsonlines" -f ./update.jq $1

--- a/services/spar/test-scim-suite/run.sh
+++ b/services/spar/test-scim-suite/run.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -eu
+
+function create_team_and_scim_token {
+    TOP_LEVEL="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../.." && pwd )"
+
+    IFS=',' read -r -a creds <<< $($TOP_LEVEL/deploy/services-demo/create_test_team_admins.sh -c)
+
+    BRIG_HOST="http://$SCIM_TEST_SUITE_BRIG_HOST:$SCIM_TEST_SUITE_BRIG_PORT"
+    WIRE_ADMIN_UUID=${creds[0]}
+    WIRE_ADMIN=${creds[1]}
+    WIRE_PASSWD=${creds[2]}
+
+    export BEARER=$(curl -X POST \
+                        --header 'Content-Type: application/json' \
+                        --header 'Accept: application/json' \
+                        -d '{"email":"'"$WIRE_ADMIN"'","password":"'"$WIRE_PASSWD"'"}' \
+                        $BRIG_HOST/login'?persist=false' | jq -r .access_token)
+
+    SPAR_HOST="http://$SCIM_TEST_SUITE_SPAR_HOST:$SCIM_TEST_SUITE_SPAR_PORT"
+
+    export SCIM_TOKEN_FULL=$(curl -X POST \
+        --header "Authorization: Bearer $BEARER" \
+        --header 'Content-Type: application/json;charset=utf-8' \
+        --header 'Z-User: '"$WIRE_ADMIN_UUID" \
+        -d '{ "description": "test '"`date`"'", "password": "'"$WIRE_PASSWD"'" }' \
+        $SPAR_HOST/scim/auth-tokens)
+
+    export SCIM_TOKEN=$(echo $SCIM_TOKEN_FULL | jq -r .token)
+    export SCIM_TOKEN_ID=$(echo $SCIM_TOKEN_FULL | jq -r .info.id)
+
+    echo $SCIM_TOKEN
+}
+
+function create_env_file {
+    token=$(create_team_and_scim_token)
+    cat > /tmp/scim_test_suite_env.json <<EOF
+{
+  "id": "8b570933-354b-4be9-8b83-c6483a251909",
+  "name": "Environment for SCIM Tests",
+  "values":
+    [
+        {
+            "key": "Server",
+            "value": "$SCIM_TEST_SUITE_SPAR_HOST",
+            "enabled": true
+        },
+        {
+            "key": "Port",
+            "value": ":$SCIM_TEST_SUITE_SPAR_PORT",
+            "enabled": true
+        },
+        {
+            "key": "Api",
+            "value": "scim/v2",
+            "enabled": true
+        },
+        {
+            "key": "token",
+            "value": "$token",
+            "enabled": true
+        }
+    ]
+}
+EOF
+}
+
+create_env_file
+newman run --environment /tmp/scim_test_suite_env.json "$@"

--- a/services/spar/test-scim-suite/run.sh
+++ b/services/spar/test-scim-suite/run.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-
+ 
 set -eu
+
+SCIM_TEST_SUITE_SPAR_HOST=localhost
+SCIM_TEST_SUITE_SPAR_PORT=8088
+SCIM_TEST_SUITE_BRIG_HOST=localhost
+SCIM_TEST_SUITE_BRIG_PORT=8082
 
 function create_team_and_scim_token {
     TOP_LEVEL="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../.." && pwd )"
@@ -67,4 +72,8 @@ EOF
 }
 
 create_env_file
-newman run --environment /tmp/scim_test_suite_env.json "$@"
+newman run \
+       --environment /tmp/scim_test_suite_env.json \
+        /tmp/scim_test_suite.json \
+        --folder "User tests" \
+        --folder "User tests with garbage"

--- a/services/spar/test-scim-suite/runsuite.sh
+++ b/services/spar/test-scim-suite/runsuite.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env nix-shell
+#!nix-shell shell.nix -i bash
+
+set -e
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [[ "$INTEGRATION_SKIP_SCIM_SUITE" -eq 1 ]]; then
+    exit 0
+fi
+
+make collection -C $SOURCE_DIR
+$SOURCE_DIR/run.sh

--- a/services/spar/test-scim-suite/setup.js
+++ b/services/spar/test-scim-suite/setup.js
@@ -1,0 +1,34 @@
+/* This script runs before every request in Postman / Newman */
+
+if (pm.environment.get("wire_setup_complete") !== "complete") {
+    const randomString = function() { return Math.random().toString(36).substr(2, 5); };
+    const randomEmail = function () { return randomString() +  "@example.com";};
+
+    /* Folder: User tests */
+    const user1userName = randomString();
+    pm.environment.set("user1userName", user1userName);
+    /* NOTE: Making assumption here that externalId is an email */
+    pm.environment.set("user1externalId", user1userName + "@example.com");
+    const user2userName = randomString();
+    pm.environment.set("user2userName", user2userName);
+    pm.environment.set("user2externalId", user2userName + "@example.com");
+    const user2userName2 = randomString();
+    pm.environment.set("user2userName2", user2userName2);
+    pm.environment.set("user2externalId2", user2userName2 + "@example.com");
+
+    /* Folder: User tests with garbage */
+    pm.environment.set("garbage1_externalId", randomEmail());
+    pm.environment.set("garbage1_externalId2", randomEmail());
+    pm.environment.set("garbage1_postemp2_externalId", randomEmail());
+    pm.environment.set("garbage1_postemp2_userName", randomString());
+    pm.environment.set("garbage1_postemp3_externalId", randomEmail());
+    pm.environment.set("garbage1_postemp3_username", randomString());
+    pm.environment.set("garbage1_postmisspelled_userName", randomString());
+    pm.environment.set("garbage1_postmisspelled_externalId", randomEmail());
+    pm.environment.set("garbage1_postenterprise_userName", randomString());
+    pm.environment.set("garbage1_postenterprise_externalId", randomEmail());
+    pm.environment.set("garbage1_putomalley_externalId", randomEmail());
+    pm.environment.set("garbage1_putomalley_userName", randomString());
+
+    pm.environment.set("wire_setup_complete", "complete");
+}

--- a/services/spar/test-scim-suite/shell.nix
+++ b/services/spar/test-scim-suite/shell.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import (import ../../../nix/sources.nix).nixpkgs {} }:
+with pkgs;
+mkShell {
+  buildInputs = [newman jq coreutils curl];
+}

--- a/services/spar/test-scim-suite/update.jq
+++ b/services/spar/test-scim-suite/update.jq
@@ -64,7 +64,7 @@
 # Step: Post user "OMalley"
 # Use email instead of uuid
 | (.requests[] | select (.name == "Post user \"OMalley\"") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_externalId}}")
-# Remove this step because the assertion fails: expected 'omalley' to deeply equal 'OMalley'
+# Remove this step because the assertion fails: expected 'omalley' to deeply equal 'OMalley' -- TODO: fix this?
 | del(.requests[] | select (.name == "Post user \"OMalley\""))
 # Step: Post emp1 with string "True"
 | (.requests[] | select (.name == "Post emp1 with string \"True\"") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_externalId2}}")

--- a/services/spar/test-scim-suite/update.jq
+++ b/services/spar/test-scim-suite/update.jq
@@ -71,7 +71,7 @@
 # Remove this step, because it fails with 400:  Error in $.active: expected Bool, but encountered String  -- TODO: fix
 | del(.requests[] | select (.name == "Post emp1 with string \"True\""))
 # Step: Get all users
-# Remove this step because had to remove  'Post user "OMalley"' and 'Post emp1 with string "True"'
+# Remove this step because had to remove  'Post user "OMalley"' and 'Post emp1 with string "True"'  -- TODO: fix?
 | del(.requests[] | select (.id == "4feb34db-d881-4b65-962b-82becad93cff"))
 # Step: Post emp2
 | (.requests[] | select (.name == "Post emp2") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_postemp2_externalId}}")

--- a/services/spar/test-scim-suite/update.jq
+++ b/services/spar/test-scim-suite/update.jq
@@ -103,7 +103,7 @@
 # Step: patch user omalley active with boolean
 | (.requests[] | select (.name == "patch user omalley active with boolean") | .url) |= sub("http://{{Server}}{{Port}}/{{Api}}/Users/{{1stuserid}}";"http://{{Server}}{{Port}}/{{Api}}/Users/{{3rduserid}}")
 | (.requests[] | select (.name == "patch user omalley active with boolean") | .rawModeData) |= sub("{{1stuserid}}";"{{3rduserid}}")
-# Remove this step because it return 204 while 200 is expected
+# Remove this step because it return 204 while 200 is expected  -- TODO: fix
 | del(.requests[] | select (.name == "patch user omalley active with boolean"))
 # Step: get user1
 # Remove this step because we had to remove the previous steps

--- a/services/spar/test-scim-suite/update.jq
+++ b/services/spar/test-scim-suite/update.jq
@@ -64,14 +64,14 @@
 # Step: Post user "OMalley"
 # Use email instead of uuid
 | (.requests[] | select (.name == "Post user \"OMalley\"") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_externalId}}")
-# Remove this step because the assertion fails: expected 'omalley' to deeply equal 'OMalley' -- TODO: fix this?
+# Remove this step because the assertion fails: expected 'omalley' to deeply equal 'OMalley' -- FUTUREWORK: fix this?
 | del(.requests[] | select (.name == "Post user \"OMalley\""))
 # Step: Post emp1 with string "True"
 | (.requests[] | select (.name == "Post emp1 with string \"True\"") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_externalId2}}")
-# Remove this step, because it fails with 400:  Error in $.active: expected Bool, but encountered String  -- TODO: fix
+# Remove this step, because it fails with 400:  Error in $.active: expected Bool, but encountered String  -- FUTUREWORK: fix
 | del(.requests[] | select (.name == "Post emp1 with string \"True\""))
 # Step: Get all users
-# Remove this step because had to remove  'Post user "OMalley"' and 'Post emp1 with string "True"'  -- TODO: fix?
+# Remove this step because had to remove  'Post user "OMalley"' and 'Post emp1 with string "True"'  -- FUTUREWORK: fix?
 | del(.requests[] | select (.id == "4feb34db-d881-4b65-962b-82becad93cff"))
 # Step: Post emp2
 | (.requests[] | select (.name == "Post emp2") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_postemp2_externalId}}")
@@ -103,7 +103,7 @@
 # Step: patch user omalley active with boolean
 | (.requests[] | select (.name == "patch user omalley active with boolean") | .url) |= sub("http://{{Server}}{{Port}}/{{Api}}/Users/{{1stuserid}}";"http://{{Server}}{{Port}}/{{Api}}/Users/{{3rduserid}}")
 | (.requests[] | select (.name == "patch user omalley active with boolean") | .rawModeData) |= sub("{{1stuserid}}";"{{3rduserid}}")
-# Remove this step because it return 204 while 200 is expected  -- TODO: fix
+# Remove this step because it return 204 while 200 is expected  -- FUTUREWORK: fix
 | del(.requests[] | select (.name == "patch user omalley active with boolean"))
 # Step: get user1
 # Remove this step because we had to remove the previous steps
@@ -113,7 +113,7 @@
 | (.requests[] | select (.name == "Put a user OMalley") | .url) |= sub("http://{{Server}}{{Port}}/{{Api}}/Users/{{1stuserid}}";"http://{{Server}}{{Port}}/{{Api}}/Users/{{3rduserid}}")
 | (.requests[] | select (.name == "Put a user OMalley") | .rawModeData) |= sub("{{1stuserid}}";"{{3rduserid}}")
 | (.requests[] | select (.name == "Put a user OMalley") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_putomalley_externalId}}")
-# without this backend responds with 400: UserName has to match UserId -- TODO: fix?
+# without this backend responds with 400: UserName has to match UserId -- FUTUREWORK: fix?
 | (.requests[] | select (.name == "Put a user OMalley") | .rawModeData) |= sub("OMalley";"{{3rduserid}}")
 | (.requests[] | select (.name == "Put a user OMalley") | .events[].script.exec[] ) |= sub("\"OMalley\"";"pm.environment.get(\"3rduserid\")")
 # Remove this step, because can't reproduce the problems manually. FUTUREWORK: explore this. Might have some interaction with step "Patch user omalley new username"
@@ -125,11 +125,11 @@
 # Remove this step, because fails with 400: Please specify a filter when getting users."
 | del(.requests[] | select (.name == "get user attributes"))
 # Step: filter eq and (val or val)
-# Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty  -- TODO: fix at least the error message?
+# Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty  -- FUTUREWORK: fix at least the error message?
 | del(.requests[] | select (.name == "filter eq and (val or val)"))
 # Step: filter starts with
-# Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty -- TODO: fix at least error message
+# Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty -- FUTUREWORK: fix at least error message
 | del(.requests[] | select (.name == "filter starts with"))
 # Step: filter greater than
-# Remove this step, because fails with 400: Error parsing query parameter filter failed: endOfInput -- TODO: fix error message
+# Remove this step, because fails with 400: Error parsing query parameter filter failed: endOfInput -- FUTUREWORK: fix error message
 | del(.requests[] | select (.name == "filter greater than"))

--- a/services/spar/test-scim-suite/update.jq
+++ b/services/spar/test-scim-suite/update.jq
@@ -125,7 +125,7 @@
 # Remove this step, because fails with 400: Please specify a filter when getting users."
 | del(.requests[] | select (.name == "get user attributes"))
 # Step: filter eq and (val or val)
-# Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty
+# Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty  -- TODO: fix at least the error message?
 | del(.requests[] | select (.name == "filter eq and (val or val)"))
 # Step: filter starts with
 # Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty

--- a/services/spar/test-scim-suite/update.jq
+++ b/services/spar/test-scim-suite/update.jq
@@ -113,7 +113,7 @@
 | (.requests[] | select (.name == "Put a user OMalley") | .url) |= sub("http://{{Server}}{{Port}}/{{Api}}/Users/{{1stuserid}}";"http://{{Server}}{{Port}}/{{Api}}/Users/{{3rduserid}}")
 | (.requests[] | select (.name == "Put a user OMalley") | .rawModeData) |= sub("{{1stuserid}}";"{{3rduserid}}")
 | (.requests[] | select (.name == "Put a user OMalley") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_putomalley_externalId}}")
-# without this backend responds with 400: UserName has to match UserId
+# without this backend responds with 400: UserName has to match UserId -- TODO: fix?
 | (.requests[] | select (.name == "Put a user OMalley") | .rawModeData) |= sub("OMalley";"{{3rduserid}}")
 | (.requests[] | select (.name == "Put a user OMalley") | .events[].script.exec[] ) |= sub("\"OMalley\"";"pm.environment.get(\"3rduserid\")")
 # Remove this step, because can't reproduce the problems manually. FUTUREWORK: explore this. Might have some interaction with step "Patch user omalley new username"
@@ -128,8 +128,8 @@
 # Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty  -- TODO: fix at least the error message?
 | del(.requests[] | select (.name == "filter eq and (val or val)"))
 # Step: filter starts with
-# Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty
+# Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty -- TODO: fix at least error message
 | del(.requests[] | select (.name == "filter starts with"))
 # Step: filter greater than
-# Remove this step, because fails with 400: Error parsing query parameter filter failed: endOfInput
+# Remove this step, because fails with 400: Error parsing query parameter filter failed: endOfInput -- TODO: fix error message
 | del(.requests[] | select (.name == "filter greater than"))

--- a/services/spar/test-scim-suite/update.jq
+++ b/services/spar/test-scim-suite/update.jq
@@ -1,0 +1,135 @@
+.
+
+| .name = "SCIM Tests (patched by Wire)"
+
+# place setup.js as collection-wide prerequest script
+| .events = [
+  {
+    "listen": "prerequest",
+    "script": {
+      "id": "bb613604-8063-4f02-a08d-bdd36c895892a",
+      "type": "text/javascript",
+      "exec": $setup_inline[0]
+    }
+  }
+]
+
+# in the integration the services run in http
+| (.requests | .[] | .url) |= sub("https"; "http")
+
+# Remove folder: Get Token
+| del(.requests | .[] | select (.folder == "8ea7d081-236a-4cee-af1c-033fb0c4de8b"))
+| del(.folders[] | select (.id == "8ea7d081-236a-4cee-af1c-033fb0c4de8b"))
+| del(.folders_order[] | select (. == "8ea7d081-236a-4cee-af1c-033fb0c4de8b"))
+
+# Remove folder: Group tests
+| del(.requests[] | select (.folder == "d8473c2e-4192-4652-ba3d-e26a6eceb94d"))
+| del(.folders[] | select (.id == "(d8473c2e-4192-4652-ba3d-e26a6eceb94d"))
+| del(.folders_order[] | select (. == "d8473c2e-4192-4652-ba3d-e26a6eceb94d"))
+
+# Remove folder: ComplexAttribute tests
+| del(.requests[] | select (.folder == "23b40117-aa00-4b91-acb3-53f470cd5d83"))
+| del(.folders[] | select (.id == "23b40117-aa00-4b91-acb3-53f470cd5d83"))
+| del(.folders_order[] | select (. == "23b40117-aa00-4b91-acb3-53f470cd5d83"))
+
+# Remove folder: Group tests with garbage
+| del(.requests[] | select (.folder == "53bd1992-2f7d-4dce-9fc1-60ca0d031345"))
+| del(.folders[] | select (.id == "53bd1992-2f7d-4dce-9fc1-60ca0d031345"))
+| del(.folders_order[] | select (. == "53bd1992-2f7d-4dce-9fc1-60ca0d031345"))
+
+# Update Folder "User tests"
+# Post User # FUTUREWORK: use SAML
+| (.requests[] | select (.name == "Post User") | .rawModeData) |= sub("\\$\\{__UUID\\}"; "{{user1externalId}}")
+| (.requests[] | select (.name == "Post User") | .rawModeData) |= sub("UserName123"; "{{user1userName}}")
+# Post Enterprise User
+| (.requests[] | select (.name == "Post EnterpriseUser") | .rawModeData) |= sub("\\$\\{__UUID\\}"; "{{user2externalId}}")
+| (.requests[] | select (.name == "Post EnterpriseUser") | .rawModeData) |= sub("UserName222"; "{{user2userName}}")
+# Get User Attributes
+# Remove this step because we dont support the standard here
+| del(.requests[] | select (.name == "Get User Attributes"))
+# Get User Filters
+# Remove this step because we dont support the standard here
+| del(.requests[] | select (.name == "Get User Filters"))
+# User 2 replace test
+| (.requests[] | select (.name == "User 2 replace test") | .rawModeData) |= sub("\\$\\{__UUID\\}"; "{{user2externalId2}}")
+| (.requests[] | select (.name == "User 2 replace test") | .rawModeData) |= sub("\\$\\{__UUID\\}"; "{{user2externalId2}}")
+# Get user2 Check replace
+#  Remove this step. This test tries to access .name.formatted in the response,
+#  which wire doesn't support. 'name' is not a required attribute (see https://tools.ietf.org/html/rfc7643#section-4.1.1)
+| del(.requests[] | select (.name == "Get user2 Check replace"))
+
+
+# Update Folder "User tests with garbage"
+
+# Step: Post user "OMalley"
+# Use email instead of uuid
+| (.requests[] | select (.name == "Post user \"OMalley\"") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_externalId}}")
+# Remove this step because the assertion fails: expected 'omalley' to deeply equal 'OMalley'
+| del(.requests[] | select (.name == "Post user \"OMalley\""))
+# Step: Post emp1 with string "True"
+| (.requests[] | select (.name == "Post emp1 with string \"True\"") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_externalId2}}")
+# Remove this step, because it fails with 400:  Error in $.active: expected Bool, but encountered String
+| del(.requests[] | select (.name == "Post emp1 with string \"True\""))
+# Step: Get all users
+# Remove this step because had to remove  'Post user "OMalley"' and 'Post emp1 with string "True"'
+| del(.requests[] | select (.id == "4feb34db-d881-4b65-962b-82becad93cff"))
+# Step: Post emp2
+| (.requests[] | select (.name == "Post emp2") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_postemp2_externalId}}")
+| (.requests[] | select (.name == "Post emp2") | .rawModeData) |= sub("emp2"; "{{garbage1_postemp2_userName}}")
+# Step: Post emp3
+| (.requests[] | select (.name == "Post emp3") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_postemp3_externalId}}")
+| (.requests[] | select (.name == "Post emp3") | .rawModeData) |= sub("emp3"; "{{garbage1_postemp3_username}}")
+# Step: Post emp3 exists
+| (.requests[] | select (.name == "Post emp3 exists") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_postemp3_externalId}}")
+| (.requests[] | select (.name == "Post emp3 exists") | .rawModeData) |= sub("emp3"; "{{garbage1_postemp3_username}}")
+# Step: Post emp3 exists try again
+| (.requests[] | select (.name == "Post emp3 exists try again") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_postemp3_externalId}}")
+| (.requests[] | select (.name == "Post emp3 exists try again") | .rawModeData) |= sub("emp3"; "{{garbage1_postemp3_username}}")
+# Step: Put a user misspelled attribute
+# User 3rd user created here because we had to disable the first step
+| (.requests[] | select (.name == "Put a user misspelled attribute") | .url) |= sub("http://{{Server}}{{Port}}/{{Api}}/Users/{{1stuserid}}";"http://{{Server}}{{Port}}/{{Api}}/Users/{{3rduserid}}")
+| (.requests[] | select (.name == "Put a user misspelled attribute") | .rawModeData) |= sub("{{1stuserid}}";"{{3rduserid}}")
+| (.requests[] | select (.name == "Put a user misspelled attribute") | .rawModeData) |= sub("OMalley"; "{{garbage1_postmisspelled_userName}}")
+| (.requests[] | select (.name == "Put a user misspelled attribute") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_postmisspelled_externalId}}")
+# Step: Post enterprise user
+| (.requests[] | select (.name == "Post enterprise user" and .id == "a0493815-66c0-40de-be52-93ba30d68973") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_postenterprise_externalId}}")
+| (.requests[] | select (.name == "Post enterprise user" and .id == "a0493815-66c0-40de-be52-93ba30d68973") | .rawModeData) |= sub("enterprise"; "{{garbage1_postenterprise_userName}}")
+# Step: Patch user omalley new username
+# Use the 3rd user created because we had to disbale the creation of the first user
+| (.requests[] | select (.name == "Patch user omalley new username") | .url) |= sub("http://{{Server}}{{Port}}/{{Api}}/Users/{{1stuserid}}";"http://{{Server}}{{Port}}/{{Api}}/Users/{{3rduserid}}")
+| (.requests[] | select (.name == "Patch user omalley new username") | .rawModeData) |= sub("{{1stuserid}}";"{{3rduserid}}")
+# Remove this step because it throws 409 Conflict. | del(.requests[] | select (.name == "Patch user omalley new username"))
+| del(.requests[] | select (.name == "Patch user omalley new username"))
+# Step: patch user omalley active with boolean
+| (.requests[] | select (.name == "patch user omalley active with boolean") | .url) |= sub("http://{{Server}}{{Port}}/{{Api}}/Users/{{1stuserid}}";"http://{{Server}}{{Port}}/{{Api}}/Users/{{3rduserid}}")
+| (.requests[] | select (.name == "patch user omalley active with boolean") | .rawModeData) |= sub("{{1stuserid}}";"{{3rduserid}}")
+# Remove this step because it return 204 while 200 is expected
+| del(.requests[] | select (.name == "patch user omalley active with boolean"))
+# Step: get user1
+# Remove this step because we had to remove the previous steps
+| del(.requests[] | select (.name == "get user1" and .id == "d0ba8c04-3912-4977-aef5-375d28cc6796"))
+# Step: Put a user OMalley
+# Use the 3rd user created because we had to disable the creation of the first user
+| (.requests[] | select (.name == "Put a user OMalley") | .url) |= sub("http://{{Server}}{{Port}}/{{Api}}/Users/{{1stuserid}}";"http://{{Server}}{{Port}}/{{Api}}/Users/{{3rduserid}}")
+| (.requests[] | select (.name == "Put a user OMalley") | .rawModeData) |= sub("{{1stuserid}}";"{{3rduserid}}")
+| (.requests[] | select (.name == "Put a user OMalley") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_putomalley_externalId}}")
+# without this backend responds with 400: UserName has to match UserId
+| (.requests[] | select (.name == "Put a user OMalley") | .rawModeData) |= sub("OMalley";"{{3rduserid}}")
+| (.requests[] | select (.name == "Put a user OMalley") | .events[].script.exec[] ) |= sub("\"OMalley\"";"pm.environment.get(\"3rduserid\")")
+# Remove this step, because can't reproduce the problems manually. FUTUREWORK: explore this. Might have some interaction with step "Patch user omalley new username"
+| del(.requests[] | select (.name == "Put a user OMalley"))
+# Step: Paginate
+# Remove this step, because fails with 400: Please specify a filter when getting users."
+| del(.requests[] | select (.name == "Paginate"))
+# Step: get user attributes
+# Remove this step, because fails with 400: Please specify a filter when getting users."
+| del(.requests[] | select (.name == "get user attributes"))
+# Step: filter eq and (val or val)
+# Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty
+| del(.requests[] | select (.name == "filter eq and (val or val)"))
+# Step: filter starts with
+# Remove this step, because fails with 400: Error parsing query parameter filter failed: Failed reading: empty
+| del(.requests[] | select (.name == "filter starts with"))
+# Step: filter greater than
+# Remove this step, because fails with 400: Error parsing query parameter filter failed: endOfInput
+| del(.requests[] | select (.name == "filter greater than"))

--- a/services/spar/test-scim-suite/update.jq
+++ b/services/spar/test-scim-suite/update.jq
@@ -68,7 +68,7 @@
 | del(.requests[] | select (.name == "Post user \"OMalley\""))
 # Step: Post emp1 with string "True"
 | (.requests[] | select (.name == "Post emp1 with string \"True\"") | .rawModeData) |= sub("22fbc523-6032-4c5f-939d-5d4850cf3e52"; "{{garbage1_externalId2}}")
-# Remove this step, because it fails with 400:  Error in $.active: expected Bool, but encountered String
+# Remove this step, because it fails with 400:  Error in $.active: expected Bool, but encountered String  -- TODO: fix
 | del(.requests[] | select (.name == "Post emp1 with string \"True\""))
 # Step: Get all users
 # Remove this step because had to remove  'Post user "OMalley"' and 'Post emp1 with string "True"'


### PR DESCRIPTION
This PR adds script files that allow running the SCIM Test suite (https://github.com/zinfra/backend-issues/issues/1782), see the [README included](https://github.com/wireapp/wire-server/blob/scim-test-suite/services/spar/test-scim-suite/README.md) for details.

The scripts are run automatically before any other spar integration tests unless `INTEGRATION_SKIP_SCIM_SUITE=1`
