### PR TITLE
json schemas for event notifications from haskell types

### DIFF
--- a/changelog.d/4-docs/FS-1008-event-notification-schemas
+++ b/changelog.d/4-docs/FS-1008-event-notification-schemas
@@ -1,0 +1,1 @@
+tentatively allow `GET /api/event-notification-schemas` for json schemas of server-initiated events (missing pieces tracked in https://wearezeta.atlassian.net/browse/FS-1008)

--- a/libs/wire-api/src/Wire/API/Event/Team.hs
+++ b/libs/wire-api/src/Wire/API/Event/Team.hs
@@ -80,7 +80,7 @@ instance ToSchema Event where
         <*> _eventData .= fieldWithDocModifier "data" (description ?~ dataFieldDesc) schema
         <* eventType .= field "version" schema
     where
-      dataFieldDesc = "TODO: this part of the docs is lying; we're working on it!"
+      dataFieldDesc = "FUTUREWORK: this part of the docs is lying; we're working on it!"
 
 instance S.ToSchema Event where
   declareNamedSchema = schemaToSwagger
@@ -164,7 +164,7 @@ data EventData
   | EdConvDelete ConvId
   deriving stock (Eq, Show, Generic)
 
--- TODO: this is outright wrong; see "Wire.API.Event.Conversation" on how to do this properly.
+-- FUTUREWORK: this is outright wrong; see "Wire.API.Event.Conversation" on how to do this properly.
 instance ToSchema EventData where
   schema =
     object "EventData" $

--- a/libs/wire-api/src/Wire/API/Event/Team.hs
+++ b/libs/wire-api/src/Wire/API/Event/Team.hs
@@ -44,12 +44,15 @@ module Wire.API.Event.Team
   )
 where
 
-import Control.Lens (makeLenses)
-import Data.Aeson
+import Control.Lens (makeLenses, (?~))
+import Data.Aeson hiding (object, (.=))
+import qualified Data.Aeson as A
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.Types (Parser)
 import Data.Id (ConvId, TeamId, UserId)
 import Data.Json.Util
+import Data.Schema
+import qualified Data.Swagger as S
 import qualified Data.Swagger.Build.Api as Doc
 import Data.Time (UTCTime)
 import Imports
@@ -68,67 +71,36 @@ data Event = Event
   }
   deriving stock (Eq, Show, Generic)
 
+instance ToSchema Event where
+  schema =
+    object "Event" $
+      Event
+        <$> _eventTeam .= field "team" schema
+        <*> _eventTime .= field "time" utcTimeSchema
+        <*> _eventData .= fieldWithDocModifier "data" (description ?~ dataFieldDesc) schema
+        <* eventType .= field "version" schema
+    where
+      dataFieldDesc = "TODO: this part of the docs is lying; we're working on it!"
+
+instance S.ToSchema Event where
+  declareNamedSchema = schemaToSwagger
+
 eventType :: Event -> EventType
 eventType = eventDataType . _eventData
 
 newEvent :: TeamId -> UTCTime -> EventData -> Event
 newEvent = Event
 
-modelEvent :: Doc.Model
-modelEvent = Doc.defineModel "TeamEvent" $ do
-  Doc.description "team event data"
-  Doc.property "type" typeEventType $
-    Doc.description "event type"
-  Doc.property "team" Doc.bytes' $
-    Doc.description "team ID"
-  Doc.property "time" Doc.dateTime' $
-    Doc.description "date and time this event occurred"
-  -- This doesn't really seem to work in swagger-ui.
-  -- The children/subTypes are not displayed.
-  Doc.children
-    "type"
-    [ modelMemberEvent,
-      modelConvEvent,
-      modelUpdateEvent
-    ]
-
-modelMemberEvent :: Doc.Model
-modelMemberEvent = Doc.defineModel "TeamMemberEvent" $ do
-  Doc.description "team member event"
-  Doc.property "data" (Doc.ref modelMemberData) $ Doc.description "member data"
-
-modelMemberData :: Doc.Model
-modelMemberData =
-  Doc.defineModel "MemberData" $
-    Doc.property "user" Doc.bytes' $
-      Doc.description "user ID"
-
-modelConvEvent :: Doc.Model
-modelConvEvent = Doc.defineModel "TeamConversationEvent" $ do
-  Doc.description "team conversation event"
-  Doc.property "data" (Doc.ref modelConversationData) $ Doc.description "conversation data"
-
-modelConversationData :: Doc.Model
-modelConversationData =
-  Doc.defineModel "ConversationData" $
-    Doc.property "conv" Doc.bytes' $
-      Doc.description "conversation ID"
-
-modelUpdateEvent :: Doc.Model
-modelUpdateEvent = Doc.defineModel "TeamUpdateEvent" $ do
-  Doc.description "team update event"
-  Doc.property "data" (Doc.ref modelUpdateData) $ Doc.description "update data"
-
 instance ToJSON Event where
-  toJSON = Object . toJSONObject
+  toJSON = A.Object . toJSONObject
 
 instance ToJSONObject Event where
   toJSONObject e =
     KeyMap.fromList
-      [ "type" .= eventType e,
-        "team" .= _eventTeam e,
-        "time" .= _eventTime e,
-        "data" .= _eventData e
+      [ "type" A..= eventType e,
+        "team" A..= _eventTeam e,
+        "time" A..= _eventTime e,
+        "data" A..= _eventData e
       ]
 
 instance FromJSON Event where
@@ -162,40 +134,21 @@ data EventType
   | ConvDelete
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform EventType)
+  deriving (FromJSON, ToJSON, S.ToSchema) via Schema EventType
 
-typeEventType :: Doc.DataType
-typeEventType =
-  Doc.string $
-    Doc.enum
-      [ "team.create",
-        "team.delete",
-        "team.update",
-        "team.member-join",
-        "team.member-leave",
-        "team.conversation-create",
-        "team.conversation-delete"
-      ]
-
-instance ToJSON EventType where
-  toJSON TeamCreate = String "team.create"
-  toJSON TeamDelete = String "team.delete"
-  toJSON TeamUpdate = String "team.update"
-  toJSON MemberJoin = String "team.member-join"
-  toJSON MemberUpdate = String "team.member-update"
-  toJSON MemberLeave = String "team.member-leave"
-  toJSON ConvCreate = String "team.conversation-create"
-  toJSON ConvDelete = String "team.conversation-delete"
-
-instance FromJSON EventType where
-  parseJSON (String "team.create") = pure TeamCreate
-  parseJSON (String "team.delete") = pure TeamDelete
-  parseJSON (String "team.update") = pure TeamUpdate
-  parseJSON (String "team.member-join") = pure MemberJoin
-  parseJSON (String "team.member-update") = pure MemberUpdate
-  parseJSON (String "team.member-leave") = pure MemberLeave
-  parseJSON (String "team.conversation-create") = pure ConvCreate
-  parseJSON (String "team.conversation-delete") = pure ConvDelete
-  parseJSON other = fail $ "Unknown event type: " <> show other
+instance ToSchema EventType where
+  schema =
+    enum @Text "EventType" $
+      mconcat
+        [ element "team.create" TeamCreate,
+          element "team.delete" TeamDelete,
+          element "team.update" TeamUpdate,
+          element "team.member-join" MemberJoin,
+          element "team.member-leave" MemberLeave,
+          element "team.member-update" MemberUpdate,
+          element "team.conversation-create" ConvCreate,
+          element "team.conversation-delete" ConvDelete
+        ]
 
 --------------------------------------------------------------------------------
 -- EventData
@@ -211,18 +164,25 @@ data EventData
   | EdConvDelete ConvId
   deriving stock (Eq, Show, Generic)
 
+-- TODO: this is outright wrong; see "Wire.API.Event.Conversation" on how to do this properly.
+instance ToSchema EventData where
+  schema =
+    object "EventData" $
+      EdTeamCreate
+        <$> (undefined :: EventData -> Team) .= field "team" schema
+
 instance ToJSON EventData where
   toJSON (EdTeamCreate tem) = toJSON tem
   toJSON EdTeamDelete = Null
-  toJSON (EdMemberJoin usr) = object ["user" .= usr]
+  toJSON (EdMemberJoin usr) = A.object ["user" A..= usr]
   toJSON (EdMemberUpdate usr mPerm) =
-    object $
-      "user" .= usr
-        # "permissions" .= mPerm
+    A.object $
+      "user" A..= usr
+        # "permissions" A..= mPerm
         # []
-  toJSON (EdMemberLeave usr) = object ["user" .= usr]
-  toJSON (EdConvCreate cnv) = object ["conv" .= cnv]
-  toJSON (EdConvDelete cnv) = object ["conv" .= cnv]
+  toJSON (EdMemberLeave usr) = A.object ["user" A..= usr]
+  toJSON (EdConvCreate cnv) = A.object ["conv" A..= cnv]
+  toJSON (EdConvDelete cnv) = A.object ["conv" A..= cnv]
   toJSON (EdTeamUpdate upd) = toJSON upd
 
 eventDataType :: EventData -> EventType
@@ -275,3 +235,65 @@ genEventData = \case
   ConvDelete -> EdConvDelete <$> arbitrary
 
 makeLenses ''Event
+
+----------------------------------------------------------------------
+-- swagger1.2 stuff, to be removed in
+-- https://wearezeta.atlassian.net/browse/SQSERVICES-1096
+
+typeEventType :: Doc.DataType
+typeEventType =
+  Doc.string $
+    Doc.enum
+      [ "team.create",
+        "team.delete",
+        "team.update",
+        "team.member-join",
+        "team.member-leave",
+        "team.conversation-create",
+        "team.conversation-delete"
+      ]
+
+modelEvent :: Doc.Model
+modelEvent = Doc.defineModel "TeamEvent" $ do
+  Doc.description "team event data"
+  Doc.property "type" typeEventType $
+    Doc.description "event type"
+  Doc.property "team" Doc.bytes' $
+    Doc.description "team ID"
+  Doc.property "time" Doc.dateTime' $
+    Doc.description "date and time this event occurred"
+  -- This doesn't really seem to work in swagger-ui.
+  -- The children/subTypes are not displayed.
+  Doc.children
+    "type"
+    [ modelMemberEvent,
+      modelConvEvent,
+      modelUpdateEvent
+    ]
+
+modelMemberEvent :: Doc.Model
+modelMemberEvent = Doc.defineModel "TeamMemberEvent" $ do
+  Doc.description "team member event"
+  Doc.property "data" (Doc.ref modelMemberData) $ Doc.description "member data"
+
+modelMemberData :: Doc.Model
+modelMemberData =
+  Doc.defineModel "MemberData" $
+    Doc.property "user" Doc.bytes' $
+      Doc.description "user ID"
+
+modelConvEvent :: Doc.Model
+modelConvEvent = Doc.defineModel "TeamConversationEvent" $ do
+  Doc.description "team conversation event"
+  Doc.property "data" (Doc.ref modelConversationData) $ Doc.description "conversation data"
+
+modelConversationData :: Doc.Model
+modelConversationData =
+  Doc.defineModel "ConversationData" $
+    Doc.property "conv" Doc.bytes' $
+      Doc.description "conversation ID"
+
+modelUpdateEvent :: Doc.Model
+modelUpdateEvent = Doc.defineModel "TeamUpdateEvent" $ do
+  Doc.description "team update event"
+  Doc.property "data" (Doc.ref modelUpdateData) $ Doc.description "update data"

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -22,8 +22,8 @@ module Brig.API.Public
   ( sitemap,
     apiDocs,
     servantSitemap,
-    swaggerDocsAPI,
-    SwaggerDocsAPI,
+    docsAPI,
+    DocsAPI,
   )
 where
 
@@ -143,8 +143,11 @@ import Wire.Sem.Now (Now)
 
 -- User API -----------------------------------------------------------
 
-swaggerDocsAPI :: Servant.Server SwaggerDocsAPI
-swaggerDocsAPI (Just V3) =
+docsAPI :: Servant.Server DocsAPI
+docsAPI = versionedSwaggerDocsAPI :<|> pure eventNotificationSchemas
+
+versionedSwaggerDocsAPI :: Servant.Server VersionedSwaggerDocsAPI
+versionedSwaggerDocsAPI (Just V3) =
   swaggerSchemaUIServer $
     ( brigSwagger
         <> versionSwagger
@@ -157,10 +160,10 @@ swaggerDocsAPI (Just V3) =
       & S.info . S.title .~ "Wire-Server API"
       & S.info . S.description ?~ $(embedText =<< makeRelativeToProject "docs/swagger.md")
       & cleanupSwagger
-swaggerDocsAPI (Just V0) = swaggerPregenUIServer $(pregenSwagger V0)
-swaggerDocsAPI (Just V1) = swaggerPregenUIServer $(pregenSwagger V1)
-swaggerDocsAPI (Just V2) = swaggerPregenUIServer $(pregenSwagger V2)
-swaggerDocsAPI Nothing = swaggerDocsAPI (Just maxBound)
+versionedSwaggerDocsAPI (Just V0) = swaggerPregenUIServer $(pregenSwagger V0)
+versionedSwaggerDocsAPI (Just V1) = swaggerPregenUIServer $(pregenSwagger V1)
+versionedSwaggerDocsAPI (Just V2) = swaggerPregenUIServer $(pregenSwagger V2)
+versionedSwaggerDocsAPI Nothing = versionedSwaggerDocsAPI (Just maxBound)
 
 servantSitemap ::
   forall r p.

--- a/services/brig/src/Brig/API/Public/Swagger.hs
+++ b/services/brig/src/Brig/API/Public/Swagger.hs
@@ -1,12 +1,18 @@
 module Brig.API.Public.Swagger
-  ( SwaggerDocsAPI,
+  ( VersionedSwaggerDocsAPI,
+    DocsAPI,
     pregenSwagger,
     swaggerPregenUIServer,
+    eventNotificationSchemas,
   )
 where
 
-import qualified Data.Aeson as Aeson
+import Control.Lens
+import qualified Data.Aeson as A
 import Data.FileEmbed
+import qualified Data.HashMap.Strict.InsOrd as HM
+import qualified Data.Swagger as S
+import qualified Data.Swagger.Declare as S
 import qualified Data.Text as T
 import FileEmbedLzma
 import Imports hiding (head)
@@ -14,11 +20,18 @@ import Language.Haskell.TH
 import Servant
 import Servant.Swagger.Internal.Orphans ()
 import Servant.Swagger.UI
+import qualified Wire.API.Event.Conversation
+import qualified Wire.API.Event.FeatureConfig
+import qualified Wire.API.Event.Team
 import Wire.API.Routes.Version
 
-type SwaggerDocsAPIBase = SwaggerSchemaUI "swagger-ui" "swagger.json"
+type VersionedSwaggerDocsAPIBase = SwaggerSchemaUI "swagger-ui" "swagger.json"
 
-type SwaggerDocsAPI = "api" :> Header VersionHeader Version :> SwaggerDocsAPIBase
+type VersionedSwaggerDocsAPI = "api" :> Header VersionHeader Version :> VersionedSwaggerDocsAPIBase
+
+type NotificationSchemasAPI = "api" :> "event-notification-schemas" :> Get '[JSON] [S.Definitions S.Schema]
+
+type DocsAPI = VersionedSwaggerDocsAPI :<|> NotificationSchemasAPI
 
 pregenSwagger :: Version -> Q Exp
 pregenSwagger v =
@@ -26,8 +39,48 @@ pregenSwagger v =
     =<< makeRelativeToProject
       ("docs/swagger-v" <> T.unpack (toUrlPiece v) <> ".json")
 
-swaggerPregenUIServer :: LByteString -> Server SwaggerDocsAPIBase
+swaggerPregenUIServer :: LByteString -> Server VersionedSwaggerDocsAPIBase
 swaggerPregenUIServer =
   swaggerSchemaUIServer
-    . fromMaybe Aeson.Null
-    . Aeson.decode
+    . fromMaybe A.Null
+    . A.decode
+
+{- FUTUREWORK(fisx): there are a few things that need to be fixed before this schema collection
+   is of any practical use!
+
+- `ToSchema` instances of team notifications are wrong.  To do this right, search
+  schema-profunctor tutorial for bind/dispatch, and consult conversation events for
+  examples.
+
+- swagger2 doesn't handle types with the same name from different models well; it silently
+  drops the second definition, which is what you want only if there are no name clashes as
+  in our case with three types called `Event` and three types called `EventType`.  We have
+  solved this by rendering the three event types seperately and returning each
+  declarations list in a super-list.  For a better work-around, check
+  https://github.com/GetShopTV/swagger2/issues/14.
+
+- The different `EventData` constructors all have different json schema that partially
+  overlap.  Our schemas only represent the union of all those constructors, rather than a
+  list of cases.  There may be a better way even in swagger v2:
+  https://swagger.io/specification/v2/ (look for "polymorphism")
+
+- (wire cloud) expose end-point via nginz (only on staging).
+
+- Document how this works in
+  https://docs.wire.com/understand/api-client-perspective/swagger.html
+
+tracked in https://wearezeta.atlassian.net/browse/FS-1008 -}
+eventNotificationSchemas :: [S.Definitions S.Schema]
+eventNotificationSchemas = fst . (`S.runDeclare` mempty) <$> renderAll
+  where
+    renderAll :: [S.Declare (S.Definitions S.Schema) ()]
+    renderAll =
+      [ render @Wire.API.Event.Conversation.Event "Wire.API.Event.Conversation.Event",
+        render @Wire.API.Event.FeatureConfig.Event "Wire.API.Event.FeatureConfig.Event",
+        render @Wire.API.Event.Team.Event "Wire.API.Event.Team.Event"
+      ]
+
+    render :: forall a. S.ToSchema a => Text -> S.Declare (S.Definitions S.Schema) ()
+    render eventTypeName = do
+      eventSchema <- S.declareNamedSchema (Proxy @a) <&> view S.schema
+      S.declare (HM.singleton eventTypeName eventSchema)

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -28,7 +28,7 @@ import Brig.API (sitemap)
 import Brig.API.Federation
 import Brig.API.Handler
 import qualified Brig.API.Internal as IAPI
-import Brig.API.Public (SwaggerDocsAPI, servantSitemap, swaggerDocsAPI)
+import Brig.API.Public (DocsAPI, docsAPI, servantSitemap)
 import qualified Brig.API.User as API
 import Brig.AWS (amazonkaEnv, sesQueue)
 import qualified Brig.AWS as AWS
@@ -139,7 +139,7 @@ mkApp o = do
        in Servant.serveWithContext
             (Proxy @ServantCombinedAPI)
             (customFormatters :. localDomain :. Servant.EmptyContext)
-            ( swaggerDocsAPI
+            ( docsAPI
                 :<|> hoistServerWithDomain @BrigAPI (toServantHandler e) servantSitemap
                 :<|> hoistServerWithDomain @IAPI.API (toServantHandler e) IAPI.servantSitemap
                 :<|> hoistServerWithDomain @FederationAPI (toServantHandler e) federationSitemap
@@ -148,7 +148,7 @@ mkApp o = do
             )
 
 type ServantCombinedAPI =
-  ( SwaggerDocsAPI
+  ( DocsAPI
       :<|> BrigAPI
       :<|> IAPI.API
       :<|> FederationAPI


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-1008

our swagger2 docs do not contain event types, since they are contained in an untyped json body in a the notification payload.  this PR partially fills this gap by creating the event type schemas under a new public end-point.  it falls short of creating schemas that are correct and complete, but it contains a list of tasks that would get us there [in the code](https://github.com/wireapp/wire-server/blob/9a050941e2a492ff93d25a61f184eade485fdb89/services/brig/src/Brig/API/Public/Swagger.hs#L48-L72).

```
$ curl http://localhost:8082/api/event-notification-schemas | jq . | tee /tmp/schema.json
```

[schema.json.zip](https://github.com/wireapp/wire-server/files/9864165/schema.json.zip)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
