### PR TITLE
Wire.API.UserMap & Brig.API.Public: Fix Swagger docs

### DIFF
--- a/libs/wire-api/src/Wire/API/Arbitrary.hs
+++ b/libs/wire-api/src/Wire/API/Arbitrary.hs
@@ -130,3 +130,12 @@ instance Arbitrary Aeson.Value where
             Aeson.Number <$> arbitrary,
             Aeson.Bool <$> arbitrary
           ]
+
+-- | Use Arbitrary instance to generate an example to be used in swagger where
+-- we cannot rely on swagger-ui to generate nice examples. So far, this is only
+-- required for maps as swagger2 doesn't have a good way to specify the type of
+-- keys.
+generateExample :: Arbitrary a => a
+generateExample =
+  let (MkGen f) = arbitrary
+   in f (mkQCGen 42) 42

--- a/libs/wire-api/src/Wire/API/Arbitrary.hs
+++ b/libs/wire-api/src/Wire/API/Arbitrary.hs
@@ -29,6 +29,7 @@ module Wire.API.Arbitrary
     list1Of',
     setOf',
     mapOf',
+    generateExample,
   )
 where
 
@@ -48,8 +49,9 @@ import qualified Generic.Random as Generic
 import Imports
 import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary))
 import qualified Test.QuickCheck.Arbitrary as QC
-import Test.QuickCheck.Gen (Gen, oneof)
+import Test.QuickCheck.Gen (Gen (MkGen), oneof)
 import Test.QuickCheck.Instances ()
+import Test.QuickCheck.Random
 
 -- | This type can be used with @DerivingVia@ to generically derive an instance
 -- for the 'Arbitrary' typeclass.

--- a/libs/wire-api/src/Wire/API/UserMap.hs
+++ b/libs/wire-api/src/Wire/API/UserMap.hs
@@ -3,16 +3,18 @@
 module Wire.API.UserMap where
 
 import Control.Lens ((?~))
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON, ToJSON (toJSON))
 import Data.Domain (Domain)
 import Data.Id (UserId)
 import Data.Proxy (Proxy (..))
-import Data.Swagger (HasDescription (description), NamedSchema (..), ToSchema (..), declareSchema)
+import Data.Swagger (HasDescription (description), HasExample (example), NamedSchema (..), ToSchema (..), declareSchema)
 import qualified Data.Text as Text
 import Data.Typeable (typeRep)
 import Imports
 import Test.QuickCheck (Arbitrary (..))
-import Wire.API.Arbitrary (mapOf')
+import Test.QuickCheck.Gen (Gen (MkGen))
+import Test.QuickCheck.Random
+import Wire.API.Arbitrary (generateExample, mapOf')
 
 newtype UserMap a = UserMap {userMap :: Map UserId a}
   deriving stock (Eq, Show)
@@ -30,7 +32,7 @@ newtype QualifiedUserMap a = QualifiedUserMap
 instance Arbitrary a => Arbitrary (QualifiedUserMap a) where
   arbitrary = QualifiedUserMap <$> mapOf' arbitrary arbitrary
 
-instance (ToSchema a, Typeable a) => ToSchema (UserMap a) where
+instance (ToSchema a, ToJSON a, Arbitrary a, Typeable a) => ToSchema (UserMap a) where
   declareNamedSchema _ = do
     mapSch <- declareSchema (Proxy @(Map UserId a))
     let valueTypeName = Text.pack $ show $ typeRep $ Proxy @a
@@ -38,8 +40,9 @@ instance (ToSchema a, Typeable a) => ToSchema (UserMap a) where
       NamedSchema (Just $ "UserMap (" <> valueTypeName <> ")") $
         mapSch
           & description ?~ "Map of UserId to " <> valueTypeName
+          & example ?~ toJSON (generateExample @(UserMap a))
 
-instance (ToSchema a, Typeable a) => ToSchema (QualifiedUserMap a) where
+instance (ToSchema a, Typeable a, ToJSON a, Arbitrary a) => ToSchema (QualifiedUserMap a) where
   declareNamedSchema _ = do
     mapSch <- declareSchema (Proxy @(Map Domain (UserMap a)))
     let valueTypeName = Text.pack $ show $ typeRep $ Proxy @a
@@ -47,3 +50,4 @@ instance (ToSchema a, Typeable a) => ToSchema (QualifiedUserMap a) where
       NamedSchema (Just $ "QaulifiedUserMap (" <> valueTypeName <> ")") $
         mapSch
           & description ?~ "Map of Domain to (UserMap (" <> valueTypeName <> "))."
+          & example ?~ toJSON (generateExample @(QualifiedUserMap a))

--- a/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
@@ -36,7 +36,7 @@ tests =
       testToJSON @User.SelfProfile,
       testToJSON @Handle.UserHandleInfo,
       testToJSON @Client.Client,
-      testToJSON @(UserMap.UserMap Client.Client),
+      testToJSON @(UserMap.UserMap (Set Client.Client)),
       testToJSON @(UserMap.QualifiedUserMap (Set Client.Client))
     ]
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -268,7 +268,7 @@ type ListUsersByUnqualifiedIdsOrHandles =
 -- See Note [ephemeral user sideeffect]
 type ListUsersByIdsOrHandles =
   Summary "List users"
-    :> Description "The 'ids' and 'handles' parameters are mutually exclusive."
+    :> Description "The 'qualified_ids' and 'qualified_handles' parameters are mutually exclusive."
     :> ZAuthServant
     :> "list-users"
     :> Servant.ReqBody '[Servant.JSON] Public.ListUsersQuery


### PR DESCRIPTION
For WIre.API.UserMap:
The examples generated by swagger will not be nice, but it is very difficult to
get it right, unless we want to add explicit examples everywhere. Perhaps we can
use Arbitrary and some DerivingVia strategy to generate those. But for now, it
doesn't seem like it is worth it.