### PR TITLE
Remove AES128 TLS ciphers for TLS 1.2 by default

### DIFF
--- a/changelog.d/2-features/tls-certs-reduce-default-list
+++ b/changelog.d/2-features/tls-certs-reduce-default-list
@@ -1,0 +1,1 @@
+For TLS1.2, by default, remove ECDHE-ECDSA-AES128-GCM-SHA256 and ECDHE-RSA-AES128-GCM-SHA256 ciphers for ingress traffic.

--- a/charts/backoffice/templates/configmap.yaml
+++ b/charts/backoffice/templates/configmap.yaml
@@ -133,7 +133,7 @@ data:
         # * https://wearezeta.atlassian.net/browse/FS-33
         # * https://wearezeta.atlassian.net/browse/FS-444
         ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384'; # for TLS 1.2
-        ssl_conf_command Ciphersuites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384"; # for TLS 1.3
+        ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384; # for TLS 1.3
         server {
           listen {{ .Values.service.internalPort }};
 

--- a/charts/backoffice/templates/configmap.yaml
+++ b/charts/backoffice/templates/configmap.yaml
@@ -132,7 +132,7 @@ data:
         # As a Wire employee, for Wire-internal discussions and context see
         # * https://wearezeta.atlassian.net/browse/FS-33
         # * https://wearezeta.atlassian.net/browse/FS-444
-        ssl_ciphers 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
+        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
         server {
           listen {{ .Values.service.internalPort }};
 

--- a/charts/backoffice/templates/configmap.yaml
+++ b/charts/backoffice/templates/configmap.yaml
@@ -132,7 +132,8 @@ data:
         # As a Wire employee, for Wire-internal discussions and context see
         # * https://wearezeta.atlassian.net/browse/FS-33
         # * https://wearezeta.atlassian.net/browse/FS-444
-        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
+        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384'; # redundant/unused due to the line below, but needed to keep nginx/openssl config parsing happy.
+        ssl_conf_command Ciphersuites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384";
         server {
           listen {{ .Values.service.internalPort }};
 

--- a/charts/backoffice/templates/configmap.yaml
+++ b/charts/backoffice/templates/configmap.yaml
@@ -132,8 +132,8 @@ data:
         # As a Wire employee, for Wire-internal discussions and context see
         # * https://wearezeta.atlassian.net/browse/FS-33
         # * https://wearezeta.atlassian.net/browse/FS-444
-        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384'; # redundant/unused due to the line below, but needed to keep nginx/openssl config parsing happy.
-        ssl_conf_command Ciphersuites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384";
+        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384'; # for TLS 1.2
+        ssl_conf_command Ciphersuites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384"; # for TLS 1.3
         server {
           listen {{ .Values.service.internalPort }};
 

--- a/charts/backoffice/templates/configmap.yaml
+++ b/charts/backoffice/templates/configmap.yaml
@@ -133,7 +133,8 @@ data:
         # * https://wearezeta.atlassian.net/browse/FS-33
         # * https://wearezeta.atlassian.net/browse/FS-444
         ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384'; # for TLS 1.2
-        ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384; # for TLS 1.3
+        # FUTUREWORK: upgrade nginx used for the backoffice to support ssl_conf_command (i.e. build a new backoffice-frontend), then uncomment below
+        # ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384; # for TLS 1.3
         server {
           listen {{ .Values.service.internalPort }};
 

--- a/charts/backoffice/templates/configmap.yaml
+++ b/charts/backoffice/templates/configmap.yaml
@@ -127,8 +127,12 @@ data:
         ssl_session_timeout 5m;
         ssl_prefer_server_ciphers on;
         ssl_protocols TLSv1.2 TLSv1.3;
-        ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
-
+        # NOTE: These are some sane defaults (compliant to TR-02102-2), you may want to overrride them on your own installation
+        # For TR-02102-2 see https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.html
+        # As a Wire employee, for Wire-internal discussions and context see
+        # * https://wearezeta.atlassian.net/browse/FS-33
+        # * https://wearezeta.atlassian.net/browse/FS-444
+        ssl_ciphers 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
         server {
           listen {{ .Values.service.internalPort }};
 

--- a/charts/cannon/templates/conf/_nginx.conf.tpl
+++ b/charts/cannon/templates/conf/_nginx.conf.tpl
@@ -196,8 +196,8 @@ http {
     ssl_certificate_key /etc/wire/nginz/tls/tls.key;
 
     ssl_protocols {{ .Values.nginx_conf.tls.protocols }};
-    ssl_ciphers {{ .Values.nginx_conf.tls.ciphers }}; # redundant/unused due to the line below, but needed to keep nginx/openssl config parsing happy.
-    ssl_conf_command Ciphersuites {{ .Values.nginx_conf.tls.ciphers }}; # needed to override TLS 1.3 ciphers.
+    ssl_ciphers {{ .Values.nginx_conf.tls.ciphers_tls12 }}; # this only sets TLS 1.2 ciphers (and has no effect if TLS 1.2 is not enabled)
+    ssl_conf_command Ciphersuites {{ .Values.nginx_conf.tls.ciphers_tls13 }}; # needed to override TLS 1.3 ciphers.
 
     # Disable session resumption. See comments in SQPIT-226 for more context and
     # discussion.

--- a/charts/cannon/templates/conf/_nginx.conf.tpl
+++ b/charts/cannon/templates/conf/_nginx.conf.tpl
@@ -196,7 +196,8 @@ http {
     ssl_certificate_key /etc/wire/nginz/tls/tls.key;
 
     ssl_protocols {{ .Values.nginx_conf.tls.protocols }};
-    ssl_ciphers {{ .Values.nginx_conf.tls.ciphers }};
+    ssl_ciphers {{ .Values.nginx_conf.tls.ciphers }}; # redundant/unused due to the line below, but needed to keep nginx/openssl config parsing happy.
+    ssl_conf_command Ciphersuites {{ .Values.nginx_conf.tls.ciphers }}; # needed to override TLS 1.3 ciphers.
 
     # Disable session resumption. See comments in SQPIT-226 for more context and
     # discussion.

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -46,7 +46,7 @@ nginx_conf:
     # As a Wire employee, for Wire-internal discussions and context see
     # * https://wearezeta.atlassian.net/browse/FS-33
     # * https://wearezeta.atlassian.net/browse/FS-444
-    ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
+    ciphers: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
 
   # The origins from which we allow CORS requests. These are combined with
   # 'external_env_domain' to form a full url

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -46,7 +46,7 @@ nginx_conf:
     # As a Wire employee, for Wire-internal discussions and context see
     # * https://wearezeta.atlassian.net/browse/FS-33
     # * https://wearezeta.atlassian.net/browse/FS-444
-    ciphers: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256"
+    ciphers: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
 
   # The origins from which we allow CORS requests. These are combined with
   # 'external_env_domain' to form a full url

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -46,7 +46,7 @@ nginx_conf:
     # As a Wire employee, for Wire-internal discussions and context see
     # * https://wearezeta.atlassian.net/browse/FS-33
     # * https://wearezeta.atlassian.net/browse/FS-444
-    ciphers: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
+    ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
 
   # The origins from which we allow CORS requests. These are combined with
   # 'external_env_domain' to form a full url

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -46,7 +46,8 @@ nginx_conf:
     # As a Wire employee, for Wire-internal discussions and context see
     # * https://wearezeta.atlassian.net/browse/FS-33
     # * https://wearezeta.atlassian.net/browse/FS-444
-    ciphers: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
+    ciphers_tls12: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
+    ciphers_tls13: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384"
 
   # The origins from which we allow CORS requests. These are combined with
   # 'external_env_domain' to form a full url

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -8,7 +8,7 @@ nginx-ingress:
       # As a Wire employee, for Wire-internal discussions and context see
       # * https://wearezeta.atlassian.net/browse/FS-33
       # * https://wearezeta.atlassian.net/browse/FS-444
-      ssl-ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256"
+      ssl-ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
       http2-max-field-size: 16k
       http2-max-header-size: 32k
       proxy-buffer-size: 16k

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -8,6 +8,8 @@ nginx-ingress:
       # As a Wire employee, for Wire-internal discussions and context see
       # * https://wearezeta.atlassian.net/browse/FS-33
       # * https://wearezeta.atlassian.net/browse/FS-444
+      #
+      # Note/FUTUREWORK: this current ingress-controller does not yet support TLS 1.3 (and its ciphers). An upgrade/different helm chart will be provided in the future.
       ssl-ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
       http2-max-field-size: 16k
       http2-max-header-size: 32k

--- a/docs/src/how-to/install/tls.rst
+++ b/docs/src/how-to/install/tls.rst
@@ -6,17 +6,19 @@ Configure TLS ciphers
 The following table lists recommended ciphers for TLS server setups, which should be used in wire deployments.
 
 
-============================= ======= ================= ========================
-Cipher                        Version `BSI TR-02102-2`_ `Mozilla TLS Guideline`_
-============================= ======= ================= ========================
-ECDHE-ECDSA-AES256-GCM-SHA384 TLSv1.2 **yes**           intermediate
-ECDHE-RSA-AES256-GCM-SHA384   TLSv1.2 **yes**           intermediate
-ECDHE-ECDSA-CHACHA20-POLY1305 TLSv1.2 no                intermediate
-ECDHE-RSA-CHACHA20-POLY1305   TLSv1.2 no                intermediate
-TLS_AES_128_GCM_SHA256        TLSv1.3 **yes**           **modern**
-TLS_AES_256_GCM_SHA384        TLSv1.3 **yes**           **modern**
-TLS_CHACHA20_POLY1305_SHA256  TLSv1.3 no                **modern**
-============================= ======= ================= ========================
+============================= ======= ============ ================= ========================
+Cipher                        Version Wire default `BSI TR-02102-2`_ `Mozilla TLS Guideline`_
+============================= ======= ============ ================= ========================
+ECDHE-ECDSA-AES128-GCM-SHA256 TLSv1.2 no           **yes**           intermediate
+ECDHE-RSA-AES128-GCM-SHA256   TLSv1.2 no           **yes**           intermediate
+ECDHE-ECDSA-AES256-GCM-SHA384 TLSv1.2 **yes**      **yes**           intermediate
+ECDHE-RSA-AES256-GCM-SHA384   TLSv1.2 **yes**      **yes**           intermediate
+ECDHE-ECDSA-CHACHA20-POLY1305 TLSv1.2 no           no                intermediate
+ECDHE-RSA-CHACHA20-POLY1305   TLSv1.2 no           no                intermediate
+TLS_AES_128_GCM_SHA256        TLSv1.3 **yes**      **yes**           **modern**
+TLS_AES_256_GCM_SHA384        TLSv1.3 **yes**      **yes**           **modern**
+TLS_CHACHA20_POLY1305_SHA256  TLSv1.3 no           no                **modern**
+============================= ======= ============ ================= ========================
 
 
 .. _bsi tr-02102-2: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.pdf

--- a/docs/src/how-to/install/tls.rst
+++ b/docs/src/how-to/install/tls.rst
@@ -9,8 +9,6 @@ The following table lists recommended ciphers for TLS server setups, which shoul
 ============================= ======= ================= ========================
 Cipher                        Version `BSI TR-02102-2`_ `Mozilla TLS Guideline`_
 ============================= ======= ================= ========================
-ECDHE-ECDSA-AES128-GCM-SHA256 TLSv1.2 **yes**           intermediate
-ECDHE-RSA-AES128-GCM-SHA256   TLSv1.2 **yes**           intermediate
 ECDHE-ECDSA-AES256-GCM-SHA384 TLSv1.2 **yes**           intermediate
 ECDHE-RSA-AES256-GCM-SHA384   TLSv1.2 **yes**           intermediate
 ECDHE-ECDSA-CHACHA20-POLY1305 TLSv1.2 no                intermediate

--- a/services/federator/src/Federator/Remote.hs
+++ b/services/federator/src/Federator/Remote.hs
@@ -177,7 +177,5 @@ blessedCiphers =
     TLS.cipher_TLS13_AES256GCM_SHA384,
     -- For TLS 1.2 (copied from default nginx ingress config):
     TLS.cipher_ECDHE_ECDSA_AES256GCM_SHA384,
-    TLS.cipher_ECDHE_RSA_AES256GCM_SHA384,
-    TLS.cipher_ECDHE_ECDSA_AES128GCM_SHA256,
-    TLS.cipher_ECDHE_RSA_AES128GCM_SHA256
+    TLS.cipher_ECDHE_RSA_AES256GCM_SHA384
   ]


### PR DESCRIPTION
As discussed with @mythsunwind and @comawill.

Removes these ciphers from ingress traffic getting to nginz; nginz-cannon; and if appliccable backoffice (which was using a larger list of ciphers). Also removes these ciphers from federation exchanges.


Also removes `TLS_CHACHA20_POLY1305_SHA256` when TLS 1.3 is active.
