### PR TITLE
upload docker images: retry, take 1

### DIFF
--- a/hack/bin/upload-image.sh
+++ b/hack/bin/upload-image.sh
@@ -42,4 +42,4 @@ image_file="$tmp_link_store/image"
 repo=$(skopeo list-tags "docker-archive://$image_file" | jq -r '.Tags[0] | split(":") | .[0]')
 printf "*** Uploading $image_file to %s:%s" "$repo" "$DOCKER_TAG"
 # shellcheck disable=SC2086
-skopeo --insecure-policy copy $credsArgs "docker-archive://$image_file" "docker://$repo:$DOCKER_TAG"
+skopeo --retry-times 5 --insecure-policy copy $credsArgs "docker-archive://$image_file" "docker://$repo:$DOCKER_TAG"


### PR DESCRIPTION
To work around:

```
*** Uploading /tmp/tmp.kIKRERgZ1H/image to quay.io/wire/spar-integration:4.25.22Getting image source signatures

Copying blob f4f33343fcb5 skipped: already exists

Copying blob a3ab88edf03d skipped: already exists

Copying blob 9360a695c022 skipped: already exists

Copying blob 62d7b43f88a6 skipped: already exists

Copying blob 134eff2df9f9 skipped: already exists

Copying blob 8834895fc941 skipped: already exists

Copying blob 52a0756d3ab1 done  ======================>----------] 30.0MiB / 40.3MiB

Copying blob fa04d4e808c5 done  ---------------------------------] 8.0b / 190.0KiB

Copying blob 6c806be006f4 skipped: already exists

FATA[0004] trying to reuse blob sha256:95218c34e1598cf423f77062d98259bedcc19c9b8f4d937d0905895ee7b0242e at destination: too many requests to registry

make: *** [Makefile:242: upload-images] Error 1

make: Leaving directory '/tmp/build/80754af9/wire-server'
```