### PR TITLE
Add extra information to `api-version` endpoint

### DIFF
--- a/changelog.d/1-api-changes/api-version-endpoint
+++ b/changelog.d/1-api-changes/api-version-endpoint
@@ -1,0 +1,6 @@
+The `api-version` endpoint now returns additional information about the backend:
+
+  - whether federation is supported (field `federation`);
+  - the federation domain (field `domain`).
+
+Note that the federation domain is always set, even if federation is disabled.

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -116,6 +116,7 @@ library
       Brig.User.Search.TeamSize
       Brig.User.Search.TeamUserSearch
       Brig.User.Template
+      Brig.Version
       Brig.Whitelist
       Brig.ZAuth
       Main

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -39,6 +39,7 @@ import qualified Brig.InternalEvent.Process as Internal
 import Brig.Options hiding (internalEvents, sesQueue)
 import qualified Brig.Queue as Queue
 import Brig.Types.Intra (AccountStatus (PendingInvitation))
+import Brig.Version
 import Cassandra (Page (Page), liftClient)
 import qualified Control.Concurrent.Async as Async
 import Control.Exception.Safe (catchAny)
@@ -130,7 +131,7 @@ mkApp o = do
             :<|> Servant.hoistServer (Proxy @BrigAPI) (toServantHandler e) servantSitemap
             :<|> Servant.hoistServer (Proxy @IAPI.API) (toServantHandler e) IAPI.servantSitemap
             :<|> Servant.hoistServer (Proxy @FederationAPI) (toServantHandler e) federationSitemap
-            :<|> versionAPI
+            :<|> Servant.hoistServer (Proxy @VersionAPI) (toServantHandler e) versionAPI
             :<|> Servant.Tagged (app e)
         )
 

--- a/services/brig/src/Brig/Version.hs
+++ b/services/brig/src/Brig/Version.hs
@@ -15,12 +15,23 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Wire.API.VersionInfo
-  ( vinfoObjectSchema,
-  )
-where
+module Brig.Version where
 
-import Data.Schema
+import Brig.API.Handler
+import Brig.App
+import Control.Lens
+import Imports
+import Servant (ServerT)
+import Wire.API.Routes.Named
+import Wire.API.Routes.Version
 
-vinfoObjectSchema :: ValueSchema NamedSwaggerDoc v -> ObjectSchema SwaggerDoc [v]
-vinfoObjectSchema sch = field "supported" (array sch)
+versionAPI :: ServerT VersionAPI (Handler r)
+versionAPI = Named $ do
+  fed <- view federator
+  dom <- viewFederationDomain
+  pure $
+    VersionInfo
+      { vinfoSupported = supportedVersions,
+        vinfoFederation = isJust fed,
+        vinfoDomain = dom
+      }


### PR DESCRIPTION
Make the `api-version` endpoint returns additional information about the backend:

  - whether federation is supported (field `federation`);
  - the federation domain (field `domain`).

Note that the federation domain is always set, even if federation is disabled.

This follows the proposal outlined in https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/560234861/Deciding+whether+to+use+federation-aware+endpoints.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
