### PR TITLE
Fix generate.sh of ./tools/convert-to-cabal

### DIFF
--- a/tools/convert-to-cabal/generate.sh
+++ b/tools/convert-to-cabal/generate.sh
@@ -5,7 +5,9 @@ TOP_LEVEL="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
 cd "$TOP_LEVEL"
 
+nix-shell ./tools/convert-to-cabal/shell.nix --command "stack2cabal --no-run-hpack"
+
 {
- echo -e "\n-- Changes by ./tools/convert-to-cabal/generate.sh \n\ntests: True\n\n"
- ./hack/bin/cabal-project-local-template.sh "ghc-options: -Werror" >> ./cabal.project
+ echo -e "\n-- Changes by ./tools/convert-to-cabal/generate.sh \n\ntests: True\n\n";
+ ./hack/bin/cabal-project-local-template.sh "ghc-options: -Werror"
 } >> ./cabal.project


### PR DESCRIPTION
Fixes a missing call in generate.sh

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
