### PR TITLE
Update nginz and cannon ACLs to match api-versioned paths

### DIFF
--- a/changelog.d/5-internal/pr-2725
+++ b/changelog.d/5-internal/pr-2725
@@ -1,0 +1,1 @@
+Update nginz and cannon ACLs to match api-versioned paths

--- a/charts/cannon/conf/static/zauth.acl
+++ b/charts/cannon/conf/static/zauth.acl
@@ -1,13 +1,1 @@
-a (blacklist (path "(/v[0-9]+)?/provider(/.*)?")
-             (path "(/v[0-9]+)?/bot(/.*)?")
-             (path "(/v[0-9]+)?/i/.*"))
-
-b (whitelist (regex "(/v[0-9]+)?/bot(/.*)?"))
-
-p (whitelist (regex "(/v[0-9]+)?/provider(/.*)?"))
-
-# LegalHold Access Tokens
-la (whitelist (regex "(/v[0-9]+)?/notifications")
-              (regex "(/v[0-9]+)?/assets/v3/.*")
-              (regex "(/v[0-9]+)?/users(/.*)?")
-              (regex "(/v[0-9]+)?/legalhold/conversations/[^/]+"))
+a (whitelist (regex "/await"))

--- a/charts/cannon/conf/static/zauth.acl
+++ b/charts/cannon/conf/static/zauth.acl
@@ -1,17 +1,13 @@
-a (blacklist (path "/provider")
-             (path "/provider/**")
-             (path "/bot")
-             (path "/bot/**")
-             (path "/i/**"))
+a (blacklist (path "(/v[0-9]+)?/provider(/.*)?")
+             (path "(/v[0-9]+)?/bot(/.*)?")
+             (path "(/v[0-9]+)?/i/.*"))
 
-b (whitelist (path "/bot")
-             (path "/bot/**"))
+b (whitelist (regex "(/v[0-9]+)?/bot(/.*)?"))
 
-p (whitelist (path "/provider")
-             (path "/provider/**"))
+p (whitelist (regex "(/v[0-9]+)?/provider(/.*)?"))
 
 # LegalHold Access Tokens
-la (whitelist (path "/notifications")
-              (path "/assets/v3/**")
-              (path "/users")
-              (path "/users/**"))
+la (whitelist (regex "(/v[0-9]+)?/notifications")
+              (regex "(/v[0-9]+)?/assets/v3/.*")
+              (regex "(/v[0-9]+)?/users(/.*)?")
+              (regex "(/v[0-9]+)?/legalhold/conversations/[^/]+"))

--- a/charts/nginz/static/conf/zauth.acl
+++ b/charts/nginz/static/conf/zauth.acl
@@ -1,18 +1,13 @@
-a (blacklist (path "/provider")
-             (path "/provider/**")
-             (path "/bot")
-             (path "/bot/**")
-             (path "/i/**"))
+a (blacklist (regex "(/v[0-9]+)?/provider(/.*)?")
+             (regex "(/v[0-9]+)?/bot(/.*)?")
+             (regex "(/v[0-9]+)?/i/.*"))
 
-b (whitelist (path "/bot")
-             (path "/bot/**"))
+b (whitelist (regex "(/v[0-9]+)?/bot(/.*)?"))
 
-p (whitelist (path "/provider")
-             (path "/provider/**"))
+p (whitelist (regex "(/v[0-9]+)?/provider(/.*)?"))
 
 # LegalHold Access Tokens
-la (whitelist (path "/notifications")
-              (path "/assets/v3/**")
-              (path "/users")
-              (path "/users/**")
-              (path "/legalhold/conversations/*"))
+la (whitelist (regex "(/v[0-9]+)?/notifications")
+              (regex "(/v[0-9]+)?/assets/v3/.*")
+              (regex "(/v[0-9]+)?/users(/.*)?")
+              (regex "(/v[0-9]+)?/legalhold/conversations/[^/]+"))


### PR DESCRIPTION
This PR updates the ACL files to include api-versioned paths (paths prefixed by `v2/`, etc).

This PR makes use of the new regex syntax in libzauth that was introduced in https://github.com/wireapp/wire-server/pull/2714

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
