### PR TITLE
Proteus actions on MLS conversations should fail

### DIFF
--- a/changelog.d/2-features/mls
+++ b/changelog.d/2-features/mls
@@ -1,5 +1,5 @@
 MLS implementation progress:
-
- - commit messages containing add proposals are now processed
- - do initial validation and forwarding of all types of messages via POST /mls/messages
- - fixed bug where users could not be added to MLS conversations if they had non-MLS clients
+ - commit messages containing add proposals are now processed (#2247)
+ - initial validation and forwarding of all types of messages via POST /mls/messages (#2253)
+ - fixed bug where users could not be added to MLS conversations if they had non-MLS clients (#2290)
+ - MLS/Proteus mismatches (e.g. sending a proteus message to an MLS conversation) are now handled (#2278)

--- a/changelog.d/5-internal/mls-tests
+++ b/changelog.d/5-internal/mls-tests
@@ -1,0 +1,1 @@
+Various Galley MLS test improvements and cleanups

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -43,51 +43,11 @@ import Data.Singletons.TH
 import qualified Data.Swagger as S
 import Data.Time.Clock
 import Imports
-import Test.QuickCheck (elements)
 import Wire.API.Arbitrary (Arbitrary (..))
 import Wire.API.Conversation
+import Wire.API.Conversation.Action.Tag
 import Wire.API.Conversation.Role
 import Wire.API.Event.Conversation
-
-data ConversationActionTag
-  = ConversationJoinTag
-  | ConversationLeaveTag
-  | ConversationRemoveMembersTag
-  | ConversationMemberUpdateTag
-  | ConversationDeleteTag
-  | ConversationRenameTag
-  | ConversationMessageTimerUpdateTag
-  | ConversationReceiptModeUpdateTag
-  | ConversationAccessDataTag
-  deriving (Show, Eq, Generic, Bounded, Enum)
-
-instance Arbitrary ConversationActionTag where
-  arbitrary = elements [minBound .. maxBound]
-
-instance ToSchema ConversationActionTag where
-  schema =
-    enum @Text "ConversationActionTag" $
-      mconcat
-        [ element "ConversationJoinTag" ConversationJoinTag,
-          element "ConversationLeaveTag" ConversationLeaveTag,
-          element "ConversationRemoveMembersTag" ConversationRemoveMembersTag,
-          element "ConversationMemberUpdateTag" ConversationMemberUpdateTag,
-          element "ConversationDeleteTag" ConversationDeleteTag,
-          element "ConversationRenameTag" ConversationRenameTag,
-          element "ConversationMessageTimerUpdateTag" ConversationMessageTimerUpdateTag,
-          element "ConversationReceiptModeUpdateTag" ConversationReceiptModeUpdateTag,
-          element "ConversationAccessDataTag" ConversationAccessDataTag
-        ]
-
-instance ToJSON ConversationActionTag where
-  toJSON = schemaToJSON
-
-instance FromJSON ConversationActionTag where
-  parseJSON = schemaParseJSON
-
-$(genSingletons [''ConversationActionTag])
-
-$(singDecideInstance ''ConversationActionTag)
 
 -- | We use this type family instead of a sum type to be able to define
 -- individual effects per conversation action. See 'HasConversationActionEffects'.

--- a/libs/wire-api/src/Wire/API/Conversation/Action/Tag.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action/Tag.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TemplateHaskell #-}
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
@@ -14,7 +16,6 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
-{-# LANGUAGE StandaloneKindSignatures #-}
 -- Ignore unused `genSingletons` Template Haskell results
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 

--- a/libs/wire-api/src/Wire/API/Conversation/Action/Tag.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action/Tag.hs
@@ -1,0 +1,68 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE StandaloneKindSignatures #-}
+-- Ignore unused `genSingletons` Template Haskell results
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
+module Wire.API.Conversation.Action.Tag where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Schema hiding (tag)
+import Data.Singletons.TH
+import Imports
+import Test.QuickCheck (elements)
+import Wire.API.Arbitrary (Arbitrary (..))
+
+data ConversationActionTag
+  = ConversationJoinTag
+  | ConversationLeaveTag
+  | ConversationRemoveMembersTag
+  | ConversationMemberUpdateTag
+  | ConversationDeleteTag
+  | ConversationRenameTag
+  | ConversationMessageTimerUpdateTag
+  | ConversationReceiptModeUpdateTag
+  | ConversationAccessDataTag
+  deriving (Show, Eq, Generic, Bounded, Enum)
+
+instance Arbitrary ConversationActionTag where
+  arbitrary = elements [minBound .. maxBound]
+
+instance ToSchema ConversationActionTag where
+  schema =
+    enum @Text "ConversationActionTag" $
+      mconcat
+        [ element "ConversationJoinTag" ConversationJoinTag,
+          element "ConversationLeaveTag" ConversationLeaveTag,
+          element "ConversationRemoveMembersTag" ConversationRemoveMembersTag,
+          element "ConversationMemberUpdateTag" ConversationMemberUpdateTag,
+          element "ConversationDeleteTag" ConversationDeleteTag,
+          element "ConversationRenameTag" ConversationRenameTag,
+          element "ConversationMessageTimerUpdateTag" ConversationMessageTimerUpdateTag,
+          element "ConversationReceiptModeUpdateTag" ConversationReceiptModeUpdateTag,
+          element "ConversationAccessDataTag" ConversationAccessDataTag
+        ]
+
+instance ToJSON ConversationActionTag where
+  toJSON = schemaToJSON
+
+instance FromJSON ConversationActionTag where
+  parseJSON = schemaParseJSON
+
+$(genSingletons [''ConversationActionTag])
+
+$(singDecideInstance ''ConversationActionTag)

--- a/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
@@ -22,6 +22,7 @@ module Wire.API.Conversation.Protocol
   ( ProtocolTag (..),
     protocolTag,
     protocolTagSchema,
+    protocolValidAction,
     Epoch (..),
     Protocol (..),
     _ProtocolMLS,
@@ -37,6 +38,7 @@ import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Schema
 import Imports
 import Wire.API.Arbitrary
+import Wire.API.Conversation.Action.Tag
 import Wire.API.MLS.Group
 import Wire.API.MLS.Message
 
@@ -65,6 +67,18 @@ $(makePrisms ''Protocol)
 protocolTag :: Protocol -> ProtocolTag
 protocolTag ProtocolProteus = ProtocolProteusTag
 protocolTag (ProtocolMLS _) = ProtocolMLSTag
+
+-- | Certain actions need to be performed at the level of the underlying
+-- protocol (MLS, mostly) before being applied to conversations. This function
+-- returns whether a given action tag is directly applicable to a conversation
+-- with the given protocol.
+protocolValidAction :: Protocol -> ConversationActionTag -> Bool
+protocolValidAction ProtocolProteus _ = True
+protocolValidAction (ProtocolMLS _) ConversationJoinTag = False
+protocolValidAction (ProtocolMLS _) ConversationLeaveTag = False
+protocolValidAction (ProtocolMLS _) ConversationRemoveMembersTag = False
+protocolValidAction (ProtocolMLS _) ConversationDeleteTag = False
+protocolValidAction (ProtocolMLS _) _ = True
 
 instance ToSchema ProtocolTag where
   schema =

--- a/libs/wire-api/src/Wire/API/MLS/Message.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Message.hs
@@ -26,7 +26,6 @@ module Wire.API.MLS.Message
     SWireFormatTag (..),
     SomeMessage (..),
     ContentType (..),
-    mpTag,
     MessagePayload (..),
     MessagePayloadTBS (..),
     Sender (..),
@@ -161,12 +160,6 @@ data ContentType
 
 instance ParseMLS ContentType where
   parseMLS = parseMLSEnum @Word8 "content type"
-
--- | Identify the content type of a message payload to be signed.
-mpTag :: MessagePayloadTBS -> ContentType
-mpTag (ApplicationMessage _) = ApplicationMessageTag
-mpTag (ProposalMessage _) = ProposalMessageTag
-mpTag (CommitMessage _) = CommitMessageTag
 
 instance ParseMLS MessagePayloadTBS where
   parseMLS =

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -23,6 +23,7 @@ library
       Wire.API.Connection
       Wire.API.Conversation
       Wire.API.Conversation.Action
+      Wire.API.Conversation.Action.Tag
       Wire.API.Conversation.Bot
       Wire.API.Conversation.Code
       Wire.API.Conversation.Member

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -342,6 +342,7 @@ executable galley-integration
       API.Federation.Util
       API.MessageTimer
       API.MLS
+      API.MLS.Util
       API.Roles
       API.SQS
       API.Teams

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -24,6 +24,7 @@ module Galley.API.Action
 
     -- * Performing actions
     updateLocalConversationWithLocalUser,
+    updateLocalConversationWithLocalUserUnchecked,
     updateLocalConversationWithRemoteUser,
     NoChanges (..),
 
@@ -73,6 +74,7 @@ import Polysemy.Error
 import Polysemy.Input
 import Wire.API.Conversation hiding (Conversation, Member)
 import Wire.API.Conversation.Action
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 import Wire.API.Error
 import Wire.API.Error.Galley
@@ -458,7 +460,45 @@ updateLocalConversationWithLocalUser lcnv lusr con action = do
   let tag = sing @tag
 
   -- retrieve conversation
-  (conv, self) <- getConversationAndMemberWithError @'ConvNotFound lusr lcnv
+  conv <- getConversationWithError lcnv
+
+  -- check that the action does not bypass the underlying protocol
+  unless (protocolValidAction (convProtocol conv) (fromSing tag)) $
+    throwS @'InvalidOperation
+
+  -- perform all authorisation checks and, if successful, the update itself
+  updateLocalConversationWithLocalUserUnchecked @tag conv lusr con action
+
+-- | Similar to 'updateLocalConversationWithLocalUser', but takes a
+-- 'Conversation' value directly, instead of a 'ConvId', and skips protocol
+-- checks. All the other checks are still performed.
+--
+-- This is intended to be used by protocol-aware code, once all the
+-- protocol-specific checks and updates have been performed, to finally apply
+-- the changes to the conversation as seen by the backend.
+updateLocalConversationWithLocalUserUnchecked ::
+  forall tag r.
+  ( SingI tag,
+    Member (ErrorS ('ActionDenied (ConversationActionPermission tag))) r,
+    Member (ErrorS 'ConvNotFound) r,
+    Member (ErrorS 'InvalidOperation) r,
+    Member ExternalAccess r,
+    Member FederatorAccess r,
+    Member GundeckAccess r,
+    Member (Input UTCTime) r,
+    HasConversationActionEffects tag r
+  ) =>
+  Conversation ->
+  Local UserId ->
+  Maybe ConnId ->
+  ConversationAction tag ->
+  Sem r Event
+updateLocalConversationWithLocalUserUnchecked conv lusr con action = do
+  let tag = sing @tag
+      lcnv = qualifyAs lusr (convId conv)
+
+  -- retrieve member
+  self <- noteS @'ConvNotFound $ getConvMember lusr conv lusr
 
   -- perform checks
   ensureConversationActionAllowed (sing @tag) lcnv action conv self

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -239,7 +239,11 @@ executeProposalAction lusr con conv action = do
       handleNoChanges
         . handleMLSProposalFailures @ProposalErrors
         . fmap pure
-        . updateLocalConversationWithLocalUser @'ConversationJoinTag (qualifyAs lusr (convId conv)) lusr (Just con)
+        . updateLocalConversationWithLocalUserUnchecked
+          @'ConversationJoinTag
+          conv
+          lusr
+          (Just con)
         $ ConversationJoin users roleNameWireMember
 
 handleNoChanges :: Monoid a => Sem (Error NoChanges ': r) a -> Sem r a

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -59,7 +59,6 @@ import Galley.Effects.BrigAccess
 import Galley.Effects.ClientStore
 import Galley.Effects.ConversationStore
 import Galley.Effects.FederatorAccess
-import Galley.Effects.MemberStore
 import Galley.Effects.TeamStore
 import Galley.Options
 import qualified Galley.Types.Clients as Clients
@@ -375,28 +374,22 @@ postQualifiedOtrMessage senderType sender mconn lcnv msg =
     . mapToRuntimeError @'ConvNotFound @(MessageNotSent MessageSendingStatus)
       MessageNotSentConversationNotFound
     $ do
-      alive <- isConversationAlive (tUnqualified lcnv)
       let localDomain = tDomain lcnv
       now <- input
       let nowMillis = toUTCTimeMillis now
       let senderDomain = qDomain sender
           senderUser = qUnqualified sender
       let senderClient = qualifiedNewOtrSender msg
-      unless alive $ do
-        deleteConversation (tUnqualified lcnv)
-        throwS @'ConvNotFound
 
-      -- conversation members
-      localMembers <- getLocalMembers (tUnqualified lcnv)
-      remoteMembers <- getRemoteMembers (tUnqualified lcnv)
+      conv <- getConversation (tUnqualified lcnv) >>= noteS @'ConvNotFound
 
-      let localMemberIds = lmId <$> localMembers
+      let localMemberIds = lmId <$> convLocalMembers conv
           localMemberMap :: Map UserId LocalMember
-          localMemberMap = Map.fromList (map (\mem -> (lmId mem, mem)) localMembers)
+          localMemberMap = Map.fromList (map (\mem -> (lmId mem, mem)) (convLocalMembers conv))
           members :: Set (Qualified UserId)
           members =
             Set.map (`Qualified` localDomain) (Map.keysSet localMemberMap)
-              <> Set.fromList (map (qUntagged . rmId) remoteMembers)
+              <> Set.fromList (map (qUntagged . rmId) (convRemoteMembers conv))
       isInternal <- view (optSettings . setIntraListing) <$> input
 
       -- check if the sender is part of the conversation
@@ -410,12 +403,12 @@ postQualifiedOtrMessage senderType sender mconn lcnv msg =
           else getClients localMemberIds
       let qualifiedLocalClients =
             Map.mapKeys (localDomain,)
-              . makeUserMap (Set.fromList (map lmId localMembers))
+              . makeUserMap (Set.fromList (map lmId (convLocalMembers conv)))
               . Clients.toMap
               $ localClients
 
       -- get remote clients
-      qualifiedRemoteClients <- getRemoteClients remoteMembers
+      qualifiedRemoteClients <- getRemoteClients (convRemoteMembers conv)
       let qualifiedClients = qualifiedLocalClients <> qualifiedRemoteClients
 
       -- check if the sender client exists (as one of the clients in the conversation)

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1278,12 +1278,8 @@ updateLocalConversationName ::
   Local ConvId ->
   ConversationRename ->
   Sem r (UpdateResult Event)
-updateLocalConversationName lusr zcon lcnv rename = getUpdateResult $
-  do
-    alive <- E.isConversationAlive (tUnqualified lcnv)
-    unless alive $ do
-      E.deleteConversation (tUnqualified lcnv)
-      throwS @'ConvNotFound
+updateLocalConversationName lusr zcon lcnv rename =
+  getUpdateResult $
     updateLocalConversationWithLocalUser @'ConversationRenameTag lcnv lusr (Just zcon) rename
 
 isTypingUnqualified ::

--- a/services/galley/src/Galley/Data/Conversation.hs
+++ b/services/galley/src/Galley/Data/Conversation.hs
@@ -53,7 +53,7 @@ import Imports hiding (Set)
 import Wire.API.Conversation hiding (Conversation)
 
 isConvDeleted :: Conversation -> Bool
-isConvDeleted = fromMaybe False . convDeleted
+isConvDeleted = convDeleted
 
 selfConv :: UserId -> ConvId
 selfConv uid = Id (toUUID uid)

--- a/services/galley/src/Galley/Data/Conversation/Types.hs
+++ b/services/galley/src/Galley/Data/Conversation/Types.hs
@@ -32,7 +32,7 @@ data Conversation = Conversation
   { convId :: ConvId,
     convLocalMembers :: [LocalMember],
     convRemoteMembers :: [RemoteMember],
-    convDeleted :: Maybe Bool,
+    convDeleted :: Bool,
     convMetadata :: ConversationMetadata,
     convProtocol :: Protocol
   }

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -51,9 +51,11 @@ import TestSetup
 import Wire.API.Conversation
 import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
+import Wire.API.Event.Conversation
 import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
 import Wire.API.MLS.Serialisation
+import Wire.API.Message
 import Wire.API.User.Client
 import Wire.API.User.Client.Prekey
 
@@ -74,12 +76,18 @@ tests s =
           test s "add user (partial client list)" testAddUserPartial,
           test s "add user with some non-MLS clients" testAddUserWithProteusClients,
           test s "add new client of an already-present user to a conversation" testAddNewClient,
-          test s "send a commit to a proteus conversation" testAddUsersToProteus,
           test s "send a stale commit" testStaleCommit
         ],
       testGroup
         "Application Message"
-        [test s "send application message" testAppMessage]
+        [test s "send application message" testAppMessage],
+      testGroup
+        "Protocol mismatch"
+        [ test s "send a commit to a proteus conversation" testAddUsersToProteus,
+          test s "add users bypassing MLS" testAddUsersDirectly,
+          test s "remove users bypassing MLS" testRemoveUsersDirectly,
+          test s "send proteus message to an MLS conversation" testProteusMessage
+        ]
     ]
 
 testLocalWelcome :: TestM ()
@@ -138,22 +146,12 @@ testWelcomeUnknownClient = do
 -- | Send a commit message, and assert that all participants see an event with
 -- the given list of new members.
 testSuccessfulCommitWithNewUsers :: HasCallStack => MessagingSetup -> [Qualified UserId] -> TestM ()
-testSuccessfulCommitWithNewUsers MessagingSetup {..} newUsers = do
+testSuccessfulCommitWithNewUsers setup@MessagingSetup {..} newUsers = do
   cannon <- view tsCannon
 
   WS.bracketRN cannon (map (qUnqualified . pUserId) users) $ \wss -> do
     -- send commit message
-    galley <- viewGalley
-    events <-
-      responseJsonError
-        =<< post
-          ( galley . paths ["mls", "messages"]
-              . zUser (qUnqualified (pUserId creator))
-              . zConn "conn"
-              . content "message/mls"
-              . bytes commit
-          )
-        <!! const 201 === statusCode
+    events <- postCommit setup
 
     let alreadyPresent =
           map snd
@@ -302,6 +300,49 @@ testAddUsersToProteus = do
   setup <- aliceInvitesBob 1 def {createConv = CreateProteusConv}
   err <- testFailedCommit setup 404
   liftIO $ Wai.label err @?= "no-conversation"
+
+testAddUsersDirectly :: TestM ()
+testAddUsersDirectly = do
+  setup@MessagingSetup {..} <- aliceInvitesBob 1 def {createConv = CreateConv}
+  void $ postCommit setup
+  charlie <- randomUser
+  e <-
+    responseJsonError
+      =<< postMembers
+        (qUnqualified (pUserId creator))
+        (pure charlie)
+        (qUnqualified conversation)
+      <!! const 403 === statusCode
+  liftIO $ Wai.label e @?= "invalid-op"
+
+testRemoveUsersDirectly :: TestM ()
+testRemoveUsersDirectly = do
+  setup@MessagingSetup {..} <- aliceInvitesBob 1 def {createConv = CreateConv}
+  void $ postCommit setup
+  e <-
+    responseJsonError
+      =<< deleteMemberQualified
+        (qUnqualified (pUserId creator))
+        (pUserId (users !! 0))
+        conversation
+      <!! const 403 === statusCode
+  liftIO $ Wai.label e @?= "invalid-op"
+
+testProteusMessage :: TestM ()
+testProteusMessage = do
+  setup@MessagingSetup {..} <- aliceInvitesBob 1 def {createConv = CreateConv}
+  void $ postCommit setup
+  e <-
+    responseJsonError
+      =<< postProteusMessageQualified
+        (qUnqualified (pUserId creator))
+        (snd (NonEmpty.head (pClients creator)))
+        conversation
+        []
+        "data"
+        MismatchReportAll
+      <!! const 404 === statusCode
+  liftIO $ Wai.label e @?= "no-conversation"
 
 testStaleCommit :: TestM ()
 testStaleCommit = withSystemTempDirectory "mls" $ \tmp -> do
@@ -598,3 +639,16 @@ addKeyPackage u c kp = do
         )
       <!! const 200 === statusCode
   liftIO $ map (Just . kpbeRef) (toList (kpbEntries bundle)) @?= [kpRef' kp]
+
+postCommit :: MessagingSetup -> TestM [Event]
+postCommit MessagingSetup {..} = do
+  galley <- viewGalley
+  responseJsonError
+    =<< post
+      ( galley . paths ["mls", "messages"]
+          . zUser (qUnqualified (pUserId creator))
+          . zConn "conn"
+          . content "message/mls"
+          . bytes commit
+      )
+    <!! const 201 === statusCode

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -19,29 +19,23 @@
 
 module API.MLS (tests) where
 
+import API.MLS.Util
 import API.Util
 import Bilge
 import Bilge.Assert
-import Control.Lens (preview, to, view)
-import qualified Control.Monad.State as State
-import qualified Data.ByteString as BS
-import Data.ByteString.Conversion
+import Control.Lens (view)
 import Data.Default
-import Data.Domain
 import Data.Id
-import Data.Json.Util hiding ((#))
-import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.List1
-import qualified Data.Map as Map
 import Data.Qualified
+import Data.Range
 import Data.String.Conversions
 import qualified Data.Text as T
 import Imports
 import qualified Network.Wai.Utilities.Error as Wai
 import System.FilePath
 import System.IO.Temp
-import System.Process
 import Test.Tasty
 import Test.Tasty.Cannon ((#))
 import qualified Test.Tasty.Cannon as WS
@@ -49,15 +43,8 @@ import Test.Tasty.HUnit
 import TestHelpers
 import TestSetup
 import Wire.API.Conversation
-import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
-import Wire.API.Event.Conversation
-import Wire.API.MLS.Credential
-import Wire.API.MLS.KeyPackage
-import Wire.API.MLS.Serialisation
 import Wire.API.Message
-import Wire.API.User.Client
-import Wire.API.User.Client.Prekey
 
 tests :: IO TestSetup -> TestTree
 tests s =
@@ -68,6 +55,11 @@ tests s =
         [ test s "local welcome" testLocalWelcome,
           test s "local welcome (client with no public key)" testWelcomeNoKey,
           test s "local welcome (client with no public key)" testWelcomeUnknownClient
+        ],
+      testGroup
+        "Creation"
+        [ test s "fail to create MLS conversation" postMLSConvFail,
+          test s "create MLS conversation" postMLSConvOk
         ],
       testGroup
         "Commit"
@@ -89,6 +81,34 @@ tests s =
           test s "send proteus message to an MLS conversation" testProteusMessage
         ]
     ]
+
+postMLSConvFail :: TestM ()
+postMLSConvFail = do
+  qalice <- randomQualifiedUser
+  let alice = qUnqualified qalice
+  bob <- randomUser
+  connectUsers alice (list1 bob [])
+  postConvQualified alice defNewMLSConv {newConvQualifiedUsers = [Qualified bob (qDomain qalice)]}
+    !!! do
+      const 400 === statusCode
+      const (Just "non-empty-member-list") === fmap Wai.label . responseJsonError
+
+postMLSConvOk :: TestM ()
+postMLSConvOk = do
+  c <- view tsCannon
+  qalice <- randomQualifiedUser
+  bob <- randomUser
+  let alice = qUnqualified qalice
+  let nameMaxSize = T.replicate 256 "a"
+  connectUsers alice (list1 bob [])
+  WS.bracketR2 c alice bob $ \(wsA, wsB) -> do
+    rsp <- postConvQualified alice defNewMLSConv {newConvName = checked nameMaxSize}
+    pure rsp !!! do
+      const 201 === statusCode
+      const Nothing === fmap Wai.label . responseJsonError
+    cid <- assertConv rsp RegularConv alice qalice [] (Just nameMaxSize) Nothing
+    WS.assertNoEvent (2 # WS.Second) [wsB]
+    checkConvCreateEvent cid wsA
 
 testLocalWelcome :: TestM ()
 testLocalWelcome = do
@@ -184,9 +204,6 @@ testSuccessfulCommitWithNewUsers setup@MessagingSetup {..} newUsers = do
       WS.assertMatch_ (5 # WS.Second) ws $
         wsAssertMLSMessage conversation (pUserId creator) commit
 
-  -- FUTUREWORK: check that messages sent to the conversation are propagated to bob
-  pure ()
-
 testFailedCommit :: HasCallStack => MessagingSetup -> Int -> TestM Wai.Error
 testFailedCommit MessagingSetup {..} status = do
   cannon <- view tsCannon
@@ -213,8 +230,18 @@ testSuccessfulCommit setup = testSuccessfulCommitWithNewUsers setup (map pUserId
 
 testAddUser :: TestM ()
 testAddUser = do
-  setup <- aliceInvitesBob 1 def {createConv = CreateConv}
+  setup@MessagingSetup {..} <- aliceInvitesBob 1 def {createConv = CreateConv}
   testSuccessfulCommit setup
+
+  -- check that bob can now see the conversation
+  let bob = users !! 0
+  convs <-
+    responseJsonError =<< getConvs (qUnqualified (pUserId bob)) Nothing Nothing
+      <!! const 200 === statusCode
+  liftIO $
+    assertBool
+      "Users added to an MLS group should find it when listing conversations"
+      (conversation `elem` map cnvQualifiedId (convList convs))
 
 testAddUserNotConnected :: TestM ()
 testAddUserNotConnected = do
@@ -376,8 +403,9 @@ testAppMessage = withSystemTempDirectory "mls" $ \tmp -> do
     liftIO $
       setupCommit tmp "group" "group" $
         users >>= toList . pClients
-  -- FUTUREWORK: manually send the commit
-  testSuccessfulCommit MessagingSetup {..}
+
+  void $ postCommit MessagingSetup {..}
+
   message <-
     liftIO $
       spawn (cli tmp ["message", "--group", tmp </> "group", "some text"]) Nothing
@@ -401,254 +429,3 @@ testAppMessage = withSystemTempDirectory "mls" $ \tmp -> do
     liftIO $
       WS.assertMatchN_ (5 # WS.Second) wss $
         wsAssertMLSMessage conversation (pUserId creator) message
-
---------------------------------------------------------------------------------
--- Messaging setup
-
-data CreateClients = CreateWithoutKey | CreateWithKey | DontCreateClients
-  deriving (Eq)
-
-data CreateConv = CreateConv | CreateProteusConv | DontCreateConv
-  deriving (Eq)
-
-createNewConv :: CreateConv -> Maybe NewConv
-createNewConv CreateConv = Just defNewMLSConv
-createNewConv CreateProteusConv = Just defNewProteusConv
-createNewConv DontCreateConv = Nothing
-
-data SetupOptions = SetupOptions
-  { createClients :: CreateClients,
-    createConv :: CreateConv,
-    makeConnections :: Bool
-  }
-
-instance Default SetupOptions where
-  def =
-    SetupOptions
-      { createClients = CreateWithKey,
-        createConv = DontCreateConv,
-        makeConnections = True
-      }
-
-data MessagingSetup = MessagingSetup
-  { creator :: Participant,
-    users :: [Participant],
-    conversation :: Qualified ConvId,
-    welcome :: ByteString,
-    commit :: ByteString
-  }
-
-data Participant = Participant
-  { pUserId :: Qualified UserId,
-    pClients :: NonEmpty (String, ClientId)
-  }
-  deriving (Show)
-
-cli :: FilePath -> [String] -> CreateProcess
-cli tmp args =
-  proc "crypto-cli" $
-    ["--store", tmp </> "store.db", "--enc-key", "test"] <> args
-
-pClientQid :: Participant -> String
-pClientQid = fst . NonEmpty.head . pClients
-
-setupUserClient ::
-  HasCallStack =>
-  FilePath ->
-  CreateClients ->
-  Qualified UserId ->
-  State.StateT [LastPrekey] TestM (String, ClientId)
-setupUserClient tmp doCreateClients usr = do
-  lpk <- takeLastPrekey
-  lift $ do
-    -- create client if requested
-    c <- case doCreateClients of
-      DontCreateClients -> randomClient (qUnqualified usr) lpk
-      _ -> addClient usr lpk
-
-    let qcid =
-          show (qUnqualified usr)
-            <> ":"
-            <> T.unpack (client c)
-            <> "@"
-            <> T.unpack (domainText (qDomain usr))
-
-    -- generate key package
-    kp <-
-      liftIO $
-        decodeMLSError
-          =<< spawn (cli tmp ["key-package", qcid]) Nothing
-    liftIO $ BS.writeFile (tmp </> qcid) (rmRaw kp)
-
-    -- set bob's private key and upload key package if required
-    case doCreateClients of
-      CreateWithKey -> addKeyPackage usr c kp
-      _ -> pure ()
-
-    pure (qcid, c)
-
-setupParticipant ::
-  HasCallStack =>
-  FilePath ->
-  CreateClients ->
-  Int ->
-  Qualified UserId ->
-  State.StateT [LastPrekey] TestM Participant
-setupParticipant tmp doCreateClients numClients usr =
-  Participant usr . NonEmpty.fromList
-    <$> replicateM numClients (setupUserClient tmp doCreateClients usr)
-
-setupParticipants ::
-  HasCallStack =>
-  FilePath ->
-  SetupOptions ->
-  [Int] ->
-  State.StateT [LastPrekey] TestM (Participant, [Participant])
-setupParticipants tmp SetupOptions {..} ns = do
-  creator <- lift randomQualifiedUser >>= setupParticipant tmp DontCreateClients 1
-  others <- for ns $ \n ->
-    lift randomQualifiedUser >>= setupParticipant tmp createClients n
-  lift . when makeConnections $
-    traverse_
-      ( connectUsers (qUnqualified (pUserId creator))
-          . List1
-          . fmap (qUnqualified . pUserId)
-      )
-      (nonEmpty others)
-  pure (creator, others)
-
-withLastPrekeys :: Monad m => State.StateT [LastPrekey] m a -> m a
-withLastPrekeys m = State.evalStateT m someLastPrekeys
-
-setupGroup :: HasCallStack => FilePath -> CreateConv -> Participant -> String -> TestM (Qualified ConvId)
-setupGroup tmp createConv creator name = do
-  (mGroupId, conversation) <- case createNewConv createConv of
-    Nothing -> pure (Nothing, error "No conversation created")
-    Just nc -> do
-      conv <-
-        responseJsonError =<< postConvQualified (qUnqualified (pUserId creator)) nc
-          <!! const 201 === statusCode
-
-      pure (preview (to cnvProtocol . _ProtocolMLS . to cnvmlsGroupId) conv, cnvQualifiedId conv)
-
-  let groupId = toBase64Text (maybe "test_group" unGroupId mGroupId)
-  groupJSON <-
-    liftIO $
-      spawn (cli tmp ["group", pClientQid creator, T.unpack groupId]) Nothing
-  liftIO $ BS.writeFile (tmp </> name) groupJSON
-
-  pure conversation
-
-setupCommit ::
-  (HasCallStack, Foldable f) =>
-  String ->
-  String ->
-  String ->
-  f (String, ClientId) ->
-  IO (ByteString, ByteString)
-setupCommit tmp groupName newGroupName clients =
-  (,)
-    <$> spawn
-      ( cli
-          tmp
-          $ [ "member",
-              "add",
-              "--group",
-              tmp </> groupName,
-              "--welcome-out",
-              tmp </> "welcome",
-              "--group-out",
-              tmp </> newGroupName
-            ]
-            <> map ((tmp </>) . fst) (toList clients)
-      )
-      Nothing
-      <*> BS.readFile (tmp </> "welcome")
-
-takeLastPrekey :: MonadFail m => State.StateT [LastPrekey] m LastPrekey
-takeLastPrekey = do
-  (lpk : lpks) <- State.get
-  State.put lpks
-  pure lpk
-
--- | Setup: Alice creates a group and invites bob. Return welcome and commit message.
-aliceInvitesBob :: HasCallStack => Int -> SetupOptions -> TestM MessagingSetup
-aliceInvitesBob numBobClients opts@SetupOptions {..} = withSystemTempDirectory "mls" $ \tmp -> do
-  (alice, [bob]) <- withLastPrekeys $ setupParticipants tmp opts [numBobClients]
-
-  -- create a group
-  conversation <- setupGroup tmp createConv alice "group"
-
-  -- add bob to it and get welcome message
-  (commit, welcome) <- liftIO $ setupCommit tmp "group" "group" (pClients bob)
-
-  pure $
-    MessagingSetup
-      { creator = alice,
-        users = [bob],
-        ..
-      }
-
-addClient :: HasCallStack => Qualified UserId -> LastPrekey -> TestM ClientId
-addClient u lpk = do
-  let new = newClient PermanentClientType lpk
-
-  brig <- view tsBrig
-  c <-
-    responseJsonError
-      =<< post
-        ( brig
-            . paths ["i", "clients", toByteString' (qUnqualified u)]
-            . zConn "conn"
-            . queryItem "skip_reauth" "true"
-            . json new
-        )
-      <!! const 201 === statusCode
-
-  pure (clientId c)
-
-addKeyPackage :: HasCallStack => Qualified UserId -> ClientId -> RawMLS KeyPackage -> TestM ()
-addKeyPackage u c kp = do
-  let update = defUpdateClient {updateClientMLSPublicKeys = Map.singleton Ed25519 (bcSignatureKey (kpCredential (rmValue kp)))}
-  -- set public key
-  brig <- view tsBrig
-  put
-    ( brig
-        . paths ["clients", toByteString' c]
-        . zUser (qUnqualified u)
-        . json update
-    )
-    !!! const 200 === statusCode
-
-  -- upload key package
-  post
-    ( brig
-        . paths ["mls", "key-packages", "self", toByteString' c]
-        . zUser (qUnqualified u)
-        . json (KeyPackageUpload [kp])
-    )
-    !!! const 201 === statusCode
-
-  -- claim key package (technically, some other user should claim them, but it doesn't really make a difference)
-  bundle <-
-    responseJsonError
-      =<< post
-        ( brig
-            . paths ["mls", "key-packages", "claim", toByteString' (qDomain u), toByteString' (qUnqualified u)]
-            . zUser (qUnqualified u)
-        )
-      <!! const 200 === statusCode
-  liftIO $ map (Just . kpbeRef) (toList (kpbEntries bundle)) @?= [kpRef' kp]
-
-postCommit :: MessagingSetup -> TestM [Event]
-postCommit MessagingSetup {..} = do
-  galley <- viewGalley
-  responseJsonError
-    =<< post
-      ( galley . paths ["mls", "messages"]
-          . zUser (qUnqualified (pUserId creator))
-          . zConn "conn"
-          . content "message/mls"
-          . bytes commit
-      )
-    <!! const 201 === statusCode

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -1,0 +1,300 @@
+{-# LANGUAGE RecordWildCards #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module API.MLS.Util where
+
+import API.Util
+import Bilge
+import Bilge.Assert
+import Control.Lens (preview, to, view)
+import qualified Control.Monad.State as State
+import qualified Data.ByteString as BS
+import Data.ByteString.Conversion
+import Data.Default
+import Data.Domain
+import Data.Id
+import Data.Json.Util
+import Data.List.NonEmpty (NonEmpty, nonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.List1
+import qualified Data.Map as Map
+import Data.Qualified
+import qualified Data.Text as T
+import Imports
+import System.FilePath
+import System.IO.Temp
+import System.Process
+import Test.Tasty.HUnit
+import TestSetup
+import Wire.API.Conversation
+import Wire.API.Conversation.Protocol
+import Wire.API.Event.Conversation
+import Wire.API.MLS.Credential
+import Wire.API.MLS.KeyPackage
+import Wire.API.MLS.Serialisation
+import Wire.API.User.Client
+import Wire.API.User.Client.Prekey
+
+data CreateClients = CreateWithoutKey | CreateWithKey | DontCreateClients
+  deriving (Eq)
+
+data CreateConv = CreateConv | CreateProteusConv | DontCreateConv
+  deriving (Eq)
+
+createNewConv :: CreateConv -> Maybe NewConv
+createNewConv CreateConv = Just defNewMLSConv
+createNewConv CreateProteusConv = Just defNewProteusConv
+createNewConv DontCreateConv = Nothing
+
+data SetupOptions = SetupOptions
+  { createClients :: CreateClients,
+    createConv :: CreateConv,
+    makeConnections :: Bool
+  }
+
+instance Default SetupOptions where
+  def =
+    SetupOptions
+      { createClients = CreateWithKey,
+        createConv = DontCreateConv,
+        makeConnections = True
+      }
+
+data MessagingSetup = MessagingSetup
+  { creator :: Participant,
+    users :: [Participant],
+    conversation :: Qualified ConvId,
+    welcome :: ByteString,
+    commit :: ByteString
+  }
+
+data Participant = Participant
+  { pUserId :: Qualified UserId,
+    pClients :: NonEmpty (String, ClientId)
+  }
+  deriving (Show)
+
+cli :: FilePath -> [String] -> CreateProcess
+cli tmp args =
+  proc "crypto-cli" $
+    ["--store", tmp </> "store.db", "--enc-key", "test"] <> args
+
+pClientQid :: Participant -> String
+pClientQid = fst . NonEmpty.head . pClients
+
+setupUserClient ::
+  HasCallStack =>
+  FilePath ->
+  CreateClients ->
+  Qualified UserId ->
+  State.StateT [LastPrekey] TestM (String, ClientId)
+setupUserClient tmp doCreateClients usr = do
+  lpk <- takeLastPrekey
+  lift $ do
+    -- create client if requested
+    c <- case doCreateClients of
+      DontCreateClients -> randomClient (qUnqualified usr) lpk
+      _ -> addClient usr lpk
+
+    let qcid =
+          show (qUnqualified usr)
+            <> ":"
+            <> T.unpack (client c)
+            <> "@"
+            <> T.unpack (domainText (qDomain usr))
+
+    -- generate key package
+    kp <-
+      liftIO $
+        decodeMLSError
+          =<< spawn (cli tmp ["key-package", qcid]) Nothing
+    liftIO $ BS.writeFile (tmp </> qcid) (rmRaw kp)
+
+    -- set bob's private key and upload key package if required
+    case doCreateClients of
+      CreateWithKey -> addKeyPackage usr c kp
+      _ -> pure ()
+
+    pure (qcid, c)
+
+setupParticipant ::
+  HasCallStack =>
+  FilePath ->
+  CreateClients ->
+  Int ->
+  Qualified UserId ->
+  State.StateT [LastPrekey] TestM Participant
+setupParticipant tmp doCreateClients numClients usr =
+  Participant usr . NonEmpty.fromList
+    <$> replicateM numClients (setupUserClient tmp doCreateClients usr)
+
+setupParticipants ::
+  HasCallStack =>
+  FilePath ->
+  SetupOptions ->
+  [Int] ->
+  State.StateT [LastPrekey] TestM (Participant, [Participant])
+setupParticipants tmp SetupOptions {..} ns = do
+  creator <- lift randomQualifiedUser >>= setupParticipant tmp DontCreateClients 1
+  others <- for ns $ \n ->
+    lift randomQualifiedUser >>= setupParticipant tmp createClients n
+  lift . when makeConnections $
+    traverse_
+      ( connectUsers (qUnqualified (pUserId creator))
+          . List1
+          . fmap (qUnqualified . pUserId)
+      )
+      (nonEmpty others)
+  pure (creator, others)
+
+withLastPrekeys :: Monad m => State.StateT [LastPrekey] m a -> m a
+withLastPrekeys m = State.evalStateT m someLastPrekeys
+
+setupGroup :: HasCallStack => FilePath -> CreateConv -> Participant -> String -> TestM (Qualified ConvId)
+setupGroup tmp createConv creator name = do
+  (mGroupId, conversation) <- case createNewConv createConv of
+    Nothing -> pure (Nothing, error "No conversation created")
+    Just nc -> do
+      conv <-
+        responseJsonError =<< postConvQualified (qUnqualified (pUserId creator)) nc
+          <!! const 201 === statusCode
+
+      pure (preview (to cnvProtocol . _ProtocolMLS . to cnvmlsGroupId) conv, cnvQualifiedId conv)
+
+  let groupId = toBase64Text (maybe "test_group" unGroupId mGroupId)
+  groupJSON <-
+    liftIO $
+      spawn (cli tmp ["group", pClientQid creator, T.unpack groupId]) Nothing
+  liftIO $ BS.writeFile (tmp </> name) groupJSON
+
+  pure conversation
+
+setupCommit ::
+  (HasCallStack, Foldable f) =>
+  String ->
+  String ->
+  String ->
+  f (String, ClientId) ->
+  IO (ByteString, ByteString)
+setupCommit tmp groupName newGroupName clients =
+  (,)
+    <$> spawn
+      ( cli
+          tmp
+          $ [ "member",
+              "add",
+              "--group",
+              tmp </> groupName,
+              "--welcome-out",
+              tmp </> "welcome",
+              "--group-out",
+              tmp </> newGroupName
+            ]
+            <> map ((tmp </>) . fst) (toList clients)
+      )
+      Nothing
+      <*> BS.readFile (tmp </> "welcome")
+
+takeLastPrekey :: MonadFail m => State.StateT [LastPrekey] m LastPrekey
+takeLastPrekey = do
+  (lpk : lpks) <- State.get
+  State.put lpks
+  pure lpk
+
+-- | Setup: Alice creates a group and invites bob. Return welcome and commit message.
+aliceInvitesBob :: HasCallStack => Int -> SetupOptions -> TestM MessagingSetup
+aliceInvitesBob numBobClients opts@SetupOptions {..} = withSystemTempDirectory "mls" $ \tmp -> do
+  (alice, [bob]) <- withLastPrekeys $ setupParticipants tmp opts [numBobClients]
+
+  -- create a group
+  conversation <- setupGroup tmp createConv alice "group"
+
+  -- add bob to it and get welcome message
+  (commit, welcome) <- liftIO $ setupCommit tmp "group" "group" (pClients bob)
+
+  pure $
+    MessagingSetup
+      { creator = alice,
+        users = [bob],
+        ..
+      }
+
+addClient :: HasCallStack => Qualified UserId -> LastPrekey -> TestM ClientId
+addClient u lpk = do
+  let new = newClient PermanentClientType lpk
+
+  brig <- view tsBrig
+  c <-
+    responseJsonError
+      =<< post
+        ( brig
+            . paths ["i", "clients", toByteString' (qUnqualified u)]
+            . zConn "conn"
+            . queryItem "skip_reauth" "true"
+            . json new
+        )
+      <!! const 201 === statusCode
+
+  pure (clientId c)
+
+addKeyPackage :: HasCallStack => Qualified UserId -> ClientId -> RawMLS KeyPackage -> TestM ()
+addKeyPackage u c kp = do
+  let update = defUpdateClient {updateClientMLSPublicKeys = Map.singleton Ed25519 (bcSignatureKey (kpCredential (rmValue kp)))}
+  -- set public key
+  brig <- view tsBrig
+  put
+    ( brig
+        . paths ["clients", toByteString' c]
+        . zUser (qUnqualified u)
+        . json update
+    )
+    !!! const 200 === statusCode
+
+  -- upload key package
+  post
+    ( brig
+        . paths ["mls", "key-packages", "self", toByteString' c]
+        . zUser (qUnqualified u)
+        . json (KeyPackageUpload [kp])
+    )
+    !!! const 201 === statusCode
+
+  -- claim key package (technically, some other user should claim them, but it doesn't really make a difference)
+  bundle <-
+    responseJsonError
+      =<< post
+        ( brig
+            . paths ["mls", "key-packages", "claim", toByteString' (qDomain u), toByteString' (qUnqualified u)]
+            . zUser (qUnqualified u)
+        )
+      <!! const 200 === statusCode
+  liftIO $ map (Just . kpbeRef) (toList (kpbEntries bundle)) @?= [kpRef' kp]
+
+postCommit :: MessagingSetup -> TestM [Event]
+postCommit MessagingSetup {..} = do
+  galley <- viewGalley
+  responseJsonError
+    =<< post
+      ( galley . paths ["mls", "messages"]
+          . zUser (qUnqualified (pUserId creator))
+          . zConn "conn"
+          . content "message/mls"
+          . bytes commit
+      )
+    <!! const 201 === statusCode

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -122,7 +122,7 @@ genConversation =
     <$> arbitrary
     <*> listOf genLocalMember
     <*> listOf genRemoteMember
-    <*> pure (Just False)
+    <*> pure False
     <*> genConversationMetadata
     <*> pure ProtocolProteus
 


### PR DESCRIPTION
Make sure that clients cannot send a proteus message to an MLS conversation, or add and remove users directly using the `/conversations/.../members` endpoints. Add corresponding tests.

Tracked by https://wearezeta.atlassian.net/browse/FS-533.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
