### PR TITLE
Skip reauth when adding clients internally

### DIFF
--- a/changelog.d/5-internal/brig-client-reauth
+++ b/changelog.d/5-internal/brig-client-reauth
@@ -1,0 +1,1 @@
+Add `skip_reauth` param to internal API for creating clients. This is intended to be used in test.

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -314,7 +314,7 @@ addClientInternalH (usr ::: req ::: connId ::: _) = do
 
 addClientInternal :: UserId -> NewClient -> Maybe ConnId -> (Handler r) Client
 addClientInternal usr new connId = do
-  API.addClient usr connId Nothing new !>> clientError
+  API.addClientWithReAuthPolicy (\_ _ -> False) usr connId Nothing new !>> clientError
 
 legalHoldClientRequestedH :: UserId ::: JsonRequest LegalHoldClientRequest ::: JSON -> (Handler r) Response
 legalHoldClientRequestedH (targetUser ::: req ::: _) = do

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -280,6 +280,7 @@ sitemap = do
   -- - UserLegalHoldEnabled event to contacts of the user, if client type is legalhold
   post "/i/clients/:uid" (continue addClientInternalH) $
     capture "uid"
+      .&. opt (param "skip_reauth")
       .&. jsonRequest @NewClient
       .&. opt zauthConnId
       .&. accept "application" "json"
@@ -307,14 +308,17 @@ sitemap = do
 -- Handlers
 
 -- | Add a client without authentication checks
-addClientInternalH :: UserId ::: JsonRequest NewClient ::: Maybe ConnId ::: JSON -> (Handler r) Response
-addClientInternalH (usr ::: req ::: connId ::: _) = do
+addClientInternalH :: UserId ::: Maybe Bool ::: JsonRequest NewClient ::: Maybe ConnId ::: JSON -> (Handler r) Response
+addClientInternalH (usr ::: mSkipReAuth ::: req ::: connId ::: _) = do
   new <- parseJsonBody req
-  setStatus status201 . json <$> addClientInternal usr new connId
+  setStatus status201 . json <$> addClientInternal usr mSkipReAuth new connId
 
-addClientInternal :: UserId -> NewClient -> Maybe ConnId -> (Handler r) Client
-addClientInternal usr new connId = do
-  API.addClientWithReAuthPolicy (\_ _ -> False) usr connId Nothing new !>> clientError
+addClientInternal :: UserId -> Maybe Bool -> NewClient -> Maybe ConnId -> (Handler r) Client
+addClientInternal usr mSkipReAuth new connId = do
+  let policy
+        | mSkipReAuth == Just True = \_ _ -> False
+        | otherwise = Data.reAuthForNewClients
+  API.addClientWithReAuthPolicy policy usr connId Nothing new !>> clientError
 
 legalHoldClientRequestedH :: UserId ::: JsonRequest LegalHoldClientRequest ::: JSON -> (Handler r) Response
 legalHoldClientRequestedH (targetUser ::: req ::: _) = do

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -580,7 +580,8 @@ addClient usr con ip new = do
   -- Users can't add legal hold clients
   when (Public.newClientType new == Public.LegalHoldClientType) $
     throwE (clientError ClientLegalHoldCannotBeAdded)
-  clientResponse <$> API.addClient usr (Just con) (ipAddr <$> ip) new !>> clientError
+  clientResponse <$> API.addClient usr (Just con) (ipAddr <$> ip) new
+    !>> clientError
   where
     clientResponse :: Public.Client -> NewClientResponse
     clientResponse client = Servant.addHeader (Public.clientId client) client

--- a/services/galley/src/Galley/Intra/Effects.hs
+++ b/services/galley/src/Galley/Intra/Effects.hs
@@ -70,7 +70,7 @@ interpretBrigAccess = interpret $ \case
   NotifyClientsAboutLegalHoldRequest self other pk ->
     embedApp $ notifyClientsAboutLegalHoldRequest self other pk
   GetLegalHoldAuthToken uid mpwd -> getLegalHoldAuthToken uid mpwd
-  AddLegalHoldClientToUser uid conn pks lpk ->
+  AddLegalHoldClientToUserEither uid conn pks lpk ->
     embedApp $ addLegalHoldClientToUser uid conn pks lpk
   RemoveLegalHoldClientFromUser uid ->
     embedApp $ removeLegalHoldClientFromUser uid


### PR DESCRIPTION
This PR changes the internal Brig endpoint for adding new clients to make it skip the check for the need to re-authenticate. This is useful for integration tests that need to set up a number of clients.

Answering comments by @fisx on a similar commit in #2247:

> Maybe it would be good to somehow rename the new `Brig.API.Client.addClient` to `addClientUnsafe` (as it allows to set a bad policy), and keep `addClient` with the same interface and behavior as before?

I have done that, but called the unsafe function `addClientWithReAuthPolicy` instead, because "unsafe" usually means something else in Haskell.

> Have you double-checked that we're not calling the internal end-point from some handler in galley in production, and rely on the authentication taking place in brig there? Maybe you should mark this end-point as "only for testing" somehow?

It seems it is only called from galley in [`addLegalHoldClientToUser`](https://github.com/wireapp/wire-server/blob/develop/services/galley/src/Galley/Intra/Client.hs#L120). I'm now handling the 403 error from Brig and throwing an `AuthenticationError` in Galley. I have also added a query parameter as discussed, to make sure that only tests are taking advantage of the ability to skip the reauth check.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
