### PR TITLE
Fix bug: handle lost after registration of scim-invited users

### DIFF
--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -104,8 +104,8 @@ data ReAuthError
   = ReAuthError !AuthError
   | ReAuthMissingPassword
 
-newAccount :: NewUser -> Maybe InvitationId -> Maybe TeamId -> AppIO (UserAccount, Maybe Password)
-newAccount u inv tid = do
+newAccount :: NewUser -> Maybe InvitationId -> Maybe TeamId -> Maybe Handle -> AppIO (UserAccount, Maybe Password)
+newAccount u inv tid mbHandle = do
   defLoc <- setDefaultLocale <$> view settings
   domain <- viewFederationDomain
   uid <-
@@ -138,7 +138,7 @@ newAccount u inv tid = do
     colour = fromMaybe defaultAccentId (newUserAccentId u)
     locale defLoc = fromMaybe defLoc (newUserLocale u)
     managedBy = fromMaybe defaultManagedBy (newUserManagedBy u)
-    user uid domain l e = User uid (Qualified uid domain) ident name pict assets colour False l Nothing Nothing e tid managedBy
+    user uid domain l e = User uid (Qualified uid domain) ident name pict assets colour False l Nothing mbHandle e tid managedBy
 
 newAccountInviteViaScim :: UserId -> TeamId -> Maybe Locale -> Name -> Email -> AppIO UserAccount
 newAccountInviteViaScim uid tid locale name email = do

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -104,6 +104,14 @@ data ReAuthError
   = ReAuthError !AuthError
   | ReAuthMissingPassword
 
+-- | Preconditions:
+--
+-- 1. @newUserUUID u == Just inv || isNothing (newUserUUID u)@.
+-- 2. If @isJust@, @mbHandle@ must be claimed by user with id @inv@.
+--
+-- Condition (2.) is essential for maintaining handle uniqueness.  It is guaranteed by the
+-- fact that we're setting getting @mbHandle@ from table @"user"@, and when/if it was added
+-- there, it was claimed properly.
 newAccount :: NewUser -> Maybe InvitationId -> Maybe TeamId -> Maybe Handle -> AppIO (UserAccount, Maybe Password)
 newAccount u inv tid mbHandle = do
   defLoc <- setDefaultLocale <$> view settings

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -283,7 +283,7 @@ testCreateUserNoIdP = do
         >>= maybe (error "could not find user in brig") pure
     liftIO $ accountStatus brigUser `shouldBe` Active
     liftIO $ userManagedBy (accountUser brigUser) `shouldBe` ManagedByScim
-
+    liftIO $ userHandle (accountUser brigUser) `shouldBe` Just handle
     susr <- getUser tok userid
     let usr = Scim.value . Scim.thing $ susr
     liftIO $ Scim.User.active usr `shouldNotBe` Just (Scim.ScimBool False)


### PR DESCRIPTION
This PR fixes the following bug:

1. SCIM creates an invitation with a user handle
2. The registers with the invitation. The registration function ignores the `handle` value from the invitation and thereby overwrites it with `null` in the users table. However the user and handle are still contained `user_handle` which leads to the issue described in https://wearezeta.atlassian.net/browse/SQSERVICES-158

This bug can be verified by an additional check in the integeration test for SCIM-invitations.