### PR TITLE
RFC: Typed Swagger schemas [skip ci]

### DIFF
--- a/libs/wire-api/src/Data/Swagger/Typed.hs
+++ b/libs/wire-api/src/Data/Swagger/Typed.hs
@@ -13,6 +13,8 @@ module Data.Swagger.Typed
     unnamed,
     array,
     enum,
+    handle,
+    coerce,
     schema,
     untypedSchema,
   )
@@ -30,6 +32,41 @@ import Imports
 type Declare = S.Declare (S.Definitions S.Schema)
 
 -- | A typed Swagger schema
+--
+-- /Note/: the 'Applicative' and 'Alternative' instances of 'Schema'
+-- have the same implementation, but different types. For example, the
+-- binary operation of 'Applicative' is:
+-- @
+-- (<*>) :: f (a -> b) -> f a -> f b
+-- @
+-- while that of 'Alternative' is:
+-- @
+-- (<|>) :: f a -> f a -> f a.
+-- @
+-- The simple reason for this distinction is that the types will line
+-- up with the 'Applicative' instance in some cases, and with the
+-- 'Alternative' instance in others, so one needs both.
+--
+-- The deeper reason is that they are conceptually different. A schema like:
+-- @
+-- (,) <$> schemaA <*> schemaB
+-- @
+-- means that you will can have fields from @A@ and @B@ in the
+-- resulting object, while
+-- @
+-- schemaA <|> schemaB
+-- @
+-- is only allowed to have fields from @A@ /or/ from @B@.
+--
+-- Unfortunately, there does not seem to be a way to express the
+-- latter constraint in the resulting schema, and that's why the
+-- implementations are the same. It seems this should be possible in
+-- openapi3, thought.
+--
+-- The difference between 'Applicative' and 'Alternative' also becomes
+-- important when we think about using a typed schema specification to
+-- derive FromJSON instances. Then they would respectively implement
+-- sequencing and alternation of the corresponding parsers.
 newtype Schema (a :: *) = Schema (Declare S.Schema)
   deriving (Functor)
 
@@ -89,9 +126,25 @@ instance HasSchemaRef NamedSchema where
       S.NamedSchema Nothing s ->
         pure (S.Inline s)
 
+-- | Just like 'field', but with a trivial "modifier".
 field' :: HasSchemaRef f => Text -> f a -> Schema a
 field' name = field name id
 
+-- | A schema for an object with a single field.
+--
+-- Multiple fields can be combined into a single object using the
+-- 'Applicative' instance of 'Schema'. Note that 'field' accepts both
+-- a 'NamedSchema' and 'Schema' for the inner field schema.
+--
+-- The second argument is an arbitrary "modifier" function from
+-- 'S.Schema' to itself, to be applied to the field schema. The most
+-- common use for this is to set some values, such as its
+-- description. For example, using lenses:
+-- @
+--     field "name" (description ?~ "The name of this object") schema
+-- @
+-- creates a field called "name" with the given description, with a
+-- type that is instance of 'TypedSchema'.
 field :: HasSchemaRef f => Text -> (S.Schema -> S.Schema) -> f a -> Schema a
 field name f s = Schema $ do
   ref <- schemaRef s
@@ -101,6 +154,10 @@ field name f s = Schema $ do
       & S.type_ ?~ S.SwaggerObject
       & S.properties . at name ?~ ref'
 
+-- | A schema for an array of items.
+--
+-- Just like 'field', it can take both 'NamedSchema' and 'Schema'
+-- definitions.
 array :: HasSchemaRef f => f a -> Schema [a]
 array s = Schema $ do
   ref <- schemaRef s
@@ -109,6 +166,13 @@ array s = Schema $ do
       & S.type_ ?~ S.SwaggerArray
       & S.items ?~ S.SwaggerItemsObject ref
 
+-- | A schema for an enumeration type.
+--
+-- This takes as argument a list of pairs @(value, schema)@ where
+-- @value@ is one of the possible JSON values of the enumeration, and
+-- @schema@ is the corresponding Swagger schema. At the moment, the
+-- schemas are ignored, but they could be used to derive a FromJSON
+-- instance.
 enum :: [(Value, Schema a)] -> Schema a
 enum ss =
   Schema $
@@ -117,22 +181,62 @@ enum ss =
         & S.type_ ?~ S.SwaggerString
         & S.enum_ ?~ map fst ss
 
+-- | Used for schemas that can potentially fail.
+handle :: Schema (Either Text a) -> Schema a
+handle = coerce
+
+-- | Coerce schema to a different type.
+--
+-- This is safe as far as the Swagger schema generation is concerned,
+-- but it makes it impossible to derive a safe 'FromJSON' instance
+-- from a typed schema definition.
+coerce :: Schema a -> Schema b
+coerce (Schema s) = Schema s
+
+-- | Turn a 'Schema' into a 'NamedSchema' with the given name.
 named :: Text -> Schema a -> NamedSchema a
 named name (Schema s) = NamedSchema (S.NamedSchema (Just name) <$> s) Nothing
 
+-- | Turn a 'NamedSchema' into a 'Schema'.
+--
+-- This is mostly useful to attach descriptions to field, since fields
+-- containing referenced schemas cannot have a description. For example:
+-- @
+--     field "elements" (description ?~ "the elements of this object") (unnamed schema)
+-- @
 unnamed :: NamedSchema a -> Schema a
 unnamed (NamedSchema s _) = Schema (view S.schema <$> s)
 
+-- | Typed schema for a type that is instance of 'ToTypedSchema'
+--
+-- Reuse the typed schema definition which is part of the
+-- 'ToTypedSchema' instance of a type. Using 'schema', one can split a
+-- complicated shema definition into manageable parts by defining
+-- instances of 'ToTypedSchema' for the various types involved.
 schema :: ToTypedSchema a => NamedSchema a
 schema = toTypedSchema Proxy
 
+-- | Derive a typed schema from an untyped schema definition
+--
+-- This can be used for types that have a 'ToSchema' instance but lack
+-- a 'ToTypedSchema' instance.
 untypedSchema :: forall a. S.ToSchema a => NamedSchema a
 untypedSchema = NamedSchema (pure (S.toNamedSchema (Proxy :: Proxy a))) Nothing
 
+-- | A type with a canonical typed schema definition.
 class ToTypedSchema a where
   toTypedSchema :: Proxy a -> NamedSchema a
 
--- to use with deriving via
+-- | Wrapper to turn 'ToTypedSchema' into 'ToSchema'.
+--
+-- This is mostly for use in a 'deriving via' clause. For example:
+-- @
+--     data MyType = ...
+--       deriving ToSchema via TypedSchema MyType
+--
+--     instance ToTypedSchema MyType where
+--       toTypedSchema _ = ...
+-- @
 newtype TypedSchema a = TypedSchema a
 
 instance ToTypedSchema a => S.ToSchema (TypedSchema a) where

--- a/libs/wire-api/src/Data/Swagger/Typed.hs
+++ b/libs/wire-api/src/Data/Swagger/Typed.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Data.Swagger.Typed
+  ( Schema,
+    NamedSchema,
+    ToTypedSchema (..),
+    TypedSchema (TypedSchema),
+    field,
+    field',
+    named,
+    unnamed,
+    array,
+    enum,
+    schema,
+    untypedSchema,
+  )
+where
+
+import Control.Applicative
+import Control.Lens (at, view, (.~), (?~))
+import Data.Aeson (Value)
+import Data.Proxy
+import qualified Data.Swagger as S
+import qualified Data.Swagger.Declare as S
+import qualified Data.Swagger.Internal.Schema as S
+import Imports
+
+type Declare = S.Declare (S.Definitions S.Schema)
+
+-- | A typed Swagger schema
+newtype Schema (a :: *) = Schema (Declare S.Schema)
+  deriving (Functor)
+
+-- FUTUREWORK: store enough information in 'Schema' to synthesise
+-- ToJSON and FromJSON instances
+
+data NamedSchema a = NamedSchema
+  { _nsSchema :: Declare S.NamedSchema,
+    _nsDescription :: Maybe Text
+  }
+  deriving (Functor)
+
+appendMaybe :: Maybe a -> Maybe a -> Maybe a
+appendMaybe Nothing x = x
+appendMaybe x _ = x
+
+appendNS :: S.NamedSchema -> S.NamedSchema -> S.NamedSchema
+appendNS (S.NamedSchema n1 s1) (S.NamedSchema n2 s2) =
+  S.NamedSchema (appendMaybe n1 n2) (s1 <> s2)
+
+instance Applicative NamedSchema where
+  pure _ = NamedSchema (pure (S.NamedSchema Nothing mempty)) Nothing
+  NamedSchema decl1 descr1 <*> NamedSchema decl2 descr2 =
+    NamedSchema (appendNS <$> decl1 <*> decl2) (appendMaybe descr1 descr2)
+
+instance Alternative NamedSchema where
+  empty = NamedSchema (pure (S.NamedSchema Nothing mempty)) Nothing
+  NamedSchema decl1 descr1 <|> NamedSchema decl2 descr2 =
+    NamedSchema (appendNS <$> decl1 <*> decl2) (appendMaybe descr1 descr2)
+
+runNamedSchema :: NamedSchema a -> Declare S.NamedSchema
+runNamedSchema (NamedSchema decl descr) = do
+  s <- decl
+  pure $ s & (S.schema . S.description) .~ descr
+
+instance Applicative Schema where
+  pure _ = Schema (pure mempty)
+  Schema a <*> Schema b = Schema ((<>) <$> a <*> b)
+
+instance Alternative Schema where
+  empty = Schema (pure mempty)
+  Schema a <|> Schema b = Schema ((<>) <$> a <*> b)
+
+class HasSchemaRef f where
+  schemaRef :: f a -> Declare (S.Referenced S.Schema)
+
+instance HasSchemaRef Schema where
+  schemaRef (Schema decl) = S.Inline <$> decl
+
+instance HasSchemaRef NamedSchema where
+  schemaRef tns = do
+    ns <- runNamedSchema tns
+    case ns of
+      S.NamedSchema (Just n) s -> do
+        S.declare [(n, s)]
+        pure (S.Ref (S.Reference n))
+      S.NamedSchema Nothing s ->
+        pure (S.Inline s)
+
+field' :: HasSchemaRef f => Text -> f a -> Schema a
+field' name = field name id
+
+field :: HasSchemaRef f => Text -> (S.Schema -> S.Schema) -> f a -> Schema a
+field name f s = Schema $ do
+  ref <- schemaRef s
+  let ref' = fmap f ref
+  pure $
+    mempty
+      & S.type_ ?~ S.SwaggerObject
+      & S.properties . at name ?~ ref'
+
+array :: HasSchemaRef f => f a -> Schema [a]
+array s = Schema $ do
+  ref <- schemaRef s
+  pure $
+    mempty
+      & S.type_ ?~ S.SwaggerArray
+      & S.items ?~ S.SwaggerItemsObject ref
+
+enum :: [(Value, Schema a)] -> Schema a
+enum ss =
+  Schema $
+    pure $
+      mempty
+        & S.type_ ?~ S.SwaggerString
+        & S.enum_ ?~ map fst ss
+
+named :: Text -> Schema a -> NamedSchema a
+named name (Schema s) = NamedSchema (S.NamedSchema (Just name) <$> s) Nothing
+
+unnamed :: NamedSchema a -> Schema a
+unnamed (NamedSchema s _) = Schema (view S.schema <$> s)
+
+schema :: ToTypedSchema a => NamedSchema a
+schema = toTypedSchema Proxy
+
+untypedSchema :: forall a. S.ToSchema a => NamedSchema a
+untypedSchema = NamedSchema (pure (S.toNamedSchema (Proxy :: Proxy a))) Nothing
+
+class ToTypedSchema a where
+  toTypedSchema :: Proxy a -> NamedSchema a
+
+-- to use with deriving via
+newtype TypedSchema a = TypedSchema a
+
+instance ToTypedSchema a => S.ToSchema (TypedSchema a) where
+  declareNamedSchema _ = runNamedSchema (toTypedSchema Proxy :: NamedSchema a)
+
+-- Lens instances
+
+instance S.HasDescription (NamedSchema a) (Maybe Text) where
+  description f s = fmap (\x -> s {_nsDescription = x}) . f . _nsDescription $ s

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -67,6 +67,7 @@ module Wire.API.Conversation
   )
 where
 
+import Control.Lens ((?~))
 import Data.Aeson
 import Data.Aeson.Types (Parser)
 import Data.Id
@@ -74,7 +75,9 @@ import Data.Json.Util
 import Data.List1
 import Data.Misc
 import Data.String.Conversions (cs)
+import Data.Swagger
 import qualified Data.Swagger.Build.Api as Doc
+import qualified Data.Swagger.Typed as TS
 import Imports
 import qualified Test.QuickCheck as QC
 import Wire.API.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
@@ -498,6 +501,13 @@ newtype ConversationRename = ConversationRename
   }
   deriving stock (Eq, Show)
   deriving newtype (Arbitrary)
+  deriving (ToSchema) via TS.TypedSchema ConversationRename
+
+instance TS.ToTypedSchema ConversationRename where
+  toTypedSchema _ =
+    TS.named "ConversationUpdateName" $
+      ConversationRename
+        <$> TS.field "name" (description ?~ "The new conversation name") TS.untypedSchema
 
 modelConversationUpdateName :: Doc.Model
 modelConversationUpdateName = Doc.defineModel "ConversationUpdateName" $ do

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -77,7 +77,7 @@ import Data.Misc
 import Data.String.Conversions (cs)
 import Data.Swagger (ToSchema (..), description)
 import qualified Data.Swagger.Build.Api as Doc
-import Data.Swagger.Typed (ToTypedSchema (..), TypedSchema (..), field, named, untypedSchema, field', enum, array, unnamed, schema)
+import Data.Swagger.Typed (ToTypedSchema (..), TypedSchema (..), array, enum, field, field', named, schema, unnamed, untypedSchema)
 import Imports
 import qualified Test.QuickCheck as QC
 import Wire.API.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
@@ -212,11 +212,14 @@ data Access
   deriving (Arbitrary) via (GenericUniform Access)
 
 instance ToTypedSchema Access where
-  toTypedSchema _ = named "Access" $ enum
-    [ ("private", pure PrivateAccess)
-    , ("invite", pure InviteAccess)
-    , ("link", pure LinkAccess)
-    , ("code", pure CodeAccess) ]
+  toTypedSchema _ =
+    named "Access" $
+      enum
+        [ ("private", pure PrivateAccess),
+          ("invite", pure InviteAccess),
+          ("link", pure LinkAccess),
+          ("code", pure CodeAccess)
+        ]
 
 typeAccess :: Doc.DataType
 typeAccess = Doc.string . Doc.enum $ cs . encode <$> [(minBound :: Access) ..]
@@ -254,11 +257,14 @@ data AccessRole
   deriving (Arbitrary) via (GenericUniform AccessRole)
 
 instance ToTypedSchema AccessRole where
-  toTypedSchema _ = named "AccessRole" $ enum
-    [ ("private", pure PrivateAccessRole)
-    , ("team", pure TeamAccessRole)
-    , ("activated", pure ActivatedAccessRole)
-    , ("non_activated", pure NonActivatedAccessRole) ]
+  toTypedSchema _ =
+    named "AccessRole" $
+      enum
+        [ ("private", pure PrivateAccessRole),
+          ("team", pure TeamAccessRole),
+          ("activated", pure ActivatedAccessRole),
+          ("non_activated", pure NonActivatedAccessRole)
+        ]
 
 instance ToJSON AccessRole where
   toJSON PrivateAccessRole = String "private"
@@ -544,11 +550,12 @@ data ConversationAccessUpdate = ConversationAccessUpdate
   deriving (Arbitrary) via (GenericUniform ConversationAccessUpdate)
 
 instance ToTypedSchema ConversationAccessUpdate where
-  toTypedSchema _ = (description ?~ "Contains conversation properties to update")
-    . named "ConversationAccessUpdate"
-    $ ConversationAccessUpdate
-      <$> field "access" (description ?~ "List of conversation access modes") (array schema)
-      <*> field' "access_role" schema
+  toTypedSchema _ =
+    (description ?~ "Contains conversation properties to update")
+      . named "ConversationAccessUpdate"
+      $ ConversationAccessUpdate
+        <$> field "access" (description ?~ "List of conversation access modes") (array schema)
+        <*> field' "access_role" schema
 
 modelConversationAccessUpdate :: Doc.Model
 modelConversationAccessUpdate = Doc.defineModel "ConversationAccessUpdate" $ do
@@ -578,13 +585,15 @@ data ConversationReceiptModeUpdate = ConversationReceiptModeUpdate
   deriving (Arbitrary) via (GenericUniform ConversationReceiptModeUpdate)
 
 instance ToTypedSchema ConversationReceiptModeUpdate where
-  toTypedSchema _ = (description ?~ desc) . named "ConversationReceiptModeUpdate" $
-    ConversationReceiptModeUpdate <$>
-      field' "receipt_mode" (ReceiptMode <$> untypedSchema)
+  toTypedSchema _ =
+    (description ?~ desc) . named "ConversationReceiptModeUpdate" $
+      ConversationReceiptModeUpdate
+        <$> field' "receipt_mode" (ReceiptMode <$> untypedSchema)
     where
-      desc = "Contains conversation receipt mode to update to. Receipt mode tells \
-             \clients whether certain types of receipts should be sent in the given \
-             \conversation or not. How this value is interpreted is up to clients."
+      desc =
+        "Contains conversation receipt mode to update to. Receipt mode tells \
+        \clients whether certain types of receipts should be sent in the given \
+        \conversation or not. How this value is interpreted is up to clients."
 
 modelConversationReceiptModeUpdate :: Doc.Model
 modelConversationReceiptModeUpdate = Doc.defineModel "conversationReceiptModeUpdate" $ do
@@ -615,9 +624,9 @@ data ConversationMessageTimerUpdate = ConversationMessageTimerUpdate
 instance ToTypedSchema ConversationMessageTimerUpdate where
   toTypedSchema _ =
     (description ?~ "Contains conversation properties to update")
-    . named "ConversationMessageTimerUpdate" $
-      ConversationMessageTimerUpdate <$>
-        field
+      . named "ConversationMessageTimerUpdate"
+      $ ConversationMessageTimerUpdate
+        <$> field
           "message_timer"
           (description ?~ "Conversation message timer (in milliseconds); can be null")
           (Just . Ms <$> unnamed untypedSchema)

--- a/libs/wire-api/src/Wire/API/Conversation/Code.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Code.hs
@@ -33,7 +33,7 @@ module Wire.API.Conversation.Code
   )
 where
 
-import Control.Lens ((.~))
+import Control.Lens ((.~), (?~))
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), (.:), (.:?), (.=))
 import qualified Data.Aeson as JSON
 import Data.ByteString.Conversion (toByteString')
@@ -45,6 +45,9 @@ import qualified Data.Swagger.Build.Api as Doc
 import Imports
 import qualified URI.ByteString as URI
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
+import Data.Swagger.Typed (ToTypedSchema (..), named, unnamed, field, untypedSchema, coerce)
+import Data.Swagger (description)
+import Control.Applicative
 
 data ConversationCode = ConversationCode
   { conversationKey :: Code.Key,
@@ -53,6 +56,21 @@ data ConversationCode = ConversationCode
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform ConversationCode)
+
+instance ToTypedSchema ConversationCode where
+  toTypedSchema _ =
+    (description ?~ "Contains conversation properties to update") .
+    named "ConversationCode" $ ConversationCode
+      <$> field "key" (description ?~ "Stable conversation identifier")
+            -- FUTUREWORK: avoid coerce
+            (coerce (unnamed (untypedSchema @Text)))
+      <*> field "code" (description ?~ "Conversation code (random)")
+            -- FUTUREWORK: avoid coerce
+            (coerce (unnamed (untypedSchema @Text)))
+      <*> field
+            "uri"
+            (description ?~ "Full URI (containing key/code) to join a conversation")
+            (optional (coerce (unnamed (untypedSchema @Text))))
 
 modelConversationCode :: Doc.Model
 modelConversationCode = Doc.defineModel "ConversationCode" $ do

--- a/libs/wire-api/src/Wire/API/Conversation/Code.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Code.hs
@@ -33,21 +33,22 @@ module Wire.API.Conversation.Code
   )
 where
 
+-- FUTUREWORK: move content of Data.Code here?
+
+import Control.Applicative
 import Control.Lens ((.~), (?~))
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), (.:), (.:?), (.=))
 import qualified Data.Aeson as JSON
 import Data.ByteString.Conversion (toByteString')
--- FUTUREWORK: move content of Data.Code here?
 import Data.Code as Code
 import Data.Json.Util ((#))
 import Data.Misc (HttpsUrl (HttpsUrl))
+import Data.Swagger (description)
 import qualified Data.Swagger.Build.Api as Doc
+import Data.Swagger.Typed (ToTypedSchema (..), coerce, field, named, unnamed, untypedSchema)
 import Imports
 import qualified URI.ByteString as URI
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
-import Data.Swagger.Typed (ToTypedSchema (..), named, unnamed, field, untypedSchema, coerce)
-import Data.Swagger (description)
-import Control.Applicative
 
 data ConversationCode = ConversationCode
   { conversationKey :: Code.Key,
@@ -59,18 +60,23 @@ data ConversationCode = ConversationCode
 
 instance ToTypedSchema ConversationCode where
   toTypedSchema _ =
-    (description ?~ "Contains conversation properties to update") .
-    named "ConversationCode" $ ConversationCode
-      <$> field "key" (description ?~ "Stable conversation identifier")
-            -- FUTUREWORK: avoid coerce
-            (coerce (unnamed (untypedSchema @Text)))
-      <*> field "code" (description ?~ "Conversation code (random)")
-            -- FUTUREWORK: avoid coerce
-            (coerce (unnamed (untypedSchema @Text)))
-      <*> field
-            "uri"
-            (description ?~ "Full URI (containing key/code) to join a conversation")
-            (optional (coerce (unnamed (untypedSchema @Text))))
+    (description ?~ "Contains conversation properties to update")
+      . named "ConversationCode"
+      $ ConversationCode
+        <$> field
+          "key"
+          (description ?~ "Stable conversation identifier")
+          -- FUTUREWORK: avoid coerce
+          (coerce (unnamed (untypedSchema @Text)))
+        <*> field
+          "code"
+          (description ?~ "Conversation code (random)")
+          -- FUTUREWORK: avoid coerce
+          (coerce (unnamed (untypedSchema @Text)))
+        <*> field
+          "uri"
+          (description ?~ "Full URI (containing key/code) to join a conversation")
+          (optional (coerce (unnamed (untypedSchema @Text))))
 
 modelConversationCode :: Doc.Model
 modelConversationCode = Doc.defineModel "ConversationCode" $ do

--- a/libs/wire-api/src/Wire/API/Conversation/Role.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Role.hs
@@ -65,6 +65,9 @@ import qualified Data.Swagger.Build.Api as Doc
 import Imports
 import qualified Test.QuickCheck as QC
 import Wire.API.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
+import Data.Swagger.Typed (ToTypedSchema (..), named, untypedSchema, unnamed)
+import Data.Swagger (description)
+import Control.Lens ((?~))
 
 --------------------------------------------------------------------------------
 -- Role
@@ -167,6 +170,15 @@ instance FromJSON ConversationRolesList where
 newtype RoleName = RoleName {fromRoleName :: Text}
   deriving stock (Eq, Show, Generic)
   deriving newtype (ToJSON, ToByteString, Hashable)
+
+instance ToTypedSchema RoleName where
+  toTypedSchema _ = (description ?~ desc)
+    . named "RoleName"
+    $ RoleName <$> unnamed untypedSchema
+    where
+      desc = "Role name, between 2 and 128 chars, 'wire_' prefix \
+             \is reserved for roles designed by Wire (i.e., no \
+             \custom roles can have the same prefix)"
 
 instance FromByteString RoleName where
   parser = parser >>= maybe (fail "Invalid RoleName") return . parseRoleName

--- a/libs/wire-api/src/Wire/API/Conversation/Role.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Role.hs
@@ -54,6 +54,7 @@ where
 
 import Cassandra.CQL hiding (Set)
 import Control.Applicative (optional)
+import Control.Lens ((?~))
 import Data.Aeson
 import Data.Aeson.TH
 import Data.Attoparsec.Text
@@ -61,13 +62,12 @@ import Data.ByteString.Conversion
 import Data.Hashable
 import Data.Range (fromRange, genRangeText)
 import qualified Data.Set as Set
+import Data.Swagger (description)
 import qualified Data.Swagger.Build.Api as Doc
+import Data.Swagger.Typed (ToTypedSchema (..), named, unnamed, untypedSchema)
 import Imports
 import qualified Test.QuickCheck as QC
 import Wire.API.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
-import Data.Swagger.Typed (ToTypedSchema (..), named, untypedSchema, unnamed)
-import Data.Swagger (description)
-import Control.Lens ((?~))
 
 --------------------------------------------------------------------------------
 -- Role
@@ -172,13 +172,15 @@ newtype RoleName = RoleName {fromRoleName :: Text}
   deriving newtype (ToJSON, ToByteString, Hashable)
 
 instance ToTypedSchema RoleName where
-  toTypedSchema _ = (description ?~ desc)
-    . named "RoleName"
-    $ RoleName <$> unnamed untypedSchema
+  toTypedSchema _ =
+    (description ?~ desc)
+      . named "RoleName"
+      $ RoleName <$> unnamed untypedSchema
     where
-      desc = "Role name, between 2 and 128 chars, 'wire_' prefix \
-             \is reserved for roles designed by Wire (i.e., no \
-             \custom roles can have the same prefix)"
+      desc =
+        "Role name, between 2 and 128 chars, 'wire_' prefix \
+        \is reserved for roles designed by Wire (i.e., no \
+        \custom roles can have the same prefix)"
 
 instance FromByteString RoleName where
   parser = parser >>= maybe (fail "Invalid RoleName") return . parseRoleName

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -63,6 +63,7 @@ module Wire.API.Event.Conversation
   )
 where
 
+import Control.Applicative
 import Data.Aeson
 import Data.Aeson.Types (Parser)
 import qualified Data.HashMap.Strict as HashMap
@@ -79,6 +80,9 @@ import Wire.API.Conversation.Code (ConversationCode (..), modelConversationCode)
 import Wire.API.Conversation.Role
 import Wire.API.Conversation.Typing (TypingData (..), modelTyping)
 import Wire.API.User (UserIdList (..))
+import Data.Swagger hiding (Schema, schema)
+import Data.Swagger.Typed
+import Control.Lens ((?~))
 
 --------------------------------------------------------------------------------
 -- Event
@@ -91,6 +95,19 @@ data Event = Event
     evtData :: Maybe EventData
   }
   deriving stock (Eq, Show, Generic)
+  deriving ToSchema via TypedSchema Event
+
+instance ToTypedSchema Event where
+  toTypedSchema _ = named "Event" $
+    Event
+      <$> field "type" (description ?~ "Event type") (unnamed schema)
+      <*> field "conversation" (description ?~ "Conversation ID") (unnamed untypedSchema)
+      <*> field "from" (description ?~ "User ID") (unnamed untypedSchema)
+      <*> field
+            "time"
+            (description ?~ "Date and time this event occurred")
+            (unnamed untypedSchema)
+      <*> field' "data" (Just <$> schema)
 
 modelEvent :: Doc.Model
 modelEvent = Doc.defineModel "Event" $ do
@@ -169,6 +186,24 @@ data EventType
   | Typing
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform EventType)
+  deriving ToSchema via TypedSchema EventType
+
+instance ToTypedSchema EventType where
+  toTypedSchema _ = named "EventType" $ enum
+    [ ("conversation.member-join", pure MemberJoin),
+      ("conversation.member-leave", pure MemberLeave),
+      ("conversation.member-update", pure MemberStateUpdate),
+      ("conversation.rename", pure ConvRename),
+      ("conversation.access-update", pure ConvAccessUpdate),
+      ("conversation.receipt-mode-update", pure ConvReceiptModeUpdate),
+      ("conversation.message-timer-update", pure ConvMessageTimerUpdate),
+      ("conversation.code-update", pure ConvCodeUpdate),
+      ("conversation.code-delete", pure ConvCodeDelete),
+      ("conversation.create", pure ConvCreate),
+      ("conversation.delete", pure ConvDelete),
+      ("conversation.connect-request", pure ConvConnect),
+      ("conversation.typing", pure Typing),
+      ("conversation.otr-message-add", pure OtrMessageAdd) ]
 
 typeEventType :: Doc.DataType
 typeEventType =
@@ -237,6 +272,21 @@ data EventData
   | EdTyping TypingData
   | EdOtrMessage OtrMessage
   deriving stock (Eq, Show, Generic)
+  deriving ToSchema via TypedSchema EventData
+
+instance ToTypedSchema EventData where
+  toTypedSchema _ = named "EventData"
+     $  EdMembersJoin . SimpleMembers <$> asum
+          [ field' "users" (array (SimpleMember
+              <$> field' "id" untypedSchema
+              <*> field' "conversation_role" untypedSchema))
+          , field' "user_ids" (array
+                (SimpleMember <$> untypedSchema <*> empty))
+          ]
+     <|> EdMembersLeave
+          <$> unnamed schema
+    -- <|> EdConnect <$> (Connect <$>
+    --                    untypedSchema <*> untypedSchema <*> untypedSchema <*> untypedSchema)
 
 modelMemberEvent :: Doc.Model
 modelMemberEvent = Doc.defineModel "MemberEvent" $ do

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -279,14 +279,23 @@ instance ToTypedSchema EventData where
      $  EdMembersJoin . SimpleMembers <$> asum
           [ field' "users" (array (SimpleMember
               <$> field' "id" untypedSchema
-              <*> field' "conversation_role" untypedSchema))
+              <*> field' "conversation_role" schema))
           , field' "user_ids" (array
                 (SimpleMember <$> untypedSchema <*> empty))
           ]
-     <|> EdMembersLeave
-          <$> unnamed schema
-    -- <|> EdConnect <$> (Connect <$>
-    --                    untypedSchema <*> untypedSchema <*> untypedSchema <*> untypedSchema)
+     <|> EdMembersLeave <$> unnamed schema
+     <|> EdConnect <$> unnamed schema
+     <|> EdConvReceiptModeUpdate <$> unnamed schema
+     <|> EdConvRename <$> unnamed schema
+     <|> EdConvAccessUpdate <$> unnamed schema
+     <|> EdConvMessageTimerUpdate <$> unnamed schema
+     <|> EdConvCodeUpdate <$> unnamed schema
+     -- FUTUREWORK: add the remaining cases
+
+     -- <|> EdMemberUpdate <$> unnamed schema
+     -- <|> EdConversation <$> unnamed schema
+     -- <|> EdTyping <$> unnamed schema
+     -- <|> EdOtrMessage <$> unnamed schema
 
 modelMemberEvent :: Doc.Model
 modelMemberEvent = Doc.defineModel "MemberEvent" $ do
@@ -455,6 +464,15 @@ data Connect = Connect
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform Connect)
+
+instance ToTypedSchema Connect where
+  toTypedSchema _ =
+    (description ?~ "User-to-user connection request") . named "Connect" $
+      Connect
+        <$> field' "recipient" untypedSchema
+        <*> field' "message" untypedSchema
+        <*> field' "name" untypedSchema
+        <*> field' "email" untypedSchema
 
 modelConnect :: Doc.Model
 modelConnect = Doc.defineModel "Connect" $ do

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -123,6 +123,7 @@ import Data.Proxy (Proxy (..))
 import Data.Qualified
 import Data.Range
 import Data.Swagger (HasExample (example), NamedSchema (..), SwaggerType (..), ToSchema (..), declareSchemaRef, description, genericDeclareNamedSchema, properties, required, schema, type_)
+import qualified Data.Swagger.Typed as TS
 import qualified Data.Swagger.Build.Api as Doc
 import Data.Text.Ascii
 import Data.UUID (UUID, nil)
@@ -163,6 +164,14 @@ instance FromJSON UserIdList where
 
 instance ToJSON UserIdList where
   toJSON e = object ["user_ids" .= mUsers e]
+
+instance TS.ToTypedSchema UserIdList where
+  toTypedSchema _ =
+    (description ?~ "list of user IDs") .
+    TS.named "UserIdList" $ UserIdList <$>
+      TS.field "user_ids"
+        (description ?~ "the array of user IDs")
+        (TS.array TS.untypedSchema)
 
 --------------------------------------------------------------------------------
 -- UserProfile

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -123,8 +123,8 @@ import Data.Proxy (Proxy (..))
 import Data.Qualified
 import Data.Range
 import Data.Swagger (HasExample (example), NamedSchema (..), SwaggerType (..), ToSchema (..), declareSchemaRef, description, genericDeclareNamedSchema, properties, required, schema, type_)
-import qualified Data.Swagger.Typed as TS
 import qualified Data.Swagger.Build.Api as Doc
+import qualified Data.Swagger.Typed as TS
 import Data.Text.Ascii
 import Data.UUID (UUID, nil)
 import qualified Data.UUID as UUID
@@ -167,11 +167,13 @@ instance ToJSON UserIdList where
 
 instance TS.ToTypedSchema UserIdList where
   toTypedSchema _ =
-    (description ?~ "list of user IDs") .
-    TS.named "UserIdList" $ UserIdList <$>
-      TS.field "user_ids"
-        (description ?~ "the array of user IDs")
-        (TS.array TS.untypedSchema)
+    (description ?~ "list of user IDs")
+      . TS.named "UserIdList"
+      $ UserIdList
+        <$> TS.field
+          "user_ids"
+          (description ?~ "the array of user IDs")
+          (TS.array TS.untypedSchema)
 
 --------------------------------------------------------------------------------
 -- UserProfile

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b0062afade680bb271c22de71f4e64c9e2fba01a00b1319536910a5fc866e8d6
+-- hash: e9b2e2a54661df850103ddb5576f601d2ea6676c1a178a1bfa239ee937f60bdf
 
 name:           wire-api
 version:        0.1.0
@@ -19,6 +19,7 @@ build-type:     Simple
 
 library
   exposed-modules:
+      Data.Swagger.Typed
       Wire.API.Arbitrary
       Wire.API.Asset
       Wire.API.Asset.V3


### PR DESCRIPTION

Defining good `ToSchema` instances is not particularly easy at the moment. One can choose between using the generic-based API in deriving-swagger2, or write instances by hand using the swagger2 Lens interface directly. The former is convenient, but can only be used in limited cases, and it is essentially impossible to attach descriptions to fields. The latter is very tedious and error prone, as there are no type-level guarantees that the schema matches the type in any sense.

So I'm proposing a different API to attach schemas to types. Since approaches based on generics or type classes are very rigid, and make it really hard to specify any metadata which is not already contained in the types (such as documentation), my proposed API is based on value-level combinators, and makes use of the `Applicative` and `Alternative` type classes to reduce the number of combinators needed.

Despite being at the value-level, this is actually *more* type safe than the other approaches. For example, forgetting to specify a field in a record is a type error.

The API is based on the type constructors `Schema` and `NamedSchema`, which are both instances of `Applicative` and `Alternative`. A value of `Schema a` (resp. `NamedSchema a`) represents a Swagger schema (resp. named schema) for the type `a`, as well as all its referenced (named) schemas.

To form a schema for a record type, one can turn an existing schema definition into a field using the `field` combinator, which returns a value of type `Schema a`. Fields can then be combined using the `Applicative` interface of `Schema a`. Similarly, arrays can be specified using the `array` combinator. The `field` and `array` combinators can accept both a `Schema` and a `NamedSchema`.

Even though not strictly necessary, I have included some support for using this API together with type classes. There is a type class `ToTypedSchema` which one can instantiate to define a canonical schema for a type. Accordingly, the `schema` combinator returns the schema canonically associated to a type. There is no need to specify type parameters or pass proxy values, as the type argument of `Schema` makes most types inferrable.

To aid the transition to this API, I've also included a combinator `untypedSchema`, which converts an existing `ToSwagger` instance to a typed schema. This makes it possible to freely schemas defined using the previous approaches with the ones obtained from this API.

I have included in this PR a commit that illustrates the use of the API in practice. This won't be merged with the PR, and is just included here for convenience.

Right now, the type parameter of `Schema` is just a phantom parameter, and the `Applicative` and `Alternative` instances are simply based on the underlying `Monoid` instance of `Swagger.Schema`. However, it should be possible to include some more information in these values so that `ToJSON` and `FromJSON` instances could also be derived automatically.
