### PR TITLE
charts/cannon: Ensure HSTS headers are set for all endpoints

### DIFF
--- a/changelog.d/2-features/cannon-hsts
+++ b/changelog.d/2-features/cannon-hsts
@@ -1,0 +1,1 @@
+charts/cannon: Ensure HSTS headers are set for all endpoints

--- a/charts/cannon/templates/conf/_nginx.conf.tpl
+++ b/charts/cannon/templates/conf/_nginx.conf.tpl
@@ -206,6 +206,8 @@ http {
     zauth_keystore {{ .Values.nginx_conf.zauth_keystore }};
     zauth_acl      {{ .Values.nginx_conf.zauth_acl }};
 
+    add_header Strict-Transport-Security 'max-age=31536000; includeSubdomains; preload' always;
+
     location /status {
         zauth off;
         access_log off;
@@ -338,7 +340,7 @@ http {
 
         more_set_headers 'Access-Control-Expose-Headers: Request-Id, Location';
         more_set_headers 'Request-Id: $request_id';
-        more_set_headers 'Strict-Transport-Security: max-age=31536000; preload';
+        more_set_headers 'Strict-Transport-Security: max-age=31536000; includeSubdomains; preload';
     }
 
           {{- end -}}


### PR DESCRIPTION
Also include subdomains

Resolves https://wearezeta.atlassian.net/browse/SEC-183

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.