### PR TITLE
Stay consistent with #2079

### DIFF
--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -18,7 +18,7 @@ cassandra-migrations:
   imagePullPolicy: {{ .Values.imagePullPolicy }}
   cassandra:
     host: cassandra-ephemeral
-    replicaCount: 1
+    replicationFactor: 1
 elasticsearch-index:
   imagePullPolicy: {{ .Values.imagePullPolicy }}
   elasticsearch:


### PR DESCRIPTION
Follow-up to #2079. Just for cleanup, old and new parameter works as #2079 has a fallback to 'replicaCount', but going forward replicationFactor is the better naming.