### PR TITLE
add info on IS_SELF_HOSTED in docs

### DIFF
--- a/docs/src/how-to/install/configuration-options.rst
+++ b/docs/src/how-to/install/configuration-options.rst
@@ -559,12 +559,13 @@ The option is `IS_SELF_HOSTED`, and you set it in your `values.yaml` file (origi
 
 In case of a demo install, replace `prod` with `demo`.
 
-First set the option under the `team-settings` section:
+First set the option under the `team-settings` section, `envVars` sub-section:
 
 .. code:: yaml
 
    # NOTE: Only relevant if you want team-settings
    team-settings:
+     envVars:
        IS_SELF_HOSTED: "true"
 
 Second, also set the option under the `account-pages` section:
@@ -573,5 +574,6 @@ Second, also set the option under the `account-pages` section:
 
    # NOTE: Only relevant if you want account-pages
    account-pages:
+     envVars:
        IS_SELF_HOSTED: "true"
 

--- a/docs/src/how-to/install/configuration-options.rst
+++ b/docs/src/how-to/install/configuration-options.rst
@@ -545,3 +545,33 @@ namespace, say ``integrations``. But it still needs to get traffic via
      nginx_conf:
        upstream_namespace:
          ibis: integrations
+
+Marking an installation as self-hosted
+--------------------------------------
+
+In case your wire installation is self-hosted (on-premise, demo installs), it needs to be made aware that it is through a configuration option.
+
+If that option is not set, team-settings will prompt users about "wire for free" and associated functions.
+
+With that option set, all payment related functionality is disabled.
+
+The option is `IS_SELF_HOSTED`, and you set it in your `values.yaml` file (originally a copy of `prod-values.example.yaml` found in `wire-server-deploy/values/wire-server/`).
+
+In case of a demo install, replace `prod` with `demo`.
+
+First set the option under the `team-settings` section:
+
+.. code:: yaml
+
+   # NOTE: Only relevant if you want team-settings
+   team-settings:
+       IS_SELF_HOSTED: "true"
+
+Second, also set the option under the `account-pages` section:
+
+.. code:: yaml
+
+   # NOTE: Only relevant if you want account-pages
+   account-pages:
+       IS_SELF_HOSTED: "true"
+


### PR DESCRIPTION
## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
