### PR TITLE
Fix brig doc module generation

### DIFF
--- a/changelog.d/4-docs/update-fed-error-docs
+++ b/changelog.d/4-docs/update-fed-error-docs
@@ -1,1 +1,1 @@
-Update federation error documentation after changes to the federation API (#1956, #1978)
+Update federation error documentation after changes to the federation API (#1956, #1975, #1978)

--- a/services/brig/Setup.hs
+++ b/services/brig/Setup.hs
@@ -22,6 +22,7 @@ import Data.Maybe
 import Distribution.Simple
 import Distribution.Simple.BuildPaths
 import Distribution.Simple.LocalBuildInfo
+import Distribution.Types.PackageDescription
 import System.Directory
 import System.FilePath
 
@@ -30,11 +31,17 @@ main =
   defaultMainWithHooks
     simpleUserHooks
       { buildHook = \desc info hooks flags -> do
-          withLibLBI desc info $ \_ lib -> do
-            let base = autogenComponentModulesDir info lib </> "Brig" </> "Docs"
-            generateDocs base "swagger.md"
-          buildHook simpleUserHooks desc info hooks flags
+          generate desc info
+          buildHook simpleUserHooks desc info hooks flags,
+        replHook = \desc info hooks flags args -> do
+          generate desc info
+          replHook simpleUserHooks desc info hooks flags args
       }
+
+generate :: PackageDescription -> LocalBuildInfo -> IO ()
+generate desc info = withLibLBI desc info $ \_ lib -> do
+  let base = autogenComponentModulesDir info lib </> "Brig" </> "Docs"
+  generateDocs base "swagger.md"
 
 generateDocs :: FilePath -> FilePath -> IO ()
 generateDocs base src = do

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -1,13 +1,13 @@
-cabal-version: 1.24
+cabal-version: 2.0
 
 -- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c37f84d005641650921717e1f340e18d82edd30045196f89649cefd53e549dfb
+-- hash: 513c0f5104342fb14b0246f7c44733a84ec36fae97633fc55cb209e0e0bcd087
 
 name:           brig
-version:        1.35.0
+version:        2.0
 synopsis:       User Service
 category:       Network
 author:         Wire Swiss GmbH
@@ -16,6 +16,8 @@ copyright:      (c) 2017 Wire Swiss GmbH
 license:        AGPL-3
 license-file:   LICENSE
 build-type:     Custom
+extra-source-files:
+    docs/swagger.md
 
 custom-setup
   setup-depends:
@@ -119,6 +121,8 @@ library
       Main
   other-modules:
       Paths_brig
+      Brig.Docs.Swagger
+  autogen-modules:
       Brig.Docs.Swagger
   hs-source-dirs:
       src

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -1,7 +1,7 @@
 defaults:
   local: ../../package-defaults.yaml
 name: brig
-version: '1.35.0'
+version: '2.0'
 synopsis: User Service
 category: Network
 author: Wire Swiss GmbH
@@ -17,10 +17,11 @@ custom-setup:
     - containers
     - directory
     - filepath
+extra-source-files:
+  - docs/*
 library:
   source-dirs: src
-  other-modules:
-    - Paths_brig
+  generated-other-modules:
     - Brig.Docs.Swagger
   dependencies:
   - aeson >=0.11


### PR DESCRIPTION
Follow-up to #1956, fixing issues reported by @fisx:

 - remove obsolete data-files stanza from brig's cabal file;
 - generate doc modules on repl invocation, as well as on build.

No CHANGELOG entry.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
