### PR TITLE
Changelog.d docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
  - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
  - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
  - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
- - [ ] **changelog.d** contains the following bits of information:
+ - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
    - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
    - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
    - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.

--- a/changelog.d/4-docs/changelog.d-docs
+++ b/changelog.d/4-docs/changelog.d-docs
@@ -1,0 +1,1 @@
+Document the wire-server PR process better.

--- a/docs/developer/changelog.md
+++ b/docs/developer/changelog.md
@@ -6,7 +6,9 @@ notes.
 
 ## tl;dr
 
-Entries have to be written in individual files in `changelog.d`.
+Entries have to be written in individual files in a relevant subfolder of `./changelog.d/`.
+
+*Example*: create the file `./changelog.d/2-features/potato-peeler` with one-line contents `Introduce automatic potato peeler functionality when buying potatoes, see [docs](link-to-docs)`
 
 ## Details
 

--- a/docs/developer/changelog.md
+++ b/docs/developer/changelog.md
@@ -1,0 +1,39 @@
+The wire-server repo has a process for changelog editing that prevents
+merge conflicts and enforces a consistent structure to the release
+notes.
+
+*Introduced in https://github.com/wireapp/wire-server/pull/1749.*
+
+## tl;dr
+
+Entries have to be written in individual files in `changelog.d`.
+
+## Details
+
+On every pull request, one is supposed to create a new file in the
+appropriate subdirectory of `changelog.d`, containing just the text of
+the corresponding changelog entry. There is no need to explicitly
+write a PR number, because the `mk-changelog.sh` script will add it
+automatically at the end. The name of the file does not matter, but
+please try to make it unique to avoid unnecessary conflicts (e.g. use
+the branch name).
+
+It is still possible to write the PR number manually if so desired,
+which is useful in case the entry should refer to multiple PRs. In
+that case, the script leaves the PR number reference intact, as long
+as it is at the very end of the entry (no period allowed afterwards!),
+and in brackets. It is also possible to use the pattern `##` to refer
+to the current PR number. This will be replaced throughout.
+
+Multiline entries are supported, and should be handled
+correctly. Again, the PR reference should either be omitted or put at
+the very end. If multiple entries for a single PR are desired, one
+should create a different file for each of them.
+
+## Generating a CHANGELOG for a release
+
+Just run the script `changelog.d/mk-changelog.sh` with no
+arguments. It will print all the entries, nicely formatted, on
+standard output. The script gets PR numbers from the `git` log. If
+that fails for any reason (e.g. if an entry was added outside of a
+PR), make sure that the entry has a manually specified PR number.


### PR DESCRIPTION
I copied some docs from the PR description into a more permanent place and referenced it here in the PR template.  This was motivated by questions from new team members that should have had an easy-to-find answer.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
