### PR TITLE
Save environment to file when entering direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -28,3 +28,6 @@ PATH_add "./.env/bin"
 # Locale
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
+
+# save environment variables
+env > .vars

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ result-*
 # Created by .envrc
 .direnv
 .env
+.vars
 
 # emacs misc
 .dir-locals.el

--- a/changelog.d/5-internal/save-env
+++ b/changelog.d/5-internal/save-env
@@ -1,0 +1,1 @@
+Save environment to file when entering direnv


### PR DESCRIPTION
This can be useful for scripts that have to run within the direnv environment, to avoid having to evaluate .envrc every time the script is run, which can be noticeably slow.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
