### PR TITLE
Remove clients synchronously from brig's DB

### DIFF
--- a/changelog.d/3-bug-fixes/2773
+++ b/changelog.d/3-bug-fixes/2773
@@ -1,0 +1,1 @@
+Revert synchronous semantics of client deletion endpoint

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -397,7 +397,7 @@ execDelete u con c = do
   wrapClient $ Data.rmClient u (clientId c)
   for_ (clientCookie c) $ \l -> wrapClient $ Auth.revokeCookies u [] [l]
   queue <- view internalEvents
-  Queue.enqueue queue (Internal.DeleteClient (clientId c) u con)
+  Queue.enqueue queue (Internal.DeleteClient c u con)
 
 -- | Defensive measure when no prekey is found for a
 -- requested client: Ensure that the client does indeed

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -394,6 +394,7 @@ claimLocalMultiPrekeyBundles protectee userClients = do
 -- | Enqueue an orderly deletion of an existing client.
 execDelete :: UserId -> Maybe ConnId -> Client -> (AppT r) ()
 execDelete u con c = do
+  wrapClient $ Data.rmClient u (clientId c)
   for_ (clientCookie c) $ \l -> wrapClient $ Auth.revokeCookies u [] [l]
   queue <- view internalEvents
   Queue.enqueue queue (Internal.DeleteClient (clientId c) u con)

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -62,7 +62,6 @@ onEvent n = handleTimeout $ case n of
     mc <- Data.lookupClient uid cid
     for_ mc $ \c -> do
       rmClient uid cid
-      Data.rmClient uid cid
       Intra.onClientEvent uid mcon (ClientRemoved uid c)
   DeleteUser uid -> do
     Log.info $

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -24,7 +24,6 @@ import Bilge.IO (MonadHttp)
 import Bilge.RPC (HasRequestId)
 import qualified Brig.API.User as API
 import Brig.App
-import qualified Brig.Data.Client as Data
 import Brig.IO.Intra (rmClient)
 import qualified Brig.IO.Intra as Intra
 import Brig.InternalEvent.Types
@@ -40,6 +39,7 @@ import Imports
 import System.Logger.Class (field, msg, val, (~~))
 import qualified System.Logger.Class as Log
 import UnliftIO (timeout)
+import Wire.API.User.Client (clientId)
 
 -- | Handle an internal event.
 --
@@ -58,11 +58,9 @@ onEvent ::
   InternalNotification ->
   m ()
 onEvent n = handleTimeout $ case n of
-  DeleteClient cid uid mcon -> do
-    mc <- Data.lookupClient uid cid
-    for_ mc $ \c -> do
-      rmClient uid cid
-      Intra.onClientEvent uid mcon (ClientRemoved uid c)
+  DeleteClient c uid mcon -> do
+    rmClient uid (clientId c)
+    Intra.onClientEvent uid mcon (ClientRemoved uid c)
   DeleteUser uid -> do
     Log.info $
       msg (val "Processing user delete event")

--- a/services/brig/src/Brig/InternalEvent/Types.hs
+++ b/services/brig/src/Brig/InternalEvent/Types.hs
@@ -23,9 +23,10 @@ where
 import BasePrelude
 import Data.Aeson
 import Data.Id
+import Wire.API.User.Client (Client)
 
 data InternalNotification
-  = DeleteClient !ClientId !UserId !(Maybe ConnId)
+  = DeleteClient !Client !UserId !(Maybe ConnId)
   | DeleteUser !UserId
   | DeleteService !ProviderId !ServiceId
   deriving (Eq, Show)
@@ -57,9 +58,9 @@ instance FromJSON InternalNotification where
       ServiceDeletion -> DeleteService <$> o .: "provider" <*> o .: "service"
 
 instance ToJSON InternalNotification where
-  toJSON (DeleteClient cid uid con) =
+  toJSON (DeleteClient c uid con) =
     object
-      [ "client" .= cid,
+      [ "client" .= c,
         "user" .= uid,
         "connection" .= con,
         "type" .= ClientDeletion

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -106,7 +106,7 @@ tests _cl _at opts p db b c g =
       test p "put /clients/:client - 200 (mls keys)" $ testMLSPublicKeyUpdate b,
       test p "get /clients/:client - 404" $ testMissingClient b,
       test p "get /clients/:client - 200" $ testMLSClient b,
-      test p "post /clients - 200 multiple temporary" $ testAddMultipleTemporary b g c,
+      test p "post /clients - 200 multiple temporary" $ testAddMultipleTemporary b g,
       test p "client/prekeys/race" $ testPreKeyRace b,
       test p "get/head nonce/clients" $ testNewNonce b,
       testGroup
@@ -904,15 +904,15 @@ testMissingClient brig = do
 -- brig) have registered it.  Add second temporary client, check
 -- again.  (NB: temp clients replace each other, there can always be
 -- at most one per account.)
-testAddMultipleTemporary :: Brig -> Galley -> Cannon -> Http ()
-testAddMultipleTemporary brig galley cannon = do
+testAddMultipleTemporary :: Brig -> Galley -> Http ()
+testAddMultipleTemporary brig galley = do
   uid <- userId <$> randomUser brig
   let clt1 =
         (defNewClient TemporaryClientType [somePrekeys !! 0] (someLastPrekeys !! 0))
           { newClientClass = Just PhoneClient,
             newClientModel = Just "featurephone1"
           }
-  client <- responseJsonError =<< addClient brig uid clt1
+  _ <- addClient brig uid clt1
   brigClients1 <- numOfBrigClients uid
   galleyClients1 <- numOfGalleyClients uid
   liftIO $ assertEqual "Too many clients found" (Just 1) brigClients1
@@ -922,14 +922,7 @@ testAddMultipleTemporary brig galley cannon = do
           { newClientClass = Just PhoneClient,
             newClientModel = Just "featurephone2"
           }
-  WS.bracketR cannon uid $ \ws -> do
-    _ <- addClient brig uid clt2
-    void . liftIO . WS.assertMatch (5 # Second) ws $ \n -> do
-      let j = Object $ List1.head (ntfPayload n)
-      let etype = j ^? key "type" . _String
-      let eclient = j ^? key "client" . key "id" . _String
-      etype @?= Just "user.client-remove"
-      fmap ClientId eclient @?= Just (clientId client)
+  _ <- addClient brig uid clt2
   brigClients2 <- numOfBrigClients uid
   galleyClients2 <- numOfGalleyClients uid
   liftIO $ assertEqual "Too many clients found" (Just 1) brigClients2

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -106,7 +106,7 @@ tests _cl _at opts p db b c g =
       test p "put /clients/:client - 200 (mls keys)" $ testMLSPublicKeyUpdate b,
       test p "get /clients/:client - 404" $ testMissingClient b,
       test p "get /clients/:client - 200" $ testMLSClient b,
-      test p "post /clients - 200 multiple temporary" $ testAddMultipleTemporary b g,
+      test p "post /clients - 200 multiple temporary" $ testAddMultipleTemporary b g c,
       test p "client/prekeys/race" $ testPreKeyRace b,
       test p "get/head nonce/clients" $ testNewNonce b,
       testGroup
@@ -904,15 +904,17 @@ testMissingClient brig = do
 -- brig) have registered it.  Add second temporary client, check
 -- again.  (NB: temp clients replace each other, there can always be
 -- at most one per account.)
-testAddMultipleTemporary :: Brig -> Galley -> Http ()
-testAddMultipleTemporary brig galley = do
+testAddMultipleTemporary :: HasCallStack => Brig -> Galley -> Cannon -> Http ()
+testAddMultipleTemporary brig galley cannon = do
   uid <- userId <$> randomUser brig
   let clt1 =
         (defNewClient TemporaryClientType [somePrekeys !! 0] (someLastPrekeys !! 0))
           { newClientClass = Just PhoneClient,
             newClientModel = Just "featurephone1"
           }
-  _ <- addClient brig uid clt1
+
+  client <- responseJsonError =<< addClient brig uid clt1
+
   brigClients1 <- numOfBrigClients uid
   galleyClients1 <- numOfGalleyClients uid
   liftIO $ assertEqual "Too many clients found" (Just 1) brigClients1
@@ -922,10 +924,20 @@ testAddMultipleTemporary brig galley = do
           { newClientClass = Just PhoneClient,
             newClientModel = Just "featurephone2"
           }
-  _ <- addClient brig uid clt2
+
   brigClients2 <- numOfBrigClients uid
-  galleyClients2 <- numOfGalleyClients uid
   liftIO $ assertEqual "Too many clients found" (Just 1) brigClients2
+
+  WS.bracketR cannon uid $ \ws -> do
+    _ <- addClient brig uid clt2
+    void . liftIO . WS.assertMatch (5 # Second) ws $ \n -> do
+      let j = Object $ List1.head (ntfPayload n)
+      let etype = j ^? key "type" . _String
+      let eclient = j ^? key "client" . key "id" . _String
+      etype @?= Just "user.client-remove"
+      fmap ClientId eclient @?= Just (clientId client)
+
+  galleyClients2 <- numOfGalleyClients uid
   liftIO $ assertEqual "Too many clients found" (Just 1) galleyClients2
   where
     numOfBrigClients u = do

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -60,7 +60,7 @@ import Data.String.Conversions (LBS, cs)
 import Data.Text.Encoding (encodeUtf8)
 import qualified Data.Time.Clock as Time
 import Data.Timeout
-import Galley.Cassandra.Client
+import Galley.Cassandra.Client (lookupClients)
 import Galley.Cassandra.LegalHold
 import qualified Galley.Cassandra.LegalHold as LegalHoldData
 import qualified Galley.Env as Galley


### PR DESCRIPTION
This PR reverts in part changes introduced in https://github.com/wireapp/wire-server/pull/2669 . Concretely it reverts the client deletion endpoints back to synchronous semantics: When the call from `DELETE /clients/{client}` returns then a call to `GET /clients` (or any other endpoint that fetches the client) will no longer list the client.

What is kept asynchronous is the removal of the client in galley and the removal of the client from (federated) MLS conversations it participates in.


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
