### PR TITLE
Remote connections schema

### DIFF
--- a/changelog.d/6-federation/remote-connections-migration
+++ b/changelog.d/6-federation/remote-connections-migration
@@ -1,0 +1,1 @@
+Add migration for remote connection table

--- a/docs/reference/cassandra-schema.cql
+++ b/docs/reference/cassandra-schema.cql
@@ -1221,6 +1221,31 @@ CREATE TABLE brig_test.budget (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
+CREATE TABLE brig_test.connection_remote (
+    left uuid,
+    right_domain text,
+    right_user uuid,
+    conv_domain text,
+    conv_id uuid,
+    last_update timestamp,
+    status int,
+    PRIMARY KEY (left, right_domain, right_user)
+) WITH CLUSTERING ORDER BY (right_domain ASC, right_user ASC)
+    AND bloom_filter_fp_chance = 0.1
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
+    AND comment = ''
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
+    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1.0
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99PERCENTILE';
+
 CREATE TABLE brig_test.users_pending_activation (
     user uuid PRIMARY KEY,
     expires_at timestamp

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9964cbee009e206492e2a4bb74873592f1963ac4c13deb477b04491ee4471a2a
+-- hash: 40cef77c160c1ffa8500043f465ab4ee307cf751450745d55010ef637b03b152
 
 name:           brig
 version:        1.35.0
@@ -435,6 +435,7 @@ executable brig-schema
       V62_RemoveFederationIdMapping
       V63_AddUsersPendingActivation
       V64_ClientCapabilities
+      V65_FederatedConnections
       V9
       Paths_brig
   hs-source-dirs:

--- a/services/brig/schema/src/Main.hs
+++ b/services/brig/schema/src/Main.hs
@@ -74,6 +74,7 @@ import qualified V61_team_invitation_email
 import qualified V62_RemoveFederationIdMapping
 import qualified V63_AddUsersPendingActivation
 import qualified V64_ClientCapabilities
+import qualified V65_FederatedConnections
 import qualified V9
 
 main :: IO ()
@@ -137,7 +138,8 @@ main = do
       V61_team_invitation_email.migration,
       V62_RemoveFederationIdMapping.migration,
       V63_AddUsersPendingActivation.migration,
-      V64_ClientCapabilities.migration
+      V64_ClientCapabilities.migration,
+      V65_FederatedConnections.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Brig.App
 

--- a/services/brig/schema/src/V65_FederatedConnections.hs
+++ b/services/brig/schema/src/V65_FederatedConnections.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V65_FederatedConnections
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 65 "Add table for federated (remote) connections" $ do
+  schema'
+    [r| CREATE TABLE connection_remote (
+        left uuid,
+        right_domain text,
+        right_user uuid,
+        last_update timestamp,
+        status int,
+        conv_domain text,
+        conv_id uuid,
+        PRIMARY KEY (left, right_domain, right_user)
+    ) WITH CLUSTERING ORDER BY (right_domain ASC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
+      |]

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -134,7 +134,7 @@ import Wire.API.Federation.Client (HasFederatorConfig (..))
 import Wire.API.User.Identity (Email)
 
 schemaVersion :: Int32
-schemaVersion = 64
+schemaVersion = 65
 
 -------------------------------------------------------------------------------
 -- Environment

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -232,6 +232,23 @@ connectionDelete = "DELETE FROM connection WHERE left = ? AND right = ?"
 connectionClear :: PrepQuery W (Identity UserId) ()
 connectionClear = "DELETE FROM connection WHERE left = ?"
 
+-- FUTUREWORK: uncomment these in the next PR
+-- TODO: Add conv id if we agree
+-- remoteConnectionInsert :: PrepQuery W (UserId, Domain, UserId, RelationWithHistory, UTCTimeMillis) ()
+-- remoteConnectionInsert = "INSERT INTO connection_remote (left, right_domain, right_user, status, last_update) VALUES (?, ?, ?, ?, ?)"
+
+-- remoteConnectionSelect :: PrepQuery R (Identity UserId) (Domain, UserId, RelationWithHistory)
+-- remoteConnectionSelect = "SELECT right_domain, right_user, status FROM connection_remote where left = ?"
+
+-- remoteConnectionSelectFrom :: PrepQuery R (UserId, Domain, UserId) (Identity RelationWithHistory)
+-- remoteConnectionSelectFrom = "SELECT status FROM connection_remote where left = ? AND right_domain = ? AND right = ?"
+
+-- remoteConnectionDelete :: PrepQuery W (UserId, Domain, UserId) ()
+-- remoteConnectionDelete = "DELETE FROM connection_remote where left = ? AND right_domain = ? AND right = ?"
+
+-- remoteConnectionClear :: PrepQuery W (Identity UserId) ()
+-- remoteConnectionClear = "DELETE FROM connection_remote where left = ?"
+
 -- Conversions
 
 toLocalUserConnection :: (UserId, UserId, RelationWithHistory, UTCTimeMillis, Maybe ConvId) -> LocalConnection

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -36,6 +36,11 @@ module Brig.Data.Connection
     lookupContactListWithRelation,
     countConnections,
     deleteConnections,
+    remoteConnectionInsert,
+    remoteConnectionSelect,
+    remoteConnectionSelectFrom,
+    remoteConnectionDelete,
+    remoteConnectionClear,
 
     -- * Re-exports
     module T,
@@ -232,22 +237,22 @@ connectionDelete = "DELETE FROM connection WHERE left = ? AND right = ?"
 connectionClear :: PrepQuery W (Identity UserId) ()
 connectionClear = "DELETE FROM connection WHERE left = ?"
 
--- FUTUREWORK: uncomment these in the next PR
--- TODO: Add conv id if we agree
--- remoteConnectionInsert :: PrepQuery W (UserId, Domain, UserId, RelationWithHistory, UTCTimeMillis) ()
--- remoteConnectionInsert = "INSERT INTO connection_remote (left, right_domain, right_user, status, last_update) VALUES (?, ?, ?, ?, ?)"
+-- Remote connections
 
--- remoteConnectionSelect :: PrepQuery R (Identity UserId) (Domain, UserId, RelationWithHistory)
--- remoteConnectionSelect = "SELECT right_domain, right_user, status FROM connection_remote where left = ?"
+remoteConnectionInsert :: PrepQuery W (UserId, Domain, UserId, RelationWithHistory, UTCTimeMillis, Domain, ConvId) ()
+remoteConnectionInsert = "INSERT INTO connection_remote (left, right_domain, right_user, status, last_update, conv_domain, conv_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
 
--- remoteConnectionSelectFrom :: PrepQuery R (UserId, Domain, UserId) (Identity RelationWithHistory)
--- remoteConnectionSelectFrom = "SELECT status FROM connection_remote where left = ? AND right_domain = ? AND right = ?"
+remoteConnectionSelect :: PrepQuery R (Identity UserId) (Domain, UserId, RelationWithHistory, Domain, ConvId)
+remoteConnectionSelect = "SELECT right_domain, right_user, status, conv_domain, conv_id FROM connection_remote where left = ?"
 
--- remoteConnectionDelete :: PrepQuery W (UserId, Domain, UserId) ()
--- remoteConnectionDelete = "DELETE FROM connection_remote where left = ? AND right_domain = ? AND right = ?"
+remoteConnectionSelectFrom :: PrepQuery R (UserId, Domain, UserId) (RelationWithHistory, Domain, ConvId)
+remoteConnectionSelectFrom = "SELECT status, conv_domain, conv_id FROM connection_remote where left = ? AND right_domain = ? AND right = ?"
 
--- remoteConnectionClear :: PrepQuery W (Identity UserId) ()
--- remoteConnectionClear = "DELETE FROM connection_remote where left = ?"
+remoteConnectionDelete :: PrepQuery W (UserId, Domain, UserId) ()
+remoteConnectionDelete = "DELETE FROM connection_remote where left = ? AND right_domain = ? AND right = ?"
+
+remoteConnectionClear :: PrepQuery W (Identity UserId) ()
+remoteConnectionClear = "DELETE FROM connection_remote where left = ?"
 
 -- Conversions
 


### PR DESCRIPTION
Migration to add a table for remote connections.

One question is whether we need the fields for the corresponding 1-1 connection. For now they are there, with the idea that it makes sense to store them in case we want to change the algorithm used to derive the conversation id from the user pair.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
