### PR TITLE
Update SFTd to version 3.0.18

### DIFF
--- a/changelog.d/6-federation/PR-2113
+++ b/changelog.d/6-federation/PR-2113
@@ -1,0 +1,2 @@
+Updated sftd to 3.0.18.
+Updated restund to 0.5.1.

--- a/charts/restund/Chart.yaml
+++ b/charts/restund/Chart.yaml
@@ -11,4 +11,4 @@ version: 0.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.4.17
+appVersion: 0.5.1

--- a/charts/sftd/Chart.yaml
+++ b/charts/sftd/Chart.yaml
@@ -11,4 +11,4 @@ version: 0.0.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.1.19
+appVersion: 3.0.18


### PR DESCRIPTION
In the M2 release, we should have included the tested SFT version 3.0.18 with Federation features, instead of the previous release 2.1.19. Jira ticket is FS-445

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
 - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
 - [x] If new config options introduced: added usage description under docs/reference/config-options.md
 - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
 - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
 - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
 - [x] If public end-points have been changed or added: does nginz need un upgrade?
 - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
