### PR TITLE
Servantify conversation rename

### DIFF
--- a/CHANGELOG-draft.md
+++ b/CHANGELOG-draft.md
@@ -29,6 +29,8 @@ THIS FILE ACCUMULATES THE RELEASE NOTES FOR THE UPCOMING RELEASE.
 
 * Add `POST /conversations/list/v2` (#1703)
 * Deprecate `POST /list-conversations` (#1703)
+* Add `PUT /conversations/:domain/:cnv/name` (#1737)
+* Deprecate `PUT /conversations/:cnv/name` (#1737)
 
 ## Features
 

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -5,7 +5,5 @@ NAMESPACE=${NAMESPACE:-test-integration}
 
 echo "Running integration tests on wire-server"
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART=wire-server
-helm test -n "${NAMESPACE}" "${NAMESPACE}-${CHART}" --timeout 600s |
-  "$DIR/integration-test-logs.sh"
+helm test --logs -n "${NAMESPACE}" "${NAMESPACE}-${CHART}" --timeout 600s

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -757,7 +757,7 @@ newtype ConversationRename = ConversationRename
   }
   deriving stock (Eq, Show)
   deriving newtype (Arbitrary)
-  deriving (ToJSON, FromJSON) via Schema ConversationRename
+  deriving (S.ToSchema, ToJSON, FromJSON) via Schema ConversationRename
 
 instance ToSchema ConversationRename where
   schema =

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -298,9 +298,26 @@ data Api routes = Api
              RemoveFromConversationResponse,
     -- This endpoint can lead to the following events being sent:
     -- - ConvRename event to members
+    updateConversationNameDeprecated ::
+      routes
+        :- Summary "Update conversation name (deprecated)"
+        :> Description "Use `/conversations/:domain/:conv/name` instead."
+        :> ZUser
+        :> ZConn
+        :> "conversations"
+        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> ReqBody '[JSON] ConversationRename
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             [ ConvNotFound,
+               Respond 200 "Conversation updated" Event
+             ]
+             (Maybe Event),
     updateConversationNameUnqualified ::
       routes
-        :- Summary "Update conversation name"
+        :- Summary "Update conversation name (deprecated)"
+        :> Description "Use `/conversations/:domain/:conv/name` instead."
         :> ZUser
         :> ZConn
         :> "conversations"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -296,6 +296,40 @@ data Api routes = Api
              '[JSON]
              RemoveFromConversationHTTPResponse
              RemoveFromConversationResponse,
+    -- This endpoint can lead to the following events being sent:
+    -- - ConvRename event to members
+    updateConversationNameUnqualified ::
+      routes
+        :- Summary "Update conversation name"
+        :> ZUser
+        :> ZConn
+        :> "conversations"
+        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "name"
+        :> ReqBody '[JSON] ConversationRename
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             [ ConvNotFound,
+               Respond 200 "Conversation updated" Event
+             ]
+             (Maybe Event),
+    updateConversationName ::
+      routes
+        :- Summary "Update conversation name"
+        :> ZUser
+        :> ZConn
+        :> "conversations"
+        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "name"
+        :> ReqBody '[JSON] ConversationRename
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             [ ConvNotFound,
+               Respond 200 "Conversation updated" Event
+             ]
+             (Maybe Event),
     -- Team Conversations
 
     getTeamConversationRoles ::

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -92,6 +92,8 @@ servantSitemap =
         GalleyAPI.addMembersToConversationV2 = Update.addMembers,
         GalleyAPI.removeMemberUnqualified = Update.removeMemberUnqualified,
         GalleyAPI.removeMember = Update.removeMemberQualified,
+        GalleyAPI.updateConversationNameUnqualified = Update.updateLocalConversationName,
+        GalleyAPI.updateConversationName = Update.updateConversationName,
         GalleyAPI.getTeamConversationRoles = Teams.getTeamConversationRoles,
         GalleyAPI.getTeamConversations = Teams.getTeamConversations,
         GalleyAPI.getTeamConversation = Teams.getTeamConversation,
@@ -542,22 +544,6 @@ sitemap = do
       .&. accept "application" "json"
 
   -- Conversation API ---------------------------------------------------
-
-  -- This endpoint can lead to the following events being sent:
-  -- - ConvRename event to members
-  put "/conversations/:cnv/name" (continue Update.updateConversationNameH) $
-    zauthUserId
-      .&. zauthConnId
-      .&. capture "cnv"
-      .&. jsonRequest @Public.ConversationRename
-  document "PUT" "updateConversationName" $ do
-    summary "Update conversation name"
-    parameter Path "cnv" bytes' $
-      description "Conversation ID"
-    body (ref Public.modelConversationUpdateName) $
-      description "JSON body"
-    returns (ref Public.modelEvent)
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - ConvRename event to members

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -92,6 +92,7 @@ servantSitemap =
         GalleyAPI.addMembersToConversationV2 = Update.addMembers,
         GalleyAPI.removeMemberUnqualified = Update.removeMemberUnqualified,
         GalleyAPI.removeMember = Update.removeMemberQualified,
+        GalleyAPI.updateConversationNameDeprecated = Update.updateLocalConversationName,
         GalleyAPI.updateConversationNameUnqualified = Update.updateLocalConversationName,
         GalleyAPI.updateConversationName = Update.updateConversationName,
         GalleyAPI.getTeamConversationRoles = Teams.getTeamConversationRoles,
@@ -544,22 +545,6 @@ sitemap = do
       .&. accept "application" "json"
 
   -- Conversation API ---------------------------------------------------
-
-  -- This endpoint can lead to the following events being sent:
-  -- - ConvRename event to members
-  put "/conversations/:cnv" (continue Update.updateConversationDeprecatedH) $
-    zauthUserId
-      .&. zauthConnId
-      .&. capture "cnv"
-      .&. jsonRequest @Public.ConversationRename
-  document "PUT" "updateConversationName" $ do
-    summary "DEPRECATED! Please use updateConversationName instead!"
-    parameter Path "cnv" bytes' $
-      description "Conversation ID"
-    body (ref Public.modelConversationUpdateName) $
-      description "JSON body"
-    returns (ref Public.modelEvent)
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberJoin event to members

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -27,7 +27,8 @@ module Galley.API.Update
     rmCodeH,
     getCodeH,
     updateConversationDeprecatedH,
-    updateConversationNameH,
+    updateLocalConversationName,
+    updateConversationName,
     updateConversationAccessH,
     updateConversationReceiptModeH,
     updateConversationMessageTimerH,
@@ -125,6 +126,7 @@ import qualified Wire.API.ErrorDescription as Public
 import qualified Wire.API.Event.Conversation as Public
 import Wire.API.Federation.API.Galley (RemoteMessage (..))
 import qualified Wire.API.Federation.API.Galley as FederatedGalley
+import Wire.API.Federation.Error
 import qualified Wire.API.Message as Public
 import Wire.API.Routes.Public.Galley (UpdateResult (..))
 import Wire.API.Routes.Public.Galley.Responses
@@ -924,32 +926,52 @@ newMessage qusr con qcnv msg now (m, c, t) ~(toBots, toUsers) =
 updateConversationDeprecatedH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.ConversationRename -> Galley Response
 updateConversationDeprecatedH (zusr ::: zcon ::: cnv ::: req) = do
   convRename <- fromJsonBody req
-  setStatus status200 . json <$> updateConversationName zusr zcon cnv convRename
+  setStatus status200 . json <$> updateLocalConversationName zusr zcon cnv convRename
 
-updateConversationNameH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.ConversationRename -> Galley Response
-updateConversationNameH (zusr ::: zcon ::: cnv ::: req) = do
-  convRename <- fromJsonBody req
-  setStatus status200 . json <$> updateConversationName zusr zcon cnv convRename
+updateConversationName ::
+  UserId ->
+  ConnId ->
+  Qualified ConvId ->
+  Public.ConversationRename ->
+  Galley (Maybe Public.Event)
+updateConversationName usr zcon qcnv convRename = do
+  localDomain <- viewFederationDomain
+  if qDomain qcnv == localDomain
+    then updateLocalConversationName usr zcon (qUnqualified qcnv) convRename
+    else throwM federationNotImplemented
 
-updateConversationName :: UserId -> ConnId -> ConvId -> Public.ConversationRename -> Galley Public.Event
-updateConversationName zusr zcon cnv convRename = do
+updateLocalConversationName ::
+  UserId ->
+  ConnId ->
+  ConvId ->
+  Public.ConversationRename ->
+  Galley (Maybe Public.Event)
+updateLocalConversationName usr zcon cnv convRename = do
+  alive <- Data.isConvAlive cnv
+  if alive
+    then Just <$> updateLiveLocalConversationName usr zcon cnv convRename
+    else Nothing <$ Data.deleteConversation cnv
+
+updateLiveLocalConversationName ::
+  UserId ->
+  ConnId ->
+  ConvId ->
+  Public.ConversationRename ->
+  Galley Public.Event
+updateLiveLocalConversationName usr zcon cnv convRename = do
   localDomain <- viewFederationDomain
   let qcnv = Qualified cnv localDomain
-      qusr = Qualified zusr localDomain
-  alive <- Data.isConvAlive cnv
-  unless alive $ do
-    Data.deleteConversation cnv
-    throwErrorDescription convNotFound
+      qusr = Qualified usr localDomain
   (bots, users) <- localBotsAndUsers <$> Data.members cnv
-  ensureActionAllowedThrowing ModifyConversationName =<< getSelfMemberFromLocalsLegacy zusr users
+  ensureActionAllowedThrowing ModifyConversationName =<< getSelfMemberFromLocalsLegacy usr users
   now <- liftIO getCurrentTime
   cn <- rangeChecked (cupName convRename)
   Data.updateConversation cnv cn
   let e = Event ConvRename qcnv qusr now (EdConvRename convRename)
-  for_ (newPushLocal ListComplete zusr (ConvEvent e) (recipient <$> users)) $ \p ->
+  for_ (newPushLocal ListComplete usr (ConvEvent e) (recipient <$> users)) $ \p ->
     push1 $ p & pushConn ?~ zcon
   void . forkIO $ void $ External.deliver (bots `zip` repeat e)
-  return e
+  pure e
 
 isTypingH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.TypingData -> Galley Response
 isTypingH (zusr ::: zcon ::: cnv ::: req) = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2427,7 +2427,9 @@ putQualifiedConvRenameFailure = do
   qbob <- randomQualifiedUser
   let qconv = Qualified conv (qDomain qbob)
   putQualifiedConversationName (qUnqualified qbob) qconv "gossip"
-    !!! const 404 === statusCode
+    !!! do
+      const 404 === statusCode
+      const (Just "no-conversation") === fmap label . responseJsonUnsafe
 
 putQualifiedConvRenameOk :: TestM ()
 putQualifiedConvRenameOk = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -169,7 +169,10 @@ tests s =
           test s "delete conversations/:domain/:cnv/members/:domain/:usr - remote conv, leave conv" leaveRemoteConvQualifiedOk,
           test s "delete conversations/:domain/:cnv/members/:domain/:usr - remote conv, remove local user, fail" removeLocalMemberConvQualifiedFail,
           test s "delete conversations/:domain/:cnv/members/:domain/:usr - remote conv, remove remote user, fail" removeRemoteMemberConvQualifiedFail,
+          test s "rename conversation (deprecated endpoint)" putConvDeprecatedRenameOk,
           test s "rename conversation" putConvRenameOk,
+          test s "rename qualified conversation" putQualifiedConvRenameOk,
+          test s "rename qualified conversation failure" putQualifiedConvRenameFailure,
           test s "member update (otr mute)" putMemberOtrMuteOk,
           test s "member update (otr archive)" putMemberOtrArchiveOk,
           test s "member update (hidden)" putMemberHiddenOk,
@@ -2418,6 +2421,63 @@ deleteMembersUnqualifiedFailO2O = do
   o2o <- decodeConvId <$> postO2OConv alice bob (Just "foo")
   deleteMemberUnqualified alice bob o2o !!! const 403 === statusCode
 
+putQualifiedConvRenameFailure :: TestM ()
+putQualifiedConvRenameFailure = do
+  conv <- randomId
+  qbob <- randomQualifiedUser
+  let qconv = Qualified conv (qDomain qbob)
+  putQualifiedConversationName (qUnqualified qbob) qconv "gossip"
+    !!! const 404 === statusCode
+
+putQualifiedConvRenameOk :: TestM ()
+putQualifiedConvRenameOk = do
+  c <- view tsCannon
+  alice <- randomUser
+  qbob <- randomQualifiedUser
+  let bob = qUnqualified qbob
+  connectUsers alice (singleton bob)
+  conv <- decodeConvId <$> postO2OConv alice bob (Just "gossip")
+  let qconv = Qualified conv (qDomain qbob)
+  WS.bracketR2 c alice bob $ \(wsA, wsB) -> do
+    void $ putQualifiedConversationName bob qconv "gossip++" !!! const 200 === statusCode
+    void . liftIO . WS.assertMatchN (5 # Second) [wsA, wsB] $ \n -> do
+      let e = List1.head (WS.unpackPayload n)
+      ntfTransient n @?= False
+      evtConv e @?= qconv
+      evtType e @?= ConvRename
+      evtFrom e @?= qbob
+      evtData e @?= EdConvRename (ConversationRename "gossip++")
+
+putConvDeprecatedRenameOk :: TestM ()
+putConvDeprecatedRenameOk = do
+  c <- view tsCannon
+  g <- view tsGalley
+  alice <- randomUser
+  qbob <- randomQualifiedUser
+  let bob = qUnqualified qbob
+  connectUsers alice (singleton bob)
+  conv <- decodeConvId <$> postO2OConv alice bob (Just "gossip")
+  let qconv = Qualified conv (qDomain qbob)
+  WS.bracketR2 c alice bob $ \(wsA, wsB) -> do
+    -- This endpoint is deprecated but clients still use it
+    put
+      ( g
+          . paths ["conversations", toByteString' conv]
+          . zUser bob
+          . zConn "conn"
+          . zType "access"
+          . json (ConversationRename "gossip++")
+      )
+      !!! const 200
+      === statusCode
+    void . liftIO . WS.assertMatchN (5 # Second) [wsA, wsB] $ \n -> do
+      let e = List1.head (WS.unpackPayload n)
+      ntfTransient n @?= False
+      evtConv e @?= qconv
+      evtType e @?= ConvRename
+      evtFrom e @?= qbob
+      evtData e @?= EdConvRename (ConversationRename "gossip++")
+
 putConvRenameOk :: TestM ()
 putConvRenameOk = do
   c <- view tsCannon
@@ -2427,7 +2487,6 @@ putConvRenameOk = do
   connectUsers alice (singleton bob)
   conv <- decodeConvId <$> postO2OConv alice bob (Just "gossip")
   let qconv = Qualified conv (qDomain qbob)
-  -- This endpoint should be deprecated but clients still use it
   WS.bracketR2 c alice bob $ \(wsA, wsB) -> do
     void $ putConversationName bob conv "gossip++" !!! const 200 === statusCode
     void . liftIO . WS.assertMatchN (5 # Second) [wsA, wsB] $ \n -> do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -973,7 +973,7 @@ putConversationName u c n = do
   let update = ConversationRename n
   put
     ( g
-        . paths ["conversations", toByteString' c]
+        . paths ["conversations", toByteString' c, "name"]
         . zUser u
         . zConn "conn"
         . zType "access"

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -967,6 +967,24 @@ putOtherMember from to m c = do
       . zType "access"
       . json m
 
+putQualifiedConversationName :: UserId -> Qualified ConvId -> Text -> TestM ResponseLBS
+putQualifiedConversationName u c n = do
+  g <- view tsGalley
+  let update = ConversationRename n
+  put
+    ( g
+        . paths
+          [ "conversations",
+            toByteString' (qDomain c),
+            toByteString' (qUnqualified c),
+            "name"
+          ]
+        . zUser u
+        . zConn "conn"
+        . zType "access"
+        . json update
+    )
+
 putConversationName :: UserId -> ConvId -> Text -> TestM ResponseLBS
 putConversationName u c n = do
   g <- view tsGalley


### PR DESCRIPTION
This migrates the conversation rename endpoints to Servant, makes them deprecated, and adds a qualified endpoint for renaming a conversation. The qualified endpoint still only works for local conversations.

I also added some tests for both deprecated endpoints and the qualified endpoint, and a failing test for the qualified endpoint.

No new nginx routes are needed.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] Section *Unreleased* of **CHANGELOG-draft.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
