### PR TITLE
Make DerivingVia a package default.

### DIFF
--- a/libs/brig-types/src/Brig/Types/User/EJPD.hs
+++ b/libs/brig-types/src/Brig/Types/User/EJPD.hs
@@ -1,4 +1,3 @@
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>

--- a/libs/brig-types/src/Brig/Types/User/EJPD.hs
+++ b/libs/brig-types/src/Brig/Types/User/EJPD.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/libs/schema-profunctor/src/Data/Schema.hs
+++ b/libs/schema-profunctor/src/Data/Schema.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedLists #-}
 

--- a/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
+++ b/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
+++ b/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
@@ -1,4 +1,3 @@
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>

--- a/libs/types-common/src/Data/Domain.hs
+++ b/libs/types-common/src/Data/Domain.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- This file is part of the Wire Server implementation.

--- a/libs/types-common/src/Data/Handle.hs
+++ b/libs/types-common/src/Data/Handle.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- This file is part of the Wire Server implementation.

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NumDecimals #-}
 {-# LANGUAGE TypeApplications #-}

--- a/libs/types-common/src/Data/Misc.hs
+++ b/libs/types-common/src/Data/Misc.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -1,4 +1,3 @@
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -1,4 +1,3 @@
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/libs/wire-api-federation/src/Wire/API/Federation/Event.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Event.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/GRPC/Types.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/GRPC/Types.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/libs/wire-api/src/Wire/API/Arbitrary.hs
+++ b/libs/wire-api/src/Wire/API/Arbitrary.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/libs/wire-api/src/Wire/API/Asset/V3.hs
+++ b/libs/wire-api/src/Wire/API/Asset/V3.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/libs/wire-api/src/Wire/API/Asset/V3/Resumable.hs
+++ b/libs/wire-api/src/Wire/API/Asset/V3/Resumable.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/libs/wire-api/src/Wire/API/Call/Config.hs
+++ b/libs/wire-api/src/Wire/API/Call/Config.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/libs/wire-api/src/Wire/API/Connection.hs
+++ b/libs/wire-api/src/Wire/API/Connection.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/Conversation/Bot.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Bot.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/Conversation/Code.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Code.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StrictData #-}
 
 -- This file is part of the Wire Server implementation.

--- a/libs/wire-api/src/Wire/API/Conversation/Member.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Member.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/Conversation/Role.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Role.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/libs/wire-api/src/Wire/API/Conversation/Typing.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Typing.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- This file is part of the Wire Server implementation.

--- a/libs/wire-api/src/Wire/API/CustomBackend.hs
+++ b/libs/wire-api/src/Wire/API/CustomBackend.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/Event/Team.hs
+++ b/libs/wire-api/src/Wire/API/Event/Team.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/libs/wire-api/src/Wire/API/Message.hs
+++ b/libs/wire-api/src/Wire/API/Message.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/Notification.hs
+++ b/libs/wire-api/src/Wire/API/Notification.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/libs/wire-api/src/Wire/API/Provider.hs
+++ b/libs/wire-api/src/Wire/API/Provider.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/libs/wire-api/src/Wire/API/Provider/Bot.hs
+++ b/libs/wire-api/src/Wire/API/Provider/Bot.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/libs/wire-api/src/Wire/API/Provider/External.hs
+++ b/libs/wire-api/src/Wire/API/Provider/External.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StrictData #-}
 
 -- This file is part of the Wire Server implementation.

--- a/libs/wire-api/src/Wire/API/Provider/Service.hs
+++ b/libs/wire-api/src/Wire/API/Provider/Service.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/libs/wire-api/src/Wire/API/Provider/Service/Tag.hs
+++ b/libs/wire-api/src/Wire/API/Provider/Service/Tag.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- This file is part of the Wire Server implementation.

--- a/libs/wire-api/src/Wire/API/Push/V2/Token.hs
+++ b/libs/wire-api/src/Wire/API/Push/V2/Token.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/libs/wire-api/src/Wire/API/Team.hs
+++ b/libs/wire-api/src/Wire/API/Team.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/libs/wire-api/src/Wire/API/Team/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Team/Conversation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/libs/wire-api/src/Wire/API/Team/Export.hs
+++ b/libs/wire-api/src/Wire/API/Team/Export.hs
@@ -1,4 +1,3 @@
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>

--- a/libs/wire-api/src/Wire/API/Team/Export.hs
+++ b/libs/wire-api/src/Wire/API/Team/Export.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/Team/Invitation.hs
+++ b/libs/wire-api/src/Wire/API/Team/Invitation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StrictData #-}
 
 -- This file is part of the Wire Server implementation.

--- a/libs/wire-api/src/Wire/API/Team/LegalHold.hs
+++ b/libs/wire-api/src/Wire/API/Team/LegalHold.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/Team/LegalHold/External.hs
+++ b/libs/wire-api/src/Wire/API/Team/LegalHold/External.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/Team/Member.hs
+++ b/libs/wire-api/src/Wire/API/Team/Member.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/libs/wire-api/src/Wire/API/Team/Permission.hs
+++ b/libs/wire-api/src/Wire/API/Team/Permission.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/libs/wire-api/src/Wire/API/Team/Role.hs
+++ b/libs/wire-api/src/Wire/API/Team/Role.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StrictData #-}
 
 -- This file is part of the Wire Server implementation.

--- a/libs/wire-api/src/Wire/API/Team/SearchVisibility.hs
+++ b/libs/wire-api/src/Wire/API/Team/SearchVisibility.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- This file is part of the Wire Server implementation.

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}

--- a/libs/wire-api/src/Wire/API/User/Activation.hs
+++ b/libs/wire-api/src/Wire/API/User/Activation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/User/Auth.hs
+++ b/libs/wire-api/src/Wire/API/User/Auth.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/User/Client.hs
+++ b/libs/wire-api/src/Wire/API/User/Client.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/User/Client/Prekey.hs
+++ b/libs/wire-api/src/Wire/API/User/Client/Prekey.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/User/Handle.hs
+++ b/libs/wire-api/src/Wire/API/User/Handle.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedLists #-}
 

--- a/libs/wire-api/src/Wire/API/User/Identity.hs
+++ b/libs/wire-api/src/Wire/API/User/Identity.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE StrictData #-}

--- a/libs/wire-api/src/Wire/API/User/Orphans.hs
+++ b/libs/wire-api/src/Wire/API/User/Orphans.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/libs/wire-api/src/Wire/API/User/Password.hs
+++ b/libs/wire-api/src/Wire/API/User/Password.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}

--- a/libs/wire-api/src/Wire/API/User/Profile.hs
+++ b/libs/wire-api/src/Wire/API/User/Profile.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/libs/wire-api/src/Wire/API/User/Search.hs
+++ b/libs/wire-api/src/Wire/API/User/Search.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ApplicativeDo #-}
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StrictData #-}
 
 -- This file is part of the Wire Server implementation.

--- a/package-defaults.yaml
+++ b/package-defaults.yaml
@@ -15,6 +15,7 @@ default-extensions:
 - DataKinds
 - DefaultSignatures
 - DerivingStrategies
+- DerivingVia
 - DeriveFunctor
 - DeriveGeneric
 - DeriveLift

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 

--- a/services/galley/src/Galley/API/Swagger.hs
+++ b/services/galley/src/Galley/API/Swagger.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/services/spar/src/Spar/Scim/Types.hs
+++ b/services/spar/src/Spar/Scim/Types.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}


### PR DESCRIPTION
This has been bugging me for a while.  I'll just add this minimal commit so we won't have to mention `DerivingVia` in the package heades any more in the future, but I'll leave the old ones in there for the sake of laziness.