### PR TITLE
Add tools/db/repair-handles

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -43,6 +43,7 @@ packages:
 - tools/db/billing-team-member-backfill
 - tools/db/find-undead
 - tools/db/move-team
+- tools/db/repair-handles
 - tools/makedeb
 - tools/rex
 - tools/stern

--- a/tools/db/repair-handles/README.md
+++ b/tools/db/repair-handles/README.md
@@ -1,6 +1,6 @@
 `repair-handles` is CLI that fixes inconsistencies between the tables `brig.user` and `brig.user_handle`.
 
-It fixes two kind of inconsistencies:
+This must be run to repair cassandra_brig after a bug fixed in https://github.com/wireapp/wire-server/pull/1303.  It fixes two kinds of inconsistencies:
 
 1. A user for which `brig.user.handle` is `null` and there is exactly one row `<row>` in `brig.user_handle` matching the user.
    The tool fixes this by setting `brig.user.handle` to `<row>.handle`.

--- a/tools/db/repair-handles/README.md
+++ b/tools/db/repair-handles/README.md
@@ -1,0 +1,8 @@
+`repair-handles` is CLI that fixes inconsistencies between the tables `brig.user` and `brig.user_handle`.
+
+It fixes two kind of inconsistencies:
+
+1. A user for which `brig.user.handle` is `null` and there is exactly one row `<row>` in `brig.user_handle` matching the user.
+   The tool fixes this by setting `brig.user.handle` to `<row>.handle`.
+2. A user for which `brig.user.handle` is set to a value `<handle>` and there are exactly 2 rows `<row1>`, `<row2>` in `brig.user_handle` matching the user, and `<row1>.handle` equals `<handle>`.
+   The tool fixes this by setting `brig.user.handle` to `<row2>.handle` and deleting `<row1>.handle` from `brig.user_handle`.

--- a/tools/db/repair-handles/package.yaml
+++ b/tools/db/repair-handles/package.yaml
@@ -1,0 +1,43 @@
+defaults:
+  local: ../../../package-defaults.yaml
+name: repair-handles
+version: '1.0.0'
+synopsis: Repair inconsistencies between tables user and user_handle
+category: Network
+author: Wire Swiss GmbH
+maintainer: Wire Swiss GmbH <backend@wire.com>
+copyright: (c) 2018 Wire Swiss GmbH
+license: AGPL-3
+
+dependencies:
+- base
+- aeson
+- brig
+- brig-types
+- bytestring
+- bytestring-conversion
+- cassandra-util
+- conduit
+- containers
+- cql
+- extended
+- imports
+- lens
+- mtl
+- optparse-applicative
+- string-conversions
+- text
+- time
+- tinylog
+- types-common
+- unliftio
+- uuid
+- vector
+- wire-api
+
+executables:
+  repair-handles:
+    main: Main.hs
+    source-dirs:
+      - repair-handles
+      - src

--- a/tools/db/repair-handles/repair-handles.cabal
+++ b/tools/db/repair-handles/repair-handles.cabal
@@ -1,0 +1,56 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 25507d1dbb4afa0928786e4a83417111283b6090077f749d0c9e8e5a99da729e
+
+name:           repair-handles
+version:        1.0.0
+synopsis:       Repair inconsistencies between tables user and user_handle
+category:       Network
+author:         Wire Swiss GmbH
+maintainer:     Wire Swiss GmbH <backend@wire.com>
+copyright:      (c) 2018 Wire Swiss GmbH
+license:        AGPL-3
+build-type:     Simple
+
+executable repair-handles
+  main-is: Main.hs
+  other-modules:
+      Options
+      Types
+      Work
+      Paths_repair_handles
+  hs-source-dirs:
+      repair-handles
+      src
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
+  ghc-options: -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
+  build-depends:
+      aeson
+    , base
+    , brig
+    , brig-types
+    , bytestring
+    , bytestring-conversion
+    , cassandra-util
+    , conduit
+    , containers
+    , cql
+    , extended
+    , imports
+    , lens
+    , mtl
+    , optparse-applicative
+    , string-conversions
+    , text
+    , time
+    , tinylog
+    , types-common
+    , unliftio
+    , uuid
+    , vector
+    , wire-api
+  default-language: Haskell2010

--- a/tools/db/repair-handles/repair-handles/Main.hs
+++ b/tools/db/repair-handles/repair-handles/Main.hs
@@ -1,0 +1,5 @@
+import qualified Work
+import Prelude
+
+main :: IO ()
+main = Work.main

--- a/tools/db/repair-handles/src/Options.hs
+++ b/tools/db/repair-handles/src/Options.hs
@@ -1,0 +1,68 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Options where
+
+import Brig.Data.Instances ()
+import Cassandra hiding (Set)
+import Data.Id
+import Data.String.Conversions (cs)
+import Data.UUID
+import Imports
+import Options.Applicative hiding (action)
+import Types
+
+settingsParser :: Parser Settings
+settingsParser =
+  Settings
+    <$> cassandraSettingsParser "brig"
+    <*> cassandraSettingsParser "galley"
+    <*> switch (short 'n' <> long "dry-run")
+    <*> switch (short 'd' <> long "debug")
+    <*> option auto (short 's' <> long "page-size" <> value 1000)
+    <*> (Id . parseUUID <$> strArgument (metavar "TEAM-UUID"))
+
+parseUUID :: HasCallStack => String -> UUID
+parseUUID = fromJust . Data.UUID.fromString
+
+cassandraSettingsParser :: String -> Parser CassandraSettings
+cassandraSettingsParser ks =
+  CassandraSettings
+    <$> strOption
+      ( long ("cassandra-host-" ++ ks)
+          <> metavar "HOST"
+          <> help ("Cassandra Host for: " ++ ks)
+          <> value "localhost"
+          <> showDefault
+      )
+    <*> option
+      auto
+      ( long ("cassandra-port-" ++ ks)
+          <> metavar "PORT"
+          <> help ("Cassandra Port for: " ++ ks)
+          <> value 9042
+          <> showDefault
+      )
+    <*> ( Keyspace . cs
+            <$> strOption
+              ( long ("cassandra-keyspace-" ++ ks)
+                  <> metavar "STRING"
+                  <> help ("Cassandra Keyspace for: " ++ ks)
+                  <> value (ks ++ "_test")
+                  <> showDefault
+              )
+        )

--- a/tools/db/repair-handles/src/Types.hs
+++ b/tools/db/repair-handles/src/Types.hs
@@ -1,0 +1,55 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Types where
+
+import Brig.Data.Instances ()
+import Cassandra hiding (Set)
+import Control.Lens
+import Data.Id
+import Imports
+import qualified System.Logger as Log
+
+data Env = Env
+  { envBrig :: ClientState,
+    envGalley :: ClientState,
+    envPageSize :: Int32,
+    envTeam :: TeamId,
+    envSettings :: Settings,
+    envLogger :: Log.Logger
+  }
+
+data Settings = Settings
+  { _setCasBrig :: !CassandraSettings,
+    _setCasGalley :: !CassandraSettings,
+    _setDryRun :: Bool,
+    _setDebug :: Bool,
+    _setPageSize :: Int32,
+    _setTeamId :: TeamId
+  }
+  deriving (Show)
+
+data CassandraSettings = CassandraSettings
+  { _cHosts :: !String,
+    _cPort :: !Word16,
+    _cKeyspace :: !Keyspace
+  }
+  deriving (Show)
+
+makeLenses ''Settings
+
+makeLenses ''CassandraSettings

--- a/tools/db/repair-handles/src/Work.hs
+++ b/tools/db/repair-handles/src/Work.hs
@@ -1,0 +1,238 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE RecordWildCards #-}
+
+module Work where
+
+import Brig.Data.Instances ()
+import Cassandra hiding (Set)
+import qualified Cassandra as Cas
+import qualified Cassandra.Settings as Cas
+import Conduit
+import Control.Lens
+import Control.Monad.Except
+import qualified Data.Conduit.Combinators as C
+import Data.Handle (Handle)
+import Data.Id
+import qualified Data.Map.Strict as Map
+import Data.String.Conversions (cs)
+import qualified Data.Text as T
+import Imports
+import Options
+import Options.Applicative hiding (action)
+import qualified System.Logger as Log
+import Types
+
+-- | The table user_handle grouped by user
+type HandleMap = Map UserId [Handle]
+
+readHandleMap :: Env -> IO HandleMap
+readHandleMap Env {..} =
+  runConduit $
+    (transPipe (runClient envBrig) $ paginateC selectUserHandle (paramsP Quorum () envPageSize) x1)
+      .| (C.foldM insertAndLog (Map.empty, 0) <&> fst)
+  where
+    selectUserHandle :: PrepQuery R () (Maybe UserId, Maybe Handle)
+    selectUserHandle = "SELECT user, handle FROM user_handle"
+
+    insertAndLog :: (HandleMap, Int) -> [(Maybe UserId, Maybe Handle)] -> IO (HandleMap, Int)
+    insertAndLog (hmap, nTotal) pairs = do
+      let n = length pairs
+      Log.info envLogger $ Log.msg @Text $ "handles loaded: " <> (cs . show $ nTotal + n)
+      pure (foldl' insert hmap pairs, nTotal + n)
+
+    insert :: HandleMap -> (Maybe UserId, Maybe Handle) -> HandleMap
+    insert hmap (Just uid, maybeToList -> handles) =
+      Map.insertWith (++) uid handles hmap
+    insert hmap (Nothing, _) = hmap
+
+data Action
+  = -- | Set the handle for user (column "handle" in table user).
+    -- Precondition:
+    -- The handle is the sole handle owned by the user (according to table user_handle)
+    SetHandle
+      UserId
+      Handle
+  | -- | Change the handle for user (column "handle" in table user)
+    -- and delete the other handle.
+    -- Precondition:
+    -- Both handles are already owned by the user (according to table user_handle)
+    -- and the user doesnt own any more handles.
+    -- syntax: ResetHandle uid handle handleToBeRemoved
+    ResetHandle
+      UserId
+      Handle
+      Handle
+  | NoActionRequired UserId
+  deriving (Show)
+
+data ActionError = ActionError UserId Text [Handle]
+  deriving (Show)
+
+type ActionResult = Either ActionError Action
+
+decideAction ::
+  UserId ->
+  -- | "handle" column in table "brig.user"
+  Maybe Handle ->
+  -- | All handles owned by user in table "brig.user_handle"
+  [Handle] ->
+  ActionResult
+decideAction uid Nothing [handle] = pure $ SetHandle uid handle
+decideAction uid Nothing [] = pure $ NoActionRequired uid
+decideAction uid Nothing handles = throwError $ ActionError uid "No handle set, but multiple handles owned" handles
+decideAction uid (Just currentHandle) handles =
+  case filter (/= currentHandle) handles of
+    [] -> pure $ NoActionRequired uid
+    [otherHandle] -> pure $ ResetHandle uid otherHandle currentHandle
+    handles' -> throwError $ ActionError uid "Handle is set, but multiple handles owned" handles'
+
+sourceActions :: Env -> HandleMap -> ConduitM () ActionResult IO ()
+sourceActions Env {..} hmap =
+  ( transPipe (runClient envGalley) $
+      paginateC selectTeam (paramsP Quorum (pure envTeam) envPageSize) x5
+        .| C.map (fmap runIdentity)
+  )
+    .| C.mapM readUsersPage
+    .| C.concat
+    .| C.map
+      ( \(uid, mbHandle) ->
+          decideAction uid mbHandle (fromMaybe [] $ Map.lookup uid hmap)
+      )
+  where
+    selectTeam :: PrepQuery R (Identity TeamId) (Identity UserId)
+    selectTeam = "SELECT user FROM team_member WHERE team = ?"
+
+    readUsersPage :: [UserId] -> IO [(UserId, Maybe Handle)]
+    readUsersPage uids =
+      runClient envBrig $
+        query selectUsers (params Quorum (pure uids))
+
+    selectUsers :: PrepQuery R (Identity [UserId]) (UserId, Maybe Handle)
+    selectUsers = "SELECT id, handle FROM user WHERE id in ?"
+
+executeAction :: Env -> Action -> IO ()
+executeAction env = \case
+  (NoActionRequired _) -> pure ()
+  (SetHandle uid handle) ->
+    setUserHandle env uid handle
+  (ResetHandle uid handle handleRemove) -> do
+    setUserHandle env uid handle
+    removeHandle env handleRemove
+  where
+    setUserHandle :: Env -> UserId -> Handle -> IO ()
+    setUserHandle Env {..} uid handle =
+      runClient envBrig $
+        Cas.write updateHandle $ params Quorum (handle, uid)
+      where
+        updateHandle :: PrepQuery W (Handle, UserId) ()
+        updateHandle = "UPDATE user SET handle = ? WHERE id = ?"
+
+    removeHandle :: Env -> Handle -> IO ()
+    removeHandle Env {..} handle =
+      runClient envBrig $
+        Cas.write deleteHandle $ params Quorum (pure handle)
+      where
+        deleteHandle :: PrepQuery W (Identity Handle) ()
+        deleteHandle = "DELETE FROM user_handle WHERE handle = ?"
+
+runCommand :: Env -> IO ()
+runCommand env@Env {..} = do
+  Log.info envLogger (Log.msg @Text "Loading all handles...")
+  hmap <- readHandleMap env
+  Log.info envLogger $ Log.msg @Text ("Processing team" <> (if envSettings ^. setDryRun then " (dry-run) " else " ") <> "...")
+  runConduit $
+    sourceActions env hmap
+      .| C.iterM (handleAction env)
+      .| chunkify 100
+      .| C.mapM_ (logSummary env)
+  Log.info envLogger $ Log.msg @Text "Done."
+  where
+    handleAction :: Env -> ActionResult -> IO ()
+    handleAction _env (Left err) = Log.err envLogger (Log.msg . show $ err)
+    handleAction _env (Right action) = do
+      Log.debug envLogger $ Log.msg @Text (cs . show $ action)
+      unless (envSettings ^. setDryRun) $
+        executeAction env action
+
+    logSummary :: Env -> [ActionResult] -> IO ()
+    logSummary _env results = do
+      Log.info envLogger $
+        Log.msg $
+          ("Action summary for batch" <> (if envSettings ^. setDryRun then " (dry-run) " else " ") <> ":\n")
+            <> T.intercalate
+              "\n"
+              ( let (nErrs, nReset, nSet, nNoOp) = foldl' tally (0, 0, 0, 0) results
+                 in catMaybes
+                      [ mark "   error(!)" nErrs,
+                        mark "   reset original handle" nReset,
+                        mark "   set missing handle" nSet,
+                        mark "   do nothing" nNoOp
+                      ]
+              )
+      where
+        mark :: Text -> Int -> Maybe Text
+        mark msg n
+          | n > 0 = Just $ msg <> ": " <> cs (show n)
+          | otherwise = Nothing
+
+        tally :: (Int, Int, Int, Int) -> ActionResult -> (Int, Int, Int, Int)
+        tally (nErrs, nReset, nSet, nNoOp) (Right ResetHandle {}) = (nErrs, nReset + 1, nSet, nNoOp)
+        tally (nErrs, nReset, nSet, nNoOp) (Right SetHandle {}) = (nErrs, nReset, nSet + 1, nNoOp)
+        tally (nErrs, nReset, nSet, nNoOp) (Right NoActionRequired {}) = (nErrs, nReset, nSet, nNoOp + 1)
+        tally (nErrs, nReset, nSet, nNoOp) (Left _) = (nErrs + 1, nReset, nSet, nNoOp)
+
+    chunkify :: Monad m => Int -> ConduitT i [i] m ()
+    chunkify n = void (C.map (: [])) .| C.chunksOfE n
+
+main :: IO ()
+main = do
+  s <- execParser (info (helper <*> settingsParser) desc)
+  lgr <- initLogger (if s ^. setDebug then Log.Debug else Log.Info)
+
+  brig <- initCas (s ^. setCasBrig) lgr
+  galley <- initCas (s ^. setCasGalley) lgr
+
+  let env =
+        Env
+          { envBrig = brig,
+            envGalley = galley,
+            envPageSize = s ^. setPageSize,
+            envTeam = s ^. setTeamId,
+            envSettings = s,
+            envLogger = lgr
+          }
+  runCommand env
+  where
+    desc =
+      header "repair-handles"
+        <> progDesc "Fix dangling and missing handles"
+        <> fullDesc
+    initLogger level =
+      Log.new
+        . Log.setOutput Log.StdOut
+        . Log.setFormat Nothing
+        . Log.setBufSize 0
+        $ Log.setLogLevel level Log.defSettings
+    initCas cas l =
+      Cas.init
+        . Cas.setLogger (Cas.mkLogger l)
+        . Cas.setContacts (cas ^. cHosts) []
+        . Cas.setPortNumber (fromIntegral $ cas ^. cPort)
+        . Cas.setKeyspace (cas ^. cKeyspace)
+        . Cas.setProtocolVersion Cas.V4
+        $ Cas.defSettings


### PR DESCRIPTION
This PR adds a CLI tool `repair-handles` that can fix DB inconsistencies described in
https://wearezeta.atlassian.net/browse/SQSERVICES-158

See also https://github.com/wireapp/wire-server/pull/1303