### PR TITLE
Add test for urls in team invitations (SQPIT-1368)

### DIFF
--- a/changelog.d/5-internal/add-invitation-url-test
+++ b/changelog.d/5-internal/add-invitation-url-test
@@ -1,1 +1,0 @@
-Add test for invitation urls in team invitation responses. These depend on the settings of galley.

--- a/changelog.d/5-internal/add-invitation-url-test
+++ b/changelog.d/5-internal/add-invitation-url-test
@@ -1,0 +1,1 @@
+Add test for invitation urls in team invitation responses. These depend on the settings of galley.

--- a/changelog.d/5-internal/add-invitation-url-tests
+++ b/changelog.d/5-internal/add-invitation-url-tests
@@ -1,0 +1,1 @@
+Add tests for invitation urls in team invitation responses. These depend on the settings of galley.

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -534,6 +534,7 @@ executable brig-integration
     , data-timeout
     , email-validate
     , exceptions
+    , extra
     , federator
     , filepath               >=1.4
     , galley-types

--- a/services/brig/default.nix
+++ b/services/brig/default.nix
@@ -72,7 +72,7 @@ mkDerivation {
     aeson async attoparsec base base16-bytestring base64-bytestring
     bilge bloodhound brig-types bytestring bytestring-conversion
     cargohold-types case-insensitive cassandra-util containers cookie
-    data-default data-timeout email-validate exceptions extended
+    data-default data-timeout email-validate exceptions extended extra
     federator filepath galley-types gundeck-types hscim HsOpenSSL
     http-api-data http-client http-client-tls http-media
     http-reverse-proxy http-types imports lens lens-aeson metrics-wai


### PR DESCRIPTION
If team invitation urls are rendered in the response of a team invitation request depends on the settings of galley. Because these cannot be changed during test runs, we first left this test out. This PR adds a test with a mocked instance of galley (such that the configuration change can be simulated).

https://wearezeta.atlassian.net/browse/SQPIT-1368

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
