### PR TITLE
fix gundeck aws endpoint parsing

### DIFF
--- a/changelog.d/3-bug-fixes/aws-error-message-parser-bug
+++ b/changelog.d/3-bug-fixes/aws-error-message-parser-bug
@@ -1,0 +1,1 @@
+The parser for the AWS/SNS error message to explain that an endpoint is already in use was incorrect. This lead to an "invalid token" error when registering push tokens for multiple user accounts (user ids) instead of updating the SNS endpoint with an additional user id.

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -414,6 +414,7 @@ test-suite gundeck-tests
     Json
     MockGundeck
     Native
+    ParseExistsError
     Paths_gundeck
     Push
     ThreadBudget

--- a/services/gundeck/test/unit/Main.hs
+++ b/services/gundeck/test/unit/Main.hs
@@ -29,6 +29,7 @@ import qualified Json
 import qualified Native
 import Network.Wai.Utilities.Server (compile)
 import OpenSSL (withOpenSSL)
+import qualified ParseExistsError
 import qualified Push
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -48,5 +49,6 @@ main =
         Json.tests,
         Native.tests,
         Push.tests,
-        ThreadBudget.tests
+        ThreadBudget.tests,
+        ParseExistsError.tests
       ]

--- a/services/gundeck/test/unit/ParseExistsError.hs
+++ b/services/gundeck/test/unit/ParseExistsError.hs
@@ -1,0 +1,23 @@
+module ParseExistsError where
+
+import Amazonka.Types
+import Gundeck.Aws
+import Gundeck.Aws.Arn
+import Gundeck.Types.Push.V2 (Transport (APNS))
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+  testGroup
+    "parseExistsError"
+    [ testCase "parse error string from real world example" parseErrorTest
+    ]
+
+parseErrorTest :: Assertion
+parseErrorTest =
+  let e = Just $ ErrorMessage "Invalid parameter: Token Reason: Endpoint arn:aws:sns:eu-west-1:093205192929:endpoint/APNS/staging-com.wire.dev.ent/f90c8f08-a0a1-33bc-aa43-23c94770d936 already exists with the same Token, but different attributes."
+      expectedTopic = mkEndpointTopic (ArnEnv "staging") APNS "com.wire.dev.ent" (EndpointId "f90c8f08-a0a1-33bc-aa43-23c94770d936")
+      expected = mkSnsArn Ireland (Account "093205192929") expectedTopic
+   in parseExistsError e @?= Just expected

--- a/services/gundeck/test/unit/ParseExistsError.hs
+++ b/services/gundeck/test/unit/ParseExistsError.hs
@@ -12,7 +12,8 @@ tests :: TestTree
 tests =
   testGroup
     "parseExistsError"
-    [ testCase "parse error string from real world example" parseErrorTest
+    [ testCase "parse error string from real world example" parseErrorTest,
+      testCase "parse errors" parseErrors
     ]
 
 parseErrorTest :: Assertion
@@ -21,3 +22,18 @@ parseErrorTest =
       expectedTopic = mkEndpointTopic (ArnEnv "staging") APNS "com.wire.dev.ent" (EndpointId "f90c8f08-a0a1-33bc-aa43-23c94770d936")
       expected = mkSnsArn Ireland (Account "093205192929") expectedTopic
    in parseExistsError e @?= Just expected
+
+parseErrors :: Assertion
+parseErrors = do
+  parseExistsError Nothing @?= Nothing
+  parseExistsError ((Just . ErrorMessage) "Invalid parameter: Token Reason: Endpoint") @?= Nothing
+  parseExistsError
+    ( (Just . ErrorMessage)
+        "Invalid parameter: Token Reason: Endpoint NO_ARN already exists with the same Token, but different attributes."
+    )
+    @?= Nothing
+  parseExistsError
+    ( (Just . ErrorMessage)
+        "Invalid parameter: Token Reason: Endpoint arn:aws:sns:eu-west-1:093205192929:endpoint/APNS/staging-com.wire.dev.ent/f90c8f08-a0a1-33bc-aa43-23c94770d936"
+    )
+    @?= Nothing


### PR DESCRIPTION
The parser for the AWS/SNS error message to explain that an endpoint is already in use was incorrect. This lead to an "invalid token" error when registering push tokens for multiple user accounts (user ids) instead of updating the SNS endpoint with an additional user id.

The fix is to not apply `endParser` twice. (Because, the end is already consumed by `manyTill`.)

### Ticket

https://wearezeta.atlassian.net/browse/SQCORE-1267

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
