### PR TITLE
Set content-type header for JSON errors in Servant

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5a4442922e75d8a8d7684845e4168c3d1bcbebff1bc24647c50f5f662e49b265
+-- hash: 9964cbee009e206492e2a4bb74873592f1963ac4c13deb477b04491ee4471a2a
 
 name:           brig
 version:        1.35.0
@@ -160,6 +160,7 @@ library
     , html-entities >=1.1
     , http-client >=0.5
     , http-client-openssl >=0.2
+    , http-media
     , http-types >=0.8
     , imports
     , insert-ordered-containers

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -58,6 +58,7 @@ library:
   - html-entities >=1.1
   - http-client >=0.5
   - http-client-openssl >=0.2
+  - http-media
   - http-types >=0.8
   - imports
   - insert-ordered-containers

--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -88,7 +88,7 @@ toServantHandler env action = do
         StdError werr -> do
           Server.logError' logger (Just reqId) werr
           Servant.throwError $
-            Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode werr) []
+            Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode werr) [("Content-Type", "application/json")]
         RichError werr body headers -> do
           Server.logError' logger (Just reqId) werr
           Servant.throwError $

--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -43,11 +43,13 @@ import qualified Control.Monad.Catch as Catch
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import Data.Default (def)
+import Data.Proxy (Proxy (..))
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.ZAuth.Validation as ZV
 import Imports
-import Network.HTTP.Types (Status (statusCode, statusMessage))
+import Network.HTTP.Media.RenderHeader (RenderHeader (..))
+import Network.HTTP.Types (Status (statusCode, statusMessage), hContentType)
 import Network.Wai (Request, ResponseReceived)
 import Network.Wai.Predicate (Media)
 import Network.Wai.Routing (Continue)
@@ -88,7 +90,7 @@ toServantHandler env action = do
         StdError werr -> do
           Server.logError' logger (Just reqId) werr
           Servant.throwError $
-            Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode werr) [("Content-Type", "application/json")]
+            Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode werr) [(hContentType, renderHeader (Servant.contentType (Proxy @Servant.JSON)))]
         RichError werr body headers -> do
           Server.logError' logger (Just reqId) werr
           Servant.throwError $

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -432,6 +432,7 @@ testTooManyClients opts brig = do
     addClient brig uid (defNewClient PermanentClientType [somePrekeys !! 11] (someLastPrekeys !! 11)) !!! do
       const 403 === statusCode
       const (Just "too-many-clients") === fmap Error.label . responseJsonMaybe
+      const (Just "application/json") === getHeader "Content-Type"
 
 testRemoveClient :: Bool -> Brig -> Cannon -> Http ()
 testRemoveClient hasPwd brig cannon = do

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -432,7 +432,7 @@ testTooManyClients opts brig = do
     addClient brig uid (defNewClient PermanentClientType [somePrekeys !! 11] (someLastPrekeys !! 11)) !!! do
       const 403 === statusCode
       const (Just "too-many-clients") === fmap Error.label . responseJsonMaybe
-      const (Just "application/json") === getHeader "Content-Type"
+      const (Just "application/json;charset=utf-8") === getHeader "Content-Type"
 
 testRemoveClient :: Bool -> Brig -> Cannon -> Http ()
 testRemoveClient hasPwd brig cannon = do

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9fb2b9ba716dce4ffe27891b8718f10b22ca443bf73c84744b150c53aae5a5c1
+-- hash: 745bcafaa54e692d5108ef64b2098eaf0602169c2272e1ca93ded164e65da7dd
 
 name:           galley
 version:        0.83.0
@@ -103,6 +103,7 @@ library
     , http-client >=0.4
     , http-client-openssl >=0.2
     , http-client-tls >=0.2.2
+    , http-media
     , http-types >=0.8
     , http2-client-grpc
     , imports

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -48,6 +48,7 @@ library:
   - http-client >=0.4
   - http-client-openssl >=0.2
   - http-client-tls >=0.2.2
+  - http-media
   - http-types >=0.8
   - http2-client-grpc
   - insert-ordered-containers

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -71,6 +71,7 @@ import qualified Data.List.NonEmpty as NE
 import Data.Metrics.Middleware
 import Data.Misc (Fingerprint, Rsa)
 import qualified Data.ProtocolBuffers as Proto
+import Data.Proxy (Proxy (..))
 import Data.Range
 import Data.Serialize.Get (runGetLazy)
 import Data.Text (unpack)
@@ -84,6 +85,8 @@ import qualified Galley.Types.Teams as Teams
 import Imports
 import Network.HTTP.Client (responseTimeoutMicro)
 import Network.HTTP.Client.OpenSSL
+import Network.HTTP.Media.RenderHeader (RenderHeader (..))
+import Network.HTTP.Types (hContentType)
 import Network.HTTP.Types.Status (statusCode, statusMessage)
 import Network.Wai
 import Network.Wai.Utilities
@@ -311,7 +314,7 @@ toServantHandler env galley = do
     handleWaiErrors logger reqId' werr = do
       Server.logError' logger (Just reqId') werr
       Servant.throwError $
-        Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode werr) [("Content-Type", "application/json")]
+        Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode werr) [(hContentType, renderHeader (Servant.contentType (Proxy @Servant.JSON)))]
 
     mkCode = statusCode . WaiError.code
     mkPhrase = Text.unpack . Text.decodeUtf8 . statusMessage . WaiError.code

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -311,7 +311,7 @@ toServantHandler env galley = do
     handleWaiErrors logger reqId' werr = do
       Server.logError' logger (Just reqId') werr
       Servant.throwError $
-        Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode werr) []
+        Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode werr) [("Content-Type", "application/json")]
 
     mkCode = statusCode . WaiError.code
     mkPhrase = Text.unpack . Text.decodeUtf8 . statusMessage . WaiError.code


### PR DESCRIPTION
Clients are relying on the content type being set in order to parse the error and react accordingly. This is true at least for the `too-many-clients` error, but possibly others.