### PR TITLE
Add python3 dependency to nix development environment

### DIFF
--- a/changelog.d/5-internal/add-python3-dev-dependency
+++ b/changelog.d/5-internal/add-python3-dev-dependency
@@ -1,0 +1,1 @@
+Add python3 to nix development environment. It's needed by hack/bin/serve-charts.sh .

--- a/dev-packages.nix
+++ b/dev-packages.nix
@@ -177,6 +177,7 @@ in
   pkgs.gnumake
   pkgs.gnused
   (pkgs.haskell-language-server.override { supportedGhcVersions = [ "8107" ]; })
+  pkgs.python3
   pkgs.jq
   pkgs.niv
   pkgs.ormolu


### PR DESCRIPTION
Without this dependency `./hack/bin/serve-charts.sh` fails:

```
make clean-charts && make charts-serve DOCKER_TAG=4.7.1 HELM_SEMVER=0.0.42
rm -rf .local/charts
./hack/bin/copy-charts.sh wire-server
copied /home/sven/src/wire-server/charts/wire-server (and its local dependencies) to /home/sven/src/wire-server/.local/charts/wire-server
./hack/bin/set-wire-server-image-version.sh 4.7.1
./hack/bin/set-helm-chart-version.sh "wire-server" 0.0.42
./hack/bin/copy-charts.sh databases-ephemeral
copied /home/sven/src/wire-server/charts/databases-ephemeral (and its local dependencies) to /home/sven/src/wire-server/.local/charts/databases-ephemeral
./hack/bin/set-wire-server-image-version.sh 4.7.1
./hack/bin/set-helm-chart-version.sh "databases-ephemeral" 0.0.42
./hack/bin/copy-charts.sh fake-aws
copied /home/sven/src/wire-server/charts/fake-aws (and its local dependencies) to /home/sven/src/wire-server/.local/charts/fake-aws
./hack/bin/set-wire-server-image-version.sh 4.7.1
./hack/bin/set-helm-chart-version.sh "fake-aws" 0.0.42
./hack/bin/copy-charts.sh nginx-ingress-controller
copied /home/sven/src/wire-server/charts/nginx-ingress-controller (and its local dependencies) to /home/sven/src/wire-server/.local/charts/nginx-ingress-controller
./hack/bin/set-wire-server-image-version.sh 4.7.1
./hack/bin/set-helm-chart-version.sh "nginx-ingress-controller" 0.0.42
./hack/bin/copy-charts.sh nginx-ingress-services
copied /home/sven/src/wire-server/charts/nginx-ingress-services (and its local dependencies) to /home/sven/src/wire-server/.local/charts/nginx-ingress-services
./hack/bin/set-wire-server-image-version.sh 4.7.1
./hack/bin/set-helm-chart-version.sh "nginx-ingress-services" 0.0.42
./hack/bin/copy-charts.sh wire-server-metrics
copied /home/sven/src/wire-server/charts/wire-server-metrics (and its local dependencies) to /home/sven/src/wire-server/.local/charts/wire-server-metrics
./hack/bin/set-wire-server-image-version.sh 4.7.1
./hack/bin/set-helm-chart-version.sh "wire-server-metrics" 0.0.42
./hack/bin/copy-charts.sh fluent-bit
copied /home/sven/src/wire-server/charts/fluent-bit (and its local dependencies) to /home/sven/src/wire-server/.local/charts/fluent-bit
./hack/bin/set-wire-server-image-version.sh 4.7.1
./hack/bin/set-helm-chart-version.sh "fluent-bit" 0.0.42
./hack/bin/copy-charts.sh kibana
copied /home/sven/src/wire-server/charts/kibana (and its local dependencies) to /home/sven/src/wire-server/.local/charts/kibana
./hack/bin/set-wire-server-image-version.sh 4.7.1
./hack/bin/set-helm-chart-version.sh "kibana" 0.0.42
./hack/bin/copy-charts.sh sftd
copied /home/sven/src/wire-server/charts/sftd (and its local dependencies) to /home/sven/src/wire-server/.local/charts/sftd
./hack/bin/set-wire-server-image-version.sh 4.7.1
./hack/bin/set-helm-chart-version.sh "sftd" 0.0.42
./hack/bin/copy-charts.sh restund
copied /home/sven/src/wire-server/charts/restund (and its local dependencies) to /home/sven/src/wire-server/.local/charts/restund
./hack/bin/set-wire-server-image-version.sh 4.7.1
./hack/bin/set-helm-chart-version.sh "restund" 0.0.42
./hack/bin/copy-charts.sh coturn
copied /home/sven/src/wire-server/charts/coturn (and its local dependencies) to /home/sven/src/wire-server/.local/charts/coturn
./hack/bin/set-wire-server-image-version.sh 4.7.1
./hack/bin/set-helm-chart-version.sh "coturn" 0.0.42
./hack/bin/serve-charts.sh wire-server databases-ephemeral fake-aws nginx-ingress-controller nginx-ingress-services wire-server-metrics fluent-bit kibana sftd restund coturn
"wire-develop" has been removed from your repositories
Updating dependencies in wire-server ...
Updating dependencies in ../legalhold ...
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://charts.bitnami.com/bitnami" chart repository
Saving 1 charts
Downloading postgresql from repo https://charts.bitnami.com/bitnami
Deleting outdated charts
... updating in ../legalhold done.
Saving 16 charts
Deleting outdated charts
... updating in wire-server done.
Successfully packaged chart and saved it to: /home/sven/src/wire-server/.local/charts/wire-server-0.0.42.tgz
Updating dependencies in databases-ephemeral ...
Updating dependencies in ../redis-ephemeral ...
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://charts.bitnami.com/bitnami" chart repository
Saving 1 charts
Downloading redis from repo https://charts.bitnami.com/bitnami
Deleting outdated charts
... updating in ../redis-ephemeral done.
Updating dependencies in ../cassandra-ephemeral ...
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://charts.helm.sh/incubator" chart repository
Saving 1 charts
Downloading cassandra from repo https://charts.helm.sh/incubator
Deleting outdated charts
... updating in ../cassandra-ephemeral done.
Saving 3 charts
Deleting outdated charts
... updating in databases-ephemeral done.
Successfully packaged chart and saved it to: /home/sven/src/wire-server/.local/charts/databases-ephemeral-0.0.42.tgz
Updating dependencies in fake-aws ...
Updating dependencies in ../fake-aws-s3 ...
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://charts.min.io/" chart repository
Saving 1 charts
Downloading minio from repo https://charts.min.io/
Deleting outdated charts
... updating in ../fake-aws-s3 done.
Saving 4 charts
Deleting outdated charts
... updating in fake-aws done.
Successfully packaged chart and saved it to: /home/sven/src/wire-server/.local/charts/fake-aws-0.0.42.tgz
Updating dependencies in nginx-ingress-controller ...
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://charts.helm.sh/stable" chart repository
Saving 1 charts
Downloading nginx-ingress from repo https://charts.helm.sh/stable
Deleting outdated charts
... updating in nginx-ingress-controller done.
Successfully packaged chart and saved it to: /home/sven/src/wire-server/.local/charts/nginx-ingress-controller-0.0.42.tgz
Successfully packaged chart and saved it to: /home/sven/src/wire-server/.local/charts/nginx-ingress-services-0.0.42.tgz
Updating dependencies in wire-server-metrics ...
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://prometheus-community.github.io/helm-charts" chart repository
Saving 1 charts
Downloading kube-prometheus-stack from repo https://prometheus-community.github.io/helm-charts
Deleting outdated charts
... updating in wire-server-metrics done.
Successfully packaged chart and saved it to: /home/sven/src/wire-server/.local/charts/wire-server-metrics-0.0.42.tgz
Updating dependencies in fluent-bit ...
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://fluent.github.io/helm-charts" chart repository
Saving 1 charts
Downloading fluent-bit from repo https://fluent.github.io/helm-charts
Deleting outdated charts
... updating in fluent-bit done.
Successfully packaged chart and saved it to: /home/sven/src/wire-server/.local/charts/fluent-bit-0.0.42.tgz
Updating dependencies in kibana ...
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://helm.elastic.co" chart repository
Saving 1 charts
Downloading kibana from repo https://helm.elastic.co
Deleting outdated charts
... updating in kibana done.
Successfully packaged chart and saved it to: /home/sven/src/wire-server/.local/charts/kibana-0.0.42.tgz
Successfully packaged chart and saved it to: /home/sven/src/wire-server/.local/charts/sftd-0.0.42.tgz
Successfully packaged chart and saved it to: /home/sven/src/wire-server/.local/charts/restund-0.0.42.tgz
Successfully packaged chart and saved it to: /home/sven/src/wire-server/.local/charts/coturn-0.0.42.tgz
./hack/bin/serve-charts.sh: line 17: python3: command not found
make: *** [Makefile:401: charts-serve] Error 127
```

## Checklist

 - [X] The **PR Title** explains the impact of the change.
 - [X] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [X] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [X] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
