### PR TITLE
brig->sft lookup: sft service internally talks http not https

### DIFF
--- a/services/brig/src/Brig/Effects/SFT.hs
+++ b/services/brig/src/Brig/Effects/SFT.hs
@@ -44,7 +44,7 @@ interpretSFT httpManager = interpret $ \(SFTGetClientUrl ipAddr port) -> do
   let req =
         parseRequest_ $
           mconcat
-            [ "GET https://",
+            [ "GET http://",
               show ipAddr,
               ":",
               show . portNumber $ port,


### PR DESCRIPTION
(note: this code is based on some deployment assumptions that don't hold and should be refactored again soon; see #2019 for upcoming work)

Fixup for the changes introduced in #2015 #2012 #2014 