### PR TITLE
Refactor conversation actions to enable dedicated effect sets for each action

### DIFF
--- a/changelog.d/5-internal/refactor-federated-conversation-actions
+++ b/changelog.d/5-internal/refactor-federated-conversation-actions
@@ -1,0 +1,7 @@
+Refactor conversation actions to an existential type consisting of a singleton
+tag (identifying the action) and a dedicated type for the action itself.
+Previously, actions were represented by a big sum type. The new approach
+enables us to describe the needed effects of an action much more precise.
+The existential type is initialized by the Servant endpoints in a way to
+mimic the previous behavior. Thus, no specific migration or service restart
+order should be needed. 

--- a/changelog.d/6-federation/refactor-federated-conversation-actions
+++ b/changelog.d/6-federation/refactor-federated-conversation-actions
@@ -3,5 +3,6 @@ tag (identifying the action) and a dedicated type for the action itself.
 Previously, actions were represented by a big sum type. The new approach
 enables us to describe the needed effects of an action much more precise.
 The existential type is initialized by the Servant endpoints in a way to
-mimic the previous behavior. Thus, no specific migration or service restart
-order should be needed. 
+mimic the previous behavior. But, the messages between services changed.
+Thus, all federated backends need to run the same (new) version. The
+deployment order itself does not matter.

--- a/changelog.d/6-federation/refactor-federated-conversation-actions
+++ b/changelog.d/6-federation/refactor-federated-conversation-actions
@@ -1,8 +1,8 @@
 Refactor conversation actions to an existential type consisting of a singleton
 tag (identifying the action) and a dedicated type for the action itself.
 Previously, actions were represented by a big sum type. The new approach
-enables us to describe the needed effects of an action much more precise.
+enables us to describe the needed effects of an action much more precisely.
 The existential type is initialized by the Servant endpoints in a way to
-mimic the previous behavior. But, the messages between services changed.
+mimic the previous behavior. However, the messages between services changed.
 Thus, all federated backends need to run the same (new) version. The
 deployment order itself does not matter.

--- a/libs/wire-api-federation/package.yaml
+++ b/libs/wire-api-federation/package.yaml
@@ -34,6 +34,7 @@ dependencies:
 - servant-client
 - servant-client-core
 - servant-server
+- singletons
 - sop-core
 - streaming-commons
 - template-haskell

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -63,7 +63,6 @@ type GalleyApi =
     -- this backend
     :<|> FedEndpoint "send-message" MessageSendRequest MessageSendResponse
     :<|> FedEndpoint "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
-    :<|> FedEndpoint "update-conversation" ConversationUpdateRequest ConversationUpdateResponse
 
 data GetConversationsRequest = GetConversationsRequest
   { gcrUserId :: UserId,
@@ -235,30 +234,3 @@ data UserDeletedConversationsNotification = UserDeletedConversationsNotification
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform UserDeletedConversationsNotification)
   deriving (FromJSON, ToJSON) via (CustomEncoded UserDeletedConversationsNotification)
-
-data ConversationUpdateRequest = ConversationUpdateRequest
-  { -- | The user that is attempting to perform the action. This is qualified
-    -- implicitly by the origin domain
-    curUser :: UserId,
-    -- | Id of conversation the action should be performed on. The is qualified
-    -- implicity by the owning backend which receives this request.
-    curConvId :: ConvId,
-    curAction :: SomeConversationAction
-  }
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ConversationUpdateRequest)
-  deriving (FromJSON, ToJSON) via (CustomEncoded ConversationUpdateRequest)
-
-data ConversationUpdateError
-  = InsufficientPrivileges
-  | TODO
-  deriving stock (Eq, Show, Generic)
-  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationUpdateError)
-
-newtype ConversationUpdateResponse = ConversationUpdateResponse
-  { conversationUpdateResponse :: Either ConversationUpdateError ConversationUpdate
-  }
-  deriving stock (Eq, Show)
-  deriving
-    (ToJSON, FromJSON)
-    via (Either (CustomEncoded ConversationUpdateError) ConversationUpdate)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -63,6 +63,7 @@ type GalleyApi =
     -- this backend
     :<|> FedEndpoint "send-message" MessageSendRequest MessageSendResponse
     :<|> FedEndpoint "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
+    :<|> FedEndpoint "update-conversation" ConversationUpdateRequest ConversationUpdateResponse
 
 data GetConversationsRequest = GetConversationsRequest
   { gcrUserId :: UserId,
@@ -145,11 +146,13 @@ data ConversationUpdate = ConversationUpdate
     -- conversation to users.
     cuAlreadyPresentUsers :: [UserId],
     -- | Information on the specific action that caused the update.
-    cuAction :: ConversationAction
+    cuAction :: SomeConversationAction
   }
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ConversationUpdate)
-  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationUpdate)
+  deriving (Eq, Show, Generic)
+
+instance ToJSON ConversationUpdate
+
+instance FromJSON ConversationUpdate
 
 data LeaveConversationRequest = LeaveConversationRequest
   { -- | The conversation is assumed to be owned by the target domain, which
@@ -232,3 +235,30 @@ data UserDeletedConversationsNotification = UserDeletedConversationsNotification
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform UserDeletedConversationsNotification)
   deriving (FromJSON, ToJSON) via (CustomEncoded UserDeletedConversationsNotification)
+
+data ConversationUpdateRequest = ConversationUpdateRequest
+  { -- | The user that is attempting to perform the action. This is qualified
+    -- implicitly by the origin domain
+    curUser :: UserId,
+    -- | Id of conversation the action should be performed on. The is qualified
+    -- implicity by the owning backend which receives this request.
+    curConvId :: ConvId,
+    curAction :: SomeConversationAction
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform ConversationUpdateRequest)
+  deriving (FromJSON, ToJSON) via (CustomEncoded ConversationUpdateRequest)
+
+data ConversationUpdateError
+  = InsufficientPrivileges
+  | TODO
+  deriving stock (Eq, Show, Generic)
+  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationUpdateError)
+
+newtype ConversationUpdateResponse = ConversationUpdateResponse
+  { conversationUpdateResponse :: Either ConversationUpdateError ConversationUpdate
+  }
+  deriving stock (Eq, Show)
+  deriving
+    (ToJSON, FromJSON)
+    via (Either (CustomEncoded ConversationUpdateError) ConversationUpdate)

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationUpdate.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationUpdate.hs
@@ -25,8 +25,10 @@ import Data.Domain (Domain (Domain))
 import Data.Id (Id (Id), UserId)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Qualified (Qualified (Qualified))
+import Data.Singletons (sing)
 import qualified Data.UUID as UUID
 import Imports
+import Wire.API.Conversation
 import Wire.API.Conversation.Action
 import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.Federation.API.Galley (ConversationUpdate (..))
@@ -56,7 +58,7 @@ testObject_ConversationUpdate1 =
       cuConvId =
         Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000006")),
       cuAlreadyPresentUsers = [],
-      cuAction = ConversationActionAddMembers (qAlice :| [qBob]) roleNameWireAdmin
+      cuAction = SomeConversationAction (sing @'ConversationJoinTag) (ConversationJoin (qAlice :| [qBob]) roleNameWireAdmin)
     }
 
 testObject_ConversationUpdate2 :: ConversationUpdate
@@ -70,5 +72,5 @@ testObject_ConversationUpdate2 =
       cuConvId =
         Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000006")),
       cuAlreadyPresentUsers = [chad, dee],
-      cuAction = ConversationActionRemoveMembers (pure qAlice)
+      cuAction = SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure qAlice))
     }

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationUpdate.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationUpdate.hs
@@ -72,5 +72,5 @@ testObject_ConversationUpdate2 =
       cuConvId =
         Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000006")),
       cuAlreadyPresentUsers = [chad, dee],
-      cuAction = SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure qAlice))
+      cuAction = SomeConversationAction (sing @'ConversationLeaveTag) (pure qAlice)
     }

--- a/libs/wire-api-federation/test/golden/testObject_ConversationUpdate1.json
+++ b/libs/wire-api-federation/test/golden/testObject_ConversationUpdate1.json
@@ -1,14 +1,8 @@
 {
-    "orig_user_id": {
-        "domain": "golden.example.com",
-        "id": "00000000-0000-0000-0000-000100000007"
-    },
-    "already_present_users": [],
-    "time": "1864-04-12T12:22:43.673Z",
-    "action": {
-        "tag": "ConversationActionAddMembers",
-        "contents": [
-            [
+    "cuAction": {
+        "action": {
+            "role": "wire_admin",
+            "users": [
                 {
                     "domain": "golden.example.com",
                     "id": "00000000-0000-0000-0000-000100004007"
@@ -17,9 +11,15 @@
                     "domain": "golden2.example.com",
                     "id": "00000000-0000-0000-0000-000100005007"
                 }
-            ],
-            "wire_admin"
-        ]
+            ]
+        },
+        "tag": "ConversationJoinTag"
     },
-    "conv_id": "00000000-0000-0000-0000-000100000006"
+    "cuAlreadyPresentUsers": [],
+    "cuConvId": "00000000-0000-0000-0000-000100000006",
+    "cuOrigUserId": {
+        "domain": "golden.example.com",
+        "id": "00000000-0000-0000-0000-000100000007"
+    },
+    "cuTime": "1864-04-12T12:22:43.673Z"
 }

--- a/libs/wire-api-federation/test/golden/testObject_ConversationUpdate2.json
+++ b/libs/wire-api-federation/test/golden/testObject_ConversationUpdate2.json
@@ -1,21 +1,23 @@
 {
-    "orig_user_id": {
-        "domain": "golden.example.com",
-        "id": "00000000-0000-0000-0000-000100000007"
+    "cuAction": {
+        "action": {
+            "users": [
+                {
+                    "domain": "golden.example.com",
+                    "id": "00000000-0000-0000-0000-000100004007"
+                }
+            ]
+        },
+        "tag": "ConversationLeaveTag"
     },
-    "already_present_users": [
+    "cuAlreadyPresentUsers": [
         "00000fff-0000-0000-0000-000100005007",
         "00000fff-0000-aaaa-0000-000100005007"
     ],
-    "time": "1864-04-12T12:22:43.673Z",
-    "action": {
-        "tag": "ConversationActionRemoveMembers",
-        "contents": [
-            {
-                "domain": "golden.example.com",
-                "id": "00000000-0000-0000-0000-000100004007"
-            }
-        ]
+    "cuConvId": "00000000-0000-0000-0000-000100000006",
+    "cuOrigUserId": {
+        "domain": "golden.example.com",
+        "id": "00000000-0000-0000-0000-000100000007"
     },
-    "conv_id": "00000000-0000-0000-0000-000100000006"
+    "cuTime": "1864-04-12T12:22:43.673Z"
 }

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -97,6 +97,7 @@ library
     , servant-client
     , servant-client-core
     , servant-server
+    , singletons
     , sop-core
     , streaming-commons
     , template-haskell
@@ -197,6 +198,7 @@ test-suite spec
     , servant-client
     , servant-client-core
     , servant-server
+    , singletons
     , sop-core
     , streaming-commons
     , template-haskell

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -70,7 +70,6 @@ module Wire.API.Conversation
     ConversationReceiptModeUpdate (..),
     ConversationMessageTimerUpdate (..),
     ConversationJoin (..),
-    ConversationRemoveMembers (..),
     ConversationMemberUpdate (..),
 
     -- * re-exports
@@ -884,21 +883,6 @@ instance ToSchema ConversationJoin where
       $ ConversationJoin
         <$> cjUsers .= field "users" (nonEmptyArray schema)
         <*> cjRole .= field "role" schema
-
-data ConversationRemoveMembers = ConversationRemoveMembers
-  { crmTargets :: NonEmpty (Qualified UserId)
-  }
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ConversationRemoveMembers)
-  deriving (FromJSON, ToJSON, S.ToSchema) via Schema ConversationRemoveMembers
-
-instance ToSchema ConversationRemoveMembers where
-  schema =
-    objectWithDocModifier
-      "ConversationRemoveMembers"
-      (description ?~ "The action of some users being removed from a conversation")
-      $ ConversationRemoveMembers
-        <$> crmTargets .= field "targets" (nonEmptyArray schema)
 
 data ConversationMemberUpdate = ConversationMemberUpdate
   { cmuTarget :: Qualified UserId,

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -73,7 +73,6 @@ module Wire.API.Conversation
     ConversationLeave (..),
     ConversationRemoveMembers (..),
     ConversationMemberUpdate (..),
-    ConversationDelete (..),
 
     -- * re-exports
     module Wire.API.Conversation.Member,
@@ -932,15 +931,3 @@ instance ToSchema ConversationMemberUpdate where
       $ ConversationMemberUpdate
         <$> cmuTarget .= field "target" schema
         <*> cmuUpdate .= field "update" schema
-
-data ConversationDelete = ConversationDelete
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ConversationDelete)
-  deriving (FromJSON, ToJSON, S.ToSchema) via Schema ConversationDelete
-
-instance ToSchema ConversationDelete where
-  schema =
-    objectWithDocModifier
-      "ConversationDelete"
-      (description ?~ "The action of deleting a conversation")
-      (pure ConversationDelete)

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -70,7 +70,6 @@ module Wire.API.Conversation
     ConversationReceiptModeUpdate (..),
     ConversationMessageTimerUpdate (..),
     ConversationJoin (..),
-    ConversationLeave (..),
     ConversationRemoveMembers (..),
     ConversationMemberUpdate (..),
 
@@ -885,20 +884,6 @@ instance ToSchema ConversationJoin where
       $ ConversationJoin
         <$> cjUsers .= field "users" (nonEmptyArray schema)
         <*> cjRole .= field "role" schema
-
-newtype ConversationLeave = ConversationLeave
-  {clUsers :: NonEmpty (Qualified UserId)}
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ConversationLeave)
-  deriving (FromJSON, ToJSON, S.ToSchema) via Schema ConversationLeave
-
-instance ToSchema ConversationLeave where
-  schema =
-    objectWithDocModifier
-      "ConversationLeave"
-      (description ?~ "The action of some users leaving a conversation on their own")
-      $ ConversationLeave
-        <$> clUsers .= field "users" (nonEmptyArray schema)
 
 data ConversationRemoveMembers = ConversationRemoveMembers
   { crmTargets :: NonEmpty (Qualified UserId)

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -32,7 +32,7 @@ import Data.Aeson (FromJSON (..), ToJSON (..), Value, object, withObject, (.:), 
 import Data.Id
 import Data.Qualified (Qualified)
 import Data.Schema (ToSchema, element, enum, schema, schemaParseJSON, schemaToJSON)
-import Data.Singletons.TH 
+import Data.Singletons.TH
 import Data.Time.Clock
 import Imports
 import Test.QuickCheck (elements)
@@ -79,7 +79,6 @@ instance FromJSON ConversationActionTag where
 
 $(genSingletons [''ConversationActionTag])
 
-$(singEqInstance ''ConversationActionTag)
 $(singDecideInstance ''ConversationActionTag)
 
 -- | We use this type family instead of a sum type to be able to define

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -28,12 +28,14 @@ module Wire.API.Conversation.Action
   )
 where
 
+import Control.Lens ((?~))
 import Data.Aeson
 import qualified Data.Aeson.KeyMap as AKeyMap
 import Data.Id
 import Data.Qualified (Qualified)
-import Data.Schema (NamedSwaggerDoc, ToSchema, ValueSchema, element, enum, schema, schemaIn, schemaOut, schemaParseJSON, schemaToJSON)
+import Data.Schema (NamedSwaggerDoc, ToSchema, ValueSchema, element, enum, objectWithDocModifier, schema, schemaIn, schemaOut, schemaParseJSON, schemaToJSON)
 import Data.Singletons.TH
+import qualified Data.Swagger as S
 import Data.Time.Clock
 import Imports
 import Test.QuickCheck (elements)
@@ -88,7 +90,7 @@ type family ConversationAction (tag :: ConversationActionTag) :: * where
   ConversationAction 'ConversationJoinTag = ConversationJoin
   ConversationAction 'ConversationLeaveTag = ConversationLeave
   ConversationAction 'ConversationMemberUpdateTag = ConversationMemberUpdate
-  ConversationAction 'ConversationDeleteTag = ConversationDelete
+  ConversationAction 'ConversationDeleteTag = ()
   ConversationAction 'ConversationRenameTag = ConversationRename
   ConversationAction 'ConversationMessageTimerUpdateTag = ConversationMessageTimerUpdate
   ConversationAction 'ConversationReceiptModeUpdateTag = ConversationReceiptModeUpdate
@@ -119,7 +121,11 @@ conversationActionSchema SConversationJoinTag = schema @ConversationJoin
 conversationActionSchema SConversationLeaveTag = schema @ConversationLeave
 conversationActionSchema SConversationRemoveMembersTag = schema @ConversationRemoveMembers
 conversationActionSchema SConversationMemberUpdateTag = schema @ConversationMemberUpdate
-conversationActionSchema SConversationDeleteTag = schema @ConversationDelete
+conversationActionSchema SConversationDeleteTag =
+  objectWithDocModifier
+    "ConversationDelete"
+    (S.description ?~ "The action of deleting a conversation")
+    (pure ())
 conversationActionSchema SConversationRenameTag = schema @ConversationRename
 conversationActionSchema SConversationMessageTimerUpdateTag = schema @ConversationMessageTimerUpdate
 conversationActionSchema SConversationReceiptModeUpdateTag = schema @ConversationReceiptModeUpdate

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -163,30 +163,23 @@ conversationActionToEvent ::
   ConversationAction tag ->
   Event
 conversationActionToEvent tag now quid qcnv action =
-  case tag of
-    SConversationJoinTag ->
-      let ConversationJoin newMembers role = action
-       in Event qcnv quid now $
-            EdMembersJoin $ SimpleMembers (map (`SimpleMember` role) (toList newMembers))
-    SConversationLeaveTag ->
-      let ConversationLeave leavingMembers = action
-       in Event qcnv quid now $
-            EdMembersLeave (QualifiedUserIdList (toList leavingMembers))
-    SConversationRemoveMembersTag ->
-      let ConversationRemoveMembers targets = action
-       in Event qcnv quid now $
-            EdMembersLeave (QualifiedUserIdList (toList targets))
-    SConversationMemberUpdateTag ->
-      let ConversationMemberUpdate target (OtherMemberUpdate role) = action
-          update = MemberUpdateData target Nothing Nothing Nothing Nothing Nothing Nothing role
-       in Event qcnv quid now (EdMemberUpdate update)
-    SConversationDeleteTag ->
-      Event qcnv quid now EdConvDelete
-    SConversationRenameTag ->
-      Event qcnv quid now $ EdConvRename action
-    SConversationMessageTimerUpdateTag ->
-      Event qcnv quid now (EdConvMessageTimerUpdate action)
-    SConversationReceiptModeUpdateTag ->
-      Event qcnv quid now (EdConvReceiptModeUpdate action)
-    SConversationAccessDataTag ->
-      Event qcnv quid now (EdConvAccessUpdate action)
+  let edata = case tag of
+        SConversationJoinTag ->
+          let ConversationJoin newMembers role = action
+           in EdMembersJoin $ SimpleMembers (map (`SimpleMember` role) (toList newMembers))
+        SConversationLeaveTag ->
+          let ConversationLeave leavingMembers = action
+           in EdMembersLeave (QualifiedUserIdList (toList leavingMembers))
+        SConversationRemoveMembersTag ->
+          let ConversationRemoveMembers targets = action
+           in EdMembersLeave (QualifiedUserIdList (toList targets))
+        SConversationMemberUpdateTag ->
+          let ConversationMemberUpdate target (OtherMemberUpdate role) = action
+              update = MemberUpdateData target Nothing Nothing Nothing Nothing Nothing Nothing role
+           in EdMemberUpdate update
+        SConversationDeleteTag -> EdConvDelete
+        SConversationRenameTag -> EdConvRename action
+        SConversationMessageTimerUpdateTag -> EdConvMessageTimerUpdate action
+        SConversationReceiptModeUpdateTag -> EdConvReceiptModeUpdate action
+        SConversationAccessDataTag -> EdConvAccessUpdate action
+   in Event qcnv quid now edata

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -162,37 +162,6 @@ conversationActionToEvent ::
   Qualified ConvId ->
   ConversationAction tag ->
   Event
--- conversationActionToEvent now quid qcnv (ConversationActionAddMembers newMembers role) =
---   Event qcnv quid now $
---     EdMembersJoin $ SimpleMembers (map (`SimpleMember` role) (toList newMembers))
--- conversationActionToEvent now quid qcnv (ConversationActionRemoveMembers removedMembers) =
---   Event qcnv quid now $
---     EdMembersLeave (QualifiedUserIdList (toList removedMembers))
--- conversationActionToEvent now quid qcnv (ConversationActionRename rename) =
---   Event qcnv quid now (EdConvRename rename)
--- conversationActionToEvent now quid qcnv (ConversationActionMessageTimerUpdate update) =
---   Event qcnv quid now (EdConvMessageTimerUpdate update)
--- conversationActionToEvent now quid qcnv (ConversationActionReceiptModeUpdate update) =
---   Event qcnv quid now (EdConvReceiptModeUpdate update)
--- conversationActionToEvent now quid qcnv (ConversationActionMemberUpdate target (OtherMemberUpdate role)) =
---   let update = MemberUpdateData target Nothing Nothing Nothing Nothing Nothing Nothing role
---    in Event qcnv quid now (EdMemberUpdate update)
--- conversationActionToEvent now quid qcnv (ConversationActionAccessUpdate update) =
---   Event qcnv quid now (EdConvAccessUpdate update)
--- conversationActionToEvent now quid qcnv ConversationActionDelete =
---   Event qcnv quid now EdConvDelete
--- 
--- conversationActionTag :: Qualified UserId -> ConversationAction -> Action
--- conversationActionTag _ (ConversationActionAddMembers _ _) = AddConversationMember
--- conversationActionTag qusr (ConversationActionRemoveMembers victims)
---   | pure qusr == victims = LeaveConversation
---   | otherwise = RemoveConversationMember
--- conversationActionTag _ (ConversationActionRename _) = ModifyConversationName
--- conversationActionTag _ (ConversationActionMessageTimerUpdate _) = ModifyConversationMessageTimer
--- conversationActionTag _ (ConversationActionReceiptModeUpdate _) = ModifyConversationReceiptMode
--- conversationActionTag _ (ConversationActionMemberUpdate _ _) = ModifyOtherConversationMember
--- conversationActionTag _ (ConversationActionAccessUpdate _) = ModifyConversationAccess
--- conversationActionTag _ ConversationActionDelete = DeleteConversation
 conversationActionToEvent tag now quid qcnv action =
   case tag of
     SConversationJoinTag ->

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -15,6 +15,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 {-# LANGUAGE StandaloneKindSignatures #-}
+-- Ignore unused `genSingletons` Template Haskell results
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 module Wire.API.Conversation.Action

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -14,74 +14,209 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 module Wire.API.Conversation.Action
-  ( ConversationAction (..),
+  ( ConversationAction,
+    ConversationActionTag (..),
+    SConversationActionTag (..),
+    SomeConversationAction (..),
     conversationActionToEvent,
-    conversationActionTag,
+    conversationActionPermission,
   )
 where
 
-import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Aeson (FromJSON (..), ToJSON (..), Value, object, withObject, (.:), (.=))
 import Data.Id
-import Data.List.NonEmpty (NonEmpty)
-import Data.Qualified
+import Data.Qualified (Qualified)
+import Data.Schema (ToSchema, element, enum, schema, schemaParseJSON, schemaToJSON)
+import Data.Singletons (Sing, SomeSing (SomeSing), fromSing, toSing)
+import Data.Singletons.TH (genSingletons, sCases)
 import Data.Time.Clock
 import Imports
-import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
+import Test.QuickCheck (elements)
+import Wire.API.Arbitrary (Arbitrary (..))
 import Wire.API.Conversation
 import Wire.API.Conversation.Role
 import Wire.API.Event.Conversation
-import Wire.API.Util.Aeson (CustomEncoded (..))
 
--- | A sum type consisting of all possible conversation actions.
-data ConversationAction
-  = ConversationActionAddMembers (NonEmpty (Qualified UserId)) RoleName
-  | ConversationActionRemoveMembers (NonEmpty (Qualified UserId))
-  | ConversationActionRename ConversationRename
-  | ConversationActionMessageTimerUpdate ConversationMessageTimerUpdate
-  | ConversationActionReceiptModeUpdate ConversationReceiptModeUpdate
-  | ConversationActionMemberUpdate (Qualified UserId) OtherMemberUpdate
-  | ConversationActionAccessUpdate ConversationAccessData
-  | ConversationActionDelete
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform ConversationAction)
-  deriving (ToJSON, FromJSON) via (CustomEncoded ConversationAction)
+data ConversationActionTag
+  = ConversationJoinTag
+  | ConversationLeaveTag
+  | ConversationRemoveMembersTag
+  | ConversationMemberUpdateTag
+  | ConversationDeleteTag
+  | ConversationRenameTag
+  | ConversationMessageTimerUpdateTag
+  | ConversationReceiptModeUpdateTag
+  | ConversationAccessDataTag
+  deriving (Show, Eq, Generic, Bounded, Enum)
+
+instance Arbitrary ConversationActionTag where
+  arbitrary = elements [minBound .. maxBound]
+
+instance ToSchema ConversationActionTag where
+  schema =
+    enum @Text "ConversationActionTag" $
+      mconcat
+        [ element "ConversationJoinTag" ConversationJoinTag,
+          element "ConversationLeaveTag" ConversationLeaveTag,
+          element "ConversationRemoveMembersTag" ConversationRemoveMembersTag,
+          element "ConversationMemberUpdateTag" ConversationMemberUpdateTag,
+          element "ConversationDeleteTag" ConversationDeleteTag,
+          element "ConversationRenameTag" ConversationRenameTag,
+          element "ConversationMessageTimerUpdateTag" ConversationMessageTimerUpdateTag,
+          element "ConversationReceiptModeUpdateTag" ConversationReceiptModeUpdateTag,
+          element "ConversationAccessDataTag" ConversationAccessDataTag
+        ]
+
+instance ToJSON ConversationActionTag where
+  toJSON = schemaToJSON
+
+instance FromJSON ConversationActionTag where
+  parseJSON = schemaParseJSON
+
+$(genSingletons [''ConversationActionTag])
+
+-- | We use this type family instead of a sum type to be able to define
+-- individual effects per conversation action. See 'HasConversationActionEffects'.
+type family ConversationAction (tag :: ConversationActionTag) :: * where
+  ConversationAction 'ConversationJoinTag = ConversationJoin
+  ConversationAction 'ConversationLeaveTag = ConversationLeave
+  ConversationAction 'ConversationMemberUpdateTag = ConversationMemberUpdate
+  ConversationAction 'ConversationDeleteTag = ConversationDelete
+  ConversationAction 'ConversationRenameTag = ConversationRename
+  ConversationAction 'ConversationMessageTimerUpdateTag = ConversationMessageTimerUpdate
+  ConversationAction 'ConversationReceiptModeUpdateTag = ConversationReceiptModeUpdate
+  ConversationAction 'ConversationAccessDataTag = ConversationAccessData
+  ConversationAction 'ConversationRemoveMembersTag = ConversationRemoveMembers
+
+data SomeConversationAction where
+  SomeConversationAction :: Sing tag -> ConversationAction tag -> SomeConversationAction
+
+instance Show SomeConversationAction where
+  show (SomeConversationAction tag action) =
+    $(sCases ''ConversationActionTag [|tag|] [|show action|])
+
+instance Eq SomeConversationAction where
+  (SomeConversationAction tag1 action1) == (SomeConversationAction tag2 action2) =
+    case (tag1, tag2) of
+      (SConversationJoinTag, SConversationJoinTag) -> action1 == action2
+      (SConversationJoinTag, _) -> False
+      (SConversationLeaveTag, SConversationLeaveTag) -> action1 == action2
+      (SConversationLeaveTag, _) -> False
+      (SConversationMemberUpdateTag, SConversationMemberUpdateTag) -> action1 == action2
+      (SConversationMemberUpdateTag, _) -> False
+      (SConversationDeleteTag, SConversationDeleteTag) -> action1 == action2
+      (SConversationDeleteTag, _) -> False
+      (SConversationRenameTag, SConversationRenameTag) -> action1 == action2
+      (SConversationRenameTag, _) -> False
+      (SConversationMessageTimerUpdateTag, SConversationMessageTimerUpdateTag) -> action1 == action2
+      (SConversationMessageTimerUpdateTag, _) -> False
+      (SConversationReceiptModeUpdateTag, SConversationReceiptModeUpdateTag) -> action1 == action2
+      (SConversationReceiptModeUpdateTag, _) -> False
+      (SConversationAccessDataTag, SConversationAccessDataTag) -> action1 == action2
+      (SConversationAccessDataTag, _) -> False
+      (SConversationRemoveMembersTag, SConversationRemoveMembersTag) -> action1 == action2
+      (SConversationRemoveMembersTag, _) -> False
+
+instance ToJSON SomeConversationAction where
+  toJSON (SomeConversationAction sb action) =
+    let tag = fromSing sb
+        actionJSON :: Value =
+          $(sCases ''ConversationActionTag [|sb|] [|toJSON action|])
+     in object ["tag" .= tag, "action" .= actionJSON]
+
+instance FromJSON SomeConversationAction where
+  parseJSON = withObject "SomeConversationAction" $ \ob -> do
+    tag :: ConversationActionTag <- ob .: "tag"
+    case toSing tag of
+      SomeSing sb -> do
+        $(sCases ''ConversationActionTag [|sb|] [|SomeConversationAction sb <$> (ob .: "action")|])
+
+instance Arbitrary SomeConversationAction where
+  arbitrary = do
+    tag <- arbitrary
+    case toSing tag of
+      SomeSing sb -> do
+        $(sCases ''ConversationActionTag [|sb|] [|SomeConversationAction sb <$> arbitrary|])
+
+conversationActionPermission :: ConversationActionTag -> Action
+conversationActionPermission ConversationJoinTag = AddConversationMember
+conversationActionPermission ConversationLeaveTag = LeaveConversation
+conversationActionPermission ConversationRemoveMembersTag = RemoveConversationMember
+conversationActionPermission ConversationMemberUpdateTag = ModifyOtherConversationMember
+conversationActionPermission ConversationDeleteTag = DeleteConversation
+conversationActionPermission ConversationRenameTag = ModifyConversationName
+conversationActionPermission ConversationMessageTimerUpdateTag = ModifyConversationMessageTimer
+conversationActionPermission ConversationReceiptModeUpdateTag = ModifyConversationReceiptMode
+conversationActionPermission ConversationAccessDataTag = ModifyConversationAccess
 
 conversationActionToEvent ::
+  forall tag.
+  Sing tag ->
   UTCTime ->
   Qualified UserId ->
   Qualified ConvId ->
-  ConversationAction ->
+  ConversationAction tag ->
   Event
-conversationActionToEvent now quid qcnv (ConversationActionAddMembers newMembers role) =
-  Event qcnv quid now $
-    EdMembersJoin $ SimpleMembers (map (`SimpleMember` role) (toList newMembers))
-conversationActionToEvent now quid qcnv (ConversationActionRemoveMembers removedMembers) =
-  Event qcnv quid now $
-    EdMembersLeave (QualifiedUserIdList (toList removedMembers))
-conversationActionToEvent now quid qcnv (ConversationActionRename rename) =
-  Event qcnv quid now (EdConvRename rename)
-conversationActionToEvent now quid qcnv (ConversationActionMessageTimerUpdate update) =
-  Event qcnv quid now (EdConvMessageTimerUpdate update)
-conversationActionToEvent now quid qcnv (ConversationActionReceiptModeUpdate update) =
-  Event qcnv quid now (EdConvReceiptModeUpdate update)
-conversationActionToEvent now quid qcnv (ConversationActionMemberUpdate target (OtherMemberUpdate role)) =
-  let update = MemberUpdateData target Nothing Nothing Nothing Nothing Nothing Nothing role
-   in Event qcnv quid now (EdMemberUpdate update)
-conversationActionToEvent now quid qcnv (ConversationActionAccessUpdate update) =
-  Event qcnv quid now (EdConvAccessUpdate update)
-conversationActionToEvent now quid qcnv ConversationActionDelete =
-  Event qcnv quid now EdConvDelete
-
-conversationActionTag :: Qualified UserId -> ConversationAction -> Action
-conversationActionTag _ (ConversationActionAddMembers _ _) = AddConversationMember
-conversationActionTag qusr (ConversationActionRemoveMembers victims)
-  | pure qusr == victims = LeaveConversation
-  | otherwise = RemoveConversationMember
-conversationActionTag _ (ConversationActionRename _) = ModifyConversationName
-conversationActionTag _ (ConversationActionMessageTimerUpdate _) = ModifyConversationMessageTimer
-conversationActionTag _ (ConversationActionReceiptModeUpdate _) = ModifyConversationReceiptMode
-conversationActionTag _ (ConversationActionMemberUpdate _ _) = ModifyOtherConversationMember
-conversationActionTag _ (ConversationActionAccessUpdate _) = ModifyConversationAccess
-conversationActionTag _ ConversationActionDelete = DeleteConversation
+-- conversationActionToEvent now quid qcnv (ConversationActionAddMembers newMembers role) =
+--   Event qcnv quid now $
+--     EdMembersJoin $ SimpleMembers (map (`SimpleMember` role) (toList newMembers))
+-- conversationActionToEvent now quid qcnv (ConversationActionRemoveMembers removedMembers) =
+--   Event qcnv quid now $
+--     EdMembersLeave (QualifiedUserIdList (toList removedMembers))
+-- conversationActionToEvent now quid qcnv (ConversationActionRename rename) =
+--   Event qcnv quid now (EdConvRename rename)
+-- conversationActionToEvent now quid qcnv (ConversationActionMessageTimerUpdate update) =
+--   Event qcnv quid now (EdConvMessageTimerUpdate update)
+-- conversationActionToEvent now quid qcnv (ConversationActionReceiptModeUpdate update) =
+--   Event qcnv quid now (EdConvReceiptModeUpdate update)
+-- conversationActionToEvent now quid qcnv (ConversationActionMemberUpdate target (OtherMemberUpdate role)) =
+--   let update = MemberUpdateData target Nothing Nothing Nothing Nothing Nothing Nothing role
+--    in Event qcnv quid now (EdMemberUpdate update)
+-- conversationActionToEvent now quid qcnv (ConversationActionAccessUpdate update) =
+--   Event qcnv quid now (EdConvAccessUpdate update)
+-- conversationActionToEvent now quid qcnv ConversationActionDelete =
+--   Event qcnv quid now EdConvDelete
+-- 
+-- conversationActionTag :: Qualified UserId -> ConversationAction -> Action
+-- conversationActionTag _ (ConversationActionAddMembers _ _) = AddConversationMember
+-- conversationActionTag qusr (ConversationActionRemoveMembers victims)
+--   | pure qusr == victims = LeaveConversation
+--   | otherwise = RemoveConversationMember
+-- conversationActionTag _ (ConversationActionRename _) = ModifyConversationName
+-- conversationActionTag _ (ConversationActionMessageTimerUpdate _) = ModifyConversationMessageTimer
+-- conversationActionTag _ (ConversationActionReceiptModeUpdate _) = ModifyConversationReceiptMode
+-- conversationActionTag _ (ConversationActionMemberUpdate _ _) = ModifyOtherConversationMember
+-- conversationActionTag _ (ConversationActionAccessUpdate _) = ModifyConversationAccess
+-- conversationActionTag _ ConversationActionDelete = DeleteConversation
+conversationActionToEvent tag now quid qcnv action =
+  case tag of
+    SConversationJoinTag ->
+      let ConversationJoin newMembers role = action
+       in Event qcnv quid now $
+            EdMembersJoin $ SimpleMembers (map (`SimpleMember` role) (toList newMembers))
+    SConversationLeaveTag ->
+      let ConversationLeave leavingMembers = action
+       in Event qcnv quid now $
+            EdMembersLeave (QualifiedUserIdList (toList leavingMembers))
+    SConversationRemoveMembersTag ->
+      let ConversationRemoveMembers targets = action
+       in Event qcnv quid now $
+            EdMembersLeave (QualifiedUserIdList (toList targets))
+    SConversationMemberUpdateTag ->
+      let ConversationMemberUpdate target (OtherMemberUpdate role) = action
+          update = MemberUpdateData target Nothing Nothing Nothing Nothing Nothing Nothing role
+       in Event qcnv quid now (EdMemberUpdate update)
+    SConversationDeleteTag ->
+      Event qcnv quid now EdConvDelete
+    SConversationRenameTag ->
+      Event qcnv quid now $ EdConvRename action
+    SConversationMessageTimerUpdateTag ->
+      Event qcnv quid now (EdConvMessageTimerUpdate action)
+    SConversationReceiptModeUpdateTag ->
+      Event qcnv quid now (EdConvReceiptModeUpdate action)
+    SConversationAccessDataTag ->
+      Event qcnv quid now (EdConvAccessUpdate action)

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/Aeson.hs
@@ -29,6 +29,7 @@ import qualified Wire.API.Asset as Asset
 import qualified Wire.API.Call.Config as Call.Config
 import qualified Wire.API.Connection as Connection
 import qualified Wire.API.Conversation as Conversation
+import qualified Wire.API.Conversation.Action as Conversation.Action
 import qualified Wire.API.Conversation.Bot as Conversation.Bot
 import qualified Wire.API.Conversation.Code as Conversation.Code
 import qualified Wire.API.Conversation.Member as Conversation.Member
@@ -317,7 +318,8 @@ tests =
       testRoundTrip @User.RichInfo.RichInfo,
       testRoundTrip @(User.Search.SearchResult User.Search.TeamContact),
       testRoundTrip @User.Search.TeamContact,
-      testRoundTrip @(Wrapped.Wrapped "some_int" Int)
+      testRoundTrip @(Wrapped.Wrapped "some_int" Int),
+      testRoundTrip @Conversation.Action.SomeConversationAction
     ]
 
 testRoundTrip ::

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -225,6 +225,7 @@ library
     , servant-server
     , servant-swagger
     , servant-swagger-ui
+    , singletons
     , sop-core
     , split >=0.2
     , ssl-util >=0.1
@@ -445,6 +446,7 @@ executable galley-integration
     , servant-client-core
     , servant-server
     , servant-swagger
+    , singletons
     , sop-core
     , ssl-util
     , string-conversions

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -77,6 +77,7 @@ library:
   - servant-server
   - servant-swagger
   - servant-swagger-ui
+  - singletons
   - sop-core
   - split >=0.2
   - ssl-util >=0.1
@@ -197,6 +198,7 @@ executables:
     - random
     - retry
     - schema-profunctor
+    - singletons
     - servant
     - servant-server
     - servant-swagger

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -33,7 +33,6 @@ module Galley.API.Action
     ensureConversationActionAllowed,
     addMembersToLocalConversation,
     notifyConversationAction,
-    notifyRemoteConversationAction,
     ConversationUpdate,
   )
 where
@@ -41,7 +40,6 @@ where
 import qualified Brig.Types.User as User
 import Control.Arrow
 import Control.Lens
-import Data.ByteString.Conversion (toByteString')
 import Data.Id
 import Data.Kind
 import Data.List.NonEmpty (nonEmpty)
@@ -74,8 +72,6 @@ import Imports
 import Polysemy
 import Polysemy.Error
 import Polysemy.Input
-import qualified Polysemy.TinyLog as P
-import qualified System.Logger as Log
 import Wire.API.Conversation hiding (Conversation, Member)
 import Wire.API.Conversation.Action
 import Wire.API.Conversation.Role
@@ -605,51 +601,3 @@ notifyConversationAction tag quid con lcnv targets action = do
 
   -- notify local participants and bots
   pushConversationEvent con e (qualifyAs lcnv (bmLocals targets)) (bmBots targets) $> e
-
--- | Notify all local members about a remote conversation update that originated
--- from a local user
-notifyRemoteConversationAction ::
-  Members
-    '[ FederatorAccess,
-       ExternalAccess,
-       GundeckAccess,
-       MemberStore,
-       Input (Local ()),
-       P.TinyLog
-     ]
-    r =>
-  Remote ConversationUpdate ->
-  ConnId ->
-  Sem r Event
-notifyRemoteConversationAction rconvUpdate con = do
-  let convUpdate = tUnqualified rconvUpdate
-      rconvId = qualifyAs rconvUpdate . cuConvId $ convUpdate
-
-  let event =
-        case cuAction convUpdate of
-          SomeConversationAction tag action ->
-            conversationActionToEvent tag (cuTime convUpdate) (cuOrigUserId convUpdate) (qUntagged rconvId) action
-
-  -- Note: we generally do not send notifications to users that are not part of
-  -- the conversation (from our point of view), to prevent spam from the remote
-  -- backend.
-  (presentUsers, allUsersArePresent) <-
-    E.selectRemoteMembers (cuAlreadyPresentUsers convUpdate) rconvId
-  loc <- qualifyLocal ()
-  let localPresentUsers = qualifyAs loc presentUsers
-
-  unless allUsersArePresent $
-    P.warn $
-      Log.field "conversation" (toByteString' . tUnqualified $ rconvId)
-        . Log.field "domain" (toByteString' (tDomain rconvUpdate))
-        . Log.msg
-          ( "Attempt to send notification about conversation update \
-            \to users not in the conversation" ::
-              ByteString
-          )
-
-  -- FUTUREWORK: Check if presentUsers contain bots when federated bots are
-  -- implemented.
-  let bots = []
-
-  pushConversationEvent (Just con) event localPresentUsers bots $> event

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -197,7 +197,7 @@ performAction origUser lcnv cnv action =
       E.deleteMembers (convId cnv) (toUserList lcnv presentVictims)
       pure (mempty, action) -- FUTUREWORK: should we return the filtered action here?
     SConversationRemoveMembersTag -> do
-      let presentVictims = filter (isConvMember lcnv cnv) (toList (crmTargets action))
+      let presentVictims = filter (isConvMember lcnv cnv) (toList action)
       when (null presentVictims) noChanges
       E.deleteMembers (convId cnv) (toUserList lcnv presentVictims)
       pure (mempty, action) -- FUTUREWORK: should we return the filtered action here?

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -141,20 +141,6 @@ type family HasConversationActionEffects (tag :: ConversationActionTag) r :: Con
   HasConversationActionEffects 'ConversationReceiptModeUpdateTag r =
     Members '[ConversationStore, Error NoChanges] r
 
--- -- | A sum type consisting of all possible conversation actions.
--- data ConversationAction
---   = ConversationActionAddMembers (NonEmpty (Qualified UserId)) RoleName
---   | ConversationActionRemoveMembers (NonEmpty (Qualified UserId))
---   | ConversationActionRename ConversationRename
---   | ConversationActionMessageTimerUpdate ConversationMessageTimerUpdate
---   | ConversationActionReceiptModeUpdate ConversationReceiptModeUpdate
---   | ConversationActionMemberUpdate (Qualified UserId) OtherMemberUpdate
---   | ConversationActionAccessUpdate ConversationAccessData
---   | ConversationActionDelete
---   deriving stock (Eq, Show, Generic)
---   deriving (Arbitrary) via (GenericUniform ConversationAction)
---   deriving (ToJSON, FromJSON) via (CustomEncoded ConversationAction)
-
 noChanges :: Member (Error NoChanges) r => Sem r a
 noChanges = throw NoChanges
 
@@ -175,7 +161,7 @@ ensureAllowed loc action conv origUser = do
         void $ E.getTeamMember tid (tUnqualified lusr) >>= noteED @NotATeamMember
     SConversationAccessDataTag -> do
       -- 'PrivateAccessRole' is for self-conversations, 1:1 conversations and
-      -- so on; users are not supposed to be able to make other conversations
+      -- so on; users not supposed to be able to make other conversations
       -- have 'PrivateAccessRole'
       when (PrivateAccess `elem` cupAccess action || Set.null (cupAccessRoles action)) $
         throw InvalidTargetAccess

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -18,7 +18,6 @@
 module Galley.API.Action
   ( -- * Conversation action types
     ConversationActionTag (..),
-    ConversationDelete (..),
     ConversationJoin (..),
     ConversationLeave (..),
     ConversationMemberUpdate (..),

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -210,9 +210,8 @@ onConversationUpdated requestingDomain cu = do
   for_ mActualAction $ \(SomeConversationAction tag action) -> do
     let event = conversationActionToEvent tag (F.cuTime cu) (F.cuOrigUserId cu) qconvId action
         targets = nubOrd $ presentUsers <> extraTargets
-    loc' <- qualifyLocal ()
     -- FUTUREWORK: support bots?
-    pushConversationEvent Nothing event (qualifyAs loc' targets) []
+    pushConversationEvent Nothing event (qualifyAs loc targets) []
 
 addLocalUsersToRemoteConv ::
   Members '[BrigAccess, MemberStore, P.TinyLog] r =>

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -169,7 +169,7 @@ onConversationUpdated requestingDomain cu = do
   -- way to make sure that they are actually supposed to receive that notification.
 
   (mActualAction :: Maybe SomeConversationAction, extraTargets :: [UserId]) <- case F.cuAction cu of
-    SomeConversationAction signTag action -> case signTag of
+    sca@(SomeConversationAction signTag action) -> case signTag of
       SConversationJoinTag -> do
         let ConversationJoin toAdd role = action
         let (localUsers, remoteUsers) = partitionQualified loc toAdd
@@ -182,21 +182,21 @@ onConversationUpdated requestingDomain cu = do
         let ConversationLeave toLeave = action
             localUsers = getLocalUsers (tDomain loc) toLeave
         E.deleteMembersInRemoteConversation rconvId localUsers
-        pure (Just $ SomeConversationAction (sing @'ConversationLeaveTag) action, [])
+        pure (Just sca, [])
       SConversationRemoveMembersTag -> do
         let ConversationRemoveMembers toRemove = action
             localUsers = getLocalUsers (tDomain loc) toRemove
         E.deleteMembersInRemoteConversation rconvId localUsers
-        pure (Just $ SomeConversationAction (sing @'ConversationRemoveMembersTag) action, [])
+        pure (Just sca, [])
       SConversationMemberUpdateTag ->
-        pure (Just (SomeConversationAction (sing @'ConversationMemberUpdateTag) action), [])
+        pure (Just sca, [])
       SConversationDeleteTag -> do
         E.deleteMembersInRemoteConversation rconvId presentUsers
-        pure (Just (SomeConversationAction (sing @'ConversationDeleteTag) action), [])
-      SConversationRenameTag -> pure (Just (SomeConversationAction (sing @'ConversationRenameTag) action), [])
-      SConversationMessageTimerUpdateTag -> pure (Just (SomeConversationAction (sing @'ConversationMessageTimerUpdateTag) action), [])
-      SConversationReceiptModeUpdateTag -> pure (Just (SomeConversationAction (sing @'ConversationReceiptModeUpdateTag) action), [])
-      SConversationAccessDataTag -> pure (Just (SomeConversationAction (sing @'ConversationAccessDataTag) action), [])
+        pure (Just sca, [])
+      SConversationRenameTag -> pure (Just sca, [])
+      SConversationMessageTimerUpdateTag -> pure (Just sca, [])
+      SConversationReceiptModeUpdateTag -> pure (Just sca, [])
+      SConversationAccessDataTag -> pure (Just sca, [])
 
   unless allUsersArePresent $
     P.warn $

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -169,7 +169,7 @@ onConversationUpdated requestingDomain cu = do
   -- way to make sure that they are actually supposed to receive that notification.
 
   (mActualAction :: Maybe SomeConversationAction, extraTargets :: [UserId]) <- case F.cuAction cu of
-    sca@(SomeConversationAction signTag action) -> case signTag of
+    sca@(SomeConversationAction singTag action) -> case singTag of
       SConversationJoinTag -> do
         let ConversationJoin toAdd role = action
         let (localUsers, remoteUsers) = partitionQualified loc toAdd

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -183,8 +183,7 @@ onConversationUpdated requestingDomain cu = do
         E.deleteMembersInRemoteConversation rconvId localUsers
         pure (Just sca, [])
       SConversationRemoveMembersTag -> do
-        let ConversationRemoveMembers toRemove = action
-            localUsers = getLocalUsers (tDomain loc) toRemove
+        let localUsers = getLocalUsers (tDomain loc) action
         E.deleteMembersInRemoteConversation rconvId localUsers
         pure (Just sca, [])
       SConversationMemberUpdateTag ->

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -26,11 +26,11 @@ where
 
 import Control.Exception.Safe (catchAny)
 import Control.Lens hiding ((.=))
-import Data.Data (Proxy (Proxy))
 import Data.Id as Id
 import Data.List1 (maybeList1)
 import Data.Qualified
 import Data.Range
+import Data.Singletons
 import Data.String.Conversions (cs)
 import Data.Time
 import GHC.TypeLits (AppendSymbol)
@@ -89,8 +89,8 @@ import qualified Servant.API as Servant
 import Servant.Server
 import System.Logger.Class hiding (Path, name)
 import qualified System.Logger.Class as Log
-import Wire.API.Conversation (ConvIdsPage, pattern GetPaginatedConversationIds)
-import Wire.API.Conversation.Action (ConversationAction (ConversationActionRemoveMembers))
+import Wire.API.Conversation
+import Wire.API.Conversation.Action
 import Wire.API.ErrorDescription
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Galley
@@ -555,7 +555,7 @@ rmUser lusr conn = do
                 cuOrigUserId = qUser,
                 cuConvId = cid,
                 cuAlreadyPresentUsers = tUnqualified remotes,
-                cuAction = ConversationActionRemoveMembers (pure qUser)
+                cuAction = SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure qUser))
               }
       let rpc = fedClient @'Galley @"on-conversation-updated" convUpdate
       runFederatedEither remotes rpc

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -555,7 +555,7 @@ rmUser lusr conn = do
                 cuOrigUserId = qUser,
                 cuConvId = cid,
                 cuAlreadyPresentUsers = tUnqualified remotes,
-                cuAction = SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure qUser))
+                cuAction = SomeConversationAction (sing @'ConversationLeaveTag) (pure qUser)
               }
       let rpc = fedClient @'Galley @"on-conversation-updated" convUpdate
       runFederatedEither remotes rpc

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1090,7 +1090,6 @@ removeMemberFromLocalConv lcnv lusr con victim
       fmap hush
       . runError @NoChanges
       . updateLocalConversationWithLocalUser @'ConversationLeaveTag lcnv lusr con
-      . ConversationLeave
       . pure
       $ victim
   | otherwise =

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1125,11 +1125,11 @@ postProteusMessage ::
   Qualified ConvId ->
   RawProto QualifiedNewOtrMessage ->
   Sem r (PostOtrResponse MessageSendingStatus)
-postProteusMessage sender zcon conv msg' = runLocalInput sender $ do
+postProteusMessage sender zcon conv msg = runLocalInput sender $ do
   foldQualified
     sender
-    (\c -> postQualifiedOtrMessage User (qUntagged sender) (Just zcon) c (rpValue msg'))
-    (\c -> postRemoteOtrMessage (qUntagged sender) c (rpRaw msg'))
+    (\c -> postQualifiedOtrMessage User (qUntagged sender) (Just zcon) c (rpValue msg))
+    (\c -> postRemoteOtrMessage (qUntagged sender) c (rpRaw msg))
     conv
 
 postProteusBroadcast ::

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -513,7 +513,7 @@ deleteLocalConversation ::
   Sem r (UpdateResult Event)
 deleteLocalConversation lusr con lcnv =
   getUpdateResult $
-    updateLocalConversationWithLocalUser @'ConversationDeleteTag lcnv lusr (Just con) ConversationDelete
+    updateLocalConversationWithLocalUser @'ConversationDeleteTag lcnv lusr (Just con) ()
 
 getUpdateResult :: Sem (Error NoChanges ': r) a -> Sem r (UpdateResult a)
 getUpdateResult = fmap (either (const Unchanged) Updated) . runError

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1097,7 +1097,6 @@ removeMemberFromLocalConv lcnv lusr con victim
       fmap hush
       . runError @NoChanges
       . updateLocalConversationWithLocalUser @'ConversationRemoveMembersTag lcnv lusr con
-      . ConversationRemoveMembers
       . pure
       $ victim
 

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -840,3 +840,13 @@ ensureMemberLimit old new = do
   let maxSize = fromIntegral (o ^. optSettings . setMaxConvSize)
   when (length old + length new > maxSize) $
     throw TooManyMembers
+
+ensureConversationUpdate ::
+  Members '[Error ActionError] r =>
+  ConversationUpdateResponse ->
+  Sem r ConversationUpdate
+ensureConversationUpdate response = do
+  case conversationUpdateResponse response of
+    Left InsufficientPrivileges -> throw InvalidPermissions
+    Left TODO -> error "TODO"
+    Right convUpdate -> pure convUpdate

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -840,13 +840,3 @@ ensureMemberLimit old new = do
   let maxSize = fromIntegral (o ^. optSettings . setMaxConvSize)
   when (length old + length new > maxSize) $
     throw TooManyMembers
-
-ensureConversationUpdate ::
-  Members '[Error ActionError] r =>
-  ConversationUpdateResponse ->
-  Sem r ConversationUpdate
-ensureConversationUpdate response = do
-  case conversationUpdateResponse response of
-    Left InsufficientPrivileges -> throw InvalidPermissions
-    Left TODO -> error "TODO"
-    Right convUpdate -> pure convUpdate

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2245,7 +2245,7 @@ testDeleteTeamConversationWithRemoteMembers = do
 
   liftIO $ do
     let convUpdates = mapMaybe (eitherToMaybe . parseFedRequest) received
-    convUpdate <- case filter ((== (SomeConversationAction (sing @'ConversationDeleteTag) ConversationDelete)) . cuAction) convUpdates of
+    convUpdate <- case filter ((== (SomeConversationAction (sing @'ConversationDeleteTag) ())) . cuAction) convUpdates of
       [] -> assertFailure "No ConversationUpdate requests received"
       [convDelete] -> pure convDelete
       _ -> assertFailure "Multiple ConversationUpdate requests received"

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1519,7 +1519,7 @@ testAccessUpdateGuestRemoved = do
         [ frComponent freq == Galley,
           frRPC freq == "on-conversation-updated",
           fmap F.cuAction (eitherDecode (frBody freq))
-            == Right (SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (charlie :| [dee])))
+            == Right (SomeConversationAction (sing @'ConversationLeaveTag) (charlie :| [dee]))
         ]
 
   -- only alice and bob remain
@@ -3542,25 +3542,25 @@ removeUser = do
       bConvUpdates <- mapM (assertRight . eitherDecode . frBody) bConvUpdateRPCs
 
       bConvUpdatesA2 <- assertOne $ filter (\cu -> cuConvId cu == convA2) bConvUpdates
-      cuAction bConvUpdatesA2 @?= SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure alexDel))
+      cuAction bConvUpdatesA2 @?= SomeConversationAction (sing @'ConversationLeaveTag) (pure alexDel)
       cuAlreadyPresentUsers bConvUpdatesA2 @?= [qUnqualified berta]
 
       bConvUpdatesA4 <- assertOne $ filter (\cu -> cuConvId cu == convA4) bConvUpdates
-      cuAction bConvUpdatesA4 @?= SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure alexDel))
+      cuAction bConvUpdatesA4 @?= SomeConversationAction (sing @'ConversationLeaveTag) (pure alexDel)
       cuAlreadyPresentUsers bConvUpdatesA4 @?= [qUnqualified bart]
 
     liftIO $ do
       cConvUpdateRPC <- assertOne $ filter (matchFedRequest cDomain "on-conversation-updated") fedRequests
       Right convUpdate <- pure . eitherDecode . frBody $ cConvUpdateRPC
       cuConvId convUpdate @?= convA4
-      cuAction convUpdate @?= SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure alexDel))
+      cuAction convUpdate @?= SomeConversationAction (sing @'ConversationLeaveTag) (pure alexDel)
       cuAlreadyPresentUsers convUpdate @?= [qUnqualified carl]
 
     liftIO $ do
       dConvUpdateRPC <- assertOne $ filter (matchFedRequest dDomain "on-conversation-updated") fedRequests
       Right convUpdate <- pure . eitherDecode . frBody $ dConvUpdateRPC
       cuConvId convUpdate @?= convA2
-      cuAction convUpdate @?= SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure alexDel))
+      cuAction convUpdate @?= SomeConversationAction (sing @'ConversationLeaveTag) (pure alexDel)
       cuAlreadyPresentUsers convUpdate @?= [qUnqualified dwight]
 
   -- Check memberships

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -568,7 +568,7 @@ notifyDeletedConversation = do
               FedGalley.cuOrigUserId = qbob,
               FedGalley.cuConvId = qUnqualified qconv,
               FedGalley.cuAlreadyPresentUsers = [alice],
-              FedGalley.cuAction = SomeConversationAction (sing @'ConversationDeleteTag) ConversationDelete
+              FedGalley.cuAction = SomeConversationAction (sing @'ConversationDeleteTag) ()
             }
     runFedClient @"on-conversation-updated" fedGalleyClient bobDomain cu
 

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -351,7 +351,7 @@ removeLocalUser = do
             FedGalley.cuConvId = conv,
             FedGalley.cuAlreadyPresentUsers = [alice],
             FedGalley.cuAction =
-              SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure qAlice))
+              SomeConversationAction (sing @'ConversationLeaveTag) (pure qAlice)
           }
 
   connectWithRemoteUser alice qBob
@@ -415,7 +415,7 @@ removeRemoteUser = do
             FedGalley.cuConvId = conv,
             FedGalley.cuAlreadyPresentUsers = [alice, charlie, dee],
             FedGalley.cuAction =
-              SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure user))
+              SomeConversationAction (sing @'ConversationLeaveTag) (pure user)
           }
 
   WS.bracketRN c [alice, charlie, dee, flo] $ \[wsA, wsC, wsD, wsF] -> do
@@ -1047,7 +1047,7 @@ onUserDeleted = do
       FedGalley.cuOrigUserId bobDomainRPCReq @?= qUntagged bob
       FedGalley.cuConvId bobDomainRPCReq @?= qUnqualified groupConvId
       sort (FedGalley.cuAlreadyPresentUsers bobDomainRPCReq) @?= sort [tUnqualified bob, qUnqualified bart]
-      FedGalley.cuAction bobDomainRPCReq @?= (SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure $ qUntagged bob)))
+      FedGalley.cuAction bobDomainRPCReq @?= (SomeConversationAction (sing @'ConversationLeaveTag) (pure $ qUntagged bob))
 
       -- Assertions about RPC to 'cDomain'
       cDomainRPC <- assertOne $ filter (\c -> frTargetDomain c == cDomain) rpcCalls
@@ -1055,4 +1055,4 @@ onUserDeleted = do
       FedGalley.cuOrigUserId cDomainRPCReq @?= qUntagged bob
       FedGalley.cuConvId cDomainRPCReq @?= qUnqualified groupConvId
       FedGalley.cuAlreadyPresentUsers cDomainRPCReq @?= [qUnqualified carl]
-      FedGalley.cuAction cDomainRPCReq @?= (SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure $ qUntagged bob)))
+      FedGalley.cuAction cDomainRPCReq @?= (SomeConversationAction (sing @'ConversationLeaveTag) (pure $ qUntagged bob))

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -32,6 +32,7 @@ import Data.List1
 import qualified Data.List1 as List1
 import Data.Misc
 import Data.Qualified
+import Data.Singletons
 import Federator.MockServer (FederatedRequest (..))
 import Galley.Types
 import Galley.Types.Conversations.Roles
@@ -174,8 +175,7 @@ messageTimerChangeWithRemotes = do
       Right cu <- pure . eitherDecode . frBody $ req
       F.cuConvId cu @?= qUnqualified qconv
       F.cuAction cu
-        @?= ConversationActionMessageTimerUpdate
-          (ConversationMessageTimerUpdate timer1sec)
+        @?= SomeConversationAction (sing @'ConversationMessageTimerUpdateTag) (ConversationMessageTimerUpdate timer1sec)
 
     void . liftIO . WS.assertMatch (5 # Second) wsB $ \n -> do
       let e = List1.head (WS.unpackPayload n)

--- a/services/galley/test/integration/API/Roles.hs
+++ b/services/galley/test/integration/API/Roles.hs
@@ -29,6 +29,7 @@ import Data.List1
 import qualified Data.List1 as List1
 import Data.Qualified
 import qualified Data.Set as Set
+import Data.Singletons
 import Federator.MockServer (FederatedRequest (..))
 import Galley.Types
 import Galley.Types.Conversations.Roles
@@ -41,6 +42,7 @@ import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
 import TestHelpers
 import TestSetup
+import Wire.API.Conversation
 import Wire.API.Conversation.Action
 import Wire.API.Event.Conversation
 import qualified Wire.API.Federation.API.Galley as F
@@ -203,7 +205,7 @@ roleUpdateRemoteMember = do
       Right cu <- pure . eitherDecode . frBody $ req
       F.cuConvId cu @?= qUnqualified qconv
       F.cuAction cu
-        @?= ConversationActionMemberUpdate qcharlie (OtherMemberUpdate (Just roleNameWireMember))
+        @?= SomeConversationAction (sing @'ConversationMemberUpdateTag) (ConversationMemberUpdate qcharlie (OtherMemberUpdate (Just roleNameWireMember)))
       sort (F.cuAlreadyPresentUsers cu) @?= sort [qUnqualified qalice, qUnqualified qcharlie]
 
     liftIO . WS.assertMatch_ (5 # Second) wsB $ \n -> do
@@ -272,7 +274,7 @@ roleUpdateWithRemotes = do
       Right cu <- pure . eitherDecode . frBody $ req
       F.cuConvId cu @?= qUnqualified qconv
       F.cuAction cu
-        @?= ConversationActionMemberUpdate qcharlie (OtherMemberUpdate (Just roleNameWireAdmin))
+        @?= SomeConversationAction (sing @'ConversationMemberUpdateTag) (ConversationMemberUpdate qcharlie (OtherMemberUpdate (Just roleNameWireAdmin)))
       F.cuAlreadyPresentUsers cu @?= [qUnqualified qalice]
 
     liftIO . WS.assertMatchN_ (5 # Second) [wsB, wsC] $ \n -> do
@@ -315,7 +317,7 @@ accessUpdateWithRemotes = do
       frRPC req @?= "on-conversation-updated"
       Right cu <- pure . eitherDecode . frBody $ req
       F.cuConvId cu @?= qUnqualified qconv
-      F.cuAction cu @?= ConversationActionAccessUpdate access
+      F.cuAction cu @?= SomeConversationAction (sing @'ConversationAccessDataTag) access
       F.cuAlreadyPresentUsers cu @?= [qUnqualified qalice]
 
     liftIO . WS.assertMatchN_ (5 # Second) [wsB, wsC] $ \n -> do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1569,7 +1569,7 @@ assertLeaveUpdate req qconvId remover alreadyPresentUsers victim = liftIO $ do
   cuOrigUserId cu @?= remover
   cuConvId cu @?= qUnqualified qconvId
   sort (cuAlreadyPresentUsers cu) @?= sort alreadyPresentUsers
-  cuAction cu @?= SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure victim))
+  cuAction cu @?= SomeConversationAction (sing @'ConversationLeaveTag) (pure victim)
 
 -------------------------------------------------------------------------------
 -- Helpers

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -36,9 +36,7 @@ import Control.Retry (constantDelay, exponentialBackoff, limitRetries, retrying)
 import Data.Aeson hiding (json)
 import Data.Aeson.Lens (key, _String)
 import qualified Data.ByteString as BS
-import Data.ByteString.Builder (toLazyByteString)
 import qualified Data.ByteString.Char8 as C
-import qualified Data.ByteString.Char8 as C8
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.CaseInsensitive as CI
@@ -60,12 +58,10 @@ import qualified Data.ProtoLens as Protolens
 import Data.ProtocolBuffers (encodeMessage)
 import Data.Qualified
 import Data.Range
-import qualified Data.Sequence as Seq
 import Data.Serialize (runPut)
 import qualified Data.Set as Set
 import Data.Singletons
 import Data.String.Conversions (ST, cs)
-import qualified Data.Text as T
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy.Encoding as T
 import Data.Time (getCurrentTime)
@@ -73,7 +69,6 @@ import qualified Data.UUID as UUID
 import Data.UUID.V4
 import Federator.MockServer (FederatedRequest (..))
 import qualified Federator.MockServer as Mock
-import GHC.TypeLits
 import Galley.Intra.User (chunkify)
 import qualified Galley.Options as Opts
 import qualified Galley.Run as Run
@@ -98,19 +93,11 @@ import Gundeck.Types.Notification
   )
 import Imports
 import Network.HTTP.Media.MediaType
-import Network.HTTP.Media.RenderHeader (renderHeader)
-import Network.HTTP.Types (http11, renderQuery)
 import qualified Network.HTTP.Types as HTTP
 import Network.Wai (Application, defaultRequest)
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Test as Wai
-import qualified Network.Wai.Test as WaiTest
 import Servant (Handler, HasServer, Server, ServerT, serve, (:<|>) (..))
-import Servant.Client (ClientError (FailureResponse))
-import qualified Servant.Client as Servant
-import Servant.Client.Core (RunClient (throwClientError))
-import qualified Servant.Client.Core as Servant
-import qualified Servant.Client.Core.Request as ServantRequest
 import System.Random
 import qualified Test.QuickCheck as Q
 import Test.Tasty.Cannon (TimeoutUnit (..), (#))
@@ -2596,99 +2583,3 @@ matchFedRequest :: Domain -> Text -> FederatedRequest -> Bool
 matchFedRequest domain reqpath req =
   frTargetDomain req == domain
     && frRPC req == reqpath
-
-wsAssertConvReceiptModeUpdate :: Qualified ConvId -> Qualified UserId -> ReceiptMode -> Notification -> IO ()
-wsAssertConvReceiptModeUpdate conv usr new n = do
-  let e = List1.head (WS.unpackPayload n)
-  ntfTransient n @?= False
-  evtConv e @?= conv
-  evtType e @?= ConvReceiptModeUpdate
-  evtFrom e @?= usr
-  evtData e @?= EdConvReceiptModeUpdate (ConversationReceiptModeUpdate new)
-
-newtype WaiTestFedClient a = WaiTestFedClient {unWaiTestFedClient :: ReaderT Domain WaiTest.Session a}
-  deriving (Functor, Applicative, Monad, MonadIO)
-
-instance Servant.RunClient WaiTestFedClient where
-  runRequestAcceptStatus expectedStatuses servantRequest = WaiTestFedClient $ do
-    domain <- ask
-    let req' = fromServantRequest domain servantRequest
-    res <- lift $ WaiTest.srequest req'
-    let servantResponse = toServantResponse res
-    let status = Servant.responseStatusCode servantResponse
-    let statusIsSuccess =
-          case expectedStatuses of
-            Nothing -> HTTP.statusIsSuccessful status
-            Just ex -> status `elem` ex
-    unless statusIsSuccess $
-      unWaiTestFedClient $ throwClientError (FailureResponse (bimap (const ()) (\x -> (Servant.BaseUrl Servant.Http "" 80 "", cs (toLazyByteString x))) servantRequest) servantResponse)
-    pure servantResponse
-  throwClientError = liftIO . throw
-
-fromServantRequest :: Domain -> Servant.Request -> WaiTest.SRequest
-fromServantRequest domain r =
-  let pathBS = "/federation" <> Data.String.Conversions.cs (toLazyByteString (Servant.requestPath r))
-      bodyBS = case Servant.requestBody r of
-        Nothing -> ""
-        Just (bdy, _) -> case bdy of
-          Servant.RequestBodyLBS lbs -> Data.String.Conversions.cs lbs
-          Servant.RequestBodyBS bs -> bs
-          Servant.RequestBodySource _ -> error "fromServantRequest: not implemented for RequestBodySource"
-
-      -- Content-Type and Accept are specified by requestBody and requestAccept
-      headers =
-        filter (\(h, _) -> h /= "Accept" && h /= "Content-Type") $
-          toList $ Servant.requestHeaders r
-      acceptHdr
-        | null hs = Nothing
-        | otherwise = Just ("Accept", renderHeader hs)
-        where
-          hs = toList $ ServantRequest.requestAccept r
-      contentTypeHdr = case ServantRequest.requestBody r of
-        Nothing -> Nothing
-        Just (_', typ) -> Just (HTTP.hContentType, renderHeader typ)
-      req =
-        Wai.defaultRequest
-          { Wai.requestMethod = Servant.requestMethod r,
-            Wai.rawPathInfo = pathBS,
-            Wai.rawQueryString = renderQuery True (toList (Servant.requestQueryString r)),
-            Wai.requestHeaders =
-              -- Inspired by 'Servant.Client.Internal.HttpClient.defaultMakeClientRequest',
-              -- the Servant function that maps @Request@ to @Client.Request@.
-              -- This solution is a bit sophisticated due to two constraints:
-              --   - Accept header may contain a list of accepted media types.
-              --   - Accept and Content-Type headers should only appear once in the result.
-              maybeToList acceptHdr
-                <> maybeToList contentTypeHdr
-                <> headers
-                <> [(originDomainHeaderName, Text.encodeUtf8 (domainText domain))],
-            Wai.isSecure = True,
-            Wai.pathInfo = filter (not . T.null) (map Data.String.Conversions.cs (C8.split '/' pathBS)),
-            Wai.queryString = toList (Servant.requestQueryString r)
-          }
-   in WaiTest.SRequest req (cs bodyBS)
-
-toServantResponse :: WaiTest.SResponse -> Servant.Response
-toServantResponse res =
-  Servant.Response
-    { Servant.responseStatusCode = WaiTest.simpleStatus res,
-      Servant.responseHeaders = Seq.fromList (WaiTest.simpleHeaders res),
-      Servant.responseBody = WaiTest.simpleBody res,
-      Servant.responseHttpVersion = http11
-    }
-
-createWaiTestFedClient ::
-  forall (name :: Symbol) comp api.
-  ( HasFedEndpoint comp api name,
-    Servant.HasClient WaiTestFedClient api
-  ) =>
-  Servant.Client WaiTestFedClient api
-createWaiTestFedClient =
-  Servant.clientIn (Proxy @api) (Proxy @WaiTestFedClient)
-
-runWaiTestFedClient ::
-  Domain ->
-  WaiTestFedClient a ->
-  WaiTest.Session a
-runWaiTestFedClient domain action =
-  runReaderT (unWaiTestFedClient action) domain

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 -- This file is part of the Wire Server implementation.

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 -- This file is part of the Wire Server implementation.
@@ -35,13 +36,14 @@ import Control.Retry (constantDelay, exponentialBackoff, limitRetries, retrying)
 import Data.Aeson hiding (json)
 import Data.Aeson.Lens (key, _String)
 import qualified Data.ByteString as BS
+import Data.ByteString.Builder (toLazyByteString)
 import qualified Data.ByteString.Char8 as C
+import qualified Data.ByteString.Char8 as C8
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Code as Code
 import qualified Data.Currency as Currency
-import Data.Data (Proxy (Proxy))
 import Data.Default
 import Data.Domain
 import qualified Data.Handle as Handle
@@ -58,9 +60,12 @@ import qualified Data.ProtoLens as Protolens
 import Data.ProtocolBuffers (encodeMessage)
 import Data.Qualified
 import Data.Range
+import qualified Data.Sequence as Seq
 import Data.Serialize (runPut)
 import qualified Data.Set as Set
+import Data.Singletons
 import Data.String.Conversions (ST, cs)
+import qualified Data.Text as T
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy.Encoding as T
 import Data.Time (getCurrentTime)
@@ -68,6 +73,7 @@ import qualified Data.UUID as UUID
 import Data.UUID.V4
 import Federator.MockServer (FederatedRequest (..))
 import qualified Federator.MockServer as Mock
+import GHC.TypeLits
 import Galley.Intra.User (chunkify)
 import qualified Galley.Options as Opts
 import qualified Galley.Run as Run
@@ -92,11 +98,19 @@ import Gundeck.Types.Notification
   )
 import Imports
 import Network.HTTP.Media.MediaType
+import Network.HTTP.Media.RenderHeader (renderHeader)
+import Network.HTTP.Types (http11, renderQuery)
 import qualified Network.HTTP.Types as HTTP
 import Network.Wai (Application, defaultRequest)
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Test as Wai
+import qualified Network.Wai.Test as WaiTest
 import Servant (Handler, HasServer, Server, ServerT, serve, (:<|>) (..))
+import Servant.Client (ClientError (FailureResponse))
+import qualified Servant.Client as Servant
+import Servant.Client.Core (RunClient (throwClientError))
+import qualified Servant.Client.Core as Servant
+import qualified Servant.Client.Core.Request as ServantRequest
 import System.Random
 import qualified Test.QuickCheck as Q
 import Test.Tasty.Cannon (TimeoutUnit (..), (#))
@@ -1559,7 +1573,17 @@ assertRemoveUpdate req qconvId remover alreadyPresentUsers victim = liftIO $ do
   cuOrigUserId cu @?= remover
   cuConvId cu @?= qUnqualified qconvId
   sort (cuAlreadyPresentUsers cu) @?= sort alreadyPresentUsers
-  cuAction cu @?= ConversationActionRemoveMembers (pure victim)
+  cuAction cu @?= SomeConversationAction (sing @'ConversationRemoveMembersTag) (ConversationRemoveMembers (pure victim))
+
+assertLeaveUpdate :: (MonadIO m, HasCallStack) => FederatedRequest -> Qualified ConvId -> Qualified UserId -> [UserId] -> Qualified UserId -> m ()
+assertLeaveUpdate req qconvId remover alreadyPresentUsers victim = liftIO $ do
+  frRPC req @?= "on-conversation-updated"
+  frOriginDomain req @?= qDomain qconvId
+  let Just cu = decode (frBody req)
+  cuOrigUserId cu @?= remover
+  cuConvId cu @?= qUnqualified qconvId
+  sort (cuAlreadyPresentUsers cu) @?= sort alreadyPresentUsers
+  cuAction cu @?= SomeConversationAction (sing @'ConversationLeaveTag) (ConversationLeave (pure victim))
 
 -------------------------------------------------------------------------------
 -- Helpers
@@ -2526,6 +2550,10 @@ assertOne :: (HasCallStack, MonadIO m, Show a) => [a] -> m a
 assertOne [a] = pure a
 assertOne xs = liftIO . assertFailure $ "Expected exactly one element, found " <> show xs
 
+assertNone :: (HasCallStack, MonadIO m, Show a) => [a] -> m ()
+assertNone [] = pure ()
+assertNone xs = liftIO . assertFailure $ "Expected exactly no elements, found " <> show xs
+
 assertJust :: (HasCallStack, MonadIO m) => Maybe a -> m a
 assertJust (Just a) = pure a
 assertJust Nothing = liftIO $ assertFailure "Expected Just, got Nothing"
@@ -2568,3 +2596,99 @@ matchFedRequest :: Domain -> Text -> FederatedRequest -> Bool
 matchFedRequest domain reqpath req =
   frTargetDomain req == domain
     && frRPC req == reqpath
+
+wsAssertConvReceiptModeUpdate :: Qualified ConvId -> Qualified UserId -> ReceiptMode -> Notification -> IO ()
+wsAssertConvReceiptModeUpdate conv usr new n = do
+  let e = List1.head (WS.unpackPayload n)
+  ntfTransient n @?= False
+  evtConv e @?= conv
+  evtType e @?= ConvReceiptModeUpdate
+  evtFrom e @?= usr
+  evtData e @?= EdConvReceiptModeUpdate (ConversationReceiptModeUpdate new)
+
+newtype WaiTestFedClient a = WaiTestFedClient {unWaiTestFedClient :: ReaderT Domain WaiTest.Session a}
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+instance Servant.RunClient WaiTestFedClient where
+  runRequestAcceptStatus expectedStatuses servantRequest = WaiTestFedClient $ do
+    domain <- ask
+    let req' = fromServantRequest domain servantRequest
+    res <- lift $ WaiTest.srequest req'
+    let servantResponse = toServantResponse res
+    let status = Servant.responseStatusCode servantResponse
+    let statusIsSuccess =
+          case expectedStatuses of
+            Nothing -> HTTP.statusIsSuccessful status
+            Just ex -> status `elem` ex
+    unless statusIsSuccess $
+      unWaiTestFedClient $ throwClientError (FailureResponse (bimap (const ()) (\x -> (Servant.BaseUrl Servant.Http "" 80 "", cs (toLazyByteString x))) servantRequest) servantResponse)
+    pure servantResponse
+  throwClientError = liftIO . throw
+
+fromServantRequest :: Domain -> Servant.Request -> WaiTest.SRequest
+fromServantRequest domain r =
+  let pathBS = "/federation" <> Data.String.Conversions.cs (toLazyByteString (Servant.requestPath r))
+      bodyBS = case Servant.requestBody r of
+        Nothing -> ""
+        Just (bdy, _) -> case bdy of
+          Servant.RequestBodyLBS lbs -> Data.String.Conversions.cs lbs
+          Servant.RequestBodyBS bs -> bs
+          Servant.RequestBodySource _ -> error "fromServantRequest: not implemented for RequestBodySource"
+
+      -- Content-Type and Accept are specified by requestBody and requestAccept
+      headers =
+        filter (\(h, _) -> h /= "Accept" && h /= "Content-Type") $
+          toList $ Servant.requestHeaders r
+      acceptHdr
+        | null hs = Nothing
+        | otherwise = Just ("Accept", renderHeader hs)
+        where
+          hs = toList $ ServantRequest.requestAccept r
+      contentTypeHdr = case ServantRequest.requestBody r of
+        Nothing -> Nothing
+        Just (_', typ) -> Just (HTTP.hContentType, renderHeader typ)
+      req =
+        Wai.defaultRequest
+          { Wai.requestMethod = Servant.requestMethod r,
+            Wai.rawPathInfo = pathBS,
+            Wai.rawQueryString = renderQuery True (toList (Servant.requestQueryString r)),
+            Wai.requestHeaders =
+              -- Inspired by 'Servant.Client.Internal.HttpClient.defaultMakeClientRequest',
+              -- the Servant function that maps @Request@ to @Client.Request@.
+              -- This solution is a bit sophisticated due to two constraints:
+              --   - Accept header may contain a list of accepted media types.
+              --   - Accept and Content-Type headers should only appear once in the result.
+              maybeToList acceptHdr
+                <> maybeToList contentTypeHdr
+                <> headers
+                <> [(originDomainHeaderName, Text.encodeUtf8 (domainText domain))],
+            Wai.isSecure = True,
+            Wai.pathInfo = filter (not . T.null) (map Data.String.Conversions.cs (C8.split '/' pathBS)),
+            Wai.queryString = toList (Servant.requestQueryString r)
+          }
+   in WaiTest.SRequest req (cs bodyBS)
+
+toServantResponse :: WaiTest.SResponse -> Servant.Response
+toServantResponse res =
+  Servant.Response
+    { Servant.responseStatusCode = WaiTest.simpleStatus res,
+      Servant.responseHeaders = Seq.fromList (WaiTest.simpleHeaders res),
+      Servant.responseBody = WaiTest.simpleBody res,
+      Servant.responseHttpVersion = http11
+    }
+
+createWaiTestFedClient ::
+  forall (name :: Symbol) comp api.
+  ( HasFedEndpoint comp api name,
+    Servant.HasClient WaiTestFedClient api
+  ) =>
+  Servant.Client WaiTestFedClient api
+createWaiTestFedClient =
+  Servant.clientIn (Proxy @api) (Proxy @WaiTestFedClient)
+
+runWaiTestFedClient ::
+  Domain ->
+  WaiTestFedClient a ->
+  WaiTest.Session a
+runWaiTestFedClient domain action =
+  runReaderT (unWaiTestFedClient action) domain

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1559,7 +1559,7 @@ assertRemoveUpdate req qconvId remover alreadyPresentUsers victim = liftIO $ do
   cuOrigUserId cu @?= remover
   cuConvId cu @?= qUnqualified qconvId
   sort (cuAlreadyPresentUsers cu) @?= sort alreadyPresentUsers
-  cuAction cu @?= SomeConversationAction (sing @'ConversationRemoveMembersTag) (ConversationRemoveMembers (pure victim))
+  cuAction cu @?= SomeConversationAction (sing @'ConversationRemoveMembersTag) (pure victim)
 
 assertLeaveUpdate :: (MonadIO m, HasCallStack) => FederatedRequest -> Qualified ConvId -> Qualified UserId -> [UserId] -> Qualified UserId -> m ()
 assertLeaveUpdate req qconvId remover alreadyPresentUsers victim = liftIO $ do


### PR DESCRIPTION
Use a tagged [existential type](https://github.com/wireapp/wire-server/pull/2173/files#diff-3c203a61ccca5fe1f578d7518b2990e3fa347690624cc9cc5e4b678fc71df441R96) and a [type family](https://github.com/wireapp/wire-server/pull/2173/files#diff-c79e1b19d4681c1519e5f54d0fc5609df659a2168f84d082f31225b8824636f6R88) to provide a dedicated list of effects for each conversation action.
Previously, actions were represented by a [sum type](https://github.com/wireapp/wire-server/pull/2173/files#diff-3c203a61ccca5fe1f578d7518b2990e3fa347690624cc9cc5e4b678fc71df441L38). The replacement is a (logical) pair of a [tag](https://github.com/wireapp/wire-server/pull/2173/files#diff-3c203a61ccca5fe1f578d7518b2990e3fa347690624cc9cc5e4b678fc71df441R45) and an accompanying [action type](https://github.com/wireapp/wire-server/pull/2173/files#diff-a3da6271c27cfbacc7d2bb7604cbe22f4a8cb336e9bb4a0807b443ac26290e92R873).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
