### PR TITLE
Increase federator monitor test timeout to 10s

### DIFF
--- a/changelog.d/5-internal/fed-cert-test-timeout
+++ b/changelog.d/5-internal/fed-cert-test-timeout
@@ -1,0 +1,1 @@
+Increased timeout on certificate update tests to 10s

--- a/services/federator/test/unit/Test/Federator/Monitor.hs
+++ b/services/federator/test/unit/Test/Federator/Monitor.hs
@@ -41,7 +41,7 @@ import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 
 timeoutMicroseconds :: Int
-timeoutMicroseconds = 1000000
+timeoutMicroseconds = 10000000
 
 tests :: TestTree
 tests =


### PR DESCRIPTION
Apparently, 1 second is not enough in CI.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
