### PR TITLE
Remote client discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ## Features
 
 * [Federation] (Not-yet-used) RPC to propagate messages to other backends (#1596).
+* [Federation] Fetch remote user's clients when sending messages (#1635).
 
 ## Internal changes
 

--- a/libs/bilge/src/Bilge/Assert.hs
+++ b/libs/bilge/src/Bilge/Assert.hs
@@ -26,6 +26,7 @@ module Bilge.Assert
     (===),
     (=/=),
     (=~=),
+    assertResponse,
     assertTrue,
     assertTrue_,
     assert,
@@ -139,6 +140,11 @@ f =/= g = Assertions $ tell [\r -> test " === " (/=) (f r) (g r)]
   (Response (Maybe Lazy.ByteString) -> a) ->
   Assertions ()
 f =~= g = Assertions $ tell [\r -> test " not in " contains (f r) (g r)]
+
+-- | Most generic assertion on a request. If the test function evaluates to
+-- @(Just msg)@ then the assertion fails with the error message @msg@.
+assertResponse :: HasCallStack => (Response (Maybe Lazy.ByteString) -> Maybe String) -> Assertions ()
+assertResponse f = Assertions $ tell [f]
 
 -- | Generic assertion on a request. The 'String' argument will be printed
 -- in case the assertion fails.

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -203,10 +203,12 @@ postQualifiedOtrMessage senderType sender mconn convId msg = runUnionT $ do
   unless (Set.member senderClient (Map.findWithDefault mempty (senderDomain, sender) qualifiedLocalClients)) $ do
     throwUnion ErrorDescription.unknownClient
 
+  qualifiedRemoteClients <- lift $ getRemoteClients convId
+
   let (sendMessage, validMessages, mismatch) =
         checkMessageClients
           (senderDomain, sender, qualifiedNewOtrSender msg)
-          qualifiedLocalClients
+          (qualifiedLocalClients <> qualifiedRemoteClients)
           (flattenMap $ qualifiedNewOtrRecipients msg)
           (qualifiedNewOtrClientMismatchStrategy msg)
       otrResult = mkMessageSendingStatus nowMillis mismatch mempty

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -8,13 +8,14 @@ import Data.List1 (singleton)
 import qualified Data.Map as Map
 import Data.Map.Lens (toMapOf)
 import Data.Proxy
-import Data.Qualified (Qualified (..))
+import Data.Qualified (Qualified (..), partitionQualified)
 import Data.SOP (I (..), htrans, unI)
 import qualified Data.Set as Set
 import Data.Set.Lens
+import Data.Tagged
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import Galley.API.LegalHold.Conflicts (guardQualifiedLegalholdPolicyConflicts)
-import Galley.API.Util (runUnionT, throwUnion, viewFederationDomain)
+import Galley.API.Util (runFederatedBrig, runUnionT, throwUnion, viewFederationDomain)
 import Galley.App
 import qualified Galley.Data as Data
 import Galley.Data.Services as Data
@@ -30,11 +31,13 @@ import Imports
 import Servant.API (Union, WithStatus (..))
 import Wire.API.ErrorDescription as ErrorDescription
 import Wire.API.Event.Conversation
+import qualified Wire.API.Federation.API.Brig as FederatedBrig
 import Wire.API.Message
 import qualified Wire.API.Message as Public
 import Wire.API.Routes.Public.Galley as Public
 import Wire.API.Team.LegalHold
 import Wire.API.User.Client
+import Wire.API.UserMap (UserMap (..))
 
 data UserType = User | Bot
 
@@ -144,6 +147,22 @@ checkMessageClients sender participantMap recipientMap mismatchStrat =
         mkQualifiedMismatch reportedMissing redundant deleted
       )
 
+getRemoteClients :: ConvId -> Galley (Map (Domain, UserId) (Set ClientId))
+getRemoteClients convId = do
+  remoteMembers <- Data.lookupRemoteMembers convId
+  -- FUTUREWORK: parallelise RPCs
+  fmap mconcat
+    . traverse (uncurry getRemoteClientsFromDomain)
+    . Map.assocs
+    . partitionQualified
+    . map (unTagged . rmId)
+    $ remoteMembers
+  where
+    getRemoteClientsFromDomain :: Domain -> [UserId] -> Galley (Map (Domain, UserId) (Set ClientId))
+    getRemoteClientsFromDomain domain uids = do
+      let rpc = FederatedBrig.getUserClients FederatedBrig.clientRoutes (FederatedBrig.GetUserClients uids)
+      Map.mapKeys (domain,) . fmap (Set.map pubClientId) . userMap <$> runFederatedBrig domain rpc
+
 postQualifiedOtrMessage :: UserType -> UserId -> Maybe ConnId -> ConvId -> Public.QualifiedNewOtrMessage -> Galley (Union Public.PostOtrResponses)
 postQualifiedOtrMessage senderType sender mconn convId msg = runUnionT $ do
   alive <- Data.isConvAlive convId
@@ -157,6 +176,7 @@ postQualifiedOtrMessage senderType sender mconn convId msg = runUnionT $ do
     Data.deleteConversation convId
     throwUnion ErrorDescription.convNotFound
 
+  -- get local clients
   localMembers <- Data.members convId
   let localMemberIds = memId <$> localMembers
       localMemberMap :: Map UserId LocalMember

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -151,7 +151,7 @@ getRemoteClients :: ConvId -> Galley (Map (Domain, UserId) (Set ClientId))
 getRemoteClients convId = do
   remoteMembers <- Data.lookupRemoteMembers convId
   -- FUTUREWORK: parallelise RPCs
-  fmap mconcat
+  fmap mconcat -- concatenating maps is correct here, because their sets of keys are disjoint
     . traverse (uncurry getRemoteClientsFromDomain)
     . Map.assocs
     . partitionQualified

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -83,6 +83,7 @@ module Galley.Data
     addLocalMembersToRemoteConv,
     member,
     members,
+    lookupRemoteMembers,
     removeMember,
     removeMembers,
     removeLocalMembers,

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -531,8 +531,7 @@ postMessageQualifiedLocalOwningBackendMissingClients = do
 
   -- Missing Bob, chadClient2 and Dee
   let message = [(chadOwningDomain, chadClient, "text-for-chad")]
-  -- FUTUREWORK: Mock federator and ensure that clients of Dee are checked. Also
-  -- ensure that message is not propagated to remotes
+  -- FUTUREWORK: Mock federator and ensure that message is not propagated to remotes
   WS.bracketR2 cannon bobUnqualified chadUnqualified $ \(wsBob, wsChad) -> do
     let responses _ = UserMap (Map.singleton (qUnqualified deeRemote) (Set.singleton (PubClient deeClient Nothing)))
     (resp2, _requests) <- postProteusMessageQualifiedWithMockFederator aliceUnqualified aliceClient convId message "data" Message.MismatchReportAll responses

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -488,7 +488,7 @@ postMessageQualifiedLocalOwningBackendSuccess = do
                           { F.component = F.Brig,
                             F.path = "/federation/get-user-clients",
                             F.body = cs (encode (FederatedBrig.GetUserClients [qUnqualified deeRemote])),
-                            F.originDomain = "example.com"
+                            F.originDomain = domainText owningDomain
                           }
                       )
                 }

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -321,11 +321,10 @@ postCryptoMessage2 = do
   -- Missing eve
   let m = [(bob, bc, toBase64Text "hello bob")]
   r1 <-
-    postOtrMessage id alice ac conv m
-      <!! const 412 === statusCode
+    postOtrMessage id alice ac conv m <!! do
+      const 412 === statusCode
+      assertMismatchWithMessage (Just "client mismatch") [(eve, Set.singleton ec)] [] []
   let x = responseJsonUnsafeWithMsg "ClientMismatch" r1
-  pure r1
-    !!! assertMismatchWithMessage (Just "client mismatch") [(eve, Set.singleton ec)] [] []
   -- Fetch all missing clients prekeys
   r2 <-
     post (b . zUser alice . path "/users/prekeys" . json (missingClients x))

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -601,8 +601,7 @@ postMessageQualifiedLocalOwningBackendRedundantAndDeletedClients = do
             (nonMemberOwningDomain, nonMemberOwningDomainClient, "text-for-non-member-owning-domain"),
             (nonMemberRemote, nonMemberRemoteClient, "text-for-non-member-remote")
           ]
-    -- FUTUREWORK: Mock federator and ensure that a message to Dee is sent and
-    -- nonParticipatingRemote is reported as redundant
+    -- FUTUREWORK: Mock federator and ensure that a message to Dee is sent
 
     let responses fedRequest =
           let request = fromMaybe (error "no request") $ F.request fedRequest

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -624,9 +624,17 @@ postMessageQualifiedLocalOwningBackendRedundantAndDeletedClients = do
     pure resp2 !!! do
       const 201 === statusCode
       let expectedRedundant =
-            QualifiedUserClients . Map.singleton owningDomain . Map.fromList $
-              [ (nonMemberUnqualified, Set.singleton nonMemberOwningDomainClient),
-                (nonMemberRemoteUnqualified, Set.singleton nonMemberRemoteClient)
+            QualifiedUserClients . Map.fromList $
+              [ ( owningDomain,
+                  Map.fromList $
+                    [ (nonMemberUnqualified, Set.singleton nonMemberOwningDomainClient)
+                    ]
+                ),
+                ( remoteDomain,
+                  Map.fromList $
+                    [ (nonMemberRemoteUnqualified, Set.singleton nonMemberRemoteClient)
+                    ]
+                )
               ]
           expectedDeleted =
             QualifiedUserClients . Map.singleton owningDomain . Map.fromList $

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -1682,7 +1682,7 @@ postCryptoBroadcastMessageJson = do
       WS.bracketR (c . queryItem "client" (toByteString' ac)) alice $ \wsA1 -> do
         Util.postOtrBroadcastMessage id alice ac msg !!! do
           const 201 === statusCode
-          assertTrue_ (eqMismatch [] [] [] . responseJsonUnsafe)
+          assertMismatch [] [] []
         -- Bob should get the broadcast (team member of alice)
         void . liftIO $ WS.assertMatch t wsB (wsAssertOtr (q (selfConv bob)) (q alice) ac bc "ciphertext1")
         -- Charlie should get the broadcast (contact of alice and user of teams feature)
@@ -1741,7 +1741,7 @@ postCryptoBroadcastMessageJsonFilteredTooLargeTeam = do
           let inbody = Just [alice, bob, charlie, dan]
           Util.postOtrBroadcastMessage' g inbody id alice ac msg !!! do
             const 201 === statusCode
-            assertTrue_ (eqMismatch [] [] [] . responseJsonUnsafe)
+            assertMismatch [] [] []
         -- Bob should get the broadcast (team member of alice)
         void . liftIO $ WS.assertMatch t wsB (wsAssertOtr (q (selfConv bob)) (q alice) ac bc "ciphertext1")
         -- Charlie should get the broadcast (contact of alice and user of teams feature)
@@ -1790,13 +1790,13 @@ postCryptoBroadcastMessageJson2 = do
   let m1 = [(bob, bc, "ciphertext1")]
   Util.postOtrBroadcastMessage id alice ac m1 !!! do
     const 412 === statusCode
-    assertTrue "1: Only Charlie and his device" (eqMismatch [(charlie, Set.singleton cc)] [] [] . responseJsonUnsafe)
+    assertMismatchWithMessage (Just "1: Only Charlie and his device") [(charlie, Set.singleton cc)] [] []
   -- Complete
   WS.bracketR2 c bob charlie $ \(wsB, wsE) -> do
     let m2 = [(bob, bc, "ciphertext2"), (charlie, cc, "ciphertext2")]
     Util.postOtrBroadcastMessage id alice ac m2 !!! do
       const 201 === statusCode
-      assertTrue "No devices expected" (eqMismatch [] [] [] . responseJsonUnsafe)
+      assertMismatchWithMessage (Just "No devices expected") [] [] []
     void . liftIO $ WS.assertMatch t wsB (wsAssertOtr (q (selfConv bob)) (q alice) ac bc "ciphertext2")
     void . liftIO $ WS.assertMatch t wsE (wsAssertOtr (q (selfConv charlie)) (q alice) ac cc "ciphertext2")
   -- Redundant self
@@ -1804,7 +1804,7 @@ postCryptoBroadcastMessageJson2 = do
     let m3 = [(alice, ac, "ciphertext3"), (bob, bc, "ciphertext3"), (charlie, cc, "ciphertext3")]
     Util.postOtrBroadcastMessage id alice ac m3 !!! do
       const 201 === statusCode
-      assertTrue "2: Only Alice and her device" (eqMismatch [] [(alice, Set.singleton ac)] [] . responseJsonUnsafe)
+      assertMismatchWithMessage (Just "2: Only Alice and her device") [] [(alice, Set.singleton ac)] []
     void . liftIO $ WS.assertMatch t wsB (wsAssertOtr (q (selfConv bob)) (q alice) ac bc "ciphertext3")
     void . liftIO $ WS.assertMatch t wsE (wsAssertOtr (q (selfConv charlie)) (q alice) ac cc "ciphertext3")
     -- Alice should not get it
@@ -1815,7 +1815,7 @@ postCryptoBroadcastMessageJson2 = do
     let m4 = [(bob, bc, "ciphertext4"), (charlie, cc, "ciphertext4")]
     Util.postOtrBroadcastMessage id alice ac m4 !!! do
       const 201 === statusCode
-      assertTrue "3: Only Charlie and his device" (eqMismatch [] [] [(charlie, Set.singleton cc)] . responseJsonUnsafe)
+      assertMismatchWithMessage (Just "3: Only Charlie and his device") [] [] [(charlie, Set.singleton cc)]
     void . liftIO $ WS.assertMatch t wsB (wsAssertOtr (q (selfConv bob)) (q alice) ac bc "ciphertext4")
     -- charlie should not get it
     assertNoMsg wsE (wsAssertOtr (q (selfConv charlie)) (q alice) ac cc "ciphertext4")
@@ -1847,7 +1847,7 @@ postCryptoBroadcastMessageProto = do
     let msg = otrRecipients [(bob, [(bc, ciphertext)]), (charlie, [(cc, ciphertext)]), (dan, [(dc, ciphertext)])]
     Util.postProtoOtrBroadcast alice ac msg !!! do
       const 201 === statusCode
-      assertTrue_ (eqMismatch [] [] [] . responseJsonUnsafe)
+      assertMismatch [] [] []
     -- Bob should get the broadcast (team member of alice)
     void . liftIO $ WS.assertMatch t wsB (wsAssertOtr' (encodeCiphertext "data") (q (selfConv bob)) (q alice) ac bc ciphertext)
     -- Charlie should get the broadcast (contact of alice and user of teams feature)
@@ -1886,7 +1886,7 @@ postCryptoBroadcastMessage100OrMaxConns = do
     let msg = (bob, bc, "ciphertext") : (f <$> others)
     Util.postOtrBroadcastMessage id alice ac msg !!! do
       const 201 === statusCode
-      assertTrue_ (eqMismatch [] [] [] . responseJsonUnsafe)
+      assertMismatch [] [] []
     let qbobself = Qualified (selfConv bob) localDomain
     void . liftIO $ WS.assertMatch t (Imports.head ws) (wsAssertOtr qbobself qalice ac bc "ciphertext")
     for_ (zip (tail ws) others) $ \(wsU, (u, clt)) -> do

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -1162,8 +1162,8 @@ testClaimKeys testcase = do
           upgradeClientToLH peer peerClient
           putLHWhitelistTeam teamPeer !!! const 200 === statusCode
 
-  let assertResponse :: Assertions ()
-      assertResponse = case testcase of
+  let assertResponse' :: Assertions ()
+      assertResponse' = case testcase of
         TCKConsentMissing -> bad
         TCKOldClient -> bad
         TCKConsentAndNewClients -> good
@@ -1173,10 +1173,10 @@ testClaimKeys testcase = do
 
   let fetchKeys :: ClientId -> TestM ()
       fetchKeys legalholderLHDevice = do
-        getUsersPrekeysClientUnqualified peer legalholder legalholderLHDevice !!! assertResponse
-        getUsersPrekeyBundleUnqualified peer legalholder !!! assertResponse
+        getUsersPrekeysClientUnqualified peer legalholder legalholderLHDevice !!! assertResponse'
+        getUsersPrekeyBundleUnqualified peer legalholder !!! assertResponse'
         let userClients = UserClients (Map.fromList [(legalholder, Set.fromList [legalholderLHDevice])])
-        getMultiUserPrekeyBundleUnqualified peer userClients !!! assertResponse
+        getMultiUserPrekeyBundleUnqualified peer userClients !!! assertResponse'
 
   putLHWhitelistTeam tid !!! const 200 === statusCode
 

--- a/services/galley/test/integration/API/Teams/LegalHold/DisabledByDefault.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold/DisabledByDefault.hs
@@ -796,8 +796,8 @@ testClaimKeys testcase = do
           upgradeClientToLH peer peerClient
           grantConsent teamPeer peer
 
-  let assertResponse :: Assertions ()
-      assertResponse = case testcase of
+  let assertResponse' :: Assertions ()
+      assertResponse' = case testcase of
         TCKConsentMissing -> bad
         TCKOldClient -> bad
         TCKConsentAndNewClients -> good
@@ -807,10 +807,10 @@ testClaimKeys testcase = do
 
   let fetchKeys :: ClientId -> TestM ()
       fetchKeys legalholderLHDevice = do
-        getUsersPrekeysClientUnqualified peer legalholder legalholderLHDevice !!! assertResponse
-        getUsersPrekeyBundleUnqualified peer legalholder !!! assertResponse
+        getUsersPrekeysClientUnqualified peer legalholder legalholderLHDevice !!! assertResponse'
+        getUsersPrekeyBundleUnqualified peer legalholder !!! assertResponse'
         let userClients = UserClients (Map.fromList [(legalholder, Set.fromList [legalholderLHDevice])])
-        getMultiUserPrekeyBundleUnqualified peer userClients !!! assertResponse
+        getMultiUserPrekeyBundleUnqualified peer userClients !!! assertResponse'
 
   withDummyTestServiceForTeam legalholder tid $ \_chan -> do
     grantConsent tid legalholder

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1673,10 +1673,9 @@ eqMismatchQualified ::
   Maybe Message.MessageSendingStatus ->
   Bool
 eqMismatchQualified _ _ _ Nothing = False
-eqMismatchQualified missing _redundant deleted (Just other) = do
+eqMismatchQualified missing redundant deleted (Just other) = do
   missing == Message.mssMissingClients other
-    -- FUTUREWORK: reenable check once remote client discovery is implemented
-    -- && redundant == Message.mssRedundantClients other
+    && redundant == Message.mssRedundantClients other
     && deleted == Message.mssDeletedClients other
 
 otrRecipients :: [(UserId, [(ClientId, Text)])] -> OtrRecipients


### PR DESCRIPTION
This PR implements fetching of remote clients when sending messages involving remote users, and takes those clients into account when checking recipients and computing missing, deleted and redundant clients. 

This supersedes #1623.

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
