### PR TITLE
Sqservices 1500 doc move internal config options docs to docs wire com

### DIFF
--- a/changelog.d/4-docs/pr-2329
+++ b/changelog.d/4-docs/pr-2329
@@ -1,0 +1,1 @@
+Documentation for the 2nd factor password challenge feature

--- a/docs/src/how-to/install/index.rst
+++ b/docs/src/how-to/install/index.rst
@@ -17,6 +17,7 @@ Installing wire-server
    (production) How to monitor wire-server <monitoring.rst>
    (production) How to see centralized logs for wire-server <logging.rst>
    (production) Other configuration options <configuration-options.rst>
+   Feature settings <team-feature-settings.md>
    sft
    restund
    configure-federation

--- a/docs/src/how-to/install/team-feature-settings.md
+++ b/docs/src/how-to/install/team-feature-settings.md
@@ -1,5 +1,9 @@
 # Feature settings
 
+Features can be enabled or disabled on a team level or server wide.
+
+When a feature's lock status is `unlocked` its settings can be overridden on a team level by team admins.
+
 ## 2nd factor password challenge
 
 By default Wire enforces a 2nd factor authentication for certain user operations like e.g. activating an account, changing email or password, or deleting an account.
@@ -20,5 +24,7 @@ galley:
         sndFactorPasswordChallenge:
           defaults:
             status: enabled
-            lockStatus: locked # note that the lockstatus is required and should be locked
+            lockStatus: locked
 ```
+
+Note that the lock status is required but has no effect, as it is currently not supported for team admins to enable or disable `sndFactorPasswordChallenge`. We recommend to set the lock status to `locked`.

--- a/docs/src/how-to/install/team-feature-settings.md
+++ b/docs/src/how-to/install/team-feature-settings.md
@@ -1,0 +1,24 @@
+# Feature settings
+
+## 2nd factor password challenge
+
+By default Wire enforces a 2nd factor authentication for certain user operations like e.g. activating an account, changing email or password, or deleting an account.
+
+If the `sndFactorPasswordChallenge` feature is enabled, a 6 digit verification code will be send per email to authenticate for additional user operations like e.g. for login, adding a new client, generating SCIM tokens, or deleting a team.
+
+Usually the default is what you want. If you explicitly want to enable additional password challenges, add the following to your Helm overrides in `values/wire-server/values.yaml`:
+
+```yaml
+galley:
+  # ...
+  config:
+    # ...
+    settings:
+      # ...
+      featureFlags:
+        # ...
+        sndFactorPasswordChallenge:
+          defaults:
+            status: enabled
+            lockStatus: locked # note that the lockstatus is required and should be locked
+```

--- a/docs/src/how-to/install/team-feature-settings.md
+++ b/docs/src/how-to/install/team-feature-settings.md
@@ -1,8 +1,8 @@
 # Feature settings
 
-Features can be enabled or disabled on a team level or server wide.
+Features can be enabled or disabled on a team level or server wide. Here we will only cover the server wide configuration.
 
-When a feature's lock status is `unlocked` its settings can be overridden on a team level by team admins.
+When a feature's lock status is `unlocked` it means that its settings can be overridden on a team level by team admins. This can be done via the team management app or via the team feature API and is not covered here.
 
 ## 2nd factor password challenge
 


### PR DESCRIPTION
## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, or feature configs have changed, the **endpoint / config-flag checklist** (see Wire-employee only backend [wiki page](https://github.com/zinfra/backend-wiki/wiki/Checklists)) has been followed.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [ ] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [ ] If new config options introduced: added usage description under docs/reference/config-options.md
   - [ ] If new config options introduced: recommended measures to be taken by on-premise instance operators.
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
   - [ ] If public end-points have been changed or added: does nginz need un upgrade?
   - [ ] If internal end-points have been added or changed: which services have to be deployed in a specific order?
