### PR TITLE
Servantify access update

### DIFF
--- a/changelog.d/1-api-changes/deprecate-access
+++ b/changelog.d/1-api-changes/deprecate-access
@@ -1,0 +1,1 @@
+Deprecate `PUT /conversations/:cnv/access` endpoint

--- a/changelog.d/1-api-changes/qualified-access
+++ b/changelog.d/1-api-changes/qualified-access
@@ -1,0 +1,1 @@
+Add qualified endpoint for updating conversation access

--- a/changelog.d/5-internal/servantify-access
+++ b/changelog.d/5-internal/servantify-access
@@ -1,2 +1,1 @@
 Convert the `PUT /conversations/:cnv/access` endpoint to Servant
-

--- a/changelog.d/5-internal/servantify-access
+++ b/changelog.d/5-internal/servantify-access
@@ -1,0 +1,2 @@
+Convert the `PUT /conversations/:cnv/access` endpoint to Servant
+

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -307,3 +307,5 @@ type InvalidOpSelfConv = InvalidOp "invalid operation for self conversation"
 type InvalidOpOne2OneConv = InvalidOp "invalid operation for 1:1 conversations"
 
 type InvalidOpConnectConv = InvalidOp "invalid operation for connect conversation"
+
+type InvalidTargetAccess = InvalidOp "invalid target access"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -444,7 +444,8 @@ data Api routes = Api
     -- - ConvAccessUpdate event to members
     updateConversationAccessUnqualified ::
       routes
-        :- Summary "Update access modes for a conversation"
+        :- Summary "Update access modes for a conversation (deprecated)"
+        :> Description "Use PUT `/conversations/:domain/:cnv/access` instead."
         :> ZUser
         :> ZConn
         :> CanThrow ConvAccessDenied
@@ -452,6 +453,23 @@ data Api routes = Api
         :> CanThrow (InvalidOp "Invalid operation")
         :> "conversations"
         :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "access"
+        :> ReqBody '[JSON] ConversationAccessUpdate
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             (UpdateResponses "Access unchanged" "Access updated" Event)
+             (UpdateResult Event),
+    updateConversationAccess ::
+      routes
+        :- Summary "Update access modes for a conversation"
+        :> ZUser
+        :> ZConn
+        :> CanThrow ConvAccessDenied
+        :> CanThrow ConvNotFound
+        :> CanThrow (InvalidOp "Invalid operation")
+        :> "conversations"
+        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
         :> "access"
         :> ReqBody '[JSON] ConversationAccessUpdate
         :> MultiVerb

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -439,6 +439,26 @@ data Api routes = Api
              '[JSON]
              (UpdateResponses "Receipt mode unchanged" "Receipt mode updated" Event)
              (UpdateResult Event),
+    -- This endpoint can lead to the following events being sent:
+    -- - MemberLeave event to members, if members get removed
+    -- - ConvAccessUpdate event to members
+    updateConversationAccessUnqualified ::
+      routes
+        :- Summary "Update access modes for a conversation"
+        :> ZUser
+        :> ZConn
+        :> CanThrow ConvAccessDenied
+        :> CanThrow ConvNotFound
+        :> CanThrow (InvalidOp "Invalid operation")
+        :> "conversations"
+        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+        :> "access"
+        :> ReqBody '[JSON] ConversationAccessUpdate
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             (UpdateResponses "Access unchanged" "Access updated" Event)
+             (UpdateResult Event),
     getConversationSelfUnqualified ::
       routes
         :- Summary "Get self membership properties (deprecated)"

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -87,9 +87,6 @@ invalidAccessOp = invalidOp "invalid operation for conversation without 'code' a
 invalidManagedConvOp :: Error
 invalidManagedConvOp = invalidOp "invalid operation for managed conversation"
 
-invalidTargetAccess :: Error
-invalidTargetAccess = invalidOp "invalid target access"
-
 invalidTargetUserOp :: Error
 invalidTargetUserOp = invalidOp "invalid target user for the given operation"
 

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -103,6 +103,8 @@ servantSitemap =
         GalleyAPI.updateConversationReceiptModeUnqualified =
           Update.updateConversationReceiptModeUnqualified,
         GalleyAPI.updateConversationReceiptMode = Update.updateConversationReceiptMode,
+        GalleyAPI.updateConversationAccessUnqualified =
+          Update.updateConversationAccessUnqualified,
         GalleyAPI.getConversationSelfUnqualified = Query.getLocalSelf,
         GalleyAPI.updateConversationSelfUnqualified = Update.updateUnqualifiedSelfMember,
         GalleyAPI.updateConversationSelf = Update.updateSelfMember,
@@ -640,30 +642,6 @@ sitemap = do
     response 200 "Conversation Code" end
     errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
     errorResponse Error.invalidAccessOp
-
-  -- This endpoint can lead to the following events being sent:
-  -- - MemberLeave event to members, if members get removed
-  -- - ConvAccessUpdate event to members
-  put "/conversations/:cnv/access" (continue Update.updateConversationAccessH) $
-    zauthUserId
-      .&. zauthConnId
-      .&. capture "cnv"
-      .&. jsonRequest @Public.ConversationAccessUpdate
-  document "PUT" "updateConversationAccess" $ do
-    summary "Update access modes for a conversation"
-    parameter Path "cnv" bytes' $
-      description "Conversation ID"
-    returns (ref Public.modelEvent)
-    response 200 "Conversation access updated." end
-    response 204 "Conversation access unchanged." end
-    body (ref Public.modelConversationAccessUpdate) $
-      description "JSON body"
-    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvNotFound)
-    errorResponse (Error.errorDescriptionTypeToWai @Error.ConvAccessDenied)
-    errorResponse Error.invalidTargetAccess
-    errorResponse Error.invalidSelfOp
-    errorResponse Error.invalidOne2OneOp
-    errorResponse Error.invalidConnectOp
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberJoin event to members

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -105,6 +105,7 @@ servantSitemap =
         GalleyAPI.updateConversationReceiptMode = Update.updateConversationReceiptMode,
         GalleyAPI.updateConversationAccessUnqualified =
           Update.updateConversationAccessUnqualified,
+        GalleyAPI.updateConversationAccess = Update.updateConversationAccess,
         GalleyAPI.getConversationSelfUnqualified = Query.getLocalSelf,
         GalleyAPI.updateConversationSelfUnqualified = Update.updateUnqualifiedSelfMember,
         GalleyAPI.updateConversationSelf = Update.updateSelfMember,


### PR DESCRIPTION
Converted endpoint to Servant, made a qualified version and deprecated the unqualified one.

This is part of https://wearezeta.atlassian.net/browse/SQCORE-885.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
