### PR TITLE
 sftd: add support for multiple SFT servers

### DIFF
--- a/charts/sftd/README.md
+++ b/charts/sftd/README.md
@@ -1,5 +1,6 @@
 # SFTD Chart
 
+
 ## Deploy
 
 Replace `example.com` with your own domain here.
@@ -37,6 +38,31 @@ server.
 
 You should configure `brig` to hand out the SFT server to clients by setting
 `brig.optSettings.setSftStaticUrl=https://sftd.example.com:443` on the `wire-server` chart
+
+## Parameters
+
+Please see [values.yaml](./values.yaml) for an overview of parameters that can be configured.
+
+
+## Rollout
+
+Kubernetes will shut down pods and start new ones when rolling out a release. Any calls
+that were in progress on said pod will be terminated and will cause the call to drop.
+
+Kubernetes can be configured to wait for a certain amount of seconds before
+stopping the pod. During this timeframe new calls wil not be initiated on the
+pod, but existing calls will also not be disrupted.  If you want to roll out a
+release with minimal impact you can set the
+[`terminationGracePeriodSeconds`](./values.yaml#L18) option to the maximum
+length you want to wait before cutting off calls.
+
+Currently due to the fact we're using a `StatefulSet` to orchestrate update
+rollouts, and `StatefulSet`s will not replace all pods at once but instead
+one-for-one, a rollout of a release will take `oldReplicas * terminationGracePeriodSeconds`
+to complete.
+
+We might switch to using a `Deployment` for `sftd` in the future, to reduce this time to just `terminationGracePeriodSeconds`.
+
 
 
 ## Multiple sftd deployments in a single cluster

--- a/charts/sftd/README.md
+++ b/charts/sftd/README.md
@@ -18,7 +18,7 @@ helm install sftd wire/sftd  \
 Using Cert-manager:
 ```
 helm install sftd wire/sftd \
-  --set host=example.com \
+  --set host=sftd.example.com \
   --set allowOrigin=https://webapp.example.com \
   --set tls.issuerRef.name=letsencrypt-staging
 ```

--- a/charts/sftd/README.md
+++ b/charts/sftd/README.md
@@ -61,7 +61,7 @@ that were in progress on said pod will be terminated and will cause the call to 
 
 Kubernetes can be configured to wait for a certain amount of seconds before
 stopping the pod. During this timeframe new calls wil not be initiated on the
-pod, but existing calls will also not be disrupted.  If you want to roll out a
+pod, but existing calls will also not be disrupted. If you want to roll out a
 release with minimal impact you can set the
 [`terminationGracePeriodSeconds`](./values.yaml#L18) option to the maximum
 length you want to wait before cutting off calls.
@@ -73,7 +73,7 @@ helm upgrade sftd wire/sftd --set terminationGracePeriodSeconds=3600
 
 Currently due to the fact we're using a `StatefulSet` to orchestrate update
 rollouts, and `StatefulSet`s will not replace all pods at once but instead
-one-for-one, a rollout of a release will take `oldReplicas * terminationGracePeriodSeconds`
+one-for-one (aka. *rolling update*), a rollout of a release will take `oldReplicas * terminationGracePeriodSeconds`
 to complete.
 
 
@@ -87,16 +87,16 @@ helm upgrade wire/sftd --set replicas=4
 
 By default we provision *3* replicas.
 
-Note that due to the usage of `hostNetwork` there can only be _one_ instance of `sftd` per kubernetes node.
+Note that due to the usage of `hostNetwork` there can only be _one_ instance of `sftd` per Kubernetes node.
 You will need as many nodes available as you have replicas.
 
 If you're using a Kubernetes cloud offering, we recommend setting up cluster
-autoscaling so that you automatically provision new kubernetes nodes when the
+auto-scaling so that you automatically provision new Kubernetes nodes when the
 amount of replicas increases.
 
 As a rule of thumb we support *50* concurrent connections per *1 vCPU*. You
 should adjust the amount of replicas based on your expected usage patterns and
-kubernetes node specifications.
+Kubernetes node specifications.
 
 
 ## Multiple sftd deployments in a single cluster

--- a/charts/sftd/README.md
+++ b/charts/sftd/README.md
@@ -37,6 +37,9 @@ Please see [values.yaml](./values.yaml) for an overview of other parameters that
 
 ## Deploy
 
+
+#### As part of `wire-server` umbrella chart
+
 The `sftd` is deployed as part of the `wire-server` umbrella chart. You can edit the `values.yaml` of your `wire-server` chart to configure sftd.
 
 ```yaml
@@ -50,13 +53,18 @@ sftd:
       name: letsencrypt-prod
 ```
 
-Or pass in the options on the command-line (useful if you need to pass in a certificate file)
+#### Standalone
+
+You can also install `sftd` as stand-alone. This is useful if you want to be more careful with releases and
+want to decouple the release lifecycle of `sftd` and `wire-server`.  For example, if you set `terminationGracePeriodSeconds` to
+allow calls to drain to a large number (say a few hours), this would make the deployment of the `wire-server` umbrella-chart that usually is snappy to run very slow.
+
 ```
-helm install wire wire/wire-server  \
-  --set sftd.host=sftd.example.com \
-  --set sftd.allowOrigin=https://webapp.example.com \
-  --set-file sftd.tls.crt=/path/to/tls.crt \
-  --set-file sftd.tls.key=/path/to/tls.key
+helm install sftd wire/sftd \
+  --set host=sftd.example.com \
+  --set allowOrigin=https://webapp.example.com \
+  --set-file tls.crt=/path/to/tls.crt \
+  --set-file tls.key=/path/to/tls.key
 ```
 
 

--- a/charts/sftd/README.md
+++ b/charts/sftd/README.md
@@ -40,7 +40,8 @@ Please see [values.yaml](./values.yaml) for an overview of other parameters that
 
 #### As part of `wire-server` umbrella chart
 
-The `sftd` is deployed as part of the `wire-server` umbrella chart. You can edit the `values.yaml` of your `wire-server` chart to configure sftd.
+The `sftd` is deployed as part of the `wire-server` umbrella chart. You can
+edit the `values.yaml` of your `wire-server` chart to configure sftd.
 
 ```yaml
 sftd:
@@ -55,9 +56,19 @@ sftd:
 
 #### Standalone
 
-You can also install `sftd` as stand-alone. This is useful if you want to be more careful with releases and
-want to decouple the release lifecycle of `sftd` and `wire-server`.  For example, if you set `terminationGracePeriodSeconds` to
-allow calls to drain to a large number (say a few hours), this would make the deployment of the `wire-server` umbrella-chart that usually is snappy to run very slow.
+You can also install `sftd` as stand-alone. This is useful if you want to be
+more careful with releases and want to decouple the release lifecycle of `sftd`
+and `wire-server`.  For example, if you set `terminationGracePeriodSeconds` to
+allow calls to drain to a large number (say a few hours), this would make the
+deployment of the `wire-server` umbrella-chart that usually is snappy to run
+very slow.
+
+In `wire-server` chart's `values.yaml` you should set:
+```yaml
+tags:
+  sftd: false
+```
+To make sure that the umbrella chart does not deploy sftd too.
 
 ```
 helm install sftd wire/sftd \

--- a/charts/sftd/README.md
+++ b/charts/sftd/README.md
@@ -56,13 +56,37 @@ release with minimal impact you can set the
 [`terminationGracePeriodSeconds`](./values.yaml#L18) option to the maximum
 length you want to wait before cutting off calls.
 
+For example to cordon SFTs for one hour before dropping calls:
+```
+helm upgrade sftd wire/sftd --set terminationGracePeriodSeconds=3600
+```
+
 Currently due to the fact we're using a `StatefulSet` to orchestrate update
 rollouts, and `StatefulSet`s will not replace all pods at once but instead
 one-for-one, a rollout of a release will take `oldReplicas * terminationGracePeriodSeconds`
 to complete.
 
-We might switch to using a `Deployment` for `sftd` in the future, to reduce this time to just `terminationGracePeriodSeconds`.
 
+## Scaling up or down
+
+You can scale up and down by specifying `replicas`:
+
+```
+helm upgrade wire/sftd --set replicas=4
+```
+
+By default we provision *3* replicas.
+
+Note that due to the usage of `hostNetwork` there can only be _one_ instance of `sftd` per kubernetes node.
+You will need as many nodes available as you have replicas.
+
+If you're using a Kubernetes cloud offering, we recommend setting up cluster
+autoscaling so that you automatically provision new kubernetes nodes when the
+amount of replicas increases.
+
+As a rule of thumb we support *50* concurrent connections per *1 vCPU*. You
+should adjust the amount of replicas based on your expected usage patterns and
+kubernetes node specifications.
 
 
 ## Multiple sftd deployments in a single cluster

--- a/charts/sftd/README.md
+++ b/charts/sftd/README.md
@@ -44,6 +44,16 @@ You should configure `brig` to hand out the SFT server to clients by setting
 Please see [values.yaml](./values.yaml) for an overview of parameters that can be configured.
 
 
+## Routability
+
+We currently require network connectivity between clients and the SFT server
+and between the SFT server and the restund servers. In other words; the SFT
+server needs to be directly reachable on its public IP to clients and should be
+able to reach the restund servers on their public IPs.
+
+More exotic setups _are_ possible but are currently *not* officially supported. Please
+contact us if you have different constraints.
+
 ## Rollout
 
 Kubernetes will shut down pods and start new ones when rolling out a release. Any calls

--- a/charts/sftd/templates/_helpers.tpl
+++ b/charts/sftd/templates/_helpers.tpl
@@ -41,11 +41,20 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+{{- define "sftd.join-call.labels" -}}
+helm.sh/chart: {{ include "sftd.chart" . }}
+{{ include "sftd.join-call.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
 
 {{/*
 Selector labels
 */}}
 {{- define "sftd.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "sftd.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- define "sftd.join-call.selectorLabels" -}}
+app.kubernetes.io/name: join-call
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/sftd/templates/configmap-join-call.yaml
+++ b/charts/sftd/templates/configmap-join-call.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sftd.fullname" . }}-join-call
+  labels:
+    {{- include "sftd.join-call.labels" . | nindent 4 }}
+
+data:
+  default.conf.template: |
+    server {
+      listen 8080;
+      resolver kube-dns.kube-system.svc.cluster.local;
+
+      location /healthz { return 204; }
+
+      location ~ ^/sfts/([a-z0-9\-]+)/(.*) {
+        proxy_pass http://$1.sftd.${POD_NAMESPACE}.svc.cluster.local:8585/$2;
+      }
+
+    }

--- a/charts/sftd/templates/configmap-join-call.yaml
+++ b/charts/sftd/templates/configmap-join-call.yaml
@@ -9,7 +9,7 @@ data:
   default.conf.template: |
     server {
       listen 8080;
-      resolver kube-dns.kube-system.svc.cluster.local;
+      resolver ${NAMESERVER};
 
       location /healthz { return 204; }
 

--- a/charts/sftd/templates/deployment-join-call.yaml
+++ b/charts/sftd/templates/deployment-join-call.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sftd.fullname" . }}-join-call
+  labels:
+    {{- include "sftd.join-call.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.joinCall.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "sftd.join-call.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "sftd.join-call.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/configmap: {{ include (print .Template.BasePath "/configmap-join-call.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "sftd.fullname" . }}-join-call
+      containers:
+        - name: nginx
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.joinCall.image.repository }}:{{ .Values.joinCall.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d/default.conf.template
+              name: nginx-config
+              subPath: default.conf.template
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              envsubst \${POD_NAMESPACE} < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+              exec nginx -g 'daemon off;'
+

--- a/charts/sftd/templates/deployment-join-call.yaml
+++ b/charts/sftd/templates/deployment-join-call.yaml
@@ -59,6 +59,6 @@ spec:
             - "/bin/sh"
             - "-c"
             - |
-              envsubst \${POD_NAMESPACE} < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+              export NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | tr '\n' ' '`
+              envsubst '$NAMESERVER $POD_NAMESPACE' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
               exec nginx -g 'daemon off;'
-

--- a/charts/sftd/templates/ingress.yaml
+++ b/charts/sftd/templates/ingress.yaml
@@ -17,7 +17,11 @@ spec:
     - host: "{{ .Values.host }}"
       http:
         paths:
-          - path: /
+          - path: /sft/
             backend:
               serviceName: "{{ include "sftd.fullname" . }}"
               servicePort: sft
+          - path: /sfts/
+            backend:
+              serviceName: "{{ include "sftd.fullname" . }}-join-call"
+              servicePort: http

--- a/charts/sftd/templates/service-join-call.yaml
+++ b/charts/sftd/templates/service-join-call.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sftd.fullname" . }}-join-call
+  labels:
+    {{- include "sftd.join-call.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      name: http
+  selector:
+    {{- include "sftd.join-call.selectorLabels" . | nindent 4 }}

--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "sftd.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  # Allows sfts to start up and shut down in parallel when scaling up and down.
+  # However this does not affect upgrades.
+  podManagementPolicy: Parallel
   serviceName: {{ include "sftd.fullname" . }}
   selector:
     matchLabels:

--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -5,9 +5,6 @@ metadata:
   labels:
     {{- include "sftd.labels" . | nindent 4 }}
 spec:
-  # TODO: Make configurable in follow-up PR
-  # This is 1 on purpose as we need more machinery to make multiple SFTs work.
-  # Work for that is tracked in: https://github.com/wireapp/wire-server-deploy/pull/383
   replicas: {{ .Values.replicaCount }}
   serviceName: {{ include "sftd.fullname" . }}
   selector:

--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -8,7 +8,7 @@ spec:
   # TODO: Make configurable in follow-up PR
   # This is 1 on purpose as we need more machinery to make multiple SFTs work.
   # Work for that is tracked in: https://github.com/wireapp/wire-server-deploy/pull/383
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   serviceName: {{ include "sftd.fullname" . }}
   selector:
     matchLabels:
@@ -65,6 +65,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: external-ip
               mountPath: /external-ip
@@ -79,7 +83,7 @@ spec:
               else
                 ACCESS_ARGS="-A ${EXTERNAL_IP}"
               fi
-              exec sftd  -I "${POD_IP}" -M "${POD_IP}" ${ACCESS_ARGS} -u "https://{{ required "must specify host" .Values.host }}"
+              exec sftd  -I "${POD_IP}" -M "${POD_IP}" ${ACCESS_ARGS} -u "https://{{ required "must specify host" .Values.host }}/sfts/${POD_NAME}"
           ports:
             - name: sft
               containerPort: 8585

--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -6,7 +6,7 @@
 # to `hostNetwork`. If this number is higher than the amount of nodes that can
 # be used for scheduling (Also see `nodeSelector`) pods will remain in a
 # pending state untill you add more capacit.
-replicaCount: 3
+replicaCount: 1
 
 image:
   repository: quay.io/wire/sftd
@@ -19,8 +19,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 # The time to wait after terminating an sft node before shutting it down. No
-# new calls will be initiated whilst a pod is terminated. This value will be
-# more useful once we support running multiple sfts behind a load-balancer
+# new calls will be initiated whilst a pod is being terminated.
 terminationGracePeriodSeconds: 10
 
 podAnnotations: {}

--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -2,6 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# The amount of SFT instances to run.  NOTE: Only one SFT can run per node due
+# to `hostNetwork`. If this number is higher than the amount of nodes that can
+# be used for scheduling (Also see `nodeSelector`) pods will remain in a
+# pending state untill you add more capacit.
+replicaCount: 3
+
 image:
   repository: quay.io/wire/sftd
   pullPolicy: IfNotPresent
@@ -67,3 +73,12 @@ tls: {}
     # This is optional since cert-manager will default to this value however
     # if you are using an external issuer, change this to that issuer group.
     # group: cert-manager.io
+
+joinCall:
+  replicaCount: 3
+  image:
+    repository: nginxinc/nginx-unprivileged
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "1.19.5"
+

--- a/charts/wire-server/requirements.yaml
+++ b/charts/wire-server/requirements.yaml
@@ -103,3 +103,8 @@ dependencies:
     - federator
     - haskellServices
     - services
+- name: sftd
+  version: "0.0.42"
+  repository: "file://../sftd"
+  tags:
+    - sftd

--- a/hack/helm_vars/wire-server/values.yaml
+++ b/hack/helm_vars/wire-server/values.yaml
@@ -12,6 +12,7 @@ tags:
   team-settings: false
   account-pages: false
   legalhold: false
+  sftd: false
 
 cassandra-migrations:
   cassandra:


### PR DESCRIPTION
* The ingress assigns an SFT allocation request to a random SFT
* Each sftd pod is made aware of an URL on which it is directly
reachable, and will return the URL in the response to the client.  e.g.
Pod `sftd-0` will be assigned `https://sft.example.com/sfts/sftd-0`
* The client tells this URL to other clients willing to join the call
* Other clients make a request to this URL
* The ingress points requests to `/sfts` to the `join-call` deployment,
which will redirect to the specific pod, such that the client can join
the conference call of the other client

