### PR TITLE
[RFC] Migrate from alpine to ubuntu 20.04 base image and experiment with different docker builders 

### DIFF
--- a/build/ubuntu/buildah.sh
+++ b/build/ubuntu/buildah.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+
+# This is based of the hack/bin/buildah_* set of scripts, with the aim of reproducing the Docker based
+# set of Dockerfiles used to create images for development, ci and deployment using Ubuntu 20.04 as 
+# a base image and nix.
+
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
+# Use layers and cache
+BUILDAH_LAYERS=true
+
+# check for the existence of; or create a working container
+# buildah containers | awk '{print $5}' | grep "ubuntu-nix-builder" \
+#     || buildah from --name "ubuntu-nix-builder" -v "${TOP_LEVEL}":/src --pull quay.io/wire/ubuntu-nix-builder:develop
+
+buildah bud -v "${TOP_LEVEL}":/src -t "base" -f "${DIR}/Dockerfile.base" .
+echo "built base"

--- a/build/ubuntu/img.sh
+++ b/build/ubuntu/img.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+img build --no-console --no-cache -t base -f build/ubuntu/Dockerfile.base .

--- a/build/ubuntu/k3c.sh
+++ b/build/ubuntu/k3c.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Not maintained, adding the k3s layer makes it harder to debug.
+
+set -ex
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+k3c build --progress plain -f "${DIR}/Dockerfile.base" .


### PR DESCRIPTION
This PR is a request for comments.

It aims to address the fact that `alpine` base images make our haskell build environment more difficult to manage for our container based build and integration testing process. 

It explores migrating to an ubuntu 20.04 base image and at the same time improving our container image building approach with the following requirements:
 - Ideally the same approach for developer machine container builds (enabling local integration tests) and CI builds
 - Should work in containerised CI setups (avoiding docker in docker or other solutions needing privileged containers).
 - Should allow fast iterative workflows for developers, including for haskell builds based on cabal nix and/or stack

## Image builders

As context, our new kubernetes based CI environment seems to be more robust than our previous environment which had problems with concurrent buildkit builds. So buildkit based builders are a possibility. I'm aiming to look at the list provided here https://github.com/GoogleContainerTools/kaniko#comparison-with-other-tools which also gives a good overview of each tool's specificity.

The current state of my experiments is:
 - [x] buildah is trialed by the backend team https://github.com/wireapp/wire-server/pull/1349
    - I did not enjoy the `bash` based building of layers.
    - It seems the community of buildah users usually uses Dockerfiles
    - It wasn't clear how to avoid rebuilding all layers each time, so an incremental workflow seems more difficult than with other builders
    - It doesn't seem to support buildkit cache mount types https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md
    - It wasn't clear how to avoid recopying the build context each time
 - [x] `k3c` is unmaintained and has external dependencies on `k3s` 
 - [x] using `img` (based on `buildkit`) worked.
    - Supports buildkit cache mount types
    - Supports layers caching like docker
    - Worked with the `haskell.nix` branch on an ubuntu 20.04 base image
 - [ ] Kaniko is k8s focused 
 - [ ] Nix itself can build docker images, and we have already some tooling for this https://github.com/wireapp/wire-server/pull/1379/files#diff-6e438548faa6e6c166d5278a41bbac9ff6184427e898f61086d096311d84450fR110-R114
 - [ ] Bazel seems integrated with nix, cabal and stack. It's supposed to be fast, and it has an incremental build story with interpreted code in ghci (which might or might not work with our code base). It might not be a good fit for containerized builds however.

## Base image

The ubuntu 20.04 based `Dockerfile` is a simple first attempt to:
 - [x] use caching features from buildkit
 - [x] try `stack --nix build` 
 - [ ] try `hakell.nix` 
 - [ ] test various builders -- _in progress_
 - [ ] create pipelines to compare build times and compare DX 
