### PR TITLE
[FS-721] Forward All Default Proposals

### DIFF
--- a/changelog.d/2-features/mls-fwd-all-default-proposals
+++ b/changelog.d/2-features/mls-fwd-all-default-proposals
@@ -1,0 +1,1 @@
+Forward all MLS default proposal types

--- a/libs/wire-api/src/Wire/API/MLS/Extension.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Extension.hs
@@ -75,6 +75,11 @@ data Extension = Extension
 instance ParseMLS Extension where
   parseMLS = Extension <$> parseMLS <*> parseMLSBytes @Word32
 
+instance SerialiseMLS Extension where
+  serialiseMLS (Extension ty d) = do
+    put ty
+    serialiseMLSBytes @Word32 d
+
 data ExtensionTag
   = CapabilitiesExtensionTag
   | LifetimeExtensionTag

--- a/libs/wire-api/src/Wire/API/MLS/Extension.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Extension.hs
@@ -77,7 +77,7 @@ instance ParseMLS Extension where
 
 instance SerialiseMLS Extension where
   serialiseMLS (Extension ty d) = do
-    put ty
+    serialiseMLS ty
     serialiseMLSBytes @Word32 d
 
 data ExtensionTag

--- a/libs/wire-api/src/Wire/API/MLS/Message.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Message.hs
@@ -39,8 +39,6 @@ module Wire.API.MLS.Message
     KnownFormatTag (..),
     verifyMessageSignature,
     mkRemoveProposalMessage,
-    mkAppAckProposalMessageFailable,
-    mkAppAckProposalMessage,
   )
 where
 
@@ -360,39 +358,6 @@ mkRemoveProposalMessage priv pub gid epoch ref = maybeCryptoError $ do
               tbsMsgAuthData = mempty,
               tbsMsgSender = PreconfiguredSender 0,
               tbsMsgPayload = ProposalMessage (mkRemoveProposal ref)
-            }
-  let sig = BA.convert $ sign priv pub (rmRaw tbs)
-  pure (Message tbs (MessageExtraFields sig Nothing Nothing))
-
-mkAppAckProposalMessage ::
-  SecretKey ->
-  PublicKey ->
-  GroupId ->
-  Epoch ->
-  KeyPackageRef ->
-  [MessageRange] ->
-  Maybe (Message 'MLSPlainText)
-mkAppAckProposalMessage priv pub gid epoch ref mrs =
-  maybeCryptoError $ mkAppAckProposalMessageFailable priv pub gid epoch ref mrs
-
-mkAppAckProposalMessageFailable ::
-  SecretKey ->
-  PublicKey ->
-  GroupId ->
-  Epoch ->
-  KeyPackageRef ->
-  [MessageRange] ->
-  CryptoFailable (Message 'MLSPlainText)
-mkAppAckProposalMessageFailable priv pub gid epoch ref mrs = do
-  let tbs =
-        mkRawMLS $
-          MessageTBS
-            { tbsMsgFormat = KnownFormatTag,
-              tbsMsgGroupId = gid,
-              tbsMsgEpoch = epoch,
-              tbsMsgAuthData = mempty,
-              tbsMsgSender = MemberSender ref,
-              tbsMsgPayload = ProposalMessage (mkAppAckProposal mrs)
             }
   let sig = BA.convert $ sign priv pub (rmRaw tbs)
   pure (Message tbs (MessageExtraFields sig Nothing Nothing))

--- a/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
@@ -22,6 +22,7 @@ module Wire.API.MLS.Serialisation
     serialiseMLSVector,
     parseMLSBytes,
     serialiseMLSBytes,
+    serialiseMLSBytesLazy,
     parseMLSOptional,
     serialiseMLSOptional,
     parseMLSEnum,
@@ -90,9 +91,7 @@ serialiseMLSVector ::
   [a] ->
   Put
 serialiseMLSVector p =
-  serialiseMLSBytes @w . LBS.toStrict . toLazyByteString
-    . execPut
-    . traverse_ p
+  serialiseMLSBytesLazy @w . toLazyByteString . execPut . traverse_ p
 
 parseMLSBytes :: forall w. (Binary w, Integral w) => Get ByteString
 parseMLSBytes = do
@@ -103,6 +102,11 @@ serialiseMLSBytes :: forall w. (Binary w, Integral w) => ByteString -> Put
 serialiseMLSBytes x = do
   put @w (fromIntegral (BS.length x))
   putByteString x
+
+serialiseMLSBytesLazy :: forall w. (Binary w, Integral w) => LBS.ByteString -> Put
+serialiseMLSBytesLazy x = do
+  put @w (fromIntegral (LBS.length x))
+  putLazyByteString x
 
 parseMLSOptional :: Get a -> Get (Maybe a)
 parseMLSOptional g = do

--- a/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
@@ -50,6 +50,7 @@ import Data.Aeson (FromJSON (..))
 import qualified Data.Aeson as Aeson
 import Data.Bifunctor
 import Data.Binary
+import Data.Binary.Builder
 import Data.Binary.Get
 import Data.Binary.Put
 import qualified Data.ByteString as BS
@@ -88,12 +89,10 @@ serialiseMLSVector ::
   (a -> Put) ->
   [a] ->
   Put
-serialiseMLSVector p as = do
-  -- every element is long the same number of bytes when serialised. If there is
-  -- no single element in the vector, the whole length is 0 anyways.
-  let elLen = maybe 0 (LBS.length . runPut . p) . listToMaybe $ as
-  put @w . fromIntegral $ elLen * fromIntegral (length as)
-  traverse_ p as
+serialiseMLSVector p =
+  serialiseMLSBytes @w . LBS.toStrict . toLazyByteString
+    . execPut
+    . traverse_ p
 
 parseMLSBytes :: forall w. (Binary w, Integral w) => Get ByteString
 parseMLSBytes = do

--- a/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
@@ -89,7 +89,10 @@ serialiseMLSVector ::
   [a] ->
   Put
 serialiseMLSVector p as = do
-  put @w . fromIntegral . length $ as
+  -- every element is long the same number of bytes when serialised. If there is
+  -- no single element in the vector, the whole length is 0 anyways.
+  let elLen = maybe 0 (LBS.length . runPut . p) . listToMaybe $ as
+  put @w . fromIntegral $ elLen * fromIntegral (length as)
   traverse_ p as
 
 parseMLSBytes :: forall w. (Binary w, Integral w) => Get ByteString

--- a/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
@@ -19,6 +19,7 @@ module Wire.API.MLS.Serialisation
   ( ParseMLS (..),
     SerialiseMLS (..),
     parseMLSVector,
+    serialiseMLSVector,
     parseMLSBytes,
     serialiseMLSBytes,
     parseMLSOptional,
@@ -80,6 +81,16 @@ parseMLSVector getItem = do
       x <- getItem
       pos <- bytesRead
       (:) x <$> (if pos < endPos then go endPos else pure [])
+
+serialiseMLSVector ::
+  forall w a.
+  (Binary w, Integral w) =>
+  (a -> Put) ->
+  [a] ->
+  Put
+serialiseMLSVector p as = do
+  put @w . fromIntegral . length $ as
+  traverse_ p as
 
 parseMLSBytes :: forall w. (Binary w, Integral w) => Get ByteString
 parseMLSBytes = do
@@ -145,6 +156,8 @@ instance ParseMLS Word16 where parseMLS = get
 instance ParseMLS Word32 where parseMLS = get
 
 instance ParseMLS Word64 where parseMLS = get
+
+instance SerialiseMLS Word32 where serialiseMLS = put
 
 -- | A wrapper to generate a 'ParseMLS' instance given a 'Binary' instance.
 newtype BinaryMLS a = BinaryMLS a

--- a/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
@@ -159,6 +159,8 @@ instance ParseMLS Word32 where parseMLS = get
 
 instance ParseMLS Word64 where parseMLS = get
 
+instance SerialiseMLS Word16 where serialiseMLS = put
+
 instance SerialiseMLS Word32 where serialiseMLS = put
 
 -- | A wrapper to generate a 'ParseMLS' instance given a 'Binary' instance.

--- a/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/MLS.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Roundtrip/MLS.hs
@@ -35,7 +35,8 @@ tests =
     [ testRoundTrip @KeyPackageRef,
       testRoundTrip @RemoveProposalSender,
       testRoundTrip @RemoveProposalMessage,
-      testRoundTrip @RemoveProposalPayload
+      testRoundTrip @RemoveProposalPayload,
+      testRoundTrip @AppAckProposalTest
     ]
 
 testRoundTrip ::
@@ -86,3 +87,13 @@ newtype RemoveProposalSender = RemoveProposalSender
 
 instance Arbitrary RemoveProposalSender where
   arbitrary = RemoveProposalSender . PreconfiguredSender <$> arbitrary
+
+newtype AppAckProposalTest = AppAckProposalTest Proposal
+  deriving newtype (ParseMLS, Eq, Show)
+
+instance Arbitrary AppAckProposalTest where
+  arbitrary = AppAckProposalTest . AppAckProposal <$> arbitrary
+
+instance SerialiseMLS AppAckProposalTest where
+  serialiseMLS (AppAckProposalTest (AppAckProposal mrs)) = serialiseAppAckProposal mrs
+  serialiseMLS _ = serialiseAppAckProposal []

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -466,6 +466,7 @@ executable galley-integration
     , kan-extensions
     , lens
     , lens-aeson
+    , memory
     , metrics-wai
     , mtl
     , optparse-applicative

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -430,6 +430,7 @@ executable galley-integration
     , base
     , base64-bytestring
     , bilge
+    , binary
     , brig-types
     , bytestring
     , bytestring-conversion
@@ -440,6 +441,7 @@ executable galley-integration
     , comonad
     , containers
     , cookie
+    , cryptonite
     , currency-codes
     , data-default
     , data-timeout

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -450,7 +450,7 @@ applyProposal (AddProposal kp) = do
 applyProposal (RemoveProposal ref) = do
   qclient <- cidQualifiedClient <$> derefKeyPackage ref
   pure (paRemoveClient qclient)
-applyProposal _ = throwS @'MLSUnsupportedProposal
+applyProposal _ = pure mempty
 
 checkProposalCipherSuite ::
   Members

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
@@ -16,7 +17,6 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
-{-# OPTIONS_GHC -Wwarn #-}
 
 module API.MLS (tests) where
 

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
@@ -17,6 +16,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# OPTIONS_GHC -Wwarn #-}
 
 module API.MLS (tests) where
 
@@ -26,10 +26,16 @@ import Bilge hiding (head)
 import Bilge.Assert
 import Cassandra
 import Control.Arrow
-import Control.Lens (view)
+import Control.Lens (view, (^..))
+import Crypto.Error
+import qualified Crypto.PubKey.Ed25519 as C
 import qualified Data.Aeson as Aeson
+import Data.Aeson.Lens
+import Data.Binary.Put
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64.URL as B64U
 import Data.ByteString.Conversion
+import qualified Data.ByteString.Lazy as LBS
 import Data.Default
 import Data.Domain
 import Data.Id
@@ -67,8 +73,10 @@ import Wire.API.Federation.API.Galley
 import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Credential
 import Wire.API.MLS.Group (convToGroupId)
+import Wire.API.MLS.KeyPackage
 import Wire.API.MLS.Keys
 import Wire.API.MLS.Message
+import Wire.API.MLS.Serialisation
 import Wire.API.Message
 import Wire.API.Routes.Version
 
@@ -137,7 +145,8 @@ tests s =
         "Proposal"
         [ test s "add a new client to a non-existing conversation" propNonExistingConv,
           test s "add a new client to an existing conversation" propExistingConv,
-          test s "add a new client in an invalid epoch" propInvalidEpoch
+          test s "add a new client in an invalid epoch" propInvalidEpoch,
+          test s "forward an unsupported proposal" propUnsupported
         ],
       testGroup
         "External Proposal"
@@ -1421,3 +1430,46 @@ testPublicKeys = do
           (unMLSPublicKeys keys)
       )
       @?= [Ed25519]
+
+propUnsupported :: TestM ()
+propUnsupported = withSystemTempDirectory "mls" $ \tmp -> do
+  MessagingSetup {..} <- aliceInvitesBobWithTmp tmp (1, LocalUser) def {createConv = CreateConv}
+  aliceKP <- liftIO $ do
+    d <- BS.readFile (tmp </> pClientQid creator)
+    either (\e -> assertFailure ("could not parse key package: " <> T.unpack e)) pure $
+      decodeMLS' d
+  let alicePublicKey = bcSignatureKey $ kpCredential aliceKP
+
+  -- "\0 " corresponds to 0020 in TLS encoding, which is the length of the
+  -- following public key
+  file <-
+    liftIO . BS.readFile $
+      tmp </> pClientQid creator <> ".db" </> cs (B64U.encode $ "\0 " <> alicePublicKey)
+  let s =
+        file ^.. key "signature_private_key" . key "value" . _Array . traverse . _Integer
+          & fmap fromIntegral
+          & BS.pack
+  let (privKey, pubKey) = BS.splitAt 32 s
+  liftIO $ alicePublicKey @?= pubKey
+  let aliceRef =
+        kpRef
+          MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+          . KeyPackageData
+          . rmRaw
+          . kpTBS
+          $ aliceKP
+  let Just appAckMsg = maybeCryptoError $ do
+        alicePriv <- C.secretKey privKey
+        alicePub <- C.publicKey pubKey
+        mkAppAckProposalMessageFailable
+          alicePriv
+          alicePub
+          groupId
+          (Epoch 0)
+          aliceRef
+          []
+      msgSerialised =
+        LBS.toStrict . runPut . serialiseMLS $ appAckMsg
+
+  postMessage (qUnqualified . pUserId $ creator) msgSerialised
+    !!! const 201 === statusCode

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -25,6 +25,8 @@ import Bilge.Assert
 import Control.Lens (preview, to, view)
 import Control.Monad.Catch
 import qualified Control.Monad.State as State
+import Crypto.PubKey.Ed25519
+import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import Data.ByteString.Conversion
 import Data.Default
@@ -51,6 +53,7 @@ import Wire.API.Event.Conversation
 import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
 import Wire.API.MLS.Message
+import Wire.API.MLS.Proposal
 import Wire.API.MLS.Serialisation
 import Wire.API.User.Client
 import Wire.API.User.Client.Prekey
@@ -560,3 +563,25 @@ postWelcome uid welcome = do
         . content "message/mls"
         . bytes welcome
     )
+
+mkAppAckProposalMessage ::
+  GroupId ->
+  Epoch ->
+  KeyPackageRef ->
+  [MessageRange] ->
+  SecretKey ->
+  PublicKey ->
+  Message 'MLSPlainText
+mkAppAckProposalMessage gid epoch ref mrs priv pub = do
+  let tbs =
+        mkRawMLS $
+          MessageTBS
+            { tbsMsgFormat = KnownFormatTag,
+              tbsMsgGroupId = gid,
+              tbsMsgEpoch = epoch,
+              tbsMsgAuthData = mempty,
+              tbsMsgSender = MemberSender ref,
+              tbsMsgPayload = ProposalMessage (mkAppAckProposal mrs)
+            }
+      sig = BA.convert $ sign priv pub (rmRaw tbs)
+   in (Message tbs (MessageExtraFields sig Nothing Nothing))


### PR DESCRIPTION
The PR adapts the Wire server such that it simply forwards all MLS default proposal types, including those that it currently does not support.

Tracked by https://wearezeta.atlassian.net/browse/FS-721.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
