### PR TITLE
chore: remove wrong "prior to" in openssl advisory

### DIFF
--- a/docs/src/security-responses/2022-11-01_openssl.md
+++ b/docs/src/security-responses/2022-11-01_openssl.md
@@ -12,7 +12,7 @@ Wire applications perform such requests to TLS servers and Wire-Servers may also
 
 **Wire/wire-server (<= 2022-10-04) is not affected by this vulnerability.** Neither Wire-server on the cloud (on wire.com) nor on-premise installations are affected.
 
-Only OpenSSL prior to version 3 is affected, all wire-server components use OpenSSL 1.1.1.
+Only OpenSSL version 3 is affected, all wire-server components use OpenSSL 1.1.1.
 
 ## Are Wire clients affected?
 


### PR DESCRIPTION
## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
