### PR TITLE
Increase the max allowed search results from 100 to 500.

### DIFF
--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -54,7 +54,7 @@ routesPublic = do
     Doc.parameter Doc.Query "q" Doc.string' $
       Doc.description "Search query"
     Doc.parameter Doc.Query "size" Doc.int32' $ do
-      Doc.description "Number of results to return"
+      Doc.description "Number of results to return (min: 1, max: 500, default: 15)"
       Doc.optional
     Doc.returns (Doc.ref Public.modelSearchResult)
     Doc.response 200 "The search result." Doc.end
@@ -84,10 +84,10 @@ routesInternal = do
 
 -- Handlers
 
-searchH :: JSON ::: UserId ::: Text ::: Range 1 100 Int32 -> Handler Response
+searchH :: JSON ::: UserId ::: Text ::: Range 1 500 Int32 -> Handler Response
 searchH (_ ::: u ::: q ::: s) = json <$> lift (search u q s)
 
-search :: UserId -> Text -> Range 1 100 Int32 -> AppIO (Public.SearchResult Public.Contact)
+search :: UserId -> Text -> Range 1 500 Int32 -> AppIO (Public.SearchResult Public.Contact)
 search searcherId searchTerm maxResults = do
   -- FUTUREWORK(federation, #1269):
   -- If the query contains a qualified handle, forward the search to the remote

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -162,14 +162,14 @@ searchIndex ::
   -- | The search query
   Text ->
   -- | The maximum number of results.
-  Range 1 100 Int32 ->
+  Range 1 500 Int32 ->
   m (SearchResult Contact)
 searchIndex u teamSearchInfo q = queryIndex (defaultUserQuery u teamSearchInfo q)
 
 queryIndex ::
   (MonadIndexIO m, FromJSON r) =>
   IndexQuery r ->
-  Range 1 100 Int32 ->
+  Range 1 500 Int32 ->
   m (SearchResult r)
 queryIndex (IndexQuery q f) (fromRange -> s) = liftIndexIO $ do
   idx <- asks idxName


### PR DESCRIPTION
We decided that we'll keep using search in team-settings for now to get some overview of the team (in addition to a csv download button for getting an exhaustive member list).

I'm hoping this is not going to put too much load on ES in prod, but we can keep an eye on it during testing on staging.