### PR TITLE
chart/nginx-ingress-services: upgrade resources and allow fine-grained configurability

### DIFF
--- a/changelog.d/0-release-notes/cert-manager
+++ b/changelog.d/0-release-notes/cert-manager
@@ -1,0 +1,1 @@
+If using [cert-manager](https://github.com/cert-manager/cert-manager), you need to have least version 1.0.0 (1.8.0 works at the time of writing) installed. Older cert-manager 0.15.X will no longer work.

--- a/changelog.d/2-features/ingress-services
+++ b/changelog.d/2-features/ingress-services
@@ -1,0 +1,1 @@
+charts/nginx-ingress-services: Allow more fine-grained control over what services are installed. Upgrade Certificate/Issuer resources to 'cert-manager.io/v1'

--- a/charts/nginx-ingress-services/templates/certificate.yaml
+++ b/charts/nginx-ingress-services/templates/certificate.yaml
@@ -10,8 +10,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   issuerRef:
-    name: letsencrypt-http01
-    kind: Issuer
+    name: {{ .Values.tls.issuer.name }}
+    kind: {{ .Values.tls.issuer.kind }}
   usages:
     - server auth
   duration: 2160h     # 90d, Letsencrypt default; NOTE: changes are ignored by Letsencrypt

--- a/charts/nginx-ingress-services/templates/certificate.yaml
+++ b/charts/nginx-ingress-services/templates/certificate.yaml
@@ -28,8 +28,12 @@ spec:
   dnsNames:
     - {{ .Values.config.dns.https }}
     - {{ .Values.config.dns.ssl }}
+    {{- if .Values.webapp.enabled }}
     - {{ .Values.config.dns.webapp }}
+    {{- end }}
+    {{- if .Values.fakeS3.enabled }}
     - {{ .Values.config.dns.fakeS3 }}
+    {{- end }}
     {{- if .Values.teamSettings.enabled }}
     - {{ .Values.config.dns.teamSettings }}
     {{- end }}

--- a/charts/nginx-ingress-services/templates/certificate.yaml
+++ b/charts/nginx-ingress-services/templates/certificate.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.tls.enabled .Values.tls.useCertManager -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "{{ include "nginx-ingress-services.zone" . | replace "." "-" }}-csr"
@@ -17,14 +17,14 @@ spec:
   duration: 2160h     # 90d, Letsencrypt default; NOTE: changes are ignored by Letsencrypt
   renewBefore: 360h   # 15d
   isCA: false
-  keyAlgorithm: ecdsa
-  keySize: 384        # 521 is not supported by Letsencrypt
-  keyEncoding: pkcs1
   secretName: {{ include "nginx-ingress-services.getCertificateSecretName" . | quote }}
-  # NOTE: disabled due to https://github.com/jetstack/cert-manager/issues/2978
-  # TODO: enable when fixed (probably when cert-manager:v0.16 released)
-  #privateKey:
-  #  rotationPolicy: Always
+
+  privateKey:
+    algorithm: ECDSA
+    size: 384         # 521 is not supported by Letsencrypt
+    encoding: PKCS1
+    rotationPolicy: Always
+
   dnsNames:
     - {{ .Values.config.dns.https }}
     - {{ .Values.config.dns.ssl }}

--- a/charts/nginx-ingress-services/templates/certificate_federator.yaml
+++ b/charts/nginx-ingress-services/templates/certificate_federator.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.federator.enabled (not .Values.tls.enabled) }}
 {{- fail "TLS is required by federator. Either disable federation or enable tls." }}
 {{- end }}
-{{- if and .Values.tls.enabled .Values.tls.useCertManager }}
+{{- if and .Values.federator.enabled (and .Values.tls.enabled .Values.tls.useCertManager) }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:

--- a/charts/nginx-ingress-services/templates/certificate_federator.yaml
+++ b/charts/nginx-ingress-services/templates/certificate_federator.yaml
@@ -13,8 +13,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   issuerRef:
-    name: letsencrypt-http01
-    kind: Issuer
+    name: {{ .Values.tls.issuer.name }}
+    kind: {{ .Values.tls.issuer.kind }}
   usages:
     - server auth
     - client auth

--- a/charts/nginx-ingress-services/templates/certificate_federator.yaml
+++ b/charts/nginx-ingress-services/templates/certificate_federator.yaml
@@ -2,7 +2,7 @@
 {{- fail "TLS is required by federator. Either disable federation or enable tls." }}
 {{- end }}
 {{- if and .Values.federator.enabled (and .Values.tls.enabled .Values.tls.useCertManager) }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "federator-{{ include "nginx-ingress-services.zone" . | replace "." "-" }}-csr"

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -11,8 +11,12 @@ spec:
   - hosts:
       - {{ .Values.config.dns.https }}
       - {{ .Values.config.dns.ssl }}
+{{- if .Values.webapp.enabled }}
       - {{ .Values.config.dns.webapp }}
+{{- end }}
+{{- if .Values.fakeS3.enabled }}
       - {{ .Values.config.dns.fakeS3 }}
+{{- end }}
 {{- if .Values.teamSettings.enabled }}
       - {{ .Values.config.dns.teamSettings }}
 {{- end }}

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -39,6 +39,7 @@ spec:
             backend:
               serviceName: nginz-tcp
               servicePort: {{ .Values.service.nginz.externalTcpPort }}
+{{- if .Values.webapp.enabled }}
     - host: {{ .Values.config.dns.webapp }}
       http:
         paths:
@@ -46,6 +47,8 @@ spec:
             backend:
               serviceName: webapp-http
               servicePort: {{ .Values.service.webapp.externalPort }}
+{{- end }}
+{{- if .Values.fakeS3.enabled }}
     - host: {{ .Values.config.dns.fakeS3 }}
       http:
         paths:
@@ -53,6 +56,7 @@ spec:
             backend:
               serviceName: {{ .Values.service.s3.serviceName }}
               servicePort: {{ .Values.service.s3.externalPort }}
+{{- end }}
 {{- if .Values.teamSettings.enabled }}
     - host: {{ .Values.config.dns.teamSettings }}
       http:

--- a/charts/nginx-ingress-services/templates/issuer.yaml
+++ b/charts/nginx-ingress-services/templates/issuer.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.tls.createIssuer -}}
-{{- if and .Values.tls.enabled .Values.tls.useCertManager -}}
+{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.tls.createIssuer -}}
 apiVersion: cert-manager.io/v1
 {{- if or (eq .Values.tls.issuer.kind "Issuer") (eq .Values.tls.issuer.kind "ClusterIssuer") }}
 kind: "{{ .Values.tls.issuer.kind }}"
@@ -30,5 +29,4 @@ spec:
           ingress:
             class: nginx
 {{- end }}
-{{- end -}}
 {{- end -}}

--- a/charts/nginx-ingress-services/templates/issuer.yaml
+++ b/charts/nginx-ingress-services/templates/issuer.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tls.createIssuer -}}
 {{- if and .Values.tls.enabled .Values.tls.useCertManager -}}
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
@@ -23,4 +24,5 @@ spec:
           ingress:
             class: nginx
 {{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/nginx-ingress-services/templates/issuer.yaml
+++ b/charts/nginx-ingress-services/templates/issuer.yaml
@@ -1,10 +1,16 @@
 {{- if .Values.tls.createIssuer -}}
 {{- if and .Values.tls.enabled .Values.tls.useCertManager -}}
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
+apiVersion: cert-manager.io/v1
+{{- if or (eq .Values.tls.issuer.kind "Issuer") (eq .Values.tls.issuer.kind "ClusterIssuer") }}
+kind: "{{ .Values.tls.issuer.kind }}"
+{{- else }}
+{{- fail (cat ".tls.issuer.kind can only be one of Issuer or ClusterIssuer, got: " .tls.issuer.kind )}}
+{{- end }}
 metadata:
-  name: letsencrypt-http01
+  name: {{ .Values.tls.issuer.name }}
+  {{- if eq .Values.tls.issuer.kind "Issuer" }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"

--- a/charts/nginx-ingress-services/templates/service.yaml
+++ b/charts/nginx-ingress-services/templates/service.yaml
@@ -1,3 +1,4 @@
+# FUTUREWORK: move services into the respective charts
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,6 +22,7 @@ spec:
       targetPort: 8081
   selector:
     wireService: nginz
+{{- if .Values.webapp.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -33,6 +35,7 @@ spec:
       targetPort: 8080
   selector:
     wireService: webapp
+{{- end }}
 {{- if not .Values.service.s3.externallyCreated }}
 ---
 apiVersion: v1

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -26,6 +26,7 @@ federator:
 # for an example)
 tls:
   enabled: true
+  createIssuer: true
   # NOTE:
   #  (1) enables automated certificate renewal provided by https://github.com/jetstack/cert-manager
   #  (2) supersedes wildcard certificate configuration mentioned above

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -6,6 +6,10 @@ teamSettings:
 # Account pages may be useful to enable password reset or email validation done after the initial registration
 accountPages:
   enabled: false
+webapp:
+  enabled: true
+fakeS3:
+  enabled: true
 federator:
   enabled: false
   integrationTestHelper: false
@@ -90,7 +94,9 @@ service:
 #     https: nginz-https.<domain>
 #     ssl: nginz-ssl.<domain>
 #     webapp: webapp.<domain>
+#     ^ webapp is ignored if webapp.enabled == false
 #     fakeS3: assets.<domain>
+#     ^ fakeS3 is ignored if fakeS3.enabled == false
 #     federator: federator.<domain>
 #     ^ federator is ignored unless federator.enabled == true
 #     teamSettings: teams.<domain>

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -26,7 +26,6 @@ federator:
 # for an example)
 tls:
   enabled: true
-  createIssuer: true
   # NOTE:
   #  (1) enables automated certificate renewal provided by https://github.com/jetstack/cert-manager
   #  (2) supersedes wildcard certificate configuration mentioned above
@@ -36,6 +35,10 @@ tls:
   useCertManager: false
   # the validation depth between a federator client certificate and tlsClientCA
   verify_depth: 1
+  issuer:
+    create: true
+    name: letsencrypt-http01
+    kind: Issuer # Issuer | ClusterIssuer
 
 certManager:
   # Indicates whether Letsencrypt's staging API server is used and therefore certificates are NOT trusted


### PR DESCRIPTION
charts/nginx-ingress-services: 

* Allow more fine-grained control over what services are installed. (e.g. allow webapp/fakeS3 to not be installed, and federator dns name to not be set if not using federator)
* Upgrade Certificate/Issuer resources: If using [cert-manager](https://github.com/cert-manager/cert-manager), you need to have least version 1.0.0 installed (0.15.X will no longer work).

Related to https://github.com/zinfra/cailleach/pull/1079

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):