### PR TITLE
[Federation] When Deleting a User, Remove Them From Remote Conversations

### DIFF
--- a/changelog.d/6-federation/remote-conversations-when-deleting-user
+++ b/changelog.d/6-federation/remote-conversations-when-deleting-user
@@ -1,0 +1,1 @@
+Remove a user from remote conversations upon deleting their account

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -307,9 +307,3 @@ type InvalidOpSelfConv = InvalidOp "invalid operation for self conversation"
 type InvalidOpOne2OneConv = InvalidOp "invalid operation for 1:1 conversations"
 
 type InvalidOpConnectConv = InvalidOp "invalid operation for connect conversation"
-
-type BadPagingState =
-  ErrorDescription
-    500
-    "bad-response"
-    "The paging state cannot be decoded"

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -307,3 +307,9 @@ type InvalidOpSelfConv = InvalidOp "invalid operation for self conversation"
 type InvalidOpOne2OneConv = InvalidOp "invalid operation for 1:1 conversations"
 
 type InvalidOpConnectConv = InvalidOp "invalid operation for connect conversation"
+
+type BadPagingState =
+  ErrorDescription
+    500
+    "bad-response"
+    "The paging state cannot be decoded"

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -104,7 +104,7 @@ getConversations domain (GetConversationsRequest uid cids) = do
   GetConversationsResponse
     . catMaybes
     . map (Mapping.conversationToRemote localDomain ruid)
-    <$> Data.conversations cids
+    <$> Data.localConversations cids
 
 getLocalUsers :: Domain -> NonEmpty (Qualified UserId) -> [UserId]
 getLocalUsers localDomain = map qUnqualified . filter ((== localDomain) . qDomain) . toList

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -473,10 +473,6 @@ rmUser user conn = do
         One2OneConv -> Data.removeMember user (Data.convId c) >> return Nothing
         ConnectConv -> Data.removeMember user (Data.convId c) >> return Nothing
         RegularConv
-          -- TODO(md): see if this membership checking makes any sense here.
-          -- Perhaps we can simply call 'Update.removeMember' and let it handle
-          -- everything. If this change is made, probably the call to
-          -- 'leaveTeams' should happen after leaving the conversations.
           | user `isMember` Data.convLocalMembers c -> do
             e <-
               Data.removeLocalMembersFromLocalConv

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -474,7 +474,6 @@ rmUser user conn = do
         ConnectConv -> Data.removeMember user (Data.convId c) >> return Nothing
         RegularConv
           | user `isMember` Data.convLocalMembers c -> do
-            -- FUTUREWORK: deal with remote members, too, see removeMembers
             e <-
               Data.removeLocalMembersFromLocalConv
                 localDomain

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -32,7 +32,7 @@ import Control.Monad.Catch (MonadCatch)
 import Data.Data (Proxy (Proxy))
 import Data.Id as Id
 import Data.List1 (maybeList1)
-import Data.Qualified (Local, Qualified (..), Remote, lUnqualified, partitionRemoteOrLocalIds', toLocal)
+import Data.Qualified (Local, Qualified (..), Remote, lUnqualified, partitionRemoteOrLocalIds')
 import Data.Range
 import Data.String.Conversions (cs)
 import GHC.TypeLits (AppendSymbol)
@@ -48,7 +48,7 @@ import qualified Galley.API.Teams as Teams
 import Galley.API.Teams.Features (DoAuth (..))
 import qualified Galley.API.Teams.Features as Features
 import qualified Galley.API.Update as Update
-import Galley.API.Util (JSON, isMember, viewFederationDomain)
+import Galley.API.Util (JSON, isMember, qualifyLocal, viewFederationDomain)
 import Galley.App
 import qualified Galley.Data as Data
 import qualified Galley.Intra.Push as Intra
@@ -445,9 +445,9 @@ rmUser user conn = do
       nRange1000 = rcast n :: Range 1 1000 Int32
   tids <- Data.teamIdsForPagination user Nothing n
   leaveTeams tids
-  localDomain <- viewFederationDomain
   allConvIds <- Query.conversationIdsPageFrom user (GetPaginatedConversationIds Nothing nRange1000)
-  goConvPages (toLocal (Qualified user localDomain)) nRange1000 allConvIds
+  lusr <- qualifyLocal user
+  goConvPages lusr nRange1000 allConvIds
   Data.eraseClients user
   where
     goConvPages :: Local UserId -> Range 1 1000 Int32 -> ConvIdsPage -> Galley ()

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -473,6 +473,10 @@ rmUser user conn = do
         One2OneConv -> Data.removeMember user (Data.convId c) >> return Nothing
         ConnectConv -> Data.removeMember user (Data.convId c) >> return Nothing
         RegularConv
+          -- TODO(md): see if this membership checking makes any sense here.
+          -- Perhaps we can simply call 'Update.removeMember' and let it handle
+          -- everything. If this change is made, probably the call to
+          -- 'leaveTeams' should happen after leaving the conversations.
           | user `isMember` Data.convLocalMembers c -> do
             e <-
               Data.removeLocalMembersFromLocalConv

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -266,7 +266,7 @@ getConversationsInternal user mids mstart msize = do
   (more, ids) <- getIds mids
   let localConvIds = ids
   cs <-
-    Data.conversations localConvIds
+    Data.localConversations localConvIds
       >>= filterM removeDeleted
       >>= filterM (pure . isMember user . Data.convLocalMembers)
   pure $ Public.ConversationList cs more
@@ -305,7 +305,7 @@ listConversations user (Public.ListConversations mIds qstart msize) = do
       pure (localMore, localConvIds, remoteConvIds)
 
   localInternalConversations <-
-    Data.conversations localConvIds
+    Data.localConversations localConvIds
       >>= filterM removeDeleted
       >>= filterM (pure . isMember user . Data.convLocalMembers)
   localConversations <- mapM (Mapping.conversationView user) localInternalConversations
@@ -342,7 +342,7 @@ listConversationsV2 user (Public.ListConversationsV2 ids) = do
   (foundLocalIds, notFoundLocalIds) <- foundsAndNotFounds (Data.localConversationIdsOf user) localIds
 
   localInternalConversations <-
-    Data.conversations foundLocalIds
+    Data.localConversations foundLocalIds
       >>= filterM removeDeleted
       >>= filterM (pure . isMember user . Data.convLocalMembers)
   localConversations <- mapM (Mapping.conversationView user) localInternalConversations

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -62,8 +62,8 @@ module Galley.Data
     localConversationIdsOf,
     remoteConversationStatus,
     localConversationIdsPageFrom,
-    conversationIdRowsForPagination,
-    conversations,
+    localConversationIdRowsForPagination,
+    localConversations,
     conversationMeta,
     conversationsRemote,
     createConnectConversation,
@@ -503,12 +503,12 @@ conversationGC conv = case join (convDeleted <$> conv) of
     return Nothing
   _ -> return conv
 
-conversations ::
+localConversations ::
   (MonadLogger m, MonadUnliftIO m, MonadClient m) =>
   [ConvId] ->
   m [Conversation]
-conversations [] = return []
-conversations ids = do
+localConversations [] = return []
+localConversations ids = do
   convs <- async fetchConvs
   mems <- async $ memberLists ids
   remoteMems <- async $ remoteMemberLists ids
@@ -580,8 +580,8 @@ remoteConversationIdsPageFrom :: (MonadClient m) => UserId -> Maybe PagingState 
 remoteConversationIdsPageFrom usr pagingState max =
   uncurry (flip Qualified) <$$> paginateWithState Cql.selectUserRemoteConvs (paramsPagingState Quorum (Identity usr) max pagingState)
 
-conversationIdRowsForPagination :: MonadClient m => UserId -> Maybe ConvId -> Range 1 1000 Int32 -> m (Page ConvId)
-conversationIdRowsForPagination usr start (fromRange -> max) =
+localConversationIdRowsForPagination :: MonadClient m => UserId -> Maybe ConvId -> Range 1 1000 Int32 -> m (Page ConvId)
+localConversationIdRowsForPagination usr start (fromRange -> max) =
   runIdentity
     <$$> case start of
       Just c -> paginate Cql.selectUserConvsFrom (paramsP Quorum (usr, c) max)

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1168,10 +1168,10 @@ deleteClientInternal u c = do
       . zConn "conn"
       . paths ["i", "clients", toByteString' c]
 
-deleteUser :: HasCallStack => UserId -> TestM ()
+deleteUser :: (MonadIO m, MonadCatch m, MonadHttp m, HasGalley m, HasCallStack) => UserId -> m ResponseLBS
 deleteUser u = do
-  g <- view tsGalley
-  delete (g . path "/i/user" . zUser u) !!! const 200 === statusCode
+  g <- viewGalley
+  delete (g . path "/i/user" . zUser u)
 
 getTeamQueue :: HasCallStack => UserId -> Maybe NotificationId -> Maybe (Int, Bool) -> Bool -> TestM [(NotificationId, UserId)]
 getTeamQueue zusr msince msize onlyLast =


### PR DESCRIPTION
This makes sure to remove a user from their remote conversation when the user's account is being deleted.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.