### PR TITLE
charts/*: drop wireService label, use app= instead, add servicemonitor support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,8 +360,8 @@ kube-integration-teardown-sans-federation:
 
 .PHONY: kube-restart-%
 kube-restart-%:
-	kubectl delete pod -n $(NAMESPACE) -l wireService=$(*)
-	kubectl delete pod -n $(NAMESPACE)-fed2 -l wireService=$(*)
+	kubectl delete pod -n $(NAMESPACE) -l app=$(*)
+	kubectl delete pod -n $(NAMESPACE)-fed2 -l app=$(*)
 
 .PHONY: latest-tag
 latest-tag:
@@ -522,8 +522,8 @@ kind-restart-nginx-ingress: .local/kind-kubeconfig
 
 kind-restart-%: .local/kind-kubeconfig
 	export KUBECONFIG=$(CURDIR)/.local/kind-kubeconfig && \
-	kubectl delete pod -n $(NAMESPACE) -l wireService=$(*) && \
-	kubectl delete pod -n $(NAMESPACE)-fed2 -l wireService=$(*)
+	kubectl delete pod -n $(NAMESPACE) -l app=$(*) && \
+	kubectl delete pod -n $(NAMESPACE)-fed2 -l app=$(*)
 
 # This target can be used to template a helm chart with values filled in from
 # hack/helm_vars (what CI uses) as overrrides, if available. This allows debugging helm

--- a/changelog.d/0-release-notes/wire-service-label
+++ b/changelog.d/0-release-notes/wire-service-label
@@ -1,0 +1,34 @@
+The `wireService` label has been removed.
+
+In some cases, we were already setting the `app` label too.
+
+Now we consistently use the `app` label to label different wire services.
+
+The `wire-server-metrics` chart was previously running some custom
+configuration to automatically add all payloads with a `wireService` label into
+metrics scraping.
+
+With the removal of the `wireService` label, this custom configuration has been
+removed.
+
+Instead, all services that expose metrics will now create `ServiceMonitor`
+resources, if their helm chart is applied with `metrics.serviceMonitor.enable`
+set to true.
+
+This prevents scraping agents from querying services that don't expose metrics
+at /i/metrics unnecessarily.
+
+Additionally, makes it easier to run other metric scraping operators, like
+`grafana-agent-operator`, without the need to also create some custom
+`wireService` label config there.
+
+Generally, if you have any monitoring solution installed in your cluster that
+uses the Prometheus CRDs, set `metrics.serviceMonitor.enable` for the following charts:
+
+ - brig
+ - cannon
+ - cargohold
+ - galley
+ - gundeck
+ - proxy
+ - spar

--- a/charts/account-pages/templates/deployment.yaml
+++ b/charts/account-pages/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: account-pages
   labels:
-    wireService: account-pages
+    app: account-pages
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,12 +16,10 @@ spec:
       maxSurge: {{ .Values.replicaCount | mul 2 }}
   selector:
     matchLabels:
-      wireService: account-pages
       app: account-pages
   template:
     metadata:
       labels:
-        wireService: account-pages
         app: account-pages
         release: {{ .Release.Name }}
     spec:

--- a/charts/aws-ingress/templates/ELB_account_pages_https.yaml
+++ b/charts/aws-ingress/templates/ELB_account_pages_https.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: LoadBalancer
   selector:
-    wireService: account-pages
+    app: account-pages
   ports:
   - name: https
     protocol: TCP

--- a/charts/aws-ingress/templates/ELB_nginz_https.yaml
+++ b/charts/aws-ingress/templates/ELB_nginz_https.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: LoadBalancer
   selector:
-    wireService: nginz
+    app: nginz
   ports:
   - name: https
     protocol: TCP

--- a/charts/aws-ingress/templates/ELB_nginz_wss.yaml
+++ b/charts/aws-ingress/templates/ELB_nginz_wss.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: LoadBalancer
   selector:
-    wireService: nginz
+    app: nginz
   ports:
   - name: wss
     protocol: TCP

--- a/charts/aws-ingress/templates/ELB_team_settings_https.yaml
+++ b/charts/aws-ingress/templates/ELB_team_settings_https.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: LoadBalancer
   selector:
-    wireService: team-settings
+    app: team-settings
   ports:
   - name: https
     protocol: TCP

--- a/charts/aws-ingress/templates/ELB_webapp_https.yaml
+++ b/charts/aws-ingress/templates/ELB_webapp_https.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: LoadBalancer
   selector:
-    wireService: webapp
+    app: webapp
   ports:
   - name: https
     protocol: TCP

--- a/charts/backoffice/templates/deployment.yaml
+++ b/charts/backoffice/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: backoffice
   labels:
-    wireService: backoffice
+    app: backoffice
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,11 +16,11 @@ spec:
       maxSurge: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      wireService: backoffice
+      app: backoffice
   template:
     metadata:
       labels:
-        wireService: backoffice
+        app: backoffice
         release: {{ .Release.Name }}
       annotations:
         # An annotation of the configmap checksum ensures changes to the configmap cause a redeployment upon `helm upgrade`

--- a/charts/backoffice/templates/service.yaml
+++ b/charts/backoffice/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: backoffice
   labels:
-    wireService: backoffice
+    app: backoffice
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -14,5 +14,5 @@ spec:
       port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
   selector:
-    wireService: backoffice
+    app: backoffice
     release: {{ .Release.Name }}

--- a/charts/brig/templates/configmap.yaml
+++ b/charts/brig/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: "brig"
   labels:
-    wireService: brig
+    app: brig
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: brig
   labels:
-    wireService: brig
+    app: brig
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,11 +16,11 @@ spec:
       maxSurge: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      wireService: brig
+      app: brig
   template:
     metadata:
       labels:
-        wireService: brig
+        app: brig
         release: {{ .Release.Name }}
       annotations:
         # An annotation of the configmap checksum ensures changes to the configmap cause a redeployment upon `helm upgrade`

--- a/charts/brig/templates/geoip-secret.yaml
+++ b/charts/brig/templates/geoip-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: brig-geoip
   labels:
-    wireService: brig
+    app: brig
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/charts/brig/templates/secret.yaml
+++ b/charts/brig/templates/secret.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: brig
   labels:
-    wireService: brig
+    app: brig
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/charts/brig/templates/service.yaml
+++ b/charts/brig/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: brig
   labels:
-    wireService: brig
+    app: brig
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -14,5 +14,5 @@ spec:
       port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
   selector:
-    wireService: brig
+    app: brig
     release: {{ .Release.Name }}

--- a/charts/brig/templates/serviceaccount.yaml
+++ b/charts/brig/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
-    wireService: brig
+    app: brig
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/brig/templates/servicemonitor.yaml
+++ b/charts/brig/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: brig
+  labels:
+    app: brig
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: http
+      path: /i/metrics
+  selector:
+    matchLabels:
+      app: brig
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/brig/templates/tests/brig-integration.yaml
+++ b/charts/brig/templates/tests/brig-integration.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: "brig-integration"
   labels:
-    wireService: brig-integration
+    app: brig-integration
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -13,7 +13,7 @@ spec:
     - port: 9000
       targetPort: 9000
   selector:
-    wireService: brig-integration
+    app: brig-integration
     release: {{ .Release.Name }}
 ---
 apiVersion: v1
@@ -23,7 +23,7 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
   labels:
-    wireService: brig-integration
+    app: brig-integration
     release: {{ .Release.Name }}
 spec:
   volumes:

--- a/charts/brig/templates/tests/nginz-service.yaml
+++ b/charts/brig/templates/tests/nginz-service.yaml
@@ -11,4 +11,4 @@ spec:
     - port: 8080
       targetPort: 8080
   selector:
-    wireService: nginz
+    app: nginz

--- a/charts/brig/templates/turnconfigmap.yaml
+++ b/charts/brig/templates/turnconfigmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: "turn"
   labels:
-    wireService: brig
+    app: brig
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -12,6 +12,9 @@ resources:
   limits:
     memory: "512Mi"
     cpu: "500m"
+metrics:
+  serviceMonitor:
+    enable: false
 config:
   logLevel: Info
   logFormat: JSON

--- a/charts/cannon/templates/headless-service.yaml
+++ b/charts/cannon/templates/headless-service.yaml
@@ -9,7 +9,7 @@ kind: Service
 metadata:
   name: {{ .Values.service.name }}
   labels:
-    wireService: cannon
+    app: cannon
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -23,5 +23,5 @@ spec:
       targetPort: {{ .Values.service.internalPort }}
       protocol: TCP
   selector:
-    wireService: cannon
+    app: cannon
     release: {{ .Release.Name }}

--- a/charts/cannon/templates/nginz-certificate-secret.yaml
+++ b/charts/cannon/templates/nginz-certificate-secret.yaml
@@ -4,7 +4,6 @@ kind: Secret
 metadata:
   name: {{ .Values.service.nginz.tls.secretName }}
   labels:
-    wireService: cannon-nginz
     app: cannon-nginz
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"

--- a/charts/cannon/templates/nginz-secret.yaml
+++ b/charts/cannon/templates/nginz-secret.yaml
@@ -4,7 +4,6 @@ kind: Secret
 metadata:
   name: cannon-nginz
   labels:
-    wireService: cannon-nginz
     app: cannon-nginz
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"

--- a/charts/cannon/templates/nginz-service.yaml
+++ b/charts/cannon/templates/nginz-service.yaml
@@ -13,7 +13,7 @@ kind: Service
 metadata:
   name: {{ .Values.service.nginz.name }}
   labels:
-    wireService: cannon
+    app: cannon
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -35,6 +35,6 @@ spec:
       targetPort: {{ .Values.service.nginz.internalPort }}
       protocol: TCP
   selector:
-    wireService: cannon
+    app: cannon
     release: {{ .Release.Name }}
 {{- end }}

--- a/charts/cannon/templates/servicemonitor.yaml
+++ b/charts/cannon/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cannon
+  labels:
+    app: cannon
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: http
+      path: /i/metrics
+  selector:
+    matchLabels:
+      app: cannon
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/cannon/templates/statefulset.yaml
+++ b/charts/cannon/templates/statefulset.yaml
@@ -9,7 +9,7 @@ kind: StatefulSet
 metadata:
   name: cannon
   labels:
-    wireService: cannon
+    app: cannon
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -17,7 +17,7 @@ spec:
   serviceName: {{ .Values.service.name }}
   selector:
     matchLabels:
-      wireService: cannon
+      app: cannon
   replicas: {{ .Values.replicaCount }}
   updateStrategy:
     type: RollingUpdate
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       labels:
-        wireService: cannon
+        app: cannon
         release: {{ .Release.Name }}
       annotations:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -20,6 +20,10 @@ config:
     millisecondsBetweenBatches: 50
     minBatchSize: 20
 
+metrics:
+  serviceMonitor:
+    enable: false
+
 nginx_conf:
   user: nginx
   group: nginx

--- a/charts/cargohold/templates/deployment.yaml
+++ b/charts/cargohold/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: cargohold
   labels:
-    wireService: cargohold
+    app: cargohold
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,11 +16,11 @@ spec:
       maxSurge: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      wireService: cargohold
+      app: cargohold
   template:
     metadata:
       labels:
-        wireService: cargohold
+        app: cargohold
         release: {{ .Release.Name }}
       annotations:
         # An annotation of the configmap checksum ensures changes to the configmap cause a redeployment upon `helm upgrade`

--- a/charts/cargohold/templates/service.yaml
+++ b/charts/cargohold/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: cargohold
   labels:
-    wireService: cargohold
+    app: cargohold
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -14,5 +14,5 @@ spec:
       port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
   selector:
-    wireService: cargohold
+    app: cargohold
     release: {{ .Release.Name }}

--- a/charts/cargohold/templates/serviceaccount.yaml
+++ b/charts/cargohold/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
-    wireService: cargohold
+    app: cargohold
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/cargohold/templates/servicemonitor.yaml
+++ b/charts/cargohold/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cargohold
+  labels:
+    app: cargohold
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: http
+      path: /i/metrics
+  selector:
+    matchLabels:
+      app: cargohold
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -5,6 +5,9 @@ image:
 service:
   externalPort: 8080
   internalPort: 8080
+metrics:
+  serviceMonitor:
+    enable: false
 resources:
   requests:
     memory: "256Mi"

--- a/charts/cassandra-migrations/templates/galley-migrate-data.yaml
+++ b/charts/cassandra-migrations/templates/galley-migrate-data.yaml
@@ -7,7 +7,7 @@ kind: Job
 metadata:
   name: galley-migrate-data
   labels:
-    wireService: "cassandra-migrations"
+    app: "cassandra-migrations"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -20,7 +20,7 @@ spec:
     metadata:
       name: "{{.Release.Name}}"
       labels:
-        wireService: galley-migrate-data
+        app: galley-migrate-data
         app: galley-migrate-data
         heritage: {{.Release.Service | quote }}
         release: {{.Release.Name | quote }}

--- a/charts/cassandra-migrations/templates/migrate-schema.yaml
+++ b/charts/cassandra-migrations/templates/migrate-schema.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: cassandra-migrations
   labels:
-    wireService: cassandra-migrations
+    app: cassandra-migrations
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        wireService: cassandra-migrations
+        app: cassandra-migrations
         release: {{ .Release.Name }}
     spec:
       restartPolicy: OnFailure

--- a/charts/cassandra-migrations/templates/spar-migrate-data.yaml
+++ b/charts/cassandra-migrations/templates/spar-migrate-data.yaml
@@ -7,7 +7,7 @@ kind: Job
 metadata:
   name: spar-migrate-data
   labels:
-    wireService: "cassandra-migrations"
+    app: "cassandra-migrations"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -20,7 +20,6 @@ spec:
     metadata:
       name: "{{.Release.Name}}"
       labels:
-        wireService: spar-migrate-data
         app: spar-migrate-data
         heritage: {{.Release.Service | quote }}
         release: {{.Release.Name | quote }}

--- a/charts/elasticsearch-ephemeral/templates/es-svc.yaml
+++ b/charts/elasticsearch-ephemeral/templates/es-svc.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    wireService: {{ template "fullname" . }}
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"

--- a/charts/elasticsearch-ephemeral/templates/es.yaml
+++ b/charts/elasticsearch-ephemeral/templates/es.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    wireService: {{ template "fullname" . }}
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"

--- a/charts/elasticsearch-index/templates/create-index.yaml
+++ b/charts/elasticsearch-index/templates/create-index.yaml
@@ -3,7 +3,6 @@ kind: Job
 metadata:
   name: elasticsearch-index-create
   labels:
-    wireService: elasticsearch-index-create
     app: elasticsearch-index-create
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
@@ -16,7 +15,6 @@ spec:
     metadata:
       name: "{{.Release.Name}}"
       labels:
-        wireService: elasticsearch-index-create
         app: elasticsearch-index-create
         heritage: {{.Release.Service | quote }}
         release: {{.Release.Name | quote }}

--- a/charts/elasticsearch-index/templates/migrate-data.yaml
+++ b/charts/elasticsearch-index/templates/migrate-data.yaml
@@ -3,7 +3,6 @@ kind: Job
 metadata:
   name: brig-index-migrate-data
   labels:
-    wireService: elasticsearch-index-migrate-data
     app: elasticsearch-index-migrate-data
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
@@ -16,7 +15,6 @@ spec:
     metadata:
       name: "{{.Release.Name}}"
       labels:
-        wireService: elasticsearch-index-migrate-data
         app: elasticsearch-index-migrate-data
         heritage: {{.Release.Service | quote }}
         release: {{.Release.Name | quote }}

--- a/charts/federator/templates/ca.yaml
+++ b/charts/federator/templates/ca.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: "federator-ca"
   labels:
-    wireService: federator
+    app: federator
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/federator/templates/configmap.yaml
+++ b/charts/federator/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: "federator"
   labels:
-    wireService: federator
+    app: federator
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/federator/templates/deployment.yaml
+++ b/charts/federator/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: federator
   labels:
-    wireService: federator
+    app: federator
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,11 +16,11 @@ spec:
       maxSurge: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      wireService: federator
+      app: federator
   template:
     metadata:
       labels:
-        wireService: federator
+        app: federator
         release: {{ .Release.Name }}
       annotations:
         # An annotation of the configmap checksum ensures changes to the configmap cause a redeployment upon `helm upgrade`

--- a/charts/federator/templates/secret.yaml
+++ b/charts/federator/templates/secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: "federator-secret"
   labels:
-    wireService: federator
+    app: federator
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/federator/templates/service.yaml
+++ b/charts/federator/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: federator
   labels:
-    wireService: federator
+    app: federator
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -18,5 +18,5 @@ spec:
       port: {{ .Values.service.externalFederatorPort }}
       targetPort: {{ .Values.service.externalFederatorPort }}
   selector:
-    wireService: federator
+    app: federator
     release: {{ .Release.Name }}

--- a/charts/galley/templates/deployment.yaml
+++ b/charts/galley/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: galley
   labels:
-    wireService: galley
+    app: galley
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,11 +16,11 @@ spec:
       maxSurge: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      wireService: galley
+      app: galley
   template:
     metadata:
       labels:
-        wireService: galley
+        app: galley
         release: {{ .Release.Name }}
       annotations:
         # An annotation of the configmap checksum ensures changes to the configmap cause a redeployment upon `helm upgrade`

--- a/charts/galley/templates/service.yaml
+++ b/charts/galley/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: galley
   labels:
-    wireService: galley
+    app: galley
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -14,5 +14,5 @@ spec:
       port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
   selector:
-    wireService: galley
+    app: galley
     release: {{ .Release.Name }}

--- a/charts/galley/templates/serviceaccount.yaml
+++ b/charts/galley/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
-    wireService: galley
+    app: galley
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/galley/templates/servicemonitor.yaml
+++ b/charts/galley/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: galley
+  labels:
+    app: galley
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: http
+      path: /i/metrics
+  selector:
+    matchLabels:
+      app: galley
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/galley/templates/tests/galley-integration.yaml
+++ b/charts/galley/templates/tests/galley-integration.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: "galley-integration"
   labels:
-    wireService: galley-integration
+    app: galley-integration
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -13,7 +13,7 @@ spec:
     - port: 9000
       targetPort: 9000
   selector:
-    wireService: galley-integration
+    app: galley-integration
     release: {{ .Release.Name }}
 ---
 apiVersion: v1
@@ -23,7 +23,7 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
   labels:
-    wireService: galley-integration
+    app: galley-integration
     release: {{ .Release.Name }}
 spec:
   volumes:

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -6,6 +6,9 @@ image:
 service:
   externalPort: 8080
   internalPort: 8080
+metrics:
+  serviceMonitor:
+    enable: false
 resources:
   requests:
     memory: "256Mi"

--- a/charts/gundeck/templates/deployment.yaml
+++ b/charts/gundeck/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: gundeck
   labels:
-    wireService: gundeck
+    app: gundeck
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,11 +16,11 @@ spec:
       maxSurge: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      wireService: gundeck
+      app: gundeck
   template:
     metadata:
       labels:
-        wireService: gundeck
+        app: gundeck
         release: {{ .Release.Name }}
       annotations:
         # An annotation of the configmap checksum ensures changes to the configmap cause a redeployment upon `helm upgrade`

--- a/charts/gundeck/templates/secret.yaml
+++ b/charts/gundeck/templates/secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: gundeck
   labels:
-    wireService: gundeck
+    app: gundeck
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/charts/gundeck/templates/service.yaml
+++ b/charts/gundeck/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: gundeck
   labels:
-    wireService: gundeck
+    app: gundeck
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -14,5 +14,5 @@ spec:
       port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
   selector:
-    wireService: gundeck
+    app: gundeck
     release: {{ .Release.Name }}

--- a/charts/gundeck/templates/serviceaccount.yaml
+++ b/charts/gundeck/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
-    wireService: gundeck
+    app: gundeck
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/gundeck/templates/servicemonitor.yaml
+++ b/charts/gundeck/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gundeck
+  labels:
+    app: gundeck
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: http
+      path: /i/metrics
+  selector:
+    matchLabels:
+      app: gundeck
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -5,6 +5,9 @@ image:
 service:
   externalPort: 8080
   internalPort: 8080
+metrics:
+  serviceMonitor:
+    enable: false
 resources:
   requests:
     memory: "256Mi"

--- a/charts/ldap-scim-bridge/templates/cronjob.yaml
+++ b/charts/ldap-scim-bridge/templates/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: ldap-scim-bridge
   labels:
-    wireService: ldap-scim-bridge
+    app: ldap-scim-bridge
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -13,7 +13,7 @@ spec:
   jobTemplate:
     metadata:
       labels:
-        wireService: ldap-scim-bridge
+        app: ldap-scim-bridge
         release: {{ .Release.Name }}
       annotations:
         # An annotation of the configmap checksum ensures changes to the configmap cause a redeployment upon `helm upgrade`

--- a/charts/ldap-scim-bridge/templates/secret.yaml
+++ b/charts/ldap-scim-bridge/templates/secret.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: ldap-scim-bridge
   labels:
-    wireService: ldap-scim-bridge
+    app: ldap-scim-bridge
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/charts/nginx-ingress-services/templates/service.yaml
+++ b/charts/nginx-ingress-services/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
     - port: {{ .Values.service.nginz.externalHttpPort }}
       targetPort: 8080
   selector:
-    wireService: nginz
+    app: nginz
 {{- if .Values.websockets.enabled }}
 ---
 apiVersion: v1
@@ -22,7 +22,7 @@ spec:
     - port: {{ .Values.service.nginz.externalTcpPort }}
       targetPort: 8081
   selector:
-    wireService: nginz
+    app: nginz
 {{- end }}
 {{- if .Values.webapp.enabled }}
 ---
@@ -36,7 +36,7 @@ spec:
     - port: {{ .Values.service.webapp.externalPort }}
       targetPort: 8080
   selector:
-    wireService: webapp
+    app: webapp
 {{- end }}
 {{- if not .Values.service.s3.externallyCreated }}
 ---
@@ -50,7 +50,7 @@ spec:
     - port: {{ .Values.service.s3.externalPort }}
       targetPort: 9000
   selector:
-    wireService: {{ .Values.service.s3.serviceName }}
+    app: {{ .Values.service.s3.serviceName }}
 {{- end }}
 {{- if .Values.teamSettings.enabled }}
 ---
@@ -64,7 +64,7 @@ spec:
     - port: {{ .Values.service.teamSettings.externalPort }}
       targetPort: 8080
   selector:
-    wireService: team-settings
+    app: team-settings
 {{- end }}
 {{- if .Values.accountPages.enabled }}
 ---
@@ -78,5 +78,5 @@ spec:
     - port: {{ .Values.service.accountPages.externalPort }}
       targetPort: 8080
   selector:
-    wireService: account-pages
+    app: account-pages
 {{- end }}

--- a/charts/nginz/templates/deployment.yaml
+++ b/charts/nginz/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: nginz
   labels:
-    wireService: nginz
+    app: nginz
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,12 +16,10 @@ spec:
       maxSurge: {{ .Values.replicaCount | mul 2 }}
   selector:
     matchLabels:
-      wireService: nginz
       app: nginz
   template:
     metadata:
       labels:
-        wireService: nginz
         app: nginz
         release: {{ .Release.Name }}
       annotations:

--- a/charts/nginz/templates/secret.yaml
+++ b/charts/nginz/templates/secret.yaml
@@ -3,7 +3,6 @@ kind: Secret
 metadata:
   name: nginz
   labels:
-    wireService: nginz
     app: nginz
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"

--- a/charts/openldap/templates/openldap.yaml
+++ b/charts/openldap/templates/openldap.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: "openldap"
   labels:
-    wireService: openldap
+    app: openldap
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/openldap/templates/secret-newusers.yaml
+++ b/charts/openldap/templates/secret-newusers.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: openldap-newusers-ldif
   labels:
-    wireService: ldap-scim-bridge
+    app: ldap-scim-bridge
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/charts/openldap/templates/service.yaml
+++ b/charts/openldap/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openldap
 spec:
   selector:
-    wireService: openldap
+    app: openldap
   ports:
     - name: openldap
       protocol: TCP

--- a/charts/proxy/templates/deployment.yaml
+++ b/charts/proxy/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: proxy
   labels:
-    wireService: proxy
+    app: proxy
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,11 +16,11 @@ spec:
       maxSurge: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      wireService: proxy
+      app: proxy
   template:
     metadata:
       labels:
-        wireService: proxy
+        app: proxy
         release: {{ .Release.Name }}
       annotations:
         # An annotation of the configmap checksum ensures changes to the configmap cause a redeployment upon `helm upgrade`

--- a/charts/proxy/templates/service.yaml
+++ b/charts/proxy/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: proxy
   labels:
-    wireService: proxy
+    app: proxy
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -14,5 +14,5 @@ spec:
       port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
   selector:
-    wireService: proxy
+    app: proxy
     release: {{ .Release.Name }}

--- a/charts/proxy/templates/servicemonitor.yaml
+++ b/charts/proxy/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: proxy
+  labels:
+    app: proxy
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: http
+      path: /i/metrics
+  selector:
+    matchLabels:
+      app: proxy
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -5,6 +5,9 @@ image:
 service:
   externalPort: 8080
   internalPort: 8080
+metrics:
+  serviceMonitor:
+    enable: false
 resources:
   requests:
     memory: "128Mi"

--- a/charts/reaper/templates/deployment.yaml
+++ b/charts/reaper/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: reaper
   labels:
-    wireService: reaper
+    app: reaper
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -11,12 +11,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      wireService: reaper
+      app: reaper
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        wireService: reaper
+        app: reaper
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: reaper-role

--- a/charts/spar/templates/deployment.yaml
+++ b/charts/spar/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: spar
   labels:
-    wireService: spar
+    app: spar
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,11 +16,11 @@ spec:
       maxSurge: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      wireService: spar
+      app: spar
   template:
     metadata:
       labels:
-        wireService: spar
+        app: spar
         release: {{ .Release.Name }}
       annotations:
         # An annotation of the configmap checksum ensures changes to the configmap cause a redeployment upon `helm upgrade`

--- a/charts/spar/templates/service.yaml
+++ b/charts/spar/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: spar
   labels:
-    wireService: spar
+    app: spar
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -14,5 +14,5 @@ spec:
       port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
   selector:
-    wireService: spar
+    app: spar
     release: {{ .Release.Name }}

--- a/charts/spar/templates/servicemonitor.yaml
+++ b/charts/spar/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: spar
+  labels:
+    app: spar
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: http
+      path: /i/metrics
+  selector:
+    matchLabels:
+      app: spar
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/spar/templates/tests/spar-integration.yaml
+++ b/charts/spar/templates/tests/spar-integration.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
   labels:
-    wireService: spar-integration
+    app: spar-integration
     release: {{ .Release.Name }}
 spec:
   volumes:

--- a/charts/spar/values.yaml
+++ b/charts/spar/values.yaml
@@ -2,6 +2,9 @@ replicaCount: 3
 image:
   repository: quay.io/wire/spar
   tag: do-not-use
+metrics:
+  serviceMonitor:
+    enable: false
 resources:
   requests:
     memory: "128Mi"

--- a/charts/team-settings/templates/deployment.yaml
+++ b/charts/team-settings/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: team-settings
   labels:
-    wireService: team-settings
+    app: team-settings
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,12 +16,10 @@ spec:
       maxSurge: {{ .Values.replicaCount | mul 2 }}
   selector:
     matchLabels:
-      wireService: team-settings
       app: team-settings
   template:
     metadata:
       labels:
-        wireService: team-settings
         app: team-settings
         release: {{ .Release.Name }}
     spec:

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: webapp
   labels:
-    wireService: webapp
+    app: webapp
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,12 +16,10 @@ spec:
       maxSurge: {{ .Values.replicaCount | mul 2 }}
   selector:
     matchLabels:
-      wireService: webapp
       app: webapp
   template:
     metadata:
       labels:
-        wireService: webapp
         app: webapp
         release: {{ .Release.Name }}
     spec:

--- a/charts/wire-server-metrics/values.yaml
+++ b/charts/wire-server-metrics/values.yaml
@@ -1,29 +1,4 @@
 kube-prometheus-stack:
-  prometheus:
-    additionalServiceMonitors:
-      - name: wire-services
-        # We copy these labels from the pod onto the collected metrics from that pod
-        targetLabels:
-          - wireService
-        endpoints:
-          - path: '/i/metrics'
-            port: http
-            interval: 10s
-            metricRelabelings:
-              # Rename 'service' to 'role' to allow sharing of grafana dashboards
-              # between k8s and AWS services.
-              - sourceLabels: [service]
-                targetLabel: role
-        # This monitors _all_ namespaces and selects all
-        # pods that with a wireServices selector
-        namespaceSelector:
-          any: true
-        selector:
-          matchExpressions:
-            # select any pod with a 'wireService' label
-            - key: wireService
-              operator: Exists
-
   prometheusOperator:
     # Don't try to create custom resource types; we prefer to do it manually
     # Otherwise we run into race conditions when installing helm charts

--- a/docs/src/how-to/administrate/restund.rst
+++ b/docs/src/how-to/administrate/restund.rst
@@ -220,7 +220,7 @@ You then need to restart the ``brig`` pods if your code is older than September 
 
 .. code:: bash
 
-  kubectl delete pod -l wireService=brig
+  kubectl delete pod -l app=brig
 
 2. Wait for traffic to drain. This can take up to 12 hours after the configuration change. Wait until current allocations (people connected to the restund server) return 0. See :ref:`allocations`.
 3. It's now safe to ``systemctl stop restund``, and take any necessary actions.

--- a/services/brig/federation-tests.sh
+++ b/services/brig/federation-tests.sh
@@ -34,7 +34,7 @@ sed -i "s=publicKeys: /etc/wire/brig/secrets/publickey.txt=publicKeys: test/reso
 declare -a alsoProxyOptions
 while read -r ip; do
   alsoProxyOptions+=("--also-proxy=${ip}")
-done < <(kubectl get pods -n "$NAMESPACE" -l wireService=cannon -o json | jq -r '.items[].status.podIPs[].ip')
+done < <(kubectl get pods -n "$NAMESPACE" -l app=cannon -o json | jq -r '.items[].status.podIPs[].ip')
 
 # shellcheck disable=SC2086
 telepresence --namespace "$NAMESPACE" --also-proxy=cassandra-ephemeral ${alsoProxyOptions[*]} --run bash -c "export INTEGRATION_FEDERATION_TESTS=1; ./dist/brig-integration -p federation-end2end-user -i i.yaml -s b.yaml"


### PR DESCRIPTION
This aligns labels a bit more with how they look like in other
deployments. In some cases, we were already setting the `app` label,
too.

There's one possible regression:
The wire-server-metrics helm chart previously configured kube-prometheus-stack to automatically scrape everything with a wireService label at port http,
path /i/metrics.

This custom configuration has been removed, and instead each chart provides the option to create `ServiceMonitor` resources, which add wire services to metric scraping that way.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
