### PR TITLE
SQSERVICES-1480-be-add-flag-for-validation-email-to-users-uid-email-in-backoffice-stern

### DIFF
--- a/changelog.d/5-internal/pr-2301
+++ b/changelog.d/5-internal/pr-2301
@@ -1,0 +1,1 @@
+Flag for sending a validation email when updating a user's email address via backoffice/stern

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -341,8 +341,8 @@ deleteBindingTeamForce tid = do
           . expect2xx
       )
 
-changeEmail :: UserId -> EmailUpdate -> Handler ()
-changeEmail u upd = do
+changeEmail :: UserId -> EmailUpdate -> Bool -> Handler ()
+changeEmail u upd validate = do
   info $ msg "Updating email address"
   b <- view brig
   void . catchRpcErrors $
@@ -351,6 +351,7 @@ changeEmail u upd = do
       b
       ( method PUT
           . path "i/self/email"
+          . (if validate then queryItem "validate" "true" else id)
           . header "Z-User" (toByteString' u)
           . header "Z-Connection" (toByteString' "")
           . lbytes (encode upd)


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1480

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.