### PR TITLE
Github Actions: disable mac builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
      matrix:
        os:
          - ubuntu-latest
-         - macos-latest
+         # This is too expensive
+         # - macos-latest
    runs-on: ${{ matrix.os }}
    steps:
      - uses: actions/checkout@v2

--- a/changelog.d/5-internal/disable-mac-builds
+++ b/changelog.d/5-internal/disable-mac-builds
@@ -1,0 +1,1 @@
+Github Actions: disable mac builds


### PR DESCRIPTION
Disabling mac builds (which are [10x more expensive](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers)) because nobody in the team needs these caches atm.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
