### PR TITLE
end2end test getting remote conversation and complete its implementation

### DIFF
--- a/charts/brig/templates/tests/configmap.yaml
+++ b/charts/brig/templates/tests/configmap.yaml
@@ -61,6 +61,10 @@ data:
         host: brig.{{ .Release.Namespace }}-fed2.svc.cluster.local
         port: 8080
 
+      galley:
+        host: galley.{{ .Release.Namespace }}-fed2.svc.cluster.local
+        port: 8080
+
       # TODO remove this
       federator:
         host: federator.{{ .Release.Namespace }}-fed2.svc.cluster.local

--- a/libs/wire-api/src/Wire/API/Conversation/Member.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Member.hs
@@ -90,6 +90,7 @@ modelConversationMembers = Doc.defineModel "ConversationMembers" $ do
 --------------------------------------------------------------------------------
 -- Members
 
+-- FUTUREWORK: Add a qualified Id here.
 data Member = Member
   { memId :: UserId,
     memService :: Maybe ServiceRef,

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -63,6 +63,7 @@ import Util.Test
 
 data BackendConf = BackendConf
   { remoteBrig :: Endpoint,
+    remoteGalley :: Endpoint,
     remoteFederatorInternal :: Endpoint,
     remoteFederatorExternal :: Endpoint
   }
@@ -72,6 +73,7 @@ instance FromJSON BackendConf where
   parseJSON = withObject "BackendConf" $ \o ->
     BackendConf
       <$> o .: "brig"
+      <*> o .: "galley"
       <*> o .: "federatorInternal"
       <*> o .: "federatorExternal"
 
@@ -105,6 +107,7 @@ runTests iConf brigOpts otherArgs = do
       s = mkRequest $ spar iConf
       f = federatorInternal iConf
       brigTwo = mkRequest $ remoteBrig (backendTwo iConf)
+      galleyTwo = mkRequest $ remoteGalley (backendTwo iConf)
 
   let turnFile = Opts.servers . Opts.turn $ brigOpts
       turnFileV2 = (Opts.serversV2 . Opts.turn) brigOpts
@@ -129,7 +132,7 @@ runTests iConf brigOpts otherArgs = do
   createIndex <- Index.Create.spec brigOpts
   browseTeam <- TeamUserSearch.tests brigOpts mg g b
   userPendingActivation <- UserPendingActivation.tests brigOpts mg db b g s
-  federationEnd2End <- Federation.End2end.spec brigOpts mg b g f brigTwo
+  federationEnd2End <- Federation.End2end.spec brigOpts mg b g f brigTwo galleyTwo
   federationEndpoints <- API.Federation.tests mg b fedBrigClient
   includeFederationTests <- (== Just "1") <$> Blank.getEnv "INTEGRATION_FEDERATION_TESTS"
   internalApi <- API.Internal.tests brigOpts mg b (brig iConf) gd

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 63f50e23b5853d8dd4b8b87b8588dc8499783ec5e7e72a181b0ccb399089a6ed
+-- hash: 9fb2b9ba716dce4ffe27891b8718f10b22ca443bf73c84744b150c53aae5a5c1
 
 name:           galley
 version:        0.83.0
@@ -377,6 +377,7 @@ test-suite galley-types-tests
   other-modules:
       Test.Galley.API
       Test.Galley.Intra.User
+      Test.Galley.Mapping
       Test.Galley.Roundtrip
       Paths_galley
   hs-source-dirs:

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -40,8 +40,10 @@ federationSitemap =
 
 getConversations :: GetConversationsRequest -> Galley GetConversationsResponse
 getConversations (GetConversationsRequest qUid gcrConvIds) = do
+  domain <- viewFederationDomain
   convs <- Data.conversations gcrConvIds
-  GetConversationsResponse . catMaybes <$> for convs (Mapping.conversationViewMaybeQualified qUid)
+  let convViews = Mapping.conversationViewMaybeQualified domain qUid <$> convs
+  pure $ GetConversationsResponse . catMaybes $ convViews
 
 -- FUTUREWORK: also remove users from conversation
 updateConversationMemberships :: ConversationMemberUpdate -> Galley ()

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -39,12 +39,9 @@ federationSitemap =
       }
 
 getConversations :: GetConversationsRequest -> Galley GetConversationsResponse
-getConversations (GetConversationsRequest (Qualified uid domain) gcrConvIds) = do
-  localDomain <- viewFederationDomain
+getConversations (GetConversationsRequest qUid gcrConvIds) = do
   convs <- Data.conversations gcrConvIds
-  if domain == localDomain
-    then GetConversationsResponse . catMaybes <$> for convs (Mapping.conversationViewMaybe uid)
-    else error "FUTUREWORK: implement & exstend integration test when schema ready"
+  GetConversationsResponse . catMaybes <$> for convs (Mapping.conversationViewMaybeQualified qUid)
 
 -- FUTUREWORK: also remove users from conversation
 updateConversationMemberships :: ConversationMemberUpdate -> Galley ()

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -56,12 +56,12 @@ conversationView uid conv = do
 conversationViewMaybe :: UserId -> Data.Conversation -> Galley (Maybe Public.Conversation)
 conversationViewMaybe u conv = do
   domain <- viewFederationDomain
-  conversationViewMaybe' (Qualified u domain) conv
+  conversationViewMaybeQualified (Qualified u domain) conv
 
 -- | View for a given user of a stored conversation.
 -- Returns 'Nothing' when the user is not part of the conversation.
-conversationViewMaybe' :: Qualified UserId -> Data.Conversation -> Galley (Maybe Public.Conversation)
-conversationViewMaybe' qUid Data.Conversation {..} = do
+conversationViewMaybeQualified :: Qualified UserId -> Data.Conversation -> Galley (Maybe Public.Conversation)
+conversationViewMaybeQualified qUid Data.Conversation {..} = do
   domain <- viewFederationDomain
   let localMembers = localToOther domain <$> convLocalMembers
   let remoteMembers = remoteToOther <$> convRemoteMembers

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -23,7 +23,7 @@ import Control.Monad.Catch
 import Data.Domain (Domain)
 import Data.Id (UserId, idToText)
 import qualified Data.List as List
-import Data.Qualified (Qualified (Qualified, qDomain, qUnqualified))
+import Data.Qualified (Qualified (..))
 import Data.Tagged (unTagged)
 import Galley.API.Util (viewFederationDomain)
 import Galley.App

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1029,11 +1029,11 @@ testAddRemoteMember = do
           ]
 
   e <- responseJsonUnsafe <$> (pure resp <!! const 200 === statusCode)
+  let bobMember = SimpleMember remoteBob roleNameWireAdmin
   liftIO $ do
     evtConv e @?= qconvId
     evtType e @?= MemberJoin
-    -- FUTUREWORK: implement returning remote users in the event.
-    -- evtData e @?= Just (EdMembersJoin (SimpleMembers [remoteBob]))
+    evtData e @?= EdMembersJoin (SimpleMembers [bobMember])
     evtFrom e @?= qalice
   conv <- responseJsonUnsafeWithMsg "conversation" <$> getConvQualified alice qconvId
   liftIO $ do

--- a/services/galley/test/unit/Main.hs
+++ b/services/galley/test/unit/Main.hs
@@ -23,6 +23,7 @@ where
 import Imports
 import qualified Test.Galley.API
 import qualified Test.Galley.Intra.User
+import qualified Test.Galley.Mapping
 import qualified Test.Galley.Roundtrip
 import Test.Tasty
 
@@ -32,5 +33,6 @@ main =
     =<< sequence
       [ pure Test.Galley.API.tests,
         pure Test.Galley.Intra.User.tests,
+        pure Test.Galley.Mapping.tests,
         Test.Galley.Roundtrip.tests
       ]

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -1,0 +1,209 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Galley.Mapping where
+
+import Data.Domain
+import Data.Id
+import Data.Qualified
+import Galley.API ()
+import Galley.API.Mapping
+import qualified Galley.Data as Data
+-- import Galley.Types
+
+import Galley.Types (LocalMember, RemoteMember)
+import qualified Galley.Types.Conversations.Members as I
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+import Wire.API.Conversation
+import Wire.API.Conversation.Role (roleNameWireAdmin)
+
+tests :: TestTree
+tests =
+  testGroup
+    "ConversationMapping"
+    [ testCase "Alice@A Conv@A" runMappingSimple,
+      testCase "Alice@A Conv@A requester=not a member@A" runMappingNotAMemberA,
+      testCase "Alice@A Conv@A requester=not a member@B" runMappingNotAMemberB,
+      testCase "Alice@A Conv@A Bob@B" runMappingRemoteUser,
+      testCase "Alice@A Conv@B Bob@B" runMappingRemoteConv,
+      testCase "Alice@A Conv@B Bob@B bobUUID=aliceUUID" runMappingSameUnqualifiedUUID
+    ]
+
+runMappingSimple :: HasCallStack => IO ()
+runMappingSimple = do
+  let convDomain = Domain "backendA.example.com"
+  let userDomain = Domain "backendA.example.com"
+  alice <- randomId
+  let requester = Qualified alice userDomain
+  let expectedSelf = Just $ mkMember requester
+  let expectedOthers = Just []
+
+  let locals = [mkInternalMember requester]
+  let remotes = []
+  conv <- mkInternalConv locals remotes
+  let actual = cnvMembers <$> conversationViewMaybeQualified convDomain requester conv
+
+  assertEqual "self:" expectedSelf (cmSelf <$> actual)
+  assertEqual "others:" expectedOthers (cmOthers <$> actual)
+
+runMappingNotAMemberA :: HasCallStack => IO ()
+runMappingNotAMemberA = do
+  let convDomain = Domain "backendA.example.com"
+  let aliceDomain = Domain "backendA.example.com"
+  alice <- flip Qualified aliceDomain <$> randomId
+  requester <- flip Qualified aliceDomain <$> randomId
+
+  let locals = [mkInternalMember alice]
+  let remotes = []
+  conv <- mkInternalConv locals remotes
+  let actual = cnvMembers <$> conversationViewMaybeQualified convDomain requester conv
+
+  assertEqual "members:" Nothing actual
+
+runMappingNotAMemberB :: HasCallStack => IO ()
+runMappingNotAMemberB = do
+  let convDomain = Domain "backendA.example.com"
+  let aliceDomain = Domain "backendA.example.com"
+  let requesterDomain = Domain "backendB.example.com"
+  alice <- flip Qualified aliceDomain <$> randomId
+  requester <- flip Qualified requesterDomain <$> randomId
+
+  let locals = [mkInternalMember alice]
+  let remotes = []
+  conv <- mkInternalConv locals remotes
+  let actual = cnvMembers <$> conversationViewMaybeQualified convDomain requester conv
+
+  assertEqual "members:" Nothing actual
+
+runMappingRemoteUser :: HasCallStack => IO ()
+runMappingRemoteUser = do
+  let aliceDomain = Domain "backendA.example.com"
+  let convDomain = Domain "backendA.example.com"
+  let bobDomain = Domain "backendB.example.com"
+  alice <- flip Qualified aliceDomain <$> randomId
+  bob <- flip Qualified bobDomain <$> randomId
+  let expectedSelf = Just $ mkMember alice
+  let expectedOthers = Just [mkOtherMember bob]
+
+  let locals = [mkInternalMember alice]
+  let remotes = [mkRemoteMember bob]
+  conv <- mkInternalConv locals remotes
+  let actual = cnvMembers <$> conversationViewMaybeQualified convDomain alice conv
+
+  assertEqual "self:" expectedSelf (cmSelf <$> actual)
+  assertEqual "others:" expectedOthers (cmOthers <$> actual)
+
+runMappingRemoteConv :: HasCallStack => IO ()
+runMappingRemoteConv = do
+  let aliceDomain = Domain "backendA.example.com"
+  let convDomain = Domain "backendB.example.com"
+  let bobDomain = Domain "backendB.example.com"
+  alice <- flip Qualified aliceDomain <$> randomId
+  bob <- flip Qualified bobDomain <$> randomId
+  let expectedSelf = Just $ mkMember alice
+  let expectedOthers = Just [mkOtherMember bob]
+
+  let locals = [mkInternalMember bob]
+  let remotes = [mkRemoteMember alice]
+  conv <- mkInternalConv locals remotes
+  let actual = cnvMembers <$> conversationViewMaybeQualified convDomain alice conv
+
+  assertEqual "self:" expectedSelf (cmSelf <$> actual)
+  assertEqual "others:" expectedOthers (cmOthers <$> actual)
+
+-- Here we expect the conversationView to return nothing, because Alice (the
+-- requester) is not part of the conversation (Her unqualified UUID is part of
+-- the conversation, but the function should catch this possibly malicious
+-- edge case)
+runMappingSameUnqualifiedUUID :: HasCallStack => IO ()
+runMappingSameUnqualifiedUUID = do
+  let aliceDomain = Domain "backendA.example.com"
+  let convDomain = Domain "backendB.example.com"
+  let bobDomain = Domain "backendB.example.com"
+  uuid <- randomId
+  let alice = Qualified uuid aliceDomain
+  let bob = Qualified uuid bobDomain
+
+  let locals = [mkInternalMember bob]
+  let remotes = []
+  conv <- mkInternalConv locals remotes
+  let actual = cnvMembers <$> conversationViewMaybeQualified convDomain alice conv
+
+  assertEqual "members:" Nothing actual
+
+--------------------------------------------------------------
+
+mkOtherMember :: Qualified UserId -> OtherMember
+mkOtherMember u = OtherMember u Nothing roleNameWireAdmin
+
+mkRemoteMember :: Qualified UserId -> RemoteMember
+mkRemoteMember u = I.RemoteMember (toRemote u) roleNameWireAdmin
+
+mkInternalConv :: [LocalMember] -> [RemoteMember] -> IO Data.Conversation
+mkInternalConv locals remotes = do
+  creator <- randomId
+  cnv <- randomId
+  pure $
+    Data.Conversation
+      { Data.convId = cnv,
+        Data.convType = RegularConv,
+        Data.convCreator = creator,
+        Data.convName = Just "unit testing gossip",
+        Data.convAccess = [],
+        Data.convAccessRole = ActivatedAccessRole,
+        Data.convLocalMembers = locals,
+        Data.convRemoteMembers = remotes,
+        Data.convTeam = Nothing,
+        Data.convDeleted = Just False,
+        Data.convMessageTimer = Nothing,
+        Data.convReceiptMode = Nothing
+      }
+
+mkMember :: Qualified UserId -> Member
+mkMember (Qualified userId _domain) =
+  Member
+    { memId = userId,
+      memService = Nothing,
+      memOtrMuted = False,
+      memOtrMutedStatus = Nothing,
+      memOtrMutedRef = Nothing,
+      memOtrArchived = False,
+      memOtrArchivedRef = Nothing,
+      memHidden = False,
+      memHiddenRef = Nothing,
+      memConvRoleName = roleNameWireAdmin
+    }
+
+mkInternalMember :: Qualified UserId -> LocalMember
+mkInternalMember (Qualified userId _domain) =
+  I.InternalMember
+    { I.memId = userId,
+      I.memService = Nothing,
+      I.memOtrMuted = False,
+      I.memOtrMutedStatus = Nothing,
+      I.memOtrMutedRef = Nothing,
+      I.memOtrArchived = False,
+      I.memOtrArchivedRef = Nothing,
+      I.memHidden = False,
+      I.memHiddenRef = Nothing,
+      I.memConvRoleName = roleNameWireAdmin
+    }

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -26,8 +26,6 @@ import Data.Qualified
 import Galley.API ()
 import Galley.API.Mapping
 import qualified Galley.Data as Data
--- import Galley.Types
-
 import Galley.Types (LocalMember, RemoteMember)
 import qualified Galley.Types.Conversations.Members as I
 import Imports
@@ -160,6 +158,7 @@ mkRemoteMember u = I.RemoteMember (toRemote u) roleNameWireAdmin
 
 mkInternalConv :: [LocalMember] -> [RemoteMember] -> IO Data.Conversation
 mkInternalConv locals remotes = do
+  -- for the conversationView unit tests, the creator plays no importance, so for simplicity this is set to a random value.
   creator <- randomId
   cnv <- randomId
   pure $

--- a/services/integration.yaml
+++ b/services/integration.yaml
@@ -60,6 +60,9 @@ backendTwo:
   brig:
     host: 127.0.0.1 # in kubernetes, brig.<NAMESPACE>.svc.cluster.local
     port: 9082
+  galley:
+    host: 127.0.0.1 # in kubernetes, galley.<NAMESPACE>.svc.cluster.local
+    port: 9085
   federatorInternal:
     host: 127.0.0.1 # in kubernetes, federator.<NAMESPACE>.svc.cluster.local
     port: 9097


### PR DESCRIPTION
* fixes the implementation of getting a conversation by ID: the conversationView and getConversationRPC call was incomplete / wrong.
* also fixes one futurework in one brig integration test

This should have been part of #1566 