### PR TITLE
Servantify conversation self member endpoints

### DIFF
--- a/CHANGELOG-draft.md
+++ b/CHANGELOG-draft.md
@@ -8,6 +8,8 @@ THIS FILE ACCUMULATES THE RELEASE NOTES FOR THE UPCOMING RELEASE.
 
 * Add `PUT /conversations/:domain/:cnv/name` (#1737)
 * Deprecate `PUT /conversations/:cnv/name` (#1737)
+* Add `GET & PUT /conversations/:domain/:cnv/self` (#1740)
+* Deprecate `GET & PUT /conversations/:cnv/self` (#1740)
 
 ## Features
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -369,6 +369,23 @@ data Api routes = Api
                Respond 200 "Membership information" Member
              ]
              (Maybe Member),
+    updateConversationSelfUnqualified ::
+      routes
+        :- Summary "Update self membership properties"
+        :> Description "At least one field has to be provided."
+        :> CanThrow ConvNotFound
+        :> CanThrow ConvAccessDenied
+        :> ZUser
+        :> ZConn
+        :> "conversations"
+        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "self"
+        :> ReqBody '[JSON] MemberUpdate
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             '[RespondEmpty 200 "Update successful"]
+             (),
     -- Team Conversations
 
     getTeamConversationRoles ::

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -349,7 +349,8 @@ data Api routes = Api
              (Maybe Event),
     getConversationSelfUnqualified ::
       routes
-        :- Summary "Get self membership properties"
+        :- Summary "Get self membership properties (deprecated)"
+        :> Description "Use `/conversations/:domain/:conv/self` instead."
         :> ZUser
         :> "conversations"
         :> Capture' '[Description "Conversation ID"] "cnv" ConvId
@@ -371,14 +372,31 @@ data Api routes = Api
              (Maybe Member),
     updateConversationSelfUnqualified ::
       routes
-        :- Summary "Update self membership properties"
-        :> Description "At least one field has to be provided."
+        :- Summary "Update self membership properties (deprecated)"
+        :> Description "Use `/conversations/:domain/:conv/self` instead."
         :> CanThrow ConvNotFound
         :> CanThrow ConvAccessDenied
         :> ZUser
         :> ZConn
         :> "conversations"
         :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "self"
+        :> ReqBody '[JSON] MemberUpdate
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             '[RespondEmpty 200 "Update successful"]
+             (),
+    updateConversationSelf ::
+      routes
+        :- Summary "Update self membership properties"
+        :> Description "**Note**: at least one field has to be provided."
+        :> CanThrow ConvNotFound
+        :> CanThrow ConvAccessDenied
+        :> ZUser
+        :> ZConn
+        :> "conversations"
+        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
         :> "self"
         :> ReqBody '[JSON] MemberUpdate
         :> MultiVerb

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -347,6 +347,28 @@ data Api routes = Api
                Respond 200 "Conversation updated" Event
              ]
              (Maybe Event),
+    getConversationSelfUnqualified ::
+      routes
+        :- Summary "Get self membership properties"
+        :> ZUser
+        :> "conversations"
+        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "self"
+        :> Get '[JSON] (Maybe Member),
+    getConversationSelf ::
+      routes
+        :- Summary "Get self membership properties"
+        :> ZUser
+        :> "conversations"
+        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "self"
+        :> MultiVerb
+             'GET
+             '[JSON]
+             [ ConvNotFound,
+               Respond 200 "Membership information" Member
+             ]
+             (Maybe Member),
     -- Team Conversations
 
     getTeamConversationRoles ::

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -97,6 +97,7 @@ servantSitemap =
         GalleyAPI.updateConversationName = Update.updateConversationName,
         GalleyAPI.getConversationSelfUnqualified = Query.getLocalSelf,
         GalleyAPI.getConversationSelf = Query.getSelf,
+        GalleyAPI.updateConversationSelfUnqualified = Update.updateLocalSelfMember,
         GalleyAPI.getTeamConversationRoles = Teams.getTeamConversationRoles,
         GalleyAPI.getTeamConversations = Teams.getTeamConversations,
         GalleyAPI.getTeamConversation = Teams.getTeamConversation,
@@ -719,22 +720,6 @@ sitemap = do
     errorResponse (Error.invalidOp "Conversation type does not allow adding members")
     errorResponse (Error.errorDescriptionToWai Error.notConnected)
     errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
-
-  -- This endpoint can lead to the following events being sent:
-  -- - MemberStateUpdate event to self
-  put "/conversations/:cnv/self" (continue Update.updateSelfMemberH) $
-    zauthUserId
-      .&. zauthConnId
-      .&. capture "cnv"
-      .&. jsonRequest @Public.MemberUpdate
-  document "PUT" "updateSelf" $ do
-    summary "Update self membership properties"
-    notes "Even though all fields are optional, at least one needs to be given."
-    parameter Path "cnv" bytes' $
-      description "Conversation ID"
-    body (ref Public.modelMemberUpdate) $
-      description "JSON body"
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberStateUpdate event to members

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -98,6 +98,7 @@ servantSitemap =
         GalleyAPI.getConversationSelfUnqualified = Query.getLocalSelf,
         GalleyAPI.getConversationSelf = Query.getSelf,
         GalleyAPI.updateConversationSelfUnqualified = Update.updateLocalSelfMember,
+        GalleyAPI.updateConversationSelf = Update.updateSelfMember,
         GalleyAPI.getTeamConversationRoles = Teams.getTeamConversationRoles,
         GalleyAPI.getTeamConversations = Teams.getTeamConversations,
         GalleyAPI.getTeamConversation = Teams.getTeamConversation,

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -95,6 +95,8 @@ servantSitemap =
         GalleyAPI.updateConversationNameDeprecated = Update.updateLocalConversationName,
         GalleyAPI.updateConversationNameUnqualified = Update.updateLocalConversationName,
         GalleyAPI.updateConversationName = Update.updateConversationName,
+        GalleyAPI.getConversationSelfUnqualified = Query.getLocalSelf,
+        GalleyAPI.getConversationSelf = Query.getSelf,
         GalleyAPI.getTeamConversationRoles = Teams.getTeamConversationRoles,
         GalleyAPI.getTeamConversations = Teams.getTeamConversations,
         GalleyAPI.getTeamConversation = Teams.getTeamConversation,
@@ -717,16 +719,6 @@ sitemap = do
     errorResponse (Error.invalidOp "Conversation type does not allow adding members")
     errorResponse (Error.errorDescriptionToWai Error.notConnected)
     errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
-
-  get "/conversations/:cnv/self" (continue Query.getSelfH) $
-    zauthUserId
-      .&. capture "cnv"
-  document "GET" "getSelf" $ do
-    summary "Get self membership properties"
-    parameter Path "cnv" bytes' $
-      description "Conversation ID"
-    returns (ref Public.modelMember)
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberStateUpdate event to self

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -37,6 +37,7 @@ module Galley.API.Update
     addMembersH,
     addMembers,
     updateLocalSelfMember,
+    updateSelfMember,
     updateOtherMemberH,
     removeMember,
     removeMemberQualified,
@@ -126,7 +127,7 @@ import qualified Wire.API.ErrorDescription as Public
 import qualified Wire.API.Event.Conversation as Public
 import Wire.API.Federation.API.Galley (RemoteMessage (..))
 import qualified Wire.API.Federation.API.Galley as FederatedGalley
-import Wire.API.Federation.Error
+import Wire.API.Federation.Error (federationNotImplemented)
 import qualified Wire.API.Message as Public
 import Wire.API.Routes.Public.Galley (UpdateResult (..))
 import Wire.API.Routes.Public.Galley.Responses
@@ -553,6 +554,13 @@ addMembers zusr zcon convId invite = do
 
     checkLHPolicyConflictsRemote :: FutureWork 'LegalholdPlusFederationNotImplemented [Remote UserId] -> Galley ()
     checkLHPolicyConflictsRemote _remotes = pure ()
+
+updateSelfMember :: UserId -> ConnId -> Qualified ConvId -> Public.MemberUpdate -> Galley ()
+updateSelfMember zusr zcon qcnv update = do
+  localDomain <- viewFederationDomain
+  if qDomain qcnv == localDomain
+    then updateLocalSelfMember zusr zcon (qUnqualified qcnv) update
+    else throwM federationNotImplemented
 
 updateLocalSelfMember :: UserId -> ConnId -> ConvId -> Public.MemberUpdate -> Galley ()
 updateLocalSelfMember zusr zcon cid update = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -36,7 +36,7 @@ module Galley.API.Update
     -- * Managing Members
     addMembersH,
     addMembers,
-    updateSelfMemberH,
+    updateLocalSelfMember,
     updateOtherMemberH,
     removeMember,
     removeMemberQualified,
@@ -554,14 +554,8 @@ addMembers zusr zcon convId invite = do
     checkLHPolicyConflictsRemote :: FutureWork 'LegalholdPlusFederationNotImplemented [Remote UserId] -> Galley ()
     checkLHPolicyConflictsRemote _remotes = pure ()
 
-updateSelfMemberH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.MemberUpdate -> Galley Response
-updateSelfMemberH (zusr ::: zcon ::: cid ::: req) = do
-  update <- fromJsonBody req
-  updateSelfMember zusr zcon cid update
-  return empty
-
-updateSelfMember :: UserId -> ConnId -> ConvId -> Public.MemberUpdate -> Galley ()
-updateSelfMember zusr zcon cid update = do
+updateLocalSelfMember :: UserId -> ConnId -> ConvId -> Public.MemberUpdate -> Galley ()
+updateLocalSelfMember zusr zcon cid update = do
   conv <- getConversationAndCheckMembership zusr cid
   m <- getSelfMemberFromLocalsLegacy zusr (Data.convLocalMembers conv)
   -- Ensure no self role upgrades


### PR DESCRIPTION
This converts `/conversation/:cnv/self` endpoints (`GET` and `PUT`) to servant, adds local-only stubs for their qualified counterparts, and deprecates the unqualified endpoints. This is only an internal change.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If end-points have been added or changed: the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] Section *Unreleased* of **CHANGELOG-draft.md** contains the following bits of information:
   - [x] A line with the title and number of the PR in one or more suitable sub-sections.
   - [x] If public end-points have been changed or added: does nginz need upgrade?
