### PR TITLE
Prevent ormolu from trying to format deleted files, fixed wrong name for make full-clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ ifdef CABAL_DIR
 else
 	rm -rf ~/.cabal/store
 endif
-	rm -rf ./dist-newbuild ./.env
+	rm -rf ./dist-newstyle ./.env
 	direnv reload
 
 .PHONY: clean

--- a/tools/ormolu.sh
+++ b/tools/ormolu.sh
@@ -74,7 +74,7 @@ fi
 if [ "$f" = "all" ] || [ "$f" = "" ]; then
     files=$(git ls-files | grep '\.hsc\?$')
 elif [ "$f" = "pr" ]; then
-    files=$(git diff --name-only origin/develop... | { grep '\.hsc\?$' || true; }; git diff --name-only HEAD | { grep \.hs\$ || true ; })
+    files=$(git diff --diff-filter=ACMR --name-only origin/develop... | { grep '\.hsc\?$' || true; }; git diff --diff-filter=ACMR --name-only HEAD | { grep \.hs\$ || true ; })
 fi
 
 count=$( echo "$files" | sed '/^\s*$/d' | wc -l )


### PR DESCRIPTION
As it says on the tin 🥤

Using diff-filter to select only added, copied, modified, and renamed files, but not deleted, unmerged, unknown status, or broken files.

Also fixes `make full-clean` trying to delete the wrongly named dist-* folder.