### PR TITLE
Update Helm chart serving script for Python 3

### DIFF
--- a/hack/bin/serve-charts.sh
+++ b/hack/bin/serve-charts.sh
@@ -14,4 +14,4 @@ for chart in $@; do
   helm package "$chart"
 done
 helm repo index .
-python -m http.server $HELM_SERVER_PORT
+python3 -m http.server $HELM_SERVER_PORT


### PR DESCRIPTION
The script for serving local Helm charts uses Python's standard library HTTP server; however, Python 2 is decreasingly available on many platforms, so we should use Python 3 instead, which has equivalent functionality. No functional changes.

---

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.