### PR TITLE
hack/bin/integration-cleanup.sh: Use jq magic instead of bash

### DIFF
--- a/hack/bin/filter-old-releases.jq
+++ b/hack/bin/filter-old-releases.jq
@@ -1,0 +1,9 @@
+.[]
+  | .parsedUpdatedTime = ( .updated
+                         | sub("(?<time>.*)\\.[\\d]+(?<tz>.*)"; "\(.time)\(.tz)")
+                         | strptime("%Y-%m-%d %H:%M:%S %z %Z")
+                         | mktime
+                         )
+  | select ( .parsedTime < (now - 3 * 60 * 60))
+  | [.name, .namespace]
+  | @tsv

--- a/hack/bin/filter-old-releases.jq
+++ b/hack/bin/filter-old-releases.jq
@@ -4,6 +4,6 @@
                          | strptime("%Y-%m-%d %H:%M:%S %z %Z")
                          | mktime
                          )
-  | select ( .parsedTime < (now - 3 * 60 * 60))
+  | select ( .parsedUpdatedTime < (now - 3 * 60 * 60))
   | [.name, .namespace]
   | @tsv

--- a/hack/bin/integration-cleanup.sh
+++ b/hack/bin/integration-cleanup.sh
@@ -4,31 +4,15 @@
 #
 # Motivation: cleanup of old test clusters that were not deleted (e.g. by the CI system, because it broke)
 
-date_seconds() {
-  d=$1
-  if [[ $OSTYPE =~ darwin* ]]; then
-    date -j -f "%b %d %H:%M:%S %Y" "$date_str" +"%s"
-  else
-    date -d "$d" +"%s"
-  fi
-}
+set -euo pipefail
 
-date_now=$(date +"%s")
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TOP_LEVEL="$DIR/../.."
 
-# Since helm only shows information as hard-to-parse text pending https://github.com/kubernetes/helm/pull/2950
-# we are stuck with brittle grep/awk magic.
-
-IFS=$'\n'
-for release in $(helm list -A | grep test-); do
-  name=$(echo "$release" | awk '{print $1}')
-  namespace=$(echo "$release" | awk '{print $2}')
-  date_str=$(echo "$release" | awk '{print $4" "$5" "$6}')
-  date_s=$(date_seconds "$date_str")
-  diff=$(( $date_now - $date_s ))
-  if [ $diff -ge 7200 ]; then
-    echo "test release '$name' older than 2 hours; deleting..."
+releases=$(helm list -A -f 'test-' -o json \
+               | jq -r -f "$DIR/filter-old-releases.jq")
+while read line; do
+    name=$(awk '{print $1}' <<<"$line")
+    namespace=$(awk '{print $2}' <<<"$line")
     helm delete -n "$namespace" "$name"
-  fi
-
-done
-unset IFS
+done <<<"$releases"

--- a/hack/bin/integration-cleanup.sh
+++ b/hack/bin/integration-cleanup.sh
@@ -14,5 +14,6 @@ releases=$(helm list -A -f 'test-' -o json \
 while read line; do
     name=$(awk '{print $1}' <<<"$line")
     namespace=$(awk '{print $2}' <<<"$line")
+    echo "test release '$name' older than 2 hours; deleting..."
     helm delete -n "$namespace" "$name"
 done <<<"$releases"

--- a/hack/bin/integration-cleanup.sh
+++ b/hack/bin/integration-cleanup.sh
@@ -6,14 +6,18 @@
 
 set -euo pipefail
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-TOP_LEVEL="$DIR/../.."
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-releases=$(helm list -A -f 'test-' -o json \
-               | jq -r -f "$DIR/filter-old-releases.jq")
-while read line; do
-    name=$(awk '{print $1}' <<<"$line")
-    namespace=$(awk '{print $2}' <<<"$line")
-    echo "test release '$name' older than 2 hours; deleting..."
-    helm delete -n "$namespace" "$name"
-done <<<"$releases"
+releases=$(helm list -A -f 'test-' -o json |
+    jq -r -f "$DIR/filter-old-releases.jq")
+
+if [ -n "$releases" ]; then
+    while read -r line; do
+        name=$(awk '{print $1}' <<<"$line")
+        namespace=$(awk '{print $2}' <<<"$line")
+        echo "test release '$name' older than 2 hours; deleting..."
+        helm delete -n "$namespace" "$name"
+    done <<<"$releases"
+else
+    echo "Nothing to clean up."
+fi


### PR DESCRIPTION
For some reason the the bash expression to calculate time fails in CI and helm
now supports outputting json, so I swapped bash magic with jq magic. It more
robust, hopefully it is also more understandable.