### PR TITLE
Sqservices 1168 add lockstatus to feature configs

### DIFF
--- a/changelog.d/0-release-notes/pr-2059
+++ b/changelog.d/0-release-notes/pr-2059
@@ -1,1 +1,0 @@
-The optional file sharing team feature config now has a new required attribute: `lockStatus`. For more information refer to the `config-options` documentation. Prior to this change the file sharing team feature was not configurable for on-premise installations. It has now been added as an optional mapping to the `configmap.yaml` galley template.

--- a/changelog.d/0-release-notes/pr-2059
+++ b/changelog.d/0-release-notes/pr-2059
@@ -1,0 +1,1 @@
+The optional file sharing team feature config now has a new required attribute: `lockStatus`. For more information refer to the `config-options` documentation. Prior to this change the file sharing team feature was not configurable for on-premise installations. It has now been added as an optional mapping to the `configmap.yaml` galley template.

--- a/changelog.d/2-features/pr-2059
+++ b/changelog.d/2-features/pr-2059
@@ -1,0 +1,1 @@
+The file sharing team feature now has a server wide configurable lock status.

--- a/changelog.d/2-features/pr-2059
+++ b/changelog.d/2-features/pr-2059
@@ -1,1 +1,1 @@
-The file sharing team feature now has a server wide configurable lock status.
+The file sharing team feature now has a server wide configurable lock status. For more information please refer to [/docs/reference/config-options.md#file-sharing](https://github.com/wireapp/wire-server/blob/develop/docs/reference/config-options.md#file-sharing).

--- a/changelog.d/5-internal/pr-2059
+++ b/changelog.d/5-internal/pr-2059
@@ -1,0 +1,1 @@
+The file sharing team feature can be updated via the internal API (`PUT /i/teams/:tid/features/fileSharing/(un)?locked`).

--- a/changelog.d/5-internal/pr-2059
+++ b/changelog.d/5-internal/pr-2059
@@ -1,1 +1,1 @@
-The file sharing team feature can be updated via the internal API (`PUT /i/teams/:tid/features/fileSharing/(un)?locked`).
+The lock status of the file sharing team feature can be updated via the internal API (`PUT /i/teams/:tid/features/fileSharing/(un)?locked`).

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -64,5 +64,9 @@ data:
         teamSearchVisibility: {{ .settings.featureFlags.teamSearchVisibility }}
         classifiedDomains:
           {{- toYaml .settings.featureFlags.classifiedDomains | nindent 10 }}
+        {{- if .settings.featureFlags.fileSharing }}
+        fileSharing:
+          {{- toYaml .settings.featureFlags.fileSharing | nindent 10 }}
+        {{- end }}
       {{- end }}
   {{- end }}

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -34,6 +34,12 @@ config:
         status: disabled
         config:
           domains: []
+      # fileSharing setting is optional
+      # if not set the default feature status is enabled and the default lock status is unlocked
+      # fileSharing:
+      #   defaults:
+      #     status: enabled
+      #     lockStatus: unlocked          
   aws:
     region: "eu-west-1"
   proxy: {}

--- a/docs/reference/cassandra-schema.cql
+++ b/docs/reference/cassandra-schema.cql
@@ -421,6 +421,7 @@ CREATE TABLE galley_test.team_features (
     conference_calling int,
     digital_signatures int,
     file_sharing int,
+    file_sharing_lock_status int,
     guest_links_lock_status int,
     guest_links_status int,
     legalhold_status int,

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -143,9 +143,9 @@ The `conferenceCalling` section is optional in `featureFlags`. If it is omitted 
 
 See also: conference falling for personal accounts (below).
 
-### File Sharing
+### File Sharing (optional)
 
-File sharing is enabled by default. If you want to disable it for all teams, add this to your feature config settings:
+File sharing is enabled and unlocked by default. If you want to disable and/or lock it for all teams, add this to your feature config settings:
 
 ```yaml
 fileSharing:

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -143,18 +143,29 @@ The `conferenceCalling` section is optional in `featureFlags`. If it is omitted 
 
 See also: conference falling for personal accounts (below).
 
-### File Sharing (optional)
+### File Sharing
 
-File sharing is enabled and unlocked by default. If you want to disable and/or lock it for all teams, add this to your feature config settings:
+File sharing is enabled and unlocked by default. If you want a different configuration, use the following syntax:
 
 ```yaml
 fileSharing:
   defaults:
-    status: disabled
-    lockStatus: locked
+    status: disabled|enabled
+    lockStatus: locked|unlocked
 ```
 
-`lockStatus` (required) can be either `unlocked` (feature status can be updated via team management) or `locked` (feature status can not be updated).
+These are all the possible combinations of `status` and `lockStatus`:
+
+| `status`   | `lockStatus` |                                                   |
+| ---------- | ------------ | ------------------------------------------------- |
+| `enabled`  | `locked`     | Feature enabled, cannot be disabled by team admin |
+| `enabled`  | `unlocked`   | Feature enabled, can be disabled by team admin    |
+| `disabled` | `locked`     | Feature disabled, cannot be enabled by team admin |
+| `disabled` | `unlocked`   | Feature disabled, can be enabled by team admin    |
+
+The lock status for individual teams can be changed via the internal API (`PUT /i/teams/:tid/features/fileSharing/(un)?locked`).
+
+The feature status for individual teams can be changed via the public API (if the feature is unlocked).
 
 ### Federation Domain
 

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -145,13 +145,16 @@ See also: conference falling for personal accounts (below).
 
 ### File Sharing
 
-File sharing is enabled by default.  If you want to disable it for all teams, add this to your feature config settings:
+File sharing is enabled by default. If you want to disable it for all teams, add this to your feature config settings:
 
-```
+```yaml
 fileSharing:
   defaults:
-    status: enabled
+    status: disabled
+    lockStatus: locked
 ```
+
+`lockStatus` (required) can be either `unlocked` (feature status can be updated via team management) or `locked` (feature status can not be updated).
 
 ### Federation Domain
 
@@ -284,7 +287,7 @@ federator:
 
 Some features (as of the time of writing this: only
 `conferenceCalling`) allow to set defaults for personal accounts in
-brig.  Those are taken into account in galley's end-points `GET
+brig. Those are taken into account in galley's end-points `GET
 /feature-configs*`.
 
 To be specific:

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -214,7 +214,7 @@ data FeatureFlags = FeatureFlags
     _flagTeamSearchVisibility :: !FeatureTeamSearchVisibility,
     _flagAppLockDefaults :: !(Defaults (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureAppLock)),
     _flagClassifiedDomains :: !(TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureClassifiedDomains),
-    _flagFileSharing :: !(Defaults (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureFileSharing)),
+    _flagFileSharing :: !(Defaults (TeamFeatureStatus 'WithLockStatus 'TeamFeatureFileSharing)),
     _flagConferenceCalling :: !(Defaults (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureConferenceCalling)),
     _flagSelfDeletingMessages :: !(Defaults (TeamFeatureStatus 'WithLockStatus 'TeamFeatureSelfDeletingMessages)),
     _flagConversationGuestLinks :: !(Defaults (TeamFeatureStatus 'WithLockStatus 'TeamFeatureGuestLinks))
@@ -261,7 +261,7 @@ instance FromJSON FeatureFlags where
       <*> obj .: "teamSearchVisibility"
       <*> (fromMaybe (Defaults defaultAppLockStatus) <$> (obj .:? "appLock"))
       <*> (fromMaybe defaultClassifiedDomains <$> (obj .:? "classifiedDomains"))
-      <*> (fromMaybe (Defaults (TeamFeatureStatusNoConfig TeamFeatureEnabled)) <$> (obj .:? "fileSharing"))
+      <*> (fromMaybe (Defaults defaultTeamFeatureFileSharing) <$> (obj .:? "fileSharing"))
       <*> (fromMaybe (Defaults (TeamFeatureStatusNoConfig TeamFeatureEnabled)) <$> (obj .:? "conferenceCalling"))
       <*> (fromMaybe (Defaults defaultSelfDeletingMessagesStatus) <$> (obj .:? "selfDeletingMessages"))
       <*> (fromMaybe (Defaults defaultGuestLinksStatus) <$> (obj .:? "conversationGuestLinks"))

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -252,21 +252,6 @@ data FeatureTeamSearchVisibility
   | FeatureTeamSearchVisibilityDisabledByDefault
   deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
-data FeatureStatusWithOptionalLockStatus = FeatureStatusWithOptionalLockStatus TeamFeatureStatusValue (Maybe LockStatusValue)
-
-instance FromJSON FeatureStatusWithOptionalLockStatus where
-  parseJSON = withObject "FeatureStatusWithOptionalLockStatus" $ \obj ->
-    FeatureStatusWithOptionalLockStatus
-      <$> obj .: "status"
-      <*> obj .:? "lockStatus"
-
-fromFeatureStatusWithOptionalLockStatus :: TeamFeatureStatusNoConfigAndLockStatus -> Maybe (Defaults FeatureStatusWithOptionalLockStatus) -> TeamFeatureStatusNoConfigAndLockStatus
-fromFeatureStatusWithOptionalLockStatus (TeamFeatureStatusNoConfigAndLockStatus defStatus defLockStatus) =
-  \case
-    Just (Defaults (FeatureStatusWithOptionalLockStatus status (Just lockStatus))) -> TeamFeatureStatusNoConfigAndLockStatus status lockStatus
-    Just (Defaults (FeatureStatusWithOptionalLockStatus status Nothing)) -> TeamFeatureStatusNoConfigAndLockStatus status defLockStatus
-    Nothing -> TeamFeatureStatusNoConfigAndLockStatus defStatus defLockStatus
-
 -- NOTE: This is used only in the config and thus YAML... camelcase
 instance FromJSON FeatureFlags where
   parseJSON = withObject "FeatureFlags" $ \obj ->
@@ -276,7 +261,7 @@ instance FromJSON FeatureFlags where
       <*> obj .: "teamSearchVisibility"
       <*> (fromMaybe (Defaults defaultAppLockStatus) <$> (obj .:? "appLock"))
       <*> (fromMaybe defaultClassifiedDomains <$> (obj .:? "classifiedDomains"))
-      <*> (Defaults . fromFeatureStatusWithOptionalLockStatus defaultTeamFeatureFileSharing <$> (obj .:? "fileSharing"))
+      <*> (fromMaybe (Defaults defaultTeamFeatureFileSharing) <$> (obj .:? "fileSharing"))
       <*> (fromMaybe (Defaults (TeamFeatureStatusNoConfig TeamFeatureEnabled)) <$> (obj .:? "conferenceCalling"))
       <*> (fromMaybe (Defaults defaultSelfDeletingMessagesStatus) <$> (obj .:? "selfDeletingMessages"))
       <*> (fromMaybe (Defaults defaultGuestLinksStatus) <$> (obj .:? "conversationGuestLinks"))

--- a/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
+++ b/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
@@ -72,7 +72,7 @@ taggedEventDataSchema =
       TeamFeatureValidateSAMLEmails -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
       TeamFeatureDigitalSignatures -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
       TeamFeatureAppLock -> tag _EdFeatureApplockChanged (unnamed schema)
-      TeamFeatureFileSharing -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
+      TeamFeatureFileSharing -> tag _EdFeatureWithoutConfigAndLockStatusChanged (unnamed schema)
       TeamFeatureClassifiedDomains -> tag _EdFeatureClassifiedDomainsChanged (unnamed schema)
       TeamFeatureConferenceCalling -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
       TeamFeatureSelfDeletingMessages -> tag _EdFeatureSelfDeletingMessagesChanged (unnamed schema)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -725,7 +725,7 @@ type FeatureAPI =
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureDigitalSignatures
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureAppLock
-    :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureFileSharing
+    :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureFileSharing
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureClassifiedDomains
     :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureConferenceCalling
     :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureSelfDeletingMessages

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -440,7 +440,6 @@ instance ToSchema cfg => ToSchema (TeamFeatureStatusWithConfigAndLockStatus cfg)
 ----------------------------------------------------------------------
 -- TeamFeatureFileSharing
 
--- TODO(leif): check if these defaults are correct
 defaultTeamFeatureFileSharing :: TeamFeatureStatusNoConfigAndLockStatus
 defaultTeamFeatureFileSharing =
   TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Unlocked

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -41,6 +41,7 @@ module Wire.API.Team.Feature
     defaultClassifiedDomains,
     defaultSelfDeletingMessagesStatus,
     defaultGuestLinksStatus,
+    defaultTeamFeatureFileSharing,
 
     -- * Swagger
     typeTeamFeatureName,
@@ -310,7 +311,8 @@ type family TeamFeatureStatus (ps :: IncludeLockStatus) (a :: TeamFeatureName) :
   TeamFeatureStatus _ 'TeamFeatureValidateSAMLEmails = TeamFeatureStatusNoConfig
   TeamFeatureStatus _ 'TeamFeatureDigitalSignatures = TeamFeatureStatusNoConfig
   TeamFeatureStatus _ 'TeamFeatureAppLock = TeamFeatureStatusWithConfig TeamFeatureAppLockConfig
-  TeamFeatureStatus _ 'TeamFeatureFileSharing = TeamFeatureStatusNoConfig
+  TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureFileSharing = TeamFeatureStatusNoConfig
+  TeamFeatureStatus 'WithLockStatus 'TeamFeatureFileSharing = TeamFeatureStatusNoConfigAndLockStatus
   TeamFeatureStatus _ 'TeamFeatureClassifiedDomains = TeamFeatureStatusWithConfig TeamFeatureClassifiedDomainsConfig
   TeamFeatureStatus _ 'TeamFeatureConferenceCalling = TeamFeatureStatusNoConfig
   TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureSelfDeletingMessages = TeamFeatureStatusWithConfig TeamFeatureSelfDeletingMessagesConfig
@@ -434,6 +436,14 @@ instance ToSchema cfg => ToSchema (TeamFeatureStatusWithConfigAndLockStatus cfg)
         <$> tfwcapsStatus .= field "status" schema
         <*> tfwcapsConfig .= field "config" schema
         <*> tfwcapsLockStatus .= field "lockStatus" schema
+
+----------------------------------------------------------------------
+-- TeamFeatureFileSharing
+
+-- TODO(leif): check if these defaults are correct
+defaultTeamFeatureFileSharing :: TeamFeatureStatusNoConfigAndLockStatus
+defaultTeamFeatureFileSharing =
+  TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Unlocked
 
 ----------------------------------------------------------------------
 -- TeamFeatureClassifiedDomainsConfig

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/FeatureConfigEvent.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/FeatureConfigEvent.hs
@@ -22,7 +22,7 @@ import Wire.API.Event.FeatureConfig
 import Wire.API.Team.Feature
 
 testObject_FeatureConfigEvent_1 :: Event
-testObject_FeatureConfigEvent_1 = Event Update TeamFeatureFileSharing (EdFeatureWithoutConfigChanged (TeamFeatureStatusNoConfig TeamFeatureEnabled))
+testObject_FeatureConfigEvent_1 = Event Update TeamFeatureFileSharing (EdFeatureWithoutConfigAndLockStatusChanged (TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Unlocked))
 
 testObject_FeatureConfigEvent_2 :: Event
 testObject_FeatureConfigEvent_2 = Event Update TeamFeatureSSO (EdFeatureWithoutConfigChanged (TeamFeatureStatusNoConfig TeamFeatureDisabled))

--- a/libs/wire-api/test/golden/testObject_FeatureConfigEvent_1.json
+++ b/libs/wire-api/test/golden/testObject_FeatureConfigEvent_1.json
@@ -1,5 +1,6 @@
 {
     "data": {
+        "lockStatus": "unlocked",
         "status": "enabled"
     },
     "name": "fileSharing",

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -597,6 +597,7 @@ executable galley-schema
       V56_GuestLinksTeamFeatureStatus
       V57_GuestLinksLockStatus
       V58_ConversationAccessRoleV2
+      V59_FileSharingLockStatus
       Paths_galley
   hs-source-dirs:
       schema/src

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -60,7 +60,6 @@ settings:
     fileSharing:
       defaults:
         status: enabled
-        lockStatus: unlocked # TODO(leif): make optional
     conferenceCalling:
       defaults:
         status: enabled

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -60,6 +60,7 @@ settings:
     fileSharing:
       defaults:
         status: enabled
+        lockStatus: unlocked
     conferenceCalling:
       defaults:
         status: enabled

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -60,6 +60,7 @@ settings:
     fileSharing:
       defaults:
         status: enabled
+        lockStatus: unlocked # TODO(leif): make optional
     conferenceCalling:
       defaults:
         status: enabled

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -61,6 +61,7 @@ import qualified V55_SelfDeletingMessagesLockStatus
 import qualified V56_GuestLinksTeamFeatureStatus
 import qualified V57_GuestLinksLockStatus
 import qualified V58_ConversationAccessRoleV2
+import qualified V59_FileSharingLockStatus
 
 main :: IO ()
 main = do
@@ -107,7 +108,8 @@ main = do
       V55_SelfDeletingMessagesLockStatus.migration,
       V56_GuestLinksTeamFeatureStatus.migration,
       V57_GuestLinksLockStatus.migration,
-      V58_ConversationAccessRoleV2.migration
+      V58_ConversationAccessRoleV2.migration,
+      V59_FileSharingLockStatus.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Galley.Cassandra
       -- (see also docs/developer/cassandra-interaction.md)

--- a/services/galley/schema/src/V59_FileSharingLockStatus.hs
+++ b/services/galley/schema/src/V59_FileSharingLockStatus.hs
@@ -1,6 +1,6 @@
 -- This file is part of the Wire Server implementation.
 --
--- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+-- Copyright (C) 2020 Wire Swiss GmbH <opensource@wire.com>
 --
 -- This program is free software: you can redistribute it and/or modify it under
 -- the terms of the GNU Affero General Public License as published by the Free
@@ -15,9 +15,19 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Cassandra (schemaVersion) where
+module V59_FileSharingLockStatus
+  ( migration,
+  )
+where
 
+import Cassandra.Schema
 import Imports
+import Text.RawString.QQ
 
-schemaVersion :: Int32
-schemaVersion = 59
+migration :: Migration
+migration = Migration 59 "Add lock status for file sharing team feature" $ do
+  schema'
+    [r| ALTER TABLE team_features ADD (
+          file_sharing_lock_status int
+        )
+     |]

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -176,7 +176,7 @@ data InternalApi routes = InternalApi
         :- IFeatureStatusPut 'Public.TeamFeatureAppLock,
     iTeamFeatureStatusFileSharingGet ::
       routes
-        :- IFeatureStatusGet 'Public.WithoutLockStatus 'Public.TeamFeatureFileSharing,
+        :- IFeatureStatusGet 'Public.WithLockStatus 'Public.TeamFeatureFileSharing,
     iTeamFeatureStatusFileSharingPut ::
       routes
         :- IFeatureStatusPut 'Public.TeamFeatureFileSharing,
@@ -319,7 +319,7 @@ servantSitemap =
         iTeamFeatureStatusDigitalSignaturesDeprecatedPut = iPutTeamFeature @'Public.TeamFeatureDigitalSignatures Features.setDigitalSignaturesInternal,
         iTeamFeatureStatusAppLockGet = iGetTeamFeature @'Public.WithoutLockStatus @'Public.TeamFeatureAppLock Features.getAppLockInternal,
         iTeamFeatureStatusAppLockPut = iPutTeamFeature @'Public.TeamFeatureAppLock Features.setAppLockInternal,
-        iTeamFeatureStatusFileSharingGet = iGetTeamFeature @'Public.WithoutLockStatus @'Public.TeamFeatureFileSharing Features.getFileSharingInternal,
+        iTeamFeatureStatusFileSharingGet = iGetTeamFeature @'Public.WithLockStatus @'Public.TeamFeatureFileSharing Features.getFileSharingInternal,
         iTeamFeatureStatusFileSharingPut = iPutTeamFeature @'Public.TeamFeatureFileSharing Features.setFileSharingInternal,
         iTeamFeatureStatusClassifiedDomainsGet = iGetTeamFeature @'Public.WithoutLockStatus @'Public.TeamFeatureClassifiedDomains Features.getClassifiedDomainsInternal,
         iTeamFeatureStatusConferenceCallingPut = iPutTeamFeature @'Public.TeamFeatureConferenceCalling Features.setConferenceCallingInternal,

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -180,6 +180,9 @@ data InternalApi routes = InternalApi
     iTeamFeatureStatusFileSharingPut ::
       routes
         :- IFeatureStatusPut 'Public.TeamFeatureFileSharing,
+    iTeamFeatureLockStatusFileSharingPut ::
+      routes
+        :- IFeatureStatusLockStatusPut 'Public.TeamFeatureFileSharing,        
     iTeamFeatureStatusClassifiedDomainsGet ::
       routes
         :- IFeatureStatusGet 'Public.WithoutLockStatus 'Public.TeamFeatureClassifiedDomains,
@@ -321,6 +324,7 @@ servantSitemap =
         iTeamFeatureStatusAppLockPut = iPutTeamFeature @'Public.TeamFeatureAppLock Features.setAppLockInternal,
         iTeamFeatureStatusFileSharingGet = iGetTeamFeature @'Public.WithLockStatus @'Public.TeamFeatureFileSharing Features.getFileSharingInternal,
         iTeamFeatureStatusFileSharingPut = iPutTeamFeature @'Public.TeamFeatureFileSharing Features.setFileSharingInternal,
+        iTeamFeatureLockStatusFileSharingPut = Features.setLockStatus @'Public.TeamFeatureFileSharing,
         iTeamFeatureStatusClassifiedDomainsGet = iGetTeamFeature @'Public.WithoutLockStatus @'Public.TeamFeatureClassifiedDomains Features.getClassifiedDomainsInternal,
         iTeamFeatureStatusConferenceCallingPut = iPutTeamFeature @'Public.TeamFeatureConferenceCalling Features.setConferenceCallingInternal,
         iTeamFeatureStatusConferenceCallingGet = iGetTeamFeature @'Public.WithoutLockStatus @'Public.TeamFeatureConferenceCalling Features.getConferenceCallingInternal,

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -182,7 +182,7 @@ data InternalApi routes = InternalApi
         :- IFeatureStatusPut 'Public.TeamFeatureFileSharing,
     iTeamFeatureLockStatusFileSharingPut ::
       routes
-        :- IFeatureStatusLockStatusPut 'Public.TeamFeatureFileSharing,        
+        :- IFeatureStatusLockStatusPut 'Public.TeamFeatureFileSharing,
     iTeamFeatureStatusClassifiedDomainsGet ::
       routes
         :- IFeatureStatusGet 'Public.WithoutLockStatus 'Public.TeamFeatureClassifiedDomains,

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -148,7 +148,7 @@ servantSitemap = conversations :<|> teamConversations :<|> messaging :<|> team :
               . DoAuth
           )
         :<|> Named @'("get", 'TeamFeatureFileSharing)
-          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureFileSharing
+          ( getFeatureStatus @'WithLockStatus @'TeamFeatureFileSharing
               getFileSharingInternal
               . DoAuth
           )
@@ -213,7 +213,7 @@ servantSitemap = conversations :<|> teamConversations :<|> messaging :<|> team :
               getAppLockInternal
           )
         :<|> Named @'("get-config", 'TeamFeatureFileSharing)
-          ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureFileSharing
+          ( getFeatureConfig @'WithLockStatus @'TeamFeatureFileSharing
               getFileSharingInternal
           )
         :<|> Named @'("get-config", 'TeamFeatureClassifiedDomains)

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -504,17 +504,23 @@ getFileSharingInternal = \case
   Right tid -> do
     cfgDefault <- getCfgDefault
     (mbFeatureStatus, fromMaybe (Public.tfwoapsLockStatus cfgDefault) -> lockStatus) <- TeamFeatures.getFeatureStatusNoConfigAndLockStatus @'Public.TeamFeatureFileSharing tid
-    -- TODO(leif): refactor
-    pure $ case (lockStatus, mbFeatureStatus) of
-      (Public.Unlocked, Just featureStatus) ->
-        Public.TeamFeatureStatusNoConfigAndLockStatus
-          (Public.tfwoStatus featureStatus)
-          lockStatus
-      (Public.Unlocked, Nothing) -> cfgDefault {Public.tfwoapsLockStatus = lockStatus}
-      (Public.Locked, _) -> cfgDefault {Public.tfwoapsLockStatus = lockStatus}
+    pure $ determineFeatureStatus cfgDefault lockStatus mbFeatureStatus
   where
     getCfgDefault :: Sem r (Public.TeamFeatureStatus 'Public.WithLockStatus 'Public.TeamFeatureFileSharing)
     getCfgDefault = input <&> view (optSettings . setFeatureFlags . flagFileSharing . unDefaults)
+
+determineFeatureStatus ::
+  Public.TeamFeatureStatusNoConfigAndLockStatus ->
+  Public.LockStatusValue ->
+  Maybe Public.TeamFeatureStatusNoConfig ->
+  Public.TeamFeatureStatusNoConfigAndLockStatus
+determineFeatureStatus cfgDefault lockStatus mbFeatureStatus = case (lockStatus, mbFeatureStatus) of
+  (Public.Unlocked, Just featureStatus) ->
+    Public.TeamFeatureStatusNoConfigAndLockStatus
+      (Public.tfwoStatus featureStatus)
+      lockStatus
+  (Public.Unlocked, Nothing) -> cfgDefault {Public.tfwoapsLockStatus = lockStatus}
+  (Public.Locked, _) -> cfgDefault {Public.tfwoapsLockStatus = lockStatus}
 
 getFeatureStatusWithDefaultConfig ::
   forall (a :: TeamFeatureName) r.
@@ -537,11 +543,31 @@ getFeatureStatusWithDefaultConfig lens' =
         <&> Public.tfwoStatus . view unDefaults
 
 setFileSharingInternal ::
-  Members '[GundeckAccess, TeamFeatureStore, TeamStore, P.TinyLog] r =>
+  forall r.
+  ( Member GundeckAccess r,
+    Member TeamFeatureStore r,
+    Member TeamStore r,
+    Member P.TinyLog r,
+    Member (Error TeamFeatureError) r,
+    Member (Input Opts) r
+  ) =>
   TeamId ->
   Public.TeamFeatureStatus 'Public.WithoutLockStatus 'Public.TeamFeatureFileSharing ->
   Sem r (Public.TeamFeatureStatus 'Public.WithoutLockStatus 'Public.TeamFeatureFileSharing)
-setFileSharingInternal = setFeatureStatusNoConfig @'Public.TeamFeatureFileSharing $ \_status _tid -> pure ()
+setFileSharingInternal tid status = do
+  getDftLockStatus >>= guardLockStatus @'Public.TeamFeatureFileSharing tid
+  let pushEvent =
+        pushFeatureConfigEvent tid $
+          Event.Event
+            Event.Update
+            Public.TeamFeatureFileSharing
+            ( EdFeatureWithoutConfigAndLockStatusChanged
+                (Public.TeamFeatureStatusNoConfigAndLockStatus (Public.tfwoStatus status) Public.Unlocked)
+            )
+  TeamFeatures.setFeatureStatusNoConfig @'Public.TeamFeatureFileSharing tid status <* pushEvent
+  where
+    getDftLockStatus :: Sem r Public.LockStatusValue
+    getDftLockStatus = input <&> view (optSettings . setFeatureFlags . flagFileSharing . unDefaults . to Public.tfwoapsLockStatus)
 
 getAppLockInternal ::
   Members '[Input Opts, TeamFeatureStore] r =>
@@ -653,13 +679,7 @@ getGuestLinkInternal = \case
   Right tid -> do
     cfgDefault <- getCfgDefault
     (mbFeatureStatus, fromMaybe (Public.tfwoapsLockStatus cfgDefault) -> lockStatus) <- TeamFeatures.getFeatureStatusNoConfigAndLockStatus @'Public.TeamFeatureGuestLinks tid
-    pure $ case (lockStatus, mbFeatureStatus) of
-      (Public.Unlocked, Just featureStatus) ->
-        Public.TeamFeatureStatusNoConfigAndLockStatus
-          (Public.tfwoStatus featureStatus)
-          lockStatus
-      (Public.Unlocked, Nothing) -> cfgDefault {Public.tfwoapsLockStatus = lockStatus}
-      (Public.Locked, _) -> cfgDefault {Public.tfwoapsLockStatus = lockStatus}
+    pure $ determineFeatureStatus cfgDefault lockStatus mbFeatureStatus
   where
     getCfgDefault :: Sem r (Public.TeamFeatureStatus 'Public.WithLockStatus 'Public.TeamFeatureGuestLinks)
     getCfgDefault = input <&> view (optSettings . setFeatureFlags . flagConversationGuestLinks . unDefaults)

--- a/services/galley/src/Galley/Data/TeamFeatures.hs
+++ b/services/galley/src/Galley/Data/TeamFeatures.hs
@@ -68,6 +68,9 @@ instance HasLockStatusCol 'TeamFeatureSelfDeletingMessages where
 instance HasLockStatusCol 'TeamFeatureGuestLinks where
   lockStatusCol = "guest_links_lock_status"
 
+instance HasLockStatusCol 'TeamFeatureFileSharing where
+  lockStatusCol = "file_sharing_lock_status"
+
 instance MaybeHasLockStatusCol 'TeamFeatureLegalHold where maybeLockStatusCol = Nothing
 
 instance MaybeHasLockStatusCol 'TeamFeatureSSO where maybeLockStatusCol = Nothing
@@ -79,7 +82,5 @@ instance MaybeHasLockStatusCol 'TeamFeatureValidateSAMLEmails where maybeLockSta
 instance MaybeHasLockStatusCol 'TeamFeatureDigitalSignatures where maybeLockStatusCol = Nothing
 
 instance MaybeHasLockStatusCol 'TeamFeatureAppLock where maybeLockStatusCol = Nothing
-
-instance MaybeHasLockStatusCol 'TeamFeatureFileSharing where maybeLockStatusCol = Nothing
 
 instance MaybeHasLockStatusCol 'TeamFeatureConferenceCalling where maybeLockStatusCol = Nothing

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -566,7 +566,7 @@ testAllFeatures = do
             .= Public.TeamFeatureStatusWithConfig
               TeamFeatureEnabled
               (Public.TeamFeatureAppLockConfig (Public.EnforceAppLock False) (60 :: Int32)),
-          toS TeamFeatureFileSharing .= Public.TeamFeatureStatusNoConfig TeamFeatureEnabled,
+          toS TeamFeatureFileSharing .= Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Public.Unlocked,
           toS TeamFeatureClassifiedDomains
             .= Public.TeamFeatureStatusWithConfig
               TeamFeatureEnabled

--- a/services/galley/test/integration/API/Util/TeamFeature.hs
+++ b/services/galley/test/integration/API/Util/TeamFeature.hs
@@ -179,20 +179,34 @@ putTeamFeatureFlagInternal ::
   TestM ResponseLBS
 putTeamFeatureFlagInternal reqmod tid status = do
   g <- view tsGalley
-  putTeamFeatureFlagInternalWithGalleyAndMod @a g reqmod tid status
+  putTeamFeatureFlagInternalWithGalleyAndMod @a @'Public.WithoutLockStatus g reqmod tid status
+
+putTeamFeatureFlagWithLockStatusInternal ::
+  forall (a :: Public.TeamFeatureName).
+  ( HasCallStack,
+    Public.KnownTeamFeatureName a,
+    ToJSON (Public.TeamFeatureStatus 'Public.WithLockStatus a)
+  ) =>
+  (Request -> Request) ->
+  TeamId ->
+  Public.TeamFeatureStatus 'Public.WithLockStatus a ->
+  TestM ResponseLBS
+putTeamFeatureFlagWithLockStatusInternal reqmod tid status = do
+  g <- view tsGalley
+  putTeamFeatureFlagInternalWithGalleyAndMod @a @'Public.WithLockStatus g reqmod tid status
 
 putTeamFeatureFlagInternalWithGalleyAndMod ::
-  forall (a :: Public.TeamFeatureName) m.
+  forall (a :: Public.TeamFeatureName) (s :: Public.IncludeLockStatus) m.
   ( MonadIO m,
     MonadHttp m,
     HasCallStack,
     Public.KnownTeamFeatureName a,
-    ToJSON (Public.TeamFeatureStatus 'Public.WithoutLockStatus a)
+    ToJSON (Public.TeamFeatureStatus s a)
   ) =>
   (Request -> Request) ->
   (Request -> Request) ->
   TeamId ->
-  Public.TeamFeatureStatus 'Public.WithoutLockStatus a ->
+  Public.TeamFeatureStatus s a ->
   m ResponseLBS
 putTeamFeatureFlagInternalWithGalleyAndMod galley reqmod tid status =
   put $

--- a/services/galley/test/integration/API/Util/TeamFeature.hs
+++ b/services/galley/test/integration/API/Util/TeamFeature.hs
@@ -179,34 +179,20 @@ putTeamFeatureFlagInternal ::
   TestM ResponseLBS
 putTeamFeatureFlagInternal reqmod tid status = do
   g <- view tsGalley
-  putTeamFeatureFlagInternalWithGalleyAndMod @a @'Public.WithoutLockStatus g reqmod tid status
-
-putTeamFeatureFlagWithLockStatusInternal ::
-  forall (a :: Public.TeamFeatureName).
-  ( HasCallStack,
-    Public.KnownTeamFeatureName a,
-    ToJSON (Public.TeamFeatureStatus 'Public.WithLockStatus a)
-  ) =>
-  (Request -> Request) ->
-  TeamId ->
-  Public.TeamFeatureStatus 'Public.WithLockStatus a ->
-  TestM ResponseLBS
-putTeamFeatureFlagWithLockStatusInternal reqmod tid status = do
-  g <- view tsGalley
-  putTeamFeatureFlagInternalWithGalleyAndMod @a @'Public.WithLockStatus g reqmod tid status
+  putTeamFeatureFlagInternalWithGalleyAndMod @a g reqmod tid status
 
 putTeamFeatureFlagInternalWithGalleyAndMod ::
-  forall (a :: Public.TeamFeatureName) (s :: Public.IncludeLockStatus) m.
+  forall (a :: Public.TeamFeatureName) m.
   ( MonadIO m,
     MonadHttp m,
     HasCallStack,
     Public.KnownTeamFeatureName a,
-    ToJSON (Public.TeamFeatureStatus s a)
+    ToJSON (Public.TeamFeatureStatus 'Public.WithoutLockStatus a)
   ) =>
   (Request -> Request) ->
   (Request -> Request) ->
   TeamId ->
-  Public.TeamFeatureStatus s a ->
+  Public.TeamFeatureStatus 'Public.WithoutLockStatus a ->
   m ResponseLBS
 putTeamFeatureFlagInternalWithGalleyAndMod galley reqmod tid status =
   put $


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1168

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
