### PR TITLE
Add pagination docs to `list-connections`

### DIFF
--- a/changelog.d/4-docs/list-connections
+++ b/changelog.d/4-docs/list-connections
@@ -1,0 +1,1 @@
+Add pagination docs to `POST /list-connections`

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -601,6 +601,7 @@ type ConnectionAPI =
     :<|> Named
            "list-connections"
            ( Summary "List the connections to other users, including remote users"
+               :> Description PaginationDocs
                :> ZUser
                :> "list-connections"
                :> ReqBody '[JSON] ListConnectionsRequestPaginated

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -225,17 +225,7 @@ type ConversationAPI =
     :<|> Named
            "list-conversation-ids"
            ( Summary "Get all conversation IDs."
-               :> Description
-                    "The IDs returned by this endpoint are paginated. To\
-                    \ get the first page, make a call with the `paging_state` field set to\
-                    \ `null` (or omitted). Whenever the `has_more` field of the response is\
-                    \ set to `true`, more results are available, and they can be obtained\
-                    \ by calling the endpoint again, but this time passing the value of\
-                    \ `paging_state` returned by the previous call. One can continue in\
-                    \ this fashion until all results are returned, which is indicated by\
-                    \ `has_more` being `false`. Note that `paging_state` should be\
-                    \ considered an opaque token. It should not be inspected, or stored, or\
-                    \ reused across multiple unrelated invokations of the endpoint."
+               :> Description PaginationDocs
                :> ZLocalUser
                :> "conversations"
                :> "list-ids"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Util.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Util.hs
@@ -77,3 +77,14 @@ instance
   fromUnion (Z (I ())) = Unchanged
   fromUnion (S (Z (I a))) = Updated a
   fromUnion (S (S x)) = case x of
+
+type PaginationDocs =
+  "The IDs returned by this endpoint are paginated. To get the first page, make\
+  \ a call with the `paging_state` field set to `null` (or omitted). Whenever the\
+  \ `has_more` field of the response is set to `true`, more results are available,\
+  \ and they can be obtained by calling the endpoint again, but this time passing\
+  \ the value of `paging_state` returned by the previous call. One can continue in\
+  \ this fashion until all results are returned, which is indicated by `has_more`\
+  \ being `false`. Note that `paging_state` should be considered an opaque token.\
+  \ It should not be inspected, or stored, or reused across multiple unrelated\
+  \ invocations of the endpoint."


### PR DESCRIPTION
Copied pagination docs from the conversation listing endpoint.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
