### PR TITLE
Use old bitnami helm repo from git for redis and postgresql

### DIFF
--- a/changelog.d/5-internal/bitnami-old-repo
+++ b/changelog.d/5-internal/bitnami-old-repo
@@ -1,0 +1,1 @@
+charts/{redis-ephemeral,legalhold}: Use old index for bitnami repo as the new index doesn't have old versions of postgresql and redis helm charts

--- a/charts/legalhold/requirements.yaml
+++ b/charts/legalhold/requirements.yaml
@@ -1,4 +1,8 @@
 dependencies:
   - name: postgresql
     version: 9.8.12
-    repository: https://charts.bitnami.com/bitnami
+    # Use helm repo from the git repo because bitnami removed charts from the
+    # official index to keep the index small. On next upgrade, this should be
+    # changed to use the official repo. Context:
+    # https://github.com/bitnami/charts/issues/10539
+    repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/

--- a/charts/redis-ephemeral/requirements.yaml
+++ b/charts/redis-ephemeral/requirements.yaml
@@ -1,5 +1,9 @@
 dependencies:
 - name: redis
   version: 11.3.4
-  repository: https://charts.bitnami.com/bitnami
+  # Use helm repo from the git repo because bitnami removed charts from the
+  # official index to keep the index small. On next upgrade, this should be
+  # changed to use the official repo. Context:
+  # https://github.com/bitnami/charts/issues/10539
+  repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
   alias: redis-ephemeral


### PR DESCRIPTION
They've deleted the versions we use from the latest index. More details:
https://github.com/bitnami/charts/issues/10539

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.