### PR TITLE
Base64 cleanup

### DIFF
--- a/changelog.d/5-internal/base64-cleanup
+++ b/changelog.d/5-internal/base64-cleanup
@@ -1,0 +1,1 @@
+Clean up `Base64ByteString` implementation

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -202,6 +202,9 @@ instance FromHttpApiData Base64ByteString where
 instance ToHttpApiData Base64ByteString where
   toUrlPiece = Text.decodeUtf8With Text.lenientDecode . B64U.encode . fromBase64ByteString
 
+instance S.ToParamSchema Base64ByteString where
+  toParamSchema _ = mempty & S.type_ ?~ S.SwaggerString
+
 base64SchemaN :: ValueSchema NamedSwaggerDoc ByteString
 base64SchemaN = toBase64Text .= parsedText "Base64ByteString" fromBase64Text
 
@@ -231,6 +234,9 @@ instance FromHttpApiData Base64ByteStringL where
 
 instance ToHttpApiData Base64ByteStringL where
   toUrlPiece = toUrlPiece . base64ToStrict
+
+instance S.ToParamSchema Base64ByteStringL where
+  toParamSchema _ = mempty & S.type_ ?~ S.SwaggerString
 
 base64SchemaLN :: ValueSchema NamedSwaggerDoc LByteString
 base64SchemaLN = L.toStrict .= fmap L.fromStrict base64SchemaN

--- a/libs/types-common/test/Test/Properties.hs
+++ b/libs/types-common/test/Test/Properties.hs
@@ -107,15 +107,15 @@ tests =
             \(c :: Char) -> Ascii.contains Ascii.Base64Url c ==> Ascii.contains Ascii.Standard c
         ],
       testGroup
-        "Base64ByteString"
+        "Base64ByteStringL"
         [ testProperty "validate (Aeson.decode . Aeson.encode) == pure . id" $
-            \(Util.Base64ByteString . L.pack -> s) ->
+            \(Util.Base64ByteStringL . L.pack -> s) ->
               (Aeson.eitherDecode . Aeson.encode) s == Right s,
           -- the property only considers valid 'String's, and it does not document the encoding very
           -- well, so here are some unit tests (see
           -- http://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt for more).
           testCase "examples" $ do
-            let go :: Util.Base64ByteString -> L.ByteString -> Assertion
+            let go :: Util.Base64ByteStringL -> L.ByteString -> Assertion
                 go b uu = do
                   Aeson.encode b @=? uu
                   (Aeson.eitherDecode . Aeson.encode) b @=? Right b

--- a/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
+++ b/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
@@ -93,7 +93,7 @@ instance ToSchema KeyPackageData where
   schema =
     (S.schema . S.example ?~ "a2V5IHBhY2thZ2UgZGF0YQo=")
       ( KeyPackageData <$> kpData
-          .= named "KeyPackage" (Base64ByteString .= fmap fromBase64ByteString base64Schema)
+          .= named "KeyPackage" (unnamed base64SchemaL)
       )
 
 data KeyPackageBundleEntry = KeyPackageBundleEntry

--- a/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
+++ b/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
@@ -93,7 +93,7 @@ instance ToSchema KeyPackageData where
   schema =
     (S.schema . S.example ?~ "a2V5IHBhY2thZ2UgZGF0YQo=")
       ( KeyPackageData <$> kpData
-          .= named "KeyPackage" (unnamed base64SchemaL)
+          .= named "KeyPackage" base64SchemaL
       )
 
 data KeyPackageBundleEntry = KeyPackageBundleEntry

--- a/libs/wire-api/src/Wire/API/Message.hs
+++ b/libs/wire-api/src/Wire/API/Message.hs
@@ -80,7 +80,7 @@ import qualified Data.ProtocolBuffers as Protobuf
 import Data.Qualified (Qualified (..))
 import Data.SOP (I (..), NS (..), unI, unZ)
 import Data.Schema
-import Data.Serialize (runGetLazy)
+import Data.Serialize (runGet)
 import qualified Data.Set as Set
 import qualified Data.Swagger as S
 import qualified Data.Swagger.Build.Api as Doc
@@ -157,7 +157,7 @@ instance ToSchema NewOtrMessage where
         <*> newOtrReportMissing .= maybe_ (optField "report_missing" (array schema))
 
 instance FromProto NewOtrMessage where
-  fromProto bs = protoToNewOtrMessage <$> runGetLazy Protobuf.decodeMessage bs
+  fromProto bs = protoToNewOtrMessage <$> runGet Protobuf.decodeMessage bs
 
 protoToNewOtrMessage :: Proto.NewOtrMessage -> NewOtrMessage
 protoToNewOtrMessage msg =
@@ -198,10 +198,10 @@ instance S.ToSchema QualifiedNewOtrMessage where
                \https://github.com/wireapp/generic-message-proto/blob/master/proto/otr.proto."
 
 instance FromProto QualifiedNewOtrMessage where
-  fromProto bs = protolensToQualifiedNewOtrMessage =<< ProtoLens.decodeMessage (LBS.toStrict bs)
+  fromProto bs = protolensToQualifiedNewOtrMessage =<< ProtoLens.decodeMessage bs
 
 instance ToProto QualifiedNewOtrMessage where
-  toProto = LBS.fromStrict . ProtoLens.encodeMessage . qualifiedNewOtrMessageToProto
+  toProto = ProtoLens.encodeMessage . qualifiedNewOtrMessageToProto
 
 protolensToQualifiedNewOtrMessage :: Proto.Otr.QualifiedNewOtrMessage -> Either String QualifiedNewOtrMessage
 protolensToQualifiedNewOtrMessage protoMsg = do

--- a/libs/wire-api/src/Wire/API/ServantProto.hs
+++ b/libs/wire-api/src/Wire/API/ServantProto.hs
@@ -17,6 +17,7 @@
 
 module Wire.API.ServantProto where
 
+import qualified Data.ByteString.Lazy as LBS
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Swagger
 import Imports
@@ -34,22 +35,22 @@ data Proto
 -- it is fairly difficult to keep our custom data type, e.g. in
 -- Wire.API.Message.Proto in sync with the proto files.
 class FromProto a where
-  fromProto :: LByteString -> Either String a
+  fromProto :: ByteString -> Either String a
 
 class ToProto a where
-  toProto :: a -> LByteString
+  toProto :: a -> ByteString
 
 instance Accept Proto where
   contentTypes _ = ("application" // "x-protobuf") :| []
 
 instance FromProto a => MimeUnrender Proto a where
-  mimeUnrender _ bs = fromProto bs
+  mimeUnrender _ bs = fromProto (LBS.toStrict bs)
 
 -- | This wrapper can be used to get the raw protobuf representation of a type.
 -- It is used when the protobuf is supposed to be forwarded somewhere like a
 -- federated remote, this saves us from having to re-encode it.
 data RawProto a = RawProto
-  { rpRaw :: LByteString,
+  { rpRaw :: ByteString,
     rpValue :: a
   }
 

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Runner.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Runner.hs
@@ -83,7 +83,7 @@ protoTestObject ::
   IO Bool
 protoTestObject obj path = do
   let actual = toProto obj
-  msg <- assertRight (decodeMessage @m (LBS.toStrict actual))
+  msg <- assertRight (decodeMessage @m actual)
   let pretty = render (pprintMessage msg)
       dir = "test/golden"
       fullPath = dir <> "/" <> path
@@ -100,7 +100,7 @@ protoTestObject obj path = do
   assertEqual
     (show (typeRep @a) <> ": FromProto of " <> path <> " should match object")
     (Right obj)
-    (fromProto (LBS.fromStrict (encodeMessage expected)))
+    (fromProto (encodeMessage expected))
 
   pure exists
 

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -234,7 +234,7 @@ postRemoteOtrMessage ::
   Members '[FederatorAccess] r =>
   Qualified UserId ->
   Remote ConvId ->
-  LByteString ->
+  ByteString ->
   Sem r (PostOtrResponse MessageSendingStatus)
 postRemoteOtrMessage sender conv rawMsg = do
   let msr =

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -42,7 +42,6 @@ import Control.Lens hiding ((#))
 import Data.Aeson (ToJSON (..))
 import qualified Data.Aeson as A
 import Data.ByteString.Conversion (toByteString')
-import qualified Data.ByteString.Lazy as LBS
 import Data.Domain
 import Data.Id (ConvId, Id (..), UserId, newClientId, randomId)
 import Data.Json.Util (Base64ByteString (..), toBase64Text)
@@ -884,9 +883,7 @@ sendMessage = do
         FedGalley.MessageSendRequest
           { FedGalley.msrConvId = convId,
             FedGalley.msrSender = bobId,
-            FedGalley.msrRawMessage =
-              Base64ByteString
-                (LBS.fromStrict (Protolens.encodeMessage msg))
+            FedGalley.msrRawMessage = Base64ByteString (Protolens.encodeMessage msg)
           }
   let responses2 req
         | frComponent req == Brig =


### PR DESCRIPTION
Clean up of `Base64ByteString`:

 - Add a strict version and make it the default
 - Clean up instances
 - Export an unnamed schema for the raw underlying `ByteString`
 - Add `*HttpApi` instances using `base64url`

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
