### PR TITLE
Remove old crypto-cli tool from the ubuntu image

### DIFF
--- a/build/ubuntu/Dockerfile.deps
+++ b/build/ubuntu/Dockerfile.deps
@@ -10,14 +10,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     export SODIUM_USE_PKG_CONFIG=1 && \
     cargo build --release
 
-# FUTUREWORK: remove core-crypto once #2508 is merged
-# compile legacy core-crypto cli tool
-RUN cd /tmp && \
-  apt-get install -y libssl-dev && \
-  git clone -b cli https://github.com/wireapp/core-crypto && \
-  cd core-crypto/cli && \
-  cargo build --release
-
 # compile mls-test-cli tool
 RUN cd /tmp && \
   git clone https://github.com/wireapp/mls-test-cli && \
@@ -29,9 +21,8 @@ FROM ubuntu:20.04
 
 COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib
 
-# FUTUREWORK: only copy crypto-cli and mls-test-cli executables if we are building an
+# FUTUREWORK: only copy mls-test-cli executables if we are building an
 # integration test image
-COPY --from=cryptobox-builder /tmp/core-crypto/cli/target/release/crypto-cli /usr/bin
 COPY --from=cryptobox-builder /tmp/mls-test-cli/target/release/mls-test-cli /usr/bin
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/changelog.d/5-internal/remove-crypto-cli
+++ b/changelog.d/5-internal/remove-crypto-cli
@@ -1,0 +1,1 @@
+Remove old crypto-cli tool from the ubuntu image


### PR DESCRIPTION
The old crypto-cli tool has been replaced by mls-test-cli.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
