### PR TITLE
Remove Content-MD5 header for asset upload

### DIFF
--- a/libs/wire-api/src/Wire/API/Asset/V3.hs
+++ b/libs/wire-api/src/Wire/API/Asset/V3.hs
@@ -59,11 +59,8 @@ where
 
 import qualified Codec.MIME.Type as MIME
 import Control.Lens (makeLenses)
-import Crypto.Hash (Digest, MD5, hashlazy)
 import Data.Aeson
 import Data.Attoparsec.ByteString.Char8
-import qualified Data.ByteArray as B
-import qualified Data.ByteString.Base64 as B64
 import Data.ByteString.Builder
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as LBS
@@ -185,7 +182,7 @@ buildMultipartBody sets typ bs =
 -- | Begin building a @multipart/mixed@ request body for a non-resumable upload.
 -- The returned 'Builder' can be immediately followed by the actual asset bytes.
 beginMultipartBody :: AssetSettings -> AssetHeaders -> Builder
-beginMultipartBody sets (AssetHeaders t l d) =
+beginMultipartBody sets (AssetHeaders t l) =
   byteString
     "--frontier\r\n\
     \Content-Type: application/json\r\n\
@@ -205,11 +202,7 @@ beginMultipartBody sets (AssetHeaders t l d) =
       \Content-Length: "
     <> wordDec l
     <> "\r\n\
-       \Content-MD5: "
-    <> byteString (B64.encode (B.convert d))
-    <> byteString
-      "\r\n\
-      \\r\n"
+       \\r\n"
   where
     settingsJson = encode sets
 
@@ -224,12 +217,11 @@ endMultipartBody = byteString "\r\n--frontier--\r\n"
 -- | Headers provided during upload.
 data AssetHeaders = AssetHeaders
   { hdrType :: MIME.Type,
-    hdrLength :: Word,
-    hdrMD5 :: Digest MD5
+    hdrLength :: Word
   }
 
 mkHeaders :: MIME.Type -> LByteString -> AssetHeaders
-mkHeaders t b = AssetHeaders t (fromIntegral (LBS.length b)) (hashlazy b)
+mkHeaders t b = AssetHeaders t (fromIntegral (LBS.length b))
 
 --------------------------------------------------------------------------------
 -- AssetSettings

--- a/services/cargohold/src/CargoHold/API/V3.hs
+++ b/services/cargohold/src/CargoHold/API/V3.hs
@@ -40,11 +40,9 @@ import Control.Applicative (optional)
 import Control.Error
 import Control.Lens (set, view, (^.))
 import Control.Monad.Trans.Resource
-import Crypto.Hash
 import Crypto.Random (getRandomBytes)
 import Data.Aeson (eitherDecodeStrict')
 import Data.Attoparsec.ByteString.Char8
-import qualified Data.ByteString.Base64 as B64
 import qualified Data.CaseInsensitive as CI
 import Data.Conduit
 import qualified Data.Conduit.Attoparsec as Conduit
@@ -171,13 +169,13 @@ assetHeaders :: Parser AssetHeaders
 assetHeaders =
   eol
     *> boundary
-    *> (headers [hContentType, hContentLength, hContentMD5] >>= go)
+    *> (headers [hContentType, hContentLength] >>= go)
     <* eol
   where
     go hdrs =
-      AssetHeaders <$> contentType hdrs
+      AssetHeaders
+        <$> contentType hdrs
         <*> contentLength hdrs
-        <*> contentMD5 hdrs
 
 contentType :: [(HeaderName, ByteString)] -> Parser MIME.Type
 contentType hdrs =
@@ -192,13 +190,6 @@ contentLength hdrs =
     (fail "Missing Content-Type")
     (either fail return . parseOnly decimal)
     (lookup (CI.mk "Content-Length") hdrs)
-
-contentMD5 :: [(HeaderName, ByteString)] -> Parser (Digest MD5)
-contentMD5 hdrs =
-  maybe
-    (fail "Missing Content-MD5")
-    (maybe (fail "Invalid Content-MD5") return . digestFromByteString . B64.decodeLenient)
-    (lookup (CI.mk "Content-MD5") hdrs)
 
 boundary :: Parser ()
 boundary =


### PR DESCRIPTION
See https://github.com/zinfra/backend-issues/issues/1843.

This passes the cargohold compatibility tests with AWS, Scality RING and Minio.