### PR TITLE
Refactor conversation record and conversation creation

### DIFF
--- a/changelog.d/5-internal/conversation-creation-refactoring
+++ b/changelog.d/5-internal/conversation-creation-refactoring
@@ -1,0 +1,9 @@
+Refactor conversation record and conversation creation functions. This removes a lot of duplication and makes the types of protocol-specific data in a conversation tighter.
+
+ - Move conversation name size check to `NewConv`
+ - Make the `NewConversation` record (used as input to the data
+   function creating a conversation) contain a `ConversationMetadata`.
+ - Implement all "special" conversation creation in terms of a general `createConversation`
+ - Move protocol field from metadata to Conversation
+ - Restructure MLS fields in Conversation record
+ - Factor out metadata fields from Data.Conversation

--- a/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
@@ -35,6 +35,7 @@ import Data.ByteString.Conversion
 import Data.Id
 import Data.List.NonEmpty hiding (cons, toList)
 import Data.List1
+import Data.Range
 import Data.Text (pack)
 import Imports
 import Network.HTTP.Types.Method
@@ -141,6 +142,6 @@ createConv users name = sessionRequest req rsc readBody
       method POST
         . path "conversations"
         . acceptJson
-        . json (NewConv users [] name mempty Nothing Nothing Nothing Nothing roleNameWireAdmin M.ProtocolProteusTag)
+        . json (NewConv users [] (name >>= checked) mempty Nothing Nothing Nothing Nothing roleNameWireAdmin M.ProtocolProteusTag)
         $ empty
     rsc = status201 :| []

--- a/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
@@ -44,6 +44,7 @@ import Network.Wire.Client.HTTP
 import Network.Wire.Client.Monad (ClientException (ParseError))
 import Network.Wire.Client.Session
 import Wire.API.Conversation as M hiding (memberUpdate)
+import Wire.API.Conversation.Protocol as M
 import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.Event.Conversation as M (MemberUpdateData)
 import Wire.API.Message as M
@@ -140,6 +141,6 @@ createConv users name = sessionRequest req rsc readBody
       method POST
         . path "conversations"
         . acceptJson
-        . json (NewConv users [] name mempty Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolProteus)
+        . json (NewConv users [] name mempty Nothing Nothing Nothing Nothing roleNameWireAdmin M.ProtocolProteusTag)
         $ empty
     rsc = status201 :| []

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -71,6 +71,7 @@ module Galley.Types
     MutedStatus (..),
     ReceiptMode (..),
     Protocol (..),
+    ProtocolTag (..),
     GroupId (..),
     TypingStatus (..),
     UserClientMap (..),
@@ -88,6 +89,7 @@ import Galley.Types.Conversations.Members (LocalMember (..), RemoteMember (..))
 import Imports
 import Wire.API.Conversation hiding (Member (..))
 import Wire.API.Conversation.Code
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Typing
 import Wire.API.CustomBackend
 import Wire.API.Event.Conversation

--- a/libs/schema-profunctor/src/Data/Schema.hs
+++ b/libs/schema-profunctor/src/Data/Schema.hs
@@ -340,7 +340,7 @@ fieldOverF l name sch = SchemaP (SchemaDoc s) (SchemaIn r) (SchemaOut w)
 
     s = mkDocF @doc @f (mkField name (schemaDoc sch))
 
--- | Like 'fieldOver', but specialised to the identity functor.
+-- | Like 'fieldOverF', but specialised to the identity functor.
 fieldOver ::
   forall doc' doc v v' a b.
   (HasField doc' doc) =>

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -29,6 +29,7 @@ import Servant.API
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import Wire.API.Conversation
 import Wire.API.Conversation.Action
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role (RoleName)
 import Wire.API.Federation.API.Common
 import Wire.API.Federation.Endpoint
@@ -75,14 +76,15 @@ data RemoteConvMembers = RemoteConvMembers
 
 -- | A conversation hosted on a remote backend. This contains the same
 -- information as a 'Conversation', with the exception that conversation status
--- fields (muted/archived/hidden) are omitted, since they are not known by the
+-- fields (muted\/archived\/hidden) are omitted, since they are not known by the
 -- remote backend.
 data RemoteConversation = RemoteConversation
   { -- | Id of the conversation, implicitly qualified with the domain of the
     -- backend that created this value.
     rcnvId :: ConvId,
     rcnvMetadata :: ConversationMetadata,
-    rcnvMembers :: RemoteConvMembers
+    rcnvMembers :: RemoteConvMembers,
+    rcnvProtocol :: Protocol
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform RemoteConversation)

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -622,7 +622,7 @@ data NewConv = NewConv
     -- | A list of qualified users, which can include some local qualified users
     -- too.
     newConvQualifiedUsers :: [Qualified UserId],
-    newConvName :: Maybe Text,
+    newConvName :: Maybe (Range 1 256 Text),
     newConvAccess :: Set Access,
     newConvAccessRoles :: Maybe (Set AccessRoleV2),
     newConvTeam :: Maybe ConvTeamInfo,

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -132,9 +132,7 @@ data ConversationMetadata = ConversationMetadata
     -- federation.
     cnvmTeam :: Maybe TeamId,
     cnvmMessageTimer :: Maybe Milliseconds,
-    cnvmReceiptMode :: Maybe ReceiptMode,
-    -- | The protocol of the conversation. It can be Proteus or MLS (1.0).
-    cnvmProtocol :: Protocol
+    cnvmReceiptMode :: Maybe ReceiptMode
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform ConversationMetadata)
@@ -187,7 +185,6 @@ conversationMetadataObjectSchema =
         (description ?~ "Per-conversation message timer (can be null)")
         (maybeWithDefault A.Null schema)
     <*> cnvmReceiptMode .= optField "receipt_mode" (maybeWithDefault A.Null schema)
-    <*> cnvmProtocol .= protocolSchema
 
 instance ToSchema ConversationMetadata where
   schema = object "ConversationMetadata" conversationMetadataObjectSchema
@@ -201,7 +198,9 @@ data Conversation = Conversation
   { -- | A qualified conversation ID
     cnvQualifiedId :: Qualified ConvId,
     cnvMetadata :: ConversationMetadata,
-    cnvMembers :: ConvMembers
+    cnvMembers :: ConvMembers,
+    -- | The protocol of the conversation. It can be Proteus or MLS (1.0).
+    cnvProtocol :: Protocol
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform Conversation)
@@ -242,6 +241,7 @@ instance ToSchema Conversation where
           .= optional (field "id" (deprecatedSchema "qualified_id" schema))
         <*> cnvMetadata .= conversationMetadataObjectSchema
         <*> cnvMembers .= field "members" schema
+        <*> cnvProtocol .= protocolSchema
 
 modelConversation :: Doc.Model
 modelConversation = Doc.defineModel "Conversation" $ do

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -23,6 +23,7 @@
 module Wire.API.Conversation
   ( -- * Conversation
     ConversationMetadata (..),
+    defConversationMetadata,
     Conversation (..),
     cnvType,
     cnvCreator,
@@ -137,6 +138,19 @@ data ConversationMetadata = ConversationMetadata
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform ConversationMetadata)
   deriving (FromJSON, ToJSON) via Schema ConversationMetadata
+
+defConversationMetadata :: UserId -> ConversationMetadata
+defConversationMetadata creator =
+  ConversationMetadata
+    { cnvmType = RegularConv,
+      cnvmCreator = creator,
+      cnvmAccess = [PrivateAccess],
+      cnvmAccessRoles = mempty,
+      cnvmName = Nothing,
+      cnvmTeam = Nothing,
+      cnvmMessageTimer = Nothing,
+      cnvmReceiptMode = Nothing
+    }
 
 accessRolesSchema :: ObjectSchema SwaggerDoc (Set AccessRoleV2)
 accessRolesSchema = toOutput .= accessRolesSchemaTuple `withParser` validate

--- a/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
@@ -27,6 +27,7 @@ where
 
 import Control.Arrow
 import Control.Lens (makePrisms, (?~))
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Schema
 import Imports
 import Wire.API.Arbitrary
@@ -73,7 +74,13 @@ protocolSchema =
     .= bind
       (fst .= protocolTagSchema)
       (snd .= dispatch protocolDataSchema)
-  where
+
+instance ToSchema Protocol where
+  schema = object "Protocol" protocolSchema
+
+deriving via (Schema Protocol) instance FromJSON Protocol
+
+deriving via (Schema Protocol) instance ToJSON Protocol
 
 protocolDataSchema :: ProtocolTag -> ObjectSchema SwaggerDoc Protocol
 protocolDataSchema ProtocolProteusTag = tag _ProtocolProteus (pure ())

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/ConversationList_20Conversation_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/ConversationList_20Conversation_user.hs
@@ -27,6 +27,7 @@ import qualified Data.Set as Set
 import qualified Data.UUID as UUID (fromString)
 import Imports
 import Wire.API.Conversation
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role (parseRoleName)
 
 domain :: Domain
@@ -48,8 +49,7 @@ testObject_ConversationList_20Conversation_user_1 =
                     cnvmTeam = Just (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000001"))),
                     cnvmMessageTimer = Just (Ms {ms = 4760386328981119}),
                     cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = 0}),
-                    cnvmProtocol = ProtocolProteus,
-                    cnvmGroupId = Nothing
+                    cnvmProtocol = ProtocolProteus
                   },
               cnvMembers =
                 ConvMembers

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/ConversationList_20Conversation_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/ConversationList_20Conversation_user.hs
@@ -48,9 +48,9 @@ testObject_ConversationList_20Conversation_user_1 =
                     cnvmName = Just "",
                     cnvmTeam = Just (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000100000001"))),
                     cnvmMessageTimer = Just (Ms {ms = 4760386328981119}),
-                    cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = 0}),
-                    cnvmProtocol = ProtocolProteus
+                    cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = 0})
                   },
+              cnvProtocol = ProtocolProteus,
               cnvMembers =
                 ConvMembers
                   { cmSelf =

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Conversation_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Conversation_user.hs
@@ -47,9 +47,9 @@ testObject_Conversation_user_1 =
             cnvmName = Just " 0",
             cnvmTeam = Just (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000100000002"))),
             cnvmMessageTimer = Nothing,
-            cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = -2}),
-            cnvmProtocol = ProtocolProteus
+            cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = -2})
           },
+      cnvProtocol = ProtocolProteus,
       cnvMembers =
         ConvMembers
           { cmSelf =
@@ -94,9 +94,9 @@ testObject_Conversation_user_2 =
             cnvmName = Just "",
             cnvmTeam = Nothing,
             cnvmMessageTimer = Just (Ms {ms = 1319272593797015}),
-            cnvmReceiptMode = Nothing,
-            cnvmProtocol = ProtocolProteus
+            cnvmReceiptMode = Nothing
           },
+      cnvProtocol = ProtocolProteus,
       cnvMembers =
         ConvMembers
           { cmSelf =

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Conversation_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Conversation_user.hs
@@ -27,6 +27,7 @@ import qualified Data.Set as Set
 import qualified Data.UUID as UUID (fromString)
 import Imports
 import Wire.API.Conversation
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role (parseRoleName)
 import Wire.API.Provider.Service (ServiceRef (ServiceRef, _serviceRefId, _serviceRefProvider))
 
@@ -47,8 +48,7 @@ testObject_Conversation_user_1 =
             cnvmTeam = Just (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000100000002"))),
             cnvmMessageTimer = Nothing,
             cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = -2}),
-            cnvmProtocol = ProtocolProteus,
-            cnvmGroupId = Nothing
+            cnvmProtocol = ProtocolProteus
           },
       cnvMembers =
         ConvMembers
@@ -95,8 +95,7 @@ testObject_Conversation_user_2 =
             cnvmTeam = Nothing,
             cnvmMessageTimer = Just (Ms {ms = 1319272593797015}),
             cnvmReceiptMode = Nothing,
-            cnvmProtocol = ProtocolProteus,
-            cnvmGroupId = Nothing
+            cnvmProtocol = ProtocolProteus
           },
       cnvMembers =
         ConvMembers

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
@@ -30,6 +30,7 @@ import qualified Data.UUID as UUID (fromString)
 import Imports
 import Wire.API.Conversation
 import Wire.API.Conversation.Code (Key (..), Value (..))
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role (parseRoleName)
 import Wire.API.Conversation.Typing (TypingStatus (..))
 import Wire.API.Event.Conversation
@@ -147,8 +148,7 @@ testObject_Event_user_8 =
                     cnvmTeam = Just (Id (fromJust (UUID.fromString "00000000-0000-0002-0000-000100000001"))),
                     cnvmMessageTimer = Just (Ms {ms = 283898987885780}),
                     cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = -1}),
-                    cnvmProtocol = ProtocolProteus,
-                    cnvmGroupId = Nothing
+                    cnvmProtocol = ProtocolProteus
                   },
               cnvMembers =
                 ConvMembers

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
@@ -147,9 +147,9 @@ testObject_Event_user_8 =
                     cnvmName = Just "\a\SO\r",
                     cnvmTeam = Just (Id (fromJust (UUID.fromString "00000000-0000-0002-0000-000100000001"))),
                     cnvmMessageTimer = Just (Ms {ms = 283898987885780}),
-                    cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = -1}),
-                    cnvmProtocol = ProtocolProteus
+                    cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = -1})
                   },
+              cnvProtocol = ProtocolProteus,
               cnvMembers =
                 ConvMembers
                   { cmSelf =

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/NewConv_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/NewConv_user.hs
@@ -26,6 +26,7 @@ import qualified Data.Set as Set (fromList)
 import qualified Data.UUID as UUID (fromString)
 import Imports
 import Wire.API.Conversation
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 
 testDomain :: Domain
@@ -51,7 +52,7 @@ testObject_NewConv_user_1 =
       newConvMessageTimer = Just (Ms {ms = 3320987366258987}),
       newConvReceiptMode = Just (ReceiptMode {unReceiptMode = 1}),
       newConvUsersRole = fromJust (parseRoleName "8tp2gs7b6"),
-      newConvProtocol = ProtocolProteus
+      newConvProtocol = ProtocolProteusTag
     }
 
 testObject_NewConv_user_3 :: NewConv
@@ -70,5 +71,5 @@ testObject_NewConv_user_3 =
           ( parseRoleName
               "y3otpiwu615lvvccxsq0315jj75jquw01flhtuf49t6mzfurvwe3_sh51f4s257e2x47zo85rif_xyiyfldpan3g4r6zr35rbwnzm0k"
           ),
-      newConvProtocol = ProtocolMLS
+      newConvProtocol = ProtocolMLSTag
     }

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationsResponse.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationsResponse.hs
@@ -61,8 +61,7 @@ conv1 =
             cnvmName = Just " 0",
             cnvmTeam = Just (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000100000002"))),
             cnvmMessageTimer = Nothing,
-            cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = -2}),
-            cnvmProtocol = ProtocolProteus
+            cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = -2})
           },
       cnvMembers =
         ConvMembers
@@ -79,7 +78,8 @@ conv1 =
                   memConvRoleName = fromJust (parseRoleName "rhhdzf0j0njilixx0g0vzrp06b_5us")
                 },
             cmOthers = []
-          }
+          },
+      cnvProtocol = ProtocolProteus
     }
 
 conv2 :: Conversation
@@ -108,8 +108,7 @@ conv2 =
             cnvmName = Just "",
             cnvmTeam = Just (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000200000000"))),
             cnvmMessageTimer = Just (Ms {ms = 1319272593797015}),
-            cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = 2}),
-            cnvmProtocol = ProtocolMLS (ConversationMLSData (GroupId ("test_group")))
+            cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = 2})
           },
       cnvMembers =
         ConvMembers
@@ -127,5 +126,6 @@ conv2 =
                     fromJust (parseRoleName "9b2d3thyqh4ptkwtq2n2v9qsni_ln1ca66et_z8dlhfs9oamp328knl3rj9kcj")
                 },
             cmOthers = []
-          }
+          },
+      cnvProtocol = ProtocolMLS (ConversationMLSData (GroupId ("test_group")))
     }

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationsResponse.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationsResponse.hs
@@ -28,6 +28,7 @@ import qualified Data.Set as Set
 import qualified Data.UUID as UUID
 import Imports
 import Wire.API.Conversation
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 
 domain :: Domain
@@ -61,8 +62,7 @@ conv1 =
             cnvmTeam = Just (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000100000002"))),
             cnvmMessageTimer = Nothing,
             cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = -2}),
-            cnvmProtocol = ProtocolProteus,
-            cnvmGroupId = Nothing
+            cnvmProtocol = ProtocolProteus
           },
       cnvMembers =
         ConvMembers
@@ -109,8 +109,7 @@ conv2 =
             cnvmTeam = Just (Id (fromJust (UUID.fromString "00000000-0000-0001-0000-000200000000"))),
             cnvmMessageTimer = Just (Ms {ms = 1319272593797015}),
             cnvmReceiptMode = Just (ReceiptMode {unReceiptMode = 2}),
-            cnvmProtocol = ProtocolMLS,
-            cnvmGroupId = Just . GroupId $ "test_group"
+            cnvmProtocol = ProtocolMLS (ConversationMLSData (GroupId ("test_group")))
           },
       cnvMembers =
         ConvMembers

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -26,6 +26,7 @@ library
       Wire.API.Conversation.Bot
       Wire.API.Conversation.Code
       Wire.API.Conversation.Member
+      Wire.API.Conversation.Protocol
       Wire.API.Conversation.Role
       Wire.API.Conversation.Typing
       Wire.API.Cookie

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -1295,7 +1295,7 @@ createConvWithAccessRoles ars g u us =
       . contentJson
       . body (RequestBodyLBS (encode conv))
   where
-    conv = NewConv us [] Nothing Set.empty ars Nothing Nothing Nothing roleNameWireAdmin ProtocolProteus
+    conv = NewConv us [] Nothing Set.empty ars Nothing Nothing Nothing roleNameWireAdmin ProtocolProteusTag
 
 postMessage ::
   Galley ->

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -212,7 +212,7 @@ createTeamConv :: HasCallStack => Galley -> TeamId -> UserId -> [UserId] -> Mayb
 createTeamConv g tid u us mtimer = do
   let tinfo = Just $ ConvTeamInfo tid
   let conv =
-        NewConv us [] Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin ProtocolProteus
+        NewConv us [] Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin ProtocolProteusTag
   r <-
     post
       ( g

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -252,7 +252,7 @@ testAddRemoteUsersToLocalConv brig1 galley1 brig2 galley2 = do
         NewConv
           []
           []
-          (Just "gossip")
+          (checked "gossip")
           mempty
           Nothing
           Nothing

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -51,6 +51,7 @@ import Util
 import Util.Options (Endpoint)
 import Wire.API.Asset
 import Wire.API.Conversation
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.Event.Conversation
 import Wire.API.Message
@@ -258,7 +259,7 @@ testAddRemoteUsersToLocalConv brig1 galley1 brig2 galley2 = do
           Nothing
           Nothing
           roleNameWireAdmin
-          ProtocolProteus
+          ProtocolProteusTag
   convId <-
     fmap cnvQualifiedId . responseJsonError
       =<< post

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -700,7 +700,7 @@ createConversation galley zusr usersToAdd = do
         NewConv
           []
           usersToAdd
-          (Just "gossip")
+          (checked "gossip")
           mempty
           Nothing
           Nothing

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -125,6 +125,7 @@ import qualified UnliftIO.Async as Async
 import Util.AWS
 import Util.Options
 import Wire.API.Conversation
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.Federation.API
 import Wire.API.Federation.Domain
@@ -706,7 +707,7 @@ createConversation galley zusr usersToAdd = do
           Nothing
           Nothing
           roleNameWireAdmin
-          ProtocolProteus
+          ProtocolProteusTag
   post $
     galley
       . path "/conversations"

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -51,6 +51,7 @@ import Data.Time.Clock
 import Galley.API.Error
 import Galley.API.Util
 import Galley.Data.Conversation
+import qualified Galley.Data.Conversation as Data
 import Galley.Data.Services
 import Galley.Data.Types
 import Galley.Effects
@@ -217,11 +218,11 @@ performAction origUser lcnv cnv action =
       E.setConversationName (tUnqualified lcnv) cn
       pure (mempty, action)
     SConversationMessageTimerUpdateTag -> do
-      when (convMessageTimer cnv == cupMessageTimer action) noChanges
+      when (Data.convMessageTimer cnv == cupMessageTimer action) noChanges
       E.setConversationMessageTimer (tUnqualified lcnv) (cupMessageTimer action)
       pure (mempty, action)
     SConversationReceiptModeUpdateTag -> do
-      when (convReceiptMode cnv == Just (cruReceiptMode action)) noChanges
+      when (Data.convReceiptMode cnv == Just (cruReceiptMode action)) noChanges
       E.setConversationReceiptMode (tUnqualified lcnv) (cruReceiptMode action)
       pure (mempty, action)
     SConversationAccessDataTag -> do

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -62,6 +62,7 @@ import Polysemy.Error
 import Polysemy.Input
 import qualified Polysemy.TinyLog as P
 import Wire.API.Conversation hiding (Conversation, Member)
+import Wire.API.Conversation.Protocol
 import Wire.API.ErrorDescription
 import Wire.API.Event.Conversation hiding (Conversation)
 import Wire.API.Federation.Error
@@ -102,8 +103,8 @@ createGroupConversation lusr conn newConv = do
   name <- rangeCheckedMaybe (newConvName newConv)
   o <- input
   checkedUsers <- case newConvProtocol newConv of
-    ProtocolProteus -> checkedConvSize o allUsers
-    ProtocolMLS -> do
+    ProtocolProteusTag -> checkedConvSize o allUsers
+    ProtocolMLSTag -> do
       unless (null allUsers) $ throw MLSNonEmptyMemberList
       pure mempty
   checkCreateConvPermissions lusr newConv tinfo allUsers

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -428,7 +428,7 @@ createConnectConversation lusr conn j = do
             p
               & pushRoute .~ RouteDirect
               & pushConn .~ conn
-        return $ conv {Data.convName = n'}
+        pure $ Data.convSetName n' conv
       | otherwise = return conv
 
 -------------------------------------------------------------------------------

--- a/services/galley/src/Galley/API/Mapping.hs
+++ b/services/galley/src/Galley/API/Mapping.hs
@@ -78,6 +78,7 @@ conversationViewMaybe luid conv = do
       (qUntagged . qualifyAs luid . convId $ conv)
       (Data.convMetadata conv)
       (ConvMembers self others)
+      (Data.convProtocol conv)
 
 -- | View for a local user of a remote conversation.
 remoteConversationView ::
@@ -97,7 +98,11 @@ remoteConversationView uid status (qUntagged -> Qualified rconv rDomain) =
               lmStatus = status,
               lmConvRoleName = rcmSelfRole mems
             }
-   in Conversation (Qualified (rcnvId rconv) rDomain) (rcnvMetadata rconv) (ConvMembers self others)
+   in Conversation
+        (Qualified (rcnvId rconv) rDomain)
+        (rcnvMetadata rconv)
+        (ConvMembers self others)
+        (rcnvProtocol rconv)
 
 -- | Convert a local conversation to a structure to be returned to a remote
 -- backend.
@@ -123,7 +128,8 @@ conversationToRemote localDomain ruid conv = do
           RemoteConvMembers
             { rcmSelfRole = selfRole,
               rcmOthers = others
-            }
+            },
+        rcnvProtocol = Data.convProtocol conv
       }
 
 -- | Convert a local conversation member (as stored in the DB) to a publicly

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -70,8 +70,8 @@ import Galley.API.Error
 import qualified Galley.API.Mapping as Mapping
 import Galley.API.Util
 import Galley.Cassandra.Paging
+import qualified Galley.Data.Conversation as Data
 import Galley.Data.Types (Code (codeConversation))
-import qualified Galley.Data.Types as Data
 import Galley.Effects
 import qualified Galley.Effects.ConversationStore as E
 import qualified Galley.Effects.FederatorAccess as E

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -558,7 +558,7 @@ addCode ::
   Sem r AddCodeResult
 addCode lusr zcon lcnv = do
   conv <- E.getConversation (tUnqualified lcnv) >>= note ConvNotFound
-  Query.ensureGuestLinksEnabled (convTeam conv)
+  Query.ensureGuestLinksEnabled (Data.convTeam conv)
   Query.ensureConvAdmin (Data.convLocalMembers conv) (tUnqualified lusr)
   ensureAccess conv CodeAccess
   ensureGuestsOrNonTeamMembersAllowed conv
@@ -583,7 +583,11 @@ addCode lusr zcon lcnv = do
       mkConversationCode (codeKey code) (codeValue code) <$> E.getConversationCodeURI
     ensureGuestsOrNonTeamMembersAllowed :: Data.Conversation -> Sem r ()
     ensureGuestsOrNonTeamMembersAllowed conv =
-      unless (GuestAccessRole `Set.member` convAccessRoles conv || NonTeamMemberAccessRole `Set.member` convAccessRoles conv) $ throw ConvAccessDenied
+      unless
+        ( GuestAccessRole `Set.member` Data.convAccessRoles conv
+            || NonTeamMemberAccessRole `Set.member` Data.convAccessRoles conv
+        )
+        $ throw ConvAccessDenied
 
 rmCodeUnqualified ::
   Members
@@ -646,7 +650,7 @@ getCode ::
 getCode lusr cnv = do
   conv <-
     E.getConversation cnv >>= note ConvNotFound
-  Query.ensureGuestLinksEnabled (convTeam conv)
+  Query.ensureGuestLinksEnabled (Data.convTeam conv)
   ensureAccess conv CodeAccess
   ensureConvMember (Data.convLocalMembers conv) (tUnqualified lusr)
   key <- E.makeKey cnv
@@ -672,7 +676,7 @@ checkReusableCode ::
 checkReusableCode convCode = do
   code <- verifyReusableCode convCode
   conv <- E.getConversation (codeConversation code) >>= note ConvNotFound
-  Query.ensureGuestLinksEnabledWithError (Right CodeNotFound) (convTeam conv)
+  Query.ensureGuestLinksEnabledWithError (Right CodeNotFound) (Data.convTeam conv)
 
 joinConversationByReusableCode ::
   Members
@@ -700,7 +704,7 @@ joinConversationByReusableCode ::
 joinConversationByReusableCode lusr zcon convCode = do
   c <- verifyReusableCode convCode
   conv <- E.getConversation (codeConversation c) >>= note ConvNotFound
-  Query.ensureGuestLinksEnabled (convTeam conv)
+  Query.ensureGuestLinksEnabled (Data.convTeam conv)
   joinConversation lusr zcon conv CodeAccess
 
 joinConversationById ::

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -665,8 +665,7 @@ fromNewRemoteConversation loc rc@NewRemoteConversation {..} =
             cnvmTeam = Nothing,
             cnvmMessageTimer = rcMessageTimer,
             cnvmReceiptMode = rcReceiptMode,
-            cnvmProtocol = ProtocolProteus,
-            cnvmGroupId = Nothing
+            cnvmProtocol = ProtocolProteus
           }
         (ConvMembers this others)
 

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -272,7 +272,7 @@ acceptOne2One lusr conv conn = do
     mems = Data.convLocalMembers conv
     promote = do
       acceptConnectConversation cid
-      return $ conv {Data.convType = One2OneConv}
+      pure $ Data.convSetType One2OneConv conv
 
 memberJoinEvent ::
   Local UserId ->
@@ -584,18 +584,18 @@ toNewRemoteConversation ::
   Data.Conversation ->
   -- | The resulting information to be sent to a remote Galley
   NewRemoteConversation ConvId
-toNewRemoteConversation now localDomain Data.Conversation {..} =
+toNewRemoteConversation now localDomain Data.Conversation {convMetadata = ConversationMetadata {..}, ..} =
   NewRemoteConversation
     { rcTime = now,
-      rcOrigUserId = convCreator,
+      rcOrigUserId = cnvmCreator,
       rcCnvId = convId,
-      rcCnvType = convType,
-      rcCnvAccess = convAccess,
-      rcCnvAccessRoles = convAccessRoles,
-      rcCnvName = convName,
-      rcNonCreatorMembers = toMembers (filter (\lm -> lmId lm /= convCreator) convLocalMembers) convRemoteMembers,
-      rcMessageTimer = convMessageTimer,
-      rcReceiptMode = convReceiptMode
+      rcCnvType = cnvmType,
+      rcCnvAccess = cnvmAccess,
+      rcCnvAccessRoles = cnvmAccessRoles,
+      rcCnvName = cnvmName,
+      rcNonCreatorMembers = toMembers (filter (\lm -> lmId lm /= cnvmCreator) convLocalMembers) convRemoteMembers,
+      rcMessageTimer = cnvmMessageTimer,
+      rcReceiptMode = cnvmReceiptMode
     }
   where
     toMembers ::

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -664,10 +664,10 @@ fromNewRemoteConversation loc rc@NewRemoteConversation {..} =
             -- domain.
             cnvmTeam = Nothing,
             cnvmMessageTimer = rcMessageTimer,
-            cnvmReceiptMode = rcReceiptMode,
-            cnvmProtocol = ProtocolProteus
+            cnvmReceiptMode = rcReceiptMode
           }
         (ConvMembers this others)
+        ProtocolProteus
 
 -- | Notify remote users of being added to a new conversation
 registerRemoteConversationMemberships ::

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -80,6 +80,7 @@ createConversation loc (NewConversation ty usr acc arole name mtid mtimer recpt 
         convLocalMembers = lmems,
         convRemoteMembers = rmems,
         convDeleted = Nothing,
+        convProtocol = protocol,
         convMetadata =
           ConversationMetadata
             { cnvmType = ty,
@@ -89,8 +90,7 @@ createConversation loc (NewConversation ty usr acc arole name mtid mtimer recpt 
               cnvmAccessRoles = arole,
               cnvmTeam = mtid,
               cnvmMessageTimer = mtimer,
-              cnvmReceiptMode = recpt,
-              cnvmProtocol = protocol
+              cnvmReceiptMode = recpt
             }
       }
   where
@@ -123,6 +123,7 @@ createConnectConversation a b name = do
         convDeleted = Nothing,
         convLocalMembers = lmems,
         convRemoteMembers = rmems,
+        convProtocol = ProtocolProteus,
         convMetadata =
           ConversationMetadata
             { cnvmType = ConnectConv,
@@ -132,8 +133,7 @@ createConnectConversation a b name = do
               cnvmAccessRoles = Set.empty,
               cnvmTeam = Nothing,
               cnvmMessageTimer = Nothing,
-              cnvmReceiptMode = Nothing,
-              cnvmProtocol = ProtocolProteus
+              cnvmReceiptMode = Nothing
             }
       }
 
@@ -154,6 +154,7 @@ createConnectConversationWithRemote cid creator m = do
         convLocalMembers = lmems,
         convRemoteMembers = rmems,
         convDeleted = Nothing,
+        convProtocol = ProtocolProteus,
         convMetadata =
           ConversationMetadata
             { cnvmType = ConnectConv,
@@ -163,8 +164,7 @@ createConnectConversationWithRemote cid creator m = do
               cnvmAccessRoles = Set.empty,
               cnvmTeam = Nothing,
               cnvmMessageTimer = Nothing,
-              cnvmReceiptMode = Nothing,
-              cnvmProtocol = ProtocolProteus
+              cnvmReceiptMode = Nothing
             }
       }
 
@@ -208,6 +208,7 @@ createOne2OneConversation conv self other name mtid = do
         convLocalMembers = lmems,
         convRemoteMembers = rmems,
         convDeleted = Nothing,
+        convProtocol = ProtocolProteus,
         convMetadata =
           ConversationMetadata
             { cnvmType = ConnectConv,
@@ -217,8 +218,7 @@ createOne2OneConversation conv self other name mtid = do
               cnvmAccessRoles = Set.empty,
               cnvmTeam = Nothing,
               cnvmMessageTimer = Nothing,
-              cnvmReceiptMode = Nothing,
-              cnvmProtocol = ProtocolProteus
+              cnvmReceiptMode = Nothing
             }
       }
 
@@ -236,6 +236,7 @@ createSelfConversation lusr name = do
         convLocalMembers = lmems,
         convRemoteMembers = rmems,
         convDeleted = Nothing,
+        convProtocol = ProtocolProteus,
         convMetadata =
           ConversationMetadata
             { cnvmType = SelfConv,
@@ -245,8 +246,7 @@ createSelfConversation lusr name = do
               cnvmAccessRoles = Set.empty,
               cnvmTeam = Nothing,
               cnvmMessageTimer = Nothing,
-              cnvmReceiptMode = Nothing,
-              cnvmProtocol = ProtocolProteus
+              cnvmReceiptMode = Nothing
             }
       }
 
@@ -267,11 +267,10 @@ conversationMeta conv =
   (toConvMeta =<<)
     <$> retry x1 (query1 Cql.selectConv (params LocalQuorum (Identity conv)))
   where
-    toConvMeta (t, c, a, r, r', n, i, _, mt, rm, p, gid) = do
+    toConvMeta (t, c, a, r, r', n, i, _, mt, rm, _, _) = do
       let mbAccessRolesV2 = Set.fromList . Cql.fromSet <$> r'
           accessRoles = maybeRole t $ parseAccessRoles r mbAccessRolesV2
-      proto <- toProtocol p gid
-      pure $ ConversationMetadata t c (defAccess t a) accessRoles n i mt rm proto
+      pure $ ConversationMetadata t c (defAccess t a) accessRoles n i mt rm
 
 isConvAlive :: ConvId -> Client Bool
 isConvAlive cid = do
@@ -410,6 +409,7 @@ toConv cid ms remoteMems mconv = do
         convDeleted = del,
         convLocalMembers = ms,
         convRemoteMembers = remoteMems,
+        convProtocol = proto,
         convMetadata =
           ConversationMetadata
             { cnvmType = cty,
@@ -419,8 +419,7 @@ toConv cid ms remoteMems mconv = do
               cnvmName = nme,
               cnvmTeam = ti,
               cnvmMessageTimer = timer,
-              cnvmReceiptMode = rm,
-              cnvmProtocol = proto
+              cnvmReceiptMode = rm
             }
       }
 

--- a/services/galley/src/Galley/Cassandra/Instances.hs
+++ b/services/galley/src/Galley/Cassandra/Instances.hs
@@ -173,15 +173,15 @@ instance Cql Public.EnforceAppLock where
     _ -> Left "fromCql EnforceAppLock: int out of range"
   fromCql _ = Left "fromCql EnforceAppLock: int expected"
 
-instance Cql Protocol where
+instance Cql ProtocolTag where
   ctype = Tagged IntColumn
 
-  toCql ProtocolProteus = CqlInt 0
-  toCql ProtocolMLS = CqlInt 1
+  toCql ProtocolProteusTag = CqlInt 0
+  toCql ProtocolMLSTag = CqlInt 1
 
   fromCql (CqlInt i) = case i of
-    0 -> return ProtocolProteus
-    1 -> return ProtocolMLS
+    0 -> return ProtocolProteusTag
+    1 -> return ProtocolMLSTag
     n -> Left $ "unexpected protocol: " ++ show n
   fromCql _ = Left "protocol: int expected"
 

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -189,10 +189,10 @@ updateTeamStatus = "update team set status = ? where team = ?"
 
 -- Conversations ------------------------------------------------------------
 
-selectConv :: PrepQuery R (Identity ConvId) (ConvType, UserId, Maybe (C.Set Access), Maybe AccessRoleLegacy, Maybe (C.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe Protocol, Maybe GroupId)
+selectConv :: PrepQuery R (Identity ConvId) (ConvType, UserId, Maybe (C.Set Access), Maybe AccessRoleLegacy, Maybe (C.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe ProtocolTag, Maybe GroupId)
 selectConv = "select type, creator, access, access_role, access_roles_v2, name, team, deleted, message_timer, receipt_mode, protocol, group_id from conversation where conv = ?"
 
-selectConvs :: PrepQuery R (Identity [ConvId]) (ConvId, ConvType, UserId, Maybe (C.Set Access), Maybe AccessRoleLegacy, Maybe (C.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe Protocol, Maybe GroupId)
+selectConvs :: PrepQuery R (Identity [ConvId]) (ConvId, ConvType, UserId, Maybe (C.Set Access), Maybe AccessRoleLegacy, Maybe (C.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe ProtocolTag, Maybe GroupId)
 selectConvs = "select conv, type, creator, access, access_role, access_roles_v2, name, team, deleted, message_timer, receipt_mode, protocol, group_id from conversation where conv in ?"
 
 selectReceiptMode :: PrepQuery R (Identity ConvId) (Identity (Maybe ReceiptMode))
@@ -201,7 +201,7 @@ selectReceiptMode = "select receipt_mode from conversation where conv = ?"
 isConvDeleted :: PrepQuery R (Identity ConvId) (Identity (Maybe Bool))
 isConvDeleted = "select deleted from conversation where conv = ?"
 
-insertConv :: PrepQuery W (ConvId, ConvType, UserId, C.Set Access, C.Set AccessRoleV2, Maybe Text, Maybe TeamId, Maybe Milliseconds, Maybe ReceiptMode, Protocol, Maybe GroupId) ()
+insertConv :: PrepQuery W (ConvId, ConvType, UserId, C.Set Access, C.Set AccessRoleV2, Maybe Text, Maybe TeamId, Maybe Milliseconds, Maybe ReceiptMode, ProtocolTag, Maybe GroupId) ()
 insertConv = "insert into conversation (conv, type, creator, access, access_roles_v2, name, team, message_timer, receipt_mode, protocol, group_id) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
 updateConvAccess :: PrepQuery W (C.Set Access, C.Set AccessRoleV2, ConvId) ()

--- a/services/galley/src/Galley/Data/Conversation/Types.hs
+++ b/services/galley/src/Galley/Data/Conversation/Types.hs
@@ -25,6 +25,7 @@ import Galley.Types.UserList
 import Galley.Validation
 import Imports
 import Wire.API.Conversation hiding (Conversation)
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 
 -- | Internal conversation type, corresponding directly to database schema.
@@ -50,5 +51,5 @@ data NewConversation = NewConversation
     ncReceiptMode :: Maybe ReceiptMode,
     ncUsers :: ConvSizeChecked UserList UserId,
     ncRole :: RoleName,
-    ncProtocol :: Protocol
+    ncProtocol :: ProtocolTag
   }

--- a/services/galley/src/Galley/Data/Conversation/Types.hs
+++ b/services/galley/src/Galley/Data/Conversation/Types.hs
@@ -32,20 +32,10 @@ import Wire.API.Conversation.Role
 -- 'ToJSON' instances).
 data Conversation = Conversation
   { convId :: ConvId,
-    convType :: ConvType,
-    convCreator :: UserId,
-    convName :: Maybe Text,
-    convAccess :: [Access],
-    convAccessRoles :: Set AccessRoleV2,
     convLocalMembers :: [LocalMember],
     convRemoteMembers :: [RemoteMember],
-    convTeam :: Maybe TeamId,
     convDeleted :: Maybe Bool,
-    -- | Global message timer
-    convMessageTimer :: Maybe Milliseconds,
-    convReceiptMode :: Maybe ReceiptMode,
-    convProtocol :: Maybe Protocol,
-    convGroupId :: Maybe GroupId
+    convMetadata :: ConversationMetadata
   }
   deriving (Show)
 

--- a/services/galley/src/Galley/Data/Conversation/Types.hs
+++ b/services/galley/src/Galley/Data/Conversation/Types.hs
@@ -20,7 +20,6 @@ module Galley.Data.Conversation.Types where
 import Data.Id
 import Galley.Types.Conversations.Members
 import Galley.Types.UserList
-import Galley.Validation
 import Imports
 import Wire.API.Conversation hiding (Conversation)
 import Wire.API.Conversation.Protocol
@@ -41,7 +40,6 @@ data Conversation = Conversation
 
 data NewConversation = NewConversation
   { ncMetadata :: ConversationMetadata,
-    ncUsers :: ConvSizeChecked UserList UserId,
-    ncRole :: RoleName,
+    ncUsers :: UserList (UserId, RoleName),
     ncProtocol :: ProtocolTag
   }

--- a/services/galley/src/Galley/Data/Conversation/Types.hs
+++ b/services/galley/src/Galley/Data/Conversation/Types.hs
@@ -18,8 +18,6 @@
 module Galley.Data.Conversation.Types where
 
 import Data.Id
-import Data.Misc
-import Data.Range
 import Galley.Types.Conversations.Members
 import Galley.Types.UserList
 import Galley.Validation
@@ -42,14 +40,7 @@ data Conversation = Conversation
   deriving (Show)
 
 data NewConversation = NewConversation
-  { ncType :: ConvType,
-    ncCreator :: UserId,
-    ncAccess :: [Access],
-    ncAccessRoles :: Set AccessRoleV2,
-    ncName :: Maybe (Range 1 256 Text),
-    ncTeam :: Maybe TeamId,
-    ncMessageTimer :: Maybe Milliseconds,
-    ncReceiptMode :: Maybe ReceiptMode,
+  { ncMetadata :: ConversationMetadata,
     ncUsers :: ConvSizeChecked UserList UserId,
     ncRole :: RoleName,
     ncProtocol :: ProtocolTag

--- a/services/galley/src/Galley/Data/Conversation/Types.hs
+++ b/services/galley/src/Galley/Data/Conversation/Types.hs
@@ -36,7 +36,8 @@ data Conversation = Conversation
     convLocalMembers :: [LocalMember],
     convRemoteMembers :: [RemoteMember],
     convDeleted :: Maybe Bool,
-    convMetadata :: ConversationMetadata
+    convMetadata :: ConversationMetadata,
+    convProtocol :: Protocol
   }
   deriving (Show)
 

--- a/services/galley/src/Galley/Effects/ConversationStore.hs
+++ b/services/galley/src/Galley/Effects/ConversationStore.hs
@@ -20,12 +20,8 @@ module Galley.Effects.ConversationStore
     ConversationStore (..),
 
     -- * Create conversation
+    createConversationId,
     createConversation,
-    createConnectConversation,
-    createConnectConversationWithRemote,
-    createLegacyOne2OneConversation,
-    createOne2OneConversation,
-    createSelfConversation,
 
     -- * Read conversation
     getConversation,
@@ -54,44 +50,15 @@ import Data.Id
 import Data.Misc
 import Data.Qualified
 import Data.Range
-import Data.UUID.Tagged
 import Galley.Data.Conversation
 import Galley.Types.Conversations.Members
-import Galley.Types.UserList
 import Imports
 import Polysemy
 import Wire.API.Conversation hiding (Conversation, Member)
 
 data ConversationStore m a where
-  CreateConversation :: Local x -> NewConversation -> ConversationStore m Conversation
-  CreateConnectConversation ::
-    UUID V4 ->
-    UUID V4 ->
-    Maybe (Range 1 256 Text) ->
-    ConversationStore m Conversation
-  CreateConnectConversationWithRemote ::
-    ConvId ->
-    UserId ->
-    UserList UserId ->
-    ConversationStore m Conversation
-  CreateLegacyOne2OneConversation ::
-    Local x ->
-    UUID V4 ->
-    UUID V4 ->
-    Maybe (Range 1 256 Text) ->
-    Maybe TeamId ->
-    ConversationStore m Conversation
-  CreateOne2OneConversation ::
-    ConvId ->
-    Local UserId ->
-    Qualified UserId ->
-    Maybe (Range 1 256 Text) ->
-    Maybe TeamId ->
-    ConversationStore m Conversation
-  CreateSelfConversation ::
-    Local UserId ->
-    Maybe (Range 1 256 Text) ->
-    ConversationStore m Conversation
+  CreateConversationId :: ConversationStore m ConvId
+  CreateConversation :: Local ConvId -> NewConversation -> ConversationStore m Conversation
   DeleteConversation :: ConvId -> ConversationStore m ()
   GetConversation :: ConvId -> ConversationStore m (Maybe Conversation)
   GetConversations :: [ConvId] -> ConversationStore m [Conversation]

--- a/services/galley/src/Galley/Types/UserList.hs
+++ b/services/galley/src/Galley/Types/UserList.hs
@@ -20,6 +20,8 @@ module Galley.Types.UserList
     toUserList,
     ulAddLocal,
     ulAll,
+    ulFromLocals,
+    ulFromRemotes,
   )
 where
 
@@ -48,3 +50,9 @@ ulAddLocal x ul = ul {ulLocals = x : ulLocals ul}
 
 ulAll :: Local x -> UserList a -> [Qualified a]
 ulAll loc ul = map (qUntagged . qualifyAs loc) (ulLocals ul) <> map qUntagged (ulRemotes ul)
+
+ulFromLocals :: [a] -> UserList a
+ulFromLocals = flip UserList []
+
+ulFromRemotes :: [Remote a] -> UserList a
+ulFromRemotes = UserList []

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2307,7 +2307,6 @@ accessConvMeta = do
           Nothing
           Nothing
           Nothing
-          ProtocolProteus
   get (g . paths ["i/conversations", toByteString' conv, "meta"] . zUser alice) !!! do
     const 200 === statusCode
     const (Just meta) === (decode <=< responseBody)
@@ -2450,6 +2449,7 @@ testGetQualifiedRemoteConv = do
           remoteConvId
           (rcnvMetadata mockConversation)
           (ConvMembers aliceAsSelfMember (rcmOthers (rcnvMembers mockConversation)))
+          ProtocolProteus
 
   (respAll, _) <-
     withTempMockFederator

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -268,9 +268,6 @@ postProteusConvOk = do
   bob <- randomUser
   jane <- randomUser
   connectUsers alice (list1 bob [jane])
-  -- Ensure name is within range, max size is 256
-  postConv alice [bob, jane] (Just (T.replicate 257 "a")) [] Nothing Nothing
-    !!! const 400 === statusCode
   let nameMaxSize = T.replicate 256 "a"
   WS.bracketR3 c alice bob jane $ \(wsA, wsB, wsJ) -> do
     rsp <-
@@ -334,10 +331,6 @@ postConvWithRemoteUsersOk = do
   qCharlie <- randomQualifiedId cDomain
   qDee <- randomQualifiedId dDomain
   mapM_ (connectWithRemoteUser alice) [qChad, qCharlie, qDee]
-
-  -- Ensure name is within range, max size is 256
-  postConvQualified alice defNewProteusConv {newConvName = checked (T.replicate 257 "a"), newConvQualifiedUsers = [qAlex, qAmy, qChad, qCharlie, qDee]}
-    !!! const 400 === statusCode
 
   let nameMaxSize = T.replicate 256 "a"
   WS.bracketR3 c alice alex amy $ \(wsAlice, wsAlex, wsAmy) -> do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2075,7 +2075,7 @@ postConvQualifiedFederationNotEnabled = do
 -- FUTUREWORK: figure out how to use functions in the TestM monad inside withSettingsOverrides and remove this duplication
 postConvHelper :: (MonadIO m, MonadHttp m) => (Request -> Request) -> UserId -> [Qualified UserId] -> m ResponseLBS
 postConvHelper g zusr newUsers = do
-  let conv = NewConv [] newUsers (Just "gossip") (Set.fromList []) Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolProteus
+  let conv = NewConv [] newUsers (Just "gossip") (Set.fromList []) Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolProteusTag
   post $ g . path "/conversations" . zUser zusr . zConn "conn" . zType "access" . json conv
 
 postSelfConvOk :: TestM ()
@@ -2104,7 +2104,7 @@ postConvO2OFailWithSelf :: TestM ()
 postConvO2OFailWithSelf = do
   g <- view tsGalley
   alice <- randomUser
-  let inv = NewConv [alice] [] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolProteus
+  let inv = NewConv [alice] [] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolProteusTag
   post (g . path "/conversations/one2one" . zUser alice . zConn "conn" . zType "access" . json inv) !!! do
     const 403 === statusCode
     const (Just "invalid-op") === fmap label . responseJsonUnsafe
@@ -2308,7 +2308,6 @@ accessConvMeta = do
           Nothing
           Nothing
           ProtocolProteus
-          Nothing
   get (g . paths ["i/conversations", toByteString' conv, "meta"] . zUser alice) !!! do
     const 200 === statusCode
     const (Just meta) === (decode <=< responseBody)

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -896,9 +896,9 @@ testCreateTeamMLSConv = do
         Nothing
         Nothing
         Nothing
-    Right conv <- fmap cnvMetadata . responseJsonError <$> getConv owner (tUnqualified lConvId)
+    Right conv <- responseJsonError <$> getConv owner (tUnqualified lConvId)
     liftIO $ do
-      assertEqual "protocol mismatch" ProtocolMLSTag (protocolTag (cnvmProtocol conv))
+      assertEqual "protocol mismatch" ProtocolMLSTag (protocolTag (cnvProtocol conv))
     checkConvCreateEvent (tUnqualified lConvId) wsOwner
     WS.assertNoEvent (2 # Second) [wsExtern]
 

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -77,6 +77,7 @@ import Test.Tasty.HUnit
 import TestHelpers (test, viewFederationDomain)
 import TestSetup (TestM, TestSetup, tsBrig, tsCannon, tsGConf, tsGalley)
 import UnliftIO (mapConcurrently, mapConcurrently_)
+import Wire.API.Conversation.Protocol
 import Wire.API.Team (Icon (..))
 import Wire.API.Team.Export (TeamExportUser (..))
 import qualified Wire.API.Team.Feature as Public
@@ -897,8 +898,7 @@ testCreateTeamMLSConv = do
         Nothing
     Right conv <- fmap cnvMetadata . responseJsonError <$> getConv owner (tUnqualified lConvId)
     liftIO $ do
-      assertEqual "protocol mismatch" ProtocolMLS (cnvmProtocol conv)
-      assertEqual "group ID mismatch" True (isJust . cnvmGroupId $ conv)
+      assertEqual "protocol mismatch" ProtocolMLSTag (protocolTag (cnvmProtocol conv))
     checkConvCreateEvent (tUnqualified lConvId) wsOwner
     WS.assertNoEvent (2 # Second) [wsExtern]
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2276,9 +2276,9 @@ mkProteusConv cnvId creator selfRole otherMembers =
         Nothing
         Nothing
         Nothing
-        ProtocolProteus
     )
     (RemoteConvMembers selfRole otherMembers)
+    ProtocolProteus
 
 -- | ES is only refreshed occasionally; we don't want to wait for that in tests.
 refreshIndex :: TestM ()

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -118,18 +118,23 @@ genConversation :: Gen Data.Conversation
 genConversation =
   Data.Conversation
     <$> arbitrary
-    <*> pure RegularConv
-    <*> arbitrary
+    <*> listOf genLocalMember
+    <*> listOf genRemoteMember
+    <*> pure (Just False)
+    <*> genConversationMetadata
+
+genConversationMetadata :: Gen ConversationMetadata
+genConversationMetadata =
+  ConversationMetadata
+    <$> pure RegularConv
     <*> arbitrary
     <*> pure []
     <*> pure (Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole])
-    <*> listOf genLocalMember
-    <*> listOf genRemoteMember
-    <*> pure Nothing
-    <*> pure (Just False)
+    <*> arbitrary
     <*> pure Nothing
     <*> pure Nothing
-    <*> pure (Just ProtocolProteus)
+    <*> pure Nothing
+    <*> pure ProtocolProteus
     <*> pure Nothing
 
 newtype RandomConversation = RandomConversation

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -123,6 +123,7 @@ genConversation =
     <*> listOf genRemoteMember
     <*> pure (Just False)
     <*> genConversationMetadata
+    <*> pure ProtocolProteus
 
 genConversationMetadata :: Gen ConversationMetadata
 genConversationMetadata =
@@ -135,7 +136,6 @@ genConversationMetadata =
     <*> pure Nothing
     <*> pure Nothing
     <*> pure Nothing
-    <*> pure ProtocolProteus
 
 newtype RandomConversation = RandomConversation
   {unRandomConversation :: Data.Conversation}

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -32,6 +32,7 @@ import Imports
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import Wire.API.Conversation
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 import Wire.API.Federation.API.Galley
   ( RemoteConvMembers (..),
@@ -135,7 +136,6 @@ genConversationMetadata =
     <*> pure Nothing
     <*> pure Nothing
     <*> pure ProtocolProteus
-    <*> pure Nothing
 
 newtype RandomConversation = RandomConversation
   {unRandomConversation :: Data.Conversation}


### PR DESCRIPTION
Refactor conversation record and conversation creation functions. This removes a lot of duplication and makes the types of protocol-specific data in a conversation tighter.

 - Move conversation name size check to `NewConv`
 - Make the `NewConversation` record (used as input to the data
   function creating a conversation) contain a `ConversationMetadata`.
 - Implement all "special" conversation creation in terms of a general `createConversation`
 - Move protocol field from metadata to Conversation
 - Restructure MLS fields in Conversation record
 - Factor out metadata fields from Data.Conversation

This is a first step towards https://wearezeta.atlassian.net/browse/FS-434.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
