### PR TITLE
Remove old federation error code

### DIFF
--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -19,10 +19,7 @@ module Galley.API.Error where
 
 import Control.Monad.Catch (MonadThrow (..))
 import Data.Domain (Domain, domainText)
-import Data.Id (Id)
-import Data.List.NonEmpty (NonEmpty)
 import Data.Proxy
-import Data.Qualified (Qualified, renderQualifiedId)
 import Data.String.Conversions (cs)
 import Data.Text.Lazy as LT (pack)
 import qualified Data.Text.Lazy as LT
@@ -32,7 +29,6 @@ import Imports
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error
 import Servant.API.Status (KnownStatus (..))
-import Type.Reflection (typeRep)
 import Wire.API.ErrorDescription
 
 errorDescriptionToWai ::
@@ -247,16 +243,3 @@ invalidTeamNotificationId = mkError status400 "invalid-notification-id" "Could n
 
 inactivityTimeoutTooLow :: Error
 inactivityTimeoutTooLow = mkError status400 "inactivity-timeout-too-low" "applock inactivity timeout must be at least 30 seconds"
-
---------------------------------------------------------------------------------
--- Federation
-
-federationNotEnabled :: forall a. Typeable a => NonEmpty (Qualified (Id a)) -> Error
-federationNotEnabled qualifiedIds =
-  mkError
-    status403
-    "federation-not-enabled"
-    ("Federation is not enabled, but remote qualified IDs (" <> idType <> ") were found: " <> rendered)
-  where
-    idType = cs (show (typeRep @a))
-    rendered = LT.intercalate ", " . toList . fmap (LT.fromStrict . renderQualifiedId) $ qualifiedIds


### PR DESCRIPTION
Just removing an unused federation error. I haven't added a CHANGELOG entry for this, should I?

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [ ] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
