### PR TITLE
Strip versions from ibis paths

### DIFF
--- a/changelog.d/1-api-changes/strip-ibis-paths
+++ b/changelog.d/1-api-changes/strip-ibis-paths
@@ -1,0 +1,3 @@
+The `/billing` and `/teams/.*/billing` endpoints are now available on a versioned path (e.g. `/v1/billing`)
+
+

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -230,7 +230,7 @@ http {
 
             {{- if $location.strip_version }}
 
-    rewrite ^/v[0-9]+({{ $location.path }}) $1
+    rewrite ^/v[0-9]+({{ $location.path }}) $1;
             {{- end }}
 
     {{- $versioned := ternary $location.versioned true (hasKey $location "versioned") -}}

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -224,7 +224,13 @@ http {
           {{- if or (eq $env $.Values.nginx_conf.env) (eq $env "all") -}}
 
             {{- if and (not (eq $.Values.nginx_conf.env "prod")) ($location.doc) -}}
+
     rewrite ^/api-docs{{ $location.path }}  {{ $location.path }}/api-docs?base_url=https://{{ $.Values.nginx_conf.env }}-nginz-https.{{ $.Values.nginx_conf.external_env_domain }}/ break;
+            {{- end }}
+
+            {{- if $location.strip_version }}
+
+    rewrite ^/v[0-9]+({{ $location.path }}) $1
             {{- end }}
 
     {{- $versioned := ternary $location.versioned true (hasKey $location "versioned") -}}

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -456,9 +456,13 @@ nginx_conf:
       envs:
       - all
       disable_zauth: true
+      versioned: false
+      strip_version: true
     - path: /teams/([^/]*)/billing(.*)
       envs:
       - all
+      versioned: false
+      strip_version: true
     calling-test:
     - path: /calling-test
       envs:


### PR DESCRIPTION
This makes it possible to access external API endpoints not implemented in wire-server with a version prefix.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
