### PR TITLE
Add more information to federation errors

### DIFF
--- a/libs/wai-utilities/src/Network/Wai/Utilities/Error.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Error.hs
@@ -50,18 +50,16 @@ instance Exception Error
 
 data ErrorData = FederationErrorData
   { federrDomain :: !Domain,
-    federrPath :: !Text,
-    federrError :: !Value
+    federrPath :: !Text
   }
   deriving (Show, Typeable)
 
 instance ToJSON ErrorData where
-  toJSON (FederationErrorData d p e) =
+  toJSON (FederationErrorData d p) =
     object
       [ "type" .= ("federation" :: Text),
         "domain" .= d,
-        "path" .= p,
-        "remote_error" .= e
+        "path" .= p
       ]
 
 instance FromJSON ErrorData where
@@ -69,7 +67,6 @@ instance FromJSON ErrorData where
     FederationErrorData
       <$> o .: "domain"
       <*> o .: "path"
-      <*> o .: "remote_error"
 
 -- | Assumes UTF-8 encoding.
 byteStringError :: Status -> LByteString -> LByteString -> Error

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Request.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Request.hs
@@ -56,7 +56,7 @@ parseBody r = readBody r >>= hoistEither . fmapL Text.pack . eitherDecode'
 parseBody' :: (FromJSON a, MonadIO m, MonadThrow m) => JsonRequest a -> m a
 parseBody' r = either thrw pure =<< runExceptT (parseBody r)
   where
-    thrw msg = throwM $ Wai.Error status400 "bad-request" msg
+    thrw msg = throwM $ Wai.mkError status400 "bad-request" msg
 
 parseOptionalBody ::
   (MonadIO m, FromJSON a) =>

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Response.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Response.hs
@@ -46,7 +46,7 @@ jsonContent :: Header
 jsonContent = (hContentType, "application/json")
 
 errorRs :: Status -> LText -> LText -> Response
-errorRs s l m = errorRs' (Error s l m)
+errorRs s l m = errorRs' (mkError s l m)
 
 errorRs' :: Error -> Response
 errorRs' e = setStatus (code e) (json e)

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -145,7 +145,7 @@ runSettingsWithShutdown s app secs = do
 compile :: Monad m => Routes a m b -> Tree (App m)
 compile routes = Route.prepare (Route.renderer predicateError >> routes)
   where
-    predicateError e = return (encode $ Wai.Error (P.status e) "client-error" (format e), [jsonContent])
+    predicateError e = return (encode $ Wai.mkError (P.status e) "client-error" (format e), [jsonContent])
     -- [label] 'source' reason: message
     format e =
       let l = labelStr $ labels e
@@ -171,7 +171,7 @@ compile routes = Route.prepare (Route.renderer predicateError >> routes)
 route :: (MonadCatch m, MonadIO m) => Tree (App m) -> Request -> Continue IO -> m ResponseReceived
 route rt rq k = Route.routeWith (Route.Config $ errorRs' noEndpoint) rt rq (liftIO . k)
   where
-    noEndpoint = Wai.Error status404 "no-endpoint" "The requested endpoint does not exist"
+    noEndpoint = Wai.mkError status404 "no-endpoint" "The requested endpoint does not exist"
 {-# INLINEABLE route #-}
 
 --------------------------------------------------------------------------------
@@ -201,12 +201,12 @@ catchErrors l m app req k =
 errorHandlers :: Applicative m => [Handler m Wai.Error]
 errorHandlers =
   [ Handler $ \(x :: Wai.Error) -> pure x,
-    Handler $ \(_ :: InvalidRequest) -> pure $ Wai.Error status400 "client-error" "Invalid Request",
-    Handler $ \(_ :: TimeoutThread) -> pure $ Wai.Error status408 "client-error" "Request Timeout",
+    Handler $ \(_ :: InvalidRequest) -> pure $ Wai.mkError status400 "client-error" "Invalid Request",
+    Handler $ \(_ :: TimeoutThread) -> pure $ Wai.mkError status408 "client-error" "Request Timeout",
     Handler $ \case
-      ZlibException (-3) -> pure $ Wai.Error status400 "client-error" "Invalid request body compression"
-      ZlibException _ -> pure $ Wai.Error status500 "server-error" "Server Error",
-    Handler $ \(_ :: SomeException) -> pure $ Wai.Error status500 "server-error" "Server Error"
+      ZlibException (-3) -> pure $ Wai.mkError status400 "client-error" "Invalid request body compression"
+      ZlibException _ -> pure $ Wai.mkError status500 "server-error" "Server Error",
+    Handler $ \(_ :: SomeException) -> pure $ Wai.mkError status500 "server-error" "Server Error"
   ]
 {-# INLINE errorHandlers #-}
 
@@ -298,7 +298,7 @@ rethrow5xx logger app req k = app req k'
         then k resp
         else do
           rsbody :: LText <- liftIO $ cs <$> lazyResponseBody resp
-          throwM $ Wai.Error st "server-error" rsbody
+          throwM $ Wai.mkError st "server-error" rsbody
 
 -- | This flushes the response!  If you want to keep using the response, you need to construct
 -- a new one with a fresh body stream.
@@ -342,13 +342,17 @@ logError :: (MonadIO m, HasRequest r) => Logger -> Maybe r -> Wai.Error -> m ()
 logError g mr = logError' g (lookupRequestId =<< mr)
 
 logError' :: (MonadIO m) => Logger -> Maybe ByteString -> Wai.Error -> m ()
-logError' g mr (Wai.Error c l m) = liftIO $ Log.debug g logMsg
+logError' g mr (Wai.Error c l m md) = liftIO $ Log.debug g logMsg
   where
     logMsg =
       field "code" (statusCode c)
         . field "label" l
         . field "request" (fromMaybe "N/A" mr)
+        . fromMaybe id (fmap logErrorData md)
         . msg (val "\"" +++ m +++ val "\"")
+
+    -- TODO: actually log error data fields
+    logErrorData _ = id
 
 logIO :: (ToBytes msg, HasRequest r) => Logger -> Level -> Maybe r -> msg -> IO ()
 logIO lg lv r a =

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -353,10 +353,9 @@ logError' g mr (Wai.Error c l m md) = liftIO $ Log.debug g logMsg
         . msg (val "\"" +++ m +++ val "\"")
 
     -- TODO: actually log error data fields
-    logErrorData (Wai.FederationErrorData d p e) =
+    logErrorData (Wai.FederationErrorData d p) =
       field "domain" (domainText d)
         . field "path" p
-        . field "remote_error" (encode e)
 
 logIO :: (ToBytes msg, HasRequest r) => Logger -> Level -> Maybe r -> msg -> IO ()
 logIO lg lv r a =

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -54,6 +54,7 @@ import qualified Data.ByteString as BS
 import Data.ByteString.Builder
 import qualified Data.ByteString.Char8 as C
 import qualified Data.ByteString.Lazy as LBS
+import Data.Domain (domainText)
 import Data.Metrics.GC (spawnGCMetricsCollector)
 import Data.Metrics.Middleware
 import Data.Streaming.Zlib (ZlibException (..))
@@ -352,7 +353,10 @@ logError' g mr (Wai.Error c l m md) = liftIO $ Log.debug g logMsg
         . msg (val "\"" +++ m +++ val "\"")
 
     -- TODO: actually log error data fields
-    logErrorData _ = id
+    logErrorData (Wai.FederationErrorData d p e) =
+      field "domain" (domainText d)
+        . field "path" p
+        . field "remote_error" (encode e)
 
 logIO :: (ToBytes msg, HasRequest r) => Logger -> Level -> Maybe r -> msg -> IO ()
 logIO lg lv r a =

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -27,7 +27,7 @@ import Servant.API.Generic
 import Servant.Client.Generic (AsClientT, genericClient)
 import Test.QuickCheck (Arbitrary)
 import Wire.API.Arbitrary (GenericUniform (..))
-import Wire.API.Federation.Client (FederationClientError, FederatorClient)
+import Wire.API.Federation.Client (FederationClientFailure, FederatorClient)
 import qualified Wire.API.Federation.GRPC.Types as Proto
 import Wire.API.Message (UserClients)
 import Wire.API.User (UserProfile)
@@ -86,5 +86,5 @@ data Api routes = Api
   }
   deriving (Generic)
 
-clientRoutes :: (MonadError FederationClientError m, MonadIO m) => Api (AsClientT (FederatorClient 'Proto.Brig m))
+clientRoutes :: (MonadError FederationClientFailure m, MonadIO m) => Api (AsClientT (FederatorClient 'Proto.Brig m))
 clientRoutes = genericClient

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -29,7 +29,7 @@ import Servant.Client.Generic (AsClientT, genericClient)
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import Wire.API.Conversation (Conversation)
 import Wire.API.Conversation.Role (RoleName)
-import Wire.API.Federation.Client (FederationClientError, FederatorClient)
+import Wire.API.Federation.Client (FederationClientFailure, FederatorClient)
 import qualified Wire.API.Federation.GRPC.Types as Proto
 import Wire.API.Federation.Util.Aeson (CustomEncoded (CustomEncoded))
 
@@ -82,5 +82,5 @@ data ConversationMemberUpdate = ConversationMemberUpdate
   deriving (Arbitrary) via (GenericUniform ConversationMemberUpdate)
   deriving (ToJSON, FromJSON) via (CustomEncoded ConversationMemberUpdate)
 
-clientRoutes :: (MonadError FederationClientError m, MonadIO m) => Api (AsClientT (FederatorClient 'Proto.Galley m))
+clientRoutes :: (MonadError FederationClientFailure m, MonadIO m) => Api (AsClientT (FederatorClient 'Proto.Galley m))
 clientRoutes = genericClient

--- a/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
@@ -21,6 +21,7 @@
 module Wire.API.Federation.Client where
 
 import Control.Monad.Except (ExceptT, MonadError (..), withExceptT)
+import Control.Monad.State (MonadState (..), StateT, evalStateT, gets)
 import Data.ByteString.Builder (toLazyByteString)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Domain (Domain, domainText)
@@ -41,11 +42,11 @@ data FederatorClientEnv = FederatorClientEnv
     originDomain :: Domain
   }
 
-newtype FederatorClient (component :: Proto.Component) m a = FederatorClient {runFederatorClient :: ReaderT FederatorClientEnv m a}
-  deriving newtype (Functor, Applicative, Monad, MonadReader FederatorClientEnv, MonadIO)
+newtype FederatorClient (component :: Proto.Component) m a = FederatorClient {runFederatorClient :: ReaderT FederatorClientEnv (StateT (Maybe ByteString) m) a}
+  deriving newtype (Functor, Applicative, Monad, MonadReader FederatorClientEnv, MonadState (Maybe ByteString), MonadIO)
 
-runFederatorClientWith :: GrpcClient -> Domain -> Domain -> FederatorClient component m a -> m a
-runFederatorClientWith client targetDomain originDomain = flip runReaderT (FederatorClientEnv client targetDomain originDomain) . runFederatorClient
+runFederatorClientWith :: Monad m => GrpcClient -> Domain -> Domain -> FederatorClient component m a -> m a
+runFederatorClientWith client targetDomain originDomain = flip evalStateT Nothing . flip runReaderT (FederatorClientEnv client targetDomain originDomain) . runFederatorClient
 
 class KnownComponent (c :: Proto.Component) where
   componentVal :: Proto.Component
@@ -58,26 +59,37 @@ instance KnownComponent 'Proto.Galley where
 
 -- | expectedStatuses is ignored as we don't get any status from the federator,
 -- all responses have '200 OK' as their status.
-instance (Monad m, MonadError FederationClientError m, MonadIO m, KnownComponent component) => RunClient (FederatorClient component m) where
+instance (Monad m, MonadIO m, MonadError FederationClientFailure m, KnownComponent component) => RunClient (FederatorClient component m) where
   runRequestAcceptStatus _expectedStatuses req = do
     env <- ask
+    let path = LBS.toStrict . toLazyByteString $ requestPath req
+        domain = targetDomain env
+        mkFailure = FederationClientFailure domain path
+        failure :: MonadError FederationClientFailure n => FederationClientError -> n x
+        failure = throwError . mkFailure
+        rpcFailure = failure . FederationClientRPCError
+        readBody = \case
+          RequestBodyLBS lbs -> pure $ LBS.toStrict lbs
+          RequestBodyBS bs -> pure bs
+          RequestBodySource _ -> failure FederationClientStreamingUnsupported
+    put (Just path)
     body <- readBody . maybe (RequestBodyBS "") fst $ requestBody req
     let call =
           Proto.ValidatedFederatedRequest
-            (targetDomain env)
+            domain
             ( Proto.Request
                 (componentVal @component)
-                (LBS.toStrict . toLazyByteString $ requestPath req)
+                path
                 body
                 (domainText (originDomain env))
             )
     grpcResponse <- callRemote (grpcClient env) call
     case grpcResponse of
-      GRpcTooMuchConcurrency _tmc -> rpcErr "too much concurrency"
-      GRpcErrorCode code -> rpcErr $ "grpc error code: " <> T.pack (show code)
-      GRpcErrorString msg -> rpcErr $ "grpc error: " <> T.pack msg
-      GRpcClientError msg -> rpcErr $ "grpc client error: " <> T.pack (show msg)
-      GRpcOk (Proto.OutwardResponseError err) -> throwError (FederationClientOutwardError err)
+      GRpcTooMuchConcurrency _tmc -> rpcFailure "too much concurrency"
+      GRpcErrorCode code -> rpcFailure $ "grpc error code: " <> T.pack (show code)
+      GRpcErrorString msg -> rpcFailure $ "grpc error: " <> T.pack msg
+      GRpcClientError msg -> rpcFailure $ "grpc client error: " <> T.pack (show msg)
+      GRpcOk (Proto.OutwardResponseError err) -> failure (FederationClientOutwardError err)
       GRpcOk (Proto.OutwardResponseBody res) -> do
         pure $
           Response
@@ -89,15 +101,13 @@ instance (Monad m, MonadError FederationClientError m, MonadIO m, KnownComponent
               responseHttpVersion = HTTP.http11,
               responseBody = LBS.fromStrict res
             }
-    where
-      rpcErr = throwError . FederationClientRPCError
-      readBody = \case
-        RequestBodyLBS lbs -> pure $ LBS.toStrict lbs
-        RequestBodyBS bs -> pure bs
-        RequestBodySource _ -> throwError FederationClientStreamingUnsupported
-  throwClientError = throwError . FederationClientServantError
 
-instance (Monad m, MonadError FederationClientError m) => MonadError FederationClientError (FederatorClient c m) where
+  throwClientError err = do
+    dom <- asks targetDomain
+    path <- gets (fromMaybe "")
+    throwError (FederationClientFailure dom path (FederationClientServantError err))
+
+instance (Monad m, MonadError FederationClientFailure m) => MonadError FederationClientFailure (FederatorClient c m) where
   throwError = FederatorClient . throwError
   catchError (FederatorClient action) f = FederatorClient $ catchError action (runFederatorClient . f)
 
@@ -105,7 +115,14 @@ data FederationError
   = FederationUnavailable Text
   | FederationNotImplemented
   | FederationNotConfigured
-  | FederationCallFailure FederationClientError
+  | FederationCallFailure FederationClientFailure
+
+data FederationClientFailure = FederationClientFailure
+  { fedFailDomain :: Domain,
+    fedFailPath :: ByteString,
+    fedFailError :: FederationClientError
+  }
+  deriving (Show, Eq)
 
 data FederationClientError
   = FederationClientInvalidMethod HTTP.Method
@@ -141,7 +158,7 @@ mkFederatorClient = do
 executeFederated ::
   (MonadIO m, HasFederatorConfig m) =>
   Domain ->
-  FederatorClient component (ExceptT FederationClientError m) a ->
+  FederatorClient component (ExceptT FederationClientFailure m) a ->
   ExceptT FederationError m a
 executeFederated targetDomain action = do
   federatorClient <- mkFederatorClient

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -17,7 +17,6 @@
 
 module Wire.API.Federation.Error where
 
-import Data.Aeson (Value (Null))
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as LT
@@ -69,12 +68,9 @@ federationErrorToWai (FederationCallFailure failure) = addErrorData $
             Just
               Wai.FederationErrorData
                 { Wai.federrDomain = fedFailDomain failure,
-                  Wai.federrPath = T.decodeUtf8 (fedFailPath failure),
-                  Wai.federrError = remoteError
+                  Wai.federrPath = T.decodeUtf8 (fedFailPath failure)
                 }
         }
-      where
-        remoteError = fromMaybe Null (fmap Wai.federrError (Wai.errorData err))
 
 noFederationStatus :: Status
 noFederationStatus = status403

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -42,14 +42,14 @@ federationErrorToWai (FederationCallFailure err) =
     FederationClientOutwardError outwardErr -> federationRemoteError outwardErr
     FederationClientServantError (Servant.DecodeFailure msg _) -> federationInvalidBody msg
     FederationClientServantError (Servant.FailureResponse _ _) ->
-      Wai.Error unexpectedFederationResponseStatus "unknown-federation-error" "Unknown federation error"
+      Wai.mkError unexpectedFederationResponseStatus "unknown-federation-error" "Unknown federation error"
     FederationClientServantError (Servant.InvalidContentTypeHeader res) ->
-      Wai.Error
+      Wai.mkError
         unexpectedFederationResponseStatus
         "federation-invalid-content-type-header"
         ("Content-type: " <> contentType res)
     FederationClientServantError (Servant.UnsupportedContentType mediaType res) ->
-      Wai.Error
+      Wai.mkError
         unexpectedFederationResponseStatus
         "federation-unsupported-content-type"
         ("Content-type: " <> contentType res <> ", Media-Type: " <> LT.pack (show mediaType))
@@ -69,48 +69,48 @@ federatorConnectionRefusedStatus = HTTP.Status 521 "Remote Federator Connection 
 
 federationNotImplemented :: Wai.Error
 federationNotImplemented =
-  Wai.Error
+  Wai.mkError
     noFederationStatus
     "federation-not-implemented"
     "Federation is not yet implemented for this endpoint"
 
 federationInvalidCode :: Word32 -> Wai.Error
 federationInvalidCode code =
-  Wai.Error
+  Wai.mkError
     unexpectedFederationResponseStatus
     "federation-invalid-code"
     ("Invalid response code from remote federator: " <> LT.pack (show code))
 
 federationInvalidBody :: Text -> Wai.Error
 federationInvalidBody msg =
-  Wai.Error
+  Wai.mkError
     unexpectedFederationResponseStatus
     "federation-invalid-body"
     ("Could not parse remote federator response: " <> LT.fromStrict msg)
 
 federationNotConfigured :: Wai.Error
 federationNotConfigured =
-  Wai.Error
+  Wai.mkError
     HTTP.status400
     "federation-not-enabled"
     "no federator configured"
 
 federationRpcError :: Text -> Wai.Error
 federationRpcError msg =
-  Wai.Error
+  Wai.mkError
     HTTP.status500
     "federation-rpc-error"
     (LT.fromStrict msg)
 
 federationUnavailable :: Text -> Wai.Error
 federationUnavailable err =
-  Wai.Error
+  Wai.mkError
     HTTP.status500
     "federation-not-available"
     ("Local federator not available: " <> LT.fromStrict err)
 
 federationRemoteError :: Proto.OutwardError -> Wai.Error
-federationRemoteError err = Wai.Error status (LT.fromStrict label) (LT.fromStrict msg)
+federationRemoteError err = Wai.mkError status (LT.fromStrict label) (LT.fromStrict msg)
   where
     decodeError :: Maybe Proto.ErrorPayload -> (Text, Text)
     decodeError Nothing = ("unknown-federation-error", "Unknown federation error")
@@ -131,4 +131,4 @@ federationRemoteError err = Wai.Error status (LT.fromStrict label) (LT.fromStric
       Proto.InvalidRequest -> HTTP.status500
 
 federationInvalidCall :: LText -> Wai.Error
-federationInvalidCall = Wai.Error HTTP.status500 "federation-invalid-call"
+federationInvalidCall = Wai.mkError HTTP.status500 "federation-invalid-call"

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/ClientSpec.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/ClientSpec.hs
@@ -22,6 +22,7 @@ module Test.Wire.API.Federation.ClientSpec where
 
 import Control.Monad.Except (ExceptT, MonadError (..), runExceptT)
 import qualified Data.Aeson as Aeson
+import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Domain (Domain (Domain))
 import qualified Data.Text as Text
@@ -30,7 +31,7 @@ import qualified Mu.Server as Mu
 import Test.Hspec
 import Test.QuickCheck (arbitrary, generate)
 import qualified Wire.API.Federation.API.Brig as Brig
-import Wire.API.Federation.Client (FederationClientError (FederationClientOutwardError, FederationClientRPCError))
+import Wire.API.Federation.Client (FederationClientError (FederationClientOutwardError, FederationClientRPCError), FederationClientFailure (..))
 import Wire.API.Federation.GRPC.Types (Component (Brig), FederatedRequest (FederatedRequest), Request (..))
 import Wire.API.Federation.Mock
 import Wire.API.User (UserProfile)
@@ -63,7 +64,8 @@ spec = do
           assertRightT . withMockFederatorClient stateRef (mkErrorResponse someErr) $
             Brig.getUserByHandle Brig.clientRoutes handle
 
-        actualResponse `shouldBe` Left (FederationClientOutwardError someErr)
+        first fedFailError actualResponse
+          `shouldBe` Left (FederationClientOutwardError someErr)
 
       it "should report federator failures correctly" $ do
         handle <- generate arbitrary
@@ -75,10 +77,10 @@ spec = do
         case actualResponse of
           Right res ->
             expectationFailure $ "Expected response to be failure, got: \n" <> show res
-          Left (FederationClientRPCError errText) ->
+          Left (FederationClientFailure _ _ (FederationClientRPCError errText)) ->
             Text.unpack errText `shouldStartWith` "grpc error: GRPC status indicates failure: status-code=INTERNAL, status-message=\"some IO error!"
           Left err ->
-            expectationFailure $ "Expected FedeartionClientRPCError, got different error: \n" <> show err
+            expectationFailure $ "Expected FederationClientRPCError, got different error: \n" <> show err
 
       it "should report GRPC errors correctly" $ do
         handle <- generate arbitrary
@@ -87,7 +89,8 @@ spec = do
           assertRightT . withMockFederatorClient stateRef (throwError $ Mu.ServerError Mu.NotFound "Just testing") $
             Brig.getUserByHandle Brig.clientRoutes handle
 
-        actualResponse `shouldBe` Left (FederationClientRPCError "grpc error: GRPC status indicates failure: status-code=NOT_FOUND, status-message=\"Just testing\"")
+        first fedFailError actualResponse
+          `shouldBe` Left (FederationClientRPCError "grpc error: GRPC status indicates failure: status-code=NOT_FOUND, status-message=\"Just testing\"")
 
 assertRight :: Either String b -> IO b
 assertRight = \case

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -219,121 +219,121 @@ updateProfileError (ProfileNotFound _) = StdError userNotFound
 -- WAI Errors -----------------------------------------------------------------
 
 tooManyProperties :: Wai.Error
-tooManyProperties = Wai.Error status403 "too-many-properties" "Too many properties"
+tooManyProperties = Wai.mkError status403 "too-many-properties" "Too many properties"
 
 propertyKeyTooLarge :: Wai.Error
-propertyKeyTooLarge = Wai.Error status403 "property-key-too-large" "The property key is too large."
+propertyKeyTooLarge = Wai.mkError status403 "property-key-too-large" "The property key is too large."
 
 propertyValueTooLarge :: Wai.Error
-propertyValueTooLarge = Wai.Error status403 "property-value-too-large" "The property value is too large"
+propertyValueTooLarge = Wai.mkError status403 "property-value-too-large" "The property value is too large"
 
 connectionLimitReached :: Wai.Error
-connectionLimitReached = Wai.Error status403 "connection-limit" "Too many sent/accepted connections."
+connectionLimitReached = Wai.mkError status403 "connection-limit" "Too many sent/accepted connections."
 
 missingAuthError :: Wai.Error
-missingAuthError = Wai.Error status403 "missing-auth" "Re-authentication via password required."
+missingAuthError = Wai.mkError status403 "missing-auth" "Re-authentication via password required."
 
 clientNotFound :: Wai.Error
-clientNotFound = Wai.Error status404 "client-not-found" "Client not found"
+clientNotFound = Wai.mkError status404 "client-not-found" "Client not found"
 
 tooManyClients :: Wai.Error
-tooManyClients = Wai.Error status403 "too-many-clients" "Too many clients"
+tooManyClients = Wai.mkError status403 "too-many-clients" "Too many clients"
 
 malformedPrekeys :: Wai.Error
-malformedPrekeys = Wai.Error status400 "bad-request" "Malformed prekeys uploaded."
+malformedPrekeys = Wai.mkError status400 "bad-request" "Malformed prekeys uploaded."
 
 clientCapabilitiesCannotBeRemoved :: Wai.Error
-clientCapabilitiesCannotBeRemoved = Wai.Error status409 "client-capabilities-cannot-be-removed" "You can only add capabilities to a client, not remove them."
+clientCapabilitiesCannotBeRemoved = Wai.mkError status409 "client-capabilities-cannot-be-removed" "You can only add capabilities to a client, not remove them."
 
 invalidUser :: Wai.Error
-invalidUser = Wai.Error status400 "invalid-user" "Invalid user."
+invalidUser = Wai.mkError status400 "invalid-user" "Invalid user."
 
 invalidTransition :: Wai.Error
-invalidTransition = Wai.Error status403 "bad-conn-update" "Invalid status transition."
+invalidTransition = Wai.mkError status403 "bad-conn-update" "Invalid status transition."
 
 notConnected :: Wai.Error
-notConnected = Wai.Error status403 "no-connection" "No connection exists between users."
+notConnected = Wai.mkError status403 "no-connection" "No connection exists between users."
 
 noIdentity :: Int -> Wai.Error
-noIdentity i = Wai.Error status403 "no-identity" ("The user has no verified identity (email or phone number). [code: " <> cs (show i) <> "]")
+noIdentity i = Wai.mkError status403 "no-identity" ("The user has no verified identity (email or phone number). [code: " <> cs (show i) <> "]")
 
 noEmail :: Wai.Error
-noEmail = Wai.Error status403 "no-email" "This operation requires the user to have a verified email address."
+noEmail = Wai.mkError status403 "no-email" "This operation requires the user to have a verified email address."
 
 lastIdentity :: Wai.Error
-lastIdentity = Wai.Error status403 "last-identity" "The last user identity (email or phone number) cannot be removed."
+lastIdentity = Wai.mkError status403 "last-identity" "The last user identity (email or phone number) cannot be removed."
 
 noPassword :: Wai.Error
-noPassword = Wai.Error status403 "no-password" "The user has no password."
+noPassword = Wai.mkError status403 "no-password" "The user has no password."
 
 invalidEmail :: Wai.Error
-invalidEmail = Wai.Error status400 "invalid-email" "Invalid e-mail address."
+invalidEmail = Wai.mkError status400 "invalid-email" "Invalid e-mail address."
 
 invalidPwResetKey :: Wai.Error
-invalidPwResetKey = Wai.Error status400 "invalid-key" "Invalid email or mobile number for password reset."
+invalidPwResetKey = Wai.mkError status400 "invalid-key" "Invalid email or mobile number for password reset."
 
 resetPasswordMustDiffer :: Wai.Error
-resetPasswordMustDiffer = Wai.Error status409 "password-must-differ" "For password reset, new and old password must be different."
+resetPasswordMustDiffer = Wai.mkError status409 "password-must-differ" "For password reset, new and old password must be different."
 
 changePasswordMustDiffer :: Wai.Error
-changePasswordMustDiffer = Wai.Error status409 "password-must-differ" "For password change, new and old password must be different."
+changePasswordMustDiffer = Wai.mkError status409 "password-must-differ" "For password change, new and old password must be different."
 
 invalidPhone :: Wai.Error
-invalidPhone = Wai.Error status400 "invalid-phone" "Invalid mobile phone number."
+invalidPhone = Wai.mkError status400 "invalid-phone" "Invalid mobile phone number."
 
 invalidInvitationCode :: Wai.Error
-invalidInvitationCode = Wai.Error status400 "invalid-invitation-code" "Invalid invitation code."
+invalidInvitationCode = Wai.mkError status400 "invalid-invitation-code" "Invalid invitation code."
 
 missingIdentity :: Wai.Error
-missingIdentity = Wai.Error status403 "missing-identity" "Using an invitation code requires registering the given email and/or phone."
+missingIdentity = Wai.mkError status403 "missing-identity" "Using an invitation code requires registering the given email and/or phone."
 
 invalidPwResetCode :: Wai.Error
-invalidPwResetCode = Wai.Error status400 "invalid-code" "Invalid password reset code."
+invalidPwResetCode = Wai.mkError status400 "invalid-code" "Invalid password reset code."
 
 duplicatePwResetCode :: Wai.Error
-duplicatePwResetCode = Wai.Error status409 "code-exists" "A password reset is already in progress."
+duplicatePwResetCode = Wai.mkError status409 "code-exists" "A password reset is already in progress."
 
 userKeyExists :: Wai.Error
-userKeyExists = Wai.Error status409 "key-exists" "The given e-mail address or phone number is in use."
+userKeyExists = Wai.mkError status409 "key-exists" "The given e-mail address or phone number is in use."
 
 emailExists :: Wai.Error
-emailExists = Wai.Error status409 "email-exists" "The given e-mail address is in use."
+emailExists = Wai.mkError status409 "email-exists" "The given e-mail address is in use."
 
 phoneExists :: Wai.Error
-phoneExists = Wai.Error status409 "phone-exists" "The given phone number is in use."
+phoneExists = Wai.mkError status409 "phone-exists" "The given phone number is in use."
 
 handleExists :: Wai.Error
-handleExists = Wai.Error status409 "handle-exists" "The given handle is already taken."
+handleExists = Wai.mkError status409 "handle-exists" "The given handle is already taken."
 
 invalidHandle :: Wai.Error
-invalidHandle = Wai.Error status400 "invalid-handle" "The given handle is invalid."
+invalidHandle = Wai.mkError status400 "invalid-handle" "The given handle is invalid."
 
 badRequest :: LText -> Wai.Error
-badRequest = Wai.Error status400 "bad-request"
+badRequest = Wai.mkError status400 "bad-request"
 
 loginCodePending :: Wai.Error
-loginCodePending = Wai.Error status403 "pending-login" "A login code is still pending."
+loginCodePending = Wai.mkError status403 "pending-login" "A login code is still pending."
 
 loginCodeNotFound :: Wai.Error
-loginCodeNotFound = Wai.Error status404 "no-pending-login" "No login code was found."
+loginCodeNotFound = Wai.mkError status404 "no-pending-login" "No login code was found."
 
 accountPending :: Wai.Error
-accountPending = Wai.Error status403 "pending-activation" "Account pending activation."
+accountPending = Wai.mkError status403 "pending-activation" "Account pending activation."
 
 accountSuspended :: Wai.Error
-accountSuspended = Wai.Error status403 "suspended" "Account suspended."
+accountSuspended = Wai.mkError status403 "suspended" "Account suspended."
 
 accountEphemeral :: Wai.Error
-accountEphemeral = Wai.Error status403 "ephemeral" "Account is ephemeral."
+accountEphemeral = Wai.mkError status403 "ephemeral" "Account is ephemeral."
 
 badCredentials :: Wai.Error
-badCredentials = Wai.Error status403 "invalid-credentials" "Authentication failed."
+badCredentials = Wai.mkError status403 "invalid-credentials" "Authentication failed."
 
 newPasswordMustDiffer :: Wai.Error
-newPasswordMustDiffer = Wai.Error status409 "password-must-differ" "For provider password change or reset, new and old password must be different."
+newPasswordMustDiffer = Wai.mkError status409 "password-must-differ" "For provider password change or reset, new and old password must be different."
 
 notFound :: LText -> Wai.Error
-notFound = Wai.Error status404 "not-found"
+notFound = Wai.mkError status404 "not-found"
 
 userNotFound :: Wai.Error
 userNotFound = notFound "User not found."
@@ -342,29 +342,29 @@ handleNotFound :: Wai.Error
 handleNotFound = notFound "Handle not found."
 
 invalidCode :: Wai.Error
-invalidCode = Wai.Error status403 "invalid-code" "Invalid verification code"
+invalidCode = Wai.mkError status403 "invalid-code" "Invalid verification code"
 
 invalidAccountStatus :: Wai.Error
-invalidAccountStatus = Wai.Error status400 "invalid-status" "The specified account status cannot be set."
+invalidAccountStatus = Wai.mkError status400 "invalid-status" "The specified account status cannot be set."
 
 activationKeyNotFound :: Wai.Error
 activationKeyNotFound = notFound "Activation key not found."
 
 invalidActivationCode :: LText -> Wai.Error
-invalidActivationCode = Wai.Error status404 "invalid-code"
+invalidActivationCode = Wai.mkError status404 "invalid-code"
 
 activationCodeNotFound :: Wai.Error
 activationCodeNotFound = invalidActivationCode "Activation key/code not found or invalid."
 
 deletionCodePending :: Wai.Error
-deletionCodePending = Wai.Error status403 "pending-delete" "A verification code for account deletion is still pending."
+deletionCodePending = Wai.mkError status403 "pending-delete" "A verification code for account deletion is still pending."
 
 whitelistError :: Wai.Error
-whitelistError = Wai.Error status403 "unauthorized" "Unauthorized e-mail address or phone number."
+whitelistError = Wai.mkError status403 "unauthorized" "Unauthorized e-mail address or phone number."
 
 blacklistedEmail :: Wai.Error
 blacklistedEmail =
-  Wai.Error
+  Wai.mkError
     status403
     "blacklisted-email"
     "The given e-mail address has been blacklisted due to a permanent bounce \
@@ -372,7 +372,7 @@ blacklistedEmail =
 
 blacklistedPhone :: Wai.Error
 blacklistedPhone =
-  Wai.Error
+  Wai.mkError
     status403
     "blacklisted-phone"
     "The given phone number has been blacklisted due to suspected abuse \
@@ -380,14 +380,14 @@ blacklistedPhone =
 
 passwordExists :: Wai.Error
 passwordExists =
-  Wai.Error
+  Wai.mkError
     status403
     "password-exists"
     "The operation is not permitted because the user has a password set."
 
 phoneBudgetExhausted :: Wai.Error
 phoneBudgetExhausted =
-  Wai.Error
+  Wai.mkError
     status403
     "phone-budget-exhausted"
     "The SMS or voice call budget for the given phone number has been \
@@ -396,34 +396,34 @@ phoneBudgetExhausted =
     \permanent blacklisting of the phone number."
 
 authMissingCookie :: Wai.Error
-authMissingCookie = Wai.Error status403 "invalid-credentials" "Missing cookie"
+authMissingCookie = Wai.mkError status403 "invalid-credentials" "Missing cookie"
 
 authMissingToken :: Wai.Error
-authMissingToken = Wai.Error status403 "invalid-credentials" "Missing token"
+authMissingToken = Wai.mkError status403 "invalid-credentials" "Missing token"
 
 authMissingCookieAndToken :: Wai.Error
-authMissingCookieAndToken = Wai.Error status403 "invalid-credentials" "Missing cookie and token"
+authMissingCookieAndToken = Wai.mkError status403 "invalid-credentials" "Missing cookie and token"
 
 invalidUserToken :: Wai.Error
-invalidUserToken = Wai.Error status403 "invalid-credentials" "Invalid user token"
+invalidUserToken = Wai.mkError status403 "invalid-credentials" "Invalid user token"
 
 invalidAccessToken :: Wai.Error
-invalidAccessToken = Wai.Error status403 "invalid-credentials" "Invalid access token"
+invalidAccessToken = Wai.mkError status403 "invalid-credentials" "Invalid access token"
 
 authTokenMismatch :: Wai.Error
-authTokenMismatch = Wai.Error status403 "invalid-credentials" "Token mismatch"
+authTokenMismatch = Wai.mkError status403 "invalid-credentials" "Token mismatch"
 
 authTokenExpired :: Wai.Error
-authTokenExpired = Wai.Error status403 "invalid-credentials" "Token expired"
+authTokenExpired = Wai.mkError status403 "invalid-credentials" "Token expired"
 
 authTokenInvalid :: Wai.Error
-authTokenInvalid = Wai.Error status403 "invalid-credentials" "Invalid token"
+authTokenInvalid = Wai.mkError status403 "invalid-credentials" "Invalid token"
 
 authTokenUnsupported :: Wai.Error
-authTokenUnsupported = Wai.Error status403 "invalid-credentials" "Unsupported token operation for this token type"
+authTokenUnsupported = Wai.mkError status403 "invalid-credentials" "Unsupported token operation for this token type"
 
 incorrectPermissions :: Wai.Error
-incorrectPermissions = Wai.Error status403 "invalid-permissions" "Copy permissions must be a subset of self permissions"
+incorrectPermissions = Wai.mkError status403 "invalid-permissions" "Copy permissions must be a subset of self permissions"
 
 -- | User's relation to the team is not what we expect it to be. Examples:
 --
@@ -434,75 +434,75 @@ incorrectPermissions = Wai.Error status403 "invalid-permissions" "Copy permissio
 --
 -- * Requested action can't be performed if the user is the only team owner left in the team.
 insufficientTeamPermissions :: Wai.Error
-insufficientTeamPermissions = Wai.Error status403 "insufficient-permissions" "Insufficient team permissions"
+insufficientTeamPermissions = Wai.mkError status403 "insufficient-permissions" "Insufficient team permissions"
 
 noBindingTeam :: Wai.Error
-noBindingTeam = Wai.Error status403 "no-binding-team" "Operation allowed only on binding teams"
+noBindingTeam = Wai.mkError status403 "no-binding-team" "Operation allowed only on binding teams"
 
 propertyManagedByScim :: LText -> Wai.Error
-propertyManagedByScim prop = Wai.Error status403 "managed-by-scim" $ "Updating \"" <> prop <> "\" is not allowed, because it is managed by SCIM"
+propertyManagedByScim prop = Wai.mkError status403 "managed-by-scim" $ "Updating \"" <> prop <> "\" is not allowed, because it is managed by SCIM"
 
 sameBindingTeamUsers :: Wai.Error
-sameBindingTeamUsers = Wai.Error status403 "same-binding-team-users" "Operation not allowed to binding team users."
+sameBindingTeamUsers = Wai.mkError status403 "same-binding-team-users" "Operation not allowed to binding team users."
 
 missingLegalholdConsent :: Wai.Error
-missingLegalholdConsent = Wai.Error status412 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
+missingLegalholdConsent = Wai.mkError status412 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
 
 ownerDeletingSelf :: Wai.Error
 ownerDeletingSelf =
-  Wai.Error
+  Wai.mkError
     status403
     "no-self-delete-for-team-owner"
     "Team owners are not allowed to delete themselves.  Ask a fellow owner."
 
 tooManyTeamInvitations :: Wai.Error
-tooManyTeamInvitations = Wai.Error status403 "too-many-team-invitations" "Too many team invitations for this team."
+tooManyTeamInvitations = Wai.mkError status403 "too-many-team-invitations" "Too many team invitations for this team."
 
 tooManyTeamMembers :: Wai.Error
-tooManyTeamMembers = Wai.Error status403 "too-many-team-members" "Too many members in this team."
+tooManyTeamMembers = Wai.mkError status403 "too-many-team-members" "Too many members in this team."
 
 -- | docs/reference/user/registration.md {#RefRestrictRegistration}.
 userCreationRestricted :: Wai.Error
-userCreationRestricted = Wai.Error status403 "user-creation-restricted" "This instance does not allow creation of personal users or teams."
+userCreationRestricted = Wai.mkError status403 "user-creation-restricted" "This instance does not allow creation of personal users or teams."
 
 -- | In contrast to 'tooManyFailedLogins', this is about too many *successful* logins.
 loginsTooFrequent :: Wai.Error
-loginsTooFrequent = Wai.Error status429 "client-error" "Logins too frequent"
+loginsTooFrequent = Wai.mkError status429 "client-error" "Logins too frequent"
 
 tooManyFailedLogins :: Wai.Error
-tooManyFailedLogins = Wai.Error status403 "client-error" "Too many failed logins"
+tooManyFailedLogins = Wai.mkError status403 "client-error" "Too many failed logins"
 
 tooLargeRichInfo :: Wai.Error
-tooLargeRichInfo = Wai.Error status413 "too-large-rich-info" "Rich info has exceeded the limit"
+tooLargeRichInfo = Wai.mkError status413 "too-large-rich-info" "Rich info has exceeded the limit"
 
 internalServerError :: Wai.Error
-internalServerError = Wai.Error status500 "internal-server-error" "Internal Server Error"
+internalServerError = Wai.mkError status500 "internal-server-error" "Internal Server Error"
 
 invalidRange :: LText -> Wai.Error
-invalidRange = Wai.Error status400 "client-error"
+invalidRange = Wai.mkError status400 "client-error"
 
 --- Legalhold
 can'tDeleteLegalHoldClient :: Wai.Error
 can'tDeleteLegalHoldClient =
-  Wai.Error
+  Wai.mkError
     status400
     "client-error"
     "LegalHold clients cannot be deleted. LegalHold must be disabled on this user by an admin"
 
 can'tAddLegalHoldClient :: Wai.Error
 can'tAddLegalHoldClient =
-  Wai.Error
+  Wai.mkError
     status400
     "client-error"
     "LegalHold clients cannot be added manually. LegalHold must be enabled on this user by an admin"
 
 legalHoldNotEnabled :: Wai.Error
-legalHoldNotEnabled = Wai.Error status403 "legalhold-not-enabled" "LegalHold must be enabled and configured on the team first"
+legalHoldNotEnabled = Wai.mkError status403 "legalhold-not-enabled" "LegalHold must be enabled and configured on the team first"
 
 -- (the tautological constraint in the type signature is added so that once we remove the
 -- feature, ghc will guide us here.)
 customerExtensionBlockedDomain :: (DomainsBlockedForRegistration ~ DomainsBlockedForRegistration) => Domain -> Wai.Error
-customerExtensionBlockedDomain domain = Wai.Error (mkStatus 451 "Unavailable For Legal Reasons") "domain-blocked-for-registration" msg
+customerExtensionBlockedDomain domain = Wai.mkError (mkStatus 451 "Unavailable For Legal Reasons") "domain-blocked-for-registration" msg
   where
     msg =
       "[Customer extension] the email domain " <> cs (show domain)

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -1091,31 +1091,31 @@ rangeChecked :: Within a n m => a -> Handler (Range n m a)
 rangeChecked = either (throwStd . invalidRange . fromString) return . checkedEither
 
 invalidServiceKey :: Wai.Error
-invalidServiceKey = Wai.Error status400 "invalid-service-key" "Invalid service key."
+invalidServiceKey = Wai.mkError status400 "invalid-service-key" "Invalid service key."
 
 invalidProvider :: Wai.Error
-invalidProvider = Wai.Error status403 "invalid-provider" "The provider does not exist."
+invalidProvider = Wai.mkError status403 "invalid-provider" "The provider does not exist."
 
 invalidBot :: Wai.Error
-invalidBot = Wai.Error status403 "invalid-bot" "The targeted user is not a bot."
+invalidBot = Wai.mkError status403 "invalid-bot" "The targeted user is not a bot."
 
 invalidConv :: Wai.Error
-invalidConv = Wai.Error status403 "invalid-conversation" "The operation is not allowed in this conversation."
+invalidConv = Wai.mkError status403 "invalid-conversation" "The operation is not allowed in this conversation."
 
 badGateway :: Wai.Error
-badGateway = Wai.Error status502 "bad-gateway" "The upstream service returned an invalid response."
+badGateway = Wai.mkError status502 "bad-gateway" "The upstream service returned an invalid response."
 
 tooManyMembers :: Wai.Error
-tooManyMembers = Wai.Error status403 "too-many-members" "Maximum number of members per conversation reached."
+tooManyMembers = Wai.mkError status403 "too-many-members" "Maximum number of members per conversation reached."
 
 tooManyBots :: Wai.Error
-tooManyBots = Wai.Error status409 "too-many-bots" "Maximum number of bots for the service reached."
+tooManyBots = Wai.mkError status409 "too-many-bots" "Maximum number of bots for the service reached."
 
 serviceDisabled :: Wai.Error
-serviceDisabled = Wai.Error status403 "service-disabled" "The desired service is currently disabled."
+serviceDisabled = Wai.mkError status403 "service-disabled" "The desired service is currently disabled."
 
 serviceNotWhitelisted :: Wai.Error
-serviceNotWhitelisted = Wai.Error status403 "service-not-whitelisted" "The desired service is not on the whitelist of allowed services for this team."
+serviceNotWhitelisted = Wai.mkError status403 "service-not-whitelisted" "The desired service is not on the whitelist of allowed services for this team."
 
 serviceError :: RPC.ServiceError -> Wai.Error
 serviceError RPC.ServiceUnavailable = badGateway

--- a/services/brig/test/unit/Test/Brig/API/Error.hs
+++ b/services/brig/test/unit/Test/Brig/API/Error.hs
@@ -1,6 +1,7 @@
 module Test.Brig.API.Error where
 
 import Brig.API.Error
+import Data.Domain
 import Imports
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai.Utilities as Wai
@@ -25,24 +26,24 @@ testFedError =
       testCase "when federation is not configured" $
         assertFedErrorStatus FederationNotConfigured 400,
       testCase "when federation call fails due to RPC error" $
-        assertFedErrorStatus (FederationCallFailure (FederationClientRPCError "some failure")) 500,
+        assertFedErrorStatus (mkFailure (FederationClientRPCError "some failure")) 500,
       testCase "when federation call fails due wrong method" $
-        assertFedErrorStatus (FederationCallFailure (FederationClientInvalidMethod "GET")) 500,
+        assertFedErrorStatus (mkFailure (FederationClientInvalidMethod "GET")) 500,
       testCase "when federation call fails due to requesting streaming" $
-        assertFedErrorStatus (FederationCallFailure FederationClientStreamingUnsupported) 500,
+        assertFedErrorStatus (mkFailure FederationClientStreamingUnsupported) 500,
       testCase "when federation call fails due to discovery failure" $ do
         let outwardErr = FederationClientOutwardError (Proto.OutwardError Proto.DiscoveryFailed Nothing)
-        assertFedErrorStatus (FederationCallFailure outwardErr) 500,
+        assertFedErrorStatus (mkFailure outwardErr) 500,
       testCase "when federation call fails due to decode failure" $
-        assertFedErrorStatus (FederationCallFailure (FederationClientServantError (Servant.DecodeFailure "some failure" emptyRes))) 533,
+        assertFedErrorStatus (mkFailure (FederationClientServantError (Servant.DecodeFailure "some failure" emptyRes))) 533,
       testCase "when federation call fails due to Servant.FailureResponse" $
-        assertFedErrorStatus (FederationCallFailure (FederationClientServantError (Servant.FailureResponse emptyReq emptyRes))) 533,
+        assertFedErrorStatus (mkFailure (FederationClientServantError (Servant.FailureResponse emptyReq emptyRes))) 533,
       testCase "when federation call fails due to invalid content type" $
-        assertFedErrorStatus (FederationCallFailure (FederationClientServantError (Servant.InvalidContentTypeHeader emptyRes))) 533,
+        assertFedErrorStatus (mkFailure (FederationClientServantError (Servant.InvalidContentTypeHeader emptyRes))) 533,
       testCase "when federation call fails due to unsupported content type" $
-        assertFedErrorStatus (FederationCallFailure (FederationClientServantError (Servant.UnsupportedContentType "application/xml" emptyRes))) 533,
+        assertFedErrorStatus (mkFailure (FederationClientServantError (Servant.UnsupportedContentType "application/xml" emptyRes))) 533,
       testCase "when federation call fails due to connection error" $
-        assertFedErrorStatus (FederationCallFailure (FederationClientServantError (Servant.ConnectionError (SomeException TestException)))) 500
+        assertFedErrorStatus (mkFailure (FederationClientServantError (Servant.ConnectionError (SomeException TestException)))) 500
     ]
 
 testOutwardError :: TestTree
@@ -83,6 +84,11 @@ testOutwardError =
             assertEqual "message should be set as unknown" (Wai.message waiErr) "Unknown federation error"
         ]
     ]
+
+mkFailure :: FederationClientError -> FederationError
+mkFailure =
+  FederationCallFailure
+    . FederationClientFailure (Domain "far-away.example.com") "/federation/test"
 
 assertFedErrorStatus :: HasCallStack => FederationError -> Int -> IO ()
 assertFedErrorStatus err sts = assertEqual ("http status should be " <> show sts) (statusFor err) sts

--- a/services/cannon/src/Cannon/App.hs
+++ b/services/cannon/src/Cannon/App.hs
@@ -153,7 +153,7 @@ readLoop ws s = loop
 
 rejectOnError :: PendingConnection -> HandshakeException -> IO a
 rejectOnError p x = do
-  let f lb mg = toStrict . encode $ Error status400 lb mg
+  let f lb mg = toStrict . encode $ mkError status400 lb mg
   case x of
     NotSupported -> rejectRequest p (f "protocol not supported" "N/A")
     MalformedRequest _ m -> rejectRequest p (f "malformed-request" (Text.pack m))

--- a/services/cannon/src/Cannon/WS.hs
+++ b/services/cannon/src/Cannon/WS.hs
@@ -221,7 +221,7 @@ isRemoteRegistered u c = do
     recovering retry3x rpcHandlers $
       const $
         rpc' "gundeck" (upstream e) (method GET . paths ["/i/presences", toByteString' u] . expect2xx)
-  cs <- map connId <$> parseResponse (Error status502 "server-error") rs
+  cs <- map connId <$> parseResponse (mkError status502 "server-error") rs
   return $ c `elem` cs
 
 sendMsg :: L.ByteString -> Key -> Websocket -> WS ()

--- a/services/cargohold/src/CargoHold/API/Error.hs
+++ b/services/cargohold/src/CargoHold/API/Error.hs
@@ -25,23 +25,23 @@ import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
 
 assetTooLarge :: Error
-assetTooLarge = Error status413 "client-error" "Asset too large."
+assetTooLarge = mkError status413 "client-error" "Asset too large."
 
 unauthorised :: Error
-unauthorised = Error status403 "unauthorised" "Unauthorised operation."
+unauthorised = mkError status403 "unauthorised" "Unauthorised operation."
 
 invalidLength :: Error
-invalidLength = Error status400 "invalid-length" "Invalid content length."
+invalidLength = mkError status400 "invalid-length" "Invalid content length."
 
 assetNotFound :: Error
-assetNotFound = Error status404 "not-found" "Asset not found."
+assetNotFound = mkError status404 "not-found" "Asset not found."
 
 invalidMD5 :: Error
-invalidMD5 = Error status400 "client-error" "Invalid MD5."
+invalidMD5 = mkError status400 "client-error" "Invalid MD5."
 
 requestTimeout :: Error
 requestTimeout =
-  Error
+  mkError
     status408
     "request-timeout"
     "The request timed out. The server was still expecting more data \
@@ -50,7 +50,7 @@ requestTimeout =
 
 invalidOffset :: Offset -> Offset -> Error
 invalidOffset expected given =
-  Error status409 "invalid-offset" $
+  mkError status409 "invalid-offset" $
     toLazyText $
       "Invalid offset: "
         <> "expected: "
@@ -62,7 +62,7 @@ invalidOffset expected given =
 
 uploadTooSmall :: Error
 uploadTooSmall =
-  Error
+  mkError
     status403
     "client-error"
     "The current chunk size is \
@@ -70,7 +70,7 @@ uploadTooSmall =
 
 uploadTooLarge :: Error
 uploadTooLarge =
-  Error
+  mkError
     status413
     "client-error"
     "The current chunk size + offset \
@@ -78,7 +78,7 @@ uploadTooLarge =
 
 uploadIncomplete :: TotalSize -> TotalSize -> Error
 uploadIncomplete expected actual =
-  Error status403 "client-error" $
+  mkError status403 "client-error" $
     toLazyText $
       "The upload is incomplete: "
         <> "expected size: "
@@ -89,7 +89,7 @@ uploadIncomplete expected actual =
         <> "."
 
 clientError :: LText -> Error
-clientError = Error status400 "client-error"
+clientError = mkError status400 "client-error"
 
 serverError :: Error
-serverError = Error status500 "server-error" "Server Error."
+serverError = mkError status500 "server-error" "Server Error."

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -35,13 +35,13 @@ internalError :: Error
 internalError = internalErrorWithDescription "internal error"
 
 internalErrorWithDescription :: LText -> Error
-internalErrorWithDescription = Error status500 "internal-error"
+internalErrorWithDescription = mkError status500 "internal-error"
 
 convNotFound :: Error
-convNotFound = Error status404 "no-conversation" "conversation not found"
+convNotFound = mkError status404 "no-conversation" "conversation not found"
 
 convMemberNotFound :: Error
-convMemberNotFound = Error status404 "no-conversation-member" "conversation member not found"
+convMemberNotFound = mkError status404 "no-conversation-member" "conversation member not found"
 
 invalidSelfOp :: Error
 invalidSelfOp = invalidOp "invalid operation for self conversation"
@@ -65,174 +65,174 @@ invalidTargetUserOp :: Error
 invalidTargetUserOp = invalidOp "invalid target user for the given operation"
 
 invalidOp :: LText -> Error
-invalidOp = Error status403 "invalid-op"
+invalidOp = mkError status403 "invalid-op"
 
 invalidPayload :: LText -> Error
-invalidPayload = Error status400 "invalid-payload"
+invalidPayload = mkError status400 "invalid-payload"
 
 badRequest :: LText -> Error
-badRequest = Error status400 "bad-request"
+badRequest = mkError status400 "bad-request"
 
 notConnected :: Error
-notConnected = Error status403 "not-connected" "Users are not connected"
+notConnected = mkError status403 "not-connected" "Users are not connected"
 
 unknownRemoteUser :: Error
-unknownRemoteUser = Error status400 "unknown-remote-user" "Remote user(s) not found"
+unknownRemoteUser = mkError status400 "unknown-remote-user" "Remote user(s) not found"
 
 tooManyMembers :: Error
-tooManyMembers = Error status403 "too-many-members" "Maximum number of members per conversation reached"
+tooManyMembers = mkError status403 "too-many-members" "Maximum number of members per conversation reached"
 
 convAccessDenied :: Error
-convAccessDenied = Error status403 "access-denied" "Conversation access denied"
+convAccessDenied = mkError status403 "access-denied" "Conversation access denied"
 
 accessDenied :: Error
-accessDenied = Error status403 "access-denied" "You do not have permission to access this resource"
+accessDenied = mkError status403 "access-denied" "You do not have permission to access this resource"
 
 reAuthFailed :: Error
-reAuthFailed = Error status403 "access-denied" "This operation requires reauthentication"
+reAuthFailed = mkError status403 "access-denied" "This operation requires reauthentication"
 
 invalidUUID4 :: Error
-invalidUUID4 = Error status400 "client-error" "Invalid UUID v4 format"
+invalidUUID4 = mkError status400 "client-error" "Invalid UUID v4 format"
 
 unknownClient :: Error
-unknownClient = Error status403 "unknown-client" "Sending client not known"
+unknownClient = mkError status403 "unknown-client" "Sending client not known"
 
 invalidRange :: LText -> Error
-invalidRange = Error status400 "client-error"
+invalidRange = mkError status400 "client-error"
 
 operationDenied :: (IsPerm perm, Show perm) => perm -> Error
 operationDenied p =
-  Error
+  mkError
     status403
     "operation-denied"
     ("Insufficient permissions (missing " <> (pack $ show p) <> ")")
 
 actionDenied :: Action -> Error
 actionDenied a =
-  Error
+  mkError
     status403
     "action-denied"
     ("Insufficient authorization (missing " <> (pack $ show a) <> ")")
 
 noBindingTeam :: Error
-noBindingTeam = Error status403 "no-binding-team" "Operation allowed only on binding teams."
+noBindingTeam = mkError status403 "no-binding-team" "Operation allowed only on binding teams."
 
 notAOneMemberTeam :: Error
-notAOneMemberTeam = Error status403 "not-one-member-team" "Can only delete teams with a single member."
+notAOneMemberTeam = mkError status403 "not-one-member-team" "Can only delete teams with a single member."
 
 notATeamMember :: Error
-notATeamMember = Error status403 "no-team-member" "Requesting user is not a team member."
+notATeamMember = mkError status403 "no-team-member" "Requesting user is not a team member."
 
 bulkGetMemberLimitExceeded :: Error
 bulkGetMemberLimitExceeded =
-  Error
+  mkError
     status400
     "too-many-uids"
     ("Can only process " <> cs (show @Int hardTruncationLimit) <> " user ids per request.")
 
 broadcastLimitExceeded :: Error
 broadcastLimitExceeded =
-  Error
+  mkError
     status400
     "too-many-users-to-broadcast"
     ("Too many users to fan out the broadcast event to.")
 
 noAddToManaged :: Error
-noAddToManaged = Error status403 "no-add-to-managed" "Adding users/bots directly to managed conversation is not allowed."
+noAddToManaged = mkError status403 "no-add-to-managed" "Adding users/bots directly to managed conversation is not allowed."
 
 teamNotFound :: Error
-teamNotFound = Error status404 "no-team" "team not found"
+teamNotFound = mkError status404 "no-team" "team not found"
 
 invalidPermissions :: Error
-invalidPermissions = Error status403 "invalid-permissions" "The specified permissions are invalid."
+invalidPermissions = mkError status403 "invalid-permissions" "The specified permissions are invalid."
 
 invalidActions :: Error
-invalidActions = Error status403 "invalid-actions" "The specified actions are invalid."
+invalidActions = mkError status403 "invalid-actions" "The specified actions are invalid."
 
 tooManyTeamMembers :: Error
-tooManyTeamMembers = Error status403 "too-many-team-members" "Maximum number of members per team reached"
+tooManyTeamMembers = mkError status403 "too-many-team-members" "Maximum number of members per team reached"
 
 tooManyTeamMembersOnTeamWithLegalhold :: Error
-tooManyTeamMembersOnTeamWithLegalhold = Error status403 "too-many-members-for-legalhold" "cannot add more members to team when legalhold service is enabled."
+tooManyTeamMembersOnTeamWithLegalhold = mkError status403 "too-many-members-for-legalhold" "cannot add more members to team when legalhold service is enabled."
 
 teamMemberNotFound :: Error
-teamMemberNotFound = Error status404 "no-team-member" "team member not found"
+teamMemberNotFound = mkError status404 "no-team-member" "team member not found"
 
 noManagedTeamConv :: Error
-noManagedTeamConv = Error status400 "no-managed-team-conv" "Managed team conversations have been deprecated."
+noManagedTeamConv = mkError status400 "no-managed-team-conv" "Managed team conversations have been deprecated."
 
 userBindingExists :: Error
-userBindingExists = Error status403 "binding-exists" "User already bound to a different team."
+userBindingExists = mkError status403 "binding-exists" "User already bound to a different team."
 
 noAddToBinding :: Error
-noAddToBinding = Error status403 "binding-team" "Cannot add users to binding teams, invite only."
+noAddToBinding = mkError status403 "binding-team" "Cannot add users to binding teams, invite only."
 
 deleteQueueFull :: Error
-deleteQueueFull = Error status503 "queue-full" "The delete queue is full. No further delete requests can be processed at the moment."
+deleteQueueFull = mkError status503 "queue-full" "The delete queue is full. No further delete requests can be processed at the moment."
 
 nonBindingTeam :: Error
-nonBindingTeam = Error status404 "non-binding-team" "not member of a binding team"
+nonBindingTeam = mkError status404 "non-binding-team" "not member of a binding team"
 
 noBindingTeamMembers :: Error
-noBindingTeamMembers = Error status403 "non-binding-team-members" "Both users must be members of the same binding team."
+noBindingTeamMembers = mkError status403 "non-binding-team-members" "Both users must be members of the same binding team."
 
 invalidTeamStatusUpdate :: Error
-invalidTeamStatusUpdate = Error status403 "invalid-team-status-update" "Cannot use this endpoint to update the team to the given status."
+invalidTeamStatusUpdate = mkError status403 "invalid-team-status-update" "Cannot use this endpoint to update the team to the given status."
 
 codeNotFound :: Error
-codeNotFound = Error status404 "no-conversation-code" "conversation code not found"
+codeNotFound = mkError status404 "no-conversation-code" "conversation code not found"
 
 cannotEnableLegalHoldServiceLargeTeam :: Error
-cannotEnableLegalHoldServiceLargeTeam = Error status403 "too-large-team-for-legalhold" "cannot enable legalhold on large teams.  (reason: for removing LH from team, we need to iterate over all members, which is only supported for teams with less than 2k members.)"
+cannotEnableLegalHoldServiceLargeTeam = mkError status403 "too-large-team-for-legalhold" "cannot enable legalhold on large teams.  (reason: for removing LH from team, we need to iterate over all members, which is only supported for teams with less than 2k members.)"
 
 legalHoldServiceInvalidKey :: Error
-legalHoldServiceInvalidKey = Error status400 "legalhold-invalid-key" "legal hold service pubkey is invalid"
+legalHoldServiceInvalidKey = mkError status400 "legalhold-invalid-key" "legal hold service pubkey is invalid"
 
 legalHoldServiceUnavailable :: Error
-legalHoldServiceUnavailable = Error status412 "legalhold-unavailable" "legal hold service does not respond or tls handshake could not be completed (did you pin the wrong public key?)"
+legalHoldServiceUnavailable = mkError status412 "legalhold-unavailable" "legal hold service does not respond or tls handshake could not be completed (did you pin the wrong public key?)"
 
 legalHoldServiceNotRegistered :: Error
-legalHoldServiceNotRegistered = Error status400 "legalhold-not-registered" "legal hold service has not been registered for this team"
+legalHoldServiceNotRegistered = mkError status400 "legalhold-not-registered" "legal hold service has not been registered for this team"
 
 legalHoldServiceBadResponse :: Error
-legalHoldServiceBadResponse = Error status400 "legalhold-status-bad" "legal hold service: invalid response"
+legalHoldServiceBadResponse = mkError status400 "legalhold-status-bad" "legal hold service: invalid response"
 
 legalHoldWhitelistedOnly :: Error
-legalHoldWhitelistedOnly = Error status403 "legalhold-whitelisted-only" "legal hold is enabled for teams via server config and cannot be changed here"
+legalHoldWhitelistedOnly = mkError status403 "legalhold-whitelisted-only" "legal hold is enabled for teams via server config and cannot be changed here"
 
 legalHoldFeatureFlagNotEnabled :: Error
-legalHoldFeatureFlagNotEnabled = Error status403 "legalhold-not-enabled" "legal hold is not enabled for this wire instance"
+legalHoldFeatureFlagNotEnabled = mkError status403 "legalhold-not-enabled" "legal hold is not enabled for this wire instance"
 
 legalHoldNotEnabled :: Error
-legalHoldNotEnabled = Error status403 "legalhold-not-enabled" "legal hold is not enabled for this team"
+legalHoldNotEnabled = mkError status403 "legalhold-not-enabled" "legal hold is not enabled for this team"
 
 legalHoldDisableUnimplemented :: Error
-legalHoldDisableUnimplemented = Error status403 "legalhold-disable-unimplemented" "legal hold cannot be disabled for whitelisted teams"
+legalHoldDisableUnimplemented = mkError status403 "legalhold-disable-unimplemented" "legal hold cannot be disabled for whitelisted teams"
 
 userLegalHoldAlreadyEnabled :: Error
-userLegalHoldAlreadyEnabled = Error status409 "legalhold-already-enabled" "legal hold is already enabled for this user"
+userLegalHoldAlreadyEnabled = mkError status409 "legalhold-already-enabled" "legal hold is already enabled for this user"
 
 userLegalHoldNoConsent :: Error
-userLegalHoldNoConsent = Error status409 "legalhold-no-consent" "user has not given consent to using legal hold"
+userLegalHoldNoConsent = mkError status409 "legalhold-no-consent" "user has not given consent to using legal hold"
 
 userLegalHoldIllegalOperation :: Error
-userLegalHoldIllegalOperation = Error status500 "legalhold-illegal-op" "internal server error: inconsistent change of user's legalhold state"
+userLegalHoldIllegalOperation = mkError status500 "legalhold-illegal-op" "internal server error: inconsistent change of user's legalhold state"
 
 userLegalHoldNotPending :: Error
-userLegalHoldNotPending = Error status412 "legalhold-not-pending" "legal hold cannot be approved without being in a pending state"
+userLegalHoldNotPending = mkError status412 "legalhold-not-pending" "legal hold cannot be approved without being in a pending state"
 
 noLegalHoldDeviceAllocated :: Error
-noLegalHoldDeviceAllocated = Error status404 "legalhold-no-device-allocated" "no legal hold device is registered for this user. POST /teams/:tid/legalhold/:uid/ to start the flow."
+noLegalHoldDeviceAllocated = mkError status404 "legalhold-no-device-allocated" "no legal hold device is registered for this user. POST /teams/:tid/legalhold/:uid/ to start the flow."
 
 legalHoldCouldNotBlockConnections :: Error
-legalHoldCouldNotBlockConnections = Error status500 "legalhold-internal" "legal hold service: could not block connections when resolving policy conflicts."
+legalHoldCouldNotBlockConnections = mkError status500 "legalhold-internal" "legal hold service: could not block connections when resolving policy conflicts."
 
 missingLegalholdConsent :: Error
-missingLegalholdConsent = Error status412 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
+missingLegalholdConsent = mkError status412 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
 
 disableSsoNotImplemented :: Error
 disableSsoNotImplemented =
-  Error
+  mkError
     status403
     "not-implemented"
     "The SSO feature flag is disabled by default.  It can only be enabled once for any team, never disabled.\n\
@@ -247,27 +247,27 @@ disableSsoNotImplemented =
     \open an issue on https://github.com/wireapp/wire-server."
 
 teamSearchVisibilityNotEnabled :: Error
-teamSearchVisibilityNotEnabled = Error status403 "team-search-visibility-not-enabled" "custom search is not available for this team"
+teamSearchVisibilityNotEnabled = mkError status403 "team-search-visibility-not-enabled" "custom search is not available for this team"
 
 customBackendNotFound :: Domain -> Error
 customBackendNotFound domain =
-  Error
+  mkError
     status404
     "custom-backend-not-found"
     ("custom backend not found for domain: " <> cs (domainText domain))
 
 invalidTeamNotificationId :: Error
-invalidTeamNotificationId = Error status400 "invalid-notification-id" "Could not parse notification id (must be UUIDv1)."
+invalidTeamNotificationId = mkError status400 "invalid-notification-id" "Could not parse notification id (must be UUIDv1)."
 
 inactivityTimeoutTooLow :: Error
-inactivityTimeoutTooLow = Error status400 "inactivity-timeout-too-low" "applock inactivity timeout must be at least 30 seconds"
+inactivityTimeoutTooLow = mkError status400 "inactivity-timeout-too-low" "applock inactivity timeout must be at least 30 seconds"
 
 --------------------------------------------------------------------------------
 -- Federation
 
 federationNotEnabled :: forall a. Typeable a => NonEmpty (Qualified (Id a)) -> Error
 federationNotEnabled qualifiedIds =
-  Error
+  mkError
     status403
     "federation-not-enabled"
     ("Federation is not enabled, but remote qualified IDs (" <> idType <> ") were found: " <> rendered)

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -51,7 +51,7 @@ conversationView uid conv = do
           +++ val " is not a member of conv "
           +++ idToText (convId conv)
       throwM badState
-    badState = Error status500 "bad-state" "Bad internal member state."
+    badState = mkError status500 "bad-state" "Bad internal member state."
 
 -- | View for a given user of a stored conversation.
 -- Returns 'Nothing' when the user is not part of the conversation.

--- a/services/galley/src/Galley/API/Teams/Notifications.hs
+++ b/services/galley/src/Galley/API/Teams/Notifications.hs
@@ -88,4 +88,4 @@ mkNotificationId = do
   where
     x10 = limitRetries 10 <> exponentialBackoff 10
     fun = const (return . isNothing)
-    err = Error status500 "internal-error" "unable to generate notification ID"
+    err = mkError status500 "internal-error" "unable to generate notification ID"

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -197,7 +197,7 @@ acceptOne2One usr conv conn = case Data.convType conv of
       Data.acceptConnect cid
       return $ conv {Data.convType = One2OneConv}
     badConvState =
-      Error status500 "bad-state" $
+      mkError status500 "bad-state" $
         "Connect conversation with more than 2 members: "
           <> LT.pack (show cid)
 

--- a/services/galley/src/Galley/Intra/Client.hs
+++ b/services/galley/src/Galley/Intra/Client.hs
@@ -58,7 +58,7 @@ lookupClients uids = do
         . path "/i/clients"
         . json (UserSet $ Set.fromList uids)
         . expect2xx
-  clients <- parseResponse (Error status502 "server-error") r
+  clients <- parseResponse (mkError status502 "server-error") r
   return $ filterClients (not . Set.null) clients
 
 -- | Calls 'Brig.API.internalListClientsFullH'.
@@ -71,7 +71,7 @@ lookupClientsFull uids = do
         . path "/i/clients/full"
         . json (UserSet $ Set.fromList uids)
         . expect2xx
-  clients <- parseResponse (Error status502 "server-error") r
+  clients <- parseResponse (mkError status502 "server-error") r
   return $ filterClientsFull (not . Set.null) clients
 
 -- | Calls 'Brig.API.legalHoldClientRequestedH'.
@@ -148,4 +148,4 @@ brigAddClient uid connId client = do
         . contentJson
         . json client
         . expect2xx
-  parseResponse (Error status502 "server-error") r
+  parseResponse (mkError status502 "server-error") r

--- a/services/galley/src/Galley/Intra/Team.hs
+++ b/services/galley/src/Galley/Intra/Team.hs
@@ -37,4 +37,4 @@ getSize tid = do
       method GET . host h . port p
         . paths ["/i/teams", toByteString' tid, "size"]
         . expect2xx
-  parseResponse (Error status502 "server-error") r
+  parseResponse (mkError status502 "server-error") r

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -66,7 +66,7 @@ getConnections uFrom uTo rlt = do
         . maybe id rfilter rlt
         . json ConnectionsStatusRequest {csrFrom = uFrom, csrTo = uTo}
         . expect2xx
-  parseResponse (Error status502 "server-error") r
+  parseResponse (mkError status502 "server-error") r
   where
     rfilter = queryItem "filter" . (pack . map toLower . show)
 
@@ -124,7 +124,7 @@ lookupActivatedUsers = chunkify $ \uids -> do
         . path "/i/users"
         . queryItem "ids" users
         . expect2xx
-  parseResponse (Error status502 "server-error") r
+  parseResponse (mkError status502 "server-error") r
 
 -- | URLs with more than ~160 uids produce 400 responses, because HAProxy has a
 --   URL length limit of ~6500 (determined experimentally). 100 is a
@@ -175,7 +175,7 @@ getContactList uid = do
       method GET . host h . port p
         . paths ["/i/users", toByteString' uid, "contacts"]
         . expect2xx
-  cUsers <$> parseResponse (Error status502 "server-error") r
+  cUsers <$> parseResponse (mkError status502 "server-error") r
 
 -- | Calls 'Brig.API.Internal.getRichInfoMultiH'
 getRichInfoMultiUser :: [UserId] -> Galley [(UserId, RichInfo)]
@@ -187,4 +187,4 @@ getRichInfoMultiUser = chunkify $ \uids -> do
         . paths ["/i/users/rich-info"]
         . queryItem "ids" (toByteString' (List uids))
         . expect2xx
-  parseResponse (Error status502 "server-error") resp
+  parseResponse (mkError status502 "server-error") resp

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -35,7 +35,7 @@ import Bilge hiding (timeout)
 import Bilge.Assert
 import Brig.Types
 import qualified Control.Concurrent.Async as Async
-import Control.Lens (at, view, (.~), (?~), (^.))
+import Control.Lens (at, ix, preview, view, (.~), (?~), (^.))
 import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
 import qualified Data.Code as Code
@@ -950,7 +950,12 @@ testAddRemoteMemberInvalidDomain = do
   let remoteBob = Qualified bobId (Domain "invalid.example.com")
   convId <- decodeConvId <$> postConv alice [] (Just "remote gossip") [] Nothing Nothing
   postQualifiedMembers alice (remoteBob :| []) convId
-    !!! const 422 === statusCode
+    !!! do
+      const 422 === statusCode
+      const (Just "/federation/get-users-by-ids")
+        === preview (ix "data" . ix "path") . responseJsonUnsafe @Value
+      const (Just "invalid.example.com")
+        === preview (ix "data" . ix "domain") . responseJsonUnsafe @Value
 
 -- This test is a safeguard to ensure adding remote members will fail
 -- on environments where federation isn't configured (such as our production as of May 2021)

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -362,7 +362,7 @@ testEnableSSOPerTeam = do
   let putSSOEnabledInternalCheckNotImplemented :: HasCallStack => TestM ()
       putSSOEnabledInternalCheckNotImplemented = do
         g <- view tsGalley
-        Wai.Error status label _ <-
+        Wai.Error status label _ _ <-
           responseJsonUnsafe
             <$> put
               ( g
@@ -392,7 +392,7 @@ testEnableTeamSearchVisibilityPerTeam = do
         liftIO $ assertEqual msg enabledness statusValue
   let putSearchVisibilityCheckNotAllowed :: (HasCallStack, Monad m, MonadIO m, MonadHttp m) => m ()
       putSearchVisibilityCheckNotAllowed = do
-        Wai.Error status label _ <- responseJsonUnsafe <$> putSearchVisibility g owner tid SearchVisibilityNoNameOutsideTeam
+        Wai.Error status label _ _ <- responseJsonUnsafe <$> putSearchVisibility g owner tid SearchVisibilityNoNameOutsideTeam
         liftIO $ do
           assertEqual "bad status" status403 status
           assertEqual "bad label" "team-search-visibility-not-enabled" label

--- a/services/gundeck/src/Gundeck/API/Error.hs
+++ b/services/gundeck/src/Gundeck/API/Error.hs
@@ -19,13 +19,13 @@ module Gundeck.API.Error where
 
 import Data.Text.Lazy (Text)
 import Network.HTTP.Types.Status
-import Network.Wai.Utilities.Error (Error (..))
+import Network.Wai.Utilities.Error (Error (..), mkError)
 
 notificationNotFound :: Error
-notificationNotFound = Error status404 "not-found" "Some notifications not found."
+notificationNotFound = mkError status404 "not-found" "Some notifications not found."
 
 clientError :: Text -> Error
-clientError = Error status400 "client-error"
+clientError = mkError status400 "client-error"
 
 invalidNotificationId :: Error
 invalidNotificationId = clientError "Notification ID must be a version 1 UUID"

--- a/services/gundeck/src/Gundeck/API/Public.hs
+++ b/services/gundeck/src/Gundeck/API/Public.hs
@@ -167,22 +167,22 @@ success t =
 
 invalidToken :: Response
 invalidToken =
-  json (Error status400 "invalid-token" "Invalid push token")
+  json (mkError status400 "invalid-token" "Invalid push token")
     & setStatus status404
 
 snsThreadBudgetReached :: Response
 snsThreadBudgetReached =
-  json (Error status400 "sns-thread-budget-reached" "Too many concurrent calls to SNS; is SNS down?")
+  json (mkError status400 "sns-thread-budget-reached" "Too many concurrent calls to SNS; is SNS down?")
     & setStatus status413
 
 tokenTooLong :: Response
 tokenTooLong =
-  json (Error status400 "token-too-long" "Push token length must be < 8192 for GCM or 400 for APNS")
+  json (mkError status400 "token-too-long" "Push token length must be < 8192 for GCM or 400 for APNS")
     & setStatus status413
 
 metadataTooLong :: Response
 metadataTooLong =
-  json (Error status400 "metadata-too-long" "Tried to add token to endpoint resulting in metadata length > 2048")
+  json (mkError status400 "metadata-too-long" "Tried to add token to endpoint resulting in metadata length > 2048")
     & setStatus status413
 
 notFound :: Response

--- a/services/gundeck/src/Gundeck/Monad.hs
+++ b/services/gundeck/src/Gundeck/Monad.hs
@@ -106,7 +106,7 @@ lookupReqId = maybe def RequestId . lookup requestIdName . requestHeaders
 {-# INLINE lookupReqId #-}
 
 fromJsonBody :: FromJSON a => JsonRequest a -> Gundeck a
-fromJsonBody r = exceptT (throwM . Error status400 "bad-request") return (parseBody r)
+fromJsonBody r = exceptT (throwM . mkError status400 "bad-request") return (parseBody r)
 {-# INLINE fromJsonBody #-}
 
 ifNothing :: Error -> Maybe a -> Gundeck a

--- a/services/gundeck/src/Gundeck/Util.hs
+++ b/services/gundeck/src/Gundeck/Util.hs
@@ -38,7 +38,7 @@ mkNotificationId = do
   where
     x10 = limitRetries 10 <> exponentialBackoff 10
     fun = const (return . isNothing)
-    err = Error status500 "internal-error" "unable to generate notification ID"
+    err = mkError status500 "internal-error" "unable to generate notification ID"
 
 mapAsync ::
   (MonadUnliftIO m, Traversable t) =>

--- a/services/proxy/src/Proxy/API/Public.hs
+++ b/services/proxy/src/Proxy/API/Public.hs
@@ -219,10 +219,10 @@ isError :: Status -> Bool
 isError (statusCode -> c) = c < 200 || c > 299
 
 error500 :: Error
-error500 = Error status500 "internal-error" "Internal server error"
+error500 = mkError status500 "internal-error" "Internal server error"
 
 error502 :: Error
-error502 = Error status502 "bad-gateway" "Bad gateway"
+error502 = mkError status502 "bad-gateway" "Bad gateway"
 
 newtype S = S Status
 

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -572,7 +572,7 @@ errorPage err inputs mcky =
     }
   where
     werr = either forceWai id $ renderSparError err
-    forceWai ServerError {..} = Wai.Error (Http.Status errHTTPCode "") (cs errReasonPhrase) (cs errBody)
+    forceWai ServerError {..} = Wai.mkError (Http.Status errHTTPCode "") (cs errReasonPhrase) (cs errBody)
     errbody :: [LT]
     errbody =
       [ "<head>",

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -110,13 +110,13 @@ sparToServerErrorWithLogging logger err = do
 
 servantToWaiError :: ServerError -> Wai.Error
 servantToWaiError (ServerError code phrase body _headers) =
-  Wai.Error (Status code (cs phrase)) (cs phrase) (cs body)
+  Wai.mkError (Status code (cs phrase)) (cs phrase) (cs body)
 
 sparToServerError :: SparError -> ServerError
 sparToServerError = either id waiToServant . renderSparError
 
 waiToServant :: Wai.Error -> ServerError
-waiToServant waierr@(Wai.Error status label _) =
+waiToServant waierr@(Wai.Error status label _ _) =
   ServerError
     { errHTTPCode = statusCode status,
       errReasonPhrase = cs label,
@@ -131,52 +131,52 @@ renderSparErrorWithLogging logger err = do
   pure errPossiblyWai
 
 renderSparError :: SparError -> Either ServerError Wai.Error
-renderSparError (SAML.CustomError SparNoSuchRequest) = Right $ Wai.Error status500 "server-error" "AuthRequest seems to have disappeared (could not find verdict format)."
-renderSparError (SAML.CustomError (SparNoRequestRefInResponse msg)) = Right $ Wai.Error status400 "server-error-unsupported-saml" ("The IdP needs to provide an InResponseTo attribute in the assertion: " <> msg)
-renderSparError (SAML.CustomError (SparCouldNotSubstituteSuccessURI msg)) = Right $ Wai.Error status400 "bad-success-redirect" ("re-parsing the substituted URI failed: " <> msg)
-renderSparError (SAML.CustomError (SparCouldNotSubstituteFailureURI msg)) = Right $ Wai.Error status400 "bad-failure-redirect" ("re-parsing the substituted URI failed: " <> msg)
-renderSparError (SAML.CustomError (SparBadInitiateLoginQueryParams label)) = Right $ Wai.Error status400 label label
-renderSparError (SAML.CustomError (SparBindFromWrongOrNoTeam msg)) = Right $ Wai.Error status403 "bad-team" ("Forbidden: wrong user team " <> msg)
-renderSparError (SAML.CustomError (SparBindFromBadAccountStatus msg)) = Right $ Wai.Error status403 "bad-account-status" ("Forbidden: user has account status " <> msg <> "; only Active, PendingInvitation are supported")
-renderSparError (SAML.CustomError SparBindUserRefTaken) = Right $ Wai.Error status403 "subject-id-taken" "Forbidden: SubjectID is used by another wire user.  If you have an old user bound to this IdP, unbind or delete that user."
-renderSparError (SAML.CustomError (SparBadUserName msg)) = Right $ Wai.Error status400 "bad-username" ("Bad UserName in SAML response, except len [1, 128]: " <> msg)
-renderSparError (SAML.CustomError (SparCannotCreateUsersOnReplacedIdP replacingIdPId)) = Right $ Wai.Error status400 "cannont-provision-on-replaced-idp" ("This IdP has been replaced, users can only be auto-provisioned on the replacing IdP " <> replacingIdPId)
+renderSparError (SAML.CustomError SparNoSuchRequest) = Right $ Wai.mkError status500 "server-error" "AuthRequest seems to have disappeared (could not find verdict format)."
+renderSparError (SAML.CustomError (SparNoRequestRefInResponse msg)) = Right $ Wai.mkError status400 "server-error-unsupported-saml" ("The IdP needs to provide an InResponseTo attribute in the assertion: " <> msg)
+renderSparError (SAML.CustomError (SparCouldNotSubstituteSuccessURI msg)) = Right $ Wai.mkError status400 "bad-success-redirect" ("re-parsing the substituted URI failed: " <> msg)
+renderSparError (SAML.CustomError (SparCouldNotSubstituteFailureURI msg)) = Right $ Wai.mkError status400 "bad-failure-redirect" ("re-parsing the substituted URI failed: " <> msg)
+renderSparError (SAML.CustomError (SparBadInitiateLoginQueryParams label)) = Right $ Wai.mkError status400 label label
+renderSparError (SAML.CustomError (SparBindFromWrongOrNoTeam msg)) = Right $ Wai.mkError status403 "bad-team" ("Forbidden: wrong user team " <> msg)
+renderSparError (SAML.CustomError (SparBindFromBadAccountStatus msg)) = Right $ Wai.mkError status403 "bad-account-status" ("Forbidden: user has account status " <> msg <> "; only Active, PendingInvitation are supported")
+renderSparError (SAML.CustomError SparBindUserRefTaken) = Right $ Wai.mkError status403 "subject-id-taken" "Forbidden: SubjectID is used by another wire user.  If you have an old user bound to this IdP, unbind or delete that user."
+renderSparError (SAML.CustomError (SparBadUserName msg)) = Right $ Wai.mkError status400 "bad-username" ("Bad UserName in SAML response, except len [1, 128]: " <> msg)
+renderSparError (SAML.CustomError (SparCannotCreateUsersOnReplacedIdP replacingIdPId)) = Right $ Wai.mkError status400 "cannont-provision-on-replaced-idp" ("This IdP has been replaced, users can only be auto-provisioned on the replacing IdP " <> replacingIdPId)
 -- RFC-specific errors
-renderSparError (SAML.CustomError (SparCouldNotParseRfcResponse service msg)) = Right $ Wai.Error status502 "bad-upstream" ("Could not parse " <> service <> " response body: " <> msg)
-renderSparError (SAML.CustomError SparReAuthRequired) = Right $ Wai.Error status403 "access-denied" "This operation requires reauthentication."
-renderSparError (SAML.CustomError SparCouldNotRetrieveCookie) = Right $ Wai.Error status502 "bad-upstream" "Unable to get a cookie from an upstream server."
-renderSparError (SAML.CustomError (SparCassandraError msg)) = Right $ Wai.Error status500 "server-error" msg -- TODO: should we be more specific here and make it 'db-error'?
-renderSparError (SAML.CustomError (SparCassandraTTLError ttlerr)) = Right $ Wai.Error status400 "ttl-error" (cs $ show ttlerr)
-renderSparError (SAML.UnknownIdP msg) = Right $ Wai.Error status404 "not-found" ("IdP not found: " <> msg)
-renderSparError (SAML.Forbidden msg) = Right $ Wai.Error status403 "forbidden" ("Forbidden: " <> msg)
-renderSparError (SAML.BadSamlResponseBase64Error msg) = Right $ Wai.Error status400 "bad-response-encoding" ("Bad response: base64 error: " <> cs msg)
-renderSparError (SAML.BadSamlResponseXmlError msg) = Right $ Wai.Error status400 "bad-response-xml" ("Bad response: XML parse error: " <> cs msg)
-renderSparError (SAML.BadSamlResponseSamlError msg) = Right $ Wai.Error status400 "bad-response-saml" ("Bad response: SAML parse error: " <> cs msg)
-renderSparError SAML.BadSamlResponseFormFieldMissing = Right $ Wai.Error status400 "bad-response-saml" ("Bad response: SAMLResponse form field missing from HTTP body")
-renderSparError SAML.BadSamlResponseIssuerMissing = Right $ Wai.Error status400 "bad-response-saml" ("Bad response: no Issuer in AuthnResponse")
-renderSparError SAML.BadSamlResponseNoAssertions = Right $ Wai.Error status400 "bad-response-saml" ("Bad response: no assertions in AuthnResponse")
-renderSparError SAML.BadSamlResponseAssertionWithoutID = Right $ Wai.Error status400 "bad-response-saml" ("Bad response: assertion without ID")
-renderSparError (SAML.BadSamlResponseInvalidSignature msg) = Right $ Wai.Error status400 "bad-response-signature" (cs msg)
-renderSparError (SAML.CustomError SparIdPNotFound) = Right $ Wai.Error status404 "not-found" "Could not find IdP."
-renderSparError (SAML.CustomError SparMissingZUsr) = Right $ Wai.Error status400 "client-error" "[header] 'Z-User' required"
-renderSparError (SAML.CustomError SparNotInTeam) = Right $ Wai.Error status403 "no-team-member" "Requesting user is not a team member or not a member of this team."
-renderSparError (SAML.CustomError (SparNoPermission perm)) = Right $ Wai.Error status403 "insufficient-permissions" ("You need permission " <> cs perm <> ".")
-renderSparError (SAML.CustomError SparSSODisabled) = Right $ Wai.Error status403 "sso-disabled" "Please ask customer support to enable this feature for your team."
-renderSparError (SAML.CustomError SparInitLoginWithAuth) = Right $ Wai.Error status403 "login-with-auth" "This end-point is only for login, not binding."
-renderSparError (SAML.CustomError SparInitBindWithoutAuth) = Right $ Wai.Error status403 "bind-without-auth" "This end-point is only for binding, not login."
-renderSparError SAML.UnknownError = Right $ Wai.Error status500 "server-error" "Unknown server error."
-renderSparError (SAML.BadServerConfig msg) = Right $ Wai.Error status500 "server-error" ("Error in server config: " <> msg)
-renderSparError (SAML.InvalidCert msg) = Right $ Wai.Error status500 "invalid-certificate" ("Error in idp certificate: " <> msg)
+renderSparError (SAML.CustomError (SparCouldNotParseRfcResponse service msg)) = Right $ Wai.mkError status502 "bad-upstream" ("Could not parse " <> service <> " response body: " <> msg)
+renderSparError (SAML.CustomError SparReAuthRequired) = Right $ Wai.mkError status403 "access-denied" "This operation requires reauthentication."
+renderSparError (SAML.CustomError SparCouldNotRetrieveCookie) = Right $ Wai.mkError status502 "bad-upstream" "Unable to get a cookie from an upstream server."
+renderSparError (SAML.CustomError (SparCassandraError msg)) = Right $ Wai.mkError status500 "server-error" msg -- TODO: should we be more specific here and make it 'db-error'?
+renderSparError (SAML.CustomError (SparCassandraTTLError ttlerr)) = Right $ Wai.mkError status400 "ttl-error" (cs $ show ttlerr)
+renderSparError (SAML.UnknownIdP msg) = Right $ Wai.mkError status404 "not-found" ("IdP not found: " <> msg)
+renderSparError (SAML.Forbidden msg) = Right $ Wai.mkError status403 "forbidden" ("Forbidden: " <> msg)
+renderSparError (SAML.BadSamlResponseBase64Error msg) = Right $ Wai.mkError status400 "bad-response-encoding" ("Bad response: base64 error: " <> cs msg)
+renderSparError (SAML.BadSamlResponseXmlError msg) = Right $ Wai.mkError status400 "bad-response-xml" ("Bad response: XML parse error: " <> cs msg)
+renderSparError (SAML.BadSamlResponseSamlError msg) = Right $ Wai.mkError status400 "bad-response-saml" ("Bad response: SAML parse error: " <> cs msg)
+renderSparError SAML.BadSamlResponseFormFieldMissing = Right $ Wai.mkError status400 "bad-response-saml" ("Bad response: SAMLResponse form field missing from HTTP body")
+renderSparError SAML.BadSamlResponseIssuerMissing = Right $ Wai.mkError status400 "bad-response-saml" ("Bad response: no Issuer in AuthnResponse")
+renderSparError SAML.BadSamlResponseNoAssertions = Right $ Wai.mkError status400 "bad-response-saml" ("Bad response: no assertions in AuthnResponse")
+renderSparError SAML.BadSamlResponseAssertionWithoutID = Right $ Wai.mkError status400 "bad-response-saml" ("Bad response: assertion without ID")
+renderSparError (SAML.BadSamlResponseInvalidSignature msg) = Right $ Wai.mkError status400 "bad-response-signature" (cs msg)
+renderSparError (SAML.CustomError SparIdPNotFound) = Right $ Wai.mkError status404 "not-found" "Could not find IdP."
+renderSparError (SAML.CustomError SparMissingZUsr) = Right $ Wai.mkError status400 "client-error" "[header] 'Z-User' required"
+renderSparError (SAML.CustomError SparNotInTeam) = Right $ Wai.mkError status403 "no-team-member" "Requesting user is not a team member or not a member of this team."
+renderSparError (SAML.CustomError (SparNoPermission perm)) = Right $ Wai.mkError status403 "insufficient-permissions" ("You need permission " <> cs perm <> ".")
+renderSparError (SAML.CustomError SparSSODisabled) = Right $ Wai.mkError status403 "sso-disabled" "Please ask customer support to enable this feature for your team."
+renderSparError (SAML.CustomError SparInitLoginWithAuth) = Right $ Wai.mkError status403 "login-with-auth" "This end-point is only for login, not binding."
+renderSparError (SAML.CustomError SparInitBindWithoutAuth) = Right $ Wai.mkError status403 "bind-without-auth" "This end-point is only for binding, not login."
+renderSparError SAML.UnknownError = Right $ Wai.mkError status500 "server-error" "Unknown server error."
+renderSparError (SAML.BadServerConfig msg) = Right $ Wai.mkError status500 "server-error" ("Error in server config: " <> msg)
+renderSparError (SAML.InvalidCert msg) = Right $ Wai.mkError status500 "invalid-certificate" ("Error in idp certificate: " <> msg)
 -- Errors related to IdP creation
-renderSparError (SAML.CustomError (SparNewIdPBadMetadata msg)) = Right $ Wai.Error status400 "invalid-metadata" msg
-renderSparError (SAML.CustomError SparNewIdPPubkeyMismatch) = Right $ Wai.Error status400 "key-mismatch" "public keys in body, metadata do not match"
-renderSparError (SAML.CustomError SparNewIdPAlreadyInUse) = Right $ Wai.Error status400 "idp-already-in-use" "an idp issuer can only be used within one team"
-renderSparError (SAML.CustomError (SparNewIdPWantHttps msg)) = Right $ Wai.Error status400 "idp-must-be-https" ("an idp request uri must be https, not http or other: " <> msg)
-renderSparError (SAML.CustomError SparIdPHasBoundUsers) = Right $ Wai.Error status412 "idp-has-bound-users" "an idp can only be deleted if it is empty"
-renderSparError (SAML.CustomError SparIdPIssuerInUse) = Right $ Wai.Error status400 "idp-issuer-in-use" "The issuer of your IdP is already in use.  Remove the entry in the team that uses it, or construct a new IdP issuer."
+renderSparError (SAML.CustomError (SparNewIdPBadMetadata msg)) = Right $ Wai.mkError status400 "invalid-metadata" msg
+renderSparError (SAML.CustomError SparNewIdPPubkeyMismatch) = Right $ Wai.mkError status400 "key-mismatch" "public keys in body, metadata do not match"
+renderSparError (SAML.CustomError SparNewIdPAlreadyInUse) = Right $ Wai.mkError status400 "idp-already-in-use" "an idp issuer can only be used within one team"
+renderSparError (SAML.CustomError (SparNewIdPWantHttps msg)) = Right $ Wai.mkError status400 "idp-must-be-https" ("an idp request uri must be https, not http or other: " <> msg)
+renderSparError (SAML.CustomError SparIdPHasBoundUsers) = Right $ Wai.mkError status412 "idp-has-bound-users" "an idp can only be deleted if it is empty"
+renderSparError (SAML.CustomError SparIdPIssuerInUse) = Right $ Wai.mkError status400 "idp-issuer-in-use" "The issuer of your IdP is already in use.  Remove the entry in the team that uses it, or construct a new IdP issuer."
 -- Errors related to provisioning
-renderSparError (SAML.CustomError (SparProvisioningMoreThanOneIdP msg)) = Right $ Wai.Error status400 "more-than-one-idp" ("Team can have at most one IdP configured: " <> msg)
-renderSparError (SAML.CustomError SparProvisioningTokenLimitReached) = Right $ Wai.Error status403 "token-limit-reached" "The limit of provisioning tokens per team has been reached"
+renderSparError (SAML.CustomError (SparProvisioningMoreThanOneIdP msg)) = Right $ Wai.mkError status400 "more-than-one-idp" ("Team can have at most one IdP configured: " <> msg)
+renderSparError (SAML.CustomError SparProvisioningTokenLimitReached) = Right $ Wai.mkError status403 "token-limit-reached" "The limit of provisioning tokens per team has been reached"
 -- SCIM errors
 renderSparError (SAML.CustomError (SparScimError err)) = Left $ Scim.scimToServerError err
 -- Other


### PR DESCRIPTION
This adds a `data` field to `Wai.Error`, containing some more specific error data. For now, only federation-specific data is supported. The federation error-conversion functions add domain and path information to the error, which can be used to diagnose which particular federated request failed in case of federation errors.

Most of the diff is about adapting every usage point of `Wai.Error`. Since `Wai.Error` gained a new field, and the constructor was used directly everywhere, I have replaced all uses of the constructor with a call to a smart constructor `mkError` which sets the extra data to `Nothing`.