### PR TITLE
Fix broken build process for package "old-time"

### DIFF
--- a/changelog.d/5-internal/ghc-8107-fix-old-time
+++ b/changelog.d/5-internal/ghc-8107-fix-old-time
@@ -1,0 +1,1 @@
+Fix broken build process of package "old-time" for some environments

--- a/dev-packages.nix
+++ b/dev-packages.nix
@@ -159,6 +159,7 @@ let
     export LIBRARY_PATH="${compile-deps}/lib"
     export PKG_CONFIG_PATH="${compile-deps}/lib/pkgconfig"
     export PATH="${compile-deps}/bin"
+    export CONFIG_SHELL="${compile-deps}/bin/sh"
     exec "${pkgs.cabal-install}/bin/cabal" "$@"
   '';
 in


### PR DESCRIPTION
This PR fixes the following bug:

Building the haskell package `old-time` with the wrapped cabal (see `dev-packages.nix`) may fail dynamic library failures for `/bin/sh` such as
```
/bin/sh: /nix/store/1yvpgm763b3hvg8q4fzpzmflr5674x4j-glibc-2.32-10/lib/libc.so.6: version `GLIBC_2.33' not foun
```
This can happen if `/bin/sh` expects a different glibc than the wrapped cabal provides via `LD_LIBRARY_PATH`.
This bug is fixed by setting `CONFIG_SHELL` which will make the build script of `old-time` not use `/bin/sh` but a `sh` defined in `dev-packages.nix`.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.