### PR TITLE
 Avoid remote calls to get conversation when it is not found locally

### DIFF
--- a/CHANGELOG-draft.md
+++ b/CHANGELOG-draft.md
@@ -28,3 +28,4 @@ THIS FILE ACCUMULATES THE RELEASE NOTES FOR THE UPCOMING RELEASE.
 
 * Ensure clients only receive messages meant for them in remote convs (#1739)
 * Federator CA store and client credentials are now automatically reloaded (#1730)
+* Avoid remote calls to get conversation when it is not found locally (#1713)

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -105,7 +105,7 @@ getConversation zusr cnv = do
   where
     getRemoteConversation :: Remote ConvId -> Galley Public.Conversation
     getRemoteConversation remoteConvId = do
-      (foundConvs, _) <- Data.remoteConversationIdOf zusr [remoteConvId]
+      foundConvs <- Data.remoteConversationIdOf zusr [remoteConvId]
       unless (remoteConvId `elem` foundConvs) $
         throwErrorDescription convNotFound
       conversations <- getRemoteConversations zusr [remoteConvId]

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1854,7 +1854,7 @@ testGetQualifiedLocalConvNotFound = do
   convId <- (`Qualified` localDomain) <$> randomId
   getConvQualified alice convId !!! do
     const 404 === statusCode
-    const (Just "no-conversation") === view (at "label") . responseJsonUnsafe @Object
+    const (Right (Just "no-conversation")) === fmap (view (at "label")) . responseJsonEither @Object
 
 testGetQualifiedLocalConvNotParticipating :: TestM ()
 testGetQualifiedLocalConvNotParticipating = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -153,7 +153,11 @@ tests s =
           test s "fail to add too many members" postTooManyMembersFail,
           test s "add remote members" testAddRemoteMember,
           test s "get conversations/:domain/:cnv - local" testGetQualifiedLocalConv,
+          test s "get conversations/:domain/:cnv - local, not found" testGetQualifiedLocalConvNotFound,
+          test s "get conversations/:domain/:cnv - local, not participating" testGetQualifiedLocalConvNotParticipating,
           test s "get conversations/:domain/:cnv - remote" testGetQualifiedRemoteConv,
+          test s "get conversations/:domain/:cnv - remote, not found" testGetQualifiedRemoteConvNotFound,
+          test s "get conversations/:domain/:cnv - remote, not found on remote" testGetQualifiedRemoteConvNotFoundOnRemote,
           test s "post list-conversations" testListRemoteConvs,
           test s "post conversations/list/v2" testBulkGetQualifiedConvs,
           test s "add non-existing remote members" testAddRemoteMemberFailure,
@@ -1843,6 +1847,24 @@ testGetQualifiedLocalConv = do
     assertEqual "conversation id" convId (cnvQualifiedId conv)
     assertEqual "conversation name" (Just "gossip") (cnvName conv)
 
+testGetQualifiedLocalConvNotFound :: TestM ()
+testGetQualifiedLocalConvNotFound = do
+  alice <- randomUser
+  localDomain <- viewFederationDomain
+  convId <- (`Qualified` localDomain) <$> randomId
+  getConvQualified alice convId !!! do
+    const 404 === statusCode
+    const (Just "no-conversation") === view (at "label") . responseJsonUnsafe @Object
+
+testGetQualifiedLocalConvNotParticipating :: TestM ()
+testGetQualifiedLocalConvNotParticipating = do
+  alice <- randomUser
+  bob <- randomUser
+  convId <- decodeQualifiedConvId <$> postConv bob [] (Just "gossip about alice") [] Nothing Nothing
+  getConvQualified alice convId !!! do
+    const 403 === statusCode
+    const (Just "access-denied") === view (at "label") . responseJsonUnsafe @Object
+
 testGetQualifiedRemoteConv :: TestM ()
 testGetQualifiedRemoteConv = do
   aliceQ <- randomQualifiedUser
@@ -1885,6 +1907,35 @@ testGetQualifiedRemoteConv = do
   -- FUTUREWORK: The backend should augment returned conversation data with
   -- Alice's membership data stored locally
   liftIO $ assertEqual "conversation" mockConversation conv
+
+testGetQualifiedRemoteConvNotFound :: TestM ()
+testGetQualifiedRemoteConvNotFound = do
+  aliceId <- randomUser
+  let remoteDomain = Domain "far-away.example.com"
+  remoteConvId <- (`Qualified` remoteDomain) <$> randomId
+  -- No need to mock federator as we don't expect a call to be made
+  getConvQualified aliceId remoteConvId !!! do
+    const 404 === statusCode
+    const (Just "no-conversation") === view (at "label") . responseJsonUnsafe @Object
+
+testGetQualifiedRemoteConvNotFoundOnRemote :: TestM ()
+testGetQualifiedRemoteConvNotFoundOnRemote = do
+  aliceQ <- randomQualifiedUser
+  let aliceId = qUnqualified aliceQ
+  bobId <- randomId
+  convId <- randomId
+  let remoteDomain = Domain "far-away.example.com"
+      bobQ = Qualified bobId remoteDomain
+      remoteConvId = Qualified convId remoteDomain
+      aliceAsOtherMember = OtherMember aliceQ Nothing roleNameWireAdmin
+
+  registerRemoteConv remoteConvId bobQ Nothing (Set.fromList [aliceAsOtherMember])
+
+  opts <- view tsGConf
+  void . withTempMockFederator opts remoteDomain (const (GetConversationsResponse [])) $ do
+    getConvQualified aliceId remoteConvId !!! do
+      const 404 === statusCode
+      const (Just "no-conversation") === view (at "label") . responseJsonUnsafe @Object
 
 testListRemoteConvs :: TestM ()
 testListRemoteConvs = do


### PR DESCRIPTION
Depends on #1703
Re-work of #1713 

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG-draft.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
