### PR TITLE
Add additional checks on incoming MLS messages

### DIFF
--- a/changelog.d/5-internal/FS-797
+++ b/changelog.d/5-internal/FS-797
@@ -1,0 +1,4 @@
+Add additional checks on incoming MLS messages:
+* if the sender matches the authenticated user
+* if the sender of message to a remote conversation is a member
+* if the group ID of a remote conversation matches the local mapping

--- a/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
+++ b/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
@@ -74,9 +74,9 @@ library
 
   build-depends:
       base             >=4.6 && <5.0
+    , cassandra-util
     , HsOpenSSL
     , hspec
-    , cassandra-util
     , imports
     , polysemy
     , polysemy-check

--- a/libs/wire-api/src/Wire/API/Error/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Error/Galley.hs
@@ -80,6 +80,7 @@ data GalleyError
   | MLSCommitMissingReferences
   | MLSSelfRemovalNotAllowed
   | MLSGroupConversationMismatch
+  | MLSClientSenderUserMismatch
   | --
     NoBindingTeamMembers
   | NoBindingTeam
@@ -196,6 +197,8 @@ type instance MapError 'MLSCommitMissingReferences = 'StaticError 409 "mls-commi
 type instance MapError 'MLSSelfRemovalNotAllowed = 'StaticError 409 "mls-self-removal-not-allowed" "Self removal from group is not allowed"
 
 type instance MapError 'MLSGroupConversationMismatch = 'StaticError 409 "mls-group-conversation-mismatch" "Conversation ID resolved from Group ID does not match submitted Conversation ID"
+
+type instance MapError 'MLSClientSenderUserMismatch = 'StaticError 409 "mls-client-sender-user-mismatch" "User ID resolved from Client ID does not match message's sender user ID"
 
 type instance MapError 'NoBindingTeamMembers = 'StaticError 403 "non-binding-team-members" "Both users must be members of the same binding team"
 

--- a/libs/wire-api/src/Wire/API/Error/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Error/Galley.hs
@@ -79,6 +79,7 @@ data GalleyError
   | MLSStaleMessage
   | MLSCommitMissingReferences
   | MLSSelfRemovalNotAllowed
+  | MLSGroupConversationMismatch
   | --
     NoBindingTeamMembers
   | NoBindingTeam
@@ -193,6 +194,8 @@ type instance MapError 'MLSStaleMessage = 'StaticError 409 "mls-stale-message" "
 type instance MapError 'MLSCommitMissingReferences = 'StaticError 409 "mls-commit-missing-references" "The commit is not refrencing all pending proposals"
 
 type instance MapError 'MLSSelfRemovalNotAllowed = 'StaticError 409 "mls-self-removal-not-allowed" "Self removal from group is not allowed"
+
+type instance MapError 'MLSGroupConversationMismatch = 'StaticError 409 "mls-group-conversation-mismatch" "Conversation ID resolved from Group ID does not match submitted Conversation ID"
 
 type instance MapError 'NoBindingTeamMembers = 'StaticError 403 "non-binding-team-members" "Both users must be members of the same binding team"
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1333,6 +1333,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MLSStaleMessage
                :> CanThrow 'MLSUnsupportedMessage
                :> CanThrow 'MLSUnsupportedProposal
+               :> CanThrow 'MLSGroupConversationMismatch
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow MLSProposalFailure
                :> "messages"
@@ -1357,6 +1358,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MLSStaleMessage
                :> CanThrow 'MLSUnsupportedMessage
                :> CanThrow 'MLSUnsupportedProposal
+               :> CanThrow 'MLSGroupConversationMismatch
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow MLSProposalFailure
                :> "messages"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1333,6 +1333,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MLSStaleMessage
                :> CanThrow 'MLSUnsupportedMessage
                :> CanThrow 'MLSUnsupportedProposal
+               :> CanThrow 'MLSClientSenderUserMismatch
                :> CanThrow 'MLSGroupConversationMismatch
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow MLSProposalFailure
@@ -1358,6 +1359,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MLSStaleMessage
                :> CanThrow 'MLSUnsupportedMessage
                :> CanThrow 'MLSUnsupportedProposal
+               :> CanThrow 'MLSClientSenderUserMismatch
                :> CanThrow 'MLSGroupConversationMismatch
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow MLSProposalFailure

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -583,7 +583,7 @@ sendMLSMessage remoteDomain msr =
       raw <- either (throw . mlsProtocolError) pure $ decodeMLS' (fromBase64ByteString (F.msrRawMessage msr))
       mapToGalleyError @MLSMessageStaticErrors $
         F.MLSMessageResponseUpdates . map lcuUpdate
-          <$> postMLSMessage loc (qUntagged sender) (Just $ F.msrConvId msr) Nothing raw
+          <$> postMLSMessage loc (qUntagged sender) Nothing raw
 
 class ToGalleyRuntimeError (effs :: EffectRow) r where
   mapToGalleyError ::

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -586,7 +586,7 @@ sendMLSMessage remoteDomain msr =
         case rmValue raw of
           SomeMessage _ msg -> do
             qcnv <- E.getConversationIdByGroupId (msgGroupId msg) >>= noteS @'ConvNotFound
-            when (qUnqualified qcnv /= F.msrConvId msr) $ throwS @'MLSUnsupportedMessage
+            when (qUnqualified qcnv /= F.msrConvId msr) $ throwS @'MLSGroupConversationMismatch
             F.MLSMessageResponseUpdates . map lcuUpdate
               <$> postMLSMessage loc (qUntagged sender) qcnv Nothing raw
 

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -583,7 +583,7 @@ sendMLSMessage remoteDomain msr =
       raw <- either (throw . mlsProtocolError) pure $ decodeMLS' (fromBase64ByteString (F.msrRawMessage msr))
       mapToGalleyError @MLSMessageStaticErrors $
         F.MLSMessageResponseUpdates . map lcuUpdate
-          <$> postMLSMessage loc (qUntagged sender) Nothing raw
+          <$> postMLSMessage loc (qUntagged sender) (Just $ F.msrConvId msr) Nothing raw
 
 class ToGalleyRuntimeError (effs :: EffectRow) r where
   mapToGalleyError ::

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -94,6 +94,7 @@ type MLSMessageStaticErrors =
      ErrorS 'MLSUnsupportedProposal,
      ErrorS 'MLSCommitMissingReferences,
      ErrorS 'MLSSelfRemovalNotAllowed,
+     ErrorS 'MLSClientSenderUserMismatch,
      ErrorS 'MLSGroupConversationMismatch
    ]
 
@@ -110,6 +111,7 @@ postMLSMessageFromLocalUserV1 ::
          ErrorS 'MLSSelfRemovalNotAllowed,
          ErrorS 'MLSStaleMessage,
          ErrorS 'MLSUnsupportedMessage,
+         ErrorS 'MLSClientSenderUserMismatch,
          ErrorS 'MLSGroupConversationMismatch,
          ErrorS 'MissingLegalholdConsent,
          Input (Local ()),
@@ -142,6 +144,7 @@ postMLSMessageFromLocalUser ::
          ErrorS 'MLSSelfRemovalNotAllowed,
          ErrorS 'MLSStaleMessage,
          ErrorS 'MLSUnsupportedMessage,
+         ErrorS 'MLSClientSenderUserMismatch,
          ErrorS 'MLSGroupConversationMismatch,
          ErrorS 'MissingLegalholdConsent,
          Input (Local ()),
@@ -175,6 +178,7 @@ postMLSMessage ::
          ErrorS 'MissingLegalholdConsent,
          ErrorS 'MLSCommitMissingReferences,
          ErrorS 'MLSSelfRemovalNotAllowed,
+         ErrorS 'MLSClientSenderUserMismatch,
          ErrorS 'MLSGroupConversationMismatch,
          Resource,
          TinyLog,
@@ -192,7 +196,7 @@ postMLSMessage ::
 postMLSMessage loc qusr qcnv con smsg = case rmValue smsg of
   SomeMessage _ msg -> do
     unless (msgEpoch msg == Epoch 0) $
-      flip unless (throwS @'MLSUnsupportedMessage) =<< isUserSender qusr smsg
+      flip unless (throwS @'MLSClientSenderUserMismatch) =<< isUserSender qusr smsg
     foldQualified
       loc
       (postMLSMessageToLocalConv qusr con smsg)

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -84,6 +84,7 @@ import Wire.API.Message
 
 type MLSMessageStaticErrors =
   '[ ErrorS 'ConvAccessDenied,
+     ErrorS 'ConvMemberNotFound,
      ErrorS 'ConvNotFound,
      ErrorS 'MLSUnsupportedMessage,
      ErrorS 'MLSStaleMessage,
@@ -172,6 +173,7 @@ postMLSMessage ::
          Error InternalError,
          ErrorS 'ConvAccessDenied,
          ErrorS 'ConvNotFound,
+         ErrorS 'ConvMemberNotFound,
          ErrorS 'MLSUnsupportedMessage,
          ErrorS 'MLSStaleMessage,
          ErrorS 'MLSProposalNotFound,
@@ -307,7 +309,7 @@ postMLSMessageToRemoteConv loc qusr con smsg rcnv = do
   -- only local users can send messages to remote conversations
   lusr <- foldQualified loc pure (\_ -> throwS @'ConvAccessDenied) qusr
   -- only members may send messages to the remote conversation
-  flip unless (throwS @'MLSUnsupportedMessage) =<< checkLocalMemberRemoteConv (tUnqualified lusr) rcnv
+  flip unless (throwS @'ConvMemberNotFound) =<< checkLocalMemberRemoteConv (tUnqualified lusr) rcnv
 
   resp <-
     runFederated rcnv $

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -284,6 +284,9 @@ postMLSMessageToRemoteConv ::
 postMLSMessageToRemoteConv loc qusr con smsg rcnv = do
   -- only local users can send messages to remote conversations
   lusr <- foldQualified loc pure (\_ -> throwS @'ConvAccessDenied) qusr
+  -- only members may send messages to the remote conversation
+  flip unless (throwS @'MLSUnsupportedMessage) =<< checkLocalMemberRemoteConv (tUnqualified lusr) rcnv
+
   resp <-
     runFederated rcnv $
       fedClient @'Galley @"send-mls-message" $

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -210,13 +210,11 @@ isUserSender qusr smsg = case rmValue smsg of
     SMLSPlainText -> case msgSender msg of
       PreconfiguredSender _ -> pure True
       NewMemberSender -> pure True
-      MemberSender ref ->
-        getClientByKeyPackageRef ref >>= \case
-          Nothing -> throwS @'MLSKeyPackageRefNotFound
-          Just ClientIdentity {ciUser, ciDomain} ->
-            pure $
-              ciUser == qUnqualified qusr
-                && ciDomain == qDomain qusr
+      MemberSender ref -> do
+        ClientIdentity {ciUser, ciDomain} <- derefKeyPackage ref
+        pure $
+          ciUser == qUnqualified qusr
+            && ciDomain == qDomain qusr
 
 postMLSMessageToLocalConv ::
   ( HasProposalEffects r,

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -123,7 +123,7 @@ postMLSMessageFromLocalUserV1 ::
   Sem r [Event]
 postMLSMessageFromLocalUserV1 lusr conn msg =
   map lcuEvent
-    <$> postMLSMessage lusr (qUntagged lusr) (Just conn) msg
+    <$> postMLSMessage lusr (qUntagged lusr) Nothing (Just conn) msg
 
 postMLSMessageFromLocalUser ::
   ( HasProposalEffects r,
@@ -179,13 +179,15 @@ postMLSMessage ::
   ) =>
   Local x ->
   Qualified UserId ->
+  Maybe ConvId ->
   Maybe ConnId ->
   RawMLS SomeMessage ->
   Sem r [LocalConversationUpdate]
-postMLSMessage loc qusr con smsg = case rmValue smsg of
+postMLSMessage loc qusr convId con smsg = case rmValue smsg of
   SomeMessage _ msg -> do
     -- fetch conversation ID
     qcnv <- getConversationIdByGroupId (msgGroupId msg) >>= noteS @'ConvNotFound
+    when (maybe False (qUnqualified qcnv /=) convId) $ throwS @'MLSUnsupportedMessage
     unless (msgEpoch msg == Epoch 0) $
       flip unless (throwS @'MLSUnsupportedMessage) =<< isUserSender qusr smsg
     foldQualified

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -93,7 +93,8 @@ type MLSMessageStaticErrors =
      ErrorS 'MLSClientMismatch,
      ErrorS 'MLSUnsupportedProposal,
      ErrorS 'MLSCommitMissingReferences,
-     ErrorS 'MLSSelfRemovalNotAllowed
+     ErrorS 'MLSSelfRemovalNotAllowed,
+     ErrorS 'MLSGroupConversationMismatch
    ]
 
 postMLSMessageFromLocalUserV1 ::
@@ -109,6 +110,7 @@ postMLSMessageFromLocalUserV1 ::
          ErrorS 'MLSSelfRemovalNotAllowed,
          ErrorS 'MLSStaleMessage,
          ErrorS 'MLSUnsupportedMessage,
+         ErrorS 'MLSGroupConversationMismatch,
          ErrorS 'MissingLegalholdConsent,
          Input (Local ()),
          ProposalStore,
@@ -140,6 +142,7 @@ postMLSMessageFromLocalUser ::
          ErrorS 'MLSSelfRemovalNotAllowed,
          ErrorS 'MLSStaleMessage,
          ErrorS 'MLSUnsupportedMessage,
+         ErrorS 'MLSGroupConversationMismatch,
          ErrorS 'MissingLegalholdConsent,
          Input (Local ()),
          ProposalStore,
@@ -172,6 +175,7 @@ postMLSMessage ::
          ErrorS 'MissingLegalholdConsent,
          ErrorS 'MLSCommitMissingReferences,
          ErrorS 'MLSSelfRemovalNotAllowed,
+         ErrorS 'MLSGroupConversationMismatch,
          Resource,
          TinyLog,
          ProposalStore,

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -282,9 +282,6 @@ postMLSMessageToRemoteConv ::
 postMLSMessageToRemoteConv loc qusr con smsg rcnv = do
   -- only local users can send messages to remote conversations
   lusr <- foldQualified loc pure (\_ -> throwS @'ConvAccessDenied) qusr
-  -- only members may send messages to the remote conversation
-  flip unless (throwS @'MLSUnsupportedMessage) =<< checkLocalMemberRemoteConv (tUnqualified lusr) rcnv
-
   resp <-
     runFederated rcnv $
       fedClient @'Galley @"send-mls-message" $

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -237,10 +237,8 @@ isUserSender qusr smsg = case rmValue smsg of
       -- skip external add proposal
       NewMemberSender -> pure True
       MemberSender ref -> do
-        ClientIdentity {ciUser, ciDomain} <- derefKeyPackage ref
-        pure $
-          ciUser == qUnqualified qusr
-            && ciDomain == qDomain qusr
+        ci <- derefKeyPackage ref
+        pure $ fmap fst (cidQualifiedClient ci) == qusr
 
 postMLSMessageToLocalConv ::
   ( HasProposalEffects r,

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -282,6 +282,9 @@ postMLSMessageToRemoteConv ::
 postMLSMessageToRemoteConv loc qusr con smsg rcnv = do
   -- only local users can send messages to remote conversations
   lusr <- foldQualified loc pure (\_ -> throwS @'ConvAccessDenied) qusr
+  -- only members may send messages to the remote conversation
+  flip unless (throwS @'MLSUnsupportedMessage) =<< checkLocalMemberRemoteConv (tUnqualified lusr) rcnv
+
   resp <-
     runFederated rcnv $
       fedClient @'Galley @"send-mls-message" $

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -383,7 +383,7 @@ interpretMemberStoreToCassandra = interpret $ \case
   GetLocalMembers cid -> embedClient $ members cid
   GetRemoteMember cid uid -> embedClient $ lookupRemoteMember cid (tDomain uid) (tUnqualified uid)
   GetRemoteMembers rcid -> embedClient $ lookupRemoteMembers rcid
-  CheckLocalMemberRemoteConv uid rcnv -> fmap null $ embedClient $ lookupLocalMemberRemoteConv uid rcnv
+  CheckLocalMemberRemoteConv uid rcnv -> fmap (not . null) $ embedClient $ lookupLocalMemberRemoteConv uid rcnv
   SelectRemoteMembers uids rcnv -> embedClient $ filterRemoteConvMembers uids rcnv
   SetSelfMember qcid luid upd -> embedClient $ updateSelfMember qcid luid upd
   SetOtherMember lcid quid upd ->

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -324,11 +324,12 @@ filterRemoteConvMembers users (qUntagged -> Qualified conv dom) =
 lookupLocalMemberRemoteConv ::
   UserId ->
   Remote ConvId ->
-  Client [UserId]
+  Client (Maybe UserId)
 lookupLocalMemberRemoteConv userId (qUntagged -> Qualified conv dom) =
-  fmap (map runIdentity)
-    . retry x5
-    $ query Cql.selectRemoteConvMembers (params LocalQuorum (userId, dom, conv))
+  runIdentity
+    <$$> retry
+      x5
+      (query1 Cql.selectRemoteConvMembers (params LocalQuorum (userId, dom, conv)))
 
 removeLocalMembersFromRemoteConv ::
   -- | The conversation to remove members from

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -321,6 +321,15 @@ filterRemoteConvMembers users (qUntagged -> Qualified conv dom) =
         . retry x1
         $ query Cql.selectRemoteConvMembers (params LocalQuorum (user, dom, conv))
 
+lookupLocalMemberRemoteConv ::
+  UserId ->
+  Remote ConvId ->
+  Client [UserId]
+lookupLocalMemberRemoteConv userId (qUntagged -> Qualified conv dom) =
+  fmap (map runIdentity)
+    . retry x5
+    $ query Cql.selectRemoteConvMembers (params LocalQuorum (userId, dom, conv))
+
 removeLocalMembersFromRemoteConv ::
   -- | The conversation to remove members from
   Remote ConvId ->
@@ -374,6 +383,7 @@ interpretMemberStoreToCassandra = interpret $ \case
   GetLocalMembers cid -> embedClient $ members cid
   GetRemoteMember cid uid -> embedClient $ lookupRemoteMember cid (tDomain uid) (tUnqualified uid)
   GetRemoteMembers rcid -> embedClient $ lookupRemoteMembers rcid
+  CheckLocalMemberRemoteConv uid rcnv -> fmap null $ embedClient $ lookupLocalMemberRemoteConv uid rcnv
   SelectRemoteMembers uids rcnv -> embedClient $ filterRemoteConvMembers uids rcnv
   SetSelfMember qcid luid upd -> embedClient $ updateSelfMember qcid luid upd
   SetOtherMember lcid quid upd ->

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -321,15 +321,6 @@ filterRemoteConvMembers users (qUntagged -> Qualified conv dom) =
         . retry x1
         $ query Cql.selectRemoteConvMembers (params LocalQuorum (user, dom, conv))
 
-lookupLocalMemberRemoteConv ::
-  UserId ->
-  Remote ConvId ->
-  Client [UserId]
-lookupLocalMemberRemoteConv userId (qUntagged -> Qualified conv dom) =
-  fmap (map runIdentity)
-    . retry x5
-    $ query Cql.selectRemoteConvMembers (params LocalQuorum (userId, dom, conv))
-
 removeLocalMembersFromRemoteConv ::
   -- | The conversation to remove members from
   Remote ConvId ->
@@ -383,7 +374,6 @@ interpretMemberStoreToCassandra = interpret $ \case
   GetLocalMembers cid -> embedClient $ members cid
   GetRemoteMember cid uid -> embedClient $ lookupRemoteMember cid (tDomain uid) (tUnqualified uid)
   GetRemoteMembers rcid -> embedClient $ lookupRemoteMembers rcid
-  CheckLocalMemberRemoteConv uid rcnv -> fmap null $ embedClient $ lookupLocalMemberRemoteConv uid rcnv
   SelectRemoteMembers uids rcnv -> embedClient $ filterRemoteConvMembers uids rcnv
   SetSelfMember qcid luid upd -> embedClient $ updateSelfMember qcid luid upd
   SetOtherMember lcid quid upd ->

--- a/services/galley/src/Galley/Effects/MemberStore.hs
+++ b/services/galley/src/Galley/Effects/MemberStore.hs
@@ -32,6 +32,7 @@ module Galley.Effects.MemberStore
     getLocalMembers,
     getRemoteMember,
     getRemoteMembers,
+    checkLocalMemberRemoteConv,
     selectRemoteMembers,
 
     -- * Update members
@@ -64,6 +65,7 @@ data MemberStore m a where
   GetLocalMembers :: ConvId -> MemberStore m [LocalMember]
   GetRemoteMember :: ConvId -> Remote UserId -> MemberStore m (Maybe RemoteMember)
   GetRemoteMembers :: ConvId -> MemberStore m [RemoteMember]
+  CheckLocalMemberRemoteConv :: UserId -> Remote ConvId -> MemberStore m Bool
   SelectRemoteMembers :: [UserId] -> Remote ConvId -> MemberStore m ([UserId], Bool)
   SetSelfMember :: Qualified ConvId -> Local UserId -> MemberUpdate -> MemberStore m ()
   SetOtherMember :: Local ConvId -> Qualified UserId -> OtherMemberUpdate -> MemberStore m ()

--- a/services/galley/src/Galley/Effects/MemberStore.hs
+++ b/services/galley/src/Galley/Effects/MemberStore.hs
@@ -32,7 +32,6 @@ module Galley.Effects.MemberStore
     getLocalMembers,
     getRemoteMember,
     getRemoteMembers,
-    checkLocalMemberRemoteConv,
     selectRemoteMembers,
 
     -- * Update members
@@ -65,7 +64,6 @@ data MemberStore m a where
   GetLocalMembers :: ConvId -> MemberStore m [LocalMember]
   GetRemoteMember :: ConvId -> Remote UserId -> MemberStore m (Maybe RemoteMember)
   GetRemoteMembers :: ConvId -> MemberStore m [RemoteMember]
-  CheckLocalMemberRemoteConv :: UserId -> Remote ConvId -> MemberStore m Bool
   SelectRemoteMembers :: [UserId] -> Remote ConvId -> MemberStore m ([UserId], Bool)
   SetSelfMember :: Qualified ConvId -> Local UserId -> MemberUpdate -> MemberStore m ()
   SetOtherMember :: Local ConvId -> Qualified UserId -> OtherMemberUpdate -> MemberStore m ()

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -106,7 +106,7 @@ tests s =
           test s "post commit that is not referencing all proposals" testCommitNotReferencingAllProposals,
           test s "admin removes user from a conversation" testAdminRemovesUserFromConv,
           test s "admin removes user from a conversation but doesn't list all clients" testRemoveClientsIncomplete,
-          -- test s "anyone removes a non-existing client from a group" (_testRemoveDeletedClient True),
+          test s "anyone removes a non-existing client from a group" (testRemoveDeletedClient True),
           test s "anyone removes an existing client from group, but the user has other clients" (testRemoveDeletedClient False),
           test s "admin removes only strict subset of clients from a user" testRemoveSubset
         ],

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -127,7 +127,8 @@ tests s =
           testGroup
             "Remote Sender/Local Conversation"
             [ test s "POST /federation/send-mls-message" testRemoteToLocal,
-              test s "POST /federation/send-mls-message, remote user is not a conversation member" testRemoteNonMemberToLocal
+              test s "POST /federation/send-mls-message, remote user is not a conversation member" testRemoteNonMemberToLocal,
+              test s "POST /federation/send-mls-message, remote user sends to wrong conversation" testRemoteToLocalWrongConversation
             ],
           testGroup
             "Remote Sender/Remote Conversation"
@@ -1311,6 +1312,72 @@ testRemoteToLocal = do
       resp @?= MLSMessageResponseUpdates []
       WS.assertMatch_ (5 # Second) ws $
         wsAssertMLSMessage conversation (pUserId bob) message
+
+testRemoteToLocalWrongConversation :: TestM ()
+testRemoteToLocalWrongConversation = do
+  -- alice is local, bob is remote
+  -- alice creates a local conversation and invites bob
+  -- bob then sends a message to the conversation
+
+  let bobDomain = Domain "faraway.example.com"
+
+  -- Simulate the whole MLS setup for both clients first. In reality,
+  -- backend calls would need to happen in order for bob to get ahold of a
+  -- welcome message, but that should not affect the correctness of the test.
+
+  (MessagingSetup {..}, message) <- withSystemTempDirectory "mls" $ \tmp -> do
+    setup <-
+      aliceInvitesBobWithTmp
+        tmp
+        (1, RemoteUser bobDomain)
+        def
+          { createConv = CreateConv
+          }
+    bob <- assertOne (users setup)
+    let mockedResponse fedReq =
+          case frRPC fedReq of
+            "mls-welcome" -> pure (Aeson.encode EmptyResponse)
+            "on-new-remote-conversation" -> pure (Aeson.encode EmptyResponse)
+            "on-conversation-updated" -> pure (Aeson.encode ())
+            "get-mls-clients" ->
+              pure
+                . Aeson.encode
+                . Set.fromList
+                . map snd
+                . toList
+                . pClients
+                $ bob
+            ms -> assertFailure ("unmocked endpoint called: " <> cs ms)
+
+    void . withTempMockFederator' mockedResponse $
+      postCommit setup
+    liftIO $ mergeWelcome tmp (pClientQid bob) "group" "groupB.json" "welcome"
+    message <-
+      liftIO $
+        spawn
+          ( cli
+              (pClientQid bob)
+              tmp
+              ["message", "--group", tmp </> "groupB.json", "hello from another backend"]
+          )
+          Nothing
+    pure (setup, message)
+
+  let bob = head users
+
+  fedGalleyClient <- view tsFedGalleyClient
+
+  -- actual test
+  randomConfId <- randomId
+  let msr =
+        MessageSendRequest
+          { msrConvId = randomConfId,
+            msrSender = qUnqualified (pUserId bob),
+            msrRawMessage = Base64ByteString message
+          }
+
+  resp <- runFedClient @"send-mls-message" fedGalleyClient bobDomain msr
+  liftIO $ resp @?= MLSMessageResponseError MLSGroupConversationMismatch
 
 testRemoteNonMemberToLocal :: TestM ()
 testRemoteNonMemberToLocal = do

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -100,7 +100,6 @@ tests s =
           test s "send a stale commit" testStaleCommit,
           test s "add remote user to a conversation" testAddRemoteUser,
           test s "return error when commit is locked" testCommitLock,
-          test s "add remote user to a conversation" testAddRemoteUser,
           test s "add user to a conversation with proposal + commit" testAddUserBareProposalCommit,
           test s "post commit that references a unknown proposal" testUnknownProposalRefCommit,
           test s "post commit that is not referencing all proposals" testCommitNotReferencingAllProposals,

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -106,9 +106,9 @@ tests s =
           test s "post commit that is not referencing all proposals" testCommitNotReferencingAllProposals,
           test s "admin removes user from a conversation" testAdminRemovesUserFromConv,
           test s "admin removes user from a conversation but doesn't list all clients" testRemoveClientsIncomplete,
-          test s "user tries to remove themselves from conversation" testUserRemovesThemselvesFromConv,
-          test s "anyone removes a non-existing client from a group" (testRemoveDeletedClient True),
-          test s "anyone removes an existing client from group, but the user has other clients" (testRemoveDeletedClient False),
+          -- test s "user tries to remove themselves from conversation" _testUserRemovesThemselvesFromConv,
+          -- test s "anyone removes a non-existing client from a group" (_testRemoveDeletedClient True),
+          -- test s "anyone removes an existing client from group, but the user has other clients" (_testRemoveDeletedClient False),
           test s "admin removes only strict subset of clients from a user" testRemoveSubset
         ],
       testGroup
@@ -752,8 +752,8 @@ testRemoveClientsIncomplete = withSystemTempDirectory "mls" $ \tmp -> do
 
   liftIO $ Wai.label err @?= "mls-client-mismatch"
 
-testUserRemovesThemselvesFromConv :: TestM ()
-testUserRemovesThemselvesFromConv = withSystemTempDirectory "mls" $ \tmp -> do
+_testUserRemovesThemselvesFromConv :: TestM ()
+_testUserRemovesThemselvesFromConv = withSystemTempDirectory "mls" $ \tmp -> do
   MessagingSetup {..} <- aliceInvitesBobWithTmp tmp (2, LocalUser) def {createConv = CreateConv}
   let [bob] = users
 
@@ -770,8 +770,8 @@ testUserRemovesThemselvesFromConv = withSystemTempDirectory "mls" $ \tmp -> do
 
   liftIO $ Wai.label err @?= "mls-self-removal-not-allowed"
 
-testRemoveDeletedClient :: Bool -> TestM ()
-testRemoveDeletedClient deleteClientBefore = withSystemTempDirectory "mls" $ \tmp -> do
+_testRemoveDeletedClient :: Bool -> TestM ()
+_testRemoveDeletedClient deleteClientBefore = withSystemTempDirectory "mls" $ \tmp -> do
   (creator, [bob, dee]) <- withLastPrekeys $ setupParticipants tmp def [(2, LocalUser), (1, LocalUser)]
 
   -- create a group
@@ -1324,8 +1324,8 @@ propInvalidEpoch = withSystemTempDirectory "mls" $ \tmp -> do
     err <-
       responseJsonError
         =<< postMessage (qUnqualified (pUserId creator)) prop
-        <!! const 409 === statusCode
-    liftIO $ Wai.label err @?= "mls-stale-message"
+        <!! const 404 === statusCode
+    liftIO $ Wai.label err @?= "mls-key-package-ref-not-found"
 
   -- same proposal with correct epoch (1)
   do


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-797

Removed the test `"user tries to remove themselves from conversation"`. In the test, the group creator was creating a _remove_ commit which was then send by Bob to the backend. It is not working anymore, since now it is made sure by the backend that Bob creates all his commits himself. Switching to Bob creating the _remove_ commit for his clients won't work either, since OpenMLS would forbid to create a commit in which the user even removes one of his/her own clients. Thus, the test was beyond repairable. However, there might be the option to craft a _remove_ commit for Bob without OpenMLS later on when crafting MLS messages is available.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.