### PR TITLE
update clients' key package refs upon committing

### DIFF
--- a/changelog.d/5-internal/update-key-package-ref
+++ b/changelog.d/5-internal/update-key-package-ref
@@ -1,0 +1,2 @@
+Add internal endpoint in Brig to update clients' key package refs in DB upon committing.
+Brig should be deployed before Galley.

--- a/libs/wire-api/src/Wire/API/MLS/Commit.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Commit.hs
@@ -31,7 +31,7 @@ instance ParseMLS Commit where
   parseMLS = Commit <$> parseMLSVector @Word32 parseMLS <*> parseMLSOptional parseMLS
 
 data UpdatePath = UpdatePath
-  { upLeaf :: KeyPackage,
+  { upLeaf :: RawMLS KeyPackage,
     upNodes :: [UpdatePathNode]
   }
 

--- a/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
+++ b/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
@@ -114,6 +114,7 @@ instance ToSchema KeyPackageCount where
 newtype KeyPackageRef = KeyPackageRef {unKeyPackageRef :: ByteString}
   deriving stock (Eq, Ord, Show)
   deriving (FromHttpApiData, ToHttpApiData, S.ToParamSchema) via Base64ByteString
+  deriving (ToJSON, FromJSON, S.ToSchema) via (Schema KeyPackageRef)
 
 instance ToSchema KeyPackageRef where
   schema = named "KeyPackageRef" $ unKeyPackageRef .= fmap KeyPackageRef base64Schema

--- a/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
+++ b/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
@@ -33,6 +33,7 @@ module Wire.API.MLS.KeyPackage
     kpRef',
     KeyPackageTBS (..),
     KeyPackageRef (..),
+    KeyPackageUpdate (..),
   )
 where
 
@@ -192,3 +193,10 @@ instance ParseMLS KeyPackage where
     KeyPackage
       <$> parseRawMLS parseMLS
       <*> parseMLSBytes @Word16
+
+--------------------------------------------------------------------------------
+
+data KeyPackageUpdate = KeyPackageUpdate
+  { kpupPrevious :: KeyPackageRef,
+    kpupNext :: KeyPackageRef
+  }

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -198,6 +198,16 @@ type MLSAPI =
                                     '[RespondEmpty 201 "Key package ref mapping created"]
                                     ()
                            )
+                    :<|> Named
+                           "post-key-package-ref"
+                           ( Summary "Update a KeyPackageRef in mapping"
+                               :> ReqBody '[Servant.JSON] KeyPackageRef
+                               :> MultiVerb
+                                    'POST
+                                    '[Servant.JSON]
+                                    '[RespondEmpty 201 "Key package ref mapping updated"]
+                                    ()
+                           )
                 )
          )
            :<|> GetMLSClients

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -120,6 +120,7 @@ mlsAPI =
                  :<|> Named @"get-conversation-by-key-package-ref" (getConvIdByKeyPackageRef ref)
              )
         :<|> Named @"put-key-package-ref" (putKeyPackageRef ref)
+        :<|> Named @"post-key-package-ref" (postKeyPackageRef ref)
   )
     :<|> getMLSClients
     :<|> mapKeyPackageRefsInternal
@@ -160,6 +161,10 @@ putKeyPackageRef ref = lift . wrapClient . Data.addKeyPackageRef ref
 -- Used by galley to retrieve conversation id from mls_key_package_ref
 getConvIdByKeyPackageRef :: KeyPackageRef -> Handler r (Maybe (Qualified ConvId))
 getConvIdByKeyPackageRef = runMaybeT . mapMaybeT wrapClientE . Data.keyPackageRefConvId
+
+-- Used by galley to update key packages in mls_key_package_ref on commits with update_path
+postKeyPackageRef :: KeyPackageRef -> KeyPackageRef -> Handler r ()
+postKeyPackageRef ref = lift . wrapClient . Data.updateKeyPackageRef ref
 
 getMLSClients :: UserId -> SignatureSchemeTag -> Handler r (Set ClientId)
 getMLSClients usr ss = do

--- a/services/brig/src/Brig/Data/MLS/KeyPackage.hs
+++ b/services/brig/src/Brig/Data/MLS/KeyPackage.hs
@@ -24,6 +24,7 @@ module Brig.Data.MLS.KeyPackage
     keyPackageRefConvId,
     keyPackageRefSetConvId,
     addKeyPackageRef,
+    updateKeyPackageRef,
   )
 where
 
@@ -194,8 +195,46 @@ addKeyPackageRef ref nkpr = do
     q :: PrepQuery W (ClientId, ConvId, Domain, Domain, UserId, KeyPackageRef) x
     q = "UPDATE mls_key_package_refs SET client = ?, conv = ?, conv_domain = ?, domain = ?, user = ? WHERE ref = ?"
 
+-- | Update key package ref, used in Galley when commit reveals key package ref update for the sender.
+-- Nothing is changed if the previous key package ref is not found in the table.
+-- Updating amounts to INSERT the new key package ref, followed by DELETE the
+-- previous one.
+--
+-- FUTUREWORK: this function has to be extended if a table mapping (client,
+-- conversation) to key package ref is added, for instance, when implementing
+-- external delete proposals.
+updateKeyPackageRef :: MonadClient m => KeyPackageRef -> KeyPackageRef -> m ()
+updateKeyPackageRef prevRef newRef =
+  void . runMaybeT $
+    backupKeyPackageMeta prevRef
+      >>= ($) lift . ((>> deleteKeyPackage prevRef) . restoreKeyPackageMeta newRef)
+
 --------------------------------------------------------------------------------
 -- Utilities
+
+backupKeyPackageMeta :: MonadClient m => KeyPackageRef -> MaybeT m (ClientId, ConvId, Domain, Domain, UserId)
+backupKeyPackageMeta ref = do
+  MaybeT . retry x1 $ query1 q (params LocalQuorum (Identity ref))
+  where
+    q :: PrepQuery R (Identity KeyPackageRef) (ClientId, ConvId, Domain, Domain, UserId)
+    q = "SELECT client, conv, conv_domain, domain, user FROM mls_key_package_refs WHERE ref = ?"
+
+restoreKeyPackageMeta :: MonadClient m => KeyPackageRef -> (ClientId, ConvId, Domain, Domain, UserId) -> m ()
+restoreKeyPackageMeta ref (client, conv, convDomain, domain, user) = do
+  write q (params LocalQuorum (ref, client, conv, convDomain, domain, user))
+  where
+    q :: PrepQuery W (KeyPackageRef, ClientId, ConvId, Domain, Domain, UserId) ()
+    q = "INSERT INTO mls_key_package_refs (ref, client, conv, conv_domain, domain, user) VALUES (?, ?, ?, ?, ?, ?)"
+
+deleteKeyPackage :: MonadClient m => KeyPackageRef -> m ()
+deleteKeyPackage ref =
+  retry x5 $
+    write
+      q
+      (params LocalQuorum (Identity ref))
+  where
+    q :: PrepQuery W (Identity KeyPackageRef) x
+    q = "DELETE FROM mls_key_package_refs WHERE ref = ?"
 
 pick :: [a] -> IO (Maybe a)
 pick [] = pure Nothing

--- a/services/brig/src/Brig/Data/MLS/KeyPackage.hs
+++ b/services/brig/src/Brig/Data/MLS/KeyPackage.hs
@@ -205,9 +205,9 @@ addKeyPackageRef ref nkpr = do
 -- external delete proposals.
 updateKeyPackageRef :: MonadClient m => KeyPackageRef -> KeyPackageRef -> m ()
 updateKeyPackageRef prevRef newRef =
-  void . runMaybeT $
-    backupKeyPackageMeta prevRef
-      >>= ($) lift . ((>> deleteKeyPackage prevRef) . restoreKeyPackageMeta newRef)
+  void . runMaybeT $ do
+    backup <- backupKeyPackageMeta prevRef
+    lift $ restoreKeyPackageMeta newRef backup >> deleteKeyPackage prevRef
 
 --------------------------------------------------------------------------------
 -- Utilities

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -388,7 +388,11 @@ processCommit qusr con lconv epoch sender commit = do
           (MemberSender senderRef, Just updatedKeyPackage) -> do
             updatedRef <- kpRef' updatedKeyPackage & note (mlsProtocolError "Could not compute key package ref")
             -- postpone key package ref update until other checks/processing passed
-            pure $ updateKeyPackageRef senderRef updatedRef
+            pure . updateKeyPackageRef $
+              KeyPackageUpdate
+                { kpupPrevious = senderRef,
+                  kpupNext = updatedRef
+                }
           (_, Nothing) -> pure $ pure () -- ignore commits without update path
           _ -> throw (mlsProtocolError "Unexpected sender")
 

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -360,9 +360,11 @@ processCommit qusr con lconv epoch sender commit = do
         -- client (the creator)
         case (sender, first (toList . lmMLSClients) self) of
           (MemberSender ref, Left [creatorClient]) -> do
+            -- use update path as sender reference and if not existing fall back to sender
+            let senderRef = maybe ref (fromMaybe ref . kpRef' . upLeaf) $ cPath commit
             -- register the creator client
             addKeyPackageRef
-              ref
+              senderRef
               qusr
               creatorClient
               (qUntagged (fmap Data.convId lconv))

--- a/services/galley/src/Galley/Effects/BrigAccess.hs
+++ b/services/galley/src/Galley/Effects/BrigAccess.hs
@@ -51,6 +51,7 @@ module Galley.Effects.BrigAccess
     getClientByKeyPackageRef,
     getLocalMLSClients,
     addKeyPackageRef,
+    updateKeyPackageRef,
 
     -- * Features
     getAccountConferenceCallingConfigClient,
@@ -128,6 +129,7 @@ data BrigAccess m a where
   GetClientByKeyPackageRef :: KeyPackageRef -> BrigAccess m (Maybe ClientIdentity)
   GetLocalMLSClients :: Local UserId -> SignatureSchemeTag -> BrigAccess m (Set ClientId)
   AddKeyPackageRef :: KeyPackageRef -> Qualified UserId -> ClientId -> Qualified ConvId -> BrigAccess m ()
+  UpdateKeyPackageRef :: KeyPackageRef -> KeyPackageRef -> BrigAccess m ()
   UpdateSearchVisibilityInbound ::
     Multi.TeamStatus SearchVisibilityInboundConfig ->
     BrigAccess m ()

--- a/services/galley/src/Galley/Effects/BrigAccess.hs
+++ b/services/galley/src/Galley/Effects/BrigAccess.hs
@@ -129,7 +129,7 @@ data BrigAccess m a where
   GetClientByKeyPackageRef :: KeyPackageRef -> BrigAccess m (Maybe ClientIdentity)
   GetLocalMLSClients :: Local UserId -> SignatureSchemeTag -> BrigAccess m (Set ClientId)
   AddKeyPackageRef :: KeyPackageRef -> Qualified UserId -> ClientId -> Qualified ConvId -> BrigAccess m ()
-  UpdateKeyPackageRef :: KeyPackageRef -> KeyPackageRef -> BrigAccess m ()
+  UpdateKeyPackageRef :: KeyPackageUpdate -> BrigAccess m ()
   UpdateSearchVisibilityInbound ::
     Multi.TeamStatus SearchVisibilityInboundConfig ->
     BrigAccess m ()

--- a/services/galley/src/Galley/Intra/Client.hs
+++ b/services/galley/src/Galley/Intra/Client.hs
@@ -25,6 +25,7 @@ module Galley.Intra.Client
     getClientByKeyPackageRef,
     getLocalMLSClients,
     addKeyPackageRef,
+    updateKeyPackageRef,
   )
 where
 
@@ -208,5 +209,16 @@ addKeyPackageRef ref qusr cl qcnv =
       ( method PUT
           . paths ["i", "mls", "key-packages", toHeader ref]
           . json (NewKeyPackageRef qusr cl qcnv)
+          . expect2xx
+      )
+
+updateKeyPackageRef :: KeyPackageRef -> KeyPackageRef -> App ()
+updateKeyPackageRef previousRef newRef =
+  void $
+    call
+      Brig
+      ( method POST
+          . paths ["i", "mls", "key-packages", toHeader previousRef]
+          . json newRef
           . expect2xx
       )

--- a/services/galley/src/Galley/Intra/Client.hs
+++ b/services/galley/src/Galley/Intra/Client.hs
@@ -212,13 +212,13 @@ addKeyPackageRef ref qusr cl qcnv =
           . expect2xx
       )
 
-updateKeyPackageRef :: KeyPackageRef -> KeyPackageRef -> App ()
-updateKeyPackageRef previousRef newRef =
+updateKeyPackageRef :: KeyPackageUpdate -> App ()
+updateKeyPackageRef keyPackageRef =
   void $
     call
       Brig
       ( method POST
-          . paths ["i", "mls", "key-packages", toHeader previousRef]
-          . json newRef
+          . paths ["i", "mls", "key-packages", toHeader $ kpupPrevious keyPackageRef]
+          . json (kpupNext keyPackageRef)
           . expect2xx
       )

--- a/services/galley/src/Galley/Intra/Effects.hs
+++ b/services/galley/src/Galley/Intra/Effects.hs
@@ -82,6 +82,9 @@ interpretBrigAccess = interpret $ \case
   AddKeyPackageRef ref qusr cl qcnv ->
     embedApp $
       addKeyPackageRef ref qusr cl qcnv
+  UpdateKeyPackageRef previousRef newRef ->
+    embedApp $
+      updateKeyPackageRef previousRef newRef
   UpdateSearchVisibilityInbound status ->
     embedApp $ updateSearchVisibilityInbound status
 

--- a/services/galley/src/Galley/Intra/Effects.hs
+++ b/services/galley/src/Galley/Intra/Effects.hs
@@ -82,9 +82,9 @@ interpretBrigAccess = interpret $ \case
   AddKeyPackageRef ref qusr cl qcnv ->
     embedApp $
       addKeyPackageRef ref qusr cl qcnv
-  UpdateKeyPackageRef previousRef newRef ->
+  UpdateKeyPackageRef update ->
     embedApp $
-      updateKeyPackageRef previousRef newRef
+      updateKeyPackageRef update
   UpdateSearchVisibilityInbound status ->
     embedApp $ updateSearchVisibilityInbound status
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-878

The logic has been manually tested. Automated tests will be added/integrated by FS-797.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
