### PR TITLE
Public end-point for getting the team size.

### DIFF
--- a/libs/wire-api/src/Wire/API/Team/Size.hs
+++ b/libs/wire-api/src/Wire/API/Team/Size.hs
@@ -15,6 +15,29 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Brig.Types.Team (module M) where
+module Wire.API.Team.Size
+  ( TeamSize (TeamSize),
+    modelTeamSize,
+  )
+where
 
-import Wire.API.Team.Size as M
+import Data.Aeson
+import qualified Data.Swagger.Build.Api as Doc
+import Imports
+import Numeric.Natural
+
+newtype TeamSize = TeamSize Natural
+  deriving (Show, Eq)
+
+instance ToJSON TeamSize where
+  toJSON (TeamSize s) = object ["teamSize" .= s]
+
+instance FromJSON TeamSize where
+  parseJSON =
+    withObject "TeamSize" $ \o -> TeamSize <$> o .: "teamSize"
+
+modelTeamSize :: Doc.Model
+modelTeamSize = Doc.defineModel "TeamSize" $ do
+  Doc.description "A simple object with a total number of team members."
+  Doc.property "teamSize" Doc.int32' $ do
+    Doc.description "Team size."

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4d09b33af474cbb5b6a2e3e258bc68f263c28dc9f5cd57f622d980c9904cccd9
+-- hash: 49237049744e0baa7ee9251441e64df42af931cc33be6ae9d025b8832b6467db
 
 name:           wire-api
 version:        0.1.0
@@ -56,6 +56,7 @@ library
       Wire.API.Team.Permission
       Wire.API.Team.Role
       Wire.API.Team.SearchVisibility
+      Wire.API.Team.Size
       Wire.API.User
       Wire.API.User.Activation
       Wire.API.User.Auth

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -169,7 +169,10 @@ routesPublic = do
       .&. capture "tid"
 
   document "GET" "teamSize" $ do
-    Doc.summary "Returns the number of team members as an integer."
+    Doc.summary
+      "Returns the number of team members as an integer.  \
+      \Can be out of sync by roughly the `refresh_interval` \
+      \of the ES index."
     Doc.returns (Doc.ref Public.modelTeamSize)
     Doc.response 200 "Invitation successful." Doc.end
     Doc.response 403 "No permission (not admin or owner of this team)." Doc.end

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -66,6 +66,7 @@ import qualified System.Logger.Class as Log
 import Util.Logging (logFunction, logTeam)
 import qualified Wire.API.Team.Invitation as Public
 import qualified Wire.API.Team.Role as Public
+import qualified Wire.API.Team.Size as Public
 import qualified Wire.API.User as Public
 
 routesPublic :: Routes Doc.ApiBuilder Handler ()
@@ -162,6 +163,17 @@ routesPublic = do
     Doc.response 404 "No pending invitations exists." Doc.end
     Doc.response 409 "Multiple conflicting invitations to different teams exists." Doc.end
 
+  get "/teams/:tid/size" (continue teamSizePublicH) $
+    accept "application" "json"
+      .&. header "Z-User"
+      .&. capture "tid"
+
+  document "GET" "teamSize" $ do
+    Doc.summary "Returns the number of team members as an integer."
+    Doc.returns (Doc.ref Public.modelTeamSize)
+    Doc.response 200 "Invitation successful." Doc.end
+    Doc.response 403 "No permission (not admin or owner of this team)." Doc.end
+
 routesInternal :: Routes a Handler ()
 routesInternal = do
   get "/i/teams/invitations/by-email" (continue getInvitationByEmailH) $
@@ -188,6 +200,14 @@ routesInternal = do
   post "/i/teams/:tid/invitations" (continue createInvitationViaScimH) $
     accept "application" "json"
       .&. jsonRequest @NewUserScimInvitation
+
+teamSizePublicH :: JSON ::: UserId ::: TeamId -> Handler Response
+teamSizePublicH (_ ::: uid ::: tid) = json <$> teamSizePublic uid tid
+
+teamSizePublic :: UserId -> TeamId -> Handler TeamSize
+teamSizePublic uid tid = do
+  ensurePermissions uid tid [Team.AddTeamMember] -- limit this to team admins to reduce risk of involuntary DOS attacks
+  teamSize tid
 
 teamSizeH :: JSON ::: TeamId -> Handler Response
 teamSizeH (_ ::: t) = json <$> teamSize t


### PR DESCRIPTION
TODO:

- [ ] add metrics for ES response time, number of calls
- [ ] add load-test *and run it*, or at least do some ad-hoc load-testing
- [ ] if needed, see if the ES query can be tuned
- [ ] if needed, throttle the end-point
- [ ] if that doesn't help enough, keep track of team sizes in cassandra with a counter (incremented and decremented as users are added and removed)
