### PR TITLE
[FS-937] Validate Remotely Claimed Key Packages

### DIFF
--- a/changelog.d/1-api-changes/validate-remotely-claimed-key-packages
+++ b/changelog.d/1-api-changes/validate-remotely-claimed-key-packages
@@ -1,0 +1,1 @@
+Validate remotely claimed key packages

--- a/libs/wire-api/src/Wire/API/Error/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Error/Brig.hs
@@ -64,6 +64,8 @@ data BrigError
   | PasswordAuthenticationFailed
   | TooManyTeamInvitations
   | InsufficientTeamPermissions
+  | KeyPackageDecodingError
+  | InvalidKeyPackageRef
 
 instance KnownError (MapError e) => IsSwaggerError (e :: BrigError) where
   addToSwagger = addStaticErrorToSwagger @(MapError e)
@@ -172,3 +174,7 @@ type instance MapError 'PasswordAuthenticationFailed = 'StaticError 403 "passwor
 type instance MapError 'TooManyTeamInvitations = 'StaticError 403 "too-many-team-invitations" "Too many team invitations for this team"
 
 type instance MapError 'InsufficientTeamPermissions = 'StaticError 403 "insufficient-permissions" "Insufficient team permissions"
+
+type instance MapError 'KeyPackageDecodingError = 'StaticError 409 "decoding-error" "Key package could not be TLS-decoded"
+
+type instance MapError 'InvalidKeyPackageRef = 'StaticError 409 "invalid-reference" "Key package's reference does not match its data"

--- a/libs/wire-api/src/Wire/API/MLS/Credential.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Credential.hs
@@ -139,8 +139,16 @@ data ClientIdentity = ClientIdentity
     ciUser :: UserId,
     ciClient :: ClientId
   }
-  deriving stock (Eq, Ord, Show, Generic)
+  deriving stock (Eq, Ord, Generic)
   deriving (FromJSON, ToJSON, S.ToSchema) via Schema ClientIdentity
+
+instance Show ClientIdentity where
+  show (ClientIdentity dom u c) =
+    show u
+      <> ":"
+      <> T.unpack (client c)
+      <> "@"
+      <> T.unpack (domainText dom)
 
 cidQualifiedClient :: ClientIdentity -> Qualified (UserId, ClientId)
 cidQualifiedClient cid = Qualified (ciUser cid, ciClient cid) (ciDomain cid)

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -182,6 +182,8 @@ clientDataError (ClientReAuthError e) = reauthError e
 clientDataError ClientMissingAuth = StdError (errorToWai @'E.MissingAuth)
 clientDataError MalformedPrekeys = StdError (errorToWai @'E.MalformedPrekeys)
 clientDataError MLSPublicKeyDuplicate = StdError (errorToWai @'E.MLSDuplicatePublicKey)
+clientDataError KeyPackageDecodingError = StdError (errorToWai @'E.KeyPackageDecodingError)
+clientDataError InvalidKeyPackageRef = StdError (errorToWai @'E.InvalidKeyPackageRef)
 
 deleteUserError :: DeleteUserError -> Error
 deleteUserError DeleteUserInvalid = StdError (errorToWai @'E.InvalidUser)

--- a/services/brig/src/Brig/Data/Client.hs
+++ b/services/brig/src/Brig/Data/Client.hs
@@ -97,6 +97,8 @@ data ClientDataError
   | ClientMissingAuth
   | MalformedPrekeys
   | MLSPublicKeyDuplicate
+  | KeyPackageDecodingError
+  | InvalidKeyPackageRef
 
 -- | Re-authentication policy.
 --

--- a/services/brig/test/integration/API/MLS/Util.hs
+++ b/services/brig/test/integration/API/MLS/Util.hs
@@ -23,12 +23,10 @@ import Bilge.Assert
 import Data.Aeson (object, toJSON, (.=))
 import Data.ByteString.Conversion
 import Data.Default
-import Data.Domain
 import Data.Id
 import Data.Json.Util
 import qualified Data.Map as Map
 import Data.Qualified
-import qualified Data.Text as T
 import Data.Timeout
 import Imports
 import System.FilePath
@@ -59,15 +57,10 @@ uploadKeyPackages ::
   Int ->
   Http ()
 uploadKeyPackages brig tmp KeyingInfo {..} u c n = do
-  let cmd0 = ["mls-test-cli", "--store", tmp </> (clientId <> ".db")]
-      clientId =
-        show (qUnqualified u)
-          <> ":"
-          <> T.unpack (client c)
-          <> "@"
-          <> T.unpack (domainText (qDomain u))
+  let cmd0 = ["mls-test-cli", "--store", tmp </> (show cid <> ".db")]
+      cid = mkClientIdentity u c
   void . liftIO . flip spawn Nothing . shell . unwords $
-    cmd0 <> ["init", clientId]
+    cmd0 <> ["init", show cid]
   kps <-
     replicateM n . liftIO . flip spawn Nothing . shell . unwords $
       cmd0


### PR DESCRIPTION
The PR validates remotely claimed key packages. Such packages go through the same kind of validation as locally claimed packages, though for local ones the validation happens upon uploading to the local backend.

Tracked by https://wearezeta.atlassian.net/browse/FS-937.

**Note**: An old Git branch to ignore is similarly named: [`fs-937/remote-claimed-kps`](https://github.com/wireapp/wire-server/tree/fs-937/remote-claimed-kps).

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
