### PR TITLE
spar-migrate-data: Add migration and *.deb package

### DIFF
--- a/services/spar/Makefile
+++ b/services/spar/Makefile
@@ -1,17 +1,18 @@
 LANG := en_US.UTF-8
-SHELL         := /usr/bin/env bash
-NAME          := spar
-VERSION       ?=
-BUILD_NUMBER  ?= 0
-BUILD_LABEL   ?= local
-BUILD         := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
-EXE_IT        := ../../dist/$(NAME)-integration
-EXE_SCHEMA    := ../../dist/$(NAME)-schema
-DEB           := dist/$(NAME)_$(VERSION)+$(BUILD)_amd64.deb
-DEB_SCHEMA    := dist/$(NAME)-schema_$(VERSION)+$(BUILD)_amd64.deb
-EXECUTABLES   := $(NAME) $(NAME)-integration $(NAME)-schema
-DOCKER_USER    ?= quay.io/wire
-DOCKER_TAG     ?= local
+SHELL             := /usr/bin/env bash
+NAME              := spar
+VERSION           ?=
+BUILD_NUMBER      ?= 0
+BUILD_LABEL       ?= local
+BUILD             := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
+EXE_IT            := ../../dist/$(NAME)-integration
+EXE_SCHEMA        := ../../dist/$(NAME)-schema
+DEB               := dist/$(NAME)_$(VERSION)+$(BUILD)_amd64.deb
+DEB_SCHEMA        := dist/$(NAME)-schema_$(VERSION)+$(BUILD)_amd64.deb
+DEB_MIGRATE_DATA  := dist/$(NAME)-migrate-data_$(VERSION)+$(BUILD)_amd64.deb
+EXECUTABLES       := $(NAME) $(NAME)-integration $(NAME)-schema
+DOCKER_USER        ?= quay.io/wire
+DOCKER_TAG         ?= local
 
 guard-%:
 	@ if [ "${${*}}" = "" ]; then \
@@ -42,7 +43,7 @@ compile:
 	stack build --fast --test --bench --no-run-benchmarks --no-copy-bins spar
 
 .PHONY: dist
-dist: guard-VERSION install $(DEB) $(DEB_SCHEMA) .metadata
+dist: guard-VERSION install $(DEB) $(DEB_SCHEMA) $(DEB_MIGRATE_DATA) .metadata
 
 .metadata:
 	echo -e "NAME=$(NAME)\nVERSION=$(VERSION)\nBUILD_NUMBER=$(BUILD)" \
@@ -58,6 +59,14 @@ $(DEB): install
 
 $(DEB_SCHEMA): install
 	makedeb --name=$(NAME)-schema \
+		--version=$(VERSION) \
+		--debian-dir=schema/deb \
+		--build=$(BUILD) \
+		--architecture=amd64 \
+		--output-dir=dist
+
+$(DEB_MIGRATE_DATA): install
+	makedeb --name=$(NAME)-migrate-data \
 		--version=$(VERSION) \
 		--debian-dir=schema/deb \
 		--build=$(BUILD) \

--- a/services/spar/migrate-data/src/Spar/DataMigration/Run.hs
+++ b/services/spar/migrate-data/src/Spar/DataMigration/Run.hs
@@ -29,6 +29,7 @@ import Imports
 import qualified Options.Applicative as Opts
 import Spar.DataMigration.Options (settingsParser)
 import Spar.DataMigration.Types
+import qualified Spar.DataMigration.V1_ExternalIds as V1
 import qualified System.Logger as Log
 
 main :: IO ()
@@ -36,7 +37,7 @@ main = do
   settings <- Opts.execParser (Opts.info (Opts.helper <*> settingsParser) desc)
   migrate
     settings
-    []
+    [V1.migration]
   where
     desc = Opts.header "Spar Cassandra Data Migrations" <> Opts.fullDesc
 


### PR DESCRIPTION
This PR:
- Adds a first migration `V1_ExternalIds` (introduced in #1400) to the list of  migrations in `spar-migrate-data`
- Adds debian package for the `spar-migrate-data` executable (#1400)