### PR TITLE
Remove unused HEAD endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,14 +54,15 @@ Upgrade nginz (#1658)
 
 ## Documentation
 
-* Improved Swagger documentation for endpoints with multiple responses (#1649).
+* Improved Swagger documentation for endpoints with multiple responses (#1649)
 
 ## Internal changes
 
 * Improvements to local integration test setup when using buildah and kind (#1667)
-* The servant-swagger dependency now points to the current upstream master (#1656).
-* Improved error handling middleware (#1671).
+* The servant-swagger dependency now points to the current upstream master (#1656)
+* Improved error handling middleware (#1671)
 * Refactor function createUser for readability (#1670)
+* Removed explicit implementation for user HEAD endpoints (#1679)
 
 ## Federation changes (alpha feature, do not use yet)
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -34,7 +34,6 @@ import Servant.API.Generic
 import Servant.Swagger (HasSwagger (toSwagger))
 import Servant.Swagger.Internal.Orphans ()
 import Wire.API.ErrorDescription (ClientNotFound)
-import Wire.API.Routes.MultiVerb
 import Wire.API.Routes.Public (EmptyResult, ZConn, ZUser)
 import Wire.API.User
 import Wire.API.User.Client
@@ -44,17 +43,6 @@ import Wire.API.User.Search (Contact, SearchResult)
 import Wire.API.UserMap
 
 type MaxUsersForListClientsBulk = 500
-
-type CheckUserExistsResponse = [EmptyResult 200, EmptyResult 404]
-
-type UserExistVerb =
-  MultiVerb
-    'HEAD
-    '[]
-    '[ RespondEmpty 404 "User not found",
-       RespondEmpty 200 "User exists"
-     ]
-    Bool
 
 type CaptureUserId name = Capture' '[Description "User Id"] name UserId
 
@@ -71,23 +59,6 @@ data Api routes = Api
     -- currently not possible due to this issue:
     -- https://github.com/haskell-servant/servant/issues/1369
 
-    -- See Note [ephemeral user sideeffect]
-    checkUserExistsUnqualified ::
-      routes
-        :- Summary "Check if a user ID exists (deprecated)"
-        :> ZUser
-        :> "users"
-        :> CaptureUserId "uid"
-        :> UserExistVerb,
-    -- See Note [ephemeral user sideeffect]
-    checkUserExistsQualified ::
-      routes
-        :- Summary "Check if a user ID exists"
-        :> ZUser
-        :> "users"
-        :> Capture "domain" Domain
-        :> CaptureUserId "uid"
-        :> UserExistVerb,
     -- See Note [ephemeral user sideeffect]
     --
     -- See Note [document responses]

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -168,9 +168,7 @@ servantSitemap :: ServerT ServantAPI Handler
 servantSitemap =
   genericServerT $
     BrigAPI.Api
-      { BrigAPI.checkUserExistsUnqualified = checkUserExistsUnqualifiedH,
-        BrigAPI.checkUserExistsQualified = checkUserExistsH,
-        BrigAPI.getUserUnqualified = getUserUnqualifiedH,
+      { BrigAPI.getUserUnqualified = getUserUnqualifiedH,
         BrigAPI.getUserQualified = getUserH,
         BrigAPI.getSelf = getSelf,
         BrigAPI.getHandleInfoUnqualified = getHandleInfoUnqualifiedH,
@@ -943,18 +941,6 @@ createUser (Public.NewUserPublic new) = do
         Team.sendMemberWelcomeMail e t n l
       Public.NewTeamMemberSSO _ ->
         Team.sendMemberWelcomeMail e t n l
-
-checkUserExistsUnqualifiedH :: UserId -> UserId -> Handler Bool
-checkUserExistsUnqualifiedH self uid = do
-  domain <- viewFederationDomain
-  checkUserExistsH self domain uid
-
-checkUserExistsH :: UserId -> Domain -> UserId -> Handler Bool
-checkUserExistsH self domain uid = checkUserExists self (Qualified uid domain)
-
-checkUserExists :: UserId -> Qualified UserId -> Handler Bool
-checkUserExists self qualifiedUserId =
-  isJust <$> getUser self qualifiedUserId
 
 getSelf :: UserId -> Handler Public.SelfProfile
 getSelf self =

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -62,7 +62,7 @@ import Data.Vector (Vector)
 import qualified Data.Vector as Vec
 import Galley.Types.Teams (noPermissions)
 import Gundeck.Types.Notification
-import Imports
+import Imports hiding (head)
 import qualified Network.Wai.Utilities.Error as Error
 import Test.Tasty hiding (Timeout)
 import Test.Tasty.Cannon hiding (Cannon)
@@ -97,6 +97,10 @@ tests _ at opts p b c ch g aws =
       test' aws p "get /users/:uid - 200" $ testExistingUserUnqualified b,
       test' aws p "get /users/<localdomain>/:uid - 200" $ testExistingUser b,
       test' aws p "get /users?:id=.... - 200" $ testMultipleUsersUnqualified b,
+      test' aws p "head /users/:uid - 200" $ testUserExistsUnqualified b,
+      test' aws p "head /users/:uid - 404" $ testUserDoesNotExistUnqualified b,
+      test' aws p "head /users/:domain/:uid - 200" $ testUserExists b,
+      test' aws p "head /users/:domain/:uid - 404" $ testUserDoesNotExist b,
       test' aws p "post /list-users - 200" $ testMultipleUsers b,
       test' aws p "put /self - 200" $ testUserUpdate b c aws,
       test' aws p "put /self/email - 2xx" $ testEmailUpdate b aws,
@@ -488,6 +492,58 @@ testExistingUser brig = do
                 b <- responseBody r
                 b ^? key "id" >>= maybeFromJSON
             )
+
+testUserExistsUnqualified :: Brig -> Http ()
+testUserExistsUnqualified brig = do
+  qself <- userQualifiedId <$> randomUser brig
+  quser <- userQualifiedId <$> randomUser brig
+  head
+    ( brig
+        . paths ["users", toByteString' (qUnqualified quser)]
+        . zUser (qUnqualified qself)
+    )
+    !!! do
+      const 200 === statusCode
+      const mempty === responseBody
+
+testUserDoesNotExistUnqualified :: Brig -> Http ()
+testUserDoesNotExistUnqualified brig = do
+  qself <- userQualifiedId <$> randomUser brig
+  uid <- liftIO $ Id <$> UUID.nextRandom
+  head
+    ( brig
+        . paths ["users", toByteString' uid]
+        . zUser (qUnqualified qself)
+    )
+    !!! do
+      const 404 === statusCode
+      const mempty === responseBody
+
+testUserExists :: Brig -> Http ()
+testUserExists brig = do
+  qself <- userQualifiedId <$> randomUser brig
+  quser <- userQualifiedId <$> randomUser brig
+  head
+    ( brig
+        . paths ["users", toByteString' (qDomain quser), toByteString' (qUnqualified quser)]
+        . zUser (qUnqualified qself)
+    )
+    !!! do
+      const 200 === statusCode
+      const mempty === responseBody
+
+testUserDoesNotExist :: Brig -> Http ()
+testUserDoesNotExist brig = do
+  qself <- userQualifiedId <$> randomUser brig
+  uid <- liftIO $ Id <$> UUID.nextRandom
+  head
+    ( brig
+        . paths ["users", toByteString' (qDomain qself), toByteString' uid]
+        . zUser (qUnqualified qself)
+    )
+    !!! do
+      const 404 === statusCode
+      const mempty === responseBody
 
 testMultipleUsersUnqualified :: Brig -> Http ()
 testMultipleUsersUnqualified brig = do


### PR DESCRIPTION
Servant implements HEAD endpoints automatically in terms of GET endpoints. As it turned out, the explicit implementations we had for `HEAD /users/:uid` (and its qualified counterpart) ended up not being invoked by Servant's routing mechanism.

This simply removes the endpoints, and adds tests showing that the functionality is still present and works as expected.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
