### PR TITLE
federator: Refactor RemoteError handling

### DIFF
--- a/CHANGELOG-draft.md
+++ b/CHANGELOG-draft.md
@@ -39,4 +39,5 @@ THIS FILE ACCUMULATES THE RELEASE NOTES FOR THE UPCOMING RELEASE.
 
 ## Internal changes
 
+* Refactored remote error handling in federator (#1681)
 * The update conversation membership federation endpoint takes OriginDomainHeader (#1719)

--- a/services/federator/src/Federator/Remote.hs
+++ b/services/federator/src/Federator/Remote.hs
@@ -114,7 +114,6 @@ blessedCiphers =
 mkGrpcClient ::
   Members
     '[ Embed IO,
-       TinyLog,
        Polysemy.Error RemoteError,
        Polysemy.Reader TLSSettings
      ]

--- a/services/federator/test/unit/Test/Federator/Remote.hs
+++ b/services/federator/test/unit/Test/Federator/Remote.hs
@@ -14,7 +14,6 @@ import qualified Network.Wai.Handler.WarpTLS as WarpTLS
 import Polysemy
 import qualified Polysemy.Error as Polysemy
 import qualified Polysemy.Reader as Polysemy
-import qualified Polysemy.TinyLog as TinyLog
 import Test.Federator.Options (defRunSettings)
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -60,18 +59,17 @@ testValidatesCertificateSuccess =
     [ testCase "when hostname=localhost and certificate-for=localhost" $ do
         bracket (startMockServer certForLocalhost) (\(serverThread, _) -> Async.cancel serverThread) $ \(_, port) -> do
           tlsSettings <- mkTLSSettings settings
-          void . Polysemy.runM . assertNoError @RemoteError . TinyLog.discardLogs . Polysemy.runReader tlsSettings $ mkGrpcClient (SrvTarget "localhost" (fromIntegral port)),
+          void . Polysemy.runM . assertNoError @RemoteError . Polysemy.runReader tlsSettings $ mkGrpcClient (SrvTarget "localhost" (fromIntegral port)),
       testCase "when hostname=localhost. and certificate-for=localhost" $ do
         bracket (startMockServer certForLocalhost) (\(serverThread, _) -> Async.cancel serverThread) $ \(_, port) -> do
           tlsSettings <- mkTLSSettings settings
-          void . Polysemy.runM . assertNoError @RemoteError . TinyLog.discardLogs . Polysemy.runReader tlsSettings $ mkGrpcClient (SrvTarget "localhost." (fromIntegral port)),
+          void . Polysemy.runM . assertNoError @RemoteError . Polysemy.runReader tlsSettings $ mkGrpcClient (SrvTarget "localhost." (fromIntegral port)),
       -- This is a limitation of the TLS library, this test just exists to document that.
       testCase "when hostname=localhost. and certificate-for=localhost." $ do
         bracket (startMockServer certForLocalhostDot) (\(serverThread, _) -> Async.cancel serverThread) $ \(_, port) -> do
           tlsSettings <- mkTLSSettings settings
           eitherClient <-
             Polysemy.runM
-              . TinyLog.discardLogs
               . Polysemy.runError @RemoteError
               . Polysemy.runReader tlsSettings
               $ mkGrpcClient (SrvTarget "localhost." (fromIntegral port))
@@ -90,7 +88,6 @@ testValidatesCertificateWrongHostname =
           eitherClient <-
             Polysemy.runM
               . Polysemy.runError
-              . TinyLog.discardLogs
               . Polysemy.runReader tlsSettings
               $ mkGrpcClient (SrvTarget "localhost." (fromIntegral port))
           case eitherClient of


### PR DESCRIPTION
Small reorganisation of how `RemoteError`s are thrown and logged in federator.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
