### PR TITLE
Correctly detect log level when rendering logs as structured JSON

### DIFF
--- a/changelog.d/3-bug-fixes/structured-json
+++ b/changelog.d/3-bug-fixes/structured-json
@@ -1,0 +1,1 @@
+Correctly detect log level when rendering logs as structured JSON

--- a/libs/extended/extended.cabal
+++ b/libs/extended/extended.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 040115252374cb428a08ab286b9a4eb9492a407e9197009e7944f163dc1bfdcc
+-- hash: 3aab57e8600541201e0b0f8cd7308f624eb479a4f5601e800399b4787656c449
 
 name:           extended
 version:        0.1.0
@@ -49,6 +49,42 @@ library
     , servant-server
     , servant-swagger
     , string-conversions
+    , tinylog
+    , wai
+  default-language: Haskell2010
+
+test-suite extended-tests
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Test.System.Logger.ExtendedSpec
+      Paths_extended
+  hs-source-dirs:
+      test
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DerivingVia DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
+  ghc-options: -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path -threaded -with-rtsopts=-N
+  build-tool-depends:
+      hspec-discover:hspec-discover
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , cassandra-util
+    , containers
+    , errors
+    , exceptions
+    , extended
+    , extra
+    , hspec
+    , http-types
+    , imports
+    , metrics-wai
+    , optparse-applicative
+    , servant
+    , servant-server
+    , servant-swagger
+    , string-conversions
+    , temporary
     , tinylog
     , wai
   default-language: Haskell2010

--- a/libs/extended/package.yaml
+++ b/libs/extended/package.yaml
@@ -36,4 +36,17 @@ dependencies:
 - wai
 library:
   source-dirs: src
+tests:
+  extended-tests:
+    main: Spec.hs
+    source-dirs: test
+    ghc-options:
+    - -threaded
+    - -with-rtsopts=-N
+    dependencies:
+    - hspec
+    - extended
+    - temporary
+    build-tools:
+    - hspec-discover:hspec-discover
 stability: experimental

--- a/libs/extended/test/Spec.hs
+++ b/libs/extended/test/Spec.hs
@@ -1,0 +1,18 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.

--- a/libs/extended/test/Test/System/Logger/ExtendedSpec.hs
+++ b/libs/extended/test/Test/System/Logger/ExtendedSpec.hs
@@ -1,0 +1,49 @@
+module Test.System.Logger.ExtendedSpec where
+
+import Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import Data.String.Conversions (cs)
+import Imports
+import System.IO.Temp
+import System.Logger.Extended hiding ((.=))
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec =
+  describe "System.Loggger.Extended" $ do
+    describe "LogFormat: StructuredJSON" $ do
+      it "should encode logs as new line separated structured JSON with log level, messages and fields" $ do
+        withSystemTempFile "structured-json" $ \f h -> do
+          hClose h -- The handle is not required
+          l <-
+            new
+              . setRenderer structuredJSONRenderer
+              . setOutput (Path f)
+              . setFormat Nothing -- date format, not having it makes it easier to test.
+              $ defSettings
+
+          warn l $
+            msg ("first message" :: ByteString)
+              . field "field1" ("val 1.1" :: ByteString)
+              . field "field2" ("val 2" :: ByteString)
+              . field "field1" ("val 1.2" :: ByteString)
+              . msg ("second message" :: ByteString)
+          info l $ msg ("just a message" :: ByteString)
+
+          flush l
+          close l
+          actualLogs <- map (Aeson.eitherDecode @Aeson.Value . cs) . lines <$> readFile f
+
+          let expectedLogs =
+                [ Aeson.object
+                    [ "level" .= Warn,
+                      "msgs" .= ["first message" :: Text, "second message"],
+                      "field1" .= ["val 1.1" :: Text, "val 1.2"],
+                      "field2" .= ("val 2" :: Text)
+                    ],
+                  Aeson.object
+                    [ "level" .= Info,
+                      "msgs" .= ["just a message" :: Text]
+                    ]
+                ]
+          actualLogs `shouldBe` (Right <$> expectedLogs)


### PR DESCRIPTION
Fix for https://github.com/wireapp/wire-server/pull/1951#issuecomment-984479669

https://wearezeta.atlassian.net/browse/FS-62

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.