### PR TITLE
Add restund chart as dependency of wire-server

### DIFF
--- a/changelog.d/5-internal/restund-chart-followup
+++ b/changelog.d/5-internal/restund-chart-followup
@@ -1,0 +1,1 @@
+Add restund chart as dependency of wire-server

--- a/charts/restund/Chart.yaml
+++ b/charts/restund/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.42
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wire-server/requirements.yaml
+++ b/charts/wire-server/requirements.yaml
@@ -108,3 +108,8 @@ dependencies:
   repository: "file://../sftd"
   tags:
     - sftd
+- name: restund
+  version: "0.0.42"
+  repository: "file://../restund"
+  tags:
+    - restund

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -11,3 +11,4 @@ tags:
   legalhold: false
   federator: false # see also galley.config.enableFederator and brig.config.enableFederator
   sftd: false
+  restund: false


### PR DESCRIPTION
This is a follow up to https://github.com/wireapp/wire-server/pull/2003.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.