### PR TITLE
download gpg keys for nginz

### DIFF
--- a/services/nginz/.gitignore
+++ b/services/nginz/.gitignore
@@ -1,0 +1,1 @@
+keys-downloaded

--- a/services/nginz/Makefile
+++ b/services/nginz/Makefile
@@ -114,8 +114,8 @@ zwagger-ui/swagger-ui: $(SWAGGER_BUNDLE)
 $(SWAGGER_BUNDLE):
 	curl -L https://github.com/swagger-api/swagger-ui/archive/v$(SWAGGER_VERSION).tar.gz -o $(SWAGGER_BUNDLE)
 
-src: $(NGINX_BUNDLE)
-	#Find keys on https://nginx.org/en/pgp_keys.html
+src: $(NGINX_BUNDLE) keys-downloaded
+	#Find keys on https://nginx.org/en/pgp_keys.html or run 'make download-gpg-keys'
 	gpg --verify $(NGINX_BUNDLE).asc $(NGINX_BUNDLE)
 	tar zxf $(NGINX_BUNDLE)
 	rm -rf src && mv nginx-$(NGINX_VERSION) src
@@ -141,3 +141,10 @@ libzauth:
 .PHONY: docker-run-demo-local
 docker-run-demo:
 	docker run --network=host -it -v $$(pwd)/../../deploy/services-demo:/configs --entrypoint /usr/sbin/nginx quay.io/wire/nginz:local -p /configs -c /configs/conf/nginz/nginx-docker.conf
+
+keys-downloaded:
+	make download-gpg-keys
+
+.PHONY: download-gpg-keys
+download-gpg-keys:
+	./download-gpg-keys.sh && touch keys-downloaded

--- a/services/nginz/download-gpg-keys.sh
+++ b/services/nginz/download-gpg-keys.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+export GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8
+found=''
+for server in \
+    hkp://keyserver.ubuntu.com:80 \
+    hkp://p80.pool.sks-keyservers.net:80 \
+    pgp.mit.edu \
+    ha.pool.sks-keyservers.net; do
+    echo "Fetching GPG key $GPG_KEYS from $server"
+    gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$GPG_KEYS" && found=yes && break
+done
+test -z "$found" && echo >&2 "error: failed to fetch GPG key $GPG_KEYS" && exit 1
+exit 0


### PR DESCRIPTION
On fresh development environments, nginx cannot be compiled without the gpg signature verification in place. Before, this had to be done manually; now GPG keys are downloaded once the first time.

Only relevant when compiling nginz locally.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.