### PR TITLE
charts/nginz: Ensure traffic can be routed to galeb correctly

### DIFF
--- a/changelog.d/3-bug-fixes/nginz-collision
+++ b/changelog.d/3-bug-fixes/nginz-collision
@@ -1,1 +1,2 @@
-charts/nginz: Resolve collision between brig and galeb endpoints
+charts/nginz: Resolve collision between brig and galeb endpoints. Ensure
+/self/consent and /signatures endpoints are configured in all environments

--- a/changelog.d/3-bug-fixes/nginz-collision
+++ b/changelog.d/3-bug-fixes/nginz-collision
@@ -1,0 +1,1 @@
+charts/nginz: Resolve collision between brig and galeb endpoints

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -528,9 +528,13 @@ nginx_conf:
       versioned: false
       strip_version: true
     - path: /self/consent
+      envs:
+      - all
       versioned: false
       strip_version: true
     - path: /signature
+      envs:
+      - all
       versioned: false
       specific_user_rate_limit: reqs_per_user_signatures
       strip_version: true

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -135,7 +135,28 @@ nginx_conf:
       disable_zauth: true
       envs:
       - all
-    - path: /self
+    - path: /self$ # Matches exactly /self
+      envs:
+      - all
+    - path: /self/name
+      envs:
+      - all
+    - path: /self/email
+      envs:
+      - all
+    - path: /self/phone
+      envs:
+      - all
+    - path: /self/password
+      envs:
+      - all
+    - path: /self/locale
+      envs:
+      - all
+    - path: /self/handle
+      envs:
+      - all
+    - path: /self/searchable
       envs:
       - all
     - path: /connections


### PR DESCRIPTION
Things done:
- List all `/self*` endpoints of brig so the catch all `/self` doesn't forward `/self/consent` to brig
- Ensure that `envs: [ all ]` is set for `/self/consent` and `/signatures`. This was missed in previous PR

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.