### PR TITLE
Add new MLS test tool to ubuntu image

### DIFF
--- a/build/ubuntu/Dockerfile.deps
+++ b/build/ubuntu/Dockerfile.deps
@@ -10,11 +10,18 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     export SODIUM_USE_PKG_CONFIG=1 && \
     cargo build --release
 
-# compile core-crypto cli tool
+# FUTUREWORK: remove core-crypto once #2508 is merged
+# compile legacy core-crypto cli tool
 RUN cd /tmp && \
   apt-get install -y libssl-dev && \
   git clone -b cli https://github.com/wireapp/core-crypto && \
   cd core-crypto/cli && \
+  cargo build --release
+
+# compile mls-test-cli tool
+RUN cd /tmp &&
+  git clone https://github.com/wireapp/mls-test-cli && \
+  cd mls-test-cli && \
   cargo build --release
 
 # Minimal dependencies for ubuntu-compiled, dynamically linked wire-server Haskell services
@@ -22,8 +29,10 @@ FROM ubuntu:20.04
 
 COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib
 
-# FUTUREWORK: only copy crypto-cli executable if we are building an integration test image
+# FUTUREWORK: only copy crypto-cli and mls-test-cli executables if we are building an
+# integration test image
 COPY --from=cryptobox-builder /tmp/core-crypto/cli/target/release/crypto-cli /usr/bin
+COPY --from=cryptobox-builder /tmp/mls-test-cli/target/release/mls-test-cli /usr/bin
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \


### PR DESCRIPTION
This PR adds a new incompatible implementation (`mls-test-cli`) of the CLI tool used in MLS integration tests in PR #2508.

Once #2508 is merged, the plan is to remove all traces of the old tool (`crypto-cli`). However, for the moment they both need to be in place, since the other active PRs are still using it.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
