### PR TITLE
servantify /self endpoint

### DIFF
--- a/libs/api-bot/src/Network/Wire/Bot/Cache.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Cache.hs
@@ -87,7 +87,7 @@ toUser _ domain acc [i, e, p] = do
       pw
       User
         { userId = ui,
-          userQualifiedUser = Qualified ui domain,
+          userQualifiedId = Qualified ui domain,
           userDisplayName = Name $ "Fakebot-" <> Text.toStrict (Text.strip i),
           userPict = Pict [],
           userAssets = [],

--- a/libs/api-bot/src/Network/Wire/Bot/Monad.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Monad.hs
@@ -149,7 +149,8 @@ data BotNetEnv = BotNetEnv
 newBotNetEnv :: Manager -> Logger -> BotNetSettings -> IO BotNetEnv
 newBotNetEnv manager logger o = do
   gen <- MWC.createSystemRandom
-  usr <- maybe Cache.empty (Cache.fromFile logger gen) (setBotNetUsersFile o)
+  let domain = setBotNetFederationDomain o
+  usr <- maybe Cache.empty (Cache.fromFile logger gen domain) (setBotNetUsersFile o)
   mbx <- maybe (return []) loadMailboxConfig (setBotNetMailboxConfig o)
   met <- initMetrics
   let srv =

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -44,7 +44,7 @@ import Data.Bifunctor (first)
 import Data.ByteString.Conversion (FromByteString (parser))
 import Data.Domain (Domain, domainText)
 import Data.Handle (Handle (..))
-import Data.Id (Id (toUUID), UserId)
+import Data.Id (Id (toUUID))
 import Data.Proxy (Proxy (..))
 import Data.String.Conversions (cs)
 import Data.Swagger
@@ -133,9 +133,9 @@ renderQualifiedId = renderQualified (cs . UUID.toString . toUUID)
 mkQualifiedId :: Text -> Either String (Qualified (Id a))
 mkQualifiedId = Atto.parseOnly (parser <* Atto.endOfInput) . Text.E.encodeUtf8
 
-instance ToSchema (Qualified UserId) where
+instance ToSchema (Qualified (Id a)) where
   declareNamedSchema _ = do
-    idSchema <- declareSchemaRef (Proxy @UserId)
+    idSchema <- declareSchemaRef (Proxy @(Id a))
     domainSchema <- declareSchemaRef (Proxy @Domain)
     return $
       NamedSchema (Just "QualifiedUserId") $

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE StrictData #-}
 
 -- This file is part of the Wire Server implementation.
@@ -35,15 +36,18 @@ module Data.Qualified
 where
 
 import Control.Applicative (optional)
-import Data.Aeson (FromJSON, ToJSON, withText)
+import Control.Lens ((.~), (?~))
+import Data.Aeson (FromJSON, ToJSON, withObject, withText, (.:), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
 import Data.Bifunctor (first)
 import Data.ByteString.Conversion (FromByteString (parser))
 import Data.Domain (Domain, domainText)
 import Data.Handle (Handle (..))
-import Data.Id (Id (toUUID))
+import Data.Id (Id (toUUID), UserId)
+import Data.Proxy (Proxy (..))
 import Data.String.Conversions (cs)
+import Data.Swagger
 import qualified Data.Text.Encoding as Text.E
 import qualified Data.UUID as UUID
 import Imports hiding (local)
@@ -129,11 +133,25 @@ renderQualifiedId = renderQualified (cs . UUID.toString . toUUID)
 mkQualifiedId :: Text -> Either String (Qualified (Id a))
 mkQualifiedId = Atto.parseOnly (parser <* Atto.endOfInput) . Text.E.encodeUtf8
 
+instance ToSchema (Qualified UserId) where
+  declareNamedSchema _ = do
+    idSchema <- declareSchemaRef (Proxy @UserId)
+    domainSchema <- declareSchemaRef (Proxy @Domain)
+    return $
+      NamedSchema (Just "QualifiedUserId") $
+        mempty
+          & type_ ?~ SwaggerObject
+          & properties
+            .~ [ ("id", idSchema),
+                 ("domain", domainSchema)
+               ]
+
 instance ToJSON (Qualified (Id a)) where
-  toJSON = Aeson.String . renderQualifiedId
+  toJSON qu = Aeson.object ["id" .= _qLocalPart qu, "domain" .= _qDomain qu]
 
 instance FromJSON (Qualified (Id a)) where
-  parseJSON = withText "QualifiedUserId" $ either fail pure . mkQualifiedId
+  parseJSON = withObject "QualifiedUserId" $ \o ->
+    Qualified <$> o .: "id" <*> o .: "domain"
 
 instance FromHttpApiData (Qualified (Id a)) where
   parseUrlPiece = first cs . mkQualifiedId

--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -35,6 +35,7 @@ library:
   - generic-random >=1.2
   - hashable
   - hostname-validate
+  - insert-ordered-containers
   - iproute >=1.5
   - iso3166-country-codes >=0.2
   - iso639 >=0.1

--- a/libs/wire-api/src/Wire/API/Swagger.hs
+++ b/libs/wire-api/src/Wire/API/Swagger.hs
@@ -137,7 +137,6 @@ models =
     Team.Permission.modelPermissions,
     Team.SearchVisibility.modelTeamSearchVisibility,
     User.modelUserIdList,
-    User.modelSelf,
     User.modelUser,
     User.modelNewUser,
     User.modelUserUpdate,

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -76,17 +76,16 @@ module Wire.API.User
     module Wire.API.User.Profile,
 
     -- * Swagger
-    modelUserIdList,
-    modelSelf,
-    modelUser,
-    modelNewUser,
-    modelUserUpdate,
-    modelChangePassword,
-    modelChangeLocale,
-    modelEmailUpdate,
-    modelPhoneUpdate,
     modelChangeHandle,
+    modelChangeLocale,
+    modelChangePassword,
     modelDelete,
+    modelEmailUpdate,
+    modelNewUser,
+    modelPhoneUpdate,
+    modelUser,
+    modelUserIdList,
+    modelUserUpdate,
     modelVerifyDelete,
   )
 where
@@ -279,38 +278,6 @@ newtype SelfProfile = SelfProfile
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform SelfProfile)
   deriving newtype (ToSchema)
-
-modelSelf :: Doc.Model
-modelSelf = Doc.defineModel "Self" $ do
-  Doc.description "Self Profile"
-  Doc.property "id" Doc.bytes' $
-    Doc.description "User ID"
-  Doc.property "name" Doc.string' $
-    Doc.description "Name"
-  Doc.property "assets" (Doc.array (Doc.ref modelAsset)) $
-    Doc.description "Profile assets"
-  Doc.property "email" Doc.string' $ do
-    Doc.description "Email address"
-    Doc.optional
-  Doc.property "phone" Doc.string' $ do
-    Doc.description "E.164 Phone number"
-    Doc.optional
-  Doc.property "accent_id" Doc.int32' $ do
-    Doc.description "Accent colour ID"
-    Doc.optional
-  Doc.property "locale" Doc.string' $
-    Doc.description "Locale in <ln-cc> format."
-  Doc.property "handle" Doc.string' $ do
-    Doc.description "Unique handle."
-    Doc.optional
-  Doc.property "deleted" Doc.bool' $ do
-    Doc.description "Whether the account has been deleted."
-    Doc.optional
-  Doc.property "managed_by" typeManagedBy $ do
-    Doc.description
-      "What is the source of truth for this user; if it's SCIM \
-      \then the profile can't be edited via normal means"
-    Doc.optional
 
 instance ToJSON SelfProfile where
   toJSON (SelfProfile u) = toJSON u

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -117,6 +117,7 @@ import Data.Json.Util (UTCTimeMillis, (#))
 import qualified Data.List as List
 import Data.Misc (PlainTextPassword (..))
 import Data.Proxy (Proxy (..))
+import Data.Qualified
 import Data.Range
 import Data.Swagger (ToSchema (..), genericDeclareNamedSchema, properties, required, schema)
 import qualified Data.Swagger.Build.Api as Doc
@@ -132,7 +133,6 @@ import Wire.API.User.Activation (ActivationCode)
 import Wire.API.User.Auth (CookieLabel)
 import Wire.API.User.Identity
 import Wire.API.User.Profile
-import Data.Qualified
 
 --------------------------------------------------------------------------------
 -- UserIdList
@@ -327,7 +327,7 @@ instance FromJSON SelfProfile where
 -- | The data of an existing user.
 data User = User
   { userId :: UserId,
-    userQualifiedUser :: Qualified UserId,
+    userQualifiedId :: Qualified UserId,
     -- | User identity. For endpoints like @/self@, it will be present in the response iff
     -- the user is activated, and the email/phone contained in it will be guaranteedly
     -- verified. {#RefActivation}
@@ -391,7 +391,7 @@ instance ToJSON User where
   toJSON u =
     object $
       "id" .= userId u
-        # "qualified_user" .= userQualifiedUser u
+        # "qualified_id" .= userQualifiedId u
         # "name" .= userDisplayName u
         # "picture" .= userPict u
         # "assets" .= userAssets u
@@ -413,7 +413,7 @@ instance FromJSON User where
     ssoid <- o .:? "sso_id"
     User
       <$> o .: "id"
-      <*> o .: "qualified_user"
+      <*> o .: "qualified_id"
       <*> parseIdentity ssoid o
       <*> o .: "name"
       <*> o .:? "picture" .!= noPict

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -132,6 +132,7 @@ import Wire.API.User.Activation (ActivationCode)
 import Wire.API.User.Auth (CookieLabel)
 import Wire.API.User.Identity
 import Wire.API.User.Profile
+import Data.Qualified
 
 --------------------------------------------------------------------------------
 -- UserIdList
@@ -326,6 +327,7 @@ instance FromJSON SelfProfile where
 -- | The data of an existing user.
 data User = User
   { userId :: UserId,
+    userQualifiedUser :: Qualified UserId,
     -- | User identity. For endpoints like @/self@, it will be present in the response iff
     -- the user is activated, and the email/phone contained in it will be guaranteedly
     -- verified. {#RefActivation}
@@ -389,6 +391,7 @@ instance ToJSON User where
   toJSON u =
     object $
       "id" .= userId u
+        # "qualified_user" .= userQualifiedUser u
         # "name" .= userDisplayName u
         # "picture" .= userPict u
         # "assets" .= userAssets u
@@ -410,6 +413,7 @@ instance FromJSON User where
     ssoid <- o .:? "sso_id"
     User
       <$> o .: "id"
+      <*> o .: "qualified_user"
       <*> parseIdentity ssoid o
       <*> o .: "name"
       <*> o .:? "picture" .!= noPict

--- a/libs/wire-api/src/Wire/API/User/Identity.hs
+++ b/libs/wire-api/src/Wire/API/User/Identity.hs
@@ -283,6 +283,9 @@ data UserSSOId
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform UserSSOId)
 
+-- FUTUREWORK: This schema should ideally be a choice of either tenant+subject, or scim_external_id
+-- but this is currently not possible to derive in swagger2
+-- Maybe this becomes possible with swagger 3?
 instance ToSchema UserSSOId where
   declareNamedSchema _ = do
     tenantSchema <- declareSchemaRef (Proxy @Text)

--- a/libs/wire-api/src/Wire/API/User/Profile.hs
+++ b/libs/wire-api/src/Wire/API/User/Profile.hs
@@ -289,6 +289,7 @@ data ManagedBy
     ManagedByScim
   deriving stock (Eq, Bounded, Enum, Show, Generic)
   deriving (Arbitrary) via (GenericUniform ManagedBy)
+  deriving (ToSchema) via (CustomSwagger '[ConstructorTagModifier (StripPrefix "ManagedBy", CamelToSnake)] ManagedBy)
 
 typeManagedBy :: Doc.DataType
 typeManagedBy =

--- a/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
@@ -28,7 +28,10 @@ import qualified Wire.API.User as User
 tests :: T.TestTree
 tests =
   T.localOption (T.Timeout (60 * 1000000) "60s") . T.testGroup "JSON roundtrip tests" $
-    [testToJSON @User.UserProfile]
+    [ testToJSON @User.UserProfile,
+      testToJSON @User.User,
+      testToJSON @User.SelfProfile
+    ]
 
 testToJSON :: forall a. (Arbitrary a, Typeable a, ToJSON a, ToSchema a, Show a) => T.TestTree
 testToJSON = testProperty msg trip

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cb5d5f266e2fdd724d4f01f6136992c85aff49fa7ad01f06f8373a1f3c99abbe
+-- hash: 4e9f1f53fb43a39da1366fe060fe0ef8e2b0185847abdc61552ca3262bf25322
 
 name:           wire-api
 version:        0.1.0
@@ -97,6 +97,7 @@ library
     , hashable
     , hostname-validate
     , imports
+    , insert-ordered-containers
     , iproute >=1.5
     , iso3166-country-codes >=0.2
     , iso639 >=0.1

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -1162,7 +1162,7 @@ createUser (Public.NewUserPublic new) = do
 
 checkUserExistsUnqualifiedH :: UserId -> UserId -> Handler (Union CheckUserExistsResponse)
 checkUserExistsUnqualifiedH self uid = do
-  domain <- API.viewFederationDomain
+  domain <- viewFederationDomain
   checkUserExistsH self domain uid
 
 checkUserExistsH :: UserId -> Domain -> UserId -> Handler (Union CheckUserExistsResponse)
@@ -1182,7 +1182,7 @@ getSelf self = do
 
 getUserUnqualifiedH :: UserId -> UserId -> Handler Public.UserProfile
 getUserUnqualifiedH self uid = do
-  domain <- API.viewFederationDomain
+  domain <- viewFederationDomain
   getUserH self domain uid
 
 getUserH :: UserId -> Domain -> UserId -> Handler Public.UserProfile
@@ -1215,7 +1215,7 @@ listUsersH (_ ::: self ::: qry) =
 listUsers :: UserId -> Either (List UserId) (Range 1 4 (List Handle)) -> Handler [Public.UserProfile]
 listUsers self = \case
   Left us -> do
-    domain <- API.viewFederationDomain
+    domain <- viewFederationDomain
     byIds $ map (`Qualified` domain) (fromList us)
   Right hs -> do
     us <- getIds (fromList $ fromRange hs)
@@ -1225,7 +1225,7 @@ listUsers self = \case
     getIds localHandles = do
       localUsers <- catMaybes <$> traverse (lift . API.lookupHandle) localHandles
       -- FUTUREWORK(federation, #1268): resolve qualified handles, too
-      domain <- API.viewFederationDomain
+      domain <- viewFederationDomain
       pure $ map (`Qualified` domain) localUsers
     byIds :: [Qualified UserId] -> Handler [Public.UserProfile]
     byIds uids =
@@ -1307,7 +1307,7 @@ getHandleInfo :: UserId -> Handle -> Handler (Maybe Public.UserHandleInfo)
 getHandleInfo self handle = do
   ownerProfile <- do
     -- FUTUREWORK(federation, #1268): resolve qualified handles, too
-    domain <- API.viewFederationDomain
+    domain <- viewFederationDomain
     maybeOwnerId <- fmap (flip Qualified domain) <$> (lift $ API.lookupHandle handle)
     case maybeOwnerId of
       Just ownerId -> lift $ API.lookupProfile self ownerId

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -88,7 +88,7 @@ where
 import qualified Brig.API.Error as Error
 import qualified Brig.API.Handler as API (Handler)
 import Brig.API.Types
-import Brig.API.Util (fetchUserIdentity, validateHandle, viewFederationDomain)
+import Brig.API.Util (fetchUserIdentity, validateHandle)
 import Brig.App
 import qualified Brig.Code as Code
 import Brig.Data.Activation (ActivationEvent (..))

--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -20,22 +20,18 @@ module Brig.API.Util
     lookupProfilesMaybeFilterSameTeamOnly,
     lookupSelfProfile,
     validateHandle,
-    viewFederationDomain,
   )
 where
 
 import qualified Brig.API.Error as Error
 import Brig.API.Handler
 import Brig.API.Types
-import Brig.App (AppIO, Env, settings)
+import Brig.App (AppIO)
 import qualified Brig.Data.User as Data
-import Brig.Options (federationDomain)
 import Brig.Types
 import Brig.Types.Intra (accountUser)
-import Control.Lens (view)
 import Control.Monad.Catch (throwM)
 import Control.Monad.Trans.Except (throwE)
-import Data.Domain (Domain)
 import Data.Handle (Handle, parseHandle)
 import Data.Id
 import Data.Maybe
@@ -63,9 +59,3 @@ lookupSelfProfile = fmap (fmap mk) . Data.lookupAccount
 
 validateHandle :: Text -> Handler Handle
 validateHandle = maybe (throwE (Error.StdError Error.invalidHandle)) return . parseHandle
-
---------------------------------------------------------------------------------
--- Federation
-
-viewFederationDomain :: MonadReader Env m => m (Domain)
-viewFederationDomain = view (settings . federationDomain)

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -62,8 +62,7 @@ module Brig.App
     runAppResourceT,
     forkAppIO,
     locationOf,
-
-    viewFederationDomain
+    viewFederationDomain,
   )
 where
 
@@ -97,6 +96,7 @@ import Control.Monad.Catch (MonadCatch, MonadMask)
 import Control.Monad.Trans.Resource
 import Data.ByteString.Conversion
 import Data.Default (def)
+import Data.Domain
 import qualified Data.GeoIP2 as GeoIp
 import Data.IP
 import Data.Id (UserId)
@@ -130,7 +130,6 @@ import qualified System.Logger.Class as LC
 import qualified System.Logger.Extended as Log
 import Util.Options
 import Wire.API.User.Identity (Email)
-import Data.Domain
 
 schemaVersion :: Int32
 schemaVersion = 61

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -62,6 +62,8 @@ module Brig.App
     runAppResourceT,
     forkAppIO,
     locationOf,
+
+    viewFederationDomain
   )
 where
 
@@ -128,6 +130,7 @@ import qualified System.Logger.Class as LC
 import qualified System.Logger.Extended as Log
 import Util.Options
 import Wire.API.User.Identity (Email)
+import Data.Domain
 
 schemaVersion :: Int32
 schemaVersion = 61
@@ -519,3 +522,9 @@ readTurnList = Text.readFile >=> return . fn . mapMaybe fromByteString . fmap Te
   where
     fn [] = Nothing
     fn (x : xs) = Just (list1 x xs)
+
+--------------------------------------------------------------------------------
+-- Federation
+
+viewFederationDomain :: MonadReader Env m => m (Domain)
+viewFederationDomain = view (settings . Opt.federationDomain)

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -67,7 +67,7 @@ module Brig.Data.User
   )
 where
 
-import Brig.App (AppIO, currentTime, settings, zauthEnv)
+import Brig.App (AppIO, currentTime, settings, viewFederationDomain, zauthEnv)
 import Brig.Data.Instances ()
 import Brig.Options
 import Brig.Password
@@ -78,10 +78,12 @@ import Cassandra
 import Control.Error
 import Control.Lens hiding (from)
 import Data.Conduit (ConduitM)
+import Data.Domain
 import Data.Handle (Handle)
 import Data.Id
 import Data.Json.Util (UTCTimeMillis, toUTCTimeMillis)
 import Data.Misc (PlainTextPassword (..))
+import Data.Qualified
 import Data.Range (fromRange)
 import Data.Time (addUTCTime)
 import Data.UUID.V4
@@ -105,6 +107,7 @@ data ReAuthError
 newAccount :: NewUser -> Maybe InvitationId -> Maybe TeamId -> AppIO (UserAccount, Maybe Password)
 newAccount u inv tid = do
   defLoc <- setDefaultLocale <$> view settings
+  domain <- viewFederationDomain
   uid <-
     Id <$> do
       case (inv, newUserUUID u) of
@@ -121,7 +124,7 @@ newAccount u inv tid = do
       now <- liftIO =<< view currentTime
       return . Just . toUTCTimeMillis $ addUTCTime (fromIntegral ttl) now
     _ -> return Nothing
-  return (UserAccount (user uid (locale defLoc) expiry) status, passwd)
+  return (UserAccount (user uid domain (locale defLoc) expiry) status, passwd)
   where
     ident = newUserIdentity u
     pass = newUserPassword u
@@ -135,16 +138,18 @@ newAccount u inv tid = do
     colour = fromMaybe defaultAccentId (newUserAccentId u)
     locale defLoc = fromMaybe defLoc (newUserLocale u)
     managedBy = fromMaybe defaultManagedBy (newUserManagedBy u)
-    user uid l e = User uid ident name pict assets colour False l Nothing Nothing e tid managedBy
+    user uid domain l e = User uid (Qualified uid domain) ident name pict assets colour False l Nothing Nothing e tid managedBy
 
 newAccountInviteViaScim :: UserId -> TeamId -> Maybe Locale -> Name -> Email -> AppIO UserAccount
 newAccountInviteViaScim uid tid locale name email = do
   defLoc <- setDefaultLocale <$> view settings
-  return (UserAccount (user (fromMaybe defLoc locale)) PendingInvitation)
+  domain <- viewFederationDomain
+  return (UserAccount (user domain (fromMaybe defLoc locale)) PendingInvitation)
   where
-    user loc =
+    user domain loc =
       User
         uid
+        (Qualified uid domain)
         (Just $ EmailIdentity email)
         name
         (Pict [])
@@ -386,7 +391,8 @@ lookupAuth u = fmap f <$> retry x1 (query1 authSelect (params Quorum (Identity u
 lookupUsers :: HavePendingInvitations -> [UserId] -> AppIO [User]
 lookupUsers hpi usrs = do
   loc <- setDefaultLocale <$> view settings
-  toUsers loc hpi <$> retry x1 (query usersSelect (params Quorum (Identity usrs)))
+  domain <- viewFederationDomain
+  toUsers domain loc hpi <$> retry x1 (query usersSelect (params Quorum (Identity usrs)))
 
 lookupAccount :: UserId -> AppIO (Maybe UserAccount)
 lookupAccount u = listToMaybe <$> lookupAccounts [u]
@@ -394,7 +400,8 @@ lookupAccount u = listToMaybe <$> lookupAccounts [u]
 lookupAccounts :: [UserId] -> AppIO [UserAccount]
 lookupAccounts usrs = do
   loc <- setDefaultLocale <$> view settings
-  fmap (toUserAccount loc) <$> retry x1 (query accountsSelect (params Quorum (Identity usrs)))
+  domain <- viewFederationDomain
+  fmap (toUserAccount domain loc) <$> retry x1 (query accountsSelect (params Quorum (Identity usrs)))
 
 lookupServiceUser :: ProviderId -> ServiceId -> BotId -> AppIO (Maybe (ConvId, Maybe TeamId))
 lookupServiceUser pid sid bid = retry x1 (query1 cql (params Quorum (pid, sid, bid)))
@@ -605,8 +612,9 @@ userRichInfoUpdate = "UPDATE rich_info SET json = ? WHERE user = ?"
 -- Conversions
 
 -- | Construct a 'UserAccount' from a raw user record in the database.
-toUserAccount :: Locale -> AccountRow -> UserAccount
+toUserAccount :: Domain -> Locale -> AccountRow -> UserAccount
 toUserAccount
+  domain
   defaultLocale
   ( uid,
     name,
@@ -635,6 +643,7 @@ toUserAccount
      in UserAccount
           ( User
               uid
+              (Qualified uid domain)
               ident
               name
               (fromMaybe noPict pict)
@@ -650,8 +659,8 @@ toUserAccount
           )
           (fromMaybe Active status)
 
-toUsers :: Locale -> HavePendingInvitations -> [UserRow] -> [User]
-toUsers defaultLocale havePendingInvitations = fmap mk . filter fp
+toUsers :: Domain -> Locale -> HavePendingInvitations -> [UserRow] -> [User]
+toUsers domain defaultLocale havePendingInvitations = fmap mk . filter fp
   where
     fp :: UserRow -> Bool
     fp =
@@ -707,6 +716,7 @@ toUsers defaultLocale havePendingInvitations = fmap mk . filter fp
             svc = newServiceRef <$> sid <*> pid
          in User
               uid
+              (Qualified uid domain)
               ident
               name
               (fromMaybe noPict pict)

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -29,7 +29,7 @@ import qualified Brig.API.Client as Client
 import Brig.API.Error
 import Brig.API.Handler
 import Brig.API.Types (PasswordResetError (..))
-import Brig.App (AppIO, internalEvents, settings)
+import Brig.App (AppIO, internalEvents, settings, viewFederationDomain)
 import qualified Brig.Code as Code
 import qualified Brig.Data.Client as User
 import qualified Brig.Data.User as User
@@ -66,6 +66,7 @@ import Data.List1 (maybeList1)
 import qualified Data.Map.Strict as Map
 import Data.Misc (Fingerprint (..), Rsa)
 import Data.Predicate
+import Data.Qualified
 import Data.Range
 import qualified Data.Set as Set
 import qualified Data.Swagger.Build.Api as Doc
@@ -829,6 +830,7 @@ addBot zuid zcon cid add = do
       throwStd serviceNotWhitelisted
   -- Prepare a user ID, client ID and token for the bot.
   bid <- BotId <$> randomId
+  domain <- viewFederationDomain
   btk <- Text.decodeLatin1 . toByteString' <$> ZAuth.newBotToken pid bid cid
   let bcl = newClientId (fromIntegral (hash bid))
   -- Ask the external service to create a bot
@@ -846,7 +848,7 @@ addBot zuid zcon cid add = do
   let colour = fromMaybe defaultAccentId (Ext.rsNewBotColour rs)
   let pict = Pict [] -- Legacy
   let sref = newServiceRef sid pid
-  let usr = User (botUserId bid) Nothing name pict assets colour False locale (Just sref) Nothing Nothing Nothing ManagedByWire
+  let usr = User (botUserId bid) (Qualified (botUserId bid) domain) Nothing name pict assets colour False locale (Just sref) Nothing Nothing Nothing ManagedByWire
   let newClt =
         (newClient PermanentClientType (Ext.rsNewBotLastPrekey rs))
           { newClientPrekeys = Ext.rsNewBotPrekeys rs

--- a/services/brig/test/integration/API/User/Handles.hs
+++ b/services/brig/test/integration/API/User/Handles.hs
@@ -156,7 +156,7 @@ testHandleQuery opts brig = do
   -- Query user profiles by handles
   get (brig . path "/users" . queryItem "handles" (toByteString' hdl) . zUser uid) !!! do
     const 200 === statusCode
-    const (Just (Handle hdl)) === (userHandle <=< listToMaybe <=< responseJsonMaybe)
+    const (Just (Handle hdl)) === (profileHandle <=< listToMaybe <=< responseJsonMaybe)
   -- Bulk availability check
   hdl2 <- randomHandle
   hdl3 <- randomHandle

--- a/services/federator/federator.integration.yaml
+++ b/services/federator/federator.integration.yaml
@@ -8,8 +8,8 @@ logNetStrings: false
 optSettings:
   # Would you like to federate with every wire-server installation ?
   #
-  # setFederationStrategy:
-  #   allowAll:
+  setFederationStrategy:
+    allowAll:
   #
   # or only with a select set of other wire-server installations?
   #


### PR DESCRIPTION
* move /self endpoint to servant & swagger 2.0
* expose `qualified_id` field for `GET /self`:

```
 "qualified_id": {
    "id": "00000000-0000-0000-0000-000000000000",
    "domain": "string"
  }
```