### PR TITLE
Bump hscim version / fix flaky test

### DIFF
--- a/libs/hscim/hscim.cabal
+++ b/libs/hscim/hscim.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: b8d0589f22bc168d16fa3a2b2800d9cc3b14b4d94bb911fe973ccf2a2025e5e5
 
 name:           hscim
-version:        0.3.4
+version:        0.3.5
 synopsis:       hscim json schema and server implementation
 description:    The README file will answer all the questions you might have
 category:       Web

--- a/libs/hscim/package.yaml
+++ b/libs/hscim/package.yaml
@@ -1,5 +1,5 @@
 name:                hscim
-version:             0.3.4
+version:             0.3.5
 synopsis:            hscim json schema and server implementation
 description:         The README file will answer all the questions you might have
 homepage:            https://github.com/wireapp/wire-server/libs/hscim/README.md

--- a/libs/hscim/src/Web/Scim/Client.hs
+++ b/libs/hscim/src/Web/Scim/Client.hs
@@ -32,7 +32,7 @@ module Web.Scim.Client
     getUser,
     postUser,
     putUser,
-    patchUserr,
+    patchUser,
     deleteUser,
 
     -- * group
@@ -143,14 +143,14 @@ putUser ::
   IO (StoredUser tag)
 putUser env tok = case users (scimClients env) tok of ((_ :<|> (_ :<|> _)) :<|> (r :<|> (_ :<|> _))) -> r
 
-patchUserr ::
+patchUser ::
   HasScimClient tag =>
   ClientEnv ->
   Maybe (AuthData tag) ->
   UserId tag ->
   PatchOp tag ->
   IO (StoredUser tag)
-patchUserr env tok = case users (scimClients env) tok of ((_ :<|> (_ :<|> _)) :<|> (_ :<|> (r :<|> _))) -> r
+patchUser env tok = case users (scimClients env) tok of ((_ :<|> (_ :<|> _)) :<|> (_ :<|> (r :<|> _))) -> r
 
 deleteUser ::
   forall tag.

--- a/libs/hscim/test/Test/Schema/MetaSchemaSpec.hs
+++ b/libs/hscim/test/Test/Schema/MetaSchemaSpec.hs
@@ -47,10 +47,11 @@ prop_roundtrip gen = property $ do
 spec :: Spec
 spec = do
   describe "MetaSchema" $ do
+    -- the extra 'decode' in the golden tests is to make attribute order not count for Eq.
     it "`Supported ()` golden test" $ do
-      encode (Supported (ScimBool True) ()) `shouldBe` "{\"supported\":true}"
+      decode @Value (encode (Supported (ScimBool True) ())) `shouldBe` decode @Value ("{\"supported\":true}")
     it "`Supported a` golden test" $ do
-      encode (Supported (ScimBool True) (FilterConfig 3)) `shouldBe` "{\"supported\":true,\"maxResults\":3}"
+      decode @Value (encode (Supported (ScimBool True) (FilterConfig 3))) `shouldBe` decode @Value "{\"supported\":true,\"maxResults\":3}"
     it "`Supported ()` roundtrips" $ do
       require (prop_roundtrip (genSupported (pure ())))
     it "`BulkConfig` roundtrips" $ do


### PR DESCRIPTION
Inspired by another upload to hackage: https://hackage.haskell.org/package/hscim-0.3.5

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
