### PR TITLE
remove leftover auto-connect internal endpoint and code

### DIFF
--- a/docs/reference/user/activation.md
+++ b/docs/reference/user/activation.md
@@ -14,8 +14,6 @@ Non-activated users can not [connect](connection.md) to others, nor can connecti
 
 * A non-activated user cannot add other users to conversations. The only way to participate in a conversation is to either create a new conversation with link access or to use a link provided by another user.
 
-* A non-activated user cannot get auto-connected to others as a result of an address book upload.
-
 The only flow where it makes sense for non-activated users to exist is the [wireless flow](registration.md#RefRegistrationWireless) used for [guest rooms](https://wire.com/en/features/encrypted-guest-rooms/)
 
 ## API {#RefActivationApi}

--- a/libs/brig-types/src/Brig/Types/Intra.hs
+++ b/libs/brig-types/src/Brig/Types/Intra.hs
@@ -174,7 +174,7 @@ instance ToJSON NewUserScimInvitation where
 -- UserList
 
 -- | Set of user ids, can be used for different purposes (e.g., used on the internal
--- APIs for auto-connections, listing user's clients)
+-- APIs for listing user's clients)
 data UserSet = UserSet
   { usUsrs :: !(Set UserId)
   }

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -19,7 +19,6 @@
 
 module Brig.Data.Connection
   ( module T,
-    connectUsers,
     insertConnection,
     updateConnection,
     lookupConnection,
@@ -49,20 +48,6 @@ import Data.Time (getCurrentTime)
 import Imports
 import UnliftIO.Async (pooledMapConcurrentlyN_)
 import Wire.API.Connection
-
-connectUsers :: UserId -> [(UserId, ConvId)] -> AppIO [UserConnection]
-connectUsers from to = do
-  now <- toUTCTimeMillis <$> liftIO getCurrentTime
-  retry x5 . batch $ do
-    setType BatchLogged
-    setConsistency Quorum
-    forM_ to $ \(u, c) -> do
-      addPrepQuery connectionInsert (from, u, AcceptedWithHistory, now, Nothing, c)
-      addPrepQuery connectionInsert (u, from, AcceptedWithHistory, now, Nothing, c)
-  return . concat . (`map` to) $ \(u, c) ->
-    [ UserConnection from u Accepted now Nothing (Just c),
-      UserConnection u from Accepted now Nothing (Just c)
-    ]
 
 insertConnection ::
   -- | From

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -42,7 +42,6 @@ import Data.Handle (Handle (Handle))
 import Data.Id hiding (client)
 import Data.Misc (PlainTextPassword (..))
 import Data.Range (unsafeRange)
-import qualified Data.Set as Set
 import qualified Data.Text.Ascii as Ascii
 import qualified Data.Vector as Vec
 import Imports
@@ -245,17 +244,6 @@ listConnections brig u =
     brig
       . path "connections"
       . zUser u
-
-postAutoConnection :: Brig -> UserId -> [UserId] -> (MonadIO m, MonadHttp m) => m ResponseLBS
-postAutoConnection brig from to =
-  post $
-    brig
-      . paths ["/i/users", toByteString' from, "auto-connect"]
-      . contentJson
-      . body payload
-      . zConn "conn"
-  where
-    payload = RequestBodyLBS . encode $ UserSet (Set.fromList to)
 
 setProperty :: Brig -> UserId -> ByteString -> Value -> (MonadIO m, MonadHttp m) => m ResponseLBS
 setProperty brig u k v =


### PR DESCRIPTION
This is more dead code forgotten to be removed in #1005 when auto-connect was
disabled.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] Section *Unreleased* of **CHANGELOG-draft.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.