### PR TITLE
chore: update nginx to latest stable version (SQSERVICES-1479)

### DIFF
--- a/changelog.d/5-internal/SQSERVICES-1479-nginx
+++ b/changelog.d/5-internal/SQSERVICES-1479-nginx
@@ -1,0 +1,1 @@
+Update nginx to latest stable: v1.20.2

--- a/services/nginz/Dockerfile
+++ b/services/nginz/Dockerfile
@@ -1,5 +1,5 @@
 # Requires docker >= 17.05 (requires support for multi-stage builds)
-FROM alpine:3.11 as libzauth-builder
+FROM alpine:3.15 as libzauth-builder
 
 # Compile libzauth
 COPY libs/libzauth /src/libzauth
@@ -8,7 +8,7 @@ RUN cd /src/libzauth/libzauth-c \
     && make install
 
 # Nginz container
-FROM alpine:3.11
+FROM alpine:3.15
 
 # Install libzauth
 COPY --from=libzauth-builder /usr/local/include/zauth.h /usr/local/include/zauth.h

--- a/services/nginz/Dockerfile
+++ b/services/nginz/Dockerfile
@@ -46,7 +46,7 @@ ENV CONFIG --prefix=/etc/nginx \
 # This uses dockerfile logic from before 1.16
 ####################################################################################
 
-ENV NGINX_VERSION 1.16.1
+ENV NGINX_VERSION 1.20.2
 
 RUN apk update
 

--- a/services/nginz/Makefile
+++ b/services/nginz/Makefile
@@ -1,7 +1,7 @@
 LANG           := en_US.UTF-8
 SHELL          := /usr/bin/env bash
 NAME           := nginz
-NGINX_VERSION   = 1.16.1
+NGINX_VERSION   = 1.20.2
 NGINZ_VERSION  ?=
 SWAGGER_VERSION:= 2.2.10
 ARCH         := $(shell if [ -f "`which dpkg-architecture`" ]; then dpkg-architecture -qDEB_HOST_ARCH; else [ -f "`which dpkg`" ] && dpkg --print-architecture; fi )


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1479

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
