### PR TITLE
SQSERVICES-1375-block-bot-api-if-2-fa-is-enabled

### DIFF
--- a/changelog.d/2-features/pr-2207
+++ b/changelog.d/2-features/pr-2207
@@ -1,0 +1,1 @@
+The bot API will be blocked if the 2nd factor authentication team feature is enabled.

--- a/changelog.d/2-features/pr-2207
+++ b/changelog.d/2-features/pr-2207
@@ -1,1 +1,1 @@
-The bot API will be blocked if the 2nd factor authentication team feature is enabled.
+The bot API will be blocked if the 2nd factor authentication team feature is enabled. Please refer to [/docs/reference/config-options.md#2nd-factor-password-challenge](https://github.com/wireapp/wire-server/blob/develop/docs/reference/config-options.md#2nd-factor-password-challenge).

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -1008,13 +1008,13 @@ getVerificationCodeEnabled tid = do
         . expect2xx
 
 getTeamFeatureStatusSndFactorPasswordChallenge :: Maybe UserId -> (AppIO r) TeamFeatureStatusNoConfig
-getTeamFeatureStatusSndFactorPasswordChallenge = \case
-  Just u -> do
-    resp <- galleyRequest GET (paths ["i", "feature-configs", toByteString' (knownTeamFeatureName @'TeamFeatureSndFactorPasswordChallenge)] . queryItem "user_id" (toByteString' u))
-    pure $ responseJsonUnsafe resp
-  Nothing -> do
-    resp <- galleyRequest GET (paths ["i", "feature-configs", toByteString' (knownTeamFeatureName @'TeamFeatureSndFactorPasswordChallenge)])
-    pure $ responseJsonUnsafe resp
+getTeamFeatureStatusSndFactorPasswordChallenge mbUserId =
+  responseJsonUnsafe
+    <$> galleyRequest
+      GET
+      ( paths ["i", "feature-configs", toByteString' (knownTeamFeatureName @'TeamFeatureSndFactorPasswordChallenge)]
+          . maybe id (queryItem "user_id" . toByteString') mbUserId
+      )
 
 -- | Calls 'Galley.API.updateTeamStatusH'.
 changeTeamStatus :: TeamId -> Team.TeamStatus -> Maybe Currency.Alpha -> (AppIO r) ()

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -58,7 +58,7 @@ module Brig.IO.Intra
     changeTeamStatus,
     getTeamSearchVisibility,
     getVerificationCodeEnabled,
-    getTeamFeatureStatusSndFactorPasswordChallengeForSite,
+    getTeamFeatureStatusSndFactorPasswordChallenge,
 
     -- * Legalhold
     guardLegalhold,
@@ -1007,9 +1007,14 @@ getVerificationCodeEnabled tid = do
       paths ["i", "teams", toByteString' tid, "features", toByteString' TeamFeatureSndFactorPasswordChallenge]
         . expect2xx
 
-getTeamFeatureStatusSndFactorPasswordChallengeForSite :: (AppIO r) TeamFeatureStatusNoConfig
-getTeamFeatureStatusSndFactorPasswordChallengeForSite =
-  responseJsonUnsafe <$> galleyRequest GET (paths ["i", "feature-configs", toByteString' (knownTeamFeatureName @'TeamFeatureSndFactorPasswordChallenge)])
+getTeamFeatureStatusSndFactorPasswordChallenge :: Maybe UserId -> (AppIO r) TeamFeatureStatusNoConfig
+getTeamFeatureStatusSndFactorPasswordChallenge = \case
+  Just u -> do
+    resp <- galleyRequest GET (paths ["i", "feature-configs", toByteString' (knownTeamFeatureName @'TeamFeatureSndFactorPasswordChallenge)] . queryItem "user_id" (toByteString' u))
+    pure $ responseJsonUnsafe resp
+  Nothing -> do
+    resp <- galleyRequest GET (paths ["i", "feature-configs", toByteString' (knownTeamFeatureName @'TeamFeatureSndFactorPasswordChallenge)])
+    pure $ responseJsonUnsafe resp
 
 -- | Calls 'Galley.API.updateTeamStatusH'.
 changeTeamStatus :: TeamId -> Team.TeamStatus -> Maybe Currency.Alpha -> (AppIO r) ()

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -123,7 +123,7 @@ import System.Logger.Class as Log hiding (name, (.=))
 import Wire.API.Federation.API.Brig
 import Wire.API.Federation.Error
 import Wire.API.Message (UserClients)
-import Wire.API.Team.Feature hiding (AllFeatureConfigs)
+import Wire.API.Team.Feature
 import Wire.API.Team.LegalHold (LegalholdProtectee)
 import qualified Wire.API.Team.Member as Member
 

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -58,7 +58,7 @@ module Brig.IO.Intra
     changeTeamStatus,
     getTeamSearchVisibility,
     getVerificationCodeEnabled,
-    getTeamFeatureStatusSndFactorPasswordChallenge,
+    getTeamFeatureStatusSndFactorPasswordChallengeForSite,
 
     -- * Legalhold
     guardLegalhold,
@@ -1007,21 +1007,9 @@ getVerificationCodeEnabled tid = do
       paths ["i", "teams", toByteString' tid, "features", toByteString' TeamFeatureSndFactorPasswordChallenge]
         . expect2xx
 
-data AllFeatureConfigs = AllFeatureConfigs
-  { afcSndFactorPasswordChallenge :: TeamFeatureStatusNoConfig
-  }
-  deriving stock (Show, Eq, Generic)
-
-instance FromJSON AllFeatureConfigs where
-  parseJSON = withObject "AllFeatureConfigs" $ \o ->
-    AllFeatureConfigs <$> o .: "sndFactorPasswordChallenge"
-
-getTeamFeatureStatusSndFactorPasswordChallenge :: Maybe UserId -> (AppIO r) TeamFeatureStatusNoConfig
-getTeamFeatureStatusSndFactorPasswordChallenge = \case
-  Just u ->
-    afcSndFactorPasswordChallenge . responseJsonUnsafe <$> galleyRequest GET (paths ["feature-configs"] . zUser u)
-  Nothing -> do
-    responseJsonUnsafe <$> galleyRequest GET (paths ["feature-configs", toByteString' (knownTeamFeatureName @'TeamFeatureSndFactorPasswordChallenge)])
+getTeamFeatureStatusSndFactorPasswordChallengeForSite :: (AppIO r) TeamFeatureStatusNoConfig
+getTeamFeatureStatusSndFactorPasswordChallengeForSite =
+  responseJsonUnsafe <$> galleyRequest GET (paths ["i", "feature-configs", toByteString' (knownTeamFeatureName @'TeamFeatureSndFactorPasswordChallenge)])
 
 -- | Calls 'Galley.API.updateTeamStatusH'.
 changeTeamStatus :: TeamId -> Team.TeamStatus -> Maybe Currency.Alpha -> (AppIO r) ()

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -320,7 +320,7 @@ routesInternal = do
 
 newAccountH :: JsonRequest Public.NewProvider -> (Handler r) Response
 newAccountH req = do
-  checkAllowedForSite
+  checkAllowed Nothing
   setStatus status201 . json <$> (newAccount =<< parseJsonBody req)
 
 newAccount :: Public.NewProvider -> (Handler r) Public.NewProviderResponse
@@ -357,7 +357,7 @@ newAccount new = do
 
 activateAccountKeyH :: Code.Key ::: Code.Value -> (Handler r) Response
 activateAccountKeyH (key ::: val) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   maybe (setStatus status204 empty) json <$> activateAccountKey key val
 
 activateAccountKey :: Code.Key -> Code.Value -> (Handler r) (Maybe Public.ProviderActivationResponse)
@@ -384,7 +384,7 @@ activateAccountKey key val = do
 
 getActivationCodeH :: Public.Email -> (Handler r) Response
 getActivationCodeH e = do
-  checkAllowedForSite
+  checkAllowed Nothing
   json <$> getActivationCode e
 
 getActivationCode :: Public.Email -> (Handler r) FoundActivationCode
@@ -405,7 +405,7 @@ instance ToJSON FoundActivationCode where
 
 approveAccountKeyH :: Code.Key ::: Code.Value -> (Handler r) Response
 approveAccountKeyH (key ::: val) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   empty <$ approveAccountKey key val
 
 approveAccountKey :: Code.Key -> Code.Value -> (Handler r) ()
@@ -420,7 +420,7 @@ approveAccountKey key val = do
 
 loginH :: JsonRequest Public.ProviderLogin -> (Handler r) Response
 loginH req = do
-  checkAllowedForSite
+  checkAllowed Nothing
   tok <- login =<< parseJsonBody req
   setProviderCookie tok empty
 
@@ -434,7 +434,7 @@ login l = do
 
 beginPasswordResetH :: JsonRequest Public.PasswordReset -> (Handler r) Response
 beginPasswordResetH req = do
-  checkAllowedForSite
+  checkAllowed Nothing
   setStatus status201 empty <$ (beginPasswordReset =<< parseJsonBody req)
 
 beginPasswordReset :: Public.PasswordReset -> (Handler r) ()
@@ -456,7 +456,7 @@ beginPasswordReset (Public.PasswordReset target) = do
 
 completePasswordResetH :: JsonRequest Public.CompletePasswordReset -> (Handler r) Response
 completePasswordResetH req = do
-  checkAllowedForSite
+  checkAllowed Nothing
   empty <$ (completePasswordReset =<< parseJsonBody req)
 
 completePasswordReset :: Public.CompletePasswordReset -> (Handler r) ()
@@ -477,7 +477,7 @@ completePasswordReset (Public.CompletePasswordReset key val newpwd) = do
 
 getAccountH :: ProviderId -> (Handler r) Response
 getAccountH pid = do
-  checkAllowedForSite
+  checkAllowed Nothing
   getAccount pid <&> \case
     Just p -> json p
     Nothing -> setStatus status404 empty
@@ -487,7 +487,7 @@ getAccount = wrapClientE . DB.lookupAccount
 
 updateAccountProfileH :: ProviderId ::: JsonRequest Public.UpdateProvider -> (Handler r) Response
 updateAccountProfileH (pid ::: req) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   empty <$ (updateAccountProfile pid =<< parseJsonBody req)
 
 updateAccountProfile :: ProviderId -> Public.UpdateProvider -> (Handler r) ()
@@ -502,7 +502,7 @@ updateAccountProfile pid upd = do
 
 updateAccountEmailH :: ProviderId ::: JsonRequest Public.EmailUpdate -> (Handler r) Response
 updateAccountEmailH (pid ::: req) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   setStatus status202 empty <$ (updateAccountEmail pid =<< parseJsonBody req)
 
 updateAccountEmail :: ProviderId -> Public.EmailUpdate -> (Handler r) ()
@@ -525,7 +525,7 @@ updateAccountEmail pid (Public.EmailUpdate new) = do
 
 updateAccountPasswordH :: ProviderId ::: JsonRequest Public.PasswordChange -> (Handler r) Response
 updateAccountPasswordH (pid ::: req) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   empty <$ (updateAccountPassword pid =<< parseJsonBody req)
 
 updateAccountPassword :: ProviderId -> Public.PasswordChange -> (Handler r) ()
@@ -539,7 +539,7 @@ updateAccountPassword pid upd = do
 
 addServiceH :: ProviderId ::: JsonRequest Public.NewService -> (Handler r) Response
 addServiceH (pid ::: req) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   setStatus status201 . json <$> (addService pid =<< parseJsonBody req)
 
 addService :: ProviderId -> Public.NewService -> (Handler r) Public.NewServiceResponse
@@ -560,7 +560,7 @@ addService pid new = do
 
 listServicesH :: ProviderId -> (Handler r) Response
 listServicesH pid = do
-  checkAllowedForSite
+  checkAllowed Nothing
   json <$> listServices pid
 
 listServices :: ProviderId -> (Handler r) [Public.Service]
@@ -568,7 +568,7 @@ listServices = wrapClientE . DB.listServices
 
 getServiceH :: ProviderId ::: ServiceId -> (Handler r) Response
 getServiceH (pid ::: sid) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   json <$> getService pid sid
 
 getService :: ProviderId -> ServiceId -> (Handler r) Public.Service
@@ -577,7 +577,7 @@ getService pid sid =
 
 updateServiceH :: ProviderId ::: ServiceId ::: JsonRequest Public.UpdateService -> (Handler r) Response
 updateServiceH (pid ::: sid ::: req) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   empty <$ (updateService pid sid =<< parseJsonBody req)
 
 updateService :: ProviderId -> ServiceId -> Public.UpdateService -> (Handler r) ()
@@ -610,7 +610,7 @@ updateService pid sid upd = do
 
 updateServiceConnH :: ProviderId ::: ServiceId ::: JsonRequest Public.UpdateServiceConn -> (Handler r) Response
 updateServiceConnH (pid ::: sid ::: req) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   empty <$ (updateServiceConn pid sid =<< parseJsonBody req)
 
 updateServiceConn :: ProviderId -> ServiceId -> Public.UpdateServiceConn -> (Handler r) ()
@@ -656,7 +656,7 @@ updateServiceConn pid sid upd = do
 -- delete the service. See 'finishDeleteService'.
 deleteServiceH :: ProviderId ::: ServiceId ::: JsonRequest Public.DeleteService -> (Handler r) Response
 deleteServiceH (pid ::: sid ::: req) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   setStatus status202 empty <$ (deleteService pid sid =<< parseJsonBody req)
 
 -- | The endpoint that is called to delete a service.
@@ -695,7 +695,7 @@ finishDeleteService pid sid = do
 
 deleteAccountH :: ProviderId ::: JsonRequest Public.DeleteProvider -> (Handler r) Response
 deleteAccountH (pid ::: req) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   empty <$ (deleteAccount pid =<< parseJsonBody req)
 
 deleteAccount :: ProviderId -> Public.DeleteProvider -> (Handler r) ()
@@ -720,7 +720,7 @@ deleteAccount pid del = do
 
 getProviderProfileH :: ProviderId -> (Handler r) Response
 getProviderProfileH pid = do
-  checkAllowedForSite
+  checkAllowed Nothing
   json <$> getProviderProfile pid
 
 getProviderProfile :: ProviderId -> (Handler r) Public.ProviderProfile
@@ -729,7 +729,7 @@ getProviderProfile pid =
 
 listServiceProfilesH :: ProviderId -> (Handler r) Response
 listServiceProfilesH pid = do
-  checkAllowedForSite
+  checkAllowed Nothing
   json <$> listServiceProfiles pid
 
 listServiceProfiles :: ProviderId -> (Handler r) [Public.ServiceProfile]
@@ -737,7 +737,7 @@ listServiceProfiles = wrapClientE . DB.listServiceProfiles
 
 getServiceProfileH :: ProviderId ::: ServiceId -> (Handler r) Response
 getServiceProfileH (pid ::: sid) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   json <$> getServiceProfile pid sid
 
 getServiceProfile :: ProviderId -> ServiceId -> (Handler r) Public.ServiceProfile
@@ -746,7 +746,7 @@ getServiceProfile pid sid =
 
 searchServiceProfilesH :: Maybe (Public.QueryAnyTags 1 3) ::: Maybe Text ::: Range 10 100 Int32 -> (Handler r) Response
 searchServiceProfilesH (qt ::: start ::: size) = do
-  checkAllowedForSite
+  checkAllowed Nothing
   json <$> searchServiceProfiles qt start size
 
 -- TODO: in order to actually make it possible for clients to implement
@@ -766,7 +766,7 @@ searchTeamServiceProfilesH ::
   UserId ::: TeamId ::: Maybe (Range 1 128 Text) ::: Bool ::: Range 10 100 Int32 ->
   (Handler r) Response
 searchTeamServiceProfilesH (uid ::: tid ::: prefix ::: filterDisabled ::: size) = do
-  checkAllowedForSite
+  checkAllowed (Just uid)
   json <$> searchTeamServiceProfiles uid tid prefix filterDisabled size
 
 -- NB: unlike 'searchServiceProfiles', we don't filter by service provider here
@@ -789,7 +789,7 @@ searchTeamServiceProfiles uid tid prefix filterDisabled size = do
 
 getServiceTagListH :: () -> (Handler r) Response
 getServiceTagListH () = do
-  checkAllowedForSite
+  checkAllowed Nothing
   json <$> getServiceTagList ()
 
 getServiceTagList :: () -> Monad m => m Public.ServiceTagList
@@ -799,7 +799,7 @@ getServiceTagList () = return (Public.ServiceTagList allTags)
 
 updateServiceWhitelistH :: UserId ::: ConnId ::: TeamId ::: JsonRequest Public.UpdateServiceWhitelist -> (Handler r) Response
 updateServiceWhitelistH (uid ::: con ::: tid ::: req) = do
-  checkAllowedForSite
+  checkAllowed (Just uid)
   resp <- updateServiceWhitelist uid con tid =<< parseJsonBody req
   let status = case resp of
         UpdateServiceWhitelistRespChanged -> status200
@@ -847,7 +847,7 @@ updateServiceWhitelist uid con tid upd = do
 
 addBotH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.AddBot -> (Handler r) Response
 addBotH (zuid ::: zcon ::: cid ::: req) = do
-  checkAllowedForSite
+  checkAllowed (Just zuid)
   setStatus status201 . json <$> (addBot zuid zcon cid =<< parseJsonBody req)
 
 addBot :: UserId -> ConnId -> ConvId -> Public.AddBot -> (Handler r) Public.AddBotResponse
@@ -926,7 +926,7 @@ addBot zuid zcon cid add = do
 
 removeBotH :: UserId ::: ConnId ::: ConvId ::: BotId -> (Handler r) Response
 removeBotH (zusr ::: zcon ::: cid ::: bid) = do
-  checkAllowedForSite
+  checkAllowed (Just zusr)
   maybe (setStatus status204 empty) json <$> removeBot zusr zcon cid bid
 
 removeBot :: UserId -> ConnId -> ConvId -> BotId -> (Handler r) (Maybe Public.RemoveBotResponse)
@@ -949,7 +949,7 @@ removeBot zusr zcon cid bid = do
 
 botGetSelfH :: BotId -> (Handler r) Response
 botGetSelfH bot = do
-  checkAllowedForSite
+  checkAllowed (Just (botUserId bot))
   json <$> botGetSelf bot
 
 botGetSelf :: BotId -> (Handler r) Public.UserProfile
@@ -959,7 +959,7 @@ botGetSelf bot = do
 
 botGetClientH :: BotId -> (Handler r) Response
 botGetClientH bot = do
-  checkAllowedForSite
+  checkAllowed (Just (botUserId bot))
   maybe (throwErrorDescriptionType @ClientNotFound) (pure . json) =<< lift (botGetClient bot)
 
 botGetClient :: BotId -> (AppIO r) (Maybe Public.Client)
@@ -968,7 +968,7 @@ botGetClient bot =
 
 botListPrekeysH :: BotId -> (Handler r) Response
 botListPrekeysH bot = do
-  checkAllowedForSite
+  checkAllowed (Just (botUserId bot))
   json <$> botListPrekeys bot
 
 botListPrekeys :: BotId -> (Handler r) [Public.PrekeyId]
@@ -980,7 +980,7 @@ botListPrekeys bot = do
 
 botUpdatePrekeysH :: BotId ::: JsonRequest Public.UpdateBotPrekeys -> (Handler r) Response
 botUpdatePrekeysH (bot ::: req) = do
-  checkAllowedForSite
+  checkAllowed (Just (botUserId bot))
   empty <$ (botUpdatePrekeys bot =<< parseJsonBody req)
 
 botUpdatePrekeys :: BotId -> Public.UpdateBotPrekeys -> (Handler r) ()
@@ -994,7 +994,7 @@ botUpdatePrekeys bot upd = do
 
 botClaimUsersPrekeysH :: JsonRequest Public.UserClients -> (Handler r) Response
 botClaimUsersPrekeysH req = do
-  checkAllowedForSite
+  checkAllowed Nothing
   json <$> (botClaimUsersPrekeys =<< parseJsonBody req)
 
 botClaimUsersPrekeys :: Public.UserClients -> (Handler r) Public.UserClientPrekeyMap
@@ -1006,7 +1006,7 @@ botClaimUsersPrekeys body = do
 
 botListUserProfilesH :: List UserId -> (Handler r) Response
 botListUserProfilesH uids = do
-  checkAllowedForSite -- should we check all user ids?
+  checkAllowed Nothing -- should we check all user ids?
   json <$> botListUserProfiles uids
 
 botListUserProfiles :: List UserId -> (Handler r) [Public.BotUserView]
@@ -1016,7 +1016,7 @@ botListUserProfiles uids = do
 
 botGetUserClientsH :: UserId -> (Handler r) Response
 botGetUserClientsH uid = do
-  checkAllowedForSite
+  checkAllowed (Just uid)
   json <$> lift (botGetUserClients uid)
 
 botGetUserClients :: UserId -> (AppIO r) [Public.PubClient]
@@ -1027,12 +1027,12 @@ botGetUserClients uid =
 
 botDeleteSelfH :: BotId ::: ConvId -> (Handler r) Response
 botDeleteSelfH (bid ::: cid) = do
-  checkAllowedForSite
+  checkAllowed (Just (botUserId bid))
   empty <$ botDeleteSelf bid cid
 
 botDeleteSelf :: BotId -> ConvId -> (Handler r) ()
 botDeleteSelf bid cid = do
-  checkAllowedForSite
+  checkAllowed (Just (botUserId bid))
   bot <- lift . wrapClient $ User.lookupUser NoPendingInvitations (botUserId bid)
   _ <- maybeInvalidBot (userService =<< bot)
   _ <- lift $ deleteBot (botUserId bid) Nothing bid cid
@@ -1041,9 +1041,9 @@ botDeleteSelf bid cid = do
 --------------------------------------------------------------------------------
 -- Utilities
 
-checkAllowedForSite :: (Handler r) ()
-checkAllowedForSite = do
-  enabled <- lift $ (==) Feature.TeamFeatureEnabled . Feature.tfwoStatus <$> RPC.getTeamFeatureStatusSndFactorPasswordChallengeForSite
+checkAllowed :: Maybe UserId -> (Handler r) ()
+checkAllowed mbUserId = do
+  enabled <- lift $ (==) Feature.TeamFeatureEnabled . Feature.tfwoStatus <$> RPC.getTeamFeatureStatusSndFactorPasswordChallenge mbUserId
   when enabled $ throwStd accessDenied
 
 minRsaKeySize :: Int

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -320,7 +320,7 @@ routesInternal = do
 
 newAccountH :: JsonRequest Public.NewProvider -> (Handler r) Response
 newAccountH req = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   setStatus status201 . json <$> (newAccount =<< parseJsonBody req)
 
 newAccount :: Public.NewProvider -> (Handler r) Public.NewProviderResponse
@@ -357,7 +357,7 @@ newAccount new = do
 
 activateAccountKeyH :: Code.Key ::: Code.Value -> (Handler r) Response
 activateAccountKeyH (key ::: val) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   maybe (setStatus status204 empty) json <$> activateAccountKey key val
 
 activateAccountKey :: Code.Key -> Code.Value -> (Handler r) (Maybe Public.ProviderActivationResponse)
@@ -384,7 +384,7 @@ activateAccountKey key val = do
 
 getActivationCodeH :: Public.Email -> (Handler r) Response
 getActivationCodeH e = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   json <$> getActivationCode e
 
 getActivationCode :: Public.Email -> (Handler r) FoundActivationCode
@@ -405,7 +405,7 @@ instance ToJSON FoundActivationCode where
 
 approveAccountKeyH :: Code.Key ::: Code.Value -> (Handler r) Response
 approveAccountKeyH (key ::: val) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   empty <$ approveAccountKey key val
 
 approveAccountKey :: Code.Key -> Code.Value -> (Handler r) ()
@@ -420,7 +420,7 @@ approveAccountKey key val = do
 
 loginH :: JsonRequest Public.ProviderLogin -> (Handler r) Response
 loginH req = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   tok <- login =<< parseJsonBody req
   setProviderCookie tok empty
 
@@ -434,7 +434,7 @@ login l = do
 
 beginPasswordResetH :: JsonRequest Public.PasswordReset -> (Handler r) Response
 beginPasswordResetH req = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   setStatus status201 empty <$ (beginPasswordReset =<< parseJsonBody req)
 
 beginPasswordReset :: Public.PasswordReset -> (Handler r) ()
@@ -456,7 +456,7 @@ beginPasswordReset (Public.PasswordReset target) = do
 
 completePasswordResetH :: JsonRequest Public.CompletePasswordReset -> (Handler r) Response
 completePasswordResetH req = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   empty <$ (completePasswordReset =<< parseJsonBody req)
 
 completePasswordReset :: Public.CompletePasswordReset -> (Handler r) ()
@@ -477,7 +477,7 @@ completePasswordReset (Public.CompletePasswordReset key val newpwd) = do
 
 getAccountH :: ProviderId -> (Handler r) Response
 getAccountH pid = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   getAccount pid <&> \case
     Just p -> json p
     Nothing -> setStatus status404 empty
@@ -487,7 +487,7 @@ getAccount = wrapClientE . DB.lookupAccount
 
 updateAccountProfileH :: ProviderId ::: JsonRequest Public.UpdateProvider -> (Handler r) Response
 updateAccountProfileH (pid ::: req) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   empty <$ (updateAccountProfile pid =<< parseJsonBody req)
 
 updateAccountProfile :: ProviderId -> Public.UpdateProvider -> (Handler r) ()
@@ -502,7 +502,7 @@ updateAccountProfile pid upd = do
 
 updateAccountEmailH :: ProviderId ::: JsonRequest Public.EmailUpdate -> (Handler r) Response
 updateAccountEmailH (pid ::: req) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   setStatus status202 empty <$ (updateAccountEmail pid =<< parseJsonBody req)
 
 updateAccountEmail :: ProviderId -> Public.EmailUpdate -> (Handler r) ()
@@ -525,7 +525,7 @@ updateAccountEmail pid (Public.EmailUpdate new) = do
 
 updateAccountPasswordH :: ProviderId ::: JsonRequest Public.PasswordChange -> (Handler r) Response
 updateAccountPasswordH (pid ::: req) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   empty <$ (updateAccountPassword pid =<< parseJsonBody req)
 
 updateAccountPassword :: ProviderId -> Public.PasswordChange -> (Handler r) ()
@@ -539,7 +539,7 @@ updateAccountPassword pid upd = do
 
 addServiceH :: ProviderId ::: JsonRequest Public.NewService -> (Handler r) Response
 addServiceH (pid ::: req) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   setStatus status201 . json <$> (addService pid =<< parseJsonBody req)
 
 addService :: ProviderId -> Public.NewService -> (Handler r) Public.NewServiceResponse
@@ -560,7 +560,7 @@ addService pid new = do
 
 listServicesH :: ProviderId -> (Handler r) Response
 listServicesH pid = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   json <$> listServices pid
 
 listServices :: ProviderId -> (Handler r) [Public.Service]
@@ -568,7 +568,7 @@ listServices = wrapClientE . DB.listServices
 
 getServiceH :: ProviderId ::: ServiceId -> (Handler r) Response
 getServiceH (pid ::: sid) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   json <$> getService pid sid
 
 getService :: ProviderId -> ServiceId -> (Handler r) Public.Service
@@ -577,7 +577,7 @@ getService pid sid =
 
 updateServiceH :: ProviderId ::: ServiceId ::: JsonRequest Public.UpdateService -> (Handler r) Response
 updateServiceH (pid ::: sid ::: req) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   empty <$ (updateService pid sid =<< parseJsonBody req)
 
 updateService :: ProviderId -> ServiceId -> Public.UpdateService -> (Handler r) ()
@@ -610,7 +610,7 @@ updateService pid sid upd = do
 
 updateServiceConnH :: ProviderId ::: ServiceId ::: JsonRequest Public.UpdateServiceConn -> (Handler r) Response
 updateServiceConnH (pid ::: sid ::: req) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   empty <$ (updateServiceConn pid sid =<< parseJsonBody req)
 
 updateServiceConn :: ProviderId -> ServiceId -> Public.UpdateServiceConn -> (Handler r) ()
@@ -656,7 +656,7 @@ updateServiceConn pid sid upd = do
 -- delete the service. See 'finishDeleteService'.
 deleteServiceH :: ProviderId ::: ServiceId ::: JsonRequest Public.DeleteService -> (Handler r) Response
 deleteServiceH (pid ::: sid ::: req) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   setStatus status202 empty <$ (deleteService pid sid =<< parseJsonBody req)
 
 -- | The endpoint that is called to delete a service.
@@ -695,7 +695,7 @@ finishDeleteService pid sid = do
 
 deleteAccountH :: ProviderId ::: JsonRequest Public.DeleteProvider -> (Handler r) Response
 deleteAccountH (pid ::: req) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   empty <$ (deleteAccount pid =<< parseJsonBody req)
 
 deleteAccount :: ProviderId -> Public.DeleteProvider -> (Handler r) ()
@@ -720,7 +720,7 @@ deleteAccount pid del = do
 
 getProviderProfileH :: ProviderId -> (Handler r) Response
 getProviderProfileH pid = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   json <$> getProviderProfile pid
 
 getProviderProfile :: ProviderId -> (Handler r) Public.ProviderProfile
@@ -729,7 +729,7 @@ getProviderProfile pid =
 
 listServiceProfilesH :: ProviderId -> (Handler r) Response
 listServiceProfilesH pid = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   json <$> listServiceProfiles pid
 
 listServiceProfiles :: ProviderId -> (Handler r) [Public.ServiceProfile]
@@ -737,7 +737,7 @@ listServiceProfiles = wrapClientE . DB.listServiceProfiles
 
 getServiceProfileH :: ProviderId ::: ServiceId -> (Handler r) Response
 getServiceProfileH (pid ::: sid) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   json <$> getServiceProfile pid sid
 
 getServiceProfile :: ProviderId -> ServiceId -> (Handler r) Public.ServiceProfile
@@ -746,7 +746,7 @@ getServiceProfile pid sid =
 
 searchServiceProfilesH :: Maybe (Public.QueryAnyTags 1 3) ::: Maybe Text ::: Range 10 100 Int32 -> (Handler r) Response
 searchServiceProfilesH (qt ::: start ::: size) = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   json <$> searchServiceProfiles qt start size
 
 -- TODO: in order to actually make it possible for clients to implement
@@ -766,7 +766,7 @@ searchTeamServiceProfilesH ::
   UserId ::: TeamId ::: Maybe (Range 1 128 Text) ::: Bool ::: Range 10 100 Int32 ->
   (Handler r) Response
 searchTeamServiceProfilesH (uid ::: tid ::: prefix ::: filterDisabled ::: size) = do
-  checkAllowed (Just uid)
+  guardSecondFactorDisabled (Just uid)
   json <$> searchTeamServiceProfiles uid tid prefix filterDisabled size
 
 -- NB: unlike 'searchServiceProfiles', we don't filter by service provider here
@@ -789,7 +789,7 @@ searchTeamServiceProfiles uid tid prefix filterDisabled size = do
 
 getServiceTagListH :: () -> (Handler r) Response
 getServiceTagListH () = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   json <$> getServiceTagList ()
 
 getServiceTagList :: () -> Monad m => m Public.ServiceTagList
@@ -799,7 +799,7 @@ getServiceTagList () = return (Public.ServiceTagList allTags)
 
 updateServiceWhitelistH :: UserId ::: ConnId ::: TeamId ::: JsonRequest Public.UpdateServiceWhitelist -> (Handler r) Response
 updateServiceWhitelistH (uid ::: con ::: tid ::: req) = do
-  checkAllowed (Just uid)
+  guardSecondFactorDisabled (Just uid)
   resp <- updateServiceWhitelist uid con tid =<< parseJsonBody req
   let status = case resp of
         UpdateServiceWhitelistRespChanged -> status200
@@ -847,7 +847,7 @@ updateServiceWhitelist uid con tid upd = do
 
 addBotH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.AddBot -> (Handler r) Response
 addBotH (zuid ::: zcon ::: cid ::: req) = do
-  checkAllowed (Just zuid)
+  guardSecondFactorDisabled (Just zuid)
   setStatus status201 . json <$> (addBot zuid zcon cid =<< parseJsonBody req)
 
 addBot :: UserId -> ConnId -> ConvId -> Public.AddBot -> (Handler r) Public.AddBotResponse
@@ -926,7 +926,7 @@ addBot zuid zcon cid add = do
 
 removeBotH :: UserId ::: ConnId ::: ConvId ::: BotId -> (Handler r) Response
 removeBotH (zusr ::: zcon ::: cid ::: bid) = do
-  checkAllowed (Just zusr)
+  guardSecondFactorDisabled (Just zusr)
   maybe (setStatus status204 empty) json <$> removeBot zusr zcon cid bid
 
 removeBot :: UserId -> ConnId -> ConvId -> BotId -> (Handler r) (Maybe Public.RemoveBotResponse)
@@ -949,7 +949,7 @@ removeBot zusr zcon cid bid = do
 
 botGetSelfH :: BotId -> (Handler r) Response
 botGetSelfH bot = do
-  checkAllowed (Just (botUserId bot))
+  guardSecondFactorDisabled (Just (botUserId bot))
   json <$> botGetSelf bot
 
 botGetSelf :: BotId -> (Handler r) Public.UserProfile
@@ -959,7 +959,7 @@ botGetSelf bot = do
 
 botGetClientH :: BotId -> (Handler r) Response
 botGetClientH bot = do
-  checkAllowed (Just (botUserId bot))
+  guardSecondFactorDisabled (Just (botUserId bot))
   maybe (throwErrorDescriptionType @ClientNotFound) (pure . json) =<< lift (botGetClient bot)
 
 botGetClient :: BotId -> (AppIO r) (Maybe Public.Client)
@@ -968,7 +968,7 @@ botGetClient bot =
 
 botListPrekeysH :: BotId -> (Handler r) Response
 botListPrekeysH bot = do
-  checkAllowed (Just (botUserId bot))
+  guardSecondFactorDisabled (Just (botUserId bot))
   json <$> botListPrekeys bot
 
 botListPrekeys :: BotId -> (Handler r) [Public.PrekeyId]
@@ -980,7 +980,7 @@ botListPrekeys bot = do
 
 botUpdatePrekeysH :: BotId ::: JsonRequest Public.UpdateBotPrekeys -> (Handler r) Response
 botUpdatePrekeysH (bot ::: req) = do
-  checkAllowed (Just (botUserId bot))
+  guardSecondFactorDisabled (Just (botUserId bot))
   empty <$ (botUpdatePrekeys bot =<< parseJsonBody req)
 
 botUpdatePrekeys :: BotId -> Public.UpdateBotPrekeys -> (Handler r) ()
@@ -994,7 +994,7 @@ botUpdatePrekeys bot upd = do
 
 botClaimUsersPrekeysH :: JsonRequest Public.UserClients -> (Handler r) Response
 botClaimUsersPrekeysH req = do
-  checkAllowed Nothing
+  guardSecondFactorDisabled Nothing
   json <$> (botClaimUsersPrekeys =<< parseJsonBody req)
 
 botClaimUsersPrekeys :: Public.UserClients -> (Handler r) Public.UserClientPrekeyMap
@@ -1006,7 +1006,7 @@ botClaimUsersPrekeys body = do
 
 botListUserProfilesH :: List UserId -> (Handler r) Response
 botListUserProfilesH uids = do
-  checkAllowed Nothing -- should we check all user ids?
+  guardSecondFactorDisabled Nothing -- should we check all user ids?
   json <$> botListUserProfiles uids
 
 botListUserProfiles :: List UserId -> (Handler r) [Public.BotUserView]
@@ -1016,7 +1016,7 @@ botListUserProfiles uids = do
 
 botGetUserClientsH :: UserId -> (Handler r) Response
 botGetUserClientsH uid = do
-  checkAllowed (Just uid)
+  guardSecondFactorDisabled (Just uid)
   json <$> lift (botGetUserClients uid)
 
 botGetUserClients :: UserId -> (AppIO r) [Public.PubClient]
@@ -1027,12 +1027,12 @@ botGetUserClients uid =
 
 botDeleteSelfH :: BotId ::: ConvId -> (Handler r) Response
 botDeleteSelfH (bid ::: cid) = do
-  checkAllowed (Just (botUserId bid))
+  guardSecondFactorDisabled (Just (botUserId bid))
   empty <$ botDeleteSelf bid cid
 
 botDeleteSelf :: BotId -> ConvId -> (Handler r) ()
 botDeleteSelf bid cid = do
-  checkAllowed (Just (botUserId bid))
+  guardSecondFactorDisabled (Just (botUserId bid))
   bot <- lift . wrapClient $ User.lookupUser NoPendingInvitations (botUserId bid)
   _ <- maybeInvalidBot (userService =<< bot)
   _ <- lift $ deleteBot (botUserId bid) Nothing bid cid
@@ -1041,8 +1041,10 @@ botDeleteSelf bid cid = do
 --------------------------------------------------------------------------------
 -- Utilities
 
-checkAllowed :: Maybe UserId -> (Handler r) ()
-checkAllowed mbUserId = do
+-- | If second factor auth is enabled, make sure that end-points that don't support it, but should, are blocked completely.
+-- (This is a workaround until we have 2FA for those end-points as well.)
+guardSecondFactorDisabled :: Maybe UserId -> Handler r ()
+guardSecondFactorDisabled mbUserId = do
   enabled <- lift $ (==) Feature.TeamFeatureEnabled . Feature.tfwoStatus <$> RPC.getTeamFeatureStatusSndFactorPasswordChallenge mbUserId
   when enabled $ throwStd accessDenied
 

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -320,7 +320,7 @@ routesInternal = do
 
 newAccountH :: JsonRequest Public.NewProvider -> (Handler r) Response
 newAccountH req = do
-  checkAllowed Nothing
+  checkAllowedForSite
   setStatus status201 . json <$> (newAccount =<< parseJsonBody req)
 
 newAccount :: Public.NewProvider -> (Handler r) Public.NewProviderResponse
@@ -357,7 +357,7 @@ newAccount new = do
 
 activateAccountKeyH :: Code.Key ::: Code.Value -> (Handler r) Response
 activateAccountKeyH (key ::: val) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   maybe (setStatus status204 empty) json <$> activateAccountKey key val
 
 activateAccountKey :: Code.Key -> Code.Value -> (Handler r) (Maybe Public.ProviderActivationResponse)
@@ -384,7 +384,7 @@ activateAccountKey key val = do
 
 getActivationCodeH :: Public.Email -> (Handler r) Response
 getActivationCodeH e = do
-  checkAllowed Nothing
+  checkAllowedForSite
   json <$> getActivationCode e
 
 getActivationCode :: Public.Email -> (Handler r) FoundActivationCode
@@ -405,7 +405,7 @@ instance ToJSON FoundActivationCode where
 
 approveAccountKeyH :: Code.Key ::: Code.Value -> (Handler r) Response
 approveAccountKeyH (key ::: val) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   empty <$ approveAccountKey key val
 
 approveAccountKey :: Code.Key -> Code.Value -> (Handler r) ()
@@ -420,7 +420,7 @@ approveAccountKey key val = do
 
 loginH :: JsonRequest Public.ProviderLogin -> (Handler r) Response
 loginH req = do
-  checkAllowed Nothing
+  checkAllowedForSite
   tok <- login =<< parseJsonBody req
   setProviderCookie tok empty
 
@@ -434,7 +434,7 @@ login l = do
 
 beginPasswordResetH :: JsonRequest Public.PasswordReset -> (Handler r) Response
 beginPasswordResetH req = do
-  checkAllowed Nothing
+  checkAllowedForSite
   setStatus status201 empty <$ (beginPasswordReset =<< parseJsonBody req)
 
 beginPasswordReset :: Public.PasswordReset -> (Handler r) ()
@@ -456,7 +456,7 @@ beginPasswordReset (Public.PasswordReset target) = do
 
 completePasswordResetH :: JsonRequest Public.CompletePasswordReset -> (Handler r) Response
 completePasswordResetH req = do
-  checkAllowed Nothing
+  checkAllowedForSite
   empty <$ (completePasswordReset =<< parseJsonBody req)
 
 completePasswordReset :: Public.CompletePasswordReset -> (Handler r) ()
@@ -477,7 +477,7 @@ completePasswordReset (Public.CompletePasswordReset key val newpwd) = do
 
 getAccountH :: ProviderId -> (Handler r) Response
 getAccountH pid = do
-  checkAllowed Nothing
+  checkAllowedForSite
   getAccount pid <&> \case
     Just p -> json p
     Nothing -> setStatus status404 empty
@@ -487,7 +487,7 @@ getAccount = wrapClientE . DB.lookupAccount
 
 updateAccountProfileH :: ProviderId ::: JsonRequest Public.UpdateProvider -> (Handler r) Response
 updateAccountProfileH (pid ::: req) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   empty <$ (updateAccountProfile pid =<< parseJsonBody req)
 
 updateAccountProfile :: ProviderId -> Public.UpdateProvider -> (Handler r) ()
@@ -502,7 +502,7 @@ updateAccountProfile pid upd = do
 
 updateAccountEmailH :: ProviderId ::: JsonRequest Public.EmailUpdate -> (Handler r) Response
 updateAccountEmailH (pid ::: req) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   setStatus status202 empty <$ (updateAccountEmail pid =<< parseJsonBody req)
 
 updateAccountEmail :: ProviderId -> Public.EmailUpdate -> (Handler r) ()
@@ -525,7 +525,7 @@ updateAccountEmail pid (Public.EmailUpdate new) = do
 
 updateAccountPasswordH :: ProviderId ::: JsonRequest Public.PasswordChange -> (Handler r) Response
 updateAccountPasswordH (pid ::: req) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   empty <$ (updateAccountPassword pid =<< parseJsonBody req)
 
 updateAccountPassword :: ProviderId -> Public.PasswordChange -> (Handler r) ()
@@ -539,7 +539,7 @@ updateAccountPassword pid upd = do
 
 addServiceH :: ProviderId ::: JsonRequest Public.NewService -> (Handler r) Response
 addServiceH (pid ::: req) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   setStatus status201 . json <$> (addService pid =<< parseJsonBody req)
 
 addService :: ProviderId -> Public.NewService -> (Handler r) Public.NewServiceResponse
@@ -560,7 +560,7 @@ addService pid new = do
 
 listServicesH :: ProviderId -> (Handler r) Response
 listServicesH pid = do
-  checkAllowed Nothing
+  checkAllowedForSite
   json <$> listServices pid
 
 listServices :: ProviderId -> (Handler r) [Public.Service]
@@ -568,7 +568,7 @@ listServices = wrapClientE . DB.listServices
 
 getServiceH :: ProviderId ::: ServiceId -> (Handler r) Response
 getServiceH (pid ::: sid) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   json <$> getService pid sid
 
 getService :: ProviderId -> ServiceId -> (Handler r) Public.Service
@@ -577,7 +577,7 @@ getService pid sid =
 
 updateServiceH :: ProviderId ::: ServiceId ::: JsonRequest Public.UpdateService -> (Handler r) Response
 updateServiceH (pid ::: sid ::: req) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   empty <$ (updateService pid sid =<< parseJsonBody req)
 
 updateService :: ProviderId -> ServiceId -> Public.UpdateService -> (Handler r) ()
@@ -610,7 +610,7 @@ updateService pid sid upd = do
 
 updateServiceConnH :: ProviderId ::: ServiceId ::: JsonRequest Public.UpdateServiceConn -> (Handler r) Response
 updateServiceConnH (pid ::: sid ::: req) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   empty <$ (updateServiceConn pid sid =<< parseJsonBody req)
 
 updateServiceConn :: ProviderId -> ServiceId -> Public.UpdateServiceConn -> (Handler r) ()
@@ -656,7 +656,7 @@ updateServiceConn pid sid upd = do
 -- delete the service. See 'finishDeleteService'.
 deleteServiceH :: ProviderId ::: ServiceId ::: JsonRequest Public.DeleteService -> (Handler r) Response
 deleteServiceH (pid ::: sid ::: req) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   setStatus status202 empty <$ (deleteService pid sid =<< parseJsonBody req)
 
 -- | The endpoint that is called to delete a service.
@@ -695,7 +695,7 @@ finishDeleteService pid sid = do
 
 deleteAccountH :: ProviderId ::: JsonRequest Public.DeleteProvider -> (Handler r) Response
 deleteAccountH (pid ::: req) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   empty <$ (deleteAccount pid =<< parseJsonBody req)
 
 deleteAccount :: ProviderId -> Public.DeleteProvider -> (Handler r) ()
@@ -720,7 +720,7 @@ deleteAccount pid del = do
 
 getProviderProfileH :: ProviderId -> (Handler r) Response
 getProviderProfileH pid = do
-  checkAllowed Nothing
+  checkAllowedForSite
   json <$> getProviderProfile pid
 
 getProviderProfile :: ProviderId -> (Handler r) Public.ProviderProfile
@@ -729,7 +729,7 @@ getProviderProfile pid =
 
 listServiceProfilesH :: ProviderId -> (Handler r) Response
 listServiceProfilesH pid = do
-  checkAllowed Nothing
+  checkAllowedForSite
   json <$> listServiceProfiles pid
 
 listServiceProfiles :: ProviderId -> (Handler r) [Public.ServiceProfile]
@@ -737,7 +737,7 @@ listServiceProfiles = wrapClientE . DB.listServiceProfiles
 
 getServiceProfileH :: ProviderId ::: ServiceId -> (Handler r) Response
 getServiceProfileH (pid ::: sid) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   json <$> getServiceProfile pid sid
 
 getServiceProfile :: ProviderId -> ServiceId -> (Handler r) Public.ServiceProfile
@@ -746,7 +746,7 @@ getServiceProfile pid sid =
 
 searchServiceProfilesH :: Maybe (Public.QueryAnyTags 1 3) ::: Maybe Text ::: Range 10 100 Int32 -> (Handler r) Response
 searchServiceProfilesH (qt ::: start ::: size) = do
-  checkAllowed Nothing
+  checkAllowedForSite
   json <$> searchServiceProfiles qt start size
 
 -- TODO: in order to actually make it possible for clients to implement
@@ -766,7 +766,7 @@ searchTeamServiceProfilesH ::
   UserId ::: TeamId ::: Maybe (Range 1 128 Text) ::: Bool ::: Range 10 100 Int32 ->
   (Handler r) Response
 searchTeamServiceProfilesH (uid ::: tid ::: prefix ::: filterDisabled ::: size) = do
-  checkAllowed (Just uid)
+  checkAllowedForSite
   json <$> searchTeamServiceProfiles uid tid prefix filterDisabled size
 
 -- NB: unlike 'searchServiceProfiles', we don't filter by service provider here
@@ -789,7 +789,7 @@ searchTeamServiceProfiles uid tid prefix filterDisabled size = do
 
 getServiceTagListH :: () -> (Handler r) Response
 getServiceTagListH () = do
-  checkAllowed Nothing
+  checkAllowedForSite
   json <$> getServiceTagList ()
 
 getServiceTagList :: () -> Monad m => m Public.ServiceTagList
@@ -799,7 +799,7 @@ getServiceTagList () = return (Public.ServiceTagList allTags)
 
 updateServiceWhitelistH :: UserId ::: ConnId ::: TeamId ::: JsonRequest Public.UpdateServiceWhitelist -> (Handler r) Response
 updateServiceWhitelistH (uid ::: con ::: tid ::: req) = do
-  checkAllowed (Just uid)
+  checkAllowedForSite
   resp <- updateServiceWhitelist uid con tid =<< parseJsonBody req
   let status = case resp of
         UpdateServiceWhitelistRespChanged -> status200
@@ -847,7 +847,7 @@ updateServiceWhitelist uid con tid upd = do
 
 addBotH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.AddBot -> (Handler r) Response
 addBotH (zuid ::: zcon ::: cid ::: req) = do
-  checkAllowed (Just zuid)
+  checkAllowedForSite
   setStatus status201 . json <$> (addBot zuid zcon cid =<< parseJsonBody req)
 
 addBot :: UserId -> ConnId -> ConvId -> Public.AddBot -> (Handler r) Public.AddBotResponse
@@ -926,7 +926,7 @@ addBot zuid zcon cid add = do
 
 removeBotH :: UserId ::: ConnId ::: ConvId ::: BotId -> (Handler r) Response
 removeBotH (zusr ::: zcon ::: cid ::: bid) = do
-  checkAllowed (Just zusr)
+  checkAllowedForSite
   maybe (setStatus status204 empty) json <$> removeBot zusr zcon cid bid
 
 removeBot :: UserId -> ConnId -> ConvId -> BotId -> (Handler r) (Maybe Public.RemoveBotResponse)
@@ -949,7 +949,7 @@ removeBot zusr zcon cid bid = do
 
 botGetSelfH :: BotId -> (Handler r) Response
 botGetSelfH bot = do
-  checkAllowed (Just (botUserId bot))
+  checkAllowedForSite
   json <$> botGetSelf bot
 
 botGetSelf :: BotId -> (Handler r) Public.UserProfile
@@ -959,7 +959,7 @@ botGetSelf bot = do
 
 botGetClientH :: BotId -> (Handler r) Response
 botGetClientH bot = do
-  checkAllowed (Just (botUserId bot))
+  checkAllowedForSite
   maybe (throwErrorDescriptionType @ClientNotFound) (pure . json) =<< lift (botGetClient bot)
 
 botGetClient :: BotId -> (AppIO r) (Maybe Public.Client)
@@ -968,7 +968,7 @@ botGetClient bot =
 
 botListPrekeysH :: BotId -> (Handler r) Response
 botListPrekeysH bot = do
-  checkAllowed (Just (botUserId bot))
+  checkAllowedForSite
   json <$> botListPrekeys bot
 
 botListPrekeys :: BotId -> (Handler r) [Public.PrekeyId]
@@ -980,7 +980,7 @@ botListPrekeys bot = do
 
 botUpdatePrekeysH :: BotId ::: JsonRequest Public.UpdateBotPrekeys -> (Handler r) Response
 botUpdatePrekeysH (bot ::: req) = do
-  checkAllowed (Just (botUserId bot))
+  checkAllowedForSite
   empty <$ (botUpdatePrekeys bot =<< parseJsonBody req)
 
 botUpdatePrekeys :: BotId -> Public.UpdateBotPrekeys -> (Handler r) ()
@@ -994,7 +994,7 @@ botUpdatePrekeys bot upd = do
 
 botClaimUsersPrekeysH :: JsonRequest Public.UserClients -> (Handler r) Response
 botClaimUsersPrekeysH req = do
-  checkAllowed Nothing
+  checkAllowedForSite
   json <$> (botClaimUsersPrekeys =<< parseJsonBody req)
 
 botClaimUsersPrekeys :: Public.UserClients -> (Handler r) Public.UserClientPrekeyMap
@@ -1006,7 +1006,7 @@ botClaimUsersPrekeys body = do
 
 botListUserProfilesH :: List UserId -> (Handler r) Response
 botListUserProfilesH uids = do
-  checkAllowed Nothing -- should we check all user ids?
+  checkAllowedForSite -- should we check all user ids?
   json <$> botListUserProfiles uids
 
 botListUserProfiles :: List UserId -> (Handler r) [Public.BotUserView]
@@ -1016,7 +1016,7 @@ botListUserProfiles uids = do
 
 botGetUserClientsH :: UserId -> (Handler r) Response
 botGetUserClientsH uid = do
-  checkAllowed (Just uid)
+  checkAllowedForSite
   json <$> lift (botGetUserClients uid)
 
 botGetUserClients :: UserId -> (AppIO r) [Public.PubClient]
@@ -1027,12 +1027,12 @@ botGetUserClients uid =
 
 botDeleteSelfH :: BotId ::: ConvId -> (Handler r) Response
 botDeleteSelfH (bid ::: cid) = do
-  checkAllowed (Just (botUserId bid))
+  checkAllowedForSite
   empty <$ botDeleteSelf bid cid
 
 botDeleteSelf :: BotId -> ConvId -> (Handler r) ()
 botDeleteSelf bid cid = do
-  checkAllowed (Just (botUserId bid))
+  checkAllowedForSite
   bot <- lift . wrapClient $ User.lookupUser NoPendingInvitations (botUserId bid)
   _ <- maybeInvalidBot (userService =<< bot)
   _ <- lift $ deleteBot (botUserId bid) Nothing bid cid
@@ -1041,9 +1041,9 @@ botDeleteSelf bid cid = do
 --------------------------------------------------------------------------------
 -- Utilities
 
-checkAllowed :: Maybe UserId -> (Handler r) ()
-checkAllowed mbUserId = do
-  enabled <- lift $ (==) Feature.TeamFeatureEnabled . Feature.tfwoStatus <$> RPC.getTeamFeatureStatusSndFactorPasswordChallenge mbUserId
+checkAllowedForSite :: (Handler r) ()
+checkAllowedForSite = do
+  enabled <- lift $ (==) Feature.TeamFeatureEnabled . Feature.tfwoStatus <$> RPC.getTeamFeatureStatusSndFactorPasswordChallengeForSite
   when enabled $ throwStd accessDenied
 
 minRsaKeySize :: Int
@@ -1183,8 +1183,8 @@ serviceError :: RPC.ServiceError -> Wai.Error
 serviceError RPC.ServiceUnavailable = badGateway
 serviceError RPC.ServiceBotConflict = tooManyBots
 
-randServiceToken :: MonadIO m => m Public.ServiceToken
-randServiceToken = ServiceToken . Ascii.encodeBase64Url <$> liftIO (randBytes 18)
-
 accessDenied :: Wai.Error
 accessDenied = Wai.mkError status403 "access-denied" "Access denied."
+
+randServiceToken :: MonadIO m => m Public.ServiceToken
+randServiceToken = ServiceToken . Ascii.encodeBase64Url <$> liftIO (randBytes 18)

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -103,6 +103,7 @@ import qualified Wire.API.Provider as Public
 import qualified Wire.API.Provider.Bot as Public (BotUserView)
 import qualified Wire.API.Provider.Service as Public
 import qualified Wire.API.Provider.Service.Tag as Public
+import qualified Wire.API.Team.Feature as Feature
 import Wire.API.Team.LegalHold (LegalholdProtectee (UnprotectedBot))
 import qualified Wire.API.User as Public (UserProfile, publicProfile)
 import qualified Wire.API.User.Client as Public (Client, ClientCapability (ClientSupportsLegalholdImplicitConsent), PubClient (..), UserClientPrekeyMap, UserClients, userClients)
@@ -319,6 +320,7 @@ routesInternal = do
 
 newAccountH :: JsonRequest Public.NewProvider -> (Handler r) Response
 newAccountH req = do
+  checkAllowed Nothing
   setStatus status201 . json <$> (newAccount =<< parseJsonBody req)
 
 newAccount :: Public.NewProvider -> (Handler r) Public.NewProviderResponse
@@ -355,6 +357,7 @@ newAccount new = do
 
 activateAccountKeyH :: Code.Key ::: Code.Value -> (Handler r) Response
 activateAccountKeyH (key ::: val) = do
+  checkAllowed Nothing
   maybe (setStatus status204 empty) json <$> activateAccountKey key val
 
 activateAccountKey :: Code.Key -> Code.Value -> (Handler r) (Maybe Public.ProviderActivationResponse)
@@ -381,6 +384,7 @@ activateAccountKey key val = do
 
 getActivationCodeH :: Public.Email -> (Handler r) Response
 getActivationCodeH e = do
+  checkAllowed Nothing
   json <$> getActivationCode e
 
 getActivationCode :: Public.Email -> (Handler r) FoundActivationCode
@@ -401,6 +405,7 @@ instance ToJSON FoundActivationCode where
 
 approveAccountKeyH :: Code.Key ::: Code.Value -> (Handler r) Response
 approveAccountKeyH (key ::: val) = do
+  checkAllowed Nothing
   empty <$ approveAccountKey key val
 
 approveAccountKey :: Code.Key -> Code.Value -> (Handler r) ()
@@ -415,6 +420,7 @@ approveAccountKey key val = do
 
 loginH :: JsonRequest Public.ProviderLogin -> (Handler r) Response
 loginH req = do
+  checkAllowed Nothing
   tok <- login =<< parseJsonBody req
   setProviderCookie tok empty
 
@@ -428,6 +434,7 @@ login l = do
 
 beginPasswordResetH :: JsonRequest Public.PasswordReset -> (Handler r) Response
 beginPasswordResetH req = do
+  checkAllowed Nothing
   setStatus status201 empty <$ (beginPasswordReset =<< parseJsonBody req)
 
 beginPasswordReset :: Public.PasswordReset -> (Handler r) ()
@@ -449,6 +456,7 @@ beginPasswordReset (Public.PasswordReset target) = do
 
 completePasswordResetH :: JsonRequest Public.CompletePasswordReset -> (Handler r) Response
 completePasswordResetH req = do
+  checkAllowed Nothing
   empty <$ (completePasswordReset =<< parseJsonBody req)
 
 completePasswordReset :: Public.CompletePasswordReset -> (Handler r) ()
@@ -469,6 +477,7 @@ completePasswordReset (Public.CompletePasswordReset key val newpwd) = do
 
 getAccountH :: ProviderId -> (Handler r) Response
 getAccountH pid = do
+  checkAllowed Nothing
   getAccount pid <&> \case
     Just p -> json p
     Nothing -> setStatus status404 empty
@@ -478,6 +487,7 @@ getAccount = wrapClientE . DB.lookupAccount
 
 updateAccountProfileH :: ProviderId ::: JsonRequest Public.UpdateProvider -> (Handler r) Response
 updateAccountProfileH (pid ::: req) = do
+  checkAllowed Nothing
   empty <$ (updateAccountProfile pid =<< parseJsonBody req)
 
 updateAccountProfile :: ProviderId -> Public.UpdateProvider -> (Handler r) ()
@@ -492,6 +502,7 @@ updateAccountProfile pid upd = do
 
 updateAccountEmailH :: ProviderId ::: JsonRequest Public.EmailUpdate -> (Handler r) Response
 updateAccountEmailH (pid ::: req) = do
+  checkAllowed Nothing
   setStatus status202 empty <$ (updateAccountEmail pid =<< parseJsonBody req)
 
 updateAccountEmail :: ProviderId -> Public.EmailUpdate -> (Handler r) ()
@@ -514,6 +525,7 @@ updateAccountEmail pid (Public.EmailUpdate new) = do
 
 updateAccountPasswordH :: ProviderId ::: JsonRequest Public.PasswordChange -> (Handler r) Response
 updateAccountPasswordH (pid ::: req) = do
+  checkAllowed Nothing
   empty <$ (updateAccountPassword pid =<< parseJsonBody req)
 
 updateAccountPassword :: ProviderId -> Public.PasswordChange -> (Handler r) ()
@@ -527,6 +539,7 @@ updateAccountPassword pid upd = do
 
 addServiceH :: ProviderId ::: JsonRequest Public.NewService -> (Handler r) Response
 addServiceH (pid ::: req) = do
+  checkAllowed Nothing
   setStatus status201 . json <$> (addService pid =<< parseJsonBody req)
 
 addService :: ProviderId -> Public.NewService -> (Handler r) Public.NewServiceResponse
@@ -546,13 +559,16 @@ addService pid new = do
   return $ Public.NewServiceResponse sid rstoken
 
 listServicesH :: ProviderId -> (Handler r) Response
-listServicesH pid = json <$> listServices pid
+listServicesH pid = do
+  checkAllowed Nothing
+  json <$> listServices pid
 
 listServices :: ProviderId -> (Handler r) [Public.Service]
 listServices = wrapClientE . DB.listServices
 
 getServiceH :: ProviderId ::: ServiceId -> (Handler r) Response
 getServiceH (pid ::: sid) = do
+  checkAllowed Nothing
   json <$> getService pid sid
 
 getService :: ProviderId -> ServiceId -> (Handler r) Public.Service
@@ -561,6 +577,7 @@ getService pid sid =
 
 updateServiceH :: ProviderId ::: ServiceId ::: JsonRequest Public.UpdateService -> (Handler r) Response
 updateServiceH (pid ::: sid ::: req) = do
+  checkAllowed Nothing
   empty <$ (updateService pid sid =<< parseJsonBody req)
 
 updateService :: ProviderId -> ServiceId -> Public.UpdateService -> (Handler r) ()
@@ -593,6 +610,7 @@ updateService pid sid upd = do
 
 updateServiceConnH :: ProviderId ::: ServiceId ::: JsonRequest Public.UpdateServiceConn -> (Handler r) Response
 updateServiceConnH (pid ::: sid ::: req) = do
+  checkAllowed Nothing
   empty <$ (updateServiceConn pid sid =<< parseJsonBody req)
 
 updateServiceConn :: ProviderId -> ServiceId -> Public.UpdateServiceConn -> (Handler r) ()
@@ -638,6 +656,7 @@ updateServiceConn pid sid upd = do
 -- delete the service. See 'finishDeleteService'.
 deleteServiceH :: ProviderId ::: ServiceId ::: JsonRequest Public.DeleteService -> (Handler r) Response
 deleteServiceH (pid ::: sid ::: req) = do
+  checkAllowed Nothing
   setStatus status202 empty <$ (deleteService pid sid =<< parseJsonBody req)
 
 -- | The endpoint that is called to delete a service.
@@ -676,6 +695,7 @@ finishDeleteService pid sid = do
 
 deleteAccountH :: ProviderId ::: JsonRequest Public.DeleteProvider -> (Handler r) Response
 deleteAccountH (pid ::: req) = do
+  checkAllowed Nothing
   empty <$ (deleteAccount pid =<< parseJsonBody req)
 
 deleteAccount :: ProviderId -> Public.DeleteProvider -> (Handler r) ()
@@ -700,6 +720,7 @@ deleteAccount pid del = do
 
 getProviderProfileH :: ProviderId -> (Handler r) Response
 getProviderProfileH pid = do
+  checkAllowed Nothing
   json <$> getProviderProfile pid
 
 getProviderProfile :: ProviderId -> (Handler r) Public.ProviderProfile
@@ -708,6 +729,7 @@ getProviderProfile pid =
 
 listServiceProfilesH :: ProviderId -> (Handler r) Response
 listServiceProfilesH pid = do
+  checkAllowed Nothing
   json <$> listServiceProfiles pid
 
 listServiceProfiles :: ProviderId -> (Handler r) [Public.ServiceProfile]
@@ -715,6 +737,7 @@ listServiceProfiles = wrapClientE . DB.listServiceProfiles
 
 getServiceProfileH :: ProviderId ::: ServiceId -> (Handler r) Response
 getServiceProfileH (pid ::: sid) = do
+  checkAllowed Nothing
   json <$> getServiceProfile pid sid
 
 getServiceProfile :: ProviderId -> ServiceId -> (Handler r) Public.ServiceProfile
@@ -723,6 +746,7 @@ getServiceProfile pid sid =
 
 searchServiceProfilesH :: Maybe (Public.QueryAnyTags 1 3) ::: Maybe Text ::: Range 10 100 Int32 -> (Handler r) Response
 searchServiceProfilesH (qt ::: start ::: size) = do
+  checkAllowed Nothing
   json <$> searchServiceProfiles qt start size
 
 -- TODO: in order to actually make it possible for clients to implement
@@ -742,6 +766,7 @@ searchTeamServiceProfilesH ::
   UserId ::: TeamId ::: Maybe (Range 1 128 Text) ::: Bool ::: Range 10 100 Int32 ->
   (Handler r) Response
 searchTeamServiceProfilesH (uid ::: tid ::: prefix ::: filterDisabled ::: size) = do
+  checkAllowed (Just uid)
   json <$> searchTeamServiceProfiles uid tid prefix filterDisabled size
 
 -- NB: unlike 'searchServiceProfiles', we don't filter by service provider here
@@ -763,7 +788,9 @@ searchTeamServiceProfiles uid tid prefix filterDisabled size = do
   wrapClientE $ DB.paginateServiceWhitelist tid prefix filterDisabled (fromRange size)
 
 getServiceTagListH :: () -> (Handler r) Response
-getServiceTagListH () = json <$> getServiceTagList ()
+getServiceTagListH () = do
+  checkAllowed Nothing
+  json <$> getServiceTagList ()
 
 getServiceTagList :: () -> Monad m => m Public.ServiceTagList
 getServiceTagList () = return (Public.ServiceTagList allTags)
@@ -772,6 +799,7 @@ getServiceTagList () = return (Public.ServiceTagList allTags)
 
 updateServiceWhitelistH :: UserId ::: ConnId ::: TeamId ::: JsonRequest Public.UpdateServiceWhitelist -> (Handler r) Response
 updateServiceWhitelistH (uid ::: con ::: tid ::: req) = do
+  checkAllowed (Just uid)
   resp <- updateServiceWhitelist uid con tid =<< parseJsonBody req
   let status = case resp of
         UpdateServiceWhitelistRespChanged -> status200
@@ -819,6 +847,7 @@ updateServiceWhitelist uid con tid upd = do
 
 addBotH :: UserId ::: ConnId ::: ConvId ::: JsonRequest Public.AddBot -> (Handler r) Response
 addBotH (zuid ::: zcon ::: cid ::: req) = do
+  checkAllowed (Just zuid)
   setStatus status201 . json <$> (addBot zuid zcon cid =<< parseJsonBody req)
 
 addBot :: UserId -> ConnId -> ConvId -> Public.AddBot -> (Handler r) Public.AddBotResponse
@@ -897,6 +926,7 @@ addBot zuid zcon cid add = do
 
 removeBotH :: UserId ::: ConnId ::: ConvId ::: BotId -> (Handler r) Response
 removeBotH (zusr ::: zcon ::: cid ::: bid) = do
+  checkAllowed (Just zusr)
   maybe (setStatus status204 empty) json <$> removeBot zusr zcon cid bid
 
 removeBot :: UserId -> ConnId -> ConvId -> BotId -> (Handler r) (Maybe Public.RemoveBotResponse)
@@ -918,15 +948,19 @@ removeBot zusr zcon cid bid = do
 -- Bot API
 
 botGetSelfH :: BotId -> (Handler r) Response
-botGetSelfH bot = json <$> botGetSelf bot
+botGetSelfH bot = do
+  checkAllowed (Just (botUserId bot))
+  json <$> botGetSelf bot
 
 botGetSelf :: BotId -> (Handler r) Public.UserProfile
 botGetSelf bot = do
+  checkAllowed (Just (botUserId bot))
   p <- lift $ wrapClient $ User.lookupUser NoPendingInvitations (botUserId bot)
   maybe (throwErrorDescriptionType @UserNotFound) (return . (`Public.publicProfile` UserLegalHoldNoConsent)) p
 
 botGetClientH :: BotId -> (Handler r) Response
 botGetClientH bot = do
+  checkAllowed (Just (botUserId bot))
   maybe (throwErrorDescriptionType @ClientNotFound) (pure . json) =<< lift (botGetClient bot)
 
 botGetClient :: BotId -> (AppIO r) (Maybe Public.Client)
@@ -935,6 +969,7 @@ botGetClient bot =
 
 botListPrekeysH :: BotId -> (Handler r) Response
 botListPrekeysH bot = do
+  checkAllowed (Just (botUserId bot))
   json <$> botListPrekeys bot
 
 botListPrekeys :: BotId -> (Handler r) [Public.PrekeyId]
@@ -946,6 +981,7 @@ botListPrekeys bot = do
 
 botUpdatePrekeysH :: BotId ::: JsonRequest Public.UpdateBotPrekeys -> (Handler r) Response
 botUpdatePrekeysH (bot ::: req) = do
+  checkAllowed (Just (botUserId bot))
   empty <$ (botUpdatePrekeys bot =<< parseJsonBody req)
 
 botUpdatePrekeys :: BotId -> Public.UpdateBotPrekeys -> (Handler r) ()
@@ -959,6 +995,7 @@ botUpdatePrekeys bot upd = do
 
 botClaimUsersPrekeysH :: JsonRequest Public.UserClients -> (Handler r) Response
 botClaimUsersPrekeysH req = do
+  checkAllowed Nothing
   json <$> (botClaimUsersPrekeys =<< parseJsonBody req)
 
 botClaimUsersPrekeys :: Public.UserClients -> (Handler r) Public.UserClientPrekeyMap
@@ -970,6 +1007,7 @@ botClaimUsersPrekeys body = do
 
 botListUserProfilesH :: List UserId -> (Handler r) Response
 botListUserProfilesH uids = do
+  checkAllowed Nothing -- should we check all user ids?
   json <$> botListUserProfiles uids
 
 botListUserProfiles :: List UserId -> (Handler r) [Public.BotUserView]
@@ -979,6 +1017,7 @@ botListUserProfiles uids = do
 
 botGetUserClientsH :: UserId -> (Handler r) Response
 botGetUserClientsH uid = do
+  checkAllowed (Just uid)
   json <$> lift (botGetUserClients uid)
 
 botGetUserClients :: UserId -> (AppIO r) [Public.PubClient]
@@ -989,10 +1028,12 @@ botGetUserClients uid =
 
 botDeleteSelfH :: BotId ::: ConvId -> (Handler r) Response
 botDeleteSelfH (bid ::: cid) = do
+  checkAllowed (Just (botUserId bid))
   empty <$ botDeleteSelf bid cid
 
 botDeleteSelf :: BotId -> ConvId -> (Handler r) ()
 botDeleteSelf bid cid = do
+  checkAllowed (Just (botUserId bid))
   bot <- lift . wrapClient $ User.lookupUser NoPendingInvitations (botUserId bid)
   _ <- maybeInvalidBot (userService =<< bot)
   _ <- lift $ deleteBot (botUserId bid) Nothing bid cid
@@ -1000,6 +1041,18 @@ botDeleteSelf bid cid = do
 
 --------------------------------------------------------------------------------
 -- Utilities
+
+checkAllowed :: Maybe UserId -> (Handler r) ()
+checkAllowed = \case
+  Just userId ->
+    whenM (isPasswordChallengeEnabled (Just userId)) $ throwStd accessDenied
+  Nothing ->
+    whenM (isPasswordChallengeEnabled Nothing) $ throwStd accessDenied
+
+isPasswordChallengeEnabled :: Maybe UserId -> (Handler r) Bool
+isPasswordChallengeEnabled mbUserId = do
+  status <- lift $ RPC.getTeamFeatureStatusSndFactorPasswordChallenge mbUserId
+  pure $ Feature.tfwoStatus status == Feature.TeamFeatureEnabled
 
 minRsaKeySize :: Int
 minRsaKeySize = 256 -- Bytes (= 2048 bits)
@@ -1140,3 +1193,6 @@ serviceError RPC.ServiceBotConflict = tooManyBots
 
 randServiceToken :: MonadIO m => m Public.ServiceToken
 randServiceToken = ServiceToken . Ascii.encodeBase64Url <$> liftIO (randBytes 18)
+
+accessDenied :: Wai.Error
+accessDenied = Wai.mkError status403 "access-denied" "Access denied."

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -158,6 +158,13 @@ type InternalAPI =
                       :> ReqBody '[Servant.JSON] UpsertOne2OneConversationRequest
                       :> Post '[Servant.JSON] UpsertOne2OneConversationResponse
                   )
+           :<|> Named
+                  "feature-config-snd-factor-password-challenge"
+                  ( Summary "Get the server wide feature config for the 2nd factor password challenge feature."
+                      :> "feature-configs"
+                      :> KnownTeamFeatureNameSymbol 'TeamFeatureSndFactorPasswordChallenge
+                      :> Get '[Servant.JSON] TeamFeatureStatusNoConfig
+                  )
            :<|> IFeatureAPI
        )
 
@@ -194,6 +201,7 @@ internalAPI =
     :<|> Named @"delete-user" rmUser
     :<|> Named @"connect" Create.createConnectConversation
     :<|> Named @"upsert-one2one" iUpsertOne2OneConversation
+    :<|> Named @"feature-config-snd-factor-password-challenge" (TeamFeatureStatusNoConfig . tfwoapsStatus <$> getSndFactorPasswordChallengeInternal (Left Nothing))
     :<|> featureAPI
 
 featureAPI :: ServerT IFeatureAPI (Sem GalleyEffects)

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -208,7 +208,11 @@ internalAPI =
     :<|> Named @"delete-user" rmUser
     :<|> Named @"connect" Create.createConnectConversation
     :<|> Named @"upsert-one2one" iUpsertOne2OneConversation
-    :<|> Named @"feature-config-snd-factor-password-challenge" (\mbUserId -> TeamFeatureStatusNoConfig . tfwoapsStatus <$> getSndFactorPasswordChallengeInternal (Left mbUserId))
+    :<|> Named @"feature-config-snd-factor-password-challenge"
+      ( \case
+          Just uid -> TeamFeatureStatusNoConfig . tfwoapsStatus <$> getFeatureConfigNoAuth @'WithLockStatus @'TeamFeatureSndFactorPasswordChallenge getSndFactorPasswordChallengeInternal uid
+          Nothing -> TeamFeatureStatusNoConfig . tfwoapsStatus <$> getSndFactorPasswordChallengeInternal (Left Nothing)
+      )
     :<|> featureAPI
 
 featureAPI :: ServerT IFeatureAPI (Sem GalleyEffects)

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -163,6 +163,13 @@ type InternalAPI =
                   ( Summary "Get the server wide feature config for the 2nd factor password challenge feature."
                       :> "feature-configs"
                       :> KnownTeamFeatureNameSymbol 'TeamFeatureSndFactorPasswordChallenge
+                      :> QueryParam'
+                           [ Optional,
+                             Strict,
+                             Description "Optional user id"
+                           ]
+                           "user_id"
+                           UserId
                       :> Get '[Servant.JSON] TeamFeatureStatusNoConfig
                   )
            :<|> IFeatureAPI
@@ -201,7 +208,7 @@ internalAPI =
     :<|> Named @"delete-user" rmUser
     :<|> Named @"connect" Create.createConnectConversation
     :<|> Named @"upsert-one2one" iUpsertOne2OneConversation
-    :<|> Named @"feature-config-snd-factor-password-challenge" (TeamFeatureStatusNoConfig . tfwoapsStatus <$> getSndFactorPasswordChallengeInternal (Left Nothing))
+    :<|> Named @"feature-config-snd-factor-password-challenge" (\mbUserId -> TeamFeatureStatusNoConfig . tfwoapsStatus <$> getSndFactorPasswordChallengeInternal (Left mbUserId))
     :<|> featureAPI
 
 featureAPI :: ServerT IFeatureAPI (Sem GalleyEffects)

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -160,7 +160,11 @@ type InternalAPI =
                   )
            :<|> Named
                   "feature-config-snd-factor-password-challenge"
-                  ( Summary "Get the server wide feature config for the 2nd factor password challenge feature."
+                  -- FUTUREWORK: Introduce `/i/feature-configs` and drop this one again.  The internal end-poins has the
+                  -- same handler as the public one, plus optional user id in the query.  Maybe require `DoAuth` to disable
+                  -- access control only on the internal end-point, not on the public one.  (This may also be a good oppportunity
+                  -- to make `AllFeatureConfigs` more type-safe.)
+                  ( Summary "Get feature config for the 2nd factor password challenge feature (for user/team; if n/a fall back to site config)."
                       :> "feature-configs"
                       :> KnownTeamFeatureNameSymbol 'TeamFeatureSndFactorPasswordChallenge
                       :> QueryParam'

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -378,7 +378,7 @@ getBotConversationH ::
   BotId ::: ConvId ::: JSON ->
   Sem r Response
 getBotConversationH arg@(zbot ::: _ ::: _) =
-  Features.continueOnSndFactorPasswordChallengeDisabledOrAccessDenied (botUserId zbot) (Query.getBotConversationH arg)
+  Features.guardSecondFactorDisabled (botUserId zbot) (Query.getBotConversationH arg)
 
 apiDocs :: Routes ApiBuilder (Sem r) ()
 apiDocs =


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1375

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.