### PR TITLE
Pure interpreter for IdP effect

### DIFF
--- a/changelog.d/5-internal/idp-effect
+++ b/changelog.d/5-internal/idp-effect
@@ -1,1 +1,1 @@
-Spar: Extract IdP effect into Polysemy (#1787)
+Spar: Extract IdP effect into Polysemy (#1787, #1793)

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5b06ec7a50a1803f0f0aefbe72aad10c986a9becf2aa984b53f253d6a8caf237
+-- hash: 920daea26e271c6f0d5688476b71beb67c388d49d00e6f57723aaf825eb3df0d
 
 name:           spar
 version:        0.1
@@ -36,6 +36,7 @@ library
       Spar.Scim.User
       Spar.Sem.IdP
       Spar.Sem.IdP.Cassandra
+      Spar.Sem.IdP.Mem
       Spar.Sem.SAMLUser
       Spar.Sem.SAMLUser.Cassandra
   other-modules:

--- a/services/spar/src/Spar/Sem/IdP/Mem.hs
+++ b/services/spar/src/Spar/Sem/IdP/Mem.hs
@@ -1,0 +1,124 @@
+{-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}
+
+module Spar.Sem.IdP.Mem (idPToMem) where
+
+import Control.Exception (assert)
+import Control.Lens ((%~), (.~), (^.), _1, _2)
+import Data.Id (TeamId)
+import qualified Data.Map as M
+import Imports
+import Polysemy
+import Polysemy.State
+import qualified SAML2.WebSSO.Types as SAML
+import qualified Spar.Sem.IdP as Eff
+import qualified Wire.API.User.IdentityProvider as IP
+
+type IS = (TypedState, RawState)
+
+type TypedState = Map SAML.IdPId IP.IdP
+
+type RawState = Map SAML.IdPId Text
+
+idPToMem ::
+  forall r a.
+  Sem (Eff.IdP ': r) a ->
+  Sem r a
+idPToMem = evState . evEff
+  where
+    evState :: Sem (State IS : r) a -> Sem r a
+    evState = evalState mempty
+
+    evEff :: Sem (Eff.IdP ': r) a -> Sem (State IS ': r) a
+    evEff = reinterpret @_ @(State IS) $ \case
+      Eff.StoreConfig iw ->
+        modify' (_1 %~ storeConfig iw)
+      Eff.GetConfig i ->
+        gets (getConfig i . (^. _1))
+      Eff.GetIdByIssuerWithoutTeam iss ->
+        gets (getIdByIssuerWithoutTeam iss . (^. _1))
+      Eff.GetIdByIssuerWithTeam iss team ->
+        gets (getIdByIssuerWithTeam iss team . (^. _1))
+      Eff.GetConfigsByTeam team ->
+        gets (getConfigsByTeam team . (^. _1))
+      Eff.DeleteConfig i iss team ->
+        modify' (_1 %~ deleteConfig i iss team)
+      Eff.SetReplacedBy (Eff.Replaced replaced) (Eff.Replacing replacing) ->
+        modify' (_1 %~ ((updateReplacedBy (Just replacing) replaced) <$>))
+      Eff.ClearReplacedBy (Eff.Replaced replaced) ->
+        modify' (_1 %~ ((updateReplacedBy Nothing replaced) <$>))
+      Eff.StoreRawMetadata i txt ->
+        modify (_2 %~ storeRawMetadata i txt)
+      Eff.GetRawMetadata i ->
+        gets (getRawMetadata i . (^. _2))
+      Eff.DeleteRawMetadata i ->
+        modify (_2 %~ deleteRawMetadata i)
+
+storeConfig :: IP.IdP -> TypedState -> TypedState
+storeConfig iw =
+  M.filter
+    ( \iw' ->
+        or
+          [ iw' ^. SAML.idpMetadata . SAML.edIssuer /= iw ^. SAML.idpMetadata . SAML.edIssuer,
+            iw' ^. SAML.idpExtraInfo . IP.wiTeam /= iw ^. SAML.idpExtraInfo . IP.wiTeam
+          ]
+    )
+    . M.insert (iw ^. SAML.idpId) iw
+
+getConfig :: SAML.IdPId -> TypedState -> Maybe IP.IdP
+getConfig = M.lookup
+
+getIdByIssuerWithoutTeam :: SAML.Issuer -> TypedState -> Eff.GetIdPResult SAML.IdPId
+getIdByIssuerWithoutTeam iss mp =
+  case filter (\idp -> idp ^. SAML.idpMetadata . SAML.edIssuer == iss) $ M.elems mp of
+    [] -> Eff.GetIdPNotFound
+    [a] -> Eff.GetIdPFound (a ^. SAML.idpId)
+    as@(_ : _ : _) -> Eff.GetIdPNonUnique ((^. SAML.idpId) <$> as)
+
+getIdByIssuerWithTeam :: SAML.Issuer -> TeamId -> TypedState -> Maybe SAML.IdPId
+getIdByIssuerWithTeam iss team mp =
+  case filter fl $ M.elems mp of
+    [] -> Nothing
+    [a] -> Just (a ^. SAML.idpId)
+    (_ : _ : _) ->
+      -- (Eff.StoreConfig doesn't let this happen)
+      error "Eff.GetIdByIssuerWithTeam: impossible"
+  where
+    fl :: IP.IdP -> Bool
+    fl idp =
+      idp ^. SAML.idpMetadata . SAML.edIssuer == iss
+        && idp ^. SAML.idpExtraInfo . IP.wiTeam == team
+
+getConfigsByTeam :: TeamId -> TypedState -> [IP.IdP]
+getConfigsByTeam team =
+  filter fl . M.elems
+  where
+    fl :: IP.IdP -> Bool
+    fl idp = idp ^. SAML.idpExtraInfo . IP.wiTeam == team
+
+deleteConfig :: SAML.IdPId -> SAML.Issuer -> TeamId -> TypedState -> TypedState
+deleteConfig i iss team =
+  M.filter fl
+  where
+    fl :: IP.IdP -> Bool
+    fl idp =
+      assert -- calling this function with inconsistent values will crash hard.
+        ( idp ^. SAML.idpMetadata . SAML.edIssuer == iss
+            && idp ^. SAML.idpExtraInfo . IP.wiTeam == team
+        )
+        (idp ^. SAML.idpId /= i)
+
+updateReplacedBy :: Maybe SAML.IdPId -> SAML.IdPId -> IP.IdP -> IP.IdP
+updateReplacedBy mbReplacing replaced idp =
+  idp
+    & if idp ^. SAML.idpId == replaced
+      then SAML.idpExtraInfo . IP.wiReplacedBy .~ mbReplacing
+      else id
+
+storeRawMetadata :: SAML.IdPId -> Text -> RawState -> RawState
+storeRawMetadata = M.insert
+
+getRawMetadata :: SAML.IdPId -> RawState -> Maybe Text
+getRawMetadata = M.lookup
+
+deleteRawMetadata :: SAML.IdPId -> RawState -> RawState
+deleteRawMetadata idpid = M.filterWithKey (\idpid' _ -> idpid' /= idpid)


### PR DESCRIPTION
New polysemy interpreter for the effect introduced in #1787.

I suppose this would be even more useful if we had a `quickcheck-state-machine`-based "proof" that the two interpreters are equivalent, but that can be done in a separate PR.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
