### PR TITLE
Specify how a message to a deleted legalhold device is refused to be sent

### DIFF
--- a/changelog.d/5-internal/specify-sending-to-deleted-legalhold-device
+++ b/changelog.d/5-internal/specify-sending-to-deleted-legalhold-device
@@ -1,0 +1,1 @@
+Specify (in a test) how a message to a deleted legalhold device is refused to be sent.

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -817,6 +817,8 @@ testNoConsentBlockOne2OneConv :: HasCallStack => Bool -> Bool -> Bool -> Bool ->
 testNoConsentBlockOne2OneConv connectFirst teamPeer approveLH testPendingConnection = do
   -- FUTUREWORK: maybe regular user for legalholder?
   (legalholder :: UserId, tid) <- createBindingTeam
+  regularClient <- randomClient legalholder (head someLastPrekeys)
+
   peer :: UserId <- if teamPeer then fst <$> createBindingTeam else randomUser
   galley <- view tsGalley
 
@@ -895,7 +897,8 @@ testNoConsentBlockOne2OneConv connectFirst teamPeer approveLH testPendingConnect
             peer
             peerClient
             (qUnqualified convId)
-            [ (legalholder, legalholderLHDevice, "cipher")
+            [ (legalholder, legalholderLHDevice, "cipher"),
+              (legalholder, regularClient, "cipher")
             ]
             !!! do
               const 404 === statusCode
@@ -928,10 +931,16 @@ testNoConsentBlockOne2OneConv connectFirst teamPeer approveLH testPendingConnect
             peer
             peerClient
             (qUnqualified convId)
-            [ (legalholder, legalholderLHDevice, "cipher")
+            [ (legalholder, legalholderLHDevice, "cipher"),
+              (legalholder, regularClient, "cipher")
             ]
             !!! do
               const 201 === statusCode
+              assertMismatchWithMessage
+                (Just "legalholderLHDevice is deleted")
+                []
+                []
+                [(legalholder, Set.singleton legalholderLHDevice)]
 
 data GroupConvAdmin
   = LegalholderIsAdmin


### PR DESCRIPTION
The test was a bit misleading about the assumptions regarding this.

## Checklist

 - [X] The **PR Title** explains the impact of the change.
 - [X] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [X] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [X] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
