### PR TITLE
Fix Remote Asset Downloading via Better Resource Handling

### DIFF
--- a/changelog.d/3-bug-fixes/fix-cargohold-streaming
+++ b/changelog.d/3-bug-fixes/fix-cargohold-streaming
@@ -1,0 +1,1 @@
+Fix an issue with remote asset streaming


### PR DESCRIPTION
Client teams reported that via PR #2004 merged, they cannot download remote assets of size 20 KB and larger. This fixes the issue by addressing incorrect resource handling. The limitation is that if an error happens before streaming starts, it will result in an empty response. @pcapriotti is working on addressing that case in a follow-up PR.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
