### PR TITLE
Federation: sanitize paths to avoid path traversal attacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This release requires a manual change in your galley configuration: `settings.co
 * [Federation] Fetch remote user's clients when sending messages (#1635).
 * [Federation] Actually propagate messages to other backends (#1638).
 * [Federation] Support sending messages to remote conversations (#1609).
+* [Federation] Guard against path traversal attacks (#1646).
 
 ## Internal changes
 

--- a/services/federator/src/Federator/ExternalServer.hs
+++ b/services/federator/src/Federator/ExternalServer.hs
@@ -52,10 +52,7 @@ import Wire.API.Federation.GRPC.Types
 -- https://higherkindness.io/mu-haskell/registry/ for some mu-haskell support
 -- for versioning schemas here.
 
--- FUTUREWORK(federation): How do we make sure that only legitimate endpoints can be
--- reached, some discussion here:
 -- https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/224166764/Limiting+access+to+federation+endpoints
--- Also, see comment in 'Federator.Service.interpretService'
 --
 -- FUTUREWORK(federation): implement server2server authentication!
 -- (current validation only checks parsing and compares to allowList)
@@ -76,7 +73,7 @@ callLocal' req@Request {..} = do
       . Log.field "request" (show req)
 
   validatedDomain <- validateDomain originDomain
-  validatedPath <- pure path -- FUTUREWORK implementation next PR
+  validatedPath <- sanitizePath path
   Log.debug $
     Log.msg ("Path validation" :: ByteString)
       . Log.field "original path:" (show path)

--- a/services/federator/src/Federator/Service.hs
+++ b/services/federator/src/Federator/Service.hs
@@ -58,7 +58,7 @@ interpretService = interpret $ \case
     res <-
       rpc' (LText.pack (show component)) (serviceReq component) $
         RPC.method HTTP.POST
-          . RPC.path path -- FUTUREWORK(federation): Protect against arbitrary paths
+          . RPC.path path
           . RPC.body (RPC.RequestBodyBS body)
           . RPC.contentJson
           . RPC.header domainHeaderName (cs (domainText domain))

--- a/services/federator/test/integration/Test/Federator/InwardSpec.hs
+++ b/services/federator/test/integration/Test/Federator/InwardSpec.hs
@@ -80,16 +80,18 @@ spec env =
         bdy <- asInwardBody =<< inwardBrigCall "federation/get-user-by-handle" (encode hdl)
         liftIO $ bdy `shouldBe` expectedProfile
 
-    it "should give InvalidEndpoint on a 404 'no-endpoint'" $
+    it "should give an InvalidEndpoint error on a 404 'no-endpoint' response from Brig" $
       runTestFederator env $ do
         err <- asInwardError =<< inwardBrigCall "federation/this-endpoint-does-not-exist" (encode Aeson.emptyObject)
         expectErr IInvalidEndpoint err
 
-    it "should not accept invalid paths" $
+    -- Note: most tests for forbidden endpoints are in the unit tests of the sanitizePath function
+    -- The integration tests are just another safeguard.
+    it "should not accept invalid/disallowed paths" $
       runTestFederator env $ do
         let o = object ["name" .= ("fakeNewUser" :: Text)]
         err <- asInwardErrorUnsafe <$> inwardBrigCall "http://localhost:8080/i/users" (encode o)
-        expectErr IInvalidEndpoint err
+        expectErr IForbiddenEndpoint err
 
     it "should only accept /federation/ paths" $
       runTestFederator env $ do

--- a/services/federator/test/integration/Test/Federator/InwardSpec.hs
+++ b/services/federator/test/integration/Test/Federator/InwardSpec.hs
@@ -85,7 +85,7 @@ spec env =
         err <- asInwardError =<< inwardBrigCall "federation/this-endpoint-does-not-exist" (encode Aeson.emptyObject)
         expectErr IInvalidEndpoint err
 
-    it "should only not accept invalid paths" $
+    it "should not accept invalid paths" $
       runTestFederator env $ do
         let o = object ["name" .= ("fakeNewUser" :: Text)]
         err <- asInwardErrorUnsafe <$> inwardBrigCall "http://localhost:8080/i/users" (encode o)
@@ -97,7 +97,7 @@ spec env =
         err <- asInwardErrorUnsafe <$> inwardBrigCall "i/users" (encode o)
         expectErr IForbiddenEndpoint err
 
-    it "should only accept /federation/ paths (also when there are .. segments)" $
+    it "should only accept /federation/ paths (also when there are /../ segments)" $
       runTestFederator env $ do
         let o = object ["name" .= ("fakeNewUser" :: Text)]
         err <- asInwardErrorUnsafe <$> inwardBrigCall "federation/../i/users" (encode o)

--- a/services/federator/test/unit/Test/Federator/ExternalServer.hs
+++ b/services/federator/test/unit/Test/Federator/ExternalServer.hs
@@ -57,7 +57,7 @@ requestBrigSuccess =
 
       res :: InwardResponse <- mock @Service @IO . noLogs . Polysemy.runReader allowAllSettings $ callLocal request
       actualCalls <- mockServiceCallCalls @IO
-      let expectedCall = (Brig, "/federation/get-user-by-handle", "\"foo\"", aValidDomain)
+      let expectedCall = (Brig, "federation/get-user-by-handle", "\"foo\"", aValidDomain)
       embed $ assertEqual "one call to brig should be made" [expectedCall] actualCalls
       embed $ assertEqual "response should be success with correct body" (InwardResponseBody "response body") res
 
@@ -71,7 +71,7 @@ requestBrigFailure =
       res <- mock @Service @IO . noLogs . Polysemy.runReader allowAllSettings $ callLocal request
 
       actualCalls <- mockServiceCallCalls @IO
-      let expectedCall = (Brig, "/federation/get-user-by-handle", "\"foo\"", aValidDomain)
+      let expectedCall = (Brig, "federation/get-user-by-handle", "\"foo\"", aValidDomain)
       embed $ assertEqual "one call to brig should be made" [expectedCall] actualCalls
       embed $ case res of
         InwardResponseBody b -> assertFailure ("expecting error, got success: " <> cs b)
@@ -82,11 +82,11 @@ requestGalleySuccess =
   testCase "should translate response from galley to 'InwardResponseBody' when response has status 200" $
     runM . evalMock @Service @IO $ do
       mockServiceCallReturns @IO (\_ _ _ _ -> pure (HTTP.ok200, Just "response body"))
-      let request = Request Galley "/federation/get-conversations" "{}" exampleDomain
+      let request = Request Galley "federation/get-conversations" "{}" exampleDomain
 
       res :: InwardResponse <- mock @Service @IO . noLogs . Polysemy.runReader allowAllSettings $ callLocal request
       actualCalls <- mockServiceCallCalls @IO
-      let expectedCall = (Galley, "/federation/get-conversations", "{}", aValidDomain)
+      let expectedCall = (Galley, "federation/get-conversations", "{}", aValidDomain)
       embed $ assertEqual "one call to brig should be made" [expectedCall] actualCalls
       embed $ assertEqual "response should be success with correct body" (InwardResponseBody "response body") res
 


### PR DESCRIPTION
At the moment we use the convention that all RPCs between federator -> brig/galley/etc use the "federation" path prefix. This PR adds validation to ensure other paths cannot be called, as that would expose non-federation APIs (including internal, non-authenticated ones) to the world.

See also the discussion in https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/224166764/Limiting+access+to+federation+endpoints

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] rebase to develop after #1637 has landed.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.