### PR TITLE
Document federation errors

### DIFF
--- a/CHANGELOG-draft.md
+++ b/CHANGELOG-draft.md
@@ -18,6 +18,8 @@ THIS FILE ACCUMULATES THE RELEASE NOTES FOR THE UPCOMING RELEASE.
 
 ## Documentation
 
+* Added documentation of federation errors (#1674)
+
 ## Internal changes
 
 * Rewrite the `POST /connections` endpoint to Servant (#1726)

--- a/libs/wire-api-federation/proto/router.proto
+++ b/libs/wire-api-federation/proto/router.proto
@@ -37,12 +37,11 @@ message OutwardError {
     DiscoveryFailed = 1;
     ConnectionRefused = 2;
     TLSFailure = 3;
-    InvalidCertificate = 4;
-    VersionMismatch = 5;
-    FederationDeniedByRemote = 6;
-    FederationDeniedLocally = 7;
-    RemoteFederatorError = 8;
-    InvalidRequest = 9;
+    VersionMismatch = 4;
+    FederationDeniedByRemote = 5;
+    FederationDeniedLocally = 6;
+    RemoteFederatorError = 7;
+    InvalidRequest = 8;
   }
 
   ErrorType type = 1;

--- a/libs/wire-api-federation/proto/router.proto
+++ b/libs/wire-api-federation/proto/router.proto
@@ -40,12 +40,13 @@ message OutwardError {
     VersionMismatch = 4;
     FederationDeniedByRemote = 5;
     FederationDeniedLocally = 6;
-    RemoteFederatorError = 7;
-    InvalidRequest = 8;
+    TooMuchConcurrency = 7;
+    GrpcError = 8;
+    InvalidRequest = 9;
   }
 
   ErrorType type = 1;
-  ErrorPayload payload = 2;
+  string msg = 2;
 }
 
 message InwardError {
@@ -59,11 +60,6 @@ message InwardError {
   }
 
   ErrorType type = 1;
-  string msg = 2;
-}
-
-message ErrorPayload {
-  string label = 1;
   string msg = 2;
 }
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -157,7 +157,6 @@ federationRemoteError err = Wai.mkError status (LT.fromStrict label) (LT.fromStr
       Proto.DiscoveryFailed -> HTTP.status500
       Proto.ConnectionRefused -> HTTP.Status 521 "Web Server Is Down"
       Proto.TLSFailure -> HTTP.Status 525 "SSL Handshake Failure"
-      Proto.InvalidCertificate -> HTTP.Status 526 "Invalid SSL Certificate"
       Proto.VersionMismatch -> HTTP.Status 531 "Version Mismatch"
       Proto.FederationDeniedByRemote -> HTTP.Status 532 "Federation Denied"
       Proto.FederationDeniedLocally -> HTTP.status400

--- a/libs/wire-api-federation/src/Wire/API/Federation/GRPC/Types.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/GRPC/Types.hs
@@ -119,7 +119,6 @@ data OutwardErrorType
   | DiscoveryFailed
   | ConnectionRefused
   | TLSFailure
-  | InvalidCertificate
   | VersionMismatch
   | FederationDeniedByRemote
   | FederationDeniedLocally

--- a/libs/wire-api-federation/src/Wire/API/Federation/GRPC/Types.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/GRPC/Types.hs
@@ -26,6 +26,7 @@ module Wire.API.Federation.GRPC.Types where
 import Data.Domain (Domain (..), domainText, mkDomain)
 import Data.Either.Validation
 import Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.Text as Text
 import Imports
 import Mu.Quasi.GRpc (grpc)
 import Mu.Schema
@@ -101,12 +102,12 @@ instance FromSchema Router "OutwardResponse" OutwardResponse where
 -- https://higherkindness.io/mu-haskell/schema/#mapping-haskell-types
 type OutwardErrorFieldMapping =
   '[ "outwardErrorType" ':-> "type",
-     "outwardErrorPayload" ':-> "payload"
+     "outwardErrorMessage" ':-> "msg"
    ]
 
 data OutwardError = OutwardError
   { outwardErrorType :: OutwardErrorType,
-    outwardErrorPayload :: Maybe ErrorPayload
+    outwardErrorMessage :: Text
   }
   deriving (Typeable, Show, Eq, Generic)
   deriving (Arbitrary) via (GenericUniform OutwardError)
@@ -122,17 +123,11 @@ data OutwardErrorType
   | VersionMismatch
   | FederationDeniedByRemote
   | FederationDeniedLocally
-  | RemoteFederatorError
+  | TooMuchConcurrency
+  | GrpcError
   | InvalidRequest
   deriving (Typeable, Show, Eq, Generic, ToSchema Router "OutwardError.ErrorType", FromSchema Router "OutwardError.ErrorType")
   deriving (Arbitrary) via (GenericUniform OutwardErrorType)
-
-data ErrorPayload = ErrorPayload
-  { label :: Text,
-    msg :: Text
-  }
-  deriving (Typeable, Show, Eq, Generic, ToSchema Router "ErrorPayload", FromSchema Router "ErrorPayload")
-  deriving (Arbitrary) via (GenericUniform ErrorPayload)
 
 -- See mu-haskell Custom Mapping documentation here:
 -- https://higherkindness.io/mu-haskell/schema/#mapping-haskell-types
@@ -188,6 +183,16 @@ data ValidatedFederatedRequest = ValidatedFederatedRequest
     vRequest :: Request
   }
   deriving (Typeable, Eq, Show)
+
+showFederatedRequestValidationError :: FederatedRequestValidationError -> Text
+showFederatedRequestValidationError (InvalidDomain msg) = "invalid domain: " <> Text.pack msg
+showFederatedRequestValidationError RequestMissing = "federation request is missing"
+
+showFederatedRequestValidationErrors :: NonEmpty FederatedRequestValidationError -> Text
+showFederatedRequestValidationErrors =
+  Text.intercalate "; "
+    . map showFederatedRequestValidationError
+    . toList
 
 validateFederatedRequest :: FederatedRequest -> Validation (NonEmpty FederatedRequestValidationError) ValidatedFederatedRequest
 validateFederatedRequest FederatedRequest {..} = do

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -188,11 +188,10 @@ An error in this category indicates an issue with configuration of federation on
 
 Errors in this category are returned in case of communication issues between the local backend and a remote one, or if the remote side encountered an error while processing an RPC.
 
- - **RPC error with code** (status: 533, label: `grpc-error-code`): An RPC to a remote federator resulted in an error. The RPC error code can be found in the error message.
- - **RPC error with string** (status: 533, label: `grpc-error-string`): An RPC to a remote federator resulted in an error. A description of the error can be found in the error message.
- - **RPC error** (status: 500, label: `federation-rpc-error`): There was a non-specified error in the RPC from this backend to another backend. Check the error message for more details.
- - **Connection refused** (status: 521, label: `cannot-connect-to-remote-federator`): The local federator could not connect to a remote one.
  - **Too much concurrency** (status: 533, label: `too-much-concurrency`): Too many concurrent requests on a remote backend.
+ - **gRPC error** (status: 533, label: `grpc-error`): The current federator encountered an error when making an RPC to a remote one. Check the error message for more details.
+ - **Client RPC error** (status: 500, label: `client-rpc-error`): There was a non-specified error when making a request to another backend. Check the error message for more details.
+ - **Connection refused** (status: 521, label: `cannot-connect-to-remote-federator`): The local federator could not connect to a remote one.
  - **Unknown remote error** (status: 500, label: `unknown-federation-error`): An RPC failed but no specific error was returned by the remote side. Check the error message for more details.
 
 ### Backend compatibility errors
@@ -202,7 +201,6 @@ An error in this category will be returned when this backend makes an invalid or
  - **Version mismatch** (status: 531): A remote backend is running an unsupported version of the federator.
  - **Invalid method** / **Streaming not supported** (status: 500, label: `federation-invalid-call`): This backend attempted an invalid RPC to another backend.
  - **Invalid request** (status: 500, label: `invalid-request-to-federator`): The local federator made an invalid request to a remote one. Check the error message for more details.
- - **RPC client error** (status: 533, label: `grpc-client-error`): The current federator encountered an error when making an RPC to a remote one.
  - **Invalid content type** (status: 503, label: `federation-invalid-content-type-header`): An RPC to another backend returned an invalid content type.
  - **Unsupported content type** (status: 503, label: `federation-unsupported-content-type`): An RPC to another backend returned an unsupported content type.
  - **Invalid origin domain** (status: 533, label: `invalid-origin-domain`): The current backend attempted an RPC with an invalid origin domain field.

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -213,8 +213,7 @@ An error in this category will be returned when this backend makes an invalid or
 
 The errors in this category relate to authentication or authorization issues between backends.
 
- - **TLS failure**: (status: 525): An error occurred during the TLS handshake between the local federator and a remote one.
- - **Invalid certificate** (status: 526): The TLS certificate on the remote end of an RPC is invalid.
+ - **TLS failure**: (status: 525): An error occurred during the TLS handshake between the local federator and a remote one. This is most likely due to an issue with the certificate on the remote end.
  - **Federation denied remotely** (status: 532): The current backend made an unauthorised request to a remote one.
 
 |]

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -168,27 +168,34 @@ Centrify allows you to upload the metadata xml document that you get from the `/
 
 Endpoints involving federated calls to other domains can return some extra failure responses, common to all endpoints. Instead of listing them as possible responses for each endpoint, we document them here.
 
+For errors that are more likely to be transient, we suggest clients to retry whatever request resulted in the error. Transient errors are indicated explicitly below.
+
 **Note**: when a failure occurs as a result of making a federated RPC to another backend, the error response contains the following extra fields:
 
  - `domain`: the target backend of the RPC that failed;
  - `path`: the path of the RPC that failed.
 
+### Domain errors
+
+Errors in this category result from trying to communicate with a backend that is considered non-existent or invalid. They can result from invalid user input or client issues, but they can also be a symptom of misconfiguration in one or multiple backends.
+
+ - **Remote backend not found** (status: 422, label: `srv-record-not-found`): This backend attempted to contact a backend which does not exist or is not properly configured. For the most part, clients can consider this error equivalent to a domain not existing, although it should be noted that certain mistakes in the DNS configuration on a remote backend can lead to the backend not being recognized, and hence to this error. It is therefore not advisable to take any destructive action upon encountering this error, such as deleting remote users from conversations.
+ - **Federation denied locally** (status: 400, label: `federation-not-allowed`): This backend attempted an RPC to a non-whitelisted backend. Similar considerations as for the previous error apply.
+
 ### Local federation errors
 
-An error in this category indicates an issue with configuration of federation on the local backend or with the federation-related content of the current client request.
+An error in this category likely indicates an issue with configuration of federation on the local backend. Possibly transient errors are indicated explicitly below.
 
- - **Federation not enabled** (status: 400, label: `federation-not-enabled`): Federation has not been configured for this backend.
- - **Federation unavailable** (status: 500, label: `federation-not-available`): Federation is configured for this backend, but the local federator cannot be reached.
+ - **Federation not enabled** (status: 400, label: `federation-not-enabled`): Federation has not been configured for this backend. This will happen if a federation-aware client tries to talk to a backend for which federation is disabled, or if federation was disabled on the backend after reaching a federation-specific state (e.g. conversations with remote users). There is no way to cleanly recover from these errors at this point.
+ - **Federation unavailable** (status: 500, label: `federation-not-available`): Federation is configured for this backend, but the local federator cannot be reached. This can be transient, so clients should retry the request.
  - **Federation not implemented** (status: 403, label: `federation-not-implemented`): Federated behaviour for a certain endpoint is not yet implemented.
- - **Remote backend not found** (status: 422, label: `srv-record-not-found`): This backend attempted to contact a backend which does not exist or is not properly configured.
- - **Federation denied locally** (status: 400, label: `federation-not-allowed`): This backend attempted an RPC to a non-whitelisted backend.
- - **Federator discovery failed** (status: 500, label: `srv-lookup-dns-error`): A DNS error occurred during discovery of a remote backend.
+ - **Federator discovery failed** (status: 500, label: `srv-lookup-dns-error`): A DNS error occurred during discovery of a remote backend. This can be transient, so clients should retry the request.
+ - **Too much concurrency** (status: 533, label: `too-much-concurrency`): Too many concurrent requests from this backend. This can be transient, so clients should retry the request.
 
 ### Remote federation errors
 
-Errors in this category are returned in case of communication issues between the local backend and a remote one, or if the remote side encountered an error while processing an RPC.
+Errors in this category are returned in case of communication issues between the local backend and a remote one, or if the remote side encountered an error while processing an RPC. Some errors in this category might be caused by incorrect client behaviour or wrong user input. All of these errors can be transient, so clients should retry the request that caused them.
 
- - **Too much concurrency** (status: 533, label: `too-much-concurrency`): Too many concurrent requests on a remote backend.
  - **gRPC error** (status: 533, label: `grpc-error`): The current federator encountered an error when making an RPC to a remote one. Check the error message for more details.
  - **Client RPC error** (status: 500, label: `client-rpc-error`): There was a non-specified error when making a request to another backend. Check the error message for more details.
  - **Connection refused** (status: 521, label: `cannot-connect-to-remote-federator`): The local federator could not connect to a remote one.
@@ -196,24 +203,23 @@ Errors in this category are returned in case of communication issues between the
 
 ### Backend compatibility errors
 
-An error in this category will be returned when this backend makes an invalid or unsupported RPC to another backend. This can indicate some incompatibility between backends or a backend bug.
+An error in this category will be returned when this backend makes an invalid or unsupported RPC to another backend. This can indicate some incompatibility between backends or a backend bug. These errors are unlikely to be transient, so retrying requests is *not* advised.
 
  - **Version mismatch** (status: 531): A remote backend is running an unsupported version of the federator.
- - **Invalid method** / **Streaming not supported** (status: 500, label: `federation-invalid-call`): This backend attempted an invalid RPC to another backend.
+ - **Invalid method** / **Streaming not supported** (status: 500, label: `federation-invalid-call`): There was an error in the communication between a service on this backend and the local federator.
  - **Invalid request** (status: 500, label: `invalid-request-to-federator`): The local federator made an invalid request to a remote one. Check the error message for more details.
  - **Invalid content type** (status: 503, label: `federation-invalid-content-type-header`): An RPC to another backend returned an invalid content type.
  - **Unsupported content type** (status: 503, label: `federation-unsupported-content-type`): An RPC to another backend returned an unsupported content type.
  - **Invalid origin domain** (status: 533, label: `invalid-origin-domain`): The current backend attempted an RPC with an invalid origin domain field.
  - **Forbidden endpoint** (status: 533, label: `forbidden-endpoint`): The current backend attempted an RPC to a forbidden or inaccessible remote endpoint.
- - **Unknown federation error** (status: 503, label: `unknown-federation-error): The target of an RPC returned an unexpected reponse. Check the error message for more details.
+ - **Unknown federation error** (status: 503, label: `unknown-federation-error`): The target of an RPC returned an unexpected reponse. Check the error message for more details.
 
 ### Authentication errors
 
-The errors in this category relate to authentication or authorization issues between backends.
+The errors in this category relate to authentication or authorization issues between backends. These errors are unlikely to be transient, so retrying requests is *not* advised.
 
  - **TLS failure**: (status: 525): An error occurred during the TLS handshake between the local federator and a remote one. This is most likely due to an issue with the certificate on the remote end.
- - **Federation denied remotely** (status: 532): The current backend made an unauthorised request to a remote one.
-
+ - **Federation denied remotely** (status: 532): The current backend made an unauthorized request to a remote one.
 |]
 
 servantSitemap :: ServerT ServantAPI Handler

--- a/services/brig/test/unit/Test/Brig/API/Error.hs
+++ b/services/brig/test/unit/Test/Brig/API/Error.hs
@@ -58,8 +58,6 @@ testOutwardError =
             assertOutwardErrorStatus Proto.ConnectionRefused 521,
           testCase "when TLS fails" $
             assertOutwardErrorStatus Proto.TLSFailure 525,
-          testCase "when remote certificate is invalid" $
-            assertOutwardErrorStatus Proto.InvalidCertificate 526,
           testCase "when remote returns version mismatch" $
             assertOutwardErrorStatus Proto.VersionMismatch 531,
           testCase "when remote denies federation" $

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2013,7 +2013,7 @@ testBulkGetQualifiedConvs = do
           case F.domain fedReq of
             d | d == domainText remoteDomainA -> success $ GetConversationsResponse [mockConversationA]
             d | d == domainText remoteDomainB -> success $ GetConversationsResponse [mockConversationB]
-            d | d == domainText remoteDomainC -> pure . F.OutwardResponseError $ F.OutwardError F.DiscoveryFailed Nothing
+            d | d == domainText remoteDomainC -> pure . F.OutwardResponseError $ F.OutwardError F.DiscoveryFailed "discovery failed"
             _ -> assertFailure $ "Unrecognized domain: " <> show fedReq
       )
       (listConvsV2 alice req)

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2123,7 +2123,7 @@ makeFedRequestToServant originDomain server fedRequest =
       if Test.simpleStatus response == status200
         then pure (F.OutwardResponseBody (cs (Test.simpleBody response)))
         else do
-          pure (F.OutwardResponseError (F.OutwardError F.RemoteFederatorError (Just (F.ErrorPayload "mock-error" (cs (Test.simpleBody response))))))
+          pure (F.OutwardResponseError (F.OutwardError F.GrpcError (cs (Test.simpleBody response))))
 
     toRequestWithoutBody :: F.Request -> Wai.Request
     toRequestWithoutBody req =


### PR DESCRIPTION
This adds documentation of federation errors to Swagger. These are not response entries by endpoints, but simply a list of errors (with some brief explanations) divided into categories. They apply more or less to all endpoints that have anything to do with federation.

I also pasted it here so it is possible to see it rendered without building anything: https://gist.github.com/pcapriotti/e50f61c3a8f6abab900e25c9ff3457aa.

## TODO

 - [x] Remove unused errors
 - [x] Move all error label assignments to a single module
 - [x] ~~Rethink some of the error codes~~
        After some discussion, we decided the error codes are mostly fine
 - [x] Add suggested client behaviour for each error

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
