### PR TITLE
Follow-up to `/api-version` changes

### DIFF
--- a/changelog.d/5-internal/api-version-endpoint
+++ b/changelog.d/5-internal/api-version-endpoint
@@ -1,0 +1,1 @@
+Add tests for additional information returned by `GET /api-version`

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -61,6 +61,8 @@ import Wire.Swagger as Doc (pendingLoginError)
 
 routesPublic :: Routes Doc.ApiBuilder (Handler r) ()
 routesPublic = do
+  -- Note: this endpoint should always remain available at its unversioned
+  -- path, since the login cookie hardcodes @/access@ as a path.
   post "/access" (continue renewH) $
     accept "application" "json"
       .&. tokenRequest

--- a/services/brig/test/integration/API/Version.hs
+++ b/services/brig/test/integration/API/Version.hs
@@ -19,7 +19,7 @@ module API.Version (tests) where
 
 import Bilge
 import Bilge.Assert
-import Data.Domain
+import Brig.Options
 import Imports
 import qualified Network.Wai.Utilities.Error as Wai
 import Test.Tasty
@@ -27,14 +27,14 @@ import Test.Tasty.HUnit
 import Util
 import Wire.API.Routes.Version
 
-tests :: Manager -> Brig -> TestTree
-tests p brig =
+tests :: Manager -> Opts -> Brig -> TestTree
+tests p opts brig =
   testGroup
     "version"
     [ test p "GET /api-version" $ testVersion brig,
       test p "GET /v1/api-version" $ testVersionV1 brig,
       test p "GET /v500/api-version" $ testUnsupportedVersion brig,
-      test p "GET /api-version (federation info)" $ testFederationDomain brig
+      test p "GET /api-version (federation info)" $ testFederationDomain opts brig
     ]
 
 testVersion :: Brig -> Http ()
@@ -60,11 +60,12 @@ testUnsupportedVersion brig = do
       <!! const 404 === statusCode
   liftIO $ Wai.label e @?= "unsupported-version"
 
-testFederationDomain :: Brig -> Http ()
-testFederationDomain brig = do
+testFederationDomain :: Opts -> Brig -> Http ()
+testFederationDomain opts brig = do
+  let domain = setFederationDomain (optSettings opts)
   vinfo <-
     responseJsonError =<< get (brig . path "/api-version")
       <!! const 200 === statusCode
   liftIO $ do
     vinfoFederation vinfo @?= True
-    vinfoDomain vinfo @?= Domain "example.com"
+    vinfoDomain vinfo @?= domain

--- a/services/brig/test/integration/API/Version.hs
+++ b/services/brig/test/integration/API/Version.hs
@@ -66,5 +66,5 @@ testFederationDomain brig = do
     responseJsonError =<< get (brig . path "/api-version")
       <!! const 200 === statusCode
   liftIO $ do
-    vinfoFederation vinfo @?= False
+    vinfoFederation vinfo @?= True
     vinfoDomain vinfo @?= Domain "example.com"

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -141,7 +141,7 @@ runTests iConf brigOpts otherArgs = do
   includeFederationTests <- (== Just "1") <$> Blank.getEnv "INTEGRATION_FEDERATION_TESTS"
   internalApi <- API.Internal.tests brigOpts mg db b (brig iConf) gd g
 
-  let versionApi = API.Version.tests mg b
+  let versionApi = API.Version.tests mg brigOpts b
 
   let mlsApi = MLS.tests mg b brigOpts
 


### PR DESCRIPTION
- Add test for additional api-version info
- Comment about /access having to be unversioned, as requested [here](https://github.com/wireapp/wire-server/pull/2152#issuecomment-1049652961).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
