### PR TITLE
SQSERVICES-1385-non-group-admins-should-not-be-able-to-create-guest-links

### DIFF
--- a/changelog.d/3-bug-fixes/pr-2211
+++ b/changelog.d/3-bug-fixes/pr-2211
@@ -1,1 +1,1 @@
-Ensure that only conversation admins can create invite links.
+Ensure that only conversation admins can create invite links.  (Until now we have relied on clients to enforce this.)

--- a/changelog.d/3-bug-fixes/pr-2211
+++ b/changelog.d/3-bug-fixes/pr-2211
@@ -1,0 +1,1 @@
+Ensure that only conversation admins can create invite links.

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -643,7 +643,7 @@ getCode lusr cnv = do
     E.getConversation cnv >>= note ConvNotFound
   Query.ensureGuestLinksEnabled (convTeam conv)
   ensureAccess conv CodeAccess
-  ensureConvAdmin (Data.convLocalMembers conv) (tUnqualified lusr)
+  ensureConvMember (Data.convLocalMembers conv) (tUnqualified lusr)
   key <- E.makeKey cnv
   c <- E.getCode key ReusableCode >>= note CodeNotFound
   returnCode c
@@ -1549,3 +1549,7 @@ ensureConvAdmin users uid =
   case find ((== uid) . lmId) users of
     Nothing -> throw ConvNotFound
     Just lm -> unless (lmConvRoleName lm == roleNameWireAdmin) $ throw ConvAccessDenied
+
+ensureConvMember :: Member (Error ConversationError) r => [LocalMember] -> UserId -> Sem r ()
+ensureConvMember users usr =
+  unless (usr `isMember` users) $ throw ConvNotFound

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -554,7 +554,7 @@ addCode ::
 addCode lusr zcon lcnv = do
   conv <- E.getConversation (tUnqualified lcnv) >>= note ConvNotFound
   Query.ensureGuestLinksEnabled (convTeam conv)
-  ensureConvMember (Data.convLocalMembers conv) (tUnqualified lusr)
+  ensureConvAdmin (Data.convLocalMembers conv) (tUnqualified lusr)
   ensureAccess conv CodeAccess
   ensureGuestsOrNonTeamMembersAllowed conv
   let (bots, users) = localBotsAndUsers $ Data.convLocalMembers conv
@@ -616,7 +616,7 @@ rmCode ::
 rmCode lusr zcon lcnv = do
   conv <-
     E.getConversation (tUnqualified lcnv) >>= note ConvNotFound
-  ensureConvMember (Data.convLocalMembers conv) (tUnqualified lusr)
+  ensureConvAdmin (Data.convLocalMembers conv) (tUnqualified lusr)
   ensureAccess conv CodeAccess
   let (bots, users) = localBotsAndUsers $ Data.convLocalMembers conv
   key <- E.makeKey (tUnqualified lcnv)
@@ -643,7 +643,7 @@ getCode lusr cnv = do
     E.getConversation cnv >>= note ConvNotFound
   Query.ensureGuestLinksEnabled (convTeam conv)
   ensureAccess conv CodeAccess
-  ensureConvMember (Data.convLocalMembers conv) (tUnqualified lusr)
+  ensureConvAdmin (Data.convLocalMembers conv) (tUnqualified lusr)
   key <- E.makeKey cnv
   c <- E.getCode key ReusableCode >>= note CodeNotFound
   returnCode c
@@ -1544,6 +1544,8 @@ rmBot lusr zcon b = do
 -------------------------------------------------------------------------------
 -- Helpers
 
-ensureConvMember :: Member (Error ConversationError) r => [LocalMember] -> UserId -> Sem r ()
-ensureConvMember users usr =
-  unless (usr `isMember` users) $ throw ConvNotFound
+ensureConvAdmin :: Member (Error ConversationError) r => [LocalMember] -> UserId -> Sem r ()
+ensureConvAdmin users uid =
+  case find ((== uid) . lmId) users of
+    Nothing -> throw ConvNotFound
+    Just lm -> unless (lmConvRoleName lm == roleNameWireAdmin) $ throw ConvAccessDenied

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1358,6 +1358,8 @@ postJoinCodeConvOk = do
     postJoinCodeConv bob incorrectCode !!! const 404 === statusCode
     -- correct code works
     postJoinCodeConv bob payload !!! const 200 === statusCode
+    -- non-admin cannot create invite link
+    postConvCode bob conv !!! const 403 === statusCode
     -- test no-op
     postJoinCodeConv bob payload !!! const 204 === statusCode
     -- eve cannot join
@@ -1370,6 +1372,8 @@ postJoinCodeConvOk = do
     let nonActivatedAccess = ConversationAccessData (Set.singleton CodeAccess) accessRolesWithGuests
     putAccessUpdate alice conv nonActivatedAccess !!! const 200 === statusCode
     postJoinCodeConv eve payload !!! const 200 === statusCode
+    -- guest cannot create invite link
+    postConvCode eve conv !!! const 403 === statusCode
     -- after removing CodeAccess, no further people can join
     let noCodeAccess = ConversationAccessData (Set.singleton InviteAccess) accessRoles
     putAccessUpdate alice conv noCodeAccess !!! const 200 === statusCode


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1385

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.