### PR TITLE
Make pinning of bot certificates optional [skip ci]

### DIFF
--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -586,8 +586,13 @@ data Settings = Settings
     setSftListAllServers :: Maybe ListAllSFTServers,
     setKeyPackageMaximumLifetime :: Maybe NominalDiffTime,
     -- | When set, development API versions are advertised to clients.
-    setEnableDevelopmentVersions :: Maybe Bool
-  }
+    setEnableDevelopmentVersions :: Maybe Bool,
+    -- | Only talk to bots that present certificates pinned earlier by the provider.  (Default
+    -- behavior, but if you run all bots inside your on-prem wire site, you may want to turn
+    -- it off.)
+    setPinPubkeysOfServices :: Maybe Bool
+    -- TODO (setPinPubkeysOfServices): make default True
+    -- TODO (setPinPubkeysOfServices): add to helm charts and docs for overriding on-prem (default should still be the safer "true").
   deriving (Show, Generic)
 
 defaultTemplateLocale :: Locale

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -625,6 +625,10 @@ updateServiceConnH (pid ::: sid ::: req) = do
 
 updateServiceConn :: ProviderId -> ServiceId -> Public.UpdateServiceConn -> (Handler r) ()
 updateServiceConn pid sid upd = do
+  -- TODO: 'Public.UpdateServiceConn' allows for empty `public_keys`, but in this handler we
+  -- need to double-check how this is handled: if there is none, and there is none in the
+  -- database either, just make sure galley doesn't store a fingerprint either.  (to be
+  -- precise: if brig doesn't have a pub key, *clear* existing fingerprints in galley if /a.)
   pass <- wrapClientE (DB.lookupPassword pid) >>= maybeBadCredentials
   unless (verifyPassword (updateServiceConnPassword upd) pass) $
     throwStd (errorToWai @'BadCredentials)

--- a/services/brig/src/Brig/Provider/DB.hs
+++ b/services/brig/src/Brig/Provider/DB.hs
@@ -396,7 +396,7 @@ data ServiceConn = ServiceConn
     sconService :: !ServiceId,
     sconBaseUrl :: !HttpsUrl,
     sconAuthTokens :: !(List1 ServiceToken),
-    sconFingerprints :: !(List1 (Fingerprint Rsa)),
+    sconFingerprints :: !(Maybe (List1 (Fingerprint Rsa))),
     sconEnabled :: !Bool
   }
 

--- a/services/galley/src/Galley/External.hs
+++ b/services/galley/src/Galley/External.hs
@@ -148,7 +148,13 @@ urlPort (HttpsUrl u) = do
 
 sendMessage :: [Fingerprint Rsa] -> (Request -> Request) -> App ()
 sendMessage fprs reqBuilder = do
+  -- TODO: what's the behavior if `null fprs`?
   (man, verifyFingerprints) <- view (extEnv . extGetManager)
+  -- TODO: when (isNothing fpts) $ do one of
+  --         (1) plain http;
+  --         (2) https with system CA certs;
+  --         (3) https without cert  verification.
+  -- option (3) is the most likely.
   liftIO . withVerifiedSslConnection (verifyFingerprints fprs) man reqBuilder $ \req ->
     Http.withResponse req man (const $ pure ())
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/BIS-44

## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
