### PR TITLE
bump nixpkgs to latest nixpkgs-unstable

### DIFF
--- a/libs/metrics-core/src/Data/Metrics.hs
+++ b/libs/metrics-core/src/Data/Metrics.hs
@@ -214,7 +214,7 @@ gaugeDecr = gaugeAdd (-1)
 
 -- | Subtract the given amount from the gauge at 'Path'
 gaugeSub :: MonadIO m => Double -> Path -> Metrics -> m ()
-gaugeSub x = gaugeAdd (- x)
+gaugeSub x = gaugeAdd (-x)
 
 -- | Get the current value of the Gauge
 gaugeValue :: MonadIO m => Gauge -> m Double

--- a/libs/wire-api/src/Wire/API/Asset.hs
+++ b/libs/wire-api/src/Wire/API/Asset.hs
@@ -420,7 +420,7 @@ instance
   fromUnion (Z (I _)) = Nothing
   fromUnion (S (Z (I loc))) = Just (LocalAsset loc)
   fromUnion (S (S (Z (I asset)))) = Just (RemoteAsset asset)
-  fromUnion (S (S (S x))) = case x of
+  fromUnion (S (S (S x))) = case x of {}
 
 makeLenses ''Asset'
 makeLenses ''AssetSettings

--- a/libs/wire-api/src/Wire/API/Error.hs
+++ b/libs/wire-api/src/Wire/API/Error.hs
@@ -305,4 +305,4 @@ instance
   toUnion (Just x) = S (Z (I x))
   fromUnion (Z (I _)) = Nothing
   fromUnion (S (Z (I x))) = Just x
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -411,7 +411,7 @@ class IsResponseList cs as where
   responseListStatuses :: [Status]
 
 instance IsResponseList cs '[] where
-  responseListRender _ x = case x of
+  responseListRender _ x = case x of {}
   responseListUnrender _ _ = empty
   responseListStatuses = []
 
@@ -517,7 +517,7 @@ class InjectBefore as bs where
   injectBefore :: Union as -> Union (as .++ bs)
 
 instance InjectBefore '[] bs where
-  injectBefore x = case x of
+  injectBefore x = case x of {}
 
 instance InjectBefore as bs => InjectBefore (a ': as) bs where
   injectBefore (Z x) = Z x
@@ -589,8 +589,8 @@ class AsConstructors xss rs where
   fromSOP :: SOP I xss -> Union (ResponseTypes rs)
 
 instance AsConstructors '[] '[] where
-  toSOP x = case x of
-  fromSOP x = case x of
+  toSOP x = case x of {}
+  fromSOP x = case x of {}
 
 instance AsConstructor '[a] (Respond code desc a) where
   toConstructor x = I x :* Nil
@@ -653,7 +653,7 @@ instance
 
   fromUnion (Z (I ())) = False
   fromUnion (S (Z (I ()))) = True
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}
 
 -- | A handler for a pair of responses where the first is empty can be
 -- implemented simply by returning a 'Maybe' value. The convention is that the
@@ -669,7 +669,7 @@ instance
 
   fromUnion (Z (I ())) = Nothing
   fromUnion (S (Z (I x))) = Just x
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}
 
 instance
   (SwaggerMethod method, IsSwaggerResponseList as) =>

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -85,7 +85,7 @@ type family FMap (f :: a -> b) (m :: Maybe a) :: Maybe b where
   FMap _ 'Nothing = 'Nothing
   FMap f ('Just a) = 'Just (f a)
 
-type family LookupEndpoint api name :: Maybe * where
+type family LookupEndpoint api name :: Maybe (*) where
   LookupEndpoint (Named name endpoint) name = 'Just endpoint
   LookupEndpoint (api1 :<|> api2) name =
     MappendMaybe

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -89,7 +89,7 @@ instance AsUnion DeleteSelfResponses (Maybe Timeout) where
   toUnion Nothing = Z (I ())
   fromUnion (Z (I ())) = Nothing
   fromUnion (S (Z (I (DeletionCodeTimeout t)))) = Just t
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}
 
 type ConnectionUpdateResponses = UpdateResponses "Connection unchanged" "Connection updated" UserConnection
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -100,7 +100,7 @@ instance
 
   fromUnion (Z (I c)) = CodeAlreadyExisted c
   fromUnion (S (Z (I e))) = CodeAdded e
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}
 
 type ConvUpdateResponses = UpdateResponses "Conversation unchanged" "Conversation updated" Event
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Util.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Util.hs
@@ -35,7 +35,7 @@ instance
 
   fromUnion (Z (I x)) = Existed x
   fromUnion (S (Z (I x))) = Created x
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}
 
 -- Note: order is important here; if you swap Existed with Created, the wrong
 -- status codes will be returned. Keep the Order in ResponseForExistedCreated
@@ -75,4 +75,4 @@ instance
 
   fromUnion (Z (I ())) = Unchanged
   fromUnion (S (Z (I a))) = Updated a
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationCoverView.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationCoverView.hs
@@ -15,7 +15,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
--- |
+--
 module Test.Wire.API.Golden.Manual.ConversationCoverView where
 
 import Data.Id (Id (Id))

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7cd44abcc3f01accbcc450d4d67609a5ea3448ec",
-        "sha256": "0f8d797mhpxggq5idlbgsvf1nlknf5yh966mnl3bian32m11rik2",
+        "rev": "ca087b7e4f67fd9d08313d241ba398201a604e9c",
+        "sha256": "0xirpv4165p1c7n8vlncz0ns68w0dplb9g5x4v3y5pjgd0fd5vwr",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/7cd44abcc3f01accbcc450d4d67609a5ea3448ec.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ca087b7e4f67fd9d08313d241ba398201a604e9c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/services/brig/src/Brig/Data/Activation.hs
+++ b/services/brig/src/Brig/Data/Activation.hs
@@ -185,7 +185,7 @@ verifyCode key code = do
     Just (ttl, Ascii t, k, c, u, r) ->
       if
           | c == code -> mkScope t k u
-          | r >= 1 -> countdown (key, t, k, c, u, r -1, ttl) >> throwE invalidCode
+          | r >= 1 -> countdown (key, t, k, c, u, r - 1, ttl) >> throwE invalidCode
           | otherwise -> revoke >> throwE invalidCode
     Nothing -> throwE invalidCode
   where

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -141,7 +141,7 @@ addClientWithReAuthPolicy reAuthPolicy u newId c maxPermClients loc cps = do
   when (reAuthPolicy count upsert) $
     fmapLT ClientReAuthError $
       User.reauthenticate u (newClientPassword c)
-  let capacity = fmap (+ (- count)) limit
+  let capacity = fmap (+ (-count)) limit
   unless (maybe True (> 0) capacity || upsert) $
     throwE TooManyClients
   new <- insert

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -167,7 +167,7 @@ mustSuspendInactiveUser uid =
     Just (SuspendInactiveUsers (Timeout suspendAge)) -> do
       now <- liftIO =<< view currentTime
       let suspendHere :: UTCTime
-          suspendHere = addUTCTime (- suspendAge) now
+          suspendHere = addUTCTime (-suspendAge) now
           youngEnough :: Cookie () -> Bool
           youngEnough = (>= suspendHere) . cookieCreated
       ckies <- listCookies uid []

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -554,7 +554,7 @@ testInvitationMutuallyExclusive brig = do
 testInvitationTooManyMembers :: Brig -> Galley -> TeamSizeLimit -> Http ()
 testInvitationTooManyMembers brig galley (TeamSizeLimit limit) = do
   (creator, tid) <- createUserWithTeam brig
-  pooledForConcurrentlyN_ 16 [1 .. limit -1] $ \_ -> do
+  pooledForConcurrentlyN_ 16 [1 .. limit - 1] $ \_ -> do
     void $ createTeamMember brig galley creator tid Team.fullPermissions
   SearchUtil.refreshIndex brig
   let invite email = stdInvitationRequest email
@@ -647,7 +647,7 @@ testInvitationInfoExpired brig timeout = do
       liftIO $ threadDelay 1000000
       r <- getCode t i
       when (statusCode r == 200 && n > 0) $
-        awaitExpiry (n -1) t i
+        awaitExpiry (n - 1) t i
 
 testSuspendTeam :: Brig -> Http ()
 testSuspendTeam brig = do

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -527,7 +527,7 @@ testCreateUserBlacklist _ brig aws =
       r <- Bilge.head (brig . path "i/users/blacklist" . queryItem "email" (toByteString' e))
       when (statusCode r == 404 && n > 0) $ do
         liftIO $ threadDelay 1000000
-        awaitBlacklist (n -1) e
+        awaitBlacklist (n - 1) e
 
 testCreateUserExternalSSO :: Brig -> Http ()
 testCreateUserExternalSSO brig = do
@@ -570,7 +570,7 @@ testActivateWithExpiry _ brig timeout = do
       liftIO $ threadDelay 1000000
       r <- activate brig kc
       when (statusCode r == 204 && n > 0) $
-        awaitExpiry (n -1) kc
+        awaitExpiry (n - 1) kc
 
 testNonExistingUserUnqualified :: Brig -> Http ()
 testNonExistingUserUnqualified brig = do
@@ -788,7 +788,7 @@ testCreateUserAnonExpiry b = do
       r <- getProfile zusr uid
       when (statusCode r == 200 && deleted r == Nothing && n > 0) $ do
         liftIO $ threadDelay 1000000
-        awaitExpiry (n -1) zusr uid
+        awaitExpiry (n - 1) zusr uid
     ensureExpiry :: UTCTime -> Maybe UTCTime -> String -> Http ()
     ensureExpiry now expiry s = case expiry of
       Nothing -> liftIO $ assertFailure ("user must have an expiry" <> s)

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -2069,7 +2069,7 @@ postCryptoBroadcastMessage100OrMaxConns bcast = do
       case (statusCode r1, statusCode r2, remaining, acc) of
         (201, 200, 0, []) -> error "Need to connect with at least 1 user"
         (201, 200, 0, (x : xs)) -> return (x, xs)
-        (201, 200, _, _) -> createAndConnectUserWhileLimitNotReached alice (remaining -1) ((uid, cid) : acc) pk
+        (201, 200, _, _) -> createAndConnectUserWhileLimitNotReached alice (remaining - 1) ((uid, cid) : acc) pk
         (403, 403, _, []) -> error "Need to connect with at least 1 user"
         (403, 403, _, x : xs) -> return (x, xs)
         (xxx, yyy, _, _) -> error ("Unexpected while connecting users: " ++ show xxx ++ " and " ++ show yyy)

--- a/services/gundeck/test/unit/DelayQueue.hs
+++ b/services/gundeck/test/unit/DelayQueue.hs
@@ -80,7 +80,7 @@ dequeueOrderProp k = ioProperty $ do
   q <- DelayQueue.new (Clock (readIORef c)) (Delay 1) (Limit 2)
   e1 <- DelayQueue.enqueue q k (1 :: Int)
   tick c
-  e2 <- DelayQueue.enqueue q (k -1) (2 :: Int)
+  e2 <- DelayQueue.enqueue q (k - 1) (2 :: Int)
   tick c
   d1 <- DelayQueue.dequeue q
   d2 <- DelayQueue.dequeue q

--- a/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
+++ b/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
@@ -56,7 +56,7 @@ mainBotNet n = do
   info $ msg $ "Starting Smoke Test with " <> show n <> " bots"
   -- Create some participants: Ally, Bill, Carl, and a bunch of goons
   [ally, bill, carl] <- mapM newBot ["Ally", "Bill", "Carl"]
-  goons <- for [1 .. n -3] $ \i ->
+  goons <- for [1 .. n - 3] $ \i ->
     newBot (fromString ("Goon" <> show i))
   -- Set up a connection from Ally to someone
   let allyConnectTo :: Bot -> BotSession ConvId


### PR DESCRIPTION
I experienced this https://github.com/haskell/haskell-language-server/issues/2672#issue-1120471115 . Seems benign

## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
