### PR TITLE
Map claimed key packages to clients

### DIFF
--- a/changelog.d/2-features/mls
+++ b/changelog.d/2-features/mls
@@ -1,0 +1,3 @@
+MLS implementation progress:
+
+ - key package refs are now mapped after being claimed

--- a/docs/reference/cassandra-schema.cql
+++ b/docs/reference/cassandra-schema.cql
@@ -765,6 +765,28 @@ CREATE TABLE brig_test.mls_key_packages (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
+CREATE TABLE brig_test.mls_key_package_refs (
+    ref blob PRIMARY KEY,
+    client text,
+    conv uuid,
+    conv_domain text,
+    domain text,
+    user uuid
+) WITH bloom_filter_fp_chance = 0.1
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
+    AND comment = ''
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
+    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1.0
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99PERCENTILE';
+
 CREATE TABLE brig_test.excluded_phones (
     prefix text PRIMARY KEY,
     comment text

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -19,6 +19,7 @@ module Wire.API.Routes.Internal.Brig
   ( API,
     EJPD_API,
     AccountAPI,
+    MLSAPI,
     EJPDRequest,
     GetAccountFeatureConfig,
     PutAccountFeatureConfig,
@@ -39,6 +40,8 @@ import Servant.Swagger (HasSwagger (toSwagger))
 import Servant.Swagger.Internal.Orphans ()
 import Servant.Swagger.UI
 import Wire.API.Connection
+import Wire.API.MLS.Credential
+import Wire.API.MLS.KeyPackage
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Routes.Internal.Brig.EJPD
 import Wire.API.Routes.MultiVerb
@@ -134,9 +137,24 @@ type AccountAPI =
         :> MultiVerb 'POST '[Servant.JSON] RegisterInternalResponses (Either RegisterError SelfProfile)
     )
 
+type MLSAPI = GetClientByKeyPackageRef
+
+type GetClientByKeyPackageRef =
+  Summary "Resolve an MLS key package ref to a qualified client ID"
+    :> "mls"
+    :> "key-packages"
+    :> Capture "ref" KeyPackageRef
+    :> MultiVerb
+         'GET
+         '[Servant.JSON]
+         '[ RespondEmpty 404 "Key package ref not found",
+            Respond 200 "Key package ref found" ClientIdentity
+          ]
+         (Maybe ClientIdentity)
+
 type API =
   "i"
-    :> (EJPD_API :<|> AccountAPI)
+    :> (EJPD_API :<|> AccountAPI :<|> MLSAPI)
 
 type SwaggerDocsAPI = "api" :> "internal" :> SwaggerSchemaUI "swagger-ui" "swagger.json"
 

--- a/libs/wire-api/src/Wire/API/User/Client.hs
+++ b/libs/wire-api/src/Wire/API/User/Client.hs
@@ -450,7 +450,7 @@ data Client = Client
   deriving (Arbitrary) via (GenericUniform Client)
   deriving (FromJSON, ToJSON, Swagger.ToSchema) via Schema Client
 
-type MLSPublicKeys = Map SignatureSchemeTag LByteString
+type MLSPublicKeys = Map SignatureSchemeTag ByteString
 
 instance ToSchema Client where
   schema =
@@ -473,7 +473,7 @@ mlsPublicKeysSchema =
     (fromMaybe mempty)
     ( optField
         "mls_public_keys"
-        (map_ base64SchemaL)
+        (map_ base64Schema)
     )
 
 modelClient :: Doc.Model

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -624,6 +624,7 @@ executable brig-schema
       V66_PersonalFeatureConfCallInit
       V67_MLSKeyPackages
       V68_AddMLSPublicKeys
+      V69_MLSKeyPackageRefMapping
       V9
       Paths_brig
   hs-source-dirs:

--- a/services/brig/schema/src/Main.hs
+++ b/services/brig/schema/src/Main.hs
@@ -78,6 +78,7 @@ import qualified V65_FederatedConnections
 import qualified V66_PersonalFeatureConfCallInit
 import qualified V67_MLSKeyPackages
 import qualified V68_AddMLSPublicKeys
+import qualified V69_MLSKeyPackageRefMapping
 import qualified V9
 
 main :: IO ()
@@ -145,7 +146,8 @@ main = do
       V65_FederatedConnections.migration,
       V66_PersonalFeatureConfCallInit.migration,
       V67_MLSKeyPackages.migration,
-      V68_AddMLSPublicKeys.migration
+      V68_AddMLSPublicKeys.migration,
+      V69_MLSKeyPackageRefMapping.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Brig.App
 

--- a/services/brig/schema/src/V69_MLSKeyPackageRefMapping.hs
+++ b/services/brig/schema/src/V69_MLSKeyPackageRefMapping.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V69_MLSKeyPackageRefMapping
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration =
+  Migration 69 "Add key package ref mapping" $
+    schema'
+      [r|
+        CREATE TABLE mls_key_package_refs
+            ( ref blob
+            , domain text
+            , user uuid
+            , client text
+            , conv_domain text
+            , conv uuid
+            , PRIMARY KEY (ref)
+        ) WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
+          AND gc_grace_seconds = 864000;
+     |]

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -35,6 +35,7 @@ import Brig.App
 import Brig.Data.Activation
 import qualified Brig.Data.Client as Data
 import qualified Brig.Data.Connection as Data
+import qualified Brig.Data.MLS.KeyPackage as Data
 import qualified Brig.Data.User as Data
 import qualified Brig.IO.Intra as Intra
 import Brig.Options hiding (internalEvents, sesQueue)
@@ -72,6 +73,8 @@ import Servant.Swagger.Internal.Orphans ()
 import Servant.Swagger.UI
 import qualified System.Logger.Class as Log
 import Wire.API.ErrorDescription
+import Wire.API.MLS.Credential
+import Wire.API.MLS.KeyPackage
 import qualified Wire.API.Routes.Internal.Brig as BrigIRoutes
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Routes.Named
@@ -84,7 +87,7 @@ import Wire.API.User.RichInfo
 -- Sitemap (servant)
 
 servantSitemap :: ServerT BrigIRoutes.API (Handler r)
-servantSitemap = ejpdAPI :<|> accountAPI
+servantSitemap = ejpdAPI :<|> accountAPI :<|> mlsAPI
 
 ejpdAPI :: ServerT BrigIRoutes.EJPD_API (Handler r)
 ejpdAPI =
@@ -94,6 +97,9 @@ ejpdAPI =
     :<|> deleteAccountFeatureConfig
     :<|> getConnectionsStatusUnqualified
     :<|> getConnectionsStatus
+
+mlsAPI :: ServerT BrigIRoutes.MLSAPI (Handler r)
+mlsAPI = getClientByKeyPackageRef
 
 accountAPI :: ServerT BrigIRoutes.AccountAPI (Handler r)
 accountAPI = Named @"createUserNoVerify" createUserNoVerify
@@ -114,6 +120,9 @@ deleteAccountFeatureConfig uid =
 
 swaggerDocsAPI :: Servant.Server BrigIRoutes.SwaggerDocsAPI
 swaggerDocsAPI = swaggerSchemaUIServer BrigIRoutes.swaggerDoc
+
+getClientByKeyPackageRef :: KeyPackageRef -> Handler r (Maybe ClientIdentity)
+getClientByKeyPackageRef ref = runMaybeT $ Data.derefKeyPackage ref
 
 ---------------------------------------------------------------------------
 -- Sitemap (wai-route)

--- a/services/brig/src/Brig/API/MLS/KeyPackages.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages.hs
@@ -65,7 +65,7 @@ claimLocalKeyPackages lusr target = do
     mkEntry :: ClientId -> AppIO r (Maybe KeyPackageBundleEntry)
     mkEntry c =
       runMaybeT $
-        KeyPackageBundleEntry (qUntagged target) c
+        uncurry (KeyPackageBundleEntry (qUntagged target) c)
           <$> Data.claimKeyPackage target c
 
 countKeyPackages :: Local UserId -> ClientId -> Handler r KeyPackageCount

--- a/services/brig/src/Brig/API/MLS/KeyPackages.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages.hs
@@ -66,7 +66,7 @@ claimLocalKeyPackages lusr target = do
     mkEntry c =
       runMaybeT $
         KeyPackageBundleEntry (qUntagged target) c
-          <$> Data.claimKeyPackage (tUnqualified target) c
+          <$> Data.claimKeyPackage target c
 
 countKeyPackages :: Local UserId -> ClientId -> Handler r KeyPackageCount
 countKeyPackages lusr c =

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -136,7 +136,7 @@ import Util.Options
 import Wire.API.User.Identity (Email)
 
 schemaVersion :: Int32
-schemaVersion = 68
+schemaVersion = 69
 
 -------------------------------------------------------------------------------
 -- Environment

--- a/services/brig/test/integration/API/MLS.hs
+++ b/services/brig/test/integration/API/MLS.hs
@@ -17,6 +17,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import UnliftIO.Temporary
 import Util
+import Web.HttpApiData
 import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
 import Wire.API.User
@@ -92,6 +93,17 @@ testKeyPackageClaim brig = do
           )
         <!! const 200 === statusCode
     liftIO $ count @?= 2
+
+  -- check that the package refs are correctly mapped
+  for_ (kpbEntries bundle) $ \e -> do
+    cid <-
+      responseJsonError
+        =<< get (brig . paths ["i", "mls", "key-packages", toHeader (kpbeRef e)])
+        <!! const 200 === statusCode
+    liftIO $ do
+      ciDomain cid @?= qDomain u
+      ciUser cid @?= qUnqualified u
+      ciClient cid @?= kpbeClient e
 
 --------------------------------------------------------------------------------
 

--- a/services/brig/test/integration/API/MLS.hs
+++ b/services/brig/test/integration/API/MLS.hs
@@ -132,7 +132,7 @@ uploadKeyPackages brig store sk u c n = do
   when (sk == SetKey) $
     do
       pk <-
-        liftIO . fmap LBS.fromStrict . spawn . shell . unwords $
+        liftIO . spawn . shell . unwords $
           cmd0 <> ["public-key", clientId]
       put
         ( brig

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -239,6 +239,7 @@ getAccountFeatureConfigClientM ::
       :<|> _
     )
     :<|> _
+    :<|> _
   ) = Client.client (Proxy @IAPI.API)
 
 runHereClientM :: HasCallStack => Client.ClientM a -> App (Either Client.ClientError a)


### PR DESCRIPTION
This PR implements a mapping of key package ref to qualified clients. The corresponding cassandra table also contains fields to hold the qualified conversation ID of where the key package is being used. These fields are not set for the moment, but they will play a role when validating incoming handshake messages.

This also adds an internal brig endpoint to dereference a key package. This is only used in tests for the moment, but it will later be used by galley to resolve a key package ref to a user and client ID.

Part of https://wearezeta.atlassian.net/browse/FS-436.

**Note**: this contains a commit from https://github.com/wireapp/wire-server/pull/2170. Rebase it away before merging.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
