### PR TITLE
nix/pkgs: fix zauth build

### DIFF
--- a/dev-packages.nix
+++ b/dev-packages.nix
@@ -141,6 +141,7 @@ let
       pkgs.libsodium.dev
       pkgs.libxml2.dev
       pkgs.ncurses.dev
+      pkgs.niv.out
       pkgs.openssl.dev
       pkgs.pcre.dev
       pkgs.snappy.dev
@@ -166,7 +167,7 @@ in
   pkgs.cfssl
   pkgs.docker-compose
   pkgs.gnumake
-  (pkgs.haskell-language-server.override {supportedGhcVersions = ["8107"];})
+  (pkgs.haskell-language-server.override { supportedGhcVersions = [ "8107" ]; })
   pkgs.jq
   pkgs.ormolu
   pkgs.telepresence

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,11 +4,11 @@ let
     config.allowUnfree = true;
     overlays = [
       # the tool we use for versioning (The thing that generates sources.json)
-      (_: _: { niv = (import sources.niv {}).niv; })
+      (_: _: { niv = (import sources.niv { }).niv; })
       # All wire-server specific packages
-      (import ./overlays/wire-server.nix)
+      (import ./overlay.nix)
 
     ];
   };
 in
-  pkgs
+pkgs

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,10 +1,10 @@
 self: super: {
-  cryptobox = self.callPackage ../pkgs/cryptobox { };
-  zauth = self.callPackage ../pkgs/zauth { };
+  cryptobox = self.callPackage ./pkgs/cryptobox { };
+  zauth = self.callPackage ./pkgs/zauth { };
 
   nginxModules = super.nginxModules // {
     zauth = {
-      src = ../../services/nginz/third_party/nginx-zauth-module;
+      src = ../services/nginz/third_party/nginx-zauth-module;
       inputs = [ self.pkg-config self.zauth ];
     };
   };

--- a/nix/overlays/wire-server.nix
+++ b/nix/overlays/wire-server.nix
@@ -1,60 +1,6 @@
 self: super: {
-  # TODO: Do not use buildRustPackage. Ces't horrible
-  cryptobox = self.callPackage (
-    { fetchFromGitHub, rustPlatform, pkgconfig, libsodium }:
-      rustPlatform.buildRustPackage rec {
-        name = "cryptobox-c-${version}";
-        version = "2019-06-17";
-        nativeBuildInputs = [ pkgconfig ];
-        buildInputs = [ libsodium ];
-        src = fetchFromGitHub {
-          owner = "wireapp";
-          repo = "cryptobox-c";
-          rev = "4067ad96b125942545dbdec8c1a89f1e1b65d013";
-          sha256 = "1i9dlhw0xk1viglyhail9fb36v1awrypps8jmhrkz8k1bhx98ci3";
-        };
-        cargoSha256 = "sha256-Afr3ShCXDCwTQNdeCZbA5/aosRt+KFpGfT1mrob6cog=";
-
-        patchLibs = super.lib.optionalString super.stdenv.isDarwin ''
-            install_name_tool -id $out/lib/libcryptobox.dylib $out/lib/libcryptobox.dylib
-          '';
-      
-        postInstall = ''
-          ${patchLibs}
-          mkdir -p $out/include
-          cp src/cbox.h $out/include
-        '';
-      }
-  ) {};
-
-  zauth = self.callPackage (
-    { fetchFromGitHub, rustPlatform, pkgconfig, libsodium }:
-      rustPlatform.buildRustPackage rec {
-        name = "libzauth-${version}";
-        version = "3.0.0";
-        nativeBuildInputs = [ pkgconfig ];
-        buildInputs = [ libsodium ];
-        src = self.nix-gitignore.gitignoreSourcePure [ ../../.gitignore ] ../../libs/libzauth;
-        sourceRoot = "libzauth/libzauth-c";
-
-        cargoSha256 = "sha256-umwOVCFHtszu64aIc8eqMPGCS7vt1nYQFAQh2XuV+v4="; # self.lib.fakeSha256;
-
-        patchLibs = super.lib.optionalString super.stdenv.isDarwin ''
-            install_name_tool -id $out/lib/libzauth.dylib $out/lib/libzauth.dylib
-          '';
-      
-        postInstall = ''
-          mkdir -p $out/lib/pkgconfig
-          mkdir -p $out/include
-          cp src/zauth.h $out/include
-          sed -e "s~<<VERSION>>~${version}~" \
-            -e "s~<<PREFIX>>~$out~" \
-            src/libzauth.pc > $out/lib/pkgconfig/libzauth.pc
-          cp target/release-tmp/libzauth.* $out/lib/
-          ${patchLibs}
-        '';
-      }
-  ) {};
+  cryptobox = self.callPackage ../pkgs/cryptobox { };
+  zauth = self.callPackage ../pkgs/zauth { };
 
   nginxModules = super.nginxModules // {
     zauth = {

--- a/nix/pkgs/cryptobox/default.nix
+++ b/nix/pkgs/cryptobox/default.nix
@@ -1,0 +1,31 @@
+{ fetchFromGitHub
+, lib
+, libsodium
+, pkg-config
+, rustPlatform
+, stdenv
+}:
+
+rustPlatform.buildRustPackage rec {
+  name = "cryptobox-c-${version}";
+  version = "2019-06-17";
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libsodium ];
+  src = fetchFromGitHub {
+    owner = "wireapp";
+    repo = "cryptobox-c";
+    rev = "4067ad96b125942545dbdec8c1a89f1e1b65d013";
+    sha256 = "1i9dlhw0xk1viglyhail9fb36v1awrypps8jmhrkz8k1bhx98ci3";
+  };
+  cargoSha256 = "sha256-Afr3ShCXDCwTQNdeCZbA5/aosRt+KFpGfT1mrob6cog=";
+
+  patchLibs = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -id $out/lib/libcryptobox.dylib $out/lib/libcryptobox.dylib
+  '';
+
+  postInstall = ''
+    ${patchLibs}
+    mkdir -p $out/include
+    cp src/cbox.h $out/include
+  '';
+}

--- a/nix/pkgs/zauth/default.nix
+++ b/nix/pkgs/zauth/default.nix
@@ -1,0 +1,34 @@
+{ fetchFromGitHub
+, lib
+, libsodium
+, nix-gitignore
+, pkg-config
+, rustPlatform
+, stdenv
+}:
+
+rustPlatform.buildRustPackage rec {
+  name = "libzauth-${version}";
+  version = "3.0.0";
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libsodium ];
+  src = nix-gitignore.gitignoreSourcePure [ ../../../.gitignore ] ../../../libs/libzauth;
+  sourceRoot = "libzauth/libzauth-c";
+
+  cargoSha256 = "10ijvi3rnnqpy589hhhp8s4p7xfpsbb1c3mzqnf65ra96q4nd6bf"; # self.lib.fakeSha256;
+
+  patchLibs = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -id $out/lib/libzauth.dylib $out/lib/libzauth.dylib
+  '';
+
+  postInstall = ''
+    mkdir -p $out/lib/pkgconfig
+    mkdir -p $out/include
+    cp src/zauth.h $out/include
+    sed -e "s~<<VERSION>>~${version}~" \
+      -e "s~<<PREFIX>>~$out~" \
+      src/libzauth.pc > $out/lib/pkgconfig/libzauth.pc
+    cp target/release-tmp/libzauth.* $out/lib/
+    ${patchLibs}
+  '';
+}

--- a/nix/pkgs/zauth/default.nix
+++ b/nix/pkgs/zauth/default.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
   src = nix-gitignore.gitignoreSourcePure [ ../../../.gitignore ] ../../../libs/libzauth;
   sourceRoot = "libzauth/libzauth-c";
 
-  cargoSha256 = "10ijvi3rnnqpy589hhhp8s4p7xfpsbb1c3mzqnf65ra96q4nd6bf"; # self.lib.fakeSha256;
+  cargoSha256 = "umwOVCFHtszu64aIc8eqMPGCS7vt1nYQFAQh2XuV+v4="; # self.lib.fakeSha256;
 
   patchLibs = lib.optionalString stdenv.isDarwin ''
     install_name_tool -id $out/lib/libzauth.dylib $out/lib/libzauth.dylib


### PR DESCRIPTION
This fixes the cargoSha256 of zauth. It also moves cryptobox and zauth into their own files, to match nixpkgs style more, and adds `niv` to the dev environment.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
