### PR TITLE
Add required fields to Swagger for SchemaP

### DIFF
--- a/libs/schema-profunctor/src/Data/Schema.hs
+++ b/libs/schema-profunctor/src/Data/Schema.hs
@@ -125,18 +125,22 @@ instance Semigroup (SchemaOut v a b) where
 instance Monoid (SchemaOut v a b) where
   mempty = SchemaOut (pure empty)
 
+-- | A near-semiring (aka seminearring).
+--
+-- This is used for schema documentation types, to support different behaviours
+-- for composing schemas sequentially vs alternatively.
+class Monoid m => NearSemiRing m where
+  zero :: m
+  add :: m -> m -> m
+
 newtype SchemaDoc doc a b = SchemaDoc {getDoc :: doc}
-  deriving (Functor, Semigroup, Monoid)
+  deriving (Functor, Semigroup, Monoid, NearSemiRing)
   deriving (Applicative) via (Const doc)
   deriving (Profunctor, Choice) via Joker (Const doc)
 
--- This instance is not exactly correct, distributivity does not hold
--- in general.
--- FUTUREWORK: introduce a NearSemiRing type class and replace the
--- `Monoid doc` constraint with `NearSemiRing doc`.
-instance Monoid doc => Alternative (SchemaDoc doc a) where
-  empty = mempty
-  (<|>) = (<>)
+instance NearSemiRing doc => Alternative (SchemaDoc doc a) where
+  empty = zero
+  (<|>) = add
 
 class HasDoc a a' doc doc' | a a' -> doc doc' where
   doc :: Lens a a' doc doc'
@@ -205,7 +209,7 @@ instance (Monoid doc, Monoid v') => Applicative (SchemaP doc v v' a) where
   SchemaP d1 i1 o1 <*> SchemaP d2 i2 o2 =
     SchemaP (d1 <*> d2) (i1 <*> i2) (o1 <*> o2)
 
-instance (Monoid doc, Monoid v') => Alternative (SchemaP doc v v' a) where
+instance (NearSemiRing doc, Monoid v') => Alternative (SchemaP doc v v' a) where
   empty = SchemaP empty empty empty
   SchemaP d1 i1 o1 <|> SchemaP d2 i2 o2 =
     SchemaP (d1 <|> d2) (i1 <|> i2) (o1 <|> o2)
@@ -434,17 +438,17 @@ enum name sch = SchemaP (SchemaDoc d) (SchemaIn i) (SchemaOut o)
 -- This is most commonly used for optional fields. The parser will
 -- return 'Nothing' if the field is missing, and conversely the
 -- serialiser will simply omit the field when its value is 'Nothing'.
-opt :: Monoid w => SchemaP d v w a b -> SchemaP d v w (Maybe a) (Maybe b)
+opt :: HasOpt d => Monoid w => SchemaP d v w a b -> SchemaP d v w (Maybe a) (Maybe b)
 opt = optWithDefault mempty
 
 -- | An optional schema with a specified failure value
 --
 -- This is a more general version of 'opt' that allows a custom
 -- serialisation 'Nothing' value.
-optWithDefault :: w -> SchemaP d v w a b -> SchemaP d v w (Maybe a) (Maybe b)
+optWithDefault :: HasOpt d => w -> SchemaP d v w a b -> SchemaP d v w (Maybe a) (Maybe b)
 optWithDefault w0 sch = SchemaP (SchemaDoc d) (SchemaIn i) (SchemaOut o)
   where
-    d = schemaDoc sch
+    d = mkOpt (schemaDoc sch)
     i = optional . schemaIn sch
     o = maybe (pure w0) (schemaOut sch)
 
@@ -539,6 +543,11 @@ instance Semigroup s => Semigroup (WithDeclare s) where
 instance Monoid s => Monoid (WithDeclare s) where
   mempty = WithDeclare (pure ()) mempty
 
+instance NearSemiRing s => NearSemiRing (WithDeclare s) where
+  zero = WithDeclare (pure ()) zero
+  add (WithDeclare d1 s1) (WithDeclare d2 s2) =
+    WithDeclare (d1 >> d2) (add s1 s2)
+
 runDeclare :: WithDeclare s -> Declare s
 runDeclare (WithDeclare m s) = s <$ m
 
@@ -550,6 +559,13 @@ unrunDeclare decl = case S.runDeclare decl mempty of
 type SwaggerDoc = WithDeclare S.Schema
 
 type NamedSwaggerDoc = WithDeclare S.NamedSchema
+
+-- addition of schemas is used by the alternative instance, and it works like
+-- multiplication (i.e. the Monoid instance), except that it intersects required
+-- fields instead of concatenating them
+instance NearSemiRing S.Schema where
+  zero = mempty
+  add x y = (x <> y) & S.required .~ intersect (x ^. S.required) (y ^. S.required)
 
 -- This class abstracts over SwaggerDoc and NamedSwaggerDoc
 class HasSchemaRef doc where
@@ -591,6 +607,9 @@ class Monoid doc => HasArray ndoc doc | ndoc -> doc where
 class Monoid doc => HasMap ndoc doc | ndoc -> doc where
   mkMap :: ndoc -> doc
 
+class HasOpt doc where
+  mkOpt :: doc -> doc
+
 class HasEnum doc where
   mkEnum :: Text -> [A.Value] -> doc
 
@@ -601,6 +620,7 @@ instance HasSchemaRef doc => HasField doc SwaggerDoc where
         mempty
           & S.type_ ?~ S.SwaggerObject
           & S.properties . at name ?~ ref
+          & S.required .~ [name]
 
 instance HasObject SwaggerDoc NamedSwaggerDoc where
   mkObject name decl = S.NamedSchema (Just name) <$> decl
@@ -636,6 +656,12 @@ instance HasEnum NamedSwaggerDoc where
       mempty
         & S.type_ ?~ S.SwaggerString
         & S.enum_ ?~ labels
+
+instance HasOpt SwaggerDoc where
+  mkOpt = (S.schema . S.required) .~ []
+
+instance HasOpt NamedSwaggerDoc where
+  mkOpt = (S.schema . S.required) .~ []
 
 -- | A type with a canonical typed schema definition.
 --

--- a/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
+++ b/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
@@ -50,6 +50,7 @@ tests =
       testUser1FromJSON,
       testUser2ToJSON,
       testUser2FromJSON,
+      testUserSchema,
       testTaggedObjectToJSON,
       testTaggedObjectFromJSON,
       testTaggedObject2ToJSON,
@@ -96,6 +97,10 @@ testFooSchema =
       "Description should match"
       (Just "A Foo object")
       (s ^. description)
+    assertEqual
+      "a, b and str should be required"
+      ["a", "b", "str"]
+      (s ^. S.required)
     assertEqual
       "Schema for \"a\" should be referenced"
       (Just (S.Ref (S.Reference "A")))
@@ -185,6 +190,15 @@ testUser2FromJSON =
       "fromJSON should match example"
       (Just exampleUser2)
       (decode exampleUser2JSON)
+
+testUserSchema :: TestTree
+testUserSchema =
+  testCase "User schema" $ do
+    let s = S.toSchema (Proxy @User)
+    assertEqual
+      "only name should be required"
+      ["name"]
+      (s ^. S.required)
 
 testTaggedObjectToJSON :: TestTree
 testTaggedObjectToJSON =
@@ -378,7 +392,7 @@ data User = User
     userExpire :: Maybe Int
   }
   deriving (Eq, Show)
-  deriving (ToJSON, FromJSON) via Schema User
+  deriving (ToJSON, FromJSON, S.ToSchema) via Schema User
 
 instance ToSchema User where
   schema =

--- a/libs/types-common/src/Data/LegalHold.hs
+++ b/libs/types-common/src/Data/LegalHold.hs
@@ -39,9 +39,9 @@ instance ToSchema UserLegalHoldStatus where
     (S.schema . description ?~ desc) $
       enum @Text "UserLegalHoldStatus" $
         element "enabled" UserLegalHoldEnabled
-          <|> element "pending" UserLegalHoldPending
-          <|> element "disabled" UserLegalHoldDisabled
-          <|> element "no_consent" UserLegalHoldNoConsent
+          <> element "pending" UserLegalHoldPending
+          <> element "disabled" UserLegalHoldDisabled
+          <> element "no_consent" UserLegalHoldNoConsent
     where
       desc =
         "states whether a user is under legal hold, "

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -294,7 +294,7 @@ data ConvType
 instance ToSchema ConvType where
   schema =
     enum @Integer "ConvType" $
-      asum
+      mconcat
         [ element 0 RegularConv,
           element 1 SelfConv,
           element 2 One2OneConv,

--- a/libs/wire-api/src/Wire/API/Conversation/Typing.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Typing.hs
@@ -64,7 +64,7 @@ instance ToSchema TypingStatus where
   schema =
     enum @Text "TypingStatus" $
       element "started" StartedTyping
-        <|> element "stopped" StoppedTyping
+        <> element "stopped" StoppedTyping
 
 typeTypingStatus :: Doc.DataType
 typeTypingStatus =

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -157,7 +157,7 @@ data EventType
 instance ToSchema EventType where
   schema =
     enum @Text "EventType" $
-      asum
+      mconcat
         [ element "conversation.member-join" MemberJoin,
           element "conversation.member-leave" MemberLeave,
           element "conversation.member-update" MemberStateUpdate,

--- a/libs/wire-api/src/Wire/API/User/Profile.hs
+++ b/libs/wire-api/src/Wire/API/User/Profile.hs
@@ -168,7 +168,7 @@ typeAssetSize =
 instance ToSchema AssetSize where
   schema =
     enum @Text "AssetSize" $
-      asum
+      mconcat
         [ element "preview" AssetPreview,
           element "complete" AssetComplete
         ]


### PR DESCRIPTION
This populates the `required` field of Swagger schemas generated using `SchemaP`. See commit description for more information on the implementation.