### PR TITLE
Document optField combinator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 -->
 
+# Unreleased
+
+## Internal changes
+
+* schema-profunctor: add `optField` combinator and corresponding documentation (#1621, #1624).
+
 # 2021-06-23
 
 ## API Changes


### PR DESCRIPTION
This adds some extra explanations to the section about optional fields, and introduces the new `optField` combinator, added to work around the parser leniency issue described in #1621.

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.