### PR TITLE
Bump wire-webapp

### DIFF
--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: 2021-05-10-production.0-2e9ab3-v0.28.10-production
+  tag: 2021-06-01-production.0-v0.28.15-0a4d64
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Addresses https://github.com/wireapp/wire-webapp/security/advisories/GHSA-382j-mmc8-m5rw

We have automation in place, so this will happen automatically in the future.  The PR with the security fix was merged just before the github action that triggers release updates was merged hence this slipped through the cracks (https://github.com/wireapp/wire-webapp/pull/11158). Hence triggering manually.

## Checklist

 - [ ] Title of this PR explains the impact of the change.
 - [ ] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
 - [ ] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
- [ ] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
