### PR TITLE
nginz: add apk installations to separate RUN task

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,8 @@
 **/target
 **/*.aci
 **/*.tgz
+.stack-work
+.stack-work-buildah
+.stack-root-buildah
+.local
 services/nginz/src/objs

--- a/services/nginz/Dockerfile
+++ b/services/nginz/Dockerfile
@@ -53,7 +53,7 @@ RUN apk add --no-cache --virtual .build-deps \
 
 ENV NGINX_VERSION 1.16.1
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk update && apk add --virtual .build-deps \
         libsodium-dev \
         llvm-libunwind-dev \
         gcc \

--- a/services/nginz/Dockerfile
+++ b/services/nginz/Dockerfile
@@ -53,11 +53,7 @@ RUN apk add --no-cache --virtual .build-deps \
 
 ENV NGINX_VERSION 1.16.1
 
-RUN set -x \
-    && addgroup -g 101 -S nginx \
-    && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
-    && export GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
-    && apk add --no-cache --virtual .build-deps \
+RUN apk add --no-cache --virtual .build-deps \
         libsodium-dev \
         llvm-libunwind-dev \
         gcc \
@@ -71,7 +67,14 @@ RUN set -x \
         gnupg1 \
         libxslt-dev \
         gd-dev \
-        geoip-dev \
+        geoip-dev
+
+RUN curl -h
+
+RUN set -x \
+    && addgroup -g 101 -S nginx \
+    && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
+    && export GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
     && curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
     && curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
     && found=''; \


### PR DESCRIPTION
nginz docker image has been flaky recently, and it seems the `apk add` command doesn't actually run (it says 'OK' but doesn't acutally install these packages; and then the next invocations using curl and gpg fail):

```
#13 0.260 + apk add --no-cache --virtual .build-deps libsodium-dev llvm-libunwind-dev gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-headers curl gnupg1 libxslt-dev gd-dev geoip-dev
#13 0.264 fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
#13 0.308 fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
#13 0.396 OK: 7 MiB in 20 packages
#13 0.408 + curl -fSL https://nginx.org/download/nginx-1.16.1.tar.gz -o nginx.tar.gz
```

This PR:

* adds `apk update` (which seems to render the thing less flaky) (or fix the problem??)
* separates the package installations from the rest and adds a `curl -h` task to make future failures more obvious of what the problem is.