### PR TITLE
Add migrate-external-ids tool

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -45,6 +45,7 @@ packages:
 - tools/db/find-undead
 - tools/db/move-team
 - tools/db/repair-handles
+- tools/db/migrate-external-ids
 - tools/makedeb
 - tools/rex
 - tools/stern

--- a/tools/db/migrate-external-ids/Makefile
+++ b/tools/db/migrate-external-ids/Makefile
@@ -1,0 +1,27 @@
+LANG := en_US.UTF-8
+
+SHELL := /usr/bin/env bash
+
+default: all
+
+all: install
+
+.PHONY: init
+init:
+	mkdir -p dist
+
+.PHONY: clean
+clean:
+	stack clean
+
+.PHONY: compile
+compile:
+	stack build
+
+.PHONY: install
+install: init
+	stack install --pedantic --local-bin-path=dist
+
+.PHONY: fast
+fast: init
+	stack install --fast --local-bin-path=dist

--- a/tools/db/migrate-external-ids/README.md
+++ b/tools/db/migrate-external-ids/README.md
@@ -1,0 +1,1 @@
+This tool fills entries in the table `spar.scim_external` (introduced in release [2021-02-16](https://github.com/wireapp/wire-server/releases/tag/v2021-02-16)) from table `spar.scim_external_ids` and `brig.user`. It is meant to be used in the migration from `spar.scim_external_ids` to `spar.scim_external`.

--- a/tools/db/migrate-external-ids/README.md
+++ b/tools/db/migrate-external-ids/README.md
@@ -1,1 +1,3 @@
 This tool fills entries in the table `spar.scim_external` (introduced in release [2021-02-16](https://github.com/wireapp/wire-server/releases/tag/v2021-02-16)) from table `spar.scim_external_ids` and `brig.user`. It is meant to be used in the migration from `spar.scim_external_ids` to `spar.scim_external`.
+
+Next steps after this migration: spar will stop using `spar.scim_external_ids` once `spar.scim_external` is fully populated.  After that, `spar.scim_external_ids` can be removed.

--- a/tools/db/migrate-external-ids/migrate-external-ids.cabal
+++ b/tools/db/migrate-external-ids/migrate-external-ids.cabal
@@ -1,0 +1,84 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: a2ee5cfae0c9a0b1391da88f47fff1d23787bb3d3aa6b74ed3debed373032c2f
+
+name:           migrate-external-ids
+version:        1.0.0
+synopsis:       Migrate from spar.scim_external_ids to spar.scim_external
+category:       Network
+author:         Wire Swiss GmbH
+maintainer:     Wire Swiss GmbH <backend@wire.com>
+copyright:      (c) 2020 Wire Swiss GmbH
+license:        AGPL-3
+build-type:     Simple
+
+library
+  exposed-modules:
+      Main
+      Options
+      Work
+  other-modules:
+      Paths_migrate_external_ids
+  hs-source-dirs:
+      src
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns RecordWildCards
+  ghc-options: -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T -rtsopts
+  build-depends:
+      attoparsec
+    , base
+    , bytestring
+    , bytestring-conversion
+    , cassandra-util
+    , conduit
+    , containers
+    , cql
+    , extended
+    , imports
+    , lens
+    , mtl
+    , optparse-applicative
+    , text
+    , time
+    , tinylog
+    , types-common
+    , unliftio
+    , uuid
+    , wire-api
+  default-language: Haskell2010
+
+executable migrate-external-ids
+  main-is: Main.hs
+  other-modules:
+      Options
+      Work
+      Paths_migrate_external_ids
+  hs-source-dirs:
+      src
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns RecordWildCards
+  ghc-options: -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T -rtsopts
+  build-depends:
+      attoparsec
+    , base
+    , bytestring
+    , bytestring-conversion
+    , cassandra-util
+    , conduit
+    , containers
+    , cql
+    , extended
+    , imports
+    , lens
+    , mtl
+    , optparse-applicative
+    , text
+    , time
+    , tinylog
+    , types-common
+    , unliftio
+    , uuid
+    , wire-api
+  default-language: Haskell2010

--- a/tools/db/migrate-external-ids/package.yaml
+++ b/tools/db/migrate-external-ids/package.yaml
@@ -1,0 +1,51 @@
+defaults:
+  local: ../../../package-defaults.yaml
+name: migrate-external-ids
+version: '1.0.0'
+synopsis: Migrate from spar.scim_external_ids to spar.scim_external
+category: Network
+author: Wire Swiss GmbH
+maintainer: Wire Swiss GmbH <backend@wire.com>
+copyright: (c) 2020 Wire Swiss GmbH
+license: AGPL-3
+ghc-options:
+- -funbox-strict-fields
+- -threaded
+- -with-rtsopts=-N
+- -with-rtsopts=-T
+- -rtsopts
+
+dependencies:
+- attoparsec
+- base
+- bytestring
+- bytestring-conversion
+- cassandra-util
+- conduit
+- containers
+- cql
+- extended
+- imports
+- lens
+- mtl
+- optparse-applicative
+- text
+- time
+- tinylog
+- types-common
+- unliftio
+- uuid
+- wire-api
+
+library:
+  source-dirs: src
+  default-extensions:
+    - RecordWildCards
+
+executables:
+  migrate-external-ids:
+    main: Main.hs
+    source-dirs: src
+
+    default-extensions:
+      - RecordWildCards

--- a/tools/db/migrate-external-ids/src/Main.hs
+++ b/tools/db/migrate-external-ids/src/Main.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Main
+  ( main,
+  )
+where
+
+import Imports
+import qualified Work
+
+main :: IO ()
+main = Work.main

--- a/tools/db/migrate-external-ids/src/Options.hs
+++ b/tools/db/migrate-external-ids/src/Options.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Options
+  ( setCasSpar,
+    setCasBrig,
+    setDebug,
+    setDryRun,
+    setPageSize,
+    cHosts,
+    cPort,
+    cKeyspace,
+    settingsParser,
+    Debug (..),
+    DryRun (..),
+  )
+where
+
+import qualified Cassandra as C
+import Control.Lens
+import Data.Text.Strict.Lens
+import Imports
+import Options.Applicative
+
+data MigratorSettings = MigratorSettings
+  { _setCasSpar :: !CassandraSettings,
+    _setCasBrig :: !CassandraSettings,
+    _setDebug :: Debug,
+    _setDryRun :: DryRun,
+    _setPageSize :: Int32
+  }
+  deriving (Show)
+
+data CassandraSettings = CassandraSettings
+  { _cHosts :: !String,
+    _cPort :: !Word16,
+    _cKeyspace :: !C.Keyspace
+  }
+  deriving (Show)
+
+data Debug = Debug | NoDebug
+  deriving (Show)
+
+data DryRun = DryRun | NoDryRun
+  deriving (Show)
+
+makeLenses ''MigratorSettings
+
+makeLenses ''CassandraSettings
+
+settingsParser :: Parser MigratorSettings
+settingsParser =
+  MigratorSettings
+    <$> cassandraSettingsParser "spar"
+    <*> cassandraSettingsParser "brig"
+    <*> flag NoDebug Debug (long "debug")
+    <*> flag NoDryRun DryRun (long "dry-run" <> short 'n')
+    <*> option auto (long "page-size" <> short 'p' <> value 1000)
+
+cassandraSettingsParser :: String -> Parser CassandraSettings
+cassandraSettingsParser ks =
+  CassandraSettings
+    <$> strOption
+      ( long ("cassandra-host-" ++ ks)
+          <> metavar "HOST"
+          <> help ("Cassandra Host for: " ++ ks)
+          <> value "localhost"
+          <> showDefault
+      )
+    <*> option
+      auto
+      ( long ("cassandra-port-" ++ ks)
+          <> metavar "PORT"
+          <> help ("Cassandra Port for: " ++ ks)
+          <> value 9042
+          <> showDefault
+      )
+    <*> ( C.Keyspace . view packed
+            <$> strOption
+              ( long ("cassandra-keyspace-" ++ ks)
+                  <> metavar "STRING"
+                  <> help ("Cassandra Keyspace for: " ++ ks)
+                  <> value (ks ++ "_test")
+                  <> showDefault
+              )
+        )

--- a/tools/db/migrate-external-ids/src/Work.hs
+++ b/tools/db/migrate-external-ids/src/Work.hs
@@ -95,7 +95,7 @@ runCommand env@Env {..} = do
 
   failCount <- readIORef envFailCount
   when (failCount > 0) $
-    Log.warn envLogger (Log.msg @String (show failCount <> " external ids have *NOT* been migrated.\nAn external id fails to me migrated if the mapped user doesn't exist or doesn't have a team."))
+    Log.warn envLogger (Log.msg @String (show failCount <> " external ids have *NOT* been migrated.\nAn external id fails to be migrated if the mapped user doesn't exist or doesn't have a team."))
 
 type LegacyExternalId = (Text, UserId)
 

--- a/tools/db/migrate-external-ids/src/Work.hs
+++ b/tools/db/migrate-external-ids/src/Work.hs
@@ -1,0 +1,159 @@
+{-# OPTIONS_GHC -Wno-orphans -Wno-unused-imports -Wno-name-shadowing #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Work where
+
+import Cassandra
+import qualified Cassandra as C
+import qualified Cassandra.Settings as C
+import Control.Lens
+import Data.Conduit
+import qualified Data.Conduit.Combinators as CC
+import Data.Conduit.Internal (zipSources)
+import qualified Data.Conduit.List as CL
+import Data.Functor.Identity
+import Data.Id
+import qualified Data.Map.Strict as Map
+import Data.Misc
+import Database.CQL.Protocol (Tuple)
+import Imports
+import Options
+import Options.Applicative
+import System.Logger (Logger)
+import qualified System.Logger as Log
+import UnliftIO.Async (pooledMapConcurrentlyN)
+import Wire.API.Team.Feature
+
+data Env = Env
+  { envBrig :: ClientState,
+    envSpar :: ClientState,
+    envLogger :: Logger,
+    envPageSize :: Int32,
+    envDebug :: Debug,
+    envDryDrun :: DryRun,
+    envFailCount :: IORef Int
+  }
+
+main :: IO ()
+main = do
+  s <- execParser (info (helper <*> settingsParser) desc)
+  lgr <- initLogger s
+  brig <- initCas (s ^. setCasBrig) lgr
+  spar <- initCas (s ^. setCasSpar) lgr
+  failCount <- newIORef 0
+  let env = Env brig spar lgr (s ^. setPageSize) (s ^. setDebug) (s ^. setDryRun) failCount
+  runCommand env
+  where
+    desc =
+      header "migrate-external-ids"
+        <> progDesc "Migrate from spar."
+        <> fullDesc
+    initLogger s =
+      Log.new
+        . Log.setOutput Log.StdOut
+        . Log.setFormat Nothing
+        . Log.setBufSize 0
+        . Log.setLogLevel
+          ( case s ^. setDebug of
+              Debug -> Log.Debug
+              _ -> Log.Warn
+          )
+        $ Log.defSettings
+    initCas cas l =
+      C.init
+        . C.setLogger (C.mkLogger l)
+        . C.setContacts (cas ^. cHosts) []
+        . C.setPortNumber (fromIntegral $ cas ^. cPort)
+        . C.setKeyspace (cas ^. cKeyspace)
+        . C.setProtocolVersion C.V4
+        $ C.defSettings
+
+runCommand :: Env -> IO ()
+runCommand env@Env {..} = do
+  runConduit $
+    zipSources
+      (CL.sourceList [(1 :: Int32) ..])
+      (readLegacyExternalIds env)
+      .| CC.mapM (resolveTeam env)
+      .| sinkMain env
+
+  failCount <- readIORef envFailCount
+  when (failCount > 0) $
+    Log.warn envLogger (Log.msg @String (show failCount <> " external ids have *NOT* been migrated.\nAn external id fails to me migrated if the mapped user doesn't exist or doesn't have a team."))
+
+type LegacyExternalId = (Text, UserId)
+
+type UserTeam = (UserId, Maybe TeamId)
+
+type NewExternalId = (TeamId, Text, UserId)
+
+data ResolveTeamResult
+  = UserHasNoTeam UserId Text
+  | NewExternalId NewExternalId
+
+readLegacyExternalIds :: Env -> ConduitM () [LegacyExternalId] IO ()
+readLegacyExternalIds Env {..} =
+  transPipe (runClient envSpar) $
+    paginateC select (paramsP Quorum () envPageSize) x5
+  where
+    select :: PrepQuery R () LegacyExternalId
+    select = "SELECT external, user FROM scim_external_ids"
+
+resolveTeam :: Env -> (Int32, [LegacyExternalId]) -> IO [ResolveTeamResult]
+resolveTeam env@Env {..} (page, exts) = do
+  Log.info envLogger (Log.msg @String ("Processing page " <> show page))
+  userToTeam <- Map.fromList <$> readUserTeam env (fmap snd exts)
+  pure $
+    exts <&> \(extid, uid) ->
+      case uid `Map.lookup` userToTeam of
+        Just (Just tid) -> NewExternalId (tid, extid, uid)
+        _ -> UserHasNoTeam uid extid
+  where
+    readUserTeam :: Env -> [UserId] -> IO [UserTeam]
+    readUserTeam Env {..} uids =
+      runClient envBrig $ do
+        query select (params Quorum (Identity uids))
+      where
+        select :: PrepQuery R (Identity [UserId]) UserTeam
+        select = "SELECT id, team FROM user where id in ?"
+
+isDebug :: Debug -> Bool
+isDebug Debug = True
+isDebug NoDebug = False
+
+sinkMain :: Env -> ConduitM [ResolveTeamResult] Void IO ()
+sinkMain Env {..} = go
+  where
+    go = do
+      mbResult <- await
+      for_ mbResult $ \results -> do
+        for_ results $ \case
+          UserHasNoTeam uid extid -> do
+            modifyIORef envFailCount (+ 1)
+            when (isDebug envDebug) $
+              Log.debug envLogger (Log.msg @String ("No team for user " <> show uid <> " from extid " <> show extid))
+          NewExternalId (tid, extid, uid) -> do
+            case envDryDrun of
+              DryRun -> pure ()
+              NoDryRun ->
+                runClient envSpar $
+                  write insert (params Quorum (tid, extid, uid))
+        go
+    insert :: PrepQuery W (TeamId, Text, UserId) ()
+    insert = "INSERT INTO scim_external (team, external_id, user) VALUES (?, ?, ?)"


### PR DESCRIPTION
This pr adds `tools/db/migrate-external-ids`

This tool fills entries in the table `spar.scim_external` (introduced in #1359 and rreleased [2021-02-16](https://github.com/wireapp/wire-server/releases/tag/v2021-02-16)) from table `spar.scim_external_ids` and `brig.user`. It is meant to be used in the migration from `spar.scim_external_ids` to `spar.scim_external`.
