### PR TITLE
charts/wire-server: enable topology-aware hints.

### DIFF
--- a/changelog.d/5-internal/topology-aware-hints
+++ b/changelog.d/5-internal/topology-aware-hints
@@ -1,0 +1,1 @@
+For wire-server cloud, on kubernetes 1.21+, favour topology-aware routing, which reduces unnecessary inter-availability-zone traffic, reducing latency and AWS costs.

--- a/changelog.d/5-internal/topology-aware-hints
+++ b/changelog.d/5-internal/topology-aware-hints
@@ -1,1 +1,1 @@
-For wire-server cloud, on kubernetes 1.21+, favour topology-aware routing, which reduces unnecessary inter-availability-zone traffic, reducing latency and AWS costs.
+For wire-server cloud, on kubernetes 1.21+, favour topology-aware routing, which reduces unnecessary inter-availability-zone traffic, reducing latency and cloud provider cross-AZ traffic costs.

--- a/charts/backoffice/templates/service.yaml
+++ b/charts/backoffice/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/brig/templates/service.yaml
+++ b/charts/brig/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/cannon/templates/headless-service.yaml
+++ b/charts/cannon/templates/headless-service.yaml
@@ -2,7 +2,7 @@
 # We use it this way so we can handle routing requests to specific cannons directly rather than distributing requests
 # between pods.
 #
-# Read more about this technique in the StatefulSet guide: 
+# Read more about this technique in the StatefulSet guide:
 # https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/
 apiVersion: v1
 kind: Service
@@ -13,6 +13,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   # This is what makes it a Headless Service

--- a/charts/cannon/templates/nginz-service.yaml
+++ b/charts/cannon/templates/nginz-service.yaml
@@ -18,6 +18,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    service.kubernetes.io/topology-aware-hints: auto
     {{- if .Values.service.nginz.externalDNS.enabled }}
     external-dns.alpha.kubernetes.io/ttl: {{ .Values.service.nginz.externalDNS.ttl | quote }}
     external-dns.alpha.kubernetes.io/hostname: {{ required "Please provide .service.nginz.hostname when .service.nginz.enabled and .service.nginz.externalDNS.enabled are True" .Values.service.nginz.hostname | quote }}

--- a/charts/cargohold/templates/service.yaml
+++ b/charts/cargohold/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/federator/templates/service.yaml
+++ b/charts/federator/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/galley/templates/service.yaml
+++ b/charts/galley/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/gundeck/templates/service.yaml
+++ b/charts/gundeck/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/legalhold/templates/service.yaml
+++ b/charts/legalhold/templates/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ .Release.Name }}-hold"
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   selector:

--- a/charts/nginz/templates/service.yaml
+++ b/charts/nginz/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/proxy/templates/service.yaml
+++ b/charts/proxy/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   ports:

--- a/charts/spar/templates/service.yaml
+++ b/charts/spar/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
For wire-server cloud, on kubernetes 1.21+, favour topology-aware routing, which reduces unnecessary inter-availability-zone traffic, reducing latency and AWS costs.

Documentation: https://kubernetes.io/docs/concepts/services-networking/topology-aware-hints/ 
See [SQPIT-1439](https://wearezeta.atlassian.net/browse/SQPIT-1439)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
