### PR TITLE
Document error handling and logging

### DIFF
--- a/changelog.d/5-internal/error-middleware
+++ b/changelog.d/5-internal/error-middleware
@@ -1,0 +1,1 @@
+Document error handling and simplify error logging

--- a/docs/developer/servant.md
+++ b/docs/developer/servant.md
@@ -55,4 +55,4 @@ Finally, the error-catching middleware `catchErrors` in `Network.Wai.Utilities.S
      - if >= 500, wrap the error response in a JSON error object (if it is not already
        one), and log it at error level.
   3. catch the exception, turn it into a JSON error object, and log it. The
-     error level depends on the status code (error for 5xx, debug otherwise).
+     log level depends on the status code (error for 5xx, debug otherwise).

--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -93,7 +93,7 @@ toServantHandler env action = do
 
     handleWaiErrors logger reqId =
       \case
-        -- throw in IO so that the `catchError` middleware can turn this error
+        -- throw in IO so that the `catchErrors` middleware can turn this error
         -- into a response and log accordingly
         StdError werr -> liftIO $ throwIO werr
         RichError werr body headers -> do

--- a/services/brig/src/Brig/API/Handler.hs
+++ b/services/brig/src/Brig/API/Handler.hs
@@ -40,6 +40,7 @@ import Brig.Options (setWhitelist)
 import Brig.Phone (Phone, PhoneException (..))
 import qualified Brig.Whitelist as Whitelist
 import Control.Error
+import Control.Exception (throwIO)
 import Control.Lens (set, view)
 import Control.Monad.Catch (catches, throwM)
 import qualified Control.Monad.Catch as Catch
@@ -47,13 +48,11 @@ import Control.Monad.Except (MonadError, throwError)
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import Data.Default (def)
-import Data.Proxy (Proxy (..))
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.ZAuth.Validation as ZV
 import Imports
-import Network.HTTP.Media.RenderHeader (RenderHeader (..))
-import Network.HTTP.Types (Status (statusCode, statusMessage), hContentType)
+import Network.HTTP.Types (Status (statusCode, statusMessage))
 import Network.Wai (Request, ResponseReceived)
 import Network.Wai.Predicate (Media)
 import Network.Wai.Routing (Continue)
@@ -94,12 +93,13 @@ toServantHandler env action = do
 
     handleWaiErrors logger reqId =
       \case
-        StdError werr -> do
-          Server.logError' logger (Just reqId) werr
-          Servant.throwError $
-            Servant.ServerError (mkCode werr) (mkPhrase (WaiError.code werr)) (Aeson.encode werr) [(hContentType, renderHeader (Servant.contentType (Proxy @Servant.JSON)))]
+        -- throw in IO so that the `catchError` middleware can turn this error
+        -- into a response and log accordingly
+        StdError werr -> liftIO $ throwIO werr
         RichError werr body headers -> do
-          Server.logError' logger (Just reqId) werr
+          when (statusCode (WaiError.code werr) < 500) $
+            -- 5xx are logged by the middleware, so we only log errors < 500 to avoid duplicated entries
+            Server.logError' logger (Just reqId) werr
           Servant.throwError $
             Servant.ServerError (mkCode werr) (mkPhrase (WaiError.code werr)) (Aeson.encode body) headers
 

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -553,7 +553,7 @@ testTooManyClients opts brig = do
     addClient brig uid (defNewClient PermanentClientType [somePrekeys !! 11] (someLastPrekeys !! 11)) !!! do
       const 403 === statusCode
       const (Just "too-many-clients") === fmap Error.label . responseJsonMaybe
-      const (Just "application/json;charset=utf-8") === getHeader "Content-Type"
+      const (Just "application/json") === getHeader "Content-Type"
 
 -- @END
 

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -50,19 +50,14 @@ import Cassandra hiding (Set)
 import qualified Cassandra as C
 import qualified Cassandra.Settings as C
 import Control.Error
-import qualified Control.Exception
 import Control.Lens hiding ((.=))
-import qualified Data.Aeson as Aeson
 import Data.ByteString.Conversion (toByteString')
 import Data.Default (def)
 import qualified Data.List.NonEmpty as NE
 import Data.Metrics.Middleware
-import Data.Proxy (Proxy (..))
 import Data.Qualified
 import Data.Range
 import Data.Text (unpack)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
 import Data.Time.Clock
 import Galley.API.Error
 import qualified Galley.Aws as Aws
@@ -92,11 +87,6 @@ import qualified Galley.Types.Teams as Teams
 import Imports hiding (forkIO)
 import Network.HTTP.Client (responseTimeoutMicro)
 import Network.HTTP.Client.OpenSSL
-import Network.HTTP.Media.RenderHeader (RenderHeader (..))
-import Network.HTTP.Types (hContentType)
-import Network.HTTP.Types.Status (statusCode, statusMessage)
-import qualified Network.Wai.Utilities as Wai
-import qualified Network.Wai.Utilities.Server as Server
 import OpenSSL.Session as Ssl
 import qualified OpenSSL.X509.SystemStore as Ssl
 import Polysemy
@@ -209,21 +199,7 @@ interpretTinyLog e = interpret $ \case
   P.Polylog l m -> Logger.log (e ^. applog) l (reqIdMsg (e ^. reqId) . m)
 
 toServantHandler :: Env -> Sem GalleyEffects a -> Servant.Handler a
-toServantHandler env galley = do
-  eith <- liftIO $ Control.Exception.try (evalGalley env galley)
-  case eith of
-    Left werr ->
-      handleWaiErrors (view applog env) (unRequestId (view reqId env)) werr
-    Right result -> pure result
-  where
-    handleWaiErrors :: Logger -> ByteString -> Wai.Error -> Servant.Handler a
-    handleWaiErrors logger reqId' werr = do
-      Server.logError' logger (Just reqId') werr
-      Servant.throwError $
-        Servant.ServerError (mkCode werr) (mkPhrase werr) (Aeson.encode werr) [(hContentType, renderHeader (Servant.contentType (Proxy @Servant.JSON)))]
-
-    mkCode = statusCode . Wai.code
-    mkPhrase = Text.unpack . Text.decodeUtf8 . statusMessage . Wai.code
+toServantHandler e = liftIO . evalGalley e
 
 interpretErrorToException ::
   (Exception exc, Member (Embed IO) r) =>


### PR DESCRIPTION
This PR adds a bit of developer documentation regarding how errors are propagated from a service, through the middleware, and to the client.

It also removes some unnecessary duplication of error logs and simplifies the way errors are thrown in the main `Handler → Servant.Handler` natural transformation.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
