### PR TITLE
bullet proof smtp

### DIFF
--- a/changelog.d/2-features/smtp-logging
+++ b/changelog.d/2-features/smtp-logging
@@ -1,0 +1,1 @@
+Add more logs to SMTP mail sending. Ensure that logs are written before the application fails due to SMTP misconfiguration.

--- a/libs/types-common/default.nix
+++ b/libs/types-common/default.nix
@@ -32,6 +32,7 @@
 , lens-datetime
 , lib
 , mime
+, network
 , optparse-applicative
 , pem
 , protobuf
@@ -91,6 +92,7 @@ mkDerivation {
     lens
     lens-datetime
     mime
+    network
     optparse-applicative
     pem
     protobuf

--- a/libs/types-common/src/Wire/Arbitrary.hs
+++ b/libs/types-common/src/Wire/Arbitrary.hs
@@ -42,9 +42,10 @@ import GHC.Generics (Rep)
 import Generic.Random (listOf', (:+) ((:+)))
 import qualified Generic.Random as Generic
 import Imports
+import Network.Socket (PortNumber)
 import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary))
 import qualified Test.QuickCheck.Arbitrary as QC
-import Test.QuickCheck.Gen (Gen (MkGen))
+import Test.QuickCheck.Gen (Gen (MkGen), chooseBoundedIntegral)
 import Test.QuickCheck.Instances ()
 import Test.QuickCheck.Random
 
@@ -120,3 +121,6 @@ generateExample :: Arbitrary a => a
 generateExample =
   let (MkGen f) = arbitrary
    in f (mkQCGen 42) 42
+
+instance Arbitrary PortNumber where
+  arbitrary = chooseBoundedIntegral (minBound :: PortNumber, maxBound :: PortNumber)

--- a/libs/types-common/types-common.cabal
+++ b/libs/types-common/types-common.cabal
@@ -113,6 +113,7 @@ library
     , lens                   >=4.10
     , lens-datetime          >=0.3
     , mime                   >=0.4.0.2
+    , network
     , optparse-applicative   >=0.10
     , pem
     , protobuf               >=0.2

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -203,6 +203,14 @@ let
         tasty-hunit = "hunit";
       };
     };
+    # This can be removed once postie 0.6.0.3 (or later) is in nixpkgs
+    postie = {
+      src = fetchgit {
+        url = "https://github.com/alexbiehl/postie.git";
+        rev = "c92702386f760fcaa65cd052dc8114889c001e3f";
+        sha256 = "sha256-yiw6hg3guRWS6CVdrUY8wyIDxoqfGjIVMrEtP+Fys0Y=";
+      };
+    };
   };
   hackagePins = {
     kind-generics = {

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -58,4 +58,7 @@ hself: hsuper: {
 
   # Make hoogle static to reduce size of the hoogle image
   hoogle = hlib.justStaticExecutables hsuper.hoogle;
+
+  # Postie has been fixed upstream (master)
+  postie = hlib.markUnbroken (hlib.doJailbreak hsuper.postie);
 }

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -585,6 +585,7 @@ executable brig-integration
     , temporary              >=1.2.1
     , text
     , time                   >=1.5
+    , time-units
     , tinylog
     , transformers
     , types-common           >=0.3

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -287,6 +287,8 @@ library
     , text                       >=0.11
     , text-icu-translit          >=0.1
     , time                       >=1.1
+    , time-out
+    , time-units
     , tinylog                    >=0.10
     , transformers               >=0.3
     , types-common               >=0.16

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -561,6 +561,7 @@ executable brig-integration
     , network
     , optparse-applicative
     , pem
+    , pipes
     , polysemy
     , polysemy-wire-zoo
     , postie                 >=0.6

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -564,7 +564,7 @@ executable brig-integration
     , pipes
     , polysemy
     , polysemy-wire-zoo
-    , postie                 >=0.6
+    , postie                 >=0.6.0.3
     , process
     , proto-lens
     , QuickCheck

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -465,6 +465,7 @@ executable brig-integration
     Federation.Util
     Index.Create
     Main
+    SMTP
     Util
     Util.AWS
 
@@ -554,6 +555,7 @@ executable brig-integration
     , lens-aeson
     , metrics-wai
     , mime                   >=0.4
+    , mime-mail
     , MonadRandom            >=0.5
     , mtl
     , network
@@ -561,6 +563,7 @@ executable brig-integration
     , pem
     , polysemy
     , polysemy-wire-zoo
+    , postie                 >=0.6
     , process
     , proto-lens
     , QuickCheck

--- a/services/brig/default.nix
+++ b/services/brig/default.nix
@@ -85,9 +85,11 @@
 , network-conduit-tls
 , optparse-applicative
 , pem
+, pipes
 , polysemy
 , polysemy-plugin
 , polysemy-wire-zoo
+, postie
 , process
 , proto-lens
 , QuickCheck
@@ -130,6 +132,8 @@
 , text
 , text-icu-translit
 , time
+, time-out
+, time-units
 , tinylog
 , transformers
 , types-common
@@ -267,6 +271,8 @@ mkDerivation {
     text
     text-icu-translit
     time
+    time-out
+    time-units
     tinylog
     transformers
     types-common
@@ -329,13 +335,16 @@ mkDerivation {
     lens-aeson
     metrics-wai
     mime
+    mime-mail
     MonadRandom
     mtl
     network
     optparse-applicative
     pem
+    pipes
     polysemy
     polysemy-wire-zoo
+    postie
     process
     proto-lens
     QuickCheck
@@ -356,6 +365,7 @@ mkDerivation {
     temporary
     text
     time
+    time-units
     tinylog
     transformers
     types-common

--- a/services/brig/src/Brig/Email.hs
+++ b/services/brig/src/Brig/Email.hs
@@ -40,19 +40,20 @@ module Brig.Email
 where
 
 import qualified Brig.AWS as AWS
-import Brig.App (Env, awsEnv, smtpEnv)
+import Brig.App (Env, applog, awsEnv, smtpEnv)
 import qualified Brig.SMTP as SMTP
 import Control.Lens (view)
+import Control.Monad.Catch
 import qualified Data.Text as Text
 import Imports
 import Network.Mail.Mime
 import Wire.API.User
 
 -------------------------------------------------------------------------------
-sendMail :: (MonadIO m, MonadReader Env m) => Mail -> m ()
+sendMail :: (MonadIO m, MonadCatch m, MonadReader Env m) => Mail -> m ()
 sendMail m =
   view smtpEnv >>= \case
-    Just smtp -> SMTP.sendMail smtp m
+    Just smtp -> view applog >>= \logger -> SMTP.sendMail logger smtp m
     Nothing -> view awsEnv >>= \e -> AWS.execute e $ AWS.sendMail m
 
 -------------------------------------------------------------------------------

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -168,21 +168,40 @@ throwOnLeft = \case
 
 logResult :: MonadIO m => Logger -> String -> Either SMTPFailure c -> m ()
 logResult lg actionString res =
-  case res of
-    Left Unauthorized -> do
-      Logger.log
-        lg
-        Logger.Warn
-        (msg $ concatToVal actionString "Failed to establish connection, check your credentials.")
-    Left ConnectionTimeout -> do
-      Logger.log lg Logger.Warn (msg $ concatToVal actionString "Connection timeout.")
-    Left (CaughtException e) -> do
-      Logger.log lg Logger.Warn (msg $ concatToVal actionString ("Caught exception : " ++ show e))
-    Right _ -> do
-      Logger.log lg Logger.Debug (msg $ concatToVal actionString "Succeeded.")
-  where
-    concatToVal :: ToBytes s1 => s1 -> String -> Builder
-    concatToVal a b = a +++ (" : " :: String) +++ b
+  let msg' = msg ("SMTP connection result" :: String)
+   in case res of
+        Left Unauthorized -> do
+          Logger.log
+            lg
+            Logger.Warn
+            ( msg'
+                . field "action" actionString
+                . field "result" ("Failed to establish connection, check your credentials." :: String)
+            )
+        Left ConnectionTimeout -> do
+          Logger.log
+            lg
+            Logger.Warn
+            ( msg'
+                . field "action" actionString
+                . field "result" ("Connection timeout." :: String)
+            )
+        Left (CaughtException e) -> do
+          Logger.log
+            lg
+            Logger.Warn
+            ( msg'
+                . field "action" actionString
+                . field "result" ("Caught exception : " ++ show e)
+            )
+        Right _ -> do
+          Logger.log
+            lg
+            Logger.Debug
+            ( msg'
+                . field "action" actionString
+                . field "result" ("Succeeded." :: String)
+            )
 
 -- | Default timeout for all actions
 --

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -19,11 +19,17 @@
 
 module Brig.SMTP where
 
+import qualified Control.Exception as CE (handle, throw)
 import Control.Lens
+import Control.Monad.Catch
+import Control.Monad.Trans.Except
+import Control.Timeout (timeout)
 import Data.Aeson
 import Data.Aeson.TH
+import Data.Either.Extra
 import Data.Pool
 import Data.Text (unpack)
+import Data.Time.Units
 import Imports
 import qualified Network.HaskellNet.SMTP as SMTP
 import qualified Network.HaskellNet.SMTP.SSL as SMTP
@@ -50,17 +56,40 @@ deriveJSON defaultOptions {constructorTagModifier = map toLower} ''SMTPConnType
 
 makeLenses ''SMTP
 
+data SMTPFailure = Unauthorized | ConnectionTimeout | CaughtException SomeException
+
+data SMTPPoolException = SMTPUnauthorized | SMTPConnectionTimeout
+  deriving (Show)
+
+instance Exception SMTPPoolException
+
 initSMTP :: Logger -> Text -> Maybe PortNumber -> Maybe (Username, Password) -> SMTPConnType -> IO SMTP
 initSMTP lg host port credentials connType = do
   -- Try to initiate a connection and fail badly right away in case of bad auth
   -- otherwise config errors will be detected "too late"
-  (success, _) <- connect
-  unless success $
-    error "Failed to authenticate against the SMTP server"
-  SMTP <$> createPool create destroy 1 5 5
+  res <- runExceptT establishConnection
+  logResult res
+  case res of
+    Left Unauthorized ->
+      error "Failed to authenticate against the SMTP server"
+    Left ConnectionTimeout ->
+      error "Failed to connect to SMTP server. Connection timeout."
+    Left (CaughtException e) ->
+      error $ "Caught exception while trying to connect to SMTP server : " ++ show e
+    Right con -> do
+      -- TODO: gracefullyCloseSMTP may throw
+      SMTP.gracefullyCloseSMTP con
+      SMTP <$> createPool create destroy 1 5 5
   where
-    connect = do
-      conn <- case (connType, port) of
+    liftSMTP :: IO a -> ExceptT SMTPFailure IO a
+    liftSMTP action =
+      ExceptT $
+        CE.handle (\e -> (pure . Left . CaughtException) e) $
+          maybeToEither ConnectionTimeout <$> ensureSMTPConnectionTimeout action
+
+    establishConnection :: ExceptT SMTPFailure IO SMTP.SMTPConnection
+    establishConnection = do
+      conn <- liftSMTP $ case (connType, port) of
         (Plain, Nothing) -> SMTP.connectSMTP (unpack host)
         (Plain, Just p) -> SMTP.connectSMTPPort (unpack host) p
         (TLS, Nothing) -> SMTP.connectSMTPSTARTTLS (unpack host)
@@ -72,18 +101,59 @@ initSMTP lg host port credentials connType = do
           SMTP.connectSMTPSSLWithSettings (unpack host) $
             SMTP.defaultSettingsSMTPSSL {SMTP.sslPort = p}
       ok <- case credentials of
-        (Just (Username u, Password p)) -> SMTP.authenticate SMTP.LOGIN (unpack u) (unpack p) conn
+        (Just (Username u, Password p)) -> liftSMTP $ SMTP.authenticate SMTP.LOGIN (unpack u) (unpack p) conn
         _ -> pure True
-      pure (ok, conn)
-    create = do
-      (ok, conn) <- connect
       if ok
-        then Logger.log lg Logger.Debug (msg $ val "Established connection to: " +++ host)
-        else Logger.log lg Logger.Warn (msg $ val "Failed to established connection, check your credentials to connect to: " +++ host)
-      pure conn
-    destroy c = do
-      SMTP.closeSMTP c
-      Logger.log lg Logger.Debug (msg $ val "Closing connection to: " +++ host)
+        then pure conn
+        else throwE Unauthorized
 
-sendMail :: MonadIO m => SMTP -> Mail -> m ()
-sendMail s m = liftIO $ withResource (s ^. pool) $ SMTP.sendMail m
+    create :: IO SMTP.SMTPConnection
+    create = do
+      res <- runExceptT establishConnection
+      logResult res
+      case res of
+        Left Unauthorized -> do
+          CE.throw SMTPUnauthorized
+        Left ConnectionTimeout -> do
+          CE.throw SMTPConnectionTimeout
+        Left (CaughtException e) -> do
+          CE.throw e
+        Right con -> do
+          pure con
+
+    logResult :: MonadIO m => Either SMTPFailure SMTP.SMTPConnection -> m ()
+    logResult res =
+      case res of
+        Left Unauthorized -> do
+          Logger.log lg Logger.Warn (msg $ val "Failed to established connection, check your credentials to connect to: " +++ host)
+        Left ConnectionTimeout -> do
+          Logger.log lg Logger.Warn (msg $ (val "Failed to connect to : " +++ host) +++ val " . Connection timeout.")
+        Left (CaughtException e) -> do
+          Logger.log lg Logger.Warn (msg $ val "Caught exception while trying to connect to SMTP server : " +++ show e)
+        Right _ -> do
+          Logger.log lg Logger.Debug (msg $ val "Established connection to: " +++ host)
+
+    destroy c = do
+      Logger.log lg Logger.Debug (msg $ val "Closing connection to: " +++ host)
+      -- TODO: gracefullyCloseSMTP may throw
+      r <- ensureSMTPConnectionTimeout $ SMTP.gracefullyCloseSMTP c
+      if isJust r
+        then Logger.log lg Logger.Debug (msg $ val "Closed connection to: " +++ host)
+        else Logger.log lg Logger.Debug (msg $ val "Closing connection to " +++ host +++ val " timed out")
+
+sendMail :: (MonadIO m, MonadCatch m) => Logger -> SMTP -> Mail -> m ()
+sendMail lg s m = liftIO $ withResource (s ^. pool) sendMail'
+  where
+    sendMail' c = ensureSMTPConnectionTimeout (SMTP.sendMail m c) >>= handleTimeout
+    handleTimeout r =
+      if isJust r
+        then do
+          Logger.log lg Logger.Debug (msg $ val "Sent mail")
+          pure ()
+        else do
+          Logger.log lg Logger.Debug (msg $ val "Sending mail timed out. Mail not sent.")
+          CE.throw SMTPConnectionTimeout
+
+-- TODO: Timeout may throw
+ensureSMTPConnectionTimeout :: (MonadIO m, MonadCatch m) => m a -> m (Maybe a)
+ensureSMTPConnectionTimeout action = timeout (15 :: Second) action

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -109,7 +109,7 @@ initSMTP' timeoutDuration lg host port credentials connType = do
           establishConnection
       )
       ( \(e :: SomeException) -> do
-          -- Ensure that the logs are written: In case of failure, the errors thrown
+          -- Ensure that the logs are written: In case of failure, the error thrown
           -- below will kill the app (which could otherwise leave the logs unwritten).
           flush lg
           error $ "Failed to establish test connection with SMTP server: " ++ show e
@@ -119,7 +119,7 @@ initSMTP' timeoutDuration lg host port credentials connType = do
         ensureSMTPConnectionTimeout timeoutDuration (SMTP.gracefullyCloseSMTP con)
     )
     ( \(e :: SomeException) -> do
-        -- Ensure that the logs are written: In case of failure, the errors thrown
+        -- Ensure that the logs are written: In case of failure, the error thrown
         -- below will kill the app (which could otherwise leave the logs unwritten).
         flush lg
         error $ "Failed to close test connection with SMTP server: " ++ show e

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -116,6 +116,7 @@ initSMTP lg host port credentials connType = do
         Right con -> do
           pure con
 
+    destroy :: SMTP.SMTPConnection -> IO ()
     destroy c =
       (ensureSMTPConnectionTimeout . SMTP.gracefullyCloseSMTP) c
         >>= void . logResult lg ("Closing connection to " ++ unpack host)
@@ -138,6 +139,7 @@ logResult lg actionString res =
 sendMail :: (MonadIO m, MonadCatch m) => Logger -> SMTP -> Mail -> m ()
 sendMail lg s m = liftIO $ withResource (s ^. pool) sendMail'
   where
+    sendMail' :: SMTP.SMTPConnection -> IO ()
     sendMail' c = ensureSMTPConnectionTimeout (SMTP.sendMail m c) >>= handleTimeout
 
     handleTimeout :: MonadIO m => Either SMTPFailure a -> m ()

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -75,7 +75,7 @@ initSMTP lg host port credentials connType = do
   -- Try to initiate a connection and fail badly right away in case of bad auth
   -- otherwise config errors will be detected "too late"
   res <- runExceptT establishConnection
-  logResult lg ("Checking test connection to " ++ unpack host ++ "on startup") res
+  logResult lg ("Checking test connection to " ++ unpack host ++ " on startup") res
   case res of
     Left e ->
       error $ "Failed to establish test connection with SMTP server. " ++ show e
@@ -116,13 +116,13 @@ initSMTP lg host port credentials connType = do
     create :: IO SMTP.SMTPConnection
     create = do
       res <- runExceptT establishConnection
-      logResult lg "Creating connection for SMTP connection pool" res
+      logResult lg "Creating pooled SMTP connection" res
       handleError res
 
     destroy :: SMTP.SMTPConnection -> IO ()
     destroy c =
       (ensureSMTPConnectionTimeout . SMTP.gracefullyCloseSMTP) c
-        >>= void . logResult lg ("Closing SMTP connection to " ++ unpack host)
+        >>= void . logResult lg ("Closing pooled SMTP connection to " ++ unpack host)
 
 handleError :: MonadIO m => Either SMTPFailure a -> m a
 handleError = \case

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -212,6 +212,14 @@ logResult lg actionString res =
 defaultTimeoutDuration :: Second
 defaultTimeoutDuration = 15 :: Second
 
+-- | Wrapper function for `SMTP` network actions
+--
+-- This function ensures that @action@ finishes in a given period of time.
+-- Additionally, all exceptions are caught and transformed into @Left
+-- (CaughtException e)@. Staying in @Either SMTPFailure a@ makes error handling
+-- in this module a lot easier compared to having to deal with both, failure
+-- values and exceptions. (We cannot be sure which exceptions may arise as this
+-- depends on a stack of libraries...)
 ensureSMTPConnectionTimeout :: (MonadIO m, MonadCatch m, TimeUnit t) => t -> m a -> m (Either SMTPFailure a)
 ensureSMTPConnectionTimeout timeoutDuration action =
   catch

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -17,7 +17,15 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Brig.SMTP where
+module Brig.SMTP
+  ( sendMail,
+    initSMTP,
+    SMTPConnType (..),
+    SMTP (..),
+    Username (..),
+    Password (..),
+  )
+where
 
 import qualified Control.Exception as CE (throw)
 import Control.Lens

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -212,7 +212,7 @@ logExceptionOrResult lg actionString action = do
 -- servers / network components aren't playing tricks to us. Other cases should
 -- be handled by the network libraries themselves.
 defaultTimeoutDuration :: Second
-defaultTimeoutDuration = 15 :: Second
+defaultTimeoutDuration = 15
 
 -- | Wrapper function for `SMTP` network actions
 --

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -68,14 +68,10 @@ initSMTP lg host port credentials connType = do
   -- Try to initiate a connection and fail badly right away in case of bad auth
   -- otherwise config errors will be detected "too late"
   res <- runExceptT establishConnection
-  logResult res
+  logResult lg ("Checking connection to " ++ unpack host ++ "on startup") res
   case res of
-    Left Unauthorized ->
-      error "Failed to authenticate against the SMTP server"
-    Left ConnectionTimeout ->
-      error "Failed to connect to SMTP server. Connection timeout."
-    Left (CaughtException e) ->
-      error $ "Caught exception while trying to connect to SMTP server : " ++ show e
+    Left _ ->
+      error "Failed to establish connection with SMTP server."
     Right con -> do
       -- TODO: gracefullyCloseSMTP may throw
       SMTP.gracefullyCloseSMTP con
@@ -84,8 +80,7 @@ initSMTP lg host port credentials connType = do
     liftSMTP :: IO a -> ExceptT SMTPFailure IO a
     liftSMTP action =
       ExceptT $
-        CE.handle (\e -> (pure . Left . CaughtException) e) $
-          maybeToEither ConnectionTimeout <$> ensureSMTPConnectionTimeout lg action
+        CE.handle (\e -> (pure . Left . CaughtException) e) $ ensureSMTPConnectionTimeout action
 
     establishConnection :: ExceptT SMTPFailure IO SMTP.SMTPConnection
     establishConnection = do
@@ -110,7 +105,7 @@ initSMTP lg host port credentials connType = do
     create :: IO SMTP.SMTPConnection
     create = do
       res <- runExceptT establishConnection
-      logResult res
+      logResult lg "Creating connection for connection pool" res
       case res of
         Left Unauthorized -> do
           CE.throw SMTPUnauthorized
@@ -121,44 +116,44 @@ initSMTP lg host port credentials connType = do
         Right con -> do
           pure con
 
-    logResult :: MonadIO m => Either SMTPFailure SMTP.SMTPConnection -> m ()
-    logResult res =
-      case res of
-        Left Unauthorized -> do
-          Logger.log lg Logger.Warn (msg $ val "Failed to established connection, check your credentials to connect to: " +++ host)
-        Left ConnectionTimeout -> do
-          Logger.log lg Logger.Warn (msg $ (val "Failed to connect to : " +++ host) +++ val " . Connection timeout.")
-        Left (CaughtException e) -> do
-          Logger.log lg Logger.Warn (msg $ val "Caught exception while trying to connect to SMTP server : " +++ show e)
-        Right _ -> do
-          Logger.log lg Logger.Debug (msg $ val "Established connection to: " +++ host)
-
     destroy c = do
       Logger.log lg Logger.Debug (msg $ val "Closing connection to: " +++ host)
-      -- TODO: gracefullyCloseSMTP may throw
-      r <- ensureSMTPConnectionTimeout lg $ SMTP.gracefullyCloseSMTP c
-      if isJust r
+      r <- ensureSMTPConnectionTimeout $ SMTP.gracefullyCloseSMTP c
+      if isRight r
         then Logger.log lg Logger.Debug (msg $ val "Closed connection to: " +++ host)
         else Logger.log lg Logger.Debug (msg $ val "Closing connection to " +++ host +++ val " timed out")
+
+logResult :: MonadIO m => Logger -> String -> Either SMTPFailure c -> m ()
+logResult lg actionString res =
+  case res of
+    Left Unauthorized -> do
+      Logger.log lg Logger.Warn (msg $ concatToVal actionString "Failed to established connection, check your credentials.")
+    Left ConnectionTimeout -> do
+      Logger.log lg Logger.Warn (msg $ concatToVal actionString "Connection timeout.")
+    Left (CaughtException e) -> do
+      Logger.log lg Logger.Warn (msg $ concatToVal actionString ("Caught exception : " ++ show e))
+    Right _ -> do
+      Logger.log lg Logger.Debug (msg $ concatToVal actionString "Succeeded.")
+  where
+    concatToVal :: ToBytes s1 => s1 -> String -> Builder
+    concatToVal a b = a +++ (" : " :: String) +++ b
 
 sendMail :: (MonadIO m, MonadCatch m) => Logger -> SMTP -> Mail -> m ()
 sendMail lg s m = liftIO $ withResource (s ^. pool) sendMail'
   where
-    sendMail' c = ensureSMTPConnectionTimeout lg (SMTP.sendMail m c) >>= handleTimeout
-    handleTimeout r =
-      if isJust r
-        then do
-          Logger.log lg Logger.Debug (msg $ val "Sent mail")
-          pure ()
-        else do
-          Logger.log lg Logger.Debug (msg $ val "Sending mail timed out. Mail not sent.")
-          CE.throw SMTPConnectionTimeout
+    sendMail' c = ensureSMTPConnectionTimeout (SMTP.sendMail m c) >>= handleTimeout
 
-ensureSMTPConnectionTimeout :: (MonadIO m, MonadCatch m) => Logger -> m a -> m (Maybe a)
-ensureSMTPConnectionTimeout lg action =
+    handleTimeout :: MonadIO m => Either SMTPFailure a -> m ()
+    handleTimeout r =
+      logResult lg "Sending mail" r
+        >> if isRight r
+          then do
+            pure ()
+          else do
+            CE.throw SMTPConnectionTimeout
+
+ensureSMTPConnectionTimeout :: (MonadIO m, MonadCatch m) => m a -> m (Either SMTPFailure a)
+ensureSMTPConnectionTimeout action =
   catch
-    (timeout (15 :: Second) action)
-    ( \(e :: SomeException) ->
-        Logger.log lg Logger.Warn (msg $ val "Caught exception while trying to connect to SMTP server : " +++ show e)
-          >> pure Nothing
-    )
+    (maybe (Left ConnectionTimeout) Right <$> timeout (15 :: Second) action)
+    (\(e :: SomeException) -> pure (Left (CaughtException e)))

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -115,7 +115,7 @@ initSMTP lg host port credentials connType = do
     create :: IO SMTP.SMTPConnection
     create = do
       res <- runExceptT establishConnection
-      logResult lg "Creating connection for connection pool" res
+      logResult lg "Creating connection for SMTP connection pool" res
       case res of
         Left Unauthorized -> do
           CE.throw SMTPUnauthorized
@@ -129,7 +129,7 @@ initSMTP lg host port credentials connType = do
     destroy :: SMTP.SMTPConnection -> IO ()
     destroy c =
       (ensureSMTPConnectionTimeout . SMTP.gracefullyCloseSMTP) c
-        >>= void . logResult lg ("Closing connection to " ++ unpack host)
+        >>= void . logResult lg ("Closing SMTP connection to " ++ unpack host)
 
 logResult :: MonadIO m => Logger -> String -> Either SMTPFailure c -> m ()
 logResult lg actionString res =
@@ -163,5 +163,5 @@ sendMail lg s m = liftIO $ withResource (s ^. pool) sendMail'
 
     handleTimeout :: MonadIO m => Either SMTPFailure a -> m ()
     handleTimeout r =
-      logResult lg "Sending mail" r
+      logResult lg "Sending mail via SMTP" r
         >> either (const (CE.throw SMTPConnectionTimeout)) (const (pure ())) r

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -220,11 +220,7 @@ defaultTimeoutDuration = 15 :: Second
 -- Throws on a timeout. Exceptions of @action@ are propagated (re-thrown).
 ensureSMTPConnectionTimeout :: (MonadIO m, MonadCatch m, TimeUnit t) => t -> m a -> m a
 ensureSMTPConnectionTimeout timeoutDuration action =
-  timeout timeoutDuration action >>= \mbA ->
-    ( case mbA of
-        Just a -> pure a
-        Nothing -> CE.throw SMTPConnectionTimeout
-    )
+  timeout timeoutDuration action >>= maybe (CE.throw SMTPConnectionTimeout) pure
 
 -- | Send a `Mail` via an existing `SMTP` connection pool
 --

--- a/services/brig/src/Brig/SMTP.hs
+++ b/services/brig/src/Brig/SMTP.hs
@@ -116,7 +116,7 @@ initSMTP' timeoutDuration lg host port credentials connType = do
       error $ "Failed to establish test connection with SMTP server: " ++ show e
     Right con ->
       either
-        (error "Failed to establish test connection with SMTP server.")
+        (error "Failed to close test connection with SMTP server.")
         (const (SMTP <$> createPool create destroy 1 5 5))
         =<< do
           r <- ensureSMTPConnectionTimeout timeoutDuration (SMTP.gracefullyCloseSMTP con)
@@ -151,7 +151,7 @@ initSMTP' timeoutDuration lg host port credentials connType = do
     create :: IO SMTP.SMTPConnection
     create = do
       res <- runExceptT establishConnection
-      logResult lg "Creating pooled SMTP connection" res
+      logResult lg ("Creating pooled SMTP connection to " ++ unpack host) res
       throwOnLeft res
 
     destroy :: SMTP.SMTPConnection -> IO ()
@@ -173,7 +173,7 @@ logResult lg actionString res =
       Logger.log
         lg
         Logger.Warn
-        (msg $ concatToVal actionString "Failed to established connection, check your credentials.")
+        (msg $ concatToVal actionString "Failed to establish connection, check your credentials.")
     Left ConnectionTimeout -> do
       Logger.log lg Logger.Warn (msg $ concatToVal actionString "Connection timeout.")
     Left (CaughtException e) -> do

--- a/services/brig/src/Brig/User/Email.hs
+++ b/services/brig/src/Brig/User/Email.hs
@@ -42,6 +42,7 @@ import Brig.Types.Activation (ActivationPair)
 import Brig.Types.User (PasswordResetPair)
 import Brig.User.Template
 import Control.Lens (view)
+import Control.Monad.Catch
 import qualified Data.Code as Code
 import Data.Json.Util (fromUTCTimeMillis)
 import Data.Range
@@ -55,6 +56,7 @@ import Wire.API.User.Password
 
 sendVerificationMail ::
   ( MonadIO m,
+    MonadCatch m,
     MonadReader Env m
   ) =>
   Email ->
@@ -69,7 +71,8 @@ sendVerificationMail to pair loc = do
 
 sendLoginVerificationMail ::
   ( MonadReader Env m,
-    MonadIO m
+    MonadIO m,
+    MonadCatch m
   ) =>
   Email ->
   Code.Value ->
@@ -82,6 +85,7 @@ sendLoginVerificationMail email code mbLocale = do
 
 sendCreateScimTokenVerificationMail ::
   ( MonadIO m,
+    MonadCatch m,
     MonadReader Env m
   ) =>
   Email ->
@@ -95,6 +99,7 @@ sendCreateScimTokenVerificationMail email code mbLocale = do
 
 sendTeamDeletionVerificationMail ::
   ( MonadIO m,
+    MonadCatch m,
     MonadReader Env m
   ) =>
   Email ->
@@ -108,6 +113,7 @@ sendTeamDeletionVerificationMail email code mbLocale = do
 
 sendActivationMail ::
   ( MonadIO m,
+    MonadCatch m,
     MonadReader Env m
   ) =>
   Email ->
@@ -129,6 +135,7 @@ sendActivationMail to name pair loc ident = do
 
 sendPasswordResetMail ::
   ( MonadIO m,
+    MonadCatch m,
     MonadReader Env m
   ) =>
   Email ->
@@ -143,6 +150,7 @@ sendPasswordResetMail to pair loc = do
 
 sendDeletionEmail ::
   ( MonadIO m,
+    MonadCatch m,
     MonadReader Env m
   ) =>
   Name ->
@@ -158,6 +166,7 @@ sendDeletionEmail name email key code locale = do
 
 sendNewClientEmail ::
   ( MonadIO m,
+    MonadCatch m,
     MonadReader Env m
   ) =>
   Name ->
@@ -172,6 +181,7 @@ sendNewClientEmail name email client locale = do
 
 sendTeamActivationMail ::
   ( MonadIO m,
+    MonadCatch m,
     MonadReader Env m
   ) =>
   Email ->

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -151,11 +151,10 @@ runTests iConf brigOpts otherArgs = do
   federationEndpoints <- API.Federation.tests mg brigOpts b c fedBrigClient
   includeFederationTests <- (== Just "1") <$> Blank.getEnv "INTEGRATION_FEDERATION_TESTS"
   internalApi <- API.Internal.tests brigOpts mg db b (brig iConf) gd g
-  smtp <- SMTP.tests mg lg
 
-  let versionApi = API.Version.tests mg brigOpts b
-
-  let mlsApi = MLS.tests mg b brigOpts
+  let smtp = SMTP.tests mg lg
+      versionApi = API.Version.tests mg brigOpts b
+      mlsApi = MLS.tests mg b brigOpts
 
   withArgs otherArgs . defaultMain
     $ testGroup

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -157,31 +157,31 @@ runTests iConf brigOpts otherArgs = do
 
   let mlsApi = MLS.tests mg b brigOpts
 
-  withArgs otherArgs . defaultMain $
-    testGroup
+  withArgs otherArgs . defaultMain
+    $ testGroup
       "Brig API Integration"
-      $ [ testCase "sitemap" $
-            assertEqual
-              "inconcistent sitemap"
-              mempty
-              (pathsConsistencyCheck . treeToPaths . compile $ Brig.API.sitemap @BrigCanonicalEffects @InternalPaging),
-          userApi,
-          providerApi,
-          searchApis,
-          teamApis,
-          turnApi,
-          metricsApi,
-          settingsApi,
-          createIndex,
-          userPendingActivation,
-          browseTeam,
-          federationEndpoints,
-          internalApi,
-          versionApi,
-          mlsApi,
-          smtp
-        ]
-        <> [federationEnd2End | includeFederationTests]
+    $ [ testCase "sitemap" $
+          assertEqual
+            "inconcistent sitemap"
+            mempty
+            (pathsConsistencyCheck . treeToPaths . compile $ Brig.API.sitemap @BrigCanonicalEffects @InternalPaging),
+        userApi,
+        providerApi,
+        searchApis,
+        teamApis,
+        turnApi,
+        metricsApi,
+        settingsApi,
+        createIndex,
+        userPendingActivation,
+        browseTeam,
+        federationEndpoints,
+        internalApi,
+        versionApi,
+        mlsApi,
+        smtp
+      ]
+      <> [federationEnd2End | includeFederationTests]
   where
     mkRequest (Endpoint h p) = host (encodeUtf8 h) . port p
 

--- a/services/brig/test/integration/SMTP.hs
+++ b/services/brig/test/integration/SMTP.hs
@@ -23,9 +23,7 @@ tests m lg =
     testGroup
       "SMTP"
       [ test m "should send mail" $ testSendMail lg,
-        -- TODO: Needs better description string: Actually, the SMTP server
-        -- refuses to accept this mail.
-        test m "should send no mail without receiver" $ testSendMailNoReceiver lg,
+        test m "should throw exception when SMTP server refuses to send mail (mail without receiver)" $ testSendMailNoReceiver lg,
         test m "should throw when an SMTP transaction is aborted (SMTP error 554: 'Transaction failed')" $ testSendMailTransactionFailed lg,
         test m "should throw an error when the connection cannot be initiated on startup" $ testSendMailFailingConnectionOnStartup lg,
         test m "should throw when the server cannot be reached on sending" $ testSendMailFailingConnectionOnSend lg

--- a/services/brig/test/integration/SMTP.hs
+++ b/services/brig/test/integration/SMTP.hs
@@ -14,6 +14,7 @@ import qualified Network.Mail.Postie as Postie
 import Network.Socket
 import qualified Pipes.Prelude
 import qualified System.Logger as Logger
+import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.HUnit
 import Util
@@ -31,9 +32,12 @@ tests m lg =
       test m "should throw an error the initiation times out" $ testSendMailTimeoutOnStartup lg
     ]
 
+randomPortNumber :: MonadIO m => m PortNumber
+randomPortNumber = liftIO $ generate arbitrary
+
 testSendMailTimeoutOnStartup :: Logger.Logger -> Bilge.Http ()
 testSendMailTimeoutOnStartup lg = do
-  let port = 4242
+  port <- randomPortNumber
   mbException <-
     liftIO $
       everDelayingTCPServer port $
@@ -44,7 +48,7 @@ testSendMailTimeoutOnStartup lg = do
 
 testSendMailTimeout :: Logger.Logger -> Bilge.Http ()
 testSendMailTimeout lg = do
-  let port = 4243
+  port <- randomPortNumber
   mbException <-
     liftIO $
       withMailServer port (delayingApp (3 :: Second)) $
@@ -58,7 +62,7 @@ testSendMailTimeout lg = do
 
 testSendMailFailingConnectionOnSend :: Logger.Logger -> Bilge.Http ()
 testSendMailFailingConnectionOnSend lg = do
-  let port = 4244
+  port <- randomPortNumber
   receivedMailRef <- liftIO $ newIORef Nothing
   conPool <-
     liftIO $
@@ -77,7 +81,7 @@ testSendMailFailingConnectionOnSend lg = do
 
 testSendMailFailingConnectionOnStartup :: Logger.Logger -> Bilge.Http ()
 testSendMailFailingConnectionOnStartup lg = do
-  let port = 4245
+  port <- randomPortNumber
   caughtError <-
     liftIO $
       handle @ErrorCall
@@ -87,7 +91,7 @@ testSendMailFailingConnectionOnStartup lg = do
 
 testSendMailNoReceiver :: Logger.Logger -> Bilge.Http ()
 testSendMailNoReceiver lg = do
-  let port = 4246
+  port <- randomPortNumber
   receivedMailRef <- liftIO $ newIORef Nothing
   liftIO
     . withMailServer port (mailStoringApp receivedMailRef)
@@ -101,7 +105,7 @@ testSendMailNoReceiver lg = do
 
 testSendMail :: Logger.Logger -> Bilge.Http ()
 testSendMail lg = do
-  let port = 4247
+  port <- randomPortNumber
   receivedMailRef <- liftIO $ newIORef Nothing
   liftIO
     . withMailServer port (mailStoringApp receivedMailRef)
@@ -155,7 +159,7 @@ toString bs = C.foldr (:) [] bs
 
 testSendMailTransactionFailed :: Logger.Logger -> Bilge.Http ()
 testSendMailTransactionFailed lg = do
-  let port = 4248
+  port <- randomPortNumber
   liftIO
     . withMailServer port mailRejectingApp
     $ do

--- a/services/brig/test/integration/SMTP.hs
+++ b/services/brig/test/integration/SMTP.hs
@@ -1,0 +1,23 @@
+module SMTP where
+
+import Bilge
+import Brig.SMTP
+import Imports
+import Network.Mail.Postie
+import qualified System.Logger as Logger
+import Test.Tasty
+import Util
+
+-- TODO: Is IO needed here?
+tests :: Manager -> Logger.Logger -> IO TestTree
+tests m lg =
+  pure $
+    testGroup
+      "SMTP"
+      [ test m "should send mail" $ testSendMail lg
+      ]
+
+-- TODO: Is Http the best Monad for this?
+testSendMail :: Logger.Logger -> Http ()
+testSendMail lg = do
+  initSMTP lg Text (Maybe PortNumber) (Maybe (Username, Password)) Plain

--- a/services/brig/test/integration/SMTP.hs
+++ b/services/brig/test/integration/SMTP.hs
@@ -58,6 +58,7 @@ testSendMail lg = do
         @=? [(unpack . addressEmail) receiver]
       let mailContent = (rmContent . fromJust) mbMail
       elem ((unpack . toStrict) body) mailContent @? "Expected the SMTP server to receive the mail body."
+      elem ("Subject: " ++ unpack subject) mailContent @? "Expected the SMTP server to receive the mail subject."
   where
     receiver = Address Nothing "foo@example.com"
     sender = Address Nothing "bar@example.com"
@@ -92,8 +93,12 @@ withMailServer app action =
 data ReceivedMail = ReceivedMail
   { rmSender :: Postie.Address,
     rmReceipients :: [Postie.Address],
+    -- | Contains all data sent to the SMTP server for this mail. (Including
+    -- /From:/, /To:/, /Subject:/, ... lines.) I.e. `Postie.mailBody` is half of
+    -- a lie; it's way more.
     rmContent :: [String]
   }
+  deriving (Eq, Show)
 
 mailStoringApp :: IORef (Maybe ReceivedMail) -> Postie.Application
 mailStoringApp receivedMailRef mail = do

--- a/services/brig/test/integration/SMTP.hs
+++ b/services/brig/test/integration/SMTP.hs
@@ -23,6 +23,8 @@ tests m lg =
     testGroup
       "SMTP"
       [ test m "should send mail" $ testSendMail lg,
+        -- TODO: Needs better description string: Actually, the SMTP server
+        -- refuses to accept this mail.
         test m "should send no mail without receiver" $ testSendMailNoReceiver lg
       ]
 

--- a/services/brig/test/integration/SMTP.hs
+++ b/services/brig/test/integration/SMTP.hs
@@ -17,17 +17,16 @@ import Test.Tasty.HUnit
 import Util
 
 -- TODO: Is IO needed here?
-tests :: Bilge.Manager -> Logger.Logger -> IO TestTree
+tests :: Bilge.Manager -> Logger.Logger -> TestTree
 tests m lg =
-  pure $
-    testGroup
-      "SMTP"
-      [ test m "should send mail" $ testSendMail lg,
-        test m "should throw exception when SMTP server refuses to send mail (mail without receiver)" $ testSendMailNoReceiver lg,
-        test m "should throw when an SMTP transaction is aborted (SMTP error 554: 'Transaction failed')" $ testSendMailTransactionFailed lg,
-        test m "should throw an error when the connection cannot be initiated on startup" $ testSendMailFailingConnectionOnStartup lg,
-        test m "should throw when the server cannot be reached on sending" $ testSendMailFailingConnectionOnSend lg
-      ]
+  testGroup
+    "SMTP"
+    [ test m "should send mail" $ testSendMail lg,
+      test m "should throw exception when SMTP server refuses to send mail (mail without receiver)" $ testSendMailNoReceiver lg,
+      test m "should throw when an SMTP transaction is aborted (SMTP error 554: 'Transaction failed')" $ testSendMailTransactionFailed lg,
+      test m "should throw an error when the connection cannot be initiated on startup" $ testSendMailFailingConnectionOnStartup lg,
+      test m "should throw when the server cannot be reached on sending" $ testSendMailFailingConnectionOnSend lg
+    ]
 
 testSendMailFailingConnectionOnSend :: Logger.Logger -> Bilge.Http ()
 testSendMailFailingConnectionOnSend lg = do

--- a/services/brig/test/integration/SMTP.hs
+++ b/services/brig/test/integration/SMTP.hs
@@ -167,19 +167,8 @@ testSendMailTransactionFailed lg = do
       caughtException <-
         handle @SomeException
           (const (pure True))
-          (sendMail lg conPool mail >> pure False)
+          (sendMail lg conPool someTestMail >> pure False)
       caughtException @? "Expected exception due to missing mail receiver."
-  where
-    receiver = Address Nothing "foo@example.com"
-    sender = Address Nothing "bar@example.com"
-    subject = "Some Subject"
-    body = "Some body"
-    mail =
-      simpleMail'
-        receiver
-        sender
-        subject
-        body
 
 withMailServer :: PortNumber -> Postie.Application -> IO a -> IO a
 withMailServer port app action = do

--- a/services/brig/test/integration/SMTP.hs
+++ b/services/brig/test/integration/SMTP.hs
@@ -1,27 +1,33 @@
 module SMTP where
 
-import Bilge
+import qualified Bilge
 import Brig.SMTP
 import Control.Exception
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as C
+import Data.Text (unpack)
+import Data.Text.Lazy (toStrict)
 import Imports
 import Network.Mail.Mime
 import qualified Network.Mail.Postie as Postie
+import qualified Pipes.Prelude
 import qualified System.Logger as Logger
 import Test.Tasty
 import Test.Tasty.HUnit
 import Util
 
 -- TODO: Is IO needed here?
-tests :: Manager -> Logger.Logger -> IO TestTree
+tests :: Bilge.Manager -> Logger.Logger -> IO TestTree
 tests m lg =
   pure $
     testGroup
       "SMTP"
-      [ test m "should send no mail without receiver" $ testSendMailNoReceiver lg
+      [ test m "should send mail" $ testSendMail lg,
+        test m "should send no mail without receiver" $ testSendMailNoReceiver lg
       ]
 
 -- TODO: Is Http the best Monad for this?
-testSendMailNoReceiver :: Logger.Logger -> Http ()
+testSendMailNoReceiver :: Logger.Logger -> Bilge.Http ()
 testSendMailNoReceiver lg = do
   receivedMailRef <- liftIO $ newIORef Nothing
   liftIO
@@ -34,11 +40,47 @@ testSendMailNoReceiver lg = do
           (sendMail lg conPool (emptyMail (Address Nothing "foo@example.com")) >> pure False)
       caughtException @? "Expected exception due to missing mail receiver."
 
---      traceM "Sent mail"
---      mbMail <-
---        retryWhileN 3 isJust $ do
---          readIORef receivedMailRef
---      isJust mbMail @? "Expected to receive mail"
+testSendMail :: Logger.Logger -> Bilge.Http ()
+testSendMail lg = do
+  receivedMailRef <- liftIO $ newIORef Nothing
+  liftIO
+    . withMailServer (mailStoringApp receivedMailRef)
+    $ do
+      conPool <- initSMTP lg "localhost" (Just 4242) Nothing Plain
+      sendMail lg conPool mail
+      mbMail <-
+        retryWhileN 3 isJust $ do
+          readIORef receivedMailRef
+      isJust mbMail @? "Expected to receive mail"
+      postieAddressAsString . rmSender <$> mbMail
+        @=? (Just . unpack . addressEmail) sender
+      postieAddressAsString <$> (concat . maybeToList) (rmReceipients <$> mbMail)
+        @=? [(unpack . addressEmail) receiver]
+      let mailContent = (rmContent . fromJust) mbMail
+      elem ((unpack . toStrict) body) mailContent @? "Expected the SMTP server to receive the mail body."
+  where
+    receiver = Address Nothing "foo@example.com"
+    sender = Address Nothing "bar@example.com"
+    subject = "Some Subject"
+    body = "Some body"
+    mail =
+      simpleMail'
+        receiver
+        sender
+        subject
+        body
+    postieAddressAsString :: Postie.Address -> String
+    postieAddressAsString addr =
+      toString
+        ( B.concat
+            [ Postie.addressLocalPart addr,
+              C.singleton '@',
+              Postie.addressDomain addr
+            ]
+        )
+
+toString :: B.ByteString -> String
+toString bs = C.foldr (:) [] bs
 
 withMailServer :: Postie.Application -> IO () -> IO ()
 withMailServer app action =
@@ -47,7 +89,20 @@ withMailServer app action =
     killThread
     (const action)
 
-mailStoringApp :: IORef (Maybe Postie.Mail) -> Postie.Application
-mailStoringApp receivedMailRef mail =
-  writeIORef receivedMailRef (Just mail)
-    >> pure Postie.Accepted
+data ReceivedMail = ReceivedMail
+  { rmSender :: Postie.Address,
+    rmReceipients :: [Postie.Address],
+    rmContent :: [String]
+  }
+
+mailStoringApp :: IORef (Maybe ReceivedMail) -> Postie.Application
+mailStoringApp receivedMailRef mail = do
+  c <- Pipes.Prelude.toListM (Postie.mailBody mail)
+  let receivedMail =
+        ReceivedMail
+          { rmSender = Postie.mailSender mail,
+            rmReceipients = Postie.mailRecipients mail,
+            rmContent = C.unpack <$> c
+          }
+  writeIORef receivedMailRef (Just receivedMail)
+  pure Postie.Accepted

--- a/services/brig/test/integration/SMTP.hs
+++ b/services/brig/test/integration/SMTP.hs
@@ -31,7 +31,6 @@ tests m lg =
       test m "should throw an error the initiation times out" $ testSendMailTimeoutOnStartup lg
     ]
 
--- TODO: Assert all exceptions on their type (not only they exist)
 testSendMailTimeoutOnStartup :: Logger.Logger -> Bilge.Http ()
 testSendMailTimeoutOnStartup lg = do
   let port = 4242
@@ -86,7 +85,6 @@ testSendMailFailingConnectionOnStartup lg = do
         (initSMTP lg "localhost" (Just port) Nothing Plain >> pure False)
   liftIO $ caughtError @? "Expected error (SMTP server unreachable.)"
 
--- TODO: Is Http the best Monad for this?
 testSendMailNoReceiver :: Logger.Logger -> Bilge.Http ()
 testSendMailNoReceiver lg = do
   let port = 4246

--- a/services/brig/test/integration/SMTP.hs
+++ b/services/brig/test/integration/SMTP.hs
@@ -2,10 +2,13 @@ module SMTP where
 
 import Bilge
 import Brig.SMTP
+import Control.Exception
 import Imports
-import Network.Mail.Postie
+import Network.Mail.Mime
+import qualified Network.Mail.Postie as Postie
 import qualified System.Logger as Logger
 import Test.Tasty
+import Test.Tasty.HUnit
 import Util
 
 -- TODO: Is IO needed here?
@@ -14,10 +17,37 @@ tests m lg =
   pure $
     testGroup
       "SMTP"
-      [ test m "should send mail" $ testSendMail lg
+      [ test m "should send no mail without receiver" $ testSendMailNoReceiver lg
       ]
 
 -- TODO: Is Http the best Monad for this?
-testSendMail :: Logger.Logger -> Http ()
-testSendMail lg = do
-  initSMTP lg Text (Maybe PortNumber) (Maybe (Username, Password)) Plain
+testSendMailNoReceiver :: Logger.Logger -> Http ()
+testSendMailNoReceiver lg = do
+  receivedMailRef <- liftIO $ newIORef Nothing
+  liftIO
+    . withMailServer (mailStoringApp receivedMailRef)
+    $ do
+      conPool <- initSMTP lg "localhost" (Just 4242) Nothing Plain
+      caughtException <-
+        handle @SomeException
+          (const (pure True))
+          (sendMail lg conPool (emptyMail (Address Nothing "foo@example.com")) >> pure False)
+      caughtException @? "Expected exception due to missing mail receiver."
+
+--      traceM "Sent mail"
+--      mbMail <-
+--        retryWhileN 3 isJust $ do
+--          readIORef receivedMailRef
+--      isJust mbMail @? "Expected to receive mail"
+
+withMailServer :: Postie.Application -> IO () -> IO ()
+withMailServer app action =
+  bracket
+    (forkIO $ Postie.run 4242 app)
+    killThread
+    (const action)
+
+mailStoringApp :: IORef (Maybe Postie.Mail) -> Postie.Application
+mailStoringApp receivedMailRef mail =
+  writeIORef receivedMailRef (Just mail)
+    >> pure Postie.Accepted


### PR DESCRIPTION
**Problem** to be solved:
When an SMTP server was misconfigured in the `brig` configuration or was misbehaving itself, `brig` was hanging on startup without any useful logs.

**Changes** in this PR:
- Add tests for sending via SMTP. The used SMTP server is [*postie*](https://hackage.haskell.org/package/postie). Unfortunately, the current version of *postie* wasn't compatible to our GHC version due to outdated dependencies. I've updated *postie*'s dependencies and brought it upstream (https://github.com/alexbiehl/postie/commit/c92702386f760fcaa65cd052dc8114889c001e3f). However, these changes are neither on *Hackage* nor in *nixpkgs*, yet. That's why I had to add a Nix override...

- The entry and exit (with result) are now logged. I've separated the log logic from other concerns.

- In the initialization code, logs are flushed before any error is thrown.

- I've added a [`timeout`](https://hackage.haskell.org/package/time-out-0.2/docs/Control-Timeout.html) with a big tolerance to every action. This should prevent use from hanging due to endlessly delaying SMTP servers and other network obscurities.

**Behaviour**:
- Despite logging and an additional exception on `timeout`, the observable behavior should be unchanged. All caught exceptions are logged and then re-thrown as is.

**Output** without and with this patch:

When the SMTP server isn't reachable on startup.
Before:
```
brig: Network.Socket.connect: <socket: 13>: does not exist (Connection refused)
```
Now:
```
brig: Failed to establish test connection with SMTP server: CaughtException Network.Socket.connect: <socket: 13>: does not exist (Connection refused)
CallStack (from HasCallStack):
  error, called at src/Brig/SMTP.hs:116:7 in brig-2.0-inplace:Brig.SMTP
[brig] W, Checking test connection to localhost on startup : Caught exception : Network.Socket.connect: <socket: 13>: does not exist (Connection refused)
```
Where `[brig]` is logged output and `brig:` `stderr/stdout`.

**Ticket**: [SQPIT-497](https://wearezeta.atlassian.net/browse/SQPIT-497)

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
