### PR TITLE
buildah-docker: use cabal instead of stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -434,7 +434,7 @@ echo-release-charts:
 
 .PHONY: buildah-docker
 buildah-docker: buildah-docker-nginz
-	./hack/bin/buildah-compile.sh
+	./hack/bin/buildah-compile.sh all
 	BUILDAH_PUSH=${BUILDAH_PUSH} KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME} BUILDAH_KIND_LOAD=${BUILDAH_KIND_LOAD}  ./hack/bin/buildah-make-images.sh
 
 .PHONY: buildah-docker-nginz

--- a/changelog.d/5-internal/buildah-cabal
+++ b/changelog.d/5-internal/buildah-cabal
@@ -1,0 +1,1 @@
+Use cabal in buildah-based builds

--- a/docs/legacy/developer/how-to.md
+++ b/docs/legacy/developer/how-to.md
@@ -139,7 +139,7 @@ Then build and push the `brig` image by running
 
 ```
 export DOCKER_TAG_LOCAL_BUILD=$USER
-hack/bin/buildah-compile.sh
+hack/bin/buildah-compile.sh all
 DOCKER_TAG=$DOCKER_TAG_LOCAL_BUILD EXECUTABLES=brig BUILDAH_PUSH=1 ./hack/bin/buildah-make-images.sh
 ```
 

--- a/hack/bin/buildah-clean.sh
+++ b/hack/bin/buildah-clean.sh
@@ -4,9 +4,6 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
-# Note: keep these paths in sync with the paths/names used in the other buildah-* scripts.
-rm -rf "$TOP_LEVEL"/dist-buildah
-rm -rf "$TOP_LEVEL"/.stack-root-buildah
-rm -rf "$TOP_LEVEL"/.stack-work-buildah
-buildah rm wire-server-dev
+rm -rf "$TOP_LEVEL"/buildah
+# buildah rm wire-server-dev
 buildah rm output

--- a/hack/bin/buildah-compile.sh
+++ b/hack/bin/buildah-compile.sh
@@ -2,7 +2,7 @@
 
 # This compiles wire-server inside an ubuntu-based container based on quay.io/wire/ubuntu20-builder.
 # the tool 'buildah' is used to mount some folders in, and to
-# keep the stack caches of .stack and .stack-work (renamed to avoid conflicts) for the next compilation
+# keep the stack caches of /.root/.cabal and dist-newstyle (renamed to avoid conflicts) for the next compilation
 
 # After compilation, ./buildah-make-images.sh can be used
 # to bake individual executables into their respective docker images used by kubernetes.
@@ -13,18 +13,18 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
 # Note: keep the following names and paths in sync with the other buildah-* scripts.
-mkdir -p "$TOP_LEVEL"/.stack-root-buildah
-mkdir -p "$TOP_LEVEL"/.stack-work-buildah
-mkdir -p "$TOP_LEVEL"/dist-buildah
+mkdir -p "$TOP_LEVEL"/buildah/dot-cabal
+mkdir -p "$TOP_LEVEL"/buildah/dist-newstyle
+mkdir -p "$TOP_LEVEL"/buildah/dist
+
 CONTAINER_NAME=wire-server-dev
 
 # check for the existence of; or create a working container
 buildah containers | awk '{print $5}' | grep "$CONTAINER_NAME" \
     || buildah from --name "$CONTAINER_NAME" -v "${TOP_LEVEL}":/src --pull quay.io/wire/ubuntu20-builder:develop
 
-# The first time round, we want to copy the .stack folder from the ubuntu20-builder for future use. Afterwards, we want to re-use the "dirty" stack root folder.
-# Current check hinges on the existence of a config file, and hardcodes some paths
-ls "$TOP_LEVEL/.stack-root-buildah/config.yaml" 2> /dev/null \
-    || buildah run "$CONTAINER_NAME" -- cp -a /root/.stack/. /src/.stack-root-buildah/
+# copy /root/.cabal out of the container
+ls "$TOP_LEVEL"/buildah/dot-cabal/store 2> /dev/null \
+    || buildah run "$CONTAINER_NAME" -- cp -a /root/.cabal/. /src/buildah/dot-cabal
 
 buildah run "$CONTAINER_NAME" -- /src/hack/bin/buildah-inside.sh "$@"

--- a/hack/bin/buildah-compile.sh
+++ b/hack/bin/buildah-compile.sh
@@ -2,7 +2,7 @@
 
 # This compiles wire-server inside an ubuntu-based container based on quay.io/wire/ubuntu20-builder.
 # the tool 'buildah' is used to mount some folders in, and to
-# keep the stack caches of /.root/.cabal and dist-newstyle (renamed to avoid conflicts) for the next compilation
+# keep the caches of /.root/.cabal and dist-newstyle (renamed to avoid conflicts) for the next compilation
 
 # After compilation, ./buildah-make-images.sh can be used
 # to bake individual executables into their respective docker images used by kubernetes.

--- a/hack/bin/buildah-inside.sh
+++ b/hack/bin/buildah-inside.sh
@@ -7,4 +7,10 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
 cd "$TOP_LEVEL"
-stack install --local-bin-path=dist-buildah --work-dir=.stack-work-buildah --stack-root="${TOP_LEVEL}"/.stack-root-buildah --fast "$@"
+
+cabal build \
+    --prefix=./buildah/dot-cabal \
+    --builddir=./buildah/dist-newstyle \
+    "$@"
+
+DIST="$TOP_LEVEL"/buildah/dist PLAN_FILE="$TOP_LEVEL"/buildah/dist-newstyle/cache/plan.json ./hack/bin/cabal-install-artefacts.sh "$@"

--- a/hack/bin/buildah-make-images.sh
+++ b/hack/bin/buildah-make-images.sh
@@ -17,7 +17,7 @@ buildah run "$CONTAINER_NAME" -- sh -c 'mkdir -p /usr/share/wire/ && cp -r "/src
 
 for EX in $EXECUTABLES; do
     # Copy the main executable into the PATH on the container
-    buildah run "$CONTAINER_NAME" -- cp "/src/dist-buildah/$EX" "/usr/bin/$EX"
+    buildah run "$CONTAINER_NAME" -- cp "/src/buildah/dist/$EX" "/usr/bin/$EX"
 
     # Start that executable by default when launching the docker image
     buildah config --entrypoint "[ \"/usr/bin/dumb-init\", \"--\", \"/usr/bin/$EX\" ]" "$CONTAINER_NAME"

--- a/hack/bin/cabal-install-artefacts.sh
+++ b/hack/bin/cabal-install-artefacts.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
-DIST="$TOP_LEVEL/dist"
+DIST=${DIST:-"$TOP_LEVEL/dist"}
+PLAN_FILE=${PLAN_FILE:-$TOP_LEVEL/dist-newstyle/cache/plan.json}
 
 mkdir -p "$DIST"
 
@@ -16,7 +17,7 @@ fi
 
 cd "$TOP_LEVEL"
 
-cabal-plan list-bins "$pattern:exe:*" |
+cabal-plan list-bins --plan-json "$PLAN_FILE" "$pattern:exe:*" |
   awk '{print $2}' |
   xargs -i sh -c 'test -f {} && echo {} || true' |
-  xargs -P8 -i rsync -a {} "$DIST"
+  xargs -P8 -I{} rsync -a {} "$DIST"


### PR DESCRIPTION
We recently removed `stack` from the builder images. This PR changes the buildah-based build scripts to use cabal instead of stack.

I manually tested `make buildah-docker`

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
