### PR TITLE
Use rust image to build mls-test-cli

### DIFF
--- a/build/ubuntu/Dockerfile.deps
+++ b/build/ubuntu/Dockerfile.deps
@@ -1,23 +1,24 @@
+FROM rust:1.63 as mls-test-cli-builder
+
+# compile mls-test-cli tool
+RUN cd /tmp && \
+    git clone https://github.com/wireapp/mls-test-cli && \
+    cd mls-test-cli && \
+    cargo build --release
+
+
 FROM ubuntu:20.04 as cryptobox-builder
 
 # compile cryptobox-c
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -y cargo file libsodium-dev git pkg-config make curl && \
+    apt-get install -y cargo file libsodium-dev git pkg-config make && \
     cd /tmp && \
     git clone https://github.com/wireapp/cryptobox-c.git && \
     cd cryptobox-c && \
     export SODIUM_USE_PKG_CONFIG=1 && \
     cargo build --release
 
-# compile mls-test-cli tool
-# note: to make use of rustup's toolchain you need to prefix commands by . "$HOME/.cargo/env"
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN cd /tmp && \
-  git clone https://github.com/wireapp/mls-test-cli && \
-  cd mls-test-cli && \
-  . "$HOME/.cargo/env" && \
-  cargo build --release
 
 # Minimal dependencies for ubuntu-compiled, dynamically linked wire-server Haskell services
 FROM ubuntu:20.04
@@ -26,7 +27,7 @@ COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /u
 
 # FUTUREWORK: only copy mls-test-cli executables if we are building an
 # integration test image
-COPY --from=cryptobox-builder /tmp/mls-test-cli/target/release/mls-test-cli /usr/bin
+COPY --from=mls-test-cli-builder /tmp/mls-test-cli/target/release/mls-test-cli /usr/bin
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \

--- a/build/ubuntu/Dockerfile.deps
+++ b/build/ubuntu/Dockerfile.deps
@@ -3,7 +3,7 @@ FROM ubuntu:20.04 as cryptobox-builder
 # compile cryptobox-c
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -y cargo file libsodium-dev git pkg-config make && \
+    apt-get install -y cargo file libsodium-dev git pkg-config make curl && \
     cd /tmp && \
     git clone https://github.com/wireapp/cryptobox-c.git && \
     cd cryptobox-c && \
@@ -11,9 +11,12 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     cargo build --release
 
 # compile mls-test-cli tool
+# note: to make use of rustup's toolchain you need to prefix commands by . "$HOME/.cargo/env"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN cd /tmp && \
   git clone https://github.com/wireapp/mls-test-cli && \
   cd mls-test-cli && \
+  . "$HOME/.cargo/env" && \
   cargo build --release
 
 # Minimal dependencies for ubuntu-compiled, dynamically linked wire-server Haskell services


### PR DESCRIPTION
## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
