### PR TITLE
Make all feature configs overridable

### DIFF
--- a/changelog.d/5-internal/pr-2479
+++ b/changelog.d/5-internal/pr-2479
@@ -1,0 +1,1 @@
+All feature configs like guest links e.g. can now be overridden in the helm configuration, so that they can be disabled/enabled and configured server wide

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -79,5 +79,25 @@ data:
         searchVisibilityInbound:
           {{- toYaml .settings.featureFlags.searchVisibilityInbound | nindent 10 }}
         {{- end }}
+        {{- if .settings.featureFlags.validateSAMLemails }}
+        validateSAMLemails:
+          {{- toYaml .settings.featureFlags.validateSAMLemails | nindent 10 }}
+        {{- end }}
+        {{- if .settings.featureFlags.appLock }}
+        appLock:
+          {{- toYaml .settings.featureFlags.appLock | nindent 10 }}
+        {{- end }}        
+        {{- if .settings.featureFlags.conferenceCalling }}
+        conferenceCalling:
+          {{- toYaml .settings.featureFlags.conferenceCalling | nindent 10 }}
+        {{- end }}        
+        {{- if .settings.featureFlags.selfDeletingMessages }}
+        selfDeletingMessages:
+          {{- toYaml .settings.featureFlags.selfDeletingMessages | nindent 10 }}
+        {{- end }}        
+        {{- if .settings.featureFlags.conversationGuestLinks }}
+        conversationGuestLinks:
+          {{- toYaml .settings.featureFlags.conversationGuestLinks | nindent 10 }}
+        {{- end }}        
       {{- end }}
   {{- end }}

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -37,17 +37,44 @@ config:
         status: disabled
         config:
           domains: []
-      # fileSharing setting is optional
-      # if not set the default feature status is enabled and the default lock status is unlocked
-      # fileSharing:
-      #   defaults:
-      #     status: enabled
-      #     lockStatus: unlocked
-      # sndFactorPasswordChallenge setting is optional
-      # sndFactorPasswordChallenge:
-      #   defaults:
-      #     status: disabled
-      #     lockStatus: locked
+      # optional
+      fileSharing:
+        defaults:
+          status: enabled
+          lockStatus: unlocked
+      # optional
+      sndFactorPasswordChallenge:
+        defaults:
+          status: disabled
+          lockStatus: locked
+      # optional
+      validateSAMLemails:
+        defaults:
+          status: enabled
+      # optional
+      appLock:
+        defaults:
+          status: enabled
+          config:
+            enforceAppLock: false
+            inactivityTimeoutSecs: 60
+      # optional
+      conferenceCalling:
+        defaults:
+          status: enabled
+      # optional
+      selfDeletingMessages:
+        defaults:
+          status: enabled
+          lockStatus: unlocked
+          config:
+            enforcedTimeoutSeconds: 0
+      # optional
+      conversationGuestLinks:
+        defaults:
+          status: enabled
+          lockStatus: unlocked
+ 
   aws:
     region: "eu-west-1"
   proxy: {}


### PR DESCRIPTION
All feature configs like guest links e.g. can now be overridden in the helm configuration, so that they can be disabled/enabled and configured server wide.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.