### PR TITLE
shell.nix: Add wget

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -65,6 +65,7 @@ in pkgs.mkShell {
     pkgs.telepresence
     pkgs.jq
     pkgs.grpcurl
+    pkgs.wget
     pkgs.cfssl
 
     pinned.stack


### PR DESCRIPTION
Running SCIM test-suite requires wget.