### PR TITLE
Implement remote key package claims

### DIFF
--- a/changelog.d/2-features/mls
+++ b/changelog.d/2-features/mls
@@ -1,0 +1,3 @@
+MLS implementation progress:
+
+ - remote key package claim is now supported (#2353)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -28,6 +28,7 @@ import Wire.API.Arbitrary (GenericUniform (..))
 import Wire.API.Federation.API.Common
 import Wire.API.Federation.Endpoint
 import Wire.API.Federation.Version
+import Wire.API.MLS.KeyPackage
 import Wire.API.Message (UserClients)
 import Wire.API.User (UserProfile)
 import Wire.API.User.Client (PubClient, UserClientPrekeyMap)
@@ -68,6 +69,7 @@ type BrigApi =
     :<|> FedEndpoint "get-user-clients" GetUserClients (UserMap (Set PubClient))
     :<|> FedEndpoint "send-connection-action" NewConnectionRequest NewConnectionResponse
     :<|> FedEndpoint "on-user-deleted-connections" UserDeletedConnectionsNotification EmptyResponse
+    :<|> FedEndpoint "claim-key-packages" ClaimKeyPackageRequest (Maybe KeyPackageBundle)
 
 newtype GetUserClients = GetUserClients
   { gucUsers :: [UserId]
@@ -127,3 +129,14 @@ data UserDeletedConnectionsNotification = UserDeletedConnectionsNotification
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform UserDeletedConnectionsNotification)
   deriving (FromJSON, ToJSON) via (CustomEncoded UserDeletedConnectionsNotification)
+
+data ClaimKeyPackageRequest = ClaimKeyPackageRequest
+  { -- | The user making the request, implictly qualified by the origin domain.
+    ckprClaimant :: UserId,
+    -- | The user whose key packages are being claimed, implictly qualified by
+    -- the target domain.
+    ckprTarget :: UserId
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform ClaimKeyPackageRequest)
+  deriving (FromJSON, ToJSON) via (CustomEncoded ClaimKeyPackageRequest)

--- a/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
+++ b/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
@@ -80,7 +80,7 @@ data KeyPackageBundleEntry = KeyPackageBundleEntry
     kpbeRef :: KeyPackageRef,
     kpbeKeyPackage :: KeyPackageData
   }
-  deriving stock (Eq, Ord)
+  deriving stock (Eq, Ord, Show)
 
 instance ToSchema KeyPackageBundleEntry where
   schema =
@@ -92,6 +92,7 @@ instance ToSchema KeyPackageBundleEntry where
         <*> kpbeKeyPackage .= field "key_package" schema
 
 newtype KeyPackageBundle = KeyPackageBundle {kpbEntries :: Set KeyPackageBundleEntry}
+  deriving stock (Eq, Show)
   deriving (FromJSON, ToJSON, S.ToSchema) via Schema KeyPackageBundle
 
 instance ToSchema KeyPackageBundle where

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -401,6 +401,7 @@ executable brig-integration
       API.Internal.Util
       API.Metrics
       API.MLS
+      API.MLS.Util
       API.Provider
       API.RichInfo.Util
       API.Search

--- a/services/brig/src/Brig/API/MLS/KeyPackages.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages.hs
@@ -18,6 +18,7 @@
 module Brig.API.MLS.KeyPackages
   ( uploadKeyPackages,
     claimKeyPackages,
+    claimLocalKeyPackages,
     countKeyPackages,
   )
 where
@@ -25,9 +26,11 @@ where
 import Brig.API.Error
 import Brig.API.Handler
 import Brig.API.MLS.KeyPackages.Validation
+import Brig.API.Types
 import Brig.App
 import qualified Brig.Data.Client as Data
 import qualified Brig.Data.MLS.KeyPackage as Data
+import Brig.Federation.Client
 import Brig.IO.Intra
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Maybe
@@ -35,7 +38,8 @@ import Data.Id
 import Data.Qualified
 import qualified Data.Set as Set
 import Imports
-import Wire.API.Federation.Error
+import Wire.API.Federation.API
+import Wire.API.Federation.API.Brig
 import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
 import Wire.API.Team.LegalHold
@@ -47,21 +51,38 @@ uploadKeyPackages lusr cid (kpuKeyPackages -> kps) = do
   kps' <- traverse (validateKeyPackage identity) kps
   lift . wrapClient $ Data.insertKeyPackages (tUnqualified lusr) cid kps'
 
-claimKeyPackages :: Local UserId -> Qualified UserId -> Maybe ClientId -> Handler r KeyPackageBundle
+claimKeyPackages ::
+  Local UserId ->
+  Qualified UserId ->
+  Maybe ClientId ->
+  Handler r KeyPackageBundle
 claimKeyPackages lusr target skipOwn =
-  foldQualified
-    lusr
-    (claimLocalKeyPackages lusr skipOwn)
-    (\_ -> throwStd federationNotImplemented)
-    target
-
-claimLocalKeyPackages :: Local UserId -> Maybe ClientId -> Local UserId -> Handler r KeyPackageBundle
-claimLocalKeyPackages lusr skipOwn target = do
-  -- skip own client when the target is the requesting user itself
-  let own = guard (lusr == target) *> skipOwn
-  clients <- map clientId <$> wrapClientE (Data.lookupClients (tUnqualified target))
   withExceptT clientError $
-    wrapHttpClientE $ guardLegalhold (ProtectedUser (tUnqualified lusr)) (mkUserClients [(tUnqualified target, clients)])
+    foldQualified
+      lusr
+      (claimLocalKeyPackages (qUntagged lusr) skipOwn)
+      (claimRemoteKeyPackages lusr)
+      target
+
+claimLocalKeyPackages ::
+  Qualified UserId ->
+  Maybe ClientId ->
+  Local UserId ->
+  ExceptT ClientError (AppT r) KeyPackageBundle
+claimLocalKeyPackages qusr skipOwn target = do
+  -- skip own client when the target is the requesting user itself
+  let own = guard (qusr == qUntagged target) *> skipOwn
+  clients <- map clientId <$> wrapClientE (Data.lookupClients (tUnqualified target))
+  foldQualified
+    target
+    ( \lusr ->
+        wrapHttpClientE $
+          guardLegalhold
+            (ProtectedUser (tUnqualified lusr))
+            (mkUserClients [(tUnqualified target, clients)])
+    )
+    (\_ -> pure ())
+    qusr
   lift $
     KeyPackageBundle . Set.fromList . catMaybes <$> traverse (mkEntry own) clients
   where
@@ -71,6 +92,23 @@ claimLocalKeyPackages lusr skipOwn target = do
         guard $ Just c /= own
         uncurry (KeyPackageBundleEntry (qUntagged target) c)
           <$> wrapClientM (Data.claimKeyPackage target c)
+
+claimRemoteKeyPackages ::
+  Local UserId ->
+  Remote UserId ->
+  ExceptT ClientError (AppT r) KeyPackageBundle
+claimRemoteKeyPackages lusr target =
+  (handleFailure =<<) $
+    withExceptT ClientFederationError $
+      runBrigFederatorClient (tDomain target) $
+        fedClient @'Brig @"claim-key-packages" $
+          ClaimKeyPackageRequest
+            { ckprClaimant = tUnqualified lusr,
+              ckprTarget = tUnqualified target
+            }
+  where
+    handleFailure :: Monad m => Maybe x -> ExceptT ClientError m x
+    handleFailure = maybe (throwE (ClientUserNotFound (tUnqualified target))) pure
 
 countKeyPackages :: Local UserId -> ClientId -> Handler r KeyPackageCount
 countKeyPackages lusr c =

--- a/services/brig/test/integration/API/Federation.hs
+++ b/services/brig/test/integration/API/Federation.hs
@@ -18,6 +18,7 @@
 
 module API.Federation where
 
+import API.MLS.Util
 import API.Search.Util (refreshIndex)
 import API.User.Util
 import Bilge hiding (head)
@@ -42,12 +43,16 @@ import Test.QuickCheck hiding ((===))
 import Test.Tasty
 import qualified Test.Tasty.Cannon as WS
 import Test.Tasty.HUnit
+import UnliftIO.Temporary
 import Util
-import Wire.API.Federation.API.Brig (GetUserClients (..), SearchRequest (SearchRequest), UserDeletedConnectionsNotification (..))
+import Web.HttpApiData
+import Wire.API.Federation.API.Brig
 import qualified Wire.API.Federation.API.Brig as FedBrig
 import qualified Wire.API.Federation.API.Brig as S
 import Wire.API.Federation.Component
 import Wire.API.Federation.Version
+import Wire.API.MLS.Credential
+import Wire.API.MLS.KeyPackage
 import Wire.API.Message (UserClients (..))
 import Wire.API.User.Client (mkUserClientPrekeyMap)
 import Wire.API.User.Search (FederatedUserSearchPolicy (..))
@@ -77,7 +82,8 @@ tests m opts brig cannon fedBrigClient =
         test m "POST /federation/get-user-clients : 200" (testGetUserClients brig fedBrigClient),
         test m "POST /federation/get-user-clients : Not Found" (testGetUserClientsNotFound fedBrigClient),
         test m "POST /federation/on-user-deleted-connections : 200" (testRemoteUserGetsDeleted opts brig cannon fedBrigClient),
-        test m "POST /federation/api-version : 200" (testAPIVersion brig fedBrigClient)
+        test m "POST /federation/api-version : 200" (testAPIVersion brig fedBrigClient),
+        test m "POST /federation/claim-key-packages : 200" (testClaimKeyPackages brig fedBrigClient)
       ]
 
 allowFullSearch :: Domain -> Opt.Opts -> Opt.Opts
@@ -393,3 +399,40 @@ testAPIVersion :: Brig -> FedClient 'Brig -> Http ()
 testAPIVersion _brig fedBrigClient = do
   vinfo <- runFedClient @"api-version" fedBrigClient (Domain "far-away.example.com") ()
   liftIO $ vinfoSupported vinfo @?= toList supportedVersions
+
+testClaimKeyPackages :: HasCallStack => Brig -> FedClient 'Brig -> Http ()
+testClaimKeyPackages brig fedBrigClient = do
+  alice <- fakeRemoteUser
+  bob <- userQualifiedId <$> randomUser brig
+
+  bobClients <- for (take 2 someLastPrekeys) $ \lpk -> do
+    let new = defNewClient PermanentClientType [] lpk
+    fmap clientId $ responseJsonError =<< addClient brig (qUnqualified bob) new
+
+  withSystemTempFile "store.db" $ \store _ ->
+    for_ bobClients $ \c ->
+      uploadKeyPackages brig store SetKey bob c 2
+
+  Just bundle <-
+    runFedClient @"claim-key-packages" fedBrigClient (qDomain alice) $
+      ClaimKeyPackageRequest (qUnqualified alice) (qUnqualified bob)
+
+  liftIO $
+    Set.map (\e -> (kpbeUser e, kpbeClient e)) (kpbEntries bundle)
+      @?= Set.fromList [(bob, c) | c <- bobClients]
+
+  -- check that we have one fewer key package now
+  for_ bobClients $ \c -> do
+    count <- getKeyPackageCount brig bob c
+    liftIO $ count @?= 1
+
+  -- check that the package refs are correctly mapped
+  for_ (kpbEntries bundle) $ \e -> do
+    cid <-
+      responseJsonError
+        =<< get (brig . paths ["i", "mls", "key-packages", toHeader (kpbeRef e)])
+        <!! const 200 === statusCode
+    liftIO $ do
+      ciDomain cid @?= qDomain bob
+      ciUser cid @?= qUnqualified bob
+      ciClient cid @?= kpbeClient e

--- a/services/brig/test/integration/API/MLS.hs
+++ b/services/brig/test/integration/API/MLS.hs
@@ -162,15 +162,6 @@ testKeyPackageSelfClaim brig = do
 
 --------------------------------------------------------------------------------
 
-getKeyPackageCount :: Brig -> Qualified UserId -> ClientId -> Http KeyPackageCount
-getKeyPackageCount brig u c =
-  responseJsonError
-    =<< get
-      ( brig . paths ["mls", "key-packages", "self", toByteString' c, "count"]
-          . zUser (qUnqualified u)
-      )
-    <!! const 200 === statusCode
-
 createClient :: Brig -> Qualified UserId -> Int -> Http ClientId
 createClient brig u i =
   fmap clientId $

--- a/services/brig/test/integration/API/MLS.hs
+++ b/services/brig/test/integration/API/MLS.hs
@@ -1,19 +1,31 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
 module API.MLS where
 
+import API.MLS.Util
 import Bilge
 import Bilge.Assert
 import Brig.Options
-import Data.Aeson (object, toJSON, (.=))
 import Data.ByteString.Conversion
-import Data.Domain
 import Data.Id
-import Data.Json.Util
-import qualified Data.Map as Map
 import Data.Qualified
 import qualified Data.Set as Set
-import qualified Data.Text as T
 import Imports
-import System.Process
 import Test.Tasty
 import Test.Tasty.HUnit
 import UnliftIO.Temporary
@@ -150,9 +162,6 @@ testKeyPackageSelfClaim brig = do
 
 --------------------------------------------------------------------------------
 
-data SetKey = SetKey | DontSetKey
-  deriving (Eq)
-
 getKeyPackageCount :: Brig -> Qualified UserId -> ClientId -> Http KeyPackageCount
 getKeyPackageCount brig u c =
   responseJsonError
@@ -171,36 +180,3 @@ createClient brig u i =
         (qUnqualified u)
         (defNewClient PermanentClientType [somePrekeys !! i] (someLastPrekeys !! i))
       <!! const 201 === statusCode
-
-uploadKeyPackages :: Brig -> FilePath -> SetKey -> Qualified UserId -> ClientId -> Int -> Http ()
-uploadKeyPackages brig store sk u c n = do
-  let cmd0 = ["crypto-cli", "--store", store, "--enc-key", "test"]
-      clientId =
-        show (qUnqualified u)
-          <> ":"
-          <> T.unpack (client c)
-          <> "@"
-          <> T.unpack (domainText (qDomain u))
-  kps <-
-    replicateM n . liftIO . spawn . shell . unwords $
-      cmd0 <> ["key-package", clientId]
-  when (sk == SetKey) $
-    do
-      pk <-
-        liftIO . spawn . shell . unwords $
-          cmd0 <> ["public-key", clientId]
-      put
-        ( brig
-            . paths ["clients", toByteString' c]
-            . zUser (qUnqualified u)
-            . json defUpdateClient {updateClientMLSPublicKeys = Map.fromList [(Ed25519, pk)]}
-        )
-      !!! const 200 === statusCode
-  let upload = object ["key_packages" .= toJSON (map Base64ByteString kps)]
-  post
-    ( brig
-        . paths ["mls", "key-packages", "self", toByteString' c]
-        . zUser (qUnqualified u)
-        . json upload
-    )
-    !!! const (case sk of SetKey -> 201; DontSetKey -> 400) === statusCode

--- a/services/brig/test/integration/API/MLS/Util.hs
+++ b/services/brig/test/integration/API/MLS/Util.hs
@@ -1,0 +1,70 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module API.MLS.Util where
+
+import Bilge
+import Bilge.Assert
+import Data.Aeson (object, toJSON, (.=))
+import Data.ByteString.Conversion
+import Data.Domain
+import Data.Id
+import Data.Json.Util
+import qualified Data.Map as Map
+import Data.Qualified
+import qualified Data.Text as T
+import Imports
+import System.Process
+import Util
+import Wire.API.MLS.Credential
+import Wire.API.User.Client
+
+data SetKey = SetKey | DontSetKey
+  deriving (Eq)
+
+uploadKeyPackages :: Brig -> FilePath -> SetKey -> Qualified UserId -> ClientId -> Int -> Http ()
+uploadKeyPackages brig store sk u c n = do
+  let cmd0 = ["crypto-cli", "--store", store, "--enc-key", "test"]
+      clientId =
+        show (qUnqualified u)
+          <> ":"
+          <> T.unpack (client c)
+          <> "@"
+          <> T.unpack (domainText (qDomain u))
+  kps <-
+    replicateM n . liftIO . spawn . shell . unwords $
+      cmd0 <> ["key-package", clientId]
+  when (sk == SetKey) $
+    do
+      pk <-
+        liftIO . spawn . shell . unwords $
+          cmd0 <> ["public-key", clientId]
+      put
+        ( brig
+            . paths ["clients", toByteString' c]
+            . zUser (qUnqualified u)
+            . json defUpdateClient {updateClientMLSPublicKeys = Map.fromList [(Ed25519, pk)]}
+        )
+      !!! const 200 === statusCode
+  let upload = object ["key_packages" .= toJSON (map Base64ByteString kps)]
+  post
+    ( brig
+        . paths ["mls", "key-packages", "self", toByteString' c]
+        . zUser (qUnqualified u)
+        . json upload
+    )
+    !!! const (case sk of SetKey -> 201; DontSetKey -> 400) === statusCode

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -660,7 +660,7 @@ claimRemoteKeyPackages brig1 brig2 = do
 
   bob <- userQualifiedId <$> randomUser brig2
   bobClients <- for (take 3 someLastPrekeys) $ \lpk -> do
-    let new = defNewClient TemporaryClientType [] lpk
+    let new = defNewClient PermanentClientType [] lpk
     fmap clientId $ responseJsonError =<< addClient brig2 (qUnqualified bob) new
 
   withSystemTempFile "store.db" $ \store _ ->

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -661,7 +661,7 @@ claimRemoteKeyPackages brig1 brig2 = do
   bob <- userQualifiedId <$> randomUser brig2
   bobClients <- for (take 3 someLastPrekeys) $ \lpk -> do
     let new = defNewClient TemporaryClientType [] lpk
-    responseJsonError =<< addClient brig2 (qUnqualified bob) new
+    fmap clientId $ responseJsonError =<< addClient brig2 (qUnqualified bob) new
 
   withSystemTempFile "store.db" $ \store _ ->
     for_ bobClients $ \c ->


### PR DESCRIPTION
This PR implements remote key package claims. It simply adds a new federation RPC for claiming remote key packages, and wires it up to the public API. When a remote key package is claimed, the corresponding key package ref mapping is established, similarly to the local case.

Tracked by: https://wearezeta.atlassian.net/browse/FS-508.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
