### PR TITLE
Allow disabling accept check in MultiVerb

### DIFF
--- a/changelog.d/5-internal/multiverb-improvements
+++ b/changelog.d/5-internal/multiverb-improvements
@@ -1,0 +1,1 @@
+Endpoints based on `MultiVerb` can now be made to return content types not listed in the `Accept` header

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -30,10 +30,9 @@ import GHC.TypeLits (KnownSymbol, Symbol, natVal, symbolVal)
 import GHC.TypeNats (Nat)
 import Imports hiding (head)
 import Network.HTTP.Types as HTTP
-import Servant hiding (Handler, addHeader, contentType, respond)
-import Servant.API (contentType)
-import Servant.API.ContentTypes (AllMimeRender, AllMimeUnrender)
-import Servant.API.Status (KnownStatus, statusVal)
+import Servant
+import Servant.API.ContentTypes
+import Servant.API.Status
 import Servant.Client.Core
 import Servant.Swagger.Internal
 import Wire.API.Routes.MultiVerb
@@ -118,7 +117,7 @@ instance KnownStatus status => HasStatus (ErrorDescription status label desc) wh
 -- * MultiVerb errors
 
 type RespondWithErrorDescription s label desc =
-  Respond s desc (ErrorDescription s label desc)
+  RespondAs JSON s desc (ErrorDescription s label desc)
 
 type instance ResponseType (ErrorDescription s label desc) = ErrorDescription s label desc
 
@@ -184,8 +183,7 @@ instance
 
   responseRender _ () =
     pure $
-      addContentType
-        (contentType (Proxy @PlainText))
+      addContentType @PlainText
         Response
           { responseStatusCode = statusVal (Proxy @s),
             responseHeaders = mempty,

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -205,21 +205,6 @@ instance
                  <> "(**Note**: This error has an empty body for legacy reasons)"
              )
 
-instance
-  ( ResponseType r ~ a,
-    KnownStatus s,
-    KnownSymbol desc
-  ) =>
-  AsUnion
-    '[EmptyErrorForLegacyReasons s desc, r]
-    (Maybe a)
-  where
-  toUnion Nothing = Z (I ())
-  toUnion (Just x) = S (Z (I x))
-  fromUnion (Z (I ())) = Nothing
-  fromUnion (S (Z (I x))) = Just x
-  fromUnion (S (S x)) = case x of
-
 -- * Errors
 
 mkErrorDescription :: forall code label desc. KnownSymbol desc => ErrorDescription code label desc

--- a/libs/wire-api/src/Wire/API/ErrorDescription.hs
+++ b/libs/wire-api/src/Wire/API/ErrorDescription.hs
@@ -31,7 +31,6 @@ import GHC.TypeNats (Nat)
 import Imports hiding (head)
 import Network.HTTP.Types as HTTP
 import Servant
-import Servant.API.ContentTypes
 import Servant.API.Status
 import Servant.Client.Core
 import Servant.Swagger.Internal
@@ -122,9 +121,7 @@ type RespondWithErrorDescription s label desc =
 type instance ResponseType (ErrorDescription s label desc) = ErrorDescription s label desc
 
 instance
-  ( AllMimeRender cs (ErrorDescription s label desc),
-    AllMimeUnrender cs (ErrorDescription s label desc),
-    KnownStatus s,
+  ( KnownStatus s,
     KnownSymbol label,
     KnownSymbol desc
   ) =>

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -607,31 +607,14 @@ instance
   toUnion (GenericAsUnion x) = fromSOP @xss @rs (GSOP.from x)
   fromUnion = GenericAsUnion . GSOP.to . toSOP @xss @rs
 
--- | A handler for a pair of empty responses can be implemented simply by
--- returning a boolean value. The convention is that the "failure" case, normally
--- represented by 'False', corresponds to the /first/ response.
-instance
-  AsUnion
-    '[ RespondEmpty s1 desc1,
-       RespondEmpty s2 desc2
-     ]
-    Bool
-  where
-  toUnion False = Z (I ())
-  toUnion True = S (Z (I ()))
-
-  fromUnion (Z (I ())) = False
-  fromUnion (S (Z (I ()))) = True
-  fromUnion (S (S x)) = case x of
-
 -- | A handler for a pair of responses where the first is empty can be
 -- implemented simply by returning a 'Maybe' value. The convention is that the
 -- "failure" case, normally represented by 'Nothing', corresponds to the /first/
 -- response.
 instance
-  AsUnion
-    '[RespondEmpty s1 desc1, Respond s2 desc2 a]
-    (Maybe a)
+  {-# OVERLAPPABLE #-}
+  (ResponseType r1 ~ (), ResponseType r2 ~ a) =>
+  AsUnion '[r1, r2] (Maybe a)
   where
   toUnion Nothing = Z (I ())
   toUnion (Just x) = S (Z (I x))

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -22,6 +22,7 @@ module Wire.API.Routes.MultiVerb
   ( -- * MultiVerb types
     MultiVerb,
     Respond,
+    RespondAs,
     RespondEmpty,
     RespondStreaming,
     WithHeaders,
@@ -84,13 +85,21 @@ type Declare = S.Declare (S.Definitions S.Schema)
 
 -- | A type to describe a 'MultiVerb' response.
 --
--- Includes status code, description, and return type.
+-- Includes status code, description, and return type. The content type of the
+-- response is determined dynamically using the accept header and the list of
+-- supported content types specified in the containing 'MultiVerb' type.
 data Respond (s :: Nat) (desc :: Symbol) (a :: *)
+
+-- | A type to describe a 'MultiVerb' response with a fixed content type.
+--
+-- Similar to 'Respond', but hardcodes the content type to be used for
+-- generating the response.
+data RespondAs ct (s :: Nat) (desc :: Symbol) (a :: *)
 
 -- | A type to describe a 'MultiVerb' response with an empty body.
 --
 -- Includes status code and description.
-data RespondEmpty (s :: Nat) (desc :: Symbol)
+type RespondEmpty s desc = RespondAs '() s desc ()
 
 -- | A type to describe a streaming 'MultiVerb' response.
 --
@@ -160,7 +169,7 @@ instance (AllMimeRender cs a, AllMimeUnrender cs a, KnownStatus s) => IsResponse
     where
       mkRenderOutput :: M.MediaType -> LByteString -> (M.MediaType, Response)
       mkRenderOutput c body =
-        (c,) . addContentType c $
+        (c,) . addContentType' c $
           Response
             { responseStatusCode = statusVal (Proxy @s),
               responseBody = body,
@@ -175,25 +184,52 @@ instance (AllMimeRender cs a, AllMimeUnrender cs a, KnownStatus s) => IsResponse
       Nothing -> empty
       Just f -> either UnrenderError UnrenderSuccess (f (responseBody output))
 
+simpleResponseSwagger :: forall a desc. (S.ToSchema a, KnownSymbol desc) => Declare S.Response
+simpleResponseSwagger = do
+  ref <- S.declareSchemaRef (Proxy @a)
+  pure $
+    mempty
+      & S.description .~ Text.pack (symbolVal (Proxy @desc))
+      & S.schema ?~ ref
+
 instance
   (KnownStatus s, KnownSymbol desc, S.ToSchema a) =>
   IsSwaggerResponse (Respond s desc a)
   where
-  responseSwagger = do
-    ref <- S.declareSchemaRef (Proxy @a)
-    pure $
-      mempty
-        & S.description .~ Text.pack (symbolVal (Proxy @desc))
-        & S.schema ?~ ref
+  responseSwagger = simpleResponseSwagger @a @desc
 
-type instance ResponseType (RespondEmpty s desc) = ()
+type instance ResponseType (RespondAs ct s desc a) = a
 
-instance KnownStatus s => IsResponse cs (RespondEmpty s desc) where
-  type ResponseStatus (RespondEmpty s desc) = s
-  type ResponseBody (RespondEmpty s desc) = ()
+instance
+  ( KnownStatus s,
+    MimeRender ct a,
+    MimeUnrender ct a
+  ) =>
+  IsResponse cs (RespondAs (ct :: *) s desc a)
+  where
+  type ResponseStatus (RespondAs ct s desc a) = s
+  type ResponseBody (RespondAs ct s desc a) = LByteString
+
+  responseRender _ x =
+    pure . addContentType @ct $
+      Response
+        { responseStatusCode = statusVal (Proxy @s),
+          responseBody = mimeRender (Proxy @ct) x,
+          responseHeaders = mempty,
+          responseHttpVersion = HTTP.http11
+        }
+
+  responseUnrender _ output = do
+    guard (responseStatusCode output == statusVal (Proxy @s))
+    either UnrenderError UnrenderSuccess $
+      mimeUnrender (Proxy @ct) (responseBody output)
+
+instance KnownStatus s => IsResponse cs (RespondAs '() s desc ()) where
+  type ResponseStatus (RespondAs '() s desc ()) = s
+  type ResponseBody (RespondAs '() s desc ()) = ()
 
   responseRender _ _ =
-    Just $
+    pure $
       Response
         { responseStatusCode = statusVal (Proxy @s),
           responseBody = (),
@@ -204,11 +240,11 @@ instance KnownStatus s => IsResponse cs (RespondEmpty s desc) where
   responseUnrender _ output =
     guard (responseStatusCode output == statusVal (Proxy @s))
 
-instance (KnownStatus s, KnownSymbol desc) => IsSwaggerResponse (RespondEmpty s desc) where
-  responseSwagger =
-    pure $
-      mempty
-        & S.description .~ Text.pack (symbolVal (Proxy @desc))
+instance
+  (KnownStatus s, KnownSymbol desc, S.ToSchema a) =>
+  IsSwaggerResponse (RespondAs ct s desc a)
+  where
+  responseSwagger = simpleResponseSwagger @a @desc
 
 type instance ResponseType (RespondStreaming s desc framing ct) = SourceIO ByteString
 
@@ -219,7 +255,7 @@ instance
   type ResponseStatus (RespondStreaming s desc framing ct) = s
   type ResponseBody (RespondStreaming s desc framing ct) = SourceIO ByteString
   responseRender _ x =
-    pure . addContentType (contentType (Proxy @ct)) $
+    pure . addContentType @ct $
       Response
         { responseStatusCode = statusVal (Proxy @s),
           responseBody = x,
@@ -529,6 +565,10 @@ instance AsConstructor '[a] (Respond code desc a) where
   toConstructor x = I x :* Nil
   fromConstructor = unI . hd
 
+instance AsConstructor '[a] (RespondAs (ct :: *) code desc a) where
+  toConstructor x = I x :* Nil
+  fromConstructor = unI . hd
+
 instance AsConstructor '[] (RespondEmpty code desc) where
   toConstructor _ = Nil
   fromConstructor _ = ()
@@ -670,8 +710,11 @@ instance IsWaiBody (SourceIO ByteString) where
 
 data SomeResponse = forall a. IsWaiBody a => SomeResponse (ResponseF a)
 
-addContentType :: M.MediaType -> ResponseF a -> ResponseF a
-addContentType c r = r {responseHeaders = (hContentType, M.renderHeader c) <| responseHeaders r}
+addContentType :: forall ct a. Accept ct => ResponseF a -> ResponseF a
+addContentType = addContentType' (contentType (Proxy @ct))
+
+addContentType' :: M.MediaType -> ResponseF a -> ResponseF a
+addContentType' c r = r {responseHeaders = (hContentType, M.renderHeader c) <| responseHeaders r}
 
 setEmptyBody :: SomeResponse -> SomeResponse
 setEmptyBody (SomeResponse r) = SomeResponse (go r)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Cargohold.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Cargohold.hs
@@ -163,7 +163,7 @@ type QualifiedAPI =
       :> QueryParam "asset_token" AssetToken
       :> MultiVerb
            'GET
-           '[JSON]
+           '()
            '[ AssetNotFound,
               AssetRedirect,
               AssetStreaming

--- a/libs/wire-api/src/Wire/API/Routes/Public/Cargohold.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Cargohold.hs
@@ -209,7 +209,7 @@ type LegacyAPI =
          )
 
 type InternalAPI =
-  "i" :> "status" :> MultiVerb 'GET '[PlainText] '[RespondEmpty 200 "OK"] ()
+  "i" :> "status" :> MultiVerb 'GET '() '[RespondEmpty 200 "OK"] ()
 
 swaggerDoc :: Swagger.Swagger
 swaggerDoc = toSwagger (Proxy @ServantAPI)

--- a/services/cargohold/test/integration/API/Util.hs
+++ b/services/cargohold/test/integration/API/Util.hs
@@ -130,19 +130,29 @@ instance IsAssetToken (Maybe AssetToken) where
 instance IsAssetToken (Request -> Request) where
   tokenParam = id
 
+downloadAssetWith ::
+  (IsAssetLocation loc, IsAssetToken tok) =>
+  (Request -> Request) ->
+  UserId ->
+  loc ->
+  tok ->
+  TestM (Response (Maybe LByteString))
+downloadAssetWith r uid loc tok = do
+  c <- viewCargohold
+  get $
+    c . r
+      . zUser uid
+      . locationPath loc
+      . tokenParam tok
+      . noRedirect
+
 downloadAsset ::
   (IsAssetLocation loc, IsAssetToken tok) =>
   UserId ->
   loc ->
   tok ->
   TestM (Response (Maybe LByteString))
-downloadAsset uid loc tok = do
-  c <- viewCargohold
-  get $
-    c . zUser uid
-      . locationPath loc
-      . tokenParam tok
-      . noRedirect
+downloadAsset = downloadAssetWith id
 
 postToken :: UserId -> AssetKey -> TestM (Response (Maybe LByteString))
 postToken uid key = do


### PR DESCRIPTION
This PR makes it possible to more cleanly separate content type negotiation in `MultiVerb` endpoints from the actual content types generated by responses.

It introduces a `RespondAs` type to be used as a `MultiVerb` response that always replies with a fixed content type, regardless of the content type that has been requested by the client.

It also makes it possible to pass a promoted unit value `'()` to `MultiVerb` instead of a list of content types. This disables content negotiation altogether and makes it possible for an endpoint to return statically chosen content types, rather than the one requested by the user.

This fixes an outstanding issue with the asset download endpoint, which was previously refusing to accept requests that had an `Accept` header not containing `application/json`.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
