### PR TITLE
port checklist documentation over to docs, and adjust PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,13 +3,10 @@
  - [ ] The **PR Title** explains the impact of the change.
  - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
  - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
- - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
+ - [ ] If HTTP endpoint paths have been added or renamed, check [docs/developer/adding-api-endpoints](https://github.com/wireapp/wire-server/blob/develop/docs/legacy/developer/adding-api-endpoints.md) and follow the steps there.
+ - [ ] If configuration options have been added or removed, check [docs/developer/adding-config-options](https://github.com/wireapp/wire-server/blob/develop/docs/legacy/developer/adding-config-options.md) and follow the steps there.
  - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
- - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
-   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
-   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
-   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
+- [ ] I swear that if I have changed internal end-points, I do not implicitly rely on deployment ordering (brig needing to be deployed before galley), i.e. I have **not** introduced a new internal endpoint in brig and already make use of if in galley, as I'm aware old deployed galleys would throw 500s until all new version have been rolled out and I do not want a few minutes of downtime. Instead, I have thought how to merge brig an galley codebases.
+ - [ ] I updated **changelog.d** subsections with one or more entries with the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
    - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
    - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
-   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
-   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?

--- a/changelog.d/5-internal/internal-PR-template-processes
+++ b/changelog.d/5-internal/internal-PR-template-processes
@@ -1,0 +1,1 @@
+Adjust developer PR template and document config and API procedures in-tree.

--- a/docs/legacy/developer/adding-api-endpoints.md
+++ b/docs/legacy/developer/adding-api-endpoints.md
@@ -1,0 +1,32 @@
+## Adding new endpoints in wire-server
+
+When adding new endpoints in the Haskell code in wire-server, correct routing needs to be applied on the nginz level.
+
+NB: The nginz paths are interpreted as *prefixes*.  If you add a new end-point that is identical to an existing one except for the path of the latter being a proper prefix of the former, and if the nginz configuration of the two paths should be the same, nothing needs to be done.  Exception: if you see a path like `/self$`, you know it doesn't match `/self/sub/what`.
+
+Let's assume you add (verbs like GET/PUT are not relevant on nginz level atm) the following:
+
+```
+GET /new/endpoint
+POST /turtles
+PUT /turtles/<turtleId>/name
+```
+
+to `galley`. The following needs to be done, ***as part of your PR***.
+
+* (1) Update nginz config under `wire-server/charts/nginz/values.yaml`
+    * For the above example, the following needs adding under the `galley` section:
+        ```
+        - path: /new/endpoint
+        - path: ^/turtles(.*)
+        ```
+    * For internal endpoints for QA access on staging environments, copy a block with `/i/` containing
+        ```
+        zauth: false
+        basic_auth: true
+        whitelisted_envs: ['staging']
+        ```
+    * For customer support access to an internal endpoint, instead update code in [stern](https://github.com/wireapp/wire-server/tree/develop/tools/stern) as part of your PR (no need to add that endpoint to nginz)
+* (2) Update nginz config in the demo in wire-server (as part of the haskell change PR ideally)
+  * [ ] Update [this file](https://github.com/wireapp/wire-server/blob/develop/deploy/services-demo/conf/nginz/nginx.conf)
+    * Use `common_response_no_zauth.conf;` for public endpoints without authentication and `common_response_with_zauth.conf;` for the normal (authenticated) endpoints. Browse the file to see examples.

--- a/docs/legacy/developer/adding-config-options.md
+++ b/docs/legacy/developer/adding-config-options.md
@@ -1,0 +1,32 @@
+<!-- vim-markdown-toc GFM -->
+
+* [Adding new configuration flags in wire-server](#adding-new-configuration-flags-in-wire-server)
+    * [Removing configuration flags](#removing-configuration-flags)
+    * [Renaming configuration flags](#renaming-configuration-flags)
+
+<!-- vim-markdown-toc -->
+
+## Adding new configuration flags in wire-server
+
+While developing code for e.g. `brig` in `wire-server`, edit:
+
+* [ ] the parser under `services/brig/src/Brig/Options.hs`
+* [ ] the integration test config: `services/brig/brig.integration.yaml`
+* [ ] the demo config: under `deploy/services-demo/conf/` files `brig.demo.yaml` and `brig.demo-docker.yaml`
+* [ ] the charts: `charts/brig/templates/configmap.yaml` (and maybe `charts/brig/values.yaml` for defaults, and `hack/helm_vars/wire-server/values.yaml` for different values during CI integration tests)
+* [ ] Add usage description under `docs/legacy/reference/config-options.md`
+
+If your configuration value is new and required, and has no default, then you need to
+
+* [ ] advertise this in the `./changelog.d/0-release-notes/` for other wire-server operators to know about.
+* [ ] update all the environments into which code will get deployed to. For wire Cloud, look into all the relevant environments (search for `helm_vars/wire-server/values.yaml.gotmpl` files.) (these configuration updates should ideally be merged **before** merging your PR to wire-server/develop.
+
+### Removing configuration flags
+
+Remove them with the PR from wire-server `./charts` folder, as charts are linked to code and go hand-in hand. Possibly notify all operators (through `./changelog.d/0-release-notes/`) that some overrides may not have any effect anymore.
+
+### Renaming configuration flags
+
+Avoid doing this. If you must, see Removing/adding sections above. But please note that all people who have an installation of wire also may have overridden any of the configuration option you may wish to change the name of. As this is not type checked, it's very error prone and people may find themselves with default configuration values being used instead of their intended configuration settings. Guideline: only rename for good reasons, not for aesthetics; or be prepared to spend a significant
+amount on documenting and communication about this change.
+


### PR DESCRIPTION
Old documentation was at
https://github.com/zinfra/backend-wiki/wiki/Checklists and was partially
outdated due to hegemony not being a thing anymore. Updated docs.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):