### PR TITLE
Change http response code for `missing-legalhold-consent`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Upgrade nginz (#1658)
 * New, hardened end-point for changing email
 * Fix: CSV export is missing SCIM external id when SAML is also used (#1608)
 * Fix: sso_id field in user record (brig) was not always filled correctly in cassandra (#1334)
+* Change http response code for `missing-legalhold-consent` from 412 to 403 (#1688)
 
 ## Documentation
 

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -456,6 +456,7 @@ propertyManagedByScim prop = Wai.mkError status403 "managed-by-scim" $ "Updating
 sameBindingTeamUsers :: Wai.Error
 sameBindingTeamUsers = Wai.mkError status403 "same-binding-team-users" "Operation not allowed to binding team users."
 
+-- | See 'Galley.API.Error.missingLegalholdConsent'.
 missingLegalholdConsent :: Wai.Error
 missingLegalholdConsent = Wai.mkError status403 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
 

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -457,7 +457,7 @@ sameBindingTeamUsers :: Wai.Error
 sameBindingTeamUsers = Wai.mkError status403 "same-binding-team-users" "Operation not allowed to binding team users."
 
 missingLegalholdConsent :: Wai.Error
-missingLegalholdConsent = Wai.mkError status412 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
+missingLegalholdConsent = Wai.mkError status403 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
 
 ownerDeletingSelf :: Wai.Error
 ownerDeletingSelf =

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -898,7 +898,7 @@ guardLegalhold protectee userClients = do
   res <- lift $ galleyRequest PUT req
   case Bilge.statusCode res of
     200 -> pure ()
-    412 -> throwE ClientMissingLegalholdConsent
+    403 -> throwE ClientMissingLegalholdConsent
     404 -> pure () -- allow for galley not to be ready, so the set of valid deployment orders is non-empty.
     _ -> throwM internalServerError
   where

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -209,6 +209,15 @@ noLegalHoldDeviceAllocated = mkError status404 "legalhold-no-device-allocated" "
 legalHoldCouldNotBlockConnections :: Error
 legalHoldCouldNotBlockConnections = mkError status500 "legalhold-internal" "legal hold service: could not block connections when resolving policy conflicts."
 
+-- | See 'Brig.API.Error.missingLegalholdConsent'.
+--
+-- FUTUREWORK: To avoid this duplication, you could turn this into an `ErrorDescription` and
+-- move it to the `ErrorDescription` module in wire-api, where it can then be used from both
+-- brig and galley. Also, it makes it easier to add it to swagger, if desired, or even later
+-- turn it into a statically checked response with `MultiVerb`.
+--
+-- For examples, see https://github.com/wireapp/wire-server/pull/1657 or
+-- https://github.com/wireapp/wire-server/pull/1657/commits/8e73769d7d4a657fef5fbe9210f885f9ccbcaab6.
 missingLegalholdConsent :: Error
 missingLegalholdConsent = mkError status403 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
 

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -210,7 +210,7 @@ legalHoldCouldNotBlockConnections :: Error
 legalHoldCouldNotBlockConnections = mkError status500 "legalhold-internal" "legal hold service: could not block connections when resolving policy conflicts."
 
 missingLegalholdConsent :: Error
-missingLegalholdConsent = mkError status412 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
+missingLegalholdConsent = mkError status403 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
 
 disableSsoNotImplemented :: Error
 disableSsoNotImplemented =

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -806,7 +806,7 @@ testOldClientsBlockDeviceHandshake = do
     -- If user has a client without the ClientSupportsLegalholdImplicitConsent
     -- capability then message sending is prevented to legalhold devices.
     peerClient <- randomClient peer (someLastPrekeys !! 2)
-    runit peer peerClient >>= errWith 412 (\err -> Error.label err == "missing-legalhold-consent")
+    runit peer peerClient >>= errWith 403 (\err -> Error.label err == "missing-legalhold-consent")
     upgradeClientToLH peer peerClient
     runit peer peerClient >>= errWith 412 (\(_ :: Msg.ClientMismatch) -> True)
 
@@ -928,8 +928,8 @@ testNoConsentBlockOne2OneConv connectFirst teamPeer approveLH testPendingConnect
               const 201 === statusCode
       else do
         void doEnableLH
-        postConnection legalholder peer !!! do testResponse 412 (Just "missing-legalhold-consent")
-        postConnection peer legalholder !!! do testResponse 412 (Just "missing-legalhold-consent")
+        postConnection legalholder peer !!! do testResponse 403 (Just "missing-legalhold-consent")
+        postConnection peer legalholder !!! do testResponse 403 (Just "missing-legalhold-consent")
 
 data GroupConvAdmin
   = LegalholderIsAdmin
@@ -1044,7 +1044,7 @@ testGroupConvInvitationHandlesLHConflicts inviteCase = do
         assertNotConvMember peer convId
       InviteAlsoNonConsenters -> do
         API.Util.postMembers userWithConsent (List1.list1 legalholder [peer2]) convId
-          >>= errWith 412 (\err -> Error.label err == "missing-legalhold-consent")
+          >>= errWith 403 (\err -> Error.label err == "missing-legalhold-consent")
 
 testNoConsentCannotBeInvited :: HasCallStack => TestM ()
 testNoConsentCannotBeInvited = do
@@ -1081,11 +1081,11 @@ testNoConsentCannotBeInvited = do
       liftIO $ assertEqual "approving should change status" UserLegalHoldEnabled userStatus
 
     API.Util.postMembers userLHNotActivated (List1.list1 peer2 []) convId
-      >>= errWith 412 (\err -> Error.label err == "missing-legalhold-consent")
+      >>= errWith 403 (\err -> Error.label err == "missing-legalhold-consent")
 
     localdomain <- viewFederationDomain
     API.Util.postQualifiedMembers userLHNotActivated ((Qualified peer2 localdomain) :| []) convId
-      >>= errWith 412 (\err -> Error.label err == "missing-legalhold-consent")
+      >>= errWith 403 (\err -> Error.label err == "missing-legalhold-consent")
 
 testCannotCreateGroupWithUsersInConflict :: HasCallStack => TestM ()
 testCannotCreateGroupWithUsersInConflict = do
@@ -1120,7 +1120,7 @@ testCannotCreateGroupWithUsersInConflict = do
       liftIO $ assertEqual "approving should change status" UserLegalHoldEnabled userStatus
 
     createTeamConvAccessRaw userLHNotActivated tid [peer2, legalholder] (Just "corp + us") Nothing Nothing Nothing (Just roleNameWireMember)
-      >>= errWith 412 (\err -> Error.label err == "missing-legalhold-consent")
+      >>= errWith 403 (\err -> Error.label err == "missing-legalhold-consent")
 
 data TestClaimKeys
   = TCKConsentMissing
@@ -1169,7 +1169,7 @@ testClaimKeys testcase = do
         TCKConsentAndNewClients -> good
         where
           good = testResponse 200 Nothing
-          bad = testResponse 412 (Just "missing-legalhold-consent")
+          bad = testResponse 403 (Just "missing-legalhold-consent")
 
   let fetchKeys :: ClientId -> TestM ()
       fetchKeys legalholderLHDevice = do

--- a/services/galley/test/integration/API/Teams/LegalHold/DisabledByDefault.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold/DisabledByDefault.hs
@@ -752,7 +752,7 @@ testOldClientsBlockDeviceHandshake = do
     -- If user has a client without the ClientSupportsLegalholdImplicitConsent
     -- capability then message sending is prevented to legalhold devices.
     peerClient <- randomClient peer (someLastPrekeys !! 2)
-    runit peer peerClient >>= errWith 412 (\err -> Error.label err == "missing-legalhold-consent")
+    runit peer peerClient >>= errWith 403 (\err -> Error.label err == "missing-legalhold-consent")
     upgradeClientToLH peer peerClient
     runit peer peerClient >>= errWith 412 (\(_ :: Msg.ClientMismatch) -> True)
 
@@ -803,7 +803,7 @@ testClaimKeys testcase = do
         TCKConsentAndNewClients -> good
         where
           good = testResponse 200 Nothing
-          bad = testResponse 412 (Just "missing-legalhold-consent")
+          bad = testResponse 403 (Just "missing-legalhold-consent")
 
   let fetchKeys :: ClientId -> TestM ()
       fetchKeys legalholderLHDevice = do


### PR DESCRIPTION
412 is used for "need to add some clients" in message posting; 403 makes client implementations more straight-forward.

It's probably worth mentioning that this only affects users about to get in contact with LH devices.  For those users, we have a new safety check in place that if the user has old clients or is not in a team cleared for LH, she will get a new error response.  403 in that case is better, since it makes it clear to the client that this won't work on retry either.  412 is used for notifying the client that they need to pick up some newly added clients listening in on the conversation, so this will probably break in less nice ways.

tl;dr: only affects users in touch with LH teams that shouldn't, and makes their UX strictly better.  :)

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
