### PR TITLE
Change conversationCodeURI in galley.yaml.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 # Unreleased
 
+## Release Notes
+
+This release requires a manual change in your galley configuration: `settings.conversationCodeURI` in `galley.yaml` was had to be set to `${WEBAPP}/join` before this release, and must be set to `${ACCOUNTS}/conversation-join` from now on, where `${WEBAPP}` is the url to the webapp and `${ACCOUNTS}` is the url to the account pages.
+
 ## API Changes
 
 * New endpoint `POST /list-conversations` similar to `GET /conversations`, but which will also return your own remote conversations (if federation is enabled). (#1591)
@@ -32,6 +36,7 @@
   added to a new conversation via `POST /federation/register-conversation` (#1622).
 * [Federation] Adjust scripts under ./hack/federation to work with recent changes to the federation API (#1632).
 * Refactored Proteus endpoint to work with qualified users (#1634).
+* Change `settings.conversationCodeURI` in galley.yaml (#1643).
 
 ## Documentation
 

--- a/deploy/services-demo/conf/galley.demo.yaml
+++ b/deploy/services-demo/conf/galley.demo.yaml
@@ -25,7 +25,7 @@ settings:
   maxTeamSize: 128
   maxConvSize: 128
   intraListing: false
-  conversationCodeURI: https://127.0.0.1/join/
+  conversationCodeURI: https://127.0.0.1/conversation-join/
   concurrentDeletionEvents: 1024
   deleteConvThrottleMillis: 0
 

--- a/hack/helm_vars/wire-server/values.yaml
+++ b/hack/helm_vars/wire-server/values.yaml
@@ -141,7 +141,7 @@ galley:
       maxTeamSize: 32
       maxFanoutSize: 18
       maxConvSize: 16
-      conversationCodeURI: https://kube-staging-nginz-https.zinfra.io/join/
+      conversationCodeURI: https://kube-staging-nginz-https.zinfra.io/conversation-join/
       enableIndexedBillingTeamMembers: true
       federationDomain: integration.example.com
       featureFlags:

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -30,7 +30,7 @@ settings:
   maxFanoutSize: 18
   maxConvSize: 16
   intraListing: false
-  conversationCodeURI: https://app.wire.com/join/
+  conversationCodeURI: https://account.wire.com/conversation-join/
   concurrentDeletionEvents: 1024
   deleteConvThrottleMillis: 0
   enableIndexedBillingTeamMembers: true


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-535

**Mote context:** (thanks @Yserz, and please correct me if I got anything wrong)

The old url was pointing to the webapp, and that will keep working as well as it works now, namely:

- webapp can create and consume those links;
- mobile clients can create, but not consume them.

In order to allow mobile clients to join conversations with the logged-in user (not a guest, that was harder to implement), the backend should now create new guest-links that point to the account pages under the new path.  For web, this does not change anything, the new link will work as well as the old.  For mobile, this will make things work via the logged-in user.

This PR makes sure that all tests, on-prem installations, ... can make this change.  Until they do, things will work as well as (but not better than) before.

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
 - [x] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
- [x] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
