### PR TITLE
Enable Insecure Requests for SFT Lookups in a Test Environment

### DIFF
--- a/changelog.d/6-federation/sft-servers-all-fixup
+++ b/changelog.d/6-federation/sft-servers-all-fixup
@@ -1,0 +1,1 @@
+Improve Brig's configuration for SFTs and fix a call to SFT servers

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -228,11 +228,12 @@ data:
       {{- if .setSftStaticUrl }}
       setSftStaticUrl: {{ .setSftStaticUrl }}
       {{- end }}
-      {{- if .sftLookupDomain }}
-      sftLookupDomain: {{ .sftLookupDomain }}
+      {{- if .setSftLookup }}
+      {{- with .setSftLookup }}
+      setSftLookup:
+        domain: {{ required "Missing value: .setSftLookup.domain" .setSftLookup.domain }}
+        port: {{ required "Missing value: .setSftLookup.port" .setSftLookup.port }}
       {{- end }}
-      {{- if .sftLookupPort }}
-      sftLookupPort: {{ .sftLookupPort }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -175,8 +175,6 @@ data:
       {{- if .sftDiscoveryIntervalSeconds }}
       sftDiscoveryIntervalSeconds: {{ .sftDiscoveryIntervalSeconds }}
       {{- end }}
-      sftLookupDomain: {{ required "Missing value: .sft.sftLookupDomain" .sftLookupDomain }}
-      sftLookupPort: {{ required "Missing value: .sft.sftLookupPort" .sftLookupPort }}
     {{- end }}
     {{- end }}
 
@@ -229,6 +227,12 @@ data:
       {{- end }}
       {{- if .setSftStaticUrl }}
       setSftStaticUrl: {{ .setSftStaticUrl }}
+      {{- end }}
+      {{- if .sftLookupDomain }}
+      sftLookupDomain: {{ .sftLookupDomain }}
+      {{- end }}
+      {{- if .sftLookupPort }}
+      sftLookupPort: {{ .sftLookupPort }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -233,6 +233,7 @@ data:
       setSftLookup:
         domain: {{ required "Missing value: .setSftLookup.domain" .setSftLookup.domain }}
         port: {{ required "Missing value: .setSftLookup.port" .setSftLookup.port }}
+        isTestingEnvironment: {{ .setSftLookup.isTestingEnvironment }}
       {{- end }}
       {{- end }}
     {{- end }}

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -154,6 +154,7 @@ library
     , cassandra-util >=0.16.2
     , comonad
     , conduit >=1.2.8
+    , connection
     , containers >=0.5
     , cookie >=0.4
     , cryptobox-haskell >=0.1.1

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f720449b2a83653c479cf0e0d1ea59541640cc25ea5851b960aa53a2dc679322
+-- hash: addf4b080e564149f44c6cdb33c824734aa68cc9ff021f41268938902e2958b0
 
 name:           brig
 version:        2.0
@@ -64,6 +64,7 @@ library
       Brig.Data.User
       Brig.Data.UserKey
       Brig.Data.UserPendingActivation
+      Brig.Effects.SFT
       Brig.Email
       Brig.Federation.Client
       Brig.Index.Eval

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 244ca5e0c12867ef47ffcfbc056775381028fbc85e5c57eb280afe842e3499d9
+-- hash: f720449b2a83653c479cf0e0d1ea59541640cc25ea5851b960aa53a2dc679322
 
 name:           brig
 version:        2.0
@@ -177,6 +177,7 @@ library
     , html-entities >=1.1
     , http-client >=0.5
     , http-client-openssl >=0.2
+    , http-client-tls
     , http-media
     , http-types >=0.8
     , imports

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -178,6 +178,11 @@ optSettings:
   #   Remember to keep it the same in Galley.
   setFederationDomain: example.com
   setFeatureFlags:  # see #RefConfigOptions in `/docs/reference`
+  # FUTUREWORK: Replace the following SFT DNS lookup parameters with something
+  # to be added to the CI environment
+  setSftLookupDomain:
+    sft01.avs.zinfra.io
+  setSftLookupPort: 443
 
 logLevel: Warn
 # ^ NOTE: We log too much in brig, if we set this to Info like other services, running tests

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -180,9 +180,9 @@ optSettings:
   setFeatureFlags:  # see #RefConfigOptions in `/docs/reference`
   # FUTUREWORK: Replace the following SFT DNS lookup parameters with something
   # to be added to the CI environment
-  setSftLookupDomain:
-    sftd.integration-tests.zinfra.io
-  setSftLookupPort: 443
+  setSftLookup:
+    domain: sftd.integration-tests.zinfra.io
+    port: 443
 
 logLevel: Warn
 # ^ NOTE: We log too much in brig, if we set this to Info like other services, running tests

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -181,7 +181,7 @@ optSettings:
   # FUTUREWORK: Replace the following SFT DNS lookup parameters with something
   # to be added to the CI environment
   setSftLookupDomain:
-    sft01.avs.zinfra.io
+    sftd.integration-tests.zinfra.io
   setSftLookupPort: 443
 
 logLevel: Warn

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -183,6 +183,7 @@ optSettings:
   setSftLookup:
     domain: sftd.integration-tests.zinfra.io
     port: 443
+    isTestingEnvironment: true
 
 logLevel: Warn
 # ^ NOTE: We log too much in brig, if we set this to Info like other services, running tests

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -44,6 +44,7 @@ library:
   - cassandra-util >=0.16.2
   - comonad
   - conduit >=1.2.8
+  - connection
   - containers >=0.5
   - cookie >=0.4
   - cryptobox-haskell >=0.1.1

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -71,6 +71,7 @@ library:
   - html-entities >=1.1
   - http-client >=0.5
   - http-client-openssl >=0.2
+  - http-client-tls
   - http-media
   - http-types >=0.8
   - imports

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -214,11 +214,7 @@ newEnv o = do
   eventsQueue <- case Opt.internalEventsQueue (Opt.internalEvents o) of
     StompQueue q -> pure (StompQueue q)
     SqsQueue q -> SqsQueue <$> AWS.getQueueUrl (aws ^. AWS.amazonkaEnv) q
-  mSFTEnv <- mapM Calling.mkSFTEnv $ do
-    sftV <- Opt.sft o
-    domain <- Opt.setSftLookupDomain . Opt.optSettings $ o
-    port <- Opt.setSftLookupPort . Opt.optSettings $ o
-    Just (sftV, domain, port)
+  mSFTEnv <- mapM Calling.mkSFTEnv $ (,Opt.setSftLookup . Opt.optSettings $ o) <$> Opt.sft o
   prekeyLocalLock <- case Opt.randomPrekeys o of
     Just True -> Just <$> newMVar ()
     _ -> pure Nothing

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -214,7 +214,11 @@ newEnv o = do
   eventsQueue <- case Opt.internalEventsQueue (Opt.internalEvents o) of
     StompQueue q -> pure (StompQueue q)
     SqsQueue q -> SqsQueue <$> AWS.getQueueUrl (aws ^. AWS.amazonkaEnv) q
-  mSFTEnv <- mapM Calling.mkSFTEnv $ Opt.sft o
+  mSFTEnv <- mapM Calling.mkSFTEnv $ do
+    sftV <- Opt.sft o
+    domain <- Opt.setSftLookupDomain . Opt.optSettings $ o
+    port <- Opt.setSftLookupPort . Opt.optSettings $ o
+    Just (sftV, domain, port)
   prekeyLocalLock <- case Opt.randomPrekeys o of
     Just True -> Just <$> newMVar ()
     _ -> pure Nothing

--- a/services/brig/src/Brig/Calling.hs
+++ b/services/brig/src/Brig/Calling.hs
@@ -114,7 +114,7 @@ data SFTEnv = SFTEnv
     -- | maximum amount of servers to give out,
     -- even if more are in the SRV record
     sftListLength :: Range 1 100 Int,
-    sftLookupDomain :: DNS.Domain,
+    sftLookupDomain :: Opts.LookupDomain,
     sftLookupPort :: Port
   }
 
@@ -160,15 +160,15 @@ sftDiscoveryLoop SFTEnv {..} = forever $ do
     Just es -> atomicWriteIORef sftServers (Discovered (SFTServers es))
   threadDelay sftDiscoveryInterval
 
-mkSFTEnv :: SFTOptions -> IO SFTEnv
-mkSFTEnv opts =
+mkSFTEnv :: (SFTOptions, Opts.LookupDomain, Port) -> IO SFTEnv
+mkSFTEnv (opts, lookupDomain, lookupPort) =
   SFTEnv
     <$> newIORef NotDiscoveredYet
     <*> pure (mkSFTDomain opts)
     <*> pure (diffTimeToMicroseconds (fromMaybe defSftDiscoveryIntervalSeconds (Opts.sftDiscoveryIntervalSeconds opts)))
     <*> pure (fromMaybe defSftListLength (Opts.sftListLength opts))
-    <*> pure (Opts.sftLookupDomain opts)
-    <*> pure (Opts.sftLookupPort opts)
+    <*> pure lookupDomain
+    <*> pure lookupPort
 
 startSFTServiceDiscovery :: Log.Logger -> SFTEnv -> IO ()
 startSFTServiceDiscovery logger =

--- a/services/brig/src/Brig/Calling/API.hs
+++ b/services/brig/src/Brig/Calling/API.hs
@@ -27,28 +27,24 @@ import Brig.App
 import Brig.Calling
 import qualified Brig.Calling as Calling
 import Brig.Calling.Internal
+import Brig.Effects.SFT
 import qualified Brig.Options as Opt
 import Control.Lens
-import qualified Data.ByteString.Char8 as BS8
 import Data.ByteString.Conversion
-import Data.ByteString.Internal (ByteString (PS), w2c)
 import Data.ByteString.Lens
-import Data.ByteString.Unsafe (unsafeTake)
 import Data.Either.Extra (eitherToMaybe)
 import Data.Id
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.List1 as List1
-import Data.Misc (HttpsUrl, Port (portNumber))
+import Data.Misc (HttpsUrl)
 import Data.Range
-import Data.String.Conversions (cs)
 import qualified Data.Swagger.Build.Api as Doc
 import Data.Text.Ascii (AsciiBase64, encodeBase64)
 import Data.Text.Strict.Lens
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Imports hiding (head)
 import Network.Connection
-import Network.HTTP.Client hiding (Response)
 import Network.HTTP.Client.TLS (mkManagerSettings, newTlsManager, newTlsManagerWith)
 import Network.Wai (Response)
 import Network.Wai.Predicate hiding (and, result, setStatus, (#))
@@ -173,39 +169,12 @@ newConfig env sftStaticUrl mSftEnv limit logger = do
         $ sftl
     case response of
       Nothing -> pure $ Nothing @[SFTServer]
-      Just ips -> fmap (eitherToMaybe @String @[SFTServer] . sequence) $
-        for ips $ \ip -> do
-          let req =
-                parseRequest_ $
-                  mconcat
-                    [ "GET https://",
-                      show ip,
-                      ":",
-                      show . portNumber . Opt.sftlPort $ sftl,
-                      "/sft/url"
-                    ]
-          -- TODO: introduce an effect for talking to SFT. Perhaps this could be a
-          -- part of an existing effect External.
-          sftUrlResponse <- liftIO (responseBody <$> httpLbs req httpMan)
-          pure @IO . fmap Public.sftServer . runParser' (parser @HttpsUrl) . cs . strip . cs $ sftUrlResponse
+      Just ips -> fmap (eitherToMaybe @SFTError @[SFTServer] . sequence) $
+        for ips $ \ip -> runM . interpretSFT httpMan $ sftGetClientUrl ip (Opt.sftlPort sftl)
 
   let mSftServers = staticSft <|> sftServerFromSrvTarget . srvTarget <$$> sftEntries
   pure $ Public.rtcConfiguration srvs mSftServers cTTL (join mSftServersAll)
   where
-    -- FUTUREWORK: remove this adopted code once upgraded to bytestring >= 0.10.12.0
-    strip :: BS8.ByteString -> BS8.ByteString
-    strip = BS8.dropWhile isSpace . dropWhileEnd' isSpace
-      where
-        dropWhileEnd' :: (Char -> Bool) -> BS8.ByteString -> BS8.ByteString
-        dropWhileEnd' f ps = unsafeTake (findFromEndUntil (not . f . w2c) ps) ps
-        findFromEndUntil :: (Word8 -> Bool) -> BS8.ByteString -> Int
-        findFromEndUntil f ps@(PS _ _ l) = case unsnoc ps of
-          Nothing -> 0
-          Just (b, c) ->
-            if f c
-              then l
-              else findFromEndUntil f b
-
     limitedList :: NonEmpty Public.TurnURI -> Range 1 10 Int -> NonEmpty Public.TurnURI
     limitedList uris lim =
       -- assuming limitServers is safe with respect to the length of its return value

--- a/services/brig/src/Brig/Calling/API.hs
+++ b/services/brig/src/Brig/Calling/API.hs
@@ -43,8 +43,9 @@ import Data.Text.Ascii (AsciiBase64, encodeBase64)
 import Data.Text.Strict.Lens
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Imports hiding (head)
+import Network.Connection
 import Network.HTTP.Client hiding (Response)
-import Network.HTTP.Client.TLS (newTlsManager)
+import Network.HTTP.Client.TLS (mkManagerSettings, newTlsManagerWith)
 import Network.Wai (Response)
 import Network.Wai.Predicate hiding (and, result, setStatus, (#))
 import Network.Wai.Routing hiding (toList)
@@ -153,7 +154,9 @@ newConfig env sftStaticUrl mSftEnv limit logger = do
 
   let mSftServers = staticSft <|> sftServerFromSrvTarget . srvTarget <$$> sftEntries
   mSftServersAll :: Maybe (Maybe [SFTServer]) <- for mSftEnv $ \e -> liftIO $ do
-    httpMan <- newTlsManager
+    httpMan <-
+      let s = TLSSettingsSimple True False True
+       in newTlsManagerWith $ mkManagerSettings s Nothing
     response <-
       runM
         . runTinyLog logger

--- a/services/brig/src/Brig/Effects/SFT.hs
+++ b/services/brig/src/Brig/Effects/SFT.hs
@@ -1,0 +1,68 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Brig.Effects.SFT where
+
+import Data.ByteString (unsnoc)
+import qualified Data.ByteString.Char8 as BS8
+import Data.ByteString.Conversion.From
+import Data.ByteString.Internal (ByteString (PS), w2c)
+import Data.ByteString.Unsafe (unsafeTake)
+import Data.IP
+import Data.Misc
+import Data.String.Conversions (cs)
+import Imports
+import Network.HTTP.Client
+import Polysemy
+import Polysemy.Internal
+import Wire.API.Call.Config
+
+newtype SFTError = SFTError {unSFTError :: String}
+
+data SFT m a where
+  SFTGetClientUrl :: IPv4 -> Port -> SFT m (Either SFTError SFTServer)
+
+sftGetClientUrl :: Member SFT r => IPv4 -> Port -> Sem r (Either SFTError SFTServer)
+sftGetClientUrl ipAddr port = send $ SFTGetClientUrl ipAddr port
+
+interpretSFT :: Member (Embed IO) r => Manager -> Sem (SFT ': r) a -> Sem r a
+interpretSFT httpManager = interpret $ \(SFTGetClientUrl ipAddr port) -> do
+  let req =
+        parseRequest_ $
+          mconcat
+            [ "GET https://",
+              show ipAddr,
+              ":",
+              show . portNumber $ port,
+              "/sft/url"
+            ]
+  sftUrlResponse <- liftIO (responseBody <$> httpLbs req httpManager)
+  pure . bimap SFTError sftServer . runParser' (parser @HttpsUrl) . cs . strip . cs $ sftUrlResponse
+  where
+    -- FUTUREWORK: remove this adopted code once upgraded to bytestring >= 0.10.12.0
+    strip :: BS8.ByteString -> BS8.ByteString
+    strip = BS8.dropWhile isSpace . dropWhileEnd' isSpace
+      where
+        dropWhileEnd' :: (Char -> Bool) -> BS8.ByteString -> BS8.ByteString
+        dropWhileEnd' f ps = unsafeTake (findFromEndUntil (not . f . w2c) ps) ps
+        findFromEndUntil :: (Word8 -> Bool) -> BS8.ByteString -> Int
+        findFromEndUntil f ps@(PS _ _ l) = case unsnoc ps of
+          Nothing -> 0
+          Just (b, c) ->
+            if f c
+              then l
+              else findFromEndUntil f b

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -502,7 +502,15 @@ data Settings = Settings
 
 data SFTLookup = SFTLookup
   { sftlDomain :: !LookupDomain,
-    sftlPort :: !Port
+    sftlPort :: !Port,
+    -- FUTUREWORK: Get rid of the test environment flag below. This is to be
+    -- done by not looking up A records and consequently making GET requests via
+    -- HTTPS based on IP addresses, instead of domain names.
+
+    -- | Set to True if running in a test environment. This will avoid
+    -- performing SSL checks in a request to an SFT server. The default value is
+    -- False.
+    sftlIsTestEnv :: Bool
   }
   deriving (Show, Generic)
 
@@ -510,7 +518,8 @@ instance FromJSON SFTLookup where
   parseJSON = Aeson.withObject "SFTLookup" $ \o -> do
     d <- o Aeson..: "domain"
     p <- o Aeson..: "port"
-    pure $ SFTLookup d p
+    t <- o Aeson..:? "isTestingEnvironment" Aeson..!= False
+    pure $ SFTLookup d p t
 
 newtype LookupDomain = LookupDomain {unLookupDomain :: DNS.Domain}
   deriving stock (Show, Generic)

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -496,11 +496,21 @@ data Settings = Settings
     -- where SFTs are deployed behind a load-balancer.  In the long-run the SRV
     -- fetching logic can go away completely
     setSftStaticUrl :: !(Maybe HttpsUrl),
-    -- FUTUREWORK: Write documentation for these two lookup parameters
-    setSftLookupDomain :: !(Maybe LookupDomain),
-    setSftLookupPort :: !(Maybe Port)
+    setSftLookup :: !(Maybe SFTLookup)
   }
   deriving (Show, Generic)
+
+data SFTLookup = SFTLookup
+  { sftlDomain :: !LookupDomain,
+    sftlPort :: !Port
+  }
+  deriving (Show, Generic)
+
+instance FromJSON SFTLookup where
+  parseJSON = Aeson.withObject "SFTLookup" $ \o -> do
+    d <- o Aeson..: "domain"
+    p <- o Aeson..: "port"
+    pure $ SFTLookup d p
 
 newtype LookupDomain = LookupDomain {unLookupDomain :: DNS.Domain}
   deriving stock (Show, Generic)
@@ -702,8 +712,7 @@ Lens.makeLensesFor
     ("setFederationDomain", "federationDomain"),
     ("setSqsThrottleMillis", "sqsThrottleMillis"),
     ("setSftStaticUrl", "sftStaticUrl"),
-    ("setSftLookupDomain", "sftLookupDomain"),
-    ("setSftLookupPort", "sftLookupPort")
+    ("setSftLookup", "sftLookup")
   ]
   ''Settings
 

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -702,8 +702,8 @@ Lens.makeLensesFor
     ("setFederationDomain", "federationDomain"),
     ("setSqsThrottleMillis", "sqsThrottleMillis"),
     ("setSftStaticUrl", "sftStaticUrl"),
-    ("setSftStaticUrl", "sftLookupDomain"),
-    ("setSftStaticUrl", "sftLookupPort")
+    ("setSftLookupDomain", "sftLookupDomain"),
+    ("setSftLookupPort", "sftLookupPort")
   ]
   ''Settings
 

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -112,16 +112,21 @@ testSFT b opts = do
       "when SFT discovery is not enabled, sft_servers_all shouldn't be returned"
       Nothing
       (cfg ^. rtcConfSftServersAll)
-  withSettingsOverrides (opts & Opts.sftL ?~ Opts.SFTOptions "integration-tests.zinfra.io" Nothing (Just 0.001) Nothing "integration-tests.zinfra.io" (Port 8585)) $ do
+  withSettingsOverrides (opts & Opts.sftL ?~ Opts.SFTOptions "integration-tests.zinfra.io" Nothing (Just 0.001) Nothing) $ do
     cfg1 <- retryWhileN 10 (isNothing . view rtcConfSftServers) (getTurnConfigurationV2 uid b)
     -- These values are controlled by https://github.com/zinfra/cailleach/tree/77ca2d23cf2959aa183dd945d0a0b13537a8950d/environments/dns-integration-tests
     let Right server1 = mkHttpsUrl =<< first show (parseURI laxURIParserOptions "https://sft01.integration-tests.zinfra.io:443")
     let Right server2 = mkHttpsUrl =<< first show (parseURI laxURIParserOptions "https://sft02.integration-tests.zinfra.io:8443")
-    liftIO $
+    let Right clientUrl = mkHttpsUrl =<< first show (parseURI laxURIParserOptions "https://sft01.avs.zinfra.io")
+    liftIO $ do
       assertEqual
         "when SFT discovery is enabled, sft_servers should be returned"
         (Set.fromList [sftServer server1, sftServer server2])
         (Set.fromList $ maybe [] NonEmpty.toList $ cfg1 ^. rtcConfSftServers)
+      assertEqual
+        "when SFT discovery is enabled, sft_servers_all should be returned"
+        (Set.singleton . sftServer $ clientUrl)
+        (Set.fromList . fromMaybe [] $ cfg1 ^. rtcConfSftServersAll)
 
 modifyAndAssert ::
   Brig ->

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -117,16 +117,17 @@ testSFT b opts = do
     -- These values are controlled by https://github.com/zinfra/cailleach/tree/77ca2d23cf2959aa183dd945d0a0b13537a8950d/environments/dns-integration-tests
     let Right server1 = mkHttpsUrl =<< first show (parseURI laxURIParserOptions "https://sft01.integration-tests.zinfra.io:443")
     let Right server2 = mkHttpsUrl =<< first show (parseURI laxURIParserOptions "https://sft02.integration-tests.zinfra.io:8443")
-    let Right clientUrl = mkHttpsUrl =<< first show (parseURI laxURIParserOptions "https://sft01.avs.zinfra.io")
     liftIO $ do
       assertEqual
         "when SFT discovery is enabled, sft_servers should be returned"
         (Set.fromList [sftServer server1, sftServer server2])
         (Set.fromList $ maybe [] NonEmpty.toList $ cfg1 ^. rtcConfSftServers)
-      assertEqual
-        "when SFT discovery is enabled, sft_servers_all should be returned"
-        (Set.singleton . sftServer $ clientUrl)
-        (Set.fromList . fromMaybe [] $ cfg1 ^. rtcConfSftServersAll)
+      void . for (cfg1 ^. rtcConfSftServersAll) $ \allServers -> do
+        let Right clientUrl = mkHttpsUrl =<< first show (parseURI laxURIParserOptions "https://sft01.avs.zinfra.io")
+        assertEqual
+          "when SFT discovery is enabled and SFT lookup configured, sft_servers_all should be returned"
+          (Set.singleton . sftServer $ clientUrl)
+          (Set.fromList allServers)
 
 modifyAndAssert ::
   Brig ->

--- a/services/brig/test/unit/Test/Brig/Calling.hs
+++ b/services/brig/test/unit/Test/Brig/Calling.hs
@@ -25,7 +25,6 @@ import Control.Retry
 import Data.IP
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
-import Data.Misc (Port (..))
 import Data.Range
 import qualified Data.Set as Set
 import Imports
@@ -117,7 +116,7 @@ testDiscoveryLoopWhenSuccessful = do
       entry3 = SrvEntry 0 0 (SrvTarget "sft3.foo.example.com." 443)
       returnedEntries = entry1 :| [entry2, entry3]
   fakeDNSEnv <- newFakeDNSEnv (\_ -> SrvAvailable returnedEntries) undefined
-  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001) Nothing, LookupDomain "foo.example.com", Port 8585)
+  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001) Nothing, Nothing)
 
   discoveryLoop <- Async.async $ runM . ignoreLogs . runFakeDNSLookup fakeDNSEnv $ sftDiscoveryLoop sftEnv
   void $ retryEvery10MicrosWhileN 2000 (== 0) (length <$> readIORef (fakeLookupCalls fakeDNSEnv))
@@ -132,7 +131,7 @@ testDiscoveryLoopWhenSuccessful = do
 testDiscoveryLoopWhenUnsuccessful :: IO ()
 testDiscoveryLoopWhenUnsuccessful = do
   fakeDNSEnv <- newFakeDNSEnv (const SrvNotAvailable) undefined
-  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001) Nothing, LookupDomain "foo.example.com", Port 8585)
+  sftEnv <- mkSFTEnv (SFTOptions "foo.example.com" Nothing (Just 0.001) Nothing, Nothing)
 
   discoveryLoop <- Async.async $ runM . ignoreLogs . runFakeDNSLookup fakeDNSEnv $ sftDiscoveryLoop sftEnv
   -- We wait for at least two lookups to be sure that the lookup loop looped at


### PR DESCRIPTION
This is a follow-up to PR #2012 as part of https://wearezeta.atlassian.net/browse/FS-266:

- It places SFT lookup parameters to a better-suited section in Brig's configuration
- It enables making an insecure connection by using an IP address in a request to an SFT server (`https://<ip-address>/...`) if a test environment flag is set in Brig's configuration
- It fixes making a request `GET https://<sft-ip-address>/sft/url`

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
