### PR TITLE
Fix flaky MLS conversation creation test

### DIFF
--- a/changelog.d/5-internal/mls-flaky-conversation
+++ b/changelog.d/5-internal/mls-flaky-conversation
@@ -1,0 +1,1 @@
+Fix flaky MLS conversation creation test

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -96,17 +96,14 @@ postMLSConvOk :: TestM ()
 postMLSConvOk = do
   c <- view tsCannon
   qalice <- randomQualifiedUser
-  bob <- randomUser
   let alice = qUnqualified qalice
   let nameMaxSize = T.replicate 256 "a"
-  connectUsers alice (list1 bob [])
-  WS.bracketR2 c alice bob $ \(wsA, wsB) -> do
+  WS.bracketR c alice $ \wsA -> do
     rsp <- postConvQualified alice defNewMLSConv {newConvName = checked nameMaxSize}
     pure rsp !!! do
       const 201 === statusCode
       const Nothing === fmap Wai.label . responseJsonError
     cid <- assertConv rsp RegularConv alice qalice [] (Just nameMaxSize) Nothing
-    WS.assertNoEvent (2 # WS.Second) [wsB]
     checkConvCreateEvent cid wsA
 
 testLocalWelcome :: TestM ()


### PR DESCRIPTION
The assertion was (very rarely) picking up a connection event between
alice and bob, and failing. Since bob is irrelevant to the test, this
commit removes bob and the related assertion altogether.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
