### PR TITLE
Improve MLS client checks

### DIFF
--- a/changelog.d/0-release-notes/get-mls-clients
+++ b/changelog.d/0-release-notes/get-mls-clients
@@ -1,1 +1,1 @@
-The `GET mls/clients` has been changed, and it now returns a pair of lists, instead of one
+The internal endpoint `GET i/mls/clients` has been changed, and it now returns a pair of lists, instead of one

--- a/changelog.d/0-release-notes/get-mls-clients
+++ b/changelog.d/0-release-notes/get-mls-clients
@@ -1,0 +1,1 @@
+The `GET mls/clients` has been changed, and it now returns a pair of lists, instead of one

--- a/changelog.d/0-release-notes/get-mls-clients
+++ b/changelog.d/0-release-notes/get-mls-clients
@@ -1,1 +1,1 @@
-The internal endpoint `GET i/mls/clients` has been changed, and it now returns a pair of lists, instead of one
+The internal endpoint `GET i/mls/clients` has been changed, and it now returns a list of `ClientInfo` instead of a list of `ClientId`.

--- a/changelog.d/3-bug-fixes/improve-client-check
+++ b/changelog.d/3-bug-fixes/improve-client-check
@@ -1,0 +1,1 @@
+Improve client check when adding clients to MLS conversations

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -68,7 +68,7 @@ type BrigApi =
     -- (handles can be up to 256 chars currently)
     :<|> FedEndpoint "search-users" SearchRequest SearchResponse
     :<|> FedEndpoint "get-user-clients" GetUserClients (UserMap (Set PubClient))
-    :<|> FedEndpoint "get-mls-clients" MLSClientsRequest (Set ClientId)
+    :<|> FedEndpoint "get-mls-clients" MLSClientsRequest (Set ClientId, Set ClientId)
     :<|> FedEndpoint "send-connection-action" NewConnectionRequest NewConnectionResponse
     :<|> FedEndpoint "on-user-deleted-connections" UserDeletedConnectionsNotification EmptyResponse
     :<|> FedEndpoint "claim-key-packages" ClaimKeyPackageRequest (Maybe KeyPackageBundle)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -30,9 +30,8 @@ import Wire.API.Federation.Endpoint
 import Wire.API.Federation.Version
 import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
-import Wire.API.Message (UserClients)
 import Wire.API.User (UserProfile)
-import Wire.API.User.Client (PubClient, UserClientPrekeyMap)
+import Wire.API.User.Client
 import Wire.API.User.Client.Prekey (ClientPrekey, PrekeyBundle)
 import Wire.API.User.Search
 import Wire.API.UserMap (UserMap)
@@ -68,7 +67,7 @@ type BrigApi =
     -- (handles can be up to 256 chars currently)
     :<|> FedEndpoint "search-users" SearchRequest SearchResponse
     :<|> FedEndpoint "get-user-clients" GetUserClients (UserMap (Set PubClient))
-    :<|> FedEndpoint "get-mls-clients" MLSClientsRequest (Set ClientId, Set ClientId)
+    :<|> FedEndpoint "get-mls-clients" MLSClientsRequest (Set ClientInfo)
     :<|> FedEndpoint "send-connection-action" NewConnectionRequest NewConnectionResponse
     :<|> FedEndpoint "on-user-deleted-connections" UserDeletedConnectionsNotification EmptyResponse
     :<|> FedEndpoint "claim-key-packages" ClaimKeyPackageRequest (Maybe KeyPackageBundle)

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -59,6 +59,7 @@ import Wire.API.Routes.MultiVerb
 import Wire.API.Routes.Named
 import Wire.API.Team.Feature
 import Wire.API.User
+import Wire.API.User.Client
 
 type EJPDRequest =
   Summary
@@ -252,7 +253,7 @@ type GetMLSClients =
     :> MultiVerb1
          'GET
          '[Servant.JSON]
-         (Respond 200 "MLS clients" (Set ClientId, Set ClientId))
+         (Respond 200 "MLS clients" (Set ClientInfo))
 
 type MapKeyPackageRefs =
   Summary "Insert bundle into the KeyPackage ref mapping. Only for tests."

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -244,7 +244,7 @@ type GetConversationByKeyPackageRef =
     )
 
 type GetMLSClients =
-  Summary "Return all MLS-enabled clients of a user"
+  Summary "Return all clients and all MLS-capable clients of a user"
     :> "clients"
     :> CanThrow 'UserNotFound
     :> Capture "user" UserId
@@ -252,7 +252,7 @@ type GetMLSClients =
     :> MultiVerb1
          'GET
          '[Servant.JSON]
-         (Respond 200 "MLS clients" (Set ClientId))
+         (Respond 200 "MLS clients" (Set ClientId, Set ClientId))
 
 type MapKeyPackageRefs =
   Summary "Insert bundle into the KeyPackage ref mapping. Only for tests."

--- a/libs/wire-api/src/Wire/API/User/Client.hs
+++ b/libs/wire-api/src/Wire/API/User/Client.hs
@@ -23,6 +23,9 @@ module Wire.API.User.Client
     ClientCapability (..),
     ClientCapabilityList (..),
 
+    -- * ClientInfo
+    ClientInfo (..),
+
     -- * UserClients
     UserClientMap (..),
     UserClientPrekeyMap (..),
@@ -331,6 +334,26 @@ qualifiedUserClientPrekeyMapFromList ::
   QualifiedUserClientPrekeyMap
 qualifiedUserClientPrekeyMapFromList =
   mkQualifiedUserClientPrekeyMap . Map.fromList . map qToPair
+
+--------------------------------------------------------------------------------
+-- ClientInfo
+
+-- | A client, together with extra information about it.
+data ClientInfo = ClientInfo
+  { -- | The ID of this client.
+    ciId :: ClientId,
+    -- | Whether this client is MLS-capable.
+    ciMLS :: Bool
+  }
+  deriving stock (Eq, Ord, Show)
+  deriving (Swagger.ToSchema, FromJSON, ToJSON) via Schema ClientInfo
+
+instance ToSchema ClientInfo where
+  schema =
+    object "ClientInfo" $
+      ClientInfo
+        <$> ciId .= field "id" schema
+        <*> ciMLS .= field "mls" schema
 
 --------------------------------------------------------------------------------
 -- UserClients

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -60,12 +60,11 @@ import Wire.API.Federation.API.Brig
 import Wire.API.Federation.API.Common
 import Wire.API.Federation.Version
 import Wire.API.MLS.KeyPackage
-import Wire.API.Message (UserClients)
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Routes.Named
 import Wire.API.Team.LegalHold (LegalholdProtectee (LegalholdPlusFederationNotImplemented))
 import Wire.API.User (UserProfile)
-import Wire.API.User.Client (PubClient, UserClientPrekeyMap)
+import Wire.API.User.Client
 import Wire.API.User.Client.Prekey
 import Wire.API.User.Search
 import Wire.API.UserMap (UserMap)
@@ -213,7 +212,7 @@ searchUsers domain (SearchRequest searchTerm) = do
 getUserClients :: Domain -> GetUserClients -> (Handler r) (UserMap (Set PubClient))
 getUserClients _ (GetUserClients uids) = API.lookupLocalPubClientsBulk uids !>> clientError
 
-getMLSClients :: Domain -> MLSClientsRequest -> Handler r (Set ClientId, Set ClientId)
+getMLSClients :: Domain -> MLSClientsRequest -> Handler r (Set ClientInfo)
 getMLSClients _domain mcr = do
   Internal.getMLSClients (mcrUserId mcr) (mcrSignatureScheme mcr)
 

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -213,7 +213,7 @@ searchUsers domain (SearchRequest searchTerm) = do
 getUserClients :: Domain -> GetUserClients -> (Handler r) (UserMap (Set PubClient))
 getUserClients _ (GetUserClients uids) = API.lookupLocalPubClientsBulk uids !>> clientError
 
-getMLSClients :: Domain -> MLSClientsRequest -> Handler r (Set ClientId)
+getMLSClients :: Domain -> MLSClientsRequest -> Handler r (Set ClientId, Set ClientId)
 getMLSClients _domain mcr = do
   Internal.getMLSClients (mcrUserId mcr) (mcrSignatureScheme mcr)
 

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -184,13 +184,14 @@ getConvIdByKeyPackageRef = runMaybeT . mapMaybeT wrapClientE . Data.keyPackageRe
 postKeyPackageRef :: KeyPackageRef -> KeyPackageRef -> Handler r ()
 postKeyPackageRef ref = lift . wrapClient . Data.updateKeyPackageRef ref
 
-getMLSClients :: UserId -> SignatureSchemeTag -> Handler r (Set ClientId)
+getMLSClients :: UserId -> SignatureSchemeTag -> Handler r (Set ClientId, Set ClientId)
 getMLSClients usr _ss = do
   -- FUTUREWORK: check existence of key packages with a given ciphersuite
   lusr <- qualifyLocal usr
-  results <- lift (wrapClient (API.lookupUsersClientIds (pure usr))) >>= getResult
-  validClients <- lift . wrapClient $ pooledMapConcurrentlyN 16 (getValidity lusr) (toList results)
-  pure . Set.fromList . map fst . filter snd $ validClients
+  allClients <- lift (wrapClient (API.lookupUsersClientIds (pure usr))) >>= getResult
+  validClients <- lift . wrapClient $ pooledMapConcurrentlyN 16 (getValidity lusr) (toList allClients)
+  let mlsClients = Set.fromList . map fst . filter snd $ validClients
+  pure (mlsClients, allClients)
   where
     getResult [] = pure mempty
     getResult ((u, cs) : rs)

--- a/services/brig/test/integration/API/Internal.hs
+++ b/services/brig/test/integration/API/Internal.hs
@@ -68,13 +68,15 @@ tests opts mgr db brig brigep gundeck galley = do
         test mgr "suspend and unsuspend user" $ testSuspendUser db brig,
         test mgr "suspend non existing user and verify no db entry" $
           testSuspendNonExistingUser db brig,
-        testGroup "mls/key-packages" $
-          [ test mgr "fresh get" $ testKpcFreshGet brig,
-            test mgr "put,get" $ testKpcPutGet brig,
-            test mgr "get,get" $ testKpcGetGet brig,
-            test mgr "put,put" $ testKpcPutPut brig,
-            test mgr "add key package ref" $ testAddKeyPackageRef brig
-          ]
+        test mgr "mls/clients" $ testGetMlsClients brig,
+        testGroup
+          "mls/key-packages"
+          $ [ test mgr "fresh get" $ testKpcFreshGet brig,
+              test mgr "put,get" $ testKpcPutGet brig,
+              test mgr "get,get" $ testKpcGetGet brig,
+              test mgr "put,put" $ testKpcPutPut brig,
+              test mgr "add key package ref" $ testAddKeyPackageRef brig
+            ]
       ]
 
 testSuspendUser :: forall m. TestConstraints m => Cass.ClientState -> Brig -> m ()
@@ -221,6 +223,31 @@ testFeatureConferenceCallingByAccount (Opt.optSettings -> settings) mgr db brig 
   check $ ApiFt.WithStatusNoLock ApiFt.FeatureStatusEnabled ApiFt.ConferenceCallingConfig ApiFt.FeatureTTLUnlimited
   check $ ApiFt.WithStatusNoLock ApiFt.FeatureStatusDisabled ApiFt.ConferenceCallingConfig ApiFt.FeatureTTLUnlimited
   check'
+
+testGetMlsClients :: Brig -> Http ()
+testGetMlsClients brig = do
+  qusr <- userQualifiedId <$> randomUser brig
+  c <- createClient brig qusr 0
+  (cs0 :: Set ClientId) <-
+    responseJsonError
+      =<< get
+        ( brig
+            . paths ["i", "mls", "clients", toByteString' (qUnqualified qusr)]
+            . queryItem "sig_scheme" "ed25519"
+        )
+  liftIO $ cs0 @?= mempty
+
+  withSystemTempDirectory "mls" $ \tmp ->
+    uploadKeyPackages brig tmp def qusr c 2
+
+  (cs1 :: Set ClientId) <-
+    responseJsonError
+      =<< get
+        ( brig
+            . paths ["i", "mls", "clients", toByteString' (qUnqualified qusr)]
+            . queryItem "sig_scheme" "ed25519"
+        )
+  liftIO $ toList cs1 @?= [c]
 
 keyPackageCreate :: HasCallStack => Brig -> Http KeyPackageRef
 keyPackageCreate brig = do

--- a/services/brig/test/integration/API/Internal.hs
+++ b/services/brig/test/integration/API/Internal.hs
@@ -228,7 +228,7 @@ testGetMlsClients :: Brig -> Http ()
 testGetMlsClients brig = do
   qusr <- userQualifiedId <$> randomUser brig
   c <- createClient brig qusr 0
-  (cs0 :: Set ClientId) <-
+  (cs0 :: Set ClientId, cs0all :: Set ClientId) <-
     responseJsonError
       =<< get
         ( brig
@@ -236,11 +236,12 @@ testGetMlsClients brig = do
             . queryItem "sig_scheme" "ed25519"
         )
   liftIO $ cs0 @?= mempty
+  liftIO $ toList cs0all @?= [c]
 
   withSystemTempDirectory "mls" $ \tmp ->
     uploadKeyPackages brig tmp def qusr c 2
 
-  (cs1 :: Set ClientId) <-
+  (cs1 :: Set ClientId, cs1all :: Set ClientId) <-
     responseJsonError
       =<< get
         ( brig
@@ -248,6 +249,7 @@ testGetMlsClients brig = do
             . queryItem "sig_scheme" "ed25519"
         )
   liftIO $ toList cs1 @?= [c]
+  liftIO $ toList cs1all @?= [c]
 
 keyPackageCreate :: HasCallStack => Brig -> Http KeyPackageRef
 keyPackageCreate brig = do

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -665,7 +665,7 @@ executeProposalAction qusr con lconv action = do
   -- FUTUREWORK: remove this check after remote admins are implemented in federation https://wearezeta.atlassian.net/browse/FS-216
   foldQualified lconv (\_ -> pure ()) (\_ -> throwS @'MLSUnsupportedProposal) qusr
 
-  -- check that all clients of each user are added to the conversation
+  -- for each user, we compare their clients with the ones being added to the conversation
   for_ newUserClients $ \(qtarget, newclients) -> case Map.lookup qtarget cm of
     -- user is already present, skip check in this case
     Just _ -> pure ()

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -674,11 +674,24 @@ executeProposalAction qusr con lconv action = do
       -- final set of clients in the conversation
       let clients = newclients <> Map.findWithDefault mempty qtarget cm
       -- get list of mls clients from brig
-      allClients <- getMLSClients lconv qtarget ss
-      -- if not all clients have been added to the conversation, return an error
-      when (clients /= allClients) $ do
-        -- FUTUREWORK: turn this error into a proper response
-        throwS @'MLSClientMismatch
+      (allMLSClients, allClients) <- getMLSClients lconv qtarget ss
+      -- We check the following condition:
+      --   allMLSClients ⊆ clients ⊆ allClients
+      -- i.e.
+      -- - if a client has at least 1 key package, it has to be added
+      -- - if a client is being added, it has to still exist
+      --
+      -- The reason why we can't simply check that clients == allMLSClients is
+      -- that a client with no remaining key packages might be added by a user
+      -- who just fetched its last key package.
+      unless
+        ( Set.isSubsetOf allMLSClients clients
+            && Set.isSubsetOf clients allClients
+        )
+        $ do
+          -- unless (Set.isSubsetOf allClients clients) $ do
+          -- FUTUREWORK: turn this error into a proper response
+          throwS @'MLSClientMismatch
 
   membersToRemove <- catMaybes <$> for removeUserClients (uncurry (checkRemoval lconv ss))
 
@@ -697,7 +710,7 @@ executeProposalAction qusr con lconv action = do
     -- For these clients there is nothing left to do
     checkRemoval :: Local x -> SignatureSchemeTag -> Qualified UserId -> Set ClientId -> Sem r (Maybe (Qualified UserId))
     checkRemoval loc ss qtarget clients = do
-      allClients <- getMLSClients loc qtarget ss
+      (_, allClients) <- getMLSClients loc qtarget ss
       let allClientsDontExist = Set.null (clients `Set.intersection` allClients)
       if allClientsDontExist
         then pure Nothing
@@ -819,10 +832,14 @@ getMLSClients ::
   Local x ->
   Qualified UserId ->
   SignatureSchemeTag ->
-  Sem r (Set ClientId)
+  Sem r (Set ClientId, Set ClientId)
 getMLSClients loc = foldQualified loc getLocalMLSClients getRemoteMLSClients
 
-getRemoteMLSClients :: Member FederatorAccess r => Remote UserId -> SignatureSchemeTag -> Sem r (Set ClientId)
+getRemoteMLSClients ::
+  Member FederatorAccess r =>
+  Remote UserId ->
+  SignatureSchemeTag ->
+  Sem r (Set ClientId, Set ClientId)
 getRemoteMLSClients rusr ss = do
   runFederated rusr $
     fedClient @'Brig @"get-mls-clients" $

--- a/services/galley/src/Galley/Effects/BrigAccess.hs
+++ b/services/galley/src/Galley/Effects/BrigAccess.hs
@@ -127,7 +127,7 @@ data BrigAccess m a where
   RemoveLegalHoldClientFromUser :: UserId -> BrigAccess m ()
   GetAccountConferenceCallingConfigClient :: UserId -> BrigAccess m (WithStatusNoLock ConferenceCallingConfig)
   GetClientByKeyPackageRef :: KeyPackageRef -> BrigAccess m (Maybe ClientIdentity)
-  GetLocalMLSClients :: Local UserId -> SignatureSchemeTag -> BrigAccess m (Set ClientId, Set ClientId)
+  GetLocalMLSClients :: Local UserId -> SignatureSchemeTag -> BrigAccess m (Set ClientInfo)
   AddKeyPackageRef :: KeyPackageRef -> Qualified UserId -> ClientId -> Qualified ConvId -> BrigAccess m ()
   UpdateKeyPackageRef :: KeyPackageUpdate -> BrigAccess m ()
   UpdateSearchVisibilityInbound ::

--- a/services/galley/src/Galley/Effects/BrigAccess.hs
+++ b/services/galley/src/Galley/Effects/BrigAccess.hs
@@ -127,7 +127,7 @@ data BrigAccess m a where
   RemoveLegalHoldClientFromUser :: UserId -> BrigAccess m ()
   GetAccountConferenceCallingConfigClient :: UserId -> BrigAccess m (WithStatusNoLock ConferenceCallingConfig)
   GetClientByKeyPackageRef :: KeyPackageRef -> BrigAccess m (Maybe ClientIdentity)
-  GetLocalMLSClients :: Local UserId -> SignatureSchemeTag -> BrigAccess m (Set ClientId)
+  GetLocalMLSClients :: Local UserId -> SignatureSchemeTag -> BrigAccess m (Set ClientId, Set ClientId)
   AddKeyPackageRef :: KeyPackageRef -> Qualified UserId -> ClientId -> Qualified ConvId -> BrigAccess m ()
   UpdateKeyPackageRef :: KeyPackageUpdate -> BrigAccess m ()
   UpdateSearchVisibilityInbound ::

--- a/services/galley/src/Galley/Intra/Client.hs
+++ b/services/galley/src/Galley/Intra/Client.hs
@@ -185,7 +185,7 @@ getClientByKeyPackageRef ref = do
     else pure Nothing
 
 -- | Calls 'Brig.API.Internal.getMLSClients'.
-getLocalMLSClients :: Local UserId -> SignatureSchemeTag -> App (Set ClientId)
+getLocalMLSClients :: Local UserId -> SignatureSchemeTag -> App (Set ClientId, Set ClientId)
 getLocalMLSClients lusr ss =
   call
     Brig

--- a/services/galley/src/Galley/Intra/Client.hs
+++ b/services/galley/src/Galley/Intra/Client.hs
@@ -185,7 +185,7 @@ getClientByKeyPackageRef ref = do
     else pure Nothing
 
 -- | Calls 'Brig.API.Internal.getMLSClients'.
-getLocalMLSClients :: Local UserId -> SignatureSchemeTag -> App (Set ClientId, Set ClientId)
+getLocalMLSClients :: Local UserId -> SignatureSchemeTag -> App (Set ClientInfo)
 getLocalMLSClients lusr ss =
   call
     Brig

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -417,8 +417,7 @@ testAddUserWithProteusClients = do
 
 testAddUserPartial :: TestM ()
 testAddUserPartial = do
-  (creator, commit) <- withSystemTempDirectory "mls" $ \_tmp -> do
-    let tmp = "/tmp/mls"
+  (creator, commit) <- withSystemTempDirectory "mls" $ \tmp -> do
     -- Bob has 3 clients, Charlie has 2
     (alice, [bob, charlie]) <- withLastPrekeys $ setupParticipants tmp def ((,LocalUser) <$> [3, 2])
 


### PR DESCRIPTION
This PR changes the way MLS-capable clients are defined to exclude those that have a public key set, but no key packages. Furthermore, adding a client to an MLS conversation that already includes the user results in the client check being skipped.

Tracked by https://wearezeta.atlassian.net/browse/FS-853.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.
   - [x] If internal end-points have been added or changed: which services have to be deployed in a specific order?
