### PR TITLE
Make conversation ID in on-conversation-created RPC unqualified

### DIFF
--- a/changelog.d/6-federation/new-remote-conversation-unqualify
+++ b/changelog.d/6-federation/new-remote-conversation-unqualify
@@ -1,0 +1,1 @@
+Make conversation ID of the on-conversation-created RPC unqualified

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -75,8 +75,9 @@ federationSitemap =
         FederationAPIGalley.sendMessage = sendMessage
       }
 
-onConversationCreated :: NewRemoteConversation -> Galley ()
-onConversationCreated rc = do
+onConversationCreated :: Domain -> NewRemoteConversation ConvId -> Galley ()
+onConversationCreated domain rc = do
+  let qrc = fmap (`Qualified` domain) rc
   localDomain <- viewFederationDomain
   let localUsers =
         foldMap (\om -> guard (qDomain (omQualifiedId om) == localDomain) $> omQualifiedId om)
@@ -84,12 +85,12 @@ onConversationCreated rc = do
           $ rc
       localUserIds = fmap qUnqualified localUsers
   unless (null localUsers) $ do
-    Data.addLocalMembersToRemoteConv localUserIds (rcCnvId rc)
-  forM_ (fromNewRemoteConversation localDomain rc) $ \(mem, c) -> do
+    Data.addLocalMembersToRemoteConv localUserIds (rcCnvId qrc)
+  forM_ (fromNewRemoteConversation localDomain qrc) $ \(mem, c) -> do
     let event =
           Event
             ConvCreate
-            (rcCnvId rc)
+            (rcCnvId qrc)
             (rcOrigUserId rc)
             (rcTime rc)
             (EdConversation c)

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -478,12 +478,12 @@ toNewRemoteConversation ::
   -- | The conversation to convert for sending to a remote Galley
   Data.Conversation ->
   -- | The resulting information to be sent to a remote Galley
-  NewRemoteConversation
+  NewRemoteConversation ConvId
 toNewRemoteConversation now localDomain Data.Conversation {..} =
   NewRemoteConversation
     { rcTime = now,
       rcOrigUserId = Qualified convCreator localDomain,
-      rcCnvId = Qualified convId localDomain,
+      rcCnvId = convId,
       rcCnvType = convType,
       rcCnvAccess = convAccess,
       rcCnvAccessRole = convAccessRole,
@@ -521,7 +521,7 @@ toNewRemoteConversation now localDomain Data.Conversation {..} =
 -- conversation.
 fromNewRemoteConversation ::
   Domain ->
-  NewRemoteConversation ->
+  NewRemoteConversation (Qualified ConvId) ->
   [(Public.Member, Public.Conversation)]
 fromNewRemoteConversation d NewRemoteConversation {..} =
   let membersView = fmap (second Set.toList) . setHoles $ rcMembers
@@ -589,11 +589,11 @@ registerRemoteConversationMemberships now localDomain c = do
     $ c
   where
     registerRemoteConversations ::
-      NewRemoteConversation ->
+      NewRemoteConversation ConvId ->
       Domain ->
       Galley ()
     registerRemoteConversations rc domain = do
-      let rpc = FederatedGalley.onConversationCreated FederatedGalley.clientRoutes rc
+      let rpc = FederatedGalley.onConversationCreated FederatedGalley.clientRoutes localDomain rc
       runFederated domain rpc
 
 -- | Notify remote backends about changes to the conversation memberships of the

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -224,7 +224,7 @@ emptyFederatedGalley =
   let e :: Text -> Handler a
       e s = throwError err501 {errBody = cs ("mock not implemented: " <> s)}
    in FederatedGalley.Api
-        { FederatedGalley.onConversationCreated = \_ -> e "onConversationCreated",
+        { FederatedGalley.onConversationCreated = \_ _ -> e "onConversationCreated",
           FederatedGalley.getConversations = \_ -> e "getConversations",
           FederatedGalley.onConversationMembershipsChanged = \_ _ -> e "onConversationMembershipsChanged",
           FederatedGalley.leaveConversation = \_ _ -> e "leaveConversation",

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1165,10 +1165,11 @@ registerRemoteConv convId originUser name othMembers = do
   now <- liftIO getCurrentTime
   FederatedGalley.onConversationCreated
     fedGalleyClient
+    (qDomain convId)
     ( FederatedGalley.NewRemoteConversation
         { rcTime = now,
           rcOrigUserId = originUser,
-          rcCnvId = convId,
+          rcCnvId = qUnqualified convId,
           rcCnvType = RegularConv,
           rcCnvAccess = [],
           rcCnvAccessRole = ActivatedAccessRole,


### PR DESCRIPTION
This makes the conversation ID field of the `on-conversation-created` RPC (previously `register-conversation`) unqualified. The domain of the conversation is assumed to be the same as the backend invoking the RPC, which is obtained via `OriginDomainHeader`, so we do not need to include it in the RPC body, and therefore we do not need to check that it matches.

https://wearezeta.atlassian.net/browse/SQCORE-891

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
