### PR TITLE
Upgrade bonanza geoip2

### DIFF
--- a/tools/bonanza/bonanza.cabal
+++ b/tools/bonanza/bonanza.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fcfbd52b153b1454a0bfcb5ed0a914a74cd3a53155171dba5aef047caf76b3e9
+-- hash: 5b23add6d90e5fa38e933ba872f9d6d79319ac2b03289e67fdc119982f5313a6
 
 name:           bonanza
 version:        3.6.0
@@ -64,7 +64,6 @@ library
     , ekg-core
     , exceptions
     , geoip2
-    , hs-GeoIP ==0.3.*
     , http-client
     , http-types
     , imports

--- a/tools/bonanza/bonanza.cabal
+++ b/tools/bonanza/bonanza.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c65bea2c25598cbdee588334b4a36a838abbe0612536a104ef9be32b01c3078b
+-- hash: fcfbd52b153b1454a0bfcb5ed0a914a74cd3a53155171dba5aef047caf76b3e9
 
 name:           bonanza
 version:        3.6.0
@@ -63,10 +63,12 @@ library
     , containers
     , ekg-core
     , exceptions
+    , geoip2
     , hs-GeoIP ==0.3.*
     , http-client
     , http-types
     , imports
+    , iproute
     , lens
     , lens-aeson
     , mtl
@@ -75,6 +77,7 @@ library
     , optparse-applicative >=0.11
     , protobuf >=0.2.1.1
     , resourcet
+    , safe
     , scientific
     , snappy
     , snappy-framing

--- a/tools/bonanza/package.yaml
+++ b/tools/bonanza/package.yaml
@@ -34,7 +34,6 @@ library:
   - ekg-core
   - exceptions
   - geoip2
-  - hs-GeoIP ==0.3.*
   - http-client
   - http-types
   - iproute

--- a/tools/bonanza/package.yaml
+++ b/tools/bonanza/package.yaml
@@ -33,9 +33,11 @@ library:
   - containers
   - ekg-core
   - exceptions
+  - geoip2
   - hs-GeoIP ==0.3.*
   - http-client
   - http-types
+  - iproute
   - lens
   - lens-aeson
   - mtl

--- a/tools/bonanza/package.yaml
+++ b/tools/bonanza/package.yaml
@@ -46,6 +46,7 @@ library:
   - optparse-applicative >=0.11
   - protobuf >=0.2.1.1
   - scientific
+  - safe
   - snappy
   - snappy-framing
   - time >=1.5

--- a/tools/bonanza/src/Bonanza/App.hs
+++ b/tools/bonanza/src/Bonanza/App.hs
@@ -230,8 +230,8 @@ runBonanza =
   where
     runGeo [] _ = Conduit.map id
     runGeo tags db =
-      Conduit.mapM
-        (\e -> foldM (\e' t -> geolocate db (T.pack t) e') e tags)
+      Conduit.map
+        (\e -> foldl' (\e' t -> geolocate db (T.pack t) e') e tags)
     runAnonymise = Conduit.map . anonymise . map T.pack
     runCmd (Kibana KibanaOpts {..}) =
       Conduit.mapM Kibana.fromLogEvent

--- a/tools/bonanza/src/Bonanza/Geo.hs
+++ b/tools/bonanza/src/Bonanza/Geo.hs
@@ -29,11 +29,11 @@ import Control.Lens
 import Data.Aeson
 import Data.Aeson.Lens
 import Data.GeoIP2
-import qualified Data.IP as IP
 import qualified Data.HashMap.Strict as HashMap
+import qualified Data.IP as IP
 import qualified Data.Text as Text
-import qualified Safe
 import Imports
+import qualified Safe
 
 mkGeo :: FilePath -> IO GeoDB
 mkGeo path = do
@@ -75,4 +75,4 @@ toGeo GeoResult {..} =
     }
   where
     toCoordinate (Just lat) (Just lon) = Just $ Coordinate lat lon
-    toCoordinate _          _          = Nothing
+    toCoordinate _ _ = Nothing

--- a/tools/bonanza/src/Bonanza/Geo.hs
+++ b/tools/bonanza/src/Bonanza/Geo.hs
@@ -30,25 +30,26 @@ import Control.Lens
 import Data.Aeson
 import Data.Aeson.Lens
 import Data.Attoparsec.ByteString.Char8 (parseOnly)
-import qualified Data.ByteString as B
-import Data.Geolocation.GeoIP
+import Data.GeoIP2
 import qualified Data.HashMap.Strict as HashMap
-import Data.Text.Encoding (decodeLatin1, encodeUtf8)
+import qualified Data.Text as Text
+import Data.Text.Encoding (encodeUtf8)
 import Imports
 
 mkGeo :: FilePath -> IO GeoDB
 mkGeo path = do
   -- exit orderly if file doesn't exist (c api segfaults)
   withBinaryFile path ReadMode (const $ pure ())
-  openGeoDB mmap_cache path
+  openGeoDB path
 
-geolocate :: GeoDB -> Text -> LogEvent -> IO LogEvent
+geolocate :: GeoDB -> Text -> LogEvent -> LogEvent
 geolocate db t evt =
   maybe
-    (pure evt)
-    (fmap update . geoLocateByIPNum db . toInteger)
+    evt
+    (update . preview _Right . findGeoData db "en" . read . Text.unpack . showIPv4Text)
     $ ip t evt
   where
+    update :: Maybe GeoResult -> LogEvent
     update x =
       evt & logTags
         %~ _Wrapped'
@@ -66,14 +67,13 @@ ip t = join . fmap parse . view (logTags . _Wrapped' . at t)
         . fmap (preview _Right . parseOnly ipv4 . encodeUtf8)
         . preview _String
 
-toGeo :: GeoIPRecord -> Geo
-toGeo GeoIPRecord {..} =
+toGeo :: GeoResult -> Geo
+toGeo GeoResult {..} =
   Geo
-    { geoCountry = ne geoCountryCode,
-      geoCity = ne geoCity,
-      geoLocation = Coordinate {lat = geoLatitude, lon = geoLongitude}
+    { geoCountry = geoCountryISO,
+      geoCity = geoCity,
+      geoLocation = toCoordinate (fmap locationLatitude geoLocation) (fmap locationLongitude geoLocation)
     }
   where
-    ne s
-      | B.length s > 0 = Just $ decodeLatin1 s
-      | otherwise = Nothing
+    toCoordinate (Just lat) (Just lon) = Just $ Coordinate lat lon
+    toCoordinate _          _          = Nothing

--- a/tools/bonanza/src/Bonanza/Types.hs
+++ b/tools/bonanza/src/Bonanza/Types.hs
@@ -133,7 +133,7 @@ instance FromJSON Host where
 data Geo = Geo
   { geoCountry :: Maybe Text,
     geoCity :: Maybe Text,
-    geoLocation :: !Coordinate
+    geoLocation :: !(Maybe Coordinate)
   }
   deriving (Eq, Show, Generic)
 


### PR DESCRIPTION
Fixes https://github.com/zinfra/backend-issues/issues/1841

It uses the newer library that has support for the [V2 version of maxmind](https://www.maxmind.com/en/geoip2-city) which we want to use but bonanza had no support for ([brig](https://github.com/wireapp/wire-server/blob/develop/services/brig/src/Brig/App.hs#L98) was already using it).

How did I test this? I didn't add integration tests so I ran some manual tests (far from ideal I know). Previous, using this log line (mind the blurred out IP addresses):
```
2020-10-26T21:58:46.99997 10.10.10.10: 2020-10-26T21:58:32.61354 |srv=nginz_access|42.86.xxx.yy - - [26/Oct/2020:21:58:32 +0000] "POST /conversations/763d2bf2-0000-4576-ac01-54c98f426105/otr/messages HTTP/1.1" 201 87 "-" "some user agent" "42.86.xxx.yy" - 409954 0.092 0.092 - 731903b6-0000-4862-9a2f-024d95572662 13716503056177597800 5ee022cdbda8f51210b8824a4e741100
``` 

and running:

```
cat /tmp/log-file | dist/bonanza-legacy --parser socklog+svlogd+nginz --geolocate http_x_forwarded_for --geolocate proxy_protocol_addr --geoip-dat GeoIP2-City.mmdb  kibana

Invalid database type GeoIP Country Edition, expected GeoIP City Edition, Rev 1
```

now:

```
cat /tmp/log-file | dist/bonanza-legacy --parser socklog+svlogd+nginz --geolocate http_x_forwarded_for --geolocate proxy_protocol_addr --geoip-dat GeoIP2-City.mmdb  kibana

Will correctly parse the IP address and give you Geo data
```