### PR TITLE
SQSERVICES-1169 New internal endpoint to configure the guest links team feature

### DIFF
--- a/changelog.d/5-internal/sqservices-1169
+++ b/changelog.d/5-internal/sqservices-1169
@@ -1,0 +1,1 @@
+New internal endpoint to configure the guest links team feature.

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -438,6 +438,7 @@ executable galley-schema
       V54_TeamFeatureSelfDeletingMessages
       V55_SelfDeletingMessagesLockStatus
       V56_GuestLinksTeamFeatureStatus
+      V57_GuestLinksLockStatus
       Paths_galley
   hs-source-dirs:
       schema/src

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -59,6 +59,7 @@ import qualified V53_AddRemoteConvStatus
 import qualified V54_TeamFeatureSelfDeletingMessages
 import qualified V55_SelfDeletingMessagesLockStatus
 import qualified V56_GuestLinksTeamFeatureStatus
+import qualified V57_GuestLinksLockStatus
 
 main :: IO ()
 main = do
@@ -103,7 +104,8 @@ main = do
       V53_AddRemoteConvStatus.migration,
       V54_TeamFeatureSelfDeletingMessages.migration,
       V55_SelfDeletingMessagesLockStatus.migration,
-      V56_GuestLinksTeamFeatureStatus.migration
+      V56_GuestLinksTeamFeatureStatus.migration,
+      V57_GuestLinksLockStatus.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Galley.Cassandra
       -- (see also docs/developer/cassandra-interaction.md)

--- a/services/galley/schema/src/V57_GuestLinksLockStatus.hs
+++ b/services/galley/schema/src/V57_GuestLinksLockStatus.hs
@@ -1,0 +1,33 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V57_GuestLinksLockStatus
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 57 "Add lock status for guest links team feature" $ do
+  schema'
+    [r| ALTER TABLE team_features ADD (
+          guest_links_lock_status int
+        )
+     |]

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -204,6 +204,9 @@ data InternalApi routes = InternalApi
     iTeamFeatureStatusGuestLinksPut ::
       routes
         :- IFeatureStatusPut 'Public.TeamFeatureGuestLinks,
+    iTeamFeatureLockStatusGuestLinksPut ::
+      routes
+        :- IFeatureStatusLockStatusPut 'Public.TeamFeatureGuestLinks,
     -- This endpoint can lead to the following events being sent:
     -- - MemberLeave event to members for all conversations the user was in
     iDeleteUser ::
@@ -325,7 +328,8 @@ servantSitemap =
         iTeamFeatureStatusSelfDeletingMessagesGet = iGetTeamFeature @'Public.WithLockStatus @'Public.TeamFeatureSelfDeletingMessages Features.getSelfDeletingMessagesInternal,
         iTeamFeatureLockStatusSelfDeletingMessagesPut = Features.setLockStatus @'Public.TeamFeatureSelfDeletingMessages,
         iTeamFeatureStatusGuestLinksGet = iGetTeamFeature @'Public.WithLockStatus @'Public.TeamFeatureGuestLinks Features.getGuestLinkInternal,
-        iTeamFeatureStatusGuestLinksPut = iPutTeamFeature @'Public.TeamFeatureGuestLinks $ Features.setGuestLinkInternal True,
+        iTeamFeatureStatusGuestLinksPut = iPutTeamFeature @'Public.TeamFeatureGuestLinks Features.setGuestLinkInternal,
+        iTeamFeatureLockStatusGuestLinksPut = Features.setLockStatus @'Public.TeamFeatureGuestLinks,
         iDeleteUser = rmUser,
         iConnect = Create.createConnectConversation,
         iUpsertOne2OneConversation = One2One.iUpsertOne2OneConversation

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -198,6 +198,12 @@ data InternalApi routes = InternalApi
     iTeamFeatureLockStatusSelfDeletingMessagesPut ::
       routes
         :- IFeatureStatusLockStatusPut 'Public.TeamFeatureSelfDeletingMessages,
+    iTeamFeatureStatusGuestLinksGet ::
+      routes
+        :- IFeatureStatusGet 'Public.WithLockStatus 'Public.TeamFeatureGuestLinks,
+    iTeamFeatureStatusGuestLinksPut ::
+      routes
+        :- IFeatureStatusPut 'Public.TeamFeatureGuestLinks,
     -- This endpoint can lead to the following events being sent:
     -- - MemberLeave event to members for all conversations the user was in
     iDeleteUser ::
@@ -318,6 +324,8 @@ servantSitemap =
         iTeamFeatureStatusSelfDeletingMessagesPut = iPutTeamFeature @'Public.TeamFeatureSelfDeletingMessages Features.setSelfDeletingMessagesInternal,
         iTeamFeatureStatusSelfDeletingMessagesGet = iGetTeamFeature @'Public.WithLockStatus @'Public.TeamFeatureSelfDeletingMessages Features.getSelfDeletingMessagesInternal,
         iTeamFeatureLockStatusSelfDeletingMessagesPut = Features.setLockStatus @'Public.TeamFeatureSelfDeletingMessages,
+        iTeamFeatureStatusGuestLinksGet = iGetTeamFeature @'Public.WithLockStatus @'Public.TeamFeatureGuestLinks Features.getGuestLinkInternal,
+        iTeamFeatureStatusGuestLinksPut = iPutTeamFeature @'Public.TeamFeatureGuestLinks $ Features.setGuestLinkInternal True,
         iDeleteUser = rmUser,
         iConnect = Create.createConnectConversation,
         iUpsertOne2OneConversation = One2One.iUpsertOne2OneConversation

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -174,7 +174,7 @@ servantSitemap =
           Features.getFeatureStatus @'Public.WithLockStatus @'Public.TeamFeatureGuestLinks Features.getGuestLinkInternal
             . DoAuth,
         GalleyAPI.featureStatusGuestLinksPut =
-          Features.setFeatureStatus @'Public.TeamFeatureGuestLinks (Features.setGuestLinkInternal False)
+          Features.setFeatureStatus @'Public.TeamFeatureGuestLinks Features.setGuestLinkInternal
             . DoAuth,
         GalleyAPI.featureAllFeatureConfigsGet = Features.getAllFeatureConfigs,
         GalleyAPI.featureConfigLegalHoldGet = Features.getFeatureConfig @'Public.WithoutLockStatus @'Public.TeamFeatureLegalHold Features.getLegalholdStatusInternal,

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -174,7 +174,7 @@ servantSitemap =
           Features.getFeatureStatus @'Public.WithLockStatus @'Public.TeamFeatureGuestLinks Features.getGuestLinkInternal
             . DoAuth,
         GalleyAPI.featureStatusGuestLinksPut =
-          Features.setFeatureStatus @'Public.TeamFeatureGuestLinks Features.setGuestLinkInternal
+          Features.setFeatureStatus @'Public.TeamFeatureGuestLinks (Features.setGuestLinkInternal False)
             . DoAuth,
         GalleyAPI.featureAllFeatureConfigsGet = Features.getAllFeatureConfigs,
         GalleyAPI.featureConfigLegalHoldGet = Features.getFeatureConfig @'Public.WithoutLockStatus @'Public.TeamFeatureLegalHold Features.getLegalholdStatusInternal,

--- a/services/galley/src/Galley/Cassandra.hs
+++ b/services/galley/src/Galley/Cassandra.hs
@@ -20,4 +20,4 @@ module Galley.Cassandra (schemaVersion) where
 import Imports
 
 schemaVersion :: Int32
-schemaVersion = 56
+schemaVersion = 57

--- a/services/galley/src/Galley/Cassandra/TeamFeatures.hs
+++ b/services/galley/src/Galley/Cassandra/TeamFeatures.hs
@@ -29,9 +29,6 @@ import Polysemy
 import Polysemy.Input
 import Wire.API.Team.Feature
 
--- TODO(leif): according to the specs it should only be supported to read the lock status via the api
--- changes can only be made in the server configuration file
--- we can probably remove the lock status from the db?
 getFeatureStatusNoConfigAndLockStatus ::
   forall (a :: TeamFeatureName) m.
   (MonadClient m, FeatureHasNoConfig 'WithoutLockStatus a, HasStatusCol a, HasLockStatusCol a) =>

--- a/services/galley/src/Galley/Data/TeamFeatures.hs
+++ b/services/galley/src/Galley/Data/TeamFeatures.hs
@@ -65,7 +65,8 @@ instance {-# OVERLAPPABLE #-} HasLockStatusCol a => MaybeHasLockStatusCol a wher
 instance HasLockStatusCol 'TeamFeatureSelfDeletingMessages where
   lockStatusCol = "self_deleting_messages_lock_status"
 
-instance MaybeHasLockStatusCol 'TeamFeatureGuestLinks where maybeLockStatusCol = Nothing
+instance HasLockStatusCol 'TeamFeatureGuestLinks where
+  lockStatusCol = "guest_links_lock_status"
 
 instance MaybeHasLockStatusCol 'TeamFeatureLegalHold where maybeLockStatusCol = Nothing
 

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -481,6 +481,7 @@ testGuestLinksInternal = do
   testGuestLinks
     (const $ Util.getTeamFeatureFlagInternal Public.TeamFeatureGuestLinks)
     (const $ Util.putTeamFeatureFlagInternal @'Public.TeamFeatureGuestLinks galley)
+    (Util.setLockStatusInternal @'Public.TeamFeatureGuestLinks galley)
 
 testGuestLinksPublic :: TestM ()
 testGuestLinksPublic = do
@@ -488,29 +489,44 @@ testGuestLinksPublic = do
   testGuestLinks
     (Util.getTeamFeatureFlagWithGalley Public.TeamFeatureGuestLinks galley)
     (Util.putTeamFeatureFlagWithGalley @'Public.TeamFeatureGuestLinks galley)
+    (Util.setLockStatusInternal @'Public.TeamFeatureGuestLinks galley)
 
 testGuestLinks ::
   (UserId -> TeamId -> TestM ResponseLBS) ->
   (UserId -> TeamId -> Public.TeamFeatureStatusNoConfig -> TestM ResponseLBS) ->
+  (TeamId -> Public.LockStatusValue -> TestM ResponseLBS) ->
   TestM ()
-testGuestLinks getStatus putStatus = do
+testGuestLinks getStatus putStatus setLockStatusInternal = do
   (owner, tid, []) <- Util.createBindingTeamWithNMembers 0
   let checkGet :: HasCallStack => Public.TeamFeatureStatusValue -> Public.LockStatusValue -> TestM ()
       checkGet status lock =
-        do
-          getStatus owner tid
-          !!! responseJsonEither === const (Right (Public.TeamFeatureStatusNoConfigAndLockStatus status lock))
-      checkSet :: HasCallStack => Public.TeamFeatureStatusValue -> TestM ()
-      checkSet status =
-        do
-          putStatus owner tid (Public.TeamFeatureStatusNoConfig status)
-          !!! statusCode === const 200
+        getStatus owner tid !!! do
+          statusCode === const 200
+          responseJsonEither === const (Right (Public.TeamFeatureStatusNoConfigAndLockStatus status lock))
+
+      checkSet :: HasCallStack => Public.TeamFeatureStatusValue -> Int -> TestM ()
+      checkSet status expectedStatusCode =
+        putStatus owner tid (Public.TeamFeatureStatusNoConfig status) !!! statusCode === const expectedStatusCode
+
+      checkSetLockStatusInternal :: HasCallStack => Public.LockStatusValue -> TestM ()
+      checkSetLockStatusInternal lockStatus =
+        setLockStatusInternal tid lockStatus !!! statusCode === const 200
 
   checkGet Public.TeamFeatureEnabled Public.Unlocked
-  checkSet Public.TeamFeatureDisabled
+  checkSet Public.TeamFeatureDisabled 200
   checkGet Public.TeamFeatureDisabled Public.Unlocked
-  checkSet Public.TeamFeatureEnabled
+  checkSet Public.TeamFeatureEnabled 200
   checkGet Public.TeamFeatureEnabled Public.Unlocked
+  checkSet Public.TeamFeatureDisabled 200
+  checkGet Public.TeamFeatureDisabled Public.Unlocked
+  -- when locks status is locked the team default feature status should be returned
+  -- and the team feature status can not be changed
+  checkSetLockStatusInternal Public.Locked
+  checkGet Public.TeamFeatureEnabled Public.Locked
+  checkSet Public.TeamFeatureDisabled 409
+  -- when lock status is unlocked again the previously set feature status is restored
+  checkSetLockStatusInternal Public.Unlocked
+  checkGet Public.TeamFeatureDisabled Public.Unlocked
 
 -- | Call 'GET /teams/:tid/features' and 'GET /feature-configs', and check if all
 -- features are there.


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1169

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
