### PR TITLE
Reduce payload size for internal client.delete event

### DIFF
--- a/changelog.d/5-internal/client-deletion-payload
+++ b/changelog.d/5-internal/client-deletion-payload
@@ -1,0 +1,1 @@
+Reduce the payload size of internal `client.delete` event

--- a/libs/brig-types/src/Brig/Types/User/Event.hs
+++ b/libs/brig-types/src/Brig/Types/User/Event.hs
@@ -69,7 +69,7 @@ data PropertyEvent
 
 data ClientEvent
   = ClientAdded !UserId !Client
-  | ClientRemoved !UserId !Client
+  | ClientRemoved !UserId !ClientId
 
 data UserUpdatedData = UserUpdatedData
   { eupId :: !UserId,

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -377,7 +377,7 @@ execDelete u con c = do
   wrapClient $ Data.rmClient u (clientId c)
   for_ (clientCookie c) $ \l -> wrapClient $ Auth.revokeCookies u [] [l]
   queue <- view internalEvents
-  Queue.enqueue queue (Internal.DeleteClient c u con)
+  Queue.enqueue queue (Internal.DeleteClient (clientId c) u con)
 
 -- | Defensive measure when no prekey is found for a
 -- requested client: Ensure that the client does indeed

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -634,11 +634,11 @@ toPushFormat (ClientEvent (ClientAdded _ c)) =
       [ "type" .= ("user.client-add" :: Text),
         "client" .= c
       ]
-toPushFormat (ClientEvent (ClientRemoved _ c)) =
+toPushFormat (ClientEvent (ClientRemoved _ clientId)) =
   Just $
     KeyMap.fromList
       [ "type" .= ("user.client-remove" :: Text),
-        "client" .= IdObject (clientId c)
+        "client" .= IdObject clientId
       ]
 toPushFormat (UserEvent (LegalHoldClientRequested payload)) =
   let LegalHoldClientRequestedData targetUser lastPrekey' clientId = payload

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -39,7 +39,6 @@ import Imports
 import System.Logger.Class (field, msg, val, (~~))
 import qualified System.Logger.Class as Log
 import UnliftIO (timeout)
-import Wire.API.User.Client (clientId)
 
 -- | Handle an internal event.
 --
@@ -58,9 +57,9 @@ onEvent ::
   InternalNotification ->
   m ()
 onEvent n = handleTimeout $ case n of
-  DeleteClient c uid mcon -> do
-    rmClient uid (clientId c)
-    Intra.onClientEvent uid mcon (ClientRemoved uid c)
+  DeleteClient clientId uid mcon -> do
+    rmClient uid clientId
+    Intra.onClientEvent uid mcon (ClientRemoved uid clientId)
   DeleteUser uid -> do
     Log.info $
       msg (val "Processing user delete event")

--- a/services/brig/src/Brig/InternalEvent/Types.hs
+++ b/services/brig/src/Brig/InternalEvent/Types.hs
@@ -23,10 +23,9 @@ where
 import BasePrelude
 import Data.Aeson
 import Data.Id
-import Wire.API.User.Client (Client)
 
 data InternalNotification
-  = DeleteClient !Client !UserId !(Maybe ConnId)
+  = DeleteClient !ClientId !UserId !(Maybe ConnId)
   | DeleteUser !UserId
   | DeleteService !ProviderId !ServiceId
   deriving (Eq, Show)

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -45,7 +45,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS
 import Data.ByteString.Conversion
 import Data.Id
-import Data.Json.Util (toUTCTimeMillis)
 import Data.LegalHold
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
@@ -440,7 +439,7 @@ testDisableLegalHoldForUser = withTeam $ \owner tid -> do
       assertEqual "method" "POST" (requestMethod req)
       assertEqual "path" (pathInfo req) ["legalhold", "remove"]
     assertNotification mws $ \case
-      Ev.ClientEvent (Ev.ClientRemoved _ clientId') -> clientId clientId' @?= someClientId
+      Ev.ClientEvent (Ev.ClientRemoved _ clientId') -> clientId' @?= someClientId
       _ -> assertBool "Unexpected event" False
     assertNotification mws $ \case
       Ev.UserEvent (Ev.UserLegalHoldDisabled uid) -> uid @?= member
@@ -1746,22 +1745,10 @@ instance FromJSON Ev.ClientEvent where
     tag :: Text <- o .: "type"
     case tag of
       "user.client-add" -> Ev.ClientAdded fakeuid <$> o .: "client"
-      "user.client-remove" -> Ev.ClientRemoved fakeuid <$> (makeFakeClient <$> (o .: "client" >>= withObject "id" (.: "id")))
+      "user.client-remove" -> Ev.ClientRemoved fakeuid <$> (o .: "client" >>= withObject "id" (.: "id"))
       x -> fail $ "Ev.ClientEvent: unsupported event type: " ++ show x
     where
       fakeuid = read @UserId "6980fb5e-ba64-11eb-a339-0b3625bf01be"
-      makeFakeClient cid =
-        Client
-          cid
-          PermanentClientType
-          (toUTCTimeMillis $ read "2021-05-23 09:39:15.937523809 UTC")
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-          (Client.ClientCapabilityList mempty)
-          mempty
 
 instance FromJSON Ev.ConnectionEvent where
   parseJSON = Aeson.withObject "ConnectionEvent" $ \o -> do


### PR DESCRIPTION
This PR:

* reduces the payload of the internal "client.delete" event by using `ClientId` instead of `Client`.
* changes also `Client` to `ClientId` in the `ClientRemoved` constructor of `ClientEvent`. There is no API change, because the push format was only using the `id` of the `Client`.

Tracked in https://wearezeta.atlassian.net/browse/FS-1131

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
