### PR TITLE
Parametric mock federator

### DIFF
--- a/libs/wire-api-federation/src/Wire/API/Federation/Mock.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Mock.hs
@@ -89,6 +89,14 @@ flushState = flip modifyIORef $ \s -> s {receivedRequests = [], effectfulRespons
 initState :: Domain -> Domain -> MockState
 initState targetDomain originDomain = MockState [] (error "No mock response provided") (error "server not started") (error "No port selected yet") targetDomain originDomain
 
+-- | Run an action with access to a mock federator.
+--
+-- The function argument `resp :: FederatedRequest -> ServerErrorIO
+-- OutwardResponse` can be used to provide a fake federator response for each
+-- possible request it is expected to receive.
+--
+-- More explicitly, any request `req` to the federator within the provided
+-- action will return `resp req` as its response.
 withMockFederator ::
   IORef MockState ->
   (FederatedRequest -> ServerErrorIO OutwardResponse) ->

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/ClientSpec.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/ClientSpec.hs
@@ -49,7 +49,7 @@ spec = do
         expectedResponse :: Maybe UserProfile <- generate arbitrary
 
         (actualResponse, sentRequests) <-
-          assertRightT . withMockFederatorClient stateRef (mkSuccessResponse expectedResponse) $
+          assertRightT . withMockFederatorClient stateRef (const (mkSuccessResponse expectedResponse)) $
             Brig.getUserByHandle Brig.clientRoutes handle
 
         sentRequests `shouldBe` [FederatedRequest "target.example.com" (Just $ Request Brig "/federation/get-user-by-handle" (LBS.toStrict (Aeson.encode handle)) "origin.example.com")]
@@ -60,7 +60,7 @@ spec = do
         someErr <- generate arbitrary
 
         (actualResponse, _) <-
-          assertRightT . withMockFederatorClient stateRef (mkErrorResponse someErr) $
+          assertRightT . withMockFederatorClient stateRef (const (mkErrorResponse someErr)) $
             Brig.getUserByHandle Brig.clientRoutes handle
 
         actualResponse `shouldBe` Left (FederationClientOutwardError someErr)
@@ -84,7 +84,7 @@ spec = do
         handle <- generate arbitrary
 
         (actualResponse, _) <-
-          assertRightT . withMockFederatorClient stateRef (throwError $ Mu.ServerError Mu.NotFound "Just testing") $
+          assertRightT . withMockFederatorClient stateRef (const (throwError $ Mu.ServerError Mu.NotFound "Just testing")) $
             Brig.getUserByHandle Brig.clientRoutes handle
 
         actualResponse `shouldBe` Left (FederationClientRPCError "grpc error: GRPC status indicates failure: status-code=NOT_FOUND, status-message=\"Just testing\"")

--- a/services/brig/test/integration/Federation/Util.hs
+++ b/services/brig/test/integration/Federation/Util.hs
@@ -70,7 +70,7 @@ import Wire.API.Team.Feature (TeamFeatureStatusValue (..))
 -- which will contact this mocked federator instead of a real federator.
 withMockFederator :: Opt.Opts -> IORef Mock.MockState -> OutwardResponse -> Session a -> IO (a, Mock.ReceivedRequests)
 withMockFederator opts ref resp action = assertRightT
-  . Mock.withMockFederator ref (pure resp)
+  . Mock.withMockFederator ref (const (pure resp))
   $ \st -> lift $ do
     let opts' =
           opts
@@ -81,7 +81,7 @@ withMockFederator opts ref resp action = assertRightT
 
 withTempMockFederator :: Opt.Opts -> Domain -> OutwardResponse -> Session a -> IO (a, Mock.ReceivedRequests)
 withTempMockFederator opts targetDomain resp action = assertRightT
-  . Mock.withTempMockFederator st0 (pure resp)
+  . Mock.withTempMockFederator st0 (const (pure resp))
   $ \st -> lift $ do
     let opts' =
           opts

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -886,7 +886,7 @@ testAddRemoteMember = do
       withTempMockFederator
         opts
         remoteDomain
-        [mkProfile remoteBob (Name "bob")]
+        (const [mkProfile remoteBob (Name "bob")])
         (postQualifiedMembers' g alice (remoteBob :| []) convId)
   e <- responseJsonUnsafe <$> (pure resp <!! const 200 === statusCode)
   liftIO $ do
@@ -917,7 +917,7 @@ testAddRemoteMemberFailure = do
       withTempMockFederator
         opts
         remoteDomain
-        [mkProfile remoteCharlie (Name "charlie")]
+        (const [mkProfile remoteCharlie (Name "charlie")])
         (postQualifiedMembers' g alice (remoteBob :| [remoteCharlie]) convId)
     statusCode resp @?= 400
     let err = responseJsonUnsafe resp :: Object
@@ -937,7 +937,7 @@ testAddDeletedRemoteUser = do
       withTempMockFederator
         opts
         remoteDomain
-        [(mkProfile remoteBob (Name "bob")) {profileDeleted = True}]
+        (const [(mkProfile remoteBob (Name "bob")) {profileDeleted = True}])
         (postQualifiedMembers' g alice (remoteBob :| []) convId)
     statusCode resp @?= 400
     let err = responseJsonUnsafe resp :: Object

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1666,6 +1666,12 @@ mkProfile quid name =
 
 -- mock federator
 
+-- | Run the given action on a temporary galley instance with access to a mock
+-- federator.
+--
+-- The `resp :: FederatedRequest -> a` argument can be used to provide a fake
+-- federator response (of an arbitrary JSON-serialisable type a) for every
+-- expected request.
 withTempMockFederator ::
   (MonadIO m, ToJSON a) =>
   Opts.Opts ->

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -92,7 +92,7 @@ import Web.Cookie
 import qualified Wire.API.Conversation as Public
 import Wire.API.Conversation.Member (Member (..))
 import qualified Wire.API.Event.Team as TE
-import Wire.API.Federation.GRPC.Types (OutwardResponse (..))
+import Wire.API.Federation.GRPC.Types (FederatedRequest, OutwardResponse (..))
 import qualified Wire.API.Federation.Mock as Mock
 import qualified Wire.API.Message.Proto as Proto
 import Wire.API.User.Client (ClientCapability (..), UserClientsFull (UserClientsFull))
@@ -1670,11 +1670,11 @@ withTempMockFederator ::
   (MonadIO m, ToJSON a) =>
   Opts.Opts ->
   Domain ->
-  a ->
+  (FederatedRequest -> a) ->
   WaiTest.Session b ->
   m (b, Mock.ReceivedRequests)
 withTempMockFederator opts targetDomain resp action = liftIO . assertRightT
-  . Mock.withTempMockFederator st0 (pure oresp)
+  . Mock.withTempMockFederator st0 (pure . oresp)
   $ \st -> lift $ do
     let opts' =
           opts & Opts.optFederator
@@ -1682,7 +1682,7 @@ withTempMockFederator opts targetDomain resp action = liftIO . assertRightT
     withSettingsOverrides opts' action
   where
     st0 = Mock.initState targetDomain (Domain "example.com")
-    oresp = OutwardResponseBody (Lazy.toStrict (encode resp))
+    oresp = OutwardResponseBody . Lazy.toStrict . encode . resp
 
 assertRight :: (MonadIO m, Show a, HasCallStack) => Either a b -> m b
 assertRight = \case


### PR DESCRIPTION
This makes the fake response provided to a mock federator take a request argument. The motivation is that it allows a single mock to be used to provide multiple fake responses depending on the requests received.

For example, when testing the endpoint for adding remote members to conversations, the mock federator will be queried twice: once to fetch remote user profiles, and once to propagate the join event to the remote backend. Therefore, we need to be able to set up different fake responses for the two requests.

See [this commit](https://github.com/wireapp/wire-server/pull/1556/commits/1f69b233508a01378d54bfd694335023ecd1d345) in #1556 for a usage example.