### PR TITLE
cabal-run-integration.sh - test same services as "make i"

### DIFF
--- a/changelog.d/5-internal/cabal-integration-folowup
+++ b/changelog.d/5-internal/cabal-integration-folowup
@@ -1,0 +1,1 @@
+cabal-run-integration.sh - Test same services as "make i"

--- a/hack/bin/cabal-run-integration.sh
+++ b/hack/bin/cabal-run-integration.sh
@@ -47,12 +47,8 @@ run_integration_tests() {
 }
 
 run_all_integration_tests() {
-  for d in "$TOP_LEVEL/services/"*/; do
-    package=$(basename "$d")
-    service_dir="$TOP_LEVEL/services/$package"
-    if [ -d "$service_dir/test/integration" ] || [ -d "$service_dir/test-integration" ]; then
-      run_integration_tests "$package"
-    fi
+  for package in cargohold galley brig gundeck spar; do
+    run_integration_tests "$package"
   done
 }
 


### PR DESCRIPTION
This updates `cabal-run-integration.sh` to run the integeration tests for the *same* services as `make i` does.
The changes in https://github.com/wireapp/wire-server/pull/2044 also run the integration tests for `cannon`, which is not run by `make i`.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect.    - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
