### PR TITLE
Extend a Federation API Test for Getting Conversations

### DIFF
--- a/changelog.d/6-federation/extend-get-conversations-test
+++ b/changelog.d/6-federation/extend-get-conversations-test
@@ -1,0 +1,1 @@
+Add a one-to-one conversation test in getting conversations in the federation API


### PR DESCRIPTION
The PR extends a federation API test for getting conversations to also include a one-to-one conversation with a remote user.

https://wearezeta.atlassian.net/browse/FS-53

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
