### PR TITLE
give integration tests more time to run

### DIFF
--- a/changelog.d/5-internal/ci-integration-test-timeout
+++ b/changelog.d/5-internal/ci-integration-test-timeout
@@ -1,0 +1,1 @@
+Bump timeout for integration tests to 15 minutes (from 10 minutes), as 10 minutes is no longer enough.

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -6,4 +6,4 @@ NAMESPACE=${NAMESPACE:-test-integration}
 echo "Running integration tests on wire-server"
 
 CHART=wire-server
-helm test --logs -n "${NAMESPACE}" "${NAMESPACE}-${CHART}" --timeout 600s
+helm test --logs -n "${NAMESPACE}" "${NAMESPACE}-${CHART}" --timeout 900s


### PR DESCRIPTION
Possibly help with some CI failures we have been seeing of the type

```
Error: unable to get pod logs for test-cbwmwl9q8aha-wire-server-cargohold-integration: pods "test-cbwmwl9q8aha-wire-server-cargohold-integration" not found
```

CI runs `make kube-integration-test` which is an alias for `./hack/bin/integration-tests.sh` which runs this line:

```
helm test --logs -n "${NAMESPACE}" "${NAMESPACE}-${CHART}" --timeout 600s
```

`helm test --logs` will run all tests as defined under `./charts/<chart-e.g.brig>/templates/tests/*`, then post all logs. My hunch is that tests did not have enough time, so there's actually a timeout; but the error doesn't say timeout, but "can't find this pod I'd expect to have started"

By looking at these timings, we can see the last log entry from being done setting up all the non-test pods, it's 17:57, and the first line of the log output from the test pods is 10 minutes (600s) afterwards, at 18:07:

![logs](https://user-images.githubusercontent.com/2112744/179559066-5d8d0ab7-80b1-44ef-a8aa-922904be6432.png)

This change should give more time to integration tests, and therefore avoid the current issues.