### PR TITLE
Refactor createUser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ settings:
 ## Internal changes
 
 * The servant-swagger dependency now points to the current upstream master (#1656).
+* Refactor function createUser for readability (#1670)
 
 ## Federation changes (alpha feature, do not use yet)
 

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -268,6 +268,9 @@ createUser new@NewUser {..} = do
       return Nothing
   return $! CreateUserResult account edata pdata (activatedTeam <|> joinedTeam)
   where
+    -- NOTE: all functions in the where block don't use any arguments of createUser
+
+    createTeam :: (UserId -> Bool -> Team.BindingNewTeam -> TeamId -> AppT IO (Maybe CreateUserTeam))
     createTeam uid activating t tid = do
       created <- Intra.createTeam uid t tid
       return $

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -211,12 +211,12 @@ createUser new = do
             newUserIdentity = ident
           }
   let mbHandle = userHandle . accountUser =<< mbExistingAccount
+  let uid = userId (accountUser account)
 
   -- Create account
   account <- lift $ do
     (account, pw) <- newAccount new' mbInv tid mbHandle
 
-    let uid = userId (accountUser account)
     Log.debug $ field "user" (toByteString uid) . field "action" (Log.val "User.createUser")
     Log.info $ field "user" (toByteString uid) . msg (val "Creating user")
 
@@ -225,8 +225,6 @@ createUser new = do
     Intra.onUserEvent uid Nothing (UserCreated (accountUser account))
 
     pure account
-
-  let uid = userId (accountUser account)
 
   createUserTeam <- do
     activatedTeam <- lift $ do

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -186,10 +186,9 @@ createUser new = do
   (newTeam, teamInvitation, tid) <-
     case (newUserTeam new, userEmailKey <$> email) of
       (Just (NewTeamMember i), e) ->
-        findTeamInvitation e i
-        >>= return . \case
+        findTeamInvitation e i <&> (\case
           Just (inv, info, tid) -> (Nothing, Just (inv, info), Just tid)
-          Nothing -> (Nothing, Nothing, Nothing)
+          Nothing -> (Nothing, Nothing, Nothing))
       (Just (NewTeamCreator t), _) -> (Just t,Nothing,) <$> (Just . Id <$> liftIO nextRandom)
       (Just (NewTeamMemberSSO tid), _) -> pure (Nothing, Nothing, Just tid)
       (Nothing, _) -> return (Nothing, Nothing, Nothing)

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -193,8 +193,7 @@ createUser new = do
           Nothing ->
             pure (Nothing, Nothing, Nothing)
       Just (NewTeamCreator t) -> do
-        tid' <- Id <$> liftIO nextRandom
-        pure (Just t, Nothing, Just tid')
+        (Just t,Nothing,) <$> (Just . Id <$> liftIO nextRandom)
       Just (NewTeamMemberSSO tid) ->
         pure (Nothing, Nothing, Just tid)
       Nothing ->

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -254,8 +254,8 @@ createUser new = do
 
   edata <-
     if isJust teamInvitation
-      then handleEmailActivation email uid newTeam
-      else pure Nothing
+      then pure Nothing
+      else handleEmailActivation email uid newTeam
 
   pdata <- handlePhoneActivation phone uid
 

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -194,8 +194,9 @@ createUser new = do
       return
       =<< lift (validatePhone p)
 
-  let ident = newIdentity email phone (newUserSSOId new)
   for_ (catMaybes [userEmailKey <$> email, userPhoneKey <$> phone]) $ verifyUniquenessAndCheckBlacklist
+
+  let ident = newIdentity email phone (newUserSSOId new)
 
   -- team user registration
   (newTeam, teamInvitation, tid) <- handleTeam (newUserTeam new) (userEmailKey <$> email)

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -211,12 +211,12 @@ createUser new = do
             newUserIdentity = ident
           }
   let mbHandle = userHandle . accountUser =<< mbExistingAccount
-  let uid = userId (accountUser account)
 
   -- Create account
   account <- lift $ do
     (account, pw) <- newAccount new' mbInv tid mbHandle
 
+    let uid = userId (accountUser account)
     Log.debug $ field "user" (toByteString uid) . field "action" (Log.val "User.createUser")
     Log.info $ field "user" (toByteString uid) . msg (val "Creating user")
 
@@ -225,6 +225,8 @@ createUser new = do
     Intra.onUserEvent uid Nothing (UserCreated (accountUser account))
 
     pure account
+
+  let uid = userId (accountUser account)
 
   createUserTeam <- do
     activatedTeam <- lift $ do


### PR DESCRIPTION
This PR is a pure refactoring of `createUser` from `Brig.API.User`. Motivation for this PR was to make function more readable.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
