### PR TITLE
Add new LogFormat: StructuredJSON

### DIFF
--- a/changelog.d/2-features/structured-json-logs
+++ b/changelog.d/2-features/structured-json-logs
@@ -1,0 +1,1 @@
+Add log format called 'StructuredJSON' for easier log aggregation

--- a/libs/extended/extended.cabal
+++ b/libs/extended/extended.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 65015665656bc1ae721971ef3e88ed707aa7a2be02ba04cf4aab39ac6188714a
+-- hash: 040115252374cb428a08ab286b9a4eb9492a407e9197009e7944f163dc1bfdcc
 
 name:           extended
 version:        0.1.0
@@ -37,6 +37,7 @@ library
     , base
     , bytestring
     , cassandra-util
+    , containers
     , errors
     , exceptions
     , extra

--- a/libs/extended/package.yaml
+++ b/libs/extended/package.yaml
@@ -14,15 +14,16 @@ maintainer: Wire Swiss GmbH <backend@wire.com>
 copyright: (c) 2018 Wire Swiss GmbH
 license: AGPL-3
 dependencies:
+- aeson
 - base
 - bytestring
+- cassandra-util
+- containers
+- exceptions
 - extra
-- aeson
 - imports
 - optparse-applicative
 - tinylog
-- exceptions
-- cassandra-util
 
 # for servant's 'ReqBodyCustomError' type defined here.
 - errors

--- a/libs/extended/src/System/Logger/Extended.hs
+++ b/libs/extended/src/System/Logger/Extended.hs
@@ -33,10 +33,11 @@ where
 
 import Cassandra (MonadClient)
 import Control.Monad.Catch
-import Data.Aeson
+import Data.Aeson as Aeson
 import Data.Aeson.Encoding (list, pair, text)
 import qualified Data.ByteString.Lazy.Builder as B
 import qualified Data.ByteString.Lazy.Char8 as L
+import qualified Data.Map.Lazy as Map
 import Data.String.Conversions (cs)
 import GHC.Generics
 import Imports
@@ -50,7 +51,7 @@ instance FromJSON LC.Level
 instance ToJSON LC.Level
 
 -- | The log formats supported
-data LogFormat = JSON | Plain | Netstring
+data LogFormat = JSON | Plain | Netstring | StructuredJSON
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
@@ -76,6 +77,43 @@ collect = foldr go (Element' mempty [])
 
 jsonRenderer :: Renderer
 jsonRenderer _sep _dateFormat _logLevel = fromEncoding . elementToEncoding . collect
+
+data StructuredJSONOutput = StructuredJSONOutput {msgs :: [Text], fields :: Map Text [Text]}
+
+-- | Displays all the 'Bytes' segments in a list under key @msgs@ and 'Field'
+-- segments as key-value pair in a JSON
+--
+-- >>> logElems = [Bytes "I", Bytes "The message", Field "field1" "val1", Field "field2" "val2", Field "field1" "val1.1"]
+-- >>> B.toLazyByteString $ structuredJSONRenderer "," iso8601UTC Info logElems
+-- "{\"msgs\":[\"I\",\"The message\"],\"field1\":[\"val1\",\"val1.1\"],\"field2\":\"val2\",\"level\":\"Info\"}"
+structuredJSONRenderer :: Renderer
+structuredJSONRenderer _sep _dateFmt lvl logElems =
+  let structuredJSON = toStructuredJSONOutput logElems
+   in fromEncoding . toEncoding $
+        object
+          ( [ "level" Aeson..= lvl,
+              "msgs" Aeson..= msgs structuredJSON
+            ]
+              <> Map.foldMapWithKey (\k v -> [k Aeson..= renderTextList v]) (fields structuredJSON)
+          )
+  where
+    -- Renders List of Text as a String, if it only contains one element. This
+    -- should be most (if not all) of the cases
+    renderTextList :: [Text] -> Value
+    renderTextList [t] = String t
+    renderTextList xs = toJSON xs
+
+    builderToText :: Builder -> Text
+    builderToText = cs . eval
+
+    toStructuredJSONOutput :: [Element] -> StructuredJSONOutput
+    toStructuredJSONOutput =
+      foldr
+        ( \e o -> case e of
+            Bytes b -> o {msgs = builderToText b : msgs o}
+            Field k v -> o {fields = Map.insertWith (<>) (builderToText k) (map builderToText [v]) (fields o)}
+        )
+        (StructuredJSONOutput mempty mempty)
 
 -- | Here for backwards-compatibility reasons
 netStringsToLogFormat :: Bool -> LogFormat
@@ -124,6 +162,7 @@ simpleSettings lvl logFormat =
       Netstring -> \_separator _dateFormat _level -> Log.renderNetstr
       Plain -> \separator _dateFormat _level -> Log.renderDefault separator
       JSON -> jsonRenderer
+      StructuredJSON -> structuredJSONRenderer
 
 -- | Replace all whitespace characters in the output of a renderer by @' '@.
 -- Log output must be ASCII encoding.


### PR DESCRIPTION
This format is intended as an imporvement over the JSON format. It tries to
improve in these ways:

- Explicitly encode log level as a key in the main JSON object logged

- Encode field values as key-value pairs in the main JSON object

Encoding logs like this makes it easy for external tools like fluent-bit and
elasticsearch to understand the log level and the fields and index them as such
without requiring bonanza to be present while processing logs.

https://wearezeta.atlassian.net/browse/FS-62

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.