### PR TITLE
Revert "Servantify Cannon's internal API (#2029)"

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -71,15 +71,6 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/haskell-servant/servant.git
-    tag: 75db4a5327d6d04ae2460bd5ffd008fe16197ba8
-    subdir: servant
-            servant-client
-            servant-client-core
-            servant-server
-
-source-repository-package
-    type: git
     location: https://github.com/kim/hs-collectd
     tag: 885da222be2375f78c7be36127620ed772b677c9
 
@@ -150,6 +141,15 @@ source-repository-package
     type: git
     location: https://github.com/wireapp/saml2-web-sso
     tag: 4227e38be5c0810012dc472fc6931f6087fbce68
+
+source-repository-package
+    type: git
+    location: https://github.com/wireapp/servant.git
+    tag: a4e15fe75f294816d9ead19ed8a48cae8e0b76e7
+    subdir: servant
+            servant-client
+            servant-client-core
+            servant-server
 
 source-repository-package
     type: git

--- a/changelog.d/5-internal/servantify-cannon-internal-api
+++ b/changelog.d/5-internal/servantify-cannon-internal-api
@@ -1,1 +1,0 @@
-Migrate the internal API of Cannon to Servant.

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -347,7 +347,3 @@ type AssetTooLarge = ErrorDescription 413 "client-error" "Asset too large"
 type InvalidLength = ErrorDescription 400 "invalid-length" "Invalid content length"
 
 type AssetNotFound = ErrorDescription 404 "not-found" "Asset not found"
-
-type PresenceNotRegistered = ErrorDescription 404 "not-found" "presence not registered"
-
-type ClientGone = ErrorDescription 410 "general" "client gone"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Cannon.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Cannon.hs
@@ -21,27 +21,23 @@ import Data.Id
 import Data.Swagger
 import Servant
 import Servant.Swagger
-import Wire.API.Routes.Named
 import Wire.API.Routes.Public (ZConn, ZUser)
 import Wire.API.Routes.WebSocket
 
-type PublicAPI =
-  Named
-    "await-notifications"
-    ( Summary "Establish websocket connection"
-        :> "await"
-        :> ZUser
-        :> ZConn
-        :> QueryParam'
-             [ Optional,
-               Strict,
-               Description "Client ID"
-             ]
-             "client"
-             ClientId
-        -- FUTUREWORK: Consider higher-level web socket combinator
-        :> WebSocketPending
-    )
+type ServantAPI =
+  Summary "Establish websocket connection"
+    :> "await"
+    :> ZUser
+    :> ZConn
+    :> QueryParam'
+         [ Optional,
+           Strict,
+           Description "Client ID"
+         ]
+         "client"
+         ClientId
+    -- FUTUREWORK: Consider higher-level web socket combinator
+    :> WebSocketPending
 
 swaggerDoc :: Swagger
-swaggerDoc = toSwagger (Proxy @PublicAPI)
+swaggerDoc = toSwagger (Proxy @ServantAPI)

--- a/services/cannon/cannon.cabal
+++ b/services/cannon/cannon.cabal
@@ -85,7 +85,6 @@ library
     , bilge >=0.12
     , bytestring >=0.10
     , bytestring-conversion >=0.2
-    , conduit >=1.3.4.2
     , data-default >=0.5
     , data-timeout >=0.3
     , exceptions >=0.6
@@ -101,7 +100,6 @@ library
     , retry >=0.7
     , safe-exceptions
     , servant
-    , servant-conduit
     , servant-server
     , strict >=0.3.2
     , swagger >=0.2

--- a/services/cannon/package.yaml
+++ b/services/cannon/package.yaml
@@ -22,7 +22,6 @@ library:
   - bilge >=0.12
   - bytestring >=0.10
   - bytestring-conversion >=0.2
-  - conduit >=1.3.4.2
   - data-default >=0.5
   - data-timeout >=0.3
   - exceptions >=0.6
@@ -36,7 +35,6 @@ library:
   - retry >=0.7
   - safe-exceptions
   - servant
-  - servant-conduit
   - servant-server
   - strict >=0.3.2
   - swagger >=0.2

--- a/services/cannon/src/Cannon/API/Internal.hs
+++ b/services/cannon/src/Cannon/API/Internal.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
@@ -18,8 +16,7 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Cannon.API.Internal
-  ( InternalAPI,
-    internalServer,
+  ( sitemap,
   )
 where
 
@@ -27,94 +24,63 @@ import Cannon.App
 import qualified Cannon.Dict as D
 import Cannon.Types
 import Cannon.WS
-import Conduit
 import Control.Monad.Catch
 import Data.Aeson (encode)
-import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
-import Data.Conduit.List
-import Data.Id hiding (client)
+import Data.Id (ConnId, UserId)
+import Data.Swagger.Build.Api hiding (Response)
 import Gundeck.Types
 import Gundeck.Types.BulkPush
-import Imports
-import Servant
-import Servant.Conduit ()
+import Imports hiding (head)
+import Network.HTTP.Types
+import Network.Wai
+import Network.Wai.Predicate
+import Network.Wai.Routing
+import Network.Wai.Utilities
 import System.Logger.Class (msg, val)
 import qualified System.Logger.Class as LC
-import Wire.API.ErrorDescription
-import Wire.API.Routes.MultiVerb
-import Wire.API.Routes.Named
 
-newtype PushNotificationStream = PushNotificationStream
-  { getPushNotificationStream :: ConduitT () ByteString (ResourceT WS) ()
-  }
-  deriving newtype (FromSourceIO ByteString)
+sitemap :: Routes ApiBuilder Cannon ()
+sitemap = do
+  get "/i/status" (continue (const $ return empty)) true
+  head "/i/status" (continue (const $ return empty)) true
 
-type InternalAPI =
-  "i"
-    :> ( Named
-           "get-status"
-           ( "status"
-               :> MultiVerb
-                    'GET
-                    '[PlainText]
-                    '[RespondEmpty 200 "Service is alive."]
-                    ()
-           )
-           :<|> Named
-                  "push-notification"
-                  ( "push"
-                      :> Capture "user" UserId
-                      :> Capture "conn" ConnId
-                      :> StreamBody NoFraming OctetStream PushNotificationStream
-                      :> MultiVerb
-                           'POST
-                           '[JSON]
-                           '[ ClientGone,
-                              RespondEmpty 200 "Successfully pushed."
-                            ]
-                           (Maybe ())
-                  )
-           :<|> Named
-                  "bulk-push-notifications"
-                  ( "bulkpush"
-                      :> ReqBody '[JSON] BulkPushRequest
-                      :> Post '[JSON] BulkPushResponse
-                  )
-           :<|> Named
-                  "check-presence"
-                  ( "presences"
-                      :> Capture "uid" UserId
-                      :> Capture "conn" ConnId
-                      :> MultiVerb
-                           'HEAD
-                           '[JSON]
-                           '[ PresenceNotRegistered,
-                              RespondEmpty 200 "Presence checked successfully."
-                            ]
-                           (Maybe ())
-                  )
-       )
+  post "/i/push/:user/:conn" (continue pushH) $
+    capture "user" .&. capture "conn" .&. request
 
-internalServer :: ServerT InternalAPI Cannon
-internalServer =
-  Named @"get-status" (pure ())
-    :<|> Named @"push-notification" pushHandler
-    :<|> Named @"bulk-push-notifications" bulkPushHandler
-    :<|> Named @"check-presence" checkPresenceHandler
+  post "/i/bulkpush" (continue bulkpushH) $
+    request
 
-pushHandler :: UserId -> ConnId -> PushNotificationStream -> Cannon (Maybe ())
-pushHandler user conn body =
-  singlePush body (PushTarget user conn) >>= \case
-    PushStatusOk -> pure $ Just ()
-    PushStatusGone -> pure Nothing
+  head "/i/presences/:uid/:conn" (continue checkPresenceH) $
+    param "uid" .&. param "conn"
+
+pushH :: UserId ::: ConnId ::: Request -> Cannon Response
+pushH (user ::: conn ::: req) =
+  singlePush (readBody req) (PushTarget user conn) >>= \case
+    PushStatusOk -> return empty
+    PushStatusGone -> return $ errorRs status410 "general" "client gone"
+
+-- | Parse the entire list of notifcations and targets, then call 'singlePush' on the each of them
+-- in order.
+bulkpushH :: Request -> Cannon Response
+bulkpushH req = json <$> (parseBody' (JsonRequest req) >>= bulkpush)
+
+-- | The typed part of 'bulkpush'.
+bulkpush :: BulkPushRequest -> Cannon BulkPushResponse
+bulkpush (BulkPushRequest notifs) =
+  BulkPushResponse . mconcat . zipWith compileResp notifs <$> (uncurry doNotif `mapM` notifs)
+  where
+    doNotif :: Notification -> [PushTarget] -> Cannon [PushStatus]
+    doNotif (pure . encode -> notif) = mapConcurrentlyCannon (singlePush notif)
+    compileResp ::
+      (Notification, [PushTarget]) ->
+      [PushStatus] ->
+      [(NotificationId, PushTarget, PushStatus)]
+    compileResp (notif, prcs) pss = zip3 (repeat (ntfId notif)) prcs pss
 
 -- | Take a serialized 'Notification' string and send it to the 'PushTarget'.
-singlePush :: PushNotificationStream -> PushTarget -> Cannon PushStatus
-singlePush = singlePush' . getPushNotificationStream
-
-singlePush' :: ConduitM () ByteString (ResourceT WS) () -> PushTarget -> Cannon PushStatus
-singlePush' notificationC (PushTarget usrid conid) = do
+singlePush :: Cannon L.ByteString -> PushTarget -> Cannon PushStatus
+singlePush notification (PushTarget usrid conid) = do
   let k = mkKey usrid conid
   d <- clients
   LC.debug $ client (key2bytes k) . msg (val "push")
@@ -125,36 +91,15 @@ singlePush' notificationC (PushTarget usrid conid) = do
       return PushStatusGone
     Just x -> do
       e <- wsenv
-      runWS e $ do
-        catchAll
-          ( runConduitRes $
-              notificationC .| (sendMsgConduit k x >> pure PushStatusOk)
-          )
-          (const (terminate k x >> pure PushStatusGone))
+      b <- notification
+      runWS e $
+        (sendMsg b k x >> return PushStatusOk)
+          `catchAll` const (terminate k x >> return PushStatusGone)
 
-bulkPushHandler :: BulkPushRequest -> Cannon BulkPushResponse
-bulkPushHandler (BulkPushRequest ns) =
-  BulkPushResponse . mconcat . zipWith compileResp ns <$> (uncurry doNotify `Imports.mapM` ns)
-  where
-    doNotify :: Notification -> [PushTarget] -> Cannon [PushStatus]
-    doNotify (encode -> notification) =
-      mapConcurrentlyCannon
-        ( singlePush'
-            (sourceLbs notification)
-        )
-    compileResp ::
-      (Notification, [PushTarget]) ->
-      [PushStatus] ->
-      [(NotificationId, PushTarget, PushStatus)]
-    compileResp (notif, prcs) pss = zip3 (repeat (ntfId notif)) prcs pss
-
-checkPresenceHandler :: UserId -> ConnId -> Cannon (Maybe ())
-checkPresenceHandler u c = do
+checkPresenceH :: UserId ::: ConnId -> Cannon Response
+checkPresenceH (u ::: c) = do
   e <- wsenv
   registered <- runWS e $ isRemoteRegistered u c
   if registered
-    then pure $ Just ()
-    else pure Nothing
-
-sourceLbs :: Monad m => L.ByteString -> ConduitT i S.ByteString m ()
-sourceLbs = sourceList . L.toChunks
+    then return empty
+    else return $ errorRs status404 "not-found" "presence not registered"

--- a/services/cannon/src/Cannon/API/Public.hs
+++ b/services/cannon/src/Cannon/API/Public.hs
@@ -16,7 +16,8 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Cannon.API.Public
-  ( publicAPIServer,
+  ( API,
+    publicAPIServer,
   )
 where
 
@@ -28,11 +29,12 @@ import Data.Id
 import GHC.Base
 import Network.WebSockets.Connection
 import Servant
-import Wire.API.Routes.Named
 import Wire.API.Routes.Public.Cannon
 
-publicAPIServer :: ServerT PublicAPI Cannon
-publicAPIServer = Named @"await-notifications" streamData
+type API = ServantAPI :<|> Raw
+
+publicAPIServer :: ServerT ServantAPI Cannon
+publicAPIServer = streamData
 
 streamData :: UserId -> ConnId -> Maybe ClientId -> PendingConnection -> Cannon ()
 streamData userId connId clientId con = do

--- a/services/cannon/src/Cannon/App.hs
+++ b/services/cannon/src/Cannon/App.hs
@@ -149,7 +149,7 @@ readLoop ws s = loop
       (DataMessage _ _ _ (Text "ping" _)) -> True
       (DataMessage _ _ _ (Binary "ping")) -> True
       _ -> False
-    sendAppLevelPong = sendMsgIO @ByteString "pong" ws
+    sendAppLevelPong = sendMsgIO "pong" ws
 
 rejectOnError :: PendingConnection -> HandshakeException -> IO a
 rejectOnError p x = do

--- a/services/cannon/test/Main.hs
+++ b/services/cannon/test/Main.hs
@@ -17,10 +17,11 @@
 
 module Main where
 
-import Cannon.API.Internal
-import Data.Metrics.Servant (routesToPaths)
+import qualified Cannon.API.Internal
 import Data.Metrics.Test (pathsConsistencyCheck)
+import Data.Metrics.WaiRoute (treeToPaths)
 import Imports
+import Network.Wai.Utilities.Server (compile)
 import qualified Test.Cannon.Dict as D
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -34,6 +35,6 @@ main =
           assertEqual
             "inconcistent sitemap"
             mempty
-            (pathsConsistencyCheck $ routesToPaths @InternalAPI),
+            (pathsConsistencyCheck . treeToPaths . compile $ Cannon.API.Internal.sitemap),
         D.tests
       ]

--- a/services/federator/test/unit/Test/Federator/Client.hs
+++ b/services/federator/test/unit/Test/Federator/Client.hs
@@ -36,7 +36,7 @@ import qualified Network.HTTP2.Client as HTTP2
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Utilities.Error as Wai
 import Servant.API
-import Servant.Client hiding ((//))
+import Servant.Client
 import Servant.Client.Core
 import Servant.Types.SourceT
 import Test.QuickCheck (arbitrary, generate)

--- a/stack.yaml
+++ b/stack.yaml
@@ -193,10 +193,10 @@ extra-deps:
 - git: https://github.com/haskell-servant/servant-swagger
   commit: bb0a84faa073fa9530f60337610d7da3d5b9393c
 
-# For changes from https://github.com/haskell-servant/servant/pull/1502
+# For changes from https://github.com/haskell-servant/servant/pull/1420
 # Not released to hackage yet
-- git: https://github.com/haskell-servant/servant.git
-  commit: 75db4a5327d6d04ae2460bd5ffd008fe16197ba8
+- git: https://github.com/wireapp/servant.git
+  commit: a4e15fe75f294816d9ead19ed8a48cae8e0b76e7
   subdirs:
   - servant
   - servant-server

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -517,55 +517,55 @@ packages:
 - completed:
     subdir: servant
     name: servant
-    version: 0.18.3
-    git: https://github.com/haskell-servant/servant.git
+    version: 0.18.2
+    git: https://github.com/wireapp/servant.git
     pantry-tree:
-      size: 2949
-      sha256: 091d8a742ea95490b787f497bfa26eaed46733945721396158f571aea7ed6dca
-    commit: 75db4a5327d6d04ae2460bd5ffd008fe16197ba8
+      size: 2809
+      sha256: 22348fceac7bca97f5c349d9db0b157e401ed273d151d8cbcbd767f4d06791e8
+    commit: a4e15fe75f294816d9ead19ed8a48cae8e0b76e7
   original:
     subdir: servant
-    git: https://github.com/haskell-servant/servant.git
-    commit: 75db4a5327d6d04ae2460bd5ffd008fe16197ba8
+    git: https://github.com/wireapp/servant.git
+    commit: a4e15fe75f294816d9ead19ed8a48cae8e0b76e7
 - completed:
     subdir: servant-server
     name: servant-server
-    version: 0.18.3
-    git: https://github.com/haskell-servant/servant.git
+    version: 0.18.2
+    git: https://github.com/wireapp/servant.git
     pantry-tree:
       size: 2727
-      sha256: 43d23c42011f5c3ff3f298b1910d7f2b43a66144e92e2e762b0efffe63634af4
-    commit: 75db4a5327d6d04ae2460bd5ffd008fe16197ba8
+      sha256: 55d3c9747550555f3861b5fabfe7cc0385c64ccaf3e5b051aa3064bddb8661ad
+    commit: a4e15fe75f294816d9ead19ed8a48cae8e0b76e7
   original:
     subdir: servant-server
-    git: https://github.com/haskell-servant/servant.git
-    commit: 75db4a5327d6d04ae2460bd5ffd008fe16197ba8
+    git: https://github.com/wireapp/servant.git
+    commit: a4e15fe75f294816d9ead19ed8a48cae8e0b76e7
 - completed:
     subdir: servant-client
     name: servant-client
-    version: 0.18.3
-    git: https://github.com/haskell-servant/servant.git
+    version: 0.18.2
+    git: https://github.com/wireapp/servant.git
     pantry-tree:
-      size: 1481
-      sha256: 86025a0c5ae0b0da07db48eed1456011ba7c0093f2dbc04b1ef3fe99e1cc0567
-    commit: 75db4a5327d6d04ae2460bd5ffd008fe16197ba8
+      size: 1346
+      sha256: 9245621a9097c0b4d5ecbd61616d00c69112e1539db8803a0fda010de484e7ba
+    commit: a4e15fe75f294816d9ead19ed8a48cae8e0b76e7
   original:
     subdir: servant-client
-    git: https://github.com/haskell-servant/servant.git
-    commit: 75db4a5327d6d04ae2460bd5ffd008fe16197ba8
+    git: https://github.com/wireapp/servant.git
+    commit: a4e15fe75f294816d9ead19ed8a48cae8e0b76e7
 - completed:
     subdir: servant-client-core
     name: servant-client-core
-    version: 0.18.3
-    git: https://github.com/haskell-servant/servant.git
+    version: 0.18.2
+    git: https://github.com/wireapp/servant.git
     pantry-tree:
-      size: 1445
-      sha256: 528c07a5fe7d7482636b9e11bbb54d92930a7db3d9635f920f250fed51a8a2fd
-    commit: 75db4a5327d6d04ae2460bd5ffd008fe16197ba8
+      size: 1444
+      sha256: b5a7abf78d2ee0887bf05d7d4ba71e3c689b65a9b2e7386c394f4bdb6ff8e55d
+    commit: a4e15fe75f294816d9ead19ed8a48cae8e0b76e7
   original:
     subdir: servant-client-core
-    git: https://github.com/haskell-servant/servant.git
-    commit: 75db4a5327d6d04ae2460bd5ffd008fe16197ba8
+    git: https://github.com/wireapp/servant.git
+    commit: a4e15fe75f294816d9ead19ed8a48cae8e0b76e7
 - completed:
     hackage: HsOpenSSL-x509-system-0.1.0.4@sha256:86be72558de4cee8f4e32f9cb8b63610d7624219910cfc205a23326078658676,1777
     pantry-tree:


### PR DESCRIPTION
This reverts commit cafa42fc455b0bbd1bde7f8fcf7454d81c5b70c2, which servantified Cannon's internal API. This seems to be causing some payloads to be truncated in websocket connections.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
