### PR TITLE
Federation: Allow conversation creation without specifying 'users' in the request (but only qualified_users)

### DIFF
--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -498,7 +498,7 @@ newConvSchema =
           )
       <*> newConvReceiptMode .= opt (field "receipt_mode" schema)
       <*> newConvUsersRole
-        .= ( field "conversation_role" schema
+        .= ( fieldWithDocModifier "conversation_role" (description ?~ usersRoleDesc) schema
                <|> pure roleNameWireAdmin
            )
   where
@@ -508,6 +508,14 @@ newConvSchema =
     qualifiedUsersDesc =
       "List of qualified user IDs (excluding the requestor) \
       \to be part of this conversation"
+    usersRoleDesc :: Text
+    usersRoleDesc =
+      cs $
+        "The conversation permissions the users \
+        \added in this request should have. \
+        \Optional, defaults to '"
+          <> show roleNameWireAdmin
+          <> "' if unset."
 
 newConvIsManaged :: NewConv -> Bool
 newConvIsManaged = maybe False cnvManaged . newConvTeam

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -460,13 +460,15 @@ newConvSchema :: ValueSchema NamedSwaggerDoc NewConv
 newConvSchema =
   objectWithDocModifier
     "NewConv"
-    (description ?~ "JSON object to create a new conversation")
+    (description ?~ "JSON object to create a new conversation. When using 'qualified_users' (preferred), you can omit 'users'")
     $ NewConv
       <$> newConvUsers
-        .= fieldWithDocModifier
-          "users"
-          (description ?~ usersDesc)
-          (array schema)
+        .= ( fieldWithDocModifier
+               "users"
+               (description ?~ usersDesc)
+               (array schema)
+               <|> pure []
+           )
       <*> newConvQualifiedUsers
         .= ( fieldWithDocModifier
                "qualified_users"

--- a/libs/wire-api/test/golden/fromJSON/testObject_NewConvUnmanaged_user_21.json
+++ b/libs/wire-api/test/golden/fromJSON/testObject_NewConvUnmanaged_user_21.json
@@ -1,0 +1,9 @@
+{
+    "qualified_users": [
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "domain": "testdomain.example.com"
+        }
+    ],
+    "conversation_role": "udhi2sbf7tzyshrh"
+}

--- a/libs/wire-api/test/unit/Test/Wire/API/Golden/FromJSON.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Golden/FromJSON.hs
@@ -38,7 +38,9 @@ tests =
           [(testObject_SimpleMember_user_1, "testObject_SimpleMember_user_1.json")],
       testCase "NewConv" $
         testFromJSONObjects
-          [(testObject_NewConvUnmanaged_user_1, "testObject_NewConvUnmanaged_user_1.json")],
+          [ (testObject_NewConvUnmanaged_user_1, "testObject_NewConvUnmanaged_user_1.json"),
+            (testObject_NewConvUnmanaged_user_21, "testObject_NewConvUnmanaged_user_21.json")
+          ],
       testCase "RmClient" $
         testFromJSONObjects
           [(testObject_RmClient_user_4, "testObject_RmClient_user_4.json")]

--- a/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/NewConvUnmanaged_user.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/NewConvUnmanaged_user.hs
@@ -524,3 +524,19 @@ testObject_NewConvUnmanaged_user_20 =
           newConvUsersRole = (fromJust (parseRoleName "udhi2sbf7tzyshrh"))
         }
     )
+
+testObject_NewConvUnmanaged_user_21 :: NewConvUnmanaged
+testObject_NewConvUnmanaged_user_21 =
+  NewConvUnmanaged
+    ( NewConv
+        { newConvUsers = [],
+          newConvQualifiedUsers = [Qualified (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000000000001"))) testDomain],
+          newConvName = Nothing,
+          newConvAccess = Set.fromList [],
+          newConvAccessRole = Nothing,
+          newConvMessageTimer = Nothing,
+          newConvReceiptMode = Nothing,
+          newConvTeam = Nothing,
+          newConvUsersRole = fromJust (parseRoleName "udhi2sbf7tzyshrh")
+        }
+    )


### PR DESCRIPTION
Allow creating a conversation without any local users by omitting the 'users' field entirely. This allows client teams to slowly deprecate the 'users' field in the request body in favour of 'qualified_users' going forward.

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
 - [x] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
- [x] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
