### PR TITLE
Search: Only perform exact handle match if term is a valid handle

### DIFF
--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -41,7 +41,7 @@ import Brig.User.Search.TeamUserSearch (RoleFilter (..), TeamUserSearchSortBy (.
 import qualified Brig.User.Search.TeamUserSearch as Q
 import Control.Lens (view)
 import Data.Domain (Domain)
-import Data.Handle (Handle (Handle))
+import Data.Handle (parseHandle)
 import Data.Id
 import Data.Predicate
 import Data.Range
@@ -199,9 +199,13 @@ searchLocally searcherId searchTerm maybeMaxResults = do
 
     exactHandleSearch :: TeamSearchInfo -> Handler (Maybe Contact)
     exactHandleSearch teamSearchInfo = do
+      let searchedHandleMaybe = parseHandle searchTerm
       exactHandleResult <-
-        contactFromProfile
-          <$$> HandleAPI.getLocalHandleInfo searcherId (Handle searchTerm)
+        case searchedHandleMaybe of
+          Nothing -> pure Nothing
+          Just searchedHandle ->
+            contactFromProfile
+              <$$> HandleAPI.getLocalHandleInfo searcherId searchedHandle
       pure $ case teamSearchInfo of
         Search.TeamOnly t ->
           if Just t == (contactTeam =<< exactHandleResult)

--- a/services/brig/src/Brig/User/Handle.hs
+++ b/services/brig/src/Brig/User/Handle.hs
@@ -72,6 +72,7 @@ glimpseHandle :: Handle -> AppIO (Maybe UserId)
 glimpseHandle = lookupHandleWithPolicy One
 
 {-# INLINE lookupHandleWithPolicy #-}
+
 -- | Sending an empty 'Handle' here causes C* to throw "Key may not be empty"
 -- error.
 --

--- a/services/brig/src/Brig/User/Handle.hs
+++ b/services/brig/src/Brig/User/Handle.hs
@@ -72,6 +72,11 @@ glimpseHandle :: Handle -> AppIO (Maybe UserId)
 glimpseHandle = lookupHandleWithPolicy One
 
 {-# INLINE lookupHandleWithPolicy #-}
+-- | Sending an empty 'Handle' here causes C* to throw "Key may not be empty"
+-- error.
+--
+-- FUTUREWORK: This should ideally be tackled by hiding constructor for 'Handle'
+-- and only allowing it to be parsed.
 lookupHandleWithPolicy :: Consistency -> Handle -> AppIO (Maybe UserId)
 lookupHandleWithPolicy policy h = do
   join . fmap runIdentity

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -68,6 +68,7 @@ tests opts mgr galley brig = do
         testWithBothIndices opts mgr "by-handle" $ testSearchByHandle brig,
         testWithBothIndices opts mgr "size - when exact handle matches a team user" $ testSearchSize brig True,
         testWithBothIndices opts mgr "size - when exact handle matches a non team user" $ testSearchSize brig False,
+        test mgr "empty query" $ testSearchEmpty brig,
         test mgr "reindex" $ testReindex brig,
         testWithBothIndices opts mgr "no match" $ testSearchNoMatch brig,
         testWithBothIndices opts mgr "no extra results" $ testSearchNoExtraResults brig,
@@ -171,6 +172,15 @@ testSearchByHandle brig = do
       uid2 = userId u2
       Just h = fromHandle <$> userHandle u1
   assertCanFind brig uid2 quid1 h
+
+testSearchEmpty :: TestConstraints m => Brig -> m ()
+testSearchEmpty brig = do
+  -- This user exists just in case empty string starts matching everything
+  _someUser <- randomUserWithHandle brig
+  searcher <- randomUser brig
+  refreshIndex brig
+  res <- searchResults <$> executeSearch brig (userId searcher) ""
+  liftIO $ assertEqual "nothing should be returned" [] res
 
 testSearchSize :: TestConstraints m => Brig -> Bool -> m ()
 testSearchSize brig exactHandleInTeam = do


### PR DESCRIPTION
This is requried because cassandra doesn't like querying with empty keys.
Ideally we should just not allow making the 'Handle' value if something isn't a
valid handle, a FUTUREWORK has been added for this.