### PR TITLE
Handle LH policy conflicts in group conversations

### DIFF
--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -98,8 +98,8 @@ internalCreateManagedConversation zusr zcon (NewConvManaged body) = do
 ensureNoLegalholdConflicts :: [Remote UserId] -> [UserId] -> Galley ()
 ensureNoLegalholdConflicts remotes locals = do
   let FutureWork _remotes = FutureWork @'LegalholdPlusFederationNotImplemented remotes
-  whenM (anyLHActivatedLocalUsers locals) $
-    whenM (anyLHConsentMissing locals) $
+  whenM (anyLegalholdActivated locals) $
+    whenM (anyLegalholdConsentMissing locals) $
       throwM missingLegalholdConsent
 
 -- | A helper for creating a regular (non-team) group conversation.

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -396,7 +396,7 @@ changeLegalholdStatus tid uid old new = do
       UserLegalHoldPending -> do
         update
         -- outcome of addblocks logic might depend on the update. we'd like to
-        -- fail the transition in case addblocks fails neverless
+        -- fail the transition in case addblocks fails nevertheless
         addblocks `onException` revert
       UserLegalHoldDisabled -> {- in case the last attempt crashed -} removeblocks
       UserLegalHoldNoConsent -> {- withdrawing consent is not (yet?) implemented -} illegal

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -531,7 +531,7 @@ handleGroupConvPolicyConflicts uid =
     getAdmins :: Member -> [(OtherMember, UserLegalHoldStatus)] -> [(UserId, ConsentGiven)]
     getAdmins mem oths =
       [(memId mem, ConsentGiven) | memConvRoleName mem == roleNameWireAdmin]
-        <> fmap (bimap memberUnqualId consentGiven) oths
+        <> fmap (bimap memberUnqualId consentGiven) (filter ((== roleNameWireAdmin) . omConvRoleName . fst) oths)
 
     memberUnqualId :: OtherMember -> UserId
     memberUnqualId = qUnqualified . omQualifiedId

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -46,6 +46,7 @@ import Data.List.Split (chunksOf)
 import qualified Data.Map.Strict as Map
 import Data.Misc
 import Galley.API.Error
+import Galley.API.Update (removeMember)
 import Galley.API.Util
 import Galley.App
 import qualified Galley.Data as Data

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -48,7 +48,6 @@ module Galley.API.Teams
     uncheckedGetTeamMemberH,
     uncheckedGetTeamMembersH,
     uncheckedDeleteTeamMember,
-    withBindingTeam,
     userIsTeamOwnerH,
     canUserJoinTeamH,
     internalDeleteBindingTeamWithOneMemberH,

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -551,8 +551,8 @@ addMembers zusr zcon convId invite = do
 
     checkLHPolicyConflictsLocal :: Data.Conversation -> [UserId] -> Galley ()
     checkLHPolicyConflictsLocal conv newUsers =
-      whenM (anyLHActivatedLocalUsers (fmap memId . Data.convLocalMembers $ conv)) $ do
-        whenM (anyLHConsentMissing newUsers) $ do
+      whenM (anyLegalholdActivated (fmap memId . Data.convLocalMembers $ conv)) $ do
+        whenM (anyLegalholdConsentMissing newUsers) $ do
           throwM missingLegalholdConsent
 
     checkLHPolicyConflictsRemote :: FutureWork 'LegalholdPlusFederationNotImplemented [Remote UserId] -> Galley ()

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -532,7 +532,6 @@ addMembers zusr zcon convId invite = do
   checkLocals conv (Data.convTeam conv) newLocals
   checkRemoteUsersExist newRemotes
   checkLHPolicyConflicts conv newLocals
-  checkRemotes newRemotes
   checkLHPolicyConflictsRemote (FutureWork newRemotes)
   addToConversation mems rMems (zusr, memConvRoleName self) zcon ((,invQRoleName invite) <$> newLocals) ((,invQRoleName invite) <$> newRemotes) conv
   where
@@ -589,13 +588,6 @@ addMembers zusr zcon convId invite = do
 
     checkLHPolicyConflictsRemote :: futurework 'LegalholdPlusFederationNotImplemented [Remote UserId] -> Galley ()
     checkLHPolicyConflictsRemote = error "TODO"
-
-    checkRemotes :: [Remote UserId] -> Galley ()
-    checkRemotes =
-      traverse_ (uncurry checkRemotesFor)
-        . Map.assocs
-        . partitionQualified
-        . map unTagged
 
 updateSelfMemberH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.MemberUpdate -> Galley Response
 updateSelfMemberH (zusr ::: zcon ::: cid ::: req) = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1296,7 +1296,7 @@ guardLegalholdPolicyConflictsUid self otherClients = do
           Log.debug $ Log.msg ("guardLegalholdPolicyConflicts[3]: consent missing" :: Text)
           throwM missingLegalholdConsent
 
--- Duplicate from 'Galley.API.Team' to break import cycles
+-- Copied from 'Galley.API.Team' to break import cycles
 withBindingTeam :: UserId -> (TeamId -> Galley b) -> Galley b
 withBindingTeam zusr callback = do
   tid <- Data.oneUserTeam zusr >>= ifNothing teamNotFound

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -377,8 +377,8 @@ getLHStatus teamOfUser other = do
       mMember <- Data.teamMember team other
       pure $ maybe defUserLegalHoldStatus (view legalHoldStatus) mMember
 
-anyLHActivatedLocalUsers :: [UserId] -> Galley Bool
-anyLHActivatedLocalUsers uids =
+anyLegalholdActivated :: [UserId] -> Galley Bool
+anyLegalholdActivated uids =
   view (options . optSettings . setFeatureFlags . flagLegalHold) >>= \case
     FeatureLegalHoldDisabledPermanently -> pure False
     FeatureLegalHoldDisabledByDefault -> do
@@ -393,8 +393,8 @@ anyLHActivatedLocalUsers uids =
         teamsPage <- nub . Map.elems <$> Data.usersTeams uidsPage
         anyM isTeamLegalholdWhitelisted teamsPage
 
-anyLHConsentMissing :: [UserId] -> Galley Bool
-anyLHConsentMissing uids = do
+anyLegalholdConsentMissing :: [UserId] -> Galley Bool
+anyLegalholdConsentMissing uids = do
   view (options . optSettings . setFeatureFlags . flagLegalHold) >>= \case
     FeatureLegalHoldDisabledPermanently -> pure True
     FeatureLegalHoldDisabledByDefault -> do

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -399,7 +399,7 @@ anyLegalholdConsentMissing uids = do
         anyM (\uid -> (== ConsentNotGiven) . consentGiven <$> getLHStatus (Map.lookup uid teamsOfUsers) uid) uidsPage
     -- For this feature the implementation is more efficient. Being part of
     -- a whitelisted team is equivalent to have given consent to be in a
-    -- conversation with LH user.
+    -- conversation with user under legalhold.
     FeatureLegalHoldWhitelistTeamsAndImplicitConsent -> do
       flip anyM (chunksOf 32 uids) $ \uidsPage -> do
         teamsPage <- nub . Map.elems <$> Data.usersTeams uidsPage

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -149,10 +149,17 @@ testsPublic s =
                 flip fmap [(a, b, c, d) | a <- [minBound ..], b <- [minBound ..], c <- [minBound ..], d <- [minBound ..]] $
                   \args@(a, b, c, d) ->
                     test s (show args) $ testNoConsentBlockOne2OneConv a b c d,
-              testGroup "If LH is activated for user in group conv, non-consenting users get removed. If all admins are non-consenting then user gets removed." $
-                [a | a <- [minBound ..]] <&> \whoIsAdmin -> test s ("test case " <> show whoIsAdmin) (onlyIfLhWhitelisted (testNoConsentRemoveFromGroupConv whoIsAdmin)),
-              test s "non-consenting users cannot be invited to conversation if LH is present" (onlyIfLhWhitelisted testNoConsentCannotBeInvited),
-              test s "cannot create conversation with both LH activated and non-consenting users" (onlyIfLhWhitelisted testCannotCreateGroupWithUsersInConflict),
+              testGroup
+                "Legalhold is activated for user A in a group conversation"
+                [ test s "All admins are consenting: all non-consenters get removed from conversation" (onlyIfLhWhitelisted (testNoConsentRemoveFromGroupConv LegalholderIsAdmin)),
+                  test s "Some admins are consenting: all non-consenters get removed from conversation" (onlyIfLhWhitelisted (testNoConsentRemoveFromGroupConv BothAreAdmins)),
+                  test s "No admins are consenting: all LH activated/pending users get removed from conversation" (onlyIfLhWhitelisted (testNoConsentRemoveFromGroupConv PeerIsAdmin))
+                ],
+              testGroup
+                "Creating group conversation with LH activated users"
+                [ test s "Non-consenting users cannot be invited to conversation if LH activated users are in conversation" (onlyIfLhWhitelisted testNoConsentCannotBeInvited),
+                  test s "Cannot create conversation with both LH activated and non-consenting users" (onlyIfLhWhitelisted testCannotCreateGroupWithUsersInConflict)
+                ],
               test s "bench hack" testBenchHack,
               test s "User cannot fetch prekeys of LH users if consent is missing" (testClaimKeys TCKConsentMissing),
               test s "User cannot fetch prekeys of LH users: if user has old client" (testClaimKeys TCKOldClient),

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -149,9 +149,10 @@ testsPublic s =
                 flip fmap [(a, b, c, d) | a <- [minBound ..], b <- [minBound ..], c <- [minBound ..], d <- [minBound ..]] $
                   \args@(a, b, c, d) ->
                     test s (show args) $ testNoConsentBlockOne2OneConv a b c d,
-              testGroup "If LH is activated for other user in group conv, this user gets removed with helpful message" $
+              testGroup "If LH is activated for user in group conv, non-consenting users get removed. If all admins are non-consenting then user gets removed." $
                 [a | a <- [minBound ..]] <&> \whoIsAdmin -> test s ("test case " <> show whoIsAdmin) (onlyIfLhWhitelisted (testNoConsentRemoveFromGroupConv whoIsAdmin)),
-              test s "XXXXXX non-consenting users cannot be invited to conversation if LH is present" testNoConsentCannotBeInvited,
+              test s "non-consenting users cannot be invited to conversation if LH is present" (onlyIfLhWhitelisted testNoConsentCannotBeInvited),
+              test s "cannot create conversation with both LH activated and non-consenting users" (onlyIfLhWhitelisted testCannotCreateGroupWithUsersInConflict),
               test s "bench hack" testBenchHack,
               test s "User cannot fetch prekeys of LH users if consent is missing" (testClaimKeys TCKConsentMissing),
               test s "User cannot fetch prekeys of LH users: if user has old client" (testClaimKeys TCKOldClient),

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -916,7 +916,6 @@ data GroupConvAdmin
 
 testNoConsentRemoveFromGroupConv :: GroupConvAdmin -> HasCallStack => TestM ()
 testNoConsentRemoveFromGroupConv whoIsAdmin = do
-  -- FUTUREWORK: maybe regular user for legalholder?
   (legalholder :: UserId, tid) <- createBindingTeam
   (peer :: UserId, teamPeer) <- createBindingTeam
   galley <- view tsGalley
@@ -978,11 +977,13 @@ testNoConsentRemoveFromGroupConv whoIsAdmin = do
 
 testNoConsentCannotBeInvited :: HasCallStack => TestM ()
 testNoConsentCannotBeInvited = do
+  -- team that is legalhold whitelisted
   (legalholder :: UserId, tid) <- createBindingTeam
   userLHNotActivated <- (^. userId) <$> addUserToTeam legalholder tid
   ensureQueueEmpty
   putLHWhitelistTeam tid !!! const 200 === statusCode
 
+  -- team without legelhold
   (peer :: UserId, teamPeer) <- createBindingTeam
   peer2 <- (^. userId) <$> addUserToTeam peer teamPeer
   ensureQueueEmpty
@@ -1000,6 +1001,7 @@ testNoConsentCannotBeInvited = do
     API.Util.postMembers userLHNotActivated (List1.list1 peer []) convId
       !!! const 200 === statusCode
 
+    -- activate legalhold for legalholder
     do
       galley <- view tsGalley
       requestLegalHoldDevice legalholder legalholder tid !!! testResponse 201 Nothing

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -998,13 +998,13 @@ testNoConsentCannotBeInvited = do
     !!! const 200 === statusCode
 
   putLHWhitelistTeam tid !!! const 200 === statusCode
-  withDummyTestServiceForTeam legalholder tid $ \_chan -> do
-    ensureQueueEmpty
 
-    API.Util.postMembers userOnLHTeam (List1.list1 peer2 []) convId
-      >>= errWith 412 (\err -> Error.label err == "missing-legalhold-consent")
+  API.Util.postMembers userOnLHTeam (List1.list1 peer2 []) convId
+    >>= errWith 412 (\err -> Error.label err == "missing-legalhold-consent")
 
--- TODO: as peer create conversation with peer2 and userOnLHteam
+  -- next case: invite users with conflicting policies
+  createTeamConvAccessRaw peer teamPeer [peer2, userOnLHTeam] (Just "bla") Nothing Nothing Nothing (Just roleNameWireMember)
+    >>= errWith 412 (\err -> Error.label err == "missing-legalhold-consent")
 
 data TestClaimKeys
   = TCKConsentMissing

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -26,7 +26,7 @@ where
 
 import API.SQS
 import qualified API.SQS as SQS
-import API.Util hiding (timeout)
+import API.Util
 import Bilge hiding (accept, head, timeout, trace)
 import Bilge.Assert
 import qualified Bilge.TestSession as BilgeTest
@@ -939,7 +939,7 @@ testNoConsentRemoveFromGroupConv whoIsAdmin = do
 
   cannon <- view tsCannon
 
-  WS.bracketR2 cannon legalholder peer $ \(legalholderWs, peerWs) -> withDummyTestServiceForTeam legalholder tid $ \_chan -> do
+  WS.bracketR2 cannon legalholder peer $ \(_legalholderWs, _peerWs) -> withDummyTestServiceForTeam legalholder tid $ \_chan -> do
     ensureQueueEmpty
 
     postConnection legalholder peer !!! const 201 === statusCode
@@ -957,8 +957,9 @@ testNoConsentRemoveFromGroupConv whoIsAdmin = do
       mapM_ (assertConvMemberWithRole roleNameWireMember convId) [invitee | whoIsAdmin /= BothAreAdmins]
       pure convId
 
-    checkConvCreateEvent convId legalholderWs
-    checkConvCreateEvent convId peerWs
+    -- TODO
+    -- checkConvCreateEvent convId legalholderWs
+    -- checkConvCreateEvent convId peerWs
 
     assertConvMember legalholder convId
     assertConvMember peer convId

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -140,8 +140,8 @@ testsPublic s =
 
       -}
       testGroup
-        "settings.legalholdEnabledTeams"
-        [ testGroup
+        "settings.legalholdEnabledTeams" -- FUTUREWORK: ungroup this level
+        [ testGroup -- FUTUREWORK: ungroup this level
             "teams listed"
             [ test s "happy flow" testInWhitelist,
               test s "handshake between LH device and user with old clients is blocked" testOldClientsBlockDeviceHandshake,

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -52,6 +52,7 @@ import Data.ByteString.Conversion
 import Data.Id
 import Data.Json.Util (toUTCTimeMillis)
 import Data.LegalHold
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.List1 as List1
 import qualified Data.Map.Strict as Map
@@ -1020,8 +1021,9 @@ testNoConsentCannotBeInvited = do
     API.Util.postMembers userLHNotActivated (List1.list1 peer2 []) convId
       >>= errWith 412 (\err -> Error.label err == "missing-legalhold-consent")
 
-    -- TODO: v2 endpoint
-    pure ()
+    localdomain <- viewFederationDomain
+    API.Util.postQualifiedMembers userLHNotActivated ((Qualified peer2 localdomain) :| []) convId
+      >>= errWith 412 (\err -> Error.label err == "missing-legalhold-consent")
 
 testCannotCreateGroupWithUsersInConflict :: HasCallStack => TestM ()
 testCannotCreateGroupWithUsersInConflict = do

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -57,6 +57,7 @@ import qualified Data.List1 as List1
 import qualified Data.Map.Strict as Map
 import Data.Misc (PlainTextPassword)
 import Data.PEM
+import Data.Qualified (Qualified (Qualified))
 import Data.Range
 import qualified Data.Set as Set
 import Data.String.Conversions (LBS, cs)
@@ -965,16 +966,24 @@ testNoConsentRemoveFromGroupConv whoIsAdmin = do
 
     void enableLHForLegalholder
 
+    localdomain <- viewFederationDomain
+
     case whoIsAdmin of
       LegalholderIsAdmin -> do
         assertConvMember legalholder convId
         assertNotConvMember peer convId
+        checkConvMemberLeaveEvent (Qualified convId localdomain) peer legalholderWs
+        checkConvMemberLeaveEvent (Qualified convId localdomain) peer peerWs
       PeerIsAdmin -> do
         assertConvMember peer convId
         assertNotConvMember legalholder convId
+        checkConvMemberLeaveEvent (Qualified convId localdomain) legalholder legalholderWs
+        checkConvMemberLeaveEvent (Qualified convId localdomain) legalholder peerWs
       BothAreAdmins -> do
         assertConvMember legalholder convId
         assertNotConvMember peer convId
+        checkConvMemberLeaveEvent (Qualified convId localdomain) peer legalholderWs
+        checkConvMemberLeaveEvent (Qualified convId localdomain) peer peerWs
 
 data TestClaimKeys
   = TCKConsentMissing

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -945,6 +945,8 @@ testNoConsentBlockGroupConv = do
   WS.bracketR2 cannon legalholder peer $ \(legalholderWs, peerWs) -> withDummyTestServiceForTeam legalholder tid $ \_chan -> do
     ensureQueueEmpty
 
+    postConnection legalholder peer !!! const 201 === statusCode
+
     -- Regular conversation:
     convId <- createTeamConv legalholder tid [peer] (Just "group chat with external peer") Nothing Nothing
     checkConvCreateEvent convId legalholderWs
@@ -953,6 +955,8 @@ testNoConsentBlockGroupConv = do
     mapM_ (assertConvMemberWithRole roleNameWireMember convId) [peer]
 
     void $ doEnableLH
+
+    mapConcurrently_ (checkTeamMemberLeave tid peer) [legalholder, peer]
 
 -- TODO: assert that peer is no longer in group
 


### PR DESCRIPTION
Description rewritten by me (@smatting):

This PR ensures that users of these categories

- category 1: users that are under legalhold (are in state
  `UserLegalholdPending` or `UserLegalholdActive`)
- category 2: users that didn't give consent to be in a conversation with user from group 1

cannot be in the same group conversation (1:1 conversations are handled in #).

This is enforced by

1) removing users from group conversations and
2) preventing the creation of conversations with users from both categories 1 and 2.

#### 1) Removing users

When a user is transitioning into the `UserLegalholdPending` state all her group
conversations are traversed and users are removed. Who gets removed from the
conversation depends on the admins of the group conversation:

- If any of the admins has given consent then all users (including potential other admins) from category 2 are removed.
- If none of the admins has given consent then the user itself is removed from
  the conversation.

#### 2) Preventing creation  of conversations

This PR adds a guard that prevents conversations with initial participants that
are both from category 1 and 2. This PR adds a guard to the invite
functionality: A user from category 2 cannot be invited to a group conversation
that contains participants from category 1 and vice versa (the vice versa case
is impossible to occur with the `whitelist-teams-and-implicit-consent` feature
flag, because connections are blocked and invitation is not possible without it.
That's why integration tests for this flag don't list this case).

Internal notes: https://wearezeta.atlassian.net/browse/SQSERVICES-428
