### PR TITLE
Spar Polysemy: Remove ReaderT from Spar

### DIFF
--- a/changelog.d/5-internal/spar-no-monad-reader
+++ b/changelog.d/5-internal/spar-no-monad-reader
@@ -1,0 +1,1 @@
+Remove the ReaderT inside of the Spar newtype

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -14,7 +14,7 @@ description:   'See README.md'
 ghc-options:
 - -j
 - -Wno-redundant-constraints
-- -Werror
+# - -Werror
 
 dependencies:
   - aeson

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -14,7 +14,7 @@ description:   'See README.md'
 ghc-options:
 - -j
 - -Wno-redundant-constraints
-# - -Werror
+- -Werror
 
 dependencies:
   - aeson

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -54,6 +54,7 @@ import Galley.Types.Teams (HiddenPerm (CreateUpdateDeleteIdp, ReadIdp))
 import Imports
 import Polysemy
 import Polysemy.Error
+import Polysemy.Input
 import qualified SAML2.WebSSO as SAML
 import Servant
 import qualified Servant.Multipart as Multipart
@@ -86,13 +87,12 @@ import Spar.Sem.ScimTokenStore (ScimTokenStore)
 import qualified Spar.Sem.ScimTokenStore as ScimTokenStore
 import Spar.Sem.ScimUserTimesStore (ScimUserTimesStore)
 import System.Logger (Msg)
+import qualified System.Logger as TinyLog
 import qualified URI.ByteString as URI
 import Wire.API.Cookie
 import Wire.API.Routes.Public.Spar
 import Wire.API.User.IdentityProvider
 import Wire.API.User.Saml
-import Polysemy.Input
-import qualified System.Logger as TinyLog
 
 app :: Env -> Application
 app ctx =
@@ -158,7 +158,19 @@ apiSSO opts =
     :<|> authresp . Just
     :<|> ssoSettings
 
-apiIDP :: Members '[Random, Logger String, GalleyAccess, BrigAccess, ScimTokenStore, IdPEffect.IdP, SAMLUserStore, Error SparError] r => ServerT APIIDP (Spar r)
+apiIDP ::
+  Members
+    '[ Random,
+       Logger String,
+       GalleyAccess,
+       BrigAccess,
+       ScimTokenStore,
+       IdPEffect.IdP,
+       SAMLUserStore,
+       Error SparError
+     ]
+    r =>
+  ServerT APIIDP (Spar r)
 apiIDP =
   idpGet
     :<|> idpGetRaw
@@ -167,7 +179,15 @@ apiIDP =
     :<|> idpUpdate
     :<|> idpDelete
 
-apiINTERNAL :: Members '[ScimTokenStore, DefaultSsoCode, IdPEffect.IdP, SAMLUserStore] r => ServerT APIINTERNAL (Spar r)
+apiINTERNAL ::
+  Members
+    '[ ScimTokenStore,
+       DefaultSsoCode,
+       IdPEffect.IdP,
+       SAMLUserStore
+     ]
+    r =>
+  ServerT APIINTERNAL (Spar r)
 apiINTERNAL =
   internalStatus
     :<|> internalDeleteTeam
@@ -186,8 +206,16 @@ authreqPrecheck msucc merr idpid =
     *> return NoContent
 
 authreq ::
-  Members '[ Random, Input Opts,
-             Logger String, BindCookieStore, AssIDStore, AReqIDStore, IdPEffect.IdP] r =>
+  Members
+    '[ Random,
+       Input Opts,
+       Logger String,
+       BindCookieStore,
+       AssIDStore,
+       AReqIDStore,
+       IdPEffect.IdP
+     ]
+    r =>
   NominalDiffTime ->
   DoInitiate ->
   Maybe UserId ->
@@ -214,9 +242,11 @@ authreq authreqttl _ zusr msucc merr idpid = do
 -- | If the user is already authenticated, create bind cookie with a given life expectancy and our
 -- domain, and store it in C*.  If the user is not authenticated, return a deletion 'SetCookie'
 -- value that deletes any bind cookies on the client.
-initializeBindCookie
-    :: Members '[Random, Input Opts, Logger String, BindCookieStore] r
-    => Maybe UserId -> NominalDiffTime -> Spar r SetBindCookie
+initializeBindCookie ::
+  Members '[Random, Input Opts, Logger String, BindCookieStore] r =>
+  Maybe UserId ->
+  NominalDiffTime ->
+  Spar r SetBindCookie
 initializeBindCookie zusr authreqttl = do
   DerivedOpts {derivedOptsBindCookiePath} <- liftSem $ inputs derivedOpts
   msecret <-
@@ -294,7 +324,15 @@ ssoSettings = do
 -- IdP API
 
 idpGet ::
-  Members '[Random, Logger String, GalleyAccess, BrigAccess, IdPEffect.IdP, Error SparError] r =>
+  Members
+    '[ Random,
+       Logger String,
+       GalleyAccess,
+       BrigAccess,
+       IdPEffect.IdP,
+       Error SparError
+     ]
+    r =>
   Maybe UserId ->
   SAML.IdPId ->
   Spar r IdP
@@ -316,7 +354,15 @@ idpGetRaw zusr idpid = do
     Nothing -> throwSpar $ SparIdPNotFound (cs $ show idpid)
 
 idpGetAll ::
-  Members '[Random, Logger String, GalleyAccess, BrigAccess, IdPEffect.IdP, Error SparError] r =>
+  Members
+    '[ Random,
+       Logger String,
+       GalleyAccess,
+       BrigAccess,
+       IdPEffect.IdP,
+       Error SparError
+     ]
+    r =>
   Maybe UserId ->
   Spar r IdPList
 idpGetAll zusr = withDebugLog "idpGetAll" (const Nothing) $ do
@@ -404,7 +450,16 @@ idpDelete zusr idpid (fromMaybe False -> purge) = withDebugLog "idpDelete" (cons
 -- | This handler only does the json parsing, and leaves all authorization checks and
 -- application logic to 'idpCreateXML'.
 idpCreate ::
-  Members '[Random, Logger String, GalleyAccess, BrigAccess, ScimTokenStore, IdPEffect.IdP, Error SparError] r =>
+  Members
+    '[ Random,
+       Logger String,
+       GalleyAccess,
+       BrigAccess,
+       ScimTokenStore,
+       IdPEffect.IdP,
+       Error SparError
+     ]
+    r =>
   Maybe UserId ->
   IdPMetadataInfo ->
   Maybe SAML.IdPId ->
@@ -414,7 +469,16 @@ idpCreate zusr (IdPMetadataValue raw xml) midpid apiversion = idpCreateXML zusr 
 
 -- | We generate a new UUID for each IdP used as IdPConfig's path, thereby ensuring uniqueness.
 idpCreateXML ::
-  Members '[Random, Logger String, GalleyAccess, BrigAccess, ScimTokenStore, IdPEffect.IdP, Error SparError] r =>
+  Members
+    '[ Random,
+       Logger String,
+       GalleyAccess,
+       BrigAccess,
+       ScimTokenStore,
+       IdPEffect.IdP,
+       Error SparError
+     ]
+    r =>
   Maybe UserId ->
   Text ->
   SAML.IdPMetadata ->
@@ -515,7 +579,15 @@ validateNewIdP apiversion _idpMetadata teamId mReplaces = withDebugLog "validate
 -- 'idpCreate', which is not a good reason.  make this one function and pass around
 -- 'IdPMetadataInfo' directly where convenient.
 idpUpdate ::
-  Members '[Random, Logger String, GalleyAccess, BrigAccess, IdPEffect.IdP, Error SparError] r =>
+  Members
+    '[ Random,
+       Logger String,
+       GalleyAccess,
+       BrigAccess,
+       IdPEffect.IdP,
+       Error SparError
+     ]
+    r =>
   Maybe UserId ->
   IdPMetadataInfo ->
   SAML.IdPId ->
@@ -523,7 +595,15 @@ idpUpdate ::
 idpUpdate zusr (IdPMetadataValue raw xml) idpid = idpUpdateXML zusr raw xml idpid
 
 idpUpdateXML ::
-  Members '[Random, Logger String, GalleyAccess, BrigAccess, IdPEffect.IdP, Error SparError] r =>
+  Members
+    '[ Random,
+       Logger String,
+       GalleyAccess,
+       BrigAccess,
+       IdPEffect.IdP,
+       Error SparError
+     ]
+    r =>
   Maybe UserId ->
   Text ->
   SAML.IdPMetadata ->
@@ -546,7 +626,15 @@ idpUpdateXML zusr raw idpmeta idpid = withDebugLog "idpUpdate" (Just . show . (^
 validateIdPUpdate ::
   forall m r.
   (HasCallStack, m ~ Spar r) =>
-  Members '[Random, Logger String, GalleyAccess, BrigAccess, IdPEffect.IdP, Error SparError] r =>
+  Members
+    '[ Random,
+       Logger String,
+       GalleyAccess,
+       BrigAccess,
+       IdPEffect.IdP,
+       Error SparError
+     ]
+    r =>
   Maybe UserId ->
   SAML.IdPMetadata ->
   SAML.IdPId ->

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -173,7 +173,6 @@ data Env = Env
     sparCtxRequestId :: RequestId
   }
 
--- TODO(sandy): This is the only use of the Reader effect
 instance Member (Input Opts) r => HasConfig (Spar r) where
   getConfig = liftSem $ inputs saml
 
@@ -779,7 +778,7 @@ verdictHandlerMobile granted denied = \case
 -- | When getting stuck during login finalization, show a nice HTML error rather than the json
 -- blob.  Show lots of debugging info for the customer to paste in any issue they might open.
 errorPage :: SparError -> [Multipart.Input] -> Maybe Text -> ServerError
-errorPage err mp_inputs mcky =
+errorPage err mpInputs mcky =
   ServerError
     { errHTTPCode = Http.statusCode $ Wai.code werr,
       errReasonPhrase = cs $ Wai.label werr,
@@ -797,7 +796,7 @@ errorPage err mp_inputs mcky =
         "</body>",
         "  sorry, something went wrong :(<br>",
         "  please copy the following debug information to your clipboard and provide it when opening an issue in our customer support.<br><br>",
-        "  <pre>" <> (cs . toText . encodeBase64 . cs . show $ (err, mp_inputs, mcky)) <> "</pre>",
+        "  <pre>" <> (cs . toText . encodeBase64 . cs . show $ (err, mpInputs, mcky)) <> "</pre>",
         "</body>"
       ]
 

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -102,6 +102,8 @@ import qualified Web.Scim.Schema.Schema as Scim.Schema
 import qualified Web.Scim.Server as Scim
 import Wire.API.Routes.Public.Spar
 import Wire.API.User.Scim
+import Polysemy.Input (Input)
+import Wire.API.User.Saml (Opts)
 
 -- | SCIM config for our server.
 --
@@ -111,7 +113,7 @@ configuration :: Scim.Meta.Configuration
 configuration = Scim.Meta.empty
 
 apiScim ::
-  Members '[Random, Logger (Msg -> Msg), Logger String, Error SparError, GalleyAccess, BrigAccess, ScimExternalIdStore, ScimUserTimesStore, ScimTokenStore, IdPEffect.IdP, SAMLUserStore] r =>
+  Members '[Random, Input Opts, Logger (Msg -> Msg), Logger String, Error SparError, GalleyAccess, BrigAccess, ScimExternalIdStore, ScimUserTimesStore, ScimTokenStore, IdPEffect.IdP, SAMLUserStore] r =>
   ServerT APIScim (Spar r)
 apiScim =
   hoistScim (toServant (server configuration))

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -94,6 +94,7 @@ import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)
 import Spar.Sem.ScimTokenStore (ScimTokenStore)
 import Spar.Sem.ScimUserTimesStore (ScimUserTimesStore)
 import System.Logger (Msg)
+import qualified System.Logger as TinyLog
 import qualified Web.Scim.Capabilities.MetaSchema as Scim.Meta
 import qualified Web.Scim.Class.Auth as Scim.Auth
 import qualified Web.Scim.Class.User as Scim.User
@@ -102,10 +103,8 @@ import qualified Web.Scim.Schema.Error as Scim
 import qualified Web.Scim.Schema.Schema as Scim.Schema
 import qualified Web.Scim.Server as Scim
 import Wire.API.Routes.Public.Spar
-import Wire.API.User.Scim
-import Polysemy.Input (Input)
 import Wire.API.User.Saml (Opts)
-import qualified System.Logger as TinyLog
+import Wire.API.User.Scim
 
 -- | SCIM config for our server.
 --
@@ -116,8 +115,22 @@ configuration = Scim.Meta.empty
 
 apiScim ::
   forall r.
-    Members '[ Input TinyLog.Logger, Random,
-               Input Opts, Logger (Msg -> Msg), Logger String, Error SparError, GalleyAccess, BrigAccess, ScimExternalIdStore, ScimUserTimesStore, ScimTokenStore, IdPEffect.IdP, SAMLUserStore] r =>
+  Members
+    '[ Input TinyLog.Logger,
+       Random,
+       Input Opts,
+       Logger (Msg -> Msg),
+       Logger String,
+       Error SparError,
+       GalleyAccess,
+       BrigAccess,
+       ScimExternalIdStore,
+       ScimUserTimesStore,
+       ScimTokenStore,
+       IdPEffect.IdP,
+       SAMLUserStore
+     ]
+    r =>
   ServerT APIScim (Spar r)
 apiScim =
   hoistScim (toServant (server configuration))

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -46,6 +46,7 @@ import Imports
 
 import Polysemy
 import Polysemy.Error
+import Polysemy.Input
 import qualified SAML2.WebSSO as SAML
 import Servant (NoContent (NoContent), ServerT, (:<|>) ((:<|>)))
 import Spar.App (Spar, liftSem, wrapMonadClientSem)
@@ -63,9 +64,8 @@ import qualified Web.Scim.Class.Auth as Scim.Class.Auth
 import qualified Web.Scim.Handler as Scim
 import qualified Web.Scim.Schema.Error as Scim
 import Wire.API.Routes.Public.Spar (APIScimToken)
-import Wire.API.User.Saml (maxScimTokens, Opts)
+import Wire.API.User.Saml (Opts, maxScimTokens)
 import Wire.API.User.Scim
-import Polysemy.Input
 
 -- | An instance that tells @hscim@ how authentication should be done for SCIM routes.
 instance Member ScimTokenStore r => Scim.Class.Auth.AuthDB SparTag (Spar r) where
@@ -85,7 +85,16 @@ instance Member ScimTokenStore r => Scim.Class.Auth.AuthDB SparTag (Spar r) wher
 -- | API for manipulating SCIM tokens (protected by normal Wire authentication and available
 -- only to team owners).
 apiScimToken ::
-  Members '[Random, Input Opts, GalleyAccess, BrigAccess, ScimTokenStore, IdPEffect.IdP, Error E.SparError] r =>
+  Members
+    '[ Random,
+       Input Opts,
+       GalleyAccess,
+       BrigAccess,
+       ScimTokenStore,
+       IdPEffect.IdP,
+       Error E.SparError
+     ]
+    r =>
   ServerT APIScimToken (Spar r)
 apiScimToken =
   createScimToken
@@ -97,7 +106,16 @@ apiScimToken =
 -- Create a token for user's team.
 createScimToken ::
   forall r.
-  Members '[Random, Input Opts, GalleyAccess, BrigAccess, ScimTokenStore, IdPEffect.IdP, Error E.SparError] r =>
+  Members
+    '[ Random,
+       Input Opts,
+       GalleyAccess,
+       BrigAccess,
+       ScimTokenStore,
+       IdPEffect.IdP,
+       Error E.SparError
+     ]
+    r =>
   -- | Who is trying to create a token
   Maybe UserId ->
   -- | Request body

--- a/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
@@ -7,13 +7,13 @@ import Control.Monad.Except (runExceptT)
 import Imports hiding (MonadReader (..), Reader)
 import Polysemy
 import Polysemy.Error
+import Polysemy.Input (Input, input)
 import SAML2.WebSSO (HasNow, fromTime, getNow)
 import qualified SAML2.WebSSO as SAML
 import qualified Spar.Data as Data
 import Spar.Error
 import Spar.Sem.AReqIDStore
 import Wire.API.User.Saml (Opts, TTLError)
-import Polysemy.Input (Input, input)
 
 instance Member (Embed IO) r => HasNow (Sem r)
 

--- a/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
@@ -7,24 +7,24 @@ import Control.Monad.Except (runExceptT)
 import Imports hiding (MonadReader (..), Reader)
 import Polysemy
 import Polysemy.Error
-import Polysemy.Reader
 import SAML2.WebSSO (HasNow, fromTime, getNow)
 import qualified SAML2.WebSSO as SAML
 import qualified Spar.Data as Data
 import Spar.Error
 import Spar.Sem.AReqIDStore
 import Wire.API.User.Saml (Opts, TTLError)
+import Polysemy.Input (Input, input)
 
 instance Member (Embed IO) r => HasNow (Sem r)
 
 aReqIDStoreToCassandra ::
   forall m r a.
-  (MonadClient m, Members '[Embed m, Error TTLError, Embed IO, Reader Opts] r) =>
+  (MonadClient m, Members '[Embed m, Error TTLError, Embed IO, Input Opts] r) =>
   Sem (AReqIDStore ': r) a ->
   Sem r a
 aReqIDStoreToCassandra = interpret $ \case
   Store itla t -> do
-    denv <- Data.mkEnv <$> ask <*> (fromTime <$> getNow)
+    denv <- Data.mkEnv <$> input <*> (fromTime <$> getNow)
     a <- embed @m $ runExceptT $ runReaderT (Data.storeAReqID itla t) denv
     case a of
       Left err -> throw err

--- a/services/spar/src/Spar/Sem/AssIDStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/AssIDStore/Cassandra.hs
@@ -5,12 +5,12 @@ import Control.Monad.Except (runExceptT)
 import Imports hiding (MonadReader (..), Reader)
 import Polysemy
 import Polysemy.Error
+import Polysemy.Input
 import SAML2.WebSSO (fromTime, getNow)
 import qualified Spar.Data as Data
 import Spar.Sem.AReqIDStore.Cassandra ()
 import Spar.Sem.AssIDStore
 import Wire.API.User.Saml (Opts, TTLError)
-import Polysemy.Input
 
 assIDStoreToCassandra ::
   forall m r a.

--- a/services/spar/src/Spar/Sem/AssIDStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/AssIDStore/Cassandra.hs
@@ -5,22 +5,22 @@ import Control.Monad.Except (runExceptT)
 import Imports hiding (MonadReader (..), Reader)
 import Polysemy
 import Polysemy.Error
-import Polysemy.Reader
 import SAML2.WebSSO (fromTime, getNow)
 import qualified Spar.Data as Data
 import Spar.Sem.AReqIDStore.Cassandra ()
 import Spar.Sem.AssIDStore
 import Wire.API.User.Saml (Opts, TTLError)
+import Polysemy.Input
 
 assIDStoreToCassandra ::
   forall m r a.
-  (MonadClient m, Members '[Embed m, Error TTLError, Embed IO, Reader Opts] r) =>
+  (MonadClient m, Members '[Embed m, Error TTLError, Embed IO, Input Opts] r) =>
   Sem (AssIDStore ': r) a ->
   Sem r a
 assIDStoreToCassandra =
   interpret $ \case
     Store itla t -> do
-      denv <- Data.mkEnv <$> ask <*> (fromTime <$> getNow)
+      denv <- Data.mkEnv <$> input <*> (fromTime <$> getNow)
       a <- embed @m $ runExceptT $ runReaderT (Data.storeAssID itla t) denv
       case a of
         Left err -> throw err

--- a/services/spar/src/Spar/Sem/BindCookieStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/BindCookieStore/Cassandra.hs
@@ -8,21 +8,21 @@ import Control.Monad.Except (runExceptT)
 import Imports hiding (MonadReader (..), Reader)
 import Polysemy
 import Polysemy.Error
-import Polysemy.Reader
 import SAML2.WebSSO (fromTime, getNow)
 import qualified Spar.Data as Data
 import Spar.Sem.AReqIDStore.Cassandra ()
 import Spar.Sem.BindCookieStore
 import Wire.API.User.Saml (Opts, TTLError)
+import Polysemy.Input
 
 bindCookieStoreToCassandra ::
   forall m r a.
-  (MonadClient m, Members '[Embed m, Error TTLError, Embed IO, Reader Opts] r) =>
+  (MonadClient m, Members '[Embed m, Error TTLError, Embed IO, Input Opts] r) =>
   Sem (BindCookieStore ': r) a ->
   Sem r a
 bindCookieStoreToCassandra = interpret $ \case
   Insert sbc uid ndt -> do
-    denv <- Data.mkEnv <$> ask <*> (fromTime <$> getNow)
+    denv <- Data.mkEnv <$> input <*> (fromTime <$> getNow)
     a <- embed @m $ runExceptT $ runReaderT (Data.insertBindCookie sbc uid ndt) denv
     case a of
       Left err -> throw err

--- a/services/spar/src/Spar/Sem/BindCookieStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/BindCookieStore/Cassandra.hs
@@ -8,12 +8,12 @@ import Control.Monad.Except (runExceptT)
 import Imports hiding (MonadReader (..), Reader)
 import Polysemy
 import Polysemy.Error
+import Polysemy.Input
 import SAML2.WebSSO (fromTime, getNow)
 import qualified Spar.Data as Data
 import Spar.Sem.AReqIDStore.Cassandra ()
 import Spar.Sem.BindCookieStore
 import Wire.API.User.Saml (Opts, TTLError)
-import Polysemy.Input
 
 bindCookieStoreToCassandra ::
   forall m r a.

--- a/stack.yaml
+++ b/stack.yaml
@@ -175,7 +175,7 @@ extra-deps:
 - servant-swagger-ui-0.3.4.3.36.1
 - tls-1.5.5
 - cryptonite-0.28
-- polysemy-1.6.0.0
+- polysemy-1.6.0.0 # needed for Polysemy.Input combinators
 
 # For changes from #128 and #135, not released to hackage yet
 - git: https://github.com/haskell-servant/servant-swagger

--- a/stack.yaml
+++ b/stack.yaml
@@ -175,6 +175,7 @@ extra-deps:
 - servant-swagger-ui-0.3.4.3.36.1
 - tls-1.5.5
 - cryptonite-0.28
+- polysemy-1.6.0.0
 
 # For changes from #128 and #135, not released to hackage yet
 - git: https://github.com/haskell-servant/servant-swagger

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -527,6 +527,13 @@ packages:
   original:
     hackage: cryptonite-0.28
 - completed:
+    hackage: polysemy-1.6.0.0@sha256:29a73b1bf3d0049b12041016b7ee25e76bd8f6e99f9c37c2dde2b46368246697,6184
+    pantry-tree:
+      size: 4577
+      sha256: c4ca508b4a6786fc27e0f484344ce8dba119ea2f7fe47fb7379a51313a94cd10
+  original:
+    hackage: polysemy-1.6.0.0
+- completed:
     name: servant-swagger
     version: 1.1.11
     git: https://github.com/haskell-servant/servant-swagger


### PR DESCRIPTION
This PR removes the `ReaderT` inside of the `Spar` newtype, instead using the `Input` effect to thread the `Opts` to whichever places need it.

To be merged after #1814.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
