### PR TITLE
Makefile: Default to setting up and testing federation in K8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,8 +251,8 @@ kube-integration-setup: charts-integration
 	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-setup-federation.sh
 
 .PHONY: kube-integration-test
-kube-integration-test: kube-integration-test-sans-federation
-	cd services/brig && ./federation-tests.sh $(NAMESPACE)
+kube-integration-test:
+	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-test.sh
 
 .PHONY: kube-integration-teardown
 kube-integration-teardown:
@@ -263,10 +263,6 @@ kube-integration-setup-sans-federation: guard-tag charts-integration
 	# by default "test-<your computer username> is used as namespace
 	# you can override the default by setting the NAMESPACE environment variable
 	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-setup.sh
-
-.PHONY: kube-integration-test-sans-federation
-kube-integration-test-sans-federation:
-	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-test.sh
 
 .PHONY: kube-integration-teardown-sans-federation
 kube-integration-teardown-sans-federation:

--- a/Makefile
+++ b/Makefile
@@ -244,29 +244,33 @@ hie.yaml:
 #   - kubectl
 #   - a valid kubectl context configured (i.e. access to a kubernetes cluster)
 .PHONY: kube-integration
-kube-integration: guard-tag charts-integration
-	# by default "test-<your computer username> is used as namespace
-	# you can override the default by setting the NAMESPACE environment variable
-	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-setup.sh
-	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-test.sh
+kube-integration:  kube-integration-setup kube-integration-test
 
 .PHONY: kube-integration-setup
-kube-integration-setup: guard-tag charts-integration
-	# by default "test-<your computer username> is used as namespace
-	# you can override the default by setting the NAMESPACE environment variable
-	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-setup.sh
+kube-integration-setup: charts-integration
+	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-setup-federation.sh
+
+.PHONY: kube-integration-test
+kube-integration-test: kube-integration-test-sans-federation
+	cd services/brig && ./federation-tests.sh $(NAMESPACE)
 
 .PHONY: kube-integration-teardown
 kube-integration-teardown:
+	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-teardown-federation.sh
+
+.PHONY: kube-integration-setup-sans-federation
+kube-integration-setup-sans-federation: guard-tag charts-integration
+	# by default "test-<your computer username> is used as namespace
+	# you can override the default by setting the NAMESPACE environment variable
+	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-setup.sh
+
+.PHONY: kube-integration-test-sans-federation
+kube-integration-test-sans-federation:
+	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-test.sh
+
+.PHONY: kube-integration-teardown-sans-federation
+kube-integration-teardown-sans-federation:
 	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-teardown.sh
-
-.PHONY: kube-integration-setup-federation
-kube-integration-setup-federation: charts-integration
-	export NAMESPACE=$(NAMESPACE); ./hack/bin/integration-setup-federation.sh
-
-.PHONY: kube-integration-federation
-kube-integration-federation:
-	cd services/brig && ./federation-tests.sh $(NAMESPACE)
 
 .PHONY: kube-restart-%
 kube-restart-%:

--- a/charts/brig/templates/tests/brig-integration.yaml
+++ b/charts/brig/templates/tests/brig-integration.yaml
@@ -80,3 +80,73 @@ spec:
     - name: AWS_REGION
       value: "eu-west-1"
   restartPolicy: Never
+
+{{- if .Values.tests.enableFederationTests }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-brig-integration-federation"
+  annotations:
+    "helm.sh/hook": test-success
+  labels:
+    wireService: brig-integration
+    release: {{ .Release.Name }}
+spec:
+  volumes:
+    - name: "brig-integration"
+      configMap:
+        name: "brig-integration"
+    # Needed in order to read some values from the brig service
+    - name: "brig-config"
+      configMap:
+        name: "brig"
+    - name: "brig-secrets"
+      secret:
+        secretName: "brig"
+    - name: "turn-servers"
+      configMap:
+        name: "turn"
+    - name: "brig-integration-secrets"
+      configMap:
+        name: "brig-integration-secrets"
+  containers:
+  - name: integration
+    image: "{{ .Values.image.repository }}-integration:{{ .Values.image.tag }}"
+    # TODO: Add TURN tests once we have an actual way to test it
+    # The brig-integration tests mutate the turn settings files before tests
+    # to get certain behaviour. This doesn't work on kubernetes because brig
+    # is a different pod than brig-integration and they can't both mouht the
+    # same file-system.
+    # The other test, "user.auth.cookies.limit", is skipped as it is flaky.
+    # This is tracked in https://github.com/zinfra/backend-issues/issues/1150.
+    command: ["brig-integration", "--pattern", "brig-federation"]
+    volumeMounts:
+    - name: "brig-integration"
+      mountPath: "/etc/wire/integration"
+    - name: "brig-config"
+      mountPath: "/etc/wire/brig/conf"
+    - name: "brig-secrets"
+      mountPath: "/etc/wire/brig/secrets"
+    - name: "turn-servers"
+      mountPath: "/etc/wire/brig/turn"
+    - name: "brig-integration-secrets"
+      # TODO: Maybe we should put integration yaml also under
+      #       `/integration/conf` by default? Note that currently
+      #       brig-integration cannot read config files from
+      #       non-default locations
+      #       (see corresp. TODO in galley.)
+      mountPath: "/etc/wire/integration-secrets"
+
+    env:
+    # these dummy values are necessary for Amazonka's "Discover"
+    - name: AWS_ACCESS_KEY_ID
+      value: "dummy"
+    - name: AWS_SECRET_ACCESS_KEY
+      value: "dummy"
+    - name: AWS_REGION
+      value: "eu-west-1"
+    - name: INTEGRATION_FEDERATION_TESTS
+      value: "1"
+  restartPolicy: Never
+{{- end }}

--- a/charts/brig/templates/tests/brig-integration.yaml
+++ b/charts/brig/templates/tests/brig-integration.yaml
@@ -53,7 +53,7 @@ spec:
     # same file-system.
     # The other test, "user.auth.cookies.limit", is skipped as it is flaky.
     # This is tracked in https://github.com/zinfra/backend-issues/issues/1150.
-    command: ["brig-integration", "--pattern", "!/turn/ && !/user.auth.cookies.limit/ && !/brig-federation/"]
+    command: [ "brig-integration", "--pattern", "!/turn/ && !/user.auth.cookies.limit/" ]
     volumeMounts:
     - name: "brig-integration"
       mountPath: "/etc/wire/integration"
@@ -79,74 +79,8 @@ spec:
       value: "dummy"
     - name: AWS_REGION
       value: "eu-west-1"
-  restartPolicy: Never
-
-{{- if .Values.tests.enableFederationTests }}
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ .Release.Name }}-brig-integration-federation"
-  annotations:
-    "helm.sh/hook": test-success
-  labels:
-    wireService: brig-integration
-    release: {{ .Release.Name }}
-spec:
-  volumes:
-    - name: "brig-integration"
-      configMap:
-        name: "brig-integration"
-    # Needed in order to read some values from the brig service
-    - name: "brig-config"
-      configMap:
-        name: "brig"
-    - name: "brig-secrets"
-      secret:
-        secretName: "brig"
-    - name: "turn-servers"
-      configMap:
-        name: "turn"
-    - name: "brig-integration-secrets"
-      configMap:
-        name: "brig-integration-secrets"
-  containers:
-  - name: integration
-    image: "{{ .Values.image.repository }}-integration:{{ .Values.image.tag }}"
-    # TODO: Add TURN tests once we have an actual way to test it
-    # The brig-integration tests mutate the turn settings files before tests
-    # to get certain behaviour. This doesn't work on kubernetes because brig
-    # is a different pod than brig-integration and they can't both mouht the
-    # same file-system.
-    # The other test, "user.auth.cookies.limit", is skipped as it is flaky.
-    # This is tracked in https://github.com/zinfra/backend-issues/issues/1150.
-    command: ["brig-integration", "--pattern", "brig-federation"]
-    volumeMounts:
-    - name: "brig-integration"
-      mountPath: "/etc/wire/integration"
-    - name: "brig-config"
-      mountPath: "/etc/wire/brig/conf"
-    - name: "brig-secrets"
-      mountPath: "/etc/wire/brig/secrets"
-    - name: "turn-servers"
-      mountPath: "/etc/wire/brig/turn"
-    - name: "brig-integration-secrets"
-      # TODO: Maybe we should put integration yaml also under
-      #       `/integration/conf` by default? Note that currently
-      #       brig-integration cannot read config files from
-      #       non-default locations
-      #       (see corresp. TODO in galley.)
-      mountPath: "/etc/wire/integration-secrets"
-
-    env:
-    # these dummy values are necessary for Amazonka's "Discover"
-    - name: AWS_ACCESS_KEY_ID
-      value: "dummy"
-    - name: AWS_SECRET_ACCESS_KEY
-      value: "dummy"
-    - name: AWS_REGION
-      value: "eu-west-1"
+    {{- if .Values.tests.enableFederationTests }}
     - name: INTEGRATION_FEDERATION_TESTS
       value: "1"
+    {{- end }}
   restartPolicy: Never
-{{- end }}

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -87,3 +87,5 @@ turnStatic:
   v2:
   - turn:localhost:3478
   - turn:localhost:3478?transport=tcp
+tests:
+  enableFederationTests: false

--- a/charts/federator/templates/configmap.yaml
+++ b/charts/federator/templates/configmap.yaml
@@ -34,9 +34,7 @@ data:
     logFormat: {{ .logFormat }}
     logLevel: {{ .logLevel }}
 
-    {{- end }}
-
-    {{- with .Values.optSettings }}
+    {{- with .optSettings }}
     optSettings:
       setFederationStrategy:
         {{- if .setFederationStrategy.allowAll }}
@@ -51,4 +49,5 @@ data:
         # list, we assume empty list when there is no list
         allowedDomains: []
         {{- end}}
+    {{- end }}
     {{- end }}

--- a/charts/federator/templates/configmap.yaml
+++ b/charts/federator/templates/configmap.yaml
@@ -34,8 +34,9 @@ data:
     logFormat: {{ .logFormat }}
     logLevel: {{ .logLevel }}
 
+    {{- end }}
 
-    {{- with .optSettings }}
+    {{- with .Values.optSettings }}
     optSettings:
       setFederationStrategy:
         {{- if .setFederationStrategy.allowAll }}
@@ -51,4 +52,3 @@ data:
         allowedDomains: []
         {{- end}}
     {{- end }}
-  {{- end }}

--- a/hack/bin/integration-teardown-federation.sh
+++ b/hack/bin/integration-teardown-federation.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
 
-USAGE="Usage: $0"
-
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-TOP_LEVEL="$DIR/../.."
 
 export NAMESPACE=${NAMESPACE:-test-integration}
 
-$DIR/integration-setup.sh
+$DIR/integration-teardown.sh
 
 # The suffix '-fed2' must be kept in sync with configuration inside
 # charts/brig/templates/tests/configmap.yaml and
-# hack/bin/integration-teardown-federation.sh
+# hack/bin/integration-setup-federation.sh
 export NAMESPACE=${NAMESPACE}-fed2
 
-$DIR/integration-setup.sh
+$DIR/integration-teardown.sh

--- a/hack/helm_vars/wire-server/values.yaml
+++ b/hack/helm_vars/wire-server/values.yaml
@@ -101,6 +101,8 @@ brig:
       key: "dummy"
       secret: "dummy"
     smtpPassword: dummy-smtp-password
+  tests:
+    enableFederationTests: true
 cannon:
   replicaCount: 2
   imagePullPolicy: Always

--- a/hack/helm_vars/wire-server/values.yaml
+++ b/hack/helm_vars/wire-server/values.yaml
@@ -237,3 +237,6 @@ spar:
 federator:
   replicaCount: 1
   imagePullPolicy: Always
+  optSettings:
+    setFederationStrategy:
+      allowAll: true

--- a/hack/helm_vars/wire-server/values.yaml
+++ b/hack/helm_vars/wire-server/values.yaml
@@ -237,6 +237,7 @@ spar:
 federator:
   replicaCount: 1
   imagePullPolicy: Always
-  optSettings:
-    setFederationStrategy:
-      allowAll: true
+  config:
+    optSettings:
+      setFederationStrategy:
+        allowAll: true


### PR DESCRIPTION
Keep old targets with suffix '-sans-federation' in case anyone needs them.