### PR TITLE
Remove stack from builder images

### DIFF
--- a/build/ubuntu/Dockerfile.builder
+++ b/build/ubuntu/Dockerfile.builder
@@ -11,19 +11,12 @@ WORKDIR /
 
 ARG wire_server_branch=develop
 ARG THREADS=4
-ARG CABAL_BUILD_ARGS=
 RUN set -x && \
     echo ${wire_server_branch} && \
     git clone -b ${wire_server_branch} https://github.com/wireapp/wire-server.git && \
     cd /wire-server && \
-    stack update && \
-    echo "allow-different-user: true" >> /root/.stack/config.yaml && \
-    stack build --dependencies-only haskell-src-exts && \
-    stack build haskell-src-exts && \
-    stack build --pedantic --test --no-run-tests --bench --no-run-benchmarks --dependencies-only -j${THREADS} && \
-    stack install ormolu && \
     cabal update && \
-    cabal build all --dependencies-only ${CABAL_BUILD_ARGS} && \
+    cabal build all --dependencies-only && \
     cd / && \
-    # we run the build only to cache the built source in /root/.stack, we can remove the source code itself
+    # we run the build only to cache the built source in /root/.cabal, we can remove the source code itself
     rm -rf /wire-server

--- a/build/ubuntu/Dockerfile.prebuilder
+++ b/build/ubuntu/Dockerfile.prebuilder
@@ -68,8 +68,6 @@ ENV PATH=/root/.ghcup/bin:/root/.cabal/bin:${PATH} \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-ARG STACK_VERSION=2.7.3
 ARG CABAL_VERSION=3.6.2.0
-RUN ghcup install stack ${STACK_VERSION} && \
-    ghcup install cabal ${CABAL_VERSION} && \
+RUN ghcup install cabal ${CABAL_VERSION} && \
     cabal install cabal-plan

--- a/changelog.d/5-internal/remvove-stack
+++ b/changelog.d/5-internal/remvove-stack
@@ -1,0 +1,1 @@
+Remove stack from all builder docker images


### PR DESCRIPTION
This PR removes the `stack` tool from the build docker images.

https://wearezeta.atlassian.net/browse/BE-560

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
