### PR TITLE
[FS-925] Add endpoint to create MLS self-conversation

### DIFF
--- a/changelog.d/1-api-changes/mls-self-conversation
+++ b/changelog.d/1-api-changes/mls-self-conversation
@@ -1,0 +1,1 @@
+Support MLS self-conversations via a new endpoint `PUT /conversations/mls-self`

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -75,9 +75,9 @@ type ConversationResponse = ResponseForExistedCreated Conversation
 
 type ConversationHeaders = '[DescHeader "Location" "Conversation ID" ConvId]
 
-type ConversationVerb =
+type ConversationVerbWithMethod (m :: StdMethod) =
   MultiVerb
-    'POST
+    m
     '[JSON]
     '[ WithHeaders
          ConversationHeaders
@@ -89,6 +89,10 @@ type ConversationVerb =
          (Respond 201 "Conversation created" Conversation)
      ]
     ConversationResponse
+
+type ConversationVerb = ConversationVerbWithMethod 'POST
+
+type ConversationPutVerb = ConversationVerbWithMethod 'PUT
 
 type CreateConversationCodeVerb =
   MultiVerb
@@ -365,6 +369,15 @@ type ConversationAPI =
                :> "conversations"
                :> "self"
                :> ConversationVerb
+           )
+    :<|> Named
+           "create-mls-self-conversation"
+           ( Summary "Create the user's MLS self-conversation"
+               :> ZLocalUser
+               :> "conversations"
+               :> "mls-self"
+               :> ZClient
+               :> ConversationPutVerb
            )
     -- This endpoint can lead to the following events being sent:
     -- - ConvCreate event to members

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -24,7 +24,8 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 module Galley.API.Create
   ( createGroupConversation,
-    createSelfConversation,
+    createProteusSelfConversation,
+    createMLSSelfConversation,
     createOne2OneConversation,
     createConnectConversation,
   )
@@ -117,8 +118,7 @@ createGroupConversation lusr conn newConv = do
 
   case newConvProtocol newConv of
     ProtocolMLSTag -> do
-      haveKey <- isJust <$> getMLSRemovalKey
-      unless haveKey $
+      unlessM (isJust <$> getMLSRemovalKey) $
         -- We fail here to notify users early about this misconfiguration
         throw (InternalErrorWithDescription "No backend removal key is configured (See 'mlsPrivateKeyPaths' in galley's config). Refusing to create MLS conversation.")
     ProtocolProteusTag -> pure ()
@@ -193,12 +193,12 @@ checkCreateConvPermissions lusr newConv (Just tinfo) allUsers = do
 ----------------------------------------------------------------------------
 -- Other kinds of conversations
 
-createSelfConversation ::
+createProteusSelfConversation ::
   forall r.
   Members '[ConversationStore, Error InternalError, P.TinyLog] r =>
   Local UserId ->
   Sem r ConversationResponse
-createSelfConversation lusr = do
+createProteusSelfConversation lusr = do
   let lcnv = fmap Data.selfConv lusr
   c <- E.getConversation (tUnqualified lcnv)
   maybe (create lcnv) (conversationExisted lusr) c
@@ -213,6 +213,42 @@ createSelfConversation lusr = do
               }
       c <- E.createConversation lcnv nc
       conversationCreated lusr c
+
+createMLSSelfConversation ::
+  forall r.
+  Members
+    '[ ConversationStore,
+       Error InternalError,
+       MemberStore,
+       P.TinyLog,
+       Input Env
+     ]
+    r =>
+  Local UserId ->
+  ClientId ->
+  Sem r ConversationResponse
+createMLSSelfConversation lusr clientId = do
+  let selfConvId = mlsSelfConvId <$> lusr
+  mconv <- E.getConversation (tUnqualified selfConvId)
+  maybe (create selfConvId) (conversationExisted lusr) mconv
+  where
+    create :: Local ConvId -> Sem r ConversationResponse
+    create lcnv = do
+      unlessM (isJust <$> getMLSRemovalKey) $
+        throw (InternalErrorWithDescription "No backend removal key is configured (See 'mlsPrivateKeyPaths' in galley's config). Refusing to create MLS conversation.")
+      let nc =
+            NewConversation
+              { ncMetadata =
+                  (defConversationMetadata (tUnqualified lusr))
+                    { cnvmType = SelfConv
+                    },
+                ncUsers = ulFromLocals [toUserRole (tUnqualified lusr)],
+                ncProtocol = ProtocolMLSTag
+              }
+      conv <- E.createConversation lcnv nc
+      -- TODO: remove this. we are planning to remove the need for a nullKeyPackageRef
+      E.addMLSClients lcnv (qUntagged lusr) (Set.singleton (clientId, nullKeyPackageRef))
+      conversationCreated lusr conv
 
 createOne2OneConversation ::
   forall r.
@@ -534,13 +570,6 @@ conversationCreated ::
   Data.Conversation ->
   Sem r ConversationResponse
 conversationCreated lusr cnv = Created <$> conversationView lusr cnv
-
-conversationExisted ::
-  Members '[Error InternalError, P.TinyLog] r =>
-  Local UserId ->
-  Data.Conversation ->
-  Sem r ConversationResponse
-conversationExisted lusr cnv = Existed <$> conversationView lusr cnv
 
 notifyCreatedConversation ::
   Members '[Error InternalError, FederatorAccess, GundeckAccess, Input UTCTime, P.TinyLog] r =>

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -246,7 +246,7 @@ createMLSSelfConversation lusr clientId = do
                 ncProtocol = ProtocolMLSTag
               }
       conv <- E.createConversation lcnv nc
-      -- TODO: remove this. we are planning to remove the need for a nullKeyPackageRef
+      -- FUTUREWORK: remove this. we are planning to remove the need for a nullKeyPackageRef
       E.addMLSClients lcnv (qUntagged lusr) (Set.singleton (clientId, nullKeyPackageRef))
       conversationCreated lusr conv
 

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -59,7 +59,8 @@ servantSitemap =
         <@> mkNamedAPI @"list-conversations" listConversations
         <@> mkNamedAPI @"get-conversation-by-reusable-code" (getConversationByReusableCode @Cassandra)
         <@> mkNamedAPI @"create-group-conversation" createGroupConversation
-        <@> mkNamedAPI @"create-self-conversation" createSelfConversation
+        <@> mkNamedAPI @"create-self-conversation" createProteusSelfConversation
+        <@> mkNamedAPI @"create-mls-self-conversation" createMLSSelfConversation
         <@> mkNamedAPI @"create-one-to-one-conversation" createOne2OneConversation
         <@> mkNamedAPI @"add-members-to-conversation-unqualified" addMembersUnqualified
         <@> mkNamedAPI @"add-members-to-conversation-unqualified2" addMembersUnqualifiedV2

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -90,10 +90,9 @@ import Polysemy.Error
 import Polysemy.Input
 import qualified Polysemy.TinyLog as P
 import qualified System.Logger.Class as Logger
-import Wire.API.Conversation (Access (CodeAccess), Conversation, ConversationCoverView (..), ConversationList (ConversationList), ConversationMetadata, convHasMore, convList)
+import Wire.API.Conversation hiding (Member)
 import qualified Wire.API.Conversation as Public
 import Wire.API.Conversation.Code
-import Wire.API.Conversation.Member hiding (Member)
 import Wire.API.Conversation.Role
 import qualified Wire.API.Conversation.Role as Public
 import Wire.API.Error

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -36,6 +36,7 @@ import Data.Singletons
 import qualified Data.Text as T
 import Data.Time
 import Galley.API.Error
+import Galley.API.Mapping
 import qualified Galley.Data.Conversation as Data
 import Galley.Data.Services (BotMember, newBotMember)
 import qualified Galley.Data.Types as DataTypes
@@ -63,6 +64,7 @@ import qualified Network.Wai.Utilities as Wai
 import Polysemy
 import Polysemy.Error
 import Polysemy.Input
+import qualified Polysemy.TinyLog as P
 import Wire.API.Connection
 import Wire.API.Conversation hiding (Member)
 import qualified Wire.API.Conversation as Public
@@ -74,6 +76,8 @@ import Wire.API.Event.Conversation
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error
+import Wire.API.Routes.Public.Galley
+import Wire.API.Routes.Public.Util
 import Wire.API.Team.Member
 import Wire.API.Team.Role
 import Wire.API.User (VerificationAction)
@@ -837,6 +841,13 @@ ensureMemberLimit old new = do
   let maxSize = fromIntegral (o ^. optSettings . setMaxConvSize)
   when (length old + length new > maxSize) $
     throwS @'TooManyMembers
+
+conversationExisted ::
+  Members '[Error InternalError, P.TinyLog] r =>
+  Local UserId ->
+  Data.Conversation ->
+  Sem r ConversationResponse
+conversationExisted lusr cnv = Existed <$> conversationView lusr cnv
 
 --------------------------------------------------------------------------------
 -- Handling remote errors

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -182,7 +182,7 @@ tests s =
       testGroup
         "CommitBundle"
         [ test s "add user with a commit bundle" testAddUserWithBundle,
-          test s "add user with a commit bundle to a remote conversation" testAddUserToRemoveConvWithBundle,
+          test s "add user with a commit bundle to a remote conversation" testAddUserToRemoteConvWithBundle,
           test s "remote user posts commit bundle" testRemoteUserPostsCommitBundle
         ]
     ]
@@ -1993,8 +1993,8 @@ testDeleteMLSConv = do
     deleteTeamConv tid (qUnqualified qcnv) aliceUnq
       !!! statusCode === const 200
 
-testAddUserToRemoveConvWithBundle :: TestM ()
-testAddUserToRemoveConvWithBundle = do
+testAddUserToRemoteConvWithBundle :: TestM ()
+testAddUserToRemoteConvWithBundle = do
   let aliceDomain = Domain "faraway.example.com"
   [alice, bob, charlie] <- createAndConnectUsers [Just (domainText aliceDomain), Nothing, Nothing]
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1833,6 +1833,9 @@ zUser = header "Z-User" . toByteString'
 zBot :: UserId -> Request -> Request
 zBot = header "Z-Bot" . toByteString'
 
+zClient :: ClientId -> Request -> Request
+zClient = header "Z-Client" . toByteString'
+
 zConn :: ByteString -> Request -> Request
 zConn = header "Z-Connection"
 


### PR DESCRIPTION
The PR introduces a new endpoint `PUT /conversations/mls-self` for creating and retrieving an MLS self-conversation.

Tracked by https://wearezeta.atlassian.net/browse/FS-925.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
