### PR TITLE
fix(docs): use if-block to support older version of sphinx when adding the logo

### DIFF
--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -2,7 +2,11 @@
 
 {% block sidebartitle %}
     <a href="{{ pathto(master_doc) }}"> 
+    {%- if logo %}
+        <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}"/>
+    {%- else %}
         <img src="{{ logo_url }}" class="logo" alt="{{ _('Logo') }}"/>
+    {%- endif %}
     </a>
 
     <!-- {%- if theme_display_version %}


### PR DESCRIPTION
It looks like the sphinx version in our docker container is older than the one being used to generate the documentation with sphinx.

Prior to this change the logo was only added correctly locally but not on the data ending up on docs.wire.com