### PR TITLE
More consistent formatting of PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,7 @@
 ## Checklist
 
  - [ ] Title of this PR explains the impact of the change.
- - [ ] The description provides context as to why the change should occur and
-       what the code contributes to that effect. This could also be a link to a
-       JIRA ticket or a Github issue, if there is one.
- - [ ] The CHANGELOG.md file in the *Unreleased* section has been updated to
-       explain the change which will be included in the release notes.
- - [ ] If a component uses a new or changed internal endpoint of another
-       component, this is mentioned in the CHANGELOG.md.
+ - [ ] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
+ - [ ] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
+ - [ ] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
 - [ ] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.


### PR DESCRIPTION
Some lines were formatted with hard breaks, while some were left long. This removes all hard breaks and relies on github for line wrapping.