### PR TITLE
fix(docs): use correct case for wire logo path

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -106,7 +106,7 @@ html_css_files = [
 ]
 
 html_favicon = '_static/favicon/favicon.ico'
-html_logo = '_static/image/wire_logo.svg'
+html_logo = '_static/image/Wire_logo.svg'
 
 smv_tag_whitelist = ''
 smv_branch_whitelist = r'^(install-with-poetry)$'


### PR DESCRIPTION
Doing something completely unrelated I've noticed the uppercase 'W' in the filename.

This could never have worked on case sensitive filesystems ;)

This should finalize our attempts done in #2471 and fix the missing logo on docs.wire.com