### PR TITLE
Update to mls-test-cli 0.5

### DIFF
--- a/changelog.d/5-internal/mls-test-cli-0.5
+++ b/changelog.d/5-internal/mls-test-cli-0.5
@@ -1,0 +1,1 @@
+Update mls-test-cli to version 0.5

--- a/nix/pkgs/mls_test_cli/default.nix
+++ b/nix/pkgs/mls_test_cli/default.nix
@@ -15,11 +15,11 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "wireapp";
     repo = "mls-test-cli";
-    sha256 = "sha256-6G01eONZb/61MrO/Py+ix7Psz+jl+3Cn7xUMez3osxw=";
-    rev = "d01258a290546a01a62dca21ba3d0e3863a288b4";
+    sha256 = "sha256-nBtXkxGstSqBEhzjcRd0RG2hv0WFgTqy1z29W2sf27U=";
+    rev = "560186482d201fe0f6194d620dba2b623fdd7f6f";
   };
   doCheck = false;
-  cargoSha256 = "sha256-frzVXP0lxXhPhfNL4zleHj2WSMwmQfCdTqkTbHXBFEI=";
+  cargoSha256 = "sha256-3zUGEowQREPKsfpH2y9C7BeeTTF3zat4Qfpw74fOCHQ=";
   cargoDepsHook = ''
     mkdir -p mls-test-cli-${version}-vendor.tar.gz/ring/.git
   '';


### PR DESCRIPTION
Update mls-test-cli to version 0.5.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
