### PR TITLE
Make FromJSON instance of InternalNotification backwards-compatible

### DIFF
--- a/changelog.d/5-internal/client-deletion-payload
+++ b/changelog.d/5-internal/client-deletion-payload
@@ -1,1 +1,1 @@
-Reduce the payload size of internal `client.delete` event
+Reduce the payload size of internal `client.delete` event (#2807, #2816)

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -740,6 +740,7 @@ test-suite brig-tests
     Test.Brig.Calling
     Test.Brig.Calling.Internal
     Test.Brig.Effects.Delay
+    Test.Brig.InternalNotification
     Test.Brig.MLS
     Test.Brig.Roundtrip
     Test.Brig.User.Search.Index.Types
@@ -809,6 +810,7 @@ test-suite brig-tests
     , lens
     , polysemy
     , polysemy-wire-zoo
+    , QuickCheck
     , retry
     , servant-client-core
     , string-conversions

--- a/services/brig/default.nix
+++ b/services/brig/default.nix
@@ -89,10 +89,10 @@ mkDerivation {
   testHaskellDepends = [
     aeson base binary bloodhound brig-types bytestring containers
     data-timeout dns dns-util exceptions HsOpenSSL http-types imports
-    lens polysemy polysemy-wire-zoo retry servant-client-core
-    string-conversions tasty tasty-hunit tasty-quickcheck time tinylog
-    types-common unliftio uri-bytestring uuid wai-utilities wire-api
-    wire-api-federation
+    lens polysemy polysemy-wire-zoo QuickCheck retry
+    servant-client-core string-conversions tasty tasty-hunit
+    tasty-quickcheck time tinylog types-common unliftio uri-bytestring
+    uuid wai-utilities wire-api wire-api-federation
   ];
   description = "User Service";
   license = lib.licenses.agpl3Only;

--- a/services/brig/test/resources/internal-notification.json
+++ b/services/brig/test/resources/internal-notification.json
@@ -1,0 +1,21 @@
+{
+  "client": {
+    "capabilities": {
+      "capabilities": []
+    },
+    "class": "legalhold",
+    "cookie": "\u0015",
+    "id": "1",
+    "location": {
+      "lat": 0.9096436047476794,
+      "lon": -0.8385084418257278
+    },
+    "mls_public_keys": {},
+    "model": "𝖫\u0013𧬲",
+    "time": "1864-05-07T01:21:11.519Z",
+    "type": "temporary"
+  },
+  "connection": null,
+  "type": "client.delete",
+  "user": "00001af5-0000-716d-0000-357a000065c2"
+}

--- a/services/brig/test/unit/Main.hs
+++ b/services/brig/test/unit/Main.hs
@@ -23,6 +23,7 @@ where
 import Imports
 import qualified Test.Brig.Calling
 import qualified Test.Brig.Calling.Internal
+import qualified Test.Brig.InternalNotification
 import qualified Test.Brig.MLS
 import qualified Test.Brig.Roundtrip
 import qualified Test.Brig.User.Search.Index.Types
@@ -37,5 +38,6 @@ main =
         Test.Brig.Calling.tests,
         Test.Brig.Calling.Internal.tests,
         Test.Brig.Roundtrip.tests,
-        Test.Brig.MLS.tests
+        Test.Brig.MLS.tests,
+        Test.Brig.InternalNotification.tests
       ]

--- a/services/brig/test/unit/Test/Brig/InternalNotification.hs
+++ b/services/brig/test/unit/Test/Brig/InternalNotification.hs
@@ -1,0 +1,45 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Brig.InternalNotification where
+
+import Brig.InternalEvent.Types (InternalNotification (..))
+import qualified Data.Aeson as A
+import Data.ByteString.Lazy as BSL
+import Data.Id (client)
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+  testGroup
+    "InternalNotification"
+    [testCase "Golden test for old format of DeleteClient" checkGolden]
+
+checkGolden :: IO ()
+checkGolden = do
+  -- This file was generated from ToJSON of the format prior to 67993ab1
+  ns <- BSL.readFile "test/resources/internal-notification.json"
+  let eith = A.eitherDecode @InternalNotification ns
+  case eith of
+    Left err -> assertFailure ("Could not parse InternalNotification: " <> show err)
+    Right n ->
+      case n of
+        DeleteClient cid _uid _mcon ->
+          client cid @?= "1"
+        _ -> assertFailure "Unexpected value"


### PR DESCRIPTION
Followup to #2807.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
