### PR TITLE
Backup and disaster recovery instructions

### DIFF
--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -71,7 +71,6 @@ Make sure (while connected via ssh) your Cassandra installation is doing well wi
 
     nodetool status
 
-You should see something like:
 
 You should see a list of nodes like this:
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -4,6 +4,12 @@
 
 While you might never use them, your backup plan (and the corresponding disaster recovery steps) are possibly your most important procedure.
 
+You should:
+
+1. Write it up fully
+2. Test it from beginning to end, simulating an actual disaster
+3. Run backups on a regular basis, ideally automatically
+
 This page explains in detail how to properly backup an on-premise Wire installation, and how to recover from your backup if you ever need to.
 
 Note that you should not trust this page (or your execution of it) to allow for a proper backup and restore, therefore, you should immediately (before it becomes critical to do so) back up your Wire installation **and** attempt (as a test) to restore it. This will ensure that you can **in fact** backup and restore Wire, and will catch any problem in the process before any problem becomes damaging to you.
@@ -128,6 +134,21 @@ Where :
 Repeat this for each of the snapshots.
 
 Now simply save these files in multiple locations as per your normal company backup procedures, and repeat this procedure on a regular basis as is appropriate.
+
+### Batch Cassandra backup
+
+The backup procedure above presumes manually backing up each Cassandra snapshot serially one by one.
+
+If you want to back all files at once, you can use the `find` command to find all snapshots and pack them into a single archive:
+
+    ssh user@cassandra-vm.your-domain.com 'find /mnt/cassandra/ -name "snapshots" -print0 | tar -cvf - --null -T - | gzip -9 ' > cassandra-batch.tar.gz
+
+* `user` is the user you used to install Wire on this server, typically `wire` or `root`
+* `cassandra-vm.your-domain.com` is the domain name or IP address for the server with your Wire install
+* `/mnt/cassandra/` is the (absolute) path, on the server, where your cassandra folder is located, to which you add the location of the specific snapshot, found with `find` above
+* `cassandra-batch.tar.gz` is the local file everything will be written to
+
+This will (over ssh) find all `snapshot` folders in the `cassandra` folder, pack them into a tar file, gzip it to save space, and output it to a local file.
 
 ### Backing up MinIO
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -1,0 +1,54 @@
+# Backup and disaster recovery
+
+## Introduction
+
+While you might never use them, your backup plan (and the corresponding disaster recovery steps) are possibly your most important procedure.
+
+This page explains in detail how to properly backup an on-premise Wire installation, and how to recover from your backup if you ever need to.
+
+## Backing up
+
+By nature, a significant part of a Wire installation is ephemeral, and not meant to be stored long-term or recovered: in case of trouble, those parts can just be started fresh with minimal impact on user experience. 
+
+The exceptions to this rule, are what you want to back up. In particular:
+
+* Your "wire-server" installation folder (used during the installation procedure)
+* Your Cassandra database
+* Your Minio data
+
+If you save these, you can then whenever needed create a fresh install of Wire, re-import/re-install them on top of it, and get back to a working state.
+
+Here is how to back up each:
+
+### Wire-server
+
+To backup the wire-server folder, we simply use ssh to read it from the server in which it is installed:
+
+    ssh user@my-wire-server.mydomain.com 'cd /path/to/my/folder/for/wire-server/ && tar -cf - wire-server | gzip -9' > wire-server-backup.tar.gz
+
+Where :
+
+* `user` is the user you used to install Wire on this server, typically `wire` or `root`
+* `my-wire-server.mydomain.com` is the domain name or IP address for the server with your Wire install
+* `/path/to/my/folder/for/wire-server/` is the (absolute) path, on the server, where your wire-server folder is located
+* `wire-server` is the name of the folder for your wire-server install, typically (as per instructions) simply `wire-server`
+* `wire-server-backup.tar.gz` is the name of the file in which your wire-server folder will be stored
+
+Once the command is done executing, make sure the file exists and is not empty with:
+
+    file wire-server-backup.tar.gz       # Should say the file type is a TAR archive
+    ls -lh wire-server-backup.tar.gz     # Should show a file size other than 0
+    tar tvf wire-server-backup.tar.gz    # Should list the files inside your wire-server folder correctly
+
+Now simply save this file in multiple locations as per your normal company backup procedures, and repeat this procedure on a regular basis as is appropriate.
+
+### Cassandra
+
+Cassandra stores things such as user profiles/accounts, conversations, etc. It is the most critical data to backup/store/recover.
+
+To backup your Cassandra database, do as follows:
+
+
+
+
+## Recovery procedure

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -254,7 +254,7 @@ You can extract this file to the remote machine with the following command:
 
 Where :
 
-* `wire-server-backup.tar.gz` is the name of the file in which your wire-server folder was be stored
+* `wire-server-backup.tar.gz` is the name of the file in which your wire-server folder has been stored
 * `my-wire-server.your-domain.com` is the domain name or IP address for the server with your Wire install
 * `user` is the user you used to install Wire on this server, typically `wire` or `root`
 * `/path/to/my/folder/for/wire-server/` is the (absolute) path, on the server, where your wire-server folder is located

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -97,7 +97,7 @@ After editing the file, make sure you restart cassandra with:
 
     sudo service cassandra restart
 
-You can find a list of all keyspaces by doing: building
+You can find a list of all keyspaces by doing:
 
     ls /mnt/cassandra/data/
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -48,9 +48,9 @@ Cassandra stores things such as user profiles/accounts, conversations, etc. It i
 
 To backup your Cassandra database, do as follows:
 
-You can read general information about connecting to your Cassandra node on [This page](/how-to/administrate/cassandra.html)
+You can read general information about connecting to your Cassandra node on [this page](/how-to/administrate/cassandra.html)
 
-In particular, SSH into the Cassandra VM with:
+In particular, SSH into the Cassandra Virtual Machine with:
 
     ssh user@cassandra-vm.your-domain.com
 
@@ -119,7 +119,24 @@ Repeat this for each of the snapshots.
 
 Now simply save these files in multiple locations as per your normal company backup procedures, and repeat this procedure on a regular basis as is appropriate.
 
+### MinIO
 
+MinIO emulates an Amazon-S3-compatible file-storage setup, and is used by Wire to store things such as file attachements, images etc.
+
+If your specific installation is using the actual Amazon file storage (and not a local emulated alternative), you should skip this section (but still actually backup whatever you are using).
+
+Similarly to Cassandra, to create a backup you need to SSH into the Virtual Machine running MinIO in your installation:
+
+You can read general information about your MinIO node on [this page](/how-to/administrate/minio.html)
+
+SSH into the MinIO Virtual Machine with:
+
+    ssh user@minio-vm.your-domain.com
+
+Where:
+
+* `user` is the user you used to install Wire on this server, typically `wire` or `root`
+* `minio-vm.mydomain.com` is the domain name or IP address for the server with your MinIO node
 
 
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -229,7 +229,7 @@ Then, you can add this to your cron file (by running `crontab -e`) to make sure 
 
 Your backup should now happen every hour automatically, ensuring you always have a backup at least an hour fresh in case of an emergency.
 
-There are ways to have incremental backups and to do more complex/refined backup procedure, but those are beyond the scope of this document. You should check out [Borg](https://borgbackup.readthedocs.io/en/stable/)
+There are ways to have incremental backups and to do more complex/refined backup procedure, but those are beyond the scope of this document. You should check out [Borg](https://borgbackup.readthedocs.io/en/stable/).
 
 You should also set up your monitoring software (for example [Nagios](https://www.nagios.org/)) to check whether your backup file is [older than an hour](https://support.nagios.com/kb/article/file-and-folder-checks-783.html#file_modified), and if it is (meaning something went wrong), warn you immediately.
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -259,7 +259,7 @@ Where :
 * `user` is the user you used to install Wire on this server, typically `wire` or `root`
 * `/path/to/my/folder/for/wire-server/` is the (absolute) path, on the server, where your wire-server folder is located
 
-Now all files should be in their proper place, with the proper values, and you should be able to run the required ansible/helm commands that will result in a full installation of Wire
+Now all files should be in their proper place, with the proper values, and you should be able to run the required ansible/helm commands that will result in a full installation of Wire.
 
 ### Restoring Cassandra from a backup
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -158,7 +158,7 @@ If your specific installation is using the actual Amazon file storage (and not a
 
 Similarly to Cassandra, to create a backup you need to SSH into the Virtual Machine running MinIO in your installation:
 
-You can read general information about your MinIO node on [this page](/how-to/administrate/minio)
+You can read general information about your MinIO node on [this page](/how-to/administrate/minio).
 
 SSH into the MinIO Virtual Machine with:
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -242,7 +242,7 @@ If the worse has happened, and you need to recover/restore your Wire installatio
 3. Restore your Cassandra backup files over your new Cassandra installation.
 4. Restore your MinIO backup files over your new MinIO installation.
 5. Restart all services.
-6. Ensure all services are functionning correctly
+6. Ensure all services are functioning correctly
 
 ### Restoring Wire-Server from a backup
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -152,7 +152,7 @@ This will (over ssh) find all `snapshot` folders in the `cassandra` folder, pack
 
 ### Backing up MinIO
 
-MinIO emulates an Amazon-S3-compatible file-storage setup, and is used by Wire to store things such as file attachements, images etc.
+MinIO emulates an Amazon-S3-compatible file-storage setup, and is used by Wire to store things such as file attachments, images etc.
 
 If your specific installation is using the actual Amazon file storage (and not a local emulated alternative), you should skip this section (but still actually backup whatever you are using).
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -90,6 +90,10 @@ After editing the file, make sure you restart cassandra with:
 
     sudo service cassandra restart
 
+You can find a list of all keyspaces by doing: building
+
+    ls /mnt/cassandra/data/
+
 Now (while connected via ssh, as per above), use nodetool to actually generate a snapshot of all tables:
 
     nodetool snapshot --tag catalog-ks catalogkeyspace
@@ -106,18 +110,18 @@ To actually save the files, you'll need to locate them with:
 
 Which should give you a list of paths to snapshots, such as:
 
-    ./cassandra/data/data/catalogkeyspace/journal-296a2d30c22a11e9b1350d927649052c/snapshots
-    ./cassandra/data/data/catalogkeyspace/magazine-446eae30c22a11e9b1350d927649052c/snapshots
+    /mnt/cassandra/data/data/catalogkeyspace/journal-296a2d30c22a11e9b1350d927649052c/snapshots
+    /mnt/cassandra/data/data/catalogkeyspace/magazine-446eae30c22a11e9b1350d927649052c/snapshots
 
 Now to create a (local) backup of these snapshots, we use `ssh` the same way we did above for `wire-server`:
 
-    ssh user@cassandra-vm.your-domain.com 'cd /path/to/my/folder/for/cassandra/cassandra/data/data/catalogkeyspace/journal-296a2d30c22a11e9b1350d927649052c/ && tar -cf - snapshots | gzip -9' > cassandra-journal-backup.tar.gz
+    ssh user@cassandra-vm.your-domain.com 'cd /mnt/cassandra/data/data/catalogkeyspace/journal-296a2d30c22a11e9b1350d927649052c/ && tar -cf - snapshots | gzip -9' > cassandra-journal-backup.tar.gz
 
 Where :
 
 * `user` is the user you used to install Wire on this server, typically `wire` or `root`
 * `cassandra-vm.your-domain.com` is the domain name or IP address for the server with your Wire install
-* `/path/to/my/folder/for/cassandra/` is the (absolute) path, on the server, where your cassandra folder is located, to which you add the location of the specific snapshot, found with `find` above
+* `/mnt/cassandra/` is the (absolute) path, on the server, where your cassandra folder is located, to which you add the location of the specific snapshot, found with `find` above
 
 Repeat this for each of the snapshots.
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -24,7 +24,7 @@ The exceptions to this rule, are what you want to back up. In particular:
 * Your Cassandra database
 * Your Minio data
 
-If you save these, you can then whenever needed create a fresh install of Wire, re-import/re-install them on top of it, and get back to a working state.
+If you save these, you can then whenever needed, create a fresh installation of Wire, re-import/re-install them on top of it, and get back to a working state.
 
 Here is how to back up each:
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -182,7 +182,7 @@ Where:
 
 ### Automated regular backups
 
-It is important to back up as often as possible. You can use `cron` to automaticall run your backup commands on a regular basis.
+It is important to back up as often as possible. You can use `cron` to automatically run your backup commands on a regular basis.
 
 For example, you can create the following shell script, and write it to `/home/myuser/backup/wire-backup.sh`:
 

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -86,6 +86,10 @@ Same with: `snapshot_before_compaction`
 
     snapshot_before_compaction: false
 
+After editing the file, make sure you restart cassandra with:
+
+    sudo service cassandra restart
+
 Now (while connected via ssh, as per above), use nodetool to actually generate a snapshot of all tables:
 
     nodetool snapshot --tag catalog-ks catalogkeyspace

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -138,8 +138,15 @@ Where:
 * `user` is the user you used to install Wire on this server, typically `wire` or `root`
 * `minio-vm.mydomain.com` is the domain name or IP address for the server with your MinIO node
 
+To backup the MinIO data, we need to backup two servers over SSH, the same way we did for Cassandra and wire-server:
 
+    ssh user@my-minio-server.mydomain.com 'cd /var/lib/ && tar -cf - minio-server1 | gzip -9' > minio-server1-backup.tar.gz
+    ssh user@my-minio-server.mydomain.com 'cd /var/lib/ && tar -cf - minio-server2 | gzip -9' > minio-server2-backup.tar.gz
 
+Where:
 
+* `user` is the user you used to install Wire on this server, typically `wire` or `root`
+* `my-minio-server.mydomain.com` is the domain name or IP address for the MinIO Virtual Machine
+* `minio-server[number]-backup.tar.gz` is the name of the file in which each minio data folder will be stored
 
 ## Recovery procedure

--- a/docs/src/how-to/administrate/backup-disaster-recovery.md
+++ b/docs/src/how-to/administrate/backup-disaster-recovery.md
@@ -56,7 +56,7 @@ Cassandra stores things such as user profiles/accounts, conversations, etc. It i
 
 To backup your Cassandra database, do as follows:
 
-You can read general information about connecting to your Cassandra node on [this page](/how-to/administrate/cassandra.html)
+You can read general information about connecting to your Cassandra node on [this page](/how-to/administrate/cassandra)
 
 In particular, SSH into the Cassandra Virtual Machine with:
 
@@ -158,7 +158,7 @@ If your specific installation is using the actual Amazon file storage (and not a
 
 Similarly to Cassandra, to create a backup you need to SSH into the Virtual Machine running MinIO in your installation:
 
-You can read general information about your MinIO node on [this page](/how-to/administrate/minio.html)
+You can read general information about your MinIO node on [this page](/how-to/administrate/minio)
 
 SSH into the MinIO Virtual Machine with:
 


### PR DESCRIPTION
Instructions on backing up Wire, and recovering from a Backup.

## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
