### PR TITLE
[FS-507] Ensure Users Connected Before Exchanging Welcome Messages

### DIFF
--- a/changelog.d/2-features/mls
+++ b/changelog.d/2-features/mls
@@ -1,3 +1,4 @@
 MLS implementation progress:
 
  - remote key package claim is now supported (#2353)
+ - ensure users are connected before exchanging welcome messages (#2391)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -60,7 +60,7 @@ type GalleyApi =
     :<|> FedEndpoint "send-message" MessageSendRequest MessageSendResponse
     :<|> FedEndpoint "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
     :<|> FedEndpoint "update-conversation" ConversationUpdateRequest ConversationUpdateResponse
-    :<|> FedEndpoint "mls-welcome" MLSWelcomeRequest ()
+    :<|> FedEndpoint "mls-welcome" MLSWelcomeRequest MLSWelcomeResponse
 
 data GetConversationsRequest = GetConversationsRequest
   { gcrUserId :: UserId,
@@ -263,10 +263,25 @@ newtype MLSWelcomeRecipient = MLSWelcomeRecipient {unMLSWelRecipient :: (UserId,
   deriving newtype (Show, Eq)
 
 data MLSWelcomeRequest = MLSWelcomeRequest
-  { mwrRawWelcome :: Base64ByteString,
+  { -- | The sender of the welcome message. They are implicitly qualified by the
+    -- origin domain.
+    mwrSender :: UserId,
+    -- | The raw welcome message
+    mwrRawWelcome :: Base64ByteString,
     -- | These are qualified implicitly by the target domain
     mwrRecipients :: [MLSWelcomeRecipient]
   }
   deriving stock (Generic)
   deriving (Arbitrary) via (GenericUniform MLSWelcomeRequest)
   deriving (FromJSON, ToJSON) via (CustomEncoded MLSWelcomeRequest)
+
+newtype MLSWelcomeResponse = MLSWelcomeResponse
+  {unWelcomeResponse :: Either MLSWelcomeError ()}
+  deriving stock (Eq, Show)
+  deriving
+    (ToJSON, FromJSON)
+    via (Either (CustomEncoded MLSWelcomeError) ())
+
+data MLSWelcomeError = MLSWelcomeErrorNotConnected
+  deriving (Eq, Generic, Show)
+  deriving (ToJSON, FromJSON) via CustomEncoded MLSWelcomeError

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -282,6 +282,10 @@ newtype MLSWelcomeResponse = MLSWelcomeResponse
     (ToJSON, FromJSON)
     via (Either (CustomEncoded MLSWelcomeError) ())
 
-data MLSWelcomeError = MLSWelcomeErrorNotConnected
+data MLSWelcomeError
+  = -- | The following error currently corresponds to a not-connected error, but
+    -- we do not expose that information to the welcome message sender. Instead,
+    -- they are given a conversation access denied error.
+    MLSWelcomeErrorConvAccessDenied
   deriving (Eq, Generic, Show)
   deriving (ToJSON, FromJSON) via CustomEncoded MLSWelcomeError

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1275,6 +1275,7 @@ type MLSMessagingAPI =
   Named
     "mls-welcome-message"
     ( Summary "Post an MLS welcome message"
+        :> CanThrow 'ConvAccessDenied
         :> CanThrow 'MLSKeyPackageRefNotFound
         :> CanThrow 'NotConnected
         :> "welcome"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1276,6 +1276,7 @@ type MLSMessagingAPI =
     "mls-welcome-message"
     ( Summary "Post an MLS welcome message"
         :> CanThrow 'MLSKeyPackageRefNotFound
+        :> CanThrow 'NotConnected
         :> "welcome"
         :> ZConn
         :> ReqBody '[MLS] (RawMLS Welcome)

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -339,10 +339,10 @@ performConversationJoin qusr lcnv conv (ConversationJoin invited role) = do
           <$> E.selectTeamMembers tid newUsers
       let userMembershipMap = map (id &&& flip Map.lookup tms) newUsers
       ensureAccessRole (convAccessRoles conv) userMembershipMap
-      ensureConnectedOrSameTeam lusr newUsers
+      ensureConnectedOrSameTeam lusr (UserList newUsers [])
     checkLocals lusr Nothing newUsers = do
       ensureAccessRole (convAccessRoles conv) (zip newUsers $ repeat Nothing)
-      ensureConnectedOrSameTeam lusr newUsers
+      ensureConnectedOrSameTeam lusr (UserList newUsers [])
 
     checkRemotes ::
       Members

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -559,5 +559,5 @@ mlsSendWelcome origDomain (F.MLSWelcomeRequest sender b64RawWelcome rcpts) = do
           e = Event (qUntagged lcnv) (qUntagged lusr) time $ EdMLSWelcome rawWelcome
        in newMessagePush l () Nothing defMessageMetadata (u, c) e
     mapRunError =
-      fmap (F.MLSWelcomeResponse . mapLeft (const MLSWelcomeErrorNotConnected))
+      fmap (F.MLSWelcomeResponse . mapLeft (const MLSWelcomeErrorConvAccessDenied))
         . runError @(Tagged 'NotConnected ())

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -48,6 +48,7 @@ import Wire.API.MLS.Welcome
 postMLSWelcome ::
   Members
     '[ BrigAccess,
+       ErrorS 'ConvAccessDenied,
        ErrorS 'MLSKeyPackageRefNotFound,
        ErrorS 'NotConnected,
        FederatorAccess,
@@ -84,7 +85,7 @@ welcomeRecipients =
 
 sendWelcomes ::
   Members
-    '[ ErrorS 'NotConnected,
+    '[ ErrorS 'ConvAccessDenied,
        FederatorAccess,
        GundeckAccess,
        Input UTCTime
@@ -120,7 +121,7 @@ sendLocalWelcomes con now rawWelcome lclients = do
 
 sendRemoteWelcomes ::
   Members
-    '[ ErrorS 'NotConnected,
+    '[ ErrorS 'ConvAccessDenied,
        FederatorAccess
      ]
     r =>
@@ -138,8 +139,8 @@ sendRemoteWelcomes lusr rawWelcome rClients = do
       rpc = fedClient @'Galley @"mls-welcome" req
   runFederated rClients rpc >>= mapFedError
   where
-    mapFedError :: Member (ErrorS 'NotConnected) r => MLSWelcomeResponse -> Sem r ()
+    mapFedError :: Member (ErrorS 'ConvAccessDenied) r => MLSWelcomeResponse -> Sem r ()
     mapFedError =
-      mapError @MLSWelcomeError @(Tagged 'NotConnected ()) (const (Tagged ()))
+      mapError @MLSWelcomeError @(Tagged 'ConvAccessDenied ()) (const (Tagged ()))
         . fromEither
         . unWelcomeResponse

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -1173,7 +1173,7 @@ sendMLSWelcomeNotConnected = do
     -- check that no event is received and make sure there was an error response
     liftIO $ do
       WS.assertNoEvent (1 # Second) [wsB]
-      resp @?= MLSWelcomeResponse (Left MLSWelcomeErrorNotConnected)
+      resp @?= MLSWelcomeResponse (Left MLSWelcomeErrorConvAccessDenied)
 
 sendMLSWelcome :: TestM ()
 sendMLSWelcome = do

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -201,7 +201,7 @@ testRemoteWelcomeNotConnected = do
         case frRPC fedReq of
           "mls-welcome" ->
             pure
-              (Aeson.encode $ MLSWelcomeResponse (Left MLSWelcomeErrorNotConnected))
+              (Aeson.encode $ MLSWelcomeResponse (Left MLSWelcomeErrorConvAccessDenied))
           ms -> assertFailure ("unmocked endpoint called: " <> cs ms)
 
   void


### PR DESCRIPTION
Neither a local nor a federated exchange of welcome messages ensured that users are connected before exchanging welcome messages. This can lead to spamming with welcome messages as well as exhausting all of key packages a user has uploaded. The PR ensures that users are connected before sending welcome messages.

Tracked by https://wearezeta.atlassian.net/browse/FS-507.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
