### PR TITLE
Remove OptionallyQualified data type from types-common

### DIFF
--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -46,7 +46,6 @@ import qualified Data.UUID as UUID
 import Imports hiding (local)
 import Test.QuickCheck (Arbitrary (arbitrary))
 
-
 ----------------------------------------------------------------------
 -- QUALIFIED
 


### PR DESCRIPTION
This simple PR removes the `Data.Qualified.OptionallyQualified` data type from types-common as it is unused.