### PR TITLE
Optionally include backoffice when installing wire-server helm chart

### DIFF
--- a/changelog.d/2-features/backoffice
+++ b/changelog.d/2-features/backoffice
@@ -1,0 +1,1 @@
+charts/wire-server: Optionally include backoffice

--- a/changelog.d/3-bug-fixes/backoffice
+++ b/changelog.d/3-bug-fixes/backoffice
@@ -1,0 +1,1 @@
+charts/backoffice: Fix version of frontend and auto-bump version of stern on every release

--- a/charts/backoffice/values.yaml
+++ b/charts/backoffice/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 images:
   frontend:
     repository: quay.io/wire/backoffice-frontend
-    tag: 2.93.0
+    tag: 2.87.0
     pullPolicy: IfNotPresent
   stern:
     repository: quay.io/wire/stern

--- a/charts/backoffice/values.yaml
+++ b/charts/backoffice/values.yaml
@@ -6,7 +6,7 @@ images:
     pullPolicy: IfNotPresent
   stern:
     repository: quay.io/wire/stern
-    tag: 2.93.0
+    tag: do-not-use
     pullPolicy: IfNotPresent
 service:
   internalPort: 8080

--- a/charts/wire-server/requirements.yaml
+++ b/charts/wire-server/requirements.yaml
@@ -15,6 +15,13 @@ dependencies:
 ########################
 ## wire-servers/services
 ########################
+- name: backoffice
+  version: "0.0.42"
+  repository: "file://../backoffice"
+  tags:
+    - backoffice
+    - haskellServices
+    - services
 - name: cannon
   version: "0.0.42"
   repository: "file://../cannon"

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -11,3 +11,4 @@ tags:
   legalhold: false
   federator: false # see also galley.config.enableFederator and brig.config.enableFederator
   sftd: false
+  backoffice: false

--- a/hack/bin/set-chart-image-version.sh
+++ b/hack/bin/set-chart-image-version.sh
@@ -12,6 +12,9 @@ do
 if [[ "$chart" == "nginz" ]]; then
     # nginz has a different docker tag indentation
     sed -i "s/^    tag: .*/    tag: $docker_tag/g" "$CHARTS_DIR/$chart/values.yaml"
+elif [[ "$chart" == "backoffice" ]]; then
+    # There are two images at the same level and we want update only stern.
+    sed -i "s/tag: do-not-use/tag: $docker_tag/g" "$CHARTS_DIR/$chart/values.yaml"
 else
     sed -i "s/^  tag: .*/  tag: $docker_tag/g" "$CHARTS_DIR/$chart/values.yaml"
 fi

--- a/hack/bin/set-wire-server-image-version.sh
+++ b/hack/bin/set-wire-server-image-version.sh
@@ -12,5 +12,9 @@ for chart in "${charts[@]}"; do
     sed -i "s/^  tag: .*/  tag: $target_version/g" "$CHARTS_DIR/$chart/values.yaml"
 done
 
-#special case nginz
+# special case nginz
 sed -i "s/^    tag: .*/    tag: $target_version/g" "$CHARTS_DIR/nginz/values.yaml"
+
+# special case backoffice as there are two images at the same level and we want
+# update only one.
+sed -i "s/tag: do-not-use/tag: $target_version/g" "$CHARTS_DIR/backoffice/values.yaml"


### PR DESCRIPTION
This change fixes the backoffice chart versions, includes it in the wire-server chart  and ensures that stern versions are bumped correctly.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.