### PR TITLE
docs: add latex to docs and publish pdf if exists

### DIFF
--- a/changelog.d/5-internal/wire-docs-pdf
+++ b/changelog.d/5-internal/wire-docs-pdf
@@ -1,0 +1,1 @@
+docs: add latex to docs and publish pdf if exists

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -64,6 +64,7 @@ docker-push:
 .PHONY: push
 push:
 	aws s3 sync $(BUILDDIR)/html s3://origin-docs.wire.com/
+	[[ -f  $(BUILDDIR)/latex/main.pdf ]] && aws cp $(BUILDDIR)/latex/main.pdf s3://origin-docs.wire.com/main.pdf || exit 0
 
 .PHONY: dev-run
 dev-run: clean

--- a/docs/nix/default.nix
+++ b/docs/nix/default.nix
@@ -13,7 +13,7 @@ in
       pkgs.zip
       pkgs.gnumake
       pkgs.entr
-      # pkgs.texlive.combined.scheme-full
+      pkgs.texlive.combined.scheme-full
 
       (pkgs.python3.withPackages (ps: with ps; [ sphinx recommonmark rst2pdf sphinx-autobuild sphinxcontrib-fulltoc sphinxcontrib-kroki sphinx-multiversion sphinx_rtd_theme ]))
     ];


### PR DESCRIPTION
This PR
- adds latex back to the build env of the docs.
- adds publishing of the pdf to docs.wire.com/main.pdf when running "make push"

Context: https://github.com/wireapp/wire-server/pull/2258#issuecomment-1109718668

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):