### PR TITLE
Add mls-test-cli to builder image

### DIFF
--- a/build/ubuntu/Dockerfile.builder
+++ b/build/ubuntu/Dockerfile.builder
@@ -1,6 +1,17 @@
 ARG prebuilder=quay.io/wire/ubuntu20-prebuilder
 
+FROM rust:1.63 as mls-test-cli-builder
+
+# compile mls-test-cli tool
+RUN cd /tmp && \
+    git clone https://github.com/wireapp/mls-test-cli
+
+RUN cd /tmp/mls-test-cli && RUSTFLAGS='-C target-feature=+crt-static' cargo install --bins --target x86_64-unknown-linux-gnu --path .
+
 FROM ${prebuilder}
+
+COPY --from=mls-test-cli-builder /usr/local/cargo/bin/mls-test-cli /usr/bin/mls-test-cli
+
 WORKDIR /
 
 # Download stack indices and compile/cache dependencies to speed up subsequent

--- a/build/ubuntu/Dockerfile.deps
+++ b/build/ubuntu/Dockerfile.deps
@@ -1,12 +1,3 @@
-FROM rust:1.63 as mls-test-cli-builder
-
-# compile mls-test-cli tool
-RUN cd /tmp && \
-    git clone https://github.com/wireapp/mls-test-cli && \
-    cd mls-test-cli && \
-    cargo build --release
-
-
 FROM ubuntu:20.04 as cryptobox-builder
 
 # compile cryptobox-c
@@ -24,10 +15,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 FROM ubuntu:20.04
 
 COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib
-
-# FUTUREWORK: only copy mls-test-cli executables if we are building an
-# integration test image
-COPY --from=mls-test-cli-builder /tmp/mls-test-cli/target/release/mls-test-cli /usr/bin
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \

--- a/changelog.d/5-internal/ml-test-cli-builder-image
+++ b/changelog.d/5-internal/ml-test-cli-builder-image
@@ -1,0 +1,1 @@
+Add mls-test-cli to builder image


### PR DESCRIPTION
Motivation: Unit tests are run in the builder image. We'd like to use the mls-test-cli in unit tests.

This PR can be tested locally by running

```
docker build --build-arg prebuilder=quay.io/wire/ubuntu20-prebuilder:develop -f ./Dockerfile.builder .
```

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
