### PR TITLE
docs/src/how-to/install/dependencies.rst: require Docker >= 20.10.14

### DIFF
--- a/docs/src/how-to/install/dependencies.rst
+++ b/docs/src/how-to/install/dependencies.rst
@@ -21,14 +21,11 @@ Checkout the repository, including its submodules:
 We provide a container containing all needed tools for setting up and
 interacting with a wire-server cluster.
 
-Ensure you have docker installed:
+Ensure you have Docker >= 20.10.14 installed, as the glibc version used is
+incompatible with older container runtimes.
 
-::
-
-   sudo apt install docker.io
-
-Or, depending on your distro, see `how to install docker <https://docker.com>`__.
-
+Your Distro might ship an older version, so best see `how to install docker
+<https://docker.com>`__.
 
 To bring the tools in scope, we run the container, and mount the local ``wire-server-deploy``
 checkout into it.


### PR DESCRIPTION
glibc 2.34 uses the clone3 syscall, which is not part of the seccomp
filters that moby ships on older versions.

While as a workaround you might be able to run containers with
`--privileged`, it's the better call to just run a more recent Docker
runtime.

References:
 - https://github.com/docker/buildx/issues/772
 - https://github.com/moby/buildkit/pull/2379
 - https://github.com/moby/moby/pull/42836
 - https://github.com/NixOS/nixpkgs/pull/170900

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
