### PR TITLE
Fix flaky key package test

### DIFF
--- a/changelog.d/5-internal/mls-flaky-key-package
+++ b/changelog.d/5-internal/mls-flaky-key-package
@@ -1,0 +1,1 @@
+Fix flaky key package test

--- a/services/brig/test/integration/API/MLS.hs
+++ b/services/brig/test/integration/API/MLS.hs
@@ -22,13 +22,14 @@ import Bilge
 import Bilge.Assert
 import Brig.Options
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
 import Data.ByteString.Conversion
 import Data.Id
 import Data.Qualified
 import qualified Data.Set as Set
 import Federation.Util
 import Imports
-import Test.QuickCheck (arbitrary, generate, resize)
+import Test.QuickCheck hiding ((===))
 import Test.Tasty
 import Test.Tasty.HUnit
 import UnliftIO.Temporary
@@ -168,8 +169,8 @@ testKeyPackageRemoteClaim opts brig = do
       KeyPackageBundleEntry
         <$> pure u
         <*> arbitrary
-        <*> (KeyPackageRef <$> arbitrary)
-        <*> (KeyPackageData <$> resize 64 arbitrary)
+        <*> (KeyPackageRef . BS.pack <$> vector 32)
+        <*> (KeyPackageData . BS.pack <$> vector 64)
   let mockBundle = KeyPackageBundle (Set.fromList entries)
   (bundle :: KeyPackageBundle, _reqs) <-
     liftIO . withTempMockFederator opts (Aeson.encode mockBundle) $


### PR DESCRIPTION
Fix flakyness in remote package claim test. The problem was that the mock key package ref could be empty, which would break assumptions in the DB code.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
