### PR TITLE
Restore old error behaviour for client not found

### DIFF
--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -59,6 +59,7 @@ import Network.Wai.Utilities.Request (JsonRequest, lookupRequestId, parseBody)
 import Network.Wai.Utilities.Response (addHeader, json, setStatus)
 import qualified Network.Wai.Utilities.Server as Server
 import qualified Servant
+import qualified System.Logger as Log
 import System.Logger.Class (Logger)
 
 -------------------------------------------------------------------------------
@@ -83,18 +84,22 @@ toServantHandler env action = do
     Right x -> pure x
   where
     mkCode = statusCode . WaiError.code
-    mkPhrase = Text.unpack . Text.decodeUtf8 . statusMessage . WaiError.code
+    mkPhrase = Text.unpack . Text.decodeUtf8 . statusMessage
 
     handleWaiErrors logger reqId =
       \case
         StdError werr -> do
           Server.logError' logger (Just reqId) werr
           Servant.throwError $
-            Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode werr) [(hContentType, renderHeader (Servant.contentType (Proxy @Servant.JSON)))]
+            Servant.ServerError (mkCode werr) (mkPhrase (WaiError.code werr)) (Aeson.encode werr) [(hContentType, renderHeader (Servant.contentType (Proxy @Servant.JSON)))]
         RichError werr body headers -> do
           Server.logError' logger (Just reqId) werr
           Servant.throwError $
-            Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode body) headers
+            Servant.ServerError (mkCode werr) (mkPhrase (WaiError.code werr)) (Aeson.encode body) headers
+        EmptyErrorForLegacyReasons code -> do
+          Log.debug logger $ Log.field "request" reqId . Log.msg ("empty error for legacy reasons" :: ByteString)
+          Servant.throwError $
+            Servant.ServerError (statusCode code) (mkPhrase code) "" [(hContentType, renderHeader (Servant.contentType (Proxy @Servant.PlainText)))]
 
 brigErrorHandlers :: [Catch.Handler IO (Either Error a)]
 brigErrorHandlers =
@@ -125,6 +130,7 @@ onError g r k e = do
     (we, hs) = case e of
       StdError x -> (x, [])
       RichError x _ h -> (x, h)
+      EmptyErrorForLegacyReasons code -> (WaiError.mkError code "" "", [])
 
 -------------------------------------------------------------------------------
 -- Utilities

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -91,7 +91,6 @@ import Servant.Swagger.UI
 import qualified System.Logger.Class as Log
 import Util.Logging (logFunction, logHandle, logTeam, logUser)
 import qualified Wire.API.Connection as Public
-import qualified Wire.API.ErrorDescription as ErrorDescription
 import qualified Wire.API.Properties as Public
 import Wire.API.Routes.Public (EmptyResult (..))
 import qualified Wire.API.Routes.Public.Brig as BrigAPI
@@ -811,7 +810,7 @@ getClient :: UserId -> ClientId -> Handler (Union BrigAPI.GetClientResponse)
 getClient zusr clientId = do
   mc <- lift $ API.lookupLocalClient zusr clientId
   case mc of
-    Nothing -> Servant.respond ErrorDescription.clientNotFound
+    Nothing -> throwEmptyForLegacyReasons status404
     Just c -> Servant.respond (WithStatus @200 c)
 
 getUserClientsUnqualified :: UserId -> Handler [Public.PubClient]

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -308,7 +308,7 @@ logInvitationRequest context action =
     eith <- action'
     case eith of
       Left err' -> do
-        Log.warn $ context . Log.msg @Text ("Failed to create invitation, label: " <> (cs . label . waiError) err')
+        Log.warn $ context . Log.msg @Text ("Failed to create invitation, label: " <> (cs . errorLabel) err')
         pure (Left err')
       Right result@(_, code) -> do
         Log.info $ (context . logInvitationCode code) . Log.msg @Text "Succesfully created invitation"

--- a/services/brig/test/unit/Test/Brig/API/Error.hs
+++ b/services/brig/test/unit/Test/Brig/API/Error.hs
@@ -98,7 +98,7 @@ assertOutwardErrorStatus errType sts =
   assertEqual ("http status should be " <> show sts) (HTTP.statusCode . Wai.code . federationRemoteError $ Proto.OutwardError errType Nothing) sts
 
 statusFor :: FederationError -> Int
-statusFor = HTTP.statusCode . Wai.code . waiError . fedError
+statusFor = HTTP.statusCode . errorStatus . fedError
 
 emptyReq :: Servant.RequestF () (Servant.BaseUrl, ByteString)
 emptyReq =


### PR DESCRIPTION
Some clients (webapp at least) are relying on the response body being empty (or at least not a valid JSON error value) when fetching a non-existing client. This restores the previous behaviour by adding a new special constructor for brig handler errors, resulting in an empty response body.