### PR TITLE
Finish integrating `MultiVerb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 ## Internal changes
 
 * Replaced uses of `UVerb` and `EmptyResult` with `MultiVerb` (#1693)
+* Added a mechanism to derive `AsUnion` instances automatically (#1693)
 
 # [2021-08-02]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,11 @@
 
 ## Documentation
 
-*  fix swagger: mark name in UserUpdate as optional (#1691)
+* fix swagger: mark name in UserUpdate as optional (#1691)
 
 ## Internal changes
 
+* Replaced uses of `UVerb` and `EmptyResult` with `MultiVerb` (#1693)
 
 # [2021-08-02]
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -38,7 +38,7 @@ import Wire.API.Federation.Client (FederationClientFailure, FederatorClient)
 import Wire.API.Federation.Domain (OriginDomainHeader)
 import qualified Wire.API.Federation.GRPC.Types as Proto
 import Wire.API.Federation.Util.Aeson (CustomEncoded (..))
-import Wire.API.Message (MessageSendingStatus, Priority)
+import Wire.API.Message (MessageNotSent, MessageSendingStatus, Priority)
 import Wire.API.User.Client (UserClientMap)
 
 -- FUTUREWORK: data types, json instances, more endpoints. See
@@ -186,15 +186,7 @@ data MessageSendRequest = MessageSendRequest
 newtype MessageSendResponse = MessageSendResponse
   {msResponse :: Either MessageNotSent MessageSendingStatus}
   deriving stock (Eq, Show)
-  deriving newtype (ToJSON, FromJSON)
-
-data MessageNotSent
-  = MessageNotSentLegalhold
-  | MessageNotSentClientMissing MessageSendingStatus
-  | MessageNotSentConversationNotFound
-  | MessageNotSentUnknownClient
-  deriving stock (Eq, Show, Generic)
-  deriving (ToJSON, FromJSON) via (CustomEncoded MessageNotSent)
+  deriving (ToJSON, FromJSON) via (Either (CustomEncoded MessageNotSent) MessageSendingStatus)
 
 clientRoutes :: (MonadError FederationClientFailure m, MonadIO m) => Api (AsClientT (FederatorClient 'Proto.Galley m))
 clientRoutes = genericClient

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -171,7 +171,7 @@ data RemoteMessage conv = RemoteMessage
   deriving (ToJSON, FromJSON) via (CustomEncoded (RemoteMessage conv))
 
 data MessageSendRequest = MessageSendRequest
-  { -- | Converastion is assumed to be owned by the target domain, this allows
+  { -- | Conversation is assumed to be owned by the target domain, this allows
     -- us to protect against relay attacks
     msrConvId :: ConvId,
     -- | Sender is assumed to be owned by the origin domain, this allows us to

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -38,7 +38,7 @@ import Wire.API.Federation.Client (FederationClientFailure, FederatorClient)
 import Wire.API.Federation.Domain (OriginDomainHeader)
 import qualified Wire.API.Federation.GRPC.Types as Proto
 import Wire.API.Federation.Util.Aeson (CustomEncoded (..))
-import Wire.API.Message (MessageNotSent, MessageSendingStatus, Priority)
+import Wire.API.Message (MessageNotSent, MessageSendingStatus, PostOtrResponse, Priority)
 import Wire.API.User.Client (UserClientMap)
 
 -- FUTUREWORK: data types, json instances, more endpoints. See
@@ -184,9 +184,14 @@ data MessageSendRequest = MessageSendRequest
   deriving (ToJSON, FromJSON) via (CustomEncoded MessageSendRequest)
 
 newtype MessageSendResponse = MessageSendResponse
-  {msResponse :: Either MessageNotSent MessageSendingStatus}
+  {msResponse :: PostOtrResponse MessageSendingStatus}
   deriving stock (Eq, Show)
-  deriving (ToJSON, FromJSON) via (Either (CustomEncoded MessageNotSent) MessageSendingStatus)
+  deriving
+    (ToJSON, FromJSON)
+    via ( Either
+            (CustomEncoded (MessageNotSent MessageSendingStatus))
+            MessageSendingStatus
+        )
 
 clientRoutes :: (MonadError FederationClientFailure m, MonadIO m) => Api (AsClientT (FederatorClient 'Proto.Galley m))
 clientRoutes = genericClient

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/MessageSendResponse.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/MessageSendResponse.hs
@@ -23,7 +23,7 @@ import Data.Json.Util (toUTCTimeMillis)
 import Data.UUID as UUID
 import GHC.Exts (IsList (fromList))
 import Imports
-import Wire.API.Federation.API.Galley (MessageNotSent (..), MessageSendResponse (..))
+import Wire.API.Federation.API.Galley (MessageSendResponse (..))
 import Wire.API.Message
 import Wire.API.User.Client (QualifiedUserClients (..))
 

--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -36,6 +36,7 @@ library:
   - extended
   - extra
   - generic-random >=1.2
+  - generics-sop
   - ghc-prim
   - hashable
   - hostname-validate

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -332,3 +332,13 @@ type MalformedPrekeys = ErrorDescription 400 "bad-request" "Malformed prekeys up
 
 malformedPrekeys :: MalformedPrekeys
 malformedPrekeys = mkErrorDescription
+
+type MissingLegalholdConsent =
+  ErrorDescription
+    403
+    "missing-legalhold-consent"
+    "Failed to connect to a user or to invite a user to a group because somebody \
+    \is under legalhold and somebody else has not granted consent."
+
+missingLegalholdConsent :: MissingLegalholdConsent
+missingLegalholdConsent = mkErrorDescription

--- a/libs/wire-api/src/Wire/API/Message.hs
+++ b/libs/wire-api/src/Wire/API/Message.hs
@@ -582,7 +582,7 @@ type MessageNotSentResponses a =
 
 type PostOtrResponses a =
   MessageNotSentResponses a
-    .++ '[Respond 201 "Message send" a]
+    .++ '[Respond 201 "Message sent" a]
 
 type PostOtrResponse a = Either (MessageNotSent a) a
 

--- a/libs/wire-api/src/Wire/API/Message.hs
+++ b/libs/wire-api/src/Wire/API/Message.hs
@@ -51,6 +51,7 @@ module Wire.API.Message
     ClientMismatch (..),
     ClientMismatchStrategy (..),
     MessageSendingStatus (..),
+    MessageNotSent (..),
     UserClients (..),
     ReportMissing (..),
     IgnoreMissing (..),
@@ -552,6 +553,13 @@ instance ToSchema MessageSendingStatus where
                    \like when some clients are missing."
             )
             schema
+
+data MessageNotSent
+  = MessageNotSentLegalhold
+  | MessageNotSentClientMissing MessageSendingStatus
+  | MessageNotSentConversationNotFound
+  | MessageNotSentUnknownClient
+  deriving stock (Eq, Show, Generic)
 
 -- QueryParams
 

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -565,7 +565,7 @@ instance
     let acc = getAcceptHeader req
         action' =
           action `addMethodCheck` methodCheck method req
-            `addMethodCheck` acceptCheck (Proxy @cs) acc
+            `addAcceptCheck` acceptCheck (Proxy @cs) acc
     runAction action' env req k $ \output -> do
       let mresp = responseListRender @cs @as acc (toUnion @as output)
       resp' <- case mresp of

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -347,6 +347,11 @@ instance rs ~ ResponseTypes as => AsUnion as (Union rs) where
   toUnion = id
   fromUnion = id
 
+instance AsUnion '[RespondEmpty code desc] () where
+  toUnion () = Z (I ())
+  fromUnion (Z (I ())) = ()
+  fromUnion (S x) = case x of
+
 -- | A handler for a pair of empty responses can be implemented simply by
 -- returning a boolean value. The convention is that the "failure" case, normally
 -- represented by 'False', corresponds to the /first/ response.

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -24,12 +24,19 @@ module Wire.API.Routes.MultiVerb
     DescHeader,
     AsHeaders (..),
     AsUnion (..),
+    eitherToUnion,
+    eitherFromUnion,
+    AsConstructor (..),
+    GenericAsConstructor (..),
+    GenericAsUnion (..),
+    ResponseType,
     IsResponse (..),
     IsSwaggerResponse (..),
     RenderOutput (..),
     roAddContentType,
     roResponse,
     ResponseSwagger (..),
+    ResponseTypes,
     IsResponseList (..),
   )
 where
@@ -46,6 +53,7 @@ import qualified Data.Swagger as S
 import qualified Data.Swagger.Declare as S
 import qualified Data.Text as Text
 import GHC.TypeLits
+import Generics.SOP as GSOP
 import Imports
 import qualified Network.HTTP.Media as M
 import Network.HTTP.Types (HeaderName, hContentType)
@@ -125,15 +133,17 @@ instance MonadPlus UnrenderResult where
 class IsSwaggerResponse a where
   responseSwagger :: Declare ResponseSwagger
 
+type family ResponseType a :: *
+
 class IsResponse cs a where
-  type ResponseType a :: *
   type ResponseStatus a :: Nat
 
   responseRender :: AcceptHeader -> ResponseType a -> Maybe RenderOutput
   responseUnrender :: M.MediaType -> RenderOutput -> UnrenderResult (ResponseType a)
 
+type instance ResponseType (Respond s desc a) = a
+
 instance (AllMimeRender cs a, AllMimeUnrender cs a, KnownStatus s) => IsResponse cs (Respond s desc a) where
-  type ResponseType (Respond s desc a) = a
   type ResponseStatus (Respond s desc a) = s
 
   -- Note: here it seems like we are rendering for all possible content types,
@@ -170,8 +180,9 @@ instance
       desc = Text.pack (symbolVal (Proxy @desc))
       status = statusVal (Proxy @s)
 
+type instance ResponseType (RespondEmpty s desc) = ()
+
 instance KnownStatus s => IsResponse cs (RespondEmpty s desc) where
-  type ResponseType (RespondEmpty s desc) = ()
   type ResponseStatus (RespondEmpty s desc) = s
 
   responseRender _ _ =
@@ -237,6 +248,8 @@ instance
       desc = Text.pack (symbolVal (Proxy @desc))
       sch = S.toParamSchema (Proxy @a)
 
+type instance ResponseType (WithHeaders hs a r) = a
+
 instance
   ( AsHeaders (ServantHeaders hs) (ResponseType r) a,
     GetHeaders' (ServantHeaders hs),
@@ -246,7 +259,6 @@ instance
   ) =>
   IsResponse cs (WithHeaders hs a r)
   where
-  type ResponseType (WithHeaders hs a r) = a
   type ResponseStatus (WithHeaders hs a r) = ResponseStatus r
 
   responseRender acc x =
@@ -275,17 +287,17 @@ instance
 class IsSwaggerResponseList as where
   responseListSwagger :: Declare [ResponseSwagger]
 
-class IsResponseList cs as where
-  type ResponseTypes as :: [*]
+type family ResponseTypes (as :: [*]) where
+  ResponseTypes '[] = '[]
+  ResponseTypes (a ': as) = ResponseType a ': ResponseTypes as
 
+class IsResponseList cs as where
   responseListRender :: AcceptHeader -> Union (ResponseTypes as) -> Maybe RenderOutput
   responseListUnrender :: M.MediaType -> RenderOutput -> UnrenderResult (Union (ResponseTypes as))
 
   responseListStatuses :: [Status]
 
 instance IsResponseList cs '[] where
-  type ResponseTypes '[] = '[]
-
   responseListRender _ x = case x of
   responseListUnrender _ _ = empty
   responseListStatuses = []
@@ -300,8 +312,6 @@ instance
   ) =>
   IsResponseList cs (a ': as)
   where
-  type ResponseTypes (a ': as) = ResponseType a ': ResponseTypes as
-
   responseListRender acc (Z (I x)) = responseRender @cs @a acc x
   responseListRender acc (S x) = responseListRender @cs @as acc x
 
@@ -351,6 +361,121 @@ instance AsUnion '[RespondEmpty code desc] () where
   toUnion () = Z (I ())
   fromUnion (Z (I ())) = ()
   fromUnion (S x) = case x of
+
+class InjectAfter as bs where
+  injectAfter :: Union bs -> Union (as .++ bs)
+
+instance InjectAfter '[] bs where
+  injectAfter = id
+
+instance InjectAfter as bs => InjectAfter (a ': as) bs where
+  injectAfter = S . injectAfter @as @bs
+
+class InjectBefore as bs where
+  injectBefore :: Union as -> Union (as .++ bs)
+
+instance InjectBefore '[] bs where
+  injectBefore x = case x of
+
+instance InjectBefore as bs => InjectBefore (a ': as) bs where
+  injectBefore (Z x) = Z x
+  injectBefore (S x) = S (injectBefore @as @bs x)
+
+eitherToUnion ::
+  forall as bs a b.
+  (InjectAfter as bs, InjectBefore as bs) =>
+  (a -> Union as) ->
+  (b -> Union bs) ->
+  (Either a b -> Union (as .++ bs))
+eitherToUnion f _ (Left a) = injectBefore @as @bs (f a)
+eitherToUnion _ g (Right b) = injectAfter @as @bs (g b)
+
+class EitherFromUnion as bs where
+  eitherFromUnion ::
+    (Union as -> a) ->
+    (Union bs -> b) ->
+    (Union (as .++ bs) -> Either a b)
+
+instance EitherFromUnion '[] bs where
+  eitherFromUnion _ g = Right . g
+
+instance EitherFromUnion as bs => EitherFromUnion (a ': as) bs where
+  eitherFromUnion f _ (Z x) = Left (f (Z x))
+  eitherFromUnion f g (S x) = eitherFromUnion @as @bs (f . S) g x
+
+-- | This class can be instantiated to get automatic derivation of 'AsUnion'
+-- instances via 'GenericAsUnion'. The idea is that one has to make sure that for
+-- each response @r@ in a 'MultiVerb' endpoint, there is an instance of
+-- @AsConstructor xs r@ for some @xs@, and that the list @xss@ of all the
+-- corresponding @xs@ is equal to 'GSOP.Code' of the handler type. Then one can
+-- write:
+-- @
+--   type Responses = ...
+--   data Result = ...
+--     deriving stock (Generic)
+--     deriving (AsUnion Responses) via (GenericAsUnion Responses Result)
+--
+--   instance GSOP.Generic Result
+-- @
+-- and get an 'AsUnion' instance for free.
+--
+-- There are a few predefined instances for constructors taking a single type
+-- corresponding to a simple response, and for empty responses, but in more
+-- general cases one either has to define an 'AsConstructor' instance by hand,
+-- or derive it via 'GenericAsConstructor'.
+class AsConstructor xs r where
+  toConstructor :: ResponseType r -> NP I xs
+  fromConstructor :: NP I xs -> ResponseType r
+
+class AsConstructors xss rs where
+  toSOP :: Union (ResponseTypes rs) -> SOP I xss
+  fromSOP :: SOP I xss -> Union (ResponseTypes rs)
+
+instance AsConstructors '[] '[] where
+  toSOP x = case x of
+  fromSOP x = case x of
+
+instance AsConstructor '[a] (Respond code desc a) where
+  toConstructor x = I x :* Nil
+  fromConstructor = unI . hd
+
+instance AsConstructor '[] (RespondEmpty code desc) where
+  toConstructor _ = Nil
+  fromConstructor _ = ()
+
+newtype GenericAsConstructor r = GenericAsConstructor r
+
+type instance ResponseType (GenericAsConstructor r) = ResponseType r
+
+instance
+  (GSOP.Code (ResponseType r) ~ '[xs], GSOP.Generic (ResponseType r)) =>
+  AsConstructor xs (GenericAsConstructor r)
+  where
+  toConstructor = unZ . unSOP . GSOP.from
+  fromConstructor = GSOP.to . SOP . Z
+
+instance
+  (AsConstructor xs r, AsConstructors xss rs) =>
+  AsConstructors (xs ': xss) (r ': rs)
+  where
+  toSOP (Z (I x)) = SOP . Z $ toConstructor @xs @r x
+  toSOP (S x) = SOP . S . unSOP $ toSOP @xss @rs x
+
+  fromSOP (SOP (Z x)) = Z (I (fromConstructor @xs @r x))
+  fromSOP (SOP (S x)) = S (fromSOP @xss @rs (SOP x))
+
+-- | This type is meant to be used with @deriving via@ in order to automatically
+-- generate an 'AsUnion' instance using 'Generics.SOP'.
+--
+-- See 'AsConstructor' for more information and examples.
+newtype GenericAsUnion rs a = GenericAsUnion a
+
+instance
+  (GSOP.Code a ~ xss, GSOP.Generic a, AsConstructors xss rs) =>
+  AsUnion rs (GenericAsUnion rs a)
+  where
+  toUnion (GenericAsUnion x) = fromSOP @xss @rs (GSOP.from x)
+  fromUnion = GenericAsUnion . GSOP.to . toSOP @xss @rs
 
 -- | A handler for a pair of empty responses can be implemented simply by
 -- returning a boolean value. The convention is that the "failure" case, normally

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -43,7 +43,7 @@ import Wire.API.ErrorDescription
     UserNotFound,
   )
 import Wire.API.Routes.MultiVerb
-import Wire.API.Routes.Public (EmptyResult, ZConn, ZUser)
+import Wire.API.Routes.Public (ZConn, ZUser)
 import Wire.API.Routes.QualifiedCapture
 import Wire.API.User
 import Wire.API.User.Client
@@ -267,7 +267,7 @@ data Api routes = Api
         :> "clients"
         :> CaptureClientId "client"
         :> ReqBody '[JSON] UpdateClient
-        :> Put '[] (EmptyResult 200),
+        :> MultiVerb 'PUT '[] '[RespondEmpty 200 "Client updated"] (),
     -- This endpoint can lead to the following events being sent:
     -- - ClientRemoved event to self
     deleteClient ::
@@ -277,7 +277,7 @@ data Api routes = Api
         :> "clients"
         :> CaptureClientId "client"
         :> ReqBody '[JSON] RmClient
-        :> Delete '[] (EmptyResult 200),
+        :> MultiVerb 'DELETE '[] '[RespondEmpty 200 "Client deleted"] (),
     listClients ::
       routes :- Summary "List the registered clients"
         :> ZUser

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -267,7 +267,7 @@ data Api routes = Api
         :> "clients"
         :> CaptureClientId "client"
         :> ReqBody '[JSON] UpdateClient
-        :> MultiVerb 'PUT '[] '[RespondEmpty 200 "Client updated"] (),
+        :> MultiVerb 'PUT '[JSON] '[RespondEmpty 200 "Client updated"] (),
     -- This endpoint can lead to the following events being sent:
     -- - ClientRemoved event to self
     deleteClient ::
@@ -277,7 +277,7 @@ data Api routes = Api
         :> "clients"
         :> CaptureClientId "client"
         :> ReqBody '[JSON] RmClient
-        :> MultiVerb 'DELETE '[] '[RespondEmpty 200 "Client deleted"] (),
+        :> MultiVerb 'DELETE '[JSON] '[RespondEmpty 200 "Client deleted"] (),
     listClients ::
       routes :- Summary "List the registered clients"
         :> ZUser

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -39,7 +39,7 @@ import Wire.API.ErrorDescription
 import qualified Wire.API.Event.Conversation as Public
 import Wire.API.Message
 import Wire.API.Routes.MultiVerb
-import Wire.API.Routes.Public (EmptyResult, ZConn, ZUser)
+import Wire.API.Routes.Public (ZConn, ZUser)
 import Wire.API.Routes.QualifiedCapture
 import Wire.API.ServantProto (Proto, RawProto)
 import qualified Wire.API.Team.Conversation as Public
@@ -283,7 +283,7 @@ data Api routes = Api
         :> Capture "tid" TeamId
         :> "conversations"
         :> Capture "cid" ConvId
-        :> Delete '[] (EmptyResult 200),
+        :> MultiVerb 'DELETE '[] '[RespondEmpty 200 "Conversation deleted"] (),
     postOtrMessageUnqualified ::
       routes
         :- Summary "Post an encrypted message to a conversation (accepts JSON or Protobuf)"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -283,7 +283,7 @@ data Api routes = Api
         :> Capture "tid" TeamId
         :> "conversations"
         :> Capture "cid" ConvId
-        :> MultiVerb 'DELETE '[] '[RespondEmpty 200 "Conversation deleted"] (),
+        :> MultiVerb 'DELETE '[JSON] '[RespondEmpty 200 "Conversation deleted"] (),
     postOtrMessageUnqualified ::
       routes
         :- Summary "Post an encrypted message to a conversation (accepts JSON or Protobuf)"

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 51eb96bf37999a61021ffce3cf4fdb0ac87752f9fe570564d30a06530ec1e844
+-- hash: c6b3b26309d37316c1e5f29b10e0a9fba3ab066898d161965fd20fa531237a89
 
 name:           wire-api
 version:        0.1.0
@@ -116,6 +116,7 @@ library
     , extended
     , extra
     , generic-random >=1.2
+    , generics-sop
     , ghc-prim
     , hashable
     , hostname-validate

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -94,7 +94,7 @@ connError (ConnectBlacklistedUserKey k) = StdError $ foldKey (const blacklistedE
 connError (ConnectInvalidEmail _ _) = StdError invalidEmail
 connError ConnectInvalidPhone {} = StdError invalidPhone
 connError ConnectSameBindingTeamUsers = StdError sameBindingTeamUsers
-connError ConnectMissingLegalholdConsent = StdError missingLegalholdConsent
+connError ConnectMissingLegalholdConsent = StdError (errorDescriptionToWai missingLegalholdConsent)
 
 actError :: ActivationError -> Error
 actError (UserKeyExists _) = StdError userKeyExists
@@ -203,7 +203,7 @@ clientError ClientLegalHoldCannotBeRemoved = StdError can'tDeleteLegalHoldClient
 clientError ClientLegalHoldCannotBeAdded = StdError can'tAddLegalHoldClient
 clientError (ClientFederationError e) = fedError e
 clientError ClientCapabilitiesCannotBeRemoved = StdError clientCapabilitiesCannotBeRemoved
-clientError ClientMissingLegalholdConsent = StdError missingLegalholdConsent
+clientError ClientMissingLegalholdConsent = StdError (errorDescriptionToWai missingLegalholdConsent)
 
 fedError :: FederationError -> Error
 fedError = StdError . federationErrorToWai
@@ -455,10 +455,6 @@ propertyManagedByScim prop = Wai.mkError status403 "managed-by-scim" $ "Updating
 
 sameBindingTeamUsers :: Wai.Error
 sameBindingTeamUsers = Wai.mkError status403 "same-binding-team-users" "Operation not allowed to binding team users."
-
--- | See 'Galley.API.Error.missingLegalholdConsent'.
-missingLegalholdConsent :: Wai.Error
-missingLegalholdConsent = Wai.mkError status403 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
 
 ownerDeletingSelf :: Wai.Error
 ownerDeletingSelf =

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -94,7 +94,6 @@ import Util.Logging (logFunction, logHandle, logTeam, logUser)
 import qualified Wire.API.Connection as Public
 import Wire.API.ErrorDescription
 import qualified Wire.API.Properties as Public
-import Wire.API.Routes.Public (EmptyResult (..))
 import qualified Wire.API.Routes.Public.Brig as BrigAPI
 import qualified Wire.API.Routes.Public.Galley as GalleyAPI
 import qualified Wire.API.Routes.Public.LegalHold as LegalHoldAPI
@@ -796,15 +795,12 @@ addClient usr con ip new = do
     clientResponse :: Public.Client -> BrigAPI.NewClientResponse
     clientResponse client = Servant.addHeader (Public.clientId client) client
 
-deleteClient :: UserId -> ConnId -> ClientId -> Public.RmClient -> Handler (EmptyResult 200)
-deleteClient usr con clt body = do
+deleteClient :: UserId -> ConnId -> ClientId -> Public.RmClient -> Handler ()
+deleteClient usr con clt body =
   API.rmClient usr con clt (Public.rmPassword body) !>> clientError
-  pure EmptyResult
 
-updateClient :: UserId -> ClientId -> Public.UpdateClient -> Handler (EmptyResult 200)
-updateClient usr clt upd = do
-  API.updateClient usr clt upd !>> clientError
-  pure EmptyResult
+updateClient :: UserId -> ClientId -> Public.UpdateClient -> Handler ()
+updateClient usr clt upd = API.updateClient usr clt upd !>> clientError
 
 listClients :: UserId -> Handler [Public.Client]
 listClients zusr =

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -49,6 +49,7 @@ import Network.Wai
 import Network.Wai.Predicate hiding (setStatus)
 import Network.Wai.Utilities
 import qualified Wire.API.Conversation as Public
+import Wire.API.ErrorDescription (missingLegalholdConsent)
 import Wire.API.Routes.Public.Galley
   ( ConversationResponse,
     ConversationResponseFor (..),
@@ -89,7 +90,7 @@ ensureNoLegalholdConflicts remotes locals = do
   let FutureWork _remotes = FutureWork @'LegalholdPlusFederationNotImplemented remotes
   whenM (anyLegalholdActivated locals) $
     unlessM (allLegalholdConsentGiven locals) $
-      throwM missingLegalholdConsent
+      throwErrorDescription missingLegalholdConsent
 
 -- | A helper for creating a regular (non-team) group conversation.
 createRegularGroupConv :: UserId -> ConnId -> NewConvUnmanaged -> Galley ConversationResponse

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -209,18 +209,6 @@ noLegalHoldDeviceAllocated = mkError status404 "legalhold-no-device-allocated" "
 legalHoldCouldNotBlockConnections :: Error
 legalHoldCouldNotBlockConnections = mkError status500 "legalhold-internal" "legal hold service: could not block connections when resolving policy conflicts."
 
--- | See 'Brig.API.Error.missingLegalholdConsent'.
---
--- FUTUREWORK: To avoid this duplication, you could turn this into an `ErrorDescription` and
--- move it to the `ErrorDescription` module in wire-api, where it can then be used from both
--- brig and galley. Also, it makes it easier to add it to swagger, if desired, or even later
--- turn it into a statically checked response with `MultiVerb`.
---
--- For examples, see https://github.com/wireapp/wire-server/pull/1657 or
--- https://github.com/wireapp/wire-server/pull/1657/commits/8e73769d7d4a657fef5fbe9210f885f9ccbcaab6.
-missingLegalholdConsent :: Error
-missingLegalholdConsent = mkError status403 "missing-legalhold-consent" "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent."
-
 disableSsoNotImplemented :: Error
 disableSsoNotImplemented =
   mkError

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -28,7 +28,7 @@ where
 import qualified Cassandra as Cql
 import Control.Exception.Safe (catchAny)
 import Control.Lens hiding ((.=))
-import Control.Monad.Catch (MonadCatch, MonadThrow (throwM))
+import Control.Monad.Catch (MonadCatch)
 import Data.Id as Id
 import Data.List1 (List1, list1, maybeList1)
 import Data.Range
@@ -37,7 +37,7 @@ import GHC.TypeLits (AppendSymbol)
 import qualified Galley.API.Clients as Clients
 import qualified Galley.API.Create as Create
 import qualified Galley.API.CustomBackend as CustomBackend
-import Galley.API.Error (missingLegalholdConsent)
+import Galley.API.Error (throwErrorDescription)
 import Galley.API.LegalHold (getTeamLegalholdWhitelistedH, setTeamLegalholdWhitelistedH, unsetTeamLegalholdWhitelistedH)
 import Galley.API.LegalHold.Conflicts (guardLegalholdPolicyConflicts)
 import qualified Galley.API.Query as Query
@@ -71,6 +71,7 @@ import Servant.API.Generic
 import Servant.Server
 import Servant.Server.Generic (genericServerT)
 import System.Logger.Class hiding (Path, name)
+import Wire.API.ErrorDescription (missingLegalholdConsent)
 import qualified Wire.API.Team.Feature as Public
 
 data InternalApi routes = InternalApi
@@ -491,5 +492,5 @@ guardLegalholdPolicyConflictsH :: (JsonRequest GuardLegalholdPolicyConflicts :::
 guardLegalholdPolicyConflictsH (req ::: _) = do
   glh <- fromJsonBody req
   guardLegalholdPolicyConflicts (glhProtectee glh) (glhUserClients glh)
-    >>= either (const (throwM missingLegalholdConsent)) pure
+    >>= either (const (throwErrorDescription missingLegalholdConsent)) pure
   pure $ Network.Wai.Utilities.setStatus status200 empty

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -17,14 +17,11 @@ import Data.Json.Util
 import Data.List1 (singleton)
 import qualified Data.Map as Map
 import Data.Map.Lens (toMapOf)
-import Data.Proxy
 import Data.Qualified (Qualified (..), partitionRemote)
-import Data.SOP (I (..), htrans, unI)
 import qualified Data.Set as Set
 import Data.Set.Lens
 import Data.Tagged (unTagged)
 import Data.Time.Clock (UTCTime, getCurrentTime)
-import Galley.API.Error (throwErrorDescription)
 import Galley.API.LegalHold.Conflicts (guardQualifiedLegalholdPolicyConflicts)
 import Galley.API.Util
   ( runFederatedBrig,
@@ -43,19 +40,14 @@ import qualified Galley.Types.Clients as Clients
 import Galley.Types.Conversations.Members
 import Gundeck.Types.Push.V2 (RecipientClients (..))
 import Imports
-import qualified Servant
-import Servant.API (Union, WithStatus (..))
 import qualified System.Logger.Class as Log
 import UnliftIO.Async
-import Wire.API.ErrorDescription as ErrorDescription
 import Wire.API.Event.Conversation
 import qualified Wire.API.Federation.API.Brig as FederatedBrig
 import qualified Wire.API.Federation.API.Galley as FederatedGalley
 import Wire.API.Federation.Client (FederationError, executeFederated)
 import Wire.API.Federation.Error (federationErrorToWai)
 import Wire.API.Message
-import qualified Wire.API.Message as Public
-import Wire.API.Routes.Public.Galley as Public
 import Wire.API.Team.LegalHold
 import Wire.API.User.Client
 import Wire.API.UserMap (UserMap (..))
@@ -205,7 +197,7 @@ postRemoteOtrMessage ::
   Qualified UserId ->
   Qualified ConvId ->
   LByteString ->
-  Galley (Union Public.PostOtrResponses)
+  Galley (PostOtrResponse MessageSendingStatus)
 postRemoteOtrMessage sender conv rawMsg = do
   let msr =
         FederatedGalley.MessageSendRequest
@@ -214,17 +206,9 @@ postRemoteOtrMessage sender conv rawMsg = do
             FederatedGalley.msrRawMessage = Base64ByteString rawMsg
           }
       rpc = FederatedGalley.sendMessage FederatedGalley.clientRoutes (qDomain sender) msr
-  mkPostOtrResponsesUnion . FederatedGalley.msResponse =<< runFederatedGalley (qDomain conv) rpc
+  FederatedGalley.msResponse <$> runFederatedGalley (qDomain conv) rpc
 
-mkPostOtrResponsesUnion :: Either MessageNotSent MessageSendingStatus -> Galley (Union Public.PostOtrResponses)
-mkPostOtrResponsesUnion (Right mss) = Servant.respond (WithStatus @201 mss)
-mkPostOtrResponsesUnion (Left reason) = case reason of
-  MessageNotSentClientMissing mss -> Servant.respond (WithStatus @412 mss)
-  MessageNotSentUnknownClient -> Servant.respond ErrorDescription.unknownClient
-  MessageNotSentConversationNotFound -> Servant.respond ErrorDescription.convNotFound
-  MessageNotSentLegalhold -> throwErrorDescription missingLegalholdConsent
-
-postQualifiedOtrMessage :: UserType -> Qualified UserId -> Maybe ConnId -> ConvId -> Public.QualifiedNewOtrMessage -> Galley (Either MessageNotSent Public.MessageSendingStatus)
+postQualifiedOtrMessage :: UserType -> Qualified UserId -> Maybe ConnId -> ConvId -> QualifiedNewOtrMessage -> Galley (PostOtrResponse MessageSendingStatus)
 postQualifiedOtrMessage senderType sender mconn convId msg = runExceptT $ do
   alive <- Data.isConvAlive convId
   localDomain <- viewFederationDomain
@@ -486,18 +470,18 @@ data MessageMetadata = MessageMetadata
   }
   deriving (Eq, Ord, Show)
 
-qualifiedNewOtrMetadata :: Public.QualifiedNewOtrMessage -> MessageMetadata
+qualifiedNewOtrMetadata :: QualifiedNewOtrMessage -> MessageMetadata
 qualifiedNewOtrMetadata msg =
   MessageMetadata
-    { mmNativePush = Public.qualifiedNewOtrNativePush msg,
-      mmTransient = Public.qualifiedNewOtrTransient msg,
-      mmNativePriority = Public.qualifiedNewOtrNativePriority msg,
-      mmData = Public.qualifiedNewOtrData msg
+    { mmNativePush = qualifiedNewOtrNativePush msg,
+      mmTransient = qualifiedNewOtrTransient msg,
+      mmNativePriority = qualifiedNewOtrNativePriority msg,
+      mmData = qualifiedNewOtrData msg
     }
 
 -- unqualified
 
-legacyClientMismatchStrategy :: Domain -> Maybe [UserId] -> Maybe Public.IgnoreMissing -> Maybe Public.ReportMissing -> ClientMismatchStrategy
+legacyClientMismatchStrategy :: Domain -> Maybe [UserId] -> Maybe IgnoreMissing -> Maybe ReportMissing -> ClientMismatchStrategy
 legacyClientMismatchStrategy localDomain (Just uids) _ _ =
   MismatchReportOnly (Set.fromList (map (`Qualified` localDomain) uids))
 legacyClientMismatchStrategy _ Nothing (Just IgnoreMissingAll) _ = MismatchIgnoreAll
@@ -514,12 +498,6 @@ class Unqualify a b where
 instance Unqualify a a where
   unqualify _ = id
 
-instance
-  Unqualify a b =>
-  Unqualify (WithStatus c a) (WithStatus c b)
-  where
-  unqualify domain (WithStatus x) = WithStatus (unqualify domain x)
-
 instance Unqualify MessageSendingStatus ClientMismatch where
   unqualify domain status =
     ClientMismatch
@@ -535,5 +513,6 @@ instance Unqualify QualifiedUserClients UserClients where
       . Map.findWithDefault mempty domain
       . qualifiedUserClients
 
-instance Unqualify (Union PostOtrResponses) (Union PostOtrResponsesUnqualified) where
-  unqualify domain = htrans (Proxy @Unqualify) $ I . unqualify domain . unI
+instance Unqualify a b => Unqualify (PostOtrResponse a) (PostOtrResponse b) where
+  unqualify domain (Left a) = Left (unqualify domain <$> a)
+  unqualify domain (Right a) = Right (unqualify domain a)

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -1,7 +1,6 @@
 module Galley.API.Message where
 
 import Control.Lens
-import Control.Monad.Catch (throwM)
 import Control.Monad.Except (throwError)
 import Control.Monad.Extra (eitherM)
 import Control.Monad.Trans.Except (runExceptT)
@@ -25,7 +24,7 @@ import qualified Data.Set as Set
 import Data.Set.Lens
 import Data.Tagged (unTagged)
 import Data.Time.Clock (UTCTime, getCurrentTime)
-import Galley.API.Error (missingLegalholdConsent)
+import Galley.API.Error (throwErrorDescription)
 import Galley.API.LegalHold.Conflicts (guardQualifiedLegalholdPolicyConflicts)
 import Galley.API.Util
   ( runFederatedBrig,
@@ -223,7 +222,7 @@ mkPostOtrResponsesUnion (Left reason) = case reason of
   MessageNotSentClientMissing mss -> Servant.respond (WithStatus @412 mss)
   MessageNotSentUnknownClient -> Servant.respond ErrorDescription.unknownClient
   MessageNotSentConversationNotFound -> Servant.respond ErrorDescription.convNotFound
-  MessageNotSentLegalhold -> throwM missingLegalholdConsent
+  MessageNotSentLegalhold -> throwErrorDescription missingLegalholdConsent
 
 postQualifiedOtrMessage :: UserType -> Qualified UserId -> Maybe ConnId -> ConvId -> Public.QualifiedNewOtrMessage -> Galley (Either MessageNotSent Public.MessageSendingStatus)
 postQualifiedOtrMessage senderType sender mconn convId msg = runExceptT $ do

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -116,7 +116,6 @@ import UnliftIO (mapConcurrently)
 import qualified Wire.API.Conversation.Role as Public
 import Wire.API.ErrorDescription (convNotFound, notATeamMember, operationDenied)
 import qualified Wire.API.Notification as Public
-import Wire.API.Routes.Public (EmptyResult (..))
 import qualified Wire.API.Team as Public
 import qualified Wire.API.Team.Conversation as Public
 import Wire.API.Team.Export (TeamExportUser (..))
@@ -761,7 +760,7 @@ getTeamConversation zusr tid cid = do
     throwErrorDescription (operationDenied GetTeamConversations)
   Data.teamConversation tid cid >>= maybe (throwErrorDescription convNotFound) pure
 
-deleteTeamConversation :: UserId -> ConnId -> TeamId -> ConvId -> Galley (EmptyResult 200)
+deleteTeamConversation :: UserId -> ConnId -> TeamId -> ConvId -> Galley ()
 deleteTeamConversation zusr zcon tid cid = do
   localDomain <- viewFederationDomain
   let qconvId = Qualified cid localDomain
@@ -778,7 +777,6 @@ deleteTeamConversation zusr zcon tid cid = do
   -- TODO: we don't delete bots here, but we should do that, since every
   -- bot user can only be in a single conversation
   Data.removeTeamConv tid cid
-  pure EmptyResult
 
 getSearchVisibilityH :: UserId ::: TeamId ::: JSON -> Galley Response
 getSearchVisibilityH (uid ::: tid ::: _) = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -103,7 +103,6 @@ import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Predicate hiding (and, failure, setStatus, _1, _2)
 import Network.Wai.Utilities
-import Servant.API.UVerb
 import qualified System.Logger.Class as Log
 import Wire.API.Conversation (InviteQualified (invQRoleName))
 import qualified Wire.API.Conversation as Public
@@ -120,7 +119,6 @@ import qualified Wire.API.Event.Conversation as Public
 import Wire.API.Federation.API.Galley (RemoteMessage (..))
 import qualified Wire.API.Message as Public
 import Wire.API.Routes.Public.Galley (UpdateResult (..))
-import qualified Wire.API.Routes.Public.Galley as GalleyAPI
 import Wire.API.ServantProto (RawProto (..))
 import Wire.API.Team.LegalHold (LegalholdProtectee (..))
 import Wire.API.User.Client
@@ -646,15 +644,15 @@ postBotMessage zbot zcnv val message = do
 -- | FUTUREWORK: Send message to remote users, as of now this function fails if
 -- the conversation is not hosted on current backend. If the conversation is
 -- hosted on current backend, it completely ignores remote users.
-postProteusMessage :: UserId -> ConnId -> Qualified ConvId -> RawProto Public.QualifiedNewOtrMessage -> Galley (Union GalleyAPI.PostOtrResponses)
+postProteusMessage :: UserId -> ConnId -> Qualified ConvId -> RawProto Public.QualifiedNewOtrMessage -> Galley (Public.PostOtrResponse Public.MessageSendingStatus)
 postProteusMessage zusr zcon conv msg = do
   localDomain <- viewFederationDomain
   let sender = Qualified zusr localDomain
   if localDomain /= qDomain conv
     then postRemoteOtrMessage sender conv (rpRaw msg)
-    else mkPostOtrResponsesUnion =<< postQualifiedOtrMessage User sender (Just zcon) (qUnqualified conv) (rpValue msg)
+    else postQualifiedOtrMessage User sender (Just zcon) (qUnqualified conv) (rpValue msg)
 
-postOtrMessageUnqualified :: UserId -> ConnId -> ConvId -> Maybe Public.IgnoreMissing -> Maybe Public.ReportMissing -> Public.NewOtrMessage -> Galley (Union GalleyAPI.PostOtrResponsesUnqualified)
+postOtrMessageUnqualified :: UserId -> ConnId -> ConvId -> Maybe Public.IgnoreMissing -> Maybe Public.ReportMissing -> Public.NewOtrMessage -> Galley (Public.PostOtrResponse Public.ClientMismatch)
 postOtrMessageUnqualified zusr zcon cnv ignoreMissing reportMissing message = do
   localDomain <- viewFederationDomain
   let sender = Qualified zusr localDomain
@@ -679,9 +677,7 @@ postOtrMessageUnqualified zusr zcon cnv ignoreMissing reportMissing message = do
             Public.qualifiedNewOtrClientMismatchStrategy = clientMismatchStrategy
           }
   unqualify localDomain
-    <$> ( mkPostOtrResponsesUnion
-            =<< postQualifiedOtrMessage User sender (Just zcon) cnv qualifiedMessage
-        )
+    <$> postQualifiedOtrMessage User sender (Just zcon) cnv qualifiedMessage
 
 postProtoOtrBroadcastH :: UserId ::: ConnId ::: Public.OtrFilterMissing ::: Request ::: JSON -> Galley Response
 postProtoOtrBroadcastH (zusr ::: zcon ::: val ::: req ::: _) = do


### PR DESCRIPTION
This PR completely removes `UVerb` from the codebase, as well as the `EmptyResult` kludge that we needed to generate empty responses. Both are now replaced by `MultiVerb`.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
