### PR TITLE
SQSERVICES-1519 IdP for SAML that was overridden by update cannot be added again

### DIFF
--- a/changelog.d/3-bug-fixes/pr-2400
+++ b/changelog.d/3-bug-fixes/pr-2400
@@ -1,0 +1,1 @@
+An IdP for SAML that was overridden can be added again

--- a/changelog.d/3-bug-fixes/pr-2400
+++ b/changelog.d/3-bug-fixes/pr-2400
@@ -1,1 +1,1 @@
-An IdP for SAML that was overridden can be added again
+When an IdP issuer (aka entity ID) is updated, the old issuer was still marked as "in use".

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -683,12 +683,14 @@ idpUpdateXML ::
 idpUpdateXML zusr raw idpmeta idpid = withDebugLog "idpUpdate" (Just . show . (^. SAML.idpId)) $ do
   (teamid, idp) <- validateIdPUpdate zusr idpmeta idpid
   GalleyAccess.assertSSOEnabled teamid
-  forM_ (idp ^. SAML.idpExtraInfo . wiOldIssuers) IdPConfigStore.deleteIssuer
   IdPRawMetadataStore.store (idp ^. SAML.idpId) raw
   -- (if raw metadata is stored and then spar goes out, raw metadata won't match the
-  -- structured idp config.  since this will lead to a 5xx response, the client is epected to
+  -- structured idp config.  since this will lead to a 5xx response, the client is expected to
   -- try again, which would clean up cassandra state.)
   storeIdPConfig idp
+  -- if the IdP issuer is updated, the old issuer must be removed explicitly.
+  -- if this step is ommitted (due to a crash) resending the update request should fix the inconsistent state.
+  forM_ (idp ^. SAML.idpExtraInfo . wiOldIssuers) IdPConfigStore.deleteIssuer
   pure idp
 
 -- | Check that: idp id is valid; calling user is admin in that idp's home team; team id in

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -683,6 +683,7 @@ idpUpdateXML ::
 idpUpdateXML zusr raw idpmeta idpid = withDebugLog "idpUpdate" (Just . show . (^. SAML.idpId)) $ do
   (teamid, idp) <- validateIdPUpdate zusr idpmeta idpid
   GalleyAccess.assertSSOEnabled teamid
+  forM_ (idp ^. SAML.idpExtraInfo . wiOldIssuers) IdPConfigStore.deleteIssuer
   IdPRawMetadataStore.store (idp ^. SAML.idpId) raw
   -- (if raw metadata is stored and then spar goes out, raw metadata won't match the
   -- structured idp config.  since this will lead to a 5xx response, the client is epected to

--- a/services/spar/src/Spar/Sem/IdPConfigStore.hs
+++ b/services/spar/src/Spar/Sem/IdPConfigStore.hs
@@ -30,6 +30,7 @@ module Spar.Sem.IdPConfigStore
     deleteConfig,
     setReplacedBy,
     clearReplacedBy,
+    deleteIssuer,
   )
 where
 
@@ -70,6 +71,7 @@ data IdPConfigStore m a where
   -- affects _wiReplacedBy in GetConfig
   SetReplacedBy :: Replaced -> Replacing -> IdPConfigStore m ()
   ClearReplacedBy :: Replaced -> IdPConfigStore m ()
+  DeleteIssuer :: SAML.Issuer -> IdPConfigStore m ()
 
 deriving stock instance Show (IdPConfigStore m a)
 

--- a/services/spar/src/Spar/Sem/IdPConfigStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/IdPConfigStore/Cassandra.hs
@@ -56,6 +56,7 @@ idPToCassandra =
          in deleteIdPConfig idpid issuer team
       SetReplacedBy r r11 -> setReplacedBy r r11
       ClearReplacedBy r -> clearReplacedBy r
+      DeleteIssuer i -> deleteIssuer i
 
 type IdPConfigRow = (SAML.IdPId, SAML.Issuer, URI, SignedCertificate, [SignedCertificate], TeamId, Maybe WireIdPAPIVersion, [SAML.Issuer], Maybe SAML.IdPId)
 
@@ -231,3 +232,9 @@ clearReplacedBy (Replaced old) = do
   where
     ins :: PrepQuery W (Identity SAML.IdPId) ()
     ins = "UPDATE idp SET replaced_by = null WHERE idp = ?"
+
+deleteIssuer :: (HasCallStack, MonadClient m) => SAML.Issuer -> m ()
+deleteIssuer issuer = retry x5 $ write del (params LocalQuorum (Identity issuer))
+  where
+    del :: PrepQuery W (Identity SAML.Issuer) ()
+    del = "DELETE FROM issuer_idp_v2 WHERE issuer = ?"

--- a/services/spar/src/Spar/Sem/IdPConfigStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/IdPConfigStore/Mem.hs
@@ -58,6 +58,7 @@ idPToMem = evState . evEff
         modify' (updateReplacedBy (Just replacing) replaced <$>)
       ClearReplacedBy (Replaced replaced) ->
         modify' (updateReplacedBy Nothing replaced <$>)
+      DeleteIssuer issuer -> modify' (deleteIssuer issuer)
 
 storeConfig :: IP.IdP -> TypedState -> TypedState
 storeConfig iw =
@@ -114,3 +115,6 @@ updateReplacedBy mbReplacing replaced idp =
     & if idp ^. SAML.idpId == replaced
       then SAML.idpExtraInfo . IP.wiReplacedBy .~ mbReplacing
       else id
+
+deleteIssuer :: SAML.Issuer -> TypedState -> TypedState
+deleteIssuer = const id

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -918,9 +918,9 @@ specCRUDIdentityProvider = do
         (SampleIdP metadata2 _ _ _) <- makeSampleIdPMetadata
         callIdpUpdate' (env ^. teSpar) (Just owner) (idp1 ^. idpId) (IdPMetadataValue (cs $ SAML.encode metadata2) undefined)
           `shouldRespondWith` ((== 200) . statusCode)
-        -- create a new idp with the first metadata
+        -- create a new idp with the first metadata (should succeed)
         callIdpCreate' (env ^. teWireIdPAPIVersion) (env ^. teSpar) (Just owner) metadata1
-          `shouldRespondWith` ((== 200) . statusCode)
+          `shouldRespondWith` ((== 201) . statusCode)
 
       context "invalid body" $ do
         it "rejects" $ do
@@ -1186,7 +1186,6 @@ specCRUDIdentityProvider = do
           idp `shouldBe` idp'
           let prefix = "<EntityDescriptor xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:samla=\"urn:oasis:names"
           ST.take (ST.length prefix) rawmeta `shouldBe` prefix
-
     context "client is owner without email" $ do
       it "responds with 2xx; makes IdP available for GET /identity-providers/" $ do
         pending

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -908,6 +908,20 @@ specCRUDIdentityProvider = do
           `shouldRespondWith` ((== 200) . statusCode)
         callIdpGet (env ^. teSpar) (Just owner) idpid
           `shouldRespondWith` ((== idpmeta') . view idpMetadata)
+      it "updates IdP metadata and creates a new IdP with the first metadata" $ do
+        env <- ask
+        (owner, _) <- call $ createUserWithTeam (env ^. teBrig) (env ^. teGalley)
+        -- create new idp
+        (SampleIdP metadata1 _ _ _) <- makeSampleIdPMetadata
+        idp1 <- call $ callIdpCreate (env ^. teWireIdPAPIVersion) (env ^. teSpar) (Just owner) metadata1
+        -- update the idp metadata
+        (SampleIdP metadata2 _ _ _) <- makeSampleIdPMetadata
+        callIdpUpdate' (env ^. teSpar) (Just owner) (idp1 ^. idpId) (IdPMetadataValue (cs $ SAML.encode metadata2) undefined)
+          `shouldRespondWith` ((== 200) . statusCode)
+        -- create a new idp with the first metadata
+        callIdpCreate' (env ^. teWireIdPAPIVersion) (env ^. teSpar) (Just owner) metadata1
+          `shouldRespondWith` ((== 200) . statusCode)
+
       context "invalid body" $ do
         it "rejects" $ do
           env <- ask
@@ -1172,6 +1186,7 @@ specCRUDIdentityProvider = do
           idp `shouldBe` idp'
           let prefix = "<EntityDescriptor xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:samla=\"urn:oasis:names"
           ST.take (ST.length prefix) rawmeta `shouldBe` prefix
+
     context "client is owner without email" $ do
       it "responds with 2xx; makes IdP available for GET /identity-providers/" $ do
         pending


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1519

## Old behavior

When an IdP was updated, the entry in the table `issuer_idp_v2` did not get overridden, but instead a new entry was made. Because the old entry still existed, adding the old IdP again failed.

## Changes

In this PR, on IdP update, old issuers in `issuer_idp_v2` will be deleted. Not sure if this is the correct fix, as those old issuers may serve some other purpose that I am not aware of?

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.