### PR TITLE
[feature config] self-deleting messages

### DIFF
--- a/changelog.d/0-release-notes/pr-1857
+++ b/changelog.d/0-release-notes/pr-1857
@@ -1,0 +1,1 @@
+Deploy galley before brig.

--- a/changelog.d/2-features/pr-1857-self-deleting-messages-feature
+++ b/changelog.d/2-features/pr-1857-self-deleting-messages-feature
@@ -1,0 +1,1 @@
+End-points for configuring self-deleting messages.

--- a/docs/reference/cassandra-schema.cql
+++ b/docs/reference/cassandra-schema.cql
@@ -422,6 +422,8 @@ CREATE TABLE galley_test.team_features (
     file_sharing int,
     legalhold_status int,
     search_visibility_status int,
+    self_deleting_messages_status int,
+    self_deleting_messages_ttl int,
     sso_status int,
     validate_saml_emails int
 ) WITH bloom_filter_fp_chance = 0.1

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -31,6 +31,7 @@ module Galley.Types.Teams
     flagAppLockDefaults,
     flagClassifiedDomains,
     flagConferenceCalling,
+    flagSelfDeletingMessages,
     Defaults (..),
     unDefaults,
     FeatureSSO (..),
@@ -214,7 +215,8 @@ data FeatureFlags = FeatureFlags
     _flagAppLockDefaults :: !(Defaults (TeamFeatureStatus 'TeamFeatureAppLock)),
     _flagClassifiedDomains :: !(TeamFeatureStatus 'TeamFeatureClassifiedDomains),
     _flagFileSharing :: !(Defaults (TeamFeatureStatus 'TeamFeatureFileSharing)),
-    _flagConferenceCalling :: !(Defaults (TeamFeatureStatus 'TeamFeatureConferenceCalling))
+    _flagConferenceCalling :: !(Defaults (TeamFeatureStatus 'TeamFeatureConferenceCalling)),
+    _flagSelfDeletingMessages :: !(Defaults (TeamFeatureStatus 'TeamFeatureSelfDeletingMessages))
   }
   deriving (Eq, Show, Generic)
 
@@ -260,9 +262,10 @@ instance FromJSON FeatureFlags where
       <*> (fromMaybe defaultClassifiedDomains <$> (obj .:? "classifiedDomains"))
       <*> (fromMaybe (Defaults (TeamFeatureStatusNoConfig TeamFeatureEnabled)) <$> (obj .:? "fileSharing"))
       <*> (fromMaybe (Defaults (TeamFeatureStatusNoConfig TeamFeatureEnabled)) <$> (obj .:? "conferenceCalling"))
+      <*> (fromMaybe (Defaults defaultSelfDeletingMessagesStatus) <$> (obj .:? "selfDeletingMessages"))
 
 instance ToJSON FeatureFlags where
-  toJSON (FeatureFlags sso legalhold searchVisibility appLock classifiedDomains fileSharing conferenceCalling) =
+  toJSON (FeatureFlags sso legalhold searchVisibility appLock classifiedDomains fileSharing conferenceCalling selfDeletingMessages) =
     object $
       [ "sso" .= sso,
         "legalhold" .= legalhold,
@@ -270,7 +273,8 @@ instance ToJSON FeatureFlags where
         "appLock" .= appLock,
         "classifiedDomains" .= classifiedDomains,
         "fileSharing" .= fileSharing,
-        "conferenceCalling" .= conferenceCalling
+        "conferenceCalling" .= conferenceCalling,
+        "selfDeletingMessages" .= selfDeletingMessages
       ]
 
 instance FromJSON FeatureSSO where
@@ -362,6 +366,7 @@ roleHiddenPermissions role = HiddenPermissions p p
             ChangeTeamFeature TeamFeatureAppLock,
             ChangeTeamFeature TeamFeatureFileSharing,
             ChangeTeamFeature TeamFeatureClassifiedDomains {- the features not listed here can only be changed in stern -},
+            ChangeTeamFeature TeamFeatureSelfDeletingMessages,
             ReadIdp,
             CreateUpdateDeleteIdp,
             CreateReadDeleteScimToken,
@@ -381,6 +386,7 @@ roleHiddenPermissions role = HiddenPermissions p p
           ViewTeamFeature TeamFeatureFileSharing,
           ViewTeamFeature TeamFeatureClassifiedDomains,
           ViewTeamFeature TeamFeatureConferenceCalling,
+          ViewTeamFeature TeamFeatureSelfDeletingMessages,
           ViewLegalHoldUserSettings,
           ViewTeamSearchVisibility
         ]

--- a/libs/galley-types/test/unit/Test/Galley/Types.hs
+++ b/libs/galley-types/test/unit/Test/Galley/Types.hs
@@ -96,3 +96,4 @@ instance Arbitrary FeatureFlags where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary

--- a/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
+++ b/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
@@ -30,7 +30,7 @@ import Data.Json.Util (ToJSONObject (..))
 import Data.Schema
 import qualified Data.Swagger as S
 import Imports
-import Wire.API.Team.Feature (TeamFeatureAppLockConfig, TeamFeatureClassifiedDomainsConfig, TeamFeatureName (..), TeamFeatureStatusNoConfig, TeamFeatureStatusWithConfig, TeamFeatureSelfDeletingMessagesConfig)
+import Wire.API.Team.Feature (TeamFeatureAppLockConfig, TeamFeatureClassifiedDomainsConfig, TeamFeatureName (..), TeamFeatureSelfDeletingMessagesConfig, TeamFeatureStatusNoConfig, TeamFeatureStatusWithConfig)
 
 data Event = Event
   { _eventType :: EventType,

--- a/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
+++ b/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
@@ -30,7 +30,7 @@ import Data.Json.Util (ToJSONObject (..))
 import Data.Schema
 import qualified Data.Swagger as S
 import Imports
-import Wire.API.Team.Feature (TeamFeatureAppLockConfig, TeamFeatureClassifiedDomainsConfig, TeamFeatureName (..), TeamFeatureStatusNoConfig, TeamFeatureStatusWithConfig)
+import Wire.API.Team.Feature (TeamFeatureAppLockConfig, TeamFeatureClassifiedDomainsConfig, TeamFeatureName (..), TeamFeatureStatusNoConfig, TeamFeatureStatusWithConfig, TeamFeatureSelfDeletingMessagesConfig)
 
 data Event = Event
   { _eventType :: EventType,
@@ -53,6 +53,7 @@ data EventData
   = EdFeatureWithoutConfigChanged TeamFeatureStatusNoConfig
   | EdFeatureApplockChanged (TeamFeatureStatusWithConfig TeamFeatureAppLockConfig)
   | EdFeatureClassifiedDomainsChanged (TeamFeatureStatusWithConfig TeamFeatureClassifiedDomainsConfig)
+  | EdFeatureSelfDeletingMessagesChanged (TeamFeatureStatusWithConfig TeamFeatureSelfDeletingMessagesConfig)
   deriving (Eq, Show, Generic)
 
 makePrisms ''EventData
@@ -73,6 +74,7 @@ taggedEventDataSchema =
       TeamFeatureFileSharing -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
       TeamFeatureClassifiedDomains -> tag _EdFeatureClassifiedDomainsChanged (unnamed schema)
       TeamFeatureConferenceCalling -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
+      TeamFeatureSelfDeletingMessages -> tag _EdFeatureSelfDeletingMessagesChanged (unnamed schema)
 
 eventObjectSchema :: ObjectSchema SwaggerDoc Event
 eventObjectSchema =

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -601,7 +601,6 @@ data Api routes = Api
              '[Servant.JSON]
              (PostOtrResponses MessageSendingStatus)
              (Either (MessageNotSent MessageSendingStatus) MessageSendingStatus),
-
     -- team features
     teamFeatureStatusSSOGet ::
       routes

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -601,6 +601,8 @@ data Api routes = Api
              '[Servant.JSON]
              (PostOtrResponses MessageSendingStatus)
              (Either (MessageNotSent MessageSendingStatus) MessageSendingStatus),
+
+    -- team features
     teamFeatureStatusSSOGet ::
       routes
         :- FeatureStatusGet 'TeamFeatureSSO,
@@ -652,6 +654,12 @@ data Api routes = Api
     teamFeatureStatusConferenceCallingGet ::
       routes
         :- FeatureStatusGet 'TeamFeatureConferenceCalling,
+    teamFeatureStatusSelfDeletingMessagesGet ::
+      routes
+        :- FeatureStatusGet 'TeamFeatureSelfDeletingMessages,
+    teamFeatureStatusSelfDeletingMessagesPut ::
+      routes
+        :- FeatureStatusPut 'TeamFeatureSelfDeletingMessages,
     featureAllFeatureConfigsGet ::
       routes
         :- AllFeatureConfigsGet,
@@ -681,7 +689,10 @@ data Api routes = Api
         :- FeatureConfigGet 'TeamFeatureClassifiedDomains,
     featureConfigConferenceCallingGet ::
       routes
-        :- FeatureConfigGet 'TeamFeatureConferenceCalling
+        :- FeatureConfigGet 'TeamFeatureConferenceCalling,
+    featureConfigSelfDeletingMessagesGet ::
+      routes
+        :- FeatureConfigGet 'TeamFeatureSelfDeletingMessages
   }
   deriving (Generic)
 

--- a/libs/wire-api/src/Wire/API/Swagger.hs
+++ b/libs/wire-api/src/Wire/API/Swagger.hs
@@ -128,6 +128,7 @@ models =
     Team.Feature.modelForTeamFeature Team.Feature.TeamFeatureClassifiedDomains,
     Team.Feature.modelTeamFeatureAppLockConfig,
     Team.Feature.modelTeamFeatureClassifiedDomainsConfig,
+    Team.Feature.modelTeamFeatureSelfDeletingMessagesConfig,
     Team.Invitation.modelTeamInvitation,
     Team.Invitation.modelTeamInvitationList,
     Team.Invitation.modelTeamInvitationRequest,

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -44,7 +44,6 @@ module Wire.API.Team.Feature
     modelTeamFeatureAppLockConfig,
     modelTeamFeatureClassifiedDomainsConfig,
     modelTeamFeatureSelfDeletingMessagesConfig,
-
     modelForTeamFeature,
   )
 where

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
@@ -204,6 +204,7 @@ tests =
       testRoundTrip @(Team.Feature.TeamFeatureStatus 'Team.Feature.TeamFeatureFileSharing),
       testRoundTrip @(Team.Feature.TeamFeatureStatus 'Team.Feature.TeamFeatureClassifiedDomains),
       testRoundTrip @(Team.Feature.TeamFeatureStatus 'Team.Feature.TeamFeatureConferenceCalling),
+      testRoundTrip @(Team.Feature.TeamFeatureStatus 'Team.Feature.TeamFeatureSelfDeletingMessages),
       testRoundTrip @Team.Feature.TeamFeatureStatusValue,
       testRoundTrip @Team.Invitation.InvitationRequest,
       testRoundTrip @Team.Invitation.Invitation,

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8bf007e90cc28a7b92252e0fccfb998d850e30df040205e1bc7316b9008a0c9f
+-- hash: 503d71d65ade51f149de711b6c0b958b0d7de6c3472c4831fc5549c20410b37a
 
 name:           galley
 version:        0.83.0
@@ -385,6 +385,7 @@ executable galley-schema
       V51_FeatureFileSharing
       V52_FeatureConferenceCalling
       V53_AddRemoteConvStatus
+      V54_TeamFeatureSelfDeletingMessages
       Paths_galley
   hs-source-dirs:
       schema/src

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -56,6 +56,7 @@ import qualified V50_AddLegalholdWhitelisted
 import qualified V51_FeatureFileSharing
 import qualified V52_FeatureConferenceCalling
 import qualified V53_AddRemoteConvStatus
+import qualified V54_TeamFeatureSelfDeletingMessages
 
 main :: IO ()
 main = do
@@ -97,7 +98,8 @@ main = do
       V50_AddLegalholdWhitelisted.migration,
       V51_FeatureFileSharing.migration,
       V52_FeatureConferenceCalling.migration,
-      V53_AddRemoteConvStatus.migration
+      V53_AddRemoteConvStatus.migration,
+      V54_TeamFeatureSelfDeletingMessages.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Galley.Data
       -- (see also docs/developer/cassandra-interaction.md)

--- a/services/galley/schema/src/V54_TeamFeatureSelfDeletingMessages.hs
+++ b/services/galley/schema/src/V54_TeamFeatureSelfDeletingMessages.hs
@@ -1,0 +1,34 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V54_TeamFeatureSelfDeletingMessages
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 54 "Add feature config for self-deleting messages" $ do
+  schema'
+    [r| ALTER TABLE team_features ADD (
+          self_deleting_messages_status int,
+          self_deleting_messages_ttl int
+        )
+     |]

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -174,6 +174,12 @@ data InternalApi routes = InternalApi
     iTeamFeatureStatusConferenceCallingGet ::
       routes
         :- IFeatureStatusGet 'Public.TeamFeatureConferenceCalling,
+    iTeamFeatureStatusSelfDeletingMessagesPut ::
+      routes
+        :- IFeatureStatusPut 'Public.TeamFeatureSelfDeletingMessages,
+    iTeamFeatureStatusSelfDeletingMessagesGet ::
+      routes
+        :- IFeatureStatusGet 'Public.TeamFeatureSelfDeletingMessages,
     -- This endpoint can lead to the following events being sent:
     -- - MemberLeave event to members for all conversations the user was in
     iDeleteUser ::
@@ -281,6 +287,8 @@ servantSitemap =
         iTeamFeatureStatusClassifiedDomainsGet = iGetTeamFeature @'Public.TeamFeatureClassifiedDomains Features.getClassifiedDomainsInternal,
         iTeamFeatureStatusConferenceCallingPut = iPutTeamFeature @'Public.TeamFeatureConferenceCalling Features.setConferenceCallingInternal,
         iTeamFeatureStatusConferenceCallingGet = iGetTeamFeature @'Public.TeamFeatureConferenceCalling Features.getConferenceCallingInternal,
+        iTeamFeatureStatusSelfDeletingMessagesPut = iPutTeamFeature @'Public.TeamFeatureSelfDeletingMessages Features.setSelfDeletingMessagesInternal,
+        iTeamFeatureStatusSelfDeletingMessagesGet = iGetTeamFeature @'Public.TeamFeatureSelfDeletingMessages Features.getSelfDeletingMessagesInternal,
         iDeleteUser = rmUser,
         iConnect = Create.createConnectConversation,
         iUpsertOne2OneConversation = One2One.iUpsertOne2OneConversation

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -162,6 +162,12 @@ servantSitemap =
         GalleyAPI.teamFeatureStatusConferenceCallingGet =
           getFeatureStatus @'Public.TeamFeatureConferenceCalling Features.getConferenceCallingInternal
             . DoAuth,
+        GalleyAPI.teamFeatureStatusSelfDeletingMessagesGet =
+          getFeatureStatus @'Public.TeamFeatureSelfDeletingMessages Features.getSelfDeletingMessagesInternal
+            . DoAuth,
+        GalleyAPI.teamFeatureStatusSelfDeletingMessagesPut =
+          setFeatureStatus @'Public.TeamFeatureSelfDeletingMessages Features.setSelfDeletingMessagesInternal
+            . DoAuth,
         GalleyAPI.featureAllFeatureConfigsGet = Features.getAllFeatureConfigs,
         GalleyAPI.featureConfigLegalHoldGet = Features.getFeatureConfig @'Public.TeamFeatureLegalHold Features.getLegalholdStatusInternal,
         GalleyAPI.featureConfigSSOGet = Features.getFeatureConfig @'Public.TeamFeatureSSO Features.getSSOStatusInternal,
@@ -171,7 +177,8 @@ servantSitemap =
         GalleyAPI.featureConfigAppLockGet = Features.getFeatureConfig @'Public.TeamFeatureAppLock Features.getAppLockInternal,
         GalleyAPI.featureConfigFileSharingGet = Features.getFeatureConfig @'Public.TeamFeatureFileSharing Features.getFileSharingInternal,
         GalleyAPI.featureConfigClassifiedDomainsGet = Features.getFeatureConfig @'Public.TeamFeatureClassifiedDomains Features.getClassifiedDomainsInternal,
-        GalleyAPI.featureConfigConferenceCallingGet = Features.getFeatureConfig @'Public.TeamFeatureConferenceCalling Features.getConferenceCallingInternal
+        GalleyAPI.featureConfigConferenceCallingGet = Features.getFeatureConfig @'Public.TeamFeatureConferenceCalling Features.getConferenceCallingInternal,
+        GalleyAPI.featureConfigSelfDeletingMessagesGet = Features.getFeatureConfig @'Public.TeamFeatureSelfDeletingMessages Features.getSelfDeletingMessagesInternal
       }
 
 sitemap :: Routes ApiBuilder (Galley GalleyEffects) ()

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -38,6 +38,8 @@ module Galley.API.Teams.Features
     setFileSharingInternal,
     getConferenceCallingInternal,
     setConferenceCallingInternal,
+    getSelfDeletingMessagesInternal,
+    setSelfDeletingMessagesInternal,
     DoAuth (..),
     GetFeatureInternalParam,
   )
@@ -162,7 +164,8 @@ getAllFeatureConfigs zusr = do
         getStatus @'Public.TeamFeatureAppLock getAppLockInternal,
         getStatus @'Public.TeamFeatureFileSharing getFileSharingInternal,
         getStatus @'Public.TeamFeatureClassifiedDomains getClassifiedDomainsInternal,
-        getStatus @'Public.TeamFeatureConferenceCalling getConferenceCallingInternal
+        getStatus @'Public.TeamFeatureConferenceCalling getConferenceCallingInternal,
+        getStatus @'Public.TeamFeatureSelfDeletingMessages getSelfDeletingMessagesInternal
       ]
 
 getAllFeaturesH :: UserId ::: TeamId ::: JSON -> Galley r Response
@@ -181,7 +184,8 @@ getAllFeatures uid tid = do
         getStatus @'Public.TeamFeatureAppLock getAppLockInternal,
         getStatus @'Public.TeamFeatureFileSharing getFileSharingInternal,
         getStatus @'Public.TeamFeatureClassifiedDomains getClassifiedDomainsInternal,
-        getStatus @'Public.TeamFeatureConferenceCalling getConferenceCallingInternal
+        getStatus @'Public.TeamFeatureConferenceCalling getConferenceCallingInternal,
+        getStatus @'Public.TeamFeatureSelfDeletingMessages getSelfDeletingMessagesInternal
       ]
   where
     getStatus ::
@@ -403,6 +407,19 @@ setConferenceCallingInternal ::
   Public.TeamFeatureStatus 'Public.TeamFeatureConferenceCalling ->
   Galley r (Public.TeamFeatureStatus 'Public.TeamFeatureConferenceCalling)
 setConferenceCallingInternal = setFeatureStatusNoConfig @'Public.TeamFeatureConferenceCalling $ \_status _tid -> pure ()
+
+getSelfDeletingMessagesInternal :: GetFeatureInternalParam -> Galley r (Public.TeamFeatureStatus 'Public.TeamFeatureSelfDeletingMessages)
+getSelfDeletingMessagesInternal = \case
+  Left _ -> pure Public.defaultSelfDeletingMessagesStatus
+  Right tid ->
+    TeamFeatures.getSelfDeletingMessagesStatus tid
+      <&> maybe Public.defaultSelfDeletingMessagesStatus id
+
+setSelfDeletingMessagesInternal ::
+  TeamId ->
+  Public.TeamFeatureStatus 'Public.TeamFeatureSelfDeletingMessages ->
+  Galley r (Public.TeamFeatureStatus 'Public.TeamFeatureSelfDeletingMessages)
+setSelfDeletingMessagesInternal = TeamFeatures.setSelfDeletingMessagesStatus
 
 pushFeatureConfigEvent :: Member GundeckAccess r => TeamId -> Event.Event -> Galley r ()
 pushFeatureConfigEvent tid event = do

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -206,7 +206,7 @@ mkResultSet page = ResultSet (result page) typ
       | otherwise = ResultSetComplete
 
 schemaVersion :: Int32
-schemaVersion = 53
+schemaVersion = 54
 
 -- | Insert a conversation code
 insertCode :: Code -> Galley r ()

--- a/services/galley/src/Galley/Data/TeamFeatures.hs
+++ b/services/galley/src/Galley/Data/TeamFeatures.hs
@@ -101,7 +101,7 @@ setFeatureStatusNoConfig tid status = do
   pure status
   where
     insert :: PrepQuery W (TeamId, TeamFeatureStatusValue) ()
-    insert = fromString $ "insert team_features (team_id, " <> statusCol @a <> ") values (?, ?)"
+    insert = fromString $ "insert into team_features (team_id, " <> statusCol @a <> ") values (?, ?)"
 
 getApplockFeatureStatus ::
   forall m.
@@ -136,7 +136,7 @@ setApplockFeatureStatus tid status = do
     insert :: PrepQuery W (TeamId, TeamFeatureStatusValue, Public.EnforceAppLock, Int32) ()
     insert =
       fromString $
-        "insert team_features (team_id, "
+        "insert into team_features (team_id, "
           <> statusCol @'Public.TeamFeatureAppLock
           <> ", app_lock_enforce, app_lock_inactivity_timeout_secs) values (?, ?, ?, ?)"
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-574

Adds end-points (public-team, public-team-oblivious, internal) for CRUDding `selfDeletingMessages` as a feature.  Team admins can now choose between previous behavior (default), disable self-deleting messages, and enforce self-deleting messages with a given time-out.

This is enforced on the client-side.  The server merely maintains the configuration for teams (not site or personal, those have a baked-in default).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If public end-points have been changed or added: does nginz need an upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
