### PR TITLE
[FS-917] Added an optional sender (ClientId) to MLS message events.

### DIFF
--- a/changelog.d/1-api-changes/fs-9127-added-sender-id-to-payload
+++ b/changelog.d/1-api-changes/fs-9127-added-sender-id-to-payload
@@ -1,0 +1,1 @@
+Modified the payload for MLSMessages to include a sender Id (client Id) when available. This is a breaking change for the clients.

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -321,6 +321,9 @@ data AddCodeResult
 
 data MLSMessage = MLSMessage
   { mlsData :: ByteString,
+    -- | ClientId isn't always present or knowable.
+    -- | External proposals have no clientIds, and
+    -- | Application messages, being encrypted, can't be inspected
     mlsSenderId :: Maybe ClientId
   }
   deriving stock (Eq, Show, Generic)

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
@@ -285,7 +285,7 @@ testObject_Event_user_15 =
     (Qualified (Id (fromJust (UUID.fromString "7cd50991-3cdd-40ec-bb0f-63ae17b2309d"))) (Domain "faraway.example.com"))
     (Qualified (Id (fromJust (UUID.fromString "04e68c50-027e-4e84-a33a-e2e28a7b8ea3"))) (Domain "faraway.example.com"))
     (read "2021-11-10 05:39:44.297 UTC")
-    (EdMLSMessage $ MLSMessage { mlsData = "hello world", mlsSenderId = Nothing })
+    (EdMLSMessage $ MLSMessage {mlsData = "hello world", mlsSenderId = Nothing})
 
 testObject_Event_user_16 :: Event
 testObject_Event_user_16 =

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
@@ -285,7 +285,7 @@ testObject_Event_user_15 =
     (Qualified (Id (fromJust (UUID.fromString "7cd50991-3cdd-40ec-bb0f-63ae17b2309d"))) (Domain "faraway.example.com"))
     (Qualified (Id (fromJust (UUID.fromString "04e68c50-027e-4e84-a33a-e2e28a7b8ea3"))) (Domain "faraway.example.com"))
     (read "2021-11-10 05:39:44.297 UTC")
-    (EdMLSMessage "hello world")
+    (EdMLSMessage $ MLSMessage { mlsData = "hello world", mlsSenderId = Nothing })
 
 testObject_Event_user_16 :: Event
 testObject_Event_user_16 =

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -921,7 +921,7 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
         evtConv e @?= qconvId
         evtType e @?= MLSMessageAdd
         evtFrom e @?= userQualifiedId bob
-        evtData e @?= EdMLSMessage (MLSMessage dove Nothing) -- TODO: add real data
+        evtData e @?= EdMLSMessage (MLSMessage dove (Just aliceClient))
 
     -- send the reply and assert reception
     WS.bracketR cannon2 (userId bob) $ \wsBob -> do
@@ -944,4 +944,4 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
         evtConv e @?= qconvId
         evtType e @?= MLSMessageAdd
         evtFrom e @?= userQualifiedId alice
-        evtData e @?= EdMLSMessage (MLSMessage reply Nothing) -- TODO: add real data
+        evtData e @?= EdMLSMessage (MLSMessage reply (Just aliceClient))

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -921,7 +921,7 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
         evtConv e @?= qconvId
         evtType e @?= MLSMessageAdd
         evtFrom e @?= userQualifiedId bob
-        evtData e @?= EdMLSMessage dove
+        evtData e @?= EdMLSMessage (MLSMessage dove Nothing) -- TODO: add real data
 
     -- send the reply and assert reception
     WS.bracketR cannon2 (userId bob) $ \wsBob -> do
@@ -944,4 +944,4 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
         evtConv e @?= qconvId
         evtType e @?= MLSMessageAdd
         evtFrom e @?= userQualifiedId alice
-        evtData e @?= EdMLSMessage reply
+        evtData e @?= EdMLSMessage (MLSMessage reply Nothing) -- TODO: add real data

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -14,7 +14,6 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
-{-# LANGUAGE RecordWildCards #-}
 
 module Galley.API.MLS.Message
   ( postMLSMessageFromLocalUser,
@@ -803,8 +802,7 @@ executeProposalAction qusr con lconv cm action = do
 
     existingLocalMembers :: Set (Qualified UserId)
     existingLocalMembers =
-      Set.fromList . map (fmap lmId . qUntagged) . sequenceA $
-        fmap convLocalMembers lconv
+      (Set.fromList . map (fmap lmId . qUntagged)) (traverse convLocalMembers lconv)
 
     existingRemoteMembers :: Set (Qualified UserId)
     existingRemoteMembers =

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -292,7 +292,7 @@ postMLSMessageToLocalConv qusr senderClient con smsg lcnv = case rmValue smsg of
         Left _ -> throwS @'MLSUnsupportedMessage
 
     -- forward message
-    propagateMessage qusr lconv cm con (rmRaw smsg)
+    propagateMessage qusr senderClient lconv cm con (rmRaw smsg)
 
     pure events
 

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -45,6 +45,11 @@ import Wire.API.Federation.Error
 import Wire.API.Message
 
 -- | Propagate a message.
+-- |
+-- | ClientId is a Maybe here, because for certain cases (including application messages)
+-- | the client is either inexistent or unknowable. External proposals would have no client ids
+-- | and application messages, being encrypted, cannot be inspected, and therefore we're not aware of
+-- | a client id for them.
 propagateMessage ::
   ( Member ExternalAccess r,
     Member FederatorAccess r,

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -75,7 +75,7 @@ propagateMessage qusr senderClient lconv cm con raw = do
   now <- input @UTCTime
   let lcnv = fmap Data.convId lconv
       qcnv = qUntagged lcnv
-      e = Event qcnv qusr now $ EdMLSMessage (MLSMessage { mlsData = raw, mlsSenderId = senderClient })
+      e = Event qcnv qusr now $ EdMLSMessage (MLSMessage {mlsData = raw, mlsSenderId = senderClient})
       mkPush :: UserId -> ClientId -> MessagePush 'NormalMessage
       mkPush u c = newMessagePush lcnv botMap con mm (u, c) e
   runMessagePush lconv (Just qcnv) $

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -55,12 +55,13 @@ propagateMessage ::
     Member TinyLog r
   ) =>
   Qualified UserId ->
+  Maybe ClientId ->
   Local Data.Conversation ->
   ClientMap ->
   Maybe ConnId ->
   ByteString ->
   Sem r ()
-propagateMessage qusr lconv cm con raw = do
+propagateMessage qusr senderClient lconv cm con raw = do
   -- FUTUREWORK: check the epoch
   let lmems = Data.convLocalMembers . tUnqualified $ lconv
       botMap = Map.fromList $ do
@@ -71,7 +72,7 @@ propagateMessage qusr lconv cm con raw = do
   now <- input @UTCTime
   let lcnv = fmap Data.convId lconv
       qcnv = qUntagged lcnv
-      e = Event qcnv qusr now $ EdMLSMessage raw
+      e = Event qcnv qusr now $ EdMLSMessage (MLSMessage { mlsData = raw, mlsSenderId = senderClient })
       mkPush :: UserId -> ClientId -> MessagePush 'NormalMessage
       mkPush u c = newMessagePush lcnv botMap con mm (u, c) e
   runMessagePush lconv (Just qcnv) $

--- a/services/galley/src/Galley/API/MLS/Removal.hs
+++ b/services/galley/src/Galley/API/MLS/Removal.hs
@@ -76,7 +76,7 @@ removeClientsWithClientMap lc cs cm qusr = do
     ProtocolMLS meta -> do
       keyPair <- mlsKeyPair_ed25519 <$> (inputs (view mlsKeys) <*> pure RemovalPurpose)
       (secKey, pubKey) <- note (InternalErrorWithDescription "backend removal key missing") $ keyPair
-      for_ cs $ \(_client, kpref) -> do
+      for_ cs $ \(client, kpref) -> do
         let proposal = mkRemoveProposal kpref
             msg = mkSignedMessage secKey pubKey (cnvmlsGroupId meta) (cnvmlsEpoch meta) (ProposalMessage proposal)
             msgEncoded = encodeMLS' msg
@@ -85,7 +85,7 @@ removeClientsWithClientMap lc cs cm qusr = do
           (cnvmlsEpoch meta)
           (proposalRef (cnvmlsCipherSuite meta) proposal)
           proposal
-        propagateMessage qusr lc cm Nothing msgEncoded
+        propagateMessage qusr (Just client) lc cm Nothing msgEncoded
 
 -- | Send remove proposals for a single client of a user to the local conversation.
 removeClient ::

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 -- This file is part of the Wire Server implementation.
@@ -906,7 +905,7 @@ testAppMessage = do
       liftIO $ events @?= []
       liftIO $
         WS.assertMatchN_ (5 # WS.Second) wss $
-        wsAssertMLSMessage qcnv alice (Just . ciClient $ alice1) (mpMessage message)
+        wsAssertMLSMessage qcnv alice Nothing (mpMessage message)
 
 testAppMessage2 :: TestM ()
 testAppMessage2 = do
@@ -937,7 +936,7 @@ testAppMessage2 = do
 
       liftIO $
         WS.assertMatchN_ (5 # WS.Second) wss $
-          wsAssertMLSMessage conversation bob (Just . ciClient $ bob1) (mpMessage message)
+          wsAssertMLSMessage conversation bob Nothing (mpMessage message)
 
 testRemoteToRemote :: TestM ()
 testRemoteToRemote = do
@@ -1050,7 +1049,7 @@ testRemoteToLocal = do
       liftIO $ do
         resp @?= MLSMessageResponseUpdates []
         WS.assertMatch_ (5 # Second) ws $
-          wsAssertMLSMessage qcnv bob (Just . ciClient $ bob1) (mpMessage message)
+          wsAssertMLSMessage qcnv bob Nothing (mpMessage message)
 
 testRemoteToLocalWrongConversation :: TestM ()
 testRemoteToLocalWrongConversation = do
@@ -1253,7 +1252,9 @@ testExternalAddProposal = do
         void $ sendAndConsumeMessage msg
         liftTest $
           WS.assertMatchN_ (5 # Second) wss $
-            wsAssertMLSMessage qcnv alice (Just . ciClient $ alice1) (mpMessage msg)
+            -- We use Nothing here for the client id, because applications messages
+            -- are encrypted, therefore we cannot inspect it and match on the client id.
+            wsAssertMLSMessage qcnv alice Nothing (mpMessage msg)
 
     -- bob adds charlie
     putOtherMemberQualified

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -905,7 +905,7 @@ testAppMessage = do
       liftIO $ events @?= []
       liftIO $
         WS.assertMatchN_ (5 # WS.Second) wss $
-        wsAssertMLSMessage qcnv alice Nothing (mpMessage message)
+          wsAssertMLSMessage qcnv alice Nothing (mpMessage message)
 
 testAppMessage2 :: TestM ()
 testAppMessage2 = do

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -906,7 +906,7 @@ testAppMessage = do
       liftIO $ events @?= []
       liftIO $
         WS.assertMatchN_ (5 # WS.Second) wss $
-          wsAssertMLSMessage qcnv alice (mpMessage message)
+        wsAssertMLSMessage qcnv alice (Just . ciClient $ alice1) (mpMessage message)
 
 testAppMessage2 :: TestM ()
 testAppMessage2 = do
@@ -937,7 +937,7 @@ testAppMessage2 = do
 
       liftIO $
         WS.assertMatchN_ (5 # WS.Second) wss $
-          wsAssertMLSMessage conversation bob (mpMessage message)
+          wsAssertMLSMessage conversation bob (Just . ciClient $ bob1) (mpMessage message)
 
 testRemoteToRemote :: TestM ()
 testRemoteToRemote = do
@@ -987,8 +987,8 @@ testRemoteToRemote = do
     void $ runFedClient @"on-mls-message-sent" fedGalleyClient bdom rm
     liftIO $ do
       -- alice should receive the message on her first client
-      WS.assertMatch_ (5 # Second) wsA1 $ \n -> wsAssertMLSMessage qconv qbob txt n
-      WS.assertMatch_ (5 # Second) wsA2 $ \n -> wsAssertMLSMessage qconv qbob txt n
+      WS.assertMatch_ (5 # Second) wsA1 $ \n -> wsAssertMLSMessage qconv qbob (Just aliceC1) txt n
+      WS.assertMatch_ (5 # Second) wsA2 $ \n -> wsAssertMLSMessage qconv qbob (Just aliceC2) txt n
 
       -- eve should not receive the message
       WS.assertNoEvent (1 # Second) [wsE]
@@ -1050,7 +1050,7 @@ testRemoteToLocal = do
       liftIO $ do
         resp @?= MLSMessageResponseUpdates []
         WS.assertMatch_ (5 # Second) ws $
-          wsAssertMLSMessage qcnv bob (mpMessage message)
+          wsAssertMLSMessage qcnv bob (Just . ciClient $ bob1) (mpMessage message)
 
 testRemoteToLocalWrongConversation :: TestM ()
 testRemoteToLocalWrongConversation = do
@@ -1253,7 +1253,7 @@ testExternalAddProposal = do
         void $ sendAndConsumeMessage msg
         liftTest $
           WS.assertMatchN_ (5 # Second) wss $
-            wsAssertMLSMessage qcnv alice (mpMessage msg)
+            wsAssertMLSMessage qcnv alice (Just . ciClient $ alice1) (mpMessage msg)
 
     -- bob adds charlie
     putOtherMemberQualified

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1608,7 +1608,7 @@ assertMLSMessageEvent conv u message e = do
   evtConv e @?= conv
   evtType e @?= MLSMessageAdd
   evtFrom e @?= u
-  evtData e @?= EdMLSMessage message
+  evtData e @?= EdMLSMessage (MLSMessage message Nothing) -- TODO: use the correct data
 
 -- | This assumes the default role name
 wsAssertMemberJoin :: HasCallStack => Qualified ConvId -> Qualified UserId -> [Qualified UserId] -> Notification -> IO ()
@@ -2812,7 +2812,7 @@ wsAssertBackendRemoveProposal fromUser convId kpref n = do
   pure bs
   where
     getMLSMessageData :: Conv.EventData -> ByteString
-    getMLSMessageData (EdMLSMessage bs) = bs
+    getMLSMessageData (EdMLSMessage (MLSMessage  bs _)) = bs
     getMLSMessageData d = error ("Excepected EdMLSMessage, but got " <> show d)
 
 wsAssertAddProposal ::
@@ -2844,7 +2844,7 @@ wsAssertAddProposal fromUser convId n = do
   pure bs
   where
     getMLSMessageData :: Conv.EventData -> ByteString
-    getMLSMessageData (EdMLSMessage bs) = bs
+    getMLSMessageData (EdMLSMessage (MLSMessage bs _)) = bs
     getMLSMessageData d = error ("Excepected EdMLSMessage, but got " <> show d)
 
 createAndConnectUsers :: [Maybe Text] -> TestM [Qualified UserId]

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2814,7 +2814,7 @@ wsAssertBackendRemoveProposal fromUser convId kpref n = do
   pure bs
   where
     getMLSMessageData :: Conv.EventData -> ByteString
-    getMLSMessageData (EdMLSMessage (MLSMessage  bs _)) = bs
+    getMLSMessageData (EdMLSMessage (MLSMessage bs _)) = bs
     getMLSMessageData d = error ("Excepected EdMLSMessage, but got " <> show d)
 
 wsAssertAddProposal ::

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1577,13 +1577,14 @@ wsAssertMLSMessage ::
   HasCallStack =>
   Qualified ConvId ->
   Qualified UserId ->
+  Maybe ClientId ->
   ByteString ->
   Notification ->
   IO ()
-wsAssertMLSMessage conv u message n = do
+wsAssertMLSMessage conv u cid message n = do
   let e = List1.head (WS.unpackPayload n)
   ntfTransient n @?= False
-  assertMLSMessageEvent conv u message e
+  assertMLSMessageEvent conv u cid message e
 
 wsAssertClientRemoved ::
   HasCallStack =>
@@ -1601,14 +1602,15 @@ assertMLSMessageEvent ::
   HasCallStack =>
   Qualified ConvId ->
   Qualified UserId ->
+  Maybe ClientId ->
   ByteString ->
   Conv.Event ->
   IO ()
-assertMLSMessageEvent conv u message e = do
+assertMLSMessageEvent conv u cid message e = do
   evtConv e @?= conv
   evtType e @?= MLSMessageAdd
   evtFrom e @?= u
-  evtData e @?= EdMLSMessage (MLSMessage message Nothing) -- TODO: use the correct data
+  evtData e @?= EdMLSMessage (MLSMessage message cid)
 
 -- | This assumes the default role name
 wsAssertMemberJoin :: HasCallStack => Qualified ConvId -> Qualified UserId -> [Qualified UserId] -> Notification -> IO ()


### PR DESCRIPTION
Client side asked for the sender id as part of the top level payload, but this raised a feel questions since it's a breaking change that will require clients to adapt how they are currently deserialising the JSON payload, for this reason we've left it as a draft, until we've reached a consensus on how to move forward with this.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
