### PR TITLE
Increase page size read from cassandra from 100 to 1000

### DIFF
--- a/changelog.d/5-internal/faster-reindex
+++ b/changelog.d/5-internal/faster-reindex
@@ -1,0 +1,1 @@
+Improve speed of reindexing by increasing the batch size of processing users.

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -396,7 +396,7 @@ reindexAll = reindexAllWith IndexUpdateIfNewerVersion
 reindexAllWith :: (MonadLogger m, MonadIndexIO m, C.MonadClient m) => IndexDocUpdateType -> m ()
 reindexAllWith updateType = do
   idx <- liftIndexIO $ asks idxName
-  C.liftClient (scanForIndex 100) >>= loop idx
+  C.liftClient (scanForIndex 1000) >>= loop idx
   where
     loop idx page = do
       info $


### PR DESCRIPTION
Reindexing goes faster with bigger pages. Reading 1000 users in memory isn't a
problem either. This is not an optimized number, just based on 1 experiment
which showed that 1000 is better than 100. Memory consuption of the `brig-index`
process in that experiment was of the order of 100 kb.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.