### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,0 +1,1 @@
+Upgrade webapp version to 2022-06-30-production.0-v0.30.5-0-3e2aaf6

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2022-06-13-production.0-v0.29.7-0-2819b90"
+  tag: "2022-06-30-production.0-v0.30.5-0-3e2aaf6"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2022-06-30-production.0-v0.30.5-0-3e2aaf6`
Release: [`2022-06-30-production.0`](https://github.com/wireapp/wire-webapp/releases/tag/2022-06-30-production.0)