### PR TITLE
Ensure clients only receive messages meant for them in remote convs

### DIFF
--- a/CHANGELOG-draft.md
+++ b/CHANGELOG-draft.md
@@ -60,4 +60,4 @@ THIS FILE ACCUMULATES THE RELEASE NOTES FOR THE UPCOMING RELEASE.
 * Refactored remote error handling in federator (#1681)
 * The update conversation membership federation endpoint takes OriginDomainHeader (#1719)
 * Added new endpoint to allow fetching conversation metadata by qualified ids (#1703)
-* Ensure clients only recieve messages meant for them in remote convs (#1739)
+* Ensure clients only receive messages meant for them in remote convs (#1739)

--- a/CHANGELOG-draft.md
+++ b/CHANGELOG-draft.md
@@ -60,3 +60,4 @@ THIS FILE ACCUMULATES THE RELEASE NOTES FOR THE UPCOMING RELEASE.
 * Refactored remote error handling in federator (#1681)
 * The update conversation membership federation endpoint takes OriginDomainHeader (#1719)
 * Added new endpoint to allow fetching conversation metadata by qualified ids (#1703)
+* Ensure clients only recieve messages meant for them in remote convs (#1739)

--- a/libs/tasty-cannon/package.yaml
+++ b/libs/tasty-cannon/package.yaml
@@ -12,6 +12,7 @@ dependencies:
 - aeson
 - async
 - base >=4.6 && <5
+- bilge
 - bytestring
 - bytestring-conversion
 - data-timeout

--- a/libs/tasty-cannon/tasty-cannon.cabal
+++ b/libs/tasty-cannon/tasty-cannon.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b7fca22ffa51fd956424d50af91793bd16e3d1b5170e6ccc48b26bf821793358
+-- hash: 3e4d6b79f93c721b5df897b6653023feaa197910713bf3a2a759ea37ca05427f
 
 name:           tasty-cannon
 version:        0.4.0
@@ -30,6 +30,7 @@ library
       aeson
     , async
     , base >=4.6 && <5
+    , bilge
     , bytestring
     , bytestring-conversion
     , data-timeout

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -16,28 +16,37 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 module Galley.API.Federation where
 
+import Control.Lens (itraversed, (<.>))
 import Control.Monad.Catch (throwM)
 import Control.Monad.Except (runExceptT)
+import Data.ByteString.Conversion (toByteString')
 import Data.Containers.ListUtils (nubOrd)
 import Data.Domain
-import Data.Id (ConvId)
+import Data.Id (ConvId, UserId)
 import Data.Json.Util (Base64ByteString (..))
 import Data.List1 (list1)
+import qualified Data.Map as Map
+import Data.Map.Lens (toMapOf)
 import Data.Qualified (Qualified (..))
+import qualified Data.Set as Set
 import Data.Tagged
 import qualified Data.Text.Lazy as LT
 import Galley.API.Error (invalidPayload)
 import qualified Galley.API.Mapping as Mapping
-import Galley.API.Message (UserType (..), postQualifiedOtrMessage)
+import Galley.API.Message (MessageMetadata (..), UserType (..), postQualifiedOtrMessage, sendLocalMessages)
 import qualified Galley.API.Update as API
 import Galley.API.Util (fromRegisterConversation, pushConversationEvent, viewFederationDomain)
 import Galley.App (Galley)
 import qualified Galley.Data as Data
+import Galley.Types.Conversations.Members (InternalMember (..), LocalMember)
 import Imports
 import Servant (ServerT)
 import Servant.API.Generic (ToServantApi)
 import Servant.Server.Generic (genericServerT)
-import Wire.API.Conversation.Member (OtherMember (..), memId)
+import qualified System.Logger.Class as Log
+import qualified Wire.API.Conversation as Public
+import Wire.API.Conversation.Member (OtherMember (..))
+import qualified Wire.API.Conversation.Role as Public
 import Wire.API.Event.Conversation
 import Wire.API.Federation.API.Galley
   ( ConversationMemberUpdate (..),
@@ -52,6 +61,7 @@ import Wire.API.Federation.API.Galley
   )
 import qualified Wire.API.Federation.API.Galley as FederationAPIGalley
 import Wire.API.ServantProto (FromProto (..))
+import Wire.API.User.Client (userClientMap)
 
 federationSitemap :: ServerT (ToServantApi FederationAPIGalley.Api) Galley
 federationSitemap =
@@ -83,7 +93,7 @@ registerConversation rc = do
             (rcOrigUserId rc)
             (rcTime rc)
             (EdConversation c)
-    pushConversationEvent Nothing event [memId mem] []
+    pushConversationEvent Nothing event [Public.memId mem] []
 
 getConversations :: GetConversationsRequest -> Galley GetConversationsResponse
 getConversations (GetConversationsRequest qUid gcrConvIds) = do
@@ -144,10 +154,49 @@ leaveConversation requestingDomain lc = do
     API.removeMemberFromLocalConv leaver Nothing (lcConvId lc) leaver
 
 -- FUTUREWORK: report errors to the originating backend
+-- FUTUREWORK: error handling for missing / mismatched clients
 receiveMessage :: Domain -> RemoteMessage ConvId -> Galley ()
-receiveMessage domain =
-  API.postRemoteToLocal
-    . fmap (Tagged . (`Qualified` domain))
+receiveMessage domain rmUnqualified = do
+  let rm = fmap (Tagged . (`Qualified` domain)) rmUnqualified
+  let convId = unTagged $ rmConversation rm
+      msgMetadata =
+        MessageMetadata
+          { mmNativePush = rmPush rm,
+            mmTransient = rmTransient rm,
+            mmNativePriority = rmPriority rm,
+            mmData = rmData rm
+          }
+      recipientMap = userClientMap $ rmRecipients rm
+      msgs = toMapOf (itraversed <.> itraversed) recipientMap
+  (members, allMembers) <- Data.filterRemoteConvMembers (Map.keys recipientMap) convId
+  unless allMembers $
+    Log.warn $
+      Log.field "conversation" (toByteString' (qUnqualified convId))
+        Log.~~ Log.field "domain" (toByteString' (qDomain convId))
+        Log.~~ Log.msg
+          ( "Attempt to send remote message to local\
+            \ users not in the conversation" ::
+              ByteString
+          )
+  localMembers <- sequence $ Map.fromSet mkLocalMember (Set.fromList members)
+  void $ sendLocalMessages (rmTime rm) (rmSender rm) (rmSenderClient rm) Nothing convId localMembers msgMetadata msgs
+  where
+    -- FUTUREWORK: https://wearezeta.atlassian.net/browse/SQCORE-875
+    mkLocalMember :: UserId -> Galley LocalMember
+    mkLocalMember m =
+      pure $
+        InternalMember
+          { memId = m,
+            memService = Nothing,
+            memOtrMuted = False,
+            memOtrMutedStatus = Nothing,
+            memOtrMutedRef = Nothing,
+            memOtrArchived = False,
+            memOtrArchivedRef = Nothing,
+            memHidden = False,
+            memHiddenRef = Nothing,
+            memConvRoleName = Public.roleNameWireMember
+          }
 
 sendMessage :: Domain -> MessageSendRequest -> Galley MessageSendResponse
 sendMessage originDomain msr = do

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -432,11 +432,11 @@ runMessagePush cnv mp = do
       mapM_ (deleteBot (qUnqualified cnv) . botMemId) gone
 
 newMessageEvent :: Qualified ConvId -> Qualified UserId -> ClientId -> Maybe Text -> UTCTime -> ClientId -> Text -> Event
-newMessageEvent convId sender senderClient dat time recieverClient cipherText =
+newMessageEvent convId sender senderClient dat time receiverClient cipherText =
   Event OtrMessageAdd convId sender time . EdOtrMessage $
     OtrMessage
       { otrSender = senderClient,
-        otrRecipient = recieverClient,
+        otrRecipient = receiverClient,
         otrCiphertext = cipherText,
         otrData = dat
       }

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -309,10 +309,10 @@ sendMessages ::
   Galley QualifiedUserClients
 sendMessages now sender senderClient mconn conv localMemberMap metadata messages = do
   localDomain <- viewFederationDomain
-  let messageMap = byDomain messages
+  let messageMap = byDomain $ fmap toBase64Text messages
   let send dom
         | localDomain == dom =
-          sendLocalMessages now sender senderClient mconn conv localMemberMap metadata
+          sendLocalMessages now sender senderClient mconn (Qualified conv localDomain) localMemberMap metadata
         | otherwise =
           sendRemoteMessages dom now sender senderClient conv metadata
   mkQualifiedUserClientsByDomain <$> Map.traverseWithKey send messageMap
@@ -328,17 +328,17 @@ sendLocalMessages ::
   Qualified UserId ->
   ClientId ->
   Maybe ConnId ->
-  ConvId ->
+  Qualified ConvId ->
   Map UserId LocalMember ->
   MessageMetadata ->
-  Map (UserId, ClientId) ByteString ->
+  Map (UserId, ClientId) Text ->
   Galley (Set (UserId, ClientId))
 sendLocalMessages now sender senderClient mconn conv localMemberMap metadata localMessages = do
   localDomain <- viewFederationDomain
   let events =
         localMessages & reindexed snd itraversed
           %@~ newMessageEvent
-            (Qualified conv localDomain)
+            conv
             sender
             senderClient
             (mmData metadata)
@@ -356,18 +356,18 @@ sendRemoteMessages ::
   ClientId ->
   ConvId ->
   MessageMetadata ->
-  Map (UserId, ClientId) ByteString ->
+  Map (UserId, ClientId) Text ->
   Galley (Set (UserId, ClientId))
 sendRemoteMessages domain now sender senderClient conv metadata messages = handle <=< runExceptT $ do
   let rcpts =
         foldr
-          (\((u, c), t) -> Map.insertWith (<>) u (Map.singleton c (toBase64Text t)))
+          (\((u, c), t) -> Map.insertWith (<>) u (Map.singleton c t))
           mempty
           (Map.assocs messages)
       rm =
         FederatedGalley.RemoteMessage
           { FederatedGalley.rmTime = now,
-            FederatedGalley.rmData = Just (toBase64Text (mmData metadata)),
+            FederatedGalley.rmData = mmData metadata,
             FederatedGalley.rmSender = sender,
             FederatedGalley.rmSenderClient = senderClient,
             FederatedGalley.rmConversation = conv,
@@ -420,21 +420,25 @@ newUserPush p = MessagePush {userPushes = pure p, botPushes = mempty}
 newBotPush :: BotMember -> Event -> MessagePush
 newBotPush b e = MessagePush {userPushes = mempty, botPushes = pure (b, e)}
 
-runMessagePush :: ConvId -> MessagePush -> Galley ()
+runMessagePush :: Qualified ConvId -> MessagePush -> Galley ()
 runMessagePush cnv mp = do
+  localDomain <- viewFederationDomain
   pushSome (userPushes mp)
-  void . forkIO $ do
-    gone <- External.deliver (botPushes mp)
-    mapM_ (deleteBot cnv . botMemId) gone
+  if localDomain /= qDomain cnv
+    then unless (null (botPushes mp)) $ do
+      Log.warn $ Log.msg ("Ignoring messages for local bots in a remote conversation" :: ByteString) . Log.field "conversation" (show cnv)
+    else void . forkIO $ do
+      gone <- External.deliver (botPushes mp)
+      mapM_ (deleteBot (qUnqualified cnv) . botMemId) gone
 
-newMessageEvent :: Qualified ConvId -> Qualified UserId -> ClientId -> ByteString -> UTCTime -> ClientId -> ByteString -> Event
+newMessageEvent :: Qualified ConvId -> Qualified UserId -> ClientId -> Maybe Text -> UTCTime -> ClientId -> Text -> Event
 newMessageEvent convId sender senderClient dat time recieverClient cipherText =
   Event OtrMessageAdd convId sender time . EdOtrMessage $
     OtrMessage
       { otrSender = senderClient,
         otrRecipient = recieverClient,
-        otrCiphertext = toBase64Text cipherText,
-        otrData = Just $ toBase64Text dat
+        otrCiphertext = cipherText,
+        otrData = dat
       }
 
 newMessagePush ::
@@ -466,7 +470,7 @@ data MessageMetadata = MessageMetadata
   { mmNativePush :: Bool,
     mmTransient :: Bool,
     mmNativePriority :: Maybe Priority,
-    mmData :: ByteString
+    mmData :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 
@@ -476,7 +480,7 @@ qualifiedNewOtrMetadata msg =
     { mmNativePush = qualifiedNewOtrNativePush msg,
       mmTransient = qualifiedNewOtrTransient msg,
       mmNativePriority = qualifiedNewOtrNativePriority msg,
-      mmData = qualifiedNewOtrData msg
+      mmData = Just . toBase64Text $ qualifiedNewOtrData msg
     }
 
 -- unqualified

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -277,7 +277,7 @@ uncheckedUpdateConversationAccess body usr zcon conv (currentAccess, targetAcces
   case removedUsers of
     [] -> return ()
     x : xs -> do
-      -- FUTUREWORK: deal with remote members, too, see removeMembers
+      -- FUTUREWORK: deal with remote members, too, see removeMembers (Jira SQCORE-903)
       e <- Data.removeLocalMembersFromLocalConv localDomain conv (Qualified usr localDomain) (x :| xs)
       -- push event to all clients, including zconn
       -- since updateConversationAccess generates a second (member removal) event here
@@ -472,19 +472,6 @@ addMembersH (zusr ::: zcon ::: cid ::: req) = do
   let qInvite = Public.InviteQualified (flip Qualified domain <$> toNonEmpty u) r
   handleUpdateResult <$> addMembers zusr zcon cid qInvite
 
--- FUTUREWORK(federation): we need the following checks/implementation:
---  - (1) [DONE] Remote qualified users must exist before they can be added (a
---  call to the respective backend should be made): Avoid clients making up random
---  Ids, and increase the chances that the updateConversationMemberships call
---  suceeds
---  - (2) [DONE] A call must be made to the remote backend informing it that this user is
---  now part of that conversation. Use and implement 'updateConversationMemberships'.
---    - that call should probably be made *after* inserting the conversation membership
---    happens in this backend.
---    - 'updateConversationMemberships' should send an event to the affected
---    users informing them they have joined a remote conversation.
---  - (3) Events should support remote / qualified users, too.
---  These checks need tests :)
 addMembers :: UserId -> ConnId -> ConvId -> Public.InviteQualified -> Galley UpdateResult
 addMembers zusr zcon convId invite = do
   conv <- Data.conversation convId >>= ifNothing (errorDescriptionToWai convNotFound)
@@ -741,9 +728,6 @@ postBotMessage :: BotId -> ConvId -> Public.OtrFilterMissing -> Public.NewOtrMes
 postBotMessage zbot zcnv val message =
   postNewOtrMessage Bot (botUserId zbot) Nothing zcnv val message
 
--- | FUTUREWORK: Send message to remote users, as of now this function fails if
--- the conversation is not hosted on current backend. If the conversation is
--- hosted on current backend, it completely ignores remote users.
 postProteusMessage :: UserId -> ConnId -> Qualified ConvId -> RawProto Public.QualifiedNewOtrMessage -> Galley (Public.PostOtrResponse Public.MessageSendingStatus)
 postProteusMessage zusr zcon conv msg = do
   localDomain <- viewFederationDomain

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -436,7 +436,7 @@ receiveMessage = do
 
       -- These should be the only events for each device of alice. This verifies
       -- that targetted delivery to the clients was used so that client 2 does
-      -- not recieve the message encrypted for client 1 and vice versa.
+      -- not receive the message encrypted for client 1 and vice versa.
       WS.assertNoEvent (1 # Second) [wsA1]
       WS.assertNoEvent (1 # Second) [wsA2]
 


### PR DESCRIPTION
This PR removes duplicated logic to push messages to clients by making logic
in Galley.API.Message.sendLocalMessages accomodating to pushing messages for
remote conversations, but still enforcing the recipients to be local. Using this
function from federation endpoint of galley allows us to not duplicate the logic
for how a message becomes an event and gets pushed to each client.

The PR also moves this logic from Galley.API.Update to Galley.API.Federation
as most of the logic to translate from inputs of the federation endpoint to
inputs for Galley.API.Message.sendLocalMessages is very federation specific and
doesn't need to live in the public API module.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] Section *Unreleased* of **CHANGELOG-draft.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If /a: measures to be taken by instance operators.
   - [x] If /a: list of cassandra migrations.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
