### PR TITLE
github workflows: use environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build-dev-env:
    name: Build dev env
+   environment: cachix # for secrets
    strategy:
      matrix:
        os:

--- a/changelog.d/5-internal/cachix
+++ b/changelog.d/5-internal/cachix
@@ -1,0 +1,1 @@
+Fix: pushing to cachix not working


### PR DESCRIPTION
Pushing to cachix failed silently because the credentials were not provided. This PR makes use of a github environment that contain the auth token and signing key required.

 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
