### PR TITLE
Fix bug: User search endpoint hides exact handle results in SearchVisibilityNoNameOutsideTeam setting

### DIFF
--- a/changelog.d/3-bug-fixes/FS-631-fix-search-visibility
+++ b/changelog.d/3-bug-fixes/FS-631-fix-search-visibility
@@ -1,0 +1,1 @@
+Fix bug: User search endpoint hides exact handle results in SearchVisibilityNoNameOutsideTeam setting

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -31,7 +31,6 @@ import qualified Brig.IO.Intra as Intra
 import qualified Brig.Options as Opts
 import Brig.Team.Util (ensurePermissions)
 import Brig.Types.Search as Search
-import Brig.User.API.Handle (contactFromProfile)
 import qualified Brig.User.API.Handle as HandleAPI
 import Brig.User.Search.Index
 import qualified Brig.User.Search.SearchIndex as Q
@@ -155,7 +154,7 @@ searchLocally searcherId searchTerm maybeMaxResults = do
   searcherTeamId <- lift $ wrapClient $ DB.lookupUserTeam searcherId
   teamSearchInfo <- mkTeamSearchInfo searcherTeamId
 
-  maybeExactHandleMatch <- exactHandleSearch teamSearchInfo
+  maybeExactHandleMatch <- exactHandleSearch
 
   let exactHandleMatchCount = length maybeExactHandleMatch
       esMaxResults = maxResults - exactHandleMatchCount
@@ -190,22 +189,14 @@ searchLocally searcherId searchTerm maybeMaxResults = do
               -- For team users, we need to check the visibility flag
               handleTeamVisibility t <$> wrapHttp (Intra.getTeamSearchVisibility t)
 
-    exactHandleSearch :: TeamSearchInfo -> (Handler r) (Maybe Contact)
-    exactHandleSearch teamSearchInfo = do
+    exactHandleSearch :: (Handler r) (Maybe Contact)
+    exactHandleSearch = do
       lsearcherId <- qualifyLocal searcherId
-      let searchedHandleMaybe = parseHandle searchTerm
-      exactHandleResult <-
-        case searchedHandleMaybe of
-          Nothing -> pure Nothing
-          Just searchedHandle ->
-            contactFromProfile
-              <$$> HandleAPI.getLocalHandleInfo lsearcherId searchedHandle
-      pure $ case teamSearchInfo of
-        Search.TeamOnly t ->
-          if Just t == (contactTeam =<< exactHandleResult)
-            then exactHandleResult
-            else Nothing
-        _ -> exactHandleResult
+      case parseHandle searchTerm of
+        Nothing -> pure Nothing
+        Just handle -> do
+          HandleAPI.contactFromProfile
+            <$$> HandleAPI.getLocalHandleInfo lsearcherId handle
 
 teamUserSearchH ::
   ( JSON


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-631

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.