### PR TITLE
Prevent duplicated rendering of FEATURE_ENABLE_PAYMENT

### DIFF
--- a/changelog.d/3-bug-fixes/fix-duplicated-enable-payment-flag-in-helm-charts
+++ b/changelog.d/3-bug-fixes/fix-duplicated-enable-payment-flag-in-helm-charts
@@ -1,0 +1,4 @@
+When `config.enablePayment` and `FEATURE_ENABLE_PAYMENT` (`envVars`) were set,
+the team-settings feature flag `FEATURE_ENABLE_PAYMENT` was rendered two times.
+The new behavior is to give the `envVars` entry priority. I.e. when it's set,
+it's used instead of the `config.enablePayment` value.

--- a/charts/team-settings/templates/deployment.yaml
+++ b/charts/team-settings/templates/deployment.yaml
@@ -40,10 +40,13 @@ spec:
             value: https://{{ .Values.config.externalUrls.backendRest }}
           - name: BACKEND_WS
             value: wss://{{ .Values.config.externalUrls.backendWebsocket }}
+
+          {{- if not (hasKey .Values.envVars "FEATURE_ENABLE_PAYMENT") }}
             # NOTE defaults to 'true', but since we assume on-prem here, we default to 'false'
             # SRC https://github.com/wireapp/wire-web-config-default/blob/master/wire-team-settings/.env.defaults#L48
           - name: FEATURE_ENABLE_PAYMENT
             value: {{ .Values.config.enablePayment | default false | quote }}
+          {{- end }}
       {{- range $key, $val := .Values.envVars }}
           - name: {{ $key }}
             value: {{ $val | quote }}


### PR DESCRIPTION
If the `FEATURE_ENABLE_PAYMENT` feature flag is set by `envVars`, do not render it again. Otherwise, we might end up in confusing cases like: The flag was set to `true`, but it's additionally rendered with a default to `false`.

I gave the `envVars` entry priority because it's used many times in *cailleach* and my gut feeling tells me that it would be confusing to override an explicitly set flag with an opposite value.

Example from k8s:

```yaml
kubectl get pod -n wire team-settings-598ddf7956-r6jfn -o yaml

...
spec:
  containers:
  - env:
    - name: NODE_PORT
      value: "8080"
    - name: APP_BASE
      value: https://teams.secusmart-column-1a.wire.link/
    - name: BACKEND_REST
      value: https://nginz-https.secusmart-column-1a.wire.link
    - name: BACKEND_WS
      value: wss://nginz-ssl.secusmart-column-1a.wire.link
    - name: FEATURE_ENABLE_PAYMENT
      value: "false"
    - name: FEATURE_ENABLE_PAYMENT
      value: "false"
...
```

## Checklist

 - [X] The **PR Title** explains the impact of the change.
 - [X] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
