### PR TITLE
Remove self role updates

### DIFF
--- a/changelog.d/1-api-changes/remove-get-self
+++ b/changelog.d/1-api-changes/remove-get-self
@@ -1,0 +1,1 @@
+Remove endpoint `GET /conversations/:domain/:cnv/self`

--- a/changelog.d/1-api-changes/remove-self-role-update
+++ b/changelog.d/1-api-changes/remove-self-role-update
@@ -1,0 +1,1 @@
+Removed the ability to update one's own role

--- a/libs/wire-api/src/Wire/API/Conversation/Member.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Member.hs
@@ -206,14 +206,13 @@ data MemberUpdate = MemberUpdate
     mupOtrArchive :: Maybe Bool,
     mupOtrArchiveRef :: Maybe Text,
     mupHidden :: Maybe Bool,
-    mupHiddenRef :: Maybe Text,
-    mupConvRoleName :: Maybe RoleName
+    mupHiddenRef :: Maybe Text
   }
   deriving stock (Eq, Show, Generic)
   deriving (FromJSON, ToJSON, S.ToSchema) via Schema MemberUpdate
 
 memberUpdate :: MemberUpdate
-memberUpdate = MemberUpdate Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+memberUpdate = MemberUpdate Nothing Nothing Nothing Nothing Nothing Nothing
 
 modelMemberUpdate :: Doc.Model
 modelMemberUpdate = Doc.defineModel "MemberUpdate" $ do
@@ -233,9 +232,6 @@ modelMemberUpdate = Doc.defineModel "MemberUpdate" $ do
   Doc.property "hidden_ref" Doc.bytes' $ do
     Doc.description "A reference point for (un)hiding"
     Doc.optional
-  Doc.property "conversation_role" Doc.string' $ do
-    Doc.description "Name of the conversation role to update to"
-    Doc.optional
 
 instance ToSchema MemberUpdate where
   schema =
@@ -248,7 +244,6 @@ instance ToSchema MemberUpdate where
         <*> mupOtrArchiveRef .= opt (field "otr_archived_ref" schema)
         <*> mupHidden .= opt (field "hidden" schema)
         <*> mupHiddenRef .= opt (field "hidden_ref" schema)
-        <*> mupConvRoleName .= opt (field "conversation_role" schema)
 
 instance Arbitrary MemberUpdate where
   arbitrary =
@@ -263,7 +258,6 @@ validateMemberUpdate u =
          || isJust (mupOtrArchiveRef u)
          || isJust (mupHidden u)
          || isJust (mupHiddenRef u)
-         || isJust (mupConvRoleName u)
      )
     then Right u
     else
@@ -272,7 +266,7 @@ validateMemberUpdate u =
         \'hidden', 'hidden_ref', 'conversation_role'} required."
 
 -- | Inbound other member updates.  This is what galley expects on its endpoint.  See also
--- 'OtherMemberUpdateData' - that event is meant to be sent to all users in a conversation.
+-- 'MemberUpdateData' - that event is meant to be sent to all users in a conversation.
 data OtherMemberUpdate = OtherMemberUpdate
   { omuConvRoleName :: Maybe RoleName
   }

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -336,26 +336,11 @@ data Api routes = Api
     getConversationSelfUnqualified ::
       routes
         :- Summary "Get self membership properties (deprecated)"
-        :> Description "Use `/conversations/:domain/:conv/self` instead."
         :> ZUser
         :> "conversations"
         :> Capture' '[Description "Conversation ID"] "cnv" ConvId
         :> "self"
         :> Get '[JSON] (Maybe Member),
-    getConversationSelf ::
-      routes
-        :- Summary "Get self membership properties"
-        :> ZUser
-        :> "conversations"
-        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "self"
-        :> MultiVerb
-             'GET
-             '[JSON]
-             [ ConvNotFound,
-               Respond 200 "Membership information" Member
-             ]
-             (Maybe Member),
     updateConversationSelfUnqualified ::
       routes
         :- Summary "Update self membership properties (deprecated)"

--- a/libs/wire-api/test/golden/testObject_MemberUpdate_user_1.json
+++ b/libs/wire-api/test/golden/testObject_MemberUpdate_user_1.json
@@ -1,5 +1,4 @@
 {
-    "conversation_role": "nn8oubrrivojp29q65krhyfzzgvzt3yb18z_39zct19xff_7_wm4xk0ixmzaep5oj3cdajj36vwbc89pgajtmzo1rbwc40ulc837b1aknib6cj03k64ovt4p0h",
     "hidden": false,
     "hidden_ref": "",
     "otr_archived": true,

--- a/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/MemberUpdate_user.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/MemberUpdate_user.hs
@@ -16,10 +16,9 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 module Test.Wire.API.Golden.Generated.MemberUpdate_user where
 
-import Imports (Bool (False, True), Maybe (Just, Nothing), fromJust, ($), (.))
+import Imports (Bool (False, True), Maybe (Just, Nothing), ($), (.))
 import Wire.API.Conversation (MemberUpdate (..))
 import Wire.API.Conversation.Member (MutedStatus (MutedStatus))
-import Wire.API.Conversation.Role (parseRoleName)
 
 testObject_MemberUpdate_user_1 :: MemberUpdate
 testObject_MemberUpdate_user_1 =
@@ -29,14 +28,7 @@ testObject_MemberUpdate_user_1 =
       mupOtrArchive = Just True,
       mupOtrArchiveRef = Just "ref",
       mupHidden = Just False,
-      mupHiddenRef = Just "",
-      mupConvRoleName =
-        Just
-          ( fromJust
-              ( parseRoleName
-                  "nn8oubrrivojp29q65krhyfzzgvzt3yb18z_39zct19xff_7_wm4xk0ixmzaep5oj3cdajj36vwbc89pgajtmzo1rbwc40ulc837b1aknib6cj03k64ovt4p0h"
-              )
-          )
+      mupHiddenRef = Just ""
     }
 
 testObject_MemberUpdate_user_2 :: MemberUpdate
@@ -47,6 +39,5 @@ testObject_MemberUpdate_user_2 =
       mupOtrArchive = Nothing,
       mupOtrArchiveRef = Nothing,
       mupHidden = Just False,
-      mupHiddenRef = Nothing,
-      mupConvRoleName = Nothing
+      mupHiddenRef = Nothing
     }

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -96,7 +96,6 @@ servantSitemap =
         GalleyAPI.updateConversationNameUnqualified = Update.updateLocalConversationName,
         GalleyAPI.updateConversationName = Update.updateConversationName,
         GalleyAPI.getConversationSelfUnqualified = Query.getLocalSelf,
-        GalleyAPI.getConversationSelf = Query.getSelf,
         GalleyAPI.updateConversationSelfUnqualified = Update.updateLocalSelfMember,
         GalleyAPI.updateConversationSelf = Update.updateSelfMember,
         GalleyAPI.getTeamConversationRoles = Teams.getTeamConversationRoles,

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -28,7 +28,6 @@ module Galley.API.Query
     listConversationsV2,
     iterateConversations,
     getLocalSelf,
-    getSelf,
     internalGetMemberH,
     getConversationMetaH,
     getConversationByReusableCode,
@@ -347,13 +346,6 @@ iterateConversations uid pageSize handleConvs = go Nothing
             else pure []
         _ -> pure []
       pure $ resultHead : resultTail
-
-getSelf :: UserId -> Qualified ConvId -> Galley (Maybe Public.Member)
-getSelf zusr qcnv = do
-  localDomain <- viewFederationDomain
-  if localDomain == qDomain qcnv
-    then getLocalSelf zusr (qUnqualified qcnv)
-    else throwM federationNotImplemented
 
 internalGetMemberH :: ConvId ::: UserId -> Galley Response
 internalGetMemberH (cnv ::: usr) = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2599,7 +2599,7 @@ putMemberOk update = do
             memOtrArchivedRef = mupOtrArchiveRef update,
             memHidden = Just True == mupHidden update,
             memHiddenRef = mupHiddenRef update,
-            memConvRoleName = fromMaybe roleNameWireAdmin (mupConvRoleName update)
+            memConvRoleName = roleNameWireAdmin
           }
   -- Update member state & verify push notification
   WS.bracketR c bob $ \ws -> do
@@ -2629,7 +2629,7 @@ putMemberOk update = do
     assertEqual "otr_archived" (memOtrArchived memberBob) (memOtrArchived newBob)
     assertEqual "otr_archived_ref" (memOtrArchivedRef memberBob) (memOtrArchivedRef newBob)
     assertEqual "hidden" (memHidden memberBob) (memHidden newBob)
-    assertEqual "hidden__ref" (memHiddenRef memberBob) (memHiddenRef newBob)
+    assertEqual "hidden_ref" (memHiddenRef memberBob) (memHiddenRef newBob)
 
 putReceiptModeOk :: TestM ()
 putReceiptModeOk = do

--- a/services/galley/test/integration/API/Roles.hs
+++ b/services/galley/test/integration/API/Roles.hs
@@ -218,10 +218,6 @@ wireMemberChecks cid mem admin otherMem = do
   putOtherMember mem mem sneakyOtherMemberUpdate cid !!! do
     const 403 === statusCode
     const (Just "invalid-op") === fmap label . responseJsonUnsafe
-  let selfMemberUpdate = memberUpdate {mupConvRoleName = Just roleNameWireAdmin}
-  putMember mem selfMemberUpdate cid !!! do
-    const 403 === statusCode
-    const (Just "invalid-actions") === fmap label . responseJsonUnsafe
   -- No updates for message timer, receipt mode or access
   putMessageTimerUpdate mem cid (ConversationMessageTimerUpdate Nothing) !!! assertActionDenied
   putReceiptMode mem cid (ReceiptMode 0) !!! assertActionDenied


### PR DESCRIPTION
Updates to a member's role now always happen via `OtherMemberUpdate`, while `MemberUpdate` is only used to change conversation self status (i.e. hidden/muted/archived).

Also remove the newly added qualified endpoint for fetching self membership data. It was not implemented for remote conversations, and it is not going to be, since the role will not even be stored remotely.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
