### PR TITLE
build/ubuntu/Dockerfile.prebuiler: Enable exe flag when installing cabal-plan

### DIFF
--- a/build/ubuntu/Dockerfile.prebuilder
+++ b/build/ubuntu/Dockerfile.prebuilder
@@ -70,4 +70,4 @@ ENV PATH=/root/.ghcup/bin:/root/.cabal/bin:${PATH} \
 
 ARG CABAL_VERSION=3.6.2.0
 RUN ghcup install cabal ${CABAL_VERSION} && \
-    cabal install cabal-plan
+    cabal install cabal-plan -fexe


### PR DESCRIPTION
From CI logs:

```
#10 155.2 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
#10 155.2 @ WARNING: Installation might not be completed as desired! @
#10 155.2 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
#10 155.2 The command "cabal install [TARGETS]" doesn't expose libraries.
#10 155.2 * You might have wanted to add them as dependencies to your package. In this
#10 155.2 case add "cabal-plan" to the build-depends field(s) of your package's .cabal
#10 155.2 file.
#10 155.2 * You might have wanted to add them to a GHC environment. In this case use
#10 155.2 "cabal install --lib cabal-plan". The "--lib" flag is provisional: see
#10 155.2 https://github.com/haskell/cabal/issues/6481 for more information.
```

This showed up when the prebuilder got built again in the new CI. Maybe we should be building the prebuilder regularly too.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d**: No need for changelog.
