### PR TITLE
[FS-736] Add rusty-jwt-tools dependency to docker deps and builder

### DIFF
--- a/build/ubuntu/Dockerfile.builder
+++ b/build/ubuntu/Dockerfile.builder
@@ -10,9 +10,22 @@ RUN cd /tmp && \
 
 RUN cd /tmp/mls-test-cli && RUSTFLAGS='-C target-feature=+crt-static' cargo build --release --target x86_64-unknown-linux-gnu
 
+FROM rust:1.63 as rusty-jwt-tools-builder
+
+# compile rusty-jwt-tools
+RUN cd /tmp && \
+    git clone https://github.com/wireapp/rusty-jwt-tools && \
+    cd rusty-jwt-tools && \
+    git checkout 6370cd556f03f6834d0b8043615ffaf0044ef1fa && \
+    git rev-parse HEAD
+
+RUN cd /tmp/rusty-jwt-tools && cargo build --release --target x86_64-unknown-linux-gnu
+
 FROM ${prebuilder}
 
 COPY --from=mls-test-cli-builder /tmp/mls-test-cli/target/x86_64-unknown-linux-gnu/release/mls-test-cli /usr/bin/mls-test-cli
+COPY --from=rusty-jwt-tools-builder /tmp/rusty-jwt-tools/target/x86_64-unknown-linux-gnu/release/librusty_jwt_tools.so /usr/lib
+COPY --from=rusty-jwt-tools-builder /tmp/rusty-jwt-tools/target/x86_64-unknown-linux-gnu/release/librusty_jwt_tools_ffi.so /usr/lib
 
 WORKDIR /
 

--- a/build/ubuntu/Dockerfile.deps
+++ b/build/ubuntu/Dockerfile.deps
@@ -20,11 +20,25 @@ RUN cd /tmp && \
 
 RUN cd /tmp/mls-test-cli && RUSTFLAGS='-C target-feature=+crt-static' cargo build --release --target x86_64-unknown-linux-gnu
 
+FROM rust:1.63 as rusty-jwt-tools-builder
+
+# compile rusty-jwt-tools
+RUN cd /tmp && \
+    git clone https://github.com/wireapp/rusty-jwt-tools && \
+    cd rusty-jwt-tools && \
+    git checkout 6370cd556f03f6834d0b8043615ffaf0044ef1fa && \
+    git rev-parse HEAD
+
+RUN cd /tmp/rusty-jwt-tools && cargo build --release --target x86_64-unknown-linux-gnu
+
+
 # Minimal dependencies for ubuntu-compiled, dynamically linked wire-server Haskell services
 FROM ubuntu:20.04
 
 COPY --from=cryptobox-builder /tmp/cryptobox-c/target/release/libcryptobox.so /usr/lib
 COPY --from=mls-test-cli-builder /tmp/mls-test-cli/target/x86_64-unknown-linux-gnu/release/mls-test-cli /usr/bin/mls-test-cli
+COPY --from=rusty-jwt-tools-builder /tmp/rusty-jwt-tools/target/x86_64-unknown-linux-gnu/release/librusty_jwt_tools.so /usr/lib
+COPY --from=rusty-jwt-tools-builder /tmp/rusty-jwt-tools/target/x86_64-unknown-linux-gnu/release/librusty_jwt_tools_ffi.so /usr/lib
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \

--- a/changelog.d/5-internal/pr-2686
+++ b/changelog.d/5-internal/pr-2686
@@ -1,0 +1,1 @@
+Added rusty-jwt-tools to docker images


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
