### PR TITLE
[SQSERVICES-1770] Register OAuth App (1/n)

### DIFF
--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -741,6 +741,24 @@ CREATE TABLE brig_test.team_invitation_info (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
+CREATE TABLE brig_test.provider_keys (
+    key text PRIMARY KEY,
+    provider uuid
+) WITH bloom_filter_fp_chance = 0.1
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
+    AND comment = ''
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
+    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1.0
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99PERCENTILE';
+
 CREATE TABLE brig_test.rich_info (
     user uuid PRIMARY KEY,
     json blob
@@ -801,12 +819,14 @@ CREATE TABLE brig_test.service_tag (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
-CREATE TABLE brig_test.login_codes (
-    user uuid PRIMARY KEY,
-    code text,
-    retries int,
-    timeout timestamp
-) WITH bloom_filter_fp_chance = 0.01
+CREATE TABLE brig_test.meta (
+    id int,
+    version int,
+    date timestamp,
+    descr text,
+    PRIMARY KEY (id, version)
+) WITH CLUSTERING ORDER BY (version ASC)
+    AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
@@ -1160,13 +1180,35 @@ CREATE TABLE brig_test.nonce (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 
-CREATE TABLE brig_test.provider_keys (
-    key text PRIMARY KEY,
-    provider uuid
-) WITH bloom_filter_fp_chance = 0.1
+CREATE TABLE brig_test.login_codes (
+    user uuid PRIMARY KEY,
+    code text,
+    retries int,
+    timeout timestamp
+) WITH bloom_filter_fp_chance = 0.01
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
+    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1.0
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99PERCENTILE';
+
+CREATE TABLE brig_test.oauth_client (
+    id uuid PRIMARY KEY,
+    name text,
+    redirect_uri blob,
+    secret blob
+) WITH bloom_filter_fp_chance = 0.01
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
+    AND comment = ''
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
     AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
@@ -1528,28 +1570,6 @@ CREATE TABLE brig_test.connection (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99PERCENTILE';
 CREATE INDEX conn_status ON brig_test.connection (status);
-
-CREATE TABLE brig_test.meta (
-    id int,
-    version int,
-    date timestamp,
-    descr text,
-    PRIMARY KEY (id, version)
-) WITH CLUSTERING ORDER BY (version ASC)
-    AND bloom_filter_fp_chance = 0.01
-    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
-    AND comment = ''
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
-    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
-    AND crc_check_chance = 1.0
-    AND dclocal_read_repair_chance = 0.1
-    AND default_time_to_live = 0
-    AND gc_grace_seconds = 864000
-    AND max_index_interval = 2048
-    AND memtable_flush_period_in_ms = 0
-    AND min_index_interval = 128
-    AND read_repair_chance = 0.0
-    AND speculative_retry = '99PERCENTILE';
 
 CREATE TABLE brig_test.invitation (
     inviter uuid,

--- a/changelog.d/5-internal/pr-2882
+++ b/changelog.d/5-internal/pr-2882
@@ -1,0 +1,1 @@
+New internal endpoint to register OAuth clients

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -377,6 +377,14 @@ nginx_conf:
       envs:
       - all
       disable_zauth: true
+    - path: /oauth/clients/([^/]*)$
+      envs:
+      - all
+    - path: i/oauth/clients$
+      envs:
+      - staging
+      disable_zauth: true
+      basic_auth: true
     galley:
     - path: /conversations/code-check
       disable_zauth: true

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -49,6 +49,7 @@ module Data.Id
     RequestId (..),
     BotId (..),
     NoId,
+    OAuthClientId,
   )
 where
 
@@ -87,7 +88,7 @@ import Servant (FromHttpApiData (..), ToHttpApiData (..))
 import Test.QuickCheck
 import Test.QuickCheck.Instances ()
 
-data IdTag = A | C | I | U | P | S | T | STo
+data IdTag = A | C | I | U | P | S | T | STo | OAuthClient
 
 idTagName :: IdTag -> Text
 idTagName A = "Asset"
@@ -98,6 +99,7 @@ idTagName P = "Provider"
 idTagName S = "Service"
 idTagName T = "Team"
 idTagName STo = "ScimToken"
+idTagName OAuthClient = "OAuthClient"
 
 class KnownIdTag (t :: IdTag) where
   idTagValue :: IdTag
@@ -118,6 +120,8 @@ instance KnownIdTag 'T where idTagValue = T
 
 instance KnownIdTag 'STo where idTagValue = STo
 
+instance KnownIdTag 'OAuthClient where idTagValue = OAuthClient
+
 type AssetId = Id 'A
 
 type InvitationId = Id 'I
@@ -135,6 +139,8 @@ type ServiceId = Id 'S
 type TeamId = Id 'T
 
 type ScimTokenId = Id 'STo
+
+type OAuthClientId = Id 'OAuthClient
 
 -- Id -------------------------------------------------------------------------
 

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -211,7 +211,6 @@ library
     , data-timeout               >=0.3
     , dns
     , dns-util
-    , DRBG
     , either                     >=4.3
     , enclosed-exceptions        >=1.0
     , errors                     >=1.4

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -682,6 +682,7 @@ executable brig-schema
     V71_AddTableVCodesThrottle
     V72_AddNonceTable
     V73_ReplaceNonceTable
+    V74_AddOAuthClientTable
     V9
     V_FUTUREWORK
 

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -30,6 +30,7 @@ library
     Brig.API.MLS.KeyPackages
     Brig.API.MLS.KeyPackages.Validation
     Brig.API.MLS.Util
+    Brig.API.OAuth
     Brig.API.Properties
     Brig.API.Public
     Brig.API.Public.Swagger
@@ -210,6 +211,7 @@ library
     , data-timeout               >=0.3
     , dns
     , dns-util
+    , DRBG
     , either                     >=4.3
     , enclosed-exceptions        >=1.0
     , errors                     >=1.4

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -443,6 +443,7 @@ executable brig-integration
     API.Metrics
     API.MLS
     API.MLS.Util
+    API.OAuth
     API.Provider
     API.RichInfo.Util
     API.Search

--- a/services/brig/schema/src/Main.hs
+++ b/services/brig/schema/src/Main.hs
@@ -83,6 +83,7 @@ import qualified V70_UserEmailUnvalidated
 import qualified V71_AddTableVCodesThrottle
 import qualified V72_AddNonceTable
 import qualified V73_ReplaceNonceTable
+import qualified V74_AddOAuthClientTable
 import qualified V9
 
 main :: IO ()
@@ -155,7 +156,8 @@ main = do
       V70_UserEmailUnvalidated.migration,
       V71_AddTableVCodesThrottle.migration,
       V72_AddNonceTable.migration,
-      V73_ReplaceNonceTable.migration
+      V73_ReplaceNonceTable.migration,
+      V74_AddOAuthClientTable.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Brig.App
 

--- a/services/brig/schema/src/V74_AddOAuthClientTable.hs
+++ b/services/brig/schema/src/V74_AddOAuthClientTable.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V74_AddOAuthClientTable
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration =
+  Migration 74 "Add table for OAuth clients" $ do
+    schema'
+      [r|
+        CREATE TABLE IF NOT EXISTS oauth_client
+          ( id uuid PRIMARY KEY
+          , name text
+          , redirect_uri blob
+          , secret blob
+          ) 
+     |]

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -30,7 +30,7 @@ import qualified Brig.API.Connection as API
 import Brig.API.Error
 import Brig.API.Handler
 import Brig.API.MLS.KeyPackages.Validation
-import Brig.API.OAuth (OAuthAPI, oauthAPI)
+import Brig.API.OAuth (IOAuthAPI, internalOauthAPI)
 import Brig.API.Types
 import qualified Brig.API.User as API
 import qualified Brig.API.User as Api
@@ -112,8 +112,8 @@ servantSitemap ::
        UserPendingActivationStore p
      ]
     r =>
-  ServerT (BrigIRoutes.API :<|> OAuthAPI) (Handler r)
-servantSitemap = brigInternalAPI :<|> oauthAPI
+  ServerT (BrigIRoutes.API :<|> IOAuthAPI) (Handler r)
+servantSitemap = brigInternalAPI :<|> internalOauthAPI
 
 brigInternalAPI ::
   Members

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -30,6 +30,7 @@ import qualified Brig.API.Connection as API
 import Brig.API.Error
 import Brig.API.Handler
 import Brig.API.MLS.KeyPackages.Validation
+import Brig.API.OAuth (OAuthAPI, oauthAPI)
 import Brig.API.Types
 import qualified Brig.API.User as API
 import qualified Brig.API.User as Api
@@ -111,8 +112,18 @@ servantSitemap ::
        UserPendingActivationStore p
      ]
     r =>
+  ServerT (BrigIRoutes.API :<|> OAuthAPI) (Handler r)
+servantSitemap = brigInternalAPI :<|> oauthAPI
+
+brigInternalAPI ::
+  Members
+    '[ BlacklistStore,
+       GalleyProvider,
+       UserPendingActivationStore p
+     ]
+    r =>
   ServerT BrigIRoutes.API (Handler r)
-servantSitemap =
+brigInternalAPI =
   ejpdAPI
     :<|> accountAPI
     :<|> mlsAPI

--- a/services/brig/src/Brig/API/OAuth.hs
+++ b/services/brig/src/Brig/API/OAuth.hs
@@ -1,0 +1,122 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Brig.API.OAuth where
+
+import Brig.API.Error (throwStd)
+import Brig.API.Handler (Handler)
+import Control.Monad.Except
+import Crypto.Random.DRBG
+import qualified Data.Aeson as A
+import Data.ByteString.Conversion
+import Data.Id (OAuthClientId, randomId)
+import Data.Range
+import Data.Schema
+import qualified Data.Swagger as S
+import Data.Text.Ascii
+import qualified Data.Text.Encoding as TE
+import Imports
+import Network.HTTP.Types
+import qualified Network.Wai.Utilities.Error as Wai
+import Servant hiding (Handler)
+import URI.ByteString
+import Wire.API.Routes.Named (Named (..))
+
+--------------------------------------------------------------------------------
+-- Types
+
+newtype RedirectUrl = RedirectUrl {unRedirectUrl :: URIRef Absolute}
+  deriving stock (Eq, Show, Generic)
+  deriving (A.ToJSON, A.FromJSON, S.ToSchema) via (Schema RedirectUrl)
+
+instance ToSchema RedirectUrl where
+  schema =
+    (TE.decodeUtf8 . serializeURIRef' . unRedirectUrl)
+      .= (RedirectUrl <$> parsedText "RedirectUrl" (runParser (uriParser strictURIParserOptions) . TE.encodeUtf8))
+
+data NewOAuthClient = NewOAuthClient
+  { nocApplicationName :: Range 1 256 Text,
+    nocRedirectURI :: RedirectUrl
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (A.ToJSON, A.FromJSON, S.ToSchema) via (Schema NewOAuthClient)
+
+instance ToSchema NewOAuthClient where
+  schema =
+    object "NewOAuthClient" $
+      NewOAuthClient
+        <$> nocApplicationName .= field "applicationName" schema
+        <*> nocRedirectURI .= field "redirectUri" schema
+
+newtype OAuthClientSecret = OAuthClientSecret {unOAuthClientSecret :: AsciiBase16}
+  deriving stock (Eq, Show, Generic)
+  deriving (A.ToJSON, A.FromJSON, S.ToSchema) via (Schema OAuthClientSecret)
+
+instance ToSchema OAuthClientSecret where
+  schema = (toText . unOAuthClientSecret) .= parsedText "OAuthClientSecret" (fmap OAuthClientSecret . validateBase16)
+
+data OAuthClientCredentials = OAuthClientCredentials
+  { occClientId :: OAuthClientId,
+    occClientSecret :: OAuthClientSecret
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (A.ToJSON, A.FromJSON, S.ToSchema) via (Schema OAuthClientCredentials)
+
+instance ToSchema OAuthClientCredentials where
+  schema =
+    object "OAuthClientCredentials" $
+      OAuthClientCredentials
+        <$> occClientId .= field "clientId" schema
+        <*> occClientSecret .= field "clientSecret" schema
+
+--------------------------------------------------------------------------------
+-- API
+
+type OAuthAPI =
+  Named
+    "create-oauth-client"
+    ( Summary "Register an OAuth client"
+        :> "i"
+        :> "oauth"
+        :> "clients"
+        :> ReqBody '[JSON] NewOAuthClient
+        :> Post '[JSON] OAuthClientCredentials
+    )
+
+oauthAPI :: ServerT OAuthAPI (Handler r)
+oauthAPI =
+  Named @"create-oauth-client" createNewOAuthClient
+
+--------------------------------------------------------------------------------
+-- Handlers
+
+createNewOAuthClient :: NewOAuthClient -> (Handler r) OAuthClientCredentials
+createNewOAuthClient _ = do
+  OAuthClientCredentials
+    <$> randomId
+    <*> (createSecret >>= either (const $ throwStd $ oauthClientSecretGenError) pure)
+  where
+    createSecret :: MonadIO m => m (Either GenError OAuthClientSecret)
+    createSecret = do
+      g :: CtrDRBG <- liftIO newGenIO
+      pure $ genBytes 32 g <&> OAuthClientSecret . encodeBase16 . fst
+
+-------------------------------------------------------------------------------
+-- Errors
+
+oauthClientSecretGenError :: Wai.Error
+oauthClientSecretGenError = Wai.mkError status500 "oauth-client-secret-gen-error" "OAuth client secret generation failed."

--- a/services/brig/src/Brig/API/OAuth.hs
+++ b/services/brig/src/Brig/API/OAuth.hs
@@ -123,10 +123,10 @@ oauthAPI =
 -- Handlers
 
 createNewOAuthClient :: NewOAuthClient -> (Handler r) OAuthClientCredentials
-createNewOAuthClient req = do
-  credentials <- OAuthClientCredentials <$> randomId <*> createSecret
-  safePw <- liftIO $ hashClientSecret (occClientSecret credentials)
-  lift $ wrapClient $ insertOAuthClient (occClientId credentials) (nocApplicationName req) (nocRedirectURI req) safePw
+createNewOAuthClient (NewOAuthClient name uri) = do
+  credentials@(OAuthClientCredentials cid secret) <- OAuthClientCredentials <$> randomId <*> createSecret
+  safeSecret <- liftIO $ hashClientSecret secret
+  lift $ wrapClient $ insertOAuthClient cid name uri safeSecret
   pure credentials
   where
     createSecret :: MonadIO m => m OAuthClientPlainTextSecret

--- a/services/brig/src/Brig/API/OAuth.hs
+++ b/services/brig/src/Brig/API/OAuth.hs
@@ -68,7 +68,7 @@ instance ToSchema OAuthApplicationName where
 
 data NewOAuthClient = NewOAuthClient
   { nocApplicationName :: OAuthApplicationName,
-    nocRedirectURI :: RedirectUrl
+    nocRedirectUrl :: RedirectUrl
   }
   deriving stock (Eq, Show, Generic)
   deriving (A.ToJSON, A.FromJSON, S.ToSchema) via (Schema NewOAuthClient)
@@ -78,7 +78,7 @@ instance ToSchema NewOAuthClient where
     object "NewOAuthClient" $
       NewOAuthClient
         <$> nocApplicationName .= field "applicationName" schema
-        <*> nocRedirectURI .= field "redirectUrl" schema
+        <*> nocRedirectUrl .= field "redirectUrl" schema
 
 newtype OAuthClientPlainTextSecret = OAuthClientPlainTextSecret {unOAuthClientPlainTextSecret :: AsciiBase16}
   deriving stock (Eq, Generic)
@@ -107,7 +107,7 @@ instance ToSchema OAuthClientCredentials where
 data OAuthClient = OAuthClient
   { ocId :: OAuthClientId,
     ocName :: OAuthApplicationName,
-    ocRedirectURI :: RedirectUrl
+    ocRedirectUrl :: RedirectUrl
   }
   deriving stock (Eq, Show, Generic)
   deriving (A.ToJSON, A.FromJSON, S.ToSchema) via (Schema OAuthClient)
@@ -118,7 +118,7 @@ instance ToSchema OAuthClient where
       OAuthClient
         <$> ocId .= field "clientId" schema
         <*> ocName .= field "applicationName" schema
-        <*> ocRedirectURI .= field "redirectUrl" schema
+        <*> ocRedirectUrl .= field "redirectUrl" schema
 
 --------------------------------------------------------------------------------
 -- API Internal

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -188,21 +188,21 @@ servantSitemap = brigAPI :<|> oauthAPI
   where
     brigAPI :: ServerT BrigAPI (Handler r)
     brigAPI =
-          userAPI
-            :<|> selfAPI
-            :<|> accountAPI
-            :<|> clientAPI
-            :<|> prekeyAPI
-            :<|> userClientAPI
-            :<|> connectionAPI
-            :<|> propertiesAPI
-            :<|> mlsAPI
-            :<|> userHandleAPI
-            :<|> searchAPI
-            :<|> authAPI
-            :<|> callingAPI
-            :<|> Team.servantAPI
-            :<|> systemSettingsAPI
+      userAPI
+        :<|> selfAPI
+        :<|> accountAPI
+        :<|> clientAPI
+        :<|> prekeyAPI
+        :<|> userClientAPI
+        :<|> connectionAPI
+        :<|> propertiesAPI
+        :<|> mlsAPI
+        :<|> userHandleAPI
+        :<|> searchAPI
+        :<|> authAPI
+        :<|> callingAPI
+        :<|> Team.servantAPI
+        :<|> systemSettingsAPI
     userAPI :: ServerT UserAPI (Handler r)
     userAPI =
       Named @"get-user-unqualified" getUserUnqualifiedH

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -33,6 +33,7 @@ import qualified Brig.API.Connection as API
 import Brig.API.Error
 import Brig.API.Handler
 import Brig.API.MLS.KeyPackages
+import Brig.API.OAuth (OAuthAPI, oauthAPI)
 import qualified Brig.API.Properties as API
 import Brig.API.Public.Swagger
 import Brig.API.Types
@@ -182,24 +183,26 @@ servantSitemap ::
        UserPendingActivationStore p
      ]
     r =>
-  ServerT BrigAPI (Handler r)
-servantSitemap =
-  userAPI
-    :<|> selfAPI
-    :<|> accountAPI
-    :<|> clientAPI
-    :<|> prekeyAPI
-    :<|> userClientAPI
-    :<|> connectionAPI
-    :<|> propertiesAPI
-    :<|> mlsAPI
-    :<|> userHandleAPI
-    :<|> searchAPI
-    :<|> authAPI
-    :<|> callingAPI
-    :<|> Team.servantAPI
-    :<|> systemSettingsAPI
+  ServerT (BrigAPI :<|> OAuthAPI) (Handler r)
+servantSitemap = brigAPI :<|> oauthAPI
   where
+    brigAPI :: ServerT BrigAPI (Handler r)
+    brigAPI =
+          userAPI
+            :<|> selfAPI
+            :<|> accountAPI
+            :<|> clientAPI
+            :<|> prekeyAPI
+            :<|> userClientAPI
+            :<|> connectionAPI
+            :<|> propertiesAPI
+            :<|> mlsAPI
+            :<|> userHandleAPI
+            :<|> searchAPI
+            :<|> authAPI
+            :<|> callingAPI
+            :<|> Team.servantAPI
+            :<|> systemSettingsAPI
     userAPI :: ServerT UserAPI (Handler r)
     userAPI =
       Named @"get-user-unqualified" getUserUnqualifiedH

--- a/services/brig/src/Brig/App.hs
+++ b/services/brig/src/Brig/App.hs
@@ -149,7 +149,7 @@ import Util.Options
 import Wire.API.User
 
 schemaVersion :: Int32
-schemaVersion = 73
+schemaVersion = 74
 
 -------------------------------------------------------------------------------
 -- Environment

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -28,7 +28,7 @@ import Brig.API (sitemap)
 import Brig.API.Federation
 import Brig.API.Handler
 import qualified Brig.API.Internal as IAPI
-import Brig.API.OAuth (OAuthAPI)
+import Brig.API.OAuth (IOAuthAPI, OAuthAPI)
 import Brig.API.Public (DocsAPI, docsAPI, servantSitemap)
 import qualified Brig.API.User as API
 import Brig.AWS (amazonkaEnv, sesQueue)
@@ -141,8 +141,8 @@ mkApp o = do
             (Proxy @ServantCombinedAPI)
             (customFormatters :. localDomain :. Servant.EmptyContext)
             ( docsAPI
-                :<|> hoistServerWithDomain @BrigAPI (toServantHandler e) servantSitemap
-                :<|> hoistServerWithDomain @(IAPI.API :<|> OAuthAPI) (toServantHandler e) IAPI.servantSitemap
+                :<|> hoistServerWithDomain @(BrigAPI :<|> OAuthAPI) (toServantHandler e) servantSitemap
+                :<|> hoistServerWithDomain @(IAPI.API :<|> IOAuthAPI) (toServantHandler e) IAPI.servantSitemap
                 :<|> hoistServerWithDomain @FederationAPI (toServantHandler e) federationSitemap
                 :<|> hoistServerWithDomain @VersionAPI (toServantHandler e) versionAPI
                 :<|> Servant.Tagged (app e)
@@ -150,8 +150,8 @@ mkApp o = do
 
 type ServantCombinedAPI =
   ( DocsAPI
-      :<|> BrigAPI
-      :<|> (IAPI.API :<|> OAuthAPI)
+      :<|> (BrigAPI :<|> OAuthAPI)
+      :<|> (IAPI.API :<|> IOAuthAPI)
       :<|> FederationAPI
       :<|> VersionAPI
       :<|> Servant.Raw

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -28,6 +28,7 @@ import Brig.API (sitemap)
 import Brig.API.Federation
 import Brig.API.Handler
 import qualified Brig.API.Internal as IAPI
+import Brig.API.OAuth (OAuthAPI)
 import Brig.API.Public (DocsAPI, docsAPI, servantSitemap)
 import qualified Brig.API.User as API
 import Brig.AWS (amazonkaEnv, sesQueue)
@@ -141,7 +142,7 @@ mkApp o = do
             (customFormatters :. localDomain :. Servant.EmptyContext)
             ( docsAPI
                 :<|> hoistServerWithDomain @BrigAPI (toServantHandler e) servantSitemap
-                :<|> hoistServerWithDomain @IAPI.API (toServantHandler e) IAPI.servantSitemap
+                :<|> hoistServerWithDomain @(IAPI.API :<|> OAuthAPI) (toServantHandler e) IAPI.servantSitemap
                 :<|> hoistServerWithDomain @FederationAPI (toServantHandler e) federationSitemap
                 :<|> hoistServerWithDomain @VersionAPI (toServantHandler e) versionAPI
                 :<|> Servant.Tagged (app e)
@@ -150,7 +151,7 @@ mkApp o = do
 type ServantCombinedAPI =
   ( DocsAPI
       :<|> BrigAPI
-      :<|> IAPI.API
+      :<|> (IAPI.API :<|> OAuthAPI)
       :<|> FederationAPI
       :<|> VersionAPI
       :<|> Servant.Raw

--- a/services/brig/test/integration/API/OAuth.hs
+++ b/services/brig/test/integration/API/OAuth.hs
@@ -1,0 +1,62 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module API.OAuth where
+
+import Bilge
+import Bilge.Assert
+import Brig.API.OAuth
+import Brig.Options
+import Data.ByteString.Conversion (toByteString')
+import Data.Id (OAuthClientId, UserId)
+import Data.Range (unsafeRange)
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+import URI.ByteString (parseURI, strictURIParserOptions)
+import Util
+import Wire.API.User
+
+tests :: Manager -> Brig -> Opts -> TestTree
+tests m b _opts = do
+  testGroup "oauth" $
+    [test m "register new OAuth client" $ testRegisterNewOAuthClient b]
+
+testRegisterNewOAuthClient :: Brig -> Http ()
+testRegisterNewOAuthClient brig = do
+  let Right redirectUrl = RedirectUrl <$> parseURI strictURIParserOptions "https://example.com"
+  let applicationName = OAuthApplicationName (unsafeRange "E Corp")
+  let newOAuthClient = NewOAuthClient applicationName redirectUrl
+  cid <- occClientId <$> registerNewOAuthClient brig newOAuthClient
+  uid <- userId <$> randomUser brig
+  oauthClientInfo <- getOAuthClientInfo brig uid cid
+  liftIO $ do
+    applicationName @?= ocName oauthClientInfo
+    redirectUrl @?= ocRedirectUrl oauthClientInfo
+
+-------------------------------------------------------------------------------
+-- Util
+
+registerNewOAuthClient :: HasCallStack => Brig -> NewOAuthClient -> Http OAuthClientCredentials
+registerNewOAuthClient brig reqBody =
+  responseJsonError =<< post (brig . paths ["i", "oauth", "clients"] . json reqBody) <!! const 200 === statusCode
+
+getOAuthClientInfo :: HasCallStack => Brig -> UserId -> OAuthClientId -> Http OAuthClient
+getOAuthClientInfo brig uid cid =
+  responseJsonError =<< get (brig . paths ["oauth", "clients", toByteString' cid] . zUser uid) <!! const 200 === statusCode

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -25,6 +25,7 @@ import qualified API.Federation
 import qualified API.Internal
 import qualified API.MLS as MLS
 import qualified API.Metrics as Metrics
+import qualified API.OAuth as API.OAuth
 import qualified API.Provider as Provider
 import qualified API.Search as Search
 import qualified API.Settings as Settings
@@ -158,6 +159,8 @@ runTests iConf brigOpts otherArgs = do
       versionApi = API.Version.tests mg brigOpts b
       mlsApi = MLS.tests mg b brigOpts
 
+  let oauthAPI = API.OAuth.tests mg b brigOpts
+
   withArgs otherArgs . defaultMain
     $ testGroup
       "Brig API Integration"
@@ -181,7 +184,8 @@ runTests iConf brigOpts otherArgs = do
         internalApi,
         versionApi,
         mlsApi,
-        smtp
+        smtp,
+        oauthAPI
       ]
       <> [federationEnd2End | includeFederationTests]
   where

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -25,7 +25,7 @@ import qualified API.Federation
 import qualified API.Internal
 import qualified API.MLS as MLS
 import qualified API.Metrics as Metrics
-import qualified API.OAuth as API.OAuth
+import qualified API.OAuth
 import qualified API.Provider as Provider
 import qualified API.Search as Search
 import qualified API.Settings as Settings

--- a/services/nginz/integration-test/conf/nginz/nginx.conf
+++ b/services/nginz/integration-test/conf/nginz/nginx.conf
@@ -291,6 +291,11 @@ http {
         proxy_pass http://brig;
     }
 
+    location ~* ^/oauth/clients/([^/]*)$ {
+      include common_response_with_zauth.conf;
+      proxy_pass http://brig;
+    }    
+
     # Cargohold Endpoints
 
     rewrite ^/api-docs/assets  /assets/api-docs?base_url=http://127.0.0.1:8080/ break;


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1770

## Todos
- [ ] Everything is implemented in a single new module. We should refactor this and extract common generic behavior that could be a standalone OAuth2 library and put the rest into places where it makes more sense, like e.g. `wire-api`. However, refactoring should probably be done in a single branch that contains all the subsequent OAuth PRs. Also, maybe define new effects for secret generation?

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
 - [x] Run `make git-add-cassandra-schema` to update the cassandra schema documentation