### PR TITLE
Close GRPC client after making a request to federator

### DIFF
--- a/changelog.d/6-federation/close-grpc-client
+++ b/changelog.d/6-federation/close-grpc-client
@@ -1,0 +1,1 @@
+Close GRPC client after making a request to a federator.

--- a/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
@@ -20,6 +20,7 @@
 
 module Wire.API.Federation.Client where
 
+import Control.Monad.Catch
 import Control.Monad.Except (ExceptT, MonadError (..), withExceptT)
 import Control.Monad.State (MonadState (..), StateT, evalStateT, gets)
 import Data.ByteString.Builder (toLazyByteString)
@@ -27,13 +28,13 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Domain (Domain, domainText)
 import qualified Data.Text as T
 import Imports
-import Mu.GRpc.Client.TyApps (GRpcMessageProtocol (MsgProtoBuf), GRpcReply (..), GrpcClient, gRpcCall, grpcClientConfigSimple)
+import Mu.GRpc.Client.TyApps
 import qualified Network.HTTP.Types as HTTP
 import Servant.Client (ResponseF (..))
 import qualified Servant.Client as Servant
 import Servant.Client.Core (RequestBody (..), RequestF (..), RunClient (..))
 import Util.Options (Endpoint (..))
-import Wire.API.Federation.GRPC.Client (createGrpcClient, reason)
+import Wire.API.Federation.GRPC.Client
 import qualified Wire.API.Federation.GRPC.Types as Proto
 
 -- FUTUREWORK: Remove originDomain from here and make it part of all the API
@@ -50,7 +51,10 @@ newtype FederatorClient (component :: Proto.Component) m a = FederatorClient {ru
   deriving newtype (Functor, Applicative, Monad, MonadReader FederatorClientEnv, MonadState (Maybe ByteString), MonadIO)
 
 runFederatorClientWith :: Monad m => GrpcClient -> Domain -> Domain -> FederatorClient component m a -> m a
-runFederatorClientWith client targetDomain originDomain = flip evalStateT Nothing . flip runReaderT (FederatorClientEnv client targetDomain originDomain) . runFederatorClient
+runFederatorClientWith client targetDomain originDomain =
+  flip evalStateT Nothing
+    . flip runReaderT (FederatorClientEnv client targetDomain originDomain)
+    . runFederatorClient
 
 class KnownComponent (c :: Proto.Component) where
   componentVal :: Proto.Component
@@ -167,11 +171,12 @@ mkFederatorClient = do
     >>= either (throwError . FederationUnavailable . reason) pure
 
 executeFederated ::
-  (MonadIO m, HasFederatorConfig m) =>
+  (MonadIO m, MonadMask m, HasFederatorConfig m) =>
   Domain ->
   FederatorClient component (ExceptT FederationClientFailure m) a ->
   ExceptT FederationError m a
 executeFederated targetDomain action = do
-  federatorClient <- mkFederatorClient
   originDomain <- lift federationDomain
-  withExceptT FederationCallFailure (runFederatorClientWith federatorClient targetDomain originDomain action)
+  bracket mkFederatorClient closeGrpcClient $ \federatorClient ->
+    withExceptT FederationCallFailure $
+      runFederatorClientWith federatorClient targetDomain originDomain action

--- a/services/federator/test/integration/Test/Federator/Util.hs
+++ b/services/federator/test/integration/Test/Federator/Util.hs
@@ -69,7 +69,8 @@ newtype TestFederator m a = TestFederator {unwrapTestFederator :: ReaderT TestEn
       MonadReader TestEnv,
       MonadFail,
       MonadThrow,
-      MonadCatch
+      MonadCatch,
+      MonadMask
     )
 
 instance MonadRandom m => MonadRandom (TestFederator m) where

--- a/services/galley/src/Galley/Intra/Federator/Types.hs
+++ b/services/galley/src/Galley/Intra/Federator/Types.hs
@@ -25,6 +25,7 @@ module Galley.Intra.Federator.Types
 where
 
 import Control.Lens
+import Control.Monad.Catch
 import Control.Monad.Except
 import Galley.Env
 import Galley.Options
@@ -43,7 +44,10 @@ newtype FederationM a = FederationM
       Monad,
       MonadIO,
       MonadReader Env,
-      MonadUnliftIO
+      MonadUnliftIO,
+      MonadThrow,
+      MonadCatch,
+      MonadMask
     )
 
 runFederationM :: Env -> FederationM a -> IO a


### PR DESCRIPTION
This is a followup PR to #1865, addressing the same issue, but for GRPC connections to the internal federator. This also takes care of cleaning of the GrpcClient in tests.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
