### PR TITLE
hlint: fix inplace option, less verbosity on ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ lint-all: formatc hlint-check-all check-local-nix-derivations treefmt
 hlint-check-all:
 	./tools/hlint.sh -f all -m check
 
+.PHONY: hlint-inplace-all
+hlint-inplace-all:
+	./tools/hlint.sh -f all -m inplace
+
 .PHONY: hlint-check-pr
 hlint-check-pr:
 	./tools/hlint.sh -f pr -m check
@@ -121,11 +125,6 @@ hlint-check-pr:
 .PHONY: hlint-inplace-pr
 hlint-inplace-pr:
 	./tools/hlint.sh -f pr -m inplace
-
-
-.PHONY: hlint-inplace-all
-hlint-inplace-all:
-	./tools/hlint.sh -f all -m inplace
 
 .PHONY: hlint-check
 hlint-check:

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -300,6 +300,7 @@ let
     pkgs.helm
     pkgs.helmfile
     pkgs.hlint
+    ( hlib.justStaticExecutables pkgs.haskellPackages.apply-refact )
     pkgs.jq
     pkgs.kubectl
     pkgs.nixpkgs-fmt

--- a/tools/hlint.sh
+++ b/tools/hlint.sh
@@ -4,14 +4,13 @@
 usage() { echo "Usage: $0 -f [all, changeset] -m [check, inplace]" 1>&2; exit 1; }
 
 files=''
-check=true
 
 while getopts ':f:m:k' opt
  do
      case $opt in
          f) f=${OPTARG}
             if [ "$f" = "all" ]; then
-              echo "Checking every file…"
+              files=$(git ls-files | grep \.hs\$)
             elif [ "$f" = "pr" ]; then
               files=$(git diff --name-only origin/develop... | grep \.hs\$)
             elif [ "$f" = "changeset" ]; then
@@ -22,9 +21,9 @@ while getopts ':f:m:k' opt
             ;;
          m) m=${OPTARG}
             if [ "$m" = "inplace" ]; then
-              check=false
+            :
             elif [ "$m" = "check" ]; then
-              check=true
+            :
             else
               usage
             fi
@@ -43,15 +42,15 @@ if [ "${k}" ]; then
   set -euo pipefail
 fi
 
-if [ "$f" = "all" ]; then
-  hlint -g -v
+if [ "$f" = "all" ] && [ "$m" = "check" ]; then
+  hlint -g
 else
   count=$(echo "$files" | grep -c -v -e '^[[:space:]]*$')
   echo "Analysing $count file(s)…"
   for f in $files
   do
     echo "$f"
-    if [ $check = true ]; then
+    if [ "$m" = "check" ]; then
       hlint --no-summary "$f"
     else
       hlint --refactor --refactor-options="--inplace" "$f"

--- a/tools/hlint.sh
+++ b/tools/hlint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-usage() { echo "Usage: $0 -f [all, changeset] -m [check, inplace]" 1>&2; exit 1; }
+usage() { echo "Usage: $0 -f [all, changeset, pr] -m [check, inplace]" 1>&2; exit 1; }
 
 files=''
 


### PR DESCRIPTION
This PR fixes some issues of the `./tools/hlint.sh` script

- adds the missing `refactor` binary to nix. Without the `-m inplace` option doesn't work
- adds missing implementation for the `-f all -m inplace` combination
- Removes verbosity for `-f all -m check`. This prevents a wall of text on our CI and makes it easier to read the suggestions of hlint
