### PR TITLE
demote logging failed invitations to a warning, rather than an error

### DIFF
--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -308,7 +308,7 @@ logInvitationRequest context action =
     eith <- action'
     case eith of
       Left err' -> do
-        Log.err $ context . Log.msg @Text ("Failed to create invitation, label: " <> (cs . label . waiError) err')
+        Log.warn $ context . Log.msg @Text ("Failed to create invitation, label: " <> (cs . label . waiError) err')
         pure (Left err')
       Right result@(_, code) -> do
         Log.info $ (context . logInvitationCode code) . Log.msg @Text "Succesfully created invitation"


### PR DESCRIPTION
Server operators can't act on these errors in any way. 