### PR TITLE
Flaky Test Note in Brig

### DIFF
--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -1750,6 +1750,8 @@ svcAssertConvAccessUpdate buf usr upd cnv = liftIO $ do
   evt <- timeout (5 # Second) $ readChan buf
   case evt of
     Just (TestBotMessage e) -> do
+      -- FUTUREWORK: Sometimes the assertion on the event type fails, but not
+      -- always. See https://wearezeta.atlassian.net/browse/BE-522.
       assertEqual "event type" ConvAccessUpdate (evtType e)
       assertEqual "conv" cnv (evtConv e)
       assertEqual "user" usr (evtFrom e)


### PR DESCRIPTION
The PR simply adds a futurework note in a flaky test in Brig. I don't think it deserves a change log entry.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
