### PR TITLE
Add route for `/api-version` to nginz chart

### DIFF
--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -87,6 +87,10 @@ nginx_conf:
       max_body_size: "0"
       disable_request_buffering: true
     brig:
+    - path: /api-version
+      envs:
+      - all
+      disable_zauth: true
     - path: /users
       envs:
       - all


### PR DESCRIPTION
Add missing route to the new `/api-version` endpoint introduced in https://github.com/wireapp/wire-server/pull/2116.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
