### PR TITLE
Add UDP endpoints to coturn Helm chart

### DIFF
--- a/changelog.d/0-release-notes/coturn-udp-ports
+++ b/changelog.d/0-release-notes/coturn-udp-ports
@@ -1,0 +1,12 @@
+For users of the (currently alpha) coturn Helm chart:
+**manual intervention may be required** when upgrading to
+this version of the chart from a prior version, due to [a bug in
+Kubernetes](https://github.com/kubernetes/kubernetes/issues/39188) which
+may interfere with applying changes to pod and service port configuration
+correctly.
+
+If, after updating this chart, the coturn pods do not have both a `coturn-udp`
+port and a `coturn-tcp` port, then the coturn `StatefulSet` must be manually
+deleted from the cluster, and then recreated by re-running Helm. Similarly, if
+the coturn `Service` does not have both a `coturn-udp` port and a `coturn-tcp`
+port, this `Service` must be similarly deleted and recreated.

--- a/changelog.d/3-bug-fixes/coturn-udp-ports
+++ b/changelog.d/3-bug-fixes/coturn-udp-ports
@@ -1,0 +1,2 @@
+The service definitions in the coturn Helm chart were missing the control plane
+UDP port used by coturn.

--- a/charts/coturn/templates/service.yaml
+++ b/charts/coturn/templates/service.yaml
@@ -13,5 +13,9 @@ spec:
     - name: coturn-tcp
       port: {{ .Values.coturnTurnListenPort }}
       targetPort: coturn-tcp
+    - name: coturn-udp
+      port: {{ .Values.coturnTurnListenPort }}
+      targetPort: coturn-udp
+      protocol: UDP
   selector:
     {{- include "coturn.selectorLabels" . | nindent 4 }}

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -107,6 +107,9 @@ spec:
             - name: coturn-tcp
               containerPort: {{ .Values.coturnTurnListenPort }}
               protocol: TCP
+            - name: coturn-udp
+              containerPort: {{ .Values.coturnTurnListenPort }}
+              protocol: UDP
             - name: status-http
               containerPort: {{ .Values.coturnMetricsListenPort }}
               protocol: TCP


### PR DESCRIPTION
This change adds the port definitions for coturn's UDP control port to the `StatefulSet` and `Service` definitions in the Helm chart. While this doesn't introduce any direct functional changes, it ensures that the control plane is aware of the fixed UDP port in use by coturn, which may then be advertised by service discovery glue which announces coturn pods based on the ports they expose.

I've run into difficulties updating prior versions of the coturn Helm chart to the one in this PR, which turns out is [a Kubernetes bug](https://github.com/kubernetes/kubernetes/issues/39188). I've added a release notes entry to the changelog with the required manual actions required to perform the upgrade.

This is the UDP half of https://wearezeta.atlassian.net/browse/SQPIT-1018.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
