### PR TITLE
nix: Use pkgs.buildEnv for development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -19,6 +19,7 @@ fi
 
 PATH_add "./.env/bin"
 path_add "PKG_CONFIG_PATH" "./.env/lib/pkgconfig"
+path_add "LIBRARY_PATH" "./.env/lib"
 
 # source .profile from `$env`. This sets NIX_PATH to pkgs defined in
 # ./nix/default.nix. Tis is useful for nix tooling that runs inside this direnv,

--- a/.envrc
+++ b/.envrc
@@ -24,7 +24,6 @@ path_add "LIBRARY_PATH" "./.env/lib"
 # source .profile from `$env`. This sets NIX_PATH to pkgs defined in
 # ./nix/default.nix. Tis is useful for nix tooling that runs inside this direnv,
 # e.g. "nix-shell -p foo" will get "foo" for pkgs defined in ./nix/default.nix
-# [[ -f "${env_dir}/profile-env/.profile" ]] && source_env "${env_dir}/profile-env/.profile"
 [[ -f "./.env/.profile" ]] && source_env "./.env/.profile"
 
 # allow local .envrc overrides

--- a/.envrc
+++ b/.envrc
@@ -9,29 +9,22 @@ store_paths=$(find . -name default.nix  | grep -v '^./nix' | grep -v '^./dist-ne
 layout_dir=$(direnv_layout_dir)
 env_dir=./.env
 
-# The env_dir used to be a symlink to env in nix store, if it exists, delete it.
-[[ ! -L "$env_dir" ]] || rm -f "$env_dir"
-
 [[ -d "$layout_dir" ]] || mkdir -p "$layout_dir"
 
 if [[ ! -d "$env_dir" || ! -f "$layout_dir/nix-rebuild" || "$store_paths" != $(< "$layout_dir/nix-rebuild" ) ]]; then
-
-  [[ -d "$env_dir" ]] || mkdir -p "$env_dir"
-
-  # this builds "wireServer.devShell" defined in ./nix/default.nix and outputs to ./.env
-  nix-shell ./nix -A wireServer.devShell --run 'direnv dump bash' > "${env_dir}/dev-shell.sh"
-
-  nix-build ./nix -A profileEnv --out-link "${env_dir}/profile-env"
+  nix-build ./nix -A wireServer.devEnv --out-link ./.env
 
   echo "$store_paths" > "$layout_dir/nix-rebuild"
 fi
 
-source_env "${env_dir}/dev-shell.sh"
+PATH_add "./.env/bin"
+path_add "PKG_CONFIG_PATH" "./.env/lib/pkgconfig"
 
 # source .profile from `$env`. This sets NIX_PATH to pkgs defined in
 # ./nix/default.nix. Tis is useful for nix tooling that runs inside this direnv,
 # e.g. "nix-shell -p foo" will get "foo" for pkgs defined in ./nix/default.nix
-[[ -f "${env_dir}/profile-env/.profile" ]] && source_env "${env_dir}/profile-env/.profile"
+# [[ -f "${env_dir}/profile-env/.profile" ]] && source_env "${env_dir}/profile-env/.profile"
+[[ -f "./.env/.profile" ]] && source_env "./.env/.profile"
 
 # allow local .envrc overrides
 [[ -f .envrc.local ]] && source_env .envrc.local

--- a/changelog.d/0-release-notes/nix-builds
+++ b/changelog.d/0-release-notes/nix-builds
@@ -1,1 +1,1 @@
-Build docker images using nix derivations instead of Dockerfiles (#2331, #2771, #2772, #2775)
+Build docker images using nix derivations instead of Dockerfiles (#2331, #2771, #2772, #2775, #2776)


### PR DESCRIPTION
Using haskellPacakges.shellFor directly forced us to use nix-shell which exports too many environment variables. These environment variables cause a lot of problems, specially for people not using NixOS.

This change reads buildInputs and nativeBuildInputs for the derivation produced by haskellPacakges.shellFor and adds it to paths of pkgs.buildEnv. To allow cabal to find C dependencies, we also have to export PKG_CONFIG_PATH.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
