### PR TITLE
charts/nginz: allow larger client requests.

### DIFF
--- a/changelog.d/3-bug-fixes/larger-client-requests
+++ b/changelog.d/3-bug-fixes/larger-client-requests
@@ -1,0 +1,1 @@
+Fix an issue for larger client requests on e.g. /list-users and /list-conversations, which were giving 413 errors for some users. See https://wearezeta.atlassian.net/browse/SQPIT-1044 Allow client requests of 256k by default (was 64k).

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -283,7 +283,7 @@ http {
             {{- if (hasKey $location "body_buffer_size") }}
         client_body_buffer_size {{ $location.body_buffer_size -}};
             {{- end }}
-        client_max_body_size {{ $location.max_body_size | default "64k" }};
+        client_max_body_size {{ $location.max_body_size | default "256k" }};
 
             {{ if ($location.use_websockets) }}
         proxy_set_header   Upgrade        $http_upgrade;

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -492,7 +492,6 @@ nginx_conf:
       - all
     spar:
     - path: /identity-providers
-      max_body_size: 256k
       envs:
       - all
     - path: /i/sso


### PR DESCRIPTION
Fix an issue for larger client requests on e.g. /list-users and /list-conversations, which were giving 413 errors for some users. 
See https://wearezeta.atlassian.net/browse/SQPIT-1044 
Allow client requests of 256k by default (was 64k).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
