### PR TITLE
Split `MultiTablePaging` module and add haddocks

### DIFF
--- a/changelog.d/4-docs/multitable-docs
+++ b/changelog.d/4-docs/multitable-docs
@@ -1,0 +1,1 @@
+Add documentation of the multi-table paging abstraction

--- a/libs/wire-api/src/Wire/API/Routes/MultiTablePaging.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiTablePaging.hs
@@ -39,7 +39,7 @@ import Wire.API.Routes.MultiTablePaging.State
 --
 --  * @name@   Name of the resources being paginated through
 --  * @tables@ A (usually finite) type that represent the table currently being
---             used (must be an instance of 'PagingTable'
+--             used (must be an instance of 'PagingTable')
 --  * @max@    Maximum page size
 --  * @def@    Default page size
 --
@@ -141,7 +141,7 @@ instance
         <*> mtpPagingState .= field "paging_state" schema
 
 -- | A type to be used as the @tables@ argument of 'GetMultiTablePageRequest'
--- when the resources being paginate through are split into local and remote.
+-- when the resources being paginated through are split into local and remote.
 data LocalOrRemoteTable
   = PagingLocals
   | PagingRemotes

--- a/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
@@ -1,0 +1,73 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Routes.MultiTablePaging.State
+  ( MultiTablePagingState (..),
+    PagingTable (..),
+  )
+where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import qualified Data.Attoparsec.ByteString as AB
+import qualified Data.ByteString as BS
+import Data.Json.Util (fromBase64Text, toBase64Text)
+import Data.Proxy
+import Data.Schema
+import qualified Data.Swagger as S
+import qualified Data.Text as Text
+import GHC.TypeLits
+import Imports
+
+-- | The state of a multi-table paginated query. It is made of a reference to
+-- the table currently being paginated, as well as an opaque token returned by
+-- Cassandra.
+data MultiTablePagingState (name :: Symbol) tables = MultiTablePagingState
+  { mtpsTable :: tables,
+    mtpsState :: Maybe ByteString
+  }
+  deriving stock (Show, Eq)
+  deriving (ToJSON, FromJSON, S.ToSchema) via Schema (MultiTablePagingState name tables)
+
+encodePagingState :: PagingTable tables => MultiTablePagingState name tables -> ByteString
+encodePagingState (MultiTablePagingState table state) =
+  let encodedTable = encodePagingTable table
+      encodedState = fromMaybe "" state
+   in BS.cons encodedTable encodedState
+
+parseConversationPagingState :: PagingTable tables => ByteString -> Either String (MultiTablePagingState name tables)
+parseConversationPagingState = AB.parseOnly conversationPagingStateParser
+
+conversationPagingStateParser :: PagingTable tables => AB.Parser (MultiTablePagingState name tables)
+conversationPagingStateParser = do
+  table <- AB.anyWord8 >>= decodePagingTable
+  state <- (AB.endOfInput $> Nothing) <|> (Just <$> AB.takeByteString <* AB.endOfInput)
+  pure $ MultiTablePagingState table state
+
+-- | A class for values that can be encoded with a single byte. Used to add a
+-- byte of extra information to the paging state in order to recover the table
+-- information from a paging token.
+class PagingTable t where
+  -- Using 'Word8' because 256 tables ought to be enough.
+  encodePagingTable :: t -> Word8
+  decodePagingTable :: MonadFail m => Word8 -> m t
+
+instance (PagingTable tables, KnownSymbol name) => ToSchema (MultiTablePagingState name tables) where
+  schema =
+    (toBase64Text . encodePagingState)
+      .= parsedText
+        (Text.pack (symbolVal (Proxy @name)) <> "_PagingState")
+        (parseConversationPagingState <=< fromBase64Text)

--- a/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
@@ -48,8 +48,8 @@ encodePagingState (MultiTablePagingState table state) =
       encodedState = fromMaybe "" state
    in BS.cons encodedTable encodedState
 
-parseConversationPagingState :: PagingTable tables => ByteString -> Either String (MultiTablePagingState name tables)
-parseConversationPagingState = AB.parseOnly conversationPagingStateParser
+parsePagingState :: PagingTable tables => ByteString -> Either String (MultiTablePagingState name tables)
+parsePagingState = AB.parseOnly conversationPagingStateParser
 
 conversationPagingStateParser :: PagingTable tables => AB.Parser (MultiTablePagingState name tables)
 conversationPagingStateParser = do
@@ -70,4 +70,4 @@ instance (PagingTable tables, KnownSymbol name) => ToSchema (MultiTablePagingSta
     (toBase64Text . encodePagingState)
       .= parsedText
         (Text.pack (symbolVal (Proxy @name)) <> "_PagingState")
-        (parseConversationPagingState <=< fromBase64Text)
+        (parsePagingState <=< fromBase64Text)

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1dce25e4dabf58eac09c8e4f384829306931a35d0c9b902d22d4f29b7a592aae
+-- hash: db0e289b12b344457a40dfe813de29c63bb9e236a45c4407a0f521833fd8cdbe
 
 name:           wire-api
 version:        0.1.0
@@ -50,6 +50,7 @@ library
       Wire.API.Push.Token
       Wire.API.Push.V2.Token
       Wire.API.Routes.MultiTablePaging
+      Wire.API.Routes.MultiTablePaging.State
       Wire.API.Routes.MultiVerb
       Wire.API.Routes.Public
       Wire.API.Routes.Public.Brig


### PR DESCRIPTION
Splitting the state encoding functions to a separate module makes it impossible to use them by mistake with the wrong bytestring (like the Cassandra paging token).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
