### PR TITLE
Make nonces lookuppable by client ids

### DIFF
--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -694,23 +694,6 @@ CREATE TABLE brig_test.team_invitation_info (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
-CREATE TABLE brig_test.client_nonce (
-    nonce uuid PRIMARY KEY
-) WITH bloom_filter_fp_chance = 0.01
-    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
-    AND comment = ''
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
-    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
-    AND crc_check_chance = 1.0
-    AND dclocal_read_repair_chance = 0.1
-    AND default_time_to_live = 300
-    AND gc_grace_seconds = 864000
-    AND max_index_interval = 2048
-    AND memtable_flush_period_in_ms = 0
-    AND min_index_interval = 128
-    AND read_repair_chance = 0.0
-    AND speculative_retry = '99PERCENTILE';
-
 CREATE TABLE brig_test.rich_info (
     user uuid PRIMARY KEY,
     json blob
@@ -1102,6 +1085,24 @@ CREATE TABLE brig_test.invitee_info (
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99PERCENTILE';
+
+CREATE TABLE brig_test.nonce (
+    key text PRIMARY KEY,
+    nonce uuid
+) WITH bloom_filter_fp_chance = 0.01
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
+    AND comment = ''
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
+    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1.0
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 300
     AND gc_grace_seconds = 864000
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0

--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -1093,9 +1093,12 @@ CREATE TABLE brig_test.invitee_info (
     AND speculative_retry = '99PERCENTILE';
 
 CREATE TABLE brig_test.nonce (
-    key text PRIMARY KEY,
-    nonce uuid
-) WITH bloom_filter_fp_chance = 0.01
+    user uuid,
+    key text,
+    nonce uuid,
+    PRIMARY KEY (user, key)
+) WITH CLUSTERING ORDER BY (key ASC)
+    AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}

--- a/changelog.d/5-internal/fix-nonce-table
+++ b/changelog.d/5-internal/fix-nonce-table
@@ -1,0 +1,1 @@
+Replace cassandra table `client_nonce` with `nonce` and introduce key

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -547,8 +547,9 @@ type NewNonce name method statusCode =
     name
     ( Summary "Get a new nonce for a client CSR, specified in the response header `Replay-Nonce` as a uuidv4 in base64url encoding"
         :> ZUser
-        :> "nonce"
         :> "clients"
+        :> CaptureClientId "client"
+        :> "nonce"
         :> MultiVerb1
              method
              '[JSON]

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -655,6 +655,7 @@ executable brig-schema
     V70_UserEmailUnvalidated
     V71_AddTableVCodesThrottle
     V72_AddNonceTable
+    V73_ReplaceNonceTable
     V9
 
   hs-source-dirs:     schema/src

--- a/services/brig/schema/src/Main.hs
+++ b/services/brig/schema/src/Main.hs
@@ -82,6 +82,7 @@ import qualified V69_MLSKeyPackageRefMapping
 import qualified V70_UserEmailUnvalidated
 import qualified V71_AddTableVCodesThrottle
 import qualified V72_AddNonceTable
+import qualified V73_ReplaceNonceTable
 import qualified V9
 
 main :: IO ()
@@ -153,7 +154,8 @@ main = do
       V69_MLSKeyPackageRefMapping.migration,
       V70_UserEmailUnvalidated.migration,
       V71_AddTableVCodesThrottle.migration,
-      V72_AddNonceTable.migration
+      V72_AddNonceTable.migration,
+      V73_ReplaceNonceTable.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Brig.App
 

--- a/services/brig/schema/src/V73_ReplaceNonceTable.hs
+++ b/services/brig/schema/src/V73_ReplaceNonceTable.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V73_ReplaceNonceTable
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration =
+  Migration 73 "Replace nonce with a better one" $ do
+    schema'
+      [r|
+        DROP TABLE IF EXISTS client_nonce
+     |]
+    schema'
+      [r|
+        CREATE TABLE IF NOT EXISTS nonce
+          ( key text PRIMARY KEY
+          , nonce uuid
+          ) WITH default_time_to_live = 300;
+     |]

--- a/services/brig/schema/src/V73_ReplaceNonceTable.hs
+++ b/services/brig/schema/src/V73_ReplaceNonceTable.hs
@@ -36,7 +36,9 @@ migration =
     schema'
       [r|
         CREATE TABLE IF NOT EXISTS nonce
-          ( key text PRIMARY KEY
+          ( user uuid,
+          , key text,
           , nonce uuid
+          , primary key (user, key)
           ) WITH default_time_to_live = 300;
      |]

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -620,10 +620,10 @@ getClientPrekeys :: UserId -> ClientId -> (Handler r) [Public.PrekeyId]
 getClientPrekeys usr clt = lift (wrapClient $ API.lookupPrekeyIds usr clt)
 
 newNonce :: UserId -> ClientId -> (Handler r) Nonce
-newNonce _ cid = do
+newNonce uid cid = do
   ttl <- setNonceTtlSecs <$> view settings
   nonce <- randomNonce
-  lift $ wrapClient $ Nonce.insertNonce ttl (client cid) nonce
+  lift $ wrapClient $ Nonce.insertNonce ttl uid (client cid) nonce
   pure nonce
 
 -- | docs/reference/user/registration.md {#RefRegistration}

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -85,7 +85,6 @@ import Data.Misc (IpAddr (..))
 import Data.Nonce (Nonce, randomNonce)
 import Data.Qualified
 import Data.Range
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Swagger.Build.Api as Doc
 import qualified Data.Text as Text
@@ -620,13 +619,11 @@ getRichInfo self user = do
 getClientPrekeys :: UserId -> ClientId -> (Handler r) [Public.PrekeyId]
 getClientPrekeys usr clt = lift (wrapClient $ API.lookupPrekeyIds usr clt)
 
-newNonce :: UserId -> (Handler r) Nonce
-newNonce _ = do
-  let cid :: ByteString
-      cid = "123" -- TODO: this requires a change in API.  we need to be given the client id from the client.
+newNonce :: UserId -> ClientId -> (Handler r) Nonce
+newNonce _ cid = do
   ttl <- setNonceTtlSecs <$> view settings
   nonce <- randomNonce
-  lift $ wrapClient $ Nonce.insertNonce ttl (cs cid) nonce
+  lift $ wrapClient $ Nonce.insertNonce ttl (client cid) nonce
   pure nonce
 
 -- | docs/reference/user/registration.md {#RefRegistration}

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -623,7 +623,7 @@ newNonce :: UserId -> (Handler r) Nonce
 newNonce _ = do
   ttl <- setNonceTtlSecs <$> view settings
   nonce <- randomNonce
-  lift $ wrapClient $ Nonce.insertNonce ttl nonce
+  lift $ wrapClient $ Nonce.insertNonce ttl undefined nonce
   pure nonce
 
 -- | docs/reference/user/registration.md {#RefRegistration}

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -85,6 +85,7 @@ import Data.Misc (IpAddr (..))
 import Data.Nonce (Nonce, randomNonce)
 import Data.Qualified
 import Data.Range
+import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Swagger.Build.Api as Doc
 import qualified Data.Text as Text
@@ -621,9 +622,11 @@ getClientPrekeys usr clt = lift (wrapClient $ API.lookupPrekeyIds usr clt)
 
 newNonce :: UserId -> (Handler r) Nonce
 newNonce _ = do
+  let cid :: ByteString
+      cid = "123" -- TODO: this requires a change in API.  we need to be given the client id from the client.
   ttl <- setNonceTtlSecs <$> view settings
   nonce <- randomNonce
-  lift $ wrapClient $ Nonce.insertNonce ttl undefined nonce
+  lift $ wrapClient $ Nonce.insertNonce ttl (cs cid) nonce
   pure nonce
 
 -- | docs/reference/user/registration.md {#RefRegistration}

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -148,7 +148,7 @@ import Util.Options
 import Wire.API.User
 
 schemaVersion :: Int32
-schemaVersion = 72
+schemaVersion = 73
 
 -------------------------------------------------------------------------------
 -- Environment

--- a/services/brig/src/Brig/Data/Nonce.hs
+++ b/services/brig/src/Brig/Data/Nonce.hs
@@ -30,14 +30,14 @@ import Imports
 
 insertNonce ::
   (MonadClient m, MonadReader Brig.App.Env m) =>
-  Word64 ->
+  Int32 ->
   Text ->
   Nonce ->
   m ()
-insertNonce ttl key nonce = retry x5 . write insert $ params LocalQuorum (key, nonce)
+insertNonce ttl key nonce = retry x5 . write insert $ params LocalQuorum (key, nonce, ttl)
   where
-    insert :: PrepQuery W (Text, Nonce) ()
-    insert = fromString $ "INSERT INTO nonce (key, nonce) VALUES (?) USING TTL " <> show ttl
+    insert :: PrepQuery W (Text, Nonce, Int32) ()
+    insert = "INSERT INTO nonce (key, nonce) VALUES (?, ?) USING TTL ?"
 
 lookupAndDeleteNonce ::
   (MonadClient m, MonadReader Env m) =>

--- a/services/brig/src/Brig/Data/Nonce.hs
+++ b/services/brig/src/Brig/Data/Nonce.hs
@@ -26,19 +26,19 @@ import Brig.Data.Instances ()
 import Cassandra
 import Control.Lens hiding (from)
 import Data.Id (UserId)
-import Data.Nonce (Nonce)
+import Data.Nonce (Nonce, NonceTtlSecs)
 import Imports
 
 insertNonce ::
   (MonadClient m, MonadReader Brig.App.Env m) =>
-  Int32 ->
+  NonceTtlSecs ->
   UserId ->
   Text ->
   Nonce ->
   m ()
 insertNonce ttl uid key nonce = retry x5 . write insert $ params LocalQuorum (uid, key, nonce, ttl)
   where
-    insert :: PrepQuery W (UserId, Text, Nonce, Int32) ()
+    insert :: PrepQuery W (UserId, Text, Nonce, NonceTtlSecs) ()
     insert = "INSERT INTO nonce (user, key, nonce) VALUES (?, ?, ?) USING TTL ?"
 
 lookupAndDeleteNonce ::

--- a/services/brig/src/Brig/Data/Nonce.hs
+++ b/services/brig/src/Brig/Data/Nonce.hs
@@ -43,7 +43,16 @@ lookupAndDeleteNonce ::
   (MonadClient m, MonadReader Env m) =>
   Text ->
   m (Maybe Nonce)
-lookupAndDeleteNonce = fmap undefined . deleteNonce
+lookupAndDeleteNonce key = lookupNonce key <* deleteNonce key
+
+lookupNonce ::
+  (MonadClient m, MonadReader Env m) =>
+  Text ->
+  m (Maybe Nonce)
+lookupNonce key = (runIdentity <$$>) . retry x5 . query1 get $ params LocalQuorum (Identity key)
+  where
+    get :: PrepQuery R (Identity Text) (Identity Nonce)
+    get = "SELECT nonce FROM nonce WHERE key = ?"
 
 deleteNonce ::
   (MonadClient m, MonadReader Env m) =>

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -38,6 +38,7 @@ import Data.Domain (Domain (..))
 import Data.Id
 import Data.LanguageCodes (ISO639_1 (EN))
 import Data.Misc (HttpsUrl)
+import Data.Nonce
 import Data.Range
 import Data.Schema
 import Data.Scientific (toBoundedInteger)
@@ -592,7 +593,7 @@ data Settings = Settings
     set2FACodeGenerationDelaySecsInternal :: !(Maybe Int),
     -- | The time-to-live of a nonce in seconds.
     -- use `setNonceTtlSecs` as the getter function which always provides a default value
-    setNonceTtlSecsInternal :: !(Maybe Int32)
+    setNonceTtlSecsInternal :: !(Maybe NonceTtlSecs)
   }
   deriving (Show, Generic)
 
@@ -620,10 +621,10 @@ def2FACodeGenerationDelaySecs = 5 * 60 -- 5 minutes
 set2FACodeGenerationDelaySecs :: Settings -> Int
 set2FACodeGenerationDelaySecs = fromMaybe def2FACodeGenerationDelaySecs . set2FACodeGenerationDelaySecsInternal
 
-defaultNonceTtlSecs :: Int32
-defaultNonceTtlSecs = 5 * 60 -- 5 minutes
+defaultNonceTtlSecs :: NonceTtlSecs
+defaultNonceTtlSecs = NonceTtlSecs $ 5 * 60 -- 5 minutes
 
-setNonceTtlSecs :: Settings -> Int32
+setNonceTtlSecs :: Settings -> NonceTtlSecs
 setNonceTtlSecs = fromMaybe defaultNonceTtlSecs . setNonceTtlSecsInternal
 
 -- | The analog to `GT.FeatureFlags`.  This type tracks only the things that we need to

--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -592,7 +592,7 @@ data Settings = Settings
     set2FACodeGenerationDelaySecsInternal :: !(Maybe Int),
     -- | The time-to-live of a nonce in seconds.
     -- use `setNonceTtlSecs` as the getter function which always provides a default value
-    setNonceTtlSecsInternal :: !(Maybe Word64)
+    setNonceTtlSecsInternal :: !(Maybe Int32)
   }
   deriving (Show, Generic)
 
@@ -620,10 +620,10 @@ def2FACodeGenerationDelaySecs = 5 * 60 -- 5 minutes
 set2FACodeGenerationDelaySecs :: Settings -> Int
 set2FACodeGenerationDelaySecs = fromMaybe def2FACodeGenerationDelaySecs . set2FACodeGenerationDelaySecsInternal
 
-defaultNonceTtlSecs :: Word64
+defaultNonceTtlSecs :: Int32
 defaultNonceTtlSecs = 5 * 60 -- 5 minutes
 
-setNonceTtlSecs :: Settings -> Word64
+setNonceTtlSecs :: Settings -> Int32
 setNonceTtlSecs = fromMaybe defaultNonceTtlSecs . setNonceTtlSecsInternal
 
 -- | The analog to `GT.FeatureFlags`.  This type tracks only the things that we need to

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -955,7 +955,9 @@ testNewNonce brig = do
   lift $ assertBool "nonces are should not be equal" (n1 /= n2)
   where
     check f status = do
-      response <- (randomUser brig >>= f brig . userId) <!! const status === statusCode
+      uid <- userId <$> randomUser brig
+      cid <- randomClient
+      response <- f brig uid cid <!! const status === statusCode
       let nonceBs = getHeader "Replay-Nonce" response
       liftIO $ do
         assertBool "Replay-Nonce header should contain a valid base64url encoded uuidv4" $ any isValidBase64UrlEncodedUUID nonceBs

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -556,6 +556,7 @@ getNonce ::
   (MonadIO m, MonadHttp m) =>
   Brig ->
   UserId ->
+  ClientId ->
   m ResponseLBS
 getNonce = nonce get
 
@@ -563,13 +564,14 @@ headNonce ::
   (MonadIO m, MonadHttp m) =>
   Brig ->
   UserId ->
+  ClientId ->
   m ResponseLBS
 headNonce = nonce Bilge.head
 
-nonce :: ((Request -> c) -> t) -> (Request -> c) -> UserId -> t
-nonce m brig uid =
+nonce :: ((Request -> c) -> t) -> (Request -> c) -> UserId -> ClientId -> t
+nonce m brig uid cid =
   m
     ( brig
-        . paths ["nonce", "clients"]
+        . paths ["clients", toByteString' cid, "nonce"]
         . zUser uid
     )


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-736 (the part where we need to change the way we store nonces)

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If HTTP endpoint paths have been added or renamed, check [docs/developer/adding-api-endpoints](https://github.com/wireapp/wire-server/blob/develop/docs/legacy/developer/adding-api-endpoints.md) and follow the steps there.
 - [x] If configuration options have been added or removed, check [docs/developer/adding-config-options](https://github.com/wireapp/wire-server/blob/develop/docs/legacy/developer/adding-config-options.md) and follow the steps there.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
- [x] I swear that if I have changed internal end-points, I do not implicitly rely on deployment ordering (brig needing to be deployed before galley), i.e. I have **not** introduced a new internal endpoint in brig and already make use of if in galley, as I'm aware old deployed galleys would throw 500s until all new version have been rolled out and I do not want a few minutes of downtime. Instead, I have thought how to merge brig an galley codebases.
 - [x] I updated **changelog.d** subsections with one or more entries with the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
