### PR TITLE
dns-util: Allow running lookup with a given resolver

### DIFF
--- a/libs/dns-util/src/Wire/Network/DNS/Effect.hs
+++ b/libs/dns-util/src/Wire/Network/DNS/Effect.hs
@@ -18,7 +18,7 @@
 module Wire.Network.DNS.Effect where
 
 import Imports
-import Network.DNS (Domain)
+import Network.DNS (Domain, Resolver)
 import qualified Network.DNS as DNS
 import Polysemy
 import Wire.Network.DNS.SRV
@@ -34,3 +34,7 @@ runDNSLookupDefault =
     rs <- DNS.makeResolvSeed DNS.defaultResolvConf
     DNS.withResolver rs $ \resolver ->
       interpretResponse <$> DNS.lookupSRV resolver domain
+
+runDNSLookupWithResolver :: Member (Embed IO) r => Resolver -> Sem (DNSLookup ': r) a -> Sem r a
+runDNSLookupWithResolver resolver =
+  interpret $ \(LookupSRV domain) -> embed (interpretResponse <$> DNS.lookupSRV resolver domain)


### PR DESCRIPTION
This will allow us to rely on caching built into the DNS library.

The function is unused right now, but this will help keep the federator work small.