### PR TITLE
gundeck/cassandra: TWCS for 'notifications' table

### DIFF
--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -602,7 +602,7 @@ CREATE TABLE gundeck_test.notifications (
     AND bloom_filter_fp_chance = 0.1
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'tombstone_threshold': '0.1'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy', 'compaction_window_size': '1', 'compaction_window_unit': 'DAYS', 'max_threshold': '32', 'min_threshold': '4'}
     AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1

--- a/changelog.d/5-internal/gundeck-notifications-cassandra-compaction-strategy
+++ b/changelog.d/5-internal/gundeck-notifications-cassandra-compaction-strategy
@@ -1,0 +1,4 @@
+In Gundeck's 'notifications' cassandra table, switch to [TWCS](https://cassandra.apache.org/doc/latest/cassandra/operating/compaction/twcs.html) compaction strategy, which should be more efficient for this workload, and possibly bring performance benefits to latencies.
+It may be beneficial to run a manual compaction before rolling out this
+change (but things should also work without this manual operation).
+In case you have time, run the following from a cassandra machine before deploying this update: `nodetool compact gundeck notifications`.

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -338,6 +338,7 @@ executable gundeck-schema
     V6
     V7
     V8
+    V9
 
   hs-source-dirs:     schema/src
   default-extensions:

--- a/services/gundeck/schema/src/V9.hs
+++ b/services/gundeck/schema/src/V9.hs
@@ -27,6 +27,7 @@ import Text.RawString.QQ
 migration :: Migration
 migration = Migration 9 "Remove deprecated tables" $ do
   -- all data in notifications is written with a TTL, therefore should be a good fit for TWCS.
-  -- TTL is 28 days, so 28 windows of 1 day each fits well with the suggestion of 20-30 windows.
+  -- TTL is 28 days (see https://github.com/wireapp/wire-server/blob/434f7a874ce5e3f7e3e57aa98afb6441d4a53169/charts/gundeck/templates/configmap.yaml#L51)
+  -- so 28 windows of 1 day each fits well with the suggestion of 20-30 windows.
   -- https://cassandra.apache.org/doc/latest/cassandra/operating/compaction/twcs.html
   schema' [r| ALTER TABLE notifications WITH compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'DAYS', 'compaction_window_size': 1}; |]

--- a/services/gundeck/schema/src/V9.hs
+++ b/services/gundeck/schema/src/V9.hs
@@ -15,41 +15,18 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Main where
+module V9
+  ( migration,
+  )
+where
 
 import Cassandra.Schema
-import Control.Exception (finally)
 import Imports
-import qualified System.Logger.Extended as Log
-import Util.Options
-import qualified V1
-import qualified V2
-import qualified V3
-import qualified V4
-import qualified V5
-import qualified V6
-import qualified V7
-import qualified V8
-import qualified V9
+import Text.RawString.QQ
 
-main :: IO ()
-main = do
-  o <- getOptions desc (Just migrationOptsParser) defaultPath
-  l <- Log.mkLogger'
-  migrateSchema
-    l
-    o
-    [ V1.migration,
-      V2.migration,
-      V3.migration,
-      V4.migration,
-      V5.migration,
-      V6.migration,
-      V7.migration,
-      V8.migration,
-      V9.migration
-    ]
-    `finally` Log.close l
-  where
-    desc = "Gundeck Cassandra Schema Migrations"
-    defaultPath = "/etc/wire/gundeck/conf/gundeck-schema.yaml"
+migration :: Migration
+migration = Migration 9 "Remove deprecated tables" $ do
+  -- all data in notifications is written with a TTL, therefore should be a good fit for TWCS.
+  -- TTL is 30 days, so 30 windows of 1 day each fits well with the suggestion of 20-30 windows.
+  -- https://cassandra.apache.org/doc/latest/cassandra/operating/compaction/twcs.html
+  schema' [r| ALTER TABLE notifications WITH compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'DAYS', 'compaction_window_size': 1}; |]

--- a/services/gundeck/schema/src/V9.hs
+++ b/services/gundeck/schema/src/V9.hs
@@ -27,6 +27,6 @@ import Text.RawString.QQ
 migration :: Migration
 migration = Migration 9 "Remove deprecated tables" $ do
   -- all data in notifications is written with a TTL, therefore should be a good fit for TWCS.
-  -- TTL is 30 days, so 30 windows of 1 day each fits well with the suggestion of 20-30 windows.
+  -- TTL is 28 days, so 28 windows of 1 day each fits well with the suggestion of 20-30 windows.
   -- https://cassandra.apache.org/doc/latest/cassandra/operating/compaction/twcs.html
   schema' [r| ALTER TABLE notifications WITH compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'DAYS', 'compaction_window_size': 1}; |]


### PR DESCRIPTION
In Gundeck's 'notifications' cassandra table, switch to [TWCS](https://cassandra.apache.org/doc/latest/cassandra/operating/compaction/twcs.html) compaction strategy, which should be more efficient for this workload, and possibly bring performance benefits to latencies.

It may be beneficial to run a manual compaction before rolling out this
change (but things should also work without this manual operation).

In case you have time, run the following before deploying this update:

```
nodetool compact gundeck notifications
```

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
