### PR TITLE
Spar debugging

### DIFF
--- a/changelog.d/5-internal/pr-2214
+++ b/changelog.d/5-internal/pr-2214
@@ -1,0 +1,1 @@
+Spar debugging; better internal combinators

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -62,13 +62,13 @@ import qualified System.Logger.Class as Log
 import Web.Cookie
 import Wire.API.User
 import Wire.API.User.RichInfo as RichInfo
-import Wire.API.User.Scim (ValidExternalId (..), runValidExternalId)
+import Wire.API.User.Scim (ValidExternalId (..), runValidExternalIdEither)
 
 ----------------------------------------------------------------------
 
 -- | FUTUREWORK: this is redundantly defined in "Spar.Intra.BrigApp".
 veidToUserSSOId :: ValidExternalId -> UserSSOId
-veidToUserSSOId = runValidExternalId UserSSOId (UserScimExternalId . fromEmail)
+veidToUserSSOId = runValidExternalIdEither UserSSOId (UserScimExternalId . fromEmail)
 
 -- | Similar to 'Network.Wire.Client.API.Auth.tokenResponse', but easier: we just need to set the
 -- cookie in the response, and the redirect will make the client negotiate a fresh auth token.

--- a/services/spar/src/Spar/Intra/BrigApp.hs
+++ b/services/spar/src/Spar/Intra/BrigApp.hs
@@ -63,13 +63,13 @@ import qualified Spar.Sem.BrigAccess as BrigAccess
 import Spar.Sem.GalleyAccess (GalleyAccess)
 import qualified Spar.Sem.GalleyAccess as GalleyAccess
 import Wire.API.User
-import Wire.API.User.Scim (ValidExternalId (..), runValidExternalId)
+import Wire.API.User.Scim (ValidExternalId (..), runValidExternalIdEither)
 
 ----------------------------------------------------------------------
 
 -- | FUTUREWORK: this is redundantly defined in "Spar.Intra.Brig"
 veidToUserSSOId :: ValidExternalId -> UserSSOId
-veidToUserSSOId = runValidExternalId UserSSOId (UserScimExternalId . fromEmail)
+veidToUserSSOId = runValidExternalIdEither UserSSOId (UserScimExternalId . fromEmail)
 
 veidFromUserSSOId :: MonadError String m => UserSSOId -> m ValidExternalId
 veidFromUserSSOId = \case
@@ -112,12 +112,12 @@ veidFromBrigUser usr mIssuer = case (userSSOId usr, userEmail usr, mIssuer) of
 mkUserName :: Maybe Text -> ValidExternalId -> Either String Name
 mkUserName (Just n) = const $ mkName n
 mkUserName Nothing =
-  runValidExternalId
+  runValidExternalIdEither
     (\uref -> mkName (CI.original . SAML.unsafeShowNameID $ uref ^. SAML.uidSubject))
     (\email -> mkName (fromEmail email))
 
 renderValidExternalId :: ValidExternalId -> Maybe Text
-renderValidExternalId = runValidExternalId urefToExternalId (Just . fromEmail)
+renderValidExternalId = runValidExternalIdEither urefToExternalId (Just . fromEmail)
 
 ----------------------------------------------------------------------
 

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -187,12 +187,7 @@ instance
 
   deleteUser :: ScimTokenInfo -> UserId -> Scim.ScimHandler (Sem r) ()
   deleteUser tokeninfo uid =
-    logScim
-      ( logFunction "Spar.Scim.User.deleteUser"
-          . logUser uid
-          . logTokenInfo tokeninfo
-      )
-      $ deleteScimUser tokeninfo uid
+    deleteScimUser tokeninfo uid
 
 ----------------------------------------------------------------------------
 -- User creation and validation

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -781,11 +781,7 @@ assertExternalIdInAllowedValues allowedValues errmsg tid veid = do
   isGood <-
     lift $
       ST.runValidExternalIdBoth
-        ( \ma mb -> do
-            a <- ma
-            b <- mb
-            pure (a && b)
-        )
+        (\ma mb -> (&&) <$> ma <*> mb)
         ( \uref ->
             getUserIdByUref (Just tid) uref <&> \case
               (Spar.App.GetUserFound uid) -> Just uid `elem` allowedValues

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -505,7 +505,7 @@ createValidScimUserSpar ::
 createValidScimUserSpar stiTeam uid storedUser veid = lift $ do
   ScimUserTimesStore.write storedUser
   ST.runValidExternalId
-    ((`SAMLUserStore.insert` uid))
+    (`SAMLUserStore.insert` uid)
     (\email -> ScimExternalIdStore.insert stiTeam email uid)
     veid
 
@@ -555,11 +555,11 @@ updateValidScimUser tokinfo@ScimTokenInfo {stiTeam} uid newValidScimUser =
           newScimStoredUser :: Scim.StoredUser ST.SparTag <-
             updScimStoredUser (synthesizeScimUser newValidScimUser) oldScimStoredUser
 
-          case ( oldValidScimUser ^. ST.vsuExternalId,
-                 newValidScimUser ^. ST.vsuExternalId
-               ) of
-            (old, new) | old /= new -> updateVsuUref stiTeam uid old new
-            _ -> pure ()
+          do
+            let old = oldValidScimUser ^. ST.vsuExternalId
+                new = newValidScimUser ^. ST.vsuExternalId
+            when (old /= new) $ do
+              updateVsuUref stiTeam uid old new
 
           when (newValidScimUser ^. ST.vsuName /= oldValidScimUser ^. ST.vsuName) $ do
             BrigAccess.setName uid (newValidScimUser ^. ST.vsuName)

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -292,7 +292,7 @@ testDeleteTeam = it "cleans up all the right tables after deletion" $ do
     mbUser1 <- case veidFromUserSSOId ssoid1 of
       Right veid ->
         runSpar $
-          runValidExternalId
+          runValidExternalIdEither
             SAMLUserStore.get
             undefined -- could be @Data.lookupScimExternalId@, but we don't hit that path.
             veid
@@ -302,7 +302,7 @@ testDeleteTeam = it "cleans up all the right tables after deletion" $ do
     mbUser2 <- case veidFromUserSSOId ssoid2 of
       Right veid ->
         runSpar $
-          runValidExternalId
+          runValidExternalIdEither
             SAMLUserStore.get
             undefined
             veid

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -36,6 +36,7 @@ import qualified Control.Exception
 import Control.Lens
 import Control.Monad.Except (MonadError (throwError))
 import Control.Monad.Random (randomRIO)
+import Control.Monad.Random.Class (getRandomR)
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Maybe
 import Control.Retry (exponentialBackoff, limitRetries, recovering)
@@ -237,26 +238,30 @@ specImportToScimFromInvitation =
       tok :: ScimToken <- do
         registerScimToken teamid ((^. SAML.idpId) <$> mbidp)
 
-      storedUserGot <- findUserByEmail tok email
-      when changeHandle $ do
-        (usr' :: Scim.User.User SparTag, uid :: UserId) <- do
-          (usr_, _) <- randomScimUserWithEmail
-          pure
-            ( (Scim.value . Scim.thing $ storedUserGot) {Scim.User.userName = Scim.User.userName usr_},
-              Scim.id . Scim.thing $ storedUserGot
-            )
-        void $ putStoredUser tok uid usr'
-      getStoredUser tok userid
+      userName {- handle -} :: Text <- do
+        if changeHandle
+          then do
+            suffix <- cs <$> replicateM 7 (getRandomR ('0', '9'))
+            pure ("scimuser_" <> suffix)
+          else do
+            Just brigUser <- runSpar (BrigAccess.getAccount NoPendingInvitations userid)
+            pure . fromHandle . fromJust . userHandle . accountUser $ brigUser
+      let externalId = fromEmail email
+          displayName = userName
 
-    getStoredUser :: ScimToken -> UserId -> TestSpar (Scim.UserC.StoredUser SparTag)
-    getStoredUser tok uid = do
-      resp <- aFewTimes (getUser_ (Just tok) uid =<< view teSpar) ((== 200) . statusCode) <!! const 200 === statusCode
-      pure $ responseJsonUnsafe resp
+      usr' :: Scim.User.User SparTag <- do
+        pure $
+          (Scim.User.empty userSchemas userName (ScimUserExtra mempty))
+            { Scim.User.displayName = Just displayName,
+              Scim.User.externalId = Just externalId
+            }
 
-    putStoredUser :: ScimToken -> UserId -> Scim.User.User SparTag -> TestSpar (Scim.UserC.StoredUser SparTag)
-    putStoredUser tok uid usr' = do
+      postStoredUser tok usr'
+
+    postStoredUser :: ScimToken -> Scim.User.User SparTag -> TestSpar (Scim.UserC.StoredUser SparTag)
+    postStoredUser tok usr' = do
       resp <-
-        aFewTimes (updateUser_ (Just tok) (Just uid) usr' =<< view teSpar) ((== 200) . statusCode)
+        aFewTimes (createUser_ (Just tok) usr' =<< view teSpar) ((== 200) . statusCode)
           <!! const 200 === statusCode
       pure $ responseJsonUnsafe resp
 

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -138,7 +138,7 @@ import qualified Bilge
 import Bilge.Assert (Assertions, (!!!), (<!!), (===))
 import qualified Brig.Types.Activation as Brig
 import Brig.Types.Common (UserIdentity (..), UserSSOId (..))
-import Brig.Types.User (User (..), selfUser, userIdentity)
+import Brig.Types.User (Email, User (..), selfUser, userIdentity)
 import qualified Brig.Types.User as Brig
 import qualified Brig.Types.User.Auth as Brig
 import Cassandra as Cas
@@ -393,9 +393,9 @@ inviteAndRegisterUser ::
   BrigReq ->
   UserId ->
   TeamId ->
+  Email ->
   m User
-inviteAndRegisterUser brig u tid = do
-  inviteeEmail <- randomEmail
+inviteAndRegisterUser brig u tid inviteeEmail = do
   let invite = stdInvitationRequest inviteeEmail
   inv <- responseJsonError =<< postInvitation tid u invite
   Just inviteeCode <- getInvitationCode tid (TeamInvitation.inInvitation inv)

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -211,7 +211,7 @@ import qualified Wire.API.User as User
 import Wire.API.User.Identity (mkSampleUref)
 import Wire.API.User.IdentityProvider
 import Wire.API.User.Saml
-import Wire.API.User.Scim (runValidExternalId)
+import Wire.API.User.Scim (runValidExternalIdEither)
 
 -- | Call 'mkEnv' with options from config files.
 mkEnvFromOptions :: IO TestEnv
@@ -1218,7 +1218,7 @@ ssoToUidSpar :: (HasCallStack, MonadIO m, MonadReader TestEnv m) => TeamId -> Br
 ssoToUidSpar tid ssoid = do
   veid <- either (error . ("could not parse brig sso_id: " <>)) pure $ Intra.veidFromUserSSOId ssoid
   runSpar $
-    runValidExternalId
+    runValidExternalIdEither
       SAMLUserStore.get
       (ScimExternalIdStore.lookup tid)
       veid

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -567,7 +567,7 @@ instance IsUser ValidScimUser where
   maybeName = Just (Just . view vsuName)
   maybeTenant = Just (^? (vsuExternalId . veidUref . SAML.uidTenant))
   maybeSubject = Just (^? (vsuExternalId . veidUref . SAML.uidSubject))
-  maybeScimExternalId = Just (runValidExternalId Intra.urefToExternalId (Just . fromEmail) . view vsuExternalId)
+  maybeScimExternalId = Just (runValidExternalIdEither Intra.urefToExternalId (Just . fromEmail) . view vsuExternalId)
 
 instance IsUser (WrappedScimStoredUser SparTag) where
   maybeUserId = Just $ scimUserId . fromWrappedScimStoredUser
@@ -606,7 +606,7 @@ instance IsUser User where
     Intra.veidFromBrigUser usr Nothing
       & either
         (const Nothing)
-        (runValidExternalId Intra.urefToExternalId (Just . fromEmail))
+        (runValidExternalIdEither Intra.urefToExternalId (Just . fromEmail))
 
 -- | For all properties that are present in both @u1@ and @u2@, check that they match.
 --


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1376

- clarify semantics of internal functions
- crank up logging of SCIM CRUD API
- remove redundant log entries
- improve test coverage

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
