### PR TITLE
Test passwordless client delete with empty object

### DIFF
--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -221,10 +221,8 @@ deleteClient brig u c pw =
       . body payload
   where
     payload =
-      RequestBodyLBS . encode $
-        object
-          [ "password" .= pw
-          ]
+      RequestBodyLBS . encode . object . maybeToList $
+        fmap ("password" .=) pw
 
 listConnections :: Brig -> UserId -> (MonadIO m, MonadHttp m) => m ResponseLBS
 listConnections brig u =


### PR DESCRIPTION
This checks that the password field of a delete client request is indeed optional. Previously, a null value was used for the password, but removing the field completely should catch more decoding bugs. See #1604.