### PR TITLE
nginz deactivate unused upstreams (SQPIT-1174)

### DIFF
--- a/changelog.d/2-features/disable-extra-nginz-upstreams-by-default
+++ b/changelog.d/2-features/disable-extra-nginz-upstreams-by-default
@@ -4,7 +4,7 @@ be enabled by adding their name (entry's key) to
 `nginx_conf.enabled_extra_upstreams`. `nginx_conf.ignored_upstreams` is only
 applied to upstreams from `nginx_conf.upstreams`. In the default configuration
 of `nginz` extra upstreams are `ibis`, `galeb`, `calling-test` and `proxy`. If one
-of those is deployed, it's name has be be added to
+of those is deployed, its name has be be added to
 `nginx_conf.enabled_extra_upstreams` (otherwise, it won't be reachable). Unless
 `nginx_conf.upstreams` hasn't been changed manually (overriding it's default),
 this should be the only needed migration step.

--- a/changelog.d/2-features/disable-extra-nginz-upstreams-by-default
+++ b/changelog.d/2-features/disable-extra-nginz-upstreams-by-default
@@ -1,0 +1,10 @@
+The list of upstreams is split into `nginx_conf.upstreams` and
+`nginx_conf.extra_upstreams`. Extra upstreams are disabled by default. They can
+be enabled by adding their name (entry's key) to
+`nginx_conf.enabled_extra_upstreams`. `nginx_conf.ignored_upstreams` is only
+applied to upstreams from `nginx_conf.upstreams`. In the default configuration
+of `nginz` extra upstreams are `ibis`, `galeb`, `calling-test` and `proxy`. If one
+of those is deployed, it's name has be be added to
+`nginx_conf.enabled_extra_upstreams` (otherwise, it won't be reachable). Unless
+`nginx_conf.upstreams` hasn't been changed manually (overriding it's default),
+this should be the only needed migration step.

--- a/changelog.d/2-features/disable-extra-nginz-upstreams-by-default
+++ b/changelog.d/2-features/disable-extra-nginz-upstreams-by-default
@@ -6,5 +6,5 @@ applied to upstreams from `nginx_conf.upstreams`. In the default configuration
 of `nginz` extra upstreams are `ibis`, `galeb`, `calling-test` and `proxy`. If one
 of those is deployed, its name has be be added to
 `nginx_conf.enabled_extra_upstreams` (otherwise, it won't be reachable). Unless
-`nginx_conf.upstreams` hasn't been changed manually (overriding it's default),
+`nginx_conf.upstreams` hasn't been changed manually (overriding its default),
 this should be the only needed migration step.

--- a/changelog.d/2-features/disable-extra-nginz-upstreams-by-default
+++ b/changelog.d/2-features/disable-extra-nginz-upstreams-by-default
@@ -1,4 +1,4 @@
-The list of upstreams is split into `nginx_conf.upstreams` and
+**Nginz helm chart**: The list of upstreams is split into `nginx_conf.upstreams` and
 `nginx_conf.extra_upstreams`. Extra upstreams are disabled by default. They can
 be enabled by adding their name (entry's key) to
 `nginx_conf.enabled_extra_upstreams`. `nginx_conf.ignored_upstreams` is only

--- a/charts/nginz/templates/_helpers.tpl
+++ b/charts/nginz/templates/_helpers.tpl
@@ -20,13 +20,9 @@ Takes no parameters and returns a merged map of upstreams ('upstreams' and 'extr
 that should be configured.
 */}}
 {{- define "valid_upstreams" -}}
-    {{- toJson $.Values.nginx_conf.upstreams }}
-{{- end -}}
-
-{{- define "valid_upstreams_2" -}}
     {{- range $e := $.Values.nginx_conf.ignored_upstreams }}
         {{- if not (hasKey $.Values.nginx_conf.upstreams $e) }}
-            {{- fail (print "Upstream '" $e "' does not exist in 'upstreams'!" (toYaml $.Values.nginx_conf.upstreams)) }}
+            {{- fail (print "Upstream '" $e "' does not exist in 'upstreams'!") }}
         {{- end }}
     {{- end }}
     {{- range $e := $.Values.nginx_conf.enabled_extra_upstreams }}
@@ -35,12 +31,12 @@ that should be configured.
         {{- end }}
     {{- end }}
 
-    {{- $validUpstreams := $.Values.nginx_conf.upstreams }}
+    {{- $validUpstreams := (deepCopy $.Values.nginx_conf.upstreams) }}
     {{- range $key := $.Values.nginx_conf.ignored_upstreams }}
         {{- $validUpstreams = unset $validUpstreams $key}}
     {{- end }}
     {{- range $key := $.Values.nginx_conf.enabled_extra_upstreams }}
-        {{- $validUpstreams = set $validUpstreams $key (get $.Values.nginx_conf.enabled_extra_upstreams $key)}}
+        {{- $validUpstreams = set $validUpstreams $key (get $.Values.nginx_conf.extra_upstreams $key)}}
     {{- end }}
 
     {{- toJson $validUpstreams}}

--- a/charts/nginz/templates/_helpers.tpl
+++ b/charts/nginz/templates/_helpers.tpl
@@ -14,3 +14,28 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Takes no parameters and returns the list of upstreams that should be configured.
+*/}}
+{{- define "valid_upstreams" -}}
+    {{- range $e := $.Values.nginx_conf.ignored_upstreams }}
+        {{- if (has $e $.Values.nginx_conf.extra_upstreams) }}
+            {{- fail (print "Contradiction: Upstream is in 'extra_upstreams' and 'ignored_upstreams' : " $e) }}
+        {{- end }}
+    {{- end }}
+    {{- $potentiallyIgnored := (concat (list "ibis" "galeb" "calling-test" "proxy") .Values.nginx_conf.ignored_upstreams) -}}
+    {{- $ignored := list }}
+    {{- range $e := $potentiallyIgnored }}
+        {{- if not (has $e $.Values.nginx_conf.extra_upstreams) }}
+            {{- $ignored = append $ignored $e }}
+        {{- end }}
+    {{- end }}
+    {{- $validUpstreams := list }}
+    {{- range $key, $value := .Values.nginx_conf.upstreams -}}
+        {{- if not (has $key $ignored) -}}
+            {{- $validUpstreams = append $validUpstreams $key }}
+        {{- end -}}
+    {{- end -}}
+    {{- toJson $validUpstreams}}
+{{- end -}}

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -217,8 +217,12 @@ http {
     # Service Routing
     #
 
+    # XXX
+    # valid_upstreams: {{- include "valid_upstreams" . | fromJsonArray }}
+
+  {{- $validUpstreams := include "valid_upstreams" . | fromJsonArray }}
   {{ range $name, $locations := .Values.nginx_conf.upstreams -}}
-    {{- if not (has $name $.Values.nginx_conf.ignored_upstreams) -}}
+    {{- if (has $name $validUpstreams) -}}
     {{- range $location := $locations -}}
       {{- if hasKey $location "envs" -}}
         {{- range $env := $location.envs -}}

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -217,12 +217,8 @@ http {
     # Service Routing
     #
 
-    # XXX
-    # valid_upstreams: {{- include "valid_upstreams" . | fromJsonArray }}
-
-  {{- $validUpstreams := include "valid_upstreams" . | fromJsonArray }}
-  {{ range $name, $locations := .Values.nginx_conf.upstreams -}}
-    {{- if (has $name $validUpstreams) -}}
+  {{- $validUpstreams := include "valid_upstreams" . | fromJson }}
+  {{ range $name, $locations := $validUpstreams -}}
     {{- range $location := $locations -}}
       {{- if hasKey $location "envs" -}}
         {{- range $env := $location.envs -}}
@@ -327,7 +323,6 @@ http {
         {{- end -}}
 
       {{- end -}}
-    {{- end -}}
     {{- end -}}
   {{- end }}
 

--- a/charts/nginz/templates/conf/_upstreams.txt.tpl
+++ b/charts/nginz/templates/conf/_upstreams.txt.tpl
@@ -1,3 +1,4 @@
 {{ define "nginz_upstreams.txt" }}
-{{ range $key, $value := .Values.nginx_conf.upstreams }}{{ if not (has $key $.Values.nginx_conf.ignored_upstreams) }} {{ $key }}{{ if hasKey $.Values.nginx_conf.upstream_namespace $key }}.{{ get $.Values.nginx_conf.upstream_namespace $key }}{{end}} {{ end }}{{ end -}}
+{{- $validUpstreams := include "valid_upstreams" . | fromJsonArray }}
+{{ range $key, $value := .Values.nginx_conf.upstreams }}{{ if (has $key $validUpstreams) }} {{ $key }}{{ if hasKey $.Values.nginx_conf.upstream_namespace $key }}.{{ get $.Values.nginx_conf.upstream_namespace $key }}{{end}} {{ end }}{{ end -}}
 {{ end }}

--- a/charts/nginz/templates/conf/_upstreams.txt.tpl
+++ b/charts/nginz/templates/conf/_upstreams.txt.tpl
@@ -1,4 +1,4 @@
-{{ define "nginz_upstreams.txt" }}
-{{- $validUpstreams := include "valid_upstreams" . | fromJsonArray }}
-{{ range $key, $value := .Values.nginx_conf.upstreams }}{{ if (has $key $validUpstreams) }} {{ $key }}{{ if hasKey $.Values.nginx_conf.upstream_namespace $key }}.{{ get $.Values.nginx_conf.upstream_namespace $key }}{{end}} {{ end }}{{ end -}}
-{{ end }}
+{{- define "nginz_upstreams.txt" }}
+{{- $validUpstreams := include "valid_upstreams" . | fromJson }}
+{{- range $key, $value := $validUpstreams }}{{ $key }}{{- if hasKey $.Values.nginx_conf.upstream_namespace $key }}.{{ get $.Values.nginx_conf.upstream_namespace $key }}{{end}} {{ end -}}
+{{- end }}

--- a/charts/nginz/templates/configmap.yaml
+++ b/charts/nginz/templates/configmap.yaml
@@ -2,8 +2,7 @@ apiVersion: v1
 data:
   nginx.conf: |2
 {{- include "nginz_nginx.conf" . | indent 4 }}
-  upstreams.txt: |2
-{{- include "nginz_upstreams.txt" . | indent 4 }}
+  upstreams.txt: "{{- include "nginz_upstreams.txt" . | trim }}"
   deeplink.json: |2
 {{- include "nginz_deeplink.json" . | indent 4 }}
   deeplink.html: |2

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -86,6 +86,14 @@ nginx_conf:
   # docs.
   ignored_upstreams: []
 
+  # Possible 'extra_upstreams' are:
+  #   - 'ibis'
+  #   - 'galeb'
+  #   - 'calling-test'
+  #   - 'proxy'
+  # For security reasons, these should only be enabled if they are deployed.
+  extra_upstreams: []
+
   # If an upstream runs in a different namespace than nginz, its namespace must
   # be specified here otherwise nginz_disco will fail to find the upstream and
   # nginx will think that the upstream is down.

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -86,14 +86,6 @@ nginx_conf:
   # docs.
   ignored_upstreams: []
 
-  # Possible 'extra_upstreams' are:
-  #   - 'ibis'
-  #   - 'galeb'
-  #   - 'calling-test'
-  #   - 'proxy'
-  # For security reasons, these should only be enabled if they are deployed.
-  extra_upstreams: []
-
   # If an upstream runs in a different namespace than nginz, its namespace must
   # be specified here otherwise nginz_disco will fail to find the upstream and
   # nginx will think that the upstream is down.
@@ -136,6 +128,12 @@ nginx_conf:
       allow_credentials: true
       max_body_size: "0"
       disable_request_buffering: true
+    cannon:
+    - path: /await
+      envs:
+      - all
+      use_websockets: true
+      doc: true
     brig:
     - path: /api-version
       envs:
@@ -553,16 +551,22 @@ nginx_conf:
     - path: /scim
       envs:
       - all
+
+  # Possible 'extra_extra_upstreams' are:
+  #   - 'ibis'
+  #   - 'galeb'
+  #   - 'calling-test'
+  #   - 'proxy'
+  # For security reasons, these should only be enabled if they are deployed.
+  # (Otherwise, there are open routes into the cluster.)
+  enabled_extra_upstreams: []
+
+  # Services that are optionally deployed.
+  extra_upstreams:
     proxy:
     - path: /proxy
       envs:
       - all
-      doc: true
-    cannon:
-    - path: /await
-      envs:
-      - all
-      use_websockets: true
       doc: true
     ibis:
     - path: /billing
@@ -600,7 +604,6 @@ nginx_conf:
       basic_auth: true
       envs:
       - staging
-
     calling-test:
     - path: /calling-test
       envs:

--- a/docs/src/how-to/install/configuration-options.rst
+++ b/docs/src/how-to/install/configuration-options.rst
@@ -176,6 +176,79 @@ There is no way to entirely disable this behaviour, two extreme examples below
        millisecondsBetweenBatches: 50
        minBatchSize: 20
 
+
+Control nginz upstreams (routes) into the Kubernetes cluster
+------------------------------------------------
+
+Open unterminated upstreams (routes) into the Kubernetes cluster are a
+potential security issue. To prevent this there are fine grained settings in the
+nginz configuration defining which upstreams should exist.
+
+Default upstreams
+^^^^^^^^^^^^^^^^^
+
+Upstreams for services that exist in (almost) every Wire installation are
+enabled by default. These are:
+
+- ``brig``
+- ``cannon``
+- ``cargohold``
+- ``galley``
+- ``gundeck``
+- ``spar``
+
+For special setups (as e.g. described in separate-websocket-traffic_) the
+upstreams of these services can be ignored (disabled) with the setting
+``nginz.nginx_conf.ignored_upstreams``.
+
+The most common example is to disable the upstream of ``cannon``:
+
+.. code:: yaml
+
+   nginz:
+     nginx_conf:
+       ignored_upstreams: ["cannon"]
+
+
+Optional upstreams
+^^^^^^^^^^^^^^^^^^
+
+There are some services that are usually not deployed on most Wire installations
+or are specific to the Wire cloud:
+
+- ``ibis``
+- ``galeb``
+- ``calling-test``
+- ``proxy``
+
+The upstreams for those are disabled by default and can be enabled by the
+setting ``nginz.nginx_conf.enabled_extra_upstreams``.
+
+The most common example is to enable the (extra) upstream of ``proxy``:
+
+.. code:: yaml
+
+   nginz:
+     nginx_conf:
+       enabled_extra_upstreams: ["proxy"]
+
+
+Combining default and extra upstream configurations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default and extra upstream configurations are independent of each other. I.e.
+``nginz.nginx_conf.ignored_upstreams`` and
+``nginz.nginx_conf.enabled_extra_upstreams`` can be combined in the same
+configuration:
+
+.. code:: yaml
+
+   nginz:
+     nginx_conf:
+       ignored_upstreams: ["cannon"]
+       enabled_extra_upstreams: ["proxy"]
+
+
 .. _separate-websocket-traffic:
 
 Separate incoming websocket network traffic from the rest of the https traffic
@@ -283,7 +356,7 @@ You may want
 Metrics/logging
 ---------------
 
-* :ref:`monitoring`
+`` :ref:`monitoring`
 * :ref:`logging`
 
 SMTP server

--- a/docs/src/how-to/install/configuration-options.rst
+++ b/docs/src/how-to/install/configuration-options.rst
@@ -178,11 +178,11 @@ There is no way to entirely disable this behaviour, two extreme examples below
 
 
 Control nginz upstreams (routes) into the Kubernetes cluster
-------------------------------------------------
+------------------------------------------------------------
 
-Open unterminated upstreams (routes) into the Kubernetes cluster are a
-potential security issue. To prevent this there are fine grained settings in the
-nginz configuration defining which upstreams should exist.
+Open unterminated upstreams (routes) into the Kubernetes cluster are a potential
+security issue. To prevent this, there are fine-grained settings in the nginz
+configuration defining which upstreams should exist.
 
 Default upstreams
 ^^^^^^^^^^^^^^^^^
@@ -356,7 +356,7 @@ You may want
 Metrics/logging
 ---------------
 
-`` :ref:`monitoring`
+* :ref:`monitoring`
 * :ref:`logging`
 
 SMTP server


### PR DESCRIPTION
### Problem

Some upstreams are configured by default in `nginz` that have no backing service. This leads to many unnecessary DNS lookups and opens unused routes into our K8s clusters (which might be a security issue).

### Solution
Upstream configuration in `nginz` goes from two entries (`ignored_upstreams`, `upstreams`) to four (`ignored_upstreams`, `upstreams`, `enabled_extra_upstreams`, `extra_upstreams`):

- `ignored_upstreams` : default upstreams that should be ignored (for backwards compatibility)
- `upstreams` : default upstreams (kept for backwards compatibility)
- `enabled_extra_upstreams` : Extra upstreams that should be enabled (routed / rendered; this one is new)
- `extra_upstreams` : Contains upstreams that are usually not deployed by default (this is new, too)

I see two benefits with this:

- Existing on-prems only need to be touched when they are using an extra upstream. This is likely only `proxy`.
- Developers should see that the place to add upstreams for their services is likely `extra_upstreams`. (As long as we don’t add one to `wire-server`, which doesn’t happen very often.)

**Ticket**: https://wearezeta.atlassian.net/browse/SQPIT-1174

### Configuration changes
The environment configurations must be changed before this change is deployed. Otherwise, the extra services (`ibis`, `galeb`, `calling-test` and `proxy`) won't be reachable.

- [`staging`](https://github.com/zinfra/cailleach/pull/1451)
- [`prod`](https://github.com/zinfra/cailleach/pull/1452)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
 - [x] Config changes for `staging` and `prod` have been merged and applied
