### PR TITLE
Only update ES index at the end of member add loop.

### DIFF
--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -150,6 +150,9 @@ createBindingTeamWithMembers numUsers = do
   members <- forM [2 .. numUsers] $ \n -> do
     mem <- addUserToTeam owner tid
     SQS.assertQueue "add member" $ SQS.tUpdate (fromIntegral n) [owner]
+    -- 'refreshIndex' needs to happen here to make tests more realistic.  one effect of
+    -- refreshing the index once at the end would be that the hard member limit wouldn't hold
+    -- any more.
     refreshIndex
     return $ view Galley.Types.Teams.userId mem
 


### PR DESCRIPTION
I can't think of a reason why an up-to-date index should be required during adding more users?