### PR TITLE
We only need one rule for `make clean`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ endif
 
 # Clean
 .PHONY: clean
-clean: delete-cache-on-linker-errors
+clean:
 	rm -rf ~/.cache/hie-bios
 ifdef CABAL_DIR
 	rm -rf $(CABAL_DIR)/store

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,6 @@ clean-hint:
 	@echo -e ">>> try 'make clean' and run your command again."
 	@echo -e ">>> see https://github.com/wireapp/wire-server/blob/develop/docs/developer/building.md#linker-errors-while-compiling\n\n\n"
 
-.PHONY: delete-cache-on-linker-errors
-delete-cache-on-linker-errors: clean
-
 .PHONY: cabal.project.local
 cabal.project.local:
 	echo "optimization: False" > ./cabal.project.local

--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,17 @@ else
 endif
 
 # Clean
-.PHONY: clean
-clean:
+.PHONY: full-clean
+full-clean: clean
 	rm -rf ~/.cache/hie-bios
 ifdef CABAL_DIR
 	rm -rf $(CABAL_DIR)/store
 else
 	rm -rf ~/.cabal/store
 endif
+
+.PHONY: clean
+clean:
 ifeq ($(WIRE_BUILD_WITH_CABAL), 1)
 	cabal clean
 else
@@ -71,7 +74,7 @@ endif
 .PHONY: clean-hint
 clean-hint:
 	@echo -e "\n\n\n>>> PSA: if you get errors that are hard to explain,"
-	@echo -e ">>> try 'make clean' and run your command again."
+	@echo -e ">>> try 'make full-clean' and run your command again."
 	@echo -e ">>> see https://github.com/wireapp/wire-server/blob/develop/docs/developer/building.md#linker-errors-while-compiling\n\n\n"
 
 .PHONY: cabal.project.local

--- a/Makefile
+++ b/Makefile
@@ -50,15 +50,32 @@ else
 	stack install --pedantic --test --bench --no-run-benchmarks --local-bin-path=dist
 endif
 
-.PHONY: delete-cache-on-linker-errors
-delete-cache-on-linker-errors:
+# Clean
+.PHONY: clean
+clean: delete-cache-on-linker-errors
 	rm -rf ~/.cache/hie-bios
 ifdef CABAL_DIR
 	rm -rf $(CABAL_DIR)/store
 else
 	rm -rf ~/.cabal/store
 endif
+ifeq ($(WIRE_BUILD_WITH_CABAL), 1)
 	cabal clean
+else
+	stack clean
+endif
+	$(MAKE) -C services/nginz clean
+	-rm -rf dist
+	-rm -f .metadata
+
+.PHONY: clean-hint
+clean-hint:
+	@echo -e "\n\n\n>>> PSA: if you get errors that are hard to explain,"
+	@echo -e ">>> try 'make clean' and run your command again."
+	@echo -e ">>> see https://github.com/wireapp/wire-server/blob/develop/docs/developer/building.md#linker-errors-while-compiling\n\n\n"
+
+.PHONY: delete-cache-on-linker-errors
+delete-cache-on-linker-errors: clean
 
 .PHONY: cabal.project.local
 cabal.project.local:
@@ -77,7 +94,7 @@ endif
 # Usage: make c package=brig test=1
 .PHONY: c
 c: cabal-fmt
-	cabal build $(WIRE_CABAL_BUILD_OPTIONS) $(package)
+	cabal build $(WIRE_CABAL_BUILD_OPTIONS) $(package) || ( make clean-hint; false )
 ifeq ($(test), 1)
 	./hack/bin/cabal-run-tests.sh $(package) $(testargs)
 endif
@@ -155,18 +172,6 @@ add-license:
 .PHONY: shellcheck
 shellcheck:
 	./hack/bin/shellcheck.sh
-
-# Clean
-.PHONY: clean
-clean:
-ifeq ($(WIRE_BUILD_WITH_CABAL), 1)
-	cabal clean
-else
-	stack clean
-endif
-	$(MAKE) -C services/nginz clean
-	-rm -rf dist
-	-rm -f .metadata
 
 #################################
 ## running integration tests

--- a/changelog.d/5-internal/tweak-makefile
+++ b/changelog.d/5-internal/tweak-makefile
@@ -1,0 +1,1 @@
+We only need one rule for 'make clean'

--- a/changelog.d/5-internal/tweak-makefile
+++ b/changelog.d/5-internal/tweak-makefile
@@ -1,1 +1,1 @@
-We only need one rule for 'make clean'
+Improve cleaning rules in Makefile.

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -46,7 +46,7 @@ Haskell Language Server stores its build artifacts in `~/.cache/hie-bios` (equiv
 The easiest course of action is to to remove these directories via: 
 
 ```
-make delete-cache-on-linker-errors
+make clean
 ```
 
 # How to run integration tests

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -43,7 +43,7 @@ Linker errors can occur if the nix-provided build environment (see `nix/` direct
 
 Haskell Language Server stores its build artifacts in `~/.cache/hie-bios` (equivalent to the `./dist-newstyle` directory) which become invalid for the same reason.
 
-The easiest course of action is to to remove these directories via: 
+The easiest course of action is to to remove these directories via:
 
 ```
 make clean
@@ -77,7 +77,7 @@ After all containers are up you can use these Makefile targets to run the tests 
 
 ```
 # build and run galley's integration tests
-make ci package=galley 
+make ci package=galley
 
 # run galley's integration tests that match a pattern
 TASTY_PATTERN="/MLS/" make ci package=galley

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -46,7 +46,7 @@ Haskell Language Server stores its build artifacts in `~/.cache/hie-bios` (equiv
 The easiest course of action is to to remove these directories via:
 
 ```
-make clean
+make full-clean
 ```
 
 # How to run integration tests


### PR DESCRIPTION
- simplify and consolidate make rule names
- drop hint in case of compiler error