### PR TITLE
Fixup for #2339

### DIFF
--- a/deploy/services-demo/conf/gundeck.demo.yaml
+++ b/deploy/services-demo/conf/gundeck.demo.yaml
@@ -11,7 +11,7 @@ cassandra:
 redis:
   host: 127.0.0.1
   port: 6379
-  connectionMode: cluster
+  connectionMode: master
 
 aws:
   queueName: integration-gundeck-events


### PR DESCRIPTION
Actually, this redis runs in "master" mode on that port (from docker-compose). There are other redises launched on other parts that run in cluster mode.

Redis part of cluster:
https://github.com/wireapp/wire-server/blob/develop/deploy/dockerephemeral/docker-compose.yaml#L98
(ports 6373 - 6378)

Redis standalone in master mode on port 6379
https://github.com/wireapp/wire-server/blob/develop/deploy/dockerephemeral/docker-compose.yaml#L77

Sorry for forgetting to do this earlier (to add config to this file). The PR #2339 is doing the wrong thing, any use of gundeck and messaging on the demo setup would fail.