### PR TITLE
Update kubernetes migration path and documentation

### DIFF
--- a/charts/elasticsearch-index/templates/create-index.yaml
+++ b/charts/elasticsearch-index/templates/create-index.yaml
@@ -37,6 +37,7 @@ spec:
             - --elasticsearch-shards=5
             - --elasticsearch-replicas=2
             - --elasticsearch-refresh-interval=5
+            - --delete-template directory
       containers:
         - name: brig-index-update-mapping
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/docs/reference/elasticsearch-migration-2021-02-15.md
+++ b/docs/reference/elasticsearch-migration-2021-02-15.md
@@ -2,7 +2,7 @@
 
 Release `2021-02-15` of `wire-server` requires creating a new ElasticSearch index for `brig` _before_ deploying the release. Without this new index the user search in TeamSettings will be defunct.
 
-The index that brig is using, is defined at brig's config at `elasticsearch.index`. This config value of the previous deployment is referred to as `<OLD_INDEX>` in the following.
+The index that brig is using, is defined in the `brig` chart's config at `elasticsearch.index`. This config value of the previous deployment is referred to as `<OLD_INDEX>` in the following.
 
 These following instructions describe how to:
 
@@ -13,7 +13,7 @@ These following instructions describe how to:
 Note: The following steps require downtime of brig. If downtime is not acceptable then please skip to section [Create the new index without downtime](#create-the-new-index-without-downtime)
 
 1. Update config for the `elasticsearch-index` chart:
-    - Set `elasticsearch-index` to `<NEW_INDEX>`
+    - Set `elasticsearch.index` to `<NEW_INDEX>`
 2. Update config for the `brig` chart:
     - Set `config.elasticsearch.directory` to `<NEW_INDEX>`
 3. Redeploy `wire-server`.
@@ -54,8 +54,9 @@ docker run "quay.io/wire/brig-index:$WIRE_VERSION" create \
 ```
 
 The `--delete-template` option will delete the index template named `directory` if it exists.
-This index template might have been created by previous releases and can cause creating
-new index to fail. If this template doesn't exist you can omit the `--delete-template` option.
+This index template might have been created by previous releases and can cause creating a
+new index to fail. If this template doesn't exist in your ES cluster you can omit the
+`--delete-template` option.
 
 2. Redeploy brig with `elasticsearch.additionalWriteIndex` set to `<NEW_INDEX>`.
 3. Make sure no old instances of brig are running.

--- a/docs/reference/elasticsearch-migration-2021-02-15.md
+++ b/docs/reference/elasticsearch-migration-2021-02-15.md
@@ -10,6 +10,21 @@ These following instructions describe how to:
 2. Populate `<NEW_INDEX>` with brig's data.
 3. Configure brig to use the new index.
 
+Note: The following steps require downtime of brig. If downtime is not acceptable then please skip to section [Create the new index without downtime](#create-the-new-index-without-downtime)
+
+1. Update config for the `elasticsearch-index` chart:
+    - Set `elasticsearch-index` to `<NEW_INDEX>`
+2. Update config for the `brig` chart:
+    - Set `config.elasticsearch.directory` to `<NEW_INDEX>`
+3. Redeploy `wire-server`.
+   The `elasticsearch-index` chart will automatically create and populate `<NEW_INDEX>`
+   before all other services are started. This might take several minutes depending on the
+   number of users.
+   
+You can delete `<OLD_INDEX>` index from ES now.
+
+## Create the new index without downtime
+
 In the following we assume the following env vars are set.
 
 ```bash
@@ -26,46 +41,6 @@ REPLICAS=<NUMBER_OF_REPLICAS_FOR_THE_INDEX> # 2 if you are unsure
 REFRESH_INTERVAL=<REFRESH_INTERVAL_IN_SECONDS> # 5 if you are unsure
 ```
 
-Delete the `directory` index template if it exists:
-
-```bash
-curl -XDELETE http://$ES_HOST:$ES_HOST/_template/directory
-```
-
-The next steps require downtime of brig. If downtime is not acceptable please skip to section [Create the new index without downtime](#create-the-new-index-without-downtime)
-
-1. Shut down the `brig` service.
-2. Create the new index by running
-```sh
-docker run "quay.io/wire/brig-index:$WIRE_VERSION" create \
-    --elasticsearch-server "http://$ES_HOST:$ES_PORT" \
-    --elasticsearch-index "$NEW_INDEX" \
-    --elastcsearch-shards "$SHARDS" \
-    --elastcsearch-replicas "$REPLICAS" \
-    --elastcsearch-refresh-interval "$REFRESH_INTERVAL"
-```
-
-3. Populate the new index by running
-```sh
-docker run "quay.io/wire/brig-index:$WIRE_VERSION" migrate-data \
-  --elasticsearch-server "http://$ES_HOST:$ES_PORT" \
-  --elasticsearch-index "$NEW_INDEX" \
-  --cassandra-host "$BRIG_CASSANDRA_HOST" \
-  --cassandra-port "$BRIG_CASSANDRA_PORT" \
-  --cassandra-keyspace "$BRIG_CASSANDRA_KEYSPACE"
-```
-This may take sevaral minutes depending on number of users.
-
-4. Configure brig to use the new index, by setting `elasticsearch.index` to `<NEW_INDEX>` and deploy of `brig` with new version "$WIRE_VERSION".
-5. Check that team member search in TeamSettings and user search in the app works.
-6. Delete the old index
-```
-```bash
-curl -XDELETE http://$ES_HOST:$ES_HOST/$OLD_INDEX
-```
-
-## Create the new index without downtime
-
 1. Create the new index by running
 
 ```sh
@@ -75,7 +50,12 @@ docker run "quay.io/wire/brig-index:$WIRE_VERSION" create \
     --elastcsearch-shards "$SHARDS" \
     --elastcsearch-replicas "$REPLICAS" \
     --elastcsearch-refresh-interval "$REFRESH_INTERVAL"
+    --delete-template "directory"
 ```
+
+The `--delete-template` option will delete the index template named `directory` if it exists.
+This index template might have been created by previous releases and can cause creating
+new index to fail. If this template doesn't exist you can omit the `--delete-template` option.
 
 2. Redeploy brig with `elasticsearch.additionalWriteIndex` set to `<NEW_INDEX>`.
 3. Make sure no old instances of brig are running.
@@ -93,12 +73,13 @@ This may take sevaral minutes depending on number of users.
 5. Redeploy brig with these config updates:
     - unset `elasticsearch.additionalWriteIndex`
     - set `elasticsearch.index` to `<NEW_INDEX>`
-6. Check that team member search in TeamSettings and user search in the app works.
-7. Delete the old index
 
-```bash
-curl -XDELETE http://$ES_HOST:$ES_HOST/$OLD_INDEX
-```
+6. Update config for the `elasticsearch-index` chart:
+    - Set `elasticsearch-index` to `<NEW_INDEX>`
+   This prevents the `elasticsearch-index` from automatically recreating the `<OLD_INDEX>`
+   when `wire-server`is deployed.
+
+You can delete `<OLD_INDEX>` index from ES now.
 
 ## Troubleshooting
 


### PR DESCRIPTION
This PR simplifies the the ES migration path introduced in #1360.
The migration instructions have been updated accordingly.

This PR requires #1339 to merged first.