### PR TITLE
removed/replaced todo comments

### DIFF
--- a/libs/wire-api/src/Wire/API/Routes/Public/Spar.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Spar.hs
@@ -107,13 +107,15 @@ type IdpCreate =
   ReqBodyCustomError '[RawXML, JSON] "wai-error" IdPMetadataInfo
     :> QueryParam' '[Optional, Strict] "replaces" SAML.IdPId
     :> QueryParam' '[Optional, Strict] "api_version" WireIdPAPIVersion
-    :> QueryParam' '[Optional, Strict] "handle" (Range 1 32 Text) -- todo(leif): check length limitation
+    -- FUTUREWORK: The handle is restricted to 32 characters. Can we find a more reasonable upper bound and create a type for it? Also see `IdpUpdate`.
+    :> QueryParam' '[Optional, Strict] "handle" (Range 1 32 Text)
     :> PostCreated '[JSON] IdP
 
 type IdpUpdate =
   ReqBodyCustomError '[RawXML, JSON] "wai-error" IdPMetadataInfo
     :> Capture "id" SAML.IdPId
-    :> QueryParam' '[Optional, Strict] "handle" (Range 1 32 Text) -- todo(leif): check length limitation
+    -- FUTUREWORK: The handle is restricted to 32 characters. Can we find a more reasonable upper bound and create a type for it? Also see `IdpCreate`.
+    :> QueryParam' '[Optional, Strict] "handle" (Range 1 32 Text)
     :> Put '[JSON] IdP
 
 type IdpDelete =

--- a/services/spar/src/Spar/Sem/IdPConfigStore/Mem.hs
+++ b/services/spar/src/Spar/Sem/IdPConfigStore/Mem.hs
@@ -46,7 +46,9 @@ idPToMem = evState . evEff
     evEff = reinterpret @_ @(State TypedState) $ \case
       InsertConfig iw ->
         modify' (insertConfig iw)
-      NewHandle _tid -> pure $ IdPHandle "IdP 1" --todo(leif): generate a new handle
+      NewHandle _tid ->
+        -- Same handle for all IdPs is good enough, for now
+        pure $ IdPHandle "IdP 1"
       GetConfig i ->
         gets (getConfig i)
       GetIdPByIssuerV1Maybe issuer ->


### PR DESCRIPTION
Replaced some "todo" comments with something more meaningful.

No changelog necessary, IMO.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
