### PR TITLE
cargohold: add compatibility mode for Scality RING S3 implementation

### DIFF
--- a/services/cargohold/src/CargoHold/App.hs
+++ b/services/cargohold/src/CargoHold/App.hs
@@ -86,7 +86,7 @@ newEnv :: Opts -> IO Env
 newEnv o = do
   met <- Metrics.metrics
   lgr <- Log.mkLogger (o ^. optLogLevel) (o ^. optLogNetStrings) (o ^. optLogFormat)
-  mgr <- initHttpManager (getLast <$> o ^. optAws . awsS3Compatibility)
+  mgr <- initHttpManager (o ^. optAws . awsS3Compatibility)
   ama <- initAws (o ^. optAws) lgr mgr
   return $ Env ama met lgr mgr def (o ^. optSettings)
 

--- a/services/cargohold/src/CargoHold/Options.hs
+++ b/services/cargohold/src/CargoHold/Options.hs
@@ -21,6 +21,7 @@ module CargoHold.Options where
 
 import CargoHold.CloudFront (Domain (..), KeyPairId (..))
 import Control.Lens hiding (Level)
+import Data.Aeson (FromJSON (..), withText)
 import Data.Aeson.TH
 import Imports
 import System.Logger.Extended (Level, LogFormat)
@@ -51,10 +52,23 @@ data AWSOpts = AWSOpts
     _awsS3DownloadEndpoint :: !(Maybe AWSEndpoint),
     -- | S3 bucket name
     _awsS3Bucket :: !Text,
+    -- | Enable this option for compatibility with specific S3 backends.
+    _awsS3Compatibility :: !(Maybe (Last S3Compatibility)),
     -- | AWS CloudFront options
     _awsCloudFront :: !(Maybe CloudFrontOpts)
   }
   deriving (Show, Generic)
+
+data S3Compatibility
+  = -- | Scality RING, might also work for Zenko CloudServer
+    -- <https://www.scality.com/products/ring/>
+    S3CompatibilityScalityRing
+  deriving (Eq, Show)
+
+instance FromJSON S3Compatibility where
+  parseJSON = withText "S3Compatibility" $ \case
+    "scality-ring" -> pure S3CompatibilityScalityRing
+    other -> fail $ "invalid S3Compatibility: " <> show other
 
 deriveFromJSON toOptionFieldName ''AWSOpts
 

--- a/services/cargohold/src/CargoHold/Options.hs
+++ b/services/cargohold/src/CargoHold/Options.hs
@@ -53,7 +53,7 @@ data AWSOpts = AWSOpts
     -- | S3 bucket name
     _awsS3Bucket :: !Text,
     -- | Enable this option for compatibility with specific S3 backends.
-    _awsS3Compatibility :: !(Maybe (Last S3Compatibility)),
+    _awsS3Compatibility :: !(Maybe S3Compatibility),
     -- | AWS CloudFront options
     _awsCloudFront :: !(Maybe CloudFrontOpts)
   }

--- a/stack.yaml
+++ b/stack.yaml
@@ -98,9 +98,9 @@ extra-deps:
 # Therefore we pin an unreleased commit directly.
 #
 # Once the fix has been merged (and released on hackage), we can pin that instead.
-- archive: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
-  sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
-  size: 11138812
+- archive: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
+  sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
+  size: 11158334
   subdirs:
   - amazonka
   - amazonka-cloudfront

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -98,125 +98,125 @@ packages:
   original:
     hackage: aeson-1.4.7.1@sha256:6d8d2fd959b7122a1df9389cf4eca30420a053d67289f92cdc0dbc0dab3530ba,7098
 - completed:
-    size: 11138812
+    size: 11158334
     subdir: amazonka
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
     name: amazonka
     version: 1.6.1
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
     pantry-tree:
       size: 1038
       sha256: 59c7840fe6c9609d1d5022149010e72db5778e4978b9384b6dee8a4a207c96b3
   original:
-    size: 11138812
+    size: 11158334
     subdir: amazonka
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
 - completed:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-cloudfront
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
     name: amazonka-cloudfront
     version: 1.6.1
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
     pantry-tree:
       size: 12839
       sha256: f0f27588c628d9996c298ab035b19999572ad8432ea05526497b608b009b1258
   original:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-cloudfront
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
 - completed:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-dynamodb
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
     name: amazonka-dynamodb
     version: 1.6.1
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
     pantry-tree:
       size: 8379
       sha256: d513775676879e3b2ff8393528882df1670a79110120b65ce6c68765581a2473
   original:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-dynamodb
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
 - completed:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-s3
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
     name: amazonka-s3
     version: 1.6.1
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
     pantry-tree:
       size: 18431
       sha256: a19d02da301bbcad502e6092d7418a59543747c8bb6f12932bcbc4606f7814ab
   original:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-s3
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
 - completed:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-ses
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
     name: amazonka-ses
     version: 1.6.1
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
     pantry-tree:
       size: 18197
       sha256: cd9b02c30d7571dc87868b054ed3826d5b8d26b717f3158da6443377e8dfd563
   original:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-ses
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
 - completed:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-sns
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
     name: amazonka-sns
     version: 1.6.1
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
     pantry-tree:
       size: 7905
       sha256: e5a6d407b92e423ccf58d784fe42d4a0598204f65c0e7753569c130428bfb5eb
   original:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-sns
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
 - completed:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-sqs
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
     name: amazonka-sqs
     version: 1.6.1
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
     pantry-tree:
       size: 5351
       sha256: 990b7e4467d557e43959483063f7229f5039857a8cd67decb53f9a5c513db7f8
   original:
-    size: 11138812
+    size: 11158334
     subdir: amazonka-sqs
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
 - completed:
-    size: 11138812
+    size: 11158334
     subdir: core
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
     name: amazonka-core
     version: 1.6.1
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
     pantry-tree:
       size: 3484
       sha256: d4e427a362d66c9ee0dc0de810015633e43e3953944a84b24cfa2e71bcf0ed4d
   original:
-    size: 11138812
+    size: 11158334
     subdir: core
-    url: https://github.com/wireapp/amazonka/archive/9de5e0e4b2511ec555fb0975581b3087a94c1b4a.tar.gz
-    sha256: b9277a51b60d639fbd91b630f353bf9db305f5759f8e1ee48f0ab026e6b43d00
+    url: https://github.com/wireapp/amazonka/archive/412172d8c28906591f01576a78792de7c34cc3eb.tar.gz
+    sha256: c5eb2007e0eef0daaa70f5c622ec0cc75227be1bc8d32bc9446754f01595ad21
 - completed:
     name: cryptobox-haskell
     version: 0.1.1


### PR DESCRIPTION
See https://github.com/zinfra/backend-issues/issues/1659

Not the nicest way to do it and doesn't adhere to the S3 spec, but at least this way it's behind an optional setting.