### PR TITLE
Optional 2nd factor for some operations [skip ci]

### DIFF
--- a/libs/wire-api/src/Wire/API/User/Scim.hs
+++ b/libs/wire-api/src/Wire/API/User/Scim.hs
@@ -365,7 +365,9 @@ data CreateScimToken = CreateScimToken
   { -- | Token description (as memory aid for whoever is creating the token)
     createScimTokenDescr :: !Text,
     -- | User password, which we ask for because creating a token is a "powerful" operation
-    createScimTokenPassword :: !(Maybe PlainTextPassword)
+    createScimTokenPassword :: !(Maybe PlainTextPassword),
+    -- | User code (sent by email), for 2nd factor to 'createScimTokenPassword'
+    createScimTokenCode :: !(Maybe Text) -- TODO: i think there is a data type for this.
   }
   deriving (Eq, Show)
 
@@ -373,6 +375,7 @@ instance A.FromJSON CreateScimToken where
   parseJSON = A.withObject "CreateScimToken" $ \o -> do
     createScimTokenDescr <- o A..: "description"
     createScimTokenPassword <- o A..:? "password"
+    createScimTokenCode <- o A..:? "code"
     pure CreateScimToken {..}
 
 -- Used for integration tests
@@ -380,7 +383,8 @@ instance A.ToJSON CreateScimToken where
   toJSON CreateScimToken {..} =
     A.object
       [ "description" A..= createScimTokenDescr,
-        "password" A..= createScimTokenPassword
+        "password" A..= createScimTokenPassword,
+        "code" A..= createScimTokenCode
       ]
 
 -- | Type used for the response of 'APIScimTokenCreate'.
@@ -463,7 +467,8 @@ instance ToSchema CreateScimToken where
           & type_ .~ Just SwaggerObject
           & properties
             .~ [ ("description", textSchema),
-                 ("password", textSchema)
+                 ("password", textSchema),
+                 ("code", textSchema)
                ]
           & required .~ ["description"]
 

--- a/services/brig/test/integration/API/UserPendingActivation.hs
+++ b/services/brig/test/integration/API/UserPendingActivation.hs
@@ -108,7 +108,8 @@ createScimToken spar' owner = do
     createToken spar' owner $
       CreateScimToken
         { createScimTokenDescr = "testCreateToken",
-          createScimTokenPassword = Just defPassword
+          createScimTokenPassword = Just defPassword,
+          createScimTokenCode = Nothing
         }
   pure tok
 

--- a/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
@@ -85,7 +85,8 @@ testCreateToken = do
       owner
       CreateScimToken
         { createScimTokenDescr = "testCreateToken",
-          createScimTokenPassword = Just defPassword
+          createScimTokenPassword = Just defPassword,
+          createScimTokenCode = Nothing
         }
   -- Try to do @GET /Users@ and check that it succeeds
   let fltr = filterBy "externalId" "67c196a0-cd0e-11ea-93c7-ef550ee48502"
@@ -105,21 +106,24 @@ testTokenLimit = do
       owner
       CreateScimToken
         { createScimTokenDescr = "testTokenLimit / #1",
-          createScimTokenPassword = Just defPassword
+          createScimTokenPassword = Just defPassword,
+          createScimTokenCode = Nothing
         }
   _ <-
     createToken
       owner
       CreateScimToken
         { createScimTokenDescr = "testTokenLimit / #2",
-          createScimTokenPassword = Just defPassword
+          createScimTokenPassword = Just defPassword,
+          createScimTokenCode = Nothing
         }
   -- Try to create the third token and see that it fails
   createToken_
     owner
     CreateScimToken
       { createScimTokenDescr = "testTokenLimit / #3",
-        createScimTokenPassword = Just defPassword
+        createScimTokenPassword = Just defPassword,
+        createScimTokenCode = Nothing
       }
     (env ^. teSpar)
     !!! checkErr 403 (Just "token-limit-reached")
@@ -138,13 +142,13 @@ testNumIdPs = do
         SAML.SampleIdP metadata _ _ _ <- SAML.makeSampleIdPMetadata
         void $ call $ Util.callIdpCreate apiversion spar (Just owner) metadata
 
-  createToken owner (CreateScimToken "eins" (Just defPassword))
+  createToken owner (CreateScimToken "eins" (Just defPassword) Nothing)
     >>= deleteToken owner . stiId . createScimTokenResponseInfo
   addSomeIdP
-  createToken owner (CreateScimToken "zwei" (Just defPassword))
+  createToken owner (CreateScimToken "zwei" (Just defPassword) Nothing)
     >>= deleteToken owner . stiId . createScimTokenResponseInfo
   addSomeIdP
-  createToken_ owner (CreateScimToken "drei" (Just defPassword)) (env ^. teSpar)
+  createToken_ owner (CreateScimToken "drei" (Just defPassword) Nothing) (env ^. teSpar)
     !!! checkErr 400 (Just "more-than-one-idp")
 
 -- @SF.Provisioning @TSFI.RESTfulAPI @S2
@@ -168,7 +172,8 @@ testCreateTokenAuthorizesOnlyAdmins = do
           uid
           CreateScimToken
             { createScimTokenDescr = "testCreateToken",
-              createScimTokenPassword = Just defPassword
+              createScimTokenPassword = Just defPassword,
+              createScimTokenCode = Nothing
             }
           (env ^. teSpar)
 
@@ -194,7 +199,8 @@ testCreateTokenRequiresPassword = do
     owner
     CreateScimToken
       { createScimTokenDescr = "testCreateTokenRequiresPassword",
-        createScimTokenPassword = Nothing
+        createScimTokenPassword = Nothing,
+        createScimTokenCode = Nothing
       }
     (env ^. teSpar)
     !!! checkErr 403 (Just "access-denied")
@@ -203,7 +209,8 @@ testCreateTokenRequiresPassword = do
     owner
     CreateScimToken
       { createScimTokenDescr = "testCreateTokenRequiresPassword",
-        createScimTokenPassword = Just (PlainTextPassword "wrong password")
+        createScimTokenPassword = Just (PlainTextPassword "wrong password"),
+        createScimTokenCode = Nothing
       }
     (env ^. teSpar)
     !!! checkErr 403 (Just "access-denied")
@@ -227,14 +234,16 @@ testListTokens = do
       owner
       CreateScimToken
         { createScimTokenDescr = "testListTokens / #1",
-          createScimTokenPassword = Just defPassword
+          createScimTokenPassword = Just defPassword,
+          createScimTokenCode = Nothing
         }
   _ <-
     createToken
       owner
       CreateScimToken
         { createScimTokenDescr = "testListTokens / #2",
-          createScimTokenPassword = Just defPassword
+          createScimTokenPassword = Just defPassword,
+          createScimTokenCode = Nothing
         }
   -- Check that the token is on the list
   list <- scimTokenListTokens <$> listTokens owner
@@ -331,7 +340,8 @@ testDeletedTokensAreUnusable = do
       owner
       CreateScimToken
         { createScimTokenDescr = "testDeletedTokensAreUnusable",
-          createScimTokenPassword = Just defPassword
+          createScimTokenPassword = Just defPassword,
+          createScimTokenCode = Nothing
         }
   -- An operation with the token should succeed
   let fltr = filterBy "externalId" "67c196a0-cd0e-11ea-93c7-ef550ee48502"
@@ -353,7 +363,8 @@ testDeletedTokensAreUnlistable = do
       owner
       CreateScimToken
         { createScimTokenDescr = "testDeletedTokensAreUnlistable",
-          createScimTokenPassword = Just defPassword
+          createScimTokenPassword = Just defPassword,
+          createScimTokenCode = Nothing
         }
   -- Delete the token
   deleteToken owner (stiId tokenInfo)

--- a/services/spar/test/Arbitrary.hs
+++ b/services/spar/test/Arbitrary.hs
@@ -61,7 +61,7 @@ instance Arbitrary ScimTokenInfo where
       <*> arbitrary
 
 instance Arbitrary CreateScimToken where
-  arbitrary = CreateScimToken <$> arbitrary <*> arbitrary
+  arbitrary = CreateScimToken <$> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary CreateScimTokenResponse where
   arbitrary = CreateScimTokenResponse <$> arbitrary <*> arbitrary


### PR DESCRIPTION
SQSERVICES-1157, probably others.

(For now I'm just taking notes here and hope to get the swagger docs generated from servant types rather than writing it first and *then* write the servant types.)

## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
