### PR TITLE
Improve readability user search test cases

### DIFF
--- a/changelog.d/5-internal/brig-search-tests
+++ b/changelog.d/5-internal/brig-search-tests
@@ -1,1 +1,1 @@
-Improve readability user search test cases
+Improve readability of user search test cases

--- a/changelog.d/5-internal/brig-search-tests
+++ b/changelog.d/5-internal/brig-search-tests
@@ -1,0 +1,1 @@
+Improve readability user search test cases

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -88,14 +88,14 @@ tests opts mgr galley brig = do
         testWithBothIndices opts mgr "by-first/middle/last name" $ testSearchByLastOrMiddleName brig,
         testWithBothIndices opts mgr "Non ascii names" $ testSearchNonAsciiNames brig,
         test mgr "migration to new index" $ testMigrationToNewIndex mgr opts brig,
-        testGroup "team-search-visibility disabled OR SearchVisibilityStandard" $
-          [ testGroup "when SearchVisibilityInbound == SearchableByOwnTeam" $
-              [ testWithBothIndices opts mgr "team member cannot be found by non-team user with display name" $ testSearchTeamMemberAsNonMemberDisplayName mgr brig galley TeamFeatureDisabled,
-                testWithBothIndices opts mgr "team member can be found by non-team user with exact handle" $ testSearchTeamMemberAsNonMemberExactHandle mgr brig galley TeamFeatureDisabled,
-                testWithBothIndices opts mgr "team A member cannot be found by team B member with display name" $ testSearchTeamMemberAsOtherMemberDisplayName mgr brig galley TeamFeatureDisabled,
-                testWithBothIndices opts mgr "team A member can be found by team B member with exact handle" $ testSearchTeamMemberAsOtherMemberExactHandle mgr brig galley TeamFeatureDisabled,
-                testWithBothIndices opts mgr "team A member can be found by other team A member" $ testSearchTeamMemberAsSameMember mgr brig galley TeamFeatureDisabled,
-                testWithBothIndices opts mgr "non team user can be found by a team member" $ testSeachNonMemberAsTeamMember brig,
+        testGroup "team A: SearchVisibilityStandard (= unrestriced outbound search)" $
+          [ testGroup "team A: SearchableByOwnTeam (= restricted inbound search)" $
+              [ testWithBothIndices opts mgr "  I. non-team user cannot find team A member by display name" $ testSearchTeamMemberAsNonMemberDisplayName mgr brig galley TeamFeatureDisabled,
+                testWithBothIndices opts mgr " II. non-team user can find team A member by exact handle" $ testSearchTeamMemberAsNonMemberExactHandle mgr brig galley TeamFeatureDisabled,
+                testWithBothIndices opts mgr "III. team B member cannot find team A member by display name" $ testSearchTeamMemberAsOtherMemberDisplayName mgr brig galley TeamFeatureDisabled,
+                testWithBothIndices opts mgr " IV. team B member can find team A member by exact handle" $ testSearchTeamMemberAsOtherMemberExactHandle mgr brig galley TeamFeatureDisabled,
+                testWithBothIndices opts mgr "  V. team A member can find team A member by display name" $ testSearchTeamMemberAsSameMember mgr brig galley TeamFeatureDisabled,
+                testWithBothIndices opts mgr " VI. team A member can find non-team user by display name" $ testSeachNonMemberAsTeamMember brig,
                 testGroup "order" $
                   [ test mgr "team-mates are listed before team-outsiders (exact match)" $ testSearchOrderingAsTeamMemberExactMatch brig,
                     test mgr "team-mates are listed before team-outsiders (prefix match)" $ testSearchOrderingAsTeamMemberPrefixMatch brig,
@@ -103,23 +103,23 @@ tests opts mgr galley brig = do
                     test mgr "team-mates are listed after team-outsiders (worse handle match)" $ testSearchOrderingAsTeamMemberWorseHandleMatch brig
                   ]
               ],
-            testGroup "when SearchVisibilityInbound == SearchableByAllTeams" $
-              [ test mgr "team member cannot be found by non-team user with display name" $ testSearchTeamMemberAsNonMemberDisplayName mgr brig galley TeamFeatureEnabled,
-                test mgr "team member can be found by non-team user with exact handle" $ testSearchTeamMemberAsNonMemberExactHandle mgr brig galley TeamFeatureEnabled,
-                test mgr "team A member can be found by team B member with display name" $ testSearchTeamMemberAsOtherMemberDisplayName mgr brig galley TeamFeatureEnabled,
-                test mgr "team A member can be found by team B member with exact handle" $ testSearchTeamMemberAsOtherMemberExactHandle mgr brig galley TeamFeatureEnabled,
-                test mgr "team A member can be found by other team A member" $ testSearchTeamMemberAsSameMember mgr brig galley TeamFeatureDisabled
+            testGroup "team A: SearchableByAllTeams (= unrestriced inbound search)" $
+              [ test mgr "   I.  non-team user cannot find team A member via display name" $ testSearchTeamMemberAsNonMemberDisplayName mgr brig galley TeamFeatureEnabled,
+                test mgr "  II.  non-team user can find team A member by exact handle" $ testSearchTeamMemberAsNonMemberExactHandle mgr brig galley TeamFeatureEnabled,
+                test mgr "III*.  team B member can find team A member by display name" $ testSearchTeamMemberAsOtherMemberDisplayName mgr brig galley TeamFeatureEnabled,
+                test mgr "  IV.  team B member can find team A member by exact handle" $ testSearchTeamMemberAsOtherMemberExactHandle mgr brig galley TeamFeatureEnabled,
+                test mgr "   V.  team A member can find team A member by display name" $ testSearchTeamMemberAsSameMember mgr brig galley TeamFeatureEnabled
               ]
           ],
-        testGroup "searchSameTeamOnly AND SearchVisibilityInbound == SearchableByOwnTeam" $
-          [ testWithBothIndicesAndOpts opts mgr "when searchSameTeamOnly flag is set, non team user cannot be found by a team member" $ testSearchSameTeamOnly brig
+        testGroup "searchSameTeamOnly == true (server setting)" $
+          [ testWithBothIndicesAndOpts opts mgr "any team user cannot find any non-team user by display name or exact handle" $ testSearchSameTeamOnly brig
           ],
-        testGroup "team-search-visibility SearchVisibilityNoNameOutsideTeam" $
-          [ testGroup "When SearchVisibilityInbound == SearchableByOwnTeam" $
-              [ test mgr "team member cannot be found by non-team user" $ testSearchTeamMemberAsNonMemberOutboundOnly brig testSetupOutboundOnly,
-                test mgr "team A member cannot be found by team B member" $ testSearchTeamMemberAsOtherMemberOutboundOnly brig testSetupOutboundOnly,
-                test mgr "team A member *can* be found by other team A member" $ testSearchTeamMemberAsSameMemberOutboundOnly brig testSetupOutboundOnly,
-                test mgr "non team user cannot be found by a team member A" $ testSeachNonMemberAsTeamMemberOutboundOnly brig testSetupOutboundOnly
+        testGroup "team A: SearchVisibilityNoNameOutsideTeam (restricted outbound search)" $
+          [ testGroup "team A: SearchableByOwnTeam (= restriced inbound search)" $
+              [ test mgr "I. non-team user cannot find team A member by display name" $ testSearchTeamMemberAsNonMemberOutboundOnly brig testSetupOutboundOnly,
+                test mgr "team A member cannot find team B member by display name or exact handle" $ testSearchTeamMemberAsOtherMemberOutboundOnly brig testSetupOutboundOnly,
+                test mgr "V. team A member can find other team A member by display name or exact handle" $ testSearchTeamMemberAsSameMemberOutboundOnly brig testSetupOutboundOnly,
+                test mgr "team A member cannot find non-team user by display name or exact handle" $ testSearchNonMemberAsTeamMemberOutboundOnly brig testSetupOutboundOnly
               ]
           ],
         testGroup "federated" $
@@ -324,6 +324,7 @@ testSearchTeamMemberAsNonMemberDisplayName mgr brig galley inboundVisibility = d
   nonTeamMember <- randomUser brig
   (tid, _, [teamMember, teamBTargetReindexedAfter]) <- createPopulatedBindingTeamWithNamesAndHandles brig 2
   circumventSettingsOverride mgr $ setTeamSearchVisibilityInboundAvailable galley tid inboundVisibility
+  -- we set a random handle her to force a reindexing of that user
   void $ setRandomHandle brig teamBTargetReindexedAfter
   refreshIndex brig
   assertCan'tFind brig (userId nonTeamMember) (userQualifiedId teamMember) (fromName (userDisplayName teamMember))
@@ -332,25 +333,28 @@ testSearchTeamMemberAsNonMemberDisplayName mgr brig galley inboundVisibility = d
 testSearchTeamMemberAsNonMemberExactHandle :: TestConstraints m => Manager -> Brig -> Galley -> TeamFeatureStatusValue -> m ()
 testSearchTeamMemberAsNonMemberExactHandle mgr brig galley inboundVisibility = do
   nonTeamMember <- randomUser brig
-  (tid, _, [teamMember, teamBTargetReindexedAfter]) <- createPopulatedBindingTeamWithNamesAndHandles brig 2
+  (tid, _, [teamMember, teamMemberReindexedAfter]) <- createPopulatedBindingTeamWithNamesAndHandles brig 2
   circumventSettingsOverride mgr $ setTeamSearchVisibilityInboundAvailable galley tid inboundVisibility
-  void $ setRandomHandle brig teamBTargetReindexedAfter
+  -- we set a random handle her to force a reindexing of that user
+  teamMemberReindexedAfterHandle <- do
+    teamMemberReindexedAfter' <- setRandomHandle brig teamMemberReindexedAfter
+    pure $ fromMaybe (error "teamATargetReindexedAfter must have a handle") (userHandle teamMemberReindexedAfter')
   refreshIndex brig
-  let teamMemberHandle = fromMaybe (error "teamBMember must have a handle") (userHandle teamMember)
+  let teamMemberHandle = fromMaybe (error "teamMember must have a handle") (userHandle teamMember)
   assertCanFind brig (userId nonTeamMember) (userQualifiedId teamMember) (fromHandle teamMemberHandle)
-  assertCan'tFind brig (userId nonTeamMember) (userQualifiedId teamBTargetReindexedAfter) (fromName (userDisplayName teamBTargetReindexedAfter))
+  assertCanFind brig (userId nonTeamMember) (userQualifiedId teamMemberReindexedAfter) (fromHandle teamMemberReindexedAfterHandle)
 
 testSearchTeamMemberAsOtherMemberDisplayName :: TestConstraints m => Manager -> Brig -> Galley -> TeamFeatureStatusValue -> m ()
 testSearchTeamMemberAsOtherMemberDisplayName mgr brig galley inboundVisibility = do
-  (_, _, [teamASearcher]) <- createPopulatedBindingTeamWithNamesAndHandles brig 1
-  (tidB, _, [teamBTarget, teamBTargetReindexedAfter]) <- createPopulatedBindingTeamWithNamesAndHandles brig 2
+  (_, _, [teamBSearcher]) <- createPopulatedBindingTeamWithNamesAndHandles brig 1
+  (tidA, _, [teamATarget, teamATargetReindexedAfter]) <- createPopulatedBindingTeamWithNamesAndHandles brig 2
   refreshIndex brig
-  circumventSettingsOverride mgr $ setTeamSearchVisibilityInboundAvailable galley tidB inboundVisibility
-  void $ setRandomHandle brig teamBTargetReindexedAfter
+  circumventSettingsOverride mgr $ setTeamSearchVisibilityInboundAvailable galley tidA inboundVisibility
+  void $ setRandomHandle brig teamATargetReindexedAfter
   hFlush stdout
   refreshIndex brig
-  assertion brig (userId teamASearcher) (userQualifiedId teamBTarget) (fromName (userDisplayName teamBTarget))
-  assertion brig (userId teamASearcher) (userQualifiedId teamBTargetReindexedAfter) (fromName (userDisplayName teamBTargetReindexedAfter))
+  assertion brig (userId teamBSearcher) (userQualifiedId teamATarget) (fromName (userDisplayName teamATarget))
+  assertion brig (userId teamBSearcher) (userQualifiedId teamATargetReindexedAfter) (fromName (userDisplayName teamATargetReindexedAfter))
   where
     assertion :: (MonadCatch m, MonadIO m, MonadHttp m, HasCallStack) => Brig -> UserId -> Qualified UserId -> Text -> m ()
     assertion =
@@ -361,13 +365,13 @@ testSearchTeamMemberAsOtherMemberDisplayName mgr brig galley inboundVisibility =
 testSearchTeamMemberAsOtherMemberExactHandle :: TestConstraints m => Manager -> Brig -> Galley -> TeamFeatureStatusValue -> m ()
 testSearchTeamMemberAsOtherMemberExactHandle mgr brig galley inboundVisibility = do
   (_, _, [teamASearcher]) <- createPopulatedBindingTeamWithNamesAndHandles brig 1
-  (tidB, _, [teamBTarget, teamBTargetReindexedAfter]) <- createPopulatedBindingTeamWithNamesAndHandles brig 2
-  circumventSettingsOverride mgr $ setTeamSearchVisibilityInboundAvailable galley tidB inboundVisibility
-  teamBTargetReindexedAfter' <- setRandomHandle brig teamBTargetReindexedAfter
+  (tidA, _, [teamATarget, teamATargetReindexedAfter]) <- createPopulatedBindingTeamWithNamesAndHandles brig 2
+  circumventSettingsOverride mgr $ setTeamSearchVisibilityInboundAvailable galley tidA inboundVisibility
+  teamATargetReindexedAfter' <- setRandomHandle brig teamATargetReindexedAfter
   refreshIndex brig
-  let teamBTargetHandle = fromMaybe (error "teamBTarget must have a handle") (userHandle teamBTarget)
-  assertCanFind brig (userId teamASearcher) (userQualifiedId teamBTarget) (fromHandle teamBTargetHandle)
-  assertCanFind brig (userId teamASearcher) (userQualifiedId teamBTargetReindexedAfter) (fromHandle (fromJust (userHandle teamBTargetReindexedAfter')))
+  let teamATargetHandle = fromMaybe (error "teamATarget must have a handle") (userHandle teamATarget)
+  assertCanFind brig (userId teamASearcher) (userQualifiedId teamATarget) (fromHandle teamATargetHandle)
+  assertCanFind brig (userId teamASearcher) (userQualifiedId teamATargetReindexedAfter) (fromHandle (fromJust (userHandle teamATargetReindexedAfter')))
 
 testSearchTeamMemberAsSameMember :: TestConstraints m => Manager -> Brig -> Galley -> TeamFeatureStatusValue -> m ()
 testSearchTeamMemberAsSameMember mgr brig galley inboundVisibility = do
@@ -441,12 +445,15 @@ testSearchOrderingAsTeamMemberWorseHandleMatch brig = do
 
 testSearchSameTeamOnly :: TestConstraints m => Brig -> Opt.Opts -> m ()
 testSearchSameTeamOnly brig opts = do
-  nonTeamMember <- randomUser brig
+  nonTeamMember' <- randomUser brig
+  nonTeamMember <- setRandomHandle brig nonTeamMember'
   (_, _, [teamMember]) <- createPopulatedBindingTeam brig 1
   refreshIndex brig
   let newOpts = opts & Opt.optionSettings . Opt.searchSameTeamOnly .~ Just True
-  withSettingsOverrides newOpts $
+  withSettingsOverrides newOpts $ do
     assertCan'tFind brig (userId teamMember) (userQualifiedId nonTeamMember) (fromName (userDisplayName nonTeamMember))
+    let nonTeamMemberHandle = fromMaybe (error "nonTeamMember must have a handle") (userHandle nonTeamMember)
+    assertCan'tFind brig (userId teamMember) (userQualifiedId nonTeamMember) (fromHandle nonTeamMemberHandle)
 
 testSearchTeamMemberAsNonMemberOutboundOnly :: Brig -> ((TeamId, User, User), (TeamId, User, User), User) -> Http ()
 testSearchTeamMemberAsNonMemberOutboundOnly brig ((_, _, teamAMember), (_, _, _), nonTeamMember) = do
@@ -467,8 +474,8 @@ testSearchTeamMemberAsSameMemberOutboundOnly brig ((_, teamAOwner, teamAMember),
   assertCanFind brig (userId teamAMember) (userQualifiedId teamAOwner) (fromName (userDisplayName teamAOwner))
   assertCanFind brig (userId teamAMember) (userQualifiedId teamAOwner) (fromHandle teamAOwnerHandle)
 
-testSeachNonMemberAsTeamMemberOutboundOnly :: Brig -> ((TeamId, User, User), (TeamId, User, User), User) -> Http ()
-testSeachNonMemberAsTeamMemberOutboundOnly brig ((_, _, teamAMember), (_, _, _), nonTeamMember) = do
+testSearchNonMemberAsTeamMemberOutboundOnly :: Brig -> ((TeamId, User, User), (TeamId, User, User), User) -> Http ()
+testSearchNonMemberAsTeamMemberOutboundOnly brig ((_, _, teamAMember), (_, _, _), nonTeamMember) = do
   let teamMemberAHandle = fromMaybe (error "nonTeamMember must have a handle") (userHandle nonTeamMember)
   assertCan'tFind brig (userId teamAMember) (userQualifiedId nonTeamMember) (fromName (userDisplayName nonTeamMember))
   assertCan'tFind brig (userId teamAMember) (userQualifiedId nonTeamMember) (fromHandle teamMemberAHandle)

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -88,7 +88,7 @@ tests opts mgr galley brig = do
         testWithBothIndices opts mgr "by-first/middle/last name" $ testSearchByLastOrMiddleName brig,
         testWithBothIndices opts mgr "Non ascii names" $ testSearchNonAsciiNames brig,
         test mgr "migration to new index" $ testMigrationToNewIndex mgr opts brig,
-        testGroup "team A: SearchVisibilityStandard (= unrestriced outbound search)" $
+        testGroup "team A: SearchVisibilityStandard (= unrestricted outbound search)" $
           [ testGroup "team A: SearchableByOwnTeam (= restricted inbound search)" $
               [ testWithBothIndices opts mgr "  I. non-team user cannot find team A member by display name" $ testSearchTeamMemberAsNonMemberDisplayName mgr brig galley TeamFeatureDisabled,
                 testWithBothIndices opts mgr " II. non-team user can find team A member by exact handle" $ testSearchTeamMemberAsNonMemberExactHandle mgr brig galley TeamFeatureDisabled,
@@ -103,7 +103,7 @@ tests opts mgr galley brig = do
                     test mgr "team-mates are listed after team-outsiders (worse handle match)" $ testSearchOrderingAsTeamMemberWorseHandleMatch brig
                   ]
               ],
-            testGroup "team A: SearchableByAllTeams (= unrestriced inbound search)" $
+            testGroup "team A: SearchableByAllTeams (= unrestricted inbound search)" $
               [ test mgr "   I.  non-team user cannot find team A member via display name" $ testSearchTeamMemberAsNonMemberDisplayName mgr brig galley TeamFeatureEnabled,
                 test mgr "  II.  non-team user can find team A member by exact handle" $ testSearchTeamMemberAsNonMemberExactHandle mgr brig galley TeamFeatureEnabled,
                 test mgr "III*.  team B member can find team A member by display name" $ testSearchTeamMemberAsOtherMemberDisplayName mgr brig galley TeamFeatureEnabled,
@@ -115,7 +115,7 @@ tests opts mgr galley brig = do
           [ testWithBothIndicesAndOpts opts mgr "any team user cannot find any non-team user by display name or exact handle" $ testSearchSameTeamOnly brig
           ],
         testGroup "team A: SearchVisibilityNoNameOutsideTeam (restricted outbound search)" $
-          [ testGroup "team A: SearchableByOwnTeam (= restriced inbound search)" $
+          [ testGroup "team A: SearchableByOwnTeam (= restricted inbound search)" $
               [ test mgr "I. non-team user cannot find team A member by display name" $ testSearchTeamMemberAsNonMemberOutboundOnly brig testSetupOutboundOnly,
                 test mgr "team A member cannot find team B member by display name or exact handle" $ testSearchTeamMemberAsOtherMemberOutboundOnly brig testSetupOutboundOnly,
                 test mgr "V. team A member can find other team A member by display name or exact handle" $ testSearchTeamMemberAsSameMemberOutboundOnly brig testSetupOutboundOnly,
@@ -324,7 +324,7 @@ testSearchTeamMemberAsNonMemberDisplayName mgr brig galley inboundVisibility = d
   nonTeamMember <- randomUser brig
   (tid, _, [teamMember, teamBTargetReindexedAfter]) <- createPopulatedBindingTeamWithNamesAndHandles brig 2
   circumventSettingsOverride mgr $ setTeamSearchVisibilityInboundAvailable galley tid inboundVisibility
-  -- we set a random handle her to force a reindexing of that user
+  -- we set a random handle here to force a reindexing of that user
   void $ setRandomHandle brig teamBTargetReindexedAfter
   refreshIndex brig
   assertCan'tFind brig (userId nonTeamMember) (userQualifiedId teamMember) (fromName (userDisplayName teamMember))
@@ -335,7 +335,7 @@ testSearchTeamMemberAsNonMemberExactHandle mgr brig galley inboundVisibility = d
   nonTeamMember <- randomUser brig
   (tid, _, [teamMember, teamMemberReindexedAfter]) <- createPopulatedBindingTeamWithNamesAndHandles brig 2
   circumventSettingsOverride mgr $ setTeamSearchVisibilityInboundAvailable galley tid inboundVisibility
-  -- we set a random handle her to force a reindexing of that user
+  -- we set a random handle here to force a reindexing of that user
   teamMemberReindexedAfterHandle <- do
     teamMemberReindexedAfter' <- setRandomHandle brig teamMemberReindexedAfter
     pure $ fromMaybe (error "teamATargetReindexedAfter must have a handle") (userHandle teamMemberReindexedAfter')


### PR DESCRIPTION
This PR updates the test suite with hopes of improving readability:

- test case description: use consistent formulation in active voice
- number similar test cases across different settings with a roman numeral
- rename variables in test code to match the names of teams in description: `teamA` and `teamB`

This PR also fixes a test case and adds a test case:

- fix test case description: "team A member cannot find team B member by display name or exact handle". The previous description in passive voice was incorrect
- fix test case "II.  non-team user can find team A member by exact handle": handle was not searched
- add test case:
  - before: "any team user cannot find any non-team user by display name"
  - after:  "any team user cannot find any non-team user by display name or exact handle"

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
