### PR TITLE
Allow features to be set with HTTP method PATCH (SQPIT-1142)

### DIFF
--- a/changelog.d/5-internal/allow-patch-method-for-feature-setting
+++ b/changelog.d/5-internal/allow-patch-method-for-feature-setting
@@ -1,0 +1,4 @@
+Allow features to be set with HTTP method PATCH. This reflects a prior behavior
+that is used by Ibis. Additionally, it's more consistent when all setters can be
+called with PUT and PATCH. As this will fix calls by Ibis, the deployment order
+doesn't matter.

--- a/libs/wire-api/src/Wire/API/MLS/CipherSuite.hs
+++ b/libs/wire-api/src/Wire/API/MLS/CipherSuite.hs
@@ -45,7 +45,7 @@ instance ToSchema CipherSuite where
       cipherSuiteNumber .= fmap CipherSuite (unnamed schema)
 
 data CipherSuiteTag = MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-  deriving stock (Bounded, Enum, Eq, Show, Generic)
+  deriving stock (Bounded, Enum, Eq, Show, Generic, Ord)
   deriving (Arbitrary) via (GenericUniform CipherSuiteTag)
 
 instance S.ToSchema CipherSuiteTag where

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -108,41 +108,52 @@ import Wire.API.Team.Feature
 import Wire.API.Team.Member
 import Wire.API.Team.SearchVisibility
 
-type IFeatureAPI =
-  -- SSOConfig
-  IFeatureStatusGet SSOConfig
-    :<|> IFeatureStatusPut '() SSOConfig
-    -- LegalholdConfig
-    :<|> IFeatureStatusGet LegalholdConfig
-    :<|> IFeatureStatusPut
-           '( 'ActionDenied 'RemoveConversationMember,
-              '( AuthenticationError,
-                 '( 'CannotEnableLegalHoldServiceLargeTeam,
-                    '( 'LegalHoldNotEnabled,
-                       '( 'LegalHoldDisableUnimplemented,
-                          '( 'LegalHoldServiceNotRegistered,
-                             '( 'UserLegalHoldIllegalOperation,
-                                '( 'LegalHoldCouldNotBlockConnections, '())
-                              )
-                           )
-                        )
+type LegalHoldFeatureStatusChangeErrors =
+  '( 'ActionDenied 'RemoveConversationMember,
+     '( AuthenticationError,
+        '( 'CannotEnableLegalHoldServiceLargeTeam,
+           '( 'LegalHoldNotEnabled,
+              '( 'LegalHoldDisableUnimplemented,
+                 '( 'LegalHoldServiceNotRegistered,
+                    '( 'UserLegalHoldIllegalOperation,
+                       '( 'LegalHoldCouldNotBlockConnections, '())
                      )
                   )
                )
             )
+         )
+      )
+   )
+
+type IFeatureAPI =
+  -- SSOConfig
+  IFeatureStatusGet SSOConfig
+    :<|> IFeatureStatusPut '() SSOConfig
+    :<|> IFeatureStatusPatch '() SSOConfig
+    -- LegalholdConfig
+    :<|> IFeatureStatusGet LegalholdConfig
+    :<|> IFeatureStatusPut
+           LegalHoldFeatureStatusChangeErrors
+           LegalholdConfig
+    :<|> IFeatureStatusPatch
+           LegalHoldFeatureStatusChangeErrors
            LegalholdConfig
     -- SearchVisibilityAvailableConfig
     :<|> IFeatureStatusGet SearchVisibilityAvailableConfig
     :<|> IFeatureStatusPut '() SearchVisibilityAvailableConfig
+    :<|> IFeatureStatusPatch '() SearchVisibilityAvailableConfig
     -- ValidateSAMLEmailsConfig
     :<|> IFeatureStatusGet ValidateSAMLEmailsConfig
     :<|> IFeatureStatusPut '() ValidateSAMLEmailsConfig
+    :<|> IFeatureStatusPatch '() ValidateSAMLEmailsConfig
     -- DigitalSignaturesConfig
     :<|> IFeatureStatusGet DigitalSignaturesConfig
     :<|> IFeatureStatusPut '() DigitalSignaturesConfig
+    :<|> IFeatureStatusPatch '() DigitalSignaturesConfig
     -- AppLockConfig
     :<|> IFeatureStatusGet AppLockConfig
     :<|> IFeatureStatusPut '() AppLockConfig
+    :<|> IFeatureStatusPatch '() AppLockConfig
     -- FileSharingConfig
     :<|> IFeatureStatusGet FileSharingConfig
     :<|> IFeatureStatusPut '() FileSharingConfig
@@ -151,6 +162,7 @@ type IFeatureAPI =
     -- ConferenceCallingConfig
     :<|> IFeatureStatusGet ConferenceCallingConfig
     :<|> IFeatureStatusPut '() ConferenceCallingConfig
+    :<|> IFeatureStatusPatch '() ConferenceCallingConfig
     -- SelfDeletingMessagesConfig
     :<|> IFeatureStatusGet SelfDeletingMessagesConfig
     :<|> IFeatureStatusPut '() SelfDeletingMessagesConfig
@@ -169,15 +181,18 @@ type IFeatureAPI =
     -- SearchVisibilityInboundConfig
     :<|> IFeatureStatusGet SearchVisibilityInboundConfig
     :<|> IFeatureStatusPut '() SearchVisibilityInboundConfig
+    :<|> IFeatureStatusPatch '() SearchVisibilityInboundConfig
     :<|> IFeatureNoConfigMultiGet SearchVisibilityInboundConfig
     -- ClassifiedDomainsConfig
     :<|> IFeatureStatusGet ClassifiedDomainsConfig
     -- MLSConfig
     :<|> IFeatureStatusGet MLSConfig
     :<|> IFeatureStatusPut '() MLSConfig
+    :<|> IFeatureStatusPatch '() MLSConfig
     -- SearchVisibilityInboundConfig
     :<|> IFeatureStatusGet SearchVisibilityInboundConfig
     :<|> IFeatureStatusPut '() SearchVisibilityInboundConfig
+    :<|> IFeatureStatusPatch '() SearchVisibilityInboundConfig
     -- all feature configs
     :<|> Named
            "feature-configs-internal"
@@ -470,22 +485,29 @@ featureAPI :: API IFeatureAPI GalleyEffects
 featureAPI =
   mkNamedAPI @'("iget", SSOConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", SSOConfig) (setFeatureStatusInternal @Cassandra)
+    <@> mkNamedAPI @'("ipatch", SSOConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("iget", LegalholdConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", LegalholdConfig) (setFeatureStatusInternal @Cassandra)
+    <@> mkNamedAPI @'("ipatch", LegalholdConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("iget", SearchVisibilityAvailableConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", SearchVisibilityAvailableConfig) (setFeatureStatusInternal @Cassandra)
+    <@> mkNamedAPI @'("ipatch", SearchVisibilityAvailableConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("iget", ValidateSAMLEmailsConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", ValidateSAMLEmailsConfig) (setFeatureStatusInternal @Cassandra)
+    <@> mkNamedAPI @'("ipatch", ValidateSAMLEmailsConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("iget", DigitalSignaturesConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", DigitalSignaturesConfig) (setFeatureStatusInternal @Cassandra)
+    <@> mkNamedAPI @'("ipatch", DigitalSignaturesConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("iget", AppLockConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", AppLockConfig) (setFeatureStatusInternal @Cassandra)
+    <@> mkNamedAPI @'("ipatch", AppLockConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("iget", FileSharingConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", FileSharingConfig) (setFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("ilock", FileSharingConfig) (updateLockStatus @Cassandra @FileSharingConfig)
     <@> mkNamedAPI @'("ipatch", FileSharingConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("iget", ConferenceCallingConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", ConferenceCallingConfig) (setFeatureStatusInternal @Cassandra)
+    <@> mkNamedAPI @'("ipatch", ConferenceCallingConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("iget", SelfDeletingMessagesConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", SelfDeletingMessagesConfig) (setFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("ilock", SelfDeletingMessagesConfig) (updateLockStatus @Cassandra @SelfDeletingMessagesConfig)
@@ -500,12 +522,15 @@ featureAPI =
     <@> mkNamedAPI @'("ipatch", SndFactorPasswordChallengeConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("iget", SearchVisibilityInboundConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", SearchVisibilityInboundConfig) (setFeatureStatusInternal @Cassandra)
+    <@> mkNamedAPI @'("ipatch", SearchVisibilityInboundConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("igetmulti", SearchVisibilityInboundConfig) (getFeatureStatusMulti @Cassandra)
     <@> mkNamedAPI @'("iget", ClassifiedDomainsConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iget", MLSConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", MLSConfig) (setFeatureStatusInternal @Cassandra)
+    <@> mkNamedAPI @'("ipatch", MLSConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @'("iget", SearchVisibilityInboundConfig) (getFeatureStatus @Cassandra DontDoAuth)
     <@> mkNamedAPI @'("iput", SearchVisibilityInboundConfig) (setFeatureStatusInternal @Cassandra)
+    <@> mkNamedAPI @'("ipatch", SearchVisibilityInboundConfig) (patchFeatureStatusInternal @Cassandra)
     <@> mkNamedAPI @"feature-configs-internal" (maybe (getAllFeatureConfigsForServer @Cassandra) (getAllFeatureConfigsForUser @Cassandra))
 
 internalSitemap :: Routes a (Sem GalleyEffects) ()

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -109,6 +109,8 @@ tests s =
             testPatchIgnoreLockStatusChange @Public.ValidateSAMLEmailsConfig Public.FeatureStatusEnabled Public.ValidateSAMLEmailsConfig,
           test s (unpack $ Public.featureNameBS @Public.DigitalSignaturesConfig) $
             testPatchIgnoreLockStatusChange @Public.DigitalSignaturesConfig Public.FeatureStatusEnabled Public.DigitalSignaturesConfig,
+          test s (unpack $ Public.featureNameBS @Public.AppLockConfig) $
+            testPatchIgnoreLockStatusChange @Public.AppLockConfig Public.FeatureStatusEnabled (Public.AppLockConfig (Public.EnforceAppLock False) 42),
           test s (unpack $ Public.featureNameBS @Public.FileSharingConfig) $
             testPatch @Public.FileSharingConfig Public.FeatureStatusEnabled Public.FileSharingConfig,
           test s (unpack $ Public.featureNameBS @Public.GuestLinksConfig) $
@@ -154,6 +156,8 @@ testPatchIgnoreLockStatusChange ::
   TestM ()
 testPatchIgnoreLockStatusChange = testPatch' False
 
+-- TODO: It's surprising that `defStatus` and `defConfig` are ignored when the
+-- status is unlocked. (Are more separate functions hiddin in this one?)
 testPatch' ::
   forall cfg.
   ( HasCallStack,

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -100,8 +100,7 @@ tests s =
       test s "SearchVisibilityInbound" $ testSimpleFlag @Public.SearchVisibilityInboundConfig Public.FeatureStatusDisabled,
       testGroup
         "Patch"
-        [
-          -- Note: `SSOConfig` and `LegalHoldConfig` may not be able to be reset
+        [ -- Note: `SSOConfig` and `LegalHoldConfig` may not be able to be reset
           -- (depending on prior state). Thus, they cannot be tested here
           -- (setting random values), but are tested with separate tests.
           test s (unpack $ Public.featureNameBS @Public.SearchVisibilityAvailableConfig) $
@@ -274,7 +273,7 @@ putSSOInternal :: HasCallStack => TeamId -> Public.FeatureStatus -> TestM ()
 putSSOInternal tid = void . Util.putTeamFeatureFlagInternal @Public.SSOConfig expect2xx tid . (`Public.WithStatusNoLock` Public.SSOConfig)
 
 patchSSOInternal :: HasCallStack => TeamId -> Public.FeatureStatus -> TestM ()
-patchSSOInternal tid status = Util.patchFeatureStatusInternal @Public.SSOConfig tid (Public.withStatus' (Just status) Nothing Nothing) !!! statusCode === const 200
+patchSSOInternal tid status = void $ Util.patchFeatureStatusInternalWithMod @Public.SSOConfig expect2xx tid (Public.withStatus' (Just status) Nothing Nothing)
 
 testLegalHold :: ((Request -> Request) -> TeamId -> Public.FeatureStatus -> TestM ()) -> TestM ()
 testLegalHold setLegalHoldInternal = do

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -105,6 +105,8 @@ tests s =
           -- here, because their state can only be set once.
           test s (unpack $ Public.featureNameBS @Public.SearchVisibilityAvailableConfig) $
             testPatchIgnoreLockStatusChange @Public.SearchVisibilityAvailableConfig Public.FeatureStatusEnabled Public.SearchVisibilityAvailableConfig,
+          test s (unpack $ Public.featureNameBS @Public.ValidateSAMLEmailsConfig) $
+            testPatchIgnoreLockStatusChange @Public.ValidateSAMLEmailsConfig Public.FeatureStatusEnabled Public.ValidateSAMLEmailsConfig,
           test s (unpack $ Public.featureNameBS @Public.FileSharingConfig) $
             testPatch @Public.FileSharingConfig Public.FeatureStatusEnabled Public.FileSharingConfig,
           test s (unpack $ Public.featureNameBS @Public.GuestLinksConfig) $

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -111,6 +111,8 @@ tests s =
             testPatchIgnoreLockStatusChange @Public.DigitalSignaturesConfig Public.FeatureStatusEnabled Public.DigitalSignaturesConfig,
           test s (unpack $ Public.featureNameBS @Public.AppLockConfig) $
             testPatchValidAppLockConfig Public.FeatureStatusEnabled (Public.AppLockConfig (Public.EnforceAppLock False) 42),
+          test s (unpack $ Public.featureNameBS @Public.ConferenceCallingConfig) $
+            testPatchIgnoreLockStatusChange @Public.ConferenceCallingConfig Public.FeatureStatusEnabled Public.ConferenceCallingConfig,
           test s (unpack $ Public.featureNameBS @Public.FileSharingConfig) $
             testPatch @Public.FileSharingConfig Public.FeatureStatusEnabled Public.FileSharingConfig,
           test s (unpack $ Public.featureNameBS @Public.GuestLinksConfig) $

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -199,9 +199,7 @@ testPatch ::
   Public.FeatureStatus ->
   cfg ->
   TestM ()
-testPatch assertLockStatusChange status cfg = do
-  c <- liftIO (generate arbitrary)
-  testPatch' assertLockStatusChange c status cfg
+testPatch assertLockStatusChange status cfg = testPatchWithCustomGen assertLockStatusChange status cfg arbitrary
 
 testPatch' ::
   forall cfg.

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -107,6 +107,8 @@ tests s =
             testPatchIgnoreLockStatusChange @Public.SearchVisibilityAvailableConfig Public.FeatureStatusEnabled Public.SearchVisibilityAvailableConfig,
           test s (unpack $ Public.featureNameBS @Public.ValidateSAMLEmailsConfig) $
             testPatchIgnoreLockStatusChange @Public.ValidateSAMLEmailsConfig Public.FeatureStatusEnabled Public.ValidateSAMLEmailsConfig,
+          test s (unpack $ Public.featureNameBS @Public.DigitalSignaturesConfig) $
+            testPatchIgnoreLockStatusChange @Public.DigitalSignaturesConfig Public.FeatureStatusEnabled Public.DigitalSignaturesConfig,
           test s (unpack $ Public.featureNameBS @Public.FileSharingConfig) $
             testPatch @Public.FileSharingConfig Public.FeatureStatusEnabled Public.FileSharingConfig,
           test s (unpack $ Public.featureNameBS @Public.GuestLinksConfig) $

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -98,7 +98,10 @@ tests s =
       test s "SearchVisibilityInbound" $ testSimpleFlag @Public.SearchVisibilityInboundConfig Public.FeatureStatusDisabled,
       testGroup
         "Patch"
-        [ test s (unpack $ Public.featureNameBS @Public.FileSharingConfig) $
+        [ -- Note: SSOConfig, SearchVisibilityAvailableConfig,
+          -- ValidateSAMLEmailsConfig, DigitalSignaturesConfig cannot be tested
+          -- here, because their state can only be set once.
+          test s (unpack $ Public.featureNameBS @Public.FileSharingConfig) $
             testPatch @Public.FileSharingConfig Public.FeatureStatusEnabled Public.FileSharingConfig,
           test s (unpack $ Public.featureNameBS @Public.GuestLinksConfig) $
             testPatch @Public.GuestLinksConfig Public.FeatureStatusEnabled Public.GuestLinksConfig,

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -100,9 +100,10 @@ tests s =
       test s "SearchVisibilityInbound" $ testSimpleFlag @Public.SearchVisibilityInboundConfig Public.FeatureStatusDisabled,
       testGroup
         "Patch"
-        [ -- Note:
-          -- ValidateSAMLEmailsConfig, DigitalSignaturesConfig cannot be tested
-          -- here, because their state can only be set once.
+        [
+          -- Note: `SSOConfig` and `LegalHoldConfig` may not be able to be reset
+          -- (depending on prior state). Thus, they cannot be tested here
+          -- (setting random values), but are tested with separate tests.
           test s (unpack $ Public.featureNameBS @Public.SearchVisibilityAvailableConfig) $
             testPatchIgnoreLockStatusChange @Public.SearchVisibilityAvailableConfig Public.FeatureStatusEnabled Public.SearchVisibilityAvailableConfig,
           test s (unpack $ Public.featureNameBS @Public.ValidateSAMLEmailsConfig) $
@@ -135,8 +136,8 @@ validMLSConfigArbitrary =
                    Just (Public.MLSConfig us _ cTags ctag) -> sortedAndNoDuplicates us && sortedAndNoDuplicates cTags && elem ctag cTags
                    _ -> True
                )
-    where
-      sortedAndNoDuplicates xs = (sort . nub) xs == xs
+  where
+    sortedAndNoDuplicates xs = (sort . nub) xs == xs
 
 testPatchValidMLSConfig ::
   Public.FeatureStatus ->

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -113,6 +113,8 @@ tests s =
             testPatchValidAppLockConfig Public.FeatureStatusEnabled (Public.AppLockConfig (Public.EnforceAppLock False) 42),
           test s (unpack $ Public.featureNameBS @Public.ConferenceCallingConfig) $
             testPatchIgnoreLockStatusChange @Public.ConferenceCallingConfig Public.FeatureStatusEnabled Public.ConferenceCallingConfig,
+          test s (unpack $ Public.featureNameBS @Public.SearchVisibilityAvailableConfig) $
+            testPatchIgnoreLockStatusChange @Public.SearchVisibilityAvailableConfig Public.FeatureStatusEnabled Public.SearchVisibilityAvailableConfig,
           test s (unpack $ Public.featureNameBS @Public.FileSharingConfig) $
             testPatch @Public.FileSharingConfig Public.FeatureStatusEnabled Public.FileSharingConfig,
           test s (unpack $ Public.featureNameBS @Public.GuestLinksConfig) $

--- a/services/galley/test/integration/API/Util/TeamFeature.hs
+++ b/services/galley/test/integration/API/Util/TeamFeature.hs
@@ -62,15 +62,6 @@ putTeamSearchVisibilityAvailableInternal g tid statusValue =
       (Public.WithStatusNoLock statusValue Public.SearchVisibilityAvailableConfig)
       Public.FeatureTTLUnlimited
 
-putLegalHoldEnabledInternal' ::
-  HasCallStack =>
-  (Request -> Request) ->
-  TeamId ->
-  Public.FeatureStatus ->
-  TestM ()
-putLegalHoldEnabledInternal' g tid statusValue =
-  void $ putTeamFeatureFlagInternal @Public.LegalholdConfig g tid (Public.WithStatusNoLock statusValue Public.LegalholdConfig)
-
 --------------------------------------------------------------------------------
 
 getTeamFeatureFlagInternal ::
@@ -277,6 +268,26 @@ patchFeatureStatusInternal tid reqBody = do
     galley
       . paths ["i", "teams", toByteString' tid, "features", Public.featureNameBS @cfg]
       . json reqBody
+
+patchFeatureStatusInternalWithMod ::
+  forall cfg.
+  ( HasCallStack,
+    Public.IsFeatureConfig cfg,
+    KnownSymbol (Public.FeatureSymbol cfg),
+    ToJSON Public.LockStatus,
+    ToSchema cfg
+  ) =>
+  (Request -> Request) ->
+  TeamId ->
+  Public.WithStatusPatch cfg ->
+  TestM ResponseLBS
+patchFeatureStatusInternalWithMod reqmod tid reqBody = do
+  galley <- view tsGalley
+  patch $
+    galley
+      . paths ["i", "teams", toByteString' tid, "features", Public.featureNameBS @cfg]
+      . json reqBody
+      . reqmod
 
 getGuestLinkStatus ::
   HasCallStack =>


### PR DESCRIPTION
This reflects a prior behavior that is used by Ibis. (They had issues because some features couldn't be `PATCH`ed anymore.) Additionally, it's more consistent when all setters can be called with PUT and PATCH.

## TODO

- [x] Manual test (does this even work?)
  - [x] `SSOConfig`
  - [x] `LegalholdConfig`
  - [x] `SearchVisibilityAvailableConfig`
  - [x] `ValidateSAMLEmailsConfig`
  - [x] `DigitalSignaturesConfig`
  - [x] `AppLockConfig`
  - [x] `ConferenceCallingConfig`
  - [x] `SearchVisibilityInboundConfig`
  - [x] `MLSConfig`
  - [x] `SearchVisibilityInboundConfig`

- [x] Add integration test(s) (if possible). This may be harder than it sounds as many flags cannot be reset. (How to get a clean test setup then?)
  - [x] `SSOConfig`
  - [x] `LegalholdConfig`
  - [x] `SearchVisibilityAvailableConfig`
  - [x] `ValidateSAMLEmailsConfig`
  - [x] `DigitalSignaturesConfig`
  - [x] `AppLockConfig`
  - [x] `ConferenceCallingConfig`
  - [x] `SearchVisibilityInboundConfig`
  - [x] `MLSConfig`
  - [x] `SearchVisibilityInboundConfig`

## Checklist

 - [X] The **PR Title** explains the impact of the change.
 - [X] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [X] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [X] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [X] If internal end-points have been added or changed: which services have to be deployed in a specific order?
