### PR TITLE
charts: Use tagged container images and update kubectl contaienr image

### DIFF
--- a/charts/cannon/templates/statefulset.yaml
+++ b/charts/cannon/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
       initContainers:
       - name: cannon-configurator
-        image: alpine
+        image: alpine:3.13.1
         command:
         - /bin/sh
         args:

--- a/charts/demo-smtp/values.yaml
+++ b/charts/demo-smtp/values.yaml
@@ -1,6 +1,6 @@
 fullnameOverride: demo-smtp
 replicaCount: 1
-image: "namshi/smtp@sha256:aa63b8de68ce63dfcf848c56f3c1a16d81354f4accd4242a0086c57dd5a91d77"
+image: "quay.io/wire/namshi-smtp:aa63b8"
 
 service:
   port: 25

--- a/charts/reaper/templates/deployment.yaml
+++ b/charts/reaper/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - name: reaper
         imagePullPolicy: Always
-        image: roffe/kubectl:v1.13.2
+        image: bitnami/kubectl:1.19.7
         command: ["bash"]
         args:
         - -c


### PR DESCRIPTION
This is needed for the wire offline package; as it doesn't support untagged container images.