### PR TITLE
CSV endpoint: Add columns to output

### DIFF
--- a/libs/wire-api/src/Wire/API/Team/Export.hs
+++ b/libs/wire-api/src/Wire/API/Team/Export.hs
@@ -46,7 +46,7 @@ data TeamExportUser = TeamExportUser
     tExportInvitedBy :: Maybe Handle,
     tExportIdpIssuer :: Maybe HttpsUrl,
     tExportManagedBy :: ManagedBy,
-    tExportSAMLNamedId :: Text,
+    tExportSAMLNamedId :: Text,  -- If SAML IdP and SCIM peer are set up correctly, 'tExportSAMLNamedId' and 'tExportSCIMExternalId' always align.
     tExportSCIMExternalId :: Text,
     tExportSCIMRichInfo :: Maybe RichInfo
   }

--- a/libs/wire-api/src/Wire/API/Team/Export.hs
+++ b/libs/wire-api/src/Wire/API/Team/Export.hs
@@ -42,8 +42,10 @@ data TeamExportUser = TeamExportUser
     tExportCreatedOn :: Maybe UTCTimeMillis,
     tExportInvitedBy :: Maybe Handle,
     tExportIdpIssuer :: Maybe HttpsUrl,
-    tExportManagedBy :: ManagedBy
-    -- FUTUREWORK: @tExportRichProfile :: Maybe RichInfo  -- (rendering: one key-value pair per csv column, sorted alphanumerically by key)@
+    tExportManagedBy :: ManagedBy,
+    tExportSAMLNamedId :: Maybe Text,
+    tExportSCIMExternalId :: Maybe Text,
+    tExportSCIMRichInfo :: Maybe Text
   }
   deriving (Show, Eq, Generic)
   deriving (Arbitrary) via (GenericUniform TeamExportUser)
@@ -51,28 +53,34 @@ data TeamExportUser = TeamExportUser
 instance ToNamedRecord TeamExportUser where
   toNamedRecord row =
     namedRecord
-      [ ("display name", toByteString' (tExportDisplayName row)),
+      [ ("display_name", toByteString' (tExportDisplayName row)),
         ("handle", maybe "" toByteString' (tExportHandle row)),
         ("email", maybe "" toByteString' (tExportEmail row)),
         ("role", maybe "" toByteString' (tExportRole row)),
-        ("created on", maybe "" toByteString' (tExportCreatedOn row)),
-        ("invited by", maybe "" toByteString' (tExportInvitedBy row)),
-        ("idp issuer", maybe "" toByteString' (tExportIdpIssuer row)),
-        ("managed by", toByteString' (tExportManagedBy row))
+        ("created_on", maybe "" toByteString' (tExportCreatedOn row)),
+        ("invited_by", maybe "" toByteString' (tExportInvitedBy row)),
+        ("idp_issuer", maybe "" toByteString' (tExportIdpIssuer row)),
+        ("managed_by", toByteString' (tExportManagedBy row)),
+        ("saml_name_id", maybe "" toByteString' (tExportSAMLNamedId row)),
+        ("scim_external_id", maybe "" toByteString' (tExportSCIMExternalId row)),
+        ("scim_rich_info", maybe "" toByteString' (tExportSCIMRichInfo row))
       ]
 
 instance DefaultOrdered TeamExportUser where
   headerOrder =
     const $
       fromList
-        [ "display name",
+        [ "display_name",
           "handle",
           "email",
           "role",
-          "created on",
-          "invited by",
-          "idp issuer",
-          "managed by"
+          "created_on",
+          "invited_by",
+          "idp_issuer",
+          "managed_by",
+          "saml_name_id",
+          "scim_external_id",
+          "scim_rich_info"
         ]
 
 allowEmpty :: (ByteString -> Parser a) -> ByteString -> Parser (Maybe a)
@@ -88,11 +96,14 @@ parseByteString bstr =
 instance FromNamedRecord TeamExportUser where
   parseNamedRecord nrec =
     TeamExportUser
-      <$> (nrec .: "display name" >>= parseByteString)
+      <$> (nrec .: "display_name" >>= parseByteString)
       <*> (nrec .: "handle" >>= allowEmpty parseByteString)
       <*> (nrec .: "email" >>= allowEmpty parseByteString)
       <*> (nrec .: "role" >>= allowEmpty parseByteString)
-      <*> (nrec .: "created on" >>= allowEmpty parseByteString)
-      <*> (nrec .: "invited by" >>= allowEmpty parseByteString)
-      <*> (nrec .: "idp issuer" >>= allowEmpty parseByteString)
-      <*> (nrec .: "managed by" >>= parseByteString)
+      <*> (nrec .: "created_on" >>= allowEmpty parseByteString)
+      <*> (nrec .: "invited_by" >>= allowEmpty parseByteString)
+      <*> (nrec .: "idp_issuer" >>= allowEmpty parseByteString)
+      <*> (nrec .: "managed_by" >>= parseByteString)
+      <*> (nrec .: "saml_name_id" >>= allowEmpty parseByteString)
+      <*> (nrec .: "scim_external_id" >>= allowEmpty parseByteString)
+      <*> (nrec .: "scim_rich_info" >>= allowEmpty parseByteString)

--- a/libs/wire-api/src/Wire/API/Team/Export.hs
+++ b/libs/wire-api/src/Wire/API/Team/Export.hs
@@ -46,7 +46,7 @@ data TeamExportUser = TeamExportUser
     tExportInvitedBy :: Maybe Handle,
     tExportIdpIssuer :: Maybe HttpsUrl,
     tExportManagedBy :: ManagedBy,
-    tExportSAMLNamedId :: Text,  -- If SAML IdP and SCIM peer are set up correctly, 'tExportSAMLNamedId' and 'tExportSCIMExternalId' always align.
+    tExportSAMLNamedId :: Text, -- If SAML IdP and SCIM peer are set up correctly, 'tExportSAMLNamedId' and 'tExportSCIMExternalId' always align.
     tExportSCIMExternalId :: Text,
     tExportSCIMRichInfo :: Maybe RichInfo
   }

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -525,9 +525,9 @@ getRichInfo uid = RichInfo . fromMaybe emptyRichInfoAssocList <$> lift (API.look
 getRichInfoMultiH :: List UserId -> Handler Response
 getRichInfoMultiH uids = json <$> getRichInfoMulti (List.fromList uids)
 
-getRichInfoMulti :: [UserId] -> Handler [Maybe RichInfo]
+getRichInfoMulti :: [UserId] -> Handler [(UserId, RichInfo)]
 getRichInfoMulti uids =
-  fmap (fmap RichInfo) <$> lift (API.lookupRichInfoMultiUsers uids)
+  lift (API.lookupRichInfoMultiUsers uids)
 
 updateHandleH :: UserId ::: JSON ::: JsonRequest HandleUpdate -> Handler Response
 updateHandleH (uid ::: _ ::: body) = empty <$ (updateHandle uid =<< parseJsonBody body)

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -46,6 +46,7 @@ import Control.Error hiding (bool)
 import Control.Lens (view)
 import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
+import qualified Data.ByteString.Conversion as List
 import Data.Handle (Handle)
 import Data.Id as Id
 import qualified Data.List1 as List1
@@ -204,6 +205,9 @@ sitemap = do
 
   get "/i/users/:uid/rich-info" (continue getRichInfoH) $
     capture "uid"
+
+  get "/i/users/rich-info" (continue getRichInfoMultiH) $
+    param "ids"
 
   head "/i/users/handles/:handle" (continue checkHandleInternalH) $
     capture "handle"
@@ -517,6 +521,13 @@ getRichInfoH uid = json <$> getRichInfo uid
 
 getRichInfo :: UserId -> Handler RichInfo
 getRichInfo uid = RichInfo . fromMaybe emptyRichInfoAssocList <$> lift (API.lookupRichInfo uid)
+
+getRichInfoMultiH :: List UserId -> Handler Response
+getRichInfoMultiH uids = json <$> getRichInfoMulti (List.fromList uids)
+
+getRichInfoMulti :: [UserId] -> Handler [RichInfo]
+getRichInfoMulti uids =
+  fmap RichInfo <$> lift (API.lookupRichInfoMultiUsers uids)
 
 updateHandleH :: UserId ::: JSON ::: JsonRequest HandleUpdate -> Handler Response
 updateHandleH (uid ::: _ ::: body) = empty <$ (updateHandle uid =<< parseJsonBody body)

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -525,9 +525,9 @@ getRichInfo uid = RichInfo . fromMaybe emptyRichInfoAssocList <$> lift (API.look
 getRichInfoMultiH :: List UserId -> Handler Response
 getRichInfoMultiH uids = json <$> getRichInfoMulti (List.fromList uids)
 
-getRichInfoMulti :: [UserId] -> Handler [RichInfo]
+getRichInfoMulti :: [UserId] -> Handler [Maybe RichInfo]
 getRichInfoMulti uids =
-  fmap RichInfo <$> lift (API.lookupRichInfoMultiUsers uids)
+  fmap (fmap RichInfo) <$> lift (API.lookupRichInfoMultiUsers uids)
 
 updateHandleH :: UserId ::: JSON ::: JsonRequest HandleUpdate -> Handler Response
 updateHandleH (uid ::: _ ::: body) = empty <$ (updateHandle uid =<< parseJsonBody body)

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -46,6 +46,7 @@ module Brig.API.User
     Data.lookupLocale,
     Data.lookupUser,
     Data.lookupRichInfo,
+    Data.lookupRichInfoMultiUsers,
     removeEmail,
     removePhone,
     revokeIdentity,

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -384,8 +384,8 @@ lookupRichInfo u =
 -- | Returned rich infos are in the same order as users
 lookupRichInfoMultiUsers :: [UserId] -> AppIO [(UserId, RichInfo)]
 lookupRichInfoMultiUsers users = do
-  pairs <- retry x1 (query richInfoSelectMulti (params Quorum (Identity users)))
-  pure $ flip mapMaybe pairs $ \(uid, mbRi) -> (uid,) . RichInfo <$> mbRi
+  mapMaybe (\(uid, mbRi) -> (uid,) . RichInfo <$> mbRi)
+    <$> retry x1 (query richInfoSelectMulti (params Quorum (Identity users)))
 
 -- | Lookup user (no matter what status) and return 'TeamId'.  Safe to use for authorization:
 -- suspended / deleted / ... users can't login, so no harm done if we authorize them *after*

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -383,11 +383,11 @@ lookupRichInfo u =
     <$> retry x1 (query1 richInfoSelect (params Quorum (Identity u)))
 
 -- | Returned rich infos are in the same order as users
-lookupRichInfoMultiUsers :: [UserId] -> AppIO [RichInfoAssocList]
+lookupRichInfoMultiUsers :: [UserId] -> AppIO [Maybe RichInfoAssocList]
 lookupRichInfoMultiUsers users = do
   pairs <- retry x1 (query richInfoSelectMulti (params Quorum (Identity users)))
   let riLookup = flip HashMap.lookup . HashMap.fromList $ pairs
-  pure $ fromMaybe emptyRichInfoAssocList . join . riLookup <$> users
+  pure $ join . riLookup <$> users
 
 -- | Lookup user (no matter what status) and return 'TeamId'.  Safe to use for authorization:
 -- suspended / deleted / ... users can't login, so no harm done if we authorize them *after*

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -558,7 +558,7 @@ richInfoSelect :: PrepQuery R (Identity UserId) (Identity RichInfoAssocList)
 richInfoSelect = "SELECT json FROM rich_info WHERE user = ?"
 
 richInfoSelectMulti :: PrepQuery R (Identity [UserId]) (UserId, Maybe RichInfoAssocList)
-richInfoSelectMulti = "SELECT id, json FROM rich_info WHERE user in ?"
+richInfoSelectMulti = "SELECT user, json FROM rich_info WHERE user in ?"
 
 teamSelect :: PrepQuery R (Identity UserId) (Identity (Maybe TeamId))
 teamSelect = "SELECT team FROM user WHERE id = ?"

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4050c5c7a2af585637fb5a1eec33f457b3c27e58879ebe3ac5a5f49353fd2542
+-- hash: b8b3a52ab3eec1ffc952d7c79a49679e0529b42ab73a30df3db680e380918809
 
 name:           galley
 version:        0.83.0
@@ -119,6 +119,7 @@ library
     , retry >=0.5
     , safe >=0.3
     , safe-exceptions >=0.1
+    , saml2-web-sso >=0.18
     , servant
     , servant-server
     , servant-swagger

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -60,6 +60,7 @@ library:
   - resourcet >=1.1
   - retry >=0.5
   - safe-exceptions >=0.1
+  - saml2-web-sso >=0.18
   - servant
   - servant-server
   - servant-swagger

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -180,6 +180,9 @@ sitemap = do
       .&. accept "text" "csv"
   document "GET" "getTeamMembersCSV" $ do
     summary "Get all members of the team as a CSV file"
+    notes
+      "The endpoint returns data in chunked transfer encoding.\
+      \ Internal server errors might result in a failed transfer instead of a 500 response."
     parameter Path "tid" bytes' $
       description "Team ID"
     response 200 "Team members CSV file" end

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -478,7 +478,7 @@ getTeamMembersCSVH (zusr ::: tid ::: _) = do
     lookupUser users = (`M.lookup` M.fromList (users <&> \user -> (U.userId user, user)))
 
     lookupRichInfo :: [(UserId, RichInfo)] -> (UserId -> Maybe RichInfo)
-    lookupRichInfo = error "TODO"
+    lookupRichInfo pairs = (`M.lookup` M.fromList pairs)
 
     samlNamedId :: User -> Maybe Text
     samlNamedId = U.userIdentity >=> userSSOId >=> ssoIdNameId

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -60,7 +60,6 @@ import Brig.Types.Intra (accountUser)
 import Brig.Types.Team (TeamSize (..))
 import Control.Lens
 import Control.Monad.Catch
-import qualified Data.Aeson as Aeson
 import Data.ByteString.Conversion hiding (fromList)
 import Data.ByteString.Lazy.Builder (lazyByteString)
 import Data.Csv (EncodeOptions (..), Quoting (QuoteAll), encodeDefaultOrderedByNameWith)
@@ -445,9 +444,9 @@ getTeamMembersCSVH (zusr ::: tid ::: _) = do
           tExportInvitedBy = mbInviterHandle . fst =<< view invitation member,
           tExportIdpIssuer = userToIdPIssuer user,
           tExportManagedBy = U.userManagedBy user,
-          tExportSAMLNamedId = samlNamedId user,
-          tExportSCIMExternalId = scimExtId user,
-          tExportSCIMRichInfo = cs . Aeson.encode <$> richInfo
+          tExportSAMLNamedId = fromMaybe "" (samlNamedId user),
+          tExportSCIMExternalId = fromMaybe "" (scimExtId user),
+          tExportSCIMRichInfo = richInfo
         }
 
     getInviters :: [TeamMember] -> Galley (UserId -> Maybe Handle.Handle)

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -393,6 +393,10 @@ getTeamMembersCSVH (zusr ::: tid ::: _) = do
     Just member -> unless (member `hasPermission` DownloadTeamMembersCsv) $ throwM accessDenied
 
   env <- ask
+  -- In case an exception is thrown inside the StreamingBody of responseStream
+  -- the response will not contain a correct error message, but rather be an
+  -- http error such as 'InvalidChunkHeaders'. The exception however still
+  -- reaches the middleware and is being tracked in logging and metrics.
   pure $
     responseStream
       status200

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -434,7 +434,7 @@ getTeamMembersCSVH (zusr ::: tid ::: _) = do
           encQuoting = QuoteAll
         }
 
-    teamExportUser :: (UserId -> Maybe Handle.Handle) -> TeamMember -> RichInfo -> User -> TeamExportUser
+    teamExportUser :: (UserId -> Maybe Handle.Handle) -> TeamMember -> Maybe RichInfo -> User -> TeamExportUser
     teamExportUser mbInviterHandle member richInfo user =
       TeamExportUser
         { tExportDisplayName = U.userDisplayName user,
@@ -447,7 +447,7 @@ getTeamMembersCSVH (zusr ::: tid ::: _) = do
           tExportManagedBy = U.userManagedBy user,
           tExportSAMLNamedId = samlNamedId user,
           tExportSCIMExternalId = scimExtId user,
-          tExportSCIMRichInfo = Just . cs . Aeson.encode $ richInfo
+          tExportSCIMRichInfo = cs . Aeson.encode <$> richInfo
         }
 
     getInviters :: [TeamMember] -> Galley (UserId -> Maybe Handle.Handle)
@@ -470,7 +470,7 @@ getTeamMembersCSVH (zusr ::: tid ::: _) = do
       Just _ -> Nothing
       Nothing -> Nothing
 
-    joinUserInfos :: [TeamMember] -> [User] -> [RichInfo] -> [(TeamMember, RichInfo, User)]
+    joinUserInfos :: [TeamMember] -> [User] -> [Maybe RichInfo] -> [(TeamMember, Maybe RichInfo, User)]
     joinUserInfos members users richInfos = do
       let usersMap = M.fromList (users <&> \user -> (U.userId user, user))
       catMaybes $

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -457,7 +457,7 @@ getTeamMembersCSVH (zusr ::: tid ::: _) = do
     lookupInviterHandle :: [TeamMember] -> Galley (UserId -> Maybe Handle.Handle)
     lookupInviterHandle members = do
       let inviterIds :: [UserId]
-          inviterIds = catMaybes $ fmap fst . view invitation <$> members
+          inviterIds = nub $ catMaybes $ fmap fst . view invitation <$> members
 
       userList :: [User] <- accountUser <$$> getUsers inviterIds
 

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -25,6 +25,7 @@ module Galley.Intra.User
     deleteUser,
     getContactList,
     chunkify,
+    getBrigUserRichInfo,
   )
 where
 
@@ -46,6 +47,7 @@ import qualified Network.HTTP.Client.Internal as Http
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
+import Wire.API.User.RichInfo (RichInfo)
 
 -- | Get statuses of all connections between two groups of users (the usual
 -- pattern is to check all connections from one user to several, or from
@@ -161,3 +163,15 @@ getContactList uid = do
         . paths ["/i/users", toByteString' uid, "contacts"]
         . expect2xx
   cUsers <$> parseResponse (Error status502 "server-error") r
+
+-- | Calls 'Brig.API.Internal.getRichInfoMultiH'
+getRichInfoMultiUser :: [UserId] -> Galley [RichInfo]
+getRichInfoMultiUser uids = do
+  (h, p) <- brigReq
+  resp <-
+    call "brig" $
+      method GET . host h . port p
+        . paths ["/i/users/rich-info"]
+        . param ""
+        . expect2xx
+  parseResponse (Error status502 "server-error") resp

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -165,7 +165,7 @@ getContactList uid = do
   cUsers <$> parseResponse (Error status502 "server-error") r
 
 -- | Calls 'Brig.API.Internal.getRichInfoMultiH'
-getRichInfoMultiUser :: [UserId] -> Galley [Maybe RichInfo]
+getRichInfoMultiUser :: [UserId] -> Galley [(UserId, RichInfo)]
 getRichInfoMultiUser = chunkify $ \uids -> do
   (h, p) <- brigReq
   resp <-

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -25,7 +25,7 @@ module Galley.Intra.User
     deleteUser,
     getContactList,
     chunkify,
-    getBrigUserRichInfo,
+    getRichInfoMultiUser,
   )
 where
 
@@ -172,6 +172,6 @@ getRichInfoMultiUser uids = do
     call "brig" $
       method GET . host h . port p
         . paths ["/i/users/rich-info"]
-        . param ""
+        . queryItem "ids" (toByteString' (List uids))
         . expect2xx
   parseResponse (Error status502 "server-error") resp

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -165,7 +165,7 @@ getContactList uid = do
   cUsers <$> parseResponse (Error status502 "server-error") r
 
 -- | Calls 'Brig.API.Internal.getRichInfoMultiH'
-getRichInfoMultiUser :: [UserId] -> Galley [RichInfo]
+getRichInfoMultiUser :: [UserId] -> Galley [Maybe RichInfo]
 getRichInfoMultiUser uids = do
   (h, p) <- brigReq
   resp <-

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -166,7 +166,7 @@ getContactList uid = do
 
 -- | Calls 'Brig.API.Internal.getRichInfoMultiH'
 getRichInfoMultiUser :: [UserId] -> Galley [Maybe RichInfo]
-getRichInfoMultiUser uids = do
+getRichInfoMultiUser = chunkify $ \uids -> do
   (h, p) <- brigReq
   resp <-
     call "brig" $


### PR DESCRIPTION
This PR updates the CSV export returned on `/teams/:tid/members/csv` as follows

- in the header of CSV use underscore `_` instead of space in column names
- add 3 columns
  - `saml_name_id` the SAML subjectects NameId
  - `scim_external_id` SCIM `externalId` field
  - `scim_rich_info` SCIM `richInfo` profile field (JSON-encoded)
- prevent duplicated unnecessary calls to /i/users

I tested all new columns manually.
