### PR TITLE
Typo

### DIFF
--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -268,7 +268,7 @@ routes = do
   document "GET" "ejpd-info" $ do
     Doc.summary "internal wire.com process: https://wearezeta.atlassian.net/wiki/spaces/~463749889/pages/256738296/EJPD+official+requests+process"
     Doc.parameter Doc.Query "handles" Doc.string' $
-      Doc.description "Handles of the user, separated by comments"
+      Doc.description "Handles of the user, separated by commas"
     Doc.parameter Doc.Query "include_contacts" Doc.bool' $ do
       Doc.description "If 'true', this gives you more more exhaustive information about this user (including social network)"
       Doc.optional

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -268,7 +268,7 @@ routes = do
   document "GET" "ejpd-info" $ do
     Doc.summary "internal wire.com process: https://wearezeta.atlassian.net/wiki/spaces/~463749889/pages/256738296/EJPD+official+requests+process"
     Doc.parameter Doc.Query "handles" Doc.string' $
-      Doc.description "Handles of the user, separated by commas"
+      Doc.description "Handles of the user, separated by commas (NB: all chars need to be lower case!)"
     Doc.parameter Doc.Query "include_contacts" Doc.bool' $ do
       Doc.description "If 'true', this gives you more more exhaustive information about this user (including social network)"
       Doc.optional


### PR DESCRIPTION
Make online help in stern/backoffice more helpful and less wrong.  I don't want to clutter the release notes with this, should I?