### PR TITLE
Servantify other member update

### DIFF
--- a/changelog.d/1-api-changes/deprecate-other-member-update
+++ b/changelog.d/1-api-changes/deprecate-other-member-update
@@ -1,0 +1,1 @@
+Deprecate `PUT /conversations/:cnv/members/:usr` endpoint

--- a/changelog.d/1-api-changes/qualified-other-member-update
+++ b/changelog.d/1-api-changes/qualified-other-member-update
@@ -1,0 +1,1 @@
+Add qualified endpoint for updating conversation members

--- a/changelog.d/6-federation/servantify-other-member-update
+++ b/changelog.d/6-federation/servantify-other-member-update
@@ -1,0 +1,1 @@
+Convert the `PUT /conversations/:cnv/members/:usr` endpoint to Servant

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -206,6 +206,8 @@ type ConvNotFound = ErrorDescription 404 "no-conversation" "Conversation not fou
 convNotFound :: ConvNotFound
 convNotFound = mkErrorDescription
 
+type ConvMemberNotFound = ErrorDescription 404 "no-conversation-member" "Conversation member not found"
+
 type UnknownClient = ErrorDescription 403 "unknown-client" "Unknown Client"
 
 unknownClient :: UnknownClient

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -278,6 +278,25 @@ data Api routes = Api
              RemoveFromConversationResponse,
     -- This endpoint can lead to the following events being sent:
     -- - MemberStateUpdate event to members
+    updateOtherMemberUnqualified ::
+      routes
+        :- Summary "Update membership of the specified user (deprecated)"
+        :> Description "Use `PUT /conversations/:cnv_domain/:cnv/members/:usr_domain/:usr` instead"
+        :> ZUser
+        :> ZConn
+        :> CanThrow ConvNotFound
+        :> CanThrow ConvMemberNotFound
+        :> CanThrow (InvalidOp "Invalid operation")
+        :> "conversations"
+        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "members"
+        :> Capture' '[Description "Target User ID"] "usr" UserId
+        :> ReqBody '[JSON] OtherMemberUpdate
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             '[RespondEmpty 200 "Membership updated"]
+             (),
     updateOtherMember ::
       routes
         :- Summary "Update membership of the specified user"
@@ -288,9 +307,9 @@ data Api routes = Api
         :> CanThrow ConvMemberNotFound
         :> CanThrow (InvalidOp "Invalid operation")
         :> "conversations"
-        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
         :> "members"
-        :> Capture' '[Description "Target User ID"] "usr" UserId
+        :> QualifiedCapture' '[Description "Target User ID"] "usr" UserId
         :> ReqBody '[JSON] OtherMemberUpdate
         :> MultiVerb
              'PUT

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -277,6 +277,27 @@ data Api routes = Api
              RemoveFromConversationHTTPResponse
              RemoveFromConversationResponse,
     -- This endpoint can lead to the following events being sent:
+    -- - MemberStateUpdate event to members
+    updateOtherMember ::
+      routes
+        :- Summary "Update membership of the specified user"
+        :> Description "**Note**: at least one field has to be provided."
+        :> ZUser
+        :> ZConn
+        :> CanThrow ConvNotFound
+        :> CanThrow ConvMemberNotFound
+        :> CanThrow (InvalidOp "Invalid operation")
+        :> "conversations"
+        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "members"
+        :> Capture' '[Description "Target User ID"] "usr" UserId
+        :> ReqBody '[JSON] OtherMemberUpdate
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             '[RespondEmpty 200 "Membership updated"]
+             (),
+    -- This endpoint can lead to the following events being sent:
     -- - ConvRename event to members
     updateConversationNameDeprecated ::
       routes

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -39,20 +39,38 @@ errorDescriptionToWai ::
 errorDescriptionToWai (ErrorDescription msg) =
   mkError (statusVal (Proxy @code)) (LT.pack (symbolVal (Proxy @lbl))) (LT.fromStrict msg)
 
+errorDescriptionTypeToWai ::
+  forall e (code :: Nat) (lbl :: Symbol) (desc :: Symbol).
+  ( KnownStatus code,
+    KnownSymbol lbl,
+    KnownSymbol desc,
+    e ~ ErrorDescription code lbl desc
+  ) =>
+  Error
+errorDescriptionTypeToWai = errorDescriptionToWai (mkErrorDescription :: e)
+
 throwErrorDescription ::
   (KnownStatus code, KnownSymbol lbl, MonadThrow m) =>
   ErrorDescription code lbl desc ->
   m a
 throwErrorDescription = throwM . errorDescriptionToWai
 
+throwErrorDescriptionType ::
+  forall e (code :: Nat) (lbl :: Symbol) (desc :: Symbol) m a.
+  ( KnownStatus code,
+    KnownSymbol lbl,
+    KnownSymbol desc,
+    MonadThrow m,
+    e ~ ErrorDescription code lbl desc
+  ) =>
+  m a
+throwErrorDescriptionType = throwErrorDescription (mkErrorDescription :: e)
+
 internalError :: Error
 internalError = internalErrorWithDescription "internal error"
 
 internalErrorWithDescription :: LText -> Error
 internalErrorWithDescription = mkError status500 "internal-error"
-
-convMemberNotFound :: Error
-convMemberNotFound = mkError status404 "no-conversation-member" "conversation member not found"
 
 invalidSelfOp :: Error
 invalidSelfOp = invalidOp "invalid operation for self conversation"

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -92,6 +92,7 @@ servantSitemap =
         GalleyAPI.addMembersToConversationV2 = Update.addMembers,
         GalleyAPI.removeMemberUnqualified = Update.removeMemberUnqualified,
         GalleyAPI.removeMember = Update.removeMemberQualified,
+        GalleyAPI.updateOtherMemberUnqualified = Update.updateOtherMemberUnqualified,
         GalleyAPI.updateOtherMember = Update.updateOtherMember,
         GalleyAPI.updateConversationNameDeprecated = Update.updateLocalConversationName,
         GalleyAPI.updateConversationNameUnqualified = Update.updateLocalConversationName,

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -739,7 +739,7 @@ sitemap = do
     body (ref Public.modelOtherMemberUpdate) $
       description "JSON body"
     errorResponse (Error.errorDescriptionToWai Error.convNotFound)
-    errorResponse Error.convMemberNotFound
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvMemberNotFound)
     errorResponse Error.invalidTargetUserOp
 
   -- This endpoint can lead to the following events being sent:

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -92,6 +92,7 @@ servantSitemap =
         GalleyAPI.addMembersToConversationV2 = Update.addMembers,
         GalleyAPI.removeMemberUnqualified = Update.removeMemberUnqualified,
         GalleyAPI.removeMember = Update.removeMemberQualified,
+        GalleyAPI.updateOtherMember = Update.updateOtherMember,
         GalleyAPI.updateConversationNameDeprecated = Update.updateLocalConversationName,
         GalleyAPI.updateConversationNameUnqualified = Update.updateLocalConversationName,
         GalleyAPI.updateConversationName = Update.updateConversationName,
@@ -720,27 +721,6 @@ sitemap = do
     errorResponse (Error.invalidOp "Conversation type does not allow adding members")
     errorResponse (Error.errorDescriptionToWai Error.notConnected)
     errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
-
-  -- This endpoint can lead to the following events being sent:
-  -- - MemberStateUpdate event to members
-  put "/conversations/:cnv/members/:usr" (continue Update.updateOtherMemberH) $
-    zauthUserId
-      .&. zauthConnId
-      .&. capture "cnv"
-      .&. capture "usr"
-      .&. jsonRequest @Public.OtherMemberUpdate
-  document "PUT" "updateOtherMember" $ do
-    summary "Update membership of the specified user"
-    notes "Even though all fields are optional, at least one needs to be given."
-    parameter Path "cnv" bytes' $
-      description "Conversation ID"
-    parameter Path "usr" bytes' $
-      description "Target User ID"
-    body (ref Public.modelOtherMemberUpdate) $
-      description "JSON body"
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
-    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvMemberNotFound)
-    errorResponse Error.invalidTargetUserOp
 
   -- This endpoint can lead to the following events being sent:
   -- - Typing event to members

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -38,7 +38,7 @@ module Galley.API.Update
     addMembers,
     updateUnqualifiedSelfMember,
     updateSelfMember,
-    updateOtherMemberH,
+    updateOtherMember,
     removeMember,
     removeMemberQualified,
     removeMemberUnqualified,
@@ -584,12 +584,6 @@ updateRemoteSelfMember zusr zcon rcid update = do
     Nothing -> throwErrorDescriptionType @ConvMemberNotFound
     Just _ ->
       void $ processUpdateMemberEvent zusr zcon (unTagged rcid) [zusr] zusr update
-
-updateOtherMemberH :: UserId ::: ConnId ::: ConvId ::: UserId ::: JsonRequest Public.OtherMemberUpdate -> Galley Response
-updateOtherMemberH (zusr ::: zcon ::: cid ::: victim ::: req) = do
-  update <- fromJsonBody req
-  updateOtherMember zusr zcon cid victim update
-  return empty
 
 updateOtherMember :: UserId -> ConnId -> ConvId -> UserId -> Public.OtherMemberUpdate -> Galley ()
 updateOtherMember zusr zcon cid victim update = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -113,7 +113,8 @@ import qualified Wire.API.Conversation as Public
 import qualified Wire.API.Conversation.Code as Public
 import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.ErrorDescription
-  ( ConvNotFound,
+  ( ConvMemberNotFound,
+    ConvNotFound,
     codeNotFound,
     convNotFound,
     missingLegalholdConsent,
@@ -580,7 +581,7 @@ updateRemoteSelfMember ::
 updateRemoteSelfMember zusr zcon rcid update = do
   statusMap <- Data.remoteConversationStatus zusr [rcid]
   case Map.lookup rcid statusMap of
-    Nothing -> throwM convMemberNotFound
+    Nothing -> throwErrorDescriptionType @ConvMemberNotFound
     Just _ ->
       void $ processUpdateMemberEvent zusr zcon (unTagged rcid) [zusr] zusr update
 

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -294,7 +294,7 @@ getSelfMemberFromLocalsLegacy usr lmems =
   eitherM (throwM . errorDescriptionToWai) pure . runExceptT $ getSelfMemberFromLocals usr lmems
 
 getOtherMember :: (Foldable t, Monad m) => UserId -> t LocalMember -> ExceptT Error m LocalMember
-getOtherMember = getLocalMember convMemberNotFound
+getOtherMember = getLocalMember (errorDescriptionTypeToWai @ConvMemberNotFound)
 
 getOtherMemberLegacy :: Foldable t => UserId -> t LocalMember -> Galley LocalMember
 getOtherMemberLegacy usr lmems =

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -955,6 +955,29 @@ putMember u m (Qualified c dom) = do
       . zType "access"
       . json m
 
+putOtherMemberQualified ::
+  UserId ->
+  Qualified UserId ->
+  OtherMemberUpdate ->
+  Qualified ConvId ->
+  TestM ResponseLBS
+putOtherMemberQualified from to m c = do
+  g <- view tsGalley
+  put $
+    g
+      . paths
+        [ "conversations",
+          toByteString' (qDomain c),
+          toByteString' (qUnqualified c),
+          "members",
+          toByteString' (qDomain to),
+          toByteString' (qUnqualified to)
+        ]
+      . zUser from
+      . zConn "conn"
+      . zType "access"
+      . json m
+
 putOtherMember :: UserId -> UserId -> OtherMemberUpdate -> ConvId -> TestM ResponseLBS
 putOtherMember from to m c = do
   g <- view tsGalley


### PR DESCRIPTION
Converted endpoint to Servant, made a qualified version and deprecated the unqualified one. This is part of https://wearezeta.atlassian.net/browse/SQCORE-885.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
