### PR TITLE
Servantify Protobuf endpoint to send messages

### DIFF
--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -25,6 +25,7 @@ library:
   - case-insensitive
   - cassandra-util
   - cassava >= 0.5
+  - cereal
   - cookie
   - cryptonite
   - currency-codes >=2.0

--- a/libs/wire-api/src/Wire/API/Message/Proto.hs
+++ b/libs/wire-api/src/Wire/API/Message/Proto.hs
@@ -35,11 +35,7 @@ module Wire.API.Message.Proto
     userEntry,
     userEntryId,
     userEntryClients,
-    toOtrRecipients,
-    fromOtrRecipients,
     Priority (..),
-    toPriority,
-    fromPriority,
     NewOtrMessage,
     newOtrMessage,
     newOtrMessageSender,
@@ -49,21 +45,14 @@ module Wire.API.Message.Proto
     newOtrMessageData,
     newOtrMessageTransient,
     newOtrMessageReportMissing,
-    toNewOtrMessage,
   )
 where
 
-import Control.Lens (view)
-import qualified Data.ByteString.Base64 as B64
 import qualified Data.Id as Id
-import qualified Data.Map.Strict as Map
 import Data.ProtocolBuffers
-import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import qualified Data.Text.Lazy as Text
 import Data.Text.Lazy.Read (hexadecimal)
 import Imports
-import qualified Wire.API.Message as Msg
-import qualified Wire.API.User.Client as Client
 
 --------------------------------------------------------------------------------
 -- UserId
@@ -163,32 +152,6 @@ userEntryId f c = (\x -> c {_userId = x}) <$> field f (_userId c)
 userEntryClients :: Functor f => ([ClientEntry] -> f [ClientEntry]) -> UserEntry -> f UserEntry
 userEntryClients f c = (\x -> c {_userVal = x}) <$> field f (_userVal c)
 
-toOtrRecipients :: [UserEntry] -> Msg.OtrRecipients
-toOtrRecipients =
-  Msg.OtrRecipients . Client.UserClientMap
-    . foldl' userEntries mempty
-  where
-    userEntries :: Map Id.UserId (Map Id.ClientId Text) -> UserEntry -> Map Id.UserId (Map Id.ClientId Text)
-    userEntries acc x =
-      let u = view userEntryId x
-          c = view userEntryClients x
-          m = foldl' clientEntries mempty c
-       in Map.insert (view userId u) m acc
-    clientEntries acc x =
-      let c = toClientId $ view clientEntryId x
-          t = toBase64Text $ view clientEntryMessage x
-       in Map.insert c t acc
-
-fromOtrRecipients :: Msg.OtrRecipients -> [UserEntry]
-fromOtrRecipients rcps =
-  let m = Client.userClientMap (Msg.otrRecipientsMap rcps)
-   in map mkProtoRecipient (Map.toList m)
-  where
-    mkProtoRecipient (usr, clts) =
-      let xs = map mkClientEntry (Map.toList clts)
-       in UserEntry (putField (fromUserId usr)) (putField xs)
-    mkClientEntry (clt, t) = clientEntry (fromClientId clt) (fromBase64Text t)
-
 --------------------------------------------------------------------------------
 -- Priority
 
@@ -210,14 +173,6 @@ instance Enum Priority where
 instance Bounded Priority where
   minBound = LowPriority
   maxBound = HighPriority
-
-toPriority :: Priority -> Msg.Priority
-toPriority LowPriority = Msg.LowPriority
-toPriority HighPriority = Msg.HighPriority
-
-fromPriority :: Msg.Priority -> Priority
-fromPriority Msg.LowPriority = LowPriority
-fromPriority Msg.HighPriority = HighPriority
 
 --------------------------------------------------------------------------------
 -- NewOtrMessage
@@ -273,28 +228,3 @@ newOtrMessageNativePriority f c = (\x -> c {_newOtrNativePriority = x}) <$> fiel
 
 newOtrMessageReportMissing :: Functor f => ([UserId] -> f [UserId]) -> NewOtrMessage -> f NewOtrMessage
 newOtrMessageReportMissing f c = (\x -> c {_newOtrReportMissing = x}) <$> field f (_newOtrReportMissing c)
-
-toNewOtrMessage :: NewOtrMessage -> Msg.NewOtrMessage
-toNewOtrMessage msg =
-  Msg.NewOtrMessage
-    { Msg.newOtrSender = toClientId (view newOtrMessageSender msg),
-      Msg.newOtrRecipients = toOtrRecipients (view newOtrMessageRecipients msg),
-      Msg.newOtrNativePush = view newOtrMessageNativePush msg,
-      Msg.newOtrTransient = view newOtrMessageTransient msg,
-      Msg.newOtrData = toBase64Text <$> view newOtrMessageData msg,
-      Msg.newOtrNativePriority = toPriority <$> view newOtrMessageNativePriority msg,
-      Msg.newOtrReportMissing = toReportMissing $ view newOtrMessageReportMissing msg
-    }
-
-toReportMissing :: [UserId] -> Maybe [Id.UserId]
-toReportMissing [] = Nothing
-toReportMissing us = Just $ view userId <$> us
-
---------------------------------------------------------------------------------
--- Utilities
-
-fromBase64Text :: Text -> ByteString
-fromBase64Text = B64.decodeLenient . encodeUtf8
-
-toBase64Text :: ByteString -> Text
-toBase64Text = decodeUtf8 . B64.encode

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -37,6 +37,7 @@ import Wire.API.ErrorDescription (ConversationNotFound, UnknownClient)
 import qualified Wire.API.Event.Conversation as Public
 import qualified Wire.API.Message as Public
 import Wire.API.Routes.Public (EmptyResult, ZConn, ZUser)
+import Wire.API.ServantProto (Proto)
 import qualified Wire.API.Team.Conversation as Public
 
 type ConversationResponses =
@@ -224,7 +225,7 @@ data Api routes = Api
         :> Delete '[] (EmptyResult 200),
     postOtrMessage ::
       routes
-        :- Summary "Post an encrypted message to a conversation (accepts JSON)"
+        :- Summary "Post an encrypted message to a conversation (accepts JSON or Protobuf)"
         :> Description PostOtrDescription
         :> ZUser
         :> ZConn
@@ -234,7 +235,7 @@ data Api routes = Api
         :> QueryParam "report_missing" Public.ReportMissing
         :> "otr"
         :> "messages"
-        :> ReqBody '[Servant.JSON] Public.NewOtrMessage
+        :> ReqBody '[Servant.JSON, Proto] Public.NewOtrMessage
         :> UVerb 'POST '[Servant.JSON] PostOtrResponses
   }
   deriving (Generic)
@@ -260,7 +261,9 @@ type PostOtrDescription =
   \- `ignore_missing` in the query param is the next.\n\
   \- `report_missing` in the query param has the lowest precedence.\n\
   \\n\
-  \This endpoint can lead to OtrMessageAdd event being sent to the recipients."
+  \This endpoint can lead to OtrMessageAdd event being sent to the recipients.\n\
+  \\n\
+  \**NOTE:** The protobuf definitions of the request body can be found at https://github.com/wireapp/generic-message-proto/blob/master/proto/otr.proto."
 
 swaggerDoc :: Swagger.Swagger
 swaggerDoc = toSwagger (Proxy @ServantAPI)

--- a/libs/wire-api/src/Wire/API/ServantProto.hs
+++ b/libs/wire-api/src/Wire/API/ServantProto.hs
@@ -1,9 +1,9 @@
 module Wire.API.ServantProto where
 
-import Servant
+import Data.List.NonEmpty (NonEmpty (..))
 import Imports
 import Network.HTTP.Media ((//))
-import Data.List.NonEmpty (NonEmpty(..))
+import Servant
 
 -- | Type to tell servant that it should unrender request body or render
 -- response body with Protobuf

--- a/libs/wire-api/src/Wire/API/ServantProto.hs
+++ b/libs/wire-api/src/Wire/API/ServantProto.hs
@@ -1,0 +1,25 @@
+module Wire.API.ServantProto where
+
+import Servant
+import Imports
+import Network.HTTP.Media ((//))
+import Data.List.NonEmpty (NonEmpty(..))
+
+-- | Type to tell servant that it should unrender request body or render
+-- response body with Protobuf
+data Proto
+
+-- | We do not use 'Data.ProtocolBuffers.Decode' so we get a little freedom in
+-- defining separate data types which match one to one with the protobuf and the
+-- data types which we actually use in business logic. Eventually we should
+-- think of better ways of doing this, perhaps using mu-schema or proto-lens as
+-- it is fairly difficult to keep our custom data type, e.g. in
+-- Wire.API.Message.Proto in sync with the proto files.
+class FromProto a where
+  fromProto :: LByteString -> Either String a
+
+instance Accept Proto where
+  contentTypes _ = ("application" // "x-protobuf") :| []
+
+instance FromProto a => MimeUnrender Proto a where
+  mimeUnrender _ bs = fromProto bs

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9404af483be016a508ad4a9919330394d673e725945662da3786fe94eb0785e1
+-- hash: c86173e7b15d84b4e33d4f6faa9f1445031dc2d669e52f7f49ccf9f74571beaf
 
 name:           wire-api
 version:        0.1.0
@@ -52,6 +52,7 @@ library
       Wire.API.Routes.Public.Galley
       Wire.API.Routes.Public.LegalHold
       Wire.API.Routes.Public.Spar
+      Wire.API.ServantProto
       Wire.API.Swagger
       Wire.API.Team
       Wire.API.Team.Conversation
@@ -100,6 +101,7 @@ library
     , case-insensitive
     , cassandra-util
     , cassava >=0.5
+    , cereal
     , containers >=0.5
     , cookie
     , cryptonite

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -771,42 +771,6 @@ sitemap = do
 
   -- This endpoint can lead to the following events being sent:
   -- - OtrMessageAdd event to recipients
-  post "/conversations/:cnv/otr/messages" (continue Update.postProtoOtrMessageH) $
-    zauthUserId
-      .&. zauthConnId
-      .&. capture "cnv"
-      .&. def Public.OtrReportAllMissing filterMissing
-      .&. request
-      .&. contentType "application" "x-protobuf"
-  document "POST" "postProtoOtrMessage" $ do
-    summary "Post an encrypted message to a conversation (accepts Protobuf)"
-    parameter Path "cnv" bytes' $
-      description "Conversation ID"
-    parameter Query "ignore_missing" bool' $ do
-      description
-        "Force message delivery even when clients are missing. \
-        \NOTE: can also be a comma-separated list of user IDs, \
-        \in which case it specifies who exactly is allowed to \
-        \have missing clients."
-      optional
-    parameter Query "report_missing" bool' $ do
-      description
-        "Don't allow message delivery when clients are missing \
-        \('ignore_missing' takes precedence when present). \
-        \NOTE: can also be a comma-separated list of user IDs, \
-        \in which case it specifies who exactly is forbidden from \
-        \having missing clients."
-      optional
-    body (ref Public.modelNewOtrMessage) $
-      description "Protobuf body"
-    returns (ref Public.modelClientMismatch)
-    response 201 "Message posted" end
-    response 412 "Missing clients" end
-    errorResponse Error.convNotFound
-    errorResponse Error.unknownClient
-
-  -- This endpoint can lead to the following events being sent:
-  -- - OtrMessageAdd event to recipients
   post "/broadcast/otr/messages" (continue Update.postOtrBroadcastH) $
     zauthUserId
       .&. zauthConnId

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -44,7 +44,6 @@ module Galley.API.Update
 
     -- * Talking
     postOtrMessage,
-    postProtoOtrMessageH,
     postOtrBroadcastH,
     postProtoOtrBroadcastH,
     isTypingH,
@@ -639,12 +638,6 @@ legalholdProtectee'2UserId (UnprotectedBot' uid) = uid
 postBotMessage :: BotId -> ConvId -> Public.OtrFilterMissing -> Public.NewOtrMessage -> Galley OtrResult
 postBotMessage zbot zcnv val message = do
   postNewOtrMessage (UnprotectedBot' $ botUserId zbot) Nothing zcnv val message
-
-postProtoOtrMessageH :: UserId ::: ConnId ::: ConvId ::: Public.OtrFilterMissing ::: Request ::: Media "application" "x-protobuf" -> Galley Response
-postProtoOtrMessageH (zusr ::: zcon ::: cnv ::: val ::: req ::: _) = do
-  message <- Public.protoToNewOtrMessage <$> fromProtoBody req
-  let val' = allowOtrFilterMissingInBody val message
-  handleOtrResult =<< postNewOtrMessage (ProtectedUser' zusr) (Just zcon) cnv val' message
 
 postOtrMessage :: UserId -> ConnId -> ConvId -> Maybe Public.IgnoreMissing -> Maybe Public.ReportMissing -> Public.NewOtrMessage -> Galley (Union GalleyAPI.PostOtrResponses)
 postOtrMessage zusr zcon cnv ignoreMissing reportMissing message = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -116,7 +116,6 @@ import qualified Wire.API.Conversation.Code as Public
 import qualified Wire.API.ErrorDescription as Public
 import qualified Wire.API.Event.Conversation as Public
 import qualified Wire.API.Message as Public
-import qualified Wire.API.Message.Proto as Proto
 import Wire.API.Routes.Public.Galley (UpdateResponses)
 import qualified Wire.API.Routes.Public.Galley as GalleyAPI
 import Wire.API.Team.LegalHold (LegalholdProtectee (..))
@@ -643,7 +642,7 @@ postBotMessage zbot zcnv val message = do
 
 postProtoOtrMessageH :: UserId ::: ConnId ::: ConvId ::: Public.OtrFilterMissing ::: Request ::: Media "application" "x-protobuf" -> Galley Response
 postProtoOtrMessageH (zusr ::: zcon ::: cnv ::: val ::: req ::: _) = do
-  message <- Proto.toNewOtrMessage <$> fromProtoBody req
+  message <- Public.protoToNewOtrMessage <$> fromProtoBody req
   let val' = allowOtrFilterMissingInBody val message
   handleOtrResult =<< postNewOtrMessage (ProtectedUser' zusr) (Just zcon) cnv val' message
 
@@ -668,7 +667,7 @@ postOtrMessage zusr zcon cnv ignoreMissing reportMissing message = do
 
 postProtoOtrBroadcastH :: UserId ::: ConnId ::: Public.OtrFilterMissing ::: Request ::: JSON -> Galley Response
 postProtoOtrBroadcastH (zusr ::: zcon ::: val ::: req ::: _) = do
-  message <- Proto.toNewOtrMessage <$> fromProtoBody req
+  message <- Public.protoToNewOtrMessage <$> fromProtoBody req
   let val' = allowOtrFilterMissingInBody val message
   handleOtrResult =<< postOtrBroadcast zusr zcon val' message
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -96,6 +96,7 @@ import qualified Wire.API.Event.Team as TE
 import Wire.API.Federation.GRPC.Types (FederatedRequest, OutwardResponse (..))
 import qualified Wire.API.Federation.Mock as Mock
 import qualified Wire.API.Message.Proto as Proto
+import qualified Wire.API.Message as Message
 import Wire.API.User.Client (ClientCapability (..), UserClientsFull (UserClientsFull))
 import qualified Wire.API.User.Client as Client
 
@@ -684,7 +685,7 @@ postProtoOtrBroadcast' reportMissing modif u d rec = do
 
 mkOtrProtoMessage :: ClientId -> OtrRecipients -> Maybe [UserId] -> Proto.NewOtrMessage
 mkOtrProtoMessage sender rec reportMissing =
-  let rcps = Proto.fromOtrRecipients rec
+  let rcps = Message.protoFromOtrRecipients rec
       sndr = Proto.fromClientId sender
       rmis = Proto.fromUserId <$> fromMaybe [] reportMissing
    in Proto.newOtrMessage sndr rcps

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -95,8 +95,8 @@ import Wire.API.Conversation.Member (Member (..))
 import qualified Wire.API.Event.Team as TE
 import Wire.API.Federation.GRPC.Types (FederatedRequest, OutwardResponse (..))
 import qualified Wire.API.Federation.Mock as Mock
-import qualified Wire.API.Message.Proto as Proto
 import qualified Wire.API.Message as Message
+import qualified Wire.API.Message.Proto as Proto
 import Wire.API.User.Client (ClientCapability (..), UserClientsFull (UserClientsFull))
 import qualified Wire.API.User.Client as Client
 


### PR DESCRIPTION
Changes:
- Introduce `Wire.API.ServantProto.Proto` to express that an endpoint can accept or respond with protobuf
- Make `Wire.API.Message` depend on `Wire.API.Message.Proto` so that an instance of `FromProto Wire.API.Message.NewOtrMessage` can be written in `Wire.API.Message` module. This required moving some functions around.
- Delete unused code in galley