### PR TITLE
Cannon:  Drain websockets in a controlled fashion on SIGTERM or SIGINT

### DIFF
--- a/changelog.d/0-release-notes/cannon-drain
+++ b/changelog.d/0-release-notes/cannon-drain
@@ -1,0 +1,2 @@
+The `.cannon.drainTimeout` setting on the wire-server helm chart has been
+removed and replaced with `.cannon.config.drainOpts`.

--- a/changelog.d/2-features/cannon-drain
+++ b/changelog.d/2-features/cannon-drain
@@ -1,0 +1,4 @@
+Drain websockets in a controlled fashion when cannon receives a SIGTERM or
+SIGINT. Instead of waiting for connections to close on their own, the websockets
+are now severed at a controlled pace. This allows for quicker rollouts of new
+versions.

--- a/charts/cannon/templates/configmap.yaml
+++ b/charts/cannon/templates/configmap.yaml
@@ -13,6 +13,12 @@ data:
     gundeck:
       host: gundeck
       port: 8080
+
+    drainOpts:
+      gracePeriodSeconds: {{ .Values.config.drainOpts.gracePeriodSeconds }}
+      millisecondsBetweenBatches: {{ .Values.config.drainOpts.millisecondsBetweenBatches }}
+      minBatchSize: {{ .Values.config.drainOpts.minBatchSize }}
+
 kind: ConfigMap
 metadata:
   name: cannon

--- a/charts/cannon/templates/statefulset.yaml
+++ b/charts/cannon/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
       initContainers:
       - name: cannon-configurator
-        image: alpine:3.13.1
+        image: alpine:3.15.4
         command:
         - /bin/sh
         args:

--- a/charts/cannon/templates/statefulset.yaml
+++ b/charts/cannon/templates/statefulset.yaml
@@ -30,17 +30,10 @@ spec:
       annotations:
         checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
-      terminationGracePeriodSeconds: {{ .Values.drainTimeout }} # should be higher than the sleep duration of preStop
+      terminationGracePeriodSeconds: {{ add .Values.config.drainOpts.gracePeriodSeconds 5 }}
       containers:
       - name: cannon
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        lifecycle:
-          preStop:
-            # kubernetes by default immediately sends a SIGTERM to the container,
-            # which would cause cannon to exit, breaking existing websocket connections.
-            # Instead we sleep for a day. (SIGTERM is still sent, but after the preStop completes)
-            exec:
-              command: ["sleep", {{ .Values.drainTimeout | quote }} ]
         volumeMounts:
         - name: empty
           mountPath: /etc/wire/cannon/externalHost

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -5,6 +5,13 @@ image:
   pullPolicy: IfNotPresent
 config:
   logLevel: Info
+  drainOpts:
+    # The following drains a minimum of 400 connections/second
+    # for a total of 10000 over 25 seconds
+    # (if cannon holds more connections, draining will happen at a faster pace)
+    gracePeriodSeconds: 25
+    millisecondsBetweenBatches: 50
+    minBatchSize: 20
 resources:
   requests:
     memory: "256Mi"

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -5,6 +5,9 @@ image:
   pullPolicy: IfNotPresent
 config:
   logLevel: Info
+
+  # See also the section 'Controlling the speed of websocket draining during
+  # cannon pod replacement' in docs/how-to/install/configuration-options.rst
   drainOpts:
     # The following drains a minimum of 400 connections/second
     # for a total of 10000 over 25 seconds

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -23,4 +23,3 @@ service:
   name: cannon
   internalPort: 8080
   externalPort: 8080
-drainTimeout: 0

--- a/deploy/services-demo/conf/cannon.demo-docker.yaml
+++ b/deploy/services-demo/conf/cannon.demo-docker.yaml
@@ -7,5 +7,10 @@ gundeck:
   host: gundeck
   port: 8086
 
+drainOpts:
+  gracePeriodSeconds: 1
+  millisecondsBetweenBatches: 5
+  minBatchSize: 100
+
 logLevel: Info
 logNetStrings: false

--- a/deploy/services-demo/conf/cannon.demo.yaml
+++ b/deploy/services-demo/conf/cannon.demo.yaml
@@ -7,5 +7,10 @@ gundeck:
   host: 127.0.0.1
   port: 8086
 
+drainOpts:
+  gracePeriodSeconds: 1
+  millisecondsBetweenBatches: 5
+  minBatchSize: 100
+
 logLevel: Info
 logNetStrings: false

--- a/services/cannon/cannon.cabal
+++ b/services/cannon/cannon.cabal
@@ -89,6 +89,7 @@ library
     , data-timeout >=0.3
     , exceptions >=0.6
     , extended
+    , extra
     , gundeck-types
     , hashable >=1.2
     , http-types >=0.8
@@ -107,6 +108,7 @@ library
     , text >=1.1
     , tinylog >=0.10
     , types-common >=0.16
+    , unliftio
     , uuid >=1.3
     , vector >=0.10
     , wai >=3.0

--- a/services/cannon/cannon.cabal
+++ b/services/cannon/cannon.cabal
@@ -108,6 +108,7 @@ library
     , text >=1.1
     , tinylog >=0.10
     , types-common >=0.16
+    , unix
     , unliftio
     , uuid >=1.3
     , vector >=0.10

--- a/services/cannon/cannon.integration.yaml
+++ b/services/cannon/cannon.integration.yaml
@@ -18,8 +18,8 @@ gundeck:
 
 drainOpts:
   gracePeriodSeconds: 1
-  millisecondsBetweenBatches: 5
-  minBatchSize: 100
+  millisecondsBetweenBatches: 500
+  minBatchSize: 5
 
 logLevel: Info
 logNetStrings: false

--- a/services/cannon/cannon.integration.yaml
+++ b/services/cannon/cannon.integration.yaml
@@ -16,5 +16,10 @@ gundeck:
   host: 127.0.0.1
   port: 8086
 
+drainOpts:
+  gracePeriodSeconds: 1
+  millisecondsBetweenBatches: 5
+  minBatchSize: 100
+
 logLevel: Info
 logNetStrings: false

--- a/services/cannon/cannon2.integration.yaml
+++ b/services/cannon/cannon2.integration.yaml
@@ -16,5 +16,10 @@ gundeck:
   host: 127.0.0.1
   port: 8086
 
+drainOpts:
+  gracePeriodSeconds: 1
+  millisecondsBetweenBatches: 5
+  minBatchSize: 100
+
 logLevel: Info
 logNetStrings: false

--- a/services/cannon/package.yaml
+++ b/services/cannon/package.yaml
@@ -44,6 +44,7 @@ library:
   - text >=1.1
   - tinylog >=0.10
   - types-common >=0.16
+  - unix
   - unliftio
   - uuid >=1.3
   - vector >=0.10

--- a/services/cannon/package.yaml
+++ b/services/cannon/package.yaml
@@ -26,6 +26,7 @@ library:
   - data-default >=0.5
   - data-timeout >=0.3
   - exceptions >=0.6
+  - extra
   - gundeck-types
   - hashable >=1.2
   - http-types >=0.8
@@ -43,6 +44,7 @@ library:
   - text >=1.1
   - tinylog >=0.10
   - types-common >=0.16
+  - unliftio
   - uuid >=1.3
   - vector >=0.10
   - wai >=3.0

--- a/services/cannon/src/Cannon/Dict.hs
+++ b/services/cannon/src/Cannon/Dict.hs
@@ -24,6 +24,7 @@ module Cannon.Dict
     removeIf,
     lookup,
     size,
+    toList,
   )
 where
 
@@ -32,10 +33,11 @@ import Data.SizedHashMap (SizedHashMap)
 import qualified Data.SizedHashMap as SHM
 import Data.Vector (Vector, (!))
 import qualified Data.Vector as V
-import Imports hiding (lookup)
+import Imports hiding (lookup, toList)
 
 newtype Dict a b = Dict
-  {_map :: Vector (IORef (SizedHashMap a b))}
+  { _map :: Vector (IORef (SizedHashMap a b))
+  }
 
 size :: MonadIO m => Dict a b -> m Int
 size d = liftIO $ sum <$> mapM (\r -> SHM.size <$> readIORef r) (_map d)
@@ -67,6 +69,12 @@ removeIf f k d = liftIO . atomicModifyIORef' (getSlice k d) $ \m ->
 
 lookup :: (Eq a, Hashable a, MonadIO m) => a -> Dict a b -> m (Maybe b)
 lookup k = liftIO . fmap (SHM.lookup k) . readIORef . getSlice k
+
+toList :: (MonadIO m, Hashable a) => Dict a b -> m [(a, b)]
+toList =
+  fmap (mconcat . V.toList)
+    . V.mapM (fmap SHM.toList . readIORef)
+    . _map
 
 -----------------------------------------------------------------------------
 -- Internal

--- a/services/cannon/src/Cannon/Options.hs
+++ b/services/cannon/src/Cannon/Options.hs
@@ -66,10 +66,10 @@ makeFields ''Gundeck
 deriveApiFieldJSON ''Gundeck
 
 data DrainOpts = DrainOpts
-  { -- | Maximum amount of time draining should take
+  { -- | Maximum amount of time draining should take. Must not be set to 0.
     _drainOptsGracePeriodSeconds :: Word64,
     -- | Maximum amount of time between batches, this speeds up draining in case
-    -- there are not many users connected
+    -- there are not many users connected. Must not be set to 0.
     _drainOptsMillisecondsBetweenBatches :: Word64,
     -- | Batch size is calculated considering actual number of websockets and
     -- gracePeriod. If this number is too little, '_drainOptsMinBatchSize' is

--- a/services/cannon/src/Cannon/Options.hs
+++ b/services/cannon/src/Cannon/Options.hs
@@ -29,7 +29,12 @@ module Cannon.Options
     logLevel,
     logNetStrings,
     logFormat,
+    drainOpts,
     Opts,
+    gracePeriodSeconds,
+    millisecondsBetweenBatches,
+    minBatchSize,
+    DrainOpts,
   )
 where
 
@@ -60,12 +65,30 @@ makeFields ''Gundeck
 
 deriveApiFieldJSON ''Gundeck
 
+data DrainOpts = DrainOpts
+  { -- | Maximum amount of time draining should take
+    _drainOptsGracePeriodSeconds :: Word64,
+    -- | Maximum amount of time between batches, this speeds up draining in case
+    -- there are not many users connected
+    _drainOptsMillisecondsBetweenBatches :: Word64,
+    -- | Batch size is calculated considering actual number of websockets and
+    -- gracePeriod. If this number is too little, '_drainOptsMinBatchSize' is
+    -- used.
+    _drainOptsMinBatchSize :: Word64
+  }
+  deriving (Eq, Show, Generic)
+
+makeFields ''DrainOpts
+
+deriveApiFieldJSON ''DrainOpts
+
 data Opts = Opts
   { _optsCannon :: !Cannon,
     _optsGundeck :: !Gundeck,
     _optsLogLevel :: !Level,
     _optsLogNetStrings :: !(Maybe (Last Bool)),
-    _optsLogFormat :: !(Maybe (Last LogFormat))
+    _optsLogFormat :: !(Maybe (Last LogFormat)),
+    _optsDrainOpts :: DrainOpts
   }
   deriving (Eq, Show, Generic)
 

--- a/services/cannon/src/Cannon/Types.hs
+++ b/services/cannon/src/Cannon/Types.hs
@@ -109,7 +109,7 @@ mkEnv ::
   Env
 mkEnv m external o l d p g t =
   Env m o l d def $
-    WS.env external (o ^. cannon . port) (encodeUtf8 $ o ^. gundeck . host) (o ^. gundeck . port) l p d g t
+    WS.env external (o ^. cannon . port) (encodeUtf8 $ o ^. gundeck . host) (o ^. gundeck . port) l p d g t (o ^. drainOpts)
 
 runCannon :: Env -> Cannon a -> Request -> IO a
 runCannon e c r =

--- a/services/cannon/src/Cannon/WS.hs
+++ b/services/cannon/src/Cannon/WS.hs
@@ -76,8 +76,7 @@ import Network.WebSockets hiding (Request)
 import qualified System.Logger as Logger
 import System.Logger.Class hiding (Error, Settings, close, (.=))
 import System.Random.MWC (GenIO, uniform)
-import UnliftIO (cancel, pooledMapConcurrentlyN_, race_)
-import UnliftIO.Async (async)
+import UnliftIO.Async (async, cancel, pooledMapConcurrentlyN_)
 
 -----------------------------------------------------------------------------
 -- Key

--- a/services/cannon/src/Cannon/WS.hs
+++ b/services/cannon/src/Cannon/WS.hs
@@ -257,7 +257,7 @@ drain = do
   numberOfConns <- fromIntegral <$> D.size websockets
   let maxNumberOfBatches = (opts ^. gracePeriodSeconds * 1000) `div` (opts ^. millisecondsBetweenBatches)
       computedBatchSize = numberOfConns `div` maxNumberOfBatches
-      batchSize = min (opts ^. minBatchSize) computedBatchSize
+      batchSize = max (opts ^. minBatchSize) computedBatchSize
   conns <- D.toList websockets
   info $
     msg (val "draining all websockets")


### PR DESCRIPTION
The plan to implement this is described internally here: https://wearezeta.atlassian.net/wiki/spaces/PS/pages/585564424/How+to+gracefully+drain+cannon+but+not+so+slowly

Related PR: https://github.com/zinfra/cailleach/pull/1092

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
