### PR TITLE
do rate limiting exemptions by proxy_protocol_ip

### DIFF
--- a/changelog.d/3-bug-fixes/nginz-rate-limit-exemptions
+++ b/changelog.d/3-bug-fixes/nginz-rate-limit-exemptions
@@ -1,0 +1,1 @@
+charts/nginz: rate limit exemptions should be by comparing with proxy_protocol_addr

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -93,7 +93,7 @@ http {
   # Rate Limiting Exemptions
   #
 
-  geo $rate_limit {
+  geo $proxy_protocol_addr $rate_limit {
       default 1;
 
   # IPs to exempt can be added in the .Values.nginx_conf.rate_limit and .Values.nginx_conf.simulators helm values


### PR DESCRIPTION
Previous place we did this was in https://github.com/zinfra/cailleach/pull/726/commits/6f10bf407915a2f07e849007f181a723660eac9f as part of https://github.com/zinfra/cailleach/pull/726

We are in general lacking tests for these issues. Anyone has ideas on how to test this to avoid regressions?