### PR TITLE
Fix saml corner case

### DIFF
--- a/changelog.d/3-bug-fixes/fix-saml-corner-case
+++ b/changelog.d/3-bug-fixes/fix-saml-corner-case
@@ -1,0 +1,1 @@
+saml-auto-provisioned users don't get to change email address

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -618,7 +618,9 @@ changeEmail u email allowScim = do
   unless available $
     throwE (EmailExists email)
 
-  usr <- maybe (throwM $ UserProfileNotFound u) pure =<< lift (wrapClient $ Data.lookupUser WithPendingInvitations u)
+  usr <-
+    maybe (throwM $ UserProfileNotFound u) pure
+      =<< lift (wrapClient $ Data.lookupUser WithPendingInvitations u)
 
   case emailIdentity =<< userIdentity usr of
     -- The user already has an email address and the new one is exactly the same

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -629,8 +629,14 @@ changeEmail u email allowScim = do
     else do
       -- case 2: No or different old email address
       let changeAllowed =
-            userManagedBy usr /= ManagedByScim
-              || allowScim == AllowSCIMUpdates
+            ( userManagedBy usr /= ManagedByScim
+                || allowScim == AllowSCIMUpdates -- spar is always allowed to call this function (from the scim handlers)
+            )
+              && not
+                ( -- user is auto-provisioned by saml (deprecated use case)
+                  userManagedBy usr /= ManagedByScim && userHasSAML usr
+                )
+
       unless changeAllowed $
         throwE EmailManagedByScim
 

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -622,10 +622,11 @@ changeEmail u email allowScim = do
     maybe (throwM $ UserProfileNotFound u) pure
       =<< lift (wrapClient $ Data.lookupUser WithPendingInvitations u)
 
-  case emailIdentity =<< userIdentity usr of
-    -- The user already has an email address and the new one is exactly the same
-    Just current | current == eml -> pure ChangeEmailIdempotent
-    _ -> do
+  if (emailIdentity =<< userIdentity usr) == Just eml
+    then do
+      -- The user already has an email address and the new one is exactly the same
+      pure ChangeEmailIdempotent
+    else do
       unless
         ( userManagedBy usr /= ManagedByScim
             || allowScim == AllowSCIMUpdates

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -288,7 +288,7 @@ revokeAccess ::
   ExceptT AuthError m ()
 revokeAccess u pw cc ll = do
   lift $ Log.debug $ field "user" (toByteString u) . field "action" (Log.val "User.revokeAccess")
-  unlessM (Data.isSamlUser u) $ Data.authenticate u pw
+  unlessM (Data.userIdHasSAML u) $ Data.authenticate u pw
   lift $ revokeCookies u cc ll
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1616

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
