### PR TITLE
Import http2 fix

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -230,7 +230,8 @@ extra-deps:
     - http2-client-grpc
 
 # Fix in for issue #27: https://github.com/kazu-yamamoto/http2/issues/27
-# Note: the patch is based on version 2.0.6 of http2
+# PR here: https://github.com/kazu-yamamoto/http2/pull/28
+# Note: the commit used here is based on version 2.0.6 of http2
 - git: https://github.com/wireapp/http2 # (2021-06-09) branch: header-encoding-0-size-table-backport
   commit: 7c465be1201e0945b106f7cc6176ac1b1193be13
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -229,6 +229,11 @@ extra-deps:
   subdirs:
     - http2-client-grpc
 
+# Fix in branch header-encoding-0-size-table-backport for issue #27
+# Note: the patch for #27 is based on version 2.0.6 of http2
+- git: https://github.com/wireapp/http2
+  commit: 7c465be1201e0945b106f7cc6176ac1b1193be13
+
 ############################################################
 # Development tools
 ############################################################

--- a/stack.yaml
+++ b/stack.yaml
@@ -229,7 +229,7 @@ extra-deps:
   subdirs:
     - http2-client-grpc
 
-# Fix in for issue #27
+# Fix in for issue #27: https://github.com/kazu-yamamoto/http2/issues/27
 # Note: the patch is based on version 2.0.6 of http2
 - git: https://github.com/wireapp/http2 # (2021-06-09) branch: header-encoding-0-size-table-backport
   commit: 7c465be1201e0945b106f7cc6176ac1b1193be13

--- a/stack.yaml
+++ b/stack.yaml
@@ -229,9 +229,9 @@ extra-deps:
   subdirs:
     - http2-client-grpc
 
-# Fix in branch header-encoding-0-size-table-backport for issue #27
-# Note: the patch for #27 is based on version 2.0.6 of http2
-- git: https://github.com/wireapp/http2
+# Fix in for issue #27
+# Note: the patch is based on version 2.0.6 of http2
+- git: https://github.com/wireapp/http2 # (2021-06-09) branch: header-encoding-0-size-table-backport
   commit: 7c465be1201e0945b106f7cc6176ac1b1193be13
 
 ############################################################

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -768,6 +768,17 @@ packages:
     git: https://github.com/akshaymankar/http2-grpc-haskell
     commit: 43507d54515cd5870e8f6d1f03b4d23e6cd460e2
 - completed:
+    name: http2
+    version: 2.0.6
+    git: https://github.com/wireapp/http2
+    pantry-tree:
+      size: 51601
+      sha256: 0a048cf85ab9614f2da80e3a8cf72ee7674cecea86b37a5e56011add73e5fa03
+    commit: 7c465be1201e0945b106f7cc6176ac1b1193be13
+  original:
+    git: https://github.com/wireapp/http2
+    commit: 7c465be1201e0945b106f7cc6176ac1b1193be13
+- completed:
     hackage: ormolu-0.1.4.1@sha256:ed404eac6e4eb64da1ca5fb749e0f99907431a9633e6ba34e44d260e7d7728ba,6499
     pantry-tree:
       size: 74141


### PR DESCRIPTION
This should fix the issue we were experiencing with end2end tests randomly failing on CI. The underlying problem is that the nginx controller proxying the federator uses an HTTP2 feature which was implemented incorrectly in the http2 library, which we indirectly depend on. See https://github.com/kazu-yamamoto/http2/issues/27.

This imports a [fix from our fork](https://github.com/wireapp/http2/tree/header-encoding-0-size-table-backport) into our stackage snapshot.