### PR TITLE
Use hs-certificate master

### DIFF
--- a/changelog.d/5-internal/hs-certificate-master
+++ b/changelog.d/5-internal/hs-certificate-master
@@ -1,0 +1,1 @@
+Depend on hs-certificate master instead of our fork

--- a/stack.yaml
+++ b/stack.yaml
@@ -249,8 +249,8 @@ extra-deps:
   commit: b0e5c08af48911caecffa4fa6a3e74872018b258 # master (Sep 03, 2021)
 
 # Error handling fix: https://github.com/vincenthz/hs-certificate/pull/125
-- git: https://github.com/wireapp/hs-certificate
-  commit: e3ea2e1166f0569982a85aad9bc9de8f5b2994c1 # master (Aug 31, 2021)
+- git: https://github.com/vincenthz/hs-certificate
+  commit: a899bda3d7666d25143be7be8f3105fc076703d9 # master (Sep 29, 2021)
   subdirs:
     - x509-store
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -804,15 +804,15 @@ packages:
     subdir: x509-store
     name: x509-store
     version: 1.6.7
-    git: https://github.com/wireapp/hs-certificate
+    git: https://github.com/vincenthz/hs-certificate
     pantry-tree:
       size: 398
-      sha256: 96deca9a5358118057cd145f198b5be06d88019eae46b263bee86c76b2fc574d
-    commit: e3ea2e1166f0569982a85aad9bc9de8f5b2994c1
+      sha256: bf71c28417dcf76a8aef361fbc74abe78962c80e7e996a2515996fd44b2f6ba6
+    commit: a899bda3d7666d25143be7be8f3105fc076703d9
   original:
     subdir: x509-store
-    git: https://github.com/wireapp/hs-certificate
-    commit: e3ea2e1166f0569982a85aad9bc9de8f5b2994c1
+    git: https://github.com/vincenthz/hs-certificate
+    commit: a899bda3d7666d25143be7be8f3105fc076703d9
 - completed:
     hackage: ormolu-0.1.4.1@sha256:ed404eac6e4eb64da1ca5fb749e0f99907431a9633e6ba34e44d260e7d7728ba,6499
     pantry-tree:


### PR DESCRIPTION
The error handling fix https://github.com/vincenthz/hs-certificate/pull/125 has been merged, so we can just use the upstream master now, and later switch to the hackage package once it is released.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
