### PR TITLE
Expand documentation of `list-ids` endpoint

### DIFF
--- a/changelog.d/4-docs/list-ids
+++ b/changelog.d/4-docs/list-ids
@@ -1,0 +1,1 @@
+Expand documentation of `conversations/list-ids` endpoint

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -122,7 +122,17 @@ data Api routes = Api
     listConversationIds ::
       routes
         :- Summary "Get all conversation IDs."
-          :> Description "To retrieve the next page, a client must pass the paging_state returned by the previous page."
+          :> Description
+               "The IDs returned by this endpoint are paginated. To\
+               \ get the first page, make a call with the `paging_state` field set to\
+               \ `null` (or omitted). Whenever the `has_more` field of the response is\
+               \ set to `true`, more results are available, and they can be obtained\
+               \ by calling the endpoint again, but this time passing the value of\
+               \ `paging_state` returned by the previous call. One can continue in\
+               \ this fashion until all results are returned, which is indicated by\
+               \ `has_more` being `false`. Note that `paging_state` should be\
+               \ considered an opaque token. It should not be inspected, or stored, or\
+               \ reused across multiple unrelated invokations of the endpoint."
           :> ZUser
           :> "conversations"
           :> "list-ids"


### PR DESCRIPTION
Added more details on how to use the `conversation/list-ids` endpoint, included some information on the `paging_state` field and how to use it.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
