### PR TITLE
Update web-saml2-sso version: contact list may now be empty

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -64,7 +64,8 @@ extra-deps:
   # a version > 1.0.0 of wai-middleware-prometheus is available
   # (required: https://github.com/fimad/prometheus-haskell/pull/45)
 - git: https://github.com/wireapp/saml2-web-sso
-  commit: 43c74bd44698e062abaa090c56de5272e66cee27  # master (Sep 24, 2020)
+  # TODO(stefan): change this as soon as is it's merged to master
+  commit: 73fa88c13f96db8ede150b518624c7ee51a49190
 
 - git: https://github.com/kim/hs-collectd
   commit: 885da222be2375f78c7be36127620ed772b677c9

--- a/stack.yaml
+++ b/stack.yaml
@@ -64,7 +64,7 @@ extra-deps:
   # a version > 1.0.0 of wai-middleware-prometheus is available
   # (required: https://github.com/fimad/prometheus-haskell/pull/45)
 - git: https://github.com/wireapp/saml2-web-sso
-  commit: dcbadb18f8ba6ca0e6245bf804405685d3e1cfce
+  commit: dcbadb18f8ba6ca0e6245bf804405685d3e1cfce  # master (Nov 12, 2020)
 
 - git: https://github.com/kim/hs-collectd
   commit: 885da222be2375f78c7be36127620ed772b677c9

--- a/stack.yaml
+++ b/stack.yaml
@@ -64,8 +64,7 @@ extra-deps:
   # a version > 1.0.0 of wai-middleware-prometheus is available
   # (required: https://github.com/fimad/prometheus-haskell/pull/45)
 - git: https://github.com/wireapp/saml2-web-sso
-  # TODO(stefan): change this as soon as is it's merged to master
-  commit: 73fa88c13f96db8ede150b518624c7ee51a49190
+  commit: dcbadb18f8ba6ca0e6245bf804405685d3e1cfce
 
 - git: https://github.com/kim/hs-collectd
   commit: 885da222be2375f78c7be36127620ed772b677c9

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -23,11 +23,11 @@ packages:
     git: https://github.com/wireapp/saml2-web-sso
     pantry-tree:
       size: 4657
-      sha256: c1c5ff18a9c8996aa33dd571662033928cda4ae4ebcda98b6777f8ebd0cc7102
-    commit: 43c74bd44698e062abaa090c56de5272e66cee27
+      sha256: 1e2e75b602379f564f1feb170a338109d7c19dae89b98d414d83eabda1f6fdb7
+    commit: 73fa88c13f96db8ede150b518624c7ee51a49190
   original:
     git: https://github.com/wireapp/saml2-web-sso
-    commit: 43c74bd44698e062abaa090c56de5272e66cee27
+    commit: 73fa88c13f96db8ede150b518624c7ee51a49190
 - completed:
     name: collectd
     version: 0.0.0.2


### PR DESCRIPTION
Fixes https://wearezeta.atlassian.net/browse/SQSERVICES-30
After this PR the spar config `saml.contacts` can be a empty list (was NonEmpty).

Related PR in saml2-web-sso: https://github.com/wireapp/saml2-web-sso/pull/68