### PR TITLE
Stop rate-limiting asset-signed-url requests

### DIFF
--- a/changelog.d/1-api-changes/rate-limit-asset-dl
+++ b/changelog.d/1-api-changes/rate-limit-asset-dl
@@ -1,0 +1,1 @@
+Stop rate-limiting asset-signed-url requests on /assets/.*

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -105,6 +105,12 @@ nginx_conf:
       - all
       max_body_size: "0"
       disable_request_buffering: true
+    - path: /assets/(.*)
+      envs:
+      - all
+      max_body_size: "0"
+      disable_request_buffering: true
+      unlimited_requests_endpoint: true
     - path: /assets
       envs:
       - all


### PR DESCRIPTION
After not using the wire client for some time, it can easily happen that many conversations have many assets that should be downloaded. We may wish to be more lenient on asset download (well, getting signed URLs to download assets) requests. See https://wearezeta.atlassian.net/browse/SQCORE-1372 and https://wearezeta.atlassian.net/browse/SQSERVICES-1763

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
