### PR TITLE
Restore v2 PUT access endpoint and add tests

### DIFF
--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -706,7 +706,7 @@ data NewConv = NewConv
 instance ToSchema NewConv where
   schema =
     newConvSchema $
-      maybe_ (optField "access_roles" (set schema))
+      maybe_ (optField "access_role" (set schema))
 
 instance ToSchema (Versioned 'V2 NewConv) where
   schema = Versioned <$> unVersioned .= newConvSchema accessRolesSchemaOptV2

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -848,7 +848,7 @@ type ConversationAPI =
     :<|> Named
            "update-conversation-access-unqualified"
            ( Summary "Update access modes for a conversation (deprecated)"
-               :> Until 'V2
+               :> Until 'V3
                :> Description "Use PUT `/conversations/:domain/:cnv/access` instead."
                :> ZLocalUser
                :> ZConn

--- a/libs/wire-api/test/golden/testObject_NewConv_user_1.json
+++ b/libs/wire-api/test/golden/testObject_NewConv_user_1.json
@@ -3,7 +3,7 @@
         "private",
         "invite"
     ],
-    "access_roles": [
+    "access_role": [
         "team_member",
         "guest"
     ],

--- a/libs/wire-api/test/golden/testObject_NewConv_user_3.json
+++ b/libs/wire-api/test/golden/testObject_NewConv_user_3.json
@@ -4,7 +4,7 @@
         "link",
         "code"
     ],
-    "access_roles": [
+    "access_role": [
         "team_member",
         "guest"
     ],

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1383,13 +1383,13 @@ postJoinCodeConvOk = do
     -- changing access to non-activated should give eve access
     Right accessRolesWithGuests <- liftIO $ genAccessRolesV2 [TeamMemberAccessRole, NonTeamMemberAccessRole, GuestAccessRole] []
     let nonActivatedAccess = ConversationAccessData (Set.singleton CodeAccess) accessRolesWithGuests
-    putAccessUpdate alice qconv nonActivatedAccess !!! const 200 === statusCode
+    putQualifiedAccessUpdate alice qconv nonActivatedAccess !!! const 200 === statusCode
     postJoinCodeConv eve payload !!! const 200 === statusCode
     -- guest cannot create invite link
     postConvCode eve conv !!! const 403 === statusCode
     -- after removing CodeAccess, no further people can join
     let noCodeAccess = ConversationAccessData (Set.singleton InviteAccess) accessRoles
-    putAccessUpdate alice qconv noCodeAccess !!! const 200 === statusCode
+    putQualifiedAccessUpdate alice qconv noCodeAccess !!! const 200 === statusCode
     postJoinCodeConv dave payload !!! const 404 === statusCode
 
 -- @END
@@ -1407,16 +1407,16 @@ postConvertCodeConv = do
   getConvCode alice conv !!! const 403 === statusCode
   -- cannot change to (Set.fromList [TeamMemberAccessRole]) as not a team conversation
   let teamAccess = ConversationAccessData (Set.singleton InviteAccess) (Set.fromList [TeamMemberAccessRole])
-  putAccessUpdate alice qconv teamAccess !!! const 403 === statusCode
+  putQualifiedAccessUpdate alice qconv teamAccess !!! const 403 === statusCode
   -- change access
   WS.bracketR c alice $ \wsA -> do
     let nonActivatedAccess =
           ConversationAccessData
             (Set.fromList [InviteAccess, CodeAccess])
             (Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole, GuestAccessRole, ServiceAccessRole])
-    putAccessUpdate alice qconv nonActivatedAccess !!! const 200 === statusCode
+    putQualifiedAccessUpdate alice qconv nonActivatedAccess !!! const 200 === statusCode
     -- test no-op
-    putAccessUpdate alice qconv nonActivatedAccess !!! const 204 === statusCode
+    putQualifiedAccessUpdate alice qconv nonActivatedAccess !!! const 204 === statusCode
     void . liftIO $
       WS.assertMatchN (5 # Second) [wsA] $
         wsAssertConvAccessUpdate qconv qalice nonActivatedAccess
@@ -1437,7 +1437,7 @@ postConvertCodeConv = do
         ConversationAccessData
           (Set.singleton InviteAccess)
           (Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole, GuestAccessRole, ServiceAccessRole])
-  putAccessUpdate alice qconv noCodeAccess !!! const 200 === statusCode
+  putQualifiedAccessUpdate alice qconv noCodeAccess !!! const 200 === statusCode
   getConvCode alice conv !!! const 403 === statusCode
 
 postConvertTeamConv :: TestM ()
@@ -1478,7 +1478,7 @@ postConvertTeamConv = do
           ConversationAccessData
             (Set.fromList [InviteAccess, CodeAccess])
             (Set.fromList [TeamMemberAccessRole])
-    putAccessUpdate alice qconv teamAccess !!! const 200 === statusCode
+    putQualifiedAccessUpdate alice qconv teamAccess !!! const 200 === statusCode
     void . liftIO $
       WS.assertMatchN (5 # Second) [wsA, wsB, wsE, wsM] $
         wsAssertConvAccessUpdate qconv qalice teamAccess
@@ -1600,7 +1600,7 @@ testTeamMemberCantJoinViaGuestLinkIfAccessRoleRemoved = do
 
   -- when the guests are disabled for the conversation
   let accessData = ConversationAccessData (Set.singleton InviteAccess) (Set.fromList [TeamMemberAccessRole, ServiceAccessRole])
-  putAccessUpdate alice qconvId accessData !!! const 200 === statusCode
+  putQualifiedAccessUpdate alice qconvId accessData !!! const 200 === statusCode
 
   -- then dee cannot join via guest link
   postJoinCodeConv dee cCode !!! const 404 === statusCode

--- a/services/galley/test/integration/API/Roles.hs
+++ b/services/galley/test/integration/API/Roles.hs
@@ -21,7 +21,7 @@ import API.Util
 import Bilge hiding (timeout)
 import Bilge.Assert
 import Control.Lens (view)
-import Data.Aeson (eitherDecode)
+import Data.Aeson hiding (json)
 import Data.ByteString.Conversion (toByteString')
 import Data.Domain
 import Data.Id
@@ -56,7 +56,8 @@ tests s =
       test s "conversation role update with remote users present" roleUpdateWithRemotes,
       test s "conversation access update with remote users present" accessUpdateWithRemotes,
       test s "conversation role update of remote member" roleUpdateRemoteMember,
-      test s "get all conversation roles" testAllConversationRoles
+      test s "get all conversation roles" testAllConversationRoles,
+      test s "access role update with v2" testAccessRoleUpdateV2
     ]
 
 testAllConversationRoles :: TestM ()
@@ -363,9 +364,9 @@ wireAdminChecks cid admin otherAdmin mem = do
   putReceiptMode admin cid (ReceiptMode 0) !!! assertActionSucceeded
   putReceiptMode admin cid (ReceiptMode 1) !!! assertActionSucceeded
   let nonActivatedAccess = ConversationAccessData (Set.singleton CodeAccess) (Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole, GuestAccessRole, ServiceAccessRole])
-  putAccessUpdate admin qcid nonActivatedAccess !!! assertActionSucceeded
+  putQualifiedAccessUpdate admin qcid nonActivatedAccess !!! assertActionSucceeded
   let activatedAccess = ConversationAccessData (Set.singleton InviteAccess) (Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole, GuestAccessRole, ServiceAccessRole])
-  putAccessUpdate admin qcid activatedAccess !!! assertActionSucceeded
+  putQualifiedAccessUpdate admin qcid activatedAccess !!! assertActionSucceeded
   -- Update your own member state
   let memUpdate = memberUpdate {mupOtrArchive = Just True}
   putMember admin memUpdate qcid !!! assertActionSucceeded
@@ -411,7 +412,7 @@ wireMemberChecks cid mem admin otherMem = do
   putMessageTimerUpdate mem cid (ConversationMessageTimerUpdate Nothing) !!! assertActionDenied
   putReceiptMode mem cid (ReceiptMode 0) !!! assertActionDenied
   let nonActivatedAccess = ConversationAccessData (Set.singleton CodeAccess) (Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole, GuestAccessRole, ServiceAccessRole])
-  putAccessUpdate mem qcid nonActivatedAccess !!! assertActionDenied
+  putQualifiedAccessUpdate mem qcid nonActivatedAccess !!! assertActionDenied
   -- Finally, you can still do the following actions:
 
   -- Update your own member state
@@ -421,6 +422,62 @@ wireMemberChecks cid mem admin otherMem = do
   deleteMemberQualified mem qmem qcid !!! assertActionSucceeded
   -- Let's readd the user to make tests easier
   postMembersWithRole admin (pure qmem) qcid role !!! const 200 === statusCode
+
+testAccessRoleUpdateV2 :: TestM ()
+testAccessRoleUpdateV2 = do
+  g <- view tsUnversionedGalley
+  [alice, bob] <- createAndConnectUsers (replicate 2 Nothing)
+  conv :: Conversation <-
+    responseJsonError
+      =<< postConvQualified
+        (qUnqualified alice)
+        defNewProteusConv
+          { newConvQualifiedUsers = [bob]
+          }
+        <!! const 201 === statusCode
+  let qcnv = cnvQualifiedId conv
+  -- Using v2 qualified endpoint
+  put
+    ( g
+        . paths
+          [ "v2",
+            "conversations",
+            toByteString' (qDomain qcnv),
+            toByteString' (qUnqualified qcnv),
+            "access"
+          ]
+        . zUser (qUnqualified alice)
+        . zConn "conn"
+        . json
+          ( object
+              [ "access" .= ["invite" :: Text],
+                "access_role_v2" .= ["guest" :: Text]
+              ]
+          )
+    )
+    !!! const 200 === statusCode
+  -- Using v2 unqualified endpoint
+  put
+    ( g
+        . paths
+          [ "v2",
+            "conversations",
+            toByteString' (qUnqualified qcnv),
+            "access"
+          ]
+        . zUser (qUnqualified alice)
+        . zConn "conn"
+        . json
+          ( object
+              [ "access" .= ["invite" :: Text],
+                "access_role_v2" .= ["guest" :: Text]
+              ]
+          )
+    )
+    !!! const 204 === statusCode
+
+--------------------------------------------------------------------------------
+-- Utilities
 
 assertActionSucceeded :: HasCallStack => Assertions ()
 assertActionSucceeded = const 200 === statusCode

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -1262,7 +1262,7 @@ testDeleteTeamConv = do
   cid1 <- Util.createTeamConv owner tid [] (Just "blaa") Nothing Nothing
   qcid1 <- Qualified cid1 <$> viewFederationDomain
   let access = ConversationAccessData (Set.fromList [InviteAccess, CodeAccess]) (Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole])
-  putAccessUpdate owner qcid1 access !!! const 200 === statusCode
+  putQualifiedAccessUpdate owner qcid1 access !!! const 200 === statusCode
   code <- decodeConvCodeEvent <$> (postConvCode owner cid1 <!! const 201 === statusCode)
   cid2 <- Util.createTeamConv owner tid (qUnqualified <$> members) (Just "blup") Nothing Nothing
   Util.postMembers owner (qExtern :| [qMember]) qcid1 !!! const 200 === statusCode

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1405,22 +1405,6 @@ postJoinCodeConv u j = do
       . zType "access"
       . json j
 
-putAccessUpdate :: UserId -> Qualified ConvId -> ConversationAccessData -> TestM ResponseLBS
-putAccessUpdate u qc acc = do
-  g <- viewGalley
-  put $
-    g
-      . paths
-        [ "/conversations",
-          toByteString' (qDomain qc),
-          toByteString' (qUnqualified qc),
-          "access"
-        ]
-      . zUser u
-      . zConn "conn"
-      . zType "access"
-      . json acc
-
 putQualifiedAccessUpdate ::
   (MonadHttp m, HasGalley m, MonadIO m) =>
   UserId ->


### PR DESCRIPTION
- Restore unqualified v2 PUT access endpoint
- Fix `access_role` field name in `NewConv`
- Add tests

https://wearezeta.atlassian.net/browse/FS-1281

## Checklist

 - [x] No CHANGELOG entry, since these bugs were not in a release
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
