### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,0 +1,1 @@
+Upgrade webapp version to 2022-02-07-production.0-v0.29.2-0-a940a2e

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2022-01-27-production.0-v0.28.29-0-42c9a1e"
+  tag: "2022-02-07-production.0-v0.29.2-0-a940a2e"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2022-02-07-production.0-v0.29.2-0-a940a2e`
Release: [`2022-02-07-production.0`](https://github.com/wireapp/wire-webapp/releases/tag/2022-02-07-production.0)