### PR TITLE
Spar Polysemy: Fully polysemize Spar

### DIFF
--- a/changelog.d/5-internal/spar-no-io-2
+++ b/changelog.d/5-internal/spar-no-io-2
@@ -1,0 +1,1 @@
+Replace the `Spar` newtype, instead using `Sem` directly.

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fe28e95f2571e0a2583e7d160ff87f80422801408c265139b1cd2392a425fd72
+-- hash: e1e1abfd9d2fd00bd96a693a9466a13e0b7aef15677f0506941f662094a340a1
 
 name:           spar
 version:        0.1
@@ -57,6 +57,8 @@ library
       Spar.Sem.Now.IO
       Spar.Sem.Random
       Spar.Sem.Random.IO
+      Spar.Sem.Reporter
+      Spar.Sem.Reporter.Wai
       Spar.Sem.SAML2
       Spar.Sem.SAML2.Library
       Spar.Sem.SamlProtocolSettings

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -125,6 +125,8 @@ api ::
        Now,
        SamlProtocolSettings,
        Logger String,
+       -- TODO(sandy): Only necessary for 'fromExceptionSem' in 'apiScim'
+       Final IO,
        Logger (Msg -> Msg)
      ]
     r =>

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -83,6 +83,7 @@ import qualified Spar.Sem.Logger as Logger
 import Spar.Sem.Now (Now)
 import Spar.Sem.Random (Random)
 import qualified Spar.Sem.Random as Random
+import Spar.Sem.Reporter (Reporter)
 import Spar.Sem.SAML2 (SAML2)
 import qualified Spar.Sem.SAML2 as SAML2
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
@@ -125,6 +126,7 @@ api ::
        Now,
        SamlProtocolSettings,
        Logger String,
+       Reporter,
        -- TODO(sandy): Only necessary for 'fromExceptionSem' in 'apiScim'
        Final IO,
        Logger (Msg -> Msg)
@@ -156,6 +158,7 @@ apiSSO ::
        Error SparError,
        SAML2,
        SamlProtocolSettings,
+       Reporter,
        SAMLUserStore
      ]
     r =>
@@ -323,6 +326,7 @@ authresp ::
        SAML2,
        SamlProtocolSettings,
        Error SparError,
+       Reporter,
        SAMLUserStore
      ]
     r =>

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -93,7 +93,6 @@ import Spar.Sem.ScimTokenStore (ScimTokenStore)
 import qualified Spar.Sem.ScimTokenStore as ScimTokenStore
 import Spar.Sem.ScimUserTimesStore (ScimUserTimesStore)
 import System.Logger (Msg)
-import qualified System.Logger as TinyLog
 import qualified URI.ByteString as URI
 import Wire.API.Cookie
 import Wire.API.Routes.Public.Spar
@@ -109,7 +108,6 @@ api ::
   Members
     '[ GalleyAccess,
        BrigAccess,
-       Input TinyLog.Logger,
        Input Opts,
        BindCookieStore,
        AssIDStore,
@@ -145,7 +143,6 @@ apiSSO ::
   Members
     '[ GalleyAccess,
        Logger String,
-       Input TinyLog.Logger,
        Input Opts,
        BrigAccess,
        BindCookieStore,
@@ -306,7 +303,6 @@ authresp ::
     '[ Random,
        Logger String,
        Input Opts,
-       Input TinyLog.Logger,
        GalleyAccess,
        BrigAccess,
        BindCookieStore,

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -125,9 +125,7 @@ api ::
        Now,
        SamlProtocolSettings,
        Logger String,
-       Logger (Msg -> Msg),
-       -- TODO(sandy): Remove me when we get rid of runSparInSem
-       Final IO
+       Logger (Msg -> Msg)
      ]
     r =>
   Opts ->
@@ -156,9 +154,7 @@ apiSSO ::
        Error SparError,
        SAML2,
        SamlProtocolSettings,
-       SAMLUserStore,
-       -- TODO(sandy): Remove me when we get rid of runSparInSem
-       Final IO
+       SAMLUserStore
      ]
     r =>
   Opts ->
@@ -325,9 +321,7 @@ authresp ::
        SAML2,
        SamlProtocolSettings,
        Error SparError,
-       SAMLUserStore,
-       -- TODO(sandy): Remove me when we get rid of runSparInSem
-       Final IO
+       SAMLUserStore
      ]
     r =>
   Maybe TeamId ->

--- a/services/spar/src/Spar/CanonicalInterpreter.hs
+++ b/services/spar/src/Spar/CanonicalInterpreter.hs
@@ -78,7 +78,7 @@ type CanonicalEffs =
      Final IO
    ]
 
-runSparToIO :: Env -> Spar CanonicalEffs a -> IO (Either SparError a)
+runSparToIO :: Env -> Sem CanonicalEffs a -> IO (Either SparError a)
 runSparToIO ctx action =
   runFinal
     . embedToFinal @IO
@@ -106,7 +106,7 @@ runSparToIO ctx action =
     . sparRouteToServant (saml $ sparCtxOpts ctx)
     $ saml2ToSaml2WebSso action
 
-runSparToHandler :: Env -> Spar CanonicalEffs a -> Handler a
+runSparToHandler :: Env -> Sem CanonicalEffs a -> Handler a
 runSparToHandler ctx spar = do
   err <- liftIO $ runSparToIO ctx spar
   throwErrorAsHandlerException err

--- a/services/spar/src/Spar/CanonicalInterpreter.hs
+++ b/services/spar/src/Spar/CanonicalInterpreter.hs
@@ -79,7 +79,7 @@ type CanonicalEffs =
    ]
 
 runSparToIO :: Env -> Spar CanonicalEffs a -> IO (Either SparError a)
-runSparToIO ctx (Spar action) =
+runSparToIO ctx action =
   runFinal
     . embedToFinal @IO
     . nowToIO

--- a/services/spar/src/Spar/CanonicalInterpreter.hs
+++ b/services/spar/src/Spar/CanonicalInterpreter.hs
@@ -33,7 +33,7 @@ import Spar.Sem.Now.IO (nowToIO)
 import Spar.Sem.Random (Random)
 import Spar.Sem.Random.IO (randomToIO)
 import Spar.Sem.Reporter (Reporter)
-import Spar.Sem.Reporter.Wai (reporterToWai)
+import Spar.Sem.Reporter.Wai (reporterToTinyLogWai)
 import Spar.Sem.SAML2 (SAML2)
 import Spar.Sem.SAML2.Library (saml2ToSaml2WebSso)
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
@@ -88,7 +88,7 @@ runSparToIO ctx action =
     . runInputConst (sparCtxOpts ctx)
     . loggerToTinyLog (sparCtxLogger ctx)
     . stringLoggerToTinyLog
-    . reporterToWai
+    . reporterToTinyLogWai
     . runError @SparError
     . ttlErrorToSparError
     . galleyAccessToHttp (sparCtxHttpManager ctx) (sparCtxHttpGalley ctx)

--- a/services/spar/src/Spar/CanonicalInterpreter.hs
+++ b/services/spar/src/Spar/CanonicalInterpreter.hs
@@ -77,8 +77,7 @@ type CanonicalEffs =
 
 runSparToIO :: Env -> Spar CanonicalEffs a -> IO (Either SparError a)
 runSparToIO ctx (Spar action) =
-  fmap join
-    . runFinal
+  runFinal
     . embedToFinal @IO
     . nowToIO
     . randomToIO
@@ -101,8 +100,7 @@ runSparToIO ctx (Spar action) =
     . assIDStoreToCassandra
     . bindCookieStoreToCassandra
     . sparRouteToServant (saml $ sparCtxOpts ctx)
-    . saml2ToSaml2WebSso
-    $ runExceptT action
+    $ saml2ToSaml2WebSso action
 
 runSparToHandler :: Env -> Spar CanonicalEffs a -> Handler a
 runSparToHandler ctx spar = do

--- a/services/spar/src/Spar/CanonicalInterpreter.hs
+++ b/services/spar/src/Spar/CanonicalInterpreter.hs
@@ -9,7 +9,7 @@ import Polysemy
 import Polysemy.Error
 import Polysemy.Input (Input, runInputConst)
 import Servant
-import Spar.App
+import Spar.App hiding (sparToServerErrorWithLogging)
 import Spar.Error
 import Spar.Orphans ()
 import Spar.Sem.AReqIDStore (AReqIDStore)
@@ -32,6 +32,8 @@ import Spar.Sem.Now (Now)
 import Spar.Sem.Now.IO (nowToIO)
 import Spar.Sem.Random (Random)
 import Spar.Sem.Random.IO (randomToIO)
+import Spar.Sem.Reporter (Reporter)
+import Spar.Sem.Reporter.Wai (reporterToWai)
 import Spar.Sem.SAML2 (SAML2)
 import Spar.Sem.SAML2.Library (saml2ToSaml2WebSso)
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
@@ -64,6 +66,7 @@ type CanonicalEffs =
      GalleyAccess,
      Error TTLError,
      Error SparError,
+     Reporter,
      -- TODO(sandy): Make this a Logger Text instead
      Logger String,
      Logger (TinyLog.Msg -> TinyLog.Msg),
@@ -85,6 +88,7 @@ runSparToIO ctx (Spar action) =
     . runInputConst (sparCtxOpts ctx)
     . loggerToTinyLog (sparCtxLogger ctx)
     . stringLoggerToTinyLog
+    . reporterToWai
     . runError @SparError
     . ttlErrorToSparError
     . galleyAccessToHttp (sparCtxHttpManager ctx) (sparCtxHttpGalley ctx)

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -111,9 +111,9 @@ data SparCustomError
   deriving (Eq, Show)
 
 sparToServerErrorWithLogging :: MonadIO m => Log.Logger -> SparError -> m ServerError
-sparToServerErrorWithLogging logger err = do
+sparToServerErrorWithLogging _logger err = do
   let errServant = sparToServerError err
-  liftIO $ Wai.logError logger (Nothing :: Maybe Wai.Request) (servantToWaiError errServant)
+  -- liftIO $ Wai.logError logger (Nothing :: Maybe Wai.Request) (servantToWaiError errServant)
   pure errServant
 
 servantToWaiError :: ServerError -> Wai.Error
@@ -132,10 +132,10 @@ waiToServant waierr@(Wai.Error status label _ _) =
       errHeaders = []
     }
 
-renderSparErrorWithLogging :: MonadIO m => Log.Logger -> SparError -> m (Either ServerError Wai.Error)
-renderSparErrorWithLogging logger err = do
+renderSparErrorWithLogging :: Applicative m => Log.Logger -> SparError -> m (Either ServerError Wai.Error)
+renderSparErrorWithLogging _logger err = do
   let errPossiblyWai = renderSparError err
-  liftIO $ Wai.logError logger (Nothing :: Maybe Wai.Request) (either servantToWaiError id $ errPossiblyWai)
+  -- liftIO $ Wai.logError logger (Nothing :: Maybe Wai.Request) (either servantToWaiError id $ errPossiblyWai)
   pure errPossiblyWai
 
 renderSparError :: SparError -> Either ServerError Wai.Error

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -75,12 +75,11 @@ import qualified SAML2.WebSSO as SAML
 import Servant
 import Servant.API.Generic
 import Servant.Server.Generic (AsServerT)
-import Spar.App (Spar (..))
+import Spar.App (Spar (..), throwSparSem)
 import Spar.Error
   ( SparCustomError (SparScimError),
     SparError,
     sparToServerErrorWithLogging,
-    throwSpar,
   )
 import Spar.Scim.Auth
 import Spar.Scim.User
@@ -139,7 +138,7 @@ apiScim =
     hoistScim =
       hoistServer
         (Proxy @(ScimSiteAPI SparTag))
-        (wrapScimErrors . Scim.fromScimHandler (throwSpar . SparScimError))
+        (wrapScimErrors . Scim.fromScimHandler (throwSparSem . SparScimError))
     -- Wrap /all/ errors into the format required by SCIM, even server exceptions that have
     -- nothing to do with SCIM.
     --

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -70,7 +70,7 @@ import Data.String.Conversions (cs)
 import Imports
 import Polysemy
 import Polysemy.Error (Error)
-import Polysemy.Input (Input, input)
+import Polysemy.Input (Input)
 import qualified SAML2.WebSSO as SAML
 import Servant
 import Servant.API.Generic
@@ -95,7 +95,6 @@ import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)
 import Spar.Sem.ScimTokenStore (ScimTokenStore)
 import Spar.Sem.ScimUserTimesStore (ScimUserTimesStore)
 import System.Logger (Msg)
-import qualified System.Logger as TinyLog
 import qualified Web.Scim.Capabilities.MetaSchema as Scim.Meta
 import qualified Web.Scim.Class.Auth as Scim.Auth
 import qualified Web.Scim.Class.User as Scim.User
@@ -117,8 +116,7 @@ configuration = Scim.Meta.empty
 apiScim ::
   forall r.
   Members
-    '[ Input TinyLog.Logger,
-       Random,
+    '[ Random,
        Input Opts,
        Logger (Msg -> Msg),
        Logger String,
@@ -165,8 +163,7 @@ apiScim =
           Right (Left sparError) -> do
             -- We caught some other Spar exception. It is rendered and wrapped into a scim error
             -- with the same status and message, and no scim error type.
-            logger <- input @TinyLog.Logger
-            err :: ServerError <- embedFinal @IO $ sparToServerErrorWithLogging logger sparError
+            err :: ServerError <- embedFinal @IO $ sparToServerErrorWithLogging undefined sparError
             pure . Left . SAML.CustomError . SparScimError $
               Scim.ScimError
                 { schemas = [Scim.Schema.Error20],

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -147,30 +147,30 @@ apiScim =
     -- for why it's hard to catch impure exceptions.
     wrapScimErrors :: Spar r a -> Spar r a
     wrapScimErrors act = Spar $ do
-        result :: Either SomeException (Either SparError a) <- undefined -- try $ runExceptT $ fromSpar $ act
-        case result of
-          Left someException -> do
-            -- We caught an exception that's not a Spar exception at all. It is wrapped into
-            -- Scim.serverError.
-            throw . SAML.CustomError . SparScimError $
-              Scim.serverError (cs (displayException someException))
-          Right (Left err@(SAML.CustomError (SparScimError _))) ->
-            -- We caught a 'SparScimError' exception. It is left as-is.
-            throw err
-          Right (Left sparError) -> do
-            -- We caught some other Spar exception. It is rendered and wrapped into a scim error
-            -- with the same status and message, and no scim error type.
-            err :: ServerError <- embedFinal @IO $ sparToServerErrorWithLogging undefined sparError
-            throw . SAML.CustomError . SparScimError $
-              Scim.ScimError
-                { schemas = [Scim.Schema.Error20],
-                  status = Scim.Status $ errHTTPCode err,
-                  scimType = Nothing,
-                  detail = Just . cs $ errBody err
-                }
-          Right (Right x) -> do
-            -- No exceptions! Good.
-            pure x
+      result :: Either SomeException (Either SparError a) <- undefined -- try $ runExceptT $ fromSpar $ act
+      case result of
+        Left someException -> do
+          -- We caught an exception that's not a Spar exception at all. It is wrapped into
+          -- Scim.serverError.
+          throw . SAML.CustomError . SparScimError $
+            Scim.serverError (cs (displayException someException))
+        Right (Left err@(SAML.CustomError (SparScimError _))) ->
+          -- We caught a 'SparScimError' exception. It is left as-is.
+          throw err
+        Right (Left sparError) -> do
+          -- We caught some other Spar exception. It is rendered and wrapped into a scim error
+          -- with the same status and message, and no scim error type.
+          err :: ServerError <- undefined -- embedFinal @IO $ sparToServerErrorWithLogging undefined sparError
+          throw . SAML.CustomError . SparScimError $
+            Scim.ScimError
+              { schemas = [Scim.Schema.Error20],
+                status = Scim.Status $ errHTTPCode err,
+                scimType = Nothing,
+                detail = Just . cs $ errBody err
+              }
+        Right (Right x) -> do
+          -- No exceptions! Good.
+          pure x
 
 -- | This is similar to 'Scim.siteServer, but does not include the 'Scim.groupServer',
 -- as we don't support it (we don't implement 'Web.Scim.Class.Group.GroupDB').

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -138,6 +138,10 @@ createScimToken zusr CreateScimToken {..} = do
       caseOneOrNoIdP midpid = do
         token <- ScimToken . cs . ES.encode <$> Random.bytes 32
         tokenid <- Random.scimTokenId
+        -- FUTUREWORK(fisx): the fact that we're using @Now.get@
+        -- here means that the 'Now' effect should not contain
+        -- types from saml2-web-sso. We can just use 'UTCTime'
+        -- there, right?
         now <- Now.get
         let info =
               ScimTokenInfo

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -48,7 +48,7 @@ import Polysemy.Error
 import Polysemy.Input
 import qualified SAML2.WebSSO as SAML
 import Servant (NoContent (NoContent), ServerT, (:<|>) ((:<|>)))
-import Spar.App (Spar, liftSem)
+import Spar.App (Spar, liftSem, throwSparSem)
 import qualified Spar.Error as E
 import qualified Spar.Intra.BrigApp as Intra.Brig
 import Spar.Sem.BrigAccess (BrigAccess)
@@ -131,7 +131,7 @@ createScimToken zusr CreateScimToken {..} = do
   tokenNumber <- fmap length $ liftSem $ ScimTokenStore.getByTeam teamid
   maxTokens <- liftSem $ inputs maxScimTokens
   unless (tokenNumber < maxTokens) $
-    E.throwSpar E.SparProvisioningTokenLimitReached
+    throwSparSem E.SparProvisioningTokenLimitReached
   idps <- liftSem $ IdPEffect.getConfigsByTeam teamid
 
   let caseOneOrNoIdP :: Maybe SAML.IdPId -> Spar r CreateScimTokenResponse
@@ -157,7 +157,7 @@ createScimToken zusr CreateScimToken {..} = do
     -- be changed.  currently, it relies on the fact that there is never more than one IdP.
     -- https://wearezeta.atlassian.net/browse/SQSERVICES-165
     _ ->
-      E.throwSpar $
+      throwSparSem $
         E.SparProvisioningMoreThanOneIdP
           "SCIM tokens can only be created for a team with at most one IdP"
 

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -49,7 +49,7 @@ import Polysemy.Error
 import Polysemy.Input
 import qualified SAML2.WebSSO as SAML
 import Servant (NoContent (NoContent), ServerT, (:<|>) ((:<|>)))
-import Spar.App (Spar, liftSem, wrapMonadClientSem)
+import Spar.App (Spar, liftSem, liftSem)
 import qualified Spar.Error as E
 import qualified Spar.Intra.BrigApp as Intra.Brig
 import Spar.Sem.BrigAccess (BrigAccess)
@@ -75,7 +75,7 @@ instance Member ScimTokenStore r => Scim.Class.Auth.AuthDB SparTag (Spar r) wher
     Scim.throwScim (Scim.unauthorized "Token not provided")
   authCheck (Just token) =
     maybe (Scim.throwScim (Scim.unauthorized "Invalid token")) pure
-      =<< lift (wrapMonadClientSem (ScimTokenStore.lookup token))
+      =<< lift (liftSem (ScimTokenStore.lookup token))
 
 ----------------------------------------------------------------------------
 -- Token API
@@ -125,11 +125,11 @@ createScimToken zusr CreateScimToken {..} = do
   let descr = createScimTokenDescr
   teamid <- liftSem $ Intra.Brig.authorizeScimTokenManagement zusr
   liftSem $ BrigAccess.ensureReAuthorised zusr createScimTokenPassword
-  tokenNumber <- fmap length $ wrapMonadClientSem $ ScimTokenStore.getByTeam teamid
+  tokenNumber <- fmap length $ liftSem $ ScimTokenStore.getByTeam teamid
   maxTokens <- liftSem $ inputs maxScimTokens
   unless (tokenNumber < maxTokens) $
     E.throwSpar E.SparProvisioningTokenLimitReached
-  idps <- wrapMonadClientSem $ IdPEffect.getConfigsByTeam teamid
+  idps <- liftSem $ IdPEffect.getConfigsByTeam teamid
 
   let caseOneOrNoIdP :: Maybe SAML.IdPId -> Spar r CreateScimTokenResponse
       caseOneOrNoIdP midpid = do
@@ -144,7 +144,7 @@ createScimToken zusr CreateScimToken {..} = do
                   stiIdP = midpid,
                   stiDescr = descr
                 }
-        wrapMonadClientSem $ ScimTokenStore.insert token info
+        liftSem $ ScimTokenStore.insert token info
         pure $ CreateScimTokenResponse token info
 
   case idps of
@@ -169,7 +169,7 @@ deleteScimToken ::
   Spar r NoContent
 deleteScimToken zusr tokenid = do
   teamid <- liftSem $ Intra.Brig.authorizeScimTokenManagement zusr
-  wrapMonadClientSem $ ScimTokenStore.delete teamid tokenid
+  liftSem $ ScimTokenStore.delete teamid tokenid
   pure NoContent
 
 -- | > docs/reference/provisioning/scim-token.md {#RefScimTokenList}
@@ -183,4 +183,4 @@ listScimTokens ::
   Spar r ScimTokenList
 listScimTokens zusr = do
   teamid <- liftSem $ Intra.Brig.authorizeScimTokenManagement zusr
-  ScimTokenList <$> wrapMonadClientSem (ScimTokenStore.getByTeam teamid)
+  ScimTokenList <$> liftSem (ScimTokenStore.getByTeam teamid)

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -447,9 +447,8 @@ createValidScimUser tokeninfo@ScimTokenInfo {stiTeam} vsu@(ST.ValidScimUser veid
           -- up.  We should consider making setUserHandle part of createUser and
           -- making it transactional.  If the user redoes the POST A new standalone
           -- user will be created.}
-          do
-            BrigAccess.setHandle buid handl
-            BrigAccess.setRichInfo buid richInfo
+          BrigAccess.setHandle buid handl
+          BrigAccess.setRichInfo buid richInfo
           pure buid
 
       -- {If we crash now,  a POST retry will fail with 409 user already exists.
@@ -576,9 +575,8 @@ updateVsuUref team uid old new = do
     (mo, mn@(Just newuref)) | mo /= mn -> validateEmailIfExists uid newuref
     _ -> pure ()
 
-  do
-    old & ST.runValidExternalId (SAMLUserStore.delete uid) (ScimExternalIdStore.delete team)
-    new & ST.runValidExternalId (`SAMLUserStore.insert` uid) (\email -> ScimExternalIdStore.insert team email uid)
+  old & ST.runValidExternalId (SAMLUserStore.delete uid) (ScimExternalIdStore.delete team)
+  new & ST.runValidExternalId (`SAMLUserStore.insert` uid) (\email -> ScimExternalIdStore.insert team email uid)
 
   BrigAccess.setVeid uid new
 

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -66,7 +66,7 @@ import Network.URI (URI, parseURI)
 import Polysemy
 import Polysemy.Input
 import qualified SAML2.WebSSO as SAML
-import Spar.App (GetUserResult (..), Spar, getUserIdByScimExternalId, getUserIdByUref, liftSem, validateEmailIfExists, liftSem)
+import Spar.App (GetUserResult (..), Spar, getUserIdByScimExternalId, getUserIdByUref, liftSem, validateEmailIfExists)
 import qualified Spar.Intra.BrigApp as Brig
 import Spar.Scim.Auth ()
 import Spar.Scim.Types (normalizeLikeStored)

--- a/services/spar/src/Spar/Sem/Reporter.hs
+++ b/services/spar/src/Spar/Sem/Reporter.hs
@@ -1,0 +1,12 @@
+module Spar.Sem.Reporter where
+
+import Imports
+import qualified Network.Wai as Wai
+import Network.Wai.Utilities.Error (Error)
+import Polysemy
+
+data Reporter m a where
+  Report :: Maybe Wai.Request -> Error -> Reporter m ()
+
+-- TODO(sandy): Inline this definition --- no TH
+makeSem ''Reporter

--- a/services/spar/src/Spar/Sem/Reporter/Wai.hs
+++ b/services/spar/src/Spar/Sem/Reporter/Wai.hs
@@ -1,0 +1,14 @@
+module Spar.Sem.Reporter.Wai where
+
+import Imports
+import qualified Network.Wai.Utilities.Server as Wai
+import Polysemy
+import Polysemy.Input
+import Spar.Sem.Reporter
+import qualified System.Logger as TinyLog
+
+reporterToWai :: Members '[Embed IO, Input TinyLog.Logger] r => Sem (Reporter ': r) a -> Sem r a
+reporterToWai = interpret $ \case
+  Report req err -> do
+    logger <- input
+    embed @IO $ Wai.logError logger req err

--- a/services/spar/src/Spar/Sem/Reporter/Wai.hs
+++ b/services/spar/src/Spar/Sem/Reporter/Wai.hs
@@ -7,8 +7,8 @@ import Polysemy.Input
 import Spar.Sem.Reporter
 import qualified System.Logger as TinyLog
 
-reporterToWai :: Members '[Embed IO, Input TinyLog.Logger] r => Sem (Reporter ': r) a -> Sem r a
-reporterToWai = interpret $ \case
+reporterToTinyLogWai :: Members '[Embed IO, Input TinyLog.Logger] r => Sem (Reporter ': r) a -> Sem r a
+reporterToTinyLogWai = interpret $ \case
   Report req err -> do
     logger <- input
     embed @IO $ Wai.logError logger req err

--- a/services/spar/src/Spar/Sem/SAML2/Library.hs
+++ b/services/spar/src/Spar/Sem/SAML2/Library.hs
@@ -75,9 +75,9 @@ instance Members '[Error SparError, IdPEffect.IdP, Final IO] r => SPStoreIdP Spa
   type IdPConfigExtra (SPImpl r) = WireIdP
   type IdPConfigSPId (SPImpl r) = TeamId
 
-  storeIdPConfig = SPImpl . App.runSparInSem . App.storeIdPConfig
-  getIdPConfig = SPImpl . App.runSparInSem . App.getIdPConfig
-  getIdPConfigByIssuerOptionalSPId a = SPImpl . App.runSparInSem . App.getIdPConfigByIssuerOptionalSPId a
+  storeIdPConfig = SPImpl . App.storeIdPConfig
+  getIdPConfig = SPImpl . App.getIdPConfig
+  getIdPConfigByIssuerOptionalSPId a = SPImpl . App.getIdPConfigByIssuerOptionalSPId a
 
 instance Member (Error SparError) r => MonadError SparError (SPImpl r) where
   throwError = SPImpl . throw

--- a/services/spar/src/Spar/Sem/SAML2/Library.hs
+++ b/services/spar/src/Spar/Sem/SAML2/Library.hs
@@ -11,6 +11,7 @@ import Data.String.Conversions (cs)
 import Imports
 import Polysemy
 import Polysemy.Error
+import Polysemy.Final
 import Polysemy.Input
 import Polysemy.Internal.Tactics
 import SAML2.WebSSO hiding (Error)
@@ -30,9 +31,19 @@ import Wire.API.User.Saml
 
 wrapMonadClientSPImpl :: Members '[Error SparError, Final IO] r => Sem r a -> SPImpl r a
 wrapMonadClientSPImpl action =
-  SPImpl $
-    action
-      `Catch.catch` (throw . SAML.CustomError . SparCassandraError . cs . show @SomeException)
+  SPImpl action
+    `Catch.catch` (SPImpl . throw . SAML.CustomError . SparCassandraError . cs . show @SomeException)
+
+instance Member (Final IO) r => Catch.MonadThrow (SPImpl r) where
+  throwM = SPImpl . embedFinal . Catch.throwM @IO
+
+instance Member (Final IO) r => Catch.MonadCatch (SPImpl r) where
+  catch (SPImpl m) handler = SPImpl $
+    withStrategicToFinal @IO $ do
+      m' <- runS m
+      st <- getInitialStateS
+      handler' <- bindS $ unSPImpl . handler
+      pure $ m' `Catch.catch` \e -> handler' $ e <$ st
 
 newtype SPImpl r a = SPImpl {unSPImpl :: Sem r a}
   deriving (Functor, Applicative, Monad)

--- a/services/spar/src/Spar/Sem/SAMLUserStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/SAMLUserStore/Cassandra.hs
@@ -2,17 +2,17 @@
 
 module Spar.Sem.SAMLUserStore.Cassandra where
 
-import qualified Control.Monad.Catch as Catch
 import Cassandra
+import qualified Control.Monad.Catch as Catch
+import Data.String.Conversions (cs)
 import Imports
 import Polysemy
-import qualified Spar.Data as Data
-import Spar.Sem.SAMLUserStore
-import Polysemy.Final
-import Spar.Error
 import Polysemy.Error
-import Data.String.Conversions (cs)
+import Polysemy.Final
 import qualified SAML2.WebSSO.Error as SAML
+import qualified Spar.Data as Data
+import Spar.Error
+import Spar.Sem.SAMLUserStore
 
 samlUserStoreToCassandra ::
   forall m r a.
@@ -40,4 +40,3 @@ interpretClientToIO ctx = interpret $ \case
     st <- getInitialStateS
     handler' <- bindS $ throw @SparError . SAML.CustomError . SparCassandraError . cs . show @SomeException
     pure $ action' `Catch.catch` \e -> handler' $ e <$ st
-

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -70,7 +70,6 @@ import qualified SAML2.WebSSO as SAML
 import SAML2.WebSSO.Test.Lenses
 import SAML2.WebSSO.Test.MockResponse
 import SAML2.WebSSO.Test.Util
-import Spar.App (liftSem)
 import qualified Spar.Intra.BrigApp as Intra
 import qualified Spar.Sem.BrigAccess as BrigAccess
 import qualified Spar.Sem.IdP as IdPEffect
@@ -870,7 +869,7 @@ specCRUDIdentityProvider = do
           pure $ idpmeta1 & edIssuer .~ (idpmeta3 ^. edIssuer)
 
         do
-          midp <- runSpar $ liftSem $ IdPEffect.getConfig idpid1
+          midp <- runSpar $ IdPEffect.getConfig idpid1
           liftIO $ do
             (midp ^? _Just . idpMetadata . edIssuer) `shouldBe` Just (idpmeta1 ^. edIssuer)
             (midp ^? _Just . idpExtraInfo . wiOldIssuers) `shouldBe` Just []
@@ -883,7 +882,7 @@ specCRUDIdentityProvider = do
               resp <- call $ callIdpUpdate' (env ^. teSpar) (Just owner1) idpid1 (IdPMetadataValue (cs $ SAML.encode new) undefined)
               liftIO $ statusCode resp `shouldBe` 200
 
-              midp <- runSpar $ liftSem $ IdPEffect.getConfig idpid1
+              midp <- runSpar $ IdPEffect.getConfig idpid1
               liftIO $ do
                 (midp ^? _Just . idpMetadata . edIssuer) `shouldBe` Just (new ^. edIssuer)
                 sort <$> (midp ^? _Just . idpExtraInfo . wiOldIssuers) `shouldBe` Just (sort $ olds <&> (^. edIssuer))
@@ -1298,7 +1297,7 @@ specDeleteCornerCases = describe "delete corner cases" $ do
       brig <- view teBrig
       resp <- call . delete $ brig . paths ["i", "users", toByteString' uid]
       liftIO $ responseStatus resp `shouldBe` status202
-      void $ aFewTimes (runSpar $ liftSem $ BrigAccess.getStatus uid) (== Deleted)
+      void $ aFewTimes (runSpar $ BrigAccess.getStatus uid) (== Deleted)
 
 specScimAndSAML :: SpecWith TestEnv
 specScimAndSAML = do

--- a/services/spar/test-integration/Test/Spar/AppSpec.hs
+++ b/services/spar/test-integration/Test/Spar/AppSpec.hs
@@ -33,7 +33,6 @@ import Imports
 import SAML2.WebSSO as SAML
 import qualified SAML2.WebSSO.Test.MockResponse as SAML
 import qualified Servant
-import Spar.App (liftSem)
 import qualified Spar.App as Spar
 import Spar.Orphans ()
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
@@ -181,5 +180,5 @@ requestAccessVerdict idp isGranted mkAuthnReq = do
           $ outcome
       qry :: [(SBS, SBS)]
       qry = queryPairs $ uriQuery loc
-  muid <- runSpar $ liftSem $ SAMLUserStore.get uref
+  muid <- runSpar $ SAMLUserStore.get uref
   pure (muid, outcome, loc, qry)

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -72,7 +72,7 @@ spec = do
       (_, _, (^. SAML.idpId) -> idpid) <- registerTestIdP
       (_, req) <- call $ callAuthnReq (env ^. teSpar) idpid
       let probe :: (MonadIO m, MonadReader TestEnv m) => m Bool
-          probe = runSpar $ liftSem $ AReqIDStore.isAlive (req ^. SAML.rqID)
+          probe = runSpar $ AReqIDStore.isAlive (req ^. SAML.rqID)
           maxttl :: Int -- musec
           maxttl = (fromIntegral . fromTTL $ env ^. teOpts . to maxttlAuthreq) * 1000 * 1000
       liftIO $ maxttl `shouldSatisfy` (< 60 * 1000 * 1000) -- otherwise the test will be really slow.
@@ -93,8 +93,8 @@ spec = do
       context "insert and get are \"inverses\"" $ do
         let check vf = it (show vf) $ do
               vid <- nextSAMLID
-              () <- runSpar $ liftSem $ AReqIDStore.storeVerdictFormat 1 vid vf
-              mvf <- runSpar $ liftSem $ AReqIDStore.getVerdictFormat vid
+              () <- runSpar $ AReqIDStore.storeVerdictFormat 1 vid vf
+              mvf <- runSpar $ AReqIDStore.getVerdictFormat vid
               liftIO $ mvf `shouldBe` Just vf
         check
           `mapM_` [ VerdictFormatWeb,
@@ -103,47 +103,47 @@ spec = do
       context "has timed out" $ do
         it "AReqIDStore.getVerdictFormat returns Nothing" $ do
           vid <- nextSAMLID
-          () <- runSpar $ liftSem $ AReqIDStore.storeVerdictFormat 1 vid VerdictFormatWeb
+          () <- runSpar $ AReqIDStore.storeVerdictFormat 1 vid VerdictFormatWeb
           liftIO $ threadDelay 2000000
-          mvf <- runSpar $ liftSem $ AReqIDStore.getVerdictFormat vid
+          mvf <- runSpar $ AReqIDStore.getVerdictFormat vid
           liftIO $ mvf `shouldBe` Nothing
       context "does not exist" $ do
         it "AReqIDStore.getVerdictFormat returns Nothing" $ do
           vid <- nextSAMLID
-          mvf <- runSpar $ liftSem $ AReqIDStore.getVerdictFormat vid
+          mvf <- runSpar $ AReqIDStore.getVerdictFormat vid
           liftIO $ mvf `shouldBe` Nothing
     describe "User" $ do
       context "user is new" $ do
         it "getUser returns Nothing" $ do
           uref <- nextUserRef
-          muid <- runSpar $ liftSem $ SAMLUserStore.get uref
+          muid <- runSpar $ SAMLUserStore.get uref
           liftIO $ muid `shouldBe` Nothing
         it "inserts new user and responds with 201 / returns new user" $ do
           uref <- nextUserRef
           uid <- nextWireId
-          () <- runSpar $ liftSem $ SAMLUserStore.insert uref uid
-          muid <- runSpar $ liftSem $ SAMLUserStore.get uref
+          () <- runSpar $ SAMLUserStore.insert uref uid
+          muid <- runSpar $ SAMLUserStore.get uref
           liftIO $ muid `shouldBe` Just uid
       context "user already exists (idempotency)" $ do
         it "inserts new user and responds with 201 / returns new user" $ do
           uref <- nextUserRef
           uid <- nextWireId
           uid' <- nextWireId
-          () <- runSpar $ liftSem $ SAMLUserStore.insert uref uid
-          () <- runSpar $ liftSem $ SAMLUserStore.insert uref uid'
-          muid <- runSpar $ liftSem $ SAMLUserStore.get uref
+          () <- runSpar $ SAMLUserStore.insert uref uid
+          () <- runSpar $ SAMLUserStore.insert uref uid'
+          muid <- runSpar $ SAMLUserStore.get uref
           liftIO $ muid `shouldBe` Just uid'
       describe "DELETE" $ do
         it "works" $ do
           uref <- nextUserRef
           uid <- nextWireId
           do
-            () <- runSpar $ liftSem $ SAMLUserStore.insert uref uid
-            muid <- runSpar $ liftSem (SAMLUserStore.get uref)
+            () <- runSpar $ SAMLUserStore.insert uref uid
+            muid <- runSpar $ SAMLUserStore.get uref
             liftIO $ muid `shouldBe` Just uid
           do
-            () <- runSpar $ liftSem $ SAMLUserStore.delete uid uref
-            muid <- runSpar (liftSem $ SAMLUserStore.get uref) `aFewTimes` isNothing
+            () <- runSpar $ SAMLUserStore.delete uid uref
+            muid <- runSpar (SAMLUserStore.get uref) `aFewTimes` isNothing
             liftIO $ muid `shouldBe` Nothing
     describe "BindCookie" $ do
       let mkcky :: TestSpar SetBindCookie
@@ -151,58 +151,58 @@ spec = do
       it "insert and get are \"inverses\"" $ do
         uid <- nextWireId
         cky <- mkcky
-        () <- runSpar $ liftSem $ BindCookieStore.insert cky uid 1
-        muid <- runSpar $ liftSem $ BindCookieStore.lookup (setBindCookieValue cky)
+        () <- runSpar $ BindCookieStore.insert cky uid 1
+        muid <- runSpar $ BindCookieStore.lookup (setBindCookieValue cky)
         liftIO $ muid `shouldBe` Just uid
       context "has timed out" $ do
         it "BindCookieStore.lookup returns Nothing" $ do
           uid <- nextWireId
           cky <- mkcky
-          () <- runSpar $ liftSem $ BindCookieStore.insert cky uid 1
+          () <- runSpar $ BindCookieStore.insert cky uid 1
           liftIO $ threadDelay 2000000
-          muid <- runSpar $ liftSem $ BindCookieStore.lookup (setBindCookieValue cky)
+          muid <- runSpar $ BindCookieStore.lookup (setBindCookieValue cky)
           liftIO $ muid `shouldBe` Nothing
       context "does not exist" $ do
         it "BindCookieStore.lookup returns Nothing" $ do
           cky <- mkcky
-          muid <- runSpar $ liftSem $ BindCookieStore.lookup (setBindCookieValue cky)
+          muid <- runSpar $ BindCookieStore.lookup (setBindCookieValue cky)
           liftIO $ muid `shouldBe` Nothing
     describe "Team" $ do
       testDeleteTeam
     describe "IdPConfig" $ do
       it "storeIdPConfig, getIdPConfig are \"inverses\"" $ do
         idp <- makeTestIdP
-        () <- runSpar $ liftSem $ IdPEffect.storeConfig idp
-        midp <- runSpar $ liftSem $ IdPEffect.getConfig (idp ^. idpId)
+        () <- runSpar $ IdPEffect.storeConfig idp
+        midp <- runSpar $ IdPEffect.getConfig (idp ^. idpId)
         liftIO $ midp `shouldBe` Just idp
       it "getIdPConfigByIssuer works" $ do
         idp <- makeTestIdP
-        () <- runSpar $ liftSem $ IdPEffect.storeConfig idp
+        () <- runSpar $ IdPEffect.storeConfig idp
         midp <- runSpar $ App.getIdPConfigByIssuer (idp ^. idpMetadata . edIssuer) (idp ^. SAML.idpExtraInfo . wiTeam)
         liftIO $ midp `shouldBe` GetIdPFound idp
       it "getIdPIdByIssuer works" $ do
         idp <- makeTestIdP
-        () <- runSpar $ liftSem $ IdPEffect.storeConfig idp
+        () <- runSpar $ IdPEffect.storeConfig idp
         midp <- runSpar $ App.getIdPIdByIssuer (idp ^. idpMetadata . edIssuer) (idp ^. SAML.idpExtraInfo . wiTeam)
         liftIO $ midp `shouldBe` GetIdPFound (idp ^. idpId)
       it "getIdPConfigsByTeam works" $ do
         skipIdPAPIVersions [WireIdPAPIV1]
         teamid <- nextWireId
         idp <- makeTestIdP <&> idpExtraInfo .~ (WireIdP teamid Nothing [] Nothing)
-        () <- runSpar $ liftSem $ IdPEffect.storeConfig idp
-        idps <- runSpar $ liftSem $ IdPEffect.getConfigsByTeam teamid
+        () <- runSpar $ IdPEffect.storeConfig idp
+        idps <- runSpar $ IdPEffect.getConfigsByTeam teamid
         liftIO $ idps `shouldBe` [idp]
       it "deleteIdPConfig works" $ do
         teamid <- nextWireId
         idpApiVersion <- asks (^. teWireIdPAPIVersion)
         idp <- makeTestIdP <&> idpExtraInfo .~ (WireIdP teamid (Just idpApiVersion) [] Nothing)
-        () <- runSpar $ liftSem $ IdPEffect.storeConfig idp
+        () <- runSpar $ IdPEffect.storeConfig idp
         do
-          midp <- runSpar $ liftSem $ IdPEffect.getConfig (idp ^. idpId)
+          midp <- runSpar $ IdPEffect.getConfig (idp ^. idpId)
           liftIO $ midp `shouldBe` Just idp
-        () <- runSpar $ liftSem $ IdPEffect.deleteConfig (idp ^. idpId) (idp ^. idpMetadata . edIssuer) teamid
+        () <- runSpar $ IdPEffect.deleteConfig (idp ^. idpId) (idp ^. idpMetadata . edIssuer) teamid
         do
-          midp <- runSpar $ liftSem $ IdPEffect.getConfig (idp ^. idpId)
+          midp <- runSpar $ IdPEffect.getConfig (idp ^. idpId)
           liftIO $ midp `shouldBe` Nothing
         do
           midp <- runSpar $ App.getIdPConfigByIssuer (idp ^. idpMetadata . edIssuer) (idp ^. SAML.idpExtraInfo . wiTeam)
@@ -211,18 +211,18 @@ spec = do
           midp <- runSpar $ App.getIdPIdByIssuer (idp ^. idpMetadata . edIssuer) (idp ^. SAML.idpExtraInfo . wiTeam)
           liftIO $ midp `shouldBe` GetIdPNotFound
         do
-          idps <- runSpar $ liftSem $ IdPEffect.getConfigsByTeam teamid
+          idps <- runSpar $ IdPEffect.getConfigsByTeam teamid
           liftIO $ idps `shouldBe` []
       describe "{set,clear}ReplacedBy" $ do
         it "handle non-existent idps gradefully" $ do
           pendingWith "this requires a cql{,-io} upgrade.  https://gitlab.com/twittner/cql-io/-/issues/7"
           idp1 <- makeTestIdP
           idp2 <- makeTestIdP
-          runSpar $ liftSem $ IdPEffect.setReplacedBy (Data.Replaced (idp1 ^. idpId)) (Data.Replacing (idp2 ^. idpId))
-          idp1' <- runSpar $ liftSem (IdPEffect.getConfig (idp1 ^. idpId))
+          runSpar $ IdPEffect.setReplacedBy (Data.Replaced (idp1 ^. idpId)) (Data.Replacing (idp2 ^. idpId))
+          idp1' <- runSpar $ IdPEffect.getConfig (idp1 ^. idpId)
           liftIO $ idp1' `shouldBe` Nothing
-          runSpar $ liftSem $ IdPEffect.clearReplacedBy (Data.Replaced (idp1 ^. idpId))
-          idp2' <- runSpar $ liftSem (IdPEffect.getConfig (idp1 ^. idpId))
+          runSpar $ IdPEffect.clearReplacedBy (Data.Replaced (idp1 ^. idpId))
+          idp2' <- runSpar $ IdPEffect.getConfig (idp1 ^. idpId)
           liftIO $ idp2' `shouldBe` Nothing
 
 -- TODO(sandy): This function should be more polymorphic over it's polysemy
@@ -240,24 +240,24 @@ testSPStoreID store unstore isalive = do
       it "isAliveID is True" $ do
         xid :: SAML.ID a <- nextSAMLID
         eol :: Time <- addTime 5 <$> runSimpleSP getNow
-        () <- runSpar $ liftSem $ store xid eol
-        isit <- runSpar $ liftSem $ isalive xid
+        () <- runSpar $ store xid eol
+        isit <- runSpar $ isalive xid
         liftIO $ isit `shouldBe` True
     context "after TTL" $ do
       it "isAliveID returns False" $ do
         xid :: SAML.ID a <- nextSAMLID
         eol :: Time <- addTime 2 <$> runSimpleSP getNow
-        () <- runSpar $ liftSem $ store xid eol
+        () <- runSpar $ store xid eol
         liftIO $ threadDelay 3000000
-        isit <- runSpar $ liftSem $ isalive xid
+        isit <- runSpar $ isalive xid
         liftIO $ isit `shouldBe` False
     context "after call to unstore" $ do
       it "isAliveID returns False" $ do
         xid :: SAML.ID a <- nextSAMLID
         eol :: Time <- addTime 5 <$> runSimpleSP getNow
-        () <- runSpar $ liftSem $ store xid eol
-        () <- runSpar $ liftSem $ unstore xid
-        isit <- runSpar $ liftSem $ isalive xid
+        () <- runSpar $ store xid eol
+        () <- runSpar $ unstore xid
+        isit <- runSpar $ isalive xid
         liftIO $ isit `shouldBe` False
 
 -- | Test that when a team is deleted, all relevant data is pruned from the
@@ -280,38 +280,36 @@ testDeleteTeam = it "cleans up all the right tables after deletion" $ do
   --
   -- The token from 'team_provisioning_by_token':
   do
-    tokenInfo <- runSpar $ liftSem $ ScimTokenStore.lookup tok
+    tokenInfo <- runSpar $ ScimTokenStore.lookup tok
     liftIO $ tokenInfo `shouldBe` Nothing
   -- The team from 'team_provisioning_by_team':
   do
-    tokens <- runSpar $ liftSem $ ScimTokenStore.getByTeam tid
+    tokens <- runSpar $ ScimTokenStore.getByTeam tid
     liftIO $ tokens `shouldBe` []
   -- The users from 'user':
   do
     mbUser1 <- case veidFromUserSSOId ssoid1 of
       Right veid ->
         runSpar $
-          liftSem $
-            runValidExternalId
-              SAMLUserStore.get
-              undefined -- could be @Data.lookupScimExternalId@, but we don't hit that path.
-              veid
+          runValidExternalId
+            SAMLUserStore.get
+            undefined -- could be @Data.lookupScimExternalId@, but we don't hit that path.
+            veid
       Left _email -> undefined -- runSparCass . Data.lookupScimExternalId . fromEmail $ _email
     liftIO $ mbUser1 `shouldBe` Nothing
   do
     mbUser2 <- case veidFromUserSSOId ssoid2 of
       Right veid ->
         runSpar $
-          liftSem $
-            runValidExternalId
-              SAMLUserStore.get
-              undefined
-              veid
+          runValidExternalId
+            SAMLUserStore.get
+            undefined
+            veid
       Left _email -> undefined
     liftIO $ mbUser2 `shouldBe` Nothing
   -- The config from 'idp':
   do
-    mbIdp <- runSpar $ liftSem $ IdPEffect.getConfig (idp ^. SAML.idpId)
+    mbIdp <- runSpar $ IdPEffect.getConfig (idp ^. SAML.idpId)
     liftIO $ mbIdp `shouldBe` Nothing
   -- The config from 'issuer_idp':
   do
@@ -320,5 +318,5 @@ testDeleteTeam = it "cleans up all the right tables after deletion" $ do
     liftIO $ mbIdp `shouldBe` GetIdPNotFound
   -- The config from 'team_idp':
   do
-    idps <- runSpar $ liftSem $ IdPEffect.getConfigsByTeam tid
+    idps <- runSpar $ IdPEffect.getConfigsByTeam tid
     liftIO $ idps `shouldBe` []

--- a/services/spar/test-integration/Test/Spar/Intra/BrigSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Intra/BrigSpec.hs
@@ -25,7 +25,6 @@ import Control.Lens ((^.))
 import Data.Id (Id (Id))
 import qualified Data.UUID as UUID
 import Imports hiding (head)
-import Spar.App (liftSem)
 import qualified Spar.Intra.BrigApp as Intra
 import Util
 import qualified Web.Scim.Schema.User as Scim.User
@@ -40,7 +39,7 @@ spec = do
 
   describe "getBrigUser" $ do
     it "return Nothing if n/a" $ do
-      musr <- runSpar $ liftSem $ Intra.getBrigUser Intra.WithPendingInvitations (Id . fromJust $ UUID.fromText "29546d9e-ed5b-11ea-8228-c324b1ea1030")
+      musr <- runSpar $ Intra.getBrigUser Intra.WithPendingInvitations (Id . fromJust $ UUID.fromText "29546d9e-ed5b-11ea-8228-c324b1ea1030")
       liftIO $ musr `shouldSatisfy` isNothing
 
     it "return Just if /a" $ do
@@ -53,5 +52,5 @@ spec = do
             scimUserId <$> createUser tok scimUser
 
       uid <- setup
-      musr <- runSpar $ liftSem $ Intra.getBrigUser Intra.WithPendingInvitations uid
+      musr <- runSpar $ Intra.getBrigUser Intra.WithPendingInvitations uid
       liftIO $ musr `shouldSatisfy` isJust

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -59,7 +59,6 @@ import Imports
 import qualified Network.Wai.Utilities.Error as Wai
 import qualified SAML2.WebSSO as SAML
 import qualified SAML2.WebSSO.Test.MockResponse as SAML
-import Spar.App (liftSem)
 import qualified Spar.Intra.BrigApp as Intra
 import Spar.Scim
 import Spar.Scim.Types (normalizeLikeStored)
@@ -118,9 +117,9 @@ specSuspend = do
           -- NOTE: once SCIM is enabled, SSO Auto-provisioning is disabled
           tok <- registerScimToken teamid (Just (idp ^. SAML.idpId))
           handle'@(Handle handle) <- nextHandle
-          runSpar $ liftSem $ BrigAccess.setHandle member handle'
+          runSpar $ BrigAccess.setHandle member handle'
           unless isActive $ do
-            runSpar $ liftSem $ BrigAccess.setStatus member Suspended
+            runSpar $ BrigAccess.setStatus member Suspended
           [user] <- listUsers tok (Just (filterBy "userName" handle))
           lift $ (fmap Scim.unScimBool . Scim.User.active . Scim.value . Scim.thing $ user) `shouldBe` Just isActive
     it "pre-existing suspended users are inactive" $ do
@@ -139,19 +138,19 @@ specSuspend = do
             -- Once we get rid of the `scim` table and make scim serve brig records directly, this is
             -- not an issue anymore.
             lift $ (fmap Scim.unScimBool . Scim.User.active . Scim.value . Scim.thing $ scimStoredUserBlah) `shouldBe` Just True
-            void $ aFewTimes (runSpar $ liftSem $ BrigAccess.getStatus uid) (== Active)
+            void $ aFewTimes (runSpar $ BrigAccess.getStatus uid) (== Active)
           do
             scimStoredUser <- putOrPatch tok uid user True
             lift $ (fmap Scim.unScimBool . Scim.User.active . Scim.value . Scim.thing $ scimStoredUser) `shouldBe` Just True
-            void $ aFewTimes (runSpar $ liftSem $ BrigAccess.getStatus uid) (== Active)
+            void $ aFewTimes (runSpar $ BrigAccess.getStatus uid) (== Active)
           do
             scimStoredUser <- putOrPatch tok uid user False
             lift $ (fmap Scim.unScimBool . Scim.User.active . Scim.value . Scim.thing $ scimStoredUser) `shouldBe` Just False
-            void $ aFewTimes (runSpar $ liftSem $ BrigAccess.getStatus uid) (== Suspended)
+            void $ aFewTimes (runSpar $ BrigAccess.getStatus uid) (== Suspended)
           do
             scimStoredUser <- putOrPatch tok uid user True
             lift $ (fmap Scim.unScimBool . Scim.User.active . Scim.value . Scim.thing $ scimStoredUser) `shouldBe` Just True
-            void $ aFewTimes (runSpar $ liftSem $ BrigAccess.getStatus uid) (== Active)
+            void $ aFewTimes (runSpar $ BrigAccess.getStatus uid) (== Active)
 
     it "PUT will change state from active to inactive and back" $ do
       void . activeInactiveAndBack $ \tok uid user active ->
@@ -190,10 +189,10 @@ specSuspend = do
       (tok, _) <- registerIdPAndScimToken
       scimStoredUserBlah <- createUser tok user
       let uid = Scim.id . Scim.thing $ scimStoredUserBlah
-      runSpar $ liftSem $ BrigAccess.setStatus uid Suspended
-      void $ aFewTimes (runSpar $ liftSem $ BrigAccess.getStatus uid) (== Suspended)
+      runSpar $ BrigAccess.setStatus uid Suspended
+      void $ aFewTimes (runSpar $ BrigAccess.getStatus uid) (== Suspended)
       void $ patchUser tok uid $ PatchOp.PatchOp [deleteAttrib "active"]
-      void $ aFewTimes (runSpar $ liftSem $ BrigAccess.getStatus uid) (== Active)
+      void $ aFewTimes (runSpar $ BrigAccess.getStatus uid) (== Active)
 
 ----------------------------------------------------------------------------
 -- User creation
@@ -304,10 +303,10 @@ testCreateUserNoIdP = do
 
   -- get account from brig, status should be PendingInvitation
   do
-    aFewTimes (runSpar $ liftSem $ BrigAccess.getAccount Intra.NoPendingInvitations userid) isJust
+    aFewTimes (runSpar $ BrigAccess.getAccount Intra.NoPendingInvitations userid) isJust
       >>= maybe (pure ()) (error "pending user in brig is visible, even though it should not be")
     brigUserAccount <-
-      aFewTimes (runSpar $ liftSem $ BrigAccess.getAccount Intra.WithPendingInvitations userid) isJust
+      aFewTimes (runSpar $ BrigAccess.getAccount Intra.WithPendingInvitations userid) isJust
         >>= maybe (error "could not find user in brig") pure
     let brigUser = accountUser brigUserAccount
     brigUser `userShouldMatch` WrappedScimStoredUser scimStoredUser
@@ -347,7 +346,7 @@ testCreateUserNoIdP = do
   -- user should now be active
   do
     brigUser <-
-      aFewTimes (runSpar $ liftSem $ BrigAccess.getAccount Intra.NoPendingInvitations userid) isJust
+      aFewTimes (runSpar $ BrigAccess.getAccount Intra.NoPendingInvitations userid) isJust
         >>= maybe (error "could not find user in brig") pure
     liftIO $ accountStatus brigUser `shouldBe` Active
     liftIO $ userManagedBy (accountUser brigUser) `shouldBe` ManagedByScim
@@ -431,7 +430,7 @@ testCreateUserWithSamlIdP = do
           . expect2xx
       )
   brigUser `userShouldMatch` WrappedScimStoredUser scimStoredUser
-  accStatus <- aFewTimes (runSpar $ liftSem $ BrigAccess.getStatus (userId brigUser)) (== Active)
+  accStatus <- aFewTimes (runSpar $ BrigAccess.getStatus (userId brigUser)) (== Active)
   liftIO $ accStatus `shouldBe` Active
   liftIO $ userManagedBy brigUser `shouldBe` ManagedByScim
 
@@ -823,9 +822,9 @@ testFindSamlAutoProvisionedUserMigratedWithEmailInTeamWithSSO = do
   -- auto-provision user via saml
   memberWithSSO <- do
     uid <- loginSsoUserFirstTime idp privCreds
-    Just usr <- runSpar $ liftSem $ Intra.getBrigUser Intra.NoPendingInvitations uid
+    Just usr <- runSpar $ Intra.getBrigUser Intra.NoPendingInvitations uid
     handle <- nextHandle
-    runSpar $ liftSem $ BrigAccess.setHandle uid handle
+    runSpar $ BrigAccess.setHandle uid handle
     pure usr
   let memberIdWithSSO = userId memberWithSSO
       externalId = either error id $ veidToText =<< Intra.veidFromBrigUser memberWithSSO Nothing
@@ -836,7 +835,7 @@ testFindSamlAutoProvisionedUserMigratedWithEmailInTeamWithSSO = do
   liftIO $ userManagedBy memberWithSSO `shouldBe` ManagedByWire
   users <- listUsers tok (Just (filterBy "externalId" externalId))
   liftIO $ (scimUserId <$> users) `shouldContain` [memberIdWithSSO]
-  Just brigUser' <- runSpar $ liftSem $ Intra.getBrigUser Intra.NoPendingInvitations memberIdWithSSO
+  Just brigUser' <- runSpar $ Intra.getBrigUser Intra.NoPendingInvitations memberIdWithSSO
   liftIO $ userManagedBy brigUser' `shouldBe` ManagedByScim
   where
     veidToText :: MonadError String m => ValidExternalId -> m Text
@@ -857,7 +856,7 @@ testFindTeamSettingsInvitedUserMigratedWithEmailInTeamWithSSO = do
 
   users' <- listUsers tok (Just (filterBy "externalId" emailInvited))
   liftIO $ (scimUserId <$> users') `shouldContain` [memberIdInvited]
-  Just brigUserInvited' <- runSpar $ liftSem $ Intra.getBrigUser Intra.NoPendingInvitations memberIdInvited
+  Just brigUserInvited' <- runSpar $ Intra.getBrigUser Intra.NoPendingInvitations memberIdInvited
   liftIO $ userManagedBy brigUserInvited' `shouldBe` ManagedByScim
 
 testFindTeamSettingsInvitedUserMigratedWithEmailInTeamWithSSOViaUserId :: TestSpar ()
@@ -869,7 +868,7 @@ testFindTeamSettingsInvitedUserMigratedWithEmailInTeamWithSSOViaUserId = do
   let memberIdInvited = userId memberInvited
 
   _ <- getUser tok memberIdInvited
-  Just brigUserInvited' <- runSpar $ liftSem $ Intra.getBrigUser Intra.NoPendingInvitations (memberIdInvited)
+  Just brigUserInvited' <- runSpar $ Intra.getBrigUser Intra.NoPendingInvitations (memberIdInvited)
   liftIO $ userManagedBy brigUserInvited' `shouldBe` ManagedByScim
 
 testFindProvisionedUserNoIdP :: TestSpar ()
@@ -888,8 +887,8 @@ testFindNonProvisionedUserNoIdP findBy = do
 
   uid <- userId <$> call (inviteAndRegisterUser (env ^. teBrig) owner teamid)
   handle <- nextHandle
-  runSpar $ liftSem $ BrigAccess.setHandle uid handle
-  Just brigUser <- runSpar $ liftSem $ Intra.getBrigUser Intra.NoPendingInvitations uid
+  runSpar $ BrigAccess.setHandle uid handle
+  Just brigUser <- runSpar $ Intra.getBrigUser Intra.NoPendingInvitations uid
   let Just email = userEmail brigUser
 
   do
@@ -904,7 +903,7 @@ testFindNonProvisionedUserNoIdP findBy = do
 
   do
     liftIO $ users `shouldBe` [uid]
-    Just brigUser' <- runSpar $ liftSem $ Intra.getBrigUser Intra.NoPendingInvitations uid
+    Just brigUser' <- runSpar $ Intra.getBrigUser Intra.NoPendingInvitations uid
     liftIO $ userManagedBy brigUser' `shouldBe` ManagedByScim
     liftIO $ brigUser' `shouldBe` brigUser {userManagedBy = ManagedByScim}
 
@@ -989,7 +988,7 @@ testGetUser = do
 
 shouldBeManagedBy :: HasCallStack => UserId -> ManagedBy -> TestSpar ()
 shouldBeManagedBy uid flag = do
-  managedBy <- maybe (error "user not found") userManagedBy <$> runSpar (liftSem $ Intra.getBrigUser Intra.WithPendingInvitations uid)
+  managedBy <- maybe (error "user not found") userManagedBy <$> runSpar (Intra.getBrigUser Intra.WithPendingInvitations uid)
   liftIO $ managedBy `shouldBe` flag
 
 -- | This is (roughly) the behavior on develop as well as on the branch where this test was
@@ -1042,12 +1041,12 @@ testGetUserWithNoHandle = do
   uid <- loginSsoUserFirstTime idp privcreds
   tok <- registerScimToken tid (Just (idp ^. SAML.idpId))
 
-  mhandle :: Maybe Handle <- maybe (error "user not found") userHandle <$> runSpar (liftSem $ Intra.getBrigUser Intra.WithPendingInvitations uid)
+  mhandle :: Maybe Handle <- maybe (error "user not found") userHandle <$> runSpar (Intra.getBrigUser Intra.WithPendingInvitations uid)
   liftIO $ mhandle `shouldSatisfy` isNothing
 
   storedUser <- getUser tok uid
   liftIO $ (Scim.User.displayName . Scim.value . Scim.thing) storedUser `shouldSatisfy` isJust
-  mhandle' :: Maybe Handle <- aFewTimes (maybe (error "user not found") userHandle <$> runSpar (liftSem $ Intra.getBrigUser Intra.WithPendingInvitations uid)) isJust
+  mhandle' :: Maybe Handle <- aFewTimes (maybe (error "user not found") userHandle <$> runSpar (Intra.getBrigUser Intra.WithPendingInvitations uid)) isJust
   liftIO $ mhandle' `shouldSatisfy` isJust
   liftIO $ (fromHandle <$> mhandle') `shouldBe` (Just . Scim.User.userName . Scim.value . Scim.thing $ storedUser)
 
@@ -1321,7 +1320,7 @@ testUpdateExternalId withidp = do
       lookupByValidExternalId :: ValidExternalId -> TestSpar (Maybe UserId)
       lookupByValidExternalId =
         runValidExternalId
-          (runSpar . liftSem . SAMLUserStore.get)
+          (runSpar . SAMLUserStore.get)
           ( \email -> do
               let action = SU.scimFindUserByEmail midp tid $ fromEmail email
               result <- runSpar . runExceptT . runMaybeT $ action
@@ -1345,7 +1344,7 @@ testBrigSideIsUpdated = do
   validScimUser <-
     either (error . show) pure $
       validateScimUser' (Just idp) 999999 user'
-  brigUser <- maybe (error "no brig user") pure =<< runSpar (liftSem $ Intra.getBrigUser Intra.WithPendingInvitations userid)
+  brigUser <- maybe (error "no brig user") pure =<< runSpar (Intra.getBrigUser Intra.WithPendingInvitations userid)
   brigUser `userShouldMatch` validScimUser
 
 ----------------------------------------------------------------------------
@@ -1527,7 +1526,7 @@ specDeleteUser = do
       storedUser <- createUser tok user
       let uid :: UserId = scimUserId storedUser
       uref :: SAML.UserRef <- do
-        usr <- runSpar $ liftSem $ Intra.getBrigUser Intra.WithPendingInvitations uid
+        usr <- runSpar $ Intra.getBrigUser Intra.WithPendingInvitations uid
         let err = error . ("brig user without UserRef: " <>) . show
         case (`Intra.veidFromBrigUser` Nothing) <$> usr of
           bad@(Just (Right veid)) -> runValidExternalId pure (const $ err bad) veid
@@ -1536,11 +1535,11 @@ specDeleteUser = do
       deleteUser_ (Just tok) (Just uid) spar
         !!! const 204 === statusCode
       brigUser :: Maybe User <-
-        aFewTimes (runSpar $ liftSem $ Intra.getBrigUser Intra.WithPendingInvitations uid) isNothing
+        aFewTimes (runSpar $ Intra.getBrigUser Intra.WithPendingInvitations uid) isNothing
       samlUser :: Maybe UserId <-
         aFewTimes (getUserIdViaRef' uref) isNothing
       scimUser <-
-        aFewTimes (runSpar $ liftSem $ ScimUserTimesStore.read uid) isNothing
+        aFewTimes (runSpar $ ScimUserTimesStore.read uid) isNothing
       liftIO $
         (brigUser, samlUser, scimUser)
           `shouldBe` (Nothing, Nothing, Nothing)
@@ -1744,7 +1743,7 @@ testDeletedUsersFreeExternalIdNoIdp = do
 
   void $
     aFewTimes
-      (runSpar $ liftSem $ ScimExternalIdStore.lookup tid email)
+      (runSpar $ ScimExternalIdStore.lookup tid email)
       (== Nothing)
 
 specSCIMManaged :: SpecWith TestEnv

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -168,6 +168,7 @@ import Network.HTTP.Client.MultipartFormData
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.Warp.Internal as Warp
 import qualified Options.Applicative as OPA
+import Polysemy (Sem)
 import SAML2.WebSSO as SAML
 import qualified SAML2.WebSSO.API.Example as SAML
 import SAML2.WebSSO.Test.Lenses (userRefL)
@@ -1220,7 +1221,7 @@ runSimpleSP action = do
 
 runSpar ::
   (MonadReader TestEnv m, MonadIO m) =>
-  Spar.Spar CanonicalEffs a ->
+  Sem CanonicalEffs a ->
   m a
 runSpar action = do
   ctx <- (^. teSparEnv) <$> ask

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -173,7 +173,6 @@ import qualified SAML2.WebSSO.API.Example as SAML
 import SAML2.WebSSO.Test.Lenses (userRefL)
 import SAML2.WebSSO.Test.MockResponse
 import SAML2.WebSSO.Test.Util (SampleIdP (..), makeSampleIdPMetadata)
-import Spar.App (liftSem)
 import qualified Spar.App as Spar
 import Spar.CanonicalInterpreter
 import qualified Spar.Intra.BrigApp as Intra
@@ -1207,8 +1206,8 @@ ssoToUidSpar tid ssoid = do
   veid <- either (error . ("could not parse brig sso_id: " <>)) pure $ Intra.veidFromUserSSOId ssoid
   runSpar $
     runValidExternalId
-      (liftSem . SAMLUserStore.get)
-      (liftSem . ScimExternalIdStore.lookup tid)
+      (SAMLUserStore.get)
+      (ScimExternalIdStore.lookup tid)
       veid
 
 runSimpleSP :: (MonadReader TestEnv m, MonadIO m) => SAML.SimpleSP a -> m a
@@ -1234,7 +1233,7 @@ getSsoidViaSelf uid = maybe (error "not found") pure =<< getSsoidViaSelf' uid
 
 getSsoidViaSelf' :: HasCallStack => UserId -> TestSpar (Maybe UserSSOId)
 getSsoidViaSelf' uid = do
-  musr <- aFewTimes (runSpar $ liftSem $ Intra.getBrigUser Intra.NoPendingInvitations uid) isJust
+  musr <- aFewTimes (runSpar $ Intra.getBrigUser Intra.NoPendingInvitations uid) isJust
   pure $ case userIdentity =<< musr of
     Just (SSOIdentity ssoid _ _) -> Just ssoid
     Just (FullIdentity _ _) -> Nothing
@@ -1247,7 +1246,7 @@ getUserIdViaRef uref = maybe (error "not found") pure =<< getUserIdViaRef' uref
 
 getUserIdViaRef' :: HasCallStack => UserRef -> TestSpar (Maybe UserId)
 getUserIdViaRef' uref = do
-  aFewTimes (runSpar $ liftSem $ SAMLUserStore.get uref) isJust
+  aFewTimes (runSpar $ SAMLUserStore.get uref) isJust
 
 checkErr :: HasCallStack => Int -> Maybe TestErrorLabel -> Assertions ()
 checkErr status mlabel = do

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -34,7 +34,6 @@ import Data.UUID.V4 as UUID
 import Imports
 import qualified SAML2.WebSSO as SAML
 import SAML2.WebSSO.Types (IdPId, idpId)
-import Spar.App (liftSem)
 import qualified Spar.Intra.BrigApp as Intra
 import Spar.Scim.User (synthesizeScimUser, validateScimUser')
 import qualified Spar.Sem.ScimTokenStore as ScimTokenStore
@@ -82,16 +81,15 @@ registerScimToken teamid midpid = do
   scimTokenId <- randomId
   now <- liftIO getCurrentTime
   runSpar $
-    liftSem $
-      ScimTokenStore.insert
-        tok
-        ScimTokenInfo
-          { stiTeam = teamid,
-            stiId = scimTokenId,
-            stiCreatedAt = now,
-            stiIdP = midpid,
-            stiDescr = "test token"
-          }
+    ScimTokenStore.insert
+      tok
+      ScimTokenInfo
+        { stiTeam = teamid,
+          stiId = scimTokenId,
+          stiCreatedAt = now,
+          stiIdP = midpid,
+          stiDescr = "test token"
+        }
   pure tok
 
 -- | Generate a SCIM user with a random name and handle.  At the very least, everything considered


### PR DESCRIPTION
This PR replaces `Spar`:

```haskell
newtype Spar r a = Spar { Member (Final IO) r => ExceptT (Sem r) a }
```

and instead uses `Sem` directly. In doing so, it means `Spar` is now completely polysemized :tada: :tada: 

Sorry for the size here, I got excited about being as close to the finish line as I was. That being said, the commits are well-organized, so they're a reasonable way to approach this monstrosity.

Most of this PR is boring; replacing `throwSpar` with `throwSparSem` and adding `Member (Error SparError)` constraints. Also, replacing `Spar` with `Sem`. But there are a few changes of interest:

1. Removing `wrapMonadClientSem`, which previously was used to guard all of the `Cassandra` effects. This function has been removed (it required `MonadIO`), but instead, it is now used to wrap each DB action in `interpretClientToIO`. 
2. `Spar.Scim.wrapScimErrors` really depended on having an `ExceptT` and `MonadIO` around. Instead, we now do some direct manipulation of the polysemy stack, to locally introduce an `Error SomeException` effect, and immediately interpret it. This lets us catch Haskell exceptions directly in polysemy, though it's not clear to me that these exceptions can ever happen here (see point 1). While this works, it does float a `Final IO` effect up for a few layers, but no application code has real access to it.



## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.