### PR TITLE
nix: fix niv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ telepresence.log
 # local config
 .envrc.local
 cabal.project.local
+
+# Nix output symlinks
+result
+result-*

--- a/dev-packages.nix
+++ b/dev-packages.nix
@@ -141,7 +141,6 @@ let
       pkgs.libsodium.dev
       pkgs.libxml2.dev
       pkgs.ncurses.dev
-      pkgs.niv.out
       pkgs.openssl.dev
       pkgs.pcre.dev
       pkgs.snappy.dev
@@ -178,6 +177,7 @@ in
   pkgs.gnumake
   (pkgs.haskell-language-server.override { supportedGhcVersions = [ "8107" ]; })
   pkgs.jq
+  pkgs.niv
   pkgs.ormolu
   pkgs.telepresence
   pkgs.wget

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,8 +3,6 @@ let
   pkgs = import sources.nixpkgs {
     config.allowUnfree = true;
     overlays = [
-      # the tool we use for versioning (The thing that generates sources.json)
-      (_: _: { niv = (import sources.niv { }).niv; })
       # All wire-server specific packages
       (import ./overlay.nix)
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,16 +1,4 @@
 {
-    "niv": {
-        "branch": "master",
-        "description": "Easy dependency management for Nix projects",
-        "homepage": "https://github.com/nmattia/niv",
-        "owner": "nmattia",
-        "repo": "niv",
-        "rev": "5830a4dd348d77e39a0f3c4c762ff2663b602d4c",
-        "sha256": "1d3lsrqvci4qz2hwjrcnd8h5vfkg8aypq3sjd4g3izbc8frwz5sm",
-        "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/5830a4dd348d77e39a0f3c4c762ff2663b602d4c.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "nixpkgs": {
         "branch": "nixpkgs-unstable",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",


### PR DESCRIPTION
This will provide the `niv` tool in the direnv, so `niv update nixpkgs` becomes possible.

There's no have `niv` from sources.json, it's inside nixpkgs.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
