### PR TITLE
Cleanup internal endpoints

### DIFF
--- a/changelog.d/5-internal/move-internal-endpoints
+++ b/changelog.d/5-internal/move-internal-endpoints
@@ -1,0 +1,1 @@
+Remove servant-generic from internal endpoints and remove them from Swagger

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Cargohold.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Cargohold.hs
@@ -1,0 +1,24 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Routes.Internal.Cargohold where
+
+import Servant
+import Wire.API.Routes.MultiVerb
+
+type InternalAPI =
+  "i" :> "status" :> MultiVerb 'GET '() '[RespondEmpty 200 "OK"] ()

--- a/libs/wire-api/src/Wire/API/Routes/Internal/LegalHold.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/LegalHold.hs
@@ -1,0 +1,29 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Routes.Internal.LegalHold where
+
+import Data.Id
+import Servant.API hiding (Header)
+import Wire.API.Team.Feature
+
+type InternalLegalHoldAPI =
+  "i" :> "teams" :> Capture "tid" TeamId :> "legalhold"
+    :> Get '[JSON] (TeamFeatureStatus 'WithLockStatus 'TeamFeatureLegalHold)
+    :<|> "i" :> "teams" :> Capture "tid" TeamId :> "legalhold"
+      :> ReqBody '[JSON] (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureLegalHold)
+      :> Put '[] NoContent

--- a/libs/wire-api/src/Wire/API/Routes/Public/Cargohold.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Cargohold.hs
@@ -113,7 +113,6 @@ type ServantAPI =
     :<|> BaseAPIv3 'ProviderPrincipalTag
     :<|> QualifiedAPI
     :<|> LegacyAPI
-    :<|> InternalAPI
 
 type BaseAPIv3 (tag :: PrincipalTag) =
   ( Summary "Upload an asset"
@@ -207,9 +206,6 @@ type LegacyAPI =
              :> Capture "id" AssetId
              :> GetAsset
          )
-
-type InternalAPI =
-  "i" :> "status" :> MultiVerb 'GET '() '[RespondEmpty 200 "OK"] ()
 
 swaggerDoc :: Swagger.Swagger
 swaggerDoc = toSwagger (Proxy @ServantAPI)

--- a/libs/wire-api/src/Wire/API/Routes/Public/LegalHold.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/LegalHold.hs
@@ -22,13 +22,10 @@ import Data.Proxy
 import Data.Swagger hiding (Header (..))
 import Servant.API hiding (Header)
 import Servant.Swagger
-import Wire.API.Team.Feature
 import Wire.API.Team.LegalHold
 
-type ServantAPI = PublicAPI :<|> InternalAPI
-
 -- FUTUREWORK: restructure this for readability and add missing bodies
-type PublicAPI =
+type ServantAPI =
   "teams" :> Capture "tid" TeamId :> "legalhold" :> "settings"
     :> ReqBody '[JSON] NewLegalHoldService
     :> Post '[JSON] ViewLegalHoldService
@@ -49,13 +46,6 @@ type PublicAPI =
     :<|> "teams" :> Capture "tid" TeamId :> "legalhold" :> Capture "uid" UserId
       -- :> ReqBody '[JSON] DisableLegalHoldForUserRequest
       :> Verb 'DELETE 204 '[] NoContent
-
-type InternalAPI =
-  "i" :> "teams" :> Capture "tid" TeamId :> "legalhold"
-    :> Get '[JSON] (TeamFeatureStatus 'WithLockStatus 'TeamFeatureLegalHold)
-    :<|> "i" :> "teams" :> Capture "tid" TeamId :> "legalhold"
-      :> ReqBody '[JSON] (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureLegalHold)
-      :> Put '[] NoContent
 
 swaggerDoc :: Swagger
 swaggerDoc = toSwagger (Proxy @ServantAPI)

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -49,6 +49,7 @@ library
       Wire.API.Routes.Internal.Brig
       Wire.API.Routes.Internal.Brig.Connection
       Wire.API.Routes.Internal.Brig.EJPD
+      Wire.API.Routes.Internal.LegalHold
       Wire.API.Routes.MultiTablePaging
       Wire.API.Routes.MultiTablePaging.State
       Wire.API.Routes.MultiVerb

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -49,6 +49,7 @@ library
       Wire.API.Routes.Internal.Brig
       Wire.API.Routes.Internal.Brig.Connection
       Wire.API.Routes.Internal.Brig.EJPD
+      Wire.API.Routes.Internal.Cargohold
       Wire.API.Routes.Internal.LegalHold
       Wire.API.Routes.MultiTablePaging
       Wire.API.Routes.MultiTablePaging.State

--- a/services/cargohold/src/CargoHold/API/Public.hs
+++ b/services/cargohold/src/CargoHold/API/Public.hs
@@ -15,7 +15,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module CargoHold.API.Public (servantSitemap) where
+module CargoHold.API.Public (servantSitemap, internalSitemap) where
 
 import qualified CargoHold.API.Legacy as LegacyAPI
 import CargoHold.API.Util
@@ -36,17 +36,18 @@ import Servant.Server hiding (Handler)
 import URI.ByteString
 import Wire.API.Asset
 import Wire.API.Routes.AssetBody
+import Wire.API.Routes.Internal.Cargohold
 import Wire.API.Routes.Public.Cargohold
 
 servantSitemap :: ServerT ServantAPI Handler
 servantSitemap =
-  renewTokenV3 :<|> deleteTokenV3
+  renewTokenV3
+    :<|> deleteTokenV3
     :<|> userAPI
     :<|> botAPI
     :<|> providerAPI
     :<|> qualifiedAPI
     :<|> legacyAPI
-    :<|> internalAPI
   where
     userAPI :: forall tag. tag ~ 'UserPrincipalTag => ServerT (BaseAPIv3 tag) Handler
     userAPI = uploadAssetV3 @tag :<|> downloadAssetV3 @tag :<|> deleteAssetV3 @tag
@@ -56,7 +57,9 @@ servantSitemap =
     providerAPI = uploadAssetV3 @tag :<|> downloadAssetV3 @tag :<|> deleteAssetV3 @tag
     legacyAPI = legacyDownloadPlain :<|> legacyDownloadPlain :<|> legacyDownloadOtr
     qualifiedAPI = downloadAssetV4 :<|> deleteAssetV4
-    internalAPI = pure ()
+
+internalSitemap :: ServerT InternalAPI Handler
+internalSitemap = pure ()
 
 class HasLocation (tag :: PrincipalTag) where
   assetLocation :: Local AssetKey -> [Text]

--- a/services/cargohold/src/CargoHold/Run.hs
+++ b/services/cargohold/src/CargoHold/Run.hs
@@ -44,9 +44,10 @@ import qualified Servant
 import Servant.API
 import Servant.Server hiding (Handler, runHandler)
 import Util.Options
-import qualified Wire.API.Routes.Public.Cargohold as Public
+import Wire.API.Routes.Internal.Cargohold
+import Wire.API.Routes.Public.Cargohold
 
-type CombinedAPI = FederationAPI :<|> Public.ServantAPI
+type CombinedAPI = FederationAPI :<|> ServantAPI :<|> InternalAPI
 
 run :: Opts -> IO ()
 run o = lowerCodensity $ do
@@ -77,7 +78,8 @@ mkApp o = Codensity $ \k ->
             (Proxy @CombinedAPI)
             ((o ^. optSettings . setFederationDomain) :. Servant.EmptyContext)
             ( hoistServer' @FederationAPI (toServantHandler e) federationSitemap
-                :<|> hoistServer' @Public.ServantAPI (toServantHandler e) servantSitemap
+                :<|> hoistServer' @ServantAPI (toServantHandler e) servantSitemap
+                :<|> hoistServer' @InternalAPI (toServantHandler e) internalSitemap
             )
             r
 

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -22,7 +22,7 @@ module Galley.API
 where
 
 import qualified Data.Swagger.Build.Api as Doc
-import qualified Galley.API.Internal as Internal
+import Galley.API.Internal
 import qualified Galley.API.Public as Public
 import Galley.API.Public.Servant
 import Galley.App (GalleyEffects)
@@ -33,4 +33,4 @@ sitemap :: Routes Doc.ApiBuilder (Sem GalleyEffects) ()
 sitemap = do
   Public.sitemap
   Public.apiDocs
-  Internal.sitemap
+  internalSitemap

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -38,7 +38,7 @@ import Data.String.Conversions (cs)
 import Data.Text (unpack)
 import qualified Galley.API as API
 import Galley.API.Federation (FederationAPI, federationSitemap)
-import qualified Galley.API.Internal as Internal
+import Galley.API.Internal
 import Galley.App
 import qualified Galley.App as App
 import Galley.Cassandra
@@ -68,7 +68,7 @@ run o = do
         (portNumber $ fromIntegral $ o ^. optGalley . epPort)
         l
         (e ^. monitor)
-  deleteQueueThread <- Async.async $ runApp e Internal.deleteLoop
+  deleteQueueThread <- Async.async $ runApp e deleteLoop
   refreshMetricsThread <- Async.async $ runApp e refreshMetrics
   runSettingsWithShutdown s app 5 `finally` do
     Async.cancel deleteQueueThread
@@ -106,7 +106,7 @@ mkApp o = do
                 :. Servant.EmptyContext
             )
             ( hoistServer' @GalleyAPI.ServantAPI (toServantHandler e) API.servantSitemap
-                :<|> hoistServer' @Internal.ServantAPI (toServantHandler e) Internal.servantSitemap
+                :<|> hoistServer' @InternalAPI (toServantHandler e) internalAPI
                 :<|> hoistServer' @FederationAPI (toServantHandler e) federationSitemap
                 :<|> Servant.Tagged (app e)
             )
@@ -152,7 +152,7 @@ bodyParserErrorFormatter' _ _ errMsg =
 
 type CombinedAPI =
   GalleyAPI.ServantAPI
-    :<|> Internal.ServantAPI
+    :<|> InternalAPI
     :<|> FederationAPI
     :<|> Servant.Raw
 
@@ -160,7 +160,7 @@ refreshMetrics :: App ()
 refreshMetrics = do
   m <- view monitor
   q <- view deleteQueue
-  Internal.safeForever "refreshMetrics" $ do
+  safeForever "refreshMetrics" $ do
     n <- Q.len q
     M.gaugeSet (fromIntegral n) (M.path "galley.deletequeue.len") m
     threadDelay 1000000


### PR DESCRIPTION
This moves internal endpoints to the `Internal` module hierarchy in `wire-api`, so that they are not included in the generated Swagger, and removes usages of servant-generic from Galley's internal API.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
