### PR TITLE
More test labels [skip ci]

### DIFF
--- a/changelog.d/5-internal/more-test-labels
+++ b/changelog.d/5-internal/more-test-labels
@@ -1,0 +1,1 @@
+Add more test mappings

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1362,6 +1362,7 @@ postJoinCodeConvOk = do
     postJoinCodeConv bob incorrectCode !!! const 404 === statusCode
     -- correct code works
     postJoinCodeConv bob payload !!! const 200 === statusCode
+    -- non-admin cannot create invite link
     postConvCode bob conv !!! const 403 === statusCode
     -- test no-op
     postJoinCodeConv bob payload !!! const 204 === statusCode
@@ -1375,6 +1376,7 @@ postJoinCodeConvOk = do
     let nonActivatedAccess = ConversationAccessData (Set.singleton CodeAccess) accessRolesWithGuests
     putAccessUpdate alice conv nonActivatedAccess !!! const 200 === statusCode
     postJoinCodeConv eve payload !!! const 200 === statusCode
+    -- guest cannot create invite link
     postConvCode eve conv !!! const 403 === statusCode
     -- after removing CodeAccess, no further people can join
     let noCodeAccess = ConversationAccessData (Set.singleton InviteAccess) accessRoles

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1326,6 +1326,12 @@ testJoinNonTeamConvGuestLinksDisabled = do
     const (Right (ConversationCoverView convId (Just convName))) === responseJsonEither
     const 200 === statusCode
 
+-- | @SF.Separation @TSFI.RESTfulAPI @S2
+-- Random users can use invite link
+-- Reusing previously used link yields same conv (idempotency)
+-- Guest can use invite link
+-- Guest cannot create invite link
+-- Non-admin cannot create invite link
 postJoinCodeConvOk :: TestM ()
 postJoinCodeConvOk = do
   c <- view tsCannon
@@ -1350,6 +1356,7 @@ postJoinCodeConvOk = do
     postJoinCodeConv bob incorrectCode !!! const 404 === statusCode
     -- correct code works
     postJoinCodeConv bob payload !!! const 200 === statusCode
+    postConvCode bob conv !!! const 403 === statusCode
     -- test no-op
     postJoinCodeConv bob payload !!! const 204 === statusCode
     -- eve cannot join
@@ -1362,6 +1369,7 @@ postJoinCodeConvOk = do
     let nonActivatedAccess = ConversationAccessData (Set.singleton CodeAccess) accessRolesWithGuests
     putAccessUpdate alice conv nonActivatedAccess !!! const 200 === statusCode
     postJoinCodeConv eve payload !!! const 200 === statusCode
+    postConvCode eve conv !!! const 403 === statusCode
     -- after removing CodeAccess, no further people can join
     let noCodeAccess = ConversationAccessData (Set.singleton InviteAccess) accessRoles
     putAccessUpdate alice conv noCodeAccess !!! const 200 === statusCode

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -1538,7 +1538,6 @@ testBillingInLargeTeamWithoutIndexedBillingTeamMembers = do
 -- Promotion, demotion of team roles.
 -- Demotion by superior roles is allowed.
 -- Demotion by inferior roles is NOT allowed.
--- Group owner cannot make a guest a group admin.
 testUpdateTeamMember :: TestM ()
 testUpdateTeamMember = do
   g <- view tsGalley
@@ -1574,8 +1573,6 @@ testUpdateTeamMember = do
     checkTeamMemberUpdateEvent tid (member ^. userId) wsMember (pure fullPermissions)
     WS.assertNoEvent timeout [wsOwner, wsMember]
   assertQueue "Member promoted to owner" $ tUpdate 2 [owner, member ^. userId]
-  -- owner can not promote guests (ephemeral users) to admins
-  () <- error "TODO"
   -- owner can **NOT** demote herself, even when another owner exists
   updateTeamMember g tid owner demoteOwner !!! do
     const 403 === statusCode

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -1533,6 +1533,11 @@ testBillingInLargeTeamWithoutIndexedBillingTeamMembers = do
             . json change
         )
 
+-- | @SF.Management @TSFI.RESTfulAPI @S2
+-- Promotion, demotion of team roles.
+-- Demotion by superior roles is allowed.
+-- Demotion by inferior roles is NOT allowed.
+-- Group owner cannot make a guest a group admin.
 testUpdateTeamMember :: TestM ()
 testUpdateTeamMember = do
   g <- view tsGalley
@@ -1568,6 +1573,8 @@ testUpdateTeamMember = do
     checkTeamMemberUpdateEvent tid (member ^. userId) wsMember (pure fullPermissions)
     WS.assertNoEvent timeout [wsOwner, wsMember]
   assertQueue "Member promoted to owner" $ tUpdate 2 [owner, member ^. userId]
+  -- owner can not promote guests (ephemeral users) to admins
+  () <- error "TODO"
   -- owner can **NOT** demote herself, even when another owner exists
   updateTeamMember g tid owner demoteOwner !!! do
     const 403 === statusCode

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -1534,6 +1534,7 @@ testBillingInLargeTeamWithoutIndexedBillingTeamMembers = do
         )
 
 -- | @SF.Management @TSFI.RESTfulAPI @S2
+-- This test covers:
 -- Promotion, demotion of team roles.
 -- Demotion by superior roles is allowed.
 -- Demotion by inferior roles is NOT allowed.
@@ -1603,6 +1604,8 @@ testUpdateTeamMember = do
       let e = List1.head (WS.unpackPayload notif)
       e ^. eventTeam @?= tid
       e ^. eventData @?= EdMemberUpdate uid mPerm
+
+-- @END
 
 testUpdateTeamStatus :: TestM ()
 testUpdateTeamStatus = do


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-488

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
