### PR TITLE
Simplify ES upgrade path

### DIFF
--- a/charts/elasticsearch-index/templates/create-index.yaml
+++ b/charts/elasticsearch-index/templates/create-index.yaml
@@ -37,7 +37,8 @@ spec:
             - --elasticsearch-shards=5
             - --elasticsearch-replicas=2
             - --elasticsearch-refresh-interval=5
-            - --delete-template directory
+            - --delete-template
+            - "{{ .Values.elasticsearch.delete_template }}"
       containers:
         - name: brig-index-update-mapping
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/elasticsearch-index/templates/create-index.yaml
+++ b/charts/elasticsearch-index/templates/create-index.yaml
@@ -37,6 +37,7 @@ spec:
             - --elasticsearch-shards=5
             - --elasticsearch-replicas=2
             - --elasticsearch-refresh-interval=5
+            - --delete-template directory
       containers:
         - name: brig-index-update-mapping
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/elasticsearch-index/values.yaml
+++ b/charts/elasticsearch-index/values.yaml
@@ -3,6 +3,7 @@ elasticsearch:
   #host:  # elasticsearch-client|elasticsearch-ephemeral
   port: 9200
   index: directory
+  delete_template: directory
 cassandra:
   # host:
   port: 9042

--- a/docs/reference/elasticsearch-migration-2021-02-15.md
+++ b/docs/reference/elasticsearch-migration-2021-02-15.md
@@ -2,13 +2,28 @@
 
 Release `2021-02-15` of `wire-server` requires creating a new ElasticSearch index for `brig` _before_ deploying the release. Without this new index the user search in TeamSettings will be defunct.
 
-The index that brig is using, is defined at brig's config at `elasticsearch.index`. This config value of the previous deployment is referred to as `<OLD_INDEX>` in the following.
+The index that brig is using, is defined in the `brig` chart's config at `elasticsearch.index`. This config value of the previous deployment is referred to as `<OLD_INDEX>` in the following.
 
 These following instructions describe how to:
 
 1. Create the new index `<NEW_INDEX>` (you can choose any name that is different from `<OLD_INDEX>`)
 2. Populate `<NEW_INDEX>` with brig's data.
 3. Configure brig to use the new index.
+
+Note: The following steps require downtime of brig. If downtime is not acceptable then please skip to section [Create the new index without downtime](#create-the-new-index-without-downtime)
+
+1. Update config for the `elasticsearch-index` chart:
+    - Set `elasticsearch.index` to `<NEW_INDEX>`
+2. Update config for the `brig` chart:
+    - Set `config.elasticsearch.directory` to `<NEW_INDEX>`
+3. Redeploy `wire-server`.
+   The `elasticsearch-index` chart will automatically create and populate `<NEW_INDEX>`
+   before all other services are started. This might take several minutes depending on the
+   number of users.
+   
+You can delete `<OLD_INDEX>` index from ES now.
+
+## Create the new index without downtime
 
 In the following we assume the following env vars are set.
 
@@ -26,46 +41,6 @@ REPLICAS=<NUMBER_OF_REPLICAS_FOR_THE_INDEX> # 2 if you are unsure
 REFRESH_INTERVAL=<REFRESH_INTERVAL_IN_SECONDS> # 5 if you are unsure
 ```
 
-Delete the `directory` index template if it exists:
-
-```bash
-curl -XDELETE http://$ES_HOST:$ES_HOST/_template/directory
-```
-
-The next steps require downtime of brig. If downtime is not acceptable please skip to section [Create the new index without downtime](#create-the-new-index-without-downtime)
-
-1. Shut down the `brig` service.
-2. Create the new index by running
-```sh
-docker run "quay.io/wire/brig-index:$WIRE_VERSION" create \
-    --elasticsearch-server "http://$ES_HOST:$ES_PORT" \
-    --elasticsearch-index "$NEW_INDEX" \
-    --elastcsearch-shards "$SHARDS" \
-    --elastcsearch-replicas "$REPLICAS" \
-    --elastcsearch-refresh-interval "$REFRESH_INTERVAL"
-```
-
-3. Populate the new index by running
-```sh
-docker run "quay.io/wire/brig-index:$WIRE_VERSION" migrate-data \
-  --elasticsearch-server "http://$ES_HOST:$ES_PORT" \
-  --elasticsearch-index "$NEW_INDEX" \
-  --cassandra-host "$BRIG_CASSANDRA_HOST" \
-  --cassandra-port "$BRIG_CASSANDRA_PORT" \
-  --cassandra-keyspace "$BRIG_CASSANDRA_KEYSPACE"
-```
-This may take sevaral minutes depending on number of users.
-
-4. Configure brig to use the new index, by setting `elasticsearch.index` to `<NEW_INDEX>` and deploy of `brig` with new version "$WIRE_VERSION".
-5. Check that team member search in TeamSettings and user search in the app works.
-6. Delete the old index
-```
-```bash
-curl -XDELETE http://$ES_HOST:$ES_HOST/$OLD_INDEX
-```
-
-## Create the new index without downtime
-
 1. Create the new index by running
 
 ```sh
@@ -75,7 +50,13 @@ docker run "quay.io/wire/brig-index:$WIRE_VERSION" create \
     --elastcsearch-shards "$SHARDS" \
     --elastcsearch-replicas "$REPLICAS" \
     --elastcsearch-refresh-interval "$REFRESH_INTERVAL"
+    --delete-template "directory"
 ```
+
+The `--delete-template` option will delete the index template named `directory` if it exists.
+This index template might have been created by previous releases and can cause creating a
+new index to fail. If this template doesn't exist in your ES cluster you can omit the
+`--delete-template` option.
 
 2. Redeploy brig with `elasticsearch.additionalWriteIndex` set to `<NEW_INDEX>`.
 3. Make sure no old instances of brig are running.
@@ -93,12 +74,13 @@ This may take sevaral minutes depending on number of users.
 5. Redeploy brig with these config updates:
     - unset `elasticsearch.additionalWriteIndex`
     - set `elasticsearch.index` to `<NEW_INDEX>`
-6. Check that team member search in TeamSettings and user search in the app works.
-7. Delete the old index
 
-```bash
-curl -XDELETE http://$ES_HOST:$ES_HOST/$OLD_INDEX
-```
+6. Update config for the `elasticsearch-index` chart:
+    - Set `elasticsearch-index` to `<NEW_INDEX>`
+   This prevents the `elasticsearch-index` from automatically recreating the `<OLD_INDEX>`
+   when `wire-server`is deployed.
+
+You can delete `<OLD_INDEX>` index from ES now.
 
 ## Troubleshooting
 

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: de21f2962373c76053047fe9f30bdc6a7dbcec8cf02f3649472597650839075c
+-- hash: b89ebb224877febe7b590ff33ee2dc7e95a5cb84f434b9668e9749623feadb2a
 
 name:           brig
 version:        1.35.0
@@ -57,6 +57,7 @@ library
       Brig.Index.Migrations
       Brig.Index.Migrations.Types
       Brig.Index.Options
+      Brig.Index.Types
       Brig.InternalEvent.Process
       Brig.InternalEvent.Types
       Brig.IO.Intra

--- a/services/brig/src/Brig/Index/Eval.hs
+++ b/services/brig/src/Brig/Index/Eval.hs
@@ -44,12 +44,10 @@ runCommand :: Logger -> Command -> IO ()
 runCommand l = \case
   Create es -> do
     e <- initIndex es
-    let (settings, nShards, mbTemplate) = mkCreateIndexSettings es
-    runIndexIO e $ createIndexIfNotPresent settings nShards mbTemplate
+    runIndexIO e $ createIndexIfNotPresent (mkCreateIndexSettings es)
   Reset es -> do
     e <- initIndex es
-    let (settings, nShards, mbTemplate) = mkCreateIndexSettings es
-    runIndexIO e $ resetIndex settings nShards mbTemplate
+    runIndexIO e $ resetIndex (mkCreateIndexSettings es)
   Reindex es cas -> do
     e <- initIndex es
     c <- initDb cas

--- a/services/brig/src/Brig/Index/Eval.hs
+++ b/services/brig/src/Brig/Index/Eval.hs
@@ -44,10 +44,12 @@ runCommand :: Logger -> Command -> IO ()
 runCommand l = \case
   Create es -> do
     e <- initIndex es
-    runIndexIO e $ uncurry createIndexIfNotPresent $ mkCreateIndexSettings es
+    let (settings, nShards, mbTemplate) = mkCreateIndexSettings es
+    runIndexIO e $ createIndexIfNotPresent settings nShards mbTemplate
   Reset es -> do
     e <- initIndex es
-    runIndexIO e $ uncurry resetIndex $ mkCreateIndexSettings es
+    let (settings, nShards, mbTemplate) = mkCreateIndexSettings es
+    runIndexIO e $ resetIndex settings nShards mbTemplate
   Reindex es cas -> do
     e <- initIndex es
     c <- initDb cas

--- a/services/brig/src/Brig/Index/Options.hs
+++ b/services/brig/src/Brig/Index/Options.hs
@@ -26,7 +26,7 @@ module Brig.Index.Options
     esIndexShardCount,
     esIndexReplicas,
     esIndexRefreshInterval,
-    esTemplateName,
+    esDeleteTemplate,
     CassandraSettings,
     cHost,
     cPort,
@@ -44,6 +44,7 @@ module Brig.Index.Options
   )
 where
 
+import Brig.Index.Types (CreateIndexSettings (..))
 import qualified Cassandra as C
 import Control.Lens
 import Data.ByteString.Lens
@@ -72,7 +73,7 @@ data ElasticSettings = ElasticSettings
     _esIndexShardCount :: Int,
     _esIndexReplicas :: ES.ReplicaCount,
     _esIndexRefreshInterval :: NominalDiffTime,
-    _esTemplateName :: Maybe ES.TemplateName
+    _esDeleteTemplate :: Maybe ES.TemplateName
   }
   deriving (Show)
 
@@ -97,14 +98,14 @@ makeLenses ''CassandraSettings
 
 makeLenses ''ReindexFromAnotherIndexSettings
 
-mkCreateIndexSettings :: ElasticSettings -> ([ES.UpdatableIndexSetting], Int, Maybe ES.TemplateName)
+mkCreateIndexSettings :: ElasticSettings -> CreateIndexSettings
 mkCreateIndexSettings es =
-  ( [ ES.NumberOfReplicas $ _esIndexReplicas es,
+  CreateIndexSettings
+    [ ES.NumberOfReplicas $ _esIndexReplicas es,
       ES.RefreshInterval $ _esIndexRefreshInterval es
-    ],
-    _esIndexShardCount es,
-    _esTemplateName es
-  )
+    ]
+    (_esIndexShardCount es)
+    (_esDeleteTemplate es)
 
 localElasticSettings :: ElasticSettings
 localElasticSettings =
@@ -114,7 +115,7 @@ localElasticSettings =
       _esIndexShardCount = 1,
       _esIndexReplicas = ES.ReplicaCount 1,
       _esIndexRefreshInterval = 1,
-      _esTemplateName = Nothing
+      _esDeleteTemplate = Nothing
     }
 
 localCassandraSettings :: CassandraSettings

--- a/services/brig/src/Brig/Index/Types.hs
+++ b/services/brig/src/Brig/Index/Types.hs
@@ -1,0 +1,28 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Brig.Index.Types where
+
+import qualified Database.Bloodhound as ES
+import Imports
+
+data CreateIndexSettings = CreateIndexSettings
+  { _cisIndexSettings :: [ES.UpdatableIndexSetting],
+    _cisShardCount :: Int,
+    _cisDeleteTemplate :: Maybe ES.TemplateName
+  }
+  deriving (Show)

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -275,6 +275,12 @@ createIndex' failIfExists settings shardCount = liftIndexIO $ do
     throwM (IndexError "Index already exists.")
   unless ex $ do
     let fullSettings = settings ++ [ES.AnalysisSetting analysisSettings]
+    let templateName = (ES.TemplateName "directory")
+    tExists <- ES.templateExists templateName
+    when tExists $ do
+      dr <- ES.deleteTemplate templateName
+      unless (ES.isSuccess dr) $
+        throwM (IndexError "Deleting template failed.")
     cr <- traceES "Create index" $ ES.createIndexWith fullSettings shardCount idx
     unless (ES.isSuccess cr) $
       throwM (IndexError "Index creation failed.")

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -50,6 +50,7 @@ module Brig.User.Search.Index
 where
 
 import Brig.Data.Instances ()
+import Brig.Index.Types (CreateIndexSettings (..))
 import Brig.Types.Intra
 import Brig.Types.User
 import Brig.User.Search.Index.Types as Types
@@ -246,19 +247,13 @@ refreshIndex = liftIndexIO $ do
 
 createIndexIfNotPresent ::
   MonadIndexIO m =>
-  [ES.UpdatableIndexSetting] ->
-  -- | Number of shards
-  Int ->
-  Maybe ES.TemplateName ->
+  CreateIndexSettings ->
   m ()
 createIndexIfNotPresent = createIndex' False
 
 createIndex ::
   MonadIndexIO m =>
-  [ES.UpdatableIndexSetting] ->
-  -- | Number of shards
-  Int ->
-  Maybe ES.TemplateName ->
+  CreateIndexSettings ->
   m ()
 createIndex = createIndex' True
 
@@ -266,13 +261,9 @@ createIndex' ::
   MonadIndexIO m =>
   -- | Fail if index alredy exists
   Bool ->
-  [ES.UpdatableIndexSetting] ->
-  -- | Number of shards
-  Int ->
-  -- | Delete this index template before creation
-  Maybe ES.TemplateName ->
+  CreateIndexSettings ->
   m ()
-createIndex' failIfExists settings shardCount mbDeleteTemplate = liftIndexIO $ do
+createIndex' failIfExists (CreateIndexSettings settings shardCount mbDeleteTemplate) = liftIndexIO $ do
   idx <- asks idxName
   ex <- ES.indexExists idx
   when (failIfExists && ex) $
@@ -291,7 +282,7 @@ createIndex' failIfExists settings shardCount mbDeleteTemplate = liftIndexIO $ d
       when tExists $ do
         dr <- traceES (cs ("Delete index template " <> "\"" <> tname <> "\"")) $ ES.deleteTemplate templateName
         unless (ES.isSuccess dr) $
-          throwM (IndexError $ "Deleting index template failed.")
+          throwM (IndexError "Deleting index template failed.")
 
     cr <- traceES "Create index" $ ES.createIndexWith fullSettings shardCount idx
     unless (ES.isSuccess cr) $
@@ -331,19 +322,16 @@ updateMapping = liftIndexIO $ do
 
 resetIndex ::
   MonadIndexIO m =>
-  [ES.UpdatableIndexSetting] ->
-  -- | Number of shards
-  Int ->
-  Maybe ES.TemplateName ->
+  CreateIndexSettings ->
   m ()
-resetIndex settings shardCount mbTemplate = liftIndexIO $ do
+resetIndex ciSettings = liftIndexIO $ do
   idx <- asks idxName
   gone <-
     ES.indexExists idx >>= \case
       True -> ES.isSuccess <$> traceES "Delete Index" (ES.deleteIndex idx)
       False -> return True
   if gone
-    then createIndex settings shardCount mbTemplate
+    then createIndex ciSettings
     else throwM (IndexError "Index deletion failed.")
 
 reindexAllIfSameOrNewer :: (MonadLogger m, MonadIndexIO m, C.MonadClient m) => m ()

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -275,7 +275,7 @@ createIndex' failIfExists settings shardCount = liftIndexIO $ do
     throwM (IndexError "Index already exists.")
   unless ex $ do
     let fullSettings = settings ++ [ES.AnalysisSetting analysisSettings]
-    let templateName = (ES.TemplateName "directory")
+    let templateName = ES.TemplateName "directory"
     tExists <- ES.templateExists templateName
     when tExists $ do
       dr <- ES.deleteTemplate templateName


### PR DESCRIPTION
This PR updates the `elasticsearch-index` chart to simplify the the ES migration path introduced in #1360.

This PR adds an optional config flag `--delete-template TEMPLATE_NAME`  to `brig-index` that deletes an index template `TEMPLATE_NAME` before it creates any index. If `--delete-template` isn't set then the bahaviour of `brig-index` is unchanged.
