### PR TITLE
Simplify and cleanup MLS message handling

### DIFF
--- a/changelog.d/5-internal/refactor-mls-message
+++ b/changelog.d/5-internal/refactor-mls-message
@@ -1,0 +1,1 @@
+Refactor and simplify MLS message handling logic

--- a/libs/wire-api/src/Wire/API/Routes/Public.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public.hs
@@ -25,6 +25,7 @@ module Wire.API.Routes.Public
     ZLocalUser,
     ZConn,
     ZOptUser,
+    ZOptClient,
     ZOptConn,
     ZBot,
     ZConversation,
@@ -178,6 +179,8 @@ type ZConversation = ZAuthServant 'ZAuthConv InternalAuthDefOpts
 type ZProvider = ZAuthServant 'ZAuthProvider InternalAuthDefOpts
 
 type ZOptUser = ZAuthServant 'ZAuthUser '[Servant.Optional, Servant.Strict]
+
+type ZOptClient = ZAuthServant 'ZAuthClient '[Servant.Optional, Servant.Strict]
 
 type ZOptConn = ZAuthServant 'ZAuthConn '[Servant.Optional, Servant.Strict]
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
@@ -65,6 +65,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow MLSProposalFailure
                :> "messages"
+               :> ZOptClient
                :> ZConn
                :> ReqBody '[MLS] (RawMLS SomeMessage)
                :> MultiVerb1 'POST '[JSON] (Respond 201 "Message sent" [Event])
@@ -91,6 +92,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow MLSProposalFailure
                :> "messages"
+               :> ZOptClient
                :> ZConn
                :> ReqBody '[MLS] (RawMLS SomeMessage)
                :> MultiVerb1 'POST '[JSON] (Respond 201 "Message sent" MLSMessageSendingStatus)
@@ -118,6 +120,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow MLSProposalFailure
                :> "commit-bundles"
+               :> ZOptClient
                :> ZConn
                :> ReqBody '[CommitBundleMimeType] CommitBundle
                :> MultiVerb1 'POST '[JSON] (Respond 201 "Commit accepted and forwarded" MLSMessageSendingStatus)

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -636,7 +636,7 @@ sendMLSCommitBundle remoteDomain msr =
         qcnv <- E.getConversationIdByGroupId (msgGroupId msg) >>= noteS @'ConvNotFound
         when (qUnqualified qcnv /= F.msrConvId msr) $ throwS @'MLSGroupConversationMismatch
         F.MLSMessageResponseUpdates . map lcuUpdate
-          <$> postMLSCommitBundle loc (qUntagged sender) qcnv Nothing bundle
+          <$> postMLSCommitBundle loc (qUntagged sender) Nothing qcnv Nothing bundle
 
 sendMLSMessage ::
   ( Members
@@ -680,7 +680,7 @@ sendMLSMessage remoteDomain msr =
             qcnv <- E.getConversationIdByGroupId (msgGroupId msg) >>= noteS @'ConvNotFound
             when (qUnqualified qcnv /= F.msrConvId msr) $ throwS @'MLSGroupConversationMismatch
             F.MLSMessageResponseUpdates . map lcuUpdate
-              <$> postMLSMessage loc (qUntagged sender) qcnv Nothing raw
+              <$> postMLSMessage loc (qUntagged sender) Nothing qcnv Nothing raw
 
 class ToGalleyRuntimeError (effs :: EffectRow) r where
   mapToGalleyError ::

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -762,7 +762,6 @@ processInternalCommit qusr senderClient con lconv cm epoch groupId action sender
   self <- noteS @'ConvNotFound $ getConvMember lconv (tUnqualified lconv) qusr
 
   withCommitLock groupId epoch $ do
-    checkEpoch epoch (tUnqualified lconv)
     postponedKeyPackageRefUpdate <-
       if epoch == Epoch 0
         then do
@@ -1312,7 +1311,9 @@ withCommitLock gid epoch action =
           throwS @'MLSStaleMessage
     )
     (const $ releaseCommitLock gid epoch)
-    (const action)
+    $ \_ -> do
+      -- FUTUREWORK: fetch epoch again and check that is matches
+      action
   where
     ttl = fromIntegral (600 :: Int) -- 10 minutes
 

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -286,18 +286,20 @@ postMLSCommitBundleToLocalConv qusr mc conn bundle lcnv = do
                 /= Set.fromList (map (snd . snd) (cmAssocs (paAdd action)))
             )
             $ throwS @'MLSWelcomeMismatch
+        updates <-
+          processCommitWithAction
+            qusr
+            senderClient
+            conn
+            lconv
+            cm
+            (msgEpoch msg)
+            groupId
+            action
+            (msgSender msg)
+            commit
         storeGroupInfoBundle lconv (cbGroupInfoBundle bundle)
-        processCommitWithAction
-          qusr
-          senderClient
-          conn
-          lconv
-          cm
-          (msgEpoch msg)
-          groupId
-          action
-          (msgSender msg)
-          commit
+        pure updates
     ApplicationMessage _ -> throwS @'MLSUnsupportedMessage
     ProposalMessage _ -> throwS @'MLSUnsupportedMessage
 


### PR DESCRIPTION
This is an attempt to simplify and streamline the logic of MLS message handling. There is still a lot of complexity there, but hopefully less than before. This PR also introduces optional Client IDs taken from the tokens into the MLS message handlers. Making those IDs mandatory and changing conversation creation logic in the V3 API will happen in a separate PR.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
