### PR TITLE
Attempt to fix flakyness of path traversal test

### DIFF
--- a/changelog.d/5-internal/develop
+++ b/changelog.d/5-internal/develop
@@ -1,0 +1,1 @@
+Fix flakyness of path traversal test

--- a/services/federator/src/Federator/Monitor/Internal.hs
+++ b/services/federator/src/Federator/Monitor/Internal.hs
@@ -18,7 +18,7 @@
 module Federator.Monitor.Internal where
 
 import Control.Exception (try)
-import Data.ByteString (packCStringLen)
+import Data.ByteString (packCStringLen, useAsCStringLen)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
@@ -28,7 +28,7 @@ import qualified Data.X509 as X509
 import Data.X509.CertificateStore
 import Federator.Env (TLSSettings (..))
 import Federator.Options (RunSettings (..))
-import GHC.Foreign (withCStringLen)
+import GHC.Foreign (peekCStringLen, withCStringLen)
 import GHC.IO.Encoding (getFileSystemEncoding)
 import Imports
 import qualified Network.TLS as TLS
@@ -66,6 +66,11 @@ rawPath :: FilePath -> IO RawFilePath
 rawPath path = do
   encoding <- getFileSystemEncoding
   withCStringLen encoding path packCStringLen
+
+fromRawPath :: RawFilePath -> IO FilePath
+fromRawPath path = do
+  encoding <- getFileSystemEncoding
+  useAsCStringLen path (peekCStringLen encoding)
 
 data WatchedPath
   = WatchedFile RawFilePath


### PR DESCRIPTION
Instead of generating `String` values, which might be invalid for the file system encoding in some locales, generate bytestrings directy and encode them as paths.

I hope this fixes a flakyness in the path traversal tests reported by @jschaul.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
