### PR TITLE
Update team-settings version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/team-settings-upgrade
+++ b/changelog.d/0-release-notes/team-settings-upgrade
@@ -1,1 +1,1 @@
-Upgrade team-settings version to 4.8.0-v0.29.7-0-17f5e28
+Upgrade team-settings version to 4.9.0-v0.29.7-0-142a76f

--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/team-settings
-  tag: "4.8.0-v0.29.7-0-17f5e28"
+  tag: "4.9.0-v0.29.7-0-142a76f"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `4.9.0-v0.29.7-0-142a76f`
Release: [`v4.9.0`](https://github.com/wireapp/wire-team-settings/releases/tag/v4.9.0)