### PR TITLE
Make file sharing feature configurable at instance level.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,21 @@
 
 ## Release Notes
 
+If you want to set the default for file sharing in all teams to `disabled`, add the following to `galley.yaml` (default is "enabled"):
+
+```
+settings:
+  featureFlags:
+    fileSharing:
+      defaults:
+        status: disabled
+```
+
 ## API Changes
 
 ## Features
 
-* `fileSharing` feature config (#1652)
+* `fileSharing` feature config (#1652, #1654)
 * Add user_id to csv export (#1663)
 
 ## Bug fixes and other updates

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -27,9 +27,11 @@ module Galley.Types.Teams
     flagSSO,
     flagLegalHold,
     flagTeamSearchVisibility,
+    flagFileSharing,
     flagAppLockDefaults,
     flagClassifiedDomains,
     Defaults (..),
+    unDefaults,
     FeatureSSO (..),
     FeatureLegalHold (..),
     FeatureTeamSearchVisibility (..),
@@ -196,7 +198,8 @@ data FeatureFlags = FeatureFlags
     _flagLegalHold :: !FeatureLegalHold,
     _flagTeamSearchVisibility :: !FeatureTeamSearchVisibility,
     _flagAppLockDefaults :: !(Defaults (TeamFeatureStatus 'TeamFeatureAppLock)),
-    _flagClassifiedDomains :: !(TeamFeatureStatus 'TeamFeatureClassifiedDomains)
+    _flagClassifiedDomains :: !(TeamFeatureStatus 'TeamFeatureClassifiedDomains),
+    _flagFileSharing :: !(Defaults (TeamFeatureStatus 'TeamFeatureFileSharing))
   }
   deriving (Eq, Show, Generic)
 
@@ -240,15 +243,17 @@ instance FromJSON FeatureFlags where
       <*> obj .: "teamSearchVisibility"
       <*> (fromMaybe (Defaults defaultAppLockStatus) <$> (obj .:? "appLock"))
       <*> (fromMaybe defaultClassifiedDomains <$> (obj .:? "classifiedDomains"))
+      <*> (fromMaybe (Defaults (TeamFeatureStatusNoConfig TeamFeatureEnabled)) <$> (obj .:? "fileSharing"))
 
 instance ToJSON FeatureFlags where
-  toJSON (FeatureFlags sso legalhold searchVisibility appLock classifiedDomains) =
+  toJSON (FeatureFlags sso legalhold searchVisibility appLock classifiedDomains fileSharing) =
     object $
       [ "sso" .= sso,
         "legalhold" .= legalhold,
         "teamSearchVisibility" .= searchVisibility,
         "appLock" .= appLock,
-        "classifiedDomains" .= classifiedDomains
+        "classifiedDomains" .= classifiedDomains,
+        "fileSharing" .= fileSharing
       ]
 
 instance FromJSON FeatureSSO where
@@ -282,6 +287,7 @@ instance ToJSON FeatureTeamSearchVisibility where
 
 makeLenses ''TeamCreationTime
 makeLenses ''FeatureFlags
+makeLenses ''Defaults
 
 -- Note [hidden team roles]
 --

--- a/libs/galley-types/test/unit/Test/Galley/Types.hs
+++ b/libs/galley-types/test/unit/Test/Galley/Types.hs
@@ -65,3 +65,4 @@ instance Arbitrary FeatureFlags where
       <*> QC.elements [minBound ..]
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -56,6 +56,9 @@ settings:
       status: enabled
       config:
         domains: ["example.com"]
+    fileSharing:
+      defaults:
+        status: enabled
 
 logLevel: Info
 logNetStrings: false

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -217,7 +217,8 @@ setLegalholdStatusInternal tid status@(Public.tfwoStatus -> statusValue) = do
   TeamFeatures.setFeatureStatusNoConfig @'Public.TeamFeatureLegalHold tid status
 
 getFileSharingInternal :: TeamId -> Galley (Public.TeamFeatureStatus 'Public.TeamFeatureFileSharing)
-getFileSharingInternal = getFeatureStatusNoConfig @'Public.TeamFeatureFileSharing $ pure Public.TeamFeatureEnabled
+getFileSharingInternal = getFeatureStatusNoConfig @'Public.TeamFeatureFileSharing $ do
+  view (options . optSettings . setFeatureFlags . flagFileSharing) <&> Public.tfwoStatus . view unDefaults
 
 setFileSharingInternal :: TeamId -> Public.TeamFeatureStatus 'Public.TeamFeatureFileSharing -> Galley (Public.TeamFeatureStatus 'Public.TeamFeatureFileSharing)
 setFileSharingInternal = setFeatureStatusNoConfig @'Public.TeamFeatureFileSharing $ \_ _ -> pure ()


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-622

Related: https://github.com/wireapp/wire-server/pull/1652

## Checklist

 - [x] Title of this PR explains the impact of the change.
 - [x] The description provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] The CHANGELOG.md file in the *Unreleased* section has been updated to explain the change which will be included in the release notes.
 - [x] If a component uses a new or changed internal endpoint of another component, this is mentioned in the CHANGELOG.md.
- [x] If this PR creates a new endpoint, or adds a new configuration flag, the endpoint / config-flag checklist (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
