### PR TITLE
fix copyright date in the docs

### DIFF
--- a/changelog.d/4-docs/copyright-date
+++ b/changelog.d/4-docs/copyright-date
@@ -1,0 +1,1 @@
+Fix copyright date on docs.wire.com

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -14,14 +14,22 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import datetime
-
+import requests
 
 # -- Project information -----------------------------------------------------
 
 project = 'Wire'
-today_date = datetime.date.today()
-copyright = f'{today_date.year}, Wire'
 author = 'Wire Swiss GmbH'
+# Since nix has an old timestamp it operates under for reproducability, get
+# current date from the internet.
+try:
+    r = requests.get("https://worldtimeapi.org/api/timezone/Europe/Berlin").json()
+    today_year = r['datetime'][:4]
+    # the first commit of wire-docs was in 2019.
+    copyright = f'2019 - {today_year}, ' + author
+except:
+    print("Error in getting online date, fallback to potentially out-of-date year")
+    copyright = f'2019 - 2022, Wire Swiss GmbH'
 version = '0.0.4'
 # the 'release' variable is used in latex-based PDF generation
 release = version


### PR DESCRIPTION
Change this:
![docs-before](https://user-images.githubusercontent.com/2112744/197505976-03dc4fd1-0952-4452-a6d3-3fd03bd21828.png)

into this:
![docs-after](https://user-images.githubusercontent.com/2112744/197506217-6f7b0013-7848-4bad-8929-2d4667acc412.png)


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
