### PR TITLE
[WIP] [RFC] per-request authorization for the example RPC get conversations [skip ci]

### DIFF
--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -32,6 +32,7 @@ import Wire.API.Conversation (Access, AccessRole, ConvType, Conversation, Receip
 import Wire.API.Conversation.Member (OtherMember)
 import Wire.API.Conversation.Role (RoleName)
 import Wire.API.Federation.Client (FederationClientFailure, FederatorClient)
+import Wire.API.Federation.Domain
 import qualified Wire.API.Federation.GRPC.Types as Proto
 import Wire.API.Federation.Util.Aeson (CustomEncoded (CustomEncoded))
 
@@ -50,7 +51,8 @@ data Api routes = Api
         :> Post '[JSON] (),
     getConversations ::
       routes
-        :- "federation"
+        :- DomainHeader
+        :> "federation"
         :> "get-conversations"
         :> ReqBody '[JSON] GetConversationsRequest
         :> Post '[JSON] GetConversationsResponse,

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -130,6 +130,13 @@ federationUnavailable err =
     "federation-not-available"
     ("Local federator not available: " <> LT.fromStrict err)
 
+federationUnauthorized :: Text -> Wai.Error
+federationUnauthorized err =
+  Wai.mkError
+    HTTP.status403
+    "federation-unauthorized"
+    (LT.fromStrict err)
+
 federationRemoteError :: Proto.OutwardError -> Wai.Error
 federationRemoteError err = Wai.mkError status (LT.fromStrict label) (LT.fromStrict msg)
   where


### PR DESCRIPTION
Given backend A, B and C with a conversation1@A containing users from A and B. We probably wish to restrict certain actions to be done by malicious backends, such as getting or inserting users into conversation1. If server2server authentication allows us to know "this requests claiming to be from server C is indeed from server C", and our membership check allows us to say "the request contains an originUser Bob@B wanting to add someone to conversation1 which is allowed since Bob belongs to conversation1", we still have a problem, since backend C can create a request with originDomain=C (which is valid) and originUser=Bob@B (which is a lie), and currently the server will accept that request, since nothing connects the domain of the sender backend with the domain of the (supposed) sending user.

Doing a check in each function as done in this first PR would in theory work, but may be brittle as prone to regressions and a missed check for the next endpoint/RPC that gets implemented. 

Can we solve this in a better fashion?

Side question: is there a way to add a header to the servant API, without needing to provide it explicitly when making requests [here](https://github.com/wireapp/wire-server/blob/develop/services/galley/src/Galley/API/Query.hs#L109) since it's already added on the way [here](https://github.com/wireapp/wire-server/blob/develop/services/federator/src/Federator/Service.hs#L64)? 

## Checklist

 - [ ] Title of this PR explains the impact of the change.
 - [ ] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
 - [ ] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
- [ ] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
