### PR TITLE
Lazily detect stale handles [skip ci]

### DIFF
--- a/services/brig/src/Brig/User/Handle.hs
+++ b/services/brig/src/Brig/User/Handle.hs
@@ -41,10 +41,12 @@ claimHandle uid oldHandle newHandle =
     -- but it wasn't before this PR)?  why do we have to do a lookup on the handle before
     -- that?
     owner <- lookupHandle newHandle
-    wasStale <- cleanupStaleHandles uid newHandle
-    case owner of
-      Just uid' | uid /= uid' && not wasStale -> pure False
-      _ -> claimHandle' uid oldHandle newHandle
+    wasSelfOwnedOrStale <- if owner == Just uid
+      then pure True
+      else cleanupStaleHandles uid newHandle
+    if wasSelfOwnedOrStale
+      then pure False
+      else claimHandle' uid oldHandle newHandle
 
 claimHandle' :: (MonadClient m, MonadReader Env m) => UserId -> Maybe Handle -> Handle -> m Bool
 claimHandle' uid oldHandle newHandle = do

--- a/services/brig/src/Brig/User/Handle.hs
+++ b/services/brig/src/Brig/User/Handle.hs
@@ -37,10 +37,15 @@ import Imports
 claimHandle :: (MonadClient m, MonadReader Env m) => UserId -> Maybe Handle -> Handle -> m Bool
 claimHandle uid oldHandle newHandle =
   do
+    -- TODO: why isn't `claimHandle'` enough?  why do we have to do a lookup on the handle
+    -- before that?
     owner <- lookupHandle newHandle
     case owner of
       Just uid' | uid /= uid' -> pure False
-      _ -> do
+      _ -> claimHandle' uid oldHandle newHandle
+
+claimHandle' :: (MonadClient m, MonadReader Env m) => UserId -> Maybe Handle -> Handle -> m Bool
+claimHandle' uid oldHandle newHandle = do
         env <- ask
         let key = "@" <> fromHandle newHandle
         isJust <$$> withClaim uid key (30 # Minute) $

--- a/services/brig/src/Brig/User/Handle.hs
+++ b/services/brig/src/Brig/User/Handle.hs
@@ -36,14 +36,14 @@ import Imports
 -- | Claim a new handle for an existing 'User'.
 claimHandle :: (MonadClient m, MonadReader Env m) => UserId -> Maybe Handle -> Handle -> m Bool
 claimHandle uid oldHandle newHandle =
-  isJust <$> do
+  do
     owner <- lookupHandle newHandle
     case owner of
-      Just uid' | uid /= uid' -> pure Nothing
+      Just uid' | uid /= uid' -> pure False
       _ -> do
         env <- ask
         let key = "@" <> fromHandle newHandle
-        withClaim uid key (30 # Minute) $
+        isJust <$$> withClaim uid key (30 # Minute) $
           runAppT env $
             do
               -- Record ownership


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1625

## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
