### PR TITLE
fixup: add redirects for pages renamed in #2808

### DIFF
--- a/changelog.d/4-docs/sphinx-redirect
+++ b/changelog.d/4-docs/sphinx-redirect
@@ -1,0 +1,1 @@
+Add extension sphinx-reredirects and configuration to generate simple JavaScript based redirects to new locations of previously inconsistently named files/URLs.

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -44,7 +44,8 @@ extensions = [
     'sphinxcontrib.kroki',
     "myst_parser",
     'rst2pdf.pdfbuilder',
-    'sphinx_multiversion'
+    'sphinx_multiversion',
+    'sphinx_reredirects',
 ]
 
 # Grouping the document tree into PDF files. List of tuples
@@ -122,3 +123,9 @@ smv_prefer_remote_refs = True
 
 # As per https://myst-parser.readthedocs.io/en/latest/syntax/optional.html?highlight=anchor#auto-generated-header-anchors
 myst_heading_anchors = 4
+
+redirects = {
+        "security-responses/log4shell": "2021-12-15_log4shell.html",
+        "security-responses/cve-2021-44521": "2022-02-21_cve-2021-44521.html",
+        "security-responses/2022-05_website_outage": "2022-05-23_website_outage.html"
+}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -127,5 +127,7 @@ myst_heading_anchors = 4
 redirects = {
         "security-responses/log4shell": "2021-12-15_log4shell.html",
         "security-responses/cve-2021-44521": "2022-02-21_cve-2021-44521.html",
-        "security-responses/2022-05_website_outage": "2022-05-23_website_outage.html"
+        "security-responses/2022-05_website_outage": "2022-05-23_website_outage.html",
+        "how-to/single-sign-on/index": "../../understand/single-sign-on/main.html#setting-up-sso-externally",
+        "how-to/scim/index": "../../understand/single-sign-on/main.html#user-provisioning",
 }

--- a/docs/src/how-to/scim/index.rst
+++ b/docs/src/how-to/scim/index.rst
@@ -1,4 +1,0 @@
-How to set up user provisioning with LDAP or SCIM
-=================================================
-
-This page has moved to :ref:`User provisioning`.

--- a/docs/src/how-to/single-sign-on/index.rst
+++ b/docs/src/how-to/single-sign-on/index.rst
@@ -1,4 +1,0 @@
-Single-sign-on how-tos
-======================
-
-This page moved to :ref:`Setting up SSO externally`.

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -26,9 +26,7 @@ This documentation may be expanded in the future to cover other aspects of Wire.
    Release notes <release-notes.rst>
    Administrator's Guide <how-to/index.rst>
    Understanding wire-server components <understand/index.rst>
-   Single-sign-on how-tos <how-to/single-sign-on/index.rst>
    Administrator's manual: single-sign-on and user provisioning <understand/single-sign-on/main.rst>
-   How to set up user provisioning with LDAP or SCIM <how-to/scim/index.rst>
    Client API documentation <understand/api-client-perspective/index.rst>
    Security responses <security-responses/index.rst>
    Notes for developers <developer/index.rst>

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -33,6 +33,7 @@ let
         sphinx-autobuild
         sphinx-multiversion
         sphinx_rtd_theme
+        sphinx_reredirects
         sphinxcontrib-fulltoc
         sphinxcontrib-kroki
       ]))

--- a/nix/overlay-docs.nix
+++ b/nix/overlay-docs.nix
@@ -3,6 +3,7 @@ self: super: rec {
     packageOverrides = pself: psuper: {
       rst2pdf = pself.callPackage ./pkgs/python-docs/rst2pdf.nix { };
       sphinx-multiversion = pself.callPackage ./pkgs/python-docs/sphinx-multiversion.nix { };
+      sphinx_reredirects = pself.callPackage ./pkgs/python-docs/sphinx_reredirects.nix { };
       sphinxcontrib-kroki = pself.callPackage ./pkgs/python-docs/sphinxcontrib-kroki.nix { };
       svg2rlg = pself.callPackage ./pkgs/python-docs/svg2rlg.nix { };
     };

--- a/nix/pkgs/python-docs/sphinx_reredirects.nix
+++ b/nix/pkgs/python-docs/sphinx_reredirects.nix
@@ -1,0 +1,20 @@
+{
+  fetchPypi,
+  buildPythonPackage,
+
+  sphinx,
+} :
+buildPythonPackage rec {
+
+  pname = "sphinx_reredirects";
+  version = "0.1.1";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256:RRmkXTFskhxGMnty/kEOHnoy/lFpR0EpYCCwygCPvO4=";
+  };
+
+  propagatedBuildInputs = [
+    sphinx
+  ];
+
+}


### PR DESCRIPTION
This PR introduces a sphinx extension [`sphinx-reredirects`](https://documatt.gitlab.io/sphinx-reredirects/index.html) and configuration to generate simple JavaScript based redirects to new locations of previously inconsistently named files.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)

