### PR TITLE
move shellcheck to bash script; use git ls-files to ignore gitignored…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,51 +134,9 @@ add-license:
 	@echo ""
 	@echo "you might want to run 'make formatf' now to make sure ormolu is happy"
 
-# lint all shell scripts with ShellCheck
-# FUTUREWORK: Fix issues of the explicitly (no globbing) excluded files.
-SHELL_FILES_TO_LINT=$(shell find \
-	-not -path "./dist-newstyle/*" \
-	-not -path "./services/nginz/third_party/*" \
-	-not -path "./libs/wire-api/test/golden/gentests.sh" \
-	-not -path "./changelog.d/mk-changelog.sh" \
-	-not -path "./hack/bin/integration-teardown.sh" \
-	-not -path "./hack/bin/diff-failure.sh" \
-	-not -path "./hack/bin/integration-setup.sh" \
-	-not -path "./hack/bin/cabal-run-tests.sh" \
-	-not -path "./hack/bin/integration-teardown-federation.sh" \
-	-not -path "./hack/bin/integration-setup-federation.sh" \
-	-not -path "./hack/bin/serve-charts.sh" \
-	-not -path "./hack/bin/cabal-install-artefacts.sh" \
-	-not -path "./hack/bin/helm-template.sh" \
-	-not -path "./hack/bin/set-chart-image-version.sh" \
-	-not -path "./hack/bin/copy-charts.sh" \
-	-not -path "./hack/bin/set-helm-chart-version.sh" \
-	-not -path "./hack/bin/integration-spring-cleaning.sh" \
-	-not -path "./hack/bin/upload-helm-charts-s3.sh" \
-	-not -path "./hack/bin/integration-test-logs.sh" \
-	-not -path "./services/nginz/nginz_reload.sh" \
-	-not -path "./services/spar/test-scim-suite/mk_collection.sh" \
-	-not -path "./services/spar/test-scim-suite/runsuite.sh" \
-	-not -path "./services/spar/test-scim-suite/run.sh" \
-	-not -path "./services/brig/federation-tests.sh" \
-	-not -path "./services/integration.sh" \
-	-not -path "./deploy/services-demo/create_test_team_members.sh" \
-	-not -path "./deploy/services-demo/demo.sh" \
-	-not -path "./deploy/services-demo/create_test_team_scim.sh" \
-	-not -path "./deploy/services-demo/create_test_user.sh" \
-	-not -path "./deploy/services-demo/create_team_members.sh" \
-	-not -path "./deploy/services-demo/register_idp_internal.sh" \
-	-not -path "./deploy/services-demo/create_test_team_admins.sh" \
-	-not -path "./deploy/dockerephemeral/init.sh" \
-	-not -path "./tools/nginz_disco/nginz_disco.sh" \
-	-not -path "./tools/rebase-onto-formatter.sh" \
-	-not -path "./tools/sftd_disco/sftd_disco.sh" \
-	-not -path "./tools/ormolu.sh" \
-	-not -path "./tools/db/move-team/dump_merge_teams.sh" \
-	-type f -iname '*.sh')
 .PHONY: shellcheck
 shellcheck:
-	shellcheck -x $(SHELL_FILES_TO_LINT)
+	./hack/bin/shellcheck.sh
 
 # Clean
 .PHONY: clean

--- a/hack/bin/shellcheck.sh
+++ b/hack/bin/shellcheck.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# lint all shell scripts with ShellCheck
+# FUTUREWORK: Fix issues of the explicitly (no globbing) excluded files.
+
+mapfile -t SHELL_FILES_TO_LINT < <(
+    git ls-files |
+        grep "\.sh$" |
+        grep -v "dist-newstyle/" |
+        grep -v "services/nginz/third_party/" |
+        grep -v "libs/wire-api/test/golden/gentests.sh" |
+        grep -v "changelog.d/mk-changelog.sh" |
+        grep -v "hack/bin/integration-teardown.sh" |
+        grep -v "hack/bin/diff-failure.sh" |
+        grep -v "hack/bin/integration-setup.sh" |
+        grep -v "hack/bin/cabal-run-tests.sh" |
+        grep -v "hack/bin/integration-teardown-federation.sh" |
+        grep -v "hack/bin/integration-setup-federation.sh" |
+        grep -v "hack/bin/serve-charts.sh" |
+        grep -v "hack/bin/cabal-install-artefacts.sh" |
+        grep -v "hack/bin/helm-template.sh" |
+        grep -v "hack/bin/set-chart-image-version.sh" |
+        grep -v "hack/bin/copy-charts.sh" |
+        grep -v "hack/bin/set-helm-chart-version.sh" |
+        grep -v "hack/bin/integration-spring-cleaning.sh" |
+        grep -v "hack/bin/upload-helm-charts-s3.sh" |
+        grep -v "hack/bin/integration-test-logs.sh" |
+        grep -v "services/nginz/nginz_reload.sh" |
+        grep -v "services/spar/test-scim-suite/mk_collection.sh" |
+        grep -v "services/spar/test-scim-suite/runsuite.sh" |
+        grep -v "services/spar/test-scim-suite/run.sh" |
+        grep -v "services/brig/federation-tests.sh" |
+        grep -v "services/integration.sh" |
+        grep -v "deploy/services-demo/create_test_team_members.sh" |
+        grep -v "deploy/services-demo/demo.sh" |
+        grep -v "deploy/services-demo/create_test_team_scim.sh" |
+        grep -v "deploy/services-demo/create_test_user.sh" |
+        grep -v "deploy/services-demo/create_team_members.sh" |
+        grep -v "deploy/services-demo/register_idp_internal.sh" |
+        grep -v "deploy/services-demo/create_test_team_admins.sh" |
+        grep -v "deploy/dockerephemeral/init.sh" |
+        grep -v "tools/nginz_disco/nginz_disco.sh" |
+        grep -v "tools/rebase-onto-formatter.sh" |
+        grep -v "tools/sftd_disco/sftd_disco.sh" |
+        grep -v "tools/ormolu.sh" |
+        grep -v "tools/db/move-team/dump_merge_teams.sh"
+)
+
+shellcheck -x "${SHELL_FILES_TO_LINT[@]}"


### PR DESCRIPTION
… files from being caught in shellcheck

As a follow-up to #2361 instead of "shell find" could we use `git ls-files` here actually? If I have built libzauth locally, or other things in gitignore, it trips the various shell scripts inside those subfolders locally, even though they are gitignored.

This PR makes use of git ls-files and moves the logic from Makefile to a shell script, as the array magic inside Makefile is a bit weird to deal with I find.