### PR TITLE
Pin direnv version in nix-hls.sh script

### DIFF
--- a/changelog.d/5-internal/nix-hls-pin-direnv
+++ b/changelog.d/5-internal/nix-hls-pin-direnv
@@ -1,0 +1,1 @@
+Pin direnv version in nix-hls.sh script

--- a/hack/bin/nix-hls.sh
+++ b/hack/bin/nix-hls.sh
@@ -6,7 +6,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
 env=$(nix-build --no-out-link "$TOP_LEVEL/direnv.nix")
-eval "$(direnv stdlib)"
+direnv="$(nix-build -A direnv "$TOP_LEVEL/nix")/bin/direnv"
+eval "$("$direnv" stdlib)"
+
 load_prefix "$env"
 
 haskell-language-server-wrapper "$@"


### PR DESCRIPTION
This fixes a problem where an older version of direnv would make the script crash

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):