### PR TITLE
Introduce 'make flake-PATTERN'

### DIFF
--- a/changelog.d/5-internal/deflake-maketarget
+++ b/changelog.d/5-internal/deflake-maketarget
@@ -1,0 +1,1 @@
+Add a 'make flake-PATTERN' target to run a subset of tests multiple times to trigger a failure case in flaky tests

--- a/services/brig/Makefile
+++ b/services/brig/Makefile
@@ -103,6 +103,19 @@ i-list:
 i-%:
 	INTEGRATION_USE_NGINZ=$(INTEGRATION_USE_NGINZ) ../integration.sh $(EXE_IT) -s $(NAME).integration.yaml -i ../integration.yaml -p "$*" $(WIRE_INTEGRATION_TEST_OPTIONS)
 
+
+# Like integration-%, but starts services only once then runs a given test pattern $FLAKE_AMOUNT times until a failure is seen
+FLAKE_FILE    ?= /tmp/flake.sh
+FLAKE_AMOUNT  ?= 1000
+flake-%: fast
+	echo 'set -ex' > $(FLAKE_FILE)
+	chmod +x $(FLAKE_FILE)
+	for i in $$(seq $(FLAKE_AMOUNT)); do \
+		echo "echo $$i" >> $(FLAKE_FILE); \
+		echo '$(EXE_IT) -s $(NAME).integration.yaml -i ../integration.yaml -p "$*" $(WIRE_INTEGRATION_TEST_OPTIONS)' >> $(FLAKE_FILE); \
+	done
+	INTEGRATION_USE_NGINZ=$(INTEGRATION_USE_NGINZ) ../integration.sh $(FLAKE_FILE)
+
 .PHONY: integration
 integration: fast i
 


### PR DESCRIPTION
Add a 'make flake-PATTERN' target to run a subset of tests multiple times to trigger a failure case in flaky tests. By default the test(s) will run up to 1000 times until a failure occurs, at which point it will stop. Scrolling up on the output will show you how many tests had to run to trigger a failure.

example output:

```
make flake-sso-id
echo 'set -ex' > /tmp/flake.sh
chmod +x /tmp/flake.sh
for i in $(seq 1000); do \
	echo "echo $i" >> /tmp/flake.sh; \
	echo '../../dist/brig-integration -s brig.integration.yaml -i ../integration.yaml -p "sso-id" ' >> /tmp/flake.sh; \
done
INTEGRATION_USE_NGINZ=1 ../integration.sh /tmp/flake.sh
Running tests using mocked AWS services
[cannon] I, Listening on 127.0.0.1:8083
[cannon] I, Listening on 127.0.0.1:8183
[cargohold] I, Listening on 0.0.0.0:8084
[spar] I, logger=cassandra.spar, Known hosts: [datacenter1:rack1:127.0.0.1:9042]
[federator] D, inotify initialized, inotify=<inotify fd=11>
[gundeck] I, Listening on 0.0.0.0:8086
[galley] I, Listening on 127.0.0.1:8085
[spar] I, Listening on 0.0.0.0:8088
[nginz] 127.0.0.1 - - [20/Oct/2021:16:33:50 +0200] "GET /i/status HTTP/1.1" 200 0 "-" "curl/7.71.1" "-" - 2 0.000 - - - - 3cabaf643c510db36a3c989301d73569
all services are up!
++ echo 1
1
++ ../../dist/brig-integration -s brig.integration.yaml -i ../integration.yaml -p sso-id
2021-10-20T14:33:51Z, D, Connecting to 127.0.0.1:9042
2021-10-20T14:33:51Z, I, Known hosts: [datacenter1:rack1:127.0.0.1:9042]
2021-10-20T14:33:51Z, I, New control connection: datacenter1:rack1:127.0.0.1:9042#<socket: 3>
Brig API Integration
  user
    account
      put /i/users/:uid/sso-id: OK (0.82s)

All 1 tests passed (0.83s)
++ echo 2
2
++ ../../dist/brig-integration -s brig.integration.yaml -i ../integration.yaml -p sso-id
2021-10-20T14:33:53Z, D, Connecting to 127.0.0.1:9042
Brig API Integration
  user
    account
      put /i/users/:uid/sso-id: 2021-10-20T14:33:53Z, I, Known hosts: [datacenter1:rack1:127.0.0.1:9042]
2021-10-20T14:33:53Z, I, New control connection: datacenter1:rack1:127.0.0.1:9042#<socket: 3>
OK (0.85s)

All 1 tests passed (0.85s)
++ echo 3
3
++ ../../dist/brig-integration -s brig.integration.yaml -i ../integration.yaml -p sso-id
2021-10-20T14:33:55Z, D, Connecting to 127.0.0.1:9042
Brig API Integration
  user
    account
      put /i/users/:uid/sso-id: 2021-10-20T14:33:55Z, I, Known hosts: [datacenter1:rack1:127.0.0.1:9042]
2021-10-20T14:33:55Z, I, New control connection: datacenter1:rack1:127.0.0.1:9042#<socket: 3>
OK (0.77s)

All 1 tests passed (0.77s)
++ echo 4
4
++ ../../dist/brig-integration -s brig.integration.yaml -i ../integration.yaml -p sso-id
2021-10-20T14:33:56Z, D, Connecting to 127.0.0.1:9042
Brig API Integration
  user
    account
      put /i/users/:uid/sso-id: 2021-10-20T14:33:56Z, I, Known hosts: [datacenter1:rack1:127.0.0.1:9042]
2021-10-20T14:33:56Z, I, New control connection: datacenter1:rack1:127.0.0.1:9042#<socket: 3>
OK (0.79s)

All 1 tests passed (0.79s)
++ echo 5
5
++ ../../dist/brig-integration -s brig.integration.yaml -i ../integration.yaml -p sso-id
```

When a failure happens:

```
++ echo 282
282
++ ../../dist/brig-integration -s brig.integration.yaml -i ../integration.yaml -p sso-id
2021-10-20T14:41:25Z, D, Connecting to 127.0.0.1:9042
[brig] W, logger=cassandra.brig, Server warning: Read 0 live rows and 2102 tombstone cells for query SELECT * FROM brig_test.users_pending_activation WHERE  LIMIT 10000 (see tombstone_warn_threshold)
Brig API Integration
  user
    account
      put /i/users/:uid/sso-id: 2021-10-20T14:41:25Z, I, Known hosts: [datacenter1:rack1:127.0.0.1:9042]
2021-10-20T14:41:25Z, I, New control connection: datacenter1:rack1:127.0.0.1:9042#<socket: 3>
[brig] W, logger=cassandra.brig, Server warning: Read 0 live rows and 2104 tombstone cells for query SELECT * FROM brig_test.users_pending_activation WHERE  LIMIT 10000 (see tombstone_warn_threshold)
FAIL
        Exception: Assertions failed:
         1: 202 =/= 403
         2: updatePhone (PUT /self/phone): failed to update to Phone {fromPhone = "+046965171332989"} - might be a flaky test tracked in https://wearezeta.atlassian.net/browse/BE-526

        Response was:

        Response {responseStatus = Status {statusCode = 403, statusMessage = "Forbidden"}, responseVersion = HTTP/1.1, responseHeaders = [("Transfer-Encoding","chunked"),("Date","Wed, 20 Oct 2021 14:41:27 GMT"),("Server","Warp/3.3.13"),("Content-Encoding","gzip"),("Content-Type","application/json")], responseBody = Just "{\"code\":403,\"message\":\"The given phone number has been blacklisted due to suspected abuse or a complaint.\",\"label\":\"blacklisted-phone\"}", responseCookieJar = CJ {expose = []}, responseClose' = ResponseClose}
        CallStack (from HasCallStack):
          error, called at src/Bilge/Assert.hs:89:5 in bilge-0.22.0-5tCtgpJGKRb38JsbN4shGd:Bilge.Assert
          <!!, called at src/Bilge/Assert.hs:107:19 in bilge-0.22.0-5tCtgpJGKRb38JsbN4shGd:Bilge.Assert
          !!!, called at test/integration/Util.hs:735:3 in main:Util
          updatePhone, called at test/integration/API/User/Account.hs:1230:11 in main:API.User.Account

1 out of 1 tests failed (0.79s)
Terminated
Terminated
[brig] W, logger=cassandra.brig, Server warning: Read 0 live rows and 2106 tombstone cells for query SELECT * FROM brig_test.users_pending_activation WHERE  LIMIT 10000 (see tombstone_warn_threshold)
make: *** [Makefile:114: flake-sso-id] Error 1

```

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.