### PR TITLE
Schema instance for MemberUpdate

### DIFF
--- a/libs/wire-api/test/golden/testObject_MemberUpdate_user_11.json
+++ b/libs/wire-api/test/golden/testObject_MemberUpdate_user_11.json
@@ -4,5 +4,6 @@
     "conversation_role": "d1pquul8mcpzzyd",
     "otr_archived": false,
     "otr_muted": false,
-    "otr_archived_ref": ""
+    "otr_archived_ref": "",
+    "otr_muted_status": -909
 }

--- a/libs/wire-api/test/golden/testObject_MemberUpdate_user_3.json
+++ b/libs/wire-api/test/golden/testObject_MemberUpdate_user_3.json
@@ -3,5 +3,6 @@
     "otr_muted_ref": "/L",
     "conversation_role": "29pgeoc1x6764fsdwtticdvz1bvso_q95d5673zo7s076hshdzoa7ufh55os_8eedfy3r8e",
     "hidden": true,
-    "otr_muted": true
+    "otr_muted": true,
+    "otr_muted_status":3
 }

--- a/libs/wire-api/test/golden/testObject_MemberUpdate_user_4.json
+++ b/libs/wire-api/test/golden/testObject_MemberUpdate_user_4.json
@@ -4,5 +4,6 @@
     "hidden": false,
     "otr_archived": false,
     "otr_muted": true,
-    "otr_archived_ref": "0T"
+    "otr_archived_ref": "0T",
+    "otr_muted_status":7182
 }

--- a/libs/wire-api/test/golden/testObject_MemberUpdate_user_7.json
+++ b/libs/wire-api/test/golden/testObject_MemberUpdate_user_7.json
@@ -2,5 +2,6 @@
     "conversation_role": "5la_7_6jn396azj61gyopd1z6dkqfkd56kerwmng27x1",
     "hidden": true,
     "otr_archived": false,
-    "otr_archived_ref": "(拜t"
+    "otr_archived_ref": "(拜t",
+    "otr_muted_status":0
 }

--- a/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/MemberUpdate_user.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/MemberUpdate_user.hs
@@ -64,7 +64,7 @@ testObject_MemberUpdate_user_3 :: MemberUpdate
 testObject_MemberUpdate_user_3 =
   MemberUpdate
     { mupOtrMute = Just True,
-      mupOtrMuteStatus = Nothing,
+      mupOtrMuteStatus = Just 3,
       mupOtrMuteRef = Just "/L",
       mupOtrArchive = Nothing,
       mupOtrArchiveRef = Nothing,
@@ -78,7 +78,7 @@ testObject_MemberUpdate_user_4 :: MemberUpdate
 testObject_MemberUpdate_user_4 =
   MemberUpdate
     { mupOtrMute = Just True,
-      mupOtrMuteStatus = Nothing,
+      mupOtrMuteStatus = Just 7182,
       mupOtrMuteRef = Nothing,
       mupOtrArchive = Just False,
       mupOtrArchiveRef = Just "0T",
@@ -124,7 +124,7 @@ testObject_MemberUpdate_user_7 :: MemberUpdate
 testObject_MemberUpdate_user_7 =
   MemberUpdate
     { mupOtrMute = Nothing,
-      mupOtrMuteStatus = Nothing,
+      mupOtrMuteStatus = Just 0,
       mupOtrMuteRef = Nothing,
       mupOtrArchive = Just False,
       mupOtrArchiveRef = Just "(\25308t",
@@ -177,7 +177,7 @@ testObject_MemberUpdate_user_11 :: MemberUpdate
 testObject_MemberUpdate_user_11 =
   MemberUpdate
     { mupOtrMute = Just False,
-      mupOtrMuteStatus = Nothing,
+      mupOtrMuteStatus = Just (-909),
       mupOtrMuteRef = Just "",
       mupOtrArchive = Just False,
       mupOtrArchiveRef = Just "",


### PR DESCRIPTION
Also adds the missing field (`otr_muted_status`) and remove the `Arbitrary` hack. The `ToJSON` instance of this type does not affect clients, so there should be no backward-compatibility worries.