### PR TITLE
Drop a Deprecated Conversation Member Removal Endpoint

### DIFF
--- a/changelog.d/1-api-changes/deprecated-member-removal
+++ b/changelog.d/1-api-changes/deprecated-member-removal
@@ -1,0 +1,1 @@
+Drop the deprecated member removal endpoint

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -557,6 +557,7 @@ type ConversationAPI =
     :<|> Named
            "remove-member-unqualified"
            ( Summary "Remove a member from a conversation (deprecated)"
+               :> Until 'V2
                :> ZLocalUser
                :> ZConn
                :> CanThrow ('ActionDenied 'RemoveConversationMember)

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1575,6 +1575,7 @@ testTeamMemberCantJoinViaGuestLinkIfAccessRoleRemoved = do
 
 getGuestLinksStatusFromForeignTeamConv :: TestM ()
 getGuestLinksStatusFromForeignTeamConv = do
+  localDomain <- viewFederationDomain
   galley <- view tsGalley
   let setTeamStatus u tid tfStatus =
         TeamFeatures.putTeamFeatureFlagWithGalley @Public.GuestLinksConfig galley u tid (Public.WithStatusNoLock tfStatus Public.GuestLinksConfig) !!! do
@@ -1589,10 +1590,12 @@ getGuestLinksStatusFromForeignTeamConv = do
 
   -- given alice is in team A with guest links allowed
   (alice, teamA, [alex]) <- createBindingTeamWithNMembers 1
+  let qalice = Qualified alice localDomain
   setTeamStatus alice teamA Public.FeatureStatusEnabled
 
   -- and given bob is in team B with guest links disallowed
   (bob, teamB, [bert]) <- createBindingTeamWithNMembers 1
+  let qbert = Qualified bert localDomain
   setTeamStatus bob teamB Public.FeatureStatusDisabled
 
   -- and given alice and bob are connected
@@ -1601,7 +1604,8 @@ getGuestLinksStatusFromForeignTeamConv = do
   -- and given bob creates a conversation, invites alice, and makes her group admin
   let accessRoles = Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole]
   conv <- decodeConvId <$> postTeamConv teamB bob [] (Just "teams b's conversation") [InviteAccess] (Just accessRoles) Nothing
-  postMembersWithRole bob (singleton alice) conv roleNameWireAdmin !!! const 200 === statusCode
+  let qconv = Qualified conv localDomain
+  postMembersWithRole bob (pure qalice) qconv roleNameWireAdmin !!! const 200 === statusCode
 
   -- when alice gets the guest link status for the conversation
   -- then the status should be disabled
@@ -1638,7 +1642,7 @@ getGuestLinksStatusFromForeignTeamConv = do
 
   -- when a conversation member that is not an admin tries to get the guest link status
   -- then the result should be forbidden
-  postMembersWithRole bob (singleton bert) conv roleNameWireMember !!! const 200 === statusCode
+  postMembersWithRole bob (pure qbert) qconv roleNameWireMember !!! const 200 === statusCode
   checkGetGuestLinksStatus 403 bert conv
 
 postJoinConvFail :: TestM ()
@@ -2638,7 +2642,7 @@ postMembersOk = do
   connectUsers eve (singleton bob)
   conv <- decodeConvId <$> postConv alice [bob, chuck] (Just "gossip") [] Nothing Nothing
   let qconv = Qualified conv (qDomain qalice)
-  e <- responseJsonError =<< postMembers alice (singleton eve) conv <!! const 200 === statusCode
+  e <- responseJsonError =<< postMembers alice (pure qeve) qconv <!! const 200 === statusCode
   liftIO $ do
     evtConv e @?= qconv
     evtType e @?= MemberJoin
@@ -2657,7 +2661,8 @@ postMembersOk2 = do
   connectUsers alice (list1 bob [qUnqualified chuck])
   connectUsers bob (singleton . qUnqualified $ chuck)
   conv <- decodeConvId <$> postConv alice [bob, qUnqualified chuck] Nothing [] Nothing Nothing
-  postMembers bob (singleton . qUnqualified $ chuck) conv !!! do
+  qconv <- Qualified conv <$> viewFederationDomain
+  postMembers bob (pure chuck) qconv !!! do
     const 204 === statusCode
     const Nothing === responseBody
   chuck' <- responseJsonUnsafe <$> (getSelfMember (qUnqualified chuck) conv <!! const 200 === statusCode)
@@ -2667,16 +2672,17 @@ postMembersOk2 = do
 postMembersOk3 :: TestM ()
 postMembersOk3 = do
   alice <- randomUser
-  bob <- randomUser
+  (bob, qbob) <- randomUserTuple
   eve <- randomUser
   connectUsers alice (list1 bob [eve])
   conv <- decodeConvId <$> postConv alice [bob, eve] (Just "gossip") [] Nothing Nothing
+  qconv <- Qualified conv <$> viewFederationDomain
   -- Bob leaves
   deleteMemberUnqualified bob bob conv !!! const 200 === statusCode
   -- Fetch bob
   getSelfMember bob conv !!! const 200 === statusCode
   -- Alice re-adds Bob to the conversation
-  postMembers alice (singleton bob) conv !!! const 200 === statusCode
+  postMembers alice (pure qbob) qconv !!! const 200 === statusCode
   -- Fetch bob again
   getSelfMember bob conv !!! const 200 === statusCode
 
@@ -2686,10 +2692,12 @@ postMembersFailNoGuestAccess = do
   bob <- randomUser
   peter <- randomUser
   eve <- ephemeralUser
+  qeve <- Qualified eve <$> viewFederationDomain
   connectUsers alice (list1 bob [peter])
   Right noGuestsAccess <- liftIO $ genAccessRolesV2 [TeamMemberAccessRole, NonTeamMemberAccessRole] [GuestAccessRole]
   conv <- decodeConvId <$> postConv alice [bob, peter] (Just "gossip") [] (Just noGuestsAccess) Nothing
-  postMembers alice (singleton eve) conv !!! const 403 === statusCode
+  qconv <- Qualified conv <$> viewFederationDomain
+  postMembers alice (pure qeve) qconv !!! const 403 === statusCode
 
 generateGuestLinkFailIfNoNonTeamMemberOrNoGuestAccess :: TestM ()
 generateGuestLinkFailIfNoNonTeamMemberOrNoGuestAccess = do
@@ -2703,23 +2711,24 @@ generateGuestLinkFailIfNoNonTeamMemberOrNoGuestAccess = do
 postMembersFail :: TestM ()
 postMembersFail = do
   alice <- randomUser
-  bob <- randomUser
+  (bob, qbob) <- randomUserTuple
   chuck <- randomUser
-  dave <- randomUser
-  eve <- randomUser
+  (dave, qdave) <- randomUserTuple
+  (eve, qeve) <- randomUserTuple
   connectUsers alice (list1 bob [chuck, eve])
   connectUsers eve (singleton bob)
   conv <- decodeConvId <$> postConv alice [bob, chuck] (Just "gossip") [] Nothing Nothing
-  postMembers eve (singleton bob) conv !!! const 404 === statusCode
-  postMembers alice (singleton eve) conv !!! const 200 === statusCode
+  qconv <- Qualified conv <$> viewFederationDomain
+  postMembers eve (pure qbob) qconv !!! const 404 === statusCode
+  postMembers alice (pure qeve) qconv !!! const 200 === statusCode
   -- Not connected but already there
-  postMembers chuck (singleton eve) conv !!! const 204 === statusCode
-  postMembers chuck (singleton dave) conv !!! do
+  postMembers chuck (pure qeve) qconv !!! const 204 === statusCode
+  postMembers chuck (pure qdave) qconv !!! do
     const 403 === statusCode
     const (Just "not-connected") === fmap label . responseJsonUnsafe
   void $ connectUsers chuck (singleton dave)
-  postMembers chuck (singleton dave) conv !!! const 200 === statusCode
-  postMembers chuck (singleton dave) conv !!! const 204 === statusCode
+  postMembers chuck (pure qdave) qconv !!! const 200 === statusCode
+  postMembers chuck (pure qdave) qconv !!! const 204 === statusCode
 
 postTooManyMembersFail :: TestM ()
 postTooManyMembersFail = do
@@ -2729,8 +2738,9 @@ postTooManyMembersFail = do
   chuck <- randomUser
   connectUsers alice (list1 bob [chuck])
   conv <- decodeConvId <$> postConv alice [bob, chuck] (Just "gossip") [] Nothing Nothing
-  x : xs <- randomUsers (n - 2)
-  postMembers chuck (list1 x xs) conv !!! do
+  qconv <- Qualified conv <$> viewFederationDomain
+  x : xs <- replicateM (n - 2) randomQualifiedUser
+  postMembers chuck (x :| xs) qconv !!! do
     const 403 === statusCode
     const (Just "too-many-members") === fmap label . responseJsonUnsafe
 

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -29,6 +29,7 @@ import Control.Arrow
 import Control.Lens (view)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
+import Data.ByteString.Conversion
 import Data.Default
 import Data.Domain
 import Data.Id
@@ -66,6 +67,7 @@ import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Group (convToGroupId)
 import Wire.API.MLS.Message
 import Wire.API.Message
+import Wire.API.Routes.Version
 
 tests :: IO TestSetup -> TestTree
 tests s =
@@ -861,9 +863,10 @@ testRemoteAppMessage = withSystemTempDirectory "mls" $ \tmp -> do
   (events :: [Event], reqs) <- fmap (first mmssEvents) . withTempMockFederator' mock $ do
     galley <- viewGalley
     void $ postCommit MessagingSetup {creator = alice, users = [bob], ..}
+    let v2 = toByteString' (toLower <$> show V2)
     responseJsonError
       =<< post
-        ( galley . paths ["v2", "mls", "messages"]
+        ( galley . paths [v2, "mls", "messages"]
             . zUser (qUnqualified (pUserId alice))
             . zConn "conn"
             . content "message/mls"

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -462,13 +462,13 @@ testAddUsersDirectly :: TestM ()
 testAddUsersDirectly = do
   setup@MessagingSetup {..} <- aliceInvitesBob (1, LocalUser) def {createConv = CreateConv}
   void $ postCommit setup
-  charlie <- randomUser
+  charlie <- randomQualifiedUser
   e <-
     responseJsonError
       =<< postMembers
         (qUnqualified (pUserId creator))
         (pure charlie)
-        (qUnqualified conversation)
+        conversation
       <!! const 403 === statusCode
   liftIO $ Wai.label e @?= "invalid-op"
 

--- a/services/galley/test/integration/API/Roles.hs
+++ b/services/galley/test/integration/API/Roles.hs
@@ -81,14 +81,11 @@ handleConversationRoleAdmin :: TestM ()
 handleConversationRoleAdmin = do
   localDomain <- viewFederationDomain
   c <- view tsCannon
-  alice <- randomUser
+  (alice, qalice) <- randomUserTuple
   bob <- randomUser
   chuck <- randomUser
-  eve <- randomUser
-  jack <- randomUser
-  let qalice = Qualified alice localDomain
-      qeve = Qualified eve localDomain
-      qjack = Qualified jack localDomain
+  (eve, qeve) <- randomUserTuple
+  (jack, qjack) <- randomUserTuple
   connectUsers alice (list1 bob [chuck, eve, jack])
   connectUsers eve (singleton bob)
   connectUsers bob (singleton jack)
@@ -99,12 +96,12 @@ handleConversationRoleAdmin = do
     let cid = decodeConvId rsp
         qcid = Qualified cid localDomain
     -- Make sure everyone gets the correct event
-    postMembersWithRole alice (singleton eve) cid role !!! const 200 === statusCode
+    postMembersWithRole alice (pure qeve) qcid role !!! const 200 === statusCode
     void . liftIO $
       WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
         wsAssertMemberJoinWithRole qcid qalice [qeve] role
     -- Add a member to help out with testing
-    postMembersWithRole alice (singleton jack) cid roleNameWireMember !!! const 200 === statusCode
+    postMembersWithRole alice (pure qjack) qcid roleNameWireMember !!! const 200 === statusCode
     void . liftIO $
       WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
         wsAssertMemberJoinWithRole qcid qalice [qjack] roleNameWireMember
@@ -141,7 +138,7 @@ handleConversationRoleMember = do
     let cid = decodeConvId rsp
         qcid = Qualified cid localDomain
     -- Make sure everyone gets the correct event
-    postMembersWithRole alice (singleton eve) cid role !!! const 200 === statusCode
+    postMembersWithRole alice (pure qeve) qcid role !!! const 200 === statusCode
     void . liftIO $
       WS.assertMatchN (5 # Second) [wsA, wsB, wsC] $
         wsAssertMemberJoinWithRole qcid qalice [qeve] role
@@ -336,18 +333,22 @@ wireAdminChecks ::
   UserId ->
   TestM ()
 wireAdminChecks cid admin otherAdmin mem = do
+  localDomain <- viewFederationDomain
   let role = roleNameWireAdmin
-  qcid <- Qualified cid <$> viewFederationDomain
-  other <- randomUser
+  let qcid = Qualified cid localDomain
+      qadmin = Qualified admin localDomain
+      qotherAdmin = Qualified otherAdmin localDomain
+      qmem = Qualified mem localDomain
+  (other, qother) <- randomUserTuple
   connectUsers admin (singleton other)
   -- Admins can perform all operations on the conversation; creator is not relevant
 
   -- Add members
-  postMembers admin (singleton other) cid !!! assertActionSucceeded
+  postMembers admin (pure qother) qcid !!! assertActionSucceeded
   -- Remove members, regardless of who they are
-  forM_ [otherAdmin, mem] $ \victim -> do
-    deleteMemberUnqualified admin victim cid !!! assertActionSucceeded
-    postMembersWithRole admin (singleton victim) cid role !!! assertActionSucceeded
+  forM_ [qotherAdmin, qmem] $ \victim -> do
+    deleteMemberUnqualified admin (qUnqualified victim) cid !!! assertActionSucceeded
+    postMembersWithRole admin (pure victim) qcid role !!! assertActionSucceeded
   -- Modify the conversation name
   void $ putConversationName admin cid "gossip++" !!! assertActionSucceeded
   -- Modify other members roles
@@ -371,7 +372,7 @@ wireAdminChecks cid admin otherAdmin mem = do
   -- You can also leave a conversation
   deleteMemberUnqualified admin admin cid !!! assertActionSucceeded
   -- Readding the user
-  postMembersWithRole otherAdmin (singleton admin) cid role !!! const 200 === statusCode
+  postMembersWithRole otherAdmin (pure qadmin) qcid role !!! const 200 === statusCode
 
 -- | Given a member, admin and otherMem, run all the necessary checks
 --   targeting mem
@@ -384,12 +385,13 @@ wireMemberChecks ::
 wireMemberChecks cid mem admin otherMem = do
   let role = roleNameWireMember
   qcid <- Qualified cid <$> viewFederationDomain
-  other <- randomUser
+  (other, qother) <- randomUserTuple
+  qmem <- Qualified mem <$> viewFederationDomain
   connectUsers mem (singleton other)
   -- Members cannot perform pretty much any action on the conversation
 
   -- Cannot add members, regardless of their role
-  postMembers mem (singleton other) cid !!! assertActionDenied
+  postMembers mem (pure qother) qcid !!! assertActionDenied
   -- Cannot remove members, regardless of who they are
   forM_ [admin, otherMem] $ \victim -> deleteMemberUnqualified mem victim cid !!! assertActionDenied
   -- Cannot modify the conversation name
@@ -416,7 +418,7 @@ wireMemberChecks cid mem admin otherMem = do
   -- Last option is to leave a conversation
   deleteMemberUnqualified mem mem cid !!! assertActionSucceeded
   -- Let's readd the user to make tests easier
-  postMembersWithRole admin (singleton mem) cid role !!! const 200 === statusCode
+  postMembersWithRole admin (pure qmem) qcid role !!! const 200 === statusCode
 
 assertActionSucceeded :: HasCallStack => Assertions ()
 assertActionSucceeded = const 200 === statusCode

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1045,16 +1045,6 @@ postMembersWithRole u us c r = do
   where
     v2 = toByteString' (toLower <$> show V2)
 
-deleteMemberUnqualified :: HasCallStack => UserId -> UserId -> ConvId -> TestM ResponseLBS
-deleteMemberUnqualified u1 u2 c = do
-  g <- view tsGalley
-  delete $
-    g
-      . zUser u1
-      . paths ["conversations", toByteString' c, "members", toByteString' u2]
-      . zConn "conn"
-      . zType "access"
-
 deleteMemberQualified ::
   (HasCallStack, MonadIO m, MonadHttp m, HasGalley m) =>
   UserId ->


### PR DESCRIPTION
The PR drops the deprecated `DELETE /conversations/:cnv/members/:usr` endpoint from version 2 of the client API. It also updates the integration tests in Galley not to use the deprecated and from version 2 removed endpoint `POST /conversations/:cnv/members` for adding members.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If public end-points have been changed or added: does nginz need an upgrade?
