### PR TITLE
Revert hack to display helm test output

### DIFF
--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -5,7 +5,5 @@ NAMESPACE=${NAMESPACE:-test-integration}
 
 echo "Running integration tests on wire-server"
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART=wire-server
-helm test -n "${NAMESPACE}" "${NAMESPACE}-${CHART}" --timeout 600s |
-  "$DIR/integration-test-logs.sh"
+helm test --logs -n "${NAMESPACE}" "${NAMESPACE}-${CHART}" --timeout 600s


### PR DESCRIPTION
The hack in #1700 does not actually seem to work in CI, and in fact it prevents log output from being displayed at all when helm test fails.

The `integration-test-logs.sh` script is still around, and it can be used to display `helm test` output interactive when running tests manually in a terminal.

*No CHANGELOG entry.*

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.