### PR TITLE
galley: Set request id correctly in Wai app

### DIFF
--- a/changelog.d/5-internal/galley-request-id
+++ b/changelog.d/5-internal/galley-request-id
@@ -1,0 +1,1 @@
+Set request ID correctly in galley logs

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -37,7 +37,6 @@ module Galley.App
 
     -- * Running Galley effects
     GalleyEffects,
-    runGalley,
     evalGalley,
     ask,
     DeleteItem (..),
@@ -95,7 +94,6 @@ import Network.HTTP.Client.OpenSSL
 import Network.HTTP.Media.RenderHeader (RenderHeader (..))
 import Network.HTTP.Types (hContentType)
 import Network.HTTP.Types.Status (statusCode, statusMessage)
-import Network.Wai
 import qualified Network.Wai.Utilities as Wai
 import qualified Network.Wai.Utilities.Server as Server
 import OpenSSL.Session as Ssl
@@ -188,11 +186,6 @@ initHttpManager o = do
         managerIdleConnectionCount = 3 * (o ^. optSettings . setHttpPoolSize)
       }
 
-runGalley :: Env -> Request -> Sem GalleyEffects a -> IO a
-runGalley e r m =
-  let e' = reqId .~ lookupReqId r $ e
-   in evalGalley e' m
-
 interpretTinyLog ::
   Members '[Embed IO] r =>
   Env ->
@@ -200,9 +193,6 @@ interpretTinyLog ::
   Sem r a
 interpretTinyLog e = interpret $ \case
   P.Polylog l m -> Logger.log (e ^. applog) l (reqIdMsg (e ^. reqId) . m)
-
-lookupReqId :: Request -> RequestId
-lookupReqId = maybe def RequestId . lookup requestIdName . requestHeaders
 
 toServantHandler :: Env -> Sem GalleyEffects a -> Servant.Handler a
 toServantHandler env galley = do


### PR DESCRIPTION
This PR makes sure that the request ID is passed correctly to the logger on all endpoints in galley. Before the fix, only wai-route endpoints were running in an environment with the correct request ID.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
