### PR TITLE
SQSERVICES-1529 Swagger docs and endpoint deprecation for API version V2

### DIFF
--- a/changelog.d/1-api-changes/pr-2492
+++ b/changelog.d/1-api-changes/pr-2492
@@ -1,0 +1,1 @@
+Retire deprecated feature config API endpoints for API version V2

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1120,16 +1120,16 @@ type FeatureAPI =
     :<|> FeatureStatusPut '() SndFactorPasswordChallengeConfig
     :<|> AllFeatureConfigsUserGet
     :<|> AllFeatureConfigsTeamGet
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" LegalholdConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" LegalholdConfig
     :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" SSOConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" SearchVisibilityAvailableConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" ValidateSAMLEmailsConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" SearchVisibilityAvailableConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" ValidateSAMLEmailsConfig
     :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" DigitalSignaturesConfig
     :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" AppLockConfig
     :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" FileSharingConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" ClassifiedDomainsConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" ConferenceCallingConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" SelfDeletingMessagesConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" ClassifiedDomainsConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" ConferenceCallingConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" SelfDeletingMessagesConfig
     :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" GuestLinksConfig
     :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" SndFactorPasswordChallengeConfig
 
@@ -1182,7 +1182,7 @@ type FeatureStatusBasePutPublic errs featureConfig =
 type FeatureStatusBaseDeprecatedGet desc featureConfig =
   ( Summary
       (AppendSymbol "[deprecated] Get config for " (FeatureSymbol featureConfig))
-      :> Until 'V2
+      -- :> Until 'V2
       :> Description
            ( "Deprecated. Please use `GET /teams/:tid/features/"
                `AppendSymbol` FeatureSymbol featureConfig
@@ -1203,7 +1203,7 @@ type FeatureStatusBaseDeprecatedGet desc featureConfig =
 type FeatureStatusBaseDeprecatedPut desc featureConfig =
   Summary
     (AppendSymbol "[deprecated] Get config for " (FeatureSymbol featureConfig))
-    :> Until 'V2
+    -- :> Until 'V2
     :> Description
          ( "Deprecated. Please use `PUT /teams/:tid/features/"
              `AppendSymbol` FeatureSymbol featureConfig
@@ -1225,7 +1225,7 @@ type FeatureConfigDeprecatedGet desc featureConfig =
   Named
     '("get-config", featureConfig)
     ( Summary (AppendSymbol "[deprecated] Get feature config for feature " (FeatureSymbol featureConfig))
-        :> Until 'V2
+        -- :> Until 'V2
         :> Description ("Deprecated. Please use `GET /feature-configs` instead.\n" `AppendSymbol` desc)
         :> ZUser
         :> CanThrow 'NotATeamMember

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1182,7 +1182,7 @@ type FeatureStatusBasePutPublic errs featureConfig =
 type FeatureStatusBaseDeprecatedGet desc featureConfig =
   ( Summary
       (AppendSymbol "[deprecated] Get config for " (FeatureSymbol featureConfig))
-      -- :> Until 'V2
+      :> Until 'V2
       :> Description
            ( "Deprecated. Please use `GET /teams/:tid/features/"
                `AppendSymbol` FeatureSymbol featureConfig
@@ -1203,7 +1203,7 @@ type FeatureStatusBaseDeprecatedGet desc featureConfig =
 type FeatureStatusBaseDeprecatedPut desc featureConfig =
   Summary
     (AppendSymbol "[deprecated] Get config for " (FeatureSymbol featureConfig))
-    -- :> Until 'V2
+    :> Until 'V2
     :> Description
          ( "Deprecated. Please use `PUT /teams/:tid/features/"
              `AppendSymbol` FeatureSymbol featureConfig
@@ -1225,7 +1225,7 @@ type FeatureConfigDeprecatedGet desc featureConfig =
   Named
     '("get-config", featureConfig)
     ( Summary (AppendSymbol "[deprecated] Get feature config for feature " (FeatureSymbol featureConfig))
-        -- :> Until 'V2
+        :> Until 'V2
         :> Description ("Deprecated. Please use `GET /feature-configs` instead.\n" `AppendSymbol` desc)
         :> ZUser
         :> CanThrow 'NotATeamMember

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1186,7 +1186,7 @@ type FeatureStatusBaseDeprecatedGet desc featureConfig =
       :> Description
            ( "Deprecated. Please use `GET /teams/:tid/features/"
                `AppendSymbol` FeatureSymbol featureConfig
-               `AppendSymbol` "` instead."
+               `AppendSymbol` "` instead.\n"
                `AppendSymbol` desc
            )
       :> CanThrow 'NotATeamMember

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1098,14 +1098,14 @@ type FeatureAPI =
            LegalholdConfig
     :<|> FeatureStatusGet SearchVisibilityAvailableConfig
     :<|> FeatureStatusPut '() SearchVisibilityAvailableConfig
-    :<|> FeatureStatusDeprecatedGet "This endpoint is potentially used the old Android client. It is not used by iOS, team management, or webapp as of June 2022" SearchVisibilityAvailableConfig
-    :<|> FeatureStatusDeprecatedPut "This endpoint is potentially used the old Android client. It is not used by iOS, team management, or webapp as of June 2022" SearchVisibilityAvailableConfig
+    :<|> FeatureStatusDeprecatedGet "This endpoint is potentially used by the old Android client. It is not used by iOS, team management, or webapp as of June 2022" SearchVisibilityAvailableConfig
+    :<|> FeatureStatusDeprecatedPut "This endpoint is potentially used by the old Android client. It is not used by iOS, team management, or webapp as of June 2022" SearchVisibilityAvailableConfig
     :<|> SearchVisibilityGet
     :<|> SearchVisibilitySet
     :<|> FeatureStatusGet ValidateSAMLEmailsConfig
-    :<|> FeatureStatusDeprecatedGet "This endpoint is potentially used the old Android client. It is not used by iOS, team management, or webapp as of June 2022" ValidateSAMLEmailsConfig
+    :<|> FeatureStatusDeprecatedGet "This endpoint is potentially used by the old Android client. It is not used by iOS, team management, or webapp as of June 2022" ValidateSAMLEmailsConfig
     :<|> FeatureStatusGet DigitalSignaturesConfig
-    :<|> FeatureStatusDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is potentially used by the old Android client. It is not used by team management, or webapp as of June 2022" DigitalSignaturesConfig
+    :<|> FeatureStatusDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is potentially used by the old Android client. It is not used by team management, or webapp as of June 2022" DigitalSignaturesConfig
     :<|> FeatureStatusGet AppLockConfig
     :<|> FeatureStatusPut '() AppLockConfig
     :<|> FeatureStatusGet FileSharingConfig
@@ -1120,18 +1120,18 @@ type FeatureAPI =
     :<|> FeatureStatusPut '() SndFactorPasswordChallengeConfig
     :<|> AllFeatureConfigsUserGet
     :<|> AllFeatureConfigsTeamGet
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" LegalholdConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" SSOConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" SearchVisibilityAvailableConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" ValidateSAMLEmailsConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" DigitalSignaturesConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" AppLockConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" FileSharingConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" ClassifiedDomainsConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" ConferenceCallingConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" SelfDeletingMessagesConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" GuestLinksConfig
-    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" SndFactorPasswordChallengeConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" LegalholdConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" SSOConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" SearchVisibilityAvailableConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" ValidateSAMLEmailsConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" DigitalSignaturesConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" AppLockConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" FileSharingConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" ClassifiedDomainsConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" ConferenceCallingConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" SelfDeletingMessagesConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" GuestLinksConfig
+    :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" SndFactorPasswordChallengeConfig
 
 type FeatureStatusGet f =
   Named

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1098,14 +1098,14 @@ type FeatureAPI =
            LegalholdConfig
     :<|> FeatureStatusGet SearchVisibilityAvailableConfig
     :<|> FeatureStatusPut '() SearchVisibilityAvailableConfig
-    :<|> FeatureStatusDeprecatedGet SearchVisibilityAvailableConfig
-    :<|> FeatureStatusDeprecatedPut SearchVisibilityAvailableConfig
+    :<|> FeatureStatusDeprecatedGet "This endpoint is potentially used the old Android client. It is not used by iOS, team management, or webapp as of June 2022" SearchVisibilityAvailableConfig
+    :<|> FeatureStatusDeprecatedPut "This endpoint is potentially used the old Android client. It is not used by iOS, team management, or webapp as of June 2022" SearchVisibilityAvailableConfig
     :<|> SearchVisibilityGet
     :<|> SearchVisibilitySet
     :<|> FeatureStatusGet ValidateSAMLEmailsConfig
-    :<|> FeatureStatusDeprecatedGet ValidateSAMLEmailsConfig
+    :<|> FeatureStatusDeprecatedGet "This endpoint is potentially used the old Android client. It is not used by iOS, team management, or webapp as of June 2022" ValidateSAMLEmailsConfig
     :<|> FeatureStatusGet DigitalSignaturesConfig
-    :<|> FeatureStatusDeprecatedGet DigitalSignaturesConfig
+    :<|> FeatureStatusDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is potentially used by the old Android client. It is not used by team management, or webapp as of June 2022" DigitalSignaturesConfig
     :<|> FeatureStatusGet AppLockConfig
     :<|> FeatureStatusPut '() AppLockConfig
     :<|> FeatureStatusGet FileSharingConfig
@@ -1120,18 +1120,18 @@ type FeatureAPI =
     :<|> FeatureStatusPut '() SndFactorPasswordChallengeConfig
     :<|> AllFeatureConfigsUserGet
     :<|> AllFeatureConfigsTeamGet
-    :<|> FeatureConfigGet LegalholdConfig
-    :<|> FeatureConfigGet SSOConfig
-    :<|> FeatureConfigGet SearchVisibilityAvailableConfig
-    :<|> FeatureConfigGet ValidateSAMLEmailsConfig
-    :<|> FeatureConfigGet DigitalSignaturesConfig
-    :<|> FeatureConfigGet AppLockConfig
-    :<|> FeatureConfigGet FileSharingConfig
-    :<|> FeatureConfigGet ClassifiedDomainsConfig
-    :<|> FeatureConfigGet ConferenceCallingConfig
-    :<|> FeatureConfigGet SelfDeletingMessagesConfig
-    :<|> FeatureConfigGet GuestLinksConfig
-    :<|> FeatureConfigGet SndFactorPasswordChallengeConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" LegalholdConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" SSOConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" SearchVisibilityAvailableConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" ValidateSAMLEmailsConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" DigitalSignaturesConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" AppLockConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" FileSharingConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" ClassifiedDomainsConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" ConferenceCallingConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp as of June 2022" SelfDeletingMessagesConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" GuestLinksConfig
+    :<|> FeatureConfigDeprecatedGet "This endpoint was removed in iOS in version 3.101. It is used by team management, webapp, and potentially the old Android client as of June 2022" SndFactorPasswordChallengeConfig
 
 type FeatureStatusGet f =
   Named
@@ -1143,15 +1143,15 @@ type FeatureStatusPut errs f =
     '("put", f)
     (ZUser :> FeatureStatusBasePutPublic errs f)
 
-type FeatureStatusDeprecatedGet f =
+type FeatureStatusDeprecatedGet d f =
   Named
     '("get-deprecated", f)
-    (ZUser :> FeatureStatusBaseDeprecatedGet f)
+    (ZUser :> FeatureStatusBaseDeprecatedGet d f)
 
-type FeatureStatusDeprecatedPut f =
+type FeatureStatusDeprecatedPut d f =
   Named
     '("put-deprecated", f)
-    (ZUser :> FeatureStatusBaseDeprecatedPut f)
+    (ZUser :> FeatureStatusBaseDeprecatedPut d f)
 
 type FeatureStatusBaseGet featureConfig =
   Summary (AppendSymbol "Get config for " (FeatureSymbol featureConfig))
@@ -1179,9 +1179,16 @@ type FeatureStatusBasePutPublic errs featureConfig =
     :> Put '[Servant.JSON] (WithStatus featureConfig)
 
 -- | A type for a GET endpoint for a feature with a deprecated path
-type FeatureStatusBaseDeprecatedGet featureConfig =
+type FeatureStatusBaseDeprecatedGet desc featureConfig =
   ( Summary
       (AppendSymbol "[deprecated] Get config for " (FeatureSymbol featureConfig))
+      :> Until 'V2
+      :> Description
+           ( "Deprecated. Please use `GET /teams/:tid/features/"
+               `AppendSymbol` FeatureSymbol featureConfig
+               `AppendSymbol` "` instead."
+               `AppendSymbol` desc
+           )
       :> CanThrow 'NotATeamMember
       :> CanThrow OperationDenied
       :> CanThrow 'TeamNotFound
@@ -1193,9 +1200,16 @@ type FeatureStatusBaseDeprecatedGet featureConfig =
   )
 
 -- | A type for a PUT endpoint for a feature with a deprecated path
-type FeatureStatusBaseDeprecatedPut featureConfig =
+type FeatureStatusBaseDeprecatedPut desc featureConfig =
   Summary
     (AppendSymbol "[deprecated] Get config for " (FeatureSymbol featureConfig))
+    :> Until 'V2
+    :> Description
+         ( "Deprecated. Please use `PUT /teams/:tid/features/"
+             `AppendSymbol` FeatureSymbol featureConfig
+             `AppendSymbol` "` instead.\n"
+             `AppendSymbol` desc
+         )
     :> CanThrow 'NotATeamMember
     :> CanThrow OperationDenied
     :> CanThrow 'TeamNotFound
@@ -1207,10 +1221,12 @@ type FeatureStatusBaseDeprecatedPut featureConfig =
     :> ReqBody '[Servant.JSON] (WithStatusNoLock featureConfig)
     :> Put '[Servant.JSON] (WithStatus featureConfig)
 
-type FeatureConfigGet featureConfig =
+type FeatureConfigDeprecatedGet desc featureConfig =
   Named
     '("get-config", featureConfig)
-    ( Summary (AppendSymbol "Get feature config for feature " (FeatureSymbol featureConfig))
+    ( Summary (AppendSymbol "[deprecated] Get feature config for feature " (FeatureSymbol featureConfig))
+        :> Until 'V2
+        :> Description ("Deprecated. Please use `GET /feature-configs` instead.\n" `AppendSymbol` desc)
         :> ZUser
         :> CanThrow 'NotATeamMember
         :> CanThrow OperationDenied

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -130,18 +130,18 @@ type IFeatureAPI =
     -- SearchVisibilityAvailableConfig
     :<|> IFeatureStatusGet SearchVisibilityAvailableConfig
     :<|> IFeatureStatusPut '() SearchVisibilityAvailableConfig
-    :<|> IFeatureStatusDeprecatedGet SearchVisibilityAvailableConfig
-    :<|> IFeatureStatusDeprecatedPut SearchVisibilityAvailableConfig
+    :<|> IFeatureStatusDeprecatedGet "" SearchVisibilityAvailableConfig
+    :<|> IFeatureStatusDeprecatedPut "" SearchVisibilityAvailableConfig
     -- ValidateSAMLEmailsConfig
     :<|> IFeatureStatusGet ValidateSAMLEmailsConfig
     :<|> IFeatureStatusPut '() ValidateSAMLEmailsConfig
-    :<|> IFeatureStatusDeprecatedGet ValidateSAMLEmailsConfig
-    :<|> IFeatureStatusDeprecatedPut ValidateSAMLEmailsConfig
+    :<|> IFeatureStatusDeprecatedGet "" ValidateSAMLEmailsConfig
+    :<|> IFeatureStatusDeprecatedPut "" ValidateSAMLEmailsConfig
     -- DigitalSignaturesConfig
     :<|> IFeatureStatusGet DigitalSignaturesConfig
     :<|> IFeatureStatusPut '() DigitalSignaturesConfig
-    :<|> IFeatureStatusDeprecatedGet DigitalSignaturesConfig
-    :<|> IFeatureStatusDeprecatedPut DigitalSignaturesConfig
+    :<|> IFeatureStatusDeprecatedGet "" DigitalSignaturesConfig
+    :<|> IFeatureStatusDeprecatedPut "" DigitalSignaturesConfig
     -- AppLockConfig
     :<|> IFeatureStatusGet AppLockConfig
     :<|> IFeatureStatusPut '() AppLockConfig
@@ -364,9 +364,9 @@ type FeatureStatusBasePutInternal errs featureConfig =
     :> QueryParam "ttl" FeatureTTL
     :> Put '[Servant.JSON] (WithStatus featureConfig)
 
-type IFeatureStatusDeprecatedGet f = Named '("iget-deprecated", f) (FeatureStatusBaseDeprecatedGet f)
+type IFeatureStatusDeprecatedGet d f = Named '("iget-deprecated", f) (FeatureStatusBaseDeprecatedGet d f)
 
-type IFeatureStatusDeprecatedPut f = Named '("iput-deprecated", f) (FeatureStatusBaseDeprecatedPut f)
+type IFeatureStatusDeprecatedPut d f = Named '("iput-deprecated", f) (FeatureStatusBaseDeprecatedPut d f)
 
 type IFeatureStatusLockStatusPut featureName =
   Named


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1529

The API changes in this PR were also added here: https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/603095166/API+changes+v1+v2

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.r?
