### PR TITLE
Fix SFT Helm chart for new sftd versions

### DIFF
--- a/changelog.d/3-bug-fixes/sftd-forwards-compat
+++ b/changelog.d/3-bug-fixes/sftd-forwards-compat
@@ -1,0 +1,1 @@
+Due to `sftd` changing how configuration is handled for "multi-SFT" calling (starting with version 3.1.10), new options have been added to the `sftd` Helm chart for compatibility with these newer versions.

--- a/charts/sftd/templates/secret.yaml
+++ b/charts/sftd/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.multiSFT.enabled (not .Values.multiSFT.discoveryRequired) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sftd.fullname" . }}-secret
+  labels:
+    {{- include "sftd.labels" . | nindent 4 }}
+type: Opaque
+data:
+  zrest_secret.txt: {{ required "must specify authentication secret" .Values.multiSFT.secret | b64enc | quote }}
+{{- end }}

--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -35,8 +35,16 @@ spec:
       volumes:
         - name: external-ip
           emptyDir: {}
+      {{- if .Values.multiSFT.enabled }}
+        {{- if .Values.multiSFT.discoveryRequired }}
         - name: multi-sft-config
           emptyDir: {}
+        {{- else }}
+        - name: sft-secret
+          secret:
+            secretName: {{ include "sftd.fullname" . }}-secret
+        {{- end }}
+      {{- end }}
       initContainers:
         - name: get-external-ip
           image: bitnami/kubectl:1.19.7
@@ -62,6 +70,8 @@ spec:
                 addr=$(kubectl get node $NODE_NAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
               fi
               echo -n "$addr" | tee /dev/stderr > /external-ip/ip
+
+        {{- if and .Values.multiSFT.enabled .Values.multiSFT.discoveryRequired }}
         - name: get-multi-sft-config
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
 
@@ -75,7 +85,6 @@ spec:
             - |
               set -e
 
-              {{- if .Values.multiSFT.enabled }}
 
               response=$(curl "{{ .Values.multiSFT.turnDiscoveryURL }}")
               if [ -z "$response" ]; then
@@ -100,8 +109,7 @@ spec:
                 echo "Response does not contain a turn server"
                 exit 1
               fi
-
-              {{- end }}
+        {{- end }}
 
       containers:
         - name: {{ .Chart.Name }}
@@ -121,8 +129,15 @@ spec:
           volumeMounts:
             - name: external-ip
               mountPath: /external-ip
+            {{- if .Values.multiSFT.enabled }}
+            {{- if .Values.multiSFT.discoveryRequired }}
             - name: multi-sft-config
               mountPath: /multi-sft-config
+            {{- else }}
+            - name: sft-secret
+              mountPath: /secrets
+            {{- end }}
+            {{- end }}
           command:
             - /bin/sh
             - -c
@@ -135,12 +150,17 @@ spec:
                 ACCESS_ARGS="-A ${EXTERNAL_IP}"
               fi
 
+              MULTI_SFT_ARGS=""
+
               {{- if .Values.multiSFT.enabled }}
+              {{- if .Values.multiSFT.discoveryRequired }}
               MULTI_SFT_ARGS="-t $(cat /multi-sft-config/turn_server) \
               -x $(cat /multi-sft-config/username) \
               -c $(cat /multi-sft-config/password)"
               {{- else }}
-              MULTI_SFT_ARGS=""
+              MULTI_SFT_ARGS="-t {{ required "must specify TURN server URI" .Values.multiSFT.turnServerURI }} \
+              -s /secrets/zrest_secret.txt"
+              {{- end }}
               {{- end }}
 
               exec sftd \

--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -89,7 +89,15 @@ turnDiscoveryEnabled: false
 # Allow establishing calls involving remote SFT servers (e.g. for Federation)
 # Requires appVersion 3.0.9 or later
 multiSFT:
-  enabled: False
-  # Required. URL that provides TURN connection configuration. These configured
-  # TURN servers will be used to connect to remote SFT servers.
+  enabled: false
+  # For sftd versions up to 3.1.3, sftd uses the TURN servers advertised at a
+  # discovery URL.
   turnDiscoveryURL: ""
+  # For sftd versions 3.1.10 and later, this discovery process is no longer
+  # required or supported, and must be disabled. sftd must instead be directly
+  # configured with the authentication secret used by the TURN server and the
+  # URI for the TURN server.
+  discoveryRequired: true
+  secret:
+  turnServerURI:
+


### PR DESCRIPTION
SFT has changed how it handles credentials in versions 3.1.10 and later. This PR adds logic to handle the different configuration options in these newer versions. This new logic is not enabled by default, for backwards compatibility with older versions of this chart.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
