### PR TITLE
[WIP] [skip ci] Attempt to allow the use of servant-client in Galley tests

### DIFF
--- a/libs/types-common/src/Data/CommaSeparatedList.hs
+++ b/libs/types-common/src/Data/CommaSeparatedList.hs
@@ -21,14 +21,15 @@ module Data.CommaSeparatedList where
 
 import Control.Lens ((?~))
 import qualified Data.Bifunctor as Bifunctor
-import Data.ByteString.Conversion (FromByteString, List, fromList, parser, runParser)
+import Data.ByteString.Conversion (FromByteString, List (..), ToByteString (..), fromList, parser, runParser, toByteString')
 import Data.Proxy (Proxy (..))
 import Data.Range (Bounds, Range)
+import Data.String.Conversions (cs)
 import Data.Swagger (CollectionFormat (CollectionCSV), SwaggerItems (SwaggerItemsPrimitive), SwaggerType (SwaggerString), ToParamSchema (..), items, type_)
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
 import Imports
-import Servant (FromHttpApiData (..))
+import Servant (FromHttpApiData (..), ToHttpApiData (..))
 
 newtype CommaSeparatedList a = CommaSeparatedList {fromCommaSeparatedList :: [a]}
   deriving stock (Show, Eq)
@@ -37,6 +38,9 @@ newtype CommaSeparatedList a = CommaSeparatedList {fromCommaSeparatedList :: [a]
 instance FromByteString (List a) => FromHttpApiData (CommaSeparatedList a) where
   parseUrlPiece t =
     CommaSeparatedList . fromList <$> Bifunctor.first Text.pack (runParser parser $ encodeUtf8 t)
+
+instance ToByteString (List a) => ToHttpApiData (CommaSeparatedList a) where
+  toUrlPiece = cs . toByteString' . List . fromCommaSeparatedList
 
 instance ToParamSchema (CommaSeparatedList a) where
   toParamSchema _ = mempty & type_ ?~ SwaggerString

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -221,6 +221,9 @@ instance FromJSON ConnId where
 instance FromHttpApiData ConnId where
   parseUrlPiece = Right . ConnId . encodeUtf8
 
+instance ToHttpApiData ConnId where
+  toUrlPiece = decodeUtf8 . fromConnId
+
 -- ClientId --------------------------------------------------------------------
 
 -- | Handle for a device.  Corresponds to the device fingerprints exposed in the UI.  It is unique

--- a/libs/types-common/src/Data/Range.hs
+++ b/libs/types-common/src/Data/Range.hs
@@ -90,7 +90,7 @@ import qualified Data.Text.Ascii as Ascii
 import qualified Data.Text.Lazy as TL
 import Imports
 import Numeric.Natural (Natural)
-import Servant (FromHttpApiData (..))
+import Servant (FromHttpApiData (..), ToHttpApiData (..))
 import System.Random (Random)
 import Test.QuickCheck (Arbitrary (arbitrary, shrink), Gen)
 import qualified Test.QuickCheck as QC
@@ -209,6 +209,9 @@ instance (Within a n m, FromHttpApiData a) => FromHttpApiData (Range n m a) wher
   parseUrlPiece t = do
     unchecked <- parseUrlPiece t
     Bifunctor.first T.pack $ checkedEither @_ @n @m unchecked
+
+instance (Within a n m, ToHttpApiData a) => ToHttpApiData (Range n m a) where
+  toUrlPiece = toUrlPiece . fromRange
 
 type LTE (n :: Nat) (m :: Nat) = (SingI n, SingI m, (n <= m) ~ 'True)
 

--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -57,6 +57,8 @@ library:
   - quickcheck-instances >=0.3.16
   - saml2-web-sso
   - servant
+  - servant-client
+  - servant-client-core
   - servant-multipart
   - servant-server
   - servant-swagger

--- a/libs/wire-api/src/Wire/API/Message.hs
+++ b/libs/wire-api/src/Wire/API/Message.hs
@@ -49,7 +49,7 @@ where
 import Control.Lens (view, (?~))
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Base64 as B64
-import Data.CommaSeparatedList (CommaSeparatedList (fromCommaSeparatedList))
+import Data.CommaSeparatedList (CommaSeparatedList (..))
 import Data.Id
 import Data.Json.Util
 import qualified Data.Map.Strict as Map
@@ -61,7 +61,7 @@ import qualified Data.Swagger as S
 import qualified Data.Swagger.Build.Api as Doc
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Imports
-import Servant (FromHttpApiData (..))
+import Servant (FromHttpApiData (..), ToHttpApiData (..))
 import Wire.API.Arbitrary (Arbitrary (..), GenericUniform (..))
 import qualified Wire.API.Message.Proto as Proto
 import Wire.API.ServantProto (FromProto (..))
@@ -296,6 +296,14 @@ instance FromHttpApiData IgnoreMissing where
     "false" -> Right $ IgnoreMissingList mempty
     list -> IgnoreMissingList . Set.fromList . fromCommaSeparatedList <$> parseQueryParam list
 
+instance ToHttpApiData IgnoreMissing where
+  toQueryParam = \case
+    IgnoreMissingAll -> "true"
+    IgnoreMissingList uids ->
+      if Set.null uids
+        then "false"
+        else toQueryParam (CommaSeparatedList (Set.toList uids))
+
 data ReportMissing
   = ReportMissingAll
   | ReportMissingList (Set UserId)
@@ -308,6 +316,14 @@ instance FromHttpApiData ReportMissing where
     "true" -> Right ReportMissingAll
     "false" -> Right $ ReportMissingList mempty
     list -> ReportMissingList . Set.fromList . fromCommaSeparatedList <$> parseQueryParam list
+
+instance ToHttpApiData ReportMissing where
+  toQueryParam = \case
+    ReportMissingAll -> "true"
+    ReportMissingList uids ->
+      if Set.null uids
+        then "false"
+        else toQueryParam (CommaSeparatedList (Set.toList uids))
 
 --------------------------------------------------------------------------------
 -- Utilities

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -29,6 +29,8 @@ import Imports hiding (head)
 import Servant hiding (Handler, JSON, addHeader, contentType, respond)
 import qualified Servant
 import Servant.API.Generic (ToServantApi, (:-))
+import Servant.Client (ClientM)
+import Servant.Client.Generic (AsClientT, genericClient)
 import Servant.Swagger.Internal
 import Servant.Swagger.Internal.Orphans ()
 import qualified Wire.API.Conversation as Public
@@ -169,18 +171,18 @@ data Api routes = Api
         :> "one2one"
         :> ReqBody '[Servant.JSON] Public.NewConvUnmanaged
         :> UVerb 'POST '[Servant.JSON] ConversationResponses,
-    addMembersToConversationV2 ::
-      routes
-        :- Summary "Add qualified members to an existing conversation: WIP, events not propagated yet."
-        :> ZUser
-        :> ZConn
-        :> "conversations"
-        :> Capture "cnv" ConvId
-        :> "members"
-        :> "v2"
-        :> ReqBody '[Servant.JSON] Public.InviteQualified
-        :> UVerb 'POST '[Servant.JSON] UpdateResponses,
-    -- Team Conversations
+    -- addMembersToConversationV2 ::
+    --   routes
+    --     :- Summary "Add qualified members to an existing conversation: WIP, events not propagated yet."
+    --     :> ZUser
+    --     :> ZConn
+    --     :> "conversations"
+    --     :> Capture "cnv" ConvId
+    --     :> "members"
+    --     :> "v2"
+    --     :> ReqBody '[Servant.JSON] Public.InviteQualified
+    --     :> UVerb 'POST '[Servant.JSON] UpdateResponses,
+    -- -- Team Conversations
 
     getTeamConversationRoles ::
       -- FUTUREWORK: errorResponse Error.notATeamMember
@@ -192,7 +194,7 @@ data Api routes = Api
         :> "conversations"
         :> "roles"
         :> Get '[Servant.JSON] Public.ConversationRolesList,
-    -- FUTUREWORK: errorResponse (Error.operationDenied Public.GetTeamConversations)
+    -- -- FUTUREWORK: errorResponse (Error.operationDenied Public.GetTeamConversations)
     getTeamConversations ::
       routes
         :- Summary "Get team conversations"
@@ -201,7 +203,7 @@ data Api routes = Api
         :> Capture "tid" TeamId
         :> "conversations"
         :> Get '[Servant.JSON] Public.TeamConversationList,
-    -- FUTUREWORK: errorResponse (Error.operationDenied Public.GetTeamConversations)
+    -- -- FUTUREWORK: errorResponse (Error.operationDenied Public.GetTeamConversations)
     getTeamConversation ::
       routes
         :- Summary "Get one team conversation"
@@ -213,16 +215,16 @@ data Api routes = Api
         :> Get '[Servant.JSON] Public.TeamConversation,
     -- FUTUREWORK: errorResponse (Error.actionDenied Public.DeleteConversation)
     --             errorResponse Error.notATeamMember
-    deleteTeamConversation ::
-      routes
-        :- Summary "Remove a team conversation"
-        :> ZUser
-        :> ZConn
-        :> "teams"
-        :> Capture "tid" TeamId
-        :> "conversations"
-        :> Capture "cid" ConvId
-        :> Delete '[] (EmptyResult 200),
+    -- deleteTeamConversation ::
+    --   routes
+    --     :- Summary "Remove a team conversation"
+    --     :> ZUser
+    --     :> ZConn
+    --     :> "teams"
+    --     :> Capture "tid" TeamId
+    --     :> "conversations"
+    --     :> Capture "cid" ConvId
+    --     :> Delete '[] (EmptyResult 200)
     postOtrMessage ::
       routes
         :- Summary "Post an encrypted message to a conversation (accepts JSON or Protobuf)"
@@ -267,3 +269,7 @@ type PostOtrDescription =
 
 swaggerDoc :: Swagger.Swagger
 swaggerDoc = toSwagger (Proxy @ServantAPI)
+
+-- TODO: remove this and
+client :: Api (AsClientT ClientM)
+client = genericClient

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 413899ff7cff9c419303a8ef3561f78f7bd719cc3e18f0b26f04a3cd4f31f358
+-- hash: 2bde7e0f56852808d81a46e3319e563192c89fb79f0f3e9188e4b9bbe2e94f95
 
 name:           wire-api
 version:        0.1.0
@@ -136,6 +136,8 @@ library
     , saml2-web-sso
     , schema-profunctor
     , servant
+    , servant-client
+    , servant-client-core
     , servant-multipart
     , servant-server
     , servant-swagger

--- a/services/galley/test/integration/Main.hs
+++ b/services/galley/test/integration/Main.hs
@@ -118,7 +118,7 @@ main = withOpenSSL $ runTests go
       let ck = fromJust gConf ^. optCassandra . casKeyspace
       lg <- Logger.new Logger.defSettings
       db <- defInitCassandra ck ch cp lg
-      return $ TestSetup (fromJust gConf) (fromJust iConf) m g b c awsEnv convMaxSize db (mkFedGalleyClient galleyEndpoint)
+      return $ TestSetup (fromJust gConf) (fromJust iConf) m g b c awsEnv convMaxSize db (mkFedGalleyClient galleyEndpoint) (mkGalleyClient galleyEndpoint)
     queueName = fmap (view awsQueueName) . view optJournal
     endpoint = fmap (view awsEndpoint) . view optJournal
     maxSize = view (optSettings . setMaxConvSize)


### PR DESCRIPTION
Currently can't resolve the missing HasClient instance, will need to pair with someone.

> Unless you are writing a new backend for servant-client-core or new combinators that you want to support client-generation, you can ignore this class.

Well, apparently one can't ignore this class.

## Checklist

 - [ ] Title of this PR explains the impact of the change.
 - [ ] The description provides context as to why the change should occur and
       what the code contributes to that effect. This could also be a link to a
       JIRA ticket or a Github issue, if there is one.
 - [ ] The CHANGELOG.md file in the *Unreleased* section has been updated to
       explain the change which will be included in the release notes.
 - [x] If a component uses a new or changed internal endpoint of another
       component, this is mentioned in the CHANGELOG.md.
 - [x] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
