### PR TITLE
[FS-899] Define Database Tables for MLS Subconversations

### DIFF
--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -194,6 +194,26 @@ CREATE TABLE galley_test.member (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
+CREATE TABLE galley_test.group_id_subconv_id (
+    group_id blob PRIMARY KEY,
+    domain text,
+    main_id uuid,
+    sub_id text
+) WITH bloom_filter_fp_chance = 0.01
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
+    AND comment = ''
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
+    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1.0
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99PERCENTILE';
+
 CREATE TABLE galley_test.custom_backend (
     domain text PRIMARY KEY,
     config_json_url blob,
@@ -485,6 +505,29 @@ CREATE TABLE galley_test.mls_commit_locks (
     epoch bigint,
     PRIMARY KEY (group_id, epoch)
 ) WITH CLUSTERING ORDER BY (epoch ASC)
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
+    AND comment = ''
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
+    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1.0
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99PERCENTILE';
+
+CREATE TABLE galley_test.subconversation (
+    main_id uuid,
+    sub_id text,
+    clients set<text>,
+    epoch bigint,
+    group_id blob,
+    PRIMARY KEY (main_id, sub_id)
+) WITH CLUSTERING ORDER BY (sub_id ASC)
     AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''

--- a/changelog.d/5-internal/subconversation-db-tables
+++ b/changelog.d/5-internal/subconversation-db-tables
@@ -1,0 +1,1 @@
+Define the MLS subconversation database tables in Galley

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -685,6 +685,7 @@ executable galley-schema
     V74_ExposeInvitationsToTeamAdmin
     V75_MLSGroupInfo
     V76_ProposalOrigin
+    V77_MLSSubconversation
 
   hs-source-dirs:     schema/src
   default-extensions:

--- a/services/galley/schema/src/Main.hs
+++ b/services/galley/schema/src/Main.hs
@@ -79,6 +79,7 @@ import qualified V73_MemberClientTable
 import qualified V74_ExposeInvitationsToTeamAdmin
 import qualified V75_MLSGroupInfo
 import qualified V76_ProposalOrigin
+import qualified V77_MLSSubconversation
 
 main :: IO ()
 main = do
@@ -143,7 +144,8 @@ main = do
       V73_MemberClientTable.migration,
       V74_ExposeInvitationsToTeamAdmin.migration,
       V75_MLSGroupInfo.migration,
-      V76_ProposalOrigin.migration
+      V76_ProposalOrigin.migration,
+      V77_MLSSubconversation.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Galley.Cassandra
       -- (see also docs/developer/cassandra-interaction.md)

--- a/services/galley/schema/src/V77_MLSSubconversation.hs
+++ b/services/galley/schema/src/V77_MLSSubconversation.hs
@@ -15,9 +15,30 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.Cassandra (schemaVersion) where
+module V77_MLSSubconversation (migration) where
 
+import Cassandra.Schema
 import Imports
+import Text.RawString.QQ
 
-schemaVersion :: Int32
-schemaVersion = 77
+migration :: Migration
+migration =
+  Migration 77 "Add the MLS subconversation tables" $ do
+    schema'
+      [r| CREATE TABLE subconversation (
+            main_id uuid,
+            sub_id text,
+            group_id blob,
+            epoch bigint,
+            clients set<text>,
+            PRIMARY KEY (main_id, sub_id)
+          );
+        |]
+    schema'
+      [r| CREATE TABLE group_id_subconv_id (
+            group_id blob PRIMARY KEY,
+            domain text,
+            main_id uuid,
+            sub_id text
+          );
+        |]


### PR DESCRIPTION
The PR just defines the DB tables in Galley for MLS subconversations.

Tracked by https://wearezeta.atlassian.net/browse/FS-899.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
