### PR TITLE
correctly set default nginx-ingress-services-issuer-creation variable

### DIFF
--- a/changelog.d/3-bug-fixes/lets-encrypt-default
+++ b/changelog.d/3-bug-fixes/lets-encrypt-default
@@ -1,0 +1,1 @@
+In nginx-ingress-services chart, when enabling useCertManager, now correctly creates the required issuer by default.

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -37,8 +37,8 @@ tls:
   useCertManager: false
   # the validation depth between a federator client certificate and tlsClientCA
   verify_depth: 1
+  createIssuer: true
   issuer:
-    create: true
     name: letsencrypt-http01
     kind: Issuer # Issuer | ClusterIssuer
 


### PR DESCRIPTION
In nginx-ingress-services chart, when enabling useCertManager, now correctly creates the required issuer by default.

See also Line 1 in https://github.com/wireapp/wire-server/blob/develop/charts/nginx-ingress-services/templates/issuer.yaml for the name of the variable checked, this didn't match the defaults inside values.yaml.