### PR TITLE
Do not purge bucket in fake-s3

### DIFF
--- a/changelog.d/5-internal/fix-cargohold-flake
+++ b/changelog.d/5-internal/fix-cargohold-flake
@@ -1,0 +1,1 @@
+Set `purge: false` in fake-s3 chart

--- a/charts/fake-aws-s3/values.yaml
+++ b/charts/fake-aws-s3/values.yaml
@@ -21,7 +21,7 @@ minio:
       memory: 200Mi
   buckets:
     - name: dummy-bucket
-      purge: true
+      purge: false
       policy: none
     - name: assets
       purge: false


### PR DESCRIPTION
With `purge: true` the reaper script will delete the bucket's content when it runs, causing integration tests to fail occasionally.

This fixes a very frequent flake in CI integration tests (e.g.  https://bridge-ie-concourse.zinfra.io/builds/21651258).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
