### PR TITLE
Fix `make c test=1`

### DIFF
--- a/changelog.d/5-internal/cabal-make-c-test-all
+++ b/changelog.d/5-internal/cabal-make-c-test-all
@@ -1,0 +1,1 @@
+Fix test runner for global cabal make target

--- a/hack/bin/cabal-run-tests.sh
+++ b/hack/bin/cabal-run-tests.sh
@@ -4,15 +4,19 @@ set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
-pkgName=${1:-Please specify package name}
+package=${1:-all}
 
-# This is required because some tests (e.g. golden tests) depend on the path
-# where they are run from.
-pkgDir=$(find "$TOP_LEVEL" -name "$pkgName.cabal" | grep -v dist-newstyle | head -1 | xargs -n 1 dirname)
-cd "$pkgDir"
-
-test_suites=$(cabal-plan list-bins "$pkgName"':test:*' | awk '{print $2}')
-
-for test_suite in $test_suites; do
+if [[ "$package" == all ]]; then
+  pattern='*.cabal'
+else
+  pattern="$package.cabal"
+fi
+for cabal in $(find "$TOP_LEVEL" -name "$pattern" | grep -v dist-newstyle); do
+  # This is required because some tests (e.g. golden tests) must be run from
+  # the package root.
+  cd "$(dirname $cabal)"
+  package="$(basename ${cabal%.*})"
+  for test_suite in $(cabal-plan list-bins "$package:test:*" | awk '{print $2}'); do
     $test_suite "${@:2}"
+  done
 done


### PR DESCRIPTION
This fixes the cabal test running script when `package=all`.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
