### PR TITLE
Remove explicit instantiations of ErrorDescription values

### DIFF
--- a/changelog.d/5-internal/remove-explicit-errdesc
+++ b/changelog.d/5-internal/remove-explicit-errdesc
@@ -1,0 +1,1 @@
+Remove explicit instantiations of ErrorDescription

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -207,9 +207,6 @@ type ConvMemberNotFound = ErrorDescription 404 "no-conversation-member" "Convers
 
 type UnknownClient = ErrorDescription 403 "unknown-client" "Unknown Client"
 
-unknownClient :: UnknownClient
-unknownClient = ErrorDescription "Sending client not known"
-
 type ClientNotFound = ErrorDescription 404 "client-not-found" "Client not found"
 
 clientNotFound :: ClientNotFound

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -213,9 +213,6 @@ type NotConnected = ErrorDescription 403 "not-connected" "Users are not connecte
 
 type ConnectionLimitReached = ErrorDescription 403 "connection-limit" "Too many sent/accepted connections."
 
-connectionLimitReached :: ConnectionLimitReached
-connectionLimitReached = mkErrorDescription
-
 type InvalidUser = ErrorDescription 400 "invalid-user" "Invalid user."
 
 invalidUser :: InvalidUser

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -244,9 +244,6 @@ type ConvMemberRemovalDenied = ErrorDescription 403 "action-denied" "Insufficien
 
 type CodeNotFound = ErrorDescription 404 "no-conversation-code" "Conversation code not found"
 
-codeNotFound :: CodeNotFound
-codeNotFound = mkErrorDescription
-
 type ConvAccessDenied = ErrorDescription 403 "access-denied" "Conversation access denied"
 
 convAccessDenied :: ConvAccessDenied

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -246,9 +246,6 @@ type CodeNotFound = ErrorDescription 404 "no-conversation-code" "Conversation co
 
 type ConvAccessDenied = ErrorDescription 403 "access-denied" "Conversation access denied"
 
-convAccessDenied :: ConvAccessDenied
-convAccessDenied = mkErrorDescription
-
 type UserNotFound = ErrorDescription 404 "not-found" "User not found"
 
 userNotFound :: UserNotFound

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -250,9 +250,6 @@ type UserNotFound = ErrorDescription 404 "not-found" "User not found"
 
 type ConnectionNotFound = ErrorDescription 404 "not-found" "Connection not found"
 
-connectionNotFound :: ConnectionNotFound
-connectionNotFound = mkErrorDescription
-
 type HandleNotFound = ErrorDescription 404 "not-found" "Handle not found"
 
 handleNotFound :: HandleNotFound

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -248,9 +248,6 @@ type ConvAccessDenied = ErrorDescription 403 "access-denied" "Conversation acces
 
 type UserNotFound = ErrorDescription 404 "not-found" "User not found"
 
-userNotFound :: UserNotFound
-userNotFound = mkErrorDescription
-
 type ConnectionNotFound = ErrorDescription 404 "not-found" "Connection not found"
 
 connectionNotFound :: ConnectionNotFound

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -209,9 +209,6 @@ type UnknownClient = ErrorDescription 403 "unknown-client" "Unknown Client"
 
 type ClientNotFound = ErrorDescription 404 "client-not-found" "Client not found"
 
-clientNotFound :: ClientNotFound
-clientNotFound = mkErrorDescription
-
 type NotConnected = ErrorDescription 403 "not-connected" "Users are not connected"
 
 notConnected :: NotConnected
@@ -232,9 +229,6 @@ type InvalidCode =
     403
     "invalid-code"
     "Invalid verification code"
-
-invalidCode :: InvalidCode
-invalidCode = mkErrorDescription
 
 type InvalidTransition = ErrorDescription 403 "bad-conn-update" "Invalid status transition."
 
@@ -315,9 +309,6 @@ type BadCredentials =
     "invalid-credentials"
     "Authentication failed."
 
-badCredentials :: BadCredentials
-badCredentials = mkErrorDescription
-
 type DeleteCodePending =
   ErrorDescription
     403
@@ -332,9 +323,6 @@ type OwnerDeletingSelf =
     403
     "no-self-delete-for-team-owner"
     "Team owners are not allowed to delete themselves.  Ask a fellow owner."
-
-ownerDeletingSelf :: OwnerDeletingSelf
-ownerDeletingSelf = mkErrorDescription
 
 type MalformedPrekeys = ErrorDescription 400 "bad-request" "Malformed prekeys uploaded"
 

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -233,9 +233,6 @@ operationDenied p =
 
 type NotATeamMember = ErrorDescription 403 "no-team-member" "Requesting user is not a team member"
 
-notATeamMember :: NotATeamMember
-notATeamMember = mkErrorDescription
-
 type ActionDenied = ErrorDescription 403 "action-denied" "Insufficient authorization"
 
 actionDenied :: Show a => a -> ActionDenied

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -219,9 +219,6 @@ type InvalidCode = ErrorDescription 403 "invalid-code" "Invalid verification cod
 
 type InvalidTransition = ErrorDescription 403 "bad-conn-update" "Invalid status transition."
 
-invalidTransition :: InvalidTransition
-invalidTransition = mkErrorDescription
-
 type NoIdentity = ErrorDescription 403 "no-identity" "The user has no verified identity (email or phone number)."
 
 noIdentity :: forall code lbl desc. (NoIdentity ~ ErrorDescription code lbl desc) => Int -> NoIdentity

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -215,14 +215,7 @@ type ConnectionLimitReached = ErrorDescription 403 "connection-limit" "Too many 
 
 type InvalidUser = ErrorDescription 400 "invalid-user" "Invalid user."
 
-invalidUser :: InvalidUser
-invalidUser = mkErrorDescription
-
-type InvalidCode =
-  ErrorDescription
-    403
-    "invalid-code"
-    "Invalid verification code"
+type InvalidCode = ErrorDescription 403 "invalid-code" "Invalid verification code"
 
 type InvalidTransition = ErrorDescription 403 "bad-conn-update" "Invalid status transition."
 

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -254,9 +254,6 @@ type HandleNotFound = ErrorDescription 404 "not-found" "Handle not found"
 
 type TooManyClients = ErrorDescription 403 "too-many-clients" "Too many clients"
 
-tooManyClients :: TooManyClients
-tooManyClients = mkErrorDescription
-
 type MissingAuth =
   ErrorDescription
     403

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -242,9 +242,6 @@ actionDenied a =
 
 type ConvMemberRemovalDenied = ErrorDescription 403 "action-denied" "Insufficient authorization"
 
-convMemberRemovalDenied :: ConvMemberRemovalDenied
-convMemberRemovalDenied = ErrorDescription "Insufficient authorization, cannot remove member from conversation"
-
 type CodeNotFound = ErrorDescription 404 "no-conversation-code" "Conversation code not found"
 
 codeNotFound :: CodeNotFound

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -252,9 +252,6 @@ type ConnectionNotFound = ErrorDescription 404 "not-found" "Connection not found
 
 type HandleNotFound = ErrorDescription 404 "not-found" "Handle not found"
 
-handleNotFound :: HandleNotFound
-handleNotFound = mkErrorDescription
-
 type TooManyClients = ErrorDescription 403 "too-many-clients" "Too many clients"
 
 tooManyClients :: TooManyClients

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -280,9 +280,6 @@ type OwnerDeletingSelf =
 
 type MalformedPrekeys = ErrorDescription 400 "bad-request" "Malformed prekeys uploaded"
 
-malformedPrekeys :: MalformedPrekeys
-malformedPrekeys = mkErrorDescription
-
 type MissingLegalholdConsent =
   ErrorDescription
     403

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -293,9 +293,6 @@ type CustomRolesNotSupported =
     "bad-request"
     "Custom roles not supported"
 
-customRolesNotSupported :: CustomRolesNotSupported
-customRolesNotSupported = mkErrorDescription
-
 type InvalidOp desc =
   ErrorDescription
     403
@@ -307,15 +304,6 @@ invalidOpErrorDesc = ErrorDescription . Text.pack . symbolVal
 
 type InvalidOpSelfConv = InvalidOp "invalid operation for self conversation"
 
-invalidOpSelfConv :: InvalidOpSelfConv
-invalidOpSelfConv = mkErrorDescription
-
 type InvalidOpOne2OneConv = InvalidOp "invalid operation for 1:1 conversations"
 
-invalidOpOne2OneConv :: InvalidOpOne2OneConv
-invalidOpOne2OneConv = mkErrorDescription
-
 type InvalidOpConnectConv = InvalidOp "invalid operation for connect conversation"
-
-invalidOpConnectConv :: InvalidOpConnectConv
-invalidOpConnectConv = mkErrorDescription

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -260,9 +260,6 @@ type MissingAuth =
     "missing-auth"
     "Re-authentication via password required"
 
-missingAuthError :: MissingAuth
-missingAuthError = mkErrorDescription
-
 type BadCredentials =
   ErrorDescription
     403

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -203,9 +203,6 @@ mkErrorDescription = ErrorDescription $ Text.pack (symbolVal (Proxy @desc))
 
 type ConvNotFound = ErrorDescription 404 "no-conversation" "Conversation not found"
 
-convNotFound :: ConvNotFound
-convNotFound = mkErrorDescription
-
 type ConvMemberNotFound = ErrorDescription 404 "no-conversation-member" "Conversation member not found"
 
 type UnknownClient = ErrorDescription 403 "unknown-client" "Unknown Client"

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -211,9 +211,6 @@ type ClientNotFound = ErrorDescription 404 "client-not-found" "Client not found"
 
 type NotConnected = ErrorDescription 403 "not-connected" "Users are not connected"
 
-notConnected :: NotConnected
-notConnected = mkErrorDescription
-
 type ConnectionLimitReached = ErrorDescription 403 "connection-limit" "Too many sent/accepted connections."
 
 connectionLimitReached :: ConnectionLimitReached

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -287,9 +287,6 @@ type MissingLegalholdConsent =
     "Failed to connect to a user or to invite a user to a group because somebody \
     \is under legalhold and somebody else has not granted consent."
 
-missingLegalholdConsent :: MissingLegalholdConsent
-missingLegalholdConsent = mkErrorDescription
-
 type CustomRolesNotSupported =
   ErrorDescription
     400

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -272,9 +272,6 @@ type DeleteCodePending =
     "pending-delete"
     "A verification code for account deletion is still pending."
 
-deleteCodePending :: DeleteCodePending
-deleteCodePending = mkErrorDescription
-
 type OwnerDeletingSelf =
   ErrorDescription
     403

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -34,7 +34,7 @@ module Brig.API.Connection
   )
 where
 
-import Brig.API.Error (errorDescriptionToWai)
+import Brig.API.Error (errorDescriptionTypeToWai)
 import Brig.API.Types
 import Brig.API.User (getLegalHoldStatus)
 import Brig.App
@@ -175,7 +175,7 @@ checkLegalholdPolicyConflict uid1 uid2 = do
   let catchProfileNotFound =
         -- Does not fit into 'ExceptT', so throw in 'AppIO'.  Anyway at the time of writing
         -- this, users are guaranteed to exist when called from 'createConnectionToLocalUser'.
-        maybe (throwM (errorDescriptionToWai userNotFound)) return
+        maybe (throwM (errorDescriptionTypeToWai @UserNotFound)) return
 
   status1 <- lift (getLegalHoldStatus uid1) >>= catchProfileNotFound
   status2 <- lift (getLegalHoldStatus uid2) >>= catchProfileNotFound

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -107,7 +107,7 @@ instance ToJSON Error where
 
 connError :: ConnectionError -> Error
 connError TooManyConnections {} = StdError (errorDescriptionTypeToWai @ConnectionLimitReached)
-connError InvalidTransition {} = StdError (errorDescriptionToWai invalidTransition)
+connError InvalidTransition {} = StdError (errorDescriptionTypeToWai @InvalidTransition)
 connError NotConnected {} = StdError (errorDescriptionTypeToWai @NotConnected)
 connError InvalidUser {} = StdError (errorDescriptionTypeToWai @InvalidUser)
 connError ConnectNoIdentity {} = StdError (errorDescriptionToWai (noIdentity 0))

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -115,7 +115,7 @@ connError (ConnectBlacklistedUserKey k) = StdError $ foldKey (const blacklistedE
 connError (ConnectInvalidEmail _ _) = StdError invalidEmail
 connError ConnectInvalidPhone {} = StdError invalidPhone
 connError ConnectSameBindingTeamUsers = StdError sameBindingTeamUsers
-connError ConnectMissingLegalholdConsent = StdError (errorDescriptionToWai missingLegalholdConsent)
+connError ConnectMissingLegalholdConsent = StdError (errorDescriptionTypeToWai @MissingLegalholdConsent)
 
 actError :: ActivationError -> Error
 actError (UserKeyExists _) = StdError userKeyExists
@@ -225,7 +225,7 @@ clientError ClientLegalHoldCannotBeRemoved = StdError can'tDeleteLegalHoldClient
 clientError ClientLegalHoldCannotBeAdded = StdError can'tAddLegalHoldClient
 clientError (ClientFederationError e) = fedError e
 clientError ClientCapabilitiesCannotBeRemoved = StdError clientCapabilitiesCannotBeRemoved
-clientError ClientMissingLegalholdConsent = StdError (errorDescriptionToWai missingLegalholdConsent)
+clientError ClientMissingLegalholdConsent = StdError (errorDescriptionTypeToWai @MissingLegalholdConsent)
 
 fedError :: FederationError -> Error
 fedError = StdError . federationErrorToWai

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -106,7 +106,7 @@ instance ToJSON Error where
 -- Error Mapping ----------------------------------------------------------
 
 connError :: ConnectionError -> Error
-connError TooManyConnections {} = StdError (errorDescriptionToWai connectionLimitReached)
+connError TooManyConnections {} = StdError (errorDescriptionTypeToWai @ConnectionLimitReached)
 connError InvalidTransition {} = StdError (errorDescriptionToWai invalidTransition)
 connError NotConnected {} = StdError (errorDescriptionTypeToWai @NotConnected)
 connError InvalidUser {} = StdError (errorDescriptionToWai invalidUser)

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -108,7 +108,7 @@ instance ToJSON Error where
 connError :: ConnectionError -> Error
 connError TooManyConnections {} = StdError (errorDescriptionToWai connectionLimitReached)
 connError InvalidTransition {} = StdError (errorDescriptionToWai invalidTransition)
-connError NotConnected {} = StdError (errorDescriptionToWai notConnected)
+connError NotConnected {} = StdError (errorDescriptionTypeToWai @NotConnected)
 connError InvalidUser {} = StdError (errorDescriptionToWai invalidUser)
 connError ConnectNoIdentity {} = StdError (errorDescriptionToWai (noIdentity 0))
 connError (ConnectBlacklistedUserKey k) = StdError $ foldKey (const blacklistedEmail) (const blacklistedPhone) k

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -239,7 +239,7 @@ propDataError :: PropertiesDataError -> Error
 propDataError TooManyProperties = StdError tooManyProperties
 
 clientDataError :: ClientDataError -> Error
-clientDataError TooManyClients = StdError (errorDescriptionToWai tooManyClients)
+clientDataError TooManyClients = StdError (errorDescriptionTypeToWai @TooManyClients)
 clientDataError (ClientReAuthError e) = reauthError e
 clientDataError ClientMissingAuth = StdError (errorDescriptionToWai missingAuthError)
 clientDataError MalformedPrekeys = StdError (errorDescriptionToWai malformedPrekeys)

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -208,7 +208,7 @@ authError AuthEphemeral = StdError accountEphemeral
 authError AuthPendingInvitation = StdError accountPending
 
 reauthError :: ReAuthError -> Error
-reauthError ReAuthMissingPassword = StdError (errorDescriptionToWai missingAuthError)
+reauthError ReAuthMissingPassword = StdError (errorDescriptionTypeToWai @MissingAuth)
 reauthError (ReAuthError e) = authError e
 
 zauthError :: ZAuth.Failure -> Error
@@ -241,14 +241,14 @@ propDataError TooManyProperties = StdError tooManyProperties
 clientDataError :: ClientDataError -> Error
 clientDataError TooManyClients = StdError (errorDescriptionTypeToWai @TooManyClients)
 clientDataError (ClientReAuthError e) = reauthError e
-clientDataError ClientMissingAuth = StdError (errorDescriptionToWai missingAuthError)
-clientDataError MalformedPrekeys = StdError (errorDescriptionToWai malformedPrekeys)
+clientDataError ClientMissingAuth = StdError (errorDescriptionTypeToWai @MissingAuth)
+clientDataError MalformedPrekeys = StdError (errorDescriptionTypeToWai @MalformedPrekeys)
 
 deleteUserError :: DeleteUserError -> Error
 deleteUserError DeleteUserInvalid = StdError (errorDescriptionTypeToWai @InvalidUser)
 deleteUserError DeleteUserInvalidCode = StdError (errorDescriptionTypeToWai @InvalidCode)
 deleteUserError DeleteUserInvalidPassword = StdError (errorDescriptionTypeToWai @BadCredentials)
-deleteUserError DeleteUserMissingPassword = StdError (errorDescriptionToWai missingAuthError)
+deleteUserError DeleteUserMissingPassword = StdError (errorDescriptionTypeToWai @MissingAuth)
 deleteUserError (DeleteUserPendingCode t) = RichError deletionCodePending (DeletionCodeTimeout t) []
 deleteUserError DeleteUserOwnerDeletingSelf = StdError (errorDescriptionTypeToWai @OwnerDeletingSelf)
 

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -262,7 +262,7 @@ phoneError (PhoneBudgetExhausted t) = RichError phoneBudgetExhausted (PhoneBudge
 
 updateProfileError :: UpdateProfileError -> Error
 updateProfileError DisplayNameManagedByScim = StdError (propertyManagedByScim "name")
-updateProfileError (ProfileNotFound _) = StdError (errorDescriptionToWai userNotFound)
+updateProfileError (ProfileNotFound _) = StdError (errorDescriptionTypeToWai @UserNotFound)
 
 -- WAI Errors -----------------------------------------------------------------
 

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -109,7 +109,7 @@ connError :: ConnectionError -> Error
 connError TooManyConnections {} = StdError (errorDescriptionTypeToWai @ConnectionLimitReached)
 connError InvalidTransition {} = StdError (errorDescriptionToWai invalidTransition)
 connError NotConnected {} = StdError (errorDescriptionTypeToWai @NotConnected)
-connError InvalidUser {} = StdError (errorDescriptionToWai invalidUser)
+connError InvalidUser {} = StdError (errorDescriptionTypeToWai @InvalidUser)
 connError ConnectNoIdentity {} = StdError (errorDescriptionToWai (noIdentity 0))
 connError (ConnectBlacklistedUserKey k) = StdError $ foldKey (const blacklistedEmail) (const blacklistedPhone) k
 connError (ConnectInvalidEmail _ _) = StdError invalidEmail
@@ -220,7 +220,7 @@ zauthError ZAuth.Unsupported = StdError authTokenUnsupported
 clientError :: ClientError -> Error
 clientError ClientNotFound = StdError (errorDescriptionTypeToWai @ClientNotFound)
 clientError (ClientDataError e) = clientDataError e
-clientError (ClientUserNotFound _) = StdError (errorDescriptionToWai invalidUser)
+clientError (ClientUserNotFound _) = StdError (errorDescriptionTypeToWai @InvalidUser)
 clientError ClientLegalHoldCannotBeRemoved = StdError can'tDeleteLegalHoldClient
 clientError ClientLegalHoldCannotBeAdded = StdError can'tAddLegalHoldClient
 clientError (ClientFederationError e) = fedError e
@@ -245,7 +245,7 @@ clientDataError ClientMissingAuth = StdError (errorDescriptionToWai missingAuthE
 clientDataError MalformedPrekeys = StdError (errorDescriptionToWai malformedPrekeys)
 
 deleteUserError :: DeleteUserError -> Error
-deleteUserError DeleteUserInvalid = StdError (errorDescriptionToWai invalidUser)
+deleteUserError DeleteUserInvalid = StdError (errorDescriptionTypeToWai @InvalidUser)
 deleteUserError DeleteUserInvalidCode = StdError (errorDescriptionTypeToWai @InvalidCode)
 deleteUserError DeleteUserInvalidPassword = StdError (errorDescriptionTypeToWai @BadCredentials)
 deleteUserError DeleteUserMissingPassword = StdError (errorDescriptionToWai missingAuthError)

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -589,7 +589,7 @@ updateUserNameH (uid ::: _ ::: body) = empty <$ (updateUserName uid =<< parseJso
 
 updateUserName :: UserId -> NameUpdate -> Handler ()
 updateUserName uid (NameUpdate nameUpd) = do
-  name <- either (const $ throwStd (errorDescriptionToWai invalidUser)) pure $ mkName nameUpd
+  name <- either (const $ throwStd (errorDescriptionTypeToWai @InvalidUser)) pure $ mkName nameUpd
   let uu =
         UserUpdate
           { uupName = Just name,
@@ -599,7 +599,7 @@ updateUserName uid (NameUpdate nameUpd) = do
           }
   lift (Data.lookupUser WithPendingInvitations uid) >>= \case
     Just _ -> API.updateUser uid Nothing uu API.AllowSCIMUpdates !>> updateProfileError
-    Nothing -> throwStd (errorDescriptionToWai invalidUser)
+    Nothing -> throwStd (errorDescriptionTypeToWai @InvalidUser)
 
 checkHandleInternalH :: Text -> Handler Response
 checkHandleInternalH =

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -363,7 +363,7 @@ deleteUserNoVerify :: UserId -> Handler ()
 deleteUserNoVerify uid = do
   void $
     lift (API.lookupAccount uid)
-      >>= ifNothing (errorDescriptionToWai userNotFound)
+      >>= ifNothing (errorDescriptionTypeToWai @UserNotFound)
   lift $ API.deleteUserNoVerify uid
 
 changeSelfEmailMaybeSendH :: UserId ::: Bool ::: JsonRequest EmailUpdate -> Handler Response

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -292,7 +292,7 @@ sitemap = do
       Doc.description "Handle to check"
     Doc.response 200 "Handle is taken" Doc.end
     Doc.errorResponse invalidHandle
-    Doc.errorResponse (errorDescriptionToWai handleNotFound)
+    Doc.errorResponse (errorDescriptionTypeToWai @HandleNotFound)
 
   -- some APIs moved to servant
   -- end User Handle API

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -794,10 +794,10 @@ getRichInfo self user = do
   -- Check that both users exist and the requesting user is allowed to see rich info of the
   -- other user
   selfUser <-
-    ifNothing (errorDescriptionToWai userNotFound)
+    ifNothing (errorDescriptionTypeToWai @UserNotFound)
       =<< lift (Data.lookupUser NoPendingInvitations self)
   otherUser <-
-    ifNothing (errorDescriptionToWai userNotFound)
+    ifNothing (errorDescriptionTypeToWai @UserNotFound)
       =<< lift (Data.lookupUser NoPendingInvitations user)
   case (Public.userTeam selfUser, Public.userTeam otherUser) of
     (Just t1, Just t2) | t1 == t2 -> pure ()
@@ -886,7 +886,7 @@ createUser (Public.NewUserPublic new) = do
 getSelf :: UserId -> Handler Public.SelfProfile
 getSelf self =
   lift (API.lookupSelfProfile self)
-    >>= ifNothing (errorDescriptionToWai userNotFound)
+    >>= ifNothing (errorDescriptionTypeToWai @UserNotFound)
 
 getUserUnqualifiedH :: UserId -> UserId -> Handler (Maybe Public.UserProfile)
 getUserUnqualifiedH self uid = do

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -716,7 +716,7 @@ getMultiUserPrekeyBundleUnqualifiedH :: UserId -> Public.UserClients -> Handler 
 getMultiUserPrekeyBundleUnqualifiedH zusr userClients = do
   maxSize <- fromIntegral . setMaxConvSize <$> view settings
   when (Map.size (Public.userClients userClients) > maxSize) $
-    throwErrorDescription tooManyClients
+    throwErrorDescriptionType @TooManyClients
   API.claimLocalMultiPrekeyBundles (ProtectedUser zusr) userClients !>> clientError
 
 getMultiUserPrekeyBundleH :: UserId -> Public.QualifiedUserClients -> Handler Public.QualifiedUserClientPrekeyMap
@@ -727,7 +727,7 @@ getMultiUserPrekeyBundleH zusr qualUserClients = do
           (\_ v -> Sum . Map.size $ v)
           (Public.qualifiedUserClients qualUserClients)
   when (size > maxSize) $
-    throwErrorDescription tooManyClients
+    throwErrorDescriptionType @TooManyClients
   API.claimMultiPrekeyBundles (ProtectedUser zusr) qualUserClients !>> clientError
 
 addClient :: UserId -> ConnId -> Maybe IpAddr -> Public.NewClient -> Handler BrigAPI.NewClientResponse

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -93,7 +93,7 @@ import Servant.Swagger.UI
 import qualified System.Logger.Class as Log
 import Util.Logging (logFunction, logHandle, logTeam, logUser)
 import qualified Wire.API.Connection as Public
-import Wire.API.ErrorDescription hiding (badCredentials, invalidCode)
+import Wire.API.ErrorDescription
 import qualified Wire.API.Properties as Public
 import qualified Wire.API.Routes.Public.Brig as BrigAPI
 import qualified Wire.API.Routes.Public.Galley as GalleyAPI
@@ -359,7 +359,7 @@ sitemap = do
     Doc.body (Doc.ref Public.modelChangePassword) $
       Doc.description "JSON body"
     Doc.response 200 "Password changed." Doc.end
-    Doc.errorResponse badCredentials
+    Doc.errorResponse (errorDescriptionTypeToWai @BadCredentials)
     Doc.errorResponse (errorDescriptionToWai (noIdentity 4))
 
   put "/self/locale" (continue changeLocaleH) $
@@ -426,7 +426,7 @@ sitemap = do
     Doc.body (Doc.ref Public.modelVerifyDelete) $
       Doc.description "JSON body"
     Doc.response 200 "Deletion is initiated." Doc.end
-    Doc.errorResponse invalidCode
+    Doc.errorResponse (errorDescriptionTypeToWai @InvalidCode)
 
   -- Properties API -----------------------------------------------------
 
@@ -783,7 +783,7 @@ getUserClientQualified quid cid = do
 getClientCapabilities :: UserId -> ClientId -> Handler Public.ClientCapabilityList
 getClientCapabilities uid cid = do
   mclient <- lift (API.lookupLocalClient uid cid)
-  maybe (throwErrorDescription clientNotFound) (pure . Public.clientCapabilities) mclient
+  maybe (throwErrorDescriptionType @ClientNotFound) (pure . Public.clientCapabilities) mclient
 
 getRichInfoH :: UserId ::: UserId ::: JSON -> Handler Response
 getRichInfoH (self ::: user ::: _) =

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -54,6 +54,7 @@ import Network.Wai.Utilities.Response (empty, json)
 import qualified Network.Wai.Utilities.Response as WaiResp
 import Network.Wai.Utilities.Swagger (document)
 import qualified Network.Wai.Utilities.Swagger as Doc
+import Wire.API.ErrorDescription
 import qualified Wire.API.User as Public
 import Wire.API.User.Auth as Public
 import Wire.Swagger as Doc (pendingLoginError)
@@ -80,7 +81,7 @@ routesPublic = do
     Doc.parameter Doc.Query "access_token" Doc.bytes' $ do
       Doc.description "The access-token as query parameter."
       Doc.optional
-    Doc.errorResponse badCredentials
+    Doc.errorResponse (errorDescriptionTypeToWai @BadCredentials)
 
   post "/login/send" (continue sendLoginCodeH) $
     jsonRequest @Public.SendLoginCode
@@ -112,7 +113,7 @@ routesPublic = do
     Doc.parameter Doc.Query "persist" (Doc.bool $ Doc.def False) $ do
       Doc.description "Request a persistent cookie instead of a session cookie."
       Doc.optional
-    Doc.errorResponse badCredentials
+    Doc.errorResponse (errorDescriptionTypeToWai @BadCredentials)
     Doc.errorResponse accountSuspended
     Doc.errorResponse accountPending
     Doc.errorResponse loginsTooFrequent
@@ -133,7 +134,7 @@ routesPublic = do
     Doc.parameter Doc.Query "access_token" Doc.bytes' $ do
       Doc.description "The access-token as query parameter."
       Doc.optional
-    Doc.errorResponse badCredentials
+    Doc.errorResponse (errorDescriptionTypeToWai @BadCredentials)
 
   put "/access/self/email" (continue changeSelfEmailH) $
     accept "application" "json"
@@ -159,7 +160,7 @@ routesPublic = do
     Doc.errorResponse blacklistedPhone
     Doc.errorResponse missingAccessToken
     Doc.errorResponse invalidAccessToken
-    Doc.errorResponse badCredentials
+    Doc.errorResponse (errorDescriptionTypeToWai @BadCredentials)
 
   get "/cookies" (continue listCookiesH) $
     header "Z-User"
@@ -178,7 +179,7 @@ routesPublic = do
   document "POST" "rmCookies" $ do
     Doc.summary "Revoke stored cookies."
     Doc.body (Doc.ref Public.modelRemoveCookies) Doc.end
-    Doc.errorResponse badCredentials
+    Doc.errorResponse (errorDescriptionTypeToWai @BadCredentials)
 
 routesInternal :: Routes a Handler ()
 routesInternal = do

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -49,7 +49,7 @@ import Network.Wai
 import Network.Wai.Predicate hiding (setStatus)
 import Network.Wai.Utilities
 import qualified Wire.API.Conversation as Public
-import Wire.API.ErrorDescription (missingLegalholdConsent)
+import Wire.API.ErrorDescription (MissingLegalholdConsent)
 import Wire.API.Routes.Public.Galley (ConversationResponse)
 import Wire.API.Routes.Public.Util
 import Wire.API.Team.LegalHold (LegalholdProtectee (LegalholdPlusFederationNotImplemented))
@@ -88,7 +88,7 @@ ensureNoLegalholdConflicts remotes locals = do
   let FutureWork _remotes = FutureWork @'LegalholdPlusFederationNotImplemented remotes
   whenM (anyLegalholdActivated locals) $
     unlessM (allLegalholdConsentGiven locals) $
-      throwErrorDescription missingLegalholdConsent
+      throwErrorDescriptionType @MissingLegalholdConsent
 
 -- | A helper for creating a regular (non-team) group conversation.
 createRegularGroupConv :: UserId -> ConnId -> NewConvUnmanaged -> Galley ConversationResponse

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -38,7 +38,7 @@ import GHC.TypeLits (AppendSymbol)
 import qualified Galley.API.Clients as Clients
 import qualified Galley.API.Create as Create
 import qualified Galley.API.CustomBackend as CustomBackend
-import Galley.API.Error (throwErrorDescription)
+import Galley.API.Error (throwErrorDescriptionType)
 import Galley.API.LegalHold (getTeamLegalholdWhitelistedH, setTeamLegalholdWhitelistedH, unsetTeamLegalholdWhitelistedH)
 import Galley.API.LegalHold.Conflicts (guardLegalholdPolicyConflicts)
 import qualified Galley.API.Query as Query
@@ -72,7 +72,7 @@ import Servant.API.Generic
 import Servant.Server
 import Servant.Server.Generic (genericServerT)
 import System.Logger.Class hiding (Path, name)
-import Wire.API.ErrorDescription (missingLegalholdConsent)
+import Wire.API.ErrorDescription (MissingLegalholdConsent)
 import Wire.API.Routes.MultiVerb (MultiVerb, RespondEmpty)
 import Wire.API.Routes.Public (ZOptConn, ZUser)
 import qualified Wire.API.Team.Feature as Public
@@ -497,5 +497,5 @@ guardLegalholdPolicyConflictsH :: (JsonRequest GuardLegalholdPolicyConflicts :::
 guardLegalholdPolicyConflictsH (req ::: _) = do
   glh <- fromJsonBody req
   guardLegalholdPolicyConflicts (glhProtectee glh) (glhUserClients glh)
-    >>= either (const (throwErrorDescription missingLegalholdConsent)) pure
+    >>= either (const (throwErrorDescriptionType @MissingLegalholdConsent)) pure
   pure $ Network.Wai.Utilities.setStatus status200 empty

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -197,7 +197,7 @@ sitemap = do
       description "Team ID"
     body (ref Public.modelUpdateData) $
       description "JSON body"
-    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.NotATeamMember)
     errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.SetTeamData))
 
   get "/teams" (continue Teams.getManyTeamsH) $
@@ -245,7 +245,7 @@ sitemap = do
       optional
       description "JSON body, required only for binding teams."
     response 202 "Team is scheduled for removal" end
-    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.NotATeamMember)
     errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.DeleteTeam))
     errorResponse Error.deleteQueueFull
     errorResponse Error.reAuthFailed
@@ -267,7 +267,7 @@ sitemap = do
       description "Maximum Results to be returned"
     returns (ref Public.modelTeamMemberList)
     response 200 "Team members" end
-    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.NotATeamMember)
 
   get "/teams/:tid/members/csv" (continue Teams.getTeamMembersCSVH) $
     -- we could discriminate based on accept header only, but having two paths makes building
@@ -303,7 +303,7 @@ sitemap = do
       description "JSON body"
     returns (ref Public.modelTeamMemberList)
     response 200 "Team members" end
-    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.NotATeamMember)
     errorResponse Error.bulkGetMemberLimitExceeded
 
   get "/teams/:tid/members/:uid" (continue Teams.getTeamMemberH) $
@@ -319,7 +319,7 @@ sitemap = do
       description "User ID"
     returns (ref Public.modelTeamMember)
     response 200 "Team member" end
-    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.NotATeamMember)
     errorResponse Error.teamMemberNotFound
 
   get "/teams/notifications" (continue Teams.getTeamNotificationsH) $
@@ -374,7 +374,7 @@ sitemap = do
       description "Team ID"
     body (ref Public.modelNewTeamMember) $
       description "JSON body"
-    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.NotATeamMember)
     errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.AddTeamMember))
     errorResponse (Error.errorDescriptionTypeToWai @Error.NotConnected)
     errorResponse Error.invalidPermissions
@@ -397,7 +397,7 @@ sitemap = do
       optional
       description "JSON body, required only for binding teams."
     response 202 "Team member scheduled for deletion" end
-    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.NotATeamMember)
     errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.RemoveTeamMember))
     errorResponse Error.reAuthFailed
 
@@ -413,7 +413,7 @@ sitemap = do
       description "Team ID"
     body (ref Public.modelNewTeamMember) $
       description "JSON body"
-    errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.NotATeamMember)
     errorResponse Error.teamMemberNotFound
     errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.SetMemberPermissions))
 

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -567,7 +567,7 @@ sitemap = do
       description "Conversation ID"
     returns (ref Public.modelEvent)
     response 200 "Conversation joined." end
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
 
   post "/conversations/code-check" (continue Update.checkReusableCodeH) $
     jsonRequest @Public.ConversationCode
@@ -591,7 +591,7 @@ sitemap = do
     body (ref Public.modelConversationCode) $
       description "JSON body"
     errorResponse (Error.errorDescriptionToWai Error.codeNotFound)
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
     errorResponse Error.tooManyMembers
 
   -- This endpoint can lead to the following events being sent:
@@ -608,7 +608,7 @@ sitemap = do
     returns (ref Public.modelConversationCode)
     response 201 "Conversation code created." (model Public.modelEvent)
     response 200 "Conversation code already exists." (model Public.modelConversationCode)
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
     errorResponse Error.invalidAccessOp
 
   -- This endpoint can lead to the following events being sent:
@@ -623,7 +623,7 @@ sitemap = do
       description "Conversation ID"
     returns (ref Public.modelEvent)
     response 200 "Conversation code deleted." end
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
     errorResponse Error.invalidAccessOp
 
   get "/conversations/:cnv/code" (continue Update.getCodeH) $
@@ -635,7 +635,7 @@ sitemap = do
       description "Conversation ID"
     returns (ref Public.modelConversationCode)
     response 200 "Conversation Code" end
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
     errorResponse Error.invalidAccessOp
 
   -- This endpoint can lead to the following events being sent:
@@ -655,7 +655,7 @@ sitemap = do
     response 204 "Conversation access unchanged." end
     body (ref Public.modelConversationAccessUpdate) $
       description "JSON body"
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
     errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
     errorResponse Error.invalidTargetAccess
     errorResponse Error.invalidSelfOp
@@ -679,7 +679,7 @@ sitemap = do
     response 204 "Conversation receipt mode unchanged." end
     body (ref Public.modelConversationReceiptModeUpdate) $
       description "JSON body"
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
     errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
 
   -- This endpoint can lead to the following events being sent:
@@ -699,7 +699,7 @@ sitemap = do
     response 200 "Members added" end
     response 204 "No change" end
     response 412 "The user(s) cannot be added to the conversation (eg., due to legalhold policy conflict)." end
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
     errorResponse (Error.invalidOp "Conversation type does not allow adding members")
     errorResponse (Error.errorDescriptionToWai Error.notConnected)
     errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
@@ -717,7 +717,7 @@ sitemap = do
       description "Conversation ID"
     body (ref Public.modelTyping) $
       description "JSON body"
-    errorResponse (Error.errorDescriptionToWai Error.convNotFound)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - OtrMessageAdd event to recipients

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -754,7 +754,7 @@ sitemap = do
     response 412 "Missing clients" end
     errorResponse Error.teamNotFound
     errorResponse Error.nonBindingTeam
-    errorResponse (Error.errorDescriptionToWai Error.unknownClient)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.UnknownClient)
     errorResponse Error.broadcastLimitExceeded
 
   -- This endpoint can lead to the following events being sent:
@@ -789,7 +789,7 @@ sitemap = do
     response 412 "Missing clients" end
     errorResponse Error.teamNotFound
     errorResponse Error.nonBindingTeam
-    errorResponse (Error.errorDescriptionToWai Error.unknownClient)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.UnknownClient)
     errorResponse Error.broadcastLimitExceeded
 
 apiDocs :: Routes ApiBuilder Galley ()

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -656,7 +656,7 @@ sitemap = do
     body (ref Public.modelConversationAccessUpdate) $
       description "JSON body"
     errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
-    errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvAccessDenied)
     errorResponse Error.invalidTargetAccess
     errorResponse Error.invalidSelfOp
     errorResponse Error.invalidOne2OneOp
@@ -680,7 +680,7 @@ sitemap = do
     body (ref Public.modelConversationReceiptModeUpdate) $
       description "JSON body"
     errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
-    errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvAccessDenied)
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberJoin event to members
@@ -702,7 +702,7 @@ sitemap = do
     errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
     errorResponse (Error.invalidOp "Conversation type does not allow adding members")
     errorResponse (Error.errorDescriptionTypeToWai @Error.NotConnected)
-    errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvAccessDenied)
 
   -- This endpoint can lead to the following events being sent:
   -- - Typing event to members

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -183,7 +183,7 @@ sitemap = do
     body (ref Public.modelNewNonBindingTeam) $
       description "JSON body"
     response 201 "Team ID as `Location` header value" end
-    errorResponse (Error.errorDescriptionToWai Error.notConnected)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.NotConnected)
 
   put "/teams/:tid" (continue Teams.updateTeamH) $
     zauthUserId
@@ -376,7 +376,7 @@ sitemap = do
       description "JSON body"
     errorResponse (Error.errorDescriptionToWai Error.notATeamMember)
     errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.AddTeamMember))
-    errorResponse (Error.errorDescriptionToWai Error.notConnected)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.NotConnected)
     errorResponse Error.invalidPermissions
     errorResponse Error.tooManyTeamMembers
 
@@ -701,7 +701,7 @@ sitemap = do
     response 412 "The user(s) cannot be added to the conversation (eg., due to legalhold policy conflict)." end
     errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
     errorResponse (Error.invalidOp "Conversation type does not allow adding members")
-    errorResponse (Error.errorDescriptionToWai Error.notConnected)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.NotConnected)
     errorResponse (Error.errorDescriptionToWai Error.convAccessDenied)
 
   -- This endpoint can lead to the following events being sent:

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -576,7 +576,7 @@ sitemap = do
     response 200 "Valid" end
     body (ref Public.modelConversationCode) $
       description "JSON body"
-    errorResponse (Error.errorDescriptionToWai Error.codeNotFound)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.CodeNotFound)
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberJoin event to members
@@ -590,7 +590,7 @@ sitemap = do
     response 200 "Conversation joined." end
     body (ref Public.modelConversationCode) $
       description "JSON body"
-    errorResponse (Error.errorDescriptionToWai Error.codeNotFound)
+    errorResponse (Error.errorDescriptionTypeToWai @Error.CodeNotFound)
     errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
     errorResponse Error.tooManyMembers
 

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -115,7 +115,7 @@ import qualified SAML2.WebSSO as SAML
 import qualified System.Logger.Class as Log
 import UnliftIO (mapConcurrently)
 import qualified Wire.API.Conversation.Role as Public
-import Wire.API.ErrorDescription (ConvNotFound, notATeamMember, operationDenied)
+import Wire.API.ErrorDescription (ConvNotFound, NotATeamMember, operationDenied)
 import qualified Wire.API.Notification as Public
 import qualified Wire.API.Team as Public
 import qualified Wire.API.Team.Conversation as Public
@@ -369,7 +369,7 @@ getTeamConversationRoles :: UserId -> TeamId -> Galley Public.ConversationRolesL
 getTeamConversationRoles zusr tid = do
   mem <- Data.teamMember tid zusr
   case mem of
-    Nothing -> throwErrorDescription notATeamMember
+    Nothing -> throwErrorDescriptionType @NotATeamMember
     Just _ -> do
       -- NOTE: If/when custom roles are added, these roles should
       --       be merged with the team roles (if they exist)
@@ -383,7 +383,7 @@ getTeamMembersH (zusr ::: tid ::: maxResults ::: _) = do
 getTeamMembers :: UserId -> TeamId -> Range 1 Public.HardTruncationLimit Int32 -> Galley (Public.TeamMemberList, Public.TeamMember -> Bool)
 getTeamMembers zusr tid maxResults = do
   Data.teamMember tid zusr >>= \case
-    Nothing -> throwErrorDescription notATeamMember
+    Nothing -> throwErrorDescriptionType @NotATeamMember
     Just m -> do
       mems <- Data.teamMembersWithLimit tid maxResults
       let withPerms = (m `canSeePermsOf`)
@@ -504,7 +504,7 @@ bulkGetTeamMembers zusr tid maxResults uids = do
   unless (length uids <= fromIntegral (fromRange maxResults)) $
     throwM bulkGetMemberLimitExceeded
   Data.teamMember tid zusr >>= \case
-    Nothing -> throwErrorDescription notATeamMember
+    Nothing -> throwErrorDescriptionType @NotATeamMember
     Just m -> do
       mems <- Data.teamMembersLimited tid uids
       let withPerms = (m `canSeePermsOf`)
@@ -520,7 +520,7 @@ getTeamMember :: UserId -> TeamId -> UserId -> Galley (Public.TeamMember, Public
 getTeamMember zusr tid uid = do
   zusrMembership <- Data.teamMember tid zusr
   case zusrMembership of
-    Nothing -> throwErrorDescription notATeamMember
+    Nothing -> throwErrorDescriptionType @NotATeamMember
     Just m -> do
       let withPerms = (m `canSeePermsOf`)
       Data.teamMember tid uid >>= \case
@@ -750,14 +750,14 @@ uncheckedDeleteTeamMember zusr zcon tid remove mems = do
 
 getTeamConversations :: UserId -> TeamId -> Galley Public.TeamConversationList
 getTeamConversations zusr tid = do
-  tm <- Data.teamMember tid zusr >>= ifNothing (errorDescriptionToWai notATeamMember)
+  tm <- Data.teamMember tid zusr >>= ifNothing (errorDescriptionTypeToWai @NotATeamMember)
   unless (tm `hasPermission` GetTeamConversations) $
     throwErrorDescription (operationDenied GetTeamConversations)
   Public.newTeamConversationList <$> Data.teamConversations tid
 
 getTeamConversation :: UserId -> TeamId -> ConvId -> Galley Public.TeamConversation
 getTeamConversation zusr tid cid = do
-  tm <- Data.teamMember tid zusr >>= ifNothing (errorDescriptionToWai notATeamMember)
+  tm <- Data.teamMember tid zusr >>= ifNothing (errorDescriptionTypeToWai @NotATeamMember)
   unless (tm `hasPermission` GetTeamConversations) $
     throwErrorDescription (operationDenied GetTeamConversations)
   Data.teamConversation tid cid >>= maybe (throwErrorDescriptionType @ConvNotFound) pure

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -115,7 +115,7 @@ import qualified SAML2.WebSSO as SAML
 import qualified System.Logger.Class as Log
 import UnliftIO (mapConcurrently)
 import qualified Wire.API.Conversation.Role as Public
-import Wire.API.ErrorDescription (convNotFound, notATeamMember, operationDenied)
+import Wire.API.ErrorDescription (ConvNotFound, notATeamMember, operationDenied)
 import qualified Wire.API.Notification as Public
 import qualified Wire.API.Team as Public
 import qualified Wire.API.Team.Conversation as Public
@@ -760,7 +760,7 @@ getTeamConversation zusr tid cid = do
   tm <- Data.teamMember tid zusr >>= ifNothing (errorDescriptionToWai notATeamMember)
   unless (tm `hasPermission` GetTeamConversations) $
     throwErrorDescription (operationDenied GetTeamConversations)
-  Data.teamConversation tid cid >>= maybe (throwErrorDescription convNotFound) pure
+  Data.teamConversation tid cid >>= maybe (throwErrorDescriptionType @ConvNotFound) pure
 
 deleteTeamConversation :: UserId -> ConnId -> TeamId -> ConvId -> Galley ()
 deleteTeamConversation zusr zcon tid cid = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -115,10 +115,10 @@ import qualified Wire.API.Conversation as Public
 import qualified Wire.API.Conversation.Code as Public
 import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.ErrorDescription
-  ( ConvMemberNotFound,
+  ( CodeNotFound,
+    ConvMemberNotFound,
     ConvNotFound,
     UnknownClient,
-    codeNotFound,
     missingLegalholdConsent,
     mkErrorDescription,
   )
@@ -423,7 +423,7 @@ getCode usr cnv = do
   key <- mkKey cnv
   c <-
     Data.lookupCode key ReusableCode
-      >>= ifNothing (errorDescriptionToWai codeNotFound)
+      >>= ifNothing (errorDescriptionTypeToWai @CodeNotFound)
   returnCode c
 
 returnCode :: Code -> Galley Public.ConversationCode

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -117,10 +117,10 @@ import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.ErrorDescription
   ( ConvMemberNotFound,
     ConvNotFound,
+    UnknownClient,
     codeNotFound,
     missingLegalholdConsent,
     mkErrorDescription,
-    unknownClient,
   )
 import qualified Wire.API.ErrorDescription as Public
 import qualified Wire.API.Event.Conversation as Public
@@ -758,7 +758,7 @@ handleOtrResult :: OtrResult -> Galley Response
 handleOtrResult = \case
   OtrSent m -> pure $ json m & setStatus status201
   OtrMissingRecipients m -> pure $ json m & setStatus status412
-  OtrUnknownClient _ -> throwErrorDescription unknownClient
+  OtrUnknownClient _ -> throwErrorDescriptionType @UnknownClient
   OtrConversationNotFound _ -> throwErrorDescriptionType @ConvNotFound
 
 postBotMessageH :: BotId ::: ConvId ::: Public.OtrFilterMissing ::: JsonRequest Public.NewOtrMessage ::: JSON -> Galley Response
@@ -1262,7 +1262,7 @@ handleOtrResponse utype usr clt rcps membs clts val now go = case checkOtrRecipi
       >>= either (const (throwErrorDescription missingLegalholdConsent)) pure
     pure (OtrMissingRecipients m)
   InvalidOtrSenderUser -> pure $ OtrConversationNotFound mkErrorDescription
-  InvalidOtrSenderClient -> pure $ OtrUnknownClient unknownClient
+  InvalidOtrSenderClient -> pure $ OtrUnknownClient mkErrorDescription
 
 -- | Check OTR sender and recipients for validity and completeness
 -- against a given list of valid members and clients, optionally

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -72,14 +72,14 @@ type JSON = Media "application" "json"
 
 ensureAccessRole :: AccessRole -> [(UserId, Maybe TeamMember)] -> Galley ()
 ensureAccessRole role users = case role of
-  PrivateAccessRole -> throwErrorDescription convAccessDenied
+  PrivateAccessRole -> throwErrorDescriptionType @ConvAccessDenied
   TeamAccessRole ->
     when (any (isNothing . snd) users) $
       throwErrorDescriptionType @NotATeamMember
   ActivatedAccessRole -> do
     activated <- lookupActivatedUsers $ map fst users
     when (length activated /= length users) $
-      throwErrorDescription convAccessDenied
+      throwErrorDescriptionType @ConvAccessDenied
   NonActivatedAccessRole -> return ()
 
 -- | Check that the given user is either part of the same team(s) as the other
@@ -362,7 +362,7 @@ getMember p ex u = hoistEither . note ex . find ((u ==) . p)
 getConversationAndCheckMembership :: UserId -> ConvId -> Galley Data.Conversation
 getConversationAndCheckMembership =
   getConversationAndCheckMembershipWithError
-    (errorDescriptionToWai convAccessDenied)
+    (errorDescriptionTypeToWai @ConvAccessDenied)
 
 getConversationAndCheckMembershipWithError :: Error -> UserId -> ConvId -> Galley Data.Conversation
 getConversationAndCheckMembershipWithError ex zusr convId = do
@@ -419,7 +419,7 @@ ensureConversationAccess zusr cnv access = do
 ensureAccess :: Data.Conversation -> Access -> Galley ()
 ensureAccess conv access =
   unless (access `elem` Data.convAccess conv) $
-    throwErrorDescription convAccessDenied
+    throwErrorDescriptionType @ConvAccessDenied
 
 --------------------------------------------------------------------------------
 -- Federation

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -75,7 +75,7 @@ ensureAccessRole role users = case role of
   PrivateAccessRole -> throwErrorDescription convAccessDenied
   TeamAccessRole ->
     when (any (isNothing . snd) users) $
-      throwErrorDescription notATeamMember
+      throwErrorDescriptionType @NotATeamMember
   ActivatedAccessRole -> do
     activated <- lookupActivatedUsers $ map fst users
     when (length activated /= length users) $
@@ -174,7 +174,7 @@ permissionCheck p = \case
     if m `hasPermission` p
       then pure m
       else throwErrorDescription (operationDenied p)
-  Nothing -> throwErrorDescription notATeamMember
+  Nothing -> throwErrorDescriptionType @NotATeamMember
 
 assertTeamExists :: TeamId -> Galley ()
 assertTeamExists tid = do
@@ -186,7 +186,7 @@ assertTeamExists tid = do
 assertOnTeam :: UserId -> TeamId -> Galley ()
 assertOnTeam uid tid = do
   Data.teamMember tid uid >>= \case
-    Nothing -> throwErrorDescription notATeamMember
+    Nothing -> throwErrorDescriptionType @NotATeamMember
     Just _ -> return ()
 
 -- | If the conversation is in a team, throw iff zusr is a team member and does not have named

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -403,9 +403,9 @@ verifyReusableCode :: ConversationCode -> Galley DataTypes.Code
 verifyReusableCode convCode = do
   c <-
     Data.lookupCode (conversationKey convCode) DataTypes.ReusableCode
-      >>= ifNothing (errorDescriptionToWai codeNotFound)
+      >>= ifNothing (errorDescriptionTypeToWai @CodeNotFound)
   unless (DataTypes.codeValue c == conversationCode convCode) $
-    throwM (errorDescriptionToWai codeNotFound)
+    throwM (errorDescriptionTypeToWai @CodeNotFound)
   return c
 
 ensureConversationAccess :: UserId -> ConvId -> Access -> Galley Data.Conversation

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -116,7 +116,7 @@ ensureConnectedToLocals u uids = do
     getConnections [u] (Just uids) (Just Accepted)
       `concurrently` getConnections uids (Just [u]) (Just Accepted)
   unless (length connsFrom == length uids && length connsTo == length uids) $
-    throwErrorDescription notConnected
+    throwErrorDescriptionType @NotConnected
 
 ensureReAuthorised :: UserId -> Maybe PlainTextPassword -> Galley ()
 ensureReAuthorised u secret = do


### PR DESCRIPTION
So far, every `ErrorDescription` type has been accompanied by a corresponding value created with `mkErrorDescription`. This PR removes all those definitions, and adds some convenience functions (to be used with type application) that make it easier to refer to the error without having an explicit typed instantiation available.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
