### PR TITLE
[WIP] building: check dynamic library dependencies are sane using ldd in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ ifeq ($(WIRE_BUILD_WITH_CABAL), 1)
 	cabal build all
 	./hack/bin/cabal-run-all-tests.sh
 	./hack/bin/cabal-install-artefacts.sh all
+	./hack/bin/check_ldd.sh
 else
 	stack install --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
 endif

--- a/changelog.d/5-internal/ldd-check-on-building
+++ b/changelog.d/5-internal/ldd-check-on-building
@@ -1,0 +1,1 @@
+Check dynamic executables for potentially missing shared library dependencies on building using `ldd`.

--- a/hack/bin/check_ldd.sh
+++ b/hack/bin/check_ldd.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOP_LEVEL="$(cd "$DIR/../.." && pwd)"
+
+for binary in "$TOP_LEVEL"/dist/*; do
+    ldd "$binary" | grep "not found"
+    grep_code=$?
+    if [[ $grep_code -eq 0 ]]; then
+        echo "Error: some shared library not available for binary $binary"
+        exit 1
+    fi
+done


### PR DESCRIPTION
compile and docker building phase.

port ldd script over from hegemony and check for shared library in dynamic executable in build phase

In the past, we checked that binaries have no missing dependencies at
deploy time. This could happen when adding a compile-time dependency in
dockerfiles for builder and prebuilder but forgetting the runtime in the
dockerfile for the end container. This now does this check 

* [x] at build time during compilation, though usually compilation would fail, so this is perhaps not so useful 
* [ ] TODO at runtime-container build time

(rather than at deploy time. The earlier the better)

(see also https://github.com/zinfra/cailleach/pull/1317)

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.