### PR TITLE
Fix: Connection type when unblocking after LH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ## Release Notes
 
-Deploy brig before galley (#1526)
+Deploy brig before galley (#1526, #1549)
 
 ## Features
 

--- a/libs/brig-types/src/Brig/Types/Connection.hs
+++ b/libs/brig-types/src/Brig/Types/Connection.hs
@@ -55,7 +55,7 @@ data UserIds = UserIds
 -- | Data that is passed to the @\/i\/users\/connections-status@ endpoint.
 data ConnectionsStatusRequest = ConnectionsStatusRequest
   { csrFrom :: ![UserId],
-    csrTo :: ![UserId]
+    csrTo :: !(Maybe [UserId])
   }
   deriving (Eq, Show, Generic)
 

--- a/libs/wire-api/src/Wire/API/Connection.hs
+++ b/libs/wire-api/src/Wire/API/Connection.hs
@@ -188,7 +188,19 @@ data RelationWithHistory
   deriving (Arbitrary) via (GenericUniform RelationWithHistory)
 
 relationDropHistory :: RelationWithHistory -> Relation
-relationDropHistory = undefined
+relationDropHistory = \case
+  AcceptedWithHistory -> Accepted
+  BlockedWithHistory -> Blocked
+  PendingWithHistory -> Pending
+  IgnoredWithHistory -> Ignored
+  SentWithHistory -> Sent
+  CancelledWithHistory -> Cancelled
+  MissingLegalholdConsentFromAccepted -> MissingLegalholdConsent
+  MissingLegalholdConsentFromBlocked -> MissingLegalholdConsent
+  MissingLegalholdConsentFromPending -> MissingLegalholdConsent
+  MissingLegalholdConsentFromIgnored -> MissingLegalholdConsent
+  MissingLegalholdConsentFromSent -> MissingLegalholdConsent
+  MissingLegalholdConsentFromCancelled -> MissingLegalholdConsent
 
 typeRelation :: Doc.DataType
 typeRelation =

--- a/libs/wire-api/src/Wire/API/Connection.hs
+++ b/libs/wire-api/src/Wire/API/Connection.hs
@@ -28,6 +28,8 @@ module Wire.API.Connection
     UserConnectionList (..),
     Message (..),
     Relation (..),
+    RelationWithHistory (..),
+    relationDropHistory,
 
     -- * Requests
     ConnectionRequest (..),
@@ -164,6 +166,29 @@ data Relation
   deriving stock (Eq, Ord, Show, Generic)
   deriving (Arbitrary) via (GenericUniform Relation)
   deriving (ToSchema) via (CustomSwagger '[ConstructorTagModifier CamelToKebab] Relation)
+
+-- | 'updateConnectionInternal', requires knowledge of the previous state (before
+-- 'MissingLegalholdConsent'), but the clients don't need that information.  To avoid having
+-- to change the API, we introduce an internal variant of 'Relation' with surjective mapping
+-- 'relationDropHistory'.
+data RelationWithHistory
+  = AcceptedWithHistory
+  | BlockedWithHistory
+  | PendingWithHistory
+  | IgnoredWithHistory
+  | SentWithHistory
+  | CancelledWithHistory
+  | MissingLegalholdConsentFromAccepted
+  | MissingLegalholdConsentFromBlocked
+  | MissingLegalholdConsentFromPending
+  | MissingLegalholdConsentFromIgnored
+  | MissingLegalholdConsentFromSent
+  | MissingLegalholdConsentFromCancelled
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform RelationWithHistory)
+
+relationDropHistory :: RelationWithHistory -> Relation
+relationDropHistory = undefined
 
 typeRelation :: Doc.DataType
 typeRelation =

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -393,18 +393,8 @@ updateConnectionInternal = \case
 
         unblockDirected :: UserConnection -> UserConnection -> ExceptT ConnectionError AppIO ()
         unblockDirected uconn uconnRev = do
-          cnv :: Maybe Conv.Conversation <- lift . for (ucConvId uconn) $ Intra.unblockConv (ucFrom uconn) Nothing
-
           uconnRevRel :: RelationWithHistory <- relationWithHistory (ucFrom uconnRev) (ucTo uconnRev)
-          uconnRev' :: UserConnection <- do
-            newRelation <- case cnvType <$> cnv of
-              Just RegularConv -> throwE (InvalidTransition (ucFrom uconn) Accepted) -- (impossible, connection conv is always 1:1)
-              Just SelfConv -> throwE (InvalidTransition (ucFrom uconn) Accepted)
-              Just One2OneConv -> pure AcceptedWithHistory
-              Just ConnectConv -> pure $ undoRelationHistory uconnRevRel
-              Nothing -> throwE (InvalidTransition (ucFrom uconn) Accepted)
-            lift $ Data.updateConnection uconnRev newRelation
-
+          uconnRev' <- lift $ Data.updateConnection uconnRev (undoRelationHistory uconnRevRel)
           connEvent :: ConnectionEvent <- lift $ ConnectionUpdated uconnRev' (Just $ ucStatus uconnRev) <$> Data.lookupName (ucFrom uconn)
           lift $ Intra.onConnectionEvent (ucFrom uconn) Nothing connEvent
 

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -30,6 +30,7 @@ module Brig.API.Connection
     lookupConnections,
     Data.lookupConnection,
     Data.lookupConnectionStatus,
+    Data.lookupConnectionStatus',
     Data.lookupContactList,
   )
 where

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -393,6 +393,7 @@ updateConnectionInternal = \case
 
         unblockDirected :: UserConnection -> UserConnection -> ExceptT ConnectionError AppIO ()
         unblockDirected uconn uconnRev = do
+          void . lift . for (ucConvId uconn) $ Intra.unblockConv (ucFrom uconn) Nothing
           uconnRevRel :: RelationWithHistory <- relationWithHistory (ucFrom uconnRev) (ucTo uconnRev)
           uconnRev' <- lift $ Data.updateConnection uconnRev (undoRelationHistory uconnRevRel)
           connEvent :: ConnectionEvent <- lift $ ConnectionUpdated uconnRev' (Just $ ucStatus uconnRev) <$> Data.lookupName (ucFrom uconn)

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -499,7 +499,7 @@ getConnectionsStatusH (_ ::: req ::: flt) = do
 
 getConnectionsStatus :: ConnectionsStatusRequest -> Maybe Relation -> AppIO [ConnectionStatus]
 getConnectionsStatus ConnectionsStatusRequest {csrFrom, csrTo} flt = do
-  r <- API.lookupConnectionStatus csrFrom csrTo
+  r <- maybe (API.lookupConnectionStatus' csrFrom) (API.lookupConnectionStatus csrFrom) csrTo
   return $ maybe r (filterByRelation r) flt
   where
     filterByRelation l rel = filter ((== rel) . csStatus) l

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -26,6 +26,7 @@ module Brig.Data.Connection
     lookupRelationWithHistory,
     lookupConnections,
     lookupConnectionStatus,
+    lookupConnectionStatus',
     lookupContactList,
     lookupContactListWithRelation,
     countConnections,
@@ -125,6 +126,12 @@ lookupConnectionStatus from to =
   map toConnectionStatus
     <$> retry x1 (query connectionStatusSelect (params Quorum (from, to)))
 
+-- | Lookup all relations between two sets of users (cartesian product).
+lookupConnectionStatus' :: [UserId] -> AppIO [ConnectionStatus]
+lookupConnectionStatus' from =
+  map toConnectionStatus
+    <$> retry x1 (query connectionStatusSelect' (params Quorum (Identity from)))
+
 -- | See 'lookupContactListWithRelation'.
 lookupContactList :: UserId -> AppIO [UserId]
 lookupContactList u =
@@ -175,6 +182,9 @@ relationSelect = "SELECT status FROM connection WHERE left = ? AND right = ?"
 
 connectionStatusSelect :: PrepQuery R ([UserId], [UserId]) (UserId, UserId, RelationWithHistory)
 connectionStatusSelect = "SELECT left, right, status FROM connection WHERE left IN ? AND right IN ?"
+
+connectionStatusSelect' :: PrepQuery R (Identity [UserId]) (UserId, UserId, RelationWithHistory)
+connectionStatusSelect' = "SELECT left, right, status FROM connection WHERE left IN ?"
 
 contactsSelect :: PrepQuery R (Identity UserId) (UserId, RelationWithHistory)
 contactsSelect = "SELECT right, status FROM connection WHERE left = ?"

--- a/services/brig/src/Brig/Data/Instances.hs
+++ b/services/brig/src/Brig/Data/Instances.hs
@@ -37,6 +37,7 @@ import Data.Range ()
 import Data.String.Conversions (LBS, ST, cs)
 import Data.Text.Ascii ()
 import Imports
+import Wire.API.Connection (RelationWithHistory (..))
 import Wire.API.User.RichInfo
 
 deriving instance Cql Name
@@ -83,27 +84,37 @@ instance Cql UserSSOId where
 
   toCql = toCql . cs @LBS @ST . encode
 
-instance Cql Relation where
+instance Cql RelationWithHistory where
   ctype = Tagged IntColumn
 
   fromCql (CqlInt i) = case i of
-    0 -> return Accepted
-    1 -> return Blocked
-    2 -> return Pending
-    3 -> return Ignored
-    4 -> return Sent
-    5 -> return Cancelled
-    6 -> return MissingLegalholdConsent
-    n -> Left $ "unexpected relation: " ++ show n
-  fromCql _ = Left "relation: int expected"
+    0 -> pure AcceptedWithHistory
+    1 -> pure BlockedWithHistory
+    2 -> pure PendingWithHistory
+    3 -> pure IgnoredWithHistory
+    4 -> pure SentWithHistory
+    5 -> pure CancelledWithHistory
+    6 -> pure MissingLegalholdConsentFromAccepted
+    7 -> pure MissingLegalholdConsentFromBlocked
+    8 -> pure MissingLegalholdConsentFromPending
+    9 -> pure MissingLegalholdConsentFromIgnored
+    10 -> pure MissingLegalholdConsentFromSent
+    11 -> pure MissingLegalholdConsentFromCancelled
+    n -> Left $ "unexpected RelationWithHistory: " ++ show n
+  fromCql _ = Left "RelationWithHistory: int expected"
 
-  toCql Accepted = CqlInt 0
-  toCql Blocked = CqlInt 1
-  toCql Pending = CqlInt 2
-  toCql Ignored = CqlInt 3
-  toCql Sent = CqlInt 4
-  toCql Cancelled = CqlInt 5
-  toCql MissingLegalholdConsent = CqlInt 6
+  toCql AcceptedWithHistory = CqlInt 0
+  toCql BlockedWithHistory = CqlInt 1
+  toCql PendingWithHistory = CqlInt 2
+  toCql IgnoredWithHistory = CqlInt 3
+  toCql SentWithHistory = CqlInt 4
+  toCql CancelledWithHistory = CqlInt 5
+  toCql MissingLegalholdConsentFromAccepted = CqlInt 6
+  toCql MissingLegalholdConsentFromBlocked = CqlInt 7
+  toCql MissingLegalholdConsentFromPending = CqlInt 8
+  toCql MissingLegalholdConsentFromIgnored = CqlInt 9
+  toCql MissingLegalholdConsentFromSent = CqlInt 10
+  toCql MissingLegalholdConsentFromCancelled = CqlInt 11
 
 -- DEPRECATED
 instance Cql Pict where

--- a/services/brig/src/Brig/User/EJPD.hs
+++ b/services/brig/src/Brig/User/EJPD.hs
@@ -35,7 +35,7 @@ import Data.Id (UserId)
 import qualified Data.Set as Set
 import Imports hiding (head)
 import Servant.Swagger.Internal.Orphans ()
-import Wire.API.Connection (Relation)
+import Wire.API.Connection (Relation, RelationWithHistory (..), relationDropHistory)
 import qualified Wire.API.Push.Token as PushTok
 import qualified Wire.API.Team.Member as Team
 import Wire.API.User (User, userDisplayName, userEmail, userHandle, userId, userPhone, userTeam)
@@ -62,11 +62,11 @@ ejpdRequest includeContacts (EJPDRequestBody handles) = do
       mbContacts <-
         if includeContacts'
           then do
-            contacts :: [(UserId, Relation)] <-
+            contacts :: [(UserId, RelationWithHistory)] <-
               Conn.lookupContactListWithRelation uid
 
             contactsFull :: [Maybe (Relation, EJPDResponseItem)] <-
-              forM contacts $ \(uid', rel) -> do
+              forM contacts $ \(uid', relationDropHistory -> rel) -> do
                 mbUsr <- lookupUser NoPendingInvitations uid'
                 maybe (pure Nothing) (\usr -> Just . (rel,) <$> go2 False usr) mbUsr
 

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -21,7 +21,6 @@ module Galley.API.Query
     getConversationRoles,
     getConversationIds,
     getConversations,
-    iterateConversations,
     getSelfH,
     internalGetMemberH,
     getConversationMetaH,
@@ -117,21 +116,6 @@ getConversations user mids mstart msize = do
     removeDeleted c
       | Data.isConvDeleted c = Data.deleteConversation (Data.convId c) >> pure False
       | otherwise = pure True
-
-iterateConversations :: forall a. UserId -> Range 1 500 Int32 -> ([Public.Conversation] -> Galley a) -> Galley [a]
-iterateConversations uid pageSize handleConvs = catMaybes <$> go Nothing
-  where
-    go :: Maybe ConvId -> Galley [Maybe a]
-    go mbConv = do
-      convResult <- getConversations uid Nothing mbConv (Just pageSize)
-      resultHead <- Just <$> handleConvs (convList convResult)
-      resultTail <- case convList convResult of
-        (conv : rest) ->
-          if convHasMore convResult
-            then go (Just (maximum (cnvId <$> (conv : rest))))
-            else pure []
-        _ -> pure []
-      pure $ resultHead : resultTail
 
 getSelfH :: UserId ::: ConvId -> Galley Response
 getSelfH (zusr ::: cnv) = do

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -94,8 +94,8 @@ ensureConnectedToLocals :: UserId -> [UserId] -> Galley ()
 ensureConnectedToLocals _ [] = pure ()
 ensureConnectedToLocals u uids = do
   (connsFrom, connsTo) <-
-    getConnections [u] uids (Just Accepted)
-      `concurrently` getConnections uids [u] (Just Accepted)
+    getConnections [u] (Just uids) (Just Accepted)
+      `concurrently` getConnections uids (Just [u]) (Just Accepted)
   unless (length connsFrom == length uids && length connsTo == length uids) $
     throwM notConnected
 

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -56,7 +56,7 @@ import Wire.API.User.RichInfo (RichInfo)
 --
 -- When a connection does not exist, it is skipped.
 -- Calls 'Brig.API.getConnectionsStatusH'.
-getConnections :: [UserId] -> [UserId] -> Maybe Relation -> Galley [ConnectionStatus]
+getConnections :: [UserId] -> Maybe [UserId] -> Maybe Relation -> Galley [ConnectionStatus]
 getConnections uFrom uTo rlt = do
   (h, p) <- brigReq
   r <-

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -171,7 +171,7 @@ tests s =
             "teams listed"
             [ test s "happy flow" testInWhitelist,
               test s "handshake between LH device and user with old clients is blocked" testOldClientsBlockDeviceHandshake,
-              testGroup "XXX no-consent" $
+              testGroup "no-consent" $
                 flip fmap [(a, b, c, d) | a <- [minBound ..], b <- [minBound ..], c <- [minBound ..], d <- [minBound ..]] $
                   \args@(a, b, c, d) ->
                     test s (show args) $ testNoConsentBlockOne2OneConv a b c d,


### PR DESCRIPTION
See haddocks for `RelationWithHistory` for more info.  Fixes a bug [introduced here](https://github.com/wireapp/wire-server/pull/1507) that can only be triggered if legalhold is enabled (not the default).