### PR TITLE
[FS-1249] Do Not List MLS Self-conversation in client API v1 and v2

### DIFF
--- a/changelog.d/3-bug-fixes/mls-self-conv-not-listed-below-v3
+++ b/changelog.d/3-bug-fixes/mls-self-conv-not-listed-below-v3
@@ -1,0 +1,1 @@
+Do not list MLS self-conversation in client API v1 and v2 if it exists

--- a/services/galley/src/Galley/API/MLS/Types.hs
+++ b/services/galley/src/Galley/API/MLS/Types.hs
@@ -19,6 +19,7 @@ module Galley.API.MLS.Types
   ( ClientMap,
     mkClientMap,
     cmAssocs,
+    ListGlobalSelfConvs (..),
   )
 where
 
@@ -41,3 +42,9 @@ mkClientMap = foldr addEntry mempty
 
 cmAssocs :: ClientMap -> [(Qualified UserId, (ClientId, KeyPackageRef))]
 cmAssocs cm = Map.assocs cm >>= traverse toList
+
+-- | Inform a handler for 'POST /conversations/list-ids' if the MLS global team
+-- conversation and the MLS self-conversation should be included in the
+-- response.
+data ListGlobalSelfConvs = ListGlobalSelf | DoNotListGlobalSelf
+  deriving (Eq)

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -19,6 +19,7 @@ module Galley.API.Public.Conversation where
 
 import Galley.API.Create
 import Galley.API.MLS.GroupInfo
+import Galley.API.MLS.Types
 import Galley.API.Query
 import Galley.API.Update
 import Galley.App
@@ -35,7 +36,7 @@ conversationAPI =
     <@> mkNamedAPI @"get-conversation-roles" getConversationRoles
     <@> mkNamedAPI @"get-group-info" getGroupInfo
     <@> mkNamedAPI @"list-conversation-ids-unqualified" conversationIdsPageFromUnqualified
-    <@> mkNamedAPI @"list-conversation-ids-v2" conversationIdsPageFromV2
+    <@> mkNamedAPI @"list-conversation-ids-v2" (conversationIdsPageFromV2 DoNotListGlobalSelf)
     <@> mkNamedAPI @"list-conversation-ids" conversationIdsPageFrom
     <@> mkNamedAPI @"get-conversations" getConversations
     <@> mkNamedAPI @"list-conversations-v1" listConversations

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -2346,7 +2346,7 @@ testSelfConversation = do
     commit <- createAddCommit creator [alice]
     welcome <- assertJust (mpWelcome commit)
     mlsBracket others $ \wss -> do
-      void $ sendAndConsumeCommit commit
+      void $ sendAndConsumeCommitBundle commit
       WS.assertMatchN_ (5 # Second) wss $
         wsAssertMLSWelcome alice welcome
       WS.assertNoEvent (1 # WS.Second) wss

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -2361,19 +2361,26 @@ testSelfConversationList isBelowV3 = do
           then ("The MLS self-conversation is listed", isNothing, listConvIdsV2)
           else ("The MLS self-conversation is not listed", isJust, listConvIds)
   alice <- randomUser
-  let paginationOpts = GetPaginatedConversationIds Nothing (toRange (Proxy @100))
-  convIds :: ConvIdsPage <-
-    responseJsonError
-      =<< listCnvs alice paginationOpts
-        <!! const 200 === statusCode
-  convs <-
-    forM (mtpResults convIds) (responseJsonError <=< getConvQualified alice)
-  let mMLSSelf = foldr (<|>) Nothing $ guard . isMLSSelf <$> convs
-  liftIO $ assertBool errMsg (justOrNothing mMLSSelf)
+  do
+    mMLSSelf <- findSelfConv alice listCnvs
+    liftIO $ assertBool errMsg (justOrNothing mMLSSelf)
+
+  -- make sure that the self-conversation is not listed below V3 even once it
+  -- has been created.
+  unless isBelowV3 $ do
+    mMLSSelf <- findSelfConv alice listConvIdsV2
+    liftIO $ assertBool errMsg (isNothing mMLSSelf)
   where
-    isMLSSelf conv =
-      cnvType conv == SelfConv
-        && protocolTag (cnvProtocol conv) == ProtocolMLSTag
+    paginationOpts = GetPaginatedConversationIds Nothing (toRange (Proxy @100))
+
+    isMLSSelf u conv = mlsSelfConvId u == qUnqualified conv
+
+    findSelfConv u listEndpoint = do
+      convIds :: ConvIdsPage <-
+        responseJsonError
+          =<< listEndpoint u paginationOpts
+            <!! const 200 === statusCode
+      pure $ foldr (<|>) Nothing $ guard . isMLSSelf u <$> mtpResults convIds
 
 testSelfConversationOtherUser :: TestM ()
 testSelfConversationOtherUser = do


### PR DESCRIPTION
Currently the call to `POST /conversation/list-ids` will list the MLS self-conversation in client API v1 and v2 if a v3 client created the conversation. Filter out the conversation in versions below v3.

Tracked by https://wearezeta.atlassian.net/browse/FS-1249.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
