### PR TITLE
Make non-collision test for 1-1 conv ids faster

### DIFF
--- a/services/galley/test/unit/Test/Galley/API/One2One.hs
+++ b/services/galley/test/unit/Test/Galley/API/One2One.hs
@@ -47,5 +47,6 @@ one2OneConvIdNonCollision = do
   let len = 10_000
   -- A generator of lists of length 'len' of qualified user ID pairs
   let gen = vectorOf len arbitrary
-  quids <- head <$> sample' gen
-  anySame (fmap (uncurry one2OneConvId) quids) @?= False
+  quids <- nubOrd <$> generate gen
+  let hashes = nubOrd (fmap (uncurry one2OneConvId) quids)
+  length hashes @?= length quids


### PR DESCRIPTION
The `anySame` function has quadratic runtime, but here we can use an `Ord` instance, and just compare the `nubOrd` lists. This also removes a potential flakyness caused by repeated input pairs (which should be quite likely to happen, given the low entropy of the UUID generator).

No CHANGELOG entry.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
