### PR TITLE
Spar Polysemy: Logger effect

### DIFF
--- a/changelog.d/5-internal/logger-effect
+++ b/changelog.d/5-internal/logger-effect
@@ -1,0 +1,1 @@
+Add a Logger effect to Spar

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 18af2f89c5e85abaed3b0ea0c9ad41d4a4360983b8eba93f626f14b8e3224f8c
+-- hash: 573e0f5c3d7b76dbb9fbf48aff2a535df3059af23f8375307021c6c005d98a5b
 
 name:           spar
 version:        0.1
@@ -50,6 +50,8 @@ library
       Spar.Sem.IdP
       Spar.Sem.IdP.Cassandra
       Spar.Sem.IdP.Mem
+      Spar.Sem.Logger
+      Spar.Sem.Logger.TinyLog
       Spar.Sem.Random
       Spar.Sem.Random.IO
       Spar.Sem.SAMLUserStore

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -78,6 +78,7 @@ import qualified Spar.Sem.IdP as IdPEffect
 import Spar.Sem.Random (Random)
 import qualified Spar.Sem.Random as Random
 import Spar.Sem.Logger (Logger)
+import qualified Spar.Sem.Logger as Logger
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)
@@ -90,7 +91,6 @@ import Wire.API.Cookie
 import Wire.API.Routes.Public.Spar
 import Wire.API.User.IdentityProvider
 import Wire.API.User.Saml
-import qualified Spar.Sem.Logger as Logger
 
 app :: Env -> Application
 app ctx =
@@ -304,7 +304,10 @@ idpGetRaw zusr idpid = do
     Just txt -> pure $ RawIdPMetadata txt
     Nothing -> throwSpar $ SparIdPNotFound (cs $ show idpid)
 
-idpGetAll :: Members '[Random, Logger String, GalleyAccess, BrigAccess, IdPEffect.IdP, Error SparError] r => Maybe UserId -> Spar r IdPList
+idpGetAll ::
+  Members '[Random, Logger String, GalleyAccess, BrigAccess, IdPEffect.IdP, Error SparError] r =>
+  Maybe UserId ->
+  Spar r IdPList
 idpGetAll zusr = withDebugLog "idpGetAll" (const Nothing) $ do
   teamid <- liftSem $ Brig.getZUsrCheckPerm zusr ReadIdp
   _idplProviders <- wrapMonadClientSem $ IdPEffect.getConfigsByTeam teamid
@@ -320,7 +323,18 @@ idpGetAll zusr = withDebugLog "idpGetAll" (const Nothing) $ do
 -- https://github.com/zinfra/backend-issues/issues/1314
 idpDelete ::
   forall r.
-  Members '[Random, Logger String, GalleyAccess, BrigAccess, ScimTokenStore, SAMLUserStore, IdPEffect.IdP, Error SparError] r =>
+  Members
+    '[ Random,
+       Logger String,
+       GalleyAccess,
+       BrigAccess,
+       ScimTokenStore,
+       SAMLUserStore,
+       IdPEffect.IdP,
+       Error SparError
+     ]
+    r =>
+>>>>>>> 0404e6650 (make format)
   Maybe UserId ->
   SAML.IdPId ->
   Maybe Bool ->

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -75,10 +75,10 @@ import qualified Spar.Sem.DefaultSsoCode as DefaultSsoCode
 import Spar.Sem.GalleyAccess (GalleyAccess)
 import qualified Spar.Sem.GalleyAccess as GalleyAccess
 import qualified Spar.Sem.IdP as IdPEffect
-import Spar.Sem.Random (Random)
-import qualified Spar.Sem.Random as Random
 import Spar.Sem.Logger (Logger)
 import qualified Spar.Sem.Logger as Logger
+import Spar.Sem.Random (Random)
+import qualified Spar.Sem.Random as Random
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)
@@ -334,7 +334,6 @@ idpDelete ::
        Error SparError
      ]
     r =>
->>>>>>> 0404e6650 (make format)
   Maybe UserId ->
   SAML.IdPId ->
   Maybe Bool ->

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -444,8 +444,8 @@ instance
                     runError @SparError $
                       ttlErrorToSparError $
                         ReaderEff.runReader (sparCtxOpts ctx) $
-                          galleyAccessToHttp (sparCtxLogger ctx) (sparCtxHttpManager ctx) (sparCtxHttpGalley ctx) $
-                            brigAccessToHttp (sparCtxLogger ctx) (sparCtxHttpManager ctx) (sparCtxHttpBrig ctx) $
+                          galleyAccessToHttp (sparCtxHttpManager ctx) (sparCtxHttpGalley ctx) $
+                            brigAccessToHttp (sparCtxHttpManager ctx) (sparCtxHttpBrig ctx) $
                               interpretClientToIO (sparCtxCas ctx) $
                                 samlUserStoreToCassandra @Cas.Client $
                                   idPToCassandra @Cas.Client $

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -24,7 +24,6 @@
 module Spar.App
   ( Spar (..),
     Env (..),
-    toLevel,
     wrapMonadClientSem,
     verdictHandler,
     GetUserResult (..),
@@ -129,7 +128,6 @@ import qualified Spar.Sem.ScimTokenStore as ScimTokenStore
 import Spar.Sem.ScimTokenStore.Cassandra (scimTokenStoreToCassandra)
 import Spar.Sem.ScimUserTimesStore (ScimUserTimesStore)
 import Spar.Sem.ScimUserTimesStore.Cassandra (scimUserTimesStoreToCassandra)
-import qualified System.Logger as Log
 import qualified System.Logger as TinyLog
 import URI.ByteString as URI
 import Web.Cookie (SetCookie, renderSetCookie)
@@ -169,7 +167,7 @@ instance Member (Logger String) r => HasLogger (Spar r) where
 
 data Env = Env
   { sparCtxOpts :: Opts,
-    sparCtxLogger :: Log.Logger,
+    sparCtxLogger :: TinyLog.Logger,
     sparCtxCas :: Cas.ClientState,
     sparCtxHttpManager :: Bilge.Manager,
     sparCtxHttpBrig :: Bilge.Request,
@@ -184,15 +182,6 @@ instance HasNow (Spar r)
 
 instance Member Random r => HasCreateUUID (Spar r) where
   createUUID = liftSem Random.uuid
-
-toLevel :: SAML.Level -> Log.Level
-toLevel = \case
-  SAML.Fatal -> Log.Fatal
-  SAML.Error -> Log.Error
-  SAML.Warn -> Log.Warn
-  SAML.Info -> Log.Info
-  SAML.Debug -> Log.Debug
-  SAML.Trace -> Log.Trace
 
 instance Member AReqIDStore r => SPStoreID AuthnRequest (Spar r) where
   storeID i r = wrapMonadClientSem $ AReqIDStore.store i r
@@ -429,6 +418,7 @@ instance
            Error SparError,
            Logger String,
            Logger (Log.Msg -> Log.Msg),
+           Logger (TinyLog.Msg -> TinyLog.Msg),
            Random,
            Embed IO,
            Final IO

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -112,11 +112,11 @@ import Spar.Sem.GalleyAccess.Http (galleyAccessToHttp)
 import Spar.Sem.IdP (GetIdPResult (..))
 import qualified Spar.Sem.IdP as IdPEffect
 import Spar.Sem.IdP.Cassandra (idPToCassandra)
+import Spar.Sem.Logger as Logger
+import Spar.Sem.Logger.TinyLog (loggerToTinyLog)
 import Spar.Sem.Random (Random)
 import qualified Spar.Sem.Random as Random
 import Spar.Sem.Random.IO (randomToIO)
-import Spar.Sem.Logger as Logger
-import Spar.Sem.Logger.TinyLog (loggerToTinyLog)
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.SAMLUserStore.Cassandra (interpretClientToIO, samlUserStoreToCassandra)
@@ -417,7 +417,6 @@ instance
            Error TTLError,
            Error SparError,
            Logger String,
-           Logger (Log.Msg -> Log.Msg),
            Logger (TinyLog.Msg -> TinyLog.Msg),
            Random,
            Embed IO,
@@ -439,25 +438,25 @@ instance
             runFinal $
               embedToFinal @IO $
                 randomToIO $
-                loggerToTinyLog (sparCtxLogger ctx) $
-                  mapLogger @String TinyLog.msg $
-                    runError @SparError $
-                      ttlErrorToSparError $
-                        ReaderEff.runReader (sparCtxOpts ctx) $
-                          galleyAccessToHttp (sparCtxHttpManager ctx) (sparCtxHttpGalley ctx) $
-                            brigAccessToHttp (sparCtxHttpManager ctx) (sparCtxHttpBrig ctx) $
-                              interpretClientToIO (sparCtxCas ctx) $
-                                samlUserStoreToCassandra @Cas.Client $
-                                  idPToCassandra @Cas.Client $
-                                    defaultSsoCodeToCassandra $
-                                      scimTokenStoreToCassandra $
-                                        scimUserTimesStoreToCassandra $
-                                          scimExternalIdStoreToCassandra $
-                                            aReqIDStoreToCassandra $
-                                              assIDStoreToCassandra $
-                                                bindCookieStoreToCassandra $
-                                                  runExceptT $
-                                                    runReaderT action ctx
+                  loggerToTinyLog (sparCtxLogger ctx) $
+                    mapLogger @String TinyLog.msg $
+                      runError @SparError $
+                        ttlErrorToSparError $
+                          ReaderEff.runReader (sparCtxOpts ctx) $
+                            galleyAccessToHttp (sparCtxHttpManager ctx) (sparCtxHttpGalley ctx) $
+                              brigAccessToHttp (sparCtxHttpManager ctx) (sparCtxHttpBrig ctx) $
+                                interpretClientToIO (sparCtxCas ctx) $
+                                  samlUserStoreToCassandra @Cas.Client $
+                                    idPToCassandra @Cas.Client $
+                                      defaultSsoCodeToCassandra $
+                                        scimTokenStoreToCassandra $
+                                          scimUserTimesStoreToCassandra $
+                                            scimExternalIdStoreToCassandra $
+                                              aReqIDStoreToCassandra $
+                                                assIDStoreToCassandra $
+                                                  bindCookieStoreToCassandra $
+                                                    runExceptT $
+                                                      runReaderT action ctx
       throwErrorAsHandlerException :: Either SparError a -> Handler a
       throwErrorAsHandlerException (Left err) =
         sparToServerErrorWithLogging (sparCtxLogger ctx) err >>= throwError

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -55,6 +55,7 @@ import System.Logger.Class (Logger)
 import qualified System.Logger.Extended as Log
 import Util.Options (casEndpoint, casKeyspace, epHost, epPort)
 import Wire.API.User.Saml as Types
+import Spar.Sem.Logger.TinyLog (toLevel)
 
 ----------------------------------------------------------------------
 -- cassandra

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -51,11 +51,11 @@ import Spar.App
 import qualified Spar.Data as Data
 import Spar.Data.Instances ()
 import Spar.Orphans ()
+import Spar.Sem.Logger.TinyLog (toLevel)
 import System.Logger.Class (Logger)
 import qualified System.Logger.Extended as Log
 import Util.Options (casEndpoint, casKeyspace, epHost, epPort)
 import Wire.API.User.Saml as Types
-import Spar.Sem.Logger.TinyLog (toLevel)
 
 ----------------------------------------------------------------------
 -- cassandra

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -87,10 +87,12 @@ import Spar.Sem.BrigAccess (BrigAccess)
 import Spar.Sem.GalleyAccess (GalleyAccess)
 import qualified Spar.Sem.IdP as IdPEffect
 import Spar.Sem.Random (Random)
+import Spar.Sem.Logger (Logger)
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)
 import Spar.Sem.ScimTokenStore (ScimTokenStore)
 import Spar.Sem.ScimUserTimesStore (ScimUserTimesStore)
+import System.Logger (Msg)
 import qualified Web.Scim.Capabilities.MetaSchema as Scim.Meta
 import qualified Web.Scim.Class.Auth as Scim.Auth
 import qualified Web.Scim.Class.User as Scim.User
@@ -100,8 +102,6 @@ import qualified Web.Scim.Schema.Schema as Scim.Schema
 import qualified Web.Scim.Server as Scim
 import Wire.API.Routes.Public.Spar
 import Wire.API.User.Scim
-import Spar.Sem.Logger (Logger)
-import System.Logger (Msg)
 
 -- | SCIM config for our server.
 --

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -86,8 +86,8 @@ import Spar.Scim.User
 import Spar.Sem.BrigAccess (BrigAccess)
 import Spar.Sem.GalleyAccess (GalleyAccess)
 import qualified Spar.Sem.IdP as IdPEffect
-import Spar.Sem.Random (Random)
 import Spar.Sem.Logger (Logger)
+import Spar.Sem.Random (Random)
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)
 import Spar.Sem.ScimTokenStore (ScimTokenStore)

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -100,6 +100,8 @@ import qualified Web.Scim.Schema.Schema as Scim.Schema
 import qualified Web.Scim.Server as Scim
 import Wire.API.Routes.Public.Spar
 import Wire.API.User.Scim
+import Spar.Sem.Logger (Logger)
+import System.Logger (Msg)
 
 -- | SCIM config for our server.
 --
@@ -109,7 +111,7 @@ configuration :: Scim.Meta.Configuration
 configuration = Scim.Meta.empty
 
 apiScim ::
-  Members '[Random, Error SparError, GalleyAccess, BrigAccess, ScimExternalIdStore, ScimUserTimesStore, ScimTokenStore, IdPEffect.IdP, SAMLUserStore] r =>
+  Members '[Random, Logger (Msg -> Msg), Logger String, Error SparError, GalleyAccess, BrigAccess, ScimExternalIdStore, ScimUserTimesStore, ScimTokenStore, IdPEffect.IdP, SAMLUserStore] r =>
   ServerT APIScim (Spar r)
 apiScim =
   hoistScim (toServant (server configuration))

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -72,10 +72,10 @@ import qualified Spar.Scim.Types as ST
 import Spar.Sem.BrigAccess as BrigAccess
 import Spar.Sem.GalleyAccess (GalleyAccess)
 import qualified Spar.Sem.IdP as IdPEffect
-import Spar.Sem.Random (Random)
-import qualified Spar.Sem.Random as Random
 import Spar.Sem.Logger (Logger)
 import qualified Spar.Sem.Logger as Logger
+import Spar.Sem.Random (Random)
+import qualified Spar.Sem.Random as Random
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -74,14 +74,14 @@ import Spar.Sem.GalleyAccess (GalleyAccess)
 import qualified Spar.Sem.IdP as IdPEffect
 import Spar.Sem.Random (Random)
 import qualified Spar.Sem.Random as Random
+import Spar.Sem.Logger (Logger)
+import qualified Spar.Sem.Logger as Logger
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)
 import qualified Spar.Sem.ScimExternalIdStore as ScimExternalIdStore
 import Spar.Sem.ScimUserTimesStore (ScimUserTimesStore)
 import qualified Spar.Sem.ScimUserTimesStore as ScimUserTimesStore
-import Spar.Sem.Logger (Logger)
-import qualified Spar.Sem.Logger as Logger
 import qualified System.Logger.Class as Log
 import System.Logger.Message (Msg)
 import qualified URI.ByteString as URIBS

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -80,6 +80,8 @@ import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)
 import qualified Spar.Sem.ScimExternalIdStore as ScimExternalIdStore
 import Spar.Sem.ScimUserTimesStore (ScimUserTimesStore)
 import qualified Spar.Sem.ScimUserTimesStore as ScimUserTimesStore
+import Spar.Sem.Logger (Logger)
+import qualified Spar.Sem.Logger as Logger
 import qualified System.Logger.Class as Log
 import System.Logger.Message (Msg)
 import qualified URI.ByteString as URIBS
@@ -105,7 +107,7 @@ import qualified Wire.API.User.Scim as ST
 ----------------------------------------------------------------------------
 -- UserDB instance
 
-instance Members '[Random, GalleyAccess, BrigAccess, ScimExternalIdStore, ScimUserTimesStore, IdPEffect.IdP, SAMLUserStore] r => Scim.UserDB ST.SparTag (Spar r) where
+instance Members '[Random, Logger (Msg -> Msg), Logger String, GalleyAccess, BrigAccess, ScimExternalIdStore, ScimUserTimesStore, IdPEffect.IdP, SAMLUserStore] r => Scim.UserDB ST.SparTag (Spar r) where
   getUsers ::
     ScimTokenInfo ->
     Maybe Scim.Filter ->
@@ -319,7 +321,7 @@ mkValidExternalId (Just idp) (Just extid) = do
               Scim.InvalidValue
               (Just $ "Can't construct a subject ID from externalId: " <> Text.pack err)
 
-logScim :: forall m r a. (m ~ Scim.ScimHandler (Spar r)) => (Msg -> Msg) -> m a -> m a
+logScim :: forall r a. (Member (Logger (Msg -> Msg)) r) => (Msg -> Msg) -> Scim.ScimHandler (Spar r) a -> Scim.ScimHandler (Spar r) a
 logScim context action =
   flip mapExceptT action $ \action' -> do
     eith <- action'
@@ -329,10 +331,10 @@ logScim context action =
               case Scim.detail e of
                 Just d -> d
                 Nothing -> cs (Aeson.encode e)
-        Log.warn $ context . Log.msg errorMsg
+        liftSem $ Logger.warn $ context . Log.msg errorMsg
         pure (Left e)
       Right x -> do
-        Log.info $ context . Log.msg @Text "call without exception"
+        liftSem $ Logger.info $ context . Log.msg @Text "call without exception"
         pure (Right x)
 
 logEmail :: Email -> (Msg -> Msg)
@@ -373,7 +375,7 @@ veidEmail (ST.EmailOnly email) = Just email
 createValidScimUser ::
   forall m r.
   (m ~ Scim.ScimHandler (Spar r)) =>
-  Members '[Random, GalleyAccess, BrigAccess, ScimExternalIdStore, ScimUserTimesStore, SAMLUserStore] r =>
+  Members '[Random, Logger (Msg -> Msg), Logger String, GalleyAccess, BrigAccess, ScimExternalIdStore, ScimUserTimesStore, SAMLUserStore] r =>
   ScimTokenInfo ->
   ST.ValidScimUser ->
   m (Scim.StoredUser ST.SparTag)
@@ -406,7 +408,7 @@ createValidScimUser tokeninfo@ScimTokenInfo {stiTeam} vsu@(ST.ValidScimUser veid
               )
               veid
 
-          Log.debug (Log.msg $ "createValidScimUser: brig says " <> show buid)
+          liftSem $ Logger.debug ("createValidScimUser: brig says " <> show buid)
 
           -- {If we crash now, we have an active user that cannot login. And can not
           -- be bound this will be a zombie user that needs to be manually cleaned
@@ -431,7 +433,7 @@ createValidScimUser tokeninfo@ScimTokenInfo {stiTeam} vsu@(ST.ValidScimUser veid
           lift (liftSem $ BrigAccess.getAccount Brig.WithPendingInvitations buid)
             >>= maybe (throwError $ Scim.serverError "Server error: user vanished") pure
         synthesizeStoredUser acc veid
-      lift $ Log.debug (Log.msg $ "createValidScimUser: spar says " <> show storedUser)
+      lift $ liftSem $ Logger.debug ("createValidScimUser: spar says " <> show storedUser)
 
       -- {(arianvp): these two actions we probably want to make transactional.}
       lift . wrapMonadClientSem $ do
@@ -456,7 +458,7 @@ createValidScimUser tokeninfo@ScimTokenInfo {stiTeam} vsu@(ST.ValidScimUser veid
 -- TODO(arianvp): how do we get this safe w.r.t. race conditions / crashes?
 updateValidScimUser ::
   forall m r.
-  Members '[Random, GalleyAccess, BrigAccess, ScimExternalIdStore, ScimUserTimesStore, IdPEffect.IdP, SAMLUserStore] r =>
+  Members '[Random, Logger (Msg -> Msg), Logger String, GalleyAccess, BrigAccess, ScimExternalIdStore, ScimUserTimesStore, IdPEffect.IdP, SAMLUserStore] r =>
   (m ~ Scim.ScimHandler (Spar r)) =>
   ScimTokenInfo ->
   UserId ->
@@ -585,7 +587,7 @@ updScimStoredUser' now usr (Scim.WithMeta meta (Scim.WithId scimuid _)) =
         }
 
 deleteScimUser ::
-  Members '[BrigAccess, ScimExternalIdStore, ScimUserTimesStore, SAMLUserStore, IdPEffect.IdP] r =>
+  Members '[Logger (Msg -> Msg), BrigAccess, ScimExternalIdStore, ScimUserTimesStore, SAMLUserStore, IdPEffect.IdP] r =>
   ScimTokenInfo ->
   UserId ->
   Scim.ScimHandler (Spar r) ()
@@ -709,7 +711,7 @@ assertHandleNotUsedElsewhere uid hndl = do
 -- | Helper function that translates a given brig user into a 'Scim.StoredUser', with some
 -- effects like updating the 'ManagedBy' field in brig and storing creation and update time
 -- stamps.
-synthesizeStoredUser :: forall r. Members '[BrigAccess, ScimUserTimesStore] r => UserAccount -> ST.ValidExternalId -> Scim.ScimHandler (Spar r) (Scim.StoredUser ST.SparTag)
+synthesizeStoredUser :: forall r. Members '[Logger (Msg -> Msg), BrigAccess, ScimUserTimesStore] r => UserAccount -> ST.ValidExternalId -> Scim.ScimHandler (Spar r) (Scim.StoredUser ST.SparTag)
 synthesizeStoredUser usr veid =
   logScim
     ( logFunction "Spar.Scim.User.synthesizeStoredUser"
@@ -796,7 +798,7 @@ synthesizeScimUser info =
         }
 
 scimFindUserByHandle ::
-  Members '[BrigAccess, ScimUserTimesStore] r =>
+  Members '[Logger (Msg -> Msg), BrigAccess, ScimUserTimesStore] r =>
   Maybe IdP ->
   TeamId ->
   Text ->
@@ -817,7 +819,7 @@ scimFindUserByHandle mIdpConfig stiTeam hndl = do
 -- successful authentication with their SAML credentials.
 scimFindUserByEmail ::
   forall r.
-  Members '[BrigAccess, ScimExternalIdStore, ScimUserTimesStore, SAMLUserStore] r =>
+  Members '[Logger (Msg -> Msg), BrigAccess, ScimExternalIdStore, ScimUserTimesStore, SAMLUserStore] r =>
   Maybe IdP ->
   TeamId ->
   Text ->

--- a/services/spar/src/Spar/Sem/BrigAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess/Http.hs
@@ -8,9 +8,9 @@ import Spar.Error (SparError)
 import qualified Spar.Intra.Brig as Intra
 import Spar.Sem.BrigAccess
 import Spar.Sem.GalleyAccess.Http (RunHttpEnv (..), viaRunHttp)
-import qualified System.Logger as TinyLog
-import qualified Spar.Sem.Logger as Logger
 import Spar.Sem.Logger (Logger)
+import qualified Spar.Sem.Logger as Logger
+import qualified System.Logger as TinyLog
 
 brigAccessToHttp ::
   Members '[Logger (TinyLog.Msg -> TinyLog.Msg), Error SparError, Embed IO] r =>

--- a/services/spar/src/Spar/Sem/BrigAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess/Http.hs
@@ -8,18 +8,19 @@ import Spar.Error (SparError)
 import qualified Spar.Intra.Brig as Intra
 import Spar.Sem.BrigAccess
 import Spar.Sem.GalleyAccess.Http (RunHttpEnv (..), viaRunHttp)
-import qualified System.Logger as Log
+import qualified System.Logger as TinyLog
+import qualified Spar.Sem.Logger as Logger
+import Spar.Sem.Logger (Logger)
 
 brigAccessToHttp ::
-  Members '[Error SparError, Embed IO] r =>
-  Log.Logger ->
+  Members '[Logger (TinyLog.Msg -> TinyLog.Msg), Error SparError, Embed IO] r =>
   Bilge.Manager ->
   Bilge.Request ->
   Sem (BrigAccess ': r) a ->
   Sem r a
-brigAccessToHttp logger mgr req =
+brigAccessToHttp mgr req =
   interpret $
-    viaRunHttp (RunHttpEnv logger mgr req) . \case
+    viaRunHttp (RunHttpEnv (\lvl msg -> Logger.log lvl msg) mgr req) . \case
       CreateSAML u itlu itlt n m -> Intra.createBrigUserSAML u itlu itlt n m
       CreateNoSAML e itlt n -> Intra.createBrigUserNoSAML e itlt n
       UpdateEmail itlu e -> Intra.updateEmail itlu e

--- a/services/spar/src/Spar/Sem/BrigAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess/Http.hs
@@ -9,7 +9,6 @@ import qualified Spar.Intra.Brig as Intra
 import Spar.Sem.BrigAccess
 import Spar.Sem.GalleyAccess.Http (RunHttpEnv (..), viaRunHttp)
 import Spar.Sem.Logger (Logger)
-import qualified Spar.Sem.Logger as Logger
 import qualified System.Logger as TinyLog
 
 brigAccessToHttp ::
@@ -20,7 +19,7 @@ brigAccessToHttp ::
   Sem r a
 brigAccessToHttp mgr req =
   interpret $
-    viaRunHttp (RunHttpEnv (\lvl msg -> Logger.log lvl msg) mgr req) . \case
+    viaRunHttp (RunHttpEnv mgr req) . \case
       CreateSAML u itlu itlt n m -> Intra.createBrigUserSAML u itlu itlt n m
       CreateNoSAML e itlt n -> Intra.createBrigUserNoSAML e itlt n
       UpdateEmail itlu e -> Intra.updateEmail itlu e

--- a/services/spar/src/Spar/Sem/GalleyAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/GalleyAccess/Http.hs
@@ -12,56 +12,68 @@ import Spar.Intra.Brig (MonadSparToBrig (..))
 import Spar.Intra.Galley (MonadSparToGalley)
 import qualified Spar.Intra.Galley as Intra
 import Spar.Sem.GalleyAccess
-import qualified System.Logger as Log
-import qualified System.Logger.Class as LogClass
+import qualified System.Logger as TinyLog
+import qualified System.Logger.Class as TinyLog
+import Spar.Sem.Logger (Logger)
+import qualified Spar.Sem.Logger as Logger
+import Spar.Sem.Logger.TinyLog (fromLevel)
 
-data RunHttpEnv = RunHttpEnv
-  { rheLogger :: Log.Logger,
+data RunHttpEnv r = RunHttpEnv
+  { rheLogger :: Logger.Level -> (TinyLog.Msg -> TinyLog.Msg) -> Sem r (),
     rheManager :: Bilge.Manager,
     rheRequest :: Bilge.Request
   }
 
-newtype RunHttp a = RunHttp
-  { unRunHttp :: ReaderT RunHttpEnv (ExceptT SparError (HttpT IO)) a
+newtype RunHttp r a = RunHttp
+  { unRunHttp :: ReaderT (RunHttpEnv r) (ExceptT SparError (HttpT (Sem r))) a
   }
-  deriving newtype (Functor, Applicative, Monad, MonadError SparError, MonadIO, MonadHttp, MonadReader RunHttpEnv)
+  deriving newtype (Functor, Applicative, Monad, MonadError SparError, MonadReader (RunHttpEnv r))
+
+instance Member (Embed IO) r => MonadIO (RunHttp r) where
+  liftIO = semToRunHttp . embed
+
+instance Member (Embed IO) r => MonadHttp (RunHttp r) where
+  handleRequestWithCont r fribia = RunHttp $ lift $ lift $
+    handleRequestWithCont r fribia
+
+semToRunHttp :: Sem r a -> RunHttp r a
+semToRunHttp = RunHttp . lift . lift . lift
 
 viaRunHttp ::
   Members '[Error SparError, Embed IO] r =>
-  RunHttpEnv ->
-  RunHttp a ->
+  RunHttpEnv r ->
+  RunHttp r a ->
   Sem r a
 viaRunHttp env m = do
-  ma <- embed @IO $ runHttpT (rheManager env) $ runExceptT $ flip runReaderT env $ unRunHttp m
+  ma <- runHttpT (rheManager env) $ runExceptT $ flip runReaderT env $ unRunHttp m
   case ma of
     Left err -> throw err
     Right a -> pure a
 
-instance LogClass.MonadLogger RunHttp where
+instance TinyLog.MonadLogger (RunHttp r) where
   log lvl msg = do
     logger <- asks rheLogger
-    Log.log logger lvl msg
+    semToRunHttp $ logger (fromLevel lvl) msg
 
-instance MonadSparToGalley RunHttp where
+instance Member (Embed IO) r => MonadSparToGalley (RunHttp r) where
   call modreq = do
     req <- asks rheRequest
     httpLbs req modreq
 
-instance MonadSparToBrig RunHttp where
+instance Member (Embed IO) r => MonadSparToBrig (RunHttp r) where
   call modreq = do
     req <- asks rheRequest
     httpLbs req modreq
 
 galleyAccessToHttp ::
-  Members '[Error SparError, Embed IO] r =>
-  Log.Logger ->
+  Members '[Logger (TinyLog.Msg -> TinyLog.Msg), Error SparError, Embed IO] r =>
   Bilge.Manager ->
   Bilge.Request ->
   Sem (GalleyAccess ': r) a ->
   Sem r a
-galleyAccessToHttp logger mgr req =
+galleyAccessToHttp mgr req =
   interpret $
-    viaRunHttp (RunHttpEnv logger mgr req) . \case
+    viaRunHttp (RunHttpEnv (\lvl msg -> Logger.log lvl msg) mgr req) . \case
       GetTeamMembers itlt -> Intra.getTeamMembers itlt
       AssertHasPermission itlt perm itlu -> Intra.assertHasPermission itlt perm itlu
       AssertSSOEnabled itlt -> Intra.assertSSOEnabled itlt

--- a/services/spar/src/Spar/Sem/GalleyAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/GalleyAccess/Http.hs
@@ -12,11 +12,11 @@ import Spar.Intra.Brig (MonadSparToBrig (..))
 import Spar.Intra.Galley (MonadSparToGalley)
 import qualified Spar.Intra.Galley as Intra
 import Spar.Sem.GalleyAccess
-import qualified System.Logger as TinyLog
-import qualified System.Logger.Class as TinyLog
 import Spar.Sem.Logger (Logger)
 import qualified Spar.Sem.Logger as Logger
 import Spar.Sem.Logger.TinyLog (fromLevel)
+import qualified System.Logger as TinyLog
+import qualified System.Logger.Class as TinyLog
 
 data RunHttpEnv r = RunHttpEnv
   { rheLogger :: Logger.Level -> (TinyLog.Msg -> TinyLog.Msg) -> Sem r (),
@@ -33,8 +33,11 @@ instance Member (Embed IO) r => MonadIO (RunHttp r) where
   liftIO = semToRunHttp . embed
 
 instance Member (Embed IO) r => MonadHttp (RunHttp r) where
-  handleRequestWithCont r fribia = RunHttp $ lift $ lift $
-    handleRequestWithCont r fribia
+  handleRequestWithCont r fribia =
+    RunHttp $
+      lift $
+        lift $
+          handleRequestWithCont r fribia
 
 semToRunHttp :: Sem r a -> RunHttp r a
 semToRunHttp = RunHttp . lift . lift . lift

--- a/services/spar/src/Spar/Sem/Logger.hs
+++ b/services/spar/src/Spar/Sem/Logger.hs
@@ -35,8 +35,8 @@ info = log SAML.Info
 warn :: Member (Logger msg) r => msg -> Sem r ()
 warn = log SAML.Warn
 
--- err :: Member (Logger msg) r => msg -> Sem r ()
--- err = log SAML.Error
+err :: Member (Logger msg) r => msg -> Sem r ()
+err = log SAML.Error
 
 fatal :: Member (Logger msg) r => msg -> Sem r ()
 fatal = log SAML.Fatal

--- a/services/spar/src/Spar/Sem/Logger.hs
+++ b/services/spar/src/Spar/Sem/Logger.hs
@@ -1,11 +1,12 @@
 module Spar.Sem.Logger
-  ( module Spar.Sem.Logger
-  , SAML.Level (..)
-  ) where
+  ( module Spar.Sem.Logger,
+    SAML.Level (..),
+  )
+where
 
+import Imports hiding (log)
 import Polysemy
 import qualified SAML2.WebSSO as SAML
-import Imports hiding (log)
 
 data Logger msg m a where
   Log :: SAML.Level -> msg -> Logger msg m ()
@@ -13,11 +14,12 @@ data Logger msg m a where
 -- TODO(sandy): Inline this definition --- no TH
 makeSem ''Logger
 
-
-mapLogger
-  :: forall msg msg' r a
-   . Member (Logger msg') r
-  => (msg -> msg') -> Sem (Logger msg ': r) a -> Sem r a
+mapLogger ::
+  forall msg msg' r a.
+  Member (Logger msg') r =>
+  (msg -> msg') ->
+  Sem (Logger msg ': r) a ->
+  Sem r a
 mapLogger f = interpret $ \case
   Log lvl msg -> log lvl $ f msg
 
@@ -38,4 +40,3 @@ warn = log SAML.Warn
 
 fatal :: Member (Logger msg) r => msg -> Sem r ()
 fatal = log SAML.Fatal
-

--- a/services/spar/src/Spar/Sem/Logger.hs
+++ b/services/spar/src/Spar/Sem/Logger.hs
@@ -1,0 +1,41 @@
+module Spar.Sem.Logger
+  ( module Spar.Sem.Logger
+  , SAML.Level (..)
+  ) where
+
+import Polysemy
+import qualified SAML2.WebSSO as SAML
+import Imports hiding (log)
+
+data Logger msg m a where
+  Log :: SAML.Level -> msg -> Logger msg m ()
+
+-- TODO(sandy): Inline this definition --- no TH
+makeSem ''Logger
+
+
+mapLogger
+  :: forall msg msg' r a
+   . Member (Logger msg') r
+  => (msg -> msg') -> Sem (Logger msg ': r) a -> Sem r a
+mapLogger f = interpret $ \case
+  Log lvl msg -> log lvl $ f msg
+
+trace :: Member (Logger msg) r => msg -> Sem r ()
+trace = log SAML.Trace
+
+debug :: Member (Logger msg) r => msg -> Sem r ()
+debug = log SAML.Debug
+
+info :: Member (Logger msg) r => msg -> Sem r ()
+info = log SAML.Info
+
+warn :: Member (Logger msg) r => msg -> Sem r ()
+warn = log SAML.Warn
+
+-- err :: Member (Logger msg) r => msg -> Sem r ()
+-- err = log SAML.Error
+
+fatal :: Member (Logger msg) r => msg -> Sem r ()
+fatal = log SAML.Fatal
+

--- a/services/spar/src/Spar/Sem/Logger/TinyLog.hs
+++ b/services/spar/src/Spar/Sem/Logger/TinyLog.hs
@@ -1,4 +1,4 @@
-module Spar.Sem.Logger.TinyLog (loggerToTinyLog) where
+module Spar.Sem.Logger.TinyLog (loggerToTinyLog, toLevel) where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/Logger/TinyLog.hs
+++ b/services/spar/src/Spar/Sem/Logger/TinyLog.hs
@@ -2,18 +2,17 @@ module Spar.Sem.Logger.TinyLog (loggerToTinyLog) where
 
 import Imports
 import Polysemy
+import Spar.Sem.Logger (Level (..), Logger (..))
 import qualified System.Logger as Log
-import Spar.Sem.Logger (Logger (..), Level(..))
 
-
-loggerToTinyLog
-    :: Member (Embed IO) r
-    => Log.Logger
-    -> Sem (Logger (Log.Msg -> Log.Msg) ': r) a -> Sem r a
+loggerToTinyLog ::
+  Member (Embed IO) r =>
+  Log.Logger ->
+  Sem (Logger (Log.Msg -> Log.Msg) ': r) a ->
+  Sem r a
 loggerToTinyLog tinylog = interpret $ \case
   Log lvl msg ->
     embed @IO $ Log.log tinylog (toLevel lvl) msg
-
 
 toLevel :: Level -> Log.Level
 toLevel = \case
@@ -23,4 +22,3 @@ toLevel = \case
   Info -> Log.Info
   Debug -> Log.Debug
   Trace -> Log.Trace
-

--- a/services/spar/src/Spar/Sem/Logger/TinyLog.hs
+++ b/services/spar/src/Spar/Sem/Logger/TinyLog.hs
@@ -1,8 +1,8 @@
-module Spar.Sem.Logger.TinyLog (loggerToTinyLog, toLevel, fromLevel) where
+module Spar.Sem.Logger.TinyLog (loggerToTinyLog, stringLoggerToTinyLog, toLevel, fromLevel) where
 
 import Imports
 import Polysemy
-import Spar.Sem.Logger (Level (..), Logger (..))
+import Spar.Sem.Logger (Level (..), Logger (..), mapLogger)
 import qualified System.Logger as Log
 
 loggerToTinyLog ::
@@ -13,6 +13,9 @@ loggerToTinyLog ::
 loggerToTinyLog tinylog = interpret $ \case
   Log lvl msg ->
     embed @IO $ Log.log tinylog (toLevel lvl) msg
+
+stringLoggerToTinyLog :: Member (Logger (Log.Msg -> Log.Msg)) r => Sem (Logger String ': r) a -> Sem r a
+stringLoggerToTinyLog = mapLogger @String Log.msg
 
 toLevel :: Level -> Log.Level
 toLevel = \case

--- a/services/spar/src/Spar/Sem/Logger/TinyLog.hs
+++ b/services/spar/src/Spar/Sem/Logger/TinyLog.hs
@@ -1,4 +1,6 @@
-module Spar.Sem.Logger.TinyLog (loggerToTinyLog, toLevel) where
+module Spar.Sem.Logger.TinyLog
+  (loggerToTinyLog, toLevel, fromLevel)
+    where
 
 import Imports
 import Polysemy
@@ -22,3 +24,14 @@ toLevel = \case
   Info -> Log.Info
   Debug -> Log.Debug
   Trace -> Log.Trace
+
+
+fromLevel :: Log.Level -> Level
+fromLevel = \case
+  Log.Fatal -> Fatal
+  Log.Error -> Error
+  Log.Warn -> Warn
+  Log.Info -> Info
+  Log.Debug -> Debug
+  Log.Trace -> Trace
+

--- a/services/spar/src/Spar/Sem/Logger/TinyLog.hs
+++ b/services/spar/src/Spar/Sem/Logger/TinyLog.hs
@@ -1,0 +1,26 @@
+module Spar.Sem.Logger.TinyLog (loggerToTinyLog) where
+
+import Imports
+import Polysemy
+import qualified System.Logger as Log
+import Spar.Sem.Logger (Logger (..), Level(..))
+
+
+loggerToTinyLog
+    :: Member (Embed IO) r
+    => Log.Logger
+    -> Sem (Logger (Log.Msg -> Log.Msg) ': r) a -> Sem r a
+loggerToTinyLog tinylog = interpret $ \case
+  Log lvl msg ->
+    embed @IO $ Log.log tinylog (toLevel lvl) msg
+
+
+toLevel :: Level -> Log.Level
+toLevel = \case
+  Fatal -> Log.Fatal
+  Error -> Log.Error
+  Warn -> Log.Warn
+  Info -> Log.Info
+  Debug -> Log.Debug
+  Trace -> Log.Trace
+

--- a/services/spar/src/Spar/Sem/Logger/TinyLog.hs
+++ b/services/spar/src/Spar/Sem/Logger/TinyLog.hs
@@ -1,6 +1,4 @@
-module Spar.Sem.Logger.TinyLog
-  (loggerToTinyLog, toLevel, fromLevel)
-    where
+module Spar.Sem.Logger.TinyLog (loggerToTinyLog, toLevel, fromLevel) where
 
 import Imports
 import Polysemy
@@ -25,7 +23,6 @@ toLevel = \case
   Debug -> Log.Debug
   Trace -> Log.Trace
 
-
 fromLevel :: Log.Level -> Level
 fromLevel = \case
   Log.Fatal -> Fatal
@@ -34,4 +31,3 @@ fromLevel = \case
   Log.Info -> Info
   Log.Debug -> Debug
   Log.Trace -> Trace
-

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -197,6 +197,8 @@ import qualified Spar.Sem.IdP as IdPEffect
 import Spar.Sem.IdP.Cassandra
 import Spar.Sem.Random (Random)
 import Spar.Sem.Random.IO (randomToIO)
+import Spar.Sem.Logger (Logger, mapLogger)
+import Spar.Sem.Logger.TinyLog (loggerToTinyLog, toLevel)
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.SAMLUserStore.Cassandra
@@ -207,8 +209,7 @@ import Spar.Sem.ScimTokenStore (ScimTokenStore)
 import Spar.Sem.ScimTokenStore.Cassandra (scimTokenStoreToCassandra)
 import Spar.Sem.ScimUserTimesStore (ScimUserTimesStore)
 import Spar.Sem.ScimUserTimesStore.Cassandra (scimUserTimesStoreToCassandra)
-import Spar.Sem.Logger (Logger, mapLogger)
-import Spar.Sem.Logger.TinyLog (loggerToTinyLog, toLevel)
+import qualified System.Logger as TinyLog
 import qualified System.Logger.Extended as Log
 import System.Random (randomRIO)
 import Test.Hspec hiding (it, pending, pendingWith, xit)
@@ -231,7 +232,6 @@ import qualified Wire.API.User as User
 import Wire.API.User.IdentityProvider
 import Wire.API.User.Saml
 import Wire.API.User.Scim (runValidExternalId)
-import qualified System.Logger as TinyLog
 
 -- | Call 'mkEnv' with options from config files.
 mkEnvFromOptions :: IO TestEnv
@@ -1283,24 +1283,24 @@ runSpar (Spar.Spar action) = do
           embedToFinal @IO $
             randomToIO $
             loggerToTinyLog (Spar.sparCtxLogger env) $
-             mapLogger @String TinyLog.msg $
-              ErrorEff.runError @SparError $
-                ttlErrorToSparError $
-                  ReaderEff.runReader (Spar.sparCtxOpts env) $
-                    interpretClientToIO (Spar.sparCtxCas env) $
-                      samlUserStoreToCassandra @Cas.Client $
-                        idPToCassandra @Cas.Client $
-                          defaultSsoCodeToCassandra @Cas.Client $
-                            scimTokenStoreToCassandra @Cas.Client $
-                              scimUserTimesStoreToCassandra @Cas.Client $
-                                scimExternalIdStoreToCassandra @Cas.Client $
-                                  aReqIDStoreToCassandra @Cas.Client $
-                                    assIDStoreToCassandra @Cas.Client $
-                                      bindCookieStoreToCassandra @Cas.Client $
-                                        brigAccessToHttp (Spar.sparCtxLogger env) (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
-                                          galleyAccessToHttp (Spar.sparCtxLogger env) (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
-                                            runExceptT $
-                                              runReaderT action env
+              mapLogger @String TinyLog.msg $
+                ErrorEff.runError @SparError $
+                  ttlErrorToSparError $
+                    ReaderEff.runReader (Spar.sparCtxOpts env) $
+                      interpretClientToIO (Spar.sparCtxCas env) $
+                        samlUserStoreToCassandra @Cas.Client $
+                          idPToCassandra @Cas.Client $
+                            defaultSsoCodeToCassandra @Cas.Client $
+                              scimTokenStoreToCassandra @Cas.Client $
+                                scimUserTimesStoreToCassandra @Cas.Client $
+                                  scimExternalIdStoreToCassandra @Cas.Client $
+                                    aReqIDStoreToCassandra @Cas.Client $
+                                      assIDStoreToCassandra @Cas.Client $
+                                        bindCookieStoreToCassandra @Cas.Client $
+                                          brigAccessToHttp (Spar.sparCtxLogger env) (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
+                                            galleyAccessToHttp (Spar.sparCtxLogger env) (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
+                                              runExceptT $
+                                                runReaderT action env
     either (throwIO . ErrorCall . show) pure result
 
 getSsoidViaSelf :: HasCallStack => UserId -> TestSpar UserSSOId

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -195,10 +195,10 @@ import Spar.Sem.GalleyAccess (GalleyAccess)
 import Spar.Sem.GalleyAccess.Http (galleyAccessToHttp)
 import qualified Spar.Sem.IdP as IdPEffect
 import Spar.Sem.IdP.Cassandra
-import Spar.Sem.Random (Random)
-import Spar.Sem.Random.IO (randomToIO)
 import Spar.Sem.Logger (Logger, mapLogger)
 import Spar.Sem.Logger.TinyLog (loggerToTinyLog, toLevel)
+import Spar.Sem.Random (Random)
+import Spar.Sem.Random.IO (randomToIO)
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.SAMLUserStore.Cassandra
@@ -1282,25 +1282,25 @@ runSpar (Spar.Spar action) = do
         runFinal $
           embedToFinal @IO $
             randomToIO $
-            loggerToTinyLog (Spar.sparCtxLogger env) $
-              mapLogger @String TinyLog.msg $
-                ErrorEff.runError @SparError $
-                  ttlErrorToSparError $
-                    ReaderEff.runReader (Spar.sparCtxOpts env) $
-                      interpretClientToIO (Spar.sparCtxCas env) $
-                        samlUserStoreToCassandra @Cas.Client $
-                          idPToCassandra @Cas.Client $
-                            defaultSsoCodeToCassandra @Cas.Client $
-                              scimTokenStoreToCassandra @Cas.Client $
-                                scimUserTimesStoreToCassandra @Cas.Client $
-                                  scimExternalIdStoreToCassandra @Cas.Client $
-                                    aReqIDStoreToCassandra @Cas.Client $
-                                      assIDStoreToCassandra @Cas.Client $
-                                        bindCookieStoreToCassandra @Cas.Client $
-                                          brigAccessToHttp (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
-                                            galleyAccessToHttp (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
-                                              runExceptT $
-                                                runReaderT action env
+              loggerToTinyLog (Spar.sparCtxLogger env) $
+                mapLogger @String TinyLog.msg $
+                  ErrorEff.runError @SparError $
+                    ttlErrorToSparError $
+                      ReaderEff.runReader (Spar.sparCtxOpts env) $
+                        interpretClientToIO (Spar.sparCtxCas env) $
+                          samlUserStoreToCassandra @Cas.Client $
+                            idPToCassandra @Cas.Client $
+                              defaultSsoCodeToCassandra @Cas.Client $
+                                scimTokenStoreToCassandra @Cas.Client $
+                                  scimUserTimesStoreToCassandra @Cas.Client $
+                                    scimExternalIdStoreToCassandra @Cas.Client $
+                                      aReqIDStoreToCassandra @Cas.Client $
+                                        assIDStoreToCassandra @Cas.Client $
+                                          bindCookieStoreToCassandra @Cas.Client $
+                                            brigAccessToHttp (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
+                                              galleyAccessToHttp (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
+                                                runExceptT $
+                                                  runReaderT action env
     either (throwIO . ErrorCall . show) pure result
 
 getSsoidViaSelf :: HasCallStack => UserId -> TestSpar UserSSOId

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -1297,8 +1297,8 @@ runSpar (Spar.Spar action) = do
                                     aReqIDStoreToCassandra @Cas.Client $
                                       assIDStoreToCassandra @Cas.Client $
                                         bindCookieStoreToCassandra @Cas.Client $
-                                          brigAccessToHttp (Spar.sparCtxLogger env) (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
-                                            galleyAccessToHttp (Spar.sparCtxLogger env) (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
+                                          brigAccessToHttp (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
+                                            galleyAccessToHttp (Spar.sparCtxHttpManager env) (Spar.sparCtxHttpBrig env) $
                                               runExceptT $
                                                 runReaderT action env
     either (throwIO . ErrorCall . show) pure result


### PR DESCRIPTION
This PR pulls a Logger effect out of Spar. It's a little roundabout currently, for two reasons:

1. `saml2-web-sso`'s exported interface requires `HasLogger`, so we keep a `HasLogger` instance around.
2. `tinylog` doesn't export enough of its internals to abstract around its usage, so we require a `Logger (Msg -> Msg)` effect to be around

Point 1 can be cleaned up by either polysemizing `saml2-web-sso`, or adding an effect to wrap it. If we're planning to do the former (currently in scope for the polysemizing project), the latter is wasted work. It seems to me like this is worth punting on until we have a game plan. In the meantime, the logger effect is nice to have teased apart, and easy to change when we figure out the longer term plan.


## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.