### PR TITLE
Sqservices 1533 be give saml id ps human readable names in tm

### DIFF
--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -1718,6 +1718,7 @@ CREATE TABLE spar_test.idp (
     idp uuid PRIMARY KEY,
     api_version int,
     extra_public_keys list<blob>,
+    handle text,
     issuer text,
     old_issuers list<text>,
     public_key blob,

--- a/changelog.d/2-features/pr-2565
+++ b/changelog.d/2-features/pr-2565
@@ -1,0 +1,1 @@
+Human readable names for SAML IdPs

--- a/libs/wire-api/src/Wire/API/Routes/Public/Spar.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Spar.hs
@@ -113,6 +113,7 @@ type IdpCreate =
 type IdpUpdate =
   ReqBodyCustomError '[RawXML, JSON] "wai-error" IdPMetadataInfo
     :> Capture "id" SAML.IdPId
+    :> QueryParam' '[Optional, Strict] "handle" (Range 1 32 Text) -- todo(leif): check length limitation
     :> Put '[JSON] IdP
 
 type IdpDelete =

--- a/libs/wire-api/src/Wire/API/Routes/Public/Spar.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Spar.hs
@@ -19,6 +19,7 @@ module Wire.API.Routes.Public.Spar where
 
 import Data.Id
 import Data.Proxy
+import Data.Range
 import Data.Swagger (Swagger)
 import Imports
 import qualified SAML2.WebSSO as SAML
@@ -106,6 +107,7 @@ type IdpCreate =
   ReqBodyCustomError '[RawXML, JSON] "wai-error" IdPMetadataInfo
     :> QueryParam' '[Optional, Strict] "replaces" SAML.IdPId
     :> QueryParam' '[Optional, Strict] "api_version" WireIdPAPIVersion
+    :> QueryParam' '[Optional, Strict] "handle" (Range 1 32 Text) -- todo(leif): check length limitation
     :> PostCreated '[JSON] IdP
 
 type IdpUpdate =

--- a/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
+++ b/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
@@ -46,7 +46,7 @@ import Wire.API.User.Orphans (samlSchemaOptions)
 type IdP = IdPConfig WireIdP
 
 newtype IdPHandle = IdPHandle {unIdPHandle :: Text}
-  deriving (Eq, Ord, Show, FromJSON, ToJSON, ToSchema)
+  deriving (Eq, Ord, Show, FromJSON, ToJSON, ToSchema, Arbitrary, Generic)
 
 data WireIdP = WireIdP
   { _wiTeam :: TeamId,

--- a/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
+++ b/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
@@ -44,6 +45,9 @@ import Wire.API.User.Orphans (samlSchemaOptions)
 -- | The identity provider type used in Spar.
 type IdP = IdPConfig WireIdP
 
+newtype IdPHandle = IdPHandle {unIdPHandle :: Text}
+  deriving (Eq, Ord, Show, FromJSON, ToJSON, ToSchema)
+
 data WireIdP = WireIdP
   { _wiTeam :: TeamId,
     -- | list of issuer names that this idp has replaced, most recent first.  this is used
@@ -54,7 +58,8 @@ data WireIdP = WireIdP
     -- | the issuer that has replaced this one.  this is set iff a new issuer is created
     -- with the @"replaces"@ query parameter, and it is used to decide whether users not
     -- existing on this IdP can be auto-provisioned (if 'isJust', they can't).
-    _wiReplacedBy :: Maybe SAML.IdPId
+    _wiReplacedBy :: Maybe SAML.IdPId,
+    _wiHandle :: IdPHandle
   }
   deriving (Eq, Show, Generic)
 

--- a/services/spar/schema/src/Main.hs
+++ b/services/spar/schema/src/Main.hs
@@ -30,6 +30,7 @@ import qualified V12
 import qualified V13
 import qualified V14
 import qualified V15
+import qualified V16
 import qualified V2
 import qualified V3
 import qualified V4
@@ -63,7 +64,8 @@ main = do
       V12.migration,
       V13.migration,
       V14.migration,
-      V15.migration
+      V15.migration,
+      V16.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Spar.Data
 

--- a/services/spar/schema/src/V16.hs
+++ b/services/spar/schema/src/V16.hs
@@ -1,0 +1,33 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V16
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 16 "Human readable name for IdP" $ do
+  void $
+    schema'
+      [r|
+        ALTER TABLE idp ADD (handle text);
+      |]

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -583,6 +583,7 @@ executable spar-schema
       V13
       V14
       V15
+      V16
       V2
       V3
       V4

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -519,7 +519,7 @@ idpCreateXML zusr raw idpmeta mReplaces (fromMaybe defWireIdPAPIVersion -> apive
   teamid <- Brig.getZUsrCheckPerm zusr CreateUpdateDeleteIdp
   GalleyAccess.assertSSOEnabled teamid
   assertNoScimOrNoIdP teamid
-  handle <- maybe (IdPConfigStore.newHandle teamid) pure mHandle
+  handle <- maybe (IdPConfigStore.newHandle teamid) pure (IdPHandle . fromRange <$> mHandle)
   idp <- validateNewIdP apiversion idpmeta teamid mReplaces handle
   IdPRawMetadataStore.store (idp ^. SAML.idpId) raw
   IdPConfigStore.insertConfig idp

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -48,7 +48,7 @@ import Wire.API.User.Saml
 
 -- | A lower bound: @schemaVersion <= whatWeFoundOnCassandra@, not @==@.
 schemaVersion :: Int32
-schemaVersion = 15
+schemaVersion = 16
 
 ----------------------------------------------------------------------
 -- helpers

--- a/services/spar/src/Spar/Sem/IdPConfigStore.hs
+++ b/services/spar/src/Spar/Sem/IdPConfigStore.hs
@@ -32,6 +32,7 @@ module Spar.Sem.IdPConfigStore
     setReplacedBy,
     clearReplacedBy,
     deleteIssuer,
+    newHandle,
   )
 where
 
@@ -50,6 +51,7 @@ newtype Replacing = Replacing SAML.IdPId
 
 data IdPConfigStore m a where
   InsertConfig :: IP.IdP -> IdPConfigStore m ()
+  NewHandle :: TeamId -> IdPConfigStore m IP.IdPHandle
   GetConfig :: SAML.IdPId -> IdPConfigStore m IP.IdP
   GetIdPByIssuerV1Maybe :: SAML.Issuer -> IdPConfigStore m (Maybe IP.IdP)
   GetIdPByIssuerV1 :: SAML.Issuer -> IdPConfigStore m IP.IdP

--- a/services/spar/src/Spar/Sem/IdPConfigStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/IdPConfigStore/Cassandra.hs
@@ -116,7 +116,7 @@ insertIdPConfig idp = do
       getAllIdPsByIssuerUnsafe issuer >>= mapM_ (failIfNot thisVersion)
 
     ins :: PrepQuery W IdPConfigRow ()
-    ins = "INSERT INTO idp (idp, issuer, request_uri, public_key, extra_public_keys, team, api_version, old_issuers, replaced_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ins = "INSERT INTO idp (idp, issuer, request_uri, public_key, extra_public_keys, team, api_version, old_issuers, replaced_by, handle) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
     -- FUTUREWORK: migrate `spar.issuer_idp` away, `spar.issuer_idp_v2` is enough.
     byIssuer :: PrepQuery W (SAML.Issuer, TeamId, SAML.IdPId) ()

--- a/services/spar/src/Spar/Sem/IdPConfigStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/IdPConfigStore/Mem.hs
@@ -27,6 +27,7 @@ import Polysemy
 import Polysemy.State
 import qualified SAML2.WebSSO.Types as SAML
 import Spar.Sem.IdPConfigStore (IdPConfigStore (..), Replaced (..), Replacing (..))
+import Wire.API.User.IdentityProvider (IdPHandle (IdPHandle))
 import qualified Wire.API.User.IdentityProvider as IP
 import qualified Wire.API.User.IdentityProvider as SAML
 
@@ -45,6 +46,7 @@ idPToMem = evState . evEff
     evEff = reinterpret @_ @(State TypedState) $ \case
       InsertConfig iw ->
         modify' (insertConfig iw)
+      NewHandle _tid -> pure $ IdPHandle "IdP 1" --todo(leif): generate a new handle
       GetConfig i ->
         gets (getConfig i)
       GetIdPByIssuerV1Maybe issuer ->

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -1047,6 +1047,7 @@ specCRUDIdentityProvider = do
                   . (idpMetadata . edIssuer .~ (idp1 ^. idpMetadata . edIssuer))
                   . (idpExtraInfo . wiOldIssuers .~ (idp1 ^. idpExtraInfo . wiOldIssuers))
                   . (idpExtraInfo . wiReplacedBy .~ (idp1 ^. idpExtraInfo . wiReplacedBy))
+                  . (idpExtraInfo . wiHandle .~ (idp1 ^. idpExtraInfo . wiHandle))
           erase idp1 `shouldBe` erase idp2
       it "users can still login on old idp as before" $ do
         env <- ask

--- a/services/spar/test-integration/Test/Spar/DataSpec.hs
+++ b/services/spar/test-integration/Test/Spar/DataSpec.hs
@@ -158,14 +158,14 @@ spec = do
       it "getIdPConfigsByTeam works" $ do
         skipIdPAPIVersions [WireIdPAPIV1]
         teamid <- nextWireId
-        idp <- makeTestIdP <&> idpExtraInfo .~ WireIdP teamid Nothing [] Nothing
+        idp <- makeTestIdP <&> idpExtraInfo .~ WireIdP teamid Nothing [] Nothing (IdPHandle "IdP 1")
         () <- runSpar $ IdPEffect.insertConfig idp
         idps <- runSpar $ IdPEffect.getConfigsByTeam teamid
         liftIO $ idps `shouldBe` [idp]
       it "deleteIdPConfig works" $ do
         teamid <- nextWireId
         idpApiVersion <- asks (^. teWireIdPAPIVersion)
-        idp <- makeTestIdP <&> idpExtraInfo .~ WireIdP teamid (Just idpApiVersion) [] Nothing
+        idp <- makeTestIdP <&> idpExtraInfo .~ WireIdP teamid (Just idpApiVersion) [] Nothing (IdPHandle "IdP 1")
         () <- runSpar $ IdPEffect.insertConfig idp
         do
           midp <- runSpar $ IdPEffect.getConfig (idp ^. idpId)

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -108,7 +108,9 @@ module Util.Core
     callIdpCreateRaw',
     callIdpCreateReplace,
     callIdpCreateReplace',
-    callIdpUpdate',
+    callIdpCreateWithHandle,
+    callIdpUpdate,
+    callIdpUpdateWithHandle,
     callIdpDelete,
     callIdpDelete',
     callIdpDeletePurge',
@@ -1094,6 +1096,33 @@ callIdpCreateRaw' sparreq_ muid ctyp metadata = do
       . body (RequestBodyLBS metadata)
       . header "Content-Type" ctyp
 
+callIdpCreateWithHandle :: (MonadIO m, MonadHttp m) => WireIdPAPIVersion -> SparReq -> Maybe UserId -> SAML.IdPMetadata -> IdPHandle -> m IdP
+callIdpCreateWithHandle apiversion sparreq_ muid metadata idpHandle = do
+  resp <- callIdpCreateWithHandle' apiversion (sparreq_ . expect2xx) muid metadata idpHandle
+  either (liftIO . throwIO . ErrorCall . show) pure $
+    responseJsonEither @IdP resp
+
+callIdpCreateWithHandle' :: (HasCallStack, MonadIO m, MonadHttp m) => WireIdPAPIVersion -> SparReq -> Maybe UserId -> IdPMetadata -> IdPHandle -> m ResponseLBS
+callIdpCreateWithHandle' apiversion sparreq_ muid metadata idpHandle = do
+  explicitQueryParam <- do
+    -- `&api_version=v1` is implicit and can be omitted from the query, but we want to test
+    -- both, and not spend extra time on it.
+    liftIO $ randomRIO (True, False)
+  let versionParam =
+        case apiversion of
+          WireIdPAPIV1 -> if explicitQueryParam then Just "v1" else Nothing
+          WireIdPAPIV2 -> Just "v2"
+  post $
+    sparreq_
+      . maybe id zUser muid
+      . path "/identity-providers/"
+      . Bilge.query
+        [ ("api_version", versionParam),
+          ("handle", Just . cs . unIdPHandle $ idpHandle)
+        ]
+      . body (RequestBodyLBS . cs $ SAML.encode metadata)
+      . header "Content-Type" "application/xml"
+
 callIdpCreateReplace :: (MonadIO m, MonadHttp m) => WireIdPAPIVersion -> SparReq -> Maybe UserId -> IdPMetadata -> IdPId -> m IdP
 callIdpCreateReplace apiversion sparreq_ muid metadata idpid = do
   resp <- callIdpCreateReplace' apiversion (sparreq_ . expect2xx) muid metadata idpid
@@ -1123,12 +1152,22 @@ callIdpCreateReplace' apiversion sparreq_ muid metadata idpid = do
       . body (RequestBodyLBS . cs $ SAML.encode metadata)
       . header "Content-Type" "application/xml"
 
-callIdpUpdate' :: (MonadIO m, MonadHttp m) => SparReq -> Maybe UserId -> IdPId -> IdPMetadataInfo -> m ResponseLBS
-callIdpUpdate' sparreq_ muid idpid (IdPMetadataValue metadata _) = do
+callIdpUpdate :: (MonadIO m, MonadHttp m) => SparReq -> Maybe UserId -> IdPId -> IdPMetadataInfo -> m ResponseLBS
+callIdpUpdate sparreq_ muid idpid (IdPMetadataValue metadata _) = do
   put $
     sparreq_
       . maybe id zUser muid
       . paths ["identity-providers", toByteString' $ idPIdToST idpid]
+      . body (RequestBodyLBS $ cs metadata)
+      . header "Content-Type" "application/xml"
+
+callIdpUpdateWithHandle :: (MonadIO m, MonadHttp m) => SparReq -> Maybe UserId -> IdPId -> IdPMetadataInfo -> IdPHandle -> m ResponseLBS
+callIdpUpdateWithHandle sparreq_ muid idpid (IdPMetadataValue metadata _) idpHandle = do
+  put $
+    sparreq_
+      . maybe id zUser muid
+      . paths ["identity-providers", toByteString' $ idPIdToST idpid]
+      . Bilge.query [("handle", Just . cs . unIdPHandle $ idpHandle)]
       . body (RequestBodyLBS $ cs metadata)
       . header "Content-Type" "application/xml"
 

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -156,6 +156,7 @@ import Data.Misc (PlainTextPassword (..))
 import Data.Proxy
 import Data.Range
 import Data.String.Conversions
+import Data.Text (pack)
 import qualified Data.Text.Ascii as Ascii
 import Data.Text.Encoding (encodeUtf8)
 import Data.UUID as UUID hiding (fromByteString, null)
@@ -543,7 +544,10 @@ nextWireId :: MonadIO m => m (Id a)
 nextWireId = Id <$> liftIO UUID.nextRandom
 
 nextWireIdP :: MonadIO m => WireIdPAPIVersion -> m WireIdP
-nextWireIdP version = WireIdP <$> (Id <$> liftIO UUID.nextRandom) <*> pure (Just version) <*> pure [] <*> pure Nothing
+nextWireIdP version = WireIdP <$> iid <*> pure (Just version) <*> pure [] <*> pure Nothing <*> idpHandle
+  where
+    iid = Id <$> liftIO UUID.nextRandom
+    idpHandle = iid <&> IdPHandle . pack . show
 
 nextSAMLID :: MonadIO m => m (ID a)
 nextSAMLID = mkID . UUID.toText <$> liftIO UUID.nextRandom

--- a/services/spar/test/Arbitrary.hs
+++ b/services/spar/test/Arbitrary.hs
@@ -44,7 +44,7 @@ instance Arbitrary IdPList where
     pure $ IdPList {..}
 
 instance Arbitrary WireIdP where
-  arbitrary = WireIdP <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary = WireIdP <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 deriving instance Arbitrary ScimToken
 
@@ -95,6 +95,8 @@ instance Arbitrary E.Replaced where
 -- TODO(sandy): IdPIds are unlikely to collide. Does the size parameter
 -- affect them?
 instance CoArbitrary IdPId
+
+instance CoArbitrary IdPHandle
 
 instance CoArbitrary WireIdP
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1533

`handle` is an optional query parameter on the POST and PUT requests. Can't easily add it to the body because the content-type is XML. Refactoring this will be a breaking change for the clients.

When a handle is not given, we will generate one like "IdP 1..n" and take the first one that is not used already.

If an IdP already exists, the handle that is returned is generated from the uuid of the IdP, taking the first 6 characters, e.g.

```
IdP 63621f
```

Since IdP handles are only alias, the uniqueness requirements for the handle can be a bit softer. Also, team admins can simply change the handles in case of a clash.

There was a discussion in the BE channel about a potential data migration. But the current implementation doesn’t need one, if it is acceptable from the user’s point of view to have the handles generated from the IdP Id as described above. There is also no need to update the database on GET requests, as discussed elsewhere.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
