### PR TITLE
Add ncurses dependency

### DIFF
--- a/build/alpine/Dockerfile.deps
+++ b/build/alpine/Dockerfile.deps
@@ -27,4 +27,5 @@ RUN apk add --no-cache \
             llvm-libunwind \
             ca-certificates \
             dumb-init \
-            libxml2
+            libxml2 \
+            ncurses

--- a/changelog.d/5-internal/ncurses-deps
+++ b/changelog.d/5-internal/ncurses-deps
@@ -1,0 +1,1 @@
+Some executables now have a runtime dependencies on ncurses

--- a/changelog.d/5-internal/ncurses-deps
+++ b/changelog.d/5-internal/ncurses-deps
@@ -1,1 +1,1 @@
-Some executables now have a runtime dependencies on ncurses
+Some executables now have a runtime dependency on ncurses


### PR DESCRIPTION
It seems https://github.com/wireapp/wire-server/commit/36f51b59914c0112b1181199534048c22f37f59e has added a runtime dependency on ncurses to spar-schema. This adds ncurses to the docker image dependencies, so that the ephemeral services and CI can run.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.