### PR TITLE
fix typo of feature flag everywhere. Is this an API breaking change?

### DIFF
--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -79,9 +79,9 @@ data:
         searchVisibilityInbound:
           {{- toYaml .settings.featureFlags.searchVisibilityInbound | nindent 10 }}
         {{- end }}
-        {{- if .settings.featureFlags.validateSAMLemails }}
-        validateSAMLemails:
-          {{- toYaml .settings.featureFlags.validateSAMLemails | nindent 10 }}
+        {{- if .settings.featureFlags.validateSAMLEmails }}
+        validateSAMLEmails:
+          {{- toYaml .settings.featureFlags.validateSAMLEmails | nindent 10 }}
         {{- end }}
         {{- if .settings.featureFlags.appLock }}
         appLock:

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -75,7 +75,7 @@ config:
           status: disabled
       sso: disabled-by-default
       teamSearchVisibility: disabled-by-default
-      validateSAMLemails:
+      validateSAMLEmails:
         defaults:
           status: enabled
  

--- a/docs/legacy/reference/spar-braindump.md
+++ b/docs/legacy/reference/spar-braindump.md
@@ -258,7 +258,7 @@ work fine.
 When users are SAML-authenticated with an email address under NameID,
 that email address is used by wire as an opaque identifier, not to
 send actual emails.  In order to *also* assign the user that email
-address, you can enable the feature flag `validateSAMLemails`.  This
+address, you can enable the feature flag `validateSAMLEmails`.  This
 will trigger the regular email validation flow that is also triggered
 when the user changes their email themselves.
 

--- a/docs/src/release-notes.rst
+++ b/docs/src/release-notes.rst
@@ -2029,7 +2029,7 @@ Bug fixes and other updates
 Documentation
 -------------
 
--  [SCIM] Document ``validateSAMLemails`` feature in
+-  [SCIM] Document ``validateSAMLEmails`` feature in
    docs/reference/spar-braindump.md (#1299)
 
 Internal changes

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -517,7 +517,7 @@ instance ToSchema ValidateSAMLEmailsConfig where
   schema = object "ValidateSAMLEmailsConfig" objectSchema
 
 instance IsFeatureConfig ValidateSAMLEmailsConfig where
-  type FeatureSymbol ValidateSAMLEmailsConfig = "validateSAMLemails"
+  type FeatureSymbol ValidateSAMLEmailsConfig = "validateSAMLEmails"
   defFeatureStatus = WithStatus FeatureStatusEnabled LockStatusUnlocked ValidateSAMLEmailsConfig
   objectSchema = pure ValidateSAMLEmailsConfig
 

--- a/services/spar/src/Spar/Intra/Galley.hs
+++ b/services/spar/src/Spar/Intra/Galley.hs
@@ -84,7 +84,7 @@ assertSSOEnabled tid = do
 
 isEmailValidationEnabledTeam :: (HasCallStack, MonadSparToGalley m) => TeamId -> m Bool
 isEmailValidationEnabledTeam tid = do
-  resp <- call $ method GET . paths ["i", "teams", toByteString' tid, "features", "validateSAMLemails"]
+  resp <- call $ method GET . paths ["i", "teams", toByteString' tid, "features", "validateSAMLEmails"]
   pure
     ( statusCode resp == 200
         && ( (wsStatus <$> responseJsonMaybe @(WithStatus ValidateSAMLEmailsConfig) resp)


### PR DESCRIPTION
It looks like settings for the feature flag in helm chart never had any effects, as the parser looked for the version with captital `E`, not lowercase `e`.

Would one of you reviewers be able to amend/push-to/merge/close-unmerged this PR as needed? I don't have any context on what this is about; we just did diffing on configurations and saw this difference between old (hegemony) and new (helm based) prod configs.