### PR TITLE
Federation: support other member updates

### DIFF
--- a/changelog.d/6-federation/fed-conv-member-update
+++ b/changelog.d/6-federation/fed-conv-member-update
@@ -1,0 +1,1 @@
+Notify remote users when a conversation member role is updated

--- a/changelog.d/6-federation/fed-update-remote-members
+++ b/changelog.d/6-federation/fed-update-remote-members
@@ -1,0 +1,1 @@
+Implement updates to remote members

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -27,6 +27,7 @@ module Data.Qualified
     toLocal,
     lUnqualified,
     lDomain,
+    foldQualified,
     renderQualifiedId,
     partitionRemoteOrLocalIds,
     partitionRemoteOrLocalIds',
@@ -82,6 +83,13 @@ lUnqualified = qUnqualified . unTagged
 
 lDomain :: Local a -> Domain
 lDomain = qDomain . unTagged
+
+foldQualified :: Local x -> (Local a -> b) -> (Remote a -> b) -> Qualified a -> b
+foldQualified loc f g q
+  | lDomain loc == qDomain q =
+    f (toLocal q)
+  | otherwise =
+    g (toRemote q)
 
 -- | FUTUREWORK: Maybe delete this, it is only used in printing federation not
 -- implemented errors

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -33,10 +33,10 @@ import Wire.API.Conversation
   ( Access,
     AccessRole,
     ConvType,
-    ConversationAction (..),
     ConversationMetadata,
     ReceiptMode,
   )
+import Wire.API.Conversation.Action
 import Wire.API.Conversation.Member (OtherMember)
 import Wire.API.Conversation.Role (RoleName)
 import Wire.API.Federation.Client (FederationClientFailure, FederatorClient)

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationUpdate.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationUpdate.hs
@@ -27,7 +27,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.Qualified (Qualified (Qualified))
 import qualified Data.UUID as UUID
 import Imports
-import Wire.API.Conversation (ConversationAction (..))
+import Wire.API.Conversation.Action
 import Wire.API.Conversation.Role (roleNameWireAdmin, roleNameWireMember)
 import Wire.API.Federation.API.Galley (ConversationUpdate (..))
 

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -68,7 +68,6 @@ module Wire.API.Conversation
     ConversationAccessUpdate (..),
     ConversationReceiptModeUpdate (..),
     ConversationMessageTimerUpdate (..),
-    ConversationAction (..),
 
     -- * re-exports
     module Wire.API.Conversation.Member,
@@ -113,7 +112,6 @@ import Wire.API.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
 import Wire.API.Conversation.Member
 import Wire.API.Conversation.Role (RoleName, roleNameWireAdmin)
 import Wire.API.Routes.MultiTablePaging
-import Wire.API.Util.Aeson (CustomEncoded (..))
 
 --------------------------------------------------------------------------------
 -- Conversation
@@ -864,17 +862,3 @@ modelConversationMessageTimerUpdate = Doc.defineModel "ConversationMessageTimerU
   Doc.description "Contains conversation properties to update"
   Doc.property "message_timer" Doc.int64' $
     Doc.description "Conversation message timer (in milliseconds); can be null"
-
---------------------------------------------------------------------------------
--- actions
-
--- | An update to a conversation, including addition and removal of members.
--- Used to send notifications to users and to remote backends.
-data ConversationAction
-  = ConversationActionAddMembers (NonEmpty (Qualified UserId, RoleName))
-  | ConversationActionRemoveMembers (NonEmpty (Qualified UserId))
-  | ConversationActionRename ConversationRename
-  | ConversationActionMessageTimerUpdate ConversationMessageTimerUpdate
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ConversationAction)
-  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationAction)

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -1,0 +1,65 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Conversation.Action
+  ( ConversationAction (..),
+    conversationActionToEvent,
+  )
+where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Id
+import Data.List.NonEmpty (NonEmpty)
+import Data.Qualified
+import Data.Time.Clock
+import Imports
+import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
+import Wire.API.Conversation
+import Wire.API.Conversation.Role
+import Wire.API.Event.Conversation
+import Wire.API.Util.Aeson (CustomEncoded (..))
+
+-- | An update to a conversation, including addition and removal of members.
+-- Used to send notifications to users and to remote backends.
+data ConversationAction
+  = ConversationActionAddMembers (NonEmpty (Qualified UserId, RoleName))
+  | ConversationActionRemoveMembers (NonEmpty (Qualified UserId))
+  | ConversationActionRename ConversationRename
+  | ConversationActionMessageTimerUpdate ConversationMessageTimerUpdate
+  | ConversationActionMemberUpdate MemberUpdateData
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform ConversationAction)
+  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationAction)
+
+conversationActionToEvent ::
+  UTCTime ->
+  Qualified UserId ->
+  Qualified ConvId ->
+  ConversationAction ->
+  Event
+conversationActionToEvent now quid qcnv (ConversationActionAddMembers newMembers) =
+  Event MemberJoin qcnv quid now $
+    EdMembersJoin $ SimpleMembers (map (uncurry SimpleMember) . toList $ newMembers)
+conversationActionToEvent now quid qcnv (ConversationActionRemoveMembers removedMembers) =
+  Event MemberLeave qcnv quid now $
+    EdMembersLeave . QualifiedUserIdList . toList $ removedMembers
+conversationActionToEvent now quid qcnv (ConversationActionRename rename) =
+  Event ConvRename qcnv quid now (EdConvRename rename)
+conversationActionToEvent now quid qcnv (ConversationActionMessageTimerUpdate update) =
+  Event ConvMessageTimerUpdate qcnv quid now (EdConvMessageTimerUpdate update)
+conversationActionToEvent now quid qcnv (ConversationActionMemberUpdate update) =
+  Event MemberStateUpdate qcnv quid now (EdMemberUpdate update)

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -394,12 +394,8 @@ modelConnect = Doc.defineModel "Connect" $ do
 -- Used for events (sent over the websocket, etc.).  See also
 -- 'MemberUpdate' and 'OtherMemberUpdate'.
 data MemberUpdateData = MemberUpdateData
-  { -- | Target user of this action, should not be optional anymore.
-    --
-    -- FUTUREWORK: make it mandatory to guarantee that no events
-    -- out there do not contain an ID.
-    -- <https://github.com/zinfra/backend-issues/issues/1309>
-    misTarget :: Maybe UserId,
+  { -- | Target user of this action
+    misTarget :: Qualified UserId,
     misOtrMutedStatus :: Maybe MutedStatus,
     misOtrMutedRef :: Maybe Text,
     misOtrArchived :: Maybe Bool,
@@ -418,7 +414,8 @@ instance ToSchema MemberUpdateData where
 memberUpdateDataObjectSchema :: ObjectSchema SwaggerDoc MemberUpdateData
 memberUpdateDataObjectSchema =
   MemberUpdateData
-    <$> misTarget .= opt (field "target" schema)
+    <$> misTarget .= field "qualified_target" schema
+    <* (Just . qUnqualified . misTarget) .= optField "target" Nothing schema
     <*> misOtrMutedStatus .= opt (field "otr_muted_status" schema)
     <*> misOtrMutedRef .= opt (field "otr_muted_ref" schema)
     <*> misOtrArchived .= opt (field "otr_archived" schema)

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -47,7 +47,6 @@ module Wire.API.Event.Conversation
     Connect (..),
     MemberUpdateData (..),
     OtrMessage (..),
-    conversationActionToEvent,
 
     -- * re-exports
     ConversationReceiptModeUpdate (..),
@@ -561,20 +560,3 @@ instance ToJSON Event where
 
 instance S.ToSchema Event where
   declareNamedSchema = schemaToSwagger
-
-conversationActionToEvent ::
-  UTCTime ->
-  Qualified UserId ->
-  Qualified ConvId ->
-  ConversationAction ->
-  Event
-conversationActionToEvent now quid qcnv (ConversationActionAddMembers newMembers) =
-  Event MemberJoin qcnv quid now $
-    EdMembersJoin $ SimpleMembers (map (uncurry SimpleMember) . toList $ newMembers)
-conversationActionToEvent now quid qcnv (ConversationActionRemoveMembers removedMembers) =
-  Event MemberLeave qcnv quid now $
-    EdMembersLeave . QualifiedUserIdList . toList $ removedMembers
-conversationActionToEvent now quid qcnv (ConversationActionRename rename) =
-  Event ConvRename qcnv quid now (EdConvRename rename)
-conversationActionToEvent now quid qcnv (ConversationActionMessageTimerUpdate update) =
-  Event ConvMessageTimerUpdate qcnv quid now (EdConvMessageTimerUpdate update)

--- a/libs/wire-api/test/golden/fromJSON/testObject_MemberUpdateData_user_1.json
+++ b/libs/wire-api/test/golden/fromJSON/testObject_MemberUpdateData_user_1.json
@@ -1,0 +1,12 @@
+{
+    "hidden": true,
+    "hidden_ref": "1",
+    "otr_archived": false,
+    "otr_archived_ref": "a",
+    "otr_muted_ref": "#M𗗐",
+    "otr_muted_status": -1,
+    "qualified_target": {
+        "domain": "target.example.com",
+        "id": "00000000-0000-0002-0000-000100000001"
+    }
+}

--- a/libs/wire-api/test/golden/testObject_Event_user_5.json
+++ b/libs/wire-api/test/golden/testObject_Event_user_5.json
@@ -5,7 +5,12 @@
         "hidden_ref": "\u0008\t\u0018",
         "otr_archived": false,
         "otr_archived_ref": "\u0001J",
-        "otr_muted_ref": "𗋭"
+        "otr_muted_ref": "𗋭",
+        "qualified_target": {
+            "domain": "target.example.com",
+            "id": "afb0e5b1-c554-4ce4-98f5-3e1671f22485"
+        },
+        "target": "afb0e5b1-c554-4ce4-98f5-3e1671f22485"
     },
     "from": "00002a12-0000-73e1-0000-71f700002ec9",
     "qualified_conversation": {

--- a/libs/wire-api/test/golden/testObject_MemberUpdateData_user_1.json
+++ b/libs/wire-api/test/golden/testObject_MemberUpdateData_user_1.json
@@ -1,10 +1,13 @@
 {
-    "conversation_role": "3fwjaofhryb7nd1hp3nwukjiyxxhgimw8ddzx5s_8ek5nnctkzkic6w51hqugeh6l50hg87dez8pw974dbuywd83njuytv0euf9619s",
     "hidden": true,
     "hidden_ref": "1",
     "otr_archived": false,
     "otr_archived_ref": "a",
     "otr_muted_ref": "#M𗗐",
     "otr_muted_status": -1,
+    "qualified_target": {
+        "domain": "target.example.com",
+        "id": "00000000-0000-0002-0000-000100000001"
+    },
     "target": "00000000-0000-0002-0000-000100000001"
 }

--- a/libs/wire-api/test/golden/testObject_MemberUpdateData_user_2.json
+++ b/libs/wire-api/test/golden/testObject_MemberUpdateData_user_2.json
@@ -1,1 +1,8 @@
-{}
+{
+    "conversation_role": "3fwjaofhryb7nd1hp3nwukjiyxxhgimw8ddzx5s_8ek5nnctkzkic6w51hqugeh6l50hg87dez8pw974dbuywd83njuytv0euf9619s",
+    "qualified_target": {
+        "domain": "target.example.com",
+        "id": "00000000-0000-0002-0000-000100000001"
+    },
+    "target": "00000000-0000-0002-0000-000100000001"
+}

--- a/libs/wire-api/test/unit/Test/Wire/API/Golden/FromJSON.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Golden/FromJSON.hs
@@ -21,6 +21,7 @@ import Imports
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Wire.API.Golden.Generated.Invite_user (testObject_Invite_user_2)
+import Test.Wire.API.Golden.Generated.MemberUpdateData_user
 import Test.Wire.API.Golden.Generated.NewConvUnmanaged_user
 import Test.Wire.API.Golden.Generated.NewOtrMessage_user
 import Test.Wire.API.Golden.Generated.RmClient_user
@@ -78,6 +79,10 @@ tests =
               \'hidden', 'hidden_ref', 'conversation_role'} required."
           )
           "testObject_MemberUpdate_user_3.json",
+      testCase "MemberUpdateData" $
+        testFromJSONObject
+          testObject_MemberUpdateData_user_1
+          "testObject_MemberUpdateData_user_1.json",
       testCase "OtherMemberUpdate" $
         testFromJSONFailure @OtherMemberUpdate "testObject_OtherMemberUpdate_user_2.json",
       testGroup "NewUser: failure" $

--- a/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/Event_user.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/Event_user.hs
@@ -96,7 +96,10 @@ testObject_Event_user_5 =
     (read "1864-04-12 03:04:00.298 UTC")
     ( EdMemberUpdate
         ( MemberUpdateData
-            { misTarget = Nothing,
+            { misTarget =
+                Qualified
+                  (Id (fromJust (UUID.fromString "afb0e5b1-c554-4ce4-98f5-3e1671f22485")))
+                  (Domain "target.example.com"),
               misOtrMutedStatus = Nothing,
               misOtrMutedRef = Just "\94957",
               misOtrArchived = Just False,

--- a/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/MemberUpdateData_user.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/MemberUpdateData_user.hs
@@ -16,7 +16,9 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 module Test.Wire.API.Golden.Generated.MemberUpdateData_user where
 
+import Data.Domain
 import Data.Id (Id (Id))
+import Data.Qualified
 import qualified Data.UUID as UUID (fromString)
 import Imports (Bool (False, True), Maybe (Just, Nothing), fromJust)
 import Wire.API.Conversation (MutedStatus (MutedStatus, fromMutedStatus))
@@ -26,13 +28,32 @@ import Wire.API.Event.Conversation (MemberUpdateData (..))
 testObject_MemberUpdateData_user_1 :: MemberUpdateData
 testObject_MemberUpdateData_user_1 =
   MemberUpdateData
-    { misTarget = Just (Id (fromJust (UUID.fromString "00000000-0000-0002-0000-000100000001"))),
+    { misTarget =
+        Qualified
+          (Id (fromJust (UUID.fromString "00000000-0000-0002-0000-000100000001")))
+          (Domain "target.example.com"),
       misOtrMutedStatus = Just (MutedStatus {fromMutedStatus = -1}),
       misOtrMutedRef = Just "#M\95696",
       misOtrArchived = Just False,
       misOtrArchivedRef = Just "a",
       misHidden = Just True,
       misHiddenRef = Just "1",
+      misConvRoleName = Nothing
+    }
+
+testObject_MemberUpdateData_user_2 :: MemberUpdateData
+testObject_MemberUpdateData_user_2 =
+  MemberUpdateData
+    { misTarget =
+        Qualified
+          (Id (fromJust (UUID.fromString "00000000-0000-0002-0000-000100000001")))
+          (Domain "target.example.com"),
+      misOtrMutedStatus = Nothing,
+      misOtrMutedRef = Nothing,
+      misOtrArchived = Nothing,
+      misOtrArchivedRef = Nothing,
+      misHidden = Nothing,
+      misHiddenRef = Nothing,
       misConvRoleName =
         Just
           ( fromJust
@@ -40,17 +61,4 @@ testObject_MemberUpdateData_user_1 =
                   "3fwjaofhryb7nd1hp3nwukjiyxxhgimw8ddzx5s_8ek5nnctkzkic6w51hqugeh6l50hg87dez8pw974dbuywd83njuytv0euf9619s"
               )
           )
-    }
-
-testObject_MemberUpdateData_user_2 :: MemberUpdateData
-testObject_MemberUpdateData_user_2 =
-  MemberUpdateData
-    { misTarget = Nothing,
-      misOtrMutedStatus = Nothing,
-      misOtrMutedRef = Nothing,
-      misOtrArchived = Nothing,
-      misOtrArchivedRef = Nothing,
-      misHidden = Nothing,
-      misHiddenRef = Nothing,
-      misConvRoleName = Nothing
     }

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1b29447efcb495e0d025de9fc8e5c6c887ef9ef16d3b075cecd9deb42ad32fc6
+-- hash: 1dce25e4dabf58eac09c8e4f384829306931a35d0c9b902d22d4f29b7a592aae
 
 name:           wire-api
 version:        0.1.0
@@ -26,6 +26,7 @@ library
       Wire.API.Call.Config
       Wire.API.Connection
       Wire.API.Conversation
+      Wire.API.Conversation.Action
       Wire.API.Conversation.Bot
       Wire.API.Conversation.Code
       Wire.API.Conversation.Member

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -614,7 +614,7 @@ updateLocalSelfMember zusr zcon (Tagged qcid) update = do
   m <- getSelfMemberFromLocalsLegacy zusr (Data.convLocalMembers conv)
   luid <- qualifyLocal zusr
   let targets = NotificationTargets [lmId m] [] []
-  processUpdateMemberEvent luid zcon qcid targets zusr update
+  processUpdateMemberEvent luid zcon qcid targets luid update
 
 updateRemoteSelfMember ::
   UserId ->
@@ -629,7 +629,7 @@ updateRemoteSelfMember zusr zcon rcid update = do
     Just _ -> do
       luid <- qualifyLocal zusr
       let targets = NotificationTargets [zusr] [] []
-      processUpdateMemberEvent luid zcon (unTagged rcid) targets zusr update
+      processUpdateMemberEvent luid zcon (unTagged rcid) targets luid update
 
 updateOtherMember ::
   UserId ->

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -112,11 +112,9 @@ import Network.Wai
 import Network.Wai.Predicate hiding (and, failure, setStatus, _1, _2)
 import Network.Wai.Utilities
 import UnliftIO (pooledForConcurrentlyN)
-import Wire.API.Conversation
-  ( ConversationAction (..),
-    InviteQualified (invQRoleName),
-  )
+import Wire.API.Conversation (InviteQualified (invQRoleName))
 import qualified Wire.API.Conversation as Public
+import Wire.API.Conversation.Action (ConversationAction (..), conversationActionToEvent)
 import qualified Wire.API.Conversation.Code as Public
 import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.ErrorDescription
@@ -614,7 +612,9 @@ updateLocalSelfMember zusr zcon (Tagged qcid) update = do
   -- only one is really needed (local members).
   conv <- getConversationAndCheckMembership zusr (qUnqualified qcid)
   m <- getSelfMemberFromLocalsLegacy zusr (Data.convLocalMembers conv)
-  void $ processUpdateMemberEvent zusr zcon qcid [lmId m] (lmId m) update
+  luid <- qualifyLocal zusr
+  let targets = NotificationTargets [lmId m] [] []
+  processUpdateMemberEvent luid zcon qcid targets zusr update
 
 updateRemoteSelfMember ::
   UserId ->
@@ -626,8 +626,10 @@ updateRemoteSelfMember zusr zcon rcid update = do
   statusMap <- Data.remoteConversationStatus zusr [rcid]
   case Map.lookup rcid statusMap of
     Nothing -> throwErrorDescriptionType @ConvMemberNotFound
-    Just _ ->
-      void $ processUpdateMemberEvent zusr zcon (unTagged rcid) [zusr] zusr update
+    Just _ -> do
+      luid <- qualifyLocal zusr
+      let targets = NotificationTargets [zusr] [] []
+      processUpdateMemberEvent luid zcon (unTagged rcid) targets zusr update
 
 updateOtherMember ::
   UserId ->
@@ -649,17 +651,30 @@ updateOtherMemberUnqualified ::
   UserId ->
   Public.OtherMemberUpdate ->
   Galley ()
-updateOtherMemberUnqualified zusr zcon cid victim update = do
-  localDomain <- viewFederationDomain
-  when (zusr == victim) $
+updateOtherMemberUnqualified zusr zcon cnv victim update = do
+  lusr <- qualifyLocal zusr
+  lcnv <- qualifyLocal cnv
+  lvictim <- qualifyLocal victim
+  updateOtherMemberLocalConv lusr zcon lcnv (unTagged lvictim) update
+
+updateOtherMemberLocalConv ::
+  Local UserId ->
+  ConnId ->
+  Local ConvId ->
+  Qualified UserId ->
+  Public.OtherMemberUpdate ->
+  Galley ()
+updateOtherMemberLocalConv luid zcon lcid qvictim update = do
+  when (unTagged luid == qvictim) $
     throwM invalidTargetUserOp
-  conv <- getConversationAndCheckMembership zusr cid
-  let (bots, users) = localBotsAndUsers (Data.convLocalMembers conv)
-  ensureActionAllowedThrowing ModifyOtherConversationMember =<< getSelfMemberFromLocalsLegacy zusr users
-  -- this has the side effect of checking that the victim is indeed part of the conversation
-  memTarget <- getOtherMemberLegacy victim users
-  e <- processUpdateMemberEvent zusr zcon (Qualified cid localDomain) (map lmId users) (lmId memTarget) update
-  void . forkIO $ void $ External.deliver (bots `zip` repeat e)
+  (conv, self) <-
+    getConversationAndMemberWithError
+      (errorDescriptionTypeToWai @ConvNotFound)
+      (lUnqualified luid)
+      (lUnqualified lcid)
+  ensureActionAllowedThrowing ModifyOtherConversationMember self
+  void $ ensureOtherMember luid qvictim (Data.convLocalMembers conv) (Data.convRemoteMembers conv)
+  processUpdateMemberEvent luid zcon (unTagged lcid) (convTargets conv) qvictim update
 
 -- | A general conversation member removal function used both by the unqualified
 -- and the qualified endpoint for member removal. This is also used to leave a
@@ -1005,7 +1020,7 @@ notifyConversationMetadataUpdate ::
 notifyConversationMetadataUpdate quid con (Tagged qcnv) targets action = do
   localDomain <- viewFederationDomain
   now <- liftIO getCurrentTime
-  let e = Public.conversationActionToEvent now quid qcnv action
+  let e = conversationActionToEvent now quid qcnv action
 
   -- notify remote participants
   let rusersByDomain = partitionRemote (ntRemotes targets)
@@ -1195,38 +1210,40 @@ ensureConvMember users usr =
 
 -- | Update a member of a conversation and propagate events.
 --
--- Note: the target is assumed to be a member of the conversation.
+-- Note: the victim is assumed to be a member of the conversation.
 processUpdateMemberEvent ::
-  Data.IsMemberUpdate mu =>
+  ( IsNotificationTarget uid,
+    Data.IsMemberUpdate mu uid
+  ) =>
   -- | Originating user
-  UserId ->
+  Local UserId ->
   -- | Connection ID for the originating user
   ConnId ->
   -- | Conversation whose members are being updated
   Qualified ConvId ->
   -- | Recipients of the notification
-  [UserId] ->
+  NotificationTargets ->
   -- | User being updated
-  UserId ->
+  uid ->
   -- | Update structure
   mu ->
-  Galley Event
-processUpdateMemberEvent zusr zcon qcid users target update = do
-  localDomain <- viewFederationDomain
-  let qusr = Qualified zusr localDomain
+  Galley ()
+processUpdateMemberEvent lusr zcon qcid targets victim update = do
   up <-
-    if localDomain == qDomain qcid
-      then Data.updateMember (qUnqualified qcid) target update
-      else Data.updateMemberRemoteConv (toRemote qcid) target update
-  now <- liftIO getCurrentTime
-  let e = Event MemberStateUpdate qcid qusr now (EdMemberUpdate up)
-  let recipients = fmap userRecipient (target : filter (/= target) users)
-  for_ (newPushLocal ListComplete zusr (ConvEvent e) recipients) $ \p ->
-    push1 $
-      p
-        & pushConn ?~ zcon
-        & pushRoute .~ RouteDirect
-  return e
+    foldQualified
+      lusr
+      Data.updateMember
+      Data.updateMemberRemoteConv
+      qcid
+      victim
+      update
+  void $
+    notifyConversationMetadataUpdate
+      (unTagged lusr)
+      zcon
+      (toLocal qcid)
+      (ntAdd lusr victim targets)
+      (ConversationActionMemberUpdate up)
 
 -------------------------------------------------------------------------------
 -- OtrRecipients Validation

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -639,10 +639,12 @@ updateOtherMember ::
   Public.OtherMemberUpdate ->
   Galley ()
 updateOtherMember zusr zcon qcid qvictim update = do
-  localDomain <- viewFederationDomain
-  if qDomain qcid == localDomain && qDomain qvictim == localDomain
-    then updateOtherMemberUnqualified zusr zcon (qUnqualified qcid) (qUnqualified qvictim) update
-    else throwM federationNotImplemented
+  lusr <- qualifyLocal zusr
+  foldQualified
+    lusr
+    (\lcid -> updateOtherMemberLocalConv lusr zcon lcid qvictim update)
+    (\_ -> throwM federationNotImplemented)
+    qcid
 
 updateOtherMemberUnqualified ::
   UserId ->

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -36,7 +36,7 @@ import qualified Data.Map as Map
 import Data.Misc (PlainTextPassword (..))
 import Data.Qualified
 import qualified Data.Set as Set
-import Data.Tagged (Tagged (unTagged))
+import Data.Tagged
 import qualified Data.Text.Lazy as LT
 import Data.Time
 import Galley.API.Error
@@ -255,11 +255,9 @@ data NotificationTargets = NotificationTargets
     ntBots :: [BotMember]
   }
 
-instance IsNotificationTarget UserId where
-  ntAdd _ uid nt = nt {ntLocals = uid : filter (/= uid) (ntLocals nt)}
-
 instance IsNotificationTarget (Local UserId) where
-  ntAdd loc luid = ntAdd loc (lUnqualified luid)
+  ntAdd _ (Tagged (Qualified uid _)) nt =
+    nt {ntLocals = uid : filter (/= uid) (ntLocals nt)}
 
 instance IsNotificationTarget (Remote UserId) where
   ntAdd _ ruid nt = nt {ntRemotes = ruid : filter (/= ruid) (ntRemotes nt)}

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -246,6 +246,10 @@ isMember u = isJust . find ((u ==) . lmId)
 isRemoteMember :: Foldable m => Remote UserId -> m RemoteMember -> Bool
 isRemoteMember u = isJust . find ((u ==) . rmId)
 
+-- | This is an ad-hoc class to update notification targets based on the type
+-- of the user id. Local user IDs get added to the local targets, remote user IDs
+-- to remote targets, and qualified user IDs get added to the appropriate list
+-- according to whether they are local or remote, by making a runtime check.
 class IsNotificationTarget uid where
   ntAdd :: Local x -> uid -> NotificationTargets -> NotificationTargets
 

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -490,7 +490,7 @@ checkRemotesFor domain uids = do
         map
           (qUnqualified . User.profileQualifiedId)
           (filter (not . User.profileDeleted) users)
-  unless (Set.fromList uids == Set.fromList uids') $
+  unless (Set.fromList uids == Set.fromList uids') $ do
     throwM unknownRemoteUser
 
 type FederatedGalleyRPC c a = FederatorClient c (ExceptT FederationClientFailure Galley) a

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -490,7 +490,7 @@ checkRemotesFor domain uids = do
         map
           (qUnqualified . User.profileQualifiedId)
           (filter (not . User.profileDeleted) users)
-  unless (Set.fromList uids == Set.fromList uids') $ do
+  unless (Set.fromList uids == Set.fromList uids') $
     throwM unknownRemoteUser
 
 type FederatedGalleyRPC c a = FederatorClient c (ExceptT FederationClientFailure Galley) a

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -295,6 +295,9 @@ removeRemoteMember = "delete from member_remote_user where conv = ? and user_rem
 selectRemoteMembers :: PrepQuery R (Identity [ConvId]) (ConvId, Domain, UserId, RoleName)
 selectRemoteMembers = "select conv, user_remote_domain, user_remote_id, conversation_role from member_remote_user where conv in ?"
 
+updateRemoteMemberConvRoleName :: PrepQuery W (RoleName, ConvId, Domain, UserId) ()
+updateRemoteMemberConvRoleName = "update member_remote_user set conversation_role = ? where conv = ? and user_remote_domain = ? and user_remote_id = ?"
+
 -- local user with remote conversations
 
 insertUserRemoteConv :: PrepQuery W (UserId, Domain, ConvId) ()

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -80,6 +80,7 @@ import TestHelpers
 import TestSetup
 import Util.Options (Endpoint (Endpoint))
 import Wire.API.Conversation
+import Wire.API.Conversation.Action
 import qualified Wire.API.Federation.API.Brig as FederatedBrig
 import Wire.API.Federation.API.Galley
   ( GetConversationsResponse (..),

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2604,7 +2604,7 @@ putQualifiedOtherMemberOk = do
   let qconv = Qualified conv (qDomain qbob)
       expectedMemberUpdateData =
         MemberUpdateData
-          { misTarget = Just alice,
+          { misTarget = qalice,
             misOtrMutedStatus = Nothing,
             misOtrMutedRef = Nothing,
             misOtrArchived = Nothing,
@@ -2629,15 +2629,16 @@ putQualifiedOtherMemberOk = do
 putOtherMemberOk :: TestM ()
 putOtherMemberOk = do
   c <- view tsCannon
-  alice <- randomUser
+  qalice <- randomQualifiedUser
   qbob <- randomQualifiedUser
-  let bob = qUnqualified qbob
+  let alice = qUnqualified qalice
+      bob = qUnqualified qbob
   connectUsers alice (singleton bob)
   conv <- decodeConvId <$> postConv alice [bob] (Just "gossip") [] Nothing Nothing
   let qconv = Qualified conv (qDomain qbob)
       expectedMemberUpdateData =
         MemberUpdateData
-          { misTarget = Just alice,
+          { misTarget = qalice,
             misOtrMutedStatus = Nothing,
             misOtrMutedRef = Nothing,
             misOtrArchived = Nothing,

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -48,7 +48,7 @@ import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
 import TestHelpers
 import TestSetup
-import Wire.API.Conversation (ConversationAction (..))
+import Wire.API.Conversation.Action (ConversationAction (..))
 import Wire.API.Conversation.Member (Member (..))
 import Wire.API.Conversation.Role
 import Wire.API.Federation.API.Galley (GetConversationsRequest (..), GetConversationsResponse (..), RemoteConvMembers (..), RemoteConversation (..))

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -349,7 +349,7 @@ notifyMemberUpdate = do
   qdee <- randomQualifiedUser
   let d =
         MemberUpdateData
-          { misTarget = Just (qUnqualified qdee),
+          { misTarget = qdee,
             misOtrMutedStatus = Nothing,
             misOtrMutedRef = Nothing,
             misOtrArchived = Nothing,

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -27,7 +27,7 @@ import qualified Data.Aeson as A
 import Data.ByteString.Conversion (toByteString')
 import qualified Data.ByteString.Lazy as LBS
 import Data.Domain
-import Data.Id (ConvId, Id (..), newClientId, randomId)
+import Data.Id (ConvId, Id (..), UserId, newClientId, randomId)
 import Data.Json.Util (Base64ByteString (..), toBase64Text)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List1
@@ -70,6 +70,7 @@ tests s =
       test s "POST /federation/on-conversation-updated : Remove a remote user from a remote conversation" removeRemoteUser,
       test s "POST /federation/on-conversation-updated : Notify local user about conversation rename" notifyConvRename,
       test s "POST /federation/on-conversation-updated : Notify local user about message timer update" notifyMessageTimer,
+      test s "POST /federation/on-conversation-updated : Notify local user about member update" notifyMemberUpdate,
       test s "POST /federation/leave-conversation : Success" leaveConversationSuccess,
       test s "POST /federation/on-message-sent : Receive a message from another backend" onMessageSent,
       test s "POST /federation/send-message : Post a message sent from another backend" sendMessage
@@ -288,8 +289,8 @@ removeRemoteUser = do
     liftIO $ do
       afterRemoval @?= [qconv]
 
-notifyConvRename :: TestM ()
-notifyConvRename = do
+notifyUpdate :: [Qualified UserId] -> ConversationAction -> EventType -> EventData -> TestM ()
+notifyUpdate extras action etype edata = do
   c <- view tsCannon
   qalice <- randomQualifiedUser
   let alice = qUnqualified qalice
@@ -299,10 +300,14 @@ notifyConvRename = do
   let bdom = Domain "bob.example.com"
       qbob = Qualified bob bdom
       qconv = Qualified conv bdom
-      aliceAsOtherMember = OtherMember qalice Nothing roleNameWireMember
+      mkMember quid = OtherMember quid Nothing roleNameWireMember
   fedGalleyClient <- view tsFedGalleyClient
 
-  registerRemoteConv qconv qbob (Just "gossip") (Set.singleton aliceAsOtherMember)
+  registerRemoteConv
+    qconv
+    qbob
+    (Just "gossip")
+    (Set.fromList (map mkMember (qalice : extras)))
 
   now <- liftIO getCurrentTime
   let cu =
@@ -311,8 +316,7 @@ notifyConvRename = do
             FedGalley.cuOrigUserId = qbob,
             FedGalley.cuConvId = conv,
             FedGalley.cuAlreadyPresentUsers = [alice, charlie],
-            FedGalley.cuAction =
-              ConversationActionRename (ConversationRename "gossip++")
+            FedGalley.cuAction = action
           }
   WS.bracketR2 c alice charlie $ \(wsA, wsC) -> do
     FedGalley.onConversationUpdated fedGalleyClient bdom cu
@@ -321,48 +325,44 @@ notifyConvRename = do
         let e = List1.head (WS.unpackPayload n)
         ntfTransient n @?= False
         evtConv e @?= qconv
-        evtType e @?= ConvRename
+        evtType e @?= etype
         evtFrom e @?= qbob
-        evtData e @?= EdConvRename (ConversationRename "gossip++")
+        evtData e @?= edata
       WS.assertNoEvent (1 # Second) [wsC]
+
+notifyConvRename :: TestM ()
+notifyConvRename = do
+  let d = ConversationRename "gossip++"
+  notifyUpdate [] (ConversationActionRename d) ConvRename (EdConvRename d)
 
 notifyMessageTimer :: TestM ()
 notifyMessageTimer = do
-  c <- view tsCannon
-  qalice <- randomQualifiedUser
-  let alice = qUnqualified qalice
-  bob <- randomId
-  charlie <- randomUser
-  conv <- randomId
-  let bdom = Domain "bob.example.com"
-      qbob = Qualified bob bdom
-      qconv = Qualified conv bdom
-      aliceAsOtherMember = OtherMember qalice Nothing roleNameWireMember
-  fedGalleyClient <- view tsFedGalleyClient
+  let d = ConversationMessageTimerUpdate (Just 5000)
+  notifyUpdate
+    []
+    (ConversationActionMessageTimerUpdate d)
+    ConvMessageTimerUpdate
+    (EdConvMessageTimerUpdate d)
 
-  registerRemoteConv qconv qbob (Just "gossip") (Set.singleton aliceAsOtherMember)
-
-  now <- liftIO getCurrentTime
-  let cu =
-        FedGalley.ConversationUpdate
-          { FedGalley.cuTime = now,
-            FedGalley.cuOrigUserId = qbob,
-            FedGalley.cuConvId = conv,
-            FedGalley.cuAlreadyPresentUsers = [alice, charlie],
-            FedGalley.cuAction =
-              ConversationActionMessageTimerUpdate (ConversationMessageTimerUpdate (Just 5000))
+notifyMemberUpdate :: TestM ()
+notifyMemberUpdate = do
+  qdee <- randomQualifiedUser
+  let d =
+        MemberUpdateData
+          { misTarget = Just (qUnqualified qdee),
+            misOtrMutedStatus = Nothing,
+            misOtrMutedRef = Nothing,
+            misOtrArchived = Nothing,
+            misOtrArchivedRef = Nothing,
+            misHidden = Nothing,
+            misHiddenRef = Nothing,
+            misConvRoleName = Just roleNameWireAdmin
           }
-  WS.bracketR2 c alice charlie $ \(wsA, wsC) -> do
-    FedGalley.onConversationUpdated fedGalleyClient bdom cu
-    liftIO $ do
-      WS.assertMatch_ (5 # Second) wsA $ \n -> do
-        let e = List1.head (WS.unpackPayload n)
-        ntfTransient n @?= False
-        evtConv e @?= qconv
-        evtType e @?= ConvMessageTimerUpdate
-        evtFrom e @?= qbob
-        evtData e @?= EdConvMessageTimerUpdate (ConversationMessageTimerUpdate (Just 5000))
-      WS.assertNoEvent (1 # Second) [wsC]
+  notifyUpdate
+    [qdee]
+    (ConversationActionMemberUpdate d)
+    MemberStateUpdate
+    (EdMemberUpdate d)
 
 -- TODO: test adding non-existing users
 -- TODO: test adding resulting in an empty notification

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -45,7 +45,7 @@ import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
 import TestHelpers
 import TestSetup
-import Wire.API.Conversation
+import Wire.API.Conversation.Action
 import qualified Wire.API.Federation.API.Galley as F
 import qualified Wire.API.Federation.GRPC.Types as F
 import qualified Wire.API.Team.Member as Member

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -67,7 +67,6 @@ import qualified Data.Text.Encoding as Text
 import Data.Time (getCurrentTime)
 import qualified Data.UUID as UUID
 import Data.UUID.V4
-import Debug.Trace as Debug
 import Galley.Intra.User (chunkify)
 import qualified Galley.Options as Opts
 import qualified Galley.Run as Run
@@ -576,7 +575,7 @@ postConvWithRemoteUsers remoteDomain users creatorUnqualified members = do
     respond :: F.FederatedRequest -> Value
     respond req
       | fmap F.component (F.request req) == Just F.Brig =
-        Debug.trace (show req) (toJSON users)
+        toJSON users
       | otherwise = toJSON ()
 
 postTeamConv :: TeamId -> UserId -> [UserId] -> Maybe Text -> [Access] -> Maybe AccessRole -> Maybe Milliseconds -> TestM ResponseLBS

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1378,7 +1378,7 @@ wsAssertMemberUpdateWithRole conv usr target role n = do
   evtFrom e @?= usr
   case evtData e of
     Conv.EdMemberUpdate mis -> do
-      assertEqual "target" (Just target) (misTarget mis)
+      assertEqual "target" (Qualified target (qDomain conv)) (misTarget mis)
       assertEqual "conversation_role" (Just role) (misConvRoleName mis)
     x -> assertFailure $ "Unexpected event data: " ++ show x
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -107,6 +107,7 @@ import Util.Options
 import Web.Cookie
 import Wire.API.Conversation
 import qualified Wire.API.Conversation as Public
+import Wire.API.Conversation.Action
 import Wire.API.Event.Conversation (_EdMembersJoin, _EdMembersLeave)
 import qualified Wire.API.Event.Team as TE
 import qualified Wire.API.Federation.API.Brig as FederatedBrig
@@ -1426,7 +1427,7 @@ assertRemoveUpdate req qconvId remover alreadyPresentUsers victim = liftIO $ do
   FederatedGalley.cuOrigUserId cu @?= remover
   FederatedGalley.cuConvId cu @?= qUnqualified qconvId
   sort (FederatedGalley.cuAlreadyPresentUsers cu) @?= sort alreadyPresentUsers
-  FederatedGalley.cuAction cu @?= Public.ConversationActionRemoveMembers (pure victim)
+  FederatedGalley.cuAction cu @?= ConversationActionRemoveMembers (pure victim)
 
 -------------------------------------------------------------------------------
 -- Helpers

--- a/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
+++ b/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
@@ -28,7 +28,7 @@ import qualified Codec.MIME.Type as MIME
 import qualified Data.ByteString.Lazy as LBS
 import Data.Id (ConvId)
 import Data.List1
-import Data.Qualified (qUnqualified)
+import Data.Qualified (Qualified (..), qUnqualified)
 import Data.Range
 import Imports
 import Network.Wire.Bot
@@ -92,10 +92,11 @@ mainBotNet n = do
     assertConvCreated conv ally others
     return conv
   info $ msg "Bill updates his member state"
+  localDomain <- viewFederationDomain
   runBotSession bill $ do
     let update =
           MemberUpdateData
-            { misTarget = Just $ botId bill,
+            { misTarget = Qualified (botId bill) localDomain,
               misOtrMutedStatus = Nothing,
               misOtrMutedRef = Nothing,
               misOtrArchived = Just True,


### PR DESCRIPTION
This generalises the `on-conversation-updated` RPC to support notifications of member updates, by adding a new constructor to the corresponding "action" type.

As part of this PR, updates to remote members have also been implemented, but at the moment only for local conversations.

Note: this includes a merge commit for #1783.

This is part of https://wearezeta.atlassian.net/browse/SQCORE-885 (federated conversation metadata updates).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
