### PR TITLE
Fix nix build on OSX

### DIFF
--- a/nix/overlays/wire-server.nix
+++ b/nix/overlays/wire-server.nix
@@ -14,7 +14,13 @@ self: super: {
           sha256 = "1i9dlhw0xk1viglyhail9fb36v1awrypps8jmhrkz8k1bhx98ci3";
         };
         cargoSha256 = "0zs8ibv7rinrrzp9naxd7yak7kn1gp3pjb3g8i4wf7xw2hkkq81z";
+
+        patchLibs = super.lib.optionalString super.stdenv.isDarwin ''
+            install_name_tool -id $out/lib/libcryptobox.dylib $out/lib/libcryptobox.dylib
+          '';
+      
         postInstall = ''
+          ${patchLibs}
           mkdir -p $out/include
           cp src/cbox.h $out/include
         '';
@@ -32,6 +38,11 @@ self: super: {
         sourceRoot = "libzauth/libzauth-c";
 
         cargoSha256 = "10ijvi3rnnqpy589hhhp8s4p7xfpsbb1c3mzqnf65ra96q4nd6bf"; # self.lib.fakeSha256;
+
+        patchLibs = super.lib.optionalString super.stdenv.isDarwin ''
+            install_name_tool -id $out/lib/libzauth.dylib $out/lib/libzauth.dylib
+          '';
+      
         postInstall = ''
           mkdir -p $out/lib/pkgconfig
           mkdir -p $out/include
@@ -39,7 +50,8 @@ self: super: {
           sed -e "s~<<VERSION>>~${version}~" \
             -e "s~<<PREFIX>>~$out~" \
             src/libzauth.pc > $out/lib/pkgconfig/libzauth.pc
-          cp target/release-tmp/libzauth.so $out/lib/
+          cp target/release-tmp/libzauth.* $out/lib/
+          ${patchLibs}
         '';
       }
   ) {};

--- a/stack-deps.nix
+++ b/stack-deps.nix
@@ -1,8 +1,15 @@
+with (import <nixpkgs> {});
 let
   pkgs = import ./nix;
+  native_libs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    Cocoa
+    CoreServices
+  ]);
+
 in
 pkgs.haskell.lib.buildStackProject {
   name = "wire-server";
+  nativeBuildInputs = native_libs;
   buildInputs = with pkgs; [
     cryptobox
     geoip


### PR DESCRIPTION
cryptobox and zauth wouldn't build on OSX because the wrong path was included in the `dylib`.

The symptom was that the `cryptobox-c` haskell library build would fail with:
```
cryptobox-haskell                > running .stack-work/dist/x86_64-osx-nix/Cabal-3.0.1.0/build/System/CryptoBox_hsc_make failed (exit code -6)
cryptobox-haskell                > rsp file was: ".stack-work/dist/x86_64-osx-nix/Cabal-3.0.1.0/build/System/hsc2hscall42850-3.rsp"           
cryptobox-haskell                > output file:".stack-work/dist/x86_64-osx-nix/Cabal-3.0.1.0/build/System/CryptoBox.hs"                      
cryptobox-haskell                > command was: .stack-work/dist/x86_64-osx-nix/Cabal-3.0.1.0/build/System/CryptoBox_hsc_make  >.stack-work/dist/x86_64-osx-nix/Cabal-3.0.1.0/build/System/CryptoBox.hs
cryptobox-haskell                > error: dyld: Library not loaded: /private/tmp/nix-build-cryptobox-c-2019-06-17.drv-0/source/target/x86_64-apple-darwin/release/deps/libcryptobox.dylib
cryptobox-haskell                >   Referenced from: /private/tmp/stack-3f8b56a5eca0af97/cryptobox-haskell-0.1.1/.stack-work/dist/x86_64-osx-nix/Cabal-3.0.1.0/build/System/CryptoBox_hsc_make
cryptobox-haskell                >   Reason: image not found
```

```
$ otool -l /nix/store/hzj1xl80qq3xg7fxd6l3adx0ahil3pyb-cryptobox-c-2019-06-17/lib/libcryptobox.dylib
...
Load command 3
          cmd LC_ID_DYLIB
      cmdsize 144
         name /private/tmp/nix-build-cryptobox-c-2019-06-17.drv-0/source/target/x86_64-apple-darwin/release/deps/libcryptobox.dylib (offset 24)
   time stamp 1 Thu Jan  1 01:00:01 1970
...
```

The fix proposed in [this post](https://discourse.nixos.org/t/patchelf-for-mach-o-shared-libraries/562/6) fixed the problem.

```
$ otool -l /nix/store/w71z1pnxxx6wi69brl5pdzssdpa54yam-cryptobox-c-2019-06-17/lib/libcryptobox.dylib
...
Load command 3
          cmd LC_ID_DYLIB
      cmdsize 120
         name /nix/store/w71z1pnxxx6wi69brl5pdzssdpa54yam-cryptobox-c-2019-06-17/lib/libcryptobox.dylib (offset 24)
   time stamp 1 Thu Jan  1 01:00:01 1970
      current version 0.0.0
...
```