### PR TITLE
Fix spar user provisioning corner case

### DIFF
--- a/changelog.d/3-bug-fixes/more-spar-tests
+++ b/changelog.d/3-bug-fixes/more-spar-tests
@@ -1,0 +1,1 @@
+Always create spar credentials during SCIM provisioning when applicable

--- a/changelog.d/5-internal/more-spar-tests
+++ b/changelog.d/5-internal/more-spar-tests
@@ -1,1 +1,0 @@
-Refactor user provisioning in spar; more integration tests

--- a/changelog.d/5-internal/more-spar-tests
+++ b/changelog.d/5-internal/more-spar-tests
@@ -1,0 +1,1 @@
+Refactor user provisioning in spar; more integration tests

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -263,7 +263,7 @@ typeTeamFeatureName = Doc.string . Doc.enum $ cs . toByteString' <$> [(minBound 
 data TeamFeatureStatusValue
   = TeamFeatureEnabled
   | TeamFeatureDisabled
-  deriving stock (Eq, Show, Generic)
+  deriving stock (Eq, Ord, Enum, Bounded, Show, Generic)
   deriving (Arbitrary) via (GenericUniform TeamFeatureStatusValue)
   deriving (ToJSON, FromJSON, S.ToSchema) via (Schema TeamFeatureStatusValue)
 

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -384,12 +384,7 @@ veidEmail (ST.EmailOnly email) = Just email
 importStoredScimUser ::
   forall m r.
   ( (m ~ Scim.ScimHandler (Sem r)),
-    Member Random r,
-    Member Now r,
-    Member (Input Opts) r,
-    Member (Logger (Msg -> Msg)) r,
     Member (Logger String) r,
-    Member GalleyAccess r,
     Member BrigAccess r,
     Member ScimExternalIdStore r,
     Member ScimUserTimesStore r,
@@ -413,13 +408,6 @@ importStoredScimUser midp stiTeam storedUsr = do
 createValidScimUserSpar ::
   forall m r.
   ( (m ~ Scim.ScimHandler (Sem r)),
-    Member Random r,
-    Member Now r,
-    Member (Input Opts) r,
-    Member (Logger (Msg -> Msg)) r,
-    Member (Logger String) r,
-    Member GalleyAccess r,
-    Member BrigAccess r,
     Member ScimExternalIdStore r,
     Member ScimUserTimesStore r,
     Member SAMLUserStore r
@@ -926,12 +914,9 @@ synthesizeScimUser info =
 getUserById ::
   forall r.
   ( Member BrigAccess r,
-    Member GalleyAccess r,
     Member (Input Opts) r,
     Member (Logger (Msg -> Msg)) r,
-    Member (Logger String) r,
     Member Now r,
-    Member Random r,
     Member SAMLUserStore r,
     Member ScimExternalIdStore r,
     Member ScimUserTimesStore r
@@ -956,12 +941,9 @@ getUserById mIdpConfig stiTeam uid = do
 scimFindUserByHandle ::
   forall r.
   ( Member BrigAccess r,
-    Member GalleyAccess r,
     Member (Input Opts) r,
     Member (Logger (Msg -> Msg)) r,
-    Member (Logger String) r,
     Member Now r,
-    Member Random r,
     Member SAMLUserStore r,
     Member ScimExternalIdStore r,
     Member ScimUserTimesStore r
@@ -984,12 +966,9 @@ scimFindUserByHandle mIdpConfig stiTeam hndl = do
 scimFindUserByEmail ::
   forall r.
   ( Member BrigAccess r,
-    Member GalleyAccess r,
     Member (Input Opts) r,
     Member (Logger (Msg -> Msg)) r,
-    Member (Logger String) r,
     Member Now r,
-    Member Random r,
     Member SAMLUserStore r,
     Member ScimExternalIdStore r,
     Member ScimUserTimesStore r

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -30,7 +30,7 @@ where
 
 import Bilge
 import Bilge.Assert
-import Brig.Types.Intra (AccountStatus (Active, PendingInvitation, Suspended), accountStatus, accountUser)
+import Brig.Types.Intra (AccountStatus (Active, PendingInvitation, Suspended), UserAccount (..), accountStatus, accountUser)
 import Brig.Types.User as Brig
 import qualified Control.Exception
 import Control.Lens
@@ -46,7 +46,7 @@ import Data.Aeson.Types (fromJSON, toJSON)
 import Data.ByteString.Conversion
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Csv as Csv
-import Data.Handle (Handle (Handle), fromHandle)
+import Data.Handle (Handle (Handle), fromHandle, parseHandleEither)
 import Data.Id (TeamId, UserId, randomId)
 import Data.Ix (inRange)
 import Data.Misc (HttpsUrl, mkHttpsUrl)
@@ -58,6 +58,8 @@ import Imports
 import qualified Network.Wai.Utilities.Error as Wai
 import qualified SAML2.WebSSO as SAML
 import qualified SAML2.WebSSO.Test.MockResponse as SAML
+import SAML2.WebSSO.Test.Util.TestSP (makeSampleIdPMetadata)
+import qualified SAML2.WebSSO.Test.Util.Types as SAML
 import qualified Spar.Intra.BrigApp as Intra
 import Spar.Scim
 import Spar.Scim.Types (normalizeLikeStored)
@@ -78,6 +80,7 @@ import qualified Web.Scim.Schema.User as Scim.User
 import qualified Wire.API.Team.Export as CsvExport
 import qualified Wire.API.Team.Feature as Feature
 import Wire.API.Team.Invitation (Invitation (..))
+import Wire.API.User.Identity (emailToSAMLNameID)
 import Wire.API.User.IdentityProvider (IdP)
 import qualified Wire.API.User.IdentityProvider as User
 import Wire.API.User.RichInfo
@@ -98,6 +101,8 @@ spec = do
   specAzureQuirks
   specEmailValidation
   specSuspend
+  specImportToScimFromSAML
+  specImportToScimFromInvitation
   specSCIMManaged
   describe "CRUD operations maintain invariants in mapScimToBrig, mapBrigToScim." $ do
     it "..." $ do
@@ -105,6 +110,199 @@ spec = do
   describe "validateScimUser'" $ do
     it "works" $ do
       pendingWith "write a list of unit tests here that make the mapping explicit, exhaustive, and easy to read."
+
+specImportToScimFromSAML :: SpecWith TestEnv
+specImportToScimFromSAML =
+  describe "Create with SAML autoprovisioning; then re-provision with SCIM" $ do
+    forM_ ((,,) <$> [minBound ..] <*> [minBound ..] <*> [minBound ..]) $ \(x, y, z) -> check x y z
+  where
+    check :: Bool -> Bool -> Feature.TeamFeatureStatusValue -> SpecWith TestEnv
+    check sameHandle sameDisplayName valemail = it (show (sameHandle, sameDisplayName, valemail)) $ do
+      (_ownerid, teamid, idp, (_, privCreds)) <- registerTestIdPWithMeta
+      setSamlEmailValidation teamid valemail
+
+      -- saml-auto-provision a new user
+      (usr :: Scim.User.User SparTag, email :: Email) <- do
+        (usr, email) <- randomScimUserWithEmail
+        pure
+          ( -- when auto-provisioning via saml, user display name is set to saml name id.
+            usr {Scim.User.displayName = Just $ fromEmail email},
+            email
+          )
+
+      (uref :: SAML.UserRef, uid :: UserId) <- do
+        let uref = SAML.UserRef tenant subj
+            subj = emailToSAMLNameID email
+            tenant = idp ^. SAML.idpMetadata . SAML.edIssuer
+        !(Just !uid) <- createViaSaml idp privCreds uref
+        samlUserShouldSatisfy uref isJust
+        pure (uref, uid)
+
+      let handle = fromRight undefined . parseHandleEither $ Scim.User.userName usr
+      runSpar (BrigAccess.setHandle uid handle)
+
+      assertSparCassandraUref (uref, Just uid)
+      assertSparCassandraScim ((teamid, email), Nothing)
+      assertBrigCassandra uid uref usr (valemail, False) ManagedByWire
+
+      -- activate email
+      case valemail of
+        Feature.TeamFeatureEnabled -> do
+          asks (view teBrig) >>= \brig -> call (activateEmail brig email)
+          assertBrigCassandra uid uref usr (valemail, True) ManagedByWire
+        Feature.TeamFeatureDisabled -> do
+          pure ()
+
+      -- now import to scim
+      tok :: ScimToken <- do
+        -- this can only happen now, since it turns off saml-autoprovisioning.
+        registerScimToken teamid (Just (idp ^. SAML.idpId))
+
+      storedUserGot :: Scim.UserC.StoredUser SparTag <- do
+        resp <-
+          aFewTimes (getUser_ (Just tok) uid =<< view teSpar) ((== 200) . statusCode)
+            <!! const 200 === statusCode
+        pure $ responseJsonUnsafe resp
+
+      liftIO $ scimUserId storedUserGot `shouldBe` uid
+      assertSparCassandraUref (uref, Just uid)
+      assertSparCassandraScim ((teamid, email), Nothing) -- we write to spar.user *or* spar.scim_external, not both.
+      assertBrigCassandra uid uref (Scim.value . Scim.thing $ storedUserGot) (valemail, True) ManagedByScim
+
+      (usr' :: Scim.User.User SparTag) <- do
+        (usr_, _) <- randomScimUserWithEmail
+        usr
+          & (if sameHandle then id else \u -> u {Scim.User.userName = Scim.User.userName usr_})
+          & (if sameDisplayName then id else \u -> u {Scim.User.displayName = Scim.User.displayName usr_})
+          & pure
+
+      storedUserUpdated :: Scim.UserC.StoredUser SparTag <- do
+        resp <-
+          aFewTimes (updateUser_ (Just tok) (Just uid) usr' =<< view teSpar) ((== 200) . statusCode)
+            <!! const 200 === statusCode
+        pure $ responseJsonUnsafe resp
+
+      -- async vodoo: wait until the dust has settled...  (just in case things look good for a
+      -- half-second, then go bad)
+      threadDelay 800000
+
+      liftIO $ scimUserId storedUserUpdated `shouldBe` uid
+      assertSparCassandraUref (uref, Just uid)
+      assertSparCassandraScim ((teamid, email), Nothing)
+      assertBrigCassandra uid uref (Scim.value . Scim.thing $ storedUserUpdated) (valemail, True) ManagedByScim
+
+      -- login again
+      !(Just !uid') <- createViaSaml idp privCreds uref
+      liftIO $ uid' `shouldBe` uid
+
+specImportToScimFromInvitation :: SpecWith TestEnv
+specImportToScimFromInvitation =
+  describe "Create with TM invitation; then re-provision with SCIM" $ do
+    check True
+  where
+    createTeam :: HasCallStack => TestSpar (UserId, TeamId)
+    createTeam = do
+      env <- ask
+      call $ createUserWithTeam (env ^. teBrig) (env ^. teGalley)
+
+    invite :: HasCallStack => UserId -> TeamId -> TestSpar (UserId, Email)
+    invite owner teamid = do
+      env <- ask
+      memberInvited <- call (inviteAndRegisterUser (env ^. teBrig) owner teamid)
+      let memberIdInvited = userId memberInvited
+          emailInvited = maybe (error "must have email") id (userEmail memberInvited)
+      pure (memberIdInvited, emailInvited)
+
+    addSamlIdP :: HasCallStack => UserId -> TestSpar (SAML.IdPConfig User.WireIdP, SAML.SignPrivCreds)
+    addSamlIdP userid = do
+      env <- ask
+      apiVersion <- view teWireIdPAPIVersion
+      SAML.SampleIdP idpmeta privkey _ _ <- makeSampleIdPMetadata
+      idp <- call $ callIdpCreate apiVersion (env ^. teSpar) (Just userid) idpmeta
+      pure (idp, privkey)
+
+    reProvisionWithScim :: HasCallStack => Bool -> Maybe (SAML.IdPConfig User.WireIdP) -> TeamId -> UserId -> ReaderT TestEnv IO ()
+    reProvisionWithScim changeHandle mbidp teamid userid = do
+      tok :: ScimToken <- do
+        registerScimToken teamid ((^. SAML.idpId) <$> mbidp)
+
+      storedUserGot :: Scim.UserC.StoredUser SparTag <- do
+        resp <-
+          aFewTimes (getUser_ (Just tok) userid =<< view teSpar) ((== 200) . statusCode)
+            <!! const 200 === statusCode
+        pure $ responseJsonUnsafe resp
+
+      when changeHandle $ do
+        (usr' :: Scim.User.User SparTag, uid :: UserId) <- do
+          (usr_, _) <- randomScimUserWithEmail
+          pure
+            ( (Scim.value . Scim.thing $ storedUserGot) {Scim.User.userName = Scim.User.userName usr_},
+              Scim.id . Scim.thing $ storedUserGot
+            )
+
+        _storedUserUpdated :: Scim.UserC.StoredUser SparTag <- do
+          resp <-
+            aFewTimes (updateUser_ (Just tok) (Just uid) usr' =<< view teSpar) ((== 200) . statusCode)
+              <!! const 200 === statusCode
+          pure $ responseJsonUnsafe resp
+
+        pure ()
+
+    signInWithSaml :: HasCallStack => (SAML.IdPConfig User.WireIdP, SAML.SignPrivCreds) -> Email -> TestSpar ()
+    signInWithSaml (idp, privCreds) email = do
+      let uref = SAML.UserRef tenant subj
+          subj = emailToSAMLNameID email
+          tenant = idp ^. SAML.idpMetadata . SAML.edIssuer
+      void $ createViaSaml idp privCreds uref
+
+    check :: Bool -> SpecWith TestEnv
+    check changeHandle = it (show changeHandle) $ do
+      (ownerid, teamid) <- createTeam
+      (userid, email) <- invite ownerid teamid
+      idp <- addSamlIdP ownerid
+      reProvisionWithScim changeHandle (Just $ fst idp) teamid userid
+      signInWithSaml idp email
+
+assertSparCassandraUref :: HasCallStack => (SAML.UserRef, Maybe UserId) -> TestSpar ()
+assertSparCassandraUref (uref, urefAnswer) = do
+  liftIO . (`shouldBe` urefAnswer)
+    =<< runSpar (SAMLUserStore.get uref)
+
+assertSparCassandraScim :: HasCallStack => ((TeamId, Email), Maybe UserId) -> TestSpar ()
+assertSparCassandraScim ((teamid, email), scimAnswer) = do
+  liftIO . (`shouldBe` scimAnswer)
+    =<< runSpar (ScimExternalIdStore.lookup teamid email)
+
+assertBrigCassandra ::
+  HasCallStack =>
+  UserId ->
+  SAML.UserRef ->
+  Scim.User.User SparTag ->
+  (Feature.TeamFeatureStatusValue, Bool) ->
+  ManagedBy ->
+  TestSpar ()
+assertBrigCassandra uid uref usr (valemail, emailValidated) managedBy = do
+  runSpar (BrigAccess.getAccount NoPendingInvitations uid) >>= \(Just acc) -> liftIO $ do
+    let handle = fromRight errmsg . parseHandleEither $ Scim.User.userName usr
+          where
+            errmsg = error . show . Scim.User.userName $ usr
+
+        name = Name . fromMaybe (error "name") $ Scim.User.displayName usr
+
+        email = case (valemail, emailValidated) of
+          (Feature.TeamFeatureEnabled, True) ->
+            Just . fromJust . parseEmail . fromJust . Scim.User.externalId $ usr
+          _ ->
+            Nothing
+
+    accountStatus acc `shouldBe` Active
+    userId (accountUser acc) `shouldBe` uid
+    userHandle (accountUser acc) `shouldBe` Just handle
+    userDisplayName (accountUser acc) `shouldBe` name
+    userManagedBy (accountUser acc) `shouldBe` managedBy
+
+    userIdentity (accountUser acc)
+      `shouldBe` Just (SSOIdentity (UserSSOId uref) email Nothing)
 
 specSuspend :: SpecWith TestEnv
 specSuspend = do
@@ -686,42 +884,42 @@ testScimCreateVsUserRef = do
       subj' = either (error . show) id $ SAML.mkNameID uname' Nothing Nothing Nothing
       tenant' = idp ^. SAML.idpMetadata . SAML.edIssuer
   createViaSamlFails idp privCreds uref'
-  where
-    samlUserShouldSatisfy :: HasCallStack => SAML.UserRef -> (Maybe UserId -> Bool) -> TestSpar ()
-    samlUserShouldSatisfy uref property = do
-      muid <- getUserIdViaRef' uref
-      liftIO $ muid `shouldSatisfy` property
 
-    createViaSamlResp :: HasCallStack => IdP -> SAML.SignPrivCreds -> SAML.UserRef -> TestSpar ResponseLBS
-    createViaSamlResp idp privCreds (SAML.UserRef _ subj) = do
-      authnReq <- negotiateAuthnRequest idp
-      let tid = idp ^. SAML.idpExtraInfo . User.wiTeam
-      spmeta <- getTestSPMetadata tid
-      authnResp <-
-        runSimpleSP $
-          SAML.mkAuthnResponseWithSubj subj privCreds idp spmeta authnReq True
-      submitAuthnResponse tid authnResp <!! const 200 === statusCode
+samlUserShouldSatisfy :: HasCallStack => SAML.UserRef -> (Maybe UserId -> Bool) -> TestSpar ()
+samlUserShouldSatisfy uref property = do
+  muid <- getUserIdViaRef' uref
+  liftIO $ muid `shouldSatisfy` property
 
-    createViaSamlFails :: HasCallStack => IdP -> SAML.SignPrivCreds -> SAML.UserRef -> TestSpar ()
-    createViaSamlFails idp privCreds uref = do
-      resp <- createViaSamlResp idp privCreds uref
-      liftIO $ do
-        maybe (error "no body") cs (responseBody resp)
-          `shouldNotContain` "<title>wire:sso:error:success</title>"
+createViaSamlResp :: HasCallStack => IdP -> SAML.SignPrivCreds -> SAML.UserRef -> TestSpar ResponseLBS
+createViaSamlResp idp privCreds (SAML.UserRef _ subj) = do
+  authnReq <- negotiateAuthnRequest idp
+  let tid = idp ^. SAML.idpExtraInfo . User.wiTeam
+  spmeta <- getTestSPMetadata tid
+  authnResp <-
+    runSimpleSP $
+      SAML.mkAuthnResponseWithSubj subj privCreds idp spmeta authnReq True
+  submitAuthnResponse tid authnResp <!! const 200 === statusCode
 
-    createViaSaml :: HasCallStack => IdP -> SAML.SignPrivCreds -> SAML.UserRef -> TestSpar (Maybe UserId)
-    createViaSaml idp privCreds uref = do
-      resp <- createViaSamlResp idp privCreds uref
-      liftIO $ do
-        maybe (error "no body") cs (responseBody resp)
-          `shouldContain` "<title>wire:sso:success</title>"
-      getUserIdViaRef' uref
+createViaSamlFails :: HasCallStack => IdP -> SAML.SignPrivCreds -> SAML.UserRef -> TestSpar ()
+createViaSamlFails idp privCreds uref = do
+  resp <- createViaSamlResp idp privCreds uref
+  liftIO $ do
+    maybe (error "no body") cs (responseBody resp)
+      `shouldNotContain` "<title>wire:sso:error:success</title>"
 
-    deleteViaBrig :: UserId -> TestSpar ()
-    deleteViaBrig uid = do
-      brig <- view teBrig
-      (call . delete $ brig . paths ["i", "users", toByteString' uid])
-        !!! const 202 === statusCode
+createViaSaml :: HasCallStack => IdP -> SAML.SignPrivCreds -> SAML.UserRef -> TestSpar (Maybe UserId)
+createViaSaml idp privCreds uref = do
+  resp <- createViaSamlResp idp privCreds uref
+  liftIO $ do
+    maybe (error "no body") cs (responseBody resp)
+      `shouldContain` "<title>wire:sso:success</title>"
+  getUserIdViaRef' uref
+
+deleteViaBrig :: UserId -> TestSpar ()
+deleteViaBrig uid = do
+  brig <- view teBrig
+  (call . delete $ brig . paths ["i", "users", toByteString' uid])
+    !!! const 202 === statusCode
 
 testCreateUserTimeout :: TestSpar ()
 testCreateUserTimeout = do


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/CS-742

With the tests in this PR, but without the changes, I get this error:

```
Failures:

  test-integration/Test/Spar/Scim/UserSpec.hs:264:7:
  1) WireIdPAPIV1.Spar.Scim.User, Create with TM invitation; then re-provision with SCIM, True
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\"><html xml:lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\"><head>  <title>wire:sso:error:not-found</title>   <script type=\"text/javascript\">       const receiverOrigin = '*';       window.opener.postMessage({\"payload\":{\"errors\":[\"Could not find SAML credentials, and auto-provisioning is disabled.\"],\"label\":\"forbidden\"},\"type\":\"AUTH_ERROR\"}, receiverOrigin);   </script></head></html>" does not contain "<title>wire:sso:success</title>"

  To rerun use: --match "/WireIdPAPIV1/Spar.Scim.User/Create with TM invitation; then re-provision with SCIM/True/"

  test-integration/Test/Spar/Scim/UserSpec.hs:264:7:
  2) WireIdPAPIV2.Spar.Scim.User, Create with TM invitation; then re-provision with SCIM, True
  [...]

Randomized with seed 55186091

Finished in 212.9946 seconds
527 examples, 2 failures, 67 pending
```

The changes in the later commits fix this.  The problem was that under certain conditions, spar did not create SAML credentials during SCIM provisioning.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
