### PR TITLE
Random prekeys strategy

### DIFF
--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -34,9 +34,10 @@ aws:
   # ^ Comment this out if you don't want to journal user events
   prekeyTable: integration-brig-prekeys
   sqsEndpoint: http://localhost:4568 # https://sqs.eu-west-1.amazonaws.com
-  dynamoDBEndpoint: http://localhost:4567 # https://dynamodb.eu-west-1.amazonaws.com
+  # dynamoDBEndpoint: http://localhost:4567 # https://dynamodb.eu-west-1.amazonaws.com
 
-randomPrekeys: []
+# Uncomment to use the randomPrekey allocation strategy instead of dynamoDB
+randomPrekeys: true
 
 # Uncomment this if you want STOMP.
 #

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -36,6 +36,8 @@ aws:
   sqsEndpoint: http://localhost:4568 # https://sqs.eu-west-1.amazonaws.com
   dynamoDBEndpoint: http://localhost:4567 # https://dynamodb.eu-west-1.amazonaws.com
 
+randomPrekeys: []
+
 # Uncomment this if you want STOMP.
 #
 # stomp:

--- a/services/brig/src/Brig/AWS.hs
+++ b/services/brig/src/Brig/AWS.hs
@@ -116,23 +116,24 @@ mkEnv lgr opts emailOpts mgr = do
   let g = Logger.clone (Just "aws.brig") lgr
   let pk = Opt.prekeyTable opts
   let sesEndpoint = mkEndpoint SES.ses . Opt.sesEndpoint <$> emailOpts
+  let dynamoEndpoint = mkEndpoint DDB.dynamoDB  <$> Opt.dynamoDBEndpoint opts
   e <-
     mkAwsEnv
       g
       sesEndpoint
+      dynamoEndpoint
       (mkEndpoint SQS.sqs (Opt.sqsEndpoint opts))
-      (mkEndpoint DDB.dynamoDB (Opt.dynamoDBEndpoint opts))
   sq <- maybe (return Nothing) (fmap Just . getQueueUrl e . Opt.sesQueue) emailOpts
   jq <- maybe (return Nothing) (fmap Just . getQueueUrl e) (Opt.userJournalQueue opts)
   return (Env g sq jq pk e)
   where
     mkEndpoint svc e = AWS.setEndpoint (e ^. awsSecure) (e ^. awsHost) (e ^. awsPort) svc
-    mkAwsEnv g ses sqs dyn =
+    mkAwsEnv g ses dyn sqs =
       set AWS.envLogger (awsLogger g)
         <$> AWS.newEnvWith AWS.Discover Nothing mgr
         <&> maybe id AWS.configure ses
+        <&> maybe id AWS.configure dyn
         <&> AWS.configure sqs
-        <&> AWS.configure dyn
     awsLogger g l = Logger.log g (mapLevel l) . Logger.msg . toLazyByteString
     mapLevel AWS.Info = Logger.Info
     -- Debug output from amazonka can be very useful for tracing requests

--- a/services/brig/src/Brig/AWS.hs
+++ b/services/brig/src/Brig/AWS.hs
@@ -116,7 +116,7 @@ mkEnv lgr opts emailOpts mgr = do
   let g = Logger.clone (Just "aws.brig") lgr
   let pk = Opt.prekeyTable opts
   let sesEndpoint = mkEndpoint SES.ses . Opt.sesEndpoint <$> emailOpts
-  let dynamoEndpoint = mkEndpoint DDB.dynamoDB  <$> Opt.dynamoDBEndpoint opts
+  let dynamoEndpoint = mkEndpoint DDB.dynamoDB <$> Opt.dynamoDBEndpoint opts
   e <-
     mkAwsEnv
       g

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -173,7 +173,7 @@ data Env = Env
     _digestSHA256 :: Digest,
     _digestMD5 :: Digest,
     _indexEnv :: IndexEnv,
-    _randomPrekeys :: Maybe (),
+    _randomPrekeys :: Bool,
     _randomPrekeyLocalLock :: MVar ()
   }
 
@@ -251,7 +251,7 @@ newEnv o = do
         _digestMD5 = md5,
         _digestSHA256 = sha256,
         _indexEnv = mkIndexEnv o lgr mgr mtr,
-        _randomPrekeys = Just (),
+        _randomPrekeys = fromMaybe False $ Opt.randomPrekeys o,
         _randomPrekeyLocalLock = prekeyLocalLock
       }
   where

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -55,6 +55,7 @@ module Brig.App
     sftEnv,
     internalEvents,
     emailSender,
+    randomPrekeys,
 
     -- * App Monad
     AppT,
@@ -170,7 +171,8 @@ data Env = Env
     _zauthEnv :: ZAuth.Env,
     _digestSHA256 :: Digest,
     _digestMD5 :: Digest,
-    _indexEnv :: IndexEnv
+    _indexEnv :: IndexEnv,
+    _randomPrekeys :: Maybe ()
   }
 
 makeLenses ''Env
@@ -245,7 +247,8 @@ newEnv o = do
         _zauthEnv = zau,
         _digestMD5 = md5,
         _digestSHA256 = sha256,
-        _indexEnv = mkIndexEnv o lgr mgr mtr
+        _indexEnv = mkIndexEnv o lgr mgr mtr,
+        _randomPrekeys = Just ()
       }
   where
     emailConn _ (Opt.EmailAWS aws) = return (Just aws, Nothing)

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -187,6 +187,7 @@ updatePrekeys u c pks = do
       case i of
         Success n -> return (CryptoBox.prekeyId n == keyId (prekeyId a))
         _ -> return False
+
 claimPrekey :: UserId -> ClientId -> AppIO (Maybe ClientPrekey)
 claimPrekey u c =
   ifM
@@ -224,6 +225,7 @@ claimPrekey u c =
       let pks' = filter (\k -> fst k /= lastPrekeyId) pks
       ind <- liftIO $ randomRIO (0, length pks' - 1)
       return $ atMay pks' ind
+
 -------------------------------------------------------------------------------
 -- Queries
 
@@ -381,6 +383,5 @@ withOptLock u c ma = go (10 :: Int)
 
 withLocalLock :: AppIO (MVar ()) -> AppIO a -> AppIO a
 withLocalLock l ma = do
-    lck <- l
-    (takeMVar lck *> ma) `finally` putMVar lck ()
-
+  lck <- l
+  (takeMVar lck *> ma) `finally` putMVar lck ()

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -166,7 +166,7 @@ rmClient :: UserId -> ClientId -> AppIO ()
 rmClient u c = do
   retry x5 $ write removeClient (params Quorum (u, c))
   retry x5 $ write removeClientKeys (params Quorum (u, c))
-  deleteOptLock u c
+  unlessM (view randomPrekeys) $ deleteOptLock u c
 
 updateClientLabel :: MonadClient m => UserId -> ClientId -> Maybe Text -> m ()
 updateClientLabel u c l = retry x5 $ write updateClientLabelQuery (params Quorum (l, u, c))

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
@@ -39,7 +41,7 @@ where
 
 import Bilge.Retry (httpHandlers)
 import Brig.AWS
-import Brig.App (AppIO, awsEnv, currentTime, metrics, randomPrekeyLocalLock, randomPrekeys)
+import Brig.App (AppIO, awsEnv, currentTime, metrics, randomPrekeyLocalLock)
 import Brig.Data.Instances ()
 import Brig.Data.User (AuthError (..), ReAuthError (..))
 import qualified Brig.Data.User as User
@@ -52,7 +54,6 @@ import Control.Error
 import qualified Control.Exception.Lens as EL
 import Control.Lens
 import Control.Monad.Catch
-import Control.Monad.Extra (ifM)
 import Control.Monad.Random (Random (randomRIO))
 import Control.Retry
 import qualified Data.ByteString.Base64 as B64
@@ -167,7 +168,7 @@ rmClient :: UserId -> ClientId -> AppIO ()
 rmClient u c = do
   retry x5 $ write removeClient (params Quorum (u, c))
   retry x5 $ write removeClientKeys (params Quorum (u, c))
-  unlessM (view randomPrekeys) $ deleteOptLock u c
+  unlessM (isJust <$> view randomPrekeyLocalLock) $ deleteOptLock u c
 
 updateClientLabel :: MonadClient m => UserId -> ClientId -> Maybe Text -> m ()
 updateClientLabel u c l = retry x5 $ write updateClientLabelQuery (params Quorum (l, u, c))
@@ -190,19 +191,16 @@ updatePrekeys u c pks = do
 
 claimPrekey :: UserId -> ClientId -> AppIO (Maybe ClientPrekey)
 claimPrekey u c =
-  ifM
-    (view randomPrekeys)
+  view randomPrekeyLocalLock >>= \case
     -- Use random prekey selection strategy
-    ( withLocalLock (view randomPrekeyLocalLock) $ do
-        prekeys <- retry x1 $ query userPrekeys (params Quorum (u, c))
-        prekey <- pickRandomPrekey prekeys
-        removeAndReturnPreKey prekey
-    )
+    Just localLock -> withLocalLock localLock $ do
+      prekeys <- retry x1 $ query userPrekeys (params Quorum (u, c))
+      prekey <- pickRandomPrekey prekeys
+      removeAndReturnPreKey prekey
     -- Use DynamoDB based optimistic locking strategy
-    ( withOptLock u c $ do
-        prekey <- retry x1 $ query1 userPrekey (params Quorum (u, c))
-        removeAndReturnPreKey prekey
-    )
+    Nothing -> withOptLock u c $ do
+      prekey <- retry x1 $ query1 userPrekey (params Quorum (u, c))
+      removeAndReturnPreKey prekey
   where
     removeAndReturnPreKey :: Maybe (PrekeyId, Text) -> AppIO (Maybe ClientPrekey)
     removeAndReturnPreKey (Just (i, k)) = do
@@ -381,7 +379,6 @@ withOptLock u c ma = go (10 :: Int)
               return Nothing
             handleErr _ = return Nothing
 
-withLocalLock :: AppIO (MVar ()) -> AppIO a -> AppIO a
+withLocalLock :: MVar () -> AppIO a -> AppIO a
 withLocalLock l ma = do
-  lck <- l
-  (takeMVar lck *> ma) `finally` putMVar lck ()
+  (takeMVar l *> ma) `finally` putMVar l ()

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -193,11 +193,11 @@ claimPrekey u c = do
   -- Log.warn $ field "randomStrategy" $ show randomStrategy
   case randomStrategy of
     -- Use DynamoDB based optimistic locking strategy
-    Nothing -> withOptLock u c $ do
+    False -> withOptLock u c $ do
       prekey <- retry x1 $ query1 userPrekey (params Quorum (u, c))
       removeAndReturnPreKey prekey
     -- Use random prekey selection strategy
-    Just () -> do
+    True -> do
       lock <- view randomPrekeyLocalLock 
       withLocalLock lock $ do
         prekeys <- retry x1 $ query userPrekeys (params Quorum (u, c))

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -353,6 +353,8 @@ data Opts = Opts
     elasticsearch :: !ElasticSearchOpts,
     -- | AWS settings
     aws :: !AWSOpts,
+    -- | Enable Random Prekey Strategy
+    randomPrekeys :: !(Maybe ()),
     -- | STOMP broker settings
     stomp :: !(Maybe StompOpts),
     -- Email & SMS

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -354,7 +354,7 @@ data Opts = Opts
     -- | AWS settings
     aws :: !AWSOpts,
     -- | Enable Random Prekey Strategy
-    randomPrekeys :: !(Maybe ()),
+    randomPrekeys :: !(Maybe Bool),
     -- | STOMP broker settings
     stomp :: !(Maybe StompOpts),
     -- Email & SMS

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -85,7 +85,7 @@ data AWSOpts = AWSOpts
     -- | AWS SQS endpoint
     sqsEndpoint :: !AWSEndpoint,
     -- | DynamoDB endpoint
-    dynamoDBEndpoint :: !AWSEndpoint
+    dynamoDBEndpoint :: !(Maybe AWSEndpoint)
   }
   deriving (Show, Generic)
 


### PR DESCRIPTION
Implement https://wearezeta.atlassian.net/browse/SQPIT-348

TODO:
 - [x] Parse `randomPrekeys: true` into `Maybe ()` instead of `randomPrekeys: []` in `brig.yaml` configuration.
 - [x] Make the DynamoDB endpoint configuration optional
 - [x] Allow both strategies to be tested in the integration tests
   - [x] Local integration tests use the randomPrekey strategy
   - [x] CI integration tests use the DynamoDB lock.
 - [ ] Deploy to staging
   - [ ] Merge to develop
   - [ ] Update brig..yaml in staging
   - [ ] Switch CI integration test to use randomPrekey strategy 