### PR TITLE
Merge Empty200, Empty404 and EmptyResult

### DIFF
--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -42,6 +42,7 @@ library:
   - hscim
   - http-api-data
   - http-media
+  - http-types
   - insert-ordered-containers
   - iproute >=1.5
   - iso3166-country-codes >=0.2
@@ -60,6 +61,7 @@ library:
   - servant-server
   - servant-swagger
   - schema-profunctor
+  - sop-core
   - string-conversions
   - swagger >=0.1
   - swagger2
@@ -70,6 +72,7 @@ library:
   - uuid >=1.3
   - vector >= 0.12
   - x509
+  - wai
 tests:
   wire-api-tests:
     main: Main.hs

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -3,9 +3,8 @@ module Wire.API.ErrorDescription where
 import Control.Lens (at, over, (.~), (?~))
 import Control.Lens.Combinators (_Just)
 import qualified Data.Aeson as A
-import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 import Data.Schema
-import Data.Swagger (PathItem (..), Swagger (..))
+import Data.Swagger (Swagger)
 import qualified Data.Swagger as Swagger
 import qualified Data.Text as Text
 import GHC.TypeLits (KnownNat, KnownSymbol, Symbol, natVal, symbolVal)
@@ -14,6 +13,7 @@ import Imports hiding (head)
 import Servant hiding (Handler, JSON, addHeader, contentType, respond)
 import Servant.API.Status (KnownStatus)
 import Servant.Swagger.Internal
+import Wire.API.ServantSwagger
 
 -- FUTUREWORK: Ponder about elevating label and messge to the type level. If all
 -- errors are static, there is probably no point in having them at value level.
@@ -69,40 +69,6 @@ instance
   toSwagger _ =
     toSwagger (Proxy @(Verb method (StatusOf (ErrorDescription status desc)) cs (ErrorDescription status desc)))
       `combineSwagger` toSwagger (Proxy @(UVerb method cs rest))
-    where
-      -- workaround for https://github.com/GetShopTV/swagger2/issues/218
-      -- We'd like to juse use (<>) but the instances are wrong
-      combinePathItem :: PathItem -> PathItem -> PathItem
-      combinePathItem s t =
-        PathItem
-          { _pathItemGet = _pathItemGet s <> _pathItemGet t,
-            _pathItemPut = _pathItemPut s <> _pathItemPut t,
-            _pathItemPost = _pathItemPost s <> _pathItemPost t,
-            _pathItemDelete = _pathItemDelete s <> _pathItemDelete t,
-            _pathItemOptions = _pathItemOptions s <> _pathItemOptions t,
-            _pathItemHead = _pathItemHead s <> _pathItemHead t,
-            _pathItemPatch = _pathItemPatch s <> _pathItemPatch t,
-            _pathItemParameters = _pathItemParameters s <> _pathItemParameters t
-          }
-
-      combineSwagger :: Swagger -> Swagger -> Swagger
-      combineSwagger s t =
-        Swagger
-          { _swaggerInfo = _swaggerInfo s <> _swaggerInfo t,
-            _swaggerHost = _swaggerHost s <|> _swaggerHost t,
-            _swaggerBasePath = _swaggerBasePath s <|> _swaggerBasePath t,
-            _swaggerSchemes = _swaggerSchemes s <> _swaggerSchemes t,
-            _swaggerConsumes = _swaggerConsumes s <> _swaggerConsumes t,
-            _swaggerProduces = _swaggerProduces s <> _swaggerProduces t,
-            _swaggerPaths = InsOrdHashMap.unionWith combinePathItem (_swaggerPaths s) (_swaggerPaths t),
-            _swaggerDefinitions = _swaggerDefinitions s <> _swaggerDefinitions t,
-            _swaggerParameters = _swaggerParameters s <> _swaggerParameters t,
-            _swaggerResponses = _swaggerResponses s <> _swaggerResponses t,
-            _swaggerSecurityDefinitions = _swaggerSecurityDefinitions s <> _swaggerSecurityDefinitions t,
-            _swaggerSecurity = _swaggerSecurity s <> _swaggerSecurity t,
-            _swaggerTags = _swaggerTags s <> _swaggerTags t,
-            _swaggerExternalDocs = _swaggerExternalDocs s <|> _swaggerExternalDocs t
-          }
 
 instance (KnownNat status, KnownStatus status) => HasStatus (ErrorDescription status desc) where
   type StatusOf (ErrorDescription status desc) = status

--- a/libs/wire-api/src/Wire/API/Routes/Public.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public.hs
@@ -20,20 +20,35 @@
 
 module Wire.API.Routes.Public where
 
-import Control.Lens ((<>~), (?~))
-import Data.Aeson hiding (json)
+import Control.Lens ((<>~))
 import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 import Data.Id as Id
+import Data.SOP.Constraint (All)
 import Data.Swagger
 import GHC.Base (Symbol)
 import GHC.TypeLits (KnownNat, KnownSymbol, natVal)
-import Imports hiding (head)
+import Imports hiding (All, head)
+import Network.HTTP.Types (Status)
+import Network.Wai (responseLBS)
 import Servant hiding (Handler, JSON, addHeader, respond)
 import Servant.API.Modifiers (FoldLenient, FoldRequired)
-import Servant.Server.Internal (noContentRouter)
+import Servant.API.Status (KnownStatus, statusVal)
+import Servant.API.UVerb.Union (foldMapUnion)
+import Servant.Server.Internal
+  ( Delayed,
+    Handler,
+    RouteResult (..),
+    Router,
+    addMethodCheck,
+    leafRouter,
+    methodCheck,
+    noContentRouter,
+    runAction,
+  )
 import Servant.Swagger (HasSwagger (toSwagger))
 import Servant.Swagger.Internal (SwaggerMethod)
 import Servant.Swagger.Internal.Orphans ()
+import Wire.API.ServantSwagger
 
 -- This type exists for the special 'HasSwagger' and 'HasServer' instances. It
 -- shows the "Authorization" header in the swagger docs, but expects the
@@ -100,34 +115,10 @@ instance
 instance ToSchema a => ToSchema (Headers ls a) where
   declareNamedSchema _ = declareNamedSchema (Proxy @a)
 
--- TODO: remove
-data Empty200 = Empty200
-  deriving (Generic)
-  deriving (HasStatus) via (WithStatus 200 Empty200)
-
-instance ToSchema Empty200 where
-  declareNamedSchema _ = declareNamedSchema (Proxy @Text)
-
-instance ToJSON Empty200 where
-  toJSON _ = toJSON ("" :: Text)
-
-data Empty404 = Empty404
-  deriving (Generic)
-  deriving (HasStatus) via (WithStatus 404 Empty404)
-
-instance ToJSON Empty404 where
-  toJSON _ = toJSON ("" :: Text)
-
-instance ToSchema Empty404 where
-  declareNamedSchema _ =
-    declareNamedSchema (Proxy @Text) <&> (schema . description ?~ "user not found")
-
 --- | Return type of an endpoint with an empty response.
 ---
 --- In principle we could use 'WithStatus n NoContent' instead, but
 --- Servant does not support it, so we would need orphan instances.
----
---- FUTUREWORK: merge with Empty200 in Brig.
 data EmptyResult n = EmptyResult
 
 instance
@@ -135,6 +126,18 @@ instance
   HasSwagger (Verb method n '[] (EmptyResult n))
   where
   toSwagger _ = toSwagger (Proxy @(Verb method n '[] NoContent))
+
+instance
+  ( SwaggerMethod method,
+    KnownNat n,
+    HasSwagger (UVerb method '[] as)
+  ) =>
+  HasSwagger (UVerb method '[] (EmptyResult n ': as))
+  where
+  toSwagger _ =
+    combineSwagger
+      (toSwagger (Proxy @(Verb method n '[] NoContent)))
+      (toSwagger (Proxy @(UVerb method '[] as)))
 
 instance
   (ReflectMethod method, KnownNat n) =>
@@ -147,6 +150,46 @@ instance
     where
       method = reflectMethod (Proxy :: Proxy method)
       status = toEnum . fromInteger $ natVal (Proxy @n)
+
+class HasStatus a => IsEmptyResponse a
+
+instance KnownStatus n => HasStatus (EmptyResult n) where
+  type StatusOf (EmptyResult n) = n
+
+instance KnownStatus n => IsEmptyResponse (EmptyResult n)
+
+-- FUTUREWORK: submit this to Servant
+instance
+  {-# OVERLAPPING #-}
+  ( ReflectMethod method,
+    All IsEmptyResponse as,
+    Unique (Statuses as)
+  ) =>
+  HasServer (UVerb method '[] as) context
+  where
+  type ServerT (UVerb method '[] as) m = m (Union as)
+  hoistServerWithContext _ _ nt s = nt s
+
+  route ::
+    forall env.
+    Proxy (UVerb method '[] as) ->
+    Context context ->
+    Delayed env (Server (UVerb method '[] as)) ->
+    Router env
+  route _proxy _ctx action = leafRouter route'
+    where
+      pickStatus :: All IsEmptyResponse as => Union as -> Status
+      pickStatus = foldMapUnion (Proxy @IsEmptyResponse) getStatus
+
+      getStatus :: forall a. IsEmptyResponse a => a -> Status
+      getStatus _ = statusVal (Proxy @(StatusOf a))
+
+      method = reflectMethod (Proxy @method)
+      route' env request cont = do
+        let action' :: Delayed env (Handler (Union as))
+            action' = addMethodCheck action (methodCheck method request)
+        runAction action' env request cont $ \(output :: Union as) -> do
+          Route $ responseLBS (pickStatus output) mempty mempty
 
 -- | A type-level tag that lets us omit any branch from Swagger docs.
 --

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -32,7 +32,7 @@ import Servant hiding (Handler, JSON, addHeader, respond)
 import Servant.API.Generic
 import Servant.Swagger (HasSwagger (toSwagger))
 import Servant.Swagger.Internal.Orphans ()
-import Wire.API.Routes.Public (Empty200, Empty404, ZUser)
+import Wire.API.Routes.Public (EmptyResult, ZUser)
 import Wire.API.User
 import Wire.API.User.Client
 import Wire.API.User.Client.Prekey
@@ -42,7 +42,7 @@ import Wire.API.UserMap
 
 type MaxUsersForListClientsBulk = 500
 
-type CheckUserExistsResponse = [Empty200, Empty404]
+type CheckUserExistsResponse = [EmptyResult 200, EmptyResult 404]
 
 type CaptureUserId name = Capture' '[Description "User Id"] name UserId
 
@@ -67,7 +67,7 @@ data Api routes = Api
         :> ZUser
         :> "users"
         :> CaptureUserId "uid"
-        :> UVerb 'HEAD '[JSON] CheckUserExistsResponse,
+        :> UVerb 'HEAD '[] CheckUserExistsResponse,
     -- See Note [ephemeral user sideeffect]
     --
     -- See Note [document responses]
@@ -81,7 +81,7 @@ data Api routes = Api
         :> "users"
         :> Capture "domain" Domain
         :> CaptureUserId "uid"
-        :> UVerb 'HEAD '[JSON] CheckUserExistsResponse,
+        :> UVerb 'HEAD '[] CheckUserExistsResponse,
     -- See Note [ephemeral user sideeffect]
     --
     -- See Note [document responses]

--- a/libs/wire-api/src/Wire/API/ServantSwagger.hs
+++ b/libs/wire-api/src/Wire/API/ServantSwagger.hs
@@ -1,0 +1,56 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.ServantSwagger where
+
+import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
+import Data.Swagger (PathItem (..), Swagger (..))
+import Imports
+
+-- workaround for https://github.com/GetShopTV/swagger2/issues/218
+-- We'd like to juse use (<>) but the instances are wrong
+combinePathItem :: PathItem -> PathItem -> PathItem
+combinePathItem s t =
+  PathItem
+    { _pathItemGet = _pathItemGet s <> _pathItemGet t,
+      _pathItemPut = _pathItemPut s <> _pathItemPut t,
+      _pathItemPost = _pathItemPost s <> _pathItemPost t,
+      _pathItemDelete = _pathItemDelete s <> _pathItemDelete t,
+      _pathItemOptions = _pathItemOptions s <> _pathItemOptions t,
+      _pathItemHead = _pathItemHead s <> _pathItemHead t,
+      _pathItemPatch = _pathItemPatch s <> _pathItemPatch t,
+      _pathItemParameters = _pathItemParameters s <> _pathItemParameters t
+    }
+
+combineSwagger :: Swagger -> Swagger -> Swagger
+combineSwagger s t =
+  Swagger
+    { _swaggerInfo = _swaggerInfo s <> _swaggerInfo t,
+      _swaggerHost = _swaggerHost s <|> _swaggerHost t,
+      _swaggerBasePath = _swaggerBasePath s <|> _swaggerBasePath t,
+      _swaggerSchemes = _swaggerSchemes s <> _swaggerSchemes t,
+      _swaggerConsumes = _swaggerConsumes s <> _swaggerConsumes t,
+      _swaggerProduces = _swaggerProduces s <> _swaggerProduces t,
+      _swaggerPaths = InsOrdHashMap.unionWith combinePathItem (_swaggerPaths s) (_swaggerPaths t),
+      _swaggerDefinitions = _swaggerDefinitions s <> _swaggerDefinitions t,
+      _swaggerParameters = _swaggerParameters s <> _swaggerParameters t,
+      _swaggerResponses = _swaggerResponses s <> _swaggerResponses t,
+      _swaggerSecurityDefinitions = _swaggerSecurityDefinitions s <> _swaggerSecurityDefinitions t,
+      _swaggerSecurity = _swaggerSecurity s <> _swaggerSecurity t,
+      _swaggerTags = _swaggerTags s <> _swaggerTags t,
+      _swaggerExternalDocs = _swaggerExternalDocs s <|> _swaggerExternalDocs t
+    }

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c86173e7b15d84b4e33d4f6faa9f1445031dc2d669e52f7f49ccf9f74571beaf
+-- hash: 58042dcdd8cad7b2456724f4cbaae1a856868fdfce42f729132e63cf21704a75
 
 name:           wire-api
 version:        0.1.0
@@ -53,6 +53,7 @@ library
       Wire.API.Routes.Public.LegalHold
       Wire.API.Routes.Public.Spar
       Wire.API.ServantProto
+      Wire.API.ServantSwagger
       Wire.API.Swagger
       Wire.API.Team
       Wire.API.Team.Conversation
@@ -119,6 +120,7 @@ library
     , hscim
     , http-api-data
     , http-media
+    , http-types
     , imports
     , insert-ordered-containers
     , iproute >=1.5
@@ -137,6 +139,7 @@ library
     , servant-multipart
     , servant-server
     , servant-swagger
+    , sop-core
     , string-conversions
     , swagger >=0.1
     , swagger2
@@ -147,6 +150,7 @@ library
     , uri-bytestring >=0.2
     , uuid >=1.3
     , vector >=0.12
+    , wai
     , x509
   default-language: Haskell2010
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -92,7 +92,7 @@ import qualified System.Logger.Class as Log
 import Util.Logging (logFunction, logHandle, logTeam, logUser)
 import qualified Wire.API.Connection as Public
 import qualified Wire.API.Properties as Public
-import Wire.API.Routes.Public (Empty200 (..), Empty404 (..))
+import Wire.API.Routes.Public (EmptyResult (..))
 import qualified Wire.API.Routes.Public.Brig as BrigAPI
 import qualified Wire.API.Routes.Public.Galley as GalleyAPI
 import qualified Wire.API.Routes.Public.LegalHold as LegalHoldAPI
@@ -1058,8 +1058,8 @@ checkUserExistsH :: UserId -> Domain -> UserId -> Handler (Union BrigAPI.CheckUs
 checkUserExistsH self domain uid = do
   exists <- checkUserExists self (Qualified uid domain)
   if exists
-    then Servant.respond Empty200
-    else Servant.respond Empty404
+    then Servant.respond (EmptyResult @200)
+    else Servant.respond (EmptyResult @404)
 
 checkUserExists :: UserId -> Qualified UserId -> Handler Bool
 checkUserExists self qualifiedUserId =


### PR DESCRIPTION
There is a slight complication here due to the fact that `Empty200` and `Empty404` are used in a `UVerb`, and `UVerb` does not really support the no content type case.

The solution in this patch is to define an overlapping instance for `HasServer UVerb` for an empty list of content types.

Also, the combinators in `ErrorDescription` (taken from `servant-swagger`) have been moved to a new module and reused for the
definition of the `Swagger` instance for a `UVerb` contaning empty results.