### PR TITLE
Merge http2 grpc fixes

### DIFF
--- a/changelog.d/5-internal/merge-http2-client-fix
+++ b/changelog.d/5-internal/merge-http2-client-fix
@@ -1,1 +1,1 @@
-Merged http2-client fixes as mentioned in #1703
+Merged http2-client fixes as mentioned in the comments of #1703

--- a/changelog.d/5-internal/merge-http2-client-fix
+++ b/changelog.d/5-internal/merge-http2-client-fix
@@ -1,0 +1,1 @@
+Merged http2-client fixes as mentioned in #1703

--- a/stack.yaml
+++ b/stack.yaml
@@ -220,16 +220,21 @@ extra-deps:
 - mu-grpc-common-0.4.0.0
 - compendium-client-0.2.1.1
 # dependencies of mu
-- http2-client-0.10.0.0
 - http2-grpc-types-0.5.0.0
 - http2-grpc-proto3-wire-0.1.0.0
 - warp-grpc-0.4.0.1
 - proto3-wire-1.2.0
 - parameterized-0.5.0.0
 
-# Fix in PR: https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/48
-- git: https://github.com/akshaymankar/http2-grpc-haskell
-  commit: 43507d54515cd5870e8f6d1f03b4d23e6cd460e2
+# Unreleased master.
+# Needed for https://github.com/lucasdicioccio/http2-client/pull/75
+- git: https://github.com/lucasdicioccio/http2-client
+  commit: 73f5975e18eda9d071aa5548fcea6b5a51e61769
+
+# Fix in PRs: https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/48
+# and https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/46
+- git: https://github.com/wireapp/http2-grpc-haskell
+  commit: eea98418672626eafbace3181ca34bf44bee91c0
   subdirs:
     - http2-client-grpc
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -720,13 +720,6 @@ packages:
   original:
     hackage: compendium-client-0.2.1.1
 - completed:
-    hackage: http2-client-0.10.0.0@sha256:85b8771e9e8d4fd0b4327373ebb4a7bc7f9a293e5d7a7dc581ca4153a841da67,2604
-    pantry-tree:
-      size: 853
-      sha256: 4731a8ea6bc88cd762a99370f71c4754bcb57806844ee57a45d59e114ab1b5cb
-  original:
-    hackage: http2-client-0.10.0.0
-- completed:
     hackage: http2-grpc-types-0.5.0.0@sha256:4d34edc06a48496130f19245817a7cd7ea15c78ac8815570c3795ffc4503cf27,1445
     pantry-tree:
       size: 405
@@ -762,18 +755,29 @@ packages:
   original:
     hackage: parameterized-0.5.0.0
 - completed:
+    name: http2-client
+    version: 0.10.0.1
+    git: https://github.com/lucasdicioccio/http2-client
+    pantry-tree:
+      size: 1545
+      sha256: d0b3ab62eee8ee4c0ddec7a90fea78090815a54884646ddcdc451ff51d7e262a
+    commit: 73f5975e18eda9d071aa5548fcea6b5a51e61769
+  original:
+    git: https://github.com/lucasdicioccio/http2-client
+    commit: 73f5975e18eda9d071aa5548fcea6b5a51e61769
+- completed:
     subdir: http2-client-grpc
     name: http2-client-grpc
     version: 0.8.0.0
-    git: https://github.com/akshaymankar/http2-grpc-haskell
+    git: https://github.com/wireapp/http2-grpc-haskell
     pantry-tree:
       size: 455
-      sha256: b5ab96f6ef5bbe3dfef31e08316d54c4793cad71dbd02d5439fddaeea170e103
-    commit: 43507d54515cd5870e8f6d1f03b4d23e6cd460e2
+      sha256: 5599a7b9b801d669e2063ffd4ab767bb8bbf12d20069de0cbd8862bca78d7e42
+    commit: eea98418672626eafbace3181ca34bf44bee91c0
   original:
     subdir: http2-client-grpc
-    git: https://github.com/akshaymankar/http2-grpc-haskell
-    commit: 43507d54515cd5870e8f6d1f03b4d23e6cd460e2
+    git: https://github.com/wireapp/http2-grpc-haskell
+    commit: eea98418672626eafbace3181ca34bf44bee91c0
 - completed:
     name: http2
     version: 2.0.6


### PR DESCRIPTION
We now depend on a fork of http2-grpc-haskell containing fixes for:

https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/46
https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/48

as well as the master of http2-client:

https://github.com/lucasdicioccio/http2-client

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
