### PR TITLE
[FS-705] Fix Repeated MLS Public Keys

### DIFF
--- a/changelog.d/3-bug-fixes/mls-public-keys
+++ b/changelog.d/3-bug-fixes/mls-public-keys
@@ -1,0 +1,1 @@
+Fix all clients having the same MLS public key

--- a/libs/wire-api/src/Wire/API/User/Client.hs
+++ b/libs/wire-api/src/Wire/API/User/Client.hs
@@ -44,6 +44,7 @@ module Wire.API.User.Client
     PubClient (..),
     ClientType (..),
     ClientClass (..),
+    MLSPublicKeys,
 
     -- * New/Update/Remove Client
     NewClient (..),

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -187,8 +187,8 @@ addClientWithReAuthPolicy reAuthPolicy u newId c maxPermClients loc cps = do
 lookupClient :: MonadClient m => UserId -> ClientId -> m (Maybe Client)
 lookupClient u c = do
   keys <- retry x1 (query selectMLSPublicKeys (params LocalQuorum (u, c)))
-  toClient keys
-    <$$> retry x1 (query1 selectClient (params LocalQuorum (u, c)))
+  fmap (toClient keys)
+    <$> retry x1 (query1 selectClient (params LocalQuorum (u, c)))
 
 lookupClientsBulk :: (MonadClient m) => [UserId] -> m (Map UserId (Imports.Set Client))
 lookupClientsBulk uids = liftClient $ do

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -308,10 +308,15 @@ testListClients brig = do
   let (pk1, lk1) = (somePrekeys !! 0, (someLastPrekeys !! 0))
   let (pk2, lk2) = (somePrekeys !! 1, (someLastPrekeys !! 1))
   let (pk3, lk3) = (somePrekeys !! 2, (someLastPrekeys !! 2))
-  c1 <- responseJsonMaybe <$> addClient brig uid (defNewClient PermanentClientType [pk1] lk1)
-  c2 <- responseJsonMaybe <$> addClient brig uid (defNewClient PermanentClientType [pk2] lk2)
-  c3 <- responseJsonMaybe <$> addClient brig uid (defNewClient TemporaryClientType [pk3] lk3)
-  let cs = sortBy (compare `on` clientId) $ catMaybes [c1, c2, c3]
+  c1 <- responseJsonError =<< addClient brig uid (defNewClient PermanentClientType [pk1] lk1)
+  c2 <- responseJsonError =<< addClient brig uid (defNewClient PermanentClientType [pk2] lk2)
+  c3 <- responseJsonError =<< addClient brig uid (defNewClient TemporaryClientType [pk3] lk3)
+
+  let pks = Map.fromList [(Ed25519, "random")]
+  void $ putClient brig uid (clientId c1) pks
+  let c1' = c1 {clientMLSPublicKeys = pks}
+  let cs = sortBy (compare `on` clientId) [c1', c2, c3]
+
   get
     ( brig
         . path "clients"

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -344,7 +344,6 @@ testMLSClient brig = do
   -- client
   getClient brig uid (clientId c2) !!! do
     const 200 === statusCode
-    -- This is unfortunate, but fixing this breaks clients.
     const (Just c2) === responseJsonMaybe
 
 testListClientsBulk :: Opt.Opts -> Brig -> Http ()

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -840,25 +840,11 @@ testMLSPublicKeyUpdate brig = do
           }
   c <- responseJsonError =<< addClient brig uid clt
   let keys = Map.fromList [(Ed25519, "aGVsbG8gd29ybGQ=")]
-  put
-    ( brig
-        . paths ["clients", toByteString' (clientId c)]
-        . zUser uid
-        . contentJson
-        . json (UpdateClient [] Nothing Nothing Nothing keys)
-    )
-    !!! const 200 === statusCode
+  putClient brig uid (clientId c) keys !!! const 200 === statusCode
   c' <- responseJsonError =<< getClient brig uid (clientId c) <!! const 200 === statusCode
   liftIO $ clientMLSPublicKeys c' @?= keys
   -- adding the key again should fail
-  put
-    ( brig
-        . paths ["clients", toByteString' (clientId c)]
-        . zUser uid
-        . contentJson
-        . json (UpdateClient [] Nothing Nothing Nothing keys)
-    )
-    !!! const 400 === statusCode
+  putClient brig uid (clientId c) keys !!! const 400 === statusCode
 
 testMissingClient :: Brig -> Http ()
 testMissingClient brig = do

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -33,7 +33,7 @@ import qualified Cassandra as DB
 import qualified Codec.MIME.Type as MIME
 import Control.Lens (preview, (^?))
 import Control.Monad.Catch (MonadCatch)
-import Data.Aeson
+import Data.Aeson hiding (json)
 import Data.Aeson.Lens
 import Data.ByteString.Builder (toLazyByteString)
 import Data.ByteString.Char8 (pack)
@@ -66,6 +66,7 @@ import Wire.API.Routes.MultiTablePaging (LocalOrRemoteTable, MultiTablePagingSta
 import Wire.API.Team.Feature (featureNameBS)
 import qualified Wire.API.Team.Feature as Public
 import qualified Wire.API.User as Public
+import Wire.API.User.Client hiding (UpdateClient)
 
 newtype ConnectionLimit = ConnectionLimit Int64
 
@@ -230,6 +231,20 @@ getClient brig u c =
     brig
       . paths ["clients", toByteString' c]
       . zUser u
+
+putClient ::
+  (MonadIO m, MonadHttp m, HasCallStack) =>
+  Brig ->
+  UserId ->
+  ClientId ->
+  MLSPublicKeys ->
+  m ResponseLBS
+putClient brig uid c keys =
+  put $
+    brig
+      . paths ["clients", toByteString' c]
+      . zUser uid
+      . json (UpdateClient [] Nothing Nothing Nothing keys)
 
 getClientCapabilities :: Brig -> UserId -> ClientId -> (MonadIO m, MonadHttp m) => m ResponseLBS
 getClientCapabilities brig u c =


### PR DESCRIPTION
This PR fixes a bug where all clients, including non-MLS clients, would be associated with the same MLS public key in the response to `GET /clients`.

Tracked by https://wearezeta.atlassian.net/browse/FS-705.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
