### PR TITLE
Build ubuntu20 docker images with cabal instead of stack

### DIFF
--- a/build/ubuntu/Dockerfile.fast-intermediate
+++ b/build/ubuntu/Dockerfile.fast-intermediate
@@ -1,5 +1,5 @@
 ARG builder=quay.io/wire/ubuntu20-builder
-ARG deps=quay.io/wire/ubuntu-deps
+ARG deps=quay.io/wire/ubuntu20-deps:develop
 
 #--- Builder stage ---
 FROM ${builder} as builder
@@ -8,7 +8,10 @@ WORKDIR /wire-server/
 
 COPY . /wire-server/
 
-RUN make clean fast
+RUN echo "optimization: False" > ./cabal.project.local && \
+   ./hack/bin/cabal-project-local-template.sh "ghc-options: -O0" >> ./cabal.project.local && \
+    WIRE_BUILD_WITH_CABAL=1 make clean && \
+    WIRE_BUILD_WITH_CABAL=1 make install
 
 #--- Minified stage ---
 FROM ${deps}

--- a/build/ubuntu/Dockerfile.fast-intermediate
+++ b/build/ubuntu/Dockerfile.fast-intermediate
@@ -9,9 +9,8 @@ WORKDIR /wire-server/
 COPY . /wire-server/
 
 RUN echo "optimization: False" > ./cabal.project.local && \
-   ./hack/bin/cabal-project-local-template.sh "ghc-options: -O0" >> ./cabal.project.local && \
-    WIRE_BUILD_WITH_CABAL=1 make clean && \
-    WIRE_BUILD_WITH_CABAL=1 make install
+    ./hack/bin/cabal-project-local-template.sh "ghc-options: -O0" >> ./cabal.project.local && \
+    WIRE_BUILD_WITH_CABAL=1 make clean install
 
 #--- Minified stage ---
 FROM ${deps}

--- a/build/ubuntu/Dockerfile.intermediate
+++ b/build/ubuntu/Dockerfile.intermediate
@@ -15,7 +15,7 @@ WORKDIR /wire-server/
 
 COPY . /wire-server/
 
-RUN make clean install
+RUN WIRE_BUILD_WITH_CABAL=1 make clean install
 
 #--- Minified stage ---
 FROM ${deps}

--- a/build/ubuntu/Dockerfile.intermediate
+++ b/build/ubuntu/Dockerfile.intermediate
@@ -6,7 +6,7 @@
 #   docker build -f build/alpine/Dockerfile.intermediate
 
 ARG builder=quay.io/wire/ubuntu20-builder
-ARG deps=quay.io/wire/ubuntu20-deps
+ARG deps=quay.io/wire/ubuntu20-deps:develop
 
 #--- Builder stage ---
 FROM ${builder} as builder

--- a/changelog.d/5-internal/cabal-builds
+++ b/changelog.d/5-internal/cabal-builds
@@ -1,0 +1,1 @@
+Build ubuntu20 docker images with cabal instead of stack

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -26,6 +26,8 @@ import qualified Brig.API.Public as Public
 import qualified Data.Swagger.Build.Api as Doc
 import Network.Wai.Routing (Routes)
 
+-- dummy change for CI: TODO: remove me before merging
+
 sitemap :: Routes Doc.ApiBuilder Handler ()
 sitemap = do
   Public.sitemap

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -26,8 +26,6 @@ import qualified Brig.API.Public as Public
 import qualified Data.Swagger.Build.Api as Doc
 import Network.Wai.Routing (Routes)
 
--- dummy change for CI: TODO: remove me before merging
-
 sitemap :: Routes Doc.ApiBuilder Handler ()
 sitemap = do
   Public.sitemap


### PR DESCRIPTION
This PR changes the way we build Docker images: `stack` is replaced by `cabal` to build all binaries.

This affects
- Docker images for PR pipelines (`Dockerfile.fast-intermediate`)
- Docker images for on-prem and other k8s-based deployments (`Dockerfile.intermediate`)


## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):