### PR TITLE
Only log IO exceptions, not polysemy errors

### DIFF
--- a/changelog.d/5-internal/galley-logging
+++ b/changelog.d/5-internal/galley-logging
@@ -1,0 +1,1 @@
+Do not log polysemy errors in Galley

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -694,7 +694,7 @@ deleteLoop = do
   safeForever "deleteLoop" $ do
     i@(TeamItem tid usr con) <- Q.pop q
     env <- ask
-    liftIO (evalGalley env (doDelete usr con tid))
+    liftIO (evalGalleyToIO env (doDelete usr con tid))
       `catchAny` someError q i
   where
     someError q i x = do

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -232,7 +232,6 @@ evalGalley e =
     . mapError toWai
     . runInputConst e
     . runInputConst (e ^. cstate)
-    . mapError toWai -- Wai.Error
     . mapError toWai -- DynError
     . interpretTinyLog e
     . interpretQueue (e ^. deleteQueue)

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -37,11 +37,10 @@ module Galley.App
 
     -- * Running Galley effects
     GalleyEffects,
-    evalGalley,
+    evalGalleyToIO,
     ask,
     DeleteItem (..),
     toServantHandler,
-    interpretWaiErrorToException,
   )
 where
 
@@ -87,6 +86,7 @@ import qualified Galley.Types.Teams as Teams
 import Imports hiding (forkIO)
 import Network.HTTP.Client (responseTimeoutMicro)
 import Network.HTTP.Client.OpenSSL
+import qualified Network.Wai.Utilities.Error as Wai
 import OpenSSL.Session as Ssl
 import qualified OpenSSL.X509.SystemStore as Ssl
 import Polysemy
@@ -117,6 +117,7 @@ type GalleyEffects0 =
      Error FederationError,
      Resource,
      Embed IO,
+     Error Wai.Error,
      Final IO
    ]
 
@@ -201,41 +202,38 @@ interpretTinyLog ::
 interpretTinyLog e = interpret $ \case
   P.Log l m -> Logger.log (e ^. applog) (Wire.Sem.Logger.toLevel l) (reqIdMsg (e ^. reqId) . m)
 
-toServantHandler :: Env -> Sem GalleyEffects a -> Servant.Handler a
-toServantHandler env action =
-  liftIO $
-    evalGalley env action `UnliftIO.catch` \(e :: SomeException) -> do
+evalGalleyToIO :: Env -> Sem GalleyEffects a -> IO a
+evalGalleyToIO env action = do
+  r <-
+    -- log IO exceptions
+    runExceptT (evalGalley env action) `UnliftIO.catch` \(e :: SomeException) -> do
       Log.err (env ^. applog) $
         Log.msg ("IO Exception occurred" :: ByteString)
           . Log.field "message" (displayException e)
           . Log.field "request" (unRequestId (env ^. reqId))
       UnliftIO.throwIO e
+  case r of
+    -- throw any errors as IO exceptions without logging them
+    Left e -> UnliftIO.throwIO e
+    Right a -> pure a
 
-interpretErrorToException ::
-  (Exception exc, Member (Embed IO) r) =>
-  (err -> exc) ->
-  Sem (Error err ': r) a ->
-  Sem r a
-interpretErrorToException f = either (embed @IO . UnliftIO.throwIO . f) pure <=< runError
+toServantHandler :: Env -> Sem GalleyEffects a -> Servant.Handler a
+toServantHandler env = liftIO . evalGalleyToIO env
 
-interpretWaiErrorToException ::
-  (APIError e, Member (Embed IO) r) =>
-  Sem (Error e ': r) a ->
-  Sem r a
-interpretWaiErrorToException = interpretErrorToException toWai
-
-evalGalley :: Env -> Sem GalleyEffects a -> IO a
+evalGalley :: Env -> Sem GalleyEffects a -> ExceptT Wai.Error IO a
 evalGalley e =
-  runFinal @IO
+  ExceptT
+    . runFinal @IO
+    . runError
     . embedToFinal @IO
     . runResource
-    . interpretWaiErrorToException
-    . interpretWaiErrorToException
-    . interpretWaiErrorToException
+    . mapError toWai
+    . mapError toWai
+    . mapError toWai
     . runInputConst e
     . runInputConst (e ^. cstate)
-    . interpretWaiErrorToException -- Wai.Error
-    . interpretWaiErrorToException -- DynError
+    . mapError toWai -- Wai.Error
+    . mapError toWai -- DynError
     . interpretTinyLog e
     . interpretQueue (e ^. deleteQueue)
     . runInputSem (embed getCurrentTime) -- FUTUREWORK: could we take the time only once instead?

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -93,7 +93,7 @@ import Polysemy
 import Polysemy.Error
 import Polysemy.Input
 import Polysemy.Internal (Append)
-import Polysemy.Resource (Resource, runResource)
+import Polysemy.Resource
 import qualified Polysemy.TinyLog as P
 import qualified Servant
 import Ssl.Util
@@ -115,9 +115,9 @@ type GalleyEffects0 =
      -- federation errors can be thrown by almost every endpoint, so we avoid
      -- having to declare it every single time, and simply handle it here
      Error FederationError,
-     Resource,
      Embed IO,
      Error Wai.Error,
+     Resource,
      Final IO
    ]
 
@@ -224,9 +224,9 @@ evalGalley :: Env -> Sem GalleyEffects a -> ExceptT Wai.Error IO a
 evalGalley e =
   ExceptT
     . runFinal @IO
+    . runResource
     . runError
     . embedToFinal @IO
-    . runResource
     . mapError toWai
     . mapError toWai
     . mapError toWai

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -88,7 +88,6 @@ import Galley.Effects.TeamStore
 import Galley.Effects.WaiRoutes
 import Galley.Env
 import Galley.Options
-import qualified Network.Wai.Utilities.Error as Wai
 import Polysemy
 import Polysemy.Error
 import Polysemy.Input
@@ -127,6 +126,5 @@ type GalleyEffects1 =
      Input UTCTime,
      Queue DeleteItem,
      TinyLog,
-     Error Wai.Error,
      Error DynError
    ]

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -105,7 +105,7 @@ mkApp opts =
     pure (middlewares $ servantApp env, env)
   where
     rtree = compile API.sitemap
-    runGalley e r k = evalGalley e (route rtree r k)
+    runGalley e r k = evalGalleyToIO e (route rtree r k)
     -- the servant API wraps the one defined using wai-routing
     servantApp e0 r =
       let e = reqId .~ lookupReqId r $ e0


### PR DESCRIPTION
This should fix the excessive logging issue reported by @jschaul.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
