### PR TITLE
Add user_id to csv export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ## Features
 
 * `fileSharing` feature config (#1652)
+* Add user_id to csv export (#1663)
 
 ## Bug fixes and other updates
 

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -455,7 +455,8 @@ getTeamMembersCSVH (zusr ::: tid ::: _) = do
             tExportManagedBy = U.userManagedBy user,
             tExportSAMLNamedId = fromMaybe "" (samlNamedId user),
             tExportSCIMExternalId = fromMaybe "" (scimExtId user),
-            tExportSCIMRichInfo = richInfos uid
+            tExportSCIMRichInfo = richInfos uid,
+            tExportUserId = U.userId user
           }
 
     lookupInviterHandle :: [TeamMember] -> Galley (UserId -> Maybe Handle.Handle)

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -274,6 +274,7 @@ testListTeamMembersCsv numMembers = do
       assertEqual ("tExportInvitedBy: " <> show (U.userId user)) Nothing (tExportInvitedBy export)
       assertEqual ("tExportIdpIssuer: " <> show (U.userId user)) (userToIdPIssuer user) (tExportIdpIssuer export)
       assertEqual ("tExportManagedBy: " <> show (U.userId user)) (U.userManagedBy user) (tExportManagedBy export)
+      assertEqual ("tExportUserId: " <> show (U.userId user)) (U.userId user) (tExportUserId export)
   where
     userToIdPIssuer :: HasCallStack => U.User -> Maybe HttpsUrl
     userToIdPIssuer usr = case (U.userIdentity >=> U.ssoIdentity) usr of


### PR DESCRIPTION
This PR adds a column "user_id" to the CSV file returned by `GET /teams/:tid/members/csv`.
The column is appended to the end with the hopes of breaking less workflows that are build upon this CSV than prepending would.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
