### PR TITLE
Changelog script: skip empty sections

### DIFF
--- a/changelog.d/mk-changelog.sh
+++ b/changelog.d/mk-changelog.sh
@@ -13,10 +13,14 @@ getPRNumber() {
 for d in "$DIR"/*; do
     if [[ ! -d "$d" ]]; then continue; fi
 
+    entries=("$d"/*[^~])
+
+    if [[ ${#entries[@]} -eq 0 ]]; then continue; fi
+
     echo -n "## "
     sed '$ a\' "$d/.title"
     echo ""
-    for f in "$d"/*[^~]; do
+    for f in "${entries[@]}"; do
         pr=$(getPRNumber $f)
         sed -r '
           # create a bullet point on the first line


### PR DESCRIPTION
Minor cosmetic improvement to changelog generation script, so that it does not print section headings for empty sections.

No CHANGELOG entry.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
