### PR TITLE
[Polysemy] Move the Random Effect from Spar to polysemy-wire-zoo

### DIFF
--- a/changelog.d/5-internal/random-effect
+++ b/changelog.d/5-internal/random-effect
@@ -1,0 +1,1 @@
+Move the Random effect from Spar to the polysemy-wire-zoo library

--- a/libs/polysemy-wire-zoo/package.yaml
+++ b/libs/polysemy-wire-zoo/package.yaml
@@ -11,6 +11,7 @@ copyright: (c) 2020 Wire Swiss GmbH
 license: AGPL-3
 dependencies:
 - base >=4.6 && <5.0
+- HsOpenSSL
 - hspec
 - imports
 - polysemy
@@ -20,5 +21,7 @@ dependencies:
 - saml2-web-sso
 - time
 - tinylog
+- types-common
+- uuid
 library:
   source-dirs: src

--- a/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
+++ b/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e2e3b663f85abbb558703a6e6bf5449020cb7d0335ae01e4a5ebb124765ed337
+-- hash: be6e191f98f61663091d940ccdb428f4f844cf94b6defd13f19a3c65d9e4e894
 
 name:           polysemy-wire-zoo
 version:        0.1.0
@@ -25,6 +25,8 @@ library
       Wire.Sem.Now.Input
       Wire.Sem.Now.IO
       Wire.Sem.Now.Spec
+      Wire.Sem.Random
+      Wire.Sem.Random.IO
   other-modules:
       Paths_polysemy_wire_zoo
   hs-source-dirs:
@@ -70,7 +72,8 @@ library
       ViewPatterns
   ghc-options: -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
   build-depends:
-      QuickCheck
+      HsOpenSSL
+    , QuickCheck
     , base >=4.6 && <5.0
     , hspec
     , imports
@@ -80,4 +83,6 @@ library
     , saml2-web-sso
     , time
     , tinylog
+    , types-common
+    , uuid
   default-language: Haskell2010

--- a/libs/polysemy-wire-zoo/src/Wire/Sem/Random.hs
+++ b/libs/polysemy-wire-zoo/src/Wire/Sem/Random.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
@@ -15,23 +17,22 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Spar.Sem.Random.IO
-  ( randomToIO,
+module Wire.Sem.Random
+  ( Random (..),
+    bytes,
+    uuid,
+    scimTokenId,
   )
 where
 
-import Data.Id (randomId)
-import qualified Data.UUID.V4 as UUID
+import Data.Id (ScimTokenId)
+import Data.UUID (UUID)
 import Imports
-import OpenSSL.Random (randBytes)
 import Polysemy
-import Spar.Sem.Random (Random (..))
 
-randomToIO ::
-  Member (Embed IO) r =>
-  Sem (Random ': r) a ->
-  Sem r a
-randomToIO = interpret $ \case
-  Bytes i -> embed $ randBytes i
-  Uuid -> embed $ UUID.nextRandom
-  ScimTokenId -> embed $ randomId @IO
+data Random m a where
+  Bytes :: Int -> Random m ByteString
+  Uuid :: Random m UUID
+  ScimTokenId :: Random m ScimTokenId
+
+makeSem ''Random

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -61,8 +61,6 @@ library
       Spar.Sem.IdPRawMetadataStore.Spec
       Spar.Sem.Logger
       Spar.Sem.Logger.TinyLog
-      Spar.Sem.Random
-      Spar.Sem.Random.IO
       Spar.Sem.Reporter
       Spar.Sem.Reporter.Wai
       Spar.Sem.SAML2

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -81,8 +81,6 @@ import Spar.Sem.IdPRawMetadataStore (IdPRawMetadataStore)
 import qualified Spar.Sem.IdPRawMetadataStore as IdPRawMetadataStore
 import Spar.Sem.Logger (Logger)
 import qualified Spar.Sem.Logger as Logger
-import Spar.Sem.Random (Random)
-import qualified Spar.Sem.Random as Random
 import Spar.Sem.Reporter (Reporter)
 import Spar.Sem.SAML2 (SAML2)
 import qualified Spar.Sem.SAML2 as SAML2
@@ -103,6 +101,8 @@ import Wire.API.Routes.Public.Spar
 import Wire.API.User.IdentityProvider
 import Wire.API.User.Saml
 import Wire.Sem.Now (Now)
+import Wire.Sem.Random (Random)
+import qualified Wire.Sem.Random as Random
 
 app :: Env -> Application
 app ctx =

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -90,8 +90,6 @@ import Spar.Sem.IdPConfigStore (GetIdPResult (..), IdPConfigStore)
 import qualified Spar.Sem.IdPConfigStore as IdPConfigStore
 import Spar.Sem.Logger (Logger)
 import qualified Spar.Sem.Logger as Logger
-import Spar.Sem.Random (Random)
-import qualified Spar.Sem.Random as Random
 import Spar.Sem.Reporter (Reporter)
 import qualified Spar.Sem.Reporter as Reporter
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
@@ -110,6 +108,8 @@ import Wire.API.User.Identity (Email (..))
 import Wire.API.User.IdentityProvider
 import Wire.API.User.Saml
 import Wire.API.User.Scim (ValidExternalId (..))
+import Wire.Sem.Random (Random)
+import qualified Wire.Sem.Random as Random
 
 throwSparSem :: Member (Error SparError) r => SparCustomError -> Sem r a
 throwSparSem = throw . SAML.CustomError

--- a/services/spar/src/Spar/CanonicalInterpreter.hs
+++ b/services/spar/src/Spar/CanonicalInterpreter.hs
@@ -52,8 +52,6 @@ import Spar.Sem.IdPRawMetadataStore (IdPRawMetadataStore)
 import Spar.Sem.IdPRawMetadataStore.Cassandra (idpRawMetadataStoreToCassandra)
 import Spar.Sem.Logger (Logger)
 import Spar.Sem.Logger.TinyLog (loggerToTinyLog, stringLoggerToTinyLog)
-import Spar.Sem.Random (Random)
-import Spar.Sem.Random.IO (randomToIO)
 import Spar.Sem.Reporter (Reporter)
 import Spar.Sem.Reporter.Wai (reporterToTinyLogWai)
 import Spar.Sem.SAML2 (SAML2)
@@ -75,6 +73,8 @@ import qualified System.Logger as TinyLog
 import Wire.API.User.Saml
 import Wire.Sem.Now (Now)
 import Wire.Sem.Now.IO (nowToIO)
+import Wire.Sem.Random (Random)
+import Wire.Sem.Random.IO (randomToIO)
 
 type CanonicalEffs =
   '[ SAML2,

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -84,7 +84,6 @@ import Spar.Sem.BrigAccess (BrigAccess)
 import Spar.Sem.GalleyAccess (GalleyAccess)
 import Spar.Sem.IdPConfigStore (IdPConfigStore)
 import Spar.Sem.Logger (Logger)
-import Spar.Sem.Random (Random)
 import Spar.Sem.Reporter (Reporter)
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)
@@ -102,6 +101,7 @@ import Wire.API.Routes.Public.Spar
 import Wire.API.User.Saml (Opts)
 import Wire.API.User.Scim
 import Wire.Sem.Now (Now)
+import Wire.Sem.Random (Random)
 
 -- | SCIM config for our server.
 --

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -56,8 +56,6 @@ import qualified Spar.Sem.BrigAccess as BrigAccess
 import Spar.Sem.GalleyAccess (GalleyAccess)
 import Spar.Sem.IdPConfigStore (IdPConfigStore)
 import qualified Spar.Sem.IdPConfigStore as IdPConfigStore
-import Spar.Sem.Random (Random)
-import qualified Spar.Sem.Random as Random
 import Spar.Sem.ScimTokenStore (ScimTokenStore)
 import qualified Spar.Sem.ScimTokenStore as ScimTokenStore
 import qualified Web.Scim.Class.Auth as Scim.Class.Auth
@@ -69,6 +67,8 @@ import Wire.API.User.Saml (Opts, maxScimTokens)
 import Wire.API.User.Scim as Api
 import Wire.Sem.Now (Now)
 import qualified Wire.Sem.Now as Now
+import Wire.Sem.Random (Random)
+import qualified Wire.Sem.Random as Random
 
 -- | An instance that tells @hscim@ how authentication should be done for SCIM routes.
 instance Member ScimTokenStore r => Scim.Class.Auth.AuthDB SparTag (Sem r) where

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -77,8 +77,6 @@ import Spar.Sem.IdPConfigStore (IdPConfigStore)
 import qualified Spar.Sem.IdPConfigStore as IdPConfigStore
 import Spar.Sem.Logger (Logger)
 import qualified Spar.Sem.Logger as Logger
-import Spar.Sem.Random (Random)
-import qualified Spar.Sem.Random as Random
 import Spar.Sem.SAMLUserStore (SAMLUserStore)
 import qualified Spar.Sem.SAMLUserStore as SAMLUserStore
 import Spar.Sem.ScimExternalIdStore (ScimExternalIdStore)
@@ -108,6 +106,8 @@ import Wire.API.User.Scim (ScimTokenInfo (..))
 import qualified Wire.API.User.Scim as ST
 import Wire.Sem.Now (Now)
 import qualified Wire.Sem.Now as Now
+import Wire.Sem.Random (Random)
+import qualified Wire.Sem.Random as Random
 
 ----------------------------------------------------------------------------
 -- UserDB instance


### PR DESCRIPTION
The PR moves the Random effect from Spar to the polysemy-wire-zoo library as it is not Spar-specific and it will be used in Brig too.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
