### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,0 +1,1 @@
+Upgrade webapp version to 2022-11-30-production.0-v0.31.9-0-43726e9

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2022-11-02-production.0-v0.31.9-0-337e400"
+  tag: "2022-11-30-production.0-v0.31.9-0-43726e9"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2022-11-30-production.0-v0.31.9-0-43726e9`
Release: [`2022-11-30-production.0`](https://github.com/wireapp/wire-webapp/releases/tag/2022-11-30-production.0)