### PR TITLE
Fix doubtless HLint issues in Federator

### DIFF
--- a/changelog.d/5-internal/hlint-federator
+++ b/changelog.d/5-internal/hlint-federator
@@ -1,0 +1,1 @@
+Fix non-controversial HLint issues in federator to improve code quality

--- a/services/federator/src/Federator/ExternalServer.hs
+++ b/services/federator/src/Federator/ExternalServer.hs
@@ -107,14 +107,14 @@ parseRequestData req = do
   when (Wai.requestMethod req /= HTTP.methodPost) $
     throw InvalidRoute
   -- No query parameters are allowed
-  when (not . BS.null . Wai.rawQueryString $ req) $
+  unless (BS.null . Wai.rawQueryString $ req) $
     throw InvalidRoute
   -- check that the path has the expected form
   (componentSeg, rpcPath) <- case Wai.pathInfo req of
     ["federation", comp, rpc] -> pure (comp, rpc)
     _ -> throw InvalidRoute
 
-  when (not (Text.all isAllowedRPCChar rpcPath)) $
+  unless (Text.all isAllowedRPCChar rpcPath) $
     throw InvalidRoute
 
   when (Text.null rpcPath) $

--- a/services/federator/src/Federator/InternalServer.hs
+++ b/services/federator/src/Federator/InternalServer.hs
@@ -90,7 +90,7 @@ parseRequestData req = do
   when (Wai.requestMethod req /= HTTP.methodPost) $
     throw InvalidRoute
   -- No query parameters are allowed
-  when (not . BS.null . Wai.rawQueryString $ req) $
+  unless (BS.null . Wai.rawQueryString $ req) $
     throw InvalidRoute
   -- check that the path has the expected form
   (domain, componentSeg, rpcPath) <- case Wai.pathInfo req of

--- a/services/federator/src/Federator/MockServer.hs
+++ b/services/federator/src/Federator/MockServer.hs
@@ -53,7 +53,7 @@ import Wire.API.Federation.Domain
 
 -- | Thrown in IO by mock federator if the server could not be started after 10
 -- seconds.
-data MockTimeout = MockTimeout Warp.Port
+newtype MockTimeout = MockTimeout Warp.Port
   deriving (Eq, Show, Typeable)
 
 instance Exception MockTimeout
@@ -159,7 +159,7 @@ withTempMockFederator headers resp action = do
                           frBody = rdBody
                         }
                     )
-              embed @IO $ modifyIORef remoteCalls $ (<> [fedRequest])
+              embed @IO $ modifyIORef remoteCalls (<> [fedRequest])
               body <-
                 fromException @MockException
                   . handle (throw . handleException)

--- a/services/federator/src/Federator/Monitor/Internal.hs
+++ b/services/federator/src/Federator/Monitor/Internal.hs
@@ -72,7 +72,7 @@ data WatchedPath
   deriving stock (Eq, Ord, Show, Generic)
   deriving (Arbitrary) via (GenericUniform WatchedPath)
 
-mergePaths :: [WatchedPath] -> (Set WatchedPath)
+mergePaths :: [WatchedPath] -> Set WatchedPath
 mergePaths = Set.fromList . merge . sort
   where
     merge [] = []

--- a/services/federator/test/integration/Test/Federator/IngressSpec.hs
+++ b/services/federator/test/integration/Test/Federator/IngressSpec.hs
@@ -62,13 +62,14 @@ spec env = do
         resp <-
           runTestSem
             . assertNoError @RemoteError
-            $ inwardBrigCallViaIngress "get-user-by-handle" $
+            $ inwardBrigCallViaIngress
+              "get-user-by-handle"
               (Aeson.fromEncoding (Aeson.toEncoding hdl))
         liftIO $ do
           bdy <- streamingResponseStrictBody resp
           let actualProfile = Aeson.decode (toLazyByteString bdy)
           responseStatusCode resp `shouldBe` HTTP.status200
-          actualProfile `shouldBe` (Just expectedProfile)
+          actualProfile `shouldBe` Just expectedProfile
 
   -- @SF.Federation @TSFI.RESTfulAPI @S2 @S3 @S7
   --
@@ -96,7 +97,9 @@ spec env = do
       r <-
         runTestSem
           . runError @RemoteError
-          $ inwardBrigCallViaIngressWithSettings tlsSettings "get-user-by-handle" $
+          $ inwardBrigCallViaIngressWithSettings
+            tlsSettings
+            "get-user-by-handle"
             (Aeson.fromEncoding (Aeson.toEncoding hdl))
       liftIO $ case r of
         Right _ -> expectationFailure "Expected client certificate error, got response"

--- a/services/federator/test/unit/Test/Federator/InternalServer.hs
+++ b/services/federator/test/unit/Test/Federator/InternalServer.hs
@@ -49,7 +49,8 @@ tests :: TestTree
 tests =
   testGroup
     "Federate"
-    [ testGroup "with remote" $
+    [ testGroup
+        "with remote"
         [ federatedRequestSuccess,
           federatedRequestFailureAllowList
         ]

--- a/services/federator/test/unit/Test/Federator/Util.hs
+++ b/services/federator/test/unit/Test/Federator/Util.hs
@@ -62,10 +62,9 @@ testRequest tr = do
   pure . flip Wai.setPath (trPath tr) $
     Wai.defaultRequest
       { Wai.requestMethod = trMethod tr,
-        Wai.requestBody = atomicModifyIORef refChunks $ \bss ->
-          case bss of
-            [] -> ([], mempty)
-            x : y -> (y, x),
+        Wai.requestBody = atomicModifyIORef refChunks $ \case
+          [] -> ([], mempty)
+          x : y -> (y, x),
         Wai.requestHeaders =
           [("X-SSL-Certificate", HTTP.urlEncode True h) | h <- toList (trCertificateHeader tr)]
             <> [(originDomainHeaderName, h) | h <- toList (trDomainHeader tr)]

--- a/services/federator/test/unit/Test/Federator/Validation.hs
+++ b/services/federator/test/unit/Test/Federator/Validation.hs
@@ -60,12 +60,15 @@ mockDiscoveryFailure = Polysemy.interpret $ \case
 
 tests :: TestTree
 tests =
-  testGroup "Validation" $
-    [ testGroup "federateWith" $
+  testGroup
+    "Validation"
+    [ testGroup
+        "federateWith"
         [ federateWithAllowListSuccess,
           federateWithAllowListFail
         ],
-      testGroup "validateDomain" $
+      testGroup
+        "validateDomain"
         [ validateDomainAllowListFailSemantic,
           validateDomainAllowListFail,
           validateDomainAllowListSuccess,


### PR DESCRIPTION

## Checklist

 - [X] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
