### PR TITLE
Make federated connection functions work with qualified IDs

### DIFF
--- a/changelog.d/5-internal/fed-connections-data
+++ b/changelog.d/5-internal/fed-connections-data
@@ -1,0 +1,1 @@
+Make connection DB functions work with Qualified IDs

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d5382afdfc45e225067c7848e99d40349897ddd6eeb69be59038373e57ada716
+-- hash: 74882d161b7ecee96907491a40139775942d4f15987cbe1aa30d13b30fc79e0e
 
 name:           brig
 version:        1.35.0
@@ -173,6 +173,7 @@ library
     , metrics-wai >=0.3
     , mime
     , mime-mail >=0.4
+    , mmorph
     , mtl >=2.1
     , mu-grpc-client
     , multihash >=0.1.3
@@ -207,6 +208,7 @@ library
     , string-conversions
     , swagger >=0.1
     , swagger2
+    , tagged
     , template >=0.2
     , text >=0.11
     , text-icu-translit >=0.1

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -72,6 +72,7 @@ library:
   - mime
   - mime-mail >=0.4
   - MonadRandom >=0.5
+  - mmorph
   - mtl >=2.1
   - mu-grpc-client
   - multihash >=0.1.3
@@ -106,6 +107,7 @@ library:
   - string-conversions
   - swagger >=0.1
   - swagger2
+  - tagged
   - template >=0.2
   - text >=0.11
   - text-icu-translit >=0.1

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -22,7 +22,7 @@
 -- User connection logic.
 module Brig.API.Connection
   ( -- * Connections
-    createConnectionToUser,
+    createConnection,
     updateConnection,
     UpdateConnectionsInternal (..),
     updateConnectionInternal,
@@ -64,12 +64,12 @@ import Wire.API.Routes.Public.Util (ResponseForExistedCreated (..))
 
 type ConnectionM = ExceptT ConnectionError AppIO
 
-createConnectionToUser ::
+createConnection ::
   Local UserId ->
   ConnId ->
   Qualified UserId ->
   ConnectionM (ResponseForExistedCreated UserConnection)
-createConnectionToUser lusr con target = do
+createConnection lusr con target = do
   let connect =
         foldQualified
           lusr

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -69,20 +69,18 @@ createConnection ::
   ConnId ->
   Qualified UserId ->
   ConnectionM (ResponseForExistedCreated UserConnection)
-createConnection lusr con target = do
-  let connect =
-        foldQualified
-          lusr
-          createConnectionToLocalUser
-          createConnectionToRemoteUser
-  connect target lusr con
+createConnection lusr con =
+  foldQualified
+    lusr
+    (createConnectionToLocalUser lusr con)
+    (createConnectionToRemoteUser lusr con)
 
 createConnectionToLocalUser ::
   Local UserId ->
-  Local UserId ->
   ConnId ->
+  Local UserId ->
   ConnectionM (ResponseForExistedCreated UserConnection)
-createConnectionToLocalUser self target conn = do
+createConnectionToLocalUser self conn target = do
   when (self == target) $
     throwE (InvalidUser (unTagged target))
   selfActive <- lift $ Data.isActivated (lUnqualified self)
@@ -178,9 +176,9 @@ createConnectionToLocalUser self target conn = do
       pure $ isJust selfTeam && selfTeam == crTeam
 
 createConnectionToRemoteUser ::
-  Remote UserId ->
   Local UserId ->
   ConnId ->
+  Remote UserId ->
   ConnectionM (ResponseForExistedCreated UserConnection)
 createConnectionToRemoteUser _ _ _ = throwM federationNotImplemented
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -1089,12 +1089,12 @@ createConnectionUnqualified :: UserId -> ConnId -> Public.ConnectionRequest -> H
 createConnectionUnqualified self conn cr = do
   lself <- qualifyLocal self
   target <- qualifyLocal (Public.crUser cr)
-  API.createConnectionToUser lself conn (unTagged target) !>> connError
+  API.createConnection lself conn (unTagged target) !>> connError
 
 createConnection :: UserId -> ConnId -> Qualified UserId -> Handler (Public.ResponseForExistedCreated Public.UserConnection)
 createConnection self conn target = do
   lself <- qualifyLocal self
-  API.createConnectionToUser lself conn target !>> connError
+  API.createConnection lself conn target !>> connError
 
 updateLocalConnection :: UserId -> ConnId -> UserId -> Public.ConnectionUpdate -> Handler (Public.UpdateResult Public.UserConnection)
 updateLocalConnection self conn other update = do

--- a/services/brig/src/Brig/API/Types.hs
+++ b/services/brig/src/Brig/API/Types.hs
@@ -41,6 +41,7 @@ import Brig.Types.Code (Timeout)
 import Brig.Types.Intra
 import Brig.User.Auth.Cookie (RetryAfter (..))
 import Data.Id
+import Data.Qualified
 import Imports
 import qualified Network.Wai.Utilities.Error as Wai
 import Wire.API.Federation.Client (FederationError)
@@ -116,9 +117,9 @@ data ConnectionError
   | -- | An invalid connection status change.
     InvalidTransition UserId Relation
   | -- | The target user in an connection attempt is invalid, e.g. not activated.
-    InvalidUser UserId
+    InvalidUser (Qualified UserId)
   | -- | An attempt at updating a non-existent connection.
-    NotConnected UserId UserId
+    NotConnected UserId (Qualified UserId)
   | -- | An attempt at creating a connection from an account with
     -- no verified user identity.
     ConnectNoIdentity

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -64,6 +64,7 @@ module Brig.App
     forkAppIO,
     locationOf,
     viewFederationDomain,
+    qualifyLocal,
   )
 where
 
@@ -106,6 +107,7 @@ import Data.List1 (List1, list1)
 import Data.Metrics (Metrics)
 import qualified Data.Metrics.Middleware as Metrics
 import Data.Misc
+import Data.Qualified (Local, Qualified (..), toLocal)
 import Data.Text (unpack)
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
@@ -540,3 +542,6 @@ readTurnList = Text.readFile >=> return . fn . mapMaybe fromByteString . fmap Te
 
 viewFederationDomain :: MonadReader Env m => m (Domain)
 viewFederationDomain = view (settings . Opt.federationDomain)
+
+qualifyLocal :: MonadReader Env m => a -> m (Local a)
+qualifyLocal a = fmap (toLocal . Qualified a) viewFederationDomain

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -18,15 +18,10 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Brig.Data.Connection
-  ( -- * DB Types
-    LocalConnection (..),
-    RemoteConnection (..),
-    localToUserConn,
-
-    -- * DB Operations
-    insertLocalConnection,
-    updateLocalConnection,
-    lookupLocalConnection,
+  ( -- * DB Operations
+    insertConnection,
+    updateConnection,
+    lookupConnection,
     lookupLocalConnectionsPage,
     lookupRelationWithHistory,
     lookupLocalConnections,
@@ -47,12 +42,14 @@ module Brig.Data.Connection
   )
 where
 
-import Brig.App (AppIO)
+import Brig.App (AppIO, qualifyLocal)
 import Brig.Data.Instances ()
 import Brig.Data.Types as T
 import Brig.Types
 import Brig.Types.Intra
 import Cassandra
+import Control.Monad.Morph
+import Control.Monad.Trans.Maybe
 import Data.Conduit (runConduit, (.|))
 import qualified Data.Conduit.List as C
 import Data.Domain (Domain)
@@ -60,101 +57,114 @@ import Data.Id
 import Data.Json.Util (UTCTimeMillis, toUTCTimeMillis)
 import Data.Qualified
 import Data.Range
+import Data.Tagged
 import Data.Time (getCurrentTime)
-import Imports
+import Imports hiding (local)
 import UnliftIO.Async (pooledMapConcurrentlyN_)
 import Wire.API.Connection
 
-data LocalConnection = LocalConnection
-  { lcFrom :: UserId,
-    lcTo :: UserId,
-    lcStatus :: Relation,
-    -- | Why is this a Maybe? Are there actually any users who have this as null in DB?
-    lcConv :: Maybe ConvId,
-    lcLastUpdated :: UTCTimeMillis
-  }
-
-localToUserConn :: Domain -> LocalConnection -> UserConnection
-localToUserConn localDomain lc =
-  UserConnection
-    { ucFrom = lcFrom lc,
-      ucTo = Qualified (lcTo lc) localDomain,
-      ucStatus = lcStatus lc,
-      ucLastUpdate = lcLastUpdated lc,
-      ucConvId = flip Qualified localDomain <$> lcConv lc
-    }
-
-data RemoteConnection = RemoteConnection
-  { rcFrom :: UserId,
-    rcTo :: Qualified UserId,
-    rcRelationWithHistory :: Relation,
-    rcConv :: Qualified ConvId
-  }
-
-insertLocalConnection ::
-  -- | From
-  UserId ->
-  -- | To
-  UserId ->
+insertConnection ::
+  Local UserId ->
+  Qualified UserId ->
   RelationWithHistory ->
-  ConvId ->
-  AppIO LocalConnection
-insertLocalConnection from to status cid = do
+  Qualified ConvId ->
+  AppIO UserConnection
+insertConnection self target rel qcnv@(Qualified cnv cdomain) = do
   now <- toUTCTimeMillis <$> liftIO getCurrentTime
-  retry x5 . write connectionInsert $ params Quorum (from, to, status, now, cid)
-  return $ toLocalUserConnection (from, to, status, now, Just cid)
+  let local (lUnqualified -> ltarget) =
+        write connectionInsert $
+          params Quorum (lUnqualified self, ltarget, rel, now, cnv)
+  let remote (unTagged -> Qualified rtarget domain) =
+        write remoteConnectionInsert $
+          params Quorum (lUnqualified self, domain, rtarget, rel, now, cdomain, cnv)
+  retry x5 $ foldQualified self local remote target
+  pure $
+    UserConnection
+      { ucFrom = lUnqualified self,
+        ucTo = target,
+        ucStatus = relationDropHistory rel,
+        ucLastUpdate = now,
+        ucConvId = Just qcnv
+      }
 
-updateLocalConnection :: LocalConnection -> RelationWithHistory -> AppIO LocalConnection
-updateLocalConnection c@LocalConnection {..} status = do
+updateConnection :: UserConnection -> RelationWithHistory -> AppIO UserConnection
+updateConnection c status = do
+  self <- qualifyLocal (ucFrom c)
   now <- toUTCTimeMillis <$> liftIO getCurrentTime
-  retry x5 . write connectionUpdate $ params Quorum (status, now, lcFrom, lcTo)
-  return $
+  let local (lUnqualified -> ltarget) =
+        write connectionUpdate $
+          params Quorum (status, now, lUnqualified self, ltarget)
+  let remote (unTagged -> Qualified rtarget domain) =
+        write remoteConnectionUpdate $
+          params Quorum (status, now, lUnqualified self, domain, rtarget)
+  retry x5 $ foldQualified self local remote (ucTo c)
+  pure $
     c
-      { lcStatus = relationDropHistory status,
-        lcLastUpdated = now
+      { ucStatus = relationDropHistory status,
+        ucLastUpdate = now
       }
 
 -- | Lookup the connection from a user 'A' to a user 'B' (A -> B).
-lookupLocalConnection ::
-  -- | User 'A'
-  UserId ->
-  -- | User 'B'
-  UserId ->
-  AppIO (Maybe LocalConnection)
-lookupLocalConnection from to =
-  toLocalUserConnection <$$> retry x1 (query1 connectionSelect (params Quorum (from, to)))
+lookupConnection :: Local UserId -> Qualified UserId -> AppIO (Maybe UserConnection)
+lookupConnection self target = runMaybeT $ do
+  let local (lUnqualified -> ltarget) = do
+        (_, _, rel, time, mcnv) <-
+          MaybeT . query1 connectionSelect $
+            params Quorum (lUnqualified self, ltarget)
+        pure (rel, time, fmap (unTagged . qualifyAs self) mcnv)
+  let remote (unTagged -> Qualified rtarget domain) = do
+        (rel, time, cdomain, cnv) <-
+          MaybeT . query1 remoteConnectionSelectFrom $
+            params Quorum (lUnqualified self, domain, rtarget)
+        pure (rel, time, Just (Qualified cnv cdomain))
+  (rel, time, mqcnv) <- hoist (retry x1) $ foldQualified self local remote target
+  pure $
+    UserConnection
+      { ucFrom = lUnqualified self,
+        ucTo = target,
+        ucStatus = relationDropHistory rel,
+        ucLastUpdate = time,
+        ucConvId = mqcnv
+      }
 
 -- | 'lookupConnection' with more 'Relation' info.
 lookupRelationWithHistory ::
   -- | User 'A'
-  UserId ->
+  Local UserId ->
   -- | User 'B'
-  UserId ->
+  Qualified UserId ->
   AppIO (Maybe RelationWithHistory)
-lookupRelationWithHistory from to =
-  runIdentity
-    <$$> retry x1 (query1 relationSelect (params Quorum (from, to)))
+lookupRelationWithHistory self target = do
+  let local (lUnqualified -> ltarget) =
+        query1 relationSelect (params Quorum (lUnqualified self, ltarget))
+  let remote (unTagged -> Qualified rtarget domain) =
+        query1 remoteRelationSelect (params Quorum (lUnqualified self, domain, rtarget))
+  runIdentity <$$> retry x1 (foldQualified self local remote target)
 
 -- | For a given user 'A', lookup their outgoing connections (A -> X) to other users.
-lookupLocalConnections :: UserId -> Maybe UserId -> Range 1 500 Int32 -> AppIO (ResultPage LocalConnection)
-lookupLocalConnections from start (fromRange -> size) =
+lookupLocalConnections :: Local UserId -> Maybe UserId -> Range 1 500 Int32 -> AppIO (ResultPage UserConnection)
+lookupLocalConnections lfrom start (fromRange -> size) =
   toResult <$> case start of
-    Just u -> retry x1 $ paginate connectionsSelectFrom (paramsP Quorum (from, u) (size + 1))
-    Nothing -> retry x1 $ paginate connectionsSelect (paramsP Quorum (Identity from) (size + 1))
+    Just u ->
+      retry x1 $
+        paginate connectionsSelectFrom (paramsP Quorum (lUnqualified lfrom, u) (size + 1))
+    Nothing ->
+      retry x1 $
+        paginate connectionsSelect (paramsP Quorum (Identity (lUnqualified lfrom)) (size + 1))
   where
-    toResult = cassandraResultPage . fmap toLocalUserConnection . trim
+    toResult = cassandraResultPage . fmap (toLocalUserConnection lfrom) . trim
     trim p = p {result = take (fromIntegral size) (result p)}
 
 -- | For a given user 'A', lookup their outgoing connections (A -> X) to other users.
 -- Similar to lookupLocalConnections
 lookupLocalConnectionsPage ::
   (MonadClient m) =>
-  UserId ->
+  Local UserId ->
   Maybe PagingState ->
   Range 1 1000 Int32 ->
-  m (PageWithState LocalConnection)
-lookupLocalConnectionsPage usr pagingState (fromRange -> size) =
-  fmap toLocalUserConnection <$> paginateWithState connectionsSelect (paramsPagingState Quorum (Identity usr) size pagingState)
+  m (PageWithState UserConnection)
+lookupLocalConnectionsPage self pagingState (fromRange -> size) =
+  fmap (toLocalUserConnection self) <$> paginateWithState connectionsSelect (paramsPagingState Quorum (Identity (lUnqualified self)) size pagingState)
 
 -- | Lookup all relations between two sets of users (cartesian product).
 lookupConnectionStatus :: [UserId] -> [UserId] -> AppIO [ConnectionStatus]
@@ -182,9 +192,9 @@ lookupContactListWithRelation u =
 -- | Count the number of connections a user has in a specific relation status.
 -- (If you want to distinguish 'RelationWithHistory', write a new function.)
 -- Note: The count is eventually consistent.
-countConnections :: UserId -> [Relation] -> AppIO Int64
+countConnections :: Local UserId -> [Relation] -> AppIO Int64
 countConnections u r = do
-  rels <- retry x1 . query selectStatus $ params One (Identity u)
+  rels <- retry x1 . query selectStatus $ params One (Identity (lUnqualified u))
   return $ foldl' count 0 rels
   where
     selectStatus :: QueryString R (Identity UserId) (Identity RelationWithHistory)
@@ -242,11 +252,14 @@ connectionClear = "DELETE FROM connection WHERE left = ?"
 remoteConnectionInsert :: PrepQuery W (UserId, Domain, UserId, RelationWithHistory, UTCTimeMillis, Domain, ConvId) ()
 remoteConnectionInsert = "INSERT INTO connection_remote (left, right_domain, right_user, status, last_update, conv_domain, conv_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
 
-remoteConnectionSelect :: PrepQuery R (Identity UserId) (Domain, UserId, RelationWithHistory, Domain, ConvId)
-remoteConnectionSelect = "SELECT right_domain, right_user, status, conv_domain, conv_id FROM connection_remote where left = ?"
+remoteConnectionSelect :: PrepQuery R (Identity UserId) (Domain, UserId, RelationWithHistory, UTCTimeMillis, Domain, ConvId)
+remoteConnectionSelect = "SELECT right_domain, right_user, status, last_update, conv_domain, conv_id FROM connection_remote where left = ?"
 
-remoteConnectionSelectFrom :: PrepQuery R (UserId, Domain, UserId) (RelationWithHistory, Domain, ConvId)
-remoteConnectionSelectFrom = "SELECT status, conv_domain, conv_id FROM connection_remote where left = ? AND right_domain = ? AND right = ?"
+remoteConnectionSelectFrom :: PrepQuery R (UserId, Domain, UserId) (RelationWithHistory, UTCTimeMillis, Domain, ConvId)
+remoteConnectionSelectFrom = "SELECT status, last_update, conv_domain, conv_id FROM connection_remote where left = ? AND right_domain = ? AND right = ?"
+
+remoteConnectionUpdate :: PrepQuery W (RelationWithHistory, UTCTimeMillis, UserId, Domain, UserId) ()
+remoteConnectionUpdate = "UPDATE connection_remote set status = ?, last_update = ? WHERE left = ? and right_domain = ? and right_user = ?"
 
 remoteConnectionDelete :: PrepQuery W (UserId, Domain, UserId) ()
 remoteConnectionDelete = "DELETE FROM connection_remote where left = ? AND right_domain = ? AND right = ?"
@@ -254,10 +267,17 @@ remoteConnectionDelete = "DELETE FROM connection_remote where left = ? AND right
 remoteConnectionClear :: PrepQuery W (Identity UserId) ()
 remoteConnectionClear = "DELETE FROM connection_remote where left = ?"
 
+remoteRelationSelect :: PrepQuery R (UserId, Domain, UserId) (Identity RelationWithHistory)
+remoteRelationSelect = "SELECT status FROM connection_remote WHERE left = ? AND right_domain = ? AND right_user = ?"
+
 -- Conversions
 
-toLocalUserConnection :: (UserId, UserId, RelationWithHistory, UTCTimeMillis, Maybe ConvId) -> LocalConnection
-toLocalUserConnection (l, r, relationDropHistory -> rel, time, cid) = LocalConnection l r rel cid time
+toLocalUserConnection ::
+  Local x ->
+  (UserId, UserId, RelationWithHistory, UTCTimeMillis, Maybe ConvId) ->
+  UserConnection
+toLocalUserConnection loc (l, r, relationDropHistory -> rel, time, cid) =
+  UserConnection l (unTagged (qualifyAs loc r)) rel time (fmap (unTagged . qualifyAs loc) cid)
 
 toConnectionStatus :: (UserId, UserId, RelationWithHistory) -> ConnectionStatus
 toConnectionStatus (l, r, relationDropHistory -> rel) = ConnectionStatus l r rel

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1602,10 +1602,10 @@ postO2OConvOk = do
   alice <- randomUser
   bob <- randomUser
   connectUsers alice (singleton bob)
-  a <- postO2OConv alice bob (Just "chat") <!! const 200 === statusCode
-  c <- postO2OConv alice bob (Just "chat") <!! const 200 === statusCode
-  aId <- assertConv a One2OneConv alice alice [bob] (Just "chat") Nothing
-  cId <- assertConv c One2OneConv alice alice [bob] (Just "chat") Nothing
+  a <- postO2OConv alice bob Nothing <!! const 200 === statusCode
+  c <- postO2OConv alice bob Nothing <!! const 200 === statusCode
+  aId <- assertConv a One2OneConv alice alice [bob] Nothing Nothing
+  cId <- assertConv c One2OneConv alice alice [bob] Nothing Nothing
   liftIO $ aId @=? cId
 
 postConvO2OFailWithSelf :: TestM ()

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -211,7 +211,7 @@ messageTimerChangeO2O = do
   rsp <-
     postO2OConv alice bob Nothing
       <!! const 200 === statusCode
-  cid <- assertConv rsp One2OneConv alice alice [bob] (Just "chat") Nothing
+  cid <- assertConv rsp One2OneConv alice alice [bob] Nothing Nothing
   -- Try to change the timer and observe failure
   putMessageTimerUpdate alice cid (ConversationMessageTimerUpdate timer1sec) !!! do
     const 403 === statusCode


### PR DESCRIPTION
This PR makes the Data functions for connections take `Qualified` arguments and simply return `UserConnection` values instead of using existing `LocalConnection`.

The `LocalConnection` type has been deleted, and now the handlers deal with `UserConnection` objects directly.

The listing/pagination functions have not been changed, since the pagination mechanism needs to be ported to the new multi-table system anyway.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
