### PR TITLE
charts/nginz: Add restrictive CORS headers to all URLs and explicitly…

### DIFF
--- a/changelog.d/0-release-notes/cors
+++ b/changelog.d/0-release-notes/cors
@@ -1,6 +1,5 @@
-
 The `nginz` chart now configures nginx to only allow cross-origin requests from
-an epxlicit allow list of sub-domains. By default these are:
+an explicit allow list of subdomains. By default these are:
 
 ```yaml
 nginz:
@@ -11,5 +10,6 @@ nginz:
     - accounts
 ```
 
-If you changed the names of these services you have to adjust those names in the nginz config as well!
+If you changed the names of these services, you must adjust those names in the
+nginz config as well.
 

--- a/changelog.d/0-release-notes/cors
+++ b/changelog.d/0-release-notes/cors
@@ -1,0 +1,15 @@
+
+The `nginz` chart now configures nginx to only allow cross-origin requests from
+an epxlicit allow list of sub-domains. By default these are:
+
+```yaml
+nginz:
+  nginx_conf:
+    allowlisted_origins:
+    - webapp
+    - teams
+    - accounts
+```
+
+If you changed the names of these services you have to adjust those names in the nginz config as well!
+

--- a/changelog.d/0-release-notes/cors
+++ b/changelog.d/0-release-notes/cors
@@ -7,7 +7,7 @@ nginz:
     allowlisted_origins:
     - webapp
     - teams
-    - accounts
+    - account
 ```
 
 If you changed the names of these services, you must adjust those names in the

--- a/changelog.d/3-bug-fixes/cors
+++ b/changelog.d/3-bug-fixes/cors
@@ -1,0 +1,2 @@
+* There is now an explicit CORS allowlist for _all_ endpoints.  Even subdomains need to be listed explicitly (whilst before all subdomains were accepted). This is technically a breaking change as now only javascript applications that are known can access the backend.
+

--- a/changelog.d/3-bug-fixes/cors
+++ b/changelog.d/3-bug-fixes/cors
@@ -1,2 +1,2 @@
-* There is now an explicit CORS allowlist for _all_ endpoints.  Even subdomains need to be listed explicitly (whilst before all subdomains were accepted). This is technically a breaking change as now only javascript applications that are known can access the backend.
+There is now an explicit CORS allow list for *all* endpoints. In previous releases, all subdomains were accepted, however they must now be listed explicitly. This is a **breaking change**, as now only known Javascript applications may access the backend.
 

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -295,7 +295,7 @@ http {
         more_set_headers 'Access-Control-Allow-Credentials: true';
             {{ end -}}
 
-        more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+        more_set_headers 'Access-Control-Allow-Origin: $cors_header';
 
         more_set_headers 'Access-Control-Expose-Headers: Request-Id, Location';
         more_set_headers 'Request-Id: $request_id';

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -125,7 +125,9 @@ http {
 
   map $http_origin $cors_header {
       default "";
-      "~^https://([^/]+\.)?{{ .Values.nginx_conf.external_env_domain | replace "." "\\." }}(:[0-9]{2,5})?$" "$http_origin";
+    {{ range $origin := required "allowlisted_origins is required" .Values.nginx_conf.allowlisted_origins }}
+      "{{ $origin }} "$http_origin";
+    {{ end }}
   }
 
 
@@ -293,11 +295,7 @@ http {
         more_set_headers 'Access-Control-Allow-Credentials: true';
             {{ end -}}
 
-            {{ if ($location.restrict_whitelisted_origin) -}}
-        more_set_headers 'Access-Control-Allow-Origin: $cors_header';
-            {{- else }}
         more_set_headers 'Access-Control-Allow-Origin: $http_origin';
-            {{- end }}
 
         more_set_headers 'Access-Control-Expose-Headers: Request-Id, Location';
         more_set_headers 'Request-Id: $request_id';

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -125,8 +125,8 @@ http {
 
   map $http_origin $cors_header {
       default "";
-    {{ range $origin := required "allowlisted_origins is required" .Values.nginx_conf.allowlisted_origins }}
-      "{{ $origin }} "$http_origin";
+    {{ range $origin := .Values.nginx_conf.allowlisted_origins }}
+      "https://{{ $origin }}.{{ .Values.nginx_conf.external_env_domain}} "$http_origin";
     {{ end }}
   }
 

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -52,6 +52,8 @@ nginx_conf:
   - ~* ^/conversations/([^/]*)/call/state
   - /search/top
   - /search/common
+  # -- The origins from which we allow CORS requests. Can be Regexes
+  # allowlisted_origins: []
   upstreams:
     cargohold:
     - path: ~* ^/conversations/([^/]*)/assets
@@ -79,7 +81,6 @@ nginx_conf:
       envs:
       - all
       allow_credentials: true
-      restrict_whitelisted_origin: true
       max_body_size: "0"
       disable_request_buffering: true
     brig:
@@ -149,7 +150,6 @@ nginx_conf:
       envs:
       - all
       allow_credentials: true
-      restrict_whitelisted_origin: true
     - path: /bot/self
       envs:
       - all
@@ -170,13 +170,11 @@ nginx_conf:
       envs:
       - all
       allow_credentials: true
-      restrict_whitelisted_origin: true
       disable_zauth: true
     - path: /activate
       envs:
       - all
       allow_credentials: true
-      restrict_whitelisted_origin: true
       disable_zauth: true
     - path: /delete
       envs:
@@ -238,7 +236,6 @@ nginx_conf:
       - all
       disable_zauth: true
       allow_credentials: true
-      restrict_whitelisted_origin: true
       unlimited_requests_endpoint: true
     - path: /login
       envs:

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -52,8 +52,11 @@ nginx_conf:
   - ~* ^/conversations/([^/]*)/call/state
   - /search/top
   - /search/common
-  # -- The origins from which we allow CORS requests. Can be Regexes
-  # allowlisted_origins: []
+  # -- The origins from which we allow CORS requests. These are combined with 'external_env_domain' to form a full url
+  allowlisted_origins:
+    - webapp
+    - teams
+    - accounts
   upstreams:
     cargohold:
     - path: ~* ^/conversations/([^/]*)/assets

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -56,7 +56,7 @@ nginx_conf:
   allowlisted_origins:
     - webapp
     - teams
-    - accounts
+    - account
   upstreams:
     cargohold:
     - path: ~* ^/conversations/([^/]*)/assets

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -192,6 +192,8 @@ nginz:
   nginx_conf:
     env: staging
     external_env_domain: zinfra.io
+    # NOTE: Web apps are disabled by default
+    allowlisted_origins: []
   secrets:
     basicAuth: "whatever"
     zAuth:


### PR DESCRIPTION
Add restrictive CORS headers to all origins and explicitly allowlist allowed origins

There is no reason not to have restrictive CORS on all endpoints; given
our API is currently only consumed by known services. We can loosen this
restriction again in the future (e.g. when we have something like OAuth
integration).

We also move to an explicit allowlist instead of trusting the entirety
of `external_env_domain`. Especially on-prem people might have many more
services running on their base domain and we as Wire have no control
over it. We do not want other services not in our control to be a vector
for e.g. XSS attacks. Hence we require the user of our charts to
explicitly allowlist all the expected origins.  We will update the docs
to guide people into making this update if needed. 



## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [ ] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
 - [ ] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
- [ ] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
