### PR TITLE
Add new custom hlint rule for runSetting.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -15,3 +15,6 @@
 # custom rules:
 - hint: { lhs: (() <$), rhs: void }
 - hint: { lhs: return, rhs: pure }
+## We want the latter to properly handle signals.
+- error: { name: Use shutdown, lhs: runSettings, rhs: runSettingsWithShutdown }
+- ignore: { name: Use shutdown, within: [Network.Wai.Utilities.Server] }

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -17,4 +17,4 @@
 - hint: { lhs: return, rhs: pure }
 ## We want the latter to properly handle signals.
 - error: { name: Use shutdown, lhs: runSettings, rhs: runSettingsWithShutdown }
-- ignore: { name: Use shutdown, within: [Network.Wai.Utilities.Server] }
+- ignore: { name: Use shutdown, within: [Network.Wai.Utilities.Server, Federator.Response] }

--- a/libs/wire-api/src/Wire/API/MLS/CommitBundle.hs
+++ b/libs/wire-api/src/Wire/API/MLS/CommitBundle.hs
@@ -14,7 +14,6 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
-{-# LANGUAGE RecordWildCards #-}
 
 module Wire.API.MLS.CommitBundle where
 

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -14,7 +14,6 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
-{-# LANGUAGE RecordWildCards #-}
 
 module Galley.API.MLS.Message
   ( postMLSCommitBundle,
@@ -1027,8 +1026,7 @@ executeProposalAction qusr con lconv cm action = do
 
     existingLocalMembers :: Set (Qualified UserId)
     existingLocalMembers =
-      Set.fromList . map (fmap lmId . qUntagged) . sequenceA $
-        fmap convLocalMembers lconv
+      (Set.fromList . map (fmap lmId . qUntagged)) (traverse convLocalMembers lconv)
 
     existingRemoteMembers :: Set (Qualified UserId)
     existingRemoteMembers =

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>

--- a/tools/hlint.sh
+++ b/tools/hlint.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 usage() { echo "Usage: $0 -f [all, changeset] -m [check, inplace]" 1>&2; exit 1; }
 
 files=''


### PR DESCRIPTION
Also applies hlint again to the whole codebase (excluding tests), as we had some drift between finalising hlint and new PRs being merged without being linted / having CI catch those cases.

I also disabled the pipefail from the script, as that would short-circuit the linter on first issue found. Hopefully that doesn't mess with CI.

PS: This will fail CI linters phase until #2715 has been merged.