### PR TITLE
add initial delay seconds to brig liveness and readiness probes

### DIFF
--- a/changelog.d/5-internal/pr-2878
+++ b/changelog.d/5-internal/pr-2878
@@ -1,0 +1,1 @@
+Add startup probe to brig helm chart.

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -138,11 +138,13 @@ spec:
               scheme: HTTP
               path: /i/status
               port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: 30
           readinessProbe:
             httpGet:
               scheme: HTTP
               path: /i/status
               port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: 30
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         {{- if .Values.config.geoip.enabled }}

--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -133,18 +133,23 @@ spec:
           {{- end }} 
           ports:
             - containerPort: {{ .Values.service.internalPort }}
+          startupProbe:
+            httpGet:
+              scheme: HTTP
+              path: /i/status
+              port: {{ .Values.service.internalPort }}
+            failureThreshold: 6
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               scheme: HTTP
               path: /i/status
               port: {{ .Values.service.internalPort }}
-            initialDelaySeconds: 30
           readinessProbe:
             httpGet:
               scheme: HTTP
               path: /i/status
               port: {{ .Values.service.internalPort }}
-            initialDelaySeconds: 30
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         {{- if .Values.config.geoip.enabled }}


### PR DESCRIPTION
Ticket - https://wearezeta.atlassian.net/browse/SQPIT-491

Brig pods continuously restarts in case of liveness and readiness probes failing on the startup in the low compute resource environment.

To reproduce - 
- reduce the memory and cpu resource limits in charts/brig/values.yaml and deploy the chart.
- Components of brig will take time to start which is greater than the wait time for before running first liveness probe, hence the pod is marked as failed and restarted again and again.

Added a initial delay before running first liveness and readiness probe, which allows all the brig containers to start on a low resource environment before running the probes.


## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
