### PR TITLE
Extract and rename PolyLog to a library for reusability

### DIFF
--- a/libs/polysemy-wire-zoo/package.yaml
+++ b/libs/polysemy-wire-zoo/package.yaml
@@ -1,0 +1,18 @@
+defaults:
+  local: ../../package-defaults.yaml
+name: polysemy-wire-zoo
+version: '0.1.0'
+synopsis: Polysemy interface for various libraries
+description: Polysemy interface for various libraries
+category: Logging
+author: Wire Swiss GmbH
+maintainer: Wire Swiss GmbH <backend@wire.com>
+copyright: (c) 2020 Wire Swiss GmbH
+license: AGPL-3
+dependencies:
+- base >=4.6 && <5.0
+- imports
+- polysemy
+- tinylog
+library:
+  source-dirs: src

--- a/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
+++ b/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
@@ -1,0 +1,34 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 671397b8455cc631d2a21af6a13b2aef0bf2a00b15a1d6d6db5515575e4d98c8
+
+name:           polysemy-wire-zoo
+version:        0.1.0
+synopsis:       Polysemy interface for various libraries
+description:    Polysemy interface for various libraries
+category:       Logging
+author:         Wire Swiss GmbH
+maintainer:     Wire Swiss GmbH <backend@wire.com>
+copyright:      (c) 2020 Wire Swiss GmbH
+license:        AGPL-3
+build-type:     Simple
+
+library
+  exposed-modules:
+      Polysemy.TinyLog
+  other-modules:
+      Paths_polysemy_wire_zoo
+  hs-source-dirs:
+      src
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
+  ghc-options: -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
+  build-depends:
+      base >=4.6 && <5.0
+    , imports
+    , polysemy
+    , tinylog
+  default-language: Haskell2010

--- a/libs/polysemy-wire-zoo/src/Polysemy/TinyLog.hs
+++ b/libs/polysemy-wire-zoo/src/Polysemy/TinyLog.hs
@@ -14,23 +14,32 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
-
-module Brig.PolyLog where
+module Polysemy.TinyLog where
 
 import Imports
 import Polysemy
+import System.Logger (Level (..))
 import qualified System.Logger as Log
 
--- | This effect will help us write tests for log messages
---
--- FUTUREWORK: Move this to a separate module if it is required
---
--- FUTUREWORK: Either write an orphan instance for MonadLogger or provide
--- equivalent functions in System.Logger.Class
-data PolyLog m a where
-  PolyLog :: Log.Level -> (Log.Msg -> Log.Msg) -> PolyLog m ()
+data TinyLog m a where
+  Polylog :: Log.Level -> (Log.Msg -> Log.Msg) -> TinyLog m ()
 
-makeSem 'PolyLog
+makeSem ''TinyLog
 
-runPolyLog :: Member (Embed IO) r => Log.Logger -> Sem (PolyLog ': r) a -> Sem r a
-runPolyLog logger = interpret $ \(PolyLog lvl msg) -> Log.log logger lvl msg
+runTinyLog :: Member (Embed IO) r => Log.Logger -> Sem (TinyLog ': r) a -> Sem r a
+runTinyLog logger = interpret $ \(Polylog lvl msg) -> Log.log logger lvl msg
+
+-- | Abbreviation of 'log' using the corresponding log level.
+trace, debug, info, warn, err, fatal :: Member TinyLog r => (Log.Msg -> Log.Msg) -> Sem r ()
+trace = polylog Trace
+debug = polylog Debug
+info = polylog Info
+warn = polylog Warn
+err = polylog Error
+fatal = polylog Fatal
+{-# INLINE trace #-}
+{-# INLINE debug #-}
+{-# INLINE info #-}
+{-# INLINE warn #-}
+{-# INLINE err #-}
+{-# INLINE fatal #-}

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bb4a3b9b5b4305ddf1e6c3bb031fa8784a988c45b2754e5be43c1db94a057502
+-- hash: 7e6bada8622059c2b1e26bbe89e7ed25aa702ac5b7221503f86aad80e842b388
 
 name:           brig
 version:        1.35.0
@@ -65,7 +65,6 @@ library
       Brig.Options
       Brig.Password
       Brig.Phone
-      Brig.PolyLog
       Brig.Provider.API
       Brig.Provider.DB
       Brig.Provider.Email
@@ -180,6 +179,7 @@ library
     , optparse-applicative >=0.11
     , pem >=0.2
     , polysemy
+    , polysemy-wire-zoo
     , prometheus-client
     , proto-lens >=0.1
     , random-shuffle >=0.0.3
@@ -469,6 +469,7 @@ test-suite brig-tests
     , dns-util
     , imports
     , polysemy
+    , polysemy-wire-zoo
     , retry
     , tasty
     , tasty-hunit

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -83,6 +83,7 @@ library:
   - optparse-applicative >=0.11
   - pem >=0.2
   - polysemy
+  - polysemy-wire-zoo
   - proto-lens >=0.1
   - prometheus-client
   - resourcet >=1.1
@@ -155,6 +156,7 @@ tests:
     - dns-util
     - imports
     - polysemy
+    - polysemy-wire-zoo
     - retry
     - tasty
     - tasty-hunit

--- a/services/brig/test/unit/Test/Brig/Calling.hs
+++ b/services/brig/test/unit/Test/Brig/Calling.hs
@@ -21,7 +21,6 @@ module Test.Brig.Calling where
 
 import Brig.Calling
 import Brig.Options
-import Brig.PolyLog
 import Control.Retry
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
@@ -30,6 +29,7 @@ import qualified Data.Set as Set
 import Imports
 import Network.DNS
 import Polysemy
+import Polysemy.TinyLog
 import qualified System.Logger as Log
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -57,12 +57,12 @@ newtype LogRecorder = LogRecorder {recordedLogs :: IORef [(Log.Level, LByteStrin
 newLogRecorder :: IO LogRecorder
 newLogRecorder = LogRecorder <$> newIORef []
 
-recordLogs :: Member (Embed IO) r => LogRecorder -> Sem (PolyLog ': r) a -> Sem r a
-recordLogs LogRecorder {..} = interpret $ \(PolyLog lvl msg) ->
+recordLogs :: Member (Embed IO) r => LogRecorder -> Sem (TinyLog ': r) a -> Sem r a
+recordLogs LogRecorder {..} = interpret $ \(Polylog lvl msg) ->
   modifyIORef' recordedLogs (++ [(lvl, Log.render (Log.renderDefault ", ") msg)])
 
-ignoreLogs :: Sem (PolyLog ': r) a -> Sem r a
-ignoreLogs = interpret $ \(PolyLog _ _) -> pure ()
+ignoreLogs :: Sem (TinyLog ': r) a -> Sem r a
+ignoreLogs = interpret $ \(Polylog _ _) -> pure ()
 
 {-# ANN tests ("HLint: ignore" :: String) #-}
 tests :: TestTree

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,6 +16,7 @@ packages:
 - libs/imports
 - libs/metrics-core
 - libs/metrics-wai
+- libs/polysemy-wire-zoo
 - libs/ropes
 - libs/sodium-crypto-sign
 - libs/ssl-util


### PR DESCRIPTION
polysemy-wire-zoo is inspired by polysemy-zoo. We can use it to keep our pets
which we might need to interface with other libraries.

I named the constructor `Polylog` so `makeSem` will generate a function called `polylog`. Ideally I would have named it `Log` and the function would've been `log`, but that would collide with `Imports`.