### PR TITLE
[FS-509] Bare Proposal Support

### DIFF
--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -543,6 +543,26 @@ CREATE TABLE galley_test.billing_team_member (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
+CREATE TABLE galley_test.mls_proposal_refs (
+    ref blob PRIMARY KEY,
+    epoch bigint,
+    group_id blob,
+    proposal blob
+) WITH bloom_filter_fp_chance = 0.01
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
+    AND comment = ''
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
+    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1.0
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99PERCENTILE';
+
 CREATE KEYSPACE gundeck_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
 
 CREATE TABLE gundeck_test.push (

--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -35,23 +35,13 @@ CREATE TABLE galley_test.meta (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
-CREATE TABLE galley_test.conversation (
-    conv uuid PRIMARY KEY,
-    access set<int>,
-    access_role int,
-    access_roles_v2 set<int>,
-    cipher_suite int,
-    creator uuid,
-    deleted boolean,
-    epoch bigint,
-    group_id blob,
-    message_timer bigint,
-    name text,
-    protocol int,
-    receipt_mode int,
+CREATE TABLE galley_test.team_conv (
     team uuid,
-    type int
-) WITH bloom_filter_fp_chance = 0.1
+    conv uuid,
+    managed boolean,
+    PRIMARY KEY (team, conv)
+) WITH CLUSTERING ORDER BY (conv ASC)
+    AND bloom_filter_fp_chance = 0.1
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
@@ -457,13 +447,23 @@ CREATE TABLE galley_test.clients (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
-CREATE TABLE galley_test.team_conv (
+CREATE TABLE galley_test.conversation (
+    conv uuid PRIMARY KEY,
+    access set<int>,
+    access_role int,
+    access_roles_v2 set<int>,
+    cipher_suite int,
+    creator uuid,
+    deleted boolean,
+    epoch bigint,
+    group_id blob,
+    message_timer bigint,
+    name text,
+    protocol int,
+    receipt_mode int,
     team uuid,
-    conv uuid,
-    managed boolean,
-    PRIMARY KEY (team, conv)
-) WITH CLUSTERING ORDER BY (conv ASC)
-    AND bloom_filter_fp_chance = 0.1
+    type int
+) WITH bloom_filter_fp_chance = 0.1
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
@@ -545,11 +545,13 @@ CREATE TABLE galley_test.billing_team_member (
     AND speculative_retry = '99PERCENTILE';
 
 CREATE TABLE galley_test.mls_proposal_refs (
-    ref blob PRIMARY KEY,
-    epoch bigint,
     group_id blob,
-    proposal blob
-) WITH bloom_filter_fp_chance = 0.01
+    epoch bigint,
+    ref blob,
+    proposal blob,
+    PRIMARY KEY (group_id, epoch, ref)
+) WITH CLUSTERING ORDER BY (epoch ASC, ref ASC)
+    AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}

--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -40,6 +40,7 @@ CREATE TABLE galley_test.conversation (
     access set<int>,
     access_role int,
     access_roles_v2 set<int>,
+    cipher_suite int,
     creator uuid,
     deleted boolean,
     epoch bigint,

--- a/changelog.d/2-features/pr-2436
+++ b/changelog.d/2-features/pr-2436
@@ -1,0 +1,1 @@
+Add support for bare MLS proposals

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationCreated.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationCreated.hs
@@ -28,6 +28,7 @@ import Wire.API.Conversation
 import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 import Wire.API.Federation.API.Galley
+import Wire.API.MLS.CipherSuite (CipherSuite (CipherSuite))
 import Wire.API.Provider.Service
 
 testObject_ConversationCreated1 :: ConversationCreated ConvId
@@ -83,5 +84,5 @@ testObject_ConversationCreated2 =
       ccNonCreatorMembers = Set.fromList [],
       ccMessageTimer = Nothing,
       ccReceiptMode = Nothing,
-      ccProtocol = ProtocolMLS (ConversationMLSData (GroupId "group") (Epoch 3))
+      ccProtocol = ProtocolMLS (ConversationMLSData (GroupId "group") (Epoch 3) (CipherSuite 1))
     }

--- a/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationCreated.hs
+++ b/libs/wire-api-federation/test/Test/Wire/API/Federation/Golden/ConversationCreated.hs
@@ -28,7 +28,7 @@ import Wire.API.Conversation
 import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 import Wire.API.Federation.API.Galley
-import Wire.API.MLS.CipherSuite (CipherSuite (CipherSuite))
+import Wire.API.MLS.CipherSuite
 import Wire.API.Provider.Service
 
 testObject_ConversationCreated1 :: ConversationCreated ConvId
@@ -84,5 +84,5 @@ testObject_ConversationCreated2 =
       ccNonCreatorMembers = Set.fromList [],
       ccMessageTimer = Nothing,
       ccReceiptMode = Nothing,
-      ccProtocol = ProtocolMLS (ConversationMLSData (GroupId "group") (Epoch 3) (CipherSuite 1))
+      ccProtocol = ProtocolMLS (ConversationMLSData (GroupId "group") (Epoch 3) MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
     }

--- a/libs/wire-api-federation/test/golden/testObject_ConversationCreated2.json
+++ b/libs/wire-api-federation/test/golden/testObject_ConversationCreated2.json
@@ -11,6 +11,7 @@
     "non_creator_members": [],
     "orig_user_id": "eed9dea3-5468-45f8-b562-7ad5de2587d0",
     "protocol": {
+        "cipher_suite": 1,
         "epoch": 3,
         "group_id": "Z3JvdXA=",
         "protocol": "mls"

--- a/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
@@ -53,7 +53,7 @@ data ConversationMLSData = ConversationMLSData
     -- | The current epoch number of the corresponding MLS group.
     cnvmlsEpoch :: Epoch,
     -- | The cipher suite to be used in the MLS group.
-    cnvmlsCipherSuite :: CipherSuite
+    cnvmlsCipherSuite :: CipherSuiteTag
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via GenericUniform ConversationMLSData

--- a/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
@@ -39,6 +39,7 @@ import Data.Schema
 import Imports
 import Wire.API.Arbitrary
 import Wire.API.Conversation.Action.Tag
+import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Group
 import Wire.API.MLS.Message
 
@@ -50,7 +51,9 @@ data ConversationMLSData = ConversationMLSData
   { -- | The MLS group ID associated to the conversation.
     cnvmlsGroupId :: GroupId,
     -- | The current epoch number of the corresponding MLS group.
-    cnvmlsEpoch :: Epoch
+    cnvmlsEpoch :: Epoch,
+    -- | The cipher suite to be used in the MLS group.
+    cnvmlsCipherSuite :: CipherSuite
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via GenericUniform ConversationMLSData
@@ -121,4 +124,9 @@ mlsDataSchema =
     .= fieldWithDocModifier
       "epoch"
       (description ?~ "The epoch number of the corresponding MLS group")
+      schema
+    <*> cnvmlsCipherSuite
+    .= fieldWithDocModifier
+      "cipher_suite"
+      (description ?~ "The cipher suite of the corresponding MLS group")
       schema

--- a/libs/wire-api/src/Wire/API/Error/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Error/Galley.hs
@@ -77,6 +77,7 @@ data GalleyError
   | MLSProtocolErrorTag
   | MLSClientMismatch
   | MLSStaleMessage
+  | MLSCommitMissingReferences
   | --
     NoBindingTeamMembers
   | NoBindingTeam
@@ -187,6 +188,8 @@ type instance MapError 'MLSProtocolErrorTag = MapError 'BrigError.MLSProtocolErr
 type instance MapError 'MLSClientMismatch = 'StaticError 409 "mls-client-mismatch" "A proposal of type Add or Remove does not apply to the full list of clients for a user"
 
 type instance MapError 'MLSStaleMessage = 'StaticError 409 "mls-stale-message" "The conversation epoch in a message is too old"
+
+type instance MapError 'MLSCommitMissingReferences = 'StaticError 409 "mls-commit-missing-references" "The commit is not refrencing all pending proposals"
 
 type instance MapError 'NoBindingTeamMembers = 'StaticError 403 "non-binding-team-members" "Both users must be members of the same binding team"
 

--- a/libs/wire-api/src/Wire/API/MLS/CipherSuite.hs
+++ b/libs/wire-api/src/Wire/API/MLS/CipherSuite.hs
@@ -40,6 +40,11 @@ newtype CipherSuite = CipherSuite {cipherSuiteNumber :: Word16}
   deriving stock (Eq, Show)
   deriving newtype (ParseMLS, Arbitrary)
 
+instance ToSchema CipherSuite where
+  schema =
+    named "CipherSuite" $
+      cipherSuiteNumber .= fmap CipherSuite (unnamed schema)
+
 data CipherSuiteTag = MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
   deriving stock (Bounded, Enum, Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform CipherSuiteTag)

--- a/libs/wire-api/src/Wire/API/MLS/Context.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Context.hs
@@ -1,0 +1,33 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.MLS.Context where
+
+import Imports
+
+-- Warning: the "context" string here is different from the one mandated by
+-- the spec, but it is the one that happens to be used by openmls. Until
+-- openmls is patched and we switch to a fixed version, we will have to use
+-- the "wrong" string here as well.
+--
+-- This is used when invoking 'csHash'.
+context :: ByteString
+context = "MLS 1.0 ref"
+
+proposalContext, keyPackageContext :: ByteString
+proposalContext = context -- TODO: see if this is how it is defined in openmls
+keyPackageContext = context

--- a/libs/wire-api/src/Wire/API/MLS/Context.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Context.hs
@@ -29,5 +29,5 @@ context :: ByteString
 context = "MLS 1.0 ref"
 
 proposalContext, keyPackageContext :: ByteString
-proposalContext = context -- TODO: see if this is how it is defined in openmls
+proposalContext = context
 keyPackageContext = context

--- a/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
+++ b/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
@@ -50,6 +50,7 @@ import Imports
 import Web.HttpApiData
 import Wire.API.Arbitrary
 import Wire.API.MLS.CipherSuite
+import Wire.API.MLS.Context
 import Wire.API.MLS.Credential
 import Wire.API.MLS.Extension
 import Wire.API.MLS.Serialisation
@@ -124,11 +125,7 @@ instance ParseMLS KeyPackageRef where
 kpRef :: CipherSuiteTag -> KeyPackageData -> KeyPackageRef
 kpRef cs =
   KeyPackageRef
-    -- Warning: the "context" string here is different from the one mandated by
-    -- the spec, but it is the one that happens to be used by openmls. Until
-    -- openmls is patched and we switch to a fixed version, we will have to use
-    -- the "wrong" string here as well.
-    . csHash cs "MLS 1.0 ref"
+    . csHash cs keyPackageContext
     . kpData
 
 -- | Compute ref of a key package. Return 'Nothing' if the key package cipher

--- a/libs/wire-api/src/Wire/API/MLS/Message.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Message.hs
@@ -149,7 +149,7 @@ instance ParseMLS (MessagePayload 'MLSPlainText) where
 
 data MessagePayloadTBS
   = ApplicationMessage ByteString
-  | ProposalMessage Proposal
+  | ProposalMessage (RawMLS Proposal)
   | CommitMessage Commit
 
 data ContentType

--- a/libs/wire-api/src/Wire/API/MLS/Proposal.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Proposal.hs
@@ -22,6 +22,7 @@ import Data.Binary.Get
 import Imports
 import Wire.API.Arbitrary
 import Wire.API.MLS.CipherSuite
+import Wire.API.MLS.Context
 import Wire.API.MLS.Extension
 import Wire.API.MLS.Group
 import Wire.API.MLS.KeyPackage
@@ -65,6 +66,13 @@ instance ParseMLS Proposal where
       AppAckProposalTag -> AppAckProposal <$> parseMLSVector @Word32 parseMLS
       GroupContextExtensionsProposalTag ->
         GroupContextExtensionsProposal <$> parseMLSVector @Word32 parseMLS
+
+-- | Compute the proposal ref given a ciphersuite and the raw proposal data.
+proposalRef :: CipherSuiteTag -> RawMLS Proposal -> ProposalRef
+proposalRef cs =
+  ProposalRef
+    . csHash cs proposalContext
+    . rmRaw
 
 data PreSharedKeyTag = ExternalKeyTag | ResumptionKeyTag
   deriving (Bounded, Enum, Eq, Show)

--- a/libs/wire-api/src/Wire/API/MLS/Proposal.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Proposal.hs
@@ -14,9 +14,11 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE TemplateHaskell #-}
 
 module Wire.API.MLS.Proposal where
 
+import Control.Lens (makePrisms)
 import Data.Binary
 import Data.Binary.Get
 import Imports
@@ -150,7 +152,9 @@ instance ParseMLS ProposalOrRef where
       RefTag -> Ref <$> parseMLS
 
 newtype ProposalRef = ProposalRef {unProposalRef :: ByteString}
-  deriving stock (Eq, Show)
+  deriving stock (Eq, Show, Ord)
 
 instance ParseMLS ProposalRef where
   parseMLS = ProposalRef <$> getByteString 16
+
+makePrisms ''ProposalOrRef

--- a/libs/wire-api/src/Wire/API/MLS/Proposal.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Proposal.hs
@@ -140,7 +140,7 @@ data ProposalOrRefTag = InlineTag | RefTag
 instance ParseMLS ProposalOrRefTag where
   parseMLS = parseMLSEnum @Word8 "ProposalOrRef type"
 
-data ProposalOrRef = Inline (RawMLS Proposal) | Ref ProposalRef
+data ProposalOrRef = Inline Proposal | Ref ProposalRef
   deriving stock (Eq, Show)
 
 instance ParseMLS ProposalOrRef where

--- a/libs/wire-api/src/Wire/API/MLS/Proposal.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Proposal.hs
@@ -140,7 +140,7 @@ data ProposalOrRefTag = InlineTag | RefTag
 instance ParseMLS ProposalOrRefTag where
   parseMLS = parseMLSEnum @Word8 "ProposalOrRef type"
 
-data ProposalOrRef = Inline Proposal | Ref ProposalRef
+data ProposalOrRef = Inline (RawMLS Proposal) | Ref ProposalRef
   deriving stock (Eq, Show)
 
 instance ParseMLS ProposalOrRef where

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1328,6 +1328,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MLSUnsupportedProposal
                :> CanThrow 'LegalHoldNotEnabled
                :> CanThrow 'MissingLegalholdConsent
+               :> CanThrow 'MLSCommitMissingReferences
                :> "messages"
                :> ZConn
                :> ReqBody '[MLS] (RawMLS SomeMessage)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1317,6 +1317,7 @@ type MLSMessagingAPI =
            ( Summary "Post an MLS message"
                :> CanThrow 'ConvAccessDenied
                :> CanThrow 'ConvNotFound
+               :> CanThrow 'ConvMemberNotFound
                :> CanThrow 'MLSKeyPackageRefNotFound
                :> CanThrow 'MLSClientMismatch
                :> CanThrow 'MLSProtocolErrorTag

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationsResponse.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationsResponse.hs
@@ -30,6 +30,7 @@ import Imports
 import Wire.API.Conversation
 import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
+import Wire.API.MLS.CipherSuite
 
 domain :: Domain
 domain = Domain "golden.example.com"
@@ -127,5 +128,5 @@ conv2 =
                 },
             cmOthers = []
           },
-      cnvProtocol = ProtocolMLS (ConversationMLSData (GroupId ("test_group")) (Epoch 42))
+      cnvProtocol = ProtocolMLS (ConversationMLSData (GroupId "test_group") (Epoch 42) (CipherSuite 1))
     }

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationsResponse.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationsResponse.hs
@@ -128,5 +128,5 @@ conv2 =
                 },
             cmOthers = []
           },
-      cnvProtocol = ProtocolMLS (ConversationMLSData (GroupId "test_group") (Epoch 42) (CipherSuite 1))
+      cnvProtocol = ProtocolMLS (ConversationMLSData (GroupId "test_group") (Epoch 42) MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
     }

--- a/libs/wire-api/test/golden/testObject_ConversationsResponse_1.json
+++ b/libs/wire-api/test/golden/testObject_ConversationsResponse_1.json
@@ -71,6 +71,7 @@
                 "guest",
                 "service"
             ],
+            "cipher_suite": 1,
             "creator": "00000000-0000-0000-0000-000200000001",
             "epoch": 42,
             "group_id": "dGVzdF9ncm91cA==",

--- a/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
@@ -96,7 +96,7 @@ testParseCommit = do
     _ -> assertFailure "Unexpected message type"
 
   case cProposals commit of
-    [Inline (RawMLS _ (AddProposal _))] -> pure ()
+    [Inline (AddProposal _)] -> pure ()
     _ -> assertFailure "Unexpected proposals"
 
 testParseApplication :: IO ()

--- a/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
@@ -96,7 +96,7 @@ testParseCommit = do
     _ -> assertFailure "Unexpected message type"
 
   case cProposals commit of
-    [Inline (AddProposal _)] -> pure ()
+    [Inline (RawMLS _ (AddProposal _))] -> pure ()
     _ -> assertFailure "Unexpected proposals"
 
 testParseApplication :: IO ()

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -46,6 +46,7 @@ library
       Wire.API.Message.Proto
       Wire.API.MLS.CipherSuite
       Wire.API.MLS.Commit
+      Wire.API.MLS.Context
       Wire.API.MLS.Credential
       Wire.API.MLS.Extension
       Wire.API.MLS.Group

--- a/nix/pkgs/mls_test_cli/default.nix
+++ b/nix/pkgs/mls_test_cli/default.nix
@@ -15,9 +15,9 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "wireapp";
     repo = "mls-test-cli";
-    rev = "4befbebfd5575537167c5952db6e9967f2076001";
-    sha256 = "sha256-j1n68VVs91uzQ9vwSuIHIMXxVZV/Xeto+V+69ErmL0Q=";
+    rev = "ed689dda175f4a11a657ed7d9474bd391023188b";
+    sha256 = "sha256:043nc7nqjs71i1hbjpygv10mw9axq0xw0y5ncm1gprw6cvnyimlq";
   };
   doCheck = false;
-  cargoSha256 = "sha256-6257yC+NyJu4PNLVQUrp+YVOOpvcuUoT9Hd9+uq+73w=";
+  cargoSha256 = "sha256:1cwyzn5gwzdb92k1b02yzpj1mv9x8vnx329v54qsm089nq5drp11";
 }

--- a/nix/pkgs/mls_test_cli/default.nix
+++ b/nix/pkgs/mls_test_cli/default.nix
@@ -15,9 +15,9 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "wireapp";
     repo = "mls-test-cli";
-    rev = "ed689dda175f4a11a657ed7d9474bd391023188b";
-    sha256 = "sha256:043nc7nqjs71i1hbjpygv10mw9axq0xw0y5ncm1gprw6cvnyimlq";
+    rev = "05cc435cfc16c0fb68434546ca4578ca35ecf550";
+    sha256 = "sha256-Gd9LwWULGKolyaYJpcdK4KpneBf6jEaZqE7LjsRkY9E=";
   };
   doCheck = false;
-  cargoSha256 = "sha256:1cwyzn5gwzdb92k1b02yzpj1mv9x8vnx329v54qsm089nq5drp11";
+  cargoSha256 = "sha256-IdzcCrYJgaoxKTuJ0e1GPe0a5P1egBWmSKt9/or9nrM=";
 }

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -627,6 +627,7 @@ executable galley-schema
       V66_AddSplashScreen
       V67_MLSFeature
       V68_MLSCommitLock
+      V69_MLSProposal
       Paths_galley
   hs-source-dirs:
       schema/src

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -628,6 +628,7 @@ executable galley-schema
       V67_MLSFeature
       V68_MLSCommitLock
       V69_MLSProposal
+      V70_MLSCipherSuite
       Paths_galley
   hs-source-dirs:
       schema/src

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -62,6 +62,7 @@ library
       Galley.Cassandra.Instances
       Galley.Cassandra.LegalHold
       Galley.Cassandra.Paging
+      Galley.Cassandra.Proposal
       Galley.Cassandra.Queries
       Galley.Cassandra.ResultSet
       Galley.Cassandra.SearchVisibility
@@ -91,6 +92,7 @@ library
       Galley.Effects.ListItems
       Galley.Effects.MemberStore
       Galley.Effects.Paging
+      Galley.Effects.ProposalStore
       Galley.Effects.Queue
       Galley.Effects.RemoteConversationListStore
       Galley.Effects.SearchVisibilityStore

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -72,6 +72,7 @@ import qualified V66_AddSplashScreen
 import qualified V67_MLSFeature
 import qualified V68_MLSCommitLock
 import qualified V69_MLSProposal
+import qualified V70_MLSCipherSuite
 
 main :: IO ()
 main = do
@@ -129,7 +130,8 @@ main = do
       V66_AddSplashScreen.migration,
       V67_MLSFeature.migration,
       V68_MLSCommitLock.migration,
-      V69_MLSProposal.migration
+      V69_MLSProposal.migration,
+      V70_MLSCipherSuite.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Galley.Cassandra
       -- (see also docs/developer/cassandra-interaction.md)

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -71,6 +71,7 @@ import qualified V65_MLSRemoteClients
 import qualified V66_AddSplashScreen
 import qualified V67_MLSFeature
 import qualified V68_MLSCommitLock
+import qualified V69_MLSProposal
 
 main :: IO ()
 main = do
@@ -127,7 +128,8 @@ main = do
       V65_MLSRemoteClients.migration,
       V66_AddSplashScreen.migration,
       V67_MLSFeature.migration,
-      V68_MLSCommitLock.migration
+      V68_MLSCommitLock.migration,
+      V69_MLSProposal.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Galley.Cassandra
       -- (see also docs/developer/cassandra-interaction.md)

--- a/services/galley/schema/src/V69_MLSProposal.hs
+++ b/services/galley/schema/src/V69_MLSProposal.hs
@@ -29,9 +29,10 @@ migration =
   Migration 69 "Introduce an MLS proposals table" $
     schema'
       [r| CREATE TABLE mls_proposal_refs (
-            ref blob PRIMARY KEY,
-            proposal blob,
             group_id blob,
-            epoch bigint
+            epoch bigint,
+            ref blob,
+            proposal blob,
+            PRIMARY KEY (group_id, epoch, ref)
           )
         |]

--- a/services/galley/schema/src/V69_MLSProposal.hs
+++ b/services/galley/schema/src/V69_MLSProposal.hs
@@ -15,9 +15,23 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Cassandra (schemaVersion) where
+module V69_MLSProposal
+  ( migration,
+  )
+where
 
+import Cassandra.Schema
 import Imports
+import Text.RawString.QQ
 
-schemaVersion :: Int32
-schemaVersion = 69
+migration :: Migration
+migration =
+  Migration 69 "Introduce an MLS proposals table" $
+    schema'
+      [r| CREATE TABLE mls_proposal_refs (
+            ref blob PRIMARY KEY,
+            proposal blob,
+            group_id blob,
+            epoch bigint
+          )
+        |]

--- a/services/galley/schema/src/V70_MLSCipherSuite.hs
+++ b/services/galley/schema/src/V70_MLSCipherSuite.hs
@@ -15,9 +15,20 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Cassandra (schemaVersion) where
+module V70_MLSCipherSuite
+  ( migration,
+  )
+where
 
+import Cassandra.Schema
 import Imports
+import Text.RawString.QQ
 
-schemaVersion :: Int32
-schemaVersion = 70
+migration :: Migration
+migration =
+  Migration 70 "Add the MLS cipher suite column to the conversation table" $
+    schema'
+      [r| ALTER TABLE conversation ADD (
+            cipher_suite int
+          )
+        |]

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -52,6 +52,7 @@ import qualified Galley.Effects.BrigAccess as E
 import qualified Galley.Effects.ConversationStore as E
 import qualified Galley.Effects.FireAndForget as E
 import qualified Galley.Effects.MemberStore as E
+import Galley.Effects.ProposalStore (ProposalStore)
 import Galley.Options
 import Galley.Types.Conversations.Members
 import Galley.Types.UserList (UserList (UserList))
@@ -561,7 +562,8 @@ sendMLSMessage ::
         MemberStore,
         Resource,
         TeamStore,
-        P.TinyLog
+        P.TinyLog,
+        ProposalStore
       ]
       r
   ) =>

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -416,7 +416,6 @@ processProposal qusr conv msg prop = do
             . cipherSuiteNumber
             $ suite
         )
-  let propRef = proposalRef suiteTag prop
 
   -- validate the proposal
   --
@@ -426,6 +425,7 @@ processProposal qusr conv msg prop = do
   unless isMember' $ throwS @'ConvNotFound
 
   -- FUTUREWORK: validate the member's conversation role
+  let propRef = proposalRef suiteTag prop
   checkProposal suite (rmValue prop) propRef
 
   storeProposal propRef prop (msgGroupId msg) (msgEpoch msg)

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -180,7 +180,7 @@ postMLSMessageToLocalConv qusr con smsg lcnv = case rmValue smsg of
         CommitMessage c ->
           processCommit qusr con (qualifyAs lcnv conv) (msgEpoch msg) (msgSender msg) c
         ApplicationMessage _ -> throwS @'MLSUnsupportedMessage
-        ProposalMessage prop -> processProposal conv msg prop
+        ProposalMessage prop -> processProposal conv msg prop $> mempty
       SMLSCipherText -> case toMLSEnum' (msgContentType (msgPayload msg)) of
         Right CommitMessageTag -> throwS @'MLSUnsupportedMessage
         Right ProposalMessageTag -> throwS @'MLSUnsupportedMessage
@@ -347,7 +347,7 @@ processProposal ::
   Data.Conversation ->
   Message 'MLSPlainText ->
   RawMLS Proposal ->
-  Sem r [LocalConversationUpdate]
+  Sem r ()
 processProposal conv msg prop = do
   suite <-
     preview (to convProtocol . _ProtocolMLS . to cnvmlsCipherSuite) conv
@@ -365,7 +365,6 @@ processProposal conv msg prop = do
   let propRef = proposalRef suiteTag prop
   -- TODO(md): do any needed validation of the proposal
   storeProposal propRef prop (msgGroupId msg) (msgEpoch msg)
-  pure mempty
 
 executeProposalAction ::
   forall r.

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -129,7 +129,8 @@ postMLSMessage ::
          ErrorS 'MLSProposalNotFound,
          ErrorS 'MissingLegalholdConsent,
          Resource,
-         TinyLog
+         TinyLog,
+         ProposalStore
        ]
       r
   ) =>
@@ -159,7 +160,8 @@ postMLSMessageToLocalConv ::
          ErrorS 'MLSProposalNotFound,
          ErrorS 'MissingLegalholdConsent,
          Resource,
-         TinyLog
+         TinyLog,
+         ProposalStore
        ]
       r
   ) =>
@@ -345,7 +347,7 @@ processProposal ::
   Data.Conversation ->
   Message 'MLSPlainText ->
   RawMLS Proposal ->
-  Sem r [Event]
+  Sem r [LocalConversationUpdate]
 processProposal conv msg prop = do
   suite <-
     preview (to convProtocol . _ProtocolMLS . to cnvmlsCipherSuite) conv

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -67,6 +67,7 @@ import Galley.Cassandra.Conversation.Members
 import Galley.Cassandra.ConversationList
 import Galley.Cassandra.CustomBackend
 import Galley.Cassandra.LegalHold
+import Galley.Cassandra.Proposal
 import Galley.Cassandra.SearchVisibility
 import Galley.Cassandra.Services
 import Galley.Cassandra.Team
@@ -254,6 +255,7 @@ evalGalley e =
     . interpretLegalHoldStoreToCassandra lh
     . interpretCustomBackendStoreToCassandra
     . interpretConversationStoreToCassandra
+    . interpretProposalStoreToCassandra
     . interpretCodeStoreToCassandra
     . interpretClientStoreToCassandra
     . interpretFireAndForget

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -63,7 +63,7 @@ createConversation lcnv nc = do
         ProtocolMLSTag ->
           let gid = convToGroupId lcnv
               ep = Epoch 0
-              cs = CipherSuite 1
+              cs = MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
            in ( ProtocolMLS
                   ConversationMLSData
                     { cnvmlsGroupId = gid,
@@ -245,7 +245,7 @@ toProtocol ::
   Maybe ProtocolTag ->
   Maybe GroupId ->
   Maybe Epoch ->
-  Maybe CipherSuite ->
+  Maybe CipherSuiteTag ->
   Maybe Protocol
 toProtocol Nothing _ _ _ = Just ProtocolProteus
 toProtocol (Just ProtocolProteusTag) _ _ _ = Just ProtocolProteus
@@ -256,7 +256,7 @@ toConv ::
   ConvId ->
   [LocalMember] ->
   [RemoteMember] ->
-  Maybe (ConvType, UserId, Maybe (Cql.Set Access), Maybe AccessRoleLegacy, Maybe (Cql.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuite) ->
+  Maybe (ConvType, UserId, Maybe (Cql.Set Access), Maybe AccessRoleLegacy, Maybe (Cql.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuiteTag) ->
   Maybe Conversation
 toConv cid ms remoteMems mconv = do
   (cty, uid, acc, role, roleV2, nme, ti, del, timer, rm, ptag, mgid, mep, mcs) <- mconv

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -52,22 +52,32 @@ import qualified System.Logger as Log
 import qualified UnliftIO
 import Wire.API.Conversation hiding (Conversation, Member)
 import Wire.API.Conversation.Protocol
+import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Group
 
 createConversation :: Local ConvId -> NewConversation -> Client Conversation
 createConversation lcnv nc = do
   let meta = ncMetadata nc
-      (proto, mgid, mep) = case ncProtocol nc of
-        ProtocolProteusTag -> (ProtocolProteus, Nothing, Nothing)
+      (proto, mgid, mep, mcs) = case ncProtocol nc of
+        ProtocolProteusTag -> (ProtocolProteus, Nothing, Nothing, Nothing)
         ProtocolMLSTag ->
           let gid = convToGroupId lcnv
+              ep = Epoch 0
+              cs = CipherSuite 1
            in ( ProtocolMLS
                   ConversationMLSData
                     { cnvmlsGroupId = gid,
-                      cnvmlsEpoch = Epoch 0
+                      cnvmlsEpoch = ep,
+                      cnvmlsCipherSuite = cs
                     },
                 Just gid,
-                Just (Epoch 0)
+                Just ep,
+                -- FUTUREWORK: Make the cipher suite be a record field in
+                -- 'NewConversation' instead of hard-coding it here.
+                --
+                -- 'CipherSuite 1' corresponds to
+                -- 'MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519'.
+                Just cs
               )
   retry x5 . batch $ do
     setType BatchLogged
@@ -85,7 +95,8 @@ createConversation lcnv nc = do
         cnvmReceiptMode meta,
         ncProtocol nc,
         mgid,
-        mep
+        mep,
+        mcs
       )
     for_ (cnvmTeam meta) $ \tid -> addPrepQuery Cql.insertTeamConv (tid, tUnqualified lcnv)
     for_ mgid $ \gid -> addPrepQuery Cql.insertGroupId (gid, tUnqualified lcnv, tDomain lcnv)
@@ -117,7 +128,7 @@ conversationMeta conv =
   (toConvMeta =<<)
     <$> retry x1 (query1 Cql.selectConv (params LocalQuorum (Identity conv)))
   where
-    toConvMeta (t, c, a, r, r', n, i, _, mt, rm, _, _, _) = do
+    toConvMeta (t, c, a, r, r', n, i, _, mt, rm, _, _, _, _) = do
       let mbAccessRolesV2 = Set.fromList . Cql.fromSet <$> r'
           accessRoles = maybeRole t $ parseAccessRoles r mbAccessRolesV2
       pure $ ConversationMetadata t c (defAccess t a) accessRoles n i mt rm
@@ -230,23 +241,28 @@ remoteConversationStatusOnDomain uid rconvs =
         toMemberStatus (omus, omur, oar, oarr, hid, hidr)
       )
 
-toProtocol :: Maybe ProtocolTag -> Maybe GroupId -> Maybe Epoch -> Maybe Protocol
-toProtocol Nothing _ _ = Just ProtocolProteus
-toProtocol (Just ProtocolProteusTag) _ _ = Just ProtocolProteus
-toProtocol (Just ProtocolMLSTag) mgid mepoch =
-  ProtocolMLS <$> (ConversationMLSData <$> mgid <*> mepoch)
+toProtocol ::
+  Maybe ProtocolTag ->
+  Maybe GroupId ->
+  Maybe Epoch ->
+  Maybe CipherSuite ->
+  Maybe Protocol
+toProtocol Nothing _ _ _ = Just ProtocolProteus
+toProtocol (Just ProtocolProteusTag) _ _ _ = Just ProtocolProteus
+toProtocol (Just ProtocolMLSTag) mgid mepoch mcs =
+  ProtocolMLS <$> (ConversationMLSData <$> mgid <*> mepoch <*> mcs)
 
 toConv ::
   ConvId ->
   [LocalMember] ->
   [RemoteMember] ->
-  Maybe (ConvType, UserId, Maybe (Cql.Set Access), Maybe AccessRoleLegacy, Maybe (Cql.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe ProtocolTag, Maybe GroupId, Maybe Epoch) ->
+  Maybe (ConvType, UserId, Maybe (Cql.Set Access), Maybe AccessRoleLegacy, Maybe (Cql.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuite) ->
   Maybe Conversation
 toConv cid ms remoteMems mconv = do
-  (cty, uid, acc, role, roleV2, nme, ti, del, timer, rm, ptag, mgid, mep) <- mconv
+  (cty, uid, acc, role, roleV2, nme, ti, del, timer, rm, ptag, mgid, mep, mcs) <- mconv
   let mbAccessRolesV2 = Set.fromList . Cql.fromSet <$> roleV2
       accessRoles = maybeRole cty $ parseAccessRoles role mbAccessRolesV2
-  proto <- toProtocol ptag mgid mep
+  proto <- toProtocol ptag mgid mep mcs
   pure
     Conversation
       { convId = cid,

--- a/services/galley/src/Galley/Cassandra/Instances.hs
+++ b/services/galley/src/Galley/Cassandra/Instances.hs
@@ -238,3 +238,12 @@ instance Cql (RawMLS Proposal) where
   toCql = CqlBlob . LBS.fromStrict . rmRaw
   fromCql (CqlBlob b) = mapLeft T.unpack $ decodeMLS b
   fromCql _ = Left "Proposal: blob expected"
+
+instance Cql CipherSuite where
+  ctype = Tagged IntColumn
+  toCql = CqlInt . fromIntegral . cipherSuiteNumber
+  fromCql (CqlInt i) =
+    if i < 2 ^ (16 :: Integer)
+      then Right . CipherSuite . fromIntegral $ i
+      else Left "CipherSuite: an out of bounds value for Word16"
+  fromCql _ = Left "CipherSuite: int expected"

--- a/services/galley/src/Galley/Cassandra/Proposal.hs
+++ b/services/galley/src/Galley/Cassandra/Proposal.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Cassandra.Proposal (interpretProposalStoreToCassandra) where
+
+import Cassandra
+import Galley.Cassandra.Instances ()
+import Galley.Cassandra.Store
+import Galley.Effects.ProposalStore
+import Imports
+import Polysemy
+import Polysemy.Input
+import Wire.API.MLS.Group
+import Wire.API.MLS.Message
+import Wire.API.MLS.Proposal
+import Wire.API.MLS.Serialisation
+
+newtype TTL = TTL Integer
+  deriving newtype (Cql)
+
+-- | Proposals in the database expire after this timeout in seconds
+ttl :: TTL
+ttl = TTL $ 30 * 24 * 60 * 60
+
+interpretProposalStoreToCassandra ::
+  Members '[Embed IO, Input ClientState] r =>
+  Sem (ProposalStore ': r) a ->
+  Sem r a
+interpretProposalStoreToCassandra =
+  interpret $
+    embedClient . \case
+      StoreProposal ref raw gid epoch ->
+        retry x5 $
+          write storeQuery (params LocalQuorum (ref, raw, gid, epoch, ttl))
+      GetProposal ref ->
+        retry x1 (query1 getQuery (params LocalQuorum (Identity ref)))
+
+storeQuery :: PrepQuery W (ProposalRef, RawMLS Proposal, GroupId, Epoch, TTL) ()
+storeQuery = "insert into mls_proposal_refs (ref, proposal, group_id, epoch) values (?, ?, ?, ?) using ttl ?"
+
+getQuery :: PrepQuery R (Identity ProposalRef) (RawMLS Proposal, GroupId, Epoch)
+getQuery = "select proposal, group_id, epoch from mls_proposal_refs where ref = ?"

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -308,6 +308,9 @@ insertRemoteMember = "insert into member_remote_user (conv, user_remote_domain, 
 removeRemoteMember :: PrepQuery W (ConvId, Domain, UserId) ()
 removeRemoteMember = "delete from member_remote_user where conv = ? and user_remote_domain = ? and user_remote_id = ?"
 
+selectRemoteMember :: PrepQuery R (ConvId, Domain, UserId) (RoleName, C.Set ClientId)
+selectRemoteMember = "select conversation_role, mls_clients from member_remote_user where conv = ? and user_remote_domain = ? and user_remote_id = ?"
+
 selectRemoteMembers :: PrepQuery R (Identity ConvId) (Domain, UserId, RoleName, C.Set ClientId)
 selectRemoteMembers = "select user_remote_domain, user_remote_id, conversation_role, mls_clients from member_remote_user where conv = ?"
 

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -196,7 +196,7 @@ updateTeamSplashScreen = "update team set splash_screen = ? where team = ?"
 
 -- Conversations ------------------------------------------------------------
 
-selectConv :: PrepQuery R (Identity ConvId) (ConvType, UserId, Maybe (C.Set Access), Maybe AccessRoleLegacy, Maybe (C.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuite)
+selectConv :: PrepQuery R (Identity ConvId) (ConvType, UserId, Maybe (C.Set Access), Maybe AccessRoleLegacy, Maybe (C.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuiteTag)
 selectConv = "select type, creator, access, access_role, access_roles_v2, name, team, deleted, message_timer, receipt_mode, protocol, group_id, epoch, cipher_suite from conversation where conv = ?"
 
 selectReceiptMode :: PrepQuery R (Identity ConvId) (Identity (Maybe ReceiptMode))
@@ -205,7 +205,7 @@ selectReceiptMode = "select receipt_mode from conversation where conv = ?"
 isConvDeleted :: PrepQuery R (Identity ConvId) (Identity (Maybe Bool))
 isConvDeleted = "select deleted from conversation where conv = ?"
 
-insertConv :: PrepQuery W (ConvId, ConvType, UserId, C.Set Access, C.Set AccessRoleV2, Maybe Text, Maybe TeamId, Maybe Milliseconds, Maybe ReceiptMode, ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuite) ()
+insertConv :: PrepQuery W (ConvId, ConvType, UserId, C.Set Access, C.Set AccessRoleV2, Maybe Text, Maybe TeamId, Maybe Milliseconds, Maybe ReceiptMode, ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuiteTag) ()
 insertConv = "insert into conversation (conv, type, creator, access, access_roles_v2, name, team, message_timer, receipt_mode, protocol, group_id, epoch, cipher_suite) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
 updateConvAccess :: PrepQuery W (C.Set Access, C.Set AccessRoleV2, ConvId) ()

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -34,6 +34,7 @@ import Wire.API.Conversation
 import Wire.API.Conversation.Code
 import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
+import Wire.API.MLS.CipherSuite
 import Wire.API.Provider
 import Wire.API.Provider.Service
 import Wire.API.Team
@@ -195,8 +196,8 @@ updateTeamSplashScreen = "update team set splash_screen = ? where team = ?"
 
 -- Conversations ------------------------------------------------------------
 
-selectConv :: PrepQuery R (Identity ConvId) (ConvType, UserId, Maybe (C.Set Access), Maybe AccessRoleLegacy, Maybe (C.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe ProtocolTag, Maybe GroupId, Maybe Epoch)
-selectConv = "select type, creator, access, access_role, access_roles_v2, name, team, deleted, message_timer, receipt_mode, protocol, group_id, epoch from conversation where conv = ?"
+selectConv :: PrepQuery R (Identity ConvId) (ConvType, UserId, Maybe (C.Set Access), Maybe AccessRoleLegacy, Maybe (C.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuite)
+selectConv = "select type, creator, access, access_role, access_roles_v2, name, team, deleted, message_timer, receipt_mode, protocol, group_id, epoch, cipher_suite from conversation where conv = ?"
 
 selectReceiptMode :: PrepQuery R (Identity ConvId) (Identity (Maybe ReceiptMode))
 selectReceiptMode = "select receipt_mode from conversation where conv = ?"
@@ -204,8 +205,8 @@ selectReceiptMode = "select receipt_mode from conversation where conv = ?"
 isConvDeleted :: PrepQuery R (Identity ConvId) (Identity (Maybe Bool))
 isConvDeleted = "select deleted from conversation where conv = ?"
 
-insertConv :: PrepQuery W (ConvId, ConvType, UserId, C.Set Access, C.Set AccessRoleV2, Maybe Text, Maybe TeamId, Maybe Milliseconds, Maybe ReceiptMode, ProtocolTag, Maybe GroupId, Maybe Epoch) ()
-insertConv = "insert into conversation (conv, type, creator, access, access_roles_v2, name, team, message_timer, receipt_mode, protocol, group_id, epoch) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+insertConv :: PrepQuery W (ConvId, ConvType, UserId, C.Set Access, C.Set AccessRoleV2, Maybe Text, Maybe TeamId, Maybe Milliseconds, Maybe ReceiptMode, ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuite) ()
+insertConv = "insert into conversation (conv, type, creator, access, access_roles_v2, name, team, message_timer, receipt_mode, protocol, group_id, epoch, cipher_suite) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
 updateConvAccess :: PrepQuery W (C.Set Access, C.Set AccessRoleV2, ConvId) ()
 updateConvAccess = "update conversation set access = ?, access_roles_v2 = ? where conv = ?"

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -77,6 +77,7 @@ import Galley.Effects.GundeckAccess
 import Galley.Effects.LegalHoldStore
 import Galley.Effects.ListItems
 import Galley.Effects.MemberStore
+import Galley.Effects.ProposalStore
 import Galley.Effects.Queue
 import Galley.Effects.SearchVisibilityStore
 import Galley.Effects.ServiceStore
@@ -105,6 +106,7 @@ type GalleyEffects1 =
      FireAndForget,
      ClientStore,
      CodeStore,
+     ProposalStore,
      ConversationStore,
      CustomBackendStore,
      LegalHoldStore,

--- a/services/galley/src/Galley/Effects/MemberStore.hs
+++ b/services/galley/src/Galley/Effects/MemberStore.hs
@@ -30,6 +30,7 @@ module Galley.Effects.MemberStore
     -- * Read members
     getLocalMember,
     getLocalMembers,
+    getRemoteMember,
     getRemoteMembers,
     selectRemoteMembers,
 
@@ -61,6 +62,7 @@ data MemberStore m a where
   CreateBotMember :: ServiceRef -> BotId -> ConvId -> MemberStore m BotMember
   GetLocalMember :: ConvId -> UserId -> MemberStore m (Maybe LocalMember)
   GetLocalMembers :: ConvId -> MemberStore m [LocalMember]
+  GetRemoteMember :: ConvId -> Remote UserId -> MemberStore m (Maybe RemoteMember)
   GetRemoteMembers :: ConvId -> MemberStore m [RemoteMember]
   SelectRemoteMembers :: [UserId] -> Remote ConvId -> MemberStore m ([UserId], Bool)
   SetSelfMember :: Qualified ConvId -> Local UserId -> MemberUpdate -> MemberStore m ()

--- a/services/galley/src/Galley/Effects/ProposalStore.hs
+++ b/services/galley/src/Galley/Effects/ProposalStore.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.ProposalStore where
+
+import Imports
+import Polysemy
+import Wire.API.MLS.Group
+import Wire.API.MLS.Message
+import Wire.API.MLS.Proposal
+import Wire.API.MLS.Serialisation
+
+data ProposalStore m a where
+  StoreProposal ::
+    ProposalRef ->
+    RawMLS Proposal ->
+    GroupId ->
+    Epoch ->
+    ProposalStore m ()
+  GetProposal ::
+    ProposalRef ->
+    ProposalStore m (Maybe (RawMLS Proposal, GroupId, Epoch))
+
+makeSem ''ProposalStore

--- a/services/galley/src/Galley/Effects/ProposalStore.hs
+++ b/services/galley/src/Galley/Effects/ProposalStore.hs
@@ -28,13 +28,19 @@ import Wire.API.MLS.Serialisation
 
 data ProposalStore m a where
   StoreProposal ::
-    ProposalRef ->
-    RawMLS Proposal ->
     GroupId ->
     Epoch ->
+    ProposalRef ->
+    RawMLS Proposal ->
     ProposalStore m ()
   GetProposal ::
+    GroupId ->
+    Epoch ->
     ProposalRef ->
-    ProposalStore m (Maybe (RawMLS Proposal, GroupId, Epoch))
+    ProposalStore m (Maybe (RawMLS Proposal))
+  GetAllPendingProposals ::
+    GroupId ->
+    Epoch ->
+    ProposalStore m [ProposalRef]
 
 makeSem ''ProposalStore

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -991,6 +991,7 @@ propNonExistingConv = withSystemTempDirectory "mls" $ \tmp -> do
             [ "proposal",
               "--group-in",
               tmp </> cs groupId,
+              "--in-place",
               "add",
               tmp </> pClientQid bob
             ]
@@ -1006,7 +1007,7 @@ propExistingConv = withSystemTempDirectory "mls" $ \tmp -> do
   -- setupGroup :: HasCallStack => FilePath -> CreateConv -> Participant -> String -> TestM (Qualified ConvId)
   void $ setupGroup tmp CreateConv creator "group.json"
 
-  prop <- liftIO $ bareAddProposal tmp creator bob "group.json"
+  prop <- liftIO $ bareAddProposal tmp creator bob "group.json" "group.json"
 
   events <-
     responseJsonError
@@ -1031,7 +1032,7 @@ propInvalidEpoch = withSystemTempDirectory "mls" $ \tmp -> do
 
   -- try to request a proposal that with too old epoch (0)
   do
-    prop <- liftIO $ bareAddProposal tmp creator charlie "group.0.json"
+    prop <- liftIO $ bareAddProposal tmp creator charlie "group.0.json" "group.0.json"
     err <-
       responseJsonError
         =<< postMessage (qUnqualified (pUserId creator)) prop
@@ -1044,7 +1045,7 @@ propInvalidEpoch = withSystemTempDirectory "mls" $ \tmp -> do
       liftIO $
         setupCommit tmp creator "group.1.json" "group.2.json" $
           toList (pClients charlie)
-    prop <- liftIO $ bareAddProposal tmp creator dee "group.2.json"
+    prop <- liftIO $ bareAddProposal tmp creator dee "group.2.json" "group.2.json"
     err <-
       responseJsonError
         =<< postMessage (qUnqualified (pUserId creator)) prop
@@ -1053,6 +1054,6 @@ propInvalidEpoch = withSystemTempDirectory "mls" $ \tmp -> do
 
   -- same proposal with correct epoch (1)
   do
-    prop <- liftIO $ bareAddProposal tmp creator dee "group.1.json"
+    prop <- liftIO $ bareAddProposal tmp creator dee "group.1.json" "group.1.json"
     postMessage (qUnqualified (pUserId creator)) prop
       !!! const 201 === statusCode

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -68,6 +68,9 @@ tests s =
   testGroup
     "MLS"
     [ testGroup
+        "Message"
+        [test s "sender must be part of conversation" testSenderNotInConversation],
+      testGroup
         "Welcome"
         [ test s "local welcome" testLocalWelcome,
           test s "local welcome (client with no public key)" testWelcomeNoKey,
@@ -119,8 +122,7 @@ tests s =
         [ test s "add a new client to a non-existing conversation" propNonExistingConv,
           test s "add a new client to an existing conversation" propExistingConv,
           test s "add a new client in an invalid epoch" propInvalidEpoch,
-          test s "add a new client with a non-matching cipher suite" (error "TODO: remove this test. if the handler throws this error it is irrespective of the request."),
-          test s "add a new client of a non-member" propNonMember
+          test s "add a new client with a non-matching cipher suite" (error "TODO: remove this test. if the handler throws this error it is irrespective of the request.")
         ],
       testGroup
         "Protocol mismatch"
@@ -161,6 +163,24 @@ postMLSConvOk = do
       const Nothing === fmap Wai.label . responseJsonError
     cid <- assertConv rsp RegularConv alice qalice [] (Just nameMaxSize) Nothing
     checkConvCreateEvent cid wsA
+
+testSenderNotInConversation :: TestM ()
+testSenderNotInConversation = do
+  withSystemTempDirectory "mls" $ \tmp -> do
+    (alice, [bob]) <- withLastPrekeys $ setupParticipants tmp def [(1, LocalUser)]
+    _ <- setupGroup tmp CreateConv alice "group"
+
+    -- FUTUREWORK: create the message with bob as sender, when mls-test-cli
+    -- supports this
+    message <- liftIO $ createMessage tmp alice "group" "some text"
+
+    -- send the message as bob, who is not in the conversation
+    err <-
+      responseJsonError
+        =<< postMessage (qUnqualified (pUserId bob)) message
+        <!! const 404 === statusCode
+
+    liftIO $ Wai.label err @?= "no-conversation-member"
 
 testLocalWelcome :: TestM ()
 testLocalWelcome = do
@@ -1032,26 +1052,3 @@ propInvalidEpoch = withSystemTempDirectory "mls" $ \tmp -> do
     prop <- liftIO $ bareAddProposal tmp creator dee "group.1.json"
     postMessage (qUnqualified (pUserId creator)) prop
       !!! const 201 === statusCode
-
-propNonMember :: TestM ()
-propNonMember = withSystemTempDirectory "mls" $ \tmp -> do
-  (creator, [bob, charlie]) <- withLastPrekeys $ setupParticipants tmp def [(1, LocalUser), (1, LocalUser)]
-
-  -- create a group
-  (groupId, conversation) <- setupGroup tmp CreateConv creator "group.json"
-
-  -- add only clients of creator and bob
-  (commit, welcome) <-
-    liftIO $
-      setupCommit tmp creator "group.json" "group.json" $
-        NonEmpty.tail (pClients creator) <> NonEmpty.tail (pClients bob)
-
-  let users = []
-  void $ postCommit MessagingSetup {..}
-
-  prop <- liftIO $ bareAddProposal tmp creator charlie "group.json"
-  err <-
-    responseJsonError
-      =<< postMessage (qUnqualified (pUserId creator)) prop
-        <!! const 409 === statusCode
-  liftIO $ Wai.label err @?= "no-conversation"

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -57,6 +57,7 @@ import Wire.API.Conversation.Role
 import Wire.API.Event.Conversation
 import Wire.API.Federation.API.Common
 import Wire.API.Federation.API.Galley
+import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Group (convToGroupId)
 import Wire.API.Message
 
@@ -678,7 +679,7 @@ testLocalToRemote = withSystemTempDirectory "mls" $ \tmp -> do
   qcnv <- randomQualifiedId (qDomain (pUserId alice))
   let nrc =
         NewRemoteConversation (qUnqualified qcnv) $
-          ProtocolMLS (ConversationMLSData groupId (Epoch 1))
+          ProtocolMLS (ConversationMLSData groupId (Epoch 1) (CipherSuite 1))
   void $
     runFedClient
       @"on-new-remote-conversation"

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -121,8 +121,7 @@ tests s =
         "Proposal"
         [ test s "add a new client to a non-existing conversation" propNonExistingConv,
           test s "add a new client to an existing conversation" propExistingConv,
-          test s "add a new client in an invalid epoch" propInvalidEpoch,
-          test s "add a new client with a non-matching cipher suite" (error "TODO: remove this test. if the handler throws this error it is irrespective of the request.")
+          test s "add a new client in an invalid epoch" propInvalidEpoch
         ],
       testGroup
         "Protocol mismatch"

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -995,6 +995,7 @@ propExistingConv = withSystemTempDirectory "mls" $ \tmp -> do
       <!! const 201 === statusCode
   liftIO $ events @?= ([] :: [Event])
 
+-- TODO: assert on error label
 propInvalidEpoch :: TestM ()
 propInvalidEpoch = withSystemTempDirectory "mls" $ \tmp -> do
   (creator, users) <- withLastPrekeys $ setupParticipants tmp def [(1, LocalUser), (1, LocalUser), (1, LocalUser)]

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -168,9 +168,26 @@ testSenderNotInConversation = do
     (alice, [bob]) <- withLastPrekeys $ setupParticipants tmp def [(1, LocalUser)]
     _ <- setupGroup tmp CreateConv alice "group"
 
-    -- FUTUREWORK: create the message with bob as sender, when mls-test-cli
-    -- supports this
-    message <- liftIO $ createMessage tmp alice "group" "some text"
+    (_commit, _welcome) <-
+      liftIO $
+        setupCommit tmp alice "group" "group" $
+          toList (pClients bob)
+
+    void . liftIO $
+      spawn
+        ( cli
+            (pClientQid bob)
+            tmp
+            [ "group",
+              "from-welcome",
+              "--group-out",
+              tmp </> "group",
+              tmp </> "welcome"
+            ]
+        )
+        Nothing
+
+    message <- liftIO $ createMessage tmp bob "group" "some text"
 
     -- send the message as bob, who is not in the conversation
     err <-

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -317,6 +317,7 @@ bareAddProposal tmp creator participantToAdd groupName =
     Nothing
 
 createMessage ::
+  HasCallStack =>
   String ->
   Participant ->
   String ->

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -295,6 +295,27 @@ setupCommit tmp admin groupName newGroupName clients =
       Nothing
       <*> BS.readFile (tmp </> "welcome")
 
+bareAddProposal ::
+  HasCallStack =>
+  String ->
+  Participant ->
+  Participant ->
+  String ->
+  IO ByteString
+bareAddProposal tmp creator participantToAdd groupName =
+  spawn
+    ( cli
+        (pClientQid creator)
+        tmp
+        $ [ "proposal",
+            "--group",
+            tmp </> groupName,
+            "add",
+            tmp </> pClientQid participantToAdd
+          ]
+    )
+    Nothing
+
 createMessage ::
   String ->
   Participant ->

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2705,15 +2705,23 @@ parseFedRequest fr = eitherDecode (frBody fr)
 
 assertOne :: (HasCallStack, MonadIO m, Show a) => [a] -> m a
 assertOne [a] = pure a
-assertOne xs = liftIO . assertFailure $ "Expected exactly one element, found " <> show xs
+assertOne xs = liftIO . error $ "Expected exactly one element, found " <> show xs
+
+assertTwo :: (HasCallStack, Show a) => [a] -> (a, a)
+assertTwo [a, b] = (a, b)
+assertTwo xs = error $ "Expected two elements, found " <> show xs
+
+assertThree :: (HasCallStack, Show a) => [a] -> (a, a, a)
+assertThree [a1, a2, a3] = (a1, a2, a3)
+assertThree xs = error $ "Expected three elements, found " <> show xs
 
 assertNone :: (HasCallStack, MonadIO m, Show a) => [a] -> m ()
 assertNone [] = pure ()
-assertNone xs = liftIO . assertFailure $ "Expected exactly no elements, found " <> show xs
+assertNone xs = liftIO . error $ "Expected exactly no elements, found " <> show xs
 
 assertJust :: (HasCallStack, MonadIO m) => Maybe a -> m a
 assertJust (Just a) = pure a
-assertJust Nothing = liftIO $ assertFailure "Expected Just, got Nothing"
+assertJust Nothing = liftIO $ error "Expected Just, got Nothing"
 
 iUpsertOne2OneConversation :: UpsertOne2OneConversationRequest -> TestM ResponseLBS
 iUpsertOne2OneConversation req = do


### PR DESCRIPTION
This patch implements the support for bare proposals in MLS.

Tracked by https://wearezeta.atlassian.net/browse/FS-509.

Things that are yet to be finished:

- [x] In `Galley.API.MLS.Message` in function `applyProposalRef` check that the add proposal's group ID and epoch number are in line with those of the conversation. Actually, it is not clear if they should be checked against the epoch number when the proposal is received or when it is committed,
- [x] In `Galley.API.MLS.Message` make use of the `checkProposal` function when processing inlined proposals,
- [ ] See if better errors (e.g., potentially new and/or statically known errors) can be used in proposal-proccessing code introduced by this PR,
- [x] Add two Galley integration tests in `API.MLS` for commits. In the commit group there should be two more tests, one successfully referencing an existing proposal, and one failing test referencing a non-existing proposal,
- [x] Finish Galley integration tests in `API.MLS` for proposals. So far there's only one finished test that tries to send an add proposal to a conversation that doesn't exist in Galley. Other tests that are yet to be implemented vacuously succeed (as denoted by `pure ()` in the proposals test group).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
