### PR TITLE
SQCORE-1166: Port Brig SearchAPI and UserRichInfo endpoints to Servant

### DIFF
--- a/changelog.d/5-internal/more-brig-api
+++ b/changelog.d/5-internal/more-brig-api
@@ -1,0 +1,1 @@
+Port Brig SearchAPI and UserRichInfo endpoints to Servant

--- a/libs/wire-api/src/Wire/API/Error/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Error/Brig.hs
@@ -63,6 +63,7 @@ data BrigError
   | ChangePasswordMustDiffer
   | PasswordAuthenticationFailed
   | TooManyTeamInvitations
+  | InsufficientTeamPermissions
 
 instance KnownError (MapError e) => IsSwaggerError (e :: BrigError) where
   addToSwagger = addStaticErrorToSwagger @(MapError e)
@@ -169,3 +170,5 @@ type instance MapError 'ChangePasswordMustDiffer = 'StaticError 409 "password-mu
 type instance MapError 'PasswordAuthenticationFailed = 'StaticError 403 "password-authentication-failed" "Password authentication failed."
 
 type instance MapError 'TooManyTeamInvitations = 'StaticError 403 "too-many-team-invitations" "Too many team invitations for this team"
+
+type instance MapError 'InsufficientTeamPermissions = 'StaticError 403 "insufficient-permissions" "Insufficient team permissions"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -920,7 +920,7 @@ type SearchAPI =
         :> MultiVerb
              'GET
              '[JSON]
-             '[]
+             '[Respond 200 "Search results" (SearchResult TeamContact)]
              (SearchResult TeamContact)
     )
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -51,9 +51,9 @@ import Wire.API.User hiding (NoIdentity)
 import Wire.API.User.Client
 import Wire.API.User.Client.Prekey
 import Wire.API.User.Handle
-import Wire.API.User.Search (Contact, SearchResult, RoleFilter, TeamUserSearchSortBy, TeamUserSearchSortOrder, TeamContact)
-import Wire.API.UserMap
 import Wire.API.User.RichInfo (RichInfoAssocList)
+import Wire.API.User.Search (Contact, RoleFilter, SearchResult, TeamContact, TeamUserSearchSortBy, TeamUserSearchSortOrder)
+import Wire.API.UserMap
 
 type MaxUsersForListClientsBulk = 500
 
@@ -192,20 +192,20 @@ type UserAPI =
                :> MultiVerb 'POST '[JSON] '[RespondEmpty 200 "Verification code sent."] ()
            )
     :<|> Named
-          "get-rich-info"
-          ( Summary "Get a user's rich info"
-              :> ZUser
-              :> "users"
-              :> CaptureUserId "uid"
-              :> "rich-info"
-              :> MultiVerb
-                  'GET
-                  '[JSON]
-                  '[ ErrorResponse 'UserNotFound,
-                    Respond 200 "User found" RichInfoAssocList
-                  ]
-                  (Maybe RichInfoAssocList)
-          )
+           "get-rich-info"
+           ( Summary "Get a user's rich info"
+               :> ZUser
+               :> "users"
+               :> CaptureUserId "uid"
+               :> "rich-info"
+               :> MultiVerb
+                    'GET
+                    '[JSON]
+                    '[ ErrorResponse 'UserNotFound,
+                       Respond 200 "User found" RichInfoAssocList
+                     ]
+                    (Maybe RichInfoAssocList)
+           )
 
 type SelfAPI =
   Named
@@ -883,40 +883,40 @@ type SearchAPI =
         :> Capture "tid" TeamId
         :> "search"
         :> QueryParam'
-            [ Optional,
-              Strict,
-              Description "Search expression"
-            ]
-            "q"
-            Text
+             [ Optional,
+               Strict,
+               Description "Search expression"
+             ]
+             "q"
+             Text
         :> QueryParam'
-            [ Optional,
-              Strict,
-              Description "Role filter, eg. `member,external-partner`.  Empty list means do not filter."
-            ]
-            "frole"
-            RoleFilter
+             [ Optional,
+               Strict,
+               Description "Role filter, eg. `member,external-partner`.  Empty list means do not filter."
+             ]
+             "frole"
+             RoleFilter
         :> QueryParam'
-            [ Optional,
-              Strict,
-              Description "Can be one of name, handle, email, saml_idp, managed_by, role, created_at."
-            ]
-            "sortby"
-            TeamUserSearchSortBy
+             [ Optional,
+               Strict,
+               Description "Can be one of name, handle, email, saml_idp, managed_by, role, created_at."
+             ]
+             "sortby"
+             TeamUserSearchSortBy
         :> QueryParam'
-            [ Optional,
-              Strict,
-              Description "Can be one of asc, desc."
-            ]
-            "sortorder"
-            TeamUserSearchSortOrder
+             [ Optional,
+               Strict,
+               Description "Can be one of asc, desc."
+             ]
+             "sortorder"
+             TeamUserSearchSortOrder
         :> QueryParam'
-            [ Optional,
-              Strict,
-              Description "Number of results to return (min: 1, max: 500, default: 15)"
-            ]
-            "size"
-            (Range 1 500 Int32)
+             [ Optional,
+               Strict,
+               Description "Number of results to return (min: 1, max: 500, default: 15)"
+             ]
+             "size"
+             (Range 1 500 Int32)
         :> MultiVerb
              'GET
              '[JSON]

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -51,7 +51,7 @@ import Wire.API.User hiding (NoIdentity)
 import Wire.API.User.Client
 import Wire.API.User.Client.Prekey
 import Wire.API.User.Handle
-import Wire.API.User.Search (Contact, SearchResult)
+import Wire.API.User.Search (Contact, SearchResult, RoleFilter, TeamUserSearchSortBy, TeamUserSearchSortOrder, TeamContact)
 import Wire.API.UserMap
 import Wire.API.User.RichInfo (RichInfoAssocList)
 
@@ -872,6 +872,58 @@ type MLSKeyPackageAPI =
                   )
        )
 
+-- Search API -----------------------------------------------------
+
+type SearchAPI =
+  Named
+    "browse-team"
+    ( Summary "Browse team for members (requires add-user permission)"
+        :> ZUser
+        :> "teams"
+        :> Capture "tid" TeamId
+        :> "search"
+        :> QueryParam'
+            [ Optional,
+              Strict,
+              Description "Search expression"
+            ]
+            "q"
+            Text
+        :> QueryParam'
+            [ Optional,
+              Strict,
+              Description "Role filter, eg. `member,external-partner`.  Empty list means do not filter."
+            ]
+            "frole"
+            RoleFilter
+        :> QueryParam'
+            [ Optional,
+              Strict,
+              Description "Can be one of name, handle, email, saml_idp, managed_by, role, created_at."
+            ]
+            "sortby"
+            TeamUserSearchSortBy
+        :> QueryParam'
+            [ Optional,
+              Strict,
+              Description "Can be one of asc, desc."
+            ]
+            "sortorder"
+            TeamUserSearchSortOrder
+        :> QueryParam'
+            [ Optional,
+              Strict,
+              Description "Number of results to return (min: 1, max: 500, default: 15)"
+            ]
+            "size"
+            (Range 1 500 Int32)
+        :> MultiVerb
+             'GET
+             '[JSON]
+             '[]
+             (SearchResult TeamContact)
+    )
+
 type MLSAPI = LiftNamed (ZLocalUser :> "mls" :> MLSKeyPackageAPI)
 
 type BrigAPI =
@@ -885,6 +937,7 @@ type BrigAPI =
     :<|> PropertiesAPI
     :<|> MLSAPI
     :<|> UserHandleAPI
+    :<|> SearchAPI
 
 brigSwagger :: Swagger
 brigSwagger = toSwagger (Proxy @BrigAPI)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -53,6 +53,7 @@ import Wire.API.User.Client.Prekey
 import Wire.API.User.Handle
 import Wire.API.User.Search (Contact, SearchResult)
 import Wire.API.UserMap
+import Wire.API.User.RichInfo (RichInfoAssocList)
 
 type MaxUsersForListClientsBulk = 500
 
@@ -190,6 +191,21 @@ type UserAPI =
                :> ReqBody '[JSON] SendVerificationCode
                :> MultiVerb 'POST '[JSON] '[RespondEmpty 200 "Verification code sent."] ()
            )
+    :<|> Named
+          "get-rich-info"
+          ( Summary "Get a user's rich info"
+              :> ZUser
+              :> "users"
+              :> CaptureUserId "uid"
+              :> "rich-info"
+              :> MultiVerb
+                  'GET
+                  '[JSON]
+                  '[ ErrorResponse 'UserNotFound,
+                    Respond 200 "User found" RichInfoAssocList
+                  ]
+                  (Maybe RichInfoAssocList)
+          )
 
 type SelfAPI =
   Named

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -194,6 +194,7 @@ type UserAPI =
     :<|> Named
            "get-rich-info"
            ( Summary "Get a user's rich info"
+               :> CanThrow 'InsufficientTeamPermissions
                :> ZUser
                :> "users"
                :> CaptureUserId "uid"

--- a/libs/wire-api/src/Wire/API/Team/Role.hs
+++ b/libs/wire-api/src/Wire/API/Team/Role.hs
@@ -27,17 +27,17 @@ module Wire.API.Team.Role
 where
 
 import qualified Cassandra as Cql
+import Control.Lens ((?~))
 import Data.Aeson
 import Data.Attoparsec.ByteString.Char8 (string)
 import Data.ByteString.Builder (toLazyByteString)
 import Data.ByteString.Conversion (FromByteString (..), ToByteString (..))
 import Data.ByteString.Conversion.From (runParser)
 import Data.String.Conversions (cs)
+import qualified Data.Swagger as S
 import qualified Data.Swagger.Model.Api as Doc
 import Imports
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
-import qualified Data.Swagger as S
-import Control.Lens ((?~))
 
 -- Note [team roles]
 -- ~~~~~~~~~~~~
@@ -82,9 +82,10 @@ data Role = RoleOwner | RoleAdmin | RoleMember | RoleExternalPartner
   deriving (Arbitrary) via (GenericUniform Role)
 
 instance S.ToParamSchema Role where
-  toParamSchema _ = mempty
-    & S.type_ ?~ S.SwaggerString
-    & S.enum_ ?~ ["RoleOwner", "RoleAdmin", "RoleMember", "RoleExternalPartner"]
+  toParamSchema _ =
+    mempty
+      & S.type_ ?~ S.SwaggerString
+      & S.enum_ ?~ ["RoleOwner", "RoleAdmin", "RoleMember", "RoleExternalPartner"]
 
 typeRole :: Doc.DataType
 typeRole =

--- a/libs/wire-api/src/Wire/API/Team/Role.hs
+++ b/libs/wire-api/src/Wire/API/Team/Role.hs
@@ -36,6 +36,8 @@ import Data.String.Conversions (cs)
 import qualified Data.Swagger.Model.Api as Doc
 import Imports
 import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
+import qualified Data.Swagger as S
+import Control.Lens ((?~))
 
 -- Note [team roles]
 -- ~~~~~~~~~~~~
@@ -78,6 +80,11 @@ import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 data Role = RoleOwner | RoleAdmin | RoleMember | RoleExternalPartner
   deriving stock (Eq, Show, Enum, Bounded, Generic)
   deriving (Arbitrary) via (GenericUniform Role)
+
+instance S.ToParamSchema Role where
+  toParamSchema _ = mempty
+    & S.type_ ?~ S.SwaggerString
+    & S.enum_ ?~ ["RoleOwner", "RoleAdmin", "RoleMember", "RoleExternalPartner"]
 
 typeRole :: Doc.DataType
 typeRole =

--- a/libs/wire-api/src/Wire/API/User/RichInfo.hs
+++ b/libs/wire-api/src/Wire/API/User/RichInfo.hs
@@ -46,7 +46,7 @@ module Wire.API.User.RichInfo
   )
 where
 
-import Data.Aeson
+import qualified Data.Aeson as A
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Types as Aeson
@@ -61,6 +61,8 @@ import qualified Data.Text as Text
 import Imports
 import qualified Test.QuickCheck as QC
 import Wire.API.Arbitrary (Arbitrary (arbitrary))
+import Data.Schema
+import qualified Data.Swagger.Internal.Schema as S
 
 --------------------------------------------------------------------------------
 -- RichInfo
@@ -69,11 +71,11 @@ import Wire.API.Arbitrary (Arbitrary (arbitrary))
 newtype RichInfo = RichInfo {unRichInfo :: RichInfoAssocList}
   deriving stock (Eq, Show, Generic)
 
-instance ToJSON RichInfo where
-  toJSON = toJSON . fromRichInfoAssocList . unRichInfo
+instance A.ToJSON RichInfo where
+  toJSON = A.toJSON . fromRichInfoAssocList . unRichInfo
 
-instance FromJSON RichInfo where
-  parseJSON = fmap (RichInfo . toRichInfoAssocList) . parseJSON
+instance A.FromJSON RichInfo where
+  parseJSON = fmap (RichInfo . toRichInfoAssocList) . A.parseJSON
 
 instance Arbitrary RichInfo where
   arbitrary = RichInfo <$> arbitrary
@@ -156,23 +158,23 @@ modelRichInfo = Doc.defineModel "RichInfo" $ do
   Doc.property "version" Doc.int32' $
     Doc.description "Format version (the current version is 0)"
 
-instance ToJSON RichInfoMapAndList where
+instance A.ToJSON RichInfoMapAndList where
   toJSON u =
-    object
+    A.object
       [ Key.fromText richInfoAssocListURN
-          .= object
+          A..= A.object
             [ "richInfo"
-                .= object
-                  [ "fields" .= richInfoAssocList u,
-                    "version" .= (0 :: Int)
+                A..= A.object
+                  [ "fields" A..= richInfoAssocList u,
+                    "version" A..= (0 :: Int)
                   ]
             ],
-        Key.fromText richInfoMapURN .= Map.mapKeys CI.original (richInfoMap u)
+        Key.fromText richInfoMapURN A..= Map.mapKeys CI.original (richInfoMap u)
       ]
 
-instance FromJSON RichInfoMapAndList where
+instance A.FromJSON RichInfoMapAndList where
   parseJSON =
-    withObject "RichInfo" $
+    A.withObject "RichInfo" $
       \o ->
         let objWithCIKeys = mapKeys CI.mk (KeyMap.toMapText o)
          in normalizeRichInfoMapAndList
@@ -181,25 +183,25 @@ instance FromJSON RichInfoMapAndList where
                       <*> extractAssocList objWithCIKeys
                   )
     where
-      extractMap :: Map (CI Text) Value -> Aeson.Parser (Map (CI Text) Text)
+      extractMap :: Map (CI Text) A.Value -> Aeson.Parser (Map (CI Text) Text)
       extractMap o =
         case Map.lookup (CI.mk richInfoMapURN) o of
           Nothing -> pure mempty
           Just innerObj -> do
-            Map.mapKeys CI.mk <$> parseJSON innerObj
+            Map.mapKeys CI.mk <$> A.parseJSON innerObj
 
-      extractAssocList :: Map (CI Text) Value -> Aeson.Parser [RichField]
+      extractAssocList :: Map (CI Text) A.Value -> Aeson.Parser [RichField]
       extractAssocList o =
         case Map.lookup (CI.mk richInfoAssocListURN) o of
           Nothing -> pure []
-          Just (Object innerObj) -> do
+          Just (A.Object innerObj) -> do
             richInfo <- lookupOrFail "richinfo" $ mapKeys CI.mk (KeyMap.toMapText innerObj)
             case richInfo of
-              Object richinfoObj -> do
+              A.Object richinfoObj -> do
                 richInfoAssocListFromObject richinfoObj
-              Array fields -> parseJSON (Array fields)
-              v -> Aeson.typeMismatch "Object or Array" v
-          Just v -> Aeson.typeMismatch "Object" v
+              A.Array fields -> A.parseJSON (A.Array fields)
+              v -> Aeson.typeMismatch "A.Object or A.Array" v
+          Just v -> Aeson.typeMismatch "A.Object" v
 
       mapKeys :: (Eq k2, Ord k2) => (k1 -> k2) -> Map k1 v -> Map k2 v
       mapKeys f = Map.fromList . map (Data.Bifunctor.first f) . Map.toList
@@ -222,6 +224,7 @@ richInfoAssocListURN = "urn:wire:scim:schemas:profile:1.0"
 
 newtype RichInfoAssocList = RichInfoAssocList {unRichInfoAssocList :: [RichField]}
   deriving stock (Eq, Show, Generic)
+  deriving (A.ToJSON, A.FromJSON, S.ToSchema) via (Schema RichInfoAssocList)
 
 -- | Uses 'normalizeRichInfoAssocList'.
 mkRichInfoAssocList :: [RichField] -> RichInfoAssocList
@@ -242,22 +245,25 @@ instance Monoid RichInfoAssocList where
 instance Semigroup RichInfoAssocList where
   RichInfoAssocList a <> RichInfoAssocList b = RichInfoAssocList $ a <> b
 
-instance ToJSON RichInfoAssocList where
-  toJSON (RichInfoAssocList l) =
-    object
-      [ "fields" .= l,
-        "version" .= (0 :: Int)
-      ]
+instance ToSchema RichInfoAssocList where
+  schema =
+    object "RichInfoAssocList" $
+      withParser
+        ((,)
+          <$> const (0 :: Int) .= field  "version" schema
+          <*> unRichInfoAssocList .= field "fields" (array schema)
+        ) $ \(version, fields) ->
+          mkRichInfoAssocList <$> validateRichInfoAssocList version fields
 
-instance FromJSON RichInfoAssocList where
-  parseJSON v =
-    mkRichInfoAssocList <$> withObject "RichInfoAssocList" richInfoAssocListFromObject v
-
-richInfoAssocListFromObject :: Object -> Aeson.Parser [RichField]
+richInfoAssocListFromObject :: A.Object -> Aeson.Parser [RichField]
 richInfoAssocListFromObject richinfoObj = do
-  version :: Int <- richinfoObj .: "version"
+  version :: Int <- richinfoObj A..: "version"
+  fields <- richinfoObj A..: "fields"
+  validateRichInfoAssocList version fields
+
+validateRichInfoAssocList :: Int -> [RichField] -> Aeson.Parser [RichField]
+validateRichInfoAssocList version fields = do
   when (version /= 0) $ fail $ "unknown version: " <> show version
-  fields <- richinfoObj .: "fields"
   checkDuplicates (map richFieldType fields)
   pure fields
   where
@@ -279,6 +285,7 @@ data RichField = RichField
     richFieldValue :: Text
   }
   deriving stock (Eq, Show, Generic)
+  deriving (A.ToJSON, A.FromJSON) via (Schema RichField)
 
 modelRichField :: Doc.Model
 modelRichField = Doc.defineModel "RichField" $ do
@@ -288,22 +295,16 @@ modelRichField = Doc.defineModel "RichField" $ do
   Doc.property "value" Doc.string' $
     Doc.description "Field value"
 
-instance ToJSON RichField where
+instance ToSchema RichField where
   -- NB: "name" would be a better name for 'richFieldType', but "type" is used because we
   -- also have "type" in SCIM; and the reason we use "type" for SCIM is that @{"type": ...,
   -- "value": ...}@ is how all other SCIM payloads are formatted, so it's quite possible
   -- that some provisioning agent would support "type" but not "name".
-  toJSON u =
-    object
-      [ "type" .= CI.original (richFieldType u),
-        "value" .= richFieldValue u
-      ]
-
-instance FromJSON RichField where
-  parseJSON = withObject "RichField" $ \o -> do
-    RichField
-      <$> (CI.mk <$> o .: "type")
-      <*> o .: "value"
+  schema =
+    object "RichField" $
+      RichField
+        <$> richFieldType .= field "type" (CI.original .= fmap CI.mk schema)
+        <*> richFieldValue .= field "value" schema
 
 instance Arbitrary RichField where
   arbitrary =

--- a/libs/wire-api/src/Wire/API/User/RichInfo.hs
+++ b/libs/wire-api/src/Wire/API/User/RichInfo.hs
@@ -55,14 +55,14 @@ import Data.CaseInsensitive (CI)
 import qualified Data.CaseInsensitive as CI
 import Data.List.Extra (nubOrdOn)
 import qualified Data.Map as Map
+import Data.Schema
 import Data.String.Conversions (cs)
 import qualified Data.Swagger.Build.Api as Doc
+import qualified Data.Swagger.Internal.Schema as S
 import qualified Data.Text as Text
 import Imports
 import qualified Test.QuickCheck as QC
 import Wire.API.Arbitrary (Arbitrary (arbitrary))
-import Data.Schema
-import qualified Data.Swagger.Internal.Schema as S
 
 --------------------------------------------------------------------------------
 -- RichInfo
@@ -249,10 +249,11 @@ instance ToSchema RichInfoAssocList where
   schema =
     object "RichInfoAssocList" $
       withParser
-        ((,)
-          <$> const (0 :: Int) .= field  "version" schema
-          <*> unRichInfoAssocList .= field "fields" (array schema)
-        ) $ \(version, fields) ->
+        ( (,)
+            <$> const (0 :: Int) .= field "version" schema
+            <*> unRichInfoAssocList .= field "fields" (array schema)
+        )
+        $ \(version, fields) ->
           mkRichInfoAssocList <$> validateRichInfoAssocList version fields
 
 richInfoAssocListFromObject :: A.Object -> Aeson.Parser [RichField]

--- a/libs/wire-api/src/Wire/API/User/Search.hs
+++ b/libs/wire-api/src/Wire/API/User/Search.hs
@@ -44,6 +44,7 @@ import Data.Attoparsec.ByteString.Char8 (char, string)
 import Data.ByteString.Conversion (FromByteString (..), ToByteString (..))
 import Data.Id (TeamId, UserId)
 import Data.Json.Util (UTCTimeMillis)
+import Data.Proxy
 import Data.Qualified
 import Data.Schema
 import qualified Data.Swagger as S
@@ -53,7 +54,6 @@ import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import Wire.API.Team.Role (Role)
 import Wire.API.User (ManagedBy)
 import Wire.API.User.Identity (Email (..))
-import Data.Proxy
 
 --------------------------------------------------------------------------------
 -- SearchResult
@@ -292,9 +292,10 @@ data TeamUserSearchSortBy
   deriving (Arbitrary) via (GenericUniform TeamUserSearchSortBy)
 
 instance S.ToParamSchema TeamUserSearchSortBy where
-  toParamSchema _ = mempty
-    & S.type_ ?~ S.SwaggerString
-    & S.enum_ ?~ ["name", "handle", "email", "saml_idp", "managed_by", "role", "created_at"]
+  toParamSchema _ =
+    mempty
+      & S.type_ ?~ S.SwaggerString
+      & S.enum_ ?~ ["name", "handle", "email", "saml_idp", "managed_by", "role", "created_at"]
 
 instance ToByteString TeamUserSearchSortBy where
   builder SortByName = "name"
@@ -322,9 +323,10 @@ data TeamUserSearchSortOrder
   deriving (Arbitrary) via (GenericUniform TeamUserSearchSortOrder)
 
 instance S.ToParamSchema TeamUserSearchSortOrder where
-  toParamSchema _ = mempty
-    & S.type_ ?~ S.SwaggerString
-    & S.enum_ ?~ ["asc", "desc"]
+  toParamSchema _ =
+    mempty
+      & S.type_ ?~ S.SwaggerString
+      & S.enum_ ?~ ["asc", "desc"]
 
 instance ToByteString TeamUserSearchSortOrder where
   builder SortOrderAsc = "asc"

--- a/libs/wire-api/src/Wire/API/User/Search.hs
+++ b/libs/wire-api/src/Wire/API/User/Search.hs
@@ -53,6 +53,7 @@ import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 import Wire.API.Team.Role (Role)
 import Wire.API.User (ManagedBy)
 import Wire.API.User.Identity (Email (..))
+import Data.Proxy
 
 --------------------------------------------------------------------------------
 -- SearchResult
@@ -290,6 +291,11 @@ data TeamUserSearchSortBy
   deriving (Show, Eq, Ord, Generic)
   deriving (Arbitrary) via (GenericUniform TeamUserSearchSortBy)
 
+instance S.ToParamSchema TeamUserSearchSortBy where
+  toParamSchema _ = mempty
+    & S.type_ ?~ S.SwaggerString
+    & S.enum_ ?~ ["name", "handle", "email", "saml_idp", "managed_by", "role", "created_at"]
+
 instance ToByteString TeamUserSearchSortBy where
   builder SortByName = "name"
   builder SortByHandle = "handle"
@@ -315,6 +321,11 @@ data TeamUserSearchSortOrder
   deriving (Show, Eq, Ord, Generic)
   deriving (Arbitrary) via (GenericUniform TeamUserSearchSortOrder)
 
+instance S.ToParamSchema TeamUserSearchSortOrder where
+  toParamSchema _ = mempty
+    & S.type_ ?~ S.SwaggerString
+    & S.enum_ ?~ ["asc", "desc"]
+
 instance ToByteString TeamUserSearchSortOrder where
   builder SortOrderAsc = "asc"
   builder SortOrderDesc = "desc"
@@ -327,6 +338,9 @@ instance FromByteString TeamUserSearchSortOrder where
 newtype RoleFilter = RoleFilter [Role]
   deriving (Show, Eq, Generic)
   deriving (Arbitrary) via (GenericUniform RoleFilter)
+
+instance S.ToParamSchema RoleFilter where
+  toParamSchema _ = S.toParamSchema (Proxy @[Role])
 
 instance ToByteString RoleFilter where
   builder (RoleFilter roles) = mconcat $ intersperse "," (fmap builder roles)

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -478,9 +478,9 @@ test-suite wire-api-golden-tests
       Test.Wire.API.Golden.Generated.VerifyDeleteUser_user
       Test.Wire.API.Golden.Generated.ViewLegalHoldService_team
       Test.Wire.API.Golden.Generated.ViewLegalHoldServiceInfo_team
-      Test.Wire.API.Golden.Generated.WithStatusPatch_team
       Test.Wire.API.Golden.Generated.WithStatus_team
       Test.Wire.API.Golden.Generated.WithStatusNoLock_team
+      Test.Wire.API.Golden.Generated.WithStatusPatch_team
       Test.Wire.API.Golden.Generated.Wrapped_20_22some_5fint_22_20Int_user
       Test.Wire.API.Golden.Manual
       Test.Wire.API.Golden.Manual.ClientCapability

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -364,7 +364,7 @@ authTokenUnsupported = Wai.mkError status403 "invalid-credentials" "Unsupported 
 --
 -- * Requested action can't be performed if the user is the only team owner left in the team.
 insufficientTeamPermissions :: Wai.Error
-insufficientTeamPermissions = Wai.mkError status403 "insufficient-permissions" "Insufficient team permissions"
+insufficientTeamPermissions = errorToWai @'E.TooManyClients
 
 noBindingTeam :: Wai.Error
 noBindingTeam = Wai.mkError status403 "no-binding-team" "Operation allowed only on binding teams"

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -55,6 +55,7 @@ import Brig.Types.Intra (AccountStatus (Ephemeral), UserAccount (UserAccount, ac
 import Brig.Types.User (HavePendingInvitations (..))
 import qualified Brig.User.API.Auth as Auth
 import qualified Brig.User.API.Handle as Handle
+import Brig.User.API.Search (teamUserSearch)
 import qualified Brig.User.API.Search as Search
 import qualified Brig.User.Auth.Cookie as Auth
 import Brig.User.Email
@@ -131,7 +132,6 @@ import qualified Wire.API.User.Password as Public
 import qualified Wire.API.User.RichInfo as Public
 import qualified Wire.API.UserMap as Public
 import qualified Wire.API.Wrapped as Public
-import Brig.User.API.Search (teamUserSearch)
 
 -- User API -----------------------------------------------------------
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -131,6 +131,7 @@ import qualified Wire.API.User.Password as Public
 import qualified Wire.API.User.RichInfo as Public
 import qualified Wire.API.UserMap as Public
 import qualified Wire.API.Wrapped as Public
+import Brig.User.API.Search (teamUserSearch)
 
 -- User API -----------------------------------------------------------
 
@@ -180,7 +181,7 @@ swaggerDocsAPI (Just V1) =
 swaggerDocsAPI Nothing = swaggerDocsAPI (Just maxBound)
 
 servantSitemap :: ServerT BrigAPI (Handler r)
-servantSitemap = userAPI :<|> selfAPI :<|> accountAPI :<|> clientAPI :<|> prekeyAPI :<|> userClientAPI :<|> connectionAPI :<|> propertiesAPI :<|> mlsAPI :<|> userHandleAPI
+servantSitemap = userAPI :<|> selfAPI :<|> accountAPI :<|> clientAPI :<|> prekeyAPI :<|> userClientAPI :<|> connectionAPI :<|> propertiesAPI :<|> mlsAPI :<|> userHandleAPI :<|> searchAPI
   where
     userAPI :: ServerT UserAPI (Handler r)
     userAPI =
@@ -271,6 +272,10 @@ servantSitemap = userAPI :<|> selfAPI :<|> accountAPI :<|> clientAPI :<|> prekey
     userHandleAPI =
       Named @"check-user-handles" checkHandles
         :<|> Named @"check-user-handle" checkHandle
+
+    searchAPI :: ServerT SearchAPI (Handler r)
+    searchAPI =
+      Named @"browse-team" teamUserSearch
 
 -- Note [ephemeral user sideeffect]
 -- If the user is ephemeral and expired, it will be removed upon calling
@@ -399,7 +404,6 @@ sitemap = do
 
   Provider.routesPublic
   Auth.routesPublic
-  Search.routesPublic
   Team.routesPublic
   Calling.routesPublic
 

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -16,9 +16,9 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Brig.User.API.Search
-  ( routesPublic,
-    routesInternal,
+  ( routesInternal,
     search,
+    teamUserSearch,
   )
 where
 
@@ -41,14 +41,10 @@ import Data.Handle (parseHandle)
 import Data.Id
 import Data.Predicate
 import Data.Range
-import qualified Data.Swagger.Build.Api as Doc
 import Imports
-import Network.Wai (Response)
-import Network.Wai.Predicate hiding (setStatus)
 import Network.Wai.Routing
 import Network.Wai.Utilities ((!>>))
-import Network.Wai.Utilities.Response (empty, json)
-import Network.Wai.Utilities.Swagger (document)
+import Network.Wai.Utilities.Response (empty)
 import System.Logger (field, msg)
 import System.Logger.Class (val, (~~))
 import qualified System.Logger.Class as Log
@@ -58,40 +54,6 @@ import qualified Wire.API.Team.Permission as Public
 import Wire.API.Team.SearchVisibility (TeamSearchVisibility (..))
 import Wire.API.User.Search
 import qualified Wire.API.User.Search as Public
-
-routesPublic :: Routes Doc.ApiBuilder (Handler r) ()
-routesPublic = do
-  get "/teams/:tid/search" (continue teamUserSearchH) $
-    accept "application" "json"
-      .&. header "Z-User"
-      .&. capture "tid"
-      .&. opt (query "q")
-      .&. opt (query "frole")
-      .&. opt (query "sortby")
-      .&. opt (query "sortorder")
-      .&. def (unsafeRange 15) (query "size")
-
-  document "GET" "browse team" $ do
-    Doc.summary "Browse team for members (requires add-user permission)"
-    Doc.parameter Doc.Path "tid" Doc.bytes' $
-      Doc.description "ID of the team to be browsed"
-    Doc.parameter Doc.Query "q" Doc.string' $ do
-      Doc.description "Search expression"
-      Doc.optional
-    Doc.parameter Doc.Query "frole" Doc.string' $ do
-      Doc.description "Role filter, eg. `member,external-partner`.  Empty list means do not filter."
-      Doc.optional
-    Doc.parameter Doc.Query "sortby" Doc.string' $ do
-      Doc.description "Can be one of name, handle, email, saml_idp, managed_by, role, created_at."
-      Doc.optional
-    Doc.parameter Doc.Query "sortorder" Doc.string' $ do
-      Doc.description "Can be one of asc, desc."
-      Doc.optional
-    Doc.parameter Doc.Query "size" Doc.int32' $ do
-      Doc.description "Number of results to return (min: 1, max: 500, default: 15)"
-      Doc.optional
-    Doc.returns (Doc.ref $ Public.modelSearchResult Public.modelTeamContact)
-    Doc.response 200 "The list of hits." Doc.end
 
 routesInternal :: Routes a (Handler r) ()
 routesInternal = do
@@ -196,20 +158,6 @@ searchLocally searcherId searchTerm maybeMaxResults = do
           HandleAPI.contactFromProfile
             <$$> HandleAPI.getLocalHandleInfo lsearcherId handle
 
-teamUserSearchH ::
-  ( JSON
-      ::: UserId
-      ::: TeamId
-      ::: Maybe Text
-      ::: Maybe RoleFilter
-      ::: Maybe TeamUserSearchSortBy
-      ::: Maybe TeamUserSearchSortOrder
-      ::: Range 1 500 Int32
-  ) ->
-  (Handler r) Response
-teamUserSearchH (_ ::: uid ::: tid ::: mQuery ::: mRoleFilter ::: mSortBy ::: mSortOrder ::: size) = do
-  json <$> teamUserSearch uid tid mQuery mRoleFilter mSortBy mSortOrder size
-
 teamUserSearch ::
   UserId ->
   TeamId ->
@@ -217,8 +165,8 @@ teamUserSearch ::
   Maybe RoleFilter ->
   Maybe TeamUserSearchSortBy ->
   Maybe TeamUserSearchSortOrder ->
-  Range 1 500 Int32 ->
+  Maybe (Range 1 500 Int32) ->
   (Handler r) (Public.SearchResult Public.TeamContact)
 teamUserSearch uid tid mQuery mRoleFilter mSortBy mSortOrder size = do
   ensurePermissions uid tid [Public.AddTeamMember] -- limit this to team admins to reduce risk of involuntary DOS attacks.  (also, this way we don't need to worry about revealing confidential user data to other team members.)
-  Q.teamUserSearch tid mQuery mRoleFilter mSortBy mSortOrder size
+  Q.teamUserSearch tid mQuery mRoleFilter mSortBy mSortOrder $ fromMaybe (unsafeRange 15) size


### PR DESCRIPTION
This PR finishes the work on [SQCORE-1166](https://wearezeta.atlassian.net/browse/SQCORE-1166), porting miscellaneous brig endpoints to servant.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.