### PR TITLE
Add client_id to token in all cases

### DIFF
--- a/changelog.d/3-bug-fixes/token-client-bug
+++ b/changelog.d/3-bug-fixes/token-client-bug
@@ -1,0 +1,1 @@
+Requesting a new token with the client_id now works correctly when the old token is part of the request

--- a/libs/zauth/src/Data/ZAuth/Creation.hs
+++ b/libs/zauth/src/Data/ZAuth/Creation.hs
@@ -155,10 +155,10 @@ providerToken dur pid = do
   d <- expiry dur
   newToken d P Nothing (mkProvider pid)
 
-renewToken :: ToByteString a => Integer -> Token a -> Create (Token a)
-renewToken dur tkn = do
+renewToken :: ToByteString a => Integer -> Header -> a -> Create (Token a)
+renewToken dur hdr bdy = do
   d <- expiry dur
-  newToken d (tkn ^. header . typ) (tkn ^. header . tag) (tkn ^. body)
+  newToken d (hdr ^. typ) (hdr ^. tag) bdy
 
 newToken :: ToByteString a => POSIXTime -> Type -> Maybe Tag -> a -> Create (Token a)
 newToken ti ty ta a = do

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -193,7 +193,7 @@ newAccessToken ::
 newAccessToken c mt = do
   t' <- case mt of
     Nothing -> ZAuth.newAccessToken (cookieValue c)
-    Just t -> ZAuth.renewAccessToken t
+    Just t -> ZAuth.renewAccessToken (ZAuth.userTokenClient (cookieValue c)) t
   zSettings <- view (zauthEnv . ZAuth.settings)
   let ttl = view (ZAuth.settingsTTL (Proxy @a)) zSettings
   pure $


### PR DESCRIPTION
Before this PR, requesting a new token with a `client_id` by passing the old token would not work correctly, and only result in the `client_id` being set in the cookie.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
