### PR TITLE
[Polysemy] Remove MonadUnliftIO for Brig's AppT

### DIFF
--- a/changelog.d/5-internal/brig-no-unliftio
+++ b/changelog.d/5-internal/brig-no-unliftio
@@ -1,0 +1,1 @@
+Remove the MonadUnliftIO instance for the app monad in Brig

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -152,7 +152,7 @@ addClient u con ip new = do
     for_ old $ execDelete u con
     Intra.newClient u (clientId clt)
     Intra.onClientEvent u con (ClientAdded u clt)
-    when (clientType clt == LegalHoldClientType) $ Intra.onUserEvent u con (UserLegalHoldEnabled u)
+    when (clientType clt == LegalHoldClientType) $ wrapHttpClient $ Intra.onUserEvent u con (UserLegalHoldEnabled u)
     when (count > 1) $
       for_ (userEmail usr) $
         \email ->
@@ -394,7 +394,7 @@ pubClient c =
 
 legalHoldClientRequested :: UserId -> LegalHoldClientRequest -> (AppIO r) ()
 legalHoldClientRequested targetUser (LegalHoldClientRequest _requester lastPrekey') =
-  Intra.onUserEvent targetUser Nothing lhClientEvent
+  wrapHttpClient $ Intra.onUserEvent targetUser Nothing lhClientEvent
   where
     clientId :: ClientId
     clientId = clientIdFromPrekey $ unpackLastPrekey lastPrekey'
@@ -410,4 +410,4 @@ removeLegalHoldClient uid = do
   let legalHoldClients = filter ((== LegalHoldClientType) . clientType) clients
   -- maybe log if this isn't the case
   forM_ legalHoldClients (execDelete uid Nothing)
-  Intra.onUserEvent uid Nothing (UserLegalHoldDisabled uid)
+  wrapHttpClient $ Intra.onUserEvent uid Nothing (UserLegalHoldDisabled uid)

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -261,6 +261,8 @@ claimMultiPrekeyBundles protectee quc = do
       qUntagged . qualifyAs luc
         <$> claimLocalMultiPrekeyBundles protectee (tUnqualified luc)
 
+-- TODO: getUserKeys doesn't actually need MonadUnliftIO, it can be MonadClient
+-- + MonadReader or so
 claimLocalMultiPrekeyBundles :: LegalholdProtectee -> UserClients -> ExceptT ClientError (AppIO r) UserClientPrekeyMap
 claimLocalMultiPrekeyBundles protectee userClients = do
   guardLegalhold protectee userClients

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -185,8 +185,8 @@ checkLegalholdPolicyConflict uid1 uid2 = do
         -- this, users are guaranteed to exist when called from 'createConnectionToLocalUser'.
         maybe (throwM (errorToWai @'E.UserNotFound)) return
 
-  status1 <- lift (getLegalHoldStatus uid1) >>= catchProfileNotFound
-  status2 <- lift (getLegalHoldStatus uid2) >>= catchProfileNotFound
+  status1 <- lift (wrapHttpClient $ getLegalHoldStatus uid1) >>= catchProfileNotFound
+  status2 <- lift (wrapHttpClient $ getLegalHoldStatus uid2) >>= catchProfileNotFound
 
   let oneway s1 s2 = case (s1, s2) of
         (LH.UserLegalHoldNoConsent, LH.UserLegalHoldNoConsent) -> pure ()

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -25,7 +25,7 @@ import Brig.API.Error (clientError)
 import Brig.API.Handler (Handler)
 import qualified Brig.API.User as API
 import Brig.API.Util (lookupSearchPolicy)
-import Brig.App (qualifyLocal, wrapClient)
+import Brig.App
 import qualified Brig.Data.Connection as Data
 import qualified Brig.Data.User as Data
 import Brig.IO.Intra (notify)
@@ -109,7 +109,7 @@ getUsersByIds _ uids =
 
 claimPrekey :: Domain -> (UserId, ClientId) -> (Handler r) (Maybe ClientPrekey)
 claimPrekey _ (user, client) = do
-  API.claimLocalPrekey LegalholdPlusFederationNotImplemented user client !>> clientError
+  wrapHttpClientE (API.claimLocalPrekey LegalholdPlusFederationNotImplemented user client) !>> clientError
 
 claimPrekeyBundle :: Domain -> UserId -> (Handler r) PrekeyBundle
 claimPrekeyBundle _ user =

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -169,7 +169,7 @@ onUserDeleted origDomain udcn = lift $ do
   acceptedLocals <-
     map csv2From
       . filter (\x -> csv2Status x == Accepted)
-      <$> Data.lookupRemoteConnectionStatuses (fromRange connections) (fmap pure deletedUser)
+      <$> wrapClient (Data.lookupRemoteConnectionStatuses (fromRange connections) (fmap pure deletedUser))
   pooledForConcurrentlyN_ 16 (nonEmpty acceptedLocals) $ \(List1 -> recipients) ->
     notify event (tUnqualified deletedUser) Push.RouteDirect Nothing (pure recipients)
   wrapClient $ Data.deleteRemoteConnections deletedUser connections

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -172,5 +172,5 @@ onUserDeleted origDomain udcn = lift $ do
       <$> Data.lookupRemoteConnectionStatuses (fromRange connections) (fmap pure deletedUser)
   pooledForConcurrentlyN_ 16 (nonEmpty acceptedLocals) $ \(List1 -> recipients) ->
     notify event (tUnqualified deletedUser) Push.RouteDirect Nothing (pure recipients)
-  Data.deleteRemoteConnections deletedUser connections
+  wrapClient $ Data.deleteRemoteConnections deletedUser connections
   pure EmptyResponse

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -19,9 +19,11 @@
 
 module Brig.API.Federation (federationSitemap, FederationAPI) where
 
+import Bilge.IO
+import Bilge.RPC
 import qualified Brig.API.Client as API
 import Brig.API.Connection.Remote (performRemoteAction)
-import Brig.API.Error (clientError)
+import Brig.API.Error
 import Brig.API.Handler (Handler)
 import qualified Brig.API.User as API
 import Brig.API.Util (lookupSearchPolicy)
@@ -32,7 +34,11 @@ import Brig.IO.Intra (notify)
 import Brig.Types (PrekeyBundle, Relation (Accepted))
 import Brig.Types.User.Event
 import Brig.User.API.Handle
+import Brig.User.Search.Index
 import qualified Brig.User.Search.SearchIndex as Q
+import Cassandra (MonadClient)
+import Control.Monad.Catch (MonadMask)
+import Control.Monad.Trans.Except
 import Data.Domain
 import Data.Handle (Handle (..), parseHandle)
 import Data.Id (ClientId, UserId)
@@ -45,6 +51,7 @@ import Imports
 import Network.Wai.Utilities.Error ((!>>))
 import Servant (ServerT)
 import Servant.API
+import qualified System.Logger.Class as Log
 import UnliftIO.Async (pooledForConcurrentlyN_)
 import Wire.API.Federation.API.Brig
 import Wire.API.Federation.API.Common
@@ -62,12 +69,12 @@ type FederationAPI = "federation" :> BrigApi
 
 federationSitemap :: ServerT FederationAPI (Handler r)
 federationSitemap =
-  Named @"get-user-by-handle" getUserByHandle
-    :<|> Named @"get-users-by-ids" getUsersByIds
+  Named @"get-user-by-handle" (\d h -> wrapHttpClientE $ getUserByHandle d h)
+    :<|> Named @"get-users-by-ids" (\d us -> wrapHttpClientE $ getUsersByIds d us)
     :<|> Named @"claim-prekey" claimPrekey
     :<|> Named @"claim-prekey-bundle" claimPrekeyBundle
     :<|> Named @"claim-multi-prekey-bundle" claimMultiPrekeyBundle
-    :<|> Named @"search-users" searchUsers
+    :<|> Named @"search-users" (\d sr -> wrapHttpClientE $ searchUsers d sr)
     :<|> Named @"get-user-clients" getUserClients
     :<|> Named @"send-connection-action" sendConnectionAction
     :<|> Named @"on-user-deleted-connections" onUserDeleted
@@ -84,7 +91,17 @@ sendConnectionAction originDomain NewConnectionRequest {..} = do
       pure $ NewConnectionResponseOk maction
     else pure NewConnectionResponseUserNotActivated
 
-getUserByHandle :: Domain -> Handle -> (Handler r) (Maybe UserProfile)
+getUserByHandle ::
+  ( HasRequestId m,
+    Log.MonadLogger m,
+    MonadClient m,
+    MonadHttp m,
+    MonadMask m,
+    MonadReader Env m
+  ) =>
+  Domain ->
+  Handle ->
+  ExceptT Error m (Maybe UserProfile)
 getUserByHandle domain handle = do
   searchPolicy <- lookupSearchPolicy domain
 
@@ -96,14 +113,24 @@ getUserByHandle domain handle = do
   if not performHandleLookup
     then pure Nothing
     else lift $ do
-      maybeOwnerId <- wrapClient $ API.lookupHandle handle
+      maybeOwnerId <- API.lookupHandle handle
       case maybeOwnerId of
         Nothing ->
           pure Nothing
         Just ownerId ->
           listToMaybe <$> API.lookupLocalProfiles Nothing [ownerId]
 
-getUsersByIds :: Domain -> [UserId] -> (Handler r) [UserProfile]
+getUsersByIds ::
+  ( MonadClient m,
+    MonadReader Env m,
+    Log.MonadLogger m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m
+  ) =>
+  Domain ->
+  [UserId] ->
+  ExceptT Error m [UserProfile]
 getUsersByIds _ uids =
   lift (API.lookupLocalProfiles Nothing uids)
 
@@ -121,9 +148,21 @@ claimMultiPrekeyBundle _ uc = API.claimLocalMultiPrekeyBundles LegalholdPlusFede
 -- | Searching for federated users on a remote backend should
 -- only search by exact handle search, not in elasticsearch.
 -- (This decision may change in the future)
-searchUsers :: Domain -> SearchRequest -> (Handler r) SearchResponse
+searchUsers ::
+  forall m.
+  ( HasRequestId m,
+    Log.MonadLogger m,
+    MonadClient m,
+    MonadHttp m,
+    MonadIndexIO m,
+    MonadMask m,
+    MonadReader Env m
+  ) =>
+  Domain ->
+  SearchRequest ->
+  ExceptT Error m SearchResponse
 searchUsers domain (SearchRequest searchTerm) = do
-  searchPolicy <- lookupSearchPolicy domain
+  searchPolicy <- lift $ lookupSearchPolicy domain
 
   let searches = case searchPolicy of
         NoSearch -> []
@@ -135,22 +174,22 @@ searchUsers domain (SearchRequest searchTerm) = do
   contacts <- go [] maxResults searches
   pure $ SearchResponse contacts searchPolicy
   where
-    go :: [Contact] -> Int -> [Int -> (Handler r) [Contact]] -> (Handler r) [Contact]
+    go :: [Contact] -> Int -> [Int -> ExceptT Error m [Contact]] -> ExceptT Error m [Contact]
     go contacts _ [] = pure contacts
     go contacts maxResult (search : searches) = do
       contactsNew <- search maxResult
       go (contacts <> contactsNew) (maxResult - length contactsNew) searches
 
-    fullSearch :: Int -> (Handler r) [Contact]
+    fullSearch :: Int -> ExceptT Error m [Contact]
     fullSearch n
-      | n > 0 = searchResults <$> Q.searchIndex Q.FederatedSearch searchTerm n
+      | n > 0 = lift $ searchResults <$> Q.searchIndex Q.FederatedSearch searchTerm n
       | otherwise = pure []
 
-    exactHandleSearch :: Int -> (Handler r) [Contact]
+    exactHandleSearch :: Int -> ExceptT Error m [Contact]
     exactHandleSearch n
       | n > 0 = do
         let maybeHandle = parseHandle searchTerm
-        maybeOwnerId <- maybe (pure Nothing) (lift . wrapClient . API.lookupHandle) maybeHandle
+        maybeOwnerId <- maybe (pure Nothing) (lift . API.lookupHandle) maybeHandle
         case maybeOwnerId of
           Nothing -> pure []
           Just foundUser -> lift $ contactFromProfile <$$> API.lookupLocalProfiles Nothing [foundUser]

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -159,6 +159,8 @@ searchUsers domain (SearchRequest searchTerm) = do
 getUserClients :: Domain -> GetUserClients -> (Handler r) (UserMap (Set PubClient))
 getUserClients _ (GetUserClients uids) = API.lookupLocalPubClientsBulk uids !>> clientError
 
+-- TODO: 'notify' could be in IO and then the whole function can instead of
+-- running in Handler r
 onUserDeleted :: Domain -> UserDeletedConnectionsNotification -> (Handler r) EmptyResponse
 onUserDeleted origDomain udcn = lift $ do
   let deletedUser = toRemoteUnsafe origDomain (udcnUser udcn)

--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -148,7 +148,7 @@ type JSON = Media "application" "json"
 -- TODO: move to libs/wai-utilities?  there is a parseJson' in "Network.Wai.Utilities.Request",
 -- but adjusting its signature to this here would require to move more code out of brig (at least
 -- badRequest and probably all the other errors).
-parseJsonBody :: FromJSON a => JsonRequest a -> (Handler r) a
+parseJsonBody :: (FromJSON a, MonadIO m) => JsonRequest a -> ExceptT Error m a
 parseJsonBody req = parseBody req !>> StdError . badRequest
 
 -- | If a whitelist is configured, consult it, otherwise a no-op. {#RefActivationWhitelist}

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -544,7 +544,7 @@ updateSSOIdH (uid ::: _ ::: req) = do
   success <- lift $ wrapClient $ Data.updateSSOId uid (Just ssoid)
   if success
     then do
-      lift $ Intra.onUserEvent uid Nothing (UserUpdated ((emptyUserUpdatedData uid) {eupSSOId = Just ssoid}))
+      lift $ wrapHttpClient $ Intra.onUserEvent uid Nothing (UserUpdated ((emptyUserUpdatedData uid) {eupSSOId = Just ssoid}))
       return empty
     else return . setStatus status404 $ plain "User does not exist or has no team."
 
@@ -553,7 +553,7 @@ deleteSSOIdH (uid ::: _) = do
   success <- lift $ wrapClient $ Data.updateSSOId uid Nothing
   if success
     then do
-      lift $ Intra.onUserEvent uid Nothing (UserUpdated ((emptyUserUpdatedData uid) {eupSSOIdRemoved = True}))
+      lift $ wrapHttpClient $ Intra.onUserEvent uid Nothing (UserUpdated ((emptyUserUpdatedData uid) {eupSSOIdRemoved = True}))
       return empty
     else return . setStatus status404 $ plain "User does not exist or has no team."
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -545,7 +545,7 @@ getPrekeyUnqualifiedH zusr user client = do
 
 getPrekeyH :: UserId -> Qualified UserId -> ClientId -> (Handler r) Public.ClientPrekey
 getPrekeyH zusr (Qualified user domain) client = do
-  mPrekey <- API.claimPrekey (ProtectedUser zusr) user domain client !>> clientError
+  mPrekey <- wrapHttpClientE $ API.claimPrekey (ProtectedUser zusr) user domain client !>> clientError
   ifNothing (notFound "prekey not found") mPrekey
 
 getPrekeyBundleUnqualifiedH :: UserId -> UserId -> (Handler r) Public.PrekeyBundle

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -732,7 +732,7 @@ getUserUnqualifiedH self uid = do
 getUser :: UserId -> Qualified UserId -> (Handler r) (Maybe Public.UserProfile)
 getUser self qualifiedUserId = do
   lself <- qualifyLocal self
-  API.lookupProfile lself qualifiedUserId !>> fedError
+  wrapHttpClientE $ API.lookupProfile lself qualifiedUserId !>> fedError
 
 -- FUTUREWORK: Make servant understand that at least one of these is required
 listUsersByUnqualifiedIdsOrHandles :: UserId -> Maybe (CommaSeparatedList UserId) -> Maybe (Range 1 4 (CommaSeparatedList Handle)) -> (Handler r) [Public.UserProfile]
@@ -771,7 +771,7 @@ listUsersByIdsOrHandles self q = do
       domain <- viewFederationDomain
       pure $ map (`Qualified` domain) localUsers
     byIds :: Local UserId -> [Qualified UserId] -> (Handler r) [Public.UserProfile]
-    byIds lself uids = API.lookupProfiles lself uids !>> fedError
+    byIds lself uids = wrapHttpClientE (API.lookupProfiles lself uids) !>> fedError
 
 newtype GetActivationCodeResp
   = GetActivationCodeResp (Public.ActivationKey, Public.ActivationCode)

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -1085,7 +1085,7 @@ deleteAccount account@(accountUser -> user) = do
   Intra.onUserEvent uid Nothing (UserDeleted (qUntagged luid))
   -- Note: Connections can only be deleted afterwards, since
   --       they need to be notified.
-  Data.deleteConnections uid
+  wrapClient $ Data.deleteConnections uid
   wrapClient $ revokeAllCookies uid
   where
     mkTombstone = do

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -1273,10 +1273,10 @@ lookupLocalProfiles ::
   [UserId] ->
   m [UserProfile]
 lookupLocalProfiles requestingUser others = do
-  users <- (Data.lookupUsers NoPendingInvitations others) >>= mapM userGC
+  users <- Data.lookupUsers NoPendingInvitations others >>= mapM userGC
   css <- case requestingUser of
     Just localReqUser -> toMap <$> Data.lookupConnectionStatus (map userId users) [localReqUser]
-    Nothing -> pure $ toMap [] -- mempty
+    Nothing -> pure mempty
   emailVisibility' <- view (settings . emailVisibility)
   emailVisibility'' <- case emailVisibility' of
     EmailVisibleIfOnTeam -> pure EmailVisibleIfOnTeam'
@@ -1323,15 +1323,15 @@ getLegalHoldStatus ::
 getLegalHoldStatus uid = traverse (getLegalHoldStatus' . accountUser) =<< lookupAccount uid
 
 getLegalHoldStatus' ::
-  ( MonadLogger f,
-    MonadReader Env f,
-    MonadIO f,
-    MonadMask f,
-    MonadHttp f,
-    HasRequestId f
+  ( MonadLogger m,
+    MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m
   ) =>
   User ->
-  f UserLegalHoldStatus
+  m UserLegalHoldStatus
 getLegalHoldStatus' user =
   case userTeam user of
     Nothing -> pure defUserLegalHoldStatus

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -1016,7 +1016,6 @@ deleteUser uid pwd = do
       Just emailOrPhone -> sendCode a emailOrPhone
       Nothing -> case pwd of
         Just _ -> throwE DeleteUserMissingPassword
-        -- TODO
         Nothing -> lift $ wrapHttpClient $ deleteAccount a >> return Nothing
     byPassword a pw = do
       Log.info $
@@ -1028,7 +1027,6 @@ deleteUser uid pwd = do
         Just p -> do
           unless (verifyPassword pw p) $
             throwE DeleteUserInvalidPassword
-          -- TODO
           lift $ wrapHttpClient $ deleteAccount a >> return Nothing
     sendCode a target = do
       gen <- Code.mkGen (either Code.ForEmail Code.ForPhone target)
@@ -1067,7 +1065,6 @@ verifyDeleteUser d = do
   c <- lift . wrapClient $ Code.verify key Code.AccountDeletion code
   a <- maybe (throwE DeleteUserInvalidCode) return (Code.codeAccount =<< c)
   account <- lift . wrapClient $ Data.lookupAccount (Id a)
-  -- TODO
   for_ account $ lift . wrapHttpClient . deleteAccount
   lift . wrapClient $ Code.delete key Code.AccountDeletion
 

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -1011,6 +1011,7 @@ deleteUser uid pwd = do
       Just emailOrPhone -> sendCode a emailOrPhone
       Nothing -> case pwd of
         Just _ -> throwE DeleteUserMissingPassword
+        -- TODO
         Nothing -> lift $ deleteAccount a >> return Nothing
     byPassword a pw = do
       Log.info $
@@ -1022,6 +1023,7 @@ deleteUser uid pwd = do
         Just p -> do
           unless (verifyPassword pw p) $
             throwE DeleteUserInvalidPassword
+          -- TODO
           lift $ deleteAccount a >> return Nothing
     sendCode a target = do
       gen <- Code.mkGen (either Code.ForEmail Code.ForPhone target)
@@ -1060,6 +1062,7 @@ verifyDeleteUser d = do
   c <- lift . wrapClient $ Code.verify key Code.AccountDeletion code
   a <- maybe (throwE DeleteUserInvalidCode) return (Code.codeAccount =<< c)
   account <- lift . wrapClient $ Data.lookupAccount (Id a)
+  -- TODO
   for_ account $ lift . deleteAccount
   lift . wrapClient $ Code.delete key Code.AccountDeletion
 

--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -88,10 +88,10 @@ logInvitationCode code = Log.field "invitation_code" (toText $ fromInvitationCod
 
 -- | Traverse concurrently and fail on first error.
 traverseConcurrentlyWithErrors ::
-  (Traversable t, Exception e) =>
-  (a -> ExceptT e (AppIO r) b) ->
+  (Traversable t, Exception e, MonadUnliftIO m) =>
+  (a -> ExceptT e m b) ->
   t a ->
-  ExceptT e (AppIO r) (t b)
+  ExceptT e m (t b)
 traverseConcurrentlyWithErrors f =
   ExceptT . try
     . ( traverse (either throwIO pure)

--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -31,7 +31,7 @@ where
 import Brig.API.Error
 import Brig.API.Handler
 import Brig.API.Types
-import Brig.App (AppIO, settings, wrapClient)
+import Brig.App
 import qualified Brig.Data.User as Data
 import Brig.Options (FederationDomainConfig, federationDomainConfigs)
 import qualified Brig.Options as Opts
@@ -101,11 +101,11 @@ traverseConcurrentlyWithErrors f =
 exceptTToMaybe :: Monad m => ExceptT e m () -> m (Maybe e)
 exceptTToMaybe = (pure . either Just (const Nothing)) <=< runExceptT
 
-lookupDomainConfig :: Domain -> (Handler r) (Maybe FederationDomainConfig)
+lookupDomainConfig :: MonadReader Env m => Domain -> m (Maybe FederationDomainConfig)
 lookupDomainConfig domain = do
   domainConfigs <- fromMaybe [] <$> view (settings . federationDomainConfigs)
   pure $ find ((== domain) . Opts.domain) domainConfigs
 
 -- | If domain is not configured fall back to `FullSearch`
-lookupSearchPolicy :: Domain -> (Handler r) FederatedUserSearchPolicy
+lookupSearchPolicy :: MonadReader Env m => Domain -> m FederatedUserSearchPolicy
 lookupSearchPolicy domain = fromMaybe NoSearch <$> (Opts.cfgSearchPolicy <$$> lookupDomainConfig domain)

--- a/services/brig/src/Brig/AWS.hs
+++ b/services/brig/src/Brig/AWS.hs
@@ -254,11 +254,11 @@ execCatch e cmd =
       AWS.send e cmd
 
 exec ::
-  (AWSRequest a, MonadUnliftIO m, MonadCatch m, MonadThrow m, MonadIO m) =>
+  (AWSRequest a, MonadCatch m, MonadThrow m, MonadIO m) =>
   AWS.Env ->
   a ->
   m (AWSResponse a)
-exec e cmd = execCatch e cmd >>= either (throwM . GeneralError) return
+exec e cmd = liftIO (execCatch e cmd) >>= either (throwM . GeneralError) return
 
 canRetry :: MonadIO m => Either AWS.Error a -> m Bool
 canRetry (Right _) = pure False

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -454,7 +454,7 @@ closeEnv e = do
 -------------------------------------------------------------------------------
 -- App Monad
 newtype AppT r m a = AppT
-  { unAppT :: ReaderT Env m a
+  { _unAppT :: ReaderT Env m a
   }
   deriving newtype
     ( Functor,
@@ -567,12 +567,6 @@ instance (MonadIndexIO (AppT r m), Monad m) => MonadIndexIO (ExceptT err (AppT r
 
 instance Monad m => HasRequestId (AppT r m) where
   getRequestId = view requestId
-
-instance MonadUnliftIO m => MonadUnliftIO (AppT r m) where
-  withRunInIO inner =
-    AppT . ReaderT $ \r ->
-      withRunInIO $ \run ->
-        inner (run . flip runReaderT r . unAppT)
 
 runAppT :: Env -> AppT r m a -> m a
 runAppT e (AppT ma) = runReaderT ma e

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -75,7 +75,6 @@ module Brig.App
     wrapClientM,
     wrapHttpClient,
     wrapHttpClientE,
-    runAppIOLifted,
     wrapHttp,
     HttpClientIO (..),
   )
@@ -577,9 +576,6 @@ instance MonadUnliftIO m => MonadUnliftIO (AppT r m) where
 
 runAppT :: Env -> AppT r m a -> m a
 runAppT e (AppT ma) = runReaderT ma e
-
-runAppIOLifted :: MonadIO m => Env -> AppIO r a -> m a
-runAppIOLifted e = liftIO . runAppT e
 
 runAppResourceT :: ResourceT (AppIO r) a -> (AppIO r) a
 runAppResourceT ma = do

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -536,7 +536,8 @@ newtype HttpClientIO a = HttpClientIO
       MonadThrow,
       MonadCatch,
       MonadMask,
-      MonadUnliftIO
+      MonadUnliftIO,
+      MonadIndexIO
     )
 
 instance HasRequestId HttpClientIO where

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -240,6 +240,7 @@ updatePrekeys u c pks = do
         Success n -> return (CryptoBox.prekeyId n == keyId (prekeyId a))
         _ -> return False
 
+-- TODO: This could probably run in MonadClient m instead of AppIO
 claimPrekey :: UserId -> ClientId -> AppIO r (Maybe ClientPrekey)
 claimPrekey u c =
   view randomPrekeyLocalLock >>= \case

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -207,7 +207,6 @@ hasClient u d = isJust <$> retry x1 (query1 checkClient (params LocalQuorum (u, 
 rmClient ::
   ( MonadClient m,
     MonadReader Brig.App.Env m,
-    MonadUnliftIO m,
     MonadCatch m
   ) =>
   UserId ->
@@ -436,8 +435,8 @@ key u c = HashMap.singleton ddbClient (ddbKey u c)
 
 deleteOptLock ::
   ( MonadReader Brig.App.Env m,
-    MonadUnliftIO m,
-    MonadCatch m
+    MonadCatch m,
+    MonadIO m
   ) =>
   UserId ->
   ClientId ->

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -50,7 +50,7 @@ import qualified Amazonka.DynamoDB as AWS
 import qualified Amazonka.DynamoDB.Lens as AWS
 import Bilge.Retry (httpHandlers)
 import Brig.AWS
-import Brig.App (AppIO, Env, awsEnv, currentTime, metrics, randomPrekeyLocalLock, wrapClient)
+import Brig.App
 import Brig.Data.Instances ()
 import Brig.Data.User (AuthError (..), ReAuthError (..))
 import qualified Brig.Data.User as User
@@ -240,17 +240,24 @@ updatePrekeys u c pks = do
         Success n -> return (CryptoBox.prekeyId n == keyId (prekeyId a))
         _ -> return False
 
--- TODO: This could probably run in MonadClient m instead of AppIO
-claimPrekey :: UserId -> ClientId -> AppIO r (Maybe ClientPrekey)
+claimPrekey ::
+  ( Log.MonadLogger m,
+    MonadMask m,
+    MonadClient m,
+    MonadReader Brig.App.Env m
+  ) =>
+  UserId ->
+  ClientId ->
+  m (Maybe ClientPrekey)
 claimPrekey u c =
   view randomPrekeyLocalLock >>= \case
     -- Use random prekey selection strategy
     Just localLock -> withLocalLock localLock $ do
-      prekeys <- wrapClient . retry x1 $ query userPrekeys (params LocalQuorum (u, c))
+      prekeys <- retry x1 $ query userPrekeys (params LocalQuorum (u, c))
       prekey <- pickRandomPrekey prekeys
-      wrapClient $ removeAndReturnPreKey prekey
+      removeAndReturnPreKey prekey
     -- Use DynamoDB based optimistic locking strategy
-    Nothing -> withOptLock u c . wrapClient $ do
+    Nothing -> withOptLock u c $ do
       prekey <- retry x1 $ query1 userPrekey (params LocalQuorum (u, c))
       removeAndReturnPreKey prekey
   where
@@ -440,7 +447,16 @@ deleteOptLock u c = do
   e <- view (awsEnv . amazonkaEnv)
   void $ exec e (AWS.newDeleteItem t & AWS.deleteItem_key .~ key u c)
 
-withOptLock :: forall effs a. UserId -> ClientId -> (AppIO effs) a -> (AppIO effs) a
+withOptLock ::
+  forall a m.
+  ( MonadIO m,
+    MonadReader Brig.App.Env m,
+    Log.MonadLogger m
+  ) =>
+  UserId ->
+  ClientId ->
+  m a ->
+  m a
 withOptLock u c ma = go (10 :: Int)
   where
     go !n = do
@@ -478,17 +494,17 @@ withOptLock u c ma = go (10 :: Int)
         key u c
     toAttributeValue :: Word32 -> AWS.AttributeValue
     toAttributeValue w = AWS.N $ AWS.toText (fromIntegral w :: Int)
-    reportAttemptFailure :: (AppIO effs) ()
+    reportAttemptFailure :: m ()
     reportAttemptFailure =
       Metrics.counterIncr (Metrics.path "client.opt_lock.optimistic_lock_grab_attempt_failed") =<< view metrics
-    reportFailureAndLogError :: (AppIO effs) ()
+    reportFailureAndLogError :: m ()
     reportFailureAndLogError = do
       Log.err $
         Log.field "user" (toByteString' u)
           . Log.field "client" (toByteString' c)
           . msg (val "PreKeys: Optimistic lock failed")
       Metrics.counterIncr (Metrics.path "client.opt_lock.optimistic_lock_failed") =<< view metrics
-    execDyn :: forall r x. (AWS.AWSRequest r) => (AWS.AWSResponse r -> Maybe x) -> (Text -> r) -> (AppIO effs) (Maybe x)
+    execDyn :: forall r x. (AWS.AWSRequest r) => (AWS.AWSResponse r -> Maybe x) -> (Text -> r) -> m (Maybe x)
     execDyn cnv mkCmd = do
       cmd <- mkCmd <$> view (awsEnv . prekeyTable)
       e <- view (awsEnv . amazonkaEnv)

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -299,11 +299,16 @@ deleteConnections u = do
   where
     delete (other, _status) = write connectionDelete $ params LocalQuorum (other, u)
 
--- TODO: This is essentially MonadClient m, no need for AppIO
-deleteRemoteConnections :: Remote UserId -> Range 1 1000 [UserId] -> AppIO r ()
+deleteRemoteConnections ::
+  ( MonadClient m,
+    MonadUnliftIO m
+  ) =>
+  Remote UserId ->
+  Range 1 1000 [UserId] ->
+  m ()
 deleteRemoteConnections (qUntagged -> Qualified remoteUser remoteDomain) (fromRange -> locals) =
   pooledForConcurrentlyN_ 16 locals $ \u ->
-    wrapClient $ write remoteConnectionDelete $ params LocalQuorum (u, remoteDomain, remoteUser)
+    write remoteConnectionDelete $ params LocalQuorum (u, remoteDomain, remoteUser)
 
 -- Queries
 

--- a/services/brig/src/Brig/Data/Connection.hs
+++ b/services/brig/src/Brig/Data/Connection.hs
@@ -214,6 +214,7 @@ lookupConnectionStatus' from =
   map toConnectionStatus
     <$> retry x1 (query connectionStatusSelect' (params LocalQuorum (Identity from)))
 
+-- TODO: This is essentially MonadClient m, no need for AppIO
 lookupLocalConnectionStatuses :: [UserId] -> Local [UserId] -> AppIO r [ConnectionStatusV2]
 lookupLocalConnectionStatuses froms tos = do
   concat <$> pooledMapConcurrentlyN 16 lookupStatuses froms
@@ -223,6 +224,7 @@ lookupLocalConnectionStatuses froms tos = do
       map (uncurry $ toConnectionStatusV2 from (tDomain tos))
         <$> wrapClient (retry x1 (query relationsSelect (params LocalQuorum (from, tUnqualified tos))))
 
+-- TODO: This is essentially MonadClient m, no need for AppIO
 lookupRemoteConnectionStatuses :: [UserId] -> Remote [UserId] -> AppIO r [ConnectionStatusV2]
 lookupRemoteConnectionStatuses froms tos = do
   concat <$> pooledMapConcurrentlyN 16 lookupStatuses froms
@@ -232,6 +234,7 @@ lookupRemoteConnectionStatuses froms tos = do
       map (uncurry $ toConnectionStatusV2 from (tDomain tos))
         <$> wrapClient (retry x1 (query remoteRelationsSelect (params LocalQuorum (from, tDomain tos, tUnqualified tos))))
 
+-- TODO: This is essentially MonadClient m, no need for AppIO
 lookupAllStatuses :: Local [UserId] -> AppIO r [ConnectionStatusV2]
 lookupAllStatuses lfroms = do
   let froms = tUnqualified lfroms
@@ -284,6 +287,7 @@ countConnections u r = do
     count n (Identity s) | relationDropHistory s `elem` r = n + 1
     count n _ = n
 
+-- TODO: This is essentially MonadClient m, no need for AppIO
 deleteConnections :: UserId -> AppIO r ()
 deleteConnections u = do
   e <- ask
@@ -298,6 +302,7 @@ deleteConnections u = do
   where
     delete (other, _status) = wrapClient $ write connectionDelete $ params LocalQuorum (other, u)
 
+-- TODO: This is essentially MonadClient m, no need for AppIO
 deleteRemoteConnections :: Remote UserId -> Range 1 1000 [UserId] -> AppIO r ()
 deleteRemoteConnections (qUntagged -> Qualified remoteUser remoteDomain) (fromRange -> locals) =
   pooledForConcurrentlyN_ 16 locals $ \u ->

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -105,9 +105,15 @@ sendConnectionAction self (qUntagged -> other) action = do
   executeFederated @"send-connection-action" (qDomain other) req
 
 notifyUserDeleted ::
+  ( MonadReader Env m,
+    MonadIO m,
+    HasFedEndpoint 'Brig api "on-user-deleted-connections",
+    HasClient ClientM api,
+    HasClient (FederatorClient 'Brig) api
+  ) =>
   Local UserId ->
   Remote (Range 1 1000 [UserId]) ->
-  (FederationAppIO r) ()
+  ExceptT FederationError m ()
 notifyUserDeleted self remotes = do
   let remoteConnections = tUnqualified remotes
   void $
@@ -133,8 +139,9 @@ runBrigFederatorClient targetDomain action = do
 
 executeFederated ::
   forall (name :: Symbol) api m.
-  (MonadReader Env m, MonadIO m) =>
-  ( HasFedEndpoint 'Brig api name,
+  ( MonadReader Env m,
+    MonadIO m,
+    HasFedEndpoint 'Brig api name,
     HasClient ClientM api,
     HasClient (FederatorClient 'Brig) api
   ) =>

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -163,12 +163,13 @@ onConnectionEvent ::
   (AppIO r) ()
 onConnectionEvent orig conn evt = do
   let from = ucFrom (ucConn evt)
-  notify
-    (singleton $ ConnectionEvent evt)
-    orig
-    Push.RouteAny
-    conn
-    (return $ list1 from [])
+  wrapHttp $
+    notify
+      (singleton $ ConnectionEvent evt)
+      orig
+      Push.RouteAny
+      conn
+      (return $ list1 from [])
 
 onPropertyEvent ::
   -- | Originator of the event.
@@ -178,12 +179,13 @@ onPropertyEvent ::
   PropertyEvent ->
   (AppIO r) ()
 onPropertyEvent orig conn e =
-  notify
-    (singleton $ PropertyEvent e)
-    orig
-    Push.RouteDirect
-    (Just conn)
-    (return $ list1 orig [])
+  wrapHttp $
+    notify
+      (singleton $ PropertyEvent e)
+      orig
+      Push.RouteDirect
+      (Just conn)
+      (return $ list1 orig [])
 
 onClientEvent ::
   -- | Originator of the event.

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -1019,7 +1019,16 @@ getTeamLegalHoldStatus tid = do
         . expect2xx
 
 -- | Calls 'Galley.API.getSearchVisibilityInternalH'.
-getTeamSearchVisibility :: TeamId -> (AppIO r) Team.TeamSearchVisibility
+getTeamSearchVisibility ::
+  ( MonadLogger m,
+    MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m
+  ) =>
+  TeamId ->
+  m Team.TeamSearchVisibility
 getTeamSearchVisibility tid =
   coerce @Team.TeamSearchVisibilityView @Team.TeamSearchVisibility <$> do
     debug $ remote "galley" . msg (val "Get search visibility settings")
@@ -1042,7 +1051,15 @@ getVerificationCodeEnabled tid = do
       paths ["i", "teams", toByteString' tid, "features", toByteString' TeamFeatureSndFactorPasswordChallenge]
         . expect2xx
 
-getTeamFeatureStatusSndFactorPasswordChallenge :: Maybe UserId -> (AppIO r) TeamFeatureStatusNoConfig
+getTeamFeatureStatusSndFactorPasswordChallenge ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m
+  ) =>
+  Maybe UserId ->
+  m TeamFeatureStatusNoConfig
 getTeamFeatureStatusSndFactorPasswordChallenge mbUserId =
   responseJsonUnsafe
     <$> galleyRequest

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -132,19 +132,13 @@ import qualified Wire.API.Team.Member as Member
 -- Event Handlers
 
 onUserEvent ::
-  ( MonadClient m,
-    MonadLogger m,
-    MonadCatch m,
-    MonadLogger m,
+  ( MonadLogger m,
     MonadCatch m,
     MonadThrow m,
     MonadIndexIO m,
     MonadReader Env m,
     MonadIO m,
-    Log.MonadLogger m,
-    MonadReader Env m,
     MonadMask m,
-    MonadCatch m,
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -685,7 +685,16 @@ toApsData _ = Nothing
 -- Conversation Management
 
 -- | Calls 'Galley.API.createSelfConversationH'.
-createSelfConv :: UserId -> (AppIO r) ()
+createSelfConv ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  UserId ->
+  m ()
 createSelfConv u = do
   debug $
     remote "galley"
@@ -699,11 +708,18 @@ createSelfConv u = do
 
 -- | Calls 'Galley.API.Create.createConnectConversation'.
 createLocalConnectConv ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
   Local UserId ->
   Local UserId ->
   Maybe Text ->
   Maybe ConnId ->
-  (AppIO r) ConvId
+  m ConvId
 createLocalConnectConv from to cname conn = do
   debug $
     logConnection (tUnqualified from) (qUntagged to)
@@ -739,7 +755,18 @@ createConnectConv from to cname conn = do
       foldQualified loc pure (\_ -> throwM federationNotImplemented) x
 
 -- | Calls 'Galley.API.acceptConvH'.
-acceptLocalConnectConv :: Local UserId -> Maybe ConnId -> ConvId -> (AppIO r) Conversation
+acceptLocalConnectConv ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  Local UserId ->
+  Maybe ConnId ->
+  ConvId ->
+  m Conversation
 acceptLocalConnectConv from conn cnv = do
   debug $
     remote "galley"
@@ -753,7 +780,7 @@ acceptLocalConnectConv from conn cnv = do
         . maybe id (header "Z-Connection" . fromConnId) conn
         . expect2xx
 
-acceptConnectConv :: Local UserId -> Maybe ConnId -> Qualified ConvId -> (AppIO r) Conversation
+acceptConnectConv :: Local UserId -> Maybe ConnId -> Qualified ConvId -> AppIO r Conversation
 acceptConnectConv from conn =
   foldQualified
     from
@@ -761,7 +788,18 @@ acceptConnectConv from conn =
     (const (throwM federationNotImplemented))
 
 -- | Calls 'Galley.API.blockConvH'.
-blockLocalConv :: Local UserId -> Maybe ConnId -> ConvId -> (AppIO r) ()
+blockLocalConv ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  Local UserId ->
+  Maybe ConnId ->
+  ConvId ->
+  m ()
 blockLocalConv lusr conn cnv = do
   debug $
     remote "galley"
@@ -775,7 +813,18 @@ blockLocalConv lusr conn cnv = do
         . maybe id (header "Z-Connection" . fromConnId) conn
         . expect2xx
 
-blockConv :: Local UserId -> Maybe ConnId -> Qualified ConvId -> (AppIO r) ()
+blockConv ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  Local UserId ->
+  Maybe ConnId ->
+  Qualified ConvId ->
+  m ()
 blockConv lusr conn =
   foldQualified
     lusr
@@ -783,7 +832,18 @@ blockConv lusr conn =
     (const (throwM federationNotImplemented))
 
 -- | Calls 'Galley.API.unblockConvH'.
-unblockLocalConv :: Local UserId -> Maybe ConnId -> ConvId -> (AppIO r) Conversation
+unblockLocalConv ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  Local UserId ->
+  Maybe ConnId ->
+  ConvId ->
+  m Conversation
 unblockLocalConv lusr conn cnv = do
   debug $
     remote "galley"
@@ -797,7 +857,18 @@ unblockLocalConv lusr conn cnv = do
         . maybe id (header "Z-Connection" . fromConnId) conn
         . expect2xx
 
-unblockConv :: Local UserId -> Maybe ConnId -> Qualified ConvId -> (AppIO r) Conversation
+unblockConv ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  Local UserId ->
+  Maybe ConnId ->
+  Qualified ConvId ->
+  m Conversation
 unblockConv luid conn =
   foldQualified
     luid
@@ -805,7 +876,17 @@ unblockConv luid conn =
     (const (throwM federationNotImplemented))
 
 -- | Calls 'Galley.API.getConversationH'.
-getConv :: UserId -> ConvId -> (AppIO r) (Maybe Conversation)
+getConv ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  UserId ->
+  ConvId ->
+  m (Maybe Conversation)
 getConv usr cnv = do
   debug $
     remote "galley"
@@ -821,7 +902,16 @@ getConv usr cnv = do
         . zUser usr
         . expect [status200, status404]
 
-upsertOne2OneConversation :: UpsertOne2OneConversationRequest -> (AppIO r) UpsertOne2OneConversationResponse
+upsertOne2OneConversation ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  UpsertOne2OneConversationRequest ->
+  m UpsertOne2OneConversationResponse
 upsertOne2OneConversation urequest = do
   response <- galleyRequest POST req
   case Bilge.statusCode response of
@@ -834,7 +924,18 @@ upsertOne2OneConversation urequest = do
         . lbytes (encode urequest)
 
 -- | Calls 'Galley.API.getTeamConversationH'.
-getTeamConv :: UserId -> TeamId -> ConvId -> (AppIO r) (Maybe Team.TeamConversation)
+getTeamConv ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  UserId ->
+  TeamId ->
+  ConvId ->
+  m (Maybe Team.TeamConversation)
 getTeamConv usr tid cnv = do
   debug $
     remote "galley"
@@ -890,7 +991,17 @@ rmUser usr asts = do
 -- Client management
 
 -- | Calls 'Galley.API.addClientH'.
-newClient :: UserId -> ClientId -> (AppIO r) ()
+newClient ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  UserId ->
+  ClientId ->
+  m ()
 newClient u c = do
   debug $
     remote "galley"
@@ -941,7 +1052,16 @@ rmClient u c = do
   where
     expected = [status200, status204, status404]
 
-lookupPushToken :: UserId -> (AppIO r) [Push.PushToken]
+lookupPushToken ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  UserId ->
+  m [Push.PushToken]
 lookupPushToken uid = do
   g <- view gundeck
   rsp <-
@@ -959,7 +1079,16 @@ lookupPushToken uid = do
 -- Team Management
 
 -- | Calls 'Galley.API.canUserJoinTeamH'.
-checkUserCanJoinTeam :: TeamId -> (AppIO r) (Maybe Wai.Error)
+checkUserCanJoinTeam ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  TeamId ->
+  m (Maybe Wai.Error)
 checkUserCanJoinTeam tid = do
   debug $
     remote "galley"
@@ -976,7 +1105,18 @@ checkUserCanJoinTeam tid = do
         . header "Content-Type" "application/json"
 
 -- | Calls 'Galley.API.uncheckedAddTeamMemberH'.
-addTeamMember :: UserId -> TeamId -> (Maybe (UserId, UTCTimeMillis), Team.Role) -> (AppIO r) Bool
+addTeamMember ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  UserId ->
+  TeamId ->
+  (Maybe (UserId, UTCTimeMillis), Team.Role) ->
+  m Bool
 addTeamMember u tid (minvmeta, role) = do
   debug $
     remote "galley"
@@ -996,7 +1136,18 @@ addTeamMember u tid (minvmeta, role) = do
         . lbytes (encode bdy)
 
 -- | Calls 'Galley.API.createBindingTeamH'.
-createTeam :: UserId -> Team.BindingNewTeam -> TeamId -> (AppIO r) CreateUserTeam
+createTeam ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  UserId ->
+  Team.BindingNewTeam ->
+  TeamId ->
+  m CreateUserTeam
 createTeam u t@(Team.BindingNewTeam bt) teamid = do
   debug $
     remote "galley"
@@ -1016,7 +1167,17 @@ createTeam u t@(Team.BindingNewTeam bt) teamid = do
         . lbytes (encode t)
 
 -- | Calls 'Galley.API.uncheckedGetTeamMemberH'.
-getTeamMember :: UserId -> TeamId -> (AppIO r) (Maybe Team.TeamMember)
+getTeamMember ::
+  ( MonadLogger m,
+    MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m
+  ) =>
+  UserId ->
+  TeamId ->
+  m (Maybe Team.TeamMember)
 getTeamMember u tid = do
   debug $
     remote "galley"
@@ -1036,7 +1197,16 @@ getTeamMember u tid = do
 -- | TODO: is now truncated.  this is (only) used for team suspension / unsuspension, which
 -- means that only the first 2000 members of a team (according to some arbitrary order) will
 -- be suspended, and the rest will remain active.
-getTeamMembers :: TeamId -> (AppIO r) Team.TeamMemberList
+getTeamMembers ::
+  ( MonadLogger m,
+    MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m
+  ) =>
+  TeamId ->
+  m Team.TeamMemberList
 getTeamMembers tid = do
   debug $ remote "galley" . msg (val "Get team members")
   galleyRequest GET req >>= decodeBody "galley"
@@ -1045,7 +1215,16 @@ getTeamMembers tid = do
       paths ["i", "teams", toByteString' tid, "members"]
         . expect2xx
 
-memberIsTeamOwner :: TeamId -> UserId -> (AppIO r) Bool
+memberIsTeamOwner ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m
+  ) =>
+  TeamId ->
+  UserId ->
+  m Bool
 memberIsTeamOwner tid uid = do
   r <-
     galleyRequest GET $
@@ -1077,7 +1256,16 @@ getTeamContacts u = do
         . expect [status200, status404]
 
 -- | Calls 'Galley.API.getBindingTeamIdH'.
-getTeamId :: UserId -> (AppIO r) (Maybe TeamId)
+getTeamId ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  UserId ->
+  m (Maybe TeamId)
 getTeamId u = do
   debug $ remote "galley" . msg (val "Get team from user")
   rs <- galleyRequest GET req
@@ -1090,7 +1278,16 @@ getTeamId u = do
         . expect [status200, status404]
 
 -- | Calls 'Galley.API.getTeamInternalH'.
-getTeam :: TeamId -> (AppIO r) Team.TeamData
+getTeam ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  TeamId ->
+  m Team.TeamData
 getTeam tid = do
   debug $ remote "galley" . msg (val "Get team info")
   galleyRequest GET req >>= decodeBody "galley"
@@ -1100,7 +1297,16 @@ getTeam tid = do
         . expect2xx
 
 -- | Calls 'Galley.API.getTeamInternalH'.
-getTeamName :: TeamId -> (AppIO r) Team.TeamName
+getTeamName ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  TeamId ->
+  m Team.TeamName
 getTeamName tid = do
   debug $ remote "galley" . msg (val "Get team info")
   galleyRequest GET req >>= decodeBody "galley"
@@ -1110,7 +1316,16 @@ getTeamName tid = do
         . expect2xx
 
 -- | Calls 'Galley.API.getTeamFeatureStatusH'.
-getTeamLegalHoldStatus :: TeamId -> (AppIO r) (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureLegalHold)
+getTeamLegalHoldStatus ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  TeamId ->
+  m (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureLegalHold)
 getTeamLegalHoldStatus tid = do
   debug $ remote "galley" . msg (val "Get legalhold settings")
   galleyRequest GET req >>= decodeBody "galley"
@@ -1139,7 +1354,16 @@ getTeamSearchVisibility tid =
       paths ["i", "teams", toByteString' tid, "search-visibility"]
         . expect2xx
 
-getVerificationCodeEnabled :: TeamId -> (AppIO r) Bool
+getVerificationCodeEnabled ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  TeamId ->
+  m Bool
 getVerificationCodeEnabled tid = do
   debug $ remote "galley" . msg (val "Get snd factor password challenge settings")
   response <- galleyRequest GET req
@@ -1170,7 +1394,18 @@ getTeamFeatureStatusSndFactorPasswordChallenge mbUserId =
       )
 
 -- | Calls 'Galley.API.updateTeamStatusH'.
-changeTeamStatus :: TeamId -> Team.TeamStatus -> Maybe Currency.Alpha -> (AppIO r) ()
+changeTeamStatus ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  TeamId ->
+  Team.TeamStatus ->
+  Maybe Currency.Alpha ->
+  m ()
 changeTeamStatus tid s cur = do
   debug $ remote "galley" . msg (val "Change Team status")
   void $ galleyRequest PUT req

--- a/services/brig/src/Brig/IO/Journal.hs
+++ b/services/brig/src/Brig/IO/Journal.hs
@@ -47,19 +47,19 @@ import qualified Proto.UserEvents_Fields as U
 -- User journal operations to SQS are a no-op when the service is started
 -- without journaling arguments for user updates
 
-userActivate :: User -> (AppIO r) ()
+userActivate :: (MonadReader Env m, MonadIO m) => User -> m ()
 userActivate u@User {..} = journalEvent UserEvent'USER_ACTIVATE userId (userEmail u) (Just userLocale) userTeam (Just userDisplayName)
 
-userUpdate :: UserId -> Maybe Email -> Maybe Locale -> Maybe Name -> (AppIO r) ()
+userUpdate :: (MonadReader Env m, MonadIO m) => UserId -> Maybe Email -> Maybe Locale -> Maybe Name -> m ()
 userUpdate uid em loc nm = journalEvent UserEvent'USER_UPDATE uid em loc Nothing nm
 
-userEmailRemove :: UserId -> Email -> (AppIO r) ()
+userEmailRemove :: (MonadReader Env m, MonadIO m) => UserId -> Email -> m ()
 userEmailRemove uid em = journalEvent UserEvent'USER_EMAIL_REMOVE uid (Just em) Nothing Nothing Nothing
 
-userDelete :: UserId -> (AppIO r) ()
+userDelete :: (MonadReader Env m, MonadIO m) => UserId -> m ()
 userDelete uid = journalEvent UserEvent'USER_DELETE uid Nothing Nothing Nothing Nothing
 
-journalEvent :: UserEvent'EventType -> UserId -> Maybe Email -> Maybe Locale -> Maybe TeamId -> Maybe Name -> (AppIO r) ()
+journalEvent :: (MonadReader Env m, MonadIO m) => UserEvent'EventType -> UserId -> Maybe Email -> Maybe Locale -> Maybe TeamId -> Maybe Name -> m ()
 journalEvent typ uid em loc tid nm =
   view awsEnv >>= \env -> for_ (view AWS.userJournalQueue env) $ \queue -> do
     ts <- now

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -60,7 +60,6 @@ onEvent n = handleTimeout $ case n of
     Log.info $
       msg (val "Processing user delete event")
         ~~ field "user" (toByteString uid)
-    -- TODO
     API.lookupAccount uid >>= mapM_ API.deleteAccount
     -- As user deletions are expensive resource-wise in the context of
     -- bulk user deletions (e.g. during team deletions),

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -54,7 +54,7 @@ onEvent n = handleTimeout $ case n of
       msg (val "Processing service delete event")
         ~~ field "provider" (toByteString pid)
         ~~ field "service" (toByteString sid)
-    API.finishDeleteService pid sid
+    wrapHttpClient $ API.finishDeleteService pid sid
   where
     handleTimeout act =
       timeout 60000000 act >>= \case

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -42,6 +42,7 @@ onEvent n = handleTimeout $ case n of
     Log.info $
       msg (val "Processing user delete event")
         ~~ field "user" (toByteString uid)
+    -- TODO
     wrapClient (API.lookupAccount uid) >>= mapM_ API.deleteAccount
     -- As user deletions are expensive resource-wise in the context of
     -- bulk user deletions (e.g. during team deletions),

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -25,6 +25,8 @@ module Brig.Provider.API
   )
 where
 
+import Bilge.IO (MonadHttp)
+import Bilge.RPC (HasRequestId)
 import qualified Brig.API.Client as Client
 import Brig.API.Error
 import Brig.API.Handler
@@ -51,9 +53,11 @@ import Brig.Types.Provider (AddBot (..), DeleteProvider (..), DeleteService (..)
 import qualified Brig.Types.Provider.External as Ext
 import Brig.Types.User (HavePendingInvitations (..), ManagedBy (..), Name (..), Pict (..), User (..), defaultAccentId)
 import qualified Brig.ZAuth as ZAuth
+import Cassandra (MonadClient)
 import Control.Error (throwE)
 import Control.Exception.Enclosed (handleAny)
 import Control.Lens (view, (^.))
+import Control.Monad.Catch (MonadMask)
 import Control.Monad.Except
 import Data.Aeson hiding (json)
 import Data.ByteString.Conversion
@@ -94,6 +98,7 @@ import qualified OpenSSL.PEM as SSL
 import qualified OpenSSL.RSA as SSL
 import OpenSSL.Random (randBytes)
 import qualified Ssl.Util as SSL
+import System.Logger.Class (MonadLogger)
 import UnliftIO.Async (pooledMapConcurrentlyN_)
 import qualified Web.Cookie as Cookie
 import qualified Wire.API.Conversation.Bot as Public
@@ -142,7 +147,7 @@ routesPublic = do
 
   -- Provider API ------------------------------------------------------------
 
-  delete "/provider" (continue deleteAccountH) $
+  delete "/provider" (continue $ wrapHttpClientE <$> deleteAccountH) $
     zauth ZAuthProvider
       .&> zauthProviderId
       .&. jsonRequest @Public.DeleteProvider
@@ -677,44 +682,73 @@ deleteService pid sid del = do
   queue <- view internalEvents
   lift $ Queue.enqueue queue (Internal.DeleteService pid sid)
 
-finishDeleteService :: ProviderId -> ServiceId -> (AppIO r) ()
+finishDeleteService ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m,
+    MonadClient m
+  ) =>
+  ProviderId ->
+  ServiceId ->
+  m ()
 finishDeleteService pid sid = do
   e <- ask
-  mbSvc <- wrapClient $ DB.lookupService pid sid
+  mbSvc <- DB.lookupService pid sid
   for_ mbSvc $ \svc -> do
     let tags = unsafeRange (serviceTags svc)
         name = serviceName svc
-    fmap
-      wrapClient
-      runConduit
-      $ User.lookupServiceUsers pid sid
+    runConduit $
+      User.lookupServiceUsers pid sid
         .| C.mapM_ (runAppIOLifted e . pooledMapConcurrentlyN_ 16 kick)
     RPC.removeServiceConn pid sid
-    wrapClient $ DB.deleteService pid sid name tags
+    DB.deleteService pid sid name tags
   where
-    kick (bid, cid, _) = deleteBot (botUserId bid) Nothing bid cid
+    kick (bid, cid, _) = wrapHttpClient $ deleteBot (botUserId bid) Nothing bid cid
 
-deleteAccountH :: ProviderId ::: JsonRequest Public.DeleteProvider -> (Handler r) Response
+deleteAccountH ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    MonadClient m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  ProviderId ::: JsonRequest Public.DeleteProvider ->
+  ExceptT Error m Response
 deleteAccountH (pid ::: req) = do
   guardSecondFactorDisabled Nothing
   empty <$ (deleteAccount pid =<< parseJsonBody req)
 
-deleteAccount :: ProviderId -> Public.DeleteProvider -> (Handler r) ()
+deleteAccount ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    MonadClient m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  ProviderId ->
+  Public.DeleteProvider ->
+  ExceptT Error m ()
 deleteAccount pid del = do
-  prov <- wrapClientE (DB.lookupAccount pid) >>= maybeInvalidProvider
-  pass <- wrapClientE (DB.lookupPassword pid) >>= maybeBadCredentials
+  prov <- (DB.lookupAccount pid) >>= maybeInvalidProvider
+  pass <- (DB.lookupPassword pid) >>= maybeBadCredentials
   unless (verifyPassword (deleteProviderPassword del) pass) $
     throwStd (errorToWai @'BadCredentials)
-  svcs <- wrapClientE $ DB.listServices pid
+  svcs <- DB.listServices pid
   forM_ svcs $ \svc -> do
     let sid = serviceId svc
     let tags = unsafeRange (serviceTags svc)
         name = serviceName svc
     lift $ RPC.removeServiceConn pid sid
-    wrapClientE $ DB.deleteService pid sid name tags
-  wrapClientE $ do
-    DB.deleteKey (mkEmailKey (providerEmail prov))
-    DB.deleteAccount pid
+    DB.deleteService pid sid name tags
+  DB.deleteKey (mkEmailKey (providerEmail prov))
+  DB.deleteAccount pid
 
 --------------------------------------------------------------------------------
 -- User API
@@ -840,7 +874,7 @@ updateServiceWhitelist uid con tid upd = do
               ( runAppIOLifted e
                   . pooledMapConcurrentlyN_
                     16
-                    ( uncurry (deleteBot uid (Just con))
+                    ( wrapHttpClient . uncurry (deleteBot uid (Just con))
                     )
               )
       wrapClientE $ DB.deleteServiceWhitelist (Just tid) pid sid
@@ -943,7 +977,7 @@ removeBot zusr zcon cid bid = do
   case bot >>= omService of
     Nothing -> return Nothing
     Just _ -> do
-      lift $ Public.RemoveBotResponse <$$> deleteBot zusr (Just zcon) bid cid
+      lift $ Public.RemoveBotResponse <$$> (wrapHttpClient $ deleteBot zusr (Just zcon) bid cid)
 
 --------------------------------------------------------------------------------
 -- Bot API
@@ -1036,7 +1070,7 @@ botDeleteSelf bid cid = do
   guardSecondFactorDisabled (Just (botUserId bid))
   bot <- lift . wrapClient $ User.lookupUser NoPendingInvitations (botUserId bid)
   _ <- maybeInvalidBot (userService =<< bot)
-  _ <- lift $ deleteBot (botUserId bid) Nothing bid cid
+  _ <- lift $ wrapHttpClient $ deleteBot (botUserId bid) Nothing bid cid
   return ()
 
 --------------------------------------------------------------------------------
@@ -1044,7 +1078,16 @@ botDeleteSelf bid cid = do
 
 -- | If second factor auth is enabled, make sure that end-points that don't support it, but should, are blocked completely.
 -- (This is a workaround until we have 2FA for those end-points as well.)
-guardSecondFactorDisabled :: Maybe UserId -> Handler r ()
+guardSecondFactorDisabled ::
+  ( MonadLogger m,
+    MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m
+  ) =>
+  Maybe UserId ->
+  ExceptT Error m ()
 guardSecondFactorDisabled mbUserId = do
   enabled <- lift $ (==) Feature.TeamFeatureEnabled . Feature.tfwoStatus <$> RPC.getTeamFeatureStatusSndFactorPasswordChallenge mbUserId
   when enabled $ throwStd accessDenied
@@ -1060,21 +1103,34 @@ activate pid old new = do
     throwStd emailExists
   wrapClientE $ DB.insertKey pid (mkEmailKey <$> old) emailKey
 
-deleteBot :: UserId -> Maybe ConnId -> BotId -> ConvId -> (AppIO r) (Maybe Public.Event)
+deleteBot ::
+  ( MonadHttp m,
+    MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    HasRequestId m,
+    MonadLogger m,
+    MonadClient m
+  ) =>
+  UserId ->
+  Maybe ConnId ->
+  BotId ->
+  ConvId ->
+  m (Maybe Public.Event)
 deleteBot zusr zcon bid cid = do
   -- Remove the bot from the conversation
   ev <- RPC.removeBotMember zusr zcon cid bid
   -- Delete the bot user and client
   let buid = botUserId bid
-  mbUser <- wrapClient $ User.lookupUser NoPendingInvitations buid
-  wrapClient (User.lookupClients buid) >>= mapM_ (wrapClient . User.rmClient buid . clientId)
+  mbUser <- User.lookupUser NoPendingInvitations buid
+  User.lookupClients buid >>= mapM_ (User.rmClient buid . clientId)
   for_ (userService =<< mbUser) $ \sref -> do
     let pid = sref ^. serviceRefProvider
         sid = sref ^. serviceRefId
-    wrapClient $ User.deleteServiceUser pid sid bid
+    User.deleteServiceUser pid sid bid
   -- TODO: Consider if we can actually delete the bot user entirely,
   -- i.e. not just marking the account as deleted.
-  wrapClient $ User.updateStatus buid Deleted
+  User.updateStatus buid Deleted
   return ev
 
 validateServiceKey :: MonadIO m => Public.ServiceKeyPEM -> m (Maybe (Public.ServiceKey, Fingerprint Rsa))
@@ -1125,34 +1181,34 @@ setProviderCookie t r = do
           Cookie.setCookieHttpOnly = True
         }
 
-maybeInvalidProvider :: Maybe a -> (Handler r) a
+maybeInvalidProvider :: Monad m => Maybe a -> (ExceptT Error m) a
 maybeInvalidProvider = maybe (throwStd invalidProvider) return
 
-maybeInvalidCode :: Maybe a -> (Handler r) a
+maybeInvalidCode :: Monad m => Maybe a -> (ExceptT Error m) a
 maybeInvalidCode = maybe (throwStd (errorToWai @'InvalidCode)) return
 
-maybeServiceNotFound :: Maybe a -> (Handler r) a
+maybeServiceNotFound :: Monad m => Maybe a -> (ExceptT Error m) a
 maybeServiceNotFound = maybe (throwStd (notFound "Service not found")) return
 
-maybeProviderNotFound :: Maybe a -> (Handler r) a
+maybeProviderNotFound :: Monad m => Maybe a -> (ExceptT Error m) a
 maybeProviderNotFound = maybe (throwStd (notFound "Provider not found")) return
 
-maybeConvNotFound :: Maybe a -> (Handler r) a
+maybeConvNotFound :: Monad m => Maybe a -> (ExceptT Error m) a
 maybeConvNotFound = maybe (throwStd (notFound "Conversation not found")) return
 
-maybeBadCredentials :: Maybe a -> (Handler r) a
+maybeBadCredentials :: Monad m => Maybe a -> (ExceptT Error m) a
 maybeBadCredentials = maybe (throwStd (errorToWai @'BadCredentials)) return
 
-maybeInvalidServiceKey :: Maybe a -> (Handler r) a
+maybeInvalidServiceKey :: Monad m => Maybe a -> (ExceptT Error m) a
 maybeInvalidServiceKey = maybe (throwStd invalidServiceKey) return
 
-maybeInvalidBot :: Maybe a -> (Handler r) a
+maybeInvalidBot :: Monad m => Maybe a -> (ExceptT Error m) a
 maybeInvalidBot = maybe (throwStd invalidBot) return
 
-maybeInvalidUser :: Maybe a -> (Handler r) a
+maybeInvalidUser :: Monad m => Maybe a -> (ExceptT Error m) a
 maybeInvalidUser = maybe (throwStd (errorToWai @'InvalidUser)) return
 
-rangeChecked :: Within a n m => a -> (Handler r) (Range n m a)
+rangeChecked :: (Within a n m, Monad monad) => a -> (ExceptT Error monad) (Range n m a)
 rangeChecked = either (throwStd . invalidRange . fromString) return . checkedEither
 
 invalidServiceKey :: Wai.Error

--- a/services/brig/src/Brig/Provider/RPC.hs
+++ b/services/brig/src/Brig/Provider/RPC.hs
@@ -29,6 +29,7 @@ module Brig.Provider.RPC
 where
 
 import Bilge
+import Bilge.RPC
 import Bilge.Retry (httpHandlers)
 import Brig.App
 import Brig.Provider.DB (ServiceConn (..))
@@ -155,7 +156,17 @@ setServiceConn scon = do
         & set Galley.serviceEnabled (sconEnabled scon)
 
 -- | Remove service connection information from galley.
-removeServiceConn :: ProviderId -> ServiceId -> (AppIO r) ()
+removeServiceConn ::
+  ( MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    MonadHttp m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
+  ProviderId ->
+  ServiceId ->
+  m ()
 removeServiceConn pid sid = do
   Log.debug $
     remote "galley"

--- a/services/brig/src/Brig/Provider/RPC.hs
+++ b/services/brig/src/Brig/Provider/RPC.hs
@@ -199,6 +199,8 @@ addBotMember zusr zcon conv bot clt pid sid = do
         . lbytes (encode (Galley.addBot (Galley.newServiceRef sid pid) conv bot clt))
         . expect2xx
 
+-- TODO: This does not have to run in AppIO as it is essentially IO
+
 -- | Tell galley to remove a service bot from a conversation.
 removeBotMember ::
   UserId ->

--- a/services/brig/src/Brig/Provider/RPC.hs
+++ b/services/brig/src/Brig/Provider/RPC.hs
@@ -210,15 +210,20 @@ addBotMember zusr zcon conv bot clt pid sid = do
         . lbytes (encode (Galley.addBot (Galley.newServiceRef sid pid) conv bot clt))
         . expect2xx
 
--- TODO: This does not have to run in AppIO as it is essentially IO
-
 -- | Tell galley to remove a service bot from a conversation.
 removeBotMember ::
+  ( MonadHttp m,
+    MonadReader Env m,
+    MonadIO m,
+    MonadMask m,
+    HasRequestId m,
+    MonadLogger m
+  ) =>
   UserId ->
   Maybe ConnId ->
   ConvId ->
   BotId ->
-  (AppIO r) (Maybe Event)
+  m (Maybe Event)
 removeBotMember zusr zcon conv bot = do
   Log.debug $
     remote "galley"

--- a/services/brig/src/Brig/Queue.hs
+++ b/services/brig/src/Brig/Queue.hs
@@ -63,7 +63,16 @@ import System.Logger.Class as Log hiding (settings)
 -- | Enqueue a message.
 --
 -- Throws an error in case of failure.
-enqueue :: ToJSON a => Queue -> a -> (AppIO r) ()
+enqueue ::
+  ( MonadReader Env m,
+    ToJSON a,
+    MonadIO m,
+    MonadLogger m,
+    MonadThrow m
+  ) =>
+  Queue ->
+  a ->
+  m ()
 enqueue (StompQueue queue) message =
   view stompEnv >>= \case
     Just env -> Stomp.enqueue (Stomp.broker env) queue message

--- a/services/brig/src/Brig/Queue/Stomp.hs
+++ b/services/brig/src/Brig/Queue/Stomp.hs
@@ -133,7 +133,7 @@ enqueue b q m =
 -- message will go into the Dead Letter Queue where it can be analyzed
 -- manually.
 --
--- TODO: This probably deserves a Polysemy action
+-- FUTUREWORK: This probably deserves a Polysemy action
 listen ::
   (FromJSON a, MonadLogger m, MonadMask m, MonadUnliftIO m) =>
   Broker ->

--- a/services/brig/src/Brig/Queue/Stomp.hs
+++ b/services/brig/src/Brig/Queue/Stomp.hs
@@ -132,6 +132,8 @@ enqueue b q m =
 -- configured properly, after failing on the same message several times the
 -- message will go into the Dead Letter Queue where it can be analyzed
 -- manually.
+--
+-- TODO: This probably deserves a Polysemy action
 listen ::
   (FromJSON a, MonadLogger m, MonadMask m, MonadUnliftIO m) =>
   Broker ->

--- a/services/brig/src/Brig/RPC.hs
+++ b/services/brig/src/Brig/RPC.hs
@@ -60,29 +60,33 @@ expect ss rq = rq {checkResponse = check}
           HttpExceptionRequest rq' (StatusCodeException rs' mempty)
 
 cargoholdRequest ::
+  (MonadReader Env m, MonadIO m, MonadMask m, MonadHttp m, HasRequestId m) =>
   StdMethod ->
   (Request -> Request) ->
-  (AppIO r) (Response (Maybe BL.ByteString))
+  m (Response (Maybe BL.ByteString))
 cargoholdRequest = serviceRequest "cargohold" cargohold
 
 galleyRequest ::
+  (MonadReader Env m, MonadIO m, MonadMask m, MonadHttp m, HasRequestId m) =>
   StdMethod ->
   (Request -> Request) ->
-  (AppIO r) (Response (Maybe BL.ByteString))
+  m (Response (Maybe BL.ByteString))
 galleyRequest = serviceRequest "galley" galley
 
 gundeckRequest ::
+  (MonadReader Env m, MonadIO m, MonadMask m, MonadHttp m, HasRequestId m) =>
   StdMethod ->
   (Request -> Request) ->
-  (AppIO r) (Response (Maybe BL.ByteString))
+  m (Response (Maybe BL.ByteString))
 gundeckRequest = serviceRequest "gundeck" gundeck
 
 serviceRequest ::
+  (MonadReader Env m, MonadIO m, MonadMask m, MonadHttp m, HasRequestId m) =>
   LT.Text ->
   Control.Lens.Getting Request Env Request ->
   StdMethod ->
   (Request -> Request) ->
-  (AppIO r) (Response (Maybe BL.ByteString))
+  m (Response (Maybe BL.ByteString))
 serviceRequest nm svc m r = do
   service <- view svc
   recovering x3 rpcHandlers $

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -85,7 +85,7 @@ run o = do
   internalEventListener <-
     Async.async $
       runAppT e $
-        Queue.listen (e ^. internalEvents) Internal.onEvent
+        Queue.listen (e ^. internalEvents) $ wrapHttpClient . Internal.onEvent
   let throttleMillis = fromMaybe defSqsThrottleMillis $ setSqsThrottleMillis (optSettings o)
   emailListener <- for (e ^. awsEnv . sesQueue) $ \q ->
     Async.async $

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -85,7 +85,8 @@ run o = do
   internalEventListener <-
     Async.async $
       runAppT e $
-        Queue.listen (e ^. internalEvents) $ wrapHttpClient . Internal.onEvent
+        wrapHttpClient $
+          Queue.listen (e ^. internalEvents) $ Internal.onEvent
   let throttleMillis = fromMaybe defSqsThrottleMillis $ setSqsThrottleMillis (optSettings o)
   emailListener <- for (e ^. awsEnv . sesQueue) $ \q ->
     Async.async $

--- a/services/brig/src/Brig/User/API/Handle.hs
+++ b/services/brig/src/Brig/User/API/Handle.hs
@@ -66,7 +66,7 @@ getLocalHandleInfo self handle = do
     Nothing -> return Nothing
     Just ownerId -> do
       domain <- viewFederationDomain
-      ownerProfile <- API.lookupProfile self (Qualified ownerId domain) !>> fedError
+      ownerProfile <- wrapHttpClientE (API.lookupProfile self (Qualified ownerId domain)) !>> fedError
       owner <- filterHandleResults self (maybeToList ownerProfile)
       return $ listToMaybe owner
 


### PR DESCRIPTION
As part of effort to introduce Polysemy to Brig, this PR removes the `MonadUnliftIO` instance for the App monad in Brig. It introduces no change in the behavior of Brig.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
