### PR TITLE
charts/brig: Support running brig with GeoIP database

### DIFF
--- a/changelog.d/2-features/chart-brig-geoip
+++ b/changelog.d/2-features/chart-brig-geoip
@@ -1,0 +1,1 @@
+* Support running brig with GeoIP database when using helm charts

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -202,7 +202,7 @@ data:
     {{- end }}
     {{- end }}
 
-    {{- if .Values.geoip.enabled }}
+    {{- if .geoip.enabled }}
     # Shared emptyDir with geoipupdate container
     geoDb: /usr/share/GeoIP/GeoIP2-City.mmdb
     {{- end }}

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -202,7 +202,7 @@ data:
     {{- end }}
     {{- end }}
 
-    {{- if .Values.geoip.enable }}
+    {{- if .Values.geoip.enabled }}
     # Shared emptyDir with geoipupdate container
     geoDb: /usr/share/GeoIP/GeoIP2-City.mmdb
     {{- end }}

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -202,6 +202,11 @@ data:
     {{- end }}
     {{- end }}
 
+    {{- if .Values.geoip.enable }}
+    # Shared emptyDir with geoipupdate container
+    geoDb: /usr/share/GeoIP/GeoIP2-City.mmdb
+    {{- end }}
+
     {{- with .optSettings }}
     optSettings:
       setActivationTimeout: {{ .setActivationTimeout }}

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -42,6 +42,51 @@ spec:
         - name: "brig-secrets"
           secret:
             secretName: "brig"
+        {{- if .Values.geoip.enable }}
+        - name: "geoip"
+          emptyDir: {}
+        {{- end }}
+      {{- if .Values.geoip.enable }}
+      # Brig needs GeoIP database to be downloaded before it can start.
+      initContainers:
+        - name: geoipdownload
+          image: "{{ .Values.geoip.image.repository }}:{{ .Values.geoip.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.geoip.imagePullPolicy | quote }}
+          volumeMounts:
+          - name: "geoip"
+            mountPath: "/usr/share/GeoIP"
+          env:
+          - name: GEOIPUPDATE_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: brig-geoip
+                key: accountId
+          - name: GEOIPUPDATE_LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: brig-geoip
+                key: licenseKey
+          - name: GEOIPUPDATE_EDITION_IDS
+            valueFrom:
+              secretKeyRef:
+                name: brig-geoip
+                key: editionIds
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              conf_file=$(mktemp)
+
+              cat <<EOF > "$conf_file"
+              AccountID $GEOIPUPDATE_ACCOUNT_ID
+              LicenseKey $GEOIPUPDATE_LICENSE_KEY
+              EditionIDs $GEOIPUPDATE_EDITION_IDS
+              EOF
+
+              geoipupdate -d /usr/share/GeoIP -f "$conf_file"
+      {{- end }}
       containers:
         - name: brig
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -54,6 +99,10 @@ spec:
           {{- if eq $.Values.turn.serversSource "files" }}
           - name: "turn-servers"
             mountPath: "/etc/wire/brig/turn"
+          {{- end }}
+          {{- if .Values.geoip.enable }}
+          - name: "geoip"
+            mountPath: "/usr/share/GeoIP"
           {{- end }}
           env:
           - name: LOG_LEVEL
@@ -107,3 +156,27 @@ spec:
               port: {{ .Values.service.internalPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+        {{- if .Values.geoip.enable }}
+        - name: geoipupdate
+          image: "{{ .Values.geoip.image.repository }}:{{ .Values.geoip.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.geoip.imagePullPolicy | quote }}
+          volumeMounts:
+          - name: "geoip"
+            mountPath: "/usr/share/GeoIP"
+          env:
+          - name: GEOIPUPDATE_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: brig-geoip
+                key: accountId
+          - name: GEOIPUPDATE_LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: brig-geoip
+                key: licenseKey
+          - name: GEOIPUPDATE_EDITION_IDS
+            valueFrom:
+              secretKeyRef:
+                name: brig-geoip
+                key: editionIds
+        {{- end }}

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
                 name: brig-geoip
                 key: editionIds
           - name: GEOIPUPDATE_FREQUENCY
-            value: 0 # Setting this to 0 makes the script only run geoipupdate once.
+            value: "0" # Setting this to 0 makes the script only run geoipupdate once.
       {{- end }}
       containers:
         - name: brig
@@ -171,5 +171,5 @@ spec:
                 name: brig-geoip
                 key: editionIds
           - name: GEOIPUPDATE_FREQUENCY
-            value: 24 # hours
+            value: "24" # hours
         {{- end }}

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
           volumeMounts:
           - name: "geoip"
             mountPath: "/usr/share/GeoIP"
+          # The environment variables are documented at:
+          # https://github.com/maxmind/geoipupdate/blob/62b34e648a842dc03ccf4ad3f61e2d85eaec98fc/doc/docker.md
           env:
           - name: GEOIPUPDATE_ACCOUNT_ID
             valueFrom:
@@ -72,7 +74,7 @@ spec:
                 name: brig-geoip
                 key: editionIds
           - name: GEOIPUPDATE_FREQUENCY
-            value: 0 # Setting this to 0 makes the script only update it once.
+            value: 0 # Setting this to 0 makes the script only run geoipupdate once.
       {{- end }}
       containers:
         - name: brig
@@ -150,6 +152,8 @@ spec:
           volumeMounts:
           - name: "geoip"
             mountPath: "/usr/share/GeoIP"
+          # The environment variables are documented at:
+          # https://github.com/maxmind/geoipupdate/blob/62b34e648a842dc03ccf4ad3f61e2d85eaec98fc/doc/docker.md
           env:
           - name: GEOIPUPDATE_ACCOUNT_ID
             valueFrom:

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -42,11 +42,11 @@ spec:
         - name: "brig-secrets"
           secret:
             secretName: "brig"
-        {{- if .Values.geoip.enable }}
+        {{- if .Values.geoip.enabled }}
         - name: "geoip"
           emptyDir: {}
         {{- end }}
-      {{- if .Values.geoip.enable }}
+      {{- if .Values.geoip.enabled }}
       # Brig needs GeoIP database to be downloaded before it can start.
       initContainers:
         - name: geoipdownload
@@ -89,7 +89,7 @@ spec:
           - name: "turn-servers"
             mountPath: "/etc/wire/brig/turn"
           {{- end }}
-          {{- if .Values.geoip.enable }}
+          {{- if .Values.geoip.enabled }}
           - name: "geoip"
             mountPath: "/usr/share/GeoIP"
           {{- end }}
@@ -145,7 +145,7 @@ spec:
               port: {{ .Values.service.internalPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-        {{- if .Values.geoip.enable }}
+        {{- if .Values.geoip.enabled }}
         - name: geoipupdate
           image: "{{ .Values.geoip.image.repository }}:{{ .Values.geoip.image.tag }}"
           imagePullPolicy: {{ default "" .Values.geoip.imagePullPolicy | quote }}

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -71,21 +71,8 @@ spec:
               secretKeyRef:
                 name: brig-geoip
                 key: editionIds
-          command:
-            - /bin/sh
-            - -c
-            - |
-              set -eu
-
-              conf_file=$(mktemp)
-
-              cat <<EOF > "$conf_file"
-              AccountID $GEOIPUPDATE_ACCOUNT_ID
-              LicenseKey $GEOIPUPDATE_LICENSE_KEY
-              EditionIDs $GEOIPUPDATE_EDITION_IDS
-              EOF
-
-              geoipupdate -d /usr/share/GeoIP -f "$conf_file"
+          - name: GEOIPUPDATE_FREQUENCY
+            value: 0 # Setting this to 0 makes the script only update it once.
       {{- end }}
       containers:
         - name: brig
@@ -179,4 +166,6 @@ spec:
               secretKeyRef:
                 name: brig-geoip
                 key: editionIds
+          - name: GEOIPUPDATE_FREQUENCY
+            value: 24 # hours
         {{- end }}

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -42,16 +42,16 @@ spec:
         - name: "brig-secrets"
           secret:
             secretName: "brig"
-        {{- if .Values.geoip.enabled }}
+        {{- if .Values.config.geoip.enabled }}
         - name: "geoip"
           emptyDir: {}
         {{- end }}
-      {{- if .Values.geoip.enabled }}
+      {{- if .Values.config.geoip.enabled }}
       # Brig needs GeoIP database to be downloaded before it can start.
       initContainers:
         - name: geoipdownload
-          image: "{{ .Values.geoip.image.repository }}:{{ .Values.geoip.image.tag }}"
-          imagePullPolicy: {{ default "" .Values.geoip.imagePullPolicy | quote }}
+          image: "{{ .Values.config.geoip.image.repository }}:{{ .Values.config.geoip.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.config.geoip.imagePullPolicy | quote }}
           volumeMounts:
           - name: "geoip"
             mountPath: "/usr/share/GeoIP"
@@ -89,7 +89,7 @@ spec:
           - name: "turn-servers"
             mountPath: "/etc/wire/brig/turn"
           {{- end }}
-          {{- if .Values.geoip.enabled }}
+          {{- if .Values.config.geoip.enabled }}
           - name: "geoip"
             mountPath: "/usr/share/GeoIP"
           {{- end }}
@@ -145,10 +145,10 @@ spec:
               port: {{ .Values.service.internalPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-        {{- if .Values.geoip.enabled }}
+        {{- if .Values.config.geoip.enabled }}
         - name: geoipupdate
-          image: "{{ .Values.geoip.image.repository }}:{{ .Values.geoip.image.tag }}"
-          imagePullPolicy: {{ default "" .Values.geoip.imagePullPolicy | quote }}
+          image: "{{ .Values.config.geoip.image.repository }}:{{ .Values.config.geoip.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.config.geoip.imagePullPolicy | quote }}
           volumeMounts:
           - name: "geoip"
             mountPath: "/usr/share/GeoIP"

--- a/charts/brig/templates/geoip-secret.yaml
+++ b/charts/brig/templates/geoip-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.geoip.enabled }}
+{{- if .Values.config.geoip.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,8 +11,8 @@ metadata:
 type: Opaque
 data:
   {{- with .Values.secrets.geoip }}
-  accountId: {{ required ".secrets.geoip.accountId must be provided when .Values.geoip.enabled is True" .accountId | quote }}
-  licenseKey: {{ required ".secrets.geoip.licenseKey must be provided when .Values.geoip.enabled is True" .licenseKey | quote }}
-  editionIds: {{ required ".secrets.geoip.editionIds must be provided when .Values.geoip.enabled is True" .editionIds | quote }}
+  accountId: {{ required ".secrets.geoip.accountId must be provided when .Values.config.geoip.enabled is True" .accountId | b64enc | quote }}
+  licenseKey: {{ required ".secrets.geoip.licenseKey must be provided when .Values.config.geoip.enabled is True" .licenseKey | b64enc | quote }}
+  editionIds: {{ required ".secrets.geoip.editionIds must be provided when .Values.config.geoip.enabled is True" .editionIds | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/brig/templates/geoip-secret.yaml
+++ b/charts/brig/templates/geoip-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.geoip.enable }}
+{{- if .Values.geoip.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,8 +11,8 @@ metadata:
 type: Opaque
 data:
   {{- with .Values.secrets.geoip }}
-  accountId: {{ required ".secrets.geoip.accountId must be provided when .Values.geoip.enable is True" .accountId | quote }}
-  licenseKey: {{ required ".secrets.geoip.licenseKey must be provided when .Values.geoip.enable is True" .licenseKey | quote }}
-  editionIds: {{ required ".secrets.geoip.editionIds must be provided when .Values.geoip.enable is True" .editionIds | quote }}
+  accountId: {{ required ".secrets.geoip.accountId must be provided when .Values.geoip.enabled is True" .accountId | quote }}
+  licenseKey: {{ required ".secrets.geoip.licenseKey must be provided when .Values.geoip.enabled is True" .licenseKey | quote }}
+  editionIds: {{ required ".secrets.geoip.editionIds must be provided when .Values.geoip.enabled is True" .editionIds | quote }}
   {{- end }}
 {{- end }}

--- a/charts/brig/templates/geoip-secret.yaml
+++ b/charts/brig/templates/geoip-secret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.geoip.enable }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: brig-geoip
+  labels:
+    wireService: brig
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{- with .Values.secrets.geoip }}
+  accountId: {{ required ".secrets.geoip.accountId must be provided when .Values.geoip.enable is True" .accountId | quote }}
+  licenseKey: {{ required ".secrets.geoip.licenseKey must be provided when .Values.geoip.enable is True" .licenseKey | quote }}
+  editionIds: {{ required ".secrets.geoip.editionIds must be provided when .Values.geoip.enable is True" .editionIds | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -84,6 +84,14 @@ config:
   smtp:
     passwordFile: /etc/wire/brig/secrets/smtp-password.txt
   proxy: {}
+
+  geoip:
+    # When enabling this, .secrets.geoip.accountId, .secrets.geoip.licenseKey and
+    # .secret.geoip.editionIds must be provided.
+    enabled: false
+    image:
+      repository: docker.io/maxmindinc/geoipupdate
+      tag: v4.9
 turnStatic:
   v1:
   - turn:localhost:3478
@@ -95,14 +103,6 @@ turn:
   serversSource: files # files | dns
   # baseDomain: turn.example.com # Must be configured if serversSource is dns
   discoveryIntervalSeconds: 10 # Used only if serversSource is dns
-
-geoip:
-  # When enabling this, .secrets.geoip.accountId, .secrets.geoip.licenseKey and
-  # .secret.geoip.editionIds must be provided.
-  enabled: false
-  image:
-    repository: docker.io/maxmindinc/geoipupdate
-    tag: v4.9
 
 tests:
   enableFederationTests: false

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -96,6 +96,14 @@ turn:
   # baseDomain: turn.example.com # Must be configured if serversSource is dns
   discoveryIntervalSeconds: 10 # Used only if serversSource is dns
 
+geoip:
+  # When enabling this, .secrets.geoip.accountId, .secrets.geoip.licenseKey and
+  # .secret.geoip.editionIds must be provided.
+  enable: false
+  image:
+    repository: docker.io/maxmindinc/geoipupdate
+    tag: v4.9
+
 tests:
   enableFederationTests: false
 serviceAccount:

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -99,7 +99,7 @@ turn:
 geoip:
   # When enabling this, .secrets.geoip.accountId, .secrets.geoip.licenseKey and
   # .secret.geoip.editionIds must be provided.
-  enable: false
+  enabled: false
   image:
     repository: docker.io/maxmindinc/geoipupdate
     tag: v4.9

--- a/hack/bin/set-chart-image-version.sh
+++ b/hack/bin/set-chart-image-version.sh
@@ -11,8 +11,8 @@ for chart in $charts
 do
 if [[ "$chart" == "nginz" ]]; then
     # nginz has a different docker tag indentation
-    sed -i "s/   tag: .*/   tag: $docker_tag/g" "$CHARTS_DIR/$chart/values.yaml"
+    sed -i "s/^    tag: .*/    tag: $docker_tag/g" "$CHARTS_DIR/$chart/values.yaml"
 else
-    sed -i "s/  tag: .*/  tag: $docker_tag/g" "$CHARTS_DIR/$chart/values.yaml"
+    sed -i "s/^  tag: .*/  tag: $docker_tag/g" "$CHARTS_DIR/$chart/values.yaml"
 fi
 done

--- a/hack/bin/set-wire-server-image-version.sh
+++ b/hack/bin/set-wire-server-image-version.sh
@@ -9,8 +9,8 @@ CHARTS_DIR="$TOP_LEVEL/.local/charts"
 charts=(brig cannon galley gundeck spar cargohold proxy cassandra-migrations elasticsearch-index federator)
 
 for chart in "${charts[@]}"; do
-    sed -i "s/  tag: .*/  tag: $target_version/g" "$CHARTS_DIR/$chart/values.yaml"
+    sed -i "s/^  tag: .*/  tag: $target_version/g" "$CHARTS_DIR/$chart/values.yaml"
 done
 
 #special case nginz
-sed -i "s/   tag: .*/   tag: $target_version/g" "$CHARTS_DIR/nginz/values.yaml"
+sed -i "s/^    tag: .*/    tag: $target_version/g" "$CHARTS_DIR/nginz/values.yaml"


### PR DESCRIPTION
This optionally allows configuring GeoIP to make IP->latitude/longitude lookups. When this is enabled, `brig` uses this during client registration to save from where a certain client was registered.

Related PR: https://github.com/zinfra/cailleach/pull/1087

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.