### PR TITLE
refactor: Change TSFI's for BSI Testmapping

### DIFF
--- a/libs/zauth/test/ZAuth.hs
+++ b/libs/zauth/test/ZAuth.hs
@@ -94,7 +94,7 @@ testNotExpired p = do
   liftIO $ assertBool "testNotExpired: validation failed" (isRight x)
 
 -- The testExpired test conforms to the following testing standards:
--- @SF.Channel @TSFI.RESTfulAPI @S2 @S3
+-- @SF.Channel @TSFI.RESTfulAPI @TSFI.NTP @S2 @S3
 --
 -- Using an expired access token should fail
 testExpired :: V.Env -> Create ()

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -402,7 +402,7 @@ testThrottleLogins conf b = do
   login b (defEmailLogin e) SessionCookie !!! const 200 === statusCode
 
 -- The testLimitRetries test conforms to the following testing standards:
--- @SF.Channel @TSFI.RESTfulAPI @S2
+-- @SF.Channel @TSFI.RESTfulAPI @TSFI.NTP @S2
 --
 -- The following test tests the login retries. It checks that a user can make
 -- only a prespecified number of attempts to log in with an invalid password,
@@ -585,7 +585,7 @@ testNoUserSsoLogin brig = do
 -- Token Refresh
 
 -- The testInvalidCookie test conforms to the following testing standards:
--- @SF.Provisioning @TSFI.RESTfulAPI @S2
+-- @SF.Provisioning @TSFI.RESTfulAPI @TSFI.NTP @S2
 --
 -- Test that invalid and expired tokens do not work.
 testInvalidCookie :: forall u. ZAuth.UserTokenLike u => ZAuth.Env -> Brig -> Http ()

--- a/services/federator/test/unit/Test/Federator/InternalServer.hs
+++ b/services/federator/test/unit/Test/Federator/InternalServer.hs
@@ -100,7 +100,7 @@ federatedRequestSuccess =
     body <- Wai.lazyResponseBody res
     body @?= "\"bar\""
 
--- @SF.Federation @TSFI.RESTfulAPI @S2 @S3 @S7
+-- @SF.Federation @TSFI.Federate @TSFI.DNS @S2 @S3 @S7
 --
 -- Refuse to send outgoing request to non-included domain when allowlist is configured.
 federatedRequestFailureAllowList :: TestTree

--- a/services/federator/test/unit/Test/Federator/Options.hs
+++ b/services/federator/test/unit/Test/Federator/Options.hs
@@ -171,7 +171,7 @@ testSettings =
             assertFailure $
               "expected failure for non-existing client certificate, got: "
                 <> show (tlsSettings ^. creds),
-      -- @SF.Federation @TSFI.RESTfulAPI @S3 @S7
+      -- @SF.Federation @TSFI.Federate @S3 @S7
       testCase "failToStartWithInvalidServerCredentials" $ do
         let settings =
               defRunSettings

--- a/services/federator/test/unit/Test/Federator/Remote.hs
+++ b/services/federator/test/unit/Test/Federator/Remote.hs
@@ -120,7 +120,7 @@ testValidatesCertificateSuccess =
             Right _ -> assertFailure "Congratulations, you fixed a known issue!"
     ]
 
--- @SF.Federation @TSFI.RESTfulAPI @S2
+-- @SF.Federation @TSFI.Federate @TSFI.DNS @S2
 --
 -- This is a group of test cases where refusing to connect with the server is
 -- checked. The second test case refuses to connect with a server when the

--- a/services/federator/test/unit/Test/Federator/Validation.hs
+++ b/services/federator/test/unit/Test/Federator/Validation.hs
@@ -117,7 +117,7 @@ validateDomainAllowListFailSemantic =
         $ validateDomain (Just exampleCert) "invalid//.><-semantic-&@-domain"
     res @?= Left (DomainParseError "invalid//.><-semantic-&@-domain")
 
--- @SF.Federation @TSFI.RESTfulAPI @S2 @S3 @S7
+-- @SF.Federation @TSFI.Federate @TSFI.DNS @S2 @S3 @S7
 --
 -- Refuse to send outgoing request to non-included domain when allowlist is configured.
 validateDomainAllowListFail :: TestTree
@@ -162,7 +162,7 @@ validateDomainCertMissing =
         $ validateDomain Nothing "foo.example.com"
     res @?= Left NoClientCertificate
 
--- @SF.Federation @TSFI.RESTfulAPI @S2 @S3 @S7
+-- @SF.Federation @TSFI.Federate @TSFI.DNS @S2 @S3 @S7
 validateDomainCertInvalid :: TestTree
 validateDomainCertInvalid =
   testCase "should fail if the client certificate is invalid" $ do
@@ -176,7 +176,7 @@ validateDomainCertInvalid =
 
 -- @END
 
--- @SF.Federation @TSFI.RESTfulAPI @S3 @S7
+-- @SF.Federation @TSFI.Federate @TSFI.DNS @S3 @S7
 --
 -- Reject request if the infrastructure domain in the client cert does not match the backend
 -- domain in the `Wire-origin-domain` header.


### PR DESCRIPTION
# What's new in this PR?

### Issues

The TSFI's have changed for our BSI test-documentation. Because of this, we need to update the tags of some of the BSI testcases.

### Solutions

Updated the TSFI tags to the new values provided by atsec.
