### PR TITLE
Use dynamically linked Haskell Language Server in direnv

### DIFF
--- a/changelog.d/5-internal/dynamically-linked-hls
+++ b/changelog.d/5-internal/dynamically-linked-hls
@@ -1,0 +1,1 @@
+Provide a dynamically linked binary of Haskell Language Server (HLS) in the local environment to resolve issues regarding Template Haskell and HLS.

--- a/docs/legacy/developer/editor-setup.md
+++ b/docs/legacy/developer/editor-setup.md
@@ -67,6 +67,11 @@ be put in the root directory of the project:
                   )))
 ```
 
+To be compatible with *Template Haskell* we're using a dynamically linked binary
+of HLS (please see
+https://haskell-language-server.readthedocs.io/en/latest/troubleshooting.html#static-binaries
+for details).
+
 ### Ormolu integration
 
 There are make targets `format`, `formatf`, `formatc` to re-format

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -83,7 +83,10 @@ let
   '';
 
   devPackages = [
-    (pkgs.haskell-language-server.override { supportedGhcVersions = [ "8107" ]; })
+    (pkgs.haskell-language-server.override {
+      dynamic = true;
+      supportedGhcVersions = [ "8107" ];
+    })
     pkgs.cfssl
     pkgs.mls_test_cli
     pkgs.ghcid


### PR DESCRIPTION
This fixes the issues with HLS + Template Haskell ("This HLS binary does not support Template Haskell. Follow the [instructions](https://haskell-language-server.readthedocs.io/en/latest/troubleshooting.html#static-binaries) to build an HLS binary with support for Template Haskell. ")

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
