### PR TITLE
Followup to remote asset download fix

### DIFF
--- a/changelog.d/3-bug-fixes/fix-cargohold-streaming
+++ b/changelog.d/3-bug-fixes/fix-cargohold-streaming
@@ -1,1 +1,1 @@
-Fix an issue with remote asset streaming
+Fix an issue with remote asset streaming (#2037, #2038)


### PR DESCRIPTION
Followup to #2037. Throw the correct user-visible error, and add test to check that error responses are generated correctly.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.