### PR TITLE
Fix conversation generator in mapping test

### DIFF
--- a/changelog.d/5-internal/fix-conv-generator
+++ b/changelog.d/5-internal/fix-conv-generator
@@ -1,0 +1,1 @@
+Fix conversation generator in mapping test

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -147,7 +147,11 @@ instance Arbitrary ConvWithLocalUser where
   arbitrary = do
     RandomConversation conv <- arbitrary
     member <- genLocalMember
-    let conv' = conv {Data.convLocalMembers = member : Data.convLocalMembers conv}
+    let conv'
+          | lmId member `elem` map lmId (Data.convLocalMembers conv) =
+            conv
+          | otherwise =
+            conv {Data.convLocalMembers = member : Data.convLocalMembers conv}
     pure $ ConvWithLocalUser conv' (lmId member)
 
 data ConvWithRemoteUser = ConvWithRemoteUser Data.Conversation (Remote UserId)
@@ -157,5 +161,9 @@ instance Arbitrary ConvWithRemoteUser where
   arbitrary = do
     RandomConversation conv <- arbitrary
     member <- genRemoteMember
-    let conv' = conv {Data.convRemoteMembers = member : Data.convRemoteMembers conv}
+    let conv'
+          | rmId member `elem` map rmId (Data.convRemoteMembers conv) =
+            conv
+          | otherwise =
+            conv {Data.convRemoteMembers = member : Data.convRemoteMembers conv}
     pure $ ConvWithRemoteUser conv' (rmId member)


### PR DESCRIPTION
The `ConvWithLocalUser` and `ConvWithRemoteUser` generators were potentially duplicating members. This makes sure that the member added by the generator was not already present.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
