### PR TITLE
Email localization when provisioning users with SCIM.

### DIFF
--- a/changelog.d/3-bug-fixes/pr-2445
+++ b/changelog.d/3-bug-fixes/pr-2445
@@ -1,0 +1,1 @@
+Use SCIM's preferred language as a fallback when privisioning users without a locale.

--- a/libs/wire-api/src/Wire/API/User/Scim.hs
+++ b/libs/wire-api/src/Wire/API/User/Scim.hs
@@ -325,7 +325,8 @@ data ValidScimUser = ValidScimUser
     _vsuHandle :: Handle,
     _vsuName :: BT.Name,
     _vsuRichInfo :: RI.RichInfo,
-    _vsuActive :: Bool
+    _vsuActive :: Bool,
+    _vsuLocale :: Maybe Locale
   }
   deriving (Eq, Show)
 

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -162,8 +162,9 @@ newAccount u inv tid mbHandle = do
 newAccountInviteViaScim :: (MonadClient m, MonadReader Env m) => UserId -> TeamId -> Maybe Locale -> Name -> Email -> m UserAccount
 newAccountInviteViaScim uid tid locale name email = do
   defLoc <- setDefaultUserLocale <$> view settings
+  let loc = fromMaybe defLoc locale
   domain <- viewFederationDomain
-  pure (UserAccount (user domain (fromMaybe defLoc locale)) PendingInvitation)
+  pure (UserAccount (user domain loc) PendingInvitation)
   where
     user domain loc =
       User

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -292,7 +292,7 @@ createInvitationViaScim newUser@(NewUserScimInvitation tid loc name email) = do
             irInviteePhone = Nothing
           }
 
-  let context =
+      context =
         logFunction "Brig.Team.API.createInvitationViaScim"
           . logTeam tid
           . logEmail email

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -118,9 +118,10 @@ createBrigUserNoSAML ::
   TeamId ->
   -- | User name
   Name ->
+  Maybe Locale ->
   m UserId
-createBrigUserNoSAML email teamid uname = do
-  let newUser = NewUserScimInvitation teamid Nothing uname email
+createBrigUserNoSAML email teamid uname locale = do
+  let newUser = NewUserScimInvitation teamid locale uname email
   resp :: ResponseLBS <-
     call $
       method POST

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -271,7 +271,7 @@ validateScimUser' errloc midp richInfoLimit user = do
     either err pure $ Brig.mkUserName (Scim.displayName user) veid
   richInfo <- validateRichInfo (Scim.extra user ^. ST.sueRichInfo)
   let active = Scim.active user
-  lang <- maybe (error "TODO: scim error") pure $ mapM parseLanguage $ Scim.preferredLanguage user
+  lang <- maybe (error "Could not parse language. Expected format is ISO 639-1.") pure $ mapM parseLanguage $ Scim.preferredLanguage user
   pure $ ST.ValidScimUser veid handl uname richInfo (maybe True Scim.unScimBool active) (flip Locale Nothing <$> lang)
   where
     -- Validate rich info (@richInfo@). It must not exceed the rich info limit.

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -43,7 +43,7 @@ where
 
 import Brig.Types.Common (parseEmail)
 import Brig.Types.Intra (AccountStatus, UserAccount (accountStatus, accountUser))
-import Brig.Types.User (ManagedBy (..), Name (..), User (..))
+import Brig.Types.User (Locale (..), ManagedBy (..), Name (..), User (..))
 import qualified Brig.Types.User as BT
 import qualified Control.Applicative as Applicative (empty)
 import Control.Lens (view, (^.))
@@ -95,7 +95,7 @@ import qualified Web.Scim.Schema.Meta as Scim
 import qualified Web.Scim.Schema.ResourceType as Scim
 import qualified Web.Scim.Schema.User as Scim
 import qualified Web.Scim.Schema.User as Scim.User (schemas)
-import Wire.API.User (Email)
+import Wire.API.User (Email, parseLanguage)
 import Wire.API.User.IdentityProvider (IdP)
 import qualified Wire.API.User.RichInfo as RI
 import Wire.API.User.Saml (Opts, derivedOpts, derivedOptsScimBaseURI, richInfoLimit)
@@ -271,7 +271,8 @@ validateScimUser' errloc midp richInfoLimit user = do
     either err pure $ Brig.mkUserName (Scim.displayName user) veid
   richInfo <- validateRichInfo (Scim.extra user ^. ST.sueRichInfo)
   let active = Scim.active user
-  pure $ ST.ValidScimUser veid handl uname richInfo (maybe True Scim.unScimBool active)
+  lang <- maybe (error "TODO: scim error") pure $ mapM parseLanguage $ Scim.preferredLanguage user
+  pure $ ST.ValidScimUser veid handl uname richInfo (maybe True Scim.unScimBool active) (flip Locale Nothing <$> lang)
   where
     -- Validate rich info (@richInfo@). It must not exceed the rich info limit.
     validateRichInfo :: RI.RichInfo -> m RI.RichInfo
@@ -367,7 +368,7 @@ logEmail email =
   Log.field "email_sha256" (sha256String . cs . show $ email)
 
 logVSU :: ST.ValidScimUser -> (Msg -> Msg)
-logVSU (ST.ValidScimUser veid handl _name _richInfo _active) =
+logVSU (ST.ValidScimUser veid handl _name _richInfo _active _lang) =
   maybe id logEmail (veidEmail veid)
     . logHandle handl
 
@@ -422,7 +423,7 @@ createValidScimUser ::
   ScimTokenInfo ->
   ST.ValidScimUser ->
   m (Scim.StoredUser ST.SparTag)
-createValidScimUser tokeninfo@ScimTokenInfo {stiTeam} vsu@(ST.ValidScimUser veid handl name richInfo _) =
+createValidScimUser tokeninfo@ScimTokenInfo {stiTeam} vsu@(ST.ValidScimUser veid handl name richInfo _active language) =
   logScim
     ( logFunction "Spar.Scim.User.createValidScimUser"
         . logVSU vsu
@@ -451,7 +452,7 @@ createValidScimUser tokeninfo@ScimTokenInfo {stiTeam} vsu@(ST.ValidScimUser veid
                     BrigAccess.createSAML uref uid stiTeam name ManagedByScim
               )
               ( \email ->
-                  BrigAccess.createNoSAML email stiTeam name
+                  BrigAccess.createNoSAML email stiTeam name language
               )
               veid
 
@@ -872,6 +873,7 @@ synthesizeStoredUser usr veid =
           createdAt
           lastUpdatedAt
           baseuri
+          (userLocale (accountUser usr))
       lift $ writeState accessTimes (userManagedBy (accountUser usr)) richInfo storedUser
       pure storedUser
 
@@ -885,8 +887,9 @@ synthesizeStoredUser' ::
   UTCTimeMillis ->
   UTCTimeMillis ->
   URIBS.URI ->
+  Locale ->
   MonadError Scim.ScimError m => m (Scim.StoredUser ST.SparTag)
-synthesizeStoredUser' uid veid dname handle richInfo accStatus createdAt lastUpdatedAt baseuri = do
+synthesizeStoredUser' uid veid dname handle richInfo accStatus createdAt lastUpdatedAt baseuri locale = do
   let scimUser :: Scim.User ST.SparTag
       scimUser =
         synthesizeScimUser
@@ -897,7 +900,8 @@ synthesizeStoredUser' uid veid dname handle richInfo accStatus createdAt lastUpd
                                         redundantly, without the 'Maybe'. -},
               ST._vsuName = dname,
               ST._vsuRichInfo = richInfo,
-              ST._vsuActive = ST.scimActiveFlagFromAccountStatus accStatus
+              ST._vsuActive = ST.scimActiveFlagFromAccountStatus accStatus,
+              ST._vsuLocale = Just locale
             }
 
   pure $ toScimStoredUser' createdAt lastUpdatedAt baseuri uid (normalizeLikeStored scimUser)

--- a/services/spar/src/Spar/Sem/BrigAccess.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess.hs
@@ -57,7 +57,7 @@ import Wire.API.User.Scim (ValidExternalId (..))
 
 data BrigAccess m a where
   CreateSAML :: SAML.UserRef -> UserId -> TeamId -> Name -> ManagedBy -> BrigAccess m UserId
-  CreateNoSAML :: Email -> TeamId -> Name -> BrigAccess m UserId
+  CreateNoSAML :: Email -> TeamId -> Name -> Maybe Locale -> BrigAccess m UserId
   UpdateEmail :: UserId -> Email -> BrigAccess m ()
   GetAccount :: HavePendingInvitations -> UserId -> BrigAccess m (Maybe UserAccount)
   GetByHandle :: Handle -> BrigAccess m (Maybe UserAccount)

--- a/services/spar/src/Spar/Sem/BrigAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess/Http.hs
@@ -41,7 +41,7 @@ brigAccessToHttp mgr req =
   interpret $
     viaRunHttp (RunHttpEnv mgr req) . \case
       CreateSAML u itlu itlt n m -> Intra.createBrigUserSAML u itlu itlt n m
-      CreateNoSAML e itlt n -> Intra.createBrigUserNoSAML e itlt n
+      CreateNoSAML e itlt n locale -> Intra.createBrigUserNoSAML e itlt n locale
       UpdateEmail itlu e -> Intra.updateEmail itlu e
       GetAccount h itlu -> Intra.getBrigUserAccount h itlu
       GetByHandle h -> Intra.getBrigUserByHandle h


### PR DESCRIPTION
We now account for the preferred language field in the SCIM spec, and fallback to it in case of locale being undefined.

Currently untested.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.