### PR TITLE
Ingress tls1.3 [WIP]

### DIFF
--- a/changelog.d/0-release-notes/kubernetes-version
+++ b/changelog.d/0-release-notes/kubernetes-version
@@ -1,0 +1,1 @@
+Your kubernetes server version must be >= 1.19 (type `kubectl version` to check)

--- a/changelog.d/0-release-notes/tls-13-ingress
+++ b/changelog.d/0-release-notes/tls-13-ingress
@@ -1,0 +1,1 @@
+If you have custom overrides for the nginx-ingress-controller, you must change the config value 'nginx-ingress' to 'ingress-nginx' or risk falling back to default settings.

--- a/changelog.d/2-features/tls-13-ingress
+++ b/changelog.d/2-features/tls-13-ingress
@@ -1,0 +1,1 @@
+Add TLS 1.3 support on the ingress level.

--- a/charts/nginx-ingress-controller/requirements.yaml
+++ b/charts/nginx-ingress-controller/requirements.yaml
@@ -1,4 +1,6 @@
 dependencies:
 - name: ingress-nginx
-  version: 3.39.0 # app version v0.49.3; k8s [1.19 - 1.21]
+  # version support: https://github.com/kubernetes/ingress-nginx#support-versions-table
+  # chart version 3.39.0 == app version v0.49.3; k8s [1.19 - 1.21]
+  version: 3.39.0
   repository: https://kubernetes.github.io/ingress-nginx

--- a/charts/nginx-ingress-controller/requirements.yaml
+++ b/charts/nginx-ingress-controller/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
-- name: nginx-ingress
-  version: 1.33.3
-  repository: https://charts.helm.sh/stable
+- name: ingress-nginx
+  version: 3.39.0 # app version v0.49.3; k8s [1.19 - 1.21]
+  repository: https://kubernetes.github.io/ingress-nginx

--- a/charts/nginx-ingress-controller/requirements.yaml
+++ b/charts/nginx-ingress-controller/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: ingress-nginx
   # version support: https://github.com/kubernetes/ingress-nginx#support-versions-table
-  # chart version 3.39.0 == app version v0.49.3; k8s [1.19 - 1.21]
-  version: 3.39.0
+  # chart version 4.0.17 == app version v1.1.1; k8s [1.19 - 1.23]
+  version: 4.0.17
   repository: https://kubernetes.github.io/ingress-nginx

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -1,5 +1,6 @@
 # Default values for nginx-ingress-controller
 
+# TODO: this should probably be ingress-nginx now
 nginx-ingress:
   controller:
     config:

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -8,7 +8,9 @@ nginx-ingress:
       # As a Wire employee, for Wire-internal discussions and context see
       # * https://wearezeta.atlassian.net/browse/FS-33
       # * https://wearezeta.atlassian.net/browse/FS-444
+      # TODO add TLS 1.3 ciphers to the list
       ssl-ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256"
+      ssl-protocols: "TLSv1.2 TLSv1.3"
       http2-max-field-size: 16k
       http2-max-header-size: 32k
       proxy-buffer-size: 16k

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -1,16 +1,18 @@
-# Default values for nginx-ingress-controller
+# FUTUREWORK(hardening): create a dhparam with openssl
+# see https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
+# and set the controller.config.ssl-dh-param value accordingly. Via helm pre-hook?
 
-# TODO: this should probably be ingress-nginx now
-nginx-ingress:
+# Default values for nginx-ingress-controller
+ingress-nginx:
   controller:
     config:
       # NOTE: These are some sane defaults (compliant to TR-02102-2), you may want to overrride them on your own installation
       # For TR-02102-2 see https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.html
+      # For an overview, see https://docs.wire.com/how-to/install/tls.html
       # As a Wire employee, for Wire-internal discussions and context see
       # * https://wearezeta.atlassian.net/browse/FS-33
       # * https://wearezeta.atlassian.net/browse/FS-444
-      # TODO add TLS 1.3 ciphers to the list
-      ssl-ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256"
+      ssl-ciphers: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256"
       ssl-protocols: "TLSv1.2 TLSv1.3"
       http2-max-field-size: 16k
       http2-max-header-size: 32k

--- a/hack/helmfile-single.yaml
+++ b/hack/helmfile-single.yaml
@@ -32,13 +32,13 @@ releases:
     namespace: '{{ .Values.namespace }}'
     chart: '../.local/charts/databases-ephemeral'
 
-  - name: '{{ .Values.namespace }}-ingress-cont'
+  - name: '{{ .Values.namespace }}-ic'
     namespace: '{{ .Values.namespace }}'
     chart: '../.local/charts/nginx-ingress-controller'
     values:
       - './helm_vars/nginx-ingress-controller/values.yaml'
 
-  - name: '{{ .Values.namespace }}-ingress-svc'
+  - name: '{{ .Values.namespace }}-is'
     namespace: '{{ .Values.namespace }}'
     chart: '../.local/charts/nginx-ingress-services'
     values:

--- a/hack/helmfile-single.yaml
+++ b/hack/helmfile-single.yaml
@@ -18,6 +18,8 @@ environments:
 repositories:
   - name: stable
     url: 'https://charts.helm.sh/stable'
+  - name: ingress
+    url: 'https://kubernetes.github.io/ingress-nginx'
 
 releases:
   - name: '{{ .Values.namespace }}-fake-aws'

--- a/hack/helmfile-single.yaml
+++ b/hack/helmfile-single.yaml
@@ -32,13 +32,13 @@ releases:
     namespace: '{{ .Values.namespace }}'
     chart: '../.local/charts/databases-ephemeral'
 
-  - name: '{{ .Values.namespace }}-nginx-ingress-controller'
+  - name: '{{ .Values.namespace }}-ingress-cont'
     namespace: '{{ .Values.namespace }}'
     chart: '../.local/charts/nginx-ingress-controller'
     values:
       - './helm_vars/nginx-ingress-controller/values.yaml'
 
-  - name: '{{ .Values.namespace }}-nginx-ingress-services'
+  - name: '{{ .Values.namespace }}-ingress-svc'
     namespace: '{{ .Values.namespace }}'
     chart: '../.local/charts/nginx-ingress-services'
     values:

--- a/hack/helmfile.yaml
+++ b/hack/helmfile.yaml
@@ -54,19 +54,19 @@ releases:
     namespace: '{{ .Values.namespaceFed2 }}'
     chart: '../.local/charts/databases-ephemeral'
 
-  - name: '{{ .Values.namespace }}-ingress-cont'
+  - name: '{{ .Values.namespace }}-ic'
     namespace: '{{ .Values.namespace }}'
     chart: '../.local/charts/nginx-ingress-controller'
     values:
       - './helm_vars/nginx-ingress-controller/values.yaml'
 
-  - name: '{{ .Values.namespace }}-ingress-cont-2'
+  - name: '{{ .Values.namespace }}-ic-2'
     namespace: '{{ .Values.namespaceFed2 }}'
     chart: '../.local/charts/nginx-ingress-controller'
     values:
       - './helm_vars/nginx-ingress-controller/values.yaml'
 
-  - name: '{{ .Values.namespace }}-ingress-svc'
+  - name: '{{ .Values.namespace }}-is'
     namespace: '{{ .Values.namespace }}'
     chart: '../.local/charts/nginx-ingress-services'
     values:
@@ -79,7 +79,7 @@ releases:
       - name: config.dns.federator
         value: {{ .Values.federationDomain }}
 
-  - name: '{{ .Values.namespace }}-ingress-svc-2'
+  - name: '{{ .Values.namespace }}-is-2'
     namespace: '{{ .Values.namespaceFed2 }}'
     chart: '../.local/charts/nginx-ingress-services'
     values:

--- a/hack/helmfile.yaml
+++ b/hack/helmfile.yaml
@@ -54,19 +54,19 @@ releases:
     namespace: '{{ .Values.namespaceFed2 }}'
     chart: '../.local/charts/databases-ephemeral'
 
-  - name: '{{ .Values.namespace }}-nginx-ingress-controller'
+  - name: '{{ .Values.namespace }}-ingress-cont'
     namespace: '{{ .Values.namespace }}'
     chart: '../.local/charts/nginx-ingress-controller'
     values:
       - './helm_vars/nginx-ingress-controller/values.yaml'
 
-  - name: '{{ .Values.namespace }}-nginx-ingress-controller-2'
+  - name: '{{ .Values.namespace }}-ingress-cont-2'
     namespace: '{{ .Values.namespaceFed2 }}'
     chart: '../.local/charts/nginx-ingress-controller'
     values:
       - './helm_vars/nginx-ingress-controller/values.yaml'
 
-  - name: '{{ .Values.namespace }}-nginx-ingress-services'
+  - name: '{{ .Values.namespace }}-ingress-svc'
     namespace: '{{ .Values.namespace }}'
     chart: '../.local/charts/nginx-ingress-services'
     values:
@@ -79,7 +79,7 @@ releases:
       - name: config.dns.federator
         value: {{ .Values.federationDomain }}
 
-  - name: '{{ .Values.namespace }}-nginx-ingress-services-2'
+  - name: '{{ .Values.namespace }}-ingress-svc-2'
     namespace: '{{ .Values.namespaceFed2 }}'
     chart: '../.local/charts/nginx-ingress-services'
     values:

--- a/hack/helmfile.yaml
+++ b/hack/helmfile.yaml
@@ -30,6 +30,8 @@ environments:
 repositories:
   - name: stable
     url: 'https://charts.helm.sh/stable'
+  - name: ingress
+    url: 'https://kubernetes.github.io/ingress-nginx'
 
 releases:
   - name: '{{ .Values.namespace }}-fake-aws'


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-33
version support: https://github.com/kubernetes/ingress-nginx#support-versions-table

This PR, once working (still WIP)

* allows TLS 1.3 connections (while maintaining TLS 1.2 support)
* upgrades the nginx-ingress chart to a recent version that supports TLS 1.3. This, as a result, requires kubernetes >= 1.19 (added a changelog entry for that)
* Any overrides will need to be adjusted (added a changelog entry for that)

Current issues:

* `Error: Service "test-bw4377dj3tiz-ic-2-ingress-nginx-controller" is invalid: spec.ports[0].nodePort: Invalid value: 31772: provided port is already allocated`: seems like we can't do an in-place upgrade with helm on the existing controller; instead a migration needs to be devised & documented.

TODO:

* [ ] test on different k8s versions
* [ ] maybe also update api version of ingress definitions to match k8s 1.19+

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
