### PR TITLE
Fix bug in SFT chart: multi sft args are quoted

### DIFF
--- a/changelog.d/5-internal/sftd-multi-sft-fixup
+++ b/changelog.d/5-internal/sftd-multi-sft-fixup
@@ -1,0 +1,1 @@
+sftd chart: Fix quoted args for multiSFT option

--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -131,9 +131,9 @@ spec:
               fi
 
               {{- if .Values.multiSFT.enabled }}
-              MULTI_SFT_ARGS="-t \"$(cat /multi-sft-config/turn_server)\" \
-              -x \"$(cat /multi-sft-config/username)\" \
-              -c \"$(cat /multi-sft-config/password)\""
+              MULTI_SFT_ARGS="-t $(cat /multi-sft-config/turn_server) \
+              -x $(cat /multi-sft-config/username) \
+              -c $(cat /multi-sft-config/password)"
               {{- else }}
               MULTI_SFT_ARGS=""
               {{- end }}


### PR DESCRIPTION
## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
