### PR TITLE
Log AWS SNS invalid token responses (SQCORE-1267)

### DIFF
--- a/changelog.d/5-internal/add-aws-sns-token-invalid-log
+++ b/changelog.d/5-internal/add-aws-sns-token-invalid-log
@@ -1,0 +1,1 @@
+Log AWS / SNS invalid token responses. This is helpful for native push notification debugging purposes.

--- a/services/gundeck/src/Gundeck/Aws.hs
+++ b/services/gundeck/src/Gundeck/Aws.hs
@@ -309,7 +309,10 @@ createEndpoint u tr arnEnv app token = do
           pure (Left (TokenTooLong $ tokenLength token))
       | is "SNS" 400 x
           && AWS.newErrorCode "InvalidParameter" == e ^. serviceCode
-          && isTokenError (e ^. serviceMessage) ->
+          && isTokenError (e ^. serviceMessage) -> do
+          debug $
+            msg @Text "InvalidParameter: InvalidToken"
+              . field "response" (show x)
           pure (Left (InvalidToken token))
       | is "SNS" 404 x ->
           pure (Left (AppNotFound app))


### PR DESCRIPTION
To debug notification (token) specific issues, we need to know the exact answer of AWS/SNS.

This happens is on log level `debug`, of course.

### Ticket

[SQCORE-1267](https://wearezeta.atlassian.net/browse/SQCORE-1267)

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
