### PR TITLE
[skip ci] PoC: trying out using cassandra for optimistic locking of prekeys

### DIFF
--- a/services/brig/src/Brig/Unique.hs
+++ b/services/brig/src/Brig/Unique.hs
@@ -88,7 +88,7 @@ deleteClaim ::
   m ()
 deleteClaim u v t = do
   let ttl = max minTtl (fromIntegral (t #> Second))
-  retry x5 $ write cql $ params Quorum (ttl * 2, C.Set [u], v)
+  retry x5 $ write cql $ params Quorum (ttl, C.Set [u], v)
   where
     cql :: PrepQuery W (Int32, C.Set (Id a), Text) ()
     cql = "UPDATE unique_claims USING TTL ? SET claims = claims - ? WHERE value = ?"
@@ -105,7 +105,7 @@ lookupClaims v =
     cql = "SELECT claims FROM unique_claims WHERE value = ?"
 
 minTtl :: Int32
-minTtl = 60 -- Seconds
+minTtl = 2 -- TODO: there might be a good reason this was 60 seconds - perhaps cassandra doesn't deal well with TTLs of only a few seconds? Or we can't know if computations will complete within a few seconds.
 
 -- [Note: Guarantees]
 -- ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This passes the prekeys/race tests `make integration-race`:

```
Brig API Integration
  user
    client
      client/prekeys/race: [brig] W, request=N/A, Aye
[brig] W, request=N/A, NOOOOOOOOOOOOOOOOOOOOOOOOO we failed a claim! Another try...
[brig] W, request=N/A, Aye
[brig] W, request=N/A, NOOOOOOOOOOOOOOOOOOOOOOOOO we failed a claim! Another try...
[brig] W, request=N/A, Aye
[brig] W, request=N/A, Aye
[brig] W, request=N/A, Aye
[brig] W, request=N/A, Aye
[brig] W, request=N/A, Aye
[brig] W, request=N/A, Aye
[brig] W, request=N/A, Aye
[brig] W, request=N/A, Aye
OK (2.19s)
```

Perhaps the in-memory lock and this claim-based lock and randomness
could all be combined? Since the claim-based lock creates as much
latency as we decide the TTL to be and is thus expensive.