### PR TITLE
Feature configs should have different swagger schema names

### DIFF
--- a/changelog.d/4-docs/feature-schema-fix
+++ b/changelog.d/4-docs/feature-schema-fix
@@ -1,0 +1,1 @@
+Feature configs should have different swagger schema names

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -473,10 +473,13 @@ modelTeamFeatureStatusWithConfig name cfgModel = Doc.defineModel (cs $ show name
 
 instance ToSchema cfg => ToSchema (TeamFeatureStatusWithConfig cfg) where
   schema =
-    object "TeamFeatureStatusWithConfig" $
+    object name $
       TeamFeatureStatusWithConfig
         <$> tfwcStatus .= field "status" schema
-        <*> tfwcConfig .= field "config" schema
+        <*> tfwcConfig .= field "config" inner
+    where
+      inner = schema @cfg
+      name = "TeamFeatureStatusWithConfig." <> fromMaybe "" (getName (schemaDoc inner))
 
 data TeamFeatureStatusWithConfigAndLockStatus (cfg :: *) = TeamFeatureStatusWithConfigAndLockStatus
   { tfwcapsStatus :: TeamFeatureStatusValue,
@@ -498,11 +501,14 @@ modelTeamFeatureStatusWithConfigAndLockStatus name cfgModel = Doc.defineModel (c
 
 instance ToSchema cfg => ToSchema (TeamFeatureStatusWithConfigAndLockStatus cfg) where
   schema =
-    object "TeamFeatureStatusWithConfigAndLockStatus" $
+    object name $
       TeamFeatureStatusWithConfigAndLockStatus
         <$> tfwcapsStatus .= field "status" schema
-        <*> tfwcapsConfig .= field "config" schema
+        <*> tfwcapsConfig .= field "config" inner
         <*> tfwcapsLockStatus .= field "lockStatus" schema
+    where
+      inner = schema @cfg
+      name = "TeamFeatureStatusWithConfigAndLockStatus." <> fromMaybe "" (getName (schemaDoc inner))
 
 ----------------------------------------------------------------------
 -- TeamFeatureClassifiedDomainsConfig


### PR DESCRIPTION
This fixes an issue with the generated swagger for e.g. `AllFeatureConfigs`, where some fields were pointing to the schema for the wrong config.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
