### PR TITLE
charts/{cannon,nginz}: Allow configuring arbitrary hosts for CORS allowlisting

### DIFF
--- a/changelog.d/5-internal/nginz-randomport
+++ b/changelog.d/5-internal/nginz-randomport
@@ -1,0 +1,3 @@
+charts/{cannon,nginz}: values listed in
+`nginx_conf.randomport_allowlisted_origins` must be full hostnames. Hostnames
+listed here will be allowlisted with and without TLS.

--- a/charts/cannon/templates/conf/_nginx.conf.tpl
+++ b/charts/cannon/templates/conf/_nginx.conf.tpl
@@ -132,7 +132,7 @@ http {
     # Allow additional origins at random ports. This is useful for testing with an HTTP proxy.
     # It should not be used in production.
     {{ range $origin := .Values.nginx_conf.randomport_allowlisted_origins }}
-      "~^https://{{ $origin }}.{{ $.Values.nginx_conf.external_env_domain}}(:[0-9]{2,5})?$" "$http_origin";
+      "~^https?://{{ $origin }}(:[0-9]{2,5})?$" "$http_origin";
     {{ end }}
    }
 

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -39,15 +39,16 @@ nginx_conf:
     # * https://wearezeta.atlassian.net/browse/FS-444
     ciphers: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256"
 
-  # -- The origins from which we allow CORS requests. These are combined with 'external_env_domain' to form a full url
+  # The origins from which we allow CORS requests. These are combined with
+  # 'external_env_domain' to form a full url
   allowlisted_origins:
     - webapp
     - teams
     - account
-  # -- The origins from which we allow CORS requests at random ports. This is
+  # The origins from which we allow CORS requests at random ports. This is
   # useful for testing with HTTP proxies and should not be used in production.
-  # The list entries are combined with 'external_env_domain' to form a full url
-  # regex that matches for all ports.
+  # The list entries must be full hostnames (they are **not** combined with
+  # 'external_env_domain'). http and https URLs are allow listed.
   randomport_allowlisted_origins: [] # default is empty by intention
   upstreams:
     cannon:

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -132,7 +132,7 @@ http {
     # Allow additional origins at random ports. This is useful for testing with an HTTP proxy.
     # It should not be used in production.
     {{ range $origin := .Values.nginx_conf.randomport_allowlisted_origins }}
-      "~^https://{{ $origin }}.{{ $.Values.nginx_conf.external_env_domain}}(:[0-9]{2,5})?$" "$http_origin";
+      "~^https?://{{ $origin }}(:[0-9]{2,5})?$" "$http_origin";
     {{ end }}
    }
 

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -51,15 +51,16 @@ nginx_conf:
   - /conversations/([^/]*)/call/state
   - /search/top
   - /search/common
-  # -- The origins from which we allow CORS requests. These are combined with 'external_env_domain' to form a full url
+  # The origins from which we allow CORS requests. These are combined with
+  # 'external_env_domain' to form a full url
   allowlisted_origins:
     - webapp
     - teams
     - account
-  # -- The origins from which we allow CORS requests at random ports. This is
+  # The origins from which we allow CORS requests at random ports. This is
   # useful for testing with HTTP proxies and should not be used in production.
-  # The list entries are combined with 'external_env_domain' to form a full url
-  # regex that matches for all ports.
+  # The list entries must be full hostnames (they are **not** combined with
+  # 'external_env_domain'). http and https URLs are allow listed.
   randomport_allowlisted_origins: [] # default is empty by intention
   # Add 'cannon' to 'ignored_upstreams' if you wish to make use of separate
   # network traffic to cannon-with-its-own-nginz


### PR DESCRIPTION
Some internal test environments like staging, must allow requests from arbitrary domains which different teams use. It should also allow requests from `localhost:<some-port>`. This PR expands the purpose of `nginx_conf.randomport_allowlisted_origins` to allow any arbitrary host name. 

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.