### PR TITLE
Fix: versioned routing for /conversations missing

### DIFF
--- a/deploy/services-demo/conf/nginz/nginx.conf
+++ b/deploy/services-demo/conf/nginz/nginx.conf
@@ -330,7 +330,7 @@ http {
       proxy_pass http://galley;
     }
 
-    location /conversations {
+    location ~* ^(/v[0-9]+)?/conversations.* {
       include common_response_with_zauth.conf;
       proxy_pass http://galley;
     }


### PR DESCRIPTION
This fixes a bug in the local testing setup of nginz.

## Checklist

 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
