### PR TITLE
Internal end-point for ejpd request processing.

### DIFF
--- a/charts/brig/templates/tests/configmap.yaml
+++ b/charts/brig/templates/tests/configmap.yaml
@@ -22,6 +22,10 @@ data:
       host: cargohold
       port: 8080
 
+    gundeck:
+      host: gundeck
+      port: 8080
+
     spar:
       host: spar
       port: 8080

--- a/libs/brig-types/brig-types.cabal
+++ b/libs/brig-types/brig-types.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1060fdc26ef57534c0f61722613ae48c5ebe98d481fcc21cae9c1ebab816a8bb
+-- hash: cdc8e9db5e496dfa5804937858da4ac01666e1c604c54b9c0ea9318d521aded2
 
 name:           brig-types
 version:        1.35.0
@@ -40,6 +40,7 @@ library
       Brig.Types.Test.Arbitrary
       Brig.Types.User
       Brig.Types.User.Auth
+      Brig.Types.User.EJPD
   other-modules:
       Paths_brig_types
   hs-source-dirs:
@@ -54,8 +55,12 @@ library
     , bytestring-conversion >=0.2
     , cassandra-util
     , containers >=0.5
+    , deriving-swagger2 >=0.1.0
     , imports
+    , servant-server >=0.18.2
+    , servant-swagger >=1.1.11
     , string-conversions
+    , swagger2 >=2.5
     , text >=0.11
     , time >=1.1
     , types-common >=0.16
@@ -77,18 +82,19 @@ test-suite brig-types-tests
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path -threaded -with-rtsopts=-N
   build-depends:
-      QuickCheck
-    , aeson
-    , attoparsec
-    , base
+      QuickCheck >=2.9
+    , aeson >=0.11
+    , attoparsec >=0.10
+    , base ==4.*
     , brig-types
-    , containers
+    , containers >=0.5
     , imports
+    , swagger2 >=2.5
     , tasty
     , tasty-quickcheck
-    , text
-    , time
-    , types-common
-    , unordered-containers
+    , text >=0.11
+    , time >=1.1
+    , types-common >=0.16
+    , unordered-containers >=0.2
     , wire-api
   default-language: Haskell2010

--- a/libs/brig-types/package.yaml
+++ b/libs/brig-types/package.yaml
@@ -9,25 +9,29 @@ maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2017 Wire Swiss GmbH
 license: AGPL-3
 dependencies:
+- aeson >=0.11
+- attoparsec >=0.10
+- base ==4.*
+- containers >=0.5
 - imports
+- QuickCheck >=2.9
+- swagger2 >=2.5
+- text >=0.11
+- time >=1.1
+- types-common >=0.16
+- unordered-containers >=0.2
 - wire-api
 library:
   source-dirs: src
   ghc-options:
   - -funbox-strict-fields
   dependencies:
-  - aeson >=0.11
-  - attoparsec >=0.10
-  - base ==4.*
   - bytestring-conversion >=0.2
   - cassandra-util
-  - containers >=0.5
-  - QuickCheck >=2.9
+  - deriving-swagger2 >=0.1.0
+  - servant-server >=0.18.2
+  - servant-swagger >=1.1.11
   - string-conversions
-  - text >=0.11
-  - time >=1.1
-  - types-common >=0.16
-  - unordered-containers >=0.2
 tests:
   brig-types-tests:
     main: Main.hs
@@ -36,15 +40,6 @@ tests:
     - -threaded
     - -with-rtsopts=-N
     dependencies:
-    - aeson
-    - attoparsec
-    - base
     - brig-types
-    - containers
-    - QuickCheck
     - tasty
     - tasty-quickcheck
-    - text
-    - time
-    - types-common
-    - unordered-containers

--- a/libs/brig-types/src/Brig/Types/User/EJPD.hs
+++ b/libs/brig-types/src/Brig/Types/User/EJPD.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE DerivingVia #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+-- | Identify users for law enforcement.  (Wire has legal requirements to cooperate with the
+-- authorities.  The wire backend operations team uses this to answer identification requests
+-- manually.)
+module Brig.Types.User.EJPD
+  ( EJPDRequestBody (EJPDRequestBody, ejpdRequestBody),
+    EJPDResponseBody (EJPDResponseBody, ejpdResponseBody),
+    EJPDResponseItem (EJPDResponseItem, ejpdResponseHandle, ejpdResponsePushTokens, ejpdResponseContacts),
+  )
+where
+
+import Data.Aeson hiding (json)
+import Data.Handle (Handle)
+import Data.Id (TeamId, UserId)
+import Data.Swagger (ToSchema)
+import Deriving.Swagger (CamelToSnake, CustomSwagger (..), FieldLabelModifier, StripSuffix)
+import Imports hiding (head)
+import Test.QuickCheck (Arbitrary)
+import Wire.API.Arbitrary (GenericUniform (..))
+import Wire.API.Connection (Relation)
+import Wire.API.Team.Member (NewListType)
+import Wire.API.User.Identity (Email, Phone)
+import Wire.API.User.Profile (Name)
+
+newtype EJPDRequestBody = EJPDRequestBody {ejpdRequestBody :: [Handle]}
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform EJPDRequestBody)
+  deriving (ToSchema) via CustomSwagger '[FieldLabelModifier (CamelToSnake, StripSuffix "_body")] EJPDRequestBody
+
+newtype EJPDResponseBody = EJPDResponseBody {ejpdResponseBody :: [EJPDResponseItem]}
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform EJPDResponseBody)
+  deriving (ToSchema) via CustomSwagger '[FieldLabelModifier (CamelToSnake, StripSuffix "_body")] EJPDResponseBody
+
+data EJPDResponseItem = EJPDResponseItem
+  { ejpdResponseUserId :: UserId,
+    ejpdResponseTeamId :: Maybe TeamId,
+    ejpdResponseName :: Name,
+    ejpdResponseHandle :: Maybe Handle,
+    ejpdResponseEmail :: Maybe Email,
+    ejpdResponsePhone :: Maybe Phone,
+    ejpdResponsePushTokens :: Set Text, -- 'Wire.API.Push.V2.Token.Token', but that would produce an orphan instance.
+    ejpdResponseContacts :: Maybe (Set (Relation, EJPDResponseItem)),
+    ejpdResponseTeamContacts :: Maybe (Set EJPDResponseItem, NewListType)
+  }
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform EJPDResponseItem)
+  deriving (ToSchema) via CustomSwagger '[FieldLabelModifier CamelToSnake] EJPDResponseItem
+
+instance ToJSON EJPDRequestBody where
+  toJSON (EJPDRequestBody hs) = object ["ejpd_request" .= hs]
+
+instance FromJSON EJPDRequestBody where
+  parseJSON = withObject "EJPDRequestBody" $ EJPDRequestBody <$$> (.: "ejpd_request")
+
+instance ToJSON EJPDResponseBody where
+  toJSON (EJPDResponseBody is) = object ["ejpd_response" .= is]
+
+instance FromJSON EJPDResponseBody where
+  parseJSON = withObject "EJPDResponseBody" $ EJPDResponseBody <$$> (.: "ejpd_response")
+
+instance ToJSON EJPDResponseItem where
+  toJSON rspi =
+    object
+      [ "ejpd_response_user_id" .= ejpdResponseUserId rspi,
+        "ejpd_response_team_id" .= ejpdResponseTeamId rspi,
+        "ejpd_response_name" .= ejpdResponseName rspi,
+        "ejpd_response_handle" .= ejpdResponseHandle rspi,
+        "ejpd_response_email" .= ejpdResponseEmail rspi,
+        "ejpd_response_phone" .= ejpdResponsePhone rspi,
+        "ejpd_response_push_tokens" .= ejpdResponsePushTokens rspi,
+        "ejpd_response_contacts" .= ejpdResponseContacts rspi,
+        "ejpd_response_team_contacts" .= ejpdResponseTeamContacts rspi
+      ]
+
+instance FromJSON EJPDResponseItem where
+  parseJSON = withObject "EJPDResponseItem" $ \obj ->
+    EJPDResponseItem
+      <$> obj .: "ejpd_response_user_id"
+      <*> obj .:? "ejpd_response_team_id"
+      <*> obj .: "ejpd_response_name"
+      <*> obj .:? "ejpd_response_handle"
+      <*> obj .:? "ejpd_response_email"
+      <*> obj .:? "ejpd_response_phone"
+      <*> obj .: "ejpd_response_push_tokens"
+      <*> obj .:? "ejpd_response_contacts"
+      <*> obj .:? "ejpd_response_team_contacts"

--- a/libs/brig-types/test/unit/Test/Brig/Types/User.hs
+++ b/libs/brig-types/test/unit/Test/Brig/Types/User.hs
@@ -29,8 +29,9 @@ module Test.Brig.Types.User where
 
 import Brig.Types.Intra (NewUserScimInvitation (..), ReAuthUser (..))
 import Brig.Types.User (ManagedByUpdate (..), RichInfoUpdate (..))
+import Brig.Types.User.EJPD (EJPDRequestBody (..), EJPDResponseBody (..))
 import Imports
-import Test.Brig.Roundtrip (testRoundTrip)
+import Test.Brig.Roundtrip (testRoundTrip, testRoundTripWithSwagger)
 import Test.QuickCheck (Arbitrary (arbitrary))
 import Test.Tasty
 
@@ -42,7 +43,9 @@ roundtripTests =
   [ testRoundTrip @ManagedByUpdate,
     testRoundTrip @ReAuthUser,
     testRoundTrip @RichInfoUpdate,
-    testRoundTrip @NewUserScimInvitation
+    testRoundTrip @NewUserScimInvitation,
+    testRoundTripWithSwagger @EJPDRequestBody,
+    testRoundTripWithSwagger @EJPDResponseBody
   ]
 
 instance Arbitrary ManagedByUpdate where

--- a/libs/hscim/src/Web/Scim/Schema/User/Phone.hs
+++ b/libs/hscim/src/Web/Scim/Schema/User/Phone.hs
@@ -26,7 +26,7 @@ data Phone = Phone
   { typ :: Maybe Text,
     value :: Maybe Text
   }
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 instance FromJSON Phone where
   parseJSON = genericParseJSON parseOptions . jsonLower

--- a/libs/types-common/src/Data/Handle.hs
+++ b/libs/types-common/src/Data/Handle.hs
@@ -46,7 +46,7 @@ import Util.Attoparsec (takeUpToWhile)
 -- | Also called username.
 newtype Handle = Handle
   {fromHandle :: Text}
-  deriving stock (Eq, Show, Generic)
+  deriving stock (Eq, Ord, Show, Generic)
   deriving newtype (ToJSON, ToByteString, Hashable, ToSchema, ToParamSchema)
 
 instance FromHttpApiData Handle where

--- a/libs/wire-api/src/Wire/API/Connection.hs
+++ b/libs/wire-api/src/Wire/API/Connection.hs
@@ -50,7 +50,9 @@ import Data.Id
 import Data.Json.Util (UTCTimeMillis)
 import Data.Range
 import qualified Data.Swagger.Build.Api as Doc
+import Data.Swagger.Schema
 import Data.Text as Text
+import Deriving.Swagger (CamelToSnake, ConstructorTagModifier, CustomSwagger)
 import Imports
 import Wire.API.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
 
@@ -160,6 +162,7 @@ data Relation
   | Cancelled
   deriving stock (Eq, Ord, Show, Generic)
   deriving (Arbitrary) via (GenericUniform Relation)
+  deriving (ToSchema) via (CustomSwagger '[ConstructorTagModifier CamelToSnake] Relation)
 
 typeRelation :: Doc.DataType
 typeRelation =

--- a/libs/wire-api/src/Wire/API/User/Identity.hs
+++ b/libs/wire-api/src/Wire/API/User/Identity.hs
@@ -225,7 +225,7 @@ validateEmail =
 -- Phone
 
 newtype Phone = Phone {fromPhone :: Text}
-  deriving stock (Eq, Show, Generic)
+  deriving stock (Eq, Ord, Show, Generic)
   deriving newtype (ToJSON, ToSchema)
 
 instance FromJSON Phone where

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
@@ -218,6 +218,7 @@ tests =
       testRoundTrip @Team.LegalHold.External.LegalHoldServiceRemove,
       testRoundTrip @Team.Member.TeamMember,
       testRoundTrip @Team.Member.ListType,
+      testRoundTrip @Team.Member.NewListType,
       testRoundTrip @Team.Member.TeamMemberList,
       testRoundTrip @Team.Member.NewTeamMember,
       testRoundTrip @Team.Member.TeamMemberDeleteData,

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e434da78c7b7f98b028bdcd4badd0403971552342a96c6dfa8f4c54e01729f8d
+-- hash: f5a02c8e0d84aa917019163aa93d946580d81a040505c093f72f345bddf36287
 
 name:           brig
 version:        1.35.0
@@ -93,6 +93,7 @@ library
       Brig.User.Auth.Cookie.Limit
       Brig.User.Auth.DB.Cookie
       Brig.User.Auth.DB.Instances
+      Brig.User.EJPD
       Brig.User.Email
       Brig.User.Event
       Brig.User.Event.Log
@@ -266,6 +267,7 @@ executable brig-integration
   other-modules:
       API.Calling
       API.Federation
+      API.Internal
       API.Metrics
       API.Provider
       API.RichInfo.Util
@@ -304,6 +306,7 @@ executable brig-integration
     , async
     , attoparsec
     , base
+    , base16-bytestring
     , bilge
     , bloodhound
     , brig

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -137,7 +137,6 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - aeson
-    - brig
     - base
     - bloodhound
     - brig
@@ -181,12 +180,12 @@ executables:
     source-dirs: test/integration
     dependencies:
     - aeson
-    - lens-aeson
     - async
     - attoparsec
+    - base
+    - base16-bytestring
     - bilge
     - bloodhound
-    - base
     - brig
     - brig-types
     - bytestring >=0.9
@@ -202,14 +201,15 @@ executables:
     - filepath >=1.4
     - galley-types
     - gundeck-types
-    - HsOpenSSL
     - hscim
+    - HsOpenSSL
     - http-api-data
     - http-client
     - http-client-tls >=0.2
     - http-types
     - imports
     - lens >=3.9
+    - lens-aeson
     - lens-aeson
     - metrics-wai
     - mime >=0.4
@@ -221,17 +221,17 @@ executables:
     - pem
     - proto-lens
     - QuickCheck
-    - raw-strings-qq
     - random >=1.0
     - random-shuffle
+    - raw-strings-qq
     - retry >=0.6
     - safe
     - saml2-web-sso
-    - spar
-    - string-conversions
     - servant
     - servant-client
     - servant-client-core
+    - spar
+    - string-conversions
     - tasty >=1.0
     - tasty-cannon >=0.3.4
     - tasty-hunit >=0.2

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -83,7 +83,9 @@ type EJPDRequest =
   Summary
     "Identify users for law enforcement.  (Wire has legal requirements to cooperate \
     \with the authorities.  The wire backend operations team uses this to answer \
-    \identification requests manually.)"
+    \identification requests manually.  It is our best-effort representation of the \
+    \minimum required information we need to hand over about targets and (in some \
+    \cases) their communication peers.)"
     :> "ejpd-request"
     :> QueryParam'
          [ Optional,

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -81,11 +81,11 @@ import Wire.API.User.RichInfo
 
 type EJPDRequest =
   Summary
-    "Identify users for law enforcement.  (Wire has legal requirements to cooperate \
+    "Identify users for law enforcement.  Wire has legal requirements to cooperate \
     \with the authorities.  The wire backend operations team uses this to answer \
     \identification requests manually.  It is our best-effort representation of the \
     \minimum required information we need to hand over about targets and (in some \
-    \cases) their communication peers.)"
+    \cases) their communication peers.  For more information, consult ejpd.admin.ch."
     :> "ejpd-request"
     :> QueryParam'
          [ Optional,

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -19,6 +19,10 @@
 
 module Brig.API.Internal
   ( sitemap,
+    servantSitemap,
+    swaggerDocsAPI,
+    ServantAPI,
+    SwaggerDocsAPI,
   )
 where
 
@@ -39,11 +43,13 @@ import Brig.Team.DB (lookupInvitationByEmail)
 import Brig.Types
 import Brig.Types.Intra
 import Brig.Types.Team.LegalHold (LegalHoldClientRequest (..))
+import qualified Brig.Types.User.EJPD as EJPD
 import qualified Brig.User.API.Auth as Auth
 import qualified Brig.User.API.Search as Search
+import qualified Brig.User.EJPD
 import Brig.User.Event (UserEvent (UserUpdated), UserUpdatedData (eupSSOId, eupSSOIdRemoved), emptyUserUpdatedData)
 import Control.Error hiding (bool)
-import Control.Lens (view)
+import Control.Lens (view, (.~))
 import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Conversion as List
@@ -52,6 +58,7 @@ import Data.Id as Id
 import qualified Data.List1 as List1
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import Data.Swagger (HasInfo (info), HasTitle (title), Swagger)
 import Galley.Types (UserClients (..))
 import Imports hiding (head)
 import Network.HTTP.Types.Status
@@ -60,12 +67,54 @@ import Network.Wai.Predicate hiding (result, setStatus)
 import Network.Wai.Routing
 import Network.Wai.Utilities as Utilities
 import Network.Wai.Utilities.ZAuth (zauthConnId, zauthUserId)
+import Servant hiding (Handler, JSON, addHeader, respond)
+import qualified Servant
+import Servant.Swagger (HasSwagger (toSwagger))
+import Servant.Swagger.Internal.Orphans ()
+import Servant.Swagger.UI
 import qualified System.Logger.Class as Log
 import Wire.API.User
 import Wire.API.User.RichInfo
 
 ---------------------------------------------------------------------------
--- Sitemap
+-- Sitemap (servant)
+
+type EJPDRequest =
+  Summary
+    "Identify users for law enforcement.  (Wire has legal requirements to cooperate \
+    \with the authorities.  The wire backend operations team uses this to answer \
+    \identification requests manually.)"
+    :> "ejpd-request"
+    :> QueryParam'
+         [ Optional,
+           Strict,
+           Description "Also provide information about all contacts of the identified users"
+         ]
+         "include_contacts"
+         Bool
+    :> Servant.ReqBody '[Servant.JSON] EJPD.EJPDRequestBody
+    :> Post '[Servant.JSON] EJPD.EJPDResponseBody
+
+type ServantAPI =
+  "i"
+    :> ( EJPDRequest
+       )
+
+servantSitemap :: ServerT ServantAPI Handler
+servantSitemap = Brig.User.EJPD.ejpdRequest
+
+type SwaggerDocsAPI = "api" :> "internal" :> SwaggerSchemaUI "swagger-ui" "swagger.json"
+
+swaggerDocsAPI :: Servant.Server SwaggerDocsAPI
+swaggerDocsAPI = swaggerSchemaUIServer swaggerDoc
+
+swaggerDoc :: Swagger
+swaggerDoc =
+  toSwagger (Proxy @ServantAPI)
+    & info . title .~ "Wire-Server API as Swagger 2.0 (internal end-points; incomplete) "
+
+---------------------------------------------------------------------------
+-- Sitemap (wai-route)
 
 sitemap :: Routes a Handler ()
 sitemap = do

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -114,14 +114,14 @@ lookupConnectionStatus from to =
 
 -- | See 'lookupContactListWithRelation'.
 lookupContactList :: UserId -> AppIO [UserId]
-lookupContactList u = fst <$$> lookupContactListWithRelation u
+lookupContactList u =
+  fst <$$> (filter ((== Accepted) . snd) <$> lookupContactListWithRelation u)
 
 -- | For a given user 'A', lookup the list of users that form his contact list,
 -- i.e. the users to whom 'A' has an outgoing 'Accepted' relation (A -> B).
 lookupContactListWithRelation :: UserId -> AppIO [(UserId, Relation)]
 lookupContactListWithRelation u =
-  filter ((== Accepted) . snd)
-    <$> retry x1 (query contactsSelect (params Quorum (Identity u)))
+  retry x1 (query contactsSelect (params Quorum (Identity u)))
 
 -- | Count the number of connections a user has in a specific relation status.
 -- Note: The count is eventually consistent.

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -26,6 +26,7 @@ module Brig.Data.Connection
     lookupConnections,
     lookupConnectionStatus,
     lookupContactList,
+    lookupContactListWithRelation,
     countConnections,
     deleteConnections,
   )
@@ -111,11 +112,15 @@ lookupConnectionStatus from to =
   map toConnectionStatus
     <$> retry x1 (query connectionStatusSelect (params Quorum (from, to)))
 
+-- | See 'lookupContactListWithRelation'.
+lookupContactList :: UserId -> AppIO [UserId]
+lookupContactList u = fst <$$> lookupContactListWithRelation u
+
 -- | For a given user 'A', lookup the list of users that form his contact list,
 -- i.e. the users to whom 'A' has an outgoing 'Accepted' relation (A -> B).
-lookupContactList :: UserId -> AppIO [UserId]
-lookupContactList u =
-  map fst . filter ((== Accepted) . snd)
+lookupContactListWithRelation :: UserId -> AppIO [(UserId, Relation)]
+lookupContactListWithRelation u =
+  filter ((== Accepted) . snd)
     <$> retry x1 (query contactsSelect (params Quorum (Identity u)))
 
 -- | Count the number of connections a user has in a specific relation status.

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -36,6 +36,7 @@ module Brig.IO.Intra
     -- * Clients
     Brig.IO.Intra.newClient,
     rmClient,
+    lookupPushToken,
 
     -- * Account Deletion
     rmUser,
@@ -686,6 +687,20 @@ rmClient u c = do
         )
   where
     expected = [status200, status204, status404]
+
+lookupPushToken :: UserId -> AppIO [Push.PushToken]
+lookupPushToken uid = do
+  g <- view gundeck
+  rsp <-
+    rpc'
+      "gundeck"
+      (g :: Request)
+      ( method GET
+          . paths ["i", "push-tokens", toByteString' uid]
+          . zUser uid
+          . expect2xx
+      )
+  responseJsonMaybe rsp & maybe (pure []) (pure . pushTokens)
 
 -------------------------------------------------------------------------------
 -- Team Management

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -26,6 +26,7 @@ where
 import Brig.API (sitemap)
 import Brig.API.Federation (federationSitemap)
 import Brig.API.Handler
+import qualified Brig.API.Internal as IAPI
 import Brig.API.Public (ServantAPI, SwaggerDocsAPI, servantSitemap, swaggerDocsAPI)
 import qualified Brig.API.User as API
 import Brig.AWS (sesQueue)
@@ -121,6 +122,7 @@ mkApp o = do
         (Proxy @ServantCombinedAPI)
         ( swaggerDocsAPI
             :<|> Servant.hoistServer (Proxy @ServantAPI) (toServantHandler e) servantSitemap
+            :<|> Servant.hoistServer (Proxy @IAPI.ServantAPI) (toServantHandler e) IAPI.servantSitemap
             :<|> Servant.hoistServer (genericApi (Proxy @FederationBrig.Api)) (toServantHandler e) federationSitemap
             :<|> Servant.Tagged (app e)
         )
@@ -128,6 +130,7 @@ mkApp o = do
 type ServantCombinedAPI =
   ( SwaggerDocsAPI
       :<|> ServantAPI
+      :<|> IAPI.ServantAPI
       :<|> ToServantApi FederationBrig.Api
       :<|> Servant.Raw
   )

--- a/services/brig/src/Brig/User/EJPD.hs
+++ b/services/brig/src/Brig/User/EJPD.hs
@@ -1,0 +1,102 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+-- | Identify users for law enforcement.  (Wire has legal requirements to cooperate with the
+-- authorities.  The wire backend operations team uses this to answer identification requests
+-- manually.)
+module Brig.User.EJPD (ejpdRequest) where
+
+import Brig.API.Handler
+import Brig.API.User (lookupHandle)
+import Brig.App (AppIO)
+import qualified Brig.Data.Connection as Conn
+import Brig.Data.User (lookupUser)
+import qualified Brig.IO.Intra as Intra
+import Brig.Types.User (HavePendingInvitations (NoPendingInvitations))
+import Brig.Types.User.EJPD (EJPDRequestBody (EJPDRequestBody), EJPDResponseBody (EJPDResponseBody), EJPDResponseItem (EJPDResponseItem))
+import Control.Error hiding (bool)
+import Control.Lens (view, (^.))
+import Data.Handle (Handle)
+import Data.Id (UserId)
+import qualified Data.Set as Set
+import Imports hiding (head)
+import Servant.Swagger.Internal.Orphans ()
+import Wire.API.Connection (Relation)
+import qualified Wire.API.Push.Token as PushTok
+import qualified Wire.API.Team.Member as Team
+import Wire.API.User (User, userDisplayName, userEmail, userHandle, userId, userPhone, userTeam)
+
+ejpdRequest :: Maybe Bool -> EJPDRequestBody -> Handler EJPDResponseBody
+ejpdRequest includeContacts (EJPDRequestBody handles) = do
+  ExceptT $ Right . EJPDResponseBody . catMaybes <$> forM handles (go1 (fromMaybe False includeContacts))
+  where
+    -- find uid given handle
+    go1 :: Bool -> Handle -> AppIO (Maybe EJPDResponseItem)
+    go1 includeContacts' handle = do
+      mbUid <- lookupHandle handle
+      mbUsr <- maybe (pure Nothing) (lookupUser NoPendingInvitations) mbUid
+      maybe (pure Nothing) (fmap Just . go2 includeContacts') mbUsr
+
+    -- construct response item given uid
+    go2 :: Bool -> User -> AppIO EJPDResponseItem
+    go2 includeContacts' target = do
+      let uid = userId target
+
+      ptoks <-
+        PushTok.tokenText . view PushTok.token <$$> Intra.lookupPushToken uid
+
+      mbContacts <-
+        if includeContacts'
+          then do
+            contacts :: [(UserId, Relation)] <-
+              Conn.lookupContactListWithRelation uid
+
+            contactsFull :: [Maybe (Relation, EJPDResponseItem)] <-
+              forM contacts $ \(uid', rel) -> do
+                mbUsr <- lookupUser NoPendingInvitations uid'
+                maybe (pure Nothing) (\usr -> Just . (rel,) <$> go2 False usr) mbUsr
+
+            pure . Just . Set.fromList . catMaybes $ contactsFull
+          else do
+            pure Nothing
+
+      mbTeamContacts <-
+        case (includeContacts', userTeam target) of
+          (True, Just tid) -> do
+            memberList <- Intra.getTeamMembers tid
+            let members = (view Team.userId <$> (memberList ^. Team.teamMembers)) \\ [uid]
+
+            contactsFull :: [Maybe EJPDResponseItem] <-
+              forM members $ \uid' -> do
+                mbUsr <- lookupUser NoPendingInvitations uid'
+                maybe (pure Nothing) (fmap Just . go2 False) mbUsr
+
+            pure . Just . (,Team.toNewListType (memberList ^. Team.teamMemberListType)) . Set.fromList . catMaybes $ contactsFull
+          _ -> do
+            pure Nothing
+
+      pure $
+        EJPDResponseItem
+          uid
+          (userTeam target)
+          (userDisplayName target)
+          (userHandle target)
+          (userEmail target)
+          (userPhone target)
+          (Set.fromList ptoks)
+          mbContacts
+          mbTeamContacts

--- a/services/brig/test/integration/API/Internal.hs
+++ b/services/brig/test/integration/API/Internal.hs
@@ -1,0 +1,164 @@
+module API.Internal
+  ( tests,
+  )
+where
+
+import API.Team.Util (createPopulatedBindingTeamWithNamesAndHandles)
+import Bilge
+import qualified Brig.API.Internal as IAPI
+import qualified Brig.Options as Opt
+import Brig.Types
+import Brig.Types.User.EJPD as EJPD
+import Control.Lens (view, (^.))
+import Control.Monad.Catch (MonadCatch, throwM)
+import qualified Data.ByteString.Base16 as B16
+import Data.Handle (Handle)
+import Data.Id
+import qualified Data.List1 as List1
+import Data.Proxy (Proxy (Proxy))
+import qualified Data.Set as Set
+import Data.String.Conversions (cs)
+import qualified Data.Text.Encoding as T
+import Imports
+import qualified Servant.Client as Client
+import System.Random (randomIO)
+import Test.Tasty
+import Test.Tasty.HUnit
+import Util
+import Util.Options (epHost, epPort)
+import qualified Wire.API.Connection as Conn
+import qualified Wire.API.Push.V2.Token as PushToken
+import qualified Wire.API.Team.Member as Team
+
+tests :: Opt.Opts -> Manager -> Brig -> Gundeck -> IO TestTree
+tests opts mgr brig gundeck = do
+  return $
+    testGroup "api/internal" $
+      [ test mgr "ejpd requests" $ testEJPDRequest opts mgr brig gundeck
+      ]
+
+type TestConstraints m = (MonadFail m, MonadCatch m, MonadIO m, MonadHttp m)
+
+type MkUsr =
+  Maybe (Set (Relation, EJPDResponseItem)) ->
+  Maybe (Set EJPDResponseItem, Team.NewListType) ->
+  EJPDResponseItem
+
+scaffolding ::
+  forall m.
+  (TestConstraints m) =>
+  Brig ->
+  Gundeck ->
+  m (Handle, MkUsr, Handle, MkUsr, MkUsr)
+scaffolding brig gundeck = do
+  (_tid, usr1, [usr3]) <- createPopulatedBindingTeamWithNamesAndHandles brig 1
+  (_handle1, usr2) <- createUserWithHandle brig
+  connectUsers brig (userId usr1) (List1.singleton $ userId usr2)
+  tok1 <- registerPushToken gundeck $ userId usr1
+  tok2 <- registerPushToken gundeck $ userId usr2
+  tok3 <- registerPushToken gundeck $ userId usr2
+  pure
+    ( fromJust $ userHandle usr1,
+      mkUsr usr1 (Set.fromList [tok1]),
+      fromJust $ userHandle usr2,
+      mkUsr usr2 (Set.fromList [tok2, tok3]),
+      mkUsr usr3 Set.empty
+    )
+  where
+    mkUsr :: User -> Set Text -> MkUsr
+    mkUsr usr toks =
+      EJPDResponseItem
+        (userId usr)
+        (userTeam usr)
+        (userDisplayName usr)
+        (userHandle usr)
+        (userEmail usr)
+        (userPhone usr)
+        toks
+
+    registerPushToken :: TestConstraints m => Gundeck -> UserId -> m Text
+    registerPushToken gd u = do
+      t <- randomToken
+      rsp <- registerPushTokenRequest gd u t
+      responseJsonEither rsp
+        & either
+          (error . show)
+          (pure . PushToken.tokenText . view PushToken.token)
+
+    registerPushTokenRequest :: TestConstraints m => Gundeck -> UserId -> PushToken.PushToken -> m ResponseLBS
+    registerPushTokenRequest gd u t = do
+      post
+        ( gd
+            . path "/push/tokens"
+            . contentJson
+            . zUser u
+            . zConn "random"
+            . json t
+        )
+
+    randomToken :: MonadIO m => m PushToken.PushToken
+    randomToken = liftIO $ do
+      c <- liftIO $ newClientId <$> (randomIO :: IO Word64)
+      tok <- PushToken.Token . T.decodeUtf8 <$> B16.encode <$> randomBytes 32
+      return $ PushToken.pushToken PushToken.APNSSandbox (PushToken.AppName "test") tok c
+
+ejpdRequestClientM :: Maybe Bool -> EJPDRequestBody -> Client.ClientM EJPDResponseBody
+ejpdRequestClientM = Client.client (Proxy @IAPI.ServantAPI)
+
+ejpdRequestClient :: TestConstraints m => Opt.Opts -> Manager -> Maybe Bool -> EJPDRequestBody -> m EJPDResponseBody
+ejpdRequestClient opts mgr includeContacts ejpdReqBody = do
+  let env = Client.mkClientEnv mgr baseurl
+      baseurl = Client.BaseUrl Client.Http (cs $ brigep ^. epHost) (fromIntegral $ brigep ^. epPort) ""
+      brigep = Opt.brig opts
+  liftIO $
+    Client.runClientM (ejpdRequestClientM includeContacts ejpdReqBody) env >>= \case
+      Left err -> throwM err
+      Right val -> pure val
+
+testEJPDRequest :: TestConstraints m => Opt.Opts -> Manager -> Brig -> Gundeck -> m ()
+testEJPDRequest opts mgr brig gundeck = do
+  (handle1, mkUsr1, handle2, mkUsr2, mkUsr3) <- scaffolding brig gundeck
+
+  do
+    let req = EJPDRequestBody [handle1]
+        want =
+          EJPDResponseBody
+            [ mkUsr1 Nothing Nothing
+            ]
+    have <- ejpdRequestClient opts mgr Nothing req
+    liftIO $ assertEqual "" want have
+
+  do
+    let req = EJPDRequestBody [handle1, handle2]
+        want =
+          EJPDResponseBody
+            [ mkUsr1 Nothing Nothing,
+              mkUsr2 Nothing Nothing
+            ]
+    have <- ejpdRequestClient opts mgr Nothing req
+    liftIO $ assertEqual "" want have
+
+  do
+    let req = EJPDRequestBody [handle2]
+        want =
+          EJPDResponseBody
+            [ mkUsr2
+                (Just (Set.fromList [(Conn.Accepted, mkUsr1 Nothing Nothing)]))
+                Nothing
+            ]
+    have <- ejpdRequestClient opts mgr (Just True) req
+    liftIO $ assertEqual "" want have
+
+  do
+    let req = EJPDRequestBody [handle1, handle2]
+        want =
+          EJPDResponseBody
+            [ mkUsr1
+                (Just (Set.fromList [(Conn.Accepted, mkUsr2 Nothing Nothing)]))
+                (Just (Set.fromList [mkUsr3 Nothing Nothing], Team.NewListComplete)),
+              mkUsr2
+                (Just (Set.fromList [(Conn.Accepted, mkUsr1 Nothing Nothing)]))
+                Nothing
+            ]
+    have <- ejpdRequestClient opts mgr (Just True) req
+    liftIO $ assertEqual "" want have

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -131,7 +131,7 @@ runTests iConf brigOpts otherArgs = do
   federationEnd2End <- Federation.End2end.spec brigOpts mg b f brigTwo
   federationEndpoints <- API.Federation.tests mg b fedBrigClient
   includeFederationTests <- (== Just "1") <$> Blank.getEnv "INTEGRATION_FEDERATION_TESTS"
-  internalApi <- API.Internal.tests brigOpts mg b gd
+  internalApi <- API.Internal.tests brigOpts mg b (brig iConf) gd
   withArgs otherArgs . defaultMain $
     testGroup
       "Brig API Integration"

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -22,6 +22,7 @@ where
 
 import qualified API.Calling as Calling
 import qualified API.Federation
+import qualified API.Internal
 import qualified API.Metrics as Metrics
 import qualified API.Provider as Provider
 import qualified API.Search as Search
@@ -78,6 +79,7 @@ data Config = Config
   -- internal endpoints
   { brig :: Endpoint,
     cannon :: Endpoint,
+    gundeck :: Endpoint,
     cargohold :: Endpoint,
     federatorInternal :: Endpoint,
     galley :: Endpoint,
@@ -96,6 +98,7 @@ runTests :: Config -> Opts.Opts -> [String] -> IO ()
 runTests iConf brigOpts otherArgs = do
   let b = mkRequest $ brig iConf
       c = mkRequest $ cannon iConf
+      gd = mkRequest $ gundeck iConf
       ch = mkRequest $ cargohold iConf
       g = mkRequest $ galley iConf
       n = mkRequest $ nginz iConf
@@ -128,6 +131,7 @@ runTests iConf brigOpts otherArgs = do
   federationEnd2End <- Federation.End2end.spec brigOpts mg b f brigTwo
   federationEndpoints <- API.Federation.tests mg b fedBrigClient
   includeFederationTests <- (== Just "1") <$> Blank.getEnv "INTEGRATION_FEDERATION_TESTS"
+  internalApi <- API.Internal.tests brigOpts mg b gd
   withArgs otherArgs . defaultMain $
     testGroup
       "Brig API Integration"
@@ -146,7 +150,8 @@ runTests iConf brigOpts otherArgs = do
           createIndex,
           userPendingActivation,
           browseTeam,
-          federationEndpoints
+          federationEndpoints,
+          internalApi
         ]
         <> [federationEnd2End | includeFederationTests]
   where

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -76,6 +76,8 @@ type Brig = Request -> Request
 
 type Cannon = Request -> Request
 
+type Gundeck = Request -> Request
+
 type CargoHold = Request -> Request
 
 type Galley = Request -> Request
@@ -388,7 +390,7 @@ sendLoginCode b p typ force =
             "force" .= force
           ]
 
-postConnection :: Brig -> UserId -> UserId -> Http ResponseLBS
+postConnection :: Brig -> UserId -> UserId -> (MonadIO m, MonadHttp m) => m ResponseLBS
 postConnection brig from to =
   post $
     brig
@@ -402,7 +404,7 @@ postConnection brig from to =
       RequestBodyLBS . encode $
         ConnectionRequest to "some conv name" (Message "some message")
 
-putConnection :: Brig -> UserId -> UserId -> Relation -> Http ResponseLBS
+putConnection :: Brig -> UserId -> UserId -> Relation -> (MonadIO m, MonadHttp m) => m ResponseLBS
 putConnection brig from to r =
   put $
     brig
@@ -414,7 +416,7 @@ putConnection brig from to r =
   where
     payload = RequestBodyLBS . encode $ object ["status" .= r]
 
-connectUsers :: Brig -> UserId -> List1 UserId -> Http ()
+connectUsers :: Brig -> UserId -> List1 UserId -> (MonadIO m, MonadHttp m) => m ()
 connectUsers b u = mapM_ connectTo
   where
     connectTo v = do
@@ -438,7 +440,7 @@ putHandle brig usr h =
   where
     payload = RequestBodyLBS . encode $ object ["handle" .= h]
 
-createUserWithHandle :: Brig -> Http (Handle, User)
+createUserWithHandle :: Brig -> (MonadCatch m, MonadIO m, MonadHttp m) => m (Handle, User)
 createUserWithHandle brig = do
   u <- randomUser brig
   h <- randomHandle


### PR DESCRIPTION
Attempt at streamlining the internal process at wire.com described [here](https://wearezeta.atlassian.net/wiki/spaces/~463749889/pages/256738296/EJPD+official+requests+process).

We are legally required to sometimes provide user information to law enforcement.  This change introduces an internal end-point to compile the minimum required information into a json blob.

**Security:** to access the internal end-point, you need the same access privileges that also give you direct access to the database.  So the information we provide here does not get any more accessible.  On the other hand, direct database access is error prone and make result in revealing information on the wrong user due to cut&paste errors.  This end-point mitigates this risk to a large extent.