### PR TITLE
direnv: watch all .nix files for changes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,11 @@
 # or any of the `default.nix` files change. We do this by adding all these files
 # to the nix store and using the store paths as a cache key.
 
-store_paths=$(find . -name default.nix  | grep -v '^./nix' | grep -v '^./dist-newstyle' | xargs nix-store --add ./nix)
+nix_files=$(find . -name default.nix  | grep -v '^./nix' | grep -v '^./dist-newstyle')
+for nix_file in $nix_files; do
+  watch_file "$nix_file"
+done
+store_paths=$(echo "$nix_files" | xargs nix-store --add ./nix)
 layout_dir=$(direnv_layout_dir)
 env_dir=./.env
 


### PR DESCRIPTION
This PR makes direnv watch all `.nix` files in the repo. If any of those files change (e.g. after a `git pull` that updates the nix env) direnv will automatically reload.