### PR TITLE
Prevent PROXY protocol clients from accessing metrics endpoint.

### DIFF
--- a/changelog.d/3-bug-fixes/nginz-access-control
+++ b/changelog.d/3-bug-fixes/nginz-access-control
@@ -1,0 +1,3 @@
+Modify the nginz access control configuration to prevent clients connecting
+to listeners with PROXY protocol enabled (such as the websocket listener) from
+accessing a private metrics endpoint.

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -203,6 +203,18 @@ http {
         allow 127.0.0.1;
         deny all;
 
+        # Requests with an X-Forwarded-For header will have the real client
+        # source IP address set correctly, due to the real_ip_header directive
+        # in the top-level configuration. However, this will not set the client
+        # IP correctly for clients which are connected via a load balancer which
+        # uses the PROXY protocol.
+        #
+        # Hence, for safety, we deny access to the vts metrics endpoints to
+        # clients which are connected via PROXY protocol.
+        if ($proxy_protocol_address != "") {
+            return 403;
+        }
+
         vhost_traffic_status_display;
         vhost_traffic_status_display_format html;
     }


### PR DESCRIPTION
Due to an access control quirk, clients connecting to nginz over a listener which has proxy protocol enabled may be able to bypass the IP address access control list and access the `/vts` metrics endpoint, which is otherwised considered internal. This change prevents clients connected via proxy protocol from accessing the metrics endpoint.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
