### PR TITLE
Revert "AWS/SNS create endpoint without custom user data (SQCORE-1267)"

### DIFF
--- a/changelog.d/3-bug-fixes/aws-sns-without-CustomUserData
+++ b/changelog.d/3-bug-fixes/aws-sns-without-CustomUserData
@@ -1,1 +1,0 @@
-Previously, AWS/SNS endpoint creation included `CustomUserData` which was the `UserId`. This doesn't make sense anymore; given that a user may be attached with the same device (Android or iOS) and several accounts (several `UserId`s!) to the same backend. So, `CustomUserData` isn't added to the request, anymore.

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -450,7 +450,7 @@ addToken uid cid newtok = mpaRunWithBudget 1 (Left Public.AddTokenErrorNoBudget)
       let tok = t ^. token
       env <- view (options . optAws . awsArnEnv)
       aws <- view awsEnv
-      ept <- Aws.execute aws (Aws.createEndpoint trp env app tok)
+      ept <- Aws.execute aws (Aws.createEndpoint uid trp env app tok)
       case ept of
         Left (Aws.EndpointInUse arn) -> do
           Log.info $ "arn" .= toText arn ~~ msg (val "ARN in use")


### PR DESCRIPTION
Reverts wireapp/wire-server#2910

It turns out that just leaving out `CustomUserData` does not solve the issue. The values of `CustomUserData` (a set of `UserId`s) are elsewhere in use.