### PR TITLE
Add spar-migrate-data to cassandara-migrations helm chart

### DIFF
--- a/charts/cassandra-migrations/templates/galley-migrate-data.yaml
+++ b/charts/cassandra-migrations/templates/galley-migrate-data.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
   annotations:
     "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:

--- a/charts/cassandra-migrations/templates/spar-migrate-data.yaml
+++ b/charts/cassandra-migrations/templates/spar-migrate-data.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
   annotations:
     "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "20"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:

--- a/charts/cassandra-migrations/templates/spar-migrate-data.yaml
+++ b/charts/cassandra-migrations/templates/spar-migrate-data.yaml
@@ -1,0 +1,43 @@
+# This jobs runs data migrations for the spar DB using the spar-migrate-data tool.
+# The source for the tool can be found at services/spar/migrate-data
+#
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: spar-migrate-data
+  labels:
+    wireService: "cassandra-migrations"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}"
+      labels:
+        wireService: spar-migrate-data
+        app: spar-migrate-data
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: spar-migrate-data
+          image: "{{ .Values.images.sparMigrateData }}:{{ .Values.images.tag }}"
+          args:
+             - --cassandra-host-spar
+             - "{{ .Values.cassandra.host }}"
+             - --cassandra-port-spar
+             - "9042"
+             - --cassandra-keyspace-spar
+             - spar
+             - --cassandra-host-brig
+             - "{{ .Values.cassandra.host }}"
+             - --cassandra-port-brig
+             - "9042"
+             - --cassandra-keyspace-brig
+             - brig

--- a/charts/cassandra-migrations/values.yaml
+++ b/charts/cassandra-migrations/values.yaml
@@ -5,3 +5,4 @@ images:
   galley: quay.io/wire/galley-schema
   spar: quay.io/wire/spar-schema
   galleyMigrateData: quay.io/wire/galley-migrate-data
+  sparMigrateData: quay.io/wire/spar-migrate-data


### PR DESCRIPTION
This PR adds `spar-migrate-data.yaml` (similar to `galley-migrate-data.yaml` in the same directory) to the `cassandra-migrations` chart.
This should be released after https://github.com/wireapp/wire-server-private/pull/283 