### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: 2021-04-01-production.0-254d51-v0.28.3-production
+  tag: "0.2.0-v0.28.16-0-0efe29f"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `0.2.0-v0.28.16-0-0efe29f`
Release: [`v0.2.0`](https://github.com/wireapp/wire-webapp/releases/tag/v0.2.0)