### PR TITLE
Make target audience explicit on docs.wire.com.

### DIFF
--- a/changelog.d/4-docs/tweak-docs-2
+++ b/changelog.d/4-docs/tweak-docs-2
@@ -1,0 +1,1 @@
+Make target audience explicit on docs.wire.com

--- a/docs/src/developer/index.rst
+++ b/docs/src/developer/index.rst
@@ -1,7 +1,7 @@
 Notes for developers
 ====================
 
-If you are a site operator, you may want to go back to `docs.wire.com <https://docs.wire.com/>`_ and ignore this section of the docs.
+If you are an on-premise operator (administrating your own self-hosted installation of wire-server), you may want to go back to `docs.wire.com <https://docs.wire.com/>`_ and ignore this section of the docs.
 
 If you are a wire end-user, please check out our `support pages <https://support.wire.com/>`_.
 

--- a/docs/src/developer/index.rst
+++ b/docs/src/developer/index.rst
@@ -1,6 +1,10 @@
 Notes for developers
 ====================
 
+If you are a site operator, you may want to go back to `docs.wire.com <https://docs.wire.com/>`_ and ignore this section of the docs.
+
+If you are a wire end-user, please check out our `support pages <https://support.wire.com/>`_.
+
 What you need to know as a user of the Wire backend: concepts, features,
 and API. We want to keep these up to date. They could benefit from some
 re-ordering, and they are far from complete, but we hope they will still

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Wire's (self-hosting) documentation!
+Welcome to Wire's documentation!
 ===============================================
 
 If you are a Wire end-user, please check out our `support pages <https://support.wire.com/>`_.

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -6,7 +6,7 @@
 Welcome to Wire's (self-hosting) documentation!
 ===============================================
 
-If you are a wire end-user, please check out our `support pages <https://support.wire.com/>`_.
+If you are a Wire end-user, please check out our `support pages <https://support.wire.com/>`_.
 
 The targeted audience of this documentation is:
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -11,7 +11,7 @@ If you are a Wire end-user, please check out our `support pages <https://support
 The targeted audience of this documentation is:
 
 * the curious power-user (people who want to understand how the server components of Wire work)
-* site operators (people who want to self-host Wire on their own datacentres or cloud)
+* on-premise operators/administrators (people who want to self-host Wire-Server on their own datacentres or cloud)
 * developers (people who are working with the wire-server source code)
 
 If you are a developer, you may want to check out the "Notes for developers" first.

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -6,10 +6,15 @@
 Welcome to Wire's (self-hosting) documentation!
 ===============================================
 
+If you are a wire end-user, please check out our `support pages <https://support.wire.com/>`_.
+
 The targeted audience of this documentation is:
 
-* people wanting to understand how the server components of Wire work
-* people wishing to self-host Wire on their own datacentres or cloud
+* the curious power-user (people who want to understand how the server components of Wire work)
+* site operators (people who want to self-host Wire on their own datacentres or cloud)
+* developers (people who are working with the wire-server source code)
+
+If you are a developer, you may want to check out the "Notes for developers" first.
 
 This documentation may be expanded in the future to cover other aspects of Wire.
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/BE-514

## Checklist

 - [x] The **PR Title** explains the impact of the change.
 - [x] The **PR description** provides context as to why the change should occur and what the code contributes to that effect. This could also be a link to a JIRA ticket or a Github issue, if there is one.
 - [x] If this PR changes development workflow or dependencies, they have been A) automated and B) documented under docs/developer/. All efforts have been taken to minimize development setup breakage or slowdown for co-workers.
 - [x] If HTTP endpoint paths have been added or renamed, check [docs/developer/adding-api-endpoints](https://github.com/wireapp/wire-server/blob/develop/docs/legacy/developer/adding-api-endpoints.md) and follow the steps there.
 - [x] If configuration options have been added or removed, check [docs/developer/adding-config-options](https://github.com/wireapp/wire-server/blob/develop/docs/legacy/developer/adding-config-options.md) and follow the steps there.
 - [x] If a cassandra schema migration has been added, I ran **`make git-add-cassandra-schema`** to update the cassandra schema documentation.
- [x] I swear that if I have changed internal end-points, I do not implicitly rely on deployment ordering (brig needing to be deployed before galley), i.e. I have **not** introduced a new internal endpoint in brig and already make use of if in galley, as I'm aware old deployed galleys would throw 500s until all new version have been rolled out and I do not want a few minutes of downtime. Instead, I have thought how to merge brig an galley codebases.
 - [x] I updated **changelog.d** subsections with one or more entries with the following bits of information ([details](https://github.com/wireapp/wire-server/blob/develop/docs/developer/changelog.md)):
   - [x] If a cassandra schema migration is backwards incompatible (see also [these docs](https://github.com/wireapp/wire-server/blob/develop/docs/developer/cassandra-interaction.md#cassandra-schema-migrations)), measures to be taken by on-premise instance operators are explained.
   - [x] If a data migration (not schema migration) introduced: measures to be taken by on-premise instance operators.
