### PR TITLE
Isovector/brig servant 2022

### DIFF
--- a/changelog.d/5-internal/brig-servant-2022
+++ b/changelog.d/5-internal/brig-servant-2022
@@ -1,0 +1,1 @@
+Port brig UserHandle API to servant

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -320,6 +320,37 @@ type SelfAPI =
                :> MultiVerb 'PUT '[JSON] ChangeHandleResponses (Maybe ChangeHandleError)
            )
 
+type UserHandleAPI =
+  Named
+    "check-user-handles"
+    ( Summary ""
+        :> Description ""
+        :> ZUser
+        :> "users"
+        :> "handles"
+        :> ReqBody '[JSON] CheckHandles
+        :> MultiVerb
+             'POST
+             '[JSON]
+             '[Respond 200 "List of free handles" [Handle]]
+             [Handle]
+    )
+    :<|> Named
+           "check-user-handle"
+           ( Summary ""
+               :> CanThrow 'InvalidHandle
+               :> CanThrow 'HandleNotFound
+               :> ZUser
+               :> "users"
+               :> "handles"
+               :> Capture "handle" Text
+               :> MultiVerb
+                    'HEAD
+                    '[JSON]
+                    '[Respond 200 "Handle is taken" ()]
+                    ()
+           )
+
 type AccountAPI =
   -- docs/reference/user/registration.md {#RefRegistration}
   --
@@ -838,6 +869,7 @@ type BrigAPI =
     :<|> ConnectionAPI
     :<|> PropertiesAPI
     :<|> MLSAPI
+    :<|> UserHandleAPI
 
 brigSwagger :: Swagger
 brigSwagger = toSwagger (Proxy @BrigAPI)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -323,8 +323,7 @@ type SelfAPI =
 type UserHandleAPI =
   Named
     "check-user-handles"
-    ( Summary ""
-        :> Description ""
+    ( Summary "Check availability of user handles"
         :> ZUser
         :> "users"
         :> "handles"
@@ -337,7 +336,7 @@ type UserHandleAPI =
     )
     :<|> Named
            "check-user-handle"
-           ( Summary ""
+           ( Summary "Check whether a user handle can be taken"
                :> CanThrow 'InvalidHandle
                :> CanThrow 'HandleNotFound
                :> ZUser

--- a/libs/wire-api/src/Wire/API/User/Handle.hs
+++ b/libs/wire-api/src/Wire/API/User/Handle.hs
@@ -74,6 +74,7 @@ data CheckHandles = CheckHandles
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform CheckHandles)
+  deriving (S.ToSchema) via Schema CheckHandles
 
 modelCheckHandles :: Doc.Model
 modelCheckHandles = Doc.defineModel "CheckHandles" $ do
@@ -96,3 +97,10 @@ instance FromJSON CheckHandles where
     CheckHandles
       <$> o A..: "handles"
       <*> o A..:? "return" A..!= unsafeRange 1
+
+instance ToSchema CheckHandles where
+  schema =
+    object "CheckHandles" $
+      CheckHandles
+        <$> checkHandlesList .= field "handles" (fromRange .= rangedSchema (array schema))
+        <*> checkHandlesNum .= field "return" schema


### PR DESCRIPTION
Part of [SQCORE-1166](https://wearezeta.atlassian.net/browse/SQCORE-1166). Ports the Brig UserHandle API to use Servant.

Leaving the last two checkboxes unchecked because I don't know the answer to them.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
