### PR TITLE
Spar errors

### DIFF
--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -116,25 +116,25 @@ apiScim =
     wrapScimErrors = over _Spar $ \act -> \env -> do
       result :: Either SomeException (Either SparError a) <- try (act env)
       case result of
-        -- We caught an exception that's not a Spar exception at all. It is wrapped into
-        -- Scim.serverError.
-        Left someException ->
-          pure $
-            Left . SAML.CustomError . SparScimError $
-              Scim.serverError (cs (displayException someException))
-        -- We caught a 'SparScimError' exception. It is left as-is.
+        Left someException -> do
+          -- We caught an exception that's not a Spar exception at all. It is wrapped into
+          -- Scim.serverError.
+          pure . Left . SAML.CustomError . SparScimError $
+            Scim.serverError (cs (displayException someException))
         Right err@(Left (SAML.CustomError (SparScimError _))) ->
+          -- We caught a 'SparScimError' exception. It is left as-is.
           pure err
-        -- We caught some other Spar exception. It is wrapped into Scim.serverError.
-        --
-        -- TODO: does it have to be logged?
         Right (Left sparError) -> do
+          -- We caught some other Spar exception. It is wrapped into Scim.serverError.
+          --
+          -- TODO: does it have to be logged?
           err <- sparToServerErrorWithLogging (sparCtxLogger env) sparError
           pure $
             Left . SAML.CustomError . SparScimError $
               Scim.serverError (cs (errBody err))
-        -- No exceptions! Good.
-        Right (Right x) -> pure $ Right x
+        Right (Right x) -> do
+          -- No exceptions! Good.
+          pure $ Right x
 
 -- | This is similar to 'Scim.siteServer, but does not include the 'Scim.groupServer',
 -- as we don't support it (we don't implement 'Web.Scim.Class.Group.GroupDB').


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-304

spar is transforming legitimate errors from eg. brig into 500 errors.  this PR fixes that.  the new scim errors in non-scim errors under scim end-points have the correct status and message and no type.  they also keep the scim error schema information.

i haven't managed to find the definition of what `Error20` or `"urn:ietf:params:scim:api:messages:2.0:Error"` says about the shape of the json object, and even if we find something scim peers may speak their own dialect violating the standard.

so there is a small risk now that instead of returning a 500 to a scim peer, they may get a much more reasonable error they still consider malformed.  i argue this is a clear improvement no matter what our scim peers think.  :)