### PR TITLE
Fix .cabal & package.yaml galley-types and galley

### DIFF
--- a/libs/galley-types/galley-types.cabal
+++ b/libs/galley-types/galley-types.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b41772acd74181a186da3c81fa43def5f82ca80b35c55f158ae40376fa8097ff
+-- hash: ca2f734c53caa46ec936e61bd48f4e3222441845a672faf97c130c4b5476dc15
 
 name:           galley-types
 version:        0.81.0

--- a/libs/galley-types/package.yaml
+++ b/libs/galley-types/package.yaml
@@ -29,6 +29,7 @@ library:
   - hashable
   - lens >=4.12
   - protobuf >=0.2
+  - QuickCheck
   - string-conversions
   - swagger >=0.1
   - text >=0.11

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8d1732701d27a292c8f93089f1ee1974b6503965f983b1f43c3a5fdda3c1cdbf
+-- hash: f35db14d16a97a4e422ca39c413622dc01ac28c6e743bfb206ed1b41ed3ff7e6
 
 name:           galley
 version:        0.83.0


### PR DESCRIPTION
Fixes broken and inconsitent cabal and package.yaml for galley-types introduced by https://github.com/wireapp/wire-server/pull/1256