### PR TITLE
[helm] certificate-manager: avoid duplicate certificate generation and rate limiting

### DIFF
--- a/CHANGELOG-draft.md
+++ b/CHANGELOG-draft.md
@@ -36,6 +36,7 @@ THIS FILE ACCUMULATES THE RELEASE NOTES FOR THE UPCOMING RELEASE.
 ## Bug fixes and other updates
 
 * Fix case sensitivity in schema parser in hscim library (#1714)
+* [helm charts] resolve a rate-limiting issue when using certificate-manager alongside wire-server and nginx-ingress-services helm charts (#1715)
 
 ## Documentation
 

--- a/charts/nginx-ingress-services/templates/certificate_federator.yaml
+++ b/charts/nginx-ingress-services/templates/certificate_federator.yaml
@@ -17,6 +17,7 @@ spec:
     kind: Issuer
   usages:
     - server auth
+    - client auth
   duration: 2160h     # 90d, Letsencrypt default; NOTE: changes are ignored by Letsencrypt
   renewBefore: 360h   # 15d
   isCA: false

--- a/charts/nginx-ingress-services/templates/secret.yaml
+++ b/charts/nginx-ingress-services/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.tls.useCertManager }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,11 +9,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: kubernetes.io/tls
 data:
-{{- if .Values.tls.useCertManager }}
-  {{/* NOTE: providing `data` (and empty strings) allows to manage this secret resource with Helm if cert-manager is used */}}
-  tls.crt: ""
-  tls.key: ""
-{{- else }}
   {{/* for_helm_linting is necessary only since the 'with' block below does not throw an error upon an empty .Values.secrets */}}
   for_helm_linting: {{ required "No .secrets found in configuration. Did you forget to helm <command> -f path/to/secrets.yaml ?" .Values.secrets | quote | b64enc | quote }}
 

--- a/charts/nginx-ingress-services/templates/secret_federator.yaml
+++ b/charts/nginx-ingress-services/templates/secret_federator.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.federator.enabled -}}
+{{- if and .Values.federator.enabled (not .Values.tls.useCertManager) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,11 +9,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: kubernetes.io/tls
 data:
-{{- if .Values.tls.useCertManager }}
-  {{/* NOTE: providing empty strings here allows to manage this secret resource with Helm if cert-manager is used */}}
-  tls.crt: ""
-  tls.key: ""
-{{- else }}
   {{/* for_helm_linting is necessary only since the 'with' block below does not throw an error upon an empty .Values.secrets */}}
   for_helm_linting: {{ required "No .secrets found in configuration. Did you forget to helm <command> -f path/to/secrets.yaml ?" .Values.secrets | quote | b64enc | quote }}
 
@@ -21,5 +16,4 @@ data:
   tls.crt: {{ .tlsWildcardCert | b64enc | quote }}
   tls.key: {{ .tlsWildcardKey | b64enc | quote }}
   {{- end -}}
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Problem description:

Before this change, when using the 'jetstack/cert-manager' alongside
'wire-server' and 'nginx-ingress-services' helm charts (with
useCertManager: true), then each subsequent 'helm upgrade' command
re-generated a fresh 'certificaterequest' object that retrieved a fresh
certificate from let's encrypt; even if the existing certificate was
still valid.
This is probably due to both the 'Certificate' resource managing the
'Secret' resource, as well as helm itself also creating the 'Secret'
resource (with empty strings)
This is a problem because:
* it wastes let's encrypt resources
* it quickly leads to duplicate certificate rate limiting (5/week)
  causing deployments to fail.

## Symptoms:

Using this command:

```
kubectl -n wire get certificaterequest --sort-by=.metadata.creationTimestamp
```

one can see that two fresh certificate request resources (one for the
regular ingress, one for the federator ingress and the federator itself) are created on
each fresh deployment. After more than 5 deployments in a given 7-day
period, deployments fail with errors such as:

```
E0823 13:29:08.667867       1 sync.go:211] cert-manager/controller/orders "msg"="failed to create Order resource due to bad request, marking Order as failed" "error"="429 urn:ietf:params:acme:error:rateLimited: Error creating new order :: too many certificates (5) already issued for this exact set of domains in the last 168 hours: DOMANNAME: see https://letsencrypt.org/docs/rate-limits/" "resource_kind"="Order" "resource_name"="DOMAINNAME-csr-9j8hq-1640003472" "resource_namespace"="wire" "resource_version"="v1"
```
## resolution

With this PR, we only create the Secret resource manually if certificate
manager is disabled. After one initial more fresh certificate request, all subsequent
deployments no longer create fresh certificate requests, solving this
issue. Thanks @akshaymankar for your hunch of what the issue could be.

Drive-by improvement:

* be explicit about client auth capabilities for the federator
  certificate
  
## Useful tools when debugging let's encrypt issues

https://crt.sh/
https://letsdebug.net
https://check-your-website.server-daten.de/

Check for `certificate` `certificaterequest` `order` and `challenge` objects in kubernetes.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] Section *Unreleased* of **CHANGELOG-draft.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
 