### PR TITLE
[SQSERVICES 1769] Allow pagination for team endpoints

### DIFF
--- a/changelog.d/2-features/pr-2802
+++ b/changelog.d/2-features/pr-2802
@@ -1,0 +1,1 @@
+The `GET /teams/{tid}/members` endpoint now supports pagination

--- a/libs/polysemy-wire-zoo/src/Wire/Sem/Paging/Cassandra.hs
+++ b/libs/polysemy-wire-zoo/src/Wire/Sem/Paging/Cassandra.hs
@@ -93,6 +93,8 @@ type instance E.Page InternalPaging a = InternalPage a
 
 type instance E.PagingBounds InternalPaging TeamMember = Range 1 HardTruncationLimit Int32
 
+type instance E.PagingBounds CassandraPaging TeamMember = Range 1 HardTruncationLimit Int32
+
 type instance E.PagingBounds InternalPaging TeamId = Range 1 100 Int32
 
 instance E.Paging InternalPaging where

--- a/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
@@ -24,6 +24,7 @@ where
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Attoparsec.ByteString as AB
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64.URL as Base64Url
 import Data.Either.Combinators (mapLeft)
 import Data.Json.Util (fromBase64Text, toBase64Text)
 import Data.Proxy
@@ -31,6 +32,7 @@ import Data.Schema
 import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 import GHC.TypeLits
 import Imports
 import Servant (FromHttpApiData (..), ToHttpApiData (..))
@@ -61,10 +63,10 @@ pagingStateParser = do
   pure $ MultiTablePagingState table state
 
 instance PagingTable tables => ToHttpApiData (MultiTablePagingState name tables) where
-  toQueryParam = toBase64Text . encodePagingState
+  toQueryParam = (Text.decodeUtf8 . Base64Url.encode) . encodePagingState
 
 instance PagingTable tables => FromHttpApiData (MultiTablePagingState name tables) where
-  parseQueryParam = mapLeft cs . (parsePagingState <=< fromBase64Text)
+  parseQueryParam = mapLeft cs . (parsePagingState <=< (Base64Url.decode . Text.encodeUtf8))
 
 -- | A class for values that can be encoded with a single byte. Used to add a
 -- byte of extra information to the paging state in order to recover the table

--- a/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
@@ -24,13 +24,16 @@ where
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Attoparsec.ByteString as AB
 import qualified Data.ByteString as BS
+import Data.Either.Combinators (mapLeft)
 import Data.Json.Util (fromBase64Text, toBase64Text)
 import Data.Proxy
 import Data.Schema
+import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as Text
 import GHC.TypeLits
 import Imports
+import Servant (FromHttpApiData (..), ToHttpApiData (..))
 
 -- | The state of a multi-table paginated query. It is made of a reference to
 -- the table currently being paginated, as well as an opaque token returned by
@@ -49,13 +52,19 @@ encodePagingState (MultiTablePagingState table state) =
    in BS.cons encodedTable encodedState
 
 parsePagingState :: PagingTable tables => ByteString -> Either String (MultiTablePagingState name tables)
-parsePagingState = AB.parseOnly conversationPagingStateParser
+parsePagingState = AB.parseOnly pagingStateParser
 
-conversationPagingStateParser :: PagingTable tables => AB.Parser (MultiTablePagingState name tables)
-conversationPagingStateParser = do
+pagingStateParser :: PagingTable tables => AB.Parser (MultiTablePagingState name tables)
+pagingStateParser = do
   table <- AB.anyWord8 >>= decodePagingTable
   state <- (AB.endOfInput $> Nothing) <|> (Just <$> AB.takeByteString <* AB.endOfInput)
   pure $ MultiTablePagingState table state
+
+instance PagingTable tables => ToHttpApiData (MultiTablePagingState name tables) where
+  toQueryParam = toBase64Text . encodePagingState
+
+instance PagingTable tables => FromHttpApiData (MultiTablePagingState name tables) where
+  parseQueryParam = mapLeft cs . (parsePagingState <=< fromBase64Text)
 
 -- | A class for values that can be encoded with a single byte. Used to add a
 -- byte of extra information to the paging state in order to recover the table

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1669,7 +1669,16 @@ type TeamMemberAPI =
              ]
              "maxResults"
              (Range 1 HardTruncationLimit Int32)
-        :> Get '[JSON] TeamMemberListOptPerms
+        :> QueryParam'
+             [ Optional,
+               Strict,
+               Description
+                 "optional, when not specified, the first page will be returned.\
+                 \Every returned page contains a paging_state, this should be supplied to retrieve the next page."
+             ]
+             "pagingState"
+             TeamMembersPagingState
+        :> Get '[JSON] TeamMembersPage
     )
     :<|> Named
            "get-team-member"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -1673,8 +1673,8 @@ type TeamMemberAPI =
              [ Optional,
                Strict,
                Description
-                 "optional, when not specified, the first page will be returned.\
-                 \Every returned page contains a paging_state, this should be supplied to retrieve the next page."
+                 "Optional, when not specified, the first page will be returned.\
+                 \Every returned page contains a `pagingState`, this should be supplied to retrieve the next page."
              ]
              "pagingState"
              TeamMembersPagingState

--- a/libs/wire-api/src/Wire/API/Team/Member.hs
+++ b/libs/wire-api/src/Wire/API/Team/Member.hs
@@ -149,25 +149,25 @@ teamMemberObjectSchema :: ObjectSchema SwaggerDoc TeamMember
 teamMemberObjectSchema =
   TeamMember
     <$> _newTeamMember
-    .= newTeamMemberSchema
+      .= newTeamMemberSchema
     <*> _legalHoldStatus
-    .= (fromMaybe defUserLegalHoldStatus <$> optFieldWithDocModifier "legalhold_status" (description ?~ lhDesc) schema)
+      .= (fromMaybe defUserLegalHoldStatus <$> optFieldWithDocModifier "legalhold_status" (description ?~ lhDesc) schema)
 
 instance ToSchema (TeamMember' 'Optional) where
   schema =
     objectWithDocModifier "TeamMember" (description ?~ "team member data") $
       TeamMember
         <$> _newTeamMember
-        .= ( NewTeamMember
-               <$> _nUserId
-               .= fieldWithDocModifier "user" (description ?~ "user ID") schema
-               <*> _nPermissions
-               .= maybe_ (optFieldWithDocModifier "permissions" (description ?~ permissionsDesc) schema)
-               <*> _nInvitation
-               .= invitedSchema'
-           )
+          .= ( NewTeamMember
+                 <$> _nUserId
+                   .= fieldWithDocModifier "user" (description ?~ "user ID") schema
+                 <*> _nPermissions
+                   .= maybe_ (optFieldWithDocModifier "permissions" (description ?~ permissionsDesc) schema)
+                 <*> _nInvitation
+                   .= invitedSchema'
+             )
         <*> _legalHoldStatus
-        .= (fromMaybe defUserLegalHoldStatus <$> optFieldWithDocModifier "legalhold_status" (description ?~ lhDesc) schema)
+          .= (fromMaybe defUserLegalHoldStatus <$> optFieldWithDocModifier "legalhold_status" (description ?~ lhDesc) schema)
     where
       permissionsDesc =
         "The permissions this user has in the given team \
@@ -205,14 +205,14 @@ instance ToSchema TeamMembersPage where
     object "TeamMembersPage" $
       TeamMembersPage
         <$> unTeamMembersPage
-        .= ( MultiTablePage
-               <$> mtpResults
-               .= field "members" (array schema)
-               <*> mtpHasMore
-               .= field "hasMore" schema
-               <*> mtpPagingState
-               .= field "pagingState" schema
-           )
+          .= ( MultiTablePage
+                 <$> mtpResults
+                   .= field "members" (array schema)
+                 <*> mtpHasMore
+                   .= field "hasMore" schema
+                 <*> mtpPagingState
+                   .= field "pagingState" schema
+             )
 
 type TeamMembersPagingState = MultiTablePagingState TeamMembersPagingName TeamMembersTable
 
@@ -266,9 +266,9 @@ instance ToSchema (TeamMember' tag) => ToSchema (TeamMemberList' tag) where
     objectWithDocModifier "TeamMemberList" (description ?~ "list of team member") $
       TeamMemberList
         <$> _teamMembers
-        .= fieldWithDocModifier "members" (description ?~ "the array of team members") (array schema)
+          .= fieldWithDocModifier "members" (description ?~ "the array of team members") (array schema)
         <*> _teamMemberListType
-        .= fieldWithDocModifier "hasMore" (description ?~ "true if 'members' doesn't contain all team members") schema
+          .= fieldWithDocModifier "hasMore" (description ?~ "true if 'members' doesn't contain all team members") schema
 
 type HardTruncationLimit = (2000 :: Nat)
 
@@ -358,19 +358,19 @@ newTeamMemberSchema :: ObjectSchema SwaggerDoc NewTeamMember
 newTeamMemberSchema =
   NewTeamMember
     <$> _nUserId
-    .= field "user" schema
+      .= field "user" schema
     <*> _nPermissions
-    .= field "permissions" schema
+      .= field "permissions" schema
     <*> _nInvitation
-    .= invitedSchema'
+      .= invitedSchema'
 
 invitedSchema :: ObjectSchemaP SwaggerDoc (Maybe (UserId, UTCTimeMillis)) (Maybe UserId, Maybe UTCTimeMillis)
 invitedSchema =
   (,)
     <$> fmap fst
-    .= optFieldWithDocModifier "created_by" (description ?~ "ID of the inviting user.  Requires created_at.") (maybeWithDefault Null schema)
+      .= optFieldWithDocModifier "created_by" (description ?~ "ID of the inviting user.  Requires created_at.") (maybeWithDefault Null schema)
     <*> fmap snd
-    .= optFieldWithDocModifier "created_at" (description ?~ "Timestamp of invitation creation.  Requires created_by.") (maybeWithDefault Null schema)
+      .= optFieldWithDocModifier "created_at" (description ?~ "Timestamp of invitation creation.  Requires created_by.") (maybeWithDefault Null schema)
 
 invitedSchema' :: ObjectSchema SwaggerDoc (Maybe (UserId, UTCTimeMillis))
 invitedSchema' = withParser invitedSchema $ \(invby, invat) ->

--- a/libs/wire-api/src/Wire/API/Team/Member.hs
+++ b/libs/wire-api/src/Wire/API/Team/Member.hs
@@ -36,6 +36,9 @@ module Wire.API.Team.Member
     -- * TeamMemberList
     TeamMemberList,
     TeamMemberListOptPerms,
+    TeamMembersPage (..),
+    TeamMembersPagingState,
+    teamMemberPagingState,
     newTeamMemberList,
     teamMembers,
     teamMemberListType,
@@ -61,17 +64,23 @@ module Wire.API.Team.Member
   )
 where
 
+import Cassandra (PageWithState (..))
+import qualified Cassandra as C
 import Control.Lens (Lens, Lens', makeLenses, (%~), (?~))
 import Data.Aeson (FromJSON (..), ToJSON (..), Value (..))
+import qualified Data.ByteString.Lazy as LBS
 import Data.Id (UserId)
 import Data.Json.Util
 import Data.LegalHold (UserLegalHoldStatus (..), defUserLegalHoldStatus)
 import Data.Misc (PlainTextPassword (..))
 import Data.Proxy
 import Data.Schema
+import Data.Swagger (ToParamSchema (..))
 import qualified Data.Swagger.Schema as S
 import GHC.TypeLits
 import Imports
+import Wire.API.Routes.MultiTablePaging (MultiTablePage (..))
+import Wire.API.Routes.MultiTablePaging.State
 import Wire.API.Team.Permission (Permissions)
 import Wire.Arbitrary (Arbitrary, GenericUniform (..))
 
@@ -139,20 +148,26 @@ instance ToSchema TeamMember where
 teamMemberObjectSchema :: ObjectSchema SwaggerDoc TeamMember
 teamMemberObjectSchema =
   TeamMember
-    <$> _newTeamMember .= newTeamMemberSchema
-    <*> _legalHoldStatus .= (fromMaybe defUserLegalHoldStatus <$> optFieldWithDocModifier "legalhold_status" (description ?~ lhDesc) schema)
+    <$> _newTeamMember
+    .= newTeamMemberSchema
+    <*> _legalHoldStatus
+    .= (fromMaybe defUserLegalHoldStatus <$> optFieldWithDocModifier "legalhold_status" (description ?~ lhDesc) schema)
 
 instance ToSchema (TeamMember' 'Optional) where
   schema =
     objectWithDocModifier "TeamMember" (description ?~ "team member data") $
       TeamMember
         <$> _newTeamMember
-          .= ( NewTeamMember
-                 <$> _nUserId .= fieldWithDocModifier "user" (description ?~ "user ID") schema
-                 <*> _nPermissions .= maybe_ (optFieldWithDocModifier "permissions" (description ?~ permissionsDesc) schema)
-                 <*> _nInvitation .= invitedSchema'
-             )
-        <*> _legalHoldStatus .= (fromMaybe defUserLegalHoldStatus <$> optFieldWithDocModifier "legalhold_status" (description ?~ lhDesc) schema)
+        .= ( NewTeamMember
+               <$> _nUserId
+               .= fieldWithDocModifier "user" (description ?~ "user ID") schema
+               <*> _nPermissions
+               .= maybe_ (optFieldWithDocModifier "permissions" (description ?~ permissionsDesc) schema)
+               <*> _nInvitation
+               .= invitedSchema'
+           )
+        <*> _legalHoldStatus
+        .= (fromMaybe defUserLegalHoldStatus <$> optFieldWithDocModifier "legalhold_status" (description ?~ lhDesc) schema)
     where
       permissionsDesc =
         "The permissions this user has in the given team \
@@ -167,6 +182,45 @@ setPerm False = const Nothing
 
 --------------------------------------------------------------------------------
 -- TeamMemberList
+
+data TeamMembersTable = TeamMembersTable
+  deriving (Eq, Show, Generic)
+
+instance PagingTable TeamMembersTable where
+  encodePagingTable TeamMembersTable = 0
+
+  decodePagingTable 0 = pure TeamMembersTable
+  decodePagingTable x = fail $ "Expected 0 while parsing TeamMembersTable, got: " <> show x
+
+type TeamMembersPagingName = "TeamMembers"
+
+type TeamMembersPage' = MultiTablePage TeamMembersPagingName "members" TeamMembersTable TeamMemberOptPerms
+
+newtype TeamMembersPage = TeamMembersPage {unTeamMembersPage :: TeamMembersPage'}
+  deriving stock (Eq, Show, Generic)
+  deriving (ToJSON, FromJSON, S.ToSchema) via (Schema TeamMembersPage)
+
+instance ToSchema TeamMembersPage where
+  schema =
+    object "TeamMembersPage" $
+      TeamMembersPage
+        <$> unTeamMembersPage
+        .= ( MultiTablePage
+               <$> mtpResults
+               .= field "members" (array schema)
+               <*> mtpHasMore
+               .= field "hasMore" schema
+               <*> mtpPagingState
+               .= field "pagingState" schema
+           )
+
+type TeamMembersPagingState = MultiTablePagingState TeamMembersPagingName TeamMembersTable
+
+teamMemberPagingState :: PageWithState TeamMember -> TeamMembersPagingState
+teamMemberPagingState p = MultiTablePagingState TeamMembersTable (LBS.toStrict . C.unPagingState <$> pwsState p)
+
+instance ToParamSchema TeamMembersPagingState where
+  toParamSchema _ = toParamSchema (Proxy @Text)
 
 type TeamMemberList = TeamMemberList' 'Required
 
@@ -211,8 +265,10 @@ instance ToSchema (TeamMember' tag) => ToSchema (TeamMemberList' tag) where
   schema =
     objectWithDocModifier "TeamMemberList" (description ?~ "list of team member") $
       TeamMemberList
-        <$> _teamMembers .= fieldWithDocModifier "members" (description ?~ "the array of team members") (array schema)
-        <*> _teamMemberListType .= fieldWithDocModifier "hasMore" (description ?~ "true if 'members' doesn't contain all team members") schema
+        <$> _teamMembers
+        .= fieldWithDocModifier "members" (description ?~ "the array of team members") (array schema)
+        <*> _teamMemberListType
+        .= fieldWithDocModifier "hasMore" (description ?~ "true if 'members' doesn't contain all team members") schema
 
 type HardTruncationLimit = (2000 :: Nat)
 
@@ -301,15 +357,20 @@ deriving via (GenericUniform (NewTeamMember' 'Optional)) instance Arbitrary (New
 newTeamMemberSchema :: ObjectSchema SwaggerDoc NewTeamMember
 newTeamMemberSchema =
   NewTeamMember
-    <$> _nUserId .= field "user" schema
-    <*> _nPermissions .= field "permissions" schema
-    <*> _nInvitation .= invitedSchema'
+    <$> _nUserId
+    .= field "user" schema
+    <*> _nPermissions
+    .= field "permissions" schema
+    <*> _nInvitation
+    .= invitedSchema'
 
 invitedSchema :: ObjectSchemaP SwaggerDoc (Maybe (UserId, UTCTimeMillis)) (Maybe UserId, Maybe UTCTimeMillis)
 invitedSchema =
   (,)
-    <$> fmap fst .= optFieldWithDocModifier "created_by" (description ?~ "ID of the inviting user.  Requires created_at.") (maybeWithDefault Null schema)
-    <*> fmap snd .= optFieldWithDocModifier "created_at" (description ?~ "Timestamp of invitation creation.  Requires created_by.") (maybeWithDefault Null schema)
+    <$> fmap fst
+    .= optFieldWithDocModifier "created_by" (description ?~ "ID of the inviting user.  Requires created_at.") (maybeWithDefault Null schema)
+    <*> fmap snd
+    .= optFieldWithDocModifier "created_at" (description ?~ "Timestamp of invitation creation.  Requires created_by.") (maybeWithDefault Null schema)
 
 invitedSchema' :: ObjectSchema SwaggerDoc (Maybe (UserId, UTCTimeMillis))
 invitedSchema' = withParser invitedSchema $ \(invby, invat) ->

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -60,10 +60,13 @@ where
 
 import Brig.Types.Intra (accountUser)
 import Brig.Types.Team (TeamSize (..))
+import Cassandra (PageWithState (pwsResults), pwsHasMore)
+import qualified Cassandra as C
 import Control.Lens
 import Data.ByteString.Builder (lazyByteString)
 import Data.ByteString.Conversion (List, toByteString)
 import qualified Data.ByteString.Conversion
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.CaseInsensitive as CI
 import Data.Csv (EncodeOptions (..), Quoting (QuoteAll), encodeDefaultOrderedByNameWith)
 import qualified Data.Handle as Handle
@@ -131,6 +134,7 @@ import Wire.API.Event.Team
 import Wire.API.Federation.Error
 import qualified Wire.API.Message as Conv
 import qualified Wire.API.Notification as Public
+import Wire.API.Routes.MultiTablePaging (MultiTablePage (MultiTablePage), MultiTablePagingState (mtpsState))
 import Wire.API.Routes.Public.Galley
 import Wire.API.Team
 import qualified Wire.API.Team as Public
@@ -138,7 +142,7 @@ import Wire.API.Team.Conversation
 import qualified Wire.API.Team.Conversation as Public
 import Wire.API.Team.Export (TeamExportUser (..))
 import Wire.API.Team.Feature
-import Wire.API.Team.Member (HardTruncationLimit, ListType (ListComplete, ListTruncated), NewTeamMember, TeamMember, TeamMemberList, TeamMemberListOptPerms, TeamMemberOptPerms, hardTruncationLimit, invitation, nPermissions, nUserId, newTeamMemberList, ntmNewTeamMember, permissions, setOptionalPerms, setOptionalPermsMany, teamMemberListType, teamMembers, tmdAuthPassword, userId)
+import Wire.API.Team.Member (HardTruncationLimit, ListType (ListComplete, ListTruncated), NewTeamMember, TeamMember, TeamMemberList, TeamMemberListOptPerms, TeamMemberOptPerms, TeamMembersPage (..), TeamMembersPagingState, hardTruncationLimit, invitation, nPermissions, nUserId, newTeamMemberList, ntmNewTeamMember, permissions, setOptionalPerms, setOptionalPermsMany, teamMemberListType, teamMemberPagingState, teamMembers, tmdAuthPassword, userId)
 import qualified Wire.API.Team.Member as Public
 import Wire.API.Team.Permission (Perm (..), Permissions (..), SPerm (..), copy, fullPermissions, self)
 import Wire.API.Team.Role
@@ -485,16 +489,26 @@ getTeamConversationRoles zusr tid = do
   pure $ Public.ConversationRolesList wireConvRoles
 
 getTeamMembers ::
-  Members '[ErrorS 'NotATeamMember, TeamStore] r =>
+  Members '[ErrorS 'NotATeamMember, TeamStore, TeamMemberStore CassandraPaging] r =>
   Local UserId ->
   TeamId ->
   Maybe (Range 1 Public.HardTruncationLimit Int32) ->
-  Sem r TeamMemberListOptPerms
-getTeamMembers lzusr tid mbMaxResults = do
-  m <- E.getTeamMember tid (tUnqualified lzusr) >>= noteS @'NotATeamMember
-  memberList <- E.getTeamMembersWithLimit tid (fromMaybe (unsafeRange Public.hardTruncationLimit) mbMaxResults)
-  let withPerms = (m `canSeePermsOf`)
-  pure $ setOptionalPermsMany withPerms memberList
+  Maybe TeamMembersPagingState ->
+  Sem r TeamMembersPage
+getTeamMembers lzusr tid mbMaxResults mbPagingState = do
+  member <- E.getTeamMember tid (tUnqualified lzusr) >>= noteS @'NotATeamMember
+  let mState = C.PagingState . LBS.fromStrict <$> (mbPagingState >>= mtpsState)
+  let mLimit = fromMaybe (unsafeRange Public.hardTruncationLimit) mbMaxResults
+  E.listTeamMembers @CassandraPaging tid mState mLimit <&> toTeamMembersPage member
+  where
+    toTeamMembersPage :: TeamMember -> C.PageWithState TeamMember -> TeamMembersPage
+    toTeamMembersPage member p =
+      let withPerms = (member `canSeePermsOf`)
+       in TeamMembersPage $
+            MultiTablePage
+              (map (setOptionalPerms withPerms) $ pwsResults p)
+              (pwsHasMore p)
+              (teamMemberPagingState p)
 
 outputToStreamingBody :: Member (Final IO) r => Sem (Output LByteString ': r) () -> Sem r StreamingBody
 outputToStreamingBody action = withWeavingToFinal @IO $ \state weave _inspect ->

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -247,6 +247,7 @@ evalGalley e =
     . interpretLegacyConversationListToCassandra
     . interpretRemoteConversationListToCassandra
     . interpretConversationListToCassandra
+    . interpretTeamMemberStoreToCassandraWithPaging lh
     . interpretTeamMemberStoreToCassandra lh
     . interpretTeamStoreToCassandra lh
     . interpretTeamNotificationStoreToCassandra

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -117,6 +117,7 @@ type GalleyEffects1 =
      TeamNotificationStore,
      TeamStore,
      TeamMemberStore InternalPaging,
+     TeamMemberStore CassandraPaging,
      ListItems CassandraPaging ConvId,
      ListItems CassandraPaging (Remote ConvId),
      ListItems LegacyPaging ConvId,

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -618,7 +618,7 @@ testRemoveBindingTeamMember ownerHasPassword = do
           . zConn "conn"
       )
       !!! const 400
-      === statusCode
+        === statusCode
     -- Deleting from a binding team without a password is forbidden
     delete
       ( g
@@ -654,7 +654,7 @@ testRemoveBindingTeamMember ownerHasPassword = do
               . json (newTeamMemberDeleteData (Just $ Util.defPassword))
           )
           !!! const 202
-          === statusCode
+            === statusCode
       else do
         -- Deleting from a binding team without a password is fine if the owner is
         -- authenticated, but has none.
@@ -666,7 +666,7 @@ testRemoveBindingTeamMember ownerHasPassword = do
               . json (newTeamMemberDeleteData Nothing)
           )
           !!! const 202
-          === statusCode
+            === statusCode
     checkTeamMemberLeave tid (mem1 ^. userId) wsOwner
     checkConvMemberLeaveEvent (Qualified cid1 localDomain) (Qualified (mem1 ^. userId) localDomain) wsMext
     assertQueue "team member leave" $ tUpdate 2 [ownerWithPassword, owner]
@@ -965,7 +965,7 @@ testDeleteBindingTeamSingleMember = do
           )
     )
     !!! const 202
-    === statusCode
+      === statusCode
   assertQueue "team member leave 1" $ tUpdate 1 [owner]
   -- Async things are hard...
   void $
@@ -982,7 +982,7 @@ testDeleteBindingTeamSingleMember = do
           . zConn "conn"
       )
       !!! const 202
-      === statusCode
+        === statusCode
     checkUserDeleteEvent owner wsOwner
 
     WS.assertNoEvent (1 # Second) [wsExtern]
@@ -1159,7 +1159,7 @@ getVerificationCode uid action = do
   resp <-
     get (brig . paths ["i", "users", toByteString' uid, "verification-code", toByteString' action])
       <!! const 200
-      === statusCode
+        === statusCode
   pure $ responseJsonUnsafe @Code.Value resp
 
 testDeleteBindingTeam :: Bool -> TestM ()
@@ -1209,7 +1209,7 @@ testDeleteBindingTeam ownerHasPassword = do
           )
     )
     !!! const 202
-    === statusCode
+      === statusCode
   assertQueue "team member leave 1" $ tUpdate 4 [ownerWithPassword, owner]
   void . WS.bracketRN c [owner, mem1 ^. userId, mem2 ^. userId, extern] $ \[wsOwner, wsMember1, wsMember2, wsExtern] -> do
     delete
@@ -1226,7 +1226,7 @@ testDeleteBindingTeam ownerHasPassword = do
             )
       )
       !!! const 202
-      === statusCode
+        === statusCode
     checkUserDeleteEvent owner wsOwner
     checkUserDeleteEvent (mem1 ^. userId) wsMember1
     checkUserDeleteEvent (mem2 ^. userId) wsMember2
@@ -1272,7 +1272,7 @@ testDeleteTeamConv = do
   WS.bracketR3 c owner extern (member ^. userId) $ \(wsOwner, wsExtern, wsMember) -> do
     deleteTeamConv tid cid2 (member ^. userId)
       !!! const 200
-      === statusCode
+        === statusCode
 
     -- We no longer send duplicate conv deletion events
     -- i.e., as both a regular "conversation.delete" to all
@@ -1285,7 +1285,7 @@ testDeleteTeamConv = do
 
     deleteTeamConv tid cid1 (member ^. userId)
       !!! const 200
-      === statusCode
+        === statusCode
     -- We no longer send duplicate conv deletion events
     -- i.e., as both a regular "conversation.delete" to all
     -- conversation members and as "team.conversation-delete"
@@ -1313,7 +1313,7 @@ testUpdateTeamIconValidation = do
               . json payload
           )
           !!! const expectedStatusCode
-          === statusCode
+            === statusCode
   let payloadWithInvalidIcon = object ["name" .= String "name", "icon" .= String "invalid"]
   update payloadWithInvalidIcon 400
   let payloadWithValidIcon =
@@ -1342,7 +1342,7 @@ testUpdateTeam = do
               . body (RequestBodyLBS payload)
           )
           !!! const code
-          === statusCode
+            === statusCode
 
   let bad = object ["name" .= T.replicate 100 "too large"]
   doPut (encode bad) 400
@@ -1444,7 +1444,7 @@ testTeamAddRemoveMemberAboveThresholdNoEvents = do
               . json u
           )
           !!! const 200
-          === statusCode
+            === statusCode
         if expect
           then mapM_ (checkUserUpdateEvent target) wsListeners
           else WS.assertNoEvent (1 # Second) wsListeners
@@ -1462,7 +1462,7 @@ testTeamAddRemoveMemberAboveThresholdNoEvents = do
               . json u
           )
           !!! const 200
-          === statusCode
+            === statusCode
         -- Due to the fact that the team is too large, we expect no events!
         if expect
           then checkTeamUpdateEvent tid u wsOrigin
@@ -1490,7 +1490,7 @@ testTeamAddRemoveMemberAboveThresholdNoEvents = do
               . json (newTeamMemberDeleteData (Just $ Util.defPassword))
           )
           !!! const 202
-          === statusCode
+            === statusCode
         if expect
           then checkTeamMemberLeave tid victim wsOwner
           else WS.assertNoEvent (1 # Second) [wsOwner]
@@ -1510,7 +1510,7 @@ testTeamAddRemoveMemberAboveThresholdNoEvents = do
               . json (newTeamDeleteData (Just Util.defPassword))
           )
           !!! const 202
-          === statusCode
+            === statusCode
         for_ (owner : otherRealUsersInTeam) $ \u -> checkUserDeleteEvent u wsExtern
         -- Ensure users are marked as deleted; since we already
         -- received the event, should _really_ be deleted
@@ -1581,7 +1581,7 @@ testBillingInLargeTeamWithoutIndexedBillingTeamMembers = do
           withoutIndexedBillingTeamMembers $
             post (galley . paths ["i", "teams", toByteString' team, "members"] . mem)
               !!! const 200
-              === statusCode
+                === statusCode
           let allBillingMembers = newBillingMemberId : billingMembers
           -- We don't make a call to brig to add member, hence the count of team is always 2
           assertQueue ("add " <> show n <> "th billing member: " <> show newBillingMemberId) $
@@ -1601,7 +1601,7 @@ testBillingInLargeTeamWithoutIndexedBillingTeamMembers = do
     g <- viewGalley
     post (g . paths ["i", "teams", toByteString' team, "members"] . memFanoutPlusTwo)
       !!! const 200
-      === statusCode
+        === statusCode
   assertQueue ("add " <> show (fanoutLimit + 2) <> "th billing member: " <> show ownerFanoutPlusTwo) $
     \s maybeEvent ->
       case maybeEvent of
@@ -1887,7 +1887,7 @@ postCryptoBroadcastMessageReportMissingBody bcast = do
       msg = [(alice, ac, "ciphertext0")]
   Util.postBroadcast qalice ac bcast {bReport = Just [bob], bMessage = msg, bReq = inquery}
     !!! const 412
-    === statusCode
+      === statusCode
 
 postCryptoBroadcastMessage2 :: Broadcast -> TestM ()
 postCryptoBroadcastMessage2 bcast = do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -260,7 +260,7 @@ changeTeamStatus tid s = do
         . json (TeamStatusUpdate s Nothing)
     )
     !!! const 200
-    === statusCode
+      === statusCode
 
 createBindingTeamInternal :: HasCallStack => Text -> UserId -> TestM TeamId
 createBindingTeamInternal name owner = do
@@ -286,7 +286,7 @@ createBindingTeamInternalWithCurrency name owner cur = do
   _ <-
     put (g . paths ["i", "teams", toByteString' tid, "status"] . json (TeamStatusUpdate Active $ Just cur))
       !!! const 200
-      === statusCode
+        === statusCode
   pure tid
 
 getTeamInternal :: HasCallStack => TeamId -> TestM TeamData
@@ -333,7 +333,7 @@ getTeamMembersPaginated usr tid n mPs = do
           . maybe id (queryItem "pagingState" . cs) mPs
       )
       <!! const 200
-      === statusCode
+        === statusCode
   responseJsonError r
 
 getTeamMembersInternalTruncated :: HasCallStack => TeamId -> Int -> TestM TeamMemberList
@@ -346,7 +346,7 @@ getTeamMembersInternalTruncated tid n = do
           . queryItem "maxResults" (C.pack $ show n)
       )
       <!! const 200
-      === statusCode
+        === statusCode
   responseJsonError r
 
 bulkGetTeamMembers :: HasCallStack => UserId -> TeamId -> [UserId] -> TestM TeamMemberList
@@ -360,7 +360,7 @@ bulkGetTeamMembers usr tid uids = do
           . json (UserIdList uids)
       )
       <!! const 200
-      === statusCode
+        === statusCode
   responseJsonError r
 
 bulkGetTeamMembersTruncated :: HasCallStack => UserId -> TeamId -> [UserId] -> Int -> TestM ResponseLBS
@@ -396,7 +396,7 @@ addTeamMember usr tid muid mperms mmbinv = do
   let payload = json (mkNewTeamMember muid mperms mmbinv)
   post (g . paths ["teams", toByteString' tid, "members"] . zUser usr . zConn "conn" . payload)
     !!! const 200
-    === statusCode
+      === statusCode
 
 -- | FUTUREWORK: do not use this, it's broken!!  use 'addUserToTeam' instead!  https://wearezeta.atlassian.net/browse/SQSERVICES-471
 addTeamMemberInternal :: HasCallStack => TeamId -> UserId -> Permissions -> Maybe (UserId, UTCTimeMillis) -> TestM ()
@@ -463,7 +463,7 @@ makeOwner owner mem tid = do
         . json changeMember
     )
     !!! const 200
-    === statusCode
+      === statusCode
 
 acceptInviteBody :: Email -> InvitationCode -> RequestBody
 acceptInviteBody email code =
@@ -703,7 +703,7 @@ postConvWithRemoteUsers u n =
     withTempMockFederator (const ()) $
       postConvQualified u n {newConvName = setName (newConvName n)}
         <!! const 201
-        === statusCode
+          === statusCode
   where
     setName :: Within Text n m => Maybe (Range n m Text) -> Maybe (Range n m Text)
     setName Nothing = checked "federated gossip"
@@ -1370,7 +1370,7 @@ getTeamQueue zusr msince msize onlyLast =
   parseEventList . responseJsonUnsafe
     <$> ( getTeamQueue' zusr msince (fst <$> msize) onlyLast
             <!! const 200
-            === statusCode
+              === statusCode
         )
   where
     parseEventList :: QueuedNotificationList -> [(NotificationId, UserId)]
@@ -1899,7 +1899,7 @@ connectWithRemoteUser self other = do
         . json req
     )
     !!! const 200
-    === statusCode
+      === statusCode
 
 -- | A copy of 'postConnection' from Brig integration tests.
 postConnection :: UserId -> UserId -> TestM ResponseLBS
@@ -2040,7 +2040,7 @@ randomClientWithCaps uid lk caps = do
           . json newClientBody
       )
       <!! const rStatus
-      === statusCode
+        === statusCode
   client <- responseJsonError resp
   pure (clientId client)
   where
@@ -2119,7 +2119,7 @@ isUserDeleted u = do
   r <-
     get (b . paths ["i", "users", toByteString' u, "status"])
       <!! const 200
-      === statusCode
+        === statusCode
   case responseBody r of
     Nothing -> error $ "getStatus: failed to parse response: " ++ show r
     Just j -> do
@@ -2786,11 +2786,11 @@ createOne2OneConvWithRemote localUser remoteUser = do
     fmap uuorConvId
       . responseJsonError
       =<< iUpsertOne2OneConversation (mkRequest LocalActor Nothing)
-      <!! const 200
-      === statusCode
+        <!! const 200
+          === statusCode
   iUpsertOne2OneConversation (mkRequest RemoteActor (Just ooConvId))
     !!! const 200
-    === statusCode
+      === statusCode
 
 generateRemoteAndConvId :: Bool -> Local UserId -> TestM (Remote UserId, Qualified ConvId)
 generateRemoteAndConvId = generateRemoteAndConvIdWithDomain (Domain "far-away.example.com")


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1769

This PR only covers the `GET /teams/{tid}/members` endpoint.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
