### PR TITLE
changelog.d/wire-service-label: document need for StatefulSet/Deployment recreation

### DIFF
--- a/changelog.d/0-release-notes/wire-service-label
+++ b/changelog.d/0-release-notes/wire-service-label
@@ -1,8 +1,20 @@
-The `wireService` label has been removed.
+In the helm charts, the `wireService` label has been removed.
 
 In some cases, we were already setting the `app` label too.
 
 Now we consistently use the `app` label to label different wire services.
+
+The `wireService` label was also used in the `spec.selector.matchLabels` field
+on existing `Deployment` / `StatefulSet` resources.
+As these fields being immutable, changing them isn't possible without recreation.
+
+If you encounter an issue like
+
+> field is immutable && cannot patch "*" with kind *
+
+you need to manually delete these StatefulSet and Deployment resources, and apply helm again, which will recreate them.
+
+This means downtime, so plan a maintenance window for it.
 
 The `wire-server-metrics` chart was previously running some custom
 configuration to automatically add all payloads with a `wireService` label into


### PR DESCRIPTION
The `wireService` label was also used in the `spec.selector.matchLabels` field
on existing `Deployment` / `StatefulSet` resources.
As these fields being immutable, changing them isn't possible without recreation.

Update the release notes to document this fact, and how to handle it.

## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
