### PR TITLE
Remove wai-routing dependency from cannon

### DIFF
--- a/changelog.d/5-internal/cannon-remove-wai
+++ b/changelog.d/5-internal/cannon-remove-wai
@@ -1,0 +1,1 @@
+Cannon has been fully migrated to Servant

--- a/services/cannon/cannon.cabal
+++ b/services/cannon/cannon.cabal
@@ -113,7 +113,6 @@ library
     , wai >=3.0
     , wai-extra >=3.0
     , wai-predicates >=0.8
-    , wai-routing >=0.12
     , wai-utilities >=0.11
     , wai-websockets >=3.0
     , warp >=3.0

--- a/services/cannon/package.yaml
+++ b/services/cannon/package.yaml
@@ -48,7 +48,6 @@ library:
   - wai >=3.0
   - wai-extra >=3.0
   - wai-predicates >=0.8
-  - wai-routing >=0.12
   - wai-utilities >=0.11
   - wai-websockets >=3.0
   - warp >=3.0


### PR DESCRIPTION
This completes the servantification of cannon.

Tracked by https://wearezeta.atlassian.net/browse/SQCORE-1176.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
