### PR TITLE
Add value for client TLS verification depth

### DIFF
--- a/changelog.d/6-federation/chain-of-trust
+++ b/changelog.d/6-federation/chain-of-trust
@@ -1,0 +1,1 @@
+Add value for verification depth of client certificates in federator ingress

--- a/charts/nginx-ingress-services/templates/ingress_federator.yaml
+++ b/charts/nginx-ingress-services/templates/ingress_federator.yaml
@@ -13,7 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
-    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ .Values.tls.verify_depth }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "{{ .Values.tls.verify_depth }}"
     nginx.ingress.kubernetes.io/auth-tls-secret: "{{ .Release.Namespace }}/federator-ca-secret"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       grpc_set_header "X-SSL-Certificate" $ssl_client_escaped_cert;

--- a/charts/nginx-ingress-services/templates/ingress_federator.yaml
+++ b/charts/nginx-ingress-services/templates/ingress_federator.yaml
@@ -13,6 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ .Values.tls.verify-depth }}
     nginx.ingress.kubernetes.io/auth-tls-secret: "{{ .Release.Namespace }}/federator-ca-secret"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       grpc_set_header "X-SSL-Certificate" $ssl_client_escaped_cert;

--- a/charts/nginx-ingress-services/templates/ingress_federator.yaml
+++ b/charts/nginx-ingress-services/templates/ingress_federator.yaml
@@ -13,7 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
-    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ .Values.tls.verify-depth }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ .Values.tls.verify_depth }}
     nginx.ingress.kubernetes.io/auth-tls-secret: "{{ .Release.Namespace }}/federator-ca-secret"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       grpc_set_header "X-SSL-Certificate" $ssl_client_escaped_cert;

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -30,7 +30,7 @@ tls:
   #
   useCertManager: false
   # the validation depth between a federator client certificate and tlsClientCA
-  verify-depth: 1
+  verify_depth: 1
 
 certManager:
   # Indicates whether Letsencrypt's staging API server is used and therefore certificates are NOT trusted

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -29,6 +29,8 @@ tls:
   #            `helm upgrade --install -n cert-manager-ns --set 'installCRDs=true' cert-manager jetstack/cert-manager`
   #
   useCertManager: false
+  # the validation depth between a federator client certificate and tlsClientCA
+  verify-depth: 1
 
 certManager:
   # Indicates whether Letsencrypt's staging API server is used and therefore certificates are NOT trusted


### PR DESCRIPTION
This makes it possible to use client certificates with a longer chain of trust to the root CA.

https://wearezeta.atlassian.net/browse/SQCORE-898

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
