### PR TITLE
Removed extra colons from new doc references.

### DIFF
--- a/docs/src/how-to/scim/index.rst
+++ b/docs/src/how-to/scim/index.rst
@@ -1,4 +1,4 @@
 How to set up user provisioning with LDAP or SCIM
 =================================================
 
-This page has moved to :ref:`User provisioning`:.
+This page has moved to :ref:`User provisioning`.

--- a/docs/src/how-to/single-sign-on/index.rst
+++ b/docs/src/how-to/single-sign-on/index.rst
@@ -1,4 +1,4 @@
 Single-sign-on how-tos
 ======================
 
-This page moved to :ref:`Setting up SSO externally`:.
+This page moved to :ref:`Setting up SSO externally`.


### PR DESCRIPTION
Accidentally added extra colons to the reference links.


## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
