### PR TITLE
mls-test-cli - use Cargo.lock

### DIFF
--- a/build/ubuntu/Dockerfile.builder
+++ b/build/ubuntu/Dockerfile.builder
@@ -8,11 +8,11 @@ RUN cd /tmp && \
     cd mls-test-cli && \
     git rev-parse HEAD
 
-RUN cd /tmp/mls-test-cli && RUSTFLAGS='-C target-feature=+crt-static' cargo install --bins --target x86_64-unknown-linux-gnu --path .
+RUN cd /tmp/mls-test-cli && RUSTFLAGS='-C target-feature=+crt-static' cargo build --release --target x86_64-unknown-linux-gnu
 
 FROM ${prebuilder}
 
-COPY --from=mls-test-cli-builder /usr/local/cargo/bin/mls-test-cli /usr/bin/mls-test-cli
+COPY --from=mls-test-cli-builder /tmp/mls-test-cli/target/x86_64-unknown-linux-gnu/release/mls-test-cli /usr/bin/mls-test-cli
 
 WORKDIR /
 

--- a/build/ubuntu/Dockerfile.deps
+++ b/build/ubuntu/Dockerfile.deps
@@ -18,13 +18,13 @@ RUN cd /tmp && \
     cd mls-test-cli && \
     git rev-parse HEAD
 
-RUN cd /tmp/mls-test-cli && RUSTFLAGS='-C target-feature=+crt-static' cargo install --bins --target x86_64-unknown-linux-gnu --path .
+RUN cd /tmp/mls-test-cli && RUSTFLAGS='-C target-feature=+crt-static' cargo build --release --target x86_64-unknown-linux-gnu
 
 # Minimal dependencies for ubuntu-compiled, dynamically linked wire-server Haskell services
 FROM ubuntu:20.04
 
 COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib
-COPY --from=mls-test-cli-builder /usr/local/cargo/bin/mls-test-cli /usr/bin/mls-test-cli
+COPY --from=mls-test-cli-builder /tmp/mls-test-cli/target/x86_64-unknown-linux-gnu/release/mls-test-cli /usr/bin/mls-test-cli
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \

--- a/changelog.d/5-internal/mls-test-cli-lock-file
+++ b/changelog.d/5-internal/mls-test-cli-lock-file
@@ -1,0 +1,1 @@
+mls-test-cli: Use Cargo.lock file when building


### PR DESCRIPTION
This PR builds `mls-test-cli` with `cargo build` instead of `cargo install`, because `cargo install` without the `--locked` file ignores `Cargo.lock` (which we don't want).

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
