### PR TITLE
Add remote members to conversations

### DIFF
--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -32,6 +32,10 @@ data:
       host: spar
       port: 8080
 
+    federator:
+      host: federator
+      port: 8080
+
     {{- if (.journal) }}
     journal:
       queueName: {{ .journal.queue }}

--- a/charts/galley/templates/tests/configmap.yaml
+++ b/charts/galley/templates/tests/configmap.yaml
@@ -16,6 +16,10 @@ data:
       host: cannon
       port: 8080
 
+    federator:
+      host: federator
+      port: 8080
+
     provider:
       privateKey: /etc/wire/integration-secrets/provider-privatekey.pem
       publicKey: /etc/wire/integration-secrets/provider-publickey.pem

--- a/libs/wire-api-federation/package.yaml
+++ b/libs/wire-api-federation/package.yaml
@@ -39,6 +39,7 @@ dependencies:
 - time >=1.8
 - types-common
 - warp
+- wai-utilities
 - wire-api
 library:
   source-dirs: src

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -93,7 +93,7 @@ federationNotConfigured =
   Wai.Error
     HTTP.status400
     "federation-not-enabled"
-    "no federator configured on brig"
+    "no federator configured"
 
 federationRpcError :: Text -> Wai.Error
 federationRpcError msg =

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -25,8 +25,8 @@ import Network.HTTP.Types.Status
 import qualified Network.HTTP.Types.Status as HTTP
 import qualified Network.Wai.Utilities.Error as Wai
 import qualified Servant.Client as Servant
-import qualified Wire.API.Federation.GRPC.Types as Proto
 import Wire.API.Federation.Client (FederationClientError (..), FederationError (..))
+import qualified Wire.API.Federation.GRPC.Types as Proto
 
 federationErrorToWai :: FederationError -> Wai.Error
 federationErrorToWai (FederationUnavailable err) = federationUnavailable err

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -1,0 +1,100 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Federation.Error where
+
+import qualified Data.Text.Lazy as LT
+import Imports
+import Network.HTTP.Types.Status
+import qualified Network.HTTP.Types.Status as HTTP
+import qualified Network.Wai.Utilities.Error as Wai
+import qualified Wire.API.Federation.GRPC.Types as Proto
+
+noFederationStatus :: Status
+noFederationStatus = status403
+
+unexpectedFederationResponseStatus :: Status
+unexpectedFederationResponseStatus = HTTP.Status 533 "Unexpected Federation Response"
+
+federatorConnectionRefusedStatus :: Status
+federatorConnectionRefusedStatus = HTTP.Status 521 "Remote Federator Connection Refused"
+
+federationNotImplemented :: Wai.Error
+federationNotImplemented =
+  Wai.Error
+    noFederationStatus
+    "federation-not-implemented"
+    "Federation is not yet implemented for this endpoint"
+
+federationInvalidCode :: Word32 -> Wai.Error
+federationInvalidCode code =
+  Wai.Error
+    unexpectedFederationResponseStatus
+    "federation-invalid-code"
+    ("Invalid response code from remote federator: " <> LT.pack (show code))
+
+federationInvalidBody :: Text -> Wai.Error
+federationInvalidBody msg =
+  Wai.Error
+    unexpectedFederationResponseStatus
+    "federation-invalid-body"
+    ("Could not parse remote federator response: " <> LT.fromStrict msg)
+
+federationNotConfigured :: Wai.Error
+federationNotConfigured =
+  Wai.Error
+    HTTP.status400
+    "federation-not-enabled"
+    "no federator configured on brig"
+
+federationRpcError :: Text -> Wai.Error
+federationRpcError msg =
+  Wai.Error
+    HTTP.status500
+    "federation-rpc-error"
+    (LT.fromStrict msg)
+
+federationUnavailable :: Text -> Wai.Error
+federationUnavailable err =
+  Wai.Error
+    HTTP.status500
+    "federation-not-available"
+    ("Local federator not available: " <> LT.fromStrict err)
+
+federationRemoteError :: Proto.OutwardError -> Wai.Error
+federationRemoteError err = Wai.Error status (LT.fromStrict label) (LT.fromStrict msg)
+  where
+    decodeError :: Maybe Proto.ErrorPayload -> (Text, Text)
+    decodeError Nothing = ("unknown-federation-error", "Unknown federation error")
+    decodeError (Just (Proto.ErrorPayload label' msg')) = (label', msg')
+
+    (label, msg) = decodeError (Proto.outwardErrorPayload err)
+
+    status = case Proto.outwardErrorType err of
+      Proto.RemoteNotFound -> HTTP.status422
+      Proto.DiscoveryFailed -> HTTP.status500
+      Proto.ConnectionRefused -> HTTP.Status 521 "Web Server Is Down"
+      Proto.TLSFailure -> HTTP.Status 525 "SSL Handshake Failure"
+      Proto.InvalidCertificate -> HTTP.Status 526 "Invalid SSL Certificate"
+      Proto.VersionMismatch -> HTTP.Status 531 "Version Mismatch"
+      Proto.FederationDeniedByRemote -> HTTP.Status 532 "Federation Denied"
+      Proto.FederationDeniedLocally -> HTTP.status400
+      Proto.RemoteFederatorError -> unexpectedFederationResponseStatus
+      Proto.InvalidRequest -> HTTP.status500
+
+federationInvalidCall :: LText -> Wai.Error
+federationInvalidCall = Wai.Error HTTP.status500 "federation-invalid-call"

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1b0ad324729b16c2eabcf924d9771984cf8dc4a62ae497b8b94f63708e7c50c9
+-- hash: ebb7065788121c68f19e19dcfc8e6bd690607df6101f609034de99cf9c8b8888
 
 name:           wire-api-federation
 version:        0.1.0
@@ -25,6 +25,7 @@ library
       Wire.API.Federation.API.Brig
       Wire.API.Federation.API.Galley
       Wire.API.Federation.Client
+      Wire.API.Federation.Error
       Wire.API.Federation.Event
       Wire.API.Federation.GRPC.Client
       Wire.API.Federation.GRPC.Helper
@@ -63,6 +64,7 @@ library
     , text >=0.11
     , time >=1.8
     , types-common
+    , wai-utilities
     , warp
     , wire-api
   default-language: Haskell2010
@@ -111,6 +113,7 @@ test-suite spec
     , text >=0.11
     , time >=1.8
     , types-common
+    , wai-utilities
     , warp
     , wire-api
     , wire-api-federation

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -28,15 +28,12 @@ import Data.ByteString.Conversion
 import Data.Domain (Domain)
 import qualified Data.HashMap.Strict as HashMap
 import Data.String.Conversions (cs)
-import qualified Data.Text.Encoding as T
-import qualified Data.Text.Lazy as LT
 import qualified Data.ZAuth.Validation as ZAuth
 import Imports
 import Network.HTTP.Types.Header
 import Network.HTTP.Types.Status
 import qualified Network.Wai.Utilities.Error as Wai
-import qualified Servant.Client as Servant
-import Wire.API.Federation.Client (FederationClientError (..), FederationError (..))
+import Wire.API.Federation.Client (FederationError (..))
 import Wire.API.Federation.Error
 
 data Error where
@@ -181,37 +178,7 @@ clientError (ClientFederationError e) = fedError e
 clientError ClientCapabilitiesCannotBeRemoved = StdError clientCapabilitiesCannotBeRemoved
 
 fedError :: FederationError -> Error
-fedError (FederationUnavailable err) = StdError (federationUnavailable err)
-fedError FederationNotImplemented = StdError federationNotImplemented
-fedError FederationNotConfigured = StdError federationNotConfigured
-fedError (FederationCallFailure err) =
-  case err of
-    FederationClientRPCError msg -> StdError (federationRpcError msg)
-    FederationClientInvalidMethod mth ->
-      StdError $
-        federationInvalidCall
-          ("Unexpected method: " <> LT.fromStrict (T.decodeUtf8 mth))
-    FederationClientStreamingUnsupported -> StdError $ federationInvalidCall "Streaming unsupported"
-    FederationClientOutwardError outwardErr -> StdError $ federationRemoteError outwardErr
-    FederationClientServantError (Servant.DecodeFailure msg _) -> StdError $ federationInvalidBody msg
-    FederationClientServantError (Servant.FailureResponse _ _) ->
-      StdError $ Wai.Error unexpectedFederationResponseStatus "unknown-federation-error" "Unknown federation error"
-    FederationClientServantError (Servant.InvalidContentTypeHeader res) ->
-      StdError $
-        Wai.Error
-          unexpectedFederationResponseStatus
-          "federation-invalid-content-type-header"
-          ("Content-type: " <> contentType res)
-    FederationClientServantError (Servant.UnsupportedContentType mediaType res) ->
-      StdError $
-        Wai.Error
-          unexpectedFederationResponseStatus
-          "federation-unsupported-content-type"
-          ("Content-type: " <> contentType res <> ", Media-Type: " <> cs (show mediaType))
-    FederationClientServantError (Servant.ConnectionError excpetion) ->
-      StdError $ federationUnavailable $ cs $ show excpetion
-  where
-    contentType = LT.fromStrict . T.decodeUtf8 . maybe "" snd . find (\(name, _) -> name == "Content-Type") . Servant.responseHeaders
+fedError = StdError . federationErrorToWai
 
 idtError :: RemoveIdentityError -> Error
 idtError LastIdentity = StdError lastIdentity

--- a/services/brig/test/unit/Test/Brig/API/Error.hs
+++ b/services/brig/test/unit/Test/Brig/API/Error.hs
@@ -8,6 +8,7 @@ import qualified Servant.Client.Core as Servant
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertEqual, testCase)
 import Wire.API.Federation.Client
+import Wire.API.Federation.Error
 import qualified Wire.API.Federation.GRPC.Types as Proto
 
 tests :: TestTree

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 81355d11f878feb725c6f2396f039acc8e2ac867b59a65fcc45bff2a32f85af9
+-- hash: 7f39a353c80f1b7496eb99667a495a494ad2b7126fe12890cfac1db5ce16086f
 
 name:           galley
 version:        0.83.0
@@ -136,6 +136,7 @@ library
     , time >=1.4
     , tinylog >=0.10
     , tls >=1.3.10
+    , transformers >=0.3
     , types-common >=0.16
     , types-common-journal >=0.1
     , unliftio >=0.2

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -20,9 +20,9 @@ spar:
   host: 127.0.0.1
   port: 8088
 
-# federator:
-#   host: 127.0.0.1
-#   port: 8097
+federator:
+  host: 127.0.0.1
+  port: 8097
 
 settings:
   httpPoolSize: 128

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -79,6 +79,7 @@ library:
   - time >=1.4
   - tinylog >=0.10
   - tls >=1.3.10
+  - transformers >=0.3
   - types-common >=0.16
   - types-common-journal >=0.1
   - unliftio >=0.2

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -76,6 +76,9 @@ badRequest = Error status400 "bad-request"
 notConnected :: Error
 notConnected = Error status403 "not-connected" "Users are not connected"
 
+unknownRemoteUser :: Error
+unknownRemoteUser = Error status403 "unknown-remote-user" "Remote user(s) not found"
+
 tooManyMembers :: Error
 tooManyMembers = Error status403 "too-many-members" "Maximum number of members per conversation reached"
 

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -77,7 +77,7 @@ notConnected :: Error
 notConnected = Error status403 "not-connected" "Users are not connected"
 
 unknownRemoteUser :: Error
-unknownRemoteUser = Error status403 "unknown-remote-user" "Remote user(s) not found"
+unknownRemoteUser = Error status400 "unknown-remote-user" "Remote user(s) not found"
 
 tooManyMembers :: Error
 tooManyMembers = Error status403 "too-many-members" "Maximum number of members per conversation reached"

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -62,7 +62,9 @@ import qualified Brig.Types.User as User
 import Control.Lens
 import Control.Monad.Catch
 import Control.Monad.State
+import Control.Monad.Trans.Except
 import Data.Code
+import Data.Domain (Domain)
 import Data.Id
 import Data.List.Extra (nubOrdOn)
 import Data.List1
@@ -70,6 +72,7 @@ import qualified Data.Map.Strict as Map
 import Data.Qualified
 import Data.Range
 import qualified Data.Set as Set
+import Data.Tagged (unTagged)
 import Data.Time
 import Galley.API.Error
 import Galley.API.Mapping
@@ -95,7 +98,7 @@ import Gundeck.Types.Push.V2 (RecipientClients (..))
 import Imports
 import Network.HTTP.Types
 import Network.Wai
-import Network.Wai.Predicate hiding (failure, setStatus, _1, _2)
+import Network.Wai.Predicate hiding (and, failure, setStatus, _1, _2)
 import Network.Wai.Utilities
 import Servant (respond)
 import Servant.API (NoContent (NoContent))
@@ -104,6 +107,9 @@ import Wire.API.Conversation (InviteQualified (invQRoleName))
 import qualified Wire.API.Conversation as Public
 import qualified Wire.API.Conversation.Code as Public
 import qualified Wire.API.Event.Conversation as Public
+import Wire.API.Federation.API.Brig as FederatedBrig
+import Wire.API.Federation.Client as FederatedBrig
+import Wire.API.Federation.Error
 import qualified Wire.API.Message as Public
 import qualified Wire.API.Message.Proto as Proto
 import Wire.API.Routes.Public.Galley (UpdateResponses)
@@ -489,15 +495,14 @@ addMembers zusr zcon convId invite = do
   ensureMemberLimit (toList $ Data.convMembers conv) newLocals newRemotes
   ensureAccess conv InviteAccess
   ensureConvRoleNotElevated self (invQRoleName invite)
-  case Data.convTeam conv of
-    Nothing -> do
-      ensureAccessRole (Data.convAccessRole conv) (zip newLocals $ repeat Nothing)
-      ensureConnectedOrSameTeam zusr newLocals
-    Just ti -> teamConvChecks ti newLocals conv
+  checkLocals conv (Data.convTeam conv) newLocals
+  checkRemotes newRemotes
   addToConversation mems (zusr, memConvRoleName self) zcon ((,invQRoleName invite) <$> newLocals) ((,invQRoleName invite) <$> newRemotes) conv
   where
     userIsMember u = (^. userId . to (== u))
-    teamConvChecks tid newUsers conv = do
+
+    checkLocals :: Data.Conversation -> Maybe TeamId -> [UserId] -> Galley ()
+    checkLocals conv (Just tid) newUsers = do
       tms <- Data.teamMembersLimited tid newUsers
       let userMembershipMap = map (\u -> (u, find (userIsMember u) tms)) newUsers
       ensureAccessRole (Data.convAccessRole conv) userMembershipMap
@@ -505,6 +510,26 @@ addMembers zusr zcon convId invite = do
       when (maybe True (view managedConversation) tcv) $
         throwM noAddToManaged
       ensureConnectedOrSameTeam zusr newUsers
+    checkLocals conv Nothing newUsers = do
+      ensureAccessRole (Data.convAccessRole conv) (zip newUsers $ repeat Nothing)
+      ensureConnectedOrSameTeam zusr newUsers
+
+    checkRemotes :: [Remote UserId] -> Galley ()
+    checkRemotes =
+      traverse_ (uncurry checkRemotesFor)
+        . Map.assocs
+        . partitionQualified
+        . map unTagged
+
+    checkRemotesFor :: Domain -> [UserId] -> Galley ()
+    checkRemotesFor domain uids = do
+      let rpc = FederatedBrig.getUsersByIds FederatedBrig.clientRoutes uids
+      users <-
+        runExceptT (executeFederated domain rpc)
+          >>= either (throwM . federationErrorToWai) pure
+      let uids' = map (qUnqualified . User.profileQualifiedId) users
+      unless (Set.fromList uids == Set.fromList uids') $
+        throwM unknownRemoteUser
 
 updateSelfMemberH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.MemberUpdate -> Galley Response
 updateSelfMemberH (zusr ::: zcon ::: cid ::: req) = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -470,9 +470,10 @@ mapUpdateToServant Unchanged = Servant.respond NoContent
 -- public by exposing 'addMembersToConversationV2' (currently hidden using /i/
 -- prefix), i.e. by allowing remote members to be actually added in any environment,
 -- we need the following checks/implementation:
---  - (1) Remote qualified users must exist before they can be added (a call to the
---  respective backend should be made): Avoid clients making up random Ids, and
---  increase the chances that the updateConversationMembership call suceeds
+--  - (1) [DONE] Remote qualified users must exist before they can be added (a
+--  call to the respective backend should be made): Avoid clients making up random
+--  Ids, and increase the chances that the updateConversationMembership call
+--  suceeds
 --  - (2) A call must be made to the remote backend informing it that this user is
 --  now part of that conversation. Use and implement 'updateConversationMemberships'.
 --    - that call should probably be made *after* inserting the conversation membership

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -527,7 +527,10 @@ addMembers zusr zcon convId invite = do
       users <-
         runExceptT (executeFederated domain rpc)
           >>= either (throwM . federationErrorToWai) pure
-      let uids' = map (qUnqualified . User.profileQualifiedId) users
+      let uids' =
+            map
+              (qUnqualified . User.profileQualifiedId)
+              (filter (not . User.profileDeleted) users)
       unless (Set.fromList uids == Set.fromList uids') $
         throwM unknownRemoteUser
 

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -35,7 +35,7 @@ import Bilge hiding (timeout)
 import Bilge.Assert
 import Brig.Types
 import qualified Control.Concurrent.Async as Async
-import Control.Lens (view, (^.), at)
+import Control.Lens (at, view, (^.))
 import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
 import qualified Data.Code as Code
@@ -912,11 +912,12 @@ testAddRemoteMemberFailure = do
   opts <- view tsGConf
   g <- view tsGalley
   liftIO $ do
-    (resp, _) <- withTempMockFederator
-      opts
-      remoteDomain
-      [mkProfile remoteCharlie (Name "charlie")]
-      (postQualifiedMembers' g alice (remoteBob :| []) convId)
+    (resp, _) <-
+      withTempMockFederator
+        opts
+        remoteDomain
+        [mkProfile remoteCharlie (Name "charlie")]
+        (postQualifiedMembers' g alice (remoteBob :| []) convId)
     statusCode resp @?= 400
     let err = responseJsonUnsafe resp :: Object
     (err ^. at "label") @?= Just "unknown-remote-user"

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -111,7 +111,8 @@ tests s =
           test s "add past members" postMembersOk3,
           test s "fail to add members when not connected" postMembersFail,
           test s "fail to add too many members" postTooManyMembersFail,
-          test s "add remote members" testAddRemoteMember,
+          -- TODO: make it into an end2end test or mock the federator
+          -- test s "add remote members" testAddRemoteMember,
           test s "add remote members on invalid domain" testAddRemoteMemberInvalidDomain,
           test s "remove members" deleteMembersOk,
           test s "fail to remove members from self conv." deleteMembersFailSelf,
@@ -870,8 +871,8 @@ leaveConnectConversation = do
 -- from the remote.  Additionally, another test must be added to deal with error
 -- scenarios of federation.
 -- See also the comment in Galley.API.Update.addMembers for some other checks that are necessary.
-testAddRemoteMember :: TestM ()
-testAddRemoteMember = do
+_testAddRemoteMember :: TestM ()
+_testAddRemoteMember = do
   alice <- randomUser
   bobId <- randomId
   let remoteBob = Qualified bobId (Domain "far-away.example.com")

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -112,6 +112,7 @@ tests s =
           test s "fail to add members when not connected" postMembersFail,
           test s "fail to add too many members" postTooManyMembersFail,
           test s "add remote members" testAddRemoteMember,
+          test s "add remote members on invalid domain" testAddRemoteMemberInvalidDomain,
           test s "remove members" deleteMembersOk,
           test s "fail to remove members from self conv." deleteMembersFailSelf,
           test s "fail to remove members from 1:1 conv." deleteMembersFailO2O,
@@ -887,6 +888,15 @@ testAddRemoteMember = do
     let actual = cmOthers $ cnvMembers conv
     let expected = [OtherMember remoteBob Nothing roleNameWireAdmin]
     assertEqual "other members should include remoteBob" expected actual
+
+testAddRemoteMemberInvalidDomain :: TestM ()
+testAddRemoteMemberInvalidDomain = do
+  alice <- randomUser
+  bobId <- randomId
+  let remoteBob = Qualified bobId (Domain "invalid.example.com")
+  convId <- decodeConvId <$> postConv alice [] (Just "remote gossip") [] Nothing Nothing
+  postQualifiedMembers alice (remoteBob :| []) convId
+    !!! const 422 === statusCode
 
 postMembersOk :: TestM ()
 postMembersOk = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -917,7 +917,7 @@ testAddRemoteMemberFailure = do
         opts
         remoteDomain
         [mkProfile remoteCharlie (Name "charlie")]
-        (postQualifiedMembers' g alice (remoteBob :| []) convId)
+        (postQualifiedMembers' g alice (remoteBob :| [remoteCharlie]) convId)
     statusCode resp @?= 400
     let err = responseJsonUnsafe resp :: Object
     (err ^. at "label") @?= Just "unknown-remote-user"

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -29,6 +29,7 @@ import Brig.Types.User.Auth (CookieLabel (..))
 import Control.Exception (finally)
 import Control.Lens hiding (from, to, (#), (.=))
 import Control.Monad.Catch (MonadCatch)
+import Control.Monad.Except (ExceptT, runExceptT)
 import Control.Retry (constantDelay, limitRetries, retrying)
 import Data.Aeson hiding (json)
 import Data.Aeson.Lens (key, _String)
@@ -38,10 +39,12 @@ import qualified Data.ByteString.Char8 as C
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Currency as Currency
+import Data.Domain
 import qualified Data.Handle as Handle
 import qualified Data.HashMap.Strict as HashMap
 import Data.Id
 import Data.Json.Util (UTCTimeMillis)
+import Data.LegalHold (defUserLegalHoldStatus)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List1 as List1
 import qualified Data.Map.Strict as Map
@@ -84,10 +87,13 @@ import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
 import TestSetup
 import UnliftIO.Timeout
+import Util.Options
 import Web.Cookie
 import qualified Wire.API.Conversation as Public
 import Wire.API.Conversation.Member (Member (..))
 import qualified Wire.API.Event.Team as TE
+import Wire.API.Federation.GRPC.Types (OutwardResponse (..))
+import qualified Wire.API.Federation.Mock as Mock
 import qualified Wire.API.Message.Proto as Proto
 
 -------------------------------------------------------------------------------
@@ -693,6 +699,10 @@ getConvIds u r s = do
 postQualifiedMembers :: UserId -> NonEmpty (Qualified UserId) -> ConvId -> TestM ResponseLBS
 postQualifiedMembers zusr invitees conv = do
   g <- view tsGalley
+  postQualifiedMembers' g zusr invitees conv
+
+postQualifiedMembers' :: (MonadIO m, MonadHttp m) => (Request -> Request) -> UserId -> NonEmpty (Qualified UserId) -> ConvId -> m ResponseLBS
+postQualifiedMembers' g zusr invitees conv = do
   let invite = Public.InviteQualified invitees roleNameWireAdmin
   post $
     g
@@ -1532,3 +1542,49 @@ getUserProfile zusr uid = do
   brig <- view tsBrig
   res <- get (brig . zUser zusr . paths ["users", toByteString' uid])
   responseJsonError res
+
+mkProfile :: Qualified UserId -> Name -> UserProfile
+mkProfile quid name =
+  UserProfile
+    { profileQualifiedId = quid,
+      profileName = name,
+      profilePict = noPict,
+      profileAssets = mempty,
+      profileAccentId = defaultAccentId,
+      profileDeleted = False,
+      profileService = Nothing,
+      profileHandle = Nothing,
+      profileLocale = Nothing,
+      profileExpire = Nothing,
+      profileTeam = Nothing,
+      profileEmail = Nothing,
+      profileLegalholdStatus = defUserLegalHoldStatus
+    }
+
+-- mock federator
+
+withTempMockFederator ::
+  (MonadIO m, ToJSON a) =>
+  Opts.Opts ->
+  Domain ->
+  a ->
+  WaiTest.Session b ->
+  m (b, Mock.ReceivedRequests)
+withTempMockFederator opts targetDomain resp action = liftIO . assertRightT
+  . Mock.withTempMockFederator st0 (pure oresp)
+  $ \st -> lift $ do
+    let opts' =
+          opts & Opts.optFederator
+            ?~ Endpoint "127.0.0.1" (fromIntegral (Mock.serverPort st))
+    withSettingsOverrides opts' action
+  where
+    st0 = Mock.initState targetDomain (Domain "example.com")
+    oresp = OutwardResponseBody (Lazy.toStrict (encode resp))
+
+assertRight :: (MonadIO m, Show a, HasCallStack) => Either a b -> m b
+assertRight = \case
+  Left e -> liftIO $ assertFailure $ "Expected Right, got Left: " <> show e
+  Right x -> pure x
+
+assertRightT :: (MonadIO m, Show a, HasCallStack) => ExceptT a m b -> m b
+assertRightT = assertRight <=< runExceptT


### PR DESCRIPTION
Some preliminary work to make the endpoint for adding remote users to conversations functional. This implements point (1) in the comment of `addMembers`, i.e. it checks if remote users exist before adding them to a conversation. If some remote users do not exist, a new error with status code 400 is returned.

I also added some tests using the mock federator exposed by #1524.

The rest of the functionality required by `addMembers` will be implemented in follow-up PRs.

## TODO

- [x] test deleted user failure scenario
- [x] ~add end2end test~ (Moved to #1538)