### PR TITLE
Simplify `rangedSchema` function

### DIFF
--- a/changelog.d/5-internal/simplify-ranged-schema
+++ b/changelog.d/5-internal/simplify-ranged-schema
@@ -1,0 +1,1 @@
+`rangedSchema` does not need to be passed singletons explicitly anymore

--- a/libs/types-common/src/Data/Range.hs
+++ b/libs/types-common/src/Data/Range.hs
@@ -122,14 +122,12 @@ instance (Within a n m, FromJSON a) => FromJSON (Range n m a) where
       msg sn sm = fail (errorMsg (fromSing sn) (fromSing sm) "")
 
 rangedSchema ::
+  forall n m d v w a b.
   (Within a n m, HasRangedSchemaDocModifier d b) =>
-  SNat n ->
-  SNat m ->
   SchemaP d v w a b ->
   SchemaP d v w a (Range n m b)
-rangedSchema sn sm sch = Range <$> untypedRangedSchema (get sn) (get sm) sch
-  where
-    get = toInteger . fromSing
+rangedSchema sch =
+  Range <$> untypedRangedSchema (toInteger (demote @n)) (toInteger (demote @m)) sch
 
 untypedRangedSchema ::
   forall d v w a b.
@@ -181,7 +179,7 @@ instance S.HasSchema d S.Schema => HasRangedSchemaDocModifier d Word32 where ran
 instance S.HasSchema d S.Schema => HasRangedSchemaDocModifier d Word64 where rangedSchemaDocModifier _ = numRangedSchemaDocModifier
 
 instance (Within a n m, ToSchema a, HasRangedSchemaDocModifier NamedSwaggerDoc a) => ToSchema (Range n m a) where
-  schema = fromRange .= rangedSchema sing sing schema
+  schema = fromRange .= rangedSchema schema
 
 instance (Within a n m, Cql a) => Cql (Range n m a) where
   ctype = retag (ctype :: Tagged a ColumnType)

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -100,7 +100,6 @@ import Data.Qualified (Qualified (qUnqualified), deprecatedSchema)
 import Data.Range (Range, fromRange, rangedSchema)
 import Data.Schema
 import qualified Data.Set as Set
-import Data.Singletons (sing)
 import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Swagger.Build.Api as Doc
@@ -366,7 +365,7 @@ instance ToSchema ListConversations where
       "ListConversations"
       (description ?~ "A request to list some of a user's conversations, including remote ones. Maximum 1000 qualified conversation IDs")
       $ ListConversations
-        <$> (fromRange . lcQualifiedIds) .= field "qualified_ids" (rangedSchema sing sing (array schema))
+        <$> (fromRange . lcQualifiedIds) .= field "qualified_ids" (rangedSchema (array schema))
 
 data ConversationsResponse = ConversationsResponse
   { crFound :: [Conversation],

--- a/libs/wire-api/src/Wire/API/Team.hs
+++ b/libs/wire-api/src/Wire/API/Team.hs
@@ -76,7 +76,6 @@ import Data.Id (TeamId, UserId)
 import Data.Misc (PlainTextPassword (..))
 import Data.Range
 import Data.Schema
-import Data.Singletons (sing)
 import qualified Data.Swagger as S
 import qualified Data.Swagger.Build.Api as Doc
 import Imports
@@ -215,7 +214,7 @@ instance ToSchema NonBindingNewTeam where
       unwrap (NonBindingNewTeam nt) = nt
 
       sch :: ValueSchema SwaggerDoc (Range 1 127 [TeamMember])
-      sch = fromRange .= rangedSchema sing sing (array schema)
+      sch = fromRange .= rangedSchema (array schema)
 
 modelNewNonBindingTeam :: Doc.Model
 modelNewNonBindingTeam = Doc.defineModel "newNonBindingTeam" $ do


### PR DESCRIPTION
There is no need to take in singletons in order to create the bounds for a ranged schema, so this PR simplifies `rangedSchema` so that it does not need to be passed singletons explicitly anymore.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
