### PR TITLE
Add nginz to nix develop environment

### DIFF
--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -318,6 +318,7 @@ in {
       pkgs.rsync
       pkgs.wget
       pkgs.yq
+      pkgs.nginz
 
       pkgs.cabal-install
       pkgs.haskellPackages.cabal-plan


### PR DESCRIPTION
If you use `INTEGRATION_USE_NGINZ=1` then it will attempt to build `nginz`. Currently `nginz` is not cached causing rebuilds, which may take long time.

## Checklist

 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
