### PR TITLE
chore: add verbose explanation and test mapping for guest links (FS-488)

### DIFF
--- a/services/federator/test/integration/Test/Federator/InwardSpec.hs
+++ b/services/federator/test/integration/Test/Federator/InwardSpec.hs
@@ -79,8 +79,8 @@ spec env =
 
     -- @SF.Federation @TSFI.RESTfulAPI @S2 @S3 @S7
     --
-    -- (This is tested in unit tests; search for
-    -- 'validateDomainCertInvalid' and 'testDiscoveryFailure'.)
+    -- This test is covered by the unit tests 'validateDomainCertWrongDomain' because
+    -- the domain matching is checked on certificate validation.
     it "shouldRejectMissmatchingOriginDomainInward" $
       runTestFederator env $ pure ()
     -- @END

--- a/services/federator/test/unit/Test/Federator/Validation.hs
+++ b/services/federator/test/unit/Test/Federator/Validation.hs
@@ -163,6 +163,7 @@ validateDomainCertMissing =
     res @?= Left NoClientCertificate
 
 -- @SF.Federation @TSFI.Federate @TSFI.DNS @S2 @S3 @S7
+-- Reject request if the client certificate for federator is invalid
 validateDomainCertInvalid :: TestTree
 validateDomainCertInvalid =
   testCase "should fail if the client certificate is invalid" $ do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1247,6 +1247,8 @@ testPostCodeRejectedIfGuestLinksDisabled = do
   setStatus Public.TeamFeatureEnabled
   checkPostCode 200
 
+-- @SF.Separation @TSFI.RESTfulAPI @S2
+-- Check if guests cannot join anymore if guest invite feature was disabled on team level
 testJoinTeamConvGuestLinksDisabled :: TestM ()
 testJoinTeamConvGuestLinksDisabled = do
   galley <- view tsGalley
@@ -1302,6 +1304,8 @@ testJoinTeamConvGuestLinksDisabled = do
   postJoinCodeConv bob' cCode !!! const 200 === statusCode
   checkFeatureStatus Public.TeamFeatureEnabled
 
+-- @END
+
 testJoinNonTeamConvGuestLinksDisabled :: TestM ()
 testJoinNonTeamConvGuestLinksDisabled = do
   galley <- view tsGalley
@@ -1326,6 +1330,10 @@ testJoinNonTeamConvGuestLinksDisabled = do
     const (Right (ConversationCoverView convId (Just convName))) === responseJsonEither
     const 200 === statusCode
 
+-- @SF.Separation @TSFI.RESTfulAPI @S2
+-- This test case covers a negative check that if access code of a guest link is revoked no further
+-- people can join the group conversation. Additionally it checks that incorrect access codes do
+-- result in a 404 and do not allow access to a conversation.
 postJoinCodeConvOk :: TestM ()
 postJoinCodeConvOk = do
   c <- view tsCannon
@@ -1366,6 +1374,8 @@ postJoinCodeConvOk = do
     let noCodeAccess = ConversationAccessData (Set.singleton InviteAccess) accessRoles
     putAccessUpdate alice conv noCodeAccess !!! const 200 === statusCode
     postJoinCodeConv dave payload !!! const 404 === statusCode
+
+-- @END
 
 postConvertCodeConv :: TestM ()
 postConvertCodeConv = do

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -201,6 +201,7 @@ specFinalizeLogin :: SpecWith TestEnv
 specFinalizeLogin = do
   describe "POST /sso/finalize-login" $ do
     -- @SF.Channel @TSFI.RESTfulAPI @S2 @S3
+    -- Send authentication error and no cookie if response from SSO IdP was rejected
     context "rejectsSAMLResponseSayingAccessNotGranted" $ do
       it "responds with a very peculiar 'forbidden' HTTP response" $ do
         (_, tid, idp, (_, privcreds)) <- registerTestIdPWithMeta
@@ -297,6 +298,7 @@ specFinalizeLogin = do
             loginSuccess =<< submitAuthnResponse tid3 authnresp
 
       -- @SF.Channel @TSFI.RESTfulAPI @S2 @S3
+      -- Do not authenticate if SSO IdP response is for different team
       context "rejectsSAMLResponseInWrongTeam" $ do
         it "fails" $ do
           skipIdPAPIVersions
@@ -420,6 +422,7 @@ specFinalizeLogin = do
                   g "" = ""
 
       -- @SF.Channel @TSFI.RESTfulAPI @S2 @S3
+      -- Do not authenticate if SSO IdP response is for unknown issuer
       it "rejectsSAMLResponseFromWrongIssuer" $ do
         let mkareq = negotiateAuthnRequest
             mkaresp privcreds idp spmeta authnreq =
@@ -441,6 +444,7 @@ specFinalizeLogin = do
       -- @END
 
       -- @SF.Channel @TSFI.RESTfulAPI @S2 @S3
+      -- Do not authenticate if SSO IdP response is signed with wrong key
       it "rejectsSAMLResponseSignedWithWrongKey" $ do
         (_, _, _, (_, badprivcreds)) <- registerTestIdPWithMeta
         let mkareq = negotiateAuthnRequest
@@ -458,6 +462,7 @@ specFinalizeLogin = do
       -- @END
 
       -- @SF.Channel @TSFI.RESTfulAPI @S2 @S3
+      -- Do not authenticate if SSO IdP response has no corresponding request anymore
       it "rejectsSAMLResponseIfRequestIsStale" $ do
         let mkareq idp = do
               req <- negotiateAuthnRequest idp
@@ -474,6 +479,7 @@ specFinalizeLogin = do
       -- @END
 
       -- @SF.Channel @TSFI.RESTfulAPI @S2 @S3
+      -- Do not authenticate if SSO IdP response is gone missing
       it "rejectsSAMLResponseIfResponseIsStale" $ do
         let mkareq = negotiateAuthnRequest
             mkaresp privcreds idp spmeta authnreq = mkAuthnResponse privcreds idp spmeta authnreq True


### PR DESCRIPTION
## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
