### PR TITLE
nix: build macos dev-env again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ jobs:
      matrix:
        os:
          - ubuntu-latest
-         # This is too expensive
-         # - macos-latest
+         - macos-latest
    runs-on: ${{ matrix.os }}
    steps:
      - uses: actions/checkout@v2

--- a/dev-packages.nix
+++ b/dev-packages.nix
@@ -173,7 +173,6 @@ let
 in
 [
   pkgs.cfssl
-  pkgs.docker-compose
   pkgs.gnumake
   pkgs.gnused
   (pkgs.haskell-language-server.override { supportedGhcVersions = [ "8107" ]; })
@@ -181,15 +180,11 @@ in
   pkgs.jq
   pkgs.niv
   pkgs.ormolu
-  pkgs.telepresence
   pkgs.wget
   pkgs.yq
   pkgs.rsync
   pkgs.netcat
   pkgs.crypto_cli
-
-  # To actually run buildah on nixos, I had to follow this: https://gist.github.com/alexhrescale/474d55635154e6b2cd6362c3bb403faf
-  pkgs.buildah
 
   stack-wrapper
   pinned.helm
@@ -204,5 +199,11 @@ in
   # which sets LD_LIBRARY_PATH and others correctly.
   cabal-wrapper
   pkgs.haskellPackages.implicit-hie
+] ++ pkgs.lib.optional pkgs.stdenv.isLinux [
+  # linux-only, not strictly required tools
+
+  pkgs.docker-compose
+  pkgs.telepresence
+  pkgs.buildah # To actually run buildah on nixos, I had to follow this: https://gist.github.com/alexhrescale/474d55635154e6b2cd6362c3bb403faf
 ]
 ++ c-lib-out-deps # Required to run HLS


### PR DESCRIPTION
There's people with Mac boxes who want to iterate on `wire-server`. Being able to use Nix, have the dev-env available in a binary cache, and CI ensure there's no regressions is highly valuable, so worth the additional CI minutes spent.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
