### PR TITLE
brig:  Allow setting a static SFT Server

### DIFF
--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -32,6 +32,7 @@ import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (typeMismatch)
 import Data.Domain (Domain (..))
 import Data.Id
+import Data.Misc (HttpsUrl)
 import Data.Scientific (toBoundedInteger)
 import Data.Time.Clock (NominalDiffTime)
 import Data.Yaml (FromJSON (..), ToJSON (..))
@@ -481,7 +482,12 @@ data Settings = Settings
     -- e.g. '_sft._tcp.example.com'
     setSftDomain :: !(Maybe Domain),
     -- | The maximum amount of SFT URLs sent to clients
-    setSftListLength :: !(Maybe Int)
+    setSftListLength :: !(Maybe Int),
+    -- | When set; instead of using SRV lookups to discover SFTs the calls
+    -- config will always return this entry. This is useful in Kubernetes
+    -- where SFTs are deployed behind a load-balancer.  In the long-run the SRV
+    -- fetching logic can go away completely
+    setSftStaticUrl :: !(Maybe HttpsUrl)
   }
   deriving (Show, Generic)
 
@@ -577,6 +583,7 @@ Lens.makeLensesFor
     ("setFederationDomain", "federationDomain"),
     ("setSftDomain", "sftDomain"),
     ("setSftListLength", "sftListLength"),
+    ("setSftStaticUrl", "sftStaticUrl"),
     ("setSqsThrottleMillis", "sqsThrottleMillis")
   ]
   ''Settings


### PR DESCRIPTION
When SFT is deployed behind a load-balancer we can get away with a
single static entry. We need this for our Kubernetes-based SFT
deployment.

This still needs an integration test

This is needed for https://github.com/wireapp/wire-server-deploy/pull/383 and https://github.com/wireapp/wire-server-deploy/pull/382

If we in the near future move SFT into kubernetes for our own production environment  we could remove the SRV code. Instead I keep it around for now.


This is currently based on https://github.com/wireapp/wire-server/pull/1271  but there is nothing in that PR that is **absolutely necessary** except that (to me) the change was a bit easier to do. 

But "ignore SRV lookups if we have a static URL" could perfectly well be done on develop as well. Lets see how controversial the other PR is; but if it's not and can be quickly merged I prefer to not rebase this :)

So I could rebase this onto develop if need be. It would some adjustments to apply cleanly


Part of  https://wearezeta.atlassian.net/browse/SQPIT-63 and https://wearezeta.atlassian.net/browse/SQPIT-64

Also see the design in https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/150930455/SFT+Load+balancing