### PR TITLE
brig: Allow setting a static SFT Server  (rebased  on develop)

### DIFF
--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -33,6 +33,7 @@ import Data.Aeson.Types (typeMismatch)
 import qualified Data.Char as Char
 import Data.Domain (Domain (..))
 import Data.Id
+import Data.Misc (HttpsUrl)
 import Data.Range
 import Data.Scientific (toBoundedInteger)
 import qualified Data.Text as Text
@@ -483,7 +484,12 @@ data Settings = Settings
     -- Customer extensions
 
     -- | Customer extensions.  Read 'CustomerExtensions' docs carefully!
-    setCustomerExtensions :: !(Maybe CustomerExtensions)
+    setCustomerExtensions :: !(Maybe CustomerExtensions),
+    -- | When set; instead of using SRV lookups to discover SFTs the calls
+    -- config will always return this entry. This is useful in Kubernetes
+    -- where SFTs are deployed behind a load-balancer.  In the long-run the SRV
+    -- fetching logic can go away completely
+    setSftStaticUrl :: !(Maybe HttpsUrl)
   }
   deriving (Show, Generic)
 
@@ -606,7 +612,8 @@ Lens.makeLensesFor
     ("setSearchSameTeamOnly", "searchSameTeamOnly"),
     ("setUserMaxPermClients", "userMaxPermClients"),
     ("setFederationDomain", "federationDomain"),
-    ("setSqsThrottleMillis", "sqsThrottleMillis")
+    ("setSqsThrottleMillis", "sqsThrottleMillis"),
+    ("setSftStaticUrl", "sftStaticUrl")
   ]
   ''Settings
 

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -54,7 +54,10 @@ tests m b opts turn turnV2 = do
             test m "multiple servers /calls/config - 200" . withTurnFile turn $ testCallsConfigMultiple b,
             test m "multiple servers /calls/config/v2 - 200" . withTurnFile turnV2 $ testCallsConfigMultipleV2 b
           ],
-        testGroup "sft" $ [test m "SFT servers /calls/config/v2 - 200" $ testSFT b opts]
+        testGroup "sft" $
+          [ test m "SFT servers /calls/config/v2 - 200" $ testSFT b opts,
+            test m "SFT servers static URI - 200" $ testSFTStatic b opts
+          ]
       ]
 
 testCallsConfig :: Brig -> Http ()
@@ -83,6 +86,18 @@ testCallsConfigMultiple b turnUpdater = do
   -- Revert the config file back to the original
   let _expected = List1.singleton (toTurnURILegacy "127.0.0.1" 3478)
   modifyAndAssert b uid getTurnConfigurationV1 turnUpdater "turn:127.0.0.1:3478" _expected
+
+testSFTStatic :: Brig -> Opts.Opts -> Http ()
+testSFTStatic b opts = do
+  uid <- userId <$> randomUser b
+  let Right server1 = mkHttpsUrl =<< first show (parseURI laxURIParserOptions "https://sft01.integration-tests.zinfra.io:443")
+  withSettingsOverrides (opts & Opts.optionSettings . Opts.sftStaticUrl ?~ server1) $ do
+    cfg1 <- retryWhileN 10 (isNothing . view rtcConfSftServers) (getTurnConfigurationV2 uid b)
+    liftIO $
+      assertEqual
+        "when SFT static URL is enabled, sft_servers should return just one static entry."
+        (Set.fromList [sftServer server1])
+        (Set.fromList $ maybe [] NonEmpty.toList $ cfg1 ^. rtcConfSftServers)
 
 testSFT :: Brig -> Opts.Opts -> Http ()
 testSFT b opts = do


### PR DESCRIPTION
When SFT is deployed behind a load-balancer we can get away with a
single static entry. We need this for our Kubernetes-based SFT
deployment.