### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,1 +1,1 @@
-Upgrade webapp version to 2022-04-21-production.0-v0.29.7-0-3929a89
+Upgrade webapp version to 2022-05-04-production.0-v0.29.7-0-a6f2ded

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2022-04-21-production.0-v0.29.7-0-3929a89"
+  tag: "2022-05-04-production.0-v0.29.7-0-a6f2ded"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2022-05-04-production.0-v0.29.7-0-a6f2ded`
Release: [`2022-05-04-production.0`](https://github.com/wireapp/wire-webapp/releases/tag/2022-05-04-production.0)