### PR TITLE
Test error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Upgrade nginz (#1658)
 * The servant-swagger dependency now points to the current upstream master (#1656).
 * Improved error handling middleware (#1671).
 * Refactor function createUser for readability (#1670)
+* Improved test coverage for error responses (#1680)
 
 ## Federation changes (alpha feature, do not use yet)
 

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -428,9 +428,13 @@ testNonExistingUserUnqualified brig = do
   findingOne <- liftIO $ Id <$> UUID.nextRandom
   foundOne <- liftIO $ Id <$> UUID.nextRandom
   get (brig . paths ["users", pack $ show foundOne] . zUser findingOne)
-    !!! const 404 === statusCode
+    !!! do
+      const 404 === statusCode
+      const (Just "not-found") === fmap Error.label . responseJsonMaybe
   get (brig . paths ["users", pack $ show foundOne] . zUser foundOne)
-    !!! const 404 === statusCode
+    !!! do
+      const 404 === statusCode
+      const (Just "not-found") === fmap Error.label . responseJsonMaybe
 
 testNonExistingUser :: Brig -> Http ()
 testNonExistingUser brig = do
@@ -440,9 +444,13 @@ testNonExistingUser brig = do
   let uid = qUnqualified qself
       domain = qDomain qself
   get (brig . paths ["users", toByteString' domain, toByteString' uid1] . zUser uid)
-    !!! const 404 === statusCode
+    !!! do
+      const 404 === statusCode
+      const (Just "not-found") === fmap Error.label . responseJsonMaybe
   get (brig . paths ["users", toByteString' domain, toByteString' uid2] . zUser uid)
-    !!! const 404 === statusCode
+    !!! do
+      const 404 === statusCode
+      const (Just "not-found") === fmap Error.label . responseJsonMaybe
 
 testUserInvalidDomain :: Brig -> Http ()
 testUserInvalidDomain brig = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1851,7 +1851,9 @@ postMembersOk2 = do
   connectUsers alice (list1 bob [chuck])
   connectUsers bob (singleton chuck)
   conv <- decodeConvId <$> postConv alice [bob, chuck] Nothing [] Nothing Nothing
-  postMembers bob (singleton chuck) conv !!! const 204 === statusCode
+  postMembers bob (singleton chuck) conv !!! do
+    const 204 === statusCode
+    const Nothing === responseBody
   chuck' <- responseJsonUnsafe <$> (getSelfMember chuck conv <!! const 200 === statusCode)
   liftIO $
     assertEqual "wrong self member" (Just chuck) (memId <$> chuck')


### PR DESCRIPTION
This PR adds integration tests to make sure that certain error responses behave as expected. This is mostly preparation for merging #1657.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
