### PR TITLE
Remove zauth dependency from wire-api

### DIFF
--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -69,7 +69,6 @@ library:
   - uuid >=1.3
   - vector >= 0.12
   - x509
-  - zauth
 tests:
   wire-api-tests:
     main: Main.hs

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c990bca1c0951c9ee339bd7db566df5ca3e30e53a8333169a3f0596536cd811e
+-- hash: 0e8b9de8cfb3741e91fb0f8978ddf5549eee8cc098022f47e1857cb890f200c6
 
 name:           wire-api
 version:        0.1.0
@@ -145,7 +145,6 @@ library
     , uuid >=1.3
     , vector >=0.12
     , x509
-    , zauth
   default-language: Haskell2010
 
 test-suite wire-api-tests


### PR DESCRIPTION
This dependency was introduced by mistake, and it added an extra libsodium dependency to all the executables.