### PR TITLE
Add ShellCheck linter target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,52 @@ add-license:
 	@echo ""
 	@echo "you might want to run 'make formatf' now to make sure ormolu is happy"
 
+# lint all shell scripts with ShellCheck
+# FUTUREWORK: Fix issues of the explicitly (no globbing) excluded files.
+SHELL_FILES_TO_LINT=$(shell find \
+	-not -path "./dist-newstyle/*" \
+	-not -path "./services/nginz/third_party/*" \
+	-not -path "./libs/wire-api/test/golden/gentests.sh" \
+	-not -path "./changelog.d/mk-changelog.sh" \
+	-not -path "./hack/bin/integration-teardown.sh" \
+	-not -path "./hack/bin/diff-failure.sh" \
+	-not -path "./hack/bin/integration-setup.sh" \
+	-not -path "./hack/bin/cabal-run-tests.sh" \
+	-not -path "./hack/bin/integration-teardown-federation.sh" \
+	-not -path "./hack/bin/integration-setup-federation.sh" \
+	-not -path "./hack/bin/serve-charts.sh" \
+	-not -path "./hack/bin/cabal-install-artefacts.sh" \
+	-not -path "./hack/bin/helm-template.sh" \
+	-not -path "./hack/bin/set-chart-image-version.sh" \
+	-not -path "./hack/bin/copy-charts.sh" \
+	-not -path "./hack/bin/set-helm-chart-version.sh" \
+	-not -path "./hack/bin/integration-spring-cleaning.sh" \
+	-not -path "./hack/bin/upload-helm-charts-s3.sh" \
+	-not -path "./hack/bin/integration-test-logs.sh" \
+	-not -path "./services/nginz/nginz_reload.sh" \
+	-not -path "./services/spar/test-scim-suite/mk_collection.sh" \
+	-not -path "./services/spar/test-scim-suite/runsuite.sh" \
+	-not -path "./services/spar/test-scim-suite/run.sh" \
+	-not -path "./services/brig/federation-tests.sh" \
+	-not -path "./services/integration.sh" \
+	-not -path "./deploy/services-demo/create_test_team_members.sh" \
+	-not -path "./deploy/services-demo/demo.sh" \
+	-not -path "./deploy/services-demo/create_test_team_scim.sh" \
+	-not -path "./deploy/services-demo/create_test_user.sh" \
+	-not -path "./deploy/services-demo/create_team_members.sh" \
+	-not -path "./deploy/services-demo/register_idp_internal.sh" \
+	-not -path "./deploy/services-demo/create_test_team_admins.sh" \
+	-not -path "./deploy/dockerephemeral/init.sh" \
+	-not -path "./tools/nginz_disco/nginz_disco.sh" \
+	-not -path "./tools/rebase-onto-formatter.sh" \
+	-not -path "./tools/sftd_disco/sftd_disco.sh" \
+	-not -path "./tools/ormolu.sh" \
+	-not -path "./tools/db/move-team/dump_merge_teams.sh" \
+	-type f -iname '*.sh')
+.PHONY: shellcheck
+shellcheck:
+	shellcheck -x $(SHELL_FILES_TO_LINT)
+
 # Clean
 .PHONY: clean
 clean:

--- a/changelog.d/5-internal/add-shellcheck-make-target
+++ b/changelog.d/5-internal/add-shellcheck-make-target
@@ -1,0 +1,1 @@
+Add a target to the Makefile to run ShellCheck. I.e. to run a linter on shell scripts. This will be used in the CI. For now, all scripts with linter issues are excluded from this check.

--- a/dev-packages.nix
+++ b/dev-packages.nix
@@ -180,6 +180,7 @@ in
   pkgs.jq
   pkgs.niv
   pkgs.ormolu
+  pkgs.shellcheck
   pkgs.wget
   pkgs.yq
   pkgs.rsync


### PR DESCRIPTION
It lints all shell scripts that are not excluded, i.e. new ones and old ones without issues. Excluded are those that currently have issues. They should be fixed on a step-by-step basis. This conservative/careful approach is necessary due to shell scripts having neither a type checker nor tests. "Surprises" should be avoided, especially as they might
appear in stressful situations.

This PR supersedes https://github.com/wireapp/wire-server/pull/2310 . In that PR I learned that even simple looking quotes may lead to awful errors.

https://wearezeta.atlassian.net/browse/SQPIT-279

## Checklist

 - [X] The **PR Title** explains the impact of the change.
 - [X] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [X] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
schema`** to update the cassandra schema documentation.
 - [X] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [X] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
