### PR TITLE
Release 2022-05-04 - (expected chart version 4.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [2022-05-04] (Chart Release 4.11.0)
+
+## Release notes
+
+
+* Upgrade webapp version to 2022-05-04-production.0-v0.29.7-0-a6f2ded (#2302)
+
+
 # [2022-04-25] (Chart Release 4.10.0)
 
 ## Release notes

--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,1 +1,1 @@
-Upgrade webapp version to 2022-04-21-production.0-v0.29.7-0-3929a89
+Upgrade webapp version to 2022-05-04-production.0-v0.29.7-0-a6f2ded

--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,1 +1,0 @@
-Upgrade webapp version to 2022-05-04-production.0-v0.29.7-0-a6f2ded

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2022-04-21-production.0-v0.29.7-0-3929a89"
+  tag: "2022-05-04-production.0-v0.29.7-0-a6f2ded"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
# [2022-05-04] (Chart Release 4.11.0)

## Release notes


* Upgrade webapp version to 2022-05-04-production.0-v0.29.7-0-a6f2ded (#2302)