### PR TITLE
Federation: support read receipts

### DIFF
--- a/changelog.d/5-internal/member-update-refactoring
+++ b/changelog.d/5-internal/member-update-refactoring
@@ -1,0 +1,3 @@
+Refactored a few functions dealing with conversation updates, in an attempt to
+make the conversation update code paths more uniform, and also reduce special
+cases for local and remote objects.

--- a/changelog.d/6-federation/fed-receipt-mode
+++ b/changelog.d/6-federation/fed-receipt-mode
@@ -1,0 +1,1 @@
+Notify remote users when a conversation receipt mode is updated

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationUpdate.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationUpdate.hs
@@ -28,7 +28,7 @@ import Data.Qualified (Qualified (Qualified))
 import qualified Data.UUID as UUID
 import Imports
 import Wire.API.Conversation.Action
-import Wire.API.Conversation.Role (roleNameWireAdmin, roleNameWireMember)
+import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.Federation.API.Galley (ConversationUpdate (..))
 
 qAlice, qBob :: Qualified UserId
@@ -56,7 +56,7 @@ testObject_ConversationUpdate1 =
       cuConvId =
         Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000006")),
       cuAlreadyPresentUsers = [],
-      cuAction = ConversationActionAddMembers ((qAlice, roleNameWireMember) :| [(qBob, roleNameWireAdmin)])
+      cuAction = ConversationActionAddMembers (qAlice :| [qBob]) roleNameWireAdmin
     }
 
 testObject_ConversationUpdate2 :: ConversationUpdate
@@ -70,5 +70,5 @@ testObject_ConversationUpdate2 =
       cuConvId =
         Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000006")),
       cuAlreadyPresentUsers = [chad, dee],
-      cuAction = ConversationActionRemoveMembers (qAlice :| [qBob])
+      cuAction = ConversationActionRemoveMember (qAlice)
     }

--- a/libs/wire-api-federation/test/golden/testObject_ConversationUpdate1.json
+++ b/libs/wire-api-federation/test/golden/testObject_ConversationUpdate1.json
@@ -13,15 +13,12 @@
                     "domain": "golden.example.com",
                     "id": "00000000-0000-0000-0000-000100004007"
                 },
-                "wire_member"
-            ],
-            [
                 {
                     "domain": "golden2.example.com",
                     "id": "00000000-0000-0000-0000-000100005007"
-                },
-                "wire_admin"
-            ]
+                }
+            ],
+            "wire_admin"
         ]
     },
     "conv_id": "00000000-0000-0000-0000-000100000006"

--- a/libs/wire-api-federation/test/golden/testObject_ConversationUpdate2.json
+++ b/libs/wire-api-federation/test/golden/testObject_ConversationUpdate2.json
@@ -9,17 +9,11 @@
     ],
     "time": "1864-04-12T12:22:43.673Z",
     "action": {
-        "tag": "ConversationActionRemoveMembers",
-        "contents": [
-            {
-                "domain": "golden.example.com",
-                "id": "00000000-0000-0000-0000-000100004007"
-            },
-            {
-                "domain": "golden2.example.com",
-                "id": "00000000-0000-0000-0000-000100005007"
-            }
-        ]
+        "tag": "ConversationActionRemoveMember",
+        "contents": {
+            "domain": "golden.example.com",
+            "id": "00000000-0000-0000-0000-000100004007"
+        }
     },
     "conv_id": "00000000-0000-0000-0000-000100000006"
 }

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -69,10 +69,12 @@ conversationActionToEvent now quid qcnv (ConversationActionMemberUpdate target (
   let update = MemberUpdateData target Nothing Nothing Nothing Nothing Nothing Nothing role
    in Event MemberStateUpdate qcnv quid now (EdMemberUpdate update)
 
-conversationActionTag :: ConversationAction -> Action
-conversationActionTag (ConversationActionAddMembers _ _) = AddConversationMember
-conversationActionTag (ConversationActionRemoveMember _) = RemoveConversationMember
-conversationActionTag (ConversationActionRename _) = ModifyConversationName
-conversationActionTag (ConversationActionMessageTimerUpdate _) = ModifyConversationMessageTimer
-conversationActionTag (ConversationActionReceiptModeUpdate _) = ModifyConversationReceiptMode
-conversationActionTag (ConversationActionMemberUpdate _ _) = ModifyOtherConversationMember
+conversationActionTag :: Qualified UserId -> ConversationAction -> Action
+conversationActionTag _ (ConversationActionAddMembers _ _) = AddConversationMember
+conversationActionTag qusr (ConversationActionRemoveMember victim)
+  | qusr == victim = LeaveConversation
+  | otherwise = RemoveConversationMember
+conversationActionTag _ (ConversationActionRename _) = ModifyConversationName
+conversationActionTag _ (ConversationActionMessageTimerUpdate _) = ModifyConversationMessageTimer
+conversationActionTag _ (ConversationActionReceiptModeUpdate _) = ModifyConversationReceiptMode
+conversationActionTag _ (ConversationActionMemberUpdate _ _) = ModifyOtherConversationMember

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -452,7 +452,6 @@ data Api routes = Api
         :- Summary "Update self membership properties (deprecated)"
         :> Description "Use `/conversations/:domain/:conv/self` instead."
         :> CanThrow ConvNotFound
-        :> CanThrow ConvAccessDenied
         :> ZUser
         :> ZConn
         :> "conversations"
@@ -469,7 +468,6 @@ data Api routes = Api
         :- Summary "Update self membership properties"
         :> Description "**Note**: at least one field has to be provided."
         :> CanThrow ConvNotFound
-        :> CanThrow ConvAccessDenied
         :> ZUser
         :> ZConn
         :> "conversations"

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0341ec52f506f40a39b7329c4eeccdccf25bcffc81318f535602bfc17e655f58
+-- hash: 0f1a6ec2e6bf117e21a1b8da6d851d6a5a60cd553c803a079a07aedefbcf0233
 
 name:           galley
 version:        0.83.0
@@ -67,6 +67,7 @@ library
       Galley.Queue
       Galley.Run
       Galley.Types.Clients
+      Galley.Types.UserList
       Galley.Validation
       Main
   other-modules:

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -29,9 +29,10 @@ import Control.Monad.Catch
 import Data.Id
 import Data.List1 (list1)
 import Data.Misc (FutureWork (FutureWork))
-import Data.Qualified (Qualified (..), Remote, partitionRemoteOrLocalIds')
+import Data.Qualified
 import Data.Range
 import qualified Data.Set as Set
+import Data.Tagged
 import Data.Time
 import qualified Data.UUID.Tagged as U
 import Galley.API.Error
@@ -41,7 +42,8 @@ import Galley.App
 import qualified Galley.Data as Data
 import Galley.Intra.Push
 import Galley.Types
-import Galley.Types.Teams (ListType (..), Perm (..), TeamBinding (Binding), notTeamMember, teamMembers, userId)
+import Galley.Types.Teams (ListType (..), Perm (..), TeamBinding (Binding), notTeamMember)
+import Galley.Types.UserList
 import Galley.Validation
 import Imports hiding ((\\))
 import Network.HTTP.Types
@@ -93,25 +95,24 @@ ensureNoLegalholdConflicts remotes locals = do
 -- | A helper for creating a regular (non-team) group conversation.
 createRegularGroupConv :: UserId -> ConnId -> NewConvUnmanaged -> Galley ConversationResponse
 createRegularGroupConv zusr zcon (NewConvUnmanaged body) = do
-  localDomain <- viewFederationDomain
+  lusr <- qualifyLocal zusr
   name <- rangeCheckedMaybe (newConvName body)
   let unqualifiedUserIds = newConvUsers body
       qualifiedUserIds = newConvQualifiedUsers body
-  let allUsers = map (`Qualified` localDomain) unqualifiedUserIds <> qualifiedUserIds
+      allUsers =
+        toUserList lusr $
+          map (unTagged . qualifyAs lusr) unqualifiedUserIds <> qualifiedUserIds
   checkedUsers <- checkedConvSize allUsers
-  let checkedPartitionedUsers = partitionRemoteOrLocalIds' localDomain <$> checkedUsers
-  let (remotes, locals) = fromConvSize checkedPartitionedUsers
-  ensureConnected zusr locals
-  checkRemoteUsersExist remotes
-  ensureNoLegalholdConflicts remotes locals
+  ensureConnected zusr (ulLocals allUsers)
+  checkRemoteUsersExist (ulRemotes allUsers)
+  ensureNoLegalholdConflicts (ulRemotes allUsers) (ulLocals allUsers)
   c <-
     Data.createConversation
-      localDomain
-      zusr
+      lusr
       name
       (access body)
       (accessRole body)
-      checkedPartitionedUsers
+      checkedUsers
       (newConvTeam body)
       (newConvMessageTimer body)
       (newConvReceiptMode body)
@@ -120,59 +121,47 @@ createRegularGroupConv zusr zcon (NewConvUnmanaged body) = do
   conversationCreated zusr c
 
 -- | A helper for creating a team group conversation, used by the endpoint
--- handlers above. Allows both unmanaged and managed conversations.
+-- handlers above. Only supports unmanaged conversations.
 createTeamGroupConv :: UserId -> ConnId -> Public.ConvTeamInfo -> Public.NewConv -> Galley ConversationResponse
 createTeamGroupConv zusr zcon tinfo body = do
-  localDomain <- viewFederationDomain
+  lusr <- qualifyLocal zusr
   name <- rangeCheckedMaybe (newConvName body)
   let unqualifiedUserIds = newConvUsers body
       qualifiedUserIds = newConvQualifiedUsers body
-      allUserIds = map (`Qualified` localDomain) unqualifiedUserIds <> qualifiedUserIds
-  let convTeam = cnvTeamId tinfo
+      allUsers =
+        toUserList lusr $
+          map (unTagged . qualifyAs lusr) unqualifiedUserIds <> qualifiedUserIds
+      convTeam = cnvTeamId tinfo
+
   zusrMembership <- Data.teamMember convTeam zusr
   void $ permissionCheck CreateConversation zusrMembership
-  checkedUsers <- checkedConvSize allUserIds
-  let checkedPartitionedUsers = partitionRemoteOrLocalIds' localDomain <$> checkedUsers
-      (remotes, localUserIds) = fromConvSize checkedPartitionedUsers
-  convLocalMemberships <- mapM (Data.teamMember convTeam) localUserIds
-  ensureAccessRole (accessRole body) (zip localUserIds convLocalMemberships)
-  checkedPartitionedUsersManaged <-
-    if cnvManaged tinfo
-      then do
-        -- ConvMaxSize MUST be < than hardlimit so the conv size check is enough
-        maybeAllMembers <- Data.teamMembersForFanout convTeam
-        let otherConvMems = filter (/= zusr) $ map (view userId) $ (maybeAllMembers ^. teamMembers)
-        checkedLocalUsers <- checkedConvSize otherConvMems
-        -- NOTE: Team members are local, therefore there are no remote users in
-        -- this case
-        pure (fmap ([],) checkedLocalUsers)
-      else do
-        -- In teams we don't have 1:1 conversations, only regular conversations. We want
-        -- users without the 'AddRemoveConvMember' permission to still be able to create
-        -- regular conversations, therefore we check for 'AddRemoveConvMember' only if
-        -- there are going to be more than two users in the conversation.
-        -- FUTUREWORK: We keep this permission around because not doing so will break backwards
-        -- compatibility in the sense that the team role 'partners' would be able to create group
-        -- conversations (which they should not be able to).
-        -- Not sure at the moment how to best solve this but it is unlikely
-        -- we can ever get rid of the team permission model anyway - the only thing I can
-        -- think of is that 'partners' can create convs but not be admins...
-        when (length allUserIds > 1) $ do
-          void $ permissionCheck DoNotUseDeprecatedAddRemoveConvMember zusrMembership
-        -- Team members are always considered to be connected, so we only check
-        -- 'ensureConnected' for non-team-members.
-        ensureConnectedToLocals zusr (notTeamMember localUserIds (catMaybes convLocalMemberships))
-        pure checkedPartitionedUsers
-  checkRemoteUsersExist remotes
-  ensureNoLegalholdConflicts remotes localUserIds
+  checkedUsers <- checkedConvSize allUsers
+  convLocalMemberships <- mapM (Data.teamMember convTeam) (ulLocals allUsers)
+  ensureAccessRole (accessRole body) (zip (ulLocals allUsers) convLocalMemberships)
+  -- In teams we don't have 1:1 conversations, only regular conversations. We want
+  -- users without the 'AddRemoveConvMember' permission to still be able to create
+  -- regular conversations, therefore we check for 'AddRemoveConvMember' only if
+  -- there are going to be more than two users in the conversation.
+  -- FUTUREWORK: We keep this permission around because not doing so will break backwards
+  -- compatibility in the sense that the team role 'partners' would be able to create group
+  -- conversations (which they should not be able to).
+  -- Not sure at the moment how to best solve this but it is unlikely
+  -- we can ever get rid of the team permission model anyway - the only thing I can
+  -- think of is that 'partners' can create convs but not be admins...
+  when (length allUsers > 1) $ do
+    void $ permissionCheck DoNotUseDeprecatedAddRemoveConvMember zusrMembership
+  -- Team members are always considered to be connected, so we only check
+  -- 'ensureConnected' for non-team-members.
+  ensureConnectedToLocals zusr (notTeamMember (ulLocals allUsers) (catMaybes convLocalMemberships))
+  checkRemoteUsersExist (ulRemotes allUsers)
+  ensureNoLegalholdConflicts (ulRemotes allUsers) (ulLocals allUsers)
   conv <-
     Data.createConversation
-      localDomain
-      zusr
+      lusr
       name
       (access body)
       (accessRole body)
-      checkedPartitionedUsersManaged
+      checkedUsers
       (newConvTeam body)
       (newConvMessageTimer body)
       (newConvReceiptMode body)
@@ -187,16 +176,17 @@ createTeamGroupConv zusr zcon tinfo body = do
 
 createSelfConversation :: UserId -> Galley ConversationResponse
 createSelfConversation zusr = do
+  lusr <- qualifyLocal zusr
   c <- Data.conversation (Id . toUUID $ zusr)
-  maybe create (conversationExisted zusr) c
+  maybe (create lusr) (conversationExisted zusr) c
   where
-    create = do
-      localDomain <- viewFederationDomain
-      c <- Data.createSelfConversation localDomain zusr Nothing
+    create lusr = do
+      c <- Data.createSelfConversation lusr Nothing
       conversationCreated zusr c
 
 createOne2OneConversation :: UserId -> ConnId -> NewConvUnmanaged -> Galley ConversationResponse
 createOne2OneConversation zusr zcon (NewConvUnmanaged j) = do
+  lusr <- qualifyLocal zusr
   otherUserId <- head . fromRange <$> (rangeChecked (newConvUsers j) :: Galley (Range 1 1 [UserId]))
   (x, y) <- toUUIDs zusr otherUserId
   when (x == y) $
@@ -211,7 +201,7 @@ createOne2OneConversation zusr zcon (NewConvUnmanaged j) = do
       ensureConnected zusr [otherUserId]
   n <- rangeCheckedMaybe (newConvName j)
   c <- Data.conversation (Data.one2OneConvId x y)
-  maybe (create x y n $ newConvTeam j) (conversationExisted zusr) c
+  maybe (create lusr x y n $ newConvTeam j) (conversationExisted zusr) c
   where
     verifyMembership tid u = do
       membership <- Data.teamMember tid u
@@ -226,9 +216,8 @@ createOne2OneConversation zusr zcon (NewConvUnmanaged j) = do
           verifyMembership tid y
         Just _ -> throwM nonBindingTeam
         Nothing -> throwM teamNotFound
-    create x y n tinfo = do
-      localDomain <- viewFederationDomain
-      c <- Data.createOne2OneConversation localDomain x y n (cnvTeamId <$> tinfo)
+    create lusr x y n tinfo = do
+      c <- Data.createOne2OneConversation lusr x y n (cnvTeamId <$> tinfo)
       notifyCreatedConversation Nothing zusr (Just zcon) c
       conversationCreated zusr c
 
@@ -239,14 +228,17 @@ createConnectConversationH (usr ::: conn ::: req) = do
 
 createConnectConversation :: UserId -> Maybe ConnId -> Connect -> Galley ConversationResponse
 createConnectConversation usr conn j = do
+  lusr <- qualifyLocal usr
   (x, y) <- toUUIDs usr (cRecipient j)
   n <- rangeCheckedMaybe (cName j)
   conv <- Data.conversation (Data.one2OneConvId x y)
-  maybe (create x y n) (update n) conv
+  maybe (create lusr x y n) (update n) conv
   where
-    create x y n = do
-      localDomain <- viewFederationDomain
-      (c, e) <- Data.createConnectConversation localDomain x y n j
+    create lusr x y n = do
+      c <- Data.createConnectConversation lusr x y n
+      now <- liftIO getCurrentTime
+      let lcid = qualifyAs lusr (Data.convId c)
+          e = Event ConvConnect (unTagged lcid) (unTagged lusr) now (EdConnect j)
       notifyCreatedConversation Nothing usr conn c
       for_ (newPushLocal ListComplete usr (ConvEvent e) (recipient <$> Data.convLocalMembers c)) $ \p ->
         push1 $
@@ -255,7 +247,6 @@ createConnectConversation usr conn j = do
             & pushConn .~ conn
       conversationCreated usr c
     update n conv = do
-      localDomain <- viewFederationDomain
       let mems = Data.convLocalMembers conv
        in conversationExisted usr
             =<< if
@@ -263,8 +254,9 @@ createConnectConversation usr conn j = do
                   -- we already were in the conversation, maybe also other
                   connect n conv
                 | otherwise -> do
-                  now <- liftIO getCurrentTime
-                  mm <- snd <$> Data.addMember localDomain now (Data.convId conv) usr
+                  lcid <- qualifyLocal (Data.convId conv)
+                  lusr <- qualifyLocal usr
+                  mm <- Data.addMember lcid lusr
                   let conv' =
                         conv
                           { Data.convLocalMembers = Data.convLocalMembers conv <> toList mm

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -140,7 +140,7 @@ onConversationUpdated requestingDomain cu = do
       pure []
     ConversationActionRename _ -> pure []
     ConversationActionMessageTimerUpdate _ -> pure []
-    ConversationActionMemberUpdate _ -> pure []
+    ConversationActionMemberUpdate _ _ -> pure []
 
   -- Send notifications
   let event = conversationActionToEvent (cuTime cu) (cuOrigUserId cu) qconvId (cuAction cu)

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -18,7 +18,7 @@ module Galley.API.Federation where
 
 import Control.Lens (itraversed, (<.>))
 import Control.Monad.Catch (throwM)
-import Control.Monad.Except (runExceptT)
+import Control.Monad.Trans.Maybe (runMaybeT)
 import Data.ByteString.Conversion (toByteString')
 import Data.Containers.ListUtils (nubOrd)
 import Data.Domain
@@ -35,7 +35,7 @@ import Galley.API.Error (invalidPayload)
 import qualified Galley.API.Mapping as Mapping
 import Galley.API.Message (MessageMetadata (..), UserType (..), postQualifiedOtrMessage, sendLocalMessages)
 import qualified Galley.API.Update as API
-import Galley.API.Util (fromNewRemoteConversation, pushConversationEvent, viewFederationDomain)
+import Galley.API.Util
 import Galley.App (Galley)
 import qualified Galley.Data as Data
 import Galley.Types.Conversations.Members (LocalMember (..), defMemberStatus)
@@ -61,6 +61,7 @@ import Wire.API.Federation.API.Galley
     RemoteMessage (..),
   )
 import qualified Wire.API.Federation.API.Galley as FederationAPIGalley
+import Wire.API.Routes.Public.Galley.Responses (RemoveFromConversationError (..))
 import Wire.API.ServantProto (FromProto (..))
 import Wire.API.User.Client (userClientMap)
 
@@ -130,17 +131,18 @@ onConversationUpdated requestingDomain cu = do
   -- updated, we do **not** add them to the list of targets, because we have no
   -- way to make sure that they are actually supposed to receive that notification.
   extraTargets <- case cuAction cu of
-    ConversationActionAddMembers toAdd -> do
-      let localUsers = getLocalUsers localDomain (fmap fst toAdd)
+    ConversationActionAddMembers toAdd _ -> do
+      let localUsers = getLocalUsers localDomain toAdd
       Data.addLocalMembersToRemoteConv qconvId localUsers
       pure localUsers
-    ConversationActionRemoveMembers toRemove -> do
-      let localUsers = getLocalUsers localDomain toRemove
+    ConversationActionRemoveMember toRemove -> do
+      let localUsers = getLocalUsers localDomain (pure toRemove)
       Data.removeLocalMembersFromRemoteConv qconvId localUsers
       pure []
     ConversationActionRename _ -> pure []
     ConversationActionMessageTimerUpdate _ -> pure []
     ConversationActionMemberUpdate _ _ -> pure []
+    ConversationActionReceiptModeUpdate _ -> pure []
 
   -- Send notifications
   let event = conversationActionToEvent (cuTime cu) (cuOrigUserId cu) qconvId (cuAction cu)
@@ -159,14 +161,23 @@ onConversationUpdated requestingDomain cu = do
   -- FUTUREWORK: support bots?
   pushConversationEvent Nothing event targets []
 
+-- FUTUREWORK: actually return errors as part of the response instead of throwing
 leaveConversation ::
   Domain ->
   LeaveConversationRequest ->
   Galley LeaveConversationResponse
 leaveConversation requestingDomain lc = do
   let leaver = Qualified (lcLeaver lc) requestingDomain
-  fmap LeaveConversationResponse . runExceptT . void $
-    API.removeMemberFromLocalConv leaver Nothing (lcConvId lc) leaver
+  lcnv <- qualifyLocal (lcConvId lc)
+  fmap
+    ( LeaveConversationResponse
+        . maybe (Left RemoveFromConversationErrorUnchanged) Right
+    )
+    . runMaybeT
+    . void
+    . API.updateLocalConversation lcnv leaver Nothing
+    . ConversationActionRemoveMember
+    $ leaver
 
 -- FUTUREWORK: report errors to the originating backend
 -- FUTUREWORK: error handling for missing / mismatched clients

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -768,7 +768,7 @@ deleteTeamConversation zusr zcon tid cid = do
   let qconvId = Qualified cid localDomain
       qusr = Qualified zusr localDomain
   (bots, cmems) <- localBotsAndUsers <$> Data.members cid
-  ensureActionAllowedThrowing Roles.DeleteConversation =<< getSelfMemberFromLocalsLegacy zusr cmems
+  ensureActionAllowed Roles.DeleteConversation =<< getSelfMemberFromLocalsLegacy zusr cmems
   flip Data.deleteCode Data.ReusableCode =<< Data.mkKey cid
   now <- liftIO getCurrentTime
   let ce = Conv.Event Conv.ConvDelete qconvId qusr now Conv.EdConvDelete

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -562,8 +562,9 @@ joinConversation zusr zcon cnv access = do
     -- NOTE: When joining conversations, all users become members
     -- as this is our desired behavior for these types of conversations
     -- where there is no way to control who joins, etc.
+    let users = filter (notIsConvMember lusr conv) [zusr]
     (extraTargets, action) <-
-      addMembersToLocalConversation lcnv (UserList [zusr] []) roleNameWireMember
+      addMembersToLocalConversation lcnv (UserList users []) roleNameWireMember
     lift $
       notifyConversationMetadataUpdate
         (unTagged lusr)

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -395,9 +395,7 @@ updateLocalConversation lcnv qusr con action = do
         (lUnqualified lcnv)
 
   -- perform checks
-  lift $ do
-    ensureConversationActionAllowed action self
-    ensureGroupConvThrowing conv
+  lift $ ensureConversationActionAllowed action conv self
 
   -- perform action
   (extraTargets, action') <- performAction qusr conv action
@@ -1131,25 +1129,6 @@ rmBot zusr zcon b = do
 
 -------------------------------------------------------------------------------
 -- Helpers
-
-data GroupConvInvalidOp
-  = GroupConvInvalidOpSelfConv
-  | GroupConvInvalidOpOne2OneConv
-  | GroupConvInvalidOpConnectConv
-
-ensureGroupConv :: ConvType -> Either GroupConvInvalidOp ()
-ensureGroupConv = \case
-  SelfConv -> Left GroupConvInvalidOpSelfConv
-  One2OneConv -> Left GroupConvInvalidOpOne2OneConv
-  ConnectConv -> Left GroupConvInvalidOpConnectConv
-  _ -> Right ()
-
-ensureGroupConvThrowing :: MonadThrow m => Data.Conversation -> m ()
-ensureGroupConvThrowing c = case ensureGroupConv (Data.convType c) of
-  Left GroupConvInvalidOpSelfConv -> throwM invalidSelfOp
-  Left GroupConvInvalidOpOne2OneConv -> throwM invalidOne2OneOp
-  Left GroupConvInvalidOpConnectConv -> throwM invalidConnectOp
-  Right () -> return ()
 
 ensureMemberLimit :: Foldable f => [LocalMember] -> f a -> Galley ()
 ensureMemberLimit old new = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -664,7 +664,7 @@ updateOtherMemberLocalConv lcnv lusr zcon qvictim update = do
       (lUnqualified lusr)
       (lUnqualified lcnv)
   ensureActionAllowedThrowing ModifyOtherConversationMember self
-  void $ ensureOtherMember lusr qvictim (Data.convLocalMembers conv) (Data.convRemoteMembers conv)
+  void $ ensureOtherMember lusr qvictim conv
   Data.updateOtherMemberLocalConv lcnv qvictim update
   void $
     notifyConversationMetadataUpdate

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -377,13 +377,12 @@ getSelfMemberFromLocalsLegacy usr lmems =
 ensureOtherMember ::
   Local a ->
   Qualified UserId ->
-  [LocalMember] ->
-  [RemoteMember] ->
+  Data.Conversation ->
   Galley (Either LocalMember RemoteMember)
-ensureOtherMember loc quid locals remotes =
+ensureOtherMember loc quid conv =
   maybe (throwErrorDescriptionType @ConvMemberNotFound) pure $
-    (Left <$> find ((== quid) . (`Qualified` lDomain loc) . lmId) locals)
-      <|> (Right <$> find ((== quid) . unTagged . rmId) remotes)
+    (Left <$> find ((== quid) . (`Qualified` lDomain loc) . lmId) (Data.convLocalMembers conv))
+      <|> (Right <$> find ((== quid) . unTagged . rmId) (Data.convRemoteMembers conv))
 
 -- | Note that we use 2 nearly identical functions but slightly different
 -- semantics; when using `getSelfMemberQualified`, if that user is _not_ part of

--- a/services/galley/src/Galley/Data/Services.hs
+++ b/services/galley/src/Galley/Data/Services.hs
@@ -52,6 +52,12 @@ import Imports
 -- FUTUREWORK(federation): allow remote bots
 newtype BotMember = BotMember {fromBotMember :: LocalMember}
 
+instance Eq BotMember where
+  (==) = (==) `on` botMemId
+
+instance Ord BotMember where
+  compare = compare `on` botMemId
+
 newBotMember :: LocalMember -> Maybe BotMember
 newBotMember m = const (BotMember m) <$> lmService m
 

--- a/services/galley/src/Galley/Types/UserList.hs
+++ b/services/galley/src/Galley/Types/UserList.hs
@@ -1,0 +1,44 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Types.UserList
+  ( UserList (..),
+    toUserList,
+    ulAddLocal,
+    ulAll,
+  )
+where
+
+import Data.Qualified
+import Data.Tagged
+import Imports
+
+-- | A list of users, partitioned into locals and remotes
+data UserList a = UserList
+  { ulLocals :: [a],
+    ulRemotes :: [Remote a]
+  }
+  deriving (Functor, Foldable, Traversable)
+
+toUserList :: Foldable f => Local x -> f (Qualified a) -> UserList a
+toUserList loc = uncurry (flip UserList) . partitionRemoteOrLocalIds' (lDomain loc)
+
+ulAddLocal :: a -> UserList a -> UserList a
+ulAddLocal x ul = ul {ulLocals = x : ulLocals ul}
+
+ulAll :: Local x -> UserList a -> [Qualified a]
+ulAll loc ul = map (unTagged . qualifyAs loc) (ulLocals ul) <> map unTagged (ulRemotes ul)

--- a/services/galley/src/Galley/Validation.hs
+++ b/services/galley/src/Galley/Validation.hs
@@ -20,10 +20,7 @@ module Galley.Validation
     rangeCheckedMaybe,
     fromConvSize,
     ConvSizeChecked,
-    ConvMemberAddSizeChecked,
-    fromMemberAddSizeChecked,
     checkedConvSize,
-    checkedMemberAddSize,
   )
 where
 
@@ -56,20 +53,6 @@ checkedConvSize x = do
   if length x < fromIntegral limit
     then return (ConvSizeChecked x)
     else throwErr (errorMsg minV limit "")
-
--- Between 1 and setMaxConvSize
-data ConvMemberAddSizeChecked f a = ConvMemberAddSizeChecked {fromMemberAddSizeChecked :: f a}
-  deriving (Functor, Foldable, Traversable)
-
-checkedMemberAddSize :: Foldable f => f a -> Galley (ConvMemberAddSizeChecked f a)
-checkedMemberAddSize new
-  | null new =
-    throwErr "List of members (local or remote) to be added must be of at least size 1"
-  | otherwise = do
-    limit <- view (options . optSettings . setMaxConvSize)
-    if length new <= fromIntegral limit
-      then pure (ConvMemberAddSizeChecked new)
-      else throwErr (errorMsg (1 :: Integer) limit "")
 
 throwErr :: String -> Galley a
 throwErr = throwM . invalidRange . fromString

--- a/services/galley/src/Galley/Validation.hs
+++ b/services/galley/src/Galley/Validation.hs
@@ -19,10 +19,9 @@ module Galley.Validation
   ( rangeChecked,
     rangeCheckedMaybe,
     fromConvSize,
-    sizeCheckedLocals,
-    sizeCheckedRemotes,
     ConvSizeChecked,
     ConvMemberAddSizeChecked,
+    fromMemberAddSizeChecked,
     checkedConvSize,
     checkedMemberAddSize,
   )
@@ -30,13 +29,10 @@ where
 
 import Control.Lens
 import Control.Monad.Catch
-import Data.Id (UserId)
-import Data.Qualified (Remote)
 import Data.Range
 import Galley.API.Error
 import Galley.App
 import Galley.Options
-import Galley.Types.Conversations.Roles (RoleName)
 import Imports
 
 rangeChecked :: Within a n m => a -> Galley (Range n m a)
@@ -49,29 +45,31 @@ rangeCheckedMaybe (Just a) = Just <$> rangeChecked a
 {-# INLINE rangeCheckedMaybe #-}
 
 -- Between 0 and (setMaxConvSize - 1)
-newtype ConvSizeChecked a = ConvSizeChecked {fromConvSize :: a}
-  deriving (Functor)
+newtype ConvSizeChecked f a = ConvSizeChecked {fromConvSize :: f a}
+  deriving (Functor, Foldable, Traversable)
 
--- Between 1 and setMaxConvSize
-data ConvMemberAddSizeChecked = ConvMemberAddSizeChecked {sizeCheckedLocals :: [(UserId, RoleName)], sizeCheckedRemotes :: [(Remote UserId, RoleName)]}
-
-checkedConvSize :: Bounds a => a -> Galley (ConvSizeChecked a)
+checkedConvSize :: Foldable f => f a -> Galley (ConvSizeChecked f a)
 checkedConvSize x = do
   o <- view options
   let minV :: Integer = 0
       limit = o ^. optSettings . setMaxConvSize - 1
-  if within x minV (fromIntegral limit)
+  if length x < fromIntegral limit
     then return (ConvSizeChecked x)
     else throwErr (errorMsg minV limit "")
 
-checkedMemberAddSize :: [(UserId, RoleName)] -> [(Remote UserId, RoleName)] -> Galley ConvMemberAddSizeChecked
-checkedMemberAddSize [] [] = throwErr "List of members (local or remote) to be added must be of at least size 1"
-checkedMemberAddSize locals remotes = do
-  o <- view options
-  let limit = o ^. optSettings . setMaxConvSize
-  if length locals + length remotes < fromIntegral limit
-    then return (ConvMemberAddSizeChecked locals remotes)
-    else throwErr (errorMsg (1 :: Integer) limit "")
+-- Between 1 and setMaxConvSize
+data ConvMemberAddSizeChecked f a = ConvMemberAddSizeChecked {fromMemberAddSizeChecked :: f a}
+  deriving (Functor, Foldable, Traversable)
+
+checkedMemberAddSize :: Foldable f => f a -> Galley (ConvMemberAddSizeChecked f a)
+checkedMemberAddSize new
+  | null new =
+    throwErr "List of members (local or remote) to be added must be of at least size 1"
+  | otherwise = do
+    limit <- view (options . optSettings . setMaxConvSize)
+    if length new <= fromIntegral limit
+      then pure (ConvMemberAddSizeChecked new)
+      else throwErr (errorMsg (1 :: Integer) limit "")
 
 throwErr :: String -> Galley a
 throwErr = throwM . invalidRange . fromString

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -197,6 +197,7 @@ tests s =
           test s "remote conversation member update (otr hidden)" putRemoteConvMemberHiddenOk,
           test s "remote conversation member update (everything)" putRemoteConvMemberAllOk,
           test s "conversation receipt mode update" putReceiptModeOk,
+          test s "conversation receipt mode update with remote members" putReceiptModeWithRemotesOk,
           test s "send typing indicators" postTypingIndicators,
           test s "leave connect conversation" leaveConnectConversation,
           test s "post conversations/:cnv/otr/message: message delivery and missing clients" postCryptoMessage1,
@@ -2902,6 +2903,44 @@ putReceiptModeOk = do
         EdConvReceiptModeUpdate (ConversationReceiptModeUpdate (ReceiptMode mode)) ->
           assertEqual "modes should match" mode 0
         _ -> assertFailure "Unexpected event data"
+
+putReceiptModeWithRemotesOk :: TestM ()
+putReceiptModeWithRemotesOk = do
+  c <- view tsCannon
+  let remoteDomain = Domain "alice.example.com"
+  qalice <- Qualified <$> randomId <*> pure remoteDomain
+  qbob <- randomQualifiedUser
+  let bob = qUnqualified qbob
+
+  resp <- postConvWithRemoteUser remoteDomain (mkProfile qalice (Name "Alice")) bob [qalice]
+  let qconv = decodeQualifiedConvId resp
+
+  opts <- view tsGConf
+  WS.bracketR c bob $ \wsB -> do
+    (_, requests) <-
+      withTempMockFederator opts remoteDomain (const ()) $
+        putQualifiedReceiptMode bob qconv (ReceiptMode 43) !!! const 200 === statusCode
+
+    req <- assertOne requests
+    liftIO $ do
+      F.domain req @?= domainText remoteDomain
+      fmap F.component (F.request req) @?= Just F.Galley
+      fmap F.path (F.request req) @?= Just "/federation/on-conversation-updated"
+      Just (Right cu) <- pure $ fmap (eitherDecode . LBS.fromStrict . F.body) (F.request req)
+      FederatedGalley.cuConvId cu @?= qUnqualified qconv
+      FederatedGalley.cuAction cu
+        @?= ConversationActionReceiptModeUpdate
+          (ConversationReceiptModeUpdate (ReceiptMode 43))
+
+    void . liftIO . WS.assertMatch (5 # Second) wsB $ \n -> do
+      let e = List1.head (WS.unpackPayload n)
+      ntfTransient n @?= False
+      evtConv e @?= qconv
+      evtType e @?= ConvReceiptModeUpdate
+      evtFrom e @?= qbob
+      evtData e
+        @?= EdConvReceiptModeUpdate
+          (ConversationReceiptModeUpdate (ReceiptMode 43))
 
 postTypingIndicators :: TestM ()
 postTypingIndicators = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1322,7 +1322,7 @@ paginateConvListIds = do
               FederatedGalley.cuOrigUserId = qChad,
               FederatedGalley.cuConvId = conv,
               FederatedGalley.cuAlreadyPresentUsers = [],
-              FederatedGalley.cuAction = ConversationActionAddMembers $ pure (qAlice, roleNameWireMember)
+              FederatedGalley.cuAction = ConversationActionAddMembers (pure qAlice) roleNameWireMember
             }
     FederatedGalley.onConversationUpdated fedGalleyClient chadDomain cu
 
@@ -1337,7 +1337,7 @@ paginateConvListIds = do
               FederatedGalley.cuOrigUserId = qDee,
               FederatedGalley.cuConvId = conv,
               FederatedGalley.cuAlreadyPresentUsers = [],
-              FederatedGalley.cuAction = ConversationActionAddMembers $ pure (qAlice, roleNameWireMember)
+              FederatedGalley.cuAction = ConversationActionAddMembers (pure qAlice) roleNameWireMember
             }
     FederatedGalley.onConversationUpdated fedGalleyClient deeDomain cu
 
@@ -1380,7 +1380,7 @@ paginateConvListIdsPageEndingAtLocalsAndDomain = do
               FederatedGalley.cuOrigUserId = qChad,
               FederatedGalley.cuConvId = conv,
               FederatedGalley.cuAlreadyPresentUsers = [],
-              FederatedGalley.cuAction = ConversationActionAddMembers $ pure (qAlice, roleNameWireMember)
+              FederatedGalley.cuAction = ConversationActionAddMembers (pure qAlice) roleNameWireMember
             }
     FederatedGalley.onConversationUpdated fedGalleyClient chadDomain cu
 
@@ -1396,7 +1396,7 @@ paginateConvListIdsPageEndingAtLocalsAndDomain = do
               FederatedGalley.cuOrigUserId = qDee,
               FederatedGalley.cuConvId = conv,
               FederatedGalley.cuAlreadyPresentUsers = [],
-              FederatedGalley.cuAction = ConversationActionAddMembers $ pure (qAlice, roleNameWireMember)
+              FederatedGalley.cuAction = ConversationActionAddMembers (pure qAlice) roleNameWireMember
             }
     FederatedGalley.onConversationUpdated fedGalleyClient deeDomain cu
 
@@ -2790,7 +2790,7 @@ putRemoteConvMemberOk update = do
             cuConvId = qUnqualified qconv,
             cuAlreadyPresentUsers = [],
             cuAction =
-              ConversationActionAddMembers (pure (qalice, roleNameWireMember))
+              ConversationActionAddMembers (pure qalice) roleNameWireMember
           }
   FederatedGalley.onConversationUpdated fedGalleyClient remoteDomain cu
 

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -71,6 +71,7 @@ tests s =
       test s "POST /federation/on-conversation-updated : Notify local user about conversation rename" notifyConvRename,
       test s "POST /federation/on-conversation-updated : Notify local user about message timer update" notifyMessageTimer,
       test s "POST /federation/on-conversation-updated : Notify local user about member update" notifyMemberUpdate,
+      test s "POST /federation/on-conversation-updated : Notify local user about receipt mode update" notifyReceiptMode,
       test s "POST /federation/leave-conversation : Success" leaveConversationSuccess,
       test s "POST /federation/on-message-sent : Receive a message from another backend" onMessageSent,
       test s "POST /federation/send-message : Post a message sent from another backend" sendMessage
@@ -354,6 +355,15 @@ notifyMessageTimer = do
     (ConversationActionMessageTimerUpdate d)
     ConvMessageTimerUpdate
     (EdConvMessageTimerUpdate d)
+
+notifyReceiptMode :: TestM ()
+notifyReceiptMode = do
+  let d = ConversationReceiptModeUpdate (ReceiptMode 42)
+  notifyUpdate
+    []
+    (ConversationActionReceiptModeUpdate d)
+    ConvReceiptModeUpdate
+    (EdConvReceiptModeUpdate d)
 
 notifyMemberUpdate :: TestM ()
 notifyMemberUpdate = do

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -360,7 +360,7 @@ notifyMemberUpdate = do
           }
   notifyUpdate
     [qdee]
-    (ConversationActionMemberUpdate d)
+    (ConversationActionMemberUpdate qdee (OtherMemberUpdate (Just roleNameWireAdmin)))
     MemberStateUpdate
     (EdMemberUpdate d)
 

--- a/services/galley/test/integration/API/Roles.hs
+++ b/services/galley/test/integration/API/Roles.hs
@@ -203,7 +203,7 @@ roleUpdateRemoteMember = do
       Just (Right cu) <- pure $ fmap (eitherDecode . LBS.fromStrict . F.body) (F.request req)
       F.cuConvId cu @?= qUnqualified qconv
       F.cuAction cu
-        @?= ConversationActionMemberUpdate mu
+        @?= ConversationActionMemberUpdate qcharlie (OtherMemberUpdate (Just roleNameWireMember))
       sort (F.cuAlreadyPresentUsers cu) @?= sort [qUnqualified qalice, qUnqualified qcharlie]
 
     liftIO . WS.assertMatch_ (5 # Second) wsB $ \n -> do
@@ -274,7 +274,7 @@ roleUpdateWithRemotes = do
       Just (Right cu) <- pure $ fmap (eitherDecode . LBS.fromStrict . F.body) (F.request req)
       F.cuConvId cu @?= qUnqualified qconv
       F.cuAction cu
-        @?= ConversationActionMemberUpdate mu
+        @?= ConversationActionMemberUpdate qcharlie (OtherMemberUpdate (Just roleNameWireAdmin))
       F.cuAlreadyPresentUsers cu @?= [qUnqualified qalice]
 
     liftIO . WS.assertMatchN_ (5 # Second) [wsB, wsC] $ \n -> do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -605,8 +605,8 @@ testRemoveNonBindingTeamMember = do
   mext3 <- Util.randomUser
   Util.connectUsers owner (list1 (mem1 ^. userId) [mem2 ^. userId, mext1, mext2, mext3])
   tid <- Util.createNonBindingTeam "foo" owner [mem1, mem2]
-  -- Managed conversation:
-  void $ Util.createManagedConv owner tid [] (Just "gossip") Nothing Nothing
+  -- This used to be a managed conversation:
+  void $ Util.createTeamConv owner tid [] (Just "gossip") Nothing Nothing
   -- Regular conversation:
   cid2 <- Util.createTeamConv owner tid [mem1 ^. userId, mem2 ^. userId, mext1] (Just "blaa") Nothing Nothing
   -- Member external 2 is a guest and not a part of any conversation that mem1 is a part of
@@ -979,10 +979,11 @@ testDeleteTeam = do
   let p = Util.symmPermissions [DoNotUseDeprecatedAddRemoveConvMember]
   member <- newTeamMember' p <$> Util.randomUser
   extern <- Util.randomUser
+  let members = [owner, member ^. userId]
   Util.connectUsers owner (list1 (member ^. userId) [extern])
   tid <- Util.createNonBindingTeam "foo" owner [member]
   cid1 <- Util.createTeamConv owner tid [] (Just "blaa") Nothing Nothing
-  cid2 <- Util.createManagedConv owner tid [] (Just "blup") Nothing Nothing
+  cid2 <- Util.createTeamConv owner tid members (Just "blup") Nothing Nothing
   Util.assertConvMember owner cid2
   Util.assertConvMember (member ^. userId) cid2
   Util.assertNotConvMember extern cid2
@@ -1165,6 +1166,7 @@ testDeleteTeamConv = do
   owner <- Util.randomUser
   let p = Util.symmPermissions [DoNotUseDeprecatedDeleteConversation]
   member <- newTeamMember' p <$> Util.randomUser
+  let members = [owner, member ^. userId]
   extern <- Util.randomUser
   Util.connectUsers owner (list1 (member ^. userId) [extern])
   tid <- Util.createNonBindingTeam "foo" owner [member]
@@ -1172,7 +1174,7 @@ testDeleteTeamConv = do
   let access = ConversationAccessUpdate [InviteAccess, CodeAccess] ActivatedAccessRole
   putAccessUpdate owner cid1 access !!! const 200 === statusCode
   code <- decodeConvCodeEvent <$> (postConvCode owner cid1 <!! const 201 === statusCode)
-  cid2 <- Util.createManagedConv owner tid [] (Just "blup") Nothing Nothing
+  cid2 <- Util.createTeamConv owner tid members (Just "blup") Nothing Nothing
   Util.postMembers owner (list1 extern [member ^. userId]) cid1 !!! const 200 === statusCode
   for_ [owner, member ^. userId, extern] $ \u -> Util.assertConvMember u cid1
   for_ [owner, member ^. userId] $ \u -> Util.assertConvMember u cid2

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1033,6 +1033,24 @@ putConversationName u c n = do
         . json update
     )
 
+putQualifiedReceiptMode ::
+  (MonadIO m, MonadHttp m, HasGalley m, HasCallStack) =>
+  UserId ->
+  Qualified ConvId ->
+  ReceiptMode ->
+  m ResponseLBS
+putQualifiedReceiptMode u (Qualified c dom) r = do
+  g <- viewGalley
+  let update = ConversationReceiptModeUpdate r
+  put
+    ( g
+        . paths ["conversations", toByteString' dom, toByteString' c, "receipt-mode"]
+        . zUser u
+        . zConn "conn"
+        . zType "access"
+        . json update
+    )
+
 putReceiptMode :: UserId -> ConvId -> ReceiptMode -> TestM ResponseLBS
 putReceiptMode u c r = do
   g <- view tsGalley

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1432,7 +1432,7 @@ assertRemoveUpdate req qconvId remover alreadyPresentUsers victim = liftIO $ do
   FederatedGalley.cuOrigUserId cu @?= remover
   FederatedGalley.cuConvId cu @?= qUnqualified qconvId
   sort (FederatedGalley.cuAlreadyPresentUsers cu) @?= sort alreadyPresentUsers
-  FederatedGalley.cuAction cu @?= ConversationActionRemoveMembers (pure victim)
+  FederatedGalley.cuAction cu @?= ConversationActionRemoveMember victim
 
 -------------------------------------------------------------------------------
 -- Helpers

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -523,26 +523,6 @@ updateTeamConv zusr convid upd = do
         . json upd
     )
 
--- | See Note [managed conversations]
-createManagedConv :: HasCallStack => UserId -> TeamId -> [UserId] -> Maybe Text -> Maybe (Set Access) -> Maybe Milliseconds -> TestM ConvId
-createManagedConv u tid us name acc mtimer = do
-  g <- view tsGalley
-  let tinfo = ConvTeamInfo tid True
-  let conv =
-        NewConvManaged $
-          NewConv us [] name (fromMaybe (Set.fromList []) acc) Nothing (Just tinfo) mtimer Nothing roleNameWireAdmin
-  r <-
-    post
-      ( g
-          . path "i/conversations/managed"
-          . zUser u
-          . zConn "conn"
-          . zType "access"
-          . json conv
-      )
-      <!! const 201 === statusCode
-  fromBS (getHeader' "Location" r)
-
 createOne2OneTeamConv :: UserId -> UserId -> Maybe Text -> TeamId -> TestM ResponseLBS
 createOne2OneTeamConv u1 u2 n tid = do
   g <- view tsGalley


### PR DESCRIPTION
The initial purpose of this PR was to add federation behaviour for receipt mode update, which it does. However, in an effort to avoid copy-pasting code, it also unifies all the federation-aware conversation update code paths, and as a consequence the diff ended up being quite large.

The core of the unified interface is the `updateLocalConversation` function, which performs an update and notifies local and remote users.

**Note**: the remove member update is a bit special, because it was implemented using checked exceptions. To make it compatible with the other updates, checked exceptions are not currently used, although they are still present in some type signatures.

To make the unification possible, a number of other changes were necessary:

 - Removed checked add member wrapper. This wasn't either safe (because it didn't encompass all the necessary size checks) nor necessary (because the checks were already performed by `ensureMemberLimit`).
 - Aligned conversation update RPC to endpoint interface. The generalised RPC interface is not necessary for now (it can always be regeneralised later if needed), and making it the same as the public interface simplifies some things.
 - Separated self-member updates from other-member updates. These are really different anyway, and there was nothing gained by having a common interface.
 - Added some general code to deal with local and remote members uniformly.  This simplifies many functions that can operate on both local and remote members. For example member removal, which is also used for leaving a remote conversation.
 - Introduced a `UserList` type, representing a list of users partitioned into locals and remotes.
 - Removed many of the convenience functions to add members to a conversation.  The default admin role functionality is now implemented using a `ToUserRole` type class.
 - Event creation for adding and removing members or creating conversations is now done outside the `Data` module. This will make it possible to unify the event creation and propagation logic across many conversation endpoints.
 - Many functions operating on lists have been generalised to `Foldable`, so they can work uniformly with `UserList`s and normal lists.
 - The `ConvSizeChecked` newtype was broken, because the `Functor` instance would allow to break the invariant encoded by the type. This is now fixed, and the type can now wrap an arbitrary `Foldable`.
 - Support for creating managed conversations has been dropped

This is part of https://wearezeta.atlassian.net/browse/SQCORE-885 (federated conversation metadata updates).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
