### PR TITLE
SQSERVICES-1560-more-canonical-handling-of-hard-wired-defaults-type-class-have-defaults-for-all-features

### DIFF
--- a/changelog.d/5-internal/SQSERVICES-1560
+++ b/changelog.d/5-internal/SQSERVICES-1560
@@ -1,0 +1,1 @@
+Type class for default team feature status

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -270,15 +270,15 @@ instance FromJSON FeatureFlags where
       <$> obj .: "sso"
       <*> obj .: "legalhold"
       <*> obj .: "teamSearchVisibility"
-      <*> (fromMaybe (Defaults defaultAppLockStatus) <$> (obj .:? "appLock"))
-      <*> (fromMaybe defaultClassifiedDomains <$> (obj .:? "classifiedDomains"))
-      <*> (fromMaybe (Defaults defaultTeamFeatureFileSharing) <$> (obj .:? "fileSharing"))
-      <*> (fromMaybe (Defaults (TeamFeatureStatusNoConfig TeamFeatureEnabled)) <$> (obj .:? "conferenceCalling"))
-      <*> (fromMaybe (Defaults defaultSelfDeletingMessagesStatus) <$> (obj .:? "selfDeletingMessages"))
-      <*> (fromMaybe (Defaults defaultGuestLinksStatus) <$> (obj .:? "conversationGuestLinks"))
-      <*> (fromMaybe (Defaults defaultTeamFeatureValidateSAMLEmailsStatus) <$> (obj .:? "validateSAMLEmails"))
-      <*> (fromMaybe (Defaults defaultTeamFeatureSndFactorPasswordChallengeStatus) <$> (obj .:? "sndFactorPasswordChallenge"))
-      <*> (fromMaybe (Defaults defaultTeamFeatureSearchVisibilityInbound) <$> (obj .:? "searchVisibilityInbound"))
+      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureAppLock)) <$> (obj .:? "appLock"))
+      <*> (fromMaybe (defTeamFeatureStatus @'TeamFeatureClassifiedDomains) <$> (obj .:? "classifiedDomains"))
+      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureFileSharing)) <$> (obj .:? "fileSharing"))
+      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureConferenceCalling)) <$> (obj .:? "conferenceCalling"))
+      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureSelfDeletingMessages)) <$> (obj .:? "selfDeletingMessages"))
+      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureGuestLinks)) <$> (obj .:? "conversationGuestLinks"))
+      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureValidateSAMLEmails)) <$> (obj .:? "validateSAMLEmails"))
+      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureSndFactorPasswordChallenge)) <$> (obj .:? "sndFactorPasswordChallenge"))
+      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureSearchVisibilityInbound)) <$> (obj .:? "searchVisibilityInbound"))
 
 instance ToJSON FeatureFlags where
   toJSON

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -37,7 +37,7 @@ module Wire.API.Team.Feature
     LockStatus (..),
     LockStatusValue (..),
     IncludeLockStatus (..),
-    TeamFeatureDefaults (..),
+    DefTeamFeatureStatus (..),
 
     -- * Swagger
     typeTeamFeatureName,
@@ -653,44 +653,44 @@ instance Cass.Cql LockStatusValue where
 ----------------------------------------------------------------------
 -- defaults
 
-class TeamFeatureDefaults (a :: TeamFeatureName) where
+class DefTeamFeatureStatus (a :: TeamFeatureName) where
   defTeamFeatureStatus :: TeamFeatureStatus 'WithLockStatus a
 
-instance TeamFeatureDefaults 'TeamFeatureGuestLinks where
+instance DefTeamFeatureStatus 'TeamFeatureGuestLinks where
   defTeamFeatureStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Unlocked
 
-instance TeamFeatureDefaults 'TeamFeatureValidateSAMLEmails where
+instance DefTeamFeatureStatus 'TeamFeatureValidateSAMLEmails where
   defTeamFeatureStatus = TeamFeatureStatusNoConfig TeamFeatureEnabled
 
-instance TeamFeatureDefaults 'TeamFeatureSndFactorPasswordChallenge where
+instance DefTeamFeatureStatus 'TeamFeatureSndFactorPasswordChallenge where
   defTeamFeatureStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureDisabled Locked
 
-instance TeamFeatureDefaults 'TeamFeatureSearchVisibilityInbound where
+instance DefTeamFeatureStatus 'TeamFeatureSearchVisibilityInbound where
   defTeamFeatureStatus = TeamFeatureStatusNoConfig TeamFeatureDisabled
 
-instance TeamFeatureDefaults 'TeamFeatureFileSharing where
+instance DefTeamFeatureStatus 'TeamFeatureFileSharing where
   defTeamFeatureStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Unlocked
 
-instance TeamFeatureDefaults 'TeamFeatureSelfDeletingMessages where
+instance DefTeamFeatureStatus 'TeamFeatureSelfDeletingMessages where
   defTeamFeatureStatus =
     TeamFeatureStatusWithConfigAndLockStatus
       TeamFeatureEnabled
       (TeamFeatureSelfDeletingMessagesConfig 0)
       Unlocked
 
-instance TeamFeatureDefaults 'TeamFeatureClassifiedDomains where
+instance DefTeamFeatureStatus 'TeamFeatureClassifiedDomains where
   defTeamFeatureStatus =
     TeamFeatureStatusWithConfig
       TeamFeatureDisabled
       (TeamFeatureClassifiedDomainsConfig [])
 
-instance TeamFeatureDefaults 'TeamFeatureAppLock where
+instance DefTeamFeatureStatus 'TeamFeatureAppLock where
   defTeamFeatureStatus =
     TeamFeatureStatusWithConfig
       TeamFeatureEnabled
       (TeamFeatureAppLockConfig (EnforceAppLock False) 60)
 
-instance TeamFeatureDefaults 'TeamFeatureConferenceCalling where
+instance DefTeamFeatureStatus 'TeamFeatureConferenceCalling where
   defTeamFeatureStatus = TeamFeatureStatusNoConfig TeamFeatureEnabled
 
 ----------------------------------------------------------------------

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -37,14 +37,7 @@ module Wire.API.Team.Feature
     LockStatus (..),
     LockStatusValue (..),
     IncludeLockStatus (..),
-    defaultAppLockStatus,
-    defaultClassifiedDomains,
-    defaultSelfDeletingMessagesStatus,
-    defaultGuestLinksStatus,
-    defaultTeamFeatureFileSharing,
-    defaultTeamFeatureValidateSAMLEmailsStatus,
-    defaultTeamFeatureSndFactorPasswordChallengeStatus,
-    defaultTeamFeatureSearchVisibilityInbound,
+    TeamFeatureDefaults (..),
 
     -- * Swagger
     typeTeamFeatureName,
@@ -512,13 +505,6 @@ instance ToSchema cfg => ToSchema (TeamFeatureStatusWithConfigAndLockStatus cfg)
         <*> tfwcapsLockStatus .= field "lockStatus" schema
 
 ----------------------------------------------------------------------
--- TeamFeatureFileSharing
-
-defaultTeamFeatureFileSharing :: TeamFeatureStatusNoConfigAndLockStatus
-defaultTeamFeatureFileSharing =
-  TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Unlocked
-
-----------------------------------------------------------------------
 -- TeamFeatureClassifiedDomainsConfig
 
 newtype TeamFeatureClassifiedDomainsConfig = TeamFeatureClassifiedDomainsConfig
@@ -539,12 +525,6 @@ modelTeamFeatureClassifiedDomainsConfig :: Doc.Model
 modelTeamFeatureClassifiedDomainsConfig =
   Doc.defineModel "TeamFeatureClassifiedDomainsConfig" $ do
     Doc.property "domains" (Doc.array Doc.string') $ Doc.description "domains"
-
-defaultClassifiedDomains :: TeamFeatureStatusWithConfig TeamFeatureClassifiedDomainsConfig
-defaultClassifiedDomains =
-  TeamFeatureStatusWithConfig
-    TeamFeatureDisabled
-    (TeamFeatureClassifiedDomainsConfig [])
 
 ----------------------------------------------------------------------
 -- TeamFeatureAppLockConfig
@@ -579,12 +559,6 @@ modelTeamFeatureAppLockConfig =
     Doc.property "enforceAppLock" Doc.bool' $ Doc.description "enforceAppLock"
     Doc.property "inactivityTimeoutSecs" Doc.int32' $ Doc.description ""
 
-defaultAppLockStatus :: TeamFeatureStatusWithConfig TeamFeatureAppLockConfig
-defaultAppLockStatus =
-  TeamFeatureStatusWithConfig
-    TeamFeatureEnabled
-    (TeamFeatureAppLockConfig (EnforceAppLock False) 60)
-
 ----------------------------------------------------------------------
 -- TeamFeatureSelfDeletingMessagesConfig
 
@@ -605,13 +579,6 @@ modelTeamFeatureSelfDeletingMessagesConfig :: Doc.Model
 modelTeamFeatureSelfDeletingMessagesConfig =
   Doc.defineModel "TeamFeatureSelfDeletingMessagesConfig" $ do
     Doc.property "enforcedTimeoutSeconds" Doc.int32' $ Doc.description "optional; default: `0` (no enforcement)"
-
-defaultSelfDeletingMessagesStatus :: TeamFeatureStatusWithConfigAndLockStatus TeamFeatureSelfDeletingMessagesConfig
-defaultSelfDeletingMessagesStatus =
-  TeamFeatureStatusWithConfigAndLockStatus
-    TeamFeatureEnabled
-    (TeamFeatureSelfDeletingMessagesConfig 0)
-    Unlocked
 
 ----------------------------------------------------------------------
 -- LockStatus
@@ -684,28 +651,47 @@ instance Cass.Cql LockStatusValue where
   toCql Unlocked = Cass.CqlInt 1
 
 ----------------------------------------------------------------------
--- guest links
+-- defaults
 
-defaultGuestLinksStatus :: TeamFeatureStatusNoConfigAndLockStatus
-defaultGuestLinksStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Unlocked
+class TeamFeatureDefaults (a :: TeamFeatureName) where
+  defTeamFeatureStatus :: TeamFeatureStatus 'WithLockStatus a
 
-----------------------------------------------------------------------
--- TeamFeatureValidateSAMLEmails
+instance TeamFeatureDefaults 'TeamFeatureGuestLinks where
+  defTeamFeatureStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Unlocked
 
-defaultTeamFeatureValidateSAMLEmailsStatus :: TeamFeatureStatusNoConfig
-defaultTeamFeatureValidateSAMLEmailsStatus = TeamFeatureStatusNoConfig TeamFeatureEnabled
+instance TeamFeatureDefaults 'TeamFeatureValidateSAMLEmails where
+  defTeamFeatureStatus = TeamFeatureStatusNoConfig TeamFeatureEnabled
 
-----------------------------------------------------------------------
--- TeamFeatureSndFactorPasswordChallenge
+instance TeamFeatureDefaults 'TeamFeatureSndFactorPasswordChallenge where
+  defTeamFeatureStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureDisabled Locked
 
-defaultTeamFeatureSndFactorPasswordChallengeStatus :: TeamFeatureStatusNoConfigAndLockStatus
-defaultTeamFeatureSndFactorPasswordChallengeStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureDisabled Locked
+instance TeamFeatureDefaults 'TeamFeatureSearchVisibilityInbound where
+  defTeamFeatureStatus = TeamFeatureStatusNoConfig TeamFeatureDisabled
 
-----------------------------------------------------------------------
--- TeamFeatureSearchVisibilityInbound
+instance TeamFeatureDefaults 'TeamFeatureFileSharing where
+  defTeamFeatureStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Unlocked
 
-defaultTeamFeatureSearchVisibilityInbound :: TeamFeatureStatusNoConfig
-defaultTeamFeatureSearchVisibilityInbound = TeamFeatureStatusNoConfig TeamFeatureDisabled
+instance TeamFeatureDefaults 'TeamFeatureSelfDeletingMessages where
+  defTeamFeatureStatus =
+    TeamFeatureStatusWithConfigAndLockStatus
+      TeamFeatureEnabled
+      (TeamFeatureSelfDeletingMessagesConfig 0)
+      Unlocked
+
+instance TeamFeatureDefaults 'TeamFeatureClassifiedDomains where
+  defTeamFeatureStatus =
+    TeamFeatureStatusWithConfig
+      TeamFeatureDisabled
+      (TeamFeatureClassifiedDomainsConfig [])
+
+instance TeamFeatureDefaults 'TeamFeatureAppLock where
+  defTeamFeatureStatus =
+    TeamFeatureStatusWithConfig
+      TeamFeatureEnabled
+      (TeamFeatureAppLockConfig (EnforceAppLock False) 60)
+
+instance TeamFeatureDefaults 'TeamFeatureConferenceCalling where
+  defTeamFeatureStatus = TeamFeatureStatusNoConfig TeamFeatureEnabled
 
 ----------------------------------------------------------------------
 -- internal

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -196,7 +196,7 @@ verifyCode mbCode action uid = do
   (mbEmail, mbTeamId) <- getEmailAndTeamId uid
   featureEnabled <- lift $ do
     mbFeatureEnabled <- Intra.getVerificationCodeEnabled `traverse` mbTeamId
-    pure $ fromMaybe (Public.tfwoapsStatus Public.defaultTeamFeatureSndFactorPasswordChallengeStatus == Public.TeamFeatureEnabled) mbFeatureEnabled
+    pure $ fromMaybe (Public.tfwoapsStatus (Public.defTeamFeatureStatus @'Public.TeamFeatureSndFactorPasswordChallenge) == Public.TeamFeatureEnabled) mbFeatureEnabled
   when featureEnabled $ do
     case (mbCode, mbEmail) of
       (Just code, Just email) -> do

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -575,7 +575,7 @@ getClassifiedDomainsInternal = Tagged . const $ do
   globalConfig <- inputs (view (optSettings . setFeatureFlags . flagClassifiedDomains))
   let config = globalConfig
   pure $ case tfwcStatus config of
-    TeamFeatureDisabled -> defaultClassifiedDomains
+    TeamFeatureDisabled -> defTeamFeatureStatus @'TeamFeatureClassifiedDomains
     TeamFeatureEnabled -> config
 
 getConferenceCallingInternal ::


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1560

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.