### PR TITLE
Spar Polysemy: Rename ScimTokenStore.GetByTeam -> ScimTokenStore.LookupByTeam

### DIFF
--- a/changelog.d/5-internal/scimtokenstore-lookup
+++ b/changelog.d/5-internal/scimtokenstore-lookup
@@ -1,0 +1,1 @@
+Rename Spar.Sem.ScimTokenStore.GetByTeam to LookupByTeam

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -473,7 +473,7 @@ idpDelete zusr idpid (fromMaybe False -> purge) = withDebugLog "idpDelete" (cons
   -- Delete tokens associated with given IdP (we rely on the fact that
   -- each IdP has exactly one team so we can look up all tokens
   -- associated with the team and then filter them)
-  tokens <- ScimTokenStore.getByTeam team
+  tokens <- ScimTokenStore.lookupByTeam team
   for_ tokens $ \ScimTokenInfo {..} ->
     when (stiIdP == Just idpid) $ ScimTokenStore.delete team stiId
   -- Delete IdP config
@@ -565,7 +565,7 @@ assertNoScimOrNoIdP ::
   TeamId ->
   Sem r ()
 assertNoScimOrNoIdP teamid = do
-  numTokens <- length <$> ScimTokenStore.getByTeam teamid
+  numTokens <- length <$> ScimTokenStore.lookupByTeam teamid
   numIdps <- length <$> IdPEffect.getConfigsByTeam teamid
   when (numTokens > 0 && numIdps > 0) $ do
     throwSparSem $

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -294,7 +294,7 @@ autoprovisionSamlUserWithId mbteam buid suid = do
     guardScimTokens :: IdP -> Sem r ()
     guardScimTokens idp = do
       let teamid = idp ^. idpExtraInfo . wiTeam
-      scimtoks <- ScimTokenStore.getByTeam teamid
+      scimtoks <- ScimTokenStore.lookupByTeam teamid
       unless (null scimtoks) $ do
         throwSparSem SparSamlCredentialsNotFound
 

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -128,7 +128,7 @@ createScimToken zusr CreateScimToken {..} = do
   let descr = createScimTokenDescr
   teamid <- Intra.Brig.authorizeScimTokenManagement zusr
   BrigAccess.ensureReAuthorised zusr createScimTokenPassword
-  tokenNumber <- fmap length $ ScimTokenStore.getByTeam teamid
+  tokenNumber <- fmap length $ ScimTokenStore.lookupByTeam teamid
   maxTokens <- inputs maxScimTokens
   unless (tokenNumber < maxTokens) $
     throwSparSem E.SparProvisioningTokenLimitReached
@@ -190,4 +190,4 @@ listScimTokens ::
   Sem r ScimTokenList
 listScimTokens zusr = do
   teamid <- Intra.Brig.authorizeScimTokenManagement zusr
-  ScimTokenList <$> ScimTokenStore.getByTeam teamid
+  ScimTokenList <$> ScimTokenStore.lookupByTeam teamid

--- a/services/spar/src/Spar/Sem/ScimTokenStore.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore.hs
@@ -25,7 +25,7 @@ import Wire.API.User.Scim
 data ScimTokenStore m a where
   Insert :: ScimToken -> ScimTokenInfo -> ScimTokenStore m ()
   Lookup :: ScimToken -> ScimTokenStore m (Maybe ScimTokenInfo)
-  GetByTeam :: TeamId -> ScimTokenStore m [ScimTokenInfo]
+  LookupByTeam :: TeamId -> ScimTokenStore m [ScimTokenInfo]
   Delete :: TeamId -> ScimTokenId -> ScimTokenStore m ()
   DeleteByTeam :: TeamId -> ScimTokenStore m ()
 

--- a/services/spar/src/Spar/Sem/ScimTokenStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore/Cassandra.hs
@@ -45,7 +45,7 @@ scimTokenStoreToCassandra =
     embed @m . \case
       Insert st sti -> insertScimToken st sti
       Lookup st -> lookupScimToken st
-      GetByTeam tid -> getScimTokens tid
+      LookupByTeam tid -> getScimTokens tid
       Delete tid ur -> deleteScimToken tid ur
       DeleteByTeam tid -> deleteTeamScimTokens tid
 

--- a/services/spar/src/Spar/Sem/ScimTokenStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore/Mem.hs
@@ -33,6 +33,6 @@ scimTokenStoreToMem = (runState mempty .) $
   reinterpret $ \case
     Insert st sti -> modify $ M.insert st sti
     Lookup st -> gets $ M.lookup st
-    GetByTeam tid -> gets $ filter ((== tid) . stiTeam) . M.elems
+    LookupByTeam tid -> gets $ filter ((== tid) . stiTeam) . M.elems
     Delete tid stid -> modify $ M.filter $ \sti -> not $ stiTeam sti == tid && stiId sti == stid
     DeleteByTeam tid -> modify $ M.filter (not . (== tid) . stiTeam)

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -285,7 +285,7 @@ testDeleteTeam = it "cleans up all the right tables after deletion" $ do
     liftIO $ tokenInfo `shouldBe` Nothing
   -- The team from 'team_provisioning_by_team':
   do
-    tokens <- runSpar $ ScimTokenStore.getByTeam tid
+    tokens <- runSpar $ ScimTokenStore.lookupByTeam tid
     liftIO $ tokens `shouldBe` []
   -- The users from 'user':
   do


### PR DESCRIPTION
This PR changes the name of `Spar.Sem.ScimTokenStore.GetByTeam` to `LookupByTeam` --- a follow-up on a promise I made to @fisx to rename this in a later PR.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.