### PR TITLE
coturn multi-tenancy support

### DIFF
--- a/changelog.d/0-release-notes/coturn-secrets
+++ b/changelog.d/0-release-notes/coturn-secrets
@@ -1,0 +1,3 @@
+Users of the (currently alpha) coturn Helm chart must **manually update
+their configuration** due to changes in how the chart handles authentication
+secrets. Please see below for further details.

--- a/changelog.d/2-features/coturn-secrets
+++ b/changelog.d/2-features/coturn-secrets
@@ -1,0 +1,8 @@
+The coturn chart now supports multiple authentication secrets, which permits
+multiple backend instances to use the same TURN servers without needing to
+share authentication secrets between the backend instances.
+
+Correspondingly, the `.Values.secrets.zrestSecret` configuration option, which
+took a single authentication secret as its argument, has been replaced with the
+option `.Values.secrets.zrestSecrets` (note spelling!), which instead takes a
+*list* of authentication secrets as its argument.

--- a/charts/coturn/templates/configmap-coturn-conf-template.yaml
+++ b/charts/coturn/templates/configmap-coturn-conf-template.yaml
@@ -15,11 +15,6 @@ data:
     ## don't turn on coturn's cli.
     no-cli
 
-    ## authentication setup
-    # FUTUREWORK: enable support for multiple secrets?
-    zrest
-    static-auth-secret=__COTURN_SECRET__
-
     ## turn, stun.
     listening-ip=__COTURN_EXT_IP__
     listening-port={{ .Values.coturnTurnListenPort }}
@@ -73,3 +68,8 @@ data:
     denied-peer-ip=fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 
     # FUTUREWORK: expose customisable access control settings.
+
+    ## authentication setup
+    zrest
+    ## static authentication secrets will be added below this line when the
+    ## runtime configuration is generated.

--- a/charts/coturn/templates/secret.yaml
+++ b/charts/coturn/templates/secret.yaml
@@ -1,3 +1,8 @@
+{{- if or (not .Values.secrets) (not .Values.secrets.zrestSecrets) }}
+{{- fail "Secrets are not defined" }}
+{{- else if eq (len .Values.secrets.zrestSecrets) 0 }}
+{{- fail "At least one authentication secret must be defined" }}
+{{- else }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +12,8 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque
-data:
-  zrest_secret.txt: {{ .Values.secrets.zrestSecret | b64enc | quote }}
-
+stringData:
+  zrest_secret.txt: |
+    {{- range .Values.secrets.zrestSecrets }}{{ . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -90,8 +90,8 @@ spec:
             - |
               set -e
               EXTERNAL_IP=$(cat /external-ip/ip)
-              ZREST_SECRET="$(cat /secrets/zrest_secret.txt)"
-              sed -Ee "s;__COTURN_EXT_IP__;$EXTERNAL_IP;g" -e "s;__COTURN_POD_IP__;$POD_IP;g" -e "s;__COTURN_SECRET__;$ZREST_SECRET;" /coturn-template/coturn.conf.template > /coturn-config/turnserver.conf
+              sed -Ee "s;__COTURN_EXT_IP__;$EXTERNAL_IP;g" -e "s;__COTURN_POD_IP__;$POD_IP;g" /coturn-template/coturn.conf.template > /coturn-config/turnserver.conf
+              sed -Ee 's/^/static-auth-secret=/' /secrets/zrest_secret.txt >> /coturn-config/turnserver.conf
               exec /usr/bin/turnserver -c /coturn-config/turnserver.conf
           {{- if .Values.coturnGracefulTermination }}
           lifecycle:


### PR DESCRIPTION
This change updates the coturn Helm chart to add support for passing multiple authentication secrets to coturn. This makes it possible to operate a multi-tenant TURN service without needing to share secrets between consumers.

coturn already supports multiple auth secrets, so this change just adds the necessary configuration machinery to the Helm chart.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
