### PR TITLE
Fix locale variables in Nix and .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -24,3 +24,7 @@ PATH_add "./.env/bin"
 
 # allow local .envrc overrides
 [[ -f .envrc.local ]] && source_env .envrc.local
+
+# Locale
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 SHELL                 := /usr/bin/env bash
-LANG                  := en_US.UTF-8
 DOCKER_USER           ?= quay.io/wire
 # kubernetes namespace for running integration tests
 NAMESPACE             ?= test-$(USER)

--- a/changelog.d/5-internal/nix-locale-archive
+++ b/changelog.d/5-internal/nix-locale-archive
@@ -1,0 +1,1 @@
+Fix locale variables in Nix and .envrc

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -117,6 +117,7 @@ let
     # This gets sourced by direnv. Set NIX_PATH, so `nix-shell` uses the same nixpkgs as here.
     text = ''
       export NIX_PATH=nixpkgs=${toString pkgs.path}
+      export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive
     '';
   };
 

--- a/tools/ormolu.sh
+++ b/tools/ormolu.sh
@@ -67,11 +67,6 @@ if [ -t 1 ]; then
     : ${ORMOLU_CONDENSE_OUTPUT:=1}
 fi
 
-# https://github.com/tweag/ormolu/issues/38
-# https://gitlab.haskell.org/ghc/ghc/-/issues/17755
-export LANG=C.UTF-8
-export LC_ALL=C.UTF-8
-
 for hsfile in $(git ls-files | grep '\.hsc\?$'); do
     FAILED=0
 


### PR DESCRIPTION
Some wire-server tests would fail if the locale variables were not set properly. This PR moves setting the LANG variable into `.envrc` (and also puts `LC_ALL` there). Furthermore, there is no need to set these variables any more in `tools/ormolu.sh`.

The C locale is Debian/Ubuntu-specific; it has been removed from the Ormolu script.

See https://sourceware.org/legacy-ml/libc-alpha/2015-02/msg00247.html.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
