### PR TITLE
Gundeck: Avoid dropping messages when redis is down

### DIFF
--- a/changelog.d/2-features/tolerate-redis-down
+++ b/changelog.d/2-features/tolerate-redis-down
@@ -1,0 +1,1 @@
+*  Avoid dropping messages when redis is down.

--- a/libs/types-common/src/Util/Test.hs
+++ b/libs/types-common/src/Util/Test.hs
@@ -42,8 +42,7 @@ instance IsOption IntegrationConfigFile where
             <> help (untag (optionHelp :: Tagged IntegrationConfigFile String))
         )
 
-handleParseError :: (Show a) => Either a b -> IO (Maybe b)
+handleParseError :: (Show a) => Either a b -> IO b
 handleParseError (Left err) = do
-  putStrLn $ "Parse failed: " ++ show err ++ "\nFalling back to environment variables"
-  pure Nothing
-handleParseError (Right val) = pure $ Just val
+  error $ "Parse failed: " ++ show err ++ "\nFalling back to environment variables"
+handleParseError (Right val) = pure val

--- a/libs/wai-utilities/package.yaml
+++ b/libs/wai-utilities/package.yaml
@@ -19,6 +19,7 @@ dependencies:
 - exceptions >=0.6
 - http-types >=0.8
 - imports
+- kan-extensions
 - metrics-core >=0.1
 - metrics-wai >=0.5.7
 - pipes >=4.1
@@ -34,5 +35,6 @@ dependencies:
 - wai-predicates >=0.8
 - wai-routing >=0.12
 - warp >=3.0
+- warp-tls
 library:
   source-dirs: src

--- a/libs/wai-utilities/src/Network/Wai/Utilities/MockServer.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/MockServer.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Network.Wai.Utilities.MockServer where
+
+import qualified Control.Concurrent.Async as Async
+import Control.Exception (throw)
+import Control.Monad.Catch
+import Control.Monad.Codensity
+import Data.Streaming.Network (bindRandomPortTCP)
+import Imports
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
+import qualified Network.Wai.Handler.WarpTLS as Warp
+import qualified System.Timeout as System
+
+-- | Thrown in IO by mock federator if the server could not be started after 10
+-- seconds.
+newtype MockTimeout = MockTimeout Warp.Port
+  deriving (Eq, Show, Typeable)
+
+instance Exception MockTimeout
+
+withMockServer :: Wai.Application -> Codensity IO Word16
+withMockServer app = Codensity $ \k ->
+  bracket
+    (liftIO $ startMockServer Nothing app)
+    (liftIO . fst)
+    (k . fromIntegral . snd)
+
+-- | Start a mock warp server on a random port, serving the given Wai application.
+--
+-- If the 'Warp.TLSSettings` argument is provided, start an HTTPS server,
+-- otherwise start a plain HTTP server.
+--
+-- Returns an action to kill the spawned server, and the port on which the
+-- server is running.
+--
+-- This function should normally be used within 'bracket', e.g.:
+-- @
+--     bracket (startMockServer Nothing app) fst $ \(close, port) ->
+--       makeRequest "localhost" port
+-- @
+startMockServer :: Maybe Warp.TLSSettings -> Wai.Application -> IO (IO (), Warp.Port)
+startMockServer mtlsSettings app = do
+  (port, sock) <- bindRandomPortTCP "*6"
+  serverStarted <- newEmptyMVar
+  let wsettings =
+        Warp.defaultSettings
+          & Warp.setPort port
+          & Warp.setGracefulCloseTimeout2 0 -- Defaults to 2 seconds, causes server stop to take very long
+          & Warp.setBeforeMainLoop (putMVar serverStarted ())
+
+  serverThread <- Async.async $ case mtlsSettings of
+    Just tlsSettings -> Warp.runTLSSocket tlsSettings wsettings sock app
+    Nothing -> Warp.runSettingsSocket wsettings sock app
+  serverStartedSignal <- System.timeout 10_000_000 (readMVar serverStarted)
+  let closeMock = do
+        me <- Async.poll serverThread
+        case me of
+          Nothing -> Async.cancel serverThread
+          Just (Left e) -> throw e
+          Just (Right a) -> pure a
+  case serverStartedSignal of
+    Nothing -> do
+      Async.cancel serverThread
+      throw (MockTimeout port)
+    Just _ -> pure (closeMock, port)

--- a/libs/wai-utilities/wai-utilities.cabal
+++ b/libs/wai-utilities/wai-utilities.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 090b7ff6c002f582879792716227598a444bd914d78ddba5861072bf5e6796da
+-- hash: 3aa2434fe6abab51a3be2ffd8f4f18d39c76a71453c3ffbabe1bbc609cec096a
 
 name:           wai-utilities
 version:        0.16.1
@@ -22,6 +22,7 @@ library
   exposed-modules:
       Network.Wai.Utilities
       Network.Wai.Utilities.Error
+      Network.Wai.Utilities.MockServer
       Network.Wai.Utilities.Request
       Network.Wai.Utilities.Response
       Network.Wai.Utilities.Server
@@ -81,6 +82,7 @@ library
     , exceptions >=0.6
     , http-types >=0.8
     , imports
+    , kan-extensions
     , metrics-core >=0.1
     , metrics-wai >=0.5.7
     , pipes >=4.1
@@ -96,4 +98,5 @@ library
     , wai-predicates >=0.8
     , wai-routing >=0.12
     , warp >=3.0
+    , warp-tls
   default-language: Haskell2010

--- a/services/cargohold/test/integration/API/Util.hs
+++ b/services/cargohold/test/integration/API/Util.hs
@@ -23,7 +23,6 @@ import CargoHold.Run
 import qualified Codec.MIME.Parse as MIME
 import qualified Codec.MIME.Type as MIME
 import Control.Lens
-import Control.Monad.Catch
 import Control.Monad.Codensity
 import Data.ByteString.Builder
 import Data.ByteString.Conversion
@@ -38,7 +37,7 @@ import Imports hiding (head)
 import qualified Network.HTTP.Media as HTTP
 import Network.HTTP.Types.Header
 import Network.HTTP.Types.Method
-import qualified Network.Wai as Wai
+import Network.Wai.Utilities.MockServer
 import TestSetup
 import Util.Options
 import Wire.API.Asset
@@ -173,13 +172,6 @@ viewFederationDomain = view (tsOpts . optSettings . setFederationDomain)
 
 --------------------------------------------------------------------------------
 -- Mocking utilities
-
-withMockServer :: Wai.Application -> Codensity IO Word16
-withMockServer app = Codensity $ \k ->
-  bracket
-    (liftIO $ startMockServer Nothing app)
-    (liftIO . fst)
-    (k . fromIntegral . snd)
 
 withSettingsOverrides :: (Opts -> Opts) -> TestM a -> TestM a
 withSettingsOverrides f action = do

--- a/services/federator/test/unit/Test/Federator/Client.hs
+++ b/services/federator/test/unit/Test/Federator/Client.hs
@@ -35,6 +35,7 @@ import Network.HTTP.Types as HTTP
 import qualified Network.HTTP2.Client as HTTP2
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Utilities.Error as Wai
+import Network.Wai.Utilities.MockServer
 import Servant.API
 import Servant.Client hiding ((//))
 import Servant.Client.Core

--- a/services/federator/test/unit/Test/Federator/Remote.hs
+++ b/services/federator/test/unit/Test/Federator/Remote.hs
@@ -22,7 +22,6 @@ import Control.Monad.Codensity
 import Data.Domain
 import Federator.Discovery
 import Federator.Env (TLSSettings)
-import Federator.MockServer (startMockServer)
 import Federator.Options
 import Federator.Remote
 import Federator.Run (mkTLSSettingsOrThrow)
@@ -31,6 +30,7 @@ import Network.HTTP.Types (status200)
 import Network.Wai
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.WarpTLS as Warp
+import Network.Wai.Utilities.MockServer (startMockServer)
 import Polysemy
 import Polysemy.Embed
 import Polysemy.Error

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -217,6 +217,7 @@ executable gundeck-integration
       API
       Metrics
       TestSetup
+      Util
       Paths_gundeck
   hs-source-dirs:
       test/integration
@@ -278,6 +279,7 @@ executable gundeck-integration
     , http-client
     , http-client-tls
     , imports
+    , kan-extensions
     , lens
     , lens-aeson
     , metrics-wai
@@ -289,6 +291,7 @@ executable gundeck-integration
     , random
     , retry
     , safe
+    , streaming-commons
     , tagged
     , tasty >=1.0
     , tasty-hunit >=0.9
@@ -299,6 +302,9 @@ executable gundeck-integration
     , unix
     , unordered-containers
     , uuid
+    , wai
+    , warp
+    , warp-tls
     , websockets >=0.8
     , yaml
   default-language: Haskell2010

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -303,6 +303,7 @@ executable gundeck-integration
     , unordered-containers
     , uuid
     , wai
+    , wai-utilities
     , warp
     , warp-tls
     , websockets >=0.8

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -3,8 +3,6 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 14e7d21fd4304ef1b51679e0624e9c632777ddb5e43509ed96d4dff1a2ab1f27
 
 name:           gundeck
 version:        1.45.0
@@ -282,7 +280,10 @@ executable gundeck-integration
     , imports
     , lens
     , lens-aeson
+    , metrics-wai
     , mtl
+    , network
+    , network-run
     , network-uri
     , optparse-applicative
     , random
@@ -295,6 +296,7 @@ executable gundeck-integration
     , time
     , tinylog
     , types-common
+    , unix
     , unordered-containers
     , uuid
     , websockets >=0.8

--- a/services/gundeck/package.yaml
+++ b/services/gundeck/package.yaml
@@ -91,7 +91,10 @@ executables:
     - HsOpenSSL
     - lens
     - lens-aeson
+    - metrics-wai
     - mtl
+    - network
+    - network-run
     - network-uri
     - optparse-applicative
     - random
@@ -104,6 +107,7 @@ executables:
     - time
     - tinylog
     - types-common
+    - unix
     - unordered-containers
     - uuid
     - websockets >=0.8

--- a/services/gundeck/package.yaml
+++ b/services/gundeck/package.yaml
@@ -89,6 +89,7 @@ executables:
     - http-client
     - http-client-tls
     - HsOpenSSL
+    - kan-extensions
     - lens
     - lens-aeson
     - metrics-wai
@@ -100,6 +101,7 @@ executables:
     - random
     - retry
     - safe
+    - streaming-commons
     - tagged
     - tasty >=1.0
     - tasty-hunit >=0.9
@@ -110,6 +112,9 @@ executables:
     - unix
     - unordered-containers
     - uuid
+    - wai
+    - warp
+    - warp-tls
     - websockets >=0.8
     - yaml
   gundeck-schema:

--- a/services/gundeck/package.yaml
+++ b/services/gundeck/package.yaml
@@ -113,6 +113,7 @@ executables:
     - unordered-containers
     - uuid
     - wai
+    - wai-utilities
     - warp
     - warp-tls
     - websockets >=0.8

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -191,7 +191,6 @@ pushAny' p = do
 pushAll :: (MonadPushAll m, MonadNativeTargets m, MonadMapAsync m) => [Push] -> m ()
 pushAll pushes = do
   newNotifications <- mapM mkNewNotification pushes
-  wsTargets <- mapM mkWSTargets newNotifications
   -- persist push request
   let cassandraTargets :: [CassandraTargets]
       cassandraTargets = map mkCassandraTargets newNotifications
@@ -201,6 +200,7 @@ pushAll pushes = do
         =<< mpaNotificationTTL
   mpaForkIO $ do
     -- websockets
+    wsTargets <- mapM mkWSTargets newNotifications
     resp <- compilePushResps wsTargets <$> mpaBulkPush (compilePushReq <$> wsTargets)
     -- native push
     perPushConcurrency <- mntgtPerPushConcurrency

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -191,6 +191,7 @@ pushAny' p = do
 pushAll :: (MonadPushAll m, MonadNativeTargets m, MonadMapAsync m) => [Push] -> m ()
 pushAll pushes = do
   newNotifications <- mapM mkNewNotification pushes
+  wsTargets <- mapM mkWSTargets newNotifications
   -- persist push request
   let cassandraTargets :: [CassandraTargets]
       cassandraTargets = map mkCassandraTargets newNotifications
@@ -200,7 +201,6 @@ pushAll pushes = do
         =<< mpaNotificationTTL
   mpaForkIO $ do
     -- websockets
-    wsTargets <- mapM mkWSTargets newNotifications
     resp <- compilePushResps wsTargets <$> mpaBulkPush (compilePushReq <$> wsTargets)
     -- native push
     perPushConcurrency <- mntgtPerPushConcurrency

--- a/services/gundeck/src/Gundeck/Run.hs
+++ b/services/gundeck/src/Gundeck/Run.hs
@@ -52,7 +52,7 @@ run o = do
   let throttleMillis = fromMaybe defSqsThrottleMillis $ o ^. (optSettings . setSqsThrottleMillis)
   lst <- Async.async $ Aws.execute (e ^. awsEnv) (Aws.listen throttleMillis (runDirect e . onEvent))
   wtbs <- forM (e ^. threadBudgetState) $ \tbs -> Async.async $ runDirect e $ watchThreadBudgetState m tbs 10
-  runSettingsWithShutdown s (middleware e $ app e) 5 `finally` do
+  runSettingsWithShutdown s (middleware e $ mkApp e) 5 `finally` do
     Log.info l $ Log.msg (Log.val "Shutting down ...")
     shutdown (e ^. cstate)
     Async.cancel lst
@@ -66,6 +66,8 @@ run o = do
         . GZip.gzip GZip.def
         . catchErrors (e ^. applog) [Right $ e ^. monitor]
         . versionMiddleware
-    app :: Env -> Wai.Application
-    app e r k = runGundeck e r (route routes r k)
+
+mkApp :: Env -> Wai.Application
+mkApp e r k = runGundeck e r (route routes r k)
+  where
     routes = compile sitemap

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -27,6 +27,7 @@ import Bilge.Assert
 import qualified Cassandra as Cql
 import Control.Arrow ((&&&))
 import Control.Concurrent.Async (Async, async, concurrently_, forConcurrently_, wait)
+import qualified Control.Concurrent.Async as Async
 import Control.Lens (view, (%~), (.~), (^.), (^?), _2)
 import Control.Retry (constantDelay, limitRetries, recoverAll, retrying)
 import Data.Aeson hiding (json)
@@ -61,6 +62,8 @@ import System.Timeout (timeout)
 import Test.Tasty
 import Test.Tasty.HUnit
 import TestSetup
+import Util (runRedisProxy, withSettingsOverrides)
+import Util.Options
 import qualified Prelude
 
 appName :: AppName
@@ -416,6 +419,21 @@ targetClientPush = do
       recipient u RouteAny
         & recipientClients .~ RecipientClientsSome (List1.singleton c)
     push u c = newPush (Just u) (unsafeRange (Set.singleton (rcpt u c))) (pload c)
+
+storeNotificationsEvenWhenRedisIsDown :: TestM ()
+storeNotificationsEvenWhenRedisIsDown = do
+  ally <- randomId
+  origRedisEndpoint <- view $ tsOpts . optRedis
+  redisProxyServer <- liftIO . async $ runRedisProxy (origRedisEndpoint ^. epHost) (origRedisEndpoint ^. epPort) 10112
+  withSettingsOverrides (optRedis .~ Endpoint "localhost" 10112) $ do
+    let pload = textPayload "hello"
+        push = buildPush ally [(ally, RecipientClientsAll)] pload
+    gu <- view tsGundeck
+    liftIO $ Async.cancel redisProxyServer
+    post (runGundeckR gu . path "i/push/v2" . json [push]) !!! const 200 === statusCode
+
+  ns <- listNotifications ally Nothing
+  liftIO $ assertEqual ("Expected 1 notification, got: " <> show ns) 1 (length ns)
 
 -----------------------------------------------------------------------------
 -- Notifications

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -49,6 +49,7 @@ import qualified Data.Set as Set
 import qualified Data.Text.Encoding as T
 import qualified Data.UUID as UUID
 import Data.UUID.V4
+import Gundeck.Options
 import qualified Gundeck.Push.Data as Push
 import Gundeck.Types
 import Imports
@@ -85,7 +86,8 @@ tests s =
           test s "Push many to Cannon via bulkpush (via gundeck; e2e notif)" $ bulkPush True 50 8,
           test s "Send a push, ensure origin does not receive it" sendSingleUserNoPiggyback,
           test s "Targeted push by connection" targetConnectionPush,
-          test s "Targeted push by client" targetClientPush
+          test s "Targeted push by client" targetClientPush,
+          test s "Store notifications even when redis is down" storeNotificationsEvenWhenRedisIsDown
         ],
       testGroup
         "Notifications"

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -432,7 +432,7 @@ storeNotificationsEvenWhenRedisIsDown = do
         push = buildPush ally [(ally, RecipientClientsAll)] pload
     gu <- view tsGundeck
     liftIO $ Async.cancel redisProxyServer
-    post (runGundeckR gu . path "i/push/v2" . json [push]) !!! const 500 === statusCode
+    post (runGundeckR gu . path "i/push/v2" . json [push]) !!! const 200 === statusCode
 
   ns <- listNotifications ally Nothing
   liftIO $ assertEqual ("Expected 1 notification, got: " <> show ns) 1 (length ns)

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -432,7 +432,7 @@ storeNotificationsEvenWhenRedisIsDown = do
         push = buildPush ally [(ally, RecipientClientsAll)] pload
     gu <- view tsGundeck
     liftIO $ Async.cancel redisProxyServer
-    post (runGundeckR gu . path "i/push/v2" . json [push]) !!! const 200 === statusCode
+    post (runGundeckR gu . path "i/push/v2" . json [push]) !!! const 500 === statusCode
 
   ns <- listNotifications ally Nothing
   liftIO $ assertEqual ("Expected 1 notification, got: " <> show ns) 1 (length ns)

--- a/services/gundeck/test/integration/TestSetup.hs
+++ b/services/gundeck/test/integration/TestSetup.hs
@@ -28,6 +28,7 @@ module TestSetup
     tsBrig,
     tsCass,
     tsLogger,
+    tsOpts,
     TestM (..),
     TestSetup (..),
     BrigR (..),
@@ -40,6 +41,7 @@ import Bilge (HttpT (..), Manager, MonadHttp, Request, runHttpT)
 import qualified Cassandra as Cql
 import Control.Lens (makeLenses, (^.))
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import qualified Gundeck.Options as Gundeck
 import Imports
 import qualified System.Logger as Log
 import Test.Tasty (TestName, TestTree)
@@ -75,7 +77,8 @@ data TestSetup = TestSetup
     _tsCannon2 :: CannonR,
     _tsBrig :: BrigR,
     _tsCass :: Cql.ClientState,
-    _tsLogger :: Log.Logger
+    _tsLogger :: Log.Logger,
+    _tsOpts :: Gundeck.Opts
   }
 
 makeLenses ''TestSetup

--- a/services/gundeck/test/integration/Util.hs
+++ b/services/gundeck/test/integration/Util.hs
@@ -1,17 +1,12 @@
-{-# LANGUAGE NumericUnderscores #-}
-
 module Util where
 
 import qualified Bilge
 import Control.Concurrent.Async (race_)
-import qualified Control.Concurrent.Async as Async
-import Control.Exception (throw)
 import Control.Lens
 import Control.Monad.Catch
 import Control.Monad.Codensity
 import qualified Data.ByteString as S
 import Data.Metrics.Middleware (metrics)
-import Data.Streaming.Network (bindRandomPortTCP)
 import qualified Data.Text as Text
 import Gundeck.Env (createEnv)
 import Gundeck.Options
@@ -20,18 +15,8 @@ import Imports
 import Network.Run.TCP (runTCPServer)
 import Network.Socket hiding (listen)
 import Network.Socket.ByteString (recv, sendAll)
-import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
-import qualified Network.Wai.Handler.WarpTLS as Warp
-import qualified System.Timeout as System
+import Network.Wai.Utilities.MockServer (withMockServer)
 import TestSetup
-
-withMockServer :: Wai.Application -> Codensity IO Word16
-withMockServer app = Codensity $ \k ->
-  bracket
-    (liftIO $ startMockServer Nothing app)
-    (liftIO . fst)
-    (k . fromIntegral . snd)
 
 withSettingsOverrides :: (Opts -> Opts) -> TestM a -> TestM a
 withSettingsOverrides f action = do
@@ -46,47 +31,6 @@ withSettingsOverrides f action = do
   where
     mkRequest p = Bilge.host "127.0.0.1" . Bilge.port p
 
--- TODO: Copy the comment from federator, perhaps create a new package or put it in one of the shared ones?
-startMockServer :: Maybe Warp.TLSSettings -> Wai.Application -> IO (IO (), Warp.Port)
-startMockServer mtlsSettings app = do
-  (port, sock) <- bindRandomPortTCP "*6"
-  serverStarted <- newEmptyMVar
-  let wsettings =
-        Warp.defaultSettings
-          & Warp.setPort port
-          & Warp.setGracefulCloseTimeout2 0 -- Defaults to 2 seconds, causes server stop to take very long
-          & Warp.setBeforeMainLoop (putMVar serverStarted ())
-
-  serverThread <- Async.async $ case mtlsSettings of
-    Just tlsSettings -> Warp.runTLSSocket tlsSettings wsettings sock app
-    Nothing -> Warp.runSettingsSocket wsettings sock app
-  serverStartedSignal <- System.timeout 10_000_000 (readMVar serverStarted)
-  let closeMock = do
-        me <- Async.poll serverThread
-        case me of
-          Nothing -> Async.cancel serverThread
-          Just (Left e) -> throw e
-          Just (Right a) -> pure a
-  case serverStartedSignal of
-    Nothing -> do
-      Async.cancel serverThread
-      throw (MockTimeout port)
-    Just _ -> pure (closeMock, port)
-
--- | Thrown in IO by mock federator if the server could not be started after 10
--- seconds.
-newtype MockTimeout = MockTimeout Warp.Port
-  deriving (Eq, Show, Typeable)
-
-instance Exception MockTimeout
-
---- TCP Proxy
-
--- data ProxySetting = ProxySetting {locPort :: PortNumber, remHost :: String, remPort :: String}
-
--- proxySetting :: ProxySetting
--- proxySetting = ProxySetting 9900 "ftp.free.fr" "80"
-
 runRedisProxy :: Text -> Word16 -> Word16 -> IO ()
 runRedisProxy redisHost redisPort proxyPort = do
   (servAddr : _) <- getAddrInfo Nothing (Just $ Text.unpack redisHost) (Just $ show redisPort)
@@ -98,17 +42,6 @@ runRedisProxy redisHost redisPort proxyPort = do
             server <- getServerSocket servAddr
             client <~~> server
   where
-    -- installHandler sigPIPE Ignore Nothing >> do
-    --   (servAddr : _) <- getAddrInfo Nothing (Just $ remHost proxySetting) (Just $ remPort proxySetting)
-    --   withSocketsDo $ do
-    --     listener <- open serverAddr
-    --     forever $
-    --       accept listener >>= \(client, _) ->
-    --         void $
-    --           forkIO $ do
-    --             server <- getServerSocket servAddr
-    --             client <~~> server
-
     getServerSocket servAddr = do
       server <- socket (addrFamily servAddr) Stream defaultProtocol
       connect server (addrAddress servAddr) >> return server
@@ -116,11 +49,3 @@ runRedisProxy redisHost redisPort proxyPort = do
     mapData f t = do
       content <- recv f 4096
       unless (S.null content) $ sendAll t content >> mapData f t
-
---   open addr = do
---     sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
---     setSocketOption sock ReuseAddr 1
---     withFdSocket sock $ setCloseOnExecIfNeeded
---     bind sock $ addrAddress addr
---     listen sock 1024
---     return sock

--- a/services/gundeck/test/integration/Util.hs
+++ b/services/gundeck/test/integration/Util.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Util where
+
+import qualified Bilge
+import Control.Concurrent.Async (race_)
+import qualified Control.Concurrent.Async as Async
+import Control.Exception (throw)
+import Control.Lens
+import Control.Monad.Catch
+import Control.Monad.Codensity
+import qualified Data.ByteString as S
+import Data.Metrics.Middleware (metrics)
+import Data.Streaming.Network (bindRandomPortTCP)
+import qualified Data.Text as Text
+import Gundeck.Env (createEnv)
+import Gundeck.Options
+import Gundeck.Run (mkApp)
+import Imports
+import Network.Run.TCP (runTCPServer)
+import Network.Socket hiding (listen)
+import Network.Socket.ByteString (recv, sendAll)
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
+import qualified Network.Wai.Handler.WarpTLS as Warp
+import qualified System.Timeout as System
+import TestSetup
+
+withMockServer :: Wai.Application -> Codensity IO Word16
+withMockServer app = Codensity $ \k ->
+  bracket
+    (liftIO $ startMockServer Nothing app)
+    (liftIO . fst)
+    (k . fromIntegral . snd)
+
+withSettingsOverrides :: (Opts -> Opts) -> TestM a -> TestM a
+withSettingsOverrides f action = do
+  ts <- ask
+  let opts = f (view tsOpts ts)
+  m <- metrics
+  env <- liftIO $ createEnv m opts
+  liftIO . lowerCodensity $ do
+    let app = mkApp env
+    p <- withMockServer app
+    liftIO $ Bilge.runHttpT (ts ^. tsManager) $ runReaderT (runTestM action) $ ts & tsGundeck .~ GundeckR (mkRequest p)
+  where
+    mkRequest p = Bilge.host "127.0.0.1" . Bilge.port p
+
+-- TODO: Copy the comment from federator, perhaps create a new package or put it in one of the shared ones?
+startMockServer :: Maybe Warp.TLSSettings -> Wai.Application -> IO (IO (), Warp.Port)
+startMockServer mtlsSettings app = do
+  (port, sock) <- bindRandomPortTCP "*6"
+  serverStarted <- newEmptyMVar
+  let wsettings =
+        Warp.defaultSettings
+          & Warp.setPort port
+          & Warp.setGracefulCloseTimeout2 0 -- Defaults to 2 seconds, causes server stop to take very long
+          & Warp.setBeforeMainLoop (putMVar serverStarted ())
+
+  serverThread <- Async.async $ case mtlsSettings of
+    Just tlsSettings -> Warp.runTLSSocket tlsSettings wsettings sock app
+    Nothing -> Warp.runSettingsSocket wsettings sock app
+  serverStartedSignal <- System.timeout 10_000_000 (readMVar serverStarted)
+  let closeMock = do
+        me <- Async.poll serverThread
+        case me of
+          Nothing -> Async.cancel serverThread
+          Just (Left e) -> throw e
+          Just (Right a) -> pure a
+  case serverStartedSignal of
+    Nothing -> do
+      Async.cancel serverThread
+      throw (MockTimeout port)
+    Just _ -> pure (closeMock, port)
+
+-- | Thrown in IO by mock federator if the server could not be started after 10
+-- seconds.
+newtype MockTimeout = MockTimeout Warp.Port
+  deriving (Eq, Show, Typeable)
+
+instance Exception MockTimeout
+
+--- TCP Proxy
+
+-- data ProxySetting = ProxySetting {locPort :: PortNumber, remHost :: String, remPort :: String}
+
+-- proxySetting :: ProxySetting
+-- proxySetting = ProxySetting 9900 "ftp.free.fr" "80"
+
+runRedisProxy :: Text -> Word16 -> Word16 -> IO ()
+runRedisProxy redisHost redisPort proxyPort = do
+  (servAddr : _) <- getAddrInfo Nothing (Just $ Text.unpack redisHost) (Just $ show redisPort)
+  runTCPServer (Just "localhost") (show proxyPort) $ \listener ->
+    forever $
+      accept listener >>= \(client, _) ->
+        void $
+          forkIO $ do
+            server <- getServerSocket servAddr
+            client <~~> server
+  where
+    -- installHandler sigPIPE Ignore Nothing >> do
+    --   (servAddr : _) <- getAddrInfo Nothing (Just $ remHost proxySetting) (Just $ remPort proxySetting)
+    --   withSocketsDo $ do
+    --     listener <- open serverAddr
+    --     forever $
+    --       accept listener >>= \(client, _) ->
+    --         void $
+    --           forkIO $ do
+    --             server <- getServerSocket servAddr
+    --             client <~~> server
+
+    getServerSocket servAddr = do
+      server <- socket (addrFamily servAddr) Stream defaultProtocol
+      connect server (addrAddress servAddr) >> return server
+    p1 <~~> p2 = finally (race_ (p1 `mapData` p2) (p2 `mapData` p1)) (close p1 >> close p2)
+    mapData f t = do
+      content <- recv f 4096
+      unless (S.null content) $ sendAll t content >> mapData f t
+
+--   open addr = do
+--     sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+--     setSocketOption sock ReuseAddr 1
+--     withFdSocket sock $ setCloseOnExecIfNeeded
+--     bind sock $ addrAddress addr
+--     listen sock 1024
+--     return sock


### PR DESCRIPTION
Right now, if redis is down, the lookup of presences which happens before the storage of notifications in cassandra, leads to messages unable to be persisted in the case of redis downtime. That's not necessary. This PR moves the "lookup presence location in redis" part further down in the "pushAll" function, making gundeck's code more tolerant to redis downtimes. An integration test is provided (using a tcp proxy to redis) to cover this case, which is can be seen failing with the (equivalent) old code in https://github.com/wireapp/wire-server/pull/2295/commits/b45a503aa04794b5ff46eb9713c47baa8107d610. 


## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.