### PR TITLE
SQSERVICES-547 post/get conversation/:cnv/code returns error if feature disabled

### DIFF
--- a/changelog.d/2-features/pr-1980
+++ b/changelog.d/2-features/pr-1980
@@ -1,1 +1,1 @@
-If guest links team feature is disabled `post /conversations/:cnv/code` and `get /conversations/:cnv/code` will return an error.
+Revoke guest links if feature is disabled. If the guest links team feature is disabled `get /conversations/join`, `post /conversations/:cnv/code`, and `get /conversations/:cnv/code` will return an error.

--- a/changelog.d/2-features/pr-1980
+++ b/changelog.d/2-features/pr-1980
@@ -1,0 +1,1 @@
+If guest links team feature is disabled `post /conversations/:cnv/code` and `get /conversations/:cnv/code` will return an error.

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -223,6 +223,7 @@ tests s =
           test s "cannot join private conversation" postJoinConvFail,
           test s "revoke guest links for team conversation" testJoinTeamConvGuestLinksDisabled,
           test s "revoke guest links for non-team conversation" testJoinNonTeamConvGuestLinksDisabled,
+          test s "get code rejected if guest links disabled" testGetCodeRejectedIfGuestLinksDisabled,
           test s "remove user with only local convs" removeUserNoFederation,
           test s "remove user with local and remote convs" removeUser,
           test s "iUpsertOne2OneConversation" testAllOne2OneConversationRequests,
@@ -1240,6 +1241,14 @@ testJoinCodeConv = do
   eve <- ephemeralUser
   getJoinCodeConv eve (conversationKey cCode) (conversationCode cCode) !!! do
     const 403 === statusCode
+
+testGetCodeRejectedIfGuestLinksDisabled :: TestM ()
+testGetCodeRejectedIfGuestLinksDisabled = do
+  let convName = "testConversation"
+  (owner, teamId, []) <- Util.createBindingTeamWithNMembers 0
+  convId <- decodeConvId <$> postTeamConv teamId owner [] (Just convName) [CodeAccess] (Just ActivatedAccessRole) Nothing
+  getConvCode owner convId !!! statusCode === const 200
+  error "todo: wip, implement test"
 
 testJoinTeamConvGuestLinksDisabled :: TestM ()
 testJoinTeamConvGuestLinksDisabled = do


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1057

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - ~~If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.~~
 - ~~If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.~~
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - ~~If new config options introduced: added usage description under docs/reference/config-options.md~~
   - ~~If new config options introduced: recommended measures to be taken by on-premise instance operators.~~
   - ~~If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.~~
   - ~~If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.~~
   - ~~If public end-points have been changed or added: does nginz need un upgrade?~~
   - ~~If internal end-points have been added or changed: which services have to be deployed in a specific order?~~
