### PR TITLE
Support local vim configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ b.yaml
 telepresence.log
 
 /.ghci
+/.vim
 
 # local config
 .envrc.local

--- a/changelog.d/5-internal/local-vim
+++ b/changelog.d/5-internal/local-vim
@@ -1,0 +1,1 @@
+Add /.vim to gitignore


### PR DESCRIPTION
Vim users (especially those using coc.nvim) like keeping local project configuration under `/.vim`. This PR gitignores `/.vim`.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
