### PR TITLE
sftd chart: add config key additionalArgs

### DIFF
--- a/changelog.d/5-internal/sftd-additional-args
+++ b/changelog.d/5-internal/sftd-additional-args
@@ -1,0 +1,1 @@
+sftd chart: add config key `additionalArgs`

--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -87,6 +87,7 @@ spec:
                       -I "${POD_IP}" \
                       -M "${POD_IP}" \
                       ${ACCESS_ARGS} \
+                      {{ .Values.additionalArgs }} \
                       {{ if .Values.turnDiscoveryEnabled }}-T{{ end }} \
                       -u "https://{{ required "must specify host" .Values.host }}/sfts/${POD_NAME}"
           ports:

--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -85,3 +85,6 @@ joinCall:
 # trying to establish a connection to clients
 # DOCS: https://docs.wire.com/understand/sft.html#prerequisites
 turnDiscoveryEnabled: false
+
+# Additional arguments to be passed to `sftd`
+additionalArgs: ""

--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -87,4 +87,5 @@ joinCall:
 turnDiscoveryEnabled: false
 
 # Additional arguments to be passed to `sftd`
+# Note: this might be removed in the future.
 additionalArgs: ""


### PR DESCRIPTION
This PR adds `additionalArgs` config key to the SFTD chart. It's intended for testing purposes.
Context: https://wearezeta.atlassian.net/browse/FS-265

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.