### PR TITLE
Fix: nginz template broken for allowlisted_origins

### DIFF
--- a/changelog.d/3-bug-fixes/cors-followup
+++ b/changelog.d/3-bug-fixes/cors-followup
@@ -1,0 +1,1 @@
+Fix bug in nginz template #1630.

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -126,7 +126,7 @@ http {
   map $http_origin $cors_header {
       default "";
     {{ range $origin := .Values.nginx_conf.allowlisted_origins }}
-      "https://{{ $origin }}.{{ .Values.nginx_conf.external_env_domain}} "$http_origin";
+      "https://{{ $origin }}.{{ $.Values.nginx_conf.external_env_domain}} "$http_origin";
     {{ end }}
   }
 


### PR DESCRIPTION
Followup to https://github.com/wireapp/wire-server/pull/1630
Without this PR the  `{{ range }}` expressions rebinds `.`, which makes `.Values.nginx_conf.external_env_domain` fail.
`$.` seems to be the outer (correct) scope. I tested the template locally with this change with the helm version in-use by `cailleach`.
