### PR TITLE
SQSERVICES 1375 - Follow up (integration test for `GET /bot/conversation`)

### DIFF
--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -32,7 +32,6 @@ import Data.Qualified
 import Data.Range
 import Data.Singletons
 import Data.String.Conversions (cs)
-import Data.Tagged
 import Data.Time
 import GHC.TypeLits (AppendSymbol)
 import qualified Galley.API.Clients as Clients
@@ -245,11 +244,7 @@ internalAPI =
       <@> mkNamedAPI @"delete-user" rmUser
       <@> mkNamedAPI @"connect" Create.createConnectConversation
       <@> mkNamedAPI @"upsert-one2one" iUpsertOne2OneConversation
-      <@> mkNamedAPI @"feature-config-snd-factor-password-challenge"
-        ( \case
-            Just uid -> TeamFeatureStatusNoConfig . tfwoapsStatus <$> getFeatureConfigNoAuth @'WithLockStatus @'TeamFeatureSndFactorPasswordChallenge (unTagged getSndFactorPasswordChallengeInternal) uid
-            Nothing -> TeamFeatureStatusNoConfig . tfwoapsStatus <$> (unTagged getSndFactorPasswordChallengeInternal) (Left Nothing)
-        )
+      <@> mkNamedAPI @"feature-config-snd-factor-password-challenge" getSndFactorPasswordChallengeNoAuth
       <@> featureAPI
 
 featureAPI :: API IFeatureAPI GalleyEffects

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -423,8 +423,8 @@ getBotConversationH ::
   ) =>
   BotId ::: ConvId ::: JSON ->
   Sem r Response
-getBotConversationH arg@(zbot ::: _ ::: _) =
-  Features.guardSecondFactorDisabled (botUserId zbot) (Query.getBotConversationH arg)
+getBotConversationH arg@(bid ::: cid ::: _) =
+  Features.guardSecondFactorDisabled (botUserId bid) cid (Query.getBotConversationH arg)
 
 apiDocs :: Routes ApiBuilder (Sem r) ()
 apiDocs =


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1375

The bot API should be blocked if the 2nd FA team feature is enabled.

This is a follow-up PR of https://github.com/wireapp/wire-server/pull/2207. This one contains an additional integration test for the `GET /bot/conversation` endpoint in galley.

If 2FA is enabled for the team the conversation belongs to, then this endpoint should return `403 access-denied`.

The `guardSecondFactorDisabled` handler needed to be changed to get the TeamId from the conversation.