### PR TITLE
[charts:sftd,restund,coturn] Fix case when hostname is not node name

### DIFF
--- a/changelog.d/3-bug-fixes/sftd-restund-coturn-hostname-nodename
+++ b/changelog.d/3-bug-fixes/sftd-restund-coturn-hostname-nodename
@@ -1,0 +1,1 @@
+For sftd/coturn/restund, fixed a bug in external ip address lookup, in case Kubernetes Node Name doesn't equal hostname.

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -60,6 +60,11 @@ spec:
           volumeMounts:
             - name: external-ip
               mountPath: /external-ip
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           command:
             - /bin/sh
             - -c
@@ -67,10 +72,10 @@ spec:
               set -e
   
               # In the cloud, this setting is available to indicate the true IP address
-              addr=$(kubectl get node $HOSTNAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
+              addr=$(kubectl get node $NODE_NAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
               # On on-prem we allow people to set  "wire.com/external-ip" to override this
               if [ -z "$addr" ]; then
-                addr=$(kubectl get node $HOSTNAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
+                addr=$(kubectl get node $NODE_NAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
               fi
               echo -n "$addr" | tee /dev/stderr > /external-ip/ip
       containers:

--- a/charts/restund/templates/statefulset.yaml
+++ b/charts/restund/templates/statefulset.yaml
@@ -53,6 +53,11 @@ spec:
           volumeMounts:
             - name: external-ip
               mountPath: /external-ip
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           command:
             - /bin/sh
             - -c
@@ -60,11 +65,11 @@ spec:
               set -e
 
               # In the cloud, this setting is available to indicate the true IP address
-              addr=$(kubectl get node $HOSTNAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
+              addr=$(kubectl get node $NODE_NAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
 
               # On on-prem we allow people to set  "wire.com/external-ip" to override this
               if [ -z "$addr" ]; then
-                addr=$(kubectl get node $HOSTNAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
+                addr=$(kubectl get node $NODE_NAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
               fi
               echo -n "$addr" | tee /dev/stderr > /external-ip/ip
       containers:

--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -43,6 +43,11 @@ spec:
           volumeMounts:
             - name: external-ip
               mountPath: /external-ip
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           command:
             - /bin/sh
             - -c
@@ -50,11 +55,11 @@ spec:
               set -e
 
               # In the cloud, this setting is available to indicate the true IP address
-              addr=$(kubectl get node $HOSTNAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
+              addr=$(kubectl get node $NODE_NAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
 
               # On on-prem we allow people to set  "wire.com/external-ip" to override this
               if [ -z "$addr" ]; then
-                addr=$(kubectl get node $HOSTNAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
+                addr=$(kubectl get node $NODE_NAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
               fi
               echo -n "$addr" | tee /dev/stderr > /external-ip/ip
         - name: get-multi-sft-config


### PR DESCRIPTION
Kubernetes might be installed in a way where the machine hostname is not used as node name. Using the statefulset's spec to determine the node name would allow for such deviation.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
