### PR TITLE
Update team-settings version in Helm chart [skip ci]

### DIFF
--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/team-settings
-  tag: "4.0.0-v0.28.21-b92fca-2"
+  tag: "4.2.0-v0.28.29-0-1e2ef75"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `4.2.0-v0.28.29-0-1e2ef75`
Release: [`v4.2.0`](https://github.com/wireapp/wire-team-settings/releases/tag/v4.2.0)