### PR TITLE
Export NIX_BUILD_SHELL for cabal also.

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -54,6 +54,7 @@ let
   # for cabal, as setting it in direnv can interfere with programs in the host
   # system, especially for non-NixOS users.
   cabal-wrapper = pkgs.writeShellScriptBin "cabal" ''
+    export NIX_BUILD_SHELL="${pkgs.bash}/bin/bash"
     export CPATH="${compile-deps}/include"
     export LD_LIBRARY_PATH="${compile-deps}/lib"
     export LIBRARY_PATH="${compile-deps}/lib"


### PR DESCRIPTION
Without this, cabal was unable to find glibc when building.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.