### PR TITLE
Make helm-template script use helmfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -522,7 +522,7 @@ kind-restart-%: .local/kind-kubeconfig
 # hack/helm_vars (what CI uses) as overrrides, if available. This allows debugging helm
 # templating issues without actually installing anything, and without needing
 # access to a kubernetes cluster. e.g.:
-#   make helm-template-wire-server
-helm-template-%: clean-charts charts-integration
-	./hack/bin/helm-template.sh $(*)
+#   make helm-template
+helm-template: clean-charts charts-integration
+	./hack/bin/helm-template.sh
 

--- a/changelog.d/5-internal/helmfile-template
+++ b/changelog.d/5-internal/helmfile-template
@@ -1,0 +1,1 @@
+Make the helm-template script use helmfile

--- a/hack/bin/helm-template.sh
+++ b/hack/bin/helm-template.sh
@@ -13,9 +13,11 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOP_LEVEL="$DIR/../.."
 CHARTS_DIR="${TOP_LEVEL}/.local/charts"
-: "${FEDERATION_DOMAIN:=example.com}"
+: "${FEDERATION_DOMAIN_BASE:=example.com}"
+: "${FEDERATION_DOMAIN:=namespace1.example.com}"
 : "${NAMESPACE:=namespace1}"
 
+export FEDERATION_DOMAIN_BASE
 export FEDERATION_DOMAIN
 export NAMESPACE
 

--- a/hack/bin/helm-template.sh
+++ b/hack/bin/helm-template.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-# This script can be used to template a helm chart with values filled in from
+# This script can be used to render all helm charts with values filled in from
 # hack/helm_vars as overrrides, if available.  This allows debugging helm
 # templating issues without actually installing anything, and without needing
 # access to a kubernetes cluster
+
+# Call the script directly (optionally with `--skip-deps`), or via the
+# `helm-template` make target.
 
 set -e
 


### PR DESCRIPTION
Adapt the `helm-template.sh` script to use `helmfile` instead of `helm` directly.  After #1805, the values files don't exist anymore, so this PR uses `helmfile` for rendering all helm charts using the actual templated values file.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
