### PR TITLE
Fix bug: SCIM-Deleting a user retains the externalId

### DIFF
--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -20,11 +20,10 @@
 -- | Client functions for interacting with the Brig API.
 module Spar.Intra.Brig
   ( veidToUserSSOId,
-    veidFromUserSSOId,
     urefToExternalId,
     urefToEmail,
-    userToExternalId,
     veidFromBrigUser,
+    veidFromUserSSOId,
     mkUserName,
     renderValidExternalId,
     emailFromSAML,
@@ -118,17 +117,6 @@ urefToEmail :: SAML.UserRef -> Maybe Email
 urefToEmail uref = case uref ^. SAML.uidSubject . SAML.nameID of
   SAML.UNameIDEmail email -> Just $ emailFromSAML email
   _ -> Nothing
-
-userToExternalId :: MonadError String m => User -> m Text
-userToExternalId usr =
-  case veidFromUserSSOId <$> userSSOId usr of
-    Nothing -> throwError "brig user without sso_id"
-    Just (Left err) -> throwError err
-    Just (Right veid) ->
-      runValidExternalId
-        (\(SAML.UserRef _ subj) -> maybe (throwError "bad uref from brig") pure $ SAML.shortShowNameID subj)
-        (pure . fromEmail)
-        veid
 
 -- | If the brig user has a 'UserSSOId', transform that into a 'ValidExternalId' (this is a
 -- total function as long as brig obeys the api).  Otherwise, if the user has an email, we can

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -32,8 +32,10 @@ import Bilge
 import Bilge.Assert
 import Brig.Types.Intra (AccountStatus (Active, PendingInvitation, Suspended), accountStatus, accountUser)
 import Brig.Types.User as Brig
+import Cassandra
 import qualified Control.Exception
 import Control.Lens
+import Control.Monad.Except (MonadError (throwError))
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Maybe
 import Control.Retry (exponentialBackoff, limitRetries, recovering)
@@ -49,6 +51,7 @@ import Data.Text.Encoding (encodeUtf8)
 import Imports
 import qualified SAML2.WebSSO.Test.MockResponse as SAML
 import qualified SAML2.WebSSO.Types as SAML
+import Spar.Data (lookupScimExternalId)
 import qualified Spar.Data as Data
 import qualified Spar.Intra.Brig as Intra
 import Spar.Scim
@@ -732,7 +735,7 @@ testFindSamlAutoProvisionedUserMigratedWithEmailInTeamWithSSO = do
     runSpar $ Intra.setBrigUserHandle uid handle
     pure usr
   let memberIdWithSSO = userId memberWithSSO
-      externalId = either error id $ Intra.userToExternalId memberWithSSO
+      externalId = either error id $ veidToText =<< Intra.veidFromBrigUser memberWithSSO Nothing
 
   -- NOTE: once SCIM is enabled, SSO auto-provisioning is disabled
   tok <- registerScimToken teamid (Just (idp ^. SAML.idpId))
@@ -742,6 +745,13 @@ testFindSamlAutoProvisionedUserMigratedWithEmailInTeamWithSSO = do
   liftIO $ (scimUserId <$> users) `shouldContain` [memberIdWithSSO]
   Just brigUser' <- runSpar $ Intra.getBrigUser Intra.NoPendingInvitations memberIdWithSSO
   liftIO $ userManagedBy brigUser' `shouldBe` ManagedByScim
+  where
+    veidToText :: MonadError String m => ValidExternalId -> m Text
+    veidToText veid =
+      runValidExternalId
+        (\(SAML.UserRef _ subj) -> maybe (throwError "bad uref from brig") pure $ SAML.shortShowNameID subj)
+        (pure . fromEmail)
+        veid
 
 testFindTeamSettingsInvitedUserMigratedWithEmailInTeamWithSSO :: TestSpar ()
 testFindTeamSettingsInvitedUserMigratedWithEmailInTeamWithSSO = do
@@ -1546,6 +1556,10 @@ specDeleteUser = do
         aFewTimes (getUser_ (Just tok) uid spar) ((== 404) . statusCode)
           !!! const 404 === statusCode
 
+      context "No IDP" $ do
+        describe "Deleting a User" $ do
+          it "should release their externalId" testDeletedUsersFreeExternalIdNoIdp
+
 -- | Azure sends a request for an unknown user to test out whether your API is online However;
 -- it sends a userName that is not a valid wire handle. So we should treat 'invalid' as 'not
 -- found'.
@@ -1594,3 +1608,35 @@ specEmailValidation = do
     context "not enabled in team" . it "does not give user email" $ do
       (uid, _) <- setup False
       eventually $ checkEmail uid Nothing
+
+testDeletedUsersFreeExternalIdNoIdp :: TestSpar ()
+testDeletedUsersFreeExternalIdNoIdp = do
+  env <- ask
+  let brig = env ^. teBrig
+  let spar = env ^. teSpar
+  let clientState = env ^. teCql
+
+  (_owner, tid) <- call $ createUserWithTeam (env ^. teBrig) (env ^. teGalley)
+  tok <- registerScimToken tid Nothing
+
+  email <- randomEmail
+  scimUser <- randomScimUser <&> \u -> u {Scim.User.externalId = Just $ fromEmail email}
+  scimStoredUser <- createUser tok scimUser
+  let uid = scimUserId scimStoredUser
+      userName = Name . fromJust . Scim.User.displayName $ scimUser
+
+  -- accept invitation
+  do
+    inv <- call $ getInvitation brig email
+    Just inviteeCode <- call $ getInvitationCode brig tid (inInvitation inv)
+    registerInvitation email userName inviteeCode True
+    call $ headInvitation404 brig email
+
+  -- delete user
+  deleteUser_ (Just tok) (Just uid) spar
+    !!! const 204 === statusCode
+
+  void $
+    aFewTimes
+      (runClient clientState $ lookupScimExternalId email)
+      (== Nothing)


### PR DESCRIPTION
This PR fixes this bug:
Deleting a user via SCIM when there is no IdP won't remove the entry from `spar.scim_external_ids`.
This might be a cause for issues such as [SQSERVICES-179](https://wearezeta.atlassian.net/browse/SQSERVICES-179)

The test `testDeletedUsersFreeExternalIdNoIdp` proves the bug and the fix.

The function `userToExternalId` was removed because its name is misleading. The only call site of this function is refactored.
