### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,1 +1,1 @@
-Upgrade Webapp to image tag: 20021-10-28-federation-m1
+Upgrade webapp version to 2021-11-01-production.0-v0.28.29-0-d919633

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2021-10-28-federation-M1"
+  tag: "2021-11-01-production.0-v0.28.29-0-d919633"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2021-11-01-production.0-v0.28.29-0-d919633`
Release: [`2021-11-01-production.0`](https://github.com/wireapp/wire-webapp/releases/tag/2021-11-01-production.0)