### PR TITLE
Remove TemplateHaskell as a Global Default Extension

### DIFF
--- a/changelog.d/5-internal/th
+++ b/changelog.d/5-internal/th
@@ -1,0 +1,1 @@
+Remove TemplateHaskell as a global default extension

--- a/libs/api-bot/api-bot.cabal
+++ b/libs/api-bot/api-bot.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 208b12ff1a7bb406c0e9b006b8badb293d9f3fb39750fa4df03a5267cf5d7bfd
+-- hash: 4010a19af0b65ce213a7afb528aa57a5ae3dba5fd870c09d28781afae11d2c4b
 
 name:           api-bot
 version:        0.4.2
@@ -68,7 +68,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/api-client/api-client.cabal
+++ b/libs/api-client/api-client.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c5b993207775ad794fae01115aca3500cbdb2ce9458af0185734c9ee5e025814
+-- hash: 7e6aaa6730e46316c0dc70278f66a66b36707f4eee741ee3c89b736543e36d07
 
 name:           api-client
 version:        0.4.2
@@ -67,7 +67,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/bilge/bilge.cabal
+++ b/libs/bilge/bilge.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 57b03ca9ff6cfe827c27bb6a0f6fb21156c8465d090f29d8a7a3d443bb308137
+-- hash: 02dbb0433605f5282d44accf8028da425b93c7e326c70ac8d2a092abab8db504
 
 name:           bilge
 version:        0.22.0
@@ -67,7 +67,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/brig-types/brig-types.cabal
+++ b/libs/brig-types/brig-types.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a7cacdf99171212e57ec80402a14ea2967be26c201f71bf7d114ff504e76ef76
+-- hash: 2e6bc533a2e630a022751905d911a3d50831c4351143ff9d1e0eb07d298ae422
 
 name:           brig-types
 version:        1.35.0
@@ -76,7 +76,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -151,7 +150,6 @@ test-suite brig-types-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/cargohold-types/cargohold-types.cabal
+++ b/libs/cargohold-types/cargohold-types.cabal
@@ -55,7 +55,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/cassandra-util/cassandra-util.cabal
+++ b/libs/cassandra-util/cassandra-util.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aaa0bf2f2e8b434044d86eef4704bf30525c4c86315058ba1290f1d34d561c9e
+-- hash: 23fae7c145e7caafdaf90ad2186c54ceffc973065e99ac6032b0241e9cb8c243
 
 name:           cassandra-util
 version:        0.16.5
@@ -61,7 +61,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/deriving-swagger2/deriving-swagger2.cabal
+++ b/libs/deriving-swagger2/deriving-swagger2.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 314df46c4097fb6a56f853e430a9148ccc7ee76375387bec6d03b68c1827f51f
+-- hash: f47dc031ff87a0941f316c2a34d49f1bc02319b7f3928c827e02b3bece3b819c
 
 name:           deriving-swagger2
 version:        0.1.0
@@ -56,7 +56,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/dns-util/dns-util.cabal
+++ b/libs/dns-util/dns-util.cabal
@@ -57,7 +57,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -115,7 +114,6 @@ test-suite spec
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/dns-util/src/Wire/Network/DNS/Effect.hs
+++ b/libs/dns-util/src/Wire/Network/DNS/Effect.hs
@@ -14,6 +14,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE TemplateHaskell #-}
 
 module Wire.Network.DNS.Effect where
 

--- a/libs/extended/extended.cabal
+++ b/libs/extended/extended.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 380f8ec2858bc5b11252ece06a472e4458f97cff4803d261b6d9624d2d0793bf
+-- hash: eabbe291d09871089819aa74d6757844129d5fa04f6ed0598668c45e9ff03032
 
 name:           extended
 version:        0.1.0
@@ -62,7 +62,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -132,7 +131,6 @@ test-suite extended-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/galley-types/galley-types.cabal
+++ b/libs/galley-types/galley-types.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9cb223453735258513c78908da15528c4b26797a131e07788f0dee41a0c469a4
+-- hash: 9468b34d92756358ec15e112490166749eeb8aa4c15ec1db90adf33e41c11e7d
 
 name:           galley-types
 version:        0.81.0
@@ -65,7 +65,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -139,7 +138,6 @@ test-suite galley-types-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/gundeck-types/gundeck-types.cabal
+++ b/libs/gundeck-types/gundeck-types.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5e5b9d44e914092fd283c32d8a12768443221b3f7f7e0f41cc1388f17f4ce373
+-- hash: 5ecbff5b5248085ccaf245621fb9388ff13a1cdace8dff356ea98ccd1cb72a03
 
 name:           gundeck-types
 version:        1.45.0
@@ -63,7 +63,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/imports/imports.cabal
+++ b/libs/imports/imports.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 09458f8cad6c5214c9692291bb633f780944463c5690e2af99d7e516dc93e0f2
+-- hash: f1840a866c870bac6a0aa233336162df7b3552185882820814eec869d0df3986
 
 name:           imports
 version:        0.1.0
@@ -61,7 +61,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/metrics-core/metrics-core.cabal
+++ b/libs/metrics-core/metrics-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ed00633977e31daad2e0efcc5e21e8e4a800a2737e5848e9b0770091f9a94b3d
+-- hash: 94e1bf0c93057c9abbeafa85bd4d465c71e20c3bda5a8962cfaad8431861ddd5
 
 name:           metrics-core
 version:        0.3.2
@@ -57,7 +57,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/metrics-wai/metrics-wai.cabal
+++ b/libs/metrics-wai/metrics-wai.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aa7fa2126e1b9420894641828a3548c191a7daa9c997585531827b092557e393
+-- hash: 727df0d926b5aa3f82005a16adac9fe9099398b9a6e997936897d6252201f249
 
 name:           metrics-wai
 version:        0.5.7
@@ -61,7 +61,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -128,7 +127,6 @@ test-suite unit
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
+++ b/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4b1ed885b5ee0e7a49013f134724d41277e8cc3ff45a6023404e24793c6303c5
+-- hash: 2c188321de9d8fa1e3a3ebbb8568be60f828a72db398a28e8c590e49d5ae9f05
 
 name:           polysemy-wire-zoo
 version:        0.1.0
@@ -56,7 +56,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/polysemy-wire-zoo/src/Polysemy/TinyLog.hs
+++ b/libs/polysemy-wire-zoo/src/Polysemy/TinyLog.hs
@@ -14,6 +14,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE TemplateHaskell #-}
 
 module Polysemy.TinyLog where
 

--- a/libs/ropes/ropes.cabal
+++ b/libs/ropes/ropes.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8ecd96e484d77945f2e5e3bf9e52fbe5847ee47bdfa13e7ecb07c186db73e04c
+-- hash: 4dc14749b24ff2e418dca953beb2c1fa2903c5c3b99832c11ec99ddc401476c6
 
 name:           ropes
 version:        0.4.20
@@ -57,7 +57,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/schema-profunctor/schema-profunctor.cabal
+++ b/libs/schema-profunctor/schema-profunctor.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fa464d91df7452e4c1891d1d922b9998bdff09e33af3b55625efa52adb24aaff
+-- hash: 7bd983abb154f5addeacc46487c7b2d05ab07a6fcc4aa1012c25f028e2f90d13
 
 name:           schema-profunctor
 version:        0.1.0
@@ -56,7 +56,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -120,7 +119,6 @@ test-suite schemas-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
+++ b/libs/schema-profunctor/test/unit/Test/Data/Schema.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/libs/sodium-crypto-sign/sodium-crypto-sign.cabal
+++ b/libs/sodium-crypto-sign/sodium-crypto-sign.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7f0ee2a8b0a69d4f589716632e47f0b9bd431ca5cbfd7a8bf5dfe273c6489de0
+-- hash: 188b33e448d43772b1e4a01c070e1148acb30cf546bc088c21c3838d16a645cb
 
 name:           sodium-crypto-sign
 version:        0.1.2
@@ -57,7 +57,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/ssl-util/ssl-util.cabal
+++ b/libs/ssl-util/ssl-util.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d91dea84564b802aae13b5514b1babf2f1a50b0d33a58bc7dade37d6c60c2182
+-- hash: 310c78c8c607c96c8c81469672bbd44ec95e9c65c63a8506f67fd66cbd124f21
 
 name:           ssl-util
 version:        0.1.0
@@ -57,7 +57,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/tasty-cannon/tasty-cannon.cabal
+++ b/libs/tasty-cannon/tasty-cannon.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2d2de3cb5a7dcf524d840d49e590bea00dd40610a5488224cf4b25b15991f64b
+-- hash: 33f3a557e5296946dc5929fd741dfa0bb68e83484e1760cd425204e7defec8af
 
 name:           tasty-cannon
 version:        0.4.0
@@ -56,7 +56,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/types-common-aws/types-common-aws.cabal
+++ b/libs/types-common-aws/types-common-aws.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b83bb5e2ebe7499bdd426bff59d23e2c08935fc24e6f182114fd5ef296f19928
+-- hash: e21810d1081ee50f1d775ea6112131f62a9fb270d33d2c8a44024afa384a34ff
 
 name:           types-common-aws
 version:        0.16.0
@@ -67,7 +67,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/types-common/types-common.cabal
+++ b/libs/types-common/types-common.cabal
@@ -75,7 +75,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -179,7 +178,6 @@ test-suite tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/wai-utilities/wai-utilities.cabal
+++ b/libs/wai-utilities/wai-utilities.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f032f8354316816e361796a0e1b2d5da703e8d447d4b12f9e6cab7be5e252e6f
+-- hash: 090b7ff6c002f582879792716227598a444bd914d78ddba5861072bf5e6796da
 
 name:           wai-utilities
 version:        0.16.1
@@ -63,7 +63,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -64,7 +64,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -159,7 +158,6 @@ test-suite spec
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -15,6 +15,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 {-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TemplateHaskell #-}
 -- Ignore unused `genSingletons` Template Haskell results
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 

--- a/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
+++ b/libs/wire-api/src/Wire/API/Event/FeatureConfig.hs
@@ -14,6 +14,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE TemplateHaskell #-}
 
 module Wire.API.Event.FeatureConfig
   ( Event (..),

--- a/libs/wire-api/src/Wire/API/MLS/Extension.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Extension.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/libs/wire-api/src/Wire/API/MLS/Message.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Message.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
+++ b/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
@@ -14,6 +14,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE TemplateHaskell #-}
 
 module Wire.API.User.IdentityProvider where
 

--- a/libs/wire-api/src/Wire/API/User/Saml.hs
+++ b/libs/wire-api/src/Wire/API/User/Saml.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/libs/wire-api/src/Wire/API/User/Search.hs
+++ b/libs/wire-api/src/Wire/API/User/Search.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -156,7 +156,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -529,7 +528,6 @@ test-suite wire-api-golden-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -634,7 +632,6 @@ test-suite wire-api-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/libs/zauth/zauth.cabal
+++ b/libs/zauth/zauth.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 645c91889ea532ce07463edf54a10559d3f581091b53c20903607d9800f6fa3f
+-- hash: e57665a219e79f60ac611473191a4fadac25f8dcca93aad3bb1ca7c9ab06604e
 
 name:           zauth
 version:        0.10.3
@@ -62,7 +62,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -127,7 +126,6 @@ executable zauth
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -191,7 +189,6 @@ test-suite zauth-unit
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/package-defaults.yaml
+++ b/package-defaults.yaml
@@ -40,7 +40,6 @@ default-extensions:
 - RankNTypes
 - ScopedTypeVariables
 - StandaloneDeriving
-- TemplateHaskell
 - TupleSections
 - TypeApplications
 - TypeFamilies

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -162,7 +162,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -330,7 +329,6 @@ executable brig
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -384,7 +382,6 @@ executable brig-index
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -470,7 +467,6 @@ executable brig-integration
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -662,7 +658,6 @@ executable brig-schema
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -727,7 +722,6 @@ test-suite brig-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/services/brig/src/Brig/AWS.hs
+++ b/services/brig/src/Brig/AWS.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
 -- FUTUREWORK: Get rid of this option once Polysemy is fully introduced to Brig
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/services/brig/src/Brig/Calling.hs
+++ b/services/brig/src/Brig/Calling.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/brig/src/Brig/Index/Options.hs
+++ b/services/brig/src/Brig/Index/Options.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/brig/src/Brig/User/Search/Index/Types.hs
+++ b/services/brig/src/Brig/User/Search/Index/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/brig/src/Brig/ZAuth.hs
+++ b/services/brig/src/Brig/ZAuth.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/cannon/cannon.cabal
+++ b/services/cannon/cannon.cabal
@@ -68,7 +68,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -156,7 +155,6 @@ executable cannon
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -215,7 +213,6 @@ test-suite cannon-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -283,7 +280,6 @@ benchmark cannon-bench
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/services/cannon/src/Cannon/Options.hs
+++ b/services/cannon/src/Cannon/Options.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
 -- This file is part of the Wire Server implementation.

--- a/services/cargohold/cargohold.cabal
+++ b/services/cargohold/cargohold.cabal
@@ -75,7 +75,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -174,7 +173,6 @@ executable cargohold
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -254,7 +252,6 @@ executable cargohold-integration
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/services/cargohold/src/CargoHold/App.hs
+++ b/services/cargohold/src/CargoHold/App.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/cargohold/src/CargoHold/Options.hs
+++ b/services/cargohold/src/CargoHold/Options.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/cargohold/test/integration/TestSetup.hs
+++ b/services/cargohold/test/integration/TestSetup.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -91,7 +91,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -197,7 +196,6 @@ executable federator
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -308,7 +306,6 @@ executable federator-integration
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -436,7 +433,6 @@ test-suite federator-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/services/federator/src/Federator/Discovery.hs
+++ b/services/federator/src/Federator/Discovery.hs
@@ -14,6 +14,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE TemplateHaskell #-}
 
 module Federator.Discovery where
 

--- a/services/federator/src/Federator/Env.hs
+++ b/services/federator/src/Federator/Env.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/federator/src/Federator/Remote.hs
+++ b/services/federator/src/Federator/Remote.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/federator/src/Federator/Service.hs
+++ b/services/federator/src/Federator/Service.hs
@@ -14,6 +14,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE TemplateHaskell #-}
 
 module Federator.Service
   ( Service (..),

--- a/services/federator/test/integration/Test/Federator/Util.hs
+++ b/services/federator/test/integration/Test/Federator/Util.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 -- This file is part of the Wire Server implementation.

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -162,7 +162,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -303,7 +302,6 @@ executable galley
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -389,7 +387,6 @@ executable galley-integration
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -533,7 +530,6 @@ executable galley-migrate-data
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -656,7 +652,6 @@ executable galley-schema
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -733,7 +728,6 @@ test-suite galley-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/services/galley/src/Galley/API/Push.hs
+++ b/services/galley/src/Galley/API/Push.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/galley/src/Galley/Aws.hs
+++ b/services/galley/src/Galley/Aws.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/galley/src/Galley/Effects/BotAccess.hs
+++ b/services/galley/src/Galley/Effects/BotAccess.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/BrigAccess.hs
+++ b/services/galley/src/Galley/Effects/BrigAccess.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/ClientStore.hs
+++ b/services/galley/src/Galley/Effects/ClientStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/CodeStore.hs
+++ b/services/galley/src/Galley/Effects/CodeStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/ConversationStore.hs
+++ b/services/galley/src/Galley/Effects/ConversationStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/CustomBackendStore.hs
+++ b/services/galley/src/Galley/Effects/CustomBackendStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/ExternalAccess.hs
+++ b/services/galley/src/Galley/Effects/ExternalAccess.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/FederatorAccess.hs
+++ b/services/galley/src/Galley/Effects/FederatorAccess.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/FireAndForget.hs
+++ b/services/galley/src/Galley/Effects/FireAndForget.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/GundeckAccess.hs
+++ b/services/galley/src/Galley/Effects/GundeckAccess.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/LegalHoldStore.hs
+++ b/services/galley/src/Galley/Effects/LegalHoldStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/ListItems.hs
+++ b/services/galley/src/Galley/Effects/ListItems.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/MemberStore.hs
+++ b/services/galley/src/Galley/Effects/MemberStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/Queue.hs
+++ b/services/galley/src/Galley/Effects/Queue.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/RemoteConversationListStore.hs
+++ b/services/galley/src/Galley/Effects/RemoteConversationListStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/SearchVisibilityStore.hs
+++ b/services/galley/src/Galley/Effects/SearchVisibilityStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/ServiceStore.hs
+++ b/services/galley/src/Galley/Effects/ServiceStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/SparAccess.hs
+++ b/services/galley/src/Galley/Effects/SparAccess.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/TeamFeatureStore.hs
+++ b/services/galley/src/Galley/Effects/TeamFeatureStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/TeamMemberStore.hs
+++ b/services/galley/src/Galley/Effects/TeamMemberStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/TeamNotificationStore.hs
+++ b/services/galley/src/Galley/Effects/TeamNotificationStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/TeamStore.hs
+++ b/services/galley/src/Galley/Effects/TeamStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Effects/WaiRoutes.hs
+++ b/services/galley/src/Galley/Effects/WaiRoutes.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Env.hs
+++ b/services/galley/src/Galley/Env.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/Intra/Push/Internal.hs
+++ b/services/galley/src/Galley/Intra/Push/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fprint-potential-instances #-}
 
 -- This file is part of the Wire Server implementation.

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b5ae0ca8cfcc22e0751375eaf5b925d7557c88056d881b85cf7d82e3a8c322be
+-- hash: 14e7d21fd4304ef1b51679e0624e9c632777ddb5e43509ed96d4dff1a2ab1f27
 
 name:           gundeck
 version:        1.45.0
@@ -90,7 +90,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -191,7 +190,6 @@ executable gundeck
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -256,7 +254,6 @@ executable gundeck-integration
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -350,7 +347,6 @@ executable gundeck-schema
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -418,7 +414,6 @@ test-suite gundeck-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -504,7 +499,6 @@ benchmark gundeck-bench
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/services/gundeck/src/Gundeck/Aws.hs
+++ b/services/gundeck/src/Gundeck/Aws.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/gundeck/src/Gundeck/Aws/Arn.hs
+++ b/services/gundeck/src/Gundeck/Aws/Arn.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/gundeck/src/Gundeck/Aws/Sns.hs
+++ b/services/gundeck/src/Gundeck/Aws/Sns.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/gundeck/src/Gundeck/Env.hs
+++ b/services/gundeck/src/Gundeck/Env.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/gundeck/src/Gundeck/Options.hs
+++ b/services/gundeck/src/Gundeck/Options.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/gundeck/src/Gundeck/Push/Native/Types.hs
+++ b/services/gundeck/src/Gundeck/Push/Native/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/gundeck/test/integration/TestSetup.hs
+++ b/services/gundeck/test/integration/TestSetup.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fprint-potential-instances #-}
 
 -- This file is part of the Wire Server implementation.

--- a/services/gundeck/test/unit/MockGundeck.hs
+++ b/services/gundeck/test/unit/MockGundeck.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/services/gundeck/test/unit/ThreadBudget.hs
+++ b/services/gundeck/test/unit/ThreadBudget.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/services/proxy/proxy.cabal
+++ b/services/proxy/proxy.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0dc85028d7242fe9422dc7b97417fd157c235bd8b6aa74a3c61f093e04e0f57a
+-- hash: 85ab17a3a3feb5b0d7f421806119efcd5694b145482efa1259c4500bc3268092
 
 name:           proxy
 version:        0.9.0
@@ -67,7 +67,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -142,7 +141,6 @@ executable proxy
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/services/proxy/src/Proxy/Env.hs
+++ b/services/proxy/src/Proxy/Env.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/proxy/src/Proxy/Options.hs
+++ b/services/proxy/src/Proxy/Options.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/migrate-data/src/Spar/DataMigration/Types.hs
+++ b/services/spar/migrate-data/src/Spar/DataMigration/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -126,7 +126,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -241,7 +240,6 @@ executable spar
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -371,7 +369,6 @@ executable spar-integration
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -505,7 +502,6 @@ executable spar-migrate-data
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -638,7 +634,6 @@ executable spar-schema
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -767,7 +762,6 @@ test-suite spec
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/services/spar/src/Spar/Sem/AReqIDStore.hs
+++ b/services/spar/src/Spar/Sem/AReqIDStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/AssIDStore.hs
+++ b/services/spar/src/Spar/Sem/AssIDStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/BindCookieStore.hs
+++ b/services/spar/src/Spar/Sem/BindCookieStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/BrigAccess.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/DefaultSsoCode.hs
+++ b/services/spar/src/Spar/Sem/DefaultSsoCode.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/GalleyAccess.hs
+++ b/services/spar/src/Spar/Sem/GalleyAccess.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/IdPConfigStore.hs
+++ b/services/spar/src/Spar/Sem/IdPConfigStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/IdPRawMetadataStore.hs
+++ b/services/spar/src/Spar/Sem/IdPRawMetadataStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/Logger.hs
+++ b/services/spar/src/Spar/Sem/Logger.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/Now.hs
+++ b/services/spar/src/Spar/Sem/Now.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/Random.hs
+++ b/services/spar/src/Spar/Sem/Random.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/Reporter.hs
+++ b/services/spar/src/Spar/Sem/Reporter.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/SAML2.hs
+++ b/services/spar/src/Spar/Sem/SAML2.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/SAMLUserStore.hs
+++ b/services/spar/src/Spar/Sem/SAMLUserStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/SamlProtocolSettings.hs
+++ b/services/spar/src/Spar/Sem/SamlProtocolSettings.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/ScimExternalIdStore.hs
+++ b/services/spar/src/Spar/Sem/ScimExternalIdStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/ScimTokenStore.hs
+++ b/services/spar/src/Spar/Sem/ScimTokenStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/ScimUserTimesStore.hs
+++ b/services/spar/src/Spar/Sem/ScimUserTimesStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/src/Spar/Sem/VerdictFormatStore.hs
+++ b/services/spar/src/Spar/Sem/VerdictFormatStore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/spar/test-integration/Util/Types.hs
+++ b/services/spar/test-integration/Util/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --

--- a/tools/api-simulations/api-simulations.cabal
+++ b/tools/api-simulations/api-simulations.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cc1ee9817c17b416b041da1872f67634723249762332426dc63b0b1ab43309e8
+-- hash: 6fadbcf542408132b2419f8f1b77897b9b1810d44ade8606c2572d6adf445ccd
 
 name:           api-simulations
 version:        0.4.2
@@ -57,7 +57,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -120,7 +119,6 @@ executable api-loadtest
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -191,7 +189,6 @@ executable api-smoketest
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/tools/bonanza/bonanza.cabal
+++ b/tools/bonanza/bonanza.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4c3c3c61ce43c6d11f5eed921640d7a287b190e400bc86db238b2aafac7d5c40
+-- hash: ffc381288ee6d06f96874ae5e486cc962dfb84f417859c96f4b3f60531aeb634
 
 name:           bonanza
 version:        3.6.0
@@ -76,7 +76,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -154,7 +153,6 @@ executable bonanza
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -209,7 +207,6 @@ executable kibana-raw
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -268,7 +265,6 @@ executable kibanana
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -336,7 +332,6 @@ test-suite bonanza-tests
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/tools/db/auto-whitelist/auto-whitelist.cabal
+++ b/tools/db/auto-whitelist/auto-whitelist.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aecd5a2bbe1504d3601577aed1719da584856f3d5f53327650f3c80331619269
+-- hash: 21225065d665150349c1451aa1276c9dae47b282d5532b251e4ad3a1b3e08061
 
 name:           auto-whitelist
 version:        1.0.0
@@ -56,7 +56,6 @@ executable auto-whitelist
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/tools/db/billing-team-member-backfill/billing-team-member-backfill.cabal
+++ b/tools/db/billing-team-member-backfill/billing-team-member-backfill.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ada20e0991745d0c8999668355177fca0aef12891245e599d89f28228f0961d4
+-- hash: 69b89f4d76894f5121e8fbff700727500dc0f48747dda5b75f74d7ce16ad4f84
 
 name:           billing-team-member-backfill
 version:        1.0.0
@@ -56,7 +56,6 @@ executable billing-team-member-backfill
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/tools/db/find-undead/find-undead.cabal
+++ b/tools/db/find-undead/find-undead.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 30202a4d538697375b0b0dc3d4789ad278c7b41e40169f1b41c538410d03d3da
+-- hash: adce5275484bd0fc90a6377e1637cb7e61416b644d1cee3b97f6e161e9fe610f
 
 name:           find-undead
 version:        1.0.0
@@ -56,7 +56,6 @@ executable find-undead
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/tools/db/migrate-sso-feature-flag/migrate-sso-feature-flag.cabal
+++ b/tools/db/migrate-sso-feature-flag/migrate-sso-feature-flag.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6a64c18d59c109cea4e58b9161d589c395fa1b34ba2705060aebc4926ee1f618
+-- hash: b2b29448c5c69da6fab48930b3ddbb84107bd66b81e718bc334f6a8d60c03b51
 
 name:           migrate-sso-feature-flag
 version:        1.0.0
@@ -56,7 +56,6 @@ executable migrate-sso-feature-flag
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/tools/db/move-team/move-team.cabal
+++ b/tools/db/move-team/move-team.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2168cecbb403740519009eb790938bbfec816c047f81bc1ec44d6157ff798516
+-- hash: a58bc40fc81a030528f9e4fbae86ecbbf74587d181f2c057c8576a04ad0e1f5c
 
 name:           move-team
 version:        1.0.0
@@ -60,7 +60,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -134,7 +133,6 @@ executable move-team
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -209,7 +207,6 @@ executable move-team-generate
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/tools/db/repair-handles/repair-handles.cabal
+++ b/tools/db/repair-handles/repair-handles.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c8ad3a3ca71a54e03d9bb6572dad0629da8c5940cfe20febf7cf1971d549f042
+-- hash: 2fd7ca4c3831fd4ea777bb2e936d638a9c10ecc613230bd5ad75212872abc110
 
 name:           repair-handles
 version:        1.0.0
@@ -58,7 +58,6 @@ executable repair-handles
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/tools/db/repair-handles/src/Types.hs
+++ b/tools/db/repair-handles/src/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/tools/db/service-backfill/service-backfill.cabal
+++ b/tools/db/service-backfill/service-backfill.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d72d11c1f8954ebb055cecdaed92fb6e31c1b534a8083b486f14bbcf5849e0ba
+-- hash: eea1868ca30f5a543a41c3059a0f4dd1dc220703b7e0ffe78baa4e70381e9934
 
 name:           service-backfill
 version:        1.0.0
@@ -56,7 +56,6 @@ executable service-backfill
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/tools/makedeb/makedeb.cabal
+++ b/tools/makedeb/makedeb.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 80100f7bcc806d6eef6f942564fb7afa966abe1df367224e68b29a904fbe3cf2
+-- hash: 261411519b3ae85505adfff99bfb0679316824330e5ae1e8742948509ddd5778
 
 name:           makedeb
 version:        0.3.0
@@ -59,7 +59,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -114,7 +113,6 @@ executable makedeb
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies

--- a/tools/stern/stern.cabal
+++ b/tools/stern/stern.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 546e7936cf8835f249ceaf80c981335ff160a2848a48cc55a707845fc3c5d2c5
+-- hash: 5287c14ec315c7bd7ae56515e9b34de87068021daadd44a2b122056bb62c9bc3
 
 name:           stern
 version:        1.7.2
@@ -67,7 +67,6 @@ library
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
@@ -152,7 +151,6 @@ executable stern
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
-      TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies


### PR DESCRIPTION
`TemplateHaskell` as a language extension can lead to unnecessary recompilations. To aid GHC in figuring out what needs recompilation, this PR removes `TemplateHaskell` as a global default extension and moves it to modules that do need it. Hopefully this reduces the compilation time by a noticeable amount of time.

The one-line change that triggered the rest is the removal of `TemplateHaskell` from `package-defaults.yaml`.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
