### PR TITLE
Bump saml2-web-sso.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -142,7 +142,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/wireapp/saml2-web-sso
-    tag: 4227e38be5c0810012dc472fc6931f6087fbce68
+    tag: 30747970da6e024b53707605d138524de6fa53b0
 
 source-repository-package
     type: git

--- a/changelog.d/5-internal/bump-saml2-lib
+++ b/changelog.d/5-internal/bump-saml2-lib
@@ -1,0 +1,1 @@
+Bump saml2-web-sso

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -228,7 +228,7 @@ library
     , retry >=0.5
     , safe >=0.3
     , safe-exceptions >=0.1
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , schema-profunctor
     , semigroups
     , servant
@@ -325,7 +325,7 @@ executable galley
     , imports
     , raw-strings-qq >=1.0
     , safe >=0.3
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , servant-client
     , ssl-util
     , tagged
@@ -456,7 +456,7 @@ executable galley-integration
     , raw-strings-qq >=1.0
     , retry
     , safe >=0.3
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , schema-profunctor
     , servant
     , servant-client
@@ -559,7 +559,7 @@ executable galley-migrate-data
     , optparse-applicative
     , raw-strings-qq >=1.0
     , safe >=0.3
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , servant-client
     , ssl-util
     , tagged
@@ -680,7 +680,7 @@ executable galley-schema
     , optparse-applicative
     , raw-strings-qq >=1.0
     , safe >=0.3
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , servant-client
     , ssl-util
     , tagged
@@ -759,7 +759,7 @@ test-suite galley-tests
     , lens
     , raw-strings-qq >=1.0
     , safe >=0.3
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , servant-client
     , servant-swagger
     , ssl-util

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -21,7 +21,7 @@ dependencies:
 - wire-api-federation
 - tagged
 - servant-client
-- saml2-web-sso >=0.18
+- saml2-web-sso >=0.19
 - transformers
 
 library:

--- a/services/spar/package.yaml
+++ b/services/spar/package.yaml
@@ -60,7 +60,7 @@ dependencies:
   - QuickCheck
   - raw-strings-qq
   - retry
-  - saml2-web-sso >= 0.18
+  - saml2-web-sso >= 0.19
   - servant
   - servant-multipart
   - servant-server

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -166,7 +166,7 @@ library
     , polysemy-wire-zoo
     , raw-strings-qq
     , retry
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , servant
     , servant-multipart
     , servant-server
@@ -281,7 +281,7 @@ executable spar
     , polysemy-wire-zoo
     , raw-strings-qq
     , retry
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , servant
     , servant-multipart
     , servant-server
@@ -418,7 +418,7 @@ executable spar-integration
     , random
     , raw-strings-qq
     , retry
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , servant
     , servant-multipart
     , servant-server
@@ -546,7 +546,7 @@ executable spar-migrate-data
     , polysemy-wire-zoo
     , raw-strings-qq
     , retry
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , servant
     , servant-multipart
     , servant-server
@@ -678,7 +678,7 @@ executable spar-schema
     , polysemy-wire-zoo
     , raw-strings-qq
     , retry
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , servant
     , servant-multipart
     , servant-server
@@ -809,7 +809,7 @@ test-suite spec
     , polysemy-wire-zoo
     , raw-strings-qq
     , retry
-    , saml2-web-sso >=0.18
+    , saml2-web-sso >=0.19
     , servant
     , servant-multipart
     , servant-server

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -309,9 +309,9 @@ authresp ::
   Sem r Void
 authresp mbtid arbody = logErrors $ SAML2.authResp mbtid (SamlProtocolSettings.spIssuer mbtid) (SamlProtocolSettings.responseURI mbtid) go arbody
   where
-    go :: SAML.AuthnResponse -> SAML.AccessVerdict -> Sem r Void
-    go resp verdict = do
-      result :: SAML.ResponseVerdict <- verdictHandler mbtid resp verdict
+    go :: SAML.AuthnResponse -> IdP -> SAML.AccessVerdict -> Sem r Void
+    go resp verdict idp = do
+      result :: SAML.ResponseVerdict <- verdictHandler resp idp verdict
       throw @SparError $ SAML.CustomServant result
 
     logErrors :: Sem r Void -> Sem r Void

--- a/services/spar/src/Spar/Sem/SAML2.hs
+++ b/services/spar/src/Spar/Sem/SAML2.hs
@@ -34,6 +34,7 @@ import Imports (Maybe)
 import Polysemy
 import SAML2.WebSSO hiding (meta, toggleCookie)
 import URI.ByteString (URI)
+import Wire.API.User.IdentityProvider (IdP)
 
 data SAML2 m a where
   AuthReq ::
@@ -45,7 +46,7 @@ data SAML2 m a where
     Maybe TeamId ->
     m Issuer ->
     m URI ->
-    (AuthnResponse -> AccessVerdict -> m resp) ->
+    (AuthnResponse -> IdP -> AccessVerdict -> m resp) ->
     AuthnResponseBody ->
     SAML2 m resp
   Meta :: ST -> m Issuer -> m URI -> SAML2 m SPMetadata

--- a/services/spar/src/Spar/Sem/SAML2/Library.hs
+++ b/services/spar/src/Spar/Sem/SAML2/Library.hs
@@ -131,10 +131,10 @@ saml2ToSaml2WebSso =
     AuthResp mitlt ma mb mc ab -> do
       get_a <- runT ma
       get_b <- runT mb
-      get_c <- bindT $ uncurry mc
+      get_c <- bindT $ \(a, (b, c)) -> mc a b c
       ins <- getInspectorT
       s <- getInitialStateT
-      x <- raise $ unSPImpl $ SAML.authresp mitlt (inspectOrBomb ins get_a) (inspectOrBomb ins get_b) (\x y -> inspectOrBomb ins $ get_c $ (x, y) <$ s) ab
+      x <- raise $ unSPImpl $ SAML.authresp mitlt (inspectOrBomb ins get_a) (inspectOrBomb ins get_b) (\x y z -> inspectOrBomb ins $ get_c $ (x, (y, z)) <$ s) ab
       pure $ x <$ s
     Meta t ma mb -> do
       get_a <- runT ma

--- a/services/spar/test-integration/Test/Spar/AppSpec.hs
+++ b/services/spar/test-integration/Test/Spar/AppSpec.hs
@@ -167,11 +167,7 @@ requestAccessVerdict idp isGranted mkAuthnReq = do
           then SAML.AccessGranted uref
           else SAML.AccessDenied [DeniedNoBearerConfSubj, DeniedNoAuthnStatement]
   outcome :: ResponseVerdict <- do
-    mbteam <-
-      asks (^. teWireIdPAPIVersion) <&> \case
-        User.WireIdPAPIV1 -> Nothing
-        User.WireIdPAPIV2 -> Just (idp ^. SAML.idpExtraInfo . User.wiTeam)
-    runSpar $ Spar.verdictHandler mbteam authnresp verdict
+    runSpar $ Spar.verdictHandler authnresp verdict idp
   let loc :: URI.URI
       loc =
         maybe (error "no location") (either error id . SAML.parseURI' . cs)

--- a/stack.yaml
+++ b/stack.yaml
@@ -87,7 +87,7 @@ extra-deps:
   # a version > 1.0.0 of wai-middleware-prometheus is available
   # (required: https://github.com/fimad/prometheus-haskell/pull/45)
 - git: https://github.com/wireapp/saml2-web-sso
-  commit: 4227e38be5c0810012dc472fc6931f6087fbce68  # master (Dec 07, 2021)
+  commit: 30747970da6e024b53707605d138524de6fa53b0  # master (Jul 07, 2022)
 
 - git: https://github.com/kim/hs-collectd
   commit: 885da222be2375f78c7be36127620ed772b677c9

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -26,15 +26,15 @@ packages:
     commit: 2e3282e5fb27ba8d989c271a0a989823fad7ec43
 - completed:
     name: saml2-web-sso
-    version: '0.18'
+    version: '0.19'
     git: https://github.com/wireapp/saml2-web-sso
     pantry-tree:
       size: 4887
-      sha256: 9d6d175cc7bbdb57558f25557e4d0d698c4aecc250f6ca03296a3d94671bf657
-    commit: 4227e38be5c0810012dc472fc6931f6087fbce68
+      sha256: 6682027579687623346c9dd7e946b676c3ae1cc2bdc435c0ea4c7982ac098577
+    commit: 30747970da6e024b53707605d138524de6fa53b0
   original:
     git: https://github.com/wireapp/saml2-web-sso
-    commit: 4227e38be5c0810012dc472fc6931f6087fbce68
+    commit: 30747970da6e024b53707605d138524de6fa53b0
 - completed:
     name: collectd
     version: 0.0.0.2


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1630

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
