### PR TITLE
SQSERVICES-609-backend-disallow-guests-and-services-on-conversation-doesnt-revoke-invite-link

### DIFF
--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1587,7 +1587,7 @@ testAccessUpdateGuestRemoved = do
 
 testTeamMemberCantJoinViaGuestLinkIfAccessRoleRemoved :: TestM ()
 testTeamMemberCantJoinViaGuestLinkIfAccessRoleRemoved = do
-  -- given alice, bob, cahrlie and dee are in a team
+  -- given alice, bob, charlie and dee are in a team
   (alice, tid, [bob, charlie, dee]) <- createBindingTeamWithNMembers 3
 
   -- and given alice and bob are in a team conversation and alice created a guest link


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-609

This PR only contains an integration test that verifies that the backend behavior is correct. The actual fix for the bug needs to be done in the frontend.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.