### PR TITLE
Added hlint pr check makefile cmd.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,15 @@ ghcid:
 hlint-check-all:
 	./tools/hlint.sh -f all -m check
 
+.PHONY: hlint-check-pr
+hlint-check-pr:
+	./tools/hlint.sh -f pr -m check
+
+.PHONY: hlint-inplace-pr
+hlint-inplace-pr:
+	./tools/hlint.sh -f pr -m inplace
+
+
 .PHONY: hlint-inplace-all
 hlint-inplace-all:
 	./tools/hlint.sh -f all -m inplace

--- a/tools/hlint.sh
+++ b/tools/hlint.sh
@@ -13,7 +13,7 @@ while getopts ':f:m:' opt
               files=$(find libs/ services/ -not -path "*/test/*" -name "*.hs")
               echo "WARNING: not linting tests."
             elif [ "$f" = "pr" ]; then
-              files=$(git diff --name-only develop | grep \.hs\$)
+              files=$(git diff --name-only origin/develop... | grep \.hs\$)
               echo "WARNING: linting test files with changes. This may lead to some hard to fix warnings/errors, it is safe to ignore those!"
             elif [ "$f" = "changeset" ]; then
               files=$(git diff --name-only HEAD | grep \.hs\$)

--- a/tools/hlint.sh
+++ b/tools/hlint.sh
@@ -12,6 +12,9 @@ while getopts ':f:m:' opt
             if [ "$f" = "all" ]; then
               files=$(find libs/ services/ -not -path "*/test/*" -name "*.hs")
               echo "WARNING: not linting tests."
+            elif [ "$f" = "pr" ]; then
+              files=$(git diff --name-only develop | grep \.hs\$)
+              echo "WARNING: linting test files with changes. This may lead to some hard to fix warnings/errors, it is safe to ignore those!"
             elif [ "$f" = "changeset" ]; then
               files=$(git diff --name-only HEAD | grep \.hs\$)
               echo "WARNING: linting test files with changes. This may lead to some hard to fix warnings/errors, it is safe to ignore those!"


### PR DESCRIPTION
Sometimes we create smaller commits during the course of work, and don't remember or take the time to wait for the linter between those steps. Sometimes it's useful / helpful to be able to run hlint over all haskell files touched by a PR as a last ste, or as a CI step.