### PR TITLE
Fix hscim serialization

### DIFF
--- a/CHANGELOG-draft.md
+++ b/CHANGELOG-draft.md
@@ -35,6 +35,8 @@ THIS FILE ACCUMULATES THE RELEASE NOTES FOR THE UPCOMING RELEASE.
 
 ## Bug fixes and other updates
 
+* Fix case sensitivity in schema parser in hscim library (#1714)
+
 ## Documentation
 
 ## Internal changes

--- a/libs/hscim/CHANGELOG
+++ b/libs/hscim/CHANGELOG
@@ -1,2 +1,5 @@
+0.3.6:
+  - fix serialization: json attributes in scim are case-insensitive
+
 0.3.4:
   - initial version

--- a/libs/hscim/hscim.cabal
+++ b/libs/hscim/hscim.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b8d0589f22bc168d16fa3a2b2800d9cc3b14b4d94bb911fe973ccf2a2025e5e5
+-- hash: 6089b5e95585547fb49e994e3d8d681c18df1e5a172f8581280066b8860167fd
 
 name:           hscim
 version:        0.3.5
@@ -173,9 +173,13 @@ test-suite spec
       Test.Class.UserSpec
       Test.FilterSpec
       Test.MiscSpec
+      Test.Schema.AuthenticationSchemeSpec
+      Test.Schema.GroupSpec
       Test.Schema.MetaSchemaSpec
       Test.Schema.PatchOpSpec
+      Test.Schema.ResourceSpec
       Test.Schema.UserSpec
+      Test.Schema.Util
       Paths_hscim
   hs-source-dirs:
       test

--- a/libs/hscim/hscim.cabal
+++ b/libs/hscim/hscim.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6089b5e95585547fb49e994e3d8d681c18df1e5a172f8581280066b8860167fd
+-- hash: 8daa0bcbe43125e8d9749dd38e62f67cb01f62a1bcd57a0391e684860203e60c
 
 name:           hscim
-version:        0.3.5
+version:        0.3.6
 synopsis:       hscim json schema and server implementation
 description:    The README file will answer all the questions you might have
 category:       Web

--- a/libs/hscim/package.yaml
+++ b/libs/hscim/package.yaml
@@ -1,5 +1,5 @@
 name:                hscim
-version:             0.3.5
+version:             0.3.6
 synopsis:            hscim json schema and server implementation
 description:         The README file will answer all the questions you might have
 homepage:            https://github.com/wireapp/wire-server/libs/hscim/README.md

--- a/libs/hscim/src/Web/Scim/Capabilities/MetaSchema.hs
+++ b/libs/hscim/src/Web/Scim/Capabilities/MetaSchema.hs
@@ -81,7 +81,7 @@ instance ToJSON BulkConfig where
   toJSON = genericToJSON serializeOptions
 
 instance FromJSON BulkConfig where
-  parseJSON = genericParseJSON serializeOptions
+  parseJSON = genericParseJSON parseOptions . jsonLower
 
 data FilterConfig = FilterConfig
   { maxResults :: Int
@@ -92,7 +92,7 @@ instance ToJSON FilterConfig where
   toJSON = genericToJSON serializeOptions
 
 instance FromJSON FilterConfig where
-  parseJSON = genericParseJSON serializeOptions
+  parseJSON = genericParseJSON parseOptions . jsonLower
 
 data Configuration = Configuration
   { documentationUri :: Maybe URI,
@@ -111,7 +111,7 @@ instance ToJSON Configuration where
   toJSON = genericToJSON serializeOptions
 
 instance FromJSON Configuration where
-  parseJSON = genericParseJSON serializeOptions
+  parseJSON = genericParseJSON parseOptions . jsonLower
 
 empty :: Configuration
 empty =

--- a/libs/hscim/src/Web/Scim/Schema/AuthenticationScheme.hs
+++ b/libs/hscim/src/Web/Scim/Schema/AuthenticationScheme.hs
@@ -66,9 +66,8 @@ instance ToJSON AuthenticationSchemeEncoding where
   toJSON = genericToJSON serializeOptions
 
 instance FromJSON AuthenticationSchemeEncoding where
+  -- NB: "typ" will be converted to "type" thanks to 'serializeOptions'
   parseJSON = genericParseJSON serializeOptions
-
--- NB: "typ" will be converted to "type" thanks to 'serializeOptions'
 
 ----------------------------------------------------------------------------
 -- Scheme encodings

--- a/libs/hscim/src/Web/Scim/Schema/AuthenticationScheme.hs
+++ b/libs/hscim/src/Web/Scim/Schema/AuthenticationScheme.hs
@@ -67,7 +67,7 @@ instance ToJSON AuthenticationSchemeEncoding where
 
 instance FromJSON AuthenticationSchemeEncoding where
   -- NB: "typ" will be converted to "type" thanks to 'serializeOptions'
-  parseJSON = genericParseJSON serializeOptions
+  parseJSON = genericParseJSON parseOptions . jsonLower
 
 ----------------------------------------------------------------------------
 -- Scheme encodings

--- a/libs/hscim/src/Web/Scim/Schema/Common.hs
+++ b/libs/hscim/src/Web/Scim/Schema/Common.hs
@@ -85,7 +85,8 @@ serializeOptions =
 jsonLower :: Value -> Value
 jsonLower (Object o) = Object . HM.fromList . fmap lowerPair . HM.toList $ o
   where
-    lowerPair (key, val) = (fromKeyword . toLower $ key, val)
+    lowerPair (key, val) = (fromKeyword . toLower $ key, jsonLower val)
+jsonLower (Array x) = Array (jsonLower <$> x)
 jsonLower x = x
 
 fromKeyword :: (IsString p, Eq p) => p -> p

--- a/libs/hscim/src/Web/Scim/Schema/Common.hs
+++ b/libs/hscim/src/Web/Scim/Schema/Common.hs
@@ -80,16 +80,20 @@ serializeOptions =
       fieldLabelModifier = toKeyword
     }
 
--- | Turn all keys in a JSON object to lowercase recursively.
+parseOptions :: Options
+parseOptions =
+  defaultOptions
+    { fieldLabelModifier = toKeyword . fmap Char.toLower
+    }
+
+-- | Turn all keys in a JSON object to lowercase recursively.  This is applied to the aeson
+-- 'Value' to be parsed; 'parseOptions' is applied to the keys passed to '(.:)' etc.
+--
+-- (FUTUREWORK: The "recursively" part is a bit of a waste and could be dropped, but we would
+-- have to spend more effort in making sure it is always called manually in nested parsers.)
 jsonLower :: Value -> Value
 jsonLower (Object o) = Object . HM.fromList . fmap lowerPair . HM.toList $ o
   where
     lowerPair (key, val) = (toLower key, jsonLower val)
 jsonLower (Array x) = Array (jsonLower <$> x)
 jsonLower x = x
-
-parseOptions :: Options
-parseOptions =
-  defaultOptions
-    { fieldLabelModifier = toKeyword . fmap Char.toLower
-    }

--- a/libs/hscim/src/Web/Scim/Schema/Common.hs
+++ b/libs/hscim/src/Web/Scim/Schema/Common.hs
@@ -25,7 +25,6 @@ import qualified Data.CaseInsensitive as CI
 import qualified Data.Char as Char
 import qualified Data.HashMap.Lazy as HML
 import qualified Data.HashMap.Strict as HM
-import Data.String (IsString)
 import Data.String.Conversions (cs)
 import Data.Text hiding (dropWhile)
 import qualified Network.URI as Network
@@ -69,7 +68,7 @@ instance FromJSON ScimBool where
       _ -> fail $ "Expected true, false, \"true\", or \"false\" (case insensitive), but got " <> cs str
   parseJSON bad = fail $ "Expected true, false, \"true\", or \"false\" (case insensitive), but got " <> show bad
 
-toKeyword :: (IsString p, Eq p) => p -> p
+toKeyword :: String -> String
 toKeyword "typ" = "type"
 toKeyword "ref" = "$ref"
 toKeyword other = other
@@ -81,21 +80,16 @@ serializeOptions =
       fieldLabelModifier = toKeyword
     }
 
--- | Turn all keys in a JSON object to lowercase.
+-- | Turn all keys in a JSON object to lowercase recursively.
 jsonLower :: Value -> Value
 jsonLower (Object o) = Object . HM.fromList . fmap lowerPair . HM.toList $ o
   where
-    lowerPair (key, val) = (fromKeyword . toLower $ key, jsonLower val)
+    lowerPair (key, val) = (toLower key, jsonLower val)
 jsonLower (Array x) = Array (jsonLower <$> x)
 jsonLower x = x
-
-fromKeyword :: (IsString p, Eq p) => p -> p
-fromKeyword "type" = "typ"
-fromKeyword "$ref" = "ref"
-fromKeyword other = other
 
 parseOptions :: Options
 parseOptions =
   defaultOptions
-    { fieldLabelModifier = fmap Char.toLower
+    { fieldLabelModifier = toKeyword . fmap Char.toLower
     }

--- a/libs/hscim/src/Web/Scim/Schema/ResourceType.hs
+++ b/libs/hscim/src/Web/Scim/Schema/ResourceType.hs
@@ -32,7 +32,7 @@ import Prelude hiding (map)
 data ResourceType
   = UserResource
   | GroupResource
-  deriving (Show, Eq)
+  deriving (Show, Eq, Enum, Bounded)
 
 instance ToJSON ResourceType where
   toJSON UserResource = "User"

--- a/libs/hscim/test/Test/Schema/AuthenticationSchemeSpec.hs
+++ b/libs/hscim/test/Test/Schema/AuthenticationSchemeSpec.hs
@@ -1,0 +1,50 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Schema.AuthenticationSchemeSpec
+  ( spec,
+  )
+where
+
+import Data.Aeson
+import HaskellWorks.Hspec.Hedgehog (require)
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import Test.Hspec
+import Test.Schema.Util (genUri, mk_prop_caseInsensitive)
+import qualified Web.Scim.Schema.AuthenticationScheme as AS
+
+prop_roundtrip :: Property
+prop_roundtrip = property $ do
+  user <- forAll genAuthenticationSchemeEncoding
+  tripping user toJSON fromJSON
+
+spec :: Spec
+spec = do
+  it "roundtrip" $ do
+    require prop_roundtrip
+  it "case-insensitive" $ do
+    require $ mk_prop_caseInsensitive genAuthenticationSchemeEncoding
+
+genAuthenticationSchemeEncoding :: Gen AS.AuthenticationSchemeEncoding
+genAuthenticationSchemeEncoding =
+  AS.AuthenticationSchemeEncoding
+    <$> Gen.element ["typ1", "typ2"]
+    <*> Gen.element ["name1", "name2", "name3"]
+    <*> Gen.element ["desc ription"]
+    <*> Gen.maybe genUri
+    <*> Gen.maybe genUri

--- a/libs/hscim/test/Test/Schema/GroupSpec.hs
+++ b/libs/hscim/test/Test/Schema/GroupSpec.hs
@@ -1,0 +1,61 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Schema.GroupSpec
+  ( spec,
+  )
+where
+
+import Data.Aeson
+import Data.Text (Text)
+import HaskellWorks.Hspec.Hedgehog (require)
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Test.Hspec
+import Test.Schema.Util (mk_prop_caseInsensitive)
+import qualified Web.Scim.Class.Group as GroupClass
+
+prop_roundtrip :: Property
+prop_roundtrip = property $ do
+  user <- forAll genGroup
+  tripping user toJSON fromJSON
+
+spec :: Spec
+spec = do
+  it "roundtrip" $ do
+    require prop_roundtrip
+  it "case-insensitive" $ do
+    require $ mk_prop_caseInsensitive genGroup
+    require $ mk_prop_caseInsensitive genMember
+
+genMember :: Gen GroupClass.Member
+genMember =
+  GroupClass.Member
+    <$> (Gen.text (Range.constant 0 20) Gen.unicode)
+    <*> (Gen.text (Range.constant 0 20) Gen.unicode)
+    <*> (Gen.text (Range.constant 0 20) Gen.unicode)
+
+genGroup :: Gen GroupClass.Group
+genGroup =
+  GroupClass.Group
+    <$> Gen.list (Range.linear 0 10) genSchema
+    <*> (Gen.text (Range.constant 0 20) Gen.unicode)
+    <*> Gen.list (Range.linear 0 10) genMember
+
+genSchema :: Gen Text
+genSchema = Gen.element ["schema1", "schema2", "schema3"]

--- a/libs/hscim/test/Test/Schema/MetaSchemaSpec.hs
+++ b/libs/hscim/test/Test/Schema/MetaSchemaSpec.hs
@@ -26,16 +26,15 @@ module Test.Schema.MetaSchemaSpec
 where
 
 import Data.Aeson
-import Data.Text (Text)
 import HaskellWorks.Hspec.Hedgehog (require)
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Network.URI.Static (uri)
 import Test.Hspec
+import Test.Schema.Util (genSimpleText, genUri, mk_prop_caseInsensitive)
 import Web.Scim.Capabilities.MetaSchema
 import Web.Scim.Schema.AuthenticationScheme
-import Web.Scim.Schema.Common (ScimBool (ScimBool), URI (..))
+import Web.Scim.Schema.Common (ScimBool (ScimBool))
 import Web.Scim.Schema.Schema (Schema (..))
 import Prelude hiding (filter)
 
@@ -62,6 +61,8 @@ spec = do
       require (prop_roundtrip genAuthenticationSchemeEncoding)
     it "`Configuration` roundtrips" $ do
       require (prop_roundtrip genConfiguration)
+    it "`Configuration` satisfies the insane json-case-insensitivity rule." $ do
+      require $ mk_prop_caseInsensitive genConfiguration
 
 genConfiguration :: Gen Configuration
 genConfiguration = do
@@ -99,9 +100,3 @@ genSupported :: forall a. Gen a -> Gen (Supported a)
 genSupported gen = do
   Supported <$> (ScimBool <$> Gen.bool)
     <*> gen
-
-genUri :: Gen URI
-genUri = Gen.element [URI [uri|https://example.com|], URI [uri|gopher://glab.io|], URI [uri|ssh://nothing/blorg|]]
-
-genSimpleText :: Gen Text
-genSimpleText = Gen.element ["one", "green", "sharp"]

--- a/libs/hscim/test/Test/Schema/ResourceSpec.hs
+++ b/libs/hscim/test/Test/Schema/ResourceSpec.hs
@@ -1,0 +1,65 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Schema.ResourceSpec
+  ( spec,
+  )
+where
+
+import Data.Aeson
+import HaskellWorks.Hspec.Hedgehog (require)
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import Test.Hspec
+import Test.Schema.Util (genUri, mk_prop_caseInsensitive)
+import Web.Scim.Schema.ResourceType
+import qualified Web.Scim.Schema.Schema as Schema
+
+prop_roundtrip :: Property
+prop_roundtrip = property $ do
+  user <- forAll genResource
+  tripping user toJSON fromJSON
+
+spec :: Spec
+spec = do
+  it "roundtrip" $ do
+    require prop_roundtrip
+  it "case-insensitive" $ do
+    require $ mk_prop_caseInsensitive genResource
+
+genResource :: Gen Resource
+genResource =
+  Resource
+    <$> Gen.element ["name1", "name2", "name3"]
+    <*> genUri
+    <*> genSchema
+
+genSchema :: Gen Schema.Schema
+genSchema =
+  Gen.element
+    [ Schema.User20,
+      Schema.ServiceProviderConfig20,
+      Schema.Group20,
+      Schema.Schema20,
+      Schema.ResourceType20,
+      Schema.ListResponse20,
+      Schema.Error20,
+      Schema.PatchOp20,
+      Schema.CustomSchema "custom1",
+      Schema.CustomSchema "custom2",
+      Schema.CustomSchema "custom3"
+    ]

--- a/libs/hscim/test/Test/Schema/UserSpec.hs
+++ b/libs/hscim/test/Test/Schema/UserSpec.hs
@@ -64,8 +64,8 @@ prop_caseInsensitive :: Property
 prop_caseInsensitive = property $ do
   user <- forAll genUser
   let (Object user') = toJSON user
-  let user'' = HM.foldlWithKey' (\u k v -> HM.insert (toUpper k) v u) user' HM.empty
-  let user''' = HM.foldlWithKey' (\u k v -> HM.insert (toLower k) v u) user' HM.empty
+  let user'' = HM.foldlWithKey' (\u k v -> HM.insert (toUpper k) v u) HM.empty user'
+  let user''' = HM.foldlWithKey' (\u k v -> HM.insert (toLower k) v u) HM.empty user'
   fromJSON (Object user'') === Success user
   fromJSON (Object user''') === Success user
 

--- a/libs/hscim/test/Test/Schema/UserSpec.hs
+++ b/libs/hscim/test/Test/Schema/UserSpec.hs
@@ -28,7 +28,7 @@ import Data.Aeson
 import Data.Either (isLeft, isRight)
 import Data.Foldable (for_)
 import qualified Data.HashMap.Strict as HM
-import Data.Text (Text, toLower, toUpper)
+import Data.Text (Text, toLower)
 import HaskellWorks.Hspec.Hedgehog (require)
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -36,9 +36,13 @@ import qualified Hedgehog.Range as Range
 import Lens.Micro
 import Network.URI.Static (uri)
 import Test.Hspec
+import Test.Schema.Util (genUri, mk_prop_caseInsensitive)
 import Text.Email.Validate (emailAddress)
+import qualified Web.Scim.Class.User as UserClass
 import Web.Scim.Filter (AttrPath (..))
-import Web.Scim.Schema.Common (ScimBool (ScimBool), URI (..))
+import Web.Scim.Schema.Common (ScimBool (ScimBool), URI (..), WithId (..))
+import qualified Web.Scim.Schema.ListResponse as ListResponse
+import Web.Scim.Schema.Meta (ETag (Strong, Weak), Meta (..), WithMeta (..))
 import Web.Scim.Schema.PatchOp (Op (..), Operation (..), PatchOp (..), Patchable (..), Path (..))
 import qualified Web.Scim.Schema.PatchOp as PatchOp
 import Web.Scim.Schema.Schema (Schema (..))
@@ -57,17 +61,6 @@ prop_roundtrip :: Property
 prop_roundtrip = property $ do
   user <- forAll genUser
   tripping user toJSON fromJSON
-
--- TODO(arianvp): Note that this only tests the top-level fields.
--- extrac this to a generic test and also do this for sub-properties
-prop_caseInsensitive :: Property
-prop_caseInsensitive = property $ do
-  user <- forAll genUser
-  let (Object user') = toJSON user
-  let user'' = HM.foldlWithKey' (\u k v -> HM.insert (toUpper k) v u) HM.empty user'
-  let user''' = HM.foldlWithKey' (\u k v -> HM.insert (toLower k) v u) HM.empty user'
-  fromJSON (Object user'') === Success user
-  fromJSON (Object user''') === Success user
 
 type PatchTag = TestTag Text () () UserExtraPatch
 
@@ -136,7 +129,8 @@ spec = do
     it "treats 'null' and '[]' as absence of fields" $
       eitherDecode (encode minimalUserJsonRedundant) `shouldBe` Right minimalUser
     it "allows casing variations in field names" $ do
-      require prop_caseInsensitive
+      require $ mk_prop_caseInsensitive (genUser)
+      require $ mk_prop_caseInsensitive (ListResponse.fromList . (: []) <$> genStoredUser)
       eitherDecode (encode minimalUserJsonNonCanonical) `shouldBe` Right minimalUser
     it "doesn't require the 'schemas' field" $
       eitherDecode (encode minimalUserJsonNoSchemas) `shouldBe` Right minimalUser
@@ -159,8 +153,20 @@ genName =
     <*> Gen.maybe (Gen.text (Range.constant 0 20) Gen.unicode)
     <*> Gen.maybe (Gen.text (Range.constant 0 20) Gen.unicode)
 
-genUri :: Gen URI
-genUri = Gen.element [URI [uri|https://example.com|], URI [uri|gopher://glab.io|], URI [uri|ssh://nothing/blorg|]]
+genStoredUser :: Gen (UserClass.StoredUser (TestTag Text () () NoUserExtra))
+genStoredUser = do
+  m <- genMeta
+  i <- Gen.element @_ @Text ["wef", "asdf", "@", "#", "1"]
+  u <- genUser
+  pure $ WithMeta m (WithId i u)
+
+genMeta :: Gen Meta
+genMeta =
+  Meta <$> Gen.enumBounded
+    <*> Gen.element [read "2021-08-23 13:13:31.450140036 UTC", read "2019-01-01 09:55:59 UTC"]
+    <*> Gen.element [read "2021-08-23 13:13:31.450140036 UTC", read "2022-01-01 09:55:59 UTC"]
+    <*> (Gen.element [Weak, Strong] <*> Gen.text (Range.constant 0 20) Gen.unicode)
+    <*> genUri
 
 -- TODO(arianvp) Generate the lists too, but first need better support for SCIM
 -- lists in the first place

--- a/libs/hscim/test/Test/Schema/Util.hs
+++ b/libs/hscim/test/Test/Schema/Util.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Schema.Util
+  ( mk_prop_caseInsensitive,
+    genUri,
+    genSimpleText,
+  )
+where
+
+import Data.Aeson
+import qualified Data.HashMap.Strict as HM
+import Data.Text (Text, toLower, toUpper)
+import Hedgehog
+import Hedgehog.Gen as Gen
+import Network.URI.Static
+import Web.Scim.Schema.Common (URI (..))
+
+genUri :: Gen URI
+genUri = Gen.element [URI [uri|https://example.com|], URI [uri|gopher://glab.io|], URI [uri|ssh://nothing/blorg|]]
+
+genSimpleText :: Gen Text
+genSimpleText = Gen.element ["one", "green", "sharp"]
+
+mk_prop_caseInsensitive :: forall a. (ToJSON a, FromJSON a, Show a, Eq a) => Gen a -> Property
+mk_prop_caseInsensitive gen = property $ do
+  val <- forAll gen
+  fromJSON (withCasing toUpper $ toJSON val) === Success val
+  fromJSON (withCasing toLower $ toJSON val) === Success val
+  where
+    withCasing :: (Text -> Text) -> Value -> Value
+    withCasing toCasing = \case
+      Object obj -> Object $ HM.foldlWithKey' (\u k v -> HM.insert (toCasing k) (withCasing toCasing v) u) HM.empty obj
+      Array arr -> Array $ withCasing toCasing <$> arr
+      same@(Number _) -> same
+      same@(String _) -> same
+      same@(Bool _) -> same
+      same@Null -> same


### PR DESCRIPTION
The SCIM requires json attribute keys to be case-insensitive, and hscim mostly implements this, but not quite, until now.  This fixes this: `stack test --fast hscim --test-arguments='--match "/Test.Schema.User/JSON serialization/allows casing variations in field names/"'` fails on 7fbe431, but passes on 8e2ef77.

This is done by [turning all keys in a JSON object to lowercase recursively](https://github.com/wireapp/wire-server/pull/1714/files#diff-62d1c322a7c5856c36271c84e557df82a8d5d0fc9c2e294db7d280cb0d46061cR89-R99)

<details>
  <summary>Failing tests on 7fbe431 for reference</summary>
  
```
  test-integration/Test/Spar/Scim/UserSpec.hs:330:5: 
  1) Spar.Scim.User, POST /Users, team has no SAML IdP, creates a user with PendingInvitation, and user can follow usual invitation process
       uncaught exception: ErrorCall
       responseJsonUnsafeWithMsg: ListResponse (WithMeta (WithId (Id * U) (User SparTag))) Error in $.resources[0].fields[0]: key "type" not found
       CallStack (from HasCallStack):
         error, called at src/Bilge/Response.hs:143:7 in bilge-0.22.0-2K7mJKDUfGc17BkrPwuOOW:Bilge.Response
         responseJsonUnsafeWithMsg, called at src/Bilge/Response.hs:132:22 in bilge-0.22.0-2K7mJKDUfGc17BkrPwuOOW:Bilge.Response
         responseJsonUnsafe, called at test-integration/Util/Scim.hs:260:12 in main:Util.Scim
         listUsers, called at test-integration/Test/Spar/Scim/UserSpec.hs:330:5 in main:Test.Spar.Scim.UserSpec

  To rerun use: --match "/Spar.Scim.User/POST /Users/team has no SAML IdP/creates a user with PendingInvitation, and user can follow usual invitation process/"

  test-integration/Test/Spar/Scim/UserSpec.hs:725:3: 
  2) Spar.Scim.User, POST /Users, team has no SAML IdP, doesn't list users that exceed their invitation period, and allows recreating them
       uncaught exception: ErrorCall
       responseJsonUnsafeWithMsg: ListResponse (WithMeta (WithId (Id * U) (User SparTag))) Error in $.resources[0].fields[0]: key "type" not found
       CallStack (from HasCallStack):
         error, called at src/Bilge/Response.hs:143:7 in bilge-0.22.0-2K7mJKDUfGc17BkrPwuOOW:Bilge.Response
         responseJsonUnsafeWithMsg, called at src/Bilge/Response.hs:132:22 in bilge-0.22.0-2K7mJKDUfGc17BkrPwuOOW:Bilge.Response
         responseJsonUnsafe, called at test-integration/Util/Scim.hs:260:12 in main:Util.Scim
         listUsers, called at test-integration/Test/Spar/Scim/UserSpec.hs:743:27 in main:Test.Spar.Scim.UserSpec
         searchUser, called at test-integration/Test/Spar/Scim/UserSpec.hs:725:3 in main:Test.Spar.Scim.UserSpec

  To rerun use: --match "/Spar.Scim.User/POST /Users/team has no SAML IdP/doesn't list users that exceed their invitation period, and allows recreating them/"

  test-integration/Test/Spar/Scim/UserSpec.hs:791:12: 
  3) Spar.Scim.User, GET /Users, 1 SAML IdP, finds a SCIM-provisioned user by userName or externalId
       uncaught exception: ErrorCall
       responseJsonUnsafeWithMsg: ListResponse (WithMeta (WithId (Id * U) (User SparTag))) Error in $.resources[0].fields[0]: key "type" not found
       CallStack (from HasCallStack):
         error, called at src/Bilge/Response.hs:143:7 in bilge-0.22.0-2K7mJKDUfGc17BkrPwuOOW:Bilge.Response
         responseJsonUnsafeWithMsg, called at src/Bilge/Response.hs:132:22 in bilge-0.22.0-2K7mJKDUfGc17BkrPwuOOW:Bilge.Response
         responseJsonUnsafe, called at test-integration/Util/Scim.hs:260:12 in main:Util.Scim
         listUsers, called at test-integration/Test/Spar/Scim/UserSpec.hs:791:12 in main:Test.Spar.Scim.UserSpec
```
</details>



## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG-draft.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
