### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,0 +1,1 @@
+Upgrade webapp version to 2022-10-04-production.0-v0.31.2-0-a438b30

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2022-09-20-production.0-v0.31.2-0-7f74074"
+  tag: "2022-10-04-production.0-v0.31.2-0-a438b30"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2022-10-04-production.0-v0.31.2-0-a438b30`
Release: [`2022-10-04-production.0`](https://github.com/wireapp/wire-webapp/releases/tag/2022-10-04-production.0)