### PR TITLE
Federation: support message timer updates

### DIFF
--- a/changelog.d/6-federation/fed-conv-message-timer
+++ b/changelog.d/6-federation/fed-conv-message-timer
@@ -1,0 +1,1 @@
+Notify remote users when a conversation message timer is updated

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -874,6 +874,7 @@ data ConversationAction
   = ConversationActionAddMembers (NonEmpty (Qualified UserId, RoleName))
   | ConversationActionRemoveMembers (NonEmpty (Qualified UserId))
   | ConversationActionRename ConversationRename
+  | ConversationActionMessageTimerUpdate ConversationMessageTimerUpdate
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform ConversationAction)
   deriving (ToJSON, FromJSON) via (CustomEncoded ConversationAction)

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -576,3 +576,5 @@ conversationActionToEvent now quid qcnv (ConversationActionRemoveMembers removed
     EdMembersLeave . QualifiedUserIdList . toList $ removedMembers
 conversationActionToEvent now quid qcnv (ConversationActionRename rename) =
   Event ConvRename qcnv quid now (EdConvRename rename)
+conversationActionToEvent now quid qcnv (ConversationActionMessageTimerUpdate update) =
+  Event ConvMessageTimerUpdate qcnv quid now (EdConvMessageTimerUpdate update)

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -138,6 +138,7 @@ onConversationUpdated requestingDomain cu = do
       Data.removeLocalMembersFromRemoteConv qconvId localUsers
       pure []
     Public.ConversationActionRename _ -> pure []
+    Public.ConversationActionMessageTimerUpdate _ -> pure []
 
   -- Send notifications
   let event = conversationActionToEvent (cuTime cu) (cuOrigUserId cu) qconvId (cuAction cu)

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -98,7 +98,7 @@ servantSitemap =
         GalleyAPI.updateConversationNameUnqualified = Update.updateUnqualifiedConversationName,
         GalleyAPI.updateConversationName = Update.updateConversationName,
         GalleyAPI.updateConversationMessageTimerUnqualified =
-          Update.updateLocalConversationMessageTimer,
+          Update.updateConversationMessageTimerUnqualified,
         GalleyAPI.updateConversationMessageTimer = Update.updateConversationMessageTimer,
         GalleyAPI.updateConversationReceiptModeUnqualified =
           Update.updateConversationReceiptModeUnqualified,

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -82,7 +82,7 @@ getBotConversationH (zbot ::: zcnv ::: _) = do
 
 getBotConversation :: BotId -> ConvId -> Galley Public.BotConvView
 getBotConversation zbot zcnv = do
-  c <- getConversationAndCheckMembershipWithError (errorDescriptionTypeToWai @ConvNotFound) (botUserId zbot) zcnv
+  (c, _) <- getConversationAndMemberWithError (errorDescriptionTypeToWai @ConvNotFound) (botUserId zbot) zcnv
   domain <- viewFederationDomain
   let cmems = mapMaybe (mkMember domain) (toList (Data.convLocalMembers c))
   pure $ Public.botConvView zcnv (Data.convName c) cmems

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2542,10 +2542,6 @@ putQualifiedConvRenameWithRemotesOk = do
       evtFrom e @?= qbob
       evtData e @?= EdConvRename (ConversationRename "gossip++")
 
-assertOne :: (HasCallStack, MonadIO m, Show a) => [a] -> m a
-assertOne [a] = pure a
-assertOne xs = liftIO . assertFailure $ "Expected exactly one element, found " <> show xs
-
 putConvDeprecatedRenameOk :: TestM ()
 putConvDeprecatedRenameOk = do
   c <- view tsCannon

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -69,6 +69,7 @@ tests s =
       test s "POST /federation/on-conversation-updated : Remove a local user from a remote conversation" removeLocalUser,
       test s "POST /federation/on-conversation-updated : Remove a remote user from a remote conversation" removeRemoteUser,
       test s "POST /federation/on-conversation-updated : Notify local user about conversation rename" notifyConvRename,
+      test s "POST /federation/on-conversation-updated : Notify local user about message timer update" notifyMessageTimer,
       test s "POST /federation/leave-conversation : Success" leaveConversationSuccess,
       test s "POST /federation/on-message-sent : Receive a message from another backend" onMessageSent,
       test s "POST /federation/send-message : Post a message sent from another backend" sendMessage
@@ -323,6 +324,44 @@ notifyConvRename = do
         evtType e @?= ConvRename
         evtFrom e @?= qbob
         evtData e @?= EdConvRename (ConversationRename "gossip++")
+      WS.assertNoEvent (1 # Second) [wsC]
+
+notifyMessageTimer :: TestM ()
+notifyMessageTimer = do
+  c <- view tsCannon
+  qalice <- randomQualifiedUser
+  let alice = qUnqualified qalice
+  bob <- randomId
+  charlie <- randomUser
+  conv <- randomId
+  let bdom = Domain "bob.example.com"
+      qbob = Qualified bob bdom
+      qconv = Qualified conv bdom
+      aliceAsOtherMember = OtherMember qalice Nothing roleNameWireMember
+  fedGalleyClient <- view tsFedGalleyClient
+
+  registerRemoteConv qconv qbob (Just "gossip") (Set.singleton aliceAsOtherMember)
+
+  now <- liftIO getCurrentTime
+  let cu =
+        FedGalley.ConversationUpdate
+          { FedGalley.cuTime = now,
+            FedGalley.cuOrigUserId = qbob,
+            FedGalley.cuConvId = conv,
+            FedGalley.cuAlreadyPresentUsers = [alice, charlie],
+            FedGalley.cuAction =
+              ConversationActionMessageTimerUpdate (ConversationMessageTimerUpdate (Just 5000))
+          }
+  WS.bracketR2 c alice charlie $ \(wsA, wsC) -> do
+    FedGalley.onConversationUpdated fedGalleyClient bdom cu
+    liftIO $ do
+      WS.assertMatch_ (5 # Second) wsA $ \n -> do
+        let e = List1.head (WS.unpackPayload n)
+        ntfTransient n @?= False
+        evtConv e @?= qconv
+        evtType e @?= ConvMessageTimerUpdate
+        evtFrom e @?= qbob
+        evtData e @?= EdConvMessageTimerUpdate (ConversationMessageTimerUpdate (Just 5000))
       WS.assertNoEvent (1 # Second) [wsC]
 
 -- TODO: test adding non-existing users

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -24,21 +24,32 @@ import API.Util
 import Bilge hiding (timeout)
 import Bilge.Assert
 import Control.Lens (view)
+import Data.Aeson (eitherDecode)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Domain
+import Data.Id
 import qualified Data.LegalHold as LH
 import Data.List1
+import qualified Data.List1 as List1
 import Data.Misc
 import Data.Qualified
 import Galley.Types
 import Galley.Types.Conversations.Roles
 import qualified Galley.Types.Teams as Teams
+import Gundeck.Types.Notification (Notification (..))
 import Imports hiding (head)
 import Network.Wai.Utilities.Error
 import Test.Tasty
 import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import qualified Test.Tasty.Cannon as WS
+import Test.Tasty.HUnit
 import TestHelpers
 import TestSetup
+import Wire.API.Conversation
+import qualified Wire.API.Federation.API.Galley as F
+import qualified Wire.API.Federation.GRPC.Types as F
 import qualified Wire.API.Team.Member as Member
+import Wire.API.User.Profile (Name (..))
 
 tests :: IO TestSetup -> TestTree
 tests s =
@@ -51,6 +62,7 @@ tests s =
         ],
       test s "timer can be changed" messageTimerChange,
       test s "timer can be changed with the qualified endpoint" messageTimerChangeQualified,
+      test s "timer changes are propagated to remote users" messageTimerChangeWithRemotes,
       test s "timer can't be set by conv member without allowed action" messageTimerChangeWithoutAllowedAction,
       test s "timer can't be set in 1:1 conversations" messageTimerChangeO2O,
       test s "setting the timer generates an event" messageTimerEvent
@@ -129,6 +141,43 @@ messageTimerChangeQualified = do
     !!! const 200 === statusCode
   getConv jane cid
     !!! const timer1year === (cnvMessageTimer <=< responseJsonUnsafe)
+
+messageTimerChangeWithRemotes :: TestM ()
+messageTimerChangeWithRemotes = do
+  c <- view tsCannon
+  let remoteDomain = Domain "alice.example.com"
+  qalice <- Qualified <$> randomId <*> pure remoteDomain
+  qbob <- randomQualifiedUser
+  let bob = qUnqualified qbob
+
+  resp <- postConvWithRemoteUser remoteDomain (mkProfile qalice (Name "Alice")) bob [qalice]
+  let qconv = decodeQualifiedConvId resp
+
+  opts <- view tsGConf
+  WS.bracketR c bob $ \wsB -> do
+    (_, requests) <-
+      withTempMockFederator opts remoteDomain (const ()) $
+        putMessageTimerUpdateQualified bob qconv (ConversationMessageTimerUpdate timer1sec)
+          !!! const 200 === statusCode
+
+    req <- assertOne requests
+    liftIO $ do
+      F.domain req @?= domainText remoteDomain
+      fmap F.component (F.request req) @?= Just F.Galley
+      fmap F.path (F.request req) @?= Just "/federation/on-conversation-updated"
+      Just (Right cu) <- pure $ fmap (eitherDecode . LBS.fromStrict . F.body) (F.request req)
+      F.cuConvId cu @?= qUnqualified qconv
+      F.cuAction cu
+        @?= ConversationActionMessageTimerUpdate
+          (ConversationMessageTimerUpdate timer1sec)
+
+    void . liftIO . WS.assertMatch (5 # Second) wsB $ \n -> do
+      let e = List1.head (WS.unpackPayload n)
+      ntfTransient n @?= False
+      evtConv e @?= qconv
+      evtType e @?= ConvMessageTimerUpdate
+      evtFrom e @?= qbob
+      evtData e @?= EdConvMessageTimerUpdate (ConversationMessageTimerUpdate timer1sec)
 
 messageTimerChangeWithoutAllowedAction :: TestM ()
 messageTimerChangeWithoutAllowedAction = do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1083,9 +1083,13 @@ putAccessUpdate u c acc = do
       . json acc
 
 putMessageTimerUpdateQualified ::
-  UserId -> Qualified ConvId -> ConversationMessageTimerUpdate -> TestM ResponseLBS
+  (HasGalley m, MonadIO m, MonadHttp m) =>
+  UserId ->
+  Qualified ConvId ->
+  ConversationMessageTimerUpdate ->
+  m ResponseLBS
 putMessageTimerUpdateQualified u c acc = do
-  g <- view tsGalley
+  g <- viewGalley
   put $
     g
       . paths
@@ -2326,3 +2330,7 @@ fedRequestsForDomain domain component =
           F.domain req == domainText domain
             && fmap F.component (F.request req) == Just component
       )
+
+assertOne :: (HasCallStack, MonadIO m, Show a) => [a] -> m a
+assertOne [a] = pure a
+assertOne xs = liftIO . assertFailure $ "Expected exactly one element, found " <> show xs


### PR DESCRIPTION
This generalises the `on-conversation-updated` RPC to support notifications of message timer updates, by adding a new constructor to the corresponding "action" type.

This is part of https://wearezeta.atlassian.net/browse/SQCORE-885 (federated conversation metadata updates).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
