### PR TITLE
Work around imprecisions in ES result ordering

### DIFF
--- a/changelog.d/3-bug-fixes/search-order-fix
+++ b/changelog.d/3-bug-fixes/search-order-fix
@@ -1,0 +1,1 @@
+Make searches more consistenty return exact name matches first

--- a/libs/brig-types/src/Brig/Types/Search.hs
+++ b/libs/brig-types/src/Brig/Types/Search.hs
@@ -28,6 +28,7 @@ module Brig.Types.Search
 where
 
 import Data.Id (TeamId)
+import Imports
 import Wire.API.User.Search
 
 data TeamSearchInfo
@@ -38,3 +39,4 @@ data TeamSearchInfo
     TeamOnly TeamId
   | -- | When searching user is part of a team and 'Brig.Options.setSearchSameTeamOnly' is False
     TeamAndNonMembers TeamId
+  deriving (Show)

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -31,7 +31,6 @@ import qualified Brig.IO.Intra as Intra
 import qualified Brig.Options as Opts
 import Brig.Team.Util (ensurePermissions)
 import Brig.Types.Search as Search
-import Brig.User.API.Handle (contactFromProfile)
 import Brig.User.Search.Index
 import qualified Brig.User.Search.SearchIndex as Q
 import Brig.User.Search.TeamUserSearch (RoleFilter (..), TeamUserSearchSortBy (..), TeamUserSearchSortOrder (..))

--- a/services/brig/src/Brig/User/Search/SearchIndex.hs
+++ b/services/brig/src/Brig/User/Search/SearchIndex.hs
@@ -97,8 +97,7 @@ defaultUserQuery u teamSearchInfo (normalized -> term') =
           ( ES.mkMultiMatchQuery
               [ ES.FieldName "handle.prefix^2",
                 ES.FieldName "normalized.prefix",
-                ES.FieldName "normalized^3",
-                ES.FieldName "handle^4"
+                ES.FieldName "normalized^3"
               ]
               (ES.QueryString term')
           )

--- a/services/brig/src/Brig/User/Search/SearchIndex.hs
+++ b/services/brig/src/Brig/User/Search/SearchIndex.hs
@@ -97,7 +97,8 @@ defaultUserQuery u teamSearchInfo (normalized -> term') =
           ( ES.mkMultiMatchQuery
               [ ES.FieldName "handle.prefix^2",
                 ES.FieldName "normalized.prefix",
-                ES.FieldName "normalized^3"
+                ES.FieldName "normalized^3",
+                ES.FieldName "handle^4"
               ]
               (ES.QueryString term')
           )
@@ -122,9 +123,7 @@ defaultUserQuery u teamSearchInfo (normalized -> term') =
             { ES.boolQueryMustMatch =
                 [ ES.QueryBoolQuery
                     boolQuery
-                      { ES.boolQueryShouldMatch = [matchPhraseOrPrefix, legacyPrefixMatch],
-                        -- This removes exact handle matches, as they are fetched from cassandra
-                        ES.boolQueryMustNotMatch = [termQ "handle" term']
+                      { ES.boolQueryShouldMatch = [matchPhraseOrPrefix, legacyPrefixMatch]
                       }
                 ],
               ES.boolQueryShouldMatch = [ES.QueryExistsQuery (ES.FieldName "handle")]


### PR DESCRIPTION
This sorts the result list after the fact by putting exact handle and name searches at the beginning, so we don't have to rely on ES being precise with the ordering of exact matches.

Hopefully this fixes the flakyness of the `order-name` integration test, and makes #1774 unnecessary.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
