### PR TITLE
Remove usage of spar.scim_external_ids table

### DIFF
--- a/services/spar/schema/src/Main.hs
+++ b/services/spar/schema/src/Main.hs
@@ -67,5 +67,8 @@ main = do
       -- (we don't want to risk running a migration which would
       -- effectively break the currently deployed spar service)
       -- see https://github.com/wireapp/wire-server/pull/476.
+
+      -- FUTUREWORK: Add a migration that removes the table `scim_external_ids` after
+      -- https://github.com/wireapp/wire-server/pull/1418 is released.
     ]
     `finally` Log.close l

--- a/services/spar/schema/src/Main.hs
+++ b/services/spar/schema/src/Main.hs
@@ -67,8 +67,5 @@ main = do
       -- (we don't want to risk running a migration which would
       -- effectively break the currently deployed spar service)
       -- see https://github.com/wireapp/wire-server/pull/476.
-
-      -- FUTUREWORK: Add a migration that removes the table `scim_external_ids` after
-      -- https://github.com/wireapp/wire-server/pull/1418 is released.
     ]
     `finally` Log.close l

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -190,7 +190,7 @@ insertUser uref uid = wrapMonadClient $ Data.insertSAMLUser uref uid
 -- password handshake have not been completed; it's still ok for the user to gain access to
 -- the team with valid SAML credentials.
 --
--- FUTUREWORK: Remove and reinstatate getUser, in AuthID refactoring PR
+-- FUTUREWORK: Remove and reinstatate getUser, in AuthID refactoring PR.  (in https://github.com/wireapp/wire-server/pull/1410, undo https://github.com/wireapp/wire-server/pull/1418)
 getUserByUref :: SAML.UserRef -> Spar (Maybe UserId)
 getUserByUref uref = do
   muid <- wrapMonadClient $ Data.getSAMLUser uref

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -26,7 +26,8 @@ module Spar.App
     wrapMonadClientWithEnv,
     wrapMonadClient,
     verdictHandler,
-    getUser,
+    getUserByUref,
+    getUserByScimExternalId,
     insertUser,
     autoprovisionSamlUser,
     autoprovisionSamlUserWithId,
@@ -84,12 +85,13 @@ import Spar.Error
 import qualified Spar.Intra.Brig as Intra
 import qualified Spar.Intra.Galley as Intra
 import Spar.Orphans ()
-import Spar.Scim.Types (ValidExternalId (..), runValidExternalId)
+import Spar.Scim.Types (ValidExternalId (..))
 import Spar.Types
 import qualified System.Logger as Log
 import System.Logger.Class (MonadLogger (log))
 import URI.ByteString as URI
 import Web.Cookie (SetCookie, renderSetCookie)
+import Wire.API.User.Identity (Email (..))
 
 newtype Spar a = Spar {fromSpar :: ReaderT Env (ExceptT SparError IO) a}
   deriving (Functor, Applicative, Monad, MonadIO, MonadReader Env, MonadError SparError)
@@ -188,11 +190,21 @@ insertUser uref uid = wrapMonadClient $ Data.insertSAMLUser uref uid
 -- password handshake have not been completed; it's still ok for the user to gain access to
 -- the team with valid SAML credentials.
 --
--- ASSUMPTIONS: User creation on brig/galley is idempotent.  Any incomplete creation (because of
--- brig or galley crashing) will cause the lookup here to yield 'Nothing'.
-getUser :: ValidExternalId -> Spar (Maybe UserId)
-getUser veid = do
-  muid <- wrapMonadClient $ runValidExternalId Data.getSAMLUser Data.lookupScimExternalId veid
+-- FUTUREWORK: Remove and reinstatate getUser, in AuthID refactoring PR
+getUserByUref :: SAML.UserRef -> Spar (Maybe UserId)
+getUserByUref uref = do
+  muid <- wrapMonadClient $ Data.getSAMLUser uref
+  case muid of
+    Nothing -> pure Nothing
+    Just uid -> do
+      let withpending = Intra.WithPendingInvitations -- see haddocks above
+      itis <- isJust <$> Intra.getBrigUserTeam withpending uid
+      pure $ if itis then Just uid else Nothing
+
+-- FUTUREWORK: Remove and reinstatate getUser, in AuthID refactoring PR
+getUserByScimExternalId :: TeamId -> Email -> Spar (Maybe UserId)
+getUserByScimExternalId tid email = do
+  muid <- wrapMonadClient $ (Data.lookupScimExternalId tid email)
   case muid of
     Nothing -> pure Nothing
     Just uid -> do
@@ -376,7 +388,7 @@ findUserWithOldIssuer (SAML.UserRef issuer subject) = do
   idp <- getIdPConfigByIssuer issuer
   let tryFind :: Maybe (SAML.UserRef, UserId) -> Issuer -> Spar (Maybe (SAML.UserRef, UserId))
       tryFind found@(Just _) _ = pure found
-      tryFind Nothing oldIssuer = (uref,) <$$> getUser (UrefOnly uref)
+      tryFind Nothing oldIssuer = (uref,) <$$> getUserByUref uref
         where
           uref = SAML.UserRef oldIssuer subject
   foldM tryFind Nothing (idp ^. idpExtraInfo . wiOldIssuers)
@@ -396,7 +408,7 @@ verdictHandlerResultCore bindCky = \case
   SAML.AccessGranted userref -> do
     uid :: UserId <- do
       viaBindCookie <- maybe (pure Nothing) (wrapMonadClient . Data.lookupBindCookie) bindCky
-      viaSparCassandra <- getUser (UrefOnly userref)
+      viaSparCassandra <- getUserByUref userref
       -- race conditions: if the user has been created on spar, but not on brig, 'getUser'
       -- returns 'Nothing'.  this is ok assuming 'createUser', 'bindUser' (called below) are
       -- idempotent.

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -784,42 +784,22 @@ deleteScimUserTimes uid = retry x5 . write del $ params Quorum (Identity uid)
 -- as a 'Text'.)
 insertScimExternalId :: (HasCallStack, MonadClient m) => TeamId -> Email -> UserId -> m ()
 insertScimExternalId tid (fromEmail -> email) uid =
-  retry
-    x5
-    ( batch $ do
-        setType BatchLogged
-        setConsistency Quorum
-        addPrepQuery ins (email, uid)
-        addPrepQuery insFuture (tid, email, uid)
-    )
+  retry x5 . write insert $ params Quorum (tid, email, uid)
   where
-    ins :: PrepQuery W (Text, UserId) ()
-    ins = "INSERT INTO scim_external_ids (external, user) VALUES (?, ?)"
-
-    insFuture :: PrepQuery W (TeamId, Text, UserId) ()
-    insFuture = "INSERT INTO scim_external (team, external_id, user) VALUES (?, ?, ?)"
+    insert :: PrepQuery W (TeamId, Text, UserId) ()
+    insert = "INSERT INTO scim_external (team, external_id, user) VALUES (?, ?, ?)"
 
 -- | The inverse of 'insertScimExternalId'.
-lookupScimExternalId :: (HasCallStack, MonadClient m) => Email -> m (Maybe UserId)
-lookupScimExternalId (fromEmail -> email) = runIdentity <$$> (retry x1 . query1 sel $ params Quorum (Identity email))
+lookupScimExternalId :: (HasCallStack, MonadClient m) => TeamId -> Email -> m (Maybe UserId)
+lookupScimExternalId tid (fromEmail -> email) = runIdentity <$$> (retry x1 . query1 sel $ params Quorum (tid, email))
   where
-    sel :: PrepQuery R (Identity Text) (Identity UserId)
-    sel = "SELECT user FROM scim_external_ids WHERE external = ?"
+    sel :: PrepQuery R (TeamId, Text) (Identity UserId)
+    sel = "SELECT user FROM scim_external WHERE team = ? and external_id = ?"
 
 -- | The other inverse of 'insertScimExternalId' :).
 deleteScimExternalId :: (HasCallStack, MonadClient m) => TeamId -> Email -> m ()
-deleteScimExternalId team (fromEmail -> email) =
-  retry
-    x5
-    ( batch $ do
-        setType BatchLogged
-        setConsistency Quorum
-        addPrepQuery del (Identity email)
-        addPrepQuery delFuture (team, email)
-    )
+deleteScimExternalId tid (fromEmail -> email) =
+  retry x5 . write delete $ params Quorum (tid, email)
   where
-    del :: PrepQuery W (Identity Text) ()
-    del = "DELETE FROM scim_external_ids WHERE external = ?"
-
-    delFuture :: PrepQuery W (TeamId, Text) ()
-    delFuture = "DELETE FROM scim_external WHERE team = ? and external_id = ?"
+    delete :: PrepQuery W (TeamId, Text) ()
+    delete = "DELETE FROM scim_external WHERE team = ? and external_id = ?"

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -64,7 +64,7 @@ import qualified Data.UUID.V4 as UUID
 import Imports
 import Network.URI (URI, parseURI)
 import qualified SAML2.WebSSO as SAML
-import Spar.App (Spar, getUser, sparCtxOpts, validateEmailIfExists, wrapMonadClient)
+import Spar.App (Spar, getUserByScimExternalId, getUserByUref, sparCtxOpts, validateEmailIfExists, wrapMonadClient)
 import qualified Spar.Data as Data
 import qualified Spar.Intra.Brig as Brig
 import Spar.Scim.Auth ()
@@ -370,7 +370,7 @@ createValidScimUser tokeninfo@ScimTokenInfo {stiTeam} vsu@(ST.ValidScimUser veid
     $ do
       -- ensure uniqueness constraints of all affected identifiers.
       -- {if we crash now, retry POST will just work}
-      assertExternalIdUnused veid
+      assertExternalIdUnused stiTeam veid
       assertHandleUnused handl
       -- {if we crash now, retry POST will just work, or user gets told the handle
       -- is already in use and stops POSTing}
@@ -444,7 +444,7 @@ updateValidScimUser ::
   UserId ->
   ST.ValidScimUser ->
   m (Scim.StoredUser ST.SparTag)
-updateValidScimUser tokinfo uid newValidScimUser =
+updateValidScimUser tokinfo@ScimTokenInfo {stiTeam} uid newValidScimUser =
   logScim
     ( logFunction "Spar.Scim.User.updateValidScimUser"
         . logVSU newValidScimUser
@@ -459,7 +459,7 @@ updateValidScimUser tokinfo uid newValidScimUser =
 
       -- assertions about new valid scim user that cannot be checked in 'validateScimUser' because
       -- they differ from the ones in 'createValidScimUser'.
-      assertExternalIdNotUsedElsewhere (newValidScimUser ^. ST.vsuExternalId) uid
+      assertExternalIdNotUsedElsewhere stiTeam (newValidScimUser ^. ST.vsuExternalId) uid
       assertHandleNotUsedElsewhere uid (newValidScimUser ^. ST.vsuHandle)
 
       if oldValidScimUser == newValidScimUser
@@ -471,7 +471,7 @@ updateValidScimUser tokinfo uid newValidScimUser =
           case ( oldValidScimUser ^. ST.vsuExternalId,
                  newValidScimUser ^. ST.vsuExternalId
                ) of
-            (old, new) | old /= new -> updateVsuUref (stiTeam tokinfo) uid old new
+            (old, new) | old /= new -> updateVsuUref stiTeam uid old new
             _ -> pure ()
 
           when (newValidScimUser ^. ST.vsuName /= oldValidScimUser ^. ST.vsuName) $ do
@@ -628,9 +628,9 @@ calculateVersion uid usr = Scim.Weak (Text.pack (show h))
 --
 -- ASSUMPTION: every scim user has a 'SAML.UserRef', and the `SAML.NameID` in it corresponds
 -- to a single `externalId`.
-assertExternalIdUnused :: ST.ValidExternalId -> Scim.ScimHandler Spar ()
-assertExternalIdUnused veid = do
-  mExistingUserId <- lift $ getUser veid
+assertExternalIdUnused :: TeamId -> ST.ValidExternalId -> Scim.ScimHandler Spar ()
+assertExternalIdUnused tid veid = do
+  mExistingUserId <- lift $ ST.runValidExternalId (getUserByUref) (getUserByScimExternalId tid) veid
   unless (isNothing mExistingUserId) $
     throwError Scim.conflict {Scim.detail = Just "externalId is already taken"}
 
@@ -640,9 +640,9 @@ assertExternalIdUnused veid = do
 --
 -- ASSUMPTION: every scim user has a 'SAML.UserRef', and the `SAML.NameID` in it corresponds
 -- to a single `externalId`.
-assertExternalIdNotUsedElsewhere :: ST.ValidExternalId -> UserId -> Scim.ScimHandler Spar ()
-assertExternalIdNotUsedElsewhere veid wireUserId = do
-  mExistingUserId <- lift $ getUser veid
+assertExternalIdNotUsedElsewhere :: TeamId -> ST.ValidExternalId -> UserId -> Scim.ScimHandler Spar ()
+assertExternalIdNotUsedElsewhere tid veid wireUserId = do
+  mExistingUserId <- lift $ ST.runValidExternalId getUserByUref (getUserByScimExternalId tid) veid
   unless (mExistingUserId `elem` [Nothing, Just wireUserId]) $ do
     throwError Scim.conflict {Scim.detail = Just "externalId already in use by another Wire user"}
 
@@ -791,7 +791,7 @@ scimFindUserByEmail mIdpConfig stiTeam email = do
         -- FUTUREWORK: we could also always lookup brig, that's simpler and possibly faster,
         -- and it never should be visible in spar, but not in brig.
         inspar, inbrig :: Spar (Maybe UserId)
-        inspar = wrapMonadClient $ Data.lookupScimExternalId eml
+        inspar = wrapMonadClient $ Data.lookupScimExternalId stiTeam eml
         inbrig = userId . accountUser <$$> Brig.getBrigUserByEmail eml
 
 logFilter :: Filter -> (Msg -> Msg)

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -1655,7 +1655,7 @@ testDeletedUsersFreeExternalIdNoIdp = do
 
   void $
     aFewTimes
-      (runClient clientState $ lookupScimExternalId email)
+      (runClient clientState $ lookupScimExternalId tid email)
       (== Nothing)
 
 specSCIMManaged :: SpecWith TestEnv

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -1123,13 +1123,13 @@ callDeleteDefaultSsoCode sparreq_ = do
 -- helpers talking to spar's cassandra directly
 
 -- | Look up 'UserId' under 'UserSSOId' on spar's cassandra directly.
-ssoToUidSpar :: (HasCallStack, MonadIO m, MonadReader TestEnv m) => Brig.UserSSOId -> m (Maybe UserId)
-ssoToUidSpar ssoid = do
+ssoToUidSpar :: (HasCallStack, MonadIO m, MonadReader TestEnv m) => TeamId -> Brig.UserSSOId -> m (Maybe UserId)
+ssoToUidSpar tid ssoid = do
   veid <- either (error . ("could not parse brig sso_id: " <>)) pure $ Intra.veidFromUserSSOId ssoid
   runSparCass @Client $
     runValidExternalId
       Data.getSAMLUser
-      Data.lookupScimExternalId
+      (Data.lookupScimExternalId tid)
       veid
 
 runSparCass ::


### PR DESCRIPTION
This PR discontinues use of `spar.scim_external_ids` table in favor of `spar.scim_externals` table.

:warning: Release this in a separate release after #1417 is released and only after the `spar-migrate-data` job has completed on production.