### PR TITLE
Remove a leftover TODO that was addressed

### DIFF
--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -117,7 +117,6 @@ data Api routes = Api
     -- - MemberLeave event to members for all conversations the user was in (via galley)
     deleteSelf ::
       routes
-        -- TODO: Add custom AsUnion
         :- Summary "Initiate account deletion."
         :> Description
              "if the account has a verified identity, a verification \


### PR DESCRIPTION
This just removes a TODO that was taken care of in a previous PR, but that made it into `develop`. I believe this one-line comment-removing PR deserves no change log entry.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.

