### PR TITLE
[FS-1267] Patch issue with initial commit bundle throwing a global team conversation error

### DIFF
--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -268,19 +268,22 @@ getGlobalTeamConversationById lconv = do
   pure $ toGlobalConv mconv
   where
     toGlobalConv mconv = do
-      (muid, mname, mtid, mgid, mepoch, mcs) <- mconv
-      tid <- mtid
-      name <- mname
-      mlsData <- ConversationMLSData <$> mgid <*> (mepoch <|> Just (Epoch 0)) <*> mcs
+      (muid, mname, mtid, mty, mgid, mepoch, mcs) <- mconv
+      if mty /= Just GlobalTeamConv
+        then Nothing
+        else do
+          tid <- mtid
+          name <- mname
+          mlsData <- ConversationMLSData <$> mgid <*> (mepoch <|> Just (Epoch 0)) <*> mcs
 
-      pure $
-        GlobalTeamConversation
-          (qUntagged lconv)
-          mlsData
-          muid
-          [SelfInviteAccess]
-          name
-          tid
+          pure $
+            GlobalTeamConversation
+              (qUntagged lconv)
+              mlsData
+              muid
+              [SelfInviteAccess]
+              name
+              tid
 
 createGlobalTeamConversation ::
   Local TeamId ->

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -269,21 +269,19 @@ getGlobalTeamConversationById lconv = do
   where
     toGlobalConv mconv = do
       (muid, mname, mtid, mty, mgid, mepoch, mcs) <- mconv
-      if mty /= Just GlobalTeamConv
-        then Nothing
-        else do
-          tid <- mtid
-          name <- mname
-          mlsData <- ConversationMLSData <$> mgid <*> (mepoch <|> Just (Epoch 0)) <*> mcs
+      guard (mty == Just GlobalTeamConv)
+      tid <- mtid
+      name <- mname
+      mlsData <- ConversationMLSData <$> mgid <*> (mepoch <|> Just (Epoch 0)) <*> mcs
 
-          pure $
-            GlobalTeamConversation
-              (qUntagged lconv)
-              mlsData
-              muid
-              [SelfInviteAccess]
-              name
-              tid
+      pure $
+        GlobalTeamConversation
+          (qUntagged lconv)
+          mlsData
+          muid
+          [SelfInviteAccess]
+          name
+          tid
 
 createGlobalTeamConversation ::
   Local TeamId ->

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -226,11 +226,12 @@ selectGlobalTeamConv ::
     ( Maybe UserId,
       Maybe Text,
       Maybe TeamId,
+      Maybe ConvType,
       Maybe GroupId,
       Maybe Epoch,
       Maybe CipherSuiteTag
     )
-selectGlobalTeamConv = "select creator, name, team, group_id, epoch, cipher_suite from conversation where conv = ?"
+selectGlobalTeamConv = "select creator, name, team, type, group_id, epoch, cipher_suite from conversation where conv = ?"
 
 selectReceiptMode :: PrepQuery R (Identity ConvId) (Identity (Maybe ReceiptMode))
 selectReceiptMode = "select receipt_mode from conversation where conv = ?"

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -20,13 +20,14 @@
 module API.MLS (tests) where
 
 import API.MLS.Util
--- import API.SQS
+import API.SQS
 import API.Util as Util
 import Bilge hiding (head)
 import Bilge.Assert
 import Cassandra
 -- import Control.Error.Util (hush)
-import Control.Lens (view) -- , (^.))
+-- import Control.Lens (view, (^.))
+import Control.Lens (view)
 import qualified Control.Monad.State as State
 import Crypto.Error
 import qualified Crypto.PubKey.Ed25519 as Ed25519
@@ -193,7 +194,8 @@ tests s =
         "CommitBundle"
         [ test s "add user with a commit bundle" testAddUserWithBundle,
           test s "add user with a commit bundle to a remote conversation" testAddUserToRemoteConvWithBundle,
-          test s "remote user posts commit bundle" testRemoteUserPostsCommitBundle
+          test s "remote user posts commit bundle" testRemoteUserPostsCommitBundle,
+          test s "add user with a commit bundle and a team conv" testAddTeamUserWithBundle
         ],
       -- testGroup
       --   "GlobalTeamConv"
@@ -2444,3 +2446,45 @@ testSelfConversationLeave = do
             const 403 === statusCode
             const (Just "invalid-op") === fmap Wai.label . responseJsonError
       WS.assertNoEvent (1 # WS.Second) wss
+
+testAddTeamUserWithBundle :: TestM ()
+testAddTeamUserWithBundle = do
+  [alice, bob] <- createAndConnectUsers [Nothing, Nothing]
+  tid <- createBindingTeamInternal "sample-team" (qUnqualified alice)
+  assertQueue "create team" tActivate
+  assertQueueEmpty
+
+  (qcnv, commit) <- runMLSTest $ do
+    (alice1 : bobClients) <- traverse createMLSClient [alice, bob, bob]
+    traverse_ uploadNewKeyPackage bobClients
+    (_, qcnv) <- setupMLSGroupWithTeam tid alice1
+    commit <- createAddCommit alice1 [bob]
+    welcome <- assertJust (mpWelcome commit)
+
+    events <- mlsBracket bobClients $ \wss -> do
+      events <- sendAndConsumeCommitBundle commit
+      for_ (zip bobClients wss) $ \(c, ws) ->
+        WS.assertMatch (5 # Second) ws $
+          wsAssertMLSWelcome (cidQualifiedUser c) welcome
+      pure events
+
+    event <- assertOne events
+    liftIO $ assertJoinEvent qcnv alice [bob] roleNameWireMember event
+    pure (qcnv, commit)
+
+  -- check that bob can now see the conversation
+  convs <-
+    responseJsonError
+      =<< getConvs (qUnqualified bob) Nothing Nothing
+        <!! const 200 === statusCode
+  liftIO $
+    assertBool
+      "Users added to an MLS group should find it when listing conversations"
+      (qcnv `elem` map cnvQualifiedId (convList convs))
+
+  returnedGS <-
+    fmap responseBody $
+      getGroupInfo (qUnqualified alice) qcnv
+        <!! const 200 === statusCode
+  liftIO $ assertBool "Commit does not contain a public group State" (isJust (mpPublicGroupState commit))
+  liftIO $ mpPublicGroupState commit @=? LBS.toStrict <$> returnedGS

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -425,6 +425,19 @@ setupMLSGroup creator = setupMLSGroupWithConv action creator
           )
           <!! const 201 === statusCode
 
+-- | Create conversation and corresponding group with a team conversation
+setupMLSGroupWithTeam :: HasCallStack => TeamId -> ClientIdentity -> MLSTest (GroupId, Qualified ConvId)
+setupMLSGroupWithTeam tid creator = setupMLSGroupWithConv action creator
+  where
+    action =
+      responseJsonError
+        =<< liftTest
+          ( postConvQualified
+              (ciUser creator)
+              (defNewMLSConv (ciClient creator)) {newConvTeam = Just $ ConvTeamInfo tid}
+          )
+          <!! const 201 === statusCode
+
 -- | Create self-conversation and corresponding group.
 setupMLSSelfGroup :: HasCallStack => ClientIdentity -> MLSTest (GroupId, Qualified ConvId)
 setupMLSSelfGroup creator = setupMLSGroupWithConv action creator

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -727,7 +727,8 @@ defNewMLSConv :: ClientId -> NewConv
 defNewMLSConv c =
   defNewProteusConv
     { newConvProtocol = ProtocolMLSTag,
-      newConvCreatorClient = Just c
+      newConvCreatorClient = Just c,
+      newConvName = Just (unsafeRange "Test conv")
     }
 
 postConvQualified ::


### PR DESCRIPTION
This fixes an edge case where a regular conversation would be mistaken for a GTC, adds a test case against regressions.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
