### PR TITLE
Fix snappy linker issue

### DIFF
--- a/CHANGELOG-draft.md
+++ b/CHANGELOG-draft.md
@@ -49,6 +49,7 @@ THIS FILE ACCUMULATES THE RELEASE NOTES FOR THE UPCOMING RELEASE.
 * The `DELETE /conversations/:cnv/members/:usr` endpoint rewritten to Servant (#1697)
 * Remove leftover auto-connect internal endpoint and code (#1716)
 * Clean up JSON golden tests (#1729)
+* Import fix for snappy linker issue (#1736)
 
 ## Federation changes
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -139,7 +139,6 @@ extra-deps:
 # Dropped from upstream snapshot
 - template-0.2.0.10
 - HaskellNet-0.5.2
-- snappy-0.2.0.2
 - smtp-mail-0.2.0.0
 - stm-containers-1.1.0.4 # Latest: lts-15.16
 - redis-resp-1.0.0
@@ -234,11 +233,15 @@ extra-deps:
   subdirs:
     - http2-client-grpc
 
-# Fix in for issue #27: https://github.com/kazu-yamamoto/http2/issues/27
+# Fix for issue #27: https://github.com/kazu-yamamoto/http2/issues/27
 # PR here: https://github.com/kazu-yamamoto/http2/pull/28
 # Note: the commit used here is based on version 2.0.6 of http2
 - git: https://github.com/wireapp/http2 # (2021-06-09) branch: header-encoding-0-size-table-backport
   commit: 7c465be1201e0945b106f7cc6176ac1b1193be13
+
+# Fix in PR: https://github.com/bos/snappy/pull/7
+- git: https://github.com/wireapp/snappy
+  commit: b0e5c08af48911caecffa4fa6a3e74872018b258 # master (Sep 03, 2021)
 
 ############################################################
 # Development tools

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -317,13 +317,6 @@ packages:
   original:
     hackage: HaskellNet-0.5.2
 - completed:
-    hackage: snappy-0.2.0.2@sha256:2931b03c5fdab2dac8d7eadb3be2f4ef8906666e43f1f1db65a06efd57ea701b,1591
-    pantry-tree:
-      size: 709
-      sha256: cd05c6ddfbbd3969adab3869d38d161e5ec8e72b1a72e00ca08f5e39538368cf
-  original:
-    hackage: snappy-0.2.0.2
-- completed:
     hackage: smtp-mail-0.2.0.0@sha256:b91c81f6dbb41a9ceee8c443385118684ecec55006b77f7d3c0e49cffd2468cf,1211
     pantry-tree:
       size: 449
@@ -792,6 +785,17 @@ packages:
   original:
     git: https://github.com/wireapp/http2
     commit: 7c465be1201e0945b106f7cc6176ac1b1193be13
+- completed:
+    name: snappy
+    version: 0.2.0.2
+    git: https://github.com/wireapp/snappy
+    pantry-tree:
+      size: 989
+      sha256: ae7fdf1988910fa026279052e85ade0a99962a3e7812ace104797e12ead0cd1d
+    commit: b0e5c08af48911caecffa4fa6a3e74872018b258
+  original:
+    git: https://github.com/wireapp/snappy
+    commit: b0e5c08af48911caecffa4fa6a3e74872018b258
 - completed:
     hackage: ormolu-0.1.4.1@sha256:ed404eac6e4eb64da1ca5fb749e0f99907431a9633e6ba34e44d260e7d7728ba,6499
     pantry-tree:


### PR DESCRIPTION
This selects a snappy branch containing a fix for a linker issue with libsnappy-1.1.9. The fix is in this PR: https://github.com/bos/snappy/pull/7

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] Section *Unreleased* of **CHANGELOG-draft.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.