### PR TITLE
Cassandra: use LOCAL_QUORUM

### DIFF
--- a/changelog.d/0-release-notes/cassandra-local-quorum
+++ b/changelog.d/0-release-notes/cassandra-local-quorum
@@ -1,0 +1,1 @@
+In case you use a multi-datacentre cassandra setup (most likely you do not), be aware that now [LOCAL_QUORUM](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html) is in use as a default.

--- a/libs/cassandra-util/src/Cassandra.hs
+++ b/libs/cassandra-util/src/Cassandra.hs
@@ -27,7 +27,7 @@ import Cassandra.CQL as C
     BatchType (BatchLogged, BatchUnLogged),
     Blob (Blob),
     ColumnType (AsciiColumn, BigIntColumn, BlobColumn, BooleanColumn, DoubleColumn, IntColumn, ListColumn, MaybeColumn, TextColumn, TimestampColumn, UdtColumn, UuidColumn),
-    Consistency (All, LocalQuorum, One),
+    Consistency (All, LocalQuorum, One), -- DO NOT EXPORT 'Quorum' here (until a DC migration is complete)
     Cql,
     Keyspace (Keyspace),
     PagingState (..),

--- a/libs/cassandra-util/src/Cassandra.hs
+++ b/libs/cassandra-util/src/Cassandra.hs
@@ -27,7 +27,7 @@ import Cassandra.CQL as C
     BatchType (BatchLogged, BatchUnLogged),
     Blob (Blob),
     ColumnType (AsciiColumn, BigIntColumn, BlobColumn, BooleanColumn, DoubleColumn, IntColumn, ListColumn, MaybeColumn, TextColumn, TimestampColumn, UdtColumn, UuidColumn),
-    Consistency (All, One, Quorum),
+    Consistency (All, One, LocalQuorum),
     Cql,
     Keyspace (Keyspace),
     PagingState (..),

--- a/libs/cassandra-util/src/Cassandra.hs
+++ b/libs/cassandra-util/src/Cassandra.hs
@@ -26,7 +26,7 @@ import Cassandra.CQL as C
   ( Ascii (Ascii),
     BatchType (BatchLogged, BatchUnLogged),
     Blob (Blob),
-    ColumnType (AsciiColumn, BigIntColumn, BlobColumn, BooleanColumn, DoubleColumn, IntColumn, ListColumn, MaybeColumn, TextColumn, TimestampColumn, UdtColumn, UuidColumn),
+    ColumnType (AsciiColumn, BigIntColumn, BlobColumn, BooleanColumn, DoubleColumn, IntColumn, ListColumn, MaybeColumn, TextColumn, TimestampColumn, UdtColumn, UuidColumn, VarCharColumn),
     Consistency (All, LocalQuorum, One), -- DO NOT EXPORT 'Quorum' here (until a DC migration is complete)
     Cql,
     Keyspace (Keyspace),

--- a/libs/cassandra-util/src/Cassandra.hs
+++ b/libs/cassandra-util/src/Cassandra.hs
@@ -38,6 +38,7 @@ import Cassandra.CQL as C
     Set (Set),
     Tagged (Tagged),
     TimeUuid (TimeUuid),
+    Tuple (),
     Value (CqlAscii, CqlBigInt, CqlBlob, CqlBoolean, CqlDouble, CqlInt, CqlList, CqlText, CqlUdt),
     Version (V4),
     W,

--- a/libs/cassandra-util/src/Cassandra.hs
+++ b/libs/cassandra-util/src/Cassandra.hs
@@ -27,7 +27,7 @@ import Cassandra.CQL as C
     BatchType (BatchLogged, BatchUnLogged),
     Blob (Blob),
     ColumnType (AsciiColumn, BigIntColumn, BlobColumn, BooleanColumn, DoubleColumn, IntColumn, ListColumn, MaybeColumn, TextColumn, TimestampColumn, UdtColumn, UuidColumn),
-    Consistency (All, One, LocalQuorum),
+    Consistency (All, LocalQuorum, One),
     Cql,
     Keyspace (Keyspace),
     PagingState (..),

--- a/libs/cassandra-util/src/Cassandra/CQL.hs
+++ b/libs/cassandra-util/src/Cassandra/CQL.hs
@@ -26,7 +26,7 @@ import Database.CQL.Protocol as C
     BatchType (BatchLogged, BatchUnLogged),
     Blob (Blob),
     ColumnType (AsciiColumn, BigIntColumn, BlobColumn, BooleanColumn, DoubleColumn, IntColumn, ListColumn, MaybeColumn, TextColumn, TimestampColumn, UdtColumn, UuidColumn),
-    Consistency (All, One, LocalQuorum),
+    Consistency (All, LocalQuorum, One),
     Cql,
     Keyspace (Keyspace),
     PagingState (..),

--- a/libs/cassandra-util/src/Cassandra/CQL.hs
+++ b/libs/cassandra-util/src/Cassandra/CQL.hs
@@ -37,6 +37,7 @@ import Database.CQL.Protocol as C
     Set (Set),
     Tagged (Tagged),
     TimeUuid (TimeUuid),
+    Tuple (),
     Value (CqlAscii, CqlBigInt, CqlBlob, CqlBoolean, CqlDouble, CqlInt, CqlList, CqlText, CqlTimestamp, CqlUdt),
     Version (V4),
     W,

--- a/libs/cassandra-util/src/Cassandra/CQL.hs
+++ b/libs/cassandra-util/src/Cassandra/CQL.hs
@@ -26,7 +26,7 @@ import Database.CQL.Protocol as C
     BatchType (BatchLogged, BatchUnLogged),
     Blob (Blob),
     ColumnType (AsciiColumn, BigIntColumn, BlobColumn, BooleanColumn, DoubleColumn, IntColumn, ListColumn, MaybeColumn, TextColumn, TimestampColumn, UdtColumn, UuidColumn),
-    Consistency (All, One, Quorum),
+    Consistency (All, One, LocalQuorum),
     Cql,
     Keyspace (Keyspace),
     PagingState (..),

--- a/libs/cassandra-util/src/Cassandra/CQL.hs
+++ b/libs/cassandra-util/src/Cassandra/CQL.hs
@@ -25,8 +25,8 @@ import Database.CQL.Protocol as C
   ( Ascii (Ascii),
     BatchType (BatchLogged, BatchUnLogged),
     Blob (Blob),
-    ColumnType (AsciiColumn, BigIntColumn, BlobColumn, BooleanColumn, DoubleColumn, IntColumn, ListColumn, MaybeColumn, TextColumn, TimestampColumn, UdtColumn, UuidColumn),
-    Consistency (All, LocalQuorum, One),
+    ColumnType (AsciiColumn, BigIntColumn, BlobColumn, BooleanColumn, DoubleColumn, IntColumn, ListColumn, MaybeColumn, TextColumn, TimestampColumn, UdtColumn, UuidColumn, VarCharColumn),
+    Consistency (All, LocalQuorum, One), -- DO NOT EXPORT 'Quorum' here (until a DC migration is complete)
     Cql,
     Keyspace (Keyspace),
     PagingState (..),

--- a/libs/extended/extended.cabal
+++ b/libs/extended/extended.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 866e03ca5b340b2470e8f7b376b18824786b15873330f6fd8483de086cfae28d
+-- hash: 18004f2559de4d4ac804d0a36a2d2780d0bbc10d79ebf78f337c9e6ba7a4ff3f
 
 name:           extended
 version:        0.1.0
@@ -36,7 +36,7 @@ library
       aeson
     , base
     , bytestring
-    , cql-io
+    , cassandra-util
     , errors
     , exceptions
     , extra

--- a/libs/extended/package.yaml
+++ b/libs/extended/package.yaml
@@ -21,8 +21,8 @@ dependencies:
 - imports
 - optparse-applicative
 - tinylog
-- cql-io
 - exceptions
+- cassandra-util
 
 # for servant's 'ReqBodyCustomError' type defined here.
 - errors

--- a/libs/extended/src/System/Logger/Extended.hs
+++ b/libs/extended/src/System/Logger/Extended.hs
@@ -31,13 +31,13 @@ module System.Logger.Extended
   )
 where
 
+import Cassandra (MonadClient)
 import Control.Monad.Catch
 import Data.Aeson
 import Data.Aeson.Encoding (list, pair, text)
 import qualified Data.ByteString.Lazy.Builder as B
 import qualified Data.ByteString.Lazy.Char8 as L
 import Data.String.Conversions (cs)
-import Database.CQL.IO
 import GHC.Generics
 import Imports
 import System.Logger as Log

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3f6cdbdd5b65f096b8f3e838b1009c4a1a0dd5e295304d123a4ad90ebcdf2057
+-- hash: 67fbb228d01b995595cb10594e0e80b0ca794cb9ecabcd5ed8f5a894c8881de7
 
 name:           brig
 version:        1.35.0
@@ -324,7 +324,6 @@ executable brig-integration
     , cassandra-util
     , containers
     , cookie
-    , cql-io
     , data-timeout
     , email-validate
     , exceptions

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -201,7 +201,6 @@ executables:
     - cassandra-util
     - containers
     - cookie
-    - cql-io
     - data-timeout
     - email-validate
     - exceptions

--- a/services/brig/src/Brig/Code.hs
+++ b/services/brig/src/Brig/Code.hs
@@ -239,7 +239,7 @@ insert c = do
   let e = codeForEmail c
   let p = codeForPhone c
   let t = round (codeTTL c)
-  retry x5 (write cql (params Quorum (k, s, v, r, e, p, a, t)))
+  retry x5 (write cql (params LocalQuorum (k, s, v, r, e, p, a, t)))
   where
     cql :: PrepQuery W (Key, Scope, Value, Retries, Maybe Email, Maybe Phone, Maybe UUID, Int32) ()
     cql =
@@ -248,7 +248,7 @@ insert c = do
 
 -- | Lookup a pending code.
 lookup :: MonadClient m => Key -> Scope -> m (Maybe Code)
-lookup k s = fmap (toCode k s) <$> retry x1 (query1 cql (params Quorum (k, s)))
+lookup k s = fmap (toCode k s) <$> retry x1 (query1 cql (params LocalQuorum (k, s)))
   where
     cql :: PrepQuery R (Key, Scope) (Value, Int32, Retries, Maybe Email, Maybe Phone, Maybe UUID)
     cql =
@@ -269,7 +269,7 @@ verify k s v = lookup k s >>= maybe (return Nothing) continue
 
 -- | Delete a code associated with the given key and scope.
 delete :: MonadClient m => Key -> Scope -> m ()
-delete k s = retry x5 $ write cql (params Quorum (k, s))
+delete k s = retry x5 $ write cql (params LocalQuorum (k, s))
   where
     cql :: PrepQuery W (Key, Scope) ()
     cql = "DELETE FROM vcodes WHERE key = ? AND scope = ?"

--- a/services/brig/src/Brig/Data/Properties.hs
+++ b/services/brig/src/Brig/Data/Properties.hs
@@ -42,31 +42,31 @@ data PropertiesDataError
 
 insertProperty :: UserId -> PropertyKey -> PropertyValue -> ExceptT PropertiesDataError AppIO ()
 insertProperty u k v = do
-  n <- lift . fmap (maybe 0 runIdentity) . retry x1 $ query1 propertyCount (params Quorum (Identity u))
+  n <- lift . fmap (maybe 0 runIdentity) . retry x1 $ query1 propertyCount (params LocalQuorum (Identity u))
   unless (n < maxProperties) $
     throwE TooManyProperties
-  lift . retry x5 $ write propertyInsert (params Quorum (u, k, v))
+  lift . retry x5 $ write propertyInsert (params LocalQuorum (u, k, v))
 
 deleteProperty :: UserId -> PropertyKey -> AppIO ()
-deleteProperty u k = retry x5 $ write propertyDelete (params Quorum (u, k))
+deleteProperty u k = retry x5 $ write propertyDelete (params LocalQuorum (u, k))
 
 clearProperties :: UserId -> AppIO ()
-clearProperties u = retry x5 $ write propertyReset (params Quorum (Identity u))
+clearProperties u = retry x5 $ write propertyReset (params LocalQuorum (Identity u))
 
 lookupProperty :: UserId -> PropertyKey -> AppIO (Maybe PropertyValue)
 lookupProperty u k =
   fmap runIdentity
-    <$> retry x1 (query1 propertySelect (params Quorum (u, k)))
+    <$> retry x1 (query1 propertySelect (params LocalQuorum (u, k)))
 
 lookupPropertyKeys :: UserId -> AppIO [PropertyKey]
 lookupPropertyKeys u =
   map runIdentity
-    <$> retry x1 (query propertyKeysSelect (params Quorum (Identity u)))
+    <$> retry x1 (query propertyKeysSelect (params LocalQuorum (Identity u)))
 
 lookupPropertyKeysAndValues :: UserId -> AppIO PropertyKeysAndValues
 lookupPropertyKeysAndValues u =
   PropertyKeysAndValues
-    <$> retry x1 (query propertyKeysValuesSelect (params Quorum (Identity u)))
+    <$> retry x1 (query propertyKeysValuesSelect (params LocalQuorum (Identity u)))
 
 -------------------------------------------------------------------------------
 -- Queries

--- a/services/brig/src/Brig/Data/UserKey.hs
+++ b/services/brig/src/Brig/Data/UserKey.hs
@@ -149,20 +149,20 @@ keyAvailable k u = do
 lookupKey :: UserKey -> AppIO (Maybe UserId)
 lookupKey k =
   fmap runIdentity
-    <$> retry x1 (query1 keySelect (params Quorum (Identity $ keyText k)))
+    <$> retry x1 (query1 keySelect (params LocalQuorum (Identity $ keyText k)))
 
 insertKey :: UserId -> UserKey -> AppIO ()
 insertKey u k = do
   hk <- hashKey k
   let kt = foldKey (\(_ :: Email) -> UKHashEmail) (\(_ :: Phone) -> UKHashPhone) k
-  retry x5 $ write insertHashed (params Quorum (hk, kt, u))
-  retry x5 $ write keyInsert (params Quorum (keyText k, u))
+  retry x5 $ write insertHashed (params LocalQuorum (hk, kt, u))
+  retry x5 $ write keyInsert (params LocalQuorum (keyText k, u))
 
 deleteKey :: UserKey -> AppIO ()
 deleteKey k = do
   hk <- hashKey k
-  retry x5 $ write deleteHashed (params Quorum (Identity hk))
-  retry x5 $ write keyDelete (params Quorum (Identity $ keyText k))
+  retry x5 $ write deleteHashed (params LocalQuorum (Identity hk))
+  retry x5 $ write keyDelete (params LocalQuorum (Identity $ keyText k))
 
 hashKey :: UserKey -> AppIO UserKeyHash
 hashKey uk = do

--- a/services/brig/src/Brig/Data/UserPendingActivation.hs
+++ b/services/brig/src/Brig/Data/UserPendingActivation.hs
@@ -40,14 +40,14 @@ data UserPendingActivation = UserPendingActivation
 
 usersPendingActivationAdd :: UserPendingActivation -> AppIO ()
 usersPendingActivationAdd (UserPendingActivation uid expiresAt) = do
-  retry x5 . write insertExpiration . params Quorum $ (uid, expiresAt)
+  retry x5 . write insertExpiration . params LocalQuorum $ (uid, expiresAt)
   where
     insertExpiration :: PrepQuery W (UserId, UTCTime) ()
     insertExpiration = "INSERT INTO users_pending_activation (user, expires_at) VALUES (?, ?)"
 
 usersPendingActivationList :: AppIO (Page UserPendingActivation)
 usersPendingActivationList = do
-  uncurry UserPendingActivation <$$> retry x1 (paginate selectExpired (params Quorum ()))
+  uncurry UserPendingActivation <$$> retry x1 (paginate selectExpired (params LocalQuorum ()))
   where
     selectExpired :: PrepQuery R () (UserId, UTCTime)
     selectExpired =
@@ -58,7 +58,7 @@ usersPendingActivationRemove uid = usersPendingActivationRemoveMultiple [uid]
 
 usersPendingActivationRemoveMultiple :: [UserId] -> AppIO ()
 usersPendingActivationRemoveMultiple uids =
-  retry x5 . write deleteExpired . params Quorum $ (Identity uids)
+  retry x5 . write deleteExpired . params LocalQuorum $ (Identity uids)
   where
     deleteExpired :: PrepQuery W (Identity [UserId]) ()
     deleteExpired =

--- a/services/brig/src/Brig/User/Handle.hs
+++ b/services/brig/src/Brig/User/Handle.hs
@@ -47,7 +47,7 @@ claimHandle uid oldHandle newHandle =
           runAppT env $
             do
               -- Record ownership
-              retry x5 $ write handleInsert (params Quorum (newHandle, uid))
+              retry x5 $ write handleInsert (params LocalQuorum (newHandle, uid))
               -- Update profile
               result <- User.updateHandle uid newHandle
               -- Free old handle (if it changed)
@@ -58,13 +58,13 @@ claimHandle uid oldHandle newHandle =
 -- | Free a 'Handle', making it available to be claimed again.
 freeHandle :: UserId -> Handle -> AppIO ()
 freeHandle uid h = do
-  retry x5 $ write handleDelete (params Quorum (Identity h))
+  retry x5 $ write handleDelete (params LocalQuorum (Identity h))
   let key = "@" <> fromHandle h
   deleteClaim uid key (30 # Minute)
 
 -- | Lookup the current owner of a 'Handle'.
 lookupHandle :: Handle -> AppIO (Maybe UserId)
-lookupHandle = lookupHandleWithPolicy Quorum
+lookupHandle = lookupHandleWithPolicy LocalQuorum
 
 -- | A weaker version of 'lookupHandle' that trades availability
 -- (and potentially speed) for the possibility of returning stale data.

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -581,7 +581,7 @@ lookupIndexUser u =
 
 lookupForIndex :: (MonadThrow m, C.MonadClient m) => UserId -> m (Maybe IndexUser)
 lookupForIndex u = do
-  result <- C.retry C.x1 (C.query1 cql (C.params C.Quorum (Identity u)))
+  result <- C.retry C.x1 (C.query1 cql (C.params C.LocalQuorum (Identity u)))
   sequence $ reindexRowToIndexUser <$> result
   where
     cql :: C.PrepQuery C.R (Identity UserId) ReindexRow

--- a/services/brig/test/integration/API/Internal.hs
+++ b/services/brig/test/integration/API/Internal.hs
@@ -8,6 +8,7 @@ import Bilge
 import Brig.Data.User (lookupFeatureConferenceCalling)
 import qualified Brig.Options as Opt
 import Brig.Types.User (userId)
+import qualified Cassandra as Cass
 import Control.Exception (ErrorCall (ErrorCall), throwIO)
 import Control.Lens ((^.), (^?!))
 import qualified Data.Aeson.Lens as Aeson
@@ -15,7 +16,6 @@ import qualified Data.Aeson.Types as Aeson
 import Data.ByteString.Conversion (toByteString')
 import Data.Id
 import qualified Data.Set as Set
-import qualified Database.CQL.IO as Cass
 import Imports
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/services/brig/test/integration/API/User/Connection.hs
+++ b/services/brig/test/integration/API/User/Connection.hs
@@ -656,7 +656,7 @@ testAllConnectionsPaging b db = do
         DB.retry DB.x5 $
           DB.write remoteConnectionInsert $
             DB.params
-              DB.Quorum
+              DB.LocalQuorum
               (self, remoteDomain, qUnqualified qOther, SentWithHistory, now, qDomain qConv, qUnqualified qConv)
 
 testConnectionLimit :: Brig -> ConnectionLimit -> Http ()

--- a/services/brig/test/integration/API/UserPendingActivation.hs
+++ b/services/brig/test/integration/API/UserPendingActivation.hs
@@ -132,7 +132,7 @@ waitUserExpiration opts' = do
 
 userExists :: MonadClient m => UserId -> m Bool
 userExists uid = do
-  x <- retry x1 (query1 usersSelect (params Quorum (Identity uid)))
+  x <- retry x1 (query1 usersSelect (params LocalQuorum (Identity uid)))
   pure $
     case x of
       Nothing -> False

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1b185cc3a9afe5d7a6c21c93d6c031963a5eb924885b6314ffc92ce96c6b545d
+-- hash: d75d1110238c01bd1523782580354026a66e5c5d003dfa5f0ba97fe03b979898
 
 name:           galley
 version:        0.83.0
@@ -269,7 +269,6 @@ executable galley-integration
     , cereal
     , containers
     , cookie
-    , cql-io
     , currency-codes
     , data-timeout
     , errors

--- a/services/galley/migrate-data/src/Galley/DataMigration.hs
+++ b/services/galley/migrate-data/src/Galley/DataMigration.hs
@@ -96,13 +96,13 @@ runMigration (Migration ver txt mig) = do
   persistVersion ver txt =<< liftIO getCurrentTime
 
 latestMigrationVersion :: MigrationActionT IO MigrationVersion
-latestMigrationVersion = MigrationVersion . maybe 0 fromIntegral <$> C.query1 cql (C.params C.Quorum ())
+latestMigrationVersion = MigrationVersion . maybe 0 fromIntegral <$> C.query1 cql (C.params C.LocalQuorum ())
   where
     cql :: C.QueryString C.R () (Identity Int32)
     cql = "select version from data_migration where id=1 order by version desc limit 1"
 
 persistVersion :: MigrationVersion -> Text -> UTCTime -> MigrationActionT IO ()
-persistVersion (MigrationVersion v) desc time = C.write cql (C.params C.Quorum (fromIntegral v, desc, time))
+persistVersion (MigrationVersion v) desc time = C.write cql (C.params C.LocalQuorum (fromIntegral v, desc, time))
   where
     cql :: C.QueryString C.W (Int32, Text, UTCTime) ()
     cql = "insert into data_migration (id, version, descr, date) values (1,?,?,?)"

--- a/services/galley/migrate-data/src/V1_BackfillBillingTeamMembers.hs
+++ b/services/galley/migrate-data/src/V1_BackfillBillingTeamMembers.hs
@@ -57,14 +57,14 @@ pageSize = 1000
 
 -- | Get team members from Galley
 getTeamMembers :: MonadClient m => ConduitM () [(TeamId, UserId, Maybe Permissions)] m ()
-getTeamMembers = paginateC cql (paramsP Quorum () pageSize) x5
+getTeamMembers = paginateC cql (paramsP LocalQuorum () pageSize) x5
   where
     cql :: PrepQuery R () (TeamId, UserId, Maybe Permissions)
     cql = "SELECT team, user, perms FROM team_member"
 
 createBillingTeamMembers :: MonadClient m => (TeamId, UserId) -> m ()
 createBillingTeamMembers pair =
-  retry x5 $ write cql (params Quorum pair)
+  retry x5 $ write cql (params LocalQuorum pair)
   where
     cql :: PrepQuery W (TeamId, UserId) ()
     cql = "INSERT INTO billing_team_member (team, user) values (?, ?)"

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -169,7 +169,6 @@ executables:
     - cereal
     - containers
     - cookie
-    - cql-io
     - currency-codes
     - metrics-wai
     - data-timeout

--- a/services/galley/src/Galley/Cassandra/Client.hs
+++ b/services/galley/src/Galley/Cassandra/Client.hs
@@ -38,7 +38,7 @@ import qualified UnliftIO
 updateClient :: Bool -> UserId -> ClientId -> Client ()
 updateClient add usr cls = do
   let q = if add then Cql.addMemberClient else Cql.rmMemberClient
-  retry x5 $ write (q cls) (params Quorum (Identity usr))
+  retry x5 $ write (q cls) (params LocalQuorum (Identity usr))
 
 -- Do, at most, 16 parallel lookups of up to 128 users each
 lookupClients :: [UserId] -> Client Clients
@@ -48,10 +48,10 @@ lookupClients users =
   where
     getClients us =
       map (second fromSet)
-        <$> retry x1 (query Cql.selectClients (params Quorum (Identity us)))
+        <$> retry x1 (query Cql.selectClients (params LocalQuorum (Identity us)))
 
 eraseClients :: UserId -> Client ()
-eraseClients user = retry x5 (write Cql.rmClients (params Quorum (Identity user)))
+eraseClients user = retry x5 (write Cql.rmClients (params LocalQuorum (Identity user)))
 
 interpretClientStoreToCassandra ::
   Members '[Embed IO, P.Reader ClientState] r =>

--- a/services/galley/src/Galley/Cassandra/Code.hs
+++ b/services/galley/src/Galley/Cassandra/Code.hs
@@ -47,12 +47,12 @@ insertCode c = do
   let cnv = codeConversation c
   let t = round (codeTTL c)
   let s = codeScope c
-  retry x5 (write Cql.insertCode (params Quorum (k, v, cnv, s, t)))
+  retry x5 (write Cql.insertCode (params LocalQuorum (k, v, cnv, s, t)))
 
 -- | Lookup a conversation by code.
 lookupCode :: Key -> Scope -> Client (Maybe Code)
-lookupCode k s = fmap (toCode k s) <$> retry x1 (query1 Cql.lookupCode (params Quorum (k, s)))
+lookupCode k s = fmap (toCode k s) <$> retry x1 (query1 Cql.lookupCode (params LocalQuorum (k, s)))
 
 -- | Delete a code associated with the given conversation key
 deleteCode :: Key -> Scope -> Client ()
-deleteCode k s = retry x5 $ write Cql.deleteCode (params Quorum (k, s))
+deleteCode k s = retry x5 $ write Cql.deleteCode (params LocalQuorum (k, s))

--- a/services/galley/src/Galley/Cassandra/ConversationList.hs
+++ b/services/galley/src/Galley/Cassandra/ConversationList.hs
@@ -44,8 +44,8 @@ conversationIdsFrom ::
   Client (ResultSet ConvId)
 conversationIdsFrom usr start (fromRange -> max) =
   mkResultSet . strip . fmap runIdentity <$> case start of
-    Just c -> paginate Cql.selectUserConvsFrom (paramsP Quorum (usr, c) (max + 1))
-    Nothing -> paginate Cql.selectUserConvs (paramsP Quorum (Identity usr) (max + 1))
+    Just c -> paginate Cql.selectUserConvsFrom (paramsP LocalQuorum (usr, c) (max + 1))
+    Nothing -> paginate Cql.selectUserConvs (paramsP LocalQuorum (Identity usr) (max + 1))
   where
     strip p = p {result = take (fromIntegral max) (result p)}
 
@@ -55,7 +55,7 @@ localConversationIdsPageFrom ::
   Range 1 1000 Int32 ->
   Client (PageWithState ConvId)
 localConversationIdsPageFrom usr pagingState (fromRange -> max) =
-  fmap runIdentity <$> paginateWithState Cql.selectUserConvs (paramsPagingState Quorum (Identity usr) max pagingState)
+  fmap runIdentity <$> paginateWithState Cql.selectUserConvs (paramsPagingState LocalQuorum (Identity usr) max pagingState)
 
 remoteConversationIdsPageFrom ::
   UserId ->
@@ -63,7 +63,7 @@ remoteConversationIdsPageFrom ::
   Int32 ->
   Client (PageWithState (Remote ConvId))
 remoteConversationIdsPageFrom usr pagingState max =
-  uncurry toRemoteUnsafe <$$> paginateWithState Cql.selectUserRemoteConvs (paramsPagingState Quorum (Identity usr) max pagingState)
+  uncurry toRemoteUnsafe <$$> paginateWithState Cql.selectUserRemoteConvs (paramsPagingState LocalQuorum (Identity usr) max pagingState)
 
 interpretConversationListToCassandra ::
   Members '[Embed IO, P.Reader ClientState] r =>

--- a/services/galley/src/Galley/Cassandra/LegalHold.hs
+++ b/services/galley/src/Galley/Cassandra/LegalHold.hs
@@ -27,4 +27,4 @@ isTeamLegalholdWhitelisted :: FeatureLegalHold -> TeamId -> Client Bool
 isTeamLegalholdWhitelisted FeatureLegalHoldDisabledPermanently _ = pure False
 isTeamLegalholdWhitelisted FeatureLegalHoldDisabledByDefault _ = pure False
 isTeamLegalholdWhitelisted FeatureLegalHoldWhitelistTeamsAndImplicitConsent tid =
-  isJust <$> (runIdentity <$$> retry x5 (query1 Q.selectLegalHoldWhitelistedTeam (params Quorum (Identity tid))))
+  isJust <$> (runIdentity <$$> retry x5 (query1 Q.selectLegalHoldWhitelistedTeam (params LocalQuorum (Identity tid))))

--- a/services/galley/src/Galley/Data/CustomBackend.hs
+++ b/services/galley/src/Galley/Data/CustomBackend.hs
@@ -34,15 +34,15 @@ import Imports
 getCustomBackend :: MonadClient m => Domain -> m (Maybe CustomBackend)
 getCustomBackend domain =
   fmap toCustomBackend <$> do
-    retry x1 $ query1 Cql.selectCustomBackend (params Quorum (Identity domain))
+    retry x1 $ query1 Cql.selectCustomBackend (params LocalQuorum (Identity domain))
   where
     toCustomBackend (backendConfigJsonUrl, backendWebappWelcomeUrl) =
       CustomBackend {..}
 
 setCustomBackend :: MonadClient m => Domain -> CustomBackend -> m ()
 setCustomBackend domain CustomBackend {..} = do
-  retry x5 $ write Cql.updateCustomBackend (params Quorum (backendConfigJsonUrl, backendWebappWelcomeUrl, domain))
+  retry x5 $ write Cql.updateCustomBackend (params LocalQuorum (backendConfigJsonUrl, backendWebappWelcomeUrl, domain))
 
 deleteCustomBackend :: MonadClient m => Domain -> m ()
 deleteCustomBackend domain = do
-  retry x5 $ write Cql.deleteCustomBackend (params Quorum (Identity domain))
+  retry x5 $ write Cql.deleteCustomBackend (params LocalQuorum (Identity domain))

--- a/services/galley/src/Galley/Data/LegalHold.hs
+++ b/services/galley/src/Galley/Data/LegalHold.hs
@@ -48,19 +48,19 @@ import Imports
 -- The Caller is responsible for checking whether legal hold is enabled for this team
 createSettings :: MonadClient m => LegalHoldService -> m ()
 createSettings (LegalHoldService tid url fpr tok key) = do
-  retry x1 $ write insertLegalHoldSettings (params Quorum (url, fpr, tok, key, tid))
+  retry x1 $ write insertLegalHoldSettings (params LocalQuorum (url, fpr, tok, key, tid))
 
 -- | Returns 'Nothing' if no settings are saved
 -- The Caller is responsible for checking whether legal hold is enabled for this team
 getSettings :: MonadClient m => TeamId -> m (Maybe LegalHoldService)
 getSettings tid =
   fmap toLegalHoldService <$> do
-    retry x1 $ query1 selectLegalHoldSettings (params Quorum (Identity tid))
+    retry x1 $ query1 selectLegalHoldSettings (params LocalQuorum (Identity tid))
   where
     toLegalHoldService (httpsUrl, fingerprint, tok, key) = LegalHoldService tid httpsUrl fingerprint tok key
 
 removeSettings :: MonadClient m => TeamId -> m ()
-removeSettings tid = retry x5 (write removeLegalHoldSettings (params Quorum (Identity tid)))
+removeSettings tid = retry x5 (write removeLegalHoldSettings (params LocalQuorum (Identity tid)))
 
 insertPendingPrekeys :: MonadClient m => UserId -> [Prekey] -> m ()
 insertPendingPrekeys uid keys = retry x5 . batch $
@@ -73,7 +73,7 @@ insertPendingPrekeys uid keys = retry x5 . batch $
 selectPendingPrekeys :: MonadClient m => UserId -> m (Maybe ([Prekey], LastPrekey))
 selectPendingPrekeys uid =
   pickLastKey . fmap fromTuple
-    <$> retry x1 (query Q.selectPendingPrekeys (params Quorum (Identity uid)))
+    <$> retry x1 (query Q.selectPendingPrekeys (params LocalQuorum (Identity uid)))
   where
     fromTuple (keyId, key) = Prekey keyId key
     pickLastKey allPrekeys =
@@ -82,19 +82,19 @@ selectPendingPrekeys uid =
         Just (keys, lst) -> pure (keys, lastPrekey . prekeyKey $ lst)
 
 dropPendingPrekeys :: MonadClient m => UserId -> m ()
-dropPendingPrekeys uid = retry x5 (write Q.dropPendingPrekeys (params Quorum (Identity uid)))
+dropPendingPrekeys uid = retry x5 (write Q.dropPendingPrekeys (params LocalQuorum (Identity uid)))
 
 setUserLegalHoldStatus :: MonadClient m => TeamId -> UserId -> UserLegalHoldStatus -> m ()
 setUserLegalHoldStatus tid uid status =
-  retry x5 (write Q.updateUserLegalHoldStatus (params Quorum (status, tid, uid)))
+  retry x5 (write Q.updateUserLegalHoldStatus (params LocalQuorum (status, tid, uid)))
 
 setTeamLegalholdWhitelisted :: MonadClient m => TeamId -> m ()
 setTeamLegalholdWhitelisted tid =
-  retry x5 (write Q.insertLegalHoldWhitelistedTeam (params Quorum (Identity tid)))
+  retry x5 (write Q.insertLegalHoldWhitelistedTeam (params LocalQuorum (Identity tid)))
 
 unsetTeamLegalholdWhitelisted :: MonadClient m => TeamId -> m ()
 unsetTeamLegalholdWhitelisted tid =
-  retry x5 (write Q.removeLegalHoldWhitelistedTeam (params Quorum (Identity tid)))
+  retry x5 (write Q.removeLegalHoldWhitelistedTeam (params LocalQuorum (Identity tid)))
 
 isTeamLegalholdWhitelisted :: (MonadReader Env m, MonadClient m) => TeamId -> m Bool
 isTeamLegalholdWhitelisted tid = do

--- a/services/galley/src/Galley/Data/SearchVisibility.hs
+++ b/services/galley/src/Galley/Data/SearchVisibility.hs
@@ -35,7 +35,7 @@ import Imports
 getSearchVisibility :: MonadClient m => TeamId -> m TeamSearchVisibility
 getSearchVisibility tid =
   toSearchVisibility <$> do
-    retry x1 $ query1 selectSearchVisibility (params Quorum (Identity tid))
+    retry x1 $ query1 selectSearchVisibility (params LocalQuorum (Identity tid))
   where
     -- The value is either set or we return the default
     toSearchVisibility :: (Maybe (Identity (Maybe TeamSearchVisibility))) -> TeamSearchVisibility
@@ -45,8 +45,8 @@ getSearchVisibility tid =
 -- | Determines whether a given team is allowed to enable/disable sso
 setSearchVisibility :: MonadClient m => TeamId -> TeamSearchVisibility -> m ()
 setSearchVisibility tid visibilityType = do
-  retry x5 $ write updateSearchVisibility (params Quorum (visibilityType, tid))
+  retry x5 $ write updateSearchVisibility (params LocalQuorum (visibilityType, tid))
 
 resetSearchVisibility :: MonadClient m => TeamId -> m ()
 resetSearchVisibility tid = do
-  retry x5 $ write updateSearchVisibility (params Quorum (SearchVisibilityStandard, tid))
+  retry x5 $ write updateSearchVisibility (params LocalQuorum (SearchVisibilityStandard, tid))

--- a/services/galley/src/Galley/Data/TeamFeatures.hs
+++ b/services/galley/src/Galley/Data/TeamFeatures.hs
@@ -79,7 +79,7 @@ getFeatureStatusNoConfig ::
   TeamId ->
   m (Maybe (TeamFeatureStatus a))
 getFeatureStatusNoConfig tid = do
-  let q = query1 select (params Quorum (Identity tid))
+  let q = query1 select (params LocalQuorum (Identity tid))
   mStatusValue <- (>>= runIdentity) <$> retry x1 q
   pure $ TeamFeatureStatusNoConfig <$> mStatusValue
   where
@@ -97,7 +97,7 @@ setFeatureStatusNoConfig ::
   m (TeamFeatureStatus a)
 setFeatureStatusNoConfig tid status = do
   let flag = Public.tfwoStatus status
-  retry x5 $ write insert (params Quorum (tid, flag))
+  retry x5 $ write insert (params LocalQuorum (tid, flag))
   pure status
   where
     insert :: PrepQuery W (TeamId, TeamFeatureStatusValue) ()
@@ -109,7 +109,7 @@ getApplockFeatureStatus ::
   TeamId ->
   m (Maybe (TeamFeatureStatus 'Public.TeamFeatureAppLock))
 getApplockFeatureStatus tid = do
-  let q = query1 select (params Quorum (Identity tid))
+  let q = query1 select (params LocalQuorum (Identity tid))
   mTuple <- retry x1 q
   pure $
     mTuple >>= \(mbStatusValue, mbEnforce, mbTimeout) ->
@@ -130,7 +130,7 @@ setApplockFeatureStatus tid status = do
   let statusValue = Public.tfwcStatus status
       enforce = Public.applockEnforceAppLock . Public.tfwcConfig $ status
       timeout = Public.applockInactivityTimeoutSecs . Public.tfwcConfig $ status
-  retry x5 $ write insert (params Quorum (tid, statusValue, enforce, timeout))
+  retry x5 $ write insert (params LocalQuorum (tid, statusValue, enforce, timeout))
   pure status
   where
     insert :: PrepQuery W (TeamId, TeamFeatureStatusValue, Public.EnforceAppLock, Int32) ()
@@ -146,7 +146,7 @@ getSelfDeletingMessagesStatus ::
   TeamId ->
   m (Maybe (TeamFeatureStatus 'Public.TeamFeatureSelfDeletingMessages))
 getSelfDeletingMessagesStatus tid = do
-  let q = query1 select (params Quorum (Identity tid))
+  let q = query1 select (params LocalQuorum (Identity tid))
   mTuple <- retry x1 q
   pure $
     mTuple >>= \(mbStatusValue, mbTimeout) ->
@@ -168,7 +168,7 @@ setSelfDeletingMessagesStatus ::
 setSelfDeletingMessagesStatus tid status = do
   let statusValue = Public.tfwcStatus status
       timeout = Public.sdmEnforcedTimeoutSeconds . Public.tfwcConfig $ status
-  retry x5 $ write insert (params Quorum (tid, statusValue, timeout))
+  retry x5 $ write insert (params LocalQuorum (tid, statusValue, timeout))
   pure status
   where
     insert :: PrepQuery W (TeamId, TeamFeatureStatusValue, Int32) ()

--- a/services/galley/src/Galley/Data/TeamNotifications.hs
+++ b/services/galley/src/Galley/Data/TeamNotifications.hs
@@ -57,7 +57,7 @@ add ::
   List1 JSON.Object ->
   Galley r ()
 add tid nid (Blob . JSON.encode -> payload) =
-  write cqlInsert (params Quorum (tid, nid, payload, notificationTTLSeconds)) & retry x5
+  write cqlInsert (params LocalQuorum (tid, nid, payload, notificationTTLSeconds)) & retry x5
   where
     cqlInsert :: PrepQuery W (TeamId, NotificationId, Blob, Int32) ()
     cqlInsert =
@@ -75,8 +75,8 @@ fetch tid since (fromRange -> size) = do
   -- report whether there are more results.
   let size' = bool (+ 1) (+ 2) (isJust since) size
   page1 <- case TimeUuid . toUUID <$> since of
-    Nothing -> paginate cqlStart (paramsP Quorum (Identity tid) size') & retry x1
-    Just s -> paginate cqlSince (paramsP Quorum (tid, s) size') & retry x1
+    Nothing -> paginate cqlStart (paramsP LocalQuorum (Identity tid) size') & retry x1
+    Just s -> paginate cqlSince (paramsP LocalQuorum (tid, s) size') & retry x1
   -- Collect results, requesting more pages until we run out of data
   -- or have found size + 1 notifications (not including the 'since').
   let isize = fromIntegral size' :: Int

--- a/services/gundeck/src/Gundeck/Client.hs
+++ b/services/gundeck/src/Gundeck/Client.hs
@@ -31,14 +31,14 @@ import Imports
 
 unregister :: UserId -> ClientId -> Gundeck ()
 unregister uid cid = do
-  toks <- filter byClient <$> Push.lookup uid Push.Quorum
+  toks <- filter byClient <$> Push.lookup uid Push.LocalQuorum
   deleteTokens toks Nothing
   where
     byClient = (cid ==) . view addrClient
 
 removeUser :: UserId -> Gundeck ()
 removeUser user = do
-  toks <- Push.lookup user Push.Quorum
+  toks <- Push.lookup user Push.LocalQuorum
   deleteTokens toks Nothing
   Push.erase user
   Notifications.deleteAll user

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -380,7 +380,7 @@ data AddTokenResponse
 
 addToken :: UserId -> ConnId -> PushToken -> Gundeck AddTokenResponse
 addToken uid cid newtok = mpaRunWithBudget 1 AddTokenNoBudget $ do
-  (cur, old) <- foldl' (matching newtok) (Nothing, []) <$> Data.lookup uid Data.Quorum
+  (cur, old) <- foldl' (matching newtok) (Nothing, []) <$> Data.lookup uid Data.LocalQuorum
   Log.info $
     "user" .= UUID.toASCIIBytes (toUUID uid)
       ~~ "token" .= Text.take 16 (tokenText (newtok ^. token))
@@ -512,10 +512,10 @@ updateEndpoint uid t arn e = do
 
 deleteToken :: UserId -> Token -> Gundeck ()
 deleteToken uid tok = do
-  as <- filter (\x -> x ^. addrToken == tok) <$> Data.lookup uid Data.Quorum
+  as <- filter (\x -> x ^. addrToken == tok) <$> Data.lookup uid Data.LocalQuorum
   when (null as) $
     throwM (mkError status404 "not-found" "Push token not found")
   Native.deleteTokens as Nothing
 
 listTokens :: UserId -> Gundeck PushTokenList
-listTokens uid = PushTokenList . map (^. addrPushToken) <$> Data.lookup uid Data.Quorum
+listTokens uid = PushTokenList . map (^. addrPushToken) <$> Data.lookup uid Data.LocalQuorum

--- a/services/gundeck/src/Gundeck/Push/Data.hs
+++ b/services/gundeck/src/Gundeck/Push/Data.hs
@@ -42,19 +42,19 @@ lookup u c = foldM mk [] =<< retry x1 (query q (params c (Identity u)))
     mk as r = maybe as (: as) <$> mkAddr r
 
 insert :: MonadClient m => UserId -> Transport -> AppName -> Token -> EndpointArn -> ConnId -> ClientId -> m ()
-insert u t a p e o c = retry x5 $ write q (params Quorum (u, t, a, p, e, o, c))
+insert u t a p e o c = retry x5 $ write q (params LocalQuorum (u, t, a, p, e, o, c))
   where
     q :: PrepQuery W (UserId, Transport, AppName, Token, EndpointArn, ConnId, ClientId) ()
     q = "insert into user_push (usr, transport, app, ptoken, arn, connection, client) values (?, ?, ?, ?, ?, ?, ?)"
 
 delete :: MonadClient m => UserId -> Transport -> AppName -> Token -> m ()
-delete u t a p = retry x5 $ write q (params Quorum (u, t, a, p))
+delete u t a p = retry x5 $ write q (params LocalQuorum (u, t, a, p))
   where
     q :: PrepQuery W (UserId, Transport, AppName, Token) ()
     q = "delete from user_push where usr = ? and transport = ? and app = ? and ptoken = ?"
 
 erase :: MonadClient m => UserId -> m ()
-erase u = retry x5 $ write q (params Quorum (Identity u))
+erase u = retry x5 $ write q (params LocalQuorum (Identity u))
   where
     q :: PrepQuery W (Identity UserId) ()
     q = "delete from user_push where usr = ?"

--- a/services/gundeck/src/Gundeck/Push/Native.hs
+++ b/services/gundeck/src/Gundeck/Push/Native.hs
@@ -187,7 +187,7 @@ deleteTokens tokens new = do
       let oldTok = a ^. addrToken
       let newArn = a' ^. addrEndpoint
       let newTok = a' ^. addrToken
-      xs <- Data.lookup u Data.Quorum
+      xs <- Data.lookup u Data.LocalQuorum
       forM_ xs $ \x ->
         when (x ^. addrEndpoint == oldArn) $ do
           Data.insert

--- a/services/gundeck/src/Gundeck/React.hs
+++ b/services/gundeck/src/Gundeck/React.hs
@@ -129,7 +129,7 @@ withEndpoint ev f = do
   e <- Aws.execute v (Aws.lookupEndpoint (ev ^. evEndpoint))
   for_ e $ \ep -> do
     let us = Set.toList (ep ^. endpointUsers)
-    as <- concat <$> mapM (`Push.lookup` Push.Quorum) us
+    as <- concat <$> mapM (`Push.lookup` Push.LocalQuorum) us
     case filter ((== (ev ^. evEndpoint)) . view addrEndpoint) as of
       [] -> do
         logEvent ev $

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -141,7 +141,7 @@ removeUser = do
   deleteUser g user
   ntfs <- listNotifications user Nothing
   liftIO $ do
-    tokens <- Cql.runClient s (Log.runWithLogger logger $ Push.lookup user Push.Quorum)
+    tokens <- Cql.runClient s (Log.runWithLogger logger $ Push.lookup user Push.LocalQuorum)
     null tokens @?= True
     ntfs @?= []
 

--- a/services/spar/migrate-data/src/Spar/DataMigration/Run.hs
+++ b/services/spar/migrate-data/src/Spar/DataMigration/Run.hs
@@ -100,7 +100,7 @@ latestMigrationVersion Env {..} =
   MigrationVersion . maybe 0 fromIntegral
     <$> C.runClient
       sparCassandra
-      (C.query1 cql (C.params C.Quorum ()))
+      (C.query1 cql (C.params C.LocalQuorum ()))
   where
     cql :: C.QueryString C.R () (Identity Int32)
     cql = "select version from data_migration where id=1 order by version desc limit 1"
@@ -108,7 +108,7 @@ latestMigrationVersion Env {..} =
 persistVersion :: Env -> MigrationVersion -> Text -> UTCTime -> IO ()
 persistVersion Env {..} (MigrationVersion v) desc time =
   C.runClient sparCassandra $
-    C.write cql (C.params C.Quorum (fromIntegral v, desc, time))
+    C.write cql (C.params C.LocalQuorum (fromIntegral v, desc, time))
   where
     cql :: C.QueryString C.W (Int32, Text, UTCTime) ()
     cql = "insert into data_migration (id, version, descr, date) values (1,?,?,?)"

--- a/services/spar/migrate-data/src/Spar/DataMigration/V1_ExternalIds.hs
+++ b/services/spar/migrate-data/src/Spar/DataMigration/V1_ExternalIds.hs
@@ -142,7 +142,7 @@ readLegacyExternalIds :: (HasSpar env, HasMigEnv env) => ConduitM () [LegacyExte
 readLegacyExternalIds = do
   pSize <- lift $ pageSize <$> askMigEnv
   transPipe runSpar $
-    paginateC select (paramsP Quorum () pSize) x5
+    paginateC select (paramsP LocalQuorum () pSize) x5
   where
     select :: PrepQuery R () LegacyExternalId
     select = "SELECT external, user FROM scim_external_ids"
@@ -160,7 +160,7 @@ resolveTeam (page, exts) = do
     readUserTeam :: HasBrig env => [UserId] -> RIO env [UserTeam]
     readUserTeam uids =
       runBrig $ do
-        query select (params Quorum (Identity uids))
+        query select (params LocalQuorum (Identity uids))
       where
         select :: PrepQuery R (Identity [UserId]) UserTeam
         select = "SELECT id, team FROM user where id in ?"
@@ -190,7 +190,7 @@ sink = go
                 DryRun -> pure ()
                 NoDryRun ->
                   runSpar $
-                    write insert (params Quorum (tid, extid, uid))
+                    write insert (params LocalQuorum (tid, extid, uid))
         go
     insert :: PrepQuery W (TeamId, Text, UserId) ()
     insert = "INSERT INTO scim_external (team, external_id, user) VALUES (?, ?, ?)"

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -1515,7 +1515,7 @@ specSparUserMigration = do
         let insert :: PrepQuery W (SAML.Issuer, SAML.NameID, UserId) ()
             insert = "INSERT INTO user (issuer, sso_id, uid) VALUES (?, ?, ?)"
         runClient client $
-          retry x5 $ write insert (params Quorum (issuer, subject, memberUid))
+          retry x5 $ write insert (params LocalQuorum (issuer, subject, memberUid))
 
       mbUserId <- do
         authnreq <- negotiateAuthnRequest idp

--- a/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
@@ -277,7 +277,7 @@ testPlaintextTokensAreConverted = do
       wrapMonadClient $ do
         retry x5 . batch $ do
           setType BatchLogged
-          setConsistency Quorum
+          setConsistency LocalQuorum
           addPrepQuery insByToken (ScimTokenLookupKeyPlaintext token, teamId, tokenId, now, Nothing, descr)
           addPrepQuery insByTeam (ScimTokenLookupKeyPlaintext token, teamId, tokenId, now, Nothing, descr)
       pure token
@@ -299,7 +299,7 @@ testPlaintextTokensAreConverted = do
     countTokensInDB :: ScimTokenLookupKey -> TestSpar Int64
     countTokensInDB key =
       wrapMonadClient $ do
-        count <- runIdentity <$$> (retry x1 . query1 selByKey $ params Quorum (Identity key))
+        count <- runIdentity <$$> (retry x1 . query1 selByKey $ params LocalQuorum (Identity key))
         pure $ fromMaybe 0 count
 
     selByKey :: PrepQuery R (Identity ScimTokenLookupKey) (Identity Int64)

--- a/tools/db/auto-whitelist/src/Work.hs
+++ b/tools/db/auto-whitelist/src/Work.hs
@@ -49,7 +49,7 @@ runCommand l brig = runClient brig $ do
 
 -- | Get all services in team conversations
 getServices :: Client [(ProviderId, ServiceId, TeamId)]
-getServices = retry x5 $ query cql (params Quorum ())
+getServices = retry x5 $ query cql (params LocalQuorum ())
   where
     cql :: PrepQuery R () (ProviderId, ServiceId, TeamId)
     cql = "SELECT provider, service, team FROM service_team"
@@ -57,7 +57,7 @@ getServices = retry x5 $ query cql (params Quorum ())
 -- | Check if a service exists
 doesServiceExist :: (ProviderId, ServiceId, a) -> Client Bool
 doesServiceExist (pid, sid, _) =
-  retry x5 $ fmap isJust $ query1 cql (params Quorum (pid, sid))
+  retry x5 $ fmap isJust $ query1 cql (params LocalQuorum (pid, sid))
   where
     cql :: PrepQuery R (ProviderId, ServiceId) (Identity ServiceId)
     cql =
@@ -73,7 +73,7 @@ whitelistService l (pid, sid, tid) = do
       . Log.field "service" (show sid)
       . Log.field "team" (show tid)
   retry x5 . batch $ do
-    setConsistency Quorum
+    setConsistency LocalQuorum
     setType BatchLogged
     addPrepQuery insert1 (tid, pid, sid)
     addPrepQuery insert1Rev (tid, pid, sid)

--- a/tools/db/billing-team-member-backfill/src/Work.hs
+++ b/tools/db/billing-team-member-backfill/src/Work.hs
@@ -61,7 +61,7 @@ pageSize = 1000
 
 -- | Get team members from Galley
 getTeamMembers :: ConduitM () [(TeamId, UserId, Maybe Permissions)] Client ()
-getTeamMembers = paginateC cql (paramsP Quorum () pageSize) x5
+getTeamMembers = paginateC cql (paramsP LocalQuorum () pageSize) x5
   where
     cql :: PrepQuery R () (TeamId, UserId, Maybe Permissions)
     cql = "SELECT team, user, perms FROM team_member"
@@ -70,7 +70,7 @@ createBillingTeamMembers :: [(TeamId, UserId)] -> Client ()
 createBillingTeamMembers pairs =
   retry x5 . batch $ do
     setType BatchLogged
-    setConsistency Quorum
+    setConsistency LocalQuorum
     mapM_ (addPrepQuery cql) pairs
   where
     cql :: PrepQuery W (TeamId, UserId) ()

--- a/tools/db/find-undead/src/Work.hs
+++ b/tools/db/find-undead/src/Work.hs
@@ -105,7 +105,7 @@ extractScrollId :: MonadThrow m => ES.SearchResult a -> m ES.ScrollId
 extractScrollId res = maybe (throwM NoScrollId) pure (ES.scrollId res)
 
 usersInCassandra :: [UUID] -> Client [(UUID, Maybe AccountStatus, Maybe (Writetime ()))]
-usersInCassandra users = retry x1 $ query cql (params Quorum (Identity users))
+usersInCassandra users = retry x1 $ query cql (params LocalQuorum (Identity users))
   where
     cql :: PrepQuery R (Identity [UUID]) (UUID, Maybe AccountStatus, Maybe (Writetime ()))
     cql = "SELECT id, status, writetime(status) from user where id in ?"

--- a/tools/db/migrate-sso-feature-flag/src/Work.hs
+++ b/tools/db/migrate-sso-feature-flag/src/Work.hs
@@ -57,7 +57,7 @@ pageSize :: Int32
 pageSize = 1000
 
 getSsoTeams :: ConduitM () [Identity TeamId] Client ()
-getSsoTeams = paginateC cql (paramsP Quorum () pageSize) x5
+getSsoTeams = paginateC cql (paramsP LocalQuorum () pageSize) x5
   where
     cql :: PrepQuery R () (Identity TeamId)
     cql = "select team from idp"
@@ -67,6 +67,6 @@ writeSsoFlags = mapM_ (`setSSOTeamConfig` TeamFeatureEnabled)
   where
     setSSOTeamConfig :: MonadClient m => TeamId -> TeamFeatureStatusValue -> m ()
     setSSOTeamConfig tid ssoTeamConfigStatus = do
-      retry x5 $ write updateSSOTeamConfig (params Quorum (ssoTeamConfigStatus, tid))
+      retry x5 $ write updateSSOTeamConfig (params LocalQuorum (ssoTeamConfigStatus, tid))
     updateSSOTeamConfig :: PrepQuery W (TeamFeatureStatusValue, TeamId) ()
     updateSSOTeamConfig = "update team_features set sso_status = ? where team_id = ?"

--- a/tools/db/move-team/move-team.cabal
+++ b/tools/db/move-team/move-team.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6c50a8e33625c79cb1b04adac7f5a9b9c337181da35f450c10ea970548a9acd4
+-- hash: 6f97fa57af68acb9606816e6048ebe009ec9c0f01a971d39ae9dbc5e2061346d
 
 name:           move-team
 version:        1.0.0
@@ -38,7 +38,6 @@ library
     , cassandra-util
     , conduit
     , containers
-    , cql
     , filepath
     , galley
     , imports
@@ -74,7 +73,6 @@ executable move-team
     , cassandra-util
     , conduit
     , containers
-    , cql
     , filepath
     , galley
     , imports
@@ -111,7 +109,6 @@ executable move-team-generate
     , cassandra-util
     , conduit
     , containers
-    , cql
     , filepath
     , galley
     , imports

--- a/tools/db/move-team/package.yaml
+++ b/tools/db/move-team/package.yaml
@@ -24,7 +24,7 @@ dependencies:
 - cassandra-util
 - conduit
 - containers
-- cql
+- cassandra-util
 - filepath
 - galley
 - imports

--- a/tools/db/move-team/src/Common.hs
+++ b/tools/db/move-team/src/Common.hs
@@ -44,5 +44,5 @@ sinkTableRows insertQuery = go
       case mbTuple of
         Nothing -> pure ()
         Just tuple -> do
-          lift $ write insertQuery (params Quorum tuple)
+          lift $ write insertQuery (params LocalQuorum tuple)
           go

--- a/tools/db/move-team/src/Common.hs
+++ b/tools/db/move-team/src/Common.hs
@@ -22,7 +22,6 @@ import Conduit
 import Data.Aeson
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Conduit.Combinators as C
-import Database.CQL.Protocol (Tuple)
 import Imports
 import System.IO
 

--- a/tools/db/move-team/src/ParseSchema.hs
+++ b/tools/db/move-team/src/ParseSchema.hs
@@ -229,7 +229,7 @@ select{{keySpaceCaml}}{{tableNameCaml}} = "SELECT {{columns}} FROM {{tableName}}
 read{{keySpaceCaml}}{{tableNameCaml}}:: Env -> {{lookupKeyType}} -> ConduitM () [Row{{keySpaceCaml}}{{tableNameCaml}}] IO ()
 read{{keySpaceCaml}}{{tableNameCaml}} Env {..} {{lookupKeyVar}} =
   transPipe (runClient env{{keySpaceCaml}}) $
-    paginateC select{{keySpaceCaml}}{{tableNameCaml}} (paramsP Quorum (pure {{lookupKeyVar}}) envPageSize) x5
+    paginateC select{{keySpaceCaml}}{{tableNameCaml}} (paramsP LocalQuorum (pure {{lookupKeyVar}}) envPageSize) x5
 
 select{{keySpaceCaml}}{{tableNameCaml}}All :: PrepQuery R () Row{{keySpaceCaml}}{{tableNameCaml}}
 select{{keySpaceCaml}}{{tableNameCaml}}All = "SELECT {{columns}} FROM {{tableName}}"
@@ -237,7 +237,7 @@ select{{keySpaceCaml}}{{tableNameCaml}}All = "SELECT {{columns}} FROM {{tableNam
 read{{keySpaceCaml}}{{tableNameCaml}}All :: Env -> ConduitM () [Row{{keySpaceCaml}}{{tableNameCaml}}] IO ()
 read{{keySpaceCaml}}{{tableNameCaml}}All Env {..} =
   transPipe (runClient env{{keySpaceCaml}}) $
-    paginateC select{{keySpaceCaml}}{{tableNameCaml}}All (paramsP Quorum () envPageSize) x5
+    paginateC select{{keySpaceCaml}}{{tableNameCaml}}All (paramsP LocalQuorum () envPageSize) x5
 
 export{{keySpaceCaml}}{{tableNameCaml}}Full :: Env -> FilePath -> IO ()
 export{{keySpaceCaml}}{{tableNameCaml}}Full env@Env {..} path = do

--- a/tools/db/move-team/src/Schema.hs
+++ b/tools/db/move-team/src/Schema.hs
@@ -46,7 +46,7 @@ selectBrigClients = "SELECT user, client, class, cookie, ip, label, lat, lon, mo
 readBrigClients :: Env -> [UserId] -> ConduitM () [RowBrigClients] IO ()
 readBrigClients Env {..} uids =
   transPipe (runClient envBrig) $
-    paginateC selectBrigClients (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectBrigClients (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectBrigClientsAll :: PrepQuery R () RowBrigClients
 selectBrigClientsAll = "SELECT user, client, class, cookie, ip, label, lat, lon, model, tstamp, type FROM clients"
@@ -54,7 +54,7 @@ selectBrigClientsAll = "SELECT user, client, class, cookie, ip, label, lat, lon,
 readBrigClientsAll :: Env -> ConduitM () [RowBrigClients] IO ()
 readBrigClientsAll Env {..} =
   transPipe (runClient envBrig) $
-    paginateC selectBrigClientsAll (paramsP Quorum () envPageSize) x5
+    paginateC selectBrigClientsAll (paramsP LocalQuorum () envPageSize) x5
 
 exportBrigClientsFull :: Env -> FilePath -> IO ()
 exportBrigClientsFull env@Env {..} path = do
@@ -92,7 +92,7 @@ selectBrigConnection = "SELECT left, right, conv, last_update, message, status F
 readBrigConnection :: Env -> [UserId] -> ConduitM () [RowBrigConnection] IO ()
 readBrigConnection Env {..} uids =
   transPipe (runClient envBrig) $
-    paginateC selectBrigConnection (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectBrigConnection (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectBrigConnectionAll :: PrepQuery R () RowBrigConnection
 selectBrigConnectionAll = "SELECT left, right, conv, last_update, message, status FROM connection"
@@ -100,7 +100,7 @@ selectBrigConnectionAll = "SELECT left, right, conv, last_update, message, statu
 readBrigConnectionAll :: Env -> ConduitM () [RowBrigConnection] IO ()
 readBrigConnectionAll Env {..} =
   transPipe (runClient envBrig) $
-    paginateC selectBrigConnectionAll (paramsP Quorum () envPageSize) x5
+    paginateC selectBrigConnectionAll (paramsP LocalQuorum () envPageSize) x5
 
 exportBrigConnectionFull :: Env -> FilePath -> IO ()
 exportBrigConnectionFull env@Env {..} path = do
@@ -138,7 +138,7 @@ selectBrigLoginCodes = "SELECT user, code, retries, timeout FROM login_codes WHE
 readBrigLoginCodes :: Env -> [UserId] -> ConduitM () [RowBrigLoginCodes] IO ()
 readBrigLoginCodes Env {..} uids =
   transPipe (runClient envBrig) $
-    paginateC selectBrigLoginCodes (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectBrigLoginCodes (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectBrigLoginCodesAll :: PrepQuery R () RowBrigLoginCodes
 selectBrigLoginCodesAll = "SELECT user, code, retries, timeout FROM login_codes"
@@ -146,7 +146,7 @@ selectBrigLoginCodesAll = "SELECT user, code, retries, timeout FROM login_codes"
 readBrigLoginCodesAll :: Env -> ConduitM () [RowBrigLoginCodes] IO ()
 readBrigLoginCodesAll Env {..} =
   transPipe (runClient envBrig) $
-    paginateC selectBrigLoginCodesAll (paramsP Quorum () envPageSize) x5
+    paginateC selectBrigLoginCodesAll (paramsP LocalQuorum () envPageSize) x5
 
 exportBrigLoginCodesFull :: Env -> FilePath -> IO ()
 exportBrigLoginCodesFull env@Env {..} path = do
@@ -184,7 +184,7 @@ selectBrigPasswordReset = "SELECT key, code, retries, timeout, user FROM passwor
 readBrigPasswordReset :: Env -> [PasswordResetKey] -> ConduitM () [RowBrigPasswordReset] IO ()
 readBrigPasswordReset Env {..} reset_keys =
   transPipe (runClient envBrig) $
-    paginateC selectBrigPasswordReset (paramsP Quorum (pure reset_keys) envPageSize) x5
+    paginateC selectBrigPasswordReset (paramsP LocalQuorum (pure reset_keys) envPageSize) x5
 
 selectBrigPasswordResetAll :: PrepQuery R () RowBrigPasswordReset
 selectBrigPasswordResetAll = "SELECT key, code, retries, timeout, user FROM password_reset"
@@ -192,7 +192,7 @@ selectBrigPasswordResetAll = "SELECT key, code, retries, timeout, user FROM pass
 readBrigPasswordResetAll :: Env -> ConduitM () [RowBrigPasswordReset] IO ()
 readBrigPasswordResetAll Env {..} =
   transPipe (runClient envBrig) $
-    paginateC selectBrigPasswordResetAll (paramsP Quorum () envPageSize) x5
+    paginateC selectBrigPasswordResetAll (paramsP LocalQuorum () envPageSize) x5
 
 exportBrigPasswordResetFull :: Env -> FilePath -> IO ()
 exportBrigPasswordResetFull env@Env {..} path = do
@@ -230,7 +230,7 @@ selectBrigPrekeys = "SELECT user, client, key, data FROM prekeys WHERE user in ?
 readBrigPrekeys :: Env -> [UserId] -> ConduitM () [RowBrigPrekeys] IO ()
 readBrigPrekeys Env {..} uids =
   transPipe (runClient envBrig) $
-    paginateC selectBrigPrekeys (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectBrigPrekeys (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectBrigPrekeysAll :: PrepQuery R () RowBrigPrekeys
 selectBrigPrekeysAll = "SELECT user, client, key, data FROM prekeys"
@@ -238,7 +238,7 @@ selectBrigPrekeysAll = "SELECT user, client, key, data FROM prekeys"
 readBrigPrekeysAll :: Env -> ConduitM () [RowBrigPrekeys] IO ()
 readBrigPrekeysAll Env {..} =
   transPipe (runClient envBrig) $
-    paginateC selectBrigPrekeysAll (paramsP Quorum () envPageSize) x5
+    paginateC selectBrigPrekeysAll (paramsP LocalQuorum () envPageSize) x5
 
 exportBrigPrekeysFull :: Env -> FilePath -> IO ()
 exportBrigPrekeysFull env@Env {..} path = do
@@ -276,7 +276,7 @@ selectBrigProperties = "SELECT user, key, value FROM properties WHERE user in ?"
 readBrigProperties :: Env -> [UserId] -> ConduitM () [RowBrigProperties] IO ()
 readBrigProperties Env {..} uids =
   transPipe (runClient envBrig) $
-    paginateC selectBrigProperties (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectBrigProperties (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectBrigPropertiesAll :: PrepQuery R () RowBrigProperties
 selectBrigPropertiesAll = "SELECT user, key, value FROM properties"
@@ -284,7 +284,7 @@ selectBrigPropertiesAll = "SELECT user, key, value FROM properties"
 readBrigPropertiesAll :: Env -> ConduitM () [RowBrigProperties] IO ()
 readBrigPropertiesAll Env {..} =
   transPipe (runClient envBrig) $
-    paginateC selectBrigPropertiesAll (paramsP Quorum () envPageSize) x5
+    paginateC selectBrigPropertiesAll (paramsP LocalQuorum () envPageSize) x5
 
 exportBrigPropertiesFull :: Env -> FilePath -> IO ()
 exportBrigPropertiesFull env@Env {..} path = do
@@ -322,7 +322,7 @@ selectBrigRichInfo = "SELECT user, json FROM rich_info WHERE user in ?"
 readBrigRichInfo :: Env -> [UserId] -> ConduitM () [RowBrigRichInfo] IO ()
 readBrigRichInfo Env {..} uids =
   transPipe (runClient envBrig) $
-    paginateC selectBrigRichInfo (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectBrigRichInfo (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectBrigRichInfoAll :: PrepQuery R () RowBrigRichInfo
 selectBrigRichInfoAll = "SELECT user, json FROM rich_info"
@@ -330,7 +330,7 @@ selectBrigRichInfoAll = "SELECT user, json FROM rich_info"
 readBrigRichInfoAll :: Env -> ConduitM () [RowBrigRichInfo] IO ()
 readBrigRichInfoAll Env {..} =
   transPipe (runClient envBrig) $
-    paginateC selectBrigRichInfoAll (paramsP Quorum () envPageSize) x5
+    paginateC selectBrigRichInfoAll (paramsP LocalQuorum () envPageSize) x5
 
 exportBrigRichInfoFull :: Env -> FilePath -> IO ()
 exportBrigRichInfoFull env@Env {..} path = do
@@ -368,7 +368,7 @@ selectBrigUser = "SELECT id, accent, accent_id, activated, assets, country, emai
 readBrigUser :: Env -> [UserId] -> ConduitM () [RowBrigUser] IO ()
 readBrigUser Env {..} uids =
   transPipe (runClient envBrig) $
-    paginateC selectBrigUser (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectBrigUser (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectBrigUserAll :: PrepQuery R () RowBrigUser
 selectBrigUserAll = "SELECT id, accent, accent_id, activated, assets, country, email, expires, handle, language, managed_by, name, password, phone, picture, provider, searchable, service, sso_id, status, team FROM user"
@@ -376,7 +376,7 @@ selectBrigUserAll = "SELECT id, accent, accent_id, activated, assets, country, e
 readBrigUserAll :: Env -> ConduitM () [RowBrigUser] IO ()
 readBrigUserAll Env {..} =
   transPipe (runClient envBrig) $
-    paginateC selectBrigUserAll (paramsP Quorum () envPageSize) x5
+    paginateC selectBrigUserAll (paramsP LocalQuorum () envPageSize) x5
 
 exportBrigUserFull :: Env -> FilePath -> IO ()
 exportBrigUserFull env@Env {..} path = do
@@ -414,7 +414,7 @@ selectBrigUserHandle = "SELECT handle, user FROM user_handle WHERE handle in ?"
 readBrigUserHandle :: Env -> [Handle] -> ConduitM () [RowBrigUserHandle] IO ()
 readBrigUserHandle Env {..} handles =
   transPipe (runClient envBrig) $
-    paginateC selectBrigUserHandle (paramsP Quorum (pure handles) envPageSize) x5
+    paginateC selectBrigUserHandle (paramsP LocalQuorum (pure handles) envPageSize) x5
 
 selectBrigUserHandleAll :: PrepQuery R () RowBrigUserHandle
 selectBrigUserHandleAll = "SELECT handle, user FROM user_handle"
@@ -422,7 +422,7 @@ selectBrigUserHandleAll = "SELECT handle, user FROM user_handle"
 readBrigUserHandleAll :: Env -> ConduitM () [RowBrigUserHandle] IO ()
 readBrigUserHandleAll Env {..} =
   transPipe (runClient envBrig) $
-    paginateC selectBrigUserHandleAll (paramsP Quorum () envPageSize) x5
+    paginateC selectBrigUserHandleAll (paramsP LocalQuorum () envPageSize) x5
 
 exportBrigUserHandleFull :: Env -> FilePath -> IO ()
 exportBrigUserHandleFull env@Env {..} path = do
@@ -460,7 +460,7 @@ selectBrigUserKeys = "SELECT key, user FROM user_keys WHERE key in ?"
 readBrigUserKeys :: Env -> [Int32] -> ConduitM () [RowBrigUserKeys] IO ()
 readBrigUserKeys Env {..} keys =
   transPipe (runClient envBrig) $
-    paginateC selectBrigUserKeys (paramsP Quorum (pure keys) envPageSize) x5
+    paginateC selectBrigUserKeys (paramsP LocalQuorum (pure keys) envPageSize) x5
 
 selectBrigUserKeysAll :: PrepQuery R () RowBrigUserKeys
 selectBrigUserKeysAll = "SELECT key, user FROM user_keys"
@@ -468,7 +468,7 @@ selectBrigUserKeysAll = "SELECT key, user FROM user_keys"
 readBrigUserKeysAll :: Env -> ConduitM () [RowBrigUserKeys] IO ()
 readBrigUserKeysAll Env {..} =
   transPipe (runClient envBrig) $
-    paginateC selectBrigUserKeysAll (paramsP Quorum () envPageSize) x5
+    paginateC selectBrigUserKeysAll (paramsP LocalQuorum () envPageSize) x5
 
 exportBrigUserKeysFull :: Env -> FilePath -> IO ()
 exportBrigUserKeysFull env@Env {..} path = do
@@ -506,7 +506,7 @@ selectBrigUserKeysHash = "SELECT key, key_type, user FROM user_keys_hash WHERE k
 readBrigUserKeysHash :: Env -> [Int32] -> ConduitM () [RowBrigUserKeysHash] IO ()
 readBrigUserKeysHash Env {..} keys =
   transPipe (runClient envBrig) $
-    paginateC selectBrigUserKeysHash (paramsP Quorum (pure keys) envPageSize) x5
+    paginateC selectBrigUserKeysHash (paramsP LocalQuorum (pure keys) envPageSize) x5
 
 selectBrigUserKeysHashAll :: PrepQuery R () RowBrigUserKeysHash
 selectBrigUserKeysHashAll = "SELECT key, key_type, user FROM user_keys_hash"
@@ -514,7 +514,7 @@ selectBrigUserKeysHashAll = "SELECT key, key_type, user FROM user_keys_hash"
 readBrigUserKeysHashAll :: Env -> ConduitM () [RowBrigUserKeysHash] IO ()
 readBrigUserKeysHashAll Env {..} =
   transPipe (runClient envBrig) $
-    paginateC selectBrigUserKeysHashAll (paramsP Quorum () envPageSize) x5
+    paginateC selectBrigUserKeysHashAll (paramsP LocalQuorum () envPageSize) x5
 
 exportBrigUserKeysHashFull :: Env -> FilePath -> IO ()
 exportBrigUserKeysHashFull env@Env {..} path = do
@@ -552,7 +552,7 @@ selectGalleyBillingTeamMember = "SELECT team, user FROM billing_team_member WHER
 readGalleyBillingTeamMember :: Env -> TeamId -> ConduitM () [RowGalleyBillingTeamMember] IO ()
 readGalleyBillingTeamMember Env {..} tid =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyBillingTeamMember (paramsP Quorum (pure tid) envPageSize) x5
+    paginateC selectGalleyBillingTeamMember (paramsP LocalQuorum (pure tid) envPageSize) x5
 
 selectGalleyBillingTeamMemberAll :: PrepQuery R () RowGalleyBillingTeamMember
 selectGalleyBillingTeamMemberAll = "SELECT team, user FROM billing_team_member"
@@ -560,7 +560,7 @@ selectGalleyBillingTeamMemberAll = "SELECT team, user FROM billing_team_member"
 readGalleyBillingTeamMemberAll :: Env -> ConduitM () [RowGalleyBillingTeamMember] IO ()
 readGalleyBillingTeamMemberAll Env {..} =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyBillingTeamMemberAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGalleyBillingTeamMemberAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGalleyBillingTeamMemberFull :: Env -> FilePath -> IO ()
 exportGalleyBillingTeamMemberFull env@Env {..} path = do
@@ -598,7 +598,7 @@ selectGalleyClients = "SELECT user, clients FROM clients WHERE user in ?"
 readGalleyClients :: Env -> [UserId] -> ConduitM () [RowGalleyClients] IO ()
 readGalleyClients Env {..} uids =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyClients (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectGalleyClients (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectGalleyClientsAll :: PrepQuery R () RowGalleyClients
 selectGalleyClientsAll = "SELECT user, clients FROM clients"
@@ -606,7 +606,7 @@ selectGalleyClientsAll = "SELECT user, clients FROM clients"
 readGalleyClientsAll :: Env -> ConduitM () [RowGalleyClients] IO ()
 readGalleyClientsAll Env {..} =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyClientsAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGalleyClientsAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGalleyClientsFull :: Env -> FilePath -> IO ()
 exportGalleyClientsFull env@Env {..} path = do
@@ -644,7 +644,7 @@ selectGalleyConversation = "SELECT conv, access, access_role, creator, deleted, 
 readGalleyConversation :: Env -> [ConvId] -> ConduitM () [RowGalleyConversation] IO ()
 readGalleyConversation Env {..} cids =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyConversation (paramsP Quorum (pure cids) envPageSize) x5
+    paginateC selectGalleyConversation (paramsP LocalQuorum (pure cids) envPageSize) x5
 
 selectGalleyConversationAll :: PrepQuery R () RowGalleyConversation
 selectGalleyConversationAll = "SELECT conv, access, access_role, creator, deleted, message_timer, name, receipt_mode, team, type FROM conversation"
@@ -652,7 +652,7 @@ selectGalleyConversationAll = "SELECT conv, access, access_role, creator, delete
 readGalleyConversationAll :: Env -> ConduitM () [RowGalleyConversation] IO ()
 readGalleyConversationAll Env {..} =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyConversationAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGalleyConversationAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGalleyConversationFull :: Env -> FilePath -> IO ()
 exportGalleyConversationFull env@Env {..} path = do
@@ -690,7 +690,7 @@ selectGalleyMember = "SELECT conv, user, conversation_role, hidden, hidden_ref, 
 readGalleyMember :: Env -> [ConvId] -> ConduitM () [RowGalleyMember] IO ()
 readGalleyMember Env {..} cids =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyMember (paramsP Quorum (pure cids) envPageSize) x5
+    paginateC selectGalleyMember (paramsP LocalQuorum (pure cids) envPageSize) x5
 
 selectGalleyMemberAll :: PrepQuery R () RowGalleyMember
 selectGalleyMemberAll = "SELECT conv, user, conversation_role, hidden, hidden_ref, otr_archived, otr_archived_ref, otr_muted, otr_muted_ref, otr_muted_status, provider, service, status, user_remote_domain, user_remote_id FROM member"
@@ -698,7 +698,7 @@ selectGalleyMemberAll = "SELECT conv, user, conversation_role, hidden, hidden_re
 readGalleyMemberAll :: Env -> ConduitM () [RowGalleyMember] IO ()
 readGalleyMemberAll Env {..} =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyMemberAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGalleyMemberAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGalleyMemberFull :: Env -> FilePath -> IO ()
 exportGalleyMemberFull env@Env {..} path = do
@@ -736,7 +736,7 @@ selectGalleyTeam = "SELECT team, binding, creator, deleted, icon, icon_key, name
 readGalleyTeam :: Env -> TeamId -> ConduitM () [RowGalleyTeam] IO ()
 readGalleyTeam Env {..} tid =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyTeam (paramsP Quorum (pure tid) envPageSize) x5
+    paginateC selectGalleyTeam (paramsP LocalQuorum (pure tid) envPageSize) x5
 
 selectGalleyTeamAll :: PrepQuery R () RowGalleyTeam
 selectGalleyTeamAll = "SELECT team, binding, creator, deleted, icon, icon_key, name, search_visibility, status FROM team"
@@ -744,7 +744,7 @@ selectGalleyTeamAll = "SELECT team, binding, creator, deleted, icon, icon_key, n
 readGalleyTeamAll :: Env -> ConduitM () [RowGalleyTeam] IO ()
 readGalleyTeamAll Env {..} =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyTeamAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGalleyTeamAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGalleyTeamFull :: Env -> FilePath -> IO ()
 exportGalleyTeamFull env@Env {..} path = do
@@ -782,7 +782,7 @@ selectGalleyTeamConv = "SELECT team, conv, managed FROM team_conv WHERE team = ?
 readGalleyTeamConv :: Env -> TeamId -> ConduitM () [RowGalleyTeamConv] IO ()
 readGalleyTeamConv Env {..} tid =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyTeamConv (paramsP Quorum (pure tid) envPageSize) x5
+    paginateC selectGalleyTeamConv (paramsP LocalQuorum (pure tid) envPageSize) x5
 
 selectGalleyTeamConvAll :: PrepQuery R () RowGalleyTeamConv
 selectGalleyTeamConvAll = "SELECT team, conv, managed FROM team_conv"
@@ -790,7 +790,7 @@ selectGalleyTeamConvAll = "SELECT team, conv, managed FROM team_conv"
 readGalleyTeamConvAll :: Env -> ConduitM () [RowGalleyTeamConv] IO ()
 readGalleyTeamConvAll Env {..} =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyTeamConvAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGalleyTeamConvAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGalleyTeamConvFull :: Env -> FilePath -> IO ()
 exportGalleyTeamConvFull env@Env {..} path = do
@@ -828,7 +828,7 @@ selectGalleyTeamFeatures = "SELECT team_id, app_lock_enforce, app_lock_inactivit
 readGalleyTeamFeatures :: Env -> TeamId -> ConduitM () [RowGalleyTeamFeatures] IO ()
 readGalleyTeamFeatures Env {..} tid =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyTeamFeatures (paramsP Quorum (pure tid) envPageSize) x5
+    paginateC selectGalleyTeamFeatures (paramsP LocalQuorum (pure tid) envPageSize) x5
 
 selectGalleyTeamFeaturesAll :: PrepQuery R () RowGalleyTeamFeatures
 selectGalleyTeamFeaturesAll = "SELECT team_id, app_lock_enforce, app_lock_inactivity_timeout_secs, app_lock_status, digital_signatures, legalhold_status, search_visibility_status, sso_status, validate_saml_emails FROM team_features"
@@ -836,7 +836,7 @@ selectGalleyTeamFeaturesAll = "SELECT team_id, app_lock_enforce, app_lock_inacti
 readGalleyTeamFeaturesAll :: Env -> ConduitM () [RowGalleyTeamFeatures] IO ()
 readGalleyTeamFeaturesAll Env {..} =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyTeamFeaturesAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGalleyTeamFeaturesAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGalleyTeamFeaturesFull :: Env -> FilePath -> IO ()
 exportGalleyTeamFeaturesFull env@Env {..} path = do
@@ -874,7 +874,7 @@ selectGalleyTeamMember = "SELECT team, user, invited_at, invited_by, legalhold_s
 readGalleyTeamMember :: Env -> TeamId -> ConduitM () [RowGalleyTeamMember] IO ()
 readGalleyTeamMember Env {..} tid =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyTeamMember (paramsP Quorum (pure tid) envPageSize) x5
+    paginateC selectGalleyTeamMember (paramsP LocalQuorum (pure tid) envPageSize) x5
 
 selectGalleyTeamMemberAll :: PrepQuery R () RowGalleyTeamMember
 selectGalleyTeamMemberAll = "SELECT team, user, invited_at, invited_by, legalhold_status, perms FROM team_member"
@@ -882,7 +882,7 @@ selectGalleyTeamMemberAll = "SELECT team, user, invited_at, invited_by, legalhol
 readGalleyTeamMemberAll :: Env -> ConduitM () [RowGalleyTeamMember] IO ()
 readGalleyTeamMemberAll Env {..} =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyTeamMemberAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGalleyTeamMemberAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGalleyTeamMemberFull :: Env -> FilePath -> IO ()
 exportGalleyTeamMemberFull env@Env {..} path = do
@@ -920,7 +920,7 @@ selectGalleyTeamNotifications = "SELECT team, id, payload FROM team_notification
 readGalleyTeamNotifications :: Env -> TeamId -> ConduitM () [RowGalleyTeamNotifications] IO ()
 readGalleyTeamNotifications Env {..} tid =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyTeamNotifications (paramsP Quorum (pure tid) envPageSize) x5
+    paginateC selectGalleyTeamNotifications (paramsP LocalQuorum (pure tid) envPageSize) x5
 
 selectGalleyTeamNotificationsAll :: PrepQuery R () RowGalleyTeamNotifications
 selectGalleyTeamNotificationsAll = "SELECT team, id, payload FROM team_notifications"
@@ -928,7 +928,7 @@ selectGalleyTeamNotificationsAll = "SELECT team, id, payload FROM team_notificat
 readGalleyTeamNotificationsAll :: Env -> ConduitM () [RowGalleyTeamNotifications] IO ()
 readGalleyTeamNotificationsAll Env {..} =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyTeamNotificationsAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGalleyTeamNotificationsAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGalleyTeamNotificationsFull :: Env -> FilePath -> IO ()
 exportGalleyTeamNotificationsFull env@Env {..} path = do
@@ -966,7 +966,7 @@ selectGalleyUser = "SELECT user, conv, conv_remote_domain, conv_remote_id FROM u
 readGalleyUser :: Env -> [UserId] -> ConduitM () [RowGalleyUser] IO ()
 readGalleyUser Env {..} uids =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyUser (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectGalleyUser (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectGalleyUserAll :: PrepQuery R () RowGalleyUser
 selectGalleyUserAll = "SELECT user, conv, conv_remote_domain, conv_remote_id FROM user"
@@ -974,7 +974,7 @@ selectGalleyUserAll = "SELECT user, conv, conv_remote_domain, conv_remote_id FRO
 readGalleyUserAll :: Env -> ConduitM () [RowGalleyUser] IO ()
 readGalleyUserAll Env {..} =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyUserAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGalleyUserAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGalleyUserFull :: Env -> FilePath -> IO ()
 exportGalleyUserFull env@Env {..} path = do
@@ -1012,7 +1012,7 @@ selectGalleyUserTeam = "SELECT user, team FROM user_team WHERE user in ?"
 readGalleyUserTeam :: Env -> [UserId] -> ConduitM () [RowGalleyUserTeam] IO ()
 readGalleyUserTeam Env {..} uids =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyUserTeam (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectGalleyUserTeam (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectGalleyUserTeamAll :: PrepQuery R () RowGalleyUserTeam
 selectGalleyUserTeamAll = "SELECT user, team FROM user_team"
@@ -1020,7 +1020,7 @@ selectGalleyUserTeamAll = "SELECT user, team FROM user_team"
 readGalleyUserTeamAll :: Env -> ConduitM () [RowGalleyUserTeam] IO ()
 readGalleyUserTeamAll Env {..} =
   transPipe (runClient envGalley) $
-    paginateC selectGalleyUserTeamAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGalleyUserTeamAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGalleyUserTeamFull :: Env -> FilePath -> IO ()
 exportGalleyUserTeamFull env@Env {..} path = do
@@ -1058,7 +1058,7 @@ selectGundeckNotifications = "SELECT user, id, clients, payload FROM notificatio
 readGundeckNotifications :: Env -> [UserId] -> ConduitM () [RowGundeckNotifications] IO ()
 readGundeckNotifications Env {..} uids =
   transPipe (runClient envGundeck) $
-    paginateC selectGundeckNotifications (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectGundeckNotifications (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectGundeckNotificationsAll :: PrepQuery R () RowGundeckNotifications
 selectGundeckNotificationsAll = "SELECT user, id, clients, payload FROM notifications"
@@ -1066,7 +1066,7 @@ selectGundeckNotificationsAll = "SELECT user, id, clients, payload FROM notifica
 readGundeckNotificationsAll :: Env -> ConduitM () [RowGundeckNotifications] IO ()
 readGundeckNotificationsAll Env {..} =
   transPipe (runClient envGundeck) $
-    paginateC selectGundeckNotificationsAll (paramsP Quorum () envPageSize) x5
+    paginateC selectGundeckNotificationsAll (paramsP LocalQuorum () envPageSize) x5
 
 exportGundeckNotificationsFull :: Env -> FilePath -> IO ()
 exportGundeckNotificationsFull env@Env {..} path = do
@@ -1104,7 +1104,7 @@ selectSparScimExternal = "SELECT team, external_id, user FROM scim_external WHER
 readSparScimExternal :: Env -> TeamId -> ConduitM () [RowSparScimExternal] IO ()
 readSparScimExternal Env {..} tid =
   transPipe (runClient envSpar) $
-    paginateC selectSparScimExternal (paramsP Quorum (pure tid) envPageSize) x5
+    paginateC selectSparScimExternal (paramsP LocalQuorum (pure tid) envPageSize) x5
 
 selectSparScimExternalAll :: PrepQuery R () RowSparScimExternal
 selectSparScimExternalAll = "SELECT team, external_id, user FROM scim_external"
@@ -1112,7 +1112,7 @@ selectSparScimExternalAll = "SELECT team, external_id, user FROM scim_external"
 readSparScimExternalAll :: Env -> ConduitM () [RowSparScimExternal] IO ()
 readSparScimExternalAll Env {..} =
   transPipe (runClient envSpar) $
-    paginateC selectSparScimExternalAll (paramsP Quorum () envPageSize) x5
+    paginateC selectSparScimExternalAll (paramsP LocalQuorum () envPageSize) x5
 
 exportSparScimExternalFull :: Env -> FilePath -> IO ()
 exportSparScimExternalFull env@Env {..} path = do
@@ -1150,7 +1150,7 @@ selectSparScimUserTimes = "SELECT uid, created_at, last_updated_at FROM scim_use
 readSparScimUserTimes :: Env -> [UserId] -> ConduitM () [RowSparScimUserTimes] IO ()
 readSparScimUserTimes Env {..} uids =
   transPipe (runClient envSpar) $
-    paginateC selectSparScimUserTimes (paramsP Quorum (pure uids) envPageSize) x5
+    paginateC selectSparScimUserTimes (paramsP LocalQuorum (pure uids) envPageSize) x5
 
 selectSparScimUserTimesAll :: PrepQuery R () RowSparScimUserTimes
 selectSparScimUserTimesAll = "SELECT uid, created_at, last_updated_at FROM scim_user_times"
@@ -1158,7 +1158,7 @@ selectSparScimUserTimesAll = "SELECT uid, created_at, last_updated_at FROM scim_
 readSparScimUserTimesAll :: Env -> ConduitM () [RowSparScimUserTimes] IO ()
 readSparScimUserTimesAll Env {..} =
   transPipe (runClient envSpar) $
-    paginateC selectSparScimUserTimesAll (paramsP Quorum () envPageSize) x5
+    paginateC selectSparScimUserTimesAll (paramsP LocalQuorum () envPageSize) x5
 
 exportSparScimUserTimesFull :: Env -> FilePath -> IO ()
 exportSparScimUserTimesFull env@Env {..} path = do
@@ -1196,7 +1196,7 @@ selectSparUser = "SELECT issuer, sso_id, uid FROM user WHERE issuer in ?"
 readSparUser :: Env -> [Text] -> ConduitM () [RowSparUser] IO ()
 readSparUser Env {..} issuer =
   transPipe (runClient envSpar) $
-    paginateC selectSparUser (paramsP Quorum (pure issuer) envPageSize) x5
+    paginateC selectSparUser (paramsP LocalQuorum (pure issuer) envPageSize) x5
 
 selectSparUserAll :: PrepQuery R () RowSparUser
 selectSparUserAll = "SELECT issuer, sso_id, uid FROM user"
@@ -1204,7 +1204,7 @@ selectSparUserAll = "SELECT issuer, sso_id, uid FROM user"
 readSparUserAll :: Env -> ConduitM () [RowSparUser] IO ()
 readSparUserAll Env {..} =
   transPipe (runClient envSpar) $
-    paginateC selectSparUserAll (paramsP Quorum () envPageSize) x5
+    paginateC selectSparUserAll (paramsP LocalQuorum () envPageSize) x5
 
 exportSparUserFull :: Env -> FilePath -> IO ()
 exportSparUserFull env@Env {..} path = do

--- a/tools/db/move-team/src/Types.hs
+++ b/tools/db/move-team/src/Types.hs
@@ -36,7 +36,6 @@ import Data.Id
 import qualified Data.Text as T
 import Data.Text.Ascii (AsciiText, Base64, decodeBase64, encodeBase64)
 import qualified Data.Vector as V
-import Database.CQL.Protocol (ColumnType (VarCharColumn))
 import Galley.Data.Instances ()
 import Imports
 import System.Logger (Logger)


### PR DESCRIPTION
As per https://wearezeta.atlassian.net/browse/BM-22 using LOCAL_QUORUM should:

* not change anything for a single-datacentre cassandra setup (which is our case atm)
* allow to make a datacentre migration that can be rolled back. 

Note: only merge this PR after the next release has been cut.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
