### PR TITLE
Fix: push events when AppLock or SelfDeletingMessages config change.

### DIFF
--- a/changelog.d/3-bug-fixes/pr-1901
+++ b/changelog.d/3-bug-fixes/pr-1901
@@ -1,0 +1,1 @@
+Push events when AppLock or SelfDeletingMessages config change.


### PR DESCRIPTION
- Emit event when SelfDeletingMessages config changes (oversight in https://github.com/wireapp/wire-server/pull/1857)
- Same for AppLock config (oversight back then)
- Remove unused event (classified domains are not changed via rest api, so event cannot occur)

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
