### PR TITLE
schema-profunctor: better optional field API

### DIFF
--- a/changelog.d/5-internal/schema-profunctor-optional
+++ b/changelog.d/5-internal/schema-profunctor-optional
@@ -1,0 +1,1 @@
+Improve optional field API in schema-profunctor

--- a/libs/galley-types/src/Galley/Types/Conversations/Intra.hs
+++ b/libs/galley-types/src/Galley/Types/Conversations/Intra.hs
@@ -72,7 +72,7 @@ instance ToSchema UpsertOne2OneConversationRequest where
         <*> (qUntagged . uooRemoteUser) .= field "remote_user" (qTagUnsafe <$> schema)
         <*> uooActor .= field "actor" schema
         <*> uooActorDesiredMembership .= field "actor_desired_membership" schema
-        <*> uooConvId .= field "conversation_id" (optWithDefault A.Null schema)
+        <*> uooConvId .= optField "conversation_id" (maybeWithDefault A.Null schema)
 
 newtype UpsertOne2OneConversationResponse = UpsertOne2OneConversationResponse
   { uuorConvId :: Qualified ConvId

--- a/libs/schema-profunctor/src/Data/Schema.hs
+++ b/libs/schema-profunctor/src/Data/Schema.hs
@@ -26,7 +26,9 @@
 module Data.Schema
   ( SchemaP,
     ValueSchema,
+    ValueSchemaP,
     ObjectSchema,
+    ObjectSchemaP,
     ToSchema (..),
     Schema (..),
     mkSchema,
@@ -34,6 +36,7 @@ module Data.Schema
     schemaIn,
     schemaOut,
     HasDoc (..),
+    HasSchemaRef (..),
     withParser,
     SwaggerDoc,
     swaggerDoc,
@@ -44,20 +47,22 @@ module Data.Schema
     objectWithDocModifier,
     objectOver,
     jsonObject,
+    FieldFunctor,
     field,
     fieldWithDocModifier,
     fieldOver,
     optField,
     optFieldWithDocModifier,
-    optFieldOver,
+    fieldF,
+    fieldOverF,
+    fieldWithDocModifierF,
     array,
     set,
     nonEmptyArray,
     map_,
     enum,
-    opt,
-    optWithDefault,
-    lax,
+    maybe_,
+    maybeWithDefault,
     bind,
     dispatch,
     text,
@@ -247,11 +252,13 @@ withParser :: SchemaP doc v w a b -> (b -> A.Parser b') -> SchemaP doc v w a b'
 withParser (SchemaP (SchemaDoc d) (SchemaIn p) (SchemaOut o)) q =
   SchemaP (SchemaDoc d) (SchemaIn (p >=> q)) (SchemaOut o)
 
-type SchemaP' doc v v' a = SchemaP doc v v' a a
+type ObjectSchemaP doc = SchemaP doc A.Object [A.Pair]
 
-type ObjectSchema doc a = SchemaP' doc A.Object [A.Pair] a
+type ObjectSchema doc a = ObjectSchemaP doc a a
 
-type ValueSchema doc a = SchemaP' doc A.Value A.Value a
+type ValueSchemaP doc = SchemaP doc A.Value A.Value
+
+type ValueSchema doc a = ValueSchemaP doc a a
 
 schemaDoc :: SchemaP ss v m a b -> ss
 schemaDoc (SchemaP (SchemaDoc d) _ _) = d
@@ -261,6 +268,18 @@ schemaIn (SchemaP _ (SchemaIn i) _) = i
 
 schemaOut :: SchemaP ss v m a b -> a -> Maybe m
 schemaOut (SchemaP _ _ (SchemaOut o)) = o
+
+class Functor f => FieldFunctor doc f where
+  parseFieldF :: (A.Value -> A.Parser a) -> A.Object -> Text -> A.Parser (f a)
+  mkDocF :: doc -> doc
+
+instance FieldFunctor doc Identity where
+  parseFieldF f obj key = Identity <$> A.explicitParseField f obj key
+  mkDocF = id
+
+instance HasOpt doc => FieldFunctor doc Maybe where
+  parseFieldF = A.explicitParseFieldMaybe
+  mkDocF = mkOpt
 
 -- | A schema for a one-field JSON object.
 field ::
@@ -274,13 +293,19 @@ field = fieldOver id
 optField ::
   (HasOpt doc, HasField doc' doc) =>
   Text ->
-  -- | The value to use when serialising Nothing.
-  Maybe A.Value ->
   SchemaP doc' A.Value A.Value a b ->
-  SchemaP doc A.Object [A.Pair] (Maybe a) (Maybe b)
-optField = optFieldOver id
+  SchemaP doc A.Object [A.Pair] a (Maybe b)
+optField = fieldF
 
-newtype Negative x y a = Negative {runNegative :: (a -> x) -> y}
+-- | A schema for a JSON object with a single optional field.
+fieldF ::
+  (HasOpt doc, HasField doc' doc, FieldFunctor doc f) =>
+  Text ->
+  SchemaP doc' A.Value A.Value a b ->
+  SchemaP doc A.Object [A.Pair] a (f b)
+fieldF = fieldOverF id
+
+newtype Positive x y a = Positive {runPositive :: (a -> x) -> y}
   deriving (Functor)
 
 -- | A version of 'field' for more general input values.
@@ -288,52 +313,36 @@ newtype Negative x y a = Negative {runNegative :: (a -> x) -> y}
 -- This can be used when the input type 'v' of the parser is not exactly a
 -- 'A.Object', but it contains one. The first argument is a lens that can
 -- extract the 'A.Object' contained in 'v'.
-fieldOver ::
-  forall doc' doc v v' a b.
-  HasField doc' doc =>
+fieldOverF ::
+  forall f doc' doc v v' a b.
+  (HasField doc' doc, FieldFunctor doc f) =>
   Lens v v' A.Object A.Value ->
   Text ->
   SchemaP doc' v' A.Value a b ->
-  SchemaP doc v [A.Pair] a b
-fieldOver l name sch = SchemaP (SchemaDoc s) (SchemaIn r) (SchemaOut w)
+  SchemaP doc v [A.Pair] a (f b)
+fieldOverF l name sch = SchemaP (SchemaDoc s) (SchemaIn r) (SchemaOut w)
   where
-    parseField :: A.Object -> Negative (A.Parser b) (A.Parser b) A.Value
-    parseField obj = Negative $ \k -> A.explicitParseField k obj name
+    parseField :: A.Object -> Positive (A.Parser b) (A.Parser (f b)) A.Value
+    parseField obj = Positive $ \k -> parseFieldF @doc k obj name
 
-    r :: v -> A.Parser b
-    r obj = runNegative (l parseField obj) (schemaIn sch)
+    r :: v -> A.Parser (f b)
+    r obj = runPositive (l parseField obj) (schemaIn sch)
 
     w x = do
       v <- schemaOut sch x
       pure [name A..= v]
 
-    s = mkField name (schemaDoc sch)
+    s = mkDocF @doc @f (mkField name (schemaDoc sch))
 
--- | A version of 'optField' for more general input values.
---
--- See documentation of 'fieldOver' for more details.
-optFieldOver ::
+-- | Like 'fieldOver', but specialised to the identity functor.
+fieldOver ::
   forall doc' doc v v' a b.
-  (HasOpt doc, HasField doc' doc) =>
+  (HasField doc' doc) =>
   Lens v v' A.Object A.Value ->
   Text ->
-  Maybe A.Value ->
   SchemaP doc' v' A.Value a b ->
-  SchemaP doc v [A.Pair] (Maybe a) (Maybe b)
-optFieldOver l name def sch = SchemaP (SchemaDoc s) (SchemaIn r) (SchemaOut w)
-  where
-    parseField :: A.Object -> Negative (A.Parser b) (A.Parser (Maybe b)) A.Value
-    parseField obj = Negative $ \k -> A.explicitParseFieldMaybe k obj name
-
-    r :: v -> A.Parser (Maybe b)
-    r obj = runNegative (l parseField obj) (schemaIn sch)
-
-    w (Just x) = do
-      v <- schemaOut sch x
-      pure [name A..= v]
-    w Nothing = pure (maybeToList (fmap (name A..=) def))
-
-    s = mkOpt (mkField name (schemaDoc sch))
+  SchemaP doc v [A.Pair] a b
+fieldOver l name = fmap runIdentity . fieldOverF l name
 
 -- | Like 'field', but apply an arbitrary function to the
 -- documentation of the field.
@@ -350,11 +359,20 @@ fieldWithDocModifier name modify sch = field name (over doc modify sch)
 optFieldWithDocModifier ::
   (HasOpt doc, HasField doc' doc) =>
   Text ->
-  Maybe A.Value ->
   (doc' -> doc') ->
   SchemaP doc' A.Value A.Value a b ->
-  SchemaP doc A.Object [A.Pair] (Maybe a) (Maybe b)
-optFieldWithDocModifier name def modify sch = optField name def (over doc modify sch)
+  SchemaP doc A.Object [A.Pair] a (Maybe b)
+optFieldWithDocModifier name modify sch = optField name (over doc modify sch)
+
+-- | Like 'fieldF', but apply an arbitrary function to the
+-- documentation of the field.
+fieldWithDocModifierF ::
+  (HasOpt doc, HasField doc' doc, FieldFunctor doc f) =>
+  Text ->
+  (doc' -> doc') ->
+  SchemaP doc' A.Value A.Value a b ->
+  SchemaP doc A.Object [A.Pair] a (f b)
+fieldWithDocModifierF name modify sch = fieldF name (over doc modify sch)
 
 -- | Change the input type of a schema.
 (.=) :: Profunctor p => (a -> a') -> p a' b -> p a b
@@ -508,32 +526,17 @@ enum name sch = SchemaP (SchemaDoc d) (SchemaIn i) (SchemaOut o)
         <|> fail ("Unexpected value for enum " <> T.unpack name)
     o = fmap A.toJSON . (getAlt <=< schemaOut sch)
 
--- | An optional schema.
+-- | A schema for 'Maybe' that omits a field on serialisation.
 --
--- This is most commonly used for optional fields. The parser will
--- return 'Nothing' if the field is missing, and conversely the
--- serialiser will simply omit the field when its value is 'Nothing'.
-opt :: HasOpt d => Monoid w => SchemaP d v w a b -> SchemaP d v w (Maybe a) (Maybe b)
-opt = optWithDefault mempty
+-- This is most commonly used for optional fields, and it will cause the field
+-- to be omitted from the output of the serialiser.
+maybe_ :: HasOpt d => Monoid w => SchemaP d v w a b -> SchemaP d v w (Maybe a) b
+maybe_ = maybeWithDefault mempty
 
--- | An optional schema with a specified failure value
---
--- This is a more general version of 'opt' that allows a custom
--- serialisation 'Nothing' value.
-optWithDefault :: HasOpt d => w -> SchemaP d v w a b -> SchemaP d v w (Maybe a) (Maybe b)
-optWithDefault w0 sch = SchemaP (SchemaDoc d) (SchemaIn i) (SchemaOut o)
-  where
-    d = mkOpt (schemaDoc sch)
-    i = optional . schemaIn sch
-    o = maybe (pure w0) (schemaOut sch)
-
--- | A schema that ignores failure.
---
--- Given a schema @sch :: SchemaP d v w a (Maybe b)@, the parser for
--- @lax sch@ is just like the one for @sch@, except that it returns
--- 'Nothing' in case of failure.
-lax :: Alternative f => f (Maybe a) -> f (Maybe a)
-lax = (<|> pure Nothing)
+-- | A schema for 'Maybe', producing the given default value on serialisation.
+maybeWithDefault :: HasOpt d => w -> SchemaP d v w a b -> SchemaP d v w (Maybe a) b
+maybeWithDefault w0 (SchemaP (SchemaDoc d) (SchemaIn i) (SchemaOut o)) =
+  SchemaP (SchemaDoc d) (SchemaIn i) (SchemaOut (maybe (pure w0) o))
 
 -- | A schema depending on a parsed value.
 --

--- a/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
+++ b/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
@@ -445,8 +445,8 @@ instance ToSchema User where
     object "User" $
       User
         <$> userName .= field "name" schema
-        <*> userHandle .= opt (field "handle" schema)
-        <*> userExpire .= opt (field "expire" schema)
+        <*> userHandle .= maybe_ (optField "handle" schema)
+        <*> userExpire .= maybe_ (optField "expire" schema)
 
 exampleUser1 :: User
 exampleUser1 = User "Alice" (Just "alice") Nothing
@@ -554,13 +554,13 @@ rmClientSchema :: ValueSchema NamedSwaggerDoc RmClient
 rmClientSchema =
   object "RmClient" $
     RmClient
-      <$> rmPassword .= lax (field "password" (optWithDefault Null passwordSchema))
+      <$> rmPassword .= optional (field "password" (maybeWithDefault Null passwordSchema))
 
 instance ToSchema RmClient where
   schema =
     object "RmClient" $
       RmClient
-        <$> rmPassword .= optField "password" Nothing passwordSchema
+        <$> rmPassword .= maybe_ (optField "password" passwordSchema)
 
 -- examples from documentation (only type-checked)
 
@@ -601,9 +601,9 @@ userSchemaWithDefaultName' :: ValueSchema NamedSwaggerDoc User
 userSchemaWithDefaultName' =
   object "User" $
     User
-      <$> (getOptText . userName) .= (fromMaybe "" <$> opt (field "name" schema))
-      <*> userHandle .= opt (field "handle" schema)
-      <*> userExpire .= opt (field "expire" schema)
+      <$> (getOptText . userName) .= maybe_ (fromMaybe "" <$> optField "name" schema)
+      <*> userHandle .= maybe_ (optField "handle" schema)
+      <*> userExpire .= maybe_ (optField "expire" schema)
   where
     getOptText :: Text -> Maybe Text
     getOptText "" = Nothing
@@ -614,5 +614,5 @@ userSchemaWithDefaultName =
   object "User" $
     User
       <$> userName .= (field "name" schema <|> pure "")
-      <*> userHandle .= opt (field "handle" schema)
-      <*> userExpire .= opt (field "expire" schema)
+      <*> userHandle .= maybe_ (optField "handle" schema)
+      <*> userExpire .= maybe_ (optField "expire" schema)

--- a/libs/types-common/src/Data/Domain.hs
+++ b/libs/types-common/src/Data/Domain.hs
@@ -30,7 +30,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Char8 as BS.Char8
 import Data.ByteString.Conversion
-import Data.Schema hiding (opt)
+import Data.Schema
 import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as Text

--- a/libs/wire-api/src/Wire/API/Connection.hs
+++ b/libs/wire-api/src/Wire/API/Connection.hs
@@ -47,13 +47,13 @@ where
 
 import Control.Applicative (optional)
 import Control.Lens ((?~))
-import Data.Aeson as Aeson
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Id
 import Data.Json.Util (UTCTimeMillis)
 import Data.Qualified (Qualified (qUnqualified), deprecatedSchema)
 import Data.Range
-import qualified Data.Schema as P
-import Data.Swagger as S
+import Data.Schema
+import qualified Data.Swagger as S
 import qualified Data.Swagger.Build.Api as Doc
 import Data.Text as Text
 import Imports
@@ -85,14 +85,14 @@ data UserConnectionList = UserConnectionList
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform UserConnectionList)
-  deriving (FromJSON, ToJSON, S.ToSchema) via (P.Schema UserConnectionList)
+  deriving (FromJSON, ToJSON, S.ToSchema) via (Schema UserConnectionList)
 
-instance P.ToSchema UserConnectionList where
+instance ToSchema UserConnectionList where
   schema =
-    P.object "UserConnectionList" $
+    object "UserConnectionList" $
       UserConnectionList
-        <$> clConnections P..= P.field "connections" (P.array P.schema)
-        <*> clHasMore P..= P.fieldWithDocModifier "has_more" (P.description ?~ "Indicator that the server has more connections than returned.") P.schema
+        <$> clConnections .= field "connections" (array schema)
+        <*> clHasMore .= fieldWithDocModifier "has_more" (description ?~ "Indicator that the server has more connections than returned.") schema
 
 modelConnectionList :: Doc.Model
 modelConnectionList = Doc.defineModel "UserConnectionList" $ do
@@ -119,21 +119,21 @@ data UserConnection = UserConnection
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform UserConnection)
-  deriving (FromJSON, ToJSON, S.ToSchema) via (P.Schema UserConnection)
+  deriving (FromJSON, ToJSON, S.ToSchema) via (Schema UserConnection)
 
-instance P.ToSchema UserConnection where
+instance ToSchema UserConnection where
   schema =
-    P.object "UserConnection" $
+    object "UserConnection" $
       UserConnection
-        <$> ucFrom P..= P.field "from" P.schema
-        <*> ucTo P..= P.field "qualified_to" P.schema
+        <$> ucFrom .= field "from" schema
+        <*> ucTo .= field "qualified_to" schema
         <* (qUnqualified . ucTo)
-          P..= optional (P.field "to" (deprecatedSchema "qualified_to" P.schema))
-        <*> ucStatus P..= P.field "status" P.schema
-        <*> ucLastUpdate P..= P.field "last_update" P.schema
-        <*> ucConvId P..= P.optField "qualified_conversation" Nothing P.schema
+          .= optional (field "to" (deprecatedSchema "qualified_to" schema))
+        <*> ucStatus .= field "status" schema
+        <*> ucLastUpdate .= field "last_update" schema
+        <*> ucConvId .= maybe_ (optField "qualified_conversation" schema)
         <* (fmap qUnqualified . ucConvId)
-          P..= P.optField "conversation" Nothing (deprecatedSchema "qualified_conversation" P.schema)
+          .= maybe_ (optField "conversation" (deprecatedSchema "qualified_conversation" schema))
 
 modelConnection :: Doc.Model
 modelConnection = Doc.defineModel "Connection" $ do
@@ -170,7 +170,7 @@ data Relation
     MissingLegalholdConsent
   deriving stock (Eq, Ord, Show, Generic)
   deriving (Arbitrary) via (GenericUniform Relation)
-  deriving (FromJSON, ToJSON, S.ToSchema) via (P.Schema Relation)
+  deriving (FromJSON, ToJSON, S.ToSchema) via (Schema Relation)
 
 instance S.ToParamSchema Relation where
   toParamSchema _ = mempty & S.type_ ?~ S.SwaggerString
@@ -234,17 +234,17 @@ typeRelation =
         "missing-legalhold-consent"
       ]
 
-instance P.ToSchema Relation where
+instance ToSchema Relation where
   schema =
-    P.enum @Text "Relation" $
+    enum @Text "Relation" $
       mconcat
-        [ P.element "accepted" Accepted,
-          P.element "blocked" Blocked,
-          P.element "pending" Pending,
-          P.element "ignored" Ignored,
-          P.element "sent" Sent,
-          P.element "cancelled" Cancelled,
-          P.element "missing-legalhold-consent" MissingLegalholdConsent
+        [ element "accepted" Accepted,
+          element "blocked" Blocked,
+          element "pending" Pending,
+          element "ignored" Ignored,
+          element "sent" Sent,
+          element "cancelled" Cancelled,
+          element "missing-legalhold-consent" MissingLegalholdConsent
         ]
 
 instance FromHttpApiData Relation where
@@ -285,14 +285,14 @@ data ConnectionRequest = ConnectionRequest
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform ConnectionRequest)
-  deriving (FromJSON, ToJSON, S.ToSchema) via (P.Schema ConnectionRequest)
+  deriving (FromJSON, ToJSON, S.ToSchema) via (Schema ConnectionRequest)
 
-instance P.ToSchema ConnectionRequest where
+instance ToSchema ConnectionRequest where
   schema =
-    P.object "ConnectionRequest" $
+    object "ConnectionRequest" $
       ConnectionRequest
-        <$> crUser P..= P.fieldWithDocModifier "user" (P.description ?~ "user ID of the user to request a connection with") P.schema
-        <*> crName P..= P.fieldWithDocModifier "name" (P.description ?~ "Name of the (pending) conversation being initiated (1 - 256) characters)") P.schema
+        <$> crUser .= fieldWithDocModifier "user" (description ?~ "user ID of the user to request a connection with") schema
+        <*> crName .= fieldWithDocModifier "name" (description ?~ "Name of the (pending) conversation being initiated (1 - 256) characters)") schema
 
 -- | Payload type for "please change the status of this connection".
 newtype ConnectionUpdate = ConnectionUpdate
@@ -300,13 +300,13 @@ newtype ConnectionUpdate = ConnectionUpdate
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform ConnectionUpdate)
-  deriving (FromJSON, ToJSON, S.ToSchema) via (P.Schema ConnectionUpdate)
+  deriving (FromJSON, ToJSON, S.ToSchema) via (Schema ConnectionUpdate)
 
-instance P.ToSchema ConnectionUpdate where
+instance ToSchema ConnectionUpdate where
   schema =
-    P.object "ConnectionUpdate" $
+    object "ConnectionUpdate" $
       ConnectionUpdate
-        <$> cuStatus P..= P.fieldWithDocModifier "status" (P.description ?~ "New relation status") P.schema
+        <$> cuStatus .= fieldWithDocModifier "status" (description ?~ "New relation status") schema
 
 modelConnectionUpdate :: Doc.Model
 modelConnectionUpdate = Doc.defineModel "ConnectionUpdate" $ do

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -148,19 +148,18 @@ conversationMetadataObjectSchema =
         schema
     <*> cnvmAccess .= field "access" (array schema)
     <*> cnvmAccessRole .= field "access_role" schema
-    <*> cnvmName .= lax (field "name" (optWithDefault A.Null schema))
+    <*> cnvmName .= optField "name" (maybeWithDefault A.Null schema)
     <* const ("0.0" :: Text) .= optional (field "last_event" schema)
     <* const ("1970-01-01T00:00:00.000Z" :: Text)
       .= optional (field "last_event_time" schema)
-    <*> cnvmTeam .= lax (field "team" (optWithDefault A.Null schema))
+    <*> cnvmTeam .= optField "team" (maybeWithDefault A.Null schema)
     <*> cnvmMessageTimer
-      .= lax
-        ( fieldWithDocModifier
-            "message_timer"
-            (description ?~ "Per-conversation message timer (can be null)")
-            (optWithDefault A.Null schema)
-        )
-    <*> cnvmReceiptMode .= lax (field "receipt_mode" (optWithDefault A.Null schema))
+      .= ( optFieldWithDocModifier
+             "message_timer"
+             (description ?~ "Per-conversation message timer (can be null)")
+             (maybeWithDefault A.Null schema)
+         )
+    <*> cnvmReceiptMode .= optField "receipt_mode" (maybeWithDefault A.Null schema)
 
 instance ToSchema ConversationMetadata where
   schema = object "ConversationMetadata" conversationMetadataObjectSchema
@@ -287,7 +286,7 @@ instance ToSchema ConversationCoverView where
       (description ?~ "Limited view of Conversation.")
       $ ConversationCoverView
         <$> cnvCoverConvId .= field "id" schema
-        <*> cnvCoverName .= lax (field "name" (optWithDefault A.Null schema))
+        <*> cnvCoverName .= optField "name" (maybeWithDefault A.Null schema)
 
 data ConversationList a = ConversationList
   { convList :: [a],
@@ -618,27 +617,25 @@ newConvSchema =
                (array schema)
                <|> pure []
            )
-      <*> newConvName .= opt (field "name" schema)
+      <*> newConvName .= maybe_ (optField "name" schema)
       <*> (Set.toList . newConvAccess)
-        .= ( field "access" (Set.fromList <$> array schema)
-               <|> pure mempty
-           )
-      <*> newConvAccessRole .= opt (field "access_role" schema)
+        .= (fromMaybe mempty <$> optField "access" (Set.fromList <$> array schema))
+      <*> newConvAccessRole .= maybe_ (optField "access_role" schema)
       <*> newConvTeam
-        .= opt
-          ( fieldWithDocModifier
+        .= maybe_
+          ( optFieldWithDocModifier
               "team"
               (description ?~ "Team information of this conversation")
               schema
           )
       <*> newConvMessageTimer
-        .= opt
-          ( fieldWithDocModifier
+        .= maybe_
+          ( optFieldWithDocModifier
               "message_timer"
               (description ?~ "Per-conversation message timer")
               schema
           )
-      <*> newConvReceiptMode .= opt (field "receipt_mode" schema)
+      <*> newConvReceiptMode .= maybe_ (optField "receipt_mode" schema)
       <*> newConvUsersRole
         .= ( fieldWithDocModifier "conversation_role" (description ?~ usersRoleDesc) schema
                <|> pure roleNameWireAdmin
@@ -711,10 +708,8 @@ instance ToSchema Invite where
       Invite
         <$> (toNonEmpty . invUsers)
           .= fmap List1 (field "users" (nonEmptyArray schema))
-        <*> (Just . invRoleName)
-          .= fmap
-            (fromMaybe roleNameWireAdmin)
-            (optField "conversation_role" Nothing schema)
+        <*> invRoleName
+          .= (fromMaybe roleNameWireAdmin <$> optField "conversation_role" schema)
 
 data InviteQualified = InviteQualified
   { invQUsers :: NonEmpty (Qualified UserId),
@@ -730,10 +725,8 @@ instance ToSchema InviteQualified where
     object "InviteQualified" $
       InviteQualified
         <$> invQUsers .= field "qualified_users" (nonEmptyArray schema)
-        <*> (Just . invQRoleName)
-          .= fmap
-            (fromMaybe roleNameWireAdmin)
-            (optField "conversation_role" Nothing schema)
+        <*> invQRoleName
+          .= (fromMaybe roleNameWireAdmin <$> optField "conversation_role" schema)
 
 newInvite :: List1 UserId -> Invite
 newInvite us = Invite us roleNameWireAdmin
@@ -836,7 +829,7 @@ instance ToSchema ConversationMessageTimerUpdate where
       "ConversationMessageTimerUpdate"
       (description ?~ "Contains conversation properties to update")
       $ ConversationMessageTimerUpdate
-        <$> cupMessageTimer .= lax (field "message_timer" (optWithDefault A.Null schema))
+        <$> cupMessageTimer .= optField "message_timer" (maybeWithDefault A.Null schema)
 
 modelConversationMessageTimerUpdate :: Doc.Model
 modelConversationMessageTimerUpdate = Doc.defineModel "ConversationMessageTimerUpdate" $ do

--- a/libs/wire-api/src/Wire/API/Conversation/Code.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Code.hs
@@ -82,8 +82,8 @@ instance ToSchema ConversationCode where
             (description ?~ "Conversation code (random)")
             schema
         <*> conversationUri
-          .= opt
-            ( fieldWithDocModifier
+          .= maybe_
+            ( optFieldWithDocModifier
                 "uri"
                 (description ?~ "Full URI (containing key/code) to join a conversation")
                 schema

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -371,10 +371,10 @@ connectObjectSchema :: ObjectSchema SwaggerDoc Connect
 connectObjectSchema =
   Connect
     <$> cRecipient .= field "qualified_recipient" schema
-    <* (Just . qUnqualified . cRecipient) .= optField "recipient" Nothing schema
-    <*> cMessage .= lax (field "message" (optWithDefault A.Null schema))
-    <*> cName .= lax (field "name" (optWithDefault A.Null schema))
-    <*> cEmail .= lax (field "email" (optWithDefault A.Null schema))
+    <* (qUnqualified . cRecipient) .= optional (field "recipient" schema)
+    <*> cMessage .= optField "message" (maybeWithDefault A.Null schema)
+    <*> cName .= optField "name" (maybeWithDefault A.Null schema)
+    <*> cEmail .= optField "email" (maybeWithDefault A.Null schema)
 
 modelConnect :: Doc.Model
 modelConnect = Doc.defineModel "Connect" $ do
@@ -416,14 +416,14 @@ memberUpdateDataObjectSchema :: ObjectSchema SwaggerDoc MemberUpdateData
 memberUpdateDataObjectSchema =
   MemberUpdateData
     <$> misTarget .= field "qualified_target" schema
-    <* (Just . qUnqualified . misTarget) .= optField "target" Nothing schema
-    <*> misOtrMutedStatus .= opt (field "otr_muted_status" schema)
-    <*> misOtrMutedRef .= opt (field "otr_muted_ref" schema)
-    <*> misOtrArchived .= opt (field "otr_archived" schema)
-    <*> misOtrArchivedRef .= opt (field "otr_archived_ref" schema)
-    <*> misHidden .= opt (field "hidden" schema)
-    <*> misHiddenRef .= opt (field "hidden_ref" schema)
-    <*> misConvRoleName .= opt (field "conversation_role" schema)
+    <* (qUnqualified . misTarget) .= optional (field "target" schema)
+    <*> misOtrMutedStatus .= maybe_ (optField "otr_muted_status" schema)
+    <*> misOtrMutedRef .= maybe_ (optField "otr_muted_ref" schema)
+    <*> misOtrArchived .= maybe_ (optField "otr_archived" schema)
+    <*> misOtrArchivedRef .= maybe_ (optField "otr_archived_ref" schema)
+    <*> misHidden .= maybe_ (optField "hidden" schema)
+    <*> misHiddenRef .= maybe_ (optField "hidden_ref" schema)
+    <*> misConvRoleName .= maybe_ (optField "conversation_role" schema)
 
 modelMemberUpdateData :: Doc.Model
 modelMemberUpdateData = Doc.defineModel "MemberUpdateData" $ do
@@ -478,8 +478,8 @@ otrMessageObjectSchema =
         (description ?~ textDesc)
         schema
     <*> otrData
-      .= opt
-        ( fieldWithDocModifier
+      .= maybe_
+        ( optFieldWithDocModifier
             "data"
             (description ?~ dataDesc)
             schema

--- a/libs/wire-api/src/Wire/API/Message.hs
+++ b/libs/wire-api/src/Wire/API/Message.hs
@@ -152,9 +152,9 @@ instance ToSchema NewOtrMessage where
         <*> newOtrRecipients .= field "recipients" schema
         <*> newOtrNativePush .= (field "native_push" schema <|> pure True)
         <*> newOtrTransient .= (field "transient" schema <|> pure False)
-        <*> newOtrNativePriority .= opt (field "native_priority" schema)
-        <*> newOtrData .= opt (field "data" schema)
-        <*> newOtrReportMissing .= opt (field "report_missing" (array schema))
+        <*> newOtrNativePriority .= maybe_ (optField "native_priority" schema)
+        <*> newOtrData .= maybe_ (optField "data" schema)
+        <*> newOtrReportMissing .= maybe_ (optField "report_missing" (array schema))
 
 instance FromProto NewOtrMessage where
   fromProto bs = protoToNewOtrMessage <$> runGetLazy Protobuf.decodeMessage bs

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig/Connection.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig/Connection.hs
@@ -22,7 +22,7 @@ instance ToSchema ConnectionsStatusRequest where
     object "ConnectionsStatusRequest" $
       ConnectionsStatusRequest
         <$> csrFrom .= field "from" (array schema)
-        <*> csrTo .= optField "to" Nothing (array schema)
+        <*> csrTo .= maybe_ (optField "to" (array schema))
 
 data ConnectionsStatusRequestV2 = ConnectionsStatusRequestV2
   { csrv2From :: ![UserId],
@@ -37,8 +37,8 @@ instance ToSchema ConnectionsStatusRequestV2 where
     object "ConnectionsStatusRequestV2" $
       ConnectionsStatusRequestV2
         <$> csrv2From .= field "from" (array schema)
-        <*> csrv2To .= optField "to" Nothing (array schema)
-        <*> csrv2Relation .= optField "relation" Nothing schema
+        <*> csrv2To .= maybe_ (optField "to" (array schema))
+        <*> csrv2Relation .= maybe_ (optField "relation" schema)
 
 data ConnectionStatus = ConnectionStatus
   { csFrom :: !UserId,

--- a/libs/wire-api/src/Wire/API/Routes/MultiTablePaging.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiTablePaging.hs
@@ -90,8 +90,8 @@ instance RequestSchemaConstraint name tables max def => ToSchema (GetMultiTableP
           ("GetPaginated_" <> textFromSymbol @name)
           (description ?~ "A request to list some or all of a user's " <> textFromSymbol @name <> ", including remote ones")
           $ GetMultiTablePageRequest
-            <$> gmtprSize .= (fieldWithDocModifier "size" addSizeDoc schema <|> pure (toRange (Proxy @def)))
-            <*> gmtprState .= optFieldWithDocModifier "paging_state" Nothing addPagingStateDoc schema
+            <$> gmtprSize .= (fromMaybe (toRange (Proxy @def)) <$> optFieldWithDocModifier "size" addSizeDoc schema)
+            <*> gmtprState .= maybe_ (optFieldWithDocModifier "paging_state" addPagingStateDoc schema)
 
 textFromNat :: forall n. KnownNat n => Text
 textFromNat = Text.pack . show . natVal $ Proxy @n

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -234,12 +234,12 @@ instance ToSchema UserProfile where
         <*> profileAssets .= (field "assets" (array schema) <|> pure [])
         <*> profileAccentId .= field "accent_id" schema
         <*> ((\del -> if del then Just True else Nothing) . profileDeleted)
-          .= fmap (fromMaybe False) (opt (field "deleted" schema))
-        <*> profileService .= opt (field "service" schema)
-        <*> profileHandle .= opt (field "handle" schema)
-        <*> profileExpire .= opt (field "expires_at" schema)
-        <*> profileTeam .= opt (field "team" schema)
-        <*> profileEmail .= opt (field "email" schema)
+          .= maybe_ (fromMaybe False <$> optField "deleted" schema)
+        <*> profileService .= maybe_ (optField "service" schema)
+        <*> profileHandle .= maybe_ (optField "handle" schema)
+        <*> profileExpire .= maybe_ (optField "expires_at" schema)
+        <*> profileTeam .= maybe_ (optField "team" schema)
+        <*> profileEmail .= maybe_ (optField "email" schema)
         <*> profileLegalholdStatus .= field "legalhold_status" schema
 
 modelUser :: Doc.Model
@@ -986,7 +986,7 @@ instance ToSchema DeleteUser where
   schema =
     object "DeleteUser" $
       DeleteUser
-        <$> deleteUserPassword .= opt (field "password" schema)
+        <$> deleteUserPassword .= maybe_ (optField "password" schema)
 
 mkDeleteUser :: Maybe PlainTextPassword -> DeleteUser
 mkDeleteUser = DeleteUser

--- a/libs/wire-api/src/Wire/API/User/Client.hs
+++ b/libs/wire-api/src/Wire/API/User/Client.hs
@@ -247,21 +247,12 @@ newtype UserClientPrekeyMap = UserClientPrekeyMap
 mkUserClientPrekeyMap :: Map UserId (Map ClientId (Maybe Prekey)) -> UserClientPrekeyMap
 mkUserClientPrekeyMap = coerce
 
-optionalSchema ::
-  ValueSchemaP SwaggerDoc a b ->
-  ValueSchemaP SwaggerDoc (Maybe a) (Maybe b)
-optionalSchema s =
-  mconcat
-    [ Just <$> maybeWithDefault A.Null s,
-      const () .= null_ $> Nothing
-    ]
-
 instance ToSchema UserClientPrekeyMap where
   schema = UserClientPrekeyMap <$> getUserClientPrekeyMap .= addDoc sch
     where
       sch =
         named "UserClientPrekeyMap" $
-          userClientMapSchema (optionalSchema (unnamed schema))
+          userClientMapSchema (nullable (unnamed schema))
       addDoc =
         Swagger.schema . Swagger.example
           ?~ toJSON

--- a/libs/wire-api/src/Wire/API/User/Profile.hs
+++ b/libs/wire-api/src/Wire/API/User/Profile.hs
@@ -126,7 +126,7 @@ instance ToSchema Asset where
     object "UserAsset" $
       ImageAsset
         <$> assetKey .= field "key" schema
-        <*> assetSize .= opt (field "size" schema)
+        <*> assetSize .= maybe_ (optField "size" schema)
         <* const () .= field "type" typeSchema
     where
       typeSchema :: ValueSchema NamedSwaggerDoc ()


### PR DESCRIPTION
Improved the API for optional fields, and made it harder to misuse it. See README for more details.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
