### PR TITLE
Quickcheck state machine for spar. [skip ci]

### DIFF
--- a/services/spar/test-integration/Test/Spar/STMSpec.hs
+++ b/services/spar/test-integration/Test/Spar/STMSpec.hs
@@ -1,0 +1,69 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Spar.STMSpec
+  ( spec,
+  )
+where
+
+import Test.Hspec
+import Imports
+
+spec :: Spec
+spec = pure ()
+
+----------------------------------------------------------------------
+
+-- FUTUREWORK:
+-- - team owners
+-- - personal accounts
+
+data TeamManage
+  = TeamCreate
+  | TeamNewIdP
+  | TeamUpdateIdP
+  | TeamReplaceIdP
+  | TeamRemoveIdP
+  | TeamNewScim
+  | TeamRemoveScim
+
+data CreateTeamMember
+  = CreateTeamManagementInv
+  | CreateSamlAuto
+  | CreateScim
+
+data Auth
+  = AuthViaPassword
+  | AuthViaSaml
+
+-- | No preconds, except that at least one user exists that can be read.
+data ReadUserState
+  = ScimGetUser
+  | ScimFindUser
+  | MembersCsv
+  | MembersSearch
+  | BrigGetUser
+  | CassandraAll -- read brig, galley, spar, and make sure all data in all tables is as predicted by the model.
+
+data UpdateUserState
+
+-- | The model keeps deleted users around so they can still try to authenticate and have the
+-- preditced experience (403).
+data DeleteUser
+  = DeleteViaTeamSettings
+  | DeleteViaScim
+  | SelfDelete -- never possible for team members?


### PR DESCRIPTION
## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information:
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
