### PR TITLE
Add some retry delay logic to Search integration tests to hopefully deflake them

### DIFF
--- a/changelog.d/5-internal/perhaps-deflake-search-tests
+++ b/changelog.d/5-internal/perhaps-deflake-search-tests
@@ -1,0 +1,1 @@
+Attempt to deflake a flaky integration test about search

--- a/services/brig/test/integration/API/UserPendingActivation.hs
+++ b/services/brig/test/integration/API/UserPendingActivation.hs
@@ -35,7 +35,6 @@ import Control.Exception (assert)
 import Control.Lens ((^.), (^?))
 import Control.Monad.Catch (MonadCatch)
 import Control.Monad.Random
-import Control.Retry (exponentialBackoff, limitRetries, retrying)
 import Data.Aeson hiding (json)
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Lens (key, _String)
@@ -363,20 +362,3 @@ acceptWithName name email code =
       "password" Aeson..= defPassword,
       "team_code" Aeson..= code
     ]
-
--- | Run a probe several times, until a "good" value materializes or until patience runs out
-aFewTimes ::
-  (HasCallStack, MonadIO m) =>
-  -- | Number of retries. Exponentially: 11 ~ total of 2 secs delay, 12 ~ 4 secs delay, ...
-  Int ->
-  m a ->
-  (a -> Bool) ->
-  m a
-aFewTimes
-  retries
-  action
-  good = do
-    retrying
-      (exponentialBackoff 1000 <> limitRetries retries)
-      (\_ -> pure . not . good)
-      (\_ -> action)


### PR DESCRIPTION
Another flaky instance of this test was seen on the CI run from #1770, quoted [here](https://github.com/wireapp/wire-server/pull/1770#issuecomment-920321326)

Perhaps using retry over a maximum of 4 seconds alleviates this problem somewhat. We care about eventual consistency I suppose, not immediate consistency.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`
