### PR TITLE
Legalhold: Remove caching for whitelisted teams

### DIFF
--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -38,7 +38,7 @@ import Data.String.Conversions (cs)
 import qualified Galley.API.Clients as Clients
 import qualified Galley.API.Create as Create
 import qualified Galley.API.CustomBackend as CustomBackend
-import Galley.API.LegalHold (getLegalholdWhitelistedTeamsH, setTeamLegalholdWhitelistedH, unsetTeamLegalholdWhitelistedH)
+import Galley.API.LegalHold (getTeamLegalholdWhitelistedH, setTeamLegalholdWhitelistedH, unsetTeamLegalholdWhitelistedH)
 import qualified Galley.API.Query as Query
 import Galley.API.Teams (uncheckedDeleteTeamMember)
 import qualified Galley.API.Teams as Teams
@@ -274,13 +274,13 @@ sitemap = do
     jsonRequest @GuardLegalholdPolicyConflicts
       .&. accept "application" "json"
 
-  get "/i/legalhold/whitelisted-teams" (continue getLegalholdWhitelistedTeamsH) $
-    accept "application" "json"
-
   put "/i/legalhold/whitelisted-teams/:tid" (continue setTeamLegalholdWhitelistedH) $
     capture "tid"
 
   delete "/i/legalhold/whitelisted-teams/:tid" (continue unsetTeamLegalholdWhitelistedH) $
+    capture "tid"
+
+  get "/i/legalhold/whitelisted-teams/:tid" (continue getTeamLegalholdWhitelistedH) $
     capture "tid"
 
 rmUserH :: UserId ::: Maybe ConnId -> Galley Response

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -49,6 +49,7 @@ import Galley.API.Error
 import Galley.API.Util
 import Galley.App
 import qualified Galley.Data as Data
+import Galley.Data.LegalHold (isTeamLegalholdWhitelisted)
 import qualified Galley.Data.LegalHold as LegalHoldData
 import qualified Galley.Data.TeamFeatures as TeamFeatures
 import qualified Galley.External.LegalHoldService as LHService
@@ -82,7 +83,7 @@ isLegalHoldEnabledForTeam tid = do
         Just Public.TeamFeatureDisabled -> False
         Nothing -> False
     FeatureLegalHoldWhitelistTeamsAndImplicitConsent ->
-      isLegalHoldEnabledForTeam tid
+      isTeamLegalholdWhitelisted tid
 
 createSettingsH :: UserId ::: TeamId ::: JsonRequest Public.NewLegalHoldService ::: JSON -> Galley Response
 createSettingsH (zusr ::: tid ::: req ::: _) = do

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -468,8 +468,8 @@ unsetTeamLegalholdWhitelistedH tid = do
 
 getTeamLegalholdWhitelistedH :: TeamId -> Galley Response
 getTeamLegalholdWhitelistedH tid = do
-  lhEnabled <- isLegalHoldEnabledForTeam tid
+  lhEnabled <- isTeamLegalholdWhitelisted tid
   pure $
     if lhEnabled
-      then setStatus status204 empty
+      then setStatus status200 empty
       else setStatus status404 empty

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -399,12 +399,6 @@ updateUserLegalHoldStatus =
           where team = ? and user = ?
     |]
 
-selectLegalHoldWhitelistedTeams :: PrepQuery R () (Identity TeamId)
-selectLegalHoldWhitelistedTeams =
-  [r|
-        select team from legalhold_whitelisted
-    |]
-
 selectLegalHoldWhitelistedTeam :: PrepQuery R (Identity TeamId) (Identity TeamId)
 selectLegalHoldWhitelistedTeam =
   [r|


### PR DESCRIPTION
Follow up from #1557. This removes the full-table scan strategy and adds a whitelist query on every team member lookup.

This PR also removes the internal endpoint
`GET /i/legalhold/whitelisted-teams`
and introduces a new internal endpoint
`GET /i/legalhold/whitelisted-teams/:tid"` (200 if the team is whitelisted, otherwise 404)