### PR TITLE
SQSERVICES 1011 servantify gally team api (PUT /teams/:tid)

### DIFF
--- a/changelog.d/5-internal/pr-2008
+++ b/changelog.d/5-internal/pr-2008
@@ -1,1 +1,1 @@
-Servantify Galley Teams API. (#2008)
+Servantify Galley Teams API. (#2008, #2010)

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -20,6 +20,7 @@ import Servant.API.Status (KnownStatus, statusVal)
 import Servant.Client.Core
 import Servant.Swagger.Internal
 import Wire.API.Routes.MultiVerb
+import Wire.API.Team.Permission
 
 -- This can be added to an endpoint to document a possible failure
 -- case outside its return type (usually through an exception).
@@ -233,6 +234,11 @@ noIdentity :: forall code lbl desc. (NoIdentity ~ ErrorDescription code lbl desc
 noIdentity n = ErrorDescription (Text.pack (symbolVal (Proxy @desc)) <> " (code " <> Text.pack (show n) <> ")")
 
 type OperationDenied = ErrorDescription 403 "operation-denied" "Insufficient permissions"
+
+-- FUTUREWORK(leif): We need this to document possible (operation denied) errors in the servant routes.
+-- Be aware that this is redundant and should be replaced by a more type safe solution in the future.
+type family OperationDeniedError (a :: Perm) :: * where
+  OperationDeniedError 'SetTeamData = ErrorDescription 403 "operation-denied" "Insufficient permissions (missing SetTeamData)"
 
 operationDeniedSpecialized :: String -> OperationDenied
 operationDeniedSpecialized p =

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -735,6 +735,7 @@ data Api routes = Api
         :> ZConn
         :> CanThrow NotATeamMember
         -- :> CanThrow (operationDenied SetTeamData)
+        :> "teams"
         :> Capture "tid" TeamId
         :> ReqBody '[JSON] TeamUpdateData
         :> MultiVerb

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -727,17 +727,21 @@ data Api routes = Api
                   TeamId
                   (RespondEmpty 201 "Team ID as `Location` header value")
               ]
-             TeamId
-             -- updateTeam ::
-             --   routes
-             --     :- Summary "Update team properties"
-             --     :> ZUser
-             --     :> ZConn
-             --     :> CanThrow NotATeamMember
-             --     -- :> CanThrow (operationDenied SetTeamData)
-             --     :> Capture "tid" TeamId
-             --     :> ReqBody '[JSON] TeamUpdateData
-             --     :> Put '[JSON] TeamUpdateData
+             TeamId,
+    updateTeam ::
+      routes
+        :- Summary "Update team properties"
+        :> ZUser
+        :> ZConn
+        :> CanThrow NotATeamMember
+        -- :> CanThrow (operationDenied SetTeamData)
+        :> Capture "tid" TeamId
+        :> ReqBody '[JSON] TeamUpdateData
+        :> MultiVerb
+             'PUT
+             '[JSON]
+             '[RespondEmpty 200 "Membership updated"]
+             ()
   }
   deriving (Generic)
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -47,8 +47,7 @@ import Wire.API.ServantProto (Proto, RawProto)
 import Wire.API.Team
 import Wire.API.Team.Conversation
 import Wire.API.Team.Feature
-
--- import Wire.API.Team.Permission (Perm (..))
+import Wire.API.Team.Permission (Perm (..))
 
 instance AsHeaders '[ConvId] Conversation Conversation where
   toHeaders c = (I (qUnqualified (cnvQualifiedId c)) :* Nil, c)
@@ -734,7 +733,7 @@ data Api routes = Api
         :> ZUser
         :> ZConn
         :> CanThrow NotATeamMember
-        -- :> CanThrow (operationDenied SetTeamData)
+        :> CanThrow (OperationDeniedError 'SetTeamData)
         :> "teams"
         :> Capture "tid" TeamId
         :> ReqBody '[JSON] TeamUpdateData

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -48,6 +48,8 @@ import Wire.API.Team
 import Wire.API.Team.Conversation
 import Wire.API.Team.Feature
 
+-- import Wire.API.Team.Permission (Perm (..))
+
 instance AsHeaders '[ConvId] Conversation Conversation where
   toHeaders c = (I (qUnqualified (cnvQualifiedId c)) :* Nil, c)
   fromHeaders = snd
@@ -726,6 +728,16 @@ data Api routes = Api
                   (RespondEmpty 201 "Team ID as `Location` header value")
               ]
              TeamId
+             -- updateTeam ::
+             --   routes
+             --     :- Summary "Update team properties"
+             --     :> ZUser
+             --     :> ZConn
+             --     :> CanThrow NotATeamMember
+             --     -- :> CanThrow (operationDenied SetTeamData)
+             --     :> Capture "tid" TeamId
+             --     :> ReqBody '[JSON] TeamUpdateData
+             --     :> Put '[JSON] TeamUpdateData
   }
   deriving (Generic)
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -740,7 +740,7 @@ data Api routes = Api
         :> MultiVerb
              'PUT
              '[JSON]
-             '[RespondEmpty 200 "Membership updated"]
+             '[RespondEmpty 200 "Team updated"]
              ()
   }
   deriving (Generic)

--- a/libs/wire-api/src/Wire/API/Team/Member.hs
+++ b/libs/wire-api/src/Wire/API/Team/Member.hs
@@ -336,7 +336,7 @@ invitedSchema' :: ObjectSchema SwaggerDoc (Maybe (UserId, UTCTimeMillis))
 invitedSchema' = withParser invitedSchema $ \(invby, invat) ->
   case (invby, invat) of
     (Just b, Just a) -> pure $ Just (b, a)
-    (Nothing, Nothing) -> pure $ Nothing
+    (Nothing, Nothing) -> pure Nothing
     _ -> fail "created_by, created_at"
 
 instance ToSchema NewTeamMember where

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -188,27 +188,13 @@ servantSitemap =
         GalleyAPI.featureConfigConferenceCallingGet = Features.getFeatureConfig @'Public.WithoutLockStatus @'Public.TeamFeatureConferenceCalling Features.getConferenceCallingInternal,
         GalleyAPI.featureConfigSelfDeletingMessagesGet = Features.getFeatureConfig @'Public.WithLockStatus @'Public.TeamFeatureSelfDeletingMessages Features.getSelfDeletingMessagesInternal,
         GalleyAPI.featureConfigGuestLinksGet = Features.getFeatureConfig @'Public.WithLockStatus @'Public.TeamFeatureGuestLinks Features.getGuestLinkInternal,
-        GalleyAPI.createNonBindingTeam = Teams.createNonBindingTeamH
+        GalleyAPI.createNonBindingTeam = Teams.createNonBindingTeamH,
+        GalleyAPI.updateTeam = Teams.updateTeamH
       }
 
 sitemap :: Routes ApiBuilder (Sem GalleyEffects) ()
 sitemap = do
   -- Team API -----------------------------------------------------------
-
-  put "/teams/:tid" (continue Teams.updateTeamH) $
-    zauthUserId
-      .&. zauthConnId
-      .&. capture "tid"
-      .&. jsonRequest @Public.TeamUpdateData
-      .&. accept "application" "json"
-  document "PUT" "updateTeam" $ do
-    summary "Update team properties"
-    parameter Path "tid" bytes' $
-      description "Team ID"
-    body (ref Public.modelUpdateData) $
-      description "JSON body"
-    errorResponse (Error.errorDescriptionTypeToWai @Error.NotATeamMember)
-    errorResponse (Error.errorDescriptionToWai (Error.operationDenied Public.SetTeamData))
 
   get "/teams" (continue Teams.getManyTeamsH) $
     zauthUserId

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -331,23 +331,6 @@ updateTeamH ::
        Error NotATeamMember,
        GundeckAccess,
        Input UTCTime,
-       TeamStore,
-       WaiRoutes
-     ]
-    r =>
-  UserId ::: ConnId ::: TeamId ::: JsonRequest Public.TeamUpdateData ::: JSON ->
-  Sem r Response
-updateTeamH (zusr ::: zcon ::: tid ::: req ::: _) = do
-  updateData <- fromJsonBody req
-  updateTeam zusr zcon tid updateData
-  pure empty
-
-updateTeam ::
-  Members
-    '[ Error ActionError,
-       Error NotATeamMember,
-       GundeckAccess,
-       Input UTCTime,
        TeamStore
      ]
     r =>
@@ -356,7 +339,7 @@ updateTeam ::
   TeamId ->
   Public.TeamUpdateData ->
   Sem r ()
-updateTeam zusr zcon tid updateData = do
+updateTeamH zusr zcon tid updateData = do
   zusrMembership <- E.getTeamMember tid zusr
   -- let zothers = map (view userId) membs
   -- Log.debug $


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1011

- `PUT /teams/:tid` endpoint

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
