### PR TITLE
Servantify receipt mode update

### DIFF
--- a/changelog.d/1-api-changes/deprecate-receipt-mode-update
+++ b/changelog.d/1-api-changes/deprecate-receipt-mode-update
@@ -1,0 +1,1 @@
+Deprecate `PUT /conversations/:cnv/receipt-mode` endpoint

--- a/changelog.d/1-api-changes/qualified-receipt-mode-update
+++ b/changelog.d/1-api-changes/qualified-receipt-mode-update
@@ -1,0 +1,1 @@
+Add qualified endpoint for updating receipt mode

--- a/changelog.d/5-internal/servantify-receipt-mode
+++ b/changelog.d/5-internal/servantify-receipt-mode
@@ -1,0 +1,1 @@
+Convert the `PUT /conversations/:cnv/receipt-mode` endpoint to Servant

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -408,13 +408,30 @@ data Api routes = Api
     -- - ConvReceiptModeUpdate event to members
     updateConversationReceiptModeUnqualified ::
       routes
-        :- Summary "Update receipt mode for a conversation"
+        :- Summary "Update receipt mode for a conversation (deprecated)"
+        :> Description "Use `PUT /conversations/:domain/:cnv/receipt-mode` instead."
         :> ZUser
         :> ZConn
         :> CanThrow ConvAccessDenied
         :> CanThrow ConvNotFound
         :> "conversations"
         :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "receipt-mode"
+        :> ReqBody '[JSON] ConversationReceiptModeUpdate
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             (UpdateResponses "Receipt mode unchanged" "Receipt mode updated" Event)
+             (UpdateResult Event),
+    updateConversationReceiptMode ::
+      routes
+        :- Summary "Update receipt mode for a conversation"
+        :> ZUser
+        :> ZConn
+        :> CanThrow ConvAccessDenied
+        :> CanThrow ConvNotFound
+        :> "conversations"
+        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
         :> "receipt-mode"
         :> ReqBody '[JSON] ConversationReceiptModeUpdate
         :> MultiVerb

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -404,6 +404,24 @@ data Api routes = Api
              '[JSON]
              (UpdateResponses "Message timer unchanged" "Message timer updated" Event)
              (UpdateResult Event),
+    -- This endpoint can lead to the following events being sent:
+    -- - ConvReceiptModeUpdate event to members
+    updateConversationReceiptModeUnqualified ::
+      routes
+        :- Summary "Update receipt mode for a conversation"
+        :> ZUser
+        :> ZConn
+        :> CanThrow ConvAccessDenied
+        :> CanThrow ConvNotFound
+        :> "conversations"
+        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "receipt-mode"
+        :> ReqBody '[JSON] ConversationReceiptModeUpdate
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             (UpdateResponses "Receipt mode unchanged" "Receipt mode updated" Event)
+             (UpdateResult Event),
     getConversationSelfUnqualified ::
       routes
         :- Summary "Get self membership properties (deprecated)"

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -100,6 +100,8 @@ servantSitemap =
         GalleyAPI.updateConversationMessageTimerUnqualified =
           Update.updateLocalConversationMessageTimer,
         GalleyAPI.updateConversationMessageTimer = Update.updateConversationMessageTimer,
+        GalleyAPI.updateConversationReceiptModeUnqualified =
+          Update.updateConversationReceiptModeUnqualified,
         GalleyAPI.getConversationSelfUnqualified = Query.getLocalSelf,
         GalleyAPI.updateConversationSelfUnqualified = Update.updateUnqualifiedSelfMember,
         GalleyAPI.updateConversationSelf = Update.updateSelfMember,
@@ -661,26 +663,6 @@ sitemap = do
     errorResponse Error.invalidSelfOp
     errorResponse Error.invalidOne2OneOp
     errorResponse Error.invalidConnectOp
-
-  -- This endpoint can lead to the following events being sent:
-  -- - ConvReceiptModeUpdate event to members
-  put "/conversations/:cnv/receipt-mode" (continue Update.updateConversationReceiptModeH) $
-    zauthUserId
-      .&. zauthConnId
-      .&. capture "cnv"
-      .&. jsonRequest @Public.ConversationReceiptModeUpdate
-      .&. accept "application" "json"
-  document "PUT" "updateConversationReceiptMode" $ do
-    summary "Update receipts mode for a conversation"
-    parameter Path "cnv" bytes' $
-      description "Conversation ID"
-    returns (ref Public.modelEvent)
-    response 200 "Conversation receipt mode updated." end
-    response 204 "Conversation receipt mode unchanged." end
-    body (ref Public.modelConversationReceiptModeUpdate) $
-      description "JSON body"
-    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
-    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvAccessDenied)
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberJoin event to members

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -102,6 +102,7 @@ servantSitemap =
         GalleyAPI.updateConversationMessageTimer = Update.updateConversationMessageTimer,
         GalleyAPI.updateConversationReceiptModeUnqualified =
           Update.updateConversationReceiptModeUnqualified,
+        GalleyAPI.updateConversationReceiptMode = Update.updateConversationReceiptMode,
         GalleyAPI.getConversationSelfUnqualified = Query.getLocalSelf,
         GalleyAPI.updateConversationSelfUnqualified = Update.updateUnqualifiedSelfMember,
         GalleyAPI.updateConversationSelf = Update.updateSelfMember,

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -30,6 +30,7 @@ module Galley.API.Update
     updateConversationName,
     updateConversationAccessH,
     updateConversationReceiptModeUnqualified,
+    updateConversationReceiptMode,
     updateLocalConversationMessageTimer,
     updateConversationMessageTimer,
 
@@ -298,6 +299,18 @@ uncheckedUpdateConversationAccess body usr zcon conv (currentAccess, targetAcces
     usersL = _1
     botsL :: Lens' ([LocalMember], [BotMember]) [BotMember]
     botsL = _2
+
+updateConversationReceiptMode ::
+  UserId ->
+  ConnId ->
+  Qualified ConvId ->
+  Public.ConversationReceiptModeUpdate ->
+  Galley (UpdateResult Event)
+updateConversationReceiptMode usr zcon qcnv update = do
+  localDomain <- viewFederationDomain
+  if qDomain qcnv == localDomain
+    then updateConversationReceiptModeUnqualified usr zcon (qUnqualified qcnv) update
+    else throwM federationNotImplemented
 
 updateConversationReceiptModeUnqualified ::
   UserId ->

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -29,7 +29,7 @@ module Galley.API.Update
     updateUnqualifiedConversationName,
     updateConversationName,
     updateConversationAccessH,
-    updateConversationReceiptModeH,
+    updateConversationReceiptModeUnqualified,
     updateLocalConversationMessageTimer,
     updateConversationMessageTimer,
 
@@ -299,13 +299,13 @@ uncheckedUpdateConversationAccess body usr zcon conv (currentAccess, targetAcces
     botsL :: Lens' ([LocalMember], [BotMember]) [BotMember]
     botsL = _2
 
-updateConversationReceiptModeH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.ConversationReceiptModeUpdate ::: JSON -> Galley Response
-updateConversationReceiptModeH (usr ::: zcon ::: cnv ::: req ::: _) = do
-  update <- fromJsonBody req
-  handleUpdateResult <$> updateConversationReceiptMode usr zcon cnv update
-
-updateConversationReceiptMode :: UserId -> ConnId -> ConvId -> Public.ConversationReceiptModeUpdate -> Galley (UpdateResult Event)
-updateConversationReceiptMode usr zcon cnv receiptModeUpdate@(Public.ConversationReceiptModeUpdate target) = do
+updateConversationReceiptModeUnqualified ::
+  UserId ->
+  ConnId ->
+  ConvId ->
+  Public.ConversationReceiptModeUpdate ->
+  Galley (UpdateResult Event)
+updateConversationReceiptModeUnqualified usr zcon cnv receiptModeUpdate@(Public.ConversationReceiptModeUpdate target) = do
   localDomain <- viewFederationDomain
   let qcnv = Qualified cnv localDomain
       qusr = Qualified usr localDomain


### PR DESCRIPTION
Converted endpoint to Servant, made a qualified version and deprecated the unqualified one. This is part of https://wearezeta.atlassian.net/browse/SQCORE-885.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
