### PR TITLE
Restore previous behaviour of kicking

### DIFF
--- a/changelog.d/1-api-changes/backend-removal-fix
+++ b/changelog.d/1-api-changes/backend-removal-fix
@@ -1,0 +1,1 @@
+Users being kicked out results in member-leave events originating from the user who caused the change in the conversation


### PR DESCRIPTION
After #2667, when users are kicked out of a conversation, the events
being sent out would look like normal leave events. This commit restores
the previous behaviour: the events reflect the fact that the user was
kicked out, with the originating user set to the user who caused the
change that required users to be removed.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
