### PR TITLE
Remove unused "dist" debian Makefile targets

### DIFF
--- a/changelog.d/5-internal/remove-deb-targets
+++ b/changelog.d/5-internal/remove-deb-targets
@@ -1,0 +1,1 @@
+Remove unused debian Makefile targets

--- a/services/brig/Makefile
+++ b/services/brig/Makefile
@@ -39,50 +39,10 @@ fast: init
 .PHONY: clean
 clean:
 	stack clean $(NAME)
-	-rm -f .metadata
 
 .PHONY: compile
 compile:
 	stack build . --fast --test --bench --no-run-benchmarks --no-copy-bins
-
-.PHONY: dist
-dist: guard-VERSION install $(DEB) $(DEB_IT) $(DEB_SCHEMA) $(DEB_INDEX) .metadata
-
-.metadata:
-	echo -e "NAME=$(NAME)\nVERSION=$(VERSION)\nBUILD_NUMBER=$(BUILD)" \
-	 > .metadata
-
-$(DEB): install
-	makedeb --name=$(NAME) \
-		--version=$(VERSION) \
-		--debian-dir=deb \
-		--build=$(BUILD) \
-		--architecture=amd64 \
-		--output-dir=dist
-
-$(DEB_IT): install
-	makedeb --name=$(NAME)-integration \
-		--version=$(VERSION) \
-		--debian-dir=deb-it \
-		--build=$(BUILD) \
-		--architecture=amd64 \
-		--output-dir=dist
-
-$(DEB_SCHEMA): install
-	makedeb --name=$(NAME)-schema \
-		--version=$(VERSION) \
-		--debian-dir=schema/deb \
-		--build=$(BUILD) \
-		--architecture=amd64 \
-		--output-dir=dist
-
-$(DEB_INDEX): install
-	makedeb --name=$(NAME)-index \
-		--version=$(VERSION) \
-		--debian-dir=index/deb \
-		--build=$(BUILD) \
-		--architecture=amd64 \
-		--output-dir=dist
 
 .PHONY: i
 i:

--- a/services/cannon/Makefile
+++ b/services/cannon/Makefile
@@ -26,7 +26,6 @@ init:
 .PHONY: clean
 clean:
 	stack clean $(NAME)
-	-rm -f .metadata
 
 .PHONY: install
 install: init
@@ -39,20 +38,6 @@ fast: init
 .PHONY:
 compile:
 	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
-
-.PHONY: dist
-dist: guard-VERSION install $(DEB) .metadata
-
-$(DEB):
-	makedeb --name=$(NAME) \
-	 --version=$(VERSION) \
-	 --debian-dir=deb \
-	 --build=$(BUILD) \
-	 --architecture=amd64 \
-	 --output-dir=dist
-
-.metadata:
-	echo -e "NAME=$(NAME)\nVERSION=$(VERSION)\nBUILD_NUMBER=$(BUILD)" > .metadata
 
 .PHONY: docker
 docker:

--- a/services/cargohold/Makefile
+++ b/services/cargohold/Makefile
@@ -40,26 +40,6 @@ compile:
 .PHONY: clean
 clean: init
 	stack clean $(NAME)
-	-rm -f .metadata
-
-.PHONY: dist
-dist: guard-VERSION install $(DEB) $(DEB_IT) .metadata
-
-$(DEB):
-	makedeb --name=$(NAME) \
-		--version=$(VERSION) \
-		--debian-dir=deb \
-		--build=$(BUILD) \
-		--architecture=amd64 \
-		--output-dir=dist
-
-$(DEB_IT):
-	makedeb --name=$(NAME)-integration \
-		--version=$(VERSION) \
-		--debian-dir=deb-it \
-		--build=$(BUILD) \
-		--architecture=amd64 \
-		--output-dir=dist
 
 .PHONY: i
 i:
@@ -94,10 +74,6 @@ integration-list: fast i-list
 
 integration-%: fast
 	make "i-$*"
-
-.metadata:
-	echo -e "NAME=$(NAME)\nVERSION=$(VERSION)\nBUILD_NUMBER=$(BUILD)" \
-	 > .metadata
 
 .PHONY: docker
 docker:

--- a/services/galley/Makefile
+++ b/services/galley/Makefile
@@ -46,41 +46,6 @@ fast: init
 compile:
 	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
 
-.PHONY: dist
-dist: guard-VERSION install $(DEB) $(DEB_IT) $(DEB_SCHEMA) $(DEB_MIGRATE_DATA) .metadata
-
-$(DEB):
-	makedeb --name=$(NAME) \
-	 --version=$(VERSION) \
-	 --debian-dir=deb \
-	 --build=$(BUILD) \
-	 --architecture=amd64 \
-	 --output-dir=dist
-
-$(DEB_IT):
-	makedeb --name=$(NAME)-integration \
-	 --version=$(VERSION) \
-	 --debian-dir=deb-it \
-	 --build=$(BUILD) \
-	 --architecture=amd64 \
-	 --output-dir=dist
-
-$(DEB_SCHEMA):
-	makedeb --name=$(NAME)-schema \
-	 --version=$(VERSION) \
-	 --debian-dir=deb-schema \
-	 --build=$(BUILD) \
-	 --architecture=amd64 \
-	 --output-dir=dist
-
-$(DEB_MIGRATE_DATA):
-	makedeb --name=$(NAME)-migrate-data \
-	 --version=$(VERSION) \
-	 --debian-dir=deb-migrate-data \
-	 --build=$(BUILD) \
-	 --architecture=amd64 \
-	 --output-dir=dist
-
 .PHONY: i
 i:
 	../integration.sh $(EXE_IT) -s $(NAME).integration.yaml -i ../integration.yaml $(WIRE_INTEGRATION_TEST_OPTIONS)
@@ -104,9 +69,6 @@ integration-list: fast i-list
 
 integration-%: fast
 	make "i-$*"
-
-.metadata:
-	echo -e "NAME=$(NAME)\nVERSION=$(VERSION)\nBUILD_NUMBER=$(BUILD)" > .metadata
 
 .PHONY: db
 db: db-reset

--- a/services/gundeck/Makefile
+++ b/services/gundeck/Makefile
@@ -47,37 +47,6 @@ compile:
 .PHONY: clean
 clean:
 	stack clean $(NAME)
-	-rm -f .metadata
-
-.PHONY: dist
-dist: guard-VERSION install $(DEB) $(DEB_IT) $(DEB_SCHEMA) .metadata
-
-$(DEB):
-	makedeb --name=$(NAME) \
-	 --version=$(VERSION) \
-	 --debian-dir=deb \
-	 --build=$(BUILD) \
-	 --architecture=amd64 \
-	 --output-dir=dist
-
-$(DEB_IT):
-	makedeb --name=$(NAME)-integration \
-	 --version=$(VERSION) \
-	 --debian-dir=deb-it \
-	 --build=$(BUILD) \
-	 --architecture=amd64 \
-	 --output-dir=dist
-
-$(DEB_SCHEMA):
-	makedeb --name=$(NAME)-schema \
-		--version=$(VERSION) \
-		--debian-dir=schema/deb \
-		--build=$(BUILD) \
-		--architecture=amd64 \
-		--output-dir=dist
-
-.metadata:
-	echo -e "NAME=$(NAME)\nVERSION=$(VERSION)\nBUILD_NUMBER=$(BUILD)" > .metadata
 
 .PHONY: test
 test: install

--- a/services/proxy/Makefile
+++ b/services/proxy/Makefile
@@ -26,7 +26,6 @@ init:
 .PHONY: clean
 clean:
 	stack clean $(NAME)
-	-rm -f .metadata
 
 .PHONY: install
 install: init
@@ -39,20 +38,6 @@ fast: init
 .PHONY:
 compile:
 	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
-
-.PHONY: dist
-dist: guard-VERSION install $(DEB) $(DEB_IT) .metadata
-
-$(DEB):
-	makedeb --name=$(NAME) \
-	 --version=$(VERSION) \
-	 --debian-dir=deb \
-	 --build=$(BUILD) \
-	 --architecture=amd64 \
-	 --output-dir=dist
-
-.metadata:
-	echo -e "NAME=$(NAME)\nVERSION=$(VERSION)\nBUILD_NUMBER=$(BUILD)" > .metadata
 
 .PHONY: docker
 docker:

--- a/services/spar/Makefile
+++ b/services/spar/Makefile
@@ -36,42 +36,10 @@ fast: init
 .PHONY: clean
 clean:
 	stack clean $(NAME)
-	rm -f .metadata
 
 .PHONY: compile
 compile:
 	stack build --fast --test --bench --no-run-benchmarks --no-copy-bins spar
-
-.PHONY: dist
-dist: guard-VERSION install $(DEB) $(DEB_SCHEMA) $(DEB_MIGRATE_DATA) .metadata
-
-.metadata:
-	echo -e "NAME=$(NAME)\nVERSION=$(VERSION)\nBUILD_NUMBER=$(BUILD)" \
-	 > .metadata
-
-$(DEB): install
-	makedeb --name=$(NAME) \
-		--version=$(VERSION) \
-		--debian-dir=deb \
-		--build=$(BUILD) \
-		--architecture=amd64 \
-		--output-dir=dist
-
-$(DEB_SCHEMA): install
-	makedeb --name=$(NAME)-schema \
-		--version=$(VERSION) \
-		--debian-dir=schema/deb \
-		--build=$(BUILD) \
-		--architecture=amd64 \
-		--output-dir=dist
-
-$(DEB_MIGRATE_DATA): install
-	makedeb --name=$(NAME)-migrate-data \
-		--version=$(VERSION) \
-		--debian-dir=migrate-data/deb \
-		--build=$(BUILD) \
-		--architecture=amd64 \
-		--output-dir=dist
 
 .PHONY: i
 i:

--- a/tools/api-simulations/Makefile
+++ b/tools/api-simulations/Makefile
@@ -23,7 +23,6 @@ init:
 .PHONY: clean
 clean:
 	stack clean api-simulations
-	-rm -f .metadata
 
 .PHONY: fast
 fast: init
@@ -37,19 +36,5 @@ compile:
 install: init
 	stack install . --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
 
-.PHONY: dist
-dist: guard-VERSION install $(DEB) .metadata
-
-$(DEB):
-	makedeb --name=$(NAME) \
-	 --version=$(VERSION) \
-	 --debian-dir=deb \
-	 --build=$(BUILD_NUMBER) \
-	 --architecture=amd64 \
-	 --output-dir=dist
-
 mailboxes.json:
 	khan artifact download --bucket z-config --key simulator/mailboxes.json --file ./mailboxes.json
-
-.metadata:
-	echo -e "NAME=$(NAME)\nVERSION=$(VERSION)\nBUILD_NUMBER=$(BUILD)" > .metadata

--- a/tools/stern/Makefile
+++ b/tools/stern/Makefile
@@ -26,7 +26,6 @@ init:
 .PHONY: clean
 clean:
 	stack clean $(NAME)
-	-rm -f .metadata
 
 .PHONY: install
 install: init
@@ -39,20 +38,6 @@ fast: init
 .PHONY:
 compile:
 	stack build . --pedantic --test --bench --no-run-benchmarks --no-copy-bins
-
-.PHONY: dist
-dist: guard-VERSION install $(DEB) $(DEB_IT) .metadata
-
-$(DEB):
-	makedeb --name=$(NAME) \
-	 --version=$(VERSION) \
-	 --debian-dir=deb \
-	 --build=$(BUILD) \
-	 --architecture=amd64 \
-	 --output-dir=dist
-
-.metadata:
-	echo -e "NAME=$(NAME)\nVERSION=$(VERSION)\nBUILD_NUMBER=$(BUILD)" > .metadata
 
 .PHONY: docker
 docker:


### PR DESCRIPTION
The invocations of `makedeb` have been moved to cailleach:
https://github.com/zinfra/cailleach/commit/d5c787e3243aa6367cba35fb121fdfbe0edb7692

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
