### PR TITLE
show package name for which tests run

### DIFF
--- a/hack/bin/cabal-run-all-tests.sh
+++ b/hack/bin/cabal-run-all-tests.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
-packages=$(find "$TOP_LEVEL" -name '*.cabal' |
+mapfile -t packages < <(find "$TOP_LEVEL" -name '*.cabal' |
     grep -v dist-newstyle |
     xargs -n 1 dirname |
     xargs -n 1 basename)
 
-for p in $packages; do
+for p in "${packages[@]}"; do
     echo "==== Testing $p..."
     "$DIR/cabal-run-tests.sh" "$p"
 done

--- a/hack/bin/cabal-run-all-tests.sh
+++ b/hack/bin/cabal-run-all-tests.sh
@@ -8,8 +8,7 @@ TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 packages=$(find "$TOP_LEVEL" -name '*.cabal' |
     grep -v dist-newstyle |
     xargs -n 1 dirname |
-    xargs -n 1 basename |
-    xargs -n 1 echo)
+    xargs -n 1 basename)
 
 for p in $packages; do
     echo "==== Testing $p..."

--- a/hack/bin/cabal-run-all-tests.sh
+++ b/hack/bin/cabal-run-all-tests.sh
@@ -2,11 +2,16 @@
 
 set -euo pipefail
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
-find "$TOP_LEVEL" -name '*.cabal' |
+packages=$(find "$TOP_LEVEL" -name '*.cabal' |
     grep -v dist-newstyle |
     xargs -n 1 dirname |
     xargs -n 1 basename |
-    xargs -n 1 "$DIR/cabal-run-tests.sh"
+    xargs -n 1 echo)
+
+for p in $packages; do
+    echo "==== Testing $p..."
+    "$DIR/cabal-run-tests.sh" "$p"
+done


### PR DESCRIPTION
This change leads to the following new behaviour:

* show package name for the unit tests that run
* stop executing other packages' unit tests if there's a failure

doesn't warrant a changelog I think.