### PR TITLE
Update team-settings version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/team-settings-upgrade
+++ b/changelog.d/0-release-notes/team-settings-upgrade
@@ -1,0 +1,1 @@
+Upgrade team-settings version to 4.12.1-v0.31.5-0-0167ea4

--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/team-settings
-  tag: "4.11.0-v0.31.1-0-9e64150"
+  tag: "4.12.1-v0.31.5-0-0167ea4"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `4.12.1-v0.31.5-0-0167ea4`
Release: [`v4.12.1`](https://github.com/wireapp/wire-team-settings/releases/tag/v4.12.1)