### PR TITLE
Include conv creator is only once in notifications sent to remotes

### DIFF
--- a/changelog.d/6-federation/ensure-one-creator-member
+++ b/changelog.d/6-federation/ensure-one-creator-member
@@ -1,0 +1,1 @@
+Ensure that the conversation creator is included only once in notifications sent to remote users

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -163,8 +163,8 @@ data NewRemoteConversation conv = NewRemoteConversation
     rcCnvAccessRole :: AccessRole,
     -- | The conversation name,
     rcCnvName :: Maybe Text,
-    -- | Members of the conversation
-    rcMembers :: Set OtherMember,
+    -- | Members of the conversation apart from the creator
+    rcNonCreatorMembers :: Set OtherMember,
     rcMessageTimer :: Maybe Milliseconds,
     rcReceiptMode :: Maybe ReceiptMode
   }

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/GoldenSpec.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/GoldenSpec.hs
@@ -25,6 +25,7 @@ import qualified Test.Wire.API.Federation.Golden.LeaveConversationResponse as Le
 import qualified Test.Wire.API.Federation.Golden.MessageSendResponse as MessageSendResponse
 import qualified Test.Wire.API.Federation.Golden.NewConnectionRequest as NewConnectionRequest
 import qualified Test.Wire.API.Federation.Golden.NewConnectionResponse as NewConnectionResponse
+import qualified Test.Wire.API.Federation.Golden.NewRemoteConversation as NewRemoteConversation
 import Test.Wire.API.Federation.Golden.Runner (testObjects)
 
 spec :: Spec
@@ -61,4 +62,8 @@ spec =
         (NewConnectionResponse.testObject_NewConnectionResponse2, "testObject_NewConnectionResponse2.json"),
         (NewConnectionResponse.testObject_NewConnectionResponse3, "testObject_NewConnectionResponse3.json"),
         (NewConnectionResponse.testObject_NewConnectionResponse4, "testObject_NewConnectionResponse4.json")
+      ]
+    testObjects
+      [ (NewRemoteConversation.testObject_NewRemoteConversation1, "testObject_NewRemoteConversation1.json"),
+        (NewRemoteConversation.testObject_NewRemoteConversation2, "testObject_NewRemoteConversation2.json")
       ]

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/NewRemoteConversation.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/NewRemoteConversation.hs
@@ -1,0 +1,67 @@
+module Test.Wire.API.Federation.Golden.NewRemoteConversation where
+
+import Data.Domain
+import Data.Id
+import Data.Misc
+import Data.Qualified
+import qualified Data.Set as Set
+import qualified Data.UUID as UUID
+import Imports
+import Wire.API.Conversation
+import Wire.API.Conversation.Role
+import Wire.API.Federation.API.Galley
+import Wire.API.Provider.Service
+
+testObject_NewRemoteConversation1 :: NewRemoteConversation ConvId
+testObject_NewRemoteConversation1 =
+  NewRemoteConversation
+    { rcTime = read "1864-04-12 12:22:43.673 UTC",
+      rcOrigUserId = Id (fromJust (UUID.fromString "eed9dea3-5468-45f8-b562-7ad5de2587d0")),
+      rcCnvId = Id (fromJust (UUID.fromString "d13dbe58-d4e3-450f-9c0c-1e632f548740")),
+      rcCnvType = RegularConv,
+      rcCnvAccess = [InviteAccess, CodeAccess],
+      rcCnvAccessRole = ActivatedAccessRole,
+      rcCnvName = Just "gossip",
+      rcNonCreatorMembers =
+        Set.fromList
+          [ OtherMember
+              { omQualifiedId =
+                  Qualified
+                    (read "50e6fff1-ffbd-4235-bc73-19c093433beb")
+                    (Domain "golden.example.com"),
+                omService = Nothing,
+                omConvRoleName = roleNameWireAdmin
+              },
+            OtherMember
+              { omQualifiedId =
+                  Qualified
+                    (read "6801e49b-918c-4eef-baed-f18522152fca")
+                    (Domain "golden.example.com"),
+                omService =
+                  Just
+                    ( ServiceRef
+                        { _serviceRefId = read "abfe2452-ed22-4f94-b4d4-765b989d7dbb",
+                          _serviceRefProvider = read "11b91f61-917e-489b-a268-60b881d08f06"
+                        }
+                    ),
+                omConvRoleName = roleNameWireMember
+              }
+          ],
+      rcMessageTimer = Just (Ms 1000),
+      rcReceiptMode = Just (ReceiptMode 42)
+    }
+
+testObject_NewRemoteConversation2 :: NewRemoteConversation ConvId
+testObject_NewRemoteConversation2 =
+  NewRemoteConversation
+    { rcTime = read "1864-04-12 12:22:43.673 UTC",
+      rcOrigUserId = Id (fromJust (UUID.fromString "eed9dea3-5468-45f8-b562-7ad5de2587d0")),
+      rcCnvId = Id (fromJust (UUID.fromString "d13dbe58-d4e3-450f-9c0c-1e632f548740")),
+      rcCnvType = One2OneConv,
+      rcCnvAccess = [],
+      rcCnvAccessRole = ActivatedAccessRole,
+      rcCnvName = Nothing,
+      rcNonCreatorMembers = Set.fromList [],
+      rcMessageTimer = Nothing,
+      rcReceiptMode = Nothing
+    }

--- a/libs/wire-api-federation/test/golden/testObject_NewRemoteConversation1.json
+++ b/libs/wire-api-federation/test/golden/testObject_NewRemoteConversation1.json
@@ -1,0 +1,38 @@
+{
+    "orig_user_id": "eed9dea3-5468-45f8-b562-7ad5de2587d0",
+    "time": "1864-04-12T12:22:43.673Z",
+    "cnv_access": [
+        "invite",
+        "code"
+    ],
+    "non_creator_members": [
+        {
+            "status": 0,
+            "conversation_role": "wire_admin",
+            "qualified_id": {
+                "domain": "golden.example.com",
+                "id": "50e6fff1-ffbd-4235-bc73-19c093433beb"
+            },
+            "id": "50e6fff1-ffbd-4235-bc73-19c093433beb"
+        },
+        {
+            "status": 0,
+            "service": {
+                "id": "abfe2452-ed22-4f94-b4d4-765b989d7dbb",
+                "provider": "11b91f61-917e-489b-a268-60b881d08f06"
+            },
+            "conversation_role": "wire_member",
+            "qualified_id": {
+                "domain": "golden.example.com",
+                "id": "6801e49b-918c-4eef-baed-f18522152fca"
+            },
+            "id": "6801e49b-918c-4eef-baed-f18522152fca"
+        }
+    ],
+    "cnv_access_role": "activated",
+    "cnv_type": 0,
+    "receipt_mode": 42,
+    "message_timer": 1000,
+    "cnv_name": "gossip",
+    "cnv_id": "d13dbe58-d4e3-450f-9c0c-1e632f548740"
+}

--- a/libs/wire-api-federation/test/golden/testObject_NewRemoteConversation2.json
+++ b/libs/wire-api-federation/test/golden/testObject_NewRemoteConversation2.json
@@ -1,0 +1,12 @@
+{
+    "orig_user_id": "eed9dea3-5468-45f8-b562-7ad5de2587d0",
+    "time": "1864-04-12T12:22:43.673Z",
+    "cnv_access": [],
+    "non_creator_members": [],
+    "cnv_access_role": "activated",
+    "cnv_type": 2,
+    "receipt_mode": null,
+    "message_timer": null,
+    "cnv_name": null,
+    "cnv_id": "d13dbe58-d4e3-450f-9c0c-1e632f548740"
+}

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 03f7245b036ccc38819ed5f5654dae8d96b7ec5917b2f898be3305193bc3faf5
+-- hash: 6b4b223086cf1ba879d202fe6b884009e44bff247db6de7a2501d599295b8457
 
 name:           wire-api-federation
 version:        0.1.0
@@ -84,6 +84,7 @@ test-suite spec
       Test.Wire.API.Federation.Golden.MessageSendResponse
       Test.Wire.API.Federation.Golden.NewConnectionRequest
       Test.Wire.API.Federation.Golden.NewConnectionResponse
+      Test.Wire.API.Federation.Golden.NewRemoteConversation
       Test.Wire.API.Federation.Golden.Runner
       Test.Wire.API.Federation.GRPC.TypesSpec
       Paths_wire_api_federation

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -83,7 +83,7 @@ onConversationCreated :: Domain -> NewRemoteConversation ConvId -> Galley ()
 onConversationCreated domain rc = do
   let qrc = fmap (toRemoteUnsafe domain) rc
   loc <- qualifyLocal ()
-  let (localUserIds, _) = partitionQualified loc (map omQualifiedId (toList (rcMembers rc)))
+  let (localUserIds, _) = partitionQualified loc (map omQualifiedId (toList (rcNonCreatorMembers rc)))
 
   addedUserIds <-
     addLocalUsersToRemoteConv
@@ -99,9 +99,9 @@ onConversationCreated domain rc = do
               (const True)
               . omQualifiedId
           )
-          (rcMembers rc)
+          (rcNonCreatorMembers rc)
   -- Make sure to notify only about local users connected to the adder
-  let qrcConnected = qrc {rcMembers = connectedMembers}
+  let qrcConnected = qrc {rcNonCreatorMembers = connectedMembers}
 
   forM_ (fromNewRemoteConversation loc qrcConnected) $ \(mem, c) -> do
     let event =

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -690,7 +690,7 @@ toNewRemoteConversation now localDomain Data.Conversation {..} =
       rcCnvAccess = convAccess,
       rcCnvAccessRole = convAccessRole,
       rcCnvName = convName,
-      rcMembers = toMembers convLocalMembers convRemoteMembers,
+      rcNonCreatorMembers = toMembers (filter (\lm -> lmId lm /= convCreator) convLocalMembers) convRemoteMembers,
       rcMessageTimer = convMessageTimer,
       rcReceiptMode = convReceiptMode
     }
@@ -714,7 +714,7 @@ fromNewRemoteConversation ::
   NewRemoteConversation (Remote ConvId) ->
   [(Public.Member, Public.Conversation)]
 fromNewRemoteConversation loc rc@NewRemoteConversation {..} =
-  let membersView = fmap (second Set.toList) . setHoles $ rcMembers
+  let membersView = fmap (second Set.toList) . setHoles $ rcNonCreatorMembers
       creatorOther =
         OtherMember
           (qUntagged (rcRemoteOrigUserId rc))


### PR DESCRIPTION
To remove any confusion in the `on-conversation-created` federation API, rename
"members" to "non_creator_members". As the creator is already specified in
"orig_user_id".

Also:
- Add Golden tests for `NewRemoteConversation`
- Add integration tests for creating conversation with remote users

https://wearezeta.atlassian.net/browse/SQCORE-1106

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.