### PR TITLE
Add originDomain to federation API

### DIFF
--- a/hack/federation/grpcurlhandle.sh
+++ b/hack/federation/grpcurlhandle.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
-command -v grpcurl >/dev/null 2>&1 || { echo >&2 "grpcurl is not installed, aborting. Maybe try ' nix-env -iA nixpkgs.grpcurl '?"; exit 1; }
+command -v grpcurl >/dev/null 2>&1 || {
+    echo >&2 "grpcurl is not installed, aborting. Maybe try ' nix-env -iA nixpkgs.grpcurl '?"
+    exit 1
+}
 
 path=$(echo -n users/by-handle | base64)
 body=$(echo -n "alice" | base64)
 
-TOP_LEVEL="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+TOP_LEVEL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 function getHandle() {
     echo ""
@@ -17,7 +20,7 @@ function getHandle() {
     fi
     set -x
     grpcurl -d @ -format json $AUTHORITY $MODE -import-path "${TOP_LEVEL}/libs/wire-api-federation/proto/" -proto router.proto "$HOST:$PORT" wire.federator.Inward/call <<EOM
-{"component": "Brig", "path": "$path", "body": "$body"}
+{"component": "Brig", "path": "$path", "body": "$body", "originDomain": "localhost"}
 EOM
     { set +x; } 2>/dev/null # stop outputting commands and don't print the set +x line
     echo "===|"

--- a/libs/wire-api-federation/proto/router.proto
+++ b/libs/wire-api-federation/proto/router.proto
@@ -68,6 +68,7 @@ message Request {
   Component component = 1;
   bytes path = 2; //Maybe this can be made into a 'function name'
   bytes body = 3;
+  string originDomain = 4;
 }
 
 // The federator actually listens on two ports and exposes two services:

--- a/libs/wire-api-federation/src/Wire/API/Federation/GRPC/Types.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/GRPC/Types.hs
@@ -135,7 +135,8 @@ data ErrorPayload = ErrorPayload
 data Request = Request
   { component :: Component,
     path :: ByteString,
-    body :: ByteString
+    body :: ByteString,
+    originDomain :: Text
   }
   deriving (Typeable, Eq, Show, Generic, ToSchema Router "Request", FromSchema Router "Request")
   deriving (Arbitrary) via (GenericUniform Request)

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -21,7 +21,7 @@
 module Brig.Federation.Client where
 
 import Brig.API.Types (FederationError (..))
-import Brig.App (AppIO, federator)
+import Brig.App (AppIO, federator, viewFederationDomain)
 import Brig.Types (Prekey, PrekeyBundle)
 import qualified Brig.Types.Search as Public
 import Brig.Types.User
@@ -101,7 +101,8 @@ mkFederatorClient = do
     >>= either (throwE . FederationUnavailable . reason) pure
 
 executeFederated :: Domain -> FederatorClient component (ExceptT FederationClientError FederationAppIO) a -> FederationAppIO a
-executeFederated domain action = do
+executeFederated targetDomain action = do
   federatorClient <- mkFederatorClient
-  runExceptT (runFederatorClientWith federatorClient domain action)
+  originDomain <- viewFederationDomain
+  runExceptT (runFederatorClientWith federatorClient targetDomain originDomain action)
     >>= either (throwE . FederationCallFailure) pure

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f25a24207c25fdeec7c300cfd5aeb3dc98e8cc26eeb6700f83174dd761b28022
+-- hash: 311e965abd7dff53117342bf9ff5ef71476466a786da53d80e80bef4dd69f317
 
 name:           federator
 version:        1.0.0
@@ -193,6 +193,7 @@ test-suite federator-tests
       Test.Federator.ExternalServer
       Test.Federator.InternalServer
       Test.Federator.Options
+      Test.Federator.Validation
       Paths_federator
   hs-source-dirs:
       test/unit

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 311e965abd7dff53117342bf9ff5ef71476466a786da53d80e80bef4dd69f317
+-- hash: 9a9d5df94719b8f46988169a22d8e7625aa61a6b91d79f5f9af0c4aa35fb1dcf
 
 name:           federator
 version:        1.0.0
@@ -27,8 +27,8 @@ library
       Federator.Options
       Federator.Remote
       Federator.Run
-      Federator.Util
       Federator.Utils.PolysemyServerError
+      Federator.Validation
   other-modules:
       Paths_federator
   hs-source-dirs:

--- a/services/federator/src/Federator/Discovery.hs
+++ b/services/federator/src/Federator/Discovery.hs
@@ -23,12 +23,12 @@ import Data.String.Conversions (cs)
 import Imports
 import qualified Network.DNS as DNS
 import Polysemy
-import Wire.Network.DNS.Effect (DNSLookup)
-import qualified Wire.Network.DNS.Effect as Lookup
-import Wire.Network.DNS.SRV (SrvEntry (srvTarget), SrvResponse (..), SrvTarget)
 import Polysemy.TinyLog (TinyLog)
 import qualified Polysemy.TinyLog as TinyLog
 import qualified System.Logger.Class as Log
+import Wire.Network.DNS.Effect (DNSLookup)
+import qualified Wire.Network.DNS.Effect as Lookup
+import Wire.Network.DNS.SRV (SrvEntry (srvTarget), SrvResponse (..), SrvTarget)
 
 data LookupError
   = LookupErrorSrvNotAvailable ByteString

--- a/services/federator/src/Federator/ExternalServer.hs
+++ b/services/federator/src/Federator/ExternalServer.hs
@@ -21,12 +21,15 @@
 
 module Federator.ExternalServer where
 
+import Control.Lens (view)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Federator.App (Federator, runAppT)
 import Federator.Brig (Brig, brigCall, interpretBrig)
-import Federator.Env (Env)
+import Federator.Env (Env, applog, runSettings)
+import Federator.Options (RunSettings)
+import Federator.Util
 import Federator.Utils.PolysemyServerError (absorbServerError)
 import Imports
 import Mu.GRpc.Server (msgProtoBuf, runGRpcAppTrans)
@@ -36,6 +39,10 @@ import qualified Network.HTTP.Types.Status as HTTP
 import Polysemy
 import qualified Polysemy.Error as Polysemy
 import Polysemy.IO (embedToMonadIO)
+import qualified Polysemy.Reader as Polysemy
+import Polysemy.TinyLog (TinyLog)
+import qualified Polysemy.TinyLog as Log
+import qualified System.Logger.Message as Log
 import Wire.API.Federation.GRPC.Types
 
 -- FUTUREWORK(federation): Versioning of the federation API. See
@@ -46,31 +53,44 @@ import Wire.API.Federation.GRPC.Types
 -- reached, some discussion here:
 -- https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/224166764/Limiting+access+to+federation+endpoints
 -- Also, see comment in 'Federator.Brig.interpretBrig'
-callLocal :: (Members '[Brig, Embed IO] r) => Request -> Sem r InwardResponse
-callLocal Request {..} = do
-  -- FUTUREWORK(federation): before making a request, check the sender domain and only make the call if the allowlist (use Util.federateWith) allows it.
-  (resStatus, resBody) <- brigCall path body
-  pure $ case HTTP.statusCode resStatus of
-    200 -> InwardResponseBody $ maybe mempty LBS.toStrict resBody
-    -- TODO: There is a unit test for this, but Akshay has seen the integration
-    -- test never sees InwardResponseErr, when the error is supposed to be
-    -- returned, the integration test just sees `InwardResponseBody` with empty
-    -- body. Maybe this is a bug in mu-haskell, maybe something is wrong with
-    -- our integration test, let's verify this.
-    code -> InwardResponseErr $ "Invalid HTTP status from component: " <> Text.pack (show code) <> " " <> Text.decodeUtf8 (HTTP.statusMessage resStatus)
+callLocal :: (Members '[Brig, Embed IO, TinyLog, Polysemy.Reader RunSettings] r) => Request -> Sem r InwardResponse
+callLocal req@Request {..} = do
+  Log.debug $
+    Log.msg ("Inward Request" :: ByteString)
+      . Log.field "request" (show req)
 
-routeToInternal :: (Members '[Brig, Embed IO, Polysemy.Error ServerError] r) => SingleServerT info Inward (Sem r) _
+  -- FUTUREWORK: implement server2server authentication!
+  -- (current validation only checks parsing and compares to allowList)
+  -- FUTUREWORK: would it make sense to have validations throw errors to reduce nesting and improve readability?
+  validation <- federateWith' originDomain
+
+  case validation of
+    Left err -> pure $ InwardResponseErr err
+    Right domain -> do
+      (resStatus, resBody) <- brigCall path body domain
+      pure $ case HTTP.statusCode resStatus of
+        200 -> InwardResponseBody $ maybe mempty LBS.toStrict resBody
+        -- TODO: There is a unit test for this, but Akshay has seen the integration
+        -- test never sees InwardResponseErr, when the error is supposed to be
+        -- returned, the integration test just sees `InwardResponseBody` with empty
+        -- body. Maybe this is a bug in mu-haskell, maybe something is wrong with
+        -- our integration test, let's verify this.
+        code -> InwardResponseErr $ "Invalid HTTP status from component: " <> Text.pack (show code) <> " " <> Text.decodeUtf8 (HTTP.statusMessage resStatus)
+
+routeToInternal :: (Members '[Brig, Embed IO, Polysemy.Error ServerError, TinyLog, Polysemy.Reader RunSettings] r) => SingleServerT info Inward (Sem r) _
 routeToInternal = singleService (Mu.method @"call" callLocal)
 
 serveInward :: Env -> Int -> IO ()
 serveInward env port = do
   runGRpcAppTrans msgProtoBuf port transformer routeToInternal
   where
-    transformer :: Sem '[Embed IO, Polysemy.Error ServerError, Brig, Embed Federator] a -> ServerErrorIO a
+    transformer :: Sem '[TinyLog, Embed IO, Polysemy.Error ServerError, Brig, Polysemy.Reader RunSettings, Embed Federator] a -> ServerErrorIO a
     transformer action =
       runAppT env
         . runM @Federator
+        . Polysemy.runReader (view runSettings env)
         . interpretBrig
         . absorbServerError
         . embedToMonadIO @Federator
+        . Log.runTinyLog (view applog env)
         $ action

--- a/services/federator/src/Federator/ExternalServer.hs
+++ b/services/federator/src/Federator/ExternalServer.hs
@@ -53,17 +53,18 @@ import Wire.API.Federation.GRPC.Types
 -- reached, some discussion here:
 -- https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/224166764/Limiting+access+to+federation+endpoints
 -- Also, see comment in 'Federator.Brig.interpretBrig'
+--
+-- FUTUREWORK(federation): implement server2server authentication!
+-- (current validation only checks parsing and compares to allowList)
+--
+-- FUTUREWORK: consider using Polysemy.Error also in callLocal to reduce nesting and improve readability.
 callLocal :: (Members '[Brig, Embed IO, TinyLog, Polysemy.Reader RunSettings] r) => Request -> Sem r InwardResponse
 callLocal req@Request {..} = do
   Log.debug $
     Log.msg ("Inward Request" :: ByteString)
       . Log.field "request" (show req)
 
-  -- FUTUREWORK: implement server2server authentication!
-  -- (current validation only checks parsing and compares to allowList)
-  -- FUTUREWORK: would it make sense to have validations throw errors to reduce nesting and improve readability?
   validation <- federateWith' originDomain
-
   case validation of
     Left err -> pure $ InwardResponseErr err
     Right domain -> do

--- a/services/federator/src/Federator/ExternalServer.hs
+++ b/services/federator/src/Federator/ExternalServer.hs
@@ -29,8 +29,8 @@ import Federator.App (Federator, runAppT)
 import Federator.Brig (Brig, brigCall, interpretBrig)
 import Federator.Env (Env, applog, runSettings)
 import Federator.Options (RunSettings)
-import Federator.Util
 import Federator.Utils.PolysemyServerError (absorbServerError)
+import Federator.Validation
 import Imports
 import Mu.GRpc.Server (msgProtoBuf, runGRpcAppTrans)
 import Mu.Server (ServerError, ServerErrorIO, SingleServerT, singleService)

--- a/services/federator/src/Federator/InternalServer.hs
+++ b/services/federator/src/Federator/InternalServer.hs
@@ -30,8 +30,8 @@ import Federator.Discovery (DiscoverFederator, LookupError (LookupErrorDNSError,
 import Federator.Env (Env, applog, dnsResolver, runSettings)
 import Federator.Options (RunSettings)
 import Federator.Remote (Remote, RemoteError (RemoteErrorClientFailure, RemoteErrorDiscoveryFailure), discoverAndCall, interpretRemote)
-import Federator.Util
 import Federator.Utils.PolysemyServerError (absorbServerError)
+import Federator.Validation
 import Imports
 import Mu.GRpc.Client.Record (GRpcReply (..))
 import Mu.GRpc.Server (msgProtoBuf, runGRpcAppTrans)

--- a/services/federator/src/Federator/Validation.hs
+++ b/services/federator/src/Federator/Validation.hs
@@ -15,7 +15,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Federator.Util -- TODO Validation
+module Federator.Validation
   ( federateWith,
     federateWith',
   )

--- a/services/federator/src/Federator/Validation.hs
+++ b/services/federator/src/Federator/Validation.hs
@@ -49,6 +49,7 @@ federateWith' targetDomain = Polysemy.runError $ do
     Polysemy.throw (errAllowList parsedDomain)
   pure parsedDomain
 
+-- FUTUREWORK: create error data types and adjust InwardResponseErr and OutwardResponseError
 errDomainParsing :: Text -> String -> Text
 errDomainParsing domain err = "Domain parse failure for [" <> domain <> "]: " <> cs err
 

--- a/services/federator/test/integration/Test/Federator/InwardSpec.hs
+++ b/services/federator/test/integration/Test/Federator/InwardSpec.hs
@@ -78,7 +78,7 @@ spec env =
         c <- case client of
           Left err -> liftIO $ assertFailure (show err)
           Right cli -> pure cli
-        let brigCall = Request Brig "federation/users/by-handle" (LBS.toStrict (encode hdl))
+        let brigCall = Request Brig "federation/users/by-handle" (LBS.toStrict (encode hdl)) "foo.example.com"
         res <- liftIO $ gRpcCall @'MsgProtoBuf @Inward @"Inward" @"call" c brigCall
 
         liftIO $ case res of

--- a/services/federator/test/unit/Main.hs
+++ b/services/federator/test/unit/Main.hs
@@ -28,7 +28,7 @@ import qualified Test.Federator.Validation as Validation
 import Test.Tasty
 
 main :: IO ()
-main = do
+main =
   defaultMain $
     testGroup
       "Tests"

--- a/services/federator/test/unit/Main.hs
+++ b/services/federator/test/unit/Main.hs
@@ -24,14 +24,16 @@ import Imports
 import qualified Test.Federator.ExternalServer
 import qualified Test.Federator.InternalServer
 import qualified Test.Federator.Options
+import qualified Test.Federator.Validation as Validation
 import Test.Tasty
 
 main :: IO ()
-main =
+main = do
   defaultMain $
     testGroup
       "Tests"
       [ Test.Federator.Options.tests,
+        Validation.tests,
         Test.Federator.InternalServer.tests,
         Test.Federator.ExternalServer.tests
       ]

--- a/services/federator/test/unit/Test/Federator/InternalServer.hs
+++ b/services/federator/test/unit/Test/Federator/InternalServer.hs
@@ -24,7 +24,6 @@ import Federator.Discovery (LookupError (LookupErrorDNSError, LookupErrorSrvNotA
 import Federator.InternalServer (callOutward)
 import Federator.Options (AllowedDomains (..), FederationStrategy (..), RunSettings (..))
 import Federator.Remote (Remote, RemoteError (RemoteErrorDiscoveryFailure))
-import Federator.Util
 import Imports
 import Mu.GRpc.Client.Record
 import Network.HTTP2.Client (TooMuchConcurrency (TooMuchConcurrency))
@@ -33,19 +32,15 @@ import qualified Polysemy.Reader as Polysemy
 import Test.Polysemy.Mock (Mock (mock), evalMock)
 import Test.Polysemy.Mock.TH (genMock)
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure, testCase)
+import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
 import Wire.API.Federation.GRPC.Types
 
 genMock ''Remote
 
 tests :: TestTree
 tests =
-  testGroup "Fedderate" $
-    [ testGroup "Util.federateWith" $
-        [ federateWithAllowListSuccess,
-          federateWithAllowListFail
-        ],
-      testGroup "with remote" $
+  testGroup "Federate" $
+    [ testGroup "with remote" $
         [ federatedRequestSuccess,
           federatedRequestFailureTMC,
           federatedRequestFailureErrCode,
@@ -164,22 +159,6 @@ federatedRequestFailureAllowList =
         assertEqual "no remote calls should be made" [] actualCalls
         assertResponseErrorWithType FederationDeniedLocally res
 
-federateWithAllowListSuccess :: TestTree
-federateWithAllowListSuccess =
-  testCase "should give True when target domain is in the list" $
-    runM . evalMock @Remote @IO $ do
-      let allowList = RunSettings (AllowList (AllowedDomains [Domain "hello.world"]))
-      res <- Polysemy.runReader allowList $ federateWith (Domain "hello.world")
-      embed $ assertBool "federating should be allowed" res
-
-federateWithAllowListFail :: TestTree
-federateWithAllowListFail =
-  testCase "should give False when target domain is not in the list" $
-    runM . evalMock @Remote @IO $ do
-      let allowList = RunSettings (AllowList (AllowedDomains [Domain "only.other.domain"]))
-      res <- Polysemy.runReader allowList $ federateWith (Domain "hello.world")
-      embed $ assertBool "federating should not be allowed" (not res)
-
 assertResponseErrorWithType :: HasCallStack => OutwardErrorType -> OutwardResponse -> IO ()
 assertResponseErrorWithType expectedType res =
   case res of
@@ -189,7 +168,7 @@ assertResponseErrorWithType expectedType res =
       assertEqual "Unexpected error type" expectedType actualType
 
 validLocalPart :: Request
-validLocalPart = Request Brig "/users" "\"foo\""
+validLocalPart = Request Brig "/users" "\"foo\"" "foo.domain"
 
 validDomainText :: Text
 validDomainText = "example.com"

--- a/services/federator/test/unit/Test/Federator/Validation.hs
+++ b/services/federator/test/unit/Test/Federator/Validation.hs
@@ -20,6 +20,8 @@
 module Test.Federator.Validation where
 
 import Data.Domain (Domain (..))
+import Data.Either.Combinators (mapLeft)
+import qualified Data.Text as Text
 import Federator.Options
 import Federator.Remote (Remote)
 import Federator.Util
@@ -70,6 +72,7 @@ federateWith'AllowListFailSemantic =
       let allowList = RunSettings (AllowList (AllowedDomains [Domain "only.other.domain"]))
       res <- Polysemy.runReader allowList $ federateWith' ("invalid//.><-semantic-&@-domain" :: Text)
       embed $ assertBool "invalid semantic domains should produce errors" (isLeft res)
+      embed $ assertEqual "semantic:" (Left ("Domain parse failure" :: Text)) (mapLeft (Text.take 20) res)
 
 federateWith'AllowListFail :: TestTree
 federateWith'AllowListFail =
@@ -78,6 +81,7 @@ federateWith'AllowListFail =
       let allowList = RunSettings (AllowList (AllowedDomains [Domain "only.other.domain"]))
       res <- Polysemy.runReader allowList $ federateWith' ("hello.world" :: Text)
       embed $ assertBool "federating should not be allowed" (isLeft res)
+      embed $ assertEqual "allow list:" (Left ("not in the federation allow list" :: Text)) (mapLeft (Text.takeEnd 32) res)
 
 federateWith'AllowListSuccess :: TestTree
 federateWith'AllowListSuccess =

--- a/services/federator/test/unit/Test/Federator/Validation.hs
+++ b/services/federator/test/unit/Test/Federator/Validation.hs
@@ -1,0 +1,90 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Federator.Validation where
+
+import Data.Domain (Domain (..))
+import Federator.Options
+import Federator.Remote (Remote)
+import Federator.Util
+import Imports
+import Polysemy (runM)
+import Polysemy.Embed
+import qualified Polysemy.Reader as Polysemy
+import Test.Federator.InternalServer ()
+import Test.Polysemy.Mock (evalMock)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+  testGroup "Validation" $
+    [ testGroup "federateWith" $
+        [ federateWithAllowListSuccess,
+          federateWithAllowListFail
+        ],
+      testGroup "federateWith'" $
+        [ federateWith'AllowListFailSemantic,
+          federateWith'AllowListFail,
+          federateWith'AllowListSuccess
+        ]
+    ]
+
+federateWithAllowListSuccess :: TestTree
+federateWithAllowListSuccess =
+  testCase "should give True when target domain is in the list" $
+    -- removing evalMock @Remote doesn't seem to work, but why?
+    runM . evalMock @Remote @IO $ do
+      let allowList = RunSettings (AllowList (AllowedDomains [Domain "hello.world"]))
+      res <- Polysemy.runReader allowList $ federateWith (Domain "hello.world")
+      embed $ assertBool "federating should be allowed" res
+
+federateWithAllowListFail :: TestTree
+federateWithAllowListFail =
+  testCase "should give False when target domain is not in the list" $
+    runM . evalMock @Remote @IO $ do
+      let allowList = RunSettings (AllowList (AllowedDomains [Domain "only.other.domain"]))
+      res <- Polysemy.runReader allowList $ federateWith (Domain "hello.world")
+      embed $ assertBool "federating should not be allowed" (not res)
+
+federateWith'AllowListFailSemantic :: TestTree
+federateWith'AllowListFailSemantic =
+  testCase "semantic validation" $
+    runM . evalMock @Remote @IO $ do
+      let allowList = RunSettings (AllowList (AllowedDomains [Domain "only.other.domain"]))
+      res <- Polysemy.runReader allowList $ federateWith' ("invalid//.><-semantic-&@-domain" :: Text)
+      embed $ assertBool "invalid semantic domains should produce errors" (isLeft res)
+
+federateWith'AllowListFail :: TestTree
+federateWith'AllowListFail =
+  testCase "allow list validation" $
+    runM . evalMock @Remote @IO $ do
+      let allowList = RunSettings (AllowList (AllowedDomains [Domain "only.other.domain"]))
+      res <- Polysemy.runReader allowList $ federateWith' ("hello.world" :: Text)
+      embed $ assertBool "federating should not be allowed" (isLeft res)
+
+federateWith'AllowListSuccess :: TestTree
+federateWith'AllowListSuccess =
+  testCase "should give parsed domain if in the allow list" $
+    -- removing evalMock @Remote doesn't seem to work, but why?
+    runM . evalMock @Remote @IO $ do
+      let domain = Domain "hello.world"
+      let allowList = RunSettings (AllowList (AllowedDomains [domain]))
+      res <- Polysemy.runReader allowList $ federateWith' ("hello.world" :: Text)
+      embed $ assertEqual "federateWith' should give 'hello.world' as domain" (Right domain) res

--- a/services/federator/test/unit/Test/Federator/Validation.hs
+++ b/services/federator/test/unit/Test/Federator/Validation.hs
@@ -24,7 +24,7 @@ import Data.Either.Combinators (mapLeft)
 import qualified Data.Text as Text
 import Federator.Options
 import Federator.Remote (Remote)
-import Federator.Util
+import Federator.Validation
 import Imports
 import Polysemy (runM)
 import Polysemy.Embed


### PR DESCRIPTION
To eventually support server-to-server authentication, the first step implemented in this PR is to add an originating domain to federated requests. At the moment this domain could be arbitrarily set (i.e. server2server authentication is not yet implemented here). But in this PR, some validation logic compares this domain to the allowList for incoming requests at federator level, if configured.

That domain can then in the future be used for:

* authenticating the domain with DNS/SRV or other means to validate that the request indeed comes from the claimed sender
* independent of authentication/authorization concerns, the domain may be required for any RPC calls that need to write data (e.g. to create a conversation).

In this PR, a field `originDomain` is added to the `Request` object in the protobuf definition, which is then turned into a `Wire-Origin-Domain` header when sending the call to a local component via plain http. 

FUTUREWORK subsequent PRs:

* [ ] Add an end2end test expecting a certain domain string header.