### PR TITLE
Document Servant endpoint errors for Galley routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 ## Documentation
 
 * Fix validation errors in Swagger documentation (#1625).
+* Document more error responses (#1645).
 
 ## Bug fixes and other updates
 

--- a/libs/schema-profunctor/src/Data/Schema.hs
+++ b/libs/schema-profunctor/src/Data/Schema.hs
@@ -38,6 +38,7 @@ module Data.Schema
     SwaggerDoc,
     swaggerDoc,
     NamedSwaggerDoc,
+    declareSwaggerSchema,
     getName,
     object,
     objectWithDocModifier,
@@ -89,6 +90,7 @@ import Data.Proxy (Proxy (..))
 import qualified Data.Set as Set
 import qualified Data.Swagger as S
 import qualified Data.Swagger.Declare as S
+import qualified Data.Swagger.Internal as S
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import Imports hiding (Product)
@@ -492,13 +494,14 @@ element label value = SchemaP (SchemaDoc d) (SchemaIn i) (SchemaOut o)
 -- This is used to convert a combination of schemas obtained using
 -- 'element' into a single schema for a JSON string.
 enum ::
-  (With v, HasEnum doc) =>
+  forall v doc a b.
+  (With v, HasEnum v doc) =>
   Text ->
   SchemaP [A.Value] v (Alt Maybe v) a b ->
   SchemaP doc A.Value A.Value a b
 enum name sch = SchemaP (SchemaDoc d) (SchemaIn i) (SchemaOut o)
   where
-    d = mkEnum name (schemaDoc sch)
+    d = mkEnum @v name (schemaDoc sch)
     i x =
       with (T.unpack name) (schemaIn sch) x
         <|> fail ("Unexpected value for enum " <> T.unpack name)
@@ -683,7 +686,7 @@ class Monoid doc => HasMap ndoc doc | ndoc -> doc where
 class HasOpt doc where
   mkOpt :: doc -> doc
 
-class HasEnum doc where
+class HasEnum a doc where
   mkEnum :: Text -> [A.Value] -> doc
 
 instance HasSchemaRef doc => HasField doc SwaggerDoc where
@@ -723,12 +726,22 @@ class HasMinItems s a where
 instance HasMinItems SwaggerDoc (Maybe Integer) where
   minItems = declared . S.minItems
 
-instance HasEnum NamedSwaggerDoc where
-  mkEnum name labels =
-    pure . S.NamedSchema (Just name) $
-      mempty
-        & S.type_ ?~ S.SwaggerString
-        & S.enum_ ?~ labels
+instance HasEnum Text NamedSwaggerDoc where
+  mkEnum = mkSwaggerEnum S.SwaggerString
+
+instance HasEnum Integer NamedSwaggerDoc where
+  mkEnum = mkSwaggerEnum S.SwaggerInteger
+
+mkSwaggerEnum ::
+  S.SwaggerType 'S.SwaggerKindSchema ->
+  Text ->
+  [A.Value] ->
+  NamedSwaggerDoc
+mkSwaggerEnum ty name labels =
+  pure . S.NamedSchema (Just name) $
+    mempty
+      & S.type_ ?~ ty
+      & S.enum_ ?~ labels
 
 instance HasOpt SwaggerDoc where
   mkOpt = (S.schema . S.required) .~ []
@@ -794,6 +807,9 @@ instance ToSchema Char where schema = genericToSchema
 instance ToSchema String where schema = genericToSchema
 
 instance ToSchema Bool where schema = genericToSchema
+
+declareSwaggerSchema :: SchemaP (WithDeclare d) v w a b -> Declare d
+declareSwaggerSchema = runDeclare . schemaDoc
 
 swaggerDoc :: forall a. S.ToSchema a => NamedSwaggerDoc
 swaggerDoc = unrunDeclare (S.declareNamedSchema (Proxy @a))

--- a/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
+++ b/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
@@ -64,7 +64,8 @@ tests =
       testNonEmptySchema,
       testRefField,
       testRmClientWrong,
-      testRmClient
+      testRmClient,
+      testEnumType
     ]
 
 testFooToJSON :: TestTree
@@ -317,6 +318,25 @@ testRmClient =
           "fromJSON error should mention password too short"
           "password too short"
           err
+
+testEnumType :: TestTree
+testEnumType =
+  testCase "Enum Swagger schema has the correct type" $ do
+    let e1 :: ValueSchema NamedSwaggerDoc Text
+        e1 = enum @Text "TextEnum" (element "hello" "hello")
+        (_, s1) = S.runDeclare (declareSwaggerSchema e1) mempty
+    assertEqual
+      "Text enum has Swagger type \"string\""
+      (s1 ^. S.type_)
+      (Just S.SwaggerString)
+
+    let e2 :: ValueSchema NamedSwaggerDoc Integer
+        e2 = enum @Integer "IntEnum" (element (3 :: Integer) (3 :: Integer))
+        (_, s2) = S.runDeclare (declareSwaggerSchema e2) mempty
+    assertEqual
+      "Integer enum has Swagger type \"integer\""
+      (s2 ^. S.type_)
+      (Just S.SwaggerInteger)
 
 ---
 

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -25,6 +25,7 @@
 module Data.Id where
 
 import Cassandra hiding (S)
+import Control.Lens ((?~))
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Encoding as A
@@ -108,7 +109,7 @@ instance ToSchema (Id a) where
       uuid :: ValueSchema NamedSwaggerDoc UUID
       uuid =
         mkSchema
-          (swaggerDoc @UUID)
+          (addExample (swaggerDoc @UUID))
           ( A.withText
               "UUID"
               ( maybe (fail "Invalid UUID") pure
@@ -116,6 +117,10 @@ instance ToSchema (Id a) where
               )
           )
           (pure . A.toJSON . UUID.toText)
+
+      addExample =
+        S.schema . S.example
+          ?~ toJSON ("99db9768-04e3-4b5d-9268-831b6a25c4ab" :: Text)
 
 -- REFACTOR: non-derived, custom show instances break pretty-show and violate the law
 -- that @show . read == id@.  can we derive Show here?

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -154,9 +154,9 @@ instance KnownStatus status => HasStatus (ErrorDescription status label desc) wh
 mkErrorDescription :: forall code label desc. KnownSymbol desc => ErrorDescription code label desc
 mkErrorDescription = ErrorDescription $ Text.pack (symbolVal (Proxy @desc))
 
-type ConversationNotFound = ErrorDescription 404 "no-conversation" "Conversation not found"
+type ConvNotFound = ErrorDescription 404 "no-conversation" "Conversation not found"
 
-convNotFound :: ConversationNotFound
+convNotFound :: ConvNotFound
 convNotFound = mkErrorDescription
 
 type UnknownClient = ErrorDescription 403 "unknown-client" "Unknown Client"
@@ -197,3 +197,8 @@ type CodeNotFound = ErrorDescription 404 "no-conversation-code" "Conversation co
 
 codeNotFound :: CodeNotFound
 codeNotFound = mkErrorDescription
+
+type ConvAccessDenied = ErrorDescription 403 "access-denied" "Conversation access denied"
+
+convAccessDenied :: ConvAccessDenied
+convAccessDenied = mkErrorDescription

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -88,11 +88,17 @@ data ErrorDescription (statusCode :: Nat) (desc :: Symbol) = ErrorDescription
 
 instance (KnownStatus statusCode, KnownSymbol desc) => ToSchema (ErrorDescription statusCode desc) where
   schema =
-    object "ErrorDescription" $
+    objectWithDocModifier "ErrorDescription" addExample $
       ErrorDescription
         <$> label .= field "label" schema
         <*> message .= field "message" schema
         <* const (natVal (Proxy @statusCode)) .= field "code" schema
+    where
+      addExample =
+        Swagger.schema . Swagger.example
+          ?~ A.toJSON
+            ( ErrorDescription @statusCode @desc "error-label" "An error has occurred"
+            )
 
 -- | This instance works with 'UVerb' only becaue of the following overlapping
 -- instance for 'UVerb method cs (ErrorDescription status desc ': rest))'

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -182,3 +182,10 @@ type NotATeamMember = ErrorDescription 403 "no-team-member" "Requesting user is 
 
 notATeamMember :: NotATeamMember
 notATeamMember = mkErrorDescription
+
+type ActionDenied = ErrorDescription 403 "action-denied" "Insufficient authorization"
+
+actionDenied :: Show a => a -> ActionDenied
+actionDenied a =
+  ErrorDescription $
+    "Insufficient authorization (missing " <> Text.pack (show a) <> ")"

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -17,6 +17,10 @@ import Wire.API.ServantSwagger
 
 -- This can be added to an endpoint to document a possible failure
 -- case outside its return type (usually through an exception).
+--
+-- Note that there is no static check for these annotations. The set of
+-- exceptions that a handler might throw can be completely independent from the
+-- set of exceptions reported by 'CanThrow', as far as the compiler is concerned.
 data CanThrow err
 
 instance

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -62,7 +62,7 @@ errorDescriptionAddToSwagger =
         response
           -- add the description of this error to the response description
           & Swagger._Inline . Swagger.description
-            <>~ (" or " <> Text.pack (symbolVal (Proxy @desc)))
+            <>~ ("\n\n" <> Text.pack (symbolVal (Proxy @desc)))
           -- add the label of this error to the possible values of the corresponding enum
           & Swagger._Inline . Swagger.schema . _Just . Swagger._Inline . Swagger.properties . ix "label" . Swagger._Inline . Swagger.enum_ . _Just
             <>~ [A.toJSON (symbolVal (Proxy @label))]
@@ -177,3 +177,8 @@ operationDenied :: Show perm => perm -> OperationDenied
 operationDenied p =
   ErrorDescription $
     "Insufficient permissions (missing " <> Text.pack (show p) <> ")"
+
+type NotATeamMember = ErrorDescription 403 "no-team-member" "Requesting user is not a team member"
+
+notATeamMember :: NotATeamMember
+notATeamMember = mkErrorDescription

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -93,9 +93,10 @@ instance (KnownStatus statusCode, KnownSymbol label, KnownSymbol desc) => ToSche
       ErrorDescription
         <$ const label .= field "label" labelSchema
           <*> edMessage .= field "message" schema
-          <* const code .= field "code" schema
+          <* const code .= field "code" codeSchema
     where
       label = Text.pack (symbolVal (Proxy @label))
+      code :: Integer
       code = natVal (Proxy @statusCode)
       desc = Text.pack (symbolVal (Proxy @desc))
       addExample =
@@ -103,6 +104,8 @@ instance (KnownStatus statusCode, KnownSymbol label, KnownSymbol desc) => ToSche
           ?~ A.toJSON (ErrorDescription @statusCode @label @desc desc)
       labelSchema :: ValueSchema SwaggerDoc Text
       labelSchema = unnamed $ enum @Text "Label" (element label label)
+      codeSchema :: ValueSchema SwaggerDoc Integer
+      codeSchema = unnamed $ enum @Integer "Status" (element code code)
 
 -- | This instance works with 'UVerb' only because of the following overlapping
 -- instance for 'UVerb method cs (ErrorDescription status label desc ': rest))'

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -7,7 +7,7 @@ import Data.Schema
 import Data.Swagger (Swagger)
 import qualified Data.Swagger as Swagger
 import qualified Data.Text as Text
-import GHC.TypeLits (KnownNat, KnownSymbol, Symbol, natVal, symbolVal)
+import GHC.TypeLits (KnownSymbol, Symbol, natVal, symbolVal)
 import GHC.TypeNats (Nat)
 import Imports hiding (head)
 import Servant hiding (Handler, JSON, addHeader, contentType, respond)
@@ -15,11 +15,56 @@ import Servant.API.Status (KnownStatus)
 import Servant.Swagger.Internal
 import Wire.API.ServantSwagger
 
+-- This can be added to an endpoint to document a possible failure
+-- case outside its return type (usually through an exception).
+data CanThrow err
+
+instance
+  (HasSwagger api, KnownStatus code, KnownSymbol desc) =>
+  HasSwagger (CanThrow (ErrorDescription code desc) :> api)
+  where
+  toSwagger _ = errorDescriptionAddToSwagger @code @desc (toSwagger (Proxy @api))
+
+-- CanThrow annotations are ignored by servant
+instance
+  ( HasContextEntry (ctx .++ DefaultErrorFormatters) ErrorFormatters,
+    HasServer api ctx
+  ) =>
+  HasServer (CanThrow t :> api) ctx
+  where
+  type ServerT (CanThrow t :> api) m = ServerT api m
+
+  route _ = route (Proxy @api)
+  hoistServerWithContext _ = hoistServerWithContext (Proxy @api)
+
+errorDescriptionAddToSwagger ::
+  forall (code :: Nat) (desc :: Symbol).
+  (KnownStatus code, KnownSymbol desc) =>
+  Swagger ->
+  Swagger
+errorDescriptionAddToSwagger =
+  over (Swagger.paths . traverse) overridePathItem
+  where
+    overridePathItem :: Swagger.PathItem -> Swagger.PathItem
+    overridePathItem =
+      over (Swagger.get . _Just) overrideOp
+        . over (Swagger.post . _Just) overrideOp
+        . over (Swagger.put . _Just) overrideOp
+        . over (Swagger.head_ . _Just) overrideOp
+        . over (Swagger.patch . _Just) overrideOp
+        . over (Swagger.delete . _Just) overrideOp
+        . over (Swagger.options . _Just) overrideOp
+    overrideOp :: Swagger.Operation -> Swagger.Operation
+    overrideOp =
+      Swagger.responses . Swagger.responses . at (fromInteger $ natVal (Proxy @code))
+        ?~ Swagger.Inline
+          ( mempty
+              & Swagger.description .~ Text.pack (symbolVal (Proxy @desc))
+              & Swagger.schema ?~ Swagger.toSchemaRef (Proxy @(ErrorDescription code desc))
+          )
+
 -- FUTUREWORK: Ponder about elevating label and messge to the type level. If all
 -- errors are static, there is probably no point in having them at value level.
---
--- This type can also be added to an endpoint to document a possible failure
--- case outside its return type (usually through an exception).
 data ErrorDescription (statusCode :: Nat) (desc :: Symbol) = ErrorDescription
   { label :: !Text,
     message :: !Text
@@ -27,7 +72,7 @@ data ErrorDescription (statusCode :: Nat) (desc :: Symbol) = ErrorDescription
   deriving stock (Show, Typeable)
   deriving (A.ToJSON, A.FromJSON, Swagger.ToSchema) via Schema (ErrorDescription statusCode desc)
 
-instance (KnownNat statusCode, KnownSymbol desc) => ToSchema (ErrorDescription statusCode desc) where
+instance (KnownStatus statusCode, KnownSymbol desc) => ToSchema (ErrorDescription statusCode desc) where
   schema =
     object "ErrorDescription" $
       ErrorDescription
@@ -37,43 +82,25 @@ instance (KnownNat statusCode, KnownSymbol desc) => ToSchema (ErrorDescription s
 
 -- | This instance works with 'UVerb' only becaue of the following overlapping
 -- instance for 'UVerb method cs (ErrorDescription status desc ': rest))'
-instance (KnownNat statusCode, KnownSymbol desc, AllAccept cs, SwaggerMethod method) => HasSwagger (Verb method statusCode cs (ErrorDescription statusCode desc)) where
-  toSwagger _ = overrrideResponseDesc $ mkEndpoint "/" (Proxy @(Verb method statusCode cs (Headers '[] (ErrorDescription statusCode desc))))
+instance (KnownStatus statusCode, KnownSymbol desc, AllAccept cs, SwaggerMethod method) => HasSwagger (Verb method statusCode cs (ErrorDescription statusCode desc)) where
+  toSwagger _ = overrideResponseDesc $ mkEndpoint "/" (Proxy @(Verb method statusCode cs (Headers '[] (ErrorDescription statusCode desc))))
     where
-      overrrideResponseDesc :: Swagger -> Swagger
-      overrrideResponseDesc =
-        over (Swagger.paths . at "/" . _Just) overridePathItem
-      overridePathItem :: Swagger.PathItem -> Swagger.PathItem
-      overridePathItem =
-        over (Swagger.get . _Just) overrideOp
-          . over (Swagger.post . _Just) overrideOp
-          . over (Swagger.put . _Just) overrideOp
-          . over (Swagger.head_ . _Just) overrideOp
-          . over (Swagger.patch . _Just) overrideOp
-          . over (Swagger.delete . _Just) overrideOp
-          . over (Swagger.options . _Just) overrideOp
-      overrideOp :: Swagger.Operation -> Swagger.Operation
-      overrideOp =
-        Swagger.responses . Swagger.responses . at (fromInteger $ natVal (Proxy @statusCode))
-          ?~ Swagger.Inline
-            ( mempty
-                & Swagger.description .~ Text.pack (symbolVal (Proxy @desc))
-                & Swagger.schema ?~ Swagger.toSchemaRef (Proxy @(ErrorDescription statusCode desc))
-            )
+      overrideResponseDesc :: Swagger -> Swagger
+      overrideResponseDesc = errorDescriptionAddToSwagger @statusCode @desc
 
 -- | This is a copy of instance for 'UVerb method cs (a:as)', but without this
 -- things don't work because the instance defined in the library is already
 -- compiled with the now overlapped version of `Verb method cs a` and won't
 -- pickup the above instance.
 instance
-  (KnownNat status, KnownSymbol desc, AllAccept cs, SwaggerMethod method, HasSwagger (UVerb method cs rest)) =>
+  (KnownStatus status, KnownSymbol desc, AllAccept cs, SwaggerMethod method, HasSwagger (UVerb method cs rest)) =>
   HasSwagger (UVerb method cs (ErrorDescription status desc ': rest))
   where
   toSwagger _ =
     toSwagger (Proxy @(Verb method (StatusOf (ErrorDescription status desc)) cs (ErrorDescription status desc)))
       `combineSwagger` toSwagger (Proxy @(UVerb method cs rest))
 
-instance (KnownNat status, KnownStatus status) => HasStatus (ErrorDescription status desc) where
+instance (KnownStatus status, KnownStatus status) => HasStatus (ErrorDescription status desc) where
   type StatusOf (ErrorDescription status desc) = status
 
 -- * Errors

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -192,3 +192,8 @@ actionDenied :: Show a => a -> ActionDenied
 actionDenied a =
   ErrorDescription $
     "Insufficient authorization (missing " <> Text.pack (show a) <> ")"
+
+type CodeNotFound = ErrorDescription 404 "no-conversation-code" "Conversation code not found"
+
+codeNotFound :: CodeNotFound
+codeNotFound = mkErrorDescription

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -17,6 +17,9 @@ import Wire.API.ServantSwagger
 
 -- FUTUREWORK: Ponder about elevating label and messge to the type level. If all
 -- errors are static, there is probably no point in having them at value level.
+--
+-- This type can also be added to an endpoint to document a possible failure
+-- case outside its return type (usually through an exception).
 data ErrorDescription (statusCode :: Nat) (desc :: Symbol) = ErrorDescription
   { label :: !Text,
     message :: !Text
@@ -89,3 +92,8 @@ type ClientNotFound = ErrorDescription 404 "Client not found"
 
 clientNotFound :: ClientNotFound
 clientNotFound = ErrorDescription "client-not-found" "client not found"
+
+type NotConnected = ErrorDescription 403 "Users are not connected"
+
+notConnected :: NotConnected
+notConnected = ErrorDescription "not-connected" "Users are not connected"

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -55,17 +55,23 @@ errorDescriptionAddToSwagger =
     addRef Nothing =
       Just . Swagger.Inline $
         mempty
-          & Swagger.description .~ Text.pack (symbolVal (Proxy @desc))
+          & Swagger.description .~ desc
           & Swagger.schema ?~ Swagger.Inline (Swagger.toSchema (Proxy @(ErrorDescription code label desc)))
     addRef (Just response) =
       Just $
         response
           -- add the description of this error to the response description
           & Swagger._Inline . Swagger.description
-            <>~ ("\n\n" <> Text.pack (symbolVal (Proxy @desc)))
+            <>~ ("\n\n" <> desc)
           -- add the label of this error to the possible values of the corresponding enum
           & Swagger._Inline . Swagger.schema . _Just . Swagger._Inline . Swagger.properties . ix "label" . Swagger._Inline . Swagger.enum_ . _Just
             <>~ [A.toJSON (symbolVal (Proxy @label))]
+
+    desc =
+      Text.pack (symbolVal (Proxy @desc))
+        <> " (label: `"
+        <> Text.pack (symbolVal (Proxy @label))
+        <> "`)"
 
     overridePathItem :: Swagger.PathItem -> Swagger.PathItem
     overridePathItem =

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -34,7 +34,7 @@ import Servant.Swagger.Internal
 import Servant.Swagger.Internal.Orphans ()
 import qualified Wire.API.Conversation as Public
 import qualified Wire.API.Conversation.Role as Public
-import Wire.API.ErrorDescription (ConversationNotFound, UnknownClient)
+import Wire.API.ErrorDescription
 import qualified Wire.API.Event.Conversation as Public
 import qualified Wire.API.Message as Public
 import Wire.API.Routes.Public (EmptyResult, ZConn, ZUser)
@@ -155,12 +155,12 @@ data Api routes = Api
         :> Post '[Servant.JSON] (Public.ConversationList Public.Conversation),
     -- This endpoint can lead to the following events being sent:
     -- - ConvCreate event to members
-    -- FUTUREWORK: errorResponse Error.notConnected
-    --             errorResponse Error.notATeamMember
+    -- FUTUREWORK: errorResponse Error.notATeamMember
     --             errorResponse (Error.operationDenied Public.CreateConversation)
     getConversationByReusableCode ::
       routes
         :- Summary "Get limited conversation information by key/code pair"
+        :> CanThrow NotConnected
         :> ZUser
         :> "conversations"
         :> "join"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -172,6 +172,7 @@ data Api routes = Api
       routes
         :- Summary "Create a new conversation"
         :> CanThrow NotATeamMember
+        :> CanThrow CodeNotFound
         :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
         :> ZUser
         :> ZConn

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -158,9 +158,10 @@ data Api routes = Api
     getConversationByReusableCode ::
       routes
         :- Summary "Get limited conversation information by key/code pair"
-        :> CanThrow NotConnected
-        :> CanThrow OperationDenied
         :> CanThrow NotATeamMember
+        :> CanThrow CodeNotFound
+        :> CanThrow ConvNotFound
+        :> CanThrow ConvAccessDenied
         :> ZUser
         :> "conversations"
         :> "join"
@@ -170,10 +171,9 @@ data Api routes = Api
     createGroupConversation ::
       routes
         :- Summary "Create a new conversation"
+        :> CanThrow NotConnected
+        :> CanThrow OperationDenied
         :> CanThrow NotATeamMember
-        :> CanThrow CodeNotFound
-        :> CanThrow ConvNotFound
-        :> CanThrow ConvAccessDenied
         :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
         :> ZUser
         :> ZConn

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -155,22 +155,23 @@ data Api routes = Api
         :> Post '[Servant.JSON] (Public.ConversationList Public.Conversation),
     -- This endpoint can lead to the following events being sent:
     -- - ConvCreate event to members
-    -- FUTUREWORK: errorResponse Error.notATeamMember
     getConversationByReusableCode ::
       routes
         :- Summary "Get limited conversation information by key/code pair"
         :> CanThrow NotConnected
         :> CanThrow OperationDenied
+        :> CanThrow NotATeamMember
         :> ZUser
         :> "conversations"
         :> "join"
         :> QueryParam' [Required, Strict] "key" Code.Key
         :> QueryParam' [Required, Strict] "code" Code.Value
         :> Get '[Servant.JSON] Public.ConversationCoverView,
-    -- FUTUREWORK: potential errors: codeNotFound, convNotFound, notATeamMember, convAccessDenied
+    -- FUTUREWORK: potential errors: codeNotFound, convNotFound, convAccessDenied
     createGroupConversation ::
       routes
         :- Summary "Create a new conversation"
+        :> CanThrow NotATeamMember
         :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
         :> ZUser
         :> ZConn
@@ -210,9 +211,9 @@ data Api routes = Api
     -- Team Conversations
 
     getTeamConversationRoles ::
-      -- FUTUREWORK: errorResponse Error.notATeamMember
       routes
         :- Summary "Get existing roles available for the given team"
+        :> CanThrow NotATeamMember
         :> ZUser
         :> "teams"
         :> Capture "tid" TeamId
@@ -239,10 +240,10 @@ data Api routes = Api
         :> Capture "cid" ConvId
         :> Get '[Servant.JSON] Public.TeamConversation,
     -- FUTUREWORK: errorResponse (Error.actionDenied Public.DeleteConversation)
-    --             errorResponse Error.notATeamMember
     deleteTeamConversation ::
       routes
         :- Summary "Remove a team conversation"
+        :> CanThrow NotATeamMember
         :> ZUser
         :> ZConn
         :> "teams"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -239,11 +239,11 @@ data Api routes = Api
         :> "conversations"
         :> Capture "cid" ConvId
         :> Get '[Servant.JSON] Public.TeamConversation,
-    -- FUTUREWORK: errorResponse (Error.actionDenied Public.DeleteConversation)
     deleteTeamConversation ::
       routes
         :- Summary "Remove a team conversation"
         :> CanThrow NotATeamMember
+        :> CanThrow ActionDenied
         :> ZUser
         :> ZConn
         :> "teams"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -54,14 +54,14 @@ type UpdateResponses =
 type PostOtrResponsesUnqualified =
   '[ WithStatus 201 Public.ClientMismatch,
      WithStatus 412 Public.ClientMismatch,
-     ConversationNotFound,
+     ConvNotFound,
      UnknownClient
    ]
 
 type PostOtrResponses =
   '[ WithStatus 201 Public.MessageSendingStatus,
      WithStatus 412 Public.MessageSendingStatus,
-     ConversationNotFound,
+     ConvNotFound,
      UnknownClient
    ]
 
@@ -167,12 +167,13 @@ data Api routes = Api
         :> QueryParam' [Required, Strict] "key" Code.Key
         :> QueryParam' [Required, Strict] "code" Code.Value
         :> Get '[Servant.JSON] Public.ConversationCoverView,
-    -- FUTUREWORK: potential errors: codeNotFound, convNotFound, convAccessDenied
     createGroupConversation ::
       routes
         :- Summary "Create a new conversation"
         :> CanThrow NotATeamMember
         :> CanThrow CodeNotFound
+        :> CanThrow ConvNotFound
+        :> CanThrow ConvAccessDenied
         :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
         :> ZUser
         :> ZConn

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -156,11 +156,11 @@ data Api routes = Api
     -- This endpoint can lead to the following events being sent:
     -- - ConvCreate event to members
     -- FUTUREWORK: errorResponse Error.notATeamMember
-    --             errorResponse (Error.operationDenied Public.CreateConversation)
     getConversationByReusableCode ::
       routes
         :- Summary "Get limited conversation information by key/code pair"
         :> CanThrow NotConnected
+        :> CanThrow OperationDenied
         :> ZUser
         :> "conversations"
         :> "join"
@@ -219,19 +219,19 @@ data Api routes = Api
         :> "conversations"
         :> "roles"
         :> Get '[Servant.JSON] Public.ConversationRolesList,
-    -- FUTUREWORK: errorResponse (Error.operationDenied Public.GetTeamConversations)
     getTeamConversations ::
       routes
         :- Summary "Get team conversations"
+        :> CanThrow OperationDenied
         :> ZUser
         :> "teams"
         :> Capture "tid" TeamId
         :> "conversations"
         :> Get '[Servant.JSON] Public.TeamConversationList,
-    -- FUTUREWORK: errorResponse (Error.operationDenied Public.GetTeamConversations)
     getTeamConversation ::
       routes
         :- Summary "Get one team conversation"
+        :> CanThrow OperationDenied
         :> ZUser
         :> "teams"
         :> Capture "tid" TeamId

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -94,9 +94,6 @@ unknownRemoteUser = mkError status400 "unknown-remote-user" "Remote user(s) not 
 tooManyMembers :: Error
 tooManyMembers = mkError status403 "too-many-members" "Maximum number of members per conversation reached"
 
-convAccessDenied :: Error
-convAccessDenied = mkError status403 "access-denied" "Conversation access denied"
-
 accessDenied :: Error
 accessDenied = mkError status403 "access-denied" "You do not have permission to access this resource"
 

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -28,7 +28,7 @@ import Data.Text.Lazy as LT (pack)
 import qualified Data.Text.Lazy as LT
 import GHC.TypeLits
 import Galley.Types.Conversations.Roles (Action)
-import Galley.Types.Teams (IsPerm, hardTruncationLimit)
+import Galley.Types.Teams (hardTruncationLimit)
 import Imports
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
@@ -109,13 +109,6 @@ invalidUUID4 = mkError status400 "client-error" "Invalid UUID v4 format"
 
 invalidRange :: LText -> Error
 invalidRange = mkError status400 "client-error"
-
-operationDenied :: (IsPerm perm, Show perm) => perm -> Error
-operationDenied p =
-  mkError
-    status403
-    "operation-denied"
-    ("Insufficient permissions (missing " <> (pack $ show p) <> ")")
 
 actionDenied :: Action -> Error
 actionDenied a =

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -37,16 +37,16 @@ import Type.Reflection (typeRep)
 import Wire.API.ErrorDescription
 
 errorDescriptionToWai ::
-  forall (code :: Nat) (desc :: Symbol).
-  KnownStatus code =>
-  ErrorDescription code desc ->
+  forall (code :: Nat) (lbl :: Symbol) (desc :: Symbol).
+  (KnownStatus code, KnownSymbol lbl) =>
+  ErrorDescription code lbl desc ->
   Error
-errorDescriptionToWai (ErrorDescription lbl msg) =
-  mkError (statusVal (Proxy @code)) (LT.fromStrict lbl) (LT.fromStrict msg)
+errorDescriptionToWai (ErrorDescription msg) =
+  mkError (statusVal (Proxy @code)) (LT.pack (symbolVal (Proxy @lbl))) (LT.fromStrict msg)
 
 throwErrorDescription ::
-  (KnownStatus code, MonadThrow m) =>
-  ErrorDescription code desc ->
+  (KnownStatus code, KnownSymbol lbl, MonadThrow m) =>
+  ErrorDescription code lbl desc ->
   m a
 throwErrorDescription = throwM . errorDescriptionToWai
 

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -171,9 +171,6 @@ noBindingTeamMembers = mkError status403 "non-binding-team-members" "Both users 
 invalidTeamStatusUpdate :: Error
 invalidTeamStatusUpdate = mkError status403 "invalid-team-status-update" "Cannot use this endpoint to update the team to the given status."
 
-codeNotFound :: Error
-codeNotFound = mkError status404 "no-conversation-code" "conversation code not found"
-
 cannotEnableLegalHoldServiceLargeTeam :: Error
 cannotEnableLegalHoldServiceLargeTeam = mkError status403 "too-large-team-for-legalhold" "cannot enable legalhold on large teams.  (reason: for removing LH from team, we need to iterate over all members, which is only supported for teams with less than 2k members.)"
 

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -27,7 +27,6 @@ import Data.String.Conversions (cs)
 import Data.Text.Lazy as LT (pack)
 import qualified Data.Text.Lazy as LT
 import GHC.TypeLits
-import Galley.Types.Conversations.Roles (Action)
 import Galley.Types.Teams (hardTruncationLimit)
 import Imports
 import Network.HTTP.Types.Status
@@ -109,13 +108,6 @@ invalidUUID4 = mkError status400 "client-error" "Invalid UUID v4 format"
 
 invalidRange :: LText -> Error
 invalidRange = mkError status400 "client-error"
-
-actionDenied :: Action -> Error
-actionDenied a =
-  mkError
-    status403
-    "action-denied"
-    ("Insufficient authorization (missing " <> (pack $ show a) <> ")")
 
 noBindingTeam :: Error
 noBindingTeam = mkError status403 "no-binding-team" "Operation allowed only on binding teams."

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -123,9 +123,6 @@ noBindingTeam = mkError status403 "no-binding-team" "Operation allowed only on b
 notAOneMemberTeam :: Error
 notAOneMemberTeam = mkError status403 "not-one-member-team" "Can only delete teams with a single member."
 
-notATeamMember :: Error
-notATeamMember = mkError status403 "no-team-member" "Requesting user is not a team member."
-
 bulkGetMemberLimitExceeded :: Error
 bulkGetMemberLimitExceeded =
   mkError

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -622,7 +622,7 @@ sitemap = do
     body (ref Public.modelConversationAccessUpdate) $
       description "JSON body"
     errorResponse (Error.errorDescriptionToWai Error.convNotFound)
-    errorResponse Error.convAccessDenied
+    errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
     errorResponse Error.invalidTargetAccess
     errorResponse Error.invalidSelfOp
     errorResponse Error.invalidOne2OneOp
@@ -646,7 +646,7 @@ sitemap = do
     body (ref Public.modelConversationReceiptModeUpdate) $
       description "JSON body"
     errorResponse (Error.errorDescriptionToWai Error.convNotFound)
-    errorResponse Error.convAccessDenied
+    errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
 
   -- This endpoint can lead to the following events being sent:
   -- - ConvMessageTimerUpdate event to members
@@ -665,7 +665,7 @@ sitemap = do
     body (ref Public.modelConversationMessageTimerUpdate) $
       description "JSON body"
     errorResponse (Error.errorDescriptionToWai Error.convNotFound)
-    errorResponse Error.convAccessDenied
+    errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
     errorResponse Error.invalidSelfOp
     errorResponse Error.invalidOne2OneOp
     errorResponse Error.invalidConnectOp
@@ -690,7 +690,7 @@ sitemap = do
     errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse (Error.invalidOp "Conversation type does not allow adding members")
     errorResponse (Error.errorDescriptionToWai Error.notConnected)
-    errorResponse Error.convAccessDenied
+    errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
 
   get "/conversations/:cnv/self" (continue Query.getSelfH) $
     zauthUserId

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -124,7 +124,7 @@ sitemap = do
       description "Team ID"
     body (ref Public.modelUpdateData) $
       description "JSON body"
-    errorResponse Error.notATeamMember
+    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
     errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.SetTeamData))
 
   get "/teams" (continue Teams.getManyTeamsH) $
@@ -172,7 +172,7 @@ sitemap = do
       optional
       description "JSON body, required only for binding teams."
     response 202 "Team is scheduled for removal" end
-    errorResponse Error.notATeamMember
+    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
     errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.DeleteTeam))
     errorResponse Error.deleteQueueFull
     errorResponse Error.reAuthFailed
@@ -194,7 +194,7 @@ sitemap = do
       description "Maximum Results to be returned"
     returns (ref Public.modelTeamMemberList)
     response 200 "Team members" end
-    errorResponse Error.notATeamMember
+    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
 
   get "/teams/:tid/members/csv" (continue Teams.getTeamMembersCSVH) $
     -- we could discriminate based on accept header only, but having two paths makes building
@@ -230,7 +230,7 @@ sitemap = do
       description "JSON body"
     returns (ref Public.modelTeamMemberList)
     response 200 "Team members" end
-    errorResponse Error.notATeamMember
+    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
     errorResponse Error.bulkGetMemberLimitExceeded
 
   get "/teams/:tid/members/:uid" (continue Teams.getTeamMemberH) $
@@ -246,7 +246,7 @@ sitemap = do
       description "User ID"
     returns (ref Public.modelTeamMember)
     response 200 "Team member" end
-    errorResponse Error.notATeamMember
+    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
     errorResponse Error.teamMemberNotFound
 
   get "/teams/notifications" (continue Teams.getTeamNotificationsH) $
@@ -301,7 +301,7 @@ sitemap = do
       description "Team ID"
     body (ref Public.modelNewTeamMember) $
       description "JSON body"
-    errorResponse Error.notATeamMember
+    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
     errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.AddTeamMember))
     errorResponse (Error.errorDescriptionToWai Error.notConnected)
     errorResponse Error.invalidPermissions
@@ -324,7 +324,7 @@ sitemap = do
       optional
       description "JSON body, required only for binding teams."
     response 202 "Team member scheduled for deletion" end
-    errorResponse Error.notATeamMember
+    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
     errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.RemoveTeamMember))
     errorResponse Error.reAuthFailed
 
@@ -340,7 +340,7 @@ sitemap = do
       description "Team ID"
     body (ref Public.modelNewTeamMember) $
       description "JSON body"
-    errorResponse Error.notATeamMember
+    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
     errorResponse Error.teamMemberNotFound
     errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.SetMemberPermissions))
 

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -125,7 +125,7 @@ sitemap = do
     body (ref Public.modelUpdateData) $
       description "JSON body"
     errorResponse Error.notATeamMember
-    errorResponse (Error.operationDenied Public.SetTeamData)
+    errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.SetTeamData))
 
   get "/teams" (continue Teams.getManyTeamsH) $
     zauthUserId
@@ -173,7 +173,7 @@ sitemap = do
       description "JSON body, required only for binding teams."
     response 202 "Team is scheduled for removal" end
     errorResponse Error.notATeamMember
-    errorResponse (Error.operationDenied Public.DeleteTeam)
+    errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.DeleteTeam))
     errorResponse Error.deleteQueueFull
     errorResponse Error.reAuthFailed
     errorResponse Error.teamNotFound
@@ -302,7 +302,7 @@ sitemap = do
     body (ref Public.modelNewTeamMember) $
       description "JSON body"
     errorResponse Error.notATeamMember
-    errorResponse (Error.operationDenied Public.AddTeamMember)
+    errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.AddTeamMember))
     errorResponse (Error.errorDescriptionToWai Error.notConnected)
     errorResponse Error.invalidPermissions
     errorResponse Error.tooManyTeamMembers
@@ -325,7 +325,7 @@ sitemap = do
       description "JSON body, required only for binding teams."
     response 202 "Team member scheduled for deletion" end
     errorResponse Error.notATeamMember
-    errorResponse (Error.operationDenied Public.RemoveTeamMember)
+    errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.RemoveTeamMember))
     errorResponse Error.reAuthFailed
 
   put "/teams/:tid/members" (continue Teams.updateTeamMemberH) $
@@ -342,7 +342,7 @@ sitemap = do
       description "JSON body"
     errorResponse Error.notATeamMember
     errorResponse Error.teamMemberNotFound
-    errorResponse (Error.operationDenied Public.SetMemberPermissions)
+    errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.SetMemberPermissions))
 
   -- Team Legalhold API -------------------------------------------------
   --

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -542,7 +542,7 @@ sitemap = do
     response 200 "Valid" end
     body (ref Public.modelConversationCode) $
       description "JSON body"
-    errorResponse Error.codeNotFound
+    errorResponse (Error.errorDescriptionToWai Error.codeNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberJoin event to members
@@ -556,7 +556,7 @@ sitemap = do
     response 200 "Conversation joined." end
     body (ref Public.modelConversationCode) $
       description "JSON body"
-    errorResponse Error.codeNotFound
+    errorResponse (Error.errorDescriptionToWai Error.codeNotFound)
     errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse Error.tooManyMembers
 

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -58,6 +58,7 @@ import qualified Wire.API.Conversation as Public
 import qualified Wire.API.Conversation.Code as Public
 import qualified Wire.API.Conversation.Typing as Public
 import qualified Wire.API.CustomBackend as Public
+import qualified Wire.API.ErrorDescription as Error
 import qualified Wire.API.Event.Team as Public ()
 import qualified Wire.API.Message as Public
 import qualified Wire.API.Notification as Public
@@ -109,7 +110,7 @@ sitemap = do
     body (ref Public.modelNewNonBindingTeam) $
       description "JSON body"
     response 201 "Team ID as `Location` header value" end
-    errorResponse Error.notConnected
+    errorResponse (Error.errorDescriptionToWai Error.notConnected)
 
   put "/teams/:tid" (continue Teams.updateTeamH) $
     zauthUserId
@@ -302,7 +303,7 @@ sitemap = do
       description "JSON body"
     errorResponse Error.notATeamMember
     errorResponse (Error.operationDenied Public.AddTeamMember)
-    errorResponse Error.notConnected
+    errorResponse (Error.errorDescriptionToWai Error.notConnected)
     errorResponse Error.invalidPermissions
     errorResponse Error.tooManyTeamMembers
 
@@ -501,7 +502,7 @@ sitemap = do
     body (ref Public.modelConversationUpdateName) $
       description "JSON body"
     returns (ref Public.modelEvent)
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - ConvRename event to members
@@ -517,7 +518,7 @@ sitemap = do
     body (ref Public.modelConversationUpdateName) $
       description "JSON body"
     returns (ref Public.modelEvent)
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberJoin event to members
@@ -532,7 +533,7 @@ sitemap = do
       description "Conversation ID"
     returns (ref Public.modelEvent)
     response 200 "Conversation joined." end
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
 
   post "/conversations/code-check" (continue Update.checkReusableCodeH) $
     jsonRequest @Public.ConversationCode
@@ -556,7 +557,7 @@ sitemap = do
     body (ref Public.modelConversationCode) $
       description "JSON body"
     errorResponse Error.codeNotFound
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse Error.tooManyMembers
 
   -- This endpoint can lead to the following events being sent:
@@ -573,7 +574,7 @@ sitemap = do
     returns (ref Public.modelConversationCode)
     response 201 "Conversation code created." (model Public.modelEvent)
     response 200 "Conversation code already exists." (model Public.modelConversationCode)
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse Error.invalidAccessOp
 
   -- This endpoint can lead to the following events being sent:
@@ -588,7 +589,7 @@ sitemap = do
       description "Conversation ID"
     returns (ref Public.modelEvent)
     response 200 "Conversation code deleted." end
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse Error.invalidAccessOp
 
   get "/conversations/:cnv/code" (continue Update.getCodeH) $
@@ -600,7 +601,7 @@ sitemap = do
       description "Conversation ID"
     returns (ref Public.modelConversationCode)
     response 200 "Conversation Code" end
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse Error.invalidAccessOp
 
   -- This endpoint can lead to the following events being sent:
@@ -620,7 +621,7 @@ sitemap = do
     response 204 "Conversation access unchanged." end
     body (ref Public.modelConversationAccessUpdate) $
       description "JSON body"
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse Error.convAccessDenied
     errorResponse Error.invalidTargetAccess
     errorResponse Error.invalidSelfOp
@@ -644,7 +645,7 @@ sitemap = do
     response 204 "Conversation receipt mode unchanged." end
     body (ref Public.modelConversationReceiptModeUpdate) $
       description "JSON body"
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse Error.convAccessDenied
 
   -- This endpoint can lead to the following events being sent:
@@ -663,7 +664,7 @@ sitemap = do
     response 204 "Message timer unchanged." end
     body (ref Public.modelConversationMessageTimerUpdate) $
       description "JSON body"
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse Error.convAccessDenied
     errorResponse Error.invalidSelfOp
     errorResponse Error.invalidOne2OneOp
@@ -686,9 +687,9 @@ sitemap = do
     response 200 "Members added" end
     response 204 "No change" end
     response 412 "The user(s) cannot be added to the conversation (eg., due to legalhold policy conflict)." end
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse (Error.invalidOp "Conversation type does not allow adding members")
-    errorResponse Error.notConnected
+    errorResponse (Error.errorDescriptionToWai Error.notConnected)
     errorResponse Error.convAccessDenied
 
   get "/conversations/:cnv/self" (continue Query.getSelfH) $
@@ -699,7 +700,7 @@ sitemap = do
     parameter Path "cnv" bytes' $
       description "Conversation ID"
     returns (ref Public.modelMember)
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberStateUpdate event to self
@@ -715,7 +716,7 @@ sitemap = do
       description "Conversation ID"
     body (ref Public.modelMemberUpdate) $
       description "JSON body"
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberStateUpdate event to members
@@ -734,7 +735,7 @@ sitemap = do
       description "Target User ID"
     body (ref Public.modelOtherMemberUpdate) $
       description "JSON body"
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse Error.convMemberNotFound
     errorResponse Error.invalidTargetUserOp
 
@@ -751,7 +752,7 @@ sitemap = do
       description "Conversation ID"
     body (ref Public.modelTyping) $
       description "JSON body"
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberLeave event to members
@@ -769,7 +770,7 @@ sitemap = do
     returns (ref Public.modelEvent)
     response 200 "Member removed" end
     response 204 "No change" end
-    errorResponse Error.convNotFound
+    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse $ Error.invalidOp "Conversation type does not allow removing members"
 
   -- This endpoint can lead to the following events being sent:
@@ -807,7 +808,7 @@ sitemap = do
     response 412 "Missing clients" end
     errorResponse Error.teamNotFound
     errorResponse Error.nonBindingTeam
-    errorResponse Error.unknownClient
+    errorResponse (Error.errorDescriptionToWai Error.unknownClient)
     errorResponse Error.broadcastLimitExceeded
 
   -- This endpoint can lead to the following events being sent:
@@ -842,7 +843,7 @@ sitemap = do
     response 412 "Missing clients" end
     errorResponse Error.teamNotFound
     errorResponse Error.nonBindingTeam
-    errorResponse Error.unknownClient
+    errorResponse (Error.errorDescriptionToWai Error.unknownClient)
     errorResponse Error.broadcastLimitExceeded
 
 apiDocs :: Routes ApiBuilder Galley ()

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -114,6 +114,7 @@ import qualified SAML2.WebSSO as SAML
 import qualified System.Logger.Class as Log
 import UnliftIO (mapConcurrently)
 import qualified Wire.API.Conversation.Role as Public
+import Wire.API.ErrorDescription (convNotFound)
 import qualified Wire.API.Notification as Public
 import Wire.API.Routes.Public (EmptyResult (..))
 import qualified Wire.API.Team as Public
@@ -771,7 +772,7 @@ getTeamConversation zusr tid cid = do
   tm <- Data.teamMember tid zusr >>= ifNothing notATeamMember
   unless (tm `hasPermission` GetTeamConversations) $
     throwM (operationDenied GetTeamConversations)
-  Data.teamConversation tid cid >>= maybe (throwM convNotFound) pure
+  Data.teamConversation tid cid >>= maybe (throwErrorDescription convNotFound) pure
 
 deleteTeamConversation :: UserId -> ConnId -> TeamId -> ConvId -> Galley (EmptyResult 200)
 deleteTeamConversation zusr zcon tid cid = do

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -114,7 +114,7 @@ import qualified SAML2.WebSSO as SAML
 import qualified System.Logger.Class as Log
 import UnliftIO (mapConcurrently)
 import qualified Wire.API.Conversation.Role as Public
-import Wire.API.ErrorDescription (convNotFound, operationDenied)
+import Wire.API.ErrorDescription (convNotFound, notATeamMember, operationDenied)
 import qualified Wire.API.Notification as Public
 import Wire.API.Routes.Public (EmptyResult (..))
 import qualified Wire.API.Team as Public
@@ -369,7 +369,7 @@ getTeamConversationRoles :: UserId -> TeamId -> Galley Public.ConversationRolesL
 getTeamConversationRoles zusr tid = do
   mem <- Data.teamMember tid zusr
   case mem of
-    Nothing -> throwM notATeamMember
+    Nothing -> throwErrorDescription notATeamMember
     Just _ -> do
       -- NOTE: If/when custom roles are added, these roles should
       --       be merged with the team roles (if they exist)
@@ -383,7 +383,7 @@ getTeamMembersH (zusr ::: tid ::: maxResults ::: _) = do
 getTeamMembers :: UserId -> TeamId -> Range 1 Public.HardTruncationLimit Int32 -> Galley (Public.TeamMemberList, Public.TeamMember -> Bool)
 getTeamMembers zusr tid maxResults = do
   Data.teamMember tid zusr >>= \case
-    Nothing -> throwM notATeamMember
+    Nothing -> throwErrorDescription notATeamMember
     Just m -> do
       mems <- Data.teamMembersWithLimit tid maxResults
       let withPerms = (m `canSeePermsOf`)
@@ -517,7 +517,7 @@ bulkGetTeamMembers zusr tid maxResults uids = do
   unless (length uids <= fromIntegral (fromRange maxResults)) $
     throwM bulkGetMemberLimitExceeded
   Data.teamMember tid zusr >>= \case
-    Nothing -> throwM notATeamMember
+    Nothing -> throwErrorDescription notATeamMember
     Just m -> do
       mems <- Data.teamMembersLimited tid uids
       let withPerms = (m `canSeePermsOf`)
@@ -533,7 +533,7 @@ getTeamMember :: UserId -> TeamId -> UserId -> Galley (Public.TeamMember, Public
 getTeamMember zusr tid uid = do
   zusrMembership <- Data.teamMember tid zusr
   case zusrMembership of
-    Nothing -> throwM notATeamMember
+    Nothing -> throwErrorDescription notATeamMember
     Just m -> do
       let withPerms = (m `canSeePermsOf`)
       Data.teamMember tid uid >>= \case
@@ -762,14 +762,14 @@ uncheckedDeleteTeamMember zusr zcon tid remove mems = do
 
 getTeamConversations :: UserId -> TeamId -> Galley Public.TeamConversationList
 getTeamConversations zusr tid = do
-  tm <- Data.teamMember tid zusr >>= ifNothing notATeamMember
+  tm <- Data.teamMember tid zusr >>= ifNothing (errorDescriptionToWai notATeamMember)
   unless (tm `hasPermission` GetTeamConversations) $
     throwErrorDescription (operationDenied GetTeamConversations)
   Public.newTeamConversationList <$> Data.teamConversations tid
 
 getTeamConversation :: UserId -> TeamId -> ConvId -> Galley Public.TeamConversation
 getTeamConversation zusr tid cid = do
-  tm <- Data.teamMember tid zusr >>= ifNothing notATeamMember
+  tm <- Data.teamMember tid zusr >>= ifNothing (errorDescriptionToWai notATeamMember)
   unless (tm `hasPermission` GetTeamConversations) $
     throwErrorDescription (operationDenied GetTeamConversations)
   Data.teamConversation tid cid >>= maybe (throwErrorDescription convNotFound) pure

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -114,7 +114,7 @@ import qualified SAML2.WebSSO as SAML
 import qualified System.Logger.Class as Log
 import UnliftIO (mapConcurrently)
 import qualified Wire.API.Conversation.Role as Public
-import Wire.API.ErrorDescription (convNotFound)
+import Wire.API.ErrorDescription (convNotFound, operationDenied)
 import qualified Wire.API.Notification as Public
 import Wire.API.Routes.Public (EmptyResult (..))
 import qualified Wire.API.Team as Public
@@ -764,14 +764,14 @@ getTeamConversations :: UserId -> TeamId -> Galley Public.TeamConversationList
 getTeamConversations zusr tid = do
   tm <- Data.teamMember tid zusr >>= ifNothing notATeamMember
   unless (tm `hasPermission` GetTeamConversations) $
-    throwM (operationDenied GetTeamConversations)
+    throwErrorDescription (operationDenied GetTeamConversations)
   Public.newTeamConversationList <$> Data.teamConversations tid
 
 getTeamConversation :: UserId -> TeamId -> ConvId -> Galley Public.TeamConversation
 getTeamConversation zusr tid cid = do
   tm <- Data.teamMember tid zusr >>= ifNothing notATeamMember
   unless (tm `hasPermission` GetTeamConversations) $
-    throwM (operationDenied GetTeamConversations)
+    throwErrorDescription (operationDenied GetTeamConversations)
   Data.teamConversation tid cid >>= maybe (throwErrorDescription convNotFound) pure
 
 deleteTeamConversation :: UserId -> ConnId -> TeamId -> ConvId -> Galley (EmptyResult 200)

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -115,7 +115,7 @@ import Wire.API.Conversation (InviteQualified (invQRoleName))
 import qualified Wire.API.Conversation as Public
 import qualified Wire.API.Conversation.Code as Public
 import Wire.API.Conversation.Role (roleNameWireAdmin)
-import Wire.API.ErrorDescription (convNotFound, unknownClient)
+import Wire.API.ErrorDescription (codeNotFound, convNotFound, unknownClient)
 import qualified Wire.API.ErrorDescription as Public
 import qualified Wire.API.Event.Conversation as Public
 import Wire.API.Federation.API.Galley (RemoteMessage (..))
@@ -415,7 +415,9 @@ getCode usr cnv = do
   ensureAccess conv CodeAccess
   ensureConvMember (Data.convLocalMembers conv) usr
   key <- mkKey cnv
-  c <- Data.lookupCode key ReusableCode >>= ifNothing codeNotFound
+  c <-
+    Data.lookupCode key ReusableCode
+      >>= ifNothing (errorDescriptionToWai codeNotFound)
   returnCode c
 
 returnCode :: Code -> Galley Public.ConversationCode

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -115,6 +115,7 @@ import Wire.API.Conversation (InviteQualified (invQRoleName))
 import qualified Wire.API.Conversation as Public
 import qualified Wire.API.Conversation.Code as Public
 import Wire.API.Conversation.Role (roleNameWireAdmin)
+import Wire.API.ErrorDescription (convNotFound, unknownClient)
 import qualified Wire.API.ErrorDescription as Public
 import qualified Wire.API.Event.Conversation as Public
 import Wire.API.Federation.API.Galley (RemoteMessage (..))
@@ -131,7 +132,7 @@ acceptConvH (usr ::: conn ::: cnv) = do
 
 acceptConv :: UserId -> Maybe ConnId -> ConvId -> Galley Conversation
 acceptConv usr conn cnv = do
-  conv <- Data.conversation cnv >>= ifNothing convNotFound
+  conv <- Data.conversation cnv >>= ifNothing (errorDescriptionToWai convNotFound)
   conv' <- acceptOne2One usr conv conn
   conversationView usr conv'
 
@@ -141,7 +142,7 @@ blockConvH (zusr ::: cnv) = do
 
 blockConv :: UserId -> ConvId -> Galley ()
 blockConv zusr cnv = do
-  conv <- Data.conversation cnv >>= ifNothing convNotFound
+  conv <- Data.conversation cnv >>= ifNothing (errorDescriptionToWai convNotFound)
   unless (Data.convType conv `elem` [ConnectConv, One2OneConv]) $
     throwM $
       invalidOp "block: invalid conversation type"
@@ -154,7 +155,7 @@ unblockConvH (usr ::: conn ::: cnv) = do
 
 unblockConv :: UserId -> Maybe ConnId -> ConvId -> Galley Conversation
 unblockConv usr conn cnv = do
-  conv <- Data.conversation cnv >>= ifNothing convNotFound
+  conv <- Data.conversation cnv >>= ifNothing (errorDescriptionToWai convNotFound)
   unless (Data.convType conv `elem` [ConnectConv, One2OneConv]) $
     throwM $
       invalidOp "unblock: invalid conversation type"
@@ -189,7 +190,7 @@ updateConversationAccess usr zcon cnv update = do
   -- The user who initiated access change has to be a conversation member
   (bots, users) <- botsAndUsers <$> Data.members cnv
   ensureConvMember users usr
-  conv <- Data.conversation cnv >>= ifNothing convNotFound
+  conv <- Data.conversation cnv >>= ifNothing (errorDescriptionToWai convNotFound)
   -- The conversation has to be a group conversation
   ensureGroupConv conv
   self <- getSelfMember usr users
@@ -330,7 +331,7 @@ updateConversationMessageTimer usr zcon cnv timerUpdate@(Public.ConversationMess
   -- checks and balances
   (bots, users) <- botsAndUsers <$> Data.members cnv
   ensureActionAllowed ModifyConversationMessageTimer =<< getSelfMember usr users
-  conv <- Data.conversation cnv >>= ifNothing convNotFound
+  conv <- Data.conversation cnv >>= ifNothing (errorDescriptionToWai convNotFound)
   ensureGroupConv conv
   let currentTimer = Data.convMessageTimer conv
   if currentTimer == target
@@ -360,7 +361,7 @@ addCode usr zcon cnv = do
   localDomain <- viewFederationDomain
   let qcnv = Qualified cnv localDomain
       qusr = Qualified usr localDomain
-  conv <- Data.conversation cnv >>= ifNothing convNotFound
+  conv <- Data.conversation cnv >>= ifNothing (errorDescriptionToWai convNotFound)
   ensureConvMember (Data.convLocalMembers conv) usr
   ensureAccess conv CodeAccess
   let (bots, users) = botsAndUsers $ Data.convLocalMembers conv
@@ -393,7 +394,7 @@ rmCode usr zcon cnv = do
   localDomain <- viewFederationDomain
   let qcnv = Qualified cnv localDomain
       qusr = Qualified usr localDomain
-  conv <- Data.conversation cnv >>= ifNothing convNotFound
+  conv <- Data.conversation cnv >>= ifNothing (errorDescriptionToWai convNotFound)
   ensureConvMember (Data.convLocalMembers conv) usr
   ensureAccess conv CodeAccess
   let (bots, users) = botsAndUsers $ Data.convLocalMembers conv
@@ -410,7 +411,7 @@ getCodeH (usr ::: cnv) = do
 
 getCode :: UserId -> ConvId -> Galley Public.ConversationCode
 getCode usr cnv = do
-  conv <- Data.conversation cnv >>= ifNothing convNotFound
+  conv <- Data.conversation cnv >>= ifNothing (errorDescriptionToWai convNotFound)
   ensureAccess conv CodeAccess
   ensureConvMember (Data.convLocalMembers conv) usr
   key <- mkKey cnv
@@ -492,7 +493,7 @@ mapUpdateToServant Unchanged = Servant.respond NoContent
 --  These checks need tests :)
 addMembers :: UserId -> ConnId -> ConvId -> Public.InviteQualified -> Galley UpdateResult
 addMembers zusr zcon convId invite = do
-  conv <- Data.conversation convId >>= ifNothing convNotFound
+  conv <- Data.conversation convId >>= ifNothing (errorDescriptionToWai convNotFound)
   let mems = botsAndUsers (Data.convLocalMembers conv)
   let rMems = Data.convRemoteMembers conv
   self <- getSelfMember zusr (snd mems)
@@ -599,7 +600,7 @@ removeMember :: UserId -> Maybe ConnId -> ConvId -> UserId -> Galley UpdateResul
 removeMember zusr zcon convId victim = do
   localDomain <- viewFederationDomain
   -- FUTUREWORK(federation, #1274): forward request to conversation's backend.
-  conv <- Data.conversation convId >>= ifNothing convNotFound
+  conv <- Data.conversation convId >>= ifNothing (errorDescriptionToWai convNotFound)
   let (bots, users) = botsAndUsers (Data.convLocalMembers conv)
   genConvChecks conv users
   case Data.convTeam conv of
@@ -639,8 +640,8 @@ handleOtrResult :: OtrResult -> Galley Response
 handleOtrResult = \case
   OtrSent m -> pure $ json m & setStatus status201
   OtrMissingRecipients m -> pure $ json m & setStatus status412
-  OtrUnknownClient _ -> throwM unknownClient
-  OtrConversationNotFound _ -> throwM convNotFound
+  OtrUnknownClient _ -> throwErrorDescription unknownClient
+  OtrConversationNotFound _ -> throwErrorDescription convNotFound
 
 postBotMessageH :: BotId ::: ConvId ::: Public.OtrFilterMissing ::: JsonRequest Public.NewOtrMessage ::: JSON -> Galley Response
 postBotMessageH (zbot ::: zcnv ::: val ::: req ::: _) = do
@@ -845,7 +846,7 @@ updateConversationName zusr zcon cnv convRename = do
   alive <- Data.isConvAlive cnv
   unless alive $ do
     Data.deleteConversation cnv
-    throwM convNotFound
+    throwErrorDescription convNotFound
   (bots, users) <- botsAndUsers <$> Data.members cnv
   ensureActionAllowed ModifyConversationName =<< getSelfMember zusr users
   now <- liftIO getCurrentTime
@@ -870,7 +871,7 @@ isTyping zusr zcon cnv typingData = do
       qusr = Qualified zusr localDomain
   mm <- Data.members cnv
   unless (zusr `isMember` mm) $
-    throwM convNotFound
+    throwErrorDescription convNotFound
   now <- liftIO getCurrentTime
   let e = Event Typing qcnv qusr now (EdTyping typingData)
   for_ (newPushLocal ListComplete zusr (ConvEvent e) (recipient <$> mm)) $ \p ->
@@ -899,7 +900,7 @@ addBot :: UserId -> ConnId -> AddBot -> Galley Event
 addBot zusr zcon b = do
   localDomain <- viewFederationDomain
   let qusr = Qualified zusr localDomain
-  c <- Data.conversation (b ^. addBotConv) >>= ifNothing convNotFound
+  c <- Data.conversation (b ^. addBotConv) >>= ifNothing (errorDescriptionToWai convNotFound)
   -- Check some preconditions on adding bots to a conversation
   for_ (Data.convTeam c) $ teamConvChecks (b ^. addBotConv)
   (bots, users) <- regularConvChecks c
@@ -914,7 +915,7 @@ addBot zusr zcon b = do
     regularConvChecks c = do
       let (bots, users) = botsAndUsers (Data.convLocalMembers c)
       unless (zusr `isMember` users) $
-        throwM convNotFound
+        throwErrorDescription convNotFound
       ensureGroupConv c
       ensureActionAllowed AddConversationMember =<< getSelfMember zusr users
       unless (any ((== b ^. addBotId) . botMemId) bots) $
@@ -932,12 +933,12 @@ rmBotH (zusr ::: zcon ::: req) = do
 
 rmBot :: UserId -> Maybe ConnId -> RemoveBot -> Galley UpdateResult
 rmBot zusr zcon b = do
-  c <- Data.conversation (b ^. rmBotConv) >>= ifNothing convNotFound
+  c <- Data.conversation (b ^. rmBotConv) >>= ifNothing (errorDescriptionToWai convNotFound)
   localDomain <- viewFederationDomain
   let qcnv = Qualified (Data.convId c) localDomain
       qusr = Qualified zusr localDomain
   unless (zusr `isMember` Data.convLocalMembers c) $
-    throwM convNotFound
+    throwErrorDescription convNotFound
   let (bots, users) = botsAndUsers (Data.convLocalMembers c)
   if not (any ((== b ^. rmBotId) . botMemId) bots)
     then pure Unchanged
@@ -1006,7 +1007,7 @@ notIsMember' cc u = not $ isRemoteMember u (Data.convRemoteMembers cc)
 ensureConvMember :: [LocalMember] -> UserId -> Galley ()
 ensureConvMember users usr =
   unless (usr `isMember` users) $
-    throwM convNotFound
+    throwErrorDescription convNotFound
 
 processUpdateMemberEvent ::
   UserId ->
@@ -1105,7 +1106,7 @@ withValidOtrRecipients utype usr clt cnv rcps val now go = do
   if not alive
     then do
       Data.deleteConversation cnv
-      pure $ OtrConversationNotFound Public.convNotFound
+      pure $ OtrConversationNotFound convNotFound
     else do
       localMembers <- Data.members cnv
       let localMemberIds = memId <$> localMembers
@@ -1141,8 +1142,8 @@ handleOtrResponse utype usr clt rcps membs clts val now go = case checkOtrRecipi
   MissingOtrRecipients m -> do
     guardLegalholdPolicyConflicts (userToProtectee utype usr) (missingClients m)
     pure (OtrMissingRecipients m)
-  InvalidOtrSenderUser -> pure $ OtrConversationNotFound Public.convNotFound
-  InvalidOtrSenderClient -> pure $ OtrUnknownClient Public.unknownClient
+  InvalidOtrSenderUser -> pure $ OtrConversationNotFound convNotFound
+  InvalidOtrSenderClient -> pure $ OtrUnknownClient unknownClient
 
 -- | Check OTR sender and recipients for validity and completeness
 -- against a given list of valid members and clients, optionally

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -636,7 +636,7 @@ data OtrResult
   = OtrSent !Public.ClientMismatch
   | OtrMissingRecipients !Public.ClientMismatch
   | OtrUnknownClient !Public.UnknownClient
-  | OtrConversationNotFound !Public.ConversationNotFound
+  | OtrConversationNotFound !Public.ConvNotFound
 
 handleOtrResult :: OtrResult -> Galley Response
 handleOtrResult = \case

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -67,7 +67,7 @@ import Servant.API (IsMember, Union, inject)
 import qualified System.Logger.Class as Log
 import UnliftIO (concurrently)
 import qualified Wire.API.Conversation as Public
-import Wire.API.ErrorDescription (convNotFound, notConnected, operationDenied)
+import Wire.API.ErrorDescription (convNotFound, notATeamMember, notConnected, operationDenied)
 import qualified Wire.API.Federation.API.Brig as FederatedBrig
 import Wire.API.Federation.API.Galley as FederatedGalley
 import Wire.API.Federation.Client (FederationClientFailure, FederatorClient, executeFederated)
@@ -82,7 +82,7 @@ ensureAccessRole role users = case role of
   PrivateAccessRole -> throwM convAccessDenied
   TeamAccessRole ->
     when (any (isNothing . snd) users) $
-      throwM notATeamMember
+      throwErrorDescription notATeamMember
   ActivatedAccessRole -> do
     activated <- lookupActivatedUsers $ map fst users
     when (length activated /= length users) $
@@ -166,7 +166,7 @@ permissionCheck p = \case
     if m `hasPermission` p
       then pure m
       else throwErrorDescription (operationDenied p)
-  Nothing -> throwM notATeamMember
+  Nothing -> throwErrorDescription notATeamMember
 
 assertTeamExists :: TeamId -> Galley ()
 assertTeamExists tid = do
@@ -178,7 +178,7 @@ assertTeamExists tid = do
 assertOnTeam :: UserId -> TeamId -> Galley ()
 assertOnTeam uid tid = do
   Data.teamMember tid uid >>= \case
-    Nothing -> throwM notATeamMember
+    Nothing -> throwErrorDescription notATeamMember
     Just _ -> return ()
 
 -- | If the conversation is in a team, throw iff zusr is a team member and does not have named

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -67,7 +67,7 @@ import Servant.API (IsMember, Union, inject)
 import qualified System.Logger.Class as Log
 import UnliftIO (concurrently)
 import qualified Wire.API.Conversation as Public
-import Wire.API.ErrorDescription (actionDenied, convNotFound, notATeamMember, notConnected, operationDenied)
+import Wire.API.ErrorDescription
 import qualified Wire.API.Federation.API.Brig as FederatedBrig
 import Wire.API.Federation.API.Galley as FederatedGalley
 import Wire.API.Federation.Client (FederationClientFailure, FederatorClient, executeFederated)
@@ -326,9 +326,11 @@ pushConversationEvent conn e users bots = do
 
 verifyReusableCode :: ConversationCode -> Galley DataTypes.Code
 verifyReusableCode convCode = do
-  c <- Data.lookupCode (conversationKey convCode) DataTypes.ReusableCode >>= ifNothing codeNotFound
+  c <-
+    Data.lookupCode (conversationKey convCode) DataTypes.ReusableCode
+      >>= ifNothing (errorDescriptionToWai codeNotFound)
   unless (DataTypes.codeValue c == conversationCode convCode) $
-    throwM codeNotFound
+    throwM (errorDescriptionToWai codeNotFound)
   return c
 
 ensureConversationAccess :: UserId -> ConvId -> Access -> Galley Data.Conversation

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -67,7 +67,7 @@ import Servant.API (IsMember, Union, inject)
 import qualified System.Logger.Class as Log
 import UnliftIO (concurrently)
 import qualified Wire.API.Conversation as Public
-import Wire.API.ErrorDescription (convNotFound, notConnected)
+import Wire.API.ErrorDescription (convNotFound, notConnected, operationDenied)
 import qualified Wire.API.Federation.API.Brig as FederatedBrig
 import Wire.API.Federation.API.Galley as FederatedGalley
 import Wire.API.Federation.Client (FederationClientFailure, FederatorClient, executeFederated)
@@ -165,7 +165,7 @@ permissionCheck p = \case
   Just m -> do
     if m `hasPermission` p
       then pure m
-      else throwM (operationDenied p)
+      else throwErrorDescription (operationDenied p)
   Nothing -> throwM notATeamMember
 
 assertTeamExists :: TeamId -> Galley ()

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -67,7 +67,7 @@ import Servant.API (IsMember, Union, inject)
 import qualified System.Logger.Class as Log
 import UnliftIO (concurrently)
 import qualified Wire.API.Conversation as Public
-import Wire.API.ErrorDescription (convNotFound, notATeamMember, notConnected, operationDenied)
+import Wire.API.ErrorDescription (actionDenied, convNotFound, notATeamMember, notConnected, operationDenied)
 import qualified Wire.API.Federation.API.Brig as FederatedBrig
 import Wire.API.Federation.API.Galley as FederatedGalley
 import Wire.API.Federation.Client (FederationClientFailure, FederatorClient, executeFederated)
@@ -138,7 +138,7 @@ ensureReAuthorised u secret = do
 ensureActionAllowed :: Action -> InternalMember a -> Galley ()
 ensureActionAllowed action mem = case isActionAllowed action (memConvRoleName mem) of
   Just True -> return ()
-  Just False -> throwM (actionDenied action)
+  Just False -> throwErrorDescription (actionDenied action)
   Nothing -> throwM (badRequest "Custom roles not supported")
 
 -- Actually, this will "never" happen due to the


### PR DESCRIPTION
This introduces a `CanThrow` type to be used in Servant APIs, declaring exceptions that can be thrown by the handler. The `CanThrow` type is ignored by Servant, but results in a new response being produced in Swagger.

This PR also arranges for specialised Swagger schemas to be displayed in the response section of endpoints with possible error responses. The specialised schemas have better example and more restrictions on the possible values of the error label. 

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
 - [x] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
 - [x] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
