### PR TITLE
Define and expose Federation API version

### DIFF
--- a/changelog.d/6-federation/expose-api-version
+++ b/changelog.d/6-federation/expose-api-version
@@ -1,0 +1,1 @@
+Expose the server-to-server API version

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -100,6 +100,10 @@ nginx_conf:
       disable_zauth: true
       envs:
       - all
+    - path: /api/federation/version
+      disable_zauth: true
+      envs:
+      - all
     - path: /self
       envs:
       - all

--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -196,6 +196,11 @@ http {
         proxy_pass http://brig;
     }
 
+    location /api/federation/version {
+        include common_response_no_zauth.conf;
+        proxy_pass http://brig;
+    }
+
     location /register {
       include common_response_no_zauth.conf;
       proxy_pass http://brig;

--- a/libs/wire-api-federation/package.yaml
+++ b/libs/wire-api-federation/package.yaml
@@ -32,10 +32,12 @@ dependencies:
 - mu-protobuf
 - mu-schema
 - mtl
+- schema-profunctor
 - servant >=0.16
 - servant-client
 - servant-client-core
 - sop-core
+- swagger2
 - template-haskell
 - text >=0.11
 - time >=1.8

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Common.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Common.hs
@@ -15,7 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Wire.API.Federation.API.Common where
+module Wire.API.Federation.API.Common
+  ( EmptyResponse (..),
+  )
+where
 
 import Data.Aeson
 import Imports

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 502683f56cc0fbb11b75807669858c1d4fdf146afa8a016fa18daec9f6a72e7a
+-- hash: 40fd742bcfe132655b2a812efd7e187b208f274c4ec7a45903c24f7b8648788c
 
 name:           wire-api-federation
 version:        0.1.0
@@ -59,10 +59,12 @@ library
     , mu-protobuf
     , mu-rpc
     , mu-schema
+    , schema-profunctor
     , servant >=0.16
     , servant-client
     , servant-client-core
     , sop-core
+    , swagger2
     , template-haskell
     , text >=0.11
     , time >=1.8
@@ -122,10 +124,12 @@ test-suite spec
     , mu-schema
     , network
     , retry
+    , schema-profunctor
     , servant >=0.16
     , servant-client
     , servant-client-core
     , sop-core
+    , swagger2
     , template-haskell
     , text >=0.11
     , time >=1.8

--- a/libs/wire-api/src/Wire/API/Routes/Public/Federation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Federation.hs
@@ -1,0 +1,64 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+-- | The publicly-facing API for federation
+module Wire.API.Routes.Public.Federation where
+
+import Data.Aeson (ToJSON)
+import Data.Schema
+import qualified Data.Swagger as S
+import GHC.TypeLits
+import Imports
+import Servant
+import Servant.API.Generic
+import Servant.Swagger (toSwagger)
+
+-- | Version of Wire's Federation API
+--
+-- Two releases of Wire are fully compatible in all federated features if they
+-- share the same federation version.
+--
+-- FUTUREWORK: Define a compatability matrix when version 2 is released.
+type FederationVersion = 1
+
+federationVersion :: forall (v :: Nat) a. (KnownNat v, Num a) => a
+federationVersion = fromInteger . natVal $ Proxy @v
+
+data FederationVersionResponse (v :: Nat) = FederationVersionResponse
+  deriving (ToJSON, S.ToSchema) via Schema (FederationVersionResponse v)
+
+instance KnownNat v => ToSchema (FederationVersionResponse v) where
+  schema =
+    object "FederationVersionResponse" $
+      FederationVersionResponse
+        <$ const (federationVersion @v) .= field "version" (schema @Word)
+
+data Api routes = Api
+  { getAPIVersion ::
+      routes
+        :- Summary "Get the Wire API version"
+        :> "api"
+        :> "federation"
+        :> "version"
+        :> Get '[Servant.JSON] (FederationVersionResponse FederationVersion)
+  }
+  deriving (Generic)
+
+type ServantAPI = ToServantApi Api
+
+swaggerDoc :: S.Swagger
+swaggerDoc = toSwagger (Proxy @ServantAPI)

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -57,6 +57,7 @@ library
       Wire.API.Routes.MultiVerb
       Wire.API.Routes.Public
       Wire.API.Routes.Public.Brig
+      Wire.API.Routes.Public.Federation
       Wire.API.Routes.Public.Galley
       Wire.API.Routes.Public.LegalHold
       Wire.API.Routes.Public.Spar

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -27,7 +27,7 @@ import Brig.API (sitemap)
 import Brig.API.Federation (federationSitemap)
 import Brig.API.Handler
 import qualified Brig.API.Internal as IAPI
-import Brig.API.Public (ServantAPI, SwaggerDocsAPI, servantSitemap, swaggerDocsAPI)
+import Brig.API.Public (ServantAPI, SwaggerDocsAPI, servantSitemap, swaggerDocsAPI, versionAPISitemap)
 import qualified Brig.API.User as API
 import Brig.AWS (sesQueue)
 import qualified Brig.AWS as AWS
@@ -70,6 +70,7 @@ import System.Logger (msg, val, (.=), (~~))
 import System.Logger.Class (MonadLogger, err)
 import Util.Options
 import qualified Wire.API.Federation.API.Brig as FederationBrig
+import qualified Wire.API.Routes.Public.Federation as VersionAPI
 
 -- FUTUREWORK: If any of these async threads die, we will have no clue about it
 -- and brig could start misbehaving. We should ensure that brig dies whenever a
@@ -128,6 +129,7 @@ mkApp o = do
             :<|> Servant.hoistServer (Proxy @ServantAPI) (toServantHandler e) servantSitemap
             :<|> Servant.hoistServer (Proxy @IAPI.API) (toServantHandler e) IAPI.servantSitemap
             :<|> Servant.hoistServer (genericApi (Proxy @FederationBrig.Api)) (toServantHandler e) federationSitemap
+            :<|> Servant.hoistServer (Proxy @VersionAPI.ServantAPI) (toServantHandler e) versionAPISitemap
             :<|> Servant.Tagged (app e)
         )
 
@@ -136,6 +138,7 @@ type ServantCombinedAPI =
       :<|> ServantAPI
       :<|> IAPI.API
       :<|> ToServantApi FederationBrig.Api
+      :<|> VersionAPI.ServantAPI
       :<|> Servant.Raw
   )
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-127

Perhaps a set of known compatible versions should be exposed too.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information:
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?