### PR TITLE
[FS-926] Create new conversation type for global team conversation

### DIFF
--- a/changelog.d/1-api-changes/fs-926-add-global-team-conv
+++ b/changelog.d/1-api-changes/fs-926-add-global-team-conv
@@ -1,0 +1,1 @@
+Added global conversation type and GET endpoint (`GET /teams/:tid/conversations/global`).

--- a/libs/bilge/src/Bilge/Assert.hs
+++ b/libs/bilge/src/Bilge/Assert.hs
@@ -26,6 +26,7 @@ module Bilge.Assert
     (===),
     (=/=),
     (=~=),
+    (=/~=),
     assertResponse,
     assertTrue,
     assertTrue_,
@@ -140,6 +141,15 @@ f =/= g = Assertions $ tell [\r -> test " === " (/=) (f r) (g r)]
   (Response (Maybe Lazy.ByteString) -> a) ->
   Assertions ()
 f =~= g = Assertions $ tell [\r -> test " not in " contains (f r) (g r)]
+
+-- | Tests the assertion that the left-hand side is **not** contained in the right-hand side.
+-- If it is, actual values will be printed.
+(=/~=) ::
+  (HasCallStack, Show a, Contains a) =>
+  (Response (Maybe Lazy.ByteString) -> a) ->
+  (Response (Maybe Lazy.ByteString) -> a) ->
+  Assertions ()
+f =/~= g = Assertions $ tell [\r -> test " in " ((not .) . contains) (f r) (g r)]
 
 -- | Most generic assertion on a request. If the test function evaluates to
 -- @(Just msg)@ then the assertion fails with the error message @msg@.

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -260,7 +260,8 @@ instance ToSchema Conversation where
       (description ?~ "A conversation object as returned from the server")
       $ Conversation
         <$> cnvQualifiedId .= field "qualified_id" schema
-        <* (qUnqualified . cnvQualifiedId) .= optional (field "id" (deprecatedSchema "qualified_id" schema))
+        <* (qUnqualified . cnvQualifiedId)
+          .= optional (field "id" (deprecatedSchema "qualified_id" schema))
         <*> cnvMetadata .= conversationMetadataObjectSchema
         <*> cnvMembers .= field "members" schema
         <*> cnvProtocol .= protocolSchema

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -25,6 +25,7 @@ module Wire.API.Conversation
     ConversationMetadata (..),
     defConversationMetadata,
     Conversation (..),
+    conversationMetadataObjectSchema,
     cnvType,
     cnvCreator,
     cnvAccess,
@@ -100,7 +101,7 @@ import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as LBS
 import Data.Id
-import Data.List.Extra (disjointOrd)
+import Data.List.Extra (disjointOrd, enumerate)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List1
 import Data.Misc
@@ -259,8 +260,7 @@ instance ToSchema Conversation where
       (description ?~ "A conversation object as returned from the server")
       $ Conversation
         <$> cnvQualifiedId .= field "qualified_id" schema
-        <* (qUnqualified . cnvQualifiedId)
-          .= optional (field "id" (deprecatedSchema "qualified_id" schema))
+        <* (qUnqualified . cnvQualifiedId) .= optional (field "id" (deprecatedSchema "qualified_id" schema))
         <*> cnvMetadata .= conversationMetadataObjectSchema
         <*> cnvMembers .= field "members" schema
         <*> cnvProtocol .= protocolSchema
@@ -436,6 +436,10 @@ data Access
     LinkAccess
   | -- | User can join knowing [changeable/revokable] code
     CodeAccess
+  | -- | In MLS the user can join the global team conversation with their
+    -- | clients via an external commit, thereby inviting their own clients to
+    -- | join.
+    SelfInviteAccess
   deriving stock (Eq, Ord, Bounded, Enum, Show, Generic)
   deriving (Arbitrary) via (GenericUniform Access)
   deriving (ToJSON, FromJSON, S.ToSchema) via Schema Access
@@ -448,7 +452,8 @@ instance ToSchema Access where
           [ element "private" PrivateAccess,
             element "invite" InviteAccess,
             element "link" LinkAccess,
-            element "code" CodeAccess
+            element "code" CodeAccess,
+            element "self_invite" SelfInviteAccess
           ]
 
 typeAccess :: Doc.DataType
@@ -496,6 +501,7 @@ defRole = activatedAccessRole
 
 maybeRole :: ConvType -> Maybe (Set AccessRoleV2) -> Set AccessRoleV2
 maybeRole SelfConv _ = privateAccessRole
+maybeRole GlobalTeamConv _ = teamAccessRole
 maybeRole ConnectConv _ = privateAccessRole
 maybeRole One2OneConv _ = privateAccessRole
 maybeRole RegularConv Nothing = defRole
@@ -578,7 +584,8 @@ data ConvType
   | SelfConv
   | One2OneConv
   | ConnectConv
-  deriving stock (Eq, Show, Generic)
+  | GlobalTeamConv
+  deriving stock (Eq, Show, Generic, Enum, Bounded)
   deriving (Arbitrary) via (GenericUniform ConvType)
   deriving (FromJSON, ToJSON, S.ToSchema) via Schema ConvType
 
@@ -589,11 +596,12 @@ instance ToSchema ConvType where
         [ element 0 RegularConv,
           element 1 SelfConv,
           element 2 One2OneConv,
-          element 3 ConnectConv
+          element 3 ConnectConv,
+          element 4 GlobalTeamConv
         ]
 
 typeConversationType :: Doc.DataType
-typeConversationType = Doc.int32 $ Doc.enum [0, 1, 2, 3]
+typeConversationType = Doc.int32 $ Doc.enum $ fromIntegral . fromEnum <$> enumerate @ConvType
 
 -- | Define whether receipts should be sent in the given conversation
 --   This datatype is defined as an int32 but the Backend does not

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -47,14 +47,13 @@ import Wire.API.Conversation
 import Wire.API.Conversation.Action.Tag
 import Wire.API.Conversation.Role
 import Wire.API.Event.Conversation
-import Wire.API.MLS.GlobalTeamConversation (GlobalTeamConversation)
 import Wire.Arbitrary (Arbitrary (..))
 
 -- | We use this type family instead of a sum type to be able to define
 -- individual effects per conversation action. See 'HasConversationActionEffects'.
 type family ConversationAction (tag :: ConversationActionTag) :: * where
   ConversationAction 'ConversationJoinTag = ConversationJoin
-  ConversationAction 'ConversationSelfInviteTag = GlobalTeamConversation
+  ConversationAction 'ConversationSelfInviteTag = ConvId
   ConversationAction 'ConversationLeaveTag = ()
   ConversationAction 'ConversationMemberUpdateTag = ConversationMemberUpdate
   ConversationAction 'ConversationDeleteTag = ()

--- a/libs/wire-api/src/Wire/API/Conversation/Action/Tag.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action/Tag.hs
@@ -30,6 +30,7 @@ import Wire.Arbitrary (Arbitrary (..))
 
 data ConversationActionTag
   = ConversationJoinTag
+  | ConversationSelfInviteTag
   | ConversationLeaveTag
   | ConversationRemoveMembersTag
   | ConversationMemberUpdateTag
@@ -48,6 +49,7 @@ instance ToSchema ConversationActionTag where
     enum @Text "ConversationActionTag" $
       mconcat
         [ element "ConversationJoinTag" ConversationJoinTag,
+          element "ConversationSelfInviteTag" ConversationSelfInviteTag,
           element "ConversationLeaveTag" ConversationLeaveTag,
           element "ConversationRemoveMembersTag" ConversationRemoveMembersTag,
           element "ConversationMemberUpdateTag" ConversationMemberUpdateTag,

--- a/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
@@ -28,6 +28,7 @@ module Wire.API.Conversation.Protocol
     _ProtocolMLS,
     _ProtocolProteus,
     protocolSchema,
+    mlsDataSchema,
     ConversationMLSData (..),
   )
 where

--- a/libs/wire-api/src/Wire/API/Conversation/Role.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Role.hs
@@ -36,6 +36,7 @@ module Wire.API.Conversation.Role
     wireConvRoleNames,
     roleNameWireAdmin,
     roleNameWireMember,
+    roleToRoleName,
 
     -- * Action
     Action (..),

--- a/libs/wire-api/src/Wire/API/MLS/GlobalTeamConversation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/GlobalTeamConversation.hs
@@ -24,7 +24,7 @@ import Data.Qualified
 import Data.Schema
 import qualified Data.Swagger as S
 import Imports
-import Wire.API.Conversation
+import Wire.API.Conversation hiding (Conversation)
 import Wire.API.Conversation.Protocol
 import Wire.Arbitrary (Arbitrary (..), GenericUniform (..))
 

--- a/libs/wire-api/src/Wire/API/MLS/GlobalTeamConversation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/GlobalTeamConversation.hs
@@ -1,0 +1,54 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.MLS.GlobalTeamConversation where
+
+import Control.Lens ((?~))
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Id
+import Data.Qualified
+import Data.Schema
+import qualified Data.Swagger as S
+import Imports
+import Wire.API.Conversation
+import Wire.API.Conversation.Protocol
+import Wire.Arbitrary (Arbitrary (..), GenericUniform (..))
+
+-- | Public-facing global team conversation.
+-- Membership is implicit. Every member of a team is part of it.
+-- Protocol is also implicit: it's always MLS.
+data GlobalTeamConversation = GlobalTeamConversation
+  { gtcId :: Qualified ConvId,
+    gtcMetadata :: ConversationMetadata,
+    gtcMlsMetadata :: ConversationMLSData
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via (GenericUniform GlobalTeamConversation)
+  deriving (FromJSON, ToJSON, S.ToSchema) via Schema GlobalTeamConversation
+
+instance ToSchema GlobalTeamConversation where
+  schema =
+    objectWithDocModifier
+      "GlobalTeamConversation"
+      (description ?~ "The global team conversation object as returned from the server")
+      $ GlobalTeamConversation
+        <$> gtcId
+          .= field "id" schema
+        <*> gtcMetadata
+          .= conversationMetadataObjectSchema
+        <*> gtcMlsMetadata
+          .= mlsDataSchema

--- a/libs/wire-api/src/Wire/API/MLS/GlobalTeamConversation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/GlobalTeamConversation.hs
@@ -33,8 +33,11 @@ import Wire.Arbitrary (Arbitrary (..), GenericUniform (..))
 -- Protocol is also implicit: it's always MLS.
 data GlobalTeamConversation = GlobalTeamConversation
   { gtcId :: Qualified ConvId,
-    gtcMetadata :: GlobalTeamConversationMetadata,
-    gtcMlsMetadata :: ConversationMLSData
+    gtcMlsMetadata :: ConversationMLSData,
+    gtcCreator :: Maybe UserId,
+    gtcAccess :: [Access],
+    gtcName :: Text,
+    gtcTeam :: TeamId
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform GlobalTeamConversation)
@@ -47,28 +50,14 @@ instance ToSchema GlobalTeamConversation where
       (description ?~ "The global team conversation object as returned from the server")
       $ GlobalTeamConversation
         <$> gtcId .= field "qualified_id" schema
-        <*> gtcMetadata .= gtcMetadataSchema
         <*> gtcMlsMetadata .= mlsDataSchema
-
-data GlobalTeamConversationMetadata = GlobalTeamConversationMetadata
-  { gtcmCreator :: Maybe UserId,
-    gtcmAccess :: [Access],
-    gtcmName :: Text,
-    gtcmTeam :: TeamId
-  }
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform GlobalTeamConversationMetadata)
-
-gtcMetadataSchema :: ObjectSchema SwaggerDoc GlobalTeamConversationMetadata
-gtcMetadataSchema =
-  GlobalTeamConversationMetadata
-    <$> gtcmCreator
-      .= maybe_
-        ( optFieldWithDocModifier
-            "creator"
-            (description ?~ "The creator's user ID")
-            schema
-        )
-    <*> gtcmAccess .= field "access" (array schema)
-    <*> gtcmName .= field "name" schema
-    <*> gtcmTeam .= field "team" schema
+        <*> gtcCreator
+          .= maybe_
+            ( optFieldWithDocModifier
+                "creator"
+                (description ?~ "The creator's user ID")
+                schema
+            )
+        <*> gtcAccess .= field "access" (array schema)
+        <*> gtcName .= field "name" schema
+        <*> gtcTeam .= field "team" schema

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -29,6 +29,7 @@ import Wire.API.Conversation.Role
 import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Event.Conversation
+import Wire.API.MLS.GlobalTeamConversation
 import Wire.API.MLS.PublicGroupState
 import Wire.API.MLS.Servant
 import Wire.API.Routes.MultiVerb
@@ -113,6 +114,19 @@ type ConversationAPI =
                :> "conversations"
                :> QualifiedCapture "cnv" ConvId
                :> Get '[Servant.JSON] Conversation
+           )
+    :<|> Named
+           "get-global-team-conversation"
+           ( Summary "Get the global conversation for a given team ID"
+               :> CanThrow 'ConvNotFound
+               :> CanThrow 'NotATeamMember
+               :> ZLocalUser
+               :> ZClient
+               :> "teams"
+               :> Capture "tid" TeamId
+               :> "conversations"
+               :> "global"
+               :> Get '[Servant.JSON] GlobalTeamConversation
            )
     :<|> Named
            "get-conversation-roles"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -121,7 +121,6 @@ type ConversationAPI =
                :> CanThrow 'ConvNotFound
                :> CanThrow 'NotATeamMember
                :> ZLocalUser
-               :> ZClient
                :> "teams"
                :> Capture "tid" TeamId
                :> "conversations"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Team.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Team.hs
@@ -34,7 +34,7 @@ type TeamAPI =
     "create-non-binding-team"
     ( Summary "Create a new non binding team"
         -- FUTUREWORK: deprecated in https://github.com/wireapp/wire-server/pull/2607
-        :> ZUser
+        :> ZLocalUser
         :> ZConn
         :> CanThrow 'NotConnected
         :> CanThrow 'UserBindingExists

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -48,6 +48,7 @@ library
     Wire.API.MLS.Credential
     Wire.API.MLS.Epoch
     Wire.API.MLS.Extension
+    Wire.API.MLS.GlobalTeamConversation
     Wire.API.MLS.Group
     Wire.API.MLS.GroupInfoBundle
     Wire.API.MLS.KeyPackage

--- a/nix/pkgs/mls-test-cli/default.nix
+++ b/nix/pkgs/mls-test-cli/default.nix
@@ -15,8 +15,8 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "wireapp";
     repo = "mls-test-cli";
-    sha256 = "sha256-/XQ/9oQTPkRqgMzDGRm+Oh9jgkdeDM1vRJ6/wEf2+bY=";
-    rev = "c6f80be2839ac1ed2894e96044541d1c3cf6ecdf";
+    sha256 = "sha256-FjgAcYdUr/ZWdQxbck2UEG6NEEQLuz0S4a55hrAxUs4=";
+    rev = "82fc148964ef5baa92a90d086fdc61adaa2b5dbf";
   };
   doCheck = false;
   cargoSha256 = "sha256-AlZrxa7f5JwxxrzFBgeFSaYU6QttsUpfLYfq1HzsdbE=";

--- a/services/brig/src/Brig/RPC.hs
+++ b/services/brig/src/Brig/RPC.hs
@@ -43,6 +43,9 @@ x3 = limitRetries 3 <> exponentialBackoff 100000
 zUser :: UserId -> Request -> Request
 zUser = header "Z-User" . toByteString'
 
+zClient :: ClientId -> Request -> Request
+zClient = header "Z-Client" . toByteString'
+
 remote :: ByteString -> Msg -> Msg
 remote = field "remote"
 

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -1328,7 +1328,19 @@ createConvWithAccessRoles ars g u us =
       . contentJson
       . body (RequestBodyLBS (encode conv))
   where
-    conv = NewConv us [] Nothing Set.empty ars Nothing Nothing Nothing roleNameWireAdmin ProtocolProteusTag Nothing
+    conv =
+      NewConv
+        us
+        []
+        Nothing
+        Set.empty
+        ars
+        Nothing
+        Nothing
+        Nothing
+        roleNameWireAdmin
+        ProtocolProteusTag
+        Nothing
 
 postMessage ::
   Galley ->

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -217,7 +217,18 @@ createTeamConv :: HasCallStack => Galley -> TeamId -> UserId -> [UserId] -> Mayb
 createTeamConv g tid u us mtimer = do
   let tinfo = Just $ ConvTeamInfo tid
   let conv =
-        NewConv us [] Nothing (Set.fromList []) Nothing tinfo mtimer Nothing roleNameWireAdmin ProtocolProteusTag Nothing
+        NewConv
+          us
+          []
+          Nothing
+          (Set.fromList [])
+          Nothing
+          tinfo
+          mtimer
+          Nothing
+          roleNameWireAdmin
+          ProtocolProteusTag
+          Nothing
   r <-
     post
       ( g

--- a/services/brig/test/integration/API/TeamUserSearch.hs
+++ b/services/brig/test/integration/API/TeamUserSearch.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-unused-imports #-}
-
 -- This file is part of the Wire Server implementation.
 --
 -- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
@@ -24,16 +22,13 @@ import API.Team.Util (createPopulatedBindingTeamWithNamesAndHandles)
 import API.User.Util (activateEmail, initiateEmailUpdateNoSend)
 import Bilge (Manager, MonadHttp)
 import qualified Brig.Options as Opt
-import Brig.User.Search.TeamUserSearch (TeamUserSearchSortBy (..), TeamUserSearchSortOrder (..))
 import Control.Monad.Catch (MonadCatch)
 import Control.Retry ()
-import Data.ByteString.Conversion (ToByteString (..), toByteString)
+import Data.ByteString.Conversion (toByteString)
 import Data.Handle (fromHandle)
 import Data.Id (TeamId, UserId)
-import qualified Data.Map.Strict as M
 import Data.String.Conversions (cs)
 import Imports
-import System.Random
 import System.Random.Shuffle (shuffleM)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, assertEqual)

--- a/services/brig/test/integration/Federation/Util.hs
+++ b/services/brig/test/integration/Federation/Util.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
-{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 -- This file is part of the Wire Server implementation.
 --
@@ -23,47 +22,19 @@
 module Federation.Util where
 
 import Bilge
-import Bilge.Assert ((!!!), (<!!), (===))
+import Bilge.Assert ((!!!), (===))
 import qualified Brig.Options as Opt
-import qualified Control.Concurrent.Async as Async
-import Control.Exception (finally, throwIO)
-import Control.Lens ((.~), (?~), (^.))
-import Control.Monad.Catch (MonadCatch, MonadThrow, bracket, try)
 import Control.Monad.Trans.Except
-import Control.Retry
-import Data.Aeson (FromJSON, Value, decode, (.=))
-import qualified Data.Aeson as Aeson
 import Data.ByteString.Conversion (toByteString')
-import Data.Domain (Domain (Domain))
-import Data.Handle (fromHandle)
 import Data.Id
-import qualified Data.Map.Strict as Map
 import Data.Qualified (Qualified (..))
-import Data.String.Conversions (cs)
-import qualified Data.Text as Text
-import qualified Database.Bloodhound as ES
 import qualified Federator.MockServer as Mock
-import Foreign.C.Error (Errno (..), eCONNREFUSED)
-import GHC.IO.Exception (IOException (ioe_errno))
 import Imports
-import qualified Network.HTTP.Client as HTTP
 import Network.HTTP.Media
-import Network.Socket
-import Network.Wai.Handler.Warp (Port)
 import Network.Wai.Test (Session)
-import qualified Network.Wai.Test as WaiTest
-import Test.QuickCheck (Arbitrary (arbitrary), generate)
-import Test.Tasty
-import Test.Tasty.HUnit
-import Text.RawString.QQ (r)
-import UnliftIO (Concurrently (..), runConcurrently)
 import Util
 import Util.Options (Endpoint (Endpoint))
 import Wire.API.Connection
-import Wire.API.Conversation (Conversation (cnvMembers))
-import Wire.API.Conversation.Member (OtherMember (OtherMember), cmOthers)
-import Wire.API.Conversation.Role (roleNameWireAdmin)
-import Wire.API.Team.Feature (FeatureStatus (..))
 import Wire.API.User
 import Wire.API.User.Client
 import Wire.API.User.Client.Prekey

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -17,7 +17,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 -- for SES notifications
-{-# OPTIONS_GHC -fno-warn-orphans -Wno-deprecations #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Util where
 

--- a/services/federator/src/Federator/InternalServer.hs
+++ b/services/federator/src/Federator/InternalServer.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# OPTIONS_GHC -Wno-partial-type-signatures -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
 -- This file is part of the Wire Server implementation.
 --
@@ -20,58 +20,22 @@
 
 module Federator.InternalServer where
 
-import Control.Exception (bracketOnError)
-import qualified Control.Exception as E
-import Control.Lens (view)
 import Data.Binary.Builder
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as C8
-import qualified Data.ByteString.Lazy as LBS
-import Data.Default
-import Data.Domain (domainText)
-import Data.Either.Validation (Validation (..))
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import Data.X509.CertificateStore
-import Federator.App (runAppT)
-import Federator.Discovery (DiscoverFederator, DiscoveryFailure (DiscoveryFailureDNSError, DiscoveryFailureSrvNotAvailable), runFederatorDiscovery)
-import Federator.Env (Env, TLSSettings, applog, caStore, dnsResolver, runSettings, tls)
+import Federator.Env (Env)
 import Federator.Error.ServerError
 import Federator.Options (RunSettings)
 import Federator.Remote
 import Federator.Response
 import Federator.Validation
-import Foreign (mallocBytes)
-import Foreign.Marshal (free)
 import Imports
-import Network.HPACK (BufferSize)
-import Network.HTTP.Client.Internal (openSocketConnection)
-import Network.HTTP.Client.OpenSSL (withOpenSSL)
 import qualified Network.HTTP.Types as HTTP
-import qualified Network.HTTP2.Client as HTTP2
-import Network.Socket (Socket)
-import qualified Network.Socket as NS
-import Network.TLS
-import qualified Network.TLS as TLS
-import qualified Network.TLS.Extra.Cipher as TLS
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import Polysemy
 import Polysemy.Error
-import qualified Polysemy.Error as Polysemy
-import Polysemy.IO (embedToMonadIO)
 import Polysemy.Input
-import qualified Polysemy.Input as Polysemy
-import qualified Polysemy.Resource as Polysemy
-import Polysemy.TinyLog (TinyLog)
-import qualified Polysemy.TinyLog as Log
-import Servant.Client.Core
-import qualified System.TimeManager as T
-import qualified System.X509 as TLS
 import Wire.API.Federation.Component
-import Wire.Network.DNS.Effect (DNSLookup)
-import qualified Wire.Network.DNS.Effect as Lookup
-import Wire.Network.DNS.SRV (SrvTarget (..))
 
 data RequestData = RequestData
   { rdTargetDomain :: Text,

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -602,7 +602,7 @@ updateLocalConversation lcnv qusr con action = do
       Just gtc ->
         let c = (gtcmCreator . gtcMetadata $ gtc)
          in case c of
-              Nothing -> 
+              Nothing ->
                 throwS @'ConvNotFound
               Just creator ->
                 pure $ gtcToConv creator gtc
@@ -668,8 +668,8 @@ updateLocalConversationUnchecked lconv qusr con action = do
   -- retrieve member
   self <-
     if (cnvmType . convMetadata . tUnqualified $ lconv) == GlobalTeamConv
-      then
-        -- TODO(elland): address this problem
+      then -- TODO(elland): address this problem
+
         pure . Left $
           LocalMember
             { lmId = qUnqualified qusr,

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -648,23 +648,7 @@ updateLocalConversationUnchecked lconv qusr con action = do
   -- retrieve member
   self <-
     if (cnvmType . convMetadata . tUnqualified $ lconv) == GlobalTeamConv
-      then -- TODO(elland): address this problem
-
-        pure . Left $
-          LocalMember
-            { lmId = qUnqualified qusr,
-              lmStatus =
-                MemberStatus
-                  { msOtrMutedStatus = Nothing,
-                    msOtrMutedRef = Nothing,
-                    msOtrArchived = False,
-                    msOtrArchivedRef = Nothing,
-                    msHidden = False,
-                    msHiddenRef = Nothing
-                  },
-              lmService = Nothing,
-              lmConvRoleName = roleToRoleName convRoleWireMember
-            }
+      then pure $ Left $ localMemberFromUser (qUnqualified qusr)
       else noteS @'ConvNotFound $ getConvMember lconv conv qusr
 
   -- perform checks
@@ -684,6 +668,23 @@ updateLocalConversationUnchecked lconv qusr con action = do
 
 -- --------------------------------------------------------------------------------
 -- -- Utilities
+
+localMemberFromUser :: UserId -> LocalMember
+localMemberFromUser uid =
+  LocalMember
+    { lmId = uid,
+      lmStatus =
+        MemberStatus
+          { msOtrMutedStatus = Nothing,
+            msOtrMutedRef = Nothing,
+            msOtrArchived = False,
+            msOtrArchivedRef = Nothing,
+            msHidden = False,
+            msHiddenRef = Nothing
+          },
+      lmService = Nothing,
+      lmConvRoleName = roleToRoleName convRoleWireMember
+    }
 
 ensureConversationActionAllowed ::
   forall tag mem x r.

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -279,7 +279,7 @@ onConversationUpdated requestingDomain cu = do
       SConversationMessageTimerUpdateTag -> pure (Just sca, [])
       SConversationReceiptModeUpdateTag -> pure (Just sca, [])
       SConversationAccessDataTag -> pure (Just sca, [])
-      SConversationSelfInviteTag -> pure (Nothing, []) -- TODO(elland): Should not happen. Should we throw?
+      SConversationSelfInviteTag -> pure (Nothing, [])
   unless allUsersArePresent $
     P.warn $
       Log.field "conversation" (toByteString' (F.cuConvId cu))

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -691,30 +691,38 @@ rmUser lusr conn = do
       let qUser = qUntagged lusr
       cc <- getConversations ids
       now <- input
-      let deleteIfNeeded c =
+      let deleteIfNeeded c = do
             when (tUnqualified lusr `isMember` Data.convLocalMembers c) $ do
               runError (removeUser (qualifyAs lusr c) (qUntagged lusr)) >>= \case
                 Left e -> P.err $ Log.msg ("failed to send remove proposal: " <> internalErrorDescription e)
                 Right _ -> pure ()
               deleteMembers (Data.convId c) (UserList [tUnqualified lusr] [])
               for_ (bucketRemote (fmap rmId (Data.convRemoteMembers c))) $ notifyRemoteMembers now qUser (Data.convId c)
-          fireEvent c =
             let e =
                   Event
                     (qUntagged (qualifyAs lusr (Data.convId c)))
                     (qUntagged lusr)
                     now
                     (EdMembersLeave (QualifiedUserIdList [qUser]))
-             in pure $
-                  Intra.newPushLocal ListComplete (tUnqualified lusr) (Intra.ConvEvent e) (Intra.recipient <$> Data.convLocalMembers c)
-                    <&> set Intra.pushConn conn
-                      . set Intra.pushRoute Intra.RouteDirect
+            pure $
+              Intra.newPushLocal ListComplete (tUnqualified lusr) (Intra.ConvEvent e) (Intra.recipient <$> Data.convLocalMembers c)
+                <&> set Intra.pushConn conn
+                  . set Intra.pushRoute Intra.RouteDirect
+
+          deleteClientsFromGlobal c = do
+            runError (removeUser (qualifyAs lusr c) (qUntagged lusr)) >>= \case
+              Left e -> P.err $ Log.msg ("failed to send remove proposal: " <> internalErrorDescription e)
+              Right _ -> pure ()
+            deleteMembers (Data.convId c) (UserList [tUnqualified lusr] [])
+            for_ (bucketRemote (fmap rmId (Data.convRemoteMembers c))) $ notifyRemoteMembers now qUser (Data.convId c)
+            pure Nothing
+
       pp <- for cc $ \c -> case Data.convType c of
         SelfConv -> pure Nothing
         One2OneConv -> deleteMembers (Data.convId c) (UserList [tUnqualified lusr] []) $> Nothing
         ConnectConv -> deleteMembers (Data.convId c) (UserList [tUnqualified lusr] []) $> Nothing
-        RegularConv -> deleteIfNeeded c >> fireEvent c
-        GlobalTeamConv -> deleteIfNeeded c >> pure Nothing
+        RegularConv -> deleteIfNeeded c
+        GlobalTeamConv -> deleteClientsFromGlobal c
 
       for_
         (maybeList1 (catMaybes pp))

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -303,7 +303,7 @@ type ITeamsAPIBase =
   Named "get-team-internal" (CanThrow 'TeamNotFound :> Get '[Servant.JSON] TeamData)
     :<|> Named
            "create-binding-team"
-           ( ZUser
+           ( ZLocalUser
                :> ReqBody '[Servant.JSON] BindingNewTeam
                :> MultiVerb1
                     'PUT
@@ -691,28 +691,30 @@ rmUser lusr conn = do
       let qUser = qUntagged lusr
       cc <- getConversations ids
       now <- input
-      pp <- for cc $ \c -> case Data.convType c of
-        SelfConv -> pure Nothing
-        One2OneConv -> deleteMembers (Data.convId c) (UserList [tUnqualified lusr] []) $> Nothing
-        ConnectConv -> deleteMembers (Data.convId c) (UserList [tUnqualified lusr] []) $> Nothing
-        RegularConv
-          | tUnqualified lusr `isMember` Data.convLocalMembers c -> do
+      let deleteIfNeeded c =
+            when (tUnqualified lusr `isMember` Data.convLocalMembers c) $ do
               runError (removeUser (qualifyAs lusr c) (qUntagged lusr)) >>= \case
                 Left e -> P.err $ Log.msg ("failed to send remove proposal: " <> internalErrorDescription e)
                 Right _ -> pure ()
               deleteMembers (Data.convId c) (UserList [tUnqualified lusr] [])
-              let e =
-                    Event
-                      (qUntagged (qualifyAs lusr (Data.convId c)))
-                      (qUntagged lusr)
-                      now
-                      (EdMembersLeave (QualifiedUserIdList [qUser]))
               for_ (bucketRemote (fmap rmId (Data.convRemoteMembers c))) $ notifyRemoteMembers now qUser (Data.convId c)
-              pure $
-                Intra.newPushLocal ListComplete (tUnqualified lusr) (Intra.ConvEvent e) (Intra.recipient <$> Data.convLocalMembers c)
-                  <&> set Intra.pushConn conn
-                    . set Intra.pushRoute Intra.RouteDirect
-          | otherwise -> pure Nothing
+          fireEvent c =
+            let e =
+                  Event
+                    (qUntagged (qualifyAs lusr (Data.convId c)))
+                    (qUntagged lusr)
+                    now
+                    (EdMembersLeave (QualifiedUserIdList [qUser]))
+             in pure $
+                  Intra.newPushLocal ListComplete (tUnqualified lusr) (Intra.ConvEvent e) (Intra.recipient <$> Data.convLocalMembers c)
+                    <&> set Intra.pushConn conn
+                      . set Intra.pushRoute Intra.RouteDirect
+      pp <- for cc $ \c -> case Data.convType c of
+        SelfConv -> pure Nothing
+        One2OneConv -> deleteMembers (Data.convId c) (UserList [tUnqualified lusr] []) $> Nothing
+        ConnectConv -> deleteMembers (Data.convId c) (UserList [tUnqualified lusr] []) $> Nothing
+        RegularConv -> deleteIfNeeded c >> fireEvent c
+        GlobalTeamConv -> deleteIfNeeded c >> pure Nothing
 
       for_
         (maybeList1 (catMaybes pp))

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -866,7 +866,6 @@ processInternalCommit qusr senderClient con lconv cm epoch groupId action sender
                 (convId <$> lconv)
                 qusr
                 (Set.singleton (creatorClient, creatorRef))
-
             (Left _, SelfConv, _) ->
               throw . InternalErrorWithDescription $
                 "Unexpected creator client set in a self-conversation"
@@ -887,11 +886,9 @@ processInternalCommit qusr senderClient con lconv cm epoch groupId action sender
                 (convId <$> lconv)
                 qusr
                 (Set.singleton (creatorClient, creatorRef))
-
             (Left _, GlobalTeamConv, _) ->
               throw . InternalErrorWithDescription $
                 "Unexpected creator client set in a global teamconversation"
-
             (Left lm, _, [(qu, (creatorClient, _))])
               | qu == qUntagged (qualifyAs lconv (lmId lm)) -> do
                   -- use update path as sender reference and if not existing fall back to sender

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -479,7 +479,7 @@ postMLSMessageToLocalConv qusr senderClient con smsg lcnv = case rmValue smsg of
     gtc <- getGlobalTeamConversationById lcnv
     conv <- case gtc of
       Just conv -> do
-        when (isNothing (gtcmCreator $ gtcMetadata $ conv)) $ do
+        when (isNothing (gtcCreator conv)) $ do
           setGlobalTeamConversationCreator conv (qUnqualified qusr)
         localMembers <- getLocalMembers (qUnqualified . gtcId $ conv)
         pure $ gtcToConv conv localMembers
@@ -509,26 +509,25 @@ postMLSMessageToLocalConv qusr senderClient con smsg lcnv = case rmValue smsg of
     pure events
   where
     gtcToConv gtc lm =
-      let meta = gtcMetadata gtc
-       in Data.Conversation
-            { convId = qUnqualified $ gtcId gtc,
-              -- FUTUREWORK: Look into reworking things if needed for performance
-              convLocalMembers = lm,
-              convRemoteMembers = mempty,
-              convDeleted = False,
-              convMetadata =
-                ConversationMetadata
-                  { cnvmType = GlobalTeamConv,
-                    cnvmCreator = fromJust . gtcmCreator . gtcMetadata $ gtc,
-                    cnvmAccess = gtcmAccess meta,
-                    cnvmAccessRoles = mempty,
-                    cnvmName = Just (gtcmName meta),
-                    cnvmTeam = Just (gtcmTeam meta),
-                    cnvmMessageTimer = Nothing,
-                    cnvmReceiptMode = Nothing
-                  },
-              convProtocol = ProtocolMLS (gtcMlsMetadata gtc)
-            }
+      Data.Conversation
+        { convId = qUnqualified $ gtcId gtc,
+          -- FUTUREWORK: Look into reworking things if needed for performance
+          convLocalMembers = lm,
+          convRemoteMembers = mempty,
+          convDeleted = False,
+          convMetadata =
+            ConversationMetadata
+              { cnvmType = GlobalTeamConv,
+                cnvmCreator = fromJust . gtcCreator $ gtc,
+                cnvmAccess = gtcAccess gtc,
+                cnvmAccessRoles = mempty,
+                cnvmName = Just (gtcName gtc),
+                cnvmTeam = Just (gtcTeam gtc),
+                cnvmMessageTimer = Nothing,
+                cnvmReceiptMode = Nothing
+              },
+          convProtocol = ProtocolMLS (gtcMlsMetadata gtc)
+        }
 
 postMLSMessageToRemoteConv ::
   ( Members MLSMessageStaticErrors r,

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -31,6 +31,7 @@ conversationAPI =
   mkNamedAPI @"get-unqualified-conversation" getUnqualifiedConversation
     <@> mkNamedAPI @"get-unqualified-conversation-legalhold-alias" getUnqualifiedConversation
     <@> mkNamedAPI @"get-conversation" getConversation
+    <@> mkNamedAPI @"get-global-team-conversation" getGlobalTeamConversation
     <@> mkNamedAPI @"get-conversation-roles" getConversationRoles
     <@> mkNamedAPI @"get-group-info" getGroupInfo
     <@> mkNamedAPI @"list-conversation-ids-unqualified" conversationIdsPageFromUnqualified

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -110,6 +110,7 @@ import qualified Wire.API.Provider.Bot as Public
 import qualified Wire.API.Routes.MultiTablePaging as Public
 import Wire.API.Team.Feature as Public hiding (setStatus)
 import Wire.Sem.Paging.Cassandra
+import qualified Galley.Effects.TeamStore as E
 
 getBotConversationH ::
   Members '[ConversationStore, ErrorS 'ConvNotFound, Input (Local ())] r =>

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -72,7 +72,6 @@ import Galley.API.MLS.Keys
 import Galley.API.Mapping
 import qualified Galley.API.Mapping as Mapping
 import Galley.API.Util
-import qualified Galley.Data.Conversation as Conv
 import qualified Galley.Data.Conversation as Data
 import Galley.Data.Types (Code (codeConversation))
 import Galley.Effects
@@ -99,7 +98,6 @@ import qualified System.Logger.Class as Logger
 import Wire.API.Conversation hiding (Member)
 import qualified Wire.API.Conversation as Public
 import Wire.API.Conversation.Code
-import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 import qualified Wire.API.Conversation.Role as Public
 import Wire.API.Error
@@ -107,7 +105,6 @@ import Wire.API.Error.Galley
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error
-import Wire.API.MLS.GlobalTeamConversation
 import qualified Wire.API.MLS.GlobalTeamConversation as Public
 import qualified Wire.API.Provider.Bot as Public
 import qualified Wire.API.Routes.MultiTablePaging as Public
@@ -171,31 +168,16 @@ getGlobalTeamConversation ::
   Sem r Public.GlobalTeamConversation
 getGlobalTeamConversation lusr cid tid = do
   let uid = tUnqualified lusr
+      ltid = qualifyAs lusr tid
   void $ noteS @'NotATeamMember =<< E.getTeamMember tid (tUnqualified lusr)
-  E.getGlobalTeamConversation tid >>= \case
+  E.getGlobalTeamConversation ltid >>= \case
     Nothing -> do
-      conv <- E.createGlobalTeamConversation (qualifyAs lusr tid) uid
-      mlsData <- case Conv.convProtocol conv of
-        ProtocolMLS mls -> pure mls
-        ProtocolProteus -> throw (InternalErrorWithDescription "Wrong protocol, expected MLS, got Proteus.")
-      -- FUTUREWORK: remove this. we are planning to remove the need for a nullKeyPackageRef
-      let convId = Conv.convId conv
-          lconv = qualifyAs lusr convId
-      E.addMLSClients lconv (qUntagged lusr) (Set.singleton (cid, nullKeyPackageRef))
-      pure $
-        GlobalTeamConversation
-          (qUntagged lconv)
-          (Conv.convMetadata conv)
-          mlsData
-    Just conv -> do
-      mlsData <- case Conv.convProtocol conv of
-        ProtocolMLS mls -> pure mls
-        ProtocolProteus -> throw (InternalErrorWithDescription "Wrong protocol, expected MLS, got Proteus.")
-      pure $
-        GlobalTeamConversation
-          (qUntagged . qualifyAs lusr $ Conv.convId conv)
-          (Conv.convMetadata conv)
-          mlsData
+      gtc <- E.createGlobalTeamConversation ltid uid
+      E.addMLSClients (localGtcId gtc) (qUntagged lusr) (Set.fromList [(cid, nullKeyPackageRef)])
+      pure gtc
+    Just conv -> pure conv
+  where
+    localGtcId = qualifyAs lusr . qUnqualified . Public.gtcId
 
 getConversation ::
   forall r.

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -163,21 +163,15 @@ getGlobalTeamConversation ::
      ]
     r =>
   Local UserId ->
-  ClientId ->
   TeamId ->
   Sem r Public.GlobalTeamConversation
-getGlobalTeamConversation lusr cid tid = do
-  let uid = tUnqualified lusr
-      ltid = qualifyAs lusr tid
+getGlobalTeamConversation lusr tid = do
+  let ltid = qualifyAs lusr tid
   void $ noteS @'NotATeamMember =<< E.getTeamMember tid (tUnqualified lusr)
   E.getGlobalTeamConversation ltid >>= \case
-    Nothing -> do
-      gtc <- E.createGlobalTeamConversation ltid uid
-      E.addMLSClients (localGtcId gtc) (qUntagged lusr) (Set.fromList [(cid, nullKeyPackageRef)])
-      pure gtc
+    Nothing ->
+      E.createGlobalTeamConversation (qualifyAs lusr tid)
     Just conv -> pure conv
-  where
-    localGtcId = qualifyAs lusr . qUnqualified . Public.gtcId
 
 getConversation ::
   forall r.

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -81,6 +81,7 @@ import qualified Galley.Effects.ListItems as E
 import qualified Galley.Effects.MemberStore as E
 import Galley.Effects.TeamFeatureStore (FeaturePersistentConstraint)
 import qualified Galley.Effects.TeamFeatureStore as TeamFeatures
+import qualified Galley.Effects.TeamStore as E
 import Galley.Env
 import Galley.Options
 import Galley.Types.Conversations.Members
@@ -110,7 +111,6 @@ import qualified Wire.API.Provider.Bot as Public
 import qualified Wire.API.Routes.MultiTablePaging as Public
 import Wire.API.Team.Feature as Public hiding (setStatus)
 import Wire.Sem.Paging.Cassandra
-import qualified Galley.Effects.TeamStore as E
 
 getBotConversationH ::
   Members '[ConversationStore, ErrorS 'ConvNotFound, Input (Local ())] r =>

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -37,6 +37,7 @@ module Galley.API.Query
   ( getBotConversationH,
     getUnqualifiedConversation,
     getConversation,
+    getGlobalTeamConversation,
     getConversationRoles,
     conversationIdsPageFromUnqualified,
     conversationIdsPageFrom,
@@ -71,6 +72,7 @@ import Galley.API.MLS.Keys
 import Galley.API.Mapping
 import qualified Galley.API.Mapping as Mapping
 import Galley.API.Util
+import qualified Galley.Data.Conversation as Conv
 import qualified Galley.Data.Conversation as Data
 import Galley.Data.Types (Code (codeConversation))
 import Galley.Effects
@@ -97,6 +99,7 @@ import qualified System.Logger.Class as Logger
 import Wire.API.Conversation hiding (Member)
 import qualified Wire.API.Conversation as Public
 import Wire.API.Conversation.Code
+import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 import qualified Wire.API.Conversation.Role as Public
 import Wire.API.Error
@@ -104,6 +107,8 @@ import Wire.API.Error.Galley
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error
+import Wire.API.MLS.GlobalTeamConversation
+import qualified Wire.API.MLS.GlobalTeamConversation as Public
 import qualified Wire.API.Provider.Bot as Public
 import qualified Wire.API.Routes.MultiTablePaging as Public
 import Wire.API.Team.Feature as Public hiding (setStatus)
@@ -150,6 +155,47 @@ getUnqualifiedConversation ::
 getUnqualifiedConversation lusr cnv = do
   c <- getConversationAndCheckMembership (tUnqualified lusr) (qualifyAs lusr cnv)
   Mapping.conversationView lusr c
+
+getGlobalTeamConversation ::
+  Members
+    '[ ConversationStore,
+       ErrorS 'NotATeamMember,
+       Error InternalError,
+       MemberStore,
+       TeamStore
+     ]
+    r =>
+  Local UserId ->
+  ClientId ->
+  TeamId ->
+  Sem r Public.GlobalTeamConversation
+getGlobalTeamConversation lusr cid tid = do
+  let uid = tUnqualified lusr
+  void $ noteS @'NotATeamMember =<< E.getTeamMember tid (tUnqualified lusr)
+  E.getGlobalTeamConversation tid >>= \case
+    Nothing -> do
+      conv <- E.createGlobalTeamConversation (qualifyAs lusr tid) uid
+      mlsData <- case Conv.convProtocol conv of
+        ProtocolMLS mls -> pure mls
+        ProtocolProteus -> throw (InternalErrorWithDescription "Wrong protocol, expected MLS, got Proteus.")
+      -- FUTUREWORK: remove this. we are planning to remove the need for a nullKeyPackageRef
+      let convId = Conv.convId conv
+          lconv = qualifyAs lusr convId
+      E.addMLSClients lconv (qUntagged lusr) (Set.singleton (cid, nullKeyPackageRef))
+      pure $
+        GlobalTeamConversation
+          (qUntagged lconv)
+          (Conv.convMetadata conv)
+          mlsData
+    Just conv -> do
+      mlsData <- case Conv.convProtocol conv of
+        ProtocolMLS mls -> pure mls
+        ProtocolProteus -> throw (InternalErrorWithDescription "Wrong protocol, expected MLS, got Proteus.")
+      pure $
+        GlobalTeamConversation
+          (qUntagged . qualifyAs lusr $ Conv.convId conv)
+          (Conv.convMetadata conv)
+          mlsData
 
 getConversation ::
   forall r.

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -258,8 +258,7 @@ createNonBindingTeamH lusr zcon (Public.NonBindingNewTeam body) = do
       (body ^. newTeamIconKey)
       NonBinding
   finishCreateTeam team owner others (Just zcon)
-  let tid = team ^. teamId
-  pure tid
+  pure $ team ^. teamId
 
 createBindingTeam ::
   Members

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -192,7 +192,7 @@ ensureActionAllowed action self = case isActionAllowed (fromSing action) (convMe
 ensureGroupConversation :: Member (ErrorS 'InvalidOperation) r => Data.Conversation -> Sem r ()
 ensureGroupConversation conv = do
   let ty = Data.convType conv
-  when (ty /= RegularConv) $ throwS @'InvalidOperation
+  unless (ty `elem` [RegularConv, GlobalTeamConv]) $ throwS @'InvalidOperation
 
 -- | Ensure that the set of actions provided are not "greater" than the user's
 --   own. This is used to ensure users cannot "elevate" allowed actions

--- a/services/galley/src/Galley/Cassandra/Access.hs
+++ b/services/galley/src/Galley/Cassandra/Access.hs
@@ -31,6 +31,7 @@ defAccess SelfConv (Just (Set [])) = [PrivateAccess]
 defAccess ConnectConv (Just (Set [])) = [PrivateAccess]
 defAccess One2OneConv (Just (Set [])) = [PrivateAccess]
 defAccess RegularConv (Just (Set [])) = defRegularConvAccess
+defAccess GlobalTeamConv s = maybe [SelfInviteAccess] fromSet s
 defAccess _ (Just (Set (x : xs))) = x : xs
 
 privateOnly :: Set Access

--- a/services/galley/src/Galley/Cassandra/Client.hs
+++ b/services/galley/src/Galley/Cassandra/Client.hs
@@ -40,9 +40,10 @@ import Polysemy.Input
 import qualified UnliftIO
 
 updateClient :: Bool -> UserId -> ClientId -> Client ()
-updateClient add usr cls = do
+updateClient add usr cid = do
+  -- add or remove client
   let q = if add then Cql.addMemberClient else Cql.rmMemberClient
-  retry x5 $ write (q cls) (params LocalQuorum (Identity usr))
+  retry x5 $ write (q cid) (params LocalQuorum (Identity usr))
 
 -- Do, at most, 16 parallel lookups of up to 128 users each
 lookupClients :: [UserId] -> Client Clients

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -249,6 +249,61 @@ getConversation conv = do
       <*> UnliftIO.wait cdata
   runMaybeT $ conversationGC =<< maybe mzero pure mbConv
 
+getGlobalTeamConversation :: TeamId -> Client (Maybe Conversation)
+getGlobalTeamConversation tid =
+  (\c -> c {convLocalMembers = [], convRemoteMembers = []})
+    <$$> getConversation (globalTeamConv tid)
+
+createGlobalTeamConversation ::
+  Local TeamId ->
+  UserId ->
+  Client Conversation
+createGlobalTeamConversation tid uid = do
+  let lconv = qualifyAs tid (globalTeamConv $ tUnqualified tid)
+      meta =
+        ConversationMetadata
+          { cnvmType = GlobalTeamConv,
+            cnvmCreator = uid,
+            cnvmAccess = [SelfInviteAccess],
+            cnvmAccessRoles = mempty,
+            cnvmName = Just "Global team conversation",
+            cnvmTeam = Just (tUnqualified tid),
+            cnvmMessageTimer = Nothing,
+            cnvmReceiptMode = Nothing
+          }
+      gid = convToGroupId lconv
+      cs = MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+      proto =
+        ProtocolMLS
+          ( ConversationMLSData
+              gid
+              (Epoch 0)
+              cs
+          )
+  retry x5 . batch $ do
+    setType BatchLogged
+    setConsistency LocalQuorum
+    addPrepQuery
+      Cql.insertGlobalTeamConv
+      ( tUnqualified lconv,
+        Cql.Set (cnvmAccess meta),
+        cnvmName meta,
+        cnvmTeam meta,
+        Just gid,
+        Just cs
+      )
+    addPrepQuery Cql.insertTeamConv (tUnqualified tid, tUnqualified lconv)
+    addPrepQuery Cql.insertGroupId (gid, tUnqualified lconv, tDomain lconv)
+  pure
+    Conversation
+      { convId = tUnqualified lconv,
+        convLocalMembers = mempty,
+        convRemoteMembers = mempty,
+        convDeleted = False,
+        convMetadata = meta,
+        convProtocol = proto
+      }
+
 -- | "Garbage collect" a 'Conversation', i.e. if the conversation is
 -- marked as deleted, actually remove it from the database and return
 -- 'Nothing'.
@@ -380,6 +435,8 @@ interpretConversationStoreToCassandra = interpret $ \case
   CreateConversation loc nc -> embedClient $ createConversation loc nc
   CreateMLSSelfConversation lusr -> embedClient $ createMLSSelfConversation lusr
   GetConversation cid -> embedClient $ getConversation cid
+  GetGlobalTeamConversation tid -> embedClient $ getGlobalTeamConversation tid
+  CreateGlobalTeamConversation tid uid -> embedClient $ createGlobalTeamConversation tid uid
   GetConversationIdByGroupId gId -> embedClient $ lookupGroupId gId
   GetConversations cids -> localConversations cids
   GetConversationMetadata cid -> embedClient $ conversationMeta cid

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -329,6 +329,11 @@ setGlobalTeamConversationCreator gtc uid = do
       ( uid,
         qUnqualified . gtcId $ gtc
       )
+    addPrepQuery
+      Cql.insertUserConv
+      ( uid,
+        qUnqualified . gtcId $ gtc
+      )
 
 -- | "Garbage collect" a 'Conversation', i.e. if the conversation is
 -- marked as deleted, actually remove it from the database and return

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -45,7 +45,7 @@ import Imports hiding (Set)
 import Polysemy
 import Polysemy.Input
 import qualified UnliftIO
-import Wire.API.Conversation.Member hiding (Member)
+import Wire.API.Conversation
 import Wire.API.Conversation.Role
 import Wire.API.MLS.KeyPackage
 import Wire.API.Provider.Service
@@ -117,9 +117,32 @@ removeRemoteMembersFromLocalConv cnv victims = do
       addPrepQuery Cql.removeRemoteMember (cnv, domain, uid)
 
 members :: ConvId -> Client [LocalMember]
-members conv =
-  fmap (mapMaybe toMember) . retry x1 $
-    query Cql.selectMembers (params LocalQuorum (Identity conv))
+members conv = do
+  mconv <- retry x1 $ query1 Cql.selectConv (params LocalQuorum (Identity conv))
+  case mconv of
+    Just (GlobalTeamConv, _, _, _, _, _, Just tid, _, _, _, _, _, _, _) -> do
+      res <-
+        retry x1 $
+          query
+            Cql.selectTeamMembers
+            (params LocalQuorum (Identity tid))
+      let uids = mapMaybe fst' $ res
+      pure $ mapMaybe toMemberFromId uids
+    _ ->
+      fmap (mapMaybe toMember) . retry x1 $
+        query Cql.selectMembers (params LocalQuorum (Identity conv))
+  where
+    fst' (a, _, _, _, _) = Just a
+
+toMemberFromId :: UserId -> Maybe LocalMember
+toMemberFromId usr =
+  Just $
+    LocalMember
+      { lmId = usr,
+        lmService = Nothing,
+        lmStatus = toMemberStatus (Nothing, Nothing, Nothing, Nothing, Nothing, Nothing),
+        lmConvRoleName = roleNameWireMember
+      }
 
 toMemberStatus ::
   ( -- otr muted
@@ -202,9 +225,15 @@ member ::
   ConvId ->
   UserId ->
   Client (Maybe LocalMember)
-member cnv usr =
-  (toMember =<<)
-    <$> retry x1 (query1 Cql.selectMember (params LocalQuorum (cnv, usr)))
+member conv usr = do
+  mconv <- retry x1 $ query1 Cql.selectConv (params LocalQuorum (Identity conv))
+  case mconv of
+    Just (GlobalTeamConv, _, _, _, _, _, _, _, _, _, _, _, _, _) ->
+      pure $ toMemberFromId usr
+    _ -> do
+      fmap (toMember =<<) $
+        retry x1 $
+          query1 Cql.selectMember (params LocalQuorum (conv, usr))
 
 -- | Set local users as belonging to a remote conversation. This is invoked by a
 -- remote galley when users from the current backend are added to conversations

--- a/services/galley/src/Galley/Cassandra/Instances.hs
+++ b/services/galley/src/Galley/Cassandra/Instances.hs
@@ -56,12 +56,14 @@ instance Cql ConvType where
   toCql SelfConv = CqlInt 1
   toCql One2OneConv = CqlInt 2
   toCql ConnectConv = CqlInt 3
+  toCql GlobalTeamConv = CqlInt 4
 
   fromCql (CqlInt i) = case i of
     0 -> pure RegularConv
     1 -> pure SelfConv
     2 -> pure One2OneConv
     3 -> pure ConnectConv
+    4 -> pure GlobalTeamConv
     n -> Left $ "unexpected conversation-type: " ++ show n
   fromCql _ = Left "conv-type: int expected"
 
@@ -72,12 +74,14 @@ instance Cql Access where
   toCql InviteAccess = CqlInt 2
   toCql LinkAccess = CqlInt 3
   toCql CodeAccess = CqlInt 4
+  toCql SelfInviteAccess = CqlInt 5
 
   fromCql (CqlInt i) = case i of
     1 -> pure PrivateAccess
     2 -> pure InviteAccess
     3 -> pure LinkAccess
     4 -> pure CodeAccess
+    5 -> pure SelfInviteAccess
     n -> Left $ "Unexpected Access value: " ++ show n
   fromCql _ = Left "Access value: int expected"
 

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -235,6 +235,9 @@ insertMLSSelfConv =
       <> show (fromEnum ProtocolMLSTag)
       <> ", ?, ?)"
 
+insertGlobalTeamConv :: PrepQuery W (ConvId, C.Set Access, Maybe Text, Maybe TeamId, Maybe GroupId, Maybe CipherSuiteTag) ()
+insertGlobalTeamConv = "insert into conversation (conv, type, access, name, team, group_id, cipher_suite) values (?, 4, ?, ?, ?, ?, ?)"
+
 updateConvAccess :: PrepQuery W (C.Set Access, C.Set AccessRoleV2, ConvId) ()
 updateConvAccess = "update conversation set access = ?, access_roles_v2 = ? where conv = ?"
 

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -198,8 +198,39 @@ updateTeamSplashScreen = "update team set splash_screen = ? where team = ?"
 
 -- Conversations ------------------------------------------------------------
 
-selectConv :: PrepQuery R (Identity ConvId) (ConvType, UserId, Maybe (C.Set Access), Maybe AccessRoleLegacy, Maybe (C.Set AccessRoleV2), Maybe Text, Maybe TeamId, Maybe Bool, Maybe Milliseconds, Maybe ReceiptMode, Maybe ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuiteTag)
+selectConv ::
+  PrepQuery
+    R
+    (Identity ConvId)
+    ( ConvType,
+      UserId,
+      Maybe (C.Set Access),
+      Maybe AccessRoleLegacy,
+      Maybe (C.Set AccessRoleV2),
+      Maybe Text,
+      Maybe TeamId,
+      Maybe Bool,
+      Maybe Milliseconds,
+      Maybe ReceiptMode,
+      Maybe ProtocolTag,
+      Maybe GroupId,
+      Maybe Epoch,
+      Maybe CipherSuiteTag
+    )
 selectConv = "select type, creator, access, access_role, access_roles_v2, name, team, deleted, message_timer, receipt_mode, protocol, group_id, epoch, cipher_suite from conversation where conv = ?"
+
+selectGlobalTeamConv ::
+  PrepQuery
+    R
+    (Identity ConvId)
+    ( Maybe UserId,
+      Maybe Text,
+      Maybe TeamId,
+      Maybe GroupId,
+      Maybe Epoch,
+      Maybe CipherSuiteTag
+    )
+selectGlobalTeamConv = "select creator, name, team, group_id, epoch, cipher_suite from conversation where conv = ?"
 
 selectReceiptMode :: PrepQuery R (Identity ConvId) (Identity (Maybe ReceiptMode))
 selectReceiptMode = "select receipt_mode from conversation where conv = ?"
@@ -235,8 +266,11 @@ insertMLSSelfConv =
       <> show (fromEnum ProtocolMLSTag)
       <> ", ?, ?)"
 
-insertGlobalTeamConv :: PrepQuery W (ConvId, C.Set Access, Maybe Text, Maybe TeamId, Maybe GroupId, Maybe CipherSuiteTag) ()
-insertGlobalTeamConv = "insert into conversation (conv, type, access, name, team, group_id, cipher_suite) values (?, 4, ?, ?, ?, ?, ?)"
+insertGlobalTeamConv :: PrepQuery W (ConvId, C.Set Access, Text, TeamId, UserId, Maybe GroupId, Maybe CipherSuiteTag) ()
+insertGlobalTeamConv = "insert into conversation (conv, type, access, name, team, creator, group_id, cipher_suite) values (?, 4, ?, ?, ?, ?, ?, ?)"
+
+setGlobalTeamConvCreator :: PrepQuery W (UserId, ConvId) ()
+setGlobalTeamConvCreator = "update conversation set creator = ? where conv = ?"
 
 updateConvAccess :: PrepQuery W (C.Set Access, C.Set AccessRoleV2, ConvId) ()
 updateConvAccess = "update conversation set access = ?, access_roles_v2 = ? where conv = ?"

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -203,7 +203,7 @@ selectConv ::
     R
     (Identity ConvId)
     ( ConvType,
-      UserId,
+      Maybe UserId,
       Maybe (C.Set Access),
       Maybe AccessRoleLegacy,
       Maybe (C.Set AccessRoleV2),
@@ -266,8 +266,8 @@ insertMLSSelfConv =
       <> show (fromEnum ProtocolMLSTag)
       <> ", ?, ?)"
 
-insertGlobalTeamConv :: PrepQuery W (ConvId, C.Set Access, Text, TeamId, UserId, Maybe GroupId, Maybe CipherSuiteTag) ()
-insertGlobalTeamConv = "insert into conversation (conv, type, access, name, team, creator, group_id, cipher_suite) values (?, 4, ?, ?, ?, ?, ?, ?)"
+insertGlobalTeamConv :: PrepQuery W (ConvId, C.Set Access, Text, TeamId, Maybe GroupId, Maybe CipherSuiteTag) ()
+insertGlobalTeamConv = "insert into conversation (conv, type, access, name, team, group_id, cipher_suite) values (?, 4, ?, ?, ?, ?, ?)"
 
 setGlobalTeamConvCreator :: PrepQuery W (UserId, ConvId) ()
 setGlobalTeamConvCreator = "update conversation set creator = ? where conv = ?"

--- a/services/galley/src/Galley/Cassandra/Team.hs
+++ b/services/galley/src/Galley/Cassandra/Team.hs
@@ -14,6 +14,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# LANGUAGE LambdaCase #-}
 
 module Galley.Cassandra.Team
   ( interpretTeamStoreToCassandra,
@@ -157,23 +158,23 @@ createTeam t uid (fromRange -> n) i k b = do
 
 listBillingTeamMembers :: TeamId -> Client [UserId]
 listBillingTeamMembers tid =
-  fmap runIdentity
-    <$> retry x1 (query Cql.listBillingTeamMembers (params LocalQuorum (Identity tid)))
+  runIdentity
+    <$$> retry x1 (query Cql.listBillingTeamMembers (params LocalQuorum (Identity tid)))
 
 getTeamName :: TeamId -> Client (Maybe Text)
 getTeamName tid =
-  fmap runIdentity
-    <$> retry x1 (query1 Cql.selectTeamName (params LocalQuorum (Identity tid)))
+  runIdentity
+    <$$> retry x1 (query1 Cql.selectTeamName (params LocalQuorum (Identity tid)))
 
 teamConversation :: TeamId -> ConvId -> Client (Maybe TeamConversation)
 teamConversation t c =
-  fmap (newTeamConversation . runIdentity)
-    <$> retry x1 (query1 Cql.selectTeamConv (params LocalQuorum (t, c)))
+  newTeamConversation . runIdentity
+    <$$> retry x1 (query1 Cql.selectTeamConv (params LocalQuorum (t, c)))
 
 getTeamConversations :: TeamId -> Client [TeamConversation]
 getTeamConversations t =
-  map (newTeamConversation . runIdentity)
-    <$> retry x1 (query Cql.selectTeamConvs (params LocalQuorum (Identity t)))
+  newTeamConversation . runIdentity
+    <$$> retry x1 (query Cql.selectTeamConvs (params LocalQuorum (Identity t)))
 
 teamIdsFrom :: UserId -> Maybe TeamId -> Range 1 100 Int32 -> Client (ResultSet TeamId)
 teamIdsFrom usr range (fromRange -> max) =
@@ -185,7 +186,7 @@ teamIdsFrom usr range (fromRange -> max) =
 
 teamIdsForPagination :: UserId -> Maybe TeamId -> Range 1 100 Int32 -> Client (Page TeamId)
 teamIdsForPagination usr range (fromRange -> max) =
-  fmap runIdentity <$> case range of
+  runIdentity <$$> case range of
     Just c -> paginate Cql.selectUserTeamsFrom (paramsP LocalQuorum (usr, c) max)
     Nothing -> paginate Cql.selectUserTeams (paramsP LocalQuorum (Identity usr) max)
 

--- a/services/galley/src/Galley/Data/Conversation.hs
+++ b/services/galley/src/Galley/Data/Conversation.hs
@@ -23,6 +23,7 @@ module Galley.Data.Conversation
     -- * Utilities
     isConvDeleted,
     selfConv,
+    globalTeamConv,
     localOne2OneConvId,
     convAccess,
     convAccessData,
@@ -57,6 +58,9 @@ isConvDeleted = convDeleted
 
 selfConv :: UserId -> ConvId
 selfConv uid = Id (toUUID uid)
+
+globalTeamConv :: TeamId -> ConvId
+globalTeamConv tid = Id (toUUID tid)
 
 -- | We deduce the conversation ID by adding the 4 components of the V4 UUID
 -- together pairwise, and then setting the version bits (v4) and variant bits

--- a/services/galley/src/Galley/Effects/ConversationStore.hs
+++ b/services/galley/src/Galley/Effects/ConversationStore.hs
@@ -29,6 +29,7 @@ module Galley.Effects.ConversationStore
     -- * Read conversation
     getConversation,
     getGlobalTeamConversation,
+    getGlobalTeamConversationById,
     createGlobalTeamConversation,
     getConversationIdByGroupId,
     getConversations,
@@ -45,6 +46,7 @@ module Galley.Effects.ConversationStore
     setConversationReceiptMode,
     setConversationMessageTimer,
     setConversationEpoch,
+    setGlobalTeamConversationCreator,
     acceptConnectConversation,
     setGroupId,
     setPublicGroupState,
@@ -70,6 +72,7 @@ import Imports
 import Polysemy
 import Wire.API.Conversation hiding (Conversation, Member)
 import Wire.API.MLS.Epoch
+import Wire.API.MLS.GlobalTeamConversation
 import Wire.API.MLS.PublicGroupState
 
 data ConversationStore m a where
@@ -80,8 +83,10 @@ data ConversationStore m a where
     ConversationStore m Conversation
   DeleteConversation :: ConvId -> ConversationStore m ()
   GetConversation :: ConvId -> ConversationStore m (Maybe Conversation)
-  GetGlobalTeamConversation :: TeamId -> ConversationStore m (Maybe Conversation)
-  CreateGlobalTeamConversation :: Local TeamId -> UserId -> ConversationStore m Conversation
+  GetGlobalTeamConversation :: Local TeamId -> ConversationStore m (Maybe GlobalTeamConversation)
+  GetGlobalTeamConversationById :: Local ConvId -> ConversationStore m (Maybe GlobalTeamConversation)
+  CreateGlobalTeamConversation :: Local TeamId -> UserId -> ConversationStore m GlobalTeamConversation
+  SetGlobalTeamConversationCreator :: GlobalTeamConversation -> UserId -> ConversationStore m ()
   GetConversationIdByGroupId :: GroupId -> ConversationStore m (Maybe (Qualified ConvId))
   GetConversations :: [ConvId] -> ConversationStore m [Conversation]
   GetConversationMetadata :: ConvId -> ConversationStore m (Maybe ConversationMetadata)

--- a/services/galley/src/Galley/Effects/ConversationStore.hs
+++ b/services/galley/src/Galley/Effects/ConversationStore.hs
@@ -28,6 +28,8 @@ module Galley.Effects.ConversationStore
 
     -- * Read conversation
     getConversation,
+    getGlobalTeamConversation,
+    createGlobalTeamConversation,
     getConversationIdByGroupId,
     getConversations,
     getConversationMetadata,
@@ -78,6 +80,8 @@ data ConversationStore m a where
     ConversationStore m Conversation
   DeleteConversation :: ConvId -> ConversationStore m ()
   GetConversation :: ConvId -> ConversationStore m (Maybe Conversation)
+  GetGlobalTeamConversation :: TeamId -> ConversationStore m (Maybe Conversation)
+  CreateGlobalTeamConversation :: Local TeamId -> UserId -> ConversationStore m Conversation
   GetConversationIdByGroupId :: GroupId -> ConversationStore m (Maybe (Qualified ConvId))
   GetConversations :: [ConvId] -> ConversationStore m [Conversation]
   GetConversationMetadata :: ConvId -> ConversationStore m (Maybe ConversationMetadata)

--- a/services/galley/src/Galley/Effects/ConversationStore.hs
+++ b/services/galley/src/Galley/Effects/ConversationStore.hs
@@ -85,7 +85,7 @@ data ConversationStore m a where
   GetConversation :: ConvId -> ConversationStore m (Maybe Conversation)
   GetGlobalTeamConversation :: Local TeamId -> ConversationStore m (Maybe GlobalTeamConversation)
   GetGlobalTeamConversationById :: Local ConvId -> ConversationStore m (Maybe GlobalTeamConversation)
-  CreateGlobalTeamConversation :: Local TeamId -> UserId -> ConversationStore m GlobalTeamConversation
+  CreateGlobalTeamConversation :: Local TeamId -> ConversationStore m GlobalTeamConversation
   SetGlobalTeamConversationCreator :: GlobalTeamConversation -> UserId -> ConversationStore m ()
   GetConversationIdByGroupId :: GroupId -> ConversationStore m (Maybe (Qualified ConvId))
   GetConversations :: [ConvId] -> ConversationStore m [Conversation]

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -3861,8 +3861,7 @@ testOne2OneConversationRequest shouldBeLocal actor desired = do
     let req = UpsertOne2OneConversationRequest alice bob actor desired Nothing
     res <-
       iUpsertOne2OneConversation req
-        <!! statusCode
-          === const 200
+        <!! statusCode === const 200
     uuorConvId <$> responseJsonError res
 
   liftIO $ convId @?= expectedConvId

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -3837,7 +3837,8 @@ testOne2OneConversationRequest shouldBeLocal actor desired = do
     let req = UpsertOne2OneConversationRequest alice bob actor desired Nothing
     res <-
       iUpsertOne2OneConversation req
-        <!! statusCode === const 200
+        <!! statusCode
+          === const 200
     uuorConvId <$> responseJsonError res
 
   liftIO $ convId @?= expectedConvId

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2075,7 +2075,19 @@ postConvQualifiedFederationNotEnabled = do
 -- FUTUREWORK: figure out how to use functions in the TestM monad inside withSettingsOverrides and remove this duplication
 postConvHelper :: (MonadIO m, MonadHttp m) => (Request -> Request) -> UserId -> [Qualified UserId] -> m ResponseLBS
 postConvHelper g zusr newUsers = do
-  let conv = NewConv [] newUsers (checked "gossip") (Set.fromList []) Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolProteusTag Nothing
+  let conv =
+        NewConv
+          []
+          newUsers
+          (checked "gossip")
+          (Set.fromList [])
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+          roleNameWireAdmin
+          ProtocolProteusTag
+          Nothing
   post $ g . path "/conversations" . zUser zusr . zConn "conn" . zType "access" . json conv
 
 postSelfConvOk :: TestM ()
@@ -2104,7 +2116,19 @@ postConvO2OFailWithSelf :: TestM ()
 postConvO2OFailWithSelf = do
   g <- viewGalley
   alice <- randomUser
-  let inv = NewConv [alice] [] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolProteusTag Nothing
+  let inv =
+        NewConv
+          [alice]
+          []
+          Nothing
+          mempty
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+          roleNameWireAdmin
+          ProtocolProteusTag
+          Nothing
   post (g . path "/conversations/one2one" . zUser alice . zConn "conn" . zType "access" . json inv) !!! do
     const 403 === statusCode
     const (Just "invalid-op") === fmap label . responseJsonUnsafe

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -1150,3 +1150,5 @@ getConvAction tquery (SomeConversationAction tag action) =
     (SConversationAccessDataTag, _) -> Nothing
     (SConversationRemoveMembersTag, SConversationRemoveMembersTag) -> Just action
     (SConversationRemoveMembersTag, _) -> Nothing
+    (SConversationSelfInviteTag, SConversationSelfInviteTag) -> Just action
+    (SConversationSelfInviteTag, _) -> Nothing

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -2193,18 +2193,16 @@ testGetGlobalTeamConv setup = do
       expected =
         GlobalTeamConversation
           (qUntagged lconv)
-          ( GlobalTeamConversationMetadata
-              { gtcmCreator = Nothing,
-                gtcmAccess = [SelfInviteAccess],
-                gtcmName = "Global team conversation",
-                gtcmTeam = tid
-              }
-          )
           ( ConversationMLSData
               (convToGroupId lconv)
               (Epoch 0)
               MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
           )
+          Nothing
+          [SelfInviteAccess]
+          "Global team conversation"
+          tid
+
   let cm = Aeson.decode rs :: Maybe GlobalTeamConversation
   liftIO $ assertEqual "conversation metadata" cm (Just expected)
 

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -199,7 +199,8 @@ tests s =
           test s "Non member of team returns 403" testGetGlobalTeamConvNonMember,
           test s "Global team conversation is created on get if not present" (testGetGlobalTeamConv s),
           test s "Can't leave global team conversation" testGlobalTeamConversationLeave,
-          test s "Send message in global team conversation" testGlobalTeamConversationMessage
+          test s "Send message in global team conversation" testGlobalTeamConversationMessage,
+          test s "Listing convs includes global team conversation" testConvListIncludesGlobal
         ],
       testGroup
         "Self conversation"
@@ -2205,6 +2206,45 @@ testGetGlobalTeamConv setup = do
 
   let cm = Aeson.decode rs :: Maybe GlobalTeamConversation
   liftIO $ assertEqual "conversation metadata" cm (Just expected)
+
+testConvListIncludesGlobal :: TestM ()
+testConvListIncludesGlobal = do
+  aliceQ <- randomQualifiedUser
+  let alice = qUnqualified aliceQ
+  tid <- createBindingTeamInternal "sample-team" alice
+  team <- getTeam alice tid
+  assertQueue "create team" tActivate
+  liftIO $ assertEqual "alice" alice (team ^. teamCreator)
+  assertQueueEmpty
+
+  -- global team conv doesn't yet include user
+  let paginationOpts = GetPaginatedConversationIds Nothing (toRange (Proxy @5))
+  listConvIds alice paginationOpts !!! do
+    const 200 === statusCode
+    const (Just [globalTeamConv tid]) =/~= (rightToMaybe . (<$$>) qUnqualified . decodeQualifiedConvIdList)
+
+  -- add user to conv
+  runMLSTest $ do
+    alice1 <- createMLSClient aliceQ
+
+    let response = getGlobalTeamConv alice tid <!! const 200 === statusCode
+    Just rs <- responseBody <$> response
+    let (Just gtc) = Aeson.decode rs :: Maybe GlobalTeamConversation
+        gid = cnvmlsGroupId $ gtcMlsMetadata gtc
+
+    void $ uploadNewKeyPackage alice1
+
+    -- create mls group
+    createGroup alice1 gid
+    void $ createAddCommit alice1 [] >>= sendAndConsumeCommitBundle
+
+  -- Now we should have the user as part of that conversation also in the backend
+  listConvIds alice paginationOpts !!! do
+    const 200 === statusCode
+    const (Just [globalTeamConv tid]) =~= (rightToMaybe . (<$$>) qUnqualified . decodeQualifiedConvIdList)
+
+rightToMaybe :: Either a b -> Maybe b
+rightToMaybe = either (const Nothing) Just
 
 testGlobalTeamConversationMessage :: TestM ()
 testGlobalTeamConversationMessage = do

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wno-incomplete-uni-patterns -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 -- This file is part of the Wire Server implementation.
 --
@@ -45,7 +45,6 @@ import Data.Singletons
 import Data.String.Conversions
 import qualified Data.Text as T
 import Data.Time
-import Debug.Trace
 import Federator.MockServer hiding (withTempMockFederator)
 import Galley.Data.Conversation
 import Galley.Options

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -130,7 +130,7 @@ postCommitBundle ::
     MonadHttp m,
     HasGalley m
   ) =>
-  UserId ->
+  ClientIdentity ->
   ByteString ->
   m ResponseLBS
 postCommitBundle sender bundle = do
@@ -138,7 +138,8 @@ postCommitBundle sender bundle = do
   post
     ( galley
         . paths ["mls", "commit-bundles"]
-        . zUser sender
+        . zUser (ciUser sender)
+        . zClient (ciClient sender)
         . zConn "conn"
         . content "application/x-protobuf"
         . bytes bundle
@@ -641,13 +642,13 @@ createAddCommitWithKeyPackages qcid clientsAndKeyPackages = do
       { mlsNewMembers = Set.fromList (map fst clientsAndKeyPackages)
       }
 
-  welcome <- liftIO $ BS.readFile welcomeFile
+  welcome <- liftIO $ readWelcome welcomeFile
   pgs <- liftIO $ BS.readFile pgsFile
   pure $
     MessagePackage
       { mpSender = qcid,
         mpMessage = commit,
-        mpWelcome = Just welcome,
+        mpWelcome = welcome,
         mpPublicGroupState = Just pgs
       }
 
@@ -862,7 +863,7 @@ sendAndConsumeCommit mp = do
 
   pure events
 
-mkBundle :: MessagePackage -> Either Text CommitBundle
+mkBundle :: HasCallStack => MessagePackage -> Either Text CommitBundle
 mkBundle mp = do
   commitB <- decodeMLS' (mpMessage mp)
   welcomeB <- traverse decodeMLS' (mpWelcome mp)
@@ -872,7 +873,7 @@ mkBundle mp = do
     CommitBundle commitB welcomeB $
       GroupInfoBundle UnencryptedGroupInfo TreeFull pgsB
 
-createBundle :: MonadIO m => MessagePackage -> m ByteString
+createBundle :: (HasCallStack, MonadIO m) => MessagePackage -> m ByteString
 createBundle mp = do
   bundle <-
     either (liftIO . assertFailure . T.unpack) pure $
@@ -888,7 +889,7 @@ sendAndConsumeCommitBundle mp = do
   events <-
     fmap mmssEvents
       . responseJsonError
-      =<< postCommitBundle (ciUser (mpSender mp)) bundle
+      =<< postCommitBundle (mpSender mp) bundle
         <!! const 201 === statusCode
   consumeMessage mp
   traverse_ consumeWelcome (mpWelcome mp)

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -7,7 +7,6 @@
 -- Software Foundation, either version 3 of the License, or (at your option) any
 -- later version.
 --
-
 -- This program is distributed in the hope that it will be useful, but WITHOUT
 -- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 -- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
@@ -15,6 +14,9 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use head" #-}
 
 module API.Teams.Feature (tests) where
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1090,16 +1090,14 @@ getConv u c = do
 getGlobalTeamConv ::
   (MonadIO m, MonadHttp m, HasGalley m, HasCallStack) =>
   UserId ->
-  ClientId ->
   TeamId ->
   m ResponseLBS
-getGlobalTeamConv u cid tid = do
+getGlobalTeamConv u tid = do
   g <- viewGalley
   get $
     g
       . paths ["teams", toByteString' tid, "conversations", "global"]
       . zUser u
-      . zClient cid
       . zConn "conn"
       . zType "access"
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -617,7 +617,18 @@ createTeamConvAccessRaw u tid us name acc role mtimer convRole = do
   g <- viewGalley
   let tinfo = ConvTeamInfo tid
   let conv =
-        NewConv us [] (name >>= checked) (fromMaybe (Set.fromList []) acc) role (Just tinfo) mtimer Nothing (fromMaybe roleNameWireAdmin convRole) ProtocolProteusTag Nothing
+        NewConv
+          us
+          []
+          (name >>= checked)
+          (fromMaybe (Set.fromList []) acc)
+          role
+          (Just tinfo)
+          mtimer
+          Nothing
+          (fromMaybe roleNameWireAdmin convRole)
+          ProtocolProteusTag
+          Nothing
   post
     ( g
         . path "/conversations"
@@ -684,7 +695,18 @@ createOne2OneTeamConv :: UserId -> UserId -> Maybe Text -> TeamId -> TestM Respo
 createOne2OneTeamConv u1 u2 n tid = do
   g <- viewGalley
   let conv =
-        NewConv [u2] [] (n >>= checked) mempty Nothing (Just $ ConvTeamInfo tid) Nothing Nothing roleNameWireAdmin ProtocolProteusTag Nothing
+        NewConv
+          [u2]
+          []
+          (n >>= checked)
+          mempty
+          Nothing
+          (Just $ ConvTeamInfo tid)
+          Nothing
+          Nothing
+          roleNameWireAdmin
+          ProtocolProteusTag
+          Nothing
   post $ g . path "/conversations/one2one" . zUser u1 . zConn "conn" . zType "access" . json conv
 
 postConv ::
@@ -740,7 +762,19 @@ postConvWithRemoteUsers u n =
 postTeamConv :: TeamId -> UserId -> [UserId] -> Maybe Text -> [Access] -> Maybe (Set AccessRoleV2) -> Maybe Milliseconds -> TestM ResponseLBS
 postTeamConv tid u us name a r mtimer = do
   g <- viewGalley
-  let conv = NewConv us [] (name >>= checked) (Set.fromList a) r (Just (ConvTeamInfo tid)) mtimer Nothing roleNameWireAdmin ProtocolProteusTag Nothing
+  let conv =
+        NewConv
+          us
+          []
+          (name >>= checked)
+          (Set.fromList a)
+          r
+          (Just (ConvTeamInfo tid))
+          mtimer
+          Nothing
+          roleNameWireAdmin
+          ProtocolProteusTag
+          Nothing
   post $ g . path "/conversations" . zUser u . zConn "conn" . zType "access" . json conv
 
 deleteTeamConv :: (HasGalley m, MonadIO m, MonadHttp m) => TeamId -> ConvId -> UserId -> m ResponseLBS
@@ -777,7 +811,19 @@ postConvWithRole u members name access arole timer role =
 postConvWithReceipt :: UserId -> [UserId] -> Maybe Text -> [Access] -> Maybe (Set AccessRoleV2) -> Maybe Milliseconds -> ReceiptMode -> TestM ResponseLBS
 postConvWithReceipt u us name a r mtimer rcpt = do
   g <- viewGalley
-  let conv = NewConv us [] (name >>= checked) (Set.fromList a) r Nothing mtimer (Just rcpt) roleNameWireAdmin ProtocolProteusTag Nothing
+  let conv =
+        NewConv
+          us
+          []
+          (name >>= checked)
+          (Set.fromList a)
+          r
+          Nothing
+          mtimer
+          (Just rcpt)
+          roleNameWireAdmin
+          ProtocolProteusTag
+          Nothing
   post $ g . path "/conversations" . zUser u . zConn "conn" . zType "access" . json conv
 
 postSelfConv :: UserId -> TestM ResponseLBS
@@ -788,7 +834,19 @@ postSelfConv u = do
 postO2OConv :: UserId -> UserId -> Maybe Text -> TestM ResponseLBS
 postO2OConv u1 u2 n = do
   g <- viewGalley
-  let conv = NewConv [u2] [] (n >>= checked) mempty Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolProteusTag Nothing
+  let conv =
+        NewConv
+          [u2]
+          []
+          (n >>= checked)
+          mempty
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+          roleNameWireAdmin
+          ProtocolProteusTag
+          Nothing
   post $ g . path "/conversations/one2one" . zUser u1 . zConn "conn" . zType "access" . json conv
 
 postConnectConv :: UserId -> UserId -> Text -> Text -> Maybe Text -> TestM ResponseLBS

--- a/services/galley/test/unit/Test/Galley/Intra/User.hs
+++ b/services/galley/test/unit/Test/Galley/Intra/User.hs
@@ -20,7 +20,6 @@
 
 module Test.Galley.Intra.User where
 
--- import Debug.Trace (traceShow)
 import Galley.Intra.User (chunkify)
 import Imports
 import Test.QuickCheck

--- a/tools/db/migrate-sso-feature-flag/src/Work.hs
+++ b/tools/db/migrate-sso-feature-flag/src/Work.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# OPTIONS_GHC -Wno-orphans -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- This file is part of the Wire Server implementation.
 --
@@ -28,12 +28,10 @@ import Data.Conduit
 import Data.Conduit.Internal (zipSources)
 import qualified Data.Conduit.List as C
 import Data.Id
-import Data.Misc
 import Galley.Cassandra.Instances ()
 import Imports
 import System.Logger (Logger)
 import qualified System.Logger as Log
-import UnliftIO.Async (pooledMapConcurrentlyN)
 import Wire.API.Team.Feature
 import Wire.API.User
 

--- a/tools/db/move-team/src/Work.hs
+++ b/tools/db/move-team/src/Work.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# OPTIONS_GHC -Wno-orphans -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- This file is part of the Wire Server implementation.
 --


### PR DESCRIPTION
This should cover [FS-927](https://wearezeta.atlassian.net/browse/FS-927), as the endpoint has been added.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
