### PR TITLE
fix: add missing newline in code-block

### DIFF
--- a/docs/src/understand/single-sign-on/main.rst
+++ b/docs/src/understand/single-sign-on/main.rst
@@ -520,6 +520,7 @@ Email address (and/or SAML NameID, if /a):
 Wire handle: same request, just replace the query part with
 
 .. code-block:: bash
+
     '?filter=userName%20eq%20%22me%22'
 
 **Update a specific user**


### PR DESCRIPTION
A missing newline prevented the code-block from being rendered, the added newline fixes this