### PR TITLE
Team search: add sorting

### DIFF
--- a/libs/wire-api/src/Wire/API/Team/Role.hs
+++ b/libs/wire-api/src/Wire/API/Team/Role.hs
@@ -29,7 +29,7 @@ where
 
 import qualified Cassandra as Cql
 import Data.Aeson
-import Data.Attoparsec.ByteString (takeLazyByteString)
+import Data.Attoparsec.ByteString.Char8 (string)
 import Data.ByteString.Conversion (FromByteString (..), ToByteString (..))
 import Data.ByteString.Conversion.From (runParser)
 import Data.ByteString.Lazy.Builder (toLazyByteString)
@@ -108,12 +108,10 @@ instance ToByteString Role where
 
 instance FromByteString Role where
   parser =
-    takeLazyByteString >>= \case
-      "owner" -> pure RoleOwner
-      "admin" -> pure RoleAdmin
-      "member" -> pure RoleMember
-      "partner" -> pure RoleExternalPartner
-      bad -> fail ("not a role:  " <> show bad)
+    RoleOwner <$ string "owner"
+      <|> RoleAdmin <$ string "admin"
+      <|> RoleMember <$ string "member"
+      <|> RoleExternalPartner <$ string "partner"
 
 defaultRole :: Role
 defaultRole = RoleMember

--- a/libs/wire-api/src/Wire/API/Team/Role.hs
+++ b/libs/wire-api/src/Wire/API/Team/Role.hs
@@ -31,6 +31,8 @@ where
 
 import qualified Cassandra as Cql
 import Data.Aeson
+import Data.Attoparsec.ByteString (takeLazyByteString)
+import Data.ByteString.Conversion (FromByteString (..), ToByteString (..))
 import qualified Data.Swagger.Model.Api as Doc
 import Imports
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
@@ -105,6 +107,21 @@ instance FromJSON Role where
     -- wondering about this, it's probably safe to remove.
     -- ~fisx, Wed Jan 23 16:38:52 CET 2019
     bad -> fail $ "not a role: " <> show bad
+
+instance ToByteString Role where
+  builder RoleOwner = "owner"
+  builder RoleAdmin = "admin"
+  builder RoleMember = "member"
+  builder RoleExternalPartner = "partner"
+
+instance FromByteString Role where
+  parser =
+    takeLazyByteString >>= \case
+      "owner" -> pure RoleOwner
+      "admin" -> pure RoleAdmin
+      "member" -> pure RoleMember
+      "partner" -> pure RoleExternalPartner
+      bad -> fail ("not a role:  " <> show bad)
 
 defaultRole :: Role
 defaultRole = RoleMember

--- a/libs/wire-api/src/Wire/API/User/Search.hs
+++ b/libs/wire-api/src/Wire/API/User/Search.hs
@@ -34,8 +34,8 @@ module Wire.API.User.Search
 where
 
 import Data.Aeson
-import Data.Attoparsec.ByteString (sepBy, takeLazyByteString)
-import Data.Attoparsec.ByteString.Char8 (char)
+import Data.Attoparsec.ByteString (sepBy)
+import Data.Attoparsec.ByteString.Char8 (char, string)
 import Data.ByteString.Conversion (FromByteString (..), ToByteString (..))
 import Data.Id (TeamId, UserId)
 import Data.Json.Util (UTCTimeMillis)
@@ -214,7 +214,8 @@ data TeamUserSearchSortBy
   | SortByManagedBy
   | SortByRole
   | SortByCreatedAt
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+  deriving (Arbitrary) via (GenericUniform TeamUserSearchSortBy)
 
 instance ToByteString TeamUserSearchSortBy where
   builder SortByName = "name"
@@ -227,20 +228,19 @@ instance ToByteString TeamUserSearchSortBy where
 
 instance FromByteString TeamUserSearchSortBy where
   parser =
-    takeLazyByteString >>= \case
-      "name" -> pure SortByName
-      "handle" -> pure SortByHandle
-      "email" -> pure SortByEmail
-      "saml_idp" -> pure SortBySAMLIdp
-      "managed_by" -> pure SortByManagedBy
-      "role" -> pure SortByRole
-      "created_at" -> pure SortByCreatedAt
-      bad -> fail ("Not a sort by field: " <> show bad)
+    SortByName <$ string "name"
+      <|> SortByHandle <$ string "handle"
+      <|> SortByEmail <$ string "email"
+      <|> SortBySAMLIdp <$ string "saml_idp"
+      <|> SortByManagedBy <$ string "managed_by"
+      <|> SortByRole <$ string "role"
+      <|> SortByCreatedAt <$ string "created_at"
 
 data TeamUserSearchSortOrder
   = SortOrderAsc
   | SortOrderDesc
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+  deriving (Arbitrary) via (GenericUniform TeamUserSearchSortOrder)
 
 instance ToByteString TeamUserSearchSortOrder where
   builder SortOrderAsc = "asc"
@@ -248,12 +248,12 @@ instance ToByteString TeamUserSearchSortOrder where
 
 instance FromByteString TeamUserSearchSortOrder where
   parser =
-    takeLazyByteString >>= \case
-      "asc" -> pure SortOrderAsc
-      "desc" -> pure SortOrderDesc
-      bad -> fail ("not a sort order:  " <> show bad)
+    SortOrderAsc <$ string "asc"
+      <|> SortOrderDesc <$ string "desc"
 
 newtype RoleFilter = RoleFilter [Role]
+  deriving (Show, Eq, Generic)
+  deriving (Arbitrary) via (GenericUniform RoleFilter)
 
 instance ToByteString RoleFilter where
   builder (RoleFilter roles) = mconcat $ intersperse "," (fmap builder roles)

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
@@ -307,7 +307,9 @@ tests =
       testRoundTrip @User.RichInfo.RichInfoMapAndList,
       testRoundTrip @User.RichInfo.RichInfo,
       testRoundTrip @(User.Search.SearchResult User.Search.Contact),
-      testRoundTrip @User.Search.Contact
+      testRoundTrip @User.Search.Contact,
+      testRoundTrip @(User.Search.SearchResult User.Search.TeamContact),
+      testRoundTrip @User.Search.TeamContact
     ]
   where
     currentlyFailing = ignoreTest

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/ByteString.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/ByteString.hs
@@ -41,6 +41,7 @@ import qualified Wire.API.User.Auth as User.Auth
 import qualified Wire.API.User.Identity as User.Identity
 import qualified Wire.API.User.Password as User.Password
 import qualified Wire.API.User.Profile as User.Profile
+import qualified Wire.API.User.Search as User.Search
 
 tests :: T.TestTree
 tests =
@@ -78,7 +79,10 @@ tests =
       testRoundTrip @User.Password.PasswordResetKey,
       testRoundTrip @User.Profile.ManagedBy,
       testRoundTrip @User.Profile.Name,
-      testRoundTrip @Team.Role.Role
+      testRoundTrip @Team.Role.Role,
+      testRoundTrip @User.Search.TeamUserSearchSortBy,
+      testRoundTrip @User.Search.TeamUserSearchSortOrder,
+      testRoundTrip @User.Search.RoleFilter
       -- FUTUREWORK:
       -- testCase "Call.Config.TurnUsername (doesn't have FromByteString)" ...
       -- testCase "User.Activation.ActivationTarget (doesn't have FromByteString)" ...

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/ByteString.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/ByteString.hs
@@ -34,6 +34,7 @@ import qualified Wire.API.Provider.Service as Provider.Service
 import qualified Wire.API.Provider.Service.Tag as Provider.Service.Tag
 import qualified Wire.API.Push.V2.Token as Push.V2.Token
 import qualified Wire.API.Team.Feature as Team.Feature
+import qualified Wire.API.Team.Role as Team.Role
 import qualified Wire.API.User as User
 import qualified Wire.API.User.Activation as User.Activation
 import qualified Wire.API.User.Auth as User.Auth
@@ -43,7 +44,7 @@ import qualified Wire.API.User.Profile as User.Profile
 
 tests :: T.TestTree
 tests =
-  T.localOption (T.Timeout (60 * 1000000) "60s") . T.testGroup "JSON roundtrip tests" $
+  T.localOption (T.Timeout (60 * 1000000) "60s") . T.testGroup "ByteString roundtrip tests" $
     [ testRoundTrip @Asset.V3.AssetKey,
       testRoundTrip @Asset.V3.AssetRetention,
       testRoundTrip @Asset.V3.AssetToken,
@@ -76,7 +77,8 @@ tests =
       testRoundTrip @User.Password.PasswordResetCode,
       testRoundTrip @User.Password.PasswordResetKey,
       testRoundTrip @User.Profile.ManagedBy,
-      testRoundTrip @User.Profile.Name
+      testRoundTrip @User.Profile.Name,
+      testRoundTrip @Team.Role.Role
       -- FUTUREWORK:
       -- testCase "Call.Config.TurnUsername (doesn't have FromByteString)" ...
       -- testCase "User.Activation.ActivationTarget (doesn't have FromByteString)" ...

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c5312f061d226f10f6e7e3dd06dce7730af75b112fd4251c5c7455dc1ab25a4f
+-- hash: 7ff121909d39774a3c4491846720553261ece3c9e8ef34a5231c53c66953bb96
 
 name:           brig
 version:        1.35.0
@@ -344,6 +344,7 @@ executable brig-integration
     , pem
     , proto-lens
     , random >=1.0
+    , random-shuffle
     , raw-strings-qq
     , retry >=0.6
     , safe

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -232,6 +232,7 @@ executables:
     - QuickCheck
     - raw-strings-qq
     - random >=1.0
+    - random-shuffle
     - retry >=0.6
     - safe
     - saml2-web-sso

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -72,7 +72,7 @@ routesPublic = do
       .&. opt (query "q")
       .&. opt (query "frole")
       .&. opt (query "sortby")
-      .&. opt (query "sortoder")
+      .&. opt (query "sortorder")
       .&. def (unsafeRange 15) (query "size")
 
   document "GET" "browse team" $ do

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -30,6 +30,7 @@ import Brig.Team.Util (ensurePermissions)
 import Brig.Types.Search as Search
 import Brig.User.Search.Index
 import qualified Brig.User.Search.SearchIndex as Q
+import Brig.User.Search.TeamUserSearch (RoleFilter (..), TeamUserSearchSortBy (..), TeamUserSearchSortOrder (..))
 import qualified Brig.User.Search.TeamUserSearch as Q
 import Control.Lens (view)
 import Data.Id
@@ -44,7 +45,6 @@ import Network.Wai.Routing
 import Network.Wai.Utilities.Response (empty, json)
 import Network.Wai.Utilities.Swagger (document)
 import qualified Wire.API.Team.Permission as Public
-import qualified Wire.API.Team.Role as Public
 import qualified Wire.API.User.Search as Public
 
 routesPublic :: Routes Doc.ApiBuilder Handler ()
@@ -152,22 +152,22 @@ teamUserSearchH ::
       ::: UserId
       ::: TeamId
       ::: Maybe Text
-      ::: Maybe Text
-      ::: Maybe Text
-      ::: Maybe Text
+      ::: Maybe RoleFilter
+      ::: Maybe TeamUserSearchSortBy
+      ::: Maybe TeamUserSearchSortOrder
       ::: Range 1 500 Int32
   ) ->
   Handler Response
 teamUserSearchH (_ ::: uid ::: tid ::: mQuery ::: mRoleFilter ::: mSortBy ::: mSortOrder ::: size) = do
-  json <$> teamUserSearch uid tid mQuery (undefined mRoleFilter) mSortBy mSortOrder size
+  json <$> teamUserSearch uid tid mQuery mRoleFilter mSortBy mSortOrder size
 
 teamUserSearch ::
   UserId ->
   TeamId ->
   Maybe Text ->
-  Maybe [Public.Role] ->
-  Maybe Text ->
-  Maybe Text ->
+  Maybe RoleFilter ->
+  Maybe TeamUserSearchSortBy ->
+  Maybe TeamUserSearchSortOrder ->
   Range 1 500 Int32 ->
   Handler (Public.SearchResult Public.TeamContact)
 teamUserSearch uid tid mQuery mRoleFilter mSortBy mSortOrder size = do

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -423,7 +423,7 @@ indexMapping =
                   mpIndex = True,
                   mpAnalyzer = Nothing,
                   mpFields =
-                    Map.fromList [("prefix", MappingField MPText "prefix_index" "prefix_search")]
+                    Map.fromList [("prefix", MappingField MPText (Just "prefix_index") (Just "prefix_search"))]
                 },
             "name"
               .= MappingProperty
@@ -440,9 +440,11 @@ indexMapping =
                   mpIndex = True,
                   mpAnalyzer = Nothing,
                   mpFields =
-                    Map.fromList [("prefix", MappingField MPText "prefix_index" "prefix_search")]
+                    Map.fromList
+                      [ ("prefix", MappingField MPText (Just "prefix_index") (Just "prefix_search")),
+                        ("keyword", MappingField MPKeyword Nothing Nothing)
+                      ]
                 },
-            -- TODO: keyword for sorting
             "email"
               .= MappingProperty
                 { mpType = MPText,
@@ -450,8 +452,10 @@ indexMapping =
                   mpIndex = True,
                   mpAnalyzer = Nothing,
                   mpFields =
-                    Map.fromList [("prefix", MappingField MPText "prefix_index" "prefix_search")]
-                    -- TODO: keyword for sorting
+                    Map.fromList
+                      [ ("prefix", MappingField MPText (Just "prefix_index") (Just "prefix_search")),
+                        ("keyword", MappingField MPKeyword Nothing Nothing)
+                      ]
                 },
             "team"
               .= MappingProperty
@@ -522,8 +526,8 @@ data MappingProperty = MappingProperty
 
 data MappingField = MappingField
   { mfType :: MappingPropertyType,
-    mfAnalyzer :: Text,
-    mfSearchAnalyzer :: Text
+    mfAnalyzer :: Maybe Text,
+    mfSearchAnalyzer :: Maybe Text
   }
 
 data MappingPropertyType = MPText | MPKeyword | MPByte | MPDate
@@ -548,11 +552,10 @@ instance ToJSON MappingPropertyType where
 
 instance ToJSON MappingField where
   toJSON mf =
-    object
-      [ "type" .= mfType mf,
-        "analyzer" .= mfAnalyzer mf,
-        "search_analyzer" .= mfSearchAnalyzer mf
-      ]
+    object $
+      ["type" .= mfType mf]
+        <> ["analyzer" .= mfAnalyzer mf | isJust (mfAnalyzer mf)]
+        <> ["search_analyzer" .= mfSearchAnalyzer mf | isJust (mfSearchAnalyzer mf)]
 
 boolQuery :: ES.BoolQuery
 boolQuery = ES.mkBoolQuery [] [] [] []

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -442,6 +442,7 @@ indexMapping =
                   mpFields =
                     Map.fromList [("prefix", MappingField MPText "prefix_index" "prefix_search")]
                 },
+            -- TODO: keyword for sorting
             "email"
               .= MappingProperty
                 { mpType = MPText,
@@ -450,6 +451,7 @@ indexMapping =
                   mpAnalyzer = Nothing,
                   mpFields =
                     Map.fromList [("prefix", MappingField MPText "prefix_index" "prefix_search")]
+                    -- TODO: keyword for sorting
                 },
             "team"
               .= MappingProperty

--- a/services/brig/src/Brig/User/Search/TeamUserSearch.hs
+++ b/services/brig/src/Brig/User/Search/TeamUserSearch.hs
@@ -31,8 +31,10 @@ import Brig.Data.Instances ()
 import Brig.Types.Search
 import Brig.User.Search.Index
 import Control.Monad.Catch (MonadThrow (throwM))
+import Data.Aeson
 import Data.Id (TeamId, idToText)
 import Data.Range (Range (..))
+import Data.String.Conversions (cs)
 import qualified Database.Bloodhound as ES
 import Imports hiding (log, searchable)
 import Wire.API.User.Search
@@ -54,6 +56,7 @@ teamUserSearch tid mbSearchText mRoleFilter mSortBy mSortOrder (fromRange -> s) 
           { ES.size = ES.Size (fromIntegral s),
             ES.sortBody = Just (fmap ES.DefaultSortSpec sortSpecs)
           }
+  putStrLn $ cs $ encode search
   r <-
     ES.searchByType idx mappingName search
       >>= ES.parseEsResponse

--- a/services/brig/src/Brig/User/Search/TeamUserSearch.hs
+++ b/services/brig/src/Brig/User/Search/TeamUserSearch.hs
@@ -140,8 +140,8 @@ teamUserSearchQuery tid mbSearchText _mRoleFilter mSortBy mSortOrder =
 
     sortLabel :: TeamUserSearchSortBy -> ES.FieldName
     sortLabel SortByName = ES.FieldName "name"
-    sortLabel SortByHandle = ES.FieldName "handle"
-    sortLabel SortByEmail = ES.FieldName "email"
+    sortLabel SortByHandle = ES.FieldName "handle.keyword"
+    sortLabel SortByEmail = ES.FieldName "email.keyword"
     sortLabel SortBySAMLIdp = ES.FieldName "saml_idp"
     sortLabel SortByManagedBy = ES.FieldName "managed_by"
     sortLabel SortByRole = ES.FieldName "role"

--- a/services/brig/src/Brig/User/Search/TeamUserSearch.hs
+++ b/services/brig/src/Brig/User/Search/TeamUserSearch.hs
@@ -31,88 +31,11 @@ import Brig.Data.Instances ()
 import Brig.Types.Search
 import Brig.User.Search.Index
 import Control.Monad.Catch (MonadThrow (throwM))
-import Data.Attoparsec.ByteString (sepBy, takeLazyByteString)
-import Data.Attoparsec.ByteString.Char8 (char)
-import Data.ByteString.Conversion (ToByteString (..))
-import Data.ByteString.Conversion.From (FromByteString (..))
 import Data.Id (TeamId, idToText)
 import Data.Range (Range (..))
 import qualified Database.Bloodhound as ES
 import Imports hiding (log, searchable)
-import Wire.API.Team.Role
 import Wire.API.User.Search
-
--- TODO: move this to wire-api API.User.Search
-data TeamUserSearchSortBy
-  = SortByName
-  | SortByHandle
-  | SortByEmail
-  | SortBySAMLIdp
-  | SortByManagedBy
-  | SortByRole
-  | SortByCreatedAt
-  deriving (Show, Eq, Ord)
-
-instance ToByteString TeamUserSearchSortBy where
-  builder SortByName = "name"
-  builder SortByHandle = "handle"
-  builder SortByEmail = "email"
-  builder SortBySAMLIdp = "saml_idp"
-  builder SortByManagedBy = "managed_by"
-  builder SortByRole = "role"
-  builder SortByCreatedAt = "created_at"
-
-instance FromByteString TeamUserSearchSortBy where
-  parser =
-    takeLazyByteString >>= \case
-      "name" -> pure SortByName
-      "handle" -> pure SortByHandle
-      "email" -> pure SortByEmail
-      "saml_idp" -> pure SortBySAMLIdp
-      "managed_by" -> pure SortByManagedBy
-      "role" -> pure SortByRole
-      "created_at" -> pure SortByCreatedAt
-      bad -> fail ("Not a sort by field: " <> show bad)
-
-data TeamUserSearchSortOrder
-  = SortOrderAsc
-  | SortOrderDesc
-  deriving (Show, Eq, Ord)
-
-instance ToByteString TeamUserSearchSortOrder where
-  builder SortOrderAsc = "asc"
-  builder SortOrderDesc = "desc"
-
-instance FromByteString TeamUserSearchSortOrder where
-  parser =
-    takeLazyByteString >>= \case
-      "asc" -> pure SortOrderAsc
-      "desc" -> pure SortOrderDesc
-      bad -> fail ("not a sort order:  " <> show bad)
-
--- TODO: move to module
-instance ToByteString Role where
-  builder RoleOwner = "owner"
-  builder RoleAdmin = "admin"
-  builder RoleMember = "member"
-  builder RoleExternalPartner = "partner"
-
-instance FromByteString Role where
-  parser =
-    takeLazyByteString >>= \case
-      "owner" -> pure RoleOwner
-      "admin" -> pure RoleAdmin
-      "member" -> pure RoleMember
-      "partner" -> pure RoleExternalPartner
-      bad -> fail ("not a role:  " <> show bad)
-
-newtype RoleFilter = RoleFilter [Role]
-
-instance ToByteString RoleFilter where
-  builder (RoleFilter roles) = mconcat $ intersperse "," (fmap builder roles)
-
-instance FromByteString RoleFilter where
-  parser = RoleFilter <$> parser `sepBy` char ','
 
 teamUserSearch ::
   (HasCallStack, MonadIndexIO m) =>

--- a/services/brig/src/Brig/User/Search/TeamUserSearch.hs
+++ b/services/brig/src/Brig/User/Search/TeamUserSearch.hs
@@ -84,11 +84,11 @@ teamUserSearchQuery tid mbSearchText _mRoleFilter mSortBy mSortOrder =
         mbQStr
     )
     teamFilter
-    [ maybe
-        (defaultSort SortByCreatedAt SortOrderDesc)
-        (\tuSortBy -> defaultSort tuSortBy (fromMaybe SortOrderAsc mSortOrder))
+    ( maybe
+        [defaultSort SortByCreatedAt SortOrderDesc | isNothing mbQStr]
+        (\tuSortBy -> [defaultSort tuSortBy (fromMaybe SortOrderAsc mSortOrder)])
         mSortBy
-    ]
+    )
   where
     mbQStr :: Maybe Text
     mbQStr =
@@ -125,7 +125,15 @@ teamUserSearchQuery tid mbSearchText _mRoleFilter mSortBy mSortOrder =
     defaultSort :: TeamUserSearchSortBy -> TeamUserSearchSortOrder -> ES.DefaultSort
     defaultSort tuSortBy sortOrder =
       ES.DefaultSort
-        (sortLabel tuSortBy)
+        ( case tuSortBy of
+            SortByName -> ES.FieldName "name"
+            SortByHandle -> ES.FieldName "handle.keyword"
+            SortByEmail -> ES.FieldName "email.keyword"
+            SortBySAMLIdp -> ES.FieldName "saml_idp"
+            SortByManagedBy -> ES.FieldName "managed_by"
+            SortByRole -> ES.FieldName "role"
+            SortByCreatedAt -> ES.FieldName "created_at"
+        )
         ( case sortOrder of
             SortOrderAsc -> ES.Ascending
             SortOrderDesc -> ES.Descending
@@ -134,12 +142,3 @@ teamUserSearchQuery tid mbSearchText _mRoleFilter mSortBy mSortOrder =
         Nothing
         Nothing
         Nothing
-
-    sortLabel :: TeamUserSearchSortBy -> ES.FieldName
-    sortLabel SortByName = ES.FieldName "name"
-    sortLabel SortByHandle = ES.FieldName "handle.keyword"
-    sortLabel SortByEmail = ES.FieldName "email.keyword"
-    sortLabel SortBySAMLIdp = ES.FieldName "saml_idp"
-    sortLabel SortByManagedBy = ES.FieldName "managed_by"
-    sortLabel SortByRole = ES.FieldName "role"
-    sortLabel SortByCreatedAt = ES.FieldName "created_at"

--- a/services/brig/src/Brig/User/Search/TeamUserSearch.hs
+++ b/services/brig/src/Brig/User/Search/TeamUserSearch.hs
@@ -31,10 +31,8 @@ import Brig.Data.Instances ()
 import Brig.Types.Search
 import Brig.User.Search.Index
 import Control.Monad.Catch (MonadThrow (throwM))
-import Data.Aeson
 import Data.Id (TeamId, idToText)
 import Data.Range (Range (..))
-import Data.String.Conversions (cs)
 import qualified Database.Bloodhound as ES
 import Imports hiding (log, searchable)
 import Wire.API.User.Search
@@ -56,7 +54,6 @@ teamUserSearch tid mbSearchText mRoleFilter mSortBy mSortOrder (fromRange -> s) 
           { ES.size = ES.Size (fromIntegral s),
             ES.sortBody = Just (fmap ES.DefaultSortSpec sortSpecs)
           }
-  putStrLn $ cs $ encode search
   r <-
     ES.searchByType idx mappingName search
       >>= ES.parseEsResponse

--- a/services/brig/test/integration/API/Search/Util.hs
+++ b/services/brig/test/integration/API/Search/Util.hs
@@ -22,12 +22,14 @@ import Bilge.Assert
 import Brig.Types
 import Control.Monad.Catch (MonadCatch)
 import Data.ByteString.Conversion (toByteString')
+import Data.ByteString.Conversion.To (toByteString)
 import Data.Id
+import Data.String.Conversions (cs)
 import Data.Text.Encoding (encodeUtf8)
 import Imports
 import Test.Tasty.HUnit
 import Util
-import Wire.API.User.Search (TeamContact (..))
+import Wire.API.User.Search (RoleFilter (..), TeamContact (..), TeamUserSearchSortBy, TeamUserSearchSortOrder)
 
 executeSearch :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Text -> m (SearchResult Contact)
 executeSearch brig self q = do
@@ -75,14 +77,26 @@ assertCan'tFind brig self expected q = do
     assertBool ("User shouldn't be present in results for query: " <> show q) $
       expected `notElem` map contactUserId r
 
-executeTeamUserSearch :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> TeamId -> UserId -> Text -> m (SearchResult TeamContact)
-executeTeamUserSearch brig teamid self q = do
+executeTeamUserSearch ::
+  (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) =>
+  Brig ->
+  TeamId ->
+  UserId ->
+  Maybe Text ->
+  Maybe RoleFilter ->
+  Maybe TeamUserSearchSortBy ->
+  Maybe TeamUserSearchSortOrder ->
+  m (SearchResult TeamContact)
+executeTeamUserSearch brig teamid self mbSearchText mRoleFilter mSortBy mSortOrder = do
   r <-
     get
       ( brig
           . paths ["/teams", toByteString' teamid, "search"]
           . zUser self
-          . queryItem "q" (encodeUtf8 q)
+          . maybe id (queryItem "q" . encodeUtf8) mbSearchText
+          . maybe id (queryItem "frole" . cs . toByteString) mRoleFilter
+          . maybe id (queryItem "sortby" . cs . toByteString) mSortBy
+          . maybe id (queryItem "sortorder" . cs . toByteString) mSortOrder
       )
       <!! const 200
       === statusCode

--- a/services/brig/test/integration/API/TeamUserSearch.hs
+++ b/services/brig/test/integration/API/TeamUserSearch.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
 module API.TeamUserSearch (tests) where
 
 import API.Search.Util (executeTeamUserSearch, refreshIndex)
@@ -8,6 +10,7 @@ import API.User.Util (activateEmail, initiateEmailUpdateNoSend)
 import Bilge (Manager, MonadHttp)
 import qualified Brig.Options as Opt
 import Brig.Types (SearchResult (searchResults), User (userId), fromEmail)
+import Brig.User.Search.TeamUserSearch (TeamUserSearchSortBy (..), TeamUserSearchSortOrder (..))
 import Control.Monad.Catch (MonadCatch)
 import Control.Retry ()
 import Data.Id (TeamId, UserId)
@@ -21,6 +24,7 @@ import Util
     test,
     withSettingsOverrides,
   )
+import Wire.API.User (User (userDisplayName), userEmail)
 import Wire.API.User.Search (TeamContact (teamContactCreatedAt, teamContactUserId))
 
 type TestConstraints m = (MonadFail m, MonadCatch m, MonadIO m, MonadHttp m)
@@ -30,7 +34,8 @@ tests opts mgr _galley brig = do
   return $
     testGroup "browse team" $
       [ testWithNewIndex "by email" (testSearchByEmailSameTeam brig),
-        testWithNewIndex "empty query lists the whole team sorted" (testEmptyQuerySorted brig)
+        testWithNewIndex "empty query lists the whole team sorted" (testEmptyQuerySorted brig),
+        testWithNewIndex "sorting by name works" (testSort brig)
       ]
   where
     testWithNewIndex name f = test mgr name $ withSettingsOverrides opts f
@@ -54,7 +59,7 @@ testSearchByEmailSameTeam brig = do
 
 assertTeamUserSearchCanFind :: TestConstraints m => Brig -> TeamId -> UserId -> UserId -> Text -> m ()
 assertTeamUserSearchCanFind brig teamid self expected q = do
-  r <- searchResults <$> executeTeamUserSearch brig teamid self q
+  r <- searchResults <$> executeTeamUserSearch brig teamid self (Just q) Nothing Nothing Nothing
   liftIO $ do
     assertBool ("No results for query: " <> show q) $
       not (null r)
@@ -63,7 +68,7 @@ assertTeamUserSearchCanFind brig teamid self expected q = do
 
 assertTeamUserSearchCannotFind :: TestConstraints m => Brig -> TeamId -> UserId -> UserId -> Text -> m ()
 assertTeamUserSearchCannotFind brig teamid self expected q = do
-  r <- searchResults <$> executeTeamUserSearch brig teamid self q
+  r <- searchResults <$> executeTeamUserSearch brig teamid self (Just q) Nothing Nothing Nothing
   liftIO $ do
     assertBool ("User shouldn't be present in results for query: " <> show q) $
       expected `notElem` map teamContactUserId r
@@ -72,7 +77,7 @@ testEmptyQuerySorted :: TestConstraints m => Brig -> m ()
 testEmptyQuerySorted brig = do
   (tid, userId -> ownerId, users) <- createPopulatedBindingTeamWithNamesAndHandles brig 4
   refreshIndex brig
-  r <- searchResults <$> executeTeamUserSearch brig tid ownerId ""
+  r <- searchResults <$> executeTeamUserSearch brig tid ownerId (Just "") Nothing Nothing Nothing
   let creationDates = fmap teamContactCreatedAt r
   liftIO $
     assertEqual
@@ -80,3 +85,22 @@ testEmptyQuerySorted brig = do
       (sort (fmap userId users <> [ownerId]))
       (sort (fmap teamContactUserId r))
   liftIO $ assertEqual "sorted team contacts" (sortOn Down creationDates) creationDates
+
+testSort :: TestConstraints m => Brig -> m ()
+testSort brig = do
+  (tid, userId -> ownerId, users) <- createPopulatedBindingTeamWithNamesAndHandles brig 4
+  refreshIndex brig
+  let tuSortBy = SortByEmail
+  let orderProp = Down . userEmail
+  r <- searchResults <$> executeTeamUserSearch brig tid ownerId Nothing Nothing (Just tuSortBy) (Just SortOrderDesc)
+  let rUids = filter (/= ownerId) $ fmap teamContactUserId r
+  liftIO $ assertEqual "sorted users" (fmap userId (sortOn orderProp users)) rUids
+  pure ()
+
+-- sortLabel SortByCreatedAt = ES.FieldName "created_at"
+-- sortLabel SortByName = ES.FieldName "name"
+-- sortLabel SortByHandle = ES.FieldName "handle"
+-- sortLabel SortByEmail = ES.FieldName "email"
+-- sortLabel SortBySAMLIdp = ES.FieldName "saml_idp"
+-- sortLabel SortByManagedBy = ES.FieldName "managed_by"
+-- sortLabel SortByRole = ES.FieldName "role"

--- a/services/brig/test/integration/API/TeamUserSearch.hs
+++ b/services/brig/test/integration/API/TeamUserSearch.hs
@@ -111,7 +111,7 @@ testSort brig = do
       let rUids = filter (/= ownerId) $ fmap teamContactUserId r
       liftIO $ assertEqual ("users sorted by " <> cs (toByteString tuSortBy)) uids rUids
 
--- Creating test users with for these cases seems overkill just to test sorting.
+-- Creating test users for these cases seems overkill just to test sorting.
 -- This tests that the search query succeeds and returns the users of the team (without testing correct order).
 testSortCallSucceeds :: TestConstraints m => Brig -> m ()
 testSortCallSucceeds brig = do

--- a/services/brig/test/integration/API/TeamUserSearch.hs
+++ b/services/brig/test/integration/API/TeamUserSearch.hs
@@ -115,8 +115,8 @@ testSort brig = do
       let rUids = filter (/= ownerId) $ fmap teamContactUserId r
       liftIO $ assertEqual ("users sorted by " <> cs (toByteString tuSortBy)) uids rUids
 
--- Creating test users for these cases seems overkill just to test sorting.
--- This tests that the search query succeeds and returns the users of the team (without testing correct order).
+-- Creating test users for these cases is hard, so we skip it.
+-- This test checks that the search query at least succeeds and returns the users of the team (without testing correct order).
 testSortCallSucceeds :: TestConstraints m => Brig -> m ()
 testSortCallSucceeds brig = do
   (tid, userId -> ownerId, users) <- createPopulatedBindingTeamWithNamesAndHandles brig 4

--- a/services/brig/test/integration/API/TeamUserSearch.hs
+++ b/services/brig/test/integration/API/TeamUserSearch.hs
@@ -111,9 +111,8 @@ testSort brig = do
       let rUids = filter (/= ownerId) $ fmap teamContactUserId r
       liftIO $ assertEqual ("users sorted by " <> cs (toByteString tuSortBy)) uids rUids
 
--- Creating test users with different saml idps and managed_by values seemed overkill,
--- since 'testSort' also tests that sorting works in general.
--- But we can test at least that the query returns the users of the team and doesnt fail
+-- Creating test users with for these cases seems overkill just to test sorting.
+-- This tests that the search query succeeds and returns the users of the team (without testing correct order).
 testSortCallSucceeds :: TestConstraints m => Brig -> m ()
 testSortCallSucceeds brig = do
   (tid, userId -> ownerId, users) <- createPopulatedBindingTeamWithNamesAndHandles brig 4

--- a/services/brig/test/integration/API/TeamUserSearch.hs
+++ b/services/brig/test/integration/API/TeamUserSearch.hs
@@ -88,6 +88,10 @@ testEmptyQuerySorted brig = do
 testSort :: TestConstraints m => Brig -> m ()
 testSort brig = do
   (tid, userId -> ownerId, usersImplicitOrder) <- createPopulatedBindingTeamWithNamesAndHandles brig 4
+  -- Shuffle here to guard against false positives in this test.
+  -- This might happen due to buggy data generation, where all users share the same value in the sort property,
+  -- resulting in an implicit order, which might coincide in the DB and ES, resulting in false positive test
+  -- result.
   users <- liftIO $ shuffleM usersImplicitOrder
   refreshIndex brig
   let sortByProperty' :: (TestConstraints m, Ord a) => TeamUserSearchSortBy -> (User -> a) -> TeamUserSearchSortOrder -> m ()


### PR DESCRIPTION
Follow-up for #1286. This PR adds ordering of the search result by name, email, handle, samlIdp, managedBy to `/teams/:tid/search`.

This PR requires rebuilding the ES index. However this PR doesn't increase the migration version, since this PR is meant to be released together with #1286.