### PR TITLE
Fix the Order of Arguments to a Test Assertion

### DIFF
--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -169,7 +169,7 @@ addLocalUser = do
     Cql.runClient cassState
       . Cql.query Cql.selectUserRemoteConvs
       $ Cql.params Cql.Quorum (Identity alice)
-  liftIO $ [(dom, conv)] @?= convs
+  liftIO $ convs @?= [(dom, conv)]
 
 notifyLocalUser :: TestM ()
 notifyLocalUser = do


### PR DESCRIPTION
This is a rather small and insignificant change, hence I haven't added a change log.

The one-line change just puts the expected and actual value arguments to `(@?=)` in the correct order in a federation test.


## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
