### PR TITLE
SQSERVICES-1595-move-feature-configs-to-self-feature-configs

### DIFF
--- a/changelog.d/4-docs/pr-2423
+++ b/changelog.d/4-docs/pr-2423
@@ -1,0 +1,1 @@
+Additional Swagger docs for the team features/feature configs API.

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1118,8 +1118,8 @@ type FeatureAPI =
     :<|> FeatureStatusPut '() 'TeamFeatureGuestLinks
     :<|> FeatureStatusGet 'TeamFeatureSndFactorPasswordChallenge
     :<|> FeatureStatusPut '() 'TeamFeatureSndFactorPasswordChallenge
-    :<|> AllFeatureConfigsGet
-    :<|> AllFeaturesGet
+    :<|> AllFeatureConfigsUserGet
+    :<|> AllFeatureConfigsTeamGet
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureLegalHold
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureSSO
     :<|> FeatureConfigGet 'WithoutLockStatus 'TeamFeatureSearchVisibility
@@ -1219,10 +1219,14 @@ type FeatureConfigGet ps featureName =
         :> Get '[Servant.JSON] (TeamFeatureStatus ps featureName)
     )
 
-type AllFeatureConfigsGet =
+type AllFeatureConfigsUserGet =
   Named
-    "get-all-feature-configs"
-    ( Summary "Get configurations of all features"
+    "get-all-feature-configs-for-user"
+    ( Summary
+        "Gets feature configs for a user"
+        :> Description
+             "Gets feature configs for a user. If the user is a member of a team and has the required permissions, this will return the team's feature configs.\
+             \If the user is not a member of a team, this will return the personal feature configs (the server defaults)."
         :> ZUser
         :> CanThrow 'NotATeamMember
         :> CanThrow OperationDenied
@@ -1231,10 +1235,11 @@ type AllFeatureConfigsGet =
         :> Get '[Servant.JSON] AllFeatureConfigs
     )
 
-type AllFeaturesGet =
+type AllFeatureConfigsTeamGet =
   Named
-    "get-all-features"
-    ( Summary "Shows the configuration status of every team feature"
+    "get-all-feature-configs-for-team"
+    ( Summary "Gets feature configs for a team"
+        :> Description "Gets feature configs for a team. User must be a member of the team and have permission to view team features."
         :> CanThrow 'NotATeamMember
         :> CanThrow OperationDenied
         :> CanThrow 'TeamNotFound

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -228,8 +228,8 @@ servantSitemap =
               setSndFactorPasswordChallengeInternal
               . DoAuth
           )
-        <@> mkNamedAPI @"get-all-feature-configs" getAllFeatureConfigsForUser
-        <@> mkNamedAPI @"get-all-features" getAllFeatureConfigsForTeam
+        <@> mkNamedAPI @"get-all-feature-configs-for-user" getAllFeatureConfigsForUser
+        <@> mkNamedAPI @"get-all-feature-configs-for-team" getAllFeatureConfigsForTeam
         <@> mkNamedAPI @'("get-config", 'TeamFeatureLegalHold)
           ( getFeatureConfig @'WithoutLockStatus @'TeamFeatureLegalHold
               getLegalholdStatusInternal

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -216,7 +216,7 @@ getFeatureConfig (Tagged getter) zusr = do
       assertTeamExists tid
       getter (FeatureScopeTeam tid)
 
--- | Get feature config for a user. If the user is a member of a team and has the required permissions, this will return the team's feature configs.
+-- | Get feature configs for a user. If the user is a member of a team and has the required permissions, this will return the team's feature configs.
 -- If the user is not a member of a team, this will return the personal feature configs (the server defaults).
 getAllFeatureConfigsForUser ::
   Members


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1595

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.