### PR TITLE
Restore PUT /connections endpoint

### DIFF
--- a/changelog.d/1-api-changes/store-put-connection
+++ b/changelog.d/1-api-changes/store-put-connection
@@ -1,0 +1,1 @@
+Restore PUT /v2/connections endpoint

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -698,7 +698,6 @@ type ConnectionAPI =
     Named
       "update-connection"
       ( Summary "Update a connection to another user"
-          :> Until 'V2
           :> CanThrow 'MissingLegalholdConsent
           :> CanThrow 'InvalidUser
           :> CanThrow 'ConnectionLimitReached


### PR DESCRIPTION
This endpoint shouldn't have been deleted, because it's not actually possible to modify a connection using the POST endpoint.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
