### PR TITLE
charts/galley: Set secrets to empty object

### DIFF
--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -92,4 +92,4 @@ serviceAccount:
   annotations: {}
   automountServiceAccountToken: true
 
-secrets:
+secrets: {}


### PR DESCRIPTION
This avoids some templating errors when deploying the chart without any secrets
as the templating code can assume that `.Values.secrets` is a map and not
`null`.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] No changelog.