### PR TITLE
 Refactoring-friendly FutureWork data type

### DIFF
--- a/libs/types-common/src/Data/Misc.hs
+++ b/libs/types-common/src/Data/Misc.hs
@@ -54,6 +54,9 @@ module Data.Misc
 
     -- * Swagger
     modelLocation,
+
+    -- * Typesafe FUTUREWORKS
+    FutureWork (..),
   )
 where
 
@@ -348,3 +351,12 @@ instance FromJSON PlainTextPassword where
 instance Arbitrary PlainTextPassword where
   -- TODO: why 6..1024? For tests we might want invalid passwords as well, e.g. 3 chars
   arbitrary = PlainTextPassword . fromRange <$> genRangeText @6 @1024 arbitrary
+
+-- | Usage:
+-- 1. Use this type in patterns to mark FUTUREWORKS.
+-- 2. Remove the label constructor -> all futureworks become compiler errors
+--
+-- Example:
+-- >>> let (FutureWork @'LegalholdPlusFederationNotImplemented -> _remoteUsers, localUsers)
+-- >>>      = partitionRemoteOrLocalIds domain qualifiedUids
+newtype FutureWork label payload = FutureWork payload

--- a/libs/wire-api/src/Wire/API/User/Orphans.hs
+++ b/libs/wire-api/src/Wire/API/User/Orphans.hs
@@ -48,8 +48,6 @@ instance ToSchema CountryCode
 
 -- TODO: steal from https://github.com/haskell-servant/servant-swagger/blob/master/example/src/Todo.hs
 
--- FUTUREWORK: push orphans upstream to saml2-web-sso, servant-multipart
-
 -- | The options to use for schema generation. Must match the options used
 -- for 'ToJSON' instances elsewhere.
 samlSchemaOptions :: SchemaOptions

--- a/libs/wire-api/src/Wire/API/User/Profile.hs
+++ b/libs/wire-api/src/Wire/API/User/Profile.hs
@@ -95,7 +95,6 @@ modelUserDisplayName = Doc.defineModel "UserDisplayName" $ do
   Doc.property "name" Doc.string' $
     Doc.description "User name"
 
--- FUTUREWORK: use @Range 1 128 Text@ and deriving this instance.
 instance ToSchema Name where
   schema = Name <$> fromName .= untypedRangedSchema 1 128 schema
 

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -423,7 +423,7 @@ blockConnectionsFrom1on1s uid = do
   where
     findConflicts :: [ConnectionStatus] -> Galley [[UserId]]
     findConflicts conns = do
-      let localUids = csTo <$> conns
+      let (FutureWork @'LegalholdPlusFederationNotImplemented -> _remoteUids, localUids) = (undefined, csTo <$> conns)
       -- FUTUREWORK: Handle remoteUsers here when federation is implemented
       for (chunksOf 32 localUids) $ \others -> do
         teamsOfUsers <- Data.usersTeams others

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -423,7 +423,7 @@ blockConnectionsFrom1on1s uid = do
   where
     findConflicts :: [ConnectionStatus] -> Galley [[UserId]]
     findConflicts conns = do
-      let (FutureWork @'LegalholdPlusFederationNotImplemented -> _remoteUids, localUids) = (undefined, csTo <$> conns)
+      let (FutureWork @'Public.LegalholdPlusFederationNotImplemented -> _remoteUids, localUids) = (undefined, csTo <$> conns)
       -- FUTUREWORK: Handle remoteUsers here when federation is implemented
       for (chunksOf 32 localUids) $ \others -> do
         teamsOfUsers <- Data.usersTeams others

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1001,7 +1001,7 @@ withValidOtrRecipients protectee clt cnv rcps val now go = do
     Data.deleteConversation cnv
     throwM convNotFound
   -- FUTUREWORK(federation): also handle remote members
-  (FutureWork @'LegalholdPlusFederationNotImplemented -> _remoteMembers, localMembers) <- (undefined, Data.members cnv)
+  (FutureWork @'LegalholdPlusFederationNotImplemented -> _remoteMembers, localMembers) <- (undefined,) <$> Data.members cnv
   let localMemberIds = memId <$> localMembers
   isInternal <- view $ options . optSettings . setIntraListing
   clts <-

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -75,6 +75,7 @@ import Data.LegalHold (UserLegalHoldStatus (UserLegalHoldNoConsent), defUserLega
 import Data.List.Extra (nubOrdOn)
 import Data.List1
 import qualified Data.Map.Strict as Map
+import Data.Misc (FutureWork (..))
 import Data.Qualified
 import Data.Range
 import qualified Data.Set as Set
@@ -1000,7 +1001,7 @@ withValidOtrRecipients protectee clt cnv rcps val now go = do
     Data.deleteConversation cnv
     throwM convNotFound
   -- FUTUREWORK(federation): also handle remote members
-  localMembers <- Data.members cnv
+  (FutureWork @'LegalholdPlusFederationNotImplemented -> _remoteMembers, localMembers) <- (undefined, Data.members cnv)
   let localMemberIds = memId <$> localMembers
   isInternal <- view $ options . optSettings . setIntraListing
   clts <-
@@ -1128,7 +1129,8 @@ guardLegalholdPolicyConflicts LegalholdPlusFederationNotImplemented _otherClient
 guardLegalholdPolicyConflicts UnprotectedBot _otherClients = pure ()
 guardLegalholdPolicyConflicts (ProtectedUser self) otherClients = do
   view (options . optSettings . setFeatureFlags . flagLegalHold) >>= \case
-    FeatureLegalHoldDisabledPermanently -> pure () -- FUTUREWORK: if federation is enabled, still run the guard!
+    FeatureLegalHoldDisabledPermanently -> case FutureWork @'LegalholdPlusFederationNotImplemented () of
+      FutureWork () -> pure () -- FUTUREWORK: if federation is enabled, we still need to run the guard!
     FeatureLegalHoldDisabledByDefault -> guardLegalholdPolicyConflictsUid self otherClients
     FeatureLegalHoldWhitelistTeamsAndImplicitConsent -> guardLegalholdPolicyConflictsUid self otherClients
 


### PR DESCRIPTION
internal change, no need to show in the release notes.  it's pretty small and self-explanatory.