### PR TITLE
MLS: Backend sends remove proposal upon user deletion

### DIFF
--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -169,7 +169,7 @@ CREATE TABLE galley_test.member (
     conversation_role text,
     hidden boolean,
     hidden_ref text,
-    mls_clients set<text>,
+    mls_clients_keypackages set<frozen<tuple<text, blob>>>,
     otr_archived boolean,
     otr_archived_ref text,
     otr_muted boolean,

--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -263,7 +263,7 @@ CREATE TABLE galley_test.member_remote_user (
     user_remote_domain text,
     user_remote_id uuid,
     conversation_role text,
-    mls_clients set<text>,
+    mls_clients_keypackages set<frozen<tuple<text, blob>>>,
     PRIMARY KEY (conv, user_remote_domain, user_remote_id)
 ) WITH CLUSTERING ORDER BY (user_remote_domain ASC, user_remote_id ASC)
     AND bloom_filter_fp_chance = 0.1

--- a/changelog.d/2-features/mls-remove-proposals-on-user-deletion
+++ b/changelog.d/2-features/mls-remove-proposals-on-user-deletion
@@ -1,0 +1,1 @@
+External remove proposals are now sent to a group when a user is deleted

--- a/docs/src/developer/reference/cassandra-schema.cql
+++ b/docs/src/developer/reference/cassandra-schema.cql
@@ -1,1 +1,1 @@
-../../../cassandra-schema.cql
+../../../../cassandra-schema.cql

--- a/libs/galley-types/src/Galley/Types/Conversations/Members.hs
+++ b/libs/galley-types/src/Galley/Types/Conversations/Members.hs
@@ -37,13 +37,14 @@ import qualified Data.Set as Set
 import Imports
 import Wire.API.Conversation
 import Wire.API.Conversation.Role (RoleName, roleNameWireAdmin)
+import Wire.API.MLS.KeyPackage
 import Wire.API.Provider.Service (ServiceRef)
 
 -- | Internal (cassandra) representation of a remote conversation member.
 data RemoteMember = RemoteMember
   { rmId :: Remote UserId,
     rmConvRoleName :: RoleName,
-    rmMLSClients :: Set ClientId
+    rmMLSClients :: Set (ClientId, KeyPackageRef)
   }
   deriving stock (Show)
 
@@ -64,7 +65,7 @@ data LocalMember = LocalMember
     lmStatus :: MemberStatus,
     lmService :: Maybe ServiceRef,
     lmConvRoleName :: RoleName,
-    lmMLSClients :: Set ClientId
+    lmMLSClients :: Set (ClientId, KeyPackageRef)
   }
   deriving stock (Show)
 

--- a/libs/wire-api/src/Wire/API/Error/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Error/Galley.hs
@@ -192,7 +192,7 @@ type instance MapError 'MLSClientMismatch = 'StaticError 409 "mls-client-mismatc
 
 type instance MapError 'MLSStaleMessage = 'StaticError 409 "mls-stale-message" "The conversation epoch in a message is too old"
 
-type instance MapError 'MLSCommitMissingReferences = 'StaticError 409 "mls-commit-missing-references" "The commit is not refrencing all pending proposals"
+type instance MapError 'MLSCommitMissingReferences = 'StaticError 409 "mls-commit-missing-references" "The commit is not referencing all pending proposals"
 
 type instance MapError 'MLSSelfRemovalNotAllowed = 'StaticError 409 "mls-self-removal-not-allowed" "Self removal from group is not allowed"
 

--- a/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
+++ b/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
@@ -37,6 +37,7 @@ module Wire.API.MLS.KeyPackage
   )
 where
 
+import Cassandra.CQL hiding (Set)
 import Control.Applicative
 import Control.Lens hiding (set, (.=))
 import Data.Aeson (FromJSON, ToJSON)
@@ -44,6 +45,7 @@ import Data.Binary
 import Data.Binary.Get
 import Data.Binary.Put
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as LBS
 import Data.Id
 import Data.Json.Util
 import Data.Qualified
@@ -78,6 +80,12 @@ instance ToSchema KeyPackageData where
       ( KeyPackageData <$> kpData
           .= named "KeyPackage" base64Schema
       )
+
+instance Cql KeyPackageData where
+  ctype = Tagged BlobColumn
+  toCql = CqlBlob . LBS.fromStrict . kpData
+  fromCql (CqlBlob b) = pure . KeyPackageData . LBS.toStrict $ b
+  fromCql _ = Left "Expected CqlBlob"
 
 data KeyPackageBundleEntry = KeyPackageBundleEntry
   { kpbeUser :: Qualified UserId,
@@ -131,6 +139,12 @@ instance ParseMLS KeyPackageRef where
 
 instance SerialiseMLS KeyPackageRef where
   serialiseMLS = putByteString . unKeyPackageRef
+
+instance Cql KeyPackageRef where
+  ctype = Tagged BlobColumn
+  toCql = CqlBlob . LBS.fromStrict . unKeyPackageRef
+  fromCql (CqlBlob b) = pure . KeyPackageRef . LBS.toStrict $ b
+  fromCql _ = Left "Expected CqlBlob"
 
 -- | Compute key package ref given a ciphersuite and the raw key package data.
 kpRef :: CipherSuiteTag -> KeyPackageData -> KeyPackageRef

--- a/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Serialisation.hs
@@ -32,6 +32,8 @@ module Wire.API.MLS.Serialisation
     fromMLSEnum,
     toMLSEnum',
     toMLSEnum,
+    encodeMLS,
+    encodeMLS',
     decodeMLS,
     decodeMLS',
     decodeMLSWith,
@@ -172,6 +174,13 @@ newtype BinaryMLS a = BinaryMLS a
 
 instance Binary a => ParseMLS (BinaryMLS a) where
   parseMLS = BinaryMLS <$> get
+
+-- | Encode an MLS value to a lazy bytestring.
+encodeMLS :: SerialiseMLS a => a -> LByteString
+encodeMLS = runPut . serialiseMLS
+
+encodeMLS' :: SerialiseMLS a => a -> ByteString
+encodeMLS' = LBS.toStrict . encodeMLS
 
 -- | Decode an MLS value from a lazy bytestring. Return an error message in case of failure.
 decodeMLS :: ParseMLS a => LByteString -> Either Text a

--- a/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
@@ -199,7 +199,20 @@ testRemoveProposalMessageSignature = withSystemTempDirectory "mls" $ \tmp -> do
   let signerKeyFilename = "signer-key.bin"
   BS.writeFile (tmp </> signerKeyFilename) (convert publicKey)
 
-  void . liftIO $ spawn (cli qcid tmp ["consume", "--group", tmp </> groupFilename, "--signer-key", tmp </> signerKeyFilename, tmp </> messageFilename]) Nothing
+  void . liftIO $
+    spawn
+      ( cli
+          qcid
+          tmp
+          [ "consume",
+            "--group",
+            tmp </> groupFilename,
+            "--signer-key",
+            tmp </> signerKeyFilename,
+            tmp </> messageFilename
+          ]
+      )
+      Nothing
 
 createGroup :: FilePath -> String -> String -> GroupId -> IO ()
 createGroup tmp store groupName gid = do

--- a/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
@@ -192,7 +192,8 @@ testRemoveProposalMessageSignature = withSystemTempDirectory "mls" $ \tmp -> do
 
   secretKey <- Ed25519.generateSecretKey
   let publicKey = Ed25519.toPublic secretKey
-  let message = fromJust (mkRemoveProposalMessage secretKey publicKey gid (Epoch 1) (fromJust (kpRef' kp)))
+  let message = mkSignedMessage secretKey publicKey gid (Epoch 1) (ProposalMessage (mkRemoveProposal (fromJust (kpRef' kp))))
+
   let messageFilename = "signed-message.mls"
   BS.writeFile (tmp </> messageFilename) (rmRaw (mkRawMLS message))
   let signerKeyFilename = "signer-key.bin"

--- a/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
@@ -199,7 +199,7 @@ testRemoveProposalMessageSignature = withSystemTempDirectory "mls" $ \tmp -> do
   let signerKeyFilename = "signer-key.bin"
   BS.writeFile (tmp </> signerKeyFilename) (convert publicKey)
 
-  void . liftIO $ spawn (cli qcid tmp ["check-signature", "--group", tmp </> groupFilename, "--message", tmp </> messageFilename, "--signer-key", tmp </> signerKeyFilename]) Nothing
+  void . liftIO $ spawn (cli qcid tmp ["consume", "--group", tmp </> groupFilename, "--signer-key", tmp </> signerKeyFilename, tmp </> messageFilename]) Nothing
 
 createGroup :: FilePath -> String -> String -> GroupId -> IO ()
 createGroup tmp store groupName gid = do

--- a/services/brig/src/Brig/Data/Instances.hs
+++ b/services/brig/src/Brig/Data/Instances.hs
@@ -31,20 +31,16 @@ import Control.Error (note)
 import Data.Aeson (eitherDecode, encode)
 import qualified Data.Aeson as JSON
 import Data.ByteString.Conversion
-import qualified Data.ByteString.Lazy as LBS
 import Data.Domain (Domain, domainText, mkDomain)
 import Data.Handle (Handle (..))
 import Data.Id ()
 import Data.Range ()
 import Data.String.Conversions (LBS, ST, cs)
-import qualified Data.Text as T
 import Data.Text.Ascii ()
 import Data.Text.Encoding (encodeUtf8)
 import Imports
 import Wire.API.Asset (AssetKey, assetKeyToText, nilAssetKey)
 import Wire.API.Connection (RelationWithHistory (..))
-import Wire.API.MLS.Credential
-import Wire.API.MLS.KeyPackage
 import Wire.API.Properties
 import Wire.API.User
 import Wire.API.User.Activation
@@ -282,26 +278,6 @@ instance Cql Domain where
   toCql = CqlText . domainText
   fromCql (CqlText txt) = mkDomain txt
   fromCql _ = Left "Domain: Text expected"
-
-instance Cql SignatureSchemeTag where
-  ctype = Tagged TextColumn
-  toCql = CqlText . signatureSchemeName
-  fromCql (CqlText name) =
-    note ("Unexpected signature scheme: " <> T.unpack name) $
-      signatureSchemeFromName name
-  fromCql _ = Left "SignatureScheme: Text expected"
-
-instance Cql KeyPackageRef where
-  ctype = Tagged BlobColumn
-  toCql = CqlBlob . LBS.fromStrict . unKeyPackageRef
-  fromCql (CqlBlob b) = pure . KeyPackageRef . LBS.toStrict $ b
-  fromCql _ = Left "Expected CqlBlob"
-
-instance Cql KeyPackageData where
-  ctype = Tagged BlobColumn
-  toCql = CqlBlob . LBS.fromStrict . kpData
-  fromCql (CqlBlob b) = pure . KeyPackageData . LBS.toStrict $ b
-  fromCql _ = Left "Expected CqlBlob"
 
 instance Cql SearchVisibilityInbound where
   ctype = Tagged IntColumn

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -660,6 +660,7 @@ executable galley-schema
     V68_MLSCommitLock
     V69_MLSProposal
     V70_MLSCipherSuite
+    V71_MemberClientKeypackage
 
   hs-source-dirs:     schema/src
   default-extensions:

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -73,6 +73,7 @@ import qualified V67_MLSFeature
 import qualified V68_MLSCommitLock
 import qualified V69_MLSProposal
 import qualified V70_MLSCipherSuite
+import qualified V71_MemberClientKeypackage
 
 main :: IO ()
 main = do
@@ -131,7 +132,8 @@ main = do
       V67_MLSFeature.migration,
       V68_MLSCommitLock.migration,
       V69_MLSProposal.migration,
-      V70_MLSCipherSuite.migration
+      V70_MLSCipherSuite.migration,
+      V71_MemberClientKeypackage.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Galley.Cassandra
       -- (see also docs/developer/cassandra-interaction.md)

--- a/services/galley/schema/src/V71_MemberClientKeypackage.hs
+++ b/services/galley/schema/src/V71_MemberClientKeypackage.hs
@@ -15,9 +15,36 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Cassandra (schemaVersion) where
+module V71_MemberClientKeypackage where
 
+import Cassandra.Schema
 import Imports
+import Text.RawString.QQ
 
-schemaVersion :: Int32
-schemaVersion = 71
+migration :: Migration
+migration =
+  Migration 71 "Replace mls_clients with mls_clients_keypackages in member table" $ do
+    schema'
+      [r|
+        ALTER TABLE member ADD (
+          mls_clients_keypackages set<frozen<tuple<text, blob>>>
+        );
+      |]
+    schema'
+      [r|
+        ALTER TABLE member DROP (
+          mls_clients
+        );
+      |]
+    schema'
+      [r|
+        ALTER TABLE member_remote_user ADD (
+          mls_clients_keypackages set<frozen<tuple<text, blob>>>
+        );
+      |]
+    schema'
+      [r|
+        ALTER TABLE member_remote_user DROP (
+          mls_clients
+        );
+      |]

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -40,7 +40,7 @@ import qualified Data.Set as Set
 import Data.Time
 import qualified Data.UUID.Tagged as U
 import Galley.API.Error
-import Galley.API.MLS.KeyPackage (dummyCreatorKeyPackageRef)
+import Galley.API.MLS.KeyPackage (nullKeyPackageRef)
 import Galley.API.Mapping
 import Galley.API.One2One
 import Galley.API.Util
@@ -118,7 +118,7 @@ createGroupConversation lusr conn newConv = do
   case (newConvProtocol newConv, newConvCreatorClient newConv) of
     (ProtocolProteusTag, _) -> pure ()
     (ProtocolMLSTag, Just c) ->
-      E.addMLSClients lcnv (qUntagged lusr) (Set.singleton (c, dummyCreatorKeyPackageRef))
+      E.addMLSClients lcnv (qUntagged lusr) (Set.singleton (c, nullKeyPackageRef))
     (ProtocolMLSTag, Nothing) ->
       throw (InvalidPayload "Missing creator_client field when creating an MLS conversation")
 

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -119,7 +119,6 @@ createGroupConversation lusr conn newConv = do
   case (newConvProtocol newConv, newConvCreatorClient newConv) of
     (ProtocolProteusTag, _) -> pure ()
     (ProtocolMLSTag, Just c) ->
-      -- TODO: add creator key package ref to NewConv
       E.addMLSClients lcnv (qUntagged lusr) (Set.singleton (c, KeyPackageRef (BS.replicate 16 0)))
     (ProtocolMLSTag, Nothing) ->
       throw (InvalidPayload "Missing creator_client field when creating an MLS conversation")

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -31,7 +31,6 @@ module Galley.API.Create
 where
 
 import Control.Lens hiding ((??))
-import qualified Data.ByteString as BS
 import Data.Id
 import Data.List1 (list1)
 import Data.Misc (FutureWork (FutureWork))
@@ -41,6 +40,7 @@ import qualified Data.Set as Set
 import Data.Time
 import qualified Data.UUID.Tagged as U
 import Galley.API.Error
+import Galley.API.MLS.KeyPackage (dummyCreatorKeyPackageRef)
 import Galley.API.Mapping
 import Galley.API.One2One
 import Galley.API.Util
@@ -69,7 +69,6 @@ import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Event.Conversation
 import Wire.API.Federation.Error
-import Wire.API.MLS.KeyPackage
 import Wire.API.Routes.Public.Galley (ConversationResponse)
 import Wire.API.Routes.Public.Util
 import Wire.API.Team
@@ -119,7 +118,7 @@ createGroupConversation lusr conn newConv = do
   case (newConvProtocol newConv, newConvCreatorClient newConv) of
     (ProtocolProteusTag, _) -> pure ()
     (ProtocolMLSTag, Just c) ->
-      E.addMLSClients lcnv (qUntagged lusr) (Set.singleton (c, KeyPackageRef (BS.replicate 16 0)))
+      E.addMLSClients lcnv (qUntagged lusr) (Set.singleton (c, dummyCreatorKeyPackageRef))
     (ProtocolMLSTag, Nothing) ->
       throw (InvalidPayload "Missing creator_client field when creating an MLS conversation")
 

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -31,6 +31,7 @@ module Galley.API.Create
 where
 
 import Control.Lens hiding ((??))
+import qualified Data.ByteString as BS
 import Data.Id
 import Data.List1 (list1)
 import Data.Misc (FutureWork (FutureWork))
@@ -68,6 +69,7 @@ import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Event.Conversation
 import Wire.API.Federation.Error
+import Wire.API.MLS.KeyPackage
 import Wire.API.Routes.Public.Galley (ConversationResponse)
 import Wire.API.Routes.Public.Util
 import Wire.API.Team
@@ -117,7 +119,8 @@ createGroupConversation lusr conn newConv = do
   case (newConvProtocol newConv, newConvCreatorClient newConv) of
     (ProtocolProteusTag, _) -> pure ()
     (ProtocolMLSTag, Just c) ->
-      E.addMLSClients lcnv (qUntagged lusr) (Set.singleton c)
+      -- TODO: add creator key package ref to NewConv
+      E.addMLSClients lcnv (qUntagged lusr) (Set.singleton (c, KeyPackageRef (BS.replicate 16 0)))
     (ProtocolMLSTag, Nothing) ->
       throw (InvalidPayload "Missing creator_client field when creating an MLS conversation")
 

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -23,6 +23,7 @@ module Galley.API.Error
     InvalidInput (..),
     InternalError (..),
     internalErrorWithDescription,
+    internalErrorDescription,
     legalHoldServiceUnavailable,
 
     -- * Errors thrown by wai-routing handlers
@@ -34,6 +35,7 @@ import Data.Id
 import Data.Text.Lazy as LT (pack)
 import Imports
 import Network.HTTP.Types.Status
+import Network.Wai.Utilities (Error (message))
 import qualified Network.Wai.Utilities.Error as Wai
 import Wire.API.Error
 
@@ -43,6 +45,9 @@ data InternalError
   | NoPrekeyForUser
   | CannotCreateManagedConv
   | InternalErrorWithDescription LText
+
+internalErrorDescription :: InternalError -> LText
+internalErrorDescription = message . toWai
 
 instance APIError InternalError where
   toWai (BadConvState convId) = badConvState convId

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -428,6 +428,7 @@ onUserDeleted ::
        Input UTCTime,
        Input Env,
        MemberStore,
+       ProposalStore,
        TinyLog
      ]
     r =>

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -62,6 +62,7 @@ import Polysemy.Error
 import Polysemy.Input
 import Polysemy.Internal.Kind (Append)
 import Polysemy.Resource
+import Polysemy.TinyLog
 import qualified Polysemy.TinyLog as P
 import Servant (ServerT)
 import Servant.API
@@ -422,9 +423,12 @@ onUserDeleted ::
        FireAndForget,
        ExternalAccess,
        GundeckAccess,
+       Error InternalError,
        Input (Local ()),
        Input UTCTime,
-       MemberStore
+       Input Env,
+       MemberStore,
+       TinyLog
      ]
     r =>
   Domain ->
@@ -454,6 +458,7 @@ onUserDeleted origDomain udcn = do
             Public.RegularConv -> do
               let action = pure untaggedDeletedUser
                   botsAndMembers = convBotsAndMembers conv
+              mlsRemoveUser conv (qUntagged deletedUser)
               void $
                 notifyConversationAction
                   (sing @'ConversationLeaveTag)
@@ -575,6 +580,8 @@ sendMLSMessage remoteDomain msr =
   fmap (either (F.MLSMessageResponseProtocolError . unTagged) id)
     . runError @MLSProtocolError
     . fmap (either F.MLSMessageResponseError id)
+    . runError
+    . fmap (either (F.MLSMessageResponseProposalFailure . pfInner) id)
     . runError
     . fmap (either (F.MLSMessageResponseProposalFailure . pfInner) id)
     . runError

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -695,11 +695,10 @@ rmUser lusr conn = do
                     now
                     (EdMembersLeave (QualifiedUserIdList [qUser]))
             for_ (bucketRemote (fmap rmId (Data.convRemoteMembers c))) $ notifyRemoteMembers now qUser (Data.convId c)
-            let events =
-                  Intra.newPushLocal ListComplete (tUnqualified lusr) (Intra.ConvEvent e) (Intra.recipient <$> Data.convLocalMembers c)
-                    <&> set Intra.pushConn conn
-                      . set Intra.pushRoute Intra.RouteDirect
-            pure events
+            pure $
+              Intra.newPushLocal ListComplete (tUnqualified lusr) (Intra.ConvEvent e) (Intra.recipient <$> Data.convLocalMembers c)
+                <&> set Intra.pushConn conn
+                  . set Intra.pushRoute Intra.RouteDirect
           | otherwise -> pure Nothing
 
       for_

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -635,6 +635,7 @@ rmUser ::
          ListItems p1 ConvId,
          ListItems p1 (Remote ConvId),
          ListItems p2 TeamId,
+         Input (Local ()),
          MemberStore,
          TeamStore,
          P.TinyLog
@@ -681,8 +682,7 @@ rmUser lusr conn = do
         ConnectConv -> deleteMembers (Data.convId c) (UserList [tUnqualified lusr] []) $> Nothing
         RegularConv
           | tUnqualified lusr `isMember` Data.convLocalMembers c -> do
-            -- TODO: this happens before the events are pushed. Is this okay?
-            runError (mlsRemoveUser c lusr) >>= \case
+            runError (mlsRemoveUser c (qUntagged lusr)) >>= \case
               Left e -> P.err $ Log.msg ("failed to send remove proposal: " <> internalErrorDescription e)
               Right _ -> pure ()
             deleteMembers (Data.convId c) (UserList [tUnqualified lusr] [])

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -60,6 +60,7 @@ import Galley.Effects.FederatorAccess
 import Galley.Effects.GundeckAccess
 import Galley.Effects.LegalHoldStore as LegalHoldStore
 import Galley.Effects.MemberStore
+import Galley.Effects.ProposalStore
 import Galley.Effects.TeamStore
 import qualified Galley.Intra.Push as Intra
 import Galley.Monad
@@ -637,6 +638,7 @@ rmUser ::
          ListItems p2 TeamId,
          Input (Local ()),
          MemberStore,
+         ProposalStore,
          TeamStore,
          P.TinyLog
        ]

--- a/services/galley/src/Galley/API/MLS/KeyPackage.hs
+++ b/services/galley/src/Galley/API/MLS/KeyPackage.hs
@@ -26,8 +26,8 @@ import Wire.API.Error.Galley
 import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
 
-dummyCreatorKeyPackageRef :: KeyPackageRef
-dummyCreatorKeyPackageRef = KeyPackageRef (BS.replicate 16 0)
+nullKeyPackageRef :: KeyPackageRef
+nullKeyPackageRef = KeyPackageRef (BS.replicate 16 0)
 
 derefKeyPackage ::
   Members

--- a/services/galley/src/Galley/API/MLS/KeyPackage.hs
+++ b/services/galley/src/Galley/API/MLS/KeyPackage.hs
@@ -17,6 +17,7 @@
 
 module Galley.API.MLS.KeyPackage where
 
+import qualified Data.ByteString as BS
 import Galley.Effects.BrigAccess
 import Imports
 import Polysemy
@@ -24,6 +25,9 @@ import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
+
+dummyCreatorKeyPackageRef :: KeyPackageRef
+dummyCreatorKeyPackageRef = KeyPackageRef (BS.replicate 16 0)
 
 derefKeyPackage ::
   Members

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -525,10 +525,10 @@ applyProposal (AddProposal kp) = do
     kpRef' kp
       & note (mlsProtocolError "Could not compute ref of a key package in an Add proposal")
   qclient <- cidQualifiedClient <$> derefKeyPackage ref
-  pure (paAddClient (fmap (fmap (,ref)) qclient))
+  pure (paAddClient ((,ref) <$$> qclient))
 applyProposal (RemoveProposal ref) = do
   qclient <- cidQualifiedClient <$> derefKeyPackage ref
-  pure (paRemoveClient (fmap (fmap (,ref)) qclient))
+  pure (paRemoveClient ((,ref) <$$> qclient))
 applyProposal _ = pure mempty
 
 checkProposalCipherSuite ::

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -429,7 +429,7 @@ processCommit qusr senderClient con lconv epoch sender commit = do
                   )
                   $ cPath commit
               -- register the creator client
-              updateKeyPackageMapping lconv qusr creatorClient Nothing senderRef
+              updateKeyPackageMapping lconv qusr creatorClient (Just dummyCreatorKeyPackageRef) senderRef
             -- remote clients cannot send the first commit
             (_, Right _) -> throwS @'MLSStaleMessage
             -- uninitialised conversations should contain exactly one client

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -429,7 +429,7 @@ processCommit qusr senderClient con lconv epoch sender commit = do
                   )
                   $ cPath commit
               -- register the creator client
-              updateKeyPackageMapping lconv qusr creatorClient (Just dummyCreatorKeyPackageRef) senderRef
+              updateKeyPackageMapping lconv qusr creatorClient Nothing senderRef
             -- remote clients cannot send the first commit
             (_, Right _) -> throwS @'MLSStaleMessage
             -- uninitialised conversations should contain exactly one client
@@ -487,9 +487,8 @@ updateKeyPackageMapping lconv qusr cid mOld new = do
           }
 
   -- remove old (client, key package) pair
-  for_ mOld $ \old ->
-    removeMLSClients lcnv qusr (Set.singleton (cid, old))
-
+  let old = fromMaybe nullKeyPackageRef mOld
+  removeMLSClients lcnv qusr (Set.singleton (cid, old))
   -- add new (client, key package) pair
   addMLSClients lcnv qusr (Set.singleton (cid, new))
 

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -46,6 +46,7 @@ import Polysemy.Input
 import qualified UnliftIO
 import Wire.API.Conversation.Member hiding (Member)
 import Wire.API.Conversation.Role
+import Wire.API.MLS.KeyPackage
 import Wire.API.Provider.Service
 
 -- | Add members to a local conversation.
@@ -157,7 +158,7 @@ toMember ::
     Maybe Text,
     -- conversation role name
     Maybe RoleName,
-    Maybe (Cassandra.Set ClientId)
+    Maybe (Cassandra.Set (ClientId, KeyPackageRef))
   ) ->
   Maybe LocalMember
 toMember (usr, srv, prv, Just 0, omus, omur, oar, oarr, hid, hidr, crn, cs) =
@@ -344,14 +345,14 @@ removeLocalMembersFromRemoteConv (qUntagged -> Qualified conv convDomain) victim
     setConsistency LocalQuorum
     for_ victims $ \u -> addPrepQuery Cql.deleteUserRemoteConv (u, convDomain, conv)
 
-addMLSClients :: Local ConvId -> Qualified UserId -> Set.Set ClientId -> Client ()
+addMLSClients :: Local ConvId -> Qualified UserId -> Set.Set (ClientId, KeyPackageRef) -> Client ()
 addMLSClients lcnv =
   foldQualified
     lcnv
     (addLocalMLSClients (tUnqualified lcnv))
     (addRemoteMLSClients (tUnqualified lcnv))
 
-addRemoteMLSClients :: ConvId -> Remote UserId -> Set.Set ClientId -> Client ()
+addRemoteMLSClients :: ConvId -> Remote UserId -> Set.Set (ClientId, KeyPackageRef) -> Client ()
 addRemoteMLSClients cid ruid cs =
   retry x5 $
     write
@@ -361,7 +362,7 @@ addRemoteMLSClients cid ruid cs =
           (Cassandra.Set (toList cs), cid, tDomain ruid, tUnqualified ruid)
       )
 
-addLocalMLSClients :: ConvId -> Local UserId -> Set.Set ClientId -> Client ()
+addLocalMLSClients :: ConvId -> Local UserId -> Set.Set (ClientId, KeyPackageRef) -> Client ()
 addLocalMLSClients cid lusr cs =
   retry x5 $
     write

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -383,7 +383,7 @@ removeLocalMLSClients :: ConvId -> Local UserId -> Set.Set (ClientId, KeyPackage
 removeLocalMLSClients cid lusr cs =
   retry x5 $
     write
-      Cql.addLocalMLSClients
+      Cql.removeLocalMLSClients
       ( params
           LocalQuorum
           (Cassandra.Set (toList cs), cid, tUnqualified lusr)

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -374,6 +374,12 @@ addLocalMLSClients = "update member set mls_clients_keypackages = mls_clients_ke
 addRemoteMLSClients :: PrepQuery W (C.Set (ClientId, KeyPackageRef), ConvId, Domain, UserId) ()
 addRemoteMLSClients = "update member_remote_user set mls_clients_keypackages = mls_clients_keypackages + ? where conv = ? and user_remote_domain = ? and user_remote_id = ?"
 
+removeLocalMLSClients :: PrepQuery W (C.Set (ClientId, KeyPackageRef), ConvId, UserId) ()
+removeLocalMLSClients = "update member set mls_clients_keypackages = mls_clients_keypackages - ? where conv = ? and user = ?"
+
+removeRemoteMLSClients :: PrepQuery W (C.Set (ClientId, KeyPackageRef), ConvId, Domain, UserId) ()
+removeRemoteMLSClients = "update member_remote_user set mls_clients_keypackages = mls_clients_keypackages - ? where conv = ? and user_remote_domain = ? and user_remote_id = ?"
+
 acquireCommitLock :: PrepQuery W (GroupId, Epoch, Int32) Row
 acquireCommitLock = "insert into mls_commit_locks (group_id, epoch) values (?, ?) if not exists using ttl ?"
 

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -34,6 +34,7 @@ import Wire.API.Conversation.Code
 import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 import Wire.API.MLS.CipherSuite
+import Wire.API.MLS.KeyPackage
 import Wire.API.Provider
 import Wire.API.Provider.Service
 import Wire.API.Team
@@ -271,14 +272,14 @@ lookupGroupId = "SELECT conv_id, domain from group_id_conv_id where group_id = ?
 
 type MemberStatus = Int32
 
-selectMember :: PrepQuery R (ConvId, UserId) (UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName, Maybe (C.Set ClientId))
-selectMember = "select user, service, provider, status, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role, mls_clients from member where conv = ? and user = ?"
+selectMember :: PrepQuery R (ConvId, UserId) (UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName, Maybe (C.Set (ClientId, KeyPackageRef)))
+selectMember = "select user, service, provider, status, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role, mls_clients_keypackages from member where conv = ? and user = ?"
 
-selectMembers :: PrepQuery R (Identity ConvId) (UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName, Maybe (C.Set ClientId))
-selectMembers = "select user, service, provider, status, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role, mls_clients from member where conv = ?"
+selectMembers :: PrepQuery R (Identity ConvId) (UserId, Maybe ServiceId, Maybe ProviderId, Maybe MemberStatus, Maybe MutedStatus, Maybe Text, Maybe Bool, Maybe Text, Maybe Bool, Maybe Text, Maybe RoleName, Maybe (C.Set (ClientId, KeyPackageRef)))
+selectMembers = "select user, service, provider, status, otr_muted_status, otr_muted_ref, otr_archived, otr_archived_ref, hidden, hidden_ref, conversation_role, mls_clients_keypackages from member where conv = ?"
 
-insertMember :: PrepQuery W (ConvId, UserId, Maybe ServiceId, Maybe ProviderId, RoleName, Maybe (C.Set ClientId)) ()
-insertMember = "insert into member (conv, user, service, provider, status, conversation_role, mls_clients) values (?, ?, ?, ?, 0, ?, ?)"
+insertMember :: PrepQuery W (ConvId, UserId, Maybe ServiceId, Maybe ProviderId, RoleName, Maybe (C.Set (ClientId, KeyPackageRef))) ()
+insertMember = "insert into member (conv, user, service, provider, status, conversation_role, mls_clients_keypackages) values (?, ?, ?, ?, 0, ?, ?)"
 
 removeMember :: PrepQuery W (ConvId, UserId) ()
 removeMember = "delete from member where conv = ? and user = ?"
@@ -307,11 +308,11 @@ insertRemoteMember = "insert into member_remote_user (conv, user_remote_domain, 
 removeRemoteMember :: PrepQuery W (ConvId, Domain, UserId) ()
 removeRemoteMember = "delete from member_remote_user where conv = ? and user_remote_domain = ? and user_remote_id = ?"
 
-selectRemoteMember :: PrepQuery R (ConvId, Domain, UserId) (RoleName, C.Set ClientId)
-selectRemoteMember = "select conversation_role, mls_clients from member_remote_user where conv = ? and user_remote_domain = ? and user_remote_id = ?"
+selectRemoteMember :: PrepQuery R (ConvId, Domain, UserId) (RoleName, C.Set (ClientId, KeyPackageRef))
+selectRemoteMember = "select conversation_role, mls_clients_keypackages from member_remote_user where conv = ? and user_remote_domain = ? and user_remote_id = ?"
 
-selectRemoteMembers :: PrepQuery R (Identity ConvId) (Domain, UserId, RoleName, C.Set ClientId)
-selectRemoteMembers = "select user_remote_domain, user_remote_id, conversation_role, mls_clients from member_remote_user where conv = ?"
+selectRemoteMembers :: PrepQuery R (Identity ConvId) (Domain, UserId, RoleName, C.Set (ClientId, KeyPackageRef))
+selectRemoteMembers = "select user_remote_domain, user_remote_id, conversation_role, mls_clients_keypackages from member_remote_user where conv = ?"
 
 updateRemoteMemberConvRoleName :: PrepQuery W (RoleName, ConvId, Domain, UserId) ()
 updateRemoteMemberConvRoleName = "update member_remote_user set conversation_role = ? where conv = ? and user_remote_domain = ? and user_remote_id = ?"
@@ -367,11 +368,11 @@ rmMemberClient c =
 
 -- MLS Clients --------------------------------------------------------------
 
-addLocalMLSClients :: PrepQuery W (C.Set ClientId, ConvId, UserId) ()
-addLocalMLSClients = "update member set mls_clients = mls_clients + ? where conv = ? and user = ?"
+addLocalMLSClients :: PrepQuery W (C.Set (ClientId, KeyPackageRef), ConvId, UserId) ()
+addLocalMLSClients = "update member set mls_clients_keypackages = mls_clients_keypackages + ? where conv = ? and user = ?"
 
-addRemoteMLSClients :: PrepQuery W (C.Set ClientId, ConvId, Domain, UserId) ()
-addRemoteMLSClients = "update member_remote_user set mls_clients = mls_clients + ? where conv = ? and user_remote_domain = ? and user_remote_id = ?"
+addRemoteMLSClients :: PrepQuery W (C.Set (ClientId, KeyPackageRef), ConvId, Domain, UserId) ()
+addRemoteMLSClients = "update member_remote_user set mls_clients_keypackages = mls_clients_keypackages + ? where conv = ? and user_remote_domain = ? and user_remote_id = ?"
 
 acquireCommitLock :: PrepQuery W (GroupId, Epoch, Int32) Row
 acquireCommitLock = "insert into mls_commit_locks (group_id, epoch) values (?, ?) if not exists using ttl ?"

--- a/services/galley/src/Galley/Data/Conversation/Types.hs
+++ b/services/galley/src/Galley/Data/Conversation/Types.hs
@@ -18,12 +18,14 @@
 module Galley.Data.Conversation.Types where
 
 import Data.Id
+import Data.Qualified
 import Galley.Types.Conversations.Members
 import Galley.Types.UserList
 import Imports
 import Wire.API.Conversation hiding (Conversation)
 import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
+import Wire.API.MLS.KeyPackage
 
 -- | Internal conversation type, corresponding directly to database schema.
 -- Should never be sent to users (and therefore doesn't have 'FromJSON' or
@@ -43,3 +45,11 @@ data NewConversation = NewConversation
     ncUsers :: UserList (UserId, RoleName),
     ncProtocol :: ProtocolTag
   }
+
+getConvMemberMLSClients :: Local () -> Conversation -> Qualified UserId -> Maybe (Set (ClientId, KeyPackageRef))
+getConvMemberMLSClients loc conv qusr =
+  foldQualified
+    loc
+    (\lusr -> lmMLSClients <$> find ((==) (tUnqualified lusr) . lmId) (convLocalMembers conv))
+    (\rusr -> rmMLSClients <$> find ((==) rusr . rmId) (convRemoteMembers conv))
+    qusr

--- a/services/galley/src/Galley/Effects/MemberStore.hs
+++ b/services/galley/src/Galley/Effects/MemberStore.hs
@@ -39,6 +39,7 @@ module Galley.Effects.MemberStore
     setSelfMember,
     setOtherMember,
     addMLSClients,
+    removeMLSClients,
 
     -- * Delete members
     deleteMembers,
@@ -73,6 +74,7 @@ data MemberStore m a where
   DeleteMembers :: ConvId -> UserList UserId -> MemberStore m ()
   DeleteMembersInRemoteConversation :: Remote ConvId -> [UserId] -> MemberStore m ()
   AddMLSClients :: Local ConvId -> Qualified UserId -> Set (ClientId, KeyPackageRef) -> MemberStore m ()
+  RemoveMLSClients :: Local ConvId -> Qualified UserId -> Set (ClientId, KeyPackageRef) -> MemberStore m ()
 
 makeSem ''MemberStore
 

--- a/services/galley/src/Galley/Effects/MemberStore.hs
+++ b/services/galley/src/Galley/Effects/MemberStore.hs
@@ -55,6 +55,7 @@ import Galley.Types.UserList
 import Imports
 import Polysemy
 import Wire.API.Conversation.Member hiding (Member)
+import Wire.API.MLS.KeyPackage
 import Wire.API.Provider.Service
 
 data MemberStore m a where
@@ -71,7 +72,7 @@ data MemberStore m a where
   SetOtherMember :: Local ConvId -> Qualified UserId -> OtherMemberUpdate -> MemberStore m ()
   DeleteMembers :: ConvId -> UserList UserId -> MemberStore m ()
   DeleteMembersInRemoteConversation :: Remote ConvId -> [UserId] -> MemberStore m ()
-  AddMLSClients :: Local ConvId -> Qualified UserId -> Set ClientId -> MemberStore m ()
+  AddMLSClients :: Local ConvId -> Qualified UserId -> Set (ClientId, KeyPackageRef) -> MemberStore m ()
 
 makeSem ''MemberStore
 

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1726,6 +1726,9 @@ testBackendRemoveProposalLocalConvLocalUser = withSystemTempDirectory "mls" $ \t
       WS.assertMatch_ (5 # WS.Second) wsA $ \notification ->
         wsAssertBackendRemoveProposal bob conversation kp notification
 
+  -- TODO: Add to test: commit  proposal (get ref from the notification) and check that commit is sucessful
+  pure ()
+
 testBackendRemoveProposalLocalConvRemoteUser :: TestM ()
 testBackendRemoveProposalLocalConvRemoteUser = withSystemTempDirectory "mls" $ \tmp -> do
   let opts =

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1721,13 +1721,13 @@ testBackendRemoveProposalLocalConvLocalUser = withSystemTempDirectory "mls" $ \t
   kprefs <- (fromJust . kpRef' . snd) <$$> liftIO (readKeyPackages tmp bobParticipant)
 
   c <- view tsCannon
-  WS.bracketR2 c (qUnqualified alice) (qUnqualified bob) $ \(wsA, wsB) -> do
+
+  WS.bracketR c (qUnqualified alice) $ \wsA -> do
     deleteUser (qUnqualified bob) !!! const 200 === statusCode
 
-    for_ [(wsA, alice), (wsB, bob)] $ \(ws, receivingUser) ->
-      for_ kprefs $ \kp ->
-        WS.assertMatch_ (5 # WS.Second) ws $ \notification ->
-          wsAssertBackendRemoveProposal receivingUser conversation kp notification
+    for_ kprefs $ \kp ->
+      WS.assertMatch_ (5 # WS.Second) wsA $ \notification ->
+        wsAssertBackendRemoveProposal bob conversation kp notification
 
 testBackendRemoveProposalRemoteConvLocalUser :: TestM ()
 testBackendRemoveProposalRemoteConvLocalUser = do

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -142,6 +142,11 @@ pClientQid p = userClientQid (pUserId p) (NonEmpty.head (pClientIds p))
 pClientId :: Participant -> ClientId
 pClientId = NonEmpty.head . pClientIds
 
+readKeyPackages :: FilePath -> Participant -> IO (NonEmpty (ClientId, RawMLS KeyPackage))
+readKeyPackages tmp participant = for (pClients participant) $ \(qcid, cid) -> do
+  b <- BS.readFile (tmp </> qcid)
+  pure (cid, fromRight (error "parsing RawMLS KeyPackage") (decodeMLS' b))
+
 setupUserClient ::
   HasCallStack =>
   FilePath ->

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -39,6 +39,8 @@ import qualified Data.Map as Map
 import Data.Qualified
 import qualified Data.Set as Set
 import qualified Data.Text as T
+import Galley.Keys
+import Galley.Options
 import Imports
 import System.FilePath
 import System.IO.Temp
@@ -52,6 +54,7 @@ import Wire.API.Conversation.Protocol
 import Wire.API.Event.Conversation
 import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
+import Wire.API.MLS.Keys
 import Wire.API.MLS.Message
 import Wire.API.MLS.Proposal
 import Wire.API.MLS.Serialisation
@@ -611,3 +614,10 @@ mkAppAckProposalMessage gid epoch ref mrs priv pub = do
             }
       sig = BA.convert $ sign priv pub (rmRaw tbs)
    in (Message tbs (MessageExtraFields sig Nothing Nothing))
+
+saveRemovalKey :: FilePath -> TestM ()
+saveRemovalKey fp = do
+  keys <- fromJust <$> view (tsGConf . optSettings . setMlsPrivateKeyPaths)
+  keysByPurpose <- liftIO $ loadAllMLSKeys keys
+  let (_, pub) = fromJust (mlsKeyPair_ed25519 (keysByPurpose RemovalPurpose))
+  liftIO $ BS.writeFile fp (BA.convert pub)

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2764,7 +2764,7 @@ wsAssertConvReceiptModeUpdate conv usr new n = do
   evtFrom e @?= usr
   evtData e @?= EdConvReceiptModeUpdate (ConversationReceiptModeUpdate new)
 
-wsAssertBackendRemoveProposal :: HasCallStack => Qualified UserId -> Qualified ConvId -> KeyPackageRef -> Notification -> IO ()
+wsAssertBackendRemoveProposal :: HasCallStack => Qualified UserId -> Qualified ConvId -> KeyPackageRef -> Notification -> IO ByteString
 wsAssertBackendRemoveProposal fromUser convId kpref n = do
   let e = List1.head (WS.unpackPayload n)
   ntfTransient n @?= False
@@ -2782,6 +2782,7 @@ wsAssertBackendRemoveProposal fromUser convId kpref n = do
           kpRefRemove @?= kpref
         otherProp -> error ("Exepected RemoveProposal but got " <> show otherProp)
     otherPayload -> error ("Exepected ProposalMessage but got " <> show otherPayload)
+  pure bs
   where
     getMLSMessageData :: Conv.EventData -> ByteString
     getMLSMessageData (EdMLSMessage bs) = bs

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -111,6 +111,9 @@ import Wire.API.Federation.API
 import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Domain (originDomainHeaderName)
 import Wire.API.Internal.Notification hiding (target)
+import Wire.API.MLS.KeyPackage
+import Wire.API.MLS.Message
+import Wire.API.MLS.Proposal
 import Wire.API.MLS.Serialisation
 import Wire.API.Message
 import qualified Wire.API.Message.Proto as Proto
@@ -2760,3 +2763,26 @@ wsAssertConvReceiptModeUpdate conv usr new n = do
   evtType e @?= ConvReceiptModeUpdate
   evtFrom e @?= usr
   evtData e @?= EdConvReceiptModeUpdate (ConversationReceiptModeUpdate new)
+
+wsAssertBackendRemoveProposal :: HasCallStack => Qualified UserId -> Qualified ConvId -> KeyPackageRef -> Notification -> IO ()
+wsAssertBackendRemoveProposal fromUser convId kpref n = do
+  let e = List1.head (WS.unpackPayload n)
+  ntfTransient n @?= False
+  evtConv e @?= convId
+  evtType e @?= MLSMessageAdd
+  evtFrom e @?= fromUser
+  let bs = getMLSMessageData (evtData e)
+  let msg = fromRight (error "Failed to parse Message 'MLSPlaintext") $ decodeMLS' bs
+  let tbs = rmValue . msgTBS $ msg
+  tbsMsgSender tbs @?= PreconfiguredSender 0
+  case tbsMsgPayload tbs of
+    ProposalMessage rp ->
+      case rmValue rp of
+        RemoveProposal kpRefRemove ->
+          kpRefRemove @?= kpref
+        otherProp -> error ("Exepected RemoveProposal but got " <> show otherProp)
+    otherPayload -> error ("Exepected ProposalMessage but got " <> show otherPayload)
+  where
+    getMLSMessageData :: Conv.EventData -> ByteString
+    getMLSMessageData (EdMLSMessage bs) = bs
+    getMLSMessageData d = error ("Excepected EdMLSMessage, but got " <> show d)


### PR DESCRIPTION
Send external remove proposals when users are deleted.

Tracked by https://wearezeta.atlassian.net/browse/FS-906.

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
 - [x] I updated **changelog.d** subsections with one or more entries with the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
