### PR TITLE
Avoid client deletion edge case condition which can lead to inconsist…

### DIFF
--- a/changelog.d/3-bug-fixes/client-deletion-ordering
+++ b/changelog.d/3-bug-fixes/client-deletion-ordering
@@ -1,0 +1,1 @@
+Avoid client deletion edge case condition which can lead to inconsistent data between brig and galley's clients tables.

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -374,10 +374,10 @@ claimLocalMultiPrekeyBundles protectee userClients = do
 -- | Enqueue an orderly deletion of an existing client.
 execDelete :: UserId -> Maybe ConnId -> Client -> (AppT r) ()
 execDelete u con c = do
-  wrapClient $ Data.rmClient u (clientId c)
   for_ (clientCookie c) $ \l -> wrapClient $ Auth.revokeCookies u [] [l]
   queue <- view internalEvents
   Queue.enqueue queue (Internal.DeleteClient (clientId c) u con)
+  wrapClient $ Data.rmClient u (clientId c)
 
 -- | Defensive measure when no prekey is found for a
 -- requested client: Ensure that the client does indeed


### PR DESCRIPTION
…ent data between brig and galley's clients tables.

This is improving the invariant from the comment

```haskell
-- nb. We must ensure that the set of clients known to brig is always
-- a superset of the clients known to galley.
```

if the process crashes in between these lines; or if there's a problem with adding something to SQS.

This is still not ideal, as there remains a race condition whereby clients will still get a prompt on message sending to also encrypt for a client that is already no longer existing in brig, if there is A) a bug in processing this queue event, or if B) a client tries to send a message after the deletion is processed in brig, but before the deletion has happened on galley. So another follow-up PR, revisiting or perhaps entirely undoing the asynchronous client deletion would be necessary (or galley should be merged into brig, but we shouldn't wait for this, as dealing with data inconsistencies is much more time-consuming that making a small code change here)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
