### PR TITLE
Add cabal-fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 
 # Usage: make c package=brig test=1
 .PHONY: c
-c:
+c: cabal-fmt
 	cabal build $(WIRE_CABAL_BUILD_OPTIONS) $(package)
 ifeq ($(test), 1)
 	./hack/bin/cabal-run-tests.sh $(package) $(testargs)

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ endif
 ci: c
 	./hack/bin/cabal-run-integration.sh $(package)
 
+.PHONY: cabal-fmt
+cabal-fmt:
+	./hack/bin/cabal-fmt.sh $(package)
+
 # Use ghcid to watch a particular package.
 # pass target=package:name to specify which target is watched.
 .PHONY: ghcid

--- a/changelog.d/5-internal/cabal-fmt
+++ b/changelog.d/5-internal/cabal-fmt
@@ -1,0 +1,1 @@
+Add cabal-fmt development tool

--- a/hack/bin/cabal-fmt.sh
+++ b/hack/bin/cabal-fmt.sh
@@ -13,7 +13,7 @@ if [ -z "$cabal_file" ]; then
     exit
 fi
 
-cabal_file=$(realpath "$TOP_LEVEL"/$cabal_file --relative-to="$(pwd)")
+cabal_file=$(realpath "$TOP_LEVEL"/"$cabal_file" --relative-to="$(pwd)")
 
 set -x
 cabal-fmt -i "$cabal_file"

--- a/hack/bin/cabal-fmt.sh
+++ b/hack/bin/cabal-fmt.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
+
+package_name="$1"
+
+cabal_file="$(cd "$TOP_LEVEL"; find . -not \( -path ./dist-newstyle -prune \) -not \( -path ./charts -prune \) -name "$package_name.cabal" | head -n 1)"
+
+if [ -z "$cabal_file" ]; then
+    echo "Could not find $package_name.cabal in project"
+    exit
+fi
+
+cabal_file=$(realpath "$TOP_LEVEL"/$cabal_file --relative-to="$(pwd)")
+
+set -x
+cabal-fmt -i "$cabal_file"

--- a/hack/bin/cabal-fmt.sh
+++ b/hack/bin/cabal-fmt.sh
@@ -6,14 +6,29 @@ TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
 
 package_name="$1"
 
-cabal_file="$(cd "$TOP_LEVEL"; find . -not \( -path ./dist-newstyle -prune \) -not \( -path ./charts -prune \) -name "$package_name.cabal" | head -n 1)"
+format_all() {
+    cabal_files="$(cd "$TOP_LEVEL"; find . -not \( -path ./dist-newstyle -prune \) -not \( -path ./charts -prune \) -name "*.cabal")"
+    for cabal_file in $cabal_files; do
+        cabal-fmt -i "$cabal_file"
+    done
+}
 
-if [ -z "$cabal_file" ]; then
-    echo "Could not find $package_name.cabal in project"
-    exit
+format_single() {
+    cabal_file="$(cd "$TOP_LEVEL"; find . -not \( -path ./dist-newstyle -prune \) -not \( -path ./charts -prune \) -name "$package_name.cabal" | head -n 1)"
+
+    if [ -z "$cabal_file" ]; then
+        echo "Could not find $package_name.cabal in project"
+        exit
+    fi
+
+    cabal_file=$(realpath "$TOP_LEVEL"/"$cabal_file" --relative-to="$(pwd)")
+
+    set -x
+    cabal-fmt -i "$cabal_file"
+}
+
+if [ "$1" = "all" ]; then
+    format_all
+else
+    format_single "$1"
 fi
-
-cabal_file=$(realpath "$TOP_LEVEL"/"$cabal_file" --relative-to="$(pwd)")
-
-set -x
-cabal-fmt -i "$cabal_file"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -105,7 +105,6 @@ let
     cabal-wrapper
     stack-wrapper
 
-    # For cabal-migration
     pkgs.haskellPackages.cabal-plan
     pkgs.haskellPackages.cabal-fmt
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -107,6 +107,7 @@ let
 
     # For cabal-migration
     pkgs.haskellPackages.cabal-plan
+    pkgs.haskellPackages.cabal-fmt
 
     # We don't use pkgs.cabal-install here, as we invoke it with a wrapper
     # which sets LD_LIBRARY_PATH and others correctly.


### PR DESCRIPTION
This PR adds `cabal-fmt` to the development environment as well as a Makefile target:

```
make cabal-fmt package=wire-api
```
which will reformat the corresponding `.cabal` file in-place. This PR also adds formatting to `make c` target.

If we add suitable stanzas like this (see [blog post](http://oleg.fi/gists/posts/2019-08-11-cabal-fmt.html#extra-expand-exposed-modules-and-other-modules))

```
-- cabal-fmt: expand src
```

then `cabal-fmt` will auto-fill modules like hpack does.

We can use this after we drop hpack in https://github.com/wireapp/wire-server/pull/2596

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.