### PR TITLE
Bump nixpkgs to latest unstable, unpin openssl

### DIFF
--- a/changelog.d/5-internal/nixpkgs-bump
+++ b/changelog.d/5-internal/nixpkgs-bump
@@ -1,0 +1,1 @@
+Bump nixpkgs to latest unstable. Stop using forked nixpkgs.

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -1,4 +1,4 @@
-{ libsodium, protobuf, hlib, mls-test-cli, openssl }:
+{ libsodium, protobuf, hlib, mls-test-cli }:
 # FUTUREWORK: Figure out a way to detect if some of these packages are not
 # actually marked broken, so we can cleanup this file on every nixpkgs bump.
 hself: hsuper: {
@@ -58,6 +58,4 @@ hself: hsuper: {
 
   # Make hoogle static to reduce size of the hoogle image
   hoogle = hlib.justStaticExecutables hsuper.hoogle;
-
-  HsOpenSSL = hsuper.HsOpenSSL.override { inherit openssl; };
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "hls-hlint-plugin-workaround",
+        "branch": "nixpkgs-unstable",
         "description": "Wire's fork of NixOS/nixpkgs. Use until HLS > 1.7.0.0 is available in NixOS/nixpkgs",
         "homepage": "https://github.com/wireapp/nixpkgs",
-        "owner": "wireapp",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0f8a37f54f802a9e8bcf3bcfa89c5ab2017d9498",
-        "sha256": "1g28g6m3bs8axwkih8ihnv2h8g53s267l7kpaghwxzr65bz6hj7w",
+        "rev": "1f3ebb2bd1a353a42e8f833895c26d8415c7b791",
+        "sha256": "03y1a3lv44b4fdnykyms5nd24v2mqn8acz1xa4jkbmryc29rsgcw",
         "type": "tarball",
-        "url": "https://github.com/wireapp/nixpkgs/archive/0f8a37f54f802a9e8bcf3bcfa89c5ab2017d9498.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/1f3ebb2bd1a353a42e8f833895c26d8415c7b791.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,8 +1,8 @@
 {
     "nixpkgs": {
         "branch": "nixpkgs-unstable",
-        "description": "Wire's fork of NixOS/nixpkgs. Use until HLS > 1.7.0.0 is available in NixOS/nixpkgs",
-        "homepage": "https://github.com/wireapp/nixpkgs",
+        "description": "Nix Packages collection",
+        "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "1f3ebb2bd1a353a42e8f833895c26d8415c7b791",

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -123,7 +123,6 @@ let lib = pkgs.lib;
       ];
     manualOverrides = import ./manual-overrides.nix (with pkgs; {
       inherit hlib libsodium protobuf mls-test-cli;
-      openssl = openssl_1_1;
     });
 
     executables = hself: hsuper:


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQPIT-1478

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
