### PR TITLE
Integrate servant-swagger-ui to brig

### DIFF
--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -143,7 +143,12 @@ http {
       proxy_pass http://brig;
     }
 
-    location /brig/api-docs {
+    location /swagger-ui {
+        include common_response_no_zauth.conf;
+        proxy_pass http://brig;
+    }
+
+    location /swagger.json {
         include common_response_no_zauth.conf;
         proxy_pass http://brig;
     }

--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -143,12 +143,12 @@ http {
       proxy_pass http://brig;
     }
 
-    location /swagger-ui {
+    location /api/swagger-ui {
         include common_response_no_zauth.conf;
         proxy_pass http://brig;
     }
 
-    location /swagger.json {
+    location /api/swagger.json {
         include common_response_no_zauth.conf;
         proxy_pass http://brig;
     }

--- a/docs/developer/dependencies.md
+++ b/docs/developer/dependencies.md
@@ -20,7 +20,7 @@ sudo dnf install -y pkgconfig haskell-platform libstdc++-devel libstdc++-static 
 _Note_: Debian is not recommended due to this issue when running local integration tests: [#327](https://github.com/wireapp/wire-server/issues/327). This issue does not occur with Ubuntu.
 
 ```bash
-sudo apt install pkg-config libsodium-dev openssl-dev libtool automake build-essential libicu-dev libsnappy-dev libgeoip-dev protobuf-compiler libxml2-dev zlib1g-dev libtinfo-dev -y
+sudo apt install pkg-config libsodium-dev openssl-dev libtool automake build-essential libicu-dev libsnappy-dev libgeoip-dev protobuf-compiler libxml2-dev zlib1g-dev libtinfo-dev liblzma-dev -y
 ```
 
 If `openssl-dev` does not work for you, try `libssl-dev`.

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9f982304b3e4de02c3a782a8053c4d3d2e0ab19d3e6bd497684f37ceaaf7215a
+-- hash: 58ca66d809d6b5ee7fb4c04547c644b520ca6b60213096123d0a384f72f6e3de
 
 name:           brig
 version:        1.35.0
@@ -195,6 +195,8 @@ library
     , servant
     , servant-server
     , servant-swagger
+    , servant-swagger-ui
+    , servant-swagger-ui-core
     , singletons >=2.0
     , smtp-mail >=0.1
     , sodium-crypto-sign >=0.1

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 58ca66d809d6b5ee7fb4c04547c644b520ca6b60213096123d0a384f72f6e3de
+-- hash: fca64102306b0e8600a5203e52836eb181aa7ddb9df6fd88d343421649b9ea0e
 
 name:           brig
 version:        1.35.0
@@ -196,7 +196,6 @@ library
     , servant-server
     , servant-swagger
     , servant-swagger-ui
-    , servant-swagger-ui-core
     , singletons >=2.0
     , smtp-mail >=0.1
     , sodium-crypto-sign >=0.1

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -98,7 +98,6 @@ library:
   - servant-server
   - servant-swagger
   - servant-swagger-ui
-  - servant-swagger-ui-core
   - singletons >=2.0
   - stomp-queue >=0.3
   - string-conversions

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -97,6 +97,8 @@ library:
   - servant
   - servant-server
   - servant-swagger
+  - servant-swagger-ui
+  - servant-swagger-ui-core
   - singletons >=2.0
   - stomp-queue >=0.3
   - string-conversions

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -89,7 +89,6 @@ import qualified Servant
 import Servant.Swagger (HasSwagger (toSwagger))
 import Servant.Swagger.Internal.Orphans ()
 import Servant.Swagger.UI
--- import qualified Servant.Swagger.UI.Core as SwaggerUI
 import qualified System.Logger.Class as Log
 import qualified Wire.API.Connection as Public
 import qualified Wire.API.Properties as Public
@@ -241,17 +240,15 @@ swaggerDoc = toSwagger (Proxy @OutsideWorldAPI)
 --
 
 servantHandlerSitemap :: Servant.Server ServantHandlerAPI
-servantHandlerSitemap =
-  (swaggerSchemaUIServer swaggerDoc)
+servantHandlerSitemap = swaggerSchemaUIServer swaggerDoc
 
 servantSitemap :: ServerT ServantAPI Handler
 servantSitemap =
   pure (toSwagger (Proxy @OutsideWorldAPI))
-    :<|> ( checkUserExistsUnqualifiedH
-             :<|> checkUserExistsH
-             :<|> getUserUnqualifiedH
-             :<|> getUserH
-         )
+    :<|> checkUserExistsUnqualifiedH
+    :<|> checkUserExistsH
+    :<|> getUserUnqualifiedH
+    :<|> getUserH
 
 -- Note [ephemeral user sideeffect]
 -- If the user is ephemeral and expired, it will be removed upon calling

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -224,8 +224,7 @@ type OutsideWorldAPI =
     :<|> GetUserUnqualified
     :<|> GetUserQualified
 
-type ServantHandlerAPI =
-  SwaggerSchemaUI "api/swagger-ui" "api/swagger.json"
+type ServantHandlerAPI = "api" :> SwaggerSchemaUI "swagger-ui" "swagger.json"
 
 type ServantAPI = OutsideWorldAPI
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -227,9 +227,7 @@ type OutsideWorldAPI =
 type ServantHandlerAPI =
   SwaggerSchemaUI "swagger-ui" "swagger.json"
 
-type ServantAPI =
-  "brig" :> "api-docs" :> Get '[Servant.JSON] Swagger
-    :<|> OutsideWorldAPI
+type ServantAPI = OutsideWorldAPI
 
 -- FUTUREWORK: At the moment this only shows endpoints from brig, but we should
 -- combine the swagger 2.0 endpoints here as well from other services (e.g. spar)
@@ -244,8 +242,7 @@ servantHandlerSitemap = swaggerSchemaUIServer swaggerDoc
 
 servantSitemap :: ServerT ServantAPI Handler
 servantSitemap =
-  pure (toSwagger (Proxy @OutsideWorldAPI))
-    :<|> checkUserExistsUnqualifiedH
+  checkUserExistsUnqualifiedH
     :<|> checkUserExistsH
     :<|> getUserUnqualifiedH
     :<|> getUserH

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -53,7 +53,7 @@ import qualified Brig.User.Auth.Cookie as Auth
 import Brig.User.Email
 import Brig.User.Phone
 import Control.Error hiding (bool)
-import Control.Lens (view, (?~), (^.))
+import Control.Lens (view, (.~), (?~), (^.))
 import Control.Monad.Catch (throwM)
 import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
@@ -67,7 +67,7 @@ import Data.Misc (IpAddr (..))
 import Data.Proxy (Proxy (..))
 import Data.Qualified (Qualified (..))
 import Data.Range
-import Data.Swagger (Swagger, ToSchema (..), description)
+import Data.Swagger (HasInfo (info), HasTitle (title), Swagger, ToSchema (..), description)
 import qualified Data.Swagger.Build.Api as Doc
 import Data.Swagger.Lens (HasSchema (..))
 import qualified Data.Text as Text
@@ -231,13 +231,13 @@ type ServantAPI =
   "brig" :> "api-docs" :> Get '[Servant.JSON] Swagger
     :<|> OutsideWorldAPI
 
+-- FUTUREWORK: At the moment this only shows endpoints from brig, but we should
+-- combine the swagger 2.0 endpoints here as well from other services (e.g. spar)
 swaggerDoc :: Swagger
-swaggerDoc = toSwagger (Proxy @OutsideWorldAPI)
-
--- & info.title       .~ "Cats API"
--- & info.version     .~ "2016.8.7"
--- & info.description ?~ "This is an API that tests servant-swagger support"
---
+swaggerDoc =
+  toSwagger (Proxy @OutsideWorldAPI)
+    & info . title .~ "Wire-Server API as Swagger 2.0 "
+    & info . description ?~ "NOTE: only a few endpoints are visible here at the moment, more will come as we migrate them to Swagger 2.0. In the meantime please also look at the old swagger docs link for the not-yet-migrated endpoints. See https://docs.wire.com/understand/api-client-perspective/swagger.html for the old endpoints."
 
 servantHandlerSitemap :: Servant.Server ServantHandlerAPI
 servantHandlerSitemap = swaggerSchemaUIServer swaggerDoc

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -225,7 +225,7 @@ type OutsideWorldAPI =
     :<|> GetUserQualified
 
 type ServantHandlerAPI =
-  SwaggerSchemaUI "swagger-ui" "swagger.json"
+  SwaggerSchemaUI "api/swagger-ui" "api/swagger.json"
 
 type ServantAPI = OutsideWorldAPI
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -22,9 +22,9 @@ module Brig.API.Public
   ( sitemap,
     apiDocs,
     servantSitemap,
-    servantHandlerSitemap,
+    swaggerDocsAPI,
     ServantAPI,
-    ServantHandlerAPI,
+    SwaggerDocsAPI,
   )
 where
 
@@ -224,7 +224,7 @@ type OutsideWorldAPI =
     :<|> GetUserUnqualified
     :<|> GetUserQualified
 
-type ServantHandlerAPI = "api" :> SwaggerSchemaUI "swagger-ui" "swagger.json"
+type SwaggerDocsAPI = "api" :> SwaggerSchemaUI "swagger-ui" "swagger.json"
 
 type ServantAPI = OutsideWorldAPI
 
@@ -236,8 +236,8 @@ swaggerDoc =
     & info . title .~ "Wire-Server API as Swagger 2.0 "
     & info . description ?~ "NOTE: only a few endpoints are visible here at the moment, more will come as we migrate them to Swagger 2.0. In the meantime please also look at the old swagger docs link for the not-yet-migrated endpoints. See https://docs.wire.com/understand/api-client-perspective/swagger.html for the old endpoints."
 
-servantHandlerSitemap :: Servant.Server ServantHandlerAPI
-servantHandlerSitemap = swaggerSchemaUIServer swaggerDoc
+swaggerDocsAPI :: Servant.Server SwaggerDocsAPI
+swaggerDocsAPI = swaggerSchemaUIServer swaggerDoc
 
 servantSitemap :: ServerT ServantAPI Handler
 servantSitemap =

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -23,7 +23,7 @@ where
 
 import Brig.API (sitemap)
 import Brig.API.Handler
-import Brig.API.Public (ServantAPI, servantSitemap)
+import Brig.API.Public (ServantHandlerAPI, servantHandlerSitemap, ServantAPI, servantSitemap)
 import Brig.AWS (sesQueue)
 import qualified Brig.AWS as AWS
 import qualified Brig.AWS.SesNotification as SesNotification
@@ -96,8 +96,8 @@ mkApp o = do
     servantApp :: Env -> Wai.Application
     servantApp e =
       Servant.serve
-        (Proxy @(ServantAPI :<|> Servant.Raw))
-        (Servant.hoistServer (Proxy @ServantAPI) (toServantHandler e) servantSitemap :<|> Servant.Tagged (app e))
+        (Proxy @(ServantHandlerAPI :<|> ServantAPI :<|> Servant.Raw))
+        (servantHandlerSitemap :<|> Servant.hoistServer (Proxy @ServantAPI) (toServantHandler e) servantSitemap :<|> Servant.Tagged (app e))
 
 lookupRequestIdMiddleware :: (RequestId -> Wai.Application) -> Wai.Application
 lookupRequestIdMiddleware mkapp req cont = do

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -23,7 +23,7 @@ where
 
 import Brig.API (sitemap)
 import Brig.API.Handler
-import Brig.API.Public (ServantAPI, ServantHandlerAPI, servantHandlerSitemap, servantSitemap)
+import Brig.API.Public (ServantAPI, SwaggerDocsAPI, servantSitemap, swaggerDocsAPI)
 import Brig.AWS (sesQueue)
 import qualified Brig.AWS as AWS
 import qualified Brig.AWS.SesNotification as SesNotification
@@ -96,8 +96,16 @@ mkApp o = do
     servantApp :: Env -> Wai.Application
     servantApp e =
       Servant.serve
-        (Proxy @(ServantHandlerAPI :<|> ServantAPI :<|> Servant.Raw))
-        (servantHandlerSitemap :<|> Servant.hoistServer (Proxy @ServantAPI) (toServantHandler e) servantSitemap :<|> Servant.Tagged (app e))
+        ( Proxy
+            @( SwaggerDocsAPI
+                 :<|> ServantAPI
+                 :<|> Servant.Raw
+             )
+        )
+        ( swaggerDocsAPI
+            :<|> Servant.hoistServer (Proxy @ServantAPI) (toServantHandler e) servantSitemap
+            :<|> Servant.Tagged (app e)
+        )
 
 lookupRequestIdMiddleware :: (RequestId -> Wai.Application) -> Wai.Application
 lookupRequestIdMiddleware mkapp req cont = do

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -23,7 +23,7 @@ where
 
 import Brig.API (sitemap)
 import Brig.API.Handler
-import Brig.API.Public (ServantHandlerAPI, servantHandlerSitemap, ServantAPI, servantSitemap)
+import Brig.API.Public (ServantAPI, ServantHandlerAPI, servantHandlerSitemap, servantSitemap)
 import Brig.AWS (sesQueue)
 import qualified Brig.AWS as AWS
 import qualified Brig.AWS.SesNotification as SesNotification

--- a/services/nginz/zwagger-ui/index.html
+++ b/services/nginz/zwagger-ui/index.html
@@ -43,7 +43,6 @@
     <div class="tab">
         <button class="tablinks" onclick="openTab(event, 'Swagger-1.2')" id="defaultOpen">Swagger-1.2</button>
         <button class="tablinks" onclick="openTab(event, 'Swagger-2.0')">Swagger-2.0</button>
-        <button class="tablinks" onclick="openTab(event, 'Brig')">Brig</button>
         <button class="tablinks" onclick="openTab(event, 'BackOffice')">Back Office (if running)</button>
     </div>
     </div>
@@ -53,9 +52,6 @@
     </iframe>
 
     <iframe id="Swagger-2.0" class="tabcontent" src="./tab.html?url_suffix=sso" height="100%" width="100%">
-    </iframe>
-
-    <iframe id="Brig" class="tabcontent" src="./tab.html?url_suffix=brig" height="100%" width="100%">
     </iframe>
 
     <iframe id="BackOffice" class="tabcontent" src="./tab.html?url_suffix=backoffice" height="100%" width="100%">

--- a/stack-deps.nix
+++ b/stack-deps.nix
@@ -17,6 +17,7 @@ pkgs.haskell.lib.buildStackProject {
     pcre
     snappy
     zlib
+    lzma
   ];
   ghc = pkgs.haskell.compiler.ghc884;
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -166,6 +166,7 @@ extra-deps:
 - servant-0.18.2
 - servant-server-0.18.2
 - servant-mock-0.8.7
+- servant-swagger-ui-0.3.4.3.36.1
 - git: https://github.com/wireapp/servant-swagger.git
   commit: 23e9afafadaade29d21181b935286087457171e3
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -499,6 +499,13 @@ packages:
   original:
     hackage: servant-mock-0.8.7
 - completed:
+    hackage: servant-swagger-ui-0.3.4.3.36.1@sha256:b696e28ed2c9090ae3306535a80f4a54a876def2d33db0c795c911826c107cda,1746
+    pantry-tree:
+      size: 878
+      sha256: 137680a15ee0147cd19634d8296d90c2150ca4fd62ed3d56f7e07ccd8823810c
+  original:
+    hackage: servant-swagger-ui-0.3.4.3.36.1
+- completed:
     name: servant-swagger
     version: 1.1.11
     git: https://github.com/wireapp/servant-swagger.git


### PR DESCRIPTION
Relates to https://wearezeta.atlassian.net/browse/SQCORE-232

This could be the first step towards deprecating usage of custom nginx-hosted zwagger-ui

See swagger json under http://localhost:8082/api/swagger.json
and a new and shiny UI under http://localhost:8082/api/swagger-ui

The same routes are also exposed through nginz.

We could keep the existing zwagger-ui as-is, but document new endpoints under a new URL going forward. In the long term, we could remove the old custom nginz-zwagger-ui.


![new-ui](https://user-images.githubusercontent.com/2112744/101078912-14d13e80-35a7-11eb-8988-c8e919a714d9.png)

