### PR TITLE
Remove Locale from the UserProfile model

### DIFF
--- a/changelog.d/1-api-changes/remove-locale-in-user-profiles
+++ b/changelog.d/1-api-changes/remove-locale-in-user-profiles
@@ -1,0 +1,1 @@
+Remove locale from publicly facing user profiles (but not from the self profile)

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -213,7 +213,6 @@ data UserProfile = UserProfile
     -- i.e. it is a "bot".
     profileService :: Maybe ServiceRef,
     profileHandle :: Maybe Handle,
-    profileLocale :: Maybe Locale,
     profileExpire :: Maybe UTCTimeMillis,
     profileTeam :: Maybe TeamId,
     profileEmail :: Maybe Email,
@@ -238,7 +237,6 @@ instance ToSchema UserProfile where
           .= fmap (fromMaybe False) (opt (field "deleted" schema))
         <*> profileService .= opt (field "service" schema)
         <*> profileHandle .= opt (field "handle" schema)
-        <*> profileLocale .= opt (field "locale" schema)
         <*> profileExpire .= opt (field "expires_at" schema)
         <*> profileTeam .= opt (field "team" schema)
         <*> profileEmail .= opt (field "email" schema)
@@ -429,7 +427,6 @@ connectedProfile u legalHoldStatus =
       profileAssets = userAssets u,
       profileAccentId = userAccentId u,
       profileService = userService u,
-      profileLocale = Just (userLocale u),
       profileDeleted = userDeleted u,
       profileExpire = userExpire u,
       profileTeam = userTeam u,
@@ -459,8 +456,7 @@ publicProfile u legalHoldStatus =
           profileLegalholdStatus
         } = connectedProfile u legalHoldStatus
    in UserProfile
-        { profileLocale = Nothing,
-          profileEmail = Nothing,
+        { profileEmail = Nothing,
           profileQualifiedId,
           profileHandle,
           profileName,

--- a/libs/wire-api/test/golden/testObject_UserProfile_user_2.json
+++ b/libs/wire-api/test/golden/testObject_UserProfile_user_2.json
@@ -7,7 +7,6 @@
     "handle": "emsonpvo3-x_4ys4qjtjtkfgx.mag6pi2ldq.77m5vnsn_tte41r-0vwgklpeejr1t4se0bknu4tsuqs-njzh34-ba_mj8lm5x6aro4o.2wsqe0ldx",
     "id": "00000002-0000-0002-0000-000000000001",
     "legalhold_status": "no_consent",
-    "locale": "ny-MU",
     "name": "si4v󴃿\u001b^'ゟk喁\u0015?􈒳\u0000Bw;\u00083*R/𨄵lrI",
     "picture": [],
     "qualified_id": {

--- a/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/UserProfile_user.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Golden/Generated/UserProfile_user.hs
@@ -20,10 +20,8 @@ module Test.Wire.API.Golden.Generated.UserProfile_user where
 
 import Data.Domain (Domain (Domain, _domainText))
 import Data.Handle (Handle (Handle, fromHandle))
-import Data.ISO3166_CountryCodes (CountryCode (MU))
 import Data.Id (Id (Id))
 import Data.Json.Util (readUTCTimeMillis)
-import qualified Data.LanguageCodes (ISO639_1 (NY))
 import Data.LegalHold (UserLegalHoldStatus (..))
 import Data.Qualified (Qualified (Qualified, qDomain, qUnqualified))
 import qualified Data.UUID as UUID (fromString)
@@ -31,10 +29,7 @@ import Imports (Bool (False, True), Maybe (Just, Nothing), fromJust)
 import Wire.API.Provider.Service (ServiceRef (ServiceRef, _serviceRefId, _serviceRefProvider))
 import Wire.API.User
   ( ColourId (ColourId, fromColourId),
-    Country (Country, fromCountry),
     Email (Email, emailDomain, emailLocal),
-    Language (Language),
-    Locale (Locale, lCountry, lLanguage),
     Name (Name, fromName),
     Pict (Pict, fromPict),
     UserProfile (..),
@@ -55,7 +50,6 @@ testObject_UserProfile_user_1 =
       profileDeleted = False,
       profileService = Nothing,
       profileHandle = Nothing,
-      profileLocale = Nothing,
       profileExpire = Nothing,
       profileTeam = Nothing,
       profileEmail = Nothing,
@@ -89,8 +83,6 @@ testObject_UserProfile_user_2 =
                   "emsonpvo3-x_4ys4qjtjtkfgx.mag6pi2ldq.77m5vnsn_tte41r-0vwgklpeejr1t4se0bknu4tsuqs-njzh34-ba_mj8lm5x6aro4o.2wsqe0ldx"
               }
           ),
-      profileLocale =
-        Just (Locale {lLanguage = Language Data.LanguageCodes.NY, lCountry = Just (Country {fromCountry = MU})}),
       profileExpire = Just (fromJust (readUTCTimeMillis "1864-05-09T01:42:22.437Z")),
       profileTeam = Just (Id (fromJust (UUID.fromString "00000000-0000-0002-0000-000200000002"))),
       profileEmail = Just (Email {emailLocal = "\172353 ", emailDomain = ""}),

--- a/libs/wire-api/test/unit/Test/Wire/API/User.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/User.hs
@@ -47,7 +47,7 @@ testUserProfile = do
   uid <- Id <$> UUID.nextRandom
   let domain = Domain "example.com"
   let colour = ColourId 0
-  let userProfile = UserProfile (Qualified uid domain) (Name "name") (Pict []) [] colour False Nothing Nothing Nothing Nothing Nothing Nothing UserLegalHoldNoConsent
+  let userProfile = UserProfile (Qualified uid domain) (Name "name") (Pict []) [] colour False Nothing Nothing Nothing Nothing Nothing UserLegalHoldNoConsent
   let profileJSONAsText = show $ Aeson.encode userProfile
   let msg = "toJSON encoding must not convert Nothing to null, but instead omit those json fields for backwards compatibility. UserProfileJSON:" <> profileJSONAsText
   assertBool msg (not $ "null" `isInfixOf` profileJSONAsText)

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2209,7 +2209,6 @@ mkProfile quid name =
       profileDeleted = False,
       profileService = Nothing,
       profileHandle = Nothing,
-      profileLocale = Nothing,
       profileExpire = Nothing,
       profileTeam = Nothing,
       profileEmail = Nothing,


### PR DESCRIPTION
The PR removes the locale from the `UserProfile` model in public endpoints. This affects, for example, the `GET /users/:domain/:uid` endpoint where the `locale` field is dropped. Client developers confirmed they do not use it.

See https://wearezeta.atlassian.net/browse/SQCORE-1077.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
