### PR TITLE
Minimal client API versioning

### DIFF
--- a/changelog.d/0-release-notes/api-version-prefix
+++ b/changelog.d/0-release-notes/api-version-prefix
@@ -1,0 +1,1 @@
+For wire.com operators: to enable versioned API paths, make sure that nginz is deployed.

--- a/changelog.d/1-api-changes/api-version-endpoint
+++ b/changelog.d/1-api-changes/api-version-endpoint
@@ -1,0 +1,1 @@
+Added minimal API version support: a list of supported API versions can be found at the endpoint `GET /api-version`. Versions can be selected by adding a prefix of the form `/vN` to every route, where `N` is the desired version number (so for example `/v1/conversations` to access version 1 of the `/conversations` endpoint).

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -207,7 +207,7 @@ http {
     }
 
     {{ range $path := .Values.nginx_conf.disabled_paths }}
-      location {{ $path }} {
+      location ~* ^(/v[0-9]+)?{{ $path }} {
 
         return 404;
       }
@@ -227,7 +227,10 @@ http {
     rewrite ^/api-docs{{ $location.path }}  {{ $location.path }}/api-docs?base_url=https://{{ $.Values.nginx_conf.env }}-nginz-https.{{ $.Values.nginx_conf.external_env_domain }}/ break;
             {{- end }}
 
-    location {{ $location.path }} {
+    {{- $versioned := ternary $location.versioned true (hasKey $location "versioned") -}}
+    {{- $path := printf "%s%s" (ternary "(/v[0-9]+)?" "" $versioned) $location.path }}
+
+    location ~* ^{{ $path }} {
 
         # remove access_token from logs, see 'Note sanitized_request' above.
         set $sanitized_request $request;

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -43,13 +43,13 @@ nginx_conf:
   #   title: "Production"
   disabled_paths:
   - /conversations/last-events
-  - ~* ^/conversations/([^/]*)/knock
-  - ~* ^/conversations/([^/]*)/hot-knock
-  - ~* ^/conversations/([^/]*)/messages
-  - ~* ^/conversations/([^/]*)/client-messages
-  - ~* ^/conversations/([^/]*)/events
-  - ~* ^/conversations/([^/]*)/call
-  - ~* ^/conversations/([^/]*)/call/state
+  - /conversations/([^/]*)/knock
+  - /conversations/([^/]*)/hot-knock
+  - /conversations/([^/]*)/messages
+  - /conversations/([^/]*)/client-messages
+  - /conversations/([^/]*)/events
+  - /conversations/([^/]*)/call
+  - /conversations/([^/]*)/call/state
   - /search/top
   - /search/common
   # -- The origins from which we allow CORS requests. These are combined with 'external_env_domain' to form a full url
@@ -59,12 +59,12 @@ nginx_conf:
     - account
   upstreams:
     cargohold:
-    - path: ~* ^/conversations/([^/]*)/assets
+    - path: /conversations/([^/]*)/assets
       envs:
       - all
       max_body_size: "0"
       disable_request_buffering: true
-    - path: ~* ^/conversations/([^/]*)/otr/assets
+    - path: /conversations/([^/]*)/otr/assets
       envs:
       - all
       max_body_size: "0"
@@ -96,7 +96,7 @@ nginx_conf:
     - path: /list-users
       envs:
       - all
-    - path: ~* ^/api/swagger.json$
+    - path: /api/swagger.json$
       disable_zauth: true
       envs:
       - all
@@ -110,7 +110,7 @@ nginx_conf:
     - path: /connections
       envs:
       - all
-    - path: ~* ^/list-connections$
+    - path: /list-connections$
       envs:
       - all
     - path: /invitations
@@ -162,7 +162,7 @@ nginx_conf:
     - path: /bot/users
       envs:
       - all
-    - path: ~* ^/conversations/([^/]*)/bots
+    - path: /conversations/([^/]*)/bots
       envs:
       - all
     - path: /invitations/info
@@ -196,41 +196,49 @@ nginx_conf:
       - staging
       disable_zauth: true
       basic_auth: true
+      versioned: false
     - path: /i/users/login-code
       envs:
       - staging
       disable_zauth: true
       basic_auth: true
+      versioned: false
     - path: /i/users/invitation-code
       envs:
       - staging
       disable_zauth: true
       basic_auth: true
-    - path: ~* ^/i/users/([^/]*)/rich-info
+      versioned: false
+    - path: /i/users/([^/]*)/rich-info
       envs:
       - staging
       disable_zauth: true
       basic_auth: true
-    - path: ~* ^/i/teams/([^/]*)/suspend
+      versioned: false
+    - path: /i/teams/([^/]*)/suspend
       envs:
       - staging
       disable_zauth: true
       basic_auth: true
-    - path: ~* ^/i/teams/([^/]*)/unsuspend
+      versioned: false
+    - path: /i/teams/([^/]*)/unsuspend
       envs:
       - staging
       disable_zauth: true
       basic_auth: true
+      versioned: false
     - path: /i/provider/activation-code
       envs:
       - staging
       disable_zauth: true
       basic_auth: true
-    - path: ~* ^/i/legalhold/whitelisted-teams(.*)
+      versioned: false
+    - path: /i/legalhold/whitelisted-teams(.*)
       envs:
         - staging
       disable_zauth: true
       basic_auth: true
+      versioned: false
     - path: /cookies
       envs:
       - all
@@ -253,17 +261,17 @@ nginx_conf:
     - path: /search
       envs:
       - all
-    - path: ~* ^/teams/([^/]*)/invitations(.*)
+    - path: /teams/([^/]*)/invitations(.*)
       envs:
       - all
-    - path: ~* ^/teams/([^/]*)/services(.*)
+    - path: /teams/([^/]*)/services(.*)
       envs:
       - all
-    - path: ~* ^/teams/invitations/info$
+    - path: /teams/invitations/info$
       envs:
       - all
       disable_zauth: true
-    - path: ~* ^/teams/invitations/by-email$
+    - path: /teams/invitations/by-email$
       envs:
       - all
       disable_zauth: true
@@ -272,13 +280,14 @@ nginx_conf:
       - staging
       disable_zauth: true
       basic_auth: true
+      versioned: false
     - path: /calls
       envs:
       - all
-    - path: ~* ^/teams/([^/]*)/size$
+    - path: /teams/([^/]*)/size$
       envs:
       - all
-    - path: ~* ^/teams/([^/]*)/search$
+    - path: /teams/([^/]*)/search$
       envs:
       - all
     - path: /verification-code/send
@@ -290,12 +299,12 @@ nginx_conf:
       disable_zauth: true
       envs:
       - all
-    - path: ~* ^/conversations/([^/]*)/otr/messages
+    - path: /conversations/([^/]*)/otr/messages
       envs:
       - all
       max_body_size: 40m
       body_buffer_size: 256k
-    - path: ~* ^/conversations/([^/]*)/([^/]*)/proteus/messages
+    - path: /conversations/([^/]*)/([^/]*)/proteus/messages
       envs:
       - all
       max_body_size: 40m
@@ -317,57 +326,60 @@ nginx_conf:
       envs:
       - all
       doc: true
-    - path: ~* ^/teams$
+    - path: /teams$
       envs:
       - all
-    - path: ~* ^/teams/([^/]*)$
+    - path: /teams/([^/]*)$
       envs:
       - all
-    - path: ~* ^/teams/([^/]*)/members(.*)
+    - path: /teams/([^/]*)/members(.*)
       envs:
       - all
-    - path: ~* ^/teams/([^/]*)/get-members-by-ids-using-post(.*)
+    - path: /teams/([^/]*)/get-members-by-ids-using-post(.*)
       envs:
       - all
-    - path: ~* ^/teams/([^/]*)/conversations(.*)
+    - path: /teams/([^/]*)/conversations(.*)
       envs:
       - all
-    - path: ~* ^/teams/([^/]*)/members/csv$
+    - path: /teams/([^/]*)/members/csv$
       envs:
       - all
-    - path: ~* ^/teams/([^/]*)/legalhold(.*)
+    - path: /teams/([^/]*)/legalhold(.*)
       envs:
       - all
-    - path: ~* ^/i/teams/([^/]*)/legalhold(.*)
+    - path: /i/teams/([^/]*)/legalhold(.*)
       envs:
       - staging
       disable_zauth: true
       basic_auth: true
-    - path: ~* ^/custom-backend/by-domain/([^/]*)$
+      versioned: false
+    - path: /custom-backend/by-domain/([^/]*)$
       disable_zauth: true
       envs:
       - all
-    - path: ~* ^/i/custom-backend/by-domain/([^/]*)$
+    - path: /i/custom-backend/by-domain/([^/]*)$
       disable_zauth: true
       basic_auth: true
       envs:
       - staging
-    - path: ~* ^/teams/api-docs
+      versioned: false
+    - path: /teams/api-docs
       envs:
       - all
       disable_zauth: true
-    - path: ~* ^/teams/([^/]*)/features
+    - path: /teams/([^/]*)/features
       envs:
       - all
-    - path: ~* ^/teams/([^/]*)/features/([^/])*
+    - path: /teams/([^/]*)/features/([^/])*
       envs:
       - all
-    - path: ~* /i/teams/([^/]*)/features/([^/]*)
+    - path: /i/teams/([^/]*)/features/([^/]*)
       envs:
       - staging
       disable_zauth: true
       basic_auth: true
-    - path: ~* ^/feature-configs(.*)
+      versioned: false
+    - path: /feature-configs(.*)
       envs:
       - all
     - path: /galley-api/swagger-ui
@@ -395,6 +407,7 @@ nginx_conf:
       basic_auth: true
       envs:
       - staging
+      versioned: false
     - path: /sso-initiate-bind
       envs:
       - all
@@ -436,7 +449,7 @@ nginx_conf:
       envs:
       - all
       disable_zauth: true
-    - path: ~* ^/teams/([^/]*)/billing(.*)
+    - path: /teams/([^/]*)/billing(.*)
       envs:
       - all
     calling-test:

--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -90,6 +90,7 @@ library:
   - wire-message-proto-lens
   - x509
   - wai
+  - wai-utilities
   - wai-websockets
   - websockets
 

--- a/libs/wire-api/package.yaml
+++ b/libs/wire-api/package.yaml
@@ -90,6 +90,7 @@ library:
   - wire-message-proto-lens
   - x509
   - wai
+  - wai-extra
   - wai-utilities
   - wai-websockets
   - websockets

--- a/libs/wire-api/src/Wire/API/Routes/Version.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Version.hs
@@ -1,0 +1,64 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Routes.Version where
+
+import Control.Lens ((?~))
+import Data.Aeson (FromJSON, ToJSON (..))
+import Data.Schema
+import qualified Data.Swagger as S
+import Imports
+import Servant
+import Servant.Swagger
+import Wire.API.Routes.Named
+import Wire.API.VersionInfo
+
+data Version = V0 | V1
+  deriving stock (Eq, Ord, Bounded, Enum, Show)
+
+instance ToSchema Version where
+  schema =
+    enum @Integer "Version" . mconcat $
+      [ element 0 V0,
+        element 1 V1
+      ]
+
+supportedVersions :: [Version]
+supportedVersions = [minBound .. maxBound]
+
+newtype VersionInfo = VersionInfo {vinfoSupported :: [Version]}
+  deriving (FromJSON, ToJSON, S.ToSchema) via (Schema VersionInfo)
+
+instance ToSchema VersionInfo where
+  schema =
+    (S.schema . S.example ?~ toJSON (VersionInfo supportedVersions))
+      (VersionInfo <$> vinfoSupported .= vinfoSchema schema)
+
+type VersionAPI =
+  Named
+    "get-version"
+    ( "api-version"
+        :> Get '[JSON] VersionInfo
+    )
+
+versionAPI :: Applicative m => ServerT VersionAPI m
+versionAPI =
+  Named @"get-version" $
+    pure . VersionInfo $ supportedVersions
+
+versionSwagger :: S.Swagger
+versionSwagger = toSwagger (Proxy @VersionAPI)

--- a/libs/wire-api/src/Wire/API/Routes/Version/Wai.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Version/Wai.hs
@@ -1,0 +1,46 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Routes.Version.Wai where
+
+import qualified Data.Text.Lazy as LText
+import Imports
+import qualified Network.HTTP.Types as HTTP
+import Network.Wai
+import Network.Wai.Utilities.Error
+import Network.Wai.Utilities.Response
+import Wire.API.Routes.Version
+
+-- | Strip off version prefix. Return 404 if the version is not supported.
+versionMiddleware :: Middleware
+versionMiddleware app req k = case parseVersion req of
+  Nothing -> app req k
+  Just (req', n) -> case mkVersion n of
+    Just _ -> app req' k
+    Nothing ->
+      k $
+        errorRs' $
+          mkError HTTP.status404 "unsupported-version" $
+            "Version " <> LText.pack (show n) <> " is not supported"
+
+parseVersion :: Request -> Maybe (Request, Integer)
+parseVersion req = do
+  (version, pinfo) <- case pathInfo req of
+    [] -> Nothing
+    (x : xs) -> pure (x, xs)
+  n <- readVersionNumber version
+  pure $ (req {pathInfo = pinfo}, n)

--- a/libs/wire-api/src/Wire/API/Routes/Version/Wai.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Version/Wai.hs
@@ -21,6 +21,7 @@ import qualified Data.Text.Lazy as LText
 import Imports
 import qualified Network.HTTP.Types as HTTP
 import Network.Wai
+import Network.Wai.Middleware.Rewrite
 import Network.Wai.Utilities.Error
 import Network.Wai.Utilities.Response
 import Wire.API.Routes.Version
@@ -43,4 +44,4 @@ parseVersion req = do
     [] -> Nothing
     (x : xs) -> pure (x, xs)
   n <- readVersionNumber version
-  pure $ (req {pathInfo = pinfo}, n)
+  pure (rewriteRequestPure (\(_, q) _ -> (pinfo, q)) req, n)

--- a/libs/wire-api/src/Wire/API/VersionInfo.hs
+++ b/libs/wire-api/src/Wire/API/VersionInfo.hs
@@ -1,0 +1,27 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.VersionInfo
+  ( vinfoSchema,
+  )
+where
+
+import Data.Schema
+import Imports
+
+vinfoSchema :: ValueSchema NamedSwaggerDoc v -> ValueSchema NamedSwaggerDoc [v]
+vinfoSchema sch = object "VersionInfo" $ field "supported" (array sch)

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -65,6 +65,7 @@ library
       Wire.API.Routes.Public.Spar
       Wire.API.Routes.Public.Util
       Wire.API.Routes.QualifiedCapture
+      Wire.API.Routes.Version
       Wire.API.Routes.WebSocket
       Wire.API.ServantProto
       Wire.API.Swagger
@@ -97,6 +98,7 @@ library
       Wire.API.User.Search
       Wire.API.UserMap
       Wire.API.Util.Aeson
+      Wire.API.VersionInfo
       Wire.API.Wrapped
   other-modules:
       Paths_wire_api

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -221,6 +221,7 @@ library
     , uuid >=1.3
     , vector >=0.12
     , wai
+    , wai-extra
     , wai-utilities
     , wai-websockets
     , websockets

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -66,6 +66,7 @@ library
       Wire.API.Routes.Public.Util
       Wire.API.Routes.QualifiedCapture
       Wire.API.Routes.Version
+      Wire.API.Routes.Version.Wai
       Wire.API.Routes.WebSocket
       Wire.API.ServantProto
       Wire.API.Swagger
@@ -220,6 +221,7 @@ library
     , uuid >=1.3
     , vector >=0.12
     , wai
+    , wai-utilities
     , wai-websockets
     , websockets
     , wire-message-proto-lens

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -424,6 +424,7 @@ executable brig-integration
       API.User.RichInfo
       API.User.Util
       API.UserPendingActivation
+      API.Version
       Federation.End2end
       Federation.Util
       Index.Create

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -108,6 +108,7 @@ import qualified Wire.API.Routes.Public.Galley as GalleyAPI
 import qualified Wire.API.Routes.Public.LegalHold as LegalHoldAPI
 import qualified Wire.API.Routes.Public.Spar as SparAPI
 import qualified Wire.API.Routes.Public.Util as Public
+import Wire.API.Routes.Version
 import qualified Wire.API.Swagger as Public.Swagger (models)
 import qualified Wire.API.Team as Public
 import Wire.API.Team.LegalHold (LegalholdProtectee (..))
@@ -130,6 +131,7 @@ swaggerDocsAPI :: Servant.Server SwaggerDocsAPI
 swaggerDocsAPI =
   swaggerSchemaUIServer $
     ( brigSwagger
+        <> versionSwagger
         <> GalleyAPI.swaggerDoc
         <> LegalHoldAPI.swaggerDoc
         <> SparAPI.swaggerDoc

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -70,6 +70,7 @@ import System.Logger.Class (MonadLogger, err)
 import Util.Options
 import Wire.API.Routes.Public.Brig
 import Wire.API.Routes.Version
+import Wire.API.Routes.Version.Wai
 
 -- FUTUREWORK: If any of these async threads die, we will have no clue about it
 -- and brig could start misbehaving. We should ensure that brig dies whenever a
@@ -115,6 +116,7 @@ mkApp o = do
         . GZip.gunzip
         . GZip.gzip GZip.def
         . catchErrors (e ^. applog) [Right $ e ^. metrics]
+        . versionMiddleware
         . lookupRequestIdMiddleware
     app e r k = runHandler e r (Server.route rtree r k) k
 

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -69,6 +69,7 @@ import System.Logger (msg, val, (.=), (~~))
 import System.Logger.Class (MonadLogger, err)
 import Util.Options
 import Wire.API.Routes.Public.Brig
+import Wire.API.Routes.Version
 
 -- FUTUREWORK: If any of these async threads die, we will have no clue about it
 -- and brig could start misbehaving. We should ensure that brig dies whenever a
@@ -127,6 +128,7 @@ mkApp o = do
             :<|> Servant.hoistServer (Proxy @BrigAPI) (toServantHandler e) servantSitemap
             :<|> Servant.hoistServer (Proxy @IAPI.API) (toServantHandler e) IAPI.servantSitemap
             :<|> Servant.hoistServer (Proxy @FederationAPI) (toServantHandler e) federationSitemap
+            :<|> versionAPI
             :<|> Servant.Tagged (app e)
         )
 
@@ -135,6 +137,7 @@ type ServantCombinedAPI =
       :<|> BrigAPI
       :<|> IAPI.API
       :<|> FederationAPI
+      :<|> VersionAPI
       :<|> Servant.Raw
   )
 

--- a/services/brig/test/integration/API/Version.hs
+++ b/services/brig/test/integration/API/Version.hs
@@ -1,0 +1,40 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module API.Version (tests) where
+
+import Bilge
+import Bilge.Assert
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+import Util
+import Wire.API.Routes.Version
+
+tests :: Manager -> Brig -> TestTree
+tests p brig =
+  testGroup
+    "version"
+    [test p "GET /api-version" $ testVersion brig]
+
+testVersion :: Brig -> Http ()
+testVersion brig = do
+  vinfo <-
+    responseJsonError =<< get (brig . path "/api-version")
+      <!! const 200 === statusCode
+  liftIO $
+    vinfoSupported vinfo @?= [V0, V1]

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -31,6 +31,7 @@ import qualified API.Team as Team
 import qualified API.TeamUserSearch as TeamUserSearch
 import qualified API.User as User
 import qualified API.UserPendingActivation as UserPendingActivation
+import qualified API.Version
 import Bilge hiding (header)
 import Brig.API (sitemap)
 import qualified Brig.AWS as AWS
@@ -138,6 +139,7 @@ runTests iConf brigOpts otherArgs = do
   federationEndpoints <- API.Federation.tests mg brigOpts b c fedBrigClient
   includeFederationTests <- (== Just "1") <$> Blank.getEnv "INTEGRATION_FEDERATION_TESTS"
   internalApi <- API.Internal.tests brigOpts mg db b (brig iConf) gd g
+  let versionApi = API.Version.tests mg b
   withArgs otherArgs . defaultMain $
     testGroup
       "Brig API Integration"
@@ -157,7 +159,8 @@ runTests iConf brigOpts otherArgs = do
           userPendingActivation,
           browseTeam,
           federationEndpoints,
-          internalApi
+          internalApi,
+          versionApi
         ]
         <> [federationEnd2End | includeFederationTests]
   where

--- a/services/cannon/src/Cannon/Run.hs
+++ b/services/cannon/src/Cannon/Run.hs
@@ -50,6 +50,7 @@ import qualified System.Logger.Class as LC
 import qualified System.Logger.Extended as L
 import System.Random.MWC (createSystemRandom)
 import Wire.API.Routes.Public.Cannon
+import Wire.API.Routes.Version.Wai
 
 type CombinedAPI = PublicAPI :<|> InternalAPI
 
@@ -74,6 +75,7 @@ run o = do
         servantPrometheusMiddleware (Proxy @CombinedAPI)
           . Gzip.gzip Gzip.def
           . catchErrors g [Right m]
+          . versionMiddleware
       app :: Application
       app = middleware (serve (Proxy @CombinedAPI) server)
       server :: Servant.Server CombinedAPI

--- a/services/cargohold/src/CargoHold/Run.hs
+++ b/services/cargohold/src/CargoHold/Run.hs
@@ -46,6 +46,7 @@ import Servant.Server hiding (Handler, runHandler)
 import Util.Options
 import Wire.API.Routes.Internal.Cargohold
 import Wire.API.Routes.Public.Cargohold
+import Wire.API.Routes.Version.Wai
 
 type CombinedAPI = FederationAPI :<|> ServantAPI :<|> InternalAPI
 
@@ -72,6 +73,7 @@ mkApp o = Codensity $ \k ->
       servantPrometheusMiddleware (Proxy @CombinedAPI)
         . GZip.gzip GZip.def
         . catchErrors (e ^. appLogger) [Right $ e ^. metrics]
+        . versionMiddleware
     servantApp e0 r =
       let e = set requestId (maybe def RequestId (lookupRequestId r)) e0
        in Servant.serveWithContext

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -56,6 +56,7 @@ import Servant hiding (route)
 import qualified System.Logger as Log
 import Util.Options
 import qualified Wire.API.Routes.Public.Galley as GalleyAPI
+import Wire.API.Routes.Version.Wai
 
 run :: Opts -> IO ()
 run o = do
@@ -92,6 +93,7 @@ mkApp o = do
           . GZip.gunzip
           . GZip.gzip GZip.def
           . catchErrors l [Right m]
+          . versionMiddleware
   return (middlewares $ servantApp e, e, finalizer)
   where
     rtree = compile API.sitemap

--- a/services/gundeck/src/Gundeck/Run.hs
+++ b/services/gundeck/src/Gundeck/Run.hs
@@ -39,6 +39,7 @@ import Network.Wai.Utilities.Server hiding (serverPort)
 import qualified System.Logger as Log
 import qualified UnliftIO.Async as Async
 import Util.Options
+import Wire.API.Routes.Version.Wai
 
 run :: Opts -> IO ()
 run o = do
@@ -64,6 +65,7 @@ run o = do
         . GZip.gunzip
         . GZip.gzip GZip.def
         . catchErrors (e ^. applog) [Right $ e ^. monitor]
+        . versionMiddleware
     app :: Env -> Wai.Application
     app e r k = runGundeck e r (route routes r k)
     routes = compile sitemap

--- a/services/proxy/package.yaml
+++ b/services/proxy/package.yaml
@@ -39,6 +39,7 @@ library:
   - wai-routing >=0.12
   - wai-utilities >=0.14.3
   - warp >=3.0
+  - wire-api
   - unliftio-core
 executables:
   proxy:

--- a/services/proxy/proxy.cabal
+++ b/services/proxy/proxy.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4b0eeea49373b98eff5aa94f2c7ec6e198b9db932ceeb3ff4311ffc25ab44b86
+-- hash: c31f9c4911b4326363bf2d4063f32f056fd40c97d528cbbec21cbe97ccdf1833
 
 name:           proxy
 version:        0.9.0
@@ -103,6 +103,7 @@ library
     , wai-routing >=0.12
     , wai-utilities >=0.14.3
     , warp >=3.0
+    , wire-api
   default-language: Haskell2010
 
 executable proxy

--- a/services/proxy/src/Proxy/Run.hs
+++ b/services/proxy/src/Proxy/Run.hs
@@ -31,6 +31,7 @@ import Proxy.API (sitemap)
 import Proxy.Env
 import Proxy.Options
 import Proxy.Proxy
+import Wire.API.Routes.Version.Wai
 
 run :: Opts -> IO ()
 run o = do
@@ -42,4 +43,5 @@ run o = do
   let middleware =
         waiPrometheusMiddleware (sitemap e)
           . catchErrors (e ^. applog) [Right m]
+          . versionMiddleware
   runSettings s (middleware app) `finally` destroyEnv e

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -55,6 +55,7 @@ import Spar.Sem.Logger.TinyLog (toLevel)
 import System.Logger.Class (Logger)
 import qualified System.Logger.Extended as Log
 import Util.Options (casEndpoint, casFilterNodesByDatacentre, casKeyspace, epHost, epPort)
+import Wire.API.Routes.Version.Wai
 import Wire.API.User.Saml as Types
 
 ----------------------------------------------------------------------
@@ -124,6 +125,7 @@ mkApp sparCtxOpts = do
           -- still here for errors outside the power of the 'Application', like network
           -- outages.
           . SAML.setHttpCachePolicy
+          . versionMiddleware
           . lookupRequestIdMiddleware
           $ \sparCtxRequestId -> app Env {..}
       heavyLogOnly :: (Wai.Request, LByteString) -> Maybe (Wai.Request, LByteString)


### PR DESCRIPTION
This PR implements the bare minimum interface for [client API version negotiation](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/555090587/Use+case+deciding+which+backend+API+version+to+use).

The changes in the nginz chart are based on https://github.com/zinfra/cailleach/pull/879 and result in the following [diff](https://gist.github.com/pcapriotti/1e0680ad99f5c128234ba0b876176542).

Tracked by https://wearezeta.atlassian.net/browse/FS-440.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
