### PR TITLE
nix: Pin openssl to 1.1

### DIFF
--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -1,4 +1,4 @@
-{ libsodium, protobuf, hlib, mls-test-cli }:
+{ libsodium, protobuf, hlib, mls-test-cli, openssl }:
 # FUTUREWORK: Figure out a way to detect if some of these packages are not
 # actually marked broken, so we can cleanup this file on every nixpkgs bump.
 hself: hsuper: {
@@ -58,4 +58,6 @@ hself: hsuper: {
 
   # Make hoogle static to reduce size of the hoogle image
   hoogle = hlib.justStaticExecutables hsuper.hoogle;
+
+  HsOpenSSL = hsuper.HsOpenSSL.override { inherit openssl; };
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -55,8 +55,6 @@ self: super: {
   zauth = self.callPackage ./pkgs/zauth { };
   mls-test-cli = self.callPackage ./pkgs/mls-test-cli { };
 
-  openssl = self.openssl_1_1;
-
   # Named like this so cabal2nix can find it
   rusty_jwt_tools_ffi = self.callPackage ./pkgs/rusty_jwt_tools_ffi { };
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -55,6 +55,8 @@ self: super: {
   zauth = self.callPackage ./pkgs/zauth { };
   mls-test-cli = self.callPackage ./pkgs/mls-test-cli { };
 
+  openssl = self.openssl_1_1;
+
   # Named like this so cabal2nix can find it
   rusty_jwt_tools_ffi = self.callPackage ./pkgs/rusty_jwt_tools_ffi { };
 

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -123,6 +123,7 @@ let lib = pkgs.lib;
       ];
     manualOverrides = import ./manual-overrides.nix (with pkgs; {
       inherit hlib libsodium protobuf mls-test-cli;
+      openssl = openssl_1_1;
     });
 
     executables = hself: hsuper:


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQPIT-1478

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog, last release used openssl 1.1 anyway.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
