### PR TITLE
Federation: support conversation renames

### DIFF
--- a/changelog.d/6-federation/fed-conv-rename
+++ b/changelog.d/6-federation/fed-conv-rename
@@ -1,0 +1,1 @@
+Notify remote users when a conversation is renamed

--- a/changelog.d/6-federation/fed-conv-update-notifications
+++ b/changelog.d/6-federation/fed-conv-update-notifications
@@ -1,0 +1,1 @@
+Make sure that only users that are actually part of a conversation get notified about updates in the conversation metadata

--- a/libs/tasty-cannon/src/Test/Tasty/Cannon.hs
+++ b/libs/tasty-cannon/src/Test/Tasty/Cannon.hs
@@ -53,6 +53,7 @@ module Test.Tasty.Cannon
     assertMatch,
     assertMatch_,
     assertMatchN,
+    assertMatchN_,
     assertSuccess,
     assertNoEvent,
 
@@ -356,6 +357,14 @@ assertMatchN ::
   (Notification -> Assertion) ->
   m [Notification]
 assertMatchN t wss f = awaitMatchN t wss f >>= mapM assertSuccess
+
+assertMatchN_ ::
+  (HasCallStack, MonadIO m, MonadThrow m) =>
+  Timeout ->
+  [WebSocket] ->
+  (Notification -> Assertion) ->
+  m ()
+assertMatchN_ t wss f = void $ assertMatchN t wss f
 
 assertSuccess :: (HasCallStack, MonadIO m, MonadThrow m) => Either MatchTimeout Notification -> m Notification
 assertSuccess = either throwM return

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -25,6 +25,8 @@ module Data.Qualified
     toRemote,
     Local,
     toLocal,
+    lUnqualified,
+    lDomain,
     renderQualifiedId,
     partitionRemoteOrLocalIds,
     partitionRemoteOrLocalIds',
@@ -74,6 +76,12 @@ type Local a = Tagged "local" (Qualified a)
 
 toLocal :: Qualified a -> Local a
 toLocal = Tagged
+
+lUnqualified :: Local a -> a
+lUnqualified = qUnqualified . unTagged
+
+lDomain :: Local a -> Domain
+lDomain = qDomain . unTagged
 
 -- | FUTUREWORK: Maybe delete this, it is only used in printing federation not
 -- implemented errors

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -21,7 +21,6 @@ import Control.Monad.Except (MonadError (..))
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Id (ClientId, ConvId, UserId)
 import Data.Json.Util (Base64ByteString)
-import Data.List.NonEmpty (NonEmpty)
 import Data.Misc (Milliseconds)
 import Data.Qualified (Qualified)
 import Data.Time.Clock (UTCTime)
@@ -31,6 +30,15 @@ import Servant.API.Generic ((:-))
 import Servant.Client.Generic (AsClientT, genericClient)
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import Wire.API.Conversation
+  ( Access,
+    AccessRole,
+    ConvType,
+    ConversationMembersAction (..),
+    ConversationMetadata,
+    ConversationMetadataAction (..),
+    ReceiptMode,
+  )
+import Wire.API.Conversation.Member (OtherMember)
 import Wire.API.Conversation.Role (RoleName)
 import Wire.API.Federation.Client (FederationClientFailure, FederatorClient)
 import Wire.API.Federation.Domain (OriginDomainHeader)
@@ -168,22 +176,7 @@ data NewRemoteConversation conv = NewRemoteConversation
   deriving stock (Eq, Show, Generic, Functor)
   deriving (ToJSON, FromJSON) via (CustomEncoded (NewRemoteConversation conv))
 
--- | A conversation membership update, as given by ' ConversationMemberUpdate',
--- can be either a member addition or removal.
-data ConversationMembersAction
-  = ConversationMembersActionAdd (NonEmpty (Qualified UserId, RoleName))
-  | ConversationMembersActionRemove (NonEmpty (Qualified UserId))
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ConversationMembersAction)
-  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationMembersAction)
-
 type ConversationMemberUpdate = ConversationUpdate ConversationMembersAction
-
-data ConversationMetadataAction
-  = ConversationMetadataActionRename ConversationRename
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ConversationMetadataAction)
-  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationMetadataAction)
 
 type ConversationMetadataUpdate = ConversationUpdate ConversationMetadataAction
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -179,7 +179,8 @@ data ConversationMembersAction
 
 type ConversationMemberUpdate = ConversationUpdate ConversationMembersAction
 
-data ConversationMetadataAction = ConversationMetadataActionRename Text
+data ConversationMetadataAction
+  = ConversationMetadataActionRename ConversationRename
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform ConversationMetadataAction)
   deriving (ToJSON, FromJSON) via (CustomEncoded ConversationMetadataAction)

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationMemberUpdate.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationMemberUpdate.hs
@@ -27,8 +27,9 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.Qualified (Qualified (Qualified))
 import qualified Data.UUID as UUID
 import Imports
+import Wire.API.Conversation (ConversationMembersAction (..))
 import Wire.API.Conversation.Role (roleNameWireAdmin, roleNameWireMember)
-import Wire.API.Federation.API.Galley (ConversationMemberUpdate, ConversationMembersAction (..), ConversationUpdate (..))
+import Wire.API.Federation.API.Galley (ConversationMemberUpdate, ConversationUpdate (..))
 
 qAlice, qBob :: Qualified UserId
 qAlice =

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationMemberUpdate.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationMemberUpdate.hs
@@ -28,7 +28,7 @@ import Data.Qualified (Qualified (Qualified))
 import qualified Data.UUID as UUID
 import Imports
 import Wire.API.Conversation.Role (roleNameWireAdmin, roleNameWireMember)
-import Wire.API.Federation.API.Galley (ConversationMemberUpdate (..), ConversationMembersAction (..))
+import Wire.API.Federation.API.Galley (ConversationMemberUpdate, ConversationMembersAction (..), ConversationUpdate (..))
 
 qAlice, qBob :: Qualified UserId
 qAlice =
@@ -46,7 +46,7 @@ dee = Id (fromJust (UUID.fromString "00000fff-0000-aaaa-0000-000100005007"))
 
 testObject_ConversationMemberUpdate1 :: ConversationMemberUpdate
 testObject_ConversationMemberUpdate1 =
-  ConversationMemberUpdate
+  ConversationUpdate
     { cmuTime = read "1864-04-12 12:22:43.673 UTC",
       cmuOrigUserId =
         Qualified
@@ -60,7 +60,7 @@ testObject_ConversationMemberUpdate1 =
 
 testObject_ConversationMemberUpdate2 :: ConversationMemberUpdate
 testObject_ConversationMemberUpdate2 =
-  ConversationMemberUpdate
+  ConversationUpdate
     { cmuTime = read "1864-04-12 12:22:43.673 UTC",
       cmuOrigUserId =
         Qualified

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationUpdate.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationUpdate.hs
@@ -15,9 +15,9 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Test.Wire.API.Federation.Golden.ConversationMemberUpdate
-  ( testObject_ConversationMemberUpdate1,
-    testObject_ConversationMemberUpdate2,
+module Test.Wire.API.Federation.Golden.ConversationUpdate
+  ( testObject_ConversationUpdate1,
+    testObject_ConversationUpdate2,
   )
 where
 
@@ -27,9 +27,9 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.Qualified (Qualified (Qualified))
 import qualified Data.UUID as UUID
 import Imports
-import Wire.API.Conversation (ConversationMembersAction (..))
+import Wire.API.Conversation (ConversationAction (..))
 import Wire.API.Conversation.Role (roleNameWireAdmin, roleNameWireMember)
-import Wire.API.Federation.API.Galley (ConversationMemberUpdate, ConversationUpdate (..))
+import Wire.API.Federation.API.Galley (ConversationUpdate (..))
 
 qAlice, qBob :: Qualified UserId
 qAlice =
@@ -45,30 +45,30 @@ chad, dee :: UserId
 chad = Id (fromJust (UUID.fromString "00000fff-0000-0000-0000-000100005007"))
 dee = Id (fromJust (UUID.fromString "00000fff-0000-aaaa-0000-000100005007"))
 
-testObject_ConversationMemberUpdate1 :: ConversationMemberUpdate
-testObject_ConversationMemberUpdate1 =
+testObject_ConversationUpdate1 :: ConversationUpdate
+testObject_ConversationUpdate1 =
   ConversationUpdate
-    { cmuTime = read "1864-04-12 12:22:43.673 UTC",
-      cmuOrigUserId =
+    { cuTime = read "1864-04-12 12:22:43.673 UTC",
+      cuOrigUserId =
         Qualified
           (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000007")))
           (Domain "golden.example.com"),
-      cmuConvId =
+      cuConvId =
         Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000006")),
-      cmuAlreadyPresentUsers = [],
-      cmuAction = ConversationMembersActionAdd ((qAlice, roleNameWireMember) :| [(qBob, roleNameWireAdmin)])
+      cuAlreadyPresentUsers = [],
+      cuAction = ConversationActionAddMembers ((qAlice, roleNameWireMember) :| [(qBob, roleNameWireAdmin)])
     }
 
-testObject_ConversationMemberUpdate2 :: ConversationMemberUpdate
-testObject_ConversationMemberUpdate2 =
+testObject_ConversationUpdate2 :: ConversationUpdate
+testObject_ConversationUpdate2 =
   ConversationUpdate
-    { cmuTime = read "1864-04-12 12:22:43.673 UTC",
-      cmuOrigUserId =
+    { cuTime = read "1864-04-12 12:22:43.673 UTC",
+      cuOrigUserId =
         Qualified
           (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000007")))
           (Domain "golden.example.com"),
-      cmuConvId =
+      cuConvId =
         Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000006")),
-      cmuAlreadyPresentUsers = [chad, dee],
-      cmuAction = ConversationMembersActionRemove (qAlice :| [qBob])
+      cuAlreadyPresentUsers = [chad, dee],
+      cuAction = ConversationActionRemoveMembers (qAlice :| [qBob])
     }

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/GoldenSpec.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/GoldenSpec.hs
@@ -19,7 +19,7 @@ module Test.Wire.API.Federation.Golden.GoldenSpec where
 
 import Imports
 import Test.Hspec
-import qualified Test.Wire.API.Federation.Golden.ConversationMemberUpdate as ConversationMemberUpdate
+import qualified Test.Wire.API.Federation.Golden.ConversationUpdate as ConversationUpdate
 import qualified Test.Wire.API.Federation.Golden.LeaveConversationRequest as LeaveConversationRequest
 import qualified Test.Wire.API.Federation.Golden.LeaveConversationResponse as LeaveConversationResponse
 import qualified Test.Wire.API.Federation.Golden.MessageSendResponse as MessageSendResponse
@@ -37,8 +37,8 @@ spec =
       ]
     testObjects [(LeaveConversationRequest.testObject_LeaveConversationRequest1, "testObject_LeaveConversationRequest1.json")]
     testObjects
-      [ (ConversationMemberUpdate.testObject_ConversationMemberUpdate1, "testObject_ConversationMemberUpdate1.json"),
-        (ConversationMemberUpdate.testObject_ConversationMemberUpdate2, "testObject_ConversationMemberUpdate2.json")
+      [ (ConversationUpdate.testObject_ConversationUpdate1, "testObject_ConversationUpdate1.json"),
+        (ConversationUpdate.testObject_ConversationUpdate2, "testObject_ConversationUpdate2.json")
       ]
     testObjects
       [ (LeaveConversationResponse.testObject_LeaveConversationResponse1, "testObject_LeaveConversationResponse1.json"),

--- a/libs/wire-api-federation/test/golden/testObject_ConversationUpdate1.json
+++ b/libs/wire-api-federation/test/golden/testObject_ConversationUpdate1.json
@@ -6,7 +6,7 @@
     "already_present_users": [],
     "time": "1864-04-12T12:22:43.673Z",
     "action": {
-        "tag": "ConversationMembersActionAdd",
+        "tag": "ConversationActionAddMembers",
         "contents": [
             [
                 {

--- a/libs/wire-api-federation/test/golden/testObject_ConversationUpdate2.json
+++ b/libs/wire-api-federation/test/golden/testObject_ConversationUpdate2.json
@@ -9,7 +9,7 @@
     ],
     "time": "1864-04-12T12:22:43.673Z",
     "action": {
-        "tag": "ConversationMembersActionRemove",
+        "tag": "ConversationActionRemoveMembers",
         "contents": [
             {
                 "domain": "golden.example.com",

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 51e5ed505621b80d7d0ea96cc1555dd231292948d5961f0eaccc4efb1b08e0d0
+-- hash: 8106f61fbca587df7a82a89effeec838bb9d9326c84bd7af8f615502cedc152f
 
 name:           wire-api-federation
 version:        0.1.0
@@ -77,7 +77,7 @@ test-suite spec
   other-modules:
       Test.Wire.API.Federation.API.BrigSpec
       Test.Wire.API.Federation.ClientSpec
-      Test.Wire.API.Federation.Golden.ConversationMemberUpdate
+      Test.Wire.API.Federation.Golden.ConversationUpdate
       Test.Wire.API.Federation.Golden.GoldenSpec
       Test.Wire.API.Federation.Golden.LeaveConversationRequest
       Test.Wire.API.Federation.Golden.LeaveConversationResponse

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -929,8 +929,8 @@ modelConversationMessageTimerUpdate = Doc.defineModel "ConversationMessageTimerU
 --------------------------------------------------------------------------------
 -- actions
 
--- | A conversation membership update, as given by 'ConversationMemberUpdate',
--- can be either a member addition or removal.
+-- | An update to a conversation, including addition and removal of members.
+-- Used to send notifications to users and to remote backends.
 data ConversationAction
   = ConversationActionAddMembers (NonEmpty (Qualified UserId, RoleName))
   | ConversationActionRemoveMembers (NonEmpty (Qualified UserId))

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -67,6 +67,8 @@ module Wire.API.Conversation
     ConversationAccessUpdate (..),
     ConversationReceiptModeUpdate (..),
     ConversationMessageTimerUpdate (..),
+    ConversationMembersAction (..),
+    ConversationMetadataAction (..),
 
     -- * re-exports
     module Wire.API.Conversation.Member,
@@ -113,6 +115,7 @@ import qualified Test.QuickCheck as QC
 import Wire.API.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
 import Wire.API.Conversation.Member
 import Wire.API.Conversation.Role (RoleName, roleNameWireAdmin)
+import Wire.API.Util.Aeson (CustomEncoded (..))
 
 --------------------------------------------------------------------------------
 -- Conversation
@@ -923,3 +926,21 @@ modelConversationMessageTimerUpdate = Doc.defineModel "ConversationMessageTimerU
   Doc.description "Contains conversation properties to update"
   Doc.property "message_timer" Doc.int64' $
     Doc.description "Conversation message timer (in milliseconds); can be null"
+
+--------------------------------------------------------------------------------
+-- actions
+
+-- | A conversation membership update, as given by 'ConversationMemberUpdate',
+-- can be either a member addition or removal.
+data ConversationMembersAction
+  = ConversationMembersActionAdd (NonEmpty (Qualified UserId, RoleName))
+  | ConversationMembersActionRemove (NonEmpty (Qualified UserId))
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform ConversationMembersAction)
+  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationMembersAction)
+
+data ConversationMetadataAction
+  = ConversationMetadataActionRename ConversationRename
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform ConversationMetadataAction)
+  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationMetadataAction)

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -67,8 +67,7 @@ module Wire.API.Conversation
     ConversationAccessUpdate (..),
     ConversationReceiptModeUpdate (..),
     ConversationMessageTimerUpdate (..),
-    ConversationMembersAction (..),
-    ConversationMetadataAction (..),
+    ConversationAction (..),
 
     -- * re-exports
     module Wire.API.Conversation.Member,
@@ -932,15 +931,10 @@ modelConversationMessageTimerUpdate = Doc.defineModel "ConversationMessageTimerU
 
 -- | A conversation membership update, as given by 'ConversationMemberUpdate',
 -- can be either a member addition or removal.
-data ConversationMembersAction
-  = ConversationMembersActionAdd (NonEmpty (Qualified UserId, RoleName))
-  | ConversationMembersActionRemove (NonEmpty (Qualified UserId))
+data ConversationAction
+  = ConversationActionAddMembers (NonEmpty (Qualified UserId, RoleName))
+  | ConversationActionRemoveMembers (NonEmpty (Qualified UserId))
+  | ConversationActionRename ConversationRename
   deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ConversationMembersAction)
-  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationMembersAction)
-
-data ConversationMetadataAction
-  = ConversationMetadataActionRename ConversationRename
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ConversationMetadataAction)
-  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationMetadataAction)
+  deriving (Arbitrary) via (GenericUniform ConversationAction)
+  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationAction)

--- a/libs/wire-api/src/Wire/API/Conversation/Role.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Role.hs
@@ -187,7 +187,7 @@ instance FromJSON ConversationRolesList where
 -- and cannot be created by externals. Therefore, never
 -- expose this constructor outside of this module.
 newtype RoleName = RoleName {fromRoleName :: Text}
-  deriving stock (Eq, Show, Generic)
+  deriving stock (Eq, Ord, Show, Generic)
   deriving newtype (ToByteString, Hashable)
   deriving (FromJSON, ToJSON, S.ToSchema) via Schema RoleName
 

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -31,6 +31,7 @@ module Wire.API.Event.Conversation
     Connect (..),
     MemberUpdateData (..),
     OtrMessage (..),
+    metadataActionToEvent,
 
     -- * re-exports
     ConversationReceiptModeUpdate (..),
@@ -544,3 +545,12 @@ instance ToJSON Event where
 
 instance S.ToSchema Event where
   declareNamedSchema = schemaToSwagger
+
+metadataActionToEvent ::
+  UTCTime ->
+  Qualified UserId ->
+  Qualified ConvId ->
+  ConversationMetadataAction ->
+  Event
+metadataActionToEvent now quid qcnv (ConversationMetadataActionRename rename) =
+  Event ConvRename qcnv quid now (EdConvRename rename)

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -24,6 +24,22 @@ module Wire.API.Event.Conversation
     EventType (..),
     EventData (..),
 
+    -- * Event lenses
+    _EdMembersJoin,
+    _EdMembersLeave,
+    _EdConnect,
+    _EdConvReceiptModeUpdate,
+    _EdConvRename,
+    _EdConvDelete,
+    _EdConvAccessUpdate,
+    _EdConvMessageTimerUpdate,
+    _EdConvCodeUpdate,
+    _EdConvCodeDelete,
+    _EdMemberUpdate,
+    _EdConversation,
+    _EdTyping,
+    _EdOtrMessage,
+
     -- * Event data helpers
     SimpleMember (..),
     smId,

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -336,7 +336,7 @@ data SimpleMember = SimpleMember
   { smQualifiedId :: Qualified UserId,
     smConvRoleName :: RoleName
   }
-  deriving stock (Eq, Show, Generic)
+  deriving stock (Eq, Ord, Show, Generic)
   deriving (Arbitrary) via (GenericUniform SimpleMember)
   deriving (FromJSON, ToJSON) via Schema SimpleMember
 

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -49,7 +49,9 @@ import Wire.API.Conversation.Member (OtherMember (..))
 import qualified Wire.API.Conversation.Role as Public
 import Wire.API.Event.Conversation
 import Wire.API.Federation.API.Galley
-  ( ConversationMemberUpdate (..),
+  ( ConversationMemberUpdate,
+    ConversationMetadataUpdate,
+    ConversationUpdate (..),
     GetConversationsRequest (..),
     GetConversationsResponse (..),
     LeaveConversationRequest (..),
@@ -70,6 +72,7 @@ federationSitemap =
       { FederationAPIGalley.onConversationCreated = onConversationCreated,
         FederationAPIGalley.getConversations = getConversations,
         FederationAPIGalley.onConversationMembershipsChanged = onConversationMembershipsChanged,
+        FederationAPIGalley.onConversationMetadataUpdated = onConversationMetadataUpdated,
         FederationAPIGalley.leaveConversation = leaveConversation,
         FederationAPIGalley.onMessageSent = onMessageSent,
         FederationAPIGalley.sendMessage = sendMessage
@@ -146,6 +149,9 @@ onConversationMembershipsChanged requestingDomain cmu = do
   -- FUTUREWORK: support bots?
   -- send notifications
   pushConversationEvent Nothing event targets []
+
+onConversationMetadataUpdated :: Domain -> ConversationMetadataUpdate -> Galley ()
+onConversationMetadataUpdated _ _ = pure () -- TODO
 
 leaveConversation ::
   Domain ->

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -94,8 +94,8 @@ servantSitemap =
         GalleyAPI.removeMember = Update.removeMemberQualified,
         GalleyAPI.updateOtherMemberUnqualified = Update.updateOtherMemberUnqualified,
         GalleyAPI.updateOtherMember = Update.updateOtherMember,
-        GalleyAPI.updateConversationNameDeprecated = Update.updateLocalConversationName,
-        GalleyAPI.updateConversationNameUnqualified = Update.updateLocalConversationName,
+        GalleyAPI.updateConversationNameDeprecated = Update.updateUnqualifiedConversationName,
+        GalleyAPI.updateConversationNameUnqualified = Update.updateUnqualifiedConversationName,
         GalleyAPI.updateConversationName = Update.updateConversationName,
         GalleyAPI.updateConversationMessageTimerUnqualified =
           Update.updateLocalConversationMessageTimer,

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -26,8 +26,7 @@ module Galley.API.Update
     addCodeH,
     rmCodeH,
     getCodeH,
-    updateConversationDeprecatedH,
-    updateLocalConversationName,
+    updateUnqualifiedConversationName,
     updateConversationName,
     updateConversationAccessH,
     updateConversationReceiptModeH,
@@ -110,6 +109,7 @@ import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Predicate hiding (and, failure, setStatus, _1, _2)
 import Network.Wai.Utilities
+import UnliftIO (pooledForConcurrentlyN)
 import Wire.API.Conversation (InviteQualified (invQRoleName))
 import qualified Wire.API.Conversation as Public
 import qualified Wire.API.Conversation.Code as Public
@@ -124,6 +124,7 @@ import Wire.API.ErrorDescription
   )
 import qualified Wire.API.ErrorDescription as Public
 import qualified Wire.API.Event.Conversation as Public
+import Wire.API.Federation.API.Galley (ConversationMetadataAction (..))
 import qualified Wire.API.Federation.API.Galley as FederatedGalley
 import Wire.API.Federation.Error (federationNotImplemented)
 import qualified Wire.API.Message as Public
@@ -893,55 +894,110 @@ newMessage qusr con qcnv msg now (m, c, t) ~(toBots, toUsers) =
                     . set pushTransient (newOtrTransient msg)
            in (toBots, p : toUsers)
 
-updateConversationDeprecatedH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.ConversationRename -> Galley Response
-updateConversationDeprecatedH (zusr ::: zcon ::: cnv ::: req) = do
-  convRename <- fromJsonBody req
-  setStatus status200 . json <$> updateLocalConversationName zusr zcon cnv convRename
-
 updateConversationName ::
   UserId ->
   ConnId ->
   Qualified ConvId ->
   Public.ConversationRename ->
   Galley (Maybe Public.Event)
-updateConversationName usr zcon qcnv convRename = do
-  localDomain <- viewFederationDomain
-  if qDomain qcnv == localDomain
-    then updateLocalConversationName usr zcon (qUnqualified qcnv) convRename
+updateConversationName zusr zcon qcnv convRename = do
+  lusr <- qualifyLocal zusr
+  if qDomain qcnv == lDomain lusr
+    then updateLocalConversationName lusr zcon (toLocal qcnv) convRename
     else throwM federationNotImplemented
 
-updateLocalConversationName ::
+updateUnqualifiedConversationName ::
   UserId ->
   ConnId ->
   ConvId ->
   Public.ConversationRename ->
   Galley (Maybe Public.Event)
-updateLocalConversationName usr zcon cnv convRename = do
-  alive <- Data.isConvAlive cnv
+updateUnqualifiedConversationName zusr zcon cnv rename = do
+  lusr <- qualifyLocal zusr
+  lcnv <- qualifyLocal cnv
+  updateLocalConversationName lusr zcon lcnv rename
+
+updateLocalConversationName ::
+  Local UserId ->
+  ConnId ->
+  Local ConvId ->
+  Public.ConversationRename ->
+  Galley (Maybe Public.Event)
+updateLocalConversationName lusr zcon lcnv convRename = do
+  alive <- Data.isConvAlive (lUnqualified lcnv)
   if alive
-    then Just <$> updateLiveLocalConversationName usr zcon cnv convRename
-    else Nothing <$ Data.deleteConversation cnv
+    then Just <$> updateLiveLocalConversationName lusr zcon lcnv convRename
+    else Nothing <$ Data.deleteConversation (lUnqualified lcnv)
 
 updateLiveLocalConversationName ::
-  UserId ->
+  Local UserId ->
   ConnId ->
-  ConvId ->
+  Local ConvId ->
   Public.ConversationRename ->
   Galley Public.Event
-updateLiveLocalConversationName usr zcon cnv convRename = do
-  localDomain <- viewFederationDomain
-  let qcnv = Qualified cnv localDomain
-      qusr = Qualified usr localDomain
-  (bots, users) <- localBotsAndUsers <$> Data.members cnv
-  ensureActionAllowedThrowing ModifyConversationName =<< getSelfMemberFromLocalsLegacy usr users
-  now <- liftIO getCurrentTime
+updateLiveLocalConversationName lusr zcon lcnv convRename = do
+  -- get local members and bots
+  (bots, lusers) <- localBotsAndUsers <$> Data.members (lUnqualified lcnv)
+
+  -- perform update
+  ensureActionAllowedThrowing ModifyConversationName
+    =<< getSelfMemberFromLocalsLegacy (lUnqualified lusr) lusers
   cn <- rangeChecked (cupName convRename)
-  Data.updateConversation cnv cn
-  let e = Event ConvRename qcnv qusr now (EdConvRename convRename)
-  for_ (newPushLocal ListComplete usr (ConvEvent e) (recipient <$> users)) $ \p ->
-    push1 $ p & pushConn ?~ zcon
-  void . forkIO $ void $ External.deliver (bots `zip` repeat e)
-  pure e
+  Data.updateConversation (lUnqualified lcnv) cn
+
+  -- send notifications
+  rusers <- Data.lookupRemoteMembers (lUnqualified lcnv)
+  let targets =
+        NotificationTargets
+          { ntLocals = map lmId lusers,
+            ntRemotes = map rmId rusers,
+            ntBots = bots
+          }
+  now <- liftIO getCurrentTime
+  let action = ConversationMetadataActionRename convRename
+  notifyConversationMetadataUpdate now (unTagged lusr) (Just zcon) (unTagged lcnv) targets action
+
+data NotificationTargets = NotificationTargets
+  { ntLocals :: [UserId],
+    ntRemotes :: [Remote UserId],
+    ntBots :: [BotMember]
+  }
+
+metadataActionToEvent ::
+  UTCTime ->
+  Qualified UserId ->
+  Qualified ConvId ->
+  ConversationMetadataAction ->
+  Event
+metadataActionToEvent now quid qcnv (ConversationMetadataActionRename rename) =
+  Event ConvRename qcnv quid now (EdConvRename rename)
+
+notifyConversationMetadataUpdate ::
+  UTCTime ->
+  Qualified UserId ->
+  Maybe ConnId ->
+  Qualified ConvId ->
+  NotificationTargets ->
+  ConversationMetadataAction ->
+  Galley Event
+notifyConversationMetadataUpdate now quid mcon qcnv targets action = do
+  localDomain <- viewFederationDomain
+  let e = metadataActionToEvent now quid qcnv action
+
+  -- if the conversation is local, notify remote participants
+  when (qDomain qcnv == localDomain) $ do
+    let rusersByDomain = partitionRemote (ntRemotes targets)
+    void . pooledForConcurrentlyN 8 rusersByDomain $ \(domain, uids) -> do
+      let req = FederatedGalley.ConversationUpdate now quid (qUnqualified qcnv) uids action
+          rpc =
+            FederatedGalley.onConversationMetadataUpdated
+              FederatedGalley.clientRoutes
+              localDomain
+              req
+      runFederatedGalley domain rpc
+
+  -- notify local participants and bots
+  pushConversationEvent mcon e (ntLocals targets) (ntBots targets) $> e
 
 isTypingH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.TypingData -> Galley Response
 isTypingH (zusr ::: zcon ::: cnv ::: req) = do

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -59,6 +59,7 @@ import Network.Wai
 import Network.Wai.Predicate hiding (Error)
 import Network.Wai.Utilities
 import UnliftIO (concurrently)
+import Wire.API.Conversation (ConversationMembersAction (..))
 import qualified Wire.API.Conversation as Public
 import Wire.API.ErrorDescription
 import qualified Wire.API.Federation.API.Brig as FederatedBrig

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -598,7 +598,7 @@ notifyRemoteAboutConvUpdate ::
   Galley ()
 notifyRemoteAboutConvUpdate origUser convId time action remotesToNotify = do
   localDomain <- viewFederationDomain
-  let mkUpdate oth = ConversationMemberUpdate time origUser convId oth action
+  let mkUpdate oth = ConversationUpdate time origUser convId oth action
   traverse_ (uncurry (notificationRPC localDomain . mkUpdate) . swap)
     . Map.assocs
     . partitionQualified

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -59,7 +59,7 @@ import Network.Wai
 import Network.Wai.Predicate hiding (Error)
 import Network.Wai.Utilities
 import UnliftIO (concurrently)
-import Wire.API.Conversation (ConversationMembersAction (..))
+import Wire.API.Conversation (ConversationAction (..))
 import qualified Wire.API.Conversation as Public
 import Wire.API.ErrorDescription
 import qualified Wire.API.Federation.API.Brig as FederatedBrig
@@ -596,7 +596,7 @@ notifyRemoteAboutConvUpdate ::
   -- | The current time
   UTCTime ->
   -- | Action being performed
-  ConversationMembersAction ->
+  ConversationAction ->
   -- | Remote members that need to be notified
   [Remote UserId] ->
   Galley ()
@@ -610,13 +610,13 @@ notifyRemoteAboutConvUpdate origUser convId time action remotesToNotify = do
     . map unTagged
     $ remotesToNotify
   where
-    notificationRPC :: Domain -> ConversationMemberUpdate -> Domain -> Galley ()
-    notificationRPC sendingDomain cmu receivingDomain = do
+    notificationRPC :: Domain -> ConversationUpdate -> Domain -> Galley ()
+    notificationRPC sendingDomain cu receivingDomain = do
       let rpc =
-            FederatedGalley.onConversationMembershipsChanged
+            FederatedGalley.onConversationUpdated
               FederatedGalley.clientRoutes
               sendingDomain
-              cmu
+              cu
       runFederated receivingDomain rpc
 
 --------------------------------------------------------------------------------

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -34,7 +34,7 @@ import Data.LegalHold (UserLegalHoldStatus (..), defUserLegalHoldStatus)
 import Data.List.Extra (chunksOf, nubOrd)
 import qualified Data.Map as Map
 import Data.Misc (PlainTextPassword (..))
-import Data.Qualified (Qualified (..), Remote, partitionQualified, toRemote)
+import Data.Qualified (Local, Qualified (..), Remote, partitionQualified, toLocal, toRemote)
 import qualified Data.Set as Set
 import Data.Tagged (Tagged (unTagged))
 import qualified Data.Text.Lazy as LT
@@ -391,7 +391,7 @@ canDeleteMember deleter deletee
     -- here, so we pick a reasonable default.)
     getRole mem = fromMaybe RoleMember $ permissionsRole $ mem ^. permissions
 
--- | Notify local users and bots of being added to a conversation
+-- | Send an event to local users and bots
 pushConversationEvent :: Maybe ConnId -> Event -> [UserId] -> [BotMember] -> Galley ()
 pushConversationEvent conn e users bots = do
   localDomain <- viewFederationDomain
@@ -426,6 +426,9 @@ ensureAccess conv access =
 
 viewFederationDomain :: MonadReader Env m => m Domain
 viewFederationDomain = view (options . optSettings . setFederationDomain)
+
+qualifyLocal :: MonadReader Env m => a -> m (Local a)
+qualifyLocal a = fmap (toLocal . Qualified a) viewFederationDomain
 
 checkRemoteUsersExist :: [Remote UserId] -> Galley ()
 checkRemoteUsersExist =

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -608,7 +608,7 @@ remoteConversationStatus uid =
 remoteConversationStatusOnDomain :: MonadClient m => UserId -> Domain -> [ConvId] -> m (Map (Remote ConvId) MemberStatus)
 remoteConversationStatusOnDomain uid domain convs =
   Map.fromList . map toPair
-    <$> query Cql.selectRemoteConvMembers (params Quorum (uid, domain, convs))
+    <$> query Cql.selectRemoteConvMemberStatuses (params Quorum (uid, domain, convs))
   where
     toPair (conv, omus, omur, oar, oarr, hid, hidr) =
       ( toRemote (Qualified conv domain),
@@ -1025,9 +1025,9 @@ filterRemoteConvMembers users (Qualified conv dom) =
   where
     filterMember :: MonadClient m => UserId -> m [UserId]
     filterMember user =
-      fmap (map (const user))
+      fmap (map runIdentity)
         . retry x1
-        $ query Cql.selectRemoteConvMembers (params Quorum (user, dom, [conv]))
+        $ query Cql.selectRemoteConvMembers (params Quorum (user, dom, conv))
 
 removeLocalMembersFromLocalConv ::
   MonadClient m =>

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -921,8 +921,9 @@ addMembersUncheckedWithRole localDomain t conv (orig, _origRole) lusrs rusrs = d
 -- | Set local users as belonging to a remote conversation. This is invoked by a
 -- remote galley when users from the current backend are added to conversations
 -- on the remote end.
-addLocalMembersToRemoteConv :: MonadClient m => [UserId] -> Qualified ConvId -> m ()
-addLocalMembersToRemoteConv users qconv = do
+addLocalMembersToRemoteConv :: MonadClient m => Qualified ConvId -> [UserId] -> m ()
+addLocalMembersToRemoteConv _ [] = pure ()
+addLocalMembersToRemoteConv qconv users = do
   -- FUTUREWORK: consider using pooledMapConcurrentlyN
   for_ (List.chunksOf 32 users) $ \chunk ->
     retry x5 . batch $ do
@@ -1071,8 +1072,9 @@ removeLocalMembersFromRemoteConv ::
   -- | The conversation to remove members from
   Qualified ConvId ->
   -- | Members to remove local to this backend
-  List1 UserId ->
+  [UserId] ->
   m ()
+removeLocalMembersFromRemoteConv _ [] = pure ()
 removeLocalMembersFromRemoteConv (Qualified conv convDomain) victims =
   retry x5 . batch $ do
     setType BatchLogged

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -303,8 +303,11 @@ insertUserRemoteConv = "insert into user_remote_conv (user, conv_remote_domain, 
 selectUserRemoteConvs :: PrepQuery R (Identity UserId) (Domain, ConvId)
 selectUserRemoteConvs = "select conv_remote_domain, conv_remote_id from user_remote_conv where user = ?"
 
-selectRemoteConvMembers :: PrepQuery R (UserId, Domain, [ConvId]) (ConvId, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text)
-selectRemoteConvMembers = "select conv_remote_id, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref from user_remote_conv where user = ? and conv_remote_domain = ? and conv_remote_id in ?"
+selectRemoteConvMemberStatuses :: PrepQuery R (UserId, Domain, [ConvId]) (ConvId, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text)
+selectRemoteConvMemberStatuses = "select conv_remote_id, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref from user_remote_conv where user = ? and conv_remote_domain = ? and conv_remote_id in ?"
+
+selectRemoteConvMembers :: PrepQuery R (UserId, Domain, ConvId) (Identity UserId)
+selectRemoteConvMembers = "select user from user_remote_conv where user = ? and conv_remote_domain = ? and conv_remote_id = ?"
 
 deleteUserRemoteConv :: PrepQuery W (UserId, Domain, ConvId) ()
 deleteUserRemoteConv = "delete from user_remote_conv where user = ? and conv_remote_domain = ? and conv_remote_id = ?"

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2747,7 +2747,7 @@ putRemoteConvMemberOk update = do
   fedGalleyClient <- view tsFedGalleyClient
   now <- liftIO getCurrentTime
   let cmu =
-        FederatedGalley.ConversationMemberUpdate
+        FederatedGalley.ConversationUpdate
           { cmuTime = now,
             cmuOrigUserId = qbob,
             cmuConvId = qUnqualified qconv,

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1320,7 +1320,7 @@ paginateConvListIds = do
               FederatedGalley.cmuOrigUserId = qChad,
               FederatedGalley.cmuConvId = conv,
               FederatedGalley.cmuAlreadyPresentUsers = [],
-              FederatedGalley.cmuAction = FederatedGalley.ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
+              FederatedGalley.cmuAction = ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
             }
     FederatedGalley.onConversationMembershipsChanged fedGalleyClient chadDomain cmu
 
@@ -1335,7 +1335,7 @@ paginateConvListIds = do
               FederatedGalley.cmuOrigUserId = qDee,
               FederatedGalley.cmuConvId = conv,
               FederatedGalley.cmuAlreadyPresentUsers = [],
-              FederatedGalley.cmuAction = FederatedGalley.ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
+              FederatedGalley.cmuAction = ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
             }
     FederatedGalley.onConversationMembershipsChanged fedGalleyClient deeDomain cmu
 
@@ -1378,7 +1378,7 @@ paginateConvListIdsPageEndingAtLocalsAndDomain = do
               FederatedGalley.cmuOrigUserId = qChad,
               FederatedGalley.cmuConvId = conv,
               FederatedGalley.cmuAlreadyPresentUsers = [],
-              FederatedGalley.cmuAction = FederatedGalley.ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
+              FederatedGalley.cmuAction = ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
             }
     FederatedGalley.onConversationMembershipsChanged fedGalleyClient chadDomain cmu
 
@@ -1394,7 +1394,7 @@ paginateConvListIdsPageEndingAtLocalsAndDomain = do
               FederatedGalley.cmuOrigUserId = qDee,
               FederatedGalley.cmuConvId = conv,
               FederatedGalley.cmuAlreadyPresentUsers = [],
-              FederatedGalley.cmuAction = FederatedGalley.ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
+              FederatedGalley.cmuAction = ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
             }
     FederatedGalley.onConversationMembershipsChanged fedGalleyClient deeDomain cmu
 
@@ -2753,7 +2753,7 @@ putRemoteConvMemberOk update = do
             cmuConvId = qUnqualified qconv,
             cmuAlreadyPresentUsers = [],
             cmuAction =
-              FederatedGalley.ConversationMembersActionAdd (pure (qalice, roleNameWireMember))
+              ConversationMembersActionAdd (pure (qalice, roleNameWireMember))
           }
   FederatedGalley.onConversationMembershipsChanged fedGalleyClient remoteDomain cmu
 

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -238,8 +238,7 @@ emptyFederatedGalley =
    in FederatedGalley.Api
         { FederatedGalley.onConversationCreated = \_ _ -> e "onConversationCreated",
           FederatedGalley.getConversations = \_ _ -> e "getConversations",
-          FederatedGalley.onConversationMembershipsChanged = \_ _ -> e "onConversationMembershipsChanged",
-          FederatedGalley.onConversationMetadataUpdated = \_ _ -> e "onConversationMetadataUpdated",
+          FederatedGalley.onConversationUpdated = \_ _ -> e "onConversationUpdated",
           FederatedGalley.leaveConversation = \_ _ -> e "leaveConversation",
           FederatedGalley.onMessageSent = \_ _ -> e "onMessageSent",
           FederatedGalley.sendMessage = \_ _ -> e "sendMessage"
@@ -1314,30 +1313,30 @@ paginateConvListIds = do
       qChad = Qualified remoteChad chadDomain
   replicateM_ 25 $ do
     conv <- randomId
-    let cmu =
+    let cu =
           FederatedGalley.ConversationUpdate
-            { FederatedGalley.cmuTime = now,
-              FederatedGalley.cmuOrigUserId = qChad,
-              FederatedGalley.cmuConvId = conv,
-              FederatedGalley.cmuAlreadyPresentUsers = [],
-              FederatedGalley.cmuAction = ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
+            { FederatedGalley.cuTime = now,
+              FederatedGalley.cuOrigUserId = qChad,
+              FederatedGalley.cuConvId = conv,
+              FederatedGalley.cuAlreadyPresentUsers = [],
+              FederatedGalley.cuAction = ConversationActionAddMembers $ pure (qAlice, roleNameWireMember)
             }
-    FederatedGalley.onConversationMembershipsChanged fedGalleyClient chadDomain cmu
+    FederatedGalley.onConversationUpdated fedGalleyClient chadDomain cu
 
   remoteDee <- randomId
   let deeDomain = Domain "dee.example.com"
       qDee = Qualified remoteDee deeDomain
   replicateM_ 31 $ do
     conv <- randomId
-    let cmu =
+    let cu =
           FederatedGalley.ConversationUpdate
-            { FederatedGalley.cmuTime = now,
-              FederatedGalley.cmuOrigUserId = qDee,
-              FederatedGalley.cmuConvId = conv,
-              FederatedGalley.cmuAlreadyPresentUsers = [],
-              FederatedGalley.cmuAction = ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
+            { FederatedGalley.cuTime = now,
+              FederatedGalley.cuOrigUserId = qDee,
+              FederatedGalley.cuConvId = conv,
+              FederatedGalley.cuAlreadyPresentUsers = [],
+              FederatedGalley.cuAction = ConversationActionAddMembers $ pure (qAlice, roleNameWireMember)
             }
-    FederatedGalley.onConversationMembershipsChanged fedGalleyClient deeDomain cmu
+    FederatedGalley.onConversationUpdated fedGalleyClient deeDomain cu
 
   -- 1 self conv + 2 convs with bob and eve + 197 local convs + 25 convs on
   -- chad.example.com + 31 on dee.example = 256 convs. Getting them 16 at a time
@@ -1372,15 +1371,15 @@ paginateConvListIdsPageEndingAtLocalsAndDomain = do
   -- The 3rd page will end with this domain
   replicateM_ 16 $ do
     conv <- randomId
-    let cmu =
+    let cu =
           FederatedGalley.ConversationUpdate
-            { FederatedGalley.cmuTime = now,
-              FederatedGalley.cmuOrigUserId = qChad,
-              FederatedGalley.cmuConvId = conv,
-              FederatedGalley.cmuAlreadyPresentUsers = [],
-              FederatedGalley.cmuAction = ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
+            { FederatedGalley.cuTime = now,
+              FederatedGalley.cuOrigUserId = qChad,
+              FederatedGalley.cuConvId = conv,
+              FederatedGalley.cuAlreadyPresentUsers = [],
+              FederatedGalley.cuAction = ConversationActionAddMembers $ pure (qAlice, roleNameWireMember)
             }
-    FederatedGalley.onConversationMembershipsChanged fedGalleyClient chadDomain cmu
+    FederatedGalley.onConversationUpdated fedGalleyClient chadDomain cu
 
   remoteDee <- randomId
   let deeDomain = Domain "dee.example.com"
@@ -1388,15 +1387,15 @@ paginateConvListIdsPageEndingAtLocalsAndDomain = do
   -- The 4th and last page will end with this domain
   replicateM_ 16 $ do
     conv <- randomId
-    let cmu =
+    let cu =
           FederatedGalley.ConversationUpdate
-            { FederatedGalley.cmuTime = now,
-              FederatedGalley.cmuOrigUserId = qDee,
-              FederatedGalley.cmuConvId = conv,
-              FederatedGalley.cmuAlreadyPresentUsers = [],
-              FederatedGalley.cmuAction = ConversationMembersActionAdd $ pure (qAlice, roleNameWireMember)
+            { FederatedGalley.cuTime = now,
+              FederatedGalley.cuOrigUserId = qDee,
+              FederatedGalley.cuConvId = conv,
+              FederatedGalley.cuAlreadyPresentUsers = [],
+              FederatedGalley.cuAction = ConversationActionAddMembers $ pure (qAlice, roleNameWireMember)
             }
-    FederatedGalley.onConversationMembershipsChanged fedGalleyClient deeDomain cmu
+    FederatedGalley.onConversationUpdated fedGalleyClient deeDomain cu
 
   foldM_ (getChunkedConvs 16 0 alice) Nothing [4, 3, 2, 1, 0 :: Int]
 
@@ -1840,7 +1839,7 @@ testAddRemoteMember = do
     map F.domain reqs @?= replicate 2 (domainText remoteDomain)
     map (fmap F.path . F.request) reqs
       @?= [ Just "/federation/get-users-by-ids",
-            Just "/federation/on-conversation-memberships-changed"
+            Just "/federation/on-conversation-updated"
           ]
 
   e <- responseJsonUnsafe <$> (pure resp <!! const 200 === statusCode)
@@ -2746,16 +2745,16 @@ putRemoteConvMemberOk update = do
   qconv <- Qualified <$> randomId <*> pure remoteDomain
   fedGalleyClient <- view tsFedGalleyClient
   now <- liftIO getCurrentTime
-  let cmu =
+  let cu =
         FederatedGalley.ConversationUpdate
-          { cmuTime = now,
-            cmuOrigUserId = qbob,
-            cmuConvId = qUnqualified qconv,
-            cmuAlreadyPresentUsers = [],
-            cmuAction =
-              ConversationMembersActionAdd (pure (qalice, roleNameWireMember))
+          { cuTime = now,
+            cuOrigUserId = qbob,
+            cuConvId = qUnqualified qconv,
+            cuAlreadyPresentUsers = [],
+            cuAction =
+              ConversationActionAddMembers (pure (qalice, roleNameWireMember))
           }
-  FederatedGalley.onConversationMembershipsChanged fedGalleyClient remoteDomain cmu
+  FederatedGalley.onConversationUpdated fedGalleyClient remoteDomain cu
 
   -- Expected member state
   let memberAlice =

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -239,6 +239,7 @@ emptyFederatedGalley =
         { FederatedGalley.onConversationCreated = \_ _ -> e "onConversationCreated",
           FederatedGalley.getConversations = \_ _ -> e "getConversations",
           FederatedGalley.onConversationMembershipsChanged = \_ _ -> e "onConversationMembershipsChanged",
+          FederatedGalley.onConversationMetadataUpdated = \_ _ -> e "onConversationMetadataUpdated",
           FederatedGalley.leaveConversation = \_ _ -> e "leaveConversation",
           FederatedGalley.onMessageSent = \_ _ -> e "onMessageSent",
           FederatedGalley.sendMessage = \_ _ -> e "sendMessage"
@@ -1314,7 +1315,7 @@ paginateConvListIds = do
   replicateM_ 25 $ do
     conv <- randomId
     let cmu =
-          FederatedGalley.ConversationMemberUpdate
+          FederatedGalley.ConversationUpdate
             { FederatedGalley.cmuTime = now,
               FederatedGalley.cmuOrigUserId = qChad,
               FederatedGalley.cmuConvId = conv,
@@ -1329,7 +1330,7 @@ paginateConvListIds = do
   replicateM_ 31 $ do
     conv <- randomId
     let cmu =
-          FederatedGalley.ConversationMemberUpdate
+          FederatedGalley.ConversationUpdate
             { FederatedGalley.cmuTime = now,
               FederatedGalley.cmuOrigUserId = qDee,
               FederatedGalley.cmuConvId = conv,
@@ -1372,7 +1373,7 @@ paginateConvListIdsPageEndingAtLocalsAndDomain = do
   replicateM_ 16 $ do
     conv <- randomId
     let cmu =
-          FederatedGalley.ConversationMemberUpdate
+          FederatedGalley.ConversationUpdate
             { FederatedGalley.cmuTime = now,
               FederatedGalley.cmuOrigUserId = qChad,
               FederatedGalley.cmuConvId = conv,
@@ -1388,7 +1389,7 @@ paginateConvListIdsPageEndingAtLocalsAndDomain = do
   replicateM_ 16 $ do
     conv <- randomId
     let cmu =
-          FederatedGalley.ConversationMemberUpdate
+          FederatedGalley.ConversationUpdate
             { FederatedGalley.cmuTime = now,
               FederatedGalley.cmuOrigUserId = qDee,
               FederatedGalley.cmuConvId = conv,

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -48,6 +48,7 @@ import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
 import TestHelpers
 import TestSetup
+import Wire.API.Conversation (ConversationMembersAction (..))
 import Wire.API.Conversation.Member (Member (..))
 import Wire.API.Conversation.Role
 import Wire.API.Federation.API.Galley (GetConversationsRequest (..), GetConversationsResponse (..), RemoteConvMembers (..), RemoteConversation (..))
@@ -161,7 +162,7 @@ addLocalUser = do
             FedGalley.cmuConvId = conv,
             FedGalley.cmuAlreadyPresentUsers = [],
             FedGalley.cmuAction =
-              FedGalley.ConversationMembersActionAdd (pure (qalice, roleNameWireMember))
+              ConversationMembersActionAdd (pure (qalice, roleNameWireMember))
           }
   WS.bracketR c alice $ \ws -> do
     FedGalley.onConversationMembershipsChanged fedGalleyClient remoteDomain cmu
@@ -199,7 +200,7 @@ removeLocalUser = do
             FedGalley.cmuConvId = conv,
             FedGalley.cmuAlreadyPresentUsers = [],
             FedGalley.cmuAction =
-              FedGalley.ConversationMembersActionAdd (pure (qAlice, roleNameWireMember))
+              ConversationMembersActionAdd (pure (qAlice, roleNameWireMember))
           }
       cmuRemove =
         FedGalley.ConversationUpdate
@@ -208,7 +209,7 @@ removeLocalUser = do
             FedGalley.cmuConvId = conv,
             FedGalley.cmuAlreadyPresentUsers = [alice],
             FedGalley.cmuAction =
-              FedGalley.ConversationMembersActionRemove (pure qAlice)
+              ConversationMembersActionRemove (pure qAlice)
           }
 
   WS.bracketR c alice $ \ws -> do
@@ -255,7 +256,7 @@ removeRemoteUser = do
             FedGalley.cmuConvId = conv,
             FedGalley.cmuAlreadyPresentUsers = [],
             FedGalley.cmuAction =
-              FedGalley.ConversationMembersActionAdd
+              ConversationMembersActionAdd
                 ((qAlice, roleNameWireMember) :| [(qEve, roleNameWireMember)])
           }
       cmuRemove =
@@ -265,7 +266,7 @@ removeRemoteUser = do
             FedGalley.cmuConvId = conv,
             FedGalley.cmuAlreadyPresentUsers = [alice],
             FedGalley.cmuAction =
-              FedGalley.ConversationMembersActionRemove (pure qEve)
+              ConversationMembersActionRemove (pure qEve)
           }
 
   WS.bracketR c alice $ \ws -> do
@@ -303,7 +304,7 @@ notifyLocalUser = do
             FedGalley.cmuConvId = conv,
             FedGalley.cmuAlreadyPresentUsers = [alice],
             FedGalley.cmuAction =
-              FedGalley.ConversationMembersActionAdd (pure (qcharlie, roleNameWireMember))
+              ConversationMembersActionAdd (pure (qcharlie, roleNameWireMember))
           }
   WS.bracketR c alice $ \ws -> do
     FedGalley.onConversationMembershipsChanged fedGalleyClient bdom cmu
@@ -397,7 +398,7 @@ onMessageSent = do
             FedGalley.cmuConvId = conv,
             FedGalley.cmuAlreadyPresentUsers = [],
             FedGalley.cmuAction =
-              FedGalley.ConversationMembersActionAdd (pure (qalice, roleNameWireMember))
+              ConversationMembersActionAdd (pure (qalice, roleNameWireMember))
           }
   FedGalley.onConversationMembershipsChanged fedGalleyClient bdom cmu
 

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -155,7 +155,7 @@ addLocalUser = do
   fedGalleyClient <- view tsFedGalleyClient
   now <- liftIO getCurrentTime
   let cmu =
-        FedGalley.ConversationMemberUpdate
+        FedGalley.ConversationUpdate
           { FedGalley.cmuTime = now,
             FedGalley.cmuOrigUserId = qbob,
             FedGalley.cmuConvId = conv,
@@ -193,7 +193,7 @@ removeLocalUser = do
   fedGalleyClient <- view tsFedGalleyClient
   now <- liftIO getCurrentTime
   let cmuAdd =
-        FedGalley.ConversationMemberUpdate
+        FedGalley.ConversationUpdate
           { FedGalley.cmuTime = now,
             FedGalley.cmuOrigUserId = qBob,
             FedGalley.cmuConvId = conv,
@@ -202,7 +202,7 @@ removeLocalUser = do
               FedGalley.ConversationMembersActionAdd (pure (qAlice, roleNameWireMember))
           }
       cmuRemove =
-        FedGalley.ConversationMemberUpdate
+        FedGalley.ConversationUpdate
           { FedGalley.cmuTime = addUTCTime (secondsToNominalDiffTime 5) now,
             FedGalley.cmuOrigUserId = qBob,
             FedGalley.cmuConvId = conv,
@@ -249,7 +249,7 @@ removeRemoteUser = do
   fedGalleyClient <- view tsFedGalleyClient
   now <- liftIO getCurrentTime
   let cmuAdd =
-        FedGalley.ConversationMemberUpdate
+        FedGalley.ConversationUpdate
           { FedGalley.cmuTime = now,
             FedGalley.cmuOrigUserId = qBob,
             FedGalley.cmuConvId = conv,
@@ -259,7 +259,7 @@ removeRemoteUser = do
                 ((qAlice, roleNameWireMember) :| [(qEve, roleNameWireMember)])
           }
       cmuRemove =
-        FedGalley.ConversationMemberUpdate
+        FedGalley.ConversationUpdate
           { FedGalley.cmuTime = addUTCTime (secondsToNominalDiffTime 5) now,
             FedGalley.cmuOrigUserId = qBob,
             FedGalley.cmuConvId = conv,
@@ -297,7 +297,7 @@ notifyLocalUser = do
   fedGalleyClient <- view tsFedGalleyClient
   now <- liftIO getCurrentTime
   let cmu =
-        FedGalley.ConversationMemberUpdate
+        FedGalley.ConversationUpdate
           { FedGalley.cmuTime = now,
             FedGalley.cmuOrigUserId = qbob,
             FedGalley.cmuConvId = conv,
@@ -391,7 +391,7 @@ onMessageSent = do
 
   -- only add alice to the remote conversation
   let cmu =
-        FedGalley.ConversationMemberUpdate
+        FedGalley.ConversationUpdate
           { FedGalley.cmuTime = now,
             FedGalley.cmuOrigUserId = qbob,
             FedGalley.cmuConvId = conv,

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -229,16 +229,6 @@ removeLocalUser = do
       afterAddition @?= [qconv]
       afterRemoval @?= []
 
--- | This test invokes the federation endpoint:
---
---   'POST /federation/on-conversation-memberships-changed'
---
--- two times in a row: first adding a local and a remote user to a remote
--- conversation, and then removing the remote user. The test asserts the
--- expected list of conversations in between the calls and at the end from the
--- point of view of the local backend and that the local conversation member got
--- notified of the removal.
---
 -- characters:
 --
 -- alice: present local user
@@ -291,8 +281,9 @@ removeRemoteUser = do
     afterRemoval <- listRemoteConvs remoteDomain alice
     liftIO $ do
       WS.assertMatchN_ (3 # Second) [wsA, wsD] $
-        wsAssertMembersLeave qconv qBob [qDee, qEve]
-      WS.assertNoEvent (1 # Second) [wsC, wsF]
+        wsAssertMembersLeave qconv qBob [qDee, qEve, qFlo]
+      WS.assertNoEvent (1 # Second) [wsC]
+      WS.assertNoEvent (1 # Second) [wsF]
     liftIO $ do
       afterRemoval @?= [qconv]
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1411,11 +1411,11 @@ assertRemoveUpdate :: (MonadIO m, HasCallStack) => F.Request -> Qualified ConvId
 assertRemoveUpdate req qconvId remover alreadyPresentUsers victim = liftIO $ do
   F.path req @?= "/federation/on-conversation-memberships-changed"
   F.originDomain req @?= (domainText . qDomain) qconvId
-  let Just cmu = decodeStrict (F.body req)
-  FederatedGalley.cmuOrigUserId cmu @?= remover
-  FederatedGalley.cmuConvId cmu @?= qUnqualified qconvId
-  sort (FederatedGalley.cmuAlreadyPresentUsers cmu) @?= sort alreadyPresentUsers
-  FederatedGalley.cmuAction cmu @?= Public.ConversationMembersActionRemove (pure victim)
+  let Just cu = decodeStrict (F.body req)
+  FederatedGalley.cuOrigUserId cu @?= remover
+  FederatedGalley.cuConvId cu @?= qUnqualified qconvId
+  sort (FederatedGalley.cuAlreadyPresentUsers cu) @?= sort alreadyPresentUsers
+  FederatedGalley.cuAction cu @?= Public.ConversationActionRemoveMembers (pure victim)
 
 -------------------------------------------------------------------------------
 -- Helpers

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -989,9 +989,9 @@ putOtherMember from to m c = do
       . zType "access"
       . json m
 
-putQualifiedConversationName :: UserId -> Qualified ConvId -> Text -> TestM ResponseLBS
+putQualifiedConversationName :: (HasGalley m, MonadIO m, MonadHttp m, MonadMask m) => UserId -> Qualified ConvId -> Text -> m ResponseLBS
 putQualifiedConversationName u c n = do
-  g <- view tsGalley
+  g <- viewGalley
   let update = ConversationRename n
   put
     ( g

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -107,7 +107,7 @@ import Util.Options
 import Web.Cookie
 import Wire.API.Conversation
 import qualified Wire.API.Conversation as Public
-import Wire.API.Event.Conversation (_EdMembersLeave)
+import Wire.API.Event.Conversation (_EdMembersJoin, _EdMembersLeave)
 import qualified Wire.API.Event.Team as TE
 import qualified Wire.API.Federation.API.Brig as FederatedBrig
 import qualified Wire.API.Federation.API.Galley as FederatedGalley
@@ -1327,7 +1327,7 @@ wsAssertMemberJoinWithRole conv usr new role n = do
   evtConv e @?= conv
   evtType e @?= Conv.MemberJoin
   evtFrom e @?= usr
-  evtData e @?= EdMembersJoin (SimpleMembers (fmap (`SimpleMember` role) new))
+  fmap (sort . mMembers) (evtData e ^? _EdMembersJoin) @?= Just (sort (fmap (`SimpleMember` role) new))
 
 -- FUTUREWORK: See if this one can be implemented in terms of:
 --
@@ -1606,7 +1606,7 @@ randomQualifiedUser :: HasCallStack => TestM (Qualified UserId)
 randomQualifiedUser = randomUser' False True True
 
 randomQualifiedId :: MonadIO m => Domain -> m (Qualified (Id a))
-randomQualifiedId domain = flip Qualified domain <$> randomId
+randomQualifiedId domain = Qualified <$> randomId <*> pure domain
 
 randomTeamCreator :: HasCallStack => TestM UserId
 randomTeamCreator = qUnqualified <$> randomUser' True True True

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1415,7 +1415,7 @@ assertRemoveUpdate req qconvId remover alreadyPresentUsers victim = liftIO $ do
   FederatedGalley.cmuOrigUserId cmu @?= remover
   FederatedGalley.cmuConvId cmu @?= qUnqualified qconvId
   sort (FederatedGalley.cmuAlreadyPresentUsers cmu) @?= sort alreadyPresentUsers
-  FederatedGalley.cmuAction cmu @?= FederatedGalley.ConversationMembersActionRemove (pure victim)
+  FederatedGalley.cmuAction cmu @?= Public.ConversationMembersActionRemove (pure victim)
 
 -------------------------------------------------------------------------------
 -- Helpers

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -990,7 +990,12 @@ putOtherMember from to m c = do
       . zType "access"
       . json m
 
-putQualifiedConversationName :: (HasGalley m, MonadIO m, MonadHttp m, MonadMask m) => UserId -> Qualified ConvId -> Text -> m ResponseLBS
+putQualifiedConversationName ::
+  (HasCallStack, HasGalley m, MonadIO m, MonadHttp m, MonadMask m) =>
+  UserId ->
+  Qualified ConvId ->
+  Text ->
+  m ResponseLBS
 putQualifiedConversationName u c n = do
   g <- viewGalley
   let update = ConversationRename n


### PR DESCRIPTION
This generalises the `on-conversation-memberships-changed` RPC to support notifications of conversation renames, by adding a new constructor to the corresponding "action" type.

We also unified and cleaned up the handling of these events on the remote side of a conversation, and added tests to make sure that we never send notifications to a usere when we are not sure they are part of the conversation.

This is part of https://wearezeta.atlassian.net/browse/SQCORE-885 (federated conversation metadata updates).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
