### PR TITLE
[FS-794] MLS: Delete Expired Key Packages

### DIFF
--- a/changelog.d/2-features/expired-key-packages
+++ b/changelog.d/2-features/expired-key-packages
@@ -1,0 +1,1 @@
+Expired MLS key packages are deleted from the database

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -478,9 +478,9 @@ test-suite wire-api-golden-tests
       Test.Wire.API.Golden.Generated.VerifyDeleteUser_user
       Test.Wire.API.Golden.Generated.ViewLegalHoldService_team
       Test.Wire.API.Golden.Generated.ViewLegalHoldServiceInfo_team
-      Test.Wire.API.Golden.Generated.WithStatusPatch_team
       Test.Wire.API.Golden.Generated.WithStatus_team
       Test.Wire.API.Golden.Generated.WithStatusNoLock_team
+      Test.Wire.API.Golden.Generated.WithStatusPatch_team
       Test.Wire.API.Golden.Generated.Wrapped_20_22some_5fint_22_20Int_user
       Test.Wire.API.Golden.Manual
       Test.Wire.API.Golden.Manual.ClientCapability

--- a/nix/pkgs/mls_test_cli/default.nix
+++ b/nix/pkgs/mls_test_cli/default.nix
@@ -15,8 +15,8 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "wireapp";
     repo = "mls-test-cli";
-    rev = "6f5c0a871dac63e4a656fc5b8fd72875bb023b4b";
-    sha256 = "sha256:1ah72kbhakp0sqkjark20912yf8ain3yjj5f76sa3vzqgfmvwahq";
+    sha256 = "sha256:0f3d9dhnxf0nx9vz9hrfhx1lkash5891wxz2163widw5nra66cvi";
+    rev = "14963eb639847f9ab9ff62c0660d02899935e776";
   };
   doCheck = false;
   cargoSha256 = "sha256:1cwyzn5gwzdb92k1b02yzpj1mv9x8vnx329v54qsm089nq5drp11";

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -537,6 +537,7 @@ executable brig-integration
     , temporary >=1.2.1
     , text
     , time >=1.5
+    , timeout
     , tinylog
     , transformers
     , types-common >=0.3

--- a/services/brig/package.yaml
+++ b/services/brig/package.yaml
@@ -261,6 +261,7 @@ executables:
     - temporary >=1.2.1
     - text
     - time >=1.5
+    - timeout
     - tinylog
     - transformers
     - types-common >=0.3

--- a/services/brig/src/Brig/API/MLS/KeyPackages.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages.hs
@@ -122,4 +122,4 @@ countKeyPackages :: Local UserId -> ClientId -> Handler r KeyPackageCount
 countKeyPackages lusr c =
   lift $
     KeyPackageCount . fromIntegral
-      <$> wrapClient (Data.countKeyPackages (tUnqualified lusr) c)
+      <$> wrapClient (Data.countKeyPackages lusr c)

--- a/services/brig/src/Brig/API/MLS/KeyPackages/Validation.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages/Validation.hs
@@ -18,6 +18,7 @@
 module Brig.API.MLS.KeyPackages.Validation
   ( -- * Main key package validation function
     validateKeyPackage,
+    reLifetime,
 
     -- * Exported for unit tests
     findExtensions,

--- a/services/brig/test/integration/API/Federation.hs
+++ b/services/brig/test/integration/API/Federation.hs
@@ -28,6 +28,7 @@ import qualified Brig.Options as Opt
 import Control.Arrow (Arrow (first), (&&&))
 import Control.Lens ((?~))
 import Data.Aeson
+import Data.Default
 import Data.Domain (Domain (Domain))
 import Data.Handle (Handle (..))
 import Data.Id
@@ -413,7 +414,7 @@ testClaimKeyPackages brig fedBrigClient = do
 
   withSystemTempDirectory "mls" $ \tmp ->
     for_ bobClients $ \c ->
-      uploadKeyPackages brig tmp SetKey bob c 2
+      uploadKeyPackages brig tmp def bob c 2
 
   Just bundle <-
     runFedClient @"claim-key-packages" fedBrigClient (qDomain alice) $

--- a/services/brig/test/integration/API/Internal.hs
+++ b/services/brig/test/integration/API/Internal.hs
@@ -22,7 +22,7 @@ where
 
 import API.Internal.Util
 import API.MLS (createClient)
-import API.MLS.Util (SetKey (SetKey), uploadKeyPackages)
+import API.MLS.Util
 import Bilge
 import Bilge.Assert
 import Brig.Data.User (lookupFeatureConferenceCalling, lookupStatus, userExists)
@@ -36,6 +36,7 @@ import Data.Aeson (decode)
 import qualified Data.Aeson.Lens as Aeson
 import qualified Data.Aeson.Types as Aeson
 import Data.ByteString.Conversion (toByteString')
+import Data.Default
 import Data.Id
 import Data.Qualified (Qualified (qDomain, qUnqualified))
 import qualified Data.Set as Set
@@ -226,7 +227,7 @@ keyPackageCreate brig = do
   uid <- userQualifiedId <$> randomUser brig
   clid <- createClient brig uid 0
   withSystemTempDirectory "mls" $ \tmp ->
-    uploadKeyPackages brig tmp SetKey uid clid 2
+    uploadKeyPackages brig tmp def uid clid 2
 
   uid2 <- userQualifiedId <$> randomUser brig
   claimResp <-

--- a/services/brig/test/integration/API/MLS.hs
+++ b/services/brig/test/integration/API/MLS.hs
@@ -24,9 +24,11 @@ import Brig.Options
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import Data.ByteString.Conversion
+import Data.Default
 import Data.Id
 import Data.Qualified
 import qualified Data.Set as Set
+import Data.Timeout
 import Federation.Util
 import Imports
 import Test.QuickCheck hiding ((===))
@@ -57,7 +59,7 @@ testKeyPackageUpload brig = do
   u <- userQualifiedId <$> randomUser brig
   c <- createClient brig u 0
   withSystemTempDirectory "mls" $ \tmp ->
-    uploadKeyPackages brig tmp SetKey u c 5
+    uploadKeyPackages brig tmp def u c 5
 
   count <- getKeyPackageCount brig u c
   liftIO $ count @?= 5
@@ -67,7 +69,7 @@ testKeyPackageUploadNoKey brig = do
   u <- userQualifiedId <$> randomUser brig
   c <- createClient brig u 0
   withSystemTempDirectory "mls" $ \tmp ->
-    uploadKeyPackages brig tmp DontSetKey u c 5
+    uploadKeyPackages brig tmp def {kiSetKey = DontSetKey} u c 5
 
   count <- getKeyPackageCount brig u c
   liftIO $ count @?= 0
@@ -87,7 +89,7 @@ testKeyPackageClaim brig = do
     c <- createClient brig u i
     -- upload 3 key packages for each client
     withSystemTempDirectory "mls" $ \tmp ->
-      uploadKeyPackages brig tmp SetKey u c 3
+      uploadKeyPackages brig tmp def u c 3
     pure c
 
   -- claim packages for both clients of u
@@ -117,7 +119,7 @@ testKeyPackageSelfClaim brig = do
     c <- createClient brig u i
     -- upload 3 key packages for each client
     withSystemTempDirectory "mls" $ \tmp ->
-      uploadKeyPackages brig tmp SetKey u c 3
+      uploadKeyPackages brig tmp def u c 3
     pure c
 
   -- claim own packages but skip the first

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -29,6 +29,7 @@ import Control.Lens hiding ((#))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import Data.ByteString.Conversion (toByteString')
+import Data.Default
 import Data.Domain
 import Data.Handle
 import Data.Id
@@ -675,7 +676,7 @@ claimRemoteKeyPackages brig1 brig2 = do
 
   withSystemTempDirectory "mls" $ \tmp ->
     for_ bobClients $ \c ->
-      uploadKeyPackages brig2 tmp SetKey bob c 5
+      uploadKeyPackages brig2 tmp def bob c 5
 
   bundle <-
     responseJsonError

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -197,6 +197,7 @@ library
     , cryptonite
     , currency-codes >=2.0
     , data-default >=0.5
+    , data-timeout
     , either
     , enclosed-exceptions >=1.0
     , errors >=2.0

--- a/services/galley/package.yaml
+++ b/services/galley/package.yaml
@@ -47,6 +47,7 @@ library:
   - cryptonite
   - currency-codes >=2.0
   - data-default >=0.5
+  - data-timeout
   - either
   - enclosed-exceptions >=1.0
   - errors >=2.0


### PR DESCRIPTION
When looking up an MLS key package for a client, all of its expired key packages are deleted first from the database. This affects the claim endpoint and the key-package count endpoint (in the sense of filtering out expired key packages).

My first attempt was to use Cassandra's `using ttl` clause, but that failed because a maximum value of 20 years is supported for  expiring records in Cassandra, yet key packages can last longer than that.

Tracked by https://wearezeta.atlassian.net/browse/FS-794.

TODO:

- [x] Merge a PR https://github.com/wireapp/mls-test-cli/pull/4 to `mls-test-cli` that incorporates the option for setting the key package lifetime and update the reference to the tool in the Nix configuration.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.