### PR TITLE
Typos etc.

### DIFF
--- a/changelog.d/5-internal/typos-etc
+++ b/changelog.d/5-internal/typos-etc
@@ -1,0 +1,1 @@
+Fix typos, dangling reference in source code haddocs, etc.

--- a/docs/legacy/reference/user/registration.md
+++ b/docs/legacy/reference/user/registration.md
@@ -192,7 +192,7 @@ The rest of the unauthorized end-points is safe:
 - `~* ^/teams/invitations/info$`: only `GET`; requires invitation code.
 - `~* ^/teams/invitations/by-email$`: only `HEAD`.
 - `/invitations/info`: discontinued feature, can be removed from nginz config.
-- `/conversations/code-check`: link validatoin for ephemeral/guest users.
+- `/conversations/code-check`: link validation for ephemeral/guest users.
 - `/provider/*`: bots need to be registered to a team before becoming active.  so if an attacker does not get access to a team, they cannot deploy a bot.
 - `~* ^/custom-backend/by-domain/([^/]*)$`: only `GET`; only exposes a list of domains that has is maintained through an internal end-point.  used to redirect stock clients from the cloud instance to on-prem instances.
 - `~* ^/teams/api-docs`: only `GET`; swagger for part of the rest API.  safe: it is trivial to identify the software that is running on the instance, and from there it is trivial to get to the source on github, where this can be obtained easily, and more.

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -178,8 +178,6 @@ data FeatureLegalHold
   deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 -- | Default value for all teams that have not enabled or disabled this feature explicitly.
--- See also 'Wire.API.Team.SearchVisibility.TeamSearchVisibilityEnabled',
--- 'Wire.API.Team.SearchVisibility.TeamSearchVisibility'.
 data FeatureTeamSearchVisibilityAvailability
   = FeatureTeamSearchVisibilityAvailableByDefault
   | FeatureTeamSearchVisibilityUnavailableByDefault

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -997,6 +997,7 @@ data AllFeatureConfigs = AllFeatureConfigs
   { afcLegalholdStatus :: WithStatus LegalholdConfig,
     afcSSOStatus :: WithStatus SSOConfig,
     afcTeamSearchVisibilityAvailable :: WithStatus SearchVisibilityAvailableConfig,
+    afcSearchVisibilityInboundConfig :: WithStatus SearchVisibilityInboundConfig,
     afcValidateSAMLEmails :: WithStatus ValidateSAMLEmailsConfig,
     afcDigitalSignatures :: WithStatus DigitalSignaturesConfig,
     afcAppLock :: WithStatus AppLockConfig,
@@ -1006,8 +1007,7 @@ data AllFeatureConfigs = AllFeatureConfigs
     afcSelfDeletingMessages :: WithStatus SelfDeletingMessagesConfig,
     afcGuestLink :: WithStatus GuestLinksConfig,
     afcSndFactorPasswordChallenge :: WithStatus SndFactorPasswordChallengeConfig,
-    afcMLS :: WithStatus MLSConfig,
-    afcSearchVisibilityInboundConfig :: WithStatus SearchVisibilityInboundConfig
+    afcMLS :: WithStatus MLSConfig
   }
   deriving stock (Eq, Show)
   deriving (FromJSON, ToJSON, S.ToSchema) via (Schema AllFeatureConfigs)
@@ -1019,6 +1019,7 @@ instance ToSchema AllFeatureConfigs where
         <$> afcLegalholdStatus .= featureField
         <*> afcSSOStatus .= featureField
         <*> afcTeamSearchVisibilityAvailable .= featureField
+        <*> afcSearchVisibilityInboundConfig .= featureField
         <*> afcValidateSAMLEmails .= featureField
         <*> afcDigitalSignatures .= featureField
         <*> afcAppLock .= featureField
@@ -1029,7 +1030,6 @@ instance ToSchema AllFeatureConfigs where
         <*> afcGuestLink .= featureField
         <*> afcSndFactorPasswordChallenge .= featureField
         <*> afcMLS .= featureField
-        <*> afcSearchVisibilityInboundConfig .= featureField
     where
       featureField ::
         forall cfg.

--- a/libs/wire-api/src/Wire/API/Team/SearchVisibility.hs
+++ b/libs/wire-api/src/Wire/API/Team/SearchVisibility.hs
@@ -60,7 +60,7 @@ import Wire.API.Arbitrary (Arbitrary, GenericUniform (..))
 --     Name: can be found by same team only
 -- @
 --
--- See also: 'FeatureTeamSearchVisibility', 'TeamSearchVisibilityEnabled'.
+-- See also: 'FeatureTeamSearchVisibilityAvailability'.
 data TeamSearchVisibility
   = SearchVisibilityStandard
   | SearchVisibilityNoNameOutsideTeam

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -427,6 +427,7 @@ getAllFeatureConfigsForServer =
     <$> getConfigForServer @db @LegalholdConfig
     <*> getConfigForServer @db @SSOConfig
     <*> getConfigForServer @db @SearchVisibilityAvailableConfig
+    <*> getConfigForServer @db @SearchVisibilityInboundConfig
     <*> getConfigForServer @db @ValidateSAMLEmailsConfig
     <*> getConfigForServer @db @DigitalSignaturesConfig
     <*> getConfigForServer @db @AppLockConfig
@@ -437,7 +438,6 @@ getAllFeatureConfigsForServer =
     <*> getConfigForServer @db @GuestLinksConfig
     <*> getConfigForServer @db @SndFactorPasswordChallengeConfig
     <*> getConfigForServer @db @MLSConfig
-    <*> getConfigForServer @db @SearchVisibilityInboundConfig
 
 getAllFeatureConfigsUser ::
   forall db r.
@@ -460,6 +460,7 @@ getAllFeatureConfigsUser uid =
     <$> getConfigForUser @db @LegalholdConfig uid
     <*> getConfigForUser @db @SSOConfig uid
     <*> getConfigForUser @db @SearchVisibilityAvailableConfig uid
+    <*> getConfigForUser @db @SearchVisibilityInboundConfig uid
     <*> getConfigForUser @db @ValidateSAMLEmailsConfig uid
     <*> getConfigForUser @db @DigitalSignaturesConfig uid
     <*> getConfigForUser @db @AppLockConfig uid
@@ -470,7 +471,6 @@ getAllFeatureConfigsUser uid =
     <*> getConfigForUser @db @GuestLinksConfig uid
     <*> getConfigForUser @db @SndFactorPasswordChallengeConfig uid
     <*> getConfigForUser @db @MLSConfig uid
-    <*> getConfigForUser @db @SearchVisibilityInboundConfig uid
 
 getAllFeatureConfigsTeam ::
   forall db r.
@@ -492,6 +492,7 @@ getAllFeatureConfigsTeam tid =
     <$> getConfigForTeam @db @LegalholdConfig tid
     <*> getConfigForTeam @db @SSOConfig tid
     <*> getConfigForTeam @db @SearchVisibilityAvailableConfig tid
+    <*> getConfigForTeam @db @SearchVisibilityInboundConfig tid
     <*> getConfigForTeam @db @ValidateSAMLEmailsConfig tid
     <*> getConfigForTeam @db @DigitalSignaturesConfig tid
     <*> getConfigForTeam @db @AppLockConfig tid
@@ -502,7 +503,6 @@ getAllFeatureConfigsTeam tid =
     <*> getConfigForTeam @db @GuestLinksConfig tid
     <*> getConfigForTeam @db @SndFactorPasswordChallengeConfig tid
     <*> getConfigForTeam @db @MLSConfig tid
-    <*> getConfigForTeam @db @SearchVisibilityInboundConfig tid
 
 -- | Note: this is an internal function which doesn't cover all features, e.g. LegalholdConfig
 genericGetConfigForTeam ::


### PR DESCRIPTION
A few trivialities that happened in the context of exploring https://wearezeta.atlassian.net/browse/SQSERVICES-1687  Hopefully uncontroversial?

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If new config options introduced: added usage description under docs/reference/config-options.md
   - [x] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [x] If public end-points have been changed or added: does nginz need un upgrade?
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
