### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: 2021-09-06-staging.3-v0.28.24-e6e306b
+  tag: "2021-09-13-production.0-v0.28.25-0-ede3342"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2021-09-13-production.0-v0.28.25-0-ede3342`
Release: [`2021-09-13-production.0`](https://github.com/wireapp/wire-webapp/releases/tag/2021-09-13-production.0)