### PR TITLE
Sqservices 1159 backend feature config 2nd factor for some password actions

### DIFF
--- a/changelog.d/0-release-notes/pr-2138
+++ b/changelog.d/0-release-notes/pr-2138
@@ -1,0 +1,2 @@
+Optional team feature config `sndFactorPasswordChallenge` added to galley.yaml.
+The feature is disabled by default. The server wide default can be changed in galley.yaml. Please refer to [/docs/reference/config-options.md#2nd-factor-password-challenge](https://github.com/wireapp/wire-server/blob/develop/docs/reference/config-options.md#2nd-factor-password-challenge)

--- a/changelog.d/5-internal/pr-2138
+++ b/changelog.d/5-internal/pr-2138
@@ -1,2 +1,2 @@
-Optional team feature config `sndFactorPasswordChallenge` added to galley.yaml.
+[not done yet, please do not enable] Optional team feature config `sndFactorPasswordChallenge` added to galley.yaml.
 The feature is disabled by default. The server wide default can be changed in galley.yaml. Please refer to [/docs/reference/config-options.md#2nd-factor-password-challenge](https://github.com/wireapp/wire-server/blob/develop/docs/reference/config-options.md#2nd-factor-password-challenge)

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -68,5 +68,9 @@ data:
         fileSharing:
           {{- toYaml .settings.featureFlags.fileSharing | nindent 10 }}
         {{- end }}
+        {{- if .settings.featureFlags.sndFactorPasswordChallenge }}
+        sndFactorPasswordChallenge:
+          {{- toYaml .settings.featureFlags.sndFactorPasswordChallenge | nindent 10 }}
+        {{- end }}
       {{- end }}
   {{- end }}

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -39,7 +39,12 @@ config:
       # fileSharing:
       #   defaults:
       #     status: enabled
-      #     lockStatus: unlocked          
+      #     lockStatus: unlocked
+      # sndFactorPasswordChallenge setting is optional
+      # sndFactorPasswordChallenge:
+      #   defaults:
+      #     status: disabled
+      #     lockStatus: unlocked
   aws:
     region: "eu-west-1"
   proxy: {}

--- a/docs/reference/cassandra-schema.cql
+++ b/docs/reference/cassandra-schema.cql
@@ -429,6 +429,8 @@ CREATE TABLE galley_test.team_features (
     self_deleting_messages_lock_status int,
     self_deleting_messages_status int,
     self_deleting_messages_ttl int,
+    snd_factor_password_challenge_lock_status int,
+    snd_factor_password_challenge_status int,
     sso_status int,
     validate_saml_emails int
 ) WITH bloom_filter_fp_chance = 0.1

--- a/docs/reference/config-options.md
+++ b/docs/reference/config-options.md
@@ -180,6 +180,21 @@ validateSAMLEmails:
     status: disabled
 ```
 
+### 2nd Factor Password Challenge
+
+By default Wire enforces a 2nd factor authentication for certain user operations like e.g. activating an account, changing email or password, or deleting an account.
+If this feature is enabled, a 2nd factor password challenge will be performed for a set of additional user operations like e.g. for generating SCIM tokens, login, or adding a client.
+
+Usually the default is what you want. If you explicitly want to enable the feature, use the following syntax:
+
+```yaml
+# galley.yaml
+sndFactorPasswordChallenge:
+  defaults:
+    status: disabled|enabled
+    lockStatus: locked|unlocked
+```
+
 ### Federation Domain
 
 Regardless of whether a backend wants to enable federation or not, the operator

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -34,6 +34,7 @@ module Galley.Types.Teams
     flagSelfDeletingMessages,
     flagConversationGuestLinks,
     flagsTeamFeatureValidateSAMLEmailsStatus,
+    flagTeamFeatureSndFactorPasswordChallengeStatus,
     Defaults (..),
     unDefaults,
     FeatureSSO (..),
@@ -218,7 +219,8 @@ data FeatureFlags = FeatureFlags
     _flagConferenceCalling :: !(Defaults (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureConferenceCalling)),
     _flagSelfDeletingMessages :: !(Defaults (TeamFeatureStatus 'WithLockStatus 'TeamFeatureSelfDeletingMessages)),
     _flagConversationGuestLinks :: !(Defaults (TeamFeatureStatus 'WithLockStatus 'TeamFeatureGuestLinks)),
-    _flagsTeamFeatureValidateSAMLEmailsStatus :: !(Defaults (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails))
+    _flagsTeamFeatureValidateSAMLEmailsStatus :: !(Defaults (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails)),
+    _flagTeamFeatureSndFactorPasswordChallengeStatus :: !(Defaults (TeamFeatureStatus 'WithLockStatus 'TeamFeatureSndFactorPasswordChallenge))
   }
   deriving (Eq, Show, Generic)
 
@@ -267,6 +269,7 @@ instance FromJSON FeatureFlags where
       <*> (fromMaybe (Defaults defaultSelfDeletingMessagesStatus) <$> (obj .:? "selfDeletingMessages"))
       <*> (fromMaybe (Defaults defaultGuestLinksStatus) <$> (obj .:? "conversationGuestLinks"))
       <*> (fromMaybe (Defaults defaultTeamFeatureValidateSAMLEmailsStatus) <$> (obj .:? "validateSAMLEmails"))
+      <*> (fromMaybe (Defaults defaultTeamFeatureSndFactorPasswordChallengeStatus) <$> (obj .:? "sndFactorPasswordChallenge"))
 
 instance ToJSON FeatureFlags where
   toJSON
@@ -281,6 +284,7 @@ instance ToJSON FeatureFlags where
         selfDeletingMessages
         guestLinks
         validateSAMLEmails
+        sndFactorPasswordChallenge
       ) =
       object
         [ "sso" .= sso,
@@ -292,7 +296,8 @@ instance ToJSON FeatureFlags where
           "conferenceCalling" .= conferenceCalling,
           "selfDeletingMessages" .= selfDeletingMessages,
           "conversationGuestLinks" .= guestLinks,
-          "validateSAMLEmails" .= validateSAMLEmails
+          "validateSAMLEmails" .= validateSAMLEmails,
+          "sndFactorPasswordChallenge" .= sndFactorPasswordChallenge
         ]
 
 instance FromJSON FeatureSSO where

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -392,6 +392,7 @@ roleHiddenPermissions role = HiddenPermissions p p
             ChangeTeamFeature TeamFeatureClassifiedDomains {- the features not listed here can only be changed in stern -},
             ChangeTeamFeature TeamFeatureSelfDeletingMessages,
             ChangeTeamFeature TeamFeatureGuestLinks,
+            ChangeTeamFeature TeamFeatureSndFactorPasswordChallenge,
             ChangeTeamMemberProfiles,
             ReadIdp,
             CreateUpdateDeleteIdp,
@@ -414,6 +415,7 @@ roleHiddenPermissions role = HiddenPermissions p p
           ViewTeamFeature TeamFeatureConferenceCalling,
           ViewTeamFeature TeamFeatureSelfDeletingMessages,
           ViewTeamFeature TeamFeatureGuestLinks,
+          ViewTeamFeature TeamFeatureSndFactorPasswordChallenge,
           ViewLegalHoldUserSettings,
           ViewTeamSearchVisibility
         ]

--- a/libs/galley-types/test/unit/Test/Galley/Types.hs
+++ b/libs/galley-types/test/unit/Test/Galley/Types.hs
@@ -99,3 +99,4 @@ instance Arbitrary FeatureFlags where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary

--- a/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
+++ b/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
@@ -77,7 +77,7 @@ taggedEventDataSchema =
       TeamFeatureConferenceCalling -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
       TeamFeatureSelfDeletingMessages -> tag _EdFeatureSelfDeletingMessagesChanged (unnamed schema)
       TeamFeatureGuestLinks -> tag _EdFeatureWithoutConfigAndLockStatusChanged (unnamed schema)
-      TeamFeatureSndFactorPasswordChallenge -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
+      TeamFeatureSndFactorPasswordChallenge -> tag _EdFeatureWithoutConfigAndLockStatusChanged (unnamed schema)
 
 eventObjectSchema :: ObjectSchema SwaggerDoc Event
 eventObjectSchema =

--- a/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
+++ b/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
@@ -77,6 +77,7 @@ taggedEventDataSchema =
       TeamFeatureConferenceCalling -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
       TeamFeatureSelfDeletingMessages -> tag _EdFeatureSelfDeletingMessagesChanged (unnamed schema)
       TeamFeatureGuestLinks -> tag _EdFeatureWithoutConfigAndLockStatusChanged (unnamed schema)
+      TeamFeatureSndFactorPasswordChallenge -> tag _EdFeatureWithoutConfigChanged (unnamed schema)
 
 eventObjectSchema :: ObjectSchema SwaggerDoc Event
 eventObjectSchema =

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -920,6 +920,8 @@ type FeatureAPI =
     :<|> FeatureStatusPut 'TeamFeatureSelfDeletingMessages
     :<|> FeatureStatusGet 'TeamFeatureGuestLinks
     :<|> FeatureStatusPut 'TeamFeatureGuestLinks
+    :<|> FeatureStatusGet 'TeamFeatureSndFactorPasswordChallenge
+    :<|> FeatureStatusPut 'TeamFeatureSndFactorPasswordChallenge
     :<|> AllFeatureConfigsGet
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureLegalHold
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureSSO
@@ -932,6 +934,7 @@ type FeatureAPI =
     :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureConferenceCalling
     :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureSelfDeletingMessages
     :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureGuestLinks
+    :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureSndFactorPasswordChallenge
 
 type FeatureStatusGet f =
   Named

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -43,6 +43,7 @@ module Wire.API.Team.Feature
     defaultGuestLinksStatus,
     defaultTeamFeatureFileSharing,
     defaultTeamFeatureValidateSAMLEmailsStatus,
+    defaultTeamFeatureSndFactorPasswordChallengeStatus,
 
     -- * Swagger
     typeTeamFeatureName,
@@ -140,6 +141,7 @@ data TeamFeatureName
   | TeamFeatureConferenceCalling
   | TeamFeatureSelfDeletingMessages
   | TeamFeatureGuestLinks
+  | TeamFeatureSndFactorPasswordChallenge
   deriving stock (Eq, Show, Ord, Generic, Enum, Bounded, Typeable)
   deriving (Arbitrary) via (GenericUniform TeamFeatureName)
 
@@ -191,6 +193,10 @@ instance KnownTeamFeatureName 'TeamFeatureGuestLinks where
   type KnownTeamFeatureNameSymbol 'TeamFeatureGuestLinks = "conversationGuestLinks"
   knownTeamFeatureName = TeamFeatureGuestLinks
 
+instance KnownTeamFeatureName 'TeamFeatureSndFactorPasswordChallenge where
+  type KnownTeamFeatureNameSymbol 'TeamFeatureSndFactorPasswordChallenge = "sndFactorPasswordChallenge"
+  knownTeamFeatureName = TeamFeatureSndFactorPasswordChallenge
+
 instance FromByteString TeamFeatureName where
   parser =
     Parser.takeByteString >>= \b ->
@@ -210,6 +216,7 @@ instance FromByteString TeamFeatureName where
         Right "conferenceCalling" -> pure TeamFeatureConferenceCalling
         Right "selfDeletingMessages" -> pure TeamFeatureSelfDeletingMessages
         Right "conversationGuestLinks" -> pure TeamFeatureGuestLinks
+        Right "sndFactorPasswordChallenge" -> pure TeamFeatureSndFactorPasswordChallenge
         Right t -> fail $ "Invalid TeamFeatureName: " <> T.unpack t
 
 -- TODO: how do we make this consistent with 'KnownTeamFeatureNameSymbol'?  add a test for
@@ -226,6 +233,7 @@ instance ToByteString TeamFeatureName where
   builder TeamFeatureConferenceCalling = "conferenceCalling"
   builder TeamFeatureSelfDeletingMessages = "selfDeletingMessages"
   builder TeamFeatureGuestLinks = "conversationGuestLinks"
+  builder TeamFeatureSndFactorPasswordChallenge = "sndFactorPasswordChallenge"
 
 instance ToSchema TeamFeatureName where
   schema =
@@ -320,6 +328,8 @@ type family TeamFeatureStatus (ps :: IncludeLockStatus) (a :: TeamFeatureName) :
   TeamFeatureStatus 'WithLockStatus 'TeamFeatureSelfDeletingMessages = TeamFeatureStatusWithConfigAndLockStatus TeamFeatureSelfDeletingMessagesConfig
   TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureGuestLinks = TeamFeatureStatusNoConfig
   TeamFeatureStatus 'WithLockStatus 'TeamFeatureGuestLinks = TeamFeatureStatusNoConfigAndLockStatus
+  TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureSndFactorPasswordChallenge = TeamFeatureStatusNoConfig
+  TeamFeatureStatus 'WithLockStatus 'TeamFeatureSndFactorPasswordChallenge = TeamFeatureStatusNoConfigAndLockStatus
 
 type family FeatureHasNoConfig (ps :: IncludeLockStatus) (a :: TeamFeatureName) :: Constraint where
   FeatureHasNoConfig 'WithLockStatus a = (TeamFeatureStatus 'WithLockStatus a ~ TeamFeatureStatusNoConfigAndLockStatus)
@@ -338,6 +348,7 @@ modelForTeamFeature name@TeamFeatureClassifiedDomains = modelTeamFeatureStatusWi
 modelForTeamFeature TeamFeatureConferenceCalling = modelTeamFeatureStatusNoConfig
 modelForTeamFeature name@TeamFeatureSelfDeletingMessages = modelTeamFeatureStatusWithConfig name modelTeamFeatureSelfDeletingMessagesConfig
 modelForTeamFeature TeamFeatureGuestLinks = modelTeamFeatureStatusNoConfig
+modelForTeamFeature TeamFeatureSndFactorPasswordChallenge = modelTeamFeatureStatusNoConfig
 
 ----------------------------------------------------------------------
 -- TeamFeatureStatusNoConfig
@@ -621,6 +632,12 @@ defaultGuestLinksStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnab
 
 defaultTeamFeatureValidateSAMLEmailsStatus :: TeamFeatureStatusNoConfig
 defaultTeamFeatureValidateSAMLEmailsStatus = TeamFeatureStatusNoConfig TeamFeatureEnabled
+
+----------------------------------------------------------------------
+-- TeamFeatureSndFactorPasswordChallenge
+
+defaultTeamFeatureSndFactorPasswordChallengeStatus :: TeamFeatureStatusNoConfigAndLockStatus
+defaultTeamFeatureSndFactorPasswordChallengeStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureDisabled Unlocked
 
 ----------------------------------------------------------------------
 -- internal

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -598,6 +598,7 @@ executable galley-schema
       V57_GuestLinksLockStatus
       V58_ConversationAccessRoleV2
       V59_FileSharingLockStatus
+      V60_TeamFeatureSndFactorPasswordChallenge
       Paths_galley
   hs-source-dirs:
       schema/src

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -62,6 +62,7 @@ import qualified V56_GuestLinksTeamFeatureStatus
 import qualified V57_GuestLinksLockStatus
 import qualified V58_ConversationAccessRoleV2
 import qualified V59_FileSharingLockStatus
+import qualified V60_TeamFeatureSndFactorPasswordChallenge
 
 main :: IO ()
 main = do
@@ -109,7 +110,8 @@ main = do
       V56_GuestLinksTeamFeatureStatus.migration,
       V57_GuestLinksLockStatus.migration,
       V58_ConversationAccessRoleV2.migration,
-      V59_FileSharingLockStatus.migration
+      V59_FileSharingLockStatus.migration,
+      V60_TeamFeatureSndFactorPasswordChallenge.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Galley.Cassandra
       -- (see also docs/developer/cassandra-interaction.md)

--- a/services/galley/schema/src/V60_TeamFeatureSndFactorPasswordChallenge.hs
+++ b/services/galley/schema/src/V60_TeamFeatureSndFactorPasswordChallenge.hs
@@ -15,9 +15,20 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Cassandra (schemaVersion) where
+module V60_TeamFeatureSndFactorPasswordChallenge
+  ( migration,
+  )
+where
 
+import Cassandra.Schema
 import Imports
+import Text.RawString.QQ
 
-schemaVersion :: Int32
-schemaVersion = 60
+migration :: Migration
+migration = Migration 60 "Add feature config for team feature snd factor password challenge" $ do
+  schema'
+    [r| ALTER TABLE team_features ADD (
+          snd_factor_password_challenge_status int,
+          snd_factor_password_challenge_lock_status int
+        )
+     |]

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -117,6 +117,7 @@ type IFeatureAPI =
     :<|> IFeatureStatus 'TeamFeatureConferenceCalling
     :<|> IFeatureStatusWithLock 'TeamFeatureSelfDeletingMessages
     :<|> IFeatureStatusWithLock 'TeamFeatureGuestLinks
+    :<|> IFeatureStatusWithLock 'TeamFeatureSndFactorPasswordChallenge
 
 type InternalAPI =
   "i"
@@ -211,6 +212,7 @@ featureAPI =
     :<|> featureStatus @'TeamFeatureConferenceCalling getConferenceCallingInternal setConferenceCallingInternal
     :<|> featureStatusWithLock getSelfDeletingMessagesInternal setSelfDeletingMessagesInternal
     :<|> featureStatusWithLock getGuestLinkInternal setGuestLinkInternal
+    :<|> featureStatusWithLock getSndFactorPasswordChallengeInternal setSndFactorPasswordChallengeInternal
 
 featureStatusGet ::
   forall (l :: IncludeLockStatus) f r.

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -200,6 +200,16 @@ servantSitemap = conversations :<|> teamConversations :<|> messaging :<|> bot :<
               setGuestLinkInternal
               . DoAuth
           )
+        :<|> Named @'("get", 'TeamFeatureSndFactorPasswordChallenge)
+          ( getFeatureStatus @'WithLockStatus @'TeamFeatureSndFactorPasswordChallenge
+              getSndFactorPasswordChallengeInternal
+              . DoAuth
+          )
+        :<|> Named @'("put", 'TeamFeatureSndFactorPasswordChallenge)
+          ( setFeatureStatus @'TeamFeatureSndFactorPasswordChallenge
+              setSndFactorPasswordChallengeInternal
+              . DoAuth
+          )
         :<|> Named @"get-all-feature-configs" getAllFeatureConfigs
         :<|> Named @'("get-config", 'TeamFeatureLegalHold)
           ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureLegalHold
@@ -244,4 +254,8 @@ servantSitemap = conversations :<|> teamConversations :<|> messaging :<|> bot :<
         :<|> Named @'("get-config", 'TeamFeatureGuestLinks)
           ( getFeatureConfig @'WithLockStatus @'TeamFeatureGuestLinks
               getGuestLinkInternal
+          )
+        :<|> Named @'("get-config", 'TeamFeatureSndFactorPasswordChallenge)
+          ( getFeatureConfig @'WithLockStatus @'TeamFeatureSndFactorPasswordChallenge
+              getSndFactorPasswordChallengeInternal
           )

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -238,7 +238,8 @@ getAllFeatureConfigs zusr = do
         getStatus @'Public.WithoutLockStatus @'Public.TeamFeatureClassifiedDomains getClassifiedDomainsInternal,
         getStatus @'Public.WithoutLockStatus @'Public.TeamFeatureConferenceCalling getConferenceCallingInternal,
         getStatus @'Public.WithLockStatus @'Public.TeamFeatureSelfDeletingMessages getSelfDeletingMessagesInternal,
-        getStatus @'Public.WithLockStatus @'Public.TeamFeatureGuestLinks getGuestLinkInternal
+        getStatus @'Public.WithLockStatus @'Public.TeamFeatureGuestLinks getGuestLinkInternal,
+        getStatus @'Public.WithLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge getSndFactorPasswordChallengeInternal
       ]
 
 getAllFeaturesH ::
@@ -287,7 +288,8 @@ getAllFeatures uid tid = do
         getStatus @'Public.WithoutLockStatus @'Public.TeamFeatureClassifiedDomains getClassifiedDomainsInternal,
         getStatus @'Public.WithoutLockStatus @'Public.TeamFeatureConferenceCalling getConferenceCallingInternal,
         getStatus @'Public.WithLockStatus @'Public.TeamFeatureSelfDeletingMessages getSelfDeletingMessagesInternal,
-        getStatus @'Public.WithLockStatus @'Public.TeamFeatureGuestLinks getGuestLinkInternal
+        getStatus @'Public.WithLockStatus @'Public.TeamFeatureGuestLinks getGuestLinkInternal,
+        getStatus @'Public.WithLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge getSndFactorPasswordChallengeInternal
       ]
   where
     getStatus ::

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -41,6 +41,8 @@ module Galley.API.Teams.Features
     setConferenceCallingInternal,
     getSelfDeletingMessagesInternal,
     setSelfDeletingMessagesInternal,
+    getSndFactorPasswordChallengeInternal,
+    setSndFactorPasswordChallengeInternal,
     getGuestLinkInternal,
     setGuestLinkInternal,
     setLockStatus,
@@ -709,6 +711,48 @@ setGuestLinkInternal tid status = do
   where
     getDftLockStatus :: Sem r Public.LockStatusValue
     getDftLockStatus = input <&> view (optSettings . setFeatureFlags . flagConversationGuestLinks . unDefaults . to Public.tfwoapsLockStatus)
+
+getSndFactorPasswordChallengeInternal ::
+  forall r.
+  (Member (Input Opts) r, Member TeamFeatureStore r) =>
+  GetFeatureInternalParam ->
+  Sem r (Public.TeamFeatureStatus 'Public.WithLockStatus 'Public.TeamFeatureSndFactorPasswordChallenge)
+getSndFactorPasswordChallengeInternal = \case
+  Left _ -> getCfgDefault
+  Right tid -> do
+    cfgDefault <- getCfgDefault
+    (mbFeatureStatus, fromMaybe (Public.tfwoapsLockStatus cfgDefault) -> lockStatus) <- TeamFeatures.getFeatureStatusNoConfigAndLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge tid
+    pure $ determineFeatureStatus cfgDefault lockStatus mbFeatureStatus
+  where
+    getCfgDefault :: Sem r (Public.TeamFeatureStatus 'Public.WithLockStatus 'Public.TeamFeatureSndFactorPasswordChallenge)
+    getCfgDefault = input <&> view (optSettings . setFeatureFlags . flagTeamFeatureSndFactorPasswordChallengeStatus . unDefaults)
+
+setSndFactorPasswordChallengeInternal ::
+  forall r.
+  ( Member GundeckAccess r,
+    Member TeamStore r,
+    Member TeamFeatureStore r,
+    Member P.TinyLog r,
+    Member (Error TeamFeatureError) r,
+    Member (Input Opts) r
+  ) =>
+  TeamId ->
+  Public.TeamFeatureStatus 'Public.WithoutLockStatus 'Public.TeamFeatureSndFactorPasswordChallenge ->
+  Sem r (Public.TeamFeatureStatus 'Public.WithoutLockStatus 'Public.TeamFeatureSndFactorPasswordChallenge)
+setSndFactorPasswordChallengeInternal tid status = do
+  getDftLockStatus >>= guardLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge tid
+  let pushEvent =
+        pushFeatureConfigEvent tid $
+          Event.Event
+            Event.Update
+            Public.TeamFeatureSndFactorPasswordChallenge
+            ( EdFeatureWithoutConfigAndLockStatusChanged
+                (Public.TeamFeatureStatusNoConfigAndLockStatus (Public.tfwoStatus status) Public.Unlocked)
+            )
+  TeamFeatures.setFeatureStatusNoConfig @'Public.TeamFeatureSndFactorPasswordChallenge tid status <* pushEvent
+  where
+    getDftLockStatus :: Sem r Public.LockStatusValue
+    getDftLockStatus = input <&> view (optSettings . setFeatureFlags . flagTeamFeatureSndFactorPasswordChallengeStatus . unDefaults . to Public.tfwoapsLockStatus)
 
 -- TODO(fisx): move this function to a more suitable place / module.
 guardLockStatus ::

--- a/services/galley/src/Galley/Data/TeamFeatures.hs
+++ b/services/galley/src/Galley/Data/TeamFeatures.hs
@@ -51,6 +51,8 @@ instance HasStatusCol 'TeamFeatureSelfDeletingMessages where statusCol = "self_d
 
 instance HasStatusCol 'TeamFeatureGuestLinks where statusCol = "guest_links_status"
 
+instance HasStatusCol 'TeamFeatureSndFactorPasswordChallenge where statusCol = "snd_factor_password_challenge_status"
+
 ----------------------------------------------------------------------
 class HasLockStatusCol (a :: TeamFeatureName) where
   lockStatusCol :: String
@@ -70,6 +72,9 @@ instance HasLockStatusCol 'TeamFeatureGuestLinks where
 
 instance HasLockStatusCol 'TeamFeatureFileSharing where
   lockStatusCol = "file_sharing_lock_status"
+
+instance HasLockStatusCol 'TeamFeatureSndFactorPasswordChallenge where
+  lockStatusCol = "snd_factor_password_challenge_lock_status"
 
 instance MaybeHasLockStatusCol 'TeamFeatureLegalHold where maybeLockStatusCol = Nothing
 

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -72,7 +72,8 @@ tests s =
       test s "SelfDeletingMessages" testSelfDeletingMessages,
       test s "ConversationGuestLinks - public API" testGuestLinksPublic,
       test s "ConversationGuestLinks - internal API" testGuestLinksInternal,
-      test s "ConversationGuestLinks - lock status" $ testSimpleFlagWithLockStatus @'Public.TeamFeatureGuestLinks Public.TeamFeatureEnabled Public.Unlocked
+      test s "ConversationGuestLinks - lock status" $ testSimpleFlagWithLockStatus @'Public.TeamFeatureGuestLinks Public.TeamFeatureEnabled Public.Unlocked,
+      test s "SndFactorPasswordChallenge - lock status" $ testSimpleFlagWithLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge Public.TeamFeatureDisabled Public.Unlocked
     ]
 
 testSSO :: TestM ()
@@ -678,7 +679,8 @@ testAllFeatures = do
             .= Public.TeamFeatureStatusNoConfigAndLockStatus
               TeamFeatureEnabled
               Public.Unlocked,
-          toS TeamFeatureValidateSAMLEmails .= Public.TeamFeatureStatusNoConfig TeamFeatureEnabled
+          toS TeamFeatureValidateSAMLEmails .= Public.TeamFeatureStatusNoConfig TeamFeatureEnabled,
+          toS TeamFeatureGuestLinks .= Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Public.Unlocked
         ]
     toS :: TeamFeatureName -> Text
     toS = TE.decodeUtf8 . toByteString'

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -680,7 +680,8 @@ testAllFeatures = do
               TeamFeatureEnabled
               Public.Unlocked,
           toS TeamFeatureValidateSAMLEmails .= Public.TeamFeatureStatusNoConfig TeamFeatureEnabled,
-          toS TeamFeatureGuestLinks .= Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Public.Unlocked
+          toS TeamFeatureGuestLinks .= Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Public.Unlocked,
+          toS TeamFeatureSndFactorPasswordChallenge .= Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureDisabled Public.Unlocked
         ]
     toS :: TeamFeatureName -> Text
     toS = TE.decodeUtf8 . toByteString'


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1159

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
