### PR TITLE
SQSERVICES-1628-dont-allow-deleting-id-ps-if-the-deleting-user-is-authenticated-by-it

### DIFF
--- a/changelog.d/3-bug-fixes/pr-2519
+++ b/changelog.d/3-bug-fixes/pr-2519
@@ -1,0 +1,1 @@
+A user now cannot delete an identity provider that they are authenticated with any more

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -31,6 +31,7 @@ module Wire.API.User
     userEmail,
     userPhone,
     userSSOId,
+    userIssuer,
     userSCIMExternalId,
     scimExternalId,
     ssoIssuerAndNameId,
@@ -395,6 +396,13 @@ ssoIssuerAndNameId (UserSSOId (SAML.UserRef (SAML.Issuer uri) nameIdXML)) = Just
     fromUri = cs . toLazyByteString . serializeURIRef
     fromNameId = CI.original . SAML.unsafeShowNameID
 ssoIssuerAndNameId (UserScimExternalId _) = Nothing
+
+userIssuer :: User -> Maybe SAML.Issuer
+userIssuer user = userSSOId user >>= fromSSOId
+  where
+    fromSSOId :: UserSSOId -> Maybe SAML.Issuer
+    fromSSOId (UserSSOId (SAML.UserRef issuer _)) = Just issuer
+    fromSSOId _ = Nothing
 
 connectedProfile :: User -> UserLegalHoldStatus -> UserProfile
 connectedProfile u legalHoldStatus =

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -463,7 +463,7 @@ idpDelete zusr idpid (fromMaybe False -> purge) = withDebugLog "idpDelete" (cons
     idpDoesAuthSelf idp uid = do
       let idpIssuer = idp ^. SAML.idpMetadata . SAML.edIssuer
       mUserIssuer <- (>>= userIssuer) <$> Brig.getBrigUser NoPendingInvitations uid
-      pure $ mUserIssuer == Just idpIssuer 
+      pure $ mUserIssuer == Just idpIssuer
 
 -- | This handler only does the json parsing, and leaves all authorization checks and
 -- application logic to 'idpCreateXML'.

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -463,7 +463,7 @@ idpDelete zusr idpid (fromMaybe False -> purge) = withDebugLog "idpDelete" (cons
     idpDoesAuthSelf idp uid = do
       let idpIssuer = idp ^. SAML.idpMetadata . SAML.edIssuer
       mUserIssuer <- (>>= userIssuer) <$> Brig.getBrigUser NoPendingInvitations uid
-      pure $ maybe False ((==) idpIssuer) mUserIssuer
+      pure $ mUserIssuer == Just idpIssuer 
 
 -- | This handler only does the json parsing, and leaves all authorization checks and
 -- application logic to 'idpCreateXML'.

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -44,6 +44,7 @@ module Spar.API
   )
 where
 
+import Brig.Types.User (HavePendingInvitations (NoPendingInvitations))
 import Control.Lens
 import Control.Monad.Except
 import qualified Data.ByteString as SBS
@@ -94,6 +95,7 @@ import qualified Spar.Sem.VerdictFormatStore as VerdictFormatStore
 import System.Logger (Msg)
 import qualified URI.ByteString as URI
 import Wire.API.Routes.Public.Spar
+import Wire.API.User (userIssuer)
 import Wire.API.User.IdentityProvider
 import Wire.API.User.Saml
 import Wire.Sem.Logger (Logger)
@@ -412,7 +414,6 @@ idpDelete zusr idpid (fromMaybe False -> purge) = withDebugLog "idpDelete" (cons
   let issuer = idp ^. SAML.idpMetadata . SAML.edIssuer
       team = idp ^. SAML.idpExtraInfo . wiTeam
   -- if idp is not empty: fail or purge
-  idpIsEmpty <- isNothing <$> SAMLUserStore.getAnyByIssuer issuer
   let doPurge :: Sem r ()
       doPurge = do
         some <- SAMLUserStore.getSomeByIssuer issuer
@@ -420,6 +421,8 @@ idpDelete zusr idpid (fromMaybe False -> purge) = withDebugLog "idpDelete" (cons
           BrigAccess.delete uid
           SAMLUserStore.delete uid uref
         unless (null some) doPurge
+  idpIsEmpty <- isNothing <$> SAMLUserStore.getAnyByIssuer issuer
+  whenM (maybe (pure False) (idpDoesAuthSelf idp) zusr) $ throwSparSem SparIdPCannotDeleteOwnIdp
   unless idpIsEmpty $
     if purge
       then doPurge
@@ -444,7 +447,7 @@ idpDelete zusr idpid (fromMaybe False -> purge) = withDebugLog "idpDelete" (cons
     -- to be deleted in its old issuers list, but it's tricky to avoid race conditions, and
     -- there is little to be gained here: we only use old issuers to find users that have not
     -- been migrated yet, and if an old user points to a deleted idp, it just means that we
-    -- won't find any users to migrate.  still, doesn't hurt mucht to look either.  so we
+    -- won't find any users to migrate.  still, doesn't hurt much to look either.  so we
     -- leave old issuers dangling for now.
 
     updateReplacingIdP :: IdP -> Sem r ()
@@ -455,6 +458,12 @@ idpDelete zusr idpid (fromMaybe False -> purge) = withDebugLog "idpDelete" (cons
         GetIdPDanglingId _ -> pure ()
         GetIdPNonUnique _ -> pure ()
         GetIdPWrongTeam _ -> pure ()
+
+    idpDoesAuthSelf :: IdP -> UserId -> Sem r Bool
+    idpDoesAuthSelf idp uid = do
+      let idpIssuer = idp ^. SAML.idpMetadata . SAML.edIssuer
+      mUserIssuer <- (>>= userIssuer) <$> Brig.getBrigUser NoPendingInvitations uid
+      pure $ maybe False ((==) idpIssuer) mUserIssuer
 
 -- | This handler only does the json parsing, and leaves all authorization checks and
 -- application logic to 'idpCreateXML'.

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -94,6 +94,7 @@ data SparCustomError
   | SparNewIdPWantHttps LT
   | SparIdPHasBoundUsers
   | SparIdPIssuerInUse
+  | SparIdPCannotDeleteOwnIdp
   | SparProvisioningMoreThanOneIdP LT
   | SparProvisioningTokenLimitReached
   | -- | FUTUREWORK(fisx): This constructor is used in exactly one place (see
@@ -172,6 +173,7 @@ renderSparError (SAML.CustomError (SparNewIdPAlreadyInUse msg)) = Right $ Wai.mk
 renderSparError (SAML.CustomError (SparNewIdPWantHttps msg)) = Right $ Wai.mkError status400 "idp-must-be-https" ("an idp request uri must be https, not http or other: " <> msg)
 renderSparError (SAML.CustomError SparIdPHasBoundUsers) = Right $ Wai.mkError status412 "idp-has-bound-users" "an idp can only be deleted if it is empty"
 renderSparError (SAML.CustomError SparIdPIssuerInUse) = Right $ Wai.mkError status400 "idp-issuer-in-use" "The issuer of your IdP is already in use.  Remove the entry in the team that uses it, or construct a new IdP issuer."
+renderSparError (SAML.CustomError SparIdPCannotDeleteOwnIdp) = Right $ Wai.mkError status409 "cannot-delete-own-idp" "You cannot delete your own IdP."
 -- Errors related to provisioning
 renderSparError (SAML.CustomError (SparProvisioningMoreThanOneIdP msg)) = Right $ Wai.mkError status400 "more-than-one-idp" ("Team can have at most one IdP configured: " <> msg)
 renderSparError (SAML.CustomError SparProvisioningTokenLimitReached) = Right $ Wai.mkError status403 "token-limit-reached" "The limit of provisioning tokens per team has been reached"

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -173,7 +173,7 @@ renderSparError (SAML.CustomError (SparNewIdPAlreadyInUse msg)) = Right $ Wai.mk
 renderSparError (SAML.CustomError (SparNewIdPWantHttps msg)) = Right $ Wai.mkError status400 "idp-must-be-https" ("an idp request uri must be https, not http or other: " <> msg)
 renderSparError (SAML.CustomError SparIdPHasBoundUsers) = Right $ Wai.mkError status412 "idp-has-bound-users" "an idp can only be deleted if it is empty"
 renderSparError (SAML.CustomError SparIdPIssuerInUse) = Right $ Wai.mkError status400 "idp-issuer-in-use" "The issuer of your IdP is already in use.  Remove the entry in the team that uses it, or construct a new IdP issuer."
-renderSparError (SAML.CustomError SparIdPCannotDeleteOwnIdp) = Right $ Wai.mkError status409 "cannot-delete-own-idp" "You cannot delete your own IdP."
+renderSparError (SAML.CustomError SparIdPCannotDeleteOwnIdp) = Right $ Wai.mkError status409 "cannot-delete-own-idp" "You cannot delete the IdP used to login with your own account."
 -- Errors related to provisioning
 renderSparError (SAML.CustomError (SparProvisioningMoreThanOneIdP msg)) = Right $ Wai.mkError status400 "more-than-one-idp" ("Team can have at most one IdP configured: " <> msg)
 renderSparError (SAML.CustomError SparProvisioningTokenLimitReached) = Right $ Wai.mkError status403 "token-limit-reached" "The limit of provisioning tokens per team has been reached"


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1628

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.