### PR TITLE
Propagate MLS messages to remotes

### DIFF
--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -267,6 +267,7 @@ CREATE TABLE galley_test.member_remote_user (
     user_remote_domain text,
     user_remote_id uuid,
     conversation_role text,
+    mls_clients set<text>,
     PRIMARY KEY (conv, user_remote_domain, user_remote_id)
 ) WITH CLUSTERING ORDER BY (user_remote_domain ASC, user_remote_id ASC)
     AND bloom_filter_fp_chance = 0.1

--- a/changelog.d/2-features/mls
+++ b/changelog.d/2-features/mls
@@ -1,4 +1,4 @@
 MLS implementation progress:
  - Remote users can be added to MLS conversations
- - MLS messages (both handshake and application) are now propagate to remote
+ - MLS messages (both handshake and application) are now propagates to remote
    conversation participants.

--- a/changelog.d/2-features/mls
+++ b/changelog.d/2-features/mls
@@ -1,0 +1,4 @@
+MLS implementation progress:
+ - Remote users can be added to MLS conversations
+ - MLS messages (both handshake and application) are now propagate to remote
+   conversation participants.

--- a/libs/galley-types/src/Galley/Types/Conversations/Members.hs
+++ b/libs/galley-types/src/Galley/Types/Conversations/Members.hs
@@ -41,7 +41,8 @@ import Wire.API.Provider.Service (ServiceRef)
 -- | Internal (cassandra) representation of a remote conversation member.
 data RemoteMember = RemoteMember
   { rmId :: Remote UserId,
-    rmConvRoleName :: RoleName
+    rmConvRoleName :: RoleName,
+    rmMLSClients :: Set ClientId
   }
   deriving stock (Show)
 

--- a/libs/galley-types/src/Galley/Types/Conversations/Members.hs
+++ b/libs/galley-types/src/Galley/Types/Conversations/Members.hs
@@ -20,6 +20,7 @@
 module Galley.Types.Conversations.Members
   ( RemoteMember (..),
     remoteMemberToOther,
+    remoteMemberQualify,
     LocalMember (..),
     localMemberToOther,
     newMember,
@@ -53,6 +54,9 @@ remoteMemberToOther x =
       omService = Nothing,
       omConvRoleName = rmConvRoleName x
     }
+
+remoteMemberQualify :: RemoteMember -> Remote RemoteMember
+remoteMemberQualify m = qualifyAs (rmId m) m
 
 -- | Internal (cassandra) representation of a local conversation member.
 data LocalMember = LocalMember

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -28,6 +28,7 @@ import Wire.API.Arbitrary (GenericUniform (..))
 import Wire.API.Federation.API.Common
 import Wire.API.Federation.Endpoint
 import Wire.API.Federation.Version
+import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
 import Wire.API.Message (UserClients)
 import Wire.API.User (UserProfile)
@@ -67,6 +68,7 @@ type BrigApi =
     -- (handles can be up to 256 chars currently)
     :<|> FedEndpoint "search-users" SearchRequest SearchResponse
     :<|> FedEndpoint "get-user-clients" GetUserClients (UserMap (Set PubClient))
+    :<|> FedEndpoint "get-mls-clients" MLSClientsRequest (Set ClientId)
     :<|> FedEndpoint "send-connection-action" NewConnectionRequest NewConnectionResponse
     :<|> FedEndpoint "on-user-deleted-connections" UserDeletedConnectionsNotification EmptyResponse
     :<|> FedEndpoint "claim-key-packages" ClaimKeyPackageRequest (Maybe KeyPackageBundle)
@@ -76,6 +78,13 @@ newtype GetUserClients = GetUserClients
   }
   deriving stock (Eq, Show, Generic)
   deriving (ToJSON, FromJSON) via (CustomEncoded GetUserClients)
+
+data MLSClientsRequest = MLSClientsRequest
+  { mcrUserId :: UserId, -- implicitly qualified by the local domain
+    mcrSignatureScheme :: SignatureSchemeTag
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (ToJSON, FromJSON) via (CustomEncoded MLSClientsRequest)
 
 -- NOTE: ConversationId for remote connections
 --

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -60,7 +60,7 @@ type GalleyApi =
     :<|> FedEndpoint "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
     :<|> FedEndpoint "update-conversation" ConversationUpdateRequest ConversationUpdateResponse
     :<|> FedEndpoint "mls-welcome" MLSWelcomeRequest EmptyResponse
-    :<|> FedEndpoint "on-mls-message-sent" RemoteMLSMessage ()
+    :<|> FedEndpoint "on-mls-message-sent" RemoteMLSMessage EmptyResponse
 
 data GetConversationsRequest = GetConversationsRequest
   { gcrUserId :: UserId,

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -60,6 +60,7 @@ type GalleyApi =
     :<|> FedEndpoint "on-user-deleted-conversations" UserDeletedConversationsNotification EmptyResponse
     :<|> FedEndpoint "update-conversation" ConversationUpdateRequest ConversationUpdateResponse
     :<|> FedEndpoint "mls-welcome" MLSWelcomeRequest EmptyResponse
+    :<|> FedEndpoint "on-mls-message-sent" RemoteMLSMessage ()
 
 data GetConversationsRequest = GetConversationsRequest
   { gcrUserId :: UserId,
@@ -190,6 +191,18 @@ data RemoteMessage conv = RemoteMessage
   deriving stock (Eq, Show, Generic, Functor)
   deriving (Arbitrary) via (GenericUniform (RemoteMessage conv))
   deriving (ToJSON, FromJSON) via (CustomEncoded (RemoteMessage conv))
+
+data RemoteMLSMessage = RemoteMLSMessage
+  { rmmTime :: UTCTime,
+    rmmMetadata :: MessageMetadata,
+    rmmSender :: Qualified UserId,
+    rmmConversation :: ConvId,
+    rmmRecipients :: [(UserId, ClientId)],
+    rmmMessage :: Base64ByteString
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform RemoteMLSMessage)
+  deriving (ToJSON, FromJSON) via (CustomEncoded RemoteMLSMessage)
 
 data MessageSendRequest = MessageSendRequest
   { -- | Conversation is assumed to be owned by the target domain, this allows

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -52,7 +52,6 @@ import Wire.API.Routes.Internal.Brig.EJPD
 import qualified Wire.API.Routes.Internal.Galley.TeamFeatureNoConfigMulti as Multi
 import Wire.API.Routes.MultiVerb
 import Wire.API.Routes.Named
-import Wire.API.Routes.QualifiedCapture
 import Wire.API.Team.Feature (TeamFeatureName (TeamFeatureSearchVisibilityInbound))
 import qualified Wire.API.Team.Feature as ApiFt
 import Wire.API.User
@@ -202,7 +201,7 @@ type GetMLSClients =
   Summary "Return all MLS-enabled clients of a user"
     :> "clients"
     :> CanThrow 'UserNotFound
-    :> QualifiedCapture "user" UserId
+    :> Capture "user" UserId
     :> QueryParam' '[Required, Strict] "sig_scheme" SignatureSchemeTag
     :> MultiVerb1
          'GET

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -25,6 +25,7 @@ import qualified Brig.API.Client as API
 import Brig.API.Connection.Remote (performRemoteAction)
 import Brig.API.Error
 import Brig.API.Handler (Handler)
+import qualified Brig.API.Internal as Internal
 import Brig.API.MLS.KeyPackages
 import qualified Brig.API.User as API
 import Brig.API.Util (lookupSearchPolicy)
@@ -81,6 +82,7 @@ federationSitemap =
     :<|> Named @"claim-multi-prekey-bundle" claimMultiPrekeyBundle
     :<|> Named @"search-users" (\d sr -> wrapHttpClientE $ searchUsers d sr)
     :<|> Named @"get-user-clients" getUserClients
+    :<|> Named @"get-mls-clients" getMLSClients
     :<|> Named @"send-connection-action" sendConnectionAction
     :<|> Named @"on-user-deleted-connections" onUserDeleted
     :<|> Named @"claim-key-packages" fedClaimKeyPackages
@@ -210,6 +212,10 @@ searchUsers domain (SearchRequest searchTerm) = do
 
 getUserClients :: Domain -> GetUserClients -> (Handler r) (UserMap (Set PubClient))
 getUserClients _ (GetUserClients uids) = API.lookupLocalPubClientsBulk uids !>> clientError
+
+getMLSClients :: Domain -> MLSClientsRequest -> Handler r (Set ClientId)
+getMLSClients _domain mcr = do
+  Internal.getMLSClients (mcrUserId mcr) (mcrSignatureScheme mcr)
 
 onUserDeleted :: Domain -> UserDeletedConnectionsNotification -> (Handler r) EmptyResponse
 onUserDeleted origDomain udcn = lift $ do

--- a/services/brig/test/integration/API/MLS/Util.hs
+++ b/services/brig/test/integration/API/MLS/Util.hs
@@ -55,12 +55,12 @@ uploadKeyPackages brig store sk u c n = do
           <> "@"
           <> T.unpack (domainText (qDomain u))
   kps <-
-    replicateM n . liftIO . spawn . shell . unwords $
+    replicateM n . liftIO . flip spawn Nothing . shell . unwords $
       cmd0 <> ["key-package", clientId]
   when (sk == SetKey) $
     do
       pk <-
-        liftIO . spawn . shell . unwords $
+        liftIO . flip spawn Nothing . shell . unwords $
           cmd0 <> ["public-key", clientId]
       put
         ( brig

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -620,6 +620,7 @@ executable galley-schema
       V62_TeamFeatureSearchVisibilityInbound
       V63_MLSConversationClients
       V64_Epoch
+      V65_MLSRemoteClients
       Paths_galley
   hs-source-dirs:
       schema/src

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -67,6 +67,7 @@ import qualified V61_MLSConversation
 import qualified V62_TeamFeatureSearchVisibilityInbound
 import qualified V63_MLSConversationClients
 import qualified V64_Epoch
+import qualified V65_MLSRemoteClients
 
 main :: IO ()
 main = do
@@ -119,7 +120,8 @@ main = do
       V61_MLSConversation.migration,
       V62_TeamFeatureSearchVisibilityInbound.migration,
       V63_MLSConversationClients.migration,
-      V64_Epoch.migration
+      V64_Epoch.migration,
+      V65_MLSRemoteClients.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Galley.Cassandra
       -- (see also docs/developer/cassandra-interaction.md)

--- a/services/galley/schema/src/V65_MLSRemoteClients.hs
+++ b/services/galley/schema/src/V65_MLSRemoteClients.hs
@@ -15,9 +15,17 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Cassandra (schemaVersion) where
+module V65_MLSRemoteClients where
 
+import Cassandra.Schema
 import Imports
+import Text.RawString.QQ
 
-schemaVersion :: Int32
-schemaVersion = 65
+migration :: Migration
+migration =
+  Migration 65 "Add a column for a list of MLS clients for remote members of a conversation" $
+    schema'
+      [r| ALTER TABLE member_remote_user ADD (
+          mls_clients set<text>
+        )
+     |]

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -78,10 +78,10 @@ import Wire.API.Federation.Error
 import Wire.API.MLS.Credential
 import Wire.API.MLS.Serialisation
 import Wire.API.MLS.Welcome
+import Wire.API.Message
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Routes.Named
 import Wire.API.ServantProto
-import Wire.API.User.Client (userClientMap)
 
 type FederationAPI = "federation" :> FedApi 'Galley
 
@@ -455,9 +455,9 @@ updateConversation ::
        ]
       r
   ) =>
-  -- |
+  --
   Domain ->
-  -- |
+  --
   F.ConversationUpdateRequest ->
   Sem r ConversationUpdateResponse
 updateConversation origDomain updateRequest = do

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -576,7 +576,7 @@ onMLSMessageSent ::
     r =>
   Domain ->
   F.RemoteMLSMessage ->
-  Sem r ()
+  Sem r EmptyResponse
 onMLSMessageSent domain rmm = do
   loc <- qualifyLocal ()
   let rcnv = toRemoteUnsafe domain (F.rmmConversation rmm)
@@ -603,3 +603,4 @@ onMLSMessageSent domain rmm = do
 
   runMessagePush loc (Just (qUntagged rcnv)) $
     foldMap mkPush recipients
+  pure EmptyResponse

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -329,7 +329,8 @@ onMessageSent domain rmUnqualified = do
       recipientMap = userClientMap $ F.rmRecipients rm
       msgs = toMapOf (itraversed <.> itraversed) recipientMap
   (members, allMembers) <-
-    E.selectRemoteMembers (Map.keys recipientMap) (F.rmConversation rm)
+    first Set.fromList
+      <$> E.selectRemoteMembers (Map.keys recipientMap) (F.rmConversation rm)
   unless allMembers $
     P.warn $
       Log.field "conversation" (toByteString' (qUnqualified convId))
@@ -350,7 +351,7 @@ onMessageSent domain rmUnqualified = do
       (Just convId)
       mempty
       msgMetadata
-      msgs
+      (Map.filterWithKey (\(uid, _) _ -> Set.member uid members) msgs)
 
 sendMessage ::
   Members

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -224,8 +224,7 @@ executeProposalAction lusr con conv action = do
   result <- foldMap addMembers . nonEmpty . map fst $ newUserClients
   -- add clients to the database
   for_ newUserClients $ \(qtarget, newClients) -> do
-    ltarget <- ensureLocal lusr qtarget -- FUTUREWORK: support remote users
-    addMLSClients (convId conv) (tUnqualified ltarget) newClients
+    addMLSClients (qualifyAs lusr (convId conv)) qtarget newClients
   pure result
   where
     addUserClients :: SignatureSchemeTag -> ClientMap -> Qualified UserId -> Set ClientId -> Sem r ()

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -61,6 +61,7 @@ import Wire.API.MLS.KeyPackage
 import Wire.API.MLS.Message
 import Wire.API.MLS.Proposal
 import Wire.API.MLS.Serialisation
+import Wire.API.Message
 
 postMLSMessage ::
   ( HasProposalEffects r,

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -332,7 +332,7 @@ propagateMessage lusr conv con raw = do
       warn $
         Logger.msg ("A message could not be delivered to a remote backend" :: ByteString)
           . Logger.field "remote_domain" (domainText (tDomain r))
-          . (logErrorMsg Nothing (toWai e))
+          . logErrorMsg (toWai e)
 
 getMLSClients ::
   Members '[BrigAccess, FederatorAccess] r =>

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -104,7 +104,7 @@ sendLocalWelcomes con now rawWelcome lclients = do
       let lcnv = qualifyAs lclients (selfConv u)
           lusr = qualifyAs lclients u
           e = Event (qUntagged lcnv) (qUntagged lusr) now $ EdMLSWelcome rawWelcome
-       in newMessagePush lclients () con defMessageMetadata (u, c) e
+       in newMessagePush lclients mempty con defMessageMetadata (u, c) e
 
 sendRemoteWelcomes ::
   Members

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -48,6 +48,7 @@ import Wire.API.Federation.Error
 import Wire.API.MLS.Credential
 import Wire.API.MLS.Serialisation
 import Wire.API.MLS.Welcome
+import Wire.API.Message
 
 postMLSWelcome ::
   Members

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -600,15 +600,6 @@ newMessageEvent mconvId sender senderClient dat time (receiver, receiverClient) 
             otrData = dat
           }
 
-qualifiedNewOtrMetadata :: QualifiedNewOtrMessage -> MessageMetadata
-qualifiedNewOtrMetadata msg =
-  MessageMetadata
-    { mmNativePush = qualifiedNewOtrNativePush msg,
-      mmTransient = qualifiedNewOtrTransient msg,
-      mmNativePriority = qualifiedNewOtrNativePriority msg,
-      mmData = Just . toBase64Text $ qualifiedNewOtrData msg
-    }
-
 -- unqualified
 
 legacyClientMismatchStrategy :: Domain -> Maybe [UserId] -> Maybe IgnoreMissing -> Maybe ReportMissing -> ClientMismatchStrategy

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -54,6 +54,7 @@ import Galley.API.LegalHold.Conflicts
 import Galley.API.Push
 import Galley.API.Util
 import Galley.Data.Conversation
+import Galley.Data.Services
 import Galley.Effects
 import Galley.Effects.BrigAccess
 import Galley.Effects.ClientStore
@@ -387,12 +388,16 @@ postQualifiedOtrMessage senderType sender mconn lcnv msg =
         throwS @'InvalidOperation
 
       let localMemberIds = lmId <$> convLocalMembers conv
-          localMemberMap :: Map UserId LocalMember
-          localMemberMap = Map.fromList (map (\mem -> (lmId mem, mem)) (convLocalMembers conv))
+          botMap :: BotMap
+          botMap = Map.fromList $ do
+            mem <- convLocalMembers conv
+            b <- maybeToList $ newBotMember mem
+            pure (lmId mem, b)
           members :: Set (Qualified UserId)
           members =
-            Set.map (`Qualified` localDomain) (Map.keysSet localMemberMap)
-              <> Set.fromList (map (qUntagged . rmId) (convRemoteMembers conv))
+            Set.fromList $
+              map (qUntagged . qualifyAs lcnv) localMemberIds
+                <> map (qUntagged . rmId) (convRemoteMembers conv)
       isInternal <- view (optSettings . setIntraListing) <$> input
 
       -- check if the sender is part of the conversation
@@ -448,7 +453,7 @@ postQualifiedOtrMessage senderType sender mconn lcnv msg =
           senderClient
           mconn
           lcnv
-          localMemberMap
+          botMap
           (qualifiedNewOtrMetadata msg)
           validMessages
       pure otrResult {mssFailedToSend = failedToSend}
@@ -468,16 +473,16 @@ sendMessages ::
   ClientId ->
   Maybe ConnId ->
   Local ConvId ->
-  LocalMemberMap t ->
+  BotMap ->
   MessageMetadata ->
   Map (Domain, UserId, ClientId) ByteString ->
   Sem r QualifiedUserClients
-sendMessages now sender senderClient mconn lcnv localMemberMap metadata messages = do
+sendMessages now sender senderClient mconn lcnv botMap metadata messages = do
   let messageMap = byDomain $ fmap toBase64Text messages
   let send dom =
         foldQualified
           lcnv
-          (\l -> sendLocalMessages l now sender senderClient mconn (Just (qUntagged lcnv)) localMemberMap metadata)
+          (\l -> sendLocalMessages @t l now sender senderClient mconn (Just (qUntagged lcnv)) botMap metadata)
           (\r -> sendRemoteMessages r now sender senderClient lcnv metadata)
           (Qualified () dom)
   mkQualifiedUserClientsByDomain <$> Map.traverseWithKey send messageMap
@@ -495,7 +500,7 @@ sendBroadcastMessages ::
 sendBroadcastMessages loc now sender senderClient mconn metadata messages = do
   let messageMap = byDomain $ fmap toBase64Text messages
       localMessages = Map.findWithDefault mempty (tDomain loc) messageMap
-  failed <- sendLocalMessages loc now sender senderClient mconn Nothing () metadata localMessages
+  failed <- sendLocalMessages @'Broadcast loc now sender senderClient mconn Nothing mempty metadata localMessages
   pure . mkQualifiedUserClientsByDomain $ Map.singleton (tDomain loc) failed
 
 byDomain :: Map (Domain, UserId, ClientId) a -> Map Domain (Map (UserId, ClientId) a)
@@ -516,11 +521,11 @@ sendLocalMessages ::
   ClientId ->
   Maybe ConnId ->
   Maybe (Qualified ConvId) ->
-  LocalMemberMap t ->
+  BotMap ->
   MessageMetadata ->
   Map (UserId, ClientId) Text ->
   Sem r (Set (UserId, ClientId))
-sendLocalMessages loc now sender senderClient mconn qcnv localMemberMap metadata localMessages = do
+sendLocalMessages loc now sender senderClient mconn qcnv botMap metadata localMessages = do
   let events =
         localMessages & reindexed (first (qualifyAs loc)) itraversed
           %@~ newMessageEvent
@@ -531,7 +536,7 @@ sendLocalMessages loc now sender senderClient mconn qcnv localMemberMap metadata
             now
       pushes =
         events & itraversed
-          %@~ newMessagePush loc localMemberMap mconn metadata
+          %@~ newMessagePush loc botMap mconn metadata
   runMessagePush @t loc qcnv (pushes ^. traversed)
   pure mempty
 

--- a/services/galley/src/Galley/API/Push.hs
+++ b/services/galley/src/Galley/API/Push.hs
@@ -102,12 +102,9 @@ newMessagePush ::
   Event ->
   MessagePush t
 newMessagePush loc members mconn mm (user, client) e = withSing @t $ \case
-  SNormalMessage -> fold $ do
-    member <- Map.lookup user members
-    newBotMessagePush member <|> newUserMessagePush loc mconn mm (lmId member) client e
-    where
-      newBotMessagePush :: LocalMember -> Maybe (MessagePush 'NormalMessage)
-      newBotMessagePush member = newBotPush <$> newBotMember member <*> pure e
+  SNormalMessage -> case newBotMember =<< Map.lookup user members of
+    Just bm -> newBotPush bm e
+    Nothing -> fold $ newUserMessagePush loc mconn mm user client e
   SBroadcast -> fold $ newUserMessagePush loc mconn mm user client e
 
 runMessagePush ::

--- a/services/galley/src/Galley/API/Push.hs
+++ b/services/galley/src/Galley/API/Push.hs
@@ -65,12 +65,12 @@ data instance MessagePush 'NormalMessage = NormalMessagePush
   { userPushes :: [Push],
     botPushes :: [(BotMember, Event)]
   }
-  deriving stock (Generic)
+  deriving stock (Generic, Show)
   deriving (Semigroup, Monoid) via GenericSemigroupMonoid (MessagePush 'NormalMessage)
 
 data instance MessagePush 'Broadcast = BroadcastPush
   {broadcastPushes :: [Push]}
-  deriving stock (Generic)
+  deriving stock (Generic, Show)
   deriving (Semigroup, Monoid) via GenericSemigroupMonoid (MessagePush 'Broadcast)
 
 newUserPush :: forall t. SingI t => Push -> MessagePush t

--- a/services/galley/src/Galley/API/Push.hs
+++ b/services/galley/src/Galley/API/Push.hs
@@ -19,11 +19,7 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Galley.API.Push
-  ( -- * Message metadata
-    MessageMetadata (..),
-    defMessageMetadata,
-
-    -- * Message pushes
+  ( -- * Message pushes
     MessagePush (..),
     MessageType (..),
     newBotPush,
@@ -57,23 +53,7 @@ import Polysemy
 import Polysemy.TinyLog
 import qualified System.Logger.Class as Log
 import Wire.API.Event.Conversation
-
-data MessageMetadata = MessageMetadata
-  { mmNativePush :: Bool,
-    mmTransient :: Bool,
-    mmNativePriority :: Maybe Priority,
-    mmData :: Maybe Text
-  }
-  deriving (Eq, Ord, Show)
-
-defMessageMetadata :: MessageMetadata
-defMessageMetadata =
-  MessageMetadata
-    { mmNativePush = True,
-      mmTransient = False,
-      mmNativePriority = Nothing,
-      mmData = Nothing
-    }
+import Wire.API.Message
 
 data MessageType = NormalMessage | Broadcast
 

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -174,17 +174,19 @@ newRemoteMemberWithRole :: Remote (UserId, RoleName) -> RemoteMember
 newRemoteMemberWithRole ur@(qUntagged -> (Qualified (u, r) _)) =
   RemoteMember
     { rmId = qualifyAs ur u,
-      rmConvRoleName = r
+      rmConvRoleName = r,
+      rmMLSClients = mempty
     }
 
 lookupRemoteMembers :: ConvId -> Client [RemoteMember]
 lookupRemoteMembers conv = do
   fmap (map mkMem) . retry x1 $ query Cql.selectRemoteMembers (params LocalQuorum (Identity conv))
   where
-    mkMem (domain, usr, role) =
+    mkMem (domain, usr, role, clients) =
       RemoteMember
         { rmId = toRemoteUnsafe domain usr,
-          rmConvRoleName = role
+          rmConvRoleName = role,
+          rmMLSClients = Set.fromList (fromSet clients)
         }
 
 member ::

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -322,10 +322,32 @@ removeLocalMembersFromRemoteConv (qUntagged -> Qualified conv convDomain) victim
     setConsistency LocalQuorum
     for_ victims $ \u -> addPrepQuery Cql.deleteUserRemoteConv (u, convDomain, conv)
 
-addMLSClients :: ConvId -> UserId -> Set.Set ClientId -> Client ()
-addMLSClients cid uid cs =
+addMLSClients :: Local ConvId -> Qualified UserId -> Set.Set ClientId -> Client ()
+addMLSClients lcnv =
+  foldQualified
+    lcnv
+    (addLocalMLSClients (tUnqualified lcnv))
+    (addRemoteMLSClients (tUnqualified lcnv))
+
+addRemoteMLSClients :: ConvId -> Remote UserId -> Set.Set ClientId -> Client ()
+addRemoteMLSClients cid ruid cs =
   retry x5 $
-    write Cql.addMLSClients (params LocalQuorum (Cassandra.Set (toList cs), cid, uid))
+    write
+      Cql.addRemoteMLSClients
+      ( params
+          LocalQuorum
+          (Cassandra.Set (toList cs), cid, tDomain ruid, tUnqualified ruid)
+      )
+
+addLocalMLSClients :: ConvId -> Local UserId -> Set.Set ClientId -> Client ()
+addLocalMLSClients cid lusr cs =
+  retry x5 $
+    write
+      Cql.addLocalMLSClients
+      ( params
+          LocalQuorum
+          (Cassandra.Set (toList cs), cid, tUnqualified lusr)
+      )
 
 interpretMemberStoreToCassandra ::
   Members '[Embed IO, Input ClientState] r =>
@@ -347,4 +369,4 @@ interpretMemberStoreToCassandra = interpret $ \case
   DeleteMembersInRemoteConversation rcnv uids ->
     embedClient $
       removeLocalMembersFromRemoteConv rcnv uids
-  AddMLSClients cid uid cs -> embedClient $ addMLSClients cid uid cs
+  AddMLSClients lcnv quid cs -> embedClient $ addMLSClients lcnv quid cs

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -359,8 +359,11 @@ rmMemberClient c =
 
 -- MLS Clients --------------------------------------------------------------
 
-addMLSClients :: PrepQuery W (C.Set ClientId, ConvId, UserId) ()
-addMLSClients = "update member set mls_clients = mls_clients + ? where conv = ? and user = ?"
+addLocalMLSClients :: PrepQuery W (C.Set ClientId, ConvId, UserId) ()
+addLocalMLSClients = "update member set mls_clients = mls_clients + ? where conv = ? and user = ?"
+
+addRemoteMLSClients :: PrepQuery W (C.Set ClientId, ConvId, Domain, UserId) ()
+addRemoteMLSClients = "update member_remote_user set mls_clients = mls_clients + ? where conv = ? and user_remote_domain = ? and user_remote_id = ?"
 
 -- Services -----------------------------------------------------------------
 

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -302,8 +302,8 @@ insertRemoteMember = "insert into member_remote_user (conv, user_remote_domain, 
 removeRemoteMember :: PrepQuery W (ConvId, Domain, UserId) ()
 removeRemoteMember = "delete from member_remote_user where conv = ? and user_remote_domain = ? and user_remote_id = ?"
 
-selectRemoteMembers :: PrepQuery R (Identity ConvId) (Domain, UserId, RoleName)
-selectRemoteMembers = "select user_remote_domain, user_remote_id, conversation_role from member_remote_user where conv = ?"
+selectRemoteMembers :: PrepQuery R (Identity ConvId) (Domain, UserId, RoleName, C.Set ClientId)
+selectRemoteMembers = "select user_remote_domain, user_remote_id, conversation_role, mls_clients from member_remote_user where conv = ?"
 
 updateRemoteMemberConvRoleName :: PrepQuery W (RoleName, ConvId, Domain, UserId) ()
 updateRemoteMemberConvRoleName = "update member_remote_user set conversation_role = ? where conv = ? and user_remote_domain = ? and user_remote_id = ?"

--- a/services/galley/src/Galley/Data/Services.hs
+++ b/services/galley/src/Galley/Data/Services.hs
@@ -34,7 +34,7 @@ import Imports
 -- | For now we assume bots to always be local
 --
 -- FUTUREWORK(federation): allow remote bots
-newtype BotMember = BotMember {fromBotMember :: LocalMember}
+newtype BotMember = BotMember {fromBotMember :: LocalMember} deriving (Show)
 
 instance Eq BotMember where
   (==) = (==) `on` botMemId

--- a/services/galley/src/Galley/Effects/BrigAccess.hs
+++ b/services/galley/src/Galley/Effects/BrigAccess.hs
@@ -49,7 +49,7 @@ module Galley.Effects.BrigAccess
 
     -- * MLS
     getClientByKeyPackageRef,
-    getMLSClients,
+    getLocalMLSClients,
 
     -- * Features
     getAccountFeatureConfigClient,
@@ -124,7 +124,7 @@ data BrigAccess m a where
   RemoveLegalHoldClientFromUser :: UserId -> BrigAccess m ()
   GetAccountFeatureConfigClient :: UserId -> BrigAccess m TeamFeatureStatusNoConfig
   GetClientByKeyPackageRef :: KeyPackageRef -> BrigAccess m (Maybe ClientIdentity)
-  GetMLSClients :: Qualified UserId -> SignatureSchemeTag -> BrigAccess m (Set ClientId)
+  GetLocalMLSClients :: Local UserId -> SignatureSchemeTag -> BrigAccess m (Set ClientId)
   UpdateSearchVisibilityInbound ::
     Multi.TeamStatusUpdate 'TeamFeatureSearchVisibilityInbound ->
     BrigAccess m ()

--- a/services/galley/src/Galley/Effects/MemberStore.hs
+++ b/services/galley/src/Galley/Effects/MemberStore.hs
@@ -67,7 +67,7 @@ data MemberStore m a where
   SetOtherMember :: Local ConvId -> Qualified UserId -> OtherMemberUpdate -> MemberStore m ()
   DeleteMembers :: ConvId -> UserList UserId -> MemberStore m ()
   DeleteMembersInRemoteConversation :: Remote ConvId -> [UserId] -> MemberStore m ()
-  AddMLSClients :: ConvId -> UserId -> Set ClientId -> MemberStore m ()
+  AddMLSClients :: Local ConvId -> Qualified UserId -> Set ClientId -> MemberStore m ()
 
 makeSem ''MemberStore
 

--- a/services/galley/src/Galley/Intra/Client.hs
+++ b/services/galley/src/Galley/Intra/Client.hs
@@ -23,7 +23,7 @@ module Galley.Intra.Client
     removeLegalHoldClientFromUser,
     getLegalHoldAuthToken,
     getClientByKeyPackageRef,
-    getMLSClients,
+    getLocalMLSClients,
   )
 where
 
@@ -182,8 +182,8 @@ getClientByKeyPackageRef ref = do
     else pure Nothing
 
 -- | Calls 'Brig.API.Internal.getMLSClients'.
-getMLSClients :: Qualified UserId -> SignatureSchemeTag -> App (Set ClientId)
-getMLSClients qusr ss =
+getLocalMLSClients :: Local UserId -> SignatureSchemeTag -> App (Set ClientId)
+getLocalMLSClients lusr ss =
   call
     Brig
     ( method GET
@@ -191,8 +191,7 @@ getMLSClients qusr ss =
           [ "i",
             "mls",
             "clients",
-            toByteString' (qDomain qusr),
-            toByteString' (qUnqualified qusr)
+            toByteString' (tUnqualified lusr)
           ]
         . queryItem "sig_scheme" (toByteString' (signatureSchemeName ss))
         . expect2xx

--- a/services/galley/src/Galley/Intra/Effects.hs
+++ b/services/galley/src/Galley/Intra/Effects.hs
@@ -78,7 +78,7 @@ interpretBrigAccess = interpret $ \case
     embedApp $ getAccountFeatureConfigClient uid
   GetClientByKeyPackageRef ref ->
     embedApp $ getClientByKeyPackageRef ref
-  GetMLSClients qusr ss -> embedApp $ getMLSClients qusr ss
+  GetLocalMLSClients qusr ss -> embedApp $ getLocalMLSClients qusr ss
   UpdateSearchVisibilityInbound status ->
     embedApp $ updateSearchVisibilityInbound status
 

--- a/services/galley/src/Galley/Intra/Push/Internal.hs
+++ b/services/galley/src/Galley/Intra/Push/Internal.hs
@@ -58,7 +58,7 @@ data RecipientBy user = Recipient
   { _recipientUserId :: user,
     _recipientClients :: RecipientClients
   }
-  deriving stock (Functor, Foldable, Traversable)
+  deriving stock (Functor, Foldable, Traversable, Show)
 
 makeLenses ''RecipientBy
 
@@ -75,7 +75,7 @@ data PushTo user = Push
     pushJson :: Object,
     pushRecipientListType :: Teams.ListType
   }
-  deriving stock (Functor, Foldable, Traversable)
+  deriving stock (Functor, Foldable, Traversable, Show)
 
 makeLenses ''PushTo
 

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -1238,7 +1238,7 @@ onMLSMessageSent = do
 
   -- send message to alice and check reception
   WS.bracketAsClientRN c [(alice, aliceC1), (alice, aliceC2), (eve, eveC)] $ \[wsA1, wsA2, wsE] -> do
-    runFedClient @"on-mls-message-sent" fedGalleyClient bdom rm
+    void $ runFedClient @"on-mls-message-sent" fedGalleyClient bdom rm
     liftIO $ do
       -- alice should receive the message on her first client
       WS.assertMatch_ (5 # Second) wsA1 $ \n -> wsAssertMLSMessage qconv qbob txt n

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -90,6 +90,7 @@ data MessagingSetup = MessagingSetup
     welcome :: ByteString,
     commit :: ByteString
   }
+  deriving (Show)
 
 data Participant = Participant
   { pUserId :: Qualified UserId,

--- a/services/galley/test/unit/Test/Galley/Mapping.hs
+++ b/services/galley/test/unit/Test/Galley/Mapping.hs
@@ -110,7 +110,7 @@ genLocalMember =
     <*> arbitrary
 
 genRemoteMember :: Gen RemoteMember
-genRemoteMember = RemoteMember <$> arbitrary <*> pure roleNameWireMember
+genRemoteMember = RemoteMember <$> arbitrary <*> pure roleNameWireMember <*> arbitrary
 
 genConversation :: Gen Data.Conversation
 genConversation =


### PR DESCRIPTION
Propagate MLS messages to remote conversation participants. This adds a new federation endpoint (`send-mls-messages`) and also restructures the function for constructing message pushes so that it does not need a member map anymore, only a map of bots.

This PR also adds an `mls-clients` column to the table containing remote members of a local conversation.

Tracked by https://wearezeta.atlassian.net/browse/FS-510

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
