### PR TITLE
Brig integration tests

### DIFF
--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -44,6 +44,15 @@ data:
       host: gundeck
       port: 8080
 
+    # TODO remove this
+    federator:
+      host: federator
+      port: 8080
+
+    federatorInternal:
+      host: federator
+      port: 8080
+
     {{- with .aws }}
     aws:
       prekeyTable: {{ .prekeyTable }}

--- a/charts/brig/templates/tests/configmap.yaml
+++ b/charts/brig/templates/tests/configmap.yaml
@@ -26,6 +26,19 @@ data:
       host: spar
       port: 8080
 
+    # TODO remove this
+    federator:
+      host: federator
+      port: 8080
+
+    federatorInternal:
+      host: federator
+      port: 8080
+
+    federatorExternal:
+      host: federator
+      port: 8081
+
     nginz:
       # Full URL is set so that there can be a common cookiedomain between nginz and brig
       # needed by some integration tests
@@ -38,3 +51,21 @@ data:
       cert: /etc/wire/integration-secrets/provider-publiccert.pem
       botHost: https://brig-integration
       botPort: 9000
+
+    backendTwo:
+      brig:
+        host: brig.{{ .Release.Namespace }}-fed2.svc.cluster.local
+        port: 8080
+
+      # TODO remove this
+      federator:
+        host: federator.{{ .Release.Namespace }}-fed2.svc.cluster.local
+        port: 8080
+
+      federatorInternal:
+        host: federator.{{ .Release.Namespace }}-fed2.svc.cluster.local
+        port: 8080
+
+      federatorExternal:
+        host: federator.{{ .Release.Namespace }}-fed2.svc.cluster.local
+        port: 8081

--- a/charts/federator/templates/configmap.yaml
+++ b/charts/federator/templates/configmap.yaml
@@ -8,16 +8,32 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{- with .Values.config }}
   federator.yaml: |
+
+    # TODO: delete this
+    federator:
+      host: 0.0.0.0
+      port: {{ .Values.service.internalFederatorPort }}
+
+    federatorInternal:
+      host: 0.0.0.0
+      port: {{ .Values.service.internalFederatorPort }}
+
+    federatorExternal:
+      host: 0.0.0.0
+      port: {{ .Values.service.externalFederatorPort }}
+
+    brig:
+      host: brig
+      port: 8080
+
+    {{- with .Values.config }}
+
     logNetStrings: True # log using netstrings encoding:
                         # http://cr.yp.to/proto/netstrings.txt
     logFormat: {{ .logFormat }}
     logLevel: {{ .logLevel }}
 
-    federator:
-      host: 0.0.0.0
-      port: 8080
 
     {{- with .optSettings }}
     optSettings:

--- a/charts/federator/templates/deployment.yaml
+++ b/charts/federator/templates/deployment.yaml
@@ -39,16 +39,20 @@ spec:
             - name: "federator-config"
               mountPath: "/etc/wire/federator/conf"
           ports:
-            - containerPort: {{ .Values.service.internalPort }}
-          livenessProbe:
-            httpGet:
-              scheme: HTTP
-              path: /i/status
-              port: {{ .Values.service.internalPort }}
-          readinessProbe:
-            httpGet:
-              scheme: HTTP
-              path: /i/status
-              port: {{ .Values.service.internalPort }}
+            - name: internal
+              containerPort: {{ .Values.service.internalFederatorPort }}
+            - name: external
+              containerPort: {{ .Values.service.externalFederatorPort }}
+          # TODO ensure to have a status endpoint!
+          # livenessProbe:
+          #   httpGet:
+          #     scheme: HTTP
+          #     path: /i/status
+          #     port: {{ .Values.service.internalFederatorPort }}
+          # readinessProbe:
+          #   httpGet:
+          #     scheme: HTTP
+          #     path: /i/status
+          #     port: {{ .Values.service.internalFederatorPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/federator/templates/service.yaml
+++ b/charts/federator/templates/service.yaml
@@ -11,8 +11,12 @@ spec:
   type: ClusterIP
   ports:
     - name: http
-      port: {{ .Values.service.externalPort }}
-      targetPort: {{ .Values.service.internalPort }}
+      port: {{ .Values.service.internalFederatorPort }}
+      targetPort: {{ .Values.service.internalFederatorPort }}
+
+    - name: external
+      port: {{ .Values.service.externalFederatorPort }}
+      targetPort: {{ .Values.service.externalFederatorPort }}
   selector:
     wireService: federator
     release: {{ .Release.Name }}

--- a/charts/federator/values.yaml
+++ b/charts/federator/values.yaml
@@ -5,8 +5,8 @@ image:
   tag: do-not-use
 
 service:
-  externalPort: 8080
-  internalPort: 8080
+  internalFederatorPort: 8080
+  externalFederatorPort: 8081
 
 resources:
   # FUTUREWORK: come up with numbers which didn't appear out of thin air

--- a/hack/bin/integration-setup.sh
+++ b/hack/bin/integration-setup.sh
@@ -24,9 +24,17 @@ done
 echo "Installing charts..."
 
 function printLogs() {
+    echo "---- a command failed, attempting to print useful debug information..."
+    echo "-------------------------------"
+    echo "-------------------------------"
+    echo "-------------------------------"
+    echo ""
+    kubectl -n ${NAMESPACE} get pods
     kubectl -n ${NAMESPACE} get pods | grep -v Running | grep -v Pending | grep -v Completed | grep -v STATUS | grep -v ContainerCreating | awk '{print $1}' | xargs -n 1 -I{} bash -c "printf '\n\n----LOGS FROM {}:\n'; kubectl -n ${NAMESPACE} logs --tail=30 {}" || true
     kubectl -n ${NAMESPACE} get pods | grep Pending | awk '{print $1}' | xargs -n 1 -I{} bash -c "printf '\n\n----DESCRIBE 'pending' {}:\n'; kubectl -n ${NAMESPACE} describe pod {}" || true
 }
+
+trap printLogs ERR
 
 FEDERATION_DOMAIN="$NAMESPACE.svc.cluster.local"
 

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c5312f061d226f10f6e7e3dd06dce7730af75b112fd4251c5c7455dc1ab25a4f
+-- hash: 83620e2ed26c5349fbca70be3e5e3978d85924a7bfbcdb9db63eac26cf8693c4
 
 name:           brig
 version:        1.35.0
@@ -294,6 +294,7 @@ executable brig-integration
       API.User.RichInfo
       API.User.Util
       API.UserPendingActivation
+      Federation.User
       Index.Create
       Util
       Util.AWS

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -24,9 +24,9 @@ gundeck:
   host: 127.0.0.1
   port: 8086
 
-# federator:
-#   host: 127.0.0.1
-#   port: 8097
+federatorInternal:
+  host: 127.0.0.1
+  port: 8097
 
 # You can set up local SQS/Dynamo running e.g. `../../deploy/dockerephemeral/run.sh`
 aws:

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -32,6 +32,7 @@ module Brig.App
     cargohold,
     galley,
     gundeck,
+    federator,
     userTemplates,
     providerTemplates,
     teamTemplates,
@@ -141,6 +142,7 @@ data Env = Env
   { _cargohold :: RPC.Request,
     _galley :: RPC.Request,
     _gundeck :: RPC.Request,
+    _federator :: Maybe Endpoint, -- FUTUREWORK: should we use a better type here? E.g. to avoid fresh connections all the time?
     _casClient :: Cas.ClientState,
     _smtpEnv :: Maybe SMTP.SMTP,
     _emailSender :: Email,
@@ -215,6 +217,7 @@ newEnv o = do
       { _cargohold = mkEndpoint $ Opt.cargohold o,
         _galley = mkEndpoint $ Opt.galley o,
         _gundeck = mkEndpoint $ Opt.gundeck o,
+        _federator = Opt.federatorInternal o,
         _casClient = cas,
         _smtpEnv = emailSMTP,
         _emailSender = Opt.emailSender . Opt.general . Opt.emailSMS $ o,

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -344,7 +344,7 @@ data Opts = Opts
     -- | Gundeck address
     gundeck :: !Endpoint,
     -- | Federator address
-    federator :: !(Maybe Endpoint),
+    federatorInternal :: !(Maybe Endpoint),
     -- external
 
     -- | Cassandra settings

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -85,9 +85,8 @@ import Test.Tasty.HUnit
 import Util
 import Web.Cookie (SetCookie (..), parseSetCookie)
 
-tests :: Maybe Config -> Manager -> DB.ClientState -> Brig -> Cannon -> Galley -> IO TestTree
-tests mbConf p db b c g = do
-  conf <- maybe getEnvConfig pure mbConf
+tests :: Config -> Manager -> DB.ClientState -> Brig -> Cannon -> Galley -> IO TestTree
+tests conf p db b c g = do
   return $
     testGroup
       "provider"
@@ -156,16 +155,6 @@ data Config = Config
   deriving (Show, Generic)
 
 instance FromJSON Config
-
--- | Get the config from environment variables (and some defaults)
-getEnvConfig :: IO Config
-getEnvConfig = do
-  privateKey <- getEnv "TEST_KEY"
-  publicKey <- getEnv "TEST_PUBKEY"
-  cert <- getEnv "TEST_CERT"
-  let botHost = "https://localhost"
-  let botPort = 9000
-  pure Config {..}
 
 -------------------------------------------------------------------------------
 -- Provider Accounts

--- a/services/brig/test/integration/Federation/User.hs
+++ b/services/brig/test/integration/Federation/User.hs
@@ -1,0 +1,65 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Federation.User where
+
+import Bilge (Http, Manager)
+import qualified Brig.Options as BrigOpts
+import Brig.Types
+import Data.Handle
+import Data.Qualified
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+import Util
+import Util.Options (Endpoint)
+
+-- NOTE: These federation tests require deploying two sets of (some) services
+-- This might be best left to a kubernetes setup.
+--
+-- While individual functions can and should be tested in a more unit-testy way,
+-- these more end-to-end integration test serve as a way to test the overall
+-- network flow
+--
+spec :: BrigOpts.Opts -> Manager -> Brig -> Endpoint -> Brig -> IO TestTree
+spec _brigOpts mg brig _federator brigTwo =
+  pure $
+    testGroup
+      "brig-federation-user"
+      [ test mg "lookup user by qualified handle on remote backend" $ testHandleLookup brig brigTwo
+      ]
+
+testHandleLookup :: Brig -> Brig -> Http ()
+testHandleLookup brig brigTwo = do
+  -- Create a user on the "other side" using an internal brig endpoint from a
+  -- second brig instance in backendTwo (in another namespace in kubernetes)
+  u <- randomUser brigTwo
+  h <- randomHandle
+  void $ putHandle brigTwo (userId u) h
+  self <- selfUser <$> getSelfProfile brigTwo (userId u)
+  let handle = fromJust (userHandle self)
+  liftIO $ assertEqual "creating user with handle should return handle" h (fromHandle handle)
+  let domain = qDomain $ userQualifiedId self
+  resultTwo <- userHandleId <$> getUserInfoFromHandle brigTwo domain handle
+  -- query the local-namespace brig for a user sitting on the other backend
+  -- which should involve the following network traffic:
+  --
+  -- brig-integration -> brig -> federator -> fed2-federator -> fed2-brig
+  -- (and back)
+  result <- userHandleId <$> getUserInfoFromHandle brig domain handle
+  liftIO $ assertEqual "remote handle lookup via federator should work in the happy case" result (Qualified (userId u) domain)
+  liftIO $ assertEqual "querying brig1 or brig2 about remote user should give same result" resultTwo result

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -36,13 +36,11 @@ import qualified Brig.Options as Opts
 import Cassandra.Util (defInitCassandra)
 import Control.Lens
 import Data.Aeson
-import qualified Data.ByteString.Char8 as BS
-import Data.ByteString.Conversion
 import Data.Metrics.Test (pathsConsistencyCheck)
 import Data.Metrics.WaiRoute (treeToPaths)
-import Data.Text (pack)
 import Data.Text.Encoding (encodeUtf8)
 import Data.Yaml (decodeFileEither)
+import qualified Federation.User
 import Imports hiding (local)
 import qualified Index.Create
 import Network.HTTP.Client.TLS (tlsManagerSettings)
@@ -54,50 +52,64 @@ import qualified System.Logger as Logger
 import Test.Tasty
 import Test.Tasty.HUnit
 import Util.Options
-import Util.Options.Common
 import Util.Test
+
+data BackendConf = BackendConf
+  { remoteBrig :: Endpoint,
+    remoteFederatorInternal :: Endpoint,
+    remoteFederatorExternal :: Endpoint
+  }
+  deriving (Show, Generic)
+
+instance FromJSON BackendConf where
+  parseJSON = withObject "BackendConf" $ \o ->
+    BackendConf
+      <$> o .: "brig"
+      <*> o .: "federatorInternal"
+      <*> o .: "federatorExternal"
 
 data Config = Config
   -- internal endpoints
   { brig :: Endpoint,
     cannon :: Endpoint,
     cargohold :: Endpoint,
+    federatorInternal :: Endpoint,
     galley :: Endpoint,
     nginz :: Endpoint,
     spar :: Endpoint,
     -- external provider
-    provider :: Provider.Config
+    provider :: Provider.Config,
+    -- for federation
+    backendTwo :: BackendConf
   }
   deriving (Show, Generic)
 
 instance FromJSON Config
 
-runTests :: Maybe Config -> Maybe Opts.Opts -> [String] -> IO ()
-runTests iConf bConf otherArgs = do
-  -- TODO: Pass Opts instead of Maybe Opts through tests now that we no longer use ENV vars
-  -- for config.
-  -- Involves removing a bunch of 'optOrEnv' calls
-  brigOpts <- maybe (fail "failed to parse options file") pure bConf
-  let local p = Endpoint {_epHost = "127.0.0.1", _epPort = p}
-  b <- mkRequest <$> optOrEnv brig iConf (local . read) "BRIG_WEB_PORT"
-  c <- mkRequest <$> optOrEnv cannon iConf (local . read) "CANNON_WEB_PORT"
-  ch <- mkRequest <$> optOrEnv cargohold iConf (local . read) "CARGOHOLD_WEB_PORT"
-  g <- mkRequest <$> optOrEnv galley iConf (local . read) "GALLEY_WEB_PORT"
-  n <- mkRequest <$> optOrEnv nginz iConf (local . read) "NGINZ_WEB_PORT"
-  s <- mkRequest <$> optOrEnv spar iConf (local . read) "SPAR_WEB_PORT"
-  turnFile <- optOrEnv (Opts.servers . Opts.turn) bConf id "TURN_SERVERS"
-  turnFileV2 <- optOrEnv (Opts.serversV2 . Opts.turn) bConf id "TURN_SERVERS_V2"
-  casHost <- optOrEnv (\v -> (Opts.cassandra v) ^. casEndpoint . epHost) bConf pack "BRIG_CASSANDRA_HOST"
-  casPort <- optOrEnv (\v -> (Opts.cassandra v) ^. casEndpoint . epPort) bConf read "BRIG_CASSANDRA_PORT"
-  casKey <- optOrEnv (\v -> (Opts.cassandra v) ^. casKeyspace) bConf pack "BRIG_CASSANDRA_KEYSPACE"
-  awsOpts <- parseAWSEnv (Opts.aws <$> bConf)
+runTests :: Config -> Opts.Opts -> [String] -> IO ()
+runTests iConf brigOpts otherArgs = do
+  let b = mkRequest $ brig iConf
+      c = mkRequest $ cannon iConf
+      ch = mkRequest $ cargohold iConf
+      g = mkRequest $ galley iConf
+      n = mkRequest $ nginz iConf
+      s = mkRequest $ spar iConf
+      f = federatorInternal iConf
+      brigTwo = mkRequest $ remoteBrig (backendTwo iConf)
+
+  let turnFile = Opts.servers . Opts.turn $ brigOpts
+      turnFileV2 = (Opts.serversV2 . Opts.turn) brigOpts
+      casHost = (\v -> (Opts.cassandra v) ^. casEndpoint . epHost) brigOpts
+      casPort = (\v -> (Opts.cassandra v) ^. casEndpoint . epPort) brigOpts
+      casKey = (\v -> (Opts.cassandra v) ^. casKeyspace) brigOpts
+      awsOpts = Opts.aws brigOpts
   lg <- Logger.new Logger.defSettings -- TODO: use mkLogger'?
   db <- defInitCassandra casKey casHost casPort lg
   mg <- newManager tlsManagerSettings
   emailAWSOpts <- parseEmailAWSOpts
   awsEnv <- AWS.mkEnv lg awsOpts emailAWSOpts mg
   userApi <- User.tests brigOpts mg b c ch g n awsEnv
-  providerApi <- Provider.tests (provider <$> iConf) mg db b c g
+  providerApi <- Provider.tests (provider iConf) mg db b c g
   searchApis <- Search.tests brigOpts mg g b
   teamApis <- Team.tests brigOpts mg n b c g awsEnv
   turnApi <- Calling.tests mg b brigOpts turnFile turnFileV2
@@ -106,6 +118,7 @@ runTests iConf bConf otherArgs = do
   createIndex <- Index.Create.spec brigOpts
   browseTeam <- TeamUserSearch.tests brigOpts mg g b
   userPendingActivation <- UserPendingActivation.tests brigOpts mg db b g s
+  federationUser <- Federation.User.spec brigOpts mg b f brigTwo
   withArgs otherArgs . defaultMain $
     testGroup
       "Brig API Integration"
@@ -123,31 +136,16 @@ runTests iConf bConf otherArgs = do
         settingsApi,
         createIndex,
         userPendingActivation,
-        browseTeam
+        browseTeam,
+        federationUser
       ]
   where
     mkRequest (Endpoint h p) = host (encodeUtf8 h) . port p
-    -- Using config files only would certainly simplify this quite a bit
-    parseAWSEnv :: Maybe Opts.AWSOpts -> IO (Opts.AWSOpts)
-    parseAWSEnv (Just o) = return o
-    parseAWSEnv Nothing = do
-      sqsEnd <- optOrEnv (Opts.sqsEndpoint . Opts.aws) bConf parseEndpoint "AWS_SQS_ENDPOINT"
-      dynEnd <- optOrEnv (Opts.dynamoDBEndpoint . Opts.aws) bConf parseEndpoint "AWS_DYNAMODB_ENDPOINT"
-      sqsJrnlQ <- join <$> optOrEnvSafe (Opts.userJournalQueue . Opts.aws) bConf (Just . pack) "AWS_USER_JOURNAL_QUEUE"
-      dynPkTbl <- optOrEnv (Opts.prekeyTable . Opts.aws) bConf pack "AWS_USER_PREKEYS_TABLE"
-      return $ Opts.AWSOpts sqsJrnlQ dynPkTbl sqsEnd dynEnd
-    parseEndpoint :: String -> AWSEndpoint
-    parseEndpoint e =
-      fromMaybe (error ("Not a valid AWS endpoint: " ++ show e)) $
-        fromByteString (BS.pack e)
+
     parseEmailAWSOpts :: IO (Maybe Opts.EmailAWSOpts)
-    parseEmailAWSOpts = case Opts.email . Opts.emailSMS <$> bConf of
-      Just (Opts.EmailAWS aws) -> return (Just aws)
-      Just (Opts.EmailSMTP _) -> return Nothing
-      _ -> do
-        sesEnd <- parseEndpoint <$> getEnv "AWS_SES_ENDPOINT"
-        sesQueue <- pack <$> getEnv "AWS_USER_SES_QUEUE"
-        return . Just $ Opts.EmailAWSOpts sesQueue sesEnd
+    parseEmailAWSOpts = case Opts.email . Opts.emailSMS $ brigOpts of
+      (Opts.EmailAWS aws) -> return (Just aws)
+      (Opts.EmailSMTP _) -> return Nothing
 
 main :: IO ()
 main = withOpenSSL $ do
@@ -159,7 +157,9 @@ main = withOpenSSL $ do
   (iPath, bPath) <- withArgs configArgs parseConfigPaths
   iConf <- join $ handleParseError <$> decodeFileEither iPath
   bConf <- join $ handleParseError <$> decodeFileEither bPath
-  runTests iConf bConf otherArgs
+  brigOpts <- maybe (fail "failed to parse brig options file") pure bConf
+  integrationConfig <- maybe (fail "failed to parse integration.yaml file") pure iConf
+  runTests integrationConfig brigOpts otherArgs
   where
     getConfigArgs args = reverse $ snd $ foldl' filterConfig (False, []) args
     filterConfig :: (Bool, [String]) -> String -> (Bool, [String])

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -46,7 +46,8 @@ import qualified Data.ByteString as BS
 import Data.ByteString.Char8 (pack)
 import qualified Data.ByteString.Char8 as C8
 import Data.ByteString.Conversion
-import Data.Domain (mkDomain)
+import Data.Domain (Domain, domainText, mkDomain)
+import Data.Handle (Handle)
 import Data.Id
 import Data.List1 (List1)
 import qualified Data.List1 as List1
@@ -432,6 +433,22 @@ putHandle brig usr h =
       . zConn "conn"
   where
     payload = RequestBodyLBS . encode $ object ["handle" .= h]
+
+getUserInfoFromHandle ::
+  (MonadIO m, MonadCatch m, MonadFail m, MonadHttp m, HasCallStack) =>
+  Brig ->
+  Domain ->
+  Handle ->
+  m UserHandleInfo
+getUserInfoFromHandle brig domain handle = do
+  u <- randomId
+  responseJsonError
+    =<< get
+      ( brig
+          . paths ["users", "handles", toByteString' (domainText domain), toByteString' handle]
+          . zUser u
+          . expect2xx
+      )
 
 addClient ::
   (Monad m, MonadCatch m, MonadIO m, MonadHttp m, MonadFail m, HasCallStack) =>

--- a/services/integration.yaml
+++ b/services/integration.yaml
@@ -35,6 +35,13 @@ nginz:
   host: 127.0.0.1
   port: 8080
 
+federatorInternal:
+  host: 127.0.0.1
+  port: 8097
+
+federatorExternal:
+  host: 127.0.0.1
+  port: 8098
 # Used by brig-integration (bot providers), galley-integration (legal hold)
 provider:
   privateKey: test/resources/key.pem
@@ -42,3 +49,15 @@ provider:
   cert: test/resources/cert.pem
   botHost: https://127.0.0.1
   botPort: 29631
+
+# Used by brig-integration (Federation subfolder)
+backendTwo:
+  brig:
+    host: 127.0.0.1 # in kubernetes, brig.<NAMESPACE>.svc.cluster.local
+    port: 9082
+  federatorInternal:
+    host: 127.0.0.1 # in kubernetes, federator.<NAMESPACE>.svc.cluster.local
+    port: 9097
+  federatorExternal:
+    host: 127.0.0.1 # in kubernetes, federator.<NAMESPACE>.svc.cluster.local
+    port: 9097


### PR DESCRIPTION
Brig integration/end2end initial test for federation

For easier review, this PR is a small piece from the now-long-running "federation" branch #1319 with the following purpose:

* refactor some brig-integration setup code (remove looking at environment
  variables)
* brig now knows about federator's existence in the config file. This is
  an optional field. (should it be required?)
* introduce a first test that needs two backends. This test is failing
  on this branch (but working to success on #1319 currently), but will
  be disabled-by-default to run both on CI and locally, as long as this PR
  is merged *after* #1341
* prepare some federation chart config. Note there is currently a `federator` and `federatorInternal` config here: the former can be deleted as soon as some PRs involving the actual federator have made their way in, but it's kept in here to keep CI happy for the time being. 
