### PR TITLE
Revert "sftd chart: upgrade to 3.1.3 (#2227)"

### DIFF
--- a/changelog.d/2-features/FS-513-restund-dtls-revert-sft-bump
+++ b/changelog.d/2-features/FS-513-restund-dtls-revert-sft-bump
@@ -1,0 +1,1 @@
+Revert temporary sftd bump

--- a/charts/sftd/Chart.yaml
+++ b/charts/sftd/Chart.yaml
@@ -11,4 +11,4 @@ version: 0.0.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.1.3
+appVersion: 2.1.19


### PR DESCRIPTION
Reverts temporary bump of sftd to 3.1.3

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):