### PR TITLE
SQSERVICES-1300-be-lock-2nd-factor-password-challenge-team-feature-as-default

### DIFF
--- a/changelog.d/2-features/pr-2205
+++ b/changelog.d/2-features/pr-2205
@@ -1,0 +1,1 @@
+The `SndFactorPasswordChallenge` team feature is locked per default.

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -44,7 +44,7 @@ config:
       # sndFactorPasswordChallenge:
       #   defaults:
       #     status: disabled
-      #     lockStatus: unlocked
+      #     lockStatus: locked
   aws:
     region: "eu-west-1"
   proxy: {}

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -394,7 +394,6 @@ roleHiddenPermissions role = HiddenPermissions p p
             ChangeTeamFeature TeamFeatureClassifiedDomains {- the features not listed here can only be changed in stern -},
             ChangeTeamFeature TeamFeatureSelfDeletingMessages,
             ChangeTeamFeature TeamFeatureGuestLinks,
-            ChangeTeamFeature TeamFeatureSndFactorPasswordChallenge,
             ChangeTeamMemberProfiles,
             ReadIdp,
             CreateUpdateDeleteIdp,

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -394,6 +394,7 @@ roleHiddenPermissions role = HiddenPermissions p p
             ChangeTeamFeature TeamFeatureClassifiedDomains {- the features not listed here can only be changed in stern -},
             ChangeTeamFeature TeamFeatureSelfDeletingMessages,
             ChangeTeamFeature TeamFeatureGuestLinks,
+            ChangeTeamFeature TeamFeatureSndFactorPasswordChallenge,
             ChangeTeamMemberProfiles,
             ReadIdp,
             CreateUpdateDeleteIdp,

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -637,7 +637,7 @@ defaultTeamFeatureValidateSAMLEmailsStatus = TeamFeatureStatusNoConfig TeamFeatu
 -- TeamFeatureSndFactorPasswordChallenge
 
 defaultTeamFeatureSndFactorPasswordChallengeStatus :: TeamFeatureStatusNoConfigAndLockStatus
-defaultTeamFeatureSndFactorPasswordChallengeStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureDisabled Unlocked
+defaultTeamFeatureSndFactorPasswordChallengeStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureDisabled Locked
 
 ----------------------------------------------------------------------
 -- internal

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -380,7 +380,7 @@ testLoginVerify6DigitEmailCodeSuccess brig galley db = do
   (u, tid) <- createUserWithTeam' brig
   let Just email = userEmail u
   let checkLoginSucceeds body = login brig body PersistentCookie !!! const 200 === statusCode
-
+  Util.setTeamFeatureLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge galley tid Public.Unlocked
   Util.setTeamSndFactorPasswordChallenge galley tid Public.TeamFeatureEnabled
   Util.generateVerificationCode brig (Public.SendVerificationCode Public.Login email)
   key <- Code.mkKey (Code.ForEmail email)
@@ -401,6 +401,7 @@ testLoginVerify6DigitResendCodeSuccess brig galley db = do
         Just c <- Util.lookupCode db key Code.AccountLogin
         pure c
 
+  Util.setTeamFeatureLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge galley tid Public.Unlocked
   Util.setTeamSndFactorPasswordChallenge galley tid Public.TeamFeatureEnabled
 
   Util.generateVerificationCode brig (Public.SendVerificationCode Public.Login email)
@@ -422,6 +423,7 @@ testLoginVerify6DigitWrongCodeFails brig galley = do
           const 403 === statusCode
           const (Just "code-authentication-failed") === errorLabel
 
+  Util.setTeamFeatureLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge galley tid Public.Unlocked
   Util.setTeamSndFactorPasswordChallenge galley tid Public.TeamFeatureEnabled
   Util.generateVerificationCode brig (Public.SendVerificationCode Public.Login email)
   let wrongCode = Code.Value $ unsafeRange (fromRight undefined (validate "123456"))
@@ -436,6 +438,7 @@ testLoginVerify6DigitMissingCodeFails brig galley = do
           const 403 === statusCode
           const (Just "code-authentication-required") === errorLabel
 
+  Util.setTeamFeatureLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge galley tid Public.Unlocked
   Util.setTeamSndFactorPasswordChallenge galley tid Public.TeamFeatureEnabled
   Util.generateVerificationCode brig (Public.SendVerificationCode Public.Login email)
   checkLoginFails $ PasswordLogin (LoginByEmail email) defPassword (Just defCookieLabel) Nothing
@@ -449,6 +452,7 @@ testLoginVerify6DigitExpiredCodeFails brig galley db = do
           const 403 === statusCode
           const (Just "code-authentication-failed") === errorLabel
 
+  Util.setTeamFeatureLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge galley tid Public.Unlocked
   Util.setTeamSndFactorPasswordChallenge galley tid Public.TeamFeatureEnabled
   Util.generateVerificationCode brig (Public.SendVerificationCode Public.Login email)
   key <- Code.mkKey (Code.ForEmail email)

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -116,6 +116,7 @@ testAddGetClientVerificationCode db brig galley = do
   let addClient' :: Maybe Code.Value -> Http Client
       addClient' codeValue = responseJsonError =<< addClient brig uid (defNewClientWithVerificationCode codeValue PermanentClientType [head somePrekeys] (head someLastPrekeys))
 
+  Util.setTeamFeatureLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge galley tid Public.Unlocked
   Util.setTeamSndFactorPasswordChallenge galley tid Public.TeamFeatureEnabled
   Util.generateVerificationCode brig (Public.SendVerificationCode Public.Login email)
   k <- Code.mkKey (Code.ForEmail email)
@@ -133,6 +134,7 @@ testAddGetClientMissingCode brig galley = do
   let Just email = userEmail u
   let addClient' codeValue = addClient brig uid (defNewClientWithVerificationCode codeValue PermanentClientType [head somePrekeys] (head someLastPrekeys))
 
+  Util.setTeamFeatureLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge galley tid Public.Unlocked
   Util.setTeamSndFactorPasswordChallenge galley tid Public.TeamFeatureEnabled
   Util.generateVerificationCode brig (Public.SendVerificationCode Public.Login email)
   addClient' Nothing !!! do
@@ -146,6 +148,7 @@ testAddGetClientWrongCode brig galley = do
   let Just email = userEmail u
   let addClient' codeValue = addClient brig uid (defNewClientWithVerificationCode codeValue PermanentClientType [head somePrekeys] (head someLastPrekeys))
 
+  Util.setTeamFeatureLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge galley tid Public.Unlocked
   Util.setTeamSndFactorPasswordChallenge galley tid Public.TeamFeatureEnabled
   Util.generateVerificationCode brig (Public.SendVerificationCode Public.Login email)
   let wrongCode = Code.Value $ unsafeRange (fromRight undefined (validate "123456"))
@@ -161,6 +164,7 @@ testAddGetClientCodeExpired db brig galley = do
   let checkLoginSucceeds b = login brig b PersistentCookie !!! const 200 === statusCode
   let addClient' codeValue = addClient brig uid (defNewClientWithVerificationCode codeValue PermanentClientType [head somePrekeys] (head someLastPrekeys))
 
+  Util.setTeamFeatureLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge galley tid Public.Unlocked
   Util.setTeamSndFactorPasswordChallenge galley tid Public.TeamFeatureEnabled
   Util.generateVerificationCode brig (Public.SendVerificationCode Public.Login email)
   k <- Code.mkKey (Code.ForEmail email)

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -493,5 +493,20 @@ setTeamSndFactorPasswordChallenge galley tid status = do
   let js = RequestBodyLBS $ encode $ Public.TeamFeatureStatusNoConfig status
   put (galley . paths ["i", "teams", toByteString' tid, "features", toByteString' Public.TeamFeatureSndFactorPasswordChallenge] . contentJson . body js) !!! const 200 === statusCode
 
+setTeamFeatureLockStatus ::
+  forall (a :: Public.TeamFeatureName) m.
+  ( MonadCatch m,
+    MonadIO m,
+    MonadHttp m,
+    HasCallStack,
+    Public.KnownTeamFeatureName a
+  ) =>
+  Galley ->
+  TeamId ->
+  Public.LockStatusValue ->
+  m ()
+setTeamFeatureLockStatus galley tid status =
+  put (galley . paths ["i", "teams", toByteString' tid, "features", toByteString' (Public.knownTeamFeatureName @a), toByteString' status]) !!! const 200 === statusCode
+
 lookupCode :: MonadIO m => DB.ClientState -> Code.Key -> Code.Scope -> m (Maybe Code.Code)
 lookupCode db k = liftIO . DB.runClient db . Code.lookup k

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -73,7 +73,7 @@ tests s =
       test s "ConversationGuestLinks - public API" testGuestLinksPublic,
       test s "ConversationGuestLinks - internal API" testGuestLinksInternal,
       test s "ConversationGuestLinks - lock status" $ testSimpleFlagWithLockStatus @'Public.TeamFeatureGuestLinks Public.TeamFeatureEnabled Public.Unlocked,
-      test s "SndFactorPasswordChallenge - lock status" $ testSimpleFlagWithLockStatus' @'Public.TeamFeatureSndFactorPasswordChallenge False Public.TeamFeatureDisabled Public.Locked
+      test s "SndFactorPasswordChallenge - lock status" $ testSimpleFlagWithLockStatus @'Public.TeamFeatureSndFactorPasswordChallenge Public.TeamFeatureDisabled Public.Locked
     ]
 
 testSSO :: TestM ()
@@ -396,23 +396,7 @@ testSimpleFlagWithLockStatus ::
   Public.TeamFeatureStatusValue ->
   Public.LockStatusValue ->
   TestM ()
-testSimpleFlagWithLockStatus = testSimpleFlagWithLockStatus' @a True
-
-testSimpleFlagWithLockStatus' ::
-  forall (a :: Public.TeamFeatureName).
-  ( HasCallStack,
-    Typeable a,
-    Public.FeatureHasNoConfig 'Public.WithLockStatus a,
-    Public.FeatureHasNoConfig 'Public.WithoutLockStatus a,
-    Public.KnownTeamFeatureName a,
-    FromJSON (Public.TeamFeatureStatus 'Public.WithLockStatus a),
-    ToJSON (Public.TeamFeatureStatus 'Public.WithLockStatus a)
-  ) =>
-  Bool ->
-  Public.TeamFeatureStatusValue ->
-  Public.LockStatusValue ->
-  TestM ()
-testSimpleFlagWithLockStatus' canChangeTeamFeature defaultStatus defaultLockStatus = do
+testSimpleFlagWithLockStatus defaultStatus defaultLockStatus = do
   galley <- view tsGalley
   let feature = Public.knownTeamFeatureName @a
   owner <- Util.randomUser
@@ -449,7 +433,7 @@ testSimpleFlagWithLockStatus' canChangeTeamFeature defaultStatus defaultLockStat
       assertSetStatusForbidden :: Public.TeamFeatureStatusValue -> TestM ()
       assertSetStatusForbidden statusValue =
         Util.putTeamFeatureFlagWithGalley @a galley owner tid (Public.TeamFeatureStatusNoConfig statusValue)
-          !!! statusCode === const (if canChangeTeamFeature then 409 else 403)
+          !!! statusCode === const 409
 
       setLockStatus :: Public.LockStatusValue -> TestM ()
       setLockStatus lockStatus =
@@ -471,14 +455,13 @@ testSimpleFlagWithLockStatus' canChangeTeamFeature defaultStatus defaultLockStat
   -- setting should work
   cannon <- view tsCannon
   -- should receive an event
-  when canChangeTeamFeature $ do
-    WS.bracketR cannon member $ \ws -> do
-      setFlagWithGalley otherStatus
-      void . liftIO $
-        WS.assertMatch (5 # Second) ws $
-          wsAssertFeatureConfigWithLockStatusUpdate feature otherStatus Public.Unlocked
+  WS.bracketR cannon member $ \ws -> do
+    setFlagWithGalley otherStatus
+    void . liftIO $
+      WS.assertMatch (5 # Second) ws $
+        wsAssertFeatureConfigWithLockStatusUpdate feature otherStatus Public.Unlocked
 
-    getFlags otherStatus Public.Unlocked
+  getFlags otherStatus Public.Unlocked
 
   -- lock feature
   setLockStatus Public.Locked
@@ -488,10 +471,10 @@ testSimpleFlagWithLockStatus' canChangeTeamFeature defaultStatus defaultLockStat
   -- unlock feature
   setLockStatus Public.Unlocked
   -- feature status should be the previously set value
-  when canChangeTeamFeature $ getFlags otherStatus Public.Unlocked
+  getFlags otherStatus Public.Unlocked
 
   -- clean up
-  when canChangeTeamFeature $ setFlagWithGalley defaultStatus
+  setFlagWithGalley defaultStatus
   setLockStatus defaultLockStatus
   getFlags defaultStatus defaultLockStatus
 

--- a/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
@@ -106,6 +106,7 @@ testCreateTokenWithVerificationCode :: TestSpar ()
 testCreateTokenWithVerificationCode = do
   env <- ask
   (owner, teamId, _) <- registerTestIdP
+  unlockFeature (env ^. teGalley) teamId
   setSndFactorPasswordChallengeStatus (env ^. teGalley) teamId Public.TeamFeatureEnabled
   user <- getUserBrig owner
   let email = fromMaybe undefined (Brig.userEmail =<< user)
@@ -127,6 +128,10 @@ testCreateTokenWithVerificationCode = do
   let fltr = filterBy "externalId" "67c196a0-cd0e-11ea-93c7-ef550ee48502"
   listUsers_ (Just token) (Just fltr) (env ^. teSpar)
     !!! const 200 === statusCode
+
+unlockFeature :: GalleyReq -> TeamId -> TestSpar ()
+unlockFeature galley tid =
+  call $ put (galley . paths ["i", "teams", toByteString' tid, "features", toByteString' Public.TeamFeatureSndFactorPasswordChallenge, toByteString' Public.Unlocked]) !!! const 200 === statusCode
 
 setSndFactorPasswordChallengeStatus :: GalleyReq -> TeamId -> Public.TeamFeatureStatusValue -> TestSpar ()
 setSndFactorPasswordChallengeStatus galley tid status = do


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1300

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
 