### PR TITLE
Fix bug: Calls config crashes when SFTs are unreachable

### DIFF
--- a/changelog.d/3-bug-fixes/fs-266-http-exceptions
+++ b/changelog.d/3-bug-fixes/fs-266-http-exceptions
@@ -1,0 +1,1 @@
+Prevent 500s when SFTs are not reachable from Backend

--- a/services/brig/src/Brig/Calling/API.hs
+++ b/services/brig/src/Brig/Calling/API.hs
@@ -33,6 +33,7 @@ import qualified Brig.Calling as Calling
 import Brig.Calling.Internal
 import Brig.Effects.SFT
 import qualified Brig.Options as Opt
+import Control.Error (hush)
 import Control.Lens
 import Data.ByteString.Conversion
 import Data.ByteString.Lens
@@ -176,9 +177,9 @@ newConfig env sftStaticUrl mSftEnv limit version = do
   mSftServersAll :: Maybe [SFTServer] <- case version of
     CallsConfigDeprecated -> pure Nothing
     CallsConfigV2 ->
-      Just <$> case sftStaticUrl of
-        Nothing -> pure $ sftServerFromSrvTarget . srvTarget <$> maybe [] toList allSrvEntries
-        Just url -> fromRight [] . unSFTGetResponse <$> sftGetAllServers url
+      case sftStaticUrl of
+        Nothing -> pure . Just $ sftServerFromSrvTarget . srvTarget <$> maybe [] toList allSrvEntries
+        Just url -> hush . unSFTGetResponse <$> sftGetAllServers url
 
   let mSftServers = staticSft <|> sftServerFromSrvTarget . srvTarget <$$> srvEntries
   pure $ Public.rtcConfiguration srvs mSftServers cTTL mSftServersAll

--- a/services/brig/test/unit/Test/Brig/Calling.hs
+++ b/services/brig/test/unit/Test/Brig/Calling.hs
@@ -325,8 +325,8 @@ testSFTStaticV2StaticUrlError = do
       -- an error
       $ newConfig env (Just staticUrl) Nothing (Just . unsafeRange $ 2) CallsConfigV2
   assertEqual
-    "when SFT static URL is enabled, but returns error, sft_servers_all should be empty"
-    (Just [])
+    "when SFT static URL is enabled, but returns error, sft_servers_all should be omitted"
+    Nothing
     (cfg ^. rtcConfSftServersAll)
 
 -- The v2 endpoint `GET /calls/config/v2` with an SFT static URL's /sft_servers_all.json


### PR DESCRIPTION
Followup to https://github.com/wireapp/wire-server/pull/2030

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside 