### PR TITLE
Spar Polysemy: Explicit export lists

### DIFF
--- a/changelog.d/5-internal/sem-exports
+++ b/changelog.d/5-internal/sem-exports
@@ -1,0 +1,1 @@
+Add explicit export lists to all Spar.Sem modules

--- a/services/spar/src/Spar/CanonicalInterpreter.hs
+++ b/services/spar/src/Spar/CanonicalInterpreter.hs
@@ -17,7 +17,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.CanonicalInterpreter where
+module Spar.CanonicalInterpreter (
+  CanonicalEffs,
+  runSparToIO,
+  runSparToHandler ) where
 
 import qualified Cassandra as Cas
 import Control.Monad.Except

--- a/services/spar/src/Spar/CanonicalInterpreter.hs
+++ b/services/spar/src/Spar/CanonicalInterpreter.hs
@@ -17,10 +17,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.CanonicalInterpreter (
-  CanonicalEffs,
-  runSparToIO,
-  runSparToHandler ) where
+module Spar.CanonicalInterpreter
+  ( CanonicalEffs,
+    runSparToIO,
+    runSparToHandler,
+  )
+where
 
 import qualified Cassandra as Cas
 import Control.Monad.Except

--- a/services/spar/src/Spar/Sem/AReqIDStore.hs
+++ b/services/spar/src/Spar/Sem/AReqIDStore.hs
@@ -15,11 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AReqIDStore (
-  AReqIDStore(..),
-  store,
-  unStore,
-  isAlive ) where
+module Spar.Sem.AReqIDStore
+  ( AReqIDStore (..),
+    store,
+    unStore,
+    isAlive,
+  )
+where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/AReqIDStore.hs
+++ b/services/spar/src/Spar/Sem/AReqIDStore.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AReqIDStore where
+module Spar.Sem.AReqIDStore (
+  AReqIDStore(..),
+  store,
+  unStore,
+  isAlive ) where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
@@ -15,12 +15,14 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AReqIDStore.Cassandra (
-  aReqIDStoreToCassandra,
-  ttlErrorToSparError,
-  storeAReqID,
-  unStoreAReqID,
-  isAliveAReqID ) where
+module Spar.Sem.AReqIDStore.Cassandra
+  ( aReqIDStoreToCassandra,
+    ttlErrorToSparError,
+    storeAReqID,
+    unStoreAReqID,
+    isAliveAReqID,
+  )
+where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
@@ -15,7 +15,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AReqIDStore.Cassandra where
+module Spar.Sem.AReqIDStore.Cassandra (
+  aReqIDStoreToCassandra,
+  ttlErrorToSparError,
+  storeAReqID,
+  unStoreAReqID,
+  isAliveAReqID ) where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
@@ -18,9 +18,6 @@
 module Spar.Sem.AReqIDStore.Cassandra
   ( aReqIDStoreToCassandra,
     ttlErrorToSparError,
-    storeAReqID,
-    unStoreAReqID,
-    isAliveAReqID,
   )
 where
 

--- a/services/spar/src/Spar/Sem/AReqIDStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/AReqIDStore/Mem.hs
@@ -17,8 +17,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AReqIDStore.Mem (
-  aReqIDStoreToMem ) where
+module Spar.Sem.AReqIDStore.Mem
+  ( aReqIDStoreToMem,
+  )
+where
 
 import qualified Data.Map as M
 import Imports

--- a/services/spar/src/Spar/Sem/AReqIDStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/AReqIDStore/Mem.hs
@@ -17,7 +17,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AReqIDStore.Mem where
+module Spar.Sem.AReqIDStore.Mem (
+  aReqIDStoreToMem ) where
 
 import qualified Data.Map as M
 import Imports

--- a/services/spar/src/Spar/Sem/AssIDStore.hs
+++ b/services/spar/src/Spar/Sem/AssIDStore.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AssIDStore where
+module Spar.Sem.AssIDStore (
+  AssIDStore(..),
+  store,
+  unStore,
+  isAlive ) where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/AssIDStore.hs
+++ b/services/spar/src/Spar/Sem/AssIDStore.hs
@@ -15,11 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AssIDStore (
-  AssIDStore(..),
-  store,
-  unStore,
-  isAlive ) where
+module Spar.Sem.AssIDStore
+  ( AssIDStore (..),
+    store,
+    unStore,
+    isAlive,
+  )
+where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/AssIDStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/AssIDStore/Cassandra.hs
@@ -15,11 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AssIDStore.Cassandra (
-  assIDStoreToCassandra,
-  storeAssID,
-  unStoreAssID,
-  isAliveAssID ) where
+module Spar.Sem.AssIDStore.Cassandra
+  ( assIDStoreToCassandra,
+    storeAssID,
+    unStoreAssID,
+    isAliveAssID,
+  )
+where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/AssIDStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/AssIDStore/Cassandra.hs
@@ -17,9 +17,6 @@
 
 module Spar.Sem.AssIDStore.Cassandra
   ( assIDStoreToCassandra,
-    storeAssID,
-    unStoreAssID,
-    isAliveAssID,
   )
 where
 

--- a/services/spar/src/Spar/Sem/AssIDStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/AssIDStore/Cassandra.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AssIDStore.Cassandra where
+module Spar.Sem.AssIDStore.Cassandra (
+  assIDStoreToCassandra,
+  storeAssID,
+  unStoreAssID,
+  isAliveAssID ) where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/AssIDStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/AssIDStore/Mem.hs
@@ -17,8 +17,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AssIDStore.Mem (
-  assIdStoreToMem ) where
+module Spar.Sem.AssIDStore.Mem
+  ( assIdStoreToMem,
+  )
+where
 
 import qualified Data.Map as M
 import Imports

--- a/services/spar/src/Spar/Sem/AssIDStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/AssIDStore/Mem.hs
@@ -17,7 +17,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.AssIDStore.Mem where
+module Spar.Sem.AssIDStore.Mem (
+  assIdStoreToMem ) where
 
 import qualified Data.Map as M
 import Imports

--- a/services/spar/src/Spar/Sem/BindCookieStore.hs
+++ b/services/spar/src/Spar/Sem/BindCookieStore.hs
@@ -15,10 +15,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.BindCookieStore (
-  BindCookieStore(..),
-  insert,
-  lookup ) where
+module Spar.Sem.BindCookieStore
+  ( BindCookieStore (..),
+    insert,
+    lookup,
+  )
+where
 
 import Data.Id (UserId)
 import Data.Time (NominalDiffTime)

--- a/services/spar/src/Spar/Sem/BindCookieStore.hs
+++ b/services/spar/src/Spar/Sem/BindCookieStore.hs
@@ -24,7 +24,7 @@ where
 
 import Data.Id (UserId)
 import Data.Time (NominalDiffTime)
-import Imports
+import Imports (Maybe)
 import Polysemy
 import Wire.API.Cookie
 

--- a/services/spar/src/Spar/Sem/BindCookieStore.hs
+++ b/services/spar/src/Spar/Sem/BindCookieStore.hs
@@ -15,7 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.BindCookieStore where
+module Spar.Sem.BindCookieStore (
+  BindCookieStore(..),
+  insert,
+  lookup ) where
 
 import Data.Id (UserId)
 import Data.Time (NominalDiffTime)

--- a/services/spar/src/Spar/Sem/BindCookieStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/BindCookieStore/Cassandra.hs
@@ -19,8 +19,6 @@
 
 module Spar.Sem.BindCookieStore.Cassandra
   ( bindCookieStoreToCassandra,
-    insertBindCookie,
-    lookupBindCookie,
   )
 where
 

--- a/services/spar/src/Spar/Sem/BindCookieStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/BindCookieStore/Cassandra.hs
@@ -17,10 +17,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.BindCookieStore.Cassandra (
-  bindCookieStoreToCassandra,
-  insertBindCookie,
-  lookupBindCookie ) where
+module Spar.Sem.BindCookieStore.Cassandra
+  ( bindCookieStoreToCassandra,
+    insertBindCookie,
+    lookupBindCookie,
+  )
+where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/BindCookieStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/BindCookieStore/Cassandra.hs
@@ -17,7 +17,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.BindCookieStore.Cassandra where
+module Spar.Sem.BindCookieStore.Cassandra (
+  bindCookieStoreToCassandra,
+  insertBindCookie,
+  lookupBindCookie ) where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/BindCookieStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/BindCookieStore/Mem.hs
@@ -15,7 +15,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.BindCookieStore.Mem where
+module Spar.Sem.BindCookieStore.Mem (
+  bindCookieStoreToMem ) where
 
 import Data.Id (UserId)
 import qualified Data.Map as M

--- a/services/spar/src/Spar/Sem/BindCookieStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/BindCookieStore/Mem.hs
@@ -15,8 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.BindCookieStore.Mem (
-  bindCookieStoreToMem ) where
+module Spar.Sem.BindCookieStore.Mem
+  ( bindCookieStoreToMem,
+  )
+where
 
 import Data.Id (UserId)
 import qualified Data.Map as M

--- a/services/spar/src/Spar/Sem/BrigAccess.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess.hs
@@ -15,27 +15,29 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.BrigAccess (
-  BrigAccess(..),
-  createSAML,
-  createNoSAML,
-  updateEmail,
-  getAccount,
-  getByHandle,
-  getByEmail,
-  setName,
-  setHandle,
-  setManagedBy,
-  setVeid,
-  setRichInfo,
-  getRichInfo,
-  checkHandleAvailable,
-  delete,
-  ensureReAuthorised,
-  ssoLogin,
-  getStatus,
-  getStatusMaybe,
-  setStatus ) where
+module Spar.Sem.BrigAccess
+  ( BrigAccess (..),
+    createSAML,
+    createNoSAML,
+    updateEmail,
+    getAccount,
+    getByHandle,
+    getByEmail,
+    setName,
+    setHandle,
+    setManagedBy,
+    setVeid,
+    setRichInfo,
+    getRichInfo,
+    checkHandleAvailable,
+    delete,
+    ensureReAuthorised,
+    ssoLogin,
+    getStatus,
+    getStatusMaybe,
+    setStatus,
+  )
+where
 
 import Brig.Types.Intra
 import Brig.Types.User

--- a/services/spar/src/Spar/Sem/BrigAccess.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess.hs
@@ -15,7 +15,27 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.BrigAccess where
+module Spar.Sem.BrigAccess (
+  BrigAccess(..),
+  createSAML,
+  createNoSAML,
+  updateEmail,
+  getAccount,
+  getByHandle,
+  getByEmail,
+  setName,
+  setHandle,
+  setManagedBy,
+  setVeid,
+  setRichInfo,
+  getRichInfo,
+  checkHandleAvailable,
+  delete,
+  ensureReAuthorised,
+  ssoLogin,
+  getStatus,
+  getStatusMaybe,
+  setStatus ) where
 
 import Brig.Types.Intra
 import Brig.Types.User

--- a/services/spar/src/Spar/Sem/BrigAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess/Http.hs
@@ -15,8 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.BrigAccess.Http (
-  brigAccessToHttp ) where
+module Spar.Sem.BrigAccess.Http
+  ( brigAccessToHttp,
+  )
+where
 
 import Bilge
 import Imports

--- a/services/spar/src/Spar/Sem/BrigAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess/Http.hs
@@ -15,7 +15,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.BrigAccess.Http where
+module Spar.Sem.BrigAccess.Http (
+  brigAccessToHttp ) where
 
 import Bilge
 import Imports

--- a/services/spar/src/Spar/Sem/DefaultSsoCode.hs
+++ b/services/spar/src/Spar/Sem/DefaultSsoCode.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.DefaultSsoCode where
+module Spar.Sem.DefaultSsoCode (
+  DefaultSsoCode(..),
+  get,
+  store,
+  delete ) where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/DefaultSsoCode.hs
+++ b/services/spar/src/Spar/Sem/DefaultSsoCode.hs
@@ -15,11 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.DefaultSsoCode (
-  DefaultSsoCode(..),
-  get,
-  store,
-  delete ) where
+module Spar.Sem.DefaultSsoCode
+  ( DefaultSsoCode (..),
+    get,
+    store,
+    delete,
+  )
+where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/DefaultSsoCode/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/DefaultSsoCode/Cassandra.hs
@@ -19,9 +19,6 @@
 
 module Spar.Sem.DefaultSsoCode.Cassandra
   ( defaultSsoCodeToCassandra,
-    getDefaultSsoCode,
-    storeDefaultSsoCode,
-    deleteDefaultSsoCode,
   )
 where
 

--- a/services/spar/src/Spar/Sem/DefaultSsoCode/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/DefaultSsoCode/Cassandra.hs
@@ -17,7 +17,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.DefaultSsoCode.Cassandra where
+module Spar.Sem.DefaultSsoCode.Cassandra (
+  defaultSsoCodeToCassandra,
+  getDefaultSsoCode,
+  storeDefaultSsoCode,
+  deleteDefaultSsoCode ) where
 
 import Cassandra
 import Imports

--- a/services/spar/src/Spar/Sem/DefaultSsoCode/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/DefaultSsoCode/Cassandra.hs
@@ -17,11 +17,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.DefaultSsoCode.Cassandra (
-  defaultSsoCodeToCassandra,
-  getDefaultSsoCode,
-  storeDefaultSsoCode,
-  deleteDefaultSsoCode ) where
+module Spar.Sem.DefaultSsoCode.Cassandra
+  ( defaultSsoCodeToCassandra,
+    getDefaultSsoCode,
+    storeDefaultSsoCode,
+    deleteDefaultSsoCode,
+  )
+where
 
 import Cassandra
 import Imports

--- a/services/spar/src/Spar/Sem/DefaultSsoCode/Mem.hs
+++ b/services/spar/src/Spar/Sem/DefaultSsoCode/Mem.hs
@@ -17,8 +17,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.DefaultSsoCode.Mem (
-  defaultSsoCodeToMem ) where
+module Spar.Sem.DefaultSsoCode.Mem
+  ( defaultSsoCodeToMem,
+  )
+where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/DefaultSsoCode/Mem.hs
+++ b/services/spar/src/Spar/Sem/DefaultSsoCode/Mem.hs
@@ -17,7 +17,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.DefaultSsoCode.Mem where
+module Spar.Sem.DefaultSsoCode.Mem (
+  defaultSsoCodeToMem ) where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/GalleyAccess.hs
+++ b/services/spar/src/Spar/Sem/GalleyAccess.hs
@@ -15,12 +15,14 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.GalleyAccess (
-  GalleyAccess(..),
-  getTeamMembers,
-  assertHasPermission,
-  assertSSOEnabled,
-  isEmailValidationEnabledTeam ) where
+module Spar.Sem.GalleyAccess
+  ( GalleyAccess (..),
+    getTeamMembers,
+    assertHasPermission,
+    assertSSOEnabled,
+    isEmailValidationEnabledTeam,
+  )
+where
 
 import Data.Id (TeamId, UserId)
 import Galley.Types.Teams (IsPerm, TeamMember)

--- a/services/spar/src/Spar/Sem/GalleyAccess.hs
+++ b/services/spar/src/Spar/Sem/GalleyAccess.hs
@@ -15,7 +15,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.GalleyAccess where
+module Spar.Sem.GalleyAccess (
+  GalleyAccess(..),
+  getTeamMembers,
+  assertHasPermission,
+  assertSSOEnabled,
+  isEmailValidationEnabledTeam ) where
 
 import Data.Id (TeamId, UserId)
 import Galley.Types.Teams (IsPerm, TeamMember)

--- a/services/spar/src/Spar/Sem/GalleyAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/GalleyAccess/Http.hs
@@ -17,12 +17,14 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.GalleyAccess.Http (
-  RunHttp(..),
-  RunHttpEnv(..),
-  semToRunHttp,
-  viaRunHttp,
-  galleyAccessToHttp ) where
+module Spar.Sem.GalleyAccess.Http
+  ( RunHttp (..),
+    RunHttpEnv (..),
+    semToRunHttp,
+    viaRunHttp,
+    galleyAccessToHttp,
+  )
+where
 
 import Bilge
 import Control.Monad.Except

--- a/services/spar/src/Spar/Sem/GalleyAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/GalleyAccess/Http.hs
@@ -18,9 +18,7 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Spar.Sem.GalleyAccess.Http
-  ( RunHttp (..),
-    RunHttpEnv (..),
-    semToRunHttp,
+  ( RunHttpEnv (..),
     viaRunHttp,
     galleyAccessToHttp,
   )

--- a/services/spar/src/Spar/Sem/GalleyAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/GalleyAccess/Http.hs
@@ -17,7 +17,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.GalleyAccess.Http where
+module Spar.Sem.GalleyAccess.Http (
+  RunHttp(..),
+  RunHttpEnv(..),
+  semToRunHttp,
+  viaRunHttp,
+  galleyAccessToHttp ) where
 
 import Bilge
 import Control.Monad.Except

--- a/services/spar/src/Spar/Sem/IdP.hs
+++ b/services/spar/src/Spar/Sem/IdP.hs
@@ -15,19 +15,21 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.IdP (
-  IdP(..),
-  Replacing(..),
-  Replaced(..),
-  GetIdPResult(..),
-  storeConfig,
-  getConfig,
-  getIdByIssuerWithoutTeam,
-  getIdByIssuerWithTeam,
-  getConfigsByTeam,
-  deleteConfig,
-  setReplacedBy,
-  clearReplacedBy ) where
+module Spar.Sem.IdP
+  ( IdP (..),
+    Replacing (..),
+    Replaced (..),
+    GetIdPResult (..),
+    storeConfig,
+    getConfig,
+    getIdByIssuerWithoutTeam,
+    getIdByIssuerWithTeam,
+    getConfigsByTeam,
+    deleteConfig,
+    setReplacedBy,
+    clearReplacedBy,
+  )
+where
 
 import Data.Id
 import Imports

--- a/services/spar/src/Spar/Sem/IdP.hs
+++ b/services/spar/src/Spar/Sem/IdP.hs
@@ -15,7 +15,19 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.IdP where
+module Spar.Sem.IdP (
+  IdP(..),
+  Replacing(..),
+  Replaced(..),
+  GetIdPResult(..),
+  storeConfig,
+  getConfig,
+  getIdByIssuerWithoutTeam,
+  getIdByIssuerWithTeam,
+  getConfigsByTeam,
+  deleteConfig,
+  setReplacedBy,
+  clearReplacedBy ) where
 
 import Data.Id
 import Imports

--- a/services/spar/src/Spar/Sem/IdP/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/IdP/Cassandra.hs
@@ -17,7 +17,17 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.IdP.Cassandra where
+module Spar.Sem.IdP.Cassandra (
+  IdPConfigRow,
+  idPToCassandra,
+  storeIdPConfig,
+  getIdPConfig,
+  getIdPIdByIssuerWithoutTeam,
+  getIdPIdByIssuerWithTeam,
+  getIdPConfigsByTeam,
+  deleteIdPConfig,
+  setReplacedBy,
+  clearReplacedBy ) where
 
 import Cassandra
 import Control.Lens ((^.))

--- a/services/spar/src/Spar/Sem/IdP/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/IdP/Cassandra.hs
@@ -17,17 +17,19 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.IdP.Cassandra (
-  IdPConfigRow,
-  idPToCassandra,
-  storeIdPConfig,
-  getIdPConfig,
-  getIdPIdByIssuerWithoutTeam,
-  getIdPIdByIssuerWithTeam,
-  getIdPConfigsByTeam,
-  deleteIdPConfig,
-  setReplacedBy,
-  clearReplacedBy ) where
+module Spar.Sem.IdP.Cassandra
+  ( IdPConfigRow,
+    idPToCassandra,
+    storeIdPConfig,
+    getIdPConfig,
+    getIdPIdByIssuerWithoutTeam,
+    getIdPIdByIssuerWithTeam,
+    getIdPConfigsByTeam,
+    deleteIdPConfig,
+    setReplacedBy,
+    clearReplacedBy,
+  )
+where
 
 import Cassandra
 import Control.Lens ((^.))

--- a/services/spar/src/Spar/Sem/IdP/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/IdP/Cassandra.hs
@@ -18,16 +18,7 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Spar.Sem.IdP.Cassandra
-  ( IdPConfigRow,
-    idPToCassandra,
-    storeIdPConfig,
-    getIdPConfig,
-    getIdPIdByIssuerWithoutTeam,
-    getIdPIdByIssuerWithTeam,
-    getIdPConfigsByTeam,
-    deleteIdPConfig,
-    setReplacedBy,
-    clearReplacedBy,
+  ( idPToCassandra,
   )
 where
 

--- a/services/spar/src/Spar/Sem/IdPRawMetadataStore.hs
+++ b/services/spar/src/Spar/Sem/IdPRawMetadataStore.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.IdPRawMetadataStore where
+module Spar.Sem.IdPRawMetadataStore (
+  IdPRawMetadataStore(..),
+  store,
+  get,
+  delete ) where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/IdPRawMetadataStore.hs
+++ b/services/spar/src/Spar/Sem/IdPRawMetadataStore.hs
@@ -15,11 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.IdPRawMetadataStore (
-  IdPRawMetadataStore(..),
-  store,
-  get,
-  delete ) where
+module Spar.Sem.IdPRawMetadataStore
+  ( IdPRawMetadataStore (..),
+    store,
+    get,
+    delete,
+  )
+where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/IdPRawMetadataStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/IdPRawMetadataStore/Cassandra.hs
@@ -17,9 +17,6 @@
 
 module Spar.Sem.IdPRawMetadataStore.Cassandra
   ( idpRawMetadataStoreToCassandra,
-    storeIdPRawMetadata,
-    getIdPRawMetadata,
-    deleteIdPRawMetadata,
   )
 where
 

--- a/services/spar/src/Spar/Sem/IdPRawMetadataStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/IdPRawMetadataStore/Cassandra.hs
@@ -15,11 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.IdPRawMetadataStore.Cassandra (
-  idpRawMetadataStoreToCassandra,
-  storeIdPRawMetadata,
-  getIdPRawMetadata,
-  deleteIdPRawMetadata ) where
+module Spar.Sem.IdPRawMetadataStore.Cassandra
+  ( idpRawMetadataStoreToCassandra,
+    storeIdPRawMetadata,
+    getIdPRawMetadata,
+    deleteIdPRawMetadata,
+  )
+where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/IdPRawMetadataStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/IdPRawMetadataStore/Cassandra.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.IdPRawMetadataStore.Cassandra where
+module Spar.Sem.IdPRawMetadataStore.Cassandra (
+  idpRawMetadataStoreToCassandra,
+  storeIdPRawMetadata,
+  getIdPRawMetadata,
+  deleteIdPRawMetadata ) where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/Now.hs
+++ b/services/spar/src/Spar/Sem/Now.hs
@@ -15,7 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Now where
+module Spar.Sem.Now (
+  Now(..),
+  get,
+  boolTTL ) where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/Now.hs
+++ b/services/spar/src/Spar/Sem/Now.hs
@@ -15,10 +15,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Now (
-  Now(..),
-  get,
-  boolTTL ) where
+module Spar.Sem.Now
+  ( Now (..),
+    get,
+    boolTTL,
+  )
+where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/Now/IO.hs
+++ b/services/spar/src/Spar/Sem/Now/IO.hs
@@ -15,7 +15,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Now.IO where
+module Spar.Sem.Now.IO (
+  nowToIO ) where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/Now/IO.hs
+++ b/services/spar/src/Spar/Sem/Now/IO.hs
@@ -15,8 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Now.IO (
-  nowToIO ) where
+module Spar.Sem.Now.IO
+  ( nowToIO,
+  )
+where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/Now/Input.hs
+++ b/services/spar/src/Spar/Sem/Now/Input.hs
@@ -15,8 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Now.Input (
-  nowToInput ) where
+module Spar.Sem.Now.Input
+  ( nowToInput,
+  )
+where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/Now/Input.hs
+++ b/services/spar/src/Spar/Sem/Now/Input.hs
@@ -15,7 +15,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Now.Input where
+module Spar.Sem.Now.Input (
+  nowToInput ) where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/Random.hs
+++ b/services/spar/src/Spar/Sem/Random.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Random where
+module Spar.Sem.Random (
+  Random(..),
+  bytes,
+  uuid,
+  scimTokenId ) where
 
 import Data.Id (ScimTokenId)
 import Data.UUID (UUID)

--- a/services/spar/src/Spar/Sem/Random.hs
+++ b/services/spar/src/Spar/Sem/Random.hs
@@ -15,11 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Random (
-  Random(..),
-  bytes,
-  uuid,
-  scimTokenId ) where
+module Spar.Sem.Random
+  ( Random (..),
+    bytes,
+    uuid,
+    scimTokenId,
+  )
+where
 
 import Data.Id (ScimTokenId)
 import Data.UUID (UUID)

--- a/services/spar/src/Spar/Sem/Random/IO.hs
+++ b/services/spar/src/Spar/Sem/Random/IO.hs
@@ -15,7 +15,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Random.IO where
+module Spar.Sem.Random.IO (
+  randomToIO ) where
 
 import Data.Id (randomId)
 import qualified Data.UUID.V4 as UUID

--- a/services/spar/src/Spar/Sem/Random/IO.hs
+++ b/services/spar/src/Spar/Sem/Random/IO.hs
@@ -15,8 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Random.IO (
-  randomToIO ) where
+module Spar.Sem.Random.IO
+  ( randomToIO,
+  )
+where
 
 import Data.Id (randomId)
 import qualified Data.UUID.V4 as UUID

--- a/services/spar/src/Spar/Sem/Reporter.hs
+++ b/services/spar/src/Spar/Sem/Reporter.hs
@@ -15,9 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Reporter (
-  Reporter(..),
-  report ) where
+module Spar.Sem.Reporter
+  ( Reporter (..),
+    report,
+  )
+where
 
 import Imports
 import qualified Network.Wai as Wai

--- a/services/spar/src/Spar/Sem/Reporter.hs
+++ b/services/spar/src/Spar/Sem/Reporter.hs
@@ -15,7 +15,9 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Reporter where
+module Spar.Sem.Reporter (
+  Reporter(..),
+  report ) where
 
 import Imports
 import qualified Network.Wai as Wai

--- a/services/spar/src/Spar/Sem/Reporter/Wai.hs
+++ b/services/spar/src/Spar/Sem/Reporter/Wai.hs
@@ -15,8 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Reporter.Wai (
-  reporterToTinyLogWai ) where
+module Spar.Sem.Reporter.Wai
+  ( reporterToTinyLogWai,
+  )
+where
 
 import Imports
 import qualified Network.Wai.Utilities.Server as Wai

--- a/services/spar/src/Spar/Sem/Reporter/Wai.hs
+++ b/services/spar/src/Spar/Sem/Reporter/Wai.hs
@@ -15,7 +15,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Reporter.Wai where
+module Spar.Sem.Reporter.Wai (
+  reporterToTinyLogWai ) where
 
 import Imports
 import qualified Network.Wai.Utilities.Server as Wai

--- a/services/spar/src/Spar/Sem/SAML2.hs
+++ b/services/spar/src/Spar/Sem/SAML2.hs
@@ -15,7 +15,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SAML2 where
+module Spar.Sem.SAML2 (
+  SAML2(..),
+  authReq,
+  authResp,
+  meta,
+  toggleCookie ) where
 
 import Data.Id (TeamId)
 import Data.String.Conversions (SBS, ST)

--- a/services/spar/src/Spar/Sem/SAML2.hs
+++ b/services/spar/src/Spar/Sem/SAML2.hs
@@ -15,12 +15,14 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SAML2 (
-  SAML2(..),
-  authReq,
-  authResp,
-  meta,
-  toggleCookie ) where
+module Spar.Sem.SAML2
+  ( SAML2 (..),
+    authReq,
+    authResp,
+    meta,
+    toggleCookie,
+  )
+where
 
 import Data.Id (TeamId)
 import Data.String.Conversions (SBS, ST)

--- a/services/spar/src/Spar/Sem/SAML2.hs
+++ b/services/spar/src/Spar/Sem/SAML2.hs
@@ -28,9 +28,9 @@ import Data.Id (TeamId)
 import Data.String.Conversions (SBS, ST)
 import Data.Time (NominalDiffTime)
 import GHC.TypeLits (KnownSymbol)
-import Imports hiding (log)
+import Imports (Maybe)
 import Polysemy
-import SAML2.WebSSO
+import SAML2.WebSSO hiding (meta, toggleCookie)
 import URI.ByteString (URI)
 
 data SAML2 m a where

--- a/services/spar/src/Spar/Sem/SAMLUserStore.hs
+++ b/services/spar/src/Spar/Sem/SAMLUserStore.hs
@@ -15,7 +15,14 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SAMLUserStore where
+module Spar.Sem.SAMLUserStore (
+  SAMLUserStore(..),
+  insert,
+  get,
+  getAnyByIssuer,
+  getSomeByIssuer,
+  deleteByIssuer,
+  delete ) where
 
 import Data.Id
 import Imports

--- a/services/spar/src/Spar/Sem/SAMLUserStore.hs
+++ b/services/spar/src/Spar/Sem/SAMLUserStore.hs
@@ -15,14 +15,16 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SAMLUserStore (
-  SAMLUserStore(..),
-  insert,
-  get,
-  getAnyByIssuer,
-  getSomeByIssuer,
-  deleteByIssuer,
-  delete ) where
+module Spar.Sem.SAMLUserStore
+  ( SAMLUserStore (..),
+    insert,
+    get,
+    getAnyByIssuer,
+    getSomeByIssuer,
+    deleteByIssuer,
+    delete,
+  )
+where
 
 import Data.Id
 import Imports

--- a/services/spar/src/Spar/Sem/SAMLUserStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/SAMLUserStore/Cassandra.hs
@@ -17,15 +17,17 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SAMLUserStore.Cassandra (
-  samlUserStoreToCassandra,
-  interpretClientToIO,
-  insertSAMLUser,
-  getSAMLAnyUserByIssuer,
-  getSAMLSomeUsersByIssuer,
-  getSAMLUser,
-  deleteSAMLUsersByIssuer,
-  deleteSAMLUser ) where
+module Spar.Sem.SAMLUserStore.Cassandra
+  ( samlUserStoreToCassandra,
+    interpretClientToIO,
+    insertSAMLUser,
+    getSAMLAnyUserByIssuer,
+    getSAMLSomeUsersByIssuer,
+    getSAMLUser,
+    deleteSAMLUsersByIssuer,
+    deleteSAMLUser,
+  )
+where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/SAMLUserStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/SAMLUserStore/Cassandra.hs
@@ -17,7 +17,15 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SAMLUserStore.Cassandra where
+module Spar.Sem.SAMLUserStore.Cassandra (
+  samlUserStoreToCassandra,
+  interpretClientToIO,
+  insertSAMLUser,
+  getSAMLAnyUserByIssuer,
+  getSAMLSomeUsersByIssuer,
+  getSAMLUser,
+  deleteSAMLUsersByIssuer,
+  deleteSAMLUser ) where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/SAMLUserStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/SAMLUserStore/Cassandra.hs
@@ -20,12 +20,6 @@
 module Spar.Sem.SAMLUserStore.Cassandra
   ( samlUserStoreToCassandra,
     interpretClientToIO,
-    insertSAMLUser,
-    getSAMLAnyUserByIssuer,
-    getSAMLSomeUsersByIssuer,
-    getSAMLUser,
-    deleteSAMLUsersByIssuer,
-    deleteSAMLUser,
   )
 where
 

--- a/services/spar/src/Spar/Sem/SAMLUserStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/SAMLUserStore/Mem.hs
@@ -18,8 +18,7 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Spar.Sem.SAMLUserStore.Mem
-  ( UserRefOrd (..),
-    samlUserStoreToMem,
+  ( samlUserStoreToMem,
   )
 where
 

--- a/services/spar/src/Spar/Sem/SAMLUserStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/SAMLUserStore/Mem.hs
@@ -17,7 +17,9 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SAMLUserStore.Mem where
+module Spar.Sem.SAMLUserStore.Mem (
+  UserRefOrd(..),
+  samlUserStoreToMem ) where
 
 import Control.Lens (view)
 import Data.Coerce (coerce)

--- a/services/spar/src/Spar/Sem/SAMLUserStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/SAMLUserStore/Mem.hs
@@ -17,9 +17,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SAMLUserStore.Mem (
-  UserRefOrd(..),
-  samlUserStoreToMem ) where
+module Spar.Sem.SAMLUserStore.Mem
+  ( UserRefOrd (..),
+    samlUserStoreToMem,
+  )
+where
 
 import Control.Lens (view)
 import Data.Coerce (coerce)

--- a/services/spar/src/Spar/Sem/SamlProtocolSettings.hs
+++ b/services/spar/src/Spar/Sem/SamlProtocolSettings.hs
@@ -15,7 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SamlProtocolSettings where
+module Spar.Sem.SamlProtocolSettings (
+  SamlProtocolSettings(..),
+  spIssuer,
+  responseURI ) where
 
 import Data.Id (TeamId)
 import Imports

--- a/services/spar/src/Spar/Sem/SamlProtocolSettings.hs
+++ b/services/spar/src/Spar/Sem/SamlProtocolSettings.hs
@@ -15,10 +15,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SamlProtocolSettings (
-  SamlProtocolSettings(..),
-  spIssuer,
-  responseURI ) where
+module Spar.Sem.SamlProtocolSettings
+  ( SamlProtocolSettings (..),
+    spIssuer,
+    responseURI,
+  )
+where
 
 import Data.Id (TeamId)
 import Imports

--- a/services/spar/src/Spar/Sem/SamlProtocolSettings/Servant.hs
+++ b/services/spar/src/Spar/Sem/SamlProtocolSettings/Servant.hs
@@ -17,7 +17,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SamlProtocolSettings.Servant where
+module Spar.Sem.SamlProtocolSettings.Servant (
+  sparRouteToServant ) where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/SamlProtocolSettings/Servant.hs
+++ b/services/spar/src/Spar/Sem/SamlProtocolSettings/Servant.hs
@@ -17,8 +17,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.SamlProtocolSettings.Servant (
-  sparRouteToServant ) where
+module Spar.Sem.SamlProtocolSettings.Servant
+  ( sparRouteToServant,
+  )
+where
 
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Sem/ScimExternalIdStore.hs
+++ b/services/spar/src/Spar/Sem/ScimExternalIdStore.hs
@@ -15,11 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimExternalIdStore (
-  ScimExternalIdStore(..),
-  insert,
-  lookup,
-  delete ) where
+module Spar.Sem.ScimExternalIdStore
+  ( ScimExternalIdStore (..),
+    insert,
+    lookup,
+    delete,
+  )
+where
 
 import Data.Id (TeamId, UserId)
 import Imports

--- a/services/spar/src/Spar/Sem/ScimExternalIdStore.hs
+++ b/services/spar/src/Spar/Sem/ScimExternalIdStore.hs
@@ -24,7 +24,7 @@ module Spar.Sem.ScimExternalIdStore
 where
 
 import Data.Id (TeamId, UserId)
-import Imports (Show, Maybe)
+import Imports (Maybe, Show)
 import Polysemy
 import Polysemy.Check (deriveGenericK)
 import Wire.API.User.Identity (Email)

--- a/services/spar/src/Spar/Sem/ScimExternalIdStore.hs
+++ b/services/spar/src/Spar/Sem/ScimExternalIdStore.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimExternalIdStore where
+module Spar.Sem.ScimExternalIdStore (
+  ScimExternalIdStore(..),
+  insert,
+  lookup,
+  delete ) where
 
 import Data.Id (TeamId, UserId)
 import Imports

--- a/services/spar/src/Spar/Sem/ScimExternalIdStore.hs
+++ b/services/spar/src/Spar/Sem/ScimExternalIdStore.hs
@@ -24,7 +24,7 @@ module Spar.Sem.ScimExternalIdStore
 where
 
 import Data.Id (TeamId, UserId)
-import Imports
+import Imports (Show, Maybe)
 import Polysemy
 import Polysemy.Check (deriveGenericK)
 import Wire.API.User.Identity (Email)

--- a/services/spar/src/Spar/Sem/ScimExternalIdStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/ScimExternalIdStore/Cassandra.hs
@@ -17,9 +17,6 @@
 
 module Spar.Sem.ScimExternalIdStore.Cassandra
   ( scimExternalIdStoreToCassandra,
-    insertScimExternalId,
-    lookupScimExternalId,
-    deleteScimExternalId,
   )
 where
 

--- a/services/spar/src/Spar/Sem/ScimExternalIdStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/ScimExternalIdStore/Cassandra.hs
@@ -15,11 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimExternalIdStore.Cassandra (
-  scimExternalIdStoreToCassandra,
-  insertScimExternalId,
-  lookupScimExternalId,
-  deleteScimExternalId ) where
+module Spar.Sem.ScimExternalIdStore.Cassandra
+  ( scimExternalIdStoreToCassandra,
+    insertScimExternalId,
+    lookupScimExternalId,
+    deleteScimExternalId,
+  )
+where
 
 import Brig.Types.Common (Email, fromEmail)
 import Cassandra

--- a/services/spar/src/Spar/Sem/ScimExternalIdStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/ScimExternalIdStore/Cassandra.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimExternalIdStore.Cassandra where
+module Spar.Sem.ScimExternalIdStore.Cassandra (
+  scimExternalIdStoreToCassandra,
+  insertScimExternalId,
+  lookupScimExternalId,
+  deleteScimExternalId ) where
 
 import Brig.Types.Common (Email, fromEmail)
 import Cassandra

--- a/services/spar/src/Spar/Sem/ScimExternalIdStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/ScimExternalIdStore/Mem.hs
@@ -17,7 +17,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimExternalIdStore.Mem where
+module Spar.Sem.ScimExternalIdStore.Mem (
+  scimExternalIdStoreToMem ) where
 
 import Data.Id (TeamId, UserId)
 import qualified Data.Map as M

--- a/services/spar/src/Spar/Sem/ScimExternalIdStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/ScimExternalIdStore/Mem.hs
@@ -17,8 +17,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimExternalIdStore.Mem (
-  scimExternalIdStoreToMem ) where
+module Spar.Sem.ScimExternalIdStore.Mem
+  ( scimExternalIdStoreToMem,
+  )
+where
 
 import Data.Id (TeamId, UserId)
 import qualified Data.Map as M

--- a/services/spar/src/Spar/Sem/ScimTokenStore.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore.hs
@@ -15,7 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimTokenStore where
+module Spar.Sem.ScimTokenStore (
+  ScimTokenStore(..),
+  insert,
+  lookup,
+  getByTeam,
+  delete,
+  deleteByTeam ) where
 
 import Data.Id
 import Imports

--- a/services/spar/src/Spar/Sem/ScimTokenStore.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore.hs
@@ -19,7 +19,7 @@ module Spar.Sem.ScimTokenStore
   ( ScimTokenStore (..),
     insert,
     lookup,
-    getByTeam,
+    lookupByTeam,
     delete,
     deleteByTeam,
   )

--- a/services/spar/src/Spar/Sem/ScimTokenStore.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore.hs
@@ -26,7 +26,7 @@ module Spar.Sem.ScimTokenStore
 where
 
 import Data.Id
-import Imports
+import Imports (Maybe)
 import Polysemy
 import Wire.API.User.Scim
 

--- a/services/spar/src/Spar/Sem/ScimTokenStore.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore.hs
@@ -15,13 +15,15 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimTokenStore (
-  ScimTokenStore(..),
-  insert,
-  lookup,
-  getByTeam,
-  delete,
-  deleteByTeam ) where
+module Spar.Sem.ScimTokenStore
+  ( ScimTokenStore (..),
+    insert,
+    lookup,
+    getByTeam,
+    delete,
+    deleteByTeam,
+  )
+where
 
 import Data.Id
 import Imports

--- a/services/spar/src/Spar/Sem/ScimTokenStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore/Cassandra.hs
@@ -18,21 +18,23 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimTokenStore.Cassandra (
-  ScimTokenRow,
-  scimTokenStoreToCassandra,
-  insertScimToken,
-  insByToken,
-  insByTeam,
-  scimTokenLookupKey,
-  lookupScimToken,
-  connvertPlaintextToken,
-  getScimTokens,
-  deleteScimToken,
-  delById,
-  delByTokenLookup,
-  deleteTeamScimTokens,
-  fromScimTokenRow ) where
+module Spar.Sem.ScimTokenStore.Cassandra
+  ( ScimTokenRow,
+    scimTokenStoreToCassandra,
+    insertScimToken,
+    insByToken,
+    insByTeam,
+    scimTokenLookupKey,
+    lookupScimToken,
+    connvertPlaintextToken,
+    getScimTokens,
+    deleteScimToken,
+    delById,
+    delByTokenLookup,
+    deleteTeamScimTokens,
+    fromScimTokenRow,
+  )
+where
 
 import Cassandra as Cas
 import Control.Arrow (Arrow ((&&&)))

--- a/services/spar/src/Spar/Sem/ScimTokenStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore/Cassandra.hs
@@ -18,7 +18,21 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimTokenStore.Cassandra where
+module Spar.Sem.ScimTokenStore.Cassandra (
+  ScimTokenRow,
+  scimTokenStoreToCassandra,
+  insertScimToken,
+  insByToken,
+  insByTeam,
+  scimTokenLookupKey,
+  lookupScimToken,
+  connvertPlaintextToken,
+  getScimTokens,
+  deleteScimToken,
+  delById,
+  delByTokenLookup,
+  deleteTeamScimTokens,
+  fromScimTokenRow ) where
 
 import Cassandra as Cas
 import Control.Arrow (Arrow ((&&&)))

--- a/services/spar/src/Spar/Sem/ScimTokenStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore/Cassandra.hs
@@ -19,20 +19,7 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Spar.Sem.ScimTokenStore.Cassandra
-  ( ScimTokenRow,
-    scimTokenStoreToCassandra,
-    insertScimToken,
-    insByToken,
-    insByTeam,
-    scimTokenLookupKey,
-    lookupScimToken,
-    connvertPlaintextToken,
-    getScimTokens,
-    deleteScimToken,
-    delById,
-    delByTokenLookup,
-    deleteTeamScimTokens,
-    fromScimTokenRow,
+  ( scimTokenStoreToCassandra,
   )
 where
 

--- a/services/spar/src/Spar/Sem/ScimTokenStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore/Mem.hs
@@ -17,7 +17,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimTokenStore.Mem where
+module Spar.Sem.ScimTokenStore.Mem (
+  scimTokenStoreToMem ) where
 
 import qualified Data.Map as M
 import Imports

--- a/services/spar/src/Spar/Sem/ScimTokenStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore/Mem.hs
@@ -17,8 +17,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimTokenStore.Mem (
-  scimTokenStoreToMem ) where
+module Spar.Sem.ScimTokenStore.Mem
+  ( scimTokenStoreToMem,
+  )
+where
 
 import qualified Data.Map as M
 import Imports

--- a/services/spar/src/Spar/Sem/ScimUserTimesStore.hs
+++ b/services/spar/src/Spar/Sem/ScimUserTimesStore.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimUserTimesStore where
+module Spar.Sem.ScimUserTimesStore (
+  ScimUserTimesStore(..),
+  write,
+  read,
+  delete ) where
 
 import Data.Id (UserId)
 import Data.Json.Util (UTCTimeMillis)

--- a/services/spar/src/Spar/Sem/ScimUserTimesStore.hs
+++ b/services/spar/src/Spar/Sem/ScimUserTimesStore.hs
@@ -15,11 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimUserTimesStore (
-  ScimUserTimesStore(..),
-  write,
-  read,
-  delete ) where
+module Spar.Sem.ScimUserTimesStore
+  ( ScimUserTimesStore (..),
+    write,
+    read,
+    delete,
+  )
+where
 
 import Data.Id (UserId)
 import Data.Json.Util (UTCTimeMillis)

--- a/services/spar/src/Spar/Sem/ScimUserTimesStore.hs
+++ b/services/spar/src/Spar/Sem/ScimUserTimesStore.hs
@@ -25,7 +25,7 @@ where
 
 import Data.Id (UserId)
 import Data.Json.Util (UTCTimeMillis)
-import Imports
+import Imports (Maybe)
 import Polysemy
 import Web.Scim.Schema.Common (WithId)
 import Web.Scim.Schema.Meta (WithMeta)

--- a/services/spar/src/Spar/Sem/ScimUserTimesStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/ScimUserTimesStore/Cassandra.hs
@@ -15,7 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimUserTimesStore.Cassandra where
+module Spar.Sem.ScimUserTimesStore.Cassandra (
+  scimUserTimesStoreToCassandra,
+  writeScimUserTimes,
+  readScimUserTimes,
+  deleteScimUserTimes ) where
 
 import Cassandra as Cas
 import Data.Id

--- a/services/spar/src/Spar/Sem/ScimUserTimesStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/ScimUserTimesStore/Cassandra.hs
@@ -17,9 +17,6 @@
 
 module Spar.Sem.ScimUserTimesStore.Cassandra
   ( scimUserTimesStoreToCassandra,
-    writeScimUserTimes,
-    readScimUserTimes,
-    deleteScimUserTimes,
   )
 where
 

--- a/services/spar/src/Spar/Sem/ScimUserTimesStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/ScimUserTimesStore/Cassandra.hs
@@ -15,11 +15,13 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimUserTimesStore.Cassandra (
-  scimUserTimesStoreToCassandra,
-  writeScimUserTimes,
-  readScimUserTimes,
-  deleteScimUserTimes ) where
+module Spar.Sem.ScimUserTimesStore.Cassandra
+  ( scimUserTimesStoreToCassandra,
+    writeScimUserTimes,
+    readScimUserTimes,
+    deleteScimUserTimes,
+  )
+where
 
 import Cassandra as Cas
 import Data.Id

--- a/services/spar/src/Spar/Sem/ScimUserTimesStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/ScimUserTimesStore/Mem.hs
@@ -17,8 +17,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimUserTimesStore.Mem (
-  scimUserTimesStoreToMem ) where
+module Spar.Sem.ScimUserTimesStore.Mem
+  ( scimUserTimesStoreToMem,
+  )
+where
 
 import Data.Id (UserId)
 import Data.Json.Util (UTCTimeMillis, toUTCTimeMillis)

--- a/services/spar/src/Spar/Sem/ScimUserTimesStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/ScimUserTimesStore/Mem.hs
@@ -17,7 +17,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.ScimUserTimesStore.Mem where
+module Spar.Sem.ScimUserTimesStore.Mem (
+  scimUserTimesStoreToMem ) where
 
 import Data.Id (UserId)
 import Data.Json.Util (UTCTimeMillis, toUTCTimeMillis)

--- a/services/spar/src/Spar/Sem/VerdictFormatStore.hs
+++ b/services/spar/src/Spar/Sem/VerdictFormatStore.hs
@@ -15,10 +15,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.VerdictFormatStore (
-  VerdictFormatStore(..),
-  store,
-  get ) where
+module Spar.Sem.VerdictFormatStore
+  ( VerdictFormatStore (..),
+    store,
+    get,
+  )
+where
 
 import Data.Time (NominalDiffTime)
 import Imports

--- a/services/spar/src/Spar/Sem/VerdictFormatStore.hs
+++ b/services/spar/src/Spar/Sem/VerdictFormatStore.hs
@@ -15,7 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.VerdictFormatStore where
+module Spar.Sem.VerdictFormatStore (
+  VerdictFormatStore(..),
+  store,
+  get ) where
 
 import Data.Time (NominalDiffTime)
 import Imports

--- a/services/spar/src/Spar/Sem/VerdictFormatStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/VerdictFormatStore/Cassandra.hs
@@ -19,8 +19,6 @@
 
 module Spar.Sem.VerdictFormatStore.Cassandra
   ( verdictFormatStoreToCassandra,
-    storeVerdictFormat,
-    getVerdictFormat,
   )
 where
 

--- a/services/spar/src/Spar/Sem/VerdictFormatStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/VerdictFormatStore/Cassandra.hs
@@ -17,7 +17,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.VerdictFormatStore.Cassandra where
+module Spar.Sem.VerdictFormatStore.Cassandra (
+  verdictFormatStoreToCassandra,
+  storeVerdictFormat,
+  getVerdictFormat ) where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/VerdictFormatStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/VerdictFormatStore/Cassandra.hs
@@ -17,10 +17,12 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.VerdictFormatStore.Cassandra (
-  verdictFormatStoreToCassandra,
-  storeVerdictFormat,
-  getVerdictFormat ) where
+module Spar.Sem.VerdictFormatStore.Cassandra
+  ( verdictFormatStoreToCassandra,
+    storeVerdictFormat,
+    getVerdictFormat,
+  )
+where
 
 import Cassandra as Cas
 import Control.Lens

--- a/services/spar/src/Spar/Sem/VerdictFormatStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/VerdictFormatStore/Mem.hs
@@ -17,7 +17,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.VerdictFormatStore.Mem where
+module Spar.Sem.VerdictFormatStore.Mem (
+  verdictFormatStoreToMem ) where
 
 import qualified Data.Map as M
 import Imports

--- a/services/spar/src/Spar/Sem/VerdictFormatStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/VerdictFormatStore/Mem.hs
@@ -17,8 +17,10 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.VerdictFormatStore.Mem (
-  verdictFormatStoreToMem ) where
+module Spar.Sem.VerdictFormatStore.Mem
+  ( verdictFormatStoreToMem,
+  )
+where
 
 import qualified Data.Map as M
 import Imports


### PR DESCRIPTION
This PR adds explicit export lists for all the new modules I've introduced when working on Spar.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.