### PR TITLE
delete namespace after helm resource deletion

### DIFF
--- a/hack/bin/integration-spring-cleaning.sh
+++ b/hack/bin/integration-spring-cleaning.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 
 set -x
 
 IFS=$'\n'
 for NAMESPACE in $(kubectl get namespaces | grep "^test-" | awk '{print $1}'); do
 
-  echo "$NAMESPACE"
-  kubectl delete namespace "$NAMESPACE"
+    echo "$NAMESPACE"
+    kubectl delete namespace "$NAMESPACE" &
 
 done

--- a/hack/bin/integration-teardown-federation.sh
+++ b/hack/bin/integration-teardown-federation.sh
@@ -14,3 +14,6 @@ export FEDERATION_DOMAIN_2="."
 
 . "$DIR/helm_overrides.sh"
 helmfile --file "${TOP_LEVEL}/hack/helmfile.yaml" destroy
+
+kubectl delete namespace "$NAMESPACE_1"
+kubectl delete namespace "$NAMESPACE_2"


### PR DESCRIPTION
For internal CI resource cleaning, otherwise we have hundreds of `test-...` namespaces that remain.