### PR TITLE
Update error checking for MLS removal key & add operator documenteation

### DIFF
--- a/changelog.d/5-internal/pr-2738
+++ b/changelog.d/5-internal/pr-2738
@@ -1,0 +1,1 @@
+Don't fail client deletion when mls remove key is undefined

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -30,6 +30,9 @@ production.
 
 ### MLS private key paths
 
+Note: This developer documentation. Documentation for site operators can be found here:
+[Messaging Layer Security (MLS)](../../how-to/install/mls.md).
+
 The `mlsPrivateKeyPaths` field should contain a mapping from *purposes* and
 signature schemes to file paths of corresponding x509 private keys in PEM
 format.

--- a/docs/src/how-to/install/index.rst
+++ b/docs/src/how-to/install/index.rst
@@ -18,6 +18,7 @@ Installing wire-server
    (production) How to see centralized logs for wire-server <logging.rst>
    (production) Other configuration options <configuration-options.rst>
    Server and team feature settings <team-feature-settings.md>
+   Messaging Layer Security (MLS) <mls.md>
    Web app settings <web-app-settings.md>
    sft
    restund

--- a/docs/src/how-to/install/mls.md
+++ b/docs/src/how-to/install/mls.md
@@ -11,14 +11,14 @@ The removal key is configured at path
 For example:
 
 ```yaml
-# values.yaml
+# values.yaml or secrets.yaml
 galley:
   secrets:
     mlsPrivateKeys:
       removal:
         ed25519: |
           -----BEGIN PRIVATE KEY-----
-          MC4CAQAwBQYDK2VwBCIEIAocCDXsKIAjb65gOUn5vEF0RIKnVJkKR4ebQzuZ709c
+          MC4CAQA....Z709c
           -----END PRIVATE KEY-----
 ```
 

--- a/docs/src/how-to/install/mls.md
+++ b/docs/src/how-to/install/mls.md
@@ -1,0 +1,38 @@
+### Messaging Layer Security (MLS)
+
+To enable support for [MLS](https://datatracker.ietf.org/wg/mls/documents/)
+conversations you need to configure the `wire-server` helm chart with a removal
+key. This key is used by the server to sign External Remove Proposals and
+enables the server to remove clients from MLS groups, e.g. when users leave
+conversations or delete their clients.
+
+The removal key is configured at path
+`galley.secrets.mlsPrivateKeys.removal.ed25519` in the wire-server helm chart.
+For example:
+
+```yaml
+# values.yaml
+galley:
+  secrets:
+    mlsPrivateKeys:
+      removal:
+        ed25519: |
+          -----BEGIN PRIVATE KEY-----
+          MC4CAQAwBQYDK2VwBCIEIAocCDXsKIAjb65gOUn5vEF0RIKnVJkKR4ebQzuZ709c
+          -----END PRIVATE KEY-----
+```
+
+The key is a private ED25519 key in PEM format. It can be created by openssl
+with this command:
+
+```sh
+openssl req -nodes -newkey ed25519 -keyout ed25519.pem -out /dev/null -subj /
+```
+
+This will create a `ed25519.pem`. Use the contents of this file as the
+configuration value.
+
+This is a sensitive configuration value. Consider using Helm/Helmfile's support
+for managing secrets instead of putting this value in plaintext in a
+`values.yaml` file.
+

--- a/services/galley/src/Galley/API/MLS/Keys.hs
+++ b/services/galley/src/Galley/API/MLS/Keys.hs
@@ -25,6 +25,8 @@ import Imports
 import Polysemy
 import Polysemy.Input
 import Wire.API.MLS.Keys
+import Wire.API.MLS.Credential (SignaturePurpose(RemovalPurpose))
+import Crypto.PubKey.Ed25519 (SecretKey, PublicKey)
 
 getMLSPublicKeys ::
   Member (Input Env) r =>
@@ -33,3 +35,6 @@ getMLSPublicKeys ::
 getMLSPublicKeys _ = do
   keys <- inputs (view mlsKeys)
   pure $ mlsKeysToPublic keys
+
+getMLSRemovalKey :: Member (Input Env) r => Sem r (Maybe (SecretKey, PublicKey)) 
+getMLSRemovalKey = mlsKeyPair_ed25519 <$> (inputs (view mlsKeys) <*> pure RemovalPurpose)

--- a/services/galley/src/Galley/API/MLS/Keys.hs
+++ b/services/galley/src/Galley/API/MLS/Keys.hs
@@ -18,15 +18,15 @@
 module Galley.API.MLS.Keys where
 
 import Control.Lens (view)
+import Crypto.PubKey.Ed25519 (PublicKey, SecretKey)
 import Data.Id
 import Data.Qualified
 import Galley.Env
 import Imports
 import Polysemy
 import Polysemy.Input
+import Wire.API.MLS.Credential (SignaturePurpose (RemovalPurpose))
 import Wire.API.MLS.Keys
-import Wire.API.MLS.Credential (SignaturePurpose(RemovalPurpose))
-import Crypto.PubKey.Ed25519 (SecretKey, PublicKey)
 
 getMLSPublicKeys ::
   Member (Input Env) r =>
@@ -36,5 +36,5 @@ getMLSPublicKeys _ = do
   keys <- inputs (view mlsKeys)
   pure $ mlsKeysToPublic keys
 
-getMLSRemovalKey :: Member (Input Env) r => Sem r (Maybe (SecretKey, PublicKey)) 
+getMLSRemovalKey :: Member (Input Env) r => Sem r (Maybe (SecretKey, PublicKey))
 getMLSRemovalKey = mlsKeyPair_ed25519 <$> (inputs (view mlsKeys) <*> pure RemovalPurpose)


### PR DESCRIPTION
This PR changes the way the backend behaves when removal key for MLS is not configured.

If the key is not configured, then:
- creating MLS conversations is not allowed (was allowed before)
- when a client gets deleted then backend will not send remove proposals to mls groups and log a warning (before the deletion process would fail halfway through)

This PR adds documentation for wire-server for operators on how to configure the removal key.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
