### PR TITLE
Servantify Team CSV endpoint

### DIFF
--- a/changelog.d/5-internal/servantify-csv
+++ b/changelog.d/5-internal/servantify-csv
@@ -1,0 +1,1 @@
+Convert Team CSV endpoint to Servant

--- a/libs/wire-api/src/Wire/API/Routes/CSV.hs
+++ b/libs/wire-api/src/Wire/API/Routes/CSV.hs
@@ -1,0 +1,26 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Routes.CSV where
+
+import Network.HTTP.Media.MediaType
+import Servant.API
+
+data CSV
+
+instance Accept CSV where
+  contentType _ = "text" // "csv"

--- a/libs/wire-api/src/Wire/API/Routes/LowLevelStream.hs
+++ b/libs/wire-api/src/Wire/API/Routes/LowLevelStream.hs
@@ -1,0 +1,89 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Routes.LowLevelStream where
+
+import Control.Lens (at, (.~), (?~))
+import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
+import Data.Metrics.Servant
+import Data.Proxy
+import qualified Data.Swagger as S
+import qualified Data.Text as Text
+import GHC.TypeLits
+import Imports
+import qualified Network.HTTP.Media as HTTP
+import Network.HTTP.Types
+import Network.Wai
+import Servant.API
+import Servant.API.ContentTypes
+import Servant.API.Status
+import Servant.Server hiding (respond)
+import Servant.Server.Internal
+import Servant.Swagger as S
+import Servant.Swagger.Internal as S
+
+data LowLevelStream method status desc ctype
+
+instance
+  (ReflectMethod method, KnownNat status, Accept ctype) =>
+  HasServer (LowLevelStream method status desc ctype) context
+  where
+  type ServerT (LowLevelStream method status desc ctype) m = m StreamingBody
+  hoistServerWithContext _ _ nt s = nt s
+
+  route Proxy _ action = leafRouter $ \env request respond ->
+    let AcceptHeader accH = getAcceptHeader request
+        cmediatype = HTTP.matchAccept [contentType (Proxy @ctype)] accH
+        accCheck = when (isNothing cmediatype) $ delayedFail err406
+        contentHeader = (hContentType, HTTP.renderHeader . maybeToList $ cmediatype)
+     in runAction
+          ( action `addMethodCheck` methodCheck method request
+              `addAcceptCheck` accCheck
+          )
+          env
+          request
+          respond
+          $ Route . responseStream status [contentHeader]
+    where
+      method = reflectMethod (Proxy :: Proxy method)
+      status = statusFromNat (Proxy :: Proxy status)
+
+instance
+  (Accept ctype, KnownNat status, KnownSymbol desc, SwaggerMethod method) =>
+  HasSwagger (LowLevelStream method status desc ctype)
+  where
+  toSwagger _ =
+    mempty
+      & S.paths
+        . at "/"
+        ?~ ( mempty
+               & method
+                 ?~ ( mempty
+                        & S.produces ?~ S.MimeList [contentType (Proxy @ctype)]
+                        & S.responses . S.responses .~ fmap S.Inline responses
+                    )
+           )
+    where
+      method = S.swaggerMethod (Proxy @method)
+      responses =
+        InsOrdHashMap.singleton
+          (fromIntegral (natVal (Proxy @status)))
+          $ mempty
+            & S.description .~ Text.pack (symbolVal (Proxy @desc))
+
+instance RoutesToPaths (LowLevelStream method status desc ctype) where
+  getRoutes = []

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1668,7 +1668,15 @@ type TeamMemberAPI =
                :> Capture "tid" TeamId
                :> "members"
                :> "csv"
-               :> LowLevelStream 'GET 200 "CSV of team members" CSV
+               :> LowLevelStream
+                    'GET
+                    200
+                    '[ '( "Content-Disposition",
+                          "attachment; filename=\"wire_team_members.csv\""
+                        )
+                     ]
+                    "CSV of team members"
+                    CSV
            )
 
 type TeamMemberDeleteResultResponseType =

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -46,6 +46,8 @@ import Wire.API.MLS.Serialisation
 import Wire.API.MLS.Servant
 import Wire.API.MLS.Welcome
 import Wire.API.Message
+import Wire.API.Routes.CSV
+import Wire.API.Routes.LowLevelStream
 import Wire.API.Routes.MultiVerb
 import Wire.API.Routes.Named
 import Wire.API.Routes.Public
@@ -1652,6 +1654,21 @@ type TeamMemberAPI =
                     'PUT
                     '[JSON]
                     (RespondEmpty 200 "")
+           )
+    :<|> Named
+           "get-team-members-csv"
+           ( Summary "Get all members of the team as a CSV file"
+               :> CanThrow 'AccessDenied
+               :> Description
+                    "The endpoint returns data in chunked transfer encoding.\
+                    \ Internal server errors might result in a failed transfer\
+                    \ instead of a 500 response."
+               :> ZLocalUser
+               :> "teams"
+               :> Capture "tid" TeamId
+               :> "members"
+               :> "csv"
+               :> LowLevelStream 'GET 200 "CSV of team members" CSV
            )
 
 type TeamMemberDeleteResultResponseType =

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -69,6 +69,7 @@ library
       Wire.API.Routes.API
       Wire.API.Routes.AssetBody
       Wire.API.Routes.ClientAlgebra
+      Wire.API.Routes.CSV
       Wire.API.Routes.Internal.Brig
       Wire.API.Routes.Internal.Brig.Connection
       Wire.API.Routes.Internal.Brig.EJPD
@@ -76,6 +77,7 @@ library
       Wire.API.Routes.Internal.Cargohold
       Wire.API.Routes.Internal.Galley.TeamFeatureNoConfigMulti
       Wire.API.Routes.Internal.LegalHold
+      Wire.API.Routes.LowLevelStream
       Wire.API.Routes.MultiTablePaging
       Wire.API.Routes.MultiTablePaging.State
       Wire.API.Routes.MultiVerb

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -110,24 +110,6 @@ errorSResponse = errorResponse (toWai (dynError @(MapError e)))
 
 sitemap :: Routes ApiBuilder (Sem GalleyEffects) ()
 sitemap = do
-  -- Team Member API -----------------------------------------------------
-
-  get "/teams/:tid/members/csv" (continueE Teams.getTeamMembersCSVH) $
-    -- we could discriminate based on accept header only, but having two paths makes building
-    -- nginz metrics dashboards easier.
-    zauthUserId
-      .&. capture "tid"
-      .&. accept "text" "csv"
-  document "GET" "getTeamMembersCSV" $ do
-    summary "Get all members of the team as a CSV file"
-    notes
-      "The endpoint returns data in chunked transfer encoding.\
-      \ Internal server errors might result in a failed transfer instead of a 500 response."
-    parameter Path "tid" bytes' $
-      description "Team ID"
-    response 200 "Team members CSV file" end
-    errorSResponse @'AccessDenied
-
   get "/teams/notifications" (continueE Teams.getTeamNotificationsH) $
     zauthUserId
       .&. opt (query "since")

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -307,3 +307,4 @@ servantSitemap =
         <@> mkNamedAPI @"delete-team-member" deleteTeamMember
         <@> mkNamedAPI @"delete-non-binding-team-member" deleteNonBindingTeamMember
         <@> mkNamedAPI @"update-team-member" updateTeamMember
+        <@> mkNamedAPI @"get-team-members-csv" getTeamMembersCSV

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -496,8 +496,6 @@ outputToStreamingBody action = withWeavingToFinal @IO $ \state weave _inspect ->
           flush
     void . weave . (<$ state) $ runOutputSem writeChunk action
 
--- TODO: add header ("Content-Disposition", "attachment; filename=\"wire_team_members.csv\"")
-
 getTeamMembersCSV ::
   (Members '[BrigAccess, ErrorS 'AccessDenied, TeamMemberStore InternalPaging, TeamStore, Final IO] r) =>
   Local UserId ->


### PR DESCRIPTION
Servantify Team CSV endpoint. Since it does not seem to be straightforward to convert a Sem action into a SourceIO value, this PR introduces a new Servant combinator called `LowLevelStream` that directly accepts a `StreamingBody` as the return type of the handler.

Tracked by https://wearezeta.atlassian.net/browse/SQSERVICES-1522.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
