### PR TITLE
Galley/int: Expect remote call when creating conv with remotes

### DIFF
--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -458,14 +458,7 @@ postMessageQualifiedLocalOwningBackendSuccess = do
   connectLocalQualifiedUsers aliceUnqualified (list1 bobOwningDomain [chadOwningDomain])
 
   -- FUTUREWORK: Do this test with more than one remote domains
-  opts <- view tsGConf
-  (resp, _) <-
-    withTempMockFederator
-      opts
-      remoteDomain
-      (const [mkProfile deeRemote (Name "Dee")])
-      (postConvQualified aliceUnqualified [bobOwningDomain, chadOwningDomain, deeRemote] (Just "federated gossip") [] Nothing Nothing)
-
+  resp <- postConvWithRemoteUser remoteDomain (mkProfile deeRemote (Name "Dee")) aliceUnqualified [bobOwningDomain, chadOwningDomain, deeRemote]
   let convId = (`Qualified` owningDomain) . decodeConvId $ resp
 
   WS.bracketR2 cannon bobUnqualified chadUnqualified $ \(wsBob, wsChad) -> do
@@ -511,14 +504,7 @@ postMessageQualifiedLocalOwningBackendMissingClients = do
   connectLocalQualifiedUsers aliceUnqualified (list1 bobOwningDomain [chadOwningDomain])
 
   -- FUTUREWORK: Do this test with more than one remote domains
-  opts <- view tsGConf
-  (resp, _) <-
-    withTempMockFederator
-      opts
-      remoteDomain
-      (const [mkProfile deeRemote (Name "Dee")])
-      (postConvQualified aliceUnqualified [bobOwningDomain, chadOwningDomain, deeRemote] (Just "federated gossip") [] Nothing Nothing)
-
+  resp <- postConvWithRemoteUser remoteDomain (mkProfile deeRemote (Name "Dee")) aliceUnqualified [bobOwningDomain, chadOwningDomain, deeRemote]
   let convId = (`Qualified` owningDomain) . decodeConvId $ resp
 
   -- Missing Bob, chadClient2 and Dee
@@ -566,14 +552,7 @@ postMessageQualifiedLocalOwningBackendRedundantAndDeletedClients = do
   connectLocalQualifiedUsers aliceUnqualified (list1 bobOwningDomain [chadOwningDomain])
 
   -- FUTUREWORK: Do this test with more than one remote domains
-  opts <- view tsGConf
-  (resp, _) <-
-    withTempMockFederator
-      opts
-      remoteDomain
-      (const [mkProfile deeRemote (Name "Dee")])
-      (postConvQualified aliceUnqualified [bobOwningDomain, chadOwningDomain, deeRemote] (Just "federated gossip") [] Nothing Nothing)
-
+  resp <- postConvWithRemoteUser remoteDomain (mkProfile deeRemote (Name "Dee")) aliceUnqualified [bobOwningDomain, chadOwningDomain, deeRemote]
   let convId = (`Qualified` owningDomain) . decodeConvId $ resp
 
   WS.bracketR3 cannon bobUnqualified chadUnqualified nonMemberUnqualified $ \(wsBob, wsChad, wsNonMember) -> do
@@ -633,14 +612,7 @@ postMessageQualifiedLocalOwningBackendIgnoreMissingClients = do
   connectLocalQualifiedUsers aliceUnqualified (list1 bobOwningDomain [chadOwningDomain])
 
   -- FUTUREWORK: Do this test with more than one remote domains
-  opts <- view tsGConf
-  (resp, _) <-
-    withTempMockFederator
-      opts
-      remoteDomain
-      (const [mkProfile deeRemote (Name "Dee")])
-      (postConvQualified aliceUnqualified [bobOwningDomain, chadOwningDomain, deeRemote] (Just "federated gossip") [] Nothing Nothing)
-
+  resp <- postConvWithRemoteUser remoteDomain (mkProfile deeRemote (Name "Dee")) aliceUnqualified [bobOwningDomain, chadOwningDomain, deeRemote]
   let convId = (`Qualified` owningDomain) . decodeConvId $ resp
 
   -- Missing Bob, chadClient2 and Dee


### PR DESCRIPTION
These tests broke when merging #1593 


## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
 - [x] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
- [x] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
