### PR TITLE
Fix compilation errors in Spar modules

### DIFF
--- a/changelog.d/5-internal/fix-pr-2070-compilation
+++ b/changelog.d/5-internal/fix-pr-2070-compilation
@@ -1,0 +1,1 @@
+Remove non-existing functions from module export lists

--- a/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/AReqIDStore/Cassandra.hs
@@ -17,7 +17,6 @@
 
 module Spar.Sem.AReqIDStore.Cassandra
   ( aReqIDStoreToCassandra,
-    ttlErrorToSparError,
   )
 where
 

--- a/services/spar/src/Spar/Sem/SAMLUserStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/SAMLUserStore/Cassandra.hs
@@ -19,7 +19,6 @@
 
 module Spar.Sem.SAMLUserStore.Cassandra
   ( samlUserStoreToCassandra,
-    interpretClientToIO,
   )
 where
 


### PR DESCRIPTION
PR #2070 made export lists explicit, but some functions are non-existent, leading to compilation errors. This PR removes such problematic exports.

Somehow PR #2070 does not have a CI section on its page at https://github.com/wireapp/wire-server/pull/2070. It is possible the CI did not run for that PR. This might be due to our changes to the CI infrastructure that have been happening.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
