### PR TITLE
Make mapping between (team) permissions and roles more lenient.

### DIFF
--- a/CHANGELOG-draft.md
+++ b/CHANGELOG-draft.md
@@ -41,6 +41,7 @@ THIS FILE ACCUMULATES THE RELEASE NOTES FOR THE UPCOMING RELEASE.
 
 * Integration test script now displays output interactively (#1700)
 * Fixed a few issues with error response documentation in Swagger (#1707)
+* Make mapping between (team) permissions and roles more lenient (#1711)
 
 ## Federation changes
 

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -149,13 +149,14 @@ rolePermissions :: Role -> Permissions
 rolePermissions role = Permissions p p where p = rolePerms role
 
 permissionsRole :: Permissions -> Maybe Role
-permissionsRole (Permissions p p') = if p /= p'
-  then do
-    -- we never did use @p /= p'@ for anything, fingers crossed that it doesn't occur anywhere
-    -- in the wild.  but if it does, this implementation prevents privilege escalation.
-    let p'' = Set.intersection p p'
-     in permissionsRole (Permissions p'' p'')
-  else permsRole p
+permissionsRole (Permissions p p') =
+  if p /= p'
+    then do
+      -- we never did use @p /= p'@ for anything, fingers crossed that it doesn't occur anywhere
+      -- in the wild.  but if it does, this implementation prevents privilege escalation.
+      let p'' = Set.intersection p p'
+       in permissionsRole (Permissions p'' p'')
+    else permsRole p
   where
     permsRole :: Set Perm -> Maybe Role
     permsRole perms =

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -161,12 +161,12 @@ permissionsRole (Permissions p p') = if p /= p'
     permsRole perms =
       Maybe.listToMaybe
         [ role
-          | (perms', role) <- reverse . sortOn (length . fst) $ (\r -> (rolePerms r, r)) <$> [minBound ..],
+          | role <- [minBound ..],
             -- if a there is a role that is strictly less permissive than the perms set that
             -- we encounter, we downgrade.  this shouldn't happen in real life, but it has
             -- happened to very old users on a staging environment, where a user (probably)
             -- was create before the current publicly visible permissions had been stabilized.
-            perms' `Set.isSubsetOf` perms
+            rolePerms role `Set.isSubsetOf` perms
         ]
 
 -- | Internal function for 'rolePermissions'.  (It works iff the two sets in 'Permissions' are

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -149,13 +149,13 @@ rolePermissions :: Role -> Permissions
 rolePermissions role = Permissions p p where p = rolePerms role
 
 permissionsRole :: Permissions -> Maybe Role
-permissionsRole (Permissions p p')
-  | p /= p' =
+permissionsRole (Permissions p p') = if p /= p'
+  then do
     -- we never did use @p /= p'@ for anything, fingers crossed that it doesn't occur anywhere
     -- in the wild.  but if it does, this implementation prevents privilege escalation.
     let p'' = Set.intersection p p'
      in permissionsRole (Permissions p'' p'')
-permissionsRole (Permissions p _) = permsRole p
+  else permsRole p
   where
     permsRole :: Set Perm -> Maybe Role
     permsRole perms =

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -161,7 +161,7 @@ permissionsRole (Permissions p p') = if p /= p'
     permsRole perms =
       Maybe.listToMaybe
         [ role
-          | (perms', role) <- reverse . sortBy (compare `on` (length . fst)) $ (\r -> (rolePerms r, r)) <$> [minBound ..],
+          | (perms', role) <- reverse . sortOn (length . fst) $ (\r -> (rolePerms r, r)) <$> [minBound ..],
             -- if a there is a role that is strictly less permissive than the perms set that
             -- we encounter, we downgrade.  this shouldn't happen in real life, but it has
             -- happened to very old users on a staging environment, where a user (probably)

--- a/libs/galley-types/test/unit/Test/Galley/Types.hs
+++ b/libs/galley-types/test/unit/Test/Galley/Types.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans -Wno-incomplete-uni-patterns #-}
 
 -- This file is part of the Wire Server implementation.
 --
@@ -23,14 +23,15 @@ module Test.Galley.Types where
 
 import Control.Lens
 import Data.Set hiding (drop)
+import qualified Data.Set as Set
 import Galley.Types.Teams
 import Galley.Types.Teams.Intra (GuardLegalholdPolicyConflicts)
 import Imports
 import Test.Galley.Roundtrip (testRoundTrip)
-import Test.QuickCheck (Arbitrary (arbitrary))
 import qualified Test.QuickCheck as QC
 import Test.Tasty
 import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
 
 tests :: TestTree
 tests =
@@ -54,7 +55,35 @@ tests =
         -- this test, and force future develpers to consider what permissions they want to set.
         assertBool "all covered" (all (roleHasPerm RoleExternalPartner) (ViewTeamFeature <$> [minBound ..])),
       testRoundTrip @FeatureFlags,
-      testRoundTrip @GuardLegalholdPolicyConflicts
+      testRoundTrip @GuardLegalholdPolicyConflicts,
+      testGroup
+        "permissionsRole, rolePermissions"
+        [ testCase "'Role' maps to expected permissions" $ do
+            assertEqual "role type changed" [minBound ..] [RoleOwner, RoleAdmin, RoleMember, RoleExternalPartner]
+            assertEqual "owner" (permissionsRole =<< newPermissions (intToPerms 8191) (intToPerms 8191)) (Just RoleOwner)
+            assertEqual "admin" (permissionsRole =<< newPermissions (intToPerms 5951) (intToPerms 5951)) (Just RoleAdmin)
+            assertEqual "member" (permissionsRole =<< newPermissions (intToPerms 1587) (intToPerms 1587)) (Just RoleMember)
+            assertEqual "external partner" (permissionsRole =<< newPermissions (intToPerms 1025) (intToPerms 1025)) (Just RoleExternalPartner),
+          testCase "Role <-> Permissions roundtrip" $ do
+            assertEqual "admin" (permissionsRole . rolePermissions <$> [minBound ..]) (Just <$> [minBound ..]),
+          testProperty "Random, incoherent 'Permission' values gracefully translate to subsets." $
+            let fakeSort (w, w') = (w `Set.union` w', w')
+             in \(fakeSort -> (w, w')) -> do
+                  let Just perms = newPermissions w w'
+                  case permissionsRole perms of
+                    Just role -> do
+                      let perms' = rolePermissions role
+                      assertEqual "eq" (perms' ^. self) (perms' ^. copy)
+                      assertBool "self" ((perms' ^. self) `Set.isSubsetOf` (perms ^. self))
+                      assertBool "copy" ((perms' ^. copy) `Set.isSubsetOf` (perms ^. copy))
+                    Nothing -> do
+                      let leastPermissions = rolePermissions maxBound
+                      assertBool "no role for perms, but strictly more perms than max role" $
+                        not
+                          ( (leastPermissions ^. self) `Set.isSubsetOf` w
+                              && (leastPermissions ^. copy) `Set.isSubsetOf` w'
+                          )
+        ]
     ]
 
 instance Arbitrary FeatureFlags where


### PR DESCRIPTION
shouldn't change behavior for any existing users, but i found a user in our staging env that has an unknown set of permissions, and for that user is should fix https://wearezeta.atlassian.net/browse/SQSERVICES-720.

I've explained things in comments in the code, where we'll be able to find it in the future.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
