### PR TITLE
Update update-helm-charts-s3.sh arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,14 +334,14 @@ clean-charts:
 # (assummption: CI sets DOCKER_TAG and HELM_SEMVER)
 .PHONY: upload-chart-%
 upload-chart-%: release-chart-%
-	./hack/bin/upload-helm-charts-s3.sh .local/charts/$(*)
+	./hack/bin/upload-helm-charts-s3.sh -r $(HELM_REPO) -d .local/charts/$(*)
 
 # Usecases for this make target:
 # To uplaod all helm charts in the CHARTS_RELEASE list (see top of the time)
 # (assummption: CI sets DOCKER_TAG and HELM_SEMVER)
 .PHONY: upload-charts
 upload-charts: charts-release
-	./hack/bin/upload-helm-charts-s3.sh
+	./hack/bin/upload-helm-charts-s3.sh -r $(HELM_REPO)
 
 .PHONY: echo-release-charts
 echo-release-charts:

--- a/hack/bin/upload-helm-charts-s3.sh
+++ b/hack/bin/upload-helm-charts-s3.sh
@@ -45,8 +45,8 @@ done
 
 # defaults
 chart_dir=""
-REPO_NAME="wire-develop"
-PUBLIC_DIR="charts-develop"
+REPO_NAME="wire-custom"
+PUBLIC_DIR="charts-custom"
 force_push=""
 reindex=""
 


### PR DESCRIPTION
This PR changes `update-helm-charts-s3.sh `

- new option `-r <wire|wire-develop|wire-custom>` - this was derived from the branch beforehand
- new option `-d CHART_DIR` - this was a positional argument before

Tested: options parsing works.
Not tested: compatibility with uses of the script (CI, where else?)

Make sure to deploy https://github.com/wireapp/wire-server-private/pull/291 after this