### PR TITLE
Add `skip_own` param to MLS kp claiming endpoint

### DIFF
--- a/changelog.d/2-features/mls
+++ b/changelog.d/2-features/mls
@@ -1,5 +1,6 @@
 MLS implementation progress:
  - commit messages containing add proposals are now processed (#2247)
- - initial validation and forwarding of all types of messages via POST /mls/messages (#2253)
+ - do initial validation and forwarding of all types of messages via POST /mls/messages (#2253)
  - fixed bug where users could not be added to MLS conversations if they had non-MLS clients (#2290)
  - MLS/Proteus mismatches (e.g. sending a proteus message to an MLS conversation) are now handled (#2278)
+ - the `POST /mls/key-packages/claim` endpoint gained a `skip_own` query parameter, which can be used to avoid claiming a key package for the requesting client itself (#2287)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -783,7 +783,7 @@ type MLSKeyPackageAPI =
                         :> QueryParam'
                              [ Optional,
                                Strict,
-                               Description "Do not claim a key packages for the given own client"
+                               Description "Do not claim a key package for the given own client"
                              ]
                              "skip_own"
                              ClientId

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -780,6 +780,13 @@ type MLSKeyPackageAPI =
                     ( "claim"
                         :> Summary "Claim one key package for each client of the given user"
                         :> QualifiedCaptureUserId "user"
+                        :> QueryParam'
+                             [ Optional,
+                               Strict,
+                               Description "Do not claim a key packages for the given own client"
+                             ]
+                             "skip_own"
+                             ClientId
                         :> MultiVerb1 'POST '[JSON] (Respond 200 "Claimed key packages" KeyPackageBundle)
                     )
                 )

--- a/services/brig/src/Brig/API/MLS/KeyPackages.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages.hs
@@ -34,7 +34,6 @@ import Control.Monad.Trans.Maybe
 import Data.Id
 import Data.Qualified
 import qualified Data.Set as Set
-import Debug.Trace
 import Imports
 import Wire.API.Federation.Error
 import Wire.API.MLS.Credential
@@ -60,7 +59,6 @@ claimLocalKeyPackages :: Local UserId -> Maybe ClientId -> Local UserId -> Handl
 claimLocalKeyPackages lusr skipOwn target = do
   -- skip own client when the target is the requesting user itself
   let own = guard (lusr == target) *> skipOwn
-  traceM $ "own: " <> show own
   clients <- map clientId <$> wrapClientE (Data.lookupClients (tUnqualified target))
   withExceptT clientError $
     wrapHttpClientE $ guardLegalhold (ProtectedUser (tUnqualified lusr)) (mkUserClients [(tUnqualified target, clients)])


### PR DESCRIPTION
Clients need to claim key packages for other clients of the same user, but never their own. This adds a `skip_own` query parameter to the key package claiming endpoint, which can be used to prevent wasting a key package for the requesting client.

Tracked by https://wearezeta.atlassian.net/browse/FS-527.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
