### PR TITLE
Update team-settings version in Helm chart [skip ci]

### DIFF
--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/team-settings
-  tag: 3.5.1-e08322-v0.28.10-production
+  tag: "4.0.0-v0.28.18-0-0846c0a"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `4.0.0-v0.28.18-0-0846c0a`
Release: [`v4.0.0`](https://github.com/wireapp/wire-team-settings/releases/tag/v4.0.0)