### PR TITLE
Fix LD_LIBRARY_PATH usage in direnv build environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
 env=$(nix-build --no-out-link "$PWD/direnv.nix")
-load_prefix "${env}"
+PATH_add "${env}/bin"
 
 # allow local .envrc overrides
 [[ -f .envrc.local ]] && source_env .envrc.local

--- a/direnv.nix
+++ b/direnv.nix
@@ -109,36 +109,9 @@ let
     };
   };
 
-  direnv-depends = pkgs.buildEnv {
-    name = "wire-server-direnv-depends";
+  compile-deps = pkgs.buildEnv {
+    name = "wire-server-compile-deps";
     paths = [
-      pkgs.cfssl
-      pkgs.docker-compose
-      pkgs.gnumake
-      pkgs.grpcurl
-      pkgs.haskell-language-server
-      pkgs.jq
-      pkgs.ormolu
-      pkgs.telepresence
-      pkgs.wget
-      pkgs.yq
-      pkgs.rsync
-
-      # To actually run buildah on nixos, I had to follow this: https://gist.github.com/alexhrescale/474d55635154e6b2cd6362c3bb403faf
-      pkgs.buildah
-
-      pinned.stack
-      pinned.helm
-      pinned.helmfile
-      pinned.kubectl
-      pinned.kind
-
-      # For cabal-migration
-      pkgs.haskell.compiler.ghc884
-
-      # We don't include cabal here, as we invoke it with a wrapper which sets
-      # LD_LIBRARY_PATH and others correctly.
-      pkgs.haskellPackages.cabal-plan
       pkgs.pkgconfig
       pkgs.protobuf
 
@@ -170,16 +143,43 @@ let
   # for cabal, as setting it in direnv can interfere with programs in the host
   # system, especially for non-NixOS users.
   cabal-wrapper = pkgs.writeShellScriptBin "cabal" ''
-    export CPATH="${direnv-depends}/include:$CPATH"
-    export LD_LIBRARY_PATH="${direnv-depends}/lib:$LD_LIBRARY_PATH"
-    export LIBRARY_PATH="${direnv-depends}/lib:$LIBRARY_PATH"
-    export PKG_CONFIG_PATH="${direnv-depends}/lib/pkgconfig:$PKG_CONFIG_PATH"
+    export CPATH="${compile-deps}/include:$CPATH"
+    export LD_LIBRARY_PATH="${compile-deps}/lib:$LD_LIBRARY_PATH"
+    export LIBRARY_PATH="${compile-deps}/lib:$LIBRARY_PATH"
+    export PKG_CONFIG_PATH="${compile-deps}/lib/pkgconfig:$PKG_CONFIG_PATH"
+    export PATH="${compile-deps}/bin:$PATH"
     exec "${pkgs.cabal-install}/bin/cabal" "$@"
   '';
 in pkgs.buildEnv {
   name = "wire-server-direnv";
   paths = [
-    direnv-depends
+    pkgs.cfssl
+    pkgs.docker-compose
+    pkgs.gnumake
+    pkgs.grpcurl
+    pkgs.haskell-language-server
+    pkgs.jq
+    pkgs.ormolu
+    pkgs.telepresence
+    pkgs.wget
+    pkgs.yq
+    pkgs.rsync
+
+    # To actually run buildah on nixos, I had to follow this: https://gist.github.com/alexhrescale/474d55635154e6b2cd6362c3bb403faf
+    pkgs.buildah
+
+    pinned.stack
+    pinned.helm
+    pinned.helmfile
+    pinned.kubectl
+    pinned.kind
+
+    # For cabal-migration
+    pkgs.haskell.compiler.ghc884
+    pkgs.haskellPackages.cabal-plan
+
+    # We don't use pkgs.cabal-install here, as we invoke it with a wrapper
+    # which sets LD_LIBRARY_PATH and others correctly.
     cabal-wrapper
   ];
 }

--- a/direnv.nix
+++ b/direnv.nix
@@ -108,58 +108,78 @@ let
       linuxAmd64Sha256 = "949f81b3c30ca03a3d4effdecda04f100fa3edc07a28b19400f72ede7c5f0491";
     };
   };
-in
-pkgs.buildEnv {
+
+  direnv-depends = pkgs.buildEnv {
+    name = "wire-server-direnv-depends";
+    paths = [
+      pkgs.cfssl
+      pkgs.docker-compose
+      pkgs.gnumake
+      pkgs.grpcurl
+      pkgs.haskell-language-server
+      pkgs.jq
+      pkgs.ormolu
+      pkgs.telepresence
+      pkgs.wget
+      pkgs.yq
+      pkgs.rsync
+
+      # To actually run buildah on nixos, I had to follow this: https://gist.github.com/alexhrescale/474d55635154e6b2cd6362c3bb403faf
+      pkgs.buildah
+
+      pinned.stack
+      pinned.helm
+      pinned.helmfile
+      pinned.kubectl
+      pinned.kind
+
+      # For cabal-migration
+      pkgs.haskell.compiler.ghc884
+
+      # We don't include cabal here, as we invoke it with a wrapper which sets
+      # LD_LIBRARY_PATH and others correctly.
+      pkgs.haskellPackages.cabal-plan
+      pkgs.pkgconfig
+      pkgs.protobuf
+
+      pkgs.cryptobox
+      pkgs.geoip
+      pkgs.icu.dev
+      pkgs.icu.out
+      pkgs.libsodium.dev
+      pkgs.libsodium.out
+      pkgs.libxml2.dev
+      pkgs.libxml2.out
+      pkgs.ncurses.dev
+      pkgs.ncurses.out
+      pkgs.openssl.dev
+      pkgs.openssl.out
+      pkgs.pcre.dev
+      pkgs.pcre.out
+      pkgs.snappy.dev
+      pkgs.snappy.out
+      pkgs.zlib.dev
+      pkgs.zlib.out
+      pkgs.lzma.dev
+      pkgs.lzma.out
+    ];
+  };
+
+  # This performs roughly the same setup as direnv's load_prefix function, but
+  # only when invoking cabal. This means that we can set LD_LIBRARY_PATH just
+  # for cabal, as setting it in direnv can interfere with programs in the host
+  # system, especially for non-NixOS users.
+  cabal-wrapper = pkgs.writeShellScriptBin "cabal" ''
+    export CPATH="${direnv-depends}/include:$CPATH"
+    export LD_LIBRARY_PATH="${direnv-depends}/lib:$LD_LIBRARY_PATH"
+    export LIBRARY_PATH="${direnv-depends}/lib:$LIBRARY_PATH"
+    export PKG_CONFIG_PATH="${direnv-depends}/lib/pkgconfig:$PKG_CONFIG_PATH"
+    exec "${pkgs.cabal-install}/bin/cabal" "$@"
+  '';
+in pkgs.buildEnv {
   name = "wire-server-direnv";
   paths = [
-    pkgs.cfssl
-    pkgs.docker-compose
-    pkgs.gnumake
-    pkgs.grpcurl
-    pkgs.haskell-language-server
-    pkgs.jq
-    pkgs.ormolu
-    pkgs.telepresence
-    pkgs.wget
-    pkgs.yq
-    pkgs.rsync
-
-    # To actually run buildah on nixos, I had to follow this: https://gist.github.com/alexhrescale/474d55635154e6b2cd6362c3bb403faf
-    pkgs.buildah
-
-    pinned.stack
-    pinned.helm
-    pinned.helmfile
-    pinned.kubectl
-    pinned.kind
-
-    # For cabal-migration
-    pkgs.haskell.compiler.ghc884
-
-    pkgs.cabal-install
-    pkgs.haskellPackages.cabal-plan
-    pkgs.pkgconfig
-    pkgs.protobuf
-
-    pkgs.cryptobox
-    pkgs.geoip
-    pkgs.icu.dev
-    pkgs.icu.out
-    pkgs.libsodium.dev
-    pkgs.libsodium.out
-    pkgs.libxml2.dev
-    pkgs.libxml2.out
-    pkgs.ncurses.dev
-    pkgs.ncurses.out
-    pkgs.openssl.dev
-    pkgs.openssl.out
-    pkgs.pcre.dev
-    pkgs.pcre.out
-    pkgs.snappy.dev
-    pkgs.snappy.out
-    pkgs.zlib.dev
-    pkgs.zlib.out
-    pkgs.lzma.dev
-    pkgs.lzma.out
+    direnv-depends
+    cabal-wrapper
   ];
 }


### PR DESCRIPTION
The direnv hook for wire-server uses the `load_prefix` function, which sets the `LD_LIBRARY_PATH` environment variable in development shells, so that cabal can pick up non-Haskell dependencies like zlib and cryptobox. However, this means that running programs inside the dev shell environment will cause libraries from the Nix store to be loaded, which can interfere with programs from the host system, especially for non-NixOS users. For example, I can't run `nix-build` inside a dev shell on Debian, as the dynamic loader tries to load an incompatible shared library from the Nix store instead of system libraries.

I've refactored the dev shell environment, and split everything but cabal into its own environment, wrapped cabal in a script which sets `LD_LIBRARY_PATH` to point to the everything-but-cabal environment, and made a second environment which encapsulates the everything-but-cabal env and the cabal wrapper. direnv then only exposes the `bin/` directory of the second environment in `PATH` instead of setting all the `LD_LIBRARY_PATH` environment variables.