### PR TITLE
[FS-509] 28-day Proposal Hold Time

### DIFF
--- a/changelog.d/5-internal/proposal-hold-time
+++ b/changelog.d/5-internal/proposal-hold-time
@@ -1,0 +1,1 @@
+ Change the proposal hold time to 28 days

--- a/services/galley/src/Galley/Cassandra/Proposal.hs
+++ b/services/galley/src/Galley/Cassandra/Proposal.hs
@@ -35,7 +35,7 @@ type TTL = Integer
 
 -- | Proposals in the database expire after this timeout in seconds
 defaultTTL :: TTL
-defaultTTL = 30 * 24 * 60 * 60
+defaultTTL = 28 * 24 * 60 * 60
 
 interpretProposalStoreToCassandra ::
   Members '[Embed IO, Input ClientState] r =>


### PR DESCRIPTION
Rohan asked to keep proposal hold time consistent with message hold time, which is 28 days by default. The PR updates the value accordingly.

Tracked by https://wearezeta.atlassian.net/browse/FS-509.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
