### PR TITLE
SQSERVICES-1388-email-localization-when-provisioning-users-with-scim-2

### DIFF
--- a/changelog.d/2-features/pr-2605
+++ b/changelog.d/2-features/pr-2605
@@ -1,0 +1,1 @@
+The `preferredLanguage` field from SCIM now maps to the user locale in BRIG and will be set and updated on post SCIM user and on update SCIM user using SAML.

--- a/libs/brig-types/src/Brig/Types/Intra.hs
+++ b/libs/brig-types/src/Brig/Types/Intra.hs
@@ -27,7 +27,6 @@ module Brig.Types.Intra
     NewUserScimInvitation (..),
     UserSet (..),
     ReAuthUser (..),
-    LocaleRsp (..),
   )
 where
 
@@ -116,16 +115,6 @@ instance ToJSON UserAccount where
         Object $ KeyMap.insert "status" (toJSON s) o
       other ->
         error $ "toJSON UserAccount: not an object: " <> show (encode other)
-
-newtype LocaleRsp = LocaleRsp {fromLocaleRsp :: Locale}
-  deriving (Eq, Show, Generic)
-
-instance ToJSON LocaleRsp where
-  toJSON (LocaleRsp s) = object ["locale" .= s]
-
-instance FromJSON LocaleRsp where
-  parseJSON = withObject "locale" $ \o ->
-    LocaleRsp <$> o .: "locale"
 
 -------------------------------------------------------------------------------
 -- NewUserScimInvitation

--- a/libs/brig-types/src/Brig/Types/Intra.hs
+++ b/libs/brig-types/src/Brig/Types/Intra.hs
@@ -27,6 +27,7 @@ module Brig.Types.Intra
     NewUserScimInvitation (..),
     UserSet (..),
     ReAuthUser (..),
+    LocaleRsp (..),
   )
 where
 
@@ -115,6 +116,16 @@ instance ToJSON UserAccount where
         Object $ KeyMap.insert "status" (toJSON s) o
       other ->
         error $ "toJSON UserAccount: not an object: " <> show (encode other)
+
+newtype LocaleRsp = LocaleRsp {fromLocaleRsp :: Locale}
+  deriving (Eq, Show, Generic)
+
+instance ToJSON LocaleRsp where
+  toJSON (LocaleRsp s) = object ["locale" .= s]
+
+instance FromJSON LocaleRsp where
+  parseJSON = withObject "locale" $ \o ->
+    LocaleRsp <$> o .: "locale"
 
 -------------------------------------------------------------------------------
 -- NewUserScimInvitation

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -21,6 +21,7 @@ module Wire.API.Routes.Internal.Brig
     AccountAPI,
     MLSAPI,
     TeamsAPI,
+    UserAPI,
     EJPDRequest,
     GetAccountConferenceCallingConfig,
     PutAccountConferenceCallingConfig,
@@ -259,7 +260,7 @@ type GetVerificationCode =
 
 type API =
   "i"
-    :> (EJPD_API :<|> AccountAPI :<|> MLSAPI :<|> GetVerificationCode :<|> TeamsAPI)
+    :> (EJPD_API :<|> AccountAPI :<|> MLSAPI :<|> GetVerificationCode :<|> TeamsAPI :<|> UserAPI)
 
 type TeamsAPI =
   Named
@@ -268,6 +269,34 @@ type TeamsAPI =
         :> ReqBody '[Servant.JSON] (Multi.TeamStatus SearchVisibilityInboundConfig)
         :> Post '[Servant.JSON] ()
     )
+
+type UserAPI =
+  UpdateUserLocale
+    :<|> DeleteUserLocale
+    :<|> GetDefaultLocale
+
+type UpdateUserLocale =
+  Summary
+    "Set the user's locale"
+    :> "users"
+    :> Capture "uid" UserId
+    :> "locale"
+    :> ReqBody '[Servant.JSON] LocaleUpdate
+    :> Put '[Servant.JSON] LocaleUpdate
+
+type DeleteUserLocale =
+  Summary
+    "Delete the user's locale"
+    :> "users"
+    :> Capture "uid" UserId
+    :> "locale"
+    :> Delete '[Servant.JSON] NoContent
+
+type GetDefaultLocale =
+  Summary "Get the default locale"
+    :> "users"
+    :> "locale"
+    :> Get '[Servant.JSON] LocaleUpdate
 
 type SwaggerDocsAPI = "api" :> "internal" :> SwaggerSchemaUI "swagger-ui" "swagger.json"
 

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -657,7 +657,8 @@ data NewUserSpar = NewUserSpar
     newUserSparTeamId :: TeamId,
     newUserSparManagedBy :: ManagedBy,
     newUserSparHandle :: Maybe Handle,
-    newUserSparRichInfo :: Maybe RichInfo
+    newUserSparRichInfo :: Maybe RichInfo,
+    newUserSparLocale :: Maybe Locale
   }
   deriving stock (Eq, Show, Generic)
   deriving (ToJSON, FromJSON, S.ToSchema) via (Schema NewUserSpar)
@@ -673,6 +674,7 @@ instance ToSchema NewUserSpar where
         <*> newUserSparManagedBy .= field "newUserSparManagedBy" schema
         <*> newUserSparHandle .= maybe_ (optField "newUserSparHandle" schema)
         <*> newUserSparRichInfo .= maybe_ (optField "newUserSparRichInfo" schema)
+        <*> newUserSparLocale .= maybe_ (optField "newUserSparLocale" schema)
 
 newUserFromSpar :: NewUserSpar -> NewUser
 newUserFromSpar new =
@@ -687,10 +689,10 @@ newUserFromSpar new =
       newUserPhoneCode = Nothing,
       newUserOrigin = Just . NewUserOriginTeamUser . NewTeamMemberSSO $ newUserSparTeamId new,
       newUserLabel = Nothing,
-      newUserLocale = Nothing,
       newUserPassword = Nothing,
       newUserExpiresIn = Nothing,
-      newUserManagedBy = Just $ newUserSparManagedBy new
+      newUserManagedBy = Just $ newUserSparManagedBy new,
+      newUserLocale = newUserSparLocale new
     }
 
 data NewUser = NewUser

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -417,6 +417,7 @@ executable spar-integration
     , http-types
     , imports
     , insert-ordered-containers
+    , iso639                     >=0.1
     , lens
     , lens-aeson
     , memory

--- a/services/spar/src/Spar/App.hs
+++ b/services/spar/src/Spar/App.hs
@@ -170,7 +170,7 @@ createSamlUserWithId ::
   Sem r ()
 createSamlUserWithId teamid buid suid = do
   uname <- either (throwSparSem . SparBadUserName . cs) pure $ Intra.mkUserName Nothing (UrefOnly suid)
-  buid' <- BrigAccess.createSAML suid buid teamid uname ManagedByWire Nothing Nothing
+  buid' <- BrigAccess.createSAML suid buid teamid uname ManagedByWire Nothing Nothing Nothing
   assert (buid == buid') $ pure ()
   SAMLUserStore.insert suid buid
 

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -27,6 +27,7 @@ module Spar.Intra.Brig
     setBrigUserManagedBy,
     setBrigUserVeid,
     setBrigUserRichInfo,
+    setBrigUserLocale,
     checkHandleAvailable,
     deleteBrigUser,
     createBrigUserSAML,
@@ -37,6 +38,7 @@ module Spar.Intra.Brig
     getStatus,
     getStatusMaybe,
     setStatus,
+    getDefaultUserLocale,
   )
 where
 
@@ -284,6 +286,24 @@ setBrigUserRichInfo buid richInfo = do
   unless (statusCode resp == 200) $
     rethrow "brig" resp
 
+setBrigUserLocale :: (HasCallStack, MonadSparToBrig m) => UserId -> Maybe Locale -> m ()
+setBrigUserLocale buid = \case
+  Just locale -> do
+    resp <-
+      call $
+        method PUT
+          . paths ["i", "users", toByteString' buid, "locale"]
+          . json (LocaleUpdate locale)
+    unless (statusCode resp == 200) $
+      rethrow "brig" resp
+  Nothing -> do
+    resp <-
+      call $
+        method DELETE
+          . paths ["i", "users", toByteString' buid, "locale"]
+    unless (statusCode resp == 200) $
+      rethrow "brig" resp
+
 getBrigUserRichInfo :: (HasCallStack, MonadSparToBrig m) => UserId -> m RichInfo
 getBrigUserRichInfo buid = do
   resp <-
@@ -391,4 +411,11 @@ setStatus uid status = do
         . json (AccountStatusUpdate status)
   case statusCode resp of
     200 -> pure ()
+    _ -> rethrow "brig" resp
+
+getDefaultUserLocale :: (HasCallStack, MonadSparToBrig m) => m Locale
+getDefaultUserLocale = do
+  resp <- call $ method GET . paths ["/i/users/locale"]
+  case statusCode resp of
+    200 -> fromLocaleRsp <$> parseResponse @LocaleRsp "brig" resp
     _ -> rethrow "brig" resp

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -417,5 +417,5 @@ getDefaultUserLocale :: (HasCallStack, MonadSparToBrig m) => m Locale
 getDefaultUserLocale = do
   resp <- call $ method GET . paths ["/i/users/locale"]
   case statusCode resp of
-    200 -> fromLocaleRsp <$> parseResponse @LocaleRsp "brig" resp
+    200 -> luLocale <$> parseResponse @LocaleUpdate "brig" resp
     _ -> rethrow "brig" resp

--- a/services/spar/src/Spar/Intra/Brig.hs
+++ b/services/spar/src/Spar/Intra/Brig.hs
@@ -95,8 +95,9 @@ createBrigUserSAML ::
   ManagedBy ->
   Maybe Handle ->
   Maybe RichInfo ->
+  Maybe Locale ->
   m UserId
-createBrigUserSAML uref (Id buid) teamid name managedBy handle richInfo = do
+createBrigUserSAML uref (Id buid) teamid name managedBy handle richInfo mLocale = do
   let newUser =
         NewUserSpar
           { newUserSparUUID = buid,
@@ -105,7 +106,8 @@ createBrigUserSAML uref (Id buid) teamid name managedBy handle richInfo = do
             newUserSparTeamId = teamid,
             newUserSparManagedBy = managedBy,
             newUserSparHandle = handle,
-            newUserSparRichInfo = richInfo
+            newUserSparRichInfo = richInfo,
+            newUserSparLocale = mLocale
           }
   resp :: ResponseLBS <-
     call $

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -446,7 +446,7 @@ createValidScimUser tokeninfo@ScimTokenInfo {stiTeam} vsu@(ST.ValidScimUser veid
                     -- `createValidScimUser` into a function `createValidScimUserBrig` similar
                     -- to `createValidScimUserSpar`?
                     uid <- Id <$> Random.uuid
-                    BrigAccess.createSAML uref uid stiTeam name ManagedByScim (Just handl) (Just richInfo)
+                    BrigAccess.createSAML uref uid stiTeam name ManagedByScim (Just handl) (Just richInfo) language
               )
               ( \email -> do
                   buid <- BrigAccess.createNoSAML email stiTeam name language

--- a/services/spar/src/Spar/Sem/BrigAccess.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess.hs
@@ -58,7 +58,7 @@ import Wire.API.User.RichInfo as RichInfo
 import Wire.API.User.Scim (ValidExternalId (..))
 
 data BrigAccess m a where
-  CreateSAML :: SAML.UserRef -> UserId -> TeamId -> Name -> ManagedBy -> Maybe Handle -> Maybe RichInfo -> BrigAccess m UserId
+  CreateSAML :: SAML.UserRef -> UserId -> TeamId -> Name -> ManagedBy -> Maybe Handle -> Maybe RichInfo -> Maybe Locale -> BrigAccess m UserId
   CreateNoSAML :: Email -> TeamId -> Name -> Maybe Locale -> BrigAccess m UserId
   UpdateEmail :: UserId -> Email -> BrigAccess m ()
   GetAccount :: HavePendingInvitations -> UserId -> BrigAccess m (Maybe UserAccount)

--- a/services/spar/src/Spar/Sem/BrigAccess.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess.hs
@@ -30,6 +30,7 @@ module Spar.Sem.BrigAccess
     setManagedBy,
     setVeid,
     setRichInfo,
+    setLocale,
     getRichInfo,
     checkHandleAvailable,
     delete,
@@ -38,6 +39,7 @@ module Spar.Sem.BrigAccess
     getStatus,
     getStatusMaybe,
     setStatus,
+    getDefaultUserLocale,
   )
 where
 
@@ -69,6 +71,7 @@ data BrigAccess m a where
   SetManagedBy :: UserId -> ManagedBy -> BrigAccess m ()
   SetVeid :: UserId -> ValidExternalId -> BrigAccess m ()
   SetRichInfo :: UserId -> RichInfo -> BrigAccess m ()
+  SetLocale :: UserId -> Maybe Locale -> BrigAccess m ()
   GetRichInfo :: UserId -> BrigAccess m RichInfo
   CheckHandleAvailable :: Handle -> BrigAccess m Bool
   Delete :: UserId -> BrigAccess m ()
@@ -77,5 +80,6 @@ data BrigAccess m a where
   GetStatus :: UserId -> BrigAccess m AccountStatus
   GetStatusMaybe :: UserId -> BrigAccess m (Maybe AccountStatus)
   SetStatus :: UserId -> AccountStatus -> BrigAccess m ()
+  GetDefaultUserLocale :: BrigAccess m Locale
 
 makeSem ''BrigAccess

--- a/services/spar/src/Spar/Sem/BrigAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess/Http.hs
@@ -41,7 +41,7 @@ brigAccessToHttp mgr req =
   interpret $
     viaRunHttp (RunHttpEnv mgr req) . \case
       CreateSAML u itlu itlt n m h ri ml -> Intra.createBrigUserSAML u itlu itlt n m h ri ml
-      CreateNoSAML e itlt n locale -> Intra.createBrigUserNoSAML e itlt n locale
+      CreateNoSAML e itlt n ml -> Intra.createBrigUserNoSAML e itlt n ml
       UpdateEmail itlu e -> Intra.updateEmail itlu e
       GetAccount h itlu -> Intra.getBrigUserAccount h itlu
       GetByHandle h -> Intra.getBrigUserByHandle h

--- a/services/spar/src/Spar/Sem/BrigAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess/Http.hs
@@ -51,6 +51,7 @@ brigAccessToHttp mgr req =
       SetManagedBy itlu m -> Intra.setBrigUserManagedBy itlu m
       SetVeid itlu v -> Intra.setBrigUserVeid itlu v
       SetRichInfo itlu r -> Intra.setBrigUserRichInfo itlu r
+      SetLocale itlu l -> Intra.setBrigUserLocale itlu l
       GetRichInfo itlu -> Intra.getBrigUserRichInfo itlu
       CheckHandleAvailable h -> Intra.checkHandleAvailable h
       Delete itlu -> Intra.deleteBrigUser itlu
@@ -59,3 +60,4 @@ brigAccessToHttp mgr req =
       GetStatus itlu -> Intra.getStatus itlu
       GetStatusMaybe itlu -> Intra.getStatusMaybe itlu
       SetStatus itlu a -> Intra.setStatus itlu a
+      GetDefaultUserLocale -> Intra.getDefaultUserLocale

--- a/services/spar/src/Spar/Sem/BrigAccess/Http.hs
+++ b/services/spar/src/Spar/Sem/BrigAccess/Http.hs
@@ -40,7 +40,7 @@ brigAccessToHttp ::
 brigAccessToHttp mgr req =
   interpret $
     viaRunHttp (RunHttpEnv mgr req) . \case
-      CreateSAML u itlu itlt n m h ri -> Intra.createBrigUserSAML u itlu itlt n m h ri
+      CreateSAML u itlu itlt n m h ri ml -> Intra.createBrigUserSAML u itlu itlt n m h ri ml
       CreateNoSAML e itlt n locale -> Intra.createBrigUserNoSAML e itlt n locale
       UpdateEmail itlu e -> Intra.updateEmail itlu e
       GetAccount h itlu -> Intra.getBrigUserAccount h itlu

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -1104,13 +1104,13 @@ testListProvisionedUsers = do
 
 testFindProvisionedUser :: TestSpar ()
 testFindProvisionedUser = do
-  defLocale <- getDefaultUserLocale
+  defLang <- lLanguage <$> getDefaultUserLocale
   user <- randomScimUser
   (tok, (_, _, _)) <- registerIdPAndScimToken
   storedUser <- createUser tok user
   [storedUser'] <- listUsers tok (Just (filterBy "userName" (Scim.User.userName user)))
   liftIO $ storedUser' `shouldBe` storedUser
-  liftIO $ Scim.value (Scim.thing storedUser') `shouldBe` normalizeLikeStored (withBrigDefaultLocaleAlt defLocale user {Scim.User.emails = [] {- only after validation -}})
+  liftIO $ Scim.value (Scim.thing storedUser') `shouldBe` normalizeLikeStored (setPreferredLanguage defLang user {Scim.User.emails = [] {- only after validation -}})
   let Just externalId = Scim.User.externalId user
   users' <- listUsers tok (Just (filterBy "externalId" externalId))
   liftIO $ users' `shouldBe` [storedUser]
@@ -1497,7 +1497,7 @@ testUserUpdateFailsWithNotFoundIfOutsideTeam = do
 -- | Test that @PUT@-ting the user and then @GET@-ting it returns the right thing.
 testScimSideIsUpdated :: TestSpar ()
 testScimSideIsUpdated = do
-  defLocale <- getDefaultUserLocale
+  defLang <- lLanguage <$> getDefaultUserLocale
   -- Create a user via SCIM
   user <- randomScimUser
   (tok, (_, _, idp)) <- registerIdPAndScimToken
@@ -1514,7 +1514,7 @@ testScimSideIsUpdated = do
   -- 'updateUser'
   richInfoLimit <- view (teOpts . to Spar.Types.richInfoLimit)
   liftIO $ do
-    Right (Scim.value (Scim.thing storedUser')) `shouldBe` whatSparReturnsFor idp richInfoLimit (withBrigDefaultLocaleAlt defLocale user')
+    Right (Scim.value (Scim.thing storedUser')) `shouldBe` whatSparReturnsFor idp richInfoLimit (setPreferredLanguage defLang user')
     Scim.id (Scim.thing storedUser') `shouldBe` Scim.id (Scim.thing storedUser)
     let meta = Scim.meta storedUser
         meta' = Scim.meta storedUser'
@@ -1549,7 +1549,7 @@ testUpdateToExistingExternalIdFails = do
 -- tries to set the name and handle, it might fail because the handle is "already claimed".
 testUpdateSameHandle :: TestSpar ()
 testUpdateSameHandle = do
-  defLocale <- getDefaultUserLocale
+  defLang <- lLanguage <$> getDefaultUserLocale
   -- Create a user via SCIM
   user <- randomScimUser
   (tok, (_, _, idp)) <- registerIdPAndScimToken
@@ -1570,7 +1570,7 @@ testUpdateSameHandle = do
   -- Check that the updated user also matches the data that we sent with 'updateUser'
   richInfoLimit <- view (teOpts . to Spar.Types.richInfoLimit)
   liftIO $ do
-    Right (Scim.value (Scim.thing storedUser')) `shouldBe` whatSparReturnsFor idp richInfoLimit (withBrigDefaultLocaleAlt defLocale user')
+    Right (Scim.value (Scim.thing storedUser')) `shouldBe` whatSparReturnsFor idp richInfoLimit (setPreferredLanguage defLang user')
     Scim.id (Scim.thing storedUser') `shouldBe` Scim.id (Scim.thing storedUser)
     let meta = Scim.meta storedUser
         meta' = Scim.meta storedUser'

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -477,6 +477,7 @@ specCreateUser = describe "POST /Users" $ do
     it "set locale to default and update to de" $ testCreateUserWithSamlIdPWithPreferredLanguage Nothing (Just (Locale (Language DE) Nothing))
     it "set locale to fr and update to de" $ testCreateUserWithSamlIdPWithPreferredLanguage (Just (Locale (Language FR) Nothing)) (Just (Locale (Language DE) Nothing))
     it "set locale to hr and update to de" $ testCreateUserWithSamlIdPWithPreferredLanguage (Just (Locale (Language HR) Nothing)) (Just (Locale (Language DE) Nothing))
+    it "set locale to hr and update to default" $ testCreateUserWithSamlIdPWithPreferredLanguage (Just (Locale (Language HR) Nothing)) Nothing
     it "set locale to default and update to default" $ testCreateUserWithSamlIdPWithPreferredLanguage (Just (Locale (Language HR) Nothing)) Nothing
   it "requires externalId to be present" $ testExternalIdIsRequired
   it "rejects invalid handle" $ testCreateRejectsInvalidHandle

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -1468,7 +1468,6 @@ testSameUpdateNoChange = do
   storedUser <- createUser tok user
   let userid = scimUserId storedUser
   storedUser' <- updateUser tok userid user
-  putStrLn $ "updated user = " <> show storedUser'
   liftIO $ storedUser `shouldBe` storedUser'
 
 -- | Test that @PUT /Users@ returns 4xx when called without the @:id@ part.
@@ -2158,7 +2157,6 @@ specSCIMManaged = do
       (tok, (owner, tid, _idp)) <- registerIdPAndScimToken
       scimStoredUser <- createUser tok user
       let _userid = scimUserId scimStoredUser
-      putStrLn $ "userid: " <> show _userid
       resp <-
         call $
           get (g . accept "text/csv" . paths ["teams", toByteString' tid, "members/csv"] . zUser owner) <!! do

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -691,6 +691,8 @@ testCreateUserWithSamlIdP = do
           . path "/self"
           . expect2xx
       )
+  putStrLn $ "Scim user locale: " <> show (scimPreferredLanguage scimStoredUser)
+  putStrLn $ "Brig user locale: " <> show (userLocale brigUser)
   brigUser `userShouldMatch` WrappedScimStoredUser scimStoredUser
   accStatus <- aFewTimes (runSpar $ BrigAccess.getStatus (userId brigUser)) (== Active)
   liftIO $ accStatus `shouldBe` Active

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -478,7 +478,7 @@ specCreateUser = describe "POST /Users" $ do
     it "set locale to fr and update to de" $ testCreateUserWithSamlIdPWithPreferredLanguage (Just (Locale (Language FR) Nothing)) (Just (Locale (Language DE) Nothing))
     it "set locale to hr and update to de" $ testCreateUserWithSamlIdPWithPreferredLanguage (Just (Locale (Language HR) Nothing)) (Just (Locale (Language DE) Nothing))
     it "set locale to hr and update to default" $ testCreateUserWithSamlIdPWithPreferredLanguage (Just (Locale (Language HR) Nothing)) Nothing
-    it "set locale to default and update to default" $ testCreateUserWithSamlIdPWithPreferredLanguage (Just (Locale (Language HR) Nothing)) Nothing
+    it "set locale to default and update to default" $ testCreateUserWithSamlIdPWithPreferredLanguage Nothing Nothing
   it "requires externalId to be present" $ testExternalIdIsRequired
   it "rejects invalid handle" $ testCreateRejectsInvalidHandle
   it "rejects occupied handle" $ testCreateRejectsTakenHandle

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -21,7 +21,6 @@ module Util.Scim where
 
 import Bilge
 import Bilge.Assert
-import Brig.Types.Intra (LocaleRsp (LocaleRsp))
 import Control.Lens
 import Control.Monad.Random
 import Data.ByteString.Conversion
@@ -666,9 +665,9 @@ whatSparReturnsFor idp richInfoSizeLimit =
   either (Left . show) (Right . synthesizeScimUser)
     . validateScimUser' "whatSparReturnsFor" (Just idp) richInfoSizeLimit
 
-withBrigDefaultLocaleAlt :: Locale -> Scim.User.User SparTag -> Scim.User.User SparTag
-withBrigDefaultLocaleAlt locale u =
-  u {Scim.preferredLanguage = Scim.preferredLanguage u <|> Just (lan2Text $ lLanguage locale)}
+setPreferredLanguage :: Language -> Scim.User.User SparTag -> Scim.User.User SparTag
+setPreferredLanguage lang u =
+  u {Scim.preferredLanguage = Scim.preferredLanguage u <|> Just (lan2Text lang)}
 
 -- this is not always correct, but hopefully for the tests that we're using it in it'll do.
 scimifyBrigUserHack :: User -> Email -> User
@@ -681,7 +680,7 @@ scimifyBrigUserHack usr email =
 getDefaultUserLocale :: TestSpar Locale
 getDefaultUserLocale = do
   env <- ask
-  LocaleRsp defLocale <-
+  LocaleUpdate defLocale <-
     fmap responseJsonUnsafe . call . get $
       ( (env ^. teBrig)
           . path "/i/users/locale"

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -140,8 +140,7 @@ randomScimUserWithSubjectAndRichInfo richInfo = do
         { Scim.User.displayName = Just ("ScimUser" <> suffix),
           Scim.User.externalId = Just externalId,
           Scim.User.emails = emails,
-          Scim.User.phoneNumbers = phones,
-          Scim.User.preferredLanguage = Just "de"
+          Scim.User.phoneNumbers = phones
         },
       subj
     )
@@ -665,6 +664,10 @@ whatSparReturnsFor :: HasCallStack => IdP -> Int -> Scim.User.User SparTag -> Ei
 whatSparReturnsFor idp richInfoSizeLimit =
   either (Left . show) (Right . synthesizeScimUser)
     . validateScimUser' "whatSparReturnsFor" (Just idp) richInfoSizeLimit
+
+withBrigDefaultLocaleAlt :: Locale -> Scim.User.User SparTag -> Scim.User.User SparTag
+withBrigDefaultLocaleAlt locale u =
+  u {Scim.preferredLanguage = Scim.preferredLanguage u <|> Just (lan2Text $ lLanguage locale)}
 
 -- this is not always correct, but hopefully for the tests that we're using it in it'll do.
 scimifyBrigUserHack :: User -> Email -> User

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -21,6 +21,7 @@ module Util.Scim where
 
 import Bilge
 import Bilge.Assert
+import Brig.Types.Intra (LocaleRsp (LocaleRsp))
 import Control.Lens
 import Control.Monad.Random
 import Data.ByteString.Conversion
@@ -676,3 +677,14 @@ scimifyBrigUserHack usr email =
     { userManagedBy = ManagedByScim,
       userIdentity = Just (SSOIdentity (UserScimExternalId (fromEmail email)) (Just email) Nothing)
     }
+
+getDefaultUserLocale :: TestSpar Locale
+getDefaultUserLocale = do
+  env <- ask
+  LocaleRsp defLocale <-
+    fmap responseJsonUnsafe . call . get $
+      ( (env ^. teBrig)
+          . path "/i/users/locale"
+          . expect2xx
+      )
+  pure defLocale


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1388

The `preferredLanguage` field from SCIM now maps to the user locale in BRIG and will be set and updated on post SCIM user and on update SCIM user using SAML.

When the `preferredLangauge` is not set in SCIM it will fall back to the `defaultUserLocale` defined in brig. This also works for updates.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.