### PR TITLE
Brig: Remove redundant constraints

### DIFF
--- a/changelog.d/5-internal/brig-redundant-constraints
+++ b/changelog.d/5-internal/brig-redundant-constraints
@@ -1,0 +1,1 @@
+Remove some redudant constraints in brig

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -181,7 +181,6 @@ addClientWithReAuthPolicy policy u con ip new = do
       ( MonadReader Env m,
         MonadMask m,
         MonadHttp m,
-        MonadIO m,
         HasRequestId m,
         Log.MonadLogger m,
         MonadClient m
@@ -228,7 +227,6 @@ rmClient u con clt pw =
 
 claimPrekey ::
   ( MonadReader Env m,
-    MonadIO m,
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
@@ -267,10 +265,6 @@ claimLocalPrekey protectee user client = do
 
 claimRemotePrekey ::
   ( MonadReader Env m,
-    MonadIO m,
-    MonadMask m,
-    MonadHttp m,
-    HasRequestId m,
     Log.MonadLogger m,
     MonadClient m
   ) =>
@@ -394,7 +388,6 @@ execDelete u con c = do
 -- (and possibly duplicated) client data.
 noPrekeys ::
   ( MonadReader Env m,
-    MonadIO m,
     MonadMask m,
     MonadHttp m,
     HasRequestId m,

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -18,7 +18,6 @@
 module Brig.API.Error where
 
 import Brig.API.Types
-import Brig.Options (DomainsBlockedForRegistration)
 import Brig.Phone (PhoneException (..))
 import Brig.Types.Common (PhoneBudgetTimeout (..))
 import Control.Monad.Error.Class hiding (Error)
@@ -414,7 +413,7 @@ legalHoldNotEnabled = Wai.mkError status403 "legalhold-not-enabled" "LegalHold m
 
 -- (the tautological constraint in the type signature is added so that once we remove the
 -- feature, ghc will guide us here.)
-customerExtensionBlockedDomain :: (DomainsBlockedForRegistration ~ DomainsBlockedForRegistration) => Domain -> Wai.Error
+customerExtensionBlockedDomain :: Domain -> Wai.Error
 customerExtensionBlockedDomain domain = Wai.mkError (mkStatus 451 "Unavailable For Legal Reasons") "domain-blocked-for-registration" msg
   where
     msg =

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -870,7 +870,7 @@ sendActivationCode Public.SendActivationCode {..} = do
 --
 -- The tautological constraint in the type signature is added so that once we remove the
 -- feature, ghc will guide us here.
-customerExtensionCheckBlockedDomains :: (DomainsBlockedForRegistration ~ DomainsBlockedForRegistration) => Public.Email -> (Handler r) ()
+customerExtensionCheckBlockedDomains :: Public.Email -> (Handler r) ()
 customerExtensionCheckBlockedDomains email = do
   mBlockedDomains <- asks (fmap domainsBlockedForRegistration . setCustomerExtensions . view settings)
   for_ mBlockedDomains $ \(DomainsBlockedForRegistration blockedDomains) -> do

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -1220,11 +1220,8 @@ verifyDeleteUser d = do
 -- other owner left.
 deleteAccount ::
   ( MonadLogger m,
-    MonadCatch m,
-    MonadThrow m,
     MonadIndexIO m,
     MonadReader Env m,
-    MonadIO m,
     MonadMask m,
     MonadHttp m,
     HasRequestId m,

--- a/services/brig/src/Brig/AWS.hs
+++ b/services/brig/src/Brig/AWS.hs
@@ -245,7 +245,7 @@ throwA :: Either AWS.Error a -> Amazon a
 throwA = either (throwM . GeneralError) pure
 
 execCatch ::
-  (AWSRequest a, MonadUnliftIO m, MonadCatch m, MonadThrow m, MonadIO m) =>
+  (AWSRequest a, MonadUnliftIO m, MonadCatch m) =>
   AWS.Env ->
   a ->
   m (Either AWS.Error (AWSResponse a))
@@ -255,7 +255,7 @@ execCatch e cmd =
       AWS.send e cmd
 
 exec ::
-  (AWSRequest a, MonadCatch m, MonadThrow m, MonadIO m) =>
+  (AWSRequest a, MonadCatch m, MonadIO m) =>
   AWS.Env ->
   a ->
   m (AWSResponse a)

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -494,7 +494,7 @@ instance MonadLogger (AppT r) where
 instance MonadLogger (ExceptT err (AppT r)) where
   log l m = lift (LC.log l m)
 
-instance MonadIO m => MonadHttp (AppT r) where
+instance MonadHttp (AppT r) where
   handleRequestWithCont req handler = do
     manager <- view httpManager
     liftIO $ withResponse req manager handler
@@ -577,7 +577,7 @@ instance MonadIndexIO (AppT r) where
 instance MonadIndexIO (AppT r) => MonadIndexIO (ExceptT err (AppT r)) where
   liftIndexIO m = view indexEnv >>= \e -> runIndexIO e m
 
-instance Monad m => HasRequestId (AppT r) where
+instance HasRequestId (AppT r) where
   getRequestId = view requestId
 
 locationOf :: (MonadIO m, MonadReader Env m) => IP -> m (Maybe Location)

--- a/services/brig/src/Brig/Data/Activation.hs
+++ b/services/brig/src/Brig/Data/Activation.hs
@@ -132,7 +132,7 @@ activateKey k c u = verifyCode k c >>= pickUser >>= activate
         for_ oldKey $ lift . deleteKey
         pure . Just $ foldKey (EmailActivated uid) (PhoneActivated uid) key
       where
-        updateEmailAndDeleteEmailUnvalidated :: MonadClient m => UserId -> Email -> m ()
+        updateEmailAndDeleteEmailUnvalidated :: UserId -> Email -> m ()
         updateEmailAndDeleteEmailUnvalidated u' email =
           updateEmail u' email <* deleteEmailUnvalidated u'
     claim key uid = do

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -141,7 +141,7 @@ addClientWithReAuthPolicy reAuthPolicy u newId c maxPermClients loc cps = do
   when (reAuthPolicy count upsert) $
     fmapLT ClientReAuthError $
       User.reauthenticate u (newClientPassword c)
-  let capacity = fmap (+ (- count)) limit
+  let capacity = fmap (+ (-count)) limit
   unless (maybe True (> 0) capacity || upsert) $
     throwE TooManyClients
   new <- insert

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -141,7 +141,7 @@ addClientWithReAuthPolicy reAuthPolicy u newId c maxPermClients loc cps = do
   when (reAuthPolicy count upsert) $
     fmapLT ClientReAuthError $
       User.reauthenticate u (newClientPassword c)
-  let capacity = fmap (+ (-count)) limit
+  let capacity = fmap (+ (- count)) limit
   unless (maybe True (> 0) capacity || upsert) $
     throwE TooManyClients
   new <- insert

--- a/services/brig/src/Brig/Data/User.hs
+++ b/services/brig/src/Brig/Data/User.hs
@@ -434,7 +434,7 @@ lookupUserTeam u =
   (runIdentity =<<)
     <$> retry x1 (query1 teamSelect (params LocalQuorum (Identity u)))
 
-lookupAuth :: MonadClient m => (MonadClient m) => UserId -> m (Maybe (Maybe Password, AccountStatus))
+lookupAuth :: MonadClient m => UserId -> m (Maybe (Maybe Password, AccountStatus))
 lookupAuth u = fmap f <$> retry x1 (query1 authSelect (params LocalQuorum (Identity u)))
   where
     f (pw, st) = (pw, fromMaybe Active st)

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -138,7 +138,6 @@ notifyUserDeleted ::
   ( MonadReader Env m,
     MonadIO m,
     HasFedEndpoint 'Brig api "on-user-deleted-connections",
-    HasClient ClientM api,
     HasClient (FederatorClient 'Brig) api
   ) =>
   Local UserId ->

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -143,11 +143,8 @@ import Wire.API.User.Client
 
 onUserEvent ::
   ( MonadLogger m,
-    MonadCatch m,
-    MonadThrow m,
     MonadIndexIO m,
     MonadReader Env m,
-    MonadIO m,
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
@@ -215,11 +212,8 @@ onClientEvent orig conn e = do
 
 updateSearchIndex ::
   ( MonadClient m,
-    MonadLogger m,
     MonadCatch m,
     MonadLogger m,
-    MonadCatch m,
-    MonadThrow m,
     MonadIndexIO m
   ) =>
   UserId ->
@@ -277,7 +271,6 @@ dispatchNotifications ::
     Log.MonadLogger m,
     MonadReader Env m,
     MonadMask m,
-    MonadCatch m,
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,
@@ -314,7 +307,6 @@ notifyUserDeletionLocals ::
     Log.MonadLogger m,
     MonadReader Env m,
     MonadMask m,
-    MonadCatch m,
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,
@@ -331,7 +323,6 @@ notifyUserDeletionLocals deleted conn event = do
 notifyUserDeletionRemotes ::
   forall m.
   ( MonadReader Env m,
-    MonadIO m,
     MonadClient m,
     MonadLogger m
   ) =>
@@ -358,7 +349,7 @@ notifyUserDeletionRemotes deleted = do
           whenLeft eitherFErr $
             logFederationError (tDomain uids)
 
-    logFederationError :: Log.MonadLogger m => Domain -> FederationError -> m ()
+    logFederationError :: Domain -> FederationError -> m ()
     logFederationError domain fErr =
       Log.err $
         Log.msg ("Federation error while notifying remote backends of a user deletion." :: ByteString)
@@ -372,7 +363,6 @@ push ::
     Log.MonadLogger m,
     MonadReader Env m,
     MonadMask m,
-    MonadCatch m,
     MonadHttp m,
     HasRequestId m
   ) =>
@@ -404,7 +394,6 @@ rawPush ::
     Log.MonadLogger m,
     MonadReader Env m,
     MonadMask m,
-    MonadCatch m,
     MonadHttp m,
     HasRequestId m
   ) =>
@@ -458,7 +447,6 @@ notify ::
     Log.MonadLogger m,
     MonadReader Env m,
     MonadMask m,
-    MonadCatch m,
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m
@@ -499,7 +487,6 @@ notifySelf ::
     Log.MonadLogger m,
     MonadReader Env m,
     MonadMask m,
-    MonadCatch m,
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m
@@ -518,7 +505,6 @@ notifySelf events orig route conn =
 notifyContacts ::
   forall m.
   ( MonadReader Env m,
-    MonadIO m,
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
@@ -538,7 +524,7 @@ notifyContacts events orig route conn = do
   notify events orig route conn $
     list1 orig <$> liftA2 (++) contacts teamContacts
   where
-    contacts :: MonadClient m => m [UserId]
+    contacts :: m [UserId]
     contacts = lookupContactList orig
 
     teamContacts :: m [UserId]
@@ -929,8 +915,7 @@ upsertOne2OneConversation ::
     MonadIO m,
     MonadMask m,
     MonadHttp m,
-    HasRequestId m,
-    MonadLogger m
+    HasRequestId m
   ) =>
   UpsertOne2OneConversationRequest ->
   m UpsertOne2OneConversationResponse
@@ -1079,8 +1064,7 @@ lookupPushToken ::
     MonadIO m,
     MonadMask m,
     MonadHttp m,
-    HasRequestId m,
-    MonadLogger m
+    HasRequestId m
   ) =>
   UserId ->
   m [Push.PushToken]

--- a/services/brig/src/Brig/Index/Eval.hs
+++ b/services/brig/src/Brig/Index/Eval.hs
@@ -111,7 +111,7 @@ runCommand l = \case
           . C.setProtocolVersion C.V4
           $ C.defSettings
 
-waitForTaskToComplete :: forall a m. (ES.MonadBH m, MonadIO m, MonadThrow m, FromJSON a) => Int -> ES.TaskNodeId -> m ()
+waitForTaskToComplete :: forall a m. (ES.MonadBH m, MonadThrow m, FromJSON a) => Int -> ES.TaskNodeId -> m ()
 waitForTaskToComplete timeoutSeconds taskNodeId = do
   -- Delay is 0.1 seconds, so retries are limited to timeoutSeconds * 10
   let policy = constantDelay 100000 <> limitRetries (timeoutSeconds * 10)
@@ -130,7 +130,7 @@ waitForTaskToComplete timeoutSeconds taskNodeId = do
     isTaskComplete (Left e) = throwM $ ReindexFromAnotherIndexError $ "Error response while getting task: " <> show e
     isTaskComplete (Right taskRes) = pure $ ES.taskResponseCompleted taskRes
 
-    errTaskGet :: MonadThrow m => ES.EsError -> m x
+    errTaskGet :: ES.EsError -> m x
     errTaskGet e = throwM $ ReindexFromAnotherIndexError $ "Error response while getting task: " <> show e
 
 newtype ReindexFromAnotherIndexError = ReindexFromAnotherIndexError String

--- a/services/brig/src/Brig/Index/Migrations.hs
+++ b/services/brig/src/Brig/Index/Migrations.hs
@@ -95,7 +95,7 @@ mkEnv l es cas galleyEndpoint = do
           $ C.defSettings
     initLogger = pure l
 
-createMigrationsIndexIfNotPresent :: (MonadThrow m, MonadIO m, ES.MonadBH m, Log.MonadLogger m) => m ()
+createMigrationsIndexIfNotPresent :: (MonadThrow m, ES.MonadBH m, Log.MonadLogger m) => m ()
 createMigrationsIndexIfNotPresent =
   do
     unlessM (ES.indexExists indexName) $ do
@@ -111,7 +111,7 @@ createMigrationsIndexIfNotPresent =
         throwM $
           err (show response)
 
-failIfIndexAbsent :: (MonadThrow m, MonadIO m, ES.MonadBH m) => ES.IndexName -> m ()
+failIfIndexAbsent :: (MonadThrow m, ES.MonadBH m) => ES.IndexName -> m ()
 failIfIndexAbsent targetIndex =
   unlessM
     (ES.indexExists targetIndex)
@@ -135,7 +135,7 @@ runMigration ver = do
           . Log.field "expectedVersion" vmax
           . Log.field "foundVersion" ver
 
-persistVersion :: (Monad m, MonadThrow m, MonadIO m) => MigrationVersion -> MigrationActionT m ()
+persistVersion :: (MonadThrow m, MonadIO m) => MigrationVersion -> MigrationActionT m ()
 persistVersion v =
   let docId = ES.DocId . Text.pack . show $ migrationVersion v
    in do

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -43,10 +43,8 @@ import UnliftIO (timeout)
 onEvent ::
   ( Log.MonadLogger m,
     MonadCatch m,
-    MonadThrow m,
     MonadIndexIO m,
     MonadReader Env m,
-    MonadIO m,
     MonadMask m,
     MonadHttp m,
     HasRequestId m,

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -689,7 +689,6 @@ deleteService pid sid del = do
 
 finishDeleteService ::
   ( MonadReader Env m,
-    MonadIO m,
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
@@ -715,7 +714,6 @@ finishDeleteService pid sid = do
 
 deleteAccountH ::
   ( MonadReader Env m,
-    MonadIO m,
     MonadMask m,
     MonadHttp m,
     MonadClient m,
@@ -730,7 +728,6 @@ deleteAccountH (pid ::: req) = do
 
 deleteAccount ::
   ( MonadReader Env m,
-    MonadIO m,
     MonadMask m,
     MonadHttp m,
     MonadClient m,
@@ -1109,7 +1106,6 @@ activate pid old new = do
 deleteBot ::
   ( MonadHttp m,
     MonadReader Env m,
-    MonadIO m,
     MonadMask m,
     HasRequestId m,
     MonadLogger m,

--- a/services/brig/src/Brig/Team/DB.hs
+++ b/services/brig/src/Brig/Team/DB.hs
@@ -174,7 +174,7 @@ deleteInvitation t i = do
     cqlInvitationEmail :: PrepQuery W (Email, TeamId) ()
     cqlInvitationEmail = "DELETE FROM team_invitation_email WHERE email = ? AND team = ?"
 
-deleteInvitations :: (MonadClient m, MonadUnliftIO m) => TeamId -> m ()
+deleteInvitations :: (MonadClient m) => TeamId -> m ()
 deleteInvitations t =
   liftClient $
     runConduit $

--- a/services/brig/src/Brig/User/API/Auth.hs
+++ b/services/brig/src/Brig/User/API/Auth.hs
@@ -396,7 +396,7 @@ tokenRequest = opt (userToken ||| legalHoldUserToken) .&. opt (accessToken ||| l
     tokenQuery :: r -> Result P.Error ByteString
     tokenQuery = query "access_token"
 
-    cookieErr :: ZAuth.UserTokenLike u => Result P.Error (List1 (ZAuth.Token u)) -> Result P.Error (List1 (ZAuth.Token u))
+    cookieErr :: Result P.Error (List1 (ZAuth.Token u)) -> Result P.Error (List1 (ZAuth.Token u))
     cookieErr x@Okay {} = x
     cookieErr (Fail x) = Fail (setMessage "Invalid user token" (P.setStatus status403 x))
 

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -137,7 +137,6 @@ login ::
   ( MonadReader Env m,
     MonadMask m,
     MonadHttp m,
-    MonadIO m,
     HasRequestId m,
     Log.MonadLogger m,
     MonadClient m,
@@ -182,7 +181,6 @@ verifyCode ::
   ( MonadReader Env m,
     MonadMask m,
     MonadHttp m,
-    MonadIO m,
     HasRequestId m,
     Log.MonadLogger m,
     MonadClient m
@@ -295,7 +293,6 @@ revokeAccess u pw cc ll = do
 
 catchSuspendInactiveUser ::
   ( MonadClient m,
-    Log.MonadLogger m,
     MonadIndexIO m,
     MonadReader Env m,
     MonadMask m,
@@ -448,7 +445,6 @@ validateToken ut at = do
 ssoLogin ::
   ( MonadClient m,
     MonadReader Env m,
-    ZAuth.MonadZAuth m,
     ZAuth.MonadZAuth m,
     Log.MonadLogger m,
     MonadIndexIO m,

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -48,7 +48,6 @@ import qualified Brig.User.Auth.DB.Cookie as DB
 import qualified Brig.ZAuth as ZAuth
 import Cassandra
 import Control.Lens (to, view)
-import Control.Monad.Catch
 import Data.ByteString.Conversion
 import Data.Id
 import qualified Data.List as List
@@ -70,9 +69,7 @@ import Wire.API.User.Auth
 newCookie ::
   ( ZAuth.UserTokenLike u,
     MonadReader Env m,
-    MonadIO m,
     ZAuth.MonadZAuth m,
-    MonadThrow m,
     MonadClient m
   ) =>
   UserId ->
@@ -103,8 +100,6 @@ newCookie uid typ label = do
 nextCookie ::
   ( ZAuth.UserTokenLike u,
     MonadReader Env m,
-    MonadIO m,
-    MonadIO m,
     Log.MonadLogger m,
     ZAuth.MonadZAuth m,
     MonadClient m
@@ -161,14 +156,14 @@ renewCookie old = do
 -- 'suspendCookiesOlderThanSecs'.  Call this always before 'newCookie', 'nextCookie',
 -- 'newCookieLimited' if there is a chance that the user should be suspended (we don't do it
 -- implicitly because of cyclical dependencies).
-mustSuspendInactiveUser :: (MonadReader Env m, MonadIO m, MonadClient m) => UserId -> m Bool
+mustSuspendInactiveUser :: (MonadReader Env m, MonadClient m) => UserId -> m Bool
 mustSuspendInactiveUser uid =
   view (settings . to setSuspendInactiveUsers) >>= \case
     Nothing -> pure False
     Just (SuspendInactiveUsers (Timeout suspendAge)) -> do
       now <- liftIO =<< view currentTime
       let suspendHere :: UTCTime
-          suspendHere = addUTCTime (-suspendAge) now
+          suspendHere = addUTCTime (- suspendAge) now
           youngEnough :: Cookie () -> Bool
           youngEnough = (>= suspendHere) . cookieCreated
       ckies <- listCookies uid []
@@ -232,7 +227,6 @@ revokeCookies u ids labels = do
 newCookieLimited ::
   ( ZAuth.UserTokenLike t,
     MonadReader Env m,
-    MonadIO m,
     MonadClient m,
     ZAuth.MonadZAuth m
   ) =>

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -163,7 +163,7 @@ mustSuspendInactiveUser uid =
     Just (SuspendInactiveUsers (Timeout suspendAge)) -> do
       now <- liftIO =<< view currentTime
       let suspendHere :: UTCTime
-          suspendHere = addUTCTime (- suspendAge) now
+          suspendHere = addUTCTime (-suspendAge) now
           youngEnough :: Cookie () -> Bool
           youngEnough = (>= suspendHere) . cookieCreated
       ckies <- listCookies uid []

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -171,7 +171,7 @@ withAdditionalESUrl action = do
 --------------------------------------------------------------------------------
 -- Updates
 
-reindex :: (MonadLogger m, MonadCatch m, MonadThrow m, MonadIndexIO m, C.MonadClient m) => UserId -> m ()
+reindex :: (MonadLogger m, MonadCatch m, MonadIndexIO m, C.MonadClient m) => UserId -> m ()
 reindex u = do
   ixu <- lookupIndexUser u
   updateIndex (maybe (IndexDeleteUser u) (IndexUpdateUser IndexUpdateIfNewerVersion) ixu)
@@ -682,7 +682,7 @@ mappingName :: ES.MappingName
 mappingName = ES.MappingName "user"
 
 lookupIndexUser ::
-  (MonadCatch m, MonadThrow m, MonadLogger m, MonadIndexIO m, C.MonadClient m) =>
+  (MonadCatch m, MonadIndexIO m, C.MonadClient m) =>
   UserId ->
   m (Maybe IndexUser)
 lookupIndexUser = lookupForIndex
@@ -911,7 +911,7 @@ getTeamSearchVisibilityInboundMulti tids = do
 
     serviceRequest' ::
       forall m.
-      (MonadIO m, MonadMask m, MonadCatch m, MonadHttp m) =>
+      (MonadIO m, MonadMask m, MonadHttp m) =>
       LT.Text ->
       Endpoint ->
       StdMethod ->


### PR DESCRIPTION
While doing some polysemy work on brig, I noticed a bunch of redundant constraints. These make it harder to determine which code paths actually require cleaning up before polysemization, so I decided to do a quick cleanup here.

There are also some unrelated changes that `make format` has been yelling at me about for several PRs now.  

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] **changelog.d** contains the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] A file with the changelog entry in one or more suitable sub-sections. The sub-sections are marked by directories inside `changelog.d`.