### PR TITLE
Add qualified broadcast endpoint

### DIFF
--- a/changelog.d/0-release-notes/nginz-upgrade
+++ b/changelog.d/0-release-notes/nginz-upgrade
@@ -1,0 +1,1 @@
+For wire.com operators: make sure that nginz is deployed

--- a/changelog.d/1-api-changes/broadcast-qualified
+++ b/changelog.d/1-api-changes/broadcast-qualified
@@ -1,0 +1,1 @@
+Add qualified broadcast endpoint

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -316,7 +316,7 @@ nginx_conf:
       - all
       max_body_size: 40m
       body_buffer_size: 256k
-    - path: /broadcast/otr/messages
+    - path: /broadcast
       envs:
       - all
       max_body_size: 40m

--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -337,7 +337,7 @@ http {
     }
 
     location /broadcast {
-      include common_response_no_zauth.conf;
+      include common_response_with_zauth.conf;
       proxy_pass http://galley;
     }
 

--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -336,8 +336,8 @@ http {
         proxy_pass http://galley;
     }
 
-    location /broadcast/otr/messages {
-      include common_response_with_zauth.conf;
+    location /broadcast {
+      include common_response_no_zauth.conf;
       proxy_pass http://galley;
     }
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -880,6 +880,25 @@ type MessagingAPI =
                     (PostOtrResponses MessageSendingStatus)
                     (Either (MessageNotSent MessageSendingStatus) MessageSendingStatus)
            )
+    :<|> Named
+           "post-proteus-broadcast"
+           ( Summary "Post an encrypted message to all team members and all contacts (accepts only Protobuf)"
+               :> Description PostOtrDescription
+               :> ZLocalUser
+               :> ZConn
+               :> CanThrow TeamNotFound
+               :> CanThrow BroadcastLimitExceeded
+               :> CanThrow NonBindingTeam
+               :> "broadcast"
+               :> "proteus"
+               :> "messages"
+               :> ReqBody '[Proto] QualifiedNewOtrMessage
+               :> MultiVerb
+                    'POST
+                    '[JSON]
+                    (PostOtrResponses MessageSendingStatus)
+                    (Either (MessageNotSent MessageSendingStatus) MessageSendingStatus)
+           )
 
 type BotAPI =
   Named
@@ -1048,7 +1067,7 @@ type PostOtrDescription =
   \- `report_only`: Takes a list of qualified UserIDs. If any clients of the listed users are missing, the message is not sent. The missing clients are reported in the response.\n\
   \- `ignore_only`: Takes a list of qualified UserIDs. If any clients of the non-listed users are missing, the message is not sent. The missing clients are reported in the response.\n\
   \\n\
-  \The sending of messages in a federated conversation could theorectically fail partially. \
+  \The sending of messages in a federated conversation could theoretically fail partially. \
   \To make this case unlikely, the backend first gets a list of clients from all the involved backends and then tries to send a message. \
   \So, if any backend is down, the message is not propagated to anyone. \
   \But the actual message fan out to multiple backends could still fail partially. This type of failure is reported as a 201, \

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -408,6 +408,7 @@ executable galley-integration
     , containers
     , cookie
     , currency-codes
+    , data-default
     , data-timeout
     , errors
     , exceptions

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -169,6 +169,7 @@ executables:
     - cookie
     - currency-codes
     - metrics-wai
+    - data-default
     - data-timeout
     - errors
     - exceptions

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -83,6 +83,7 @@ servantSitemap = conversations :<|> teamConversations :<|> messaging :<|> bot :<
       Named @"post-otr-message-unqualified" postOtrMessageUnqualified
         :<|> Named @"post-otr-broadcast-unqualified" postOtrBroadcastUnqualified
         :<|> Named @"post-proteus-message" postProteusMessage
+        :<|> Named @"post-proteus-broadcast" postProteusBroadcast
 
     bot =
       Named @"post-bot-message-unqualified" postBotMessageUnqualified

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -52,6 +52,7 @@ module Galley.API.Update
     -- * Talking
     postProteusMessage,
     postOtrMessageUnqualified,
+    postProteusBroadcast,
     postOtrBroadcastUnqualified,
     isTypingUnqualified,
 
@@ -1113,6 +1114,32 @@ postProteusMessage sender zcon conv msg = runLocalInput sender $ do
     (\c -> postQualifiedOtrMessage User (qUntagged sender) (Just zcon) c (rpValue msg))
     (\c -> postRemoteOtrMessage (qUntagged sender) c (rpRaw msg))
     conv
+
+postProteusBroadcast ::
+  Members
+    '[ BotAccess,
+       BrigAccess,
+       ClientStore,
+       ConversationStore,
+       Error ActionError,
+       Error TeamError,
+       FederatorAccess,
+       GundeckAccess,
+       ExternalAccess,
+       Input Opts,
+       Input UTCTime,
+       MemberStore,
+       TeamStore,
+       TinyLog
+     ]
+    r =>
+  Local UserId ->
+  ConnId ->
+  QualifiedNewOtrMessage ->
+  Sem r (PostOtrResponse MessageSendingStatus)
+postProteusBroadcast sender zcon msg =
+  runLocalInput sender $
+    postBroadcast sender (Just zcon) msg
 
 unqualifyEndpoint ::
   Functor f =>

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1137,9 +1137,7 @@ postProteusBroadcast ::
   ConnId ->
   QualifiedNewOtrMessage ->
   Sem r (PostOtrResponse MessageSendingStatus)
-postProteusBroadcast sender zcon msg =
-  runLocalInput sender $
-    postBroadcast sender (Just zcon) msg
+postProteusBroadcast sender zcon msg = postBroadcast sender (Just zcon) msg
 
 unqualifyEndpoint ::
   Functor f =>

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -471,7 +471,7 @@ postCryptoMessageVerifyRejectMissingClientAndRepondMissingPrekeysProto = do
   conv <- decodeConvId <$> postConv alice [bob, eve] (Just "gossip") [] Nothing Nothing
   -- Missing eve
   let ciphertext = toBase64Text "hello bob"
-  let m = otrRecipients [(bob, [(bc, ciphertext)])]
+  let m = otrRecipients [(bob, bc, ciphertext)]
   r1 <-
     postProtoOtrMessage alice ac conv m
       <!! const 412 === statusCode
@@ -500,7 +500,7 @@ postCryptoMessageNotAuthorizeUnknownClient = do
   conv <- decodeConvId <$> postConv alice [bob] (Just "gossip") [] Nothing Nothing
   -- Unknown client ID => 403
   let ciphertext = toBase64Text "hello bob"
-  let m = otrRecipients [(bob, [(bc, ciphertext)])]
+  let m = otrRecipients [(bob, bc, ciphertext)]
   postProtoOtrMessage alice (ClientId "172618352518396") conv m
     !!! const 403 === statusCode
 
@@ -575,7 +575,7 @@ postCryptoMessageVerifyCorrectResponseIfIgnoreAndReportMissingQueryParam = do
   conv <- decodeConvId <$> postConv alice [bob, chad, eve] (Just "gossip") [] Nothing Nothing
   -- Missing eve
   let msgMissingChadAndEve = [(bob, bc, toBase64Text "hello bob")]
-  let m' = otrRecipients [(bob, [(bc, toBase64Text "hello bob")])]
+  let m' = otrRecipients [(bob, bc, toBase64Text "hello bob")]
   -- These three are equivalent (i.e. report all missing clients)
   postOtrMessage id alice ac conv msgMissingChadAndEve
     !!! const 412 === statusCode

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -38,6 +38,7 @@ import Data.ByteString.Conversion
 import Data.ByteString.Lazy (fromStrict)
 import Data.Csv (FromNamedRecord (..), decodeByName)
 import qualified Data.Currency as Currency
+import Data.Default
 import Data.Id
 import Data.Json.Util hiding ((#))
 import qualified Data.LegalHold as LH
@@ -135,13 +136,19 @@ tests s =
       test s "team tests around truncation limits - no events, too large team" (testTeamAddRemoveMemberAboveThresholdNoEvents >> ensureQueueEmpty),
       test s "send billing events to owners even in large teams" testBillingInLargeTeam,
       test s "send billing events to some owners in large teams (indexedBillingTeamMembers disabled)" testBillingInLargeTeamWithoutIndexedBillingTeamMembers,
-      test s "post crypto broadcast message json" postCryptoBroadcastMessageJson,
-      test s "post crypto broadcast message json - filtered only, too large team" postCryptoBroadcastMessageJsonFilteredTooLargeTeam,
-      test s "post crypto broadcast message json (report missing in body)" postCryptoBroadcastMessageJsonReportMissingBody,
-      test s "post crypto broadcast message protobuf" postCryptoBroadcastMessageProto,
-      test s "post crypto broadcast message redundant/missing" postCryptoBroadcastMessageJson2,
-      test s "post crypto broadcast message no-team" postCryptoBroadcastMessageNoTeam,
-      test s "post crypto broadcast message 100 (or max conns)" postCryptoBroadcastMessage100OrMaxConns
+      testGroup "broadcast" $
+        [BroadcastLegacyBody, BroadcastLegacyQueryParams] <&> \api ->
+          let bcast = def {bAPI = api}
+           in testGroup
+                (broadcastAPIName api)
+                [ test s "json" (postCryptoBroadcastMessageJson bcast),
+                  test s "json - filtered only, too large team" (postCryptoBroadcastMessageJsonFilteredTooLargeTeam bcast),
+                  test s "json - report missing in body" (postCryptoBroadcastMessageJsonReportMissingBody bcast),
+                  test s "protobuf" (postCryptoBroadcastMessageProto bcast),
+                  test s "redundant/missing" (postCryptoBroadcastMessageJson2 bcast),
+                  test s "no-team" (postCryptoBroadcastMessageNoTeam bcast),
+                  test s "100 (or max conns)" (postCryptoBroadcastMessage100OrMaxConns bcast)
+                ]
     ]
 
 timeout :: WS.Timeout
@@ -1613,8 +1620,8 @@ testUpdateTeamStatus = do
         const 403 === statusCode
         const "invalid-team-status-update" === (Error.label . responseJsonUnsafeWithMsg "error label")
 
-postCryptoBroadcastMessageJson :: TestM ()
-postCryptoBroadcastMessageJson = do
+postCryptoBroadcastMessageJson :: Broadcast -> TestM ()
+postCryptoBroadcastMessageJson bcast = do
   localDomain <- viewFederationDomain
   let q :: Id a -> Qualified (Id a)
       q = (`Qualified` localDomain)
@@ -1645,7 +1652,7 @@ postCryptoBroadcastMessageJson = do
     -- Alice's clients 1 and 2 listen to their own messages only
     WS.bracketR (c . queryItem "client" (toByteString' ac2)) alice $ \wsA2 ->
       WS.bracketR (c . queryItem "client" (toByteString' ac)) alice $ \wsA1 -> do
-        Util.postOtrBroadcastMessage id alice ac msg !!! do
+        Util.postBroadcast alice ac bcast {bMessage = msg} !!! do
           const 201 === statusCode
           assertMismatch [] [] []
         -- Bob should get the broadcast (team member of alice)
@@ -1663,13 +1670,12 @@ postCryptoBroadcastMessageJson = do
         void . liftIO $
           WS.assertMatch t wsA2 (wsAssertOtr (q (selfConv alice)) (q alice) ac ac2 (toBase64Text "ciphertext0"))
 
-postCryptoBroadcastMessageJsonFilteredTooLargeTeam :: TestM ()
-postCryptoBroadcastMessageJsonFilteredTooLargeTeam = do
+postCryptoBroadcastMessageJsonFilteredTooLargeTeam :: Broadcast -> TestM ()
+postCryptoBroadcastMessageJsonFilteredTooLargeTeam bcast = do
   localDomain <- viewFederationDomain
   let q :: Id a -> Qualified (Id a)
       q = (`Qualified` localDomain)
   opts <- view tsGConf
-  g <- view tsCannon
   c <- view tsCannon
   -- Team1: alice, bob and 3 unnamed
   (alice, tid) <- Util.createBindingTeam
@@ -1708,12 +1714,12 @@ postCryptoBroadcastMessageJsonFilteredTooLargeTeam = do
                 & optSettings . setMaxConvSize .~ 4
         withSettingsOverrides newOpts $ do
           -- Untargeted, Alice's team is too large
-          Util.postOtrBroadcastMessage' g Nothing id alice ac msg !!! do
+          Util.postBroadcast alice ac bcast {bMessage = msg} !!! do
             const 400 === statusCode
             const "too-many-users-to-broadcast" === Error.label . responseJsonUnsafeWithMsg "error label"
           -- We target the message to the 4 users, that should be fine
           let inbody = Just [alice, bob, charlie, dan]
-          Util.postOtrBroadcastMessage' g inbody id alice ac msg !!! do
+          Util.postBroadcast alice ac bcast {bReport = inbody, bMessage = msg} !!! do
             const 201 === statusCode
             assertMismatch [] [] []
         -- Bob should get the broadcast (team member of alice)
@@ -1731,23 +1737,24 @@ postCryptoBroadcastMessageJsonFilteredTooLargeTeam = do
         void . liftIO $
           WS.assertMatch t wsA2 (wsAssertOtr (q (selfConv alice)) (q alice) ac ac2 (toBase64Text "ciphertext0"))
 
-postCryptoBroadcastMessageJsonReportMissingBody :: TestM ()
-postCryptoBroadcastMessageJsonReportMissingBody = do
-  g <- view tsGalley
+postCryptoBroadcastMessageJsonReportMissingBody :: Broadcast -> TestM ()
+postCryptoBroadcastMessageJsonReportMissingBody bcast = do
   (alice, tid) <- Util.createBindingTeam
   bob <- view userId <$> Util.addUserToTeam alice tid
   _bc <- Util.randomClient bob (someLastPrekeys !! 1) -- this is important!
   assertQueue "add bob" $ tUpdate 2 [alice]
   refreshIndex
   ac <- Util.randomClient alice (someLastPrekeys !! 0)
-  let inbody = Just [bob] -- body triggers report
-      inquery = (queryItem "report_missing" (toByteString' alice)) -- query doesn't
+  let -- add extraneous query parameter (unless using query parameter API)
+      inquery = case bAPI bcast of
+        BroadcastLegacyQueryParams -> id
+        _ -> queryItem "report_missing" (toByteString' alice)
       msg = [(alice, ac, "ciphertext0")]
-  Util.postOtrBroadcastMessage' g inbody inquery alice ac msg
+  Util.postBroadcast alice ac bcast {bReport = Just [bob], bMessage = msg, bReq = inquery, bAPI = BroadcastLegacyBody}
     !!! const 412 === statusCode
 
-postCryptoBroadcastMessageJson2 :: TestM ()
-postCryptoBroadcastMessageJson2 = do
+postCryptoBroadcastMessageJson2 :: Broadcast -> TestM ()
+postCryptoBroadcastMessageJson2 bcast = do
   localDomain <- viewFederationDomain
   let q :: Id a -> Qualified (Id a)
       q = (`Qualified` localDomain)
@@ -1766,13 +1773,13 @@ postCryptoBroadcastMessageJson2 = do
   let t = 3 # Second -- WS receive timeout
   -- Missing charlie
   let m1 = [(bob, bc, toBase64Text "ciphertext1")]
-  Util.postOtrBroadcastMessage id alice ac m1 !!! do
+  Util.postBroadcast alice ac bcast {bMessage = m1} !!! do
     const 412 === statusCode
     assertMismatchWithMessage (Just "1: Only Charlie and his device") [(charlie, Set.singleton cc)] [] []
   -- Complete
   WS.bracketR2 c bob charlie $ \(wsB, wsE) -> do
     let m2 = [(bob, bc, toBase64Text "ciphertext2"), (charlie, cc, toBase64Text "ciphertext2")]
-    Util.postOtrBroadcastMessage id alice ac m2 !!! do
+    Util.postBroadcast alice ac bcast {bMessage = m2} !!! do
       const 201 === statusCode
       assertMismatchWithMessage (Just "No devices expected") [] [] []
     void . liftIO $
@@ -1786,7 +1793,7 @@ postCryptoBroadcastMessageJson2 = do
             (bob, bc, toBase64Text "ciphertext3"),
             (charlie, cc, toBase64Text "ciphertext3")
           ]
-    Util.postOtrBroadcastMessage id alice ac m3 !!! do
+    Util.postBroadcast alice ac bcast {bMessage = m3} !!! do
       const 201 === statusCode
       assertMismatchWithMessage (Just "2: Only Alice and her device") [] [(alice, Set.singleton ac)] []
     void . liftIO $
@@ -1799,7 +1806,7 @@ postCryptoBroadcastMessageJson2 = do
   WS.bracketR2 c bob charlie $ \(wsB, wsE) -> do
     deleteClient charlie cc (Just defPassword) !!! const 200 === statusCode
     let m4 = [(bob, bc, toBase64Text "ciphertext4"), (charlie, cc, toBase64Text "ciphertext4")]
-    Util.postOtrBroadcastMessage id alice ac m4 !!! do
+    Util.postBroadcast alice ac bcast {bMessage = m4} !!! do
       const 201 === statusCode
       assertMismatchWithMessage (Just "3: Only Charlie and his device") [] [] [(charlie, Set.singleton cc)]
     void . liftIO $
@@ -1807,8 +1814,8 @@ postCryptoBroadcastMessageJson2 = do
     -- charlie should not get it
     assertNoMsg wsE (wsAssertOtr (q (selfConv charlie)) (q alice) ac cc (toBase64Text "ciphertext4"))
 
-postCryptoBroadcastMessageProto :: TestM ()
-postCryptoBroadcastMessageProto = do
+postCryptoBroadcastMessageProto :: Broadcast -> TestM ()
+postCryptoBroadcastMessageProto bcast = do
   localDomain <- viewFederationDomain
   let q :: Id a -> Qualified (Id a)
       q = (`Qualified` localDomain)
@@ -1831,8 +1838,8 @@ postCryptoBroadcastMessageProto = do
   let t = 1 # Second -- WS receive timeout
   let ciphertext = toBase64Text "hello bob"
   WS.bracketRN c [alice, bob, charlie, dan] $ \ws@[_, wsB, wsC, wsD] -> do
-    let msg = otrRecipients [(bob, [(bc, ciphertext)]), (charlie, [(cc, ciphertext)]), (dan, [(dc, ciphertext)])]
-    Util.postProtoOtrBroadcast alice ac msg !!! do
+    let msg = [(bob, bc, ciphertext), (charlie, cc, ciphertext), (dan, dc, ciphertext)]
+    Util.postBroadcast alice ac bcast {bMessage = msg, bType = BroadcastProto} !!! do
       const 201 === statusCode
       assertMismatch [] [] []
     -- Bob should get the broadcast (team member of alice)
@@ -1843,22 +1850,24 @@ postCryptoBroadcastMessageProto = do
     void . liftIO $ WS.assertMatch t wsD (wsAssertOtr' (toBase64Text "data") (q (selfConv dan)) (q alice) ac dc ciphertext)
     -- Alice should not get her own broadcast
     WS.assertNoEvent timeout ws
-  let inbody = Just [bob] -- body triggers report
-      inquery = (queryItem "report_missing" (toByteString' alice)) -- query doesn't
-      msg = otrRecipients [(alice, [(ac, ciphertext)])]
-  Util.postProtoOtrBroadcast' inbody inquery alice ac msg
+  let -- add extraneous query parameter (unless using query parameter API)
+      inquery = case bAPI bcast of
+        BroadcastLegacyQueryParams -> id
+        _ -> queryItem "report_missing" (toByteString' alice)
+      msg = [(alice, ac, ciphertext)]
+  Util.postBroadcast alice ac bcast {bMessage = msg, bType = BroadcastProto, bReport = Just [bob], bReq = inquery}
     !!! const 412 === statusCode
 
-postCryptoBroadcastMessageNoTeam :: TestM ()
-postCryptoBroadcastMessageNoTeam = do
+postCryptoBroadcastMessageNoTeam :: Broadcast -> TestM ()
+postCryptoBroadcastMessageNoTeam bcast = do
   (alice, ac) <- randomUserWithClient (someLastPrekeys !! 0)
   (bob, bc) <- randomUserWithClient (someLastPrekeys !! 1)
   connectUsers alice (list1 bob [])
   let msg = [(bob, bc, toBase64Text "ciphertext1")]
-  Util.postOtrBroadcastMessage id alice ac msg !!! const 404 === statusCode
+  Util.postBroadcast alice ac bcast {bMessage = msg} !!! const 404 === statusCode
 
-postCryptoBroadcastMessage100OrMaxConns :: TestM ()
-postCryptoBroadcastMessage100OrMaxConns = do
+postCryptoBroadcastMessage100OrMaxConns :: Broadcast -> TestM ()
+postCryptoBroadcastMessage100OrMaxConns bcast = do
   localDomain <- viewFederationDomain
   c <- view tsCannon
   (alice, ac) <- randomUserWithClient (someLastPrekeys !! 0)
@@ -1871,7 +1880,7 @@ postCryptoBroadcastMessage100OrMaxConns = do
   WS.bracketRN c (bob : (fst <$> others)) $ \ws -> do
     let f (u, clt) = (u, clt, toBase64Text "ciphertext")
     let msg = (bob, bc, toBase64Text "ciphertext") : (f <$> others)
-    Util.postOtrBroadcastMessage id alice ac msg !!! do
+    Util.postBroadcast alice ac bcast {bMessage = msg} !!! do
       const 201 === statusCode
       assertMismatch [] [] []
     let qbobself = Qualified (selfConv bob) localDomain

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -146,10 +146,10 @@ tests s =
             let bcast = def {bAPI = api, bType = ty}
              in testGroup
                   (broadcastAPIName api <> " - " <> broadcastTypeName ty)
-                  [ test s "message" (postCryptoBroadcastMessageJson bcast),
-                    test s "filtered only, too large team" (postCryptoBroadcastMessageJsonFilteredTooLargeTeam bcast),
-                    test s "report missing in body" (postCryptoBroadcastMessageJsonReportMissingBody bcast),
-                    test s "redundant/missing" (postCryptoBroadcastMessageJson2 bcast),
+                  [ test s "message" (postCryptoBroadcastMessage bcast),
+                    test s "filtered only, too large team" (postCryptoBroadcastMessageFilteredTooLargeTeam bcast),
+                    test s "report missing in body" (postCryptoBroadcastMessageReportMissingBody bcast),
+                    test s "redundant/missing" (postCryptoBroadcastMessage2 bcast),
                     test s "no-team" (postCryptoBroadcastMessageNoTeam bcast),
                     test s "100 (or max conns)" (postCryptoBroadcastMessage100OrMaxConns bcast)
                   ]
@@ -1624,8 +1624,8 @@ testUpdateTeamStatus = do
         const 403 === statusCode
         const "invalid-team-status-update" === (Error.label . responseJsonUnsafeWithMsg "error label")
 
-postCryptoBroadcastMessageJson :: Broadcast -> TestM ()
-postCryptoBroadcastMessageJson bcast = do
+postCryptoBroadcastMessage :: Broadcast -> TestM ()
+postCryptoBroadcastMessage bcast = do
   localDomain <- viewFederationDomain
   let q :: Id a -> Qualified (Id a)
       q = (`Qualified` localDomain)
@@ -1674,8 +1674,8 @@ postCryptoBroadcastMessageJson bcast = do
         void . liftIO $
           WS.assertMatch t wsA2 (wsAssertOtr (q (selfConv alice)) (q alice) ac ac2 (toBase64Text "ciphertext0"))
 
-postCryptoBroadcastMessageJsonFilteredTooLargeTeam :: Broadcast -> TestM ()
-postCryptoBroadcastMessageJsonFilteredTooLargeTeam bcast = do
+postCryptoBroadcastMessageFilteredTooLargeTeam :: Broadcast -> TestM ()
+postCryptoBroadcastMessageFilteredTooLargeTeam bcast = do
   localDomain <- viewFederationDomain
   let q :: Id a -> Qualified (Id a)
       q = (`Qualified` localDomain)
@@ -1741,8 +1741,8 @@ postCryptoBroadcastMessageJsonFilteredTooLargeTeam bcast = do
         void . liftIO $
           WS.assertMatch t wsA2 (wsAssertOtr (q (selfConv alice)) (q alice) ac ac2 (toBase64Text "ciphertext0"))
 
-postCryptoBroadcastMessageJsonReportMissingBody :: Broadcast -> TestM ()
-postCryptoBroadcastMessageJsonReportMissingBody bcast = do
+postCryptoBroadcastMessageReportMissingBody :: Broadcast -> TestM ()
+postCryptoBroadcastMessageReportMissingBody bcast = do
   localDomain <- viewFederationDomain
   (alice, tid) <- Util.createBindingTeam
   let qalice = Qualified alice localDomain
@@ -1759,8 +1759,8 @@ postCryptoBroadcastMessageJsonReportMissingBody bcast = do
   Util.postBroadcast qalice ac bcast {bReport = Just [bob], bMessage = msg, bReq = inquery}
     !!! const 412 === statusCode
 
-postCryptoBroadcastMessageJson2 :: Broadcast -> TestM ()
-postCryptoBroadcastMessageJson2 bcast = do
+postCryptoBroadcastMessage2 :: Broadcast -> TestM ()
+postCryptoBroadcastMessage2 bcast = do
   localDomain <- viewFederationDomain
   let q :: Id a -> Qualified (Id a)
       q = (`Qualified` localDomain)

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -137,18 +137,22 @@ tests s =
       test s "send billing events to owners even in large teams" testBillingInLargeTeam,
       test s "send billing events to some owners in large teams (indexedBillingTeamMembers disabled)" testBillingInLargeTeamWithoutIndexedBillingTeamMembers,
       testGroup "broadcast" $
-        [BroadcastLegacyBody, BroadcastLegacyQueryParams] <&> \api ->
-          let bcast = def {bAPI = api}
-           in testGroup
-                (broadcastAPIName api)
-                [ test s "json" (postCryptoBroadcastMessageJson bcast),
-                  test s "json - filtered only, too large team" (postCryptoBroadcastMessageJsonFilteredTooLargeTeam bcast),
-                  test s "json - report missing in body" (postCryptoBroadcastMessageJsonReportMissingBody bcast),
-                  test s "protobuf" (postCryptoBroadcastMessageProto bcast),
-                  test s "redundant/missing" (postCryptoBroadcastMessageJson2 bcast),
-                  test s "no-team" (postCryptoBroadcastMessageNoTeam bcast),
-                  test s "100 (or max conns)" (postCryptoBroadcastMessage100OrMaxConns bcast)
-                ]
+        [ (BroadcastLegacyBody, BroadcastJSON),
+          (BroadcastLegacyQueryParams, BroadcastJSON),
+          (BroadcastLegacyBody, BroadcastProto),
+          (BroadcastQualified, BroadcastProto)
+        ]
+          <&> \(api, ty) ->
+            let bcast = def {bAPI = api, bType = ty}
+             in testGroup
+                  (broadcastAPIName api <> " - " <> broadcastTypeName ty)
+                  [ test s "message" (postCryptoBroadcastMessageJson bcast),
+                    test s "filtered only, too large team" (postCryptoBroadcastMessageJsonFilteredTooLargeTeam bcast),
+                    test s "report missing in body" (postCryptoBroadcastMessageJsonReportMissingBody bcast),
+                    test s "redundant/missing" (postCryptoBroadcastMessageJson2 bcast),
+                    test s "no-team" (postCryptoBroadcastMessageNoTeam bcast),
+                    test s "100 (or max conns)" (postCryptoBroadcastMessage100OrMaxConns bcast)
+                  ]
     ]
 
 timeout :: WS.Timeout
@@ -1652,7 +1656,7 @@ postCryptoBroadcastMessageJson bcast = do
     -- Alice's clients 1 and 2 listen to their own messages only
     WS.bracketR (c . queryItem "client" (toByteString' ac2)) alice $ \wsA2 ->
       WS.bracketR (c . queryItem "client" (toByteString' ac)) alice $ \wsA1 -> do
-        Util.postBroadcast alice ac bcast {bMessage = msg} !!! do
+        Util.postBroadcast (q alice) ac bcast {bMessage = msg} !!! do
           const 201 === statusCode
           assertMismatch [] [] []
         -- Bob should get the broadcast (team member of alice)
@@ -1714,12 +1718,12 @@ postCryptoBroadcastMessageJsonFilteredTooLargeTeam bcast = do
                 & optSettings . setMaxConvSize .~ 4
         withSettingsOverrides newOpts $ do
           -- Untargeted, Alice's team is too large
-          Util.postBroadcast alice ac bcast {bMessage = msg} !!! do
+          Util.postBroadcast (q alice) ac bcast {bMessage = msg} !!! do
             const 400 === statusCode
             const "too-many-users-to-broadcast" === Error.label . responseJsonUnsafeWithMsg "error label"
           -- We target the message to the 4 users, that should be fine
           let inbody = Just [alice, bob, charlie, dan]
-          Util.postBroadcast alice ac bcast {bReport = inbody, bMessage = msg} !!! do
+          Util.postBroadcast (q alice) ac bcast {bReport = inbody, bMessage = msg} !!! do
             const 201 === statusCode
             assertMismatch [] [] []
         -- Bob should get the broadcast (team member of alice)
@@ -1739,7 +1743,9 @@ postCryptoBroadcastMessageJsonFilteredTooLargeTeam bcast = do
 
 postCryptoBroadcastMessageJsonReportMissingBody :: Broadcast -> TestM ()
 postCryptoBroadcastMessageJsonReportMissingBody bcast = do
+  localDomain <- viewFederationDomain
   (alice, tid) <- Util.createBindingTeam
+  let qalice = Qualified alice localDomain
   bob <- view userId <$> Util.addUserToTeam alice tid
   _bc <- Util.randomClient bob (someLastPrekeys !! 1) -- this is important!
   assertQueue "add bob" $ tUpdate 2 [alice]
@@ -1750,7 +1756,7 @@ postCryptoBroadcastMessageJsonReportMissingBody bcast = do
         BroadcastLegacyQueryParams -> id
         _ -> queryItem "report_missing" (toByteString' alice)
       msg = [(alice, ac, "ciphertext0")]
-  Util.postBroadcast alice ac bcast {bReport = Just [bob], bMessage = msg, bReq = inquery, bAPI = BroadcastLegacyBody}
+  Util.postBroadcast qalice ac bcast {bReport = Just [bob], bMessage = msg, bReq = inquery, bAPI = BroadcastLegacyBody}
     !!! const 412 === statusCode
 
 postCryptoBroadcastMessageJson2 :: Broadcast -> TestM ()
@@ -1773,13 +1779,13 @@ postCryptoBroadcastMessageJson2 bcast = do
   let t = 3 # Second -- WS receive timeout
   -- Missing charlie
   let m1 = [(bob, bc, toBase64Text "ciphertext1")]
-  Util.postBroadcast alice ac bcast {bMessage = m1} !!! do
+  Util.postBroadcast (q alice) ac bcast {bMessage = m1} !!! do
     const 412 === statusCode
     assertMismatchWithMessage (Just "1: Only Charlie and his device") [(charlie, Set.singleton cc)] [] []
   -- Complete
   WS.bracketR2 c bob charlie $ \(wsB, wsE) -> do
     let m2 = [(bob, bc, toBase64Text "ciphertext2"), (charlie, cc, toBase64Text "ciphertext2")]
-    Util.postBroadcast alice ac bcast {bMessage = m2} !!! do
+    Util.postBroadcast (q alice) ac bcast {bMessage = m2} !!! do
       const 201 === statusCode
       assertMismatchWithMessage (Just "No devices expected") [] [] []
     void . liftIO $
@@ -1793,7 +1799,7 @@ postCryptoBroadcastMessageJson2 bcast = do
             (bob, bc, toBase64Text "ciphertext3"),
             (charlie, cc, toBase64Text "ciphertext3")
           ]
-    Util.postBroadcast alice ac bcast {bMessage = m3} !!! do
+    Util.postBroadcast (q alice) ac bcast {bMessage = m3} !!! do
       const 201 === statusCode
       assertMismatchWithMessage (Just "2: Only Alice and her device") [] [(alice, Set.singleton ac)] []
     void . liftIO $
@@ -1806,7 +1812,7 @@ postCryptoBroadcastMessageJson2 bcast = do
   WS.bracketR2 c bob charlie $ \(wsB, wsE) -> do
     deleteClient charlie cc (Just defPassword) !!! const 200 === statusCode
     let m4 = [(bob, bc, toBase64Text "ciphertext4"), (charlie, cc, toBase64Text "ciphertext4")]
-    Util.postBroadcast alice ac bcast {bMessage = m4} !!! do
+    Util.postBroadcast (q alice) ac bcast {bMessage = m4} !!! do
       const 201 === statusCode
       assertMismatchWithMessage (Just "3: Only Charlie and his device") [] [] [(charlie, Set.singleton cc)]
     void . liftIO $
@@ -1814,57 +1820,15 @@ postCryptoBroadcastMessageJson2 bcast = do
     -- charlie should not get it
     assertNoMsg wsE (wsAssertOtr (q (selfConv charlie)) (q alice) ac cc (toBase64Text "ciphertext4"))
 
-postCryptoBroadcastMessageProto :: Broadcast -> TestM ()
-postCryptoBroadcastMessageProto bcast = do
-  localDomain <- viewFederationDomain
-  let q :: Id a -> Qualified (Id a)
-      q = (`Qualified` localDomain)
-  -- similar to postCryptoBroadcastMessageJson, postCryptoBroadcastMessageJsonReportMissingBody except uses protobuf
-
-  c <- view tsCannon
-  -- Team1: Alice, Bob. Team2: Charlie. Regular user: Dan. Connect Alice,Charlie,Dan
-  (alice, tid) <- Util.createBindingTeam
-  bob <- view userId <$> Util.addUserToTeam alice tid
-  assertQueue "add bob" $ tUpdate 2 [alice]
-  refreshIndex
-  (charlie, _) <- Util.createBindingTeam
-  refreshIndex
-  ac <- Util.randomClient alice (someLastPrekeys !! 0)
-  bc <- Util.randomClient bob (someLastPrekeys !! 1)
-  cc <- Util.randomClient charlie (someLastPrekeys !! 2)
-  (dan, dc) <- randomUserWithClient (someLastPrekeys !! 3)
-  connectUsers alice (list1 charlie [dan])
-  -- Complete: Alice broadcasts a message to Bob,Charlie,Dan
-  let t = 1 # Second -- WS receive timeout
-  let ciphertext = toBase64Text "hello bob"
-  WS.bracketRN c [alice, bob, charlie, dan] $ \ws@[_, wsB, wsC, wsD] -> do
-    let msg = [(bob, bc, ciphertext), (charlie, cc, ciphertext), (dan, dc, ciphertext)]
-    Util.postBroadcast alice ac bcast {bMessage = msg, bType = BroadcastProto} !!! do
-      const 201 === statusCode
-      assertMismatch [] [] []
-    -- Bob should get the broadcast (team member of alice)
-    void . liftIO $ WS.assertMatch t wsB (wsAssertOtr' (toBase64Text "data") (q (selfConv bob)) (q alice) ac bc ciphertext)
-    -- Charlie should get the broadcast (contact of alice and user of teams feature)
-    void . liftIO $ WS.assertMatch t wsC (wsAssertOtr' (toBase64Text "data") (q (selfConv charlie)) (q alice) ac cc ciphertext)
-    -- Dan should get the broadcast (contact of alice and not user of teams feature)
-    void . liftIO $ WS.assertMatch t wsD (wsAssertOtr' (toBase64Text "data") (q (selfConv dan)) (q alice) ac dc ciphertext)
-    -- Alice should not get her own broadcast
-    WS.assertNoEvent timeout ws
-  let -- add extraneous query parameter (unless using query parameter API)
-      inquery = case bAPI bcast of
-        BroadcastLegacyQueryParams -> id
-        _ -> queryItem "report_missing" (toByteString' alice)
-      msg = [(alice, ac, ciphertext)]
-  Util.postBroadcast alice ac bcast {bMessage = msg, bType = BroadcastProto, bReport = Just [bob], bReq = inquery}
-    !!! const 412 === statusCode
-
 postCryptoBroadcastMessageNoTeam :: Broadcast -> TestM ()
 postCryptoBroadcastMessageNoTeam bcast = do
+  localDomain <- viewFederationDomain
   (alice, ac) <- randomUserWithClient (someLastPrekeys !! 0)
+  let qalice = Qualified alice localDomain
   (bob, bc) <- randomUserWithClient (someLastPrekeys !! 1)
   connectUsers alice (list1 bob [])
   let msg = [(bob, bc, toBase64Text "ciphertext1")]
-  Util.postBroadcast alice ac bcast {bMessage = msg} !!! const 404 === statusCode
+  Util.postBroadcast qalice ac bcast {bMessage = msg} !!! const 404 === statusCode
 
 postCryptoBroadcastMessage100OrMaxConns :: Broadcast -> TestM ()
 postCryptoBroadcastMessage100OrMaxConns bcast = do
@@ -1880,7 +1844,7 @@ postCryptoBroadcastMessage100OrMaxConns bcast = do
   WS.bracketRN c (bob : (fst <$> others)) $ \ws -> do
     let f (u, clt) = (u, clt, toBase64Text "ciphertext")
     let msg = (bob, bc, toBase64Text "ciphertext") : (f <$> others)
-    Util.postBroadcast alice ac bcast {bMessage = msg} !!! do
+    Util.postBroadcast qalice ac bcast {bMessage = msg} !!! do
       const 201 === statusCode
       assertMismatch [] [] []
     let qbobself = Qualified (selfConv bob) localDomain


### PR DESCRIPTION
This adds a qualified version of the message broadcast endpoint, with the same API as the one for normal messages. This makes it possible for the clients to uniformly use the qualified API for all possible message types.

Tracked by https://wearezeta.atlassian.net/browse/SQCORE-1257.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
