### PR TITLE
Provide ormolu via direnv, run `make formatc` in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+on:
+ pull_request:
+ push:
+   branches: [master]
+
+jobs:
+  build-dev-env:
+   name: Build dev env
+   strategy:
+     matrix:
+       os:
+         - ubuntu-latest
+         # This is too expensive
+         # - macos-latest
+   runs-on: ${{ matrix.os }}
+   steps:
+     - uses: actions/checkout@v2
+       with:
+         submodules: true
+     - uses: cachix/install-nix-action@v14.1
+     - uses: cachix/cachix-action@v10
+       with:
+         name: wire-server
+         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+     - name: Build the wire-server-direnv
+       run: nix-build --no-out-link direnv.nix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,7 @@ jobs:
          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
      - name: Build the wire-server-direnv
        run: nix-build --no-out-link direnv.nix
+     - name: Install the wire-server-direnv
+       run: nix-env -f direnv.nix -i
+     - name: Ensure everything is formatted
+       run: make formatc

--- a/changelog.d/5-internal/ormolu-direnv
+++ b/changelog.d/5-internal/ormolu-direnv
@@ -1,0 +1,1 @@
+Add ormolu to the direnv, add a GH Action to ensure formatting

--- a/direnv.nix
+++ b/direnv.nix
@@ -6,14 +6,17 @@ let
 
       src =
         if pkgs.stdenv.isDarwin
-        then pkgs.fetchurl {
-          url = darwinAmd64Url;
-          sha256 = darwinAmd64Sha256;
-        }
-        else pkgs.fetchurl {
-          url = linuxAmd64Url;
-          sha256 = linuxAmd64Sha256;
-        };
+        then
+          pkgs.fetchurl
+            {
+              url = darwinAmd64Url;
+              sha256 = darwinAmd64Sha256;
+            }
+        else
+          pkgs.fetchurl {
+            url = linuxAmd64Url;
+            sha256 = linuxAmd64Sha256;
+          };
 
       installPhase = ''
         mkdir -p $out/bin
@@ -21,28 +24,31 @@ let
       '';
     };
 
-    staticBinary = { pname, version, linuxAmd64Url, linuxAmd64Sha256, darwinAmd64Url, darwinAmd64Sha256, binPath ? pname }:
-      pkgs.stdenv.mkDerivation {
-        inherit pname version;
+  staticBinary = { pname, version, linuxAmd64Url, linuxAmd64Sha256, darwinAmd64Url, darwinAmd64Sha256, binPath ? pname }:
+    pkgs.stdenv.mkDerivation {
+      inherit pname version;
 
-        src =
-          if pkgs.stdenv.isDarwin
-          then pkgs.fetchurl {
-            url = darwinAmd64Url;
-            sha256 = darwinAmd64Sha256;
-          }
-          else pkgs.fetchurl {
+      src =
+        if pkgs.stdenv.isDarwin
+        then
+          pkgs.fetchurl
+            {
+              url = darwinAmd64Url;
+              sha256 = darwinAmd64Sha256;
+            }
+        else
+          pkgs.fetchurl {
             url = linuxAmd64Url;
             sha256 = linuxAmd64Sha256;
           };
-        phases = ["installPhase" "patchPhase"];
+      phases = [ "installPhase" "patchPhase" ];
 
-        installPhase = ''
-          mkdir -p $out/bin
-          cp $src $out/bin/${binPath}
-          chmod +x $out/bin/${binPath}
-        '';
-      };
+      installPhase = ''
+        mkdir -p $out/bin
+        cp $src $out/bin/${binPath}
+        chmod +x $out/bin/${binPath}
+      '';
+    };
 
   pinned = {
     stack = staticBinaryInTarball {
@@ -102,7 +108,8 @@ let
       linuxAmd64Sha256 = "949f81b3c30ca03a3d4effdecda04f100fa3edc07a28b19400f72ede7c5f0491";
     };
   };
-in pkgs.buildEnv {
+in
+pkgs.buildEnv {
   name = "wire-server-direnv";
   paths = [
     pkgs.cfssl
@@ -126,4 +133,3 @@ in pkgs.buildEnv {
     pinned.kind
   ];
 }
-

--- a/direnv.nix
+++ b/direnv.nix
@@ -105,14 +105,15 @@ let
 in pkgs.buildEnv {
   name = "wire-server-direnv";
   paths = [
+    pkgs.cfssl
     pkgs.docker-compose
     pkgs.gnumake
-    pkgs.haskell-language-server
-    pkgs.telepresence
-    pkgs.jq
     pkgs.grpcurl
+    pkgs.haskell-language-server
+    pkgs.jq
+    pkgs.ormolu
+    pkgs.telepresence
     pkgs.wget
-    pkgs.cfssl
     pkgs.yq
 
     # To actually run buildah on nixos, I had to follow this: https://gist.github.com/alexhrescale/474d55635154e6b2cd6362c3bb403faf

--- a/tools/ormolu.sh
+++ b/tools/ormolu.sh
@@ -4,13 +4,6 @@ set -e
 
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
-command -v grep >/dev/null 2>&1 || { echo >&2 "grep is not installed, aborting."; exit 1; }
-command -v sed  >/dev/null 2>&1 || { echo >&2 "sed is not installed, aborting."; exit 1; }
-
-ORMOLU_VERSION=$(sed -n '/^extra-deps:/,$ { s/^- ormolu-//p }' < stack.yaml)
-( ormolu -v 2>/dev/null | grep -q $ORMOLU_VERSION ) || ( echo "please install ormolu $ORMOLU_VERSION (eg., run 'stack install ormolu' and ensure ormolu is on your PATH.)"; exit 1 )
-echo "ormolu version: $ORMOLU_VERSION"
-
 ARG_ALLOW_DIRTY_WC="0"
 ARG_ORMOLU_MODE="inplace"
 

--- a/tools/ormolu.sh
+++ b/tools/ormolu.sh
@@ -67,6 +67,11 @@ if [ -t 1 ]; then
     : ${ORMOLU_CONDENSE_OUTPUT:=1}
 fi
 
+# https://github.com/tweag/ormolu/issues/38
+# https://gitlab.haskell.org/ghc/ghc/-/issues/17755
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+
 for hsfile in $(git ls-files | grep '\.hsc\?$'); do
     FAILED=0
 


### PR DESCRIPTION
This will provide ormolu via direnv, and do some CI steps in GH Actions:

 - ensuring the direnv environment (still) builds
 - uploading it to the cachix cache
 - run `make formatc` and provide feedback if code is not formatted.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information:
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
