### PR TITLE
update enabled key for servicemonitor in helm chart default values

### DIFF
--- a/changelog.d/3-bug-fixes/2896
+++ b/changelog.d/3-bug-fixes/2896
@@ -1,0 +1,1 @@
+Fix typo for Servicemonitor enable var in default values for helm charts.

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -13,7 +13,7 @@ resources:
     memory: "512Mi"
 metrics:
   serviceMonitor:
-    enable: false
+    enabled: false
 config:
   logLevel: Info
   logFormat: StructuredJSON

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -24,7 +24,7 @@ config:
 
 metrics:
   serviceMonitor:
-    enable: false
+    enabled: false
 
 nginx_conf:
   user: nginx

--- a/charts/cargohold/values.yaml
+++ b/charts/cargohold/values.yaml
@@ -7,7 +7,7 @@ service:
   internalPort: 8080
 metrics:
   serviceMonitor:
-    enable: false
+    enabled: false
 resources:
   requests:
     memory: "80Mi"

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -8,7 +8,7 @@ service:
   internalPort: 8080
 metrics:
   serviceMonitor:
-    enable: false
+    enabled: false
 resources:
   requests:
     memory: "100Mi"

--- a/charts/gundeck/values.yaml
+++ b/charts/gundeck/values.yaml
@@ -7,7 +7,7 @@ service:
   internalPort: 8080
 metrics:
   serviceMonitor:
-    enable: false
+    enabled: false
 resources:
   requests:
     memory: "300Mi"

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -7,7 +7,7 @@ service:
   internalPort: 8080
 metrics:
   serviceMonitor:
-    enable: false
+    enabled: false
 resources:
   requests:
     memory: "25Mi"

--- a/charts/spar/values.yaml
+++ b/charts/spar/values.yaml
@@ -4,7 +4,7 @@ image:
   tag: do-not-use
 metrics:
   serviceMonitor:
-    enable: false
+    enabled: false
 resources:
   requests:
     memory: "25Mi"


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
