### PR TITLE
Update webapp version in Helm chart

### DIFF
--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: 2021-04-01-production.0-254d51-v0.28.3-production
+  tag: "0.2.0-v0.28.16-0-578e128"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `0.2.0-v0.28.16-0-578e128`
[Release: `v0.2.0`]()

[skip ci]