### PR TITLE
Release 2022-03-09

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+# [2022-03-09]
+
+## Release notes
+
+
+* For wire.com operators: make sure that nginz is deployed (#2166)
+
+* Upgrade team-settings version to 4.6.2-v0.29.7-0-4f43ee4 (#2180)
+
+
+## API changes
+
+
+* Add qualified broadcast endpoint (#2166)
+
+
+## Bug fixes and other updates
+
+
+* Always create spar credentials during SCIM provisioning when applicable (#2174)
+
+
+## Internal changes
+
+
+* Add tests for additional information returned by `GET /api-version` (#2159)
+
+* Clean up `Base64ByteString` implementation (#2170)
+
+* The `Event` record type does not contain a `type` field anymore (#2160)
+
+* Add MLS message types and corresponding deserialisers (#2145)
+
+* Asset keys are now internally validated. (#2162)
+
+* Servantify `POST /register` and `POST /i/users` endpoints (#2121)
+
+
 # [2022-03-01]
 
 ## Release notes

--- a/changelog.d/0-release-notes/nginz-upgrade
+++ b/changelog.d/0-release-notes/nginz-upgrade
@@ -1,1 +1,0 @@
-For wire.com operators: make sure that nginz is deployed

--- a/changelog.d/0-release-notes/team-settings-upgrade
+++ b/changelog.d/0-release-notes/team-settings-upgrade
@@ -1,0 +1,1 @@
+Upgrade team-settings version to 4.6.2-v0.29.7-0-4f43ee4

--- a/changelog.d/0-release-notes/team-settings-upgrade
+++ b/changelog.d/0-release-notes/team-settings-upgrade
@@ -1,1 +1,0 @@
-Upgrade team-settings version to 4.6.2-v0.29.7-0-4f43ee4

--- a/changelog.d/1-api-changes/broadcast-qualified
+++ b/changelog.d/1-api-changes/broadcast-qualified
@@ -1,1 +1,0 @@
-Add qualified broadcast endpoint

--- a/changelog.d/3-bug-fixes/more-spar-tests
+++ b/changelog.d/3-bug-fixes/more-spar-tests
@@ -1,1 +1,0 @@
-Always create spar credentials during SCIM provisioning when applicable

--- a/changelog.d/5-internal/api-version-endpoint
+++ b/changelog.d/5-internal/api-version-endpoint
@@ -1,1 +1,0 @@
-Add tests for additional information returned by `GET /api-version`

--- a/changelog.d/5-internal/base64-cleanup
+++ b/changelog.d/5-internal/base64-cleanup
@@ -1,1 +1,0 @@
-Clean up `Base64ByteString` implementation

--- a/changelog.d/5-internal/event-cleanup
+++ b/changelog.d/5-internal/event-cleanup
@@ -1,1 +1,0 @@
-The `Event` record type does not contain a `type` field anymore

--- a/changelog.d/5-internal/mls-messages
+++ b/changelog.d/5-internal/mls-messages
@@ -1,1 +1,0 @@
-Add MLS message types and corresponding deserialisers

--- a/changelog.d/5-internal/pr-2162
+++ b/changelog.d/5-internal/pr-2162
@@ -1,1 +1,0 @@
-Asset keys are now internally validated.

--- a/changelog.d/5-internal/servantify-register
+++ b/changelog.d/5-internal/servantify-register
@@ -1,1 +1,0 @@
-Servantify `POST /register` and `POST /i/users` endpoints

--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/team-settings
-  tag: "4.6.1-v0.29.3-0-28cbbd7"
+  tag: "4.6.2-v0.29.7-0-4f43ee4"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
# [2022-03-09]

## Release notes


* For wire.com operators: make sure that nginz is deployed (#2166)

* Upgrade team-settings version to 4.6.2-v0.29.7-0-4f43ee4 (#2180)


## API changes


* Add qualified broadcast endpoint (#2166)


## Bug fixes and other updates


* Always create spar credentials during SCIM provisioning when applicable (#2174)


## Internal changes


* Add tests for additional information returned by `GET /api-version` (#2159)

* Clean up `Base64ByteString` implementation (#2170)

* The `Event` record type does not contain a `type` field anymore (#2160)

* Add MLS message types and corresponding deserialisers (#2145)

* Asset keys are now internally validated. (#2162)

* Servantify `POST /register` and `POST /i/users` endpoints (#2121)


