### PR TITLE
Update servant.md: Add link to schema-profunctor README.md

### DIFF
--- a/docs/developer/servant.md
+++ b/docs/developer/servant.md
@@ -4,7 +4,7 @@ We currently use Servant for the public (i.e. client-facing) API in brig, galley
 
 Client-facing APIs are defined in `Wire.API.Routes.Public.{Brig,Galley}`. Internal APIs are all over the place at the moment. Federation APIs are in `Wire.API.Federation.API.{Brig,Galley}`.
 
-Our APIs are able to generate Swagger documentation semi-automatically using `servant-swagger2`. The `schema-profunctor` library (see README in libs/schema-profunctor) is used to create "schemas" for the input and output types used in the Servant APIs. A schema contains all the information needed to serialise/deserialise JSON values, as well as the documentation and metadata needed to generate Swagger.
+Our APIs are able to generate Swagger documentation semi-automatically using `servant-swagger2`. The `schema-profunctor` library (see [`README.md`](/libs/schema-profunctor/README.md) in `libs/schema-profunctor`) is used to create "schemas" for the input and output types used in the Servant APIs. A schema contains all the information needed to serialise/deserialise JSON values, as well as the documentation and metadata needed to generate Swagger.
 
 # Combinators
 


### PR DESCRIPTION
The link makes it easier to go to the mentioned `README.md`.

## Checklist

 - [X] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
