### PR TITLE
Fix wire-server metrics-dashboards queries

### DIFF
--- a/charts/wire-server-metrics/dashboards/message-stats.json
+++ b/charts/wire-server-metrics/dashboards/message-stats.json
@@ -22,17 +22,13 @@
   "fiscalYearStartMonth": 0,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1637052673609,
+  "iteration": 1662376697254,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "collapsed": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -155,94 +151,72 @@
       }
     },
     {
+      "cards": {
+        "cardPadding": null,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
       "datasource": null,
       "description": "A client can fetch many prekeys with one API call, so the count here just represents how many calls are made to the API",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
         "y": 1
       },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
       "id": 34,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
+      "legend": {
+        "show": false
       },
+      "reverseYBuckets": false,
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(http_request_duration_seconds_count{namespace=\"$namespace\", handler=~\"/federation/claim-multi-prekey-bundle|/users/:uid/prekeys/:client|/users/:uid_domain/:uid/prekeys/:client|/users/:uid/prekeys|/users/:uid_domain/:uid/prekeys/users/prekys|/users/list-prekeys\"}[5m]))",
+          "expr": "sum(increase(http_request_duration_seconds_bucket{handler=\"/users/prekeys\"}[5m])) by (le)",
+          "format": "heatmap",
           "interval": "",
-          "legendFormat": "API Calls",
+          "intervalFactor": 10,
+          "legendFormat": "{{ le }}",
           "refId": "A"
         }
       ],
       "title": "Prekey fetch count",
-      "type": "timeseries"
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "short",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
     },
     {
       "collapsed": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -287,7 +261,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(http_request_duration_seconds_bucket{handler=~\"(/conversations/:cnv/otr/messages|/conversations/:cnv_domain/:cnv/proteus/messages|/federation/send-message)\", namespace=\"$namespace\"}[5m])) by (le)",
+          "expr": "sum(increase(http_request_duration_seconds_bucket{handler=\"/conversations/:cnv/otr/messages\"}[5m])) by (le)",
           "format": "heatmap",
           "instant": false,
           "interval": "",
@@ -298,7 +272,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Message sending latencies for local and remote conversations",
+      "title": "Message sending latencies",
       "tooltip": {
         "show": true,
         "showHistogram": false
@@ -529,7 +503,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(http_request_duration_seconds_count{role=\"galley\", handler=~\"(/conversations/:cnv/otr/messages|/conversations/:cnv_domain/:cnv/proteus/messages)\", status_code=~\"2..\", namespace=\"$namespace\"}[10m]))",
+          "expr": "sum(increase(http_request_duration_seconds_count{service=\"galley\", handler=\"/conversations/:cnv/otr/messages\", status_code=~\"2..\"}[10m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 5,
@@ -538,7 +512,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(increase(http_request_duration_seconds_count{role=\"galley\", handler=~\"(/conversations/:cnv/otr/messages|/conversations/:cnv_domain/:cnv/proteus/messages)\", status_code=~\"4..\", namespace=\"$namespace\"}[10m]))",
+          "expr": "sum(increase(http_request_duration_seconds_count{service=\"galley\", handler=\"/conversations/:cnv/otr/messages\", status_code=~\"400\"}[10m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -548,7 +522,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(increase(http_request_duration_seconds_count{role=\"galley\", handler=~\"(/conversations/:cnv/otr/messages|/conversations/:cnv_domain/:cnv/proteus/messages)\", status_code=~\"5..\", namespace=\"$namespace\"}[10m]))",
+          "expr": "sum(increase(http_request_duration_seconds_count{service=\"galley\", handler=\"/conversations/:cnv/otr/messages\", status_code=~\"5..\"}[10m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 5,
@@ -600,10 +574,6 @@
     {
       "collapsed": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -711,10 +681,6 @@
     {
       "collapsed": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -769,25 +735,37 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(http_request_duration_seconds_count{handler=\"/assets/v3\", status_code=\"201\", namespace=\"$namespace\"}[5m]))",
+          "exemplar": true,
+          "expr": "sum(increase(http_request_duration_seconds_count{service=\"cargohold\", handler=\"/assets/v3\", status_code=~\"2..\"}[10m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "uploaded/sec",
+          "legendFormat": "2XX",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(http_request_duration_seconds_count{handler=\"/assets/v3/:key\", status_code=\"302\", namespace=\"$namespace\"}[5m]))\n",
+          "exemplar": true,
+          "expr": "sum(increase(http_request_duration_seconds_count{service=\"cargohold\", handler=\"/assets/v3\", status_code=~\"4..\"}[10m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "downloaded/sec",
+          "legendFormat": "4XX",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(increase(http_request_duration_seconds_count{service=\"cargohold\", handler=\"/assets/v3\", status_code=~\"5..\"}[10m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "5XX",
+          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Assets",
+      "title": "Asset uploads as % by Status Code (cargohold)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -827,10 +805,6 @@
     {
       "collapsed": false,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1069,8 +1043,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(http_request_duration_seconds_count{role=\"gundeck\", handler=\"/i/push/v2\", namespace=\"$namespace\"}[5m])) by (status_code)",
+          "exemplar": true,
+          "expr": "sum(increase(http_request_duration_seconds_count{service=\"gundeck\", handler=\"/i/push/v2\"}[5m])) by (status_code)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{ status_code }}",
           "refId": "A"
@@ -1161,8 +1137,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(http_request_duration_seconds_count{handler=\"/i/push/v2\", namespace=\"$namespace\"}) by (status_code)",
+          "exemplar": true,
+          "expr": "sum(http_request_duration_seconds_count{service=\"gundeck\", handler=\"/i/push/v2\", namespace=\"$namespace\"}) by (status_code)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{ status_code }}",
           "refId": "A"
@@ -1219,8 +1197,8 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "wire-a",
-          "value": "wire-a"
+          "text": "default",
+          "value": "default"
         },
         "datasource": "Prometheus",
         "definition": "kube_namespace_labels",

--- a/charts/wire-server-metrics/dashboards/services.json
+++ b/charts/wire-server-metrics/dashboards/services.json
@@ -110,12 +110,12 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"5..\", namespace=\"$namespace\"}[5m])) by (role)",
+          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"5..\"}[5m])) by (service)",
           "format": "time_series",
           "instant": false,
           "interval": "",
           "intervalFactor": 5,
-          "legendFormat": "{{role}}",
+          "legendFormat": "{{service}}",
           "refId": "A"
         }
       ],
@@ -225,7 +225,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"5..\", namespace=\"$namespace\"}[$__range])) by (role, handler)",
+          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"5..\"}[$__range])) by (service, method, handler)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -306,7 +306,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"2..\", role=\"$service\", namespace=\"$namespace\"}[5m])) # Disabled because it's way too slow",
+          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"2..\", service=\"$service\"}[1m])) # Disabled because it's way too slow",
           "format": "time_series",
           "hide": true,
           "instant": false,
@@ -315,7 +315,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"4..\", role=\"$service\", namespace=\"$namespace\"}[5m]))",
+          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"4..\", service=\"$service\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -324,7 +324,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"5..\", role=\"$service\", namespace=\"$namespace\"}[5m]))",
+          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"5..\", service=\"$service\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -438,11 +438,11 @@
       ],
       "targets": [
         {
-          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"4..\", role=\"$service\", namespace=\"$namespace\"}[$__range])) by (handler)",
+          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"4..\", service=\"$service\"}[$__range])) by (handler)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
-          "legendFormat": "# 5XXs",
+          "legendFormat": "# 4XXs",
           "refId": "A"
         }
       ],
@@ -516,7 +516,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"5..\", role=\"$service\", namespace=\"$namespace\"}[$__range])) by (handler)",
+          "expr": "sum(increase(http_request_duration_seconds_count{status_code=~\"5..\", service=\"$service\"}[$__range])) by (handler)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -578,12 +578,12 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$service.*\", namespace=\"$namespace\"}[5m])) by (pod_name)",
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$service.*\", namespace=\"$namespace\"}[5m])) by (pod)",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{pod}}",
           "refId": "A",
           "step": 3600,
           "target": "alias(scale(scaleToSeconds(nonNegativeDerivative(sumSeries(gundeck.*.eu-west-1.compute.internal.interface.eth0.if_octets.rx)), 1), 0.001), 'kb/s - inbound')"
@@ -696,13 +696,13 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(container_cpu_load_average_10s{pod=~\"$service.*\", namespace=\"$namespace\"}) by (pod_name) * 100",
+          "expr": "sum(container_cpu_load_average_10s{pod=~\"$service.*\", namespace=\"$namespace\"}) by (pod) * 100",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "B",
           "step": 2400,
           "target": "alias(averageSeries(gundeck.*.eu-west-1.compute.internal.load.load.shortterm), 'load - shorterm')"
@@ -808,12 +808,12 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$service.*\", namespace=\"$namespace\"}) by (pod_name) / (1024 * 1024)",
+          "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$service.*\", namespace=\"$namespace\"}) by (pod) / (1024 * 1024)",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A",
           "step": 2400,
           "target": "alias(scale(averageSeries(gundeck.*.eu-west-1.compute.internal.memory.memory.used), 0.000001), 'used')"
@@ -904,7 +904,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(net_connections{role=\"$service\", namespace=\"$namespace\"})",
+          "expr": "net_connections{service=\"$service\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Inbound Connections",


### PR DESCRIPTION
Update the prometheus queries for the message-stats and services dashboard in wire-server-metrics

Some of the metrics were not working, replaced them with the one used in the staging/prod grafana metrics.