### PR TITLE
Fix Brig's configmap for SFT Lookup Templating

### DIFF
--- a/changelog.d/6-federation/sft-brig-configmap-fix
+++ b/changelog.d/6-federation/sft-brig-configmap-fix
@@ -1,0 +1,1 @@
+Fix Brig's configmap for SFT lookups

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -231,9 +231,11 @@ data:
       {{- if .setSftLookup }}
       {{- with .setSftLookup }}
       setSftLookup:
-        domain: {{ required "Missing value: .setSftLookup.domain" .setSftLookup.domain }}
-        port: {{ required "Missing value: .setSftLookup.port" .setSftLookup.port }}
-        isTestingEnvironment: {{ .setSftLookup.isTestingEnvironment }}
+        domain: {{ required "Missing value: .setSftLookup.domain" .domain }}
+        port: {{ required "Missing value: .setSftLookup.port" .port }}
+        {{- if .isTestingEnvironment }}
+        isTestingEnvironment: {{ .isTestingEnvironment }}
+        {{- end }}
       {{- end }}
       {{- end }}
     {{- end }}

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -720,8 +720,7 @@ Lens.makeLensesFor
     ("setUserMaxPermClients", "userMaxPermClients"),
     ("setFederationDomain", "federationDomain"),
     ("setSqsThrottleMillis", "sqsThrottleMillis"),
-    ("setSftStaticUrl", "sftStaticUrl"),
-    ("setSftLookup", "sftLookup")
+    ("setSftStaticUrl", "sftStaticUrl")
   ]
   ''Settings
 


### PR DESCRIPTION
This is a follow-up to PR #2014 and part of https://wearezeta.atlassian.net/browse/FS-266. It fixes templating in Brig's configmap.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.