### PR TITLE
Added convert-to-cabal and stern docs to /docs.

### DIFF
--- a/docs/developer/convert-to-cabal.md
+++ b/docs/developer/convert-to-cabal.md
@@ -1,0 +1,1 @@
+../../tools/convert-to-cabal/README.md

--- a/docs/developer/stern.md
+++ b/docs/developer/stern.md
@@ -1,0 +1,1 @@
+../../tools/stern/README.md


### PR DESCRIPTION
I keep getting lost trying to find specific docs because… they're not under `docs/`. I didn't want to do an exhaustive check before making sure we want this, or what we have planned for docs, considering all the legacy stuff.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [X] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.