### PR TITLE
[FS-207] MLS Messages Endpoint

### DIFF
--- a/changelog.d/0-release-notes/mls-message-endpoint
+++ b/changelog.d/0-release-notes/mls-message-endpoint
@@ -1,0 +1,1 @@
+Note for wire.com operators: deploy nginz

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -396,6 +396,9 @@ nginx_conf:
     - path: /mls/welcome
       envs:
       - all
+    - path: /mls/messages
+      envs:
+      - all
     gundeck:
     - path: /push
       envs:

--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -409,6 +409,9 @@ http {
     location /mls/welcome {
       include common_response_with_zauth.conf;
       proxy_pass http://galley;
+    location /mls/messages {
+      include common_response_with_zauth.conf;
+      proxy_pass http://galley;
     }
 
     # Gundeck Endpoints

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -31,7 +31,14 @@ import Wire.API.Routes.Public.Galley
 import Wire.API.Team.Feature
 
 servantSitemap :: API ServantAPI GalleyEffects
-servantSitemap = conversations <@> teamConversations <@> messaging <@> bot <@> team <@> features <@> mls
+servantSitemap =
+  conversations
+    <@> teamConversations
+    <@> messaging
+    <@> bot
+    <@> team
+    <@> features
+    <@> mls
   where
     conversations =
       mkNamedAPI @"get-unqualified-conversation" getUnqualifiedConversation
@@ -95,10 +102,6 @@ servantSitemap = conversations <@> teamConversations <@> messaging <@> bot <@> t
         <@> mkNamedAPI @"get-teams" getManyTeams
         <@> mkNamedAPI @"get-team" getTeamH
         <@> mkNamedAPI @"delete-team" deleteTeam
-
-    mls =
-      mkNamedAPI @"mls-welcome-message" postMLSWelcome
-        <@> mkNamedAPI @"mls-message" postMLSMessage
 
     features =
       mkNamedAPI @'("get", 'TeamFeatureSSO)
@@ -265,3 +268,8 @@ servantSitemap = conversations <@> teamConversations <@> messaging <@> bot <@> t
           ( getFeatureConfig @'WithLockStatus @'TeamFeatureSndFactorPasswordChallenge
               getSndFactorPasswordChallengeInternal
           )
+
+    mls :: API MLSAPI GalleyEffects
+    mls =
+      mkNamedAPI @"mls-welcome-message" postMLSWelcome
+        <@> mkNamedAPI @"mls-message" postMLSMessage


### PR DESCRIPTION
The PR introduces the `POST /mls/messages` endpoint and a stub handler.

This is tracked via https://wearezeta.atlassian.net/browse/FS-207.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
