### PR TITLE
SQSERVICES-1561 add lock status to all features as hard wired default plus optionall server yaml and or db default unlocked

### DIFF
--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -38,7 +38,6 @@ module Galley.Types.Teams
     flagTeamFeatureSndFactorPasswordChallengeStatus,
     flagTeamFeatureSearchVisibilityInbound,
     Defaults (..),
-    unDefaults,
     FeatureSSO (..),
     FeatureLegalHold (..),
     FeatureTeamSearchVisibility (..),
@@ -220,15 +219,15 @@ data FeatureFlags = FeatureFlags
   { _flagSSO :: !FeatureSSO,
     _flagLegalHold :: !FeatureLegalHold,
     _flagTeamSearchVisibility :: !FeatureTeamSearchVisibility,
-    _flagAppLockDefaults :: !(Defaults (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureAppLock)),
+    _flagAppLockDefaults :: !(TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureAppLock),
     _flagClassifiedDomains :: !(TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureClassifiedDomains),
-    _flagFileSharing :: !(Defaults (TeamFeatureStatus 'WithLockStatus 'TeamFeatureFileSharing)),
-    _flagConferenceCalling :: !(Defaults (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureConferenceCalling)),
-    _flagSelfDeletingMessages :: !(Defaults (TeamFeatureStatus 'WithLockStatus 'TeamFeatureSelfDeletingMessages)),
-    _flagConversationGuestLinks :: !(Defaults (TeamFeatureStatus 'WithLockStatus 'TeamFeatureGuestLinks)),
-    _flagsTeamFeatureValidateSAMLEmailsStatus :: !(Defaults (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails)),
-    _flagTeamFeatureSndFactorPasswordChallengeStatus :: !(Defaults (TeamFeatureStatus 'WithLockStatus 'TeamFeatureSndFactorPasswordChallenge)),
-    _flagTeamFeatureSearchVisibilityInbound :: !(Defaults (TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureSearchVisibilityInbound))
+    _flagFileSharing :: !(TeamFeatureStatus 'WithLockStatus 'TeamFeatureFileSharing),
+    _flagConferenceCalling :: !(TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureConferenceCalling),
+    _flagSelfDeletingMessages :: !(TeamFeatureStatus 'WithLockStatus 'TeamFeatureSelfDeletingMessages),
+    _flagConversationGuestLinks :: !(TeamFeatureStatus 'WithLockStatus 'TeamFeatureGuestLinks),
+    _flagsTeamFeatureValidateSAMLEmailsStatus :: !(TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails),
+    _flagTeamFeatureSndFactorPasswordChallengeStatus :: !(TeamFeatureStatus 'WithLockStatus 'TeamFeatureSndFactorPasswordChallenge),
+    _flagTeamFeatureSearchVisibilityInbound :: !(TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureSearchVisibilityInbound)
   }
   deriving (Eq, Show, Generic)
 
@@ -270,15 +269,15 @@ instance FromJSON FeatureFlags where
       <$> obj .: "sso"
       <*> obj .: "legalhold"
       <*> obj .: "teamSearchVisibility"
-      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureAppLock)) <$> (obj .:? "appLock"))
+      <*> (maybe (defTeamFeatureStatus @'TeamFeatureAppLock) _unDefaults <$> (obj .:? "appLock"))
       <*> (fromMaybe (defTeamFeatureStatus @'TeamFeatureClassifiedDomains) <$> (obj .:? "classifiedDomains"))
-      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureFileSharing)) <$> (obj .:? "fileSharing"))
-      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureConferenceCalling)) <$> (obj .:? "conferenceCalling"))
-      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureSelfDeletingMessages)) <$> (obj .:? "selfDeletingMessages"))
-      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureGuestLinks)) <$> (obj .:? "conversationGuestLinks"))
-      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureValidateSAMLEmails)) <$> (obj .:? "validateSAMLEmails"))
-      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureSndFactorPasswordChallenge)) <$> (obj .:? "sndFactorPasswordChallenge"))
-      <*> (fromMaybe (Defaults (defTeamFeatureStatus @'TeamFeatureSearchVisibilityInbound)) <$> (obj .:? "searchVisibilityInbound"))
+      <*> (maybe (defTeamFeatureStatus @'TeamFeatureFileSharing) _unDefaults <$> (obj .:? "fileSharing"))
+      <*> (maybe (defTeamFeatureStatus @'TeamFeatureConferenceCalling) _unDefaults <$> (obj .:? "conferenceCalling"))
+      <*> (maybe (defTeamFeatureStatus @'TeamFeatureSelfDeletingMessages) _unDefaults <$> (obj .:? "selfDeletingMessages"))
+      <*> (maybe (defTeamFeatureStatus @'TeamFeatureGuestLinks) _unDefaults <$> (obj .:? "conversationGuestLinks"))
+      <*> (maybe (defTeamFeatureStatus @'TeamFeatureValidateSAMLEmails) _unDefaults <$> (obj .:? "validateSAMLEmails"))
+      <*> (maybe (defTeamFeatureStatus @'TeamFeatureSndFactorPasswordChallenge) _unDefaults <$> (obj .:? "sndFactorPasswordChallenge"))
+      <*> (maybe (defTeamFeatureStatus @'TeamFeatureSearchVisibilityInbound) _unDefaults <$> (obj .:? "searchVisibilityInbound"))
 
 instance ToJSON FeatureFlags where
   toJSON
@@ -300,15 +299,15 @@ instance ToJSON FeatureFlags where
         [ "sso" .= sso,
           "legalhold" .= legalhold,
           "teamSearchVisibility" .= searchVisibility,
-          "appLock" .= appLock,
+          "appLock" .= Defaults appLock,
           "classifiedDomains" .= classifiedDomains,
-          "fileSharing" .= fileSharing,
-          "conferenceCalling" .= conferenceCalling,
-          "selfDeletingMessages" .= selfDeletingMessages,
-          "conversationGuestLinks" .= guestLinks,
-          "validateSAMLEmails" .= validateSAMLEmails,
-          "sndFactorPasswordChallenge" .= sndFactorPasswordChallenge,
-          "searchVisibilityInbound" .= searchVisibilityInbound
+          "fileSharing" .= Defaults fileSharing,
+          "conferenceCalling" .= Defaults conferenceCalling,
+          "selfDeletingMessages" .= Defaults selfDeletingMessages,
+          "conversationGuestLinks" .= Defaults guestLinks,
+          "validateSAMLEmails" .= Defaults validateSAMLEmails,
+          "sndFactorPasswordChallenge" .= Defaults sndFactorPasswordChallenge,
+          "searchVisibilityInbound" .= Defaults searchVisibilityInbound
         ]
 
 instance FromJSON FeatureSSO where
@@ -342,7 +341,6 @@ instance ToJSON FeatureTeamSearchVisibility where
 
 makeLenses ''TeamCreationTime
 makeLenses ''FeatureFlags
-makeLenses ''Defaults
 
 -- Note [hidden team roles]
 --

--- a/libs/galley-types/test/unit/Test/Galley/Types.hs
+++ b/libs/galley-types/test/unit/Test/Galley/Types.hs
@@ -32,6 +32,7 @@ import qualified Test.QuickCheck as QC
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
+import Wire.API.Team.Feature as Public
 
 tests :: TestTree
 tests =
@@ -90,6 +91,8 @@ instance Arbitrary FeatureFlags where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      -- the default lock status is implicitly added on deserialization and ignored on serialization, therefore we need to fix it to the default here
+      -- we will be able to remove this once the lock status is explicitly included in the config
+      <*> (arbitrary <&> \status -> status {Public.tfwoapsLockStatus = Public.Unlocked})
       <*> arbitrary
       <*> arbitrary

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1103,7 +1103,7 @@ type FeatureAPI =
     :<|> SearchVisibilityGet
     :<|> SearchVisibilitySet
     :<|> FeatureStatusGet 'TeamFeatureValidateSAMLEmails
-    :<|> FeatureStatusDeprecatedGet 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails
+    :<|> FeatureStatusDeprecatedGet 'WithLockStatus 'TeamFeatureValidateSAMLEmails
     :<|> FeatureStatusGet 'TeamFeatureDigitalSignatures
     :<|> FeatureStatusDeprecatedGet 'WithoutLockStatus 'TeamFeatureDigitalSignatures
     :<|> FeatureStatusGet 'TeamFeatureAppLock
@@ -1123,7 +1123,7 @@ type FeatureAPI =
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureLegalHold
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureSSO
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureSearchVisibility
-    :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails
+    :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureValidateSAMLEmails
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureDigitalSignatures
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureAppLock
     :<|> FeatureConfigGet 'WithLockStatus 'TeamFeatureFileSharing

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -317,7 +317,8 @@ type family TeamFeatureStatus (ps :: IncludeLockStatus) (a :: TeamFeatureName) :
   TeamFeatureStatus _ 'TeamFeatureLegalHold = TeamFeatureStatusNoConfig
   TeamFeatureStatus _ 'TeamFeatureSSO = TeamFeatureStatusNoConfig
   TeamFeatureStatus _ 'TeamFeatureSearchVisibility = TeamFeatureStatusNoConfig
-  TeamFeatureStatus _ 'TeamFeatureValidateSAMLEmails = TeamFeatureStatusNoConfig
+  TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails = TeamFeatureStatusNoConfig
+  TeamFeatureStatus 'WithLockStatus 'TeamFeatureValidateSAMLEmails = TeamFeatureStatusNoConfigAndLockStatus
   TeamFeatureStatus _ 'TeamFeatureDigitalSignatures = TeamFeatureStatusNoConfig
   TeamFeatureStatus _ 'TeamFeatureAppLock = TeamFeatureStatusWithConfig TeamFeatureAppLockConfig
   TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureFileSharing = TeamFeatureStatusNoConfig
@@ -353,18 +354,18 @@ modelForTeamFeature TeamFeatureSndFactorPasswordChallenge = modelTeamFeatureStat
 modelForTeamFeature TeamFeatureSearchVisibilityInbound = modelTeamFeatureStatusNoConfig
 
 data AllFeatureConfigs = AllFeatureConfigs
-  { afcLegalholdStatusInternal :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureLegalHold,
-    afcSSOStatusInternal :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureSSO,
-    afcTeamSearchVisibilityAvailableInternal :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureSearchVisibility,
-    afcValidateSAMLEmailsInternal :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureValidateSAMLEmails,
-    afcDigitalSignaturesInternal :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureDigitalSignatures,
-    afcAppLockInternal :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureAppLock,
-    afcFileSharingInternal :: TeamFeatureStatus 'WithLockStatus 'TeamFeatureFileSharing,
-    afcClassifiedDomainsInternal :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureClassifiedDomains,
-    afcConferenceCallingInternal :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureConferenceCalling,
-    afcSelfDeletingMessagesInternal :: TeamFeatureStatus 'WithLockStatus 'TeamFeatureSelfDeletingMessages,
-    afcGuestLinkInternal :: TeamFeatureStatus 'WithLockStatus 'TeamFeatureGuestLinks,
-    afcSndFactorPasswordChallengeInternal :: TeamFeatureStatus 'WithLockStatus 'TeamFeatureSndFactorPasswordChallenge
+  { afcLegalholdStatus :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureLegalHold,
+    afcSSOStatus :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureSSO,
+    afcTeamSearchVisibilityAvailable :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureSearchVisibility,
+    afcValidateSAMLEmails :: TeamFeatureStatus 'WithLockStatus 'TeamFeatureValidateSAMLEmails,
+    afcDigitalSignatures :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureDigitalSignatures,
+    afcAppLock :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureAppLock,
+    afcFileSharing :: TeamFeatureStatus 'WithLockStatus 'TeamFeatureFileSharing,
+    afcClassifiedDomains :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureClassifiedDomains,
+    afcConferenceCalling :: TeamFeatureStatus 'WithoutLockStatus 'TeamFeatureConferenceCalling,
+    afcSelfDeletingMessages :: TeamFeatureStatus 'WithLockStatus 'TeamFeatureSelfDeletingMessages,
+    afcGuestLink :: TeamFeatureStatus 'WithLockStatus 'TeamFeatureGuestLinks,
+    afcSndFactorPasswordChallenge :: TeamFeatureStatus 'WithLockStatus 'TeamFeatureSndFactorPasswordChallenge
   }
   deriving stock (Eq, Show)
   deriving (FromJSON, ToJSON, S.ToSchema) via (Schema AllFeatureConfigs)
@@ -373,18 +374,18 @@ instance ToSchema AllFeatureConfigs where
   schema =
     object "AllFeatureConfigs" $
       AllFeatureConfigs
-        <$> afcLegalholdStatusInternal .= field (name @'TeamFeatureLegalHold) schema
-        <*> afcSSOStatusInternal .= field (name @'TeamFeatureSSO) schema
-        <*> afcTeamSearchVisibilityAvailableInternal .= field (name @'TeamFeatureSearchVisibility) schema
-        <*> afcValidateSAMLEmailsInternal .= field (name @'TeamFeatureValidateSAMLEmails) schema
-        <*> afcDigitalSignaturesInternal .= field (name @'TeamFeatureDigitalSignatures) schema
-        <*> afcAppLockInternal .= field (name @'TeamFeatureAppLock) schema
-        <*> afcFileSharingInternal .= field (name @'TeamFeatureFileSharing) schema
-        <*> afcClassifiedDomainsInternal .= field (name @'TeamFeatureClassifiedDomains) schema
-        <*> afcConferenceCallingInternal .= field (name @'TeamFeatureConferenceCalling) schema
-        <*> afcSelfDeletingMessagesInternal .= field (name @'TeamFeatureSelfDeletingMessages) schema
-        <*> afcGuestLinkInternal .= field (name @'TeamFeatureGuestLinks) schema
-        <*> afcSndFactorPasswordChallengeInternal .= field (name @'TeamFeatureSndFactorPasswordChallenge) schema
+        <$> afcLegalholdStatus .= field (name @'TeamFeatureLegalHold) schema
+        <*> afcSSOStatus .= field (name @'TeamFeatureSSO) schema
+        <*> afcTeamSearchVisibilityAvailable .= field (name @'TeamFeatureSearchVisibility) schema
+        <*> afcValidateSAMLEmails .= field (name @'TeamFeatureValidateSAMLEmails) schema
+        <*> afcDigitalSignatures .= field (name @'TeamFeatureDigitalSignatures) schema
+        <*> afcAppLock .= field (name @'TeamFeatureAppLock) schema
+        <*> afcFileSharing .= field (name @'TeamFeatureFileSharing) schema
+        <*> afcClassifiedDomains .= field (name @'TeamFeatureClassifiedDomains) schema
+        <*> afcConferenceCalling .= field (name @'TeamFeatureConferenceCalling) schema
+        <*> afcSelfDeletingMessages .= field (name @'TeamFeatureSelfDeletingMessages) schema
+        <*> afcGuestLink .= field (name @'TeamFeatureGuestLinks) schema
+        <*> afcSndFactorPasswordChallenge .= field (name @'TeamFeatureSndFactorPasswordChallenge) schema
     where
       name :: forall a. KnownTeamFeatureName a => Text
       name = cs (toByteString' (knownTeamFeatureName @a))
@@ -660,7 +661,7 @@ instance DefTeamFeatureStatus 'TeamFeatureGuestLinks where
   defTeamFeatureStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Unlocked
 
 instance DefTeamFeatureStatus 'TeamFeatureValidateSAMLEmails where
-  defTeamFeatureStatus = TeamFeatureStatusNoConfig TeamFeatureEnabled
+  defTeamFeatureStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Unlocked
 
 instance DefTeamFeatureStatus 'TeamFeatureSndFactorPasswordChallenge where
   defTeamFeatureStatus = TeamFeatureStatusNoConfigAndLockStatus TeamFeatureDisabled Locked

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -123,11 +123,13 @@ type IFeatureAPI =
             )
            'TeamFeatureLegalHold
     :<|> IFeatureStatus '() 'TeamFeatureSearchVisibility
-    :<|> IFeatureStatusDeprecated 'TeamFeatureSearchVisibility
-    :<|> IFeatureStatus '() 'TeamFeatureValidateSAMLEmails
-    :<|> IFeatureStatusDeprecated 'TeamFeatureValidateSAMLEmails
+    :<|> IFeatureStatusDeprecated 'WithoutLockStatus 'TeamFeatureSearchVisibility
+    :<|> IFeatureStatusGet 'WithLockStatus 'TeamFeatureValidateSAMLEmails
+    :<|> IFeatureStatusPut '() 'TeamFeatureValidateSAMLEmails
+    :<|> Named '("iget-deprecated", 'TeamFeatureValidateSAMLEmails) (FeatureStatusBaseDeprecatedGet 'WithLockStatus 'TeamFeatureValidateSAMLEmails)
+    :<|> Named '("iput-deprecated", 'TeamFeatureValidateSAMLEmails) (FeatureStatusBaseDeprecatedPut 'TeamFeatureValidateSAMLEmails)
     :<|> IFeatureStatus '() 'TeamFeatureDigitalSignatures
-    :<|> IFeatureStatusDeprecated 'TeamFeatureDigitalSignatures
+    :<|> IFeatureStatusDeprecated 'WithoutLockStatus 'TeamFeatureDigitalSignatures
     :<|> IFeatureStatus '() 'TeamFeatureAppLock
     :<|> IFeatureStatusWithLock '() 'TeamFeatureFileSharing
     :<|> IFeatureStatusGet 'WithLockStatus 'TeamFeatureClassifiedDomains
@@ -316,8 +318,8 @@ type IFeatureStatusPut errs f = Named '("iput", f) (FeatureStatusBasePut errs f)
 
 type IFeatureStatus errs f = IFeatureStatusGet 'WithoutLockStatus f :<|> IFeatureStatusPut errs f
 
-type IFeatureStatusDeprecated f =
-  Named '("iget-deprecated", f) (FeatureStatusBaseDeprecatedGet 'WithoutLockStatus f)
+type IFeatureStatusDeprecated l f =
+  Named '("iget-deprecated", f) (FeatureStatusBaseDeprecatedGet l f)
     :<|> Named '("iput-deprecated", f) (FeatureStatusBaseDeprecatedPut f)
 
 type IFeatureStatusLockStatusPut featureName =
@@ -408,8 +410,10 @@ featureAPI =
     <@> fs getLegalholdStatusInternal (setLegalholdStatusInternal @InternalPaging)
     <@> fs getTeamSearchVisibilityAvailableInternal setTeamSearchVisibilityAvailableInternal
     <@> fs getTeamSearchVisibilityAvailableInternal setTeamSearchVisibilityAvailableInternal
-    <@> fs getValidateSAMLEmailsInternal setValidateSAMLEmailsInternal
-    <@> fs getValidateSAMLEmailsInternal setValidateSAMLEmailsInternal
+    <@> fsGet getValidateSAMLEmailsInternal
+    <@> fsSet setValidateSAMLEmailsInternal
+    <@> fsGet getValidateSAMLEmailsInternal
+    <@> fsSet setValidateSAMLEmailsInternal
     <@> fs getDigitalSignaturesInternal setDigitalSignaturesInternal
     <@> fs getDigitalSignaturesInternal setDigitalSignaturesInternal
     <@> fs getAppLockInternal setAppLockInternal

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -149,12 +149,12 @@ servantSitemap =
         <@> mkNamedAPI @"get-search-visibility" getSearchVisibility
         <@> mkNamedAPI @"set-search-visibility" setSearchVisibility
         <@> mkNamedAPI @'("get", 'TeamFeatureValidateSAMLEmails)
-          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureValidateSAMLEmails
+          ( getFeatureStatus @'WithLockStatus @'TeamFeatureValidateSAMLEmails
               getValidateSAMLEmailsInternal
               . DoAuth
           )
         <@> mkNamedAPI @'("get-deprecated", 'TeamFeatureValidateSAMLEmails)
-          ( getFeatureStatus @'WithoutLockStatus @'TeamFeatureValidateSAMLEmails
+          ( getFeatureStatus @'WithLockStatus @'TeamFeatureValidateSAMLEmails
               getValidateSAMLEmailsInternal
               . DoAuth
           )
@@ -243,7 +243,7 @@ servantSitemap =
               getTeamSearchVisibilityAvailableInternal
           )
         <@> mkNamedAPI @'("get-config", 'TeamFeatureValidateSAMLEmails)
-          ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureValidateSAMLEmails
+          ( getFeatureConfig @'WithLockStatus @'TeamFeatureValidateSAMLEmails
               getValidateSAMLEmailsInternal
           )
         <@> mkNamedAPI @'("get-config", 'TeamFeatureDigitalSignatures)

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -592,7 +592,7 @@ getConversationGuestLinksStatusValue ::
   Maybe TeamId ->
   Sem r TeamFeatureStatusValue
 getConversationGuestLinksStatusValue mbTid = do
-  defaultStatus <- tfwoapsStatus <$> (input <&> view (optSettings . setFeatureFlags . flagConversationGuestLinks . unDefaults))
+  defaultStatus <- tfwoapsStatus <$> (input <&> view (optSettings . setFeatureFlags . flagConversationGuestLinks))
   maybe defaultStatus tfwoStatus . join <$> TeamFeatures.getFeatureStatusNoConfig @'TeamFeatureGuestLinks `traverse` mbTid
 
 -------------------------------------------------------------------------------

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -488,7 +488,6 @@ testSelfDeletingMessages = do
           . optSettings
           . setFeatureFlags
           . flagSelfDeletingMessages
-          . unDefaults
           . to Public.tfwcapsLockStatus
       )
 
@@ -637,7 +636,6 @@ testAllFeatures = do
           . optSettings
           . setFeatureFlags
           . flagSelfDeletingMessages
-          . unDefaults
           . to Public.tfwcapsLockStatus
       )
 

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -652,21 +652,21 @@ testAllFeatures = do
   where
     expected :: Public.TeamFeatureStatusValue -> Public.LockStatusValue -> Public.AllFeatureConfigs
     expected confCalling lockState =
-        Public.AllFeatureConfigs
-          { Public.afcLegalholdStatus = Public.TeamFeatureStatusNoConfig TeamFeatureDisabled,
-            Public.afcSSOStatus = Public.TeamFeatureStatusNoConfig TeamFeatureDisabled,
-            Public.afcTeamSearchVisibilityAvailable = Public.TeamFeatureStatusNoConfig TeamFeatureDisabled,
-            Public.afcValidateSAMLEmails = Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Public.Unlocked,
-            Public.afcDigitalSignatures = Public.TeamFeatureStatusNoConfig TeamFeatureDisabled,
-            Public.afcAppLock = Public.TeamFeatureStatusWithConfig TeamFeatureEnabled (Public.TeamFeatureAppLockConfig (Public.EnforceAppLock False) (60 :: Int32)),
-            Public.afcFileSharing = Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Public.Unlocked,
-            Public.afcClassifiedDomains = Public.TeamFeatureStatusWithConfig TeamFeatureEnabled (Public.TeamFeatureClassifiedDomainsConfig [Domain "example.com"]),
-            Public.afcConferenceCalling = Public.TeamFeatureStatusNoConfig confCalling,
-            Public.afcSelfDeletingMessages = Public.TeamFeatureStatusWithConfigAndLockStatus @Public.TeamFeatureSelfDeletingMessagesConfig TeamFeatureEnabled (Public.TeamFeatureSelfDeletingMessagesConfig 0) lockState,
-            Public.afcGuestLink = Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Public.Unlocked,
-            Public.afcSndFactorPasswordChallenge = Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureDisabled Public.Locked
-          }
-          
+      Public.AllFeatureConfigs
+        { Public.afcLegalholdStatus = Public.TeamFeatureStatusNoConfig TeamFeatureDisabled,
+          Public.afcSSOStatus = Public.TeamFeatureStatusNoConfig TeamFeatureDisabled,
+          Public.afcTeamSearchVisibilityAvailable = Public.TeamFeatureStatusNoConfig TeamFeatureDisabled,
+          Public.afcValidateSAMLEmails = Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Public.Unlocked,
+          Public.afcDigitalSignatures = Public.TeamFeatureStatusNoConfig TeamFeatureDisabled,
+          Public.afcAppLock = Public.TeamFeatureStatusWithConfig TeamFeatureEnabled (Public.TeamFeatureAppLockConfig (Public.EnforceAppLock False) (60 :: Int32)),
+          Public.afcFileSharing = Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Public.Unlocked,
+          Public.afcClassifiedDomains = Public.TeamFeatureStatusWithConfig TeamFeatureEnabled (Public.TeamFeatureClassifiedDomainsConfig [Domain "example.com"]),
+          Public.afcConferenceCalling = Public.TeamFeatureStatusNoConfig confCalling,
+          Public.afcSelfDeletingMessages = Public.TeamFeatureStatusWithConfigAndLockStatus @Public.TeamFeatureSelfDeletingMessagesConfig TeamFeatureEnabled (Public.TeamFeatureSelfDeletingMessagesConfig 0) lockState,
+          Public.afcGuestLink = Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureEnabled Public.Unlocked,
+          Public.afcSndFactorPasswordChallenge = Public.TeamFeatureStatusNoConfigAndLockStatus TeamFeatureDisabled Public.Locked
+        }
+
 testFeatureConfigConsistency :: TestM ()
 testFeatureConfigConsistency = do
   owner <- Util.randomUser


### PR DESCRIPTION
## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
