### PR TITLE
Fix stack warning about bloodhound.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -84,7 +84,7 @@ extra-deps:
   commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25
 
 - git: https://github.com/wireapp/bloodhound
-  commit: 8c2b6f77bf6cd2506ea0ad3c1cd1251c9f42545b # (2020-05-25) branch: wire-fork-ghc-8.8
+  commit: 92de9aa632d590f288a353d03591c38ba72b3cb3 # (2020-10-27) branch: wire-fork-ghc-8.8
 
 # For bloodhound
 - deriving-aeson-0.2.5@sha256:a1efa4ab7ff94f73e6d2733a9d4414cb4c3526761295722cff28027b5b3da1a4,1277

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -84,6 +84,17 @@ packages:
     git: https://github.com/wireapp/hspec-wai
     commit: 0a5142cd3ba48116ff059c041348b817fb7bdb25
 - completed:
+    name: bloodhound
+    version: 0.17.0.0
+    git: https://github.com/wireapp/bloodhound
+    pantry-tree:
+      size: 4587
+      sha256: fc77d3295fba77f96f80bf10860afac1855d393020f3d04d71bf530afa17c143
+    commit: 92de9aa632d590f288a353d03591c38ba72b3cb3
+  original:
+    git: https://github.com/wireapp/bloodhound
+    commit: 92de9aa632d590f288a353d03591c38ba72b3cb3
+- completed:
     hackage: deriving-aeson-0.2.5@sha256:a1efa4ab7ff94f73e6d2733a9d4414cb4c3526761295722cff28027b5b3da1a4,1277
     pantry-tree:
       size: 441


### PR DESCRIPTION
stack wants you to commit cabal files now, even if there is a package.yaml in version control.