### PR TITLE
[FS-1271] Do not throw 500 when listing conversations

### DIFF
--- a/changelog.d/3-bug-fixes/list-self-mls-not-configured
+++ b/changelog.d/3-bug-fixes/list-self-mls-not-configured
@@ -1,0 +1,1 @@
+Do not throw 500 when listing conversations and MLS is not configured

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -44,7 +44,7 @@ conversationAPI =
     <@> mkNamedAPI @"get-conversation-by-reusable-code" (getConversationByReusableCode @Cassandra)
     <@> mkNamedAPI @"create-group-conversation" createGroupConversation
     <@> mkNamedAPI @"create-self-conversation" createProteusSelfConversation
-    <@> mkNamedAPI @"get-mls-self-conversation" getMLSSelfConversation
+    <@> mkNamedAPI @"get-mls-self-conversation" getMLSSelfConversationWithError
     <@> mkNamedAPI @"create-one-to-one-conversation" createOne2OneConversation
     <@> mkNamedAPI @"add-members-to-conversation-unqualified" addMembersUnqualified
     <@> mkNamedAPI @"add-members-to-conversation-unqualified2" addMembersUnqualifiedV2


### PR DESCRIPTION
This fixes a bug where conversations couldn't be listed in an environment not configured for MLS. This was because of automatic MLS self-conversation creation when listing conversations.

Tracked by https://wearezeta.atlassian.net/browse/FS-1271.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
