### PR TITLE
Pin kubectl image in sftd chart

### DIFF
--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: get-external-ip
-          image: bitnami/kubectl
+          image: bitnami/kubectl:1.19.7
           volumeMounts:
             - name: external-ip
               mountPath: /external-ip


### PR DESCRIPTION
I somehow missed this. It's needed for the offline deliverable

Can I somehow get this into master without making a release though?