### PR TITLE
fix swagger: mark name in UserUpdate as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 ## Documentation
 
+*  fix swagger: mark name in UserUpdate as optional (#1691)
+
 ## Internal changes
 
 

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -814,6 +814,7 @@ modelUserUpdate = Doc.defineModel "UserUpdate" $ do
   Doc.description "User Update Data"
   Doc.property "name" Doc.string' $
     Doc.description "Name (1 - 128 characters)"
+    Doc.optional
   Doc.property "assets" (Doc.array (Doc.ref modelAsset)) $ do
     Doc.description "Profile assets"
     Doc.optional


### PR DESCRIPTION
## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [ ] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
