### PR TITLE
Rename `DomainHeader` to `OriginDomainHeader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Upgrade nginz (#1658)
 * Added a `QualifiedCapture` type to Servant for qualified paths (#1669)
 * Removed explicit implementation for user HEAD endpoints (#1679)
 * Improved test coverage for error responses (#1680)
+* Renamed `DomainHeader` type to `OriginDomainHeader` (#1689)
 
 ## Federation changes (alpha feature, do not use yet)
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -35,7 +35,7 @@ import Wire.API.Conversation (Access, AccessRole, ConvType, Conversation, Receip
 import Wire.API.Conversation.Member (OtherMember)
 import Wire.API.Conversation.Role (RoleName)
 import Wire.API.Federation.Client (FederationClientFailure, FederatorClient)
-import Wire.API.Federation.Domain (DomainHeader)
+import Wire.API.Federation.Domain (OriginDomainHeader)
 import qualified Wire.API.Federation.GRPC.Types as Proto
 import Wire.API.Federation.Util.Aeson (CustomEncoded (..))
 import Wire.API.Message (MessageSendingStatus, Priority)
@@ -74,7 +74,7 @@ data Api routes = Api
       routes
         :- "federation"
         :> "receive-message"
-        :> DomainHeader
+        :> OriginDomainHeader
         :> ReqBody '[JSON] (RemoteMessage ConvId)
         :> Post '[JSON] (),
     -- used by a remote backend to send a message to a conversation owned by
@@ -83,7 +83,7 @@ data Api routes = Api
       routes
         :- "federation"
         :> "send-message"
-        :> DomainHeader
+        :> OriginDomainHeader
         :> ReqBody '[JSON] MessageSendRequest
         :> Post '[JSON] MessageSendResponse
   }

--- a/libs/wire-api-federation/src/Wire/API/Federation/Domain.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Domain.hs
@@ -23,9 +23,9 @@ import GHC.TypeLits (Symbol, symbolVal)
 import Imports
 import Servant.API (Header', Required, Strict)
 
-type DomainHeaderName = "Wire-Origin-Domain" :: Symbol
+type OriginDomainHeaderName = "Wire-Origin-Domain" :: Symbol
 
-type DomainHeader = Header' [Strict, Required] DomainHeaderName Domain
+type OriginDomainHeader = Header' [Strict, Required] OriginDomainHeaderName Domain
 
-domainHeaderName :: IsString a => a
-domainHeaderName = fromString $ symbolVal (Proxy @DomainHeaderName)
+originDomainHeaderName :: IsString a => a
+originDomainHeaderName = fromString $ symbolVal (Proxy @OriginDomainHeaderName)

--- a/services/federator/src/Federator/Service.hs
+++ b/services/federator/src/Federator/Service.hs
@@ -31,7 +31,7 @@ import Federator.Env (service)
 import Imports
 import qualified Network.HTTP.Types as HTTP
 import Polysemy
-import Wire.API.Federation.Domain (domainHeaderName)
+import Wire.API.Federation.Domain (originDomainHeaderName)
 import Wire.API.Federation.GRPC.Types
 
 newtype ServiceError = ServiceErrorInvalidStatus HTTP.Status
@@ -61,5 +61,5 @@ interpretService = interpret $ \case
           . RPC.path path
           . RPC.body (RPC.RequestBodyBS body)
           . RPC.contentJson
-          . RPC.header domainHeaderName (cs (domainText domain))
+          . RPC.header originDomainHeaderName (cs (domainText domain))
     pure (RPC.responseStatus res, RPC.responseBody res)

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -109,7 +109,7 @@ import Wire.API.Event.Team (EventType (MemberJoin, MemberLeave, TeamDelete, Team
 import qualified Wire.API.Event.Team as TE
 import qualified Wire.API.Federation.API.Brig as FederatedBrig
 import qualified Wire.API.Federation.API.Galley as FederatedGalley
-import Wire.API.Federation.Domain (domainHeaderName)
+import Wire.API.Federation.Domain (originDomainHeaderName)
 import Wire.API.Federation.GRPC.Types (FederatedRequest, OutwardResponse (..))
 import qualified Wire.API.Federation.GRPC.Types as F
 import qualified Wire.API.Federation.Mock as Mock
@@ -1982,7 +1982,7 @@ makeFedRequestToServant originDomain server fedRequest =
           Wai.requestHeaders =
             [ (CI.mk "Content-Type", "application/json"),
               (CI.mk "Accept", "application/json"),
-              (domainHeaderName, cs . domainText $ originDomain)
+              (originDomainHeaderName, cs . domainText $ originDomain)
             ]
         }
 


### PR DESCRIPTION
Purely internal change.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
