### PR TITLE
galley: refactor withSettingsOverrides

### DIFF
--- a/changelog.d/5-internal/galley-no-sessiont
+++ b/changelog.d/5-internal/galley-no-sessiont
@@ -1,0 +1,1 @@
+galley: refactor withSettingsOverrides

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -437,6 +437,7 @@ executable galley-integration
     , http-media
     , http-types
     , imports
+    , kan-extensions
     , lens
     , lens-aeson
     , metrics-wai

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -210,6 +210,7 @@ library
     , http-types >=0.8
     , imports
     , insert-ordered-containers
+    , kan-extensions
     , lens >=4.4
     , memory
     , metrics-wai >=0.4

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -193,6 +193,7 @@ executables:
     - http-client-tls
     - http-media
     - http-types
+    - kan-extensions
     - lens
     - lens-aeson
     - mtl

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -61,6 +61,7 @@ library:
   - http-media
   - http-types >=0.8
   - insert-ordered-containers
+  - kan-extensions
   - lens >=4.4
   - memory
   - metrics-wai >=0.4

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -25,8 +25,9 @@ import Bilge.Request (requestIdName)
 import Cassandra (runClient, shutdown)
 import Cassandra.Schema (versionCheck)
 import qualified Control.Concurrent.Async as Async
-import Control.Exception (finally)
+import Control.Exception (bracket, finally)
 import Control.Lens (view, (.~), (^.))
+import Control.Monad.Codensity
 import qualified Data.Aeson as Aeson
 import Data.Default
 import Data.Id
@@ -59,45 +60,55 @@ import qualified Wire.API.Routes.Public.Galley as GalleyAPI
 import Wire.API.Routes.Version.Wai
 
 run :: Opts -> IO ()
-run o = do
-  (app, e, appFinalizer) <- mkApp o
-  let l = e ^. App.applog
-  s <-
-    newSettings $
-      defaultServer
-        (unpack $ o ^. optGalley . epHost)
-        (portNumber $ fromIntegral $ o ^. optGalley . epPort)
-        l
-        (e ^. monitor)
-  deleteQueueThread <- Async.async $ runApp e deleteLoop
-  refreshMetricsThread <- Async.async $ runApp e refreshMetrics
-  runSettingsWithShutdown s app 5 `finally` do
-    Async.cancel deleteQueueThread
-    Async.cancel refreshMetricsThread
-    shutdown (e ^. cstate)
-    appFinalizer
+run o = lowerCodensity $ do
+  (app, env) <- mkApp o
+  let l = env ^. App.applog
+  lift $ do
+    s <-
+      newSettings $
+        defaultServer
+          (unpack $ o ^. optGalley . epHost)
+          (portNumber $ fromIntegral $ o ^. optGalley . epPort)
+          l
+          (env ^. monitor)
+    deleteQueueThread <- Async.async $ runApp env deleteLoop
+    refreshMetricsThread <- Async.async $ runApp env refreshMetrics
+    runSettingsWithShutdown s app 5 `finally` do
+      Async.cancel deleteQueueThread
+      Async.cancel refreshMetricsThread
+      shutdown (env ^. cstate)
 
-mkApp :: Opts -> IO (Application, Env, IO ())
-mkApp o = do
-  m <- M.metrics
-  e <- App.createEnv m o
-  let l = e ^. App.applog
-  runClient (e ^. cstate) $
-    versionCheck schemaVersion
-  let finalizer = do
-        Log.info l $ Log.msg @Text "Galley application finished."
-        Log.flush l
-        Log.close l
-      middlewares =
-        versionMiddleware
-          . servantPlusWAIPrometheusMiddleware API.sitemap (Proxy @CombinedAPI)
-          . GZip.gunzip
-          . GZip.gzip GZip.def
-          . catchErrors l [Right m]
-  return (middlewares $ servantApp e, e, finalizer)
+mkApp :: Opts -> Codensity IO (Application, Env)
+mkApp opts = Codensity $ \k ->
+  bracket
+    ( liftIO $ do
+        metrics <- M.metrics
+        env <- App.createEnv metrics opts
+
+        runClient (env ^. cstate) $
+          versionCheck schemaVersion
+
+        let logger = env ^. App.applog
+
+        let middlewares =
+              versionMiddleware
+                . servantPlusWAIPrometheusMiddleware API.sitemap (Proxy @CombinedAPI)
+                . GZip.gunzip
+                . GZip.gzip GZip.def
+                . catchErrors logger [Right metrics]
+
+        pure (middlewares $ servantApp env, env, metrics)
+    )
+    ( \(_app, env, _metrics) -> do
+        let logger = env ^. App.applog
+        Log.info logger $ Log.msg @Text "Galley application finished."
+        Log.flush logger
+        Log.close logger
+    )
+    (\(app, env, _metrics) -> k (app, env))
   where
     rtree = compile API.sitemap
-    app e r k = evalGalley e (route rtree r k)
+    runGalley e r k = evalGalley e (route rtree r k)
     -- the servant API wraps the one defined using wai-routing
     servantApp e0 r =
       let e = reqId .~ lookupReqId r $ e0
@@ -110,7 +121,7 @@ mkApp o = do
             ( hoistAPIHandler (toServantHandler e) API.servantSitemap
                 :<|> hoistAPIHandler (toServantHandler e) internalAPI
                 :<|> hoistServerWithDomain @FederationAPI (toServantHandler e) federationSitemap
-                :<|> Servant.Tagged (app e)
+                :<|> Servant.Tagged (runGalley e)
             )
             r
 

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2024,7 +2024,7 @@ postConvQualifiedFederationNotEnabled = do
   alice <- randomUser
   bob <- flip Qualified (Domain "some-remote-backend.example.com") <$> randomId
   connectWithRemoteUser alice bob
-  let federatorNotConfigured = \opts -> opts & optFederator .~ Nothing
+  let federatorNotConfigured = optFederator .~ Nothing
   withSettingsOverrides federatorNotConfigured $ do
     g <- view tsGalley
     postConvHelper g alice [bob] !!! do
@@ -2586,7 +2586,7 @@ testAddRemoteMemberFederationDisabled = do
 
   -- federator endpoint not configured is equivalent to federation being disabled
   -- This is the case on staging/production in May 2021.
-  let federatorNotConfigured = \opts -> opts & optFederator .~ Nothing
+  let federatorNotConfigured = optFederator .~ Nothing
   withSettingsOverrides federatorNotConfigured $
     postQualifiedMembers alice (remoteBob :| []) convId !!! do
       const 400 === statusCode
@@ -2607,7 +2607,7 @@ testAddRemoteMemberFederationUnavailable = do
   -- available (i.e. no service listing on that IP/port) can happen due to a
   -- misconfiguration of federator. That should give a 500.
   -- Port 1 should always be wrong hopefully.
-  let federatorUnavailable = \opts -> opts & optFederator ?~ Endpoint "127.0.0.1" 1
+  let federatorUnavailable = optFederator ?~ Endpoint "127.0.0.1" 1
   withSettingsOverrides federatorUnavailable $
     postQualifiedMembers alice (remoteBob :| []) convId !!! do
       const 500 === statusCode

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -38,7 +38,6 @@ module API.Federation where
 import API.Util
 import Bilge
 import Bilge.Assert
-import Bilge.TestSession (liftSession)
 import Control.Lens hiding ((#))
 import Data.Aeson (ToJSON (..))
 import qualified Data.Aeson as A
@@ -1101,11 +1100,9 @@ updateConversationByRemoteAdmin = do
                   curConvId = qUnqualified cnv,
                   curAction = action
                 }
-        resp <-
-          liftSession $
-            runWaiTestFedClient bdomain $
-              createWaiTestFedClient @"update-conversation" @'Galley $
-                cnvUpdateRequest
+        resp <- do
+          fedGalleyClient <- view tsFedGalleyClient
+          runFedClient @"update-conversation" fedGalleyClient bdomain cnvUpdateRequest
 
         cnvUpdate' <- liftIO $ case resp of
           ConversationUpdateResponseError err -> assertFailure ("Expected ConversationUpdateResponseUpdate but got " <> show err)

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -1926,9 +1926,9 @@ postCryptoBroadcastMessageFilteredTooLargeTeam bcast = do
     WS.bracketR (c . queryItem "client" (toByteString' ac2)) alice $ \wsA2 ->
       WS.bracketR (c . queryItem "client" (toByteString' ac)) alice $ \wsA1 -> do
         -- We change also max conv size due to the invariants that galley forces us to keep
-        let newOpts = \opts ->
-              opts & optSettings . setMaxFanoutSize .~ Just (unsafeRange 4)
-                & optSettings . setMaxConvSize .~ 4
+        let newOpts =
+              ((optSettings . setMaxFanoutSize) ?~ unsafeRange 4)
+                . (optSettings . setMaxConvSize .~ 4)
         withSettingsOverrides newOpts $ do
           -- Untargeted, Alice's team is too large
           Util.postBroadcast (q alice) ac bcast {bMessage = msg} !!! do

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -429,27 +429,30 @@ testEnableSSOPerTeam = do
 
 testEnableTeamSearchVisibilityPerTeam :: TestM ()
 testEnableTeamSearchVisibilityPerTeam = do
-  g <- view tsGalley
   (tid, owner, member : _) <- Util.createBindingTeamWithMembers 2
-  let check :: (HasCallStack, MonadCatch m, MonadIO m, Monad m, MonadHttp m) => String -> Public.TeamFeatureStatusValue -> m ()
+  let check :: String -> Public.TeamFeatureStatusValue -> TestM ()
       check msg enabledness = do
+        g <- view tsGalley
         status :: Public.TeamFeatureStatus 'Public.WithoutLockStatus 'Public.TeamFeatureSearchVisibility <- responseJsonUnsafe <$> (Util.getTeamSearchVisibilityAvailableInternal g tid <!! testResponse 200 Nothing)
         let statusValue = Public.tfwoStatus status
 
         liftIO $ assertEqual msg enabledness statusValue
-  let putSearchVisibilityCheckNotAllowed :: (HasCallStack, Monad m, MonadIO m, MonadHttp m) => m ()
+  let putSearchVisibilityCheckNotAllowed :: TestM ()
       putSearchVisibilityCheckNotAllowed = do
+        g <- view tsGalley
         Wai.Error status label _ _ <- responseJsonUnsafe <$> putSearchVisibility g owner tid SearchVisibilityNoNameOutsideTeam
         liftIO $ do
           assertEqual "bad status" status403 status
           assertEqual "bad label" "team-search-visibility-not-enabled" label
-  let getSearchVisibilityCheck :: (HasCallStack, MonadCatch m, MonadIO m, MonadHttp m) => TeamSearchVisibility -> m ()
-      getSearchVisibilityCheck vis =
+  let getSearchVisibilityCheck :: TeamSearchVisibility -> TestM ()
+      getSearchVisibilityCheck vis = do
+        g <- view tsGalley
         getSearchVisibility g owner tid !!! do
           const 200 === statusCode
           const (Just (TeamSearchVisibilityView vis)) === responseJsonUnsafe
 
   Util.withCustomSearchFeature FeatureTeamSearchVisibilityEnabledByDefault $ do
+    g <- view tsGalley
     check "Teams should start with Custom Search Visibility enabled" Public.TeamFeatureEnabled
     putSearchVisibility g owner tid SearchVisibilityNoNameOutsideTeam !!! const 204 === statusCode
     putSearchVisibility g owner tid SearchVisibilityStandard !!! const 204 === statusCode
@@ -457,6 +460,7 @@ testEnableTeamSearchVisibilityPerTeam = do
     check "Teams should start with Custom Search Visibility disabled" Public.TeamFeatureDisabled
     putSearchVisibilityCheckNotAllowed
 
+  g <- view tsGalley
   Util.putTeamSearchVisibilityAvailableInternal g tid Public.TeamFeatureEnabled
   -- Nothing was set, default value
   getSearchVisibilityCheck SearchVisibilityStandard
@@ -1649,7 +1653,7 @@ testBillingInLargeTeamWithoutIndexedBillingTeamMembers = do
   opts <- view tsGConf
   galley <- view tsGalley
   let withoutIndexedBillingTeamMembers =
-        withSettingsOverrides (opts & optSettings . setEnableIndexedBillingTeamMembers ?~ False)
+        withSettingsOverrides (\o -> o & optSettings . setEnableIndexedBillingTeamMembers ?~ False)
   let fanoutLimit = fromRange $ Galley.currentFanoutLimit opts
 
   -- Billing should work properly upto fanout limit
@@ -1678,8 +1682,9 @@ testBillingInLargeTeamWithoutIndexedBillingTeamMembers = do
   let memFanoutPlusTwo = json $ Member.mkNewTeamMember ownerFanoutPlusTwo (rolePermissions RoleOwner) Nothing
   -- We cannot properly add the new owner with an invite as we don't have a way to
   -- override galley settings while making a call to brig
-  withoutIndexedBillingTeamMembers $
-    post (galley . paths ["i", "teams", toByteString' team, "members"] . memFanoutPlusTwo)
+  withoutIndexedBillingTeamMembers $ do
+    g <- view tsGalley
+    post (g . paths ["i", "teams", toByteString' team, "members"] . memFanoutPlusTwo)
       !!! const 200 === statusCode
   assertQueue ("add " <> show (fanoutLimit + 2) <> "th billing member: " <> show ownerFanoutPlusTwo) $
     \s maybeEvent ->
@@ -1888,7 +1893,6 @@ postCryptoBroadcastMessageFilteredTooLargeTeam bcast = do
   localDomain <- viewFederationDomain
   let q :: Id a -> Qualified (Id a)
       q = (`Qualified` localDomain)
-  opts <- view tsGConf
   c <- view tsCannon
   -- Team1: alice, bob and 3 unnamed
   (alice, tid) <- Util.createBindingTeam
@@ -1922,7 +1926,7 @@ postCryptoBroadcastMessageFilteredTooLargeTeam bcast = do
     WS.bracketR (c . queryItem "client" (toByteString' ac2)) alice $ \wsA2 ->
       WS.bracketR (c . queryItem "client" (toByteString' ac)) alice $ \wsA1 -> do
         -- We change also max conv size due to the invariants that galley forces us to keep
-        let newOpts =
+        let newOpts = \opts ->
               opts & optSettings . setMaxFanoutSize .~ Just (unsafeRange 4)
                 & optSettings . setMaxConvSize .~ 4
         withSettingsOverrides newOpts $ do

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -172,43 +172,31 @@ testSearchVisibility = do
   Util.connectUsers owner (list1 member [])
   Util.addTeamMember owner tid member (rolePermissions RoleMember) Nothing
 
-  g <- view tsGalley
-  let getTeamSearchVisibility ::
-        (Monad m, MonadHttp m, MonadIO m, MonadCatch m, HasCallStack) =>
-        TeamId ->
-        Public.TeamFeatureStatusValue ->
-        m ()
-      getTeamSearchVisibility teamid expected =
+  let getTeamSearchVisibility :: TeamId -> Public.TeamFeatureStatusValue -> TestM ()
+      getTeamSearchVisibility teamid expected = do
+        g <- view tsGalley
         Util.getTeamSearchVisibilityAvailable g owner teamid !!! do
           statusCode === const 200
           responseJsonEither === const (Right (Public.TeamFeatureStatusNoConfig expected))
 
-  let getTeamSearchVisibilityInternal ::
-        (Monad m, MonadHttp m, MonadIO m, MonadCatch m, HasCallStack) =>
-        TeamId ->
-        Public.TeamFeatureStatusValue ->
-        m ()
-      getTeamSearchVisibilityInternal teamid expected =
+  let getTeamSearchVisibilityInternal :: TeamId -> Public.TeamFeatureStatusValue -> TestM ()
+      getTeamSearchVisibilityInternal teamid expected = do
+        g <- view tsGalley
         Util.getTeamSearchVisibilityAvailableInternal g teamid !!! do
           statusCode === const 200
           responseJsonEither === const (Right (Public.TeamFeatureStatusNoConfig expected))
 
-  let getTeamSearchVisibilityFeatureConfig ::
-        (Monad m, MonadHttp m, MonadIO m, MonadCatch m, HasCallStack) =>
-        UserId ->
-        Public.TeamFeatureStatusValue ->
-        m ()
-      getTeamSearchVisibilityFeatureConfig uid expected =
+  let getTeamSearchVisibilityFeatureConfig :: UserId -> Public.TeamFeatureStatusValue -> TestM ()
+      getTeamSearchVisibilityFeatureConfig uid expected = do
+        g <- view tsGalley
         Util.getFeatureConfigWithGalley Public.TeamFeatureSearchVisibility g uid !!! do
           statusCode === const 200
           responseJsonEither === const (Right (Public.TeamFeatureStatusNoConfig expected))
 
-  let setTeamSearchVisibilityInternal ::
-        (Monad m, MonadHttp m, MonadIO m, HasCallStack) =>
-        TeamId ->
-        Public.TeamFeatureStatusValue ->
-        m ()
-      setTeamSearchVisibilityInternal = Util.putTeamSearchVisibilityAvailableInternal g
+  let setTeamSearchVisibilityInternal :: TeamId -> Public.TeamFeatureStatusValue -> TestM ()
+      setTeamSearchVisibilityInternal teamid val = do
+        g <- view tsGalley
+        Util.putTeamSearchVisibilityAvailableInternal g teamid val
 
   assertFlagForbidden $ Util.getTeamFeatureFlag Public.TeamFeatureSearchVisibility nonMember tid
 
@@ -311,8 +299,7 @@ testClassifiedDomainsDisabled = do
         assertFlagWithConfig @Public.TeamFeatureClassifiedDomainsConfig $
           Util.getFeatureConfig Public.TeamFeatureClassifiedDomains uid
 
-  opts <- view tsGConf
-  let classifiedDomainsDisabled =
+  let classifiedDomainsDisabled = \opts ->
         opts
           & over
             (optSettings . setFeatureFlags . flagClassifiedDomains)

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -29,7 +29,6 @@ import qualified API.SQS as SQS
 import API.Util
 import Bilge hiding (accept, head, timeout, trace)
 import Bilge.Assert
-import qualified Bilge.TestSession as BilgeTest
 import Brig.Types.Client
 import Brig.Types.Intra (UserSet (..))
 import Brig.Types.Provider
@@ -1564,11 +1563,11 @@ withDummyTestServiceForTeamNoService go = do
 -- it's here for historical reason because we did this in galley.yaml
 -- at some point in the past rather than in an internal end-point, and that required spawning
 -- another galley 'Application' with 'withSettingsOverrides'.
-withLHWhitelist :: forall a. HasCallStack => TeamId -> BilgeTest.SessionT TestM a -> TestM a
+withLHWhitelist :: forall a. HasCallStack => TeamId -> TestM a -> TestM a
 withLHWhitelist tid action = do
   void $ putLHWhitelistTeam tid
   opts <- view tsGConf
-  withSettingsOverrides opts action
+  withSettingsOverrides (const opts) action
 
 -- | If you play with whitelists, you should use this one.  Every whitelisted team that does
 -- not get fully deleted will blow up the whitelist that is cached in every warp handler.

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -28,17 +28,16 @@ import Brig.Types.Intra (UserAccount (..), UserSet (..))
 import Brig.Types.Team.Invitation
 import Brig.Types.User.Auth (CookieLabel (..))
 import Control.Concurrent.Async
-import Control.Exception (throw)
+import Control.Exception (finally, throw)
 import Control.Lens hiding (from, to, (#), (.=))
-import Control.Monad.Catch (MonadCatch, MonadMask, finally)
+import Control.Monad.Catch (MonadCatch, MonadMask)
+import Control.Monad.Codensity (lowerCodensity)
 import Control.Monad.Except (ExceptT, runExceptT)
 import Control.Retry (constantDelay, exponentialBackoff, limitRetries, retrying)
 import Data.Aeson hiding (json)
 import Data.Aeson.Lens (key, _String)
 import qualified Data.ByteString as BS
-import Data.ByteString.Builder (toLazyByteString)
 import qualified Data.ByteString.Char8 as C
-import qualified Data.ByteString.Char8 as C8
 import Data.ByteString.Conversion
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.CaseInsensitive as CI
@@ -60,7 +59,6 @@ import qualified Data.ProtoLens as Protolens
 import Data.ProtocolBuffers (encodeMessage)
 import Data.Qualified
 import Data.Range
-import qualified Data.Sequence as Seq
 import Data.Serialize (runPut)
 import qualified Data.Set as Set
 import Data.Singletons
@@ -74,7 +72,6 @@ import qualified Data.UUID as UUID
 import Data.UUID.V4
 import Federator.MockServer (FederatedRequest (..))
 import qualified Federator.MockServer as Mock
-import GHC.TypeLits
 import Galley.Intra.User (chunkify)
 import qualified Galley.Options as Opts
 import qualified Galley.Run as Run
@@ -89,19 +86,12 @@ import Galley.Types.Teams.Intra
 import Galley.Types.UserList
 import Imports
 import Network.HTTP.Media.MediaType
-import Network.HTTP.Media.RenderHeader (renderHeader)
-import Network.HTTP.Types (http11, renderQuery)
 import qualified Network.HTTP.Types as HTTP
 import Network.Wai (Application, defaultRequest)
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Test as Wai
-import qualified Network.Wai.Test as WaiTest
+import Network.Wai.Utilities.MockServer (withMockServer)
 import Servant (Handler, HasServer, Server, ServerT, serve, (:<|>) (..))
-import Servant.Client (ClientError (FailureResponse))
-import qualified Servant.Client as Servant
-import Servant.Client.Core (RunClient (throwClientError))
-import qualified Servant.Client.Core as Servant
-import qualified Servant.Client.Core.Request as ServantRequest
 import System.Exit
 import System.Process
 import System.Random
@@ -661,10 +651,9 @@ defNewMLSConv :: NewConv
 defNewMLSConv = defNewProteusConv {newConvProtocol = ProtocolMLSTag}
 
 postConvQualified ::
-  (HasCallStack, HasGalley m, MonadIO m, MonadMask m, MonadHttp m) =>
   UserId ->
   NewConv ->
-  m ResponseLBS
+  TestM ResponseLBS
 postConvQualified u n = do
   g <- viewGalley
   post $
@@ -2338,14 +2327,21 @@ postSSOUser name hasEmail ssoid teamid = do
 defCookieLabel :: CookieLabel
 defCookieLabel = CookieLabel "auth"
 
--- | This allows you to run requests against a galley instantiated using the given options.
---   Note that ONLY 'galley' calls should occur within the provided action, calls to other
---   services will fail.
-withSettingsOverrides :: (HasGalley m, MonadIO m, MonadMask m) => Opts.Opts -> SessionT m a -> m a
-withSettingsOverrides opts action = do
+withSettingsOverrides :: (Opts.Opts -> Opts.Opts) -> TestM a -> TestM a
+withSettingsOverrides f action = do
+  ts :: TestSetup <- ask
+  let opts = f (ts ^. tsGConf)
   (galleyApp, _, finalizer) <- liftIO $ Run.mkApp opts
-  runSessionT action galleyApp
-    `finally` liftIO finalizer
+  liftIO . lowerCodensity $ do
+    port' <- withMockServer galleyApp
+    liftIO $
+      runReaderT
+        (runTestM action)
+        ( ts
+            & tsGalley .~ Bilge.host "127.0.0.1" . Bilge.port port'
+            & tsFedGalleyClient .~ FedClient (ts ^. tsManager) (Endpoint "127.0.0.1" port')
+        )
+        `finally` finalizer
 
 waitForMemberDeletion :: UserId -> TeamId -> UserId -> TestM ()
 waitForMemberDeletion zusr tid uid = do
@@ -2483,36 +2479,30 @@ mkProfile quid name =
 -- federator response (of an arbitrary JSON-serialisable type a) for every
 -- expected request.
 withTempMockFederator ::
-  (MonadIO m, ToJSON a, HasGalley m, MonadMask m) =>
+  ToJSON a =>
   (FederatedRequest -> a) ->
-  SessionT m b ->
-  m (b, [FederatedRequest])
+  TestM b ->
+  TestM (b, [FederatedRequest])
 withTempMockFederator resp = withTempMockFederator' $ pure . encode . resp
 
 withTempMockFederator' ::
-  (MonadIO m, HasGalley m, MonadMask m) =>
   (FederatedRequest -> IO LByteString) ->
-  SessionT m b ->
-  m (b, [FederatedRequest])
+  TestM b ->
+  TestM (b, [FederatedRequest])
 withTempMockFederator' resp action = do
-  opts <- viewGalleyOpts
   Mock.withTempMockFederator
     [("Content-Type", "application/json")]
     ((\r -> pure ("application" // "json", r)) <=< resp)
     $ \mockPort -> do
-      let opts' =
-            opts & Opts.optFederator
-              ?~ Endpoint "127.0.0.1" (fromIntegral mockPort)
-      withSettingsOverrides opts' action
+      withSettingsOverrides (\opts -> opts & Opts.optFederator ?~ Endpoint "127.0.0.1" (fromIntegral mockPort)) action
 
 -- Start a mock federator. Use proveded Servant handler for the mocking mocking function.
 withTempServantMockFederator ::
-  (MonadMask m, MonadIO m, HasGalley m) =>
   (Domain -> ServerT (FedApi 'Brig) Handler) ->
   (Domain -> ServerT (FedApi 'Galley) Handler) ->
   Domain ->
-  SessionT m b ->
-  m (b, [FederatedRequest])
+  TestM b ->
+  TestM (b, [FederatedRequest])
 withTempServantMockFederator brigApi galleyApi originDomain =
   withTempMockFederator' mock
   where
@@ -2793,90 +2783,3 @@ wsAssertConvReceiptModeUpdate conv usr new n = do
   evtType e @?= ConvReceiptModeUpdate
   evtFrom e @?= usr
   evtData e @?= EdConvReceiptModeUpdate (ConversationReceiptModeUpdate new)
-
-newtype WaiTestFedClient a = WaiTestFedClient {unWaiTestFedClient :: ReaderT Domain WaiTest.Session a}
-  deriving (Functor, Applicative, Monad, MonadIO)
-
-instance Servant.RunClient WaiTestFedClient where
-  runRequestAcceptStatus expectedStatuses servantRequest = WaiTestFedClient $ do
-    domain <- ask
-    let req' = fromServantRequest domain servantRequest
-    res <- lift $ WaiTest.srequest req'
-    let servantResponse = toServantResponse res
-    let status = Servant.responseStatusCode servantResponse
-    let statusIsSuccess =
-          case expectedStatuses of
-            Nothing -> HTTP.statusIsSuccessful status
-            Just ex -> status `elem` ex
-    unless statusIsSuccess $
-      unWaiTestFedClient $ throwClientError (FailureResponse (bimap (const ()) (\x -> (Servant.BaseUrl Servant.Http "" 80 "", cs (toLazyByteString x))) servantRequest) servantResponse)
-    pure servantResponse
-  throwClientError = liftIO . throw
-
-fromServantRequest :: Domain -> Servant.Request -> WaiTest.SRequest
-fromServantRequest domain r =
-  let pathBS = "/federation" <> Data.String.Conversions.cs (toLazyByteString (Servant.requestPath r))
-      bodyBS = case Servant.requestBody r of
-        Nothing -> ""
-        Just (bdy, _) -> case bdy of
-          Servant.RequestBodyLBS lbs -> Data.String.Conversions.cs lbs
-          Servant.RequestBodyBS bs -> bs
-          Servant.RequestBodySource _ -> error "fromServantRequest: not implemented for RequestBodySource"
-
-      -- Content-Type and Accept are specified by requestBody and requestAccept
-      headers =
-        filter (\(h, _) -> h /= "Accept" && h /= "Content-Type") $
-          toList $ Servant.requestHeaders r
-      acceptHdr
-        | null hs = Nothing
-        | otherwise = Just ("Accept", renderHeader hs)
-        where
-          hs = toList $ ServantRequest.requestAccept r
-      contentTypeHdr = case ServantRequest.requestBody r of
-        Nothing -> Nothing
-        Just (_', typ) -> Just (HTTP.hContentType, renderHeader typ)
-      req =
-        Wai.defaultRequest
-          { Wai.requestMethod = Servant.requestMethod r,
-            Wai.rawPathInfo = pathBS,
-            Wai.rawQueryString = renderQuery True (toList (Servant.requestQueryString r)),
-            Wai.requestHeaders =
-              -- Inspired by 'Servant.Client.Internal.HttpClient.defaultMakeClientRequest',
-              -- the Servant function that maps @Request@ to @Client.Request@.
-              -- This solution is a bit sophisticated due to two constraints:
-              --   - Accept header may contain a list of accepted media types.
-              --   - Accept and Content-Type headers should only appear once in the result.
-              maybeToList acceptHdr
-                <> maybeToList contentTypeHdr
-                <> headers
-                <> [(originDomainHeaderName, Text.encodeUtf8 (domainText domain))],
-            Wai.isSecure = True,
-            Wai.pathInfo = filter (not . Text.null) (map Data.String.Conversions.cs (C8.split '/' pathBS)),
-            Wai.queryString = toList (Servant.requestQueryString r)
-          }
-   in WaiTest.SRequest req (cs bodyBS)
-
-toServantResponse :: WaiTest.SResponse -> Servant.Response
-toServantResponse res =
-  Servant.Response
-    { Servant.responseStatusCode = WaiTest.simpleStatus res,
-      Servant.responseHeaders = Seq.fromList (WaiTest.simpleHeaders res),
-      Servant.responseBody = WaiTest.simpleBody res,
-      Servant.responseHttpVersion = http11
-    }
-
-createWaiTestFedClient ::
-  forall (name :: Symbol) comp api.
-  ( HasFedEndpoint comp api name,
-    Servant.HasClient WaiTestFedClient api
-  ) =>
-  Servant.Client WaiTestFedClient api
-createWaiTestFedClient =
-  Servant.clientIn (Proxy @api) (Proxy @WaiTestFedClient)
-
-runWaiTestFedClient ::
-  Domain ->
-  WaiTestFedClient a ->
-  WaiTest.Session a
-runWaiTestFedClient domain action =
-  runReaderT (unWaiTestFedClient action) domain

--- a/services/galley/test/integration/API/Util/TeamFeature.hs
+++ b/services/galley/test/integration/API/Util/TeamFeature.hs
@@ -20,7 +20,6 @@ module API.Util.TeamFeature where
 import API.Util (HasGalley (viewGalley), zUser)
 import qualified API.Util as Util
 import Bilge
-import qualified Bilge.TestSession as BilgeTest
 import Control.Lens (view, (.~))
 import Data.Aeson (ToJSON)
 import Data.ByteString.Conversion (toByteString')
@@ -31,11 +30,9 @@ import Imports
 import TestSetup
 import qualified Wire.API.Team.Feature as Public
 
-withCustomSearchFeature :: FeatureTeamSearchVisibility -> BilgeTest.SessionT TestM () -> TestM ()
+withCustomSearchFeature :: FeatureTeamSearchVisibility -> TestM () -> TestM ()
 withCustomSearchFeature flag action = do
-  opts <- view tsGConf
-  let opts' = opts & optSettings . setFeatureFlags . flagTeamSearchVisibility .~ flag
-  Util.withSettingsOverrides opts' action
+  Util.withSettingsOverrides (\opts -> opts & optSettings . setFeatureFlags . flagTeamSearchVisibility .~ flag) action
 
 getTeamSearchVisibilityAvailable :: HasCallStack => (Request -> Request) -> UserId -> TeamId -> (MonadIO m, MonadHttp m) => m ResponseLBS
 getTeamSearchVisibilityAvailable = getTeamFeatureFlagWithGalley Public.TeamFeatureSearchVisibility


### PR DESCRIPTION
Refactors `withSettingsOverrides` analogous to the refactorings `withSettingsOverrides` of  `cargohold` and `gundeck`:

This PR makes `withSettingsOverrides` spawn galley in a proper http server instead of relying on `SessionT`.

Using `SessionT` has the common pitfall that *any* http calls get interpreted as calls to the application, e.g.

without this PR:
```haskell
brig <- view tsBrig
galley <- view tsGalley
withSettingsOverrides opts $ do
   callBrig brig -- this is a lie. The MonadHttp call is interepred as a SessionT call to galley (host ignored), not brig! Most likely this results in `404` that is hard to debug
   callGalley galley -- another lie, same as above
```

with this PR (real http server):
```haskell
brig <- view tsBrig
withSettingsOverrides updateOpts $ do
   galleyWithOpts <- view tsGalley
   callBrig brig -- the MonadHttp call is interpreted as a real HTTP call to brig
   callGalley galleyWithOpts -- the MonadHttp call is interpreted as a real HTTP call to `galleyWithOpts` instance
```

After applying PR we could also write helper functions in `TestM` and get the galley endpoint from the environment. E.g. `callGalley :: TestM ()`

```haskell
callGalley -- calls the unmodified galley
withSettingsOverrides updateOpts $ do
   callGalley -- calls the galley spawned with `updateOpts`
```

### Effect on CI runs
What is the overhead of spawning a http server? Lets run `time make ci package=galley`

- without this PR: `8:39.72`
- with this this PR applied: `7:43.75 total`

this is surprising... On CI the run times are the same, so I don't think this PR affects the test run duration

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.