### PR TITLE
Data.Qualified: Better field names

### DIFF
--- a/libs/types-common/src/Data/IdMapping.hs
+++ b/libs/types-common/src/Data/IdMapping.hs
@@ -78,11 +78,11 @@ instance ToJSON (IdMapping a) where
 -- FUTUREWORK: This uses V5 UUID namespaces (SHA-1 under the hood). To provide better
 -- protection against collisions, we should use something else, e.g. based on SHA-256.
 hashQualifiedId :: Qualified (Id (Remote a)) -> UUID
-hashQualifiedId Qualified {_qLocalPart, _qDomain} = UUID.V5.generateNamed namespace object
+hashQualifiedId Qualified {qUnqualified, qDomain} = UUID.V5.generateNamed namespace object
   where
     -- using the ID as the namespace sounds backwards, but it works
-    namespace = toUUID _qLocalPart
-    object = BS.unpack . Text.E.encodeUtf8 . domainText $ _qDomain
+    namespace = toUUID qUnqualified
+    object = BS.unpack . Text.E.encodeUtf8 . domainText $ qDomain
 
 ----------------------------------------------------------------------
 -- ARBITRARY

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -96,8 +96,8 @@ instance FromByteString (OptionallyQualified Handle) where
 -- QUALIFIED
 
 data Qualified a = Qualified
-  { _qLocalPart :: a,
-    _qDomain :: Domain
+  { qUnqualified :: a,
+    qDomain :: Domain
   }
   deriving stock (Eq, Ord, Show, Generic)
 
@@ -123,8 +123,8 @@ qualifiedParser localParser = do
 
 partitionRemoteOrLocalIds :: Foldable f => Domain -> f (Qualified a) -> ([Qualified a], [a])
 partitionRemoteOrLocalIds localDomain = foldMap $ \qualifiedId ->
-  if (_qDomain qualifiedId == localDomain)
-    then (mempty, [_qLocalPart qualifiedId])
+  if qDomain qualifiedId == localDomain
+    then (mempty, [qUnqualified qualifiedId])
     else ([qualifiedId], mempty)
 
 ----------------------------------------------------------------------
@@ -156,7 +156,11 @@ instance ToSchema (Qualified (Id a)) where
                ]
 
 instance ToJSON (Qualified (Id a)) where
-  toJSON qu = Aeson.object ["id" .= _qLocalPart qu, "domain" .= _qDomain qu]
+  toJSON qu =
+    Aeson.object
+      [ "id" .= qUnqualified qu,
+        "domain" .= qDomain qu
+      ]
 
 instance FromJSON (Qualified (Id a)) where
   parseJSON = withObject "QualifiedUserId" $ \o ->

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -60,8 +60,8 @@ import Test.QuickCheck (Arbitrary (arbitrary))
 -- OPTIONALLY QUALIFIED
 
 data OptionallyQualified a = OptionallyQualified
-  { _oqLocalPart :: a,
-    _oqDomain :: Maybe Domain
+  { oqUnqualified :: a,
+    oqDomain :: Maybe Domain
   }
   deriving (Eq, Show)
 

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -240,7 +240,7 @@ modelUser = Doc.defineModel "User" $ do
 instance ToJSON UserProfile where
   toJSON u =
     object
-      [ "id" .= _qLocalPart (profileQualifiedId u),
+      [ "id" .= qUnqualified (profileQualifiedId u),
         "qualified_id" .= profileQualifiedId u,
         "name" .= profileName u,
         "picture" .= profilePict u,

--- a/libs/wire-api/src/Wire/API/User/Handle.hs
+++ b/libs/wire-api/src/Wire/API/User/Handle.hs
@@ -70,7 +70,7 @@ instance ToSchema UserHandleInfo where
 instance ToJSON UserHandleInfo where
   toJSON (UserHandleInfo u) =
     object
-      [ "user" .= _qLocalPart u, -- For backwards compatibility
+      [ "user" .= qUnqualified u, -- For backwards compatibility
         "qualified_user" .= u
       ]
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -1331,12 +1331,12 @@ getHandleInfoH self domain handle =
 getHandleInfo :: UserId -> Qualified Handle -> Handler (Maybe Public.UserHandleInfo)
 getHandleInfo self handle = do
   domain <- viewFederationDomain
-  if _qDomain handle == domain
+  if qDomain handle == domain
     then getLocalHandleInfo domain
     else getRemoteHandleInfo
   where
     getLocalHandleInfo domain = do
-      maybeOwnerId <- lift $ API.lookupHandle (_qLocalPart handle)
+      maybeOwnerId <- lift $ API.lookupHandle (qUnqualified handle)
       case maybeOwnerId of
         Nothing -> return Nothing
         Just ownerId -> do


### PR DESCRIPTION
* Typing underscores was getting annoying.
* _qDomain becomes qDomain.
* _qLocalPart becomes qUnqualified. The qualified thing may not be local, so
calling this local seems wrong.
* The `OptionallyQualified` type seems to be unused, I didn't delete it since I thought
  it would be useful when we want to be backwards compatible in request body.