### PR TITLE
Add remote users when creating a conversation

### DIFF
--- a/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
@@ -140,6 +140,6 @@ createConv users name = sessionRequest req rsc readBody
       method POST
         . path "conversations"
         . acceptJson
-        . json (NewConvUnmanaged (NewConv users name mempty Nothing Nothing Nothing Nothing roleNameWireAdmin))
+        . json (NewConvUnmanaged (NewConv users [] name mempty Nothing Nothing Nothing Nothing roleNameWireAdmin))
         $ empty
     rsc = status201 :| []

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -384,6 +384,8 @@ modelNewConversation = Doc.defineModel "NewConversation" $ do
   Doc.description "JSON object to create a new conversation"
   Doc.property "users" (Doc.unique $ Doc.array Doc.bytes') $
     Doc.description "List of user IDs (excluding the requestor) to be part of this conversation"
+  Doc.property "qualified_users" (Doc.unique . Doc.array $ Doc.bytes') $
+    Doc.description "List of qualified user IDs to be part of this conversation"
   Doc.property "name" Doc.string' $ do
     Doc.description "The conversation name"
     Doc.optional
@@ -414,6 +416,9 @@ instance Arbitrary NewConvUnmanaged where
 
 data NewConv = NewConv
   { newConvUsers :: [UserId],
+    -- | A list of qualified users, which can include some local qualified users
+    -- too.
+    newConvQualifiedUsers :: [Qualified UserId],
     newConvName :: Maybe Text,
     newConvAccess :: Set Access,
     newConvAccessRole :: Maybe AccessRole,
@@ -437,6 +442,13 @@ newConvSchema =
           "users"
           (description ?~ usersDesc)
           (array schema)
+      <*> newConvQualifiedUsers
+        .= ( fieldWithDocModifier
+               "qualified_users"
+               (description ?~ qualifiedUsersDesc)
+               (array schema)
+               <|> pure []
+           )
       <*> newConvName .= opt (field "name" schema)
       <*> (Set.toList . newConvAccess)
         .= ( field "access" (Set.fromList <$> array schema)
@@ -465,7 +477,10 @@ newConvSchema =
   where
     usersDesc =
       "List of user IDs (excluding the requestor) to be \
-      \part of this conversation"
+      \part of this conversation (deprecated)"
+    qualifiedUsersDesc =
+      "List of qualified user IDs (excluding the requestor) \
+      \to be part of this conversation"
 
 newConvIsManaged :: NewConv -> Bool
 newConvIsManaged = maybe False cnvManaged . newConvTeam

--- a/libs/wire-api/test/golden/fromJSON/testObject_NewConvUnmanaged_user_1.json
+++ b/libs/wire-api/test/golden/fromJSON/testObject_NewConvUnmanaged_user_1.json
@@ -1,0 +1,18 @@
+{
+    "access": [
+        "private",
+        "invite"
+    ],
+    "access_role": "activated",
+    "users": [
+        "00000001-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000000"
+    ],
+    "conversation_role": "8tp2gs7b6",
+    "team": {
+        "managed": false,
+        "teamid": "00000000-0000-0001-0000-000000000000"
+    },
+    "receipt_mode": 1,
+    "message_timer": 3320987366258987
+}

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_1.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_1.json
@@ -8,5 +8,6 @@
         "teamid": "00000001-0000-0001-0000-000200000000"
     },
     "receipt_mode": 4,
-    "message_timer": 193643728192048
+    "message_timer": 193643728192048,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_10.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_10.json
@@ -12,5 +12,6 @@
         "teamid": "00000001-0000-0001-0000-000000000001"
     },
     "receipt_mode": 1,
-    "message_timer": 8061252799624904
+    "message_timer": 8061252799624904,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_11.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_11.json
@@ -11,5 +11,6 @@
         "teamid": "00000001-0000-0000-0000-000200000001"
     },
     "receipt_mode": -2,
-    "message_timer": 6292627004994884
+    "message_timer": 6292627004994884,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_12.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_12.json
@@ -14,5 +14,6 @@
         "managed": true,
         "teamid": "00000000-0000-0001-0000-000100000000"
     },
-    "message_timer": 7043412511612101
+    "message_timer": 7043412511612101,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_13.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_13.json
@@ -12,5 +12,6 @@
         "managed": true,
         "teamid": "00000000-0000-0001-0000-000100000001"
     },
-    "receipt_mode": 0
+    "receipt_mode": 0,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_14.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_14.json
@@ -20,5 +20,6 @@
         "managed": true,
         "teamid": "00000001-0000-0001-0000-000000000000"
     },
-    "message_timer": 8669416711689656
+    "message_timer": 8669416711689656,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_15.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_15.json
@@ -17,5 +17,6 @@
         "teamid": "00000001-0000-0001-0000-000000000000"
     },
     "receipt_mode": 2,
-    "message_timer": 1166285470102499
+    "message_timer": 1166285470102499,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_16.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_16.json
@@ -10,5 +10,6 @@
         "managed": true,
         "teamid": "00000002-0000-0001-0000-000000000001"
     },
-    "message_timer": 4425819976591162
+    "message_timer": 4425819976591162,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_17.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_17.json
@@ -17,5 +17,6 @@
         "managed": true,
         "teamid": "00000000-0000-0000-0000-000000000000"
     },
-    "message_timer": 5065871950676797
+    "message_timer": 5065871950676797,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_18.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_18.json
@@ -8,5 +8,6 @@
         "managed": true,
         "teamid": "00000001-0000-0000-0000-000100000001"
     },
-    "receipt_mode": -1
+    "receipt_mode": -1,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_19.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_19.json
@@ -12,5 +12,6 @@
         "managed": true,
         "teamid": "00000001-0000-0000-0000-000100000001"
     },
-    "message_timer": 8428756728484885
+    "message_timer": 8428756728484885,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_2.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_2.json
@@ -14,5 +14,11 @@
         "managed": true,
         "teamid": "00000002-0000-0002-0000-000200000002"
     },
-    "message_timer": 5509522199847054
+    "message_timer": 5509522199847054,
+    "qualified_users": [
+        {
+            "domain": "test.example.com",
+            "id": "00000000-0000-0000-0000-000100000001"
+        }
+    ]
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_20.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_20.json
@@ -15,5 +15,6 @@
         "managed": true,
         "teamid": "00000000-0000-0000-0000-000000000001"
     },
-    "message_timer": 6168723896440273
+    "message_timer": 6168723896440273,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_3.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_3.json
@@ -14,5 +14,11 @@
         "teamid": "00000001-0000-0001-0000-000000000000"
     },
     "receipt_mode": 2,
-    "message_timer": 582808797322573
+    "message_timer": 582808797322573,
+    "qualified_users": [
+        {
+            "domain": "test.example.com",
+            "id": "00000000-0000-0000-0000-000100000001"
+        }
+    ]
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_4.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_4.json
@@ -14,5 +14,6 @@
     "team": {
         "managed": true,
         "teamid": "00000001-0000-0001-0000-000100000002"
-    }
+    },
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_5.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_5.json
@@ -13,5 +13,6 @@
         "teamid": "00000001-0000-0000-0000-000100000000"
     },
     "receipt_mode": -1,
-    "message_timer": 1570858821505994
+    "message_timer": 1570858821505994,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_6.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_6.json
@@ -15,5 +15,6 @@
         "managed": true,
         "teamid": "00000000-0000-0000-0000-000000000001"
     },
-    "message_timer": 6614365418177275
+    "message_timer": 6614365418177275,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_7.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_7.json
@@ -12,5 +12,6 @@
         "teamid": "00000001-0000-0001-0000-000100000000"
     },
     "receipt_mode": 0,
-    "message_timer": 7417375067718994
+    "message_timer": 7417375067718994,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_8.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_8.json
@@ -11,5 +11,6 @@
         "managed": true,
         "teamid": "00000001-0000-0000-0000-000100000001"
     },
-    "receipt_mode": 2
+    "receipt_mode": 2,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvManaged_user_9.json
+++ b/libs/wire-api/test/golden/testObject_NewConvManaged_user_9.json
@@ -12,5 +12,6 @@
         "teamid": "00000001-0000-0000-0000-000000000000"
     },
     "receipt_mode": 1,
-    "message_timer": 2550845209410146
+    "message_timer": 2550845209410146,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_1.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_1.json
@@ -14,5 +14,6 @@
         "teamid": "00000000-0000-0001-0000-000000000000"
     },
     "receipt_mode": 1,
-    "message_timer": 3320987366258987
+    "message_timer": 3320987366258987,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_10.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_10.json
@@ -11,5 +11,6 @@
     "conversation_role": "30mnzwj79jo9ear300qs4k_x2262nyaqxt9qga1_zaqmto43q2935t4dzaan_qnlstgjix7efmqfljkpww2lz",
     "name": "",
     "receipt_mode": 2,
-    "message_timer": 5041503034744095
+    "message_timer": 5041503034744095,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_11.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_11.json
@@ -10,5 +10,6 @@
         "teamid": "00000000-0000-0000-0000-000000000000"
     },
     "receipt_mode": 1,
-    "message_timer": 6019134025424754
+    "message_timer": 6019134025424754,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_12.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_12.json
@@ -3,5 +3,6 @@
     "users": [],
     "conversation_role": "wqhaeljk9zpp5nmspwl",
     "name": ">+",
-    "receipt_mode": 1
+    "receipt_mode": 1,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_13.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_13.json
@@ -13,5 +13,6 @@
         "teamid": "00000000-0000-0000-0000-000000000001"
     },
     "receipt_mode": -2,
-    "message_timer": 211460552735402
+    "message_timer": 211460552735402,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_14.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_14.json
@@ -10,5 +10,6 @@
     "conversation_role": "fga_hfm9uzn_5z883y6r_kumb",
     "name": "",
     "receipt_mode": -2,
-    "message_timer": 854777662274030
+    "message_timer": 854777662274030,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_15.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_15.json
@@ -14,5 +14,6 @@
         "teamid": "00000001-0000-0001-0000-000200000002"
     },
     "receipt_mode": 1,
-    "message_timer": 4005602882980532
+    "message_timer": 4005602882980532,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_16.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_16.json
@@ -11,5 +11,6 @@
         "managed": false,
         "teamid": "00000000-0000-0001-0000-000100000000"
     },
-    "receipt_mode": 1
+    "receipt_mode": 1,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_17.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_17.json
@@ -22,5 +22,6 @@
         "teamid": "00000000-0000-0001-0000-000100000001"
     },
     "receipt_mode": 0,
-    "message_timer": 880163555151907
+    "message_timer": 880163555151907,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_18.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_18.json
@@ -12,5 +12,6 @@
     "conversation_role": "ugehcdyu_ob9_woawlths95ez8cgtb6wjqypp7vbjaooiczerb5zpc6srxszgkrdu8l24ygz_",
     "name": "sd\u0006",
     "receipt_mode": -2,
-    "message_timer": 3120553871655858
+    "message_timer": 3120553871655858,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_19.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_19.json
@@ -9,5 +9,6 @@
     "conversation_role": "xik7vc3wp82gw4r934rad_bhmf2orany3qgu_tx9huwfrlxy8m0id71x20uddebps30zdahe_ffcxxhc",
     "name": "Cu\u0011",
     "receipt_mode": -1,
-    "message_timer": 864918593306344
+    "message_timer": 864918593306344,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_2.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_2.json
@@ -9,5 +9,11 @@
         "teamid": "00000000-0000-0001-0000-000000000001"
     },
     "receipt_mode": -1,
-    "message_timer": 2406292360203739
+    "message_timer": 2406292360203739,
+    "qualified_users": [
+        {
+            "domain": "testdomain.example.com",
+            "id": "00000000-0000-0000-0000-000100000001"
+        }
+    ]
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_20.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_20.json
@@ -6,5 +6,6 @@
     "conversation_role": "udhi2sbf7tzyshrh",
     "name": "\u000f􅚶",
     "receipt_mode": -1,
-    "message_timer": 3641984282941906
+    "message_timer": 3641984282941906,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_3.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_3.json
@@ -13,5 +13,6 @@
         "teamid": "00000000-0000-0001-0000-000000000001"
     },
     "receipt_mode": 0,
-    "message_timer": 6764297310186120
+    "message_timer": 6764297310186120,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_4.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_4.json
@@ -9,5 +9,6 @@
         "managed": false,
         "teamid": "00000000-0000-0001-0000-000000000000"
     },
-    "receipt_mode": -2
+    "receipt_mode": -2,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_5.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_5.json
@@ -13,5 +13,6 @@
     "team": {
         "managed": false,
         "teamid": "00000001-0000-0001-0000-000100000000"
-    }
+    },
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_6.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_6.json
@@ -7,5 +7,6 @@
     "conversation_role": "5zlsxm_95e5j1lk04d6rka_1svnnk65pov7tqs",
     "name": "`3",
     "receipt_mode": 2,
-    "message_timer": 3993332602038581
+    "message_timer": 3993332602038581,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_7.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_7.json
@@ -11,5 +11,6 @@
         "teamid": "00000001-0000-0002-0000-000200000000"
     },
     "receipt_mode": -3,
-    "message_timer": 5300164242243961
+    "message_timer": 5300164242243961,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_8.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_8.json
@@ -13,5 +13,6 @@
         "teamid": "00000000-0000-0001-0000-000100000001"
     },
     "receipt_mode": -1,
-    "message_timer": 5317293791913533
+    "message_timer": 5317293791913533,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_9.json
+++ b/libs/wire-api/test/golden/testObject_NewConvUnmanaged_user_9.json
@@ -11,5 +11,6 @@
     ],
     "conversation_role": "n8cjajmyhnw3hqv8sohb8674nwnpsv7g57i2hjhexg9tww",
     "name": "L",
-    "message_timer": 7179840365742041
+    "message_timer": 7179840365742041,
+    "qualified_users": []
 }

--- a/libs/wire-api/test/unit/Test/Wire/API/Golden/FromJSON.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Golden/FromJSON.hs
@@ -20,6 +20,7 @@ module Test.Wire.API.Golden.FromJSON where
 import Imports
 import Test.Tasty
 import Test.Tasty.HUnit
+import Test.Wire.API.Golden.Generated.NewConvUnmanaged_user
 import Test.Wire.API.Golden.Generated.NewOtrMessage_user
 import Test.Wire.API.Golden.Runner
 
@@ -29,5 +30,8 @@ tests =
     "FromJSON golden tests"
     [ testCase ("NewOtrMessage") $
         testFromJSONObjects
-          [(testObject_NewOtrMessage_user_1, "testObject_NewOtrMessage_user_1.json")]
+          [(testObject_NewOtrMessage_user_1, "testObject_NewOtrMessage_user_1.json")],
+      testCase "NewConv" $
+        testFromJSONObjects
+          [(testObject_NewConvUnmanaged_user_1, "testObject_NewConvUnmanaged_user_1.json")]
     ]

--- a/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/NewConvManaged_user.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/NewConvManaged_user.hs
@@ -18,8 +18,10 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 module Test.Wire.API.Golden.Generated.NewConvManaged_user where
 
+import Data.Domain
 import Data.Id (Id (Id))
 import Data.Misc (Milliseconds (Ms, ms))
+import Data.Qualified
 import qualified Data.Set as Set (fromList)
 import qualified Data.UUID as UUID (fromString)
 import Imports (Bool (True), Maybe (Just, Nothing), fromJust)
@@ -38,6 +40,7 @@ import Wire.API.Conversation
         newConvAccessRole,
         newConvMessageTimer,
         newConvName,
+        newConvQualifiedUsers,
         newConvReceiptMode,
         newConvTeam,
         newConvUsers,
@@ -48,11 +51,15 @@ import Wire.API.Conversation
   )
 import Wire.API.Conversation.Role (parseRoleName)
 
+testDomain :: Domain
+testDomain = Domain "test.example.com"
+
 testObject_NewConvManaged_user_1 :: NewConvManaged
 testObject_NewConvManaged_user_1 =
   NewConvManaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Nothing,
           newConvAccess = Set.fromList [],
           newConvAccessRole = Just ActivatedAccessRole,
@@ -74,6 +81,7 @@ testObject_NewConvManaged_user_2 =
   NewConvManaged
     ( NewConv
         { newConvUsers = [(Id (fromJust (UUID.fromString "00000002-0000-0001-0000-000400000000")))],
+          newConvQualifiedUsers = [Qualified (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000001"))) testDomain],
           newConvName = Just "\995491\SUB5",
           newConvAccess = Set.fromList [PrivateAccess, InviteAccess, LinkAccess],
           newConvAccessRole = Just NonActivatedAccessRole,
@@ -98,6 +106,7 @@ testObject_NewConvManaged_user_3 =
             [ (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000100000000"))),
               (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000100000001")))
             ],
+          newConvQualifiedUsers = [Qualified (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000001"))) testDomain],
           newConvName = Just "NwK",
           newConvAccess = Set.fromList [CodeAccess],
           newConvAccessRole = Just TeamAccessRole,
@@ -128,6 +137,7 @@ testObject_NewConvManaged_user_4 =
               (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000100000001"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000000000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "k\61561-",
           newConvAccess = Set.fromList [PrivateAccess, LinkAccess],
           newConvAccessRole = Just TeamAccessRole,
@@ -159,6 +169,7 @@ testObject_NewConvManaged_user_5 =
               (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000001"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000100000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "v",
           newConvAccess = Set.fromList [],
           newConvAccessRole = Nothing,
@@ -184,6 +195,7 @@ testObject_NewConvManaged_user_6 =
               (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000000000000"))),
               (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "P\1098873\r",
           newConvAccess = Set.fromList [InviteAccess, CodeAccess],
           newConvAccessRole = Just PrivateAccessRole,
@@ -213,6 +225,7 @@ testObject_NewConvManaged_user_7 =
             [ (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000000"))),
               (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000000000001")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "\CAN",
           newConvAccess = Set.fromList [],
           newConvAccessRole = Just ActivatedAccessRole,
@@ -242,6 +255,7 @@ testObject_NewConvManaged_user_8 =
             [ (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000100000000"))),
               (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000000000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "&",
           newConvAccess = Set.fromList [],
           newConvAccessRole = Just ActivatedAccessRole,
@@ -263,6 +277,7 @@ testObject_NewConvManaged_user_9 =
   NewConvManaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Nothing,
           newConvAccess = Set.fromList [PrivateAccess, InviteAccess, LinkAccess],
           newConvAccessRole = Just NonActivatedAccessRole,
@@ -284,6 +299,7 @@ testObject_NewConvManaged_user_10 =
   NewConvManaged
     ( NewConv
         { newConvUsers = [(Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000100000001")))],
+          newConvQualifiedUsers = [],
           newConvName = Just "z\1112901",
           newConvAccess = Set.fromList [LinkAccess],
           newConvAccessRole = Nothing,
@@ -310,6 +326,7 @@ testObject_NewConvManaged_user_11 =
   NewConvManaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Just "r",
           newConvAccess = Set.fromList [InviteAccess],
           newConvAccessRole = Just NonActivatedAccessRole,
@@ -334,6 +351,7 @@ testObject_NewConvManaged_user_12 =
             [ (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "",
           newConvAccess = Set.fromList [PrivateAccess, CodeAccess],
           newConvAccessRole = Just TeamAccessRole,
@@ -360,6 +378,7 @@ testObject_NewConvManaged_user_13 =
   NewConvManaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Just "\tB",
           newConvAccess = Set.fromList [PrivateAccess, InviteAccess, LinkAccess],
           newConvAccessRole = Just NonActivatedAccessRole,
@@ -397,6 +416,7 @@ testObject_NewConvManaged_user_14 =
               (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000000"))),
               (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000100000001")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "",
           newConvAccess = Set.fromList [CodeAccess],
           newConvAccessRole = Nothing,
@@ -424,6 +444,7 @@ testObject_NewConvManaged_user_15 =
               (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000000000001"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000000000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Nothing,
           newConvAccess = Set.fromList [PrivateAccess, CodeAccess],
           newConvAccessRole = Just NonActivatedAccessRole,
@@ -445,6 +466,7 @@ testObject_NewConvManaged_user_16 =
   NewConvManaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Just "",
           newConvAccess = Set.fromList [InviteAccess, CodeAccess],
           newConvAccessRole = Nothing,
@@ -478,6 +500,7 @@ testObject_NewConvManaged_user_17 =
               (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000100000000"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "",
           newConvAccess = Set.fromList [LinkAccess],
           newConvAccessRole = Just TeamAccessRole,
@@ -499,6 +522,7 @@ testObject_NewConvManaged_user_18 =
   NewConvManaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Just "\36412\tJ",
           newConvAccess = Set.fromList [],
           newConvAccessRole = Just ActivatedAccessRole,
@@ -520,6 +544,7 @@ testObject_NewConvManaged_user_19 =
   NewConvManaged
     ( NewConv
         { newConvUsers = [(Id (fromJust (UUID.fromString "00000003-0000-0004-0000-000400000002")))],
+          newConvQualifiedUsers = [],
           newConvName = Just "",
           newConvAccess = Set.fromList [PrivateAccess],
           newConvAccessRole = Just ActivatedAccessRole,
@@ -546,6 +571,7 @@ testObject_NewConvManaged_user_20 =
               (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001"))),
               (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000100000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "\SOH?(",
           newConvAccess = Set.fromList [PrivateAccess, InviteAccess],
           newConvAccessRole = Just NonActivatedAccessRole,

--- a/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/NewConvUnmanaged_user.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/NewConvUnmanaged_user.hs
@@ -18,8 +18,10 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 module Test.Wire.API.Golden.Generated.NewConvUnmanaged_user where
 
+import Data.Domain (Domain (Domain))
 import Data.Id (Id (Id))
 import Data.Misc (Milliseconds (Ms, ms))
+import Data.Qualified (Qualified (Qualified))
 import qualified Data.Set as Set (fromList)
 import qualified Data.UUID as UUID (fromString)
 import Imports (Bool (False), Maybe (Just, Nothing), fromJust)
@@ -38,6 +40,7 @@ import Wire.API.Conversation
         newConvAccessRole,
         newConvMessageTimer,
         newConvName,
+        newConvQualifiedUsers,
         newConvReceiptMode,
         newConvTeam,
         newConvUsers,
@@ -48,6 +51,9 @@ import Wire.API.Conversation
   )
 import Wire.API.Conversation.Role (parseRoleName)
 
+testDomain :: Domain
+testDomain = Domain "testdomain.example.com"
+
 testObject_NewConvUnmanaged_user_1 :: NewConvUnmanaged
 testObject_NewConvUnmanaged_user_1 =
   NewConvUnmanaged
@@ -56,6 +62,7 @@ testObject_NewConvUnmanaged_user_1 =
             [ (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000000000001"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000000000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Nothing,
           newConvAccess = Set.fromList [PrivateAccess, InviteAccess],
           newConvAccessRole = Just ActivatedAccessRole,
@@ -77,6 +84,7 @@ testObject_NewConvUnmanaged_user_2 =
   NewConvUnmanaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [Qualified (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000001"))) testDomain],
           newConvName = Just "\128527\1061495",
           newConvAccess = Set.fromList [],
           newConvAccessRole = Just PrivateAccessRole,
@@ -103,6 +111,7 @@ testObject_NewConvUnmanaged_user_3 =
   NewConvUnmanaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Just "f",
           newConvAccess = Set.fromList [InviteAccess, LinkAccess, CodeAccess],
           newConvAccessRole = Just ActivatedAccessRole,
@@ -129,6 +138,7 @@ testObject_NewConvUnmanaged_user_4 =
   NewConvUnmanaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Just "\135359\70751z",
           newConvAccess = Set.fromList [CodeAccess],
           newConvAccessRole = Nothing,
@@ -159,6 +169,7 @@ testObject_NewConvUnmanaged_user_5 =
               (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000100000001"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000100000001")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "X9",
           newConvAccess = Set.fromList [InviteAccess, LinkAccess],
           newConvAccessRole = Nothing,
@@ -185,6 +196,7 @@ testObject_NewConvUnmanaged_user_6 =
   NewConvUnmanaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Just "`3",
           newConvAccess = Set.fromList [LinkAccess],
           newConvAccessRole = Just TeamAccessRole,
@@ -200,6 +212,7 @@ testObject_NewConvUnmanaged_user_7 =
   NewConvUnmanaged
     ( NewConv
         { newConvUsers = [(Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000400000004")))],
+          newConvQualifiedUsers = [],
           newConvName = Just "\1038759\b\1057989'",
           newConvAccess = Set.fromList [],
           newConvAccessRole = Just ActivatedAccessRole,
@@ -221,6 +234,7 @@ testObject_NewConvUnmanaged_user_8 =
   NewConvUnmanaged
     ( NewConv
         { newConvUsers = [(Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000000")))],
+          newConvQualifiedUsers = [],
           newConvName = Just "",
           newConvAccess = Set.fromList [InviteAccess],
           newConvAccessRole = Just ActivatedAccessRole,
@@ -250,6 +264,7 @@ testObject_NewConvUnmanaged_user_9 =
             [ (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000100000001"))),
               (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000100000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "L",
           newConvAccess = Set.fromList [PrivateAccess, InviteAccess, LinkAccess],
           newConvAccessRole = Just ActivatedAccessRole,
@@ -268,6 +283,7 @@ testObject_NewConvUnmanaged_user_10 =
             [ (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000001"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000000000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "",
           newConvAccess = Set.fromList [PrivateAccess, CodeAccess],
           newConvAccessRole = Just ActivatedAccessRole,
@@ -289,6 +305,7 @@ testObject_NewConvUnmanaged_user_11 =
             [ (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000100000000"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000000000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Nothing,
           newConvAccess = Set.fromList [],
           newConvAccessRole = Nothing,
@@ -310,6 +327,7 @@ testObject_NewConvUnmanaged_user_12 =
   NewConvUnmanaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Just ">+",
           newConvAccess = Set.fromList [],
           newConvAccessRole = Nothing,
@@ -330,6 +348,7 @@ testObject_NewConvUnmanaged_user_13 =
               (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000000000001"))),
               (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000100000001")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just ".L'",
           newConvAccess = Set.fromList [],
           newConvAccessRole = Nothing,
@@ -359,6 +378,7 @@ testObject_NewConvUnmanaged_user_14 =
             [ (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000100000001"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000000000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "",
           newConvAccess = Set.fromList [CodeAccess],
           newConvAccessRole = Just NonActivatedAccessRole,
@@ -374,6 +394,7 @@ testObject_NewConvUnmanaged_user_15 =
   NewConvUnmanaged
     ( NewConv
         { newConvUsers = [(Id (fromJust (UUID.fromString "00000002-0000-0003-0000-000300000003")))],
+          newConvQualifiedUsers = [],
           newConvName = Just "b\1008988",
           newConvAccess = Set.fromList [PrivateAccess, InviteAccess, CodeAccess],
           newConvAccessRole = Nothing,
@@ -395,6 +416,7 @@ testObject_NewConvUnmanaged_user_16 =
   NewConvUnmanaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Just "!",
           newConvAccess = Set.fromList [PrivateAccess, CodeAccess],
           newConvAccessRole = Just PrivateAccessRole,
@@ -426,6 +448,7 @@ testObject_NewConvUnmanaged_user_17 =
               (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000000000000"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "\ETXB\119338",
           newConvAccess = Set.fromList [PrivateAccess, LinkAccess, CodeAccess],
           newConvAccessRole = Nothing,
@@ -457,6 +480,7 @@ testObject_NewConvUnmanaged_user_18 =
               (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000000000001"))),
               (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000100000000")))
             ],
+          newConvQualifiedUsers = [],
           newConvName = Just "sd\ACK",
           newConvAccess = Set.fromList [PrivateAccess, CodeAccess],
           newConvAccessRole = Nothing,
@@ -473,6 +497,7 @@ testObject_NewConvUnmanaged_user_19 =
   NewConvUnmanaged
     ( NewConv
         { newConvUsers = [(Id (fromJust (UUID.fromString "00000002-0000-0001-0000-000000000002")))],
+          newConvQualifiedUsers = [],
           newConvName = Just "Cu\DC1",
           newConvAccess = Set.fromList [InviteAccess, LinkAccess],
           newConvAccessRole = Nothing,
@@ -489,6 +514,7 @@ testObject_NewConvUnmanaged_user_20 =
   NewConvUnmanaged
     ( NewConv
         { newConvUsers = [],
+          newConvQualifiedUsers = [],
           newConvName = Just "\SI\1070774",
           newConvAccess = Set.fromList [PrivateAccess],
           newConvAccessRole = Nothing,

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -1252,7 +1252,7 @@ createConv g u us =
       . contentJson
       . body (RequestBodyLBS (encode (NewConvUnmanaged conv)))
   where
-    conv = NewConv us Nothing Set.empty Nothing Nothing Nothing Nothing roleNameWireAdmin
+    conv = NewConv us [] Nothing Set.empty Nothing Nothing Nothing Nothing roleNameWireAdmin
 
 postMessage ::
   Galley ->

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -206,7 +206,7 @@ createTeamConv g tid u us mtimer = do
   let tinfo = Just $ ConvTeamInfo tid False
   let conv =
         NewConvUnmanaged $
-          NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin
+          NewConv us [] Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin
   r <-
     post
       ( g
@@ -228,7 +228,7 @@ createManagedConv g tid u us mtimer = do
   let tinfo = Just $ ConvTeamInfo tid True
   let conv =
         NewConvManaged $
-          NewConv us Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin
+          NewConv us [] Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin
   r <-
     post
       ( g

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -212,7 +212,7 @@ testAddRemoteUsersToLocalConv brig1 galley1 brig2 = do
   alice <- randomUser brig1
   bob <- randomUser brig2
 
-  let conv = NewConvUnmanaged $ NewConv [] (Just "gossip") mempty Nothing Nothing Nothing Nothing roleNameWireAdmin
+  let conv = NewConvUnmanaged $ NewConv [] [] (Just "gossip") mempty Nothing Nothing Nothing Nothing roleNameWireAdmin
   convId <-
     cnvId . responseJsonUnsafe
       <$> post

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c1d012009b1ef15dcf63843768bedfcf8ca4b2e86ac33d5f43ab680cb82e7450
+-- hash: 63f50e23b5853d8dd4b8b87b8588dc8499783ec5e7e72a181b0ccb399089a6ed
 
 name:           galley
 version:        0.83.0
@@ -215,6 +215,7 @@ executable galley-integration
     , brig-types
     , bytestring
     , bytestring-conversion
+    , case-insensitive
     , cassandra-util
     , cassava
     , cereal

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -153,6 +153,7 @@ executables:
     - brig-types
     - bytestring
     - bytestring-conversion
+    - case-insensitive
     - cassandra-util
     - cassava
     - cereal

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -21,12 +21,15 @@ import Brig.Types (Relation (..))
 import Brig.Types.Intra (ReAuthUser (..))
 import Control.Lens (view, (.~), (^.))
 import Control.Monad.Catch
+import Control.Monad.Except (runExceptT)
 import Data.ByteString.Conversion
 import Data.Domain (Domain)
 import Data.Id as Id
+import qualified Data.Map as Map
 import Data.Misc (PlainTextPassword (..))
-import Data.Qualified (Remote)
+import Data.Qualified (Qualified (qUnqualified), Remote, partitionQualified)
 import qualified Data.Set as Set
+import Data.Tagged (Tagged (unTagged))
 import qualified Data.Text.Lazy as LT
 import Data.Time
 import Galley.API.Error
@@ -48,6 +51,10 @@ import Network.Wai
 import Network.Wai.Predicate hiding (Error)
 import Network.Wai.Utilities
 import UnliftIO (concurrently)
+import qualified Wire.API.Federation.API.Brig as FederatedBrig
+import qualified Wire.API.Federation.Client as Federation
+import Wire.API.Federation.Error (federationErrorToWai)
+import qualified Wire.API.User as User
 
 type JSON = Media "application" "json"
 
@@ -131,9 +138,9 @@ ensureConvRoleNotElevated origMember targetRole = do
     (_, _) ->
       throwM (badRequest "Custom roles not supported")
 
--- | If a team memeber is not given throw 'notATeamMember'; if the given team
+-- | If a team member is not given throw 'notATeamMember'; if the given team
 -- member does not have the given permission, throw 'operationDenied'.
--- Otherwise, return unit.
+-- Otherwise, return the team member.
 permissionCheck :: (IsPerm perm, Show perm) => perm -> Maybe TeamMember -> Galley TeamMember
 permissionCheck p = \case
   Just m -> do
@@ -299,3 +306,24 @@ pushConversationEvent e users bots = do
 
 viewFederationDomain :: MonadReader Env m => m Domain
 viewFederationDomain = view (options . optSettings . setFederationDomain)
+
+checkRemoteUsersExist :: [Remote UserId] -> Galley ()
+checkRemoteUsersExist =
+  -- FUTUREWORK: pooledForConcurrentlyN_ instead of sequential checks per domain
+  traverse_ (uncurry checkRemotesFor)
+    . Map.assocs
+    . partitionQualified
+    . map unTagged
+
+checkRemotesFor :: Domain -> [UserId] -> Galley ()
+checkRemotesFor domain uids = do
+  let rpc = FederatedBrig.getUsersByIds FederatedBrig.clientRoutes uids
+  users <-
+    runExceptT (Federation.executeFederated domain rpc)
+      >>= either (throwM . federationErrorToWai) pure
+  let uids' =
+        map
+          (qUnqualified . User.profileQualifiedId)
+          (filter (not . User.profileDeleted) users)
+  unless (Set.fromList uids == Set.fromList uids') $
+    throwM unknownRemoteUser

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -574,7 +574,7 @@ createConversation ::
   Maybe (Range 1 256 Text) ->
   [Access] ->
   AccessRole ->
-  ConvSizeChecked [UserId] ->
+  ConvSizeChecked ([Remote UserId], [UserId]) ->
   Maybe ConvTeamInfo ->
   -- | Message timer
   Maybe Milliseconds ->
@@ -592,10 +592,8 @@ createConversation usr name acc role others tinfo mtimer recpt othersConversatio
       setConsistency Quorum
       addPrepQuery Cql.insertConv (conv, RegularConv, usr, Set (toList acc), role, fromRange <$> name, Just (cnvTeamId ti), mtimer, recpt)
       addPrepQuery Cql.insertTeamConv (cnvTeamId ti, conv, cnvManaged ti)
-  -- FUTUREWORK: split users into list of remote and local users
-  let remoteUsers :: [Remote UserId]
-      remoteUsers = []
-  (_, mems, rMems) <- addMembersUncheckedWithRole now conv (usr, roleNameWireAdmin) (toList $ list1 (usr, roleNameWireAdmin) ((,othersConversationRole) <$> fromConvSize others)) ((,othersConversationRole) <$> remoteUsers)
+  let (remoteUsers, localUsers) = fromConvSize others
+  (_, mems, rMems) <- addMembersUncheckedWithRole now conv (usr, roleNameWireAdmin) (toList $ list1 (usr, roleNameWireAdmin) ((,othersConversationRole) <$> localUsers)) ((,othersConversationRole) <$> remoteUsers)
   return $ newConv conv RegularConv usr mems rMems acc role name (cnvTeamId <$> tinfo) mtimer recpt
 
 createSelfConversation :: MonadClient m => UserId -> Maybe (Range 1 256 Text) -> m Conversation

--- a/services/galley/src/Galley/Validation.hs
+++ b/services/galley/src/Galley/Validation.hs
@@ -50,6 +50,7 @@ rangeCheckedMaybe (Just a) = Just <$> rangeChecked a
 
 -- Between 0 and (setMaxConvSize - 1)
 newtype ConvSizeChecked a = ConvSizeChecked {fromConvSize :: a}
+  deriving (Functor)
 
 -- Between 1 and setMaxConvSize
 data ConvMemberAddSizeChecked = ConvMemberAddSizeChecked {sizeCheckedLocals :: [(UserId, RoleName)], sizeCheckedRemotes :: [(Remote UserId, RoleName)]}

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -98,8 +98,14 @@ tests s =
           test s "fail to get >1000 conversation ids" getConvIdsFailMaxSize,
           test s "page through conversations" getConvsPagingOk,
           test s "fail to create conversation when not connected" postConvFailNotConnected,
+          test s "fail to create conversation with qualified users when not connected" postConvQualifiedFailNotConnected,
           test s "M:N conversation creation must have <N members" postConvFailNumMembers,
+          test s "M:N conversation creation must have <N qualified members" postConvQualifiedFailNumMembers,
           test s "fail to create conversation when blocked" postConvFailBlocked,
+          test s "fail to create conversation when blocked by qualified member" postConvQualifiedFailBlocked,
+          test s "fail to create conversation with remote users when remote user's domain doesn't exist" postConvQualifiedNonExistentDomain,
+          test s "fail to create conversation with remote users when remote user doesn't exist" postConvQualifiedNonExistentUser,
+          test s "fail to create conversation with remote users when federation not configured" postConvQualifiedFederationNotEnabled,
           test s "create self conversation" postSelfConvOk,
           test s "create 1:1 conversation" postO2OConvOk,
           test s "fail to create 1:1 conversation with yourself" postConvO2OFailWithSelf,
@@ -111,6 +117,7 @@ tests s =
           test s "repeat / cancel connect requests" postRepeatConnectConvCancel,
           test s "block/unblock a connect/1-1 conversation" putBlockConvOk,
           test s "get conversation" getConvOk,
+          test s "get qualified conversation" getConvQualifiedOk,
           test s "conversation meta access" accessConvMeta,
           test s "add members" postMembersOk,
           test s "add existing members" postMembersOk2,
@@ -644,6 +651,15 @@ postConvFailNotConnected = do
     const 403 === statusCode
     const (Just "not-connected") === fmap label . responseJsonUnsafe
 
+postConvQualifiedFailNotConnected :: TestM ()
+postConvQualifiedFailNotConnected = do
+  alice <- randomUser
+  bob <- randomQualifiedUser
+  jane <- randomQualifiedUser
+  postConvQualified alice [bob, jane] Nothing [] Nothing Nothing !!! do
+    const 403 === statusCode
+    const (Just "not-connected") === fmap label . responseJsonUnsafe
+
 postConvFailNumMembers :: TestM ()
 postConvFailNumMembers = do
   n <- fromIntegral <$> view tsMaxConvSize
@@ -651,6 +667,16 @@ postConvFailNumMembers = do
   bob : others <- replicateM n (randomUser)
   connectUsers alice (list1 bob others)
   postConv alice (bob : others) Nothing [] Nothing Nothing !!! do
+    const 400 === statusCode
+    const (Just "client-error") === fmap label . responseJsonUnsafe
+
+postConvQualifiedFailNumMembers :: TestM ()
+postConvQualifiedFailNumMembers = do
+  n <- fromIntegral <$> view tsMaxConvSize
+  alice <- randomUser
+  bob : others <- replicateM n randomQualifiedUser
+  connectLocalQualifiedUsers alice (list1 bob others)
+  postConvQualified alice (bob : others) Nothing [] Nothing Nothing !!! do
     const 400 === statusCode
     const (Just "client-error") === fmap label . responseJsonUnsafe
 
@@ -667,6 +693,67 @@ postConvFailBlocked = do
   postConv alice [bob, jane] Nothing [] Nothing Nothing !!! do
     const 403 === statusCode
     const (Just "not-connected") === fmap label . responseJsonUnsafe
+
+--- | If somebody has blocked a user, that user shouldn't be able to create a
+-- group conversation which includes them.
+postConvQualifiedFailBlocked :: TestM ()
+postConvQualifiedFailBlocked = do
+  alice <- randomUser
+  bob <- randomQualifiedUser
+  jane <- randomQualifiedUser
+  connectLocalQualifiedUsers alice (list1 bob [jane])
+  putConnectionQualified jane alice Blocked
+    !!! const 200 === statusCode
+  postConvQualified alice [bob, jane] Nothing [] Nothing Nothing !!! do
+    const 403 === statusCode
+    const (Just "not-connected") === fmap label . responseJsonUnsafe
+
+postConvQualifiedNonExistentDomain :: TestM ()
+postConvQualifiedNonExistentDomain = do
+  alice <- randomUser
+  bob <- flip Qualified (Domain "non-existent.example.com") <$> randomId
+  postConvQualified alice [bob] Nothing [] Nothing Nothing !!! do
+    const 422 === statusCode
+
+postConvQualifiedNonExistentUser :: TestM ()
+postConvQualifiedNonExistentUser = do
+  alice <- randomUser
+  bobId <- randomId
+  charlieId <- randomId
+  let remoteDomain = Domain "far-away.example.com"
+      bob = Qualified bobId remoteDomain
+      charlie = Qualified charlieId remoteDomain
+  opts <- view tsGConf
+  _g <- view tsGalley
+  (resp, _) <-
+    withTempMockFederator
+      opts
+      remoteDomain
+      (const [mkProfile charlie (Name "charlie")])
+      (postConvQualified alice [bob, charlie] (Just "remote gossip") [] Nothing Nothing)
+  liftIO $ do
+    statusCode resp @?= 400
+    let err = responseJsonUnsafe resp :: Object
+    (err ^. at "label") @?= Just "unknown-remote-user"
+
+postConvQualifiedFederationNotEnabled :: TestM ()
+postConvQualifiedFederationNotEnabled = do
+  g <- view tsGalley
+  alice <- randomUser
+  bob <- flip Qualified (Domain "some-remote-backend.example.com") <$> randomId
+  opts <- view tsGConf
+  let federatorNotConfigured :: Opts = opts & optFederator .~ Nothing
+  withSettingsOverrides federatorNotConfigured $
+    postConvHelper g alice [bob] !!! do
+      const 400 === statusCode
+      const (Just "federation-not-enabled") === fmap label . responseJsonUnsafe
+
+-- like postConvQualified
+-- FUTUREWORK: figure out how to use functions in the TestM monad inside withSettingsOverrides and remove this duplication
+postConvHelper :: (MonadIO m, MonadHttp m) => (Request -> Request) -> UserId -> [Qualified UserId] -> m ResponseLBS
+postConvHelper g zusr newUsers = do
+  let conv = NewConvUnmanaged $ NewConv [] newUsers (Just "gossip") (Set.fromList []) Nothing Nothing Nothing Nothing roleNameWireAdmin
+  post $ g . path "/conversations" . zUser zusr . zConn "conn" . zType "access" . json conv
 
 postSelfConvOk :: TestM ()
 postSelfConvOk = do
@@ -692,7 +779,7 @@ postConvO2OFailWithSelf :: TestM ()
 postConvO2OFailWithSelf = do
   g <- view tsGalley
   alice <- randomUser
-  let inv = NewConvUnmanaged (NewConv [alice] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin)
+  let inv = NewConvUnmanaged (NewConv [alice] [] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin)
   post (g . path "/conversations/one2one" . zUser alice . zConn "conn" . zType "access" . json inv) !!! do
     const 403 === statusCode
     const (Just "invalid-op") === fmap label . responseJsonUnsafe
@@ -852,6 +939,17 @@ getConvOk = do
   getConv alice conv !!! const 200 === statusCode
   getConv bob conv !!! const 200 === statusCode
   getConv chuck conv !!! const 200 === statusCode
+
+getConvQualifiedOk :: TestM ()
+getConvQualifiedOk = do
+  alice <- randomUser
+  bob <- randomQualifiedUser
+  chuck <- randomQualifiedUser
+  connectLocalQualifiedUsers alice (list1 bob [chuck])
+  conv <- decodeConvId <$> postConvQualified alice [bob, chuck] (Just "gossip") [] Nothing Nothing
+  getConv alice conv !!! const 200 === statusCode
+  getConv (qUnqualified bob) conv !!! const 200 === statusCode
+  getConv (qUnqualified chuck) conv !!! const 200 === statusCode
 
 accessConvMeta :: TestM ()
 accessConvMeta = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -888,12 +888,11 @@ testAddRemoteMember = do
   opts <- view tsGConf
   g <- view tsGalley
   (resp, _) <-
-    liftIO $
-      withTempMockFederator
-        opts
-        remoteDomain
-        (const [mkProfile remoteBob (Name "bob")])
-        (postQualifiedMembers' g alice (remoteBob :| []) convId)
+    withTempMockFederator
+      opts
+      remoteDomain
+      (const [mkProfile remoteBob (Name "bob")])
+      (postQualifiedMembers' g alice (remoteBob :| []) convId)
   e <- responseJsonUnsafe <$> (pure resp <!! const 200 === statusCode)
   liftIO $ do
     evtConv e @?= convId
@@ -936,12 +935,11 @@ testGetRemoteConversation = do
   opts <- view tsGConf
   g <- view tsGalley
   (resp, _) <-
-    liftIO $
-      withTempMockFederator
-        opts
-        remoteDomain
-        (const remoteConversationResponse)
-        (getConvQualified' g alice remoteConv)
+    withTempMockFederator
+      opts
+      remoteDomain
+      (const remoteConversationResponse)
+      (getConvQualified' g alice remoteConv)
   conv :: Conversation <- responseJsonUnsafe <$> (pure resp <!! const 200 === statusCode)
   liftIO $ do
     let actual = cmOthers $ cnvMembers conv
@@ -959,16 +957,15 @@ testAddRemoteMemberFailure = do
   convId <- decodeConvId <$> postConv alice [] (Just "remote gossip") [] Nothing Nothing
   opts <- view tsGConf
   g <- view tsGalley
-  liftIO $ do
-    (resp, _) <-
-      withTempMockFederator
-        opts
-        remoteDomain
-        (const [mkProfile remoteCharlie (Name "charlie")])
-        (postQualifiedMembers' g alice (remoteBob :| [remoteCharlie]) convId)
-    statusCode resp @?= 400
-    let err = responseJsonUnsafe resp :: Object
-    (err ^. at "label") @?= Just "unknown-remote-user"
+  (resp, _) <-
+    withTempMockFederator
+      opts
+      remoteDomain
+      (const [mkProfile remoteCharlie (Name "charlie")])
+      (postQualifiedMembers' g alice (remoteBob :| [remoteCharlie]) convId)
+  liftIO $ statusCode resp @?= 400
+  let err = responseJsonUnsafe resp :: Object
+  liftIO $ (err ^. at "label") @?= Just "unknown-remote-user"
 
 testAddDeletedRemoteUser :: TestM ()
 testAddDeletedRemoteUser = do
@@ -979,16 +976,15 @@ testAddDeletedRemoteUser = do
   convId <- decodeConvId <$> postConv alice [] (Just "remote gossip") [] Nothing Nothing
   opts <- view tsGConf
   g <- view tsGalley
-  liftIO $ do
-    (resp, _) <-
-      withTempMockFederator
-        opts
-        remoteDomain
-        (const [(mkProfile remoteBob (Name "bob")) {profileDeleted = True}])
-        (postQualifiedMembers' g alice (remoteBob :| []) convId)
-    statusCode resp @?= 400
-    let err = responseJsonUnsafe resp :: Object
-    (err ^. at "label") @?= Just "unknown-remote-user"
+  (resp, _) <-
+    withTempMockFederator
+      opts
+      remoteDomain
+      (const [(mkProfile remoteBob (Name "bob")) {profileDeleted = True}])
+      (postQualifiedMembers' g alice (remoteBob :| []) convId)
+  liftIO $ statusCode resp @?= 400
+  let err = responseJsonUnsafe resp :: Object
+  liftIO $ (err ^. at "label") @?= Just "unknown-remote-user"
 
 testAddRemoteMemberInvalidDomain :: TestM ()
 testAddRemoteMemberInvalidDomain = do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -880,7 +880,7 @@ testAddManagedConv = do
   let tinfo = ConvTeamInfo tid True
   let conv =
         NewConvManaged $
-          NewConv [owner] (Just "blah") (Set.fromList []) Nothing (Just tinfo) Nothing Nothing roleNameWireAdmin
+          NewConv [owner] [] (Just "blah") (Set.fromList []) Nothing (Just tinfo) Nothing Nothing roleNameWireAdmin
   post
     ( g
         . path "/conversations"

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -29,6 +29,7 @@ import qualified API.SQS as SQS
 import API.Util
 import Bilge hiding (accept, head, timeout, trace)
 import Bilge.Assert
+import qualified Bilge.TestSession as BilgeTest
 import Brig.Types.Client
 import Brig.Types.Intra (ConnectionStatus (ConnectionStatus), UserSet (..))
 import Brig.Types.Provider
@@ -71,12 +72,10 @@ import Galley.Types.Teams
 import Gundeck.Types.Notification (ntfPayload)
 import Imports
 import Network.HTTP.Types.Status (status200, status400, status404)
-import Network.Wai
 import Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.Warp.Internal as Warp
 import qualified Network.Wai.Handler.WarpTLS as Warp
-import qualified Network.Wai.Test as WaiTest
 import qualified Network.Wai.Utilities.Error as Error
 import qualified Network.Wai.Utilities.Response as Wai
 import System.IO (hPutStrLn)
@@ -1350,7 +1349,7 @@ withDummyTestServiceForTeamNoService go = do
 -- it's here for historical reason because we did this in galley.yaml
 -- at some point in the past rather than in an internal end-point, and that required spawning
 -- another galley 'Application' with 'withSettingsOverrides'.
-withLHWhitelist :: forall a. HasCallStack => TeamId -> WaiTest.Session a -> TestM a
+withLHWhitelist :: forall a. HasCallStack => TeamId -> BilgeTest.SessionT TestM a -> TestM a
 withLHWhitelist tid action = do
   void $ putLHWhitelistTeam tid
   opts <- view tsGConf

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -22,13 +22,13 @@ module API.Util where
 import qualified API.SQS as SQS
 import Bilge hiding (timeout)
 import Bilge.Assert
+import Bilge.TestSession
 import Brig.Types
 import Brig.Types.Intra (ConnectionStatus (ConnectionStatus), UserAccount (..), UserSet (..))
 import Brig.Types.Team.Invitation
 import Brig.Types.User.Auth (CookieLabel (..))
-import Control.Exception (finally)
 import Control.Lens hiding (from, to, (#), (.=))
-import Control.Monad.Catch (MonadCatch)
+import Control.Monad.Catch (MonadCatch, finally)
 import Control.Monad.Except (ExceptT, runExceptT)
 import Control.Retry (constantDelay, exponentialBackoff, limitRetries, retrying)
 import Data.Aeson hiding (json)
@@ -100,6 +100,16 @@ import qualified Wire.API.User.Client as Client
 
 -------------------------------------------------------------------------------
 -- API Operations
+
+-- | A class for monads with access to a Galley instance
+class HasGalley m where
+  viewGalley :: m GalleyR
+
+instance HasGalley TestM where
+  viewGalley = view tsGalley
+
+instance (HasGalley m, Monad m) => HasGalley (SessionT m) where
+  viewGalley = lift viewGalley
 
 symmPermissions :: [Perm] -> Permissions
 symmPermissions p = let s = Set.fromList p in fromJust (newPermissions s s)

--- a/services/galley/test/integration/API/Util/TeamFeature.hs
+++ b/services/galley/test/integration/API/Util/TeamFeature.hs
@@ -20,6 +20,7 @@ module API.Util.TeamFeature where
 import API.Util (zUser)
 import qualified API.Util as Util
 import Bilge
+import qualified Bilge.TestSession as BilgeTest
 import Control.Lens (view, (.~))
 import Data.Aeson (ToJSON)
 import Data.ByteString.Conversion (toByteString')
@@ -27,11 +28,10 @@ import Data.Id (TeamId, UserId)
 import Galley.Options (optSettings, setFeatureFlags)
 import Galley.Types.Teams
 import Imports
-import qualified Network.Wai.Test as WaiTest
 import TestSetup
 import qualified Wire.API.Team.Feature as Public
 
-withCustomSearchFeature :: FeatureTeamSearchVisibility -> WaiTest.Session () -> TestM ()
+withCustomSearchFeature :: FeatureTeamSearchVisibility -> BilgeTest.SessionT TestM () -> TestM ()
 withCustomSearchFeature flag action = do
   opts <- view tsGConf
   let opts' = opts & optSettings . setFeatureFlags . flagTeamSearchVisibility .~ flag


### PR DESCRIPTION
This adds remote users when creating a conversation. Note: several checks are still missing, as noted in a related funuction `addMembers`:

* A call must be made to the remote backend informing it that this user is now part of that conversation. Use 'updateConversationMemberships'.
-- that call should probably be made after inserting the conversation membership happens in this backend.
* Events should support remote / qualified users, too.

This PR supersedes PR #1528.