### PR TITLE
Add feature flag "conferenceCalling"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Upgrade nginz (#1658)
 
 * Extend feature config API (#1658)
 * `fileSharing` feature config (#1652, #1654, #1655)
+* `conferenceCalling` feature flag (#1683)
 * Add user_id to csv export (#1663)
 * Validate server TLS certificate between federators (#1662)
 

--- a/docs/reference/cassandra-schema.cql
+++ b/docs/reference/cassandra-schema.cql
@@ -411,6 +411,7 @@ CREATE TABLE galley_test.team_features (
     app_lock_enforce int,
     app_lock_inactivity_timeout_secs int,
     app_lock_status int,
+    conference_calling int,
     digital_signatures int,
     file_sharing int,
     legalhold_status int,

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -124,6 +124,23 @@ classifiedDomains:
     domains: []
 ```
 
+### Conference Calling
+
+The `conferenceCalling` feature flag controls whether a user can initiate a conference call. The flag can be toggled between its states `enabled` and `disabled` per team via an internal endpoint. 
+
+The `conferenceCalling` section in `featureFlags` defines the state of the `conferenceCalling` feature flag for all personal users (users that don't belong to a team). For personal users there is no way to toggle the flag, so the setting of the config section wholly defines the state of `conferenceCalling` for all personal users.
+
+The `conferenceCalling` section in `featureFlags` also defines the _initial_ state of the `conferenceCalling` flag for all teams. After the flag is set for the first time for a team via the internal endpoint the value from the config section will be ignored.
+
+Example value for the config section:
+```yaml
+conferenceCalling:
+  defaults:
+    status: enabled
+```
+
+The `conferenceCalling` section is optional in `featureFlags`. If it is omitted then it is assumed to be `enabled`.
+
 ### Federation Domain
 
 Regardless of whether a backend wants to enable federation or not, the operator

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -128,7 +128,7 @@ classifiedDomains:
 
 The `conferenceCalling` feature flag controls whether a user can initiate a conference call. The flag can be toggled between its states `enabled` and `disabled` per team via an internal endpoint. 
 
-The `conferenceCalling` section in `featureFlags` defines the state of the `conferenceCalling` feature flag for all personal users (users that don't belong to a team). For personal users there is no way to toggle the flag, so the setting of the config section wholly defines the state of `conferenceCalling` for all personal users.
+The `conferenceCalling` section in `featureFlags` defines the state of the `conferenceCalling` feature flag for all personal users (users that don't belong to a team). For personal users there is no way to toggle the flag, so the setting of the config section wholly defines the state of `conferenceCalling` flag for all personal users.
 
 The `conferenceCalling` section in `featureFlags` also defines the _initial_ state of the `conferenceCalling` flag for all teams. After the flag is set for the first time for a team via the internal endpoint the value from the config section will be ignored.
 

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -30,6 +30,7 @@ module Galley.Types.Teams
     flagFileSharing,
     flagAppLockDefaults,
     flagClassifiedDomains,
+    flagConferenceCalling,
     Defaults (..),
     unDefaults,
     FeatureSSO (..),
@@ -199,7 +200,8 @@ data FeatureFlags = FeatureFlags
     _flagTeamSearchVisibility :: !FeatureTeamSearchVisibility,
     _flagAppLockDefaults :: !(Defaults (TeamFeatureStatus 'TeamFeatureAppLock)),
     _flagClassifiedDomains :: !(TeamFeatureStatus 'TeamFeatureClassifiedDomains),
-    _flagFileSharing :: !(Defaults (TeamFeatureStatus 'TeamFeatureFileSharing))
+    _flagFileSharing :: !(Defaults (TeamFeatureStatus 'TeamFeatureFileSharing)),
+    _flagConferenceCalling :: !(Defaults (TeamFeatureStatus 'TeamFeatureConferenceCalling))
   }
   deriving (Eq, Show, Generic)
 
@@ -244,16 +246,18 @@ instance FromJSON FeatureFlags where
       <*> (fromMaybe (Defaults defaultAppLockStatus) <$> (obj .:? "appLock"))
       <*> (fromMaybe defaultClassifiedDomains <$> (obj .:? "classifiedDomains"))
       <*> (fromMaybe (Defaults (TeamFeatureStatusNoConfig TeamFeatureEnabled)) <$> (obj .:? "fileSharing"))
+      <*> (fromMaybe (Defaults (TeamFeatureStatusNoConfig TeamFeatureEnabled)) <$> (obj .:? "conferenceCalling"))
 
 instance ToJSON FeatureFlags where
-  toJSON (FeatureFlags sso legalhold searchVisibility appLock classifiedDomains fileSharing) =
+  toJSON (FeatureFlags sso legalhold searchVisibility appLock classifiedDomains fileSharing conferenceCalling) =
     object $
       [ "sso" .= sso,
         "legalhold" .= legalhold,
         "teamSearchVisibility" .= searchVisibility,
         "appLock" .= appLock,
         "classifiedDomains" .= classifiedDomains,
-        "fileSharing" .= fileSharing
+        "fileSharing" .= fileSharing,
+        "conferenceCalling" .= conferenceCalling
       ]
 
 instance FromJSON FeatureSSO where
@@ -363,6 +367,7 @@ roleHiddenPermissions role = HiddenPermissions p p
           ViewTeamFeature TeamFeatureAppLock,
           ViewTeamFeature TeamFeatureFileSharing,
           ViewTeamFeature TeamFeatureClassifiedDomains,
+          ViewTeamFeature TeamFeatureConferenceCalling,
           ViewLegalHoldUserSettings,
           ViewTeamSearchVisibility
         ]

--- a/libs/galley-types/test/unit/Test/Galley/Types.hs
+++ b/libs/galley-types/test/unit/Test/Galley/Types.hs
@@ -66,3 +66,4 @@ instance Arbitrary FeatureFlags where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary

--- a/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
+++ b/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
@@ -72,6 +72,7 @@ taggedEventDataSchema =
       TeamFeatureAppLock -> tag _EdFeatureApplockChanged (unnamed schema)
       TeamFeatureFileSharing -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
       TeamFeatureClassifiedDomains -> tag _EdFeatureClassifiedDomainsChanged (unnamed schema)
+      TeamFeatureConferenceCalling -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
 
 eventObjectSchema :: ObjectSchema SwaggerDoc Event
 eventObjectSchema =

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -366,6 +366,9 @@ data Api routes = Api
     teamFeatureStatusClassifiedDomainsGet ::
       routes
         :- FeatureStatusGet 'TeamFeatureClassifiedDomains,
+    teamFeatureStatusConferenceCallingGet ::
+      routes
+        :- FeatureStatusGet 'TeamFeatureConferenceCalling,
     featureAllFeatureConfigsGet ::
       routes
         :- AllFeatureConfigsGet,
@@ -392,7 +395,10 @@ data Api routes = Api
         :- FeatureConfigGet 'TeamFeatureFileSharing,
     featureConfigClassifiedDomainsGet ::
       routes
-        :- FeatureConfigGet 'TeamFeatureClassifiedDomains
+        :- FeatureConfigGet 'TeamFeatureClassifiedDomains,
+    featureConfigConferenceCallingGet ::
+      routes
+        :- FeatureConfigGet 'TeamFeatureConferenceCalling
   }
   deriving (Generic)
 

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
@@ -204,6 +204,7 @@ tests =
       testRoundTrip @(Team.Feature.TeamFeatureStatus 'Team.Feature.TeamFeatureAppLock),
       testRoundTrip @(Team.Feature.TeamFeatureStatus 'Team.Feature.TeamFeatureFileSharing),
       testRoundTrip @(Team.Feature.TeamFeatureStatus 'Team.Feature.TeamFeatureClassifiedDomains),
+      testRoundTrip @(Team.Feature.TeamFeatureStatus 'Team.Feature.TeamFeatureConferenceCalling),
       testRoundTrip @Team.Feature.TeamFeatureStatusValue,
       testRoundTrip @Team.Invitation.InvitationRequest,
       testRoundTrip @Team.Invitation.Invitation,

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b6af0b547d17e02b65a3d3cdef9ca81eb86c1292957b7f9ae6b6e3e108cb983f
+-- hash: 7ae942605e2cd7ddc1fc423b068b429970064332a02e90994295385a0722d1b9
 
 name:           federator
 version:        1.0.0
@@ -17,8 +17,6 @@ license:        AGPL-3
 build-type:     Simple
 extra-source-files:
     test/resources/integration-ca.pem
-    test/resources/integration-leaf-key.pem
-    test/resources/integration-leaf.pem
     test/resources/unit/gen-certs.sh
     test/resources/unit/localhost-dot-key.pem
     test/resources/unit/localhost-dot.pem

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bb7dc649f5fc67c5e449f5b5984e8d7ae01caa5833ba0fa6a5db4f45cd5b1b42
+-- hash: 8728b07d9aff8cd747ea5ca33259f9168c966ae28ca76825e0a073e166d43213
 
 name:           galley
 version:        0.83.0
@@ -357,6 +357,7 @@ executable galley-schema
       V49_ReAddRemoteIdentifiers
       V50_AddLegalholdWhitelisted
       V51_FeatureFileSharing
+      V52_FeatureConferenceCalling
       Paths_galley
   hs-source-dirs:
       schema/src

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -59,6 +59,9 @@ settings:
     fileSharing:
       defaults:
         status: enabled
+    conferenceCalling:
+      defaults:
+        status: enabled
 
 logLevel: Info
 logNetStrings: false

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -54,6 +54,7 @@ import qualified V48_DeleteRemoteIdentifiers
 import qualified V49_ReAddRemoteIdentifiers
 import qualified V50_AddLegalholdWhitelisted
 import qualified V51_FeatureFileSharing
+import qualified V52_FeatureConferenceCalling
 
 main :: IO ()
 main = do
@@ -93,7 +94,8 @@ main = do
       V48_DeleteRemoteIdentifiers.migration,
       V49_ReAddRemoteIdentifiers.migration,
       V50_AddLegalholdWhitelisted.migration,
-      V51_FeatureFileSharing.migration
+      V51_FeatureFileSharing.migration,
+      V52_FeatureConferenceCalling.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Galley.Data
     ]

--- a/services/galley/schema/src/V52_FeatureConferenceCalling.hs
+++ b/services/galley/schema/src/V52_FeatureConferenceCalling.hs
@@ -1,0 +1,29 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V52_FeatureConferenceCalling
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 52 "Add feature flag \"conferenceCalling\"." $ do
+  schema' [r| ALTER TABLE team_features ADD conference_calling int; |]

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -150,7 +150,13 @@ data InternalApi routes = InternalApi
         :- IFeatureStatusPut 'Public.TeamFeatureFileSharing,
     iTeamFeatureStatusClassifiedDomainsGet ::
       routes
-        :- IFeatureStatusGet 'Public.TeamFeatureClassifiedDomains
+        :- IFeatureStatusGet 'Public.TeamFeatureClassifiedDomains,
+    iTeamFeatureStatusConferenceCallingPut ::
+      routes
+        :- IFeatureStatusPut 'Public.TeamFeatureConferenceCalling,
+    iTeamFeatureStatusConferenceCallingGet ::
+      routes
+        :- IFeatureStatusGet 'Public.TeamFeatureConferenceCalling
   }
   deriving (Generic)
 
@@ -222,7 +228,9 @@ servantSitemap =
         iTeamFeatureStatusAppLockPut = iPutTeamFeature @'Public.TeamFeatureAppLock Features.setAppLockInternal,
         iTeamFeatureStatusFileSharingGet = iGetTeamFeature @'Public.TeamFeatureFileSharing Features.getFileSharingInternal,
         iTeamFeatureStatusFileSharingPut = iPutTeamFeature @'Public.TeamFeatureFileSharing Features.setFileSharingInternal,
-        iTeamFeatureStatusClassifiedDomainsGet = iGetTeamFeature @'Public.TeamFeatureClassifiedDomains Features.getClassifiedDomainsInternal
+        iTeamFeatureStatusClassifiedDomainsGet = iGetTeamFeature @'Public.TeamFeatureClassifiedDomains Features.getClassifiedDomainsInternal,
+        iTeamFeatureStatusConferenceCallingPut = iPutTeamFeature @'Public.TeamFeatureConferenceCalling Features.setConferenceCallingInternal,
+        iTeamFeatureStatusConferenceCallingGet = iGetTeamFeature @'Public.TeamFeatureConferenceCalling Features.getConferenceCallingInternal
       }
 
 iGetTeamFeature ::

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -139,6 +139,9 @@ servantSitemap =
         GalleyAPI.teamFeatureStatusClassifiedDomainsGet =
           getFeatureStatus @'Public.TeamFeatureClassifiedDomains Features.getClassifiedDomainsInternal
             . DoAuth,
+        GalleyAPI.teamFeatureStatusConferenceCallingGet =
+          getFeatureStatus @'Public.TeamFeatureConferenceCalling Features.getConferenceCallingInternal
+            . DoAuth,
         GalleyAPI.featureAllFeatureConfigsGet = Features.getAllFeatureConfigs,
         GalleyAPI.featureConfigLegalHoldGet = Features.getFeatureConfig @'Public.TeamFeatureLegalHold Features.getLegalholdStatusInternal,
         GalleyAPI.featureConfigSSOGet = Features.getFeatureConfig @'Public.TeamFeatureSSO Features.getSSOStatusInternal,
@@ -147,7 +150,8 @@ servantSitemap =
         GalleyAPI.featureConfigDigitalSignaturesGet = Features.getFeatureConfig @'Public.TeamFeatureDigitalSignatures Features.getDigitalSignaturesInternal,
         GalleyAPI.featureConfigAppLockGet = Features.getFeatureConfig @'Public.TeamFeatureAppLock Features.getAppLockInternal,
         GalleyAPI.featureConfigFileSharingGet = Features.getFeatureConfig @'Public.TeamFeatureFileSharing Features.getFileSharingInternal,
-        GalleyAPI.featureConfigClassifiedDomainsGet = Features.getFeatureConfig @'Public.TeamFeatureClassifiedDomains Features.getClassifiedDomainsInternal
+        GalleyAPI.featureConfigClassifiedDomainsGet = Features.getFeatureConfig @'Public.TeamFeatureClassifiedDomains Features.getClassifiedDomainsInternal,
+        GalleyAPI.featureConfigConferenceCallingGet = Features.getFeatureConfig @'Public.TeamFeatureConferenceCalling Features.getConferenceCallingInternal
       }
 
 sitemap :: Routes ApiBuilder Galley ()

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -36,6 +36,8 @@ module Galley.API.Teams.Features
     setAppLockInternal,
     getFileSharingInternal,
     setFileSharingInternal,
+    getConferenceCallingInternal,
+    setConferenceCallingInternal,
     DoAuth (..),
   )
 where
@@ -65,7 +67,7 @@ import Network.Wai.Utilities
 import qualified System.Logger.Class as Log
 import Wire.API.Event.FeatureConfig (EventData (EdFeatureWithoutConfigChanged))
 import qualified Wire.API.Event.FeatureConfig as Event
-import Wire.API.Team.Feature (AllFeatureConfigs (..))
+import Wire.API.Team.Feature (AllFeatureConfigs (..), FeatureHasNoConfig, KnownTeamFeatureName, TeamFeatureName)
 import qualified Wire.API.Team.Feature as Public
 
 data DoAuth = DoAuth UserId | DontDoAuth
@@ -336,6 +338,12 @@ getClassifiedDomainsInternal _mbtid = do
     Public.TeamFeatureDisabled ->
       Public.TeamFeatureStatusWithConfig Public.TeamFeatureDisabled (Public.TeamFeatureClassifiedDomainsConfig [])
     Public.TeamFeatureEnabled -> config
+
+getConferenceCallingInternal :: Maybe TeamId -> Galley (Public.TeamFeatureStatus 'Public.TeamFeatureConferenceCalling)
+getConferenceCallingInternal = getFeatureStatusWithDefaultConfig @'Public.TeamFeatureConferenceCalling flagConferenceCalling
+
+setConferenceCallingInternal :: TeamId -> Public.TeamFeatureStatus 'Public.TeamFeatureConferenceCalling -> Galley (Public.TeamFeatureStatus 'Public.TeamFeatureConferenceCalling)
+setConferenceCallingInternal = setFeatureStatusNoConfig @'Public.TeamFeatureConferenceCalling $ \_status _tid -> pure ()
 
 pushFeatureConfigEvent :: TeamId -> Event.Event -> Galley ()
 pushFeatureConfigEvent tid event = do

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -147,7 +147,8 @@ getAllFeatureConfigs zusr = do
         getStatus @'Public.TeamFeatureDigitalSignatures getDigitalSignaturesInternal,
         getStatus @'Public.TeamFeatureAppLock getAppLockInternal,
         getStatus @'Public.TeamFeatureFileSharing getFileSharingInternal,
-        getStatus @'Public.TeamFeatureClassifiedDomains getClassifiedDomainsInternal
+        getStatus @'Public.TeamFeatureClassifiedDomains getClassifiedDomainsInternal,
+        getStatus @'Public.TeamFeatureConferenceCalling getConferenceCallingInternal
       ]
 
 getAllFeaturesH :: UserId ::: TeamId ::: JSON -> Galley Response
@@ -165,7 +166,8 @@ getAllFeatures uid tid = do
         getStatus @'Public.TeamFeatureDigitalSignatures getDigitalSignaturesInternal,
         getStatus @'Public.TeamFeatureAppLock getAppLockInternal,
         getStatus @'Public.TeamFeatureFileSharing getFileSharingInternal,
-        getStatus @'Public.TeamFeatureClassifiedDomains getClassifiedDomainsInternal
+        getStatus @'Public.TeamFeatureClassifiedDomains getClassifiedDomainsInternal,
+        getStatus @'Public.TeamFeatureConferenceCalling getConferenceCallingInternal
       ]
   where
     getStatus ::

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -188,7 +188,7 @@ mkResultSet page = ResultSet (result page) typ
       | otherwise = ResultSetComplete
 
 schemaVersion :: Int32
-schemaVersion = 51
+schemaVersion = 52
 
 -- | Insert a conversation code
 insertCode :: MonadClient m => Code -> m ()

--- a/services/galley/src/Galley/Data/TeamFeatures.hs
+++ b/services/galley/src/Galley/Data/TeamFeatures.hs
@@ -64,6 +64,8 @@ instance HasStatusCol 'TeamFeatureAppLock where statusCol = "app_lock_status"
 
 instance HasStatusCol 'TeamFeatureFileSharing where statusCol = "file_sharing"
 
+instance HasStatusCol 'TeamFeatureConferenceCalling where statusCol = "conference_calling"
+
 getFeatureStatusNoConfig ::
   forall (a :: Public.TeamFeatureName) m.
   ( MonadClient m,

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -391,7 +391,9 @@ testAllFeatures = do
           toS TeamFeatureClassifiedDomains
             .= Public.TeamFeatureStatusWithConfig
               TeamFeatureEnabled
-              (Public.TeamFeatureClassifiedDomainsConfig [Domain "example.com"])
+              (Public.TeamFeatureClassifiedDomainsConfig [Domain "example.com"]),
+          toS TeamFeatureConferenceCalling
+            .= Public.TeamFeatureStatusNoConfig TeamFeatureEnabled
         ]
     toS :: TeamFeatureName -> Text
     toS = TE.decodeUtf8 . toByteString'

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -357,7 +357,7 @@ testSimpleFlag defaultValue = do
         Public.TeamFeatureDisabled -> Public.TeamFeatureEnabled
         Public.TeamFeatureEnabled -> Public.TeamFeatureDisabled
 
-  -- Disabled by default
+  -- Initial value should be the default value
   getFlag defaultValue
   getFlagInternal defaultValue
   getFeatureConfig defaultValue

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -67,7 +67,8 @@ tests s =
       test s "Classified Domains (disabled)" testClassifiedDomainsDisabled,
       test s "All features" testAllFeatures,
       test s "Feature Configs / Team Features Consistency" testFeatureConfigConsistency,
-      test s "FileSharing - event" $ testSimpleFlagEvent @'Public.TeamFeatureFileSharing Public.TeamFeatureEnabled Public.TeamFeatureDisabled
+      test s "FileSharing - event" $ testSimpleFlagEvent @'Public.TeamFeatureFileSharing Public.TeamFeatureEnabled Public.TeamFeatureDisabled,
+      test s "ConferenceCalling" $ testSimpleFlag @'Public.TeamFeatureConferenceCalling Public.TeamFeatureEnabled
     ]
 
 testSSO :: TestM ()
@@ -366,6 +367,10 @@ testSimpleFlag defaultValue = do
   getFlag otherValue
   getFeatureConfig otherValue
   getFlagInternal otherValue
+
+  -- Clean up
+  setFlagInternal defaultValue
+  getFlag defaultValue
 
 -- | Call 'GET /teams/:tid/features' and check if all features are there
 testAllFeatures :: TestM ()


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-681

This PR also:
- refactor some of the feature endpoint implementation
- adds to test that all simple flags should emit a `feature-config.update` event

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
