### PR TITLE
Add TLS cipher configuration to coturn Helm chart [SQPIT-1512]

### DIFF
--- a/changelog.d/2-features/coturn-tls
+++ b/changelog.d/2-features/coturn-tls
@@ -1,0 +1,4 @@
+The coturn Helm chart now has a `.tls.ciphers` option to allow setting
+the cipher list for TLS connections, when TLS is enabled. By default,
+this option is set to a cipher list which is compliant with [BSI
+TR-02102-2](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.pdf).

--- a/charts/coturn/templates/configmap-coturn-conf-template.yaml
+++ b/charts/coturn/templates/configmap-coturn-conf-template.yaml
@@ -13,6 +13,9 @@ data:
     {{- if .Values.tls.enabled }}
     cert=/secrets-tls/tls.crt
     pkey=/secrets-tls/tls.key
+    {{- if .Values.tls.ciphers }}
+    cipher-list={{ .Values.tls.ciphers }}
+    {{- end }}
     {{- else }}
     no-tls
     {{- end }}

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -28,6 +28,8 @@ coturnTurnTlsListenPort: 5349
 
 tls:
   enabled: false
+  # compliant with BSI TR-02102-2
+  ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384'
   secretRef:
   reloaderImage:
     # container image containing https://github.com/Pluies/config-reloader-sidecar


### PR DESCRIPTION
This PR introduces a configuration option in the coturn Helm chart to allow operators to set the list of ciphers permitted for TLS connections, with the defaults set for compliance with BSI TR-02102-2. Based on [this coturn PR](https://github.com/coturn/coturn/pull/1118), it's likely that TLS 1.3 ciphersuite configuration will reuse the same configuration option for TLS 1.2 and below cipher list configuration, so we can provide the configuration strings for both versions concatenated together.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
