### PR TITLE
Release 2022-12-01 - (expected chart version 4.28.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,94 @@
+# [2022-12-01] (Chart Release 4.28.0)
+
+## Release notes
+
+
+* This realease migrates data from `galley.member_client` to `galley.mls_group_member_client`. When upgrading wire-server no manual steps are required. (#2859)
+
+* Upgrade webapp version to 2022-11-30-production.0-v0.31.9-0-43726e9 (#2302)
+
+
+## API changes
+
+
+* Support MLS self-conversations via a new endpoint `GET /conversations/mls-self`. This removes the `PUT` counterpart introduced in #2730 (#2839)
+
+* List the MLS self-conversation automatically without needing to call `GET /conversations/mls-self` first (#2856)
+
+
+## Features
+
+
+* A team member's role can now be provisioned via SCIM (#2851, #2855)
+
+
+## Bug fixes and other updates
+
+
+* Avoid client deletion edge case condition which can lead to inconsistent data between brig and galley's clients tables. (#2830)
+
+* Do not throw 500 when listing conversations and MLS is not configured (#2893)
+
+* Do not list MLS self-conversation in client API v1 and v2 if it exists (#2872)
+
+* Prevention of storing unnecessary data in the database if adding a bot to a conversation fails. (#2870)
+
+* Fix bug in MLS user removal from conversation: the list of removed clients has to be compared with those in the conversation, not the list of *all* clients of that user (#2817)
+
+* Due to `sftd` changing how configuration is handled for "multi-SFT" calling (starting with version 3.1.10), new options have been added to the `sftd` Helm chart for compatibility with these newer versions. (#2886)
+
+* For sftd/coturn/restund, fixed a bug in external ip address lookup, in case Kubernetes Node Name doesn't equal hostname. (#2837)
+
+* Requesting a new token with the client_id now works correctly when the old token is part of the request (#2860)
+
+
+## Documentation
+
+
+* PR guidelines docs are updated with correct helm configuration syntax (#2889)
+
+
+## Internal changes
+
+
+* Add tests for invitation urls in team invitation responses. These depend on the settings of galley. (#2797)
+
+* Remove support for compiling local docker images with buildah. Nix is used to build docker images these days (#2822)
+
+* bump nginx-module-vts from v0.1.15 to v0.2.1 (#2827)
+
+* Nix-created docker images: add some debugging tools in the containers, and add 'make build-image-<packagename>' for convenience (#2829)
+
+* Split galley API routes and handler definitions into several modules (#2820)
+
+* Default intraListing to true. This means that the list of clients, so far saved in both brig's and galley's databases, will still be written to both, but only read from brig's database. This avoids cases where these two tables go out of sync. Brig becomes the source of truth for clients. In the future, if this holds, code and data for galley's clients table can be removed. (#2847)
+
+* Build nginz and nginz_disco docker images using nix (#2796)
+
+* Bump nixpkgs to latest unstable. Stop using forked nixpkgs. (#2828)
+
+* Brig calling API is now migrated to servant (#2815)
+
+* Fixed flaky feature TTL integration test (#2823)
+
+* Brig teams API is now migrated to servant (#2824)
+
+* Backoffice Swagger 2.x docs is exposed on `/` and the old Swagger has been removed. Backoffice helm chart only runs stern without an extra nginx. (#2846)
+
+* Stern API endpoint `GET ejpd-info` has now the correct HTTP method (#2850)
+
+* External commits: add additional checks (#2852)
+
+* Golden tests for conversation and feature config event schemas (#2861)
+
+* Refactor and simplify MLS message handling logic (#2844)
+
+* Replay external backend proposals after forwarding external commits.
+  One column added to Galley's mls_proposal_refs. (#2842)
+
+* Use treefmt to ensure consistent formatting of .nix files, use for shellcheck too (#2831)
+
+
 # [2022-11-03] (Chart Release 4.26.0)
 
 ## Release notes

--- a/changelog.d/0-release-notes/member_clients_migration
+++ b/changelog.d/0-release-notes/member_clients_migration
@@ -1,1 +1,0 @@
-This realease migrates data from `galley.member_client` to `galley.mls_group_member_client`. When upgrading wire-server no manual steps are required.

--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,1 +1,0 @@
-Upgrade webapp version to 2022-11-30-production.0-v0.31.9-0-43726e9

--- a/changelog.d/1-api-changes/get-mls-self-conversation
+++ b/changelog.d/1-api-changes/get-mls-self-conversation
@@ -1,1 +1,0 @@
-Support MLS self-conversations via a new endpoint `GET /conversations/mls-self`. This removes the `PUT` counterpart introduced in #2730

--- a/changelog.d/1-api-changes/list-mls-self-conversation-automatically
+++ b/changelog.d/1-api-changes/list-mls-self-conversation-automatically
@@ -1,1 +1,0 @@
-List the MLS self-conversation automatically without needing to call `GET /conversations/mls-self` first

--- a/changelog.d/2-features/pr-2855
+++ b/changelog.d/2-features/pr-2855
@@ -1,1 +1,0 @@
-A team member's role can now be provisioned via SCIM (#2851, #2855)

--- a/changelog.d/3-bug-fixes/client-deletion-ordering
+++ b/changelog.d/3-bug-fixes/client-deletion-ordering
@@ -1,1 +1,0 @@
-Avoid client deletion edge case condition which can lead to inconsistent data between brig and galley's clients tables.

--- a/changelog.d/3-bug-fixes/list-self-mls-not-configured
+++ b/changelog.d/3-bug-fixes/list-self-mls-not-configured
@@ -1,1 +1,0 @@
-Do not throw 500 when listing conversations and MLS is not configured

--- a/changelog.d/3-bug-fixes/list-self-mls-not-configured
+++ b/changelog.d/3-bug-fixes/list-self-mls-not-configured
@@ -1,0 +1,1 @@
+Do not throw 500 when listing conversations and MLS is not configured

--- a/changelog.d/3-bug-fixes/mls-self-conv-not-listed-below-v3
+++ b/changelog.d/3-bug-fixes/mls-self-conv-not-listed-below-v3
@@ -1,1 +1,0 @@
-Do not list MLS self-conversation in client API v1 and v2 if it exists

--- a/changelog.d/3-bug-fixes/pr-2870
+++ b/changelog.d/3-bug-fixes/pr-2870
@@ -1,1 +1,0 @@
-Prevention of storing unnecessary data in the database if adding a bot to a conversation fails.

--- a/changelog.d/3-bug-fixes/removal-client-check
+++ b/changelog.d/3-bug-fixes/removal-client-check
@@ -1,1 +1,0 @@
-Fix bug in MLS user removal from conversation: the list of removed clients has to be compared with those in the conversation, not the list of *all* clients of that user

--- a/changelog.d/3-bug-fixes/sftd-forwards-compat
+++ b/changelog.d/3-bug-fixes/sftd-forwards-compat
@@ -1,1 +1,0 @@
-Due to `sftd` changing how configuration is handled for "multi-SFT" calling (starting with version 3.1.10), new options have been added to the `sftd` Helm chart for compatibility with these newer versions.

--- a/changelog.d/3-bug-fixes/sftd-restund-coturn-hostname-nodename
+++ b/changelog.d/3-bug-fixes/sftd-restund-coturn-hostname-nodename
@@ -1,1 +1,0 @@
-For sftd/coturn/restund, fixed a bug in external ip address lookup, in case Kubernetes Node Name doesn't equal hostname.

--- a/changelog.d/3-bug-fixes/token-client-bug
+++ b/changelog.d/3-bug-fixes/token-client-bug
@@ -1,1 +1,0 @@
-Requesting a new token with the client_id now works correctly when the old token is part of the request

--- a/changelog.d/4-docs/pr-2889
+++ b/changelog.d/4-docs/pr-2889
@@ -1,1 +1,0 @@
-PR guidelines docs are updated with correct helm configuration syntax

--- a/changelog.d/5-internal/add-invitation-url-tests
+++ b/changelog.d/5-internal/add-invitation-url-tests
@@ -1,1 +1,0 @@
-Add tests for invitation urls in team invitation responses. These depend on the settings of galley.

--- a/changelog.d/5-internal/buildah-drop-support
+++ b/changelog.d/5-internal/buildah-drop-support
@@ -1,1 +1,0 @@
-Remove support for compiling local docker images with buildah. Nix is used to build docker images these days

--- a/changelog.d/5-internal/bump-nginx-module-vts
+++ b/changelog.d/5-internal/bump-nginx-module-vts
@@ -1,1 +1,0 @@
-bump nginx-module-vts from v0.1.15 to v0.2.1 (#2827)

--- a/changelog.d/5-internal/debugging-tools
+++ b/changelog.d/5-internal/debugging-tools
@@ -1,1 +1,0 @@
-Nix-created docker images: add some debugging tools in the containers, and add 'make build-image-<packagename>' for convenience

--- a/changelog.d/5-internal/galley-servant-split
+++ b/changelog.d/5-internal/galley-servant-split
@@ -1,1 +1,0 @@
-Split galley API routes and handler definitions into several modules

--- a/changelog.d/5-internal/intra-listing
+++ b/changelog.d/5-internal/intra-listing
@@ -1,1 +1,0 @@
-Default intraListing to true. This means that the list of clients, so far saved in both brig's and galley's databases, will still be written to both, but only read from brig's database. This avoids cases where these two tables go out of sync. Brig becomes the source of truth for clients. In the future, if this holds, code and data for galley's clients table can be removed.

--- a/changelog.d/5-internal/nginz-nix
+++ b/changelog.d/5-internal/nginz-nix
@@ -1,1 +1,0 @@
-Build nginz and nginz_disco docker images using nix

--- a/changelog.d/5-internal/nixpkgs-bump
+++ b/changelog.d/5-internal/nixpkgs-bump
@@ -1,1 +1,0 @@
-Bump nixpkgs to latest unstable. Stop using forked nixpkgs.

--- a/changelog.d/5-internal/pr-2815
+++ b/changelog.d/5-internal/pr-2815
@@ -1,1 +1,0 @@
-Brig calling API is now migrated to servant

--- a/changelog.d/5-internal/pr-2823
+++ b/changelog.d/5-internal/pr-2823
@@ -1,1 +1,0 @@
-Fixed flaky feature TTL integration test

--- a/changelog.d/5-internal/pr-2824
+++ b/changelog.d/5-internal/pr-2824
@@ -1,1 +1,0 @@
-Brig teams API is now migrated to servant

--- a/changelog.d/5-internal/pr-2846
+++ b/changelog.d/5-internal/pr-2846
@@ -1,1 +1,0 @@
-Backoffice Swagger 2.x docs is exposed on `/` and the old Swagger has been removed. Backoffice helm chart only runs stern without an extra nginx.

--- a/changelog.d/5-internal/pr-2850
+++ b/changelog.d/5-internal/pr-2850
@@ -1,1 +1,0 @@
-Stern API endpoint `GET ejpd-info` has now the correct HTTP method

--- a/changelog.d/5-internal/pr-2852
+++ b/changelog.d/5-internal/pr-2852
@@ -1,1 +1,0 @@
-External commits: add additional checks

--- a/changelog.d/5-internal/pr-2861
+++ b/changelog.d/5-internal/pr-2861
@@ -1,1 +1,0 @@
-Golden tests for conversation and feature config event schemas

--- a/changelog.d/5-internal/refactor-mls-message
+++ b/changelog.d/5-internal/refactor-mls-message
@@ -1,1 +1,0 @@
-Refactor and simplify MLS message handling logic

--- a/changelog.d/5-internal/replay-backend-proposals
+++ b/changelog.d/5-internal/replay-backend-proposals
@@ -1,2 +1,0 @@
-Replay external backend proposals after forwarding external commits.
-One column added to Galley's mls_proposal_refs.

--- a/changelog.d/5-internal/treefmt
+++ b/changelog.d/5-internal/treefmt
@@ -1,1 +1,0 @@
-Use treefmt to ensure consistent formatting of .nix files, use for shellcheck too (#2831)

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -44,7 +44,7 @@ conversationAPI =
     <@> mkNamedAPI @"get-conversation-by-reusable-code" (getConversationByReusableCode @Cassandra)
     <@> mkNamedAPI @"create-group-conversation" createGroupConversation
     <@> mkNamedAPI @"create-self-conversation" createProteusSelfConversation
-    <@> mkNamedAPI @"get-mls-self-conversation" getMLSSelfConversation
+    <@> mkNamedAPI @"get-mls-self-conversation" getMLSSelfConversationWithError
     <@> mkNamedAPI @"create-one-to-one-conversation" createOne2OneConversation
     <@> mkNamedAPI @"add-members-to-conversation-unqualified" addMembersUnqualified
     <@> mkNamedAPI @"add-members-to-conversation-unqualified2" addMembersUnqualifiedV2


### PR DESCRIPTION
# [2022-12-01] (Chart Release 4.28.0)

## Release notes


* This realease migrates data from `galley.member_client` to `galley.mls_group_member_client`. When upgrading wire-server no manual steps are required. (#2859)

* Upgrade webapp version to 2022-11-30-production.0-v0.31.9-0-43726e9 (#2302)


## API changes


* Support MLS self-conversations via a new endpoint `GET /conversations/mls-self`. This removes the `PUT` counterpart introduced in #2730 (#2839)

* List the MLS self-conversation automatically without needing to call `GET /conversations/mls-self` first (#2856)


## Features


* A team member's role can now be provisioned via SCIM (#2851, #2855)


## Bug fixes and other updates


* Avoid client deletion edge case condition which can lead to inconsistent data between brig and galley's clients tables. (#2830)

* Do not throw 500 when listing conversations and MLS is not configured (#2893)

* Do not list MLS self-conversation in client API v1 and v2 if it exists (#2872)

* Prevention of storing unnecessary data in the database if adding a bot to a conversation fails. (#2870)

* Fix bug in MLS user removal from conversation: the list of removed clients has to be compared with those in the conversation, not the list of *all* clients of that user (#2817)

* Due to `sftd` changing how configuration is handled for "multi-SFT" calling (starting with version 3.1.10), new options have been added to the `sftd` Helm chart for compatibility with these newer versions. (#2886)

* For sftd/coturn/restund, fixed a bug in external ip address lookup, in case Kubernetes Node Name doesn't equal hostname. (#2837)

* Requesting a new token with the client_id now works correctly when the old token is part of the request (#2860)


## Documentation


* PR guidelines docs are updated with correct helm configuration syntax (#2889)


## Internal changes


* Add tests for invitation urls in team invitation responses. These depend on the settings of galley. (#2797)

* Remove support for compiling local docker images with buildah. Nix is used to build docker images these days (#2822)

* bump nginx-module-vts from v0.1.15 to v0.2.1 (#2827)

* Nix-created docker images: add some debugging tools in the containers, and add 'make build-image-<packagename>' for convenience (#2829)

* Split galley API routes and handler definitions into several modules (#2820)

* Default intraListing to true. This means that the list of clients, so far saved in both brig's and galley's databases, will still be written to both, but only read from brig's database. This avoids cases where these two tables go out of sync. Brig becomes the source of truth for clients. In the future, if this holds, code and data for galley's clients table can be removed. (#2847)

* Build nginz and nginz_disco docker images using nix (#2796)

* Bump nixpkgs to latest unstable. Stop using forked nixpkgs. (#2828)

* Brig calling API is now migrated to servant (#2815)

* Fixed flaky feature TTL integration test (#2823)

* Brig teams API is now migrated to servant (#2824)

* Backoffice Swagger 2.x docs is exposed on `/` and the old Swagger has been removed. Backoffice helm chart only runs stern without an extra nginx. (#2846)

* Stern API endpoint `GET ejpd-info` has now the correct HTTP method (#2850)

* External commits: add additional checks (#2852)

* Golden tests for conversation and feature config event schemas (#2861)

* Refactor and simplify MLS message handling logic (#2844)

* Replay external backend proposals after forwarding external commits.
  One column added to Galley's mls_proposal_refs. (#2842)

* Use treefmt to ensure consistent formatting of .nix files, use for shellcheck too (#2831)


