### PR TITLE
Brig: Prepare for TURN Discovery using SRV records

### DIFF
--- a/changelog.d/5-internal/refactor-turn-discovery
+++ b/changelog.d/5-internal/refactor-turn-discovery
@@ -1,0 +1,1 @@
+Start TURN discovery only when the app starts and not when the Env is created

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -65,6 +65,7 @@ library
       Brig.Data.User
       Brig.Data.UserKey
       Brig.Data.UserPendingActivation
+      Brig.Effects.Delay
       Brig.Effects.SFT
       Brig.Email
       Brig.Federation.Client
@@ -688,6 +689,7 @@ test-suite brig-tests
   other-modules:
       Test.Brig.Calling
       Test.Brig.Calling.Internal
+      Test.Brig.Effects.Delay
       Test.Brig.MLS
       Test.Brig.Roundtrip
       Test.Brig.User.Search.Index.Types
@@ -743,6 +745,7 @@ test-suite brig-tests
     , brig-types
     , bytestring
     , containers
+    , data-timeout
     , dns
     , dns-util
     , exceptions

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -745,6 +745,7 @@ test-suite brig-tests
     , containers
     , dns
     , dns-util
+    , exceptions
     , http-types
     , imports
     , lens

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -163,6 +163,7 @@ tests:
     - containers
     - dns
     - dns-util
+    - exceptions
     - http-types
     - imports
     - lens

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -161,6 +161,7 @@ tests:
     - brig-types
     - bytestring
     - containers
+    - data-timeout
     - dns
     - dns-util
     - exceptions

--- a/services/brig/src/Brig/Calling/API.hs
+++ b/services/brig/src/Brig/Calling/API.hs
@@ -23,9 +23,11 @@ module Brig.Calling.API
     -- * Exposed for testing purposes
     newConfig,
     CallsConfigVersion (..),
+    NoTurnServers,
   )
 where
 
+import Brig.API.Error
 import Brig.API.Handler
 import Brig.App
 import Brig.Calling
@@ -34,14 +36,13 @@ import Brig.Calling.Internal
 import Brig.Effects.SFT
 import Brig.Options (ListAllSFTServers (..))
 import qualified Brig.Options as Opt
-import Control.Error (hush)
+import Control.Error (hush, throwE)
 import Control.Lens
 import Data.ByteString.Conversion
 import Data.ByteString.Lens
 import Data.Id
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
-import qualified Data.List1 as List1
 import Data.Misc (HttpsUrl)
 import Data.Range
 import qualified Data.Swagger.Build.Api as Doc
@@ -56,6 +57,8 @@ import Network.Wai.Utilities hiding (code, message)
 import Network.Wai.Utilities.Swagger (document)
 import OpenSSL.EVP.Digest (Digest, hmacBS)
 import Polysemy
+import qualified Polysemy.Error as Polysemy
+import qualified System.Logger.Class as Log
 import qualified System.Random.MWC as MWC
 import Wire.API.Call.Config (SFTServer)
 import qualified Wire.API.Call.Config as Public
@@ -101,17 +104,32 @@ getCallsConfigV2H (_ ::: uid ::: connid ::: limit) =
 -- | ('UserId', 'ConnId' are required as args here to make sure this is an authenticated end-point.)
 getCallsConfigV2 :: UserId -> ConnId -> Maybe (Range 1 10 Int) -> (Handler r) Public.RTCConfiguration
 getCallsConfigV2 _ _ limit = do
-  env <- liftIO . readIORef =<< view turnEnvV2
+  env <- view turnEnv
   staticUrl <- view $ settings . Opt.sftStaticUrl
   sftListAllServers <- fromMaybe Opt.HideAllSFTServers <$> view (settings . Opt.sftListAllServers)
   sftEnv' <- view sftEnv
   logger <- view applog
   manager <- view httpManager
-  liftIO
-    . runM @IO
-    . loggerToTinyLog logger
-    . interpretSFT manager
-    $ newConfig env staticUrl sftEnv' limit sftListAllServers CallsConfigV2
+  eitherConfig <-
+    liftIO
+      . runM @IO
+      . loggerToTinyLog logger
+      . interpretSFT manager
+      . Polysemy.runError
+      $ newConfig env turnServersV2 staticUrl sftEnv' limit sftListAllServers CallsConfigV2
+  handleNoTurnServers eitherConfig
+
+-- | Throws '500 Internal Server Error' when no turn servers are found. This is
+-- done to keep backwards compatiblity, the previous code initialized an 'IORef'
+-- with an 'error' so reading the 'IORef' threw a 500.
+--
+-- FUTUREWORK: Making this a '404 Not Found' would be more idiomatic, but this
+-- should be done after consulting with client teams.
+handleNoTurnServers :: Either NoTurnServers a -> (Handler r) a
+handleNoTurnServers (Right x) = pure x
+handleNoTurnServers (Left NoTurnServers) = do
+  Log.err $ Log.msg (Log.val "Call config requested before TURN URIs could be discovered.")
+  throwE $ StdError internalServerError
 
 getCallsConfigH :: JSON ::: UserId ::: ConnId -> (Handler r) Response
 getCallsConfigH (_ ::: uid ::: connid) =
@@ -119,15 +137,18 @@ getCallsConfigH (_ ::: uid ::: connid) =
 
 getCallsConfig :: UserId -> ConnId -> (Handler r) Public.RTCConfiguration
 getCallsConfig _ _ = do
-  env <- liftIO . readIORef =<< view turnEnv
+  env <- view turnEnv
   logger <- view applog
   manager <- view httpManager
-  fmap dropTransport
-    . liftIO
-    . runM @IO
-    . loggerToTinyLog logger
-    . interpretSFT manager
-    $ newConfig env Nothing Nothing Nothing HideAllSFTServers CallsConfigDeprecated
+  eitherConfig <-
+    (dropTransport <$$>)
+      . liftIO
+      . runM @IO
+      . loggerToTinyLog logger
+      . interpretSFT manager
+      . Polysemy.runError
+      $ newConfig env turnServersV1 Nothing Nothing Nothing HideAllSFTServers CallsConfigDeprecated
+  handleNoTurnServers eitherConfig
   where
     -- In order to avoid being backwards incompatible, remove the `transport` query param from the URIs
     dropTransport :: Public.RTCConfiguration -> Public.RTCConfiguration
@@ -140,24 +161,35 @@ data CallsConfigVersion
   = CallsConfigDeprecated
   | CallsConfigV2
 
+data NoTurnServers = NoTurnServers
+  deriving (Show)
+
+instance Exception NoTurnServers
+
 -- | FUTUREWORK: It is not reflected in the function type the part of the
 -- business logic that says that the SFT static URL parameter cannot be set at
 -- the same time as the SFT environment parameter. See how to allow either none
 -- to be set or only one of them (perhaps Data.These combined with error
 -- handling).
 newConfig ::
-  Members [Embed IO, SFT] r =>
-  Calling.Env ->
+  Members [Embed IO, SFT, Polysemy.Error NoTurnServers] r =>
+  Calling.TurnEnv ->
+  Getter Calling.TurnEnv (IORef (Discovery (NonEmpty Public.TurnURI))) ->
   Maybe HttpsUrl ->
   Maybe SFTEnv ->
   Maybe (Range 1 10 Int) ->
   ListAllSFTServers ->
   CallsConfigVersion ->
   Sem r Public.RTCConfiguration
-newConfig env sftStaticUrl mSftEnv limit listAllServers version = do
+newConfig env discoveredServersL sftStaticUrl mSftEnv limit listAllServers version = do
   let (sha, secret, tTTL, cTTL, prng) = (env ^. turnSHA512, env ^. turnSecret, env ^. turnTokenTTL, env ^. turnConfigTTL, env ^. turnPrng)
   -- randomize list of servers (before limiting the list, to ensure not always the same servers are chosen if limit is set)
-  randomizedUris <- liftIO $ randomize (List1.toNonEmpty $ env ^. turnServers)
+  randomizedUris <-
+    liftIO
+      . randomize
+      =<< Polysemy.note NoTurnServers
+        . discoveryToMaybe
+      =<< readIORef (env ^. discoveredServersL)
   let limitedUris = case limit of
         Nothing -> randomizedUris
         Just lim -> limitedList randomizedUris lim

--- a/services/brig/src/Brig/Effects/Delay.hs
+++ b/services/brig/src/Brig/Effects/Delay.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Brig.Effects.Delay where
+
+import Imports
+import Polysemy
+
+data Delay m a where
+  Delay :: Int -> Delay m ()
+
+makeSem ''Delay
+
+runDelay :: Member (Embed IO) r => Sem (Delay ': r) a -> Sem r a
+runDelay = interpret $ \case
+  Delay i -> threadDelay i

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -122,6 +122,7 @@ testSFTUnavailble b opts domain = do
         (cfg ^. rtcConfSftServersAll)
 
 modifyAndAssert ::
+  HasCallStack =>
   Brig ->
   UserId ->
   (UserId -> Brig -> Http RTCConfiguration) ->

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -58,8 +58,8 @@ tests m b opts turn turnV2 = do
         testGroup
           "sft"
           [ test m "SFT servers /calls/config/v2 - 200" $ testSFT b opts,
-            test m "SFT servers /calls/config/v2 - 200 - SFT does not respond as expected" $ testSFTUnavailble b opts "https://example.com",
-            test m "SFT servers /calls/config/v2 - 200 - SFT DNS does not resolve" $ testSFTUnavailble b opts "https://sft.example.com"
+            test m "SFT servers /calls/config/v2 - 200 - SFT does not respond as expected" $ testSFTUnavailable b opts "https://example.com",
+            test m "SFT servers /calls/config/v2 - 200 - SFT DNS does not resolve" $ testSFTUnavailable b opts "https://sft.example.com"
           ]
       ]
 
@@ -110,8 +110,8 @@ testSFT b opts = do
         (Set.fromList [sftServer server1, sftServer server2])
         (Set.fromList $ maybe [] NonEmpty.toList $ cfg1 ^. rtcConfSftServers)
 
-testSFTUnavailble :: Brig -> Opts.Opts -> String -> Http ()
-testSFTUnavailble b opts domain = do
+testSFTUnavailable :: Brig -> Opts.Opts -> String -> Http ()
+testSFTUnavailable b opts domain = do
   uid <- userId <$> randomUser b
   withSettingsOverrides (opts {Opts.optSettings = (Opts.optSettings opts) {Opts.setSftStaticUrl = fromByteString (cs domain), Opts.setSftListAllServers = Just Opts.ListAllSFTServers}}) $ do
     cfg <- getTurnConfigurationV2 uid b

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -42,7 +42,7 @@ import Bilge
 import Bilge.Assert
 import qualified Brig.AWS as AWS
 import Brig.AWS.Types
-import Brig.App (applog, sftEnv)
+import Brig.App (applog, fsWatcher, sftEnv, turnEnv)
 import Brig.Calling as Calling
 import qualified Brig.Code as Code
 import qualified Brig.Options as Opt
@@ -1005,6 +1005,7 @@ withSettingsOverrides opts action = liftIO $ do
   sftDiscovery <-
     forM (env ^. sftEnv) $ \sftEnv' ->
       Async.async $ Calling.startSFTServiceDiscovery (env ^. applog) sftEnv'
+  Calling.startTurnDiscovery (env ^. applog) (env ^. fsWatcher) (env ^. turnEnv)
   res <- WaiTest.runSession action brigApp
   mapM_ Async.cancel sftDiscovery
   pure res

--- a/services/brig/test/unit/Test/Brig/Effects/Delay.hs
+++ b/services/brig/test/unit/Test/Brig/Effects/Delay.hs
@@ -1,0 +1,28 @@
+module Test.Brig.Effects.Delay where
+
+import Brig.Effects.Delay
+import Imports
+import Polysemy
+
+-- | Ignores the delay time and only progresses when the 'MVar' is empty using
+-- 'putMVar'. This way a test using this interpreter can know when the delay
+-- event gets called by just waiting using 'takeMVar'. The test can also start
+-- this interpreter with a full 'MVar' and use 'takeMVar' to control when the
+-- 'Delay' action returns.
+--
+-- In addition, this interpreter also tracks calls to the 'Delay' action in a
+-- 'TVar'.
+--
+-- Example:
+-- > tick <- newEmptyMVar
+-- > delayCallsTVar <- newTVarIO []
+-- > async . runDelayWithTick tick delayCallsTVar $ do
+-- >   doStuff
+-- >   delay 100
+-- > takeMVar tick -- This blocks until doStuff is done
+-- > assertStuffDone
+runDelayWithTick :: Member (Embed IO) r => MVar () -> TVar [Int] -> Sem (Delay ': r) a -> Sem r a
+runDelayWithTick tick calls = interpret $ \case
+  Delay i -> do
+    putMVar tick ()
+    atomically $ modifyTVar calls (<> [i])


### PR DESCRIPTION
Two changes:

1. Start TURN discovery only when the app starts

Instead of starting it when the `Env` is created. This aligns the service
discovery of TURN with that of SFT. In next commits, SRV based discovery for
TURN will be implemented.

2. Refactor SFT SRV Record discovery to make it more generic and reusable

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.