### PR TITLE
Install libssl-dev for core-crypto in ubuntu deps

### DIFF
--- a/build/ubuntu/Dockerfile.deps
+++ b/build/ubuntu/Dockerfile.deps
@@ -12,6 +12,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 # compile core-crypto cli tool
 RUN cd /tmp && \
+  apt-get install -y libssl-dev && \
   git clone -b cli https://github.com/wireapp/core-crypto && \
   cd core-crypto/cli && \
   cargo build --release


### PR DESCRIPTION
The libssl-dev library is now needed in order to build `core-crypto` in the deps image.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
