### PR TITLE
Adapt wire-server charts so they can be used to run wire cloud

### DIFF
--- a/changelog.d/2-features/charts-brig-new-settings
+++ b/changelog.d/2-features/charts-brig-new-settings
@@ -1,0 +1,22 @@
+charts: Various new values can now be configured and some got changed
+
+Allow new configurations in the brig chart:
+* `config.emailSMS.user.invitationUrl`
+* `config.emailSMS.team.tInvitationUrl`
+* `config.emailSMS.team.tActivationUrl`
+* `config.emailSMS.team.tCreatorWelcomeUrl`
+* `config.emailSMS.team.tMemberWelcomeUrl`
+* `config.setProviderSearchFilter`
+* `config.setWhitelist`
+* `config.setFeatureFlags`
+* `config.setCustomerExtensions`
+
+If any values in config.emailSMS.team are specified, all must be specified.
+
+Allow new configurations in the gundeck chart:
+* `config.perNativePushConcurrency`
+* `config.maxConcurrentNativePushes.soft`
+* `config.maxConcurrentNativePushes.hard`
+
+Other changes:
+* Default `maxTeamSize` changed to 10000 from 500.

--- a/changelog.d/2-features/no-aws-creds
+++ b/changelog.d/2-features/no-aws-creds
@@ -1,0 +1,2 @@
+charts/{brig,cargohol,galley,gundeck}: Allow not configuring AWS credentials and allow using a special service account.
+This way, when operating wire in AWS cloud either instance profiles or IAM role attached to a service account can be used to communicate with AWS.

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -67,6 +67,9 @@ data:
       {{- if .dynamoDBEndpoint }}
       dynamoDBEndpoint: {{ .dynamoDBEndpoint | quote }}
       {{- end }}
+      {{- if .userJournalQueue }}
+      userJournalQueue: {{ .userJournalQueue | quote }}
+      {{- end }}
     {{- end }}
 
     internalEvents:
@@ -112,7 +115,9 @@ data:
         activationUrl: {{ .emailSMS.user.activationUrl }}
         smsActivationUrl: {{ .emailSMS.user.smsActivationUrl }}
         passwordResetUrl: {{ .emailSMS.user.passwordResetUrl }}
+        {{- if .emailSMS.user.invitationUrl }}
         invitationUrl: {{ .emailSMS.user.invitationUrl }}
+        {{- end }}
         deletionUrl: {{ .emailSMS.user.deletionUrl }}
       {{- else }}
         activationUrl: {{ .externalUrls.nginz }}/activate?key=${key}&code=${code}
@@ -226,6 +231,9 @@ data:
       {{- if .setSearchSameTeamOnly }}
       setSearchSameTeamOnly: {{ .setSearchSameTeamOnly }}
       {{- end }}
+      {{- if .setProviderSearchFilter }}
+      setProviderSearchFilter: {{ .setProviderSearchFilter }}
+      {{- end }}
       {{- if .setUserMaxPermClients }}
       setUserMaxPermClients: {{ .setUserMaxPermClients }}
       {{- end }}
@@ -241,6 +249,17 @@ data:
       {{- end }}
       {{- if .setSftListAllServers }}
       setSftListAllServers: {{ .setSftListAllServers }}
+      {{- end }}
+      {{- if .setWhitelist }}
+      setWhitelist: {{ toYaml .setWhitelist | nindent 8 }}
+      {{- end }}
+      {{- if .setFeatureFlags }}
+      setFeatureFlags: {{ toYaml .setFeatureFlags | nindent 8 }}
+      {{- end }}
+      # Customer extensions. If this is not part of your contract with wire, use at your own risk!
+      # Details: https://github.com/wireapp/wire-server/blob/3a21a82a1781f0d128f503df6a705b0b5f733d7b/services/brig/src/Brig/Options.hs#L465-L503
+      {{- if .setCustomerExtensions }}
+      setCustomerExtensions: {{ toYaml .setCustomerExtensions | nindent 8 }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -143,6 +143,12 @@ data:
       {{- end }}
 
       team:
+      {{- if .emailSMS.team }}
+        tInvitationUrl: {{ .emailSMS.team.tInvitationUrl }}
+        tActivationUrl: {{ .emailSMS.team.tActivationUrl }}
+        tCreatorWelcomeUrl: {{ .emailSMS.team.tCreatorWelcomeUrl }}
+        tMemberWelcomeUrl: {{ .emailSMS.team.tMemberWelcomeUrl }}
+      {{- else }}
       {{- if .externalUrls.teamSettings }}
         tInvitationUrl: {{ .externalUrls.teamSettings }}/join/?team-code=${code}
       {{- else }}
@@ -151,6 +157,7 @@ data:
         tActivationUrl: {{ .externalUrls.nginz }}/register?team=${team}&team_code=${code}
         tCreatorWelcomeUrl: {{ .externalUrls.teamCreatorWelcome }}
         tMemberWelcomeUrl: {{ .externalUrls.teamMemberWelcome }}
+      {{- end }}
 
     zauth:
       privateKeys: /etc/wire/brig/secrets/secretkey.txt

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
         fluentbit.io/parser: json
     spec:
+      {{- if hasKey .Values "serviceAccountName" }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       volumes:
         - name: "brig-config"
           configMap:
@@ -53,6 +56,7 @@ spec:
           env:
           - name: LOG_LEVEL
             value: {{ .Values.config.logLevel }}
+          {{- if hasKey .Values.secrets "awsKeyId" }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
@@ -63,6 +67,7 @@ spec:
               secretKeyRef:
                 name: brig
                 key: awsSecretKey
+          {{- end }}
           # TODO: Is this the best way to do this?
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -29,9 +29,7 @@ spec:
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
         fluentbit.io/parser: json
     spec:
-      {{- if hasKey .Values "serviceAccountName" }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       volumes:
         - name: "brig-config"
           configMap:

--- a/charts/brig/templates/secret.yaml
+++ b/charts/brig/templates/secret.yaml
@@ -16,8 +16,10 @@ data:
   secretkey.txt: {{ .zAuth.privateKeys | b64enc | quote }}
   publickey.txt: {{ .zAuth.publicKeys | b64enc | quote }}
   turn-secret.txt: {{ .turn.secret | b64enc | quote }}
+  {{- if .awsKeyId }}
   awsKeyId: {{ .awsKeyId | b64enc | quote }}
   awsSecretKey: {{ .awsSecretKey | b64enc | quote }}
+  {{- end }}
   twilio-credentials.yaml: {{ .setTwilio | b64enc | quote }}
   nexmo-credentials.yaml: {{ .setNexmo | b64enc | quote }}
   {{- if (not $.Values.config.useSES) }}

--- a/charts/brig/templates/serviceaccount.yaml
+++ b/charts/brig/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    wireService: brig
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -64,7 +64,7 @@ config:
       retryAfter: 86400
     setRichInfoLimit: 5000
     setDefaultUserLocale: en
-    setMaxTeamSize: 500
+    setMaxTeamSize: 10000
     setMaxConvSize: 500
     # Allowed values: https://github.com/wireapp/wire-server/blob/0126651a25aabc0c5589edc2b1988bb06550a03a/services/brig/src/Brig/Options.hs#L304-L306
     # Description: https://github.com/wireapp/wire-server/blob/0126651a25aabc0c5589edc2b1988bb06550a03a/services/brig/src/Brig/Options.hs#L290-L299

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -92,3 +92,10 @@ turnStatic:
   - turn:localhost:3478?transport=tcp
 tests:
   enableFederationTests: false
+serviceAccount:
+  # When setting this to 'false', either make sure that a service account named
+  # 'brig' exists or change the 'name' field to 'default'
+  create: true
+  name: brig
+  annotations: {}
+  automountServiceAccountToken: true

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -99,3 +99,5 @@ serviceAccount:
   name: brig
   annotations: {}
   automountServiceAccountToken: true
+
+secrets: {}

--- a/charts/cargohold/templates/deployment.yaml
+++ b/charts/cargohold/templates/deployment.yaml
@@ -27,9 +27,7 @@ spec:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
-      {{- if hasKey .Values "serviceAccountName" }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       volumes:
         - name: "cargohold-config"
           configMap:

--- a/charts/cargohold/templates/deployment.yaml
+++ b/charts/cargohold/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
+      {{- if hasKey .Values "serviceAccountName" }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       volumes:
         - name: "cargohold-config"
           configMap:
@@ -44,6 +47,7 @@ spec:
           - name: "cargohold-config"
             mountPath: "/etc/wire/cargohold/conf"
           env:
+          {{- if hasKey .Values.secrets "awsKeyId" }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
@@ -54,6 +58,7 @@ spec:
               secretKeyRef:
                 name: cargohold
                 key: awsSecretKey
+          {{- end }}
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
           {{- with .Values.config.proxy }}

--- a/charts/cargohold/templates/secret.yaml
+++ b/charts/cargohold/templates/secret.yaml
@@ -16,7 +16,9 @@ data:
   {{ if .cloudFront }}
   cf-pk.pem: {{ .cloudFront.cfPrivateKey | b64enc | quote }}
   {{ end }}
-  
+
+  {{- if .awsKeyId }}
   awsKeyId: {{ .awsKeyId | b64enc | quote }}
   awsSecretKey: {{ .awsSecretKey | b64enc | quote }}
+  {{- end }}
   {{- end }}

--- a/charts/cargohold/templates/serviceaccount.yaml
+++ b/charts/cargohold/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    wireService: cargohold
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -19,4 +19,10 @@ config:
     region: "eu-west-1"
     s3Bucket: assets
   proxy: {}
-# serviceAccountName:
+serviceAccount:
+  # When setting this to 'false', either make sure that a service account named
+  # 'cargohold' exists or change the 'name' field to 'default'
+  create: true
+  name: cargohold
+  annotations: {}
+  automountServiceAccountToken: true

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -26,3 +26,5 @@ serviceAccount:
   name: cargohold
   annotations: {}
   automountServiceAccountToken: true
+
+secrets: {}

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -19,3 +19,4 @@ config:
     region: "eu-west-1"
     s3Bucket: assets
   proxy: {}
+# serviceAccountName:

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -43,7 +43,7 @@ data:
 
     {{- if (.journal) }}
     journal:
-      queueName: {{ .journal.queue }}
+      queueName: {{ .journal.queueName }}
       endpoint: {{ .journal.endpoint }}
     {{- end }}
 

--- a/charts/galley/templates/deployment.yaml
+++ b/charts/galley/templates/deployment.yaml
@@ -27,23 +27,22 @@ spec:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
+      {{- if hasKey .Values "serviceAccountName" }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       volumes:
         - name: "galley-config"
           configMap:
             name: "galley"
-        - name: "galley-secrets"
-          secret:
-            secretName: "galley"
       containers:
         - name: galley
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           volumeMounts:
-          - name: "galley-secrets"
-            mountPath: "/etc/wire/galley/secrets"
           - name: "galley-config"
             mountPath: "/etc/wire/galley/conf"
           env:
+          {{- if hasKey .Values.secrets "awsKeyId" }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
@@ -54,6 +53,7 @@ spec:
               secretKeyRef:
                 name: galley
                 key: awsSecretKey
+          {{- end }}
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
           {{- with .Values.config.proxy }}

--- a/charts/galley/templates/deployment.yaml
+++ b/charts/galley/templates/deployment.yaml
@@ -27,9 +27,7 @@ spec:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
-      {{- if hasKey .Values "serviceAccountName" }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       volumes:
         - name: "galley-config"
           configMap:

--- a/charts/galley/templates/secret.yaml
+++ b/charts/galley/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if hasKey .Values.secrets "awsKeyId" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,3 +14,4 @@ data:
   awsKeyId: {{ .awsKeyId | b64enc | quote }}
   awsSecretKey: {{ .awsSecretKey | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/galley/templates/serviceaccount.yaml
+++ b/charts/galley/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    wireService: galley
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -21,7 +21,7 @@ config:
     replicaCount: 3
   enableFederator: false # keep enableFederator default in sync with brig and cargohold chart's config.enableFederator as well as wire-server chart's tag.federator
   settings:
-    maxTeamSize: 500
+    maxTeamSize: 10000
     maxConvSize: 500
     # Before making indexedBillingTeamMember true while upgrading, please
     # refer to notes here: https://github.com/wireapp/wire-server-deploy/releases/tag/v2020-05-15

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -55,3 +55,5 @@ serviceAccount:
   name: galley
   annotations: {}
   automountServiceAccountToken: true
+
+secrets: {}

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -48,5 +48,10 @@ config:
   aws:
     region: "eu-west-1"
   proxy: {}
-
-# serviceAccountName:
+serviceAccount:
+  # When setting this to 'false', either make sure that a service account named
+  # 'galley' exists or change the 'name' field to 'default'
+  create: true
+  name: galley
+  annotations: {}
+  automountServiceAccountToken: true

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -48,3 +48,5 @@ config:
   aws:
     region: "eu-west-1"
   proxy: {}
+
+# serviceAccountName:

--- a/charts/gundeck/templates/configmap.yaml
+++ b/charts/gundeck/templates/configmap.yaml
@@ -50,7 +50,13 @@ data:
       httpPoolSize: 1024
       notificationTTL: 2419200
       bulkPush: {{ .bulkPush }}
+      {{- if hasKey . "perNativePushConcurrency" }}
+      perNativePushConcurrency: {{ .perNativePushConcurrency }}
+      {{- end }}
       maxConcurrentNativePushes:
-        soft: 1000
+        soft: {{ .maxConcurrentNativePushes.soft }}
+        {{- if hasKey .maxConcurrentNativePushes "hard" }}
+        hard: {{ .maxConcurrentNativePushes.hard }}
+        {{- end }}
         # hard: 30  # more than this number of threads will not be allowed
   {{- end }}

--- a/charts/gundeck/templates/deployment.yaml
+++ b/charts/gundeck/templates/deployment.yaml
@@ -27,23 +27,22 @@ spec:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
+      {{- if hasKey .Values "serviceAccountName" }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       volumes:
         - name: "gundeck-config"
           configMap:
             name: "gundeck"
-        - name: "gundeck-secrets"
-          secret:
-            secretName: "gundeck"
       containers:
         - name: gundeck
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           volumeMounts:
-          - name: "gundeck-secrets"
-            mountPath: "/etc/wire/gundeck/secrets"
           - name: "gundeck-config"
             mountPath: "/etc/wire/gundeck/conf"
           env:
+          {{- if hasKey .Values.secrets "awsKeyId" }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
@@ -54,6 +53,7 @@ spec:
               secretKeyRef:
                 name: gundeck
                 key: awsSecretKey
+          {{- end }}
           - name: AWS_REGION
             value: "{{ .Values.config.aws.region }}"
           {{- with .Values.config.proxy }}

--- a/charts/gundeck/templates/deployment.yaml
+++ b/charts/gundeck/templates/deployment.yaml
@@ -27,9 +27,7 @@ spec:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
-      {{- if hasKey .Values "serviceAccountName" }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       volumes:
         - name: "gundeck-config"
           configMap:

--- a/charts/gundeck/templates/secret.yaml
+++ b/charts/gundeck/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if hasKey .Values.secrets "awsKeyId" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,3 +14,4 @@ data:
   awsKeyId: {{ .awsKeyId | b64enc | quote }}
   awsSecretKey: {{ .awsSecretKey | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/gundeck/templates/serviceaccount.yaml
+++ b/charts/gundeck/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    wireService: gundeck
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -28,10 +28,9 @@ config:
   aws:
     region: "eu-west-1"
   proxy: {}
-  settings:
-    # perNativePushConcurrency
-    maxConcurrentNativePushes:
-      soft: 1000
+  # perNativePushConcurrency
+  maxConcurrentNativePushes:
+    soft: 1000
 serviceAccount:
   # When setting this to 'false', either make sure that a service account named
   # 'gundeck' exists or change the 'name' field to 'default'

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -36,3 +36,4 @@ serviceAccount:
   annotations: {}
   automountServiceAccountToken: true
 
+secrets: {}

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -28,6 +28,10 @@ config:
   aws:
     region: "eu-west-1"
   proxy: {}
+  settings:
+    # perNativePushConcurrency
+    maxConcurrentNativePushes:
+      soft: 1000
 serviceAccount:
   # When setting this to 'false', either make sure that a service account named
   # 'gundeck' exists or change the 'name' field to 'default'

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -28,3 +28,4 @@ config:
   aws:
     region: "eu-west-1"
   proxy: {}
+# serviceAccountName:

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -28,7 +28,7 @@ config:
   aws:
     region: "eu-west-1"
   proxy: {}
-  # perNativePushConcurrency
+  # perNativePushConcurrency: 32
   maxConcurrentNativePushes:
     soft: 1000
 serviceAccount:

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -28,4 +28,11 @@ config:
   aws:
     region: "eu-west-1"
   proxy: {}
-# serviceAccountName:
+serviceAccount:
+  # When setting this to 'false', either make sure that a service account named
+  # 'gundeck' exists or change the 'name' field to 'default'
+  create: true
+  name: gundeck
+  annotations: {}
+  automountServiceAccountToken: true
+

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -99,8 +99,6 @@ nginx_conf:
     - path: /users
       envs:
       - all
-      envs:
-      - all
       doc: true
     - path: /list-users
       envs:

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -162,7 +162,7 @@ galley:
             domains: ["example.com"]
     journal:
       endpoint: http://fake-aws-sqs:4568
-      queue: integration-team-events.fifo
+      queueName: integration-team-events.fifo
   secrets:
     awsKeyId: dummykey
     awsSecretKey: dummysecret


### PR DESCRIPTION
charts/{brig,cargohol,galley,gundeck}: Allow not configuring AWS credentials and allow using a special service account.
This way, when operating wire in AWS cloud either instance profiles or IAM role attached to a service account can be used to communicate with AWS.


Allow new configurations in the brig chart:
* `config.emailSMS.user.invitationUrl`
* `config.emailSMS.team.tInvitationUrl`
* `config.emailSMS.team.tActivationUrl`
* `config.emailSMS.team.tCreatorWelcomeUrl`
* `config.emailSMS.team.tMemberWelcomeUrl`
* `config.setProviderSearchFilter`
* `config.setWhitelist`
* `config.setFeatureFlags`
* `config.setCustomerExtensions`

If any values in config.emailSMS.team are specified, all must be specified.

Allow new configurations in the gundeck chart:
* `config.perNativePushConcurrency`
* `config.maxConcurrentNativePushes.soft`
* `config.maxConcurrentNativePushes.hard`

Other changes:
* Default `maxTeamSize` changed from 500 to 10000. (larger teams have been supported by wire-server code for a while; but the default value had not been increased yet)

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
