### PR TITLE
bump nginx-module-vts from v0.1.15 to v0.2.1

### DIFF
--- a/changelog.d/2-features/2827
+++ b/changelog.d/2-features/2827
@@ -1,0 +1,1 @@
+bump nginx-module-vts from v0.1.15 to v0.2.1

--- a/changelog.d/2-features/2827
+++ b/changelog.d/2-features/2827
@@ -1,1 +1,0 @@
-bump nginx-module-vts from v0.1.15 to v0.2.1

--- a/changelog.d/5-internal/bump-nginx-module-vts
+++ b/changelog.d/5-internal/bump-nginx-module-vts
@@ -1,1 +1,1 @@
-bump nginx-module-vts from v0.1.15 to v0.2.1
+bump nginx-module-vts from v0.1.15 to v0.2.1 (#2827)


### PR DESCRIPTION
This PR re-applies the changes from https://github.com/wireapp/wire-server/pull/2793
which were un-done by https://github.com/wireapp/wire-server/pull/2780

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
