### PR TITLE
Fix: SQSERVICES-1193-stern-backoffice-updating-email-address-for-user-fails-with-status-500

### DIFF
--- a/changelog.d/3-bug-fixes/pr-2281
+++ b/changelog.d/3-bug-fixes/pr-2281
@@ -1,0 +1,1 @@
+Fix update of user email in backoffice/stern

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -333,7 +333,7 @@ changeEmail u upd = do
       "brig"
       b
       ( method PUT
-          . path "/self/email"
+          . path "i/self/email"
           . header "Z-User" (toByteString' u)
           . header "Z-Connection" (toByteString' "")
           . lbytes (encode upd)


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1193

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.