### PR TITLE
External commits: add additional checks

### DIFF
--- a/changelog.d/5-internal/pr-2852
+++ b/changelog.d/5-internal/pr-2852
@@ -1,0 +1,1 @@
+External commits: add additional checks

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -714,9 +714,6 @@ processExternalCommit qusr mSenderClient lconv cm epoch groupId action updatePat
     throw . mlsProtocolError $
       "The external commit attempts to add another client of the user, it must only add itself"
 
-  -- for_ senderClient $ \senderClient' ->
-  --   pure ()
-
   -- check if there is a key package ref in the remove proposal
   remRef <-
     if Map.null (paRemove action)

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -385,7 +385,7 @@ testAddUserWithBundleIncompleteWelcome = do
     bundle <- createBundle commit
     err <-
       responseJsonError
-        =<< postCommitBundle (ciUser (mpSender commit)) bundle
+        =<< postCommitBundle (mpSender commit) bundle
           <!! const 400 === statusCode
     liftIO $ Wai.label err @?= "mls-welcome-mismatch"
 
@@ -987,7 +987,7 @@ testExternalCommitNotMember = do
         <$> getGroupInfo (ciUser alice1) qcnv
     mp <- createExternalCommit bob1 (Just pgs) qcnv
     bundle <- createBundle mp
-    postCommitBundle (ciUser (mpSender mp)) bundle
+    postCommitBundle (mpSender mp) bundle
       !!! const 404 === statusCode
 
 testExternalCommitSameClient :: TestM ()

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -130,7 +130,7 @@ postCommitBundle ::
     MonadHttp m,
     HasGalley m
   ) =>
-  UserId ->
+  ClientIdentity ->
   ByteString ->
   m ResponseLBS
 postCommitBundle sender bundle = do
@@ -138,7 +138,8 @@ postCommitBundle sender bundle = do
   post
     ( galley
         . paths ["mls", "commit-bundles"]
-        . zUser sender
+        . zUser (ciUser sender)
+        . zClient (ciClient sender)
         . zConn "conn"
         . content "application/x-protobuf"
         . bytes bundle
@@ -888,7 +889,7 @@ sendAndConsumeCommitBundle mp = do
   events <-
     fmap mmssEvents
       . responseJsonError
-      =<< postCommitBundle (ciUser (mpSender mp)) bundle
+      =<< postCommitBundle (mpSender mp) bundle
         <!! const 201 === statusCode
   consumeMessage mp
   traverse_ consumeWelcome (mpWelcome mp)


### PR DESCRIPTION
This PR affects external comits:
- adds requirement of Z-Client
- adds a check that Z-Client matches the client idenity in the keypackage that is added
- adds a check that Z-User matches the client idenity in the keypackage that is added
- removes a duplicated call to `addKeyPackageRef`

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
