### PR TITLE
Brig: Delete `GET /self/name` endpoint

### DIFF
--- a/changelog.d/1-api-changes/delete-self-name
+++ b/changelog.d/1-api-changes/delete-self-name
@@ -1,0 +1,1 @@
+Delete `GET /self/name` endpoint

--- a/libs/wire-api/src/Wire/API/Swagger.hs
+++ b/libs/wire-api/src/Wire/API/Swagger.hs
@@ -168,7 +168,6 @@ models =
     User.Handle.modelCheckHandles,
     User.Password.modelNewPasswordReset,
     User.Password.modelCompletePasswordReset,
-    User.Profile.modelUserDisplayName,
     User.Profile.modelAsset,
     User.RichInfo.modelRichInfo,
     User.RichInfo.modelRichField,

--- a/libs/wire-api/src/Wire/API/User/Profile.hs
+++ b/libs/wire-api/src/Wire/API/User/Profile.hs
@@ -48,7 +48,6 @@ module Wire.API.User.Profile
     noPict,
 
     -- * Swagger
-    modelUserDisplayName,
     modelAsset,
     typeManagedBy,
   )
@@ -88,12 +87,6 @@ newtype Name = Name
 
 mkName :: Text -> Either String Name
 mkName txt = Name . fromRange <$> checkedEitherMsg @_ @1 @128 "Name" txt
-
-modelUserDisplayName :: Doc.Model
-modelUserDisplayName = Doc.defineModel "UserDisplayName" $ do
-  Doc.description "User name"
-  Doc.property "name" Doc.string' $
-    Doc.description "User name"
 
 instance ToSchema Name where
   schema = Name <$> fromName .= untypedRangedSchema 1 128 schema

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -261,18 +261,6 @@ sitemap = do
     Doc.response 200 "RichInfo" Doc.end
     Doc.errorResponse insufficientTeamPermissions
 
-  -- User Self API ------------------------------------------------------
-
-  get "/self/name" (continue getUserDisplayNameH) $
-    accept "application" "json"
-      .&. zauthUserId
-  document "GET" "selfName" $ do
-    Doc.summary "Get your profile name"
-    Doc.returns (Doc.ref Public.modelUserDisplayName)
-    Doc.response 200 "Profile name found." Doc.end
-
-  -- TODO put  where?
-
   -- This endpoint can lead to the following events being sent:
   -- UserDeleted event to contacts of deleted user
   -- MemberLeave event to members for all conversations the user was in (via galley)
@@ -755,13 +743,6 @@ getUser :: UserId -> Qualified UserId -> Handler (Maybe Public.UserProfile)
 getUser self qualifiedUserId = do
   lself <- qualifyLocal self
   API.lookupProfile lself qualifiedUserId !>> fedError
-
-getUserDisplayNameH :: JSON ::: UserId -> Handler Response
-getUserDisplayNameH (_ ::: self) = do
-  name :: Maybe Public.Name <- lift $ API.lookupName self
-  return $ case name of
-    Just n -> json $ object ["name" .= n]
-    Nothing -> setStatus status404 empty
 
 -- FUTUREWORK: Make servant understand that at least one of these is required
 listUsersByUnqualifiedIdsOrHandles :: UserId -> Maybe (CommaSeparatedList UserId) -> Maybe (Range 1 4 (CommaSeparatedList Handle)) -> Handler [Public.UserProfile]

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -850,14 +850,6 @@ testUserUpdate brig cannon aws = do
               )
           )
         . responseJsonMaybe
-  -- get only the new name
-  get (brig . path "/self/name" . zUser alice) !!! do
-    const 200 === statusCode
-    const (String . fromName <$> mNewName)
-      === ( \r -> do
-              b <- responseBody r
-              b ^? key "name"
-          )
   -- should appear in search by 'newName'
   suid <- userId <$> randomUser brig
   Search.refreshIndex brig


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQCORE-1167

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.