### PR TITLE
Adjust grpccurl and python client examples to recent protobuf changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * schema-profunctor: add `optField` combinator and corresponding documentation (#1621, #1624).
 * [Federation] Let a receiving backend decide conversation attribute specifics of its users
   added to a new conversation via `POST /federation/register-conversation` (#1622)
+* [Federation] Adjust scripts under ./hack/federation to work with recent changes to the federation API (#1632)
 
 ## Documentation
 

--- a/hack/federation/grpcurlhandle.sh
+++ b/hack/federation/grpcurlhandle.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 
+# Usage:
+#
+# First, run services (including nginz) locally:
+#
+#   export INTEGRATION_USE_NGINZ=1; ./services/start-services-only.sh
+#
+# Then, run this command for user search (ideally on a handle that exists)
+#
+#
+#
+handle="pyaewrqxggbtbvzdsubkl" # change this to a valid handle in your local database
+
 command -v grpcurl >/dev/null 2>&1 || {
     echo >&2 "grpcurl is not installed, aborting. Maybe try ' nix-env -iA nixpkgs.grpcurl '?"
     exit 1
 }
 
-path=$(echo -n users/by-handle | base64)
-body=$(echo -n "alice" | base64)
+path=$(echo -n federation/get-user-by-handle | base64)
+body=$(echo -n "\"$handle\"" | base64)
 
 TOP_LEVEL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
@@ -20,22 +32,15 @@ function getHandle() {
     fi
     set -x
     grpcurl -d @ -format json $AUTHORITY $MODE -import-path "${TOP_LEVEL}/libs/wire-api-federation/proto/" -proto router.proto "$HOST:$PORT" wire.federator.Inward/call <<EOM
-{"component": "Brig", "path": "$path", "body": "$body", "originDomain": "localhost"}
+{"component": "Brig", "path": "$path", "body": "$body", "originDomain": "grpcurl.example.com"}
 EOM
     { set +x; } 2>/dev/null # stop outputting commands and don't print the set +x line
     echo "===|"
     echo
 }
 
-HOST=localhost
+HOST="localhost"
+SERVERNAME="federator.integration.example.com"
 PORT=8443
 MODE="-cacert ${TOP_LEVEL}/services/nginz/integration-test/conf/nginz/integration-ca.pem"
-SERVERNAME="federator.integration.example.com"
-getHandle "local nginz on port 8443 using self-signed cert"
-
-# HOST=
-# PORT=443 # tls port of currently-deployed ingress in 'grpc' namespace
-# MODE="-insecure"
-# SERVERNAME="federator.integration.example.com"
-# # making an insecure/ignore-certificates connection over TLS works:
-# getHandle "description"
+getHandle "local"

--- a/hack/federation/python-client/README.md
+++ b/hack/federation/python-client/README.md
@@ -8,6 +8,7 @@ poetry run python -m grpc_tools.protoc -I../../../libs/wire-api-federation/proto
 Run services locally:
 
 ```
+export INTEGRATION_USE_NGINZ=1
 ../../../services/start-services-only.sh
 ```
 
@@ -21,14 +22,22 @@ expected output should be:
 
 ```
 starting client...
-request:  path: "users/by-handle"
-query {
-  key: "handle"
-  value: "alice"
-}
+request:  path: "federation/get-user-by-handle"
+body: "\"pyaewrqxggbtbvzdsubkl\""
+originDomain: "python.example.com"
 
-response:  httpResponse {
-  responseStatus: 404
-  responseBody: "Handle not found."
+json reponse:
+ {
+  "handle": "pyaewrqxggbtbvzdsubkl",
+  "qualified_id": {
+    "domain": "example.com",
+    "id": "0f3880e6-5fb5-4c3d-963d-8ea36e15717c"
+  },
+  "accent_id": 0,
+  "picture": [],
+  "legalhold_status": "no_consent",
+  "name": "\u7985\u9a71\ud4d1\u7485",
+  "id": "0f3880e6-5fb5-4c3d-963d-8ea36e15717c",
+  "assets": []
 }
 ```

--- a/hack/federation/python-client/client.py
+++ b/hack/federation/python-client/client.py
@@ -1,4 +1,5 @@
 import grpc
+import json
 
 from router_pb2 import *
 import router_pb2_grpc
@@ -10,17 +11,19 @@ channel = grpc.insecure_channel('localhost:8098') # public-facing federator port
 stub = router_pb2_grpc.InwardStub(channel)
 
 def handle_search(handle):
-    param = QueryParam(key="handle".encode("utf-8"), value=handle.encode("utf-8"))
     return Request(
-            path="users/by-handle".encode("utf-8"),
-            query=[param],
-            method=GET,
+            path="federation/get-user-by-handle".encode("utf-8"),
+            body=('"' + handle + '"').encode("utf-8"),
+            originDomain="python.example.com",
             component=Brig)
 
-req = handle_search("alice")
+req = handle_search("pyaewrqxggbtbvzdsubkl")
 
 print("request: ", req)
 
 response = stub.call(req)
-
-print("response: ", response)
+try:
+    jsonresponse = json.dumps(json.loads(response.body.decode('utf-8')), indent=2)
+    print("json reponse:\n", jsonresponse)
+except:
+    print("non-json response:\n", response)


### PR DESCRIPTION
Both the grpcurl and the python client were not working anymore after the changes made in #1447, #1445 and #1511 This Pr makes these scripts work again.

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.