### PR TITLE
Add two missing license headers

### DIFF
--- a/libs/deriving-swagger2/src/Deriving/Swagger.hs
+++ b/libs/deriving-swagger2/src/Deriving/Swagger.hs
@@ -1,3 +1,20 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
 module Deriving.Swagger where
 
 import Data.Kind (Constraint)

--- a/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
@@ -1,3 +1,20 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
 module Test.Wire.API.Swagger (tests) where
 
 import Data.Aeson (ToJSON)


### PR DESCRIPTION
Maybe it makes sense to add `headroom` to our CI pipeline? Should be straight-forward. Maybe `ormolu` + `headroom` = `haskell-stylecheck-ubuntu`?