### PR TITLE
Use local serial consistency for LWT

### DIFF
--- a/changelog.d/5-internal/use-local-consistency
+++ b/changelog.d/5-internal/use-local-consistency
@@ -1,0 +1,1 @@
+Use local serial consistency for Cassandra lightweight transactions

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -300,7 +300,15 @@ addMLSPublicKey ::
   ByteString ->
   ExceptT ClientDataError m ()
 addMLSPublicKey u c ss pk = do
-  rows <- trans insertMLSPublicKeys (params LocalQuorum (u, c, ss, Blob (LBS.fromStrict pk)))
+  rows <-
+    trans
+      insertMLSPublicKeys
+      ( params
+          LocalQuorum
+          (u, c, ss, Blob (LBS.fromStrict pk))
+      )
+        { serialConsistency = Just LocalSerialConsistency
+        }
   case rows of
     [row]
       | C.fromRow 0 row /= Right (Just True) ->


### PR DESCRIPTION
This should avoid the use of Quorum consistency under the hood.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
