### PR TITLE
nginz_disco: docker building consistency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,5 @@
 **/dist
 **/target
 **/*.aci
+**/*.tgz
 services/nginz/src/objs

--- a/tools/nginz_disco/Dockerfile
+++ b/tools/nginz_disco/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.10
+FROM alpine:3.12.3
 
 RUN apk add --no-cache curl bash openssl bind-tools
 
-COPY nginz_disco.sh /usr/bin/nginz_disco.sh
+COPY tools/nginz_disco/nginz_disco.sh /usr/bin/nginz_disco.sh
 
 ENTRYPOINT ["/usr/bin/nginz_disco.sh"]

--- a/tools/nginz_disco/Makefile
+++ b/tools/nginz_disco/Makefile
@@ -1,4 +1,4 @@
 .PHONY: docker
 
 docker:
-	docker build -t quay.io/wire/nginz_disco .
+	docker build -t quay.io/wire/nginz_disco -f Dockerfile ../..


### PR DESCRIPTION
Other docker images get their build context from the top level, nginz_disco is inconsistently expecting a subdirectory (and trips up CI).