### PR TITLE
elasticsearch-ephemeral: Disable automatic creation of indices

### DIFF
--- a/changelog.d/3-bug-fixes/elasticsearch-ephemeral-disable-auto-creation
+++ b/changelog.d/3-bug-fixes/elasticsearch-ephemeral-disable-auto-creation
@@ -1,0 +1,1 @@
+elasticsearch-ephemeral: Disable automatic creation of indices

--- a/charts/elasticsearch-ephemeral/templates/es.yaml
+++ b/charts/elasticsearch-ephemeral/templates/es.yaml
@@ -31,6 +31,8 @@ spec:
           value: "false"
         - name: "discovery.type"
           value: "single-node"
+        - name: "action.auto_create_index"
+          value: ".watches,.triggered_watches,.watcher-history-*"
         ports:
         - containerPort: 9200
           name: http


### PR DESCRIPTION
This PR disables the automatic creation of indices in the `elasticsearch-ephemeral` chart.

Without this PR ES will create an index whenever a document is attempted to be indexed. This leads to a race-condition right after the `elasticsearch-ephemeral` release is deployed and all indices have been removed:

A) `brig` or `brig-index-migrate-data` indexes a user into a newly auto-created index `directory`
B) The `elasticsearch-index-create` job creates  a index `directory` if it doesn't exist yet

If A) happens before B) the `directory` index is useless to brig. Brig will not be able to find any users, because it assumes that fields like `team` are of type `keyword`. The auto-created index however gives all fields the type `text`.
If B) happens before A) all is good.

This PR assures that A) cannot happen before B), because auto-creation is disabled.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
