### PR TITLE
Fix assertion after #1956

### DIFF
--- a/changelog.d/4-docs/update-fed-error-docs
+++ b/changelog.d/4-docs/update-fed-error-docs
@@ -1,1 +1,1 @@
-Update federation error documentation after changes to the federation API
+Update federation error documentation after changes to the federation API (#1956, #1978)

--- a/services/federator/test/integration/Test/Federator/InwardSpec.hs
+++ b/services/federator/test/integration/Test/Federator/InwardSpec.hs
@@ -75,7 +75,7 @@ spec env =
     it "should be able to call cargohold" $
       runTestFederator env $ do
         inwardCall "/federation/cargohold/get-asset" (encode ())
-          !!! const 403 === statusCode
+          !!! const 500 === statusCode
 
     it "should return 404 'no-endpoint' response from Brig" $
       runTestFederator env $ do


### PR DESCRIPTION
Fix failing test on develop caused by merging #1956 and #1973.

No CHANGELOG entry.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
