### PR TITLE
KeyPackage -> Conversation Internal API

### DIFF
--- a/changelog.d/5-internal/fs-532-brig
+++ b/changelog.d/5-internal/fs-532-brig
@@ -1,0 +1,1 @@
+New internal brig endpoints for MLS KeyPackage -> Conversation association query/update


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-532 (partial, brig changes)

New endpoints are not in use, but brig will need to be deployed before galley, which I think is the status quo.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
