### PR TITLE
SQSERVICES-547 Enforce disabling guest links when conversation is joined

### DIFF
--- a/changelog.d/2-features/pr-1976
+++ b/changelog.d/2-features/pr-1976
@@ -1,0 +1,1 @@
+If the guest links team feature is disabled guest links will be revoked.

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -261,6 +261,8 @@ type HandleNotFound = ErrorDescription 404 "not-found" "Handle not found"
 
 type TooManyClients = ErrorDescription 403 "too-many-clients" "Too many clients"
 
+type GuestLinksDisabled = ErrorDescription 409 "guest-links-disabled" "The guest link feature is disabled and all guest links have been revoked."
+
 type MissingAuth =
   ErrorDescription
     403

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -195,6 +195,7 @@ data Api routes = Api
         :> CanThrow CodeNotFound
         :> CanThrow ConvNotFound
         :> CanThrow ConvAccessDenied
+        :> CanThrow GuestLinksDisabled
         :> ZLocalUser
         :> "conversations"
         :> "join"

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -122,6 +122,7 @@ data ConversationError
   | ConvMemberNotFound
   | NoBindingTeamMembers
   | NoManagedTeamConv
+  | GuestLinksDisabled
 
 instance APIError ConversationError where
   toWai ConvAccessDenied = errorDescriptionTypeToWai @ConvAccessDenied
@@ -130,6 +131,7 @@ instance APIError ConversationError where
   toWai ConvMemberNotFound = errorDescriptionTypeToWai @ConvMemberNotFound
   toWai NoBindingTeamMembers = noBindingTeamMembers
   toWai NoManagedTeamConv = noManagedTeamConv
+  toWai GuestLinksDisabled = guestLinksDisabled
 
 data TeamError
   = NoBindingTeam
@@ -395,6 +397,9 @@ teamMemberNotFound = mkError status404 "no-team-member" "team member not found"
 
 noManagedTeamConv :: Error
 noManagedTeamConv = mkError status400 "no-managed-team-conv" "Managed team conversations have been deprecated."
+
+guestLinksDisabled :: Error
+guestLinksDisabled = mkError status409 "guest-links-disabled" "The guest link feature is disabled and all guest links have been revoked."
 
 userBindingExists :: Error
 userBindingExists = mkError status403 "binding-exists" "User already bound to a different team."

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -45,6 +45,7 @@ import Data.Proxy
 import Data.Qualified
 import Data.Range
 import qualified Data.Set as Set
+import Debug.Trace
 import Galley.API.Error
 import qualified Galley.API.Mapping as Mapping
 import Galley.API.Util
@@ -531,5 +532,5 @@ getConversationByReusableCode lusr key value = do
     getFeatureStatus :: Data.Conversation -> Sem r TeamFeatureStatusValue
     getFeatureStatus conv = do
       defaultStatus <- getDefaultFeatureStatus
-      maybeFeatureStatus <- join <$> TeamFeatures.getFeatureStatusNoConfig @'TeamFeatureGuestLinks `traverse` Data.convTeam conv
+      maybeFeatureStatus <- join <$> TeamFeatures.getFeatureStatusNoConfig @'TeamFeatureGuestLinks `traverse` (traceShowId $ Data.convTeam conv)
       pure $ maybe defaultStatus tfwoStatus maybeFeatureStatus

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -45,7 +45,6 @@ import Data.Proxy
 import Data.Qualified
 import Data.Range
 import qualified Data.Set as Set
-import Debug.Trace
 import Galley.API.Error
 import qualified Galley.API.Mapping as Mapping
 import Galley.API.Util
@@ -532,5 +531,5 @@ getConversationByReusableCode lusr key value = do
     getFeatureStatus :: Data.Conversation -> Sem r TeamFeatureStatusValue
     getFeatureStatus conv = do
       defaultStatus <- getDefaultFeatureStatus
-      maybeFeatureStatus <- join <$> TeamFeatures.getFeatureStatusNoConfig @'TeamFeatureGuestLinks `traverse` (traceShowId $ Data.convTeam conv)
+      maybeFeatureStatus <- join <$> TeamFeatures.getFeatureStatusNoConfig @'TeamFeatureGuestLinks `traverse` (Data.convTeam conv)
       pure $ maybe defaultStatus tfwoStatus maybeFeatureStatus

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -531,5 +531,5 @@ getConversationByReusableCode lusr key value = do
     getFeatureStatus :: Data.Conversation -> Sem r TeamFeatureStatusValue
     getFeatureStatus conv = do
       defaultStatus <- getDefaultFeatureStatus
-      maybeFeatureStatus <- join <$> TeamFeatures.getFeatureStatusNoConfig @'TeamFeatureGuestLinks `traverse` (Data.convTeam conv)
+      maybeFeatureStatus <- join <$> TeamFeatures.getFeatureStatusNoConfig @'TeamFeatureGuestLinks `traverse` Data.convTeam conv
       pure $ maybe defaultStatus tfwoStatus maybeFeatureStatus

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -525,9 +525,8 @@ getConversationByReusableCode lusr key value = do
         }
 
     getDefaultFeatureStatus :: Sem r TeamFeatureStatusValue
-    getDefaultFeatureStatus = do
-      status <- input <&> view (optSettings . setFeatureFlags . flagConversationGuestLinks . unDefaults)
-      pure $ tfwoapsStatus status
+    getDefaultFeatureStatus =
+      input <&> view (optSettings . setFeatureFlags . flagConversationGuestLinks . unDefaults . to tfwoapsStatus)
 
     getFeatureStatus :: Data.Conversation -> Sem r TeamFeatureStatusValue
     getFeatureStatus conv = do

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -34,6 +34,7 @@ module Galley.API.Query
 where
 
 import qualified Cassandra as C
+import Control.Lens
 import qualified Data.ByteString.Lazy as LBS
 import Data.Code
 import Data.CommaSeparatedList
@@ -54,9 +55,12 @@ import qualified Galley.Effects.ConversationStore as E
 import qualified Galley.Effects.FederatorAccess as E
 import qualified Galley.Effects.ListItems as E
 import qualified Galley.Effects.MemberStore as E
+import qualified Galley.Effects.TeamFeatureStore as TeamFeatures
+import Galley.Options
 import Galley.Types
 import Galley.Types.Conversations.Members
 import Galley.Types.Conversations.Roles
+import Galley.Types.Teams
 import Imports
 import Network.HTTP.Types
 import Network.Wai
@@ -77,6 +81,7 @@ import qualified Wire.API.Federation.API.Galley as F
 import Wire.API.Federation.Error
 import qualified Wire.API.Provider.Bot as Public
 import qualified Wire.API.Routes.MultiTablePaging as Public
+import Wire.API.Team.Feature as Public
 
 getBotConversationH ::
   Members '[ConversationStore, Error ConversationError, Input (Local ())] r =>
@@ -490,16 +495,17 @@ getConversationMeta cnv = do
       pure Nothing
 
 getConversationByReusableCode ::
-  Members
-    '[ BrigAccess,
-       CodeStore,
-       ConversationStore,
-       Error CodeError,
-       Error ConversationError,
-       Error NotATeamMember,
-       TeamStore
-     ]
-    r =>
+  forall r.
+  ( Member BrigAccess r,
+    Member CodeStore r,
+    Member ConversationStore r,
+    Member (Error CodeError) r,
+    Member (Error ConversationError) r,
+    Member (Error NotATeamMember) r,
+    Member TeamStore r,
+    Member TeamFeatureStore r,
+    Member (Input Opts) r
+  ) =>
   Local UserId ->
   Key ->
   Value ->
@@ -507,7 +513,9 @@ getConversationByReusableCode ::
 getConversationByReusableCode lusr key value = do
   c <- verifyReusableCode (ConversationCode key value Nothing)
   conv <- ensureConversationAccess (tUnqualified lusr) (Data.codeConversation c) CodeAccess
-  pure $ coverView conv
+  getFeatureStatus conv >>= \case
+    TeamFeatureEnabled -> pure $ coverView conv
+    TeamFeatureDisabled -> throw GuestLinksDisabled
   where
     coverView :: Data.Conversation -> ConversationCoverView
     coverView conv =
@@ -515,3 +523,14 @@ getConversationByReusableCode lusr key value = do
         { cnvCoverConvId = Data.convId conv,
           cnvCoverName = Data.convName conv
         }
+
+    getDefaultFeatureStatus :: Sem r TeamFeatureStatusValue
+    getDefaultFeatureStatus = do
+      status <- input <&> view (optSettings . setFeatureFlags . flagConversationGuestLinks . unDefaults)
+      pure $ tfwoapsStatus status
+
+    getFeatureStatus :: Data.Conversation -> Sem r TeamFeatureStatusValue
+    getFeatureStatus conv = do
+      defaultStatus <- getDefaultFeatureStatus
+      maybeFeatureStatus <- join <$> TeamFeatures.getFeatureStatusNoConfig @'TeamFeatureGuestLinks `traverse` Data.convTeam conv
+      pure $ maybe defaultStatus tfwoStatus maybeFeatureStatus

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -17,6 +17,7 @@
 
 module Galley.API.Teams.Features
   ( getFeatureStatus,
+    getFeatureStatusNoConfig,
     setFeatureStatus,
     getFeatureConfig,
     getAllFeatureConfigs,

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1246,7 +1246,7 @@ testJoinConvGuestLinksDisabled = do
   let convName = "testConversation"
   (owner, teamId, []) <- Util.createBindingTeamWithNMembers 0
   userNotInTeam <- randomUser
-  convId <- decodeConvId <$> postConv owner [] (Just convName) [CodeAccess] (Just ActivatedAccessRole) Nothing
+  convId <- decodeConvId <$> postTeamConv teamId owner [] (Just convName) [CodeAccess] (Just ActivatedAccessRole) Nothing
   cCode <- decodeConvCodeEvent <$> postConvCode owner convId
 
   -- works by default
@@ -1259,7 +1259,6 @@ testJoinConvGuestLinksDisabled = do
   TeamFeatures.putTeamFeatureFlagWithGalley @'Public.TeamFeatureGuestLinks galley owner teamId tfStatus !!! do
     const 200 === statusCode
 
-  -- TODO(leif): this assertion fails because the team is not found in the server implementation
   getJoinCodeConv userNotInTeam (conversationKey cCode) (conversationCode cCode) !!! do
     const 409 === statusCode
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1057

This PR handles only `conversations/join`

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - ~~If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.~~
 - ~~If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.~~
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - ~~If new config options introduced: added usage description under docs/reference/config-options.md~~
   - ~~If new config options introduced: recommended measures to be taken by on-premise instance operators.~~
   - ~~If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.~~
   - ~~If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.~~
   - ~~If public end-points have been changed or added: does nginz need un upgrade?~~
   - ~~If internal end-points have been added or changed: which services have to be deployed in a specific order?~~
