### PR TITLE
Drop deprecated table spar.scim_external_ids.

### DIFF
--- a/changelog.d/0-release-notes/gc-spar-schema
+++ b/changelog.d/0-release-notes/gc-spar-schema
@@ -1,0 +1,1 @@
+If your on-prem instance is older than 2021-04 AND you are using SCIM in any of your teams, deploy chart chart/4.4.0 before this one.

--- a/changelog.d/5-internal/gc-spar-schema
+++ b/changelog.d/5-internal/gc-spar-schema
@@ -1,0 +1,1 @@
+Drop deprecated table spar.scim_external_ids

--- a/docs/reference/cassandra-schema.cql
+++ b/docs/reference/cassandra-schema.cql
@@ -1440,24 +1440,6 @@ CREATE TABLE brig_test.service_prefix (
 
 CREATE KEYSPACE spar_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
 
-CREATE TABLE spar_test.scim_external_ids (
-    external text PRIMARY KEY,
-    user uuid
-) WITH bloom_filter_fp_chance = 0.1
-    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
-    AND comment = ''
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
-    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
-    AND crc_check_chance = 1.0
-    AND dclocal_read_repair_chance = 0.1
-    AND default_time_to_live = 0
-    AND gc_grace_seconds = 864000
-    AND max_index_interval = 2048
-    AND memtable_flush_period_in_ms = 0
-    AND min_index_interval = 128
-    AND read_repair_chance = 0.0
-    AND speculative_retry = '99PERCENTILE';
-
 CREATE TABLE spar_test.bind_cookie (
     cookie text PRIMARY KEY,
     session_owner uuid

--- a/services/spar/schema/src/Main.hs
+++ b/services/spar/schema/src/Main.hs
@@ -30,6 +30,7 @@ import qualified V12
 import qualified V13
 import qualified V14
 import qualified V15
+import qualified V16
 import qualified V2
 import qualified V3
 import qualified V4
@@ -63,7 +64,8 @@ main = do
       V12.migration,
       V13.migration,
       V14.migration,
-      V15.migration
+      V15.migration,
+      V16.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Spar.Data
 

--- a/services/spar/schema/src/V16.hs
+++ b/services/spar/schema/src/V16.hs
@@ -1,0 +1,33 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V16
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 16 "Remove scim_external_ids (out of use since 2021-03)" $ do
+  void $
+    schema'
+      [r|
+        DROP TABLE scim_external_ids;
+      |]

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -595,6 +595,7 @@ executable spar-schema
       V13
       V14
       V15
+      V16
       V2
       V3
       V4

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -51,7 +51,7 @@ import Wire.API.User.Saml
 
 -- | A lower bound: @schemaVersion <= whatWeFoundOnCassandra@, not @==@.
 schemaVersion :: Int32
-schemaVersion = 15
+schemaVersion = 16
 
 ----------------------------------------------------------------------
 -- helpers


### PR DESCRIPTION
## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
