### PR TITLE
 Galley polysemy (2/5) - Store effects

### DIFF
--- a/changelog.d/5-internal/polysemy-store
+++ b/changelog.d/5-internal/polysemy-store
@@ -1,0 +1,1 @@
+Add polysemy store effects and split off Cassandra specific functionality from the Galley.Data module hierarchy.

--- a/libs/galley-types/src/Galley/Types/Conversations/Members.hs
+++ b/libs/galley-types/src/Galley/Types/Conversations/Members.hs
@@ -22,6 +22,8 @@ module Galley.Types.Conversations.Members
     remoteMemberToOther,
     LocalMember (..),
     localMemberToOther,
+    newMember,
+    newMemberWithRole,
     MemberStatus (..),
     defMemberStatus,
   )
@@ -32,7 +34,7 @@ import Data.Id as Id
 import Data.Qualified
 import Imports
 import Wire.API.Conversation
-import Wire.API.Conversation.Role (RoleName)
+import Wire.API.Conversation.Role (RoleName, roleNameWireAdmin)
 import Wire.API.Provider.Service (ServiceRef)
 
 -- | Internal (cassandra) representation of a remote conversation member.
@@ -58,6 +60,18 @@ data LocalMember = LocalMember
     lmConvRoleName :: RoleName
   }
   deriving stock (Show)
+
+newMember :: UserId -> LocalMember
+newMember u = newMemberWithRole (u, roleNameWireAdmin)
+
+newMemberWithRole :: (UserId, RoleName) -> LocalMember
+newMemberWithRole (u, r) =
+  LocalMember
+    { lmId = u,
+      lmService = Nothing,
+      lmStatus = defMemberStatus,
+      lmConvRoleName = r
+    }
 
 localMemberToOther :: Domain -> LocalMember -> OtherMember
 localMemberToOther domain x =

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -21,6 +21,7 @@
 
 module Data.Qualified
   ( -- * Qualified
+    QTag (..),
     Qualified (..),
     qToPair,
     QualifiedWithTag,

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -580,15 +580,9 @@ testBadFingerprint config db brig galley _cannon = do
 
 testAddRemoveBotTeam :: Config -> DB.ClientState -> Brig -> Galley -> Cannon -> Http ()
 testAddRemoveBotTeam config db brig galley cannon = withTestService config db brig defServiceApp $ \sref buf -> do
-  (u1, u2, h, tid, cid, pid, sid) <- prepareBotUsersTeam brig galley sref
-  let (uid1, uid2) = (userId u1, userId u2)
-      quid1 = userQualifiedId u1
+  (u1, u2, h, _, cid, pid, sid) <- prepareBotUsersTeam brig galley sref
+  let quid1 = userQualifiedId u1
       localDomain = qDomain quid1
-  -- Ensure cannot add bots to managed conversations
-  cidFail <- Team.createManagedConv galley tid uid1 [uid2] Nothing
-  addBot brig uid1 pid sid cidFail !!! do
-    const 403 === statusCode
-    const (Just "invalid-conversation") === fmap Error.label . responseJsonMaybe
   testAddRemoveBotUtil localDomain pid sid cid u1 u2 h sref buf brig galley cannon
 
 testBotTeamOnlyConv :: Config -> DB.ClientState -> Brig -> Galley -> Cannon -> Http ()

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c2d7d561f622d7840a187818b94c695954d150a41b6731efff3fd0755c843f6c
+-- hash: dc34370a02320432a6a8741b025ec2bbfba0dae6eff8b1761db542dbd1bf04c6
 
 name:           galley
 version:        0.83.0
@@ -45,6 +45,7 @@ library
       Galley.API.Util
       Galley.App
       Galley.Aws
+      Galley.Cassandra
       Galley.Cassandra.Client
       Galley.Cassandra.Code
       Galley.Cassandra.Conversation
@@ -54,7 +55,6 @@ library
       Galley.Cassandra.Paging
       Galley.Cassandra.Store
       Galley.Cassandra.Team
-      Galley.Data
       Galley.Data.Access
       Galley.Data.Conversation
       Galley.Data.Conversation.Types

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5a3ccdb08ac650b5725a2768c9a3d27b1dca1f5b21f5203df1c68d033bc36ccb
+-- hash: 7d1492b32fa296d8cfef6fca543011a6ebf0e4c641d960958f302aceda2de044
 
 name:           galley
 version:        0.83.0
@@ -48,8 +48,10 @@ library
       Galley.Cassandra.Conversation
       Galley.Cassandra.Conversation.Members
       Galley.Cassandra.ConversationList
+      Galley.Cassandra.LegalHold
       Galley.Cassandra.Paging
       Galley.Cassandra.Store
+      Galley.Cassandra.Team
       Galley.Data
       Galley.Data.Access
       Galley.Data.Conversation
@@ -68,9 +70,12 @@ library
       Galley.Effects
       Galley.Effects.ConversationStore
       Galley.Effects.FireAndForget
+      Galley.Effects.ListItems
       Galley.Effects.MemberStore
       Galley.Effects.Paging
       Galley.Effects.RemoteConversationListStore
+      Galley.Effects.TeamMemberStore
+      Galley.Effects.TeamStore
       Galley.Env
       Galley.External
       Galley.External.LegalHoldService

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 44662379ad01cec255460e33e2e8ca6b68fa03f38647a06060dfdf4fb7179da8
+-- hash: e766852c726a9a3e57fdfa335f55129160f2396a2f66e63bb4c66a9225123b3a
 
 name:           galley
 version:        0.83.0
@@ -47,6 +47,8 @@ library
       Galley.Aws
       Galley.Cassandra.Conversation
       Galley.Cassandra.Conversation.Members
+      Galley.Cassandra.ConversationList
+      Galley.Cassandra.Paging
       Galley.Cassandra.Store
       Galley.Data
       Galley.Data.Access
@@ -56,6 +58,7 @@ library
       Galley.Data.Instances
       Galley.Data.LegalHold
       Galley.Data.Queries
+      Galley.Data.ResultSet
       Galley.Data.Scope
       Galley.Data.SearchVisibility
       Galley.Data.Services
@@ -63,8 +66,11 @@ library
       Galley.Data.TeamNotifications
       Galley.Data.Types
       Galley.Effects
+      Galley.Effects.ConversationListStore
       Galley.Effects.ConversationStore
       Galley.Effects.FireAndForget
+      Galley.Effects.Paging
+      Galley.Effects.RemoteConversationListStore
       Galley.Env
       Galley.External
       Galley.External.LegalHoldService

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 503d71d65ade51f149de711b6c0b958b0d7de6c3472c4831fc5549c20410b37a
+-- hash: 44662379ad01cec255460e33e2e8ca6b68fa03f38647a06060dfdf4fb7179da8
 
 name:           galley
 version:        0.83.0
@@ -45,18 +45,27 @@ library
       Galley.API.Util
       Galley.App
       Galley.Aws
+      Galley.Cassandra.Conversation
+      Galley.Cassandra.Conversation.Members
+      Galley.Cassandra.Store
       Galley.Data
+      Galley.Data.Access
+      Galley.Data.Conversation
+      Galley.Data.Conversation.Types
       Galley.Data.CustomBackend
       Galley.Data.Instances
       Galley.Data.LegalHold
       Galley.Data.Queries
+      Galley.Data.Scope
       Galley.Data.SearchVisibility
       Galley.Data.Services
       Galley.Data.TeamFeatures
       Galley.Data.TeamNotifications
       Galley.Data.Types
       Galley.Effects
+      Galley.Effects.ConversationStore
       Galley.Effects.FireAndForget
+      Galley.Env
       Galley.External
       Galley.External.LegalHoldService
       Galley.Intra.Client
@@ -70,6 +79,7 @@ library
       Galley.Queue
       Galley.Run
       Galley.Types.Clients
+      Galley.Types.ToUserRole
       Galley.Types.UserList
       Galley.Validation
       Main
@@ -124,6 +134,7 @@ library
     , optparse-applicative >=0.10
     , pem
     , polysemy
+    , polysemy-wire-zoo
     , proto-lens >=0.2
     , protobuf >=0.2
     , raw-strings-qq >=1.0

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7d1492b32fa296d8cfef6fca543011a6ebf0e4c641d960958f302aceda2de044
+-- hash: 881a30190b3b9413fe0180d4e62a297cd6df4c32fd285847a5a8e90a90288023
 
 name:           galley
 version:        0.83.0
@@ -45,6 +45,7 @@ library
       Galley.API.Util
       Galley.App
       Galley.Aws
+      Galley.Cassandra.Client
       Galley.Cassandra.Conversation
       Galley.Cassandra.Conversation.Members
       Galley.Cassandra.ConversationList
@@ -68,6 +69,7 @@ library
       Galley.Data.TeamNotifications
       Galley.Data.Types
       Galley.Effects
+      Galley.Effects.ClientStore
       Galley.Effects.ConversationStore
       Galley.Effects.FireAndForget
       Galley.Effects.ListItems

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: dc34370a02320432a6a8741b025ec2bbfba0dae6eff8b1761db542dbd1bf04c6
+-- hash: 1b185cc3a9afe5d7a6c21c93d6c031963a5eb924885b6314ffc92ce96c6b545d
 
 name:           galley
 version:        0.83.0
@@ -53,6 +53,7 @@ library
       Galley.Cassandra.ConversationList
       Galley.Cassandra.LegalHold
       Galley.Cassandra.Paging
+      Galley.Cassandra.Services
       Galley.Cassandra.Store
       Galley.Cassandra.Team
       Galley.Data.Access
@@ -78,6 +79,7 @@ library
       Galley.Effects.MemberStore
       Galley.Effects.Paging
       Galley.Effects.RemoteConversationListStore
+      Galley.Effects.ServiceStore
       Galley.Effects.TeamMemberStore
       Galley.Effects.TeamStore
       Galley.Env

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e766852c726a9a3e57fdfa335f55129160f2396a2f66e63bb4c66a9225123b3a
+-- hash: 5a3ccdb08ac650b5725a2768c9a3d27b1dca1f5b21f5203df1c68d033bc36ccb
 
 name:           galley
 version:        0.83.0
@@ -66,9 +66,9 @@ library
       Galley.Data.TeamNotifications
       Galley.Data.Types
       Galley.Effects
-      Galley.Effects.ConversationListStore
       Galley.Effects.ConversationStore
       Galley.Effects.FireAndForget
+      Galley.Effects.MemberStore
       Galley.Effects.Paging
       Galley.Effects.RemoteConversationListStore
       Galley.Env
@@ -94,7 +94,7 @@ library
   hs-source-dirs:
       src
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DerivingVia DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
-  ghc-options: -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
+  ghc-options: -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path -fplugin=Polysemy.Plugin
   build-depends:
       HsOpenSSL >=0.11
     , HsOpenSSL-x509-system >=0.1
@@ -140,6 +140,7 @@ library
     , optparse-applicative >=0.10
     , pem
     , polysemy
+    , polysemy-plugin
     , polysemy-wire-zoo
     , proto-lens >=0.2
     , protobuf >=0.2

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 881a30190b3b9413fe0180d4e62a297cd6df4c32fd285847a5a8e90a90288023
+-- hash: c2d7d561f622d7840a187818b94c695954d150a41b6731efff3fd0755c843f6c
 
 name:           galley
 version:        0.83.0
@@ -46,6 +46,7 @@ library
       Galley.App
       Galley.Aws
       Galley.Cassandra.Client
+      Galley.Cassandra.Code
       Galley.Cassandra.Conversation
       Galley.Cassandra.Conversation.Members
       Galley.Cassandra.ConversationList
@@ -70,6 +71,7 @@ library
       Galley.Data.Types
       Galley.Effects
       Galley.Effects.ClientStore
+      Galley.Effects.CodeStore
       Galley.Effects.ConversationStore
       Galley.Effects.FireAndForget
       Galley.Effects.ListItems

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -26,6 +26,7 @@ dependencies:
 
 library:
   source-dirs: src
+  ghc-options: -fplugin=Polysemy.Plugin
   dependencies:
   - aeson >=0.11
   - amazonka >=1.4.5
@@ -66,6 +67,7 @@ library:
   - optparse-applicative >=0.10
   - pem
   - polysemy
+  - polysemy-plugin
   - polysemy-wire-zoo
   - protobuf >=0.2
   - proto-lens >=0.2

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -66,6 +66,7 @@ library:
   - optparse-applicative >=0.10
   - pem
   - polysemy
+  - polysemy-wire-zoo
   - protobuf >=0.2
   - proto-lens >=0.2
   - QuickCheck >=2.14

--- a/services/galley/src/Galley/API/Clients.hs
+++ b/services/galley/src/Galley/API/Clients.hs
@@ -25,8 +25,8 @@ where
 import Control.Lens (view)
 import Data.Id
 import Galley.App
-import qualified Galley.Data as Data
 import Galley.Effects
+import qualified Galley.Effects.ClientStore as E
 import qualified Galley.Intra.Client as Intra
 import Galley.Options
 import Galley.Types.Clients (clientIds, fromUserClients)
@@ -35,25 +35,37 @@ import Network.Wai
 import Network.Wai.Predicate hiding (setStatus)
 import Network.Wai.Utilities
 
-getClientsH :: Member BrigAccess r => UserId -> Galley r Response
+getClientsH ::
+  Members '[BrigAccess, ClientStore] r =>
+  UserId ->
+  Galley r Response
 getClientsH usr = do
   json <$> getClients usr
 
-getClients :: Member BrigAccess r => UserId -> Galley r [ClientId]
+getClients ::
+  Members '[BrigAccess, ClientStore] r =>
+  UserId ->
+  Galley r [ClientId]
 getClients usr = do
   isInternal <- view $ options . optSettings . setIntraListing
   clts <-
     if isInternal
       then fromUserClients <$> Intra.lookupClients [usr]
-      else Data.lookupClients [usr]
+      else liftSem $ E.getClients [usr]
   return $ clientIds usr clts
 
-addClientH :: UserId ::: ClientId -> Galley r Response
-addClientH (usr ::: clt) = do
-  Data.updateClient True usr clt
+addClientH ::
+  Member ClientStore r =>
+  UserId ::: ClientId ->
+  Galley r Response
+addClientH (usr ::: clt) = liftSem $ do
+  E.createClient usr clt
   return empty
 
-rmClientH :: UserId ::: ClientId -> Galley r Response
-rmClientH (usr ::: clt) = do
-  Data.updateClient False usr clt
+rmClientH ::
+  Member ClientStore r =>
+  UserId ::: ClientId ->
+  Galley r Response
+rmClientH (usr ::: clt) = liftSem $ do
+  E.deleteClient usr clt
   return empty

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -6,7 +6,7 @@
 -- the terms of the GNU Affero General Public License as published by the Free
 -- Software Foundation, either version 3 of the License, or (at your option) any
 -- later version.
---
+
 -- This program is distributed in the hope that it will be useful, but WITHOUT
 -- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 -- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
@@ -40,9 +40,12 @@ import Galley.API.One2One
 import Galley.API.Util
 import Galley.App
 import qualified Galley.Data as Data
+import qualified Galley.Data.Conversation as Data
+import Galley.Data.Conversation.Types
 import Galley.Effects
+import qualified Galley.Effects.ConversationStore as E
 import Galley.Intra.Push
-import Galley.Types
+import Galley.Types.Conversations.Members
 import Galley.Types.Teams (ListType (..), Perm (..), TeamBinding (Binding), notTeamMember)
 import Galley.Types.UserList
 import Galley.Validation
@@ -51,8 +54,10 @@ import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Predicate hiding (setStatus)
 import Network.Wai.Utilities
+import Wire.API.Conversation hiding (Conversation, Member)
 import qualified Wire.API.Conversation as Public
 import Wire.API.ErrorDescription (MissingLegalholdConsent)
+import Wire.API.Event.Conversation hiding (Conversation)
 import Wire.API.Federation.Error (federationNotImplemented)
 import Wire.API.Routes.Public.Galley (ConversationResponse)
 import Wire.API.Routes.Public.Util
@@ -65,7 +70,7 @@ import Wire.API.Team.LegalHold (LegalholdProtectee (LegalholdPlusFederationNotIm
 --
 -- See Note [managed conversations].
 createGroupConversation ::
-  Members '[BrigAccess, FederatorAccess, GundeckAccess] r =>
+  Members '[ConversationStore, BrigAccess, FederatorAccess, GundeckAccess] r =>
   UserId ->
   ConnId ->
   Public.NewConvUnmanaged ->
@@ -78,7 +83,7 @@ createGroupConversation user conn wrapped@(Public.NewConvUnmanaged body) =
 -- | An internal endpoint for creating managed group conversations. Will
 -- throw an error for everything else.
 internalCreateManagedConversationH ::
-  Members '[BrigAccess, FederatorAccess, GundeckAccess] r =>
+  Members '[ConversationStore, BrigAccess, FederatorAccess, GundeckAccess] r =>
   UserId ::: ConnId ::: JsonRequest NewConvManaged ->
   Galley r Response
 internalCreateManagedConversationH (zusr ::: zcon ::: req) = do
@@ -86,7 +91,7 @@ internalCreateManagedConversationH (zusr ::: zcon ::: req) = do
   handleConversationResponse <$> internalCreateManagedConversation zusr zcon newConv
 
 internalCreateManagedConversation ::
-  Members '[BrigAccess, FederatorAccess, GundeckAccess] r =>
+  Members '[ConversationStore, BrigAccess, FederatorAccess, GundeckAccess] r =>
   UserId ->
   ConnId ->
   NewConvManaged ->
@@ -108,7 +113,7 @@ ensureNoLegalholdConflicts remotes locals = do
 
 -- | A helper for creating a regular (non-team) group conversation.
 createRegularGroupConv ::
-  Members '[BrigAccess, FederatorAccess, GundeckAccess] r =>
+  Members '[ConversationStore, BrigAccess, FederatorAccess, GundeckAccess] r =>
   UserId ->
   ConnId ->
   NewConvUnmanaged ->
@@ -121,23 +126,27 @@ createRegularGroupConv zusr zcon (NewConvUnmanaged body) = do
   ensureConnected lusr allUsers
   ensureNoLegalholdConflicts (ulRemotes allUsers) (ulLocals allUsers)
   c <-
-    Data.createConversation
-      lusr
-      name
-      (access body)
-      (accessRole body)
-      checkedUsers
-      (newConvTeam body)
-      (newConvMessageTimer body)
-      (newConvReceiptMode body)
-      (newConvUsersRole body)
+    liftSem $
+      E.createConversation
+        NewConversation
+          { ncType = RegularConv,
+            ncCreator = tUnqualified lusr,
+            ncAccess = access body,
+            ncAccessRole = accessRole body,
+            ncName = name,
+            ncTeam = fmap cnvTeamId (newConvTeam body),
+            ncMessageTimer = newConvMessageTimer body,
+            ncReceiptMode = newConvReceiptMode body,
+            ncUsers = checkedUsers,
+            ncRole = newConvUsersRole body
+          }
   notifyCreatedConversation Nothing zusr (Just zcon) c
   conversationCreated zusr c
 
 -- | A helper for creating a team group conversation, used by the endpoint
 -- handlers above. Only supports unmanaged conversations.
 createTeamGroupConv ::
-  Members '[BrigAccess, FederatorAccess, GundeckAccess] r =>
+  Members '[ConversationStore, BrigAccess, FederatorAccess, GundeckAccess] r =>
   UserId ->
   ConnId ->
   Public.ConvTeamInfo ->
@@ -172,16 +181,20 @@ createTeamGroupConv zusr zcon tinfo body = do
   ensureConnectedToRemotes lusr (ulRemotes allUsers)
   ensureNoLegalholdConflicts (ulRemotes allUsers) (ulLocals allUsers)
   conv <-
-    Data.createConversation
-      lusr
-      name
-      (access body)
-      (accessRole body)
-      checkedUsers
-      (newConvTeam body)
-      (newConvMessageTimer body)
-      (newConvReceiptMode body)
-      (newConvUsersRole body)
+    liftSem $
+      E.createConversation
+        NewConversation
+          { ncType = RegularConv,
+            ncCreator = tUnqualified lusr,
+            ncAccess = access body,
+            ncAccessRole = accessRole body,
+            ncName = name,
+            ncTeam = fmap cnvTeamId (newConvTeam body),
+            ncMessageTimer = newConvMessageTimer body,
+            ncReceiptMode = newConvReceiptMode body,
+            ncUsers = checkedUsers,
+            ncRole = newConvUsersRole body
+          }
   now <- liftIO getCurrentTime
   -- NOTE: We only send (conversation) events to members of the conversation
   notifyCreatedConversation (Just now) zusr (Just zcon) conv
@@ -190,18 +203,21 @@ createTeamGroupConv zusr zcon tinfo body = do
 ----------------------------------------------------------------------------
 -- Other kinds of conversations
 
-createSelfConversation :: UserId -> Galley r ConversationResponse
+createSelfConversation ::
+  Member ConversationStore r =>
+  UserId ->
+  Galley r ConversationResponse
 createSelfConversation zusr = do
   lusr <- qualifyLocal zusr
-  c <- Data.conversation (Id . toUUID $ zusr)
+  c <- liftSem $ E.getConversation (Id . toUUID $ zusr)
   maybe (create lusr) (conversationExisted zusr) c
   where
     create lusr = do
-      c <- Data.createSelfConversation lusr Nothing
+      c <- liftSem $ E.createSelfConversation lusr Nothing
       conversationCreated zusr c
 
 createOne2OneConversation ::
-  Members '[BrigAccess, FederatorAccess, GundeckAccess] r =>
+  Members '[BrigAccess, ConversationStore, FederatorAccess, GundeckAccess] r =>
   UserId ->
   ConnId ->
   NewConvUnmanaged ->
@@ -245,7 +261,7 @@ createOne2OneConversation zusr zcon (NewConvUnmanaged j) = do
         Nothing -> throwM teamNotFound
 
 createLegacyOne2OneConversationUnchecked ::
-  Members '[FederatorAccess, GundeckAccess] r =>
+  Members '[ConversationStore, FederatorAccess, GundeckAccess] r =>
   Local UserId ->
   ConnId ->
   Maybe (Range 1 256 Text) ->
@@ -254,17 +270,17 @@ createLegacyOne2OneConversationUnchecked ::
   Galley r ConversationResponse
 createLegacyOne2OneConversationUnchecked self zcon name mtid other = do
   lcnv <- localOne2OneConvId self other
-  mc <- Data.conversation (tUnqualified lcnv)
+  mc <- liftSem $ E.getConversation (tUnqualified lcnv)
   case mc of
     Just c -> conversationExisted (tUnqualified self) c
     Nothing -> do
       (x, y) <- toUUIDs (tUnqualified self) (tUnqualified other)
-      c <- Data.createLegacyOne2OneConversation self x y name mtid
+      c <- liftSem $ E.createLegacyOne2OneConversation self x y name mtid
       notifyCreatedConversation Nothing (tUnqualified self) (Just zcon) c
       conversationCreated (tUnqualified self) c
 
 createOne2OneConversationUnchecked ::
-  Members '[FederatorAccess, GundeckAccess] r =>
+  Members '[ConversationStore, FederatorAccess, GundeckAccess] r =>
   Local UserId ->
   ConnId ->
   Maybe (Range 1 256 Text) ->
@@ -280,7 +296,7 @@ createOne2OneConversationUnchecked self zcon name mtid other = do
   create (one2OneConvId (qUntagged self) other) self zcon name mtid other
 
 createOne2OneConversationLocally ::
-  Members '[FederatorAccess, GundeckAccess] r =>
+  Members '[ConversationStore, FederatorAccess, GundeckAccess] r =>
   Local ConvId ->
   Local UserId ->
   ConnId ->
@@ -289,11 +305,11 @@ createOne2OneConversationLocally ::
   Qualified UserId ->
   Galley r ConversationResponse
 createOne2OneConversationLocally lcnv self zcon name mtid other = do
-  mc <- Data.conversation (tUnqualified lcnv)
+  mc <- liftSem $ E.getConversation (tUnqualified lcnv)
   case mc of
     Just c -> conversationExisted (tUnqualified self) c
     Nothing -> do
-      c <- Data.createOne2OneConversation lcnv self other name mtid
+      c <- liftSem $ E.createOne2OneConversation (tUnqualified lcnv) self other name mtid
       notifyCreatedConversation Nothing (tUnqualified self) (Just zcon) c
       conversationCreated (tUnqualified self) c
 
@@ -309,7 +325,7 @@ createOne2OneConversationRemotely _ _ _ _ _ _ =
   throwM federationNotImplemented
 
 createConnectConversation ::
-  Members '[FederatorAccess, GundeckAccess] r =>
+  Members '[ConversationStore, FederatorAccess, GundeckAccess] r =>
   UserId ->
   Maybe ConnId ->
   Connect ->
@@ -331,7 +347,7 @@ createConnectConversationWithRemote _ _ _ =
   throwM federationNotImplemented
 
 createLegacyConnectConversation ::
-  Members '[FederatorAccess, GundeckAccess] r =>
+  Members '[ConversationStore, FederatorAccess, GundeckAccess] r =>
   Local UserId ->
   Maybe ConnId ->
   Local UserId ->
@@ -340,11 +356,11 @@ createLegacyConnectConversation ::
 createLegacyConnectConversation lusr conn lrecipient j = do
   (x, y) <- toUUIDs (tUnqualified lusr) (tUnqualified lrecipient)
   n <- rangeCheckedMaybe (cName j)
-  conv <- Data.conversation (Data.localOne2OneConvId x y)
+  conv <- liftSem $ E.getConversation (Data.localOne2OneConvId x y)
   maybe (create x y n) (update n) conv
   where
     create x y n = do
-      c <- Data.createConnectConversation lusr x y n
+      c <- liftSem $ E.createConnectConversation x y n
       now <- liftIO getCurrentTime
       let lcid = qualifyAs lusr (Data.convId c)
           e = Event ConvConnect (qUntagged lcid) (qUntagged lusr) now (EdConnect j)
@@ -384,8 +400,8 @@ createLegacyConnectConversation lusr conn lrecipient j = do
         localDomain <- viewFederationDomain
         let qconv = Qualified (Data.convId conv) localDomain
         n' <- case n of
-          Just x -> do
-            Data.updateConversation (Data.convId conv) x
+          Just x -> liftSem $ do
+            E.setConversationName (Data.convId conv) x
             return . Just $ fromRange x
           Nothing -> return $ Data.convName conv
         t <- liftIO getCurrentTime

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -39,7 +39,7 @@ import Galley.API.Mapping
 import Galley.API.One2One
 import Galley.API.Util
 import Galley.App
-import qualified Galley.Data as Data
+import Galley.Data.Access
 import qualified Galley.Data.Conversation as Data
 import Galley.Data.Conversation.Types
 import Galley.Effects
@@ -496,11 +496,11 @@ toUUIDs a b = do
   return (a', b')
 
 accessRole :: NewConv -> AccessRole
-accessRole b = fromMaybe Data.defRole (newConvAccessRole b)
+accessRole b = fromMaybe defRole (newConvAccessRole b)
 
 access :: NewConv -> [Access]
 access a = case Set.toList (newConvAccess a) of
-  [] -> Data.defRegularConvAccess
+  [] -> defRegularConvAccess
   (x : xs) -> x : xs
 
 newConvMembers :: Local x -> NewConv -> UserList UserId

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -240,6 +240,7 @@ leaveConversation ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -315,6 +315,7 @@ sendMessage ::
   Members
     '[ BotAccess,
        BrigAccess,
+       ClientStore,
        ConversationStore,
        FederatorAccess,
        GundeckAccess,

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -39,12 +39,13 @@ import Galley.API.Update (notifyConversationMetadataUpdate)
 import qualified Galley.API.Update as API
 import Galley.API.Util
 import Galley.App
-import qualified Galley.Data as Data
 import qualified Galley.Data.Conversation as Data
 import Galley.Effects
 import qualified Galley.Effects.ConversationStore as E
+import qualified Galley.Effects.MemberStore as E
 import Galley.Intra.User (getConnections)
 import Galley.Types.Conversations.Members (LocalMember (..), defMemberStatus)
+import Galley.Types.UserList
 import Imports
 import Servant (ServerT)
 import Servant.API.Generic (ToServantApi)
@@ -88,7 +89,7 @@ federationSitemap =
       }
 
 onConversationCreated ::
-  Members '[BrigAccess, GundeckAccess, ExternalAccess] r =>
+  Members '[BrigAccess, GundeckAccess, ExternalAccess, MemberStore] r =>
   Domain ->
   NewRemoteConversation ConvId ->
   Galley r ()
@@ -144,7 +145,7 @@ getLocalUsers localDomain = map qUnqualified . filter ((== localDomain) . qDomai
 -- | Update the local database with information on conversation members joining
 -- or leaving. Finally, push out notifications to local users.
 onConversationUpdated ::
-  Members '[BrigAccess, GundeckAccess, ExternalAccess] r =>
+  Members '[BrigAccess, GundeckAccess, ExternalAccess, MemberStore] r =>
   Domain ->
   ConversationUpdate ->
   Galley r ()
@@ -157,7 +158,9 @@ onConversationUpdated requestingDomain cu = do
   -- Note: we generally do not send notifications to users that are not part of
   -- the conversation (from our point of view), to prevent spam from the remote
   -- backend. See also the comment below.
-  (presentUsers, allUsersArePresent) <- Data.filterRemoteConvMembers (cuAlreadyPresentUsers cu) qconvId
+  (presentUsers, allUsersArePresent) <-
+    liftSem $
+      E.selectRemoteMembers (cuAlreadyPresentUsers cu) rconvId
 
   -- Perform action, and determine extra notification targets.
   --
@@ -175,17 +178,17 @@ onConversationUpdated requestingDomain cu = do
       case allAddedUsers of
         [] -> pure (Nothing, []) -- If no users get added, its like no action was performed.
         (u : us) -> pure (Just $ ConversationActionAddMembers (u :| us) role, addedLocalUsers)
-    ConversationActionRemoveMembers toRemove -> do
+    ConversationActionRemoveMembers toRemove -> liftSem $ do
       let localUsers = getLocalUsers localDomain toRemove
-      Data.removeLocalMembersFromRemoteConv rconvId localUsers
+      E.deleteMembersInRemoteConversation rconvId localUsers
       pure (Just $ cuAction cu, [])
     ConversationActionRename _ -> pure (Just $ cuAction cu, [])
     ConversationActionMessageTimerUpdate _ -> pure (Just $ cuAction cu, [])
     ConversationActionMemberUpdate _ _ -> pure (Just $ cuAction cu, [])
     ConversationActionReceiptModeUpdate _ -> pure (Just $ cuAction cu, [])
     ConversationActionAccessUpdate _ -> pure (Just $ cuAction cu, [])
-    ConversationActionDelete -> do
-      Data.removeLocalMembersFromRemoteConv rconvId presentUsers
+    ConversationActionDelete -> liftSem $ do
+      E.deleteMembersInRemoteConversation rconvId presentUsers
       pure (Just $ cuAction cu, [])
 
   unless allUsersArePresent $
@@ -207,7 +210,7 @@ onConversationUpdated requestingDomain cu = do
     pushConversationEvent Nothing event targets []
 
 addLocalUsersToRemoteConv ::
-  Member BrigAccess r =>
+  Members '[BrigAccess, MemberStore] r =>
   Remote ConvId ->
   Qualified UserId ->
   [UserId] ->
@@ -229,7 +232,7 @@ addLocalUsersToRemoteConv remoteConvId qAdder localUsers = do
 
   -- Update the local view of the remote conversation by adding only those local
   -- users that are connected to the adder
-  Data.addLocalMembersToRemoteConv remoteConvId connectedList
+  liftSem $ E.createMembersInRemoteConversation remoteConvId connectedList
   pure connected
 
 -- FUTUREWORK: actually return errors as part of the response instead of throwing
@@ -241,7 +244,8 @@ leaveConversation ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       MemberStore
      ]
     r =>
   Domain ->
@@ -264,7 +268,7 @@ leaveConversation requestingDomain lc = do
 -- FUTUREWORK: report errors to the originating backend
 -- FUTUREWORK: error handling for missing / mismatched clients
 onMessageSent ::
-  Members '[BotAccess, GundeckAccess, ExternalAccess] r =>
+  Members '[BotAccess, GundeckAccess, ExternalAccess, MemberStore] r =>
   Domain ->
   RemoteMessage ConvId ->
   Galley r ()
@@ -280,7 +284,9 @@ onMessageSent domain rmUnqualified = do
           }
       recipientMap = userClientMap $ rmRecipients rm
       msgs = toMapOf (itraversed <.> itraversed) recipientMap
-  (members, allMembers) <- Data.filterRemoteConvMembers (Map.keys recipientMap) convId
+  (members, allMembers) <-
+    liftSem $
+      E.selectRemoteMembers (Map.keys recipientMap) (rmConversation rm)
   unless allMembers $
     Log.warn $
       Log.field "conversation" (toByteString' (qUnqualified convId))
@@ -311,7 +317,8 @@ sendMessage ::
        ConversationStore,
        FederatorAccess,
        GundeckAccess,
-       ExternalAccess
+       ExternalAccess,
+       MemberStore
      ]
     r =>
   Domain ->
@@ -330,7 +337,8 @@ onUserDeleted ::
        FederatorAccess,
        FireAndForget,
        ExternalAccess,
-       GundeckAccess
+       GundeckAccess,
+       MemberStore
      ]
     r =>
   Domain ->
@@ -345,7 +353,7 @@ onUserDeleted origDomain udcn = do
     fromRange convIds <&> \c -> do
       lc <- qualifyLocal c
       mconv <- liftSem $ E.getConversation c
-      Data.removeRemoteMembersFromLocalConv c (pure deletedUser)
+      liftSem $ E.deleteMembers c (UserList [] [deletedUser])
       for_ mconv $ \conv -> do
         when (isRemoteMember deletedUser (Data.convRemoteMembers conv)) $
           case Data.convType conv of
@@ -359,6 +367,7 @@ onUserDeleted origDomain udcn = do
             Public.SelfConv -> pure ()
             Public.RegularConv -> do
               let action = ConversationActionRemoveMembers (pure untaggedDeletedUser)
+
                   botsAndMembers = convBotsAndMembers conv
               void $ notifyConversationMetadataUpdate untaggedDeletedUser Nothing lc botsAndMembers action
   pure EmptyResponse

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -245,7 +245,8 @@ leaveConversation ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       MemberStore
+       MemberStore,
+       TeamStore
      ]
     r =>
   Domain ->
@@ -318,7 +319,8 @@ sendMessage ::
        FederatorAccess,
        GundeckAccess,
        ExternalAccess,
-       MemberStore
+       MemberStore,
+       TeamStore
      ]
     r =>
   Domain ->

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -53,6 +53,7 @@ import qualified Galley.API.Teams.Features as Features
 import qualified Galley.API.Update as Update
 import Galley.API.Util (JSON, isMember, qualifyLocal, viewFederationDomain)
 import Galley.App
+import Galley.Cassandra.Paging
 import qualified Galley.Data as Data
 import qualified Galley.Data.Conversation as Data
 import Galley.Effects
@@ -476,15 +477,19 @@ sitemap = do
     capture "tid"
 
 rmUser ::
-  forall r.
-  Members
-    '[ BrigAccess,
-       ConversationStore,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess
-     ]
-    r =>
+  forall p r.
+  ( p ~ CassandraPaging,
+    Members
+      '[ BrigAccess,
+         ConversationStore,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         ListItems p ConvId,
+         ListItems p (Remote ConvId)
+       ]
+      r
+  ) =>
   UserId ->
   Maybe ConnId ->
   Galley r ()

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -53,6 +53,7 @@ import Galley.API.Update (removeMemberFromLocalConv)
 import Galley.API.Util
 import Galley.App
 import qualified Galley.Data as Data
+import qualified Galley.Data.Conversation as Data
 import Galley.Data.LegalHold (isTeamLegalholdWhitelisted)
 import qualified Galley.Data.LegalHold as LegalHoldData
 import qualified Galley.Data.TeamFeatures as TeamFeatures
@@ -132,7 +133,16 @@ getSettings zusr tid = do
     (True, Just result) -> viewLegalHoldService result
 
 removeSettingsH ::
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   UserId ::: TeamId ::: JsonRequest Public.RemoveLegalHoldSettingsRequest ::: JSON ->
   Galley r Response
 removeSettingsH (zusr ::: tid ::: req ::: _) = do
@@ -141,7 +151,16 @@ removeSettingsH (zusr ::: tid ::: req ::: _) = do
   pure noContent
 
 removeSettings ::
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   UserId ->
   TeamId ->
   Public.RemoveLegalHoldSettingsRequest ->
@@ -169,7 +188,16 @@ removeSettings zusr tid (Public.RemoveLegalHoldSettingsRequest mPassword) = do
 -- | Remove legal hold settings from team; also disabling for all users and removing LH devices
 removeSettings' ::
   forall r.
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   TeamId ->
   Galley r ()
 removeSettings' tid = do
@@ -228,7 +256,16 @@ getUserStatus tid uid = do
 -- @withdrawExplicitConsentH@ (lots of corner cases we'd have to implement for that to pan
 -- out).
 grantConsentH ::
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   UserId ::: TeamId ::: JSON ->
   Galley r Response
 grantConsentH (zusr ::: tid ::: _) = do
@@ -241,7 +278,16 @@ data GrantConsentResult
   | GrantConsentAlreadyGranted
 
 grantConsent ::
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   UserId ->
   TeamId ->
   Galley r GrantConsentResult
@@ -258,7 +304,16 @@ grantConsent zusr tid = do
 
 -- | Request to provision a device on the legal hold service for a user
 requestDeviceH ::
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   UserId ::: TeamId ::: UserId ::: JSON ->
   Galley r Response
 requestDeviceH (zusr ::: tid ::: uid ::: _) = do
@@ -272,7 +327,16 @@ data RequestDeviceResult
 
 requestDevice ::
   forall r.
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   UserId ->
   TeamId ->
   UserId ->
@@ -319,7 +383,16 @@ requestDevice zusr tid uid = do
 -- it gets interupted. There's really no reason to delete them anyways
 -- since they are replaced if needed when registering new LH devices.
 approveDeviceH ::
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   UserId ::: TeamId ::: UserId ::: ConnId ::: JsonRequest Public.ApproveLegalHoldForUserRequest ::: JSON ->
   Galley r Response
 approveDeviceH (zusr ::: tid ::: uid ::: connId ::: req ::: _) = do
@@ -328,7 +401,16 @@ approveDeviceH (zusr ::: tid ::: uid ::: connId ::: req ::: _) = do
   pure empty
 
 approveDevice ::
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   UserId ->
   TeamId ->
   UserId ->
@@ -372,7 +454,16 @@ approveDevice zusr tid uid connId (Public.ApproveLegalHoldForUserRequest mPasswo
         UserLegalHoldNoConsent -> throwM userLegalHoldNotPending
 
 disableForUserH ::
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   UserId ::: TeamId ::: UserId ::: JsonRequest Public.DisableLegalHoldForUserRequest ::: JSON ->
   Galley r Response
 disableForUserH (zusr ::: tid ::: uid ::: req ::: _) = do
@@ -387,7 +478,16 @@ data DisableLegalHoldForUserResponse
 
 disableForUser ::
   forall r.
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   UserId ->
   TeamId ->
   UserId ->
@@ -419,7 +519,16 @@ disableForUser zusr tid uid (Public.DisableLegalHoldForUserRequest mPassword) = 
 -- or disabled, make sure the affected connections are screened for policy conflict (anybody
 -- with no-consent), and put those connections in the appropriate blocked state.
 changeLegalholdStatus ::
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   TeamId ->
   UserId ->
   UserLegalHoldStatus ->
@@ -530,7 +639,16 @@ getTeamLegalholdWhitelistedH tid = do
 -- contains the hypothetical new LH status of `uid`'s so it can be consulted instead of the
 -- one from the database.
 handleGroupConvPolicyConflicts ::
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   UserId ->
   UserLegalHoldStatus ->
   Galley r ()

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -154,6 +154,7 @@ removeSettingsH ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,
@@ -178,6 +179,7 @@ removeSettings ::
     Members
       '[ BotAccess,
          BrigAccess,
+         CodeStore,
          ConversationStore,
          ExternalAccess,
          FederatorAccess,
@@ -222,6 +224,7 @@ removeSettings' ::
     Members
       '[ BotAccess,
          BrigAccess,
+         CodeStore,
          ConversationStore,
          ExternalAccess,
          FederatorAccess,
@@ -295,6 +298,7 @@ grantConsentH ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,
@@ -320,6 +324,7 @@ grantConsent ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,
@@ -351,6 +356,7 @@ requestDeviceH ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,
@@ -377,6 +383,7 @@ requestDevice ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,
@@ -436,6 +443,7 @@ approveDeviceH ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,
@@ -457,6 +465,7 @@ approveDevice ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,
@@ -515,6 +524,7 @@ disableForUserH ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,
@@ -542,6 +552,7 @@ disableForUser ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,
@@ -588,6 +599,7 @@ changeLegalholdStatus ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,
@@ -715,6 +727,7 @@ handleGroupConvPolicyConflicts ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -52,6 +52,7 @@ import Galley.API.Query (iterateConversations)
 import Galley.API.Update (removeMemberFromLocalConv)
 import Galley.API.Util
 import Galley.App
+import Galley.Cassandra.Paging
 import qualified Galley.Data as Data
 import qualified Galley.Data.Conversation as Data
 import Galley.Data.LegalHold (isTeamLegalholdWhitelisted)
@@ -140,7 +141,8 @@ removeSettingsH ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   UserId ::: TeamId ::: JsonRequest Public.RemoveLegalHoldSettingsRequest ::: JSON ->
@@ -158,7 +160,8 @@ removeSettings ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   UserId ->
@@ -195,7 +198,8 @@ removeSettings' ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   TeamId ->
@@ -263,7 +267,8 @@ grantConsentH ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   UserId ::: TeamId ::: JSON ->
@@ -285,7 +290,8 @@ grantConsent ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   UserId ->
@@ -311,7 +317,8 @@ requestDeviceH ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   UserId ::: TeamId ::: UserId ::: JSON ->
@@ -334,7 +341,8 @@ requestDevice ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   UserId ->
@@ -390,7 +398,8 @@ approveDeviceH ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   UserId ::: TeamId ::: UserId ::: ConnId ::: JsonRequest Public.ApproveLegalHoldForUserRequest ::: JSON ->
@@ -408,7 +417,8 @@ approveDevice ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   UserId ->
@@ -461,7 +471,8 @@ disableForUserH ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   UserId ::: TeamId ::: UserId ::: JsonRequest Public.DisableLegalHoldForUserRequest ::: JSON ->
@@ -485,7 +496,8 @@ disableForUser ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   UserId ->
@@ -526,7 +538,8 @@ changeLegalholdStatus ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   TeamId ->
@@ -646,7 +659,8 @@ handleGroupConvPolicyConflicts ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   UserId ->

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -142,7 +142,8 @@ removeSettingsH ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   UserId ::: TeamId ::: JsonRequest Public.RemoveLegalHoldSettingsRequest ::: JSON ->
@@ -161,7 +162,8 @@ removeSettings ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   UserId ->
@@ -199,7 +201,8 @@ removeSettings' ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   TeamId ->
@@ -268,7 +271,8 @@ grantConsentH ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   UserId ::: TeamId ::: JSON ->
@@ -291,7 +295,8 @@ grantConsent ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   UserId ->
@@ -318,7 +323,8 @@ requestDeviceH ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   UserId ::: TeamId ::: UserId ::: JSON ->
@@ -342,7 +348,8 @@ requestDevice ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   UserId ->
@@ -399,7 +406,8 @@ approveDeviceH ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   UserId ::: TeamId ::: UserId ::: ConnId ::: JsonRequest Public.ApproveLegalHoldForUserRequest ::: JSON ->
@@ -418,7 +426,8 @@ approveDevice ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   UserId ->
@@ -472,7 +481,8 @@ disableForUserH ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   UserId ::: TeamId ::: UserId ::: JsonRequest Public.DisableLegalHoldForUserRequest ::: JSON ->
@@ -497,7 +507,8 @@ disableForUser ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   UserId ->
@@ -539,7 +550,8 @@ changeLegalholdStatus ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   TeamId ->
@@ -660,7 +672,8 @@ handleGroupConvPolicyConflicts ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   UserId ->

--- a/services/galley/src/Galley/API/LegalHold/Conflicts.hs
+++ b/services/galley/src/Galley/API/LegalHold/Conflicts.hs
@@ -29,8 +29,8 @@ import Data.Misc
 import qualified Data.Set as Set
 import Galley.API.Util
 import Galley.App
-import qualified Galley.Data as Data
 import Galley.Effects
+import Galley.Effects.TeamStore
 import qualified Galley.Intra.Client as Intra
 import Galley.Intra.User (getUser)
 import Galley.Options
@@ -44,7 +44,7 @@ import Wire.API.User.Client as Client
 data LegalholdConflicts = LegalholdConflicts
 
 guardQualifiedLegalholdPolicyConflicts ::
-  Member BrigAccess r =>
+  Members '[BrigAccess, TeamStore] r =>
   LegalholdProtectee ->
   QualifiedUserClients ->
   Galley r (Either LegalholdConflicts ())
@@ -63,7 +63,7 @@ guardQualifiedLegalholdPolicyConflicts protectee qclients = do
 -- This is a fallback safeguard that shouldn't get triggered if backend and clients work as
 -- intended.
 guardLegalholdPolicyConflicts ::
-  Member BrigAccess r =>
+  Members '[BrigAccess, TeamStore] r =>
   LegalholdProtectee ->
   UserClients ->
   Galley r (Either LegalholdConflicts ())
@@ -78,7 +78,7 @@ guardLegalholdPolicyConflicts (ProtectedUser self) otherClients = do
 
 guardLegalholdPolicyConflictsUid ::
   forall r.
-  Member BrigAccess r =>
+  Members '[BrigAccess, TeamStore] r =>
   UserId ->
   UserClients ->
   Galley r (Either LegalholdConflicts ())
@@ -130,7 +130,7 @@ guardLegalholdPolicyConflictsUid self otherClients = runExceptT $ do
           -- (we could also get the profile from brig.  would make the code slightly more
           -- concise, but not really help with the rpc back-and-forth, so, like, why?)
           mbUser <- accountUser <$$> getUser self
-          mbTeamMember <- join <$> for (mbUser >>= userTeam) (`Data.teamMember` self)
+          mbTeamMember <- liftSem $ join <$> for (mbUser >>= userTeam) (`getTeamMember` self)
           let lhStatus = maybe defUserLegalHoldStatus (view legalHoldStatus) mbTeamMember
           pure (lhStatus == UserLegalHoldNoConsent)
 

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -32,7 +32,7 @@ import Data.Id (UserId, idToText)
 import Data.Qualified
 import Galley.API.Util (qualifyLocal)
 import Galley.App
-import qualified Galley.Data as Data
+import qualified Galley.Data.Conversation as Data
 import Galley.Data.Types (convId)
 import Galley.Types.Conversations.Members
 import Imports

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -24,9 +24,9 @@ import Data.Time.Clock (UTCTime, getCurrentTime)
 import Galley.API.LegalHold.Conflicts (guardQualifiedLegalholdPolicyConflicts)
 import Galley.API.Util
 import Galley.App
-import qualified Galley.Data as Data
 import Galley.Data.Services as Data
 import Galley.Effects
+import Galley.Effects.ClientStore
 import Galley.Effects.ConversationStore
 import Galley.Effects.MemberStore
 import qualified Galley.External as External
@@ -209,6 +209,7 @@ postQualifiedOtrMessage ::
   Members
     '[ BotAccess,
        BrigAccess,
+       ClientStore,
        ConversationStore,
        FederatorAccess,
        GundeckAccess,
@@ -257,7 +258,7 @@ postQualifiedOtrMessage senderType sender mconn convId msg = runExceptT $ do
     lift $
       if isInternal
         then Clients.fromUserClients <$> Intra.lookupClients localMemberIds
-        else Data.lookupClients localMemberIds
+        else liftSem $ getClients localMemberIds
   let qualifiedLocalClients =
         Map.mapKeys (localDomain,)
           . makeUserMap (Set.fromList (map lmId localMembers))

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -28,6 +28,7 @@ import qualified Galley.Data as Data
 import Galley.Data.Services as Data
 import Galley.Effects
 import Galley.Effects.ConversationStore
+import Galley.Effects.MemberStore
 import qualified Galley.External as External
 import qualified Galley.Intra.Client as Intra
 import Galley.Intra.Push
@@ -211,7 +212,8 @@ postQualifiedOtrMessage ::
        ConversationStore,
        FederatorAccess,
        GundeckAccess,
-       ExternalAccess
+       ExternalAccess,
+       MemberStore
      ]
     r =>
   UserType ->
@@ -233,8 +235,8 @@ postQualifiedOtrMessage senderType sender mconn convId msg = runExceptT $ do
     throwError MessageNotSentConversationNotFound
 
   -- conversation members
-  localMembers <- lift $ Data.members convId
-  remoteMembers <- lift $ Data.lookupRemoteMembers convId
+  localMembers <- lift . liftSem $ getLocalMembers convId
+  remoteMembers <- lift . liftSem $ getRemoteMembers convId
 
   let localMemberIds = lmId <$> localMembers
       localMemberMap :: Map UserId LocalMember

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -213,7 +213,8 @@ postQualifiedOtrMessage ::
        FederatorAccess,
        GundeckAccess,
        ExternalAccess,
-       MemberStore
+       MemberStore,
+       TeamStore
      ]
     r =>
   UserType ->

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -486,7 +486,7 @@ getConversationMeta cnv = liftSem $ do
       pure Nothing
 
 getConversationByReusableCode ::
-  Members '[ConversationStore, BrigAccess, TeamStore] r =>
+  Members '[CodeStore, ConversationStore, BrigAccess, TeamStore] r =>
   UserId ->
   Key ->
   Value ->

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -357,7 +357,7 @@ getConversationsInternal user mids mstart msize = do
           user
           (fromCommaSeparatedList (fromRange ids))
     getIds Nothing = do
-      r <- E.listItems @LegacyPaging @ConvId user mstart (rcast size)
+      r <- E.listItems user mstart (rcast size)
       let hasMore = Data.resultSetType r == Data.ResultSetTruncated
       pure (hasMore, Data.resultSetResult r)
 

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -51,10 +51,12 @@ import Galley.API.Error
 import qualified Galley.API.Mapping as Mapping
 import Galley.API.Util
 import Galley.App
+import Galley.Cassandra.Paging
 import qualified Galley.Data as Data
 import qualified Galley.Data.Types as Data
 import Galley.Effects
 import qualified Galley.Effects.ConversationStore as E
+import qualified Galley.Effects.Paging as E
 import Galley.Types
 import Galley.Types.Conversations.Members
 import Galley.Types.Conversations.Roles
@@ -64,6 +66,7 @@ import Network.Wai
 import Network.Wai.Predicate hiding (result, setStatus)
 import Network.Wai.Utilities
 import qualified Network.Wai.Utilities.Error as Wai
+import Polysemy
 import qualified System.Logger.Class as Logger
 import UnliftIO (pooledForConcurrentlyN)
 import Wire.API.Conversation (ConversationCoverView (..))
@@ -112,6 +115,7 @@ getUnqualifiedConversation zusr cnv = do
   Mapping.conversationView zusr c
 
 getConversation ::
+  forall r.
   Member ConversationStore r =>
   UserId ->
   Qualified ConvId ->
@@ -132,7 +136,11 @@ getConversation zusr cnv = do
         [conv] -> pure conv
         _convs -> throwM (federationUnexpectedBody "expected one conversation, got multiple")
 
-getRemoteConversations :: UserId -> [Remote ConvId] -> Galley r [Public.Conversation]
+getRemoteConversations ::
+  Member ConversationStore r =>
+  UserId ->
+  [Remote ConvId] ->
+  Galley r [Public.Conversation]
 getRemoteConversations zusr remoteConvs =
   getRemoteConversationsWithFailures zusr remoteConvs >>= \case
     -- throw first error
@@ -173,6 +181,7 @@ partitionGetConversationFailures = bimap concat concat . partitionEithers . map 
     split (FailedGetConversation convs (FailedGetConversationRemotely _)) = Right convs
 
 getRemoteConversationsWithFailures ::
+  Member ConversationStore r =>
   UserId ->
   [Remote ConvId] ->
   Galley r ([FailedGetConversation], [Public.Conversation])
@@ -181,7 +190,7 @@ getRemoteConversationsWithFailures zusr convs = do
   lusr <- qualifyLocal zusr
 
   -- get self member statuses from the database
-  statusMap <- Data.remoteConversationStatus zusr convs
+  statusMap <- liftSem $ E.getRemoteConversationStatus zusr convs
   let remoteView :: Remote FederatedGalley.RemoteConversation -> Maybe Conversation
       remoteView rconv =
         Mapping.remoteConversationView
@@ -232,10 +241,15 @@ getConversationRoles zusr cnv = do
   --       be merged with the team roles (if they exist)
   pure $ Public.ConversationRolesList wireConvRoles
 
-conversationIdsPageFromUnqualified :: UserId -> Maybe ConvId -> Maybe (Range 1 1000 Int32) -> Galley r (Public.ConversationList ConvId)
-conversationIdsPageFromUnqualified zusr start msize = do
+conversationIdsPageFromUnqualified ::
+  Member (ListItems LegacyPaging ConvId) r =>
+  UserId ->
+  Maybe ConvId ->
+  Maybe (Range 1 1000 Int32) ->
+  Galley r (Public.ConversationList ConvId)
+conversationIdsPageFromUnqualified zusr start msize = liftSem $ do
   let size = fromMaybe (toRange (Proxy @1000)) msize
-  ids <- Data.conversationIdsFrom zusr start size
+  ids <- E.listItems zusr start size
   pure $
     Public.ConversationList
       (Data.resultSetResult ids)
@@ -249,29 +263,50 @@ conversationIdsPageFromUnqualified zusr start msize = do
 --
 -- - After local conversations, remote conversations are listed ordered
 -- - lexicographically by their domain and then by their id.
-conversationIdsPageFrom :: UserId -> Public.GetPaginatedConversationIds -> Galley r Public.ConvIdsPage
+conversationIdsPageFrom ::
+  forall p r.
+  ( p ~ CassandraPaging,
+    Members '[ListItems p ConvId, ListItems p (Remote ConvId)] r
+  ) =>
+  UserId ->
+  Public.GetPaginatedConversationIds ->
+  Galley r Public.ConvIdsPage
 conversationIdsPageFrom zusr Public.GetMultiTablePageRequest {..} = do
   localDomain <- viewFederationDomain
-  case gmtprState of
-    Just (Public.ConversationPagingState Public.PagingRemotes stateBS) -> remotesOnly (mkState <$> stateBS) (fromRange gmtprSize)
+  liftSem $ case gmtprState of
+    Just (Public.ConversationPagingState Public.PagingRemotes stateBS) ->
+      remotesOnly (mkState <$> stateBS) gmtprSize
     _ -> localsAndRemotes localDomain (fmap mkState . Public.mtpsState =<< gmtprState) gmtprSize
   where
     mkState :: ByteString -> C.PagingState
     mkState = C.PagingState . LBS.fromStrict
 
-    localsAndRemotes :: Domain -> Maybe C.PagingState -> Range 1 1000 Int32 -> Galley r Public.ConvIdsPage
+    localsAndRemotes ::
+      Domain ->
+      Maybe C.PagingState ->
+      Range 1 1000 Int32 ->
+      Sem r Public.ConvIdsPage
     localsAndRemotes localDomain pagingState size = do
-      localPage <- pageToConvIdPage Public.PagingLocals . fmap (`Qualified` localDomain) <$> Data.localConversationIdsPageFrom zusr pagingState size
+      localPage <-
+        pageToConvIdPage Public.PagingLocals . fmap (`Qualified` localDomain)
+          <$> E.listItems zusr pagingState size
       let remainingSize = fromRange size - fromIntegral (length (Public.mtpResults localPage))
       if Public.mtpHasMore localPage || remainingSize <= 0
         then pure localPage {Public.mtpHasMore = True} -- We haven't checked the remotes yet, so has_more must always be True here.
         else do
-          remotePage <- remotesOnly Nothing remainingSize
+          -- remainingSize <= size and remainingSize >= 1, so it is safe to convert to Range
+          remotePage <- remotesOnly Nothing (unsafeRange remainingSize)
           pure $ remotePage {Public.mtpResults = Public.mtpResults localPage <> Public.mtpResults remotePage}
 
-    remotesOnly :: Maybe C.PagingState -> Int32 -> Galley r Public.ConvIdsPage
+    remotesOnly ::
+      Members '[ListItems p (Remote ConvId)] r =>
+      Maybe C.PagingState ->
+      Range 1 1000 Int32 ->
+      Sem r Public.ConvIdsPage
     remotesOnly pagingState size =
-      pageToConvIdPage Public.PagingRemotes <$> Data.remoteConversationIdsPageFrom zusr pagingState size
+      pageToConvIdPage Public.PagingRemotes
+        . fmap (qUntagged @'QRemote)
+        <$> E.listItems zusr pagingState size
 
     pageToConvIdPage :: Public.LocalOrRemoteTable -> Data.PageWithState (Qualified ConvId) -> Public.ConvIdsPage
     pageToConvIdPage table page@Data.PageWithState {..} =
@@ -282,7 +317,7 @@ conversationIdsPageFrom zusr Public.GetMultiTablePageRequest {..} = do
         }
 
 getConversations ::
-  Member ConversationStore r =>
+  Members '[ListItems LegacyPaging ConvId, ConversationStore] r =>
   UserId ->
   Maybe (Range 1 32 (CommaSeparatedList ConvId)) ->
   Maybe ConvId ->
@@ -293,38 +328,44 @@ getConversations user mids mstart msize = do
   flip ConversationList more <$> mapM (Mapping.conversationView user) cs
 
 getConversationsInternal ::
-  forall r.
-  Member ConversationStore r =>
+  Members '[ConversationStore, ListItems LegacyPaging ConvId] r =>
   UserId ->
   Maybe (Range 1 32 (CommaSeparatedList ConvId)) ->
   Maybe ConvId ->
   Maybe (Range 1 500 Int32) ->
   Galley r (Public.ConversationList Data.Conversation)
 getConversationsInternal user mids mstart msize = do
-  (more, ids) <- getIds mids
+  (more, ids) <- liftSem $ getIds mids
   let localConvIds = ids
   cs <-
     liftSem (E.getConversations localConvIds)
-      >>= filterM removeDeleted
+      >>= filterM (liftSem . removeDeleted)
       >>= filterM (pure . isMember user . Data.convLocalMembers)
   pure $ Public.ConversationList cs more
   where
     size = fromMaybe (toRange (Proxy @32)) msize
 
     -- get ids and has_more flag
+    getIds ::
+      Members '[ConversationStore, ListItems LegacyPaging ConvId] r =>
+      Maybe (Range 1 32 (CommaSeparatedList ConvId)) ->
+      Sem r (Bool, [ConvId])
     getIds (Just ids) =
       (False,)
-        <$> Data.localConversationIdsOf
+        <$> E.selectConversations
           user
           (fromCommaSeparatedList (fromRange ids))
     getIds Nothing = do
-      r <- Data.conversationIdsFrom user mstart (rcast size)
+      r <- E.listItems @LegacyPaging @ConvId user mstart (rcast size)
       let hasMore = Data.resultSetType r == Data.ResultSetTruncated
       pure (hasMore, Data.resultSetResult r)
 
-    removeDeleted :: Data.Conversation -> Galley r Bool
+    removeDeleted ::
+      Member ConversationStore r =>
+      Data.Conversation ->
+      Sem r Bool
     removeDeleted c
-      | Data.isConvDeleted c = liftSem $ E.deleteConversation (Data.convId c) >> pure False
+      | Data.isConvDeleted c = E.deleteConversation (Data.convId c) >> pure False
       | otherwise = pure True
 
 listConversations ::
@@ -336,7 +377,9 @@ listConversations user (Public.ListConversations ids) = do
   luser <- qualifyLocal user
 
   let (localIds, remoteIds) = partitionQualified luser (fromRange ids)
-  (foundLocalIds, notFoundLocalIds) <- foundsAndNotFounds (Data.localConversationIdsOf user) localIds
+  (foundLocalIds, notFoundLocalIds) <-
+    liftSem $
+      foundsAndNotFounds (E.selectConversations user) localIds
 
   localInternalConversations <-
     liftSem (E.getConversations foundLocalIds)
@@ -382,7 +425,7 @@ listConversations user (Public.ListConversations ids) = do
       pure (founds, notFounds)
 
 iterateConversations ::
-  Member ConversationStore r =>
+  Members '[ListItems LegacyPaging ConvId, ConversationStore] r =>
   UserId ->
   Range 1 500 Int32 ->
   ([Data.Conversation] -> Galley r a) ->

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -56,8 +56,8 @@ import qualified Galley.Data as Data
 import qualified Galley.Data.Types as Data
 import Galley.Effects
 import qualified Galley.Effects.ConversationStore as E
+import qualified Galley.Effects.ListItems as E
 import qualified Galley.Effects.MemberStore as E
-import qualified Galley.Effects.Paging as E
 import Galley.Types
 import Galley.Types.Conversations.Members
 import Galley.Types.Conversations.Roles
@@ -486,7 +486,7 @@ getConversationMeta cnv = liftSem $ do
       pure Nothing
 
 getConversationByReusableCode ::
-  Members '[ConversationStore, BrigAccess] r =>
+  Members '[ConversationStore, BrigAccess, TeamStore] r =>
   UserId ->
   Key ->
   Value ->

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -981,6 +981,7 @@ deleteTeamConversation ::
   Members
     '[ BotAccess,
        BrigAccess,
+       CodeStore,
        ConversationStore,
        ExternalAccess,
        FederatorAccess,

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -87,9 +87,9 @@ import qualified Galley.API.Update as API
 import Galley.API.Util
 import Galley.App
 import Galley.Cassandra.Paging
-import qualified Galley.Data as Data
 import qualified Galley.Data.Conversation as Data
 import qualified Galley.Data.LegalHold as Data
+import qualified Galley.Data.ResultSet as Data
 import qualified Galley.Data.SearchVisibility as SearchVisibilityData
 import Galley.Data.Services (BotMember)
 import qualified Galley.Data.TeamFeatures as TeamFeatures

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -61,7 +61,8 @@ import Brig.Types.Intra (accountUser)
 import Brig.Types.Team (TeamSize (..))
 import Control.Lens
 import Control.Monad.Catch
-import Data.ByteString.Conversion hiding (fromList)
+import Data.ByteString.Conversion (List, toByteString)
+import qualified Data.ByteString.Conversion
 import Data.ByteString.Lazy.Builder (lazyByteString)
 import qualified Data.CaseInsensitive as CI
 import Data.Csv (EncodeOptions (..), Quoting (QuoteAll), encodeDefaultOrderedByNameWith)
@@ -70,11 +71,11 @@ import Data.Id
 import qualified Data.LegalHold as LH
 import qualified Data.List.Extra as List
 import Data.List1 (list1)
+import qualified Data.Map as Map
 import qualified Data.Map.Strict as M
 import Data.Misc (HttpsUrl, mkHttpsUrl)
 import Data.Qualified
 import Data.Range as Range
-import Data.Set (fromList)
 import qualified Data.Set as Set
 import Data.Time.Clock (UTCTime (..), getCurrentTime)
 import qualified Data.UUID as UUID
@@ -92,8 +93,9 @@ import qualified Galley.Data.SearchVisibility as SearchVisibilityData
 import Galley.Data.Services (BotMember)
 import qualified Galley.Data.TeamFeatures as TeamFeatures
 import Galley.Effects
-import Galley.Effects.ConversationStore
-import Galley.Effects.MemberStore
+import qualified Galley.Effects.ConversationStore as E
+import qualified Galley.Effects.MemberStore as E
+import qualified Galley.Effects.TeamStore as E
 import qualified Galley.External as External
 import qualified Galley.Intra.Journal as Journal
 import Galley.Intra.Push
@@ -115,9 +117,9 @@ import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Predicate hiding (or, result, setStatus)
 import Network.Wai.Utilities
+import Polysemy
 import qualified SAML2.WebSSO as SAML
 import qualified System.Logger.Class as Log
-import UnliftIO.Async (mapConcurrently)
 import qualified Wire.API.Conversation.Role as Public
 import Wire.API.ErrorDescription (ConvNotFound, NotATeamMember, operationDenied)
 import qualified Wire.API.Notification as Public
@@ -133,40 +135,45 @@ import qualified Wire.API.User as U
 import Wire.API.User.Identity (UserSSOId (UserSSOId))
 import Wire.API.User.RichInfo (RichInfo)
 
-getTeamH :: UserId ::: TeamId ::: JSON -> Galley r Response
+getTeamH :: Member TeamStore r => UserId ::: TeamId ::: JSON -> Galley r Response
 getTeamH (zusr ::: tid ::: _) =
   maybe (throwM teamNotFound) (pure . json) =<< lookupTeam zusr tid
 
-getTeamInternalH :: TeamId ::: JSON -> Galley r Response
+getTeamInternalH :: Member TeamStore r => TeamId ::: JSON -> Galley r Response
 getTeamInternalH (tid ::: _) =
-  maybe (throwM teamNotFound) (pure . json) =<< getTeamInternal tid
+  maybe (throwM teamNotFound) (pure . json) =<< liftSem (E.getTeam tid)
 
-getTeamInternal :: TeamId -> Galley r (Maybe TeamData)
-getTeamInternal = Data.team
-
-getTeamNameInternalH :: TeamId ::: JSON -> Galley r Response
+getTeamNameInternalH :: Member TeamStore r => TeamId ::: JSON -> Galley r Response
 getTeamNameInternalH (tid ::: _) =
-  maybe (throwM teamNotFound) (pure . json) =<< getTeamNameInternal tid
+  maybe (throwM teamNotFound) (pure . json) =<< liftSem (getTeamNameInternal tid)
 
-getTeamNameInternal :: TeamId -> Galley r (Maybe TeamName)
-getTeamNameInternal = fmap (fmap TeamName) . Data.teamName
+getTeamNameInternal :: Member TeamStore r => TeamId -> Sem r (Maybe TeamName)
+getTeamNameInternal = fmap (fmap TeamName) . E.getTeamName
 
-getManyTeamsH :: UserId ::: Maybe (Either (Range 1 32 (List TeamId)) TeamId) ::: Range 1 100 Int32 ::: JSON -> Galley r Response
+getManyTeamsH ::
+  Member TeamStore r =>
+  UserId ::: Maybe (Either (Range 1 32 (List TeamId)) TeamId) ::: Range 1 100 Int32 ::: JSON ->
+  Galley r Response
 getManyTeamsH (zusr ::: range ::: size ::: _) =
   json <$> getManyTeams zusr range size
 
-getManyTeams :: UserId -> Maybe (Either (Range 1 32 (List TeamId)) TeamId) -> Range 1 100 Int32 -> Galley r Public.TeamList
+getManyTeams ::
+  Member TeamStore r =>
+  UserId ->
+  Maybe (Either (Range 1 32 (List TeamId)) TeamId) ->
+  Range 1 100 Int32 ->
+  Galley r Public.TeamList
 getManyTeams zusr range size =
   withTeamIds zusr range size $ \more ids -> do
     teams <- mapM (lookupTeam zusr) ids
     pure (Public.newTeamList (catMaybes teams) more)
 
-lookupTeam :: UserId -> TeamId -> Galley r (Maybe Public.Team)
+lookupTeam :: Member TeamStore r => UserId -> TeamId -> Galley r (Maybe Public.Team)
 lookupTeam zusr tid = do
-  tm <- Data.teamMember tid zusr
+  tm <- liftSem $ E.getTeamMember tid zusr
   if isJust tm
     then do
-      t <- Data.team tid
+      t <- liftSem $ E.getTeam tid
       when (Just PendingDelete == (tdStatus <$> t)) $ do
         q <- view deleteQueue
         void $ Q.tryPush q (TeamItem tid zusr Nothing)
@@ -174,7 +181,7 @@ lookupTeam zusr tid = do
     else pure Nothing
 
 createNonBindingTeamH ::
-  Members '[GundeckAccess, BrigAccess] r =>
+  Members '[GundeckAccess, BrigAccess, TeamStore] r =>
   UserId ::: ConnId ::: JsonRequest Public.NonBindingNewTeam ::: JSON ->
   Galley r Response
 createNonBindingTeamH (zusr ::: zcon ::: req ::: _) = do
@@ -183,7 +190,7 @@ createNonBindingTeamH (zusr ::: zcon ::: req ::: _) = do
   pure (empty & setStatus status201 . location newTeamId)
 
 createNonBindingTeam ::
-  Members '[BrigAccess, GundeckAccess] r =>
+  Members '[BrigAccess, GundeckAccess, TeamStore] r =>
   UserId ->
   ConnId ->
   Public.NonBindingNewTeam ->
@@ -200,12 +207,20 @@ createNonBindingTeam zusr zcon (Public.NonBindingNewTeam body) = do
   Log.debug $
     Log.field "targets" (toByteString . show $ toByteString <$> zothers)
       . Log.field "action" (Log.val "Teams.createNonBindingTeam")
-  team <- Data.createTeam Nothing zusr (body ^. newTeamName) (body ^. newTeamIcon) (body ^. newTeamIconKey) NonBinding
+  team <-
+    liftSem $
+      E.createTeam
+        Nothing
+        zusr
+        (body ^. newTeamName)
+        (body ^. newTeamIcon)
+        (body ^. newTeamIconKey)
+        NonBinding
   finishCreateTeam team owner others (Just zcon)
   pure (team ^. teamId)
 
 createBindingTeamH ::
-  Members '[BrigAccess, GundeckAccess] r =>
+  Members '[BrigAccess, GundeckAccess, TeamStore] r =>
   UserId ::: TeamId ::: JsonRequest BindingNewTeam ::: JSON ->
   Galley r Response
 createBindingTeamH (zusr ::: tid ::: req ::: _) = do
@@ -214,34 +229,39 @@ createBindingTeamH (zusr ::: tid ::: req ::: _) = do
   pure (empty & setStatus status201 . location newTeamId)
 
 createBindingTeam ::
-  Members '[BrigAccess, GundeckAccess] r =>
+  Members '[BrigAccess, GundeckAccess, TeamStore] r =>
   UserId ->
   TeamId ->
   BindingNewTeam ->
   Galley r TeamId
 createBindingTeam zusr tid (BindingNewTeam body) = do
   let owner = Public.TeamMember zusr fullPermissions Nothing LH.defUserLegalHoldStatus
-  team <- Data.createTeam (Just tid) zusr (body ^. newTeamName) (body ^. newTeamIcon) (body ^. newTeamIconKey) Binding
+  team <-
+    liftSem $
+      E.createTeam (Just tid) zusr (body ^. newTeamName) (body ^. newTeamIcon) (body ^. newTeamIconKey) Binding
   finishCreateTeam team owner [] Nothing
   pure tid
 
-updateTeamStatusH :: Member BrigAccess r => TeamId ::: JsonRequest TeamStatusUpdate ::: JSON -> Galley r Response
+updateTeamStatusH ::
+  Members '[BrigAccess, TeamStore] r =>
+  TeamId ::: JsonRequest TeamStatusUpdate ::: JSON ->
+  Galley r Response
 updateTeamStatusH (tid ::: req ::: _) = do
   teamStatusUpdate <- fromJsonBody req
   updateTeamStatus tid teamStatusUpdate
   return empty
 
-updateTeamStatus :: Member BrigAccess r => TeamId -> TeamStatusUpdate -> Galley r ()
+updateTeamStatus :: Members '[BrigAccess, TeamStore] r => TeamId -> TeamStatusUpdate -> Galley r ()
 updateTeamStatus tid (TeamStatusUpdate newStatus cur) = do
-  oldStatus <- tdStatus <$> (Data.team tid >>= ifNothing teamNotFound)
+  oldStatus <- tdStatus <$> (liftSem (E.getTeam tid) >>= ifNothing teamNotFound)
   valid <- validateTransition (oldStatus, newStatus)
   when valid $ do
     journal newStatus cur
-    Data.updateTeamStatus tid newStatus
+    liftSem $ E.setTeamStatus tid newStatus
   where
     journal Suspended _ = Journal.teamSuspend tid
     journal Active c = do
-      teamCreationTime <- Data.teamCreationTime tid
+      teamCreationTime <- liftSem $ E.getTeamCreationTime tid
       -- When teams are created, they are activated immediately. In this situation, Brig will
       -- most likely report team size as 0 due to ES taking some time to index the team creator.
       -- This is also very difficult to test, so is not tested.
@@ -262,7 +282,7 @@ updateTeamStatus tid (TeamStatusUpdate newStatus cur) = do
       (_, _) -> throwM invalidTeamStatusUpdate
 
 updateTeamH ::
-  Member GundeckAccess r =>
+  Members '[GundeckAccess, TeamStore] r =>
   UserId ::: ConnId ::: TeamId ::: JsonRequest Public.TeamUpdateData ::: JSON ->
   Galley r Response
 updateTeamH (zusr ::: zcon ::: tid ::: req ::: _) = do
@@ -271,28 +291,28 @@ updateTeamH (zusr ::: zcon ::: tid ::: req ::: _) = do
   pure empty
 
 updateTeam ::
-  Member GundeckAccess r =>
+  Members '[GundeckAccess, TeamStore] r =>
   UserId ->
   ConnId ->
   TeamId ->
   Public.TeamUpdateData ->
   Galley r ()
 updateTeam zusr zcon tid updateData = do
-  zusrMembership <- Data.teamMember tid zusr
+  zusrMembership <- liftSem $ E.getTeamMember tid zusr
   -- let zothers = map (view userId) membs
   -- Log.debug $
   --   Log.field "targets" (toByteString . show $ toByteString <$> zothers)
   --     . Log.field "action" (Log.val "Teams.updateTeam")
   void $ permissionCheck SetTeamData zusrMembership
-  Data.updateTeam tid updateData
+  liftSem $ E.setTeamData tid updateData
   now <- liftIO getCurrentTime
-  memList <- Data.teamMembersForFanout tid
+  memList <- getTeamMembersForFanout tid
   let e = newEvent TeamUpdate tid now & eventData .~ Just (EdTeamUpdate updateData)
   let r = list1 (userRecipient zusr) (membersToRecipients (Just zusr) (memList ^. teamMembers))
   push1 $ newPushLocal1 (memList ^. teamMemberListType) zusr (TeamEvent e) r & pushConn .~ Just zcon
 
 deleteTeamH ::
-  Member BrigAccess r =>
+  Members '[BrigAccess, TeamStore] r =>
   UserId ::: ConnId ::: TeamId ::: OptionalJsonRequest Public.TeamDeleteData ::: JSON ->
   Galley r Response
 deleteTeamH (zusr ::: zcon ::: tid ::: req ::: _) = do
@@ -302,14 +322,14 @@ deleteTeamH (zusr ::: zcon ::: tid ::: req ::: _) = do
 
 -- | 'TeamDeleteData' is only required for binding teams
 deleteTeam ::
-  Member BrigAccess r =>
+  Members '[BrigAccess, TeamStore] r =>
   UserId ->
   ConnId ->
   TeamId ->
   Maybe Public.TeamDeleteData ->
   Galley r ()
 deleteTeam zusr zcon tid mBody = do
-  team <- Data.team tid >>= ifNothing teamNotFound
+  team <- liftSem (E.getTeam tid) >>= ifNothing teamNotFound
   case tdStatus team of
     Deleted ->
       throwM teamNotFound
@@ -320,18 +340,18 @@ deleteTeam zusr zcon tid mBody = do
       queueTeamDeletion tid zusr (Just zcon)
   where
     checkPermissions team = do
-      void $ permissionCheck DeleteTeam =<< Data.teamMember tid zusr
+      void $ permissionCheck DeleteTeam =<< liftSem (E.getTeamMember tid zusr)
       when ((tdTeam team) ^. teamBinding == Binding) $ do
         body <- mBody & ifNothing (invalidPayload "missing request body")
         ensureReAuthorised zusr (body ^. tdAuthPassword)
 
 -- This can be called by stern
-internalDeleteBindingTeamWithOneMember :: TeamId -> Galley r ()
+internalDeleteBindingTeamWithOneMember :: Member TeamStore r => TeamId -> Galley r ()
 internalDeleteBindingTeamWithOneMember tid = do
-  team <- Data.team tid
+  team <- liftSem (E.getTeam tid)
   unless ((view teamBinding . tdTeam <$> team) == Just Binding) $
     throwM noBindingTeam
-  mems <- Data.teamMembersWithLimit tid (unsafeRange 2)
+  mems <- liftSem $ E.getTeamMembersWithLimit tid (unsafeRange 2)
   case mems ^. teamMembers of
     (mem : []) -> queueTeamDeletion tid (mem ^. userId) Nothing
     _ -> throwM notAOneMemberTeam
@@ -339,23 +359,33 @@ internalDeleteBindingTeamWithOneMember tid = do
 -- This function is "unchecked" because it does not validate that the user has the `DeleteTeam` permission.
 uncheckedDeleteTeam ::
   forall r.
-  Members '[BrigAccess, ExternalAccess, GundeckAccess, MemberStore, SparAccess] r =>
+  Members
+    '[ BrigAccess,
+       ExternalAccess,
+       GundeckAccess,
+       MemberStore,
+       SparAccess,
+       TeamStore
+     ]
+    r =>
   UserId ->
   Maybe ConnId ->
   TeamId ->
   Galley r ()
 uncheckedDeleteTeam zusr zcon tid = do
-  team <- Data.team tid
+  team <- liftSem $ E.getTeam tid
   when (isJust team) $ do
     Spar.deleteTeam tid
     now <- liftIO getCurrentTime
-    convs <- filter (not . view managedConversation) <$> Data.teamConversations tid
+    convs <-
+      liftSem $
+        filter (not . view managedConversation) <$> E.getTeamConversations tid
     -- Even for LARGE TEAMS, we _DO_ want to fetch all team members here because we
     -- want to generate conversation deletion events for non-team users. This should
     -- be fine as it is done once during the life team of a team and we still do not
     -- fanout this particular event to all team members anyway. And this is anyway
     -- done asynchronously
-    membs <- Data.teamMembersCollectedWithPagination tid
+    membs <- liftSem $ E.getTeamMembers tid
     (ue, be) <- foldrM (createConvDeleteEvents now membs) ([], []) convs
     let e = newEvent TeamDelete tid now
     pushDeleteEvents membs e ue
@@ -367,7 +397,7 @@ uncheckedDeleteTeam zusr zcon tid = do
       mapM_ (deleteUser . view userId) membs
       Journal.teamDelete tid
     Data.unsetTeamLegalholdWhitelisted tid
-    Data.deleteTeam tid
+    liftSem $ E.deleteTeam tid
   where
     pushDeleteEvents :: [TeamMember] -> Event -> [Push] -> Galley r ()
     pushDeleteEvents membs e ue = do
@@ -397,7 +427,7 @@ uncheckedDeleteTeam zusr zcon tid = do
       localDomain <- viewFederationDomain
       let qconvId = Qualified (c ^. conversationId) localDomain
           qorig = Qualified zusr localDomain
-      (bots, convMembs) <- liftSem $ localBotsAndUsers <$> getLocalMembers (c ^. conversationId)
+      (bots, convMembs) <- liftSem $ localBotsAndUsers <$> E.getLocalMembers (c ^. conversationId)
       -- Only nonTeamMembers need to get any events, since on team deletion,
       -- all team users are deleted immediately after these events are sent
       -- and will thus never be able to see these events in practice.
@@ -409,9 +439,13 @@ uncheckedDeleteTeam zusr zcon tid = do
       let pp' = maybe pp (\x -> (x & pushConn .~ zcon) : pp) p
       pure (pp', ee' ++ ee)
 
-getTeamConversationRoles :: UserId -> TeamId -> Galley r Public.ConversationRolesList
+getTeamConversationRoles ::
+  Member TeamStore r =>
+  UserId ->
+  TeamId ->
+  Galley r Public.ConversationRolesList
 getTeamConversationRoles zusr tid = do
-  mem <- Data.teamMember tid zusr
+  mem <- liftSem $ E.getTeamMember tid zusr
   case mem of
     Nothing -> throwErrorDescriptionType @NotATeamMember
     Just _ -> do
@@ -419,26 +453,34 @@ getTeamConversationRoles zusr tid = do
       --       be merged with the team roles (if they exist)
       pure $ Public.ConversationRolesList wireConvRoles
 
-getTeamMembersH :: UserId ::: TeamId ::: Range 1 Public.HardTruncationLimit Int32 ::: JSON -> Galley r Response
+getTeamMembersH ::
+  Member TeamStore r =>
+  UserId ::: TeamId ::: Range 1 Public.HardTruncationLimit Int32 ::: JSON ->
+  Galley r Response
 getTeamMembersH (zusr ::: tid ::: maxResults ::: _) = do
   (memberList, withPerms) <- getTeamMembers zusr tid maxResults
   pure . json $ teamMemberListJson withPerms memberList
 
-getTeamMembers :: UserId -> TeamId -> Range 1 Public.HardTruncationLimit Int32 -> Galley r (Public.TeamMemberList, Public.TeamMember -> Bool)
+getTeamMembers ::
+  Member TeamStore r =>
+  UserId ->
+  TeamId ->
+  Range 1 Public.HardTruncationLimit Int32 ->
+  Galley r (Public.TeamMemberList, Public.TeamMember -> Bool)
 getTeamMembers zusr tid maxResults = do
-  Data.teamMember tid zusr >>= \case
+  liftSem (E.getTeamMember tid zusr) >>= \case
     Nothing -> throwErrorDescriptionType @NotATeamMember
     Just m -> do
-      mems <- Data.teamMembersWithLimit tid maxResults
+      mems <- liftSem $ E.getTeamMembersWithLimit tid maxResults
       let withPerms = (m `canSeePermsOf`)
       pure (mems, withPerms)
 
 getTeamMembersCSVH ::
-  Member BrigAccess r =>
+  Members '[BrigAccess, TeamStore] r =>
   UserId ::: TeamId ::: JSON ->
   Galley r Response
 getTeamMembersCSVH (zusr ::: tid ::: _) = do
-  Data.teamMember tid zusr >>= \case
+  liftSem (E.getTeamMember tid zusr) >>= \case
     Nothing -> throwM accessDenied
     Just member -> unless (member `hasPermission` DownloadTeamMembersCsv) $ throwM accessDenied
 
@@ -539,66 +581,97 @@ getTeamMembersCSVH (zusr ::: tid ::: _) = do
         (UserSSOId (SAML.UserRef _idp nameId)) -> Just . CI.original . SAML.unsafeShowNameID $ nameId
         (UserScimExternalId _) -> Nothing
 
-bulkGetTeamMembersH :: UserId ::: TeamId ::: Range 1 Public.HardTruncationLimit Int32 ::: JsonRequest Public.UserIdList ::: JSON -> Galley r Response
+bulkGetTeamMembersH ::
+  Member TeamStore r =>
+  UserId ::: TeamId ::: Range 1 Public.HardTruncationLimit Int32 ::: JsonRequest Public.UserIdList ::: JSON ->
+  Galley r Response
 bulkGetTeamMembersH (zusr ::: tid ::: maxResults ::: body ::: _) = do
   UserIdList uids <- fromJsonBody body
   (memberList, withPerms) <- bulkGetTeamMembers zusr tid maxResults uids
   pure . json $ teamMemberListJson withPerms memberList
 
 -- | like 'getTeamMembers', but with an explicit list of users we are to return.
-bulkGetTeamMembers :: UserId -> TeamId -> Range 1 HardTruncationLimit Int32 -> [UserId] -> Galley r (TeamMemberList, TeamMember -> Bool)
+bulkGetTeamMembers ::
+  Member TeamStore r =>
+  UserId ->
+  TeamId ->
+  Range 1 HardTruncationLimit Int32 ->
+  [UserId] ->
+  Galley r (TeamMemberList, TeamMember -> Bool)
 bulkGetTeamMembers zusr tid maxResults uids = do
   unless (length uids <= fromIntegral (fromRange maxResults)) $
     throwM bulkGetMemberLimitExceeded
-  Data.teamMember tid zusr >>= \case
+  liftSem (E.getTeamMember tid zusr) >>= \case
     Nothing -> throwErrorDescriptionType @NotATeamMember
-    Just m -> do
-      mems <- Data.teamMembersLimited tid uids
+    Just m -> liftSem $ do
+      mems <- E.selectTeamMembers tid uids
       let withPerms = (m `canSeePermsOf`)
           hasMore = ListComplete
       pure (newTeamMemberList mems hasMore, withPerms)
 
-getTeamMemberH :: UserId ::: TeamId ::: UserId ::: JSON -> Galley r Response
+getTeamMemberH ::
+  Member TeamStore r =>
+  UserId ::: TeamId ::: UserId ::: JSON ->
+  Galley r Response
 getTeamMemberH (zusr ::: tid ::: uid ::: _) = do
   (member, withPerms) <- getTeamMember zusr tid uid
   pure . json $ teamMemberJson withPerms member
 
-getTeamMember :: UserId -> TeamId -> UserId -> Galley r (Public.TeamMember, Public.TeamMember -> Bool)
+getTeamMember ::
+  Member TeamStore r =>
+  UserId ->
+  TeamId ->
+  UserId ->
+  Galley r (Public.TeamMember, Public.TeamMember -> Bool)
 getTeamMember zusr tid uid = do
-  zusrMembership <- Data.teamMember tid zusr
+  zusrMembership <- liftSem $ E.getTeamMember tid zusr
   case zusrMembership of
     Nothing -> throwErrorDescriptionType @NotATeamMember
     Just m -> do
       let withPerms = (m `canSeePermsOf`)
-      Data.teamMember tid uid >>= \case
+      liftSem (E.getTeamMember tid uid) >>= \case
         Nothing -> throwM teamMemberNotFound
         Just member -> pure (member, withPerms)
 
-internalDeleteBindingTeamWithOneMemberH :: TeamId -> Galley r Response
+internalDeleteBindingTeamWithOneMemberH ::
+  Member TeamStore r =>
+  TeamId ->
+  Galley r Response
 internalDeleteBindingTeamWithOneMemberH tid = do
   internalDeleteBindingTeamWithOneMember tid
   pure (empty & setStatus status202)
 
-uncheckedGetTeamMemberH :: TeamId ::: UserId ::: JSON -> Galley r Response
+uncheckedGetTeamMemberH ::
+  Member TeamStore r =>
+  TeamId ::: UserId ::: JSON ->
+  Galley r Response
 uncheckedGetTeamMemberH (tid ::: uid ::: _) = do
   json <$> uncheckedGetTeamMember tid uid
 
-uncheckedGetTeamMember :: TeamId -> UserId -> Galley r TeamMember
+uncheckedGetTeamMember ::
+  Member TeamStore r =>
+  TeamId ->
+  UserId ->
+  Galley r TeamMember
 uncheckedGetTeamMember tid uid = do
-  Data.teamMember tid uid >>= ifNothing teamMemberNotFound
+  liftSem (E.getTeamMember tid uid) >>= ifNothing teamMemberNotFound
 
-uncheckedGetTeamMembersH :: TeamId ::: Range 1 HardTruncationLimit Int32 ::: JSON -> Galley r Response
+uncheckedGetTeamMembersH ::
+  Member TeamStore r =>
+  TeamId ::: Range 1 HardTruncationLimit Int32 ::: JSON ->
+  Galley r Response
 uncheckedGetTeamMembersH (tid ::: maxResults ::: _) = do
   json <$> uncheckedGetTeamMembers tid maxResults
 
 uncheckedGetTeamMembers ::
+  Member TeamStore r =>
   TeamId ->
   Range 1 HardTruncationLimit Int32 ->
   Galley r TeamMemberList
-uncheckedGetTeamMembers tid maxResults = Data.teamMembersWithLimit tid maxResults
+uncheckedGetTeamMembers tid maxResults = liftSem $ E.getTeamMembersWithLimit tid maxResults
 
 addTeamMemberH ::
-  Members '[BrigAccess, GundeckAccess, MemberStore] r =>
+  Members '[BrigAccess, GundeckAccess, MemberStore, TeamStore] r =>
   UserId ::: ConnId ::: TeamId ::: JsonRequest Public.NewTeamMember ::: JSON ->
   Galley r Response
 addTeamMemberH (zusr ::: zcon ::: tid ::: req ::: _) = do
@@ -607,7 +680,7 @@ addTeamMemberH (zusr ::: zcon ::: tid ::: req ::: _) = do
   pure empty
 
 addTeamMember ::
-  Members '[BrigAccess, GundeckAccess, MemberStore] r =>
+  Members '[BrigAccess, GundeckAccess, MemberStore, TeamStore] r =>
   UserId ->
   ConnId ->
   TeamId ->
@@ -620,7 +693,7 @@ addTeamMember zusr zcon tid nmem = do
       . Log.field "action" (Log.val "Teams.addTeamMember")
   -- verify permissions
   zusrMembership <-
-    Data.teamMember tid zusr
+    liftSem (E.getTeamMember tid zusr)
       >>= permissionCheck AddTeamMember
   let targetPermissions = nmem ^. ntmNewTeamMember . permissions
   targetPermissions `ensureNotElevated` zusrMembership
@@ -629,12 +702,12 @@ addTeamMember zusr zcon tid nmem = do
   ensureConnectedToLocals zusr [uid]
   (TeamSize sizeBeforeJoin) <- BrigTeam.getSize tid
   ensureNotTooLargeForLegalHold tid (fromIntegral sizeBeforeJoin + 1)
-  memList <- Data.teamMembersForFanout tid
+  memList <- getTeamMembersForFanout tid
   void $ addTeamMemberInternal tid (Just zusr) (Just zcon) nmem memList
 
 -- This function is "unchecked" because there is no need to check for user binding (invite only).
 uncheckedAddTeamMemberH ::
-  Members '[BrigAccess, GundeckAccess, MemberStore] r =>
+  Members '[BrigAccess, GundeckAccess, MemberStore, TeamStore] r =>
   TeamId ::: JsonRequest NewTeamMember ::: JSON ->
   Galley r Response
 uncheckedAddTeamMemberH (tid ::: req ::: _) = do
@@ -643,12 +716,12 @@ uncheckedAddTeamMemberH (tid ::: req ::: _) = do
   return empty
 
 uncheckedAddTeamMember ::
-  Members '[BrigAccess, GundeckAccess, MemberStore] r =>
+  Members '[BrigAccess, GundeckAccess, MemberStore, TeamStore] r =>
   TeamId ->
   NewTeamMember ->
   Galley r ()
 uncheckedAddTeamMember tid nmem = do
-  mems <- Data.teamMembersForFanout tid
+  mems <- getTeamMembersForFanout tid
   (TeamSize sizeBeforeJoin) <- BrigTeam.getSize tid
   ensureNotTooLargeForLegalHold tid (fromIntegral sizeBeforeJoin + 1)
   (TeamSize sizeBeforeAdd) <- addTeamMemberInternal tid Nothing Nothing nmem mems
@@ -656,7 +729,7 @@ uncheckedAddTeamMember tid nmem = do
   Journal.teamUpdate tid (sizeBeforeAdd + 1) billingUserIds
 
 updateTeamMemberH ::
-  Members '[BrigAccess, GundeckAccess] r =>
+  Members '[BrigAccess, GundeckAccess, TeamStore] r =>
   UserId ::: ConnId ::: TeamId ::: JsonRequest Public.NewTeamMember ::: JSON ->
   Galley r Response
 updateTeamMemberH (zusr ::: zcon ::: tid ::: req ::: _) = do
@@ -667,7 +740,7 @@ updateTeamMemberH (zusr ::: zcon ::: tid ::: req ::: _) = do
 
 updateTeamMember ::
   forall r.
-  Members '[BrigAccess, GundeckAccess] r =>
+  Members '[BrigAccess, GundeckAccess, TeamStore] r =>
   UserId ->
   ConnId ->
   TeamId ->
@@ -681,15 +754,15 @@ updateTeamMember zusr zcon tid targetMember = do
       . Log.field "action" (Log.val "Teams.updateTeamMember")
 
   -- get the team and verify permissions
-  team <- tdTeam <$> (Data.team tid >>= ifNothing teamNotFound)
+  team <- tdTeam <$> (liftSem (E.getTeam tid) >>= ifNothing teamNotFound)
   user <-
-    Data.teamMember tid zusr
+    liftSem (E.getTeamMember tid zusr)
       >>= permissionCheck SetMemberPermissions
 
   -- user may not elevate permissions
   targetPermissions `ensureNotElevated` user
   previousMember <-
-    Data.teamMember tid targetId >>= \case
+    liftSem (E.getTeamMember tid targetId) >>= \case
       Nothing ->
         -- target user must be in same team
         throwM teamMemberNotFound
@@ -701,9 +774,9 @@ updateTeamMember zusr zcon tid targetMember = do
     $ throwM accessDenied
 
   -- update target in Cassandra
-  Data.updateTeamMember (previousMember ^. permissions) tid targetId targetPermissions
+  liftSem $ E.setTeamMemberPermissions (previousMember ^. permissions) tid targetId targetPermissions
 
-  updatedMembers <- Data.teamMembersForFanout tid
+  updatedMembers <- getTeamMembersForFanout tid
   updateJournal team updatedMembers
   updatePeers targetId targetPermissions updatedMembers
   where
@@ -736,7 +809,15 @@ updateTeamMember zusr zcon tid targetMember = do
       for_ pushPriv $ \p -> push1 $ p & pushConn .~ Just zcon
 
 deleteTeamMemberH ::
-  Members '[BrigAccess, ConversationStore, ExternalAccess, GundeckAccess, MemberStore] r =>
+  Members
+    '[ BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       GundeckAccess,
+       MemberStore,
+       TeamStore
+     ]
+    r =>
   UserId ::: ConnId ::: TeamId ::: UserId ::: OptionalJsonRequest Public.TeamMemberDeleteData ::: JSON ->
   Galley r Response
 deleteTeamMemberH (zusr ::: zcon ::: tid ::: remove ::: req ::: _) = do
@@ -751,7 +832,15 @@ data TeamMemberDeleteResult
 
 -- | 'TeamMemberDeleteData' is only required for binding teams
 deleteTeamMember ::
-  Members '[BrigAccess, ConversationStore, ExternalAccess, GundeckAccess, MemberStore] r =>
+  Members
+    '[ BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       GundeckAccess,
+       MemberStore,
+       TeamStore
+     ]
+    r =>
   UserId ->
   ConnId ->
   TeamId ->
@@ -762,15 +851,15 @@ deleteTeamMember zusr zcon tid remove mBody = do
   Log.debug $
     Log.field "targets" (toByteString remove)
       . Log.field "action" (Log.val "Teams.deleteTeamMember")
-  zusrMember <- Data.teamMember tid zusr
-  targetMember <- Data.teamMember tid remove
+  zusrMember <- liftSem $ E.getTeamMember tid zusr
+  targetMember <- liftSem $ E.getTeamMember tid remove
   void $ permissionCheck RemoveTeamMember zusrMember
   do
     dm <- maybe (throwM teamMemberNotFound) pure zusrMember
     tm <- maybe (throwM teamMemberNotFound) pure targetMember
     unless (canDeleteMember dm tm) $ throwM accessDenied
-  team <- tdTeam <$> (Data.team tid >>= ifNothing teamNotFound)
-  mems <- Data.teamMembersForFanout tid
+  team <- tdTeam <$> (liftSem (E.getTeam tid) >>= ifNothing teamNotFound)
+  mems <- getTeamMembersForFanout tid
   if team ^. teamBinding == Binding && isJust targetMember
     then do
       body <- mBody & ifNothing (invalidPayload "missing request body")
@@ -794,7 +883,15 @@ deleteTeamMember zusr zcon tid remove mBody = do
 -- This function is "unchecked" because it does not validate that the user has the `RemoveTeamMember` permission.
 uncheckedDeleteTeamMember ::
   forall r.
-  Members '[BrigAccess, ConversationStore, GundeckAccess, ExternalAccess, MemberStore] r =>
+  Members
+    '[ BrigAccess,
+       ConversationStore,
+       GundeckAccess,
+       ExternalAccess,
+       MemberStore,
+       TeamStore
+     ]
+    r =>
   UserId ->
   Maybe ConnId ->
   TeamId ->
@@ -804,7 +901,7 @@ uncheckedDeleteTeamMember ::
 uncheckedDeleteTeamMember zusr zcon tid remove mems = do
   now <- liftIO getCurrentTime
   pushMemberLeaveEvent now
-  Data.removeTeamMember tid remove
+  liftSem $ E.deleteTeamMember tid remove
   removeFromConvsAndPushConvLeaveEvent now
   where
     -- notify all team members.
@@ -822,11 +919,11 @@ uncheckedDeleteTeamMember zusr zcon tid remove mems = do
       localDomain <- viewFederationDomain
       let tmids = Set.fromList $ map (view userId) (mems ^. teamMembers)
       let edata = Conv.EdMembersLeave (Conv.QualifiedUserIdList [Qualified remove localDomain])
-      cc <- Data.teamConversations tid
+      cc <- liftSem $ E.getTeamConversations tid
       for_ cc $ \c ->
-        liftSem (getConversation (c ^. conversationId)) >>= \conv ->
+        liftSem (E.getConversation (c ^. conversationId)) >>= \conv ->
           for_ conv $ \dc -> when (remove `isMember` Data.convLocalMembers dc) $ do
-            liftSem $ deleteMembers (c ^. conversationId) (UserList [remove] [])
+            liftSem $ E.deleteMembers (c ^. conversationId) (UserList [remove] [])
             -- If the list was truncated, then the tmids list is incomplete so we simply drop these events
             unless (c ^. managedConversation || mems ^. teamMemberListType == ListTruncated) $
               pushEvent tmids edata now dc
@@ -842,19 +939,33 @@ uncheckedDeleteTeamMember zusr zcon tid remove mems = do
         push1 $ p & pushConn .~ zcon
       External.deliverAsync (bots `zip` repeat y)
 
-getTeamConversations :: UserId -> TeamId -> Galley r Public.TeamConversationList
+getTeamConversations ::
+  Member TeamStore r =>
+  UserId ->
+  TeamId ->
+  Galley r Public.TeamConversationList
 getTeamConversations zusr tid = do
-  tm <- Data.teamMember tid zusr >>= ifNothing (errorDescriptionTypeToWai @NotATeamMember)
+  tm <-
+    liftSem (E.getTeamMember tid zusr)
+      >>= ifNothing (errorDescriptionTypeToWai @NotATeamMember)
   unless (tm `hasPermission` GetTeamConversations) $
     throwErrorDescription (operationDenied GetTeamConversations)
-  Public.newTeamConversationList <$> Data.teamConversations tid
+  liftSem $ Public.newTeamConversationList <$> E.getTeamConversations tid
 
-getTeamConversation :: UserId -> TeamId -> ConvId -> Galley r Public.TeamConversation
+getTeamConversation ::
+  Member TeamStore r =>
+  UserId ->
+  TeamId ->
+  ConvId ->
+  Galley r Public.TeamConversation
 getTeamConversation zusr tid cid = do
-  tm <- Data.teamMember tid zusr >>= ifNothing (errorDescriptionTypeToWai @NotATeamMember)
+  tm <-
+    liftSem (E.getTeamMember tid zusr)
+      >>= ifNothing (errorDescriptionTypeToWai @NotATeamMember)
   unless (tm `hasPermission` GetTeamConversations) $
     throwErrorDescription (operationDenied GetTeamConversations)
-  Data.teamConversation tid cid >>= maybe (throwErrorDescriptionType @ConvNotFound) pure
+  liftSem (E.getTeamConversation tid cid)
+    >>= maybe (throwErrorDescriptionType @ConvNotFound) pure
 
 deleteTeamConversation ::
   Members
@@ -865,7 +976,8 @@ deleteTeamConversation ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       MemberStore
+       MemberStore,
+       TeamStore
      ]
     r =>
   UserId ->
@@ -878,15 +990,21 @@ deleteTeamConversation zusr zcon _tid cid = do
   lconv <- qualifyLocal cid
   void $ API.deleteLocalConversation lusr zcon lconv
 
-getSearchVisibilityH :: UserId ::: TeamId ::: JSON -> Galley r Response
+getSearchVisibilityH ::
+  Member TeamStore r =>
+  UserId ::: TeamId ::: JSON ->
+  Galley r Response
 getSearchVisibilityH (uid ::: tid ::: _) = do
-  zusrMembership <- Data.teamMember tid uid
+  zusrMembership <- liftSem $ E.getTeamMember tid uid
   void $ permissionCheck ViewTeamSearchVisibility zusrMembership
   json <$> getSearchVisibilityInternal tid
 
-setSearchVisibilityH :: UserId ::: TeamId ::: JsonRequest Public.TeamSearchVisibilityView ::: JSON -> Galley r Response
+setSearchVisibilityH ::
+  Member TeamStore r =>
+  UserId ::: TeamId ::: JsonRequest Public.TeamSearchVisibilityView ::: JSON ->
+  Galley r Response
 setSearchVisibilityH (uid ::: tid ::: req ::: _) = do
-  zusrMembership <- Data.teamMember tid uid
+  zusrMembership <- liftSem $ E.getTeamMember tid uid
   void $ permissionCheck ChangeTeamSearchVisibility zusrMembership
   setSearchVisibilityInternal tid =<< fromJsonBody req
   pure noContent
@@ -904,6 +1022,7 @@ setSearchVisibilityH (uid ::: tid ::: req ::: _) = do
 -- user. Additionally 'k' is passed in a 'hasMore' indication (which is
 -- always false if the third lookup-case is used).
 withTeamIds ::
+  Member TeamStore r =>
   UserId ->
   Maybe (Either (Range 1 32 (List TeamId)) TeamId) ->
   Range 1 100 Int32 ->
@@ -916,24 +1035,23 @@ withTeamIds usr range size k = case range of
   Just (Right c) -> do
     r <- Data.teamIdsFrom usr (Just c) (rcast size)
     k (Data.resultSetType r == Data.ResultSetTruncated) (Data.resultSetResult r)
-  Just (Left cc) -> do
-    ids <- Data.teamIdsOf usr cc
+  Just (Left (fromRange -> cc)) -> do
+    ids <- liftSem (E.selectTeams usr (Data.ByteString.Conversion.fromList cc))
     k False ids
 {-# INLINE withTeamIds #-}
 
-ensureUnboundUsers :: [UserId] -> Galley r ()
+ensureUnboundUsers :: Member TeamStore r => [UserId] -> Galley r ()
 ensureUnboundUsers uids = do
   -- We check only 1 team because, by definition, users in binding teams
   -- can only be part of one team.
-  ts <- liftGalley0 $ mapConcurrently Data.oneUserTeam uids
-  let teams = toList $ fromList (catMaybes ts)
-  binds <- liftGalley0 $ mapConcurrently Data.teamBinding teams
-  when (any ((==) (Just Binding)) binds) $
+  teams <- liftSem $ Map.elems <$> E.getUsersTeams uids
+  binds <- liftSem $ E.getTeamsBindings teams
+  when (any (== Binding) binds) $
     throwM userBindingExists
 
-ensureNonBindingTeam :: TeamId -> Galley r ()
+ensureNonBindingTeam :: Member TeamStore r => TeamId -> Galley r ()
 ensureNonBindingTeam tid = do
-  team <- Data.team tid >>= ifNothing teamNotFound
+  team <- liftSem (E.getTeam tid) >>= ifNothing teamNotFound
   when ((tdTeam team) ^. teamBinding == Binding) $
     throwM noAddToBinding
 
@@ -970,7 +1088,7 @@ ensureNotTooLargeForLegalHold tid teamSize = do
     unlessM (teamSizeBelowLimit teamSize) $ do
       throwM tooManyTeamMembersOnTeamWithLegalhold
 
-ensureNotTooLargeToActivateLegalHold :: Member BrigAccess r => TeamId -> Galley r ()
+ensureNotTooLargeToActivateLegalHold :: Members '[BrigAccess] r => TeamId -> Galley r ()
 ensureNotTooLargeToActivateLegalHold tid = do
   (TeamSize teamSize) <- BrigTeam.getSize tid
   unlessM (teamSizeBelowLimit (fromIntegral teamSize)) $ do
@@ -988,7 +1106,7 @@ teamSizeBelowLimit teamSize = do
       pure True
 
 addTeamMemberInternal ::
-  Members '[BrigAccess, GundeckAccess, MemberStore] r =>
+  Members '[BrigAccess, GundeckAccess, MemberStore, TeamStore] r =>
   TeamId ->
   Maybe UserId ->
   Maybe ConnId ->
@@ -1000,13 +1118,13 @@ addTeamMemberInternal tid origin originConn (view ntmNewTeamMember -> new) memLi
     Log.field "targets" (toByteString (new ^. userId))
       . Log.field "action" (Log.val "Teams.addTeamMemberInternal")
   sizeBeforeAdd <- ensureNotTooLarge tid
-  Data.addTeamMember tid new
-  cc <- filter (view managedConversation) <$> Data.teamConversations tid
+  liftSem $ E.createTeamMember tid new
+  cc <- liftSem $ filter (view managedConversation) <$> E.getTeamConversations tid
   now <- liftIO getCurrentTime
   for_ cc $ \c -> do
     lcid <- qualifyLocal (c ^. conversationId)
     luid <- qualifyLocal (new ^. userId)
-    liftSem $ createMember lcid luid
+    liftSem $ E.createMember lcid luid
   let e = newEvent MemberJoin tid now & eventData ?~ EdMemberJoin (new ^. userId)
   push1 $ newPushLocal1 (memList ^. teamMemberListType) (new ^. userId) (TeamEvent e) (recipients origin new) & pushConn .~ originConn
   APITeamQueue.pushTeamEvent tid e
@@ -1050,7 +1168,7 @@ getTeamNotificationsH (zusr ::: sinceRaw ::: size ::: _) = do
     isV1UUID u = if UUID.version u == 1 then Just u else Nothing
 
 finishCreateTeam ::
-  Member GundeckAccess r =>
+  Members '[GundeckAccess, TeamStore] r =>
   Team ->
   TeamMember ->
   [TeamMember] ->
@@ -1058,33 +1176,34 @@ finishCreateTeam ::
   Galley r ()
 finishCreateTeam team owner others zcon = do
   let zusr = owner ^. userId
-  for_ (owner : others) $
-    Data.addTeamMember (team ^. teamId)
+  liftSem $
+    for_ (owner : others) $
+      E.createTeamMember (team ^. teamId)
   now <- liftIO getCurrentTime
   let e = newEvent TeamCreate (team ^. teamId) now & eventData ?~ EdTeamCreate team
   let r = membersToRecipients Nothing others
   push1 $ newPushLocal1 ListComplete zusr (TeamEvent e) (list1 (userRecipient zusr) r) & pushConn .~ zcon
 
-withBindingTeam :: UserId -> (TeamId -> Galley r b) -> Galley r b
+withBindingTeam :: Member TeamStore r => UserId -> (TeamId -> Galley r b) -> Galley r b
 withBindingTeam zusr callback = do
-  tid <- Data.oneUserTeam zusr >>= ifNothing teamNotFound
-  binding <- Data.teamBinding tid >>= ifNothing teamNotFound
+  tid <- liftSem (E.getOneUserTeam zusr) >>= ifNothing teamNotFound
+  binding <- liftSem (E.getTeamBinding tid) >>= ifNothing teamNotFound
   case binding of
     Binding -> callback tid
     NonBinding -> throwM nonBindingTeam
 
-getBindingTeamIdH :: UserId -> Galley r Response
+getBindingTeamIdH :: Member TeamStore r => UserId -> Galley r Response
 getBindingTeamIdH = fmap json . getBindingTeamId
 
-getBindingTeamId :: UserId -> Galley r TeamId
+getBindingTeamId :: Member TeamStore r => UserId -> Galley r TeamId
 getBindingTeamId zusr = withBindingTeam zusr pure
 
-getBindingTeamMembersH :: UserId -> Galley r Response
+getBindingTeamMembersH :: Member TeamStore r => UserId -> Galley r Response
 getBindingTeamMembersH = fmap json . getBindingTeamMembers
 
-getBindingTeamMembers :: UserId -> Galley r TeamMemberList
+getBindingTeamMembers :: Member TeamStore r => UserId -> Galley r TeamMemberList
 getBindingTeamMembers zusr = withBindingTeam zusr $ \tid ->
-  Data.teamMembersForFanout tid
+  getTeamMembersForFanout tid
 
 canUserJoinTeamH :: Member BrigAccess r => TeamId -> Galley r Response
 canUserJoinTeamH tid = canUserJoinTeam tid >> pure empty
@@ -1129,13 +1248,13 @@ setSearchVisibilityInternal tid (TeamSearchVisibilityView searchVisibility) = do
     throwM teamSearchVisibilityNotEnabled
   SearchVisibilityData.setSearchVisibility tid searchVisibility
 
-userIsTeamOwnerH :: TeamId ::: UserId ::: JSON -> Galley r Response
+userIsTeamOwnerH :: Member TeamStore r => TeamId ::: UserId ::: JSON -> Galley r Response
 userIsTeamOwnerH (tid ::: uid ::: _) = do
   userIsTeamOwner tid uid >>= \case
     True -> pure empty
     False -> throwM accessDenied
 
-userIsTeamOwner :: TeamId -> UserId -> Galley r Bool
+userIsTeamOwner :: Member TeamStore r => TeamId -> UserId -> Galley r Bool
 userIsTeamOwner tid uid = do
   let asking = uid
   isTeamOwner . fst <$> getTeamMember asking tid uid

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -63,6 +63,7 @@ import Galley.Cassandra.Paging
 import qualified Galley.Data.SearchVisibility as SearchVisibilityData
 import qualified Galley.Data.TeamFeatures as TeamFeatures
 import Galley.Effects
+import Galley.Effects.Paging
 import Galley.Effects.TeamStore
 import Galley.Intra.Push (PushEvent (FeatureConfigEvent), newPush, push1)
 import Galley.Options
@@ -320,19 +321,23 @@ getLegalholdStatusInternal (Right tid) = do
     False -> Public.TeamFeatureStatusNoConfig Public.TeamFeatureDisabled
 
 setLegalholdStatusInternal ::
-  Members
-    '[ BotAccess,
-       BrigAccess,
-       ConversationStore,
-       ExternalAccess,
-       FederatorAccess,
-       FireAndForget,
-       GundeckAccess,
-       ListItems LegacyPaging ConvId,
-       MemberStore,
-       TeamStore
-     ]
-    r =>
+  ( Paging p,
+    Bounded (PagingBounds p TeamMember),
+    Members
+      '[ BotAccess,
+         BrigAccess,
+         ConversationStore,
+         ExternalAccess,
+         FederatorAccess,
+         FireAndForget,
+         GundeckAccess,
+         ListItems LegacyPaging ConvId,
+         MemberStore,
+         TeamStore,
+         TeamMemberStore p
+       ]
+      r
+  ) =>
   TeamId ->
   Public.TeamFeatureStatus 'Public.TeamFeatureLegalHold ->
   Galley r (Public.TeamFeatureStatus 'Public.TeamFeatureLegalHold)

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -318,7 +318,16 @@ getLegalholdStatusInternal (Right tid) = do
     False -> Public.TeamFeatureStatusNoConfig Public.TeamFeatureDisabled
 
 setLegalholdStatusInternal ::
-  Members '[BotAccess, BrigAccess, ExternalAccess, FederatorAccess, FireAndForget, GundeckAccess] r =>
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ConversationStore,
+       ExternalAccess,
+       FederatorAccess,
+       FireAndForget,
+       GundeckAccess
+     ]
+    r =>
   TeamId ->
   Public.TeamFeatureStatus 'Public.TeamFeatureLegalHold ->
   Galley r (Public.TeamFeatureStatus 'Public.TeamFeatureLegalHold)

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -326,6 +326,7 @@ setLegalholdStatusInternal ::
     Members
       '[ BotAccess,
          BrigAccess,
+         CodeStore,
          ConversationStore,
          ExternalAccess,
          FederatorAccess,

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -327,7 +327,8 @@ setLegalholdStatusInternal ::
        FederatorAccess,
        FireAndForget,
        GundeckAccess,
-       ListItems LegacyPaging ConvId
+       ListItems LegacyPaging ConvId,
+       MemberStore
      ]
     r =>
   TeamId ->

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -59,6 +59,7 @@ import Galley.API.LegalHold
 import Galley.API.Teams (ensureNotTooLargeToActivateLegalHold)
 import Galley.API.Util
 import Galley.App
+import Galley.Cassandra.Paging
 import qualified Galley.Data as Data
 import qualified Galley.Data.SearchVisibility as SearchVisibilityData
 import qualified Galley.Data.TeamFeatures as TeamFeatures
@@ -325,7 +326,8 @@ setLegalholdStatusInternal ::
        ExternalAccess,
        FederatorAccess,
        FireAndForget,
-       GundeckAccess
+       GundeckAccess,
+       ListItems LegacyPaging ConvId
      ]
     r =>
   TeamId ->

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 
 -- This file is part of the Wire Server implementation.
@@ -88,6 +87,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Galley.API.Error
 import qualified Galley.Aws as Aws
+import Galley.Cassandra.Client
 import Galley.Cassandra.Conversation
 import Galley.Cassandra.Conversation.Members
 import Galley.Cassandra.ConversationList
@@ -364,6 +364,7 @@ interpretGalleyToGalley0 =
     . withLH interpretTeamStoreToCassandra
     . interpretMemberStoreToCassandra
     . interpretConversationStoreToCassandra
+    . interpretClientStoreToCassandra
     . interpretFireAndForget
     . interpretIntra
     . interpretBot

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -354,6 +354,7 @@ interpretTeamStoreToCassandraWithEnv action = do
 interpretGalleyToGalley0 :: Galley GalleyEffects a -> Galley0 a
 interpretGalleyToGalley0 =
   Galley
+    . interpretTeamListToCassandra
     . interpretLegacyConversationListToCassandra
     . interpretRemoteConversationListToCassandra
     . interpretConversationListToCassandra

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -89,6 +89,7 @@ import qualified Data.Text.Encoding as Text
 import Galley.API.Error
 import qualified Galley.Aws as Aws
 import Galley.Cassandra.Conversation
+import Galley.Cassandra.Conversation.Members
 import Galley.Cassandra.ConversationList
 import Galley.Effects
 import qualified Galley.Effects.FireAndForget as E
@@ -347,6 +348,7 @@ interpretGalleyToGalley0 =
     . interpretLegacyConversationListToCassandra
     . interpretRemoteConversationListToCassandra
     . interpretConversationListToCassandra
+    . interpretMemberStoreToCassandra
     . interpretConversationStoreToCassandra
     . interpretFireAndForget
     . interpretIntra

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -88,6 +88,7 @@ import qualified Data.Text.Encoding as Text
 import Galley.API.Error
 import qualified Galley.Aws as Aws
 import Galley.Cassandra.Client
+import Galley.Cassandra.Code
 import Galley.Cassandra.Conversation
 import Galley.Cassandra.Conversation.Members
 import Galley.Cassandra.ConversationList
@@ -364,6 +365,7 @@ interpretGalleyToGalley0 =
     . withLH interpretTeamStoreToCassandra
     . interpretMemberStoreToCassandra
     . interpretConversationStoreToCassandra
+    . interpretCodeStoreToCassandra
     . interpretClientStoreToCassandra
     . interpretFireAndForget
     . interpretIntra

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -92,6 +92,7 @@ import Galley.Cassandra.Code
 import Galley.Cassandra.Conversation
 import Galley.Cassandra.Conversation.Members
 import Galley.Cassandra.ConversationList
+import Galley.Cassandra.Services
 import Galley.Cassandra.Team
 import Galley.Effects
 import qualified Galley.Effects.FireAndForget as E
@@ -363,6 +364,7 @@ interpretGalleyToGalley0 =
     . interpretConversationListToCassandra
     . withLH interpretTeamMemberStoreToCassandra
     . withLH interpretTeamStoreToCassandra
+    . interpretServiceStoreToCassandra
     . interpretMemberStoreToCassandra
     . interpretConversationStoreToCassandra
     . interpretCodeStoreToCassandra

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -77,10 +77,8 @@ import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import Data.ByteString.Conversion (toByteString')
 import Data.Default (def)
-import Data.Id (ConnId, TeamId, UserId)
 import qualified Data.List.NonEmpty as NE
 import Data.Metrics.Middleware
-import Data.Misc (Fingerprint, Rsa)
 import qualified Data.ProtocolBuffers as Proto
 import Data.Proxy (Proxy (..))
 import Data.Range
@@ -90,8 +88,10 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Galley.API.Error
 import qualified Galley.Aws as Aws
+import Galley.Cassandra.Conversation
 import Galley.Effects
 import qualified Galley.Effects.FireAndForget as E
+import Galley.Env
 import Galley.Options
 import qualified Galley.Queue as Q
 import qualified Galley.Types.Teams as Teams
@@ -111,45 +111,18 @@ import qualified OpenSSL.X509.SystemStore as Ssl
 import Polysemy
 import Polysemy.Internal (Append)
 import qualified Polysemy.Reader as P
+import qualified Polysemy.TinyLog as P
 import qualified Servant
 import Ssl.Util
-import System.Logger.Class hiding (Error, info)
+import System.Logger.Class
 import qualified System.Logger.Extended as Logger
 import qualified UnliftIO.Exception as UnliftIO
 import Util.Options
 import Wire.API.Federation.Client (HasFederatorConfig (..))
 
-data DeleteItem = TeamItem TeamId UserId (Maybe ConnId)
-  deriving (Eq, Ord, Show)
-
--- | Main application environment.
-data Env = Env
-  { _reqId :: RequestId,
-    _monitor :: Metrics,
-    _options :: Opts,
-    _applog :: Logger,
-    _manager :: Manager,
-    _federator :: Maybe Endpoint, -- FUTUREWORK: should we use a better type here? E.g. to avoid fresh connections all the time?
-    _brig :: Endpoint, -- FUTUREWORK: see _federator
-    _cstate :: ClientState,
-    _deleteQueue :: Q.Queue DeleteItem,
-    _extEnv :: ExtEnv,
-    _aEnv :: Maybe Aws.Env
-  }
-
--- | Environment specific to the communication with external
--- service providers.
-data ExtEnv = ExtEnv
-  { _extGetManager :: (Manager, [Fingerprint Rsa] -> Ssl.SSL -> IO ())
-  }
-
-makeLenses ''Env
-
-makeLenses ''ExtEnv
-
 -- MTL-style effects derived from the old implementation of the Galley monad.
 -- They will disappear as we introduce more high-level effects into Galley.
-type GalleyEffects0 = '[P.Reader ClientState, P.Reader Env, Embed IO, Final IO]
+type GalleyEffects0 = '[P.TinyLog, P.Reader ClientState, P.Reader Env, Embed IO, Final IO]
 
 type GalleyEffects = Append GalleyEffects1 GalleyEffects0
 
@@ -198,7 +171,7 @@ currentFanoutLimit o = do
   unsafeRange (min maxTeamSize optFanoutLimit)
 
 -- Define some invariants for the options used
-validateOptions :: Logger.Logger -> Opts -> IO ()
+validateOptions :: Logger -> Opts -> IO ()
 validateOptions l o = do
   let settings = view optSettings o
       optFanoutLimit = fromIntegral . fromRange $ currentFanoutLimit o
@@ -221,9 +194,7 @@ validateOptions l o = do
     error "setMaxTeamSize cannot be < setTruncationLimit"
 
 instance MonadLogger (Galley r) where
-  log l m = do
-    e <- ask
-    Logger.log (e ^. applog) l (reqIdMsg (e ^. reqId) . m)
+  log l m = Galley $ P.polylog l m
 
 instance MonadHttp (Galley r) where
   handleRequestWithCont req handler = do
@@ -314,6 +285,15 @@ evalGalley0 e =
     . embedToFinal @IO
     . P.runReader e
     . P.runReader (e ^. cstate)
+    . interpretTinyLog e
+
+interpretTinyLog ::
+  Members '[Embed IO] r =>
+  Env ->
+  Sem (P.TinyLog ': r) a ->
+  Sem r a
+interpretTinyLog e = interpret $ \case
+  P.Polylog l m -> Logger.log (e ^. applog) l (reqIdMsg (e ^. reqId) . m)
 
 evalGalley :: Env -> Galley GalleyEffects a -> IO a
 evalGalley e = evalGalley0 e . unGalley . interpretGalleyToGalley0
@@ -321,7 +301,7 @@ evalGalley e = evalGalley0 e . unGalley . interpretGalleyToGalley0
 lookupReqId :: Request -> RequestId
 lookupReqId = maybe def RequestId . lookup requestIdName . requestHeaders
 
-reqIdMsg :: RequestId -> Msg -> Msg
+reqIdMsg :: RequestId -> Logger.Msg -> Logger.Msg
 reqIdMsg = ("request" .=) . unRequestId
 {-# INLINE reqIdMsg #-}
 
@@ -360,6 +340,20 @@ toServantHandler env galley = do
     mkCode = statusCode . WaiError.code
     mkPhrase = Text.unpack . Text.decodeUtf8 . statusMessage . WaiError.code
 
+interpretGalleyToGalley0 :: Galley GalleyEffects a -> Galley0 a
+interpretGalleyToGalley0 =
+  Galley
+    . interpretConversationStoreToCassandra
+    . interpretFireAndForget
+    . interpretIntra
+    . interpretBot
+    . interpretFederator
+    . interpretExternal
+    . interpretSpar
+    . interpretGundeck
+    . interpretBrig
+    . unGalley
+
 ----------------------------------------------------------------------------------
 ---- temporary MonadUnliftIO support code for the polysemy refactoring
 
@@ -393,16 +387,3 @@ liftGalley0 (Galley m) = Galley $ subsume_ m
 
 liftSem :: Sem r a -> Galley r a
 liftSem m = Galley m
-
-interpretGalleyToGalley0 :: Galley GalleyEffects a -> Galley0 a
-interpretGalleyToGalley0 =
-  Galley
-    . interpretFireAndForget
-    . interpretIntra
-    . interpretBot
-    . interpretFederator
-    . interpretExternal
-    . interpretSpar
-    . interpretGundeck
-    . interpretBrig
-    . unGalley

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -89,6 +89,7 @@ import qualified Data.Text.Encoding as Text
 import Galley.API.Error
 import qualified Galley.Aws as Aws
 import Galley.Cassandra.Conversation
+import Galley.Cassandra.ConversationList
 import Galley.Effects
 import qualified Galley.Effects.FireAndForget as E
 import Galley.Env
@@ -343,6 +344,9 @@ toServantHandler env galley = do
 interpretGalleyToGalley0 :: Galley GalleyEffects a -> Galley0 a
 interpretGalleyToGalley0 =
   Galley
+    . interpretLegacyConversationListToCassandra
+    . interpretRemoteConversationListToCassandra
+    . interpretConversationListToCassandra
     . interpretConversationStoreToCassandra
     . interpretFireAndForget
     . interpretIntra

--- a/services/galley/src/Galley/Cassandra.hs
+++ b/services/galley/src/Galley/Cassandra.hs
@@ -1,6 +1,6 @@
 -- This file is part of the Wire Server implementation.
 --
--- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
 --
 -- This program is free software: you can redistribute it and/or modify it under
 -- the terms of the GNU Affero General Public License as published by the Free
@@ -15,30 +15,9 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Data
-  ( ResultSet,
-    ResultSetType (..),
-    PageWithState (..),
-    mkResultSet,
-    resultSetType,
-    resultSetResult,
-    schemaVersion,
+module Galley.Cassandra (schemaVersion) where
 
-    -- * Utilities
-    localOne2OneConvId,
-
-    -- * Defaults
-    defRole,
-    defRegularConvAccess,
-  )
-where
-
-import Cassandra
-import Galley.Data.Access
-import Galley.Data.Conversation
-import Galley.Data.Instances ()
-import Galley.Data.ResultSet
-import Imports hiding (Set, max)
+import Imports
 
 schemaVersion :: Int32
 schemaVersion = 54

--- a/services/galley/src/Galley/Cassandra/Client.hs
+++ b/services/galley/src/Galley/Cassandra/Client.hs
@@ -1,0 +1,64 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Cassandra.Client
+  ( interpretClientStoreToCassandra,
+    lookupClients,
+  )
+where
+
+import Cassandra
+import Control.Arrow
+import Data.Id
+import Data.List.Split (chunksOf)
+import Galley.Cassandra.Store
+import qualified Galley.Data.Queries as Cql
+import Galley.Effects.ClientStore (ClientStore (..))
+import Galley.Types.Clients (Clients)
+import qualified Galley.Types.Clients as Clients
+import Imports
+import Polysemy
+import qualified Polysemy.Reader as P
+import qualified UnliftIO
+
+updateClient :: Bool -> UserId -> ClientId -> Client ()
+updateClient add usr cls = do
+  let q = if add then Cql.addMemberClient else Cql.rmMemberClient
+  retry x5 $ write (q cls) (params Quorum (Identity usr))
+
+-- Do, at most, 16 parallel lookups of up to 128 users each
+lookupClients :: [UserId] -> Client Clients
+lookupClients users =
+  Clients.fromList . concat . concat
+    <$> forM (chunksOf 2048 users) (UnliftIO.mapConcurrently getClients . chunksOf 128)
+  where
+    getClients us =
+      map (second fromSet)
+        <$> retry x1 (query Cql.selectClients (params Quorum (Identity us)))
+
+eraseClients :: UserId -> Client ()
+eraseClients user = retry x5 (write Cql.rmClients (params Quorum (Identity user)))
+
+interpretClientStoreToCassandra ::
+  Members '[Embed IO, P.Reader ClientState] r =>
+  Sem (ClientStore ': r) a ->
+  Sem r a
+interpretClientStoreToCassandra = interpret $ \case
+  GetClients uids -> embedClient $ lookupClients uids
+  CreateClient uid cid -> embedClient $ updateClient True uid cid
+  DeleteClient uid cid -> embedClient $ updateClient False uid cid
+  DeleteClients uid -> embedClient $ eraseClients uid

--- a/services/galley/src/Galley/Cassandra/Code.hs
+++ b/services/galley/src/Galley/Cassandra/Code.hs
@@ -1,0 +1,58 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Cassandra.Code
+  ( interpretCodeStoreToCassandra,
+  )
+where
+
+import Brig.Types.Code
+import Cassandra
+import Galley.Cassandra.Store
+import qualified Galley.Data.Queries as Cql
+import Galley.Data.Types
+import Galley.Effects.CodeStore (CodeStore (..))
+import Imports
+import Polysemy
+import qualified Polysemy.Reader as P
+
+interpretCodeStoreToCassandra ::
+  Members '[Embed IO, P.Reader ClientState] r =>
+  Sem (CodeStore ': r) a ->
+  Sem r a
+interpretCodeStoreToCassandra = interpret $ \case
+  GetCode k s -> embedClient $ lookupCode k s
+  CreateCode code -> embedClient $ insertCode code
+  DeleteCode k s -> embedClient $ deleteCode k s
+
+-- | Insert a conversation code
+insertCode :: Code -> Client ()
+insertCode c = do
+  let k = codeKey c
+  let v = codeValue c
+  let cnv = codeConversation c
+  let t = round (codeTTL c)
+  let s = codeScope c
+  retry x5 (write Cql.insertCode (params Quorum (k, v, cnv, s, t)))
+
+-- | Lookup a conversation by code.
+lookupCode :: Key -> Scope -> Client (Maybe Code)
+lookupCode k s = fmap (toCode k s) <$> retry x1 (query1 Cql.lookupCode (params Quorum (k, s)))
+
+-- | Delete a code associated with the given conversation key
+deleteCode :: Key -> Scope -> Client ()
+deleteCode k s = retry x5 $ write Cql.deleteCode (params Quorum (k, s))

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -1,0 +1,336 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Cassandra.Conversation
+  ( createConversation,
+    deleteConversation,
+    interpretConversationStoreToCassandra,
+  )
+where
+
+import Cassandra
+import Data.ByteString.Conversion
+import Data.Id
+import Data.List.NonEmpty (nonEmpty)
+import qualified Data.Map as Map
+import Data.Misc
+import Data.Qualified
+import Data.Range
+import qualified Data.UUID.Tagged as U
+import Data.UUID.V4 (nextRandom)
+import Galley.Cassandra.Conversation.Members
+import Galley.Cassandra.Store
+import Galley.Data.Access
+import Galley.Data.Conversation
+import Galley.Data.Conversation.Types
+import qualified Galley.Data.Queries as Cql
+import Galley.Effects.ConversationStore (ConversationStore (..))
+import Galley.Types.Conversations.Members
+import Galley.Types.UserList
+import Galley.Validation
+import Imports
+import Polysemy
+import qualified Polysemy.Reader as P
+import Polysemy.TinyLog
+import qualified System.Logger as Log
+import qualified UnliftIO
+import Wire.API.Conversation hiding (Conversation, Member)
+import Wire.API.Conversation.Role (roleNameWireAdmin)
+
+createConversation :: NewConversation -> Client Conversation
+createConversation (NewConversation ty usr acc arole name mtid mtimer recpt users role) = do
+  conv <- Id <$> liftIO nextRandom
+  retry x5 $ case mtid of
+    Nothing ->
+      write Cql.insertConv (params Quorum (conv, ty, usr, Set (toList acc), arole, fmap fromRange name, Nothing, mtimer, recpt))
+    Just tid -> batch $ do
+      setType BatchLogged
+      setConsistency Quorum
+      addPrepQuery Cql.insertConv (conv, ty, usr, Set (toList acc), arole, fmap fromRange name, Just tid, mtimer, recpt)
+      addPrepQuery Cql.insertTeamConv (tid, conv, False)
+  let newUsers = fmap (,role) (fromConvSize users)
+  (lmems, rmems) <- addMembers conv (ulAddLocal (usr, roleNameWireAdmin) newUsers)
+  pure $
+    Conversation
+      { convId = conv,
+        convType = ty,
+        convCreator = usr,
+        convName = fmap fromRange name,
+        convAccess = acc,
+        convAccessRole = arole,
+        convLocalMembers = lmems,
+        convRemoteMembers = rmems,
+        convTeam = mtid,
+        convDeleted = Nothing,
+        convMessageTimer = mtimer,
+        convReceiptMode = recpt
+      }
+
+createConnectConversation ::
+  U.UUID U.V4 ->
+  U.UUID U.V4 ->
+  Maybe (Range 1 256 Text) ->
+  Client Conversation
+createConnectConversation a b name = do
+  let conv = localOne2OneConvId a b
+      a' = Id . U.unpack $ a
+  retry x5 $
+    write Cql.insertConv (params Quorum (conv, ConnectConv, a', privateOnly, privateRole, fromRange <$> name, Nothing, Nothing, Nothing))
+  -- We add only one member, second one gets added later,
+  -- when the other user accepts the connection request.
+  (lmems, rmems) <- addMembers conv (UserList [a'] [])
+  pure
+    Conversation
+      { convId = conv,
+        convType = ConnectConv,
+        convCreator = a',
+        convName = fmap fromRange name,
+        convAccess = [PrivateAccess],
+        convAccessRole = privateRole,
+        convLocalMembers = lmems,
+        convRemoteMembers = rmems,
+        convTeam = Nothing,
+        convDeleted = Nothing,
+        convMessageTimer = Nothing,
+        convReceiptMode = Nothing
+      }
+
+createConnectConversationWithRemote ::
+  ConvId ->
+  UserId ->
+  UserList UserId ->
+  Client Conversation
+createConnectConversationWithRemote cid creator m = do
+  retry x5 $
+    write Cql.insertConv (params Quorum (cid, ConnectConv, creator, privateOnly, privateRole, Nothing, Nothing, Nothing, Nothing))
+  -- We add only one member, second one gets added later,
+  -- when the other user accepts the connection request.
+  (lmems, rmems) <- addMembers cid m
+  pure
+    Conversation
+      { convId = cid,
+        convType = ConnectConv,
+        convCreator = creator,
+        convName = Nothing,
+        convAccess = [PrivateAccess],
+        convAccessRole = privateRole,
+        convLocalMembers = lmems,
+        convRemoteMembers = rmems,
+        convTeam = Nothing,
+        convDeleted = Nothing,
+        convMessageTimer = Nothing,
+        convReceiptMode = Nothing
+      }
+
+createLegacyOne2OneConversation ::
+  Local x ->
+  U.UUID U.V4 ->
+  U.UUID U.V4 ->
+  Maybe (Range 1 256 Text) ->
+  Maybe TeamId ->
+  Client Conversation
+createLegacyOne2OneConversation loc a b name ti = do
+  let conv = localOne2OneConvId a b
+      a' = Id (U.unpack a)
+      b' = Id (U.unpack b)
+  createOne2OneConversation
+    conv
+    (qualifyAs loc a')
+    (qUntagged (qualifyAs loc b'))
+    name
+    ti
+
+createOne2OneConversation ::
+  ConvId ->
+  Local UserId ->
+  Qualified UserId ->
+  Maybe (Range 1 256 Text) ->
+  Maybe TeamId ->
+  Client Conversation
+createOne2OneConversation conv self other name mtid = do
+  retry x5 $ case mtid of
+    Nothing -> write Cql.insertConv (params Quorum (conv, One2OneConv, tUnqualified self, privateOnly, privateRole, fromRange <$> name, Nothing, Nothing, Nothing))
+    Just tid -> batch $ do
+      setType BatchLogged
+      setConsistency Quorum
+      addPrepQuery Cql.insertConv (conv, One2OneConv, tUnqualified self, privateOnly, privateRole, fromRange <$> name, Just tid, Nothing, Nothing)
+      addPrepQuery Cql.insertTeamConv (tid, conv, False)
+  (lmems, rmems) <- addMembers conv (toUserList self [qUntagged self, other])
+  pure
+    Conversation
+      { convId = conv,
+        convType = ConnectConv,
+        convCreator = tUnqualified self,
+        convName = fmap fromRange name,
+        convAccess = [PrivateAccess],
+        convAccessRole = privateRole,
+        convLocalMembers = lmems,
+        convRemoteMembers = rmems,
+        convTeam = Nothing,
+        convDeleted = Nothing,
+        convMessageTimer = Nothing,
+        convReceiptMode = Nothing
+      }
+
+createSelfConversation :: Local UserId -> Maybe (Range 1 256 Text) -> Client Conversation
+createSelfConversation lusr name = do
+  let usr = tUnqualified lusr
+      conv = selfConv usr
+      lconv = qualifyAs lusr conv
+  retry x5 $
+    write Cql.insertConv (params Quorum (conv, SelfConv, usr, privateOnly, privateRole, fromRange <$> name, Nothing, Nothing, Nothing))
+  (lmems, rmems) <- addMembers (tUnqualified lconv) (UserList [tUnqualified lusr] [])
+  pure
+    Conversation
+      { convId = conv,
+        convType = SelfConv,
+        convCreator = usr,
+        convName = fmap fromRange name,
+        convAccess = [PrivateAccess],
+        convAccessRole = privateRole,
+        convLocalMembers = lmems,
+        convRemoteMembers = rmems,
+        convTeam = Nothing,
+        convDeleted = Nothing,
+        convMessageTimer = Nothing,
+        convReceiptMode = Nothing
+      }
+
+deleteConversation :: ConvId -> Client ()
+deleteConversation cid = do
+  retry x5 $ write Cql.markConvDeleted (params Quorum (Identity cid))
+
+  localMembers <- members cid
+  for_ (nonEmpty localMembers) $ \ms ->
+    removeLocalMembersFromLocalConv cid (lmId <$> ms)
+
+  remoteMembers <- lookupRemoteMembers cid
+  for_ (nonEmpty remoteMembers) $ \ms ->
+    removeRemoteMembersFromLocalConv cid (rmId <$> ms)
+
+  retry x5 $ write Cql.deleteConv (params Quorum (Identity cid))
+
+conversationMeta :: ConvId -> Client (Maybe ConversationMetadata)
+conversationMeta conv =
+  fmap toConvMeta
+    <$> retry x1 (query1 Cql.selectConv (params Quorum (Identity conv)))
+  where
+    toConvMeta (t, c, a, r, n, i, _, mt, rm) =
+      ConversationMetadata t c (defAccess t a) (maybeRole t r) n i mt rm
+
+isConvAlive :: ConvId -> Client Bool
+isConvAlive cid = do
+  result <- retry x1 (query1 Cql.isConvDeleted (params Quorum (Identity cid)))
+  case runIdentity <$> result of
+    Nothing -> pure False
+    Just Nothing -> pure True
+    Just (Just True) -> pure False
+    Just (Just False) -> pure True
+
+updateConvType :: ConvId -> ConvType -> Client ()
+updateConvType cid ty =
+  retry x5 $
+    write Cql.updateConvType (params Quorum (ty, cid))
+
+updateConvName :: ConvId -> Range 1 256 Text -> Client ()
+updateConvName cid name = retry x5 $ write Cql.updateConvName (params Quorum (fromRange name, cid))
+
+updateConvAccess :: ConvId -> ConversationAccessData -> Client ()
+updateConvAccess cid (ConversationAccessData acc role) =
+  retry x5 $
+    write Cql.updateConvAccess (params Quorum (Set (toList acc), role, cid))
+
+updateConvReceiptMode :: ConvId -> ReceiptMode -> Client ()
+updateConvReceiptMode cid receiptMode = retry x5 $ write Cql.updateConvReceiptMode (params Quorum (receiptMode, cid))
+
+updateConvMessageTimer :: ConvId -> Maybe Milliseconds -> Client ()
+updateConvMessageTimer cid mtimer = retry x5 $ write Cql.updateConvMessageTimer (params Quorum (mtimer, cid))
+
+getConversation :: ConvId -> Client (Maybe Conversation)
+getConversation conv = do
+  cdata <- UnliftIO.async $ retry x1 (query1 Cql.selectConv (params Quorum (Identity conv)))
+  remoteMems <- UnliftIO.async $ lookupRemoteMembers conv
+  mbConv <-
+    toConv conv
+      <$> members conv
+      <*> UnliftIO.wait remoteMems
+      <*> UnliftIO.wait cdata
+  return mbConv >>= conversationGC
+
+{- "Garbage collect" the conversation, i.e. the conversation may be
+   marked as deleted, in which case we delete it and return Nothing -}
+conversationGC ::
+  Maybe Conversation ->
+  Client (Maybe Conversation)
+conversationGC conv = case join (convDeleted <$> conv) of
+  (Just True) -> do
+    sequence_ $ deleteConversation . convId <$> conv
+    return Nothing
+  _ -> return conv
+
+localConversations ::
+  (Members '[Embed IO, P.Reader ClientState, TinyLog] r) =>
+  [ConvId] ->
+  Sem r [Conversation]
+localConversations [] = return []
+localConversations ids = do
+  cs <- embedClient $ do
+    convs <- UnliftIO.async fetchConvs
+    mems <- UnliftIO.async $ memberLists ids
+    remoteMems <- UnliftIO.async $ remoteMemberLists ids
+    zipWith4 toConv ids
+      <$> UnliftIO.wait mems
+        <*> UnliftIO.wait remoteMems
+        <*> UnliftIO.wait convs
+  foldrM flatten [] (zip ids cs)
+  where
+    fetchConvs = do
+      cs <- retry x1 $ query Cql.selectConvs (params Quorum (Identity ids))
+      let m = Map.fromList $ map (\(c, t, u, n, a, r, i, d, mt, rm) -> (c, (t, u, n, a, r, i, d, mt, rm))) cs
+      return $ map (`Map.lookup` m) ids
+    flatten (i, c) cc = case c of
+      Nothing -> do
+        warn $ Log.msg ("No conversation for: " <> toByteString i)
+        return cc
+      Just c' -> return (c' : cc)
+
+interpretConversationStoreToCassandra ::
+  Members '[Embed IO, P.Reader ClientState, TinyLog] r =>
+  Sem (ConversationStore ': r) a ->
+  Sem r a
+interpretConversationStoreToCassandra = interpret $ \case
+  CreateConversation nc -> embedClient $ createConversation nc
+  CreateConnectConversation x y name ->
+    embedClient $ createConnectConversation x y name
+  CreateConnectConversationWithRemote cid lusr mems ->
+    embedClient $ createConnectConversationWithRemote cid lusr mems
+  CreateLegacyOne2OneConversation loc x y name tid ->
+    embedClient $ createLegacyOne2OneConversation loc x y name tid
+  CreateOne2OneConversation conv self other name mtid ->
+    embedClient $ createOne2OneConversation conv self other name mtid
+  CreateSelfConversation lusr name ->
+    embedClient $ createSelfConversation lusr name
+  GetConversation cid -> embedClient $ getConversation cid
+  GetConversations cids -> localConversations cids
+  GetConversationMetadata cid -> embedClient $ conversationMeta cid
+  IsConversationAlive cid -> embedClient $ isConvAlive cid
+  SetConversationType cid ty -> embedClient $ updateConvType cid ty
+  SetConversationName cid value -> embedClient $ updateConvName cid value
+  SetConversationAccess cid value -> embedClient $ updateConvAccess cid value
+  SetConversationReceiptMode cid value -> embedClient $ updateConvReceiptMode cid value
+  SetConversationMessageTimer cid value -> embedClient $ updateConvMessageTimer cid value
+  DeleteConversation cid -> embedClient $ deleteConversation cid

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -25,7 +25,6 @@ where
 import Cassandra
 import Data.ByteString.Conversion
 import Data.Id
-import Data.List.NonEmpty (nonEmpty)
 import qualified Data.Map as Map
 import Data.Misc
 import Data.Qualified
@@ -215,12 +214,10 @@ deleteConversation cid = do
   retry x5 $ write Cql.markConvDeleted (params Quorum (Identity cid))
 
   localMembers <- members cid
-  for_ (nonEmpty localMembers) $ \ms ->
-    removeLocalMembersFromLocalConv cid (lmId <$> ms)
-
   remoteMembers <- lookupRemoteMembers cid
-  for_ (nonEmpty remoteMembers) $ \ms ->
-    removeRemoteMembersFromLocalConv cid (rmId <$> ms)
+
+  removeMembersFromLocalConv cid $
+    UserList (lmId <$> localMembers) (rmId <$> remoteMembers)
 
   retry x5 $ write Cql.deleteConv (params Quorum (Identity cid))
 

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -34,6 +34,7 @@ import qualified Data.List.Extra as List
 import qualified Data.Map as Map
 import Data.Monoid
 import Data.Qualified
+import Galley.Cassandra.Services
 import Galley.Cassandra.Store
 import Galley.Data.Instances ()
 import qualified Galley.Data.Queries as Cql
@@ -346,6 +347,7 @@ interpretMemberStoreToCassandra = interpret $ \case
   CreateMembers cid ul -> embedClient $ addMembers cid ul
   CreateMembersInRemoteConversation rcid uids ->
     embedClient $ addLocalMembersToRemoteConv rcid uids
+  CreateBotMember sr bid cid -> embedClient $ addBotMember sr bid cid
   GetLocalMember cid uid -> embedClient $ member cid uid
   GetLocalMembers cid -> embedClient $ members cid
   GetRemoteMembers rcid -> embedClient $ lookupRemoteMembers rcid

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -1,0 +1,183 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Cassandra.Conversation.Members where
+
+import Cassandra
+import Data.Domain
+import Data.Id
+import qualified Data.List.Extra as List
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.Map as Map
+import Data.Qualified
+import Galley.Data.Instances ()
+import qualified Galley.Data.Queries as Cql
+import Galley.Types.Conversations.Members
+import Galley.Types.ToUserRole
+import Galley.Types.UserList
+import Imports
+import Wire.API.Conversation.Member
+import Wire.API.Conversation.Role
+import Wire.API.Provider.Service
+
+-- | Add members to a local conversation.
+-- Conversation is local, so we can add any member to it (including remote ones).
+-- When the role is not specified, it defaults to admin.
+-- Please make sure the conversation doesn't exceed the maximum size!
+addMembers ::
+  ToUserRole a =>
+  ConvId ->
+  UserList a ->
+  Client ([LocalMember], [RemoteMember])
+addMembers conv (fmap toUserRole -> UserList lusers rusers) = do
+  -- batch statement with 500 users are known to be above the batch size limit
+  -- and throw "Batch too large" errors. Therefor we chunk requests and insert
+  -- sequentially. (parallelizing would not aid performance as the partition
+  -- key, i.e. the convId, is on the same cassandra node)
+  -- chunk size 32 was chosen to lead to batch statements
+  -- below the batch threshold
+  -- With chunk size of 64:
+  -- [galley] Server warning: Batch for [galley_test.member, galley_test.user] is of size 7040, exceeding specified threshold of 5120 by 1920.
+  --
+  for_ (List.chunksOf 32 lusers) $ \chunk -> do
+    retry x5 . batch $ do
+      setType BatchLogged
+      setConsistency Quorum
+      for_ chunk $ \(u, r) -> do
+        -- User is local, too, so we add it to both the member and the user table
+        addPrepQuery Cql.insertMember (conv, u, Nothing, Nothing, r)
+        addPrepQuery Cql.insertUserConv (u, conv)
+
+  for_ (List.chunksOf 32 rusers) $ \chunk -> do
+    retry x5 . batch $ do
+      setType BatchLogged
+      setConsistency Quorum
+      for_ chunk $ \(qUntagged -> Qualified (uid, role) domain) -> do
+        -- User is remote, so we only add it to the member_remote_user
+        -- table, but the reverse mapping has to be done on the remote
+        -- backend; so we assume an additional call to their backend has
+        -- been (or will be) made separately. See Galley.API.Update.addMembers
+        addPrepQuery Cql.insertRemoteMember (conv, domain, uid, role)
+
+  pure (map newMemberWithRole lusers, map newRemoteMemberWithRole rusers)
+
+removeLocalMembersFromLocalConv :: ConvId -> NonEmpty UserId -> Client ()
+removeLocalMembersFromLocalConv cnv victims = do
+  retry x5 . batch $ do
+    setType BatchLogged
+    setConsistency Quorum
+    for_ victims $ \victim -> do
+      addPrepQuery Cql.removeMember (cnv, victim)
+      addPrepQuery Cql.deleteUserConv (victim, cnv)
+
+removeRemoteMembersFromLocalConv :: ConvId -> NonEmpty (Remote UserId) -> Client ()
+removeRemoteMembersFromLocalConv cnv victims = do
+  retry x5 . batch $ do
+    setType BatchLogged
+    setConsistency Quorum
+    for_ victims $ \(qUntagged -> Qualified uid domain) ->
+      addPrepQuery Cql.removeRemoteMember (cnv, domain, uid)
+
+memberLists :: [ConvId] -> Client [[LocalMember]]
+memberLists convs = do
+  mems <- retry x1 $ query Cql.selectMembers (params Quorum (Identity convs))
+  let convMembers = foldr (\m acc -> insert (mkMem m) acc) mempty mems
+  return $ map (\c -> fromMaybe [] (Map.lookup c convMembers)) convs
+  where
+    insert (_, Nothing) acc = acc
+    insert (conv, Just mem) acc =
+      let f = (Just . maybe [mem] (mem :))
+       in Map.alter f conv acc
+    mkMem (cnv, usr, srv, prv, st, omus, omur, oar, oarr, hid, hidr, crn) =
+      (cnv, toMember (usr, srv, prv, st, omus, omur, oar, oarr, hid, hidr, crn))
+
+members :: ConvId -> Client [LocalMember]
+members = fmap concat . liftClient . memberLists . pure
+
+toMemberStatus ::
+  ( -- otr muted
+    Maybe MutedStatus,
+    Maybe Text,
+    -- otr archived
+    Maybe Bool,
+    Maybe Text,
+    -- hidden
+    Maybe Bool,
+    Maybe Text
+  ) ->
+  MemberStatus
+toMemberStatus (omus, omur, oar, oarr, hid, hidr) =
+  MemberStatus
+    { msOtrMutedStatus = omus,
+      msOtrMutedRef = omur,
+      msOtrArchived = fromMaybe False oar,
+      msOtrArchivedRef = oarr,
+      msHidden = fromMaybe False hid,
+      msHiddenRef = hidr
+    }
+
+toMember ::
+  ( UserId,
+    Maybe ServiceId,
+    Maybe ProviderId,
+    Maybe Cql.MemberStatus,
+    -- otr muted
+    Maybe MutedStatus,
+    Maybe Text,
+    -- otr archived
+    Maybe Bool,
+    Maybe Text,
+    -- hidden
+    Maybe Bool,
+    Maybe Text,
+    -- conversation role name
+    Maybe RoleName
+  ) ->
+  Maybe LocalMember
+toMember (usr, srv, prv, Just 0, omus, omur, oar, oarr, hid, hidr, crn) =
+  Just $
+    LocalMember
+      { lmId = usr,
+        lmService = newServiceRef <$> srv <*> prv,
+        lmStatus = toMemberStatus (omus, omur, oar, oarr, hid, hidr),
+        lmConvRoleName = fromMaybe roleNameWireAdmin crn
+      }
+toMember _ = Nothing
+
+toRemoteMember :: UserId -> Domain -> RoleName -> RemoteMember
+toRemoteMember u d = RemoteMember (toRemoteUnsafe d u)
+
+newRemoteMemberWithRole :: Remote (UserId, RoleName) -> RemoteMember
+newRemoteMemberWithRole ur@(qUntagged -> (Qualified (u, r) _)) =
+  RemoteMember
+    { rmId = qualifyAs ur u,
+      rmConvRoleName = r
+    }
+
+remoteMemberLists :: [ConvId] -> Client [[RemoteMember]]
+remoteMemberLists convs = do
+  mems <- retry x1 $ query Cql.selectRemoteMembers (params Quorum (Identity convs))
+  let convMembers = foldr (insert . mkMem) Map.empty mems
+  return $ map (\c -> fromMaybe [] (Map.lookup c convMembers)) convs
+  where
+    insert (conv, mem) acc =
+      let f = (Just . maybe [mem] (mem :))
+       in Map.alter f conv acc
+    mkMem (cnv, domain, usr, role) = (cnv, toRemoteMember usr domain role)
+
+lookupRemoteMembers :: ConvId -> Client [RemoteMember]
+lookupRemoteMembers conv = join <$> remoteMemberLists [conv]

--- a/services/galley/src/Galley/Cassandra/ConversationList.hs
+++ b/services/galley/src/Galley/Cassandra/ConversationList.hs
@@ -31,7 +31,7 @@ import Galley.Cassandra.Store
 import Galley.Data.Instances ()
 import qualified Galley.Data.Queries as Cql
 import Galley.Data.ResultSet
-import Galley.Effects.Paging hiding (Page, PagingState)
+import Galley.Effects.ListItems
 import Imports hiding (max)
 import Polysemy
 import qualified Polysemy.Reader as P

--- a/services/galley/src/Galley/Cassandra/ConversationList.hs
+++ b/services/galley/src/Galley/Cassandra/ConversationList.hs
@@ -1,0 +1,87 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Cassandra.ConversationList
+  ( interpretConversationListToCassandra,
+    interpretRemoteConversationListToCassandra,
+    interpretLegacyConversationListToCassandra,
+  )
+where
+
+import Cassandra
+import Data.Id
+import Data.Qualified
+import Data.Range
+import Galley.Cassandra.Paging
+import Galley.Cassandra.Store
+import Galley.Data.Instances ()
+import qualified Galley.Data.Queries as Cql
+import Galley.Data.ResultSet
+import Galley.Effects.Paging hiding (Page, PagingState)
+import Imports hiding (max)
+import Polysemy
+import qualified Polysemy.Reader as P
+
+-- | Deprecated, use 'localConversationIdsPageFrom'
+conversationIdsFrom ::
+  UserId ->
+  Maybe ConvId ->
+  Range 1 1000 Int32 ->
+  Client (ResultSet ConvId)
+conversationIdsFrom usr start (fromRange -> max) =
+  mkResultSet . strip . fmap runIdentity <$> case start of
+    Just c -> paginate Cql.selectUserConvsFrom (paramsP Quorum (usr, c) (max + 1))
+    Nothing -> paginate Cql.selectUserConvs (paramsP Quorum (Identity usr) (max + 1))
+  where
+    strip p = p {result = take (fromIntegral max) (result p)}
+
+localConversationIdsPageFrom ::
+  UserId ->
+  Maybe PagingState ->
+  Range 1 1000 Int32 ->
+  Client (PageWithState ConvId)
+localConversationIdsPageFrom usr pagingState (fromRange -> max) =
+  fmap runIdentity <$> paginateWithState Cql.selectUserConvs (paramsPagingState Quorum (Identity usr) max pagingState)
+
+remoteConversationIdsPageFrom ::
+  UserId ->
+  Maybe PagingState ->
+  Int32 ->
+  Client (PageWithState (Remote ConvId))
+remoteConversationIdsPageFrom usr pagingState max =
+  uncurry toRemoteUnsafe <$$> paginateWithState Cql.selectUserRemoteConvs (paramsPagingState Quorum (Identity usr) max pagingState)
+
+interpretConversationListToCassandra ::
+  Members '[Embed IO, P.Reader ClientState] r =>
+  Sem (ListItems CassandraPaging ConvId ': r) a ->
+  Sem r a
+interpretConversationListToCassandra = interpret $ \case
+  ListItems uid ps max -> embedClient $ localConversationIdsPageFrom uid ps max
+
+interpretRemoteConversationListToCassandra ::
+  Members '[Embed IO, P.Reader ClientState] r =>
+  Sem (ListItems CassandraPaging (Remote ConvId) ': r) a ->
+  Sem r a
+interpretRemoteConversationListToCassandra = interpret $ \case
+  ListItems uid ps max -> embedClient $ remoteConversationIdsPageFrom uid ps (fromRange max)
+
+interpretLegacyConversationListToCassandra ::
+  Members '[Embed IO, P.Reader ClientState] r =>
+  Sem (ListItems LegacyPaging ConvId ': r) a ->
+  Sem r a
+interpretLegacyConversationListToCassandra = interpret $ \case
+  ListItems uid ps max -> embedClient $ conversationIdsFrom uid ps max

--- a/services/galley/src/Galley/Cassandra/Paging.hs
+++ b/services/galley/src/Galley/Cassandra/Paging.hs
@@ -22,8 +22,12 @@ module Galley.Cassandra.Paging
 where
 
 import Cassandra
+import Data.Id
+import Data.Qualified
+import Data.Range
 import Galley.Data.ResultSet
 import qualified Galley.Effects.Paging as E
+import Imports
 
 -- | This paging system uses Cassandra's 'PagingState' to keep track of state,
 -- and does not rely on ordering. This is the preferred way of paging across
@@ -34,6 +38,12 @@ type instance E.PagingState CassandraPaging a = PagingState
 
 type instance E.Page CassandraPaging a = PageWithState a
 
+type instance E.PagingBounds CassandraPaging ConvId = Range 1 1000 Int32
+
+type instance E.PagingBounds CassandraPaging (Remote ConvId) = Range 1 1000 Int32
+
+type instance E.PagingBounds CassandraPaging TeamId = Range 1 100 Int32
+
 -- | This paging system is based on ordering, and keeps track of state using
 -- the id of the next item to fetch. Implementations of this paging system also
 -- contain extra logic to detect if the last page has been fetched.
@@ -42,3 +52,7 @@ data LegacyPaging
 type instance E.PagingState LegacyPaging a = a
 
 type instance E.Page LegacyPaging a = ResultSet a
+
+type instance E.PagingBounds LegacyPaging ConvId = Range 1 1000 Int32
+
+type instance E.PagingBounds LegacyPaging TeamId = Range 1 100 Int32

--- a/services/galley/src/Galley/Cassandra/Paging.hs
+++ b/services/galley/src/Galley/Cassandra/Paging.hs
@@ -1,0 +1,38 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Cassandra.Paging
+  ( CassandraPaging,
+    LegacyPaging,
+  )
+where
+
+import Cassandra
+import Galley.Data.ResultSet
+import qualified Galley.Effects.Paging as E
+
+data CassandraPaging
+
+type instance E.PagingState CassandraPaging a = PagingState
+
+type instance E.Page CassandraPaging a = PageWithState a
+
+data LegacyPaging
+
+type instance E.PagingState LegacyPaging a = a
+
+type instance E.Page LegacyPaging a = ResultSet a

--- a/services/galley/src/Galley/Cassandra/Paging.hs
+++ b/services/galley/src/Galley/Cassandra/Paging.hs
@@ -25,12 +25,18 @@ import Cassandra
 import Galley.Data.ResultSet
 import qualified Galley.Effects.Paging as E
 
+-- | This paging system uses Cassandra's 'PagingState' to keep track of state,
+-- and does not rely on ordering. This is the preferred way of paging across
+-- multiple tables, as in  'MultiTablePaging'.
 data CassandraPaging
 
 type instance E.PagingState CassandraPaging a = PagingState
 
 type instance E.Page CassandraPaging a = PageWithState a
 
+-- | This paging system is based on ordering, and keeps track of state using
+-- the id of the next item to fetch. Implementations of this paging system also
+-- contain extra logic to detect if the last page has been fetched.
 data LegacyPaging
 
 type instance E.PagingState LegacyPaging a = a

--- a/services/galley/src/Galley/Cassandra/Services.hs
+++ b/services/galley/src/Galley/Cassandra/Services.hs
@@ -1,0 +1,78 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Cassandra.Services where
+
+import Cassandra
+import Control.Lens
+import Data.Id
+import Galley.Cassandra.Store
+import Galley.Data.Queries
+import Galley.Data.Services
+import Galley.Effects.ServiceStore (ServiceStore (..))
+import Galley.Types hiding (Conversation)
+import Galley.Types.Bot
+import Galley.Types.Conversations.Members (newMember)
+import Imports
+import Polysemy
+import qualified Polysemy.Reader as P
+
+-- FUTUREWORK: support adding bots to a remote conversation
+addBotMember :: ServiceRef -> BotId -> ConvId -> Client BotMember
+addBotMember s bot cnv = do
+  retry x5 . batch $ do
+    setType BatchLogged
+    setConsistency Quorum
+    addPrepQuery insertUserConv (botUserId bot, cnv)
+    addPrepQuery insertBot (cnv, bot, sid, pid)
+  pure (BotMember mem)
+  where
+    pid = s ^. serviceRefProvider
+    sid = s ^. serviceRefId
+    mem = (newMember (botUserId bot)) {lmService = Just s}
+
+-- Service --------------------------------------------------------------------
+
+interpretServiceStoreToCassandra ::
+  Members '[Embed IO, P.Reader ClientState] r =>
+  Sem (ServiceStore ': r) a ->
+  Sem r a
+interpretServiceStoreToCassandra = interpret $ \case
+  CreateService s -> embedClient $ insertService s
+  GetService sr -> embedClient $ lookupService sr
+  DeleteService sr -> embedClient $ deleteService sr
+
+insertService :: MonadClient m => Service -> m ()
+insertService s = do
+  let sid = s ^. serviceRef . serviceRefId
+  let pid = s ^. serviceRef . serviceRefProvider
+  let tok = s ^. serviceToken
+  let url = s ^. serviceUrl
+  let fps = Set (s ^. serviceFingerprints)
+  let ena = s ^. serviceEnabled
+  retry x5 $ write insertSrv (params Quorum (pid, sid, url, tok, fps, ena))
+
+lookupService :: MonadClient m => ServiceRef -> m (Maybe Service)
+lookupService s =
+  fmap toService
+    <$> retry x1 (query1 selectSrv (params Quorum (s ^. serviceRefProvider, s ^. serviceRefId)))
+  where
+    toService (url, tok, Set fps, ena) =
+      newService s url tok fps & set serviceEnabled ena
+
+deleteService :: MonadClient m => ServiceRef -> m ()
+deleteService s = retry x5 (write rmSrv (params Quorum (s ^. serviceRefProvider, s ^. serviceRefId)))

--- a/services/galley/src/Galley/Cassandra/Store.hs
+++ b/services/galley/src/Galley/Cassandra/Store.hs
@@ -1,0 +1,31 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Cassandra.Store
+  ( embedClient,
+  )
+where
+
+import Cassandra
+import Imports
+import Polysemy
+import Polysemy.Reader as P
+
+embedClient :: Members '[Embed IO, P.Reader ClientState] r => Client a -> Sem r a
+embedClient client = do
+  cs <- P.ask
+  embed @IO $ runClient cs client

--- a/services/galley/src/Galley/Cassandra/Team.hs
+++ b/services/galley/src/Galley/Cassandra/Team.hs
@@ -1,0 +1,384 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Cassandra.Team where
+
+import Cassandra
+import Cassandra.Util
+import Control.Exception (ErrorCall (ErrorCall))
+import Control.Lens hiding ((<|))
+import Control.Monad.Catch (throwM)
+import Control.Monad.Extra (ifM)
+import Data.Id as Id
+import Data.Json.Util (UTCTimeMillis (..))
+import Data.LegalHold (UserLegalHoldStatus (..), defUserLegalHoldStatus)
+import qualified Data.Map.Strict as Map
+import Data.Range
+import qualified Data.Set as Set
+import Data.UUID.V4 (nextRandom)
+import qualified Galley.Cassandra.Conversation as C
+import Galley.Cassandra.LegalHold (isTeamLegalholdWhitelisted)
+import Galley.Cassandra.Store
+import Galley.Data.Instances ()
+import qualified Galley.Data.Queries as Cql
+import Galley.Data.ResultSet
+import Galley.Effects.TeamStore (TeamStore (..))
+import Galley.Types.Teams hiding
+  ( DeleteTeam,
+    GetTeamConversations,
+    SetTeamData,
+  )
+import qualified Galley.Types.Teams as Teams
+import Galley.Types.Teams.Intra
+import Imports hiding (Set, max)
+import Polysemy
+import qualified Polysemy.Reader as P
+import qualified UnliftIO
+import Wire.API.Team.Member
+
+interpretTeamStoreToCassandra ::
+  Members '[Embed IO, P.Reader ClientState] r =>
+  FeatureLegalHold ->
+  Sem (TeamStore ': r) a ->
+  Sem r a
+interpretTeamStoreToCassandra lh = interpret $ \case
+  CreateTeamMember tid mem -> embedClient $ addTeamMember tid mem
+  SetTeamMemberPermissions perm0 tid uid perm1 ->
+    embedClient $ updateTeamMember perm0 tid uid perm1
+  CreateTeam t uid n i k b -> embedClient $ createTeam t uid n i k b
+  DeleteTeamMember tid uid -> embedClient $ removeTeamMember tid uid
+  GetBillingTeamMembers tid -> embedClient $ listBillingTeamMembers tid
+  GetTeam tid -> embedClient $ team tid
+  GetTeamName tid -> embedClient $ getTeamName tid
+  GetTeamConversation tid cid -> embedClient $ teamConversation tid cid
+  GetTeamConversations tid -> embedClient $ getTeamConversations tid
+  SelectTeams uid tids -> embedClient $ teamIdsOf uid tids
+  GetTeamMember tid uid -> embedClient $ teamMember lh tid uid
+  GetTeamMembersWithLimit tid n -> embedClient $ teamMembersWithLimit lh tid n
+  GetTeamMembers tid -> embedClient $ teamMembersCollectedWithPagination lh tid
+  SelectTeamMembers tid uids -> embedClient $ teamMembersLimited lh tid uids
+  GetUserTeams uid -> embedClient $ userTeams uid
+  GetUsersTeams uids -> embedClient $ usersTeams uids
+  GetOneUserTeam uid -> embedClient $ oneUserTeam uid
+  GetTeamsBindings tid -> embedClient $ getTeamsBindings tid
+  GetTeamBinding tid -> embedClient $ getTeamBinding tid
+  GetTeamCreationTime tid -> embedClient $ teamCreationTime tid
+  DeleteTeam tid -> embedClient $ deleteTeam tid
+  DeleteTeamConversation tid cid -> embedClient $ removeTeamConv tid cid
+  SetTeamData tid upd -> embedClient $ updateTeam tid upd
+  SetTeamStatus tid st -> embedClient $ updateTeamStatus tid st
+
+createTeam ::
+  Maybe TeamId ->
+  UserId ->
+  Range 1 256 Text ->
+  Range 1 256 Text ->
+  Maybe (Range 1 256 Text) ->
+  TeamBinding ->
+  Client Team
+createTeam t uid (fromRange -> n) (fromRange -> i) k b = do
+  tid <- maybe (Id <$> liftIO nextRandom) return t
+  retry x5 $ write Cql.insertTeam (params Quorum (tid, uid, n, i, fromRange <$> k, initialStatus b, b))
+  pure (newTeam tid uid n i b & teamIconKey .~ (fromRange <$> k))
+  where
+    initialStatus Binding = PendingActive -- Team becomes Active after User account activation
+    initialStatus NonBinding = Active
+
+listBillingTeamMembers :: TeamId -> Client [UserId]
+listBillingTeamMembers tid =
+  fmap runIdentity
+    <$> retry x1 (query Cql.listBillingTeamMembers (params Quorum (Identity tid)))
+
+getTeamName :: TeamId -> Client (Maybe Text)
+getTeamName tid =
+  fmap runIdentity
+    <$> retry x1 (query1 Cql.selectTeamName (params Quorum (Identity tid)))
+
+teamConversation :: TeamId -> ConvId -> Client (Maybe TeamConversation)
+teamConversation t c =
+  fmap (newTeamConversation c . runIdentity)
+    <$> retry x1 (query1 Cql.selectTeamConv (params Quorum (t, c)))
+
+getTeamConversations :: TeamId -> Client [TeamConversation]
+getTeamConversations t =
+  map (uncurry newTeamConversation)
+    <$> retry x1 (query Cql.selectTeamConvs (params Quorum (Identity t)))
+
+teamIdsFrom :: UserId -> Maybe TeamId -> Range 1 100 Int32 -> Client (ResultSet TeamId)
+teamIdsFrom usr range (fromRange -> max) =
+  mkResultSet . fmap runIdentity . strip <$> case range of
+    Just c -> paginate Cql.selectUserTeamsFrom (paramsP Quorum (usr, c) (max + 1))
+    Nothing -> paginate Cql.selectUserTeams (paramsP Quorum (Identity usr) (max + 1))
+  where
+    strip p = p {result = take (fromIntegral max) (result p)}
+
+teamIdsForPagination :: UserId -> Maybe TeamId -> Range 1 100 Int32 -> Client (Page TeamId)
+teamIdsForPagination usr range (fromRange -> max) =
+  fmap runIdentity <$> case range of
+    Just c -> paginate Cql.selectUserTeamsFrom (paramsP Quorum (usr, c) max)
+    Nothing -> paginate Cql.selectUserTeams (paramsP Quorum (Identity usr) max)
+
+teamMember :: FeatureLegalHold -> TeamId -> UserId -> Client (Maybe TeamMember)
+teamMember lh t u =
+  newTeamMember'' u =<< retry x1 (query1 Cql.selectTeamMember (params Quorum (t, u)))
+  where
+    newTeamMember'' ::
+      UserId ->
+      Maybe (Permissions, Maybe UserId, Maybe UTCTimeMillis, Maybe UserLegalHoldStatus) ->
+      Client (Maybe TeamMember)
+    newTeamMember'' _ Nothing = pure Nothing
+    newTeamMember'' uid (Just (perms, minvu, minvt, mulhStatus)) =
+      Just <$> newTeamMember' lh t (uid, perms, minvu, minvt, mulhStatus)
+
+addTeamMember :: TeamId -> TeamMember -> Client ()
+addTeamMember t m =
+  retry x5 . batch $ do
+    setType BatchLogged
+    setConsistency Quorum
+    addPrepQuery
+      Cql.insertTeamMember
+      ( t,
+        m ^. userId,
+        m ^. permissions,
+        m ^? invitation . _Just . _1,
+        m ^? invitation . _Just . _2
+      )
+    addPrepQuery Cql.insertUserTeam (m ^. userId, t)
+    when (m `hasPermission` SetBilling) $
+      addPrepQuery Cql.insertBillingTeamMember (t, m ^. userId)
+
+updateTeamMember ::
+  -- | Old permissions, used for maintaining 'billing_team_member' table
+  Permissions ->
+  TeamId ->
+  UserId ->
+  -- | New permissions
+  Permissions ->
+  Client ()
+updateTeamMember oldPerms tid uid newPerms = do
+  retry x5 . batch $ do
+    setType BatchLogged
+    setConsistency Quorum
+    addPrepQuery Cql.updatePermissions (newPerms, tid, uid)
+
+    when (SetBilling `Set.member` acquiredPerms) $
+      addPrepQuery Cql.insertBillingTeamMember (tid, uid)
+
+    when (SetBilling `Set.member` lostPerms) $
+      addPrepQuery Cql.deleteBillingTeamMember (tid, uid)
+  where
+    permDiff = Set.difference `on` view Teams.self
+    acquiredPerms = newPerms `permDiff` oldPerms
+    lostPerms = oldPerms `permDiff` newPerms
+
+removeTeamMember :: TeamId -> UserId -> Client ()
+removeTeamMember t m =
+  retry x5 . batch $ do
+    setType BatchLogged
+    setConsistency Quorum
+    addPrepQuery Cql.deleteTeamMember (t, m)
+    addPrepQuery Cql.deleteUserTeam (m, t)
+    addPrepQuery Cql.deleteBillingTeamMember (t, m)
+
+team :: TeamId -> Client (Maybe TeamData)
+team tid =
+  fmap toTeam <$> retry x1 (query1 Cql.selectTeam (params Quorum (Identity tid)))
+  where
+    toTeam (u, n, i, k, d, s, st, b) =
+      let t = newTeam tid u n i (fromMaybe NonBinding b) & teamIconKey .~ k
+          status = if d then PendingDelete else fromMaybe Active s
+       in TeamData t status (writeTimeToUTC <$> st)
+
+teamIdsOf :: UserId -> [TeamId] -> Client [TeamId]
+teamIdsOf usr tids =
+  map runIdentity <$> retry x1 (query Cql.selectUserTeamsIn (params Quorum (usr, toList tids)))
+
+teamMembersWithLimit ::
+  FeatureLegalHold ->
+  TeamId ->
+  Range 1 HardTruncationLimit Int32 ->
+  Client TeamMemberList
+teamMembersWithLimit lh t (fromRange -> limit) = do
+  -- NOTE: We use +1 as size and then trim it due to the semantics of C* when getting a page with the exact same size
+  pageTuple <- retry x1 (paginate Cql.selectTeamMembers (paramsP Quorum (Identity t) (limit + 1)))
+  ms <- mapM (newTeamMember' lh t) . take (fromIntegral limit) $ result pageTuple
+  pure $
+    if hasMore pageTuple
+      then newTeamMemberList ms ListTruncated
+      else newTeamMemberList ms ListComplete
+
+-- NOTE: Use this function with care... should only be required when deleting a team!
+--       Maybe should be left explicitly for the caller?
+teamMembersCollectedWithPagination :: FeatureLegalHold -> TeamId -> Client [TeamMember]
+teamMembersCollectedWithPagination lh tid = do
+  mems <- teamMembersForPagination tid Nothing (unsafeRange 2000)
+  collectTeamMembersPaginated [] mems
+  where
+    collectTeamMembersPaginated acc mems = do
+      tMembers <- mapM (newTeamMember' lh tid) (result mems)
+      if (null $ result mems)
+        then collectTeamMembersPaginated (tMembers ++ acc) =<< nextPage mems
+        else return (tMembers ++ acc)
+
+-- Lookup only specific team members: this is particularly useful for large teams when
+-- needed to look up only a small subset of members (typically 2, user to perform the action
+-- and the target user)
+teamMembersLimited :: FeatureLegalHold -> TeamId -> [UserId] -> Client [TeamMember]
+teamMembersLimited lh t u =
+  mapM (newTeamMember' lh t)
+    =<< retry x1 (query Cql.selectTeamMembers' (params Quorum (t, u)))
+
+userTeams :: UserId -> Client [TeamId]
+userTeams u =
+  map runIdentity
+    <$> retry x1 (query Cql.selectUserTeams (params Quorum (Identity u)))
+
+usersTeams :: [UserId] -> Client (Map UserId TeamId)
+usersTeams uids = do
+  pairs :: [(UserId, TeamId)] <-
+    catMaybes
+      <$> UnliftIO.pooledMapConcurrentlyN 8 (\uid -> (uid,) <$$> oneUserTeam uid) uids
+  pure $ foldl' (\m (k, v) -> Map.insert k v m) Map.empty pairs
+
+oneUserTeam :: UserId -> Client (Maybe TeamId)
+oneUserTeam u =
+  fmap runIdentity
+    <$> retry x1 (query1 Cql.selectOneUserTeam (params Quorum (Identity u)))
+
+teamCreationTime :: TeamId -> Client (Maybe TeamCreationTime)
+teamCreationTime t =
+  checkCreation . fmap runIdentity
+    <$> retry x1 (query1 Cql.selectTeamBindingWritetime (params Quorum (Identity t)))
+  where
+    checkCreation (Just (Just ts)) = Just $ TeamCreationTime ts
+    checkCreation _ = Nothing
+
+getTeamBinding :: TeamId -> Client (Maybe TeamBinding)
+getTeamBinding t =
+  fmap (fromMaybe NonBinding . runIdentity)
+    <$> retry x1 (query1 Cql.selectTeamBinding (params Quorum (Identity t)))
+
+getTeamsBindings :: [TeamId] -> Client [TeamBinding]
+getTeamsBindings =
+  fmap catMaybes
+    . UnliftIO.pooledMapConcurrentlyN 8 getTeamBinding
+
+deleteTeam :: TeamId -> Client ()
+deleteTeam tid = do
+  -- TODO: delete service_whitelist records that mention this team
+  retry x5 $ write Cql.markTeamDeleted (params Quorum (PendingDelete, tid))
+  mems <- teamMembersForPagination tid Nothing (unsafeRange 2000)
+  removeTeamMembers mems
+  cnvs <- teamConversationsForPagination tid Nothing (unsafeRange 2000)
+  removeConvs cnvs
+  retry x5 $ write Cql.deleteTeam (params Quorum (Deleted, tid))
+  where
+    removeConvs :: Page TeamConversation -> Client ()
+    removeConvs cnvs = do
+      for_ (result cnvs) $ removeTeamConv tid . view conversationId
+      unless (null $ result cnvs) $
+        removeConvs =<< liftClient (nextPage cnvs)
+
+    removeTeamMembers ::
+      Page
+        ( UserId,
+          Permissions,
+          Maybe UserId,
+          Maybe UTCTimeMillis,
+          Maybe UserLegalHoldStatus
+        ) ->
+      Client ()
+    removeTeamMembers mems = do
+      mapM_ (removeTeamMember tid . view _1) (result mems)
+      unless (null $ result mems) $
+        removeTeamMembers =<< liftClient (nextPage mems)
+
+removeTeamConv :: TeamId -> ConvId -> Client ()
+removeTeamConv tid cid = liftClient $ do
+  retry x5 . batch $ do
+    setType BatchLogged
+    setConsistency Quorum
+    addPrepQuery Cql.markConvDeleted (Identity cid)
+    addPrepQuery Cql.deleteTeamConv (tid, cid)
+  C.deleteConversation cid
+
+updateTeamStatus :: TeamId -> TeamStatus -> Client ()
+updateTeamStatus t s = retry x5 $ write Cql.updateTeamStatus (params Quorum (s, t))
+
+updateTeam :: TeamId -> TeamUpdateData -> Client ()
+updateTeam tid u = retry x5 . batch $ do
+  setType BatchLogged
+  setConsistency Quorum
+  for_ (u ^. nameUpdate) $ \n ->
+    addPrepQuery Cql.updateTeamName (fromRange n, tid)
+  for_ (u ^. iconUpdate) $ \i ->
+    addPrepQuery Cql.updateTeamIcon (fromRange i, tid)
+  for_ (u ^. iconKeyUpdate) $ \k ->
+    addPrepQuery Cql.updateTeamIconKey (fromRange k, tid)
+
+-- | Construct 'TeamMember' from database tuple.
+-- If FeatureLegalHoldWhitelistTeamsAndImplicitConsent is enabled set UserLegalHoldDisabled
+-- if team is whitelisted.
+--
+-- Throw an exception if one of invitation timestamp and inviter is 'Nothing' and the
+-- other is 'Just', which can only be caused by inconsistent database content.
+newTeamMember' ::
+  FeatureLegalHold ->
+  TeamId ->
+  (UserId, Permissions, Maybe UserId, Maybe UTCTimeMillis, Maybe UserLegalHoldStatus) ->
+  Client TeamMember
+newTeamMember' lh tid (uid, perms, minvu, minvt, fromMaybe defUserLegalHoldStatus -> lhStatus) = do
+  mk minvu minvt >>= maybeGrant
+  where
+    maybeGrant :: TeamMember -> Client TeamMember
+    maybeGrant m =
+      ifM
+        (isTeamLegalholdWhitelisted lh tid)
+        (pure (grantImplicitConsent m))
+        (pure m)
+
+    grantImplicitConsent :: TeamMember -> TeamMember
+    grantImplicitConsent =
+      legalHoldStatus %~ \case
+        UserLegalHoldNoConsent -> UserLegalHoldDisabled
+        -- the other cases don't change; we just enumerate them to catch future changes in
+        -- 'UserLegalHoldStatus' better.
+        UserLegalHoldDisabled -> UserLegalHoldDisabled
+        UserLegalHoldPending -> UserLegalHoldPending
+        UserLegalHoldEnabled -> UserLegalHoldEnabled
+
+    mk (Just invu) (Just invt) = pure $ TeamMember uid perms (Just (invu, invt)) lhStatus
+    mk Nothing Nothing = pure $ TeamMember uid perms Nothing lhStatus
+    mk _ _ = throwM $ ErrorCall "TeamMember with incomplete metadata."
+
+teamConversationsForPagination :: TeamId -> Maybe ConvId -> Range 1 HardTruncationLimit Int32 -> Client (Page TeamConversation)
+teamConversationsForPagination tid start (fromRange -> max) =
+  fmap (uncurry newTeamConversation) <$> case start of
+    Just c -> paginate Cql.selectTeamConvsFrom (paramsP Quorum (tid, c) max)
+    Nothing -> paginate Cql.selectTeamConvs (paramsP Quorum (Identity tid) max)
+
+type RawTeamMember = (UserId, Permissions, Maybe UserId, Maybe UTCTimeMillis, Maybe UserLegalHoldStatus)
+
+-- This function has a bit of a difficult type to work with because we don't
+-- have a pure function of type RawTeamMember -> TeamMember so we cannot fmap
+-- over the ResultSet. We don't want to mess around with the Result size
+-- nextPage either otherwise
+teamMembersForPagination :: TeamId -> Maybe UserId -> Range 1 HardTruncationLimit Int32 -> Client (Page RawTeamMember)
+teamMembersForPagination tid start (fromRange -> max) =
+  case start of
+    Just u -> paginate Cql.selectTeamMembersFrom (paramsP Quorum (tid, u) max)
+    Nothing -> paginate Cql.selectTeamMembers (paramsP Quorum (Identity tid) max)

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -25,33 +25,9 @@ module Galley.Data
     schemaVersion,
 
     -- * Teams
-    addTeamMember,
-    updateTeamMember,
-    createTeam,
-    removeTeamMember,
-    listBillingTeamMembers,
-    team,
-    Galley.Data.teamName,
-    teamConversation,
-    teamConversations,
-    teamIdsFrom,
-    teamIdsForPagination,
-    teamIdsOf,
-    teamMember,
     withTeamMembersWithChunks,
-    teamMembersWithLimit,
-    teamMembersForFanout,
-    teamMembersCollectedWithPagination,
-    teamMembersLimited,
-    userTeams,
-    usersTeams,
-    oneUserTeam,
-    Galley.Data.teamBinding,
-    teamCreationTime,
-    deleteTeam,
-    removeTeamConv,
-    updateTeam,
-    updateTeamStatus,
+    teamIdsForPagination,
+    teamIdsFrom,
 
     -- * Conversation Codes
     lookupCode,
@@ -75,23 +51,17 @@ where
 
 import Brig.Types.Code
 import Cassandra
-import Cassandra.Util
 import Control.Arrow (second)
 import Control.Exception (ErrorCall (ErrorCall))
 import Control.Lens hiding ((<|))
 import Control.Monad.Catch (throwM)
 import Control.Monad.Extra (ifM)
-import Data.ByteString.Conversion hiding (parser)
 import Data.Id as Id
 import Data.Json.Util (UTCTimeMillis (..))
 import Data.LegalHold (UserLegalHoldStatus (..), defUserLegalHoldStatus)
 import Data.List.Split (chunksOf)
-import qualified Data.Map.Strict as Map
 import Data.Range
-import qualified Data.Set as Set
-import Data.UUID.V4 (nextRandom)
 import Galley.App
-import qualified Galley.Cassandra.Conversation as C
 import Galley.Data.Access
 import Galley.Data.Conversation
 import Galley.Data.Instances ()
@@ -108,8 +78,6 @@ import Galley.Types.Teams hiding
     teamConversations,
     teamMembers,
   )
-import qualified Galley.Types.Teams as Teams
-import Galley.Types.Teams.Intra
 import Imports hiding (Set, max)
 import qualified UnliftIO
 import Wire.API.Team.Member
@@ -137,24 +105,6 @@ deleteCode k s = retry x5 $ write Cql.deleteCode (params Quorum (k, s))
 
 -- Teams --------------------------------------------------------------------
 
-team :: TeamId -> Galley r (Maybe TeamData)
-team tid =
-  fmap toTeam <$> retry x1 (query1 Cql.selectTeam (params Quorum (Identity tid)))
-  where
-    toTeam (u, n, i, k, d, s, st, b) =
-      let t = newTeam tid u n i (fromMaybe NonBinding b) & teamIconKey .~ k
-          status = if d then PendingDelete else fromMaybe Active s
-       in TeamData t status (writeTimeToUTC <$> st)
-
-teamName :: TeamId -> Galley r (Maybe Text)
-teamName tid =
-  fmap runIdentity
-    <$> retry x1 (query1 Cql.selectTeamName (params Quorum (Identity tid)))
-
-teamIdsOf :: UserId -> Range 1 32 (List TeamId) -> Galley r [TeamId]
-teamIdsOf usr (fromList . fromRange -> tids) =
-  map runIdentity <$> retry x1 (query Cql.selectUserTeamsIn (params Quorum (usr, tids)))
-
 teamIdsFrom :: UserId -> Maybe TeamId -> Range 1 100 Int32 -> Galley r (ResultSet TeamId)
 teamIdsFrom usr range (fromRange -> max) =
   mkResultSet . fmap runIdentity . strip <$> case range of
@@ -169,35 +119,6 @@ teamIdsForPagination usr range (fromRange -> max) =
     Just c -> paginate Cql.selectUserTeamsFrom (paramsP Quorum (usr, c) max)
     Nothing -> paginate Cql.selectUserTeams (paramsP Quorum (Identity usr) max)
 
-teamConversation :: TeamId -> ConvId -> Galley r (Maybe TeamConversation)
-teamConversation t c =
-  fmap (newTeamConversation c . runIdentity)
-    <$> retry x1 (query1 Cql.selectTeamConv (params Quorum (t, c)))
-
-teamConversations :: TeamId -> Galley r [TeamConversation]
-teamConversations t =
-  map (uncurry newTeamConversation)
-    <$> retry x1 (query Cql.selectTeamConvs (params Quorum (Identity t)))
-
-teamConversationsForPagination :: TeamId -> Maybe ConvId -> Range 1 HardTruncationLimit Int32 -> Galley r (Page TeamConversation)
-teamConversationsForPagination tid start (fromRange -> max) =
-  fmap (uncurry newTeamConversation) <$> case start of
-    Just c -> paginate Cql.selectTeamConvsFrom (paramsP Quorum (tid, c) max)
-    Nothing -> paginate Cql.selectTeamConvs (paramsP Quorum (Identity tid) max)
-
-teamMembersForFanout :: TeamId -> Galley r TeamMemberList
-teamMembersForFanout t = fanoutLimit >>= teamMembersWithLimit t
-
-teamMembersWithLimit :: TeamId -> Range 1 HardTruncationLimit Int32 -> Galley r TeamMemberList
-teamMembersWithLimit t (fromRange -> limit) = do
-  -- NOTE: We use +1 as size and then trim it due to the semantics of C* when getting a page with the exact same size
-  pageTuple <- retry x1 (paginate Cql.selectTeamMembers (paramsP Quorum (Identity t) (limit + 1)))
-  ms <- mapM (newTeamMember' t) . take (fromIntegral limit) $ result pageTuple
-  pure $
-    if hasMore pageTuple
-      then newTeamMemberList ms ListTruncated
-      else newTeamMemberList ms ListComplete
-
 -- This function has a bit of a difficult type to work with because we don't have a pure function of type
 -- (UserId, Permissions, Maybe UserId, Maybe UTCTimeMillis, Maybe UserLegalHoldStatus) -> TeamMember so we
 -- cannot fmap over the ResultSet. We don't want to mess around with the Result size nextPage either otherwise
@@ -206,195 +127,6 @@ teamMembersForPagination tid start (fromRange -> max) =
   case start of
     Just u -> paginate Cql.selectTeamMembersFrom (paramsP Quorum (tid, u) max)
     Nothing -> paginate Cql.selectTeamMembers (paramsP Quorum (Identity tid) max)
-
--- NOTE: Use this function with care... should only be required when deleting a team!
---       Maybe should be left explicitly for the caller?
-teamMembersCollectedWithPagination :: TeamId -> Galley r [TeamMember]
-teamMembersCollectedWithPagination tid = do
-  mems <- teamMembersForPagination tid Nothing (unsafeRange 2000)
-  collectTeamMembersPaginated [] mems
-  where
-    collectTeamMembersPaginated acc mems = do
-      tMembers <- mapM (newTeamMember' tid) (result mems)
-      if (null $ result mems)
-        then collectTeamMembersPaginated (tMembers ++ acc) =<< liftClient (nextPage mems)
-        else return (tMembers ++ acc)
-
--- Lookup only specific team members: this is particularly useful for large teams when
--- needed to look up only a small subset of members (typically 2, user to perform the action
--- and the target user)
-teamMembersLimited :: TeamId -> [UserId] -> Galley r [TeamMember]
-teamMembersLimited t u =
-  mapM (newTeamMember' t)
-    =<< retry x1 (query Cql.selectTeamMembers' (params Quorum (t, u)))
-
-teamMember :: TeamId -> UserId -> Galley r (Maybe TeamMember)
-teamMember t u = newTeamMember'' u =<< retry x1 (query1 Cql.selectTeamMember (params Quorum (t, u)))
-  where
-    newTeamMember'' ::
-      UserId ->
-      Maybe (Permissions, Maybe UserId, Maybe UTCTimeMillis, Maybe UserLegalHoldStatus) ->
-      Galley r (Maybe TeamMember)
-    newTeamMember'' _ Nothing = pure Nothing
-    newTeamMember'' uid (Just (perms, minvu, minvt, mulhStatus)) =
-      Just <$> newTeamMember' t (uid, perms, minvu, minvt, mulhStatus)
-
-userTeams :: UserId -> Galley r [TeamId]
-userTeams u =
-  map runIdentity
-    <$> retry x1 (query Cql.selectUserTeams (params Quorum (Identity u)))
-
-usersTeams :: [UserId] -> Galley r (Map UserId TeamId)
-usersTeams uids = liftClient $ do
-  pairs :: [(UserId, TeamId)] <-
-    catMaybes
-      <$> UnliftIO.pooledMapConcurrentlyN 8 (\uid -> (uid,) <$$> oneUserTeamC uid) uids
-  pure $ foldl' (\m (k, v) -> Map.insert k v m) Map.empty pairs
-
-oneUserTeam :: UserId -> Galley r (Maybe TeamId)
-oneUserTeam = liftClient . oneUserTeamC
-
-oneUserTeamC :: UserId -> Client (Maybe TeamId)
-oneUserTeamC u =
-  fmap runIdentity
-    <$> retry x1 (query1 Cql.selectOneUserTeam (params Quorum (Identity u)))
-
-teamCreationTime :: TeamId -> Galley r (Maybe TeamCreationTime)
-teamCreationTime t =
-  checkCreation . fmap runIdentity
-    <$> retry x1 (query1 Cql.selectTeamBindingWritetime (params Quorum (Identity t)))
-  where
-    checkCreation (Just (Just ts)) = Just $ TeamCreationTime ts
-    checkCreation _ = Nothing
-
-teamBinding :: TeamId -> Galley r (Maybe TeamBinding)
-teamBinding t =
-  fmap (fromMaybe NonBinding . runIdentity)
-    <$> retry x1 (query1 Cql.selectTeamBinding (params Quorum (Identity t)))
-
-createTeam ::
-  Maybe TeamId ->
-  UserId ->
-  Range 1 256 Text ->
-  Range 1 256 Text ->
-  Maybe (Range 1 256 Text) ->
-  TeamBinding ->
-  Galley r Team
-createTeam t uid (fromRange -> n) (fromRange -> i) k b = do
-  tid <- maybe (Id <$> liftIO nextRandom) return t
-  retry x5 $ write Cql.insertTeam (params Quorum (tid, uid, n, i, fromRange <$> k, initialStatus b, b))
-  pure (newTeam tid uid n i b & teamIconKey .~ (fromRange <$> k))
-  where
-    initialStatus Binding = PendingActive -- Team becomes Active after User account activation
-    initialStatus NonBinding = Active
-
-deleteTeam :: TeamId -> Galley r ()
-deleteTeam tid = do
-  -- TODO: delete service_whitelist records that mention this team
-  retry x5 $ write Cql.markTeamDeleted (params Quorum (PendingDelete, tid))
-  mems <- teamMembersForPagination tid Nothing (unsafeRange 2000)
-  removeTeamMembers mems
-  cnvs <- teamConversationsForPagination tid Nothing (unsafeRange 2000)
-  removeConvs cnvs
-  retry x5 $ write Cql.deleteTeam (params Quorum (Deleted, tid))
-  where
-    removeConvs :: Page TeamConversation -> Galley r ()
-    removeConvs cnvs = do
-      for_ (result cnvs) $ removeTeamConv tid . view conversationId
-      unless (null $ result cnvs) $
-        removeConvs =<< liftClient (nextPage cnvs)
-
-    removeTeamMembers ::
-      Page
-        ( UserId,
-          Permissions,
-          Maybe UserId,
-          Maybe UTCTimeMillis,
-          Maybe UserLegalHoldStatus
-        ) ->
-      Galley r ()
-    removeTeamMembers mems = do
-      mapM_ (removeTeamMember tid . view _1) (result mems)
-      unless (null $ result mems) $
-        removeTeamMembers =<< liftClient (nextPage mems)
-
-addTeamMember :: TeamId -> TeamMember -> Galley r ()
-addTeamMember t m =
-  retry x5 . batch $ do
-    setType BatchLogged
-    setConsistency Quorum
-    addPrepQuery
-      Cql.insertTeamMember
-      ( t,
-        m ^. userId,
-        m ^. permissions,
-        m ^? invitation . _Just . _1,
-        m ^? invitation . _Just . _2
-      )
-    addPrepQuery Cql.insertUserTeam (m ^. userId, t)
-    when (m `hasPermission` SetBilling) $
-      addPrepQuery Cql.insertBillingTeamMember (t, m ^. userId)
-
-updateTeamMember ::
-  -- | Old permissions, used for maintaining 'billing_team_member' table
-  Permissions ->
-  TeamId ->
-  UserId ->
-  -- | New permissions
-  Permissions ->
-  Galley r ()
-updateTeamMember oldPerms tid uid newPerms = do
-  retry x5 . batch $ do
-    setType BatchLogged
-    setConsistency Quorum
-    addPrepQuery Cql.updatePermissions (newPerms, tid, uid)
-
-    when (SetBilling `Set.member` acquiredPerms) $
-      addPrepQuery Cql.insertBillingTeamMember (tid, uid)
-
-    when (SetBilling `Set.member` lostPerms) $
-      addPrepQuery Cql.deleteBillingTeamMember (tid, uid)
-  where
-    permDiff = Set.difference `on` view Teams.self
-    acquiredPerms = newPerms `permDiff` oldPerms
-    lostPerms = oldPerms `permDiff` newPerms
-
-removeTeamMember :: TeamId -> UserId -> Galley r ()
-removeTeamMember t m =
-  retry x5 . batch $ do
-    setType BatchLogged
-    setConsistency Quorum
-    addPrepQuery Cql.deleteTeamMember (t, m)
-    addPrepQuery Cql.deleteUserTeam (m, t)
-    addPrepQuery Cql.deleteBillingTeamMember (t, m)
-
-listBillingTeamMembers :: TeamId -> Galley r [UserId]
-listBillingTeamMembers tid =
-  fmap runIdentity
-    <$> retry x1 (query Cql.listBillingTeamMembers (params Quorum (Identity tid)))
-
-removeTeamConv :: TeamId -> ConvId -> Galley r ()
-removeTeamConv tid cid = liftClient $ do
-  retry x5 . batch $ do
-    setType BatchLogged
-    setConsistency Quorum
-    addPrepQuery Cql.markConvDeleted (Identity cid)
-    addPrepQuery Cql.deleteTeamConv (tid, cid)
-  C.deleteConversation cid
-
-updateTeamStatus :: TeamId -> TeamStatus -> Galley r ()
-updateTeamStatus t s = retry x5 $ write Cql.updateTeamStatus (params Quorum (s, t))
-
-updateTeam :: TeamId -> TeamUpdateData -> Galley r ()
-updateTeam tid u = retry x5 . batch $ do
-  setType BatchLogged
-  setConsistency Quorum
-  for_ (u ^. nameUpdate) $ \n ->
-    addPrepQuery Cql.updateTeamName (fromRange n, tid)
-  for_ (u ^. iconUpdate) $ \i ->
-    addPrepQuery Cql.updateTeamIcon (fromRange i, tid)
-  for_ (u ^. iconKeyUpdate) $ \k ->
-    addPrepQuery Cql.updateTeamIconKey (fromRange k, tid)
 
 -- Clients ------------------------------------------------------------------
 

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -27,7 +27,6 @@ module Galley.Data
     -- * Teams
     withTeamMembersWithChunks,
     teamIdsForPagination,
-    teamIdsFrom,
 
     -- * Conversation Codes
     lookupCode,
@@ -104,14 +103,6 @@ deleteCode :: Key -> Scope -> Galley r ()
 deleteCode k s = retry x5 $ write Cql.deleteCode (params Quorum (k, s))
 
 -- Teams --------------------------------------------------------------------
-
-teamIdsFrom :: UserId -> Maybe TeamId -> Range 1 100 Int32 -> Galley r (ResultSet TeamId)
-teamIdsFrom usr range (fromRange -> max) =
-  mkResultSet . fmap runIdentity . strip <$> case range of
-    Just c -> paginate Cql.selectUserTeamsFrom (paramsP Quorum (usr, c) (max + 1))
-    Nothing -> paginate Cql.selectUserTeams (paramsP Quorum (Identity usr) (max + 1))
-  where
-    strip p = p {result = take (fromIntegral max) (result p)}
 
 teamIdsForPagination :: UserId -> Maybe TeamId -> Range 1 100 Int32 -> Galley r (Page TeamId)
 teamIdsForPagination usr range (fromRange -> max) =

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -24,10 +24,6 @@ module Galley.Data
     resultSetResult,
     schemaVersion,
 
-    -- * Teams
-    withTeamMembersWithChunks,
-    teamIdsForPagination,
-
     -- * Conversation Codes
     lookupCode,
     deleteCode,
@@ -51,35 +47,20 @@ where
 import Brig.Types.Code
 import Cassandra
 import Control.Arrow (second)
-import Control.Exception (ErrorCall (ErrorCall))
 import Control.Lens hiding ((<|))
-import Control.Monad.Catch (throwM)
-import Control.Monad.Extra (ifM)
 import Data.Id as Id
-import Data.Json.Util (UTCTimeMillis (..))
-import Data.LegalHold (UserLegalHoldStatus (..), defUserLegalHoldStatus)
 import Data.List.Split (chunksOf)
-import Data.Range
 import Galley.App
 import Galley.Data.Access
 import Galley.Data.Conversation
 import Galley.Data.Instances ()
-import Galley.Data.LegalHold (isTeamLegalholdWhitelisted)
 import qualified Galley.Data.Queries as Cql
 import Galley.Data.ResultSet
 import Galley.Data.Types as Data
 import Galley.Types.Clients (Clients)
 import qualified Galley.Types.Clients as Clients
-import Galley.Types.Teams hiding
-  ( Event,
-    EventType (..),
-    self,
-    teamConversations,
-    teamMembers,
-  )
 import Imports hiding (Set, max)
 import qualified UnliftIO
-import Wire.API.Team.Member
 
 schemaVersion :: Int32
 schemaVersion = 54
@@ -101,23 +82,6 @@ lookupCode k s = fmap (toCode k s) <$> retry x1 (query1 Cql.lookupCode (params Q
 -- | Delete a code associated with the given conversation key
 deleteCode :: Key -> Scope -> Galley r ()
 deleteCode k s = retry x5 $ write Cql.deleteCode (params Quorum (k, s))
-
--- Teams --------------------------------------------------------------------
-
-teamIdsForPagination :: UserId -> Maybe TeamId -> Range 1 100 Int32 -> Galley r (Page TeamId)
-teamIdsForPagination usr range (fromRange -> max) =
-  fmap runIdentity <$> case range of
-    Just c -> paginate Cql.selectUserTeamsFrom (paramsP Quorum (usr, c) max)
-    Nothing -> paginate Cql.selectUserTeams (paramsP Quorum (Identity usr) max)
-
--- This function has a bit of a difficult type to work with because we don't have a pure function of type
--- (UserId, Permissions, Maybe UserId, Maybe UTCTimeMillis, Maybe UserLegalHoldStatus) -> TeamMember so we
--- cannot fmap over the ResultSet. We don't want to mess around with the Result size nextPage either otherwise
-teamMembersForPagination :: TeamId -> Maybe UserId -> Range 1 HardTruncationLimit Int32 -> Galley r (Page (UserId, Permissions, Maybe UserId, Maybe UTCTimeMillis, Maybe UserLegalHoldStatus))
-teamMembersForPagination tid start (fromRange -> max) =
-  case start of
-    Just u -> paginate Cql.selectTeamMembersFrom (paramsP Quorum (tid, u) max)
-    Nothing -> paginate Cql.selectTeamMembers (paramsP Quorum (Identity tid) max)
 
 -- Clients ------------------------------------------------------------------
 
@@ -142,53 +106,3 @@ lookupClients' users =
 
 eraseClients :: UserId -> Galley r ()
 eraseClients user = retry x5 (write Cql.rmClients (params Quorum (Identity user)))
-
--- Internal utilities
-
--- | Construct 'TeamMember' from database tuple.
--- If FeatureLegalHoldWhitelistTeamsAndImplicitConsent is enabled set UserLegalHoldDisabled
--- if team is whitelisted.
---
--- Throw an exception if one of invitation timestamp and inviter is 'Nothing' and the
--- other is 'Just', which can only be caused by inconsistent database content.
-newTeamMember' :: TeamId -> (UserId, Permissions, Maybe UserId, Maybe UTCTimeMillis, Maybe UserLegalHoldStatus) -> Galley r TeamMember
-newTeamMember' tid (uid, perms, minvu, minvt, fromMaybe defUserLegalHoldStatus -> lhStatus) = do
-  mk minvu minvt >>= maybeGrant
-  where
-    maybeGrant :: TeamMember -> Galley r TeamMember
-    maybeGrant m =
-      ifM
-        (isTeamLegalholdWhitelisted tid)
-        (pure (grantImplicitConsent m))
-        (pure m)
-
-    grantImplicitConsent :: TeamMember -> TeamMember
-    grantImplicitConsent =
-      legalHoldStatus %~ \case
-        UserLegalHoldNoConsent -> UserLegalHoldDisabled
-        -- the other cases don't change; we just enumerate them to catch future changes in
-        -- 'UserLegalHoldStatus' better.
-        UserLegalHoldDisabled -> UserLegalHoldDisabled
-        UserLegalHoldPending -> UserLegalHoldPending
-        UserLegalHoldEnabled -> UserLegalHoldEnabled
-
-    mk (Just invu) (Just invt) = pure $ TeamMember uid perms (Just (invu, invt)) lhStatus
-    mk Nothing Nothing = pure $ TeamMember uid perms Nothing lhStatus
-    mk _ _ = throwM $ ErrorCall "TeamMember with incomplete metadata."
-
--- | Invoke the given action with a list of TeamMemberRows IDs
--- which are looked up based on:
-withTeamMembersWithChunks ::
-  TeamId ->
-  ([TeamMember] -> Galley r ()) ->
-  Galley r ()
-withTeamMembersWithChunks tid action = do
-  mems <- teamMembersForPagination tid Nothing (unsafeRange hardTruncationLimit)
-  handleMembers mems
-  where
-    handleMembers mems = do
-      tMembers <- mapM (newTeamMember' tid) (result mems)
-      action tMembers
-      when (hasMore mems) $
-        handleMembers =<< liftClient (nextPage mems)
-{-# INLINE withTeamMembersWithChunks #-}

--- a/services/galley/src/Galley/Data.hs
+++ b/services/galley/src/Galley/Data.hs
@@ -29,12 +29,6 @@ module Galley.Data
     deleteCode,
     insertCode,
 
-    -- * Clients
-    eraseClients,
-    lookupClients,
-    lookupClients',
-    updateClient,
-
     -- * Utilities
     localOne2OneConvId,
 
@@ -46,10 +40,6 @@ where
 
 import Brig.Types.Code
 import Cassandra
-import Control.Arrow (second)
-import Control.Lens hiding ((<|))
-import Data.Id as Id
-import Data.List.Split (chunksOf)
 import Galley.App
 import Galley.Data.Access
 import Galley.Data.Conversation
@@ -57,10 +47,7 @@ import Galley.Data.Instances ()
 import qualified Galley.Data.Queries as Cql
 import Galley.Data.ResultSet
 import Galley.Data.Types as Data
-import Galley.Types.Clients (Clients)
-import qualified Galley.Types.Clients as Clients
 import Imports hiding (Set, max)
-import qualified UnliftIO
 
 schemaVersion :: Int32
 schemaVersion = 54
@@ -82,27 +69,3 @@ lookupCode k s = fmap (toCode k s) <$> retry x1 (query1 Cql.lookupCode (params Q
 -- | Delete a code associated with the given conversation key
 deleteCode :: Key -> Scope -> Galley r ()
 deleteCode k s = retry x5 $ write Cql.deleteCode (params Quorum (k, s))
-
--- Clients ------------------------------------------------------------------
-
-updateClient :: Bool -> UserId -> ClientId -> Galley r ()
-updateClient add usr cls = do
-  let q = if add then Cql.addMemberClient else Cql.rmMemberClient
-  retry x5 $ write (q cls) (params Quorum (Identity usr))
-
--- Do, at most, 16 parallel lookups of up to 128 users each
-lookupClients :: [UserId] -> Galley r Clients
-lookupClients = liftClient . lookupClients'
-
--- This is only used by tests
-lookupClients' :: [UserId] -> Client Clients
-lookupClients' users =
-  Clients.fromList . concat . concat
-    <$> forM (chunksOf 2048 users) (UnliftIO.mapConcurrently getClients . chunksOf 128)
-  where
-    getClients us =
-      map (second fromSet)
-        <$> retry x1 (query Cql.selectClients (params Quorum (Identity us)))
-
-eraseClients :: UserId -> Galley r ()
-eraseClients user = retry x5 (write Cql.rmClients (params Quorum (Identity user)))

--- a/services/galley/src/Galley/Data/Access.hs
+++ b/services/galley/src/Galley/Data/Access.hs
@@ -1,0 +1,60 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Data.Access where
+
+import Cassandra
+import qualified Data.Set as Set
+import Galley.Data.Conversation.Types
+import Imports hiding (Set)
+import Wire.API.Conversation hiding (Conversation)
+
+defAccess :: ConvType -> Maybe (Set Access) -> [Access]
+defAccess SelfConv Nothing = [PrivateAccess]
+defAccess ConnectConv Nothing = [PrivateAccess]
+defAccess One2OneConv Nothing = [PrivateAccess]
+defAccess RegularConv Nothing = defRegularConvAccess
+defAccess SelfConv (Just (Set [])) = [PrivateAccess]
+defAccess ConnectConv (Just (Set [])) = [PrivateAccess]
+defAccess One2OneConv (Just (Set [])) = [PrivateAccess]
+defAccess RegularConv (Just (Set [])) = defRegularConvAccess
+defAccess _ (Just (Set (x : xs))) = x : xs
+
+defRegularConvAccess :: [Access]
+defRegularConvAccess = [InviteAccess]
+
+maybeRole :: ConvType -> Maybe AccessRole -> AccessRole
+maybeRole SelfConv _ = privateRole
+maybeRole ConnectConv _ = privateRole
+maybeRole One2OneConv _ = privateRole
+maybeRole RegularConv Nothing = defRole
+maybeRole RegularConv (Just r) = r
+
+defRole :: AccessRole
+defRole = ActivatedAccessRole
+
+privateRole :: AccessRole
+privateRole = PrivateAccessRole
+
+privateOnly :: Set Access
+privateOnly = Set [PrivateAccess]
+
+convAccessData :: Conversation -> ConversationAccessData
+convAccessData conv =
+  ConversationAccessData
+    (Set.fromList (convAccess conv))
+    (convAccessRole conv)

--- a/services/galley/src/Galley/Data/Conversation.hs
+++ b/services/galley/src/Galley/Data/Conversation.hs
@@ -1,0 +1,89 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Data.Conversation
+  ( -- * Data Conversation types
+    Conversation (..),
+    NewConversation,
+
+    -- * Utilities
+    isSelfConv,
+    isO2OConv,
+    isTeamConv,
+    isConvDeleted,
+    selfConv,
+    toConv,
+    localOne2OneConvId,
+    convMetadata,
+  )
+where
+
+import Cassandra
+import Data.Id
+import Data.Misc
+import qualified Data.UUID.Tagged as U
+import Galley.Data.Access
+import Galley.Data.Conversation.Types
+import Galley.Data.Instances ()
+import Galley.Types.Conversations.Members
+import Imports hiding (Set)
+import Wire.API.Conversation hiding (Conversation)
+
+isSelfConv :: Conversation -> Bool
+isSelfConv = (SelfConv ==) . convType
+
+isO2OConv :: Conversation -> Bool
+isO2OConv = (One2OneConv ==) . convType
+
+isTeamConv :: Conversation -> Bool
+isTeamConv = isJust . convTeam
+
+isConvDeleted :: Conversation -> Bool
+isConvDeleted = fromMaybe False . convDeleted
+
+selfConv :: UserId -> ConvId
+selfConv uid = Id (toUUID uid)
+
+toConv ::
+  ConvId ->
+  [LocalMember] ->
+  [RemoteMember] ->
+  Maybe (ConvType, UserId, Maybe (Set Access), Maybe AccessRole, Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode) ->
+  Maybe Conversation
+toConv cid mms remoteMems conv =
+  f mms <$> conv
+  where
+    f ms (cty, uid, acc, role, nme, ti, del, timer, rm) = Conversation cid cty uid nme (defAccess cty acc) (maybeRole cty role) ms remoteMems ti del timer rm
+
+-- | We deduce the conversation ID by adding the 4 components of the V4 UUID
+-- together pairwise, and then setting the version bits (v4) and variant bits
+-- (variant 2). This means that we always know what the UUID is for a
+-- one-to-one conversation which hopefully makes them unique.
+localOne2OneConvId :: U.UUID U.V4 -> U.UUID U.V4 -> ConvId
+localOne2OneConvId a b = Id . U.unpack $ U.addv4 a b
+
+convMetadata :: Conversation -> ConversationMetadata
+convMetadata c =
+  ConversationMetadata
+    (convType c)
+    (convCreator c)
+    (convAccess c)
+    (convAccessRole c)
+    (convName c)
+    (convTeam c)
+    (convMessageTimer c)
+    (convReceiptMode c)

--- a/services/galley/src/Galley/Data/Conversation/Types.hs
+++ b/services/galley/src/Galley/Data/Conversation/Types.hs
@@ -1,0 +1,61 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Data.Conversation.Types where
+
+import Data.Id
+import Data.Misc
+import Data.Range
+import Galley.Types.Conversations.Members
+import Galley.Types.UserList
+import Galley.Validation
+import Imports
+import Wire.API.Conversation hiding (Conversation)
+import Wire.API.Conversation.Role
+
+-- | Internal conversation type, corresponding directly to database schema.
+-- Should never be sent to users (and therefore doesn't have 'FromJSON' or
+-- 'ToJSON' instances).
+data Conversation = Conversation
+  { convId :: ConvId,
+    convType :: ConvType,
+    convCreator :: UserId,
+    convName :: Maybe Text,
+    convAccess :: [Access],
+    convAccessRole :: AccessRole,
+    convLocalMembers :: [LocalMember],
+    convRemoteMembers :: [RemoteMember],
+    convTeam :: Maybe TeamId,
+    convDeleted :: Maybe Bool,
+    -- | Global message timer
+    convMessageTimer :: Maybe Milliseconds,
+    convReceiptMode :: Maybe ReceiptMode
+  }
+  deriving (Show)
+
+data NewConversation = NewConversation
+  { ncType :: ConvType,
+    ncCreator :: UserId,
+    ncAccess :: [Access],
+    ncAccessRole :: AccessRole,
+    ncName :: Maybe (Range 1 256 Text),
+    ncTeam :: Maybe TeamId,
+    ncMessageTimer :: Maybe Milliseconds,
+    ncReceiptMode :: Maybe ReceiptMode,
+    ncUsers :: ConvSizeChecked UserList UserId,
+    ncRole :: RoleName
+  }

--- a/services/galley/src/Galley/Data/Queries.hs
+++ b/services/galley/src/Galley/Data/Queries.hs
@@ -28,7 +28,7 @@ import Data.Json.Util
 import Data.LegalHold
 import Data.Misc
 import qualified Data.Text.Lazy as LT
-import Galley.Data.Types
+import Galley.Data.Scope
 import Galley.Types hiding (Conversation)
 import Galley.Types.Conversations.Roles
 import Galley.Types.Teams

--- a/services/galley/src/Galley/Data/ResultSet.hs
+++ b/services/galley/src/Galley/Data/ResultSet.hs
@@ -1,0 +1,51 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Data.ResultSet where
+
+import Cassandra
+import Imports
+
+-- We use this newtype to highlight the fact that the 'Page' wrapped in here
+-- can not reliably used for paging.
+--
+-- The reason for this is that Cassandra returns 'hasMore' as true if the
+-- page size requested is equal to result size. To work around this we
+-- actually request for one additional element and drop the last value if
+-- necessary. This means however that 'nextPage' does not work properly as
+-- we would miss a value on every page size.
+-- Thus, and since we don't want to expose the ResultSet constructor
+-- because it gives access to `nextPage`, we give accessors to the results
+-- and a more typed `hasMore` (ResultSetComplete | ResultSetTruncated)
+data ResultSet a = ResultSet
+  { resultSetResult :: [a],
+    resultSetType :: ResultSetType
+  }
+  deriving stock (Show, Functor, Foldable, Traversable)
+
+-- | A more descriptive type than using a simple bool to represent `hasMore`
+data ResultSetType
+  = ResultSetComplete
+  | ResultSetTruncated
+  deriving stock (Eq, Show)
+
+mkResultSet :: Page a -> ResultSet a
+mkResultSet page = ResultSet (result page) typ
+  where
+    typ
+      | hasMore page = ResultSetTruncated
+      | otherwise = ResultSetComplete

--- a/services/galley/src/Galley/Data/Scope.hs
+++ b/services/galley/src/Galley/Data/Scope.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE StrictData #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Data.Scope where
+
+import Cassandra hiding (Value)
+import Imports
+
+data Scope = ReusableCode
+  deriving (Eq, Show, Generic)
+
+instance Cql Scope where
+  ctype = Tagged IntColumn
+
+  toCql ReusableCode = CqlInt 1
+
+  fromCql (CqlInt 1) = return ReusableCode
+  fromCql _ = Left "unknown Scope"

--- a/services/galley/src/Galley/Data/Services.hs
+++ b/services/galley/src/Galley/Data/Services.hs
@@ -17,32 +17,16 @@
 
 module Galley.Data.Services
   ( -- * BotMember
-    BotMember,
-    fromBotMember,
+    BotMember (..),
     newBotMember,
     botMemId,
     botMemService,
-    addBotMember,
-
-    -- * Service
-    insertService,
-    lookupService,
-    deleteService,
   )
 where
 
-import Cassandra
-import Control.Lens
 import Data.Id
-import Data.Qualified
-import Data.Time.Clock
-import Galley.App
-import Galley.Data.Instances ()
-import Galley.Data.Queries
 import Galley.Types hiding (Conversation)
 import Galley.Types.Bot
-import Galley.Types.Conversations.Members (newMember)
-import Galley.Types.Conversations.Roles
 import Imports
 
 -- BotMember ------------------------------------------------------------------
@@ -66,47 +50,3 @@ botMemId = BotId . lmId . fromBotMember
 
 botMemService :: BotMember -> ServiceRef
 botMemService = fromJust . lmService . fromBotMember
-
-addBotMember :: Qualified UserId -> ServiceRef -> BotId -> ConvId -> UTCTime -> Galley r (Event, BotMember)
-addBotMember qorig s bot cnv now = do
-  retry x5 . batch $ do
-    setType BatchLogged
-    setConsistency Quorum
-    addPrepQuery insertUserConv (botUserId bot, cnv)
-    addPrepQuery insertBot (cnv, bot, sid, pid)
-  return (e, BotMember mem)
-  where
-    pid = s ^. serviceRefProvider
-    sid = s ^. serviceRefId
-    -- FUTUREWORK: support adding bots to a remote conversation
-    qcnv = Qualified cnv localDomain
-    localDomain = qDomain qorig
-    -- FUTUREWORK: support remote bots
-    e = Event MemberJoin qcnv qorig now (EdMembersJoin . SimpleMembers $ (fmap toSimpleMember [botUserId bot]))
-    mem = (newMember (botUserId bot)) {lmService = Just s}
-
-    toSimpleMember :: UserId -> SimpleMember
-    toSimpleMember u = SimpleMember (Qualified u localDomain) roleNameWireAdmin
-
--- Service --------------------------------------------------------------------
-
-insertService :: MonadClient m => Service -> m ()
-insertService s = do
-  let sid = s ^. serviceRef . serviceRefId
-  let pid = s ^. serviceRef . serviceRefProvider
-  let tok = s ^. serviceToken
-  let url = s ^. serviceUrl
-  let fps = Set (s ^. serviceFingerprints)
-  let ena = s ^. serviceEnabled
-  retry x5 $ write insertSrv (params Quorum (pid, sid, url, tok, fps, ena))
-
-lookupService :: MonadClient m => ServiceRef -> m (Maybe Service)
-lookupService s =
-  fmap toService
-    <$> retry x1 (query1 selectSrv (params Quorum (s ^. serviceRefProvider, s ^. serviceRefId)))
-  where
-    toService (url, tok, Set fps, ena) =
-      newService s url tok fps & set serviceEnabled ena
-
-deleteService :: MonadClient m => ServiceRef -> m ()
-deleteService s = retry x5 (write rmSrv (params Quorum (s ^. serviceRefProvider, s ^. serviceRefId)))

--- a/services/galley/src/Galley/Data/Services.hs
+++ b/services/galley/src/Galley/Data/Services.hs
@@ -37,11 +37,11 @@ import Data.Id
 import Data.Qualified
 import Data.Time.Clock
 import Galley.App
-import Galley.Data (newMember)
 import Galley.Data.Instances ()
 import Galley.Data.Queries
 import Galley.Types hiding (Conversation)
 import Galley.Types.Bot
+import Galley.Types.Conversations.Members (newMember)
 import Galley.Types.Conversations.Roles
 import Imports
 

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -55,6 +55,7 @@ module Galley.Effects
     ConversationStore,
     MemberStore,
     TeamStore,
+    TeamMemberStore,
 
     -- * Paging effects
     ListItems,
@@ -72,6 +73,7 @@ import Galley.Effects.ConversationStore
 import Galley.Effects.FireAndForget
 import Galley.Effects.ListItems
 import Galley.Effects.MemberStore
+import Galley.Effects.TeamMemberStore
 import Galley.Effects.TeamStore
 import Imports
 import Polysemy
@@ -124,8 +126,10 @@ type GalleyEffects1 =
      ConversationStore,
      MemberStore,
      TeamStore,
+     TeamMemberStore InternalPaging,
      ListItems CassandraPaging ConvId,
      ListItems CassandraPaging (Remote ConvId),
      ListItems LegacyPaging ConvId,
-     ListItems LegacyPaging TeamId
+     ListItems LegacyPaging TeamId,
+     ListItems InternalPaging TeamId
    ]

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -53,6 +53,7 @@ module Galley.Effects
 
     -- * Store effects
     ConversationStore,
+    MemberStore,
 
     -- * Paging effects
     ListItems,
@@ -68,6 +69,7 @@ import Data.Qualified
 import Galley.Cassandra.Paging
 import Galley.Effects.ConversationStore
 import Galley.Effects.FireAndForget
+import Galley.Effects.MemberStore
 import Galley.Effects.Paging
 import Imports
 import Polysemy
@@ -118,6 +120,7 @@ type GalleyEffects1 =
      Intra,
      FireAndForget,
      ConversationStore,
+     MemberStore,
      ListItems CassandraPaging ConvId,
      ListItems CassandraPaging (Remote ConvId),
      ListItems LegacyPaging ConvId

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -126,5 +126,6 @@ type GalleyEffects1 =
      TeamStore,
      ListItems CassandraPaging ConvId,
      ListItems CassandraPaging (Remote ConvId),
-     ListItems LegacyPaging ConvId
+     ListItems LegacyPaging ConvId,
+     ListItems LegacyPaging TeamId
    ]

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -51,12 +51,16 @@ module Galley.Effects
     FireAndForget,
     interpretFireAndForget,
 
+    -- * Store effects
+    ConversationStore,
+
     -- * Polysemy re-exports
     Member,
     Members,
   )
 where
 
+import Galley.Effects.ConversationStore
 import Galley.Effects.FireAndForget
 import Imports
 import Polysemy
@@ -105,5 +109,6 @@ type GalleyEffects1 =
      FederatorAccess,
      BotAccess,
      Intra,
-     FireAndForget
+     FireAndForget,
+     ConversationStore
    ]

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -54,14 +54,21 @@ module Galley.Effects
     -- * Store effects
     ConversationStore,
 
+    -- * Paging effects
+    ListItems,
+
     -- * Polysemy re-exports
     Member,
     Members,
   )
 where
 
+import Data.Id
+import Data.Qualified
+import Galley.Cassandra.Paging
 import Galley.Effects.ConversationStore
 import Galley.Effects.FireAndForget
+import Galley.Effects.Paging
 import Imports
 import Polysemy
 
@@ -110,5 +117,8 @@ type GalleyEffects1 =
      BotAccess,
      Intra,
      FireAndForget,
-     ConversationStore
+     ConversationStore,
+     ListItems CassandraPaging ConvId,
+     ListItems CassandraPaging (Remote ConvId),
+     ListItems LegacyPaging ConvId
    ]

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -56,6 +56,7 @@ module Galley.Effects
     CodeStore,
     ConversationStore,
     MemberStore,
+    ServiceStore,
     TeamStore,
     TeamMemberStore,
 
@@ -77,6 +78,7 @@ import Galley.Effects.ConversationStore
 import Galley.Effects.FireAndForget
 import Galley.Effects.ListItems
 import Galley.Effects.MemberStore
+import Galley.Effects.ServiceStore
 import Galley.Effects.TeamMemberStore
 import Galley.Effects.TeamStore
 import Imports
@@ -131,6 +133,7 @@ type GalleyEffects1 =
      CodeStore,
      ConversationStore,
      MemberStore,
+     ServiceStore,
      TeamStore,
      TeamMemberStore InternalPaging,
      ListItems CassandraPaging ConvId,

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -53,6 +53,7 @@ module Galley.Effects
 
     -- * Store effects
     ClientStore,
+    CodeStore,
     ConversationStore,
     MemberStore,
     TeamStore,
@@ -71,6 +72,7 @@ import Data.Id
 import Data.Qualified
 import Galley.Cassandra.Paging
 import Galley.Effects.ClientStore
+import Galley.Effects.CodeStore
 import Galley.Effects.ConversationStore
 import Galley.Effects.FireAndForget
 import Galley.Effects.ListItems
@@ -126,6 +128,7 @@ type GalleyEffects1 =
      Intra,
      FireAndForget,
      ClientStore,
+     CodeStore,
      ConversationStore,
      MemberStore,
      TeamStore,

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -54,6 +54,7 @@ module Galley.Effects
     -- * Store effects
     ConversationStore,
     MemberStore,
+    TeamStore,
 
     -- * Paging effects
     ListItems,
@@ -69,8 +70,9 @@ import Data.Qualified
 import Galley.Cassandra.Paging
 import Galley.Effects.ConversationStore
 import Galley.Effects.FireAndForget
+import Galley.Effects.ListItems
 import Galley.Effects.MemberStore
-import Galley.Effects.Paging
+import Galley.Effects.TeamStore
 import Imports
 import Polysemy
 
@@ -121,6 +123,7 @@ type GalleyEffects1 =
      FireAndForget,
      ConversationStore,
      MemberStore,
+     TeamStore,
      ListItems CassandraPaging ConvId,
      ListItems CassandraPaging (Remote ConvId),
      ListItems LegacyPaging ConvId

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -52,6 +52,7 @@ module Galley.Effects
     interpretFireAndForget,
 
     -- * Store effects
+    ClientStore,
     ConversationStore,
     MemberStore,
     TeamStore,
@@ -69,6 +70,7 @@ where
 import Data.Id
 import Data.Qualified
 import Galley.Cassandra.Paging
+import Galley.Effects.ClientStore
 import Galley.Effects.ConversationStore
 import Galley.Effects.FireAndForget
 import Galley.Effects.ListItems
@@ -123,6 +125,7 @@ type GalleyEffects1 =
      BotAccess,
      Intra,
      FireAndForget,
+     ClientStore,
      ConversationStore,
      MemberStore,
      TeamStore,

--- a/services/galley/src/Galley/Effects/ClientStore.hs
+++ b/services/galley/src/Galley/Effects/ClientStore.hs
@@ -1,0 +1,44 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.ClientStore
+  ( -- * ClientStore Effect
+    ClientStore (..),
+
+    -- * Create client
+    createClient,
+
+    -- * Get client
+    getClients,
+
+    -- * Delete client
+    deleteClient,
+    deleteClients,
+  )
+where
+
+import Data.Id
+import Galley.Types.Clients
+import Polysemy
+
+data ClientStore m a where
+  GetClients :: [UserId] -> ClientStore m Clients
+  CreateClient :: UserId -> ClientId -> ClientStore m ()
+  DeleteClient :: UserId -> ClientId -> ClientStore m ()
+  DeleteClients :: UserId -> ClientStore m ()
+
+makeSem ''ClientStore

--- a/services/galley/src/Galley/Effects/CodeStore.hs
+++ b/services/galley/src/Galley/Effects/CodeStore.hs
@@ -1,6 +1,6 @@
 -- This file is part of the Wire Server implementation.
 --
--- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
 --
 -- This program is free software: you can redistribute it and/or modify it under
 -- the terms of the GNU Affero General Public License as published by the Free
@@ -15,30 +15,29 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Data
-  ( ResultSet,
-    ResultSetType (..),
-    PageWithState (..),
-    mkResultSet,
-    resultSetType,
-    resultSetResult,
-    schemaVersion,
+module Galley.Effects.CodeStore
+  ( -- * Code store effect
+    CodeStore (..),
 
-    -- * Utilities
-    localOne2OneConvId,
+    -- * Create code
+    createCode,
 
-    -- * Defaults
-    defRole,
-    defRegularConvAccess,
+    -- * Read code,
+    getCode,
+
+    -- * Delete code,
+    deleteCode,
   )
 where
 
-import Cassandra
-import Galley.Data.Access
-import Galley.Data.Conversation
-import Galley.Data.Instances ()
-import Galley.Data.ResultSet
-import Imports hiding (Set, max)
+import Brig.Types.Code
+import Galley.Data.Types
+import Imports
+import Polysemy
 
-schemaVersion :: Int32
-schemaVersion = 54
+data CodeStore m a where
+  CreateCode :: Code -> CodeStore m ()
+  GetCode :: Key -> Scope -> CodeStore m (Maybe Code)
+  DeleteCode :: Key -> Scope -> CodeStore m ()
+
+makeSem ''CodeStore

--- a/services/galley/src/Galley/Effects/ConversationStore.hs
+++ b/services/galley/src/Galley/Effects/ConversationStore.hs
@@ -1,0 +1,104 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.ConversationStore
+  ( -- * ConversationStore Effect
+    ConversationStore (..),
+
+    -- * Create conversation
+    createConversation,
+    createConnectConversation,
+    createConnectConversationWithRemote,
+    createLegacyOne2OneConversation,
+    createOne2OneConversation,
+    createSelfConversation,
+
+    -- * Read conversation
+    getConversation,
+    getConversations,
+    getConversationMetadata,
+    isConversationAlive,
+
+    -- * Update conversation
+    setConversationType,
+    setConversationName,
+    setConversationAccess,
+    setConversationReceiptMode,
+    setConversationMessageTimer,
+    acceptConnectConversation,
+
+    -- * Delete conversation
+    deleteConversation,
+  )
+where
+
+import Data.Id
+import Data.Misc
+import Data.Qualified
+import Data.Range
+import Data.UUID.Tagged
+import Galley.Data.Conversation
+import Galley.Types.UserList
+import Imports
+import Polysemy
+import Wire.API.Conversation hiding (Conversation, Member)
+
+data ConversationStore m a where
+  CreateConversation :: NewConversation -> ConversationStore m Conversation
+  CreateConnectConversation ::
+    UUID V4 ->
+    UUID V4 ->
+    Maybe (Range 1 256 Text) ->
+    ConversationStore m Conversation
+  CreateConnectConversationWithRemote ::
+    ConvId ->
+    UserId ->
+    UserList UserId ->
+    ConversationStore m Conversation
+  CreateLegacyOne2OneConversation ::
+    Local x ->
+    UUID V4 ->
+    UUID V4 ->
+    Maybe (Range 1 256 Text) ->
+    Maybe TeamId ->
+    ConversationStore m Conversation
+  CreateOne2OneConversation ::
+    ConvId ->
+    Local UserId ->
+    Qualified UserId ->
+    Maybe (Range 1 256 Text) ->
+    Maybe TeamId ->
+    ConversationStore m Conversation
+  CreateSelfConversation ::
+    Local UserId ->
+    Maybe (Range 1 256 Text) ->
+    ConversationStore m Conversation
+  DeleteConversation :: ConvId -> ConversationStore m ()
+  GetConversation :: ConvId -> ConversationStore m (Maybe Conversation)
+  GetConversations :: [ConvId] -> ConversationStore m [Conversation]
+  GetConversationMetadata :: ConvId -> ConversationStore m (Maybe ConversationMetadata)
+  IsConversationAlive :: ConvId -> ConversationStore m Bool
+  SetConversationType :: ConvId -> ConvType -> ConversationStore m ()
+  SetConversationName :: ConvId -> Range 1 256 Text -> ConversationStore m ()
+  SetConversationAccess :: ConvId -> ConversationAccessData -> ConversationStore m ()
+  SetConversationReceiptMode :: ConvId -> ReceiptMode -> ConversationStore m ()
+  SetConversationMessageTimer :: ConvId -> Maybe Milliseconds -> ConversationStore m ()
+
+makeSem ''ConversationStore
+
+acceptConnectConversation :: Member ConversationStore r => ConvId -> Sem r ()
+acceptConnectConversation cid = setConversationType cid One2OneConv

--- a/services/galley/src/Galley/Effects/ConversationStore.hs
+++ b/services/galley/src/Galley/Effects/ConversationStore.hs
@@ -32,6 +32,8 @@ module Galley.Effects.ConversationStore
     getConversations,
     getConversationMetadata,
     isConversationAlive,
+    getRemoteConversationStatus,
+    selectConversations,
 
     -- * Update conversation
     setConversationType,
@@ -52,6 +54,7 @@ import Data.Qualified
 import Data.Range
 import Data.UUID.Tagged
 import Galley.Data.Conversation
+import Galley.Types.Conversations.Members
 import Galley.Types.UserList
 import Imports
 import Polysemy
@@ -92,6 +95,11 @@ data ConversationStore m a where
   GetConversations :: [ConvId] -> ConversationStore m [Conversation]
   GetConversationMetadata :: ConvId -> ConversationStore m (Maybe ConversationMetadata)
   IsConversationAlive :: ConvId -> ConversationStore m Bool
+  GetRemoteConversationStatus ::
+    UserId ->
+    [Remote ConvId] ->
+    ConversationStore m (Map (Remote ConvId) MemberStatus)
+  SelectConversations :: UserId -> [ConvId] -> ConversationStore m [ConvId]
   SetConversationType :: ConvId -> ConvType -> ConversationStore m ()
   SetConversationName :: ConvId -> Range 1 256 Text -> ConversationStore m ()
   SetConversationAccess :: ConvId -> ConversationAccessData -> ConversationStore m ()

--- a/services/galley/src/Galley/Effects/ListItems.hs
+++ b/services/galley/src/Galley/Effects/ListItems.hs
@@ -15,22 +15,24 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Effects.Paging
-  ( -- * General paging types
-    Page,
-    PagingState,
-
-    -- * Simple paging
-    SimplePaging,
+module Galley.Effects.ListItems
+  ( ListItems (..),
+    listItems,
   )
 where
 
-type family Page p a :: (page :: *) | page -> p
+import Data.Id
+import Data.Range
+import Galley.Effects.Paging
+import Imports
+import Polysemy
 
-type family PagingState p a = (ps :: *)
+-- | General pagination-aware list-by-user effect
+data ListItems p i m a where
+  ListItems ::
+    UserId ->
+    Maybe (PagingState p i) ->
+    Range 1 1000 Int32 ->
+    ListItems p i m (Page p i)
 
-data SimplePaging
-
-type instance Page SimplePaging a = [a]
-
-type instance PagingState SimplePaging a = ()
+makeSem ''ListItems

--- a/services/galley/src/Galley/Effects/ListItems.hs
+++ b/services/galley/src/Galley/Effects/ListItems.hs
@@ -22,7 +22,6 @@ module Galley.Effects.ListItems
 where
 
 import Data.Id
-import Data.Range
 import Galley.Effects.Paging
 import Imports
 import Polysemy
@@ -32,7 +31,7 @@ data ListItems p i m a where
   ListItems ::
     UserId ->
     Maybe (PagingState p i) ->
-    Range 1 1000 Int32 ->
+    PagingBounds p i ->
     ListItems p i m (Page p i)
 
 makeSem ''ListItems

--- a/services/galley/src/Galley/Effects/MemberStore.hs
+++ b/services/galley/src/Galley/Effects/MemberStore.hs
@@ -23,6 +23,7 @@ module Galley.Effects.MemberStore
     createMember,
     createMembers,
     createMembersInRemoteConversation,
+    createBotMember,
 
     -- * Read members
     getLocalMember,
@@ -42,6 +43,8 @@ where
 
 import Data.Id
 import Data.Qualified
+import Galley.Data.Services
+import Galley.Types.Bot
 import Galley.Types.Conversations.Members
 import Galley.Types.ToUserRole
 import Galley.Types.UserList
@@ -52,6 +55,7 @@ import Wire.API.Conversation.Member hiding (Member)
 data MemberStore m a where
   CreateMembers :: ToUserRole u => ConvId -> UserList u -> MemberStore m ([LocalMember], [RemoteMember])
   CreateMembersInRemoteConversation :: Remote ConvId -> [UserId] -> MemberStore m ()
+  CreateBotMember :: ServiceRef -> BotId -> ConvId -> MemberStore m BotMember
   GetLocalMember :: ConvId -> UserId -> MemberStore m (Maybe LocalMember)
   GetLocalMembers :: ConvId -> MemberStore m [LocalMember]
   GetRemoteMembers :: ConvId -> MemberStore m [RemoteMember]

--- a/services/galley/src/Galley/Effects/MemberStore.hs
+++ b/services/galley/src/Galley/Effects/MemberStore.hs
@@ -1,0 +1,68 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.MemberStore
+  ( -- * Member store effect
+    MemberStore (..),
+
+    -- * Create members
+    createMember,
+    createMembers,
+    createMembersInRemoteConversation,
+
+    -- * Read members
+    getLocalMember,
+    getLocalMembers,
+    getRemoteMembers,
+    selectRemoteMembers,
+
+    -- * Update members
+    setSelfMember,
+    setOtherMember,
+
+    -- * Delete members
+    deleteMembers,
+    deleteMembersInRemoteConversation,
+  )
+where
+
+import Data.Id
+import Data.Qualified
+import Galley.Types.Conversations.Members
+import Galley.Types.ToUserRole
+import Galley.Types.UserList
+import Imports
+import Polysemy
+import Wire.API.Conversation.Member hiding (Member)
+
+data MemberStore m a where
+  CreateMembers :: ToUserRole u => ConvId -> UserList u -> MemberStore m ([LocalMember], [RemoteMember])
+  CreateMembersInRemoteConversation :: Remote ConvId -> [UserId] -> MemberStore m ()
+  GetLocalMember :: ConvId -> UserId -> MemberStore m (Maybe LocalMember)
+  GetLocalMembers :: ConvId -> MemberStore m [LocalMember]
+  GetRemoteMembers :: ConvId -> MemberStore m [RemoteMember]
+  SelectRemoteMembers :: [UserId] -> Remote ConvId -> MemberStore m ([UserId], Bool)
+  SetSelfMember :: Qualified ConvId -> Local UserId -> MemberUpdate -> MemberStore m ()
+  SetOtherMember :: Local ConvId -> Qualified UserId -> OtherMemberUpdate -> MemberStore m ()
+  DeleteMembers :: ConvId -> UserList UserId -> MemberStore m ()
+  DeleteMembersInRemoteConversation :: Remote ConvId -> [UserId] -> MemberStore m ()
+
+makeSem ''MemberStore
+
+-- | Add a member to a local conversation, as an admin.
+createMember :: Member MemberStore r => Local ConvId -> Local UserId -> Sem r [LocalMember]
+createMember c u = fst <$> createMembers (tUnqualified c) (UserList [tUnqualified u] [])

--- a/services/galley/src/Galley/Effects/Paging.hs
+++ b/services/galley/src/Galley/Effects/Paging.hs
@@ -1,0 +1,54 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.Paging
+  ( -- * General paging types
+    Page,
+    PagingState,
+
+    -- * Paging effect
+    ListItems (..),
+    listItems,
+
+    -- * Simple paging
+    SimplePaging,
+  )
+where
+
+import Data.Id
+import Data.Range
+import Imports
+import Polysemy
+
+type family Page p a :: (page :: *) | page -> p
+
+type family PagingState p a = (ps :: *)
+
+data ListItems p i m a where
+  ListItems ::
+    UserId ->
+    Maybe (PagingState p i) ->
+    Range 1 1000 Int32 ->
+    ListItems p i m (Page p i)
+
+makeSem ''ListItems
+
+data SimplePaging
+
+type instance Page SimplePaging a = [a]
+
+type instance PagingState SimplePaging a = ()

--- a/services/galley/src/Galley/Effects/Paging.hs
+++ b/services/galley/src/Galley/Effects/Paging.hs
@@ -19,18 +19,25 @@ module Galley.Effects.Paging
   ( -- * General paging types
     Page,
     PagingState,
+    PagingBounds,
 
     -- * Simple paging
     SimplePaging,
   )
 where
 
+import Imports
+
 type family Page p a :: (page :: *) | page -> p
 
 type family PagingState p a = (ps :: *)
+
+type family PagingBounds p a :: *
 
 data SimplePaging
 
 type instance Page SimplePaging a = [a]
 
 type instance PagingState SimplePaging a = ()
+
+type instance PagingBounds SimplePaging a = Int32

--- a/services/galley/src/Galley/Effects/RemoteConversationListStore.hs
+++ b/services/galley/src/Galley/Effects/RemoteConversationListStore.hs
@@ -1,0 +1,43 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.RemoteConversationListStore
+  ( RemoteConversationListStore (..),
+    listRemoteConversations,
+    getRemoteConversationStatus,
+  )
+where
+
+import Data.Id
+import Data.Qualified
+import Galley.Effects.Paging
+import Galley.Types.Conversations.Members
+import Imports
+import Polysemy
+
+data RemoteConversationListStore p m a where
+  ListRemoteConversations ::
+    UserId ->
+    Maybe (PagingState p (Remote ConvId)) ->
+    Int32 ->
+    RemoteConversationListStore p m (Page p (Remote ConvId))
+  GetRemoteConversationStatus ::
+    UserId ->
+    [Remote ConvId] ->
+    RemoteConversationListStore p m (Map (Remote ConvId) MemberStatus)
+
+makeSem ''RemoteConversationListStore

--- a/services/galley/src/Galley/Effects/ServiceStore.hs
+++ b/services/galley/src/Galley/Effects/ServiceStore.hs
@@ -1,0 +1,42 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.ServiceStore
+  ( -- * Service effect
+    ServiceStore (..),
+
+    -- * Create service
+    createService,
+
+    -- * Read service
+    getService,
+
+    -- * Delete service
+    deleteService,
+  )
+where
+
+import Galley.Types.Bot
+import Imports
+import Polysemy
+
+data ServiceStore m a where
+  CreateService :: Service -> ServiceStore m ()
+  GetService :: ServiceRef -> ServiceStore m (Maybe Service)
+  DeleteService :: ServiceRef -> ServiceStore m ()
+
+makeSem ''ServiceStore

--- a/services/galley/src/Galley/Effects/TeamMemberStore.hs
+++ b/services/galley/src/Galley/Effects/TeamMemberStore.hs
@@ -21,27 +21,20 @@ module Galley.Effects.TeamMemberStore
 
     -- * Team member pagination
     listTeamMembers,
-    listTeamMemberIds,
   )
 where
 
 import Data.Id
-import Data.Range
 import Galley.Effects.Paging
 import Galley.Types.Teams
 import Imports
 import Polysemy
 
-data TeamMemberStore p limit m a where
+data TeamMemberStore p m a where
   ListTeamMembers ::
     TeamId ->
-    PagingState p UserId ->
-    Range 1 limit Int32 ->
-    TeamMemberStore p limit m (Page p TeamMember)
-  ListTeamMemberIds ::
-    TeamId ->
-    PagingState p UserId ->
-    Range 1 limit Int32 ->
-    TeamMemberStore p limit m (Page p UserId)
+    Maybe (PagingState p TeamMember) ->
+    PagingBounds p TeamMember ->
+    TeamMemberStore p m (Page p TeamMember)
 
 makeSem ''TeamMemberStore

--- a/services/galley/src/Galley/Effects/TeamMemberStore.hs
+++ b/services/galley/src/Galley/Effects/TeamMemberStore.hs
@@ -15,22 +15,33 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Effects.Paging
-  ( -- * General paging types
-    Page,
-    PagingState,
+module Galley.Effects.TeamMemberStore
+  ( -- * Team member store effect
+    TeamMemberStore (..),
 
-    -- * Simple paging
-    SimplePaging,
+    -- * Team member pagination
+    listTeamMembers,
+    listTeamMemberIds,
   )
 where
 
-type family Page p a :: (page :: *) | page -> p
+import Data.Id
+import Data.Range
+import Galley.Effects.Paging
+import Galley.Types.Teams
+import Imports
+import Polysemy
 
-type family PagingState p a = (ps :: *)
+data TeamMemberStore p limit m a where
+  ListTeamMembers ::
+    TeamId ->
+    PagingState p UserId ->
+    Range 1 limit Int32 ->
+    TeamMemberStore p limit m (Page p TeamMember)
+  ListTeamMemberIds ::
+    TeamId ->
+    PagingState p UserId ->
+    Range 1 limit Int32 ->
+    TeamMemberStore p limit m (Page p UserId)
 
-data SimplePaging
-
-type instance Page SimplePaging a = [a]
-
-type instance PagingState SimplePaging a = ()
+makeSem ''TeamMemberStore

--- a/services/galley/src/Galley/Effects/TeamStore.hs
+++ b/services/galley/src/Galley/Effects/TeamStore.hs
@@ -1,0 +1,108 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.TeamStore
+  ( -- * Team store effect
+    TeamStore (..),
+
+    -- * Teams
+
+    -- ** Create teams
+    createTeam,
+
+    -- ** Read teams
+    getTeam,
+    getTeamName,
+    getTeamBinding,
+    getTeamsBindings,
+    getTeamConversation,
+    getTeamConversations,
+    getTeamCreationTime,
+    selectTeams,
+    getUserTeams,
+    getUsersTeams,
+    getOneUserTeam,
+
+    -- ** Update teams
+    deleteTeamConversation,
+    setTeamData,
+    setTeamStatus,
+
+    -- ** Delete teams
+    deleteTeam,
+
+    -- * Team Members
+
+    -- ** Create team members
+    createTeamMember,
+
+    -- ** Read team members
+    getTeamMember,
+    getTeamMembersWithLimit,
+    getTeamMembers,
+    getBillingTeamMembers,
+    selectTeamMembers,
+
+    -- ** Update team members
+    setTeamMemberPermissions,
+
+    -- ** Delete team members
+    deleteTeamMember,
+  )
+where
+
+import Data.Id
+import Data.Range
+import Galley.Types.Teams
+import Galley.Types.Teams.Intra
+import Imports
+import Polysemy
+
+data TeamStore m a where
+  CreateTeamMember :: TeamId -> TeamMember -> TeamStore m ()
+  SetTeamMemberPermissions :: Permissions -> TeamId -> UserId -> Permissions -> TeamStore m ()
+  CreateTeam ::
+    Maybe TeamId ->
+    UserId ->
+    Range 1 256 Text ->
+    Range 1 256 Text ->
+    Maybe (Range 1 256 Text) ->
+    TeamBinding ->
+    TeamStore m Team
+  DeleteTeamMember :: TeamId -> UserId -> TeamStore m ()
+  GetBillingTeamMembers :: TeamId -> TeamStore m [UserId]
+  GetTeam :: TeamId -> TeamStore m (Maybe TeamData)
+  GetTeamName :: TeamId -> TeamStore m (Maybe Text)
+  GetTeamConversation :: TeamId -> ConvId -> TeamStore m (Maybe TeamConversation)
+  GetTeamConversations :: TeamId -> TeamStore m [TeamConversation]
+  SelectTeams :: UserId -> [TeamId] -> TeamStore m [TeamId]
+  GetTeamMember :: TeamId -> UserId -> TeamStore m (Maybe TeamMember)
+  GetTeamMembersWithLimit :: TeamId -> Range 1 HardTruncationLimit Int32 -> TeamStore m TeamMemberList
+  GetTeamMembers :: TeamId -> TeamStore m [TeamMember]
+  SelectTeamMembers :: TeamId -> [UserId] -> TeamStore m [TeamMember]
+  GetUserTeams :: UserId -> TeamStore m [TeamId]
+  GetUsersTeams :: [UserId] -> TeamStore m (Map UserId TeamId)
+  GetOneUserTeam :: UserId -> TeamStore m (Maybe TeamId)
+  GetTeamsBindings :: [TeamId] -> TeamStore m [TeamBinding]
+  GetTeamBinding :: TeamId -> TeamStore m (Maybe TeamBinding)
+  GetTeamCreationTime :: TeamId -> TeamStore m (Maybe TeamCreationTime)
+  DeleteTeam :: TeamId -> TeamStore m ()
+  DeleteTeamConversation :: TeamId -> ConvId -> TeamStore m ()
+  SetTeamData :: TeamId -> TeamUpdateData -> TeamStore m ()
+  SetTeamStatus :: TeamId -> TeamStatus -> TeamStore m ()
+
+makeSem ''TeamStore

--- a/services/galley/src/Galley/Effects/TeamStore.hs
+++ b/services/galley/src/Galley/Effects/TeamStore.hs
@@ -32,6 +32,7 @@ module Galley.Effects.TeamStore
     getTeamConversation,
     getTeamConversations,
     getTeamCreationTime,
+    listTeams,
     selectTeams,
     getUserTeams,
     getUsersTeams,
@@ -67,6 +68,8 @@ where
 
 import Data.Id
 import Data.Range
+import Galley.Effects.ListItems
+import Galley.Effects.Paging
 import Galley.Types.Teams
 import Galley.Types.Teams.Intra
 import Imports
@@ -106,3 +109,11 @@ data TeamStore m a where
   SetTeamStatus :: TeamId -> TeamStatus -> TeamStore m ()
 
 makeSem ''TeamStore
+
+listTeams ::
+  Member (ListItems p TeamId) r =>
+  UserId ->
+  Maybe (PagingState p TeamId) ->
+  PagingBounds p TeamId ->
+  Sem r (Page p TeamId)
+listTeams = listItems

--- a/services/galley/src/Galley/Env.hs
+++ b/services/galley/src/Galley/Env.hs
@@ -1,0 +1,60 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Env where
+
+import Cassandra
+import Control.Lens
+import Data.Id
+import Data.Metrics.Middleware
+import Data.Misc (Fingerprint, Rsa)
+import qualified Galley.Aws as Aws
+import Galley.Options
+import qualified Galley.Queue as Q
+import Imports
+import Network.HTTP.Client
+import OpenSSL.Session as Ssl
+import System.Logger
+import Util.Options
+
+data DeleteItem = TeamItem TeamId UserId (Maybe ConnId)
+  deriving (Eq, Ord, Show)
+
+-- | Main application environment.
+data Env = Env
+  { _reqId :: RequestId,
+    _monitor :: Metrics,
+    _options :: Opts,
+    _applog :: Logger,
+    _manager :: Manager,
+    _federator :: Maybe Endpoint, -- FUTUREWORK: should we use a better type here? E.g. to avoid fresh connections all the time?
+    _brig :: Endpoint, -- FUTUREWORK: see _federator
+    _cstate :: ClientState,
+    _deleteQueue :: Q.Queue DeleteItem,
+    _extEnv :: ExtEnv,
+    _aEnv :: Maybe Aws.Env
+  }
+
+-- | Environment specific to the communication with external
+-- service providers.
+data ExtEnv = ExtEnv
+  { _extGetManager :: (Manager, [Fingerprint Rsa] -> Ssl.SSL -> IO ())
+  }
+
+makeLenses ''Env
+
+makeLenses ''ExtEnv

--- a/services/galley/src/Galley/External.hs
+++ b/services/galley/src/Galley/External.hs
@@ -30,8 +30,8 @@ import Data.ByteString.Conversion.To
 import Data.Id
 import Data.Misc
 import Galley.App
+import Galley.Cassandra.Services
 import Galley.Data.Services (BotMember, botMemId, botMemService)
-import qualified Galley.Data.Services as Data
 import Galley.Effects
 import Galley.Intra.User
 import Galley.Types (Event)
@@ -75,7 +75,7 @@ deliver0 pp = mapM (async . exec) pp >>= foldM eval [] . zip (map fst pp)
   where
     exec :: (BotMember, Event) -> Galley0 Bool
     exec (b, e) =
-      Data.lookupService (botMemService b) >>= \case
+      lookupService (botMemService b) >>= \case
         Nothing -> return False
         Just s -> do
           deliver1 s b e

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -37,7 +37,7 @@ import Galley.API.Federation (federationSitemap)
 import qualified Galley.API.Internal as Internal
 import Galley.App
 import qualified Galley.App as App
-import qualified Galley.Data as Data
+import Galley.Cassandra
 import Galley.Options (Opts, optGalley)
 import qualified Galley.Queue as Q
 import Imports
@@ -82,7 +82,7 @@ mkApp o = do
   e <- App.createEnv m o
   let l = e ^. App.applog
   runClient (e ^. cstate) $
-    versionCheck Data.schemaVersion
+    versionCheck schemaVersion
   let finalizer = do
         Log.info l $ Log.msg @Text "Galley application finished."
         Log.flush l

--- a/services/galley/src/Galley/Types/ToUserRole.hs
+++ b/services/galley/src/Galley/Types/ToUserRole.hs
@@ -1,0 +1,30 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Types.ToUserRole where
+
+import Data.Id
+import Wire.API.Conversation.Role
+
+class ToUserRole a where
+  toUserRole :: a -> (UserId, RoleName)
+
+instance ToUserRole (UserId, RoleName) where
+  toUserRole x = x
+
+instance ToUserRole UserId where
+  toUserRole uid = (uid, roleNameWireAdmin)

--- a/services/galley/src/Galley/Validation.hs
+++ b/services/galley/src/Galley/Validation.hs
@@ -28,15 +28,18 @@ import Control.Lens
 import Control.Monad.Catch
 import Data.Range
 import Galley.API.Error
-import Galley.App
+import Galley.Env
 import Galley.Options
 import Imports
 
-rangeChecked :: Within a n m => a -> Galley r (Range n m a)
+rangeChecked :: (MonadThrow galley, Within a n m) => a -> galley (Range n m a)
 rangeChecked = either throwErr return . checkedEither
 {-# INLINE rangeChecked #-}
 
-rangeCheckedMaybe :: Within a n m => Maybe a -> Galley r (Maybe (Range n m a))
+rangeCheckedMaybe ::
+  (MonadThrow galley, Within a n m) =>
+  Maybe a ->
+  galley (Maybe (Range n m a))
 rangeCheckedMaybe Nothing = return Nothing
 rangeCheckedMaybe (Just a) = Just <$> rangeChecked a
 {-# INLINE rangeCheckedMaybe #-}
@@ -45,7 +48,10 @@ rangeCheckedMaybe (Just a) = Just <$> rangeChecked a
 newtype ConvSizeChecked f a = ConvSizeChecked {fromConvSize :: f a}
   deriving (Functor, Foldable, Traversable)
 
-checkedConvSize :: Foldable f => f a -> Galley r (ConvSizeChecked f a)
+checkedConvSize ::
+  (MonadReader Env galley, MonadThrow galley, Foldable f) =>
+  f a ->
+  galley (ConvSizeChecked f a)
 checkedConvSize x = do
   o <- view options
   let minV :: Integer = 0
@@ -54,5 +60,5 @@ checkedConvSize x = do
     then return (ConvSizeChecked x)
     else throwErr (errorMsg minV limit "")
 
-throwErr :: String -> Galley r a
+throwErr :: MonadThrow galley => String -> galley a
 throwErr = throwM . invalidRange . fromString

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -65,7 +65,7 @@ import Data.String.Conversions (LBS, cs)
 import Data.Text.Encoding (encodeUtf8)
 import qualified Data.Time.Clock as Time
 import qualified Galley.App as Galley
-import qualified Galley.Data as Data
+import Galley.Cassandra.Client
 import qualified Galley.Data.LegalHold as LegalHoldData
 import Galley.External.LegalHoldService (validateServiceKey)
 import Galley.Options (optSettings, setFeatureFlags)
@@ -324,7 +324,7 @@ testApproveLegalHoldDevice = do
         renewToken authToken
       cassState <- view tsCass
       liftIO $ do
-        clients' <- Cql.runClient cassState $ Data.lookupClients' [member]
+        clients' <- Cql.runClient cassState $ lookupClients [member]
         assertBool "Expect clientId to be saved on the user" $
           Clients.contains member someClientId clients'
       UserLegalHoldStatusResponse userStatus _ _ <- getUserStatusTyped member tid

--- a/services/galley/test/integration/API/Teams/LegalHold/DisabledByDefault.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold/DisabledByDefault.hs
@@ -59,7 +59,7 @@ import qualified Data.Set as Set
 import Data.String.Conversions (LBS, cs)
 import Data.Text.Encoding (encodeUtf8)
 import qualified Galley.App as Galley
-import qualified Galley.Data as Data
+import Galley.Cassandra.Client
 import qualified Galley.Data.LegalHold as LegalHoldData
 import Galley.External.LegalHoldService (validateServiceKey)
 import Galley.Options (optSettings, setFeatureFlags)
@@ -256,7 +256,7 @@ testApproveLegalHoldDevice = do
         renewToken authToken
       cassState <- view tsCass
       liftIO $ do
-        clients' <- Cql.runClient cassState $ Data.lookupClients' [member]
+        clients' <- Cql.runClient cassState $ lookupClients [member]
         assertBool "Expect clientId to be saved on the user" $
           Clients.contains member someClientId clients'
       UserLegalHoldStatusResponse userStatus _ _ <- getUserStatusTyped member tid

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -25,7 +25,7 @@ import Data.Domain
 import Data.Id
 import Data.Qualified
 import Galley.API.Mapping
-import qualified Galley.Data as Data
+import qualified Galley.Data.Conversation as Data
 import Galley.Types.Conversations.Members
 import Imports
 import Test.Tasty


### PR DESCRIPTION
This PR introduces store effects as part of the conversion of Galley to Sem.

## Overall plan

*(This is subject to change.)*

 1. Turn `Galley` into a newtype over `Sem`, and introduce "access" effects.
 2. **Add "store" effects and convert `Data` code into interpretations.** (this pr)
 3. Turn placeholders into actual effects.
 4. Make `Galley` into a type synonym over `Sem`, and get rid of `Galley0`.
 5. Add fine-grained `Error` effects, and integrate them with `Servant`.

## Summary

 - [x] Add `ConversationStore` effect
 - [x] Add conversation paging effects
 - [x] Add `MemberStore` effect
 - [x] Add `TeamStore` effect
 - [x] Add `ClientStore` effect
 - [x] Add `CodeStore` effect

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
