### PR TITLE
Update team-settings version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/team-settings-upgrade
+++ b/changelog.d/0-release-notes/team-settings-upgrade
@@ -1,1 +1,1 @@
-Upgrade team-settings version to 4.6.0-v0.29.3-0-4d9c229
+Upgrade team-settings version to 4.6.1-v0.29.3-0-28cbbd7

--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/team-settings
-  tag: "4.6.0-v0.29.3-0-4d9c229"
+  tag: "4.6.1-v0.29.3-0-28cbbd7"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `4.6.1-v0.29.3-0-28cbbd7`
Release: [`v4.6.1`](https://github.com/wireapp/wire-team-settings/releases/tag/v4.6.1)