### PR TITLE
Add "sed" to direnv

### DIFF
--- a/changelog.d/5-internal/add-gnused
+++ b/changelog.d/5-internal/add-gnused
@@ -1,0 +1,1 @@
+Add sed to direnv

--- a/dev-packages.nix
+++ b/dev-packages.nix
@@ -175,6 +175,7 @@ in
   pkgs.cfssl
   pkgs.docker-compose
   pkgs.gnumake
+  pkgs.gnused
   (pkgs.haskell-language-server.override { supportedGhcVersions = [ "8107" ]; })
   pkgs.jq
   pkgs.niv


### PR DESCRIPTION
Our CI scripts depend on sed being in the direnv.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
