### PR TITLE
Bump mls-test-cli

### DIFF
--- a/libs/metrics-core/src/Data/Metrics.hs
+++ b/libs/metrics-core/src/Data/Metrics.hs
@@ -214,7 +214,7 @@ gaugeDecr = gaugeAdd (-1)
 
 -- | Subtract the given amount from the gauge at 'Path'
 gaugeSub :: MonadIO m => Double -> Path -> Metrics -> m ()
-gaugeSub x = gaugeAdd (- x)
+gaugeSub x = gaugeAdd (-x)
 
 -- | Get the current value of the Gauge
 gaugeValue :: MonadIO m => Gauge -> m Double

--- a/libs/wire-api/src/Wire/API/Asset.hs
+++ b/libs/wire-api/src/Wire/API/Asset.hs
@@ -420,7 +420,7 @@ instance
   fromUnion (Z (I _)) = Nothing
   fromUnion (S (Z (I loc))) = Just (LocalAsset loc)
   fromUnion (S (S (Z (I asset)))) = Just (RemoteAsset asset)
-  fromUnion (S (S (S x))) = case x of
+  fromUnion (S (S (S x))) = case x of {}
 
 makeLenses ''Asset'
 makeLenses ''AssetSettings

--- a/libs/wire-api/src/Wire/API/Error.hs
+++ b/libs/wire-api/src/Wire/API/Error.hs
@@ -305,4 +305,4 @@ instance
   toUnion (Just x) = S (Z (I x))
   fromUnion (Z (I _)) = Nothing
   fromUnion (S (Z (I x))) = Just x
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -411,7 +411,7 @@ class IsResponseList cs as where
   responseListStatuses :: [Status]
 
 instance IsResponseList cs '[] where
-  responseListRender _ x = case x of
+  responseListRender _ x = case x of {}
   responseListUnrender _ _ = empty
   responseListStatuses = []
 
@@ -517,7 +517,7 @@ class InjectBefore as bs where
   injectBefore :: Union as -> Union (as .++ bs)
 
 instance InjectBefore '[] bs where
-  injectBefore x = case x of
+  injectBefore x = case x of {}
 
 instance InjectBefore as bs => InjectBefore (a ': as) bs where
   injectBefore (Z x) = Z x
@@ -589,8 +589,8 @@ class AsConstructors xss rs where
   fromSOP :: SOP I xss -> Union (ResponseTypes rs)
 
 instance AsConstructors '[] '[] where
-  toSOP x = case x of
-  fromSOP x = case x of
+  toSOP x = case x of {}
+  fromSOP x = case x of {}
 
 instance AsConstructor '[a] (Respond code desc a) where
   toConstructor x = I x :* Nil
@@ -653,7 +653,7 @@ instance
 
   fromUnion (Z (I ())) = False
   fromUnion (S (Z (I ()))) = True
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}
 
 -- | A handler for a pair of responses where the first is empty can be
 -- implemented simply by returning a 'Maybe' value. The convention is that the
@@ -669,7 +669,7 @@ instance
 
   fromUnion (Z (I ())) = Nothing
   fromUnion (S (Z (I x))) = Just x
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}
 
 instance
   (SwaggerMethod method, IsSwaggerResponseList as) =>

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -85,7 +85,7 @@ type family FMap (f :: a -> b) (m :: Maybe a) :: Maybe b where
   FMap _ 'Nothing = 'Nothing
   FMap f ('Just a) = 'Just (f a)
 
-type family LookupEndpoint api name :: Maybe * where
+type family LookupEndpoint api name :: Maybe (*) where
   LookupEndpoint (Named name endpoint) name = 'Just endpoint
   LookupEndpoint (api1 :<|> api2) name =
     MappendMaybe

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -91,7 +91,7 @@ instance AsUnion DeleteSelfResponses (Maybe Timeout) where
   toUnion Nothing = Z (I ())
   fromUnion (Z (I ())) = Nothing
   fromUnion (S (Z (I (DeletionCodeTimeout t)))) = Just t
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}
 
 type ConnectionUpdateResponses = UpdateResponses "Connection unchanged" "Connection updated" UserConnection
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -105,7 +105,7 @@ instance
 
   fromUnion (Z (I c)) = CodeAlreadyExisted c
   fromUnion (S (Z (I e))) = CodeAdded e
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}
 
 type ConvUpdateResponses = UpdateResponses "Conversation unchanged" "Conversation updated" Event
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Util.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Util.hs
@@ -35,7 +35,7 @@ instance
 
   fromUnion (Z (I x)) = Existed x
   fromUnion (S (Z (I x))) = Created x
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}
 
 -- Note: order is important here; if you swap Existed with Created, the wrong
 -- status codes will be returned. Keep the Order in ResponseForExistedCreated
@@ -76,7 +76,7 @@ instance
 
   fromUnion (Z (I ())) = Unchanged
   fromUnion (S (Z (I a))) = Updated a
-  fromUnion (S (S x)) = case x of
+  fromUnion (S (S x)) = case x of {}
 
 type PaginationDocs =
   "The IDs returned by this endpoint are paginated. To get the first page, make\

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationCoverView.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationCoverView.hs
@@ -15,7 +15,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
--- |
+--
 module Test.Wire.API.Golden.Manual.ConversationCoverView where
 
 import Data.Id (Id (Id))

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,13 +6,6 @@ let
     overlays = [
       # All wire-server specific packages
       (import ./overlay.nix)
-    ];
-  };
-
-  # a different pin for building wire-server docs.
-  # should eventually be moved to use the same pin.
-  pkgsDocs = import sources.nixpkgsDocs {
-    overlays = [
       (import ./overlay-docs.nix)
     ];
   };
@@ -141,8 +134,8 @@ let
 
   # packages necessary to build wire-server docs
   docsPkgs = [
-    pkgsDocs.texlive.combined.scheme-full
-    (pkgsDocs.python3.withPackages
+    pkgs.texlive.combined.scheme-full
+    (pkgs.python3.withPackages
       (ps: with ps; [
         myst-parser
         rst2pdf
@@ -172,13 +165,14 @@ let
     {
       name = "wire-server-docs-env";
       paths = [
-        pkgsDocs.awscli
-        pkgsDocs.jq
-        pkgsDocs.niv
-        pkgsDocs.zip
-        pkgsDocs.entr
+        pkgs.awscli
+        pkgs.jq
+        pkgs.niv
+        pkgs.zip
+        pkgs.entr
       ] ++ docsPkgs;
     };
+  mls_test_cli = pkgs.mls_test_cli;
 in
 {
   inherit pkgs devPackages devEnv docs docsEnv compile-deps;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -175,5 +175,5 @@ let
   mls_test_cli = pkgs.mls_test_cli;
 in
 {
-  inherit pkgs devPackages devEnv docs docsEnv compile-deps;
+  inherit pkgs devPackages devEnv docs docsEnv compile-deps mls_test_cli;
 }

--- a/nix/overlay-docs.nix
+++ b/nix/overlay-docs.nix
@@ -8,5 +8,7 @@ self: super: rec {
     };
   });
 
+  mls_test_cli = self.callPackage ./pkgs/mls_test_cli { };
+
   python3Packages = python3.pkgs;
 }

--- a/nix/pkgs/mls_test_cli/default.nix
+++ b/nix/pkgs/mls_test_cli/default.nix
@@ -9,15 +9,18 @@
 
 rustPlatform.buildRustPackage rec {
   name = "mls-test-cli-${version}";
-  version = "0.2.0";
+  version = "0.3.0";
   nativeBuildInputs = [ pkg-config perl ];
   buildInputs = [ libsodium ];
   src = fetchFromGitHub {
     owner = "wireapp";
     repo = "mls-test-cli";
-    sha256 = "sha256:0f3d9dhnxf0nx9vz9hrfhx1lkash5891wxz2163widw5nra66cvi";
-    rev = "14963eb639847f9ab9ff62c0660d02899935e776";
+    sha256 = "sha256-5CjGd7Di58XvseC0zmkU2Xc5t2qH/g1a6cjDDQvrCsU=";
+    rev = "aeead948a40d968119c847741f4610a25ab94595";
   };
   doCheck = false;
-  cargoSha256 = "sha256:1cwyzn5gwzdb92k1b02yzpj1mv9x8vnx329v54qsm089nq5drp11";
+  cargoSha256 = "sha256-UOB+fiHjz2xUP50CN766aT9TDVpd5Ebd+EDxrddmJbo=";
+  cargoDepsHook = ''
+    mkdir -p mls-test-cli-0.3.0-vendor.tar.gz/ring/.git
+  '';
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,22 +5,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7cd44abcc3f01accbcc450d4d67609a5ea3448ec",
-        "sha256": "0f8d797mhpxggq5idlbgsvf1nlknf5yh966mnl3bian32m11rik2",
+        "rev": "964d60ff2e6bc76c0618962da52859603784fa78",
+        "sha256": "1qvs9a59araglrrbzp5zdx81nmjgaxpfp36yl708il0lyqdjawvd",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/7cd44abcc3f01accbcc450d4d67609a5ea3448ec.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nixpkgsDocs": {
-        "branch": "nixpkgs-unstable",
-        "description": "Nix Packages collection",
-        "homepage": "",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5f9b871b72b24f066b1a1e189efd0669f2888c49",
-        "sha256": "1lldnr2ik3wwx1mqcq93bs83dp0g0fxvcrgbbjwg9p9brgdfx3sv",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5f9b871b72b24f066b1a1e189efd0669f2888c49.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/964d60ff2e6bc76c0618962da52859603784fa78.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -31,8 +31,28 @@ let
           if spec ? branch then "refs/heads/${spec.branch}" else
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules == true
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                {}
+            else {};
+        in
+          if nixSupportsSubmodules
+          then { inherit submodules; }
+          else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
+      builtins.fetchGit
+        ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 

--- a/services/brig/src/Brig/Data/Activation.hs
+++ b/services/brig/src/Brig/Data/Activation.hs
@@ -185,7 +185,7 @@ verifyCode key code = do
     Just (ttl, Ascii t, k, c, u, r) ->
       if
           | c == code -> mkScope t k u
-          | r >= 1 -> countdown (key, t, k, c, u, r -1, ttl) >> throwE invalidCode
+          | r >= 1 -> countdown (key, t, k, c, u, r - 1, ttl) >> throwE invalidCode
           | otherwise -> revoke >> throwE invalidCode
     Nothing -> throwE invalidCode
   where

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -141,7 +141,7 @@ addClientWithReAuthPolicy reAuthPolicy u newId c maxPermClients loc cps = do
   when (reAuthPolicy count upsert) $
     fmapLT ClientReAuthError $
       User.reauthenticate u (newClientPassword c)
-  let capacity = fmap (+ (- count)) limit
+  let capacity = fmap (+ (-count)) limit
   unless (maybe True (> 0) capacity || upsert) $
     throwE TooManyClients
   new <- insert

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -168,7 +168,7 @@ mustSuspendInactiveUser uid =
     Just (SuspendInactiveUsers (Timeout suspendAge)) -> do
       now <- liftIO =<< view currentTime
       let suspendHere :: UTCTime
-          suspendHere = addUTCTime (- suspendAge) now
+          suspendHere = addUTCTime (-suspendAge) now
           youngEnough :: Cookie () -> Bool
           youngEnough = (>= suspendHere) . cookieCreated
       ckies <- listCookies uid []

--- a/services/brig/test/integration/API/Team.hs
+++ b/services/brig/test/integration/API/Team.hs
@@ -558,7 +558,7 @@ testInvitationMutuallyExclusive brig = do
 testInvitationTooManyMembers :: Brig -> Galley -> TeamSizeLimit -> Http ()
 testInvitationTooManyMembers brig galley (TeamSizeLimit limit) = do
   (creator, tid) <- createUserWithTeam brig
-  pooledForConcurrentlyN_ 16 [1 .. limit -1] $ \_ -> do
+  pooledForConcurrentlyN_ 16 [1 .. limit - 1] $ \_ -> do
     void $ createTeamMember brig galley creator tid fullPermissions
   SearchUtil.refreshIndex brig
   let invite email = stdInvitationRequest email
@@ -651,7 +651,7 @@ testInvitationInfoExpired brig timeout = do
       liftIO $ threadDelay 1000000
       r <- getCode t i
       when (statusCode r == 200 && n > 0) $
-        awaitExpiry (n -1) t i
+        awaitExpiry (n - 1) t i
 
 testSuspendTeam :: Brig -> Http ()
 testSuspendTeam brig = do

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -531,7 +531,7 @@ testCreateUserBlacklist _ brig aws =
       r <- Bilge.head (brig . path "i/users/blacklist" . queryItem "email" (toByteString' e))
       when (statusCode r == 404 && n > 0) $ do
         liftIO $ threadDelay 1000000
-        awaitBlacklist (n -1) e
+        awaitBlacklist (n - 1) e
 
 testCreateUserExternalSSO :: Brig -> Http ()
 testCreateUserExternalSSO brig = do
@@ -574,7 +574,7 @@ testActivateWithExpiry _ brig timeout = do
       liftIO $ threadDelay 1000000
       r <- activate brig kc
       when (statusCode r == 204 && n > 0) $
-        awaitExpiry (n -1) kc
+        awaitExpiry (n - 1) kc
 
 testNonExistingUserUnqualified :: Brig -> Http ()
 testNonExistingUserUnqualified brig = do
@@ -792,7 +792,7 @@ testCreateUserAnonExpiry b = do
       r <- getProfile zusr uid
       when (statusCode r == 200 && isNothing (deleted r) && n > 0) $ do
         liftIO $ threadDelay 1000000
-        awaitExpiry (n -1) zusr uid
+        awaitExpiry (n - 1) zusr uid
     ensureExpiry :: UTCTime -> Maybe UTCTime -> String -> Http ()
     ensureExpiry now expiry s = case expiry of
       Nothing -> liftIO $ assertFailure ("user must have an expiry" <> s)

--- a/services/gundeck/test/unit/DelayQueue.hs
+++ b/services/gundeck/test/unit/DelayQueue.hs
@@ -80,7 +80,7 @@ dequeueOrderProp k = ioProperty $ do
   q <- DelayQueue.new (Clock (readIORef c)) (Delay 1) (Limit 2)
   e1 <- DelayQueue.enqueue q k (1 :: Int)
   tick c
-  e2 <- DelayQueue.enqueue q (k -1) (2 :: Int)
+  e2 <- DelayQueue.enqueue q (k - 1) (2 :: Int)
   tick c
   d1 <- DelayQueue.dequeue q
   d2 <- DelayQueue.dequeue q

--- a/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
+++ b/tools/api-simulations/smoketest/src/Network/Wire/Simulations/SmokeTest.hs
@@ -56,7 +56,7 @@ mainBotNet n = do
   info $ msg $ "Starting Smoke Test with " <> show n <> " bots"
   -- Create some participants: Ally, Bill, Carl, and a bunch of goons
   [ally, bill, carl] <- mapM newBot ["Ally", "Bill", "Carl"]
-  goons <- for [1 .. n -3] $ \i ->
+  goons <- for [1 .. n - 3] $ \i ->
     newBot (fromString ("Goon" <> show i))
   -- Set up a connection from Ally to someone
   let allyConnectTo :: Bot -> BotSession ConvId


### PR DESCRIPTION
Updated mls-test-cli dependency, and the pin nixpkgs itself. Also removed the nixpkgs pin for building the docs.

This required some fiddling with rust dependencies (in particular the `ring` crate), since it seems to require the presence of a `.git` directory in order to build successfully. Hopefully this kludge can be removed eventually once the rust libraries mature.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.