### PR TITLE
bump nixpkgs for hls 1.4.0.0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8e1891d5b8d0b898db8890ddab73141f0cd3c2bc",
-        "sha256": "0a767mn0nfp4qnklsvs6bnc0vng4nc3ch566nmrz18ypk67z4zz0",
+        "rev": "cc61d6cca06aaa46ccde79a92cd94dbb27c634a7",
+        "sha256": "0qi05m6vk9zqqs9573w2rhwm5k7jga70sjzq370npcipayrifw99",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/8e1891d5b8d0b898db8890ddab73141f0cd3c2bc.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc61d6cca06aaa46ccde79a92cd94dbb27c634a7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This PR bumps nixpkgs to a commit that includes Haskell Language Server 1.4.0.0

In its current state `wire-message-proto-lens` fails to build with error
```
$ cabal build wire-message-proto-lens
...
/nix/store/hp8wcylqr14hrrpqap4wdrwzq092wfln-glibc-2.32-37/lib/libc.so.6: version `GLIBC_2.33' not found (required by /nix/store/lw2br602v3sijay0z5xqvkkgpnmbbl4s-wire-server-compile-deps/lib/libncursesw.so.6)
```

This is due to the fact that `cabal` is wrapped (see `cabal-wrapper` in `dev-packages.nix`) which sets env vars `LD_LIBRARY_PATH`. When this wrapper calls `protoc` during building the `protoc` inherits these env vars which causes this error. If you build wire-message-proto-lens with the unwrapped cabal binary
```
/nix/store/23w1rh354pidr4pwa190k0n7j6hk1xqx-cabal-install-3.6.2.0/bin/cabal cabal build wire-message-proto-lens
```
this succeeds.
One solution to fix this issue could be to wrap `protoc` itself which clears the env vars before running.

## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
