### PR TITLE
wire-server helm chart: Adjust default CPU/Memory

### DIFF
--- a/changelog.d/0-release-notes/helm-chart-default-resources
+++ b/changelog.d/0-release-notes/helm-chart-default-resources
@@ -1,0 +1,1 @@
+wire-server helm charts: Adjust default CPU/Memory resources: Remove CPU limits to avoid CPU throttling; adjust request CPU and memory based on observed values. Overall this decreases the amount of CPU/memory that the wire-server chart needs to install/schedule pods.

--- a/charts/backoffice/values.yaml
+++ b/charts/backoffice/values.yaml
@@ -13,11 +13,10 @@ service:
   externalPort: 8080
 resources:
   requests:
-    memory: 128Mi
-    cpu: 125m
+    memory: 20Mi
+    cpu: 30m
   limits:
-    memory: 512Mi
-    cpu: 500m
+    memory: 50Mi
 config:
   logLevel: Info
   galebHost: galeb.integrations

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -7,11 +7,10 @@ service:
   internalPort: 8080
 resources:
   requests:
-    memory: "256Mi"
+    memory: "200Mi"
     cpu: "100m"
   limits:
     memory: "512Mi"
-    cpu: "500m"
 metrics:
   serviceMonitor:
     enable: false

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -84,8 +84,7 @@ resources:
     memory: "256Mi"
     cpu: "100m"
   limits:
-    memory: "512Mi"
-    cpu: "500m"
+    memory: "1024Mi"
 service:
   name: cannon
   internalPort: 8080

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -10,11 +10,10 @@ metrics:
     enable: false
 resources:
   requests:
-    memory: "256Mi"
+    memory: "80Mi"
     cpu: "100m"
   limits:
-    memory: "512Mi"
-    cpu: "500m"
+    memory: "200Mi"
 config:
   logLevel: Info
   logFormat: StructuredJSON

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -11,11 +11,10 @@ metrics:
     enable: false
 resources:
   requests:
-    memory: "256Mi"
+    memory: "100Mi"
     cpu: "100m"
   limits:
-    memory: "512Mi"
-    cpu: "500m"
+    memory: "200Mi"
 config:
   logLevel: Info
   logFormat: StructuredJSON

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -10,11 +10,10 @@ metrics:
     enable: false
 resources:
   requests:
-    memory: "256Mi"
+    memory: "300Mi"
     cpu: "100m"
   limits:
-    memory: "512Mi"
-    cpu: "500m"
+    memory: "1Gi"
 config:
   logLevel: Info
   logFormat: StructuredJSON

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -4,8 +4,7 @@ resources:
     memory: "256Mi"
     cpu: "100m"
   limits:
-    memory: "1024Mi"
-    cpu: "2"
+    memory: "800Mi"
 metrics:
   serviceMonitor:
     enabled: false

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -10,11 +10,10 @@ metrics:
     enable: false
 resources:
   requests:
-    memory: "128Mi"
-    cpu: "100m"
+    memory: "25Mi"
+    cpu: "50m"
   limits:
-    memory: "512Mi"
-    cpu: "500m"
+    memory: "50Mi"
 config:
   logLevel: Info
   logFormat: StructuredJSON

--- a/charts/spar/values.yaml
+++ b/charts/spar/values.yaml
@@ -7,11 +7,10 @@ metrics:
     enable: false
 resources:
   requests:
-    memory: "128Mi"
-    cpu: "100m"
+    memory: "25Mi"
+    cpu: "50m"
   limits:
-    memory: "512Mi"
-    cpu: "500m"
+    memory: "50Mi"
 service:
   externalPort: 8080
   internalPort: 8080


### PR DESCRIPTION
Related to https://wearezeta.atlassian.net/browse/SQPIT-1347

* Remove CPU limits to avoid CPU throttling
* adjust request CPU and memory based on observed values

Overall this decreases the amount of CPU/memory that the wire-server chart needs to install/schedule pods.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
