### PR TITLE
Make mlsPrivateKeys value optional

### DIFF
--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -59,11 +59,13 @@ data:
       enableIndexedBillingTeamMembers: {{ .settings.enableIndexedBillingTeamMembers }}
       {{- end }}
       federationDomain: {{ .settings.federationDomain }}
+      {{- if $.Values.secrets.mlsPrivateKeys }}
       mlsPrivateKeyPaths:
         {{- if $.Values.secrets.mlsPrivateKeys.removal.ed25519 }}
         removal:
           ed25519: "/etc/wire/galley/secrets/removal_ed25519.pem"
         {{- end }}
+      {{- end -}}
       {{- if .settings.featureFlags }}
       featureFlags:
         sso: {{ .settings.featureFlags.sso }}

--- a/charts/galley/templates/mls-secret.yaml
+++ b/charts/galley/templates/mls-secret.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
+  {{- if .Values.secrets.mlsPrivateKeys }}
   {{- if .Values.secrets.mlsPrivateKeys.removal.ed25519 }}
   removal_ed25519.pem: {{ .Values.secrets.mlsPrivateKeys.removal.ed25519 | b64enc | quote }}
+  {{- end -}}
   {{- end -}}


### PR DESCRIPTION
This is a followup to #2602, fixing an issue with the helm templates. This PR makes it possible to omit the `mlsPrivateKeys` value.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
