### PR TITLE
Fix: spar user import to SCIM

### DIFF
--- a/changelog.d/3-bug-fixes/fix-saml-thing
+++ b/changelog.d/3-bug-fixes/fix-saml-thing
@@ -1,0 +1,1 @@
+Fix data consistency issue in import of users from TM invitation to SCIM-managed

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -916,10 +916,23 @@ getUserById midp stiTeam uid = do
       assertExternalIdNotUsedElsewhere stiTeam veid uid
       createValidScimUserSpar stiTeam uid storedUser veid
       lift $ do
-        BrigAccess.setVeid uid veid
-        BrigAccess.setManagedBy uid ManagedByScim
+        when (veidChanged (accountUser brigUser) veid) $ do
+          BrigAccess.setVeid uid veid
+        when (managedByChanged (accountUser brigUser)) $ do
+          BrigAccess.setManagedBy uid ManagedByScim
       pure storedUser
     _ -> Applicative.empty
+  where
+    veidChanged :: BT.User -> ST.ValidExternalId -> Bool
+    veidChanged usr veid = case BT.userIdentity usr of
+      Nothing -> True
+      Just (BT.FullIdentity _ _) -> True
+      Just (BT.EmailIdentity _) -> True
+      Just (BT.PhoneIdentity _) -> True
+      Just (BT.SSOIdentity ssoid _ _) -> Brig.veidToUserSSOId veid /= ssoid
+
+    managedByChanged :: BT.User -> Bool
+    managedByChanged usr = userManagedBy usr /= ManagedByScim
 
 scimFindUserByHandle ::
   forall r.

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -915,6 +915,9 @@ getUserById midp stiTeam uid = do
       -- function to move it under scim control.
       assertExternalIdNotUsedElsewhere stiTeam veid uid
       createValidScimUserSpar stiTeam uid storedUser veid
+      lift $ do
+        BrigAccess.setVeid uid veid
+        BrigAccess.setManagedBy uid ManagedByScim
       pure storedUser
     _ -> Applicative.empty
 

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -272,22 +272,22 @@ specImportToScimFromInvitation =
       SAML.IdPConfig User.WireIdP ->
       Scim.UserC.StoredUser SparTag ->
       TestSpar ()
-    checkCsvDownload ownerid teamid idp storedusr = do
+    checkCsvDownload ownerId teamId idp storedUsr = do
       g <- view teGalley
       resp <-
         call $
-          get (g . accept "text/csv" . paths ["teams", toByteString' teamid, "members/csv"] . zUser ownerid) <!! do
+          get (g . accept "text/csv" . paths ["teams", toByteString' teamId, "members/csv"] . zUser ownerId) <!! do
             const 200 === statusCode
             const (Just "chunked") === lookup "Transfer-Encoding" . responseHeaders
       let rbody = fromMaybe (error "no body") . responseBody $ resp
 
-      let scimusr = Scim.value (Scim.thing storedusr)
-          uid = Scim.id (Scim.thing storedusr)
-          handle = fromRight undefined . parseHandleEither $ Scim.User.userName scimusr
-          email = fromJust . parseEmail . fromJust . Scim.User.externalId $ scimusr
+      let scimUsr = Scim.value (Scim.thing storedUsr)
+          uid = Scim.id (Scim.thing storedUsr)
+          handle = fromRight undefined . parseHandleEither $ Scim.User.userName scimUsr
+          email = fromJust . parseEmail . fromJust . Scim.User.externalId $ scimUsr
           Right idpissuer = idp ^. SAML.idpMetadata . SAML.edIssuer . SAML.fromIssuer . to mkHttpsUrl
-          Just samlNameID = Scim.User.externalId scimusr
-          Just scimExternalId = Scim.User.externalId scimusr
+          Just samlNameID = Scim.User.externalId scimUsr
+          Just scimExternalId = Scim.User.externalId scimUsr
 
       liftIO $ do
         let csvtyped = decodeCSV @CsvExport.TeamExportUser rbody

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -1161,7 +1161,7 @@ testFindNonProvisionedUserNoIdP findBy = do
     liftIO $ users `shouldBe` [uid]
     Just brigUser' <- runSpar $ Intra.getBrigUser Intra.NoPendingInvitations uid
     liftIO $ userManagedBy brigUser' `shouldBe` ManagedByScim
-    liftIO $ brigUser' `shouldBe` brigUser {userManagedBy = ManagedByScim}
+    liftIO $ brigUser' `shouldBe` scimifyBrigUserHack brigUser email
 
 -- | Test that deleted users are not listed.
 testListNoDeletedUsers :: TestSpar ()

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -80,6 +80,7 @@ import qualified Web.Scim.Schema.User as Scim.User
 import qualified Wire.API.Team.Export as CsvExport
 import qualified Wire.API.Team.Feature as Feature
 import Wire.API.Team.Invitation (Invitation (..))
+import Wire.API.Team.Role (Role (RoleMember))
 import Wire.API.User.Identity (emailToSAMLNameID)
 import Wire.API.User.IdentityProvider (IdP)
 import qualified Wire.API.User.IdentityProvider as User
@@ -222,17 +223,18 @@ specImportToScimFromInvitation =
       idp <- call $ callIdpCreate apiVersion (env ^. teSpar) (Just userid) idpmeta
       pure (idp, privkey)
 
-    reProvisionWithScim :: HasCallStack => Bool -> Maybe (SAML.IdPConfig User.WireIdP) -> TeamId -> UserId -> ReaderT TestEnv IO ()
+    reProvisionWithScim ::
+      HasCallStack =>
+      Bool ->
+      Maybe (SAML.IdPConfig User.WireIdP) ->
+      TeamId ->
+      UserId ->
+      TestSpar (Scim.UserC.StoredUser SparTag)
     reProvisionWithScim changeHandle mbidp teamid userid = do
       tok :: ScimToken <- do
         registerScimToken teamid ((^. SAML.idpId) <$> mbidp)
 
-      storedUserGot :: Scim.UserC.StoredUser SparTag <- do
-        resp <-
-          aFewTimes (getUser_ (Just tok) userid =<< view teSpar) ((== 200) . statusCode)
-            <!! const 200 === statusCode
-        pure $ responseJsonUnsafe resp
-
+      storedUserGot <- getStoredUser tok userid
       when changeHandle $ do
         (usr' :: Scim.User.User SparTag, uid :: UserId) <- do
           (usr_, _) <- randomScimUserWithEmail
@@ -240,14 +242,20 @@ specImportToScimFromInvitation =
             ( (Scim.value . Scim.thing $ storedUserGot) {Scim.User.userName = Scim.User.userName usr_},
               Scim.id . Scim.thing $ storedUserGot
             )
+        void $ putStoredUser tok uid usr'
+      getStoredUser tok userid
 
-        _storedUserUpdated :: Scim.UserC.StoredUser SparTag <- do
-          resp <-
-            aFewTimes (updateUser_ (Just tok) (Just uid) usr' =<< view teSpar) ((== 200) . statusCode)
-              <!! const 200 === statusCode
-          pure $ responseJsonUnsafe resp
+    getStoredUser :: ScimToken -> UserId -> TestSpar (Scim.UserC.StoredUser SparTag)
+    getStoredUser tok uid = do
+      resp <- aFewTimes (getUser_ (Just tok) uid =<< view teSpar) ((== 200) . statusCode) <!! const 200 === statusCode
+      pure $ responseJsonUnsafe resp
 
-        pure ()
+    putStoredUser :: ScimToken -> UserId -> Scim.User.User SparTag -> TestSpar (Scim.UserC.StoredUser SparTag)
+    putStoredUser tok uid usr' = do
+      resp <-
+        aFewTimes (updateUser_ (Just tok) (Just uid) usr' =<< view teSpar) ((== 200) . statusCode)
+          <!! const 200 === statusCode
+      pure $ responseJsonUnsafe resp
 
     signInWithSaml :: HasCallStack => (SAML.IdPConfig User.WireIdP, SAML.SignPrivCreds) -> Email -> UserId -> TestSpar ()
     signInWithSaml (idp, privCreds) email userid = do
@@ -257,14 +265,54 @@ specImportToScimFromInvitation =
       mbUid <- createViaSaml idp privCreds uref
       liftIO $ mbUid `shouldBe` Just userid
 
+    checkCsvDownload ::
+      HasCallStack =>
+      UserId ->
+      TeamId ->
+      SAML.IdPConfig User.WireIdP ->
+      Scim.UserC.StoredUser SparTag ->
+      TestSpar ()
+    checkCsvDownload ownerid teamid idp storedusr = do
+      g <- view teGalley
+      resp <-
+        call $
+          get (g . accept "text/csv" . paths ["teams", toByteString' teamid, "members/csv"] . zUser ownerid) <!! do
+            const 200 === statusCode
+            const (Just "chunked") === lookup "Transfer-Encoding" . responseHeaders
+      let rbody = fromMaybe (error "no body") . responseBody $ resp
+
+      let scimusr = Scim.value (Scim.thing storedusr)
+          uid = Scim.id (Scim.thing storedusr)
+          handle = fromRight undefined . parseHandleEither $ Scim.User.userName scimusr
+          email = fromJust . parseEmail . fromJust . Scim.User.externalId $ scimusr
+          Right idpissuer = idp ^. SAML.idpMetadata . SAML.edIssuer . SAML.fromIssuer . to mkHttpsUrl
+          Just samlNameID = Scim.User.externalId scimusr
+          Just scimExternalId = Scim.User.externalId scimusr
+
+      liftIO $ do
+        let csvtyped = decodeCSV @CsvExport.TeamExportUser rbody
+        length csvtyped `shouldBe` 2
+
+        let [member] = filter ((== ManagedByScim) . CsvExport.tExportManagedBy) csvtyped
+        CsvExport.tExportDisplayName member `shouldBe` Name "Bob"
+        CsvExport.tExportHandle member `shouldBe` Just handle
+        CsvExport.tExportEmail member `shouldBe` Just email
+        CsvExport.tExportRole member `shouldBe` Just RoleMember
+        CsvExport.tExportInvitedBy member `shouldBe` Nothing
+        CsvExport.tExportIdpIssuer member `shouldBe` Just idpissuer
+        CsvExport.tExportSAMLNamedId member `shouldBe` samlNameID
+        CsvExport.tExportSCIMExternalId member `shouldBe` scimExternalId
+        CsvExport.tExportSCIMRichInfo member `shouldBe` Nothing
+        CsvExport.tExportUserId member `shouldBe` uid
+
     check :: Bool -> SpecWith TestEnv
     check changeHandle = it (show changeHandle) $ do
       (ownerid, teamid) <- createTeam
       (userid, email) <- invite ownerid teamid
-      idp <- addSamlIdP ownerid
-      reProvisionWithScim changeHandle (Just $ fst idp) teamid userid
-      signInWithSaml idp email userid
-      checkCsvDownload ownerid teamid
+      (idp, privcreds) <- addSamlIdP ownerid
+      storedusr <- reProvisionWithScim changeHandle (Just idp) teamid userid
+      signInWithSaml (idp, privcreds) email userid
+      checkCsvDownload ownerid teamid idp storedusr
 
 assertSparCassandraUref :: HasCallStack => (SAML.UserRef, Maybe UserId) -> TestSpar ()
 assertSparCassandraUref (uref, urefAnswer) = do
@@ -467,11 +515,11 @@ testCsvData tid owner uid mbeid mbsaml hasissuer = do
             Just (UserScimExternalId _) -> ""
             Nothing -> ""
       ('n', CsvExport.tExportSAMLNamedId export) `shouldBe` ('n', haveSubject)
-  where
-    decodeCSV :: Csv.FromNamedRecord a => LByteString -> [a]
-    decodeCSV bstr =
-      either (error "could not decode csv") id $
-        Csv.decodeByName bstr <&> (V.toList . snd)
+
+decodeCSV :: Csv.FromNamedRecord a => LByteString -> [a]
+decodeCSV bstr =
+  either (error "could not decode csv") id $
+    Csv.decodeByName bstr <&> (V.toList . snd)
 
 testCreateUserWithPass :: TestSpar ()
 testCreateUserWithPass = do

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -646,3 +646,11 @@ whatSparReturnsFor :: HasCallStack => IdP -> Int -> Scim.User.User SparTag -> Ei
 whatSparReturnsFor idp richInfoSizeLimit =
   either (Left . show) (Right . synthesizeScimUser)
     . validateScimUser' "whatSparReturnsFor" (Just idp) richInfoSizeLimit
+
+-- this is not always correct, but hopefully for the tests that we're using it in it'll do.
+scimifyBrigUserHack :: User -> Email -> User
+scimifyBrigUserHack usr email =
+  usr
+    { userManagedBy = ManagedByScim,
+      userIdentity = Just (SSOIdentity (UserScimExternalId (fromEmail email)) (Just email) Nothing)
+    }


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1376

I recommend reading this PR commit-by-commit.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
