### PR TITLE
Internal brig API: only return MLS clients

### DIFF
--- a/changelog.d/2-features/mls
+++ b/changelog.d/2-features/mls
@@ -2,3 +2,4 @@ MLS implementation progress:
 
  - commit messages containing add proposals are now processed
  - do initial validation and forwarding of all types of messages via POST /mls/messages
+ - fixed bug where users could not be added to MLS conversations if they had non-MLS clients

--- a/libs/wire-api/src/Wire/API/MLS/Credential.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Credential.hs
@@ -19,6 +19,8 @@
 
 module Wire.API.MLS.Credential where
 
+import Control.Error.Util
+import Control.Lens ((?~))
 import Data.Aeson (FromJSON (..), FromJSONKey (..), ToJSON (..), ToJSONKey (..))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
@@ -34,6 +36,7 @@ import qualified Data.Swagger as S
 import qualified Data.Text as T
 import Data.UUID
 import Imports
+import Web.HttpApiData
 import Wire.API.Arbitrary
 import Wire.API.MLS.Serialisation
 
@@ -108,6 +111,12 @@ instance FromJSON SignatureSchemeTag where
 
 instance FromJSONKey SignatureSchemeTag where
   fromJSONKey = Aeson.FromJSONKeyTextParser parseSignatureScheme
+
+instance S.ToParamSchema SignatureSchemeTag where
+  toParamSchema _ = mempty & S.type_ ?~ S.SwaggerString
+
+instance FromHttpApiData SignatureSchemeTag where
+  parseQueryParam = note "Unknown signature scheme" . signatureSchemeFromName
 
 instance ToJSON SignatureSchemeTag where
   toJSON = Aeson.String . signatureSchemeName

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -165,6 +165,7 @@ type GetMLSClients =
     :> "clients"
     :> CanThrow 'UserNotFound
     :> QualifiedCapture "user" UserId
+    :> QueryParam' '[Required, Strict] "sig_scheme" SignatureSchemeTag
     :> MultiVerb1
          'GET
          '[Servant.JSON]

--- a/services/galley/src/Galley/Effects/BrigAccess.hs
+++ b/services/galley/src/Galley/Effects/BrigAccess.hs
@@ -122,7 +122,7 @@ data BrigAccess m a where
   RemoveLegalHoldClientFromUser :: UserId -> BrigAccess m ()
   GetAccountFeatureConfigClient :: UserId -> BrigAccess m TeamFeatureStatusNoConfig
   GetClientByKeyPackageRef :: KeyPackageRef -> BrigAccess m (Maybe ClientIdentity)
-  GetMLSClients :: Qualified UserId -> BrigAccess m (Set ClientId)
+  GetMLSClients :: Qualified UserId -> SignatureSchemeTag -> BrigAccess m (Set ClientId)
   UpdateSearchVisibilityInbound ::
     Multi.TeamStatusUpdate 'TeamFeatureSearchVisibilityInbound ->
     BrigAccess m ()

--- a/services/galley/src/Galley/Intra/Client.hs
+++ b/services/galley/src/Galley/Intra/Client.hs
@@ -182,12 +182,19 @@ getClientByKeyPackageRef ref = do
     else pure Nothing
 
 -- | Calls 'Brig.API.Internal.getMLSClients'.
-getMLSClients :: Qualified UserId -> App (Set ClientId)
-getMLSClients qusr =
+getMLSClients :: Qualified UserId -> SignatureSchemeTag -> App (Set ClientId)
+getMLSClients qusr ss =
   call
     Brig
     ( method GET
-        . paths ["i", "mls", "clients", toByteString' (qDomain qusr), toByteString' (qUnqualified qusr)]
+        . paths
+          [ "i",
+            "mls",
+            "clients",
+            toByteString' (qDomain qusr),
+            toByteString' (qUnqualified qusr)
+          ]
+        . queryItem "sig_scheme" (toByteString' (signatureSchemeName ss))
         . expect2xx
     )
     >>= parseResponse (mkError status502 "server-error")

--- a/services/galley/src/Galley/Intra/Effects.hs
+++ b/services/galley/src/Galley/Intra/Effects.hs
@@ -78,7 +78,7 @@ interpretBrigAccess = interpret $ \case
     embedApp $ getAccountFeatureConfigClient uid
   GetClientByKeyPackageRef ref ->
     embedApp $ getClientByKeyPackageRef ref
-  GetMLSClients qusr -> embedApp $ getMLSClients qusr
+  GetMLSClients qusr ss -> embedApp $ getMLSClients qusr ss
   UpdateSearchVisibilityInbound status ->
     embedApp $ updateSearchVisibilityInbound status
 


### PR DESCRIPTION
This makes it possible to add users to an MLS conversation even if some of their clients don't have MLS public keys (and hence key packages) set up.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
