### PR TITLE
SQSERVICES 1011 Servantify Gally Team API (GET /teams)

### DIFF
--- a/changelog.d/0-release-notes/pr-2027
+++ b/changelog.d/0-release-notes/pr-2027
@@ -1,0 +1,8 @@
+The deprecated endpoint `GET /teams` has changed slightly in a non-breaking way.
+The endpoint was designed to query non-binding teams. However, non-binding teams is a feature 
+that has never been implemented, but the endpoint also returns the binding team of a user and it is 
+possible that this is being used by a client, even though unlikely.
+
+The following functionality has been changed. Query parameters will be ignored, which has the effect 
+that regardless of the parameters the response will always contain the binding team of the user if 
+it exists. Even though they are ignored, the use of query parameters will not result in an error.

--- a/changelog.d/0-release-notes/pr-2027
+++ b/changelog.d/0-release-notes/pr-2027
@@ -1,8 +1,0 @@
-The deprecated endpoint `GET /teams` has changed slightly in a non-breaking way.
-The endpoint was designed to query non-binding teams. However, non-binding teams is a feature 
-that has never been implemented, but the endpoint also returns the binding team of a user and it is 
-possible that this is being used by a client, even though unlikely.
-
-The following functionality has been changed. Query parameters will be ignored, which has the effect 
-that regardless of the parameters the response will always contain the binding team of the user if 
-it exists. Even though they are ignored, the use of query parameters will not result in an error.

--- a/changelog.d/1-api-changes/pr-2027
+++ b/changelog.d/1-api-changes/pr-2027
@@ -1,0 +1,1 @@
+The deprecated endpoint `GET /teams` now ignores query parameters `ids`, `start`

--- a/changelog.d/5-internal/pr-2008
+++ b/changelog.d/5-internal/pr-2008
@@ -1,1 +1,1 @@
-Servantify Galley Teams API. (#2008, #2010)
+Servantify Galley Teams API. (#2008, #2010, #2027)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -744,15 +744,14 @@ data Api routes = Api
              '[JSON]
              '[RespondEmpty 200 "Team updated"]
              (),
-    getTeams :: routes :- GetTeams
+    getTeams ::
+      routes
+        :- Summary "Get teams (deprecated); use `GET /teams/:tid`"
+        :> ZUser
+        :> "teams"
+        :> Get '[JSON] TeamList
   }
   deriving (Generic)
-
-type GetTeams =
-  Summary "Get teams (deprecated)"
-    :> ZUser
-    :> "teams"
-    :> Get '[JSON] TeamList
 
 type ServantAPI = ToServantApi Api
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -743,22 +743,16 @@ data Api routes = Api
              'PUT
              '[JSON]
              '[RespondEmpty 200 "Team updated"]
-             ()
+             (),
+    getTeams :: routes :- GetTeams
   }
   deriving (Generic)
 
 type GetTeams =
   Summary "Get teams"
     :> ZUser
-    :> ZConn
     :> "teams"
-    :> QueryParam'
-         [ Optional,
-           Strict,
-           Description "Max. number of teams to return"
-         ]
-         "size"
-         (Range 1 100 Int32)
+    :> Get '[JSON] TeamList
 
 type ServantAPI = ToServantApi Api
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -49,6 +49,8 @@ import Wire.API.Team.Conversation
 import Wire.API.Team.Feature
 import Wire.API.Team.Permission (Perm (..))
 
+-- import Wire.API.Team.Permission (Perm (..))
+
 instance AsHeaders '[ConvId] Conversation Conversation where
   toHeaders c = (I (qUnqualified (cnvQualifiedId c)) :* Nil, c)
   fromHeaders = snd
@@ -744,6 +746,13 @@ data Api routes = Api
              ()
   }
   deriving (Generic)
+
+type GetTeams =
+  Summary "Get teams"
+    :> ZUser
+    :> ZConn
+    :> "teams"
+    :> Capture "size" (Range 1 100 Int32)
 
 type ServantAPI = ToServantApi Api
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -752,7 +752,13 @@ type GetTeams =
     :> ZUser
     :> ZConn
     :> "teams"
-    :> Capture "size" (Range 1 100 Int32)
+    :> QueryParam'
+         [ Optional,
+           Strict,
+           Description "Max. number of teams to return"
+         ]
+         "size"
+         (Range 1 100 Int32)
 
 type ServantAPI = ToServantApi Api
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -749,7 +749,7 @@ data Api routes = Api
   deriving (Generic)
 
 type GetTeams =
-  Summary "Get teams"
+  Summary "Get teams (deprecated)"
     :> ZUser
     :> "teams"
     :> Get '[JSON] TeamList

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -189,31 +189,13 @@ servantSitemap =
         GalleyAPI.featureConfigSelfDeletingMessagesGet = Features.getFeatureConfig @'Public.WithLockStatus @'Public.TeamFeatureSelfDeletingMessages Features.getSelfDeletingMessagesInternal,
         GalleyAPI.featureConfigGuestLinksGet = Features.getFeatureConfig @'Public.WithLockStatus @'Public.TeamFeatureGuestLinks Features.getGuestLinkInternal,
         GalleyAPI.createNonBindingTeam = Teams.createNonBindingTeamH,
-        GalleyAPI.updateTeam = Teams.updateTeamH
+        GalleyAPI.updateTeam = Teams.updateTeamH,
+        GalleyAPI.getTeams = Teams.getManyTeams
       }
 
 sitemap :: Routes ApiBuilder (Sem GalleyEffects) ()
 sitemap = do
   -- Team API -----------------------------------------------------------
-
-  get "/teams" (continue Teams.getManyTeamsH) $
-    zauthUserId
-      .&. opt (query "ids" ||| query "start")
-      .&. def (unsafeRange 100) (query "size")
-      .&. accept "application" "json"
-  document "GET" "getManyTeams" $ do
-    parameter Query "ids" (array string') $ do
-      optional
-      description "At most 32 team IDs per request. Mutually exclusive with `start`."
-    parameter Query "start" string' $ do
-      optional
-      description "Team ID to start from (exclusive). Mutually exclusive with `ids`."
-    parameter Query "size" (int32Between 1 100) $ do
-      optional
-      description "Max. number of teams to return"
-    summary "Get teams"
-    returns (ref Public.modelTeamList)
-    response 200 "Teams list" end
 
   get "/teams/:tid" (continue Teams.getTeamH) $
     zauthUserId

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -171,6 +171,19 @@ getTeamNameInternalH (tid ::: _) =
 getTeamNameInternal :: Member TeamStore r => TeamId -> Sem r (Maybe TeamName)
 getTeamNameInternal = fmap (fmap TeamName) . E.getTeamName
 
+-- | DEPRECATED.
+--
+-- The endpoint was designed to query non-binding teams. However, non-binding teams is a feature
+-- that has never been adopted by clients, but the endpoint also returns the binding team of a user and it is
+-- possible that this is being used by a client, even though unlikely.
+--
+-- The following functionality has been changed: query parameters will be ignored, which has the effect
+-- that regardless of the parameters the response will always contain the binding team of the user if
+-- it exists. Even though they are ignored, the use of query parameters will not result in an error.
+--
+-- (If you want to be pedantic, the `size` parameter is still honored: its allowed range is
+-- between 1 and 100, and that will always be an upper bound of the result set of size 0 or
+-- one.)
 getManyTeams ::
   (Members '[TeamStore, Queue DeleteItem, ListItems LegacyPaging TeamId] r) =>
   UserId ->

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -170,12 +170,14 @@ testGetTeams = do
   owner <- Util.randomUser
   Util.getTeams owner [] >>= checkTeamList Nothing
   tid <- Util.createBindingTeamInternal "foo" owner <* assertQueue "create team" tActivate
+  wrongTid <- (Util.randomUser >>= Util.createBindingTeamInternal "foobar") <* assertQueue "create team" tActivate
   Util.getTeams owner [] >>= checkTeamList (Just tid)
   Util.getTeams owner [("size", "1")] >>= checkTeamList (Just tid)
   Util.getTeams owner [("ids", show tid)] >>= checkTeamList (Just tid)
-  Util.getTeams owner [("ids", show tid <> "," <> show tid)] >>= checkTeamList (Just tid)
-  -- start is exclusive and therefore should not return the team
-  Util.getTeams owner [("start", show tid)] >>= checkTeamList Nothing
+  Util.getTeams owner [("ids", show tid <> "," <> show wrongTid)] >>= checkTeamList (Just tid)
+  -- these two queries do not yield responses that are equivalent to the odl wai route API
+  Util.getTeams owner [("ids", show wrongTid)] >>= checkTeamList (Just tid)
+  Util.getTeams owner [("start", show tid)] >>= checkTeamList (Just tid)
   where
     checkTeamList :: Maybe TeamId -> TeamList -> TestM ()
     checkTeamList mbTid tl = liftIO $ do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -83,6 +83,9 @@ tests :: IO TestSetup -> TestTree
 tests s =
   testGroup "Teams API" $
     [ test s "create team" testCreateTeam,
+      testGroup "get teams 12123" $
+        [ test s "get teams 1" testGetTeams
+        ],
       test s "create multiple binding teams fail" testCreateMulitpleBindingTeams,
       test s "create binding team with currency" testCreateBindingTeamWithCurrency,
       test s "create team with members" testCreateTeamWithMembers,
@@ -163,6 +166,10 @@ testCreateTeam = do
         e ^. eventTeam @?= tid
         e ^. eventData @?= Just (EdTeamCreate team)
       void $ WS.assertSuccess eventChecks
+
+testGetTeams :: TestM ()
+testGetTeams = do
+  undefined
 
 testCreateMulitpleBindingTeams :: TestM ()
 testCreateMulitpleBindingTeams = do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -176,23 +176,20 @@ createBindingTeamWithQualifiedMembers num = do
   (tid, owner, users) <- createBindingTeamWithMembers num
   pure (tid, Qualified owner localDomain, map (`Qualified` localDomain) users)
 
-getTeams :: UserId -> [(String, String)] -> TestM TeamList
+getTeams :: UserId -> [(ByteString, Maybe ByteString)] -> TestM TeamList
 getTeams u queryItems = do
   g <- view tsGalley
   r <-
     get
       ( g
           . paths ["teams"]
-          . mkQueryItems queryItems
+          . query queryItems
           . zUser u
           . zConn "conn"
           . zType "access"
           . expect2xx
       )
   return $ responseJsonUnsafe r
-  where
-    mkQueryItems :: [(String, String)] -> Request -> Request
-    mkQueryItems = foldl (\f (n, v) -> f . queryItem (C.pack n) (C.pack v)) id
 
 createBindingTeamWithNMembers :: Int -> TestM (UserId, TeamId, [UserId])
 createBindingTeamWithNMembers = createBindingTeamWithNMembersWithHandles False


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1011

`GET /teams`

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.