### PR TITLE
Testing: Rewrite Conversation Generators in an Applicative Style

### DIFF
--- a/changelog.d/5-internal/applicative-style-generators
+++ b/changelog.d/5-internal/applicative-style-generators
@@ -1,0 +1,1 @@
+Testing: rewrite monadic to applicative style generators

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -114,7 +114,7 @@ genLocalMember =
 genRemoteMember :: Gen RemoteMember
 genRemoteMember = RemoteMember <$> arbitrary <*> pure roleNameWireMember
 
-genConversation :: [LocalMember] -> [RemoteMember] -> Gen Data.Conversation
+genConversation :: Gen Data.Conversation
 genConversation locals remotes =
   Data.Conversation
     <$> arbitrary
@@ -123,8 +123,8 @@ genConversation locals remotes =
     <*> arbitrary
     <*> pure []
     <*> pure ActivatedAccessRole
-    <*> pure locals
-    <*> pure remotes
+    <*> listof genLocalMember
+    <*> listOf genRemoteMember
     <*> pure Nothing
     <*> pure (Just False)
     <*> pure Nothing
@@ -135,14 +135,7 @@ newtype RandomConversation = RandomConversation
   deriving (Show)
 
 instance Arbitrary RandomConversation where
-  arbitrary =
-    RandomConversation
-      <$> join
-        ( liftA2
-            genConversation
-            (listOf genLocalMember)
-            (listOf genRemoteMember)
-        )
+  arbitrary = RandomConversation <$> genConversation
 
 data ConvWithLocalUser = ConvWithLocalUser Data.Conversation UserId
   deriving (Show)

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -20,6 +20,7 @@
 
 module Test.Galley.Mapping where
 
+import Data.Containers.ListUtils (nubOrdOn)
 import Data.Domain
 import Data.Id
 import Data.Qualified
@@ -30,7 +31,6 @@ import Galley.Types.Conversations.Members
 import Imports
 import Test.Tasty
 import Test.Tasty.QuickCheck
--- import Test.Tasty.HUnit
 import Wire.API.Conversation
 import Wire.API.Conversation.Role
 import Wire.API.Federation.API.Galley
@@ -130,40 +130,42 @@ genConversation locals remotes =
     <*> pure Nothing
     <*> pure Nothing
 
-newtype RandomConversation = RandomConversation Data.Conversation
+newtype RandomConversation = RandomConversation
+  {unRandomConversation :: Data.Conversation}
   deriving (Show)
 
 instance Arbitrary RandomConversation where
   arbitrary =
-    RandomConversation <$> do
-      locals <- listOf genLocalMember
-      remotes <- listOf genRemoteMember
-      genConversation locals remotes
+    RandomConversation
+      <$> join
+        ( liftA2
+            genConversation
+            (listOf genLocalMember)
+            (listOf genRemoteMember)
+        )
 
 data ConvWithLocalUser = ConvWithLocalUser Data.Conversation UserId
   deriving (Show)
 
 instance Arbitrary ConvWithLocalUser where
   arbitrary = do
-    RandomConversation conv <- arbitrary
     member <- genLocalMember
-    let conv'
-          | lmId member `elem` map lmId (Data.convLocalMembers conv) =
-            conv
-          | otherwise =
-            conv {Data.convLocalMembers = member : Data.convLocalMembers conv}
-    pure $ ConvWithLocalUser conv' (lmId member)
+    ConvWithLocalUser <$> genConv member <*> pure (lmId member)
+    where
+      genConv m = uniqueMembers m . unRandomConversation <$> arbitrary
+      uniqueMembers :: LocalMember -> Data.Conversation -> Data.Conversation
+      uniqueMembers m c =
+        c {Data.convLocalMembers = nubOrdOn lmId (m : Data.convLocalMembers c)}
 
 data ConvWithRemoteUser = ConvWithRemoteUser Data.Conversation (Remote UserId)
   deriving (Show)
 
 instance Arbitrary ConvWithRemoteUser where
   arbitrary = do
-    RandomConversation conv <- arbitrary
     member <- genRemoteMember
-    let conv'
-          | rmId member `elem` map rmId (Data.convRemoteMembers conv) =
-            conv
-          | otherwise =
-            conv {Data.convRemoteMembers = member : Data.convRemoteMembers conv}
-    pure $ ConvWithRemoteUser conv' (rmId member)
+    ConvWithRemoteUser <$> genConv member <*> pure (rmId member)
+    where
+      genConv m = uniqueMembers m . unRandomConversation <$> arbitrary
+      uniqueMembers :: RemoteMember -> Data.Conversation -> Data.Conversation
+      uniqueMembers m c =
+        c {Data.convRemoteMembers = nubOrdOn rmId (m : Data.convRemoteMembers c)}

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -115,7 +115,7 @@ genRemoteMember :: Gen RemoteMember
 genRemoteMember = RemoteMember <$> arbitrary <*> pure roleNameWireMember
 
 genConversation :: Gen Data.Conversation
-genConversation locals remotes =
+genConversation =
   Data.Conversation
     <$> arbitrary
     <*> pure RegularConv
@@ -123,7 +123,7 @@ genConversation locals remotes =
     <*> arbitrary
     <*> pure []
     <*> pure ActivatedAccessRole
-    <*> listof genLocalMember
+    <*> listOf genLocalMember
     <*> listOf genRemoteMember
     <*> pure Nothing
     <*> pure (Just False)


### PR DESCRIPTION
In Galley testing, this patch rewrites monadic style generators to applicative style generators. This has the benefit of smaller counterexamples in failing test cases, which makes debugging the tests easier and managable.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
