### PR TITLE
cabal-run-integration.sh - remove Makefile indirection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ endif
 
 # ci here doesn't refer to continuous integration, but to cabal-integration
 # Usage: make ci package=brig test=1
+# Makefile has weird escaping rules: if you struggle to pass pattern correctly,
+# just call the script directly
 .PHONY: ci
 ci: c
 	./hack/bin/cabal-run-integration.sh $(package) $(pattern)

--- a/changelog.d/5-internal/cabal-integration-test-improvement
+++ b/changelog.d/5-internal/cabal-integration-test-improvement
@@ -1,0 +1,1 @@
+cabal-run-integration.sh - remove Makefile indirection


### PR DESCRIPTION
This PR improves `cabal-run-integration.sh`:

1. calls `integration.sh` directly instead of calling the Makefile of the service to-be-tested. This makes passing test pattern arguments such as ``-p '$2 == "provider" && $3 == "account"'`` feasable which was almost impossible with gnumake's escaping rules.
2. Allows passing any argument to the integration test binary, not just patterns

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
