### PR TITLE
bulkpush on by default in gundeck's helm chart

### DIFF
--- a/changelog.d/5-internal/bulkpush-default
+++ b/changelog.d/5-internal/bulkpush-default
@@ -1,0 +1,1 @@
+Chart/gundeck's 'bulkpush' optimization is now activated by default (after using it in production for some time)

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -19,7 +19,7 @@ config:
   redis:
     host: redis-ephemeral-master
     port: 6379
-  bulkPush: false
+  bulkPush: true
   aws:
     region: "eu-west-1"
   proxy: {}


### PR DESCRIPTION
We've been using this setting ourselves for months as can be seen in https://github.com/zinfra/cailleach/blob/master/environments/hegemony/roles/gundeck/vars/main.yml#L11-L12 - there's no reason this should not be the default these days.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):