### PR TITLE
fix flaky test by waiting for user deletion to finish

### DIFF
--- a/changelog.d/5-internal/fix-flaky-spar-test
+++ b/changelog.d/5-internal/fix-flaky-spar-test
@@ -1,0 +1,1 @@
+Fix for flaky test in spar

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -23,6 +23,7 @@ module Test.Spar.APISpec
 where
 
 import Bilge
+import Brig.Types.Intra (AccountStatus (Deleted))
 import Brig.Types.User
 import Cassandra hiding (Value)
 import Control.Lens hiding ((.=))
@@ -1184,8 +1185,9 @@ specDeleteCornerCases = describe "delete corner cases" $ do
     deleteViaBrig :: UserId -> TestSpar ()
     deleteViaBrig uid = do
       brig <- view teBrig
-      resp <- (call . delete $ brig . paths ["i", "users", toByteString' uid])
+      resp <- call . delete $ brig . paths ["i", "users", toByteString' uid]
       liftIO $ responseStatus resp `shouldBe` status202
+      void $ aFewTimes (runSpar $ Intra.getStatus uid) (== Deleted)
 
 specScimAndSAML :: SpecWith TestEnv
 specScimAndSAML = do


### PR DESCRIPTION
Possible fix for flaky test as described in https://wearezeta.atlassian.net/browse/SQSERVICES-780

```
Failures:
  test-integration/Test/Spar/APISpec.hs:1159:17: 
  
  1) Spar.API, delete corner cases, re-create previously deleted, dangling users

       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\"><html xml:lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\"><head>  <title>wire:sso:error:unknown-error</title>   <script type=\"text/javascript\">       const receiverOrigin = '*';       window.opener.postMessage({\"payload\":{\"errors\":[\"invalid-credentials {\\\"code\\\":403,\\\"message\\\":\\\"Authentication failed.\\\",\\\"label\\\":\\\"invalid-credentials\\\"}\"],\"label\":\"forbidden\"},\"type\":\"AUTH_ERROR\"}, receiverOrigin);   </script></head></html>" does not contain "<title>wire:sso:success</title>"
```

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
