### PR TITLE
Polysemy: intersperse combinator

### DIFF
--- a/changelog.d/5-internal/polysemy-intersperse
+++ b/changelog.d/5-internal/polysemy-intersperse
@@ -1,0 +1,1 @@
+Implemented a new intersperse combinator for Polysemy

--- a/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
+++ b/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
@@ -12,6 +12,7 @@ build-type:    Simple
 
 library
   exposed-modules:
+    Polysemy.Testing
     Polysemy.TinyLog
     Wire.Sem.Concurrency
     Wire.Sem.Concurrency.IO
@@ -92,5 +93,74 @@ library
     , unliftio
     , uuid
     , wire-api
+
+  default-language:   Haskell2010
+
+
+test-suite spec
+  type:               exitcode-stdio-1.0
+  main-is:            Spec.hs
+  other-modules:
+    Paths_polysemy_wire_zoo
+    Test.IntersperseSpec
+
+  hs-source-dirs:     test
+  default-extensions:
+    NoImplicitPrelude
+    AllowAmbiguousTypes
+    BangPatterns
+    ConstraintKinds
+    DataKinds
+    DefaultSignatures
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    EmptyCase
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    InstanceSigs
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    MultiWayIf
+    NamedFieldPuns
+    OverloadedStrings
+    PackageImports
+    PatternSynonyms
+    PolyKinds
+    QuasiQuotes
+    RankNTypes
+    ScopedTypeVariables
+    StandaloneDeriving
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeFamilyDependencies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns
+
+  ghc-options:
+    -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path -j
+    -Wno-redundant-constraints -Werror -threaded -rtsopts
+    -with-rtsopts=-N
+
+  build-tool-depends: hspec-discover:hspec-discover
+  build-depends:
+      base
+    , containers
+    , hspec
+    , imports
+    , polysemy
+    , polysemy-check             >=0.9
+    , polysemy-plugin
+    , polysemy-wire-zoo
+    , unliftio
 
   default-language:   Haskell2010

--- a/libs/polysemy-wire-zoo/src/Polysemy/Testing.hs
+++ b/libs/polysemy-wire-zoo/src/Polysemy/Testing.hs
@@ -1,0 +1,17 @@
+module Polysemy.Testing where
+
+import Polysemy
+import Polysemy.Internal
+import Imports
+
+-- | @'intersperse' m a@ runs @m@ before every action in @a@. In this way, it's
+-- like injecting logic into each bind. Useful for polling asynchronous results
+-- when testing IO.
+intersperse
+  :: Sem r () ->
+  Sem r a ->
+  Sem r a
+intersperse a (Sem m) =
+  Sem $ \k -> m $ \u -> do
+    usingSem k a
+    k u

--- a/libs/polysemy-wire-zoo/src/Polysemy/Testing.hs
+++ b/libs/polysemy-wire-zoo/src/Polysemy/Testing.hs
@@ -1,14 +1,14 @@
 module Polysemy.Testing where
 
+import Imports
 import Polysemy
 import Polysemy.Internal
-import Imports
 
 -- | @'intersperse' m a@ runs @m@ before every action in @a@. In this way, it's
 -- like injecting logic into each bind. Useful for polling asynchronous results
 -- when testing IO.
-intersperse
-  :: Sem r () ->
+intersperse ::
+  Sem r () ->
   Sem r a ->
   Sem r a
 intersperse a (Sem m) =

--- a/libs/polysemy-wire-zoo/test/Spec.hs
+++ b/libs/polysemy-wire-zoo/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/libs/polysemy-wire-zoo/test/Test/IntersperseSpec.hs
+++ b/libs/polysemy-wire-zoo/test/Test/IntersperseSpec.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE NumDecimals                 #-}
+{-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}
+
+module Test.IntersperseSpec where
+
+import qualified Data.Set as S
+import Imports hiding (intersperse)
+import Polysemy
+import Polysemy.Testing
+import Polysemy.Trace
+import UnliftIO (async)
+import Test.Hspec
+
+-- | This test spins up an async thread that communicates with the main
+-- polysemy monad via an 'MVar'. We then use 'intersperse' to inject polling
+-- logic between each bind in order to read from the 'MVar'.
+spec :: Spec
+spec = do
+  it "should poll from async-written channel" $ do
+    result <- liftIO test
+    let desired = S.fromList $ mconcat
+          [ fmap ("loaded: " <>) ["hello", "world", "last"]
+          , fmap (show @Int) [1..4]
+          , ["finished"]
+          ]
+    result `shouldBe` desired
+
+
+pull :: (Member (Embed IO) r, Member Trace r) => MVar String -> Sem r ()
+pull chan = do
+  embed (tryTakeMVar chan) >>= \case
+    Nothing -> pure ()
+    Just s -> do
+      trace $ "loaded: " <> s
+      pull chan
+
+
+push :: MVar String -> IO ()
+push chan = do
+  putMVar chan "hello"
+  putMVar chan "world"
+  putMVar chan "last"
+
+
+
+test :: IO (Set String)
+test = fmap S.fromList $ do
+  chan <- newEmptyMVar @_ @String
+  _ <- async $ push chan
+  fmap fst $ runM $
+    runTraceList $
+      intersperse (pull chan) $ do
+        for_ [1 .. 4] $ \i -> do
+          trace $ show @Int i
+          liftIO $ threadDelay 1e5
+        trace "finished"
+

--- a/libs/polysemy-wire-zoo/test/Test/IntersperseSpec.hs
+++ b/libs/polysemy-wire-zoo/test/Test/IntersperseSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NumDecimals                 #-}
+{-# LANGUAGE NumDecimals #-}
 {-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}
 
 module Test.IntersperseSpec where
@@ -8,8 +8,8 @@ import Imports hiding (intersperse)
 import Polysemy
 import Polysemy.Testing
 import Polysemy.Trace
-import UnliftIO (async)
 import Test.Hspec
+import UnliftIO (async)
 
 -- | This test spins up an async thread that communicates with the main
 -- polysemy monad via an 'MVar'. We then use 'intersperse' to inject polling
@@ -18,13 +18,14 @@ spec :: Spec
 spec = do
   it "should poll from async-written channel" $ do
     result <- liftIO test
-    let desired = S.fromList $ mconcat
-          [ fmap ("loaded: " <>) ["hello", "world", "last"]
-          , fmap (show @Int) [1..4]
-          , ["finished"]
-          ]
+    let desired =
+          S.fromList $
+            mconcat
+              [ fmap ("loaded: " <>) ["hello", "world", "last"],
+                fmap (show @Int) [1 .. 4],
+                ["finished"]
+              ]
     result `shouldBe` desired
-
 
 pull :: (Member (Embed IO) r, Member Trace r) => MVar String -> Sem r ()
 pull chan = do
@@ -34,24 +35,21 @@ pull chan = do
       trace $ "loaded: " <> s
       pull chan
 
-
 push :: MVar String -> IO ()
 push chan = do
   putMVar chan "hello"
   putMVar chan "world"
   putMVar chan "last"
 
-
-
 test :: IO (Set String)
 test = fmap S.fromList $ do
   chan <- newEmptyMVar @_ @String
   _ <- async $ push chan
-  fmap fst $ runM $
-    runTraceList $
-      intersperse (pull chan) $ do
-        for_ [1 .. 4] $ \i -> do
-          trace $ show @Int i
-          liftIO $ threadDelay 1e5
-        trace "finished"
-
+  fmap fst $
+    runM $
+      runTraceList $
+        intersperse (pull chan) $ do
+          for_ [1 .. 4] $ \i -> do
+            trace $ show @Int i
+            liftIO $ threadDelay 1e5
+          trace "finished"

--- a/libs/polysemy-wire-zoo/test/Test/IntersperseSpec.hs
+++ b/libs/polysemy-wire-zoo/test/Test/IntersperseSpec.hs
@@ -6,7 +6,7 @@ module Test.IntersperseSpec where
 import qualified Data.Set as S
 import Imports hiding (intersperse)
 import Polysemy
-import Polysemy.Output (output, runOutputList)
+import Polysemy.Output (output)
 import Polysemy.State (evalState, get, modify)
 import Polysemy.Testing
 import Polysemy.Trace

--- a/libs/polysemy-wire-zoo/test/Test/IntersperseSpec.hs
+++ b/libs/polysemy-wire-zoo/test/Test/IntersperseSpec.hs
@@ -13,6 +13,7 @@ import Polysemy.Trace
 import Test.Hspec
 import UnliftIO (async)
 
+{-# ANN spec ("HLint: ignore Redundant pure" :: String) #-}
 spec :: Spec
 spec = do
   -- This test spins up an async thread that communicates with the main


### PR DESCRIPTION
This PR implements a new polysemy combinator `intersperse` which allows for injecting logic between every handled action in the effect stack. It also adds a test-suite to `polysemy-wire-zoo`, with a new test showing how to use `intersperse` to poll from an `async` thread. 

The short-term use case for this is to use it to test brig's STOMP client, where we can `intersperse` the listener callback, which otherwise gets in the way of the removing `IO` effort.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
