### PR TITLE
charts/nginz: move /vts endpoint to a new http-metrics port

### DIFF
--- a/changelog.d/0-release-notes/nginz-ingress
+++ b/changelog.d/0-release-notes/nginz-ingress
@@ -8,6 +8,8 @@ no need to set matching `service.nginz.external{Http,Tcp}Port` inside the
 The `config.http.httpPort` and `config.ws.wsPort` values in the `nginz` chart
 still configure the ports the `nginz` service is listening on.
 
+Metrics were moved from `config.http.httpPort` to a new `http-metrics` port.
+
 The `nginz` chart also gained support for `metrics.serviceMonitor.enabled`,
 creating a `ServiceMonitor` resource to scrape metrics, like for other wire
 services.

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -199,29 +199,6 @@ http {
         return 200;
     }
 
-    location /vts {
-        zauth off;
-        access_log off;
-        allow 10.0.0.0/8;
-        allow 127.0.0.1;
-        deny all;
-
-        # Requests with an X-Forwarded-For header will have the real client
-        # source IP address set correctly, due to the real_ip_header directive
-        # in the top-level configuration. However, this will not set the client
-        # IP correctly for clients which are connected via a load balancer which
-        # uses the PROXY protocol.
-        #
-        # Hence, for safety, we deny access to the vts metrics endpoints to
-        # clients which are connected via PROXY protocol.
-        if ($proxy_protocol_addr != "") {
-            return 403;
-        }
-
-        vhost_traffic_status_display;
-        vhost_traffic_status_display_format html;
-    }
-
     # Block "Franz" -- http://meetfranz.com
     if ($http_user_agent ~* Franz) {
         return 403;
@@ -399,5 +376,23 @@ http {
     }
     {{- end }}
   }
+
+  server {
+    # even though we don't use zauth for this server block,
+    # we need to specify zauth_keystore etc.
+    zauth_keystore {{ .Values.nginx_conf.zauth_keystore }};
+    zauth_acl      {{ .Values.nginx_conf.zauth_acl }};
+
+    listen {{ .Values.config.http.metricsPort }};
+
+    location /vts {
+        access_log off;
+        zauth off;
+
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format html;
+    }
+  }
+
 }
 {{- end }}

--- a/charts/nginz/templates/deployment.yaml
+++ b/charts/nginz/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
           containerPort: {{ .Values.config.http.httpPort }}
         - name: tcp
           containerPort: {{ .Values.config.ws.wsPort }}
+        - name: http-metrics
+          containerPort: {{ .Values.config.http.metricsPort }}
         readinessProbe:
           httpGet:
             path: /status

--- a/charts/nginz/templates/service.yaml
+++ b/charts/nginz/templates/service.yaml
@@ -16,5 +16,8 @@ spec:
     - name: ws
       port: {{ .Values.config.ws.wsPort }}
       targetPort: 8081
+    - name: http-metrics
+      port: {{ .Values.config.http.metricsPort }}
+      targetPort: 8082
   selector:
     app: nginz

--- a/charts/nginz/templates/servicemonitor.yaml
+++ b/charts/nginz/templates/servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   endpoints:
-    - port: http
+    - port: http-metrics
       path: /vts/status/format/prometheus
   selector:
     matchLabels:

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -19,6 +19,7 @@ images:
 config:
   http:
     httpPort: 8080
+    metricsPort: 8082
   ws:
     wsPort: 8081
     useProxyProtocol: true


### PR DESCRIPTION
## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
