### PR TITLE
Add label to parse error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 * Fix validation errors in Swagger documentation (#1625).
 
+## Bug fixes and other updates
+
+* Restore old behaviour for parse errors in request bodies (#1628, #1629).
+
 # 2021-06-23
 
 ## API Changes

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -159,7 +159,8 @@ bodyParserErrorFormatter _ _ errMsg =
         Aeson.encode $
           Aeson.object
             [ "code" Aeson..= Aeson.Number 400,
-              "message" Aeson..= errMsg
+              "message" Aeson..= errMsg,
+              "label" Aeson..= ("bad-request" :: Text)
             ],
       Servant.errHeaders = [(HTTP.hContentType, HTTPMedia.renderHeader (Servant.contentType (Proxy @Servant.JSON)))]
     }

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -493,6 +493,7 @@ testRemoveClientShortPwd brig = do
   err :: Object <- responseJsonError resp
   liftIO $ do
     (err ^. at "code") @?= Just (Number 400)
+    (err ^. at "label") @?= Just (String "bad-request")
     (err ^. at "message") @?= Just (String "Error in $.password: outside range [6, 1024]")
   where
     client ty lk =

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -123,7 +123,8 @@ bodyParserErrorFormatter _ _ errMsg =
         Aeson.encode $
           Aeson.object
             [ "code" Aeson..= Aeson.Number 400,
-              "message" Aeson..= errMsg
+              "message" Aeson..= errMsg,
+              "label" Aeson..= ("bad-request" :: Text)
             ],
       Servant.errHeaders = [(HTTP.hContentType, HTTPMedia.renderHeader (Servant.contentType (Proxy @Servant.JSON)))]
     }


### PR DESCRIPTION
A parse error in an endpoint body now returns a proper JSON error object that includes the label "bad-request". This should reproduce the behaviour on parse errors before the migration to Servant.

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
 - [x] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
- [x] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
