### PR TITLE
Use minio helm chart from charts.min.io instead of helm.min.io

### DIFF
--- a/changelog.d/0-release-notes/minio-helm
+++ b/changelog.d/0-release-notes/minio-helm
@@ -1,0 +1,1 @@
+Breaking change to the `fake-aws-s3` helm chart. We now use minio helm chart from https://charts.min.io. The options are documented here: https://github.com/minio/minio/tree/master/helm/minio

--- a/changelog.d/5-internal/minio-helm
+++ b/changelog.d/5-internal/minio-helm
@@ -1,0 +1,1 @@
+Use minio helm chart in fake-aws-s3 from charts.min.io instead of helm.min.io, the latter seems to be down

--- a/charts/fake-aws-s3/requirements.yaml
+++ b/charts/fake-aws-s3/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: minio
-  version: 8.0.3
-  repository: https://helm.min.io/
+  version: 3.2.0
+  repository: https://charts.min.io/

--- a/charts/fake-aws-s3/templates/reaper.yaml
+++ b/charts/fake-aws-s3/templates/reaper.yaml
@@ -1,11 +1,3 @@
-{{- $accessKey := "" }}
-{{- $secretKey := "" }}
-{{- range .Values.minio.users }}
-{{- if (eq .policy "consoleAdmin") }}
-{{- $accessKey = .accessKey }}
-{{- $secretKey = .secretKey }}
-{{- end }}
-{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,21 +17,36 @@ spec:
       labels:
         app: {{ template "fullname" . }}-reaper
     spec:
+      volumes:
+      - name: minio-configuration
+        projected:
+          # These are created by the minio chart and used for create buckets and
+          # users after deployment.
+          sources:
+          - configMap:
+              name: {{ .Values.minio.fullnameOverride }}
+          - secret:
+              name: {{ .Values.minio.fullnameOverride }}
       containers:
       - name: initiate-fake-aws-s3
-        image: mesosphere/aws-cli:1.14.5
+        image: "{{ .Values.minio.mcImage.repository }}:{{ .Values.minio.mcImage.tag }}"
+        imagePullPolicy: {{ .Values.minio.mcImage.pullPolicy }}
         command: [/bin/sh]
         args:
         - -c
         - |
-          echo 'Creating AWS resources'
+          echo 'Creating MinIO Users and Buckets'
           while true
           do
-              export AWS_SECRET_ACCESS_KEY={{ $secretKey }}
-              export AWS_ACCESS_KEY_ID={{ $accessKey }}
-              {{- range .Values.minio.buckets }}
-              aws s3 --endpoint http://{{ $.Values.minio.fullnameOverride }}:9000 mb s3://{{ .name }} | grep -ev "BucketAlreadyOwnedByYou"
-              {{- end }}
+              /bin/sh /config/initialize
+              /bin/sh /config/add-user
               sleep 10
           done
-
+        env:
+        - name: MINIO_ENDPOINT
+          value: {{ .Values.minio.fullnameOverride | quote }}
+        - name: MINIO_PORT
+          value: {{ .Values.minio.service.port | quote }}
+        volumeMounts:
+        - name: minio-configuration
+          mountPath: /config

--- a/charts/fake-aws-s3/templates/reaper.yaml
+++ b/charts/fake-aws-s3/templates/reaper.yaml
@@ -1,3 +1,11 @@
+{{- $accessKey := "" }}
+{{- $secretKey := "" }}
+{{- range .Values.minio.users }}
+{{- if (eq .policy "consoleAdmin") }}
+{{- $accessKey = .accessKey }}
+{{- $secretKey = .secretKey }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,9 +35,8 @@ spec:
           echo 'Creating AWS resources'
           while true
           do
-              # TODO: Do not assume that the first user has consoleAdmin privileges
-              export AWS_SECRET_ACCESS_KEY={{ (index .Values.minio.users 0).secretKey }}
-              export AWS_ACCESS_KEY_ID={{ (index .Values.minio.users 0).accessKey }}
+              export AWS_SECRET_ACCESS_KEY={{ $secretKey }}
+              export AWS_ACCESS_KEY_ID={{ $accessKey }}
               {{- range .Values.minio.buckets }}
               aws s3 --endpoint http://{{ $.Values.minio.fullnameOverride }}:9000 mb s3://{{ .name }} | grep -ev "BucketAlreadyOwnedByYou"
               {{- end }}

--- a/charts/fake-aws-s3/templates/reaper.yaml
+++ b/charts/fake-aws-s3/templates/reaper.yaml
@@ -27,7 +27,12 @@ spec:
           echo 'Creating AWS resources'
           while true
           do
-              AWS_SECRET_ACCESS_KEY={{ .Values.minio.secretKey }} AWS_ACCESS_KEY_ID={{ .Values.minio.accessKey }} aws s3 --endpoint http://{{ .Values.minio.fullnameOverride }}:9000 mb s3://{{ .Values.minio.defaultBucket.name }} | grep -ev "BucketAlreadyOwnedByYou"
+              # TODO: Do not assume that the first user has consoleAdmin privileges
+              export AWS_SECRET_ACCESS_KEY={{ (index .Values.minio.users 0).secretKey }}
+              export AWS_ACCESS_KEY_ID={{ (index .Values.minio.users 0).accessKey }}
+              {{- range .Values.minio.buckets }}
+              aws s3 --endpoint http://{{ $.Values.minio.fullnameOverride }}:9000 mb s3://{{ .name }} | grep -ev "BucketAlreadyOwnedByYou"
+              {{- end }}
               sleep 10
           done
 

--- a/charts/fake-aws-s3/values.yaml
+++ b/charts/fake-aws-s3/values.yaml
@@ -1,6 +1,7 @@
 # See defaults in https://github.com/helm/charts/tree/master/stable/minio
 minio:
   fullnameOverride: fake-aws-s3
+  mode: standalone
   users:
     - accessKey: dummykey
       secretKey: dummysecret

--- a/charts/fake-aws-s3/values.yaml
+++ b/charts/fake-aws-s3/values.yaml
@@ -1,14 +1,14 @@
 # See defaults in https://github.com/helm/charts/tree/master/stable/minio
 minio:
   fullnameOverride: fake-aws-s3
-  accessKey: dummykey
-  secretKey: dummysecret
+  users:
+    - accessKey: dummykey
+      secretKey: dummysecret
+      policy: consoleAdmin
   persistence:
     enabled: false
   environment:
     MINIO_BROWSER: "off"
-  defaultBucket:
-    name: dummy-bucket
   buckets:
     - name: dummy-bucket
       purge: true

--- a/charts/fake-aws-s3/values.yaml
+++ b/charts/fake-aws-s3/values.yaml
@@ -10,6 +10,9 @@ minio:
     enabled: false
   environment:
     MINIO_BROWSER: "off"
+  resources:
+    requests:
+      memory: 200Mi
   buckets:
     - name: dummy-bucket
       purge: true

--- a/charts/fake-aws-s3/values.yaml
+++ b/charts/fake-aws-s3/values.yaml
@@ -1,6 +1,12 @@
 # See defaults in https://github.com/helm/charts/tree/master/stable/minio
 minio:
+  mcImage:
+    repository: quay.io/minio/mc
+    tag: RELEASE.2021-10-07T04-19-58Z
+    pullPolicy: IfNotPresent
   fullnameOverride: fake-aws-s3
+  service:
+    port: "9000"
   mode: standalone
   users:
     - accessKey: dummykey

--- a/charts/fake-aws/templates/NOTES.txt
+++ b/charts/fake-aws/templates/NOTES.txt
@@ -20,7 +20,7 @@ SQS      : http://fake-aws-sqs:{{ index .Values "fake-aws-sqs" "service" "httpPo
 {{- end }}
 {{- if index .Values "fake-aws-s3" "enabled" }}
 S3       : http://fake-aws-s3:9000
-  bucket: {{ index .Values "fake-aws-s3" "minio" "defaultBucket" "name" }}
+  bucket: {{ index .Values "fake-aws-s3" "minio" "buckets" 0 "name" }}
 {{- end }}
 {{- if index .Values "fake-aws-ses" "enabled" }}
 SES      : http://fake-aws-ses:{{ index .Values "fake-aws-ses" "service" "externalPort" }}


### PR DESCRIPTION
The repository at helm.min.io is down. But the one at charts.min.io is up. Unfortunately, the one at charts.min.io provides a slightly different helm chart. So, some options need to be adjusted accordingly.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.