### PR TITLE
upload docker images: retry, take 2

### DIFF
--- a/hack/bin/upload-image.sh
+++ b/hack/bin/upload-image.sh
@@ -17,8 +17,8 @@ readonly DOCKER_TAG=${DOCKER_TAG:?"Please set the DOCKER_TAG env variable"}
 readonly usage="USAGE: $0 <image_attr>"
 readonly IMAGE_ATTR=${1:?$usage}
 
-SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-ROOT_DIR=$(cd -- "$SCRIPT_DIR/../../" &> /dev/null && pwd)
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+ROOT_DIR=$(cd -- "$SCRIPT_DIR/../../" &>/dev/null && pwd)
 readonly SCRIPT_DIR ROOT_DIR
 
 credsArgs=""
@@ -26,6 +26,39 @@ if [[ "${DOCKER_USER+x}" != "" ]]; then
     DOCKER_PASSWORD=${DOCKER_PASSWORD:?"DOCKER_PASSWORD must be provided when DOCKER_USER is provided"}
     credsArgs="--dest-creds=$DOCKER_USER:$DOCKER_PASSWORD"
 fi
+
+# Retry a command with exponential backoff
+# quay.io sometimes rate-limits us, so try again.
+# Also, skopeo's retry logic doesn't properly work, look here if you want to see very badly written go code:
+# https://github.com/containers/skopeo/blob/869d496f185cc086f22d6bbb79bb57ac3a415617/vendor/github.com/containers/common/pkg/retry/retry.go#L52-L113
+function retry {
+    local maxAttempts=$1
+    local secondsDelay=1
+    local attemptCount=1
+    local output=
+    shift 1
+
+    while [ $attemptCount -le "$maxAttempts" ]; do
+        output=$("$@")
+        local status=$?
+
+        if [ $status -eq 0 ]; then
+            break
+        fi
+
+        if [ $attemptCount -lt "$maxAttempts" ]; then
+            echo "Command [$*] failed after attempt $attemptCount of $maxAttempts. Retrying in $secondsDelay second(s)." >&2
+            sleep $secondsDelay
+        elif [ $attemptCount -eq "$maxAttempts" ]; then
+            echo "Command [$*] failed after $attemptCount attempt(s)" >&2
+            return $status
+        fi
+        attemptCount=$((attemptCount + 1))
+        secondsDelay=$((secondsDelay * 2))
+    done
+
+    echo "$output"
+}
 
 tmp_link_store=$(mktemp -d)
 # Using dockerTools.streamLayeredImage outputs an executable which prints the
@@ -38,8 +71,8 @@ tmp_link_store=$(mktemp -d)
 image_stream_file="$tmp_link_store/image_stream"
 nix -v --show-trace -L build -f "$ROOT_DIR/nix" "$IMAGE_ATTR" -o "$image_stream_file"
 image_file="$tmp_link_store/image"
-"$image_stream_file" > "$image_file"
+"$image_stream_file" >"$image_file"
 repo=$(skopeo list-tags "docker-archive://$image_file" | jq -r '.Tags[0] | split(":") | .[0]')
 printf "*** Uploading $image_file to %s:%s" "$repo" "$DOCKER_TAG"
 # shellcheck disable=SC2086
-skopeo --insecure-policy copy --retry-times 5 $credsArgs "docker-archive://$image_file" "docker://$repo:$DOCKER_TAG"
+retry 5 skopeo --insecure-policy copy --retry-times 5 $credsArgs "docker-archive://$image_file" "docker://$repo:$DOCKER_TAG"


### PR DESCRIPTION
As it turns out, 'skopeo --retry 5' doesn't actually help us. Wrap it in bash, then.
    
To work around:

```
*** Uploading /tmp/tmp.kIKRERgZ1H/image to quay.io/wire/spar-integration:4.25.22Getting image source signatures

Copying blob f4f33343fcb5 skipped: already exists

Copying blob a3ab88edf03d skipped: already exists

Copying blob 9360a695c022 skipped: already exists

Copying blob 62d7b43f88a6 skipped: already exists

Copying blob 134eff2df9f9 skipped: already exists

Copying blob 8834895fc941 skipped: already exists

Copying blob 52a0756d3ab1 done  ======================>----------] 30.0MiB / 40.3MiB

Copying blob fa04d4e808c5 done  ---------------------------------] 8.0b / 190.0KiB

Copying blob 6c806be006f4 skipped: already exists

FATA[0004] trying to reuse blob sha256:95218c34e1598cf423f77062d98259bedcc19c9b8f4d937d0905895ee7b0242e at destination: too many requests to registry

make: *** [Makefile:242: upload-images] Error 1

make: Leaving directory '/tmp/build/80754af9/wire-server'
```

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
