### PR TITLE
Update team-settings version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/team-settings-upgrade
+++ b/changelog.d/0-release-notes/team-settings-upgrade
@@ -1,0 +1,1 @@
+Upgrade team-settings version to 4.4.0-v0.28.29-0-bafe932

--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/team-settings
-  tag: "4.3.0-v0.28.28-a2f11cf"
+  tag: "4.4.0-v0.28.29-0-bafe932"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `4.4.0-v0.28.29-0-bafe932`
Release: [`v4.4.0`](https://github.com/wireapp/wire-team-settings/releases/tag/v4.4.0)