### PR TITLE
Add missing features to stern/backoffice.

### DIFF
--- a/changelog.d/5-internal/stern-features
+++ b/changelog.d/5-internal/stern-features
@@ -1,0 +1,1 @@
+Update configurable boolean team feature list in backoffice/stern.

--- a/tools/stern/src/Stern/Swagger.hs
+++ b/tools/stern/src/Stern/Swagger.hs
@@ -44,7 +44,7 @@ typeTeamFeatureNameNoConfig =
     cs . toByteString'
       <$> [ Public.TeamFeatureLegalHold,
             Public.TeamFeatureSSO,
-            Public.TeamFeatureSearchVisibility,  -- TODO: is this working?  then remove the custom entry below.
+            Public.TeamFeatureSearchVisibility, -- TODO: is this working?  then remove the custom entry below.
             Public.TeamFeatureValidateSAMLEmails,
             Public.TeamFeatureDigitalSignatures,
             Public.TeamFeatureFileSharing,

--- a/tools/stern/src/Stern/Swagger.hs
+++ b/tools/stern/src/Stern/Swagger.hs
@@ -44,9 +44,18 @@ typeTeamFeatureNameNoConfig =
     cs . toByteString'
       <$> [ Public.TeamFeatureLegalHold,
             Public.TeamFeatureSSO,
-            Public.TeamFeatureSearchVisibility,
+            Public.TeamFeatureSearchVisibility,  -- TODO: is this working?  then remove the custom entry below.
             Public.TeamFeatureValidateSAMLEmails,
-            Public.TeamFeatureDigitalSignatures
+            Public.TeamFeatureDigitalSignatures,
+            Public.TeamFeatureFileSharing,
+            Public.TeamFeatureClassifiedDomains,
+            Public.TeamFeatureConferenceCalling
+            -- you can keep this list updated by pulling all constructors `c`
+            -- `Public.TeamFeatureName` for which `TeamFeatureStatus c ~
+            -- TeamFeatureStatusNoConfig`
+            --
+            -- TODO: since we can't do this in code without dependent types, make an assertion
+            -- that we have not missed any.
           ]
 
 emailUpdate :: Model


### PR DESCRIPTION
Currently, these need to be added here manually.  I also left a TODO that we should automate that.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
