### PR TITLE
Makefile: allow overriding NAMESPACE for kube-integration target

### DIFF
--- a/hack/bin/integration-teardown.sh
+++ b/hack/bin/integration-teardown.sh
@@ -8,7 +8,7 @@ set -ex
 
 echo "NAMESPACE = $NAMESPACE"
 
-helm ls --all --namespace ${NAMESPACE} | grep "test-" | awk '{print $1}' | xargs -n 1 helm -n "$NAMESPACE" delete
+helm ls --all --namespace ${NAMESPACE} | grep -v NAME | awk '{print $1}' | xargs -n 1 helm -n "$NAMESPACE" delete
 
 sleep 10
 


### PR DESCRIPTION
And minor drive-by fixes to bash/Makefile.