### PR TITLE
Faster brig setup

### DIFF
--- a/changelog.d/5-internal/brig-faster-doc
+++ b/changelog.d/5-internal/brig-faster-doc
@@ -1,0 +1,1 @@
+The Swagger documentation module is not regenerated anymore if its content is unchanged

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -26,6 +26,7 @@ custom-setup
     , containers
     , directory
     , filepath
+    , text
 
 library
   exposed-modules:

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -17,6 +17,7 @@ custom-setup:
     - containers
     - directory
     - filepath
+    - text
 extra-source-files:
   - docs/*
 library:


### PR DESCRIPTION
This PR makes it so that the Swagger documentation module is not regenerated if its content is unchanged. This makes brig compile times a bit better.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
