### PR TITLE
FS-266: Add sft_servers_all to calls/config/v2

### DIFF
--- a/changelog.d/6-federation/sft-servers-all
+++ b/changelog.d/6-federation/sft-servers-all
@@ -1,0 +1,1 @@
+Extend GET /calls/config/v2 to include all SFT servers in federation

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -175,6 +175,8 @@ data:
       {{- if .sftDiscoveryIntervalSeconds }}
       sftDiscoveryIntervalSeconds: {{ .sftDiscoveryIntervalSeconds }}
       {{- end }}
+      sftLookupDomain: {{ required "Missing value: .sft.sftLookupDomain" .sftLookupDomain }}
+      sftLookupPort: {{ required "Missing value: .sft.sftLookupPort" .sftLookupPort }}
     {{- end }}
     {{- end }}
 

--- a/libs/dns-util/dns-util.cabal
+++ b/libs/dns-util/dns-util.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: eb1c3d83585fec582c135dbe676c68498f2546468581882f07fdba8f0d16aec3
+-- hash: d71d0f07f44620f73670692eb75544d71d97efd5ddfd25d72388d073f8cf2494
 
 name:           dns-util
 version:        0.1.0
@@ -20,6 +20,7 @@ build-type:     Simple
 
 library
   exposed-modules:
+      Wire.Network.DNS.A
       Wire.Network.DNS.Effect
       Wire.Network.DNS.Helper
       Wire.Network.DNS.SRV
@@ -33,6 +34,7 @@ library
       base >=4.6 && <5.0
     , dns
     , imports
+    , iproute
     , polysemy
     , random
   default-language: Haskell2010
@@ -55,6 +57,7 @@ test-suite spec
     , dns-util
     , hspec
     , imports
+    , iproute
     , polysemy
     , random
   default-language: Haskell2010

--- a/libs/dns-util/package.yaml
+++ b/libs/dns-util/package.yaml
@@ -14,6 +14,7 @@ dependencies:
 - dns
 - random
 - imports
+- iproute
 - polysemy
 library:
   source-dirs: src

--- a/libs/dns-util/src/Wire/Network/DNS/A.hs
+++ b/libs/dns-util/src/Wire/Network/DNS/A.hs
@@ -1,0 +1,32 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.Network.DNS.A where
+
+import Data.IP
+import Imports
+import Network.DNS
+
+-- | A response to lookupA, i.e., a reponse to a lookup of IPv4 addresses of a
+-- domain.
+data AResponse
+  = AIPv4s [IPv4]
+  | AResponseError DNSError
+  deriving (Eq)
+
+interpretResponse :: Either DNSError [IPv4] -> AResponse
+interpretResponse = either AResponseError AIPv4s

--- a/libs/wire-api/src/Wire/API/Call/Config.hs
+++ b/libs/wire-api/src/Wire/API/Call/Config.hs
@@ -25,6 +25,7 @@ module Wire.API.Call.Config
     rtcConfiguration,
     rtcConfIceServers,
     rtcConfSftServers,
+    rtcConfSftServersAll,
     rtcConfTTL,
 
     -- * RTCIceServer
@@ -105,7 +106,7 @@ data RTCConfiguration = RTCConfiguration
   { _rtcConfIceServers :: NonEmpty RTCIceServer,
     _rtcConfSftServers :: Maybe (NonEmpty SFTServer),
     _rtcConfTTL :: Word32,
-    rtcConfSftServersAll :: Maybe [SFTServer]
+    _rtcConfSftServersAll :: Maybe [SFTServer]
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform RTCConfiguration)

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/RTCConfiguration_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/RTCConfiguration_user.hs
@@ -152,6 +152,7 @@ testObject_RTCConfiguration_user_1 =
       )
       (Nothing)
       (2)
+      Nothing
   )
 
 testObject_RTCConfiguration_user_2 :: RTCConfiguration
@@ -334,6 +335,7 @@ testObject_RTCConfiguration_user_2 =
           )
       )
       (4)
+      Nothing
   )
 
 testObject_RTCConfiguration_user_3 :: RTCConfiguration
@@ -480,6 +482,7 @@ testObject_RTCConfiguration_user_3 =
           )
       )
       (9)
+      Nothing
   )
 
 testObject_RTCConfiguration_user_4 :: RTCConfiguration
@@ -685,6 +688,7 @@ testObject_RTCConfiguration_user_4 =
           )
       )
       (2)
+      Nothing
   )
 
 testObject_RTCConfiguration_user_5 :: RTCConfiguration
@@ -728,6 +732,7 @@ testObject_RTCConfiguration_user_5 =
           )
       )
       (2)
+      Nothing
   )
 
 testObject_RTCConfiguration_user_6 :: RTCConfiguration
@@ -750,4 +755,5 @@ testObject_RTCConfiguration_user_6 =
       )
       Nothing
       (2)
+      Nothing
   )

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 513c0f5104342fb14b0246f7c44733a84ec36fae97633fc55cb209e0e0bcd087
+-- hash: 8c0c7f0e61001bf27032247013479a6103600929df6470ef092a25b22e2642d6
 
 name:           brig
 version:        2.0
@@ -167,6 +167,7 @@ library
     , errors >=1.4
     , exceptions >=0.5
     , extended
+    , extra
     , filepath >=1.3
     , fsnotify >=0.2
     , galley-types >=0.75.3

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8c0c7f0e61001bf27032247013479a6103600929df6470ef092a25b22e2642d6
+-- hash: 244ca5e0c12867ef47ffcfbc056775381028fbc85e5c57eb280afe842e3499d9
 
 name:           brig
 version:        2.0
@@ -497,6 +497,7 @@ test-suite brig-tests
     , dns-util
     , http-types
     , imports
+    , iproute
     , polysemy
     , polysemy-wire-zoo
     , retry

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -161,6 +161,7 @@ tests:
     - dns-util
     - http-types
     - imports
+    - iproute
     - polysemy
     - polysemy-wire-zoo
     - retry

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -57,6 +57,7 @@ library:
   - errors >=1.4
   - exceptions >=0.5
   - extended
+  - extra
   - filepath >=1.3
   - fsnotify >=0.2
   - galley-types >=0.75.3

--- a/services/brig/src/Brig/Calling.hs
+++ b/services/brig/src/Brig/Calling.hs
@@ -29,6 +29,7 @@ module Brig.Calling
     newEnv,
     sftDiscoveryLoop,
     discoverSFTServers,
+    discoverSFTServersAll,
     discoveryToMaybe,
     randomize,
     startSFTServiceDiscovery,
@@ -46,9 +47,11 @@ import qualified Brig.Options as Opts
 import Brig.Types (TurnURI)
 import Control.Lens
 import Control.Monad.Random.Class (MonadRandom)
+import Data.IP
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.List1
+import Data.Misc (Port (..))
 import Data.Range
 import Data.Time.Clock (DiffTime, diffTimeToPicoseconds)
 import Imports
@@ -59,6 +62,7 @@ import Polysemy.TinyLog
 import qualified System.Logger as Log
 import System.Random.MWC (GenIO, createSystemRandom)
 import System.Random.Shuffle
+import Wire.Network.DNS.A
 import Wire.Network.DNS.Effect
 import Wire.Network.DNS.SRV
 
@@ -109,7 +113,9 @@ data SFTEnv = SFTEnv
     sftDiscoveryInterval :: Int,
     -- | maximum amount of servers to give out,
     -- even if more are in the SRV record
-    sftListLength :: Range 1 100 Int
+    sftListLength :: Range 1 100 Int,
+    sftLookupDomain :: DNS.Domain,
+    sftLookupPort :: Port
   }
 
 data Discovery a
@@ -133,6 +139,14 @@ discoverSFTServers domain =
       err (Log.msg ("DNS Lookup failed for SFT Discovery" :: ByteString) . Log.field "Error" (show e))
       pure Nothing
 
+discoverSFTServersAll :: Members [DNSLookup, TinyLog] r => DNS.Domain -> Sem r (Maybe [IPv4])
+discoverSFTServersAll domain =
+  lookupA domain >>= \case
+    AIPv4s ips -> pure . Just $ ips
+    AResponseError e -> do
+      err (Log.msg ("DNS Lookup failed for SFT Discovery" :: ByteString) . Log.field "Error" (show e))
+      pure Nothing
+
 mkSFTDomain :: SFTOptions -> DNS.Domain
 mkSFTDomain SFTOptions {..} = DNS.normalize $ maybe defSftServiceName ("_" <>) sftSRVServiceName <> "._tcp." <> sftBaseDomain
 
@@ -153,6 +167,8 @@ mkSFTEnv opts =
     <*> pure (mkSFTDomain opts)
     <*> pure (diffTimeToMicroseconds (fromMaybe defSftDiscoveryIntervalSeconds (Opts.sftDiscoveryIntervalSeconds opts)))
     <*> pure (fromMaybe defSftListLength (Opts.sftListLength opts))
+    <*> pure (Opts.sftLookupDomain opts)
+    <*> pure (Opts.sftLookupPort opts)
 
 startSFTServiceDiscovery :: Log.Logger -> SFTEnv -> IO ()
 startSFTServiceDiscovery logger =

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -33,7 +33,7 @@ import Data.Aeson.Types (typeMismatch)
 import qualified Data.Char as Char
 import Data.Domain (Domain (..))
 import Data.Id
-import Data.Misc (HttpsUrl)
+import Data.Misc (HttpsUrl, Port (..))
 import Data.Range
 import Data.Scientific (toBoundedInteger)
 import qualified Data.Text as Text
@@ -612,7 +612,9 @@ data SFTOptions = SFTOptions
   { sftBaseDomain :: !DNS.Domain,
     sftSRVServiceName :: !(Maybe ByteString), -- defaults to defSftServiceName if unset
     sftDiscoveryIntervalSeconds :: !(Maybe DiffTime), -- defaults to defSftDiscoveryIntervalSeconds
-    sftListLength :: !(Maybe (Range 1 100 Int)) -- defaults to defSftListLength
+    sftListLength :: !(Maybe (Range 1 100 Int)), -- defaults to defSftListLength
+    sftLookupDomain :: !DNS.Domain,
+    sftLookupPort :: !Port
   }
   deriving (Show, Generic)
 
@@ -623,6 +625,8 @@ instance FromJSON SFTOptions where
       <*> (mapM asciiOnly =<< o .:? "sftSRVServiceName")
       <*> (secondsToDiffTime <$$> o .:? "sftDiscoveryIntervalSeconds")
       <*> (o .:? "sftListLength")
+      <*> (asciiOnly =<< o .: "sftLookupDomain")
+      <*> o .: "sftLookupPort"
     where
       asciiOnly :: Text -> Y.Parser ByteString
       asciiOnly t =

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -103,11 +103,15 @@ testSFT :: Brig -> Opts.Opts -> Http ()
 testSFT b opts = do
   uid <- userId <$> randomUser b
   cfg <- getTurnConfigurationV2 uid b
-  liftIO $
+  liftIO $ do
     assertEqual
       "when SFT discovery is not enabled, sft_servers shouldn't be returned"
       Nothing
       (cfg ^. rtcConfSftServers)
+    assertEqual
+      "when SFT discovery is not enabled, sft_servers_all shouldn't be returned"
+      Nothing
+      (cfg ^. rtcConfSftServersAll)
   withSettingsOverrides (opts & Opts.sftL ?~ Opts.SFTOptions "integration-tests.zinfra.io" Nothing (Just 0.001) Nothing "integration-tests.zinfra.io" (Port 8585)) $ do
     cfg1 <- retryWhileN 10 (isNothing . view rtcConfSftServers) (getTurnConfigurationV2 uid b)
     -- These values are controlled by https://github.com/zinfra/cailleach/tree/77ca2d23cf2959aa183dd945d0a0b13537a8950d/environments/dns-integration-tests

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -32,7 +32,7 @@ import Data.Id
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.List1 (List1)
 import qualified Data.List1 as List1
-import Data.Misc (Port, mkHttpsUrl)
+import Data.Misc (Port (..), mkHttpsUrl)
 import qualified Data.Set as Set
 import Imports
 import System.FilePath ((</>))
@@ -108,7 +108,7 @@ testSFT b opts = do
       "when SFT discovery is not enabled, sft_servers shouldn't be returned"
       Nothing
       (cfg ^. rtcConfSftServers)
-  withSettingsOverrides (opts & Opts.sftL ?~ Opts.SFTOptions "integration-tests.zinfra.io" Nothing (Just 0.001) Nothing) $ do
+  withSettingsOverrides (opts & Opts.sftL ?~ Opts.SFTOptions "integration-tests.zinfra.io" Nothing (Just 0.001) Nothing "integration-tests.zinfra.io" (Port 8585)) $ do
     cfg1 <- retryWhileN 10 (isNothing . view rtcConfSftServers) (getTurnConfigurationV2 uid b)
     -- These values are controlled by https://github.com/zinfra/cailleach/tree/77ca2d23cf2959aa183dd945d0a0b13537a8950d/environments/dns-integration-tests
     let Right server1 = mkHttpsUrl =<< first show (parseURI laxURIParserOptions "https://sft01.integration-tests.zinfra.io:443")

--- a/services/brig/test/unit/Test/Brig/Calling.hs
+++ b/services/brig/test/unit/Test/Brig/Calling.hs
@@ -24,6 +24,7 @@ import Brig.Options
 import Control.Retry
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
+import Data.Misc (Port (..))
 import Data.Range
 import qualified Data.Set as Set
 import Imports
@@ -34,23 +35,28 @@ import qualified System.Logger as Log
 import Test.Tasty
 import Test.Tasty.HUnit
 import qualified UnliftIO.Async as Async
+import qualified Wire.Network.DNS.A as A
 import Wire.Network.DNS.Effect
 import Wire.Network.DNS.SRV
 
 data FakeDNSEnv = FakeDNSEnv
-  { fakeLookupFn :: Domain -> SrvResponse,
+  { fakeLookupSrv :: Domain -> SrvResponse,
+    fakeLookupA :: Domain -> A.AResponse,
     fakeLookupCalls :: IORef [Domain]
   }
 
-newFakeDNSEnv :: (Domain -> SrvResponse) -> IO FakeDNSEnv
-newFakeDNSEnv lookupFn =
-  FakeDNSEnv lookupFn <$> newIORef []
+newFakeDNSEnv :: (Domain -> SrvResponse) -> (Domain -> A.AResponse) -> IO FakeDNSEnv
+newFakeDNSEnv lookupSrvFn lookupAFn =
+  FakeDNSEnv lookupSrvFn lookupAFn <$> newIORef []
 
 runFakeDNSLookup :: Member (Embed IO) r => FakeDNSEnv -> Sem (DNSLookup ': r) a -> Sem r a
 runFakeDNSLookup FakeDNSEnv {..} = interpret $ \case
   LookupSRV domain -> do
     modifyIORef' fakeLookupCalls (++ [domain])
-    pure $ fakeLookupFn domain
+    pure $ fakeLookupSrv domain
+  LookupA domain -> do
+    modifyIORef' fakeLookupCalls (++ [domain])
+    pure $ fakeLookupA domain
 
 newtype LogRecorder = LogRecorder {recordedLogs :: IORef [(Log.Level, LByteString)]}
 
@@ -73,12 +79,12 @@ tests =
             assertEqual
               "should use the service name to form domain"
               "_foo._tcp.example.com."
-              (mkSFTDomain (SFTOptions "example.com" (Just "foo") Nothing Nothing)),
+              (mkSFTDomain (SFTOptions "example.com" (Just "foo") Nothing Nothing "example.com" (Port 8585))),
           testCase "when service name is not provided" $
             assertEqual
               "should assume service name to be 'sft'"
               "_sft._tcp.example.com."
-              (mkSFTDomain (SFTOptions "example.com" Nothing Nothing Nothing))
+              (mkSFTDomain (SFTOptions "example.com" Nothing Nothing Nothing "example.com" (Port 8585)))
         ],
       testGroup "sftDiscoveryLoop" $
         [ testCase "when service can be discovered" $ void testDiscoveryLoopWhenSuccessful,
@@ -104,8 +110,8 @@ testDiscoveryLoopWhenSuccessful = do
       entry2 = SrvEntry 0 0 (SrvTarget "sft2.foo.example.com." 443)
       entry3 = SrvEntry 0 0 (SrvTarget "sft3.foo.example.com." 443)
       returnedEntries = entry1 :| [entry2, entry3]
-  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvAvailable returnedEntries)
-  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001) Nothing)
+  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvAvailable returnedEntries) undefined
+  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001) Nothing "foo.example.com" (Port 8585))
 
   discoveryLoop <- Async.async $ runM . ignoreLogs . runFakeDNSLookup fakeDNSEnv $ sftDiscoveryLoop sftEnv
   void $ retryEvery10MicrosWhileN 2000 (== 0) (length <$> readIORef (fakeLookupCalls fakeDNSEnv))
@@ -119,8 +125,8 @@ testDiscoveryLoopWhenSuccessful = do
 
 testDiscoveryLoopWhenUnsuccessful :: IO ()
 testDiscoveryLoopWhenUnsuccessful = do
-  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvNotAvailable)
-  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001) Nothing)
+  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvNotAvailable) undefined
+  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001) Nothing "foo.example.com" (Port 8585))
 
   discoveryLoop <- Async.async $ runM . ignoreLogs . runFakeDNSLookup fakeDNSEnv $ sftDiscoveryLoop sftEnv
   -- We wait for at least two lookups to be sure that the lookup loop looped at
@@ -138,7 +144,7 @@ testDiscoveryLoopWhenUnsuccessfulAfterSuccess = do
 
   -- In the following lines we re-use the 'sftEnv' from a successful lookup to
   -- replicate what will happen when a dns lookup fails after success
-  failingFakeDNSEnv <- newFakeDNSEnv (\_ -> SrvNotAvailable)
+  failingFakeDNSEnv <- newFakeDNSEnv (\_ -> SrvNotAvailable) undefined
   discoveryLoop <- Async.async $ runM . ignoreLogs . runFakeDNSLookup failingFakeDNSEnv $ sftDiscoveryLoop sftEnv
   -- We wait for at least two lookups to be sure that the lookup loop looped at
   -- least once
@@ -158,7 +164,7 @@ testDiscoveryLoopWhenURLsChange = do
       entry2 = SrvEntry 0 0 (SrvTarget "sft5.foo.example.com." 443)
       newEntries = (entry1 :| [entry2])
 
-  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvAvailable newEntries)
+  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvAvailable newEntries) undefined
   discoveryLoop <- Async.async $ runM . ignoreLogs . runFakeDNSLookup fakeDNSEnv $ sftDiscoveryLoop sftEnv
   void $ retryEvery10MicrosWhileN 2000 (== 0) (length <$> readIORef (fakeLookupCalls fakeDNSEnv))
   -- We don't want to stop the loop before it has written to the sftServers IORef
@@ -174,7 +180,7 @@ testSFTDiscoverWhenAvailable = do
   let entry1 = SrvEntry 0 0 (SrvTarget "sft7.foo.example.com." 443)
       entry2 = SrvEntry 0 0 (SrvTarget "sft8.foo.example.com." 8843)
       returnedEntries = (entry1 :| [entry2])
-  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvAvailable returnedEntries)
+  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvAvailable returnedEntries) undefined
 
   assertEqual "discovered servers should be returned" (Just returnedEntries)
     =<< ( runM . recordLogs logRecorder . runFakeDNSLookup fakeDNSEnv $
@@ -186,7 +192,7 @@ testSFTDiscoverWhenAvailable = do
 testSFTDiscoverWhenNotAvailable :: IO ()
 testSFTDiscoverWhenNotAvailable = do
   logRecorder <- newLogRecorder
-  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvNotAvailable)
+  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvNotAvailable) undefined
 
   assertEqual "discovered servers should be returned" Nothing
     =<< ( runM . recordLogs logRecorder . runFakeDNSLookup fakeDNSEnv $
@@ -198,7 +204,7 @@ testSFTDiscoverWhenNotAvailable = do
 testSFTDiscoverWhenDNSFails :: IO ()
 testSFTDiscoverWhenDNSFails = do
   logRecorder <- newLogRecorder
-  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvResponseError IllegalDomain)
+  fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvResponseError IllegalDomain) undefined
 
   assertEqual "discovered servers should be returned" Nothing
     =<< ( runM . recordLogs logRecorder . runFakeDNSLookup fakeDNSEnv $

--- a/services/brig/test/unit/Test/Brig/Calling.hs
+++ b/services/brig/test/unit/Test/Brig/Calling.hs
@@ -206,7 +206,7 @@ testSFTDiscoverWhenDNSFails = do
   logRecorder <- newLogRecorder
   fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvResponseError IllegalDomain) undefined
 
-  assertEqual "discovered servers should be returned" Nothing
+  assertEqual "no servers should be returned" Nothing
     =<< ( runM . recordLogs logRecorder . runFakeDNSLookup fakeDNSEnv $
             discoverSFTServers "_sft._tcp.foo.example.com"
         )


### PR DESCRIPTION
This implements https://wearezeta.atlassian.net/browse/FS-266.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.