### PR TITLE
Update conversation membership

### DIFF
--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -21,12 +21,14 @@ import Control.Monad.Except (MonadError (..))
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Id (ConvId, UserId)
 import Data.Qualified (Qualified)
+import Data.Time.Clock (UTCTime)
 import Imports
 import Servant.API (JSON, Post, ReqBody, (:>))
 import Servant.API.Generic ((:-))
 import Servant.Client.Generic (AsClientT, genericClient)
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import Wire.API.Conversation (Conversation)
+import Wire.API.Conversation.Role (RoleName)
 import Wire.API.Federation.Client (FederationClientError, FederatorClient)
 import qualified Wire.API.Federation.GRPC.Types as Proto
 import Wire.API.Federation.Util.Aeson (CustomEncoded (CustomEncoded))
@@ -69,8 +71,11 @@ newtype GetConversationsResponse = GetConversationsResponse
   deriving (ToJSON, FromJSON) via (CustomEncoded GetConversationsResponse)
 
 data ConversationMemberUpdate = ConversationMemberUpdate
-  { cmuConvId :: Qualified ConvId,
-    cmuUsersAdd :: [UserId],
+  { cmuTime :: UTCTime,
+    cmuOrigUserId :: Qualified UserId,
+    cmuConvId :: Qualified ConvId,
+    cmuAlreadyPresentUsers :: [UserId], -- pre-existing users in the conversation from the receiving domain
+    cmuUsersAdd :: [(UserId, RoleName)],
     cmuUsersRemove :: [UserId]
   }
   deriving stock (Eq, Show, Generic)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -75,7 +75,7 @@ data ConversationMemberUpdate = ConversationMemberUpdate
     cmuOrigUserId :: Qualified UserId,
     cmuConvId :: Qualified ConvId,
     cmuAlreadyPresentUsers :: [UserId], -- pre-existing users in the conversation from the receiving domain
-    cmuUsersAdd :: [(UserId, RoleName)],
+    cmuUsersAdd :: [(Qualified UserId, RoleName)],
     cmuUsersRemove :: [UserId]
   }
   deriving stock (Eq, Show, Generic)

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -89,8 +89,8 @@ import Wire.API.User (UserIdList (..))
 
 data Event = Event
   { evtType :: EventType,
-    evtConv :: ConvId,
-    evtFrom :: UserId,
+    evtConv :: ConvId, -- FUTUREWORK: make this qualified
+    evtFrom :: UserId, -- FUTUREWORK: make this qualified
     evtTime :: UTCTime,
     evtData :: EventData
   }

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -34,8 +34,9 @@ federationSitemap :: ServerT (ToServantApi FederationAPIGalley.Api) Galley
 federationSitemap =
   genericServerT $
     FederationAPIGalley.Api
-      getConversations
-      updateConversationMembership
+      { FederationAPIGalley.getConversations = getConversations,
+        FederationAPIGalley.updateConversationMemberships = updateConversationMemberships
+      }
 
 getConversations :: GetConversationsRequest -> Galley GetConversationsResponse
 getConversations (GetConversationsRequest (Qualified uid domain) gcrConvIds) = do
@@ -46,8 +47,8 @@ getConversations (GetConversationsRequest (Qualified uid domain) gcrConvIds) = d
     else error "FUTUREWORK: implement & exstend integration test when schema ready"
 
 -- FUTUREWORK: also remove users from conversation
-updateConversationMembership :: ConversationMemberUpdate -> Galley ()
-updateConversationMembership cmu = do
+updateConversationMemberships :: ConversationMemberUpdate -> Galley ()
+updateConversationMemberships cmu = do
   localDomain <- viewFederationDomain
   let localUsers = filter ((== localDomain) . qDomain . fst) (cmuUsersAdd cmu)
   when (not (null localUsers)) $ do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -485,7 +485,7 @@ mapUpdateToServant Unchanged = Servant.respond NoContent
 -- we need the following checks/implementation:
 --  - (1) [DONE] Remote qualified users must exist before they can be added (a
 --  call to the respective backend should be made): Avoid clients making up random
---  Ids, and increase the chances that the updateConversationMembership call
+--  Ids, and increase the chances that the updateConversationMemberships call
 --  suceeds
 --  - (2) A call must be made to the remote backend informing it that this user is
 --  now part of that conversation. Use and implement 'updateConversationMemberships'.

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -34,13 +34,14 @@ import Galley.App
 import qualified Galley.Data as Data
 import Galley.Data.Services (BotMember, newBotMember)
 import qualified Galley.Data.Types as DataTypes
+import qualified Galley.External as External
 import Galley.Intra.Push
 import Galley.Intra.User
 import Galley.Options (optSettings, setFederationDomain)
 import Galley.Types
 import Galley.Types.Conversations.Members (RemoteMember (rmId))
 import Galley.Types.Conversations.Roles
-import Galley.Types.Teams
+import Galley.Types.Teams hiding (Event)
 import Imports
 import Network.HTTP.Types
 import Network.Wai
@@ -292,6 +293,12 @@ canDeleteMember deleter deletee
     -- (team members having no role is an internal error, but we don't want to deal with that
     -- here, so we pick a reasonable default.)
     getRole mem = fromMaybe RoleMember $ permissionsRole $ mem ^. permissions
+
+pushConversationEvent :: Event -> [UserId] -> [BotMember] -> Galley ()
+pushConversationEvent e users bots = do
+  for_ (newPush ListComplete (evtFrom e) (ConvEvent e) (map userRecipient users)) $ \p ->
+    push1 $ p & pushConn .~ Nothing
+  void . forkIO $ void $ External.deliver (bots `zip` repeat e)
 
 --------------------------------------------------------------------------------
 -- Federation

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -79,6 +79,7 @@ module Galley.Data
     -- * Conversation Members
     addMember,
     addMembersWithRole,
+    addLocalMembersToRemoteConv,
     member,
     members,
     removeMember,
@@ -850,6 +851,36 @@ addMembersUncheckedWithRole t conv (orig, _origRole) lusrs rusrs = do
   where
     toSimpleMembers :: [(UserId, RoleName)] -> [SimpleMember]
     toSimpleMembers = fmap (uncurry SimpleMember)
+
+-- | Set local users as belonging to a remote conversation. This is invoked by
+-- a remote galley (using the RPC updateConversationMembership) when users from
+-- the current backend are added to conversations on the remote end.
+addLocalMembersToRemoteConv ::
+  MonadClient m =>
+  UTCTime ->
+  Qualified UserId ->
+  [(UserId, RoleName)] ->
+  Qualified ConvId ->
+  m Event
+addLocalMembersToRemoteConv t qorig users qconv = do
+  -- FUTUREWORK: consider using pooledMapConcurrentlyN
+  for_ (List.chunksOf 32 users) $ \chunk ->
+    retry x5 . batch $ do
+      setType BatchLogged
+      setConsistency Quorum
+      for_ chunk $ \(u, _) ->
+        addPrepQuery
+          Cql.insertUserRemoteConv
+          (u, qDomain qconv, qUnqualified qconv)
+  let mems = SimpleMembers (map (uncurry SimpleMember) users)
+  -- FUTUREWORK: the resulting event should record the originating domain
+  pure $
+    Event
+      MemberJoin
+      (qUnqualified qconv)
+      (qUnqualified qorig)
+      t
+      (EdMembersJoin mems)
 
 updateMember :: MonadClient m => ConvId -> UserId -> MemberUpdate -> m MemberUpdateData
 updateMember cid uid mup = do

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -304,12 +304,12 @@ selectRemoteMembers = "select conv, user_remote_domain, user_remote_id, conversa
 insertUserRemoteConv :: PrepQuery W (UserId, Domain, ConvId) ()
 insertUserRemoteConv = "insert into user_remote_conv (user, conv_remote_domain, conv_remote_id) values (?, ?, ?)"
 
+selectUserRemoteConvs :: PrepQuery R (Identity UserId) (Domain, ConvId)
+selectUserRemoteConvs = "select conv_remote_domain, conv_remote_id from user_remote_conv where user = ? order by conv_remote_domain"
+
 -- FUTUREWORK: actually make use of these cql statements.
 deleteUserRemoteConv :: PrepQuery W (UserId, Domain, ConvId) ()
 deleteUserRemoteConv = "delete from user_remote_conv where user = ? and conv_remote_domain = ? and conv_remote_id = ?"
-
-selectUserRemoteConvs :: PrepQuery R (Identity UserId) (Domain, ConvId)
-selectUserRemoteConvs = "select conv_remote_domain, conv_remote_id from user_remote_conv where user = ? order by conv_remote_domain"
 
 -- Clients ------------------------------------------------------------------
 

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -301,10 +301,10 @@ selectRemoteMembers = "select conv, user_remote_domain, user_remote_id, conversa
 
 -- local user with remote conversations
 
--- FUTUREWORK: actually make use of these cql statements.
 insertUserRemoteConv :: PrepQuery W (UserId, Domain, ConvId) ()
 insertUserRemoteConv = "insert into user_remote_conv (user, conv_remote_domain, conv_remote_id) values (?, ?, ?)"
 
+-- FUTUREWORK: actually make use of these cql statements.
 deleteUserRemoteConv :: PrepQuery W (UserId, Domain, ConvId) ()
 deleteUserRemoteConv = "delete from user_remote_conv where user = ? and conv_remote_domain = ? and conv_remote_id = ?"
 


### PR DESCRIPTION
This implements the federation RPC `update-conversation-membership` in galley. It simply registers local users as belonging to the given remote conversation and sends out an event. Actually calling this RPC from the other domain will be implemented separately in another PR.

Note that at this point the event type does not properly reflect the fact that the conversation and the joined users may belong to different domains. This will be fixed once #1547 is merged.