### PR TITLE
Prometheus: Exclude ResponseRaw responses from metrics

### DIFF
--- a/changelog.d/5-internal/prometheus-ignore-raw-responses
+++ b/changelog.d/5-internal/prometheus-ignore-raw-responses
@@ -1,0 +1,1 @@
+Prometheus: Ignore RawResponses (e.g. cannon's await responses) from metrics


### PR DESCRIPTION
This PR makes the `servantPrometheusMiddleware` ignore all `ResponseRaw` responses. The implementation of wai and prometheus lead to `ResponseRaw` being tracked with `statusCode` `500` irrespective if the handler was successful or not (see documentation of `wai-middleware-prometheus`'s `ignoreRawResponses` or note `[Raw Response]` in the codebase).

This would remove all metrics for these endpoints, however looking at `observeSeconds` of `wai-middleware-prometheus` suggests that the status is optional, so maybe reporting duration without status is possible.

This PR is a followup to https://github.com/wireapp/wire-server/pull/2081 which lead to `cannon`'s `"await-notifications"` endpoint erroneously reporting 500s metrics.

This will also affect future potential future endpoints in `spar` and `carghold` as they also use `servantPrometheusMiddleware`.