### PR TITLE
Fixes a k8s typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ It also contains
 - **build**: Build scripts and Dockerfiles for some platforms
 - **deploy**: (Work-in-progress) - how to run wire-server in an ephemeral, in-memory demo mode
 - **doc**: Documentation
-- **hack**: scripts and configuration for kuberentes helm chart development/releases mainly used by CI
+- **hack**: scripts and configuration for kubernetes helm chart development/releases mainly used by CI
 - **charts**: kubernetes helm charts
 
 ## Architecture Overview


### PR DESCRIPTION
This one-line fix is about a typo in the README