### PR TITLE
RFC: Use sed instead of yq to read yaml files in ormolu script

### DIFF
--- a/tools/ormolu.sh
+++ b/tools/ormolu.sh
@@ -5,11 +5,9 @@ set -e
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
 command -v grep >/dev/null 2>&1 || { echo >&2 "grep is not installed, aborting."; exit 1; }
-command -v awk  >/dev/null 2>&1 || { echo >&2 "awk is not installed, aborting."; exit 1; }
 command -v sed  >/dev/null 2>&1 || { echo >&2 "sed is not installed, aborting."; exit 1; }
-command -v yq   >/dev/null 2>&1 || { echo >&2 "yq is not installed, aborting. See https://github.com/mikefarah/yq"; exit 1; }
 
-ORMOLU_VERSION=$(yq read stack.yaml 'extra-deps[*]' | sed -n 's/ormolu-//p')
+ORMOLU_VERSION=$(sed -n '/^extra-deps:/,$ { s/^- ormolu-//p }' < stack.yaml)
 ( ormolu -v 2>/dev/null | grep -q $ORMOLU_VERSION ) || ( echo "please install ormolu $ORMOLU_VERSION (eg., run 'stack install ormolu' and ensure ormolu is on your PATH.)"; exit 1 )
 echo "ormolu version: $ORMOLU_VERSION"
 
@@ -66,9 +64,9 @@ if [ "$(git status -s | grep -v \?\?)" != "" ]; then
     fi
 fi
 
-LANGUAGE_EXTS=$(yq read package-defaults.yaml 'default-extensions[*]' | awk '{print "--ghc-opt -X" $0}' ORS=' ')
+readarray -t EXTS < <(sed -n '/^default-extensions:/,$ { s/^- //p }' < package-defaults.yaml)
 echo "ormolu mode: $ARG_ORMOLU_MODE"
-echo "language extensions: $LANGUAGE_EXTS"
+echo "language extensions: ${EXTS[@]}"
 
 FAILURES=0
 
@@ -80,7 +78,7 @@ for hsfile in $(git ls-files | grep '\.hsc\?$'); do
     FAILED=0
 
     # run in background so that we can detect Ctrl-C properly
-    ormolu --mode $ARG_ORMOLU_MODE --check-idempotence $LANGUAGE_EXTS "$hsfile" &
+    ormolu --mode $ARG_ORMOLU_MODE --check-idempotence ${EXTS[@]/#/'-o -X'} "$hsfile" &
     wait $! && err=0 || err=$?
 
     if [ "$err" == "100" ]; then


### PR DESCRIPTION
This is probably slightly less robust, but it removes a dev dependency with multiple incompatible incarnations (https://github.com/mikefarah/yq, https://github.com/abesto/yq, https://github.com/kislyuk/yq ...) and different incompatible versions. Also avoids the use of awk in the script.