### PR TITLE
Remove uses of servant-generic in public Galley API

### DIFF
--- a/changelog.d/5-internal/avoid-servant-generics
+++ b/changelog.d/5-internal/avoid-servant-generics
@@ -1,0 +1,1 @@
+Replace servant-generic in Galley with a custom `Named` combinator

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -1,0 +1,40 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Routes.Named where
+
+import Data.Metrics.Servant
+import Data.Proxy
+import Imports
+import Servant.Server
+import Servant.Swagger
+
+newtype Named named x = Named {unnamed :: x}
+  deriving (Functor)
+
+instance HasSwagger api => HasSwagger (Named name api) where
+  toSwagger _ = toSwagger (Proxy @api)
+
+instance HasServer api ctx => HasServer (Named name api) ctx where
+  type ServerT (Named name api) m = Named name (ServerT api m)
+
+  route _ ctx action = route (Proxy @api) ctx (fmap unnamed action)
+  hoistServerWithContext _ ctx f =
+    fmap (hoistServerWithContext (Proxy @api) ctx f)
+
+instance RoutesToPaths api => RoutesToPaths (Named name api) where
+  getRoutes = getRoutes @api

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -31,7 +31,6 @@ import qualified Data.Swagger as Swagger
 import GHC.TypeLits (AppendSymbol)
 import Imports hiding (head)
 import Servant
-import Servant.API.Generic (ToServantApi, (:-))
 import Servant.Swagger.Internal
 import Servant.Swagger.Internal.Orphans ()
 import Wire.API.Conversation
@@ -40,6 +39,7 @@ import Wire.API.ErrorDescription
 import Wire.API.Event.Conversation
 import Wire.API.Message
 import Wire.API.Routes.MultiVerb
+import Wire.API.Routes.Named
 import Wire.API.Routes.Public
 import Wire.API.Routes.Public.Util
 import Wire.API.Routes.QualifiedCapture
@@ -85,501 +85,584 @@ type RemoveFromConversationVerb =
      ]
     (Maybe Event)
 
-data Api routes = Api
-  { -- Conversations
+type ServantAPI =
+  ConversationAPI
+    :<|> TeamConversationAPI
+    :<|> MessagingAPI
+    :<|> TeamAPI
+    :<|> FeatureAPI
 
-    getUnqualifiedConversation ::
-      routes
-        :- Summary "Get a conversation by ID"
+type ConversationAPI =
+  Named
+    "get-unqualified-conversation"
+    ( Summary "Get a conversation by ID"
         :> ZLocalUser
         :> "conversations"
         :> Capture "cnv" ConvId
-        :> Get '[Servant.JSON] Conversation,
-    getConversation ::
-      routes
-        :- Summary "Get a conversation by ID"
-        :> ZLocalUser
-        :> "conversations"
-        :> QualifiedCapture "cnv" ConvId
-        :> Get '[Servant.JSON] Conversation,
-    getConversationRoles ::
-      routes
-        :- Summary "Get existing roles available for the given conversation"
-        :> ZLocalUser
-        :> "conversations"
-        :> Capture "cnv" ConvId
-        :> "roles"
-        :> Get '[Servant.JSON] ConversationRolesList,
-    listConversationIdsUnqualified ::
-      routes
-        :- Summary "[deprecated] Get all local conversation IDs."
-        -- FUTUREWORK: add bounds to swagger schema for Range
-        :> ZLocalUser
-        :> "conversations"
-        :> "ids"
-        :> QueryParam'
-             [ Optional,
-               Strict,
-               Description "Conversation ID to start from (exclusive)"
-             ]
-             "start"
-             ConvId
-        :> QueryParam'
-             [ Optional,
-               Strict,
-               Description "Maximum number of IDs to return"
-             ]
-             "size"
-             (Range 1 1000 Int32)
-        :> Get '[Servant.JSON] (ConversationList ConvId),
-    listConversationIds ::
-      routes
-        :- Summary "Get all conversation IDs."
-          :> Description
-               "The IDs returned by this endpoint are paginated. To\
-               \ get the first page, make a call with the `paging_state` field set to\
-               \ `null` (or omitted). Whenever the `has_more` field of the response is\
-               \ set to `true`, more results are available, and they can be obtained\
-               \ by calling the endpoint again, but this time passing the value of\
-               \ `paging_state` returned by the previous call. One can continue in\
-               \ this fashion until all results are returned, which is indicated by\
-               \ `has_more` being `false`. Note that `paging_state` should be\
-               \ considered an opaque token. It should not be inspected, or stored, or\
-               \ reused across multiple unrelated invokations of the endpoint."
-          :> ZLocalUser
-          :> "conversations"
-          :> "list-ids"
-          :> ReqBody '[Servant.JSON] GetPaginatedConversationIds
-          :> Post '[Servant.JSON] ConvIdsPage,
-    getConversations ::
-      routes
-        :- Summary "Get all *local* conversations."
-        :> Description
-             "Will not return remote conversations.\n\n\
-             \Use `POST /conversations/list-ids` followed by \
-             \`POST /conversations/list/v2` instead."
-        :> ZLocalUser
-        :> "conversations"
-        :> QueryParam'
-             [ Optional,
-               Strict,
-               Description "Mutually exclusive with 'start' (at most 32 IDs per request)"
-             ]
-             "ids"
-             (Range 1 32 (CommaSeparatedList ConvId))
-        :> QueryParam'
-             [ Optional,
-               Strict,
-               Description "Conversation ID to start from (exclusive)"
-             ]
-             "start"
-             ConvId
-        :> QueryParam'
-             [ Optional,
-               Strict,
-               Description "Maximum number of conversations to return"
-             ]
-             "size"
-             (Range 1 500 Int32)
-        :> Get '[Servant.JSON] (ConversationList Conversation),
-    listConversations ::
-      routes
-        :- Summary "Get conversation metadata for a list of conversation ids"
-        :> ZLocalUser
-        :> "conversations"
-        :> "list"
-        :> "v2"
-        :> ReqBody '[Servant.JSON] ListConversations
-        :> Post '[Servant.JSON] ConversationsResponse,
+        :> Get '[Servant.JSON] Conversation
+    )
+    :<|> Named
+           "get-conversation"
+           ( Summary "Get a conversation by ID"
+               :> ZLocalUser
+               :> "conversations"
+               :> QualifiedCapture "cnv" ConvId
+               :> Get '[Servant.JSON] Conversation
+           )
+    :<|> Named
+           "get-conversation-roles"
+           ( Summary "Get existing roles available for the given conversation"
+               :> ZLocalUser
+               :> "conversations"
+               :> Capture "cnv" ConvId
+               :> "roles"
+               :> Get '[Servant.JSON] ConversationRolesList
+           )
+    :<|> Named
+           "list-conversation-ids-unqualified"
+           ( Summary "[deprecated] Get all local conversation IDs."
+               -- FUTUREWORK: add bounds to swagger schema for Range
+               :> ZLocalUser
+               :> "conversations"
+               :> "ids"
+               :> QueryParam'
+                    [ Optional,
+                      Strict,
+                      Description "Conversation ID to start from (exclusive)"
+                    ]
+                    "start"
+                    ConvId
+               :> QueryParam'
+                    [ Optional,
+                      Strict,
+                      Description "Maximum number of IDs to return"
+                    ]
+                    "size"
+                    (Range 1 1000 Int32)
+               :> Get '[Servant.JSON] (ConversationList ConvId)
+           )
+    :<|> Named
+           "list-conversation-ids"
+           ( Summary "Get all conversation IDs."
+               :> Description
+                    "The IDs returned by this endpoint are paginated. To\
+                    \ get the first page, make a call with the `paging_state` field set to\
+                    \ `null` (or omitted). Whenever the `has_more` field of the response is\
+                    \ set to `true`, more results are available, and they can be obtained\
+                    \ by calling the endpoint again, but this time passing the value of\
+                    \ `paging_state` returned by the previous call. One can continue in\
+                    \ this fashion until all results are returned, which is indicated by\
+                    \ `has_more` being `false`. Note that `paging_state` should be\
+                    \ considered an opaque token. It should not be inspected, or stored, or\
+                    \ reused across multiple unrelated invokations of the endpoint."
+               :> ZLocalUser
+               :> "conversations"
+               :> "list-ids"
+               :> ReqBody '[Servant.JSON] GetPaginatedConversationIds
+               :> Post '[Servant.JSON] ConvIdsPage
+           )
+    :<|> Named
+           "get-conversations"
+           ( Summary "Get all *local* conversations."
+               :> Description
+                    "Will not return remote conversations.\n\n\
+                    \Use `POST /conversations/list-ids` followed by \
+                    \`POST /conversations/list/v2` instead."
+               :> ZLocalUser
+               :> "conversations"
+               :> QueryParam'
+                    [ Optional,
+                      Strict,
+                      Description "Mutually exclusive with 'start' (at most 32 IDs per request)"
+                    ]
+                    "ids"
+                    (Range 1 32 (CommaSeparatedList ConvId))
+               :> QueryParam'
+                    [ Optional,
+                      Strict,
+                      Description "Conversation ID to start from (exclusive)"
+                    ]
+                    "start"
+                    ConvId
+               :> QueryParam'
+                    [ Optional,
+                      Strict,
+                      Description "Maximum number of conversations to return"
+                    ]
+                    "size"
+                    (Range 1 500 Int32)
+               :> Get '[Servant.JSON] (ConversationList Conversation)
+           )
+    :<|> Named
+           "list-conversations"
+           ( Summary "Get conversation metadata for a list of conversation ids"
+               :> ZLocalUser
+               :> "conversations"
+               :> "list"
+               :> "v2"
+               :> ReqBody '[Servant.JSON] ListConversations
+               :> Post '[Servant.JSON] ConversationsResponse
+           )
     -- This endpoint can lead to the following events being sent:
     -- - ConvCreate event to members
-    getConversationByReusableCode ::
-      routes
-        :- Summary "Get limited conversation information by key/code pair"
-        :> CanThrow NotATeamMember
-        :> CanThrow CodeNotFound
-        :> CanThrow ConvNotFound
-        :> CanThrow ConvAccessDenied
-        :> CanThrow GuestLinksDisabled
-        :> ZLocalUser
-        :> "conversations"
-        :> "join"
-        :> QueryParam' [Required, Strict] "key" Code.Key
-        :> QueryParam' [Required, Strict] "code" Code.Value
-        :> Get '[Servant.JSON] ConversationCoverView,
-    createGroupConversation ::
-      routes
-        :- Summary "Create a new conversation"
-        :> CanThrow NotConnected
-        :> CanThrow OperationDenied
-        :> CanThrow NotATeamMember
-        :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
-        :> ZLocalUser
-        :> ZConn
-        :> "conversations"
-        :> ReqBody '[Servant.JSON] NewConvUnmanaged
-        :> ConversationVerb,
-    createSelfConversation ::
-      routes
-        :- Summary "Create a self-conversation"
-        :> ZLocalUser
-        :> "conversations"
-        :> "self"
-        :> ConversationVerb,
+    :<|> Named
+           "get-conversation-by-reusable-code"
+           ( Summary "Get limited conversation information by key/code pair"
+               :> CanThrow NotATeamMember
+               :> CanThrow CodeNotFound
+               :> CanThrow ConvNotFound
+               :> CanThrow ConvAccessDenied
+               :> CanThrow GuestLinksDisabled
+               :> ZLocalUser
+               :> "conversations"
+               :> "join"
+               :> QueryParam' [Required, Strict] "key" Code.Key
+               :> QueryParam' [Required, Strict] "code" Code.Value
+               :> Get '[Servant.JSON] ConversationCoverView
+           )
+    :<|> Named
+           "create-group-conversation"
+           ( Summary "Create a new conversation"
+               :> CanThrow NotConnected
+               :> CanThrow OperationDenied
+               :> CanThrow NotATeamMember
+               :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
+               :> ZLocalUser
+               :> ZConn
+               :> "conversations"
+               :> ReqBody '[Servant.JSON] NewConvUnmanaged
+               :> ConversationVerb
+           )
+    :<|> Named
+           "create-self-conversation"
+           ( Summary "Create a self-conversation"
+               :> ZLocalUser
+               :> "conversations"
+               :> "self"
+               :> ConversationVerb
+           )
     -- This endpoint can lead to the following events being sent:
     -- - ConvCreate event to members
     -- TODO: add note: "On 201, the conversation ID is the `Location` header"
-    createOne2OneConversation ::
-      routes
-        :- Summary "Create a 1:1 conversation"
-        :> ZLocalUser
-        :> ZConn
-        :> "conversations"
-        :> "one2one"
-        :> ReqBody '[Servant.JSON] NewConvUnmanaged
-        :> ConversationVerb,
+    :<|> Named
+           "create-one-to-one-conversation"
+           ( Summary "Create a 1:1 conversation"
+               :> ZLocalUser
+               :> ZConn
+               :> "conversations"
+               :> "one2one"
+               :> ReqBody '[Servant.JSON] NewConvUnmanaged
+               :> ConversationVerb
+           )
     -- This endpoint can lead to the following events being sent:
     -- - MemberJoin event to members
-    addMembersToConversationUnqualified ::
-      routes
-        :- Summary "Add members to an existing conversation (deprecated)"
-        :> CanThrow ConvNotFound
-        :> CanThrow NotConnected
-        :> CanThrow ConvAccessDenied
-        :> CanThrow (InvalidOp "Invalid operation")
-        :> ZLocalUser
-        :> ZConn
-        :> "conversations"
-        :> Capture "cnv" ConvId
-        :> "members"
-        :> ReqBody '[JSON] Invite
-        :> MultiVerb 'POST '[JSON] ConvUpdateResponses (UpdateResult Event),
-    addMembersToConversation ::
-      routes
-        :- Summary "Add qualified members to an existing conversation."
-        :> ZLocalUser
-        :> ZConn
-        :> "conversations"
-        :> Capture "cnv" ConvId
-        :> "members"
-        :> "v2"
-        :> ReqBody '[Servant.JSON] InviteQualified
-        :> MultiVerb 'POST '[Servant.JSON] ConvUpdateResponses (UpdateResult Event),
+    :<|> Named
+           "add-members-to-conversation-unqualified"
+           ( Summary "Add members to an existing conversation (deprecated)"
+               :> CanThrow ConvNotFound
+               :> CanThrow NotConnected
+               :> CanThrow ConvAccessDenied
+               :> CanThrow (InvalidOp "Invalid operation")
+               :> ZLocalUser
+               :> ZConn
+               :> "conversations"
+               :> Capture "cnv" ConvId
+               :> "members"
+               :> ReqBody '[JSON] Invite
+               :> MultiVerb 'POST '[JSON] ConvUpdateResponses (UpdateResult Event)
+           )
+    :<|> Named
+           "add-members-to-conversation"
+           ( Summary "Add qualified members to an existing conversation."
+               :> ZLocalUser
+               :> ZConn
+               :> "conversations"
+               :> Capture "cnv" ConvId
+               :> "members"
+               :> "v2"
+               :> ReqBody '[Servant.JSON] InviteQualified
+               :> MultiVerb 'POST '[Servant.JSON] ConvUpdateResponses (UpdateResult Event)
+           )
     -- This endpoint can lead to the following events being sent:
     -- - MemberLeave event to members
-    removeMemberUnqualified ::
-      routes
-        :- Summary "Remove a member from a conversation (deprecated)"
-        :> ZLocalUser
-        :> ZConn
-        :> CanThrow ConvNotFound
-        :> CanThrow (InvalidOp "Invalid operation")
-        :> "conversations"
-        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "members"
-        :> Capture' '[Description "Target User ID"] "usr" UserId
-        :> RemoveFromConversationVerb,
+    :<|> Named
+           "remove-member-unqualified"
+           ( Summary "Remove a member from a conversation (deprecated)"
+               :> ZLocalUser
+               :> ZConn
+               :> CanThrow ConvNotFound
+               :> CanThrow (InvalidOp "Invalid operation")
+               :> "conversations"
+               :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "members"
+               :> Capture' '[Description "Target User ID"] "usr" UserId
+               :> RemoveFromConversationVerb
+           )
     -- This endpoint can lead to the following events being sent:
     -- - MemberLeave event to members
-    removeMember ::
-      routes
-        :- Summary "Remove a member from a conversation"
-        :> ZLocalUser
-        :> ZConn
-        :> CanThrow ConvNotFound
-        :> CanThrow (InvalidOp "Invalid operation")
-        :> "conversations"
-        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "members"
-        :> QualifiedCapture' '[Description "Target User ID"] "usr" UserId
-        :> RemoveFromConversationVerb,
+    :<|> Named
+           "remove-member"
+           ( Summary "Remove a member from a conversation"
+               :> ZLocalUser
+               :> ZConn
+               :> CanThrow ConvNotFound
+               :> CanThrow (InvalidOp "Invalid operation")
+               :> "conversations"
+               :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "members"
+               :> QualifiedCapture' '[Description "Target User ID"] "usr" UserId
+               :> RemoveFromConversationVerb
+           )
     -- This endpoint can lead to the following events being sent:
     -- - MemberStateUpdate event to members
-    updateOtherMemberUnqualified ::
-      routes
-        :- Summary "Update membership of the specified user (deprecated)"
-        :> Description "Use `PUT /conversations/:cnv_domain/:cnv/members/:usr_domain/:usr` instead"
-        :> ZLocalUser
-        :> ZConn
-        :> CanThrow ConvNotFound
-        :> CanThrow ConvMemberNotFound
-        :> CanThrow (InvalidOp "Invalid operation")
-        :> "conversations"
-        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "members"
-        :> Capture' '[Description "Target User ID"] "usr" UserId
-        :> ReqBody '[JSON] OtherMemberUpdate
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             '[RespondEmpty 200 "Membership updated"]
-             (),
-    updateOtherMember ::
-      routes
-        :- Summary "Update membership of the specified user"
-        :> Description "**Note**: at least one field has to be provided."
-        :> ZLocalUser
-        :> ZConn
-        :> CanThrow ConvNotFound
-        :> CanThrow ConvMemberNotFound
-        :> CanThrow (InvalidOp "Invalid operation")
-        :> "conversations"
-        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "members"
-        :> QualifiedCapture' '[Description "Target User ID"] "usr" UserId
-        :> ReqBody '[JSON] OtherMemberUpdate
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             '[RespondEmpty 200 "Membership updated"]
-             (),
+    :<|> Named
+           "update-other-member-unqualified"
+           ( Summary "Update membership of the specified user (deprecated)"
+               :> Description "Use `PUT /conversations/:cnv_domain/:cnv/members/:usr_domain/:usr` instead"
+               :> ZLocalUser
+               :> ZConn
+               :> CanThrow ConvNotFound
+               :> CanThrow ConvMemberNotFound
+               :> CanThrow (InvalidOp "Invalid operation")
+               :> "conversations"
+               :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "members"
+               :> Capture' '[Description "Target User ID"] "usr" UserId
+               :> ReqBody '[JSON] OtherMemberUpdate
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    '[RespondEmpty 200 "Membership updated"]
+                    ()
+           )
+    :<|> Named
+           "update-other-member"
+           ( Summary "Update membership of the specified user"
+               :> Description "**Note**: at least one field has to be provided."
+               :> ZLocalUser
+               :> ZConn
+               :> CanThrow ConvNotFound
+               :> CanThrow ConvMemberNotFound
+               :> CanThrow (InvalidOp "Invalid operation")
+               :> "conversations"
+               :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "members"
+               :> QualifiedCapture' '[Description "Target User ID"] "usr" UserId
+               :> ReqBody '[JSON] OtherMemberUpdate
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    '[RespondEmpty 200 "Membership updated"]
+                    ()
+           )
     -- This endpoint can lead to the following events being sent:
     -- - ConvRename event to members
-    updateConversationNameDeprecated ::
-      routes
-        :- Summary "Update conversation name (deprecated)"
-        :> Description "Use `/conversations/:domain/:conv/name` instead."
-        :> ZLocalUser
-        :> ZConn
-        :> "conversations"
-        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
-        :> ReqBody '[JSON] ConversationRename
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             [ ConvNotFound,
-               Respond 200 "Conversation updated" Event
-             ]
-             (Maybe Event),
-    updateConversationNameUnqualified ::
-      routes
-        :- Summary "Update conversation name (deprecated)"
-        :> Description "Use `/conversations/:domain/:conv/name` instead."
-        :> ZLocalUser
-        :> ZConn
-        :> "conversations"
-        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "name"
-        :> ReqBody '[JSON] ConversationRename
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             [ ConvNotFound,
-               Respond 200 "Conversation updated" Event
-             ]
-             (Maybe Event),
-    updateConversationName ::
-      routes
-        :- Summary "Update conversation name"
-        :> ZLocalUser
-        :> ZConn
-        :> "conversations"
-        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "name"
-        :> ReqBody '[JSON] ConversationRename
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             [ ConvNotFound,
-               Respond 200 "Conversation updated" Event
-             ]
-             (Maybe Event),
+    :<|> Named
+           "update-conversation-name-deprecated"
+           ( Summary "Update conversation name (deprecated)"
+               :> Description "Use `/conversations/:domain/:conv/name` instead."
+               :> ZLocalUser
+               :> ZConn
+               :> "conversations"
+               :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+               :> ReqBody '[JSON] ConversationRename
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    [ ConvNotFound,
+                      Respond 200 "Conversation updated" Event
+                    ]
+                    (Maybe Event)
+           )
+    :<|> Named
+           "update-conversation-name-unqualified"
+           ( Summary "Update conversation name (deprecated)"
+               :> Description "Use `/conversations/:domain/:conv/name` instead."
+               :> ZLocalUser
+               :> ZConn
+               :> "conversations"
+               :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "name"
+               :> ReqBody '[JSON] ConversationRename
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    [ ConvNotFound,
+                      Respond 200 "Conversation updated" Event
+                    ]
+                    (Maybe Event)
+           )
+    :<|> Named
+           "update-conversation-name"
+           ( Summary "Update conversation name"
+               :> ZLocalUser
+               :> ZConn
+               :> "conversations"
+               :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "name"
+               :> ReqBody '[JSON] ConversationRename
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    [ ConvNotFound,
+                      Respond 200 "Conversation updated" Event
+                    ]
+                    (Maybe Event)
+           )
     -- This endpoint can lead to the following events being sent:
     -- - ConvMessageTimerUpdate event to members
-    updateConversationMessageTimerUnqualified ::
-      routes
-        :- Summary "Update the message timer for a conversation (deprecated)"
-        :> Description "Use `/conversations/:domain/:cnv/message-timer` instead."
-        :> ZLocalUser
-        :> ZConn
-        :> CanThrow ConvAccessDenied
-        :> CanThrow ConvNotFound
-        :> CanThrow (InvalidOp "Invalid operation")
-        :> "conversations"
-        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "message-timer"
-        :> ReqBody '[JSON] ConversationMessageTimerUpdate
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             (UpdateResponses "Message timer unchanged" "Message timer updated" Event)
-             (UpdateResult Event),
-    updateConversationMessageTimer ::
-      routes
-        :- Summary "Update the message timer for a conversation"
-        :> ZLocalUser
-        :> ZConn
-        :> CanThrow ConvAccessDenied
-        :> CanThrow ConvNotFound
-        :> CanThrow (InvalidOp "Invalid operation")
-        :> "conversations"
-        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "message-timer"
-        :> ReqBody '[JSON] ConversationMessageTimerUpdate
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             (UpdateResponses "Message timer unchanged" "Message timer updated" Event)
-             (UpdateResult Event),
+    :<|> Named
+           "update-conversation-message-timer-unqualified"
+           ( Summary "Update the message timer for a conversation (deprecated)"
+               :> Description "Use `/conversations/:domain/:cnv/message-timer` instead."
+               :> ZLocalUser
+               :> ZConn
+               :> CanThrow ConvAccessDenied
+               :> CanThrow ConvNotFound
+               :> CanThrow (InvalidOp "Invalid operation")
+               :> "conversations"
+               :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "message-timer"
+               :> ReqBody '[JSON] ConversationMessageTimerUpdate
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    (UpdateResponses "Message timer unchanged" "Message timer updated" Event)
+                    (UpdateResult Event)
+           )
+    :<|> Named
+           "update-conversation-message-timer"
+           ( Summary "Update the message timer for a conversation"
+               :> ZLocalUser
+               :> ZConn
+               :> CanThrow ConvAccessDenied
+               :> CanThrow ConvNotFound
+               :> CanThrow (InvalidOp "Invalid operation")
+               :> "conversations"
+               :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "message-timer"
+               :> ReqBody '[JSON] ConversationMessageTimerUpdate
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    (UpdateResponses "Message timer unchanged" "Message timer updated" Event)
+                    (UpdateResult Event)
+           )
     -- This endpoint can lead to the following events being sent:
     -- - ConvReceiptModeUpdate event to members
-    updateConversationReceiptModeUnqualified ::
-      routes
-        :- Summary "Update receipt mode for a conversation (deprecated)"
-        :> Description "Use `PUT /conversations/:domain/:cnv/receipt-mode` instead."
-        :> ZLocalUser
-        :> ZConn
-        :> CanThrow ConvAccessDenied
-        :> CanThrow ConvNotFound
-        :> "conversations"
-        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "receipt-mode"
-        :> ReqBody '[JSON] ConversationReceiptModeUpdate
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             (UpdateResponses "Receipt mode unchanged" "Receipt mode updated" Event)
-             (UpdateResult Event),
-    updateConversationReceiptMode ::
-      routes
-        :- Summary "Update receipt mode for a conversation"
-        :> ZLocalUser
-        :> ZConn
-        :> CanThrow ConvAccessDenied
-        :> CanThrow ConvNotFound
-        :> "conversations"
-        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "receipt-mode"
-        :> ReqBody '[JSON] ConversationReceiptModeUpdate
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             (UpdateResponses "Receipt mode unchanged" "Receipt mode updated" Event)
-             (UpdateResult Event),
+    :<|> Named
+           "update-conversation-receipt-mode-unqualified"
+           ( Summary "Update receipt mode for a conversation (deprecated)"
+               :> Description "Use `PUT /conversations/:domain/:cnv/receipt-mode` instead."
+               :> ZLocalUser
+               :> ZConn
+               :> CanThrow ConvAccessDenied
+               :> CanThrow ConvNotFound
+               :> "conversations"
+               :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "receipt-mode"
+               :> ReqBody '[JSON] ConversationReceiptModeUpdate
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    (UpdateResponses "Receipt mode unchanged" "Receipt mode updated" Event)
+                    (UpdateResult Event)
+           )
+    :<|> Named
+           "update-conversation-receipt-mode"
+           ( Summary "Update receipt mode for a conversation"
+               :> ZLocalUser
+               :> ZConn
+               :> CanThrow ConvAccessDenied
+               :> CanThrow ConvNotFound
+               :> "conversations"
+               :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "receipt-mode"
+               :> ReqBody '[JSON] ConversationReceiptModeUpdate
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    (UpdateResponses "Receipt mode unchanged" "Receipt mode updated" Event)
+                    (UpdateResult Event)
+           )
     -- This endpoint can lead to the following events being sent:
     -- - MemberLeave event to members, if members get removed
     -- - ConvAccessUpdate event to members
-    updateConversationAccessUnqualified ::
-      routes
-        :- Summary "Update access modes for a conversation (deprecated)"
-        :> Description "Use PUT `/conversations/:domain/:cnv/access` instead."
-        :> ZLocalUser
-        :> ZConn
-        :> CanThrow ConvAccessDenied
-        :> CanThrow ConvNotFound
-        :> CanThrow (InvalidOp "Invalid operation")
-        :> "conversations"
-        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "access"
-        :> ReqBody '[JSON] ConversationAccessData
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             (UpdateResponses "Access unchanged" "Access updated" Event)
-             (UpdateResult Event),
-    updateConversationAccess ::
-      routes
-        :- Summary "Update access modes for a conversation"
-        :> ZLocalUser
-        :> ZConn
-        :> CanThrow ConvAccessDenied
-        :> CanThrow ConvNotFound
-        :> CanThrow (InvalidOp "Invalid operation")
-        :> "conversations"
-        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "access"
-        :> ReqBody '[JSON] ConversationAccessData
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             (UpdateResponses "Access unchanged" "Access updated" Event)
-             (UpdateResult Event),
-    getConversationSelfUnqualified ::
-      routes
-        :- Summary "Get self membership properties (deprecated)"
-        :> ZLocalUser
-        :> "conversations"
-        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "self"
-        :> Get '[JSON] (Maybe Member),
-    updateConversationSelfUnqualified ::
-      routes
-        :- Summary "Update self membership properties (deprecated)"
-        :> Description "Use `/conversations/:domain/:conv/self` instead."
-        :> CanThrow ConvNotFound
-        :> ZLocalUser
-        :> ZConn
-        :> "conversations"
-        :> Capture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "self"
-        :> ReqBody '[JSON] MemberUpdate
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             '[RespondEmpty 200 "Update successful"]
-             (),
-    updateConversationSelf ::
-      routes
-        :- Summary "Update self membership properties"
-        :> Description "**Note**: at least one field has to be provided."
-        :> CanThrow ConvNotFound
-        :> ZLocalUser
-        :> ZConn
-        :> "conversations"
-        :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
-        :> "self"
-        :> ReqBody '[JSON] MemberUpdate
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             '[RespondEmpty 200 "Update successful"]
-             (),
-    -- Team Conversations
+    :<|> Named
+           "update-conversation-access-unqualified"
+           ( Summary "Update access modes for a conversation (deprecated)"
+               :> Description "Use PUT `/conversations/:domain/:cnv/access` instead."
+               :> ZLocalUser
+               :> ZConn
+               :> CanThrow ConvAccessDenied
+               :> CanThrow ConvNotFound
+               :> CanThrow (InvalidOp "Invalid operation")
+               :> "conversations"
+               :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "access"
+               :> ReqBody '[JSON] ConversationAccessData
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    (UpdateResponses "Access unchanged" "Access updated" Event)
+                    (UpdateResult Event)
+           )
+    :<|> Named
+           "update-conversation-access"
+           ( Summary "Update access modes for a conversation"
+               :> ZLocalUser
+               :> ZConn
+               :> CanThrow ConvAccessDenied
+               :> CanThrow ConvNotFound
+               :> CanThrow (InvalidOp "Invalid operation")
+               :> "conversations"
+               :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "access"
+               :> ReqBody '[JSON] ConversationAccessData
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    (UpdateResponses "Access unchanged" "Access updated" Event)
+                    (UpdateResult Event)
+           )
+    :<|> Named
+           "get-conversation-self-unqualified"
+           ( Summary "Get self membership properties (deprecated)"
+               :> ZLocalUser
+               :> "conversations"
+               :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "self"
+               :> Get '[JSON] (Maybe Member)
+           )
+    :<|> Named
+           "update-conversation-self-unqualified"
+           ( Summary "Update self membership properties (deprecated)"
+               :> Description "Use `/conversations/:domain/:conv/self` instead."
+               :> CanThrow ConvNotFound
+               :> ZLocalUser
+               :> ZConn
+               :> "conversations"
+               :> Capture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "self"
+               :> ReqBody '[JSON] MemberUpdate
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    '[RespondEmpty 200 "Update successful"]
+                    ()
+           )
+    :<|> Named
+           "update-conversation-self"
+           ( Summary "Update self membership properties"
+               :> Description "**Note**: at least one field has to be provided."
+               :> CanThrow ConvNotFound
+               :> ZLocalUser
+               :> ZConn
+               :> "conversations"
+               :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
+               :> "self"
+               :> ReqBody '[JSON] MemberUpdate
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    '[RespondEmpty 200 "Update successful"]
+                    ()
+           )
 
-    getTeamConversationRoles ::
-      routes
-        :- Summary "Get existing roles available for the given team"
+type TeamConversationAPI =
+  Named
+    "get-team-conversation-roles"
+    ( Summary "Get existing roles available for the given team"
         :> CanThrow NotATeamMember
         :> ZUser
         :> "teams"
         :> Capture "tid" TeamId
         :> "conversations"
         :> "roles"
-        :> Get '[Servant.JSON] ConversationRolesList,
-    getTeamConversations ::
-      routes
-        :- Summary "Get team conversations"
-        :> CanThrow OperationDenied
+        :> Get '[Servant.JSON] ConversationRolesList
+    )
+    :<|> Named
+           "get-team-conversations"
+           ( Summary "Get team conversations"
+               :> CanThrow OperationDenied
+               :> ZUser
+               :> "teams"
+               :> Capture "tid" TeamId
+               :> "conversations"
+               :> Get '[Servant.JSON] TeamConversationList
+           )
+    :<|> Named
+           "get-team-conversation"
+           ( Summary "Get one team conversation"
+               :> CanThrow OperationDenied
+               :> ZUser
+               :> "teams"
+               :> Capture "tid" TeamId
+               :> "conversations"
+               :> Capture "cid" ConvId
+               :> Get '[Servant.JSON] TeamConversation
+           )
+    :<|> Named
+           "delete-team-conversation"
+           ( Summary "Remove a team conversation"
+               :> CanThrow NotATeamMember
+               :> CanThrow ActionDenied
+               :> ZLocalUser
+               :> ZConn
+               :> "teams"
+               :> Capture "tid" TeamId
+               :> "conversations"
+               :> Capture "cid" ConvId
+               :> MultiVerb 'DELETE '[JSON] '[RespondEmpty 200 "Conversation deleted"] ()
+           )
+
+type TeamAPI =
+  Named
+    "create-non-binding-team"
+    ( Summary "Create a new non binding team"
         :> ZUser
-        :> "teams"
-        :> Capture "tid" TeamId
-        :> "conversations"
-        :> Get '[Servant.JSON] TeamConversationList,
-    getTeamConversation ::
-      routes
-        :- Summary "Get one team conversation"
-        :> CanThrow OperationDenied
-        :> ZUser
-        :> "teams"
-        :> Capture "tid" TeamId
-        :> "conversations"
-        :> Capture "cid" ConvId
-        :> Get '[Servant.JSON] TeamConversation,
-    deleteTeamConversation ::
-      routes
-        :- Summary "Remove a team conversation"
-        :> CanThrow NotATeamMember
-        :> CanThrow ActionDenied
-        :> ZLocalUser
         :> ZConn
+        :> CanThrow NotConnected
         :> "teams"
-        :> Capture "tid" TeamId
-        :> "conversations"
-        :> Capture "cid" ConvId
-        :> MultiVerb 'DELETE '[JSON] '[RespondEmpty 200 "Conversation deleted"] (),
-    postOtrMessageUnqualified ::
-      routes
-        :- Summary "Post an encrypted message to a conversation (accepts JSON or Protobuf)"
+        :> ReqBody '[Servant.JSON] NonBindingNewTeam
+        :> MultiVerb
+             'POST
+             '[JSON]
+             '[ WithHeaders
+                  '[DescHeader "Location" "Team ID" TeamId]
+                  TeamId
+                  (RespondEmpty 201 "Team ID as `Location` header value")
+              ]
+             TeamId
+    )
+    :<|> Named
+           "update-team"
+           ( Summary "Update team properties"
+               :> ZUser
+               :> ZConn
+               :> CanThrow NotATeamMember
+               :> CanThrow (OperationDeniedError 'SetTeamData)
+               :> "teams"
+               :> Capture "tid" TeamId
+               :> ReqBody '[JSON] TeamUpdateData
+               :> MultiVerb
+                    'PUT
+                    '[JSON]
+                    '[RespondEmpty 200 "Team updated"]
+                    ()
+           )
+    :<|> Named
+           "get-teams"
+           ( Summary "Get teams (deprecated); use `GET /teams/:tid`"
+               :> ZUser
+               :> "teams"
+               :> Get '[JSON] TeamList
+           )
+
+type MessagingAPI =
+  Named
+    "post-otr-message-unqualified"
+    ( Summary "Post an encrypted message to a conversation (accepts JSON or Protobuf)"
         :> Description PostOtrDescriptionUnqualified
         :> ZLocalUser
         :> ZConn
@@ -594,219 +677,133 @@ data Api routes = Api
              'POST
              '[Servant.JSON]
              (PostOtrResponses ClientMismatch)
-             (Either (MessageNotSent ClientMismatch) ClientMismatch),
-    postProteusMessage ::
-      routes
-        :- Summary "Post an encrypted message to a conversation (accepts only Protobuf)"
-        :> Description PostOtrDescription
-        :> ZLocalUser
-        :> ZConn
-        :> "conversations"
-        :> QualifiedCapture "cnv" ConvId
-        :> "proteus"
-        :> "messages"
-        :> ReqBody '[Proto] (RawProto QualifiedNewOtrMessage)
-        :> MultiVerb
-             'POST
-             '[Servant.JSON]
-             (PostOtrResponses MessageSendingStatus)
-             (Either (MessageNotSent MessageSendingStatus) MessageSendingStatus),
-    -- team features
-    teamFeatureStatusSSOGet ::
-      routes
-        :- FeatureStatusGet 'TeamFeatureSSO,
-    teamFeatureStatusLegalHoldGet ::
-      routes
-        :- FeatureStatusGet 'TeamFeatureLegalHold,
-    teamFeatureStatusLegalHoldPut ::
-      routes
-        :- FeatureStatusPut 'TeamFeatureLegalHold,
-    teamFeatureStatusSearchVisibilityGet ::
-      routes
-        :- FeatureStatusGet 'TeamFeatureSearchVisibility,
-    teamFeatureStatusSearchVisibilityPut ::
-      routes
-        :- FeatureStatusPut 'TeamFeatureSearchVisibility,
-    teamFeatureStatusSearchVisibilityDeprecatedGet ::
-      routes
-        :- FeatureStatusDeprecatedGet 'WithoutLockStatus 'TeamFeatureSearchVisibility,
-    teamFeatureStatusSearchVisibilityDeprecatedPut ::
-      routes
-        :- FeatureStatusDeprecatedPut 'TeamFeatureSearchVisibility,
-    teamFeatureStatusValidateSAMLEmailsGet ::
-      routes
-        :- FeatureStatusGet 'TeamFeatureValidateSAMLEmails,
-    teamFeatureStatusValidateSAMLEmailsDeprecatedGet ::
-      routes
-        :- FeatureStatusDeprecatedGet 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails,
-    teamFeatureStatusDigitalSignaturesGet ::
-      routes
-        :- FeatureStatusGet 'TeamFeatureDigitalSignatures,
-    teamFeatureStatusDigitalSignaturesDeprecatedGet ::
-      routes
-        :- FeatureStatusDeprecatedGet 'WithoutLockStatus 'TeamFeatureDigitalSignatures,
-    teamFeatureStatusAppLockGet ::
-      routes
-        :- FeatureStatusGet 'TeamFeatureAppLock,
-    teamFeatureStatusAppLockPut ::
-      routes
-        :- FeatureStatusPut 'TeamFeatureAppLock,
-    teamFeatureStatusFileSharingGet ::
-      routes
-        :- FeatureStatusGet 'TeamFeatureFileSharing,
-    teamFeatureStatusFileSharingPut ::
-      routes
-        :- FeatureStatusPut 'TeamFeatureFileSharing,
-    teamFeatureStatusClassifiedDomainsGet ::
-      routes
-        :- FeatureStatusGet 'TeamFeatureClassifiedDomains,
-    teamFeatureStatusConferenceCallingGet ::
-      routes
-        :- FeatureStatusGet 'TeamFeatureConferenceCalling,
-    teamFeatureStatusSelfDeletingMessagesGet ::
-      routes
-        :- FeatureStatusGet 'TeamFeatureSelfDeletingMessages,
-    teamFeatureStatusSelfDeletingMessagesPut ::
-      routes
-        :- FeatureStatusPut 'TeamFeatureSelfDeletingMessages,
-    featureStatusGuestLinksGet ::
-      routes
-        :- FeatureStatusGet 'TeamFeatureGuestLinks,
-    featureStatusGuestLinksPut ::
-      routes
-        :- FeatureStatusPut 'TeamFeatureGuestLinks,
-    featureAllFeatureConfigsGet ::
-      routes
-        :- AllFeatureConfigsGet,
-    featureConfigLegalHoldGet ::
-      routes
-        :- FeatureConfigGet 'WithoutLockStatus 'TeamFeatureLegalHold,
-    featureConfigSSOGet ::
-      routes
-        :- FeatureConfigGet 'WithoutLockStatus 'TeamFeatureSSO,
-    featureConfigSearchVisibilityGet ::
-      routes
-        :- FeatureConfigGet 'WithoutLockStatus 'TeamFeatureSearchVisibility,
-    featureConfigValidateSAMLEmailsGet ::
-      routes
-        :- FeatureConfigGet 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails,
-    featureConfigDigitalSignaturesGet ::
-      routes
-        :- FeatureConfigGet 'WithoutLockStatus 'TeamFeatureDigitalSignatures,
-    featureConfigAppLockGet ::
-      routes
-        :- FeatureConfigGet 'WithoutLockStatus 'TeamFeatureAppLock,
-    featureConfigFileSharingGet ::
-      routes
-        :- FeatureConfigGet 'WithoutLockStatus 'TeamFeatureFileSharing,
-    featureConfigClassifiedDomainsGet ::
-      routes
-        :- FeatureConfigGet 'WithoutLockStatus 'TeamFeatureClassifiedDomains,
-    featureConfigConferenceCallingGet ::
-      routes
-        :- FeatureConfigGet 'WithLockStatus 'TeamFeatureConferenceCalling,
-    featureConfigSelfDeletingMessagesGet ::
-      routes
-        :- FeatureConfigGet 'WithLockStatus 'TeamFeatureSelfDeletingMessages,
-    featureConfigGuestLinksGet ::
-      routes
-        :- FeatureConfigGet 'WithLockStatus 'TeamFeatureGuestLinks,
-    -- teams
-    createNonBindingTeam ::
-      routes
-        :- Summary "Create a new non binding team"
-        :> ZUser
-        :> ZConn
-        :> CanThrow NotConnected
-        :> "teams"
-        :> ReqBody '[Servant.JSON] NonBindingNewTeam
-        :> MultiVerb
-             'POST
-             '[JSON]
-             '[ WithHeaders
-                  '[DescHeader "Location" "Team ID" TeamId]
-                  TeamId
-                  (RespondEmpty 201 "Team ID as `Location` header value")
-              ]
-             TeamId,
-    updateTeam ::
-      routes
-        :- Summary "Update team properties"
-        :> ZUser
-        :> ZConn
-        :> CanThrow NotATeamMember
-        :> CanThrow (OperationDeniedError 'SetTeamData)
-        :> "teams"
-        :> Capture "tid" TeamId
-        :> ReqBody '[JSON] TeamUpdateData
-        :> MultiVerb
-             'PUT
-             '[JSON]
-             '[RespondEmpty 200 "Team updated"]
-             (),
-    getTeams ::
-      routes
-        :- Summary "Get teams (deprecated); use `GET /teams/:tid`"
-        :> ZUser
-        :> "teams"
-        :> Get '[JSON] TeamList
-  }
-  deriving (Generic)
+             (Either (MessageNotSent ClientMismatch) ClientMismatch)
+    )
+    :<|> Named
+           "post-proteus-message"
+           ( Summary "Post an encrypted message to a conversation (accepts only Protobuf)"
+               :> Description PostOtrDescription
+               :> ZLocalUser
+               :> ZConn
+               :> "conversations"
+               :> QualifiedCapture "cnv" ConvId
+               :> "proteus"
+               :> "messages"
+               :> ReqBody '[Proto] (RawProto QualifiedNewOtrMessage)
+               :> MultiVerb
+                    'POST
+                    '[Servant.JSON]
+                    (PostOtrResponses MessageSendingStatus)
+                    (Either (MessageNotSent MessageSendingStatus) MessageSendingStatus)
+           )
 
-type ServantAPI = ToServantApi Api
+type FeatureAPI =
+  FeatureStatusGet 'TeamFeatureSSO
+    :<|> FeatureStatusGet 'TeamFeatureLegalHold
+    :<|> FeatureStatusPut 'TeamFeatureLegalHold
+    :<|> FeatureStatusGet 'TeamFeatureSearchVisibility
+    :<|> FeatureStatusPut 'TeamFeatureSearchVisibility
+    :<|> FeatureStatusDeprecatedGet 'WithoutLockStatus 'TeamFeatureSearchVisibility
+    :<|> FeatureStatusDeprecatedPut 'TeamFeatureSearchVisibility
+    :<|> FeatureStatusGet 'TeamFeatureValidateSAMLEmails
+    :<|> FeatureStatusDeprecatedGet 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails
+    :<|> FeatureStatusGet 'TeamFeatureDigitalSignatures
+    :<|> FeatureStatusDeprecatedGet 'WithoutLockStatus 'TeamFeatureDigitalSignatures
+    :<|> FeatureStatusGet 'TeamFeatureAppLock
+    :<|> FeatureStatusPut 'TeamFeatureAppLock
+    :<|> FeatureStatusGet 'TeamFeatureFileSharing
+    :<|> FeatureStatusPut 'TeamFeatureFileSharing
+    :<|> FeatureStatusGet 'TeamFeatureClassifiedDomains
+    :<|> FeatureStatusGet 'TeamFeatureConferenceCalling
+    :<|> FeatureStatusGet 'TeamFeatureSelfDeletingMessages
+    :<|> FeatureStatusPut 'TeamFeatureSelfDeletingMessages
+    :<|> FeatureStatusGet 'TeamFeatureGuestLinks
+    :<|> FeatureStatusPut 'TeamFeatureGuestLinks
+    :<|> AllFeatureConfigsGet
+    :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureLegalHold
+    :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureSSO
+    :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureSearchVisibility
+    :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails
+    :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureDigitalSignatures
+    :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureAppLock
+    :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureFileSharing
+    :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureClassifiedDomains
+    :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureConferenceCalling
+    :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureSelfDeletingMessages
+    :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureGuestLinks
 
 type FeatureStatusGet featureName =
-  Summary (AppendSymbol "Get config for " (KnownTeamFeatureNameSymbol featureName))
-    :> ZUser
-    :> "teams"
-    :> Capture "tid" TeamId
-    :> "features"
-    :> KnownTeamFeatureNameSymbol featureName
-    :> Get '[Servant.JSON] (TeamFeatureStatus 'WithLockStatus featureName)
+  Named
+    '("get", featureName)
+    ( Summary (AppendSymbol "Get config for " (KnownTeamFeatureNameSymbol featureName))
+        :> ZUser
+        :> "teams"
+        :> Capture "tid" TeamId
+        :> "features"
+        :> KnownTeamFeatureNameSymbol featureName
+        :> Get '[Servant.JSON] (TeamFeatureStatus 'WithLockStatus featureName)
+    )
 
 type FeatureStatusPut featureName =
-  Summary (AppendSymbol "Put config for " (KnownTeamFeatureNameSymbol featureName))
-    :> ZUser
-    :> "teams"
-    :> Capture "tid" TeamId
-    :> "features"
-    :> KnownTeamFeatureNameSymbol featureName
-    :> ReqBody '[Servant.JSON] (TeamFeatureStatus 'WithoutLockStatus featureName)
-    :> Put '[Servant.JSON] (TeamFeatureStatus 'WithoutLockStatus featureName)
+  Named
+    '("put", featureName)
+    ( Summary (AppendSymbol "Put config for " (KnownTeamFeatureNameSymbol featureName))
+        :> ZUser
+        :> "teams"
+        :> Capture "tid" TeamId
+        :> "features"
+        :> KnownTeamFeatureNameSymbol featureName
+        :> ReqBody '[Servant.JSON] (TeamFeatureStatus 'WithoutLockStatus featureName)
+        :> Put '[Servant.JSON] (TeamFeatureStatus 'WithoutLockStatus featureName)
+    )
 
 -- | A type for a GET endpoint for a feature with a deprecated path
 type FeatureStatusDeprecatedGet ps featureName =
-  Summary (AppendSymbol "[deprecated] Get config for " (KnownTeamFeatureNameSymbol featureName))
-    :> ZUser
-    :> "teams"
-    :> Capture "tid" TeamId
-    :> "features"
-    :> DeprecatedFeatureName featureName
-    :> Get '[Servant.JSON] (TeamFeatureStatus ps featureName)
+  Named
+    '("get-deprecated", featureName)
+    ( Summary
+        (AppendSymbol "[deprecated] Get config for " (KnownTeamFeatureNameSymbol featureName))
+        :> ZUser
+        :> "teams"
+        :> Capture "tid" TeamId
+        :> "features"
+        :> DeprecatedFeatureName featureName
+        :> Get '[Servant.JSON] (TeamFeatureStatus ps featureName)
+    )
 
 -- | A type for a PUT endpoint for a feature with a deprecated path
 type FeatureStatusDeprecatedPut featureName =
-  Summary (AppendSymbol "[deprecated] Get config for " (KnownTeamFeatureNameSymbol featureName))
-    :> ZUser
-    :> "teams"
-    :> Capture "tid" TeamId
-    :> "features"
-    :> DeprecatedFeatureName featureName
-    :> ReqBody '[Servant.JSON] (TeamFeatureStatus 'WithoutLockStatus featureName)
-    :> Put '[Servant.JSON] (TeamFeatureStatus 'WithoutLockStatus featureName)
+  Named
+    '("put-deprecated", featureName)
+    ( Summary
+        (AppendSymbol "[deprecated] Get config for " (KnownTeamFeatureNameSymbol featureName))
+        :> ZUser
+        :> "teams"
+        :> Capture "tid" TeamId
+        :> "features"
+        :> DeprecatedFeatureName featureName
+        :> ReqBody '[Servant.JSON] (TeamFeatureStatus 'WithoutLockStatus featureName)
+        :> Put '[Servant.JSON] (TeamFeatureStatus 'WithoutLockStatus featureName)
+    )
 
 type FeatureConfigGet ps featureName =
-  Summary (AppendSymbol "Get feature config for feature " (KnownTeamFeatureNameSymbol featureName))
-    :> ZUser
-    :> "feature-configs"
-    :> KnownTeamFeatureNameSymbol featureName
-    :> Get '[Servant.JSON] (TeamFeatureStatus ps featureName)
+  Named
+    '("get-config", featureName)
+    ( Summary (AppendSymbol "Get feature config for feature " (KnownTeamFeatureNameSymbol featureName))
+        :> ZUser
+        :> "feature-configs"
+        :> KnownTeamFeatureNameSymbol featureName
+        :> Get '[Servant.JSON] (TeamFeatureStatus ps featureName)
+    )
 
 type AllFeatureConfigsGet =
-  Summary "Get configurations of all features"
-    :> ZUser
-    :> "feature-configs"
-    :> Get '[Servant.JSON] AllFeatureConfigs
+  Named
+    "get-all-feature-configs"
+    ( Summary "Get configurations of all features"
+        :> ZUser
+        :> "feature-configs"
+        :> Get '[Servant.JSON] AllFeatureConfigs
+    )
 
 type PostOtrDescriptionUnqualified =
   "This endpoint ensures that the list of clients is correct and only sends the message if the list is correct.\n\

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 58d272ac852b49af92f6387c08a6a4f797f799df93374f68296cb67600b00653
+-- hash: 751fabb66be258a1c5a5cf055e0d9f8f59070f7084eb3dfdf88272f5ed177ed6
 
 name:           wire-api
 version:        0.1.0
@@ -54,6 +54,7 @@ library
       Wire.API.Routes.MultiTablePaging
       Wire.API.Routes.MultiTablePaging.State
       Wire.API.Routes.MultiVerb
+      Wire.API.Routes.Named
       Wire.API.Routes.Public
       Wire.API.Routes.Public.Brig
       Wire.API.Routes.Public.Cannon

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7b6d6110c4a94aa87c7d65d1e004acb6cbc1ce6775be39cde27ff7e5eca83f59
+-- hash: 5ca30f9e591f66b924afc6773c95ecd6284e794ced766eca4ebe37af49b4984a
 
 name:           galley
 version:        0.83.0
@@ -38,6 +38,7 @@ library
       Galley.API.Message
       Galley.API.One2One
       Galley.API.Public
+      Galley.API.Public.Servant
       Galley.API.Query
       Galley.API.Teams
       Galley.API.Teams.Features

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -17,13 +17,14 @@
 
 module Galley.API
   ( sitemap,
-    Public.servantSitemap,
+    servantSitemap,
   )
 where
 
 import qualified Data.Swagger.Build.Api as Doc
 import qualified Galley.API.Internal as Internal
 import qualified Galley.API.Public as Public
+import Galley.API.Public.Servant
 import Galley.App (GalleyEffects)
 import Network.Wai.Routing (Routes)
 import Polysemy

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -1,0 +1,234 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.API.Public.Servant (servantSitemap) where
+
+import Galley.API.Create
+import Galley.API.Query
+import Galley.API.Teams
+import Galley.API.Teams.Features
+import Galley.API.Update
+import Galley.App
+import Galley.Cassandra.Paging
+import Imports
+import Polysemy
+import Servant.API
+import Servant.Server
+import Wire.API.Routes.Named
+import Wire.API.Routes.Public.Galley
+import Wire.API.Team.Feature
+
+servantSitemap :: ServerT ServantAPI (Sem GalleyEffects)
+servantSitemap = conversations :<|> teamConversations :<|> messaging :<|> team :<|> features
+  where
+    conversations =
+      Named @"get-unqualified-conversation" getUnqualifiedConversation
+        :<|> Named @"get-conversation" getConversation
+        :<|> Named @"get-conversation-roles" getConversationRoles
+        :<|> Named @"list-conversation-ids-unqualified" conversationIdsPageFromUnqualified
+        :<|> Named @"list-conversation-ids" conversationIdsPageFrom
+        :<|> Named @"get-conversations" getConversations
+        :<|> Named @"list-conversations" listConversations
+        :<|> Named @"get-conversation-by-reusable-code" getConversationByReusableCode
+        :<|> Named @"create-group-conversation" createGroupConversation
+        :<|> Named @"create-self-conversation" createSelfConversation
+        :<|> Named @"create-one-to-one-conversation" createOne2OneConversation
+        :<|> Named @"add-members-to-conversation-unqualified" addMembersUnqualified
+        :<|> Named @"add-members-to-conversation" addMembers
+        :<|> Named @"remove-member-unqualified" removeMemberUnqualified
+        :<|> Named @"remove-member" removeMemberQualified
+        :<|> Named @"update-other-member-unqualified" updateOtherMemberUnqualified
+        :<|> Named @"update-other-member" updateOtherMember
+        :<|> Named @"update-conversation-name-deprecated" updateUnqualifiedConversationName
+        :<|> Named @"update-conversation-name-unqualified" updateUnqualifiedConversationName
+        :<|> Named @"update-conversation-name" updateConversationName
+        :<|> Named @"update-conversation-message-timer-unqualified" updateConversationMessageTimerUnqualified
+        :<|> Named @"update-conversation-message-timer" updateConversationMessageTimer
+        :<|> Named @"update-conversation-receipt-mode-unqualified" updateConversationReceiptModeUnqualified
+        :<|> Named @"update-conversation-receipt-mode" updateConversationReceiptMode
+        :<|> Named @"update-conversation-access-unqualified" updateConversationAccessUnqualified
+        :<|> Named @"update-conversation-access" updateConversationAccess
+        :<|> Named @"get-conversation-self-unqualified" getLocalSelf
+        :<|> Named @"update-conversation-self-unqualified" updateUnqualifiedSelfMember
+        :<|> Named @"update-conversation-self" updateSelfMember
+
+    teamConversations =
+      Named @"get-team-conversation-roles" getTeamConversationRoles
+        :<|> Named @"get-team-conversations" getTeamConversations
+        :<|> Named @"get-team-conversation" getTeamConversation
+        :<|> Named @"delete-team-conversation" deleteTeamConversation
+
+    messaging =
+      Named @"post-otr-message-unqualified" postOtrMessageUnqualified
+        :<|> Named @"post-proteus-message" postProteusMessage
+
+    team =
+      Named @"create-non-binding-team" createNonBindingTeamH
+        :<|> Named @"update-team" updateTeamH
+        :<|> Named @"get-teams" getManyTeams
+
+    features =
+      Named @'("get", 'TeamFeatureSSO)
+        ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureSSO
+            getSSOStatusInternal
+            . DoAuth
+        )
+        :<|> Named @'("get", 'TeamFeatureLegalHold)
+          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureLegalHold
+              getLegalholdStatusInternal
+              . DoAuth
+          )
+        :<|> Named @'("put", 'TeamFeatureLegalHold)
+          ( setFeatureStatus @'TeamFeatureLegalHold
+              (setLegalholdStatusInternal @InternalPaging)
+              . DoAuth
+          )
+        :<|> Named @'("get", 'TeamFeatureSearchVisibility)
+          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureSearchVisibility
+              getTeamSearchVisibilityAvailableInternal
+              . DoAuth
+          )
+        :<|> Named @'("put", 'TeamFeatureSearchVisibility)
+          ( setFeatureStatus @'TeamFeatureSearchVisibility
+              setTeamSearchVisibilityAvailableInternal
+              . DoAuth
+          )
+        :<|> Named @'("get-deprecated", 'TeamFeatureSearchVisibility)
+          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureSearchVisibility
+              getTeamSearchVisibilityAvailableInternal
+              . DoAuth
+          )
+        :<|> Named @'("put-deprecated", 'TeamFeatureSearchVisibility)
+          ( setFeatureStatus @'TeamFeatureSearchVisibility
+              setTeamSearchVisibilityAvailableInternal
+              . DoAuth
+          )
+        :<|> Named @'("get", 'TeamFeatureValidateSAMLEmails)
+          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureValidateSAMLEmails
+              getValidateSAMLEmailsInternal
+              . DoAuth
+          )
+        :<|> Named @'("get-deprecated", 'TeamFeatureValidateSAMLEmails)
+          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureValidateSAMLEmails
+              getValidateSAMLEmailsInternal
+              . DoAuth
+          )
+        :<|> Named @'("get", 'TeamFeatureDigitalSignatures)
+          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureDigitalSignatures
+              getDigitalSignaturesInternal
+              . DoAuth
+          )
+        :<|> Named @'("get-deprecated", 'TeamFeatureDigitalSignatures)
+          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureDigitalSignatures
+              getDigitalSignaturesInternal
+              . DoAuth
+          )
+        :<|> Named @'("get", 'TeamFeatureAppLock)
+          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureAppLock
+              getAppLockInternal
+              . DoAuth
+          )
+        :<|> Named @'("put", 'TeamFeatureAppLock)
+          ( setFeatureStatus @'TeamFeatureAppLock
+              setAppLockInternal
+              . DoAuth
+          )
+        :<|> Named @'("get", 'TeamFeatureFileSharing)
+          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureFileSharing
+              getFileSharingInternal
+              . DoAuth
+          )
+        :<|> Named @'("put", 'TeamFeatureFileSharing)
+          ( setFeatureStatus @'TeamFeatureFileSharing
+              setFileSharingInternal
+              . DoAuth
+          )
+        :<|> Named @'("get", 'TeamFeatureClassifiedDomains)
+          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureClassifiedDomains
+              getClassifiedDomainsInternal
+              . DoAuth
+          )
+        :<|> Named @'("get", 'TeamFeatureConferenceCalling)
+          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureConferenceCalling
+              getConferenceCallingInternal
+              . DoAuth
+          )
+        :<|> Named @'("get", 'TeamFeatureSelfDeletingMessages)
+          ( getFeatureStatus @'WithLockStatus @'TeamFeatureSelfDeletingMessages
+              getSelfDeletingMessagesInternal
+              . DoAuth
+          )
+        :<|> Named @'("put", 'TeamFeatureSelfDeletingMessages)
+          ( setFeatureStatus @'TeamFeatureSelfDeletingMessages
+              setSelfDeletingMessagesInternal
+              . DoAuth
+          )
+        :<|> Named @'("get", 'TeamFeatureGuestLinks)
+          ( getFeatureStatus @'WithLockStatus @'TeamFeatureGuestLinks
+              getGuestLinkInternal
+              . DoAuth
+          )
+        :<|> Named @'("put", 'TeamFeatureGuestLinks)
+          ( setFeatureStatus @'TeamFeatureGuestLinks
+              setGuestLinkInternal
+              . DoAuth
+          )
+        :<|> Named @"get-all-feature-configs" getAllFeatureConfigs
+        :<|> Named @'("get-config", 'TeamFeatureLegalHold)
+          ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureLegalHold
+              getLegalholdStatusInternal
+          )
+        :<|> Named @'("get-config", 'TeamFeatureSSO)
+          ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureSSO
+              getSSOStatusInternal
+          )
+        :<|> Named @'("get-config", 'TeamFeatureSearchVisibility)
+          ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureSearchVisibility
+              getTeamSearchVisibilityAvailableInternal
+          )
+        :<|> Named @'("get-config", 'TeamFeatureValidateSAMLEmails)
+          ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureValidateSAMLEmails
+              getValidateSAMLEmailsInternal
+          )
+        :<|> Named @'("get-config", 'TeamFeatureDigitalSignatures)
+          ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureDigitalSignatures
+              getDigitalSignaturesInternal
+          )
+        :<|> Named @'("get-config", 'TeamFeatureAppLock)
+          ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureAppLock
+              getAppLockInternal
+          )
+        :<|> Named @'("get-config", 'TeamFeatureFileSharing)
+          ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureFileSharing
+              getFileSharingInternal
+          )
+        :<|> Named @'("get-config", 'TeamFeatureClassifiedDomains)
+          ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureClassifiedDomains
+              getClassifiedDomainsInternal
+          )
+        :<|> Named @'("get-config", 'TeamFeatureConferenceCalling)
+          ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureConferenceCalling
+              getConferenceCallingInternal
+          )
+        :<|> Named @'("get-config", 'TeamFeatureSelfDeletingMessages)
+          ( getFeatureConfig @'WithLockStatus @'TeamFeatureSelfDeletingMessages
+              getSelfDeletingMessagesInternal
+          )
+        :<|> Named @'("get-config", 'TeamFeatureGuestLinks)
+          ( getFeatureConfig @'WithLockStatus @'TeamFeatureGuestLinks
+              getGuestLinkInternal
+          )


### PR DESCRIPTION
The generic mechanism in Servant for defining API types is cumbersome and slow to compile. This commit replaces the API record for the public Galley API with a tree explicitly built using the `:<|>` operator.

To make up for the lack of record labels, it also introduces a `Named` combinator for servant API types, which can be used to tag an endpoint with a name (usually a symbol). The name must match the one with which the handler is wrapped.

Compile times are indeed better with this change, but unfortunately not by much.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
