### PR TITLE
Servantify message timer update endpoint

### DIFF
--- a/changelog.d/1-api-changes/deprecate-messager-timer-update
+++ b/changelog.d/1-api-changes/deprecate-messager-timer-update
@@ -1,0 +1,1 @@
+Deprecate `PUT /conversations/:cnv/message-timer` endpoint

--- a/changelog.d/1-api-changes/qualified-message-timer-update
+++ b/changelog.d/1-api-changes/qualified-message-timer-update
@@ -1,0 +1,1 @@
+Add qualified endpoint for updating message timer

--- a/changelog.d/5-internal/servantify-message-timer
+++ b/changelog.d/5-internal/servantify-message-timer
@@ -1,0 +1,1 @@
+Convert the `PUT /conversations/:cnv/message-timer` endpoint to Servant

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -317,6 +317,25 @@ data Api routes = Api
                Respond 200 "Conversation updated" Event
              ]
              (Maybe Event),
+    -- This endpoint can lead to the following events being sent:
+    -- - ConvMessageTimerUpdate event to members
+    updateConversationMessageTimerUnqualified ::
+      routes
+        :- Summary "Update the message timer for a conversation"
+        :> ZUser
+        :> ZConn
+        :> CanThrow ConvAccessDenied
+        :> CanThrow ConvNotFound
+        :> CanThrow (InvalidOp "Invalid operation")
+        :> "conversations"
+        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "message-timer"
+        :> ReqBody '[JSON] ConversationMessageTimerUpdate
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             (UpdateResponses "Message timer unchanged" "Message timer updated" Event)
+             (UpdateResult Event),
     getConversationSelfUnqualified ::
       routes
         :- Summary "Get self membership properties (deprecated)"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -321,7 +321,8 @@ data Api routes = Api
     -- - ConvMessageTimerUpdate event to members
     updateConversationMessageTimerUnqualified ::
       routes
-        :- Summary "Update the message timer for a conversation"
+        :- Summary "Update the message timer for a conversation (deprecated)"
+        :> Description "Use `/conversations/:domain/:cnv/message-timer` instead."
         :> ZUser
         :> ZConn
         :> CanThrow ConvAccessDenied
@@ -329,6 +330,23 @@ data Api routes = Api
         :> CanThrow (InvalidOp "Invalid operation")
         :> "conversations"
         :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "message-timer"
+        :> ReqBody '[JSON] ConversationMessageTimerUpdate
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             (UpdateResponses "Message timer unchanged" "Message timer updated" Event)
+             (UpdateResult Event),
+    updateConversationMessageTimer ::
+      routes
+        :- Summary "Update the message timer for a conversation"
+        :> ZUser
+        :> ZConn
+        :> CanThrow ConvAccessDenied
+        :> CanThrow ConvNotFound
+        :> CanThrow (InvalidOp "Invalid operation")
+        :> "conversations"
+        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
         :> "message-timer"
         :> ReqBody '[JSON] ConversationMessageTimerUpdate
         :> MultiVerb

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -95,6 +95,8 @@ servantSitemap =
         GalleyAPI.updateConversationNameDeprecated = Update.updateLocalConversationName,
         GalleyAPI.updateConversationNameUnqualified = Update.updateLocalConversationName,
         GalleyAPI.updateConversationName = Update.updateConversationName,
+        GalleyAPI.updateConversationMessageTimerUnqualified =
+          Update.updateConversationMessageTimerUnqualified,
         GalleyAPI.getConversationSelfUnqualified = Query.getLocalSelf,
         GalleyAPI.updateConversationSelfUnqualified = Update.updateUnqualifiedSelfMember,
         GalleyAPI.updateConversationSelf = Update.updateSelfMember,
@@ -676,28 +678,6 @@ sitemap = do
       description "JSON body"
     errorResponse (Error.errorDescriptionToWai Error.convNotFound)
     errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
-
-  -- This endpoint can lead to the following events being sent:
-  -- - ConvMessageTimerUpdate event to members
-  put "/conversations/:cnv/message-timer" (continue Update.updateConversationMessageTimerH) $
-    zauthUserId
-      .&. zauthConnId
-      .&. capture "cnv"
-      .&. jsonRequest @Public.ConversationMessageTimerUpdate
-  document "PUT" "updateConversationMessageTimer" $ do
-    summary "Update the message timer for a conversation"
-    parameter Path "cnv" bytes' $
-      description "Conversation ID"
-    returns (ref Public.modelEvent)
-    response 200 "Message timer updated." end
-    response 204 "Message timer unchanged." end
-    body (ref Public.modelConversationMessageTimerUpdate) $
-      description "JSON body"
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
-    errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
-    errorResponse Error.invalidSelfOp
-    errorResponse Error.invalidOne2OneOp
-    errorResponse Error.invalidConnectOp
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberJoin event to members

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -96,7 +96,8 @@ servantSitemap =
         GalleyAPI.updateConversationNameUnqualified = Update.updateLocalConversationName,
         GalleyAPI.updateConversationName = Update.updateConversationName,
         GalleyAPI.updateConversationMessageTimerUnqualified =
-          Update.updateConversationMessageTimerUnqualified,
+          Update.updateLocalConversationMessageTimer,
+        GalleyAPI.updateConversationMessageTimer = Update.updateConversationMessageTimer,
         GalleyAPI.getConversationSelfUnqualified = Query.getLocalSelf,
         GalleyAPI.updateConversationSelfUnqualified = Update.updateUnqualifiedSelfMember,
         GalleyAPI.updateConversationSelf = Update.updateSelfMember,

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -31,7 +31,7 @@ module Galley.API.Update
     updateConversationName,
     updateConversationAccessH,
     updateConversationReceiptModeH,
-    updateConversationMessageTimerH,
+    updateConversationMessageTimerUnqualified,
 
     -- * Managing Members
     addMembersH,
@@ -318,13 +318,8 @@ updateConversationReceiptMode usr zcon cnv receiptModeUpdate@(Public.Conversatio
       pushConversationEvent (Just zcon) receiptEvent (map lmId users) bots
       pure receiptEvent
 
-updateConversationMessageTimerH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.ConversationMessageTimerUpdate -> Galley Response
-updateConversationMessageTimerH (usr ::: zcon ::: cnv ::: req) = do
-  timerUpdate <- fromJsonBody req
-  handleUpdateResult <$> updateConversationMessageTimer usr zcon cnv timerUpdate
-
-updateConversationMessageTimer :: UserId -> ConnId -> ConvId -> Public.ConversationMessageTimerUpdate -> Galley (UpdateResult Event)
-updateConversationMessageTimer usr zcon cnv timerUpdate@(Public.ConversationMessageTimerUpdate target) = do
+updateConversationMessageTimerUnqualified :: UserId -> ConnId -> ConvId -> Public.ConversationMessageTimerUpdate -> Galley (UpdateResult Event)
+updateConversationMessageTimerUnqualified usr zcon cnv timerUpdate@(Public.ConversationMessageTimerUpdate target) = do
   localDomain <- viewFederationDomain
   let qcnv = Qualified cnv localDomain
       qusr = Qualified usr localDomain

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1052,6 +1052,23 @@ putAccessUpdate u c acc = do
       . zType "access"
       . json acc
 
+putMessageTimerUpdateQualified ::
+  UserId -> Qualified ConvId -> ConversationMessageTimerUpdate -> TestM ResponseLBS
+putMessageTimerUpdateQualified u c acc = do
+  g <- view tsGalley
+  put $
+    g
+      . paths
+        [ "/conversations",
+          toByteString' (qDomain c),
+          toByteString' (qUnqualified c),
+          "message-timer"
+        ]
+      . zUser u
+      . zConn "conn"
+      . zType "access"
+      . json acc
+
 putMessageTimerUpdate ::
   UserId -> ConvId -> ConversationMessageTimerUpdate -> TestM ResponseLBS
 putMessageTimerUpdate u c acc = do


### PR DESCRIPTION
Converted endpoint to Servant, made a qualified version and deprecated the unqualified one. This is part of https://wearezeta.atlassian.net/browse/SQCORE-885.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
