### PR TITLE
[SQSERVICES-1773] Allow pagination for team search endpoints - `has_more`

### DIFF
--- a/changelog.d/2-features/pr-2895
+++ b/changelog.d/2-features/pr-2895
@@ -1,1 +1,1 @@
-Team search endpoint now supports pagination
+Team search endpoint now supports pagination (#2898, #2895)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -1162,7 +1162,9 @@ type SearchAPI =
         :> QueryParam'
              [ Optional,
                Strict,
-               Description "Paging state for the next page of results"
+               Description
+                 "Optional, when not specified, the first page will be returned. \
+                 \Every returned page contains a `paging_state`, this should be supplied to retrieve the next page."
              ]
              "pagingState"
              PagingState

--- a/libs/wire-api/src/Wire/API/User/Search.hs
+++ b/libs/wire-api/src/Wire/API/User/Search.hs
@@ -122,8 +122,8 @@ instance ToSchema a => ToSchema (SearchResult a) where
         <*> searchTook .= fieldWithDocModifier "took" (S.description ?~ "Search time in ms") schema
         <*> searchResults .= fieldWithDocModifier "documents" (S.description ?~ "List of contacts found") (array schema)
         <*> searchPolicy .= fieldWithDocModifier "search_policy" (S.description ?~ "Search policy that was applied when searching for users") schema
-        <*> searchPagingState .= maybe_ (optFieldWithDocModifier "paging_state" (S.description ?~ "Paging state for the next page of results") schema)
-        <*> searchHasMore .= maybe_ (optFieldWithDocModifier "has_more" (S.description ?~ "Whether there are more results to be fetched") schema)
+        <*> searchPagingState .= maybe_ (optFieldWithDocModifier "paging_state" (S.description ?~ "Paging state that should be supplied to retrieve the next page of results") schema)
+        <*> searchHasMore .= maybe_ (optFieldWithDocModifier "has_more" (S.description ?~ "Indicates whether there are more results to be fetched") schema)
 
 deriving via (Schema (SearchResult Contact)) instance ToJSON (SearchResult Contact)
 

--- a/libs/wire-api/src/Wire/API/User/Search.hs
+++ b/libs/wire-api/src/Wire/API/User/Search.hs
@@ -99,7 +99,8 @@ data SearchResult a = SearchResult
     searchTook :: Int,
     searchResults :: [a],
     searchPolicy :: FederatedUserSearchPolicy,
-    searchPagingState :: Maybe PagingState
+    searchPagingState :: Maybe PagingState,
+    searchHasMore :: Maybe Bool
   }
   deriving stock (Eq, Show, Generic, Functor)
   deriving (Arbitrary) via (GenericUniform (SearchResult a))
@@ -122,6 +123,7 @@ instance ToSchema a => ToSchema (SearchResult a) where
         <*> searchResults .= fieldWithDocModifier "documents" (S.description ?~ "List of contacts found") (array schema)
         <*> searchPolicy .= fieldWithDocModifier "search_policy" (S.description ?~ "Search policy that was applied when searching for users") schema
         <*> searchPagingState .= maybe_ (optFieldWithDocModifier "paging_state" (S.description ?~ "Paging state for the next page of results") schema)
+        <*> searchHasMore .= maybe_ (optFieldWithDocModifier "has_more" (S.description ?~ "Whether there are more results to be fetched") schema)
 
 deriving via (Schema (SearchResult Contact)) instance ToJSON (SearchResult Contact)
 

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/SearchResult_20Contact_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/SearchResult_20Contact_user.hs
@@ -23,7 +23,7 @@ import Data.Domain (Domain (Domain, _domainText))
 import Data.Id (Id (Id))
 import Data.Qualified (Qualified (Qualified, qDomain, qUnqualified))
 import qualified Data.UUID as UUID (fromString)
-import Imports (Maybe (Just, Nothing), fromJust)
+import Imports (Bool (..), Maybe (Just, Nothing), fromJust)
 import Wire.API.User.Search (Contact (..), FederatedUserSearchPolicy (ExactHandleSearch, FullSearch), PagingState (..), SearchResult (..))
 
 testObject_SearchResult_20Contact_user_1 :: SearchResult Contact
@@ -34,7 +34,8 @@ testObject_SearchResult_20Contact_user_1 =
       searchTook = 1,
       searchResults = [],
       searchPolicy = FullSearch,
-      searchPagingState = Just (PagingState "WzE2Njk5OTQ5MzIyNjdd")
+      searchPagingState = Just (PagingState "WzE2Njk5OTQ5MzIyNjdd"),
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_2 :: SearchResult Contact
@@ -45,7 +46,8 @@ testObject_SearchResult_20Contact_user_2 =
       searchTook = -5,
       searchResults = [],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Just True
     }
 
 testObject_SearchResult_20Contact_user_3 :: SearchResult Contact
@@ -68,7 +70,8 @@ testObject_SearchResult_20Contact_user_3 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Just False
     }
 
 testObject_SearchResult_20Contact_user_4 :: SearchResult Contact
@@ -146,7 +149,8 @@ testObject_SearchResult_20Contact_user_4 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_5 :: SearchResult Contact
@@ -169,7 +173,8 @@ testObject_SearchResult_20Contact_user_5 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_6 :: SearchResult Contact
@@ -180,7 +185,8 @@ testObject_SearchResult_20Contact_user_6 =
       searchTook = 5,
       searchResults = [],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_7 :: SearchResult Contact
@@ -214,7 +220,8 @@ testObject_SearchResult_20Contact_user_7 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_8 :: SearchResult Contact
@@ -237,7 +244,8 @@ testObject_SearchResult_20Contact_user_8 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_9 :: SearchResult Contact
@@ -248,7 +256,8 @@ testObject_SearchResult_20Contact_user_9 =
       searchTook = 3,
       searchResults = [],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_10 :: SearchResult Contact
@@ -259,7 +268,8 @@ testObject_SearchResult_20Contact_user_10 =
       searchTook = -5,
       searchResults = [],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_11 :: SearchResult Contact
@@ -293,7 +303,8 @@ testObject_SearchResult_20Contact_user_11 =
             }
         ],
       searchPolicy = ExactHandleSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_12 :: SearchResult Contact
@@ -304,7 +315,8 @@ testObject_SearchResult_20Contact_user_12 =
       searchTook = 3,
       searchResults = [],
       searchPolicy = ExactHandleSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_13 :: SearchResult Contact
@@ -360,7 +372,8 @@ testObject_SearchResult_20Contact_user_13 =
             }
         ],
       searchPolicy = ExactHandleSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_14 :: SearchResult Contact
@@ -394,7 +407,8 @@ testObject_SearchResult_20Contact_user_14 =
             }
         ],
       searchPolicy = ExactHandleSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_15 :: SearchResult Contact
@@ -405,7 +419,8 @@ testObject_SearchResult_20Contact_user_15 =
       searchTook = 4,
       searchResults = [],
       searchPolicy = ExactHandleSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_16 :: SearchResult Contact
@@ -416,7 +431,8 @@ testObject_SearchResult_20Contact_user_16 =
       searchTook = -7,
       searchResults = [],
       searchPolicy = ExactHandleSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_17 :: SearchResult Contact
@@ -427,7 +443,8 @@ testObject_SearchResult_20Contact_user_17 =
       searchTook = -1,
       searchResults = [],
       searchPolicy = ExactHandleSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_18 :: SearchResult Contact
@@ -438,7 +455,8 @@ testObject_SearchResult_20Contact_user_18 =
       searchTook = -5,
       searchResults = [],
       searchPolicy = ExactHandleSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_19 :: SearchResult Contact
@@ -472,7 +490,8 @@ testObject_SearchResult_20Contact_user_19 =
             }
         ],
       searchPolicy = ExactHandleSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20Contact_user_20 :: SearchResult Contact
@@ -627,5 +646,6 @@ testObject_SearchResult_20Contact_user_20 =
             }
         ],
       searchPolicy = ExactHandleSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/SearchResult_20TeamContact_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/SearchResult_20TeamContact_user.hs
@@ -22,7 +22,7 @@ module Test.Wire.API.Golden.Generated.SearchResult_20TeamContact_user where
 import Data.Id (Id (Id))
 import Data.Json.Util (readUTCTimeMillis)
 import qualified Data.UUID as UUID (fromString)
-import Imports (Maybe (Just, Nothing), fromJust)
+import Imports (Bool (False, True), Maybe (Just, Nothing), fromJust)
 import Wire.API.Team.Role (Role (RoleAdmin, RoleExternalPartner, RoleMember, RoleOwner))
 import Wire.API.User (Email (Email, emailDomain, emailLocal), ManagedBy (ManagedByScim, ManagedByWire))
 import Wire.API.User.Search (FederatedUserSearchPolicy (ExactHandleSearch, FullSearch), PagingState (..), SearchResult (..), Sso (..), TeamContact (..))
@@ -66,7 +66,8 @@ testObject_SearchResult_20TeamContact_user_1 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Just (PagingState "WzE2Njk5OTQ5MzIyNjdd")
+      searchPagingState = Just (PagingState "WzE2Njk5OTQ5MzIyNjdd"),
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_2 :: SearchResult TeamContact
@@ -77,7 +78,8 @@ testObject_SearchResult_20TeamContact_user_2 =
       searchTook = 6,
       searchResults = [],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Just True
     }
 
 testObject_SearchResult_20TeamContact_user_3 :: SearchResult TeamContact
@@ -134,7 +136,8 @@ testObject_SearchResult_20TeamContact_user_3 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Just False
     }
 
 testObject_SearchResult_20TeamContact_user_4 :: SearchResult TeamContact
@@ -206,7 +209,8 @@ testObject_SearchResult_20TeamContact_user_4 =
             }
         ],
       searchPolicy = ExactHandleSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_5 :: SearchResult TeamContact
@@ -233,7 +237,8 @@ testObject_SearchResult_20TeamContact_user_5 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_6 :: SearchResult TeamContact
@@ -440,7 +445,8 @@ testObject_SearchResult_20TeamContact_user_6 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_7 :: SearchResult TeamContact
@@ -542,7 +548,8 @@ testObject_SearchResult_20TeamContact_user_7 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_8 :: SearchResult TeamContact
@@ -614,7 +621,8 @@ testObject_SearchResult_20TeamContact_user_8 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_9 :: SearchResult TeamContact
@@ -686,7 +694,8 @@ testObject_SearchResult_20TeamContact_user_9 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_10 :: SearchResult TeamContact
@@ -697,7 +706,8 @@ testObject_SearchResult_20TeamContact_user_10 =
       searchTook = -4,
       searchResults = [],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_11 :: SearchResult TeamContact
@@ -829,7 +839,8 @@ testObject_SearchResult_20TeamContact_user_11 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_12 :: SearchResult TeamContact
@@ -856,7 +867,8 @@ testObject_SearchResult_20TeamContact_user_12 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_13 :: SearchResult TeamContact
@@ -913,7 +925,8 @@ testObject_SearchResult_20TeamContact_user_13 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_14 :: SearchResult TeamContact
@@ -940,7 +953,8 @@ testObject_SearchResult_20TeamContact_user_14 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_15 :: SearchResult TeamContact
@@ -967,7 +981,8 @@ testObject_SearchResult_20TeamContact_user_15 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_16 :: SearchResult TeamContact
@@ -1024,7 +1039,8 @@ testObject_SearchResult_20TeamContact_user_16 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_17 :: SearchResult TeamContact
@@ -1051,7 +1067,8 @@ testObject_SearchResult_20TeamContact_user_17 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_18 :: SearchResult TeamContact
@@ -1078,7 +1095,8 @@ testObject_SearchResult_20TeamContact_user_18 =
             }
         ],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_19 :: SearchResult TeamContact
@@ -1089,7 +1107,8 @@ testObject_SearchResult_20TeamContact_user_19 =
       searchTook = -2,
       searchResults = [],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResult_20TeamContact_user_20 :: SearchResult TeamContact
@@ -1100,5 +1119,6 @@ testObject_SearchResult_20TeamContact_user_20 =
       searchTook = 1,
       searchResults = [],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/SearchResultContact.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/SearchResultContact.hs
@@ -29,7 +29,8 @@ testObject_SearchResultContact_1 =
       searchTook = 100,
       searchResults = [testObject_Contact_1, testObject_Contact_2],
       searchPolicy = FullSearch,
-      searchPagingState = Nothing
+      searchPagingState = Nothing,
+      searchHasMore = Nothing
     }
 
 testObject_SearchResultContact_2 :: SearchResult Contact
@@ -40,5 +41,6 @@ testObject_SearchResultContact_2 =
       searchTook = 100,
       searchResults = [testObject_Contact_1, testObject_Contact_2],
       searchPolicy = FullSearch,
-      searchPagingState = Just $ PagingState "WzE2Njk5OTQ5MzIyNjdd"
+      searchPagingState = Just $ PagingState "WzE2Njk5OTQ5MzIyNjdd",
+      searchHasMore = Just False
     }

--- a/libs/wire-api/test/golden/testObject_SearchResultContact_2.json
+++ b/libs/wire-api/test/golden/testObject_SearchResultContact_2.json
@@ -24,6 +24,7 @@
         }
     ],
     "found": 2,
+    "has_more": false,
     "paging_state": "WzE2Njk5OTQ5MzIyNjdd",
     "returned": 2,
     "search_policy": "full_search",

--- a/libs/wire-api/test/golden/testObject_SearchResult_20Contact_user_2.json
+++ b/libs/wire-api/test/golden/testObject_SearchResult_20Contact_user_2.json
@@ -1,6 +1,7 @@
 {
     "documents": [],
     "found": -4,
+    "has_more": true,
     "returned": 6,
     "search_policy": "full_search",
     "took": -5

--- a/libs/wire-api/test/golden/testObject_SearchResult_20Contact_user_3.json
+++ b/libs/wire-api/test/golden/testObject_SearchResult_20Contact_user_3.json
@@ -13,6 +13,7 @@
         }
     ],
     "found": 4,
+    "has_more": false,
     "returned": 0,
     "search_policy": "full_search",
     "took": 7

--- a/libs/wire-api/test/golden/testObject_SearchResult_20TeamContact_user_2.json
+++ b/libs/wire-api/test/golden/testObject_SearchResult_20TeamContact_user_2.json
@@ -1,6 +1,7 @@
 {
     "documents": [],
     "found": -5,
+    "has_more": true,
     "returned": 4,
     "search_policy": "full_search",
     "took": 6

--- a/libs/wire-api/test/golden/testObject_SearchResult_20TeamContact_user_3.json
+++ b/libs/wire-api/test/golden/testObject_SearchResult_20TeamContact_user_3.json
@@ -47,6 +47,7 @@
         }
     ],
     "found": -5,
+    "has_more": false,
     "returned": -2,
     "search_policy": "full_search",
     "took": -7

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -114,7 +114,8 @@ searchRemotely domain searchTerm = do
         searchReturned = count,
         searchTook = 0,
         searchPolicy = S.searchPolicy searchResponse,
-        searchPagingState = Nothing
+        searchPagingState = Nothing,
+        searchHasMore = Nothing
       }
 
 searchLocally ::
@@ -137,7 +138,7 @@ searchLocally searcherId searchTerm maybeMaxResults = do
   esResult <-
     if esMaxResults > 0
       then Q.searchIndex (Q.LocalSearch searcherId searcherTeamId teamSearchInfo) searchTerm esMaxResults
-      else pure $ SearchResult 0 0 0 [] FullSearch Nothing
+      else pure $ SearchResult 0 0 0 [] FullSearch Nothing Nothing
 
   -- Prepend results matching exact handle and results from ES.
   pure $

--- a/services/brig/src/Brig/User/Search/SearchIndex.hs
+++ b/services/brig/src/Brig/User/Search/SearchIndex.hs
@@ -88,7 +88,8 @@ queryIndex (IndexQuery q f _) s = do
               searchTook = ES.took es,
               searchResults = results,
               searchPolicy = FullSearch,
-              searchPagingState = Nothing
+              searchPagingState = Nothing,
+              searchHasMore = Nothing
             }
 
 userDocToContact :: MonadThrow m => Domain -> UserDoc -> m Contact

--- a/services/brig/src/Brig/User/Search/TeamUserSearch.hs
+++ b/services/brig/src/Brig/User/Search/TeamUserSearch.hs
@@ -50,12 +50,12 @@ teamUserSearch ::
   Range 1 500 Int32 ->
   Maybe PagingState ->
   m (SearchResult TeamContact)
-teamUserSearch tid mbSearchText mRoleFilter mSortBy mSortOrder (fromRange -> s) mPagingState = liftIndexIO $ do
+teamUserSearch tid mbSearchText mRoleFilter mSortBy mSortOrder (fromRange -> size) mPagingState = liftIndexIO $ do
   let (IndexQuery q f sortSpecs) = teamUserSearchQuery tid mbSearchText mRoleFilter mSortBy mSortOrder
   idx <- asks idxName
   let search =
         (ES.mkSearch (Just q) (Just f))
-          { ES.size = ES.Size (fromIntegral s),
+          { ES.size = ES.Size (fromIntegral size + 1),
             ES.sortBody = Just (fmap ES.DefaultSortSpec sortSpecs),
             ES.searchAfterKey = toSearchAfterKey =<< mPagingState
           }
@@ -71,8 +71,9 @@ teamUserSearch tid mbSearchText mRoleFilter mSortBy mSortOrder (fromRange -> s) 
     fromSearchAfterKey = PagingState . encodeBase64Url . cs . encode
 
     mkResult es =
-      let hits = ES.hits . ES.searchHits $ es
-          mps = fmap fromSearchAfterKey . ES.hitSort =<< lastMay hits
+      let hitsPlusOne = ES.hits . ES.searchHits $ es
+          hits = take (fromIntegral size) hitsPlusOne
+          mps = fromSearchAfterKey <$> lastMay (mapMaybe ES.hitSort hits)
           results = mapMaybe ES.hitSource hits
        in SearchResult
             { searchFound = ES.hitsTotal . ES.searchHits $ es,
@@ -80,7 +81,8 @@ teamUserSearch tid mbSearchText mRoleFilter mSortBy mSortOrder (fromRange -> s) 
               searchTook = ES.took es,
               searchResults = results,
               searchPolicy = FullSearch,
-              searchPagingState = mps
+              searchPagingState = mps,
+              searchHasMore = Just $ length hitsPlusOne > length hits
             }
 
 -- FUTURWORK: Implement role filter (needs galley data)

--- a/services/brig/src/Brig/User/Search/TeamUserSearch.hs
+++ b/services/brig/src/Brig/User/Search/TeamUserSearch.hs
@@ -55,7 +55,8 @@ teamUserSearch tid mbSearchText mRoleFilter mSortBy mSortOrder (fromRange -> siz
   idx <- asks idxName
   let search =
         (ES.mkSearch (Just q) (Just f))
-          { ES.size = ES.Size (fromIntegral size + 1),
+          { -- we are requesting one more result than the page size to determine if there is a next page
+            ES.size = ES.Size (fromIntegral size + 1),
             ES.sortBody = Just (fmap ES.DefaultSortSpec sortSpecs),
             ES.searchAfterKey = toSearchAfterKey =<< mPagingState
           }

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -558,7 +558,8 @@ testSearchOtherDomain opts brig = do
             searchReturned = length otherSearchResult,
             searchTook = 0,
             searchPolicy = ExactHandleSearch,
-            searchPagingState = Nothing
+            searchPagingState = Nothing,
+            searchHasMore = Nothing
           }
   liftIO $ do
     assertEqual "The search request should get its result from federator" expectedResult searchResult

--- a/services/brig/test/integration/API/TeamUserSearch.hs
+++ b/services/brig/test/integration/API/TeamUserSearch.hs
@@ -149,5 +149,7 @@ testEmptyQuerySortedWithPagination brig = do
   liftIO $ do
     searchReturned searchResultFirst10 @?= 10
     searchFound searchResultFirst10 @?= 21
+    searchHasMore searchResultFirst10 @?= Just True
     searchReturned searchResultLast11 @?= 11
     searchFound searchResultLast11 @?= 21
+    searchHasMore searchResultLast11 @?= Just False


### PR DESCRIPTION
This is an extension of https://github.com/wireapp/wire-server/pull/2895 and adds the `has_more` field to the search result.

https://wearezeta.atlassian.net/browse/SQSERVICES-1773

## Checklist

 - [x] No new changelog entry needed as this already exists in the base PR
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
