### PR TITLE
SQSERVICES-1530 view and change team feature permission not by individual feature

### DIFF
--- a/changelog.d/5-internal/SQSERVICES-1530
+++ b/changelog.d/5-internal/SQSERVICES-1530
@@ -1,0 +1,1 @@
+View and change team feature permissions apply to all features now

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -362,8 +362,8 @@ data HiddenPerm
   = ChangeLegalHoldTeamSettings
   | ChangeLegalHoldUserSettings
   | ViewLegalHoldUserSettings
-  | ViewTeamFeature TeamFeatureName
-  | ChangeTeamFeature TeamFeatureName
+  | ViewTeamFeature
+  | ChangeTeamFeature
   | ChangeTeamSearchVisibility
   | ViewTeamSearchVisibility
   | ViewSameTeamEmails
@@ -398,13 +398,7 @@ roleHiddenPermissions role = HiddenPermissions p p
           [ ChangeLegalHoldTeamSettings,
             ChangeLegalHoldUserSettings,
             ChangeTeamSearchVisibility,
-            ChangeTeamFeature TeamFeatureAppLock,
-            ChangeTeamFeature TeamFeatureFileSharing,
-            ChangeTeamFeature TeamFeatureClassifiedDomains {- the features not listed here can only be changed in stern -},
-            ChangeTeamFeature TeamFeatureSelfDeletingMessages,
-            ChangeTeamFeature TeamFeatureGuestLinks,
-            ChangeTeamFeature TeamFeatureSndFactorPasswordChallenge,
-            ChangeTeamFeature TeamFeatureSearchVisibilityInbound,
+            ChangeTeamFeature,
             ChangeTeamMemberProfiles,
             ReadIdp,
             CreateUpdateDeleteIdp,
@@ -416,18 +410,7 @@ roleHiddenPermissions role = HiddenPermissions p p
         Set.fromList [ViewSameTeamEmails]
     roleHiddenPerms RoleExternalPartner =
       Set.fromList
-        [ ViewTeamFeature TeamFeatureLegalHold,
-          ViewTeamFeature TeamFeatureSSO,
-          ViewTeamFeature TeamFeatureSearchVisibility,
-          ViewTeamFeature TeamFeatureValidateSAMLEmails,
-          ViewTeamFeature TeamFeatureDigitalSignatures,
-          ViewTeamFeature TeamFeatureAppLock,
-          ViewTeamFeature TeamFeatureFileSharing,
-          ViewTeamFeature TeamFeatureClassifiedDomains,
-          ViewTeamFeature TeamFeatureConferenceCalling,
-          ViewTeamFeature TeamFeatureSelfDeletingMessages,
-          ViewTeamFeature TeamFeatureGuestLinks,
-          ViewTeamFeature TeamFeatureSndFactorPasswordChallenge,
+        [ ViewTeamFeature,
           ViewLegalHoldUserSettings,
           ViewTeamSearchVisibility
         ]

--- a/libs/galley-types/test/unit/Test/Galley/Types.hs
+++ b/libs/galley-types/test/unit/Test/Galley/Types.hs
@@ -22,7 +22,6 @@
 module Test.Galley.Types where
 
 import Control.Lens
-import qualified Data.List as List
 import Data.Set hiding (drop)
 import qualified Data.Set as Set
 import Galley.Types.Teams
@@ -33,7 +32,6 @@ import qualified Test.QuickCheck as QC
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
-import Wire.API.Team.Feature (TeamFeatureName (TeamFeatureSearchVisibilityInbound))
 
 tests :: TestTree
 tests =
@@ -48,15 +46,6 @@ tests =
           \(r1, r2) -> do
             assertBool "owner.self" ((rolePermissions r2 ^. self) `isSubsetOf` (rolePermissions r1 ^. self))
             assertBool "owner.copy" ((rolePermissions r2 ^. copy) `isSubsetOf` (rolePermissions r1 ^. copy)),
-      testCase "permissions for viewing feature flags" $
-        -- We currently (at the time of writing this test) grant view permissions for all
-        -- 'TeamFeatureName's to all roles.  If we add more features in the future and forget to
-        -- add them, this test will fail, and remind us that there we should consider adding.
-        -- If you want to handle view permissions for future features differntly, adopt the test
-        -- accordingly.  Just maintain the property that adding a new feature name will break
-        -- this test, and force future develpers to consider what permissions they want to set.
-        let viewableFeatures = List.filter (/= TeamFeatureSearchVisibilityInbound) [minBound ..]
-         in assertBool "all covered" (all (roleHasPerm RoleExternalPartner) (ViewTeamFeature <$> viewableFeatures)),
       testRoundTrip @FeatureFlags,
       testRoundTrip @GuardLegalholdPolicyConflicts,
       testGroup

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -161,7 +161,7 @@ getSettings ::
 getSettings lzusr tid = do
   let zusr = tUnqualified lzusr
   zusrMembership <- getTeamMember tid zusr
-  void $ permissionCheck (ViewTeamFeature Public.TeamFeatureLegalHold) zusrMembership
+  void $ permissionCheck ViewTeamFeature zusrMembership
   isenabled <- isLegalHoldEnabledForTeam tid
   mresult <- LegalHoldData.getSettings tid
   pure $ case (isenabled, mresult) of

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -137,7 +137,7 @@ getFeatureStatus (Tagged getter) doauth tid = do
   case doauth of
     DoAuth uid -> do
       zusrMembership <- getTeamMember tid uid
-      void $ permissionCheck (ViewTeamFeature (knownTeamFeatureName @a)) zusrMembership
+      void $ permissionCheck ViewTeamFeature zusrMembership
     DontDoAuth ->
       assertTeamExists tid
   getter (Right tid)
@@ -165,7 +165,7 @@ setFeatureStatus (Tagged setter) doauth tid status = do
   case doauth of
     DoAuth uid -> do
       zusrMembership <- getTeamMember tid uid
-      void $ permissionCheck (ChangeTeamFeature (knownTeamFeatureName @a)) zusrMembership
+      void $ permissionCheck ChangeTeamFeature zusrMembership
     DontDoAuth ->
       assertTeamExists tid
   setter tid status
@@ -211,7 +211,7 @@ getFeatureConfig (Tagged getter) zusr = do
     Nothing -> getter (Left (Just zusr))
     Just tid -> do
       zusrMembership <- getTeamMember tid zusr
-      void $ permissionCheck (ViewTeamFeature (knownTeamFeatureName @a)) zusrMembership
+      void $ permissionCheck ViewTeamFeature zusrMembership
       assertTeamExists tid
       getter (Right tid)
 
@@ -241,7 +241,7 @@ getAllFeatureConfigs zusr = do
         Sem r (Aeson.Key, Aeson.Value)
       getStatus (Tagged getter) = do
         when (isJust mbTeam) $ do
-          void $ permissionCheck (ViewTeamFeature (knownTeamFeatureName @a)) zusrMembership
+          void $ permissionCheck ViewTeamFeature zusrMembership
         status <- getter (maybe (Left (Just zusr)) Right mbTeam)
         let feature = knownTeamFeatureName @a
         pure $ AesonKey.fromText (cs (toByteString' feature)) Aeson..= status


### PR DESCRIPTION
## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
