### PR TITLE
Fix broken hls-hlint-plugin in nix env

### DIFF
--- a/changelog.d/5-internal/hls-hlint-plugin-workaround
+++ b/changelog.d/5-internal/hls-hlint-plugin-workaround
@@ -1,0 +1,1 @@
+Fix broken hls-hlint-plugin in nix env

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/wireapp/nixpkgs",
         "owner": "wireapp",
         "repo": "nixpkgs",
-        "rev": "e76544a8e8c35eabc285379cff7168d8083879db",
-        "sha256": "1rsci29r6lwrhh52zpy4xkiyws2am2a7n90mvrd8apq54nkdkaj7",
+        "rev": "c1f2214fb86c79f577460a3acd1b41ba284178c0",
+        "sha256": "0hdc53q8xmx6wgcyilxwy450dwhzwakdbbil1hg3vraprr1kpxcp",
         "type": "tarball",
-        "url": "https://github.com/wireapp/nixpkgs/archive/e76544a8e8c35eabc285379cff7168d8083879db.tar.gz",
+        "url": "https://github.com/wireapp/nixpkgs/archive/c1f2214fb86c79f577460a3acd1b41ba284178c0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "nixpkgs-unstable",
-        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
-        "homepage": "https://github.com/NixOS/nixpkgs",
-        "owner": "NixOS",
+        "branch": "hls-hlint-plugin-workaround",
+        "description": "Wire's fork of NixOS/nixpkgs. Use until HLS > 1.7.0.0 is available in NixOS/nixpkgs",
+        "homepage": "https://github.com/wireapp/nixpkgs",
+        "owner": "wireapp",
         "repo": "nixpkgs",
-        "rev": "964d60ff2e6bc76c0618962da52859603784fa78",
-        "sha256": "1qvs9a59araglrrbzp5zdx81nmjgaxpfp36yl708il0lyqdjawvd",
+        "rev": "e76544a8e8c35eabc285379cff7168d8083879db",
+        "sha256": "1rsci29r6lwrhh52zpy4xkiyws2am2a7n90mvrd8apq54nkdkaj7",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/964d60ff2e6bc76c0618962da52859603784fa78.tar.gz",
+        "url": "https://github.com/wireapp/nixpkgs/archive/e76544a8e8c35eabc285379cff7168d8083879db.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This PR applies this suggestion https://github.com/NixOS/nixpkgs/issues/168064#issuecomment-1146691884
in a wire's nixpkgs fork. Since the problem has been fixed in https://github.com/haskell/haskell-language-server/pull/2854 we can switch to nixos/nixpkgs once a new HLS version is released an available in nixpkgs.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
