### PR TITLE
federator: rename Brig -> Service and add galley

### DIFF
--- a/charts/federator/templates/configmap.yaml
+++ b/charts/federator/templates/configmap.yaml
@@ -27,6 +27,10 @@ data:
       host: brig
       port: 8080
 
+    galley:
+      host: brig
+      port: 8080
+
     {{- with .Values.config }}
 
     logNetStrings: True # log using netstrings encoding:

--- a/charts/federator/templates/configmap.yaml
+++ b/charts/federator/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
       port: 8080
 
     galley:
-      host: brig
+      host: galley
       port: 8080
 
     {{- with .Values.config }}

--- a/charts/federator/templates/tests/configmap.yaml
+++ b/charts/federator/templates/tests/configmap.yaml
@@ -14,5 +14,5 @@ data:
       host: brig
       port: 8080
     galley:
-      host: brig
+      host: galley
       port: 8080

--- a/charts/federator/templates/tests/configmap.yaml
+++ b/charts/federator/templates/tests/configmap.yaml
@@ -13,4 +13,6 @@ data:
     brig:
       host: brig
       port: 8080
-
+    galley:
+      host: brig
+      port: 8080

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9838302126363c5c21222de184bbf831d238744bb2871b425aadee55a917b341
+-- hash: b7d470767dc3f1475b43b3914d7aa4572f00de52e59a396331bf20062d1e71fb
 
 name:           federator
 version:        1.0.0
@@ -19,7 +19,6 @@ build-type:     Simple
 library
   exposed-modules:
       Federator.App
-      Federator.Brig
       Federator.Discovery
       Federator.Env
       Federator.ExternalServer
@@ -27,6 +26,7 @@ library
       Federator.Options
       Federator.Remote
       Federator.Run
+      Federator.Service
       Federator.Utils.PolysemyServerError
       Federator.Validation
   other-modules:

--- a/services/federator/federator.integration.yaml
+++ b/services/federator/federator.integration.yaml
@@ -7,6 +7,9 @@ federatorExternal:
 brig:
   host: 0.0.0.0
   port: 8082
+galley:
+  host: 0.0.0.0
+  port: 8085
 
 logLevel: Debug
 logNetStrings: false

--- a/services/federator/src/Federator/Env.hs
+++ b/services/federator/src/Federator/Env.hs
@@ -28,7 +28,7 @@ import Federator.Options (RunSettings)
 import Network.DNS.Resolver (Resolver)
 import qualified Network.HTTP.Client as HTTP
 import qualified System.Logger.Class as LC
-import Util.Options
+import Wire.API.Federation.GRPC.Types
 
 data Env = Env
   { _metrics :: Metrics,
@@ -36,8 +36,7 @@ data Env = Env
     _requestId :: RequestId,
     _dnsResolver :: Resolver,
     _runSettings :: RunSettings,
-    _brig :: RPC.Request,
-    _brigEndpoint :: Endpoint,
+    _brig :: Component -> RPC.Request,
     _httpManager :: HTTP.Manager
   }
 

--- a/services/federator/src/Federator/Env.hs
+++ b/services/federator/src/Federator/Env.hs
@@ -36,7 +36,7 @@ data Env = Env
     _requestId :: RequestId,
     _dnsResolver :: Resolver,
     _runSettings :: RunSettings,
-    _brig :: Component -> RPC.Request,
+    _service :: Component -> RPC.Request,
     _httpManager :: HTTP.Manager
   }
 

--- a/services/federator/src/Federator/Options.hs
+++ b/services/federator/src/Federator/Options.hs
@@ -77,6 +77,8 @@ data Opts = Opts
     federatorExternal :: Endpoint,
     -- | Host and port of brig
     brig :: Endpoint,
+    -- | Host and port of galley
+    galley :: Endpoint,
     -- | Log level (Debug, Info, etc)
     logLevel :: Level,
     -- | Use netstrings encoding (see <http://cr.yp.to/proto/netstrings.txt>)

--- a/services/federator/src/Federator/Run.hs
+++ b/services/federator/src/Federator/Run.hs
@@ -51,6 +51,7 @@ import qualified System.Logger.Extended as LogExt
 import UnliftIO (bracket)
 import UnliftIO.Async (async, waitAnyCancel)
 import Util.Options
+import Wire.API.Federation.GRPC.Types
 import qualified Wire.Network.DNS.Helper as DNS
 
 ------------------------------------------------------------------------------
@@ -86,8 +87,8 @@ newEnv o _dnsResolver = do
   _applog <- LogExt.mkLogger (Opt.logLevel o) (Opt.logNetStrings o) (Opt.logFormat o)
   let _requestId = def
   let _runSettings = Opt.optSettings o
-  let _brig = mkEndpoint (Opt.brig o)
-  let _brigEndpoint = Opt.brig o
+  let _brig Brig = mkEndpoint (Opt.brig o)
+      _brig Galley = mkEndpoint (Opt.galley o)
   _httpManager <- initHttpManager
   return Env {..}
   where

--- a/services/federator/src/Federator/Run.hs
+++ b/services/federator/src/Federator/Run.hs
@@ -87,12 +87,12 @@ newEnv o _dnsResolver = do
   _applog <- LogExt.mkLogger (Opt.logLevel o) (Opt.logNetStrings o) (Opt.logFormat o)
   let _requestId = def
   let _runSettings = Opt.optSettings o
-  let _brig Brig = mkEndpoint (Opt.brig o)
-      _brig Galley = mkEndpoint (Opt.galley o)
+  let _service Brig = mkEndpoint (Opt.brig o)
+      _service Galley = mkEndpoint (Opt.galley o)
   _httpManager <- initHttpManager
   return Env {..}
   where
-    mkEndpoint service = RPC.host (encodeUtf8 (service ^. epHost)) . RPC.port (service ^. epPort) $ RPC.empty
+    mkEndpoint s = RPC.host (encodeUtf8 (s ^. epHost)) . RPC.port (s ^. epPort) $ RPC.empty
 
 closeEnv :: Env -> IO ()
 closeEnv e = do

--- a/services/federator/src/Federator/Service.hs
+++ b/services/federator/src/Federator/Service.hs
@@ -25,8 +25,9 @@ import Bilge.RPC (rpc')
 import Control.Lens (view)
 import Data.Domain
 import Data.String.Conversions (cs)
+import qualified Data.Text.Lazy as LText
 import Federator.App (Federator, liftAppIOToFederator)
-import Federator.Env (brig)
+import Federator.Env (service)
 import Imports
 import qualified Network.HTTP.Types as HTTP
 import Polysemy
@@ -52,9 +53,9 @@ interpretService ::
   Sem r a
 interpretService = interpret $ \case
   ServiceCall component path body domain -> embed @Federator . liftAppIOToFederator $ do
-    brigReq <- view brig <$> ask
+    serviceReq <- view service <$> ask
     res <-
-      rpc' "brig" (brigReq component) $
+      rpc' (LText.pack (show component)) (serviceReq component) $
         RPC.method HTTP.POST
           . RPC.path path -- FUTUREWORK(federation): Protect against arbitrary paths
           . RPC.body (RPC.RequestBodyBS body)

--- a/services/federator/test/unit/Test/Federator/ExternalServer.hs
+++ b/services/federator/test/unit/Test/Federator/ExternalServer.hs
@@ -51,11 +51,11 @@ requestBrigSuccess =
   testCase "should translate response from brig to 'InwardResponseBody' when response has status 200" $
     runM . evalMock @Service @IO $ do
       mockServiceCallReturns @IO (\_ _ _ _ -> pure (HTTP.ok200, Just "response body"))
-      let request = Request Brig "/users" "\"foo\"" exampleDomain
+      let request = Request Brig "/get-user-by-handle" "\"foo\"" exampleDomain
 
       res :: InwardResponse <- mock @Service @IO . noLogs . Polysemy.runReader allowAllSettings $ callLocal request
       actualCalls <- mockServiceCallCalls @IO
-      let expectedCall = (Brig, "/users", "\"foo\"", aValidDomain)
+      let expectedCall = (Brig, "/get-user-by-handle", "\"foo\"", aValidDomain)
       embed $ assertEqual "one call to brig should be made" [expectedCall] actualCalls
       embed $ assertEqual "response should be success with correct body" (InwardResponseBody "response body") res
 
@@ -64,12 +64,12 @@ requestBrigFailure =
   testCase "should translate response from brig to 'InwardResponseBody' when response has status 404" $
     runM . evalMock @Service @IO $ do
       mockServiceCallReturns @IO (\_ _ _ _ -> pure (HTTP.notFound404, Just "response body"))
-      let request = Request Brig "/users" "\"foo\"" exampleDomain
+      let request = Request Brig "/get-user-by-handle" "\"foo\"" exampleDomain
 
       res <- mock @Service @IO . noLogs . Polysemy.runReader allowAllSettings $ callLocal request
 
       actualCalls <- mockServiceCallCalls @IO
-      let expectedCall = (Brig, "/users", "\"foo\"", aValidDomain)
+      let expectedCall = (Brig, "/get-user-by-handle", "\"foo\"", aValidDomain)
       embed $ assertEqual "one call to brig should be made" [expectedCall] actualCalls
       embed $ assertEqual "response should be success with correct body" (InwardResponseErr "Invalid HTTP status from component: 404 Not Found") res
 
@@ -78,11 +78,11 @@ requestGalleySuccess =
   testCase "should translate response from galley to 'InwardResponseBody' when response has status 200" $
     runM . evalMock @Service @IO $ do
       mockServiceCallReturns @IO (\_ _ _ _ -> pure (HTTP.ok200, Just "response body"))
-      let request = Request Galley "/users" "\"foo\"" exampleDomain
+      let request = Request Galley "/get-conversations" "{}" exampleDomain
 
       res :: InwardResponse <- mock @Service @IO . noLogs . Polysemy.runReader allowAllSettings $ callLocal request
       actualCalls <- mockServiceCallCalls @IO
-      let expectedCall = (Galley, "/users", "\"foo\"", aValidDomain)
+      let expectedCall = (Galley, "/get-conversations", "{}", aValidDomain)
       embed $ assertEqual "one call to brig should be made" [expectedCall] actualCalls
       embed $ assertEqual "response should be success with correct body" (InwardResponseBody "response body") res
 


### PR DESCRIPTION
Federator is currently forwarding all its requests to brig, regardless of the value of the `Component` field. This PR adds support for arbitrary internal services, renames the `Brig` effect to `Service` to reflect its generalised function, and adds a configuration option for galley.
