### PR TITLE
[FS-266] Fix SFT URL fecthing based on plain HTTP via IPv4

### DIFF
--- a/changelog.d/6-federation/sft-fix-ipv4-http
+++ b/changelog.d/6-federation/sft-fix-ipv4-http
@@ -1,0 +1,1 @@
+Allow making HTTP-only requests to SFTs via an IPv4 address

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: addf4b080e564149f44c6cdb33c824734aa68cc9ff021f41268938902e2958b0
+-- hash: 2f8a3d719633015dac9204d43e0b4c79ce5b21b022cd9d4cce3868feea9460e8
 
 name:           brig
 version:        2.0
@@ -506,6 +506,7 @@ test-suite brig-tests
     , polysemy-wire-zoo
     , retry
     , servant-client-core
+    , string-conversions
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -182,7 +182,7 @@ optSettings:
   # to be added to the CI environment
   setSftLookup:
     domain: sftd.integration-tests.zinfra.io
-    port: 443
+    port: 80
     isTestingEnvironment: true
 
 logLevel: Warn

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -169,6 +169,7 @@ tests:
     - polysemy-wire-zoo
     - retry
     - servant-client-core
+    - string-conversions
     - tasty
     - tasty-hunit
     - tasty-quickcheck

--- a/services/brig/src/Brig/Calling.hs
+++ b/services/brig/src/Brig/Calling.hs
@@ -140,7 +140,9 @@ discoverSFTServers domain =
 discoverSFTServersAll :: Members [DNSLookup, TinyLog] r => DNS.Domain -> Sem r (Maybe [IPv4])
 discoverSFTServersAll domain =
   lookupA domain >>= \case
-    AIPv4s ips -> pure . Just $ ips
+    AIPv4s ips -> do
+      info (Log.msg ("Found the following IP addresses for SFT servers" :: ByteString) . Log.field "addresses" (show ips))
+      pure . Just $ ips
     AResponseError e -> do
       err (Log.msg ("DNS Lookup failed for SFT Discovery" :: ByteString) . Log.field "Error" (show e))
       pure Nothing

--- a/services/brig/src/Brig/Effects/SFT.hs
+++ b/services/brig/src/Brig/Effects/SFT.hs
@@ -44,7 +44,7 @@ interpretSFT httpManager = interpret $ \(SFTGetClientUrl ipAddr port) -> do
   let req =
         parseRequest_ $
           mconcat
-            [ "GET https://",
+            [ "GET http://",
               show ipAddr,
               ":",
               show . portNumber $ port,

--- a/services/brig/test/unit/Test/Brig/Calling.hs
+++ b/services/brig/test/unit/Test/Brig/Calling.hs
@@ -27,6 +27,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Range
 import qualified Data.Set as Set
+import Data.String.Conversions
 import Imports
 import Network.DNS
 import Polysemy
@@ -264,7 +265,14 @@ testSFTDiscoverAWhenAvailable = do
     =<< ( runM . recordLogs logRecorder . runFakeDNSLookup fakeDNSEnv $
             discoverSFTServersAll "foo.example.com"
         )
-  assertEqual "nothing should be logged" []
+  assertEqual
+    "should report discovered IP addresses"
+    [ ( Log.Info,
+        "Found the following IP addresses for SFT servers, addresses="
+          <> (cs . show $ returnedEntries)
+          <> "\n"
+      )
+    ]
     =<< readIORef (recordedLogs logRecorder)
 
 testSFTDiscoverAWhenDNSFails :: IO ()


### PR DESCRIPTION
This is part of https://wearezeta.atlassian.net/browse/FS-266:

- It allows for using a plain HTTP connection given an IPv4 address of an SFT server,
- It adds a proper integration test for `sft_servers_all` as the previously extended test silently ignored a code path.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
