### PR TITLE
Avoid lazily garbage-collected rows in brig.user table.

### DIFF
--- a/libs/brig-types/src/Brig/Types/Intra.hs
+++ b/libs/brig-types/src/Brig/Types/Intra.hs
@@ -35,11 +35,13 @@ where
 import Brig.Types.Connection
 import Brig.Types.User
 import Data.Aeson
+import Data.Handle (Handle)
 import qualified Data.HashMap.Strict as M
 import Data.Id (TeamId, UserId)
 import Data.Misc (PlainTextPassword (..))
 import qualified Data.Text as Text
 import Imports
+import Wire.API.User.RichInfo (RichInfo)
 
 -------------------------------------------------------------------------------
 -- AccountStatus
@@ -149,7 +151,9 @@ data NewUserScimInvitation = NewUserScimInvitation
   { newUserScimInvTeamId :: TeamId,
     newUserScimInvLocale :: Maybe Locale,
     newUserScimInvName :: Name,
-    newUserScimInvEmail :: Email
+    newUserScimInvHandle :: Handle,
+    newUserScimInvEmail :: Email,
+    newUserScimInvRichInfo :: RichInfo
   }
   deriving (Eq, Show, Generic)
 
@@ -159,15 +163,19 @@ instance FromJSON NewUserScimInvitation where
       <$> o .: "team_id"
       <*> o .:? "locale"
       <*> o .: "name"
+      <*> o .: "handle"
       <*> o .: "email"
+      <*> o .: "richinfo"
 
 instance ToJSON NewUserScimInvitation where
-  toJSON (NewUserScimInvitation tid loc name email) =
+  toJSON (NewUserScimInvitation tid loc name handle email richinfo) =
     object
       [ "team_id" .= tid,
         "locale" .= loc,
         "name" .= name,
-        "email" .= email
+        "handle" .= handle,
+        "email" .= email,
+        "richinfo" .= richinfo
       ]
 
 -------------------------------------------------------------------------------

--- a/libs/brig-types/test/unit/Test/Brig/Types/User.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/User.hs
@@ -55,4 +55,4 @@ instance Arbitrary ReAuthUser where
   arbitrary = ReAuthUser <$> arbitrary
 
 instance Arbitrary NewUserScimInvitation where
-  arbitrary = NewUserScimInvitation <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary = NewUserScimInvitation <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -437,6 +437,7 @@ changeHandleWith mbTTL uid mconn hdl = do
     Nothing -> throwE ChangeHandleNoIdentity
     Just u -> claim u
   where
+    claim :: User -> ExceptT ChangeHandleError AppIO ()
     claim u = do
       unless (isJust (userIdentity u)) $
         throwE ChangeHandleNoIdentity

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -353,7 +353,9 @@ makeUserPermanent muid teamInvitation = do
   case (muid, teamInvitation) of
     (Just (Id -> uid), Just _) -> do
       mbAccount <- Data.lookupAccount uid
-      (\account -> Data.insertAccount account Nothing Nothing True) `mapM_` mbAccount
+      for_ mbAccount $ \account -> do
+        Data.insertAccount account Nothing Nothing True
+        makeHandlePermanent `mapM_` userHandle (accountUser account)
       mbRichInfo <- Data.lookupRichInfo uid
       Data.updateRichInfo uid `mapM_` mbRichInfo
     _ -> pure ()

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -58,7 +58,6 @@ module Brig.Data.User
     updateLocale,
     updatePassword,
     updateStatus,
-    updateHandle,
     updateHandleWithTTL,
     updateRichInfo,
     updateRichInfoWithTTL,
@@ -288,9 +287,6 @@ updateSSOId u ssoid = do
 
 updateManagedBy :: UserId -> ManagedBy -> AppIO ()
 updateManagedBy u h = retry x5 $ write userManagedByUpdate (params Quorum (h, u))
-
-updateHandle :: UserId -> Handle -> AppIO ()
-updateHandle = updateHandleWithTTL 0
 
 updateHandleWithTTL :: Int32 -> UserId -> Handle -> AppIO ()
 updateHandleWithTTL ttl u h = retry x5 $ write userHandleUpdate (params Quorum (ttl, h, u))

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -238,7 +238,7 @@ createInvitationViaScimH (_ ::: req) = do
   setStatus status201 . json <$> createInvitationViaScim body
 
 createInvitationViaScim :: NewUserScimInvitation -> Handler UserAccount
-createInvitationViaScim newUser@(NewUserScimInvitation tid loc name email) = do
+createInvitationViaScim newUser@(NewUserScimInvitation tid loc name _ email _) = do
   env <- ask
   let inviteeRole = Team.defaultRole
       fromEmail = env ^. emailSender

--- a/services/brig/src/Brig/User/Handle.hs
+++ b/services/brig/src/Brig/User/Handle.hs
@@ -21,6 +21,7 @@ module Brig.User.Handle
     freeHandle,
     lookupHandle,
     glimpseHandle,
+    makeHandlePermanent,
   )
 where
 
@@ -79,6 +80,12 @@ lookupHandleWithPolicy :: Consistency -> Handle -> AppIO (Maybe UserId)
 lookupHandleWithPolicy policy h = do
   join . fmap runIdentity
     <$> retry x1 (query1 handleSelect (params policy (Identity h)))
+
+makeHandlePermanent :: Handle -> AppIO ()
+makeHandlePermanent handl = do
+  mbUid <- lookupHandle handl
+  forM_ mbUid $ \uid -> do
+    retry x5 $ write handleInsert (params Quorum (handl, uid, 0))
 
 --------------------------------------------------------------------------------
 -- Queries

--- a/services/brig/src/Brig/User/Handle.hs
+++ b/services/brig/src/Brig/User/Handle.hs
@@ -35,6 +35,7 @@ import Imports
 
 -- | Claim a new handle for an existing 'User'.  Returns 'True' if the handle is available.
 claimHandleWithTTL :: Maybe Int32 -> UserId -> Maybe Handle -> Handle -> AppIO Bool
+claimHandleWithTTL (Just 0) uid oldHandle h = claimHandleWithTTL Nothing uid oldHandle h -- otherwise, ttl computations below will misbehave.
 claimHandleWithTTL mbTTL claimer oldHandle h = do
   mbOwner <- lookupHandle h
   case mbOwner of

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -233,9 +233,11 @@ createBrigUserNoSAML ::
   TeamId ->
   -- | User name
   Name ->
+  Handle ->
+  RichInfo ->
   m UserId
-createBrigUserNoSAML email teamid uname = do
-  let newUser = NewUserScimInvitation teamid Nothing uname email
+createBrigUserNoSAML email teamid uname uhandle richinfo = do
+  let newUser = NewUserScimInvitation teamid Nothing uname uhandle email richinfo
   resp :: Response (Maybe LBS) <-
     call $
       method POST

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -673,6 +673,8 @@ testCreateUserTimeout = do
     searchUser :: HasCallStack => Spar.Types.ScimToken -> Scim.User.User tag -> Email -> Bool -> TestSpar ()
     searchUser tok scimUser email shouldSucceed = do
       let handle = Handle . Scim.User.userName $ scimUser
+
+          tryquery :: HasCallStack => Filter.Filter -> TestSpar ()
           tryquery qry =
             aFewTimesAssert
               (length <$> listUsers tok (Just qry))

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -686,8 +686,9 @@ testCreateUserTimeout = do
       -- view teBrigOpts $ env@, but if this goes out of sync with the brig config, we will only get benign false
       -- negatives, and importing brig options into spar integration tests is just too awkward.
       let setTeamInvitationTimeout = 5
+          safetyFactor = 2 -- Brig.Unique errs on the side of caution, so waiting 5 secs is not enough.
       Control.Exception.assert (setTeamInvitationTimeout < 30) $ do
-        threadDelay $ (setTeamInvitationTimeout + 1) * 1_000_000
+        threadDelay $ (setTeamInvitationTimeout * safetyFactor + 1) * 1_000_000
 
 ----------------------------------------------------------------------------
 -- Listing users

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -654,6 +654,13 @@ testCreateUserTimeout = do
   waitUserExpiration
   searchUser tok scimUser email True
   where
+    createUser'step ::
+      HasCallStack =>
+      Spar.Types.ScimToken ->
+      TeamId ->
+      Scim.User.User SparTag ->
+      Email ->
+      TestSpar (Scim.UserC.StoredUser SparTag, Invitation, InvitationCode)
     createUser'step tok tid scimUser email = do
       env <- ask
       let brig = env ^. teBrig

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -246,6 +246,8 @@ testCreateUserNoIdP = do
     let brigUser = accountUser brigUserAccount
     brigUser `userShouldMatch` WrappedScimStoredUser scimStoredUser
     liftIO $ accountStatus brigUserAccount `shouldBe` PendingInvitation
+    liftIO $ userDisplayName brigUser `shouldBe` userName
+    liftIO $ userHandle brigUser `shouldBe` (Just handle)
     liftIO $ userEmail brigUser `shouldBe` Just email
     liftIO $ userManagedBy brigUser `shouldBe` ManagedByScim
 

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -690,7 +690,7 @@ testCreateUserTimeout = do
       let setTeamInvitationTimeout = 5
           safetyFactor = 2 -- Brig.Unique errs on the side of caution, so waiting 5 secs is not enough.
       Control.Exception.assert (setTeamInvitationTimeout < 30) $ do
-        threadDelay $ (setTeamInvitationTimeout * safetyFactor + 1) * 1_000_000
+        threadDelay $ (setTeamInvitationTimeout * safetyFactor + 2) * 1_000_000
 
 ----------------------------------------------------------------------------
 -- Listing users

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -690,7 +690,7 @@ testCreateUserTimeout = do
       let setTeamInvitationTimeout = 5
           safetyFactor = 2 -- Brig.Unique errs on the side of caution, so waiting 5 secs is not enough.
       Control.Exception.assert (setTeamInvitationTimeout < 30) $ do
-        threadDelay $ (setTeamInvitationTimeout * safetyFactor + 2) * 1_000_000
+        threadDelay $ (setTeamInvitationTimeout * safetyFactor + 1) * 1_000_000
 
 ----------------------------------------------------------------------------
 -- Listing users


### PR DESCRIPTION
Fixes https://github.com/zinfra/backend-issues/issues/1847

Don't lazily remove `brig.user` records if in status `PendingInvitation` with `Invitation` expired.  Instead, give them TTL values corresponding to the ones for the `Invitations`.

This is slightly complicated by the fact that we're not doing a single, clean insert, but updating the record for handle, and touch a second table for rich info.