### PR TITLE
Log IO exceptions in Brig and Galley

### DIFF
--- a/changelog.d/5-internal/log-exceptions
+++ b/changelog.d/5-internal/log-exceptions
@@ -1,0 +1,1 @@
+Log IO exceptions in Galley and Brig


### PR DESCRIPTION
IO exceptions in brig and galley were previously just caught by the "error handling" middleware, resulting in a generic "Server Error" log message, which was useless for diagnosing the actual cause of the error. This PR adds logging for IO exceptions in Brig and Galley. The actual response returned in case of IO exceptions is unaffected.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
