### PR TITLE
Add mls-test-cli to deps image

### DIFF
--- a/build/ubuntu/Dockerfile.deps
+++ b/build/ubuntu/Dockerfile.deps
@@ -10,11 +10,19 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     export SODIUM_USE_PKG_CONFIG=1 && \
     cargo build --release
 
+FROM rust:1.63 as mls-test-cli-builder
+
+# compile mls-test-cli tool
+RUN cd /tmp && \
+    git clone https://github.com/wireapp/mls-test-cli
+
+RUN cd /tmp/mls-test-cli && RUSTFLAGS='-C target-feature=+crt-static' cargo install --bins --target x86_64-unknown-linux-gnu --path .
 
 # Minimal dependencies for ubuntu-compiled, dynamically linked wire-server Haskell services
 FROM ubuntu:20.04
 
 COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib
+COPY --from=mls-test-cli-builder /usr/local/cargo/bin/mls-test-cli /usr/bin/mls-test-cli
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \

--- a/changelog.d/5-internal/mls-test-cli-deps-image
+++ b/changelog.d/5-internal/mls-test-cli-deps-image
@@ -1,0 +1,1 @@
+Add mls-test-cli to deps image


### PR DESCRIPTION
Followup to https://github.com/wireapp/wire-server/pull/2626 (which removed `mls-test-cli` from the deps image). `mls-test-cli` is also needed in the `deps` image for integration tests.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
