### PR TITLE
Fix cabal install script

### DIFF
--- a/changelog.d/5-internal/fix-cabal-install
+++ b/changelog.d/5-internal/fix-cabal-install
@@ -1,0 +1,1 @@
+The `cabal-install-artefacts.sh` script now creates the `dist` directory if it does not exist

--- a/hack/bin/cabal-install-artefacts.sh
+++ b/hack/bin/cabal-install-artefacts.sh
@@ -6,6 +6,8 @@ TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
 DIST="$TOP_LEVEL/dist"
 
+mkdir -p "$DIST"
+
 if [[ "$1" == "all" ]]; then
   pattern='*'
 else


### PR DESCRIPTION
The script should create the `dist` directory, if it does not exist.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
