### PR TITLE
Revert "Remove deprecated end-point for changing email."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@
 ## Bug fixes and other updates
 
 * New, hardened end-point for changing email
-* Remove old end-point for changing email
 
 ## Documentation
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -269,6 +269,21 @@ sitemap o = do
     Doc.returns (Doc.ref Public.modelUserDisplayName)
     Doc.response 200 "Profile name found." Doc.end
 
+  put "/self/email" (continue changeSelfEmailH) $
+    zauthUserId
+      .&. zauthConnId
+      .&. jsonRequest @Public.EmailUpdate
+  document "PUT" "changeEmail" $ do
+    Doc.summary "Change your email address"
+    Doc.body (Doc.ref Public.modelEmailUpdate) $
+      Doc.description "JSON body"
+    Doc.response 202 "Update accepted and pending activation of the new email." Doc.end
+    Doc.response 204 "No update, current and new email address are the same." Doc.end
+    Doc.errorResponse invalidEmail
+    Doc.errorResponse userKeyExists
+    Doc.errorResponse blacklistedEmail
+    Doc.errorResponse blacklistedPhone
+
   put "/self/phone" (continue changePhoneH) $
     zauthUserId
       .&. zauthConnId
@@ -1144,6 +1159,13 @@ customerExtensionCheckBlockedDomains email = do
       Right domain ->
         when (domain `elem` blockedDomains) $
           throwM $ customerExtensionBlockedDomain domain
+
+changeSelfEmailH :: UserId ::: ConnId ::: JsonRequest Public.EmailUpdate -> Handler Response
+changeSelfEmailH (u ::: _ ::: req) = do
+  email <- Public.euEmail <$> parseJsonBody req
+  API.changeSelfEmail u email API.ForbidSCIMUpdates >>= \case
+    ChangeEmailResponseIdempotent -> pure (setStatus status204 empty)
+    ChangeEmailResponseNeedsActivation -> pure (setStatus status202 empty)
 
 createConnectionH :: JSON ::: UserId ::: ConnId ::: JsonRequest Public.ConnectionRequest -> Handler Response
 createConnectionH (_ ::: self ::: conn ::: req) = do

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -99,7 +99,7 @@ tests _ at opts p b c ch g aws =
       test' aws p "get /users?:id=.... - 200" $ testMultipleUsersUnqualified b,
       test' aws p "post /list-users - 200" $ testMultipleUsers b,
       test' aws p "put /self - 200" $ testUserUpdate b c aws,
-      test' aws p "put /access/self/email - 2xx" $ testEmailUpdate b aws,
+      test' aws p "put /self/email - 2xx" $ testEmailUpdate b aws,
       test' aws p "put /self/phone - 202" $ testPhoneUpdate b,
       test' aws p "head /self/password - 200/404" $ testPasswordSet b,
       test' aws p "put /self/password - 200" $ testPasswordChange b,
@@ -276,10 +276,9 @@ testCreateUserNoEmailNoPassword brig = do
       <!! const 201 === statusCode
   let Just uid = userId <$> responseJsonMaybe rs
   e <- randomEmail
-  Just code <- do
-    sendLoginCode brig p LoginCodeSMS False !!! const 200 === statusCode
-    getPhoneLoginCode brig p
-  initiateEmailUpdateLogin brig e (SmsLogin p code Nothing) uid !!! (const 202 === statusCode)
+  let setEmail = RequestBodyLBS . encode $ EmailUpdate e
+  put (brig . path "/self/email" . contentJson . zUser uid . zConn "conn" . body setEmail)
+    !!! const 202 === statusCode
 
 -- | email address must not be taken on @/register@.
 testCreateUserConflict :: Opt.Opts -> Brig -> Http ()
@@ -654,14 +653,13 @@ testEmailUpdate brig aws = do
   let uid = userId usr
   eml <- randomEmail
   -- update email
-  let Just oldeml = userEmail usr
-  initiateEmailUpdateLogin brig eml (emailLogin oldeml defPassword Nothing) uid !!! const 202 === statusCode
+  initiateEmailUpdate brig eml uid !!! const 202 === statusCode
   -- activate
   activateEmail brig eml
   checkEmail brig uid eml
   liftIO $ Util.assertUserJournalQueue "user update" aws (userEmailUpdateJournaled uid eml)
-  -- update email, which is exactly the same as before (idempotency)
-  initiateEmailUpdateLogin brig eml (emailLogin eml defPassword Nothing) uid !!! const 204 === statusCode
+  -- update email, which is exactly the same as before
+  initiateEmailUpdate brig eml uid !!! const 204 === statusCode
   -- ensure no other user has "test+<uuid>@example.com"
   -- if there is such a user, let's delete it first.  otherwise
   -- this test fails since there can be only one user with "test+...@example.com"
@@ -934,11 +932,6 @@ testEmailPhoneDelete brig cannon = do
   user <- randomUser brig
   let uid = userId user
   let Just email = userEmail user
-  (cky, tok) <- do
-    rsp <-
-      login brig (emailLogin email defPassword Nothing) PersistentCookie
-        <!! const 200 === statusCode
-    pure (decodeCookie rsp, decodeToken rsp)
   -- Cannot remove the only identity
   delete (brig . path "/self/email" . zUser uid . zConn "c")
     !!! const 403 === statusCode
@@ -971,7 +964,9 @@ testEmailPhoneDelete brig cannon = do
     !!! const 403 === statusCode
   -- Add back a new email address
   eml <- randomEmail
-  initiateEmailUpdateCreds brig eml (cky, tok) uid !!! (const 202 === statusCode)
+  let emailUpdate = RequestBodyLBS . encode $ EmailUpdate eml
+  put (brig . path "/self/email" . contentJson . zUser uid . zConn "c" . body emailUpdate)
+    !!! const 202 === statusCode
   act' <- getActivationCode brig (Left eml)
   case act' of
     Nothing -> liftIO $ assertFailure "missing activation key/code"
@@ -1001,8 +996,9 @@ testDeleteUserByPassword brig cannon aws = do
   -- Initiate a change of email address, to verify that activation
   -- does not work after the account has been deleted.
   eml <- randomEmail
-  let Just oldeml = userEmail u
-  initiateEmailUpdateLogin brig eml (emailLogin oldeml defPassword Nothing) uid1 !!! (const 202 === statusCode)
+  let emailUpdate = RequestBodyLBS . encode $ EmailUpdate eml
+  put (brig . path "/self/email" . contentJson . zUser uid1 . zConn "c" . body emailUpdate)
+    !!! const 202 === statusCode
   -- Establish some connections
   usr2 <- randomUser brig
   let uid2 = userId usr2

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -372,6 +372,33 @@ testLoginFailure brig = do
   let badmail = Email "wrong" "wire.com"
   login brig (PasswordLogin (LoginByEmail badmail) defPassword Nothing) PersistentCookie
     !!! const 403 === statusCode
+  -- Create user with only phone number
+  p <- randomPhone
+  let newUser =
+        RequestBodyLBS . encode $
+          object
+            [ "name" .= ("Alice" :: Text),
+              "phone" .= fromPhone p
+            ]
+  res <-
+    post (brig . path "/i/users" . contentJson . Http.body newUser)
+      <!! const 201 === statusCode
+  uid <- userId <$> responseJsonError res
+  eml <- randomEmail
+  -- Add email
+  let emailUpdate = RequestBodyLBS . encode $ EmailUpdate eml
+  put (brig . path "/self/email" . contentJson . zUser uid . zConn "c" . Http.body emailUpdate)
+    !!! (const 202 === statusCode)
+  -- Activate
+  act <- getActivationCode brig (Left eml)
+  case act of
+    Nothing -> liftIO $ assertFailure "missing activation key/code"
+    Just kc -> do
+      activate brig kc !!! const 200 === statusCode
+      -- Attempt to log in without having set a password
+      login brig (defEmailLogin eml) PersistentCookie !!! do
+        const 403 === statusCode
+        const (Just "invalid-credentials") === errorLabel
 
 testThrottleLogins :: Opts.Opts -> Brig -> Http ()
 testThrottleLogins conf b = do
@@ -643,7 +670,6 @@ testTokenMismatchLegalhold z brig galley = do
 -- | This only tests access; the logic is tested in 'testEmailUpdate' in `Account.hs`.
 testAccessSelfEmailAllowed :: Nginz -> Brig -> Http ()
 testAccessSelfEmailAllowed nginz brig = do
-  -- this test duplicates some of 'initiateEmailUpdateLogin' intentionally.
   forM_ [True, False] $ \withCookie -> do
     usr <- randomUser brig
     let Just email = userEmail usr
@@ -668,7 +694,6 @@ testAccessSelfEmailAllowed nginz brig = do
 
 testAccessSelfEmailDenied :: ZAuth.Env -> Nginz -> Brig -> Http ()
 testAccessSelfEmailDenied zenv nginz brig = do
-  -- this test duplicates some of 'initiateEmailUpdateLogin' intentionally.
   forM_ [True, False] $ \withCookie -> do
     mbCky <-
       if withCookie

--- a/services/brig/test/integration/API/User/PasswordReset.hs
+++ b/services/brig/test/integration/API/User/PasswordReset.hs
@@ -38,7 +38,7 @@ tests _cl _at _conf p b _c _g =
   testGroup
     "password-reset"
     [ test p "post /password-reset[/complete] - 201[/200]" $ testPasswordReset b,
-      test p "post /password-reset after put /access/self/email - 400" $ testPasswordResetAfterEmailUpdate b
+      test p "post /password-reset & put /self/email - 400" $ testPasswordResetAfterEmailUpdate b
     ]
 
 testPasswordReset :: Brig -> Http ()
@@ -69,7 +69,7 @@ testPasswordResetAfterEmailUpdate brig = do
   let uid = userId u
   let Just email = userEmail u
   eml <- randomEmail
-  initiateEmailUpdateLogin brig eml (emailLogin email defPassword Nothing) uid !!! const 202 === statusCode
+  initiateEmailUpdate brig eml uid !!! const 202 === statusCode
   initiatePasswordReset brig email !!! const 201 === statusCode
   passwordResetData <- preparePasswordReset brig email uid (PlainTextPassword "newsecret")
   -- activate new email

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -26,7 +26,6 @@ import Brig.Types
 import Brig.Types.Intra
 import Brig.Types.Team.LegalHold (LegalHoldClientRequest (..))
 import Brig.Types.User.Auth hiding (user)
-import qualified Brig.ZAuth
 import qualified CargoHold.Types.V3 as CHV3
 import qualified Codec.MIME.Type as MIME
 import Control.Lens (preview, (^?))
@@ -150,24 +149,10 @@ checkEmail brig uid expectedEmail =
     const 200 === statusCode
     const (Just expectedEmail) === (userEmail <=< responseJsonMaybe)
 
-initiateEmailUpdateLogin :: Brig -> Email -> Login -> UserId -> (MonadIO m, MonadCatch m, MonadHttp m) => m ResponseLBS
-initiateEmailUpdateLogin brig email loginCreds uid = do
-  (cky, tok) <- do
-    rsp <-
-      login brig loginCreds PersistentCookie
-        <!! const 200 === statusCode
-    pure (decodeCookie rsp, decodeToken rsp)
-  initiateEmailUpdateCreds brig email (cky, tok) uid
-
-initiateEmailUpdateCreds :: Brig -> Email -> (Bilge.Cookie, Brig.ZAuth.AccessToken) -> UserId -> (MonadIO m, MonadCatch m, MonadHttp m) => m ResponseLBS
-initiateEmailUpdateCreds brig email (cky, tok) uid = do
-  put $
-    brig
-      . path "/access/self/email"
-      . cookie cky
-      . header "Authorization" ("Bearer " <> toByteString' tok)
-      . zUser uid
-      . Bilge.json (EmailUpdate email)
+initiateEmailUpdate :: Brig -> Email -> UserId -> (MonadIO m, MonadHttp m) => m ResponseLBS
+initiateEmailUpdate brig email uid =
+  let emailUpdate = RequestBodyLBS . encode $ EmailUpdate email
+   in put (brig . path "/self/email" . contentJson . zUser uid . zConn "c" . body emailUpdate)
 
 initiateEmailUpdateNoSend :: Brig -> Email -> UserId -> (MonadIO m, MonadHttp m) => m ResponseLBS
 initiateEmailUpdateNoSend brig email uid =

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -37,7 +37,7 @@ import Brig.Types.User
 import Brig.Types.User.Auth
 import qualified Brig.ZAuth as ZAuth
 import Control.Lens ((^.), (^?), (^?!))
-import Control.Monad.Catch (MonadCatch, MonadMask)
+import Control.Monad.Catch (MonadCatch)
 import Control.Retry
 import Data.Aeson hiding (json)
 import Data.Aeson.Lens (key, _Integral, _JSON, _String)
@@ -799,12 +799,6 @@ retryWhileN n f m =
   retrying
     (constantDelay 1000000 <> limitRetries n)
     (const (return . f))
-    (const m)
-
-recoverN :: (MonadIO m, MonadMask m) => Int -> m a -> m a
-recoverN n m =
-  recoverAll
-    (constantDelay 1000000 <> limitRetries n)
     (const m)
 
 -- | This allows you to run requests against a brig instantiated using the given options.


### PR DESCRIPTION
This reverts commit 72fefad91e6d569e247541bedf7571004950825d, which breaks both our CI and QA test automation.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
