### PR TITLE
Swagger fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 * schema-profunctor: add `optField` combinator and corresponding documentation (#1621, #1624).
 
+## Documentation
+
+* Fix validation errors in Swagger documentation (#1625).
+
 # 2021-06-23
 
 ## API Changes

--- a/libs/schema-profunctor/src/Data/Schema.hs
+++ b/libs/schema-profunctor/src/Data/Schema.hs
@@ -269,7 +269,7 @@ field = fieldOver id
 
 -- | A schema for a JSON object with a single optional field.
 optField ::
-  HasField doc' doc =>
+  (HasOpt doc, HasField doc' doc) =>
   Text ->
   -- | The value to use when serialising Nothing.
   Maybe A.Value ->
@@ -311,7 +311,7 @@ fieldOver l name sch = SchemaP (SchemaDoc s) (SchemaIn r) (SchemaOut w)
 -- See documentation of 'fieldOver' for more details.
 optFieldOver ::
   forall doc' doc v v' a b.
-  HasField doc' doc =>
+  (HasOpt doc, HasField doc' doc) =>
   Lens v v' A.Object A.Value ->
   Text ->
   Maybe A.Value ->
@@ -330,7 +330,7 @@ optFieldOver l name def sch = SchemaP (SchemaDoc s) (SchemaIn r) (SchemaOut w)
       pure [name A..= v]
     w Nothing = pure (maybeToList (fmap (name A..=) def))
 
-    s = mkField name (schemaDoc sch)
+    s = mkOpt (mkField name (schemaDoc sch))
 
 -- | Like 'field', but apply an arbitrary function to the
 -- documentation of the field.
@@ -345,7 +345,7 @@ fieldWithDocModifier name modify sch = field name (over doc modify sch)
 -- | Like 'optField', but apply an arbitrary function to the
 -- documentation of the field.
 optFieldWithDocModifier ::
-  HasField doc' doc =>
+  (HasOpt doc, HasField doc' doc) =>
   Text ->
   Maybe A.Value ->
   (doc' -> doc') ->

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -102,7 +102,7 @@ qualifiedSchema ::
   ValueSchema NamedSwaggerDoc a ->
   ValueSchema NamedSwaggerDoc (Qualified a)
 qualifiedSchema name fieldName sch =
-  object ("Qualified." <> name) $
+  object ("Qualified_" <> name) $
     Qualified
       <$> qUnqualified .= field fieldName sch
       <*> qDomain .= field "domain" schema

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -102,7 +102,7 @@ qualifiedSchema ::
   ValueSchema NamedSwaggerDoc a ->
   ValueSchema NamedSwaggerDoc (Qualified a)
 qualifiedSchema name fieldName sch =
-  object ("Qualified " <> name) $
+  object ("Qualified." <> name) $
     Qualified
       <$> qUnqualified .= field fieldName sch
       <*> qDomain .= field "domain" schema

--- a/libs/wire-api/src/Wire/API/Conversation/Role.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Role.hs
@@ -102,12 +102,13 @@ instance S.ToSchema ConversationRole where
   declareNamedSchema _ = do
     conversationRoleSchema <-
       S.declareSchemaRef (Proxy @RoleName)
+    actionsSchema <- S.declareSchema (Proxy @[Action])
     let convRoleSchema :: S.Schema =
           mempty
             & S.properties . at "conversation_role" ?~ conversationRoleSchema
             & S.properties . at "actions"
               ?~ S.Inline
-                ( S.toSchema (Proxy @[Action])
+                ( actionsSchema
                     & description ?~ "The set of actions allowed for this role"
                 )
     pure (S.NamedSchema (Just "ConversationRole") convRoleSchema)

--- a/libs/wire-api/src/Wire/API/UserMap.hs
+++ b/libs/wire-api/src/Wire/API/UserMap.hs
@@ -61,7 +61,7 @@ instance (Typeable a, ToSchema a, ToJSON a, Arbitrary a) => ToSchema (UserMap (S
     mapSch <- declareSchema (Proxy @(Map UserId (Set a)))
     let valueTypeName = Text.pack $ show $ typeRep $ Proxy @a
     return $
-      NamedSchema (Just $ "UserMap (Set " <> valueTypeName <> ")") $
+      NamedSchema (Just $ "UserMap.Set." <> valueTypeName) $
         mapSch
           & description ?~ "Map of UserId to (Set " <> valueTypeName <> ")"
           & example ?~ toJSON (Map.singleton (generateExample @UserId) (Set.singleton (generateExample @a)))
@@ -70,9 +70,9 @@ instance (Typeable a, ToSchema (UserMap a)) => ToSchema (QualifiedUserMap a) whe
   declareNamedSchema _ = do
     mapSch <- declareSchema (Proxy @(Map Domain (UserMap a)))
     let userMapSchema = toSchema (Proxy @(UserMap a))
-    let valueTypeName = Text.pack $ show $ typeRep $ Proxy @a
+    let valueTypeName = Text.replace " " "." . Text.pack $ show $ typeRep $ Proxy @a
     return $
-      NamedSchema (Just $ "QualifiedUserMap (" <> valueTypeName <> ")") $
+      NamedSchema (Just $ "QualifiedUserMap." <> valueTypeName) $
         mapSch
           & description ?~ "Map of Domain to (UserMap (" <> valueTypeName <> "))."
           & example

--- a/libs/wire-api/src/Wire/API/UserMap.hs
+++ b/libs/wire-api/src/Wire/API/UserMap.hs
@@ -61,7 +61,7 @@ instance (Typeable a, ToSchema a, ToJSON a, Arbitrary a) => ToSchema (UserMap (S
     mapSch <- declareSchema (Proxy @(Map UserId (Set a)))
     let valueTypeName = Text.pack $ show $ typeRep $ Proxy @a
     return $
-      NamedSchema (Just $ "UserMap.Set." <> valueTypeName) $
+      NamedSchema (Just $ "UserMap_Set_" <> valueTypeName) $
         mapSch
           & description ?~ "Map of UserId to (Set " <> valueTypeName <> ")"
           & example ?~ toJSON (Map.singleton (generateExample @UserId) (Set.singleton (generateExample @a)))
@@ -70,9 +70,9 @@ instance (Typeable a, ToSchema (UserMap a)) => ToSchema (QualifiedUserMap a) whe
   declareNamedSchema _ = do
     mapSch <- declareSchema (Proxy @(Map Domain (UserMap a)))
     let userMapSchema = toSchema (Proxy @(UserMap a))
-    let valueTypeName = Text.replace " " "." . Text.pack $ show $ typeRep $ Proxy @a
+    let valueTypeName = Text.replace " " "_" . Text.pack $ show $ typeRep $ Proxy @a
     return $
-      NamedSchema (Just $ "QualifiedUserMap." <> valueTypeName) $
+      NamedSchema (Just $ "QualifiedUserMap_" <> valueTypeName) $
         mapSch
           & description ?~ "Map of Domain to (UserMap (" <> valueTypeName <> "))."
           & example

--- a/libs/wire-api/src/Wire/API/Wrapped.hs
+++ b/libs/wire-api/src/Wire/API/Wrapped.hs
@@ -43,7 +43,7 @@ instance (FromJSON a, KnownSymbol name) => FromJSON (Wrapped name a) where
 -- here.
 instance (ToSchema a, KnownSymbol name) => ToSchema (Wrapped name a) where
   declareNamedSchema _ = do
-    let wrappedSchema = Inline (toSchema (Proxy @a))
+    wrappedSchema <- declareSchemaRef (Proxy @a)
     pure $
       NamedSchema Nothing $
         mempty

--- a/libs/wire-api/src/Wire/API/Wrapped.hs
+++ b/libs/wire-api/src/Wire/API/Wrapped.hs
@@ -43,7 +43,7 @@ instance (FromJSON a, KnownSymbol name) => FromJSON (Wrapped name a) where
 -- here.
 instance (ToSchema a, KnownSymbol name) => ToSchema (Wrapped name a) where
   declareNamedSchema _ = do
-    wrappedSchema <- declareSchemaRef (Proxy @a)
+    let wrappedSchema = Inline (toSchema (Proxy @a))
     pure $
       NamedSchema Nothing $
         mempty

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -53,7 +53,7 @@ import qualified Brig.User.Auth.Cookie as Auth
 import Brig.User.Email
 import Brig.User.Phone
 import Control.Error hiding (bool)
-import Control.Lens (view, (.~), (?~), (^.))
+import Control.Lens (view, (%~), (.~), (?~), (^.))
 import Control.Monad.Catch (throwM)
 import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
@@ -123,6 +123,7 @@ swaggerDocsAPI =
     (BrigAPI.swagger <> GalleyAPI.swaggerDoc <> LegalHoldAPI.swaggerDoc <> SparAPI.swaggerDoc)
       & S.info . S.title .~ "Wire-Server API"
       & S.info . S.description ?~ desc
+      & S.security %~ nub
   where
     desc =
       Text.pack

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -59,6 +59,7 @@ import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
 import Data.CommaSeparatedList (CommaSeparatedList (fromCommaSeparatedList))
+import Data.Containers.ListUtils (nubOrd)
 import Data.Domain
 import Data.Handle (Handle, parseHandle)
 import Data.Id as Id
@@ -124,7 +125,10 @@ swaggerDocsAPI =
       & S.info . S.title .~ "Wire-Server API"
       & S.info . S.description ?~ desc
       & S.security %~ nub
+      & S.definitions . traverse %~ sanitise
   where
+    sanitise :: S.Schema -> S.Schema
+    sanitise = (S.properties . traverse . S._Inline %~ sanitise) . (S.required %~ nubOrd)
     desc =
       Text.pack
         [QQ.i|


### PR DESCRIPTION
This fixes issues in our Swagger schema reported by @ffflorian, plus other validation errors reported by https://editor.swagger.io/.

## Fixes

 - Removed spaces and parentheses from schema names. I simply used dots instead of spaces and avoided parentheses.
 - Fixed dangling reference by explicitly declaring `Action` in a manually defined `Swagger.Schema`.
 - Made the schema produced by `optField` optional (this should have been part of #1621, but I forgot).
 - Fixed the schema for `FormRedirect`, which made absolutely no sense. It was generated by the generic mechanism, but now it's written by hand. See the corresponding commit (or comment) for more information on why it was broken.
 - Removed duplicated `SecurityRequirement` entries. This is a bit strange, since it is a list of maps, instead of simply a map, so it concatenates in the wrong way. For now I've simply fixed it by removing duplicates at the point where we generate the final Swagger.
 - Removed duplicated `required` properties. Again, this should be a set instead of a list, but for now I've also fixed it by running a simple-minded sanitisation function where we generate the final Swagger.

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
