### PR TITLE
stop re-compiling nginz when running integration test for unrelated changes

### DIFF
--- a/services/integration.sh
+++ b/services/integration.sh
@@ -121,9 +121,9 @@ fi
 function run_nginz() {
     colour=$1
 
-    # For nix we dont need LD_LIBRARY_PATH; we link against libzauth directly.
-    # nix-build will put a symlink to ./result with the nginx artifact
-    if which nix-build; then
+    if [[ $COMPILE_NGINX_USING_NIX -eq 1 ]]; then
+      # For nix we don't need LD_LIBRARY_PATH; we link against libzauth directly.
+      # nix-build will put a symlink to ./result with the nginx artifact
       nginz=$(nix-build "${TOP_LEVEL}/nix" -A nginz --no-out-link )
       (cd ${NGINZ_WORK_DIR} && ${nginz}/bin/nginx -p ${NGINZ_WORK_DIR} -c ${NGINZ_WORK_DIR}/conf/nginz/nginx.conf -g 'daemon off;' || kill_all) \
           | sed -e "s/^/$(tput setaf ${colour})[nginz] /" -e "s/$/$(tput sgr0)/" &


### PR DESCRIPTION
I have nix, but I don't want to use the nix-compiled version of nginz, especially when making changes such as https://github.com/wireapp/wire-server/pull/1386 which change which modules we use.
Also, my experience has been that something in the nix derivatation changes every week or every other week, leading to a nginx recomilation side effect each time I wish to run an integration test (which is not the time this should run: it could be hooked into services/nginz's makefile if that is useful)

@fisx you can set `COMPILE_NGINX_USING_NIX=1` globally in your bashprofile if you'd like to use the previous behaviour.