### PR TITLE
Cargohold: remote assets

### DIFF
--- a/changelog.d/1-api-changes/remote-assets
+++ b/changelog.d/1-api-changes/remote-assets
@@ -1,0 +1,4 @@
+Enable downloading assets from a remote (federated) cargohold instance via the v4 API. 
+The content of remote assets is returned as stream with content type
+`application/octet-stream`.
+Please refer to the Swagger API documentation for more details.

--- a/charts/brig/templates/tests/configmap.yaml
+++ b/charts/brig/templates/tests/configmap.yaml
@@ -65,6 +65,10 @@ data:
         host: galley.{{ .Release.Namespace }}-fed2.svc.cluster.local
         port: 8080
 
+      cargohold:
+        host: cargohold.{{ .Release.Namespace }}-fed2.svc.cluster.local
+        port: 8080
+
       # TODO remove this
       federator:
         host: federator.{{ .Release.Namespace }}-fed2.svc.cluster.local

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -29,7 +29,7 @@ config:
   # -- If set to false,  'dynamoDBEndpoint' _must_ be set.
   randomPrekeys: true
   useSES: true
-  enableFederator: false # keep enableFederator default in sync with galley chart's config.enableFederator as well as wire-server chart's tag.federator
+  enableFederator: false # keep enableFederator default in sync with galley and cargohold chart's config.enableFederator as well as wire-server chart's tag.federator
   emailSMS:
     general:
       templateBranding:

--- a/charts/cargohold/templates/configmap.yaml
+++ b/charts/cargohold/templates/configmap.yaml
@@ -11,6 +11,12 @@ data:
       host: 0.0.0.0
       port: {{ .Values.service.internalPort }}
 
+    {{- if .Values.config.enableFederator }}
+    federator:
+      host: federator
+      port: 8080
+    {{- end }}
+
     aws:
       {{- with .Values.config.aws }}
       s3Bucket: {{ .s3Bucket }}

--- a/charts/cargohold/templates/tests/cargohold-integration.yaml
+++ b/charts/cargohold/templates/tests/cargohold-integration.yaml
@@ -9,6 +9,9 @@ spec:
     - name: "cargohold-integration"
       configMap:
         name: "cargohold-integration"
+    - name: "cargohold-config"
+      configMap:
+        name: "cargohold"
   containers:
     # NOTE: the bucket for these tests must be created.
     # If using the wire-server/fake-aws-s3 chart, `dummy-bucket` will already be created.
@@ -17,6 +20,8 @@ spec:
     volumeMounts:
     - name: "cargohold-integration"
       mountPath: "/etc/wire/integration"
+    - name: "cargohold-config"
+      mountPath: "/etc/wire/cargohold/conf"
     env:
     # these dummy values are necessary for Amazonka's "Discover"
     - name: AWS_ACCESS_KEY_ID

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -14,6 +14,7 @@ resources:
     cpu: "500m"
 config:
   logLevel: Info
+  enableFederator: false # keep enableFederator default in sync with brig and galley chart's config.enableFederator as well as wire-server chart's tag.federator
   aws:
     region: "eu-west-1"
     s3Bucket: assets

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -19,7 +19,7 @@ config:
   cassandra:
     host: aws-cassandra
     replicaCount: 3
-  enableFederator: false # keep enableFederator default in sync with brig chart's config.enableFederator as well as wire-server chart's tag.federator
+  enableFederator: false # keep enableFederator default in sync with brig and cargohold chart's config.enableFederator as well as wire-server chart's tag.federator
   settings:
     maxTeamSize: 500
     maxConvSize: 500

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -51,7 +51,7 @@ brig:
       sessionTokenTimeout: 20
       accessTokenTimeout: 30
       providerTokenTimeout: 60
-    enableFederator: true # keep in sync with galley.config.enableFederator and tags.federator!
+    enableFederator: true # keep in sync with galley.config.enableFederator, cargohold.config.enableFederator and tags.federator!
     optSettings:
       setActivationTimeout: 5
       # keep this in sync with brigSettingsTeamInvitationTimeout in spar/templates/tests/configmap.yaml
@@ -125,6 +125,7 @@ cargohold:
     aws:
       s3Bucket: dummy-bucket
       s3Endpoint: http://fake-aws-s3:9000
+    enableFederator: true # keep in sync with brig.config.enableFederator, galley.config.enableFederator and tags.federator!
   secrets:
     awsKeyId: dummykey
     awsSecretKey: dummysecret
@@ -135,7 +136,7 @@ galley:
     cassandra:
       host: cassandra-ephemeral
       replicaCount: 1
-    enableFederator: true # keep in sync with brig.config.enableFederator and tags.federator!
+    enableFederator: true # keep in sync with brig.config.enableFederator, cargohold.config.enableFederator and tags.federator!
     settings:
       maxConvAndTeamSize: 16
       maxTeamSize: 32

--- a/libs/metrics-wai/src/Data/Metrics/Servant.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Servant.hs
@@ -137,6 +137,9 @@ instance RoutesToPaths (Verb method status cts a) where
 instance RoutesToPaths (NoContentVerb method) where
   getRoutes = []
 
+instance RoutesToPaths (Stream method status framing ct a) where
+  getRoutes = []
+
 -- route :<|> routes
 instance
   ( RoutesToPaths route,

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
@@ -17,15 +17,33 @@
 
 module Wire.API.Federation.API.Cargohold where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Id
+import Imports
 import Servant.API
 import Servant.API.Generic
-import Wire.API.Federation.API.Common
+import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
+import Wire.API.Asset
+import Wire.API.Util.Aeson
+
+data GetAsset = GetAsset
+  { -- | User requesting the asset. Implictly qualified with the source domain.
+    gaUser :: UserId,
+    -- | Asset key for the asset to download. Implictly qualified with the
+    -- target domain.
+    gaKey :: AssetKey,
+    -- | Optional asset token.
+    gaToken :: Maybe AssetToken
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform GetAsset)
+  deriving (ToJSON, FromJSON) via (CustomEncoded GetAsset)
 
 data CargoholdApi routes = CargoholdApi
   { getAsset ::
       routes
         :- "get-asset"
-        :> ReqBody '[JSON] ()
-        :> Post '[JSON] EmptyResponse
+        :> ReqBody '[JSON] GetAsset
+        :> StreamPost NoFraming OctetStream (SourceIO ByteString)
   }
   deriving (Generic)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
@@ -25,6 +25,7 @@ import Servant.API.Generic
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import Wire.API.Asset
 import Wire.API.Util.Aeson
+import Wire.API.Routes.AssetBody
 
 data GetAsset = GetAsset
   { -- | User requesting the asset. Implictly qualified with the source domain.
@@ -55,6 +56,6 @@ data CargoholdApi routes = CargoholdApi
       routes
         :- "stream-asset"
         :> ReqBody '[JSON] GetAsset
-        :> StreamPost NoFraming OctetStream (SourceIO ByteString)
+        :> StreamPost NoFraming OctetStream AssetSource
   }
   deriving (Generic)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
@@ -24,8 +24,8 @@ import Servant.API
 import Servant.API.Generic
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import Wire.API.Asset
-import Wire.API.Util.Aeson
 import Wire.API.Routes.AssetBody
+import Wire.API.Util.Aeson
 
 data GetAsset = GetAsset
   { -- | User requesting the asset. Implictly qualified with the source domain.

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
@@ -39,10 +39,21 @@ data GetAsset = GetAsset
   deriving (Arbitrary) via (GenericUniform GetAsset)
   deriving (ToJSON, FromJSON) via (CustomEncoded GetAsset)
 
+data GetAssetResponse = GetAssetResponse
+  {gaAvailable :: Bool}
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform GetAssetResponse)
+  deriving (ToJSON, FromJSON) via (CustomEncoded GetAssetResponse)
+
 data CargoholdApi routes = CargoholdApi
   { getAsset ::
       routes
         :- "get-asset"
+        :> ReqBody '[JSON] GetAsset
+        :> Post '[JSON] GetAssetResponse,
+    streamAsset ::
+      routes
+        :- "stream-asset"
         :> ReqBody '[JSON] GetAsset
         :> StreamPost NoFraming OctetStream (SourceIO ByteString)
   }

--- a/libs/wire-api/src/Wire/API/Routes/AssetBody.hs
+++ b/libs/wire-api/src/Wire/API/Routes/AssetBody.hs
@@ -45,10 +45,10 @@ newtype AssetSource = AssetSource
   { getAssetSource ::
       ConduitT () ByteString (ResourceT IO) ()
   }
-  deriving newtype (FromSourceIO ByteString)
+  deriving newtype (FromSourceIO ByteString, ToSourceIO ByteString)
 
 instance ToSchema AssetSource where
-  declareNamedSchema _ = pure $ named "AssetSource" $ mempty
+  declareNamedSchema _ = pure $ named "AssetSource" mempty
 
 type AssetBody =
   StreamBody'

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -349,6 +349,7 @@ executable brig-integration
     , http-api-data
     , http-client
     , http-client-tls >=0.2
+    , http-media
     , http-types
     , imports
     , lens >=3.9

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 350e615ec20264419ad3244b5ba5b93c8a0bbea7dc35db5f300a3fbf3ef4e4c0
+-- hash: 2a5e368730d4530d05df5395f6b3157536513b1049130b541d257aa79296cb75
 
 name:           brig
 version:        2.0

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -226,6 +226,7 @@ executables:
     - http-api-data
     - http-client
     - http-client-tls >=0.2
+    - http-media
     - http-types
     - imports
     - lens >=3.9

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -1319,7 +1319,7 @@ testDeleteInternal brig cannon aws = do
 testDeleteWithProfilePic :: Brig -> CargoHold -> Http ()
 testDeleteWithProfilePic brig cargohold = do
   uid <- userId <$> createAnonUser "anon" brig
-  ast <- uploadAsset cargohold uid "this is my profile pic"
+  ast <- responseJsonError =<< uploadAsset cargohold uid "this is my profile pic"
   -- Ensure that the asset is there
   downloadAsset cargohold uid (ast ^. Asset.assetKey) !!! const 200 === statusCode
   let newAssets =

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -1319,7 +1319,7 @@ testDeleteInternal brig cannon aws = do
 testDeleteWithProfilePic :: Brig -> CargoHold -> Http ()
 testDeleteWithProfilePic brig cargohold = do
   uid <- userId <$> createAnonUser "anon" brig
-  ast <- responseJsonError =<< uploadAsset cargohold uid "this is my profile pic"
+  ast <- responseJsonError =<< uploadAsset cargohold uid Asset.defAssetSettings "this is my profile pic"
   -- Ensure that the asset is there
   downloadAsset cargohold uid (ast ^. Asset.assetKey) !!! const 200 === statusCode
   let newAssets =

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -27,7 +27,6 @@ import Brig.Types
 import Brig.Types.Team.LegalHold (LegalHoldClientRequest (..))
 import Brig.Types.User.Auth hiding (user)
 import qualified Brig.ZAuth
-import qualified CargoHold.Types.V3 as CHV3
 import qualified Codec.MIME.Type as MIME
 import Control.Lens (preview, (^?))
 import Control.Monad.Catch (MonadCatch)
@@ -409,23 +408,21 @@ uploadAsset ::
   CargoHold ->
   UserId ->
   ByteString ->
-  m CHV3.Asset
+  m (Response (Maybe LByteString))
 uploadAsset c usr dat = do
-  let sts = CHV3.defAssetSettings
+  let sts = defAssetSettings
       ct = MIME.Type (MIME.Application "text") []
-      mpb = CHV3.buildMultipartBody sts ct (LB.fromStrict dat)
-  rsp <-
-    post
-      ( c
-          . path "/assets/v3"
-          . zUser usr
-          . zConn "conn"
-          . content "multipart/mixed"
-          . lbytes (toLazyByteString mpb)
-      )
-      <!! const 201
-      === statusCode
-  responseJsonError rsp
+      mpb = buildMultipartBody sts ct (LB.fromStrict dat)
+  post
+    ( c
+        . path "/assets/v3"
+        . zUser usr
+        . zConn "conn"
+        . content "multipart/mixed"
+        . lbytes (toLazyByteString mpb)
+    )
+    <!! const 201
+    === statusCode
 
 downloadAsset ::
   (MonadIO m, MonadHttp m) =>

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -407,11 +407,11 @@ uploadAsset ::
   (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) =>
   CargoHold ->
   UserId ->
+  AssetSettings ->
   ByteString ->
   m (Response (Maybe LByteString))
-uploadAsset c usr dat = do
-  let sts = defAssetSettings
-      ct = MIME.Type (MIME.Application "text") []
+uploadAsset c usr sts dat = do
+  let ct = MIME.Type (MIME.Application "text") []
       mpb = buildMultipartBody sts ct (LB.fromStrict dat)
   post
     ( c

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -25,7 +25,7 @@ import Brig.API.Client (pubClient)
 import qualified Brig.Options as BrigOpts
 import Brig.Types hiding (assetKey)
 import Control.Arrow ((&&&))
-import Control.Lens (sequenceAOf, view, _1)
+import Control.Lens (sequenceAOf, view, (.~), _1)
 import qualified Data.Aeson as Aeson
 import Data.ByteString.Conversion (toByteString')
 import Data.Domain (Domain)
@@ -629,7 +629,8 @@ testRemoteAsset brig1 brig2 ch1 ch2 = do
   alice <- userQualifiedId <$> randomUser brig1
   bob <- userQualifiedId <$> randomUser brig2
 
-  ast <- responseJsonError =<< uploadAsset ch2 (qUnqualified bob) "hello world"
+  let sts = defAssetSettings & setAssetPublic .~ True
+  ast <- responseJsonError =<< uploadAsset ch2 (qUnqualified bob) sts "hello world"
   let qkey = view assetKey ast
 
   downloadAsset ch1 (qUnqualified alice) qkey

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -77,14 +77,14 @@ spec ::
   Manager ->
   Brig ->
   Galley ->
-  Cannon ->
   CargoHold ->
+  Cannon ->
   Endpoint ->
   Brig ->
   Galley ->
   CargoHold ->
   IO TestTree
-spec _brigOpts mg brig galley cannon cargohold _federator brigTwo galleyTwo cargoholdTwo =
+spec _brigOpts mg brig galley cargohold cannon _federator brigTwo galleyTwo cargoholdTwo =
   pure $
     testGroup
       "federation-end2end-user"

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -23,9 +23,9 @@ import Bilge
 import Bilge.Assert ((!!!), (<!!), (===))
 import Brig.API.Client (pubClient)
 import qualified Brig.Options as BrigOpts
-import Brig.Types
+import Brig.Types hiding (assetKey)
 import Control.Arrow ((&&&))
-import Control.Lens (sequenceAOf, _1)
+import Control.Lens (sequenceAOf, view, _1)
 import qualified Data.Aeson as Aeson
 import Data.ByteString.Conversion (toByteString')
 import Data.Domain (Domain)
@@ -49,6 +49,7 @@ import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
 import Util
 import Util.Options (Endpoint)
+import Wire.API.Asset
 import Wire.API.Conversation
 import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.Event.Conversation
@@ -77,11 +78,13 @@ spec ::
   Brig ->
   Galley ->
   Cannon ->
+  CargoHold ->
   Endpoint ->
   Brig ->
   Galley ->
+  CargoHold ->
   IO TestTree
-spec _brigOpts mg brig galley cannon _federator brigTwo galleyTwo =
+spec _brigOpts mg brig galley cannon cargohold _federator brigTwo galleyTwo cargoholdTwo =
   pure $
     testGroup
       "federation-end2end-user"
@@ -99,7 +102,8 @@ spec _brigOpts mg brig galley cannon _federator brigTwo galleyTwo =
         test mg "include remote users to new conversation" $ testRemoteUsersInNewConv brig galley brigTwo galleyTwo,
         test mg "send a message to a remote user" $ testSendMessage brig brigTwo galleyTwo cannon,
         test mg "send a message in a remote conversation" $ testSendMessageToRemoteConv brig brigTwo galley galleyTwo cannon,
-        test mg "delete user connected to remotes and in conversation with remotes" $ testDeleteUser brig brigTwo galley galleyTwo cannon
+        test mg "delete user connected to remotes and in conversation with remotes" $ testDeleteUser brig brigTwo galley galleyTwo cannon,
+        test mg "download remote asset" $ testRemoteAsset brig brigTwo cargohold cargoholdTwo
       ]
 
 -- | Path covered by this test:
@@ -619,3 +623,16 @@ testDeleteUser brig1 brig2 galley1 galley2 cannon1 = do
     WS.assertMatch_ (5 # Second) wsAlice $ matchDeleteUserNotification bobDel
     WS.assertMatch_ (5 # Second) wsAlice $ matchConvLeaveNotification conv1 bobDel [bobDel]
     WS.assertMatch_ (5 # Second) wsAlice $ matchConvLeaveNotification conv2 bobDel [bobDel]
+
+testRemoteAsset :: Brig -> Brig -> CargoHold -> CargoHold -> Http ()
+testRemoteAsset brig1 brig2 ch1 ch2 = do
+  alice <- userQualifiedId <$> randomUser brig1
+  bob <- userQualifiedId <$> randomUser brig2
+
+  ast <- responseJsonError =<< uploadAsset ch2 (qUnqualified bob) "hello world"
+  let qkey = view assetKey ast
+
+  downloadAsset ch1 (qUnqualified alice) qkey
+    !!! do
+      const 200 === statusCode
+      const (Just "hello world") === responseBody

--- a/services/brig/test/integration/Federation/Util.hs
+++ b/services/brig/test/integration/Federation/Util.hs
@@ -50,6 +50,7 @@ import GHC.IO.Exception (IOException (ioe_errno))
 import qualified Galley.Types.Teams.SearchVisibility as Team
 import Imports
 import qualified Network.HTTP.Client as HTTP
+import Network.HTTP.Media
 import Network.Socket
 import Network.Wai.Handler.Warp (Port)
 import Network.Wai.Test (Session)
@@ -73,7 +74,7 @@ withTempMockFederator :: Opt.Opts -> LByteString -> Session a -> IO (a, [Mock.Fe
 withTempMockFederator opts resp action =
   Mock.withTempMockFederator
     [("Content-Type", "application/json")]
-    (const (pure resp))
+    (const (pure ("application" // "json", resp)))
     $ \mockPort -> do
       let opts' =
             opts

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -74,6 +74,7 @@ import Wire.API.Federation.Domain
 data BackendConf = BackendConf
   { remoteBrig :: Endpoint,
     remoteGalley :: Endpoint,
+    remoteCargohold :: Endpoint,
     remoteFederatorInternal :: Endpoint,
     remoteFederatorExternal :: Endpoint
   }
@@ -84,6 +85,7 @@ instance FromJSON BackendConf where
     BackendConf
       <$> o .: "brig"
       <*> o .: "galley"
+      <*> o .: "cargohold"
       <*> o .: "federatorInternal"
       <*> o .: "federatorExternal"
 
@@ -118,6 +120,7 @@ runTests iConf brigOpts otherArgs = do
       f = federatorInternal iConf
       brigTwo = mkRequest $ remoteBrig (backendTwo iConf)
       galleyTwo = mkRequest $ remoteGalley (backendTwo iConf)
+      ch2 = mkRequest $ remoteCargohold (backendTwo iConf)
 
   let turnFile = Opts.servers . Opts.turn $ brigOpts
       turnFileV2 = (Opts.serversV2 . Opts.turn) brigOpts
@@ -143,7 +146,7 @@ runTests iConf brigOpts otherArgs = do
   createIndex <- Index.Create.spec brigOpts
   browseTeam <- TeamUserSearch.tests brigOpts mg g b
   userPendingActivation <- UserPendingActivation.tests brigOpts mg db b g s
-  federationEnd2End <- Federation.End2end.spec brigOpts mg b g c f brigTwo galleyTwo
+  federationEnd2End <- Federation.End2end.spec brigOpts mg b g ch c f brigTwo galleyTwo ch2
   federationEndpoints <- API.Federation.tests mg brigOpts b c fedBrigClient
   includeFederationTests <- (== Just "1") <$> Blank.getEnv "INTEGRATION_FEDERATION_TESTS"
   internalApi <- API.Internal.tests brigOpts mg db b (brig iConf) gd g

--- a/services/cargohold/cargohold.cabal
+++ b/services/cargohold/cargohold.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 915e3568610b72400bc699b63907a3c4d73e455b6f129cf9042da0dcd383e564
+-- hash: 93df3f250b8c522ed3f403bd28709754a4fb8a2c6bdddf1fdfda8af830f1a2b8
 
 name:           cargohold
 version:        1.5.0
@@ -136,6 +136,7 @@ executable cargohold-integration
   main-is: Main.hs
   other-modules:
       API
+      API.Federation
       API.Util
       API.V3
       Metrics
@@ -177,5 +178,6 @@ executable cargohold-integration
     , uuid >=1.3
     , wai-utilities >=0.12
     , wire-api
+    , wire-api-federation
     , yaml >=0.8
   default-language: Haskell2010

--- a/services/cargohold/cargohold.cabal
+++ b/services/cargohold/cargohold.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 72508174bb671f8fe70e1f2c55ec552085e259931b8ab57598e81e924c0fc69d
+-- hash: 1f988801cabe4cd973f420029e9c5bfb8f1b0e44346a00fc59741a5e14d4dbd6
 
 name:           cargohold
 version:        1.5.0
@@ -167,10 +167,15 @@ executable cargohold-integration
     , http-client-tls >=0.2
     , http-types >=0.8
     , imports
+    , kan-extensions
     , lens >=3.8
     , mime >=0.4
+    , mmorph
+    , mtl
     , optparse-applicative
     , safe >=0.3
+    , servant-client
+    , servant-client-core
     , tagged >=0.8
     , tasty >=1.0
     , tasty-hunit >=0.9

--- a/services/cargohold/cargohold.cabal
+++ b/services/cargohold/cargohold.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 93df3f250b8c522ed3f403bd28709754a4fb8a2c6bdddf1fdfda8af830f1a2b8
+-- hash: 72508174bb671f8fe70e1f2c55ec552085e259931b8ab57598e81e924c0fc69d
 
 name:           cargohold
 version:        1.5.0
@@ -156,7 +156,9 @@ executable cargohold-integration
     , bytestring-conversion >=0.2
     , cargohold
     , cargohold-types
+    , conduit
     , containers >=0.5
+    , cryptonite
     , data-default >=0.5
     , errors >=1.4
     , exceptions >=0.6

--- a/services/cargohold/cargohold.cabal
+++ b/services/cargohold/cargohold.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1f988801cabe4cd973f420029e9c5bfb8f1b0e44346a00fc59741a5e14d4dbd6
+-- hash: 8291075b6b5e2e43a811343e51abb02d402fbc38a5a3efd0928f3f1b4c769485
 
 name:           cargohold
 version:        1.5.0
@@ -75,6 +75,7 @@ library
     , http-client-openssl >=0.2
     , http-types >=0.8
     , imports
+    , kan-extensions
     , lens >=4.1
     , metrics-wai >=0.4
     , mime >=0.4
@@ -123,6 +124,7 @@ executable cargohold
     , http-client >=0.4
     , http-types >=0.8
     , imports
+    , kan-extensions
     , mime >=0.4
     , safe >=0.3
     , text >=1.1
@@ -163,8 +165,10 @@ executable cargohold-integration
     , errors >=1.4
     , exceptions >=0.6
     , extended
+    , federator
     , http-client >=0.4
     , http-client-tls >=0.2
+    , http-media
     , http-types >=0.8
     , imports
     , kan-extensions
@@ -183,6 +187,7 @@ executable cargohold-integration
     , time >=1.5
     , types-common >=0.7
     , uuid >=1.3
+    , wai
     , wai-utilities >=0.12
     , wire-api
     , wire-api-federation

--- a/services/cargohold/cargohold.cabal
+++ b/services/cargohold/cargohold.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3633e0db5e928a51056ef8474859ed8f6edf06bc84b9ade6db39f62c48bfce07
+-- hash: 915e3568610b72400bc699b63907a3c4d73e455b6f129cf9042da0dcd383e564
 
 name:           cargohold
 version:        1.5.0
@@ -34,6 +34,7 @@ library
       CargoHold.App
       CargoHold.AWS
       CargoHold.CloudFront
+      CargoHold.Federation
       CargoHold.Metrics
       CargoHold.Options
       CargoHold.Run

--- a/services/cargohold/cargohold.integration.yaml
+++ b/services/cargohold/cargohold.integration.yaml
@@ -2,6 +2,10 @@ cargohold:
   host: 0.0.0.0
   port: 8084
 
+federator:
+  host: 127.0.0.1
+  port: 8097
+
 aws:
   s3Bucket: dummy-bucket # <-- insert-bucket-name-here
   s3Endpoint: http://localhost:4570 # https://s3-eu-west-1.amazonaws.com:443

--- a/services/cargohold/package.yaml
+++ b/services/cargohold/package.yaml
@@ -71,6 +71,8 @@ executables:
     - base ==4.*
     - cargohold
     - cargohold-types
+    - conduit
+    - cryptonite
     - http-client-tls >=0.2
     - lens >=3.8
     - optparse-applicative

--- a/services/cargohold/package.yaml
+++ b/services/cargohold/package.yaml
@@ -74,8 +74,13 @@ executables:
     - conduit
     - cryptonite
     - http-client-tls >=0.2
+    - kan-extensions
     - lens >=3.8
+    - mmorph
+    - mtl
     - optparse-applicative
+    - servant-client-core
+    - servant-client
     - tagged >=0.8
     - tasty >=1.0
     - tasty-hunit >=0.9

--- a/services/cargohold/package.yaml
+++ b/services/cargohold/package.yaml
@@ -82,6 +82,7 @@ executables:
     - uuid >=1.3
     - wai-utilities >=0.12
     - wire-api
+    - wire-api-federation
   cargohold:
     main: src/Main.hs
     ghc-options:

--- a/services/cargohold/package.yaml
+++ b/services/cargohold/package.yaml
@@ -23,6 +23,7 @@ dependencies:
 - HsOpenSSL >=0.11
 - http-client >=0.4
 - http-types >=0.8
+- kan-extensions
 - mime >=0.4
 - safe >=0.3
 - text >=1.1
@@ -73,8 +74,9 @@ executables:
     - cargohold-types
     - conduit
     - cryptonite
+    - federator
     - http-client-tls >=0.2
-    - kan-extensions
+    - http-media
     - lens >=3.8
     - mmorph
     - mtl
@@ -87,6 +89,7 @@ executables:
     - time >=1.5
     - types-common >=0.7
     - uuid >=1.3
+    - wai
     - wai-utilities >=0.12
     - wire-api
     - wire-api-federation

--- a/services/cargohold/src/CargoHold/API/Federation.hs
+++ b/services/cargohold/src/CargoHold/API/Federation.hs
@@ -39,7 +39,13 @@ type FederationAPI = "federation" :> ToServantApi (FedApi 'Cargohold)
 federationSitemap :: ServerT FederationAPI Handler
 federationSitemap =
   genericServerT $
-    F.CargoholdApi {F.getAsset = getAsset}
+    F.CargoholdApi
+      { F.getAsset = getAsset,
+        F.streamAsset = streamAsset
+      }
 
-getAsset :: F.GetAsset -> Handler (SourceIO ByteString)
+streamAsset :: F.GetAsset -> Handler (SourceIO ByteString)
+streamAsset F.GetAsset {..} = throwE federationNotImplemented
+
+getAsset :: F.GetAsset -> Handler F.GetAssetResponse
 getAsset F.GetAsset {..} = throwE federationNotImplemented

--- a/services/cargohold/src/CargoHold/API/Federation.hs
+++ b/services/cargohold/src/CargoHold/API/Federation.hs
@@ -59,6 +59,4 @@ streamAsset ga = do
   AssetSource <$> S3.downloadV3 (F.gaKey ga)
 
 getAsset :: F.GetAsset -> Handler F.GetAssetResponse
-getAsset ga = do
-  available <- checkAsset ga
-  pure $ F.GetAssetResponse {F.gaAvailable = available}
+getAsset = fmap F.GetAssetResponse . checkAsset

--- a/services/cargohold/src/CargoHold/API/Federation.hs
+++ b/services/cargohold/src/CargoHold/API/Federation.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
@@ -30,7 +32,6 @@ import Servant.Server hiding (Handler)
 import Servant.Server.Generic
 import Wire.API.Federation.API
 import qualified Wire.API.Federation.API.Cargohold as F
-import Wire.API.Federation.API.Common
 import Wire.API.Federation.Error
 
 type FederationAPI = "federation" :> ToServantApi (FedApi 'Cargohold)
@@ -40,5 +41,5 @@ federationSitemap =
   genericServerT $
     F.CargoholdApi {F.getAsset = getAsset}
 
-getAsset :: () -> Handler EmptyResponse
-getAsset _ = throwE federationNotImplemented
+getAsset :: F.GetAsset -> Handler (SourceIO ByteString)
+getAsset F.GetAsset {..} = throwE federationNotImplemented

--- a/services/cargohold/src/CargoHold/API/Federation.hs
+++ b/services/cargohold/src/CargoHold/API/Federation.hs
@@ -26,6 +26,7 @@ where
 import CargoHold.API.Error
 import CargoHold.API.V3
 import CargoHold.App
+import qualified CargoHold.S3 as S3
 import Control.Error
 import Imports
 import Servant.API
@@ -34,7 +35,6 @@ import Servant.Server hiding (Handler)
 import Servant.Server.Generic
 import Wire.API.Federation.API
 import qualified Wire.API.Federation.API.Cargohold as F
-import qualified CargoHold.S3 as S3
 import Wire.API.Routes.AssetBody
 
 type FederationAPI = "federation" :> ToServantApi (FedApi 'Cargohold)

--- a/services/cargohold/src/CargoHold/API/Federation.hs
+++ b/services/cargohold/src/CargoHold/API/Federation.hs
@@ -49,7 +49,7 @@ federationSitemap =
 
 checkAsset :: F.GetAsset -> Handler Bool
 checkAsset ga =
-  fmap (maybe False (const True)) . runMaybeT $
+  fmap isJust . runMaybeT $
     checkMetadata Nothing (F.gaKey ga) (F.gaToken ga)
 
 streamAsset :: F.GetAsset -> Handler AssetSource

--- a/services/cargohold/src/CargoHold/Federation.hs
+++ b/services/cargohold/src/CargoHold/Federation.hs
@@ -60,7 +60,7 @@ downloadRemoteAsset usr rkey tok = do
     fmap gaAvailable . executeFederated rkey $
       getAsset clientRoutes ga
   if exists
-    then
+    then do
       fmap (Just . toSourceIO) . executeFederated rkey $
         streamAsset clientRoutes ga
     else pure Nothing

--- a/services/cargohold/src/CargoHold/Federation.hs
+++ b/services/cargohold/src/CargoHold/Federation.hs
@@ -61,7 +61,7 @@ downloadRemoteAsset usr rkey tok = do
       getAsset clientRoutes ga
   if exists
     then
-      fmap Just . executeFederated rkey $
+      fmap (Just . toSourceIO) . executeFederated rkey $
         streamAsset clientRoutes ga
     else pure Nothing
 

--- a/services/cargohold/src/CargoHold/Federation.hs
+++ b/services/cargohold/src/CargoHold/Federation.hs
@@ -1,0 +1,75 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module CargoHold.Federation where
+
+import CargoHold.App
+import CargoHold.Options
+import Control.Error
+import Control.Lens
+import Data.Id
+import Data.Qualified
+import Imports hiding (head)
+import Servant.API
+import Wire.API.Asset
+import Wire.API.Federation.API
+import Wire.API.Federation.API.Cargohold
+import Wire.API.Federation.Client
+import Wire.API.Federation.Error
+
+-- [Note]
+-- There are several ways a remote asset could be streamed to the client:
+--
+-- "all-the-way": the remote federator streams the asset back to us in the RPC
+--    itself, and we forward it to the client
+-- "two-step": the remote federator returns a redirect response, we follow it
+--    and stream the data to the client
+-- "one-step": the remote federator returns a redirect response, and we simply
+--    forward it to the client
+--
+-- For now, only the "all-the-way" solution is implemented. Note that the asset
+-- is streamed back through our outward federator, as well as the remote one.
+
+downloadRemoteAsset ::
+  Local UserId ->
+  Remote AssetKey ->
+  Maybe AssetToken ->
+  Handler (Maybe (SourceIO ByteString))
+downloadRemoteAsset usr rkey tok =
+  fmap Just . executeFederated rkey $
+    getAsset
+      clientRoutes
+      GetAsset
+        { gaKey = tUnqualified rkey,
+          gaUser = tUnqualified usr,
+          gaToken = tok
+        }
+
+executeFederated :: Remote x -> FederatorClient 'Cargohold a -> Handler a
+executeFederated remote c = do
+  loc <- view localUnit
+  endpoint <-
+    view (options . optFederator)
+      >>= maybe (throwE federationNotConfigured) pure
+  let env =
+        FederatorClientEnv
+          { ceOriginDomain = tDomain loc,
+            ceTargetDomain = tDomain remote,
+            ceFederator = endpoint
+          }
+  liftIO (runFederatorClient @'Cargohold env c)
+    >>= either (throwE . federationErrorToWai . FederationCallFailure) pure

--- a/services/cargohold/src/CargoHold/Options.hs
+++ b/services/cargohold/src/CargoHold/Options.hs
@@ -98,11 +98,15 @@ deriveFromJSON toOptionFieldName ''Settings
 
 makeLenses ''Settings
 
+-- | Options consist of information the server needs to operate, and 'Settings'
+-- modify the behavior.
 data Opts = Opts
   { -- | Hostname and port to bind to
     _optCargohold :: !Endpoint,
     _optAws :: !AWSOpts,
     _optSettings :: !Settings,
+    -- | Federator endpoint
+    _optFederator :: Maybe Endpoint,
     -- Logging
 
     -- | Log level (Debug, Info, etc)

--- a/services/cargohold/src/CargoHold/S3.hs
+++ b/services/cargohold/src/CargoHold/S3.hs
@@ -23,6 +23,7 @@ module CargoHold.S3
   ( S3AssetKey,
     S3AssetMeta (..),
     uploadV3,
+    downloadV3,
     getMetadataV3,
     updateMetadataV3,
     deleteV3,
@@ -50,7 +51,7 @@ import Data.ByteString.Builder (toLazyByteString)
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.CaseInsensitive as CI
-import qualified Data.Conduit.Binary as Conduit
+import Data.Conduit.Binary
 import qualified Data.HashMap.Lazy as HML
 import Data.Id
 import qualified Data.Text as Text
@@ -95,7 +96,7 @@ uploadV3 ::
   V3.AssetKey ->
   V3.AssetHeaders ->
   Maybe V3.AssetToken ->
-  Conduit.ConduitM () ByteString (ResourceT IO) () ->
+  ConduitM () ByteString (ResourceT IO) () ->
   ExceptT Error App ()
 uploadV3 prc (s3Key . mkKey -> key) originalHeaders@(V3.AssetHeaders _ cl) tok src = do
   Log.info $
@@ -115,9 +116,9 @@ uploadV3 prc (s3Key . mkKey -> key) originalHeaders@(V3.AssetHeaders _ cl) tok s
       src
         -- Rechunk bytestream to ensure we satisfy AWS's minimum chunk size
         -- on uploads
-        .| Conduit.chunksOfCE (fromIntegral defaultChunkSize)
+        .| chunksOfCE (fromIntegral defaultChunkSize)
         -- Ignore any 'junk' after the content; take only 'cl' bytes.
-        .| Conduit.isolate (fromIntegral cl)
+        .| isolate (fromIntegral cl)
 
     reqBdy :: ChunkedBody
     reqBdy = ChunkedBody defaultChunkSize (fromIntegral cl) stream
@@ -127,6 +128,16 @@ uploadV3 prc (s3Key . mkKey -> key) originalHeaders@(V3.AssetHeaders _ cl) tok s
       putObject (BucketName b) (ObjectKey key) (toBody reqBdy)
         & poContentType ?~ MIME.showType ct
         & poMetadata .~ metaHeaders tok prc
+
+downloadV3 ::
+  V3.AssetKey ->
+  ExceptT Error App (ConduitM () ByteString (ResourceT IO) ())
+downloadV3 (s3Key . mkKey -> key) = do
+   _streamBody . view gorsBody <$> exec req 
+  where
+    req :: Text -> GetObject
+    req b = getObject (BucketName b) (ObjectKey key) 
+             & goResponseContentType ?~ MIME.showType octets
 
 getMetadataV3 :: V3.AssetKey -> ExceptT Error App (Maybe S3AssetMeta)
 getMetadataV3 (s3Key . mkKey -> key) = do

--- a/services/cargohold/test/integration/API.hs
+++ b/services/cargohold/test/integration/API.hs
@@ -276,10 +276,11 @@ testRemoteDownloadNoAsset = do
   (_, reqs) <- withMockFederator respond $ do
     downloadAsset uid qkey () !!! do
       const 404 === statusCode
+  localDomain <- viewFederationDomain
   liftIO $
     reqs
       @?= [ FederatedRequest
-              { frOriginDomain = Domain "example.com",
+              { frOriginDomain = localDomain,
                 frTargetDomain = Domain "faraway.example.com",
                 frComponent = Cargohold,
                 frRPC = "get-asset",
@@ -303,18 +304,19 @@ testRemoteDownload = do
       const 200 === statusCode
       const (Just "asset content") === responseBody
 
+  localDomain <- viewFederationDomain
   let ga = Aeson.encode (GetAsset uid key Nothing)
   liftIO $
     reqs
       @?= [ FederatedRequest
-              { frOriginDomain = Domain "example.com",
+              { frOriginDomain = localDomain,
                 frTargetDomain = Domain "faraway.example.com",
                 frComponent = Cargohold,
                 frRPC = "get-asset",
                 frBody = ga
               },
             FederatedRequest
-              { frOriginDomain = Domain "example.com",
+              { frOriginDomain = localDomain,
                 frTargetDomain = Domain "faraway.example.com",
                 frComponent = Cargohold,
                 frRPC = "stream-asset",

--- a/services/cargohold/test/integration/API.hs
+++ b/services/cargohold/test/integration/API.hs
@@ -268,3 +268,4 @@ testRemoteDownload = do
       void $
         downloadAsset uid qkey () <!! do
           const 200 === statusCode
+          const (Just "asset content") === responseBody

--- a/services/cargohold/test/integration/API.hs
+++ b/services/cargohold/test/integration/API.hs
@@ -41,20 +41,20 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import TestSetup
 
-tests :: FilePath -> TestTree
-tests configPath =
+tests :: IO TestSetup -> TestTree
+tests s =
   testGroup
     "API Integration"
     [ testGroup
         "simple"
-        [ test configPath "roundtrip" testSimpleRoundtrip,
-          test configPath "tokens" testSimpleTokens,
-          test configPath "s3-upstream-closed" testSimpleS3ClosedConnectionReuse,
-          test configPath "client-compatibility" testUploadCompatibility
+        [ test s "roundtrip" testSimpleRoundtrip,
+          test s "tokens" testSimpleTokens,
+          test s "s3-upstream-closed" testSimpleS3ClosedConnectionReuse,
+          test s "client-compatibility" testUploadCompatibility
         ],
       testGroup
         "remote"
-        [ test configPath "download" testRemoteDownload
+        [ test s "download" testRemoteDownload
         ]
     ]
 

--- a/services/cargohold/test/integration/API/Federation.hs
+++ b/services/cargohold/test/integration/API/Federation.hs
@@ -1,0 +1,62 @@
+module API.Federation (tests) where
+
+import API.Util
+import Bilge
+import Bilge.Assert
+import Control.Lens
+import Data.Id
+import Data.Qualified
+import Data.UUID.V4
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+import TestSetup
+import Wire.API.Asset
+import Wire.API.Federation.API.Cargohold
+
+tests :: IO TestSetup -> TestTree
+tests s =
+  testGroup
+    "API Federation"
+    [ testGroup
+        "Streaming - get-asset"
+        [ test s "available " testGetAssetAvailable,
+          test s "not available " testGetAssetNotAvailable
+        ]
+        -- TODO: is not available case
+    ]
+
+testGetAssetAvailable :: TestSignature ()
+testGetAssetAvailable c = do
+  -- Initial upload
+  let bdy = (applicationOctetStream, "Hello World")
+      settings = defAssetSettings & set setAssetRetention (Just AssetVolatile)
+  uid <- liftIO $ Id <$> nextRandom
+  ast :: Asset <-
+    responseJsonError
+      =<< uploadSimple (c . path "/assets/v3") uid settings bdy
+      <!! const 201 === statusCode
+
+  -- Call get-asset federation API
+  let tok = view assetToken ast
+  let key = view assetKey ast
+  let ga =
+        GetAsset
+          { gaUser = uid,
+            gaToken = tok,
+            gaKey = qUnqualified key
+          }
+  ok <-
+    fmap gaAvailable . responseJsonError
+      =<< get (c . path "/federation/get-asset" . json ga)
+      <!! const 200 === statusCode
+
+  -- check that asset is available
+  liftIO $ ok @?= True
+
+testGetAssetNotAvailable :: TestSignature ()
+testGetAssetNotAvailable _ = do
+  pure ()
+
+-- uid <- Id <$> nextRandom
+-- let ga = GetAsset { gaUserId = uid, gaToken = Nothing, gaKey =

--- a/services/cargohold/test/integration/API/Federation.hs
+++ b/services/cargohold/test/integration/API/Federation.hs
@@ -13,6 +13,7 @@ import Data.Qualified
 import Data.UUID.V4
 import Imports
 import qualified Network.HTTP.Types as HTTP
+import qualified Network.Wai.Utilities.Error as Wai
 import Test.Tasty
 import Test.Tasty.HUnit
 import TestSetup
@@ -33,7 +34,9 @@ tests s =
       testGroup
         "stream-asset"
         [ test s "streaming large asset" testLargeAsset,
-          test s "stream an asset" testStreamAsset
+          test s "stream an asset" testStreamAsset,
+          test s "stream asset not available" testStreamAssetNotAvailable,
+          test s "stream asset wrong token" testStreamAssetWrongToken
         ]
     ]
 
@@ -185,3 +188,48 @@ testStreamAsset c = do
         <!! const 200 === statusCode
 
   liftIO $ respBody @?= Just "Hello World"
+
+testStreamAssetNotAvailable :: TestSignature ()
+testStreamAssetNotAvailable c = do
+  uid <- liftIO $ Id <$> nextRandom
+  token <- randToken
+
+  assetId <- liftIO $ Id <$> nextRandom
+  let key = AssetKeyV3 assetId AssetPersistent
+  let ga =
+        GetAsset
+          { gaUser = uid,
+            gaToken = Just token,
+            gaKey = key
+          }
+  err <-
+    responseJsonError
+      =<< post (c . path "/federation/stream-asset" . json ga)
+      <!! const 404 === statusCode
+  liftIO $ Wai.label err @?= "not-found"
+
+testStreamAssetWrongToken :: TestSignature ()
+testStreamAssetWrongToken c = do
+  -- Initial upload
+  let bdy = (applicationOctetStream, "Hello World")
+      settings = defAssetSettings & set setAssetRetention (Just AssetVolatile)
+  uid <- liftIO $ Id <$> nextRandom
+  ast :: Asset <-
+    responseJsonError
+      =<< uploadSimple (c . path "/assets/v3") uid settings bdy
+      <!! const 201 === statusCode
+
+  -- Call get-asset federation API with wrong (random) token
+  tok <- randToken
+  let key = view assetKey ast
+  let ga =
+        GetAsset
+          { gaUser = uid,
+            gaToken = Just tok,
+            gaKey = qUnqualified key
+          }
+  err <-
+    responseJsonError
+      =<< post (c . path "/federation/stream-asset" . json ga)
+      <!! const 404 === statusCode
+  liftIO $ Wai.label err @?= "not-found"

--- a/services/cargohold/test/integration/API/Federation.hs
+++ b/services/cargohold/test/integration/API/Federation.hs
@@ -4,11 +4,13 @@ import API.Util
 import Bilge
 import Bilge.Assert
 import CargoHold.API.V3 (randToken)
+import Conduit
 import Control.Lens
 import Data.Id
 import Data.Qualified
 import Data.UUID.V4
 import Imports
+import qualified Network.HTTP.Types as HTTP
 import Test.Tasty
 import Test.Tasty.HUnit
 import TestSetup
@@ -20,12 +22,15 @@ tests s =
   testGroup
     "API Federation"
     [ testGroup
-        "Streaming - get-asset"
+        "get-asset"
         [ test s "private asset is available" (testGetAssetAvailable False),
           test s "public asset is available" (testGetAssetAvailable True),
           test s "not available" testGetAssetNotAvailable,
           test s "wrong token" testGetAssetWrongToken
-        ]
+        ],
+      testGroup
+        "stream-asset"
+        [test s "streaming large asset" testLargeAsset]
     ]
 
 testGetAssetAvailable :: Bool -> TestSignature ()
@@ -107,3 +112,31 @@ testGetAssetWrongToken c = do
 
   -- check that asset is not available
   liftIO $ ok @?= False
+
+testLargeAsset :: TestSignature ()
+testLargeAsset c = do
+  -- Initial upload
+  let size = 1024 * 1024
+      settings =
+        defAssetSettings
+          & set setAssetRetention (Just AssetVolatile)
+  uid <- liftIO $ Id <$> nextRandom
+  ast :: Asset <-
+    responseJsonError
+      =<< uploadRandom (c . path "/assets/v3") uid settings applicationOctetStream size
+      <!! const 201 === statusCode
+
+  -- Call get-asset federation API
+  let tok = view assetToken ast
+  let key = view assetKey ast
+  let ga =
+        GetAsset
+          { gaUser = uid,
+            gaToken = tok,
+            gaKey = qUnqualified key
+          }
+  http empty (method HTTP.POST . c . path "/federation/stream-asset" . json ga) $ \resp -> do
+    statusCode resp @?= 200
+    -- check that the first chunk is received
+    chunk <- responseBody resp
+    print chunk

--- a/services/cargohold/test/integration/API/Federation.hs
+++ b/services/cargohold/test/integration/API/Federation.hs
@@ -20,23 +20,23 @@ import TestSetup
 import Wire.API.Asset
 import Wire.API.Federation.API.Cargohold
 
-tests :: FilePath -> TestTree
-tests configPath =
+tests :: IO TestSetup -> TestTree
+tests s =
   testGroup
     "API Federation"
     [ testGroup
         "get-asset"
-        [ test configPath "private asset is available" (testGetAssetAvailable False),
-          test configPath "public asset is available" (testGetAssetAvailable True),
-          test configPath "not available" testGetAssetNotAvailable,
-          test configPath "wrong token" testGetAssetWrongToken
+        [ test s "private asset is available" (testGetAssetAvailable False),
+          test s "public asset is available" (testGetAssetAvailable True),
+          test s "not available" testGetAssetNotAvailable,
+          test s "wrong token" testGetAssetWrongToken
         ],
       testGroup
         "stream-asset"
-        [ test configPath "streaming large asset" testLargeAsset,
-          test configPath "stream an asset" testStreamAsset,
-          test configPath "stream asset not available" testStreamAssetNotAvailable,
-          test configPath "stream asset wrong token" testStreamAssetWrongToken
+        [ test s "streaming large asset" testLargeAsset,
+          test s "stream an asset" testStreamAsset,
+          test s "stream asset not available" testStreamAssetNotAvailable,
+          test s "stream asset wrong token" testStreamAssetWrongToken
         ]
     ]
 

--- a/services/cargohold/test/integration/API/Federation.hs
+++ b/services/cargohold/test/integration/API/Federation.hs
@@ -13,6 +13,7 @@ import Test.Tasty.HUnit
 import TestSetup
 import Wire.API.Asset
 import Wire.API.Federation.API.Cargohold
+import CargoHold.API.V3 (randToken)
 
 tests :: IO TestSetup -> TestTree
 tests s =
@@ -21,9 +22,9 @@ tests s =
     [ testGroup
         "Streaming - get-asset"
         [ test s "available " testGetAssetAvailable,
-          test s "not available " testGetAssetNotAvailable
+          test s "not available" testGetAssetNotAvailable,
+          test s "wrong token" testGetAssetWrongToken
         ]
-        -- TODO: is not available case
     ]
 
 testGetAssetAvailable :: TestSignature ()
@@ -48,15 +49,57 @@ testGetAssetAvailable c = do
           }
   ok <-
     fmap gaAvailable . responseJsonError
-      =<< get (c . path "/federation/get-asset" . json ga)
+      =<< post (c . path "/federation/get-asset" . json ga)
       <!! const 200 === statusCode
 
   -- check that asset is available
   liftIO $ ok @?= True
 
 testGetAssetNotAvailable :: TestSignature ()
-testGetAssetNotAvailable _ = do
-  pure ()
+testGetAssetNotAvailable c = do
+  uid <- liftIO $ Id <$> nextRandom
+  token <- randToken
 
--- uid <- Id <$> nextRandom
--- let ga = GetAsset { gaUserId = uid, gaToken = Nothing, gaKey =
+  assetId <- liftIO $ Id <$> nextRandom
+  let key = AssetKeyV3 assetId AssetPersistent 
+  let ga =
+        GetAsset
+          { gaUser = uid,
+            gaToken = Just token,
+            gaKey = key
+          }
+  ok <-
+    fmap gaAvailable . responseJsonError
+      =<< post (c . path "/federation/get-asset" . json ga)
+      <!! const 200 === statusCode
+
+  -- check that asset is not available
+  liftIO $ ok @?= False 
+
+testGetAssetWrongToken :: TestSignature ()
+testGetAssetWrongToken c = do
+   -- Initial upload
+  let bdy = (applicationOctetStream, "Hello World")
+      settings = defAssetSettings & set setAssetRetention (Just AssetVolatile)
+  uid <- liftIO $ Id <$> nextRandom
+  ast :: Asset <-
+    responseJsonError
+      =<< uploadSimple (c . path "/assets/v3") uid settings bdy
+      <!! const 201 === statusCode
+
+  -- Call get-asset federation API with wrong (random) token
+  tok <- randToken  
+  let key = view assetKey ast
+  let ga =
+        GetAsset
+          { gaUser = uid,
+            gaToken = Just tok,
+            gaKey = qUnqualified key
+          }
+  ok <-
+    fmap gaAvailable . responseJsonError
+      =<< post (c . path "/federation/get-asset" . json ga)
+      <!! const 200 === statusCode
+
+  -- check that asset is not available
+  liftIO $ ok @?= False

--- a/services/cargohold/test/integration/API/Util.hs
+++ b/services/cargohold/test/integration/API/Util.hs
@@ -25,6 +25,7 @@ import qualified Codec.MIME.Type as MIME
 import Control.Lens (set, view, _Just)
 import Control.Monad.Catch
 import Control.Monad.Codensity
+import Crypto.Random
 import Data.ByteString.Builder
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
@@ -41,7 +42,6 @@ import qualified Network.Wai as Wai
 import TestSetup
 import Util.Options
 import Wire.API.Asset
-import Crypto.Random
 
 uploadSimple ::
   (Request -> Request) ->

--- a/services/cargohold/test/integration/API/Util.hs
+++ b/services/cargohold/test/integration/API/Util.hs
@@ -18,9 +18,9 @@
 module API.Util where
 
 import Bilge hiding (body)
-import qualified CargoHold.Types.V3 as V3
 import qualified Codec.MIME.Parse as MIME
 import qualified Codec.MIME.Type as MIME
+import Crypto.Random
 import Data.ByteString.Builder
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
@@ -32,15 +32,16 @@ import Imports hiding (head)
 import Network.HTTP.Types.Header
 import Network.HTTP.Types.Method
 import TestSetup
+import Wire.API.Asset
 
 uploadSimple ::
   CargoHold ->
   UserId ->
-  V3.AssetSettings ->
+  AssetSettings ->
   (MIME.Type, ByteString) ->
   Http (Response (Maybe Lazy.ByteString))
 uploadSimple c usr sets (ct, bs) =
-  let mp = V3.buildMultipartBody sets ct (Lazy.fromStrict bs)
+  let mp = buildMultipartBody sets ct (Lazy.fromStrict bs)
    in uploadRaw c usr (toLazyByteString mp)
 
 decodeHeaderOrFail :: (HasCallStack, FromByteString a) => HeaderName -> Response b -> a
@@ -48,6 +49,17 @@ decodeHeaderOrFail h =
   fromMaybe (error $ "decodeHeaderOrFail: missing or invalid header: " ++ show h)
     . fromByteString
     . getHeader' h
+
+uploadRandom ::
+  CargoHold ->
+  UserId ->
+  AssetSettings ->
+  MIME.Type ->
+  Int ->
+  Http (Response (Maybe LByteString))
+uploadRandom c usr settings ct size = do
+  bs <- liftIO $ getRandomBytes size
+  uploadSimple c usr settings (ct, bs)
 
 uploadRaw ::
   CargoHold ->
@@ -78,10 +90,10 @@ zUser = header "Z-User" . UUID.toASCIIBytes . toUUID
 zConn :: ByteString -> Request -> Request
 zConn = header "Z-Connection"
 
-deleteAssetV3 :: CargoHold -> UserId -> Qualified V3.AssetKey -> Http (Response (Maybe Lazy.ByteString))
+deleteAssetV3 :: CargoHold -> UserId -> Qualified AssetKey -> Http (Response (Maybe Lazy.ByteString))
 deleteAssetV3 c u k = delete $ c . zUser u . paths ["assets", "v3", toByteString' (qUnqualified k)]
 
-deleteAsset :: CargoHold -> UserId -> Qualified V3.AssetKey -> Http (Response (Maybe Lazy.ByteString))
+deleteAsset :: CargoHold -> UserId -> Qualified AssetKey -> Http (Response (Maybe Lazy.ByteString))
 deleteAsset c u k =
   delete $
     c . zUser u

--- a/services/cargohold/test/integration/API/Util.hs
+++ b/services/cargohold/test/integration/API/Util.hs
@@ -28,6 +28,7 @@ import Control.Monad.Codensity
 import Data.ByteString.Builder
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
+import Data.Domain
 import Data.Id
 import Data.Qualified
 import Data.Text.Encoding (decodeLatin1)
@@ -156,6 +157,9 @@ deleteToken uid key = do
   delete $
     c . zUser uid
       . paths ["assets", "v3", toByteString' key, "token"]
+
+viewFederationDomain :: TestM Domain
+viewFederationDomain = view (tsOpts . optSettings . setFederationDomain)
 
 --------------------------------------------------------------------------------
 -- Mocking utilities

--- a/services/cargohold/test/integration/API/Util.hs
+++ b/services/cargohold/test/integration/API/Util.hs
@@ -174,8 +174,10 @@ withSettingsOverrides f action = do
   liftIO . lowerCodensity $ do
     (app, _) <- mkApp opts
     p <- withMockServer app
-    let setEndpoint = (epPort .~ p) . (epHost .~ "127.0.0.1")
-    liftIO $ runTestM (ts & tsEndpoint %~ setEndpoint) action
+    liftIO $ runTestM (ts & tsEndpoint %~ setLocalEndpoint p) action
+
+setLocalEndpoint :: Word16 -> Endpoint -> Endpoint
+setLocalEndpoint p = (epPort .~ p) . (epHost .~ "127.0.0.1")
 
 withMockFederator ::
   (FederatedRequest -> IO (HTTP.MediaType, LByteString)) ->
@@ -184,5 +186,5 @@ withMockFederator ::
 withMockFederator respond action = do
   withTempMockFederator [] respond $ \p ->
     withSettingsOverrides
-      (set (optFederator . _Just . epPort) (fromIntegral p))
+      (optFederator . _Just %~ setLocalEndpoint (fromIntegral p))
       action

--- a/services/cargohold/test/integration/API/Util.hs
+++ b/services/cargohold/test/integration/API/Util.hs
@@ -20,7 +20,6 @@ module API.Util where
 import Bilge hiding (body)
 import qualified Codec.MIME.Parse as MIME
 import qualified Codec.MIME.Type as MIME
-import Crypto.Random
 import Data.ByteString.Builder
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
@@ -33,6 +32,7 @@ import Network.HTTP.Types.Header
 import Network.HTTP.Types.Method
 import TestSetup
 import Wire.API.Asset
+import Crypto.Random
 
 uploadSimple ::
   CargoHold ->

--- a/services/cargohold/test/integration/API/Util.hs
+++ b/services/cargohold/test/integration/API/Util.hs
@@ -25,7 +25,6 @@ import qualified Codec.MIME.Type as MIME
 import Control.Lens (set, view, _Just)
 import Control.Monad.Catch
 import Control.Monad.Codensity
-import Crypto.Random
 import Data.ByteString.Builder
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
@@ -58,17 +57,6 @@ decodeHeaderOrFail h =
   fromMaybe (error $ "decodeHeaderOrFail: missing or invalid header: " ++ show h)
     . fromByteString
     . getHeader' h
-
-uploadRandom ::
-  Cargohold ->
-  UserId ->
-  AssetSettings ->
-  MIME.Type ->
-  Int ->
-  TestM (Response (Maybe LByteString))
-uploadRandom c usr settings ct size = do
-  bs <- liftIO $ getRandomBytes size
-  uploadSimple c usr settings (ct, bs)
 
 uploadRaw ::
   (Request -> Request) ->

--- a/services/cargohold/test/integration/API/V3.hs
+++ b/services/cargohold/test/integration/API/V3.hs
@@ -38,13 +38,13 @@ import Test.Tasty.HUnit
 import TestSetup
 import Wire.API.Asset
 
-tests :: FilePath -> TestTree
-tests configPath =
+tests :: IO TestSetup -> TestTree
+tests s =
   testGroup
     "API Integration v3"
     [ testGroup
         "simple"
-        [test configPath "roundtrip using v3 API" testSimpleRoundtrip]
+        [test s "roundtrip using v3 API" testSimpleRoundtrip]
     ]
 
 --------------------------------------------------------------------------------

--- a/services/cargohold/test/integration/Main.hs
+++ b/services/cargohold/test/integration/Main.hs
@@ -38,6 +38,7 @@ import TestSetup
 import Util.Options
 import Util.Options.Common
 import Util.Test
+import API.Federation (tests)
 
 data IntegrationConfig = IntegrationConfig
   -- internal endpoint
@@ -84,7 +85,8 @@ main = runTests go
         "Cargohold"
         [ API.tests opts,
           API.V3.tests opts,
-          Metrics.tests opts
+          Metrics.tests opts,
+          API.Federation.tests opts
         ]
     getOpts _ i = do
       -- TODO: It would actually be useful to read some

--- a/services/cargohold/test/integration/Main.hs
+++ b/services/cargohold/test/integration/Main.hs
@@ -53,19 +53,20 @@ main :: IO ()
 main = do
   defaultMainWithIngredients ings $
     askOption $ \(IntegrationConfigFile configPath) ->
-      -- we treat the configuration file as a tasty "resource", so that we can
-      -- read it once before all tests
-      withResource
-        (createTestSetup configPath)
-        (const (pure ()))
-        $ \ts ->
-          testGroup
-            "Cargohold"
-            [ API.tests ts,
-              API.V3.tests ts,
-              Metrics.tests ts,
-              API.Federation.tests ts
-            ]
+      askOption $ \(ServiceConfigFile optsPath) ->
+        -- we treat the configuration file as a tasty "resource", so that we can
+        -- read it once before all tests
+        withResource
+          (createTestSetup optsPath configPath)
+          (const (pure ()))
+          $ \ts ->
+            testGroup
+              "Cargohold"
+              [ API.tests ts,
+                API.V3.tests ts,
+                Metrics.tests ts,
+                API.Federation.tests ts
+              ]
   where
     ings =
       includingOptions

--- a/services/cargohold/test/integration/Metrics.hs
+++ b/services/cargohold/test/integration/Metrics.hs
@@ -26,11 +26,12 @@ import Imports
 import Test.Tasty
 import TestSetup
 
-tests :: IO TestSetup -> TestTree
-tests s = testGroup "Metrics" [test s "prometheus" testPrometheusMetrics]
+tests :: FilePath -> TestTree
+tests configPath = testGroup "Metrics" [test configPath "prometheus" testPrometheusMetrics]
 
-testPrometheusMetrics :: TestSignature ()
-testPrometheusMetrics cargohold =
+testPrometheusMetrics :: TestM ()
+testPrometheusMetrics = do
+  cargohold <- viewCargohold
   get (cargohold . path "/i/metrics") !!! do
     const 200 === statusCode
     -- Should contain the request duration metric in its output

--- a/services/cargohold/test/integration/Metrics.hs
+++ b/services/cargohold/test/integration/Metrics.hs
@@ -26,8 +26,8 @@ import Imports
 import Test.Tasty
 import TestSetup
 
-tests :: FilePath -> TestTree
-tests configPath = testGroup "Metrics" [test configPath "prometheus" testPrometheusMetrics]
+tests :: IO TestSetup -> TestTree
+tests s = testGroup "Metrics" [test s "prometheus" testPrometheusMetrics]
 
 testPrometheusMetrics :: TestM ()
 testPrometheusMetrics = do

--- a/services/cargohold/test/integration/TestSetup.hs
+++ b/services/cargohold/test/integration/TestSetup.hs
@@ -48,4 +48,4 @@ test s n h = testCase n runTest
   where
     runTest = do
       setup <- s
-      (void $ runHttpT (setup ^. tsManager) (h (setup ^. tsCargohold)))
+      void $ runHttpT (setup ^. tsManager) (h (setup ^. tsCargohold))

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 36d6439a89df818d535b525df7fa1c14f6dd1a1f82f0449d61e5c8a81134386e
+-- hash: 292e08dea16bd9d7d61af769a915f4186507ba5d61e292d6f5380f3ea149aa8d
 
 name:           federator
 version:        1.0.0
@@ -200,7 +200,8 @@ executable federator-integration
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DerivingStrategies DerivingVia DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PackageImports PatternSynonyms PolyKinds QuasiQuotes RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
   build-depends:
-      aeson
+      QuickCheck
+    , aeson
     , async
     , base
     , bilge

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 371580e0c3adbdb4994c74a23ada11c91023bc654f2f0fe304ead7e88a3b8ba6
+-- hash: 36d6439a89df818d535b525df7fa1c14f6dd1a1f82f0449d61e5c8a81134386e
 
 name:           federator
 version:        1.0.0
@@ -80,6 +80,7 @@ library
     , hinotify
     , http-client
     , http-client-openssl
+    , http-media
     , http-types
     , http2
     , imports
@@ -147,6 +148,7 @@ executable federator
     , hinotify
     , http-client
     , http-client-openssl
+    , http-media
     , http-types
     , http2
     , imports
@@ -223,6 +225,7 @@ executable federator-integration
     , http-client
     , http-client-openssl
     , http-client-tls
+    , http-media
     , http-types
     , http2
     , imports
@@ -307,6 +310,7 @@ test-suite federator-tests
     , hinotify
     , http-client
     , http-client-openssl
+    , http-media
     , http-types
     , http2
     , imports

--- a/services/federator/package.yaml
+++ b/services/federator/package.yaml
@@ -29,6 +29,7 @@ dependencies:
 - hinotify
 - http-client
 - http-client-openssl
+- http-media
 - http-types
 - http2
 - kan-extensions

--- a/services/federator/package.yaml
+++ b/services/federator/package.yaml
@@ -94,6 +94,7 @@ executables:
     - http-client-tls
     - mtl
     - optparse-applicative
+    - QuickCheck
     - random
     - retry
     - tasty

--- a/services/federator/src/Federator/MockServer.hs
+++ b/services/federator/src/Federator/MockServer.hs
@@ -160,7 +160,7 @@ withTempMockFederator headers resp action = do
                           frBody = rdBody
                         }
                     )
-              embed @IO $ modifyIORef remoteCalls $ (<> [fedRequest])
+              embed @IO $ modifyIORef remoteCalls (<> [fedRequest])
               (ct, body) <-
                 fromException @MockException
                   . handle (throw . handleException)

--- a/services/federator/src/Federator/MockServer.hs
+++ b/services/federator/src/Federator/MockServer.hs
@@ -39,6 +39,7 @@ import Federator.InternalServer
 import Federator.Response
 import Federator.Validation
 import Imports hiding (fromException)
+import qualified Network.HTTP.Media as HTTP
 import Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
@@ -125,7 +126,7 @@ data FederatedRequest = FederatedRequest
 withTempMockFederator ::
   (MonadIO m, MonadMask m) =>
   [HTTP.Header] ->
-  (FederatedRequest -> IO LByteString) ->
+  (FederatedRequest -> IO (HTTP.MediaType, LByteString)) ->
   (Warp.Port -> m a) ->
   m (a, [FederatedRequest])
 withTempMockFederator headers resp action = do
@@ -159,12 +160,13 @@ withTempMockFederator headers resp action = do
                           frBody = rdBody
                         }
                     )
-              embed @IO $ modifyIORef remoteCalls (<> [fedRequest])
-              body <-
+              embed @IO $ modifyIORef remoteCalls $ (<> [fedRequest])
+              (ct, body) <-
                 fromException @MockException
                   . handle (throw . handleException)
                   $ resp fedRequest
-              pure $ Wai.responseLBS HTTP.status200 headers body
+              let headers' = ("Content-Type", HTTP.renderHeader ct) : headers
+              pure $ Wai.responseLBS HTTP.status200 headers' body
         respond response
   result <-
     bracket

--- a/services/federator/test/integration/Test/Federator/InwardSpec.hs
+++ b/services/federator/test/integration/Test/Federator/InwardSpec.hs
@@ -34,7 +34,9 @@ import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai.Utilities.Error as E
 import Test.Federator.Util
 import Test.Hspec
+import Test.QuickCheck (arbitrary, generate)
 import Util.Options (Endpoint (Endpoint))
+import Wire.API.Federation.API.Cargohold
 import Wire.API.Federation.Domain
 import Wire.API.User
 
@@ -85,8 +87,11 @@ spec env =
 
     it "should be able to call cargohold" $
       runTestFederator env $ do
-        inwardCall "/federation/cargohold/get-asset" (encode ())
-          !!! const 500 === statusCode
+        uid <- liftIO $ generate arbitrary
+        key <- liftIO $ generate arbitrary
+        let ga = GetAsset uid key Nothing
+        inwardCall "/federation/cargohold/get-asset" (encode ga)
+          !!! const 200 === statusCode
 
     it "should return 404 'no-endpoint' response from Brig" $
       runTestFederator env $ do

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -305,6 +305,7 @@ executable galley-integration
     , http-client-openssl
     , http-client-tls
     , http-types
+    , http-media
     , imports
     , lens
     , lens-aeson

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -182,6 +182,7 @@ executables:
     - http-client
     - http-client-openssl
     - http-client-tls
+    - http-media
     - http-types
     - lens
     - lens-aeson

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -92,6 +92,7 @@ import Gundeck.Types.Notification
     queuedTime,
   )
 import Imports
+import Network.HTTP.Media.MediaType
 import qualified Network.HTTP.Types as HTTP
 import Network.Wai (Application, defaultRequest)
 import qualified Network.Wai as Wai
@@ -2241,11 +2242,14 @@ withTempMockFederator' ::
   m (b, [FederatedRequest])
 withTempMockFederator' resp action = do
   opts <- viewGalleyOpts
-  Mock.withTempMockFederator [("Content-Type", "application/json")] resp $ \mockPort -> do
-    let opts' =
-          opts & Opts.optFederator
-            ?~ Endpoint "127.0.0.1" (fromIntegral mockPort)
-    withSettingsOverrides opts' action
+  Mock.withTempMockFederator
+    [("Content-Type", "application/json")]
+    ((\r -> pure ("application" // "json", r)) <=< resp)
+    $ \mockPort -> do
+      let opts' =
+            opts & Opts.optFederator
+              ?~ Endpoint "127.0.0.1" (fromIntegral mockPort)
+      withSettingsOverrides opts' action
 
 -- Start a mock federator. Use proveded Servant handler for the mocking mocking function.
 withTempServantMockFederator ::


### PR DESCRIPTION
This PR implements the Cargohold federation API. There are only two endpoints:

 - `get-asset`, used to check if an asset exists
 - `stream-asset`, used to retrieve the asset contents.

The reason for having a separate `get-asset` RPC is that the federation API has no direct way of communicating that the asset does not exist, since non-success HTTP status codes are always interepreted as server errors by federator.

Tracked by https://wearezeta.atlassian.net/browse/FS-305.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
