### PR TITLE
Make RespondEmpty responses show up without a schema in swagger

### DIFF
--- a/changelog.d/3-bug-fixes/fix-respond-empty-swagger
+++ b/changelog.d/3-bug-fixes/fix-respond-empty-swagger
@@ -1,0 +1,1 @@
+Ensure empty responses show up without a schema in swagger. They were shown as empty arrays before.

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -196,7 +196,7 @@ simpleResponseSwagger = do
       & S.schema ?~ ref
 
 instance
-  (KnownStatus s, KnownSymbol desc, S.ToSchema a) =>
+  (KnownSymbol desc, S.ToSchema a) =>
   IsSwaggerResponse (Respond s desc a)
   where
   responseSwagger = simpleResponseSwagger @a @desc
@@ -244,10 +244,19 @@ instance KnownStatus s => IsResponse cs (RespondAs '() s desc ()) where
     guard (responseStatusCode output == statusVal (Proxy @s))
 
 instance
-  (KnownStatus s, KnownSymbol desc, S.ToSchema a) =>
-  IsSwaggerResponse (RespondAs ct s desc a)
+  (KnownSymbol desc, S.ToSchema a) =>
+  IsSwaggerResponse (RespondAs (ct :: *) s desc a)
   where
   responseSwagger = simpleResponseSwagger @a @desc
+
+instance
+  (KnownSymbol desc) =>
+  IsSwaggerResponse (RespondEmpty s desc)
+  where
+  responseSwagger =
+    pure $
+      mempty
+        & S.description .~ Text.pack (symbolVal (Proxy @desc))
 
 type instance ResponseType (RespondStreaming s desc framing ct) = SourceIO ByteString
 


### PR DESCRIPTION
They appeared as empty arrays, which is the schema for the unit type.

Before this fix:
![image](https://user-images.githubusercontent.com/649161/152759276-f0bd7048-39c4-4176-afa2-302786bd7983.png)

After this fix:
![image](https://user-images.githubusercontent.com/649161/152759358-479b4733-36dc-4523-8efb-a51bff0c8fca.png)


## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.