### PR TITLE
Refactor Scim.Scim.UserSpec tests to use composable pieces

### DIFF
--- a/changelog.d/5-internal/cleanup-scim-tests
+++ b/changelog.d/5-internal/cleanup-scim-tests
@@ -1,0 +1,1 @@
+Refactor some internal Scim user tests

--- a/services/spar/test/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test/Test/Spar/Scim/UserSpec.hs
@@ -133,8 +133,8 @@ mockBrig lookup_user delete_response = interpret $ \case
 withActiveUser :: UserAccount -> UserId -> Maybe UserAccount
 withActiveUser acc uid =
   if uid == (userId . accountUser) acc
-      then Just acc
-      else Nothing
+    then Just acc
+    else Nothing
 
 someActiveUser :: ScimTokenInfo -> IO UserAccount
 someActiveUser tokenInfo = do


### PR DESCRIPTION
This PR is a minor cleanup of some of the tests from #2637, which are delightful examples of writing tests against Polysemy. It tests the same things, but in a slightly more reusable way, notably:

- Factoring the mock brig interpreters into a single, parameterized version
- Adding a little combinator `withActiveUser` for building those parameters
- Introducing a combinator `ignoringState` to dramatically reduce the typing burden

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
