### PR TITLE
Refactor Brig federation error handling

### DIFF
--- a/libs/wire-api-federation/package.yaml
+++ b/libs/wire-api-federation/package.yaml
@@ -15,6 +15,7 @@ dependencies:
 - QuickCheck >=2.13
 - aeson >=1.4
 - base >=4.6 && <5.0
+- bytestring-conversion
 - either
 - http-types
 - http2-client-grpc

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 543c75e131e7444c4c6cbb2e5b5045cd1a3a4da7e43b4bc90251bf308b224bf6
+-- hash: 61d775f3324bfa1e9bcfa85ff7a8cd7ff88ca5b2572db64fa29bca6c4175911c
 
 name:           wire-api-federation
 version:        0.1.0
@@ -40,6 +40,7 @@ library
       QuickCheck >=2.13
     , aeson >=1.4
     , base >=4.6 && <5.0
+    , bytestring-conversion
     , either
     , http-types
     , http2-client-grpc
@@ -72,6 +73,7 @@ test-suite spec
       QuickCheck >=2.13
     , aeson >=1.4
     , base >=4.6 && <5.0
+    , bytestring-conversion
     , either
     , hspec
     , http-types

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -171,7 +171,7 @@ claimPrekeyBundle domain uid = do
   if isLocalDomain
     then lift $ claimLocalPrekeyBundle uid
     else -- FUTUREWORK(federation, #1272): claim keys from other backend
-      throwE ClientFederationNotImplemented
+      throwE (ClientFedError FederationNotImplemented)
   where
     claimLocalPrekeyBundle :: UserId -> AppIO PrekeyBundle
     claimLocalPrekeyBundle u = do
@@ -184,7 +184,7 @@ claimMultiPrekeyBundles quc = do
   res <- forM (Map.toList . qualifiedUserClients $ quc) $ \(domain, userClients) -> do
     if domain == localDomain
       then (domain,) <$> lift (getLocal userClients)
-      else throwE ClientFederationNotImplemented
+      else throwE (ClientFedError FederationNotImplemented)
   pure $ (QualifiedUserClientMap . Map.fromList) res
   where
     getLocal :: UserClients -> AppIO (UserClientMap (Maybe Prekey))

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -171,7 +171,7 @@ claimPrekeyBundle domain uid = do
   if isLocalDomain
     then lift $ claimLocalPrekeyBundle uid
     else -- FUTUREWORK(federation, #1272): claim keys from other backend
-      throwE (ClientFedError FederationNotImplemented)
+      throwE (ClientFederationError FederationNotImplemented)
   where
     claimLocalPrekeyBundle :: UserId -> AppIO PrekeyBundle
     claimLocalPrekeyBundle u = do
@@ -184,7 +184,7 @@ claimMultiPrekeyBundles quc = do
   res <- forM (Map.toList . qualifiedUserClients $ quc) $ \(domain, userClients) -> do
     if domain == localDomain
       then (domain,) <$> lift (getLocal userClients)
-      else throwE (ClientFedError FederationNotImplemented)
+      else throwE (ClientFederationError FederationNotImplemented)
   pure $ (QualifiedUserClientMap . Map.fromList) res
   where
     getLocal :: UserClients -> AppIO (UserClientMap (Maybe Prekey))

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -77,7 +77,7 @@ lookupClient (Qualified uid domain) clientId = do
   if domain == localdomain
     then lift $ lookupLocalClient uid clientId
     else -- FUTUREWORK(federation, #1271): look up remote clients
-      throwE ClientFederationNotImplemented
+      throwE (ClientFederationError FederationNotImplemented)
 
 lookupLocalClient :: UserId -> ClientId -> AppIO (Maybe Client)
 lookupLocalClient = Data.lookupClient
@@ -88,7 +88,7 @@ lookupClients (Qualified uid domain) = do
   if domain == localdomain
     then lift $ lookupLocalClients uid
     else -- FUTUREWORK(federation, #1271): look up remote clients
-      throwE ClientFederationNotImplemented
+      throwE (ClientFederationError FederationNotImplemented)
 
 lookupLocalClients :: UserId -> AppIO [Client]
 lookupLocalClients = Data.lookupClients

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -182,8 +182,8 @@ clientError (ClientFederationError e) = fedError e
 
 fedError :: FederationError -> Error
 fedError (FederationRpcError msg) = StdError (federationRpcError msg)
-fedError (InvalidResponseCode code) = StdError (federationInvalidCode code)
-fedError (InvalidResponseBody msg) = StdError (federationInvalidBody msg)
+fedError (FederationInvalidResponseCode code) = StdError (federationInvalidCode code)
+fedError (FederationInvalidResponseBody msg) = StdError (federationInvalidBody msg)
 fedError (FederationRemoteError status label err) =
   StdError (federationRemoteError status label err)
 fedError (FederationUnavailable err) = StdError (federationUnavailable err)

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -513,6 +513,12 @@ customerExtensionBlockedDomain domain = Wai.Error (mkStatus 451 "Unavailable For
 noFederationStatus :: Status
 noFederationStatus = status403
 
+unexpectedFederationResponseStatus :: Status
+unexpectedFederationResponseStatus = HTTP.Status 533 "Unexpected Federation Response"
+
+federatorConnectionRefusedStatus :: Status
+federatorConnectionRefusedStatus = HTTP.Status 521 "Remote Federator Connection Refused"
+
 federationNotImplemented :: Wai.Error
 federationNotImplemented =
   Wai.Error
@@ -523,35 +529,35 @@ federationNotImplemented =
 federationInvalidCode :: Word32 -> Wai.Error
 federationInvalidCode code =
   Wai.Error
-    noFederationStatus
+    unexpectedFederationResponseStatus
     "federation-invalid-code"
     ("Invalid response code from remote federator: " <> LT.pack (show code))
 
 federationInvalidBody :: Text -> Wai.Error
 federationInvalidBody msg =
   Wai.Error
-    noFederationStatus
+    unexpectedFederationResponseStatus
     "federation-invalid-body"
     ("Could not parse remote federator response: " <> LT.fromStrict msg)
 
 federationNotConfigured :: Wai.Error
 federationNotConfigured =
   Wai.Error
-    noFederationStatus
+    HTTP.status400
     "federation-not-enabled"
     "no federator configured on brig"
 
 federationRpcError :: Text -> Wai.Error
 federationRpcError msg =
   Wai.Error
-    noFederationStatus
+    HTTP.status500
     "federation-rpc-error"
     (LT.fromStrict msg)
 
 federationUnavailable :: Text -> Wai.Error
 federationUnavailable err =
   Wai.Error
-    noFederationStatus
+    HTTP.status500
     "federation-not-available"
     ("Local federator not available: " <> LT.fromStrict err)
 
@@ -573,5 +579,5 @@ federationRemoteError err = Wai.Error status (LT.fromStrict label) (LT.fromStric
       Proto.VersionMismatch -> HTTP.Status 531 "Version Mismatch"
       Proto.FederationDeniedByRemote -> HTTP.Status 532 "Federation Denied"
       Proto.FederationDeniedLocally -> HTTP.status400
-      Proto.RemoteFederatorError -> HTTP.Status 533 "Unexpected Federation Response"
+      Proto.RemoteFederatorError -> unexpectedFederationResponseStatus
       Proto.InvalidRequest -> HTTP.status500

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -178,15 +178,15 @@ clientError (ClientDataError e) = clientDataError e
 clientError (ClientUserNotFound _) = StdError invalidUser
 clientError ClientLegalHoldCannotBeRemoved = StdError can'tDeleteLegalHoldClient
 clientError ClientLegalHoldCannotBeAdded = StdError can'tAddLegalHoldClient
-clientError (ClientFedError e) = fedError e
+clientError (ClientFederationError e) = fedError e
 
-fedError :: FedError -> Error
-fedError (FedRpcError msg) = StdError (federationRpcError msg)
+fedError :: FederationError -> Error
+fedError (FederationRpcError msg) = StdError (federationRpcError msg)
 fedError (InvalidResponseCode code) = StdError (federationInvalidCode code)
 fedError (InvalidResponseBody msg) = StdError (federationInvalidBody msg)
 fedError (FederationRemoteError status label err) =
   StdError (federationRemoteError status label err)
-fedError FederationUnavailable = StdError federationUnavailable
+fedError (FederationUnavailable err) = StdError (federationUnavailable err)
 fedError FederationNotImplemented = StdError federationNotImplemented'
 fedError FederationNotConfigured = StdError federationNotConfigured
 
@@ -574,12 +574,12 @@ federationRpcError msg =
     "federation-rpc-error"
     (LT.fromStrict msg)
 
-federationUnavailable :: Wai.Error
-federationUnavailable =
+federationUnavailable :: Text -> Wai.Error
+federationUnavailable err =
   Wai.Error
     noFederationStatus
     "federation-not-available"
-    "Local federator not available"
+    ("Local federator not available: " <> LT.fromStrict err)
 
 federationRemoteError :: Status -> Text -> Text -> Wai.Error
 federationRemoteError status label msg =

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -577,13 +577,13 @@ federationRpcError msg =
 federationUnavailable :: Wai.Error
 federationUnavailable =
   Wai.Error
-  noFederationStatus
-  "federation-not-available"
-  "Local federator not available"
+    noFederationStatus
+    "federation-not-available"
+    "Local federator not available"
 
 federationRemoteError :: Status -> Text -> Text -> Wai.Error
 federationRemoteError status label msg =
   Wai.Error
-  status
-  (LT.fromStrict label)
-  (LT.fromStrict msg)
+    status
+    (LT.fromStrict label)
+    (LT.fromStrict msg)

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -33,9 +33,9 @@ import qualified Data.ZAuth.Validation as ZAuth
 import Imports
 import Network.HTTP.Types.Header
 import Network.HTTP.Types.Status
+import qualified Network.HTTP.Types.Status as HTTP
 import qualified Network.Wai.Utilities.Error as Wai
 import qualified Wire.API.Federation.GRPC.Types as Proto
-import qualified Network.HTTP.Types.Status as HTTP
 
 data Error where
   StdError :: !Wai.Error -> Error
@@ -567,9 +567,9 @@ federationRemoteError err = Wai.Error status (LT.fromStrict label) (LT.fromStric
     decodeError :: Maybe Proto.ErrorPayload -> (Text, Text)
     decodeError Nothing = ("unknown-federation-error", "Unknown federation error")
     decodeError (Just (Proto.ErrorPayload label' msg')) = (label', msg')
-    
+
     (label, msg) = decodeError (Proto.outwardErrorPayload err)
-    
+
     status = case Proto.outwardErrorType err of
       Proto.RemoteNotFound -> HTTP.status422
       Proto.DiscoveryFailed -> HTTP.status500

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -185,13 +185,12 @@ data SendLoginCodeError
   = SendLoginInvalidPhone Phone
   | SendLoginPasswordExists
 
--- TODO: ok to use 'Fed' abbreviation?
-data FedError
-  = FedRpcError Text
+data FederationError
+  = FederationRpcError Text
   | InvalidResponseCode Word32
   | InvalidResponseBody Text
   | FederationRemoteError Status Text Text
-  | FederationUnavailable
+  | FederationUnavailable Text
   | FederationNotImplemented
   | FederationNotConfigured
 
@@ -201,7 +200,7 @@ data ClientError
   | ClientUserNotFound !OpaqueUserId
   | ClientLegalHoldCannotBeRemoved
   | ClientLegalHoldCannotBeAdded
-  | ClientFedError FedError
+  | ClientFederationError FederationError
 
 data RemoveIdentityError
   = LastIdentity

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -42,8 +42,8 @@ import Brig.Types.Intra
 import Brig.User.Auth.Cookie (RetryAfter (..))
 import Data.Id
 import Imports
-import Network.HTTP.Types.Status (Status)
 import qualified Network.Wai.Utilities.Error as Wai
+import qualified Wire.API.Federation.GRPC.Types as Proto
 
 -------------------------------------------------------------------------------
 -- Successes
@@ -189,7 +189,7 @@ data FederationError
   = FederationRpcError Text
   | FederationInvalidResponseCode Word32
   | FederationInvalidResponseBody Text
-  | FederationRemoteError Status Text Text
+  | FederationRemoteError Proto.OutwardError
   | FederationUnavailable Text
   | FederationNotImplemented
   | FederationNotConfigured

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -187,8 +187,8 @@ data SendLoginCodeError
 
 data FederationError
   = FederationRpcError Text
-  | InvalidResponseCode Word32
-  | InvalidResponseBody Text
+  | FederationInvalidResponseCode Word32
+  | FederationInvalidResponseBody Text
   | FederationRemoteError Status Text Text
   | FederationUnavailable Text
   | FederationNotImplemented

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -42,6 +42,7 @@ import Brig.Types.Intra
 import Brig.User.Auth.Cookie (RetryAfter (..))
 import Data.Id
 import Imports
+import Network.HTTP.Types.Status (Status)
 import qualified Network.Wai.Utilities.Error as Wai
 
 -------------------------------------------------------------------------------
@@ -184,13 +185,23 @@ data SendLoginCodeError
   = SendLoginInvalidPhone Phone
   | SendLoginPasswordExists
 
+-- TODO: ok to use 'Fed' abbreviation?
+data FedError
+  = FedRpcError Text
+  | InvalidResponseCode Word32
+  | InvalidResponseBody Text
+  | FederationRemoteError Status Text Text
+  | FederationUnavailable
+  | FederationNotImplemented
+  | FederationNotConfigured
+
 data ClientError
   = ClientNotFound
   | ClientDataError !ClientDataError
   | ClientUserNotFound !OpaqueUserId
   | ClientLegalHoldCannotBeRemoved
   | ClientLegalHoldCannotBeAdded
-  | ClientFederationNotImplemented
+  | ClientFedError FedError
 
 data RemoveIdentityError
   = LastIdentity

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -60,9 +60,9 @@ getUserHandleInfo (Qualified handle domain) = do
   case Proto.responseStatus res of
     404 -> pure Nothing
     200 -> case Aeson.eitherDecodeStrict (Proto.responseBody res) of
-      Left err -> throwE (InvalidResponseBody (T.pack err))
+      Left err -> throwE (FederationInvalidResponseBody (T.pack err))
       Right x -> pure $ Just x
-    code -> throwE (InvalidResponseCode code)
+    code -> throwE (FederationInvalidResponseCode code)
 
 -- FUTUREWORK: It would be nice to share the client across all calls to
 -- federator and not call this function on every invocation of federated

--- a/services/brig/test/integration/API/User/Handles.hs
+++ b/services/brig/test/integration/API/User/Handles.hs
@@ -272,8 +272,8 @@ testGetUserByQualifiedHandleNoFederation opt brig = do
           . zUser (userId someUser)
       )
       !!! do
-        const 403 === statusCode
-        const "Forbidden" === statusMessage
+        const 400 === statusCode
+        const "Bad Request" === statusMessage
         const (Right "federation-not-enabled") === fmap Wai.label . responseJsonEither
 
 assertCanFind :: (Monad m, MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> User -> User -> m ()


### PR DESCRIPTION
This changes the error handling of federated requests away from the `Handler` monad, so that the final conversion of errors to HTTP errors can keep happening at the level of the public API, while the lower level API (e.g. `Brig.API.Client`) can throw abstract errors (e.g. `ClientError`).