### PR TITLE
Add endpoint to list clients which doesn't accept a JSON list in req

### DIFF
--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -169,6 +169,8 @@ instance ToJSON UserIdList where
 --------------------------------------------------------------------------------
 -- LimitedQualifiedUserIdList
 
+-- | We cannot use 'Wrapped' here because all the instances require proof that 1
+-- is less than or equal to 'max'.
 newtype LimitedQualifiedUserIdList (max :: Nat) = LimitedQualifiedUserIdList
   {qualifiedUsers :: Range 1 max [Qualified UserId]}
   deriving stock (Eq, Show, Generic)
@@ -177,11 +179,11 @@ newtype LimitedQualifiedUserIdList (max :: Nat) = LimitedQualifiedUserIdList
 instance (KnownNat max, LTE 1 max) => Arbitrary (LimitedQualifiedUserIdList max) where
   arbitrary = LimitedQualifiedUserIdList <$> arbitrary
 
-instance Within [Qualified UserId] 1 max => FromJSON (LimitedQualifiedUserIdList max) where
-  parseJSON = withObject "" $ \o ->
+instance LTE 1 max => FromJSON (LimitedQualifiedUserIdList max) where
+  parseJSON = withObject "LimitedQualifiedUserIdList" $ \o ->
     LimitedQualifiedUserIdList <$> o .: "qualified_users"
 
-instance Within [Qualified UserId] 1 max => ToJSON (LimitedQualifiedUserIdList max) where
+instance LTE 1 max => ToJSON (LimitedQualifiedUserIdList max) where
   toJSON e = object ["qualified_users" .= qualifiedUsers e]
 
 --------------------------------------------------------------------------------

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -22,6 +22,7 @@
 
 module Wire.API.User
   ( UserIdList (..),
+    LimitedQualifiedUserIdList (..),
     -- Profiles
     UserProfile (..),
     SelfProfile (..),
@@ -128,6 +129,7 @@ import Data.Text.Ascii
 import Data.UUID (UUID, nil)
 import qualified Data.UUID as UUID
 import Deriving.Swagger
+import GHC.TypeLits (KnownNat, Nat)
 import Imports
 import qualified Test.QuickCheck as QC
 import Wire.API.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
@@ -163,6 +165,24 @@ instance FromJSON UserIdList where
 
 instance ToJSON UserIdList where
   toJSON e = object ["user_ids" .= mUsers e]
+
+--------------------------------------------------------------------------------
+-- LimitedQualifiedUserIdList
+
+newtype LimitedQualifiedUserIdList (max :: Nat) = LimitedQualifiedUserIdList
+  {qualifiedUsers :: Range 1 max [Qualified UserId]}
+  deriving stock (Eq, Show, Generic)
+  deriving (ToSchema) via CustomSwagger '[FieldLabelModifier CamelToSnake] (LimitedQualifiedUserIdList max)
+
+instance (KnownNat max, LTE 1 max) => Arbitrary (LimitedQualifiedUserIdList max) where
+  arbitrary = LimitedQualifiedUserIdList <$> arbitrary
+
+instance Within [Qualified UserId] 1 max => FromJSON (LimitedQualifiedUserIdList max) where
+  parseJSON = withObject "" $ \o ->
+    LimitedQualifiedUserIdList <$> o .: "qualified_users"
+
+instance Within [Qualified UserId] 1 max => ToJSON (LimitedQualifiedUserIdList max) where
+  toJSON e = object ["qualified_users" .= qualifiedUsers e]
 
 --------------------------------------------------------------------------------
 -- UserProfile

--- a/libs/wire-api/src/Wire/API/UserMap.hs
+++ b/libs/wire-api/src/Wire/API/UserMap.hs
@@ -32,6 +32,7 @@ import Data.Typeable (typeRep)
 import Imports
 import Test.QuickCheck (Arbitrary (..))
 import Wire.API.Arbitrary (generateExample, mapOf')
+import Wire.API.Wrapped (Wrapped)
 
 newtype UserMap a = UserMap {userMap :: Map UserId a}
   deriving stock (Eq, Show)
@@ -39,6 +40,8 @@ newtype UserMap a = UserMap {userMap :: Map UserId a}
 
 instance Arbitrary a => Arbitrary (UserMap a) where
   arbitrary = UserMap <$> mapOf' arbitrary arbitrary
+
+type WrappedQualifiedUserMap a = Wrapped "qualified_user_map" (QualifiedUserMap a)
 
 newtype QualifiedUserMap a = QualifiedUserMap
   { qualifiedUserMap :: Map Domain (UserMap a)

--- a/libs/wire-api/src/Wire/API/Wrapped.hs
+++ b/libs/wire-api/src/Wire/API/Wrapped.hs
@@ -1,0 +1,37 @@
+module Wire.API.Wrapped where
+
+import Control.Lens ((.~), (?~))
+import Data.Aeson
+import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
+import Data.Proxy (Proxy (..))
+import Data.Swagger
+import qualified Data.Text as Text
+import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
+import Imports
+import Test.QuickCheck (Arbitrary (..))
+
+-- | Used for wrapping request or response types so we always accept and return
+-- JSON maps
+newtype Wrapped (name :: Symbol) a = Wrapped {unwrap :: a}
+  deriving stock (Show, Eq)
+
+instance (ToJSON a, KnownSymbol name) => ToJSON (Wrapped name a) where
+  toJSON (Wrapped thing) = object [Text.pack (symbolVal (Proxy @name)) .= thing]
+
+instance (FromJSON a, KnownSymbol name) => FromJSON (Wrapped name a) where
+  parseJSON = withObject ("Wrapped" <> symbolVal (Proxy @name)) $ \o ->
+    Wrapped <$> o .: Text.pack (symbolVal (Proxy @name))
+
+-- | Creates schema without name, as coming up with a _nice_ name is fairly hard
+-- here.
+instance (ToSchema a, KnownSymbol name) => ToSchema (Wrapped name a) where
+  declareNamedSchema _ = do
+    wrappedSchema <- declareSchemaRef (Proxy @a)
+    pure $
+      NamedSchema Nothing $
+        mempty
+          & type_ ?~ SwaggerObject
+          & properties .~ InsOrdHashMap.singleton (Text.pack (symbolVal (Proxy @name))) wrappedSchema
+
+instance (Arbitrary a, KnownSymbol name) => Arbitrary (Wrapped name a) where
+  arbitrary = Wrapped <$> arbitrary

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
@@ -229,6 +229,7 @@ tests =
       testRoundTrip @User.NewUser,
       testRoundTrip @User.NewUserPublic,
       testRoundTrip @User.UserIdList,
+      testRoundTrip @(User.LimitedQualifiedUserIdList 20),
       testRoundTrip @User.UserProfile,
       testRoundTrip @User.User,
       testRoundTrip @User.SelfProfile,

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
@@ -68,6 +68,7 @@ import qualified Wire.API.User.Password as User.Password
 import qualified Wire.API.User.Profile as User.Profile
 import qualified Wire.API.User.RichInfo as User.RichInfo
 import qualified Wire.API.User.Search as User.Search
+import qualified Wire.API.Wrapped as Wrapped
 
 -- FUTUREWORK(#1446): fix tests marked as failing
 -- (either fixing Arbitrary or serialization instance)
@@ -310,7 +311,8 @@ tests =
       testRoundTrip @(User.Search.SearchResult User.Search.Contact),
       testRoundTrip @User.Search.Contact,
       testRoundTrip @(User.Search.SearchResult User.Search.TeamContact),
-      testRoundTrip @User.Search.TeamContact
+      testRoundTrip @User.Search.TeamContact,
+      testRoundTrip @(Wrapped.Wrapped "some_int" Int)
     ]
   where
     currentlyFailing = ignoreTest

--- a/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
@@ -36,6 +36,7 @@ tests =
     [ testToJSON @User.UserProfile,
       testToJSON @User.User,
       testToJSON @User.SelfProfile,
+      testToJSON @(User.LimitedQualifiedUserIdList 20),
       testToJSON @Handle.UserHandleInfo,
       testToJSON @Client.Client,
       testToJSON @Client.PubClient,

--- a/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Swagger.hs
@@ -29,6 +29,7 @@ import qualified Wire.API.User.Client.Prekey as Prekey
 import qualified Wire.API.User.Handle as Handle
 import qualified Wire.API.User.Search as Search
 import qualified Wire.API.UserMap as UserMap
+import qualified Wire.API.Wrapped as Wrapped
 
 tests :: T.TestTree
 tests =
@@ -51,7 +52,8 @@ tests =
       testToJSON @(Client.QualifiedUserClientMap (Maybe Prekey.Prekey)),
       testToJSON @Client.QualifiedUserClients,
       testToJSON @Search.Contact,
-      testToJSON @(Search.SearchResult Search.Contact)
+      testToJSON @(Search.SearchResult Search.Contact),
+      testToJSON @(Wrapped.Wrapped "some_user" User.User)
     ]
 
 testToJSON :: forall a. (Arbitrary a, Typeable a, ToJSON a, ToSchema a, Show a) => T.TestTree

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b0062afade680bb271c22de71f4e64c9e2fba01a00b1319536910a5fc866e8d6
+-- hash: f916d8c16937ff52a5fc56653f79d0444071736b0f0a275944eb24b7d1eb2952
 
 name:           wire-api
 version:        0.1.0
@@ -71,6 +71,7 @@ library
       Wire.API.User.RichInfo
       Wire.API.User.Search
       Wire.API.UserMap
+      Wire.API.Wrapped
   other-modules:
       Paths_wire_api
   hs-source-dirs:

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -328,7 +328,7 @@ type GetUserClientQualified =
     :> Get '[Servant.JSON] Public.PubClient
 
 type ListClientsBulk =
-  Summary "List all clients for a set of user ids (deprecated, use /user/list-clients/v2)"
+  Summary "List all clients for a set of user ids (deprecated, use /users/list-clients/v2)"
     :> ZAuthServant
     :> "users"
     :> "list-clients"

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -120,6 +120,7 @@ import qualified Wire.API.User.Handle as Public
 import qualified Wire.API.User.Password as Public
 import qualified Wire.API.User.RichInfo as Public
 import qualified Wire.API.UserMap as Public
+import qualified Wire.API.Wrapped as Public
 
 ---------------------------------------------------------------------------
 -- Sitemap
@@ -342,7 +343,7 @@ type ListClientsBulkV2 =
     :> "list-clients"
     :> "v2"
     :> Servant.ReqBody '[Servant.JSON] (Public.LimitedQualifiedUserIdList MaxUsersForListClientsBulk)
-    :> Post '[Servant.JSON] (Public.QualifiedUserMap (Set Public.PubClient))
+    :> Post '[Servant.JSON] (Public.WrappedQualifiedUserMap (Set Public.PubClient))
 
 type GetUsersPrekeysClientUnqualified =
   Summary "(deprecated) Get a prekey for a specific client of a user."
@@ -1193,8 +1194,8 @@ listClientsBulk :: UserId -> Range 1 MaxUsersForListClientsBulk [Qualified UserI
 listClientsBulk _zusr limitedUids = do
   API.lookupPubClientsBulk (fromRange limitedUids) !>> clientError
 
-listClientsBulkV2 :: UserId -> Public.LimitedQualifiedUserIdList MaxUsersForListClientsBulk -> Handler (Public.QualifiedUserMap (Set Public.PubClient))
-listClientsBulkV2 zusr userIds = listClientsBulk zusr (Public.qualifiedUsers userIds)
+listClientsBulkV2 :: UserId -> Public.LimitedQualifiedUserIdList MaxUsersForListClientsBulk -> Handler (Public.WrappedQualifiedUserMap (Set Public.PubClient))
+listClientsBulkV2 zusr userIds = Public.Wrapped <$> listClientsBulk zusr (Public.qualifiedUsers userIds)
 
 getUserClientQualified :: Domain -> UserId -> ClientId -> Handler Public.PubClient
 getUserClientQualified domain uid cid = do

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -49,6 +49,8 @@ import UnliftIO (mapConcurrently)
 import Util
 import Wire.API.User.Client (QualifiedUserClientMap (..), QualifiedUserClients (..), UserClientMap (..), UserClients (..))
 import Wire.API.UserMap (QualifiedUserMap (..), UserMap (..))
+import Wire.API.User (LimitedQualifiedUserIdList(LimitedQualifiedUserIdList))
+import Data.Range (unsafeRange)
 
 tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
 tests _cl _at opts p b c g =
@@ -68,6 +70,7 @@ tests _cl _at opts p b c g =
       test p "post /users/prekeys" $ testMultiUserGetPrekeys b,
       test p "post /users/list-prekeys" $ testMultiUserGetPrekeysQualified b opts,
       test p "post /users/list-clients - 200" $ testListClientsBulk opts b,
+      test p "post /users/list-clients/v2 - 200" $ testListClientsBulkV2 opts b,
       test p "post /clients - 201 (pwd)" $ testAddGetClient True b c,
       test p "post /clients - 201 (no pwd)" $ testAddGetClient False b c,
       test p "post /clients - 403" $ testClientReauthentication b,
@@ -229,6 +232,46 @@ testListClientsBulk opts brig = do
         . zUser uid3
         . contentJson
         . body (RequestBodyLBS $ encode [Qualified uid1 domain, Qualified uid2 domain])
+    )
+    !!! do
+      const 200 === statusCode
+      const (Just expectedResponse) === responseJsonMaybe
+
+testListClientsBulkV2 :: Opt.Opts -> Brig -> Http ()
+testListClientsBulkV2 opts brig = do
+  uid1 <- userId <$> randomUser brig
+  let (pk11, lk11) = (somePrekeys !! 0, (someLastPrekeys !! 0))
+  let (pk12, lk12) = (somePrekeys !! 1, (someLastPrekeys !! 1))
+  let (pk13, lk13) = (somePrekeys !! 2, (someLastPrekeys !! 2))
+  c11 <- responseJsonError =<< addClient brig uid1 (defNewClient PermanentClientType [pk11] lk11)
+  c12 <- responseJsonError =<< addClient brig uid1 (defNewClient PermanentClientType [pk12] lk12)
+  c13 <- responseJsonError =<< addClient brig uid1 (defNewClient TemporaryClientType [pk13] lk13)
+
+  uid2 <- userId <$> randomUser brig
+  let (pk21, lk21) = (somePrekeys !! 3, (someLastPrekeys !! 3))
+  let (pk22, lk22) = (somePrekeys !! 4, (someLastPrekeys !! 4))
+  c21 <- responseJsonError =<< addClient brig uid2 (defNewClient PermanentClientType [pk21] lk21)
+  c22 <- responseJsonError =<< addClient brig uid2 (defNewClient PermanentClientType [pk22] lk22)
+
+  let domain = Opt.setFederationDomain $ Opt.optSettings opts
+  uid3 <- userId <$> randomUser brig
+  let mkPubClient cl = PubClient (clientId cl) (clientClass cl)
+  let expectedResponse :: QualifiedUserMap (Set PubClient) =
+        QualifiedUserMap $
+          Map.singleton
+            domain
+            ( UserMap $
+                Map.fromList
+                  [ (uid1, Set.fromList $ mkPubClient <$> [c11, c12, c13]),
+                    (uid2, Set.fromList $ mkPubClient <$> [c21, c22])
+                  ]
+            )
+  post
+    ( brig
+        . paths ["users", "list-clients", "v2"]
+        . zUser uid3
+        . contentJson
+        . body (RequestBodyLBS $ encode (LimitedQualifiedUserIdList @20 (unsafeRange [Qualified uid1 domain, Qualified uid2 domain])))
     )
     !!! do
       const 200 === statusCode

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -28,7 +28,7 @@ import Bilge.Assert
 import qualified Brig.Options as Opt
 import Brig.Types
 import Brig.Types.User.Auth hiding (user)
-import Control.Lens hiding ((#))
+import Control.Lens (preview, (.~), (^.), (^?))
 import Data.Aeson
 import Data.Aeson.Lens
 import Data.ByteString.Conversion
@@ -50,7 +50,8 @@ import UnliftIO (mapConcurrently)
 import Util
 import Wire.API.User (LimitedQualifiedUserIdList (LimitedQualifiedUserIdList))
 import Wire.API.User.Client (QualifiedUserClientMap (..), QualifiedUserClients (..), UserClientMap (..), UserClients (..))
-import Wire.API.UserMap (QualifiedUserMap (..), UserMap (..))
+import Wire.API.UserMap (QualifiedUserMap (..), UserMap (..), WrappedQualifiedUserMap)
+import Wire.API.Wrapped (Wrapped (..))
 
 tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
 tests _cl _at opts p b c g =
@@ -256,8 +257,8 @@ testListClientsBulkV2 opts brig = do
   let domain = Opt.setFederationDomain $ Opt.optSettings opts
   uid3 <- userId <$> randomUser brig
   let mkPubClient cl = PubClient (clientId cl) (clientClass cl)
-  let expectedResponse :: QualifiedUserMap (Set PubClient) =
-        QualifiedUserMap $
+  let expectedResponse :: WrappedQualifiedUserMap (Set PubClient) =
+        Wrapped . QualifiedUserMap $
           Map.singleton
             domain
             ( UserMap $

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -36,6 +36,7 @@ import Data.Id hiding (client)
 import qualified Data.List1 as List1
 import qualified Data.Map as Map
 import Data.Qualified (Qualified (..))
+import Data.Range (unsafeRange)
 import qualified Data.Set as Set
 import qualified Data.Vector as Vec
 import Gundeck.Types.Notification
@@ -47,10 +48,9 @@ import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
 import UnliftIO (mapConcurrently)
 import Util
+import Wire.API.User (LimitedQualifiedUserIdList (LimitedQualifiedUserIdList))
 import Wire.API.User.Client (QualifiedUserClientMap (..), QualifiedUserClients (..), UserClientMap (..), UserClients (..))
 import Wire.API.UserMap (QualifiedUserMap (..), UserMap (..))
-import Wire.API.User (LimitedQualifiedUserIdList(LimitedQualifiedUserIdList))
-import Data.Range (unsafeRange)
 
 tests :: ConnectionLimit -> Opt.Timeout -> Opt.Opts -> Manager -> Brig -> Cannon -> Galley -> TestTree
 tests _cl _at opts p b c g =


### PR DESCRIPTION
The new endpoint is at `POST /users/list-clients/v2`, this endpoint consumes a
JSON object with one key `qualified_users` whose value must be a list of
`Qualiified UserId` limited to MaxUsersForListClientsBulk.