### PR TITLE
Add a repl target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,11 @@ ci: c
 cabal-fmt:
 	./hack/bin/cabal-fmt.sh $(package)
 
+# Get a ghci environment running for the given package.
+.PHONY: repl
+repl: cabal-fmt
+	cabal repl $(WIRE_CABAL_BUILD_OPTIONS) $(package)
+
 # Use ghcid to watch a particular package.
 # pass target=package:name to specify which target is watched.
 .PHONY: ghcid

--- a/changelog.d/5-internal/make-repl
+++ b/changelog.d/5-internal/make-repl
@@ -1,0 +1,1 @@
+Add a Make target for ghci


### PR DESCRIPTION
This PR adds a little Make target to get into a `ghci` environment.

Usage:

> make repl package=brig

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
