### PR TITLE
Servantify Galley Teams [1/3]

### DIFF
--- a/changelog.d/5-internal/SQSERVICES-1080-servantify-galley_teams-1
+++ b/changelog.d/5-internal/SQSERVICES-1080-servantify-galley_teams-1
@@ -1,0 +1,1 @@
+Migrate 5 internal endpoints (/i/teams/:tid...) to Servant for better Swagger.

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -210,6 +210,9 @@ type ITeamsAPIBase =
            ( CanThrow 'NoBindingTeam :> CanThrow 'NotAOneMemberTeam :> CanThrow 'DeleteQueueFull
                :> DeleteAccepted '[Servant.JSON] NoContent
            )
+    :<|> "name" :> IGetTeamNameAPI
+
+type IGetTeamNameAPI = Named "get-team-name" (Get '[Servant.JSON] TeamName)
 
 type ITeamEffects = ErrorS 'TeamNotFound : GalleyEffects
 
@@ -274,6 +277,7 @@ iTeamsAPI = mkAPI $ \tid -> hoistAPIHandler id (base tid)
       mkNamedAPI @"get-team" (Teams.getTeamInternalH tid)
         <@> mkNamedAPI @"create-binding-team" (Teams.createBindingTeamH tid)
         <@> mkNamedAPI @"delete-binding-team-with-one-member" (Teams.internalDeleteBindingTeamWithOneMemberH tid)
+        <@> hoistAPI @IGetTeamNameAPI id (mkNamedAPI @"get-team-name" $ Teams.getTeamNameInternalH tid)
 
 featureAPI :: API IFeatureAPI GalleyEffects
 featureAPI =
@@ -351,10 +355,6 @@ internalSitemap = do
     capture "cnv"
 
   -- Team API (internal) ------------------------------------------------
-
-  get "/i/teams/:tid/name" (continueE Teams.getTeamNameInternalH) $
-    capture "tid"
-      .&. accept "application" "json"
 
   put "/i/teams/:tid/status" (continueE Teams.updateTeamStatusH) $
     capture "tid"

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -283,12 +283,11 @@ updateTeamStatusH ::
        WaiRoutes
      ]
     r =>
-  TeamId ::: JsonRequest TeamStatusUpdate ::: JSON ->
-  Sem r Response
-updateTeamStatusH (tid ::: req ::: _) = do
-  teamStatusUpdate <- fromJsonBody req
-  updateTeamStatus tid teamStatusUpdate
-  return empty
+  TeamId ->
+  TeamStatusUpdate ->
+  Sem r NoContent
+updateTeamStatusH tid teamStatusUpdate =
+  NoContent <$ updateTeamStatus tid teamStatusUpdate
 
 updateTeamStatus ::
   Members

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -165,11 +165,10 @@ getTeamInternalH tid =
 
 getTeamNameInternalH ::
   Members '[ErrorS 'TeamNotFound, TeamStore] r =>
-  TeamId ::: JSON ->
-  Sem r Response
-getTeamNameInternalH (tid ::: _) =
-  fmap json $
-    getTeamNameInternal tid >>= noteS @'TeamNotFound
+  TeamId ->
+  Sem r TeamName
+getTeamNameInternalH tid =
+  getTeamNameInternal tid >>= noteS @'TeamNotFound
 
 getTeamNameInternal :: Member TeamStore r => TeamId -> Sem r (Maybe TeamName)
 getTeamNameInternal = fmap (fmap TeamName) . E.getTeamName


### PR DESCRIPTION
## Checklist

 - [X] The **PR Title** explains the impact of the change.
 - [X] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.

JIRA: https://wearezeta.atlassian.net/browse/SQSERVICES-1080

 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.

No endpoints were supposed to be added or renamed, but they are now specified in servant type instead of wai-routes paths, so this should be a point of review.

 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need an upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
