### PR TITLE
Brig: Return correct status phrase and body on error

### DIFF
--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -43,11 +43,11 @@ import qualified Control.Monad.Catch as Catch
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import Data.Default (def)
-import qualified Data.Text.Lazy as LText
-import qualified Data.Text.Lazy.Encoding as LText
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 import qualified Data.ZAuth.Validation as ZV
 import Imports
-import Network.HTTP.Types (Status (statusCode))
+import Network.HTTP.Types (Status (statusCode, statusMessage))
 import Network.Wai (Request, ResponseReceived)
 import Network.Wai.Predicate (Media)
 import Network.Wai.Routing (Continue)
@@ -81,14 +81,14 @@ toServantHandler env action = do
     Right x -> pure x
   where
     mkCode = statusCode . WaiError.code
-    mkPhrase = LText.unpack . WaiError.label
+    mkPhrase = Text.unpack . Text.decodeUtf8 . statusMessage . WaiError.code
 
     handleWaiErrors logger reqId =
       \case
         StdError werr -> do
           Server.logError' logger (Just reqId) werr
           Servant.throwError $
-            Servant.ServerError (mkCode werr) (mkPhrase werr) (LText.encodeUtf8 $ WaiError.message werr) []
+            Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode werr) []
         RichError werr body headers -> do
           Server.logError' logger (Just reqId) werr
           Servant.throwError $

--- a/services/brig/test/integration/API/User/Handles.hs
+++ b/services/brig/test/integration/API/User/Handles.hs
@@ -41,6 +41,7 @@ import qualified Galley.Types.Teams.SearchVisibility as Team
 import Gundeck.Types.Notification hiding (target)
 import Imports
 import qualified Network.Wai.Utilities.Error as Error
+import qualified Network.Wai.Utilities.Error as Wai
 import Test.Tasty hiding (Timeout)
 import Test.Tasty.Cannon hiding (Cannon)
 import qualified Test.Tasty.Cannon as WS
@@ -48,7 +49,6 @@ import Test.Tasty.HUnit
 import UnliftIO (mapConcurrently)
 import Util
 import Wire.API.Team.Feature (TeamFeatureStatusValue (..))
-import qualified Network.Wai.Utilities.Error as Wai
 
 tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
 tests _cl _at conf p b c g =


### PR DESCRIPTION
Previously all the servant endpoints were wrongly fabricating the phrase for
status and only putting the message in the body. So, some 404's would return
something like:

```
HTTP/1.1 404 handle-not-found
```

This is allowed in HTTP, but still is a breaking change to our API. So, I think
it should be reverted.

Apart from this we also broke our API by not writing the whole error object in
the body, fortunately nothing broke, but I am pretty sure something would have
broken if we touched the endpoints where clients try to parse the error labels
and messages.