### PR TITLE
Fix bug: clients without prekeys are not deleted competely

### DIFF
--- a/changelog.d/3-bug-fixes/pr-2758
+++ b/changelog.d/3-bug-fixes/pr-2758
@@ -1,0 +1,1 @@
+Clients without any prekeys are not deleted completely

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -32,15 +32,17 @@ import Brig.Effects.UserPendingActivationStore (UserPendingActivationStore)
 import qualified Data.Swagger.Build.Api as Doc
 import Network.Wai.Routing (Routes)
 import Polysemy
+import Wire.Sem.Concurrency
 
 sitemap ::
   forall r p.
   Members
-    '[ CodeStore,
-       PasswordResetStore,
+    '[ BlacklistPhonePrefixStore,
        BlacklistStore,
-       BlacklistPhonePrefixStore,
        GalleyProvider,
+       CodeStore,
+       Concurrency 'Unsafe,
+       PasswordResetStore,
        UserPendingActivationStore p
      ]
     r =>

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -389,14 +389,19 @@ noPrekeys ::
   ClientId ->
   (AppT r) ()
 noPrekeys u c = do
-  Log.info $
-    field "user" (toByteString u)
-      ~~ field "client" (toByteString c)
-      ~~ msg (val "No prekey found. Ensuring client does not exist.")
-  clientM <- wrapClient $ Data.lookupClient u c
-  case clientM of
-    Nothing -> error "fun"
-    Just client -> execDelete u Nothing client
+  mclient <- wrapClient $ Data.lookupClient u c
+  case mclient of
+    Nothing -> do
+      Log.warn $
+        field "user" (toByteString u)
+          ~~ field "client" (toByteString c)
+          ~~ msg (val "No prekey found. Client is missing, so doing nothing.")
+    Just client -> do
+      Log.warn $
+        field "user" (toByteString u)
+          ~~ field "client" (toByteString c)
+          ~~ msg (val "No prekey found. Deleting client.")
+      execDelete u Nothing client
 
 pubClient :: Client -> PubClient
 pubClient c =

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -138,7 +138,7 @@ getUsersByIds _ uids =
 
 claimPrekey :: Domain -> (UserId, ClientId) -> (Handler r) (Maybe ClientPrekey)
 claimPrekey _ (user, client) = do
-  wrapHttpClientE (API.claimLocalPrekey LegalholdPlusFederationNotImplemented user client) !>> clientError
+  API.claimLocalPrekey LegalholdPlusFederationNotImplemented user client !>> clientError
 
 claimPrekeyBundle :: Domain -> UserId -> (Handler r) PrekeyBundle
 claimPrekeyBundle _ user =

--- a/services/brig/src/Brig/API/MLS/KeyPackages.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages.hs
@@ -76,10 +76,9 @@ claimLocalKeyPackages qusr skipOwn target = do
   foldQualified
     target
     ( \lusr ->
-        wrapHttpClientE $
-          guardLegalhold
-            (ProtectedUser (tUnqualified lusr))
-            (mkUserClients [(tUnqualified target, clients)])
+        guardLegalhold
+          (ProtectedUser (tUnqualified lusr))
+          (mkUserClients [(tUnqualified target, clients)])
     )
     (\_ -> pure ())
     qusr

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -394,7 +394,7 @@ getPrekeyUnqualifiedH zusr user client = do
 
 getPrekeyH :: UserId -> Qualified UserId -> ClientId -> (Handler r) Public.ClientPrekey
 getPrekeyH zusr (Qualified user domain) client = do
-  mPrekey <- wrapHttpClientE $ API.claimPrekey (ProtectedUser zusr) user domain client !>> clientError
+  mPrekey <- API.claimPrekey (ProtectedUser zusr) user domain client !>> clientError
   ifNothing (notFound "prekey not found") mPrekey
 
 getPrekeyBundleUnqualifiedH :: UserId -> UserId -> (Handler r) Public.PrekeyBundle

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -484,9 +484,6 @@ instance MonadReader Env (AppT r) where
 liftSem :: Sem r a -> AppT r a
 liftSem sem = AppT $ lift sem
 
-lowerAppT :: Member (Final IO) r => Env -> AppT r a -> Sem r a
-lowerAppT env = flip runReaderT env . unAppT
-
 instance MonadIO m => MonadLogger (ReaderT Env m) where
   log l m = do
     g <- view applog

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -484,6 +484,9 @@ instance MonadReader Env (AppT r) where
 liftSem :: Sem r a -> AppT r a
 liftSem sem = AppT $ lift sem
 
+lowerAppT :: Member (Final IO) r => Env -> AppT r a -> Sem r a
+lowerAppT env = flip runReaderT env . unAppT
+
 instance MonadIO m => MonadLogger (ReaderT Env m) where
   log l m = do
     g <- view applog

--- a/services/brig/src/Brig/CanonicalInterpreter.hs
+++ b/services/brig/src/Brig/CanonicalInterpreter.hs
@@ -27,8 +27,8 @@ import Imports
 import Polysemy (Embed, Final, embedToFinal, runFinal)
 import Polysemy.Error (Error, mapError, runError)
 import Polysemy.TinyLog (TinyLog)
-import Wire.Sem.Concurrency (Concurrency, ConcurrencySafety (Unsafe))
-import Wire.Sem.Concurrency.IO (unsafelyPerformConcurrency)
+import Wire.Sem.Concurrency
+import Wire.Sem.Concurrency.IO
 import Wire.Sem.Logger.TinyLog (loggerToTinyLog)
 import Wire.Sem.Now (Now)
 import Wire.Sem.Now.IO (nowToIOAction)

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -986,17 +986,11 @@ getTeamContacts u = do
         . expect [status200, status404]
 
 guardLegalhold ::
-  ( MonadReader Env m,
-    MonadIO m,
-    MonadMask m,
-    MonadHttp m,
-    HasRequestId m
-  ) =>
   LegalholdProtectee ->
   UserClients ->
-  ExceptT ClientError m ()
+  ExceptT ClientError (AppT r) ()
 guardLegalhold protectee userClients = do
-  res <- lift $ galleyRequest PUT req
+  res <- lift . wrapHttp $ galleyRequest PUT req
   case Bilge.statusCode res of
     200 -> pure ()
     403 -> throwE ClientMissingLegalholdConsent

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -87,6 +87,7 @@ tests _cl _at opts p db b c g =
       test p "post /users/list-prekeys" $ testMultiUserGetPrekeysQualified b opts,
       test p "post /users/list-clients - 200" $ testListClientsBulk opts b,
       test p "post /users/list-clients/v2 - 200" $ testListClientsBulkV2 opts b,
+      test p "post /users/list-prekeys - clients without prekeys" $ testClientsWithoutPrekeys b c db opts,
       test p "post /clients - 201 (pwd)" $ testAddGetClient def {addWithPassword = True} b c,
       test p "post /clients - 201 (no pwd)" $ testAddGetClient def {addWithPassword = False} b c,
       testGroup
@@ -398,6 +399,61 @@ testListClientsBulk opts brig = do
     !!! do
       const 200 === statusCode
       const (Just expectedResponse) === responseJsonMaybe
+
+testClientsWithoutPrekeys :: Brig -> Cannon -> DB.ClientState -> Opt.Opts -> Http ()
+testClientsWithoutPrekeys brig cannon db opts = do
+  uid1 <- userId <$> randomUser brig
+  let (pk11, lk11) = (somePrekeys !! 0, someLastPrekeys !! 0)
+  c11 <- responseJsonError =<< addClient brig uid1 (defNewClient PermanentClientType [pk11] lk11)
+
+  getClient brig uid1 (clientId c11) !!! do
+    const 200 === statusCode
+
+  -- Simulating loss of all prekeys (due e.g. DB problems, business logic
+  -- prevents this from happening)
+  let removeClientKeys :: DB.PrepQuery DB.W (UserId, ClientId) ()
+      removeClientKeys = "DELETE FROM prekeys where user = ? and client = ?"
+  liftIO $
+    DB.runClient db $ DB.write removeClientKeys (DB.params DB.LocalQuorum (uid1, clientId c11))
+
+  uid2 <- userId <$> randomUser brig
+
+  let domain = opts ^. Opt.optionSettings & Opt.setFederationDomain
+
+  let userClients =
+        QualifiedUserClients $
+          Map.singleton domain $
+            Map.singleton uid1 $
+              Set.fromList [clientId c11]
+
+  let expectedUserClientMap =
+        mkQualifiedUserClientPrekeyMap $
+          Map.singleton domain $
+            mkUserClientPrekeyMap $
+              Map.singleton uid1 $
+                Map.singleton (clientId c11) Nothing
+
+  WS.bracketR cannon uid1 $ \ws -> do
+    post
+      ( brig
+          . paths ["users", "list-prekeys"]
+          . contentJson
+          . body (RequestBodyLBS $ encode userClients)
+          . zUser uid2
+      )
+      !!! do
+        const 200 === statusCode
+        const (Right $ expectedUserClientMap) === responseJsonEither
+
+    getClient brig uid1 (clientId c11) !!! do
+      const 404 === statusCode
+
+    liftIO . WS.assertMatch (5 # Second) ws $ \n -> do
+      let ob = Object $ List1.head (ntfPayload n)
+      ob ^? key "type" . _String
+        @?= Just "user.client-remove"
+      fmap ClientId (ob ^? key "client" . key "id" . _String)
+        @?= Just (clientId c11)
 
 testListClientsBulkV2 :: Opt.Opts -> Brig -> Http ()
 testListClientsBulkV2 opts brig = do

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -38,6 +38,7 @@ import Data.Aeson hiding (json)
 import Data.Aeson.Lens
 import Data.ByteString.Conversion
 import Data.Default
+import Data.Domain (Domain (..))
 import Data.Id hiding (client)
 import qualified Data.List1 as List1
 import qualified Data.Map as Map
@@ -405,12 +406,11 @@ testClientsWithoutPrekeys brig cannon db opts = do
   uid1 <- userId <$> randomUser brig
   let (pk11, lk11) = (somePrekeys !! 0, someLastPrekeys !! 0)
   c11 <- responseJsonError =<< addClient brig uid1 (defNewClient PermanentClientType [pk11] lk11)
+  let (pk12, lk12) = (somePrekeys !! 1, someLastPrekeys !! 1)
+  c12 <- responseJsonError =<< addClient brig uid1 (defNewClient PermanentClientType [pk12] lk12)
 
-  getClient brig uid1 (clientId c11) !!! do
-    const 200 === statusCode
-
-  -- Simulating loss of all prekeys (due e.g. DB problems, business logic
-  -- prevents this from happening)
+  -- Simulating loss of all prekeys from c11 (due e.g. DB problems, business
+  -- logic prevents this from happening)
   let removeClientKeys :: DB.PrepQuery DB.W (UserId, ClientId) ()
       removeClientKeys = "DELETE FROM prekeys where user = ? and client = ?"
   liftIO $
@@ -424,16 +424,12 @@ testClientsWithoutPrekeys brig cannon db opts = do
         QualifiedUserClients $
           Map.singleton domain $
             Map.singleton uid1 $
-              Set.fromList [clientId c11]
-
-  let expectedUserClientMap =
-        mkQualifiedUserClientPrekeyMap $
-          Map.singleton domain $
-            mkUserClientPrekeyMap $
-              Map.singleton uid1 $
-                Map.singleton (clientId c11) Nothing
+              Set.fromList [clientId c11, clientId c12]
 
   WS.bracketR cannon uid1 $ \ws -> do
+    getClient brig uid1 (clientId c11) !!! do
+      const 200 === statusCode
+
     post
       ( brig
           . paths ["users", "list-prekeys"]
@@ -443,7 +439,17 @@ testClientsWithoutPrekeys brig cannon db opts = do
       )
       !!! do
         const 200 === statusCode
-        const (Right $ expectedUserClientMap) === responseJsonEither
+        const
+          ( Right $
+              ( expectedClientMap
+                  domain
+                  uid1
+                  [ (clientId c11, Nothing),
+                    (clientId c12, Just pk12)
+                  ]
+              )
+          )
+          === responseJsonEither
 
     getClient brig uid1 (clientId c11) !!! do
       const 404 === statusCode
@@ -454,6 +460,34 @@ testClientsWithoutPrekeys brig cannon db opts = do
         @?= Just "user.client-remove"
       fmap ClientId (ob ^? key "client" . key "id" . _String)
         @?= Just (clientId c11)
+
+  post
+    ( brig
+        . paths ["users", "list-prekeys"]
+        . contentJson
+        . body (RequestBodyLBS $ encode userClients)
+        . zUser uid2
+    )
+    !!! do
+      const 200 === statusCode
+      const
+        ( Right $
+            expectedClientMap
+              domain
+              uid1
+              [ (clientId c11, Nothing),
+                (clientId c12, Just (unpackLastPrekey lk12))
+              ]
+        )
+        === responseJsonEither
+  where
+    expectedClientMap :: Domain -> UserId -> [(ClientId, Maybe Prekey)] -> QualifiedUserClientPrekeyMap
+    expectedClientMap domain u xs =
+      mkQualifiedUserClientPrekeyMap $
+        Map.singleton domain $
+          mkUserClientPrekeyMap $
+            Map.singleton u $
+              Map.fromList xs
 
 testListClientsBulkV2 :: Opt.Opts -> Brig -> Http ()
 testListClientsBulkV2 opts brig = do


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-966

This PR changes the behaviour when clients without prekeys are detected during prekey claiming.

Without this PR: a client without any prekeys is deleted from other services synchronously, but _not_ from brig.
With this PR: a client without any prekeys is deleted
1) synchronously from brig: This leads to the client not be listed anymore. Without this change the client's prekeys are attempted to be fetched over and over again also triggering the deletion attempts over and over again.
2) asynchronously from all other services: This should improve response times when claming prekeys. The removal of clients from the galley service can be particularly slow for MLS clients. with this change it won't block prekey claiming

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
