### PR TITLE
Add documentation about linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,9 @@ hie.yaml
 hie.orig.yaml
 stack-dev.yaml
 
+# HIE db files (e.g. generated for stan)
+*.hie
+
 # generated files under .local
 .local
 

--- a/docs/developer/linting.md
+++ b/docs/developer/linting.md
@@ -1,0 +1,55 @@
+# Linting
+
+# HLint
+
+To run [HLint](https://github.com/ndmitchell/hlint) you need it's binary, e.g.
+by executing:
+
+```sh
+nix-shell -p hlint
+```
+
+To run it on the whole project (Warning: This takes long!):
+
+```sh
+hlint .
+```
+
+To run it on a sub-project:
+
+```sh
+hlint services/federator
+```
+
+# Stan
+
+To run [Stan](https://github.com/kowainik/stan), you need it's binary compiled
+by the same GHC version as used in the project.
+
+```sh
+nix-shell -p haskell.packages.ghc884.stan
+```
+
+Stan depends on [*hie*](https://www.haskell.org/ghc/blog/20190626-HIEFiles.html)
+database files that are created during compilation. To generate them for all
+packages add this to your `cabal.project.local` file:
+
+```
+package *
+    ghc-options: -fwrite-ide-info -hiedir=.hie
+```
+
+Of course, you can append the `ghc-options` to the respective entry of a package or
+add a new one:
+
+```sh
+package cargohold
+    ghc-options: -fwrite-ide-info -hiedir=.hie
+```
+
+To analyze a sub-project with stan:
+
+```sh
+cd services/cargohold
+stan
+```

--- a/docs/developer/linting.md
+++ b/docs/developer/linting.md
@@ -9,7 +9,7 @@ by executing:
 nix-shell -p hlint
 ```
 
-To run it on the whole project (Warning: This takes long!):
+To run it on the whole project (Warning: This takes a long time!):
 
 ```sh
 hlint .


### PR DESCRIPTION
## Checklist

 - [X] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
