### PR TITLE
Fix: Ensure asset download URL uses S3DownloadEndpoint when provided

### DIFF
--- a/changelog.d/5-internal/bump-aeson-amazonka
+++ b/changelog.d/5-internal/bump-aeson-amazonka
@@ -1,1 +1,1 @@
-Bump aeson to v2.0.3.0 and update amazonka fork from upstream repository.  (#2153, #2157)
+Bump aeson to v2.0.3.0 and update amazonka fork from upstream repository.  (#2153, #2157, #2163)

--- a/charts/cargohold/templates/tests/cargohold-integration.yaml
+++ b/charts/cargohold/templates/tests/cargohold-integration.yaml
@@ -23,11 +23,17 @@ spec:
     - name: "cargohold-config"
       mountPath: "/etc/wire/cargohold/conf"
     env:
-    # these dummy values are necessary for Amazonka's "Discover"
+    # these values are necessary for Amazonka's "Discover"
     - name: AWS_ACCESS_KEY_ID
-      value: "dummy"
+      valueFrom:
+        secretKeyRef:
+          name: cargohold
+          key: awsKeyId
     - name: AWS_SECRET_ACCESS_KEY
-      value: "dummy"
+      valueFrom:
+        secretKeyRef:
+          name: cargohold
+          key: awsSecretKey
     - name: AWS_REGION
-      value: "eu-west-1"
+      value: "{{ .Values.config.aws.region }}"
   restartPolicy: Never

--- a/services/cargohold/src/CargoHold/AWS.hs
+++ b/services/cargohold/src/CargoHold/AWS.hs
@@ -22,7 +22,7 @@ module CargoHold.AWS
   ( -- * Monad
     Env,
     mkEnv,
-    useDownloadEndpoint,
+    amazonkaEnvWithDownloadEndpoint,
     Amazon,
     amazonkaEnv,
     execute,
@@ -70,9 +70,9 @@ data Env = Env
 makeLenses ''Env
 
 -- | Override the endpoint in the '_amazonkaEnv' with '_amazonkaDownloadEndpoint'.
-useDownloadEndpoint :: Env -> Env
-useDownloadEndpoint e =
-  e & amazonkaEnv %~ AWS.override (setAWSEndpoint (e ^. amazonkaDownloadEndpoint))
+amazonkaEnvWithDownloadEndpoint :: Env -> AWS.Env
+amazonkaEnvWithDownloadEndpoint e =
+  AWS.override (setAWSEndpoint (e ^. amazonkaDownloadEndpoint)) (e ^. amazonkaEnv)
 
 setAWSEndpoint :: AWSEndpoint -> AWS.Service -> AWS.Service
 setAWSEndpoint e = AWS.setEndpoint (_awsSecure e) (_awsHost e) (_awsPort e)

--- a/services/cargohold/src/CargoHold/S3.hs
+++ b/services/cargohold/src/CargoHold/S3.hs
@@ -41,7 +41,7 @@ import Amazonka hiding (Error, ToByteString, (.=))
 import Amazonka.S3
 import Amazonka.S3.Lens
 import CargoHold.API.Error
-import CargoHold.AWS (amazonkaEnv)
+import CargoHold.AWS (amazonkaEnvWithDownloadEndpoint)
 import qualified CargoHold.AWS as AWS
 import CargoHold.App hiding (Env, Handler)
 import CargoHold.Options
@@ -215,8 +215,7 @@ signedURL path = do
   ttl <- view (settings . setDownloadLinkTTL)
   let req = newGetObject (BucketName b) (ObjectKey . Text.decodeLatin1 $ toByteString' path)
   signed <-
-    AWS.execute (AWS.useDownloadEndpoint e) $
-      presignURL (e ^. amazonkaEnv) now (Seconds (fromIntegral ttl)) req
+    presignURL (amazonkaEnvWithDownloadEndpoint e) now (Seconds (fromIntegral ttl)) req
   toUri signed
   where
     toUri x = case parseURI strictURIParserOptions x of

--- a/services/cargohold/test/integration/API.hs
+++ b/services/cargohold/test/integration/API.hs
@@ -248,7 +248,9 @@ testDownloadURLOverride = do
         const Nothing === responseBody
     downloadURL <- parseUrlThrow (C8.unpack (getHeader' "Location" downloadURLRes))
     liftIO $ do
-      assertEqual "status" downloadEndpoint (HTTP.host downloadURL)
+      assertEqual "download host" downloadEndpoint (HTTP.host downloadURL)
+      assertEqual "download port" 443 (HTTP.port downloadURL)
+      assertEqual "download secure" True (HTTP.secure downloadURL)
 
 --------------------------------------------------------------------------------
 -- Client compatibility tests


### PR DESCRIPTION
Regression introduced by #2153 

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.