### PR TITLE
Allow specifying digest of webapp

### DIFF
--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -27,7 +27,11 @@ spec:
     spec:
       containers:
       - name: webapp
+        {{- if .Values.image.digest }}
+        image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         # Check variables here: https://github.com/wireapp/wire-webapp/wiki/Self-hosting
         env:
           # it is vital that you don't add trailing '/' in this section!


### PR DESCRIPTION
This will allow us to detect new webapps and deploy them immediately to some
environment without having to relying on `imagePullPolicy: Always`.

Using `imagePullPolicy: Always` supresses tranparency of what and when something
was deployed.