### PR TITLE
//services/nginz/third_party/nginx-module-vts: update

### DIFF
--- a/changelog.d/0-release-notes/nginz-ingress
+++ b/changelog.d/0-release-notes/nginz-ingress
@@ -1,0 +1,15 @@
+The `nginz{-tcp,-http}` services have been unified into a `nginz` service, and
+moved into the nginz chart.
+
+The nginz-ingress-services chart simply targets the `nginz` service, so there's
+no need to set matching `service.nginz.external{Http,Tcp}Port` inside the
+`nginx-ingress-services` chart anymore.
+
+The `config.http.httpPort` and `config.ws.wsPort` values in the `nginz` chart
+still configure the ports the `nginz` service is listening on.
+
+The `nginz` chart also gained support for `metrics.serviceMonitor.enabled`,
+creating a `ServiceMonitor` resource to scrape metrics, like for other wire
+services.
+
+(#2476)

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -32,16 +32,16 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: nginz-http
-              servicePort: {{ .Values.service.nginz.externalHttpPort }}
+              serviceName: nginz
+              servicePort: http
 {{- if .Values.websockets.enabled }}
     - host: {{ .Values.config.dns.ssl }}
       http:
         paths:
           - path: /
             backend:
-              serviceName: nginz-tcp
-              servicePort: {{ .Values.service.nginz.externalTcpPort }}
+              serviceName: nginz
+              servicePort: ws
 {{- end }}
 {{- if .Values.webapp.enabled }}
     - host: {{ .Values.config.dns.webapp }}

--- a/charts/nginx-ingress-services/templates/service.yaml
+++ b/charts/nginx-ingress-services/templates/service.yaml
@@ -1,21 +1,4 @@
 # FUTUREWORK: move services into the respective charts
-apiVersion: v1
-kind: Service
-metadata:
-  name: nginz
-spec:
-  type: ClusterIP
-  ports:
-    - name: http
-      port: {{ .Values.service.nginz.externalHttpPort }}
-      targetPort: 8080
-{{- if .Values.websockets.enabled }}
-    - name: ws
-      port: {{ .Values.service.nginz.externalTcpPort }}
-      targetPort: 8081
-{{- end }}
-  selector:
-    app: nginz
 {{- if .Values.webapp.enabled }}
 ---
 apiVersion: v1

--- a/charts/nginx-ingress-services/templates/service.yaml
+++ b/charts/nginx-ingress-services/templates/service.yaml
@@ -2,28 +2,20 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginz-http
+  name: nginz
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.service.nginz.externalHttpPort }}
+    - name: http
+      port: {{ .Values.service.nginz.externalHttpPort }}
       targetPort: 8080
-  selector:
-    app: nginz
 {{- if .Values.websockets.enabled }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: nginz-tcp
-spec:
-  type: ClusterIP
-  ports:
-    - port: {{ .Values.service.nginz.externalTcpPort }}
+    - name: ws
+      port: {{ .Values.service.nginz.externalTcpPort }}
       targetPort: 8081
+{{- end }}
   selector:
     app: nginz
-{{- end }}
 {{- if .Values.webapp.enabled }}
 ---
 apiVersion: v1

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -80,9 +80,6 @@ certManager:
   customSolvers:
 
 service:
-  nginz:
-    externalHttpPort: 8080
-    externalTcpPort: 8081
   webapp:
     externalPort: 8080
   s3:

--- a/charts/nginz/templates/service.yaml
+++ b/charts/nginz/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginz
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.config.http.httpPort }}
+      targetPort: 8080
+    - name: ws
+      port: {{ .Values.config.ws.wsPort }}
+      targetPort: 8081
+  selector:
+    app: nginz

--- a/charts/nginz/templates/servicemonitor.yaml
+++ b/charts/nginz/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginz
+  labels:
+    app: nginz
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: http
+      path: /vts/status/format/prometheus
+  selector:
+    matchLabels:
+      app: nginz
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -6,6 +6,9 @@ resources:
   limits:
     memory: "1024Mi"
     cpu: "2"
+metrics:
+  serviceMonitor:
+    enabled: false
 images:
   nginzDisco:
     repository: quay.io/wire/nginz_disco


### PR DESCRIPTION
This provides a prometheus endpoint out of the box, so we can access it
at /vts/status/format/prometheus.

It also moves the `nginz{-tcp,-http}` service into a merged `nginz` service in the `nginz` helm chart, and adds `servicemonitor` support to it, so metrics can be scraped.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
