### PR TITLE
Custom Encoded Union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   added to a new conversation via `POST /federation/register-conversation` (#1622).
 * [Federation] Adjust scripts under ./hack/federation to work with recent changes to the federation API (#1632).
 * Refactored Proteus endpoint to work with qualified users (#1634).
+* Added a CustomEncodedUnion newtype to simplify the implementation of RPCs returning unions (#1639).
 
 ## Documentation
 

--- a/libs/wire-api-federation/package.yaml
+++ b/libs/wire-api-federation/package.yaml
@@ -35,6 +35,7 @@ dependencies:
 - servant >=0.16
 - servant-client
 - servant-client-core
+- sop-core
 - template-haskell
 - text >=0.11
 - time >=1.8

--- a/libs/wire-api-federation/src/Wire/API/Federation/Util/Aeson.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Util/Aeson.hs
@@ -55,6 +55,10 @@ instance (Generic a, GFromJSON Zero (Rep a)) => FromJSON (CustomEncoded a) where
 newtype CustomEncodedUnion as = CustomEncodedUnion
   {unCustomEncodedUnion :: NS I as}
 
+deriving instance All (Compose Show I) as => Show (CustomEncodedUnion as)
+
+deriving instance All (Compose Eq I) as => Eq (CustomEncodedUnion as)
+
 class HasStatus a => UnionMember a where
   memberToJSON :: a -> Value
   memberParseJSON :: Value -> Parser a

--- a/libs/wire-api-federation/src/Wire/API/Federation/Util/Aeson.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Util/Aeson.hs
@@ -18,13 +18,21 @@
 module Wire.API.Federation.Util.Aeson
   ( customEncodingOptions,
     CustomEncoded (..),
+    CustomEncodedUnion (..),
+    UnionMember (..),
   )
 where
 
 import Data.Aeson
+import Data.Aeson.Types (Parser, parseEither)
 import qualified Data.Char as Char
+import Data.SOP
+import Data.SOP.NS
 import GHC.Generics (Rep)
-import Imports
+import Imports hiding (All)
+import Network.HTTP.Types (statusCode)
+import Servant.API (HasStatus (..), WithStatus (..), statusOf)
+import Servant.API.Status (KnownStatus (..))
 
 -- | Drops record field name prefixes (anything until the first upper-case char)
 -- and turns the rest into snake_case.
@@ -43,3 +51,64 @@ instance (Generic a, GToJSON Zero (Rep a)) => ToJSON (CustomEncoded a) where
 
 instance (Generic a, GFromJSON Zero (Rep a)) => FromJSON (CustomEncoded a) where
   parseJSON = fmap CustomEncoded . genericParseJSON @a customEncodingOptions
+
+newtype CustomEncodedUnion as = CustomEncodedUnion
+  {unCustomEncodedUnion :: NS I as}
+
+class HasStatus a => UnionMember a where
+  memberToJSON :: a -> Value
+  memberParseJSON :: Value -> Parser a
+
+instance {-# OVERLAPPABLE #-} (FromJSON a, ToJSON a, HasStatus a) => UnionMember a where
+  memberToJSON = toJSON
+  memberParseJSON = parseJSON
+
+instance (FromJSON a, ToJSON a, KnownStatus c) => UnionMember (WithStatus c a) where
+  memberToJSON (WithStatus x) = toJSON x
+  memberParseJSON = fmap WithStatus . parseJSON
+
+getStatus :: forall a. HasStatus a => Int
+getStatus = statusCode (statusOf (Proxy @a))
+
+getStatuses :: forall as. All HasStatus as => [Int]
+getStatuses = unK (cpara_SList (Proxy @HasStatus) (K []) g :: K [Int] as)
+  where
+    g :: forall y ys. (HasStatus y, All HasStatus ys) => K [Int] ys -> K [Int] (y ': ys)
+    g = K . (getStatus @y :) . unK
+
+instance All UnionMember as => ToJSON (CustomEncodedUnion as) where
+  toJSON = cfoldMap_NS (Proxy @UnionMember) go . unCustomEncodedUnion
+    where
+      go :: forall a. UnionMember a => I a -> Value
+      go (I x) =
+        object
+          [ "status" .= getStatus @a,
+            "value" .= memberToJSON x
+          ]
+
+-- | A status code that is guaranteed to be one of those associated to the types in
+-- the list.
+data ValidStatus x as = ValidStatus Int x
+
+impossibleStatus :: ValidStatus x '[] -> r
+impossibleStatus _ = error "bug: unhandled status in ValidStatus"
+
+validateStatus :: forall as x. All HasStatus as => Int -> x -> Maybe (ValidStatus x as)
+validateStatus s v = guard (s `elem` getStatuses @as) $> ValidStatus s v
+
+instance (SListI as, All UnionMember as, All HasStatus as) => FromJSON (CustomEncodedUnion as) where
+  parseJSON = withObject "Union" $ \obj -> do
+    (status :: Int) <- obj .: "status"
+    (value :: Value) <- obj .: "value"
+    vs <-
+      maybe
+        (fail ("unexpected status " <> show status))
+        pure
+        (validateStatus status value)
+    fmap CustomEncodedUnion . either fail pure . sequence_NS $
+      cana_NS (Proxy @UnionMember) impossibleStatus g vs
+    where
+      g :: forall y ys. UnionMember y => ValidStatus Value (y ': ys) -> Either (Either String y) (ValidStatus Value ys)
+      g (ValidStatus s v)
+        | s /= getStatus @y = Right (ValidStatus s v)
+        | otherwise = Left (parseEither memberParseJSON v)

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/UtilSpec.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/UtilSpec.hs
@@ -1,0 +1,59 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Wire.API.Federation.UtilSpec where
+
+import Data.Aeson
+import Data.SOP (I (..))
+import Imports
+import Servant.API (WithStatus (..), inject)
+import Test.Hspec
+import Wire.API.Federation.Util.Aeson (CustomEncodedUnion (..))
+
+type ExampleMembers = [WithStatus 200 Int, WithStatus 400 String]
+
+type ExampleUnion = CustomEncodedUnion ExampleMembers
+
+example1 :: ExampleUnion
+example1 = CustomEncodedUnion (inject (I (WithStatus @200 (42 :: Int))))
+
+example2 :: ExampleUnion
+example2 = CustomEncodedUnion (inject (I (WithStatus @400 ("failed" :: String))))
+
+spec :: Spec
+spec = describe "CustomEncodedUnion" $ do
+  it "should generate a JSON object with status and value fields" $ do
+    toJSON example1 `shouldBe` object ["status" .= (200 :: Int), "value" .= (42 :: Int)]
+    toJSON example2 `shouldBe` object ["status" .= (400 :: Int), "value" .= ("failed" :: String)]
+
+  it "should parse a JSON object containing status and value fields" $ do
+    fromJSON (object ["status" .= (200 :: Int), "value" .= (42 :: Int)])
+      `shouldBe` Success example1
+    fromJSON (object ["status" .= (400 :: Int), "value" .= ("failed" :: String)])
+      `shouldBe` Success example2
+
+  it "should give an error when the status code is not in the union" $ do
+    fromJSON (object ["status" .= (201 :: Int), "value" .= (37 :: Int)])
+      `shouldBe` (Error "unexpected status 201" :: Result ExampleUnion)
+
+  it "should give an error for invalid JSON" $ do
+    fromJSON (object ["value" .= True])
+      `shouldBe` (Error "key \"status\" not found" :: Result ExampleUnion)
+    fromJSON (object ["status" .= (200 :: Int)])
+      `shouldBe` (Error "key \"value\" not found" :: Result ExampleUnion)
+    fromJSON (object ["status" .= (200 :: Int), "value" .= ("42" :: String)])
+      `shouldBe` (Error "Error in $: parsing Int failed, expected Number, but encountered String" :: Result ExampleUnion)

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 96dff81406479414ae1895ab698c0a9e3ca78542243155bfb89a3293998bcd32
+-- hash: e1a83c1b20eca671d522ff038f5806370b5224f08b9ffce56eaad51162ec6d43
 
 name:           wire-api-federation
 version:        0.1.0
@@ -79,6 +79,7 @@ test-suite spec
       Test.Wire.API.Federation.API.BrigSpec
       Test.Wire.API.Federation.ClientSpec
       Test.Wire.API.Federation.GRPC.TypesSpec
+      Test.Wire.API.Federation.UtilSpec
       Paths_wire_api_federation
   hs-source-dirs:
       test

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: daa78b8456ee89c52c754d98427c3e13c99938ce4760461a5e8858173c582d2c
+-- hash: 96dff81406479414ae1895ab698c0a9e3ca78542243155bfb89a3293998bcd32
 
 name:           wire-api-federation
 version:        0.1.0
@@ -62,6 +62,7 @@ library
     , servant >=0.16
     , servant-client
     , servant-client-core
+    , sop-core
     , template-haskell
     , text >=0.11
     , time >=1.8
@@ -112,6 +113,7 @@ test-suite spec
     , servant >=0.16
     , servant-client
     , servant-client-core
+    , sop-core
     , template-haskell
     , text >=0.11
     , time >=1.8


### PR DESCRIPTION
This introduces a `CustomEncodedUnion` newtype, to be used mainly with `deriving via` to get JSON instances for `Union as` types. This is useful to expose functions returning unions (such as Servant handlers) through the RPC interface, which cannot handle arbitrary status codes.

The way the instances are generated assumes that the JSON value corresponding to a union is an object with a "status" field containing the status code of a particular case in the union (Servant statically enforces union types to have distinct status codes) and a "value" field containing the JSON serialisation of the corresponding value.

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
