### PR TITLE
integration.yaml add missing backendTwo.carghold

### DIFF
--- a/changelog.d/5-internal/fix-integration-yaml
+++ b/changelog.d/5-internal/fix-integration-yaml
@@ -1,0 +1,1 @@
+Add missing backendTwo.carghold in integration.yaml

--- a/services/integration.yaml
+++ b/services/integration.yaml
@@ -84,3 +84,6 @@ backendTwo:
   federatorExternal:
     host: 127.0.0.1 # in kubernetes, federator.<NAMESPACE>.svc.cluster.local
     port: 9097
+  cargohold:
+    host: 127.0.0.1
+    port: 9084


### PR DESCRIPTION
## Checklist

https://github.com/wireapp/wire-server/pull/2004 introduced a field backendTwo.carghold. This needs to be populated to be able to locally run integration tests.

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
