### PR TITLE
Remove deprecated spar table in cassandra.

### DIFF
--- a/changelog.d/5-internal/cleanup-cassandra-schema
+++ b/changelog.d/5-internal/cleanup-cassandra-schema
@@ -1,0 +1,3 @@
+Remove deprecated table for storing scim external_ids.
+
+Data has been migrated away in [release 2021-03-21](https://github.com/wireapp/wire-server/releases/tag/v2021-03-21) (see `/services/spar/migrate-data/src/Spar/DataMigration/V1_ExternalIds.hs`); last time the deprecated table has has been touched in production is before upgrade to [release 2021-03-23 (Chart Release 2.104.0)](https://github.com/wireapp/wire-server/releases/tag/v2021-03-23).

--- a/services/spar/schema/src/Run.hs
+++ b/services/spar/schema/src/Run.hs
@@ -31,6 +31,7 @@ import qualified V13
 import qualified V14
 import qualified V15
 import qualified V16
+import qualified V17
 import qualified V2
 import qualified V3
 import qualified V4
@@ -65,7 +66,8 @@ main = do
       V13.migration,
       V14.migration,
       V15.migration,
-      V16.migration
+      V16.migration,
+      V17.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Spar.Data
 

--- a/services/spar/schema/src/V17.hs
+++ b/services/spar/schema/src/V17.hs
@@ -1,0 +1,33 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V17
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration = Migration 17 "Remove table `scim_external_ids` (from db migration V10, deprecated in favor of `scim_external`, emptied in `/services/spar/migrate-data/src/Spar/DataMigration/V1_ExternalIds.hs`)" $ do
+  void $
+    schema'
+      [r|
+        DROP TABLE if exists scim_external_ids;
+      |]

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -611,6 +611,7 @@ executable spar-schema
     V14
     V15
     V16
+    V17
     V2
     V3
     V4

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -48,7 +48,7 @@ import Wire.API.User.Saml
 
 -- | A lower bound: @schemaVersion <= whatWeFoundOnCassandra@, not @==@.
 schemaVersion :: Int32
-schemaVersion = 16
+schemaVersion = 17
 
 ----------------------------------------------------------------------
 -- helpers


### PR DESCRIPTION
## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
