### PR TITLE
Allow add proposal commits by non-admins

### DIFF
--- a/changelog.d/2-features/non-admin-commits
+++ b/changelog.d/2-features/non-admin-commits
@@ -1,0 +1,1 @@
+Allow non-admins to commit add proposals in MLS conversations

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1232,8 +1232,8 @@ testExternalAddProposal = do
       createAddCommit alice1 [bob]
         >>= sendAndConsumeCommit
 
-    bob2 <- createMLSClient bob
     -- bob joins with an external proposal
+    bob2 <- createMLSClient bob
     mlsBracket [alice1, bob1] $ \wss -> do
       void $
         createExternalAddProposal bob2
@@ -1254,6 +1254,16 @@ testExternalAddProposal = do
         liftTest $
           WS.assertMatchN_ (5 # Second) wss $
             wsAssertMLSMessage qcnv alice (mpMessage msg)
+
+    -- bob adds charlie
+    putOtherMemberQualified
+      (qUnqualified alice)
+      bob
+      (OtherMemberUpdate (Just roleNameWireAdmin))
+      qcnv
+      !!! const 200 === statusCode
+    createAddCommit bob2 [charlie]
+      >>= sendAndConsumeCommit
 
 testExternalAddProposalNonAdminCommit :: TestM ()
 testExternalAddProposalNonAdminCommit = do

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
@@ -16,7 +17,6 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
-{-# OPTIONS_GHC -Wwarn #-}
 
 module API.MLS (tests) where
 
@@ -140,6 +140,7 @@ tests s =
       testGroup
         "External Add Proposal"
         [ test s "member adds new client" testExternalAddProposal,
+          test s "non-admin commits external add proposal" testExternalAddProposalNonAdminCommit,
           test s "non-member adds new client" testExternalAddProposalWrongUser,
           test s "member adds unknown new client" testExternalAddProposalWrongClient
         ],
@@ -1208,8 +1209,54 @@ propInvalidEpoch = do
 -- alice1 creates a group and adds bob1
 -- bob2 joins with external proposal (alice1 commits it)
 -- bob2 adds charlie1
+-- alice1 sends a message
 testExternalAddProposal :: TestM ()
 testExternalAddProposal = do
+  -- create users
+  [alice, bob, charlie] <-
+    createAndConnectUsers (replicate 3 Nothing)
+
+  void . runMLSTest $ do
+    -- create clients
+    alice1 <- createMLSClient alice
+    bob1 <- createMLSClient bob
+    charlie1 <- createMLSClient charlie
+
+    -- upload key packages
+    void $ uploadNewKeyPackage bob1
+    void $ uploadNewKeyPackage charlie1
+
+    -- create group with alice1 and bob1
+    (_, qcnv) <- setupMLSGroup alice1
+    void $
+      createAddCommit alice1 [bob]
+        >>= sendAndConsumeCommit
+
+    bob2 <- createMLSClient bob
+    -- bob joins with an external proposal
+    mlsBracket [alice1, bob1] $ \wss -> do
+      void $
+        createExternalAddProposal bob2
+          >>= sendAndConsumeMessage
+      liftTest $
+        WS.assertMatchN_ (5 # Second) wss $
+          void . wsAssertAddProposal bob qcnv
+
+    void $
+      createPendingProposalCommit alice1
+        >>= sendAndConsumeCommit
+
+    -- alice sends a message
+    do
+      msg <- createApplicationMessage alice1 "hi bob"
+      mlsBracket [bob1, bob2] $ \wss -> do
+        void $ sendAndConsumeMessage msg
+        liftTest $
+          WS.assertMatchN_ (5 # Second) wss $
+            wsAssertMLSMessage qcnv alice (mpMessage msg)
+
+testExternalAddProposalNonAdminCommit :: TestM ()
+testExternalAddProposalNonAdminCommit = do
   -- create users
   [alice, bob, charlie] <-
     createAndConnectUsers (replicate 3 Nothing)
@@ -1238,19 +1285,14 @@ testExternalAddProposal = do
       liftTest $
         WS.assertMatchN_ (5 # Second) wss $
           void . wsAssertAddProposal bob qcnv
+
+    -- bob1 commits
     void $
-      createPendingProposalCommit alice1
+      createPendingProposalCommit bob1
         >>= sendAndConsumeCommit
 
-    -- bob adds charlie
-    putOtherMemberQualified
-      (qUnqualified alice)
-      bob
-      (OtherMemberUpdate (Just roleNameWireAdmin))
-      qcnv
-      !!! const 200 === statusCode
-    createAddCommit bob2 [charlie]
-      >>= sendAndConsumeCommit
+-- bob adds charlie
+-- void $ createAddCommit bob2 [charlie] >>= sendAndConsumeCommit
 
 -- scenario:
 -- alice adds bob and charlie

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1301,9 +1301,6 @@ testExternalAddProposalNonAdminCommit = do
       createPendingProposalCommit bob1
         >>= sendAndConsumeCommit
 
--- bob adds charlie
--- void $ createAddCommit bob2 [charlie] >>= sendAndConsumeCommit
-
 -- scenario:
 -- alice adds bob and charlie
 -- charlie sends an external proposal for bob


### PR DESCRIPTION
- Allow non-admins to commit add proposals
- Test non-admin commit for client deletion

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
