### PR TITLE
Wrap stack with NIX_BUILD_SHELL set to LD_LIBRARY_PATH compatible shell

### DIFF
--- a/changelog.d/5-internal/nix-fix-build-shell
+++ b/changelog.d/5-internal/nix-fix-build-shell
@@ -1,0 +1,1 @@
+Wrap stack with NIX_BUILD_SHELL set to LD_LIBRARY_PATH compatible shell

--- a/dev-packages.nix
+++ b/dev-packages.nix
@@ -162,6 +162,14 @@ let
     export CONFIG_SHELL="${compile-deps}/bin/sh"
     exec "${pkgs.cabal-install}/bin/cabal" "$@"
   '';
+
+  # stack-deps.nix sets LD_LIBRARY_PATH, which could be incompatible with the
+  # system bash. To ensure that nix-shell invoked by stack uses the correct
+  # shell to build we set NIX_BUILD_SHELL here.
+  stack-wrapper = pkgs.writeShellScriptBin "stack" ''
+    export NIX_BUILD_SHELL="${pkgs.bash}/bin/bash"
+    exec "${pinned.stack}/bin/stack" "$@"
+  '';
 in
 [
   pkgs.cfssl
@@ -179,7 +187,7 @@ in
   # To actually run buildah on nixos, I had to follow this: https://gist.github.com/alexhrescale/474d55635154e6b2cd6362c3bb403faf
   pkgs.buildah
 
-  pinned.stack
+  stack-wrapper
   pinned.helm
   pinned.helmfile
   pinned.kubectl


### PR DESCRIPTION
On some machines running `stack` from `direnv.nix` can lead to this error:

```
bash: /nix/store/xg6ilb9g9zhi2zg1dpi4zcp288rhnvns-glibc-2.30/lib/libc.so.6:
version `GLIBC_2.33' not found
(required by /nix/store/h22cdxm1252slxvb3qyfx1lnn85x5f0c-ncurses-6.2/lib/libncursesw.so.6)
```

This PR fixes this. See changes to [dev-packages.nix](https://github.com/wireapp/wire-server/pull/2105/files#diff-d3ac13b146a2d4234dbb2ef3d3f313425b08d8bd55be7df954820f6b9fcc8e9d) for details.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. 
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):