### PR TITLE
Remove oromolu Github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,3 @@ jobs:
        run: nix-build --no-out-link direnv.nix
      - name: Install the wire-server-direnv
        run: nix-env -f direnv.nix -i
-     - name: Ensure everything is formatted
-       run: make formatc

--- a/changelog.d/5-internal/remove-ormolu-gh-action
+++ b/changelog.d/5-internal/remove-ormolu-gh-action
@@ -1,0 +1,1 @@
+Remove oromolu GH action (has been moved to concourse https://github.com/zinfra/cailleach/pull/1033)


### PR DESCRIPTION
This job is duplicated by a job running in concourse. Since the backend team decided to favor running jobs in concourse over github let's remove it here. The concourse job has been updated to also run in the direnv: https://github.com/zinfra/cailleach/pull/1033

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
