### PR TITLE
Saml IDP: allow to re-use previously used issuer names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 ## Bug fixes and other updates
 
 * Restore old behaviour for parse errors in request bodies (#1628, #1629).
+* Allow to change IdP Issuer name to previous name (#1615).
 
 # 2021-06-23
 

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -386,7 +386,7 @@ validateIdPUpdate zusr _idpMetadata _idpId = do
               Nothing -> True
               Just c -> c ^. SAML.idpId == _idpId
         if notInUseByOthers
-          then pure $ (previousIdP ^. SAML.idpExtraInfo) & wiOldIssuers %~ (previousIssuer :)
+          then pure $ (previousIdP ^. SAML.idpExtraInfo) & wiOldIssuers %~ nub . (previousIssuer :)
           else throwSpar SparIdPIssuerInUse
   let requri = _idpMetadata ^. SAML.edRequestURI
   enforceHttps requri

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -357,8 +357,9 @@ idpUpdateXML zusr raw idpmeta idpid = withDebugLog "idpUpdate" (Just . show . (^
   pure idp
 
 -- | Check that: idp id is valid; calling user is admin in that idp's home team; team id in
--- new metainfo doesn't change; new issuer (if changed) is not in use anywhere else; request
--- uri is https.  Keep track of old issuer in extra info if issuer has changed.
+-- new metainfo doesn't change; new issuer (if changed) is not in use anywhere else (except as
+-- an earlier IdP under the same ID); request uri is https.  Keep track of old issuer in extra
+-- info if issuer has changed.
 validateIdPUpdate ::
   forall m.
   (HasCallStack, m ~ Spar) =>
@@ -380,8 +381,11 @@ validateIdPUpdate zusr _idpMetadata _idpId = do
     if previousIssuer == newIssuer
       then pure $ previousIdP ^. SAML.idpExtraInfo
       else do
-        notInUse <- isNothing <$> wrapMonadClient (Data.getIdPConfigByIssuer newIssuer)
-        if notInUse
+        foundConfig <- wrapMonadClient (Data.getIdPConfigByIssuer newIssuer)
+        let notInUseByOthers = case foundConfig of
+              Nothing -> True
+              Just c -> c ^. SAML.idpId == _idpId
+        if notInUseByOthers
           then pure $ (previousIdP ^. SAML.idpExtraInfo) & wiOldIssuers %~ (previousIssuer :)
           else throwSpar SparIdPIssuerInUse
   let requri = _idpMetadata ^. SAML.edRequestURI

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -746,8 +746,8 @@ specCRUDIdentityProvider = do
         (owner1, _, (^. idpId) -> idpid1, (IdPMetadataValue _ idpmeta1, _)) <- registerTestIdPWithMeta
         (SampleIdP idpmeta2 _ _ _) <- makeSampleIdPMetadata
         _ <- call $ callIdpCreate (env ^. teSpar) (Just owner1) idpmeta2
-        let idpmeta3 = idpmeta1 & edIssuer .~ (idpmeta2 ^. edIssuer)
-        callIdpUpdate' (env ^. teSpar) (Just owner1) idpid1 (IdPMetadataValue (cs $ SAML.encode idpmeta3) undefined)
+        let idpmeta1' = idpmeta1 & edIssuer .~ (idpmeta2 ^. edIssuer)
+        callIdpUpdate' (env ^. teSpar) (Just owner1) idpid1 (IdPMetadataValue (cs $ SAML.encode idpmeta1') undefined)
           `shouldRespondWith` checkErrHspec 400 "idp-issuer-in-use"
     describe "issuer changed to one that is new" $ do
       it "updates old idp, updating both issuer and old_issuers" $ do


### PR DESCRIPTION
**Bug:** If an IdP issuer is changed from A to B and then back to A, the second update fails with the message "A alredy in use".  This is technically correct, since we keep old idp configs around to allow gradual migration of users from old issuer name to new.  

**Fix:** IdPs should be allowed to reuser their *own* issuer names.

**Technical details:** [from memory, I probably should double-check] the idp keeps a list of old idp issuer names around.  If a user tries to auth with a new issuer name, but cannot be found in `spar.user`, we pull the list of old idp issuer names, and do lookups in `spar.user` by those.  If we find a user, it is because that user has not been seen since before one or more idp metadata updates, and the entry in `spar.user` is outdated.  We fix the entry and return the user.

Internal issue: https://wearezeta.atlassian.net/browse/SQSERVICES-537

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
 - [x] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
- [x] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
