### PR TITLE
Make sure that unnamed schemas are referenced

### DIFF
--- a/changelog.d/4-docs/reference-schemas
+++ b/changelog.d/4-docs/reference-schemas
@@ -1,0 +1,1 @@
+All named Swagger schemas are now displayed in the Swagger UI

--- a/libs/schema-profunctor/src/Data/Schema.hs
+++ b/libs/schema-profunctor/src/Data/Schema.hs
@@ -708,7 +708,9 @@ instance HasSchemaRef doc => HasField doc SwaggerDoc where
 
 instance HasObject SwaggerDoc NamedSwaggerDoc where
   mkObject name decl = S.NamedSchema (Just name) <$> decl
-  unmkObject = fmap S._namedSchemaSchema
+  unmkObject (WithDeclare d (S.NamedSchema Nothing s)) = WithDeclare d s
+  unmkObject (WithDeclare d (S.NamedSchema (Just n) s)) =
+    WithDeclare (d *> S.declare [(n, s)]) s
 
 instance HasSchemaRef ndoc => HasArray ndoc SwaggerDoc where
   mkArray = fmap f . schemaRef

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -313,7 +313,7 @@ newtype SimpleMembers = SimpleMembers
 
 instance ToSchema SimpleMembers where
   schema =
-    object "Members" $
+    object "SimpleMembers" $
       SimpleMembers
         <$> mMembers .= field "users" (array schema)
         <* (fmap smId . mMembers)


### PR DESCRIPTION
This changes the Swagger implementation of `unnamed` in schema-profunctor to drop the name, but still declare the corresponding named schema. Now even unnamed schemas that are not actually referenced anywhere will appear in the list of schemas in Swagger.

Also changed the name of the schema for `SimpleMember` to make it reflect the Haskell type name.

![shot](https://user-images.githubusercontent.com/2141/134367426-ebb53229-b3fa-41d9-b63b-204c82b6fbe1.png)

Thanks @atomrc for reporting this issue.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
