### PR TITLE
brig: Add exact handle matches from all teams in /search/contacts

### DIFF
--- a/docs/developer/how-to.md
+++ b/docs/developer/how-to.md
@@ -49,7 +49,7 @@ The process consists of:
 
 ### (1) Inspect/change the multi-backend test code
 
-Refer to `services/brig/test/integration/API/Federation.hs` for the current multi-backend tests.
+Refer to `services/brig/test/integration/API/Federation/End2End.hs` for the current multi-backend tests.
 
 *Note that they only run if `INTEGRATION_FEDERATION_TESTS` is set to `1`. This is currently configured to be OFF when running regular brig integration tests (e.g. via `make -C services/brig integration`) but is by default ON when running tests on kubernetes or on CI, or when using the `services/brig/federation-tests.sh` script.*
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -52,3 +52,14 @@ mkGetUserInfoByHandle handle =
     "users/by-handle"
     [Proto.QueryParam "handle" (T.encodeUtf8 (fromHandle handle))]
     mempty
+
+-- TODO: Can we write a test which makes use of mkSearchUsers against the Api in this file?
+-- Naming bikeshedding: current /search/contacts. /search/users is a better name, no?
+mkSearchUsers :: Text -> Proto.Request
+mkSearchUsers searchTerm =
+  Proto.Request
+    Proto.Brig
+    (Proto.HTTPMethod HTTP.GET)
+    "search/users"
+    [Proto.QueryParam "q" (T.encodeUtf8 searchTerm)]
+    mempty

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -43,6 +43,8 @@ data Api routes = Api
         :> "users"
         -- FUTUREWORK(federation): do we want to perform some type-level validation like length checks?
         -- (handles can be up to 256 chars currently)
+        -- FUTUREWORK(federation): change this to a POST with a body,
+        -- rather than a query parameter, after deciding on a general pattern here
         :> QueryParam' '[Required, Strict] "q" Text
         :> Get '[JSON] (SearchResult Contact)
   }
@@ -64,7 +66,6 @@ mkGetUserInfoByHandle handle =
     mempty
 
 -- FUTUREWORK: Can we write a test which makes use of mkSearchUsers against the Api in this file?
--- Naming bikeshedding: current /search/contacts. /search/users is a better name, no?
 mkSearchUsers :: Text -> Proto.Request
 mkSearchUsers searchTerm =
   Proto.Request
@@ -72,5 +73,5 @@ mkSearchUsers searchTerm =
     (Proto.HTTPMethod HTTP.GET)
     "search/users"
     [Proto.QueryParam "q" (T.encodeUtf8 searchTerm)]
-    -- FUTUREWORK: do we want to pass other parameters like the number of results?
+    -- FUTUREWORK(federation): do we want to pass other parameters like the number of results?
     mempty

--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -68,6 +68,7 @@ tests:
     - aeson-qq
     - lens
     - swagger2
+    - string-conversions
     - tasty
     - tasty-expected-failure
     - tasty-hunit

--- a/libs/wire-api/src/Wire/API/User/Search.hs
+++ b/libs/wire-api/src/Wire/API/User/Search.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StrictData #-}
-{-# LANGUAGE ApplicativeDo #-}
 
 -- This file is part of the Wire Server implementation.
 --
@@ -71,7 +71,7 @@ instance Foldable SearchResult where
 instance Traversable SearchResult where
   traverse f r = do
     newResults <- traverse f (searchResults r)
-    pure $ r { searchResults = newResults }
+    pure $ r {searchResults = newResults}
 
 instance ToSchema (SearchResult Contact) where
   declareNamedSchema _ = do
@@ -122,7 +122,7 @@ instance FromJSON a => FromJSON (SearchResult a) where
 --------------------------------------------------------------------------------
 -- Contact
 
-type ContactLabelMappings = '[ "color_id" ':-> "accent_id"]
+type ContactLabelMappings = '["color_id" ':-> "accent_id"]
 
 -- | Returned by 'searchIndex' under @/contacts/search@.
 -- This is a subset of 'User' and json instances should reflect that.

--- a/libs/wire-api/src/Wire/API/User/Search.hs
+++ b/libs/wire-api/src/Wire/API/User/Search.hs
@@ -136,8 +136,6 @@ data Contact = Contact
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform Contact)
 
--- deriving (ToSchema) via (CustomSwagger '[FieldLabelModifier (StripPrefix "contact", CamelToSnake, LabelMappings ContactLabelMappings)] Contact)
-
 instance ToSchema Contact where
   declareNamedSchema _ = do
     genericSchema <-

--- a/libs/wire-api/test/unit/Main.hs
+++ b/libs/wire-api/test/unit/Main.hs
@@ -29,6 +29,7 @@ import qualified Test.Wire.API.Roundtrip.CSV as Roundtrip.CSV
 import qualified Test.Wire.API.Swagger as Swagger
 import qualified Test.Wire.API.Team.Member as Team.Member
 import qualified Test.Wire.API.User as User
+import qualified Test.Wire.API.User.Search as User.Search
 import qualified Test.Wire.API.User.RichInfo as User.RichInfo
 
 main :: IO ()
@@ -39,6 +40,7 @@ main =
       [ Call.Config.tests,
         Team.Member.tests,
         User.tests,
+        User.Search.tests,
         User.RichInfo.tests,
         Roundtrip.Aeson.tests,
         Roundtrip.ByteString.tests,

--- a/libs/wire-api/test/unit/Main.hs
+++ b/libs/wire-api/test/unit/Main.hs
@@ -29,8 +29,8 @@ import qualified Test.Wire.API.Roundtrip.CSV as Roundtrip.CSV
 import qualified Test.Wire.API.Swagger as Swagger
 import qualified Test.Wire.API.Team.Member as Team.Member
 import qualified Test.Wire.API.User as User
-import qualified Test.Wire.API.User.Search as User.Search
 import qualified Test.Wire.API.User.RichInfo as User.RichInfo
+import qualified Test.Wire.API.User.Search as User.Search
 
 main :: IO ()
 main =

--- a/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
@@ -27,8 +27,8 @@ import qualified Wire.API.User as User
 import qualified Wire.API.User.Client as Client
 import qualified Wire.API.User.Client.Prekey as Prekey
 import qualified Wire.API.User.Handle as Handle
-import qualified Wire.API.UserMap as UserMap
 import qualified Wire.API.User.Search as Search
+import qualified Wire.API.UserMap as UserMap
 
 tests :: T.TestTree
 tests =

--- a/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
@@ -28,6 +28,7 @@ import qualified Wire.API.User.Client as Client
 import qualified Wire.API.User.Client.Prekey as Prekey
 import qualified Wire.API.User.Handle as Handle
 import qualified Wire.API.UserMap as UserMap
+import qualified Wire.API.User.Search as Search
 
 tests :: T.TestTree
 tests =
@@ -47,7 +48,9 @@ tests =
       testToJSON @Prekey.PrekeyBundle,
       testToJSON @Prekey.ClientPrekey,
       testToJSON @(Client.QualifiedUserClientMap (Maybe Prekey.Prekey)),
-      testToJSON @Client.QualifiedUserClients
+      testToJSON @Client.QualifiedUserClients,
+      testToJSON @Search.Contact,
+      testToJSON @(Search.SearchResult Search.Contact)
     ]
 
 testToJSON :: forall a. (Arbitrary a, Typeable a, ToJSON a, ToSchema a, Show a) => T.TestTree

--- a/libs/wire-api/test/unit/Test/Wire/API/User/Search.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/User/Search.hs
@@ -1,0 +1,24 @@
+module Test.Wire.API.User.Search where
+
+import Data.Aeson (encode, toJSON)
+import qualified Data.Aeson as Aeson
+import qualified Data.HashMap.Strict as HashMap
+import Data.String.Conversions (cs)
+import Imports
+import qualified Test.Tasty as T
+import Test.Tasty.QuickCheck (counterexample, testProperty)
+import Wire.API.User.Search (Contact)
+
+tests :: T.TestTree
+tests = T.testGroup "Search" [searchResultBackwardsCompatibility]
+
+searchResultBackwardsCompatibility :: T.TestTree
+searchResultBackwardsCompatibility =
+  testProperty
+    "Contact always contains id"
+    $ \(c :: Contact) ->
+      let prop =
+            case toJSON c of
+              Aeson.Object o -> "id" `elem` HashMap.keys o
+              _ -> False
+       in counterexample ("This json doesn't contain 'id': \n" <> cs (encode c)) prop

--- a/libs/wire-api/test/unit/Test/Wire/API/User/Search.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/User/Search.hs
@@ -1,3 +1,20 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
 module Test.Wire.API.User.Search where
 
 import Data.Aeson (encode, toJSON)

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d226cd42f64696f109ecd24028399adba016e6ef413e11fdef8a720d0f895612
+-- hash: b0062afade680bb271c22de71f4e64c9e2fba01a00b1319536910a5fc866e8d6
 
 name:           wire-api
 version:        0.1.0
@@ -132,6 +132,7 @@ test-suite wire-api-tests
       Test.Wire.API.Team.Member
       Test.Wire.API.User
       Test.Wire.API.User.RichInfo
+      Test.Wire.API.User.Search
       Paths_wire_api
   hs-source-dirs:
       test/unit
@@ -146,6 +147,7 @@ test-suite wire-api-tests
     , containers >=0.5
     , imports
     , lens
+    , string-conversions
     , swagger2
     , tasty
     , tasty-expected-failure

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ea8a15344ea9b64dfcd0a9688dc6f9865929148d9372ded633097ad38920745d
+-- hash: 8b1bf9b0f4a61cc416d891351b1ed1c83620d9df719acf06b0213543ee162774
 
 name:           brig
 version:        1.35.0
@@ -330,6 +330,8 @@ executable brig-integration
     , lens-aeson
     , metrics-wai
     , mime >=0.4
+    , mu-grpc-server
+    , mu-rpc
     , network
     , optparse-applicative
     , pem
@@ -364,6 +366,7 @@ executable brig-integration
     , warp
     , warp-tls >=3.2
     , wire-api
+    , wire-api-federation
     , yaml
     , zauth
   default-language: Haskell2010

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 60a597a6684aa4798b13f3f4e72b929bda0fe91ddbb77a06cdf5ac7d34f01293
+-- hash: ea8a15344ea9b64dfcd0a9688dc6f9865929148d9372ded633097ad38920745d
 
 name:           brig
 version:        1.35.0
@@ -87,6 +87,7 @@ library
       Brig.Template
       Brig.Unique
       Brig.User.API.Auth
+      Brig.User.API.Handle
       Brig.User.API.Search
       Brig.User.Auth
       Brig.User.Auth.Cookie

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8b1bf9b0f4a61cc416d891351b1ed1c83620d9df719acf06b0213543ee162774
+-- hash: 80c573dfafbff131b59987222d2d3a08f8181b6b1855157ac341c06fed15d722
 
 name:           brig
 version:        1.35.0
@@ -287,6 +287,7 @@ executable brig-integration
       API.User.Util
       API.UserPendingActivation
       Federation.User
+      Federation.Util
       Index.Create
       Util
       Util.AWS

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 80c573dfafbff131b59987222d2d3a08f8181b6b1855157ac341c06fed15d722
+-- hash: 8aa3470f92c5ea954371a93f42b7564fcf446e389fed9bcc5907348de6aa133d
 
 name:           brig
 version:        1.35.0
@@ -286,7 +286,7 @@ executable brig-integration
       API.User.RichInfo
       API.User.Util
       API.UserPendingActivation
-      Federation.User
+      Federation.End2end
       Federation.Util
       Index.Create
       Util

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -209,6 +209,8 @@ executables:
     - metrics-wai
     - mime >=0.4
     - MonadRandom >= 0.5
+    - mu-grpc-server
+    - mu-rpc
     - network
     - optparse-applicative
     - pem
@@ -244,6 +246,7 @@ executables:
     - warp
     - warp-tls >=3.2
     - wire-api
+    - wire-api-federation
     - yaml
     - zauth
   brig-index:

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -20,16 +20,18 @@ module Brig.API.Federation where
 import Brig.API.Error (handleNotFound, throwStd)
 import Brig.API.Handler (Handler)
 import qualified Brig.API.User as API
-import Data.Handle (Handle)
+import Brig.User.API.Handle
+import Data.Handle (Handle (..))
 import Imports
 import Servant (ServerT)
 import Servant.API.Generic (ToServantApi)
 import Servant.Server.Generic (genericServerT)
 import qualified Wire.API.Federation.API.Brig as FederationAPIBrig
 import Wire.API.User (UserProfile)
+import Wire.API.User.Search
 
 federationSitemap :: ServerT (ToServantApi FederationAPIBrig.Api) Handler
-federationSitemap = genericServerT (FederationAPIBrig.Api getUserByHandle)
+federationSitemap = genericServerT (FederationAPIBrig.Api getUserByHandle searchUsers)
 
 getUserByHandle :: Handle -> Handler UserProfile
 getUserByHandle handle = do
@@ -40,3 +42,28 @@ getUserByHandle handle = do
       lift (API.lookupProfilesOfLocalUsers Nothing [ownerId]) >>= \case
         [] -> throwStd handleNotFound
         user : _ -> pure user
+
+-- | Searching for federated users on a remote backend should
+-- only search by exact handle search, not in elasticsearch.
+-- (This decision may change in the future)
+searchUsers :: Text -> Handler (SearchResult Contact)
+searchUsers searchTerm = do
+  maybeOwnerId <- lift $ API.lookupHandle (Handle searchTerm)
+  exactLookupProfile <- case maybeOwnerId of
+    Nothing -> pure []
+    Just (foundUser) -> lift $ contactFromProfile <$$> API.lookupProfilesOfLocalUsers Nothing [foundUser]
+
+  let exactHandleMatchCount = length exactLookupProfile
+  pure $
+    SearchResult
+      { searchResults = exactLookupProfile,
+        searchFound = exactHandleMatchCount,
+        searchReturned = exactHandleMatchCount,
+        searchTook = 0
+      }
+
+-- FUTUREWORK(federation): currently these API types make use of the same types in the
+-- federation server-server API than the client-server API does. E.g.
+-- SearchResult Contact, or UserProfile.  This means changing these types in
+-- federation or in the client-server API without changing them on the other
+-- side may be tricky. Should new types be introduced for that flexibility?

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -253,7 +253,7 @@ type GetSelf =
 --   Doc.response 200 "Handle info" Doc.end
 --   Doc.errorResponse handleNotFound
 type GetHandleInfoUnqualified =
-  Summary "Get information on a user handle"
+  Summary "(deprecated, use search) Get information on a user handle"
     :> ZAuthServant
     :> "users"
     :> "handles"
@@ -266,7 +266,7 @@ type GetHandleInfoUnqualified =
 --   Doc.response 200 "Handle info" Doc.end
 --   Doc.errorResponse handleNotFound
 type GetUserByHandleQualfied =
-  Summary "Get information on a user handle"
+  Summary "(deprecated, use search) Get information on a user handle"
     :> ZAuthServant
     :> "users"
     :> "by-handle"

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -253,7 +253,7 @@ type GetSelf =
 --   Doc.response 200 "Handle info" Doc.end
 --   Doc.errorResponse handleNotFound
 type GetHandleInfoUnqualified =
-  Summary "(deprecated, use search) Get information on a user handle"
+  Summary "(deprecated, use /search/contacts) Get information on a user handle"
     :> ZAuthServant
     :> "users"
     :> "handles"
@@ -266,7 +266,7 @@ type GetHandleInfoUnqualified =
 --   Doc.response 200 "Handle info" Doc.end
 --   Doc.errorResponse handleNotFound
 type GetUserByHandleQualfied =
-  Summary "(deprecated, use search) Get information on a user handle"
+  Summary "(deprecated, use /search/contacts) Get information on a user handle"
     :> ZAuthServant
     :> "users"
     :> "by-handle"

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -41,7 +41,6 @@ import qualified Brig.API.Util as API
 import Brig.App
 import qualified Brig.Calling.API as Calling
 import qualified Brig.Data.User as Data
-import Brig.Federation.Client as Federation
 import Brig.Options hiding (internalEvents, sesQueue)
 import qualified Brig.Provider.API as Provider
 import qualified Brig.Team.API as Team
@@ -50,6 +49,7 @@ import Brig.Types.Activation (ActivationPair)
 import Brig.Types.Intra (AccountStatus (Ephemeral), UserAccount (UserAccount, accountUser))
 import Brig.Types.User (HavePendingInvitations (..), User (userId))
 import qualified Brig.User.API.Auth as Auth
+import qualified Brig.User.API.Handle as Handle
 import qualified Brig.User.API.Search as Search
 import qualified Brig.User.Auth.Cookie as Auth
 import Brig.User.Email
@@ -1353,7 +1353,7 @@ listUsersByIdsOrHandles self q = do
       domain <- viewFederationDomain
       let (_remoteHandles, localHandles) = partitionRemoteOrLocalIds domain (fromRange hs)
       us <- getIds localHandles
-      filterHandleResults self =<< byIds us
+      Handle.filterHandleResults self =<< byIds us
   case foundUsers of
     [] -> throwStd $ notFound "None of the specified ids or handles match any users"
     _ -> pure foundUsers
@@ -1444,31 +1444,10 @@ getHandleInfoUnqualifiedH self handle = do
 -- traffic between backends in a federated scenario.
 getUserByHandleH :: UserId -> Domain -> Handle -> Handler Public.UserProfile
 getUserByHandleH self domain handle = do
-  maybeProfile <- getHandleInfo self (Qualified handle domain)
+  maybeProfile <- Handle.getHandleInfo self (Qualified handle domain)
   case maybeProfile of
     Nothing -> throwStd handleNotFound
     Just u -> pure u
-
--- FUTUREWORK: use 'runMaybeT' to simplify this.
-getHandleInfo :: UserId -> Qualified Handle -> Handler (Maybe Public.UserProfile)
-getHandleInfo self handle = do
-  domain <- viewFederationDomain
-  if qDomain handle == domain
-    then getLocalHandleInfo domain
-    else getRemoteHandleInfo
-  where
-    getLocalHandleInfo domain = do
-      Log.info $ Log.msg $ Log.val "getHandleInfo - local lookup"
-      maybeOwnerId <- lift $ API.lookupHandle (qUnqualified handle)
-      case maybeOwnerId of
-        Nothing -> return Nothing
-        Just ownerId -> do
-          ownerProfile <- lift $ API.lookupProfile self (Qualified ownerId domain)
-          owner <- filterHandleResults self (maybeToList ownerProfile)
-          return $ listToMaybe owner
-    getRemoteHandleInfo = do
-      Log.info $ Log.msg (Log.val "getHandleInfo - remote lookup") Log.~~ Log.field "domain" (show (qDomain handle))
-      Federation.getUserHandleInfo handle
 
 changeHandleH :: UserId ::: ConnId ::: JsonRequest Public.HandleUpdate -> Handler Response
 changeHandleH (u ::: conn ::: req) = do
@@ -1643,15 +1622,3 @@ deprecatedCompletePasswordResetH (_ ::: k ::: req) = do
 
 ifNothing :: Utilities.Error -> Maybe a -> Handler a
 ifNothing e = maybe (throwStd e) return
-
--- | Checks search permissions and filters accordingly
-filterHandleResults :: UserId -> [Public.UserProfile] -> Handler [Public.UserProfile]
-filterHandleResults searchingUser us = do
-  sameTeamSearchOnly <- fromMaybe False <$> view (settings . searchSameTeamOnly)
-  if sameTeamSearchOnly
-    then do
-      fromTeam <- lift $ Data.lookupUserTeam searchingUser
-      return $ case fromTeam of
-        Just team -> filter (\x -> Public.profileTeam x == Just team) us
-        Nothing -> us
-    else return us

--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -22,6 +22,8 @@ module Brig.API.Util
     logInvitationCode,
     validateHandle,
     logEmail,
+    ZAuthServant,
+    InternalAuth
   )
 where
 
@@ -43,6 +45,43 @@ import Imports
 import System.Logger (Msg)
 import qualified System.Logger as Log
 import Util.Logging (sha256String)
+import Servant.Swagger (HasSwagger(..))
+import Servant hiding (Handler)
+import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
+import Data.Swagger (SecurityScheme(..), HasSecurityDefinitions (..), HasSecurity (..), SecurityRequirement(..), SecuritySchemeType (..), ApiKeyParams(..), ApiKeyLocation (..))
+import Control.Lens ((<>~))
+
+-- | This type exists for the special 'HasSwagger' and 'HasServer' instances. It
+-- shows the "Authorization" header in the swagger docs, but expects the
+-- "Z-Auth" header in the server. This helps keep the swagger docs usable
+-- through nginz.
+data ZAuthServant
+
+type InternalAuth = Header' '[Servant.Required, Servant.Strict] "Z-User" UserId
+
+instance HasSwagger api => HasSwagger (ZAuthServant :> api) where
+  toSwagger _ =
+    toSwagger (Proxy @api)
+      & securityDefinitions <>~ InsOrdHashMap.singleton "ZAuth" secScheme
+      & security <>~ [SecurityRequirement $ InsOrdHashMap.singleton "ZAuth" []]
+    where
+      secScheme =
+        SecurityScheme
+          { _securitySchemeType = SecuritySchemeApiKey (ApiKeyParams "Authorization" ApiKeyHeader),
+            _securitySchemeDescription = Just "Must be a token retrieved by calling 'POST /login' or 'POST /access'. It must be presented in this format: 'Bearer \\<token\\>'."
+          }
+
+instance
+  ( HasContextEntry (ctx .++ DefaultErrorFormatters) ErrorFormatters,
+    HasServer api ctx
+  ) =>
+  HasServer (ZAuthServant :> api) ctx
+  where
+  type ServerT (ZAuthServant :> api) m = ServerT (InternalAuth :> api) m
+
+  route _ = Servant.route (Proxy @(InternalAuth :> api))
+  hoistServerWithContext _ pc nt s =
+    Servant.hoistServerWithContext (Proxy @(InternalAuth :> api)) pc nt s
 
 lookupProfilesMaybeFilterSameTeamOnly :: UserId -> [UserProfile] -> Handler [UserProfile]
 lookupProfilesMaybeFilterSameTeamOnly self us = do

--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -23,7 +23,7 @@ module Brig.API.Util
     validateHandle,
     logEmail,
     ZAuthServant,
-    InternalAuth
+    InternalAuth,
   )
 where
 
@@ -34,22 +34,22 @@ import Brig.App (AppIO)
 import qualified Brig.Data.User as Data
 import Brig.Types
 import Brig.Types.Intra (accountUser)
+import Control.Lens ((<>~))
 import Control.Monad.Catch (throwM)
 import Control.Monad.Trans.Except (throwE)
 import Data.Handle (Handle, parseHandle)
+import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 import Data.Id
 import Data.Maybe
 import Data.String.Conversions (cs)
+import Data.Swagger (ApiKeyLocation (..), ApiKeyParams (..), HasSecurity (..), HasSecurityDefinitions (..), SecurityRequirement (..), SecurityScheme (..), SecuritySchemeType (..))
 import Data.Text.Ascii (AsciiText (toText))
 import Imports
+import Servant hiding (Handler)
+import Servant.Swagger (HasSwagger (..))
 import System.Logger (Msg)
 import qualified System.Logger as Log
 import Util.Logging (sha256String)
-import Servant.Swagger (HasSwagger(..))
-import Servant hiding (Handler)
-import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
-import Data.Swagger (SecurityScheme(..), HasSecurityDefinitions (..), HasSecurity (..), SecurityRequirement(..), SecuritySchemeType (..), ApiKeyParams(..), ApiKeyLocation (..))
-import Control.Lens ((<>~))
 
 -- | This type exists for the special 'HasSwagger' and 'HasServer' instances. It
 -- shows the "Authorization" header in the swagger docs, but expects the

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -69,7 +69,7 @@ mkFederatorClient :: Handler GrpcClient
 mkFederatorClient = do
   maybeFederatorEndpoint <- view federator
   federatorEndpoint <- case maybeFederatorEndpoint of
-    Nothing -> throwStd $ federationNotConfigured
+    Nothing -> throwStd federationNotConfigured
     Just ep -> pure ep
   let cfg = grpcClientConfigSimple (T.unpack (federatorEndpoint ^. epHost)) (fromIntegral (federatorEndpoint ^. epPort)) False
   eitherClient <- createGrpcClient cfg

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -24,9 +24,11 @@ module Brig.Federation.Client where
 import Brig.API.Error (federationNotConfigured, notFound, throwStd)
 import Brig.API.Handler (Handler)
 import Brig.App (federator)
+import qualified Brig.Types.Search as Public
 import Brig.Types.User
 import Control.Lens (view, (^.))
 import qualified Data.Aeson as Aeson
+import Data.Domain
 import Data.Handle
 import Data.Qualified
 import Data.String.Conversions
@@ -58,6 +60,11 @@ getUserHandleInfo (Qualified handle domain) = do
       Left err -> throwStd $ notFound $ "Failed to parse response: " <> LT.pack err
       Right x -> pure $ Just x
     code -> throwStd $ notFound $ "Invalid response from remote: " <> LT.pack (show code)
+
+search :: Domain -> Text -> Handler (Public.SearchResult Public.Contact)
+search _domain _searchTerm = do
+  Log.info $ Log.msg $ T.pack "Brig-federation: search call on remote backend"
+  throwStd $ notFound $ "TODO implement this"
 
 -- FUTUREWORK: It would be nice to share the client across all calls to
 -- federator and not call this function on every invocation of federated

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -61,10 +61,22 @@ getUserHandleInfo (Qualified handle domain) = do
       Right x -> pure $ Just x
     code -> throwStd $ notFound $ "Invalid response from remote: " <> LT.pack (show code)
 
-search :: Domain -> Text -> Handler (Public.SearchResult Public.Contact)
-search _domain _searchTerm = do
-  Log.info $ Log.msg $ T.pack "Brig-federation: search call on remote backend"
-  throwStd $ notFound $ "TODO implement this"
+-- TODO: reduce duplication between these functions
+-- TODO: rework error handling and FUTUREWORK from getUserHandleInfo and search:
+--       decoding error should not throw a 404 most likely
+--       and non-200, non-404 should also not become 404s. Looks like some tests are missing and
+--       https://wearezeta.atlassian.net/browse/SQCORE-491 is not quite done yet.
+searchUsers :: Domain -> Text -> Handler (Public.SearchResult Public.Contact)
+searchUsers domain searchTerm = do
+  Log.warn $ Log.msg $ T.pack "Brig-federation: search call on remote backend"
+  federatorClient <- mkFederatorClient
+  let call = Proto.ValidatedFederatedRequest domain (mkSearchUsers searchTerm)
+  res <- expectOk =<< callRemote federatorClient call
+  case Proto.responseStatus res of
+    200 -> case Aeson.eitherDecodeStrict (Proto.responseBody res) of
+      Left err -> throwStd $ notFound $ "Failed to parse response: " <> LT.pack err
+      Right x -> pure $ x
+    code -> throwStd $ notFound $ "Invalid response from remote: " <> LT.pack (show code)
 
 -- FUTUREWORK: It would be nice to share the client across all calls to
 -- federator and not call this function on every invocation of federated

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -61,8 +61,8 @@ getUserHandleInfo (Qualified handle domain) = do
       Right x -> pure $ Just x
     code -> throwStd $ notFound $ "Invalid response from remote: " <> LT.pack (show code)
 
--- TODO: reduce duplication between these functions
--- TODO: rework error handling and FUTUREWORK from getUserHandleInfo and search:
+-- FUTUREWORK(federation): reduce duplication between these functions
+-- FUTUREWORK(federation): rework error handling and FUTUREWORK from getUserHandleInfo and search:
 --       decoding error should not throw a 404 most likely
 --       and non-200, non-404 should also not become 404s. Looks like some tests are missing and
 --       https://wearezeta.atlassian.net/browse/SQCORE-491 is not quite done yet.

--- a/services/brig/src/Brig/User/API/Handle.hs
+++ b/services/brig/src/Brig/User/API/Handle.hs
@@ -1,4 +1,10 @@
-module Brig.User.API.Handle (getHandleInfo, getLocalHandleInfo, filterHandleResults) where
+module Brig.User.API.Handle
+  ( getHandleInfo,
+    getLocalHandleInfo,
+    filterHandleResults,
+    contactFromProfile,
+  )
+where
 
 import Brig.API.Handler (Handler)
 import qualified Brig.API.User as API
@@ -7,33 +13,36 @@ import qualified Brig.Data.User as Data
 import qualified Brig.Federation.Client as Federation
 import Brig.Options (searchSameTeamOnly)
 import Control.Lens (view)
-import Data.Domain
-import Data.Handle (Handle)
+import Data.Handle (Handle, fromHandle)
 import Data.Id (UserId)
 import Data.Qualified (Qualified (..))
 import Imports
 import qualified System.Logger.Class as Log
+import Wire.API.User
 import qualified Wire.API.User as Public
+import Wire.API.User.Search
+import qualified Wire.API.User.Search as Public
 
 -- FUTUREWORK: use 'runMaybeT' to simplify this.
 getHandleInfo :: UserId -> Qualified Handle -> Handler (Maybe Public.UserProfile)
 getHandleInfo self handle = do
   domain <- viewFederationDomain
   if qDomain handle == domain
-    then getLocalHandleInfo self domain (qUnqualified handle)
+    then getLocalHandleInfo self (qUnqualified handle)
     else getRemoteHandleInfo
   where
     getRemoteHandleInfo = do
       Log.info $ Log.msg (Log.val "getHandleInfo - remote lookup") Log.~~ Log.field "domain" (show (qDomain handle))
       Federation.getUserHandleInfo handle
 
-getLocalHandleInfo :: UserId -> Domain -> Handle -> Handler (Maybe Public.UserProfile)
-getLocalHandleInfo self domain handle = do
+getLocalHandleInfo :: UserId -> Handle -> Handler (Maybe Public.UserProfile)
+getLocalHandleInfo self handle = do
   Log.info $ Log.msg $ Log.val "getHandleInfo - local lookup"
   maybeOwnerId <- lift $ API.lookupHandle handle
   case maybeOwnerId of
     Nothing -> return Nothing
     Just ownerId -> do
+      domain <- viewFederationDomain
       ownerProfile <- lift $ API.lookupProfile self (Qualified ownerId domain)
       owner <- filterHandleResults self (maybeToList ownerProfile)
       return $ listToMaybe owner
@@ -49,3 +58,13 @@ filterHandleResults searchingUser us = do
         Just team -> filter (\x -> Public.profileTeam x == Just team) us
         Nothing -> us
     else return us
+
+contactFromProfile :: Public.UserProfile -> Public.Contact
+contactFromProfile profile =
+  Contact
+    { contactQualifiedId = profileQualifiedId profile,
+      contactName = fromName $ profileName profile,
+      contactHandle = fromHandle <$> profileHandle profile,
+      contactColorId = Just . fromIntegral . fromColourId $ profileAccentId profile,
+      contactTeam = profileTeam profile
+    }

--- a/services/brig/src/Brig/User/API/Handle.hs
+++ b/services/brig/src/Brig/User/API/Handle.hs
@@ -1,0 +1,48 @@
+module Brig.User.API.Handle (getHandleInfo, filterHandleResults) where
+
+import Brig.API.Handler (Handler)
+import qualified Brig.API.User as API
+import Brig.App (settings, viewFederationDomain)
+import qualified Brig.Data.User as Data
+import qualified Brig.Federation.Client as Federation
+import Brig.Options (searchSameTeamOnly)
+import Control.Lens (view)
+import Data.Handle (Handle)
+import Data.Id (UserId)
+import Data.Qualified (Qualified (..))
+import Imports
+import qualified System.Logger.Class as Log
+import qualified Wire.API.User as Public
+
+-- FUTUREWORK: use 'runMaybeT' to simplify this.
+getHandleInfo :: UserId -> Qualified Handle -> Handler (Maybe Public.UserProfile)
+getHandleInfo self handle = do
+  domain <- viewFederationDomain
+  if qDomain handle == domain
+    then getLocalHandleInfo domain
+    else getRemoteHandleInfo
+  where
+    getLocalHandleInfo domain = do
+      Log.info $ Log.msg $ Log.val "getHandleInfo - local lookup"
+      maybeOwnerId <- lift $ API.lookupHandle (qUnqualified handle)
+      case maybeOwnerId of
+        Nothing -> return Nothing
+        Just ownerId -> do
+          ownerProfile <- lift $ API.lookupProfile self (Qualified ownerId domain)
+          owner <- filterHandleResults self (maybeToList ownerProfile)
+          return $ listToMaybe owner
+    getRemoteHandleInfo = do
+      Log.info $ Log.msg (Log.val "getHandleInfo - remote lookup") Log.~~ Log.field "domain" (show (qDomain handle))
+      Federation.getUserHandleInfo handle
+
+-- | Checks search permissions and filters accordingly
+filterHandleResults :: UserId -> [Public.UserProfile] -> Handler [Public.UserProfile]
+filterHandleResults searchingUser us = do
+  sameTeamSearchOnly <- fromMaybe False <$> view (settings . searchSameTeamOnly)
+  if sameTeamSearchOnly
+    then do
+      fromTeam <- lift $ Data.lookupUserTeam searchingUser
+      return $ case fromTeam of
+        Just team -> filter (\x -> Public.profileTeam x == Just team) us
+        Nothing -> us
+    else return us

--- a/services/brig/src/Brig/User/API/Handle.hs
+++ b/services/brig/src/Brig/User/API/Handle.hs
@@ -1,3 +1,20 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
 module Brig.User.API.Handle
   ( getHandleInfo,
     getLocalHandleInfo,

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -133,6 +133,18 @@ routesInternal = do
 
 -- Handlers
 
+-- search ::
+--   if remoteDomain -> remoteSearch
+--   else localSearch
+
+-- (create /i/localSearch)
+-- localSearch::
+--   handleSearch
+--   ESSearch
+-- (create /i/remoteSearch)
+-- remoteSearch
+--
+
 search :: UserId -> Text -> Maybe Domain -> Maybe (Range 1 500 Int32) -> Handler (Public.SearchResult Public.Contact)
 search searcherId searchTerm maybeDomain maybeMaxResults = do
   let maxResults = maybe 15 (fromIntegral . fromRange) maybeMaxResults

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -153,18 +153,21 @@ search searcherId searchTerm maybeMaxResults = do
   (toPrepend, esMaxResults) <- do
     exactHandleResult <- contactFromProfile <$$> exactHandleMatch
     pure $ case teamSearchInfo of
-      Search.TeamOnly t -> if Just t == (contactTeam =<< exactHandleResult)
-        then (maybeToList exactHandleResult, maxResults - 1)
-        else ([], maxResults)
+      Search.TeamOnly t ->
+        if Just t == (contactTeam =<< exactHandleResult)
+          then (maybeToList exactHandleResult, maxResults - 1)
+          else ([], maxResults)
       _ -> (maybeToList exactHandleResult, maxResults - length exactHandleResult)
   esResult <-
     if esMaxResults > 0
-    then Q.searchIndex searcherId teamSearchInfo searchTerm esMaxResults
-    else pure $ SearchResult 0 0 0 []
-  pure $ esResult { searchResults = toPrepend <> searchResults esResult
-                  , searchFound = length toPrepend + searchFound esResult
-                  , searchReturned = length toPrepend + searchReturned esResult
-                  }
+      then Q.searchIndex searcherId teamSearchInfo searchTerm esMaxResults
+      else pure $ SearchResult 0 0 0 []
+  pure $
+    esResult
+      { searchResults = toPrepend <> searchResults esResult,
+        searchFound = length toPrepend + searchFound esResult,
+        searchReturned = length toPrepend + searchReturned esResult
+      }
   where
     handleTeamVisibility :: TeamId -> TeamSearchVisibility -> Search.TeamSearchInfo
     handleTeamVisibility t Team.SearchVisibilityStandard = Search.TeamAndNonMembers t

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -156,7 +156,7 @@ searchRemotely domain searchTerm = do
     msg (val "searchRemotely")
       ~~ field "domain" (show domain)
       ~~ field "searchTerm" searchTerm
-  Federation.search domain searchTerm
+  Federation.searchUsers domain searchTerm
 
 searchLocally :: UserId -> Text -> Maybe (Range 1 500 Int32) -> Handler (Public.SearchResult Public.Contact)
 searchLocally searcherId searchTerm maybeMaxResults = do

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -198,8 +198,8 @@ search searcherId searchTerm maybeDomain maybeMaxResults = do
       pure $ case teamSearchInfo of
         Search.TeamOnly t ->
           if Just t == (contactTeam =<< exactHandleResult)
-          then exactHandleResult
-          else Nothing
+            then exactHandleResult
+            else Nothing
         _ -> exactHandleResult
 
 teamUserSearchH ::

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -146,11 +146,9 @@ search searcherId searchTerm maybeDomain maybeMaxResults = do
       esMaxResults = maxResults - exactHandleMatchCount
 
   esResult <-
-    -- We don't want to do a local search if domain is not local. FUTUREWORK:
-    -- This is not tested as it is not easy to do so right now. We should either
-    -- figure out how to mock external communication in integration tests or
-    -- refactor this code to make it unit testable.
-    if esMaxResults > 0 || searchedDomain == localDomain
+    -- We don't want to do a search in ES if domain is not same as current
+    -- backend domain.
+    if esMaxResults > 0 && searchedDomain == localDomain
       then Q.searchIndex searcherId teamSearchInfo searchTerm esMaxResults
       else pure $ SearchResult 0 0 0 []
 

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -152,7 +152,7 @@ search searcherId searchTerm maybeDomain maybeMaxResults = do
 
 searchRemotely :: Domain -> Text -> Handler (Public.SearchResult Public.Contact)
 searchRemotely domain searchTerm = do
-  Log.warn $
+  Log.info $
     msg (val "searchRemotely")
       ~~ field "domain" (show domain)
       ~~ field "searchTerm" searchTerm

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -136,12 +136,8 @@ routesInternal = do
 
 -- Handlers
 
--- TODO question: would it make sense to create a second endpoint with a mandatory domain?
--- That would make it easier in the future to see from logs whether the old endpoint is still in use or can be removed.
---
--- FUTUREWORK: Consider augmenting 'SearchResult' with full user profiles either
--- for only the exact handle match or for all results or for the first X results.
--- See also https://wearezeta.atlassian.net/browse/SQCORE-599
+-- FUTUREWORK: Consider augmenting 'SearchResult' with full user profiles
+-- for all results. This is tracked in https://wearezeta.atlassian.net/browse/SQCORE-599
 search :: UserId -> Text -> Maybe Domain -> Maybe (Range 1 500 Int32) -> Handler (Public.SearchResult Public.Contact)
 search searcherId searchTerm maybeDomain maybeMaxResults = do
   federationDomain <- viewFederationDomain

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -23,6 +23,7 @@ module Brig.User.API.Search
   )
 where
 
+import Brig.API.Error (fedError)
 import Brig.API.Handler
 import Brig.API.Util (ZAuthServant)
 import Brig.App
@@ -50,6 +51,7 @@ import Imports
 import Network.Wai (Response)
 import Network.Wai.Predicate hiding (setStatus)
 import Network.Wai.Routing
+import Network.Wai.Utilities ((!>>))
 import Network.Wai.Utilities.Response (empty, json)
 import Network.Wai.Utilities.Swagger (document)
 import Servant hiding (Handler, JSON)
@@ -152,7 +154,7 @@ searchRemotely domain searchTerm = do
     msg (val "searchRemotely")
       ~~ field "domain" (show domain)
       ~~ field "searchTerm" searchTerm
-  Federation.searchUsers domain searchTerm
+  Federation.searchUsers domain searchTerm !>> fedError
 
 searchLocally :: UserId -> Text -> Maybe (Range 1 500 Int32) -> Handler (Public.SearchResult Public.Contact)
 searchLocally searcherId searchTerm maybeMaxResults = do

--- a/services/brig/src/Brig/User/Search/SearchIndex.hs
+++ b/services/brig/src/Brig/User/Search/SearchIndex.hs
@@ -123,10 +123,10 @@ defaultUserQuery u teamSearchInfo (normalized -> term') =
                 [ ES.QueryBoolQuery
                     boolQuery
                       { ES.boolQueryShouldMatch = [matchPhraseOrPrefix, legacyPrefixMatch],
+                        -- This removes exact handle matches, as they are fetched from cassandra
                         ES.boolQueryMustNotMatch = [termQ "handle" term']
                       }
                 ],
-              -- This removes exact handle matches, as they are fetched from cassandra
               ES.boolQueryShouldMatch = [ES.QueryExistsQuery (ES.FieldName "handle")]
             }
       -- This reduces relevance on non-team users by 90%, there was no science

--- a/services/brig/test/integration/API/Federation.hs
+++ b/services/brig/test/integration/API/Federation.hs
@@ -36,8 +36,8 @@ tests :: Manager -> Brig -> IO TestTree
 tests m brig = do
   return $
     testGroup "federation" $
-      [ test m "GET /federation/search/users : 200" (testSearchSuccess brig),
-        test m "GET /federation/search/users : 404" (testSearchNotFound brig),
+      [ test m "GET /federation/search/users : Found" (testSearchSuccess brig),
+        test m "GET /federation/search/users : NotFound" (testSearchNotFound brig),
         test m "GET /federation/users/by-handle : 200" (testGetUserByHandleSuccess brig),
         test m "GET /federation/users/by-handle : 404" (testGetUserByHandleNotFound brig)
       ]

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -28,6 +28,7 @@ import API.Search.Util
 import API.Team.Util
 import API.User.Util
 import Bilge
+import Bilge.Assert ((!!!), (===))
 import qualified Brig.Options as Opt
 import Brig.Types
 import Control.Lens ((.~), (?~), (^.))
@@ -35,10 +36,11 @@ import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Retry
 import Data.Aeson (FromJSON, Value, decode, (.=))
 import qualified Data.Aeson as Aeson
+import Data.Domain (Domain (Domain))
 import Data.Handle (fromHandle)
 import Data.Id
 import qualified Data.Map.Strict as Map
-import Data.Qualified (Qualified (qUnqualified, qDomain))
+import Data.Qualified (Qualified (qDomain, qUnqualified))
 import Data.String.Conversions (cs)
 import qualified Data.Text as Text
 import qualified Database.Bloodhound as ES
@@ -52,8 +54,6 @@ import Text.RawString.QQ (r)
 import UnliftIO (Concurrently (..), runConcurrently)
 import Util
 import Wire.API.Team.Feature (TeamFeatureStatusValue (..))
-import Data.Domain (Domain(Domain))
-import Bilge.Assert ((!!!), (===))
 
 tests :: Opt.Opts -> Manager -> Galley -> Brig -> IO TestTree
 tests opts mgr galley brig = do
@@ -417,8 +417,8 @@ testRemoteLookup brig = do
   assertCanFindWithDomain brig searcherId searcheeQid searcheeName searcheeDomain
   -- We cannot assert on a real federated request here, so we make a request to
   -- some server which doesn't have an SRV record and expect a 422.
-  searchRequest brig searcherId searcheeName (Just $ Domain "non-existent.example.com") Nothing !!!
-    const 422 === statusCode
+  searchRequest brig searcherId searcheeName (Just $ Domain "non-existent.example.com") Nothing
+    !!! const 422 === statusCode
 
 -- | Migration sequence:
 -- 1. A migration is planned, in this time brig writes to two indices

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -434,6 +434,9 @@ testSearchWithDomain brig = do
       searcheeDomain = qDomain searcheeQid
   assertCanFindWithDomain brig searcherId searcheeQid searcheeName searcheeDomain
 
+-- | WARNING: this test only tests that brig will indeed make a call to federator
+-- (i.e. does the correct if/else branching based on the domain),
+-- it does not test any of the federation API details. This needs to be tested separately.
 testSearchOtherDomain :: TestConstraints m => Opt.Opts -> Brig -> m ()
 testSearchOtherDomain opts brig = do
   user <- randomUser brig

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -113,8 +113,10 @@ tests opts mgr galley brig = do
           ],
         testGroup "federated" $
           [ test mgr "search passing own domain" $ testSearchWithDomain brig,
-            test mgr "remote lookup should call remote code path" $ testSearchOtherDomain opts brig,
-            test mgr "remote lookup federator -> brig" $ testTheActualApi brig
+            test mgr "remote lookup should call remote code path" $ testSearchOtherDomain opts brig
+            -- FUTUREWORK(federation): we need tests for:
+            -- failure/error cases on search (augment the federatorMock?)
+            -- wire-api-federation Servant-Api vs protobuf-client interactions
           ]
       ]
   where
@@ -448,10 +450,6 @@ testSearchOtherDomain opts brig = do
     executeSearchWithDomain brig (userId user) "someSearchText" (Domain "non-existent.example.com")
   liftIO $ do
     assertEqual "The search request should get its result from federator" otherSearchResult results
-
-testTheActualApi :: TestConstraints m => Brig -> m ()
-testTheActualApi _brig = do
-  liftIO $ assertEqual "Reminder that all other tests pass but the wire-api-federation (Wire.API.Federation.API.Brig) implementation is WRONG and UNTESTED so far" True False
 
 -- | Migration sequence:
 -- 1. A migration is planned, in this time brig writes to two indices

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -30,15 +30,12 @@ import API.Search.Util
 import API.Team.Util
 import API.User.Util
 import Bilge
-import Bilge.Assert ((!!!), (===))
 import qualified Brig.Options as Opt
 import Brig.Types
-import qualified Control.Concurrent.Async as Async
-import Control.Exception (finally, throwIO)
 import Control.Lens ((.~), (?~), (^.))
-import Control.Monad.Catch (MonadCatch, MonadThrow, bracket, try)
+import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Retry
-import Data.Aeson (FromJSON, Value, decode, (.=))
+import Data.Aeson (FromJSON, Value, decode)
 import qualified Data.Aeson as Aeson
 import Data.Domain (Domain (Domain))
 import Data.Handle (fromHandle)
@@ -49,17 +46,9 @@ import Data.String.Conversions (cs)
 import qualified Data.Text as Text
 import qualified Database.Bloodhound as ES
 import Federation.Util
-import Foreign.C.Error (Errno (..), eCONNREFUSED)
-import GHC.IO.Exception (IOException (ioe_errno))
 import qualified Galley.Types.Teams.SearchVisibility as Team
 import Imports
-import Mu.GRpc.Server (msgProtoBuf, runGRpcApp)
-import Mu.Server (ServerErrorIO, SingleServerT)
-import qualified Mu.Server as Mu
 import qualified Network.HTTP.Client as HTTP
-import Network.Socket
-import Network.Wai.Handler.Warp (Port)
-import Network.Wai.Test (Session)
 import qualified Network.Wai.Test as WaiTest
 import Test.QuickCheck (Arbitrary (arbitrary), generate)
 import Test.Tasty
@@ -67,8 +56,7 @@ import Test.Tasty.HUnit
 import Text.RawString.QQ (r)
 import UnliftIO (Concurrently (..), runConcurrently)
 import Util
-import Util.Options (Endpoint (Endpoint))
-import Wire.API.Federation.GRPC.Types (FederatedRequest, HTTPResponse (HTTPResponse), Outward, OutwardResponse (OutwardResponseError, OutwardResponseHTTPResponse))
+import Wire.API.Federation.GRPC.Types
 import Wire.API.Team.Feature (TeamFeatureStatusValue (..))
 
 tests :: Opt.Opts -> Manager -> Galley -> Brig -> IO TestTree

--- a/services/brig/test/integration/API/Search/Util.hs
+++ b/services/brig/test/integration/API/Search/Util.hs
@@ -23,6 +23,7 @@ import Brig.Types
 import Control.Monad.Catch (MonadCatch)
 import Data.ByteString.Conversion (toByteString')
 import Data.ByteString.Conversion.To (toByteString)
+import Data.Domain (Domain)
 import Data.Id
 import Data.Qualified (Qualified (..))
 import Data.String.Conversions (cs)
@@ -33,21 +34,28 @@ import Util
 import Wire.API.User.Search (RoleFilter (..), TeamContact (..), TeamUserSearchSortBy, TeamUserSearchSortOrder)
 
 executeSearch :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Text -> m (SearchResult Contact)
-executeSearch = executeSearchWithSize Nothing
+executeSearch brig self term = executeSearch' brig self term Nothing Nothing
 
-executeSearchWithSize :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Maybe Int -> Brig -> UserId -> Text -> m (SearchResult Contact)
-executeSearchWithSize maybeSize brig self q = do
+executeSearchWithDomain :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Text -> Domain -> m (SearchResult Contact)
+executeSearchWithDomain brig self term domain = executeSearch' brig self term (Just domain) Nothing
+
+executeSearch' :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Text -> Maybe Domain -> Maybe Int -> m (SearchResult Contact)
+executeSearch' brig self q maybeDomain maybeSize = do
   r <-
-    get
-      ( brig
-          . path "/search/contacts"
-          . zUser self
-          . queryItem "q" (encodeUtf8 q)
-          . maybe id (queryItem "size" . toByteString') maybeSize
-      )
-      <!! const 200
-      === statusCode
+    searchRequest brig self q maybeDomain maybeSize
+      <!! const 200 === statusCode
   responseJsonError r
+
+searchRequest :: (MonadIO m, MonadHttp m) => Brig -> UserId -> Text -> Maybe Domain -> Maybe Int -> m ResponseLBS
+searchRequest brig self q maybeDomain maybeSize = do
+  get
+    ( brig
+        . path "/search/contacts"
+        . zUser self
+        . queryItem "q" (encodeUtf8 q)
+        . maybe id (queryItem "domain" . toByteString') maybeDomain
+        . maybe id (queryItem "size" . toByteString') maybeSize
+    )
 
 -- | ES is only refreshed occasionally; we don't want to wait for that in tests.
 refreshIndex :: (Monad m, MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> m ()
@@ -75,9 +83,25 @@ assertCanFind brig self expected q = do
     assertBool ("User not in results for query: " <> show q) $
       expected `elem` map contactQualifiedId r
 
+assertCanFindWithDomain :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Qualified UserId -> Text -> Domain -> m ()
+assertCanFindWithDomain brig self expected q domain = do
+  r <- searchResults <$> executeSearchWithDomain brig self q domain
+  liftIO $ do
+    assertBool ("No results for query: " <> show q) $
+      not (null r)
+    assertBool ("User not in results for query: " <> show q) $
+      expected `elem` map contactQualifiedId r
+
 assertCan'tFind :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Qualified UserId -> Text -> m ()
 assertCan'tFind brig self expected q = do
   r <- searchResults <$> executeSearch brig self q
+  liftIO $ do
+    assertBool ("User shouldn't be present in results for query: " <> show q) $
+      expected `notElem` map contactQualifiedId r
+
+assertCan'tFindWithDomain :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Qualified UserId -> Text -> Domain -> m ()
+assertCan'tFindWithDomain brig self expected q domain = do
+  r <- searchResults <$> executeSearchWithDomain brig self q domain
   liftIO $ do
     assertBool ("User shouldn't be present in results for query: " <> show q) $
       expected `notElem` map contactQualifiedId r

--- a/services/brig/test/integration/API/Search/Util.hs
+++ b/services/brig/test/integration/API/Search/Util.hs
@@ -24,12 +24,12 @@ import Control.Monad.Catch (MonadCatch)
 import Data.ByteString.Conversion (toByteString')
 import Data.ByteString.Conversion.To (toByteString)
 import Data.Id
+import Data.Qualified (Qualified (..))
 import Data.String.Conversions (cs)
 import Data.Text.Encoding (encodeUtf8)
 import Imports
 import Test.Tasty.HUnit
 import Util
-import Data.Qualified (Qualified(..))
 import Wire.API.User.Search (RoleFilter (..), TeamContact (..), TeamUserSearchSortBy, TeamUserSearchSortOrder)
 
 executeSearch :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Text -> m (SearchResult Contact)

--- a/services/brig/test/integration/API/Search/Util.hs
+++ b/services/brig/test/integration/API/Search/Util.hs
@@ -33,13 +33,17 @@ import Data.Qualified (Qualified(..))
 import Wire.API.User.Search (RoleFilter (..), TeamContact (..), TeamUserSearchSortBy, TeamUserSearchSortOrder)
 
 executeSearch :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Text -> m (SearchResult Contact)
-executeSearch brig self q = do
+executeSearch = executeSearchWithSize Nothing
+
+executeSearchWithSize :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Maybe Int -> Brig -> UserId -> Text -> m (SearchResult Contact)
+executeSearchWithSize maybeSize brig self q = do
   r <-
     get
       ( brig
           . path "/search/contacts"
           . zUser self
           . queryItem "q" (encodeUtf8 q)
+          . maybe id (queryItem "size" . toByteString') maybeSize
       )
       <!! const 200
       === statusCode

--- a/services/brig/test/integration/API/Search/Util.hs
+++ b/services/brig/test/integration/API/Search/Util.hs
@@ -56,30 +56,27 @@ reindex brig =
 
 assertCanFindByName :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> User -> User -> m ()
 assertCanFindByName brig self expected =
-  assertCanFind brig (userId self) (userId expected) (fromName $ userDisplayName expected)
+  assertCanFind brig (userId self) (userQualifiedId expected) (fromName $ userDisplayName expected)
 
 assertCan'tFindByName :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> User -> User -> m ()
 assertCan'tFindByName brig self expected =
-  assertCan'tFind brig (userId self) (userId expected) (fromName $ userDisplayName expected)
+  assertCan'tFind brig (userId self) (userQualifiedId expected) (fromName $ userDisplayName expected)
 
-assertCanFind :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> UserId -> Text -> m ()
+assertCanFind :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Qualified UserId -> Text -> m ()
 assertCanFind brig self expected q = do
   r <- searchResults <$> executeSearch brig self q
   liftIO $ do
     assertBool ("No results for query: " <> show q) $
       not (null r)
     assertBool ("User not in results for query: " <> show q) $
-      expected `elem` (map contactUserId r)
+      expected `elem` map contactQualifiedId r
 
-assertCan'tFind :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> UserId -> Text -> m ()
+assertCan'tFind :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Qualified UserId -> Text -> m ()
 assertCan'tFind brig self expected q = do
   r <- searchResults <$> executeSearch brig self q
   liftIO $ do
     assertBool ("User shouldn't be present in results for query: " <> show q) $
-      expected `notElem` map contactUserId r
-
-contactUserId :: Contact -> UserId
-contactUserId = qUnqualified . contactQualifiedId
+      expected `notElem` map contactQualifiedId r
 
 executeTeamUserSearch ::
   (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) =>

--- a/services/brig/test/integration/API/Search/Util.hs
+++ b/services/brig/test/integration/API/Search/Util.hs
@@ -29,6 +29,7 @@ import Data.Text.Encoding (encodeUtf8)
 import Imports
 import Test.Tasty.HUnit
 import Util
+import Data.Qualified (Qualified(..))
 import Wire.API.User.Search (RoleFilter (..), TeamContact (..), TeamUserSearchSortBy, TeamUserSearchSortOrder)
 
 executeSearch :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Text -> m (SearchResult Contact)
@@ -76,6 +77,9 @@ assertCan'tFind brig self expected q = do
   liftIO $ do
     assertBool ("User shouldn't be present in results for query: " <> show q) $
       expected `notElem` map contactUserId r
+
+contactUserId :: Contact -> UserId
+contactUserId = qUnqualified . contactQualifiedId
 
 executeTeamUserSearch ::
   (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) =>

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -15,7 +15,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Federation.User where
+module Federation.End2end where
 
 import API.Search.Util
 import Bilge (Http, Manager)
@@ -45,7 +45,7 @@ spec :: BrigOpts.Opts -> Manager -> Brig -> Endpoint -> Brig -> IO TestTree
 spec _brigOpts mg brig _federator brigTwo =
   pure $
     testGroup
-      "brig-federation-user"
+      "federation-end2end-user"
       [ test mg "lookup user by qualified handle on remote backend" $ testHandleLookup brig brigTwo,
         test mg "search users on remote backend" $ testSearchUsers brig brigTwo
       ]
@@ -88,14 +88,3 @@ testSearchUsers brig brigTwo = do
   -- exercises multi-backend network traffic
   liftIO $ putStrLn "search for user on brigOne via federators to remote brig..."
   assertCanFindWithDomain brig searcher expectedUserId searchTerm domain
-
-createUserWithHandle :: Brig -> Http (Handle, User)
-createUserWithHandle brig = do
-  u <- randomUser brig
-  h <- randomHandle
-  void $ putHandle brig (userId u) h
-  userWithHandle <- selfUser <$> getSelfProfile brig (userId u)
-  -- Verify if creating user and setting handle succeeded
-  let handle = fromJust (userHandle userWithHandle)
-  liftIO $ assertEqual "creating user with handle should return handle" h (fromHandle handle)
-  pure (handle, userWithHandle)

--- a/services/brig/test/integration/Federation/User.hs
+++ b/services/brig/test/integration/Federation/User.hs
@@ -17,6 +17,7 @@
 
 module Federation.User where
 
+import API.Search.Util
 import Bilge (Http, Manager)
 import qualified Brig.Options as BrigOpts
 import Brig.Types
@@ -35,7 +36,7 @@ import Util.Options (Endpoint)
 -- these more end-to-end integration test serve as a way to test the overall
 -- network flow
 --
--- FUTUREWORK(federation): Add tests for these scenarios:
+-- FUTUREWORK(federation): Add tests for these scenarios (but not here in end2end, but in unit/1-backend-integration tests):
 -- - Remote discovery fails
 -- - Remote discovery succeeds but server doesn't exist
 -- - Remote federator fails to respond in many ways (protocol error, timeout, etc.)
@@ -45,7 +46,8 @@ spec _brigOpts mg brig _federator brigTwo =
   pure $
     testGroup
       "brig-federation-user"
-      [ test mg "lookup user by qualified handle on remote backend" $ testHandleLookup brig brigTwo
+      [ test mg "lookup user by qualified handle on remote backend" $ testHandleLookup brig brigTwo,
+        test mg "search users on remote backend" $ testSearchUsers brig brigTwo
       ]
 
 -- | Path covered by this test:
@@ -58,24 +60,42 @@ testHandleLookup :: Brig -> Brig -> Http ()
 testHandleLookup brig brigTwo = do
   -- Create a user on the "other side" using an internal brig endpoint from a
   -- second brig instance in backendTwo (in another namespace in kubernetes)
-  u <- randomUser brigTwo
-  h <- randomHandle
-  void $ putHandle brigTwo (userId u) h
-
-  -- Verify if creating user and setting handle succeeded
-  self <- selfUser <$> getSelfProfile brigTwo (userId u)
-  let handle = fromJust (userHandle self)
-  liftIO $ assertEqual "creating user with handle should return handle" h (fromHandle handle)
-
+  (handle, userBrigTwo) <- createUserWithHandle brigTwo
   -- Get result from brig two for comparison
-  let domain = qDomain $ userQualifiedId self
+  let domain = qDomain $ userQualifiedId userBrigTwo
   resultViaBrigTwo <- getUserInfoFromHandle brigTwo domain handle
 
   -- query the local-namespace brig for a user sitting on the other backend
-  -- which should involve the following network traffic:
-  --
-  -- brig-integration -> brig -> federator -> fed2-federator -> fed2-brig
-  -- (and back)
+  -- (which will exercise the network traffic via two federators to the remote brig)
   resultViaBrigOne <- getUserInfoFromHandle brig domain handle
-  liftIO $ assertEqual "remote handle lookup via federator should work in the happy case" (profileQualifiedId resultViaBrigOne) (userQualifiedId u)
+
+  liftIO $ assertEqual "remote handle lookup via federator should work in the happy case" (profileQualifiedId resultViaBrigOne) (userQualifiedId userBrigTwo)
   liftIO $ assertEqual "querying brig1 or brig2 about the same user should give same result" resultViaBrigTwo resultViaBrigOne
+
+testSearchUsers :: Brig -> Brig -> Http ()
+testSearchUsers brig brigTwo = do
+  -- Create a user on the "other side" using an internal brig endpoint from a
+  -- second brig instance in backendTwo (in another namespace in kubernetes)
+  (handle, userBrigTwo) <- createUserWithHandle brigTwo
+
+  searcher <- userId <$> randomUser brig
+  let expectedUserId = userQualifiedId userBrigTwo
+      searchTerm = (fromHandle handle)
+      domain = (qDomain expectedUserId)
+  liftIO $ putStrLn "search for user on brigTwo (directly)..."
+  assertCanFindWithDomain brigTwo searcher expectedUserId searchTerm domain
+
+  -- exercises multi-backend network traffic
+  liftIO $ putStrLn "search for user on brigOne via federators to remote brig..."
+  assertCanFindWithDomain brig searcher expectedUserId searchTerm domain
+
+createUserWithHandle :: Brig -> Http (Handle, User)
+createUserWithHandle brig = do
+  u <- randomUser brig
+  h <- randomHandle
+  void $ putHandle brig (userId u) h
+  userWithHandle <- selfUser <$> getSelfProfile brig (userId u)
+  -- Verify if creating user and setting handle succeeded
+  let handle = fromJust (userHandle userWithHandle)
+  liftIO $ assertEqual "creating user with handle should return handle" h (fromHandle handle)
+  pure (handle, userWithHandle)

--- a/services/brig/test/integration/Federation/Util.hs
+++ b/services/brig/test/integration/Federation/Util.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Federation.Util where
+
+import Bilge
+import qualified Brig.Options as Opt
+import Brig.Types
+import qualified Control.Concurrent.Async as Async
+import Control.Exception (finally, throwIO)
+import Control.Lens ((.~), (?~), (^.))
+import Control.Monad.Catch (MonadCatch, MonadThrow, bracket, try)
+import Control.Retry
+import Data.Aeson (FromJSON, Value, decode, (.=))
+import qualified Data.Aeson as Aeson
+import Data.Domain (Domain (Domain))
+import Data.Handle (fromHandle)
+import Data.Id
+import qualified Data.Map.Strict as Map
+import Data.Qualified (Qualified (qDomain, qUnqualified))
+import Data.String.Conversions (cs)
+import qualified Data.Text as Text
+import qualified Database.Bloodhound as ES
+import Foreign.C.Error (Errno (..), eCONNREFUSED)
+import GHC.IO.Exception (IOException (ioe_errno))
+import qualified Galley.Types.Teams.SearchVisibility as Team
+import Imports
+import Mu.GRpc.Server (msgProtoBuf, runGRpcApp)
+import Mu.Server (ServerErrorIO, SingleServerT)
+import qualified Mu.Server as Mu
+import qualified Network.HTTP.Client as HTTP
+import Network.Socket
+import Network.Wai.Handler.Warp (Port)
+import Network.Wai.Test (Session)
+import qualified Network.Wai.Test as WaiTest
+import Test.QuickCheck (Arbitrary (arbitrary), generate)
+import Test.Tasty
+import Test.Tasty.HUnit
+import Text.RawString.QQ (r)
+import UnliftIO (Concurrently (..), runConcurrently)
+import Util
+import Util.Options (Endpoint (Endpoint))
+import Wire.API.Federation.GRPC.Types (FederatedRequest, HTTPResponse (HTTPResponse), Outward, OutwardResponse (OutwardResponseError, OutwardResponseHTTPResponse))
+import Wire.API.Team.Feature (TeamFeatureStatusValue (..))
+
+-- | Starts a grpc server which will return the 'OutwardResponse' passed to this
+-- function, and makes the action passed to this function run in a modified brig
+-- which will contact this mocked federator instead of a real federator.
+withMockFederator :: forall (m :: * -> *) a. MonadIO m => Opt.Opts -> Port -> OutwardResponse -> Session a -> m a
+withMockFederator opts p res action = do
+  federatorThread <- liftIO . Async.async $ runGRpcApp msgProtoBuf p (outwardService res)
+  void $ retryWhileN 5 id isPortOpen
+  liftIO $
+    (withSettingsOverrides newOpts action)
+      `finally` (Async.cancel federatorThread)
+  where
+    newOpts :: Opt.Opts
+    newOpts = opts {Opt.federatorInternal = Just (Endpoint "127.0.0.1" (fromIntegral p))}
+
+    isPortOpen :: m Bool
+    isPortOpen = liftIO $ do
+      let sockAddr = SockAddrInet (fromIntegral p) (tupleToHostAddress (127, 0, 0, 1))
+      bracket (socket AF_INET Stream 6 {- TCP -}) close' $ \sock -> do
+        portRes <- try $ connect sock sockAddr
+        case portRes of
+          Right () -> return True
+          Left e ->
+            if (Errno <$> ioe_errno e) == Just eCONNREFUSED
+              then return False
+              else throwIO e
+
+outwardService :: OutwardResponse -> SingleServerT info Outward ServerErrorIO _
+outwardService response = Mu.singleService (Mu.method @"call" (callOutward response))
+
+callOutward :: OutwardResponse -> FederatedRequest -> ServerErrorIO OutwardResponse
+callOutward res _ = pure res

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -41,7 +41,7 @@ import Data.Metrics.Test (pathsConsistencyCheck)
 import Data.Metrics.WaiRoute (treeToPaths)
 import Data.Text.Encoding (encodeUtf8)
 import Data.Yaml (decodeFileEither)
-import qualified Federation.User
+import qualified Federation.End2end
 import Imports hiding (local)
 import qualified Index.Create
 import Network.HTTP.Client.TLS (tlsManagerSettings)
@@ -120,7 +120,7 @@ runTests iConf brigOpts otherArgs = do
   createIndex <- Index.Create.spec brigOpts
   browseTeam <- TeamUserSearch.tests brigOpts mg g b
   userPendingActivation <- UserPendingActivation.tests brigOpts mg db b g s
-  federationUser <- Federation.User.spec brigOpts mg b f brigTwo
+  federationEnd2End <- Federation.End2end.spec brigOpts mg b f brigTwo
   federationEndpoints <- API.Federation.tests mg b
   includeFederationTests <- (== Just "1") <$> Blank.getEnv "INTEGRATION_FEDERATION_TESTS"
   withArgs otherArgs . defaultMain $
@@ -143,7 +143,7 @@ runTests iConf brigOpts otherArgs = do
           browseTeam,
           federationEndpoints
         ]
-        <> [federationUser | includeFederationTests]
+        <> [federationEnd2End | includeFederationTests]
   where
     mkRequest (Endpoint h p) = host (encodeUtf8 h) . port p
 

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -47,7 +47,7 @@ import Data.ByteString.Char8 (pack)
 import qualified Data.ByteString.Char8 as C8
 import Data.ByteString.Conversion
 import Data.Domain (Domain, domainText, mkDomain)
-import Data.Handle (Handle)
+import Data.Handle (Handle (..))
 import Data.Id
 import Data.List1 (List1)
 import qualified Data.List1 as List1
@@ -433,6 +433,17 @@ putHandle brig usr h =
       . zConn "conn"
   where
     payload = RequestBodyLBS . encode $ object ["handle" .= h]
+
+createUserWithHandle :: Brig -> Http (Handle, User)
+createUserWithHandle brig = do
+  u <- randomUser brig
+  h <- randomHandle
+  void $ putHandle brig (userId u) h
+  userWithHandle <- selfUser <$> getSelfProfile brig (userId u)
+  -- Verify if creating user and setting handle succeeded
+  let handle = fromJust (userHandle userWithHandle)
+  liftIO $ assertEqual "creating user with handle should return handle" h (fromHandle handle)
+  pure (handle, userWithHandle)
 
 getUserInfoFromHandle ::
   (MonadIO m, MonadCatch m, MonadFail m, MonadHttp m, HasCallStack) =>

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -443,6 +443,9 @@ createUserWithHandle brig = do
   -- Verify if creating user and setting handle succeeded
   let handle = fromJust (userHandle userWithHandle)
   liftIO $ assertEqual "creating user with handle should return handle" h (fromHandle handle)
+  -- We return the handle separately in this function for convenience
+  -- of not needing to de-maybe-ify the user handle field of the user object
+  -- when using this function.
   pure (handle, userWithHandle)
 
 getUserInfoFromHandle ::


### PR DESCRIPTION
Fixes https://wearezeta.atlassian.net/browse/SQCORE-563

Pending:

* [x] Enable doing federated exact handle search
* [x] Mark `/users/by-handle/:domain/:handle` endpoint as deprecated (can we delete it already?)