### PR TITLE
added information on finding and deleting users that are not part of …

### DIFF
--- a/docs/src/how-to/administrate/users.rst
+++ b/docs/src/how-to/administrate/users.rst
@@ -109,7 +109,7 @@ This will give you a list of handles and IDs with no team associated:
    null |       null | 1b5ca44a-aeb4-4a68-861b-48612438c4cc
    null |        bob | 701b4eab-6df2-476d-a818-90dc93e8446e
 
-You can then delete each user with the instructions found at `this link <./users.html#deleting-a-user-which-is-not-a-team-user>`__.
+You can then `delete each user with these instructions <./users.html#deleting-a-user-which-is-not-a-team-user>`__.
 
 Manual search on elasticsearch (via brig, recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/src/how-to/administrate/users.rst
+++ b/docs/src/how-to/administrate/users.rst
@@ -88,6 +88,29 @@ Afterwards, the previous command (to search for a user in cassandra) should retu
 
 When done, on terminal 1, ctrl+c to cancel the port-forwarding.
 
+Searching and deleting users with no team
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you require users to be part of a team, or for some other reason you need to delete all users who are not part of a team, you need to first find all such users, and then delete them.
+
+To find users that are not part of a team, first you need to connect via SSH to the machine where cassandra is running, and then run the following command:
+
+.. code:: sh
+
+   cqlsh 9042 -e "select team, handle, id from brig.user" | grep -E "^\s+null"
+
+This will give you a list of handles and IDs with no team associated: 
+
+.. code:: sh
+
+   null |       null | bc22119f-ce11-4402-aa70-307a58fb22ec
+   null |        tom | 8ecee3d0-47a4-43ff-977b-40a4fc350fed
+   null |      alice | 2a4c3468-c1e6-422f-bc4d-4aeff47941ac
+   null |       null | 1b5ca44a-aeb4-4a68-861b-48612438c4cc
+   null |        bob | 701b4eab-6df2-476d-a818-90dc93e8446e
+
+You can then delete each user with the instructions found at `this link <./users.html#deleting-a-user-which-is-not-a-team-user>`__.
+
 Manual search on elasticsearch (via brig, recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION

![Screenshot from 2022-08-23 15-35-29](https://user-images.githubusercontent.com/108821/186172167-3b427f5c-dc3f-4cbd-877a-524964f13d02.png)


## Checklist

 - [ ] The **PR Title** explains the impact of the change.
 - [ ] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [ ] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [ ] If HTTP endpoint paths have been added or renamed, check [docs/developer/adding-api-endpoints](https://github.com/wireapp/wire-server/blob/develop/docs/legacy/developer/adding-api-endpoints.md) and follow the steps there.
 - [ ] If configuration options have been added or removed, check [docs/developer/adding-config-options](https://github.com/wireapp/wire-server/blob/develop/docs/legacy/developer/adding-config-options.md) and follow the steps there.
 - [ ] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
- [ ] I swear that if I have changed internal end-points, I do not implicitly rely on deployment ordering (brig needing to be deployed before galley), i.e. I have **not** introduced a new internal endpoint in brig and already make use of if in galley, as I'm aware old deployed galleys would throw 500s until all new version have been rolled out and I do not want a few minutes of downtime. Instead, I have thought how to merge brig an galley codebases.
 - [ ] I updated **changelog.d** subsections with one or more entries with the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [ ] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [ ] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
