### PR TITLE
Allow /conversations/<uuid> paths for legalhold tokens

### DIFF
--- a/changelog.d/5-internal/acl-legalhold-tokens
+++ b/changelog.d/5-internal/acl-legalhold-tokens
@@ -1,0 +1,1 @@
+Allow legalhold tokens access to `/converations/<uuid>` endpoint (#2682, #2726)

--- a/charts/nginz/static/conf/zauth.acl
+++ b/charts/nginz/static/conf/zauth.acl
@@ -7,7 +7,9 @@ b (whitelist (regex "(/v[0-9]+)?/bot(/.*)?"))
 p (whitelist (regex "(/v[0-9]+)?/provider(/.*)?"))
 
 # LegalHold Access Tokens
+# FUTUREWORK: remove /legalhold/conversations/ when support for v1 dropped
 la (whitelist (regex "(/v[0-9]+)?/notifications")
               (regex "(/v[0-9]+)?/assets/v3/.*")
               (regex "(/v[0-9]+)?/users(/.*)?")
-              (regex "(/v[0-9]+)?/legalhold/conversations/[^/]+"))
+              (regex "(/v[0-9]+)?/legalhold/conversations/[^/]+")
+              (regex "(/v[0-9]+)?/conversations/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"))

--- a/deploy/services-demo/conf/nginz/zauth_acl.txt
+++ b/deploy/services-demo/conf/nginz/zauth_acl.txt
@@ -1,18 +1,15 @@
-a (blacklist (path "/provider")
-             (path "/provider/**")
-             (path "/bot")
-             (path "/bot/**")
-             (path "/i/**"))
+a (blacklist (regex "(/v[0-9]+)?/provider(/.*)?")
+             (regex "(/v[0-9]+)?/bot(/.*)?")
+             (regex "(/v[0-9]+)?/i/.*"))
 
-b (whitelist (path "/bot")
-             (path "/bot/**"))
+b (whitelist (regex "(/v[0-9]+)?/bot(/.*)?"))
 
-p (whitelist (path "/provider")
-             (path "/provider/**"))
+p (whitelist (regex "(/v[0-9]+)?/provider(/.*)?"))
 
 # LegalHold Access Tokens
-la (whitelist (path "/notifications")
-              (path "/assets/v3/**")
-              (path "/users")
-              (path "/users/**")
-              (path "/legalhold/conversations/*"))
+# FUTUREWORK: remove /legalhold/conversations/ when support for v1 dropped
+la (whitelist (regex "(/v[0-9]+)?/notifications")
+              (regex "(/v[0-9]+)?/assets/v3/.*")
+              (regex "(/v[0-9]+)?/users(/.*)?")
+              (regex "(/v[0-9]+)?/legalhold/conversations/[^/]+")
+              (regex "(/v[0-9]+)?/conversations/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"))

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -243,6 +243,8 @@ testNginzLegalHold b g n = do
 
   get (n . paths ["legalhold", "conversations", toByteString' (qUnqualified qconv)] . header "Authorization" ("Bearer " <> toByteString' t)) !!! const 200 === statusCode
 
+  get (n . paths ["conversations", toByteString' (qUnqualified qconv)] . header "Authorization" ("Bearer " <> toByteString' t)) !!! const 200 === statusCode
+
 -- | Corner case for 'testNginz': when upgrading a wire backend from the old behavior (setting
 -- cookie domain to eg. @*.wire.com@) to the new behavior (leaving cookie domain empty,
 -- effectively setting it to the backend host), clients may start sending two cookies for a


### PR DESCRIPTION
This PR:

- adds `/conversations/<uuid>` to the allowlist for legalhold tokens. It can replace the changes introduced https://github.com/wireapp/wire-server/pull/2682 by using of the new regex syntax for acl files introduced in https://github.com/wireapp/wire-server/pull/2714
- sets acl file for integration tests to the same as the acl file embedded in the nginz chart

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
