### PR TITLE
Fix assertion in testWelcomeNoKey

### DIFF
--- a/changelog.d/6-federation/fix-mls-client-assertions
+++ b/changelog.d/6-federation/fix-mls-client-assertions
@@ -1,0 +1,1 @@
+Fix assertion in testWelcomeNoKey

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -53,8 +53,7 @@ tests s =
     [ testGroup
         "Welcome"
         [ test s "local welcome" testLocalWelcome,
-          test s "local welcome (client with no public key)" testWelcomeNoKey,
-          test s "local welcome (client with no public key)" testWelcomeUnknownClient
+          test s "local welcome (client with no public key)" testWelcomeNoKey
         ],
       testGroup
         "Creation"
@@ -145,23 +144,10 @@ testWelcomeNoKey = do
         . paths ["mls", "welcome"]
         . zUser (qUnqualified (pUserId creator))
         . content "message/mls"
+        . zConn "conn"
         . bytes welcome
     )
-    !!! const 400 === statusCode
-
-testWelcomeUnknownClient :: TestM ()
-testWelcomeUnknownClient = do
-  MessagingSetup {..} <- aliceInvitesBob 1 def {createClients = DontCreateClients}
-
-  galley <- viewGalley
-  post
-    ( galley
-        . paths ["mls", "welcome"]
-        . zUser (qUnqualified (pUserId creator))
-        . content "message/mls"
-        . bytes welcome
-    )
-    !!! const 400 === statusCode
+    !!! const 404 === statusCode
 
 -- | Send a commit message, and assert that all participants see an event with
 -- the given list of new members.
@@ -264,7 +250,7 @@ testAddUserWithProteusClients = do
       participants@(_, [bob]) <- setupParticipants tmp def [2]
 
       -- and a non-MLS client
-      void $ takeLastPrekey >>= lift . addClient (pUserId bob)
+      void $ takeLastPrekey >>= lift . randomClient (qUnqualified (pUserId bob))
 
       pure participants
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2004,7 +2004,12 @@ randomClientWithCaps :: HasCallStack => UserId -> LastPrekey -> Maybe (Set Clien
 randomClientWithCaps uid lk caps = do
   b <- view tsBrig
   resp <-
-    post (b . paths ["i", "clients", toByteString' uid] . json newClientBody)
+    post
+      ( b
+          . paths ["i", "clients", toByteString' uid]
+          . queryItem "skip_reauth" "true"
+          . json newClientBody
+      )
       <!! const rStatus === statusCode
   client <- responseJsonError resp
   return (clientId client)


### PR DESCRIPTION
Fix assertion (should be 404), remove duplicated `addClient` function and a redundant test.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
