### PR TITLE
Upgrade kibana and fluent-bit helm charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ DOCKER_TAG            ?= $(USER)
 # default helm chart version must be 0.0.42 for local development (because 42 is the answer to the universe and everything)
 HELM_SEMVER           ?= 0.0.42
 # The list of helm charts needed for integration tests on kubernetes
-CHARTS_INTEGRATION    := wire-server databases-ephemeral fake-aws nginx-ingress-controller nginx-ingress-services wire-server-metrics
+CHARTS_INTEGRATION    := wire-server databases-ephemeral fake-aws nginx-ingress-controller nginx-ingress-services wire-server-metrics fluent-bit kibana
 # The list of helm charts to publish on S3
 # FUTUREWORK: after we "inline local subcharts",
 # (e.g. move charts/brig to charts/wire-server/brig)
 # this list could be generated from the folder names under ./charts/ like so:
 # CHARTS_RELEASE := $(shell find charts/ -maxdepth 1 -type d | xargs -n 1 basename | grep -v charts)
-CHARTS_RELEASE        := wire-server redis-ephemeral databases-ephemeral fake-aws fake-aws-s3 fake-aws-sqs aws-ingress  fluent-bit kibana backoffice calling-test demo-smtp elasticsearch-curator elasticsearch-external elasticsearch-ephemeral fluent-bit minio-external cassandra-external nginx-ingress-controller nginx-ingress-services reaper wire-server-metrics sftd
+CHARTS_RELEASE        := wire-server redis-ephemeral databases-ephemeral fake-aws fake-aws-s3 fake-aws-sqs aws-ingress  fluent-bit kibana backoffice calling-test demo-smtp elasticsearch-curator elasticsearch-external elasticsearch-ephemeral minio-external cassandra-external nginx-ingress-controller nginx-ingress-services reaper wire-server-metrics sftd
 BUILDAH_PUSH          ?= 0
 KIND_CLUSTER_NAME     := wire-server
 BUILDAH_KIND_LOAD     ?= 1

--- a/changelog.d/2-features/elasticsearch
+++ b/changelog.d/2-features/elasticsearch
@@ -1,0 +1,1 @@
+By default install elasticsearch version 6.8.18 when using the elasticsearch-ephemeral chart

--- a/changelog.d/2-features/fluent-bit
+++ b/changelog.d/2-features/fluent-bit
@@ -1,0 +1,1 @@
+Use fluent-bit chart from fluent.github.io instead of deprecated charts.helm.sh. Previous fluent-bit values are not compatible with the new chart, the documentation for the new chart can be found [here](https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit)

--- a/changelog.d/2-features/kibana
+++ b/changelog.d/2-features/kibana
@@ -1,0 +1,1 @@
+Use kibana chart from helm.elastic.co instead of deprecated charts.helm.sh. Previous kibana values are not compatible with the new chart, the documentation for the new chart can be found [here](https://github.com/elastic/helm-charts/tree/main/kibana). This also upgrades kibana to version 6.8.18.

--- a/charts/elasticsearch-ephemeral/values.yaml
+++ b/charts/elasticsearch-ephemeral/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: elasticsearch
-  tag: 6.7.1
+  tag: 6.8.18
 
 service:
   httpPort: 9200

--- a/charts/fluent-bit/requirements.yaml
+++ b/charts/fluent-bit/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: fluent-bit
-  version: 2.7.0
-  repository: https://charts.helm.sh/stable
+  version: 0.19.6
+  repository: https://fluent.github.io/helm-charts

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -1,11 +1,39 @@
-# See defaults in https://github.com/helm/charts/tree/master/stable/fluent-bit
+# See defaults in https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit
 fluent-bit:
-  backend:
-    type: es
-    es:
-      host: elasticsearch-ephemeral
-  parsers:
-    enabled: true
-    regex:
-      - name: nginz
-        regex: '^(?<remote_addr>[^ ]*) (?<remote_user>[^ ]*) "(?<thetime>[0-9\/a-zA-Z:]* [+][0-9]*)" "(?<path>.*)" (?<status>[0-9]*) (?<body_bytes_sent>[0-9]*) "(?<http_referer>[^ ])" "(?<http_user_agent>.*)" (?<http_x_forwarded_for>[^ ]*) (?<connection>[^ ]*) (?<request_time>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_cache_status>[^ ]*) (?<zauth_user>[^ ]*) (?<zauth_connection>[^ ]*) (?<request>[a-z0-9]*)'
+  config:
+    outputs: |
+      [OUTPUT]
+          Name es
+          Match kube.*
+          Host elasticsearch-ephemeral
+          Generate_ID On
+          Logstash_Format On
+          Logstash_Prefix pod
+          Retry_Limit False
+          Trace_Error On
+          Replace_Dots On
+      [OUTPUT]
+          Name es
+          Match host.*
+          Host elasticsearch-ephemeral
+          Generate_ID On
+          Logstash_Format On
+          Logstash_Prefix node
+          Retry_Limit False
+          Trace_Error On
+          Replace_Dots On
+    ## https://docs.fluentbit.io/manual/pipeline/parsers
+    customParsers: |
+      [PARSER]
+          Name docker_no_time
+          Format json
+          Time_Keep Off
+          Time_Key time
+          Time_Format %Y-%m-%dT%H:%M:%S.%L
+
+      [PARSER]
+          Name nginz
+          Format regex
+          Regex ^(?<remote_addr>[^ ]*) (?<remote_user>[^ ]*) "(?<thetime>[0-9\/a-zA-Z:]* [+][0-9]*)" "(?<method>[^ ]*) (?<path>.*) (?<http_version>.*)" (?<status>[0-9]*) (?<body_bytes_sent>[0-9]*) "(?<http_referer>[^ ])" "(?<http_user_agent>.*)" (?<http_x_forwarded_for>[^ ]*) (?<connection>[^ ]*) (?<request_time>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_cache_status>[^ ]*) (?<zauth_user>[^ ]*) (?<zauth_connection>[^ ]*) (?<request>[a-z0-9]*)
+          Time_Key thetime
+          Time_Format %d/%b/%Y:%H:%M:%S %z

--- a/charts/kibana/requirements.yaml
+++ b/charts/kibana/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: kibana
-  version: 2.2.0
-  repository: https://charts.helm.sh/stable
+  version: 6.8.18
+  repository: https://helm.elastic.co

--- a/charts/kibana/templates/basic-auth-secret.yaml
+++ b/charts/kibana/templates/basic-auth-secret.yaml
@@ -1,0 +1,13 @@
+{{- if (hasKey .Values "basicAuthSecret") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kibana-basic-auth
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  auth: {{ .Values.basicAuthSecret | b64enc | quote }}
+{{- end }}

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -1,11 +1,22 @@
-# See defaults in https://github.com/helm/charts/tree/master/stable/kibana
+## When this is configured, a secret called kibana-basic-auth is created with key
+## `auth` and value of this key.
+# basicAuthSecret: <secret>
+
+# See defaults in https://github.com/elastic/helm-charts/tree/main/kibana
 kibana:
-  env:
-    # All Kibana configuration options are adjustable via env vars.
-    # To adjust a config option to an env var uppercase + replace `.` with `_`
-    # Ref: https://www.elastic.co/guide/en/kibana/current/settings.html
-    #
-    ELASTICSEARCH_URL: http://elasticsearch-ephemeral:9200
-  files:
-    kibana.yml:
-      elasticsearch.url: http://elasticsearch-ephemeral:9200
+  elasticsearchHosts: "http://elasticsearch-ephemeral:9200"
+
+  lifecycle:
+    postStart:
+      exec:
+        command:
+          - bash
+          - -c
+          - |
+            #!/bin/bash
+            KB_URL=http://localhost:5601
+            # Wait for kibana to be ready
+            while [[ "$(curl -s -o /dev/null -w '%{http_code}\n' -L $KB_URL)" != "200" ]]; do sleep 1; done
+            # Import index patterns for pods logs and node logs, for kibana <7,
+            # we have to use the dashboard import API.
+            curl -XPOST "$KB_URL/api/kibana/dashboards/import" -H "Content-Type: application/json" -H 'kbn-xsrf: true' -d'{"objects":[{"type": "index-pattern", "id": "7e7061cc-7d7e-4287-b631-a7c5257f73e5", "attributes": {"title": "pod-*", "timeFieldName": "@timestamp"}},{"type": "index-pattern", "id": "b1a2866f-70ec-40fb-bfea-d78e9662b741", "attributes": {"title": "node-*", "timeFieldName": "@timestamp"}}]}'


### PR DESCRIPTION
This change removes dependency on the deprecated https://charts.helm.sh repository for kibana and fluent-bit. As a result we get v6.8.18 of kibana. Kibana 6.8.x requires elasticsearch 6.8.x, so this change also upgrades the default version of elasticsearch to 6.8.18 when installing with the elasticsearch-ephemeral chart.  

https://wearezeta.atlassian.net/browse/FS-62

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.