### PR TITLE
docs: update links to helm chart values

### DIFF
--- a/docs/src/how-to/install/includes/helm_dns-ingress-troubleshooting.inc.rst
+++ b/docs/src/how-to/install/includes/helm_dns-ingress-troubleshooting.inc.rst
@@ -16,7 +16,7 @@ You need
 * (optional) one DNS name for the federator, usually called `federator.<domain>`.
 * (optional) one DNS name for SFTD (conference calling), usually called `sftd.<domain>`.
 
-If you are on the most recent charts from wire-server-deploy, these are your names:
+If you are on the most recent charts, these are your names:
 
 * nginz-https.<domain>
 * nginz-ssl.<domain>

--- a/docs/src/how-to/install/troubleshooting.rst
+++ b/docs/src/how-to/install/troubleshooting.rst
@@ -29,9 +29,9 @@ In the file that you use as override when running ``helm install/update -f <over
 
 For more info, you can have a look at respective charts values files, i.e.:
 
-  * `charts/account-pages/values.yaml <https://github.com/wireapp/wire-server-deploy/blob/develop/charts/account-pages/values.yaml>`__
-  * `charts/team-settings/values.yaml <https://github.com/wireapp/wire-server-deploy/blob/develop/charts/team-settings/values.yaml>`__
-  * `charts/webapp/values.yaml <https://github.com/wireapp/wire-server-deploy/blob/develop/charts/webapp/values.yaml>`__
+  * `charts/account-pages/values.yaml <https://github.com/wireapp/wire-server/blob/develop/charts/account-pages/values.yaml>`__
+  * `charts/team-settings/values.yaml <https://github.com/wireapp/wire-server/blob/develop/charts/team-settings/values.yaml>`__
+  * `charts/webapp/values.yaml <https://github.com/wireapp/wire-server/blob/develop/charts/webapp/values.yaml>`__
 
 Problems with ansible and python versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/src/understand/helm.rst
+++ b/docs/src/understand/helm.rst
@@ -14,7 +14,7 @@ Overriding helm configuration settings
 Default values
 ^^^^^^^^^^^^^^
 
-Default values are under a specific chart's ``values.yaml`` file, e.g. for the chart named ``cassandra-ephemeral``, this file: `charts/cassandra-ephemeral/values.yaml <https://github.com/wireapp/wire-server-deploy/blob/develop/charts/cassandra-ephemeral/values.yaml>`__. When you install or upgrade a chart, with e.g.::
+Default values are under a specific chart's ``values.yaml`` file, e.g. for the chart named ``cassandra-ephemeral``, this file: `charts/cassandra-ephemeral/values.yaml <https://github.com/wireapp/wire-server/blob/develop/charts/cassandra-ephemeral/values.yaml>`__. When you install or upgrade a chart, with e.g.::
 
     helm upgrade --install my-cassandra wire/cassandra-ephemeral
 


### PR DESCRIPTION
Helm charts live in wire-server codebase, so these links were broken.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
