### PR TITLE
Federation API versioning

### DIFF
--- a/libs/wire-api-federation/package.yaml
+++ b/libs/wire-api-federation/package.yaml
@@ -34,6 +34,7 @@ dependencies:
 - servant-client
 - servant-client-core
 - servant-server
+- singletons
 - sop-core
 - streaming-commons
 - template-haskell

--- a/libs/wire-api-federation/package.yaml
+++ b/libs/wire-api-federation/package.yaml
@@ -28,6 +28,7 @@ dependencies:
 - kan-extensions
 - lifted-base
 - metrics-wai
+- mmorph
 - mtl
 - network
 - servant >=0.16

--- a/libs/wire-api-federation/src/Wire/API/Federation/API.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API.hs
@@ -55,16 +55,22 @@ type HasFedEndpoint comp v api name = ('Just api ~ LookupEndpoint (FedApi comp v
 
 -- | Return a client for a named endpoint.
 fedClient ::
-  forall (comp :: Component) (v :: Version) (name :: Symbol) m api.
-  (HasFedEndpoint comp v api name, HasClient m api, m ~ FederatorClient comp ('Just v)) =>
-  Client m api
-fedClient = clientIn (Proxy @api) (Proxy @m)
+  forall (comp :: Component) (v :: Version) (name :: Symbol) api.
+  ( HasFedEndpoint comp v api name,
+    HasClient FederatorClient api,
+    KnownSymbol (ComponentPrefix comp)
+  ) =>
+  Client FederatorClient api
+fedClient = fedClientIn @comp @v @name @FederatorClient
 
 fedClientIn ::
   forall (comp :: Component) (v :: Version) (name :: Symbol) m api.
-  (HasFedEndpoint comp v api name, HasClient m api) =>
+  ( HasFedEndpoint comp v api name,
+    HasClient m api,
+    KnownSymbol (ComponentPrefix comp)
+  ) =>
   Client m api
-fedClientIn = clientIn (Proxy @api) (Proxy @m)
+fedClientIn = clientIn (Proxy @(ComponentPrefix comp :> api)) (Proxy @m)
 
 type family CombinedApi (comp :: Component) (vs :: [Version]) where
   CombinedApi comp '[v0] = FedApi comp v0

--- a/libs/wire-api-federation/src/Wire/API/Federation/API.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API.hs
@@ -57,7 +57,7 @@ type HasFedEndpoint comp v api name = ('Just api ~ LookupEndpoint (FedApi comp v
 -- | Return a client for a named endpoint.
 fedClient ::
   forall (comp :: Component) (v :: Version) (name :: Symbol) m api.
-  (HasFedEndpoint comp v api name, HasClient m api, m ~ FederatorClient comp) =>
+  (HasFedEndpoint comp v api name, HasClient m api, m ~ FederatorClient comp v) =>
   Client m api
 fedClient = clientIn (Proxy @api) (Proxy @m)
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/API.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API.hs
@@ -18,6 +18,7 @@
 module Wire.API.Federation.API
   ( FedApi,
     VersionedFedApi,
+    VersionedFedApi',
     HasFedEndpoint,
     fedClient,
     fedClientIn,
@@ -77,13 +78,16 @@ type ApiVersionEndpoint =
 apiVersionEndpoint :: Applicative m => ServerT ApiVersionEndpoint m
 apiVersionEndpoint = Named @"api-versions" $ \_ _ -> pure supportedVersionInfo
 
-type VersionedFedApi (comp :: Component) =
-  ApiVersionEndpoint
-    :<|> CombinedApi comp SupportedVersions
+-- | All versions of the federation API.
+type VersionedFedApi (comp :: Component) = CombinedApi comp SupportedVersions
+
+-- | All versions of the federation API, plus an endpoint returning all versions.
+type VersionedFedApi' (comp :: Component) =
+  ApiVersionEndpoint :<|> VersionedFedApi comp
 
 mkVersionedServer ::
   forall (comp :: Component) m.
   Applicative m =>
-  ServerT (CombinedApi comp SupportedVersions) m ->
-  ServerT (VersionedFedApi comp) m
+  ServerT (VersionedFedApi comp) m ->
+  ServerT (VersionedFedApi' comp) m
 mkVersionedServer h = apiVersionEndpoint :<|> h

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -27,6 +27,7 @@ import Test.QuickCheck (Arbitrary)
 import Wire.API.Arbitrary (GenericUniform (..))
 import Wire.API.Federation.API.Common
 import Wire.API.Federation.Endpoint
+import Wire.API.Federation.Version
 import Wire.API.Message (UserClients)
 import Wire.API.User (UserProfile)
 import Wire.API.User.Client (PubClient, UserClientPrekeyMap)
@@ -43,21 +44,22 @@ instance ToJSON SearchRequest
 
 instance FromJSON SearchRequest
 
+type family BrigApi (v :: Version)
+
 -- | For conventions see /docs/developer/federation-api-conventions.md
---
--- Maybe this module should be called Brig
-type BrigApi =
-  FedEndpoint "get-user-by-handle" Handle (Maybe UserProfile)
-    :<|> FedEndpoint "get-users-by-ids" [UserId] [UserProfile]
-    :<|> FedEndpoint "claim-prekey" (UserId, ClientId) (Maybe ClientPrekey)
-    :<|> FedEndpoint "claim-prekey-bundle" UserId PrekeyBundle
-    :<|> FedEndpoint "claim-multi-prekey-bundle" UserClients UserClientPrekeyMap
-    -- FUTUREWORK(federation): do we want to perform some type-level validation like length checks?
-    -- (handles can be up to 256 chars currently)
-    :<|> FedEndpoint "search-users" SearchRequest [Contact]
-    :<|> FedEndpoint "get-user-clients" GetUserClients (UserMap (Set PubClient))
-    :<|> FedEndpoint "send-connection-action" NewConnectionRequest NewConnectionResponse
-    :<|> FedEndpoint "on-user-deleted-connections" UserDeletedConnectionsNotification EmptyResponse
+type instance
+  BrigApi 'V0 =
+    FedEndpoint "get-user-by-handle" Handle (Maybe UserProfile)
+      :<|> FedEndpoint "get-users-by-ids" [UserId] [UserProfile]
+      :<|> FedEndpoint "claim-prekey" (UserId, ClientId) (Maybe ClientPrekey)
+      :<|> FedEndpoint "claim-prekey-bundle" UserId PrekeyBundle
+      :<|> FedEndpoint "claim-multi-prekey-bundle" UserClients UserClientPrekeyMap
+      -- FUTUREWORK(federation): do we want to perform some type-level validation like length checks?
+      -- (handles can be up to 256 chars currently)
+      :<|> FedEndpoint "search-users" SearchRequest [Contact]
+      :<|> FedEndpoint "get-user-clients" GetUserClients (UserMap (Set PubClient))
+      :<|> FedEndpoint "send-connection-action" NewConnectionRequest NewConnectionResponse
+      :<|> FedEndpoint "on-user-deleted-connections" UserDeletedConnectionsNotification EmptyResponse
 
 newtype GetUserClients = GetUserClients
   { gucUsers :: [UserId]

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Cargohold.hs
@@ -24,6 +24,7 @@ import Servant.API
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import Wire.API.Asset
 import Wire.API.Federation.Endpoint
+import Wire.API.Federation.Version
 import Wire.API.Routes.AssetBody
 import Wire.API.Util.Aeson
 
@@ -46,6 +47,9 @@ data GetAssetResponse = GetAssetResponse
   deriving (Arbitrary) via (GenericUniform GetAssetResponse)
   deriving (ToJSON, FromJSON) via (CustomEncoded GetAssetResponse)
 
-type CargoholdApi =
-  FedEndpoint "get-asset" GetAsset GetAssetResponse
-    :<|> StreamingFedEndpoint "stream-asset" GetAsset AssetSource
+type family CargoholdApi (v :: Version)
+
+type instance
+  CargoholdApi 'V0 =
+    FedEndpoint "get-asset" GetAsset GetAssetResponse
+      :<|> StreamingFedEndpoint "stream-asset" GetAsset AssetSource

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Common.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Common.hs
@@ -18,6 +18,7 @@
 module Wire.API.Federation.API.Common
   ( EmptyResponse (..),
     EmptyRequest,
+    pattern EmptyRequest,
   )
 where
 
@@ -33,6 +34,9 @@ data EmptyResponse = EmptyResponse
   deriving (Arbitrary) via (GenericUniform EmptyResponse)
 
 type EmptyRequest = EmptyResponse
+
+pattern EmptyRequest :: EmptyResponse
+pattern EmptyRequest = EmptyResponse
 
 instance FromJSON EmptyResponse where
   parseJSON = withObject "EmptyResponse" . const $ pure EmptyResponse

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Common.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Common.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Wire.API.Federation.API.Common where
+module Wire.API.Federation.API.Common
+  ( EmptyResponse (..),
+    EmptyRequest,
+  )
+where
 
 import Data.Aeson
 import Imports
@@ -27,6 +31,8 @@ import Wire.API.Arbitrary
 data EmptyResponse = EmptyResponse
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform EmptyResponse)
+
+type EmptyRequest = EmptyResponse
 
 instance FromJSON EmptyResponse where
   parseJSON = withObject "EmptyResponse" . const $ pure EmptyResponse

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -39,6 +39,7 @@ import Wire.API.Conversation.Member (OtherMember)
 import Wire.API.Conversation.Role (RoleName)
 import Wire.API.Federation.API.Common
 import Wire.API.Federation.Endpoint
+import Wire.API.Federation.Version
 import Wire.API.Message (MessageNotSent, MessageSendingStatus, PostOtrResponse, Priority)
 import Wire.API.User.Client (UserClientMap)
 import Wire.API.Util.Aeson (CustomEncoded (..))
@@ -48,21 +49,24 @@ import Wire.API.Util.Aeson (CustomEncoded (..))
 -- for the current list we need.
 
 -- | For conventions see /docs/developer/federation-api-conventions.md
-type GalleyApi =
-  -- | Register a new conversation
-  FedEndpoint "on-conversation-created" (NewRemoteConversation ConvId) ()
-    :<|> FedEndpoint "get-conversations" GetConversationsRequest GetConversationsResponse
-    -- used by the backend that owns a conversation to inform this backend of
-    -- changes to the conversation
-    :<|> FedEndpoint "on-conversation-updated" ConversationUpdate ()
-    :<|> FedEndpoint "leave-conversation" LeaveConversationRequest LeaveConversationResponse
-    -- used to notify this backend that a new message has been posted to a
-    -- remote conversation
-    :<|> FedEndpoint "on-message-sent" (RemoteMessage ConvId) ()
-    -- used by a remote backend to send a message to a conversation owned by
-    -- this backend
-    :<|> FedEndpoint "send-message" MessageSendRequest MessageSendResponse
-    :<|> FedEndpoint "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
+type family GalleyApi (v :: Version)
+
+type instance
+  GalleyApi 'V0 =
+    -- Register a new conversation
+    FedEndpoint "on-conversation-created" (NewRemoteConversation ConvId) ()
+      :<|> FedEndpoint "get-conversations" GetConversationsRequest GetConversationsResponse
+      -- used by the backend that owns a conversation to inform this backend of
+      -- changes to the conversation
+      :<|> FedEndpoint "on-conversation-updated" ConversationUpdate ()
+      :<|> FedEndpoint "leave-conversation" LeaveConversationRequest LeaveConversationResponse
+      -- used to notify this backend that a new message has been posted to a
+      -- remote conversation
+      :<|> FedEndpoint "on-message-sent" (RemoteMessage ConvId) ()
+      -- used by a remote backend to send a message to a conversation owned by
+      -- this backend
+      :<|> FedEndpoint "send-message" MessageSendRequest MessageSendResponse
+      :<|> FedEndpoint "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
 
 data GetConversationsRequest = GetConversationsRequest
   { gcrUserId :: UserId,

--- a/libs/wire-api-federation/src/Wire/API/Federation/Component.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Component.hs
@@ -20,6 +20,7 @@
 module Wire.API.Federation.Component where
 
 import Data.Singletons.TH
+import GHC.TypeLits
 import Imports
 import Test.QuickCheck (Arbitrary)
 import Wire.API.Arbitrary (GenericUniform (..))
@@ -43,3 +44,8 @@ componentName :: Component -> Text
 componentName Brig = "brig"
 componentName Galley = "galley"
 componentName Cargohold = "cargohold"
+
+type family ComponentPrefix (c :: Component) :: Symbol where
+  ComponentPrefix 'Brig = "brig"
+  ComponentPrefix 'Galley = "galley"
+  ComponentPrefix 'Cargohold = "cargohold"

--- a/libs/wire-api-federation/src/Wire/API/Federation/Component.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Component.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE StandaloneKindSignatures #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
@@ -17,6 +19,7 @@
 
 module Wire.API.Federation.Component where
 
+import Data.Singletons.TH
 import Imports
 import Test.QuickCheck (Arbitrary)
 import Wire.API.Arbitrary (GenericUniform (..))
@@ -28,6 +31,8 @@ data Component
   deriving (Show, Eq, Generic)
   deriving (Arbitrary) via (GenericUniform Component)
 
+$(genSingletons [''Component])
+
 parseComponent :: Text -> Maybe Component
 parseComponent "brig" = Just Brig
 parseComponent "galley" = Just Galley
@@ -38,15 +43,3 @@ componentName :: Component -> Text
 componentName Brig = "brig"
 componentName Galley = "galley"
 componentName Cargohold = "cargohold"
-
-class KnownComponent (c :: Component) where
-  componentVal :: Component
-
-instance KnownComponent 'Brig where
-  componentVal = Brig
-
-instance KnownComponent 'Galley where
-  componentVal = Galley
-
-instance KnownComponent 'Cargohold where
-  componentVal = Cargohold

--- a/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
@@ -65,6 +65,7 @@ type instance (api @! name) @@ v = FromJust (LookupEndpoint (api @@ v) name)
 class VersionedApi (vapi :: *) where
   hoistV :: Sing v -> (forall x. m x -> n x) -> Client m (vapi @@ v) -> Client n (vapi @@ v)
   clientV :: RunClient m => Proxy m -> Sing v -> Client m (vapi @@ v)
+  flattenV :: Monad m => Sing v -> m (Client m (vapi @@ v)) -> Client m (vapi @@ v)
 
 -- flattenV :: m (Client m (vapi @@ v)) -> Client m (vapi @@ v)
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
@@ -20,6 +20,7 @@ module Wire.API.Federation.Endpoint where
 import Imports
 import Servant.API
 import Wire.API.Federation.Domain
+import Wire.API.Federation.Version.Info
 import Wire.API.Routes.Named
 
 type FedEndpoint name input output =
@@ -45,3 +46,5 @@ type family LookupEndpoint api name :: Maybe * where
       (LookupEndpoint api1 name)
       (LookupEndpoint api2 name)
   LookupEndpoint api name = 'Nothing
+
+type ApiVersionEndpoint = "api-versions" :> Post '[JSON] VersionInfo

--- a/libs/wire-api-federation/src/Wire/API/Federation/Example.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Example.hs
@@ -1,0 +1,15 @@
+module Wire.API.Federation.Example where
+
+import Control.Monad.Codensity
+import Control.Monad.Except
+import Data.Handle
+import Imports
+import Wire.API.Federation.API.Brig
+import Wire.API.Federation.Client
+import Wire.API.Federation.Endpoint
+import Wire.API.Federation.Error
+import Wire.API.User
+
+example :: FederatorClientEnv -> Handle -> ExceptT FederatorClientError (Codensity IO) (Maybe UserProfile)
+example env h = case runFederatorClientWithNegotiation @(BrigApi @! "get-user-by-handle") env of
+  SomeClient _ cli -> cli h

--- a/libs/wire-api-federation/src/Wire/API/Federation/Example.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Example.hs
@@ -8,8 +8,9 @@ import Wire.API.Federation.API.Brig
 import Wire.API.Federation.Client
 import Wire.API.Federation.Endpoint
 import Wire.API.Federation.Error
+import Wire.API.Federation.Version
 import Wire.API.User
 
 example :: FederatorClientEnv -> Handle -> ExceptT FederatorClientError (Codensity IO) (Maybe UserProfile)
 example env h = case runFederatorClientWithNegotiation @(BrigApi @! "get-user-by-handle") env of
-  SomeClient _ cli -> cli h
+  SomeClient SV0 cli -> cli h

--- a/libs/wire-api-federation/src/Wire/API/Federation/Version.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Version.hs
@@ -1,0 +1,22 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Federation.Version where
+
+data Version = V0
+
+type VL = 'V0 :: Version

--- a/libs/wire-api-federation/src/Wire/API/Federation/Version/Info.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Version/Info.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE StandaloneKindSignatures #-}
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
@@ -16,33 +14,23 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
-module Wire.API.Federation.Version where
+
+module Wire.API.Federation.Version.Info
+  ( VersionInfo (..),
+    supportedVersionInfo,
+  )
+where
 
 import Data.Aeson
-import Data.Singletons
-import GHC.Generics
 import Imports
 import Wire.API.Arbitrary
-import Wire.API.Federation.Version.TH
+import Wire.API.Federation.Version
+import Wire.API.Util.Aeson (CustomEncoded (..))
 
-data Version = V0
-  deriving (Eq, Ord, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform Version)
+newtype VersionInfo = VersionInfo {vinfoSupported :: [Version]}
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform VersionInfo)
+  deriving (ToJSON, FromJSON) via (CustomEncoded VersionInfo)
 
-versionOptions :: Options
-versionOptions =
-  defaultOptions
-    { constructorTagModifier = map toLower,
-      tagSingleConstructors = True
-    }
-
-instance ToJSON Version where
-  toJSON = genericToJSON @Version versionOptions
-
-instance FromJSON Version where
-  parseJSON = genericParseJSON @Version versionOptions
-
-$(genVersions ''Version)
-
-supportedVersions :: [Version]
-supportedVersions = demote @SupportedVersions
+supportedVersionInfo :: VersionInfo
+supportedVersionInfo = VersionInfo supportedVersions

--- a/libs/wire-api-federation/src/Wire/API/Federation/Version/TH.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Version/TH.hs
@@ -1,0 +1,53 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Federation.Version.TH (genVersions) where
+
+import Data.Singletons.TH
+import Imports
+import Language.Haskell.TH
+
+genVersions :: Name -> Q [Dec]
+genVersions ty =
+  reify ty >>= \case
+    TyConI (DataD _ name _ _ cs _) -> do
+      pcs <- traverse promoteConstructor cs
+      vl <- genLastVersion cs
+      singl <- genSingletons [ty]
+      pure $
+        [ TySynD
+            (mkName ("Supported" <> nameBase name <> "s"))
+            []
+            (foldr pcons PromotedNilT pcs)
+        ]
+          <> singl
+          <> vl
+    _ -> fail $ "Unsupported version type: " <> nameBase ty
+
+genLastVersion :: [Con] -> Q [Dec]
+genLastVersion [] = pure []
+genLastVersion cs = do
+  let c = last cs
+  val <- promoteConstructor c
+  pure [TySynD (mkName "VL") [] val]
+
+promoteConstructor :: Con -> Q Type
+promoteConstructor (NormalC name []) = pure $ PromotedT name
+promoteConstructor _ = fail "Unsupported constructor"
+
+pcons :: Type -> Type -> Type
+pcons x y = PromotedConsT `AppT` x `AppT` y

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -29,6 +29,7 @@ library
       Wire.API.Federation.Endpoint
       Wire.API.Federation.Error
       Wire.API.Federation.Event
+      Wire.API.Federation.Example
       Wire.API.Federation.Version
       Wire.API.Federation.Version.Info
       Wire.API.Federation.Version.TH

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -30,6 +30,8 @@ library
       Wire.API.Federation.Error
       Wire.API.Federation.Event
       Wire.API.Federation.Version
+      Wire.API.Federation.Version.Info
+      Wire.API.Federation.Version.TH
   other-modules:
       Paths_wire_api_federation
   hs-source-dirs:
@@ -99,6 +101,7 @@ library
     , servant-client
     , servant-client-core
     , servant-server
+    , singletons
     , sop-core
     , streaming-commons
     , template-haskell
@@ -199,6 +202,7 @@ test-suite spec
     , servant-client
     , servant-client-core
     , servant-server
+    , singletons
     , sop-core
     , streaming-commons
     , template-haskell

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -29,6 +29,7 @@ library
       Wire.API.Federation.Endpoint
       Wire.API.Federation.Error
       Wire.API.Federation.Event
+      Wire.API.Federation.Version
   other-modules:
       Paths_wire_api_federation
   hs-source-dirs:

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -95,6 +95,7 @@ library
     , kan-extensions
     , lifted-base
     , metrics-wai
+    , mmorph
     , mtl
     , network
     , servant >=0.16
@@ -195,6 +196,7 @@ test-suite spec
     , kan-extensions
     , lifted-base
     , metrics-wai
+    , mmorph
     , mtl
     , network
     , retry

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -20,6 +20,8 @@ module Wire.API.Routes.Named where
 import Data.Metrics.Servant
 import Data.Proxy
 import Imports
+import Servant.Client
+import Servant.Client.Core
 import Servant.Server
 import Servant.Swagger
 
@@ -35,6 +37,11 @@ instance HasServer api ctx => HasServer (Named name api) ctx where
   route _ ctx action = route (Proxy @api) ctx (fmap unnamed action)
   hoistServerWithContext _ ctx f =
     fmap (hoistServerWithContext (Proxy @api) ctx f)
+
+instance (RunClient m, HasClient m api) => HasClient m (Named name api) where
+  type Client m (Named name api) = Client m api
+  clientWithRoute m _ = clientWithRoute m (Proxy @api)
+  hoistClientMonad m _ = hoistClientMonad m (Proxy @api)
 
 instance RoutesToPaths api => RoutesToPaths (Named name api) where
   getRoutes = getRoutes @api

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -255,6 +255,7 @@ library
     , servant-server
     , servant-swagger
     , servant-swagger-ui
+    , singletons
     , sodium-crypto-sign >=0.1
     , split >=0.2
     , ssl-util

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -112,6 +112,7 @@ library:
   - servant-server
   - servant-swagger
   - servant-swagger-ui
+  - singletons
   - sodium-crypto-sign >=0.1
   - split >=0.2
   - ssl-util

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -44,6 +44,7 @@ import Network.Wai.Utilities.Error ((!>>))
 import Servant (ServerT)
 import Servant.API
 import UnliftIO.Async (pooledForConcurrentlyN_)
+import Wire.API.Federation.API
 import Wire.API.Federation.API.Brig
 import Wire.API.Federation.API.Common
 import Wire.API.Message (UserClients)
@@ -56,7 +57,7 @@ import Wire.API.User.Client.Prekey (ClientPrekey)
 import Wire.API.User.Search
 import Wire.API.UserMap (UserMap)
 
-type FederationAPI = "federation" :> BrigApi
+type FederationAPI = "federation" :> VersionedFedApi 'Brig
 
 federationSitemap :: ServerT FederationAPI Handler
 federationSitemap =

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -57,7 +57,7 @@ import Wire.API.User.Client.Prekey (ClientPrekey)
 import Wire.API.User.Search
 import Wire.API.UserMap (UserMap)
 
-type FederationAPI = "federation" :> VersionedFedApi 'Brig
+type FederationAPI = "federation" :> VersionedFedApi' 'Brig
 
 federationSitemap :: ServerT FederationAPI Handler
 federationSitemap =

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -61,15 +61,16 @@ type FederationAPI = "federation" :> VersionedFedApi 'Brig
 
 federationSitemap :: ServerT FederationAPI Handler
 federationSitemap =
-  Named @"get-user-by-handle" getUserByHandle
-    :<|> Named @"get-users-by-ids" getUsersByIds
-    :<|> Named @"claim-prekey" claimPrekey
-    :<|> Named @"claim-prekey-bundle" claimPrekeyBundle
-    :<|> Named @"claim-multi-prekey-bundle" claimMultiPrekeyBundle
-    :<|> Named @"search-users" searchUsers
-    :<|> Named @"get-user-clients" getUserClients
-    :<|> Named @"send-connection-action" sendConnectionAction
-    :<|> Named @"on-user-deleted-connections" onUserDeleted
+  mkVersionedServer @'Brig $
+    Named @"get-user-by-handle" getUserByHandle
+      :<|> Named @"get-users-by-ids" getUsersByIds
+      :<|> Named @"claim-prekey" claimPrekey
+      :<|> Named @"claim-prekey-bundle" claimPrekeyBundle
+      :<|> Named @"claim-multi-prekey-bundle" claimMultiPrekeyBundle
+      :<|> Named @"search-users" searchUsers
+      :<|> Named @"get-user-clients" getUserClients
+      :<|> Named @"send-connection-action" sendConnectionAction
+      :<|> Named @"on-user-deleted-connections" onUserDeleted
 
 sendConnectionAction :: Domain -> NewConnectionRequest -> Handler NewConnectionResponse
 sendConnectionAction originDomain NewConnectionRequest {..} = do

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -107,7 +107,7 @@ notifyUserDeleted self remotes = do
     executeFederated @"on-user-deleted-connections" @VL (tDomain remotes) $
       UserDeletedConnectionsNotification (tUnqualified self) remoteConnections
 
-runBrigFederatorClient :: Domain -> FederatorClient 'Brig a -> FederationAppIO a
+runBrigFederatorClient :: Domain -> FederatorClient 'Brig v a -> FederationAppIO a
 runBrigFederatorClient targetDomain action = do
   ownDomain <- viewFederationDomain
   endpoint <- view federator >>= maybe (throwE FederationNotConfigured) pure
@@ -124,10 +124,10 @@ executeFederated ::
   forall (name :: Symbol) (v :: Version) api.
   ( HasFedEndpoint 'Brig v api name,
     HasClient ClientM api,
-    HasClient (FederatorClient 'Brig) api
+    HasClient (FederatorClient 'Brig v) api
   ) =>
   Domain ->
   Client FederationAppIO api
 executeFederated domain =
-  hoistClient (Proxy @api) (runBrigFederatorClient domain) $
-    clientIn (Proxy @api) (Proxy @(FederatorClient 'Brig))
+  hoistClient (Proxy @api) (runBrigFederatorClient @v domain) $
+    clientIn (Proxy @api) (Proxy @(FederatorClient 'Brig v))

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -600,7 +600,7 @@ testUserInvalidDomain brig = do
   get (brig . paths ["users", "invalid.example.com", toByteString' uid] . zUser uid)
     !!! do
       const 422 === statusCode
-      const (Just "/federation/get-users-by-ids")
+      const (Just "/federation/api-versions")
         === preview (ix "data" . ix "path") . responseJsonUnsafe @Value
       const (Just "invalid.example.com")
         === preview (ix "data" . ix "domain") . responseJsonUnsafe @Value

--- a/services/brig/test/integration/API/User/Connection.hs
+++ b/services/brig/test/integration/API/User/Connection.hs
@@ -44,9 +44,9 @@ import Test.Tasty hiding (Timeout)
 import Test.Tasty.HUnit
 import Util
 import Wire.API.Connection
+import Wire.API.Federation.API
 import Wire.API.Federation.API.Brig
-import Wire.API.Federation.API.Galley (GetConversationsRequest (..), GetConversationsResponse (gcresConvs), RemoteConvMembers (rcmOthers), RemoteConversation (rcnvMembers))
-import Wire.API.Federation.Component
+import Wire.API.Federation.API.Galley
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Routes.MultiTablePaging
 
@@ -739,7 +739,7 @@ testConnectWithAnon brig fedBrigClient = do
   fromUser <- randomId
   toUser <- userId <$> createAnonUser "anon1234" brig
   res <-
-    runFedClient @"send-connection-action" fedBrigClient (Domain "far-away.example.com") $
+    runFedClient @"send-connection-action" @VL fedBrigClient (Domain "far-away.example.com") $
       NewConnectionRequest fromUser toUser RemoteConnect
   liftIO $
     assertEqual "The response should specify that the user is not activated" NewConnectionResponseUserNotActivated res
@@ -794,7 +794,7 @@ testConnectMutualRemoteActionThenLocalAction opts brig fedBrigClient fedGalleyCl
             gcrConvIds = [qUnqualified convId]
           }
 
-  res <- runFedClient @"get-conversations" fedGalleyClient (qDomain quid2) request
+  res <- runFedClient @"get-conversations" @VL fedGalleyClient (qDomain quid2) request
   liftIO $
     fmap (fmap omQualifiedId . rcmOthers . rcnvMembers) (gcresConvs res) @?= [[]]
 

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -116,8 +116,8 @@ type Spar = Request -> Request
 data FedClient (comp :: Component) = FedClient HTTP.Manager Endpoint
 
 runFedClient ::
-  forall (name :: Symbol) comp api.
-  ( HasFedEndpoint comp api name,
+  forall (name :: Symbol) (v :: Version) comp api.
+  ( HasFedEndpoint comp v api name,
     Servant.HasClient Servant.ClientM api
   ) =>
   FedClient comp ->

--- a/services/cargohold/cargohold.cabal
+++ b/services/cargohold/cargohold.cabal
@@ -122,6 +122,7 @@ library
     , safe >=0.3
     , servant
     , servant-server
+    , singletons
     , swagger >=0.2
     , text >=1.1
     , time >=1.4
@@ -203,6 +204,7 @@ executable cargohold
     , kan-extensions
     , mime >=0.4
     , safe >=0.3
+    , singletons
     , text >=1.1
     , types-common
     , yaml >=0.8
@@ -295,6 +297,7 @@ executable cargohold-integration
     , safe >=0.3
     , servant-client
     , servant-client-core
+    , singletons
     , tagged >=0.8
     , tasty >=1.0
     , tasty-hunit >=0.9

--- a/services/cargohold/package.yaml
+++ b/services/cargohold/package.yaml
@@ -26,6 +26,7 @@ dependencies:
 - kan-extensions
 - mime >=0.4
 - safe >=0.3
+- singletons
 - text >=1.1
 - yaml >=0.8
 - imports

--- a/services/cargohold/src/CargoHold/API/Federation.hs
+++ b/services/cargohold/src/CargoHold/API/Federation.hs
@@ -37,7 +37,7 @@ import qualified Wire.API.Federation.API.Cargohold as F
 import Wire.API.Routes.AssetBody
 import Wire.API.Routes.Named
 
-type FederationAPI = "federation" :> FedApi 'Cargohold
+type FederationAPI = "federation" :> VersionedFedApi 'Cargohold
 
 federationSitemap :: ServerT FederationAPI Handler
 federationSitemap =

--- a/services/cargohold/src/CargoHold/API/Federation.hs
+++ b/services/cargohold/src/CargoHold/API/Federation.hs
@@ -41,8 +41,9 @@ type FederationAPI = "federation" :> VersionedFedApi 'Cargohold
 
 federationSitemap :: ServerT FederationAPI Handler
 federationSitemap =
-  Named @"get-asset" getAsset
-    :<|> Named @"stream-asset" streamAsset
+  mkVersionedServer @'Cargohold $
+    Named @"get-asset" getAsset
+      :<|> Named @"stream-asset" streamAsset
 
 checkAsset :: F.GetAsset -> Handler Bool
 checkAsset ga =

--- a/services/cargohold/src/CargoHold/API/Federation.hs
+++ b/services/cargohold/src/CargoHold/API/Federation.hs
@@ -41,9 +41,8 @@ type FederationAPI = "federation" :> VersionedFedApi 'Cargohold
 
 federationSitemap :: ServerT FederationAPI Handler
 federationSitemap =
-  mkVersionedServer @'Cargohold $
-    Named @"get-asset" getAsset
-      :<|> Named @"stream-asset" streamAsset
+  Named @"get-asset" getAsset
+    :<|> Named @"stream-asset" streamAsset
 
 checkAsset :: F.GetAsset -> Handler Bool
 checkAsset ga =

--- a/services/cargohold/src/CargoHold/Federation.hs
+++ b/services/cargohold/src/CargoHold/Federation.hs
@@ -61,14 +61,14 @@ downloadRemoteAsset usr rkey tok = do
           }
   exists <-
     fmap gaAvailable . executeFederated rkey $
-      fedClient @'Cargohold @"get-asset" ga
+      fedClient @'Cargohold @VL @"get-asset" ga
   if exists
     then
       Just
         <$> executeFederatedStreaming
           rkey
           ( toSourceIO
-              <$> fedClient @'Cargohold @"stream-asset" ga
+              <$> fedClient @'Cargohold @VL @"stream-asset" ga
           )
     else pure Nothing
 

--- a/services/cargohold/src/CargoHold/Federation.hs
+++ b/services/cargohold/src/CargoHold/Federation.hs
@@ -85,7 +85,7 @@ mkFederatorClientEnv remote = do
         ceFederator = endpoint
       }
 
-executeFederated :: Remote x -> FederatorClient 'Cargohold a -> Handler a
+executeFederated :: Remote x -> FederatorClient 'Cargohold v a -> Handler a
 executeFederated remote c = do
   env <- mkFederatorClientEnv remote
   liftIO (runFederatorClient @'Cargohold env c)
@@ -93,7 +93,7 @@ executeFederated remote c = do
 
 executeFederatedStreaming ::
   Remote x ->
-  FederatorClient 'Cargohold (SourceIO ByteString) ->
+  FederatorClient 'Cargohold v (SourceIO ByteString) ->
   Handler (SourceIO ByteString)
 executeFederatedStreaming remote c = do
   env <- mkFederatorClientEnv remote

--- a/services/cargohold/src/CargoHold/Federation.hs
+++ b/services/cargohold/src/CargoHold/Federation.hs
@@ -25,6 +25,7 @@ import Control.Lens
 import Control.Monad.Codensity
 import Data.Id
 import Data.Qualified
+import Data.Singletons
 import Imports hiding (head)
 import Servant.API
 import Servant.Types.SourceT
@@ -85,15 +86,16 @@ mkFederatorClientEnv remote = do
         ceFederator = endpoint
       }
 
-executeFederated :: Remote x -> FederatorClient 'Cargohold v a -> Handler a
+executeFederated :: SingI v => Remote x -> FederatorClient 'Cargohold ('Just v) a -> Handler a
 executeFederated remote c = do
   env <- mkFederatorClientEnv remote
   liftIO (runFederatorClient @'Cargohold env c)
     >>= either (throwE . federationErrorToWai . FederationCallFailure) pure
 
 executeFederatedStreaming ::
+  SingI v =>
   Remote x ->
-  FederatorClient 'Cargohold v (SourceIO ByteString) ->
+  FederatorClient 'Cargohold ('Just v) (SourceIO ByteString) ->
   Handler (SourceIO ByteString)
 executeFederatedStreaming remote c = do
   env <- mkFederatorClientEnv remote

--- a/services/cargohold/src/CargoHold/Federation.hs
+++ b/services/cargohold/src/CargoHold/Federation.hs
@@ -109,5 +109,5 @@ executeFederatedStreaming remote c = do
   pure $
     SourceT $ \k ->
       runCodensity
-        (runFederatorClientToCodensity env c)
+        (runExceptT (runFederatorClientToCodensity env c))
         (either (throw . federationErrorToWai . FederationCallFailure) (flip unSourceT k))

--- a/services/cargohold/test/integration/API.hs
+++ b/services/cargohold/test/integration/API.hs
@@ -35,6 +35,7 @@ import Data.ByteString.Conversion
 import Data.Domain
 import Data.Id
 import Data.Qualified
+import Data.Singletons
 import qualified Data.Text.Encoding.Error as Text
 import qualified Data.Text.Lazy.Encoding as LText
 import Data.Time.Clock
@@ -52,6 +53,7 @@ import Test.Tasty.HUnit
 import TestSetup
 import Wire.API.Federation.API.Cargohold
 import Wire.API.Federation.Component
+import Wire.API.Federation.Version
 
 tests :: IO TestSetup -> TestTree
 tests s =
@@ -292,7 +294,8 @@ testRemoteDownloadNoAsset = do
                 frTargetDomain = Domain "faraway.example.com",
                 frComponent = Cargohold,
                 frRPC = "get-asset",
-                frBody = Aeson.encode (GetAsset uid key Nothing)
+                frBody = Aeson.encode (GetAsset uid key Nothing),
+                frVersion = Just (demote @VL)
               }
           ]
 
@@ -339,13 +342,15 @@ testRemoteDownload assetContent = do
                 frTargetDomain = Domain "faraway.example.com",
                 frComponent = Cargohold,
                 frRPC = "get-asset",
-                frBody = ga
+                frBody = ga,
+                frVersion = Just (demote @VL)
               },
             FederatedRequest
               { frOriginDomain = localDomain,
                 frTargetDomain = Domain "faraway.example.com",
                 frComponent = Cargohold,
                 frRPC = "stream-asset",
-                frBody = ga
+                frBody = ga,
+                frVersion = Just (demote @VL)
               }
           ]

--- a/services/cargohold/test/integration/API/Federation.hs
+++ b/services/cargohold/test/integration/API/Federation.hs
@@ -66,7 +66,7 @@ testGetAssetAvailable isPublicAsset = do
           }
   ok <-
     withFederationClient $
-      gaAvailable <$> runFederationClient (fedClientIn @'Cargohold @"get-asset" ga)
+      gaAvailable <$> runFederationClient (fedClientIn @'Cargohold @VL @"get-asset" ga)
 
   -- check that asset is available
   liftIO $ ok @?= True
@@ -86,7 +86,7 @@ testGetAssetNotAvailable = do
           }
   ok <-
     withFederationClient $
-      gaAvailable <$> runFederationClient (fedClientIn @'Cargohold @"get-asset" ga)
+      gaAvailable <$> runFederationClient (fedClientIn @'Cargohold @VL @"get-asset" ga)
 
   -- check that asset is not available
   liftIO $ ok @?= False
@@ -113,7 +113,7 @@ testGetAssetWrongToken = do
           }
   ok <-
     withFederationClient $
-      gaAvailable <$> runFederationClient (fedClientIn @'Cargohold @"get-asset" ga)
+      gaAvailable <$> runFederationClient (fedClientIn @'Cargohold @VL @"get-asset" ga)
 
   -- check that asset is not available
   liftIO $ ok @?= False
@@ -144,7 +144,7 @@ testLargeAsset = do
             gaKey = qUnqualified key
           }
   chunks <- withFederationClient $ do
-    source <- getAssetSource <$> runFederationClient (fedClientIn @'Cargohold @"stream-asset" ga)
+    source <- getAssetSource <$> runFederationClient (fedClientIn @'Cargohold @VL @"stream-asset" ga)
     liftIO . runResourceT $ connect source sinkList
   liftIO $ do
     let minNumChunks = 8
@@ -176,7 +176,7 @@ testStreamAsset = do
             gaKey = qUnqualified key
           }
   respBody <- withFederationClient $ do
-    source <- getAssetSource <$> runFederationClient (fedClientIn @'Cargohold @"stream-asset" ga)
+    source <- getAssetSource <$> runFederationClient (fedClientIn @'Cargohold @VL @"stream-asset" ga)
     liftIO . runResourceT $ connect source sinkLazy
   liftIO $ respBody @?= "Hello World"
 
@@ -194,7 +194,7 @@ testStreamAssetNotAvailable = do
             gaKey = key
           }
   err <- withFederationError $ do
-    runFederationClient (fedClientIn @'Cargohold @"stream-asset" ga)
+    runFederationClient (fedClientIn @'Cargohold @VL @"stream-asset" ga)
   liftIO $ do
     Wai.code err @?= HTTP.notFound404
     Wai.label err @?= "not-found"
@@ -220,7 +220,7 @@ testStreamAssetWrongToken = do
             gaKey = qUnqualified key
           }
   err <- withFederationError $ do
-    runFederationClient (fedClientIn @'Cargohold @"stream-asset" ga)
+    runFederationClient (fedClientIn @'Cargohold @VL @"stream-asset" ga)
   liftIO $ do
     Wai.code err @?= HTTP.notFound404
     Wai.label err @?= "not-found"

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -134,6 +134,7 @@ library
     , retry
     , servant
     , servant-client-core
+    , singletons
     , streaming-commons
     , string-conversions
     , text
@@ -241,6 +242,7 @@ executable federator
     , retry
     , servant
     , servant-client-core
+    , singletons
     , streaming-commons
     , string-conversions
     , text
@@ -360,6 +362,7 @@ executable federator-integration
     , retry
     , servant
     , servant-client-core
+    , singletons
     , streaming-commons
     , string-conversions
     , tasty
@@ -484,6 +487,7 @@ test-suite federator-tests
     , servant
     , servant-client
     , servant-client-core
+    , singletons
     , streaming-commons
     , string-conversions
     , tasty

--- a/services/federator/package.yaml
+++ b/services/federator/package.yaml
@@ -46,6 +46,7 @@ dependencies:
 - retry
 - servant
 - servant-client-core
+- singletons
 - streaming-commons
 - string-conversions
 - text

--- a/services/federator/src/Federator/Error/ServerError.hs
+++ b/services/federator/src/Federator/Error/ServerError.hs
@@ -27,6 +27,7 @@ import Wire.API.Federation.Domain
 data ServerError
   = InvalidRoute
   | UnknownComponent Text
+  | InvalidVersion Text
   | NoOriginDomain
   deriving (Eq, Show, Typeable)
 
@@ -39,7 +40,10 @@ instance AsWai ServerError where
     Wai.mkError HTTP.status403 "unknown-component" (LText.fromStrict (waiErrorDescription e))
   toWai e@NoOriginDomain =
     Wai.mkError HTTP.status403 "no-origin-domain" (LText.fromStrict (waiErrorDescription e))
+  toWai e@(InvalidVersion _) =
+    Wai.mkError HTTP.status403 "invalid-version" (LText.fromStrict (waiErrorDescription e))
 
   waiErrorDescription InvalidRoute = "The requested endpoint does not exist"
   waiErrorDescription (UnknownComponent name) = "No such component: " <> name
   waiErrorDescription NoOriginDomain = "No " <> originDomainHeaderName <> " header"
+  waiErrorDescription (InvalidVersion v) = "Invalid version: " <> v

--- a/services/federator/src/Federator/MockServer.hs
+++ b/services/federator/src/Federator/MockServer.hs
@@ -117,6 +117,7 @@ startMockServer mtlsSettings app = do
 data FederatedRequest = FederatedRequest
   { frOriginDomain :: Domain,
     frTargetDomain :: Domain,
+    frVersion :: Maybe Version,
     frComponent :: Component,
     frRPC :: Text,
     frBody :: LByteString
@@ -159,17 +160,18 @@ withTempMockFederator headers resp action = do
                   MockException
                 ]
             $ do
-              RequestData {..} <- parseRequestData request
-              domainText <- note NoOriginDomain $ lookup originDomainHeaderName rdHeaders
+              rd <- parseRequestData request
+              domainText <- note NoOriginDomain $ lookup originDomainHeaderName (rdHeaders rd)
               originDomain <- parseDomain domainText
-              targetDomain <- parseDomainText rdTargetDomain
+              targetDomain <- parseDomainText (rdTargetDomain rd)
               let fedRequest =
                     ( FederatedRequest
                         { frOriginDomain = originDomain,
                           frTargetDomain = targetDomain,
-                          frComponent = rdComponent,
-                          frRPC = rdRPC,
-                          frBody = rdBody
+                          frVersion = rdVersion rd,
+                          frComponent = rdComponent rd,
+                          frRPC = rdRPC rd,
+                          frBody = rdBody rd
                         }
                     )
               (ct, body) <-

--- a/services/federator/test/unit/Test/Federator/Client.hs
+++ b/services/federator/test/unit/Test/Federator/Client.hs
@@ -109,7 +109,7 @@ testClientSuccess = do
     withMockFederatorClient
       defaultHeaders
       (const (pure ("application/json", Aeson.encode (Just expectedResponse))))
-      $ fedClient @'Brig @"get-user-by-handle" handle
+      $ fedClient @'Brig @VL @"get-user-by-handle" handle
 
   sentRequests
     @?= [ FederatedRequest
@@ -149,7 +149,7 @@ testClientFailure = do
       defaultHeaders
       (const (throw (MockErrorResponse HTTP.status422 "wrong domain")))
       $ do
-        fedClient @'Brig @"get-user-by-handle" handle
+        fedClient @'Brig @VL @"get-user-by-handle" handle
 
   case actualResponse of
     Right _ -> assertFailure "unexpected success"
@@ -166,7 +166,7 @@ testFederatorFailure = do
       defaultHeaders
       (const (throw (MockErrorResponse HTTP.status403 "invalid path")))
       $ do
-        fedClient @'Brig @"get-user-by-handle" handle
+        fedClient @'Brig @VL @"get-user-by-handle" handle
 
   case actualResponse of
     Right _ -> assertFailure "unexpected success"
@@ -180,7 +180,7 @@ testClientExceptions = do
 
   (response, _) <-
     withMockFederatorClient defaultHeaders (const (evaluate (error "unhandled exception"))) $
-      fedClient @'Brig @"get-user-by-handle" handle
+      fedClient @'Brig @VL @"get-user-by-handle" handle
 
   case response of
     Right _ -> assertFailure "unexpected success"
@@ -195,7 +195,7 @@ testClientConnectionError = do
             ceTargetDomain = targetDomain,
             ceFederator = Endpoint "127.0.0.1" 1
           }
-  result <- runFederatorClient env (fedClient @'Brig @"get-user-by-handle" handle)
+  result <- runFederatorClient env (fedClient @'Brig @VL @"get-user-by-handle" handle)
   case result of
     Left (FederatorClientHTTP2Error (FederatorClientConnectionError _)) -> pure ()
     Left x -> assertFailure $ "Expected connection error, got: " <> show x

--- a/services/federator/test/unit/Test/Federator/Client.hs
+++ b/services/federator/test/unit/Test/Federator/Client.hs
@@ -46,7 +46,6 @@ import Test.Tasty.HUnit
 import Util.Options
 import Wire.API.Federation.API
 import Wire.API.Federation.Client
-import Wire.API.Federation.Component
 import Wire.API.Federation.Error
 import Wire.API.User (UserProfile)
 
@@ -83,7 +82,7 @@ newtype ResponseFailure = ResponseFailure Wai.Error
   deriving (Show)
 
 withMockFederatorClient ::
-  (KnownComponent c, SingI v) =>
+  (SingI c, SingI v) =>
   [HTTP.Header] ->
   (FederatedRequest -> IO (MediaType, LByteString)) ->
   FederatorClient c ('Just v) a ->

--- a/services/federator/test/unit/Test/Federator/Client.hs
+++ b/services/federator/test/unit/Test/Federator/Client.hs
@@ -85,7 +85,7 @@ withMockFederatorClient ::
   KnownComponent c =>
   [HTTP.Header] ->
   (FederatedRequest -> IO (MediaType, LByteString)) ->
-  FederatorClient c a ->
+  FederatorClient c v a ->
   IO (Either ResponseFailure a, [FederatedRequest])
 withMockFederatorClient headers resp action = withTempMockFederator headers resp $ \port -> do
   let env =
@@ -132,7 +132,7 @@ testClientStreaming = withInfiniteMockServer $ \port -> do
             ceTargetDomain = targetDomain,
             ceFederator = Endpoint "127.0.0.1" (fromIntegral port)
           }
-  let c = clientIn (Proxy @StreamingAPI) (Proxy @(FederatorClient 'Brig))
+  let c = clientIn (Proxy @StreamingAPI) (Proxy @(FederatorClient 'Brig VL))
   runCodensity (runFederatorClientToCodensity env c) $ \case
     Left err -> assertFailure $ "Unexpected error: " <> displayException err
     Right out -> do

--- a/services/federator/test/unit/Test/Federator/Client.hs
+++ b/services/federator/test/unit/Test/Federator/Client.hs
@@ -133,7 +133,7 @@ testClientStreaming = withInfiniteMockServer $ \port -> do
             ceFederator = Endpoint "127.0.0.1" (fromIntegral port)
           }
   let c = clientIn (Proxy @StreamingAPI) (Proxy @FederatorClient)
-  runCodensity (runFederatorClientToCodensity env c) $ \case
+  runCodensity (runExceptT (runFederatorClientToCodensity env c)) $ \case
     Left err -> assertFailure $ "Unexpected error: " <> displayException err
     Right out -> do
       let expected = mconcat (replicate 500 "Hello")

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -225,6 +225,7 @@ library
     , servant-server
     , servant-swagger
     , servant-swagger-ui
+    , singletons
     , sop-core
     , split >=0.2
     , ssl-util >=0.1

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -77,6 +77,7 @@ library:
   - servant-server
   - servant-swagger
   - servant-swagger-ui
+  - singletons
   - sop-core
   - split >=0.2
   - ssl-util >=0.1

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -526,7 +526,7 @@ notifyConversationAction quid con lcnv targets action = do
 
   -- notify remote participants
   E.runFederatedConcurrently_ (toList (bmRemotes targets)) $ \ruids ->
-    fedClient @'Galley @"on-conversation-updated" $
+    fedClient @'Galley @VL @"on-conversation-updated" $
       ConversationUpdate now quid (tUnqualified lcnv) (tUnqualified ruids) action
 
   -- notify local participants and bots

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -67,7 +67,7 @@ import Wire.API.Routes.Named
 import Wire.API.ServantProto
 import Wire.API.User.Client (userClientMap)
 
-type FederationAPI = "federation" :> FedApi 'Galley
+type FederationAPI = "federation" :> VersionedFedApi 'Galley
 
 federationSitemap :: ServerT FederationAPI (Sem GalleyEffects)
 federationSitemap =

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -71,14 +71,13 @@ type FederationAPI = "federation" :> VersionedFedApi 'Galley
 
 federationSitemap :: ServerT FederationAPI (Sem GalleyEffects)
 federationSitemap =
-  mkVersionedServer @'Galley $
-    Named @"on-conversation-created" onConversationCreated
-      :<|> Named @"get-conversations" getConversations
-      :<|> Named @"on-conversation-updated" onConversationUpdated
-      :<|> Named @"leave-conversation" leaveConversation
-      :<|> Named @"on-message-sent" onMessageSent
-      :<|> Named @"send-message" sendMessage
-      :<|> Named @"on-user-deleted-conversations" onUserDeleted
+  Named @"on-conversation-created" onConversationCreated
+    :<|> Named @"get-conversations" getConversations
+    :<|> Named @"on-conversation-updated" onConversationUpdated
+    :<|> Named @"leave-conversation" leaveConversation
+    :<|> Named @"on-message-sent" onMessageSent
+    :<|> Named @"send-message" sendMessage
+    :<|> Named @"on-user-deleted-conversations" onUserDeleted
 
 onConversationCreated ::
   Members '[BrigAccess, GundeckAccess, ExternalAccess, Input (Local ()), MemberStore, P.TinyLog] r =>

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -71,13 +71,14 @@ type FederationAPI = "federation" :> VersionedFedApi 'Galley
 
 federationSitemap :: ServerT FederationAPI (Sem GalleyEffects)
 federationSitemap =
-  Named @"on-conversation-created" onConversationCreated
-    :<|> Named @"get-conversations" getConversations
-    :<|> Named @"on-conversation-updated" onConversationUpdated
-    :<|> Named @"leave-conversation" leaveConversation
-    :<|> Named @"on-message-sent" onMessageSent
-    :<|> Named @"send-message" sendMessage
-    :<|> Named @"on-user-deleted-conversations" onUserDeleted
+  mkVersionedServer @'Galley $
+    Named @"on-conversation-created" onConversationCreated
+      :<|> Named @"get-conversations" getConversations
+      :<|> Named @"on-conversation-updated" onConversationUpdated
+      :<|> Named @"leave-conversation" leaveConversation
+      :<|> Named @"on-message-sent" onMessageSent
+      :<|> Named @"send-message" sendMessage
+      :<|> Named @"on-user-deleted-conversations" onUserDeleted
 
 onConversationCreated ::
   Members '[BrigAccess, GundeckAccess, ExternalAccess, Input (Local ()), MemberStore, P.TinyLog] r =>

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -627,7 +627,7 @@ rmUser lusr conn = do
                 cuAlreadyPresentUsers = tUnqualified remotes,
                 cuAction = ConversationActionRemoveMembers (pure qUser)
               }
-      let rpc = fedClient @'Galley @"on-conversation-updated" convUpdate
+      let rpc = fedClient @'Galley @VL @"on-conversation-updated" convUpdate
       runFederatedEither remotes rpc
         >>= logAndIgnoreError "Error in onConversationUpdated call" (qUnqualified qUser)
 
@@ -635,7 +635,7 @@ rmUser lusr conn = do
     leaveRemoteConversations cids = do
       for_ (bucketRemote (fromRange cids)) $ \remoteConvs -> do
         let userDelete = UserDeletedConversationsNotification (tUnqualified lusr) (unsafeRange (tUnqualified remoteConvs))
-        let rpc = fedClient @'Galley @"on-user-deleted-conversations" userDelete
+        let rpc = fedClient @'Galley @VL @"on-user-deleted-conversations" userDelete
         runFederatedEither remoteConvs rpc
           >>= logAndIgnoreError "Error in onUserDeleted call" (tUnqualified lusr)
 

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -192,7 +192,7 @@ getRemoteClients remoteMembers =
   where
     getRemoteClientsFromDomain (qUntagged -> Qualified uids domain) =
       Map.mapKeys (domain,) . fmap (Set.map pubClientId) . userMap
-        <$> fedClient @'Brig @"get-user-clients" (GetUserClients uids)
+        <$> fedClient @'Brig @VL @"get-user-clients" (GetUserClients uids)
 
 -- FUTUREWORK: sender should be Local UserId
 postRemoteOtrMessage ::
@@ -208,7 +208,7 @@ postRemoteOtrMessage sender conv rawMsg = do
             msrSender = qUnqualified sender,
             msrRawMessage = Base64ByteString rawMsg
           }
-      rpc = fedClient @'Galley @"send-message" msr
+      rpc = fedClient @'Galley @VL @"send-message" msr
   msResponse <$> runFederated conv rpc
 
 postQualifiedOtrMessage ::
@@ -409,7 +409,7 @@ sendRemoteMessages domain now sender senderClient lcnv metadata messages = (hand
             rmTransient = mmTransient metadata,
             rmRecipients = UserClientMap rcpts
           }
-  let rpc = fedClient @'Galley @"on-message-sent" rm
+  let rpc = fedClient @'Galley @VL @"on-message-sent" rm
   runFederatedEither domain rpc
   where
     handle :: Either FederationError a -> Sem r (Set (UserId, ClientId))

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -225,7 +225,7 @@ getRemoteConversationsWithFailures lusr convs = do
         | otherwise = [failedGetConversationLocally (map qUntagged locallyNotFound)]
 
   -- request conversations from remote backends
-  let rpc = fedClient @'Galley @"get-conversations"
+  let rpc = fedClient @'Galley @VL @"get-conversations"
   resp <-
     E.runFederatedConcurrentlyEither locallyFound $ \someConvs ->
       rpc $ GetConversationsRequest (tUnqualified lusr) (tUnqualified someConvs)

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1101,7 +1101,7 @@ removeMemberFromRemoteConv ::
 removeMemberFromRemoteConv cnv lusr victim
   | qUntagged lusr == victim = do
     let lc = LeaveConversationRequest (tUnqualified cnv) (qUnqualified victim)
-    let rpc = fedClient @'Galley @"leave-conversation" lc
+    let rpc = fedClient @'Galley @VL @"leave-conversation" lc
     (either handleError handleSuccess =<<) . fmap leaveResponse $
       E.runFederated cnv rpc
   | otherwise = throw (ActionDenied RemoveConversationMember)

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -735,7 +735,7 @@ registerRemoteConversationMemberships now localDomain c = do
   let allRemoteMembers = nubOrd (map rmId (Data.convRemoteMembers c))
       rc = toNewRemoteConversation now localDomain c
   runFederatedConcurrently_ allRemoteMembers $ \_ ->
-    fedClient @'Galley @"on-conversation-created" rc
+    fedClient @'Galley @VL @"on-conversation-created" rc
 
 --------------------------------------------------------------------------------
 -- Legalhold

--- a/services/galley/src/Galley/Effects/FederatorAccess.hs
+++ b/services/galley/src/Galley/Effects/FederatorAccess.hs
@@ -37,23 +37,23 @@ import Wire.API.Federation.Error
 
 data FederatorAccess m a where
   RunFederated ::
-    (KnownComponent c, SingI v) =>
+    (SingI c, SingI v) =>
     Remote x ->
     FederatorClient c ('Just v) a ->
     FederatorAccess m a
   RunFederatedEither ::
-    (KnownComponent c, SingI v) =>
+    (SingI c, SingI v) =>
     Remote x ->
     FederatorClient c ('Just v) a ->
     FederatorAccess m (Either FederationError a)
   RunFederatedConcurrently ::
-    (KnownComponent c, SingI v, Foldable f, Functor f) =>
+    (SingI c, SingI v, Foldable f, Functor f) =>
     f (Remote x) ->
     (Remote [x] -> FederatorClient c ('Just v) a) ->
     FederatorAccess m [Remote a]
   RunFederatedConcurrentlyEither ::
     forall (c :: Component) v f a m x.
-    (KnownComponent c, SingI v, Foldable f, Functor f) =>
+    (SingI c, SingI v, Foldable f, Functor f) =>
     f (Remote x) ->
     (Remote [x] -> FederatorClient c ('Just v) a) ->
     FederatorAccess m [Either (Remote [x], FederationError) (Remote a)]
@@ -62,7 +62,7 @@ data FederatorAccess m a where
 makeSem ''FederatorAccess
 
 runFederatedConcurrently_ ::
-  (KnownComponent c, SingI v, Foldable f, Functor f, Member FederatorAccess r) =>
+  (SingI c, SingI v, Foldable f, Functor f, Member FederatorAccess r) =>
   f (Remote a) ->
   (Remote [a] -> FederatorClient c ('Just v) ()) ->
   Sem r ()

--- a/services/galley/src/Galley/Effects/FederatorAccess.hs
+++ b/services/galley/src/Galley/Effects/FederatorAccess.hs
@@ -38,23 +38,23 @@ data FederatorAccess m a where
   RunFederated ::
     KnownComponent c =>
     Remote x ->
-    FederatorClient c a ->
+    FederatorClient c v a ->
     FederatorAccess m a
   RunFederatedEither ::
     KnownComponent c =>
     Remote x ->
-    FederatorClient c a ->
+    FederatorClient c v a ->
     FederatorAccess m (Either FederationError a)
   RunFederatedConcurrently ::
     (KnownComponent c, Foldable f, Functor f) =>
     f (Remote x) ->
-    (Remote [x] -> FederatorClient c a) ->
+    (Remote [x] -> FederatorClient c v a) ->
     FederatorAccess m [Remote a]
   RunFederatedConcurrentlyEither ::
-    forall (c :: Component) f a m x.
+    forall (c :: Component) v f a m x.
     (KnownComponent c, Foldable f, Functor f) =>
     f (Remote x) ->
-    (Remote [x] -> FederatorClient c a) ->
+    (Remote [x] -> FederatorClient c v a) ->
     FederatorAccess m [Either (Remote [x], FederationError) (Remote a)]
   IsFederationConfigured :: FederatorAccess m Bool
 
@@ -63,6 +63,6 @@ makeSem ''FederatorAccess
 runFederatedConcurrently_ ::
   (KnownComponent c, Foldable f, Functor f, Member FederatorAccess r) =>
   f (Remote a) ->
-  (Remote [a] -> FederatorClient c ()) ->
+  (Remote [a] -> FederatorClient c v ()) ->
   Sem r ()
 runFederatedConcurrently_ xs = void . runFederatedConcurrently xs

--- a/services/galley/src/Galley/Effects/FederatorAccess.hs
+++ b/services/galley/src/Galley/Effects/FederatorAccess.hs
@@ -28,42 +28,38 @@ module Galley.Effects.FederatorAccess
 where
 
 import Data.Qualified
-import Data.Singletons
 import Imports
 import Polysemy
 import Wire.API.Federation.Client
-import Wire.API.Federation.Component
 import Wire.API.Federation.Error
 
 data FederatorAccess m a where
   RunFederated ::
-    (SingI c, SingI v) =>
     Remote x ->
-    FederatorClient c ('Just v) a ->
+    FederatorClient a ->
     FederatorAccess m a
   RunFederatedEither ::
-    (SingI c, SingI v) =>
     Remote x ->
-    FederatorClient c ('Just v) a ->
+    FederatorClient a ->
     FederatorAccess m (Either FederationError a)
   RunFederatedConcurrently ::
-    (SingI c, SingI v, Foldable f, Functor f) =>
+    (Foldable f, Functor f) =>
     f (Remote x) ->
-    (Remote [x] -> FederatorClient c ('Just v) a) ->
+    (Remote [x] -> FederatorClient a) ->
     FederatorAccess m [Remote a]
   RunFederatedConcurrentlyEither ::
-    forall (c :: Component) v f a m x.
-    (SingI c, SingI v, Foldable f, Functor f) =>
+    forall f a m x.
+    (Foldable f, Functor f) =>
     f (Remote x) ->
-    (Remote [x] -> FederatorClient c ('Just v) a) ->
+    (Remote [x] -> FederatorClient a) ->
     FederatorAccess m [Either (Remote [x], FederationError) (Remote a)]
   IsFederationConfigured :: FederatorAccess m Bool
 
 makeSem ''FederatorAccess
 
 runFederatedConcurrently_ ::
-  (SingI c, SingI v, Foldable f, Functor f, Member FederatorAccess r) =>
+  (Foldable f, Functor f, Member FederatorAccess r) =>
   f (Remote a) ->
-  (Remote [a] -> FederatorClient c ('Just v) ()) ->
+  (Remote [a] -> FederatorClient ()) ->
   Sem r ()
 runFederatedConcurrently_ xs = void . runFederatedConcurrently xs

--- a/services/galley/src/Galley/Intra/Federator.hs
+++ b/services/galley/src/Galley/Intra/Federator.hs
@@ -51,7 +51,7 @@ interpretFederatorAccess = interpret $ \case
 runFederatedEither ::
   KnownComponent c =>
   Remote x ->
-  FederatorClient c a ->
+  FederatorClient c v a ->
   App (Either FederationError a)
 runFederatedEither (tDomain -> remoteDomain) rpc = do
   ownDomain <- view (options . optSettings . setFederationDomain)
@@ -70,7 +70,7 @@ runFederatedEither (tDomain -> remoteDomain) rpc = do
 runFederated ::
   KnownComponent c =>
   Remote x ->
-  FederatorClient c a ->
+  FederatorClient c v a ->
   App a
 runFederated dom rpc =
   runFederatedEither dom rpc
@@ -82,7 +82,7 @@ runFederatedConcurrently ::
     KnownComponent c
   ) =>
   f (Remote a) ->
-  (Remote [a] -> FederatorClient c b) ->
+  (Remote [a] -> FederatorClient c v b) ->
   App [Remote b]
 runFederatedConcurrently xs rpc =
   pooledForConcurrentlyN 8 (bucketRemote xs) $ \r ->
@@ -91,7 +91,7 @@ runFederatedConcurrently xs rpc =
 runFederatedConcurrentlyEither ::
   (Foldable f, Functor f, KnownComponent c) =>
   f (Remote a) ->
-  (Remote [a] -> FederatorClient c b) ->
+  (Remote [a] -> FederatorClient c v b) ->
   App [Either (Remote [a], FederationError) (Remote b)]
 runFederatedConcurrentlyEither xs rpc =
   pooledForConcurrentlyN 8 (bucketRemote xs) $ \r ->

--- a/services/galley/src/Galley/Intra/Federator.hs
+++ b/services/galley/src/Galley/Intra/Federator.hs
@@ -33,7 +33,6 @@ import Polysemy
 import Polysemy.Input
 import UnliftIO
 import Wire.API.Federation.Client
-import Wire.API.Federation.Component
 import Wire.API.Federation.Error
 
 interpretFederatorAccess ::
@@ -50,7 +49,7 @@ interpretFederatorAccess = interpret $ \case
   IsFederationConfigured -> embedApp $ isJust <$> view federator
 
 runFederatedEither ::
-  (KnownComponent c, SingI v) =>
+  (SingI c, SingI v) =>
   Remote x ->
   FederatorClient c ('Just v) a ->
   App (Either FederationError a)
@@ -69,7 +68,7 @@ runFederatedEither (tDomain -> remoteDomain) rpc = do
       liftIO . fmap (first FederationCallFailure) $ runFederatorClient ce rpc
 
 runFederated ::
-  (KnownComponent c, SingI v) =>
+  (SingI c, SingI v) =>
   Remote x ->
   FederatorClient c ('Just v) a ->
   App a
@@ -80,7 +79,7 @@ runFederated dom rpc =
 runFederatedConcurrently ::
   ( Foldable f,
     Functor f,
-    KnownComponent c,
+    SingI c,
     SingI v
   ) =>
   f (Remote a) ->
@@ -91,7 +90,7 @@ runFederatedConcurrently xs rpc =
     qualifyAs r <$> runFederated r (rpc r)
 
 runFederatedConcurrentlyEither ::
-  (Foldable f, Functor f, KnownComponent c, SingI v) =>
+  (Foldable f, Functor f, SingI c, SingI v) =>
   f (Remote a) ->
   (Remote [a] -> FederatorClient c ('Just v) b) ->
   App [Either (Remote [a], FederationError) (Remote b)]

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2416,7 +2416,7 @@ testAddRemoteMemberInvalidDomain = do
   postQualifiedMembers alice (remoteBob :| []) convId
     !!! do
       const 422 === statusCode
-      const (Just "/federation/on-conversation-updated")
+      const (Just "/federation/api-versions")
         === preview (ix "data" . ix "path") . responseJsonUnsafe @Value
       const (Just "invalid.example.com")
         === preview (ix "data" . ix "domain") . responseJsonUnsafe @Value

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -128,8 +128,8 @@ instance MonadHttp TestM where
     liftIO $ withResponse req manager handler
 
 runFedClient ::
-  forall (name :: Symbol) comp m api.
-  ( HasFedEndpoint comp api name,
+  forall (name :: Symbol) (v :: Version) comp m api.
+  ( HasFedEndpoint comp v api name,
     Servant.HasClient Servant.ClientM api,
     MonadIO m
   ) =>


### PR DESCRIPTION
This is the first step towards implementing the API versioning scheme outlined in https://github.com/wireapp/wire-server/blob/develop/docs/developer/api-versioning.md for the federation API.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
