### PR TITLE
Implement remote admin action: Update receipt mode

### DIFF
--- a/changelog.d/6-federation/receipt-mode
+++ b/changelog.d/6-federation/receipt-mode
@@ -1,0 +1,1 @@
+Implement remote admin action: Update receipt mode

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -140,6 +140,8 @@ data FederationError
     -- indicate a bug in either backend, or an incompatibility in the
     -- server-to-server API.
     FederationUnexpectedBody Text
+  | -- | Federator client got an unexpected error response from remote backend
+    FederationUnexpectedError Text
   deriving (Show, Typeable)
 
 instance Exception FederationError
@@ -152,6 +154,7 @@ federationErrorToWai FederationNotImplemented = federationNotImplemented
 federationErrorToWai FederationNotConfigured = federationNotConfigured
 federationErrorToWai (FederationCallFailure err) = federationClientErrorToWai err
 federationErrorToWai (FederationUnexpectedBody s) = federationUnexpectedBody s
+federationErrorToWai (FederationUnexpectedError t) = federationUnexpectedError t
 
 federationClientErrorToWai :: FederatorClientError -> Wai.Error
 federationClientErrorToWai (FederatorClientHTTP2Error e) =
@@ -275,6 +278,13 @@ federationUnexpectedBody msg =
     unexpectedFederationResponseStatus
     "federation-unexpected-body"
     ("Could parse body, but response was not expected: " <> LT.fromStrict msg)
+
+federationUnexpectedError :: Text -> Wai.Error
+federationUnexpectedError msg =
+  Wai.mkError
+    unexpectedFederationResponseStatus
+    "federation-unexpected-wai-error"
+    ("Could parse body, but got an unexpected error response: " <> LT.fromStrict msg)
 
 federationNotConfigured :: Wai.Error
 federationNotConfigured =

--- a/libs/wire-api/src/Wire/API/Error/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Error/Galley.hs
@@ -14,6 +14,9 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 module Wire.API.Error.Galley
   ( GalleyError (..),
@@ -27,6 +30,8 @@ module Wire.API.Error.Galley
 where
 
 import Control.Lens ((%~))
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Singletons.CustomStar (genSingletons)
 import Data.Singletons.Prelude (Show_)
 import qualified Data.Swagger as S
 import Data.Tagged
@@ -40,6 +45,7 @@ import Wire.API.Error
 import qualified Wire.API.Error.Brig as BrigError
 import Wire.API.Routes.API
 import Wire.API.Team.Permission
+import Wire.API.Util.Aeson (CustomEncoded (..))
 
 data GalleyError
   = InvalidAction
@@ -100,6 +106,10 @@ data GalleyError
   | TooManyTeamMembersOnTeamWithLegalhold
   | NoLegalHoldDeviceAllocated
   | UserLegalHoldNotPending
+  deriving (Show, Eq, Generic)
+  deriving (FromJSON, ToJSON) via (CustomEncoded GalleyError)
+
+$(genSingletons [''GalleyError])
 
 instance KnownError (MapError e) => IsSwaggerError (e :: GalleyError) where
   addToSwagger = addStaticErrorToSwagger @(MapError e)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Util.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Util.hs
@@ -60,6 +60,7 @@ type ResponsesForExistedCreated eDesc cDesc a =
 data UpdateResult a
   = Unchanged
   | Updated !a
+  deriving (Functor)
 
 type UpdateResponses unchangedDesc updatedDesc a =
   '[ RespondEmpty 204 unchangedDesc,

--- a/libs/wire-api/src/Wire/API/Team/Permission.hs
+++ b/libs/wire-api/src/Wire/API/Team/Permission.hs
@@ -58,6 +58,7 @@ import qualified Data.Swagger as S
 import qualified Data.Swagger.Build.Api as Doc
 import Imports
 import Wire.API.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
+import Wire.API.Util.Aeson (CustomEncoded (..))
 
 --------------------------------------------------------------------------------
 -- Permissions
@@ -151,6 +152,7 @@ data Perm
   -- read Note [team roles] first.
   deriving stock (Eq, Ord, Show, Enum, Bounded, Generic)
   deriving (Arbitrary) via (GenericUniform Perm)
+  deriving (FromJSON, ToJSON) via (CustomEncoded Perm)
 
 permsToInt :: Set Perm -> Word64
 permsToInt = Set.foldr' (\p n -> n .|. permToInt p) 0


### PR DESCRIPTION
This PR is the first in a series of PR that add missing implemention of conversation actions when the admin is remote (i.e. the admin is on a backend that doesn't own the conversation).

This PR implements functionality for the receipt mode update in the Client API
```
PUT /conversations/:domain/:conversation/receipt-mode
```
when `:domain` is a domain that is remote to the user calling the endpoint.

This PR also introduces a Federation API RPC `update-conversation` which is used by a backend to request a conversation update on the backend that owns the conversation. The requested action is any one of the supported conversation actions:

- `ConversationJoin`
- `ConversationLeave`
- `ConversationRemoveMembers`
- `ConversationMemberUpdate`
- `ConversationDelete`
- `ConversationRename`
- `ConversationMessageTimerUpdate`
- `ConversationReceiptModeUpdate` (gets used by `/conversations/:domain/:conversation/receipt-mode`)
- `ConversationAccessData`

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
