### PR TITLE
Fixed flakiness of a test by adding a clean-up step at the end.

### DIFF
--- a/changelog.d/5-internal/flaky-email-update-test-fix
+++ b/changelog.d/5-internal/flaky-email-update-test-fix
@@ -1,0 +1,1 @@
+Fixed flakiness of email update test, related to the test user account being suspended, causing subsequent runs of the test to fail.

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -875,6 +875,12 @@ testEmailUpdate brig aws = do
   -- we want to use a non-trusted domain in order to verify profile changes
   flip initiateUpdateAndActivate uid =<< mkEmailRandomLocalSuffix "test@example.com"
   flip initiateUpdateAndActivate uid =<< mkEmailRandomLocalSuffix "test@example.com"
+
+  -- adding a clean-up step seems to avoid the subsequent failures.
+  -- If subsequent runs start failint, it's possible that the aggressive setting
+  -- for `setSuspendInactiveUsers` is triggering before we can clean that user up.
+  -- In that case, you might need to manually delete the user from the test DB. @elland
+  deleteUserInternal uid brig !!! const 202 === statusCode
   where
     ensureNoOtherUserWithEmail :: Email -> Http ()
     ensureNoOtherUserWithEmail eml = do

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -877,7 +877,7 @@ testEmailUpdate brig aws = do
   flip initiateUpdateAndActivate uid =<< mkEmailRandomLocalSuffix "test@example.com"
 
   -- adding a clean-up step seems to avoid the subsequent failures.
-  -- If subsequent runs start failint, it's possible that the aggressive setting
+  -- If subsequent runs start failing, it's possible that the aggressive setting
   -- for `setSuspendInactiveUsers` is triggering before we can clean that user up.
   -- In that case, you might need to manually delete the user from the test DB. @elland
   deleteUserInternal uid brig !!! const 202 === statusCode


### PR DESCRIPTION
As the code comment hints at, we have a very narrow window between a user being created and the account being suspended inside the test environment. For a good reason too. We don't want to run a test that takes too long to check that account suspension works. But a suspended account can no longer be updated, rendering this particular test flaky, especially on subsequent test suite runs.

This should address that issue but immediately cleaning up after itself.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
