### PR TITLE
Support zero-downtime migration between ES clusters

### DIFF
--- a/changelog.d/2-features/brig-two-es-clusters
+++ b/changelog.d/2-features/brig-two-es-clusters
@@ -1,0 +1,2 @@
+Allow brig's additionalWriteIndex to be on a different ElasticSearch cluster.
+This allows migrating to a new ElasticSearch cluster.

--- a/docs/reference/elastic-search.md
+++ b/docs/reference/elastic-search.md
@@ -117,7 +117,7 @@ deleted from the index. Attempts at reproducing this issue in a simpler
 environment have failed. As a workaround, there is a tool in
 [tools/db/find-undead](../../tools/db/find-undead) which can be used to find the
 undead users right after the migration. If they exist, please run refill the ES
-documents from cassandra as described [above](#refill-es-documents-from-cassandra**
+documents from cassandra as described [above](#refill-es-documents-from-cassandra)
 
 ## Migrate to a new cluster
 
@@ -135,9 +135,13 @@ ES_NEW_HOST=<YOUR_HOST>
 ES_NEW_PORT=<YOUR_PORT> # usually 9200
 ES_NEW_INDEX=<NEW_INDEX_NAME>
 WIRE_VERSION=<VERSION_YOU_ARE_DEPLOYING>
+
+# Use curl http://$ES_OLD_HOST:$ES_OLD_PORT/$ES_OLD_INDEX/_settings
+# to know previous values of SHARDS, REPLICAS and REFRESH_INTERVAL
 SHARDS=<NUMBER_OF_SHARDS_FOR_THE_NEW_INDEX>
 REPLICAS=<NUMBER_OF_REPLICAS_FOR_THE_INDEX>
 REFRESH_INTERVAL=<REFRESH_INTERVAL_IN_SECONDS>
+
 BRIG_CASSANDRA_HOST=<YOUR_C*_HOST>
 BRIG_CASSANDRA_PORT=<YOUR_C*_PORT>
 BRIG_CASSANDRA_KEYSPACE=<YOUR_C*_KEYSPACE>
@@ -154,7 +158,8 @@ BRIG_CASSANDRA_KEYSPACE=<YOUR_C*_KEYSPACE>
    ```
 1. Redeploy brig with `elasticsearch.additionalWriteIndexUrl` set to the URL of
    the new cluster and `elasticsearch.additionalWriteIndex` set to
-   `$ES_NEW_INDEX`. Make sure no old instances of brig are running.
+   `$ES_NEW_INDEX`.
+1. Make sure no old instances of brig are running.
 1. Reindex data to the new index
    ```bash
    docker run "quay.io/wire/brig-index:$WIRE_VERSION" migrate-data \

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -505,6 +505,7 @@ executable brig-integration
     , http-client
     , http-client-tls >=0.2
     , http-media
+    , http-reverse-proxy
     , http-types
     , imports
     , lens >=3.9

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -228,6 +228,7 @@ executables:
     - http-client
     - http-client-tls >=0.2
     - http-media
+    - http-reverse-proxy
     - http-types
     - imports
     - lens >=3.9

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -274,7 +274,8 @@ mkIndexEnv o lgr mgr mtr =
       lgr' = Log.clone (Just "index.brig") lgr
       mainIndex = ES.IndexName $ Opt.index (Opt.elasticsearch o)
       additionalIndex = ES.IndexName <$> Opt.additionalWriteIndex (Opt.elasticsearch o)
-   in IndexEnv mtr lgr' bhe Nothing mainIndex additionalIndex
+      additionalBhe = flip ES.mkBHEnv mgr . ES.Server <$> Opt.additionalWriteIndexUrl (Opt.elasticsearch o)
+   in IndexEnv mtr lgr' bhe Nothing mainIndex additionalIndex additionalBhe
 
 geoSetup :: Logger -> FS.WatchManager -> Maybe FilePath -> IO (Maybe (IORef GeoIp.GeoDB))
 geoSetup _ _ Nothing = return Nothing

--- a/services/brig/src/Brig/Index/Eval.hs
+++ b/services/brig/src/Brig/Index/Eval.hs
@@ -95,6 +95,7 @@ runCommand l = \case
         <*> pure Nothing
         <*> pure indexName
         <*> pure Nothing
+        <*> pure Nothing
     initES esURI =
       ES.mkBHEnv (toESServer esURI)
         <$> newManager defaultManagerSettings

--- a/services/brig/src/Brig/Index/Migrations/Types.hs
+++ b/services/brig/src/Brig/Index/Migrations/Types.hs
@@ -65,7 +65,7 @@ instance MonadIO m => MonadLogger (MigrationActionT m) where
 instance MonadIO m => Search.MonadIndexIO (MigrationActionT m) where
   liftIndexIO m = do
     Env {..} <- ask
-    let indexEnv = Search.IndexEnv metrics logger bhEnv Nothing searchIndex Nothing
+    let indexEnv = Search.IndexEnv metrics logger bhEnv Nothing searchIndex Nothing Nothing
     Search.runIndexIO indexEnv m
 
 instance MonadIO m => ES.MonadBH (MigrationActionT m) where

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -74,7 +74,12 @@ data ElasticSearchOpts = ElasticSearchOpts
     -- tools/db/find-undead which can be used to find the undead users right
     -- after the migration, if they exist, we can run the reindexing to get data
     -- in elasticsearch in a consistent state.
-    additionalWriteIndex :: !(Maybe Text)
+    additionalWriteIndex :: !(Maybe Text),
+    -- | An additional ES URL to write user data, useful while migrating to a
+    -- new instace of ES. It is necessary to provide 'additionalWriteIndex' for
+    -- this to be used. If this is 'Nothing' and 'additionalWriteIndex' is
+    -- configured, the 'url' field will be used.
+    additionalWriteIndexUrl :: !(Maybe Text)
   }
   deriving (Show, Generic)
 
@@ -717,7 +722,8 @@ Lens.makeLensesFor
 Lens.makeLensesFor
   [ ("url", "urlL"),
     ("index", "indexL"),
-    ("additionalWriteIndex", "additionalWriteIndexL")
+    ("additionalWriteIndex", "additionalWriteIndexL"),
+    ("additionalWriteIndexUrl", "additionalWriteIndexUrlL")
   ]
   ''ElasticSearchOpts
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/wiki/spaces/PS/pages/548798616/ElasticSearch+Migration+Proposal#3.-Zero-Downtime-Migration%3F

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.