### PR TITLE
Expose internal EJPD request end-point to backoffice.

### DIFF
--- a/changelog.d/5-internal/stern-ejpd
+++ b/changelog.d/5-internal/stern-ejpd
@@ -1,0 +1,1 @@
+Expose wire.com internal EJDP process to backoffice/stern.

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -29,6 +29,7 @@ module Stern.Intra
     getUsersConnections,
     getUserProfiles,
     getUserProfilesByIdentity,
+    getEjpdInfo,
     getUserProperties,
     getInvoiceUrl,
     revokeIdentity,
@@ -77,6 +78,7 @@ import Data.Id
 import Data.Int
 import Data.List.Split (chunksOf)
 import Data.Qualified (qUnqualified)
+import Data.String.Conversions (cs)
 import Data.Text (strip)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Text.Lazy (pack)
@@ -94,6 +96,7 @@ import Stern.Types
 import System.Logger.Class hiding (Error, name, (.=))
 import qualified System.Logger.Class as Log
 import UnliftIO.Exception hiding (Handler)
+import qualified Wire.API.Routes.Internal.Brig.EJPD as EJPD
 import qualified Wire.API.Team.Feature as Public
 
 -------------------------------------------------------------------------------
@@ -222,6 +225,25 @@ getUserProfilesByIdentity emailOrPhone = do
         ( method GET
             . path "/i/users"
             . userKeyToParam emailOrPhone
+            . expect2xx
+        )
+  parseResponse (mkError status502 "bad-upstream") r
+
+getEjpdInfo :: [Handle] -> Bool -> Handler EJPD.EJPDResponseBody
+getEjpdInfo handles includeContacts = do
+  info $ msg "Getting ejpd info on users by handle"
+  b <- view brig
+  let bdy :: Value
+      bdy = object ["ejpd_request" .= ((cs @_ @Text . toByteString') <$> handles)]
+  r <-
+    catchRpcErrors $
+      rpc'
+        "brig"
+        b
+        ( method POST
+            . path "/i/ejpd-request"
+            . Bilge.json bdy
+            . (if includeContacts then queryItem "include_contacts" "true" else id)
             . expect2xx
         )
   parseResponse (mkError status502 "bad-upstream") r


### PR DESCRIPTION
This exposes an internal end-point from brig for communication with swiss law enforcement to the stern/backoffice app.  Internal process to wire.com; does not increase exposure in any way as long as you don't operate stern insecurely.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
  - [x] **changelog.d** contains the following bits of information:
    - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
