### PR TITLE
Add crypto-cli to the deps docker image

### DIFF
--- a/build/ubuntu/Dockerfile.deps
+++ b/build/ubuntu/Dockerfile.deps
@@ -3,17 +3,26 @@ FROM ubuntu:20.04 as cryptobox-builder
 # compile cryptobox-c
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -y cargo file libsodium-dev git pkg-config && \
+    apt-get install -y cargo file libsodium-dev git pkg-config make && \
     cd /tmp && \
     git clone https://github.com/wireapp/cryptobox-c.git && \
     cd cryptobox-c && \
     export SODIUM_USE_PKG_CONFIG=1 && \
     cargo build --release
 
+# compile core-crypto cli tool
+RUN cd /tmp && \
+  git clone -b cli https://github.com/wireapp/core-crypto && \
+  cd core-crypto/cli && \
+  cargo build --release
+
 # Minimal dependencies for ubuntu-compiled, dynamically linked wire-server Haskell services
 FROM ubuntu:20.04
 
 COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib
+
+# FUTUREWORK: only copy crypto-cli executable if we are building an integration test image
+COPY --from=cryptobox-builder /tmp/core-crypto/target/release/crypto-cli /usr/bin
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \


### PR DESCRIPTION
The crypto-cli tool is going to be used in integration test images for testing MLS functionality. See for example https://github.com/wireapp/wire-server/pull/2102.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
