### PR TITLE
Direnv: Consider all .nix files (especially the ones in ./nix)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,7 @@
 # or any of the `default.nix` files change. We do this by adding all these files
 # to the nix store and using the store paths as a cache key.
 
-nix_files=$(find . -name default.nix  | grep -v '^./nix' | grep -v '^./dist-newstyle')
+nix_files=$(find . -name '*.nix' | grep -v '^./dist-newstyle')
 for nix_file in $nix_files; do
   watch_file "$nix_file"
 done


### PR DESCRIPTION
This PR fixes a problem in direnv setup: `.nix` files in in the `./nix` subdirectory were ignored for the computation of cache-key: `nix-rebuild`. This is wrong because nix files in `./nix` directory define the environment.
