### PR TITLE
Servantify legacy addMember endpoint

### DIFF
--- a/changelog.d/5-internal/servantify-add-member
+++ b/changelog.d/5-internal/servantify-add-member
@@ -1,0 +1,1 @@
+Convert legacy POST conversations/:cnv/members endpoint to Servant

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -233,7 +233,23 @@ data Api routes = Api
         :> "one2one"
         :> ReqBody '[Servant.JSON] NewConvUnmanaged
         :> ConversationVerb,
-    addMembersToConversationV2 ::
+    -- This endpoint can lead to the following events being sent:
+    -- - MemberJoin event to members
+    addMembersToConversationUnqualified ::
+      routes
+        :- Summary "Add members to an existing conversation (deprecated)"
+        :> CanThrow ConvNotFound
+        :> CanThrow NotConnected
+        :> CanThrow ConvAccessDenied
+        :> CanThrow (InvalidOp "Invalid operation")
+        :> ZUser
+        :> ZConn
+        :> "conversations"
+        :> Capture "cnv" ConvId
+        :> "members"
+        :> ReqBody '[JSON] Invite
+        :> MultiVerb 'POST '[JSON] ConvUpdateResponses (UpdateResult Event),
+    addMembersToConversation ::
       routes
         :- Summary "Add qualified members to an existing conversation."
         :> ZUser


### PR DESCRIPTION
Servantify a leftover unqualified endpoint for adding members to a conversation.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
