### PR TITLE
[Federation] [Documentation] Clarify Whitelisting Your Own Domain as Classified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ Upgrade nginz (#1658)
 
 ## Documentation
 
+- A clarification is added about listing your own domain as a classified domain
+  (#1678).
+
 ## Internal changes
 
 * Improvements to local integration test setup when using buildah and kind (#1667)

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -112,6 +112,9 @@ classifiedDomains:
     domains: ["example.com", "example2.com"]
 ```
 
+Note that when enabling this feature, it is important to provide your own domain
+too in the list of domains. In the example above, `example.com` or `example2.com` is your domain.
+
 To disable, either omit the entry entirely (it is disabled by default), or provide the following:
 
 ```yaml


### PR DESCRIPTION
This improves the documentation for the classified domains feature by making it clear that your own domain has to be listed as a classified domain for the feature to work properly.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
