### PR TITLE
Use hlint with no summary instead of grep.

### DIFF
--- a/tools/hlint.sh
+++ b/tools/hlint.sh
@@ -35,6 +35,14 @@ while getopts ':f:m:' opt
      esac
 done
 
+ret=$?
+if [ $ret -ne 0 ]; then
+  echo
+else
+  echo "No files to check"
+  exit 1
+fi
+
 if [ -z "${f}" ] || [ -z "${m}" ]; then
     usage
 fi
@@ -47,7 +55,7 @@ for f in $files
 do
   echo "$f"
   if [ $check = true ]; then
-    hlint "$f" | grep -v 'No hints'
+    hlint --no-summary "$f"
   else
     hlint --refactor --refactor-options="--inplace" "$f"
   fi

--- a/tools/hlint.sh
+++ b/tools/hlint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 usage() { echo "Usage: $0 -f [all, changeset] -m [check, inplace]" 1>&2; exit 1; }
 
 files=''
@@ -34,18 +36,6 @@ while getopts ':f:m:' opt
          *) usage;;
      esac
 done
-
-ret=$?
-if [ $ret -ne 0 ]; then
-  echo
-else
-  echo "No files to check"
-  exit 1
-fi
-
-if [ -z "${f}" ] || [ -z "${m}" ]; then
-    usage
-fi
 
 count=$(echo "$files" | grep -c -v -e '^[[:space:]]*$')
 

--- a/tools/hlint.sh
+++ b/tools/hlint.sh
@@ -37,6 +37,10 @@ while getopts ':f:m:' opt
      esac
 done
 
+if [ -z "${f}" ] || [ -z "${m}" ]; then
+    usage
+fi
+
 count=$(echo "$files" | grep -c -v -e '^[[:space:]]*$')
 
 echo "Analysing $count file(s)…"


### PR DESCRIPTION
Turns out hlint already provided a way to silence the annoying no hints output.
On top of that, I added a quick early break with a better error message in case of grep failures b/c no files were found.
