### PR TITLE
bump nginx-module-vts from v0.1.15 to v0.2.1

### DIFF
--- a/changelog.d/5-internal/bump-nginx-module-vts
+++ b/changelog.d/5-internal/bump-nginx-module-vts
@@ -1,0 +1,1 @@
+bump nginx-module-vts from v0.1.15 to v0.2.1


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SER-218

upstream changelog: https://github.com/vozlt/nginx-module-vts/blob/v0.2.1/CHANGELOG.md

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
