### PR TITLE
Replace 'otr' with 'proteus' in new message sending API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,13 @@
 
 ## API Changes
 
-* [Federation] Add qualified endpoint for sending messages at `POST /conversations/:domain/:cnv/otr/messages` (#1593).
+* [Federation] Add qualified endpoint for sending messages at `POST /conversations/:domain/:cnv/proteus/messages` (#1593, #1614, ...).
 
 ## Features
 
 ## Bug fixes and other updates
+
+* [helm] Allow sending messages upto 40 MB by default (#1614)
 
 ## Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ## API Changes
 
-* [Federation] Add qualified endpoint for sending messages at `POST /conversations/:domain/:cnv/proteus/messages` (#1593, #1614, ...).
+* [Federation] Add qualified endpoint for sending messages at `POST /conversations/:domain/:cnv/proteus/messages` (#1593, #1614, #1616).
 
 ## Features
 

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -279,7 +279,7 @@ nginx_conf:
       - all
       max_body_size: 40m
       body_buffer_size: 256k
-    - path: ~* ^/conversations/([^/]*)/([^/]*)/otr/messages
+    - path: ~* ^/conversations/([^/]*)/([^/]*)/proteus/messages
       envs:
       - all
       max_body_size: 40m

--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -311,7 +311,7 @@ http {
       proxy_pass http://galley;
     }
 
-    location ~* ^/conversations/([^/]*)/([^/]*)/otr/messages {
+    location ~* ^/conversations/([^/]*)/([^/]*)/proteus/messages {
         include common_response_with_zauth.conf;
         proxy_pass http://galley;
     }

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -255,7 +255,7 @@ data Api routes = Api
         :> "messages"
         :> ReqBody '[Servant.JSON, Proto] Public.NewOtrMessage
         :> UVerb 'POST '[Servant.JSON] PostOtrResponsesUnqualified,
-    postOtrMessage ::
+    postProteusMessage ::
       routes
         :- Summary "Post an encrypted message to a conversation (accepts only Protobuf)"
         :> Description PostOtrDescription
@@ -264,7 +264,7 @@ data Api routes = Api
         :> "conversations"
         :> Capture "domain" Domain
         :> Capture "cnv" ConvId
-        :> "otr"
+        :> "proteus"
         :> "messages"
         :> ReqBody '[Proto] Public.QualifiedNewOtrMessage
         :> UVerb 'POST '[Servant.JSON] PostOtrResponses

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -91,7 +91,7 @@ servantSitemap =
         GalleyAPI.getTeamConversation = Teams.getTeamConversation,
         GalleyAPI.deleteTeamConversation = Teams.deleteTeamConversation,
         GalleyAPI.postOtrMessageUnqualified = Update.postOtrMessageUnqualified,
-        GalleyAPI.postOtrMessage = Update.postOtrMessage
+        GalleyAPI.postProteusMessage = Update.postProteusMessage
       }
 
 sitemap :: Routes ApiBuilder Galley ()

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -43,7 +43,7 @@ module Galley.API.Update
     UpdateResponses,
 
     -- * Talking
-    postOtrMessage,
+    postProteusMessage,
     postOtrMessageUnqualified,
     postOtrBroadcastH,
     postProtoOtrBroadcastH,
@@ -639,8 +639,8 @@ postBotMessage zbot zcnv val message = do
 -- | FUTUREWORK: Send message to remote users, as of now this function fails if
 -- the conversation is not hosted on current backend. If the converastion is
 -- hosted on current backend, it completely ignores remote users.
-postOtrMessage :: UserId -> ConnId -> Domain -> ConvId -> Public.QualifiedNewOtrMessage -> Galley (Union GalleyAPI.PostOtrResponses)
-postOtrMessage zusr zcon convDomain cnv msg = do
+postProteusMessage :: UserId -> ConnId -> Domain -> ConvId -> Public.QualifiedNewOtrMessage -> Galley (Union GalleyAPI.PostOtrResponses)
+postProteusMessage zusr zcon convDomain cnv msg = do
   localDomain <- viewFederationDomain
   if localDomain /= convDomain
     then throwM federationNotImplemented

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -469,7 +469,7 @@ postMessageQualifiedLocalOwningBackendSuccess = do
             (deeRemote, deeClient, "text-for-dee")
           ]
     -- FUTUREWORK: Mock federator and ensure that a message to Dee is sent.
-    postOtrMessageQualified aliceUnqualified aliceClient convId message "data" Message.MismatchReportAll !!! do
+    postProteusMessageQualified aliceUnqualified aliceClient convId message "data" Message.MismatchReportAll !!! do
       const 201 === statusCode
       assertTrue_ (eqMismatchQualified mempty mempty mempty . responseJsonMaybe)
     liftIO $ do
@@ -512,7 +512,7 @@ postMessageQualifiedLocalOwningBackendMissingClients = do
   -- FUTUREWORK: Mock federator and ensure that clients of Dee are checked. Also
   -- ensure that message is not propagated to remotes
   WS.bracketR2 cannon bobUnqualified chadUnqualified $ \(wsBob, wsChad) -> do
-    postOtrMessageQualified aliceUnqualified aliceClient convId message "data" Message.MismatchReportAll !!! do
+    postProteusMessageQualified aliceUnqualified aliceClient convId message "data" Message.MismatchReportAll !!! do
       const 412 === statusCode
       let expectedMissing =
             QualifiedUserClients . Map.singleton owningDomain . UserClients . Map.fromList $
@@ -566,7 +566,7 @@ postMessageQualifiedLocalOwningBackendRedundantAndDeletedClients = do
           ]
     -- FUTUREWORK: Mock federator and ensure that a message to Dee is sent and
     -- nonParticipatingRemote is reported as redundant
-    postOtrMessageQualified aliceUnqualified aliceClient convId message "data" Message.MismatchReportAll !!! do
+    postProteusMessageQualified aliceUnqualified aliceClient convId message "data" Message.MismatchReportAll !!! do
       const 201 === statusCode
       let expectedRedundant =
             QualifiedUserClients . Map.singleton owningDomain . UserClients . Map.fromList $
@@ -620,7 +620,7 @@ postMessageQualifiedLocalOwningBackendIgnoreMissingClients = do
   -- FUTUREWORK: Mock federator and ensure that clients of Dee are checked. Also
   -- ensure that message is not propagated to remotes
   WS.bracketR2 cannon bobUnqualified chadUnqualified $ \(wsBob, wsChad) -> do
-    postOtrMessageQualified aliceUnqualified aliceClient convId message "data" Message.MismatchIgnoreAll !!! do
+    postProteusMessageQualified aliceUnqualified aliceClient convId message "data" Message.MismatchIgnoreAll !!! do
       const 201 === statusCode
       assertTrue_ (eqMismatchQualified mempty mempty mempty . responseJsonMaybe)
     let encodedTextForChad = Text.decodeUtf8 (B64.encode "text-for-chad")
@@ -630,7 +630,7 @@ postMessageQualifiedLocalOwningBackendIgnoreMissingClients = do
 
   -- Another way to ignore all is to report nobody
   WS.bracketR2 cannon bobUnqualified chadUnqualified $ \(wsBob, wsChad) -> do
-    postOtrMessageQualified aliceUnqualified aliceClient convId message "data" (Message.MismatchReportOnly mempty) !!! do
+    postProteusMessageQualified aliceUnqualified aliceClient convId message "data" (Message.MismatchReportOnly mempty) !!! do
       const 201 === statusCode
       assertTrue_ (eqMismatchQualified mempty mempty mempty . responseJsonMaybe)
     let encodedTextForChad = Text.decodeUtf8 (B64.encode "text-for-chad")
@@ -640,7 +640,7 @@ postMessageQualifiedLocalOwningBackendIgnoreMissingClients = do
 
   -- Yet another way to ignore all is to ignore specific users
   WS.bracketR2 cannon bobUnqualified chadUnqualified $ \(wsBob, wsChad) -> do
-    postOtrMessageQualified aliceUnqualified aliceClient convId message "data" (Message.MismatchIgnoreOnly (Set.fromList [bobOwningDomain, chadOwningDomain, deeRemote])) !!! do
+    postProteusMessageQualified aliceUnqualified aliceClient convId message "data" (Message.MismatchIgnoreOnly (Set.fromList [bobOwningDomain, chadOwningDomain, deeRemote])) !!! do
       const 201 === statusCode
       assertTrue_ (eqMismatchQualified mempty mempty mempty . responseJsonMaybe)
     let encodedTextForChad = Text.decodeUtf8 (B64.encode "text-for-chad")
@@ -651,7 +651,7 @@ postMessageQualifiedLocalOwningBackendIgnoreMissingClients = do
   -- When we ask only chad be reported, but one of their clients is missing, the
   -- message shouldn't be sent!
   WS.bracketR2 cannon bobUnqualified chadUnqualified $ \(wsBob, wsChad) -> do
-    postOtrMessageQualified aliceUnqualified aliceClient convId message "data" (Message.MismatchReportOnly (Set.fromList [chadOwningDomain])) !!! do
+    postProteusMessageQualified aliceUnqualified aliceClient convId message "data" (Message.MismatchReportOnly (Set.fromList [chadOwningDomain])) !!! do
       const 412 === statusCode
       let expectedMissing =
             QualifiedUserClients . Map.singleton owningDomain . UserClients . Map.fromList $
@@ -666,7 +666,7 @@ postMessageQualifiedRemoteOwningBackendNotImplemented = do
   convIdUnqualified <- randomId
   let remoteDomain = Domain "far-away.example.com"
       convId = Qualified convIdUnqualified remoteDomain
-  postOtrMessageQualified aliceUnqualified aliceClient convId [] "data" Message.MismatchReportAll !!! do
+  postProteusMessageQualified aliceUnqualified aliceClient convId [] "data" Message.MismatchReportAll !!! do
     const 403 === statusCode
     const (Right (Just (String "federation-not-implemented"))) === fmap (view (at @Object "label")) . responseJsonEither
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -639,7 +639,7 @@ postOtrMessage' reportMissing f u d c rec = do
       . zType "access"
       . json (mkOtrPayload d rec reportMissing)
 
-postOtrMessageQualified ::
+postProteusMessageQualified ::
   UserId ->
   ClientId ->
   Qualified ConvId ->
@@ -647,12 +647,12 @@ postOtrMessageQualified ::
   ByteString ->
   Message.ClientMismatchStrategy ->
   TestM ResponseLBS
-postOtrMessageQualified senderUser senderClient (Qualified conv domain) recipients dat strat = do
+postProteusMessageQualified senderUser senderClient (Qualified conv domain) recipients dat strat = do
   g <- view tsGalley
   let protoMsg = mkQualifiedOtrPayload senderClient recipients dat strat
   post $
     g
-      . paths ["conversations", toByteString' domain, toByteString' conv, "otr", "messages"]
+      . paths ["conversations", toByteString' domain, toByteString' conv, "proteus", "messages"]
       . zUser senderUser
       . zConn "conn"
       . zType "access"


### PR DESCRIPTION
'OTR' refers to the predecessor of proteus. Since we use proteus as our messaging protocol, it is more appropriate to call it so.

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
 - [x] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
- [x] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
