### PR TITLE
More logs in gundeck - Make sure `Debug` log level may be used in production

### DIFF
--- a/changelog.d/5-internal/gundeck-debug-logs
+++ b/changelog.d/5-internal/gundeck-debug-logs
@@ -1,0 +1,4 @@
+To investigate issues related to push notifications, adjust Gundeck `Debug`
+leveled logs to not print the message itself. So, that it can safely be turned
+on in production environments. Add a log entry when a bulk notification is 
+pushed to Cannon.

--- a/services/gundeck/src/Gundeck/Push/Native.hs
+++ b/services/gundeck/src/Gundeck/Push/Native.hs
@@ -24,7 +24,6 @@ where
 
 import Control.Lens (view, (.~), (^.))
 import Control.Monad.Catch
-import Data.Aeson (encode)
 import Data.ByteString.Conversion.To
 import Data.Id
 import Data.List1
@@ -125,8 +124,6 @@ publish m a = flip catches pushException $ do
       ~~ field "arn" (toText (a ^. addrEndpoint))
       ~~ field "notificationId" (toText (npNotificationid m))
       ~~ field "prio" (show (npPriority m))
-      ~~ field "apsData" (encode (npApsData m))
-      ~~ field "payload" (show txt)
       ~~ Log.msg (val "Native push")
   case txt of
     Left f -> return $! Failure f a

--- a/services/gundeck/src/Gundeck/Push/Websocket.hs
+++ b/services/gundeck/src/Gundeck/Push/Websocket.hs
@@ -151,7 +151,8 @@ bulkSend ::
     MonadMask m,
     HasRequestId m,
     MonadHttp m,
-    MonadUnliftIO m
+    MonadUnliftIO m,
+    Log.MonadLogger m
   ) =>
   URI ->
   BulkPushRequest ->
@@ -166,12 +167,21 @@ bulkSend' ::
     MonadMask m,
     HasRequestId m,
     MonadHttp m,
-    MonadUnliftIO m
+    MonadUnliftIO m,
+    Log.MonadLogger m
   ) =>
   URI ->
   BulkPushRequest ->
   m BulkPushResponse
-bulkSend' uri (encode -> jsbody) = do
+bulkSend' uri bulkPushRequest = do
+  forM_ (fromBulkPushRequest bulkPushRequest) $ \(notification, targets) ->
+    Log.debug $
+      Log.msg ("Bulk sending notification to Cannon." :: Text)
+        . Log.field "ntf_id" (show (ntfId notification))
+        . Log.field "user_ids" (show (map ptUserId targets))
+        . Log.field "conn_ids" (show (map ptConnId targets))
+
+  let jsbody = encode bulkPushRequest
   req <-
     ( check
         . method POST
@@ -388,5 +398,5 @@ send n pp =
 
 logPresence :: Presence -> Log.Msg -> Log.Msg
 logPresence p =
-  Log.field "user" (toByteString (userId p))
-    ~~ Log.field "zconn" (toByteString (connId p))
+  Log.field "user_id" (toByteString (userId p))
+    ~~ Log.field "conn_id" (toByteString (connId p))


### PR DESCRIPTION
As described in https://wearezeta.atlassian.net/browse/SQPIT-834, there is an on-prem environment where we do not understand how notifications are lost or delayed.
To shed some light on this, this PR should accomplish two things:

- Ensure that all notification pushes (web and native) are logged.
- Ensure that no private / secret data is logged on level `Debug`.

With these in place, we can turn on the higher log level (`Debug`) when needed to investigate the issue further.

## Checklist

 - [X] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
