### PR TITLE
Galley: Add /teams/:tid/members csv download

### DIFF
--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -323,6 +323,10 @@ data HiddenPerm
   | ViewSameTeamEmails
   | CreateUpdateDeleteIdp
   | CreateReadDeleteScimToken
+  | -- | this has its own permission because we're not sure how
+    -- efficient this end-point is.  better not let all team members
+    -- play with it unless we have to.
+    DownloadTeamMembersCsv
   deriving (Eq, Ord, Show)
 
 -- | See Note [hidden team roles]
@@ -348,7 +352,8 @@ roleHiddenPermissions role = HiddenPermissions p p
             ChangeTeamSearchVisibility,
             ChangeTeamFeature TeamFeatureAppLock {- the other features can only be changed in stern -},
             CreateUpdateDeleteIdp,
-            CreateReadDeleteScimToken
+            CreateReadDeleteScimToken,
+            DownloadTeamMembersCsv
           ]
     roleHiddenPerms RoleMember =
       (roleHiddenPerms RoleExternalPartner <>) $

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -41,9 +41,12 @@ import Control.Lens (coerced, (%~))
 import Data.Aeson
 import Data.Aeson.Types
 import qualified Data.ByteString.Base64.Lazy as EL
+import qualified Data.ByteString.Builder as BB
+import qualified Data.ByteString.Conversion as BS
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Char8 as L8
 import Data.Fixed
+import Data.String.Conversions (cs)
 import Data.Swagger (ToSchema (..))
 import Data.Text (pack)
 import qualified Data.Text.Encoding
@@ -103,6 +106,12 @@ instance ToJSON UTCTimeMillis where
 
 instance FromJSON UTCTimeMillis where
   parseJSON = fmap UTCTimeMillis . parseJSON
+
+instance BS.ToByteString UTCTimeMillis where
+  builder = BB.byteString . cs . show
+
+instance BS.FromByteString UTCTimeMillis where
+  parser = maybe (fail "UTCTimeMillis") pure . readUTCTimeMillis =<< BS.parser
 
 instance CQL.Cql UTCTimeMillis where
   ctype = CQL.Tagged CQL.TimestampColumn

--- a/libs/types-common/test/Test/Properties.hs
+++ b/libs/types-common/test/Test/Properties.hs
@@ -29,7 +29,7 @@ import Data.Aeson (FromJSON (parseJSON), FromJSONKey, ToJSON (toJSON), ToJSONKey
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString.Char8 as C8
-import Data.ByteString.Conversion
+import Data.ByteString.Conversion as BS
 import Data.ByteString.Lazy as L
 import Data.Domain (Domain)
 import Data.Handle (Handle)
@@ -37,6 +37,7 @@ import Data.Id
 import qualified Data.Json.Util as Util
 import Data.ProtocolBuffers.Internal
 import Data.Serialize
+import Data.String.Conversions (cs)
 import Data.Text.Ascii
 import qualified Data.Text.Ascii as Ascii
 import Data.Time
@@ -124,9 +125,15 @@ tests =
       testGroup
         "UTCTimeMillis"
         [ testProperty "validate (Aeson.decode . Aeson.encode) == pure . id" $
-            \(t :: Util.UTCTimeMillis) ->
-              (Aeson.eitherDecode . Aeson.encode) t == Right t,
+            \(t :: Util.UTCTimeMillis) -> do
+              (Aeson.eitherDecode . Aeson.encode) t === Right t,
           -- (we could test @show x == show y ==> x == y@, but that kind of follows from the above.)
+
+          testProperty
+            "validate (Aeson.decode . Aeson.encode) == pure . id"
+            $ \(t :: Util.UTCTimeMillis) -> do
+              (BS.fromByteString' . cs . BS.toByteString') t === Just t,
+          --
 
           let toUTCTimeMillisSlow :: HasCallStack => UTCTime -> Maybe UTCTime
               toUTCTimeMillisSlow t = parseExact formatRounded

--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -24,6 +24,7 @@ library:
   - bytestring-conversion >=0.2
   - case-insensitive
   - cassandra-util
+  - cassava >= 0.5
   - cryptonite >=0.11
   - currency-codes >=2.0
   - deriving-aeson >=0.2
@@ -57,6 +58,7 @@ library:
   - unordered-containers >=0.2
   - uri-bytestring >=0.2
   - uuid >=1.3
+  - vector >= 0.12
 tests:
   wire-api-tests:
     main: Main.hs

--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -69,6 +69,7 @@ tests:
     dependencies:
     - base
     - bytestring-conversion
+    - cassava
     - wire-api
     - uuid
     - aeson-qq
@@ -79,3 +80,4 @@ tests:
     - tasty-hunit
     - tasty-quickcheck
     - unordered-containers
+    - vector

--- a/libs/wire-api/src/Wire/API/Team/Export.hs
+++ b/libs/wire-api/src/Wire/API/Team/Export.hs
@@ -1,0 +1,47 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Team.Export (TeamExportUser (..)) where
+
+import Data.ByteString.Conversion (toByteString')
+import Data.Csv (DefaultOrdered (..), ToNamedRecord (..), namedRecord)
+import Data.Handle (Handle)
+import Data.Vector (fromList)
+import Imports
+import Wire.API.Team.Role (Role)
+import Wire.API.User (Name)
+import Wire.API.User.Identity (Email)
+
+data TeamExportUser = TeamExportUser
+  { tExportDisplayName :: Name,
+    tExportUserName :: Maybe Handle,
+    tExportEmail :: Email,
+    tExportRole :: Role
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToNamedRecord TeamExportUser where
+  toNamedRecord row =
+    namedRecord
+      [ ("name", toByteString' (tExportDisplayName row)),
+        ("username", maybe "" toByteString' (tExportUserName row)),
+        ("email", toByteString' (tExportEmail row)),
+        ("role", toByteString' (tExportRole row))
+      ]
+
+instance DefaultOrdered TeamExportUser where
+  headerOrder = const $ fromList ["name", "username", "email", "role"]

--- a/libs/wire-api/src/Wire/API/Team/Export.hs
+++ b/libs/wire-api/src/Wire/API/Team/Export.hs
@@ -52,9 +52,9 @@ instance ToNamedRecord TeamExportUser where
 instance DefaultOrdered TeamExportUser where
   headerOrder = const $ fromList ["name", "username", "email", "role"]
 
-maybeParser :: (ByteString -> Parser a) -> ByteString -> Parser (Maybe a)
-maybeParser _ "" = pure Nothing
-maybeParser p str = Just <$> p str
+allowEmpty :: (ByteString -> Parser a) -> ByteString -> Parser (Maybe a)
+allowEmpty _ "" = pure Nothing
+allowEmpty p str = Just <$> p str
 
 parseByteString :: forall a. FromByteString a => ByteString -> Parser a
 parseByteString bstr =
@@ -66,6 +66,6 @@ instance FromNamedRecord TeamExportUser where
   parseNamedRecord nrec =
     TeamExportUser
       <$> (nrec .: "name" >>= parseByteString)
-      <*> (nrec .: "username" >>= maybeParser parseByteString)
-      <*> (nrec .: "email" >>= maybeParser parseByteString)
-      <*> (nrec .: "role" >>= maybeParser parseByteString)
+      <*> (nrec .: "username" >>= allowEmpty parseByteString)
+      <*> (nrec .: "email" >>= allowEmpty parseByteString)
+      <*> (nrec .: "role" >>= allowEmpty parseByteString)

--- a/libs/wire-api/src/Wire/API/Team/Export.hs
+++ b/libs/wire-api/src/Wire/API/Team/Export.hs
@@ -33,7 +33,7 @@ import Wire.API.User.Identity (Email)
 
 data TeamExportUser = TeamExportUser
   { tExportDisplayName :: Name,
-    tExportUserName :: Maybe Handle,
+    tExportHandle :: Maybe Handle,
     tExportEmail :: Maybe Email,
     tExportRole :: Maybe Role
   }
@@ -43,14 +43,14 @@ data TeamExportUser = TeamExportUser
 instance ToNamedRecord TeamExportUser where
   toNamedRecord row =
     namedRecord
-      [ ("name", toByteString' (tExportDisplayName row)),
-        ("username", maybe "" toByteString' (tExportUserName row)),
+      [ ("display name", toByteString' (tExportDisplayName row)),
+        ("handle", maybe "" toByteString' (tExportHandle row)),
         ("email", maybe "" toByteString' (tExportEmail row)),
         ("role", maybe "" toByteString' (tExportRole row))
       ]
 
 instance DefaultOrdered TeamExportUser where
-  headerOrder = const $ fromList ["name", "username", "email", "role"]
+  headerOrder = const $ fromList ["display name", "handle", "email", "role"]
 
 allowEmpty :: (ByteString -> Parser a) -> ByteString -> Parser (Maybe a)
 allowEmpty _ "" = pure Nothing
@@ -65,7 +65,7 @@ parseByteString bstr =
 instance FromNamedRecord TeamExportUser where
   parseNamedRecord nrec =
     TeamExportUser
-      <$> (nrec .: "name" >>= parseByteString)
-      <*> (nrec .: "username" >>= allowEmpty parseByteString)
+      <$> (nrec .: "display name" >>= parseByteString)
+      <*> (nrec .: "handle" >>= allowEmpty parseByteString)
       <*> (nrec .: "email" >>= allowEmpty parseByteString)
       <*> (nrec .: "role" >>= allowEmpty parseByteString)

--- a/libs/wire-api/src/Wire/API/Team/Role.hs
+++ b/libs/wire-api/src/Wire/API/Team/Role.hs
@@ -73,7 +73,7 @@ import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 -- Creating a new permission flag is thus very tricky, because if we decide
 -- that all team admins must have this new permission, we will have to
 -- identify all existing team admins. And if it turns out that some users
--- don't fit into one of those three team roleswe're screwed.
+-- don't fit into one of those three team roles, we're screwed.
 
 -- | Team-level role.  Analog to conversation-level 'ConversationRole'.
 data Role = RoleOwner | RoleAdmin | RoleMember | RoleExternalPartner

--- a/libs/wire-api/src/Wire/API/Team/Role.hs
+++ b/libs/wire-api/src/Wire/API/Team/Role.hs
@@ -73,7 +73,7 @@ import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 -- Creating a new permission flag is thus very tricky, because if we decide
 -- that all team admins must have this new permission, we will have to
 -- identify all existing team admins. And if it turns out that some users
--- don't fit into one of those three team roles, we're screwed.
+-- don't fit into one of those three team roleswe're screwed.
 
 -- | Team-level role.  Analog to conversation-level 'ConversationRole'.
 data Role = RoleOwner | RoleAdmin | RoleMember | RoleExternalPartner

--- a/libs/wire-api/test/unit/Main.hs
+++ b/libs/wire-api/test/unit/Main.hs
@@ -25,6 +25,7 @@ import Test.Tasty
 import qualified Test.Wire.API.Call.Config as Call.Config
 import qualified Test.Wire.API.Roundtrip.Aeson as Roundtrip.Aeson
 import qualified Test.Wire.API.Roundtrip.ByteString as Roundtrip.ByteString
+import qualified Test.Wire.API.Roundtrip.CSV as Roundtrip.CSV
 import qualified Test.Wire.API.Swagger as Swagger
 import qualified Test.Wire.API.Team.Member as Team.Member
 import qualified Test.Wire.API.User as User
@@ -41,5 +42,6 @@ main =
         User.RichInfo.tests,
         Roundtrip.Aeson.tests,
         Roundtrip.ByteString.tests,
-        Swagger.tests
+        Swagger.tests,
+        Roundtrip.CSV.tests
       ]

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/CSV.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/CSV.hs
@@ -1,0 +1,50 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Wire.API.Roundtrip.CSV where
+
+import Control.Arrow ((>>>))
+import Data.Csv
+import qualified Data.Vector as V
+import Imports
+import qualified Test.Tasty as T
+import Test.Tasty.QuickCheck (Arbitrary, counterexample, testProperty, (===))
+import Type.Reflection (typeRep)
+import qualified Wire.API.Team.Export as Team.Export
+
+tests :: T.TestTree
+tests =
+  T.localOption (T.Timeout (60 * 1000000) "60s") . T.testGroup "CSV roundtrip tests" $
+    [testRoundTrip @Team.Export.TeamExportUser]
+
+testRoundTrip ::
+  forall a.
+  (Arbitrary a, Typeable a, ToNamedRecord a, FromNamedRecord a, DefaultOrdered a, Eq a, Show a) =>
+  T.TestTree
+testRoundTrip = testProperty msg trip
+  where
+    msg = show (typeRep @[a])
+
+    trip (v :: [a]) =
+      counterexample (show $ encodeCSV v) $
+        Right v === (decodeCSV . encodeCSV) v
+
+    encodeCSV :: (DefaultOrdered a, ToNamedRecord a) => [a] -> LByteString
+    encodeCSV = encodeDefaultOrderedByName
+
+    decodeCSV :: FromNamedRecord a => LByteString -> Either String [a]
+    decodeCSV bstr = decodeByName bstr <&> (snd >>> V.toList)

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -48,6 +48,7 @@ library
       Wire.API.Swagger
       Wire.API.Team
       Wire.API.Team.Conversation
+      Wire.API.Team.Export
       Wire.API.Team.Feature
       Wire.API.Team.Invitation
       Wire.API.Team.LegalHold
@@ -86,6 +87,7 @@ library
     , bytestring-conversion >=0.2
     , case-insensitive
     , cassandra-util
+    , cassava >=0.5
     , containers >=0.5
     , cryptonite >=0.11
     , currency-codes >=2.0
@@ -122,6 +124,7 @@ library
     , unordered-containers >=0.2
     , uri-bytestring >=0.2
     , uuid >=1.3
+    , vector >=0.12
   default-language: Haskell2010
 
 test-suite wire-api-tests

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -134,6 +134,7 @@ test-suite wire-api-tests
       Test.Wire.API.Call.Config
       Test.Wire.API.Roundtrip.Aeson
       Test.Wire.API.Roundtrip.ByteString
+      Test.Wire.API.Roundtrip.CSV
       Test.Wire.API.Swagger
       Test.Wire.API.Team.Member
       Test.Wire.API.User
@@ -148,6 +149,7 @@ test-suite wire-api-tests
     , aeson-qq
     , base
     , bytestring-conversion
+    , cassava
     , containers >=0.5
     , imports
     , lens
@@ -159,5 +161,6 @@ test-suite wire-api-tests
     , types-common >=0.16
     , unordered-containers
     , uuid
+    , vector
     , wire-api
   default-language: Haskell2010

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 49237049744e0baa7ee9251441e64df42af931cc33be6ae9d025b8832b6467db
+-- hash: ae3bc6605d8c9cc44467e5d9b8e6bb02e36757ae26b4f9552e9bc03cb32a86f8
 
 name:           wire-api
 version:        0.1.0

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f75b1fb69c6fca4419cbc7df1a7d45722b48173fda95c920075ca095dcea0427
+-- hash: de4aa0b8e28014de5878b77c3c11538cf9bcce27c362a900ec11ad6372600c55
 
 name:           galley
 version:        0.83.0
@@ -248,6 +248,7 @@ executable galley-integration
     , proto-lens
     , protobuf
     , quickcheck-instances
+    , random
     , raw-strings-qq >=1.0
     , retry
     , safe >=0.3

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 61540c1efb6e5d3607c723f3d7d8a9db425693ef362f9fe8cfd68683a4459b7a
+-- hash: 9a4ee3362b7f8864eb89f4f5b9ab0cd93eea2fd0961992edab678bf52af955c0
 
 name:           galley
 version:        0.83.0
@@ -91,6 +91,7 @@ library
     , bytestring-conversion >=0.2
     , case-insensitive >=1.0
     , cassandra-util >=0.16.2
+    , cassava >=0.5.2
     , cereal >=0.4
     , containers >=0.5
     , currency-codes >=2.0

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9a4ee3362b7f8864eb89f4f5b9ab0cd93eea2fd0961992edab678bf52af955c0
+-- hash: f75b1fb69c6fca4419cbc7df1a7d45722b48173fda95c920075ca095dcea0427
 
 name:           galley
 version:        0.83.0
@@ -219,6 +219,7 @@ executable galley-integration
     , bytestring
     , bytestring-conversion
     , cassandra-util
+    , cassava
     , cereal
     , containers
     , cookie
@@ -269,6 +270,7 @@ executable galley-integration
     , unordered-containers
     , uri-bytestring
     , uuid
+    , vector
     , wai
     , wai-extra
     , wai-route

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -185,6 +185,7 @@ executables:
     - proto-lens
     - QuickCheck
     - quickcheck-instances
+    - random
     - retry
     - servant-swagger
     - string-conversions

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -155,6 +155,7 @@ executables:
     - bytestring
     - bytestring-conversion
     - cassandra-util
+    - cassava
     - cereal
     - containers
     - cookie
@@ -203,6 +204,7 @@ executables:
     - unordered-containers
     - uri-bytestring
     - uuid
+    - vector
     - wai
     - wai-extra
     - wai-route

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -33,6 +33,7 @@ library:
   - bytestring-conversion >=0.2
   - case-insensitive >=1.0
   - cassandra-util >=0.16.2
+  - cassava >= 0.5.2
   - cereal >=0.4
   - containers >=0.5
   - currency-codes >=2.0

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -172,7 +172,9 @@ sitemap = do
     response 200 "Team members" end
     errorResponse Error.notATeamMember
 
-  get "/teams/:tid/members" (continue Teams.getTeamMembersCSVH) $
+  get "/teams/:tid/members/csv" (continue Teams.getTeamMembersCSVH) $
+    -- we could discriminate based on accept header only, but having two paths makes building
+    -- nginz metrics dashboards easier.
     zauthUserId
       .&. capture "tid"
       .&. accept "text" "csv"

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -172,6 +172,11 @@ sitemap = do
     response 200 "Team members" end
     errorResponse Error.notATeamMember
 
+  get "/teams/:tid/members" (continue Teams.getTeamMembersCSVH) $
+    zauthUserId
+      .&. capture "tid"
+      .&. accept "text" "csv"
+
   post "/teams/:tid/get-members-by-ids-using-post" (continue Teams.bulkGetTeamMembersH) $
     zauthUserId
       .&. capture "tid"

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -379,12 +379,9 @@ getTeamMembers zusr tid maxResults = do
 
 getTeamMembersCSVH :: UserId ::: TeamId ::: JSON -> Galley Response
 getTeamMembersCSVH (zusr ::: tid ::: _) = do
-  mbZusrMembership <- Data.teamMember tid zusr
-  case mbZusrMembership of
-    Just zusrMembership ->
-      unless (isTeamOwner zusrMembership) $
-        throwM accessDenied
+  Data.teamMember tid zusr >>= \case
     Nothing -> throwM accessDenied
+    Just member -> unless (member `hasPermission` DownloadTeamMembersCsv) $ throwM accessDenied
 
   env <- ask
   pure $

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -68,11 +68,10 @@ import Data.IdMapping (MappedOrLocalId (Local))
 import qualified Data.List.Extra as List
 import Data.List1 (list1)
 import qualified Data.Map.Strict as M
-import qualified Data.Metrics.Middleware as Metrics
 import Data.Range as Range
 import Data.Set (fromList)
 import qualified Data.Set as Set
-import Data.Time.Clock (UTCTime (..), diffUTCTime, getCurrentTime)
+import Data.Time.Clock (UTCTime (..), getCurrentTime)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.Util as UUID
 import Galley.API.Error as Galley

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -409,7 +409,7 @@ getTeamMembersCSVH (zusr ::: tid ::: _) = do
       EncodeOptions
         { encDelimiter = 44, -- comma
           encUseCrLf = True, -- to be compatible with Mac and Windows
-          encIncludeHeader = False,
+          encIncludeHeader = False, -- (so we can flush when the header is on the wire)
           encQuoting = QuoteAll
         }
 

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -417,7 +417,7 @@ getTeamMembersCSVH (zusr ::: tid ::: _) = do
     teamExportUser member user =
       TeamExportUser
         { tExportDisplayName = U.userDisplayName user,
-          tExportUserName = U.userHandle user,
+          tExportHandle = U.userHandle user,
           tExportEmail = U.userIdentity user >>= U.emailIdentity,
           tExportRole = permissionsRole . view permissions $ member
         }

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -31,6 +31,7 @@ module Galley.API.Teams
     addTeamMemberH,
     getTeamNotificationsH,
     getTeamMembersH,
+    getTeamMembersCSVH,
     bulkGetTeamMembersH,
     getTeamMemberH,
     deleteTeamMemberH,
@@ -369,6 +370,14 @@ getTeamMembers zusr tid maxResults = do
       mems <- Data.teamMembersWithLimit tid maxResults
       let withPerms = (m `canSeePermsOf`)
       pure (mems, withPerms)
+
+getTeamMembersCSVH :: UserId ::: TeamId ::: JSON -> Galley Response
+getTeamMembersCSVH (_zusr ::: _tid ::: _) = do
+  -- TODO: metrics
+  -- TODO: integeration test with n users
+  pure $
+    responseStream status200 [] $ \write flush -> do
+      pure ()
 
 bulkGetTeamMembersH :: UserId ::: TeamId ::: Range 1 Public.HardTruncationLimit Int32 ::: JsonRequest Public.UserIdList ::: JSON -> Galley Response
 bulkGetTeamMembersH (zusr ::: tid ::: maxResults ::: body ::: _) = do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -36,7 +36,6 @@ import Data.Aeson hiding (json)
 import Data.Aeson.Lens
 import Data.ByteString.Conversion
 import Data.ByteString.Lazy (fromStrict)
-import qualified Data.ByteString.Lazy.Char8 as LBS (split)
 import qualified Data.Currency as Currency
 import Data.Id
 import Data.List1
@@ -44,6 +43,7 @@ import qualified Data.List1 as List1
 import Data.Misc (PlainTextPassword (..))
 import Data.Range
 import qualified Data.Set as Set
+import Data.String.Conversions (cs)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.UUID.Util as UUID
@@ -228,23 +228,27 @@ testListTeamMembersCsv = do
   -- happens.  but please don't give that number to our ci!  :)
   (owner, tid, mbs) <- Util.createBindingTeamWithNMembers numMembers
   resp <- Util.getTeamMembersCsv owner tid
+  let teamSize = length mbs + 1
+  let rbody = fromMaybe (error "no body") . responseBody $ resp
+  let nLines = length . T.lines . cs $ rbody
 
-  let rawLines :: [LByteString]
-      rawLines = LBS.split '\n' . fromMaybe (error "no body") . responseBody $ resp
+  -- let rawLines :: [LByteString]
+  --     rawLines = LBS.split '\n' body
 
-      parseLine :: LByteString -> UserId
-      parseLine = undefined
+  -- parseLine :: LByteString -> UserId
+  -- parseLine = undefined
 
   liftIO $
     assertEqual
       "csv file size"
-      (length rawLines)
-      (length mbs + 1)
-  liftIO $
-    assertEqual
-      "csv user ids"
-      (Set.fromList (parseLine <$> rawLines))
-      (Set.fromList mbs)
+      (teamSize + 1) -- +1 for header line
+      nLines
+
+-- liftIO $
+--   assertEqual
+--     "csv user ids"
+--     (Set.fromList mbs)
+--     (Set.fromList (parseLine <$> rawLines))
 
 testListTeamMembersTruncated :: TestM ()
 testListTeamMembersTruncated = do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -239,6 +239,7 @@ testListTeamMembersCsv numMembers = do
   let teamSize = numMembers + 1
 
   (owner, tid, _mbs) <- Util.createBindingTeamWithNMembersWithHandles True numMembers
+  liftIO $ writeFile "/tmp/csv-test" (show (owner, tid))
   resp <- Util.getTeamMembersCsv owner tid
   let rbody = fromMaybe (error "no body") . responseBody $ resp
   usersInCsv <- either (error "could not decode csv") pure (decodeCSV @TeamExportUser rbody)
@@ -246,6 +247,21 @@ testListTeamMembersCsv numMembers = do
     assertEqual "total number of team members" teamSize (length usersInCsv)
     assertEqual "owners in team" 1 (countOn tExportRole (Just RoleOwner) usersInCsv)
     assertEqual "members in team" numMembers (countOn tExportRole (Just RoleMember) usersInCsv)
+
+  {-
+   1000: OK (73.74s)
+   2000: OK (145.92s)
+   3000: _
+   3000 (only pull csv, not create members): _
+   10000:
+  -}
+
+  -- fuck it, we should really use the library.
+
+  -- then create a team with 10k members (100k?), and drop the team id.  then tweak this test
+  -- to pull all members for that team id and take the time (and ram) for just doing that.
+
+  -- https://stackoverflow.com/questions/8362428/stream-response-from-curl-request-without-waiting-for-it-to-finish#36368249
 
   do
     let someUsersInCsv = take 50 usersInCsv

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -240,18 +240,13 @@ testListTeamMembersCsv numMembers = do
   resp <- Util.getTeamMembersCsv owner tid
   let rbody = fromMaybe (error "no body") . responseBody $ resp
   usersInCsv <- either (error "could not decode csv") pure (decodeCSV @TeamExportUser rbody)
-
-  liftIO $
-    assertEqual
-      "total number of team members"
-      teamSize
-      (length usersInCsv)
-
-  users <- Util.getUsers mbs
   liftIO $ do
+    assertEqual "total number of team members" teamSize (length usersInCsv)
     assertEqual "owners in team" 1 (countOn tExportRole (Just RoleOwner) usersInCsv)
     assertEqual "members in team" numMembers (countOn tExportRole (Just RoleMember) usersInCsv)
 
+  users <- Util.getUsers mbs
+  liftIO $ do
     forM_ users $ \user -> do
       let displayName = U.userDisplayName user
       assertEqual ("user with display name " <> show displayName) 1 (countOn tExportDisplayName displayName usersInCsv)

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -85,7 +85,11 @@ tests s =
       test s "create team with members" testCreateTeamWithMembers,
       testGroup "List Team Members" $
         [ test s "a member should be able to list their team" testListTeamMembersDefaultLimit,
-          test s "admins should be able to get a csv stream with their team" testListTeamMembersCsv,
+          let numMembers = 5
+           in test
+                s
+                ("admins should be able to get a csv stream with their team (" <> show numMembers <> " members)")
+                (testListTeamMembersCsv numMembers),
           test s "the list should be limited to the number requested (hard truncation is not tested here)" testListTeamMembersTruncated
         ],
       testGroup "List Team Members (by ids)" $
@@ -226,11 +230,10 @@ testListTeamMembersDefaultLimit = do
       "member list indicates that there are no more members"
       (listFromServer ^. teamMemberListType == ListComplete)
 
-testListTeamMembersCsv :: HasCallStack => TestM ()
-testListTeamMembersCsv = do
-  -- for ad-hoc load-testing, set this is 10k or something and see what
-  -- happens.  but please don't give that number to our ci!  :)
-  let numMembers = 5
+-- | for ad-hoc load-testing, set @numMembers@ to, say, 10k and see what
+-- happens.  but please don't give that number to our ci!  :)
+testListTeamMembersCsv :: HasCallStack => Int -> TestM ()
+testListTeamMembersCsv numMembers = do
   let teamSize = numMembers + 1
 
   (owner, tid, mbs) <- Util.createBindingTeamWithNMembers numMembers

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -197,6 +197,14 @@ getTeamMembers usr tid = do
   r <- get (g . paths ["teams", toByteString' tid, "members"] . zUser usr) <!! const 200 === statusCode
   responseJsonError r
 
+-- alternative to 'ResponseLBS': [BodyReader](https://hoogle.zinfra.io/file/root/.stack/snapshots/x86_64-linux/82492d944a85db90f4cd7cec6f4d5215ef9ac1ac8aeffeed4a805fbd6b1232c5/8.8.4/doc/http-client-0.7.0/Network-HTTP-Client.html#t:BodyReader)
+getTeamMembersCsv :: HasCallStack => UserId -> TeamId -> TestM ResponseLBS
+getTeamMembersCsv usr tid = do
+  g <- view tsGalley
+  get (g . accept "text/csv" . paths ["teams", toByteString' tid, "members"] . zUser usr) <!! do
+    const 200 === statusCode
+    const (Just "chunked") === lookup "Transfer-Encoding" . responseHeaders
+
 getTeamMembersTruncated :: HasCallStack => UserId -> TeamId -> Int -> TestM TeamMemberList
 getTeamMembersTruncated usr tid n = do
   g <- view tsGalley

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -72,6 +72,7 @@ import Gundeck.Types.Notification
   )
 import Imports
 import qualified Network.Wai.Test as WaiTest
+import System.Random
 import qualified Test.QuickCheck as Q
 import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import qualified Test.Tasty.Cannon as WS
@@ -125,14 +126,36 @@ getTeams u = do
   return $ responseJsonUnsafe r
 
 createBindingTeamWithNMembers :: Int -> TestM (UserId, TeamId, [UserId])
-createBindingTeamWithNMembers n = do
+createBindingTeamWithNMembers = createBindingTeamWithNMembersWithHandles False
+
+createBindingTeamWithNMembersWithHandles :: Bool -> Int -> TestM (UserId, TeamId, [UserId])
+createBindingTeamWithNMembersWithHandles withHandles n = do
   (owner, tid) <- createBindingTeam
+  setHandle owner
   mems <- replicateM n $ do
     member1 <- randomUser
     addTeamMemberInternal tid $ newTeamMember member1 (rolePermissions RoleMember) Nothing
+    setHandle member1
     pure member1
   SQS.ensureQueueEmpty
   pure (owner, tid, mems)
+  where
+    mkRandomHandle :: MonadIO m => m Text
+    mkRandomHandle = liftIO $ do
+      nrs <- replicateM 21 (randomRIO (97, 122)) -- a-z
+      return (cs (map chr nrs))
+
+    setHandle :: UserId -> TestM ()
+    setHandle uid = when withHandles $ do
+      b <- view tsBrig
+      randomHandle <- mkRandomHandle
+      put
+        ( b
+            . paths ["/i/users", toByteString' uid, "handle"]
+            . json (HandleUpdate randomHandle)
+        )
+        !!! do
+          const 200 === statusCode
 
 -- | FUTUREWORK: this is dead code (see 'NonBindingNewTeam').  remove!
 createNonBindingTeam :: HasCallStack => Text -> UserId -> [TeamMember] -> TestM TeamId
@@ -1444,17 +1467,23 @@ deleteTeamMember g tid owner deletee =
     !!! do
       const 202 === statusCode
 
+getUsersByUid :: [UserId] -> TestM [User]
+getUsersByUid = getUsersBy "ids"
+
 getUsersByHandle :: [Handle.Handle] -> TestM [User]
-getUsersByHandle handles = do
+getUsersByHandle = getUsersBy "handles"
+
+getUsersBy :: (ToByteString uidsOrHandles) => ByteString -> [uidsOrHandles] -> TestM [User]
+getUsersBy searchKey uidsOrHandles = do
   brig <- view tsBrig
   res <-
     get
       ( brig
           . path "/i/users"
-          . queryItem "handles" users
+          . queryItem searchKey users
           . expect2xx
       )
   let accounts = fromJust $ responseJsonMaybe @[UserAccount] res
   return $ fmap accountUser accounts
   where
-    users = BS.intercalate "," $ toByteString' <$> handles
+    users = BS.intercalate "," $ toByteString' <$> uidsOrHandles

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -203,7 +203,7 @@ getTeamMembers usr tid = do
 getTeamMembersCsv :: HasCallStack => UserId -> TeamId -> TestM ResponseLBS
 getTeamMembersCsv usr tid = do
   g <- view tsGalley
-  get (g . accept "text/csv" . paths ["teams", toByteString' tid, "members"] . zUser usr) <!! do
+  get (g . accept "text/csv" . paths ["teams", toByteString' tid, "members/csv"] . zUser usr) <!! do
     const 200 === statusCode
     const (Just "chunked") === lookup "Transfer-Encoding" . responseHeaders
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -37,6 +37,7 @@ import qualified Data.ByteString.Char8 as C
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Currency as Currency
+import qualified Data.Handle as Handle
 import qualified Data.HashMap.Strict as HashMap
 import Data.Id
 import Data.List1 as List1
@@ -1443,17 +1444,17 @@ deleteTeamMember g tid owner deletee =
     !!! do
       const 202 === statusCode
 
-getUsers :: [UserId] -> TestM [User]
-getUsers uids = do
+getUsersByHandle :: [Handle.Handle] -> TestM [User]
+getUsersByHandle handles = do
   brig <- view tsBrig
   res <-
     get
       ( brig
           . path "/i/users"
-          . queryItem "ids" users
+          . queryItem "handles" users
           . expect2xx
       )
   let accounts = fromJust $ responseJsonMaybe @[UserAccount] res
   return $ fmap accountUser accounts
   where
-    users = BS.intercalate "," $ toByteString' <$> uids
+    users = BS.intercalate "," $ toByteString' <$> handles


### PR DESCRIPTION
This PR extends the existing `/teams/:tid/members` so that it if it is requested with `Accept: text/csv` it will respond with a csv file. For details see https://wearezeta.atlassian.net/browse/SQSERVICES-107