### PR TITLE
charts/{cannon,nginz}: Increase map_hash_bucket_size for nginx to 128

### DIFF
--- a/changelog.d/5-internal/nginz-map-hash-bucket-size
+++ b/changelog.d/5-internal/nginz-map-hash-bucket-size
@@ -1,0 +1,1 @@
+charts/{nginz,cannon}: Increase map_hash_bucket_size for nginx to 128

--- a/charts/cannon/templates/conf/_nginx.conf.tpl
+++ b/charts/cannon/templates/conf/_nginx.conf.tpl
@@ -35,6 +35,7 @@ http {
   ignore_invalid_headers off;
 
   types_hash_max_size 2048;
+  map_hash_bucket_size 128;
 
   server_names_hash_bucket_size 64;
   server_name_in_redirect off;

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -35,6 +35,7 @@ http {
   ignore_invalid_headers off;
 
   types_hash_max_size 2048;
+  map_hash_bucket_size 128;
 
   server_names_hash_bucket_size 64;
   server_name_in_redirect off;


### PR DESCRIPTION
This is needed when there are many CORS origin to be allowed.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.