### PR TITLE
[skip ci] faster local docker image building using buildah

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,8 @@ hie.yaml
 
 # generated files under .local
 .local
+
+# buildah-based docker image building
+.stack-root-buildah/
+.stack-work-buildah/
+dist-buildah

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ CHARTS_INTEGRATION    := wire-server databases-ephemeral fake-aws
 # this list could be generated from the folder names under ./charts/ like so:
 # CHARTS_RELEASE := $(shell find charts/ -maxdepth 1 -type d | xargs -n 1 basename | grep -v charts)
 CHARTS_RELEASE        := wire-server databases-ephemeral fake-aws aws-ingress backoffice calling-test demo-smtp elasticsearch-curator elasticsearch-external fluent-bit minio-external cassandra-external nginx-ingress-controller nginx-ingress-services reaper wire-server-metrics sftd
+BUILDAH_PUSH          ?= 1
 
 default: fast
 
@@ -344,5 +345,8 @@ echo-release-charts:
 .PHONY: buildah-docker
 buildah-docker:
 	./hack/bin/buildah-compile.sh
-	# FUTUREWORK: Allow overriding BUILDAH_PUSH
-	BUILDAH_PUSH=1 ./hack/bin/buildah-make-images.sh
+	BUILDAH_PUSH=${BUILDAH_PUSH} ./hack/bin/buildah-make-images.sh
+
+.PHONY: buildah-clean
+buildah-clean:
+	./hack/bin/buildah-clean.sh

--- a/Makefile
+++ b/Makefile
@@ -344,4 +344,5 @@ echo-release-charts:
 .PHONY: buildah-docker
 buildah-docker:
 	./hack/bin/buildah-compile.sh
+	# FUTUREWORK: Allow overriding BUILDAH_PUSH
 	BUILDAH_PUSH=1 ./hack/bin/buildah-make-images.sh

--- a/Makefile
+++ b/Makefile
@@ -340,3 +340,8 @@ upload-charts: charts-release
 .PHONY: echo-release-charts
 echo-release-charts:
 	@echo ${CHARTS_RELEASE}
+
+.PHONY: buildah-docker
+buildah-docker:
+	./hack/bin/buildah-compile.sh
+	BUILDAH_PUSH=1 ./hack/bin/buildah-make-images.sh

--- a/docs/developer/dependencies.md
+++ b/docs/developer/dependencies.md
@@ -215,6 +215,12 @@ telepresence --namespace "$NAMESPACE" --also-proxy cassandra-ephemeral --run bas
 
 In both cases, you need to adjust the various integration configuration files and names so that this can work.
 
+## Buildah (optional)
+
+[Buildah](https://buildah.io/) is used for local docker image creation during development. See [buildah installation](https://github.com/containers/buildah/blob/master/install.md)
+
+See `make buildah-docker` for an entry point here.
+
 ## Helm chart development, integration tests in kubernetes
 
 You need `kubectl`, `helm`, and a valid kubernetes context. Refer to https://docs.wire.com for details.

--- a/hack/bin/buildah-clean.sh
+++ b/hack/bin/buildah-clean.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
+
+# Note: keep these paths in sync with the paths/names used in the other buildah-* scripts.
+rm -rf "$TOP_LEVEL"/dist-buildah
+rm -rf "$TOP_LEVEL"/.stack-root-buildah
+rm -rf "$TOP_LEVEL"/.stack-work-buildah
+buildah rm wire-server-dev
+buildah rm output

--- a/hack/bin/buildah-compile.sh
+++ b/hack/bin/buildah-compile.sh
@@ -19,6 +19,7 @@ mkdir -p "$TOP_LEVEL"/dist-buildah
 CONTAINER_NAME=wire-server-dev
 
 # check for the existence of; or create a working container
+# FUTUREWORK: Allow cleaning up old working container using some env variable or explicit make task like `make buildah-clean`
 buildah containers | awk '{print $5}' | grep "$CONTAINER_NAME" \
     || buildah from --name "$CONTAINER_NAME" -v "${TOP_LEVEL}":/src --pull quay.io/wire/alpine-builder:develop
 

--- a/hack/bin/buildah-compile.sh
+++ b/hack/bin/buildah-compile.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# This compiles wire-server inside an alpine-based container based on quay.io/wire/alpine-builder.
+# the tool 'buildah' is used to mount some folders in, and to
+# keep the stack caches of .stack and .stack-work (renamed to avoid conflicts) for the next compilation
+
+# After compilation, ./buildah-make-images.sh can be used
+# to bake individual executables into their respective docker images used by kubernetes.
+
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
+
+mkdir -p "$TOP_LEVEL"/.stack-root-buildah
+mkdir -p "$TOP_LEVEL"/.stack-work-buildah
+mkdir -p "$TOP_LEVEL"/dist-buildah
+
+CONTAINER_NAME=wire-server-dev
+
+# check for the existence of; or create a working container
+buildah containers | awk '{print $5}' | grep "$CONTAINER_NAME" \
+    || buildah from --name "$CONTAINER_NAME" -v "${TOP_LEVEL}":/src --pull quay.io/wire/alpine-builder:develop
+
+# The first time round, we want to copy the .stack folder from the alpine-builder for future use. Afterwards, we want to re-use the "dirty" stack root folder.
+# Current check hinges on the existence of a config file, and hardcodes some paths
+ls "$TOP_LEVEL/.stack-root-buildah/config.yaml" 2> /dev/null \
+    || buildah run "$CONTAINER_NAME" -- cp -a /root/.stack/. /src/.stack-root-buildah/
+
+buildah run "$CONTAINER_NAME" -- /src/hack/bin/buildah-inside.sh

--- a/hack/bin/buildah-compile.sh
+++ b/hack/bin/buildah-compile.sh
@@ -12,14 +12,13 @@ set -ex
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
+# Note: keep the following names and paths in sync with the other buildah-* scripts.
 mkdir -p "$TOP_LEVEL"/.stack-root-buildah
 mkdir -p "$TOP_LEVEL"/.stack-work-buildah
 mkdir -p "$TOP_LEVEL"/dist-buildah
-
 CONTAINER_NAME=wire-server-dev
 
 # check for the existence of; or create a working container
-# FUTUREWORK: Allow cleaning up old working container using some env variable or explicit make task like `make buildah-clean`
 buildah containers | awk '{print $5}' | grep "$CONTAINER_NAME" \
     || buildah from --name "$CONTAINER_NAME" -v "${TOP_LEVEL}":/src --pull quay.io/wire/alpine-builder:develop
 

--- a/hack/bin/buildah-inside.sh
+++ b/hack/bin/buildah-inside.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# This script is meant to be run from inside a buildah container. See buildah-compile.sh for details.
+
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
+
+cd "$TOP_LEVEL"
+stack install . --local-bin-path=dist-buildah --work-dir=.stack-work-buildah --stack-root="${TOP_LEVEL}"/.stack-root-buildah --fast

--- a/hack/bin/buildah-make-images.sh
+++ b/hack/bin/buildah-make-images.sh
@@ -36,3 +36,5 @@ if [[ $BUILDAH_PUSH -eq 1 ]]; then
         buildah push "quay.io/wire/$EX:$DOCKER_TAG"
     done
 fi
+
+"$DIR/buildah-purge-untagged.sh"

--- a/hack/bin/buildah-make-images.sh
+++ b/hack/bin/buildah-make-images.sh
@@ -5,9 +5,10 @@ set -ex
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
+# FUTUREWORK: Define this list in the makefile to allow overriding
 EXECUTABLES="cannon brig cargohold galley gundeck federator brig-index brig-schema galley-schema galley-migrate-data gundeck-schema proxy spar spar-schema"
 CONTAINER_NAME="output"
-DOCKER_TAG=$USER
+DOCKER_TAG=${DOCKER_TAG:-$USER}
 
 buildah containers | awk '{print $5}' | grep "$CONTAINER_NAME" \
     || buildah from --name "$CONTAINER_NAME" -v "${TOP_LEVEL}":/src --pull quay.io/wire/alpine-deps:develop

--- a/hack/bin/buildah-make-images.sh
+++ b/hack/bin/buildah-make-images.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
+
+EXECUTABLES="cannon brig cargohold galley gundeck federator brig-index brig-schema galley-schema galley-migrate-data gundeck-schema proxy spar spar-schema"
+CONTAINER_NAME="output"
+DOCKER_TAG=$USER
+
+buildah containers | awk '{print $5}' | grep "$CONTAINER_NAME" \
+    || buildah from --name "$CONTAINER_NAME" -v "${TOP_LEVEL}":/src --pull quay.io/wire/alpine-deps:develop
+
+# Only brig needs these templates, but for simplicity we add them to all resulting images (optimization FUTUREWORK)
+buildah run "$CONTAINER_NAME" -- sh -c 'mkdir -p /usr/share/wire/templates && cp -r "/src/services/brig/deb/opt/brig/templates" "/usr/share/wire/templates"'
+
+for EX in $EXECUTABLES; do
+    # Copy the main executable into the PATH on the container
+    buildah run "$CONTAINER_NAME" -- cp "/src/dist/$EX" "/usr/bin/$EX"
+
+    # Start that executable by default when launching the docker image
+    buildah config --entrypoint "[ \"/usr/bin/dumb-init\", \"--\", \"/usr/bin/$EX\" ]" "$CONTAINER_NAME"
+    buildah config --cmd null "$CONTAINER_NAME"
+
+    # Bake an image
+    buildah commit "$CONTAINER_NAME" quay.io/wire/"$EX":"$DOCKER_TAG"
+
+    # remove executable from the image in preparation for the next iteration
+    buildah run "$CONTAINER_NAME" -- rm "/usr/bin/$EX"
+done
+
+if [[ $BUILDAH_PUSH -eq 1 ]]; then
+    for EX in $EXECUTABLES; do
+        buildah push "quay.io/wire/$EX:$DOCKER_TAG"
+    done
+fi

--- a/hack/bin/buildah-purge-untagged.sh
+++ b/hack/bin/buildah-purge-untagged.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Remove untagged images (if there are any) in the buildah store
+if buildah images | grep "<none>"; then
+    buildah images | grep "<none>" | awk '{print $3}' | xargs -n 1 buildah rmi
+fi


### PR DESCRIPTION
buildah-compile.sh compiles wire-server inside an alpine-based container based on quay.io/wire/alpine-builder.
the tool 'buildah' is used to mount some folders in, and to
keep the stack caches of .stack and .stack-work (renamed to avoid conflicts) for the next compilation. 

After compilation, ./buildah-make-images.sh can be used
to bake individual executables into their respective docker images used by kubernetes.

Usage: just run 'make buildah-docker' which will compile and upload
images to quay.io under the docker tag $USER by default.

On my machine, the overhead (from a successful `stack build` of wire-server to a set of ~15 docker images locally) is 1.5 minutes. Pushing to quay.io depends on your internet connection. Pushing to a local kubernetes cluster would be faster.

FUTUREWORK: build only some, not all images. (good luck figuring out the bash syntax to pass space-separated executables as arguments...)
FUTUREWORK: provide buildah using nix
FUTUREWORK: parameterize having or not `--fast` and maybe also use this on CI
FUTUREWORK: remove some docker makefile targets that are somewhat outdated
