### PR TITLE
Galley polysemy (3/5) - Access effects

### DIFF
--- a/changelog.d/5-internal/polysemy-access-effects
+++ b/changelog.d/5-internal/polysemy-access-effects
@@ -1,0 +1,1 @@
+Turn placeholder access effects into actual Polysemy effects.

--- a/libs/bilge/src/Bilge/IO.hs
+++ b/libs/bilge/src/Bilge/IO.hs
@@ -91,7 +91,7 @@ data Debug
     Full
   deriving (Eq, Ord, Show, Enum)
 
-type Http a = HttpT IO a
+type Http = HttpT IO
 
 newtype HttpT m a = HttpT
   { unwrap :: ReaderT Manager m a

--- a/libs/bilge/src/Bilge/RPC.hs
+++ b/libs/bilge/src/Bilge/RPC.hs
@@ -45,6 +45,9 @@ import System.Logger.Class
 class HasRequestId m where
   getRequestId :: m RequestId
 
+instance Monad m => HasRequestId (ReaderT RequestId m) where
+  getRequestId = ask
+
 data RPCException = RPCException
   { rpceRemote :: !LText,
     rpceRequest :: !Request,

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1b185cc3a9afe5d7a6c21c93d6c031963a5eb924885b6314ffc92ce96c6b545d
+-- hash: 38ac7f6aba3a32570b8ba7cee173570f8bbe29c53084b8aac249f9b809e49d86
 
 name:           galley
 version:        0.83.0
@@ -71,6 +71,8 @@ library
       Galley.Data.TeamNotifications
       Galley.Data.Types
       Galley.Effects
+      Galley.Effects.BotAccess
+      Galley.Effects.BrigAccess
       Galley.Effects.ClientStore
       Galley.Effects.CodeStore
       Galley.Effects.ConversationStore
@@ -80,12 +82,15 @@ library
       Galley.Effects.Paging
       Galley.Effects.RemoteConversationListStore
       Galley.Effects.ServiceStore
+      Galley.Effects.SparAccess
       Galley.Effects.TeamMemberStore
       Galley.Effects.TeamStore
       Galley.Env
       Galley.External
       Galley.External.LegalHoldService
+      Galley.External.LegalHoldService.Types
       Galley.Intra.Client
+      Galley.Intra.Effects
       Galley.Intra.Journal
       Galley.Intra.Push
       Galley.Intra.Spar

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0288be53c0e2448eda9a34b6b6647916892e60b409b27b6132e12e238184073c
+-- hash: aaed6006a10580d11a903fa32d0d6d09234867ab992f293833616eb68c7071bb
 
 name:           galley
 version:        0.83.0
@@ -77,6 +77,7 @@ library
       Galley.Effects.CodeStore
       Galley.Effects.ConversationStore
       Galley.Effects.ExternalAccess
+      Galley.Effects.FederatorAccess
       Galley.Effects.FireAndForget
       Galley.Effects.GundeckAccess
       Galley.Effects.ListItems
@@ -93,6 +94,8 @@ library
       Galley.External.LegalHoldService.Types
       Galley.Intra.Client
       Galley.Intra.Effects
+      Galley.Intra.Federator
+      Galley.Intra.Federator.Types
       Galley.Intra.Journal
       Galley.Intra.Push
       Galley.Intra.Push.Internal
@@ -171,6 +174,7 @@ library
     , saml2-web-sso >=0.18
     , servant
     , servant-client
+    , servant-client-core
     , servant-server
     , servant-swagger
     , servant-swagger-ui

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 38ac7f6aba3a32570b8ba7cee173570f8bbe29c53084b8aac249f9b809e49d86
+-- hash: 3bd7e34f83220a77974f10753932ac7b2173378ff547bd97176857a87c3d2d4b
 
 name:           galley
 version:        0.83.0
@@ -77,6 +77,7 @@ library
       Galley.Effects.CodeStore
       Galley.Effects.ConversationStore
       Galley.Effects.FireAndForget
+      Galley.Effects.GundeckAccess
       Galley.Effects.ListItems
       Galley.Effects.MemberStore
       Galley.Effects.Paging
@@ -93,6 +94,7 @@ library
       Galley.Intra.Effects
       Galley.Intra.Journal
       Galley.Intra.Push
+      Galley.Intra.Push.Internal
       Galley.Intra.Spar
       Galley.Intra.Team
       Galley.Intra.User

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3bd7e34f83220a77974f10753932ac7b2173378ff547bd97176857a87c3d2d4b
+-- hash: 0288be53c0e2448eda9a34b6b6647916892e60b409b27b6132e12e238184073c
 
 name:           galley
 version:        0.83.0
@@ -76,6 +76,7 @@ library
       Galley.Effects.ClientStore
       Galley.Effects.CodeStore
       Galley.Effects.ConversationStore
+      Galley.Effects.ExternalAccess
       Galley.Effects.FireAndForget
       Galley.Effects.GundeckAccess
       Galley.Effects.ListItems

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -76,6 +76,7 @@ library:
   - retry >=0.5
   - safe-exceptions >=0.1
   - servant
+  - servant-client-core
   - servant-server
   - servant-swagger
   - servant-swagger-ui

--- a/services/galley/src/Galley/API/Clients.hs
+++ b/services/galley/src/Galley/API/Clients.hs
@@ -26,8 +26,8 @@ import Control.Lens (view)
 import Data.Id
 import Galley.App
 import Galley.Effects
+import qualified Galley.Effects.BrigAccess as E
 import qualified Galley.Effects.ClientStore as E
-import qualified Galley.Intra.Client as Intra
 import Galley.Options
 import Galley.Types.Clients (clientIds, fromUserClients)
 import Imports
@@ -49,9 +49,10 @@ getClients ::
 getClients usr = do
   isInternal <- view $ options . optSettings . setIntraListing
   clts <-
-    if isInternal
-      then fromUserClients <$> Intra.lookupClients [usr]
-      else liftSem $ E.getClients [usr]
+    liftSem $
+      if isInternal
+        then fromUserClients <$> E.lookupClients [usr]
+        else E.getClients [usr]
   return $ clientIds usr clts
 
 addClientH ::

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -41,9 +41,9 @@ import Galley.API.Util
 import Galley.App
 import qualified Galley.Data.Conversation as Data
 import Galley.Effects
+import qualified Galley.Effects.BrigAccess as E
 import qualified Galley.Effects.ConversationStore as E
 import qualified Galley.Effects.MemberStore as E
-import Galley.Intra.User (getConnections)
 import Galley.Types.Conversations.Members (LocalMember (..), defMemberStatus)
 import Galley.Types.UserList
 import Imports
@@ -216,7 +216,7 @@ addLocalUsersToRemoteConv ::
   [UserId] ->
   Galley r (Set UserId)
 addLocalUsersToRemoteConv remoteConvId qAdder localUsers = do
-  connStatus <- getConnections localUsers (Just [qAdder]) (Just Accepted)
+  connStatus <- liftSem $ E.getConnections localUsers (Just [qAdder]) (Just Accepted)
   let localUserIdsSet = Set.fromList localUsers
       connected = Set.fromList $ fmap csv2From connStatus
       unconnected = Set.difference localUserIdsSet connected

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -57,6 +57,7 @@ import qualified Galley.Data.Conversation as Data
 import Galley.Effects
 import Galley.Effects.ClientStore
 import Galley.Effects.ConversationStore
+import Galley.Effects.GundeckAccess
 import Galley.Effects.MemberStore
 import Galley.Effects.Paging
 import Galley.Effects.TeamStore
@@ -556,7 +557,7 @@ rmUser user conn = do
           | otherwise -> return Nothing
       for_
         (maybeList1 (catMaybes pp))
-        Intra.push
+        (liftSem . push)
 
     leaveRemoteConversations :: Local UserId -> Range 1 FedGalley.UserDeletedNotificationMaxConvs [Remote ConvId] -> Galley r ()
     leaveRemoteConversations lusr cids = do

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -29,9 +29,9 @@ import Galley.Effects
 import Galley.Effects.BrigAccess
 import Galley.Effects.ClientStore
 import Galley.Effects.ConversationStore
+import Galley.Effects.ExternalAccess
 import Galley.Effects.GundeckAccess hiding (Push)
 import Galley.Effects.MemberStore
-import qualified Galley.External as External
 import Galley.Intra.Push
 import Galley.Options (optSettings, setIntraListing)
 import qualified Galley.Types.Clients as Clients
@@ -454,7 +454,7 @@ runMessagePush cnv mp = do
       if localDomain /= qDomain cnv
         then unless (null pushes) $ do
           Log.warn $ Log.msg ("Ignoring messages for local bots in a remote conversation" :: ByteString) . Log.field "conversation" (show cnv)
-        else External.deliverAndDeleteAsync (qUnqualified cnv) pushes
+        else liftSem $ deliverAndDeleteAsync (qUnqualified cnv) pushes
 
 newMessageEvent :: Qualified ConvId -> Qualified UserId -> ClientId -> Maybe Text -> UTCTime -> ClientId -> Text -> Event
 newMessageEvent convId sender senderClient dat time receiverClient cipherText =

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -26,11 +26,11 @@ import Galley.API.Util
 import Galley.App
 import Galley.Data.Services as Data
 import Galley.Effects
+import Galley.Effects.BrigAccess
 import Galley.Effects.ClientStore
 import Galley.Effects.ConversationStore
 import Galley.Effects.MemberStore
 import qualified Galley.External as External
-import qualified Galley.Intra.Client as Intra
 import Galley.Intra.Push
 import Galley.Options (optSettings, setIntraListing)
 import qualified Galley.Types.Clients as Clients
@@ -255,10 +255,10 @@ postQualifiedOtrMessage senderType sender mconn convId msg = runExceptT $ do
 
   -- get local clients
   localClients <-
-    lift $
+    lift . liftSem $
       if isInternal
-        then Clients.fromUserClients <$> Intra.lookupClients localMemberIds
-        else liftSem $ getClients localMemberIds
+        then Clients.fromUserClients <$> lookupClients localMemberIds
+        else getClients localMemberIds
   let qualifiedLocalClients =
         Map.mapKeys (localDomain,)
           . makeUserMap (Set.fromList (map lmId localMembers))

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -29,6 +29,7 @@ import Galley.Effects
 import Galley.Effects.BrigAccess
 import Galley.Effects.ClientStore
 import Galley.Effects.ConversationStore
+import Galley.Effects.GundeckAccess hiding (Push)
 import Galley.Effects.MemberStore
 import qualified Galley.External as External
 import Galley.Intra.Push
@@ -444,7 +445,7 @@ runMessagePush ::
   MessagePush ->
   Galley r ()
 runMessagePush cnv mp = do
-  pushSome (userPushes mp)
+  liftSem $ push (userPushes mp)
   pushToBots (botPushes mp)
   where
     pushToBots :: [(BotMember, Event)] -> Galley r ()

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -63,9 +63,10 @@ import Galley.Cassandra.Paging
 import qualified Galley.Data.SearchVisibility as SearchVisibilityData
 import qualified Galley.Data.TeamFeatures as TeamFeatures
 import Galley.Effects
+import Galley.Effects.GundeckAccess
 import Galley.Effects.Paging
 import Galley.Effects.TeamStore
-import Galley.Intra.Push (PushEvent (FeatureConfigEvent), newPush, push1)
+import Galley.Intra.Push (PushEvent (FeatureConfigEvent), newPush)
 import Galley.Options
 import Galley.Types.Teams hiding (newTeam)
 import Imports
@@ -459,7 +460,7 @@ pushFeatureConfigEvent tid event = do
   let recipients = membersToRecipients Nothing (memList ^. teamMembers)
   for_
     (newPush (memList ^. teamMemberListType) Nothing (FeatureConfigEvent event) recipients)
-    push1
+    (liftSem . push1)
 
 -- | (Currently, we only have 'Public.TeamFeatureConferenceCalling' here, but we may have to
 -- extend this in the future.)

--- a/services/galley/src/Galley/API/Teams/Notifications.hs
+++ b/services/galley/src/Galley/API/Teams/Notifications.hs
@@ -52,7 +52,7 @@ import Galley.API.Error
 import Galley.App
 import qualified Galley.Data.TeamNotifications as DataTeamQueue
 import Galley.Effects
-import Galley.Intra.User as Intra
+import Galley.Effects.BrigAccess as Intra
 import Galley.Types.Teams hiding (newTeam)
 import Gundeck.Types.Notification
 import Imports
@@ -67,7 +67,7 @@ getTeamNotifications ::
   Galley r QueuedNotificationList
 getTeamNotifications zusr since size = do
   tid :: TeamId <- do
-    mtid <- (userTeam . accountUser =<<) <$> Intra.getUser zusr
+    mtid <- liftSem $ (userTeam . accountUser =<<) <$> Intra.getUser zusr
     let err = throwM teamNotFound
     maybe err pure mtid
   page <- DataTeamQueue.fetch tid since size

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -48,10 +48,10 @@ import Galley.Effects
 import Galley.Effects.BrigAccess
 import Galley.Effects.CodeStore
 import Galley.Effects.ConversationStore
+import Galley.Effects.ExternalAccess
 import Galley.Effects.GundeckAccess
 import Galley.Effects.MemberStore
 import Galley.Effects.TeamStore
-import qualified Galley.External as External
 import Galley.Intra.Push
 import Galley.Options (optSettings, setFeatureFlags, setFederationDomain)
 import Galley.Types
@@ -586,7 +586,7 @@ pushConversationEvent conn e users bots = do
   localDomain <- viewFederationDomain
   for_ (newConversationEventPush localDomain e (toList users)) $ \p ->
     liftSem $ push1 $ p & set pushConn conn
-  External.deliverAsync (toList bots `zip` repeat e)
+  liftSem $ deliverAsync (toList bots `zip` repeat e)
 
 verifyReusableCode ::
   Member CodeStore r =>

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -96,6 +96,7 @@ import Galley.Cassandra.Team
 import Galley.Effects
 import qualified Galley.Effects.FireAndForget as E
 import Galley.Env
+import Galley.External
 import Galley.Intra.Effects
 import Galley.Options
 import qualified Galley.Queue as Q
@@ -338,7 +339,7 @@ interpretGalleyToGalley0 =
     . interpretFireAndForget
     . interpretBotAccess
     . interpretFederator
-    . interpretExternal
+    . interpretExternalAccess
     . interpretSparAccess
     . interpretGundeckAccess
     . interpretBrigAccess

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -94,10 +94,12 @@ import Galley.Cassandra.ConversationList
 import Galley.Cassandra.Services
 import Galley.Cassandra.Team
 import Galley.Effects
+import Galley.Effects.FireAndForget (interpretFireAndForget)
 import qualified Galley.Effects.FireAndForget as E
 import Galley.Env
 import Galley.External
 import Galley.Intra.Effects
+import Galley.Intra.Federator
 import Galley.Options
 import qualified Galley.Queue as Q
 import qualified Galley.Types.Teams as Teams
@@ -338,7 +340,7 @@ interpretGalleyToGalley0 =
     . interpretClientStoreToCassandra
     . interpretFireAndForget
     . interpretBotAccess
-    . interpretFederator
+    . interpretFederatorAccess
     . interpretExternalAccess
     . interpretSparAccess
     . interpretGundeckAccess

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -50,7 +50,6 @@ module Galley.App
     fromJsonBody,
     fromOptionalJsonBody,
     fromProtoBody,
-    initExtEnv,
     fanoutLimit,
     currentFanoutLimit,
 
@@ -97,6 +96,7 @@ import Galley.Cassandra.Team
 import Galley.Effects
 import qualified Galley.Effects.FireAndForget as E
 import Galley.Env
+import Galley.Intra.Effects
 import Galley.Options
 import qualified Galley.Queue as Q
 import qualified Galley.Types.Teams as Teams
@@ -110,7 +110,6 @@ import Network.Wai
 import Network.Wai.Utilities hiding (Error)
 import qualified Network.Wai.Utilities as WaiError
 import qualified Network.Wai.Utilities.Server as Server
-import OpenSSL.EVP.Digest (getDigestByName)
 import OpenSSL.Session as Ssl
 import qualified OpenSSL.X509.SystemStore as Ssl
 import Polysemy
@@ -256,29 +255,6 @@ initHttpManager o = do
         managerIdleConnectionCount = 3 * (o ^. optSettings . setHttpPoolSize)
       }
 
--- TODO: somewhat duplicates Brig.App.initExtGetManager
-initExtEnv :: IO ExtEnv
-initExtEnv = do
-  ctx <- Ssl.context
-  Ssl.contextSetVerificationMode ctx Ssl.VerifyNone
-  Ssl.contextAddOption ctx SSL_OP_NO_SSLv2
-  Ssl.contextAddOption ctx SSL_OP_NO_SSLv3
-  Ssl.contextAddOption ctx SSL_OP_NO_TLSv1
-  Ssl.contextSetCiphers ctx rsaCiphers
-  Ssl.contextLoadSystemCerts ctx
-  mgr <-
-    newManager
-      (opensslManagerSettings (pure ctx))
-        { managerResponseTimeout = responseTimeoutMicro 10000000,
-          managerConnCount = 100
-        }
-  Just sha <- getDigestByName "SHA256"
-  return $ ExtEnv (mgr, mkVerify sha)
-  where
-    mkVerify sha fprs =
-      let pinset = map toByteString' fprs
-       in verifyRsaFingerprint sha pinset
-
 runGalley :: Env -> Request -> Galley GalleyEffects a -> IO a
 runGalley e r m =
   let e' = reqId .~ lookupReqId r $ e
@@ -371,12 +347,12 @@ interpretGalleyToGalley0 =
     . interpretClientStoreToCassandra
     . interpretFireAndForget
     . interpretIntra
-    . interpretBot
+    . interpretBotAccess
     . interpretFederator
     . interpretExternal
-    . interpretSpar
+    . interpretSparAccess
     . interpretGundeck
-    . interpretBrig
+    . interpretBrigAccess
     . unGalley
 
 ----------------------------------------------------------------------------------

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -346,7 +346,6 @@ interpretGalleyToGalley0 =
     . interpretCodeStoreToCassandra
     . interpretClientStoreToCassandra
     . interpretFireAndForget
-    . interpretIntra
     . interpretBotAccess
     . interpretFederator
     . interpretExternal

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -168,12 +168,6 @@ instance HasFederatorConfig (Galley r) where
 fanoutLimit :: Galley r (Range 1 Teams.HardTruncationLimit Int32)
 fanoutLimit = view options >>= return . currentFanoutLimit
 
-currentFanoutLimit :: Opts -> Range 1 Teams.HardTruncationLimit Int32
-currentFanoutLimit o = do
-  let optFanoutLimit = fromIntegral . fromRange $ fromMaybe defFanoutLimit (o ^. optSettings ^. setMaxFanoutSize)
-  let maxTeamSize = fromIntegral (o ^. optSettings ^. setMaxTeamSize)
-  unsafeRange (min maxTeamSize optFanoutLimit)
-
 -- Define some invariants for the options used
 validateOptions :: Logger -> Opts -> IO ()
 validateOptions l o = do
@@ -282,10 +276,6 @@ evalGalley e = evalGalley0 e . unGalley . interpretGalleyToGalley0
 lookupReqId :: Request -> RequestId
 lookupReqId = maybe def RequestId . lookup requestIdName . requestHeaders
 
-reqIdMsg :: RequestId -> Logger.Msg -> Logger.Msg
-reqIdMsg = ("request" .=) . unRequestId
-{-# INLINE reqIdMsg #-}
-
 fromJsonBody :: FromJSON a => JsonRequest a -> Galley r a
 fromJsonBody r = exceptT (throwM . invalidPayload) return (parseBody r)
 {-# INLINE fromJsonBody #-}
@@ -350,7 +340,7 @@ interpretGalleyToGalley0 =
     . interpretFederator
     . interpretExternal
     . interpretSparAccess
-    . interpretGundeck
+    . interpretGundeckAccess
     . interpretBrigAccess
     . unGalley
 

--- a/services/galley/src/Galley/Data/LegalHold.hs
+++ b/services/galley/src/Galley/Data/LegalHold.hs
@@ -36,10 +36,10 @@ import Cassandra
 import Control.Lens (unsnoc, view)
 import Data.Id
 import Data.LegalHold
-import Galley.App (Env, options)
 import qualified Galley.Cassandra.LegalHold as C
 import Galley.Data.Instances ()
 import Galley.Data.Queries as Q
+import Galley.Env
 import qualified Galley.Options as Opts
 import Galley.Types.Teams (flagLegalHold)
 import Imports

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -25,14 +25,12 @@ module Galley.Effects
     FederatorAccess,
     GundeckAccess,
     SparAccess,
-    interpretFederator,
 
     -- * External services
     ExternalAccess,
 
     -- * Fire-and-forget async
     FireAndForget,
-    interpretFireAndForget,
 
     -- * Store effects
     ClientStore,
@@ -61,6 +59,7 @@ import Galley.Effects.ClientStore
 import Galley.Effects.CodeStore
 import Galley.Effects.ConversationStore
 import Galley.Effects.ExternalAccess
+import Galley.Effects.FederatorAccess
 import Galley.Effects.FireAndForget
 import Galley.Effects.GundeckAccess
 import Galley.Effects.ListItems
@@ -69,13 +68,7 @@ import Galley.Effects.ServiceStore
 import Galley.Effects.SparAccess
 import Galley.Effects.TeamMemberStore
 import Galley.Effects.TeamStore
-import Imports
 import Polysemy
-
-data FederatorAccess m a
-
-interpretFederator :: Sem (FederatorAccess ': r) a -> Sem r a
-interpretFederator = interpret $ \case
 
 -- All the possible high-level effects.
 type GalleyEffects1 =

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -19,10 +19,6 @@ module Galley.Effects
   ( -- * Effects needed in Galley
     GalleyEffects1,
 
-    -- * Internal services
-    Intra,
-    interpretIntra,
-
     -- * Brig
     BrigAccess,
 
@@ -84,11 +80,6 @@ import Galley.Effects.TeamStore
 import Imports
 import Polysemy
 
-data Intra m a
-
-interpretIntra :: Sem (Intra ': r) a -> Sem r a
-interpretIntra = interpret $ \case
-
 data GundeckAccess m a
 
 interpretGundeck :: Sem (GundeckAccess ': r) a -> Sem r a
@@ -112,7 +103,6 @@ type GalleyEffects1 =
      ExternalAccess,
      FederatorAccess,
      BotAccess,
-     Intra,
      FireAndForget,
      ClientStore,
      CodeStore,

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -25,7 +25,6 @@ module Galley.Effects
 
     -- * Brig
     BrigAccess,
-    interpretBrig,
 
     -- * Federator
     FederatorAccess,
@@ -33,7 +32,6 @@ module Galley.Effects
 
     -- * Spar
     SparAccess,
-    interpretSpar,
 
     -- * Gundeck
     GundeckAccess,
@@ -45,7 +43,6 @@ module Galley.Effects
 
     -- * Bot API
     BotAccess,
-    interpretBot,
 
     -- * Fire-and-forget async
     FireAndForget,
@@ -72,6 +69,8 @@ where
 import Data.Id
 import Data.Qualified
 import Galley.Cassandra.Paging
+import Galley.Effects.BotAccess
+import Galley.Effects.BrigAccess
 import Galley.Effects.ClientStore
 import Galley.Effects.CodeStore
 import Galley.Effects.ConversationStore
@@ -79,6 +78,7 @@ import Galley.Effects.FireAndForget
 import Galley.Effects.ListItems
 import Galley.Effects.MemberStore
 import Galley.Effects.ServiceStore
+import Galley.Effects.SparAccess
 import Galley.Effects.TeamMemberStore
 import Galley.Effects.TeamStore
 import Imports
@@ -88,11 +88,6 @@ data Intra m a
 
 interpretIntra :: Sem (Intra ': r) a -> Sem r a
 interpretIntra = interpret $ \case
-
-data BrigAccess m a
-
-interpretBrig :: Sem (BrigAccess ': r) a -> Sem r a
-interpretBrig = interpret $ \case
 
 data GundeckAccess m a
 
@@ -108,16 +103,6 @@ data FederatorAccess m a
 
 interpretFederator :: Sem (FederatorAccess ': r) a -> Sem r a
 interpretFederator = interpret $ \case
-
-data SparAccess m a
-
-interpretSpar :: Sem (SparAccess ': r) a -> Sem r a
-interpretSpar = interpret $ \case
-
-data BotAccess m a
-
-interpretBot :: Sem (BotAccess ': r) a -> Sem r a
-interpretBot = interpret $ \case
 
 -- All the possible high-level effects.
 type GalleyEffects1 =

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -20,18 +20,15 @@ module Galley.Effects
     GalleyEffects1,
 
     -- * Effects to access the Intra API
+    BotAccess,
     BrigAccess,
     FederatorAccess,
-    SparAccess,
     GundeckAccess,
+    SparAccess,
     interpretFederator,
 
     -- * External services
     ExternalAccess,
-    interpretExternal,
-
-    -- * Bot API
-    BotAccess,
 
     -- * Fire-and-forget async
     FireAndForget,
@@ -63,6 +60,7 @@ import Galley.Effects.BrigAccess
 import Galley.Effects.ClientStore
 import Galley.Effects.CodeStore
 import Galley.Effects.ConversationStore
+import Galley.Effects.ExternalAccess
 import Galley.Effects.FireAndForget
 import Galley.Effects.GundeckAccess
 import Galley.Effects.ListItems
@@ -73,11 +71,6 @@ import Galley.Effects.TeamMemberStore
 import Galley.Effects.TeamStore
 import Imports
 import Polysemy
-
-data ExternalAccess m a
-
-interpretExternal :: Sem (ExternalAccess ': r) a -> Sem r a
-interpretExternal = interpret $ \case
 
 data FederatorAccess m a
 

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -19,19 +19,12 @@ module Galley.Effects
   ( -- * Effects needed in Galley
     GalleyEffects1,
 
-    -- * Brig
+    -- * Effects to access the Intra API
     BrigAccess,
-
-    -- * Federator
     FederatorAccess,
-    interpretFederator,
-
-    -- * Spar
     SparAccess,
-
-    -- * Gundeck
     GundeckAccess,
-    interpretGundeck,
+    interpretFederator,
 
     -- * External services
     ExternalAccess,
@@ -71,6 +64,7 @@ import Galley.Effects.ClientStore
 import Galley.Effects.CodeStore
 import Galley.Effects.ConversationStore
 import Galley.Effects.FireAndForget
+import Galley.Effects.GundeckAccess
 import Galley.Effects.ListItems
 import Galley.Effects.MemberStore
 import Galley.Effects.ServiceStore
@@ -79,11 +73,6 @@ import Galley.Effects.TeamMemberStore
 import Galley.Effects.TeamStore
 import Imports
 import Polysemy
-
-data GundeckAccess m a
-
-interpretGundeck :: Sem (GundeckAccess ': r) a -> Sem r a
-interpretGundeck = interpret $ \case
 
 data ExternalAccess m a
 

--- a/services/galley/src/Galley/Effects/BotAccess.hs
+++ b/services/galley/src/Galley/Effects/BotAccess.hs
@@ -15,24 +15,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Intra.Team where
+module Galley.Effects.BotAccess where
 
-import Bilge
-import Bilge.RPC
-import Brig.Types.Team
-import Data.ByteString.Conversion
 import Data.Id
-import Galley.Intra.Util
-import Imports
-import Network.HTTP.Types.Method
-import Network.HTTP.Types.Status
-import Network.Wai.Utilities.Error
+import Polysemy
 
-getSize :: TeamId -> IntraM TeamSize
-getSize tid = do
-  r <-
-    call Brig $
-      method GET
-        . paths ["/i/teams", toByteString' tid, "size"]
-        . expect2xx
-  parseResponse (mkError status502 "server-error") r
+data BotAccess m a where
+  DeleteBot :: ConvId -> BotId -> BotAccess m ()
+
+makeSem ''BotAccess

--- a/services/galley/src/Galley/Effects/BrigAccess.hs
+++ b/services/galley/src/Galley/Effects/BrigAccess.hs
@@ -1,0 +1,113 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.BrigAccess
+  ( -- * Brig access effect
+    BrigAccess (..),
+
+    -- * Connections
+    getConnectionsUnqualified,
+    getConnectionsUnqualifiedBidi,
+    getConnections,
+    putConnectionInternal,
+
+    -- * Users
+    reauthUser,
+    lookupActivatedUsers,
+    getUser,
+    getUsers,
+    deleteUser,
+    getContactList,
+    getRichInfoMultiUser,
+
+    -- * Teams
+    getSize,
+
+    -- * Clients
+    lookupClients,
+    lookupClientsFull,
+    notifyClientsAboutLegalHoldRequest,
+    getLegalHoldAuthToken,
+    addLegalHoldClientToUser,
+    removeLegalHoldClientFromUser,
+  )
+where
+
+import Brig.Types.Client
+import Brig.Types.Connection
+import Brig.Types.Intra
+import Brig.Types.User
+import Data.Id
+import Data.Misc
+import Data.Qualified
+import Galley.External.LegalHoldService.Types
+import Imports
+import Network.HTTP.Types.Status
+import Polysemy
+import Wire.API.Routes.Internal.Brig.Connection
+import Wire.API.Team.Size
+import Wire.API.User.Client
+import Wire.API.User.RichInfo
+
+data BrigAccess m a where
+  GetConnectionsUnqualified ::
+    [UserId] ->
+    Maybe [UserId] ->
+    Maybe Relation ->
+    BrigAccess m [ConnectionStatus]
+  GetConnectionsUnqualifiedBidi ::
+    [UserId] ->
+    [UserId] ->
+    Maybe Relation ->
+    Maybe Relation ->
+    BrigAccess m ([ConnectionStatus], [ConnectionStatus])
+  GetConnections ::
+    [UserId] ->
+    Maybe [Qualified UserId] ->
+    Maybe Relation ->
+    BrigAccess m [ConnectionStatusV2]
+  PutConnectionInternal :: UpdateConnectionsInternal -> BrigAccess m Status
+  ReauthUser :: UserId -> ReAuthUser -> BrigAccess m Bool
+  LookupActivatedUsers :: [UserId] -> BrigAccess m [User]
+  GetUsers :: [UserId] -> BrigAccess m [UserAccount]
+  DeleteUser :: UserId -> BrigAccess m ()
+  GetContactList :: UserId -> BrigAccess m [UserId]
+  GetRichInfoMultiUser :: [UserId] -> BrigAccess m [(UserId, RichInfo)]
+  GetSize :: TeamId -> BrigAccess m TeamSize
+  LookupClients :: [UserId] -> BrigAccess m UserClients
+  LookupClientsFull :: [UserId] -> BrigAccess m UserClientsFull
+  NotifyClientsAboutLegalHoldRequest ::
+    UserId ->
+    UserId ->
+    LastPrekey ->
+    BrigAccess m ()
+  GetLegalHoldAuthToken ::
+    UserId ->
+    Maybe PlainTextPassword ->
+    BrigAccess m OpaqueAuthToken
+  AddLegalHoldClientToUser ::
+    UserId ->
+    ConnId ->
+    [Prekey] ->
+    LastPrekey ->
+    BrigAccess m ClientId
+  RemoveLegalHoldClientFromUser :: UserId -> BrigAccess m ()
+
+makeSem ''BrigAccess
+
+getUser :: Member BrigAccess r => UserId -> Sem r (Maybe UserAccount)
+getUser = fmap listToMaybe . getUsers . pure

--- a/services/galley/src/Galley/Effects/ExternalAccess.hs
+++ b/services/galley/src/Galley/Effects/ExternalAccess.hs
@@ -1,0 +1,38 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.ExternalAccess
+  ( -- * External access effect
+    ExternalAccess (..),
+    deliver,
+    deliverAsync,
+    deliverAndDeleteAsync,
+  )
+where
+
+import Data.Id
+import Galley.Data.Services
+import Imports
+import Polysemy
+import Wire.API.Event.Conversation
+
+data ExternalAccess m a where
+  Deliver :: Foldable f => f (BotMember, Event) -> ExternalAccess m [BotMember]
+  DeliverAsync :: Foldable f => f (BotMember, Event) -> ExternalAccess m ()
+  DeliverAndDeleteAsync :: Foldable f => ConvId -> f (BotMember, Event) -> ExternalAccess m ()
+
+makeSem ''ExternalAccess

--- a/services/galley/src/Galley/Effects/FederatorAccess.hs
+++ b/services/galley/src/Galley/Effects/FederatorAccess.hs
@@ -1,0 +1,60 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.FederatorAccess
+  ( -- * Federator access effect
+    FederatorAccess (..),
+    runFederated,
+    runFederatedEither,
+    runFederatedConcurrently,
+    runFederatedConcurrently_,
+  )
+where
+
+import Data.Qualified
+import Galley.Intra.Federator.Types
+import Imports
+import Polysemy
+import Wire.API.Federation.Client
+import Wire.API.Federation.GRPC.Types
+
+data FederatorAccess m a where
+  RunFederated ::
+    forall (c :: Component) a m x.
+    Remote x ->
+    FederatedRPC c a ->
+    FederatorAccess m a
+  RunFederatedEither ::
+    forall (c :: Component) a m x.
+    Remote x ->
+    FederatedRPC c a ->
+    FederatorAccess m (Either FederationError a)
+  RunFederatedConcurrently ::
+    forall (c :: Component) f a m x.
+    (Foldable f, Functor f) =>
+    f (Remote x) ->
+    (Remote [x] -> FederatedRPC c a) ->
+    FederatorAccess m [Remote a]
+
+makeSem ''FederatorAccess
+
+runFederatedConcurrently_ ::
+  (Foldable f, Functor f, Member FederatorAccess r) =>
+  f (Remote a) ->
+  (Remote [a] -> FederatedRPC c ()) ->
+  Sem r ()
+runFederatedConcurrently_ xs = void . runFederatedConcurrently xs

--- a/services/galley/src/Galley/Effects/FireAndForget.hs
+++ b/services/galley/src/Galley/Effects/FireAndForget.hs
@@ -37,6 +37,10 @@ makeSem ''FireAndForget
 fireAndForget :: Member FireAndForget r => Sem r () -> Sem r ()
 fireAndForget = fireAndForgetOne
 
+-- | Run actions in separate threads and ignore results.
+--
+-- /Note/: this will also ignore any state and error effects contained in the
+-- 'FireAndForget' action. Use with care.
 interpretFireAndForget :: Member (Final IO) r => Sem (FireAndForget ': r) a -> Sem r a
 interpretFireAndForget = interpretFinal @IO $ \case
   FireAndForgetOne action -> do

--- a/services/galley/src/Galley/Effects/GundeckAccess.hs
+++ b/services/galley/src/Galley/Effects/GundeckAccess.hs
@@ -1,6 +1,6 @@
 -- This file is part of the Wire Server implementation.
 --
--- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
 --
 -- This program is free software: you can redistribute it and/or modify it under
 -- the terms of the GNU Affero General Public License as published by the Free
@@ -15,36 +15,24 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Intra.Push
-  ( -- * Push
-    Push,
-    newPush,
-    newPushLocal,
-    newConversationEventPush,
-    newPush1,
-    newPushLocal1,
-    PushEvent (..),
-
-    -- * Push Configuration
-    pushConn,
-    pushTransient,
-    pushRoute,
-    pushNativePriority,
-    pushAsync,
-    pushRecipients,
-
-    -- * Push Recipients
-    Recipient,
-    recipient,
-    userRecipient,
-    recipientUserId,
-    recipientClients,
-
-    -- * Re-Exports
-    Gundeck.Route (..),
-    Gundeck.Priority (..),
+module Galley.Effects.GundeckAccess
+  ( -- * Gundeck access effect
+    GundeckAccess (..),
+    push,
+    push1,
   )
 where
 
-import Galley.Intra.Push.Internal
-import qualified Gundeck.Types.Push.V2 as Gundeck
+import qualified Galley.Intra.Push as G
+import Imports
+import Polysemy
+
+data GundeckAccess m a where
+  Push :: Foldable f => f G.Push -> GundeckAccess m ()
+
+makeSem ''GundeckAccess
+
+-- | Asynchronously send a single push, chunking it into multiple
+-- requests if there are more than 128 recipients.
+push1 :: Member GundeckAccess r => G.Push -> Sem r ()
+push1 x = push [x]

--- a/services/galley/src/Galley/Effects/SparAccess.hs
+++ b/services/galley/src/Galley/Effects/SparAccess.hs
@@ -15,24 +15,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Intra.Team where
+module Galley.Effects.SparAccess where
 
-import Bilge
-import Bilge.RPC
-import Brig.Types.Team
-import Data.ByteString.Conversion
 import Data.Id
-import Galley.Intra.Util
-import Imports
-import Network.HTTP.Types.Method
-import Network.HTTP.Types.Status
-import Network.Wai.Utilities.Error
+import Polysemy
 
-getSize :: TeamId -> IntraM TeamSize
-getSize tid = do
-  r <-
-    call Brig $
-      method GET
-        . paths ["/i/teams", toByteString' tid, "size"]
-        . expect2xx
-  parseResponse (mkError status502 "server-error") r
+data SparAccess m a where
+  DeleteTeam :: TeamId -> SparAccess m ()
+
+makeSem ''SparAccess

--- a/services/galley/src/Galley/External.hs
+++ b/services/galley/src/Galley/External.hs
@@ -34,6 +34,7 @@ import Galley.Cassandra.Services
 import Galley.Data.Services (BotMember, botMemId, botMemService)
 import Galley.Effects
 import Galley.Intra.User
+import Galley.Intra.Util
 import Galley.Types (Event)
 import Galley.Types.Bot
 import Imports
@@ -60,7 +61,7 @@ deliverAndDeleteAsync ::
   Galley r ()
 deliverAndDeleteAsync cnv pushes = liftGalley0 . void . forkIO $ do
   gone <- liftGalley0 $ deliver0 pushes
-  mapM_ (deleteBot0 cnv . botMemId) gone
+  liftGalley0 . liftSem . embedIntra $ mapM_ (deleteBot cnv . botMemId) gone
 
 -- | Deliver events to external (bot) services.
 --

--- a/services/galley/src/Galley/External.hs
+++ b/services/galley/src/Galley/External.hs
@@ -15,12 +15,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.External
-  ( deliver,
-    deliverAndDeleteAsync,
-    deliverAsync,
-  )
-where
+module Galley.External (interpretExternalAccess) where
 
 import Bilge.Request
 import Bilge.Retry (httpHandlers)
@@ -29,10 +24,11 @@ import Control.Retry
 import Data.ByteString.Conversion.To
 import Data.Id
 import Data.Misc
-import Galley.App
 import Galley.Cassandra.Services
 import Galley.Data.Services (BotMember, botMemId, botMemService)
 import Galley.Effects
+import Galley.Effects.ExternalAccess (ExternalAccess (..))
+import Galley.Env
 import Galley.Intra.User
 import Galley.Intra.Util
 import Galley.Types (Event)
@@ -41,47 +37,46 @@ import Imports
 import qualified Network.HTTP.Client as Http
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status (status410)
+import Polysemy
+import qualified Polysemy.Reader as P
 import Ssl.Util (withVerifiedSslConnection)
 import qualified System.Logger.Class as Log
 import System.Logger.Message (field, msg, val, (~~))
 import URI.ByteString
 import UnliftIO (Async, async, waitCatch)
 
+interpretExternalAccess ::
+  Members '[Embed IO, P.Reader Env] r =>
+  Sem (ExternalAccess ': r) a ->
+  Sem r a
+interpretExternalAccess = interpret $ \case
+  Deliver pp -> embedIntra $ deliver (toList pp)
+  DeliverAsync pp -> embedIntra $ deliverAsync (toList pp)
+  DeliverAndDeleteAsync cid pp -> embedIntra $ deliverAndDeleteAsync cid (toList pp)
+
 -- | Like deliver, but ignore orphaned bots and return immediately.
 --
 -- FUTUREWORK: Check if this can be removed.
-deliverAsync :: Member ExternalAccess r => [(BotMember, Event)] -> Galley r ()
-deliverAsync = liftGalley0 . void . forkIO . void . deliver0
+deliverAsync :: [(BotMember, Event)] -> IntraM ()
+deliverAsync = void . forkIO . void . deliver
 
 -- | Like deliver, but remove orphaned bots and return immediately.
-deliverAndDeleteAsync ::
-  Members '[ExternalAccess, BotAccess] r =>
-  ConvId ->
-  [(BotMember, Event)] ->
-  Galley r ()
-deliverAndDeleteAsync cnv pushes = liftGalley0 . void . forkIO $ do
-  gone <- liftGalley0 $ deliver0 pushes
-  liftGalley0 . liftSem . embedIntra $ mapM_ (deleteBot cnv . botMemId) gone
+deliverAndDeleteAsync :: ConvId -> [(BotMember, Event)] -> IntraM ()
+deliverAndDeleteAsync cnv pushes = void . forkIO $ do
+  gone <- deliver pushes
+  mapM_ (deleteBot cnv . botMemId) gone
 
--- | Deliver events to external (bot) services.
---
--- Returns those bots which are found to be orphaned by the external
--- service, e.g. when the service tells us that it no longer knows about the
--- bot.
-deliver :: Member ExternalAccess r => [(BotMember, Event)] -> Galley r [BotMember]
-deliver = liftGalley0 . deliver0
-
-deliver0 :: [(BotMember, Event)] -> Galley0 [BotMember]
-deliver0 pp = mapM (async . exec) pp >>= foldM eval [] . zip (map fst pp)
+deliver :: [(BotMember, Event)] -> IntraM [BotMember]
+deliver pp = mapM (async . exec) pp >>= foldM eval [] . zip (map fst pp)
   where
-    exec :: (BotMember, Event) -> Galley0 Bool
+    exec :: (BotMember, Event) -> IntraM Bool
     exec (b, e) =
       lookupService (botMemService b) >>= \case
         Nothing -> return False
         Just s -> do
           deliver1 s b e
           return True
-    eval :: [BotMember] -> (BotMember, Async Bool) -> Galley r [BotMember]
+    eval :: [BotMember] -> (BotMember, Async Bool) -> IntraM [BotMember]
     eval gone (b, a) = do
       let s = botMemService b
       r <- waitCatch a
@@ -120,7 +115,7 @@ deliver0 pp = mapM (async . exec) pp >>= foldM eval [] . zip (map fst pp)
 
 -- Internal -------------------------------------------------------------------
 
-deliver1 :: Service -> BotMember -> Event -> Galley0 ()
+deliver1 :: Service -> BotMember -> Event -> IntraM ()
 deliver1 s bm e
   | s ^. serviceEnabled = do
     let t = toByteString' (s ^. serviceToken)
@@ -150,7 +145,7 @@ urlPort (HttpsUrl u) = do
   p <- a ^. authorityPortL
   return (fromIntegral (p ^. portNumberL))
 
-sendMessage :: [Fingerprint Rsa] -> (Request -> Request) -> Galley r ()
+sendMessage :: [Fingerprint Rsa] -> (Request -> Request) -> IntraM ()
 sendMessage fprs reqBuilder = do
   (man, verifyFingerprints) <- view (extEnv . extGetManager)
   liftIO . withVerifiedSslConnection (verifyFingerprints fprs) man reqBuilder $ \req ->

--- a/services/galley/src/Galley/External/LegalHoldService.hs
+++ b/services/galley/src/Galley/External/LegalHoldService.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
@@ -26,9 +24,6 @@ module Galley.External.LegalHoldService
 
     -- * helpers
     validateServiceKey,
-
-    -- * types
-    OpaqueAuthToken (..),
   )
 where
 
@@ -50,6 +45,8 @@ import Data.Misc
 import Galley.API.Error
 import Galley.App
 import qualified Galley.Data.LegalHold as LegalHoldData
+import Galley.Env
+import Galley.External.LegalHoldService.Types
 import Imports
 import qualified Network.HTTP.Client as Http
 import Network.HTTP.Types
@@ -237,14 +234,3 @@ validateServiceKey pem =
         (SSL.readPublicKey (LC8.unpack (toByteString pem)) >>= return . Just)
     minRsaKeySize :: Int
     minRsaKeySize = 256 -- Bytes (= 2048 bits)
-
--- Types
-
--- | When receiving tokens from other services which are 'just passing through'
--- it's error-prone useless extra work to parse and render them from JSON over and over again.
--- We'll just wrap them with this to give some level of typesafety and a reasonable JSON
--- instance
-newtype OpaqueAuthToken = OpaqueAuthToken
-  { opaqueAuthTokenToText :: Text
-  }
-  deriving newtype (Eq, Show, FromJSON, ToJSON, ToByteString)

--- a/services/galley/src/Galley/External/LegalHoldService/Types.hs
+++ b/services/galley/src/Galley/External/LegalHoldService/Types.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 -- This file is part of the Wire Server implementation.
 --
--- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
 --
 -- This program is free software: you can redistribute it and/or modify it under
 -- the terms of the GNU Affero General Public License as published by the Free
@@ -15,24 +17,20 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Intra.Team where
+module Galley.External.LegalHoldService.Types
+  ( OpaqueAuthToken (..),
+  )
+where
 
-import Bilge
-import Bilge.RPC
-import Brig.Types.Team
-import Data.ByteString.Conversion
-import Data.Id
-import Galley.Intra.Util
+import Data.Aeson
+import Data.ByteString.Conversion.To
 import Imports
-import Network.HTTP.Types.Method
-import Network.HTTP.Types.Status
-import Network.Wai.Utilities.Error
 
-getSize :: TeamId -> IntraM TeamSize
-getSize tid = do
-  r <-
-    call Brig $
-      method GET
-        . paths ["/i/teams", toByteString' tid, "size"]
-        . expect2xx
-  parseResponse (mkError status502 "server-error") r
+-- | When receiving tokens from other services which are 'just passing through'
+-- it's error-prone useless extra work to parse and render them from JSON over and over again.
+-- We'll just wrap them with this to give some level of typesafety and a reasonable JSON
+-- instance
+newtype OpaqueAuthToken = OpaqueAuthToken
+  { opaqueAuthTokenToText :: Text
+  }
+  deriving newtype (Eq, Show, FromJSON, ToJSON, ToByteString)

--- a/services/galley/src/Galley/Intra/Effects.hs
+++ b/services/galley/src/Galley/Intra/Effects.hs
@@ -19,14 +19,17 @@ module Galley.Intra.Effects
   ( interpretBrigAccess,
     interpretSparAccess,
     interpretBotAccess,
+    interpretGundeckAccess,
   )
 where
 
 import Galley.Effects.BotAccess (BotAccess (..))
 import Galley.Effects.BrigAccess (BrigAccess (..))
+import Galley.Effects.GundeckAccess (GundeckAccess (..))
 import Galley.Effects.SparAccess (SparAccess (..))
 import Galley.Env
 import Galley.Intra.Client
+import qualified Galley.Intra.Push.Internal as G
 import Galley.Intra.Spar
 import Galley.Intra.Team
 import Galley.Intra.User
@@ -83,3 +86,10 @@ interpretBotAccess ::
   Sem r a
 interpretBotAccess = interpret $ \case
   DeleteBot cid bid -> embedIntra $ deleteBot cid bid
+
+interpretGundeckAccess ::
+  Members '[Embed IO, P.TinyLog, P.Reader Env] r =>
+  Sem (GundeckAccess ': r) a ->
+  Sem r a
+interpretGundeckAccess = interpret $ \case
+  Push ps -> embedIntra $ G.push ps

--- a/services/galley/src/Galley/Intra/Effects.hs
+++ b/services/galley/src/Galley/Intra/Effects.hs
@@ -1,0 +1,85 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Intra.Effects
+  ( interpretBrigAccess,
+    interpretSparAccess,
+    interpretBotAccess,
+  )
+where
+
+import Galley.Effects.BotAccess (BotAccess (..))
+import Galley.Effects.BrigAccess (BrigAccess (..))
+import Galley.Effects.SparAccess (SparAccess (..))
+import Galley.Env
+import Galley.Intra.Client
+import Galley.Intra.Spar
+import Galley.Intra.Team
+import Galley.Intra.User
+import Galley.Intra.Util
+import Imports
+import Polysemy
+import qualified Polysemy.Reader as P
+import qualified Polysemy.TinyLog as P
+import qualified UnliftIO
+
+interpretBrigAccess ::
+  Members '[Embed IO, P.TinyLog, P.Reader Env] r =>
+  Sem (BrigAccess ': r) a ->
+  Sem r a
+interpretBrigAccess = interpret $ \case
+  GetConnectionsUnqualified uids muids mrel ->
+    embedIntra $ getConnectionsUnqualified uids muids mrel
+  GetConnectionsUnqualifiedBidi uids1 uids2 mrel1 mrel2 ->
+    embedIntra $
+      UnliftIO.concurrently
+        (getConnectionsUnqualified uids1 (Just uids2) mrel1)
+        (getConnectionsUnqualified uids2 (Just uids1) mrel2)
+  GetConnections uids mquids mrel ->
+    embedIntra $
+      getConnections uids mquids mrel
+  PutConnectionInternal uc -> embedIntra $ putConnectionInternal uc
+  ReauthUser uid reauth -> embedIntra $ reAuthUser uid reauth
+  LookupActivatedUsers uids -> embedIntra $ lookupActivatedUsers uids
+  GetUsers uids -> embedIntra $ getUsers uids
+  DeleteUser uid -> embedIntra $ deleteUser uid
+  GetContactList uid -> embedIntra $ getContactList uid
+  GetRichInfoMultiUser uids -> embedIntra $ getRichInfoMultiUser uids
+  GetSize tid -> embedIntra $ getSize tid
+  LookupClients uids -> embedIntra $ lookupClients uids
+  LookupClientsFull uids -> embedIntra $ lookupClientsFull uids
+  NotifyClientsAboutLegalHoldRequest self other pk ->
+    embedIntra $ notifyClientsAboutLegalHoldRequest self other pk
+  GetLegalHoldAuthToken uid mpwd -> getLegalHoldAuthToken uid mpwd
+  AddLegalHoldClientToUser uid conn pks lpk ->
+    embedIntra $ addLegalHoldClientToUser uid conn pks lpk
+  RemoveLegalHoldClientFromUser uid ->
+    embedIntra $ removeLegalHoldClientFromUser uid
+
+interpretSparAccess ::
+  Members '[Embed IO, P.Reader Env] r =>
+  Sem (SparAccess ': r) a ->
+  Sem r a
+interpretSparAccess = interpret $ \case
+  DeleteTeam tid -> embedIntra $ deleteTeam tid
+
+interpretBotAccess ::
+  Members '[Embed IO, P.Reader Env] r =>
+  Sem (BotAccess ': r) a ->
+  Sem r a
+interpretBotAccess = interpret $ \case
+  DeleteBot cid bid -> embedIntra $ deleteBot cid bid

--- a/services/galley/src/Galley/Intra/Federator.hs
+++ b/services/galley/src/Galley/Intra/Federator.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Intra.Federator (interpretFederatorAccess) where
+
+import Control.Monad.Except
+import Data.Qualified
+import Galley.Effects.FederatorAccess (FederatorAccess (..))
+import Galley.Env
+import Galley.Intra.Federator.Types
+import Imports
+import Polysemy
+import qualified Polysemy.Reader as P
+import UnliftIO
+import Wire.API.Federation.Client
+import Wire.API.Federation.Error
+
+embedFederationM ::
+  Members '[Embed IO, P.Reader Env] r =>
+  FederationM a ->
+  Sem r a
+embedFederationM action = do
+  env <- P.ask
+  embed $ runFederationM env action
+
+interpretFederatorAccess ::
+  Members '[Embed IO, P.Reader Env] r =>
+  Sem (FederatorAccess ': r) a ->
+  Sem r a
+interpretFederatorAccess = interpret $ \case
+  RunFederated dom rpc -> embedFederationM $ runFederated dom rpc
+  RunFederatedEither dom rpc -> embedFederationM $ runFederatedEither dom rpc
+  RunFederatedConcurrently rs f -> embedFederationM $ runFederatedConcurrently rs f
+
+runFederatedEither ::
+  Remote x ->
+  FederatedRPC c a ->
+  FederationM (Either FederationError a)
+runFederatedEither (tDomain -> remoteDomain) rpc = do
+  env <- ask
+  liftIO $ runFederationM env (runExceptT (executeFederated remoteDomain rpc))
+
+runFederated ::
+  Remote x ->
+  FederatedRPC c a ->
+  FederationM a
+runFederated dom rpc =
+  runFederatedEither dom rpc
+    >>= either (throwIO . federationErrorToWai) pure
+
+runFederatedConcurrently ::
+  (Foldable f, Functor f) =>
+  f (Remote a) ->
+  (Remote [a] -> FederatedRPC c b) ->
+  FederationM [Remote b]
+runFederatedConcurrently xs rpc =
+  pooledForConcurrentlyN 8 (bucketRemote xs) $ \r ->
+    qualifyAs r <$> runFederated r (rpc r)

--- a/services/galley/src/Galley/Intra/Federator/Types.hs
+++ b/services/galley/src/Galley/Intra/Federator/Types.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Intra.Federator.Types
+  ( FederatedRPC,
+    FederationM,
+    runFederationM,
+  )
+where
+
+import Control.Lens
+import Control.Monad.Except
+import Galley.Env
+import Galley.Options
+import Imports
+import Wire.API.Federation.Client
+import Wire.API.Federation.GRPC.Types
+
+type FederatedRPC (c :: Component) =
+  FederatorClient c (ExceptT FederationClientFailure FederationM)
+
+newtype FederationM a = FederationM
+  {unFederationM :: ReaderT Env IO a}
+  deriving
+    ( Functor,
+      Applicative,
+      Monad,
+      MonadIO,
+      MonadReader Env,
+      MonadUnliftIO
+    )
+
+runFederationM :: Env -> FederationM a -> IO a
+runFederationM env = flip runReaderT env . unFederationM
+
+instance HasFederatorConfig FederationM where
+  federatorEndpoint = view federator
+  federationDomain = view (options . optSettings . setFederationDomain)

--- a/services/galley/src/Galley/Intra/Push/Internal.hs
+++ b/services/galley/src/Galley/Intra/Push/Internal.hs
@@ -1,0 +1,181 @@
+{-# LANGUAGE StrictData #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Intra.Push.Internal where
+
+import Bilge hiding (options)
+import Control.Lens (makeLenses, set, view, (.~))
+import Data.Aeson (Object)
+import Data.Domain
+import Data.Id (ConnId, UserId)
+import Data.Json.Util
+import Data.List.Extra (chunksOf)
+import Data.List.NonEmpty (nonEmpty)
+import Data.List1
+import Data.Qualified
+import Data.Range
+import qualified Data.Set as Set
+import Galley.Env
+import Galley.Intra.Util
+import Galley.Types
+import qualified Galley.Types.Teams as Teams
+import Gundeck.Types.Push.V2 (RecipientClients (..))
+import qualified Gundeck.Types.Push.V2 as Gundeck
+import Imports hiding (forkIO)
+import Safe (headDef, tailDef)
+import UnliftIO.Async (mapConcurrently)
+import qualified Wire.API.Event.FeatureConfig as FeatureConfig
+
+data PushEvent
+  = ConvEvent Event
+  | TeamEvent Teams.Event
+  | FeatureConfigEvent FeatureConfig.Event
+
+pushEventJson :: PushEvent -> Object
+pushEventJson (ConvEvent e) = toJSONObject e
+pushEventJson (TeamEvent e) = toJSONObject e
+pushEventJson (FeatureConfigEvent e) = toJSONObject e
+
+data RecipientBy user = Recipient
+  { _recipientUserId :: user,
+    _recipientClients :: RecipientClients
+  }
+  deriving stock (Functor, Foldable, Traversable)
+
+makeLenses ''RecipientBy
+
+type Recipient = RecipientBy UserId
+
+data PushTo user = Push
+  { _pushConn :: Maybe ConnId,
+    _pushTransient :: Bool,
+    _pushRoute :: Gundeck.Route,
+    _pushNativePriority :: Maybe Gundeck.Priority,
+    _pushAsync :: Bool,
+    pushOrigin :: Maybe UserId,
+    _pushRecipients :: List1 (RecipientBy user),
+    pushJson :: Object,
+    pushRecipientListType :: Teams.ListType
+  }
+  deriving stock (Functor, Foldable, Traversable)
+
+makeLenses ''PushTo
+
+type Push = PushTo UserId
+
+push :: Foldable f => f Push -> IntraM ()
+push ps = do
+  let (localPushes, remotePushes) = foldMap (bimap toList toList . splitPush) ps
+  traverse_ (pushLocal . List1) (nonEmpty localPushes)
+  traverse_ (pushRemote . List1) (nonEmpty remotePushes)
+  where
+    splitPush :: Push -> (Maybe (PushTo UserId), Maybe (PushTo UserId))
+    splitPush p =
+      (mkPushTo localRecipients p, mkPushTo remoteRecipients p)
+      where
+        localRecipients = toList $ _pushRecipients p
+        remoteRecipients = [] -- FUTUREWORK: deal with remote sending
+    mkPushTo :: [RecipientBy a] -> PushTo b -> Maybe (PushTo a)
+    mkPushTo recipients p =
+      nonEmpty recipients <&> \nonEmptyRecipients ->
+        p {_pushRecipients = List1 nonEmptyRecipients}
+
+-- | Asynchronously send multiple pushes, aggregating them into as
+-- few requests as possible, such that no single request targets
+-- more than 128 recipients.
+pushLocal :: List1 (PushTo UserId) -> IntraM ()
+pushLocal ps = do
+  opts <- view options
+  let limit = currentFanoutLimit opts
+  -- Do not fan out for very large teams
+  let (asyncs, syncs) = partition _pushAsync (removeIfLargeFanout limit $ toList ps)
+  traverse_ (asyncCall Gundeck . json) (pushes asyncs)
+  void $ mapConcurrently (call Gundeck . json) (pushes syncs)
+  where
+    pushes = fst . foldr chunk ([], 0)
+    chunk p (pss, !n) =
+      let r = recipientList p
+          nr = length r
+       in if n + nr > maxRecipients
+            then
+              let pss' = map (pure . toPush p) (chunksOf maxRecipients r)
+               in (pss' ++ pss, 0)
+            else
+              let hd = headDef [] pss
+                  tl = tailDef [] pss
+               in ((toPush p r : hd) : tl, n + nr)
+    maxRecipients = 128
+    recipientList p = map (toRecipient p) . toList $ _pushRecipients p
+    toPush p r =
+      let pload = Gundeck.singletonPayload (pushJson p)
+       in Gundeck.newPush (pushOrigin p) (unsafeRange (Set.fromList r)) pload
+            & Gundeck.pushOriginConnection .~ _pushConn p
+            & Gundeck.pushTransient .~ _pushTransient p
+            & maybe id (set Gundeck.pushNativePriority) (_pushNativePriority p)
+    toRecipient p r =
+      Gundeck.recipient (_recipientUserId r) (_pushRoute p)
+        & Gundeck.recipientClients .~ _recipientClients r
+    -- Ensure that under no circumstances we exceed the threshold
+    removeIfLargeFanout limit =
+      filter
+        ( \p ->
+            (pushRecipientListType p == Teams.ListComplete)
+              && (length (_pushRecipients p) <= (fromIntegral $ fromRange limit))
+        )
+
+-- instead of IdMapping, we could also just take qualified IDs
+pushRemote :: List1 (PushTo UserId) -> IntraM ()
+pushRemote _ps = do
+  -- FUTUREWORK(federation, #1261): send these to the other backends
+  pure ()
+
+recipient :: LocalMember -> Recipient
+recipient = userRecipient . lmId
+
+userRecipient :: user -> RecipientBy user
+userRecipient u = Recipient u RecipientClientsAll
+
+newPush1 :: Teams.ListType -> Maybe UserId -> PushEvent -> List1 Recipient -> Push
+newPush1 recipientListType from e rr =
+  Push
+    { _pushConn = Nothing,
+      _pushTransient = False,
+      _pushRoute = Gundeck.RouteAny,
+      _pushNativePriority = Nothing,
+      _pushAsync = False,
+      pushRecipientListType = recipientListType,
+      pushJson = pushEventJson e,
+      pushOrigin = from,
+      _pushRecipients = rr
+    }
+
+newPushLocal1 :: Teams.ListType -> UserId -> PushEvent -> List1 Recipient -> Push
+newPushLocal1 lt uid e rr = newPush1 lt (Just uid) e rr
+
+newPush :: Teams.ListType -> Maybe UserId -> PushEvent -> [Recipient] -> Maybe Push
+newPush _ _ _ [] = Nothing
+newPush t u e (r : rr) = Just $ newPush1 t u e (list1 r rr)
+
+newPushLocal :: Teams.ListType -> UserId -> PushEvent -> [Recipient] -> Maybe Push
+newPushLocal lt uid e rr = newPush lt (Just uid) e rr
+
+newConversationEventPush :: Domain -> Event -> [UserId] -> Maybe Push
+newConversationEventPush localDomain e users =
+  let musr = guard (localDomain == qDomain (evtFrom e)) $> qUnqualified (evtFrom e)
+   in newPush Teams.ListComplete musr (ConvEvent e) (map userRecipient users)

--- a/services/galley/src/Galley/Intra/Spar.hs
+++ b/services/galley/src/Galley/Intra/Spar.hs
@@ -23,19 +23,14 @@ where
 import Bilge
 import Data.ByteString.Conversion
 import Data.Id
-import Galley.App
-import Galley.Effects
 import Galley.Intra.Util
 import Imports
 import Network.HTTP.Types.Method
 
 -- | Notify Spar that a team is being deleted.
-deleteTeam :: Member SparAccess r => TeamId -> Galley r ()
+deleteTeam :: TeamId -> IntraM ()
 deleteTeam tid = do
-  (h, p) <- sparReq
-  _ <-
-    callSpar $
-      method DELETE . host h . port p
-        . paths ["i", "teams", toByteString' tid]
-        . expect2xx
-  pure ()
+  void . call Spar $
+    method DELETE
+      . paths ["i", "teams", toByteString' tid]
+      . expect2xx


### PR DESCRIPTION
This PR turns placeholder access effect for internal APIs and external services into actual Polysemy effects.

## Summary

- Implemented effects: 
    * `BrigAccess`
    * `BotAccess` 
    * `SparAccess`
    * `GundeckAccess`
    * `ExternalAccess`
    * `FederatorAccess`
- Removed placeholder Intra effect

## Overall plan for the Polysemy refactoring of Galley

 1. Turn `Galley` into a newtype over `Sem`, and introduce "access" effects.
 2. Add "store" effects and convert `Data` code into interpretations.
 3. **Turn placeholders into actual effects.** (this pr)
 4. Add fine-grained `Error` effects, and integrate them with `Servant`.
 5. Make `Galley` into a type synonym over `Sem`, and get rid of `Galley0`.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
