### PR TITLE
Cleanup noise from #1351

### DIFF
--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -297,6 +297,9 @@ nginx_conf:
     - path: ~* ^/teams/([^/]*)/conversations(.*)
       envs:
       - all
+    - path: ~* ^/teams/([^/]*)/members/csv$
+      envs:
+      - all
     - path: ~* ^/teams/([^/]*)/legalhold(.*)
       envs:
       - all

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -332,6 +332,9 @@ nginx_conf:
       - staging
       disable_zauth: true
       basic_auth: true
+    - path: ~* ^/teams/([^/]*)/size$
+      envs:
+      - all
     gundeck:
     - path: /push
       envs:

--- a/deploy/services-demo/conf/nginz/nginx-docker.conf
+++ b/deploy/services-demo/conf/nginz/nginx-docker.conf
@@ -208,6 +208,11 @@ http {
       proxy_pass http://brig;
     }
 
+    location ~* ^/teams/([^/]*)/size$ {
+      include common_response_with_zauth.conf;
+      proxy_pass http://brig;
+    }
+
     # Cargohold Endpoints
 
     rewrite ^/api-docs/assets  /assets/api-docs?base_url=http://127.0.0.1:8080/ break;

--- a/deploy/services-demo/conf/nginz/nginx-docker.conf
+++ b/deploy/services-demo/conf/nginz/nginx-docker.conf
@@ -298,6 +298,11 @@ http {
       proxy_pass http://galley;
     }
 
+    location ~* ^/teams/([^/]*)/members/csv$ {
+      include common_response_with_zauth.conf;
+      proxy_pass http://galley;
+    }
+
     # Gundeck Endpoints
 
     rewrite ^/api-docs/push  /push/api-docs?base_url=http://127.0.0.1:8080/ break;

--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -315,6 +315,11 @@ http {
       proxy_pass http://galley;
     }
 
+    location ~* ^/teams/([^/]*)/members/csv$ {
+      include common_response_with_zauth.conf;
+      proxy_pass http://galley;
+    }
+
     # Gundeck Endpoints
 
     rewrite ^/api-docs/push  /push/api-docs?base_url=http://127.0.0.1:8080/ break;

--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -220,6 +220,11 @@ http {
       proxy_pass http://brig;
     }
 
+    location ~* ^/teams/([^/]*)/size$ {
+        include common_response_with_zauth.conf;
+        proxy_pass http://brig;
+    }
+
     # Cargohold Endpoints
 
     rewrite ^/api-docs/assets  /assets/api-docs?base_url=http://127.0.0.1:8080/ break;

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -173,6 +173,8 @@ routesPublic = do
       "Returns the number of team members as an integer.  \
       \Can be out of sync by roughly the `refresh_interval` \
       \of the ES index."
+    Doc.parameter Doc.Path "tid" Doc.bytes' $
+      Doc.description "Team ID"
     Doc.returns (Doc.ref Public.modelTeamSize)
     Doc.response 200 "Invitation successful." Doc.end
     Doc.response 403 "No permission (not admin or owner of this team)." Doc.end

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -178,6 +178,12 @@ sitemap = do
     zauthUserId
       .&. capture "tid"
       .&. accept "text" "csv"
+  document "GET" "getTeamMembersCSV" $ do
+    summary "Get all members of the team as a CSV file"
+    parameter Path "tid" bytes' $
+      description "Team ID"
+    response 200 "Team members CSV file" end
+    errorResponse Error.accessDenied
 
   post "/teams/:tid/get-members-by-ids-using-post" (continue Teams.bulkGetTeamMembersH) $
     zauthUserId

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -239,7 +239,6 @@ testListTeamMembersCsv numMembers = do
   let teamSize = numMembers + 1
 
   (owner, tid, _mbs) <- Util.createBindingTeamWithNMembersWithHandles True numMembers
-  liftIO $ writeFile "/tmp/csv-test" (show (owner, tid))
   resp <- Util.getTeamMembersCsv owner tid
   let rbody = fromMaybe (error "no body") . responseBody $ resp
   usersInCsv <- either (error "could not decode csv") pure (decodeCSV @TeamExportUser rbody)
@@ -247,21 +246,6 @@ testListTeamMembersCsv numMembers = do
     assertEqual "total number of team members" teamSize (length usersInCsv)
     assertEqual "owners in team" 1 (countOn tExportRole (Just RoleOwner) usersInCsv)
     assertEqual "members in team" numMembers (countOn tExportRole (Just RoleMember) usersInCsv)
-
-  {-
-   1000: OK (73.74s)
-   2000: OK (145.92s)
-   3000: _
-   3000 (only pull csv, not create members): _
-   10000:
-  -}
-
-  -- fuck it, we should really use the library.
-
-  -- then create a team with 10k members (100k?), and drop the team id.  then tweak this test
-  -- to pull all members for that team id and take the time (and ram) for just doing that.
-
-  -- https://stackoverflow.com/questions/8362428/stream-response-from-curl-request-without-waiting-for-it-to-finish#36368249
 
   do
     let someUsersInCsv = take 50 usersInCsv


### PR DESCRIPTION
see https://github.com/wireapp/wire-server/pull/1351

I really didn't mean for this to get committed, apologies for my language.

This PR:
- removes some leftovers from #1351 
- adds routes + swagger docs + headers for csv endpoint  (#1351)
- adds routes for team size endpoint (#1295)


