### PR TITLE
Use named routes in Federation API

### DIFF
--- a/changelog.d/6-federation/named-fed-api-routes
+++ b/changelog.d/6-federation/named-fed-api-routes
@@ -1,0 +1,1 @@
+Use `Named` routes for the federation API

--- a/libs/wire-api-federation/src/Wire/API/Federation/API.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API.hs
@@ -19,6 +19,7 @@ module Wire.API.Federation.API
   ( FedApi,
     HasFedEndpoint,
     fedClient,
+    fedClientIn,
 
     -- * Re-exports
     Component (..),
@@ -55,3 +56,9 @@ fedClient ::
   (HasFedEndpoint comp api name, HasClient m api, m ~ FederatorClient comp) =>
   Client m api
 fedClient = clientIn (Proxy @api) (Proxy @m)
+
+fedClientIn ::
+  forall (comp :: Component) (name :: Symbol) m api.
+  (HasFedEndpoint comp api name, HasClient m api) =>
+  Client m api
+fedClientIn = clientIn (Proxy @api) (Proxy @m)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API.hs
@@ -33,6 +33,7 @@ import Servant.Client.Core
 import Wire.API.Federation.API.Brig
 import Wire.API.Federation.API.Cargohold
 import Wire.API.Federation.API.Galley
+import Wire.API.Federation.Client
 import Wire.API.Federation.Component
 import Wire.API.Federation.Endpoint
 
@@ -51,6 +52,6 @@ type HasFedEndpoint comp api name = ('Just api ~ LookupEndpoint (FedApi comp) na
 -- | Return a client for a named endpoint.
 fedClient ::
   forall (comp :: Component) (name :: Symbol) m api.
-  (HasFedEndpoint comp api name, HasClient m api) =>
+  (HasFedEndpoint comp api name, HasClient m api, m ~ FederatorClient comp) =>
   Client m api
 fedClient = clientIn (Proxy @api) (Proxy @m)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -56,8 +56,8 @@ type BrigApi =
     -- (handles can be up to 256 chars currently)
     :<|> FedEndpoint "search-users" SearchRequest [Contact]
     :<|> FedEndpoint "get-user-clients" GetUserClients (UserMap (Set PubClient))
-    :<|> FedEndpointWithDomain "send-connection-action" NewConnectionRequest NewConnectionResponse
-    :<|> FedEndpointWithDomain "on-user-deleted-connections" UserDeletedConnectionsNotification EmptyResponse
+    :<|> FedEndpoint "send-connection-action" NewConnectionRequest NewConnectionResponse
+    :<|> FedEndpoint "on-user-deleted-connections" UserDeletedConnectionsNotification EmptyResponse
 
 newtype GetUserClients = GetUserClients
   { gucUsers :: [UserId]

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
@@ -47,5 +47,5 @@ data GetAssetResponse = GetAssetResponse
   deriving (ToJSON, FromJSON) via (CustomEncoded GetAssetResponse)
 
 type CargoholdApi =
-  FedEndpointWithDomain "get-asset" GetAsset GetAssetResponse
-    :<|> FedEndpointWithDomain "stream-asset" GetAsset AssetSource
+  FedEndpoint "get-asset" GetAsset GetAssetResponse
+    :<|> FedEndpoint "stream-asset" GetAsset AssetSource

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
@@ -48,4 +48,4 @@ data GetAssetResponse = GetAssetResponse
 
 type CargoholdApi =
   FedEndpoint "get-asset" GetAsset GetAssetResponse
-    :<|> FedEndpoint "stream-asset" GetAsset AssetSource
+    :<|> StreamingFedEndpoint "stream-asset" GetAsset AssetSource

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
@@ -21,9 +21,9 @@ import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Id
 import Imports
 import Servant.API
-import Servant.API.Generic
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import Wire.API.Asset
+import Wire.API.Federation.Endpoint
 import Wire.API.Routes.AssetBody
 import Wire.API.Util.Aeson
 
@@ -46,16 +46,6 @@ data GetAssetResponse = GetAssetResponse
   deriving (Arbitrary) via (GenericUniform GetAssetResponse)
   deriving (ToJSON, FromJSON) via (CustomEncoded GetAssetResponse)
 
-data CargoholdApi routes = CargoholdApi
-  { getAsset ::
-      routes
-        :- "get-asset"
-        :> ReqBody '[JSON] GetAsset
-        :> Post '[JSON] GetAssetResponse,
-    streamAsset ::
-      routes
-        :- "stream-asset"
-        :> ReqBody '[JSON] GetAsset
-        :> StreamPost NoFraming OctetStream AssetSource
-  }
-  deriving (Generic)
+type CargoholdApi =
+  FedEndpointWithDomain "get-asset" GetAsset GetAssetResponse
+    :<|> FedEndpointWithDomain "stream-asset" GetAsset AssetSource

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -25,8 +25,7 @@ import Data.Qualified
 import Data.Range
 import Data.Time.Clock (UTCTime)
 import Imports
-import Servant.API (JSON, Post, ReqBody, Summary, (:>))
-import Servant.API.Generic
+import Servant.API
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import Wire.API.Conversation
   ( Access,
@@ -39,7 +38,7 @@ import Wire.API.Conversation.Action
 import Wire.API.Conversation.Member (OtherMember)
 import Wire.API.Conversation.Role (RoleName)
 import Wire.API.Federation.API.Common
-import Wire.API.Federation.Domain (OriginDomainHeader)
+import Wire.API.Federation.Endpoint
 import Wire.API.Message (MessageNotSent, MessageSendingStatus, PostOtrResponse, Priority)
 import Wire.API.User.Client (UserClientMap)
 import Wire.API.Util.Aeson (CustomEncoded (..))
@@ -49,59 +48,22 @@ import Wire.API.Util.Aeson (CustomEncoded (..))
 -- for the current list we need.
 
 -- | For conventions see /docs/developer/federation-api-conventions.md
-data GalleyApi routes = GalleyApi
-  { -- | Register a new conversation
-    onConversationCreated ::
-      routes
-        :- Summary "Register users to be in a new remote conversation"
-        :> "on-conversation-created"
-        :> OriginDomainHeader
-        :> ReqBody '[JSON] (NewRemoteConversation ConvId)
-        :> Post '[JSON] (),
-    getConversations ::
-      routes
-        :- "get-conversations"
-        :> OriginDomainHeader
-        :> ReqBody '[JSON] GetConversationsRequest
-        :> Post '[JSON] GetConversationsResponse,
+type GalleyApi =
+  -- | Register a new conversation
+  Summary "Register users to be in a new remote conversation"
+    :> FedEndpointWithDomain "on-conversation-created" (NewRemoteConversation ConvId) ()
+    :<|> FedEndpointWithDomain "get-conversations" GetConversationsRequest GetConversationsResponse
     -- used by the backend that owns a conversation to inform this backend of
     -- changes to the conversation
-    onConversationUpdated ::
-      routes
-        :- "on-conversation-updated"
-        :> OriginDomainHeader
-        :> ReqBody '[JSON] ConversationUpdate
-        :> Post '[JSON] (),
-    leaveConversation ::
-      routes
-        :- "leave-conversation"
-        :> OriginDomainHeader
-        :> ReqBody '[JSON] LeaveConversationRequest
-        :> Post '[JSON] LeaveConversationResponse,
+    :<|> FedEndpointWithDomain "on-conversation-updated" ConversationUpdate ()
+    :<|> FedEndpointWithDomain "leave-conversation" LeaveConversationRequest LeaveConversationResponse
     -- used to notify this backend that a new message has been posted to a
     -- remote conversation
-    onMessageSent ::
-      routes
-        :- "on-message-sent"
-        :> OriginDomainHeader
-        :> ReqBody '[JSON] (RemoteMessage ConvId)
-        :> Post '[JSON] (),
+    :<|> FedEndpointWithDomain "on-message-sent" (RemoteMessage ConvId) ()
     -- used by a remote backend to send a message to a conversation owned by
     -- this backend
-    sendMessage ::
-      routes
-        :- "send-message"
-        :> OriginDomainHeader
-        :> ReqBody '[JSON] MessageSendRequest
-        :> Post '[JSON] MessageSendResponse,
-    onUserDeleted ::
-      routes
-        :- "on-user-deleted-conversations"
-        :> OriginDomainHeader
-        :> ReqBody '[JSON] UserDeletedConversationsNotification
-        :> Post '[JSON] EmptyResponse
-  }
-  deriving (Generic)
+    :<|> FedEndpointWithDomain "send-message" MessageSendRequest MessageSendResponse
+    :<|> FedEndpointWithDomain "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
 
 data GetConversationsRequest = GetConversationsRequest
   { gcrUserId :: UserId,

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -50,20 +50,19 @@ import Wire.API.Util.Aeson (CustomEncoded (..))
 -- | For conventions see /docs/developer/federation-api-conventions.md
 type GalleyApi =
   -- | Register a new conversation
-  Summary "Register users to be in a new remote conversation"
-    :> FedEndpoint "on-conversation-created" (NewRemoteConversation ConvId) ()
-      :<|> FedEndpoint "get-conversations" GetConversationsRequest GetConversationsResponse
-      -- used by the backend that owns a conversation to inform this backend of
-      -- changes to the conversation
-      :<|> FedEndpoint "on-conversation-updated" ConversationUpdate ()
-      :<|> FedEndpoint "leave-conversation" LeaveConversationRequest LeaveConversationResponse
-      -- used to notify this backend that a new message has been posted to a
-      -- remote conversation
-      :<|> FedEndpoint "on-message-sent" (RemoteMessage ConvId) ()
-      -- used by a remote backend to send a message to a conversation owned by
-      -- this backend
-      :<|> FedEndpoint "send-message" MessageSendRequest MessageSendResponse
-      :<|> FedEndpoint "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
+  FedEndpoint "on-conversation-created" (NewRemoteConversation ConvId) ()
+    :<|> FedEndpoint "get-conversations" GetConversationsRequest GetConversationsResponse
+    -- used by the backend that owns a conversation to inform this backend of
+    -- changes to the conversation
+    :<|> FedEndpoint "on-conversation-updated" ConversationUpdate ()
+    :<|> FedEndpoint "leave-conversation" LeaveConversationRequest LeaveConversationResponse
+    -- used to notify this backend that a new message has been posted to a
+    -- remote conversation
+    :<|> FedEndpoint "on-message-sent" (RemoteMessage ConvId) ()
+    -- used by a remote backend to send a message to a conversation owned by
+    -- this backend
+    :<|> FedEndpoint "send-message" MessageSendRequest MessageSendResponse
+    :<|> FedEndpoint "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
 
 data GetConversationsRequest = GetConversationsRequest
   { gcrUserId :: UserId,

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -51,19 +51,19 @@ import Wire.API.Util.Aeson (CustomEncoded (..))
 type GalleyApi =
   -- | Register a new conversation
   Summary "Register users to be in a new remote conversation"
-    :> FedEndpointWithDomain "on-conversation-created" (NewRemoteConversation ConvId) ()
-      :<|> FedEndpointWithDomain "get-conversations" GetConversationsRequest GetConversationsResponse
+    :> FedEndpoint "on-conversation-created" (NewRemoteConversation ConvId) ()
+      :<|> FedEndpoint "get-conversations" GetConversationsRequest GetConversationsResponse
       -- used by the backend that owns a conversation to inform this backend of
       -- changes to the conversation
-      :<|> FedEndpointWithDomain "on-conversation-updated" ConversationUpdate ()
-      :<|> FedEndpointWithDomain "leave-conversation" LeaveConversationRequest LeaveConversationResponse
+      :<|> FedEndpoint "on-conversation-updated" ConversationUpdate ()
+      :<|> FedEndpoint "leave-conversation" LeaveConversationRequest LeaveConversationResponse
       -- used to notify this backend that a new message has been posted to a
       -- remote conversation
-      :<|> FedEndpointWithDomain "on-message-sent" (RemoteMessage ConvId) ()
+      :<|> FedEndpoint "on-message-sent" (RemoteMessage ConvId) ()
       -- used by a remote backend to send a message to a conversation owned by
       -- this backend
-      :<|> FedEndpointWithDomain "send-message" MessageSendRequest MessageSendResponse
-      :<|> FedEndpointWithDomain "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
+      :<|> FedEndpoint "send-message" MessageSendRequest MessageSendResponse
+      :<|> FedEndpoint "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
 
 data GetConversationsRequest = GetConversationsRequest
   { gcrUserId :: UserId,

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -52,18 +52,18 @@ type GalleyApi =
   -- | Register a new conversation
   Summary "Register users to be in a new remote conversation"
     :> FedEndpointWithDomain "on-conversation-created" (NewRemoteConversation ConvId) ()
-    :<|> FedEndpointWithDomain "get-conversations" GetConversationsRequest GetConversationsResponse
-    -- used by the backend that owns a conversation to inform this backend of
-    -- changes to the conversation
-    :<|> FedEndpointWithDomain "on-conversation-updated" ConversationUpdate ()
-    :<|> FedEndpointWithDomain "leave-conversation" LeaveConversationRequest LeaveConversationResponse
-    -- used to notify this backend that a new message has been posted to a
-    -- remote conversation
-    :<|> FedEndpointWithDomain "on-message-sent" (RemoteMessage ConvId) ()
-    -- used by a remote backend to send a message to a conversation owned by
-    -- this backend
-    :<|> FedEndpointWithDomain "send-message" MessageSendRequest MessageSendResponse
-    :<|> FedEndpointWithDomain "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
+      :<|> FedEndpointWithDomain "get-conversations" GetConversationsRequest GetConversationsResponse
+      -- used by the backend that owns a conversation to inform this backend of
+      -- changes to the conversation
+      :<|> FedEndpointWithDomain "on-conversation-updated" ConversationUpdate ()
+      :<|> FedEndpointWithDomain "leave-conversation" LeaveConversationRequest LeaveConversationResponse
+      -- used to notify this backend that a new message has been posted to a
+      -- remote conversation
+      :<|> FedEndpointWithDomain "on-message-sent" (RemoteMessage ConvId) ()
+      -- used by a remote backend to send a message to a conversation owned by
+      -- this backend
+      :<|> FedEndpointWithDomain "send-message" MessageSendRequest MessageSendResponse
+      :<|> FedEndpointWithDomain "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
 
 data GetConversationsRequest = GetConversationsRequest
   { gcrUserId :: UserId,

--- a/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
@@ -17,6 +17,7 @@
 
 module Wire.API.Federation.Endpoint where
 
+import Imports
 import Servant.API
 import Wire.API.Federation.Domain
 import Wire.API.Routes.Named
@@ -31,3 +32,15 @@ type FedEndpointWithDomain name input output =
   Named
     name
     (name :> OriginDomainHeader :> ReqBody '[JSON] input :> Post '[JSON] output)
+
+type family MappendMaybe (x :: Maybe k) (y :: Maybe k) :: Maybe k where
+  MappendMaybe 'Nothing y = y
+  MappendMaybe ('Just x) y = 'Just x
+
+type family LookupEndpoint api name :: Maybe * where
+  LookupEndpoint (Named name endpoint) name = 'Just endpoint
+  LookupEndpoint (api1 :<|> api2) name =
+    MappendMaybe
+      (LookupEndpoint api1 name)
+      (LookupEndpoint api2 name)
+  LookupEndpoint api name = 'Nothing

--- a/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
@@ -1,6 +1,6 @@
 -- This file is part of the Wire Server implementation.
 --
--- Copyright (C) 2021 Wire Swiss GmbH <opensource@wire.com>
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
 --
 -- This program is free software: you can redistribute it and/or modify it under
 -- the terms of the GNU Affero General Public License as published by the Free
@@ -15,25 +15,19 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Wire.API.Federation.API
-  ( FedApi,
+module Wire.API.Federation.Endpoint where
 
-    -- * Re-exports
-    Component (..),
-  )
-where
+import Servant.API
+import Wire.API.Federation.Domain
+import Wire.API.Routes.Named
 
-import Wire.API.Federation.API.Brig
-import Wire.API.Federation.API.Cargohold
-import Wire.API.Federation.API.Galley
-import Wire.API.Federation.Component
+type FedEndpoint name input output =
+  Named
+    name
+    ( name :> ReqBody '[JSON] input :> Post '[JSON] output
+    )
 
--- Note: this type family being injective means that in most cases there is no need
--- to add component annotations when invoking the federator client
-type family FedApi (comp :: Component) = (api :: *) | api -> comp
-
-type instance FedApi 'Galley = GalleyApi
-
-type instance FedApi 'Brig = BrigApi
-
-type instance FedApi 'Cargohold = CargoholdApi
+type FedEndpointWithDomain name input output =
+  Named
+    name
+    (name :> OriginDomainHeader :> ReqBody '[JSON] input :> Post '[JSON] output)

--- a/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
@@ -25,12 +25,6 @@ import Wire.API.Routes.Named
 type FedEndpoint name input output =
   Named
     name
-    ( name :> ReqBody '[JSON] input :> Post '[JSON] output
-    )
-
-type FedEndpointWithDomain name input output =
-  Named
-    name
     (name :> OriginDomainHeader :> ReqBody '[JSON] input :> Post '[JSON] output)
 
 type family MappendMaybe (x :: Maybe k) (y :: Maybe k) :: Maybe k where

--- a/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
@@ -27,6 +27,13 @@ type FedEndpoint name input output =
     name
     (name :> OriginDomainHeader :> ReqBody '[JSON] input :> Post '[JSON] output)
 
+type StreamingFedEndpoint name input output =
+  Named
+    name
+    ( name :> OriginDomainHeader :> ReqBody '[JSON] input
+        :> StreamPost NoFraming OctetStream output
+    )
+
 type family MappendMaybe (x :: Maybe k) (y :: Maybe k) :: Maybe k where
   MappendMaybe 'Nothing y = y
   MappendMaybe ('Just x) y = 'Just x

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f62744549c34b54e9900b31c33a4ebad5c51ac13ec44010ad2da6c6ca67fdc29
+-- hash: 41830e5193234bf215634c6d48cfa68be3a633d1f2750d9f8e3c237f37021709
 
 name:           wire-api-federation
 version:        0.1.0
@@ -28,6 +28,7 @@ library
       Wire.API.Federation.Client
       Wire.API.Federation.Component
       Wire.API.Federation.Domain
+      Wire.API.Federation.Endpoint
       Wire.API.Federation.Error
       Wire.API.Federation.Event
   other-modules:

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2a5e368730d4530d05df5395f6b3157536513b1049130b541d257aa79296cb75
+-- hash: ebb0470fb0502f00b8e472c5afbb27c0cad11b42d703d7330b43c75f80ea8257
 
 name:           brig
 version:        2.0
@@ -214,6 +214,7 @@ library
     , scrypt >=0.5
     , servant
     , servant-client
+    , servant-client-core
     , servant-server
     , servant-swagger
     , servant-swagger-ui

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -108,6 +108,7 @@ library:
   - scrypt >=0.5
   - servant
   - servant-client
+  - servant-client-core
   - servant-server
   - servant-swagger
   - servant-swagger-ui

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -43,14 +43,12 @@ import Imports
 import Network.Wai.Utilities.Error ((!>>))
 import Servant (ServerT)
 import Servant.API
-import Servant.API.Generic (ToServantApi)
-import Servant.Server.Generic (genericServerT)
 import UnliftIO.Async (pooledForConcurrentlyN_)
-import Wire.API.Federation.API.Brig hiding (BrigApi (..))
-import qualified Wire.API.Federation.API.Brig as F
+import Wire.API.Federation.API.Brig
 import Wire.API.Federation.API.Common
 import Wire.API.Message (UserClients)
 import Wire.API.Routes.Internal.Brig.Connection
+import Wire.API.Routes.Named
 import Wire.API.Team.LegalHold (LegalholdProtectee (LegalholdPlusFederationNotImplemented))
 import Wire.API.User (UserProfile)
 import Wire.API.User.Client (PubClient, UserClientPrekeyMap)
@@ -58,22 +56,19 @@ import Wire.API.User.Client.Prekey (ClientPrekey)
 import Wire.API.User.Search
 import Wire.API.UserMap (UserMap)
 
-type FederationAPI = "federation" :> ToServantApi F.BrigApi
+type FederationAPI = "federation" :> BrigApi
 
 federationSitemap :: ServerT FederationAPI Handler
 federationSitemap =
-  genericServerT $
-    F.BrigApi
-      { F.getUserByHandle = getUserByHandle,
-        F.getUsersByIds = getUsersByIds,
-        F.claimPrekey = claimPrekey,
-        F.claimPrekeyBundle = claimPrekeyBundle,
-        F.claimMultiPrekeyBundle = claimMultiPrekeyBundle,
-        F.searchUsers = searchUsers,
-        F.getUserClients = getUserClients,
-        F.sendConnectionAction = sendConnectionAction,
-        F.onUserDeleted = onUserDeleted
-      }
+  Named @"get-user-by-handle" getUserByHandle
+    :<|> Named @"get-users-by-ids" getUsersByIds
+    :<|> Named @"claim-prekey" claimPrekey
+    :<|> Named @"claim-prekey-bundle" claimPrekeyBundle
+    :<|> Named @"claim-multi-prekey-bundle" claimMultiPrekeyBundle
+    :<|> Named @"search-users" searchUsers
+    :<|> Named @"get-user-clients" getUserClients
+    :<|> Named @"send-connection-action" sendConnectionAction
+    :<|> Named @"on-user-deleted-connections" onUserDeleted
 
 sendConnectionAction :: Domain -> NewConnectionRequest -> Handler NewConnectionResponse
 sendConnectionAction originDomain NewConnectionRequest {..} = do

--- a/services/brig/test/integration/API/User.hs
+++ b/services/brig/test/integration/API/User.hs
@@ -40,8 +40,21 @@ import Imports
 import Test.Tasty hiding (Timeout)
 import Util
 import Util.Options.Common
+import Wire.API.Federation.Component
 
-tests :: Opt.Opts -> FedBrigClient -> FedGalleyClient -> Manager -> Brig -> Cannon -> CargoHold -> Galley -> Nginz -> AWS.Env -> DB.ClientState -> IO TestTree
+tests ::
+  Opt.Opts ->
+  FedClient 'Brig ->
+  FedClient 'Galley ->
+  Manager ->
+  Brig ->
+  Cannon ->
+  CargoHold ->
+  Galley ->
+  Nginz ->
+  AWS.Env ->
+  DB.ClientState ->
+  IO TestTree
 tests conf fbc fgc p b c ch g n aws db = do
   let cl = ConnectionLimit $ Opt.setUserMaxConnections (Opt.optSettings conf)
   let at = Opt.setActivationTimeout (Opt.optSettings conf)

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -336,7 +336,7 @@ assertConnectionQualified brig u1 qu2 rel =
 receiveConnectionAction ::
   HasCallStack =>
   Brig ->
-  FedBrigClient ->
+  FedClient 'Brig ->
   UserId ->
   Qualified UserId ->
   F.RemoteConnectionAction ->
@@ -345,7 +345,7 @@ receiveConnectionAction ::
   Http ()
 receiveConnectionAction brig fedBrigClient uid1 quid2 action expectedReaction expectedRel = do
   res <-
-    F.sendConnectionAction (fedBrigClient (qDomain quid2)) $
+    runFedClient @"send-connection-action" fedBrigClient (qDomain quid2) $
       F.NewConnectionRequest (qUnqualified quid2) uid1 action
   liftIO $ do
     res @?= F.NewConnectionResponseOk expectedReaction

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -38,38 +38,26 @@ import qualified Brig.Options as Opts
 import Cassandra.Util (defInitCassandra)
 import Control.Lens
 import Data.Aeson
-import Data.ByteString.Conversion
-import Data.Domain
 import Data.Metrics.Test (pathsConsistencyCheck)
 import Data.Metrics.WaiRoute (treeToPaths)
-import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
 import Data.Yaml (decodeFileEither)
 import qualified Federation.End2end
 import Imports hiding (local)
 import qualified Index.Create
-import qualified Network.HTTP.Client as HTTP
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.Wai.Utilities.Server (compile)
 import OpenSSL (withOpenSSL)
 import Options.Applicative hiding (action)
-import Servant.API.Generic (GenericServant, ToServant, ToServantApi)
-import qualified Servant.Client as Servant
-import Servant.Client.Core
-import qualified Servant.Client.Core.Request as Client
-import Servant.Client.Generic (AsClientT)
-import qualified Servant.Client.Generic as Servant
 import System.Environment (withArgs)
 import qualified System.Environment.Blank as Blank
 import qualified System.Logger as Logger
 import Test.Tasty
 import Test.Tasty.HUnit
-import Util (FedBrigClient, FedGalleyClient)
+import Util
 import Util.Options
 import Util.Test
-import qualified Wire.API.Federation.API.Brig as F
-import qualified Wire.API.Federation.API.Galley as F
-import Wire.API.Federation.Domain
+import Wire.API.Federation.API
 
 data BackendConf = BackendConf
   { remoteBrig :: Endpoint,
@@ -132,8 +120,8 @@ runTests iConf brigOpts otherArgs = do
   lg <- Logger.new Logger.defSettings -- TODO: use mkLogger'?
   db <- defInitCassandra casKey casHost casPort lg
   mg <- newManager tlsManagerSettings
-  let fedBrigClient = mkFedBrigClient mg (brig iConf)
-  let fedGalleyClient = mkFedGalleyClient mg (galley iConf)
+  let fedBrigClient = FedClient @'Brig mg (brig iConf)
+  let fedGalleyClient = FedClient @'Galley mg (galley iConf)
   emailAWSOpts <- parseEmailAWSOpts
   awsEnv <- AWS.mkEnv lg awsOpts emailAWSOpts mg
   userApi <- User.tests brigOpts fedBrigClient fedGalleyClient mg b c ch g n awsEnv db
@@ -226,40 +214,3 @@ parseConfigPaths = do
                   <> showDefault
                   <> value defaultBrigPath
             )
-
-mkFedBrigClient :: Manager -> Endpoint -> FedBrigClient
-mkFedBrigClient = mkFedBrigClientGen @F.BrigApi
-
-mkFedGalleyClient :: Manager -> Endpoint -> FedGalleyClient
-mkFedGalleyClient = mkFedBrigClientGen @F.GalleyApi
-
-mkFedBrigClientGen ::
-  forall routes.
-  ( HasClient Servant.ClientM (ToServantApi routes),
-    GenericServant routes (AsClientT (HttpT IO)),
-    Servant.Client (HttpT IO) (ToServantApi routes) ~ ToServant routes (AsClientT (HttpT IO))
-  ) =>
-  Manager ->
-  Endpoint ->
-  Domain ->
-  routes (AsClientT (HttpT IO))
-mkFedBrigClientGen mgr endpoint originDomain = Servant.genericClientHoist servantClientMToHttp
-  where
-    servantClientMToHttp :: Servant.ClientM a -> Http a
-    servantClientMToHttp action = liftIO $ do
-      let brigHost = Text.unpack $ endpoint ^. epHost
-          brigPort = fromInteger . toInteger $ endpoint ^. epPort
-          baseUrl = Servant.BaseUrl Servant.Http brigHost brigPort "/federation"
-          clientEnv = Servant.ClientEnv mgr baseUrl Nothing makeClientRequest
-      eitherRes <- Servant.runClientM action clientEnv
-      case eitherRes of
-        Right res -> pure res
-        Left err -> assertFailure $ "Servant client failed with: " <> show err
-
-    makeClientRequest :: BaseUrl -> Client.Request -> HTTP.Request
-    makeClientRequest burl req =
-      let req' = Servant.defaultMakeClientRequest burl req
-       in req'
-            { HTTP.requestHeaders =
-                HTTP.requestHeaders req' <> [(originDomainHeaderName, toByteString' originDomain)]
-            }

--- a/services/cargohold/src/CargoHold/Federation.hs
+++ b/services/cargohold/src/CargoHold/Federation.hs
@@ -61,9 +61,15 @@ downloadRemoteAsset usr rkey tok = do
           }
   exists <-
     fmap gaAvailable . executeFederated rkey $
-      getAsset clientRoutes ga
+      fedClient @'Cargohold @"get-asset" ga
   if exists
-    then Just <$> executeFederatedStreaming rkey (toSourceIO <$> streamAsset clientRoutes ga)
+    then
+      Just
+        <$> executeFederatedStreaming
+          rkey
+          ( toSourceIO
+              <$> fedClient @'Cargohold @"stream-asset" ga
+          )
     else pure Nothing
 
 mkFederatorClientEnv :: Remote x -> Handler FederatorClientEnv

--- a/services/cargohold/test/integration/API/Federation.hs
+++ b/services/cargohold/test/integration/API/Federation.hs
@@ -13,11 +13,11 @@ import Data.UUID.V4
 import Imports
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai.Utilities.Error as Wai
-import Servant.Client.Generic
 import Test.Tasty
 import Test.Tasty.HUnit
 import TestSetup
 import Wire.API.Asset
+import Wire.API.Federation.API
 import Wire.API.Federation.API.Cargohold
 import Wire.API.Routes.AssetBody
 
@@ -66,7 +66,7 @@ testGetAssetAvailable isPublicAsset = do
           }
   ok <-
     withFederationClient $
-      gaAvailable <$> runFederationClient (getAsset genericClient ga)
+      gaAvailable <$> runFederationClient (fedClientIn @'Cargohold @"get-asset" ga)
 
   -- check that asset is available
   liftIO $ ok @?= True
@@ -86,7 +86,7 @@ testGetAssetNotAvailable = do
           }
   ok <-
     withFederationClient $
-      gaAvailable <$> runFederationClient (getAsset genericClient ga)
+      gaAvailable <$> runFederationClient (fedClientIn @'Cargohold @"get-asset" ga)
 
   -- check that asset is not available
   liftIO $ ok @?= False
@@ -113,7 +113,7 @@ testGetAssetWrongToken = do
           }
   ok <-
     withFederationClient $
-      gaAvailable <$> runFederationClient (getAsset genericClient ga)
+      gaAvailable <$> runFederationClient (fedClientIn @'Cargohold @"get-asset" ga)
 
   -- check that asset is not available
   liftIO $ ok @?= False
@@ -144,7 +144,7 @@ testLargeAsset = do
             gaKey = qUnqualified key
           }
   chunks <- withFederationClient $ do
-    source <- getAssetSource <$> runFederationClient (streamAsset genericClient ga)
+    source <- getAssetSource <$> runFederationClient (fedClientIn @'Cargohold @"stream-asset" ga)
     liftIO . runResourceT $ connect source sinkList
   liftIO $ do
     let minNumChunks = 8
@@ -176,7 +176,7 @@ testStreamAsset = do
             gaKey = qUnqualified key
           }
   respBody <- withFederationClient $ do
-    source <- getAssetSource <$> runFederationClient (streamAsset genericClient ga)
+    source <- getAssetSource <$> runFederationClient (fedClientIn @'Cargohold @"stream-asset" ga)
     liftIO . runResourceT $ connect source sinkLazy
   liftIO $ respBody @?= "Hello World"
 
@@ -194,7 +194,7 @@ testStreamAssetNotAvailable = do
             gaKey = key
           }
   err <- withFederationError $ do
-    runFederationClient (streamAsset genericClient ga)
+    runFederationClient (fedClientIn @'Cargohold @"stream-asset" ga)
   liftIO $ do
     Wai.code err @?= HTTP.notFound404
     Wai.label err @?= "not-found"
@@ -220,7 +220,7 @@ testStreamAssetWrongToken = do
             gaKey = qUnqualified key
           }
   err <- withFederationError $ do
-    runFederationClient (streamAsset genericClient ga)
+    runFederationClient (fedClientIn @'Cargohold @"stream-asset" ga)
   liftIO $ do
     Wai.code err @?= HTTP.notFound404
     Wai.label err @?= "not-found"

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5ca30f9e591f66b924afc6773c95ecd6284e794ced766eca4ebe37af49b4984a
+-- hash: d0f941574eb095a4662d0a6333d341636673f8bbb0d097daed4d4e277ad7f37d
 
 name:           galley
 version:        0.83.0
@@ -254,6 +254,7 @@ executable galley-integration
       API
       API.CustomBackend
       API.Federation
+      API.Federation.Util
       API.MessageTimer
       API.Roles
       API.SQS
@@ -305,8 +306,8 @@ executable galley-integration
     , http-client
     , http-client-openssl
     , http-client-tls
-    , http-types
     , http-media
+    , http-types
     , imports
     , lens
     , lens-aeson

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -75,7 +75,7 @@ import Wire.API.Conversation.Role
 import Wire.API.ErrorDescription
 import Wire.API.Event.Conversation hiding (Conversation)
 import Wire.API.Federation.API
-import qualified Wire.API.Federation.API.Galley as F
+import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error
 import Wire.API.Team.LegalHold
 import Wire.API.Team.Member
@@ -526,8 +526,8 @@ notifyConversationAction quid con lcnv targets action = do
 
   -- notify remote participants
   E.runFederatedConcurrently_ (toList (bmRemotes targets)) $ \ruids ->
-    F.onConversationUpdated clientRoutes $
-      F.ConversationUpdate now quid (tUnqualified lcnv) (tUnqualified ruids) action
+    fedClient @'Galley @"on-conversation-updated" $
+      ConversationUpdate now quid (tUnqualified lcnv) (tUnqualified ruids) action
 
   -- notify local participants and bots
   pushConversationEvent con e (qualifyAs lcnv (bmLocals targets)) (bmBots targets) $> e

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -97,7 +97,7 @@ import Wire.API.Conversation (ConvIdsPage, pattern GetPaginatedConversationIds)
 import Wire.API.Conversation.Action (ConversationAction (ConversationActionRemoveMembers))
 import Wire.API.ErrorDescription
 import Wire.API.Federation.API
-import Wire.API.Federation.API.Galley hiding (getConversations)
+import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error
 import Wire.API.Routes.MultiTablePaging (mtpHasMore, mtpPagingState, mtpResults)
 import Wire.API.Routes.MultiVerb (MultiVerb, RespondEmpty)
@@ -627,7 +627,7 @@ rmUser lusr conn = do
                 cuAlreadyPresentUsers = tUnqualified remotes,
                 cuAction = ConversationActionRemoveMembers (pure qUser)
               }
-      let rpc = onConversationUpdated clientRoutes convUpdate
+      let rpc = fedClient @'Galley @"on-conversation-updated" convUpdate
       runFederatedEither remotes rpc
         >>= logAndIgnoreError "Error in onConversationUpdated call" (qUnqualified qUser)
 
@@ -635,7 +635,7 @@ rmUser lusr conn = do
     leaveRemoteConversations cids = do
       for_ (bucketRemote (fromRange cids)) $ \remoteConvs -> do
         let userDelete = UserDeletedConversationsNotification (tUnqualified lusr) (unsafeRange (tUnqualified remoteConvs))
-        let rpc = onUserDeleted clientRoutes userDelete
+        let rpc = fedClient @'Galley @"on-user-deleted-conversations" userDelete
         runFederatedEither remoteConvs rpc
           >>= logAndIgnoreError "Error in onUserDeleted call" (tUnqualified lusr)
 

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -192,7 +192,7 @@ getRemoteClients remoteMembers =
   where
     getRemoteClientsFromDomain (qUntagged -> Qualified uids domain) =
       Map.mapKeys (domain,) . fmap (Set.map pubClientId) . userMap
-        <$> getUserClients clientRoutes (GetUserClients uids)
+        <$> fedClient @'Brig @"get-user-clients" (GetUserClients uids)
 
 -- FUTUREWORK: sender should be Local UserId
 postRemoteOtrMessage ::
@@ -208,7 +208,7 @@ postRemoteOtrMessage sender conv rawMsg = do
             msrSender = qUnqualified sender,
             msrRawMessage = Base64ByteString rawMsg
           }
-      rpc = sendMessage clientRoutes msr
+      rpc = fedClient @'Galley @"send-message" msr
   msResponse <$> runFederated conv rpc
 
 postQualifiedOtrMessage ::
@@ -409,7 +409,7 @@ sendRemoteMessages domain now sender senderClient lcnv metadata messages = (hand
             rmTransient = mmTransient metadata,
             rmRecipients = UserClientMap rcpts
           }
-  let rpc = onMessageSent clientRoutes rm
+  let rpc = fedClient @'Galley @"on-message-sent" rm
   runFederatedEither domain rpc
   where
     handle :: Either FederationError a -> Sem r (Set (UserId, ClientId))

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -77,8 +77,7 @@ import qualified Wire.API.Conversation as Public
 import qualified Wire.API.Conversation.Role as Public
 import Wire.API.ErrorDescription
 import Wire.API.Federation.API
-import Wire.API.Federation.API.Galley hiding (getConversations)
-import qualified Wire.API.Federation.API.Galley as F
+import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error
 import qualified Wire.API.Provider.Bot as Public
 import qualified Wire.API.Routes.MultiTablePaging as Public
@@ -226,7 +225,7 @@ getRemoteConversationsWithFailures lusr convs = do
         | otherwise = [failedGetConversationLocally (map qUntagged locallyNotFound)]
 
   -- request conversations from remote backends
-  let rpc = F.getConversations clientRoutes
+  let rpc = fedClient @'Galley @"get-conversations"
   resp <-
     E.runFederatedConcurrentlyEither locallyFound $ \someConvs ->
       rpc $ GetConversationsRequest (tUnqualified lusr) (tUnqualified someConvs)

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1101,7 +1101,7 @@ removeMemberFromRemoteConv ::
 removeMemberFromRemoteConv cnv lusr victim
   | qUntagged lusr == victim = do
     let lc = LeaveConversationRequest (tUnqualified cnv) (qUnqualified victim)
-    let rpc = leaveConversation clientRoutes lc
+    let rpc = fedClient @'Galley @"leave-conversation" lc
     (either handleError handleSuccess =<<) . fmap leaveResponse $
       E.runFederated cnv rpc
   | otherwise = throw (ActionDenied RemoveConversationMember)

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -735,7 +735,7 @@ registerRemoteConversationMemberships now localDomain c = do
   let allRemoteMembers = nubOrd (map rmId (Data.convRemoteMembers c))
       rc = toNewRemoteConversation now localDomain c
   runFederatedConcurrently_ allRemoteMembers $ \_ ->
-    onConversationCreated clientRoutes rc
+    fedClient @'Galley @"on-conversation-created" rc
 
 --------------------------------------------------------------------------------
 -- Legalhold

--- a/services/galley/test/integration/Main.hs
+++ b/services/galley/test/integration/Main.hs
@@ -118,7 +118,7 @@ main = withOpenSSL $ runTests go
       let ck = fromJust gConf ^. optCassandra . casKeyspace
       lg <- Logger.new Logger.defSettings
       db <- defInitCassandra ck ch cp lg
-      return $ TestSetup (fromJust gConf) (fromJust iConf) m g b c awsEnv convMaxSize db (mkFedGalleyClient galleyEndpoint)
+      return $ TestSetup (fromJust gConf) (fromJust iConf) m g b c awsEnv convMaxSize db (FedClient m galleyEndpoint)
     queueName = fmap (view awsQueueName) . view optJournal
     endpoint = fmap (view awsEndpoint) . view optJournal
     maxSize = view (optSettings . setMaxConvSize)


### PR DESCRIPTION
This refactors the federation API routing tables to use the `Named` convention introduced in #2022. It also implements a mechanism to construct Servant clients for specific endpoints by name.

This is preliminary refactoring work for the implementation of [API versioning](https://github.com/wireapp/wire-server/blob/develop/docs/developer/api-versioning.md).

Tracked by https://wearezeta.atlassian.net/browse/FS-127.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
