### PR TITLE
More examples in schema-profunctor documentation

### DIFF
--- a/libs/schema-profunctor/src/Data/Schema.hs
+++ b/libs/schema-profunctor/src/Data/Schema.hs
@@ -454,7 +454,7 @@ optWithDefault w0 sch = SchemaP (SchemaDoc d) (SchemaIn i) (SchemaOut o)
 -- @lax sch@ is just like the one for @sch@, except that it returns
 -- 'Nothing' in case of failure.
 lax :: Alternative f => f (Maybe a) -> f (Maybe a)
-lax = fmap join . optional
+lax = (<|> pure Nothing)
 
 -- | A schema depending on a parsed value.
 --


### PR DESCRIPTION
I have added some more explanations and examples to the README of schema-profunctor. These should hopefully cover most of the situations encountered in wire-api.