### PR TITLE
Add optional subconversation field to conversation events

### DIFF
--- a/changelog.d/1-api-changes/subconv-field
+++ b/changelog.d/1-api-changes/subconv-field
@@ -1,0 +1,1 @@
+Conversation events may have a "subconv" field for events that originate in a MLS subconversation

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -47,6 +47,7 @@ import Wire.API.Conversation
 import Wire.API.Conversation.Action.Tag
 import Wire.API.Conversation.Role
 import Wire.API.Event.Conversation
+import Wire.API.MLS.SubConversation
 import Wire.Arbitrary (Arbitrary (..))
 
 -- | We use this type family instead of a sum type to be able to define
@@ -143,9 +144,10 @@ conversationActionToEvent ::
   UTCTime ->
   Qualified UserId ->
   Qualified ConvId ->
+  Maybe SubConvId ->
   ConversationAction tag ->
   Event
-conversationActionToEvent tag now quid qcnv action =
+conversationActionToEvent tag now quid qcnv subconv action =
   let edata = case tag of
         SConversationJoinTag ->
           let ConversationJoin newMembers role = action
@@ -163,4 +165,4 @@ conversationActionToEvent tag now quid qcnv action =
         SConversationMessageTimerUpdateTag -> EdConvMessageTimerUpdate action
         SConversationReceiptModeUpdateTag -> EdConvReceiptModeUpdate action
         SConversationAccessDataTag -> EdConvAccessUpdate action
-   in Event qcnv quid now edata
+   in Event qcnv subconv quid now edata

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/AddBotResponse_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/AddBotResponse_user.hs
@@ -53,6 +53,7 @@ testObject_AddBotResponse_user_1 =
       rsAddBotEvent =
         Event
           (Qualified (Id (fromJust (UUID.fromString "00000001-0000-0000-0000-000200000003"))) (Domain "faraway.example.com"))
+          Nothing
           (Qualified (Id (fromJust (UUID.fromString "00000004-0000-0004-0000-000400000004"))) (Domain "faraway.example.com"))
           (read "1864-05-12 19:20:22.286 UTC")
           (EdConvRename (ConversationRename {cupName = "6"}))
@@ -73,6 +74,7 @@ testObject_AddBotResponse_user_2 =
       rsAddBotEvent =
         Event
           (Qualified (Id (fromJust (UUID.fromString "00000000-0000-0002-0000-000300000001"))) (Domain "faraway.example.com"))
+          Nothing
           (Qualified (Id (fromJust (UUID.fromString "00000004-0000-0000-0000-000300000001"))) (Domain "faraway.example.com"))
           (read "1864-05-08 19:02:58.6 UTC")
           (EdTyping StartedTyping)

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_conversation.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_conversation.hs
@@ -39,6 +39,7 @@ testObject_Event_conversation_1 :: Event
 testObject_Event_conversation_1 =
   Event
     { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "oym59-06.i423w"}},
+      evtSubConv = Nothing,
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "n8nl6tp.h5"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData = EdConvCodeDelete
@@ -48,6 +49,7 @@ testObject_Event_conversation_2 :: Event
 testObject_Event_conversation_2 =
   Event
     { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "2m99----34.id7u09"}},
+      evtSubConv = Nothing,
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "b.0-7.0.rg"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData =
@@ -69,6 +71,7 @@ testObject_Event_conversation_3 :: Event
 testObject_Event_conversation_3 =
   Event
     { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "91.ii9vf.mbwj9k7lmk"}},
+      evtSubConv = Nothing,
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "k3.f.z"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData =
@@ -85,6 +88,7 @@ testObject_Event_conversation_4 :: Event
 testObject_Event_conversation_4 =
   Event
     { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "ma--6us.i8o--0440"}},
+      evtSubConv = Nothing,
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "97k-u0.b-5c"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData = EdConvAccessUpdate (ConversationAccessData {cupAccess = fromList [PrivateAccess, CodeAccess], cupAccessRoles = fromList []})
@@ -94,6 +98,7 @@ testObject_Event_conversation_5 :: Event
 testObject_Event_conversation_5 =
   Event
     { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "q.6lm833.o95.l.y2"}},
+      evtSubConv = Nothing,
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "7.m4f7p.ez4zs61"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData = EdMLSWelcome ""
@@ -103,6 +108,7 @@ testObject_Event_conversation_6 :: Event
 testObject_Event_conversation_6 =
   Event
     { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "391.r"}},
+      evtSubConv = Nothing,
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "8.0-6.t7pxv"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData = EdOtrMessage (OtrMessage {otrSender = ClientId {client = "1"}, otrRecipient = ClientId {client = "1"}, otrCiphertext = "", otrData = Just "I\68655"})
@@ -112,6 +118,7 @@ testObject_Event_conversation_7 :: Event
 testObject_Event_conversation_7 =
   Event
     { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "b2.ue4k"}},
+      evtSubConv = Nothing,
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "64b3--h.u"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData = EdOtrMessage (OtrMessage {otrSender = ClientId {client = "3"}, otrRecipient = ClientId {client = "3"}, otrCiphertext = "%\SI", otrData = Nothing})
@@ -121,6 +128,7 @@ testObject_Event_conversation_8 :: Event
 testObject_Event_conversation_8 =
   Event
     { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "36.e9.s-o-17"}},
+      evtSubConv = Nothing,
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "0--gy.705nsa8.j4m"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData = EdTyping StartedTyping
@@ -130,6 +138,7 @@ testObject_Event_conversation_9 :: Event
 testObject_Event_conversation_9 =
   Event
     { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "743846p6-pp33.1.ktb9.0bmn.efm2bly"}},
+      evtSubConv = Nothing,
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "9--5grmn.j39y3--9n"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData =
@@ -163,6 +172,7 @@ testObject_Event_conversation_10 :: Event
 testObject_Event_conversation_10 =
   Event
     { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "1852a.o-4"}},
+      evtSubConv = Nothing,
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "4-p.d7b8d3.6.c8--jds3-1acy"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData = EdMLSMessage "s\b\138w\236\231P(\ESC\216\205"
@@ -172,6 +182,7 @@ testObject_Event_conversation_11 :: Event
 testObject_Event_conversation_11 =
   Event
     { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "wwzw-ly4jk5.6790-y.j04o-21.ltl"}},
+      evtSubConv = Nothing,
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "70-o.ncd"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData = EdTyping StoppedTyping

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
@@ -43,6 +43,7 @@ testObject_Event_user_1 :: Event
 testObject_Event_user_1 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "00005d81-0000-0d71-0000-1d8f00007d32"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "00003b8b-0000-3395-0000-076a00007830"))) (Domain "faraway.example.com"))
     (read "1864-05-22 09:51:07.104 UTC")
     EdConvDelete
@@ -51,6 +52,7 @@ testObject_Event_user_2 :: Event
 testObject_Event_user_2 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "0000064d-0000-7a7f-0000-5749000029e1"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "00006a88-0000-2acb-0000-6aa0000061b2"))) (Domain "faraway.example.com"))
     (read "1864-06-05 23:01:18.769 UTC")
     ( EdConvAccessUpdate
@@ -65,6 +67,7 @@ testObject_Event_user_3 :: Event
 testObject_Event_user_3 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "00006f8c-0000-00d6-0000-1568000001e9"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "00004b11-0000-5504-0000-55d800002188"))) (Domain "faraway.example.com"))
     (read "1864-04-27 15:44:23.844 UTC")
     ( EdOtrMessage
@@ -81,6 +84,7 @@ testObject_Event_user_4 :: Event
 testObject_Event_user_4 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "00004f04-0000-3939-0000-472d0000316b"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "00007c90-0000-766a-0000-01b700002ab7"))) (Domain "faraway.example.com"))
     (read "1864-05-12 00:59:09.2 UTC")
     EdConvCodeDelete
@@ -89,6 +93,7 @@ testObject_Event_user_5 :: Event
 testObject_Event_user_5 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "00003c8c-0000-6394-0000-294b0000098b"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "00002a12-0000-73e1-0000-71f700002ec9"))) (Domain "faraway.example.com"))
     (read "1864-04-12 03:04:00.298 UTC")
     ( EdMemberUpdate
@@ -116,6 +121,7 @@ testObject_Event_user_6 :: Event
 testObject_Event_user_6 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "00001fdb-0000-3127-0000-23ef00007183"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "0000705a-0000-0b62-0000-425c000049c8"))) (Domain "faraway.example.com"))
     (read "1864-05-09 05:44:41.382 UTC")
     (EdConvMessageTimerUpdate (ConversationMessageTimerUpdate {cupMessageTimer = Just (Ms {ms = 5029817038083912})}))
@@ -124,6 +130,7 @@ testObject_Event_user_7 :: Event
 testObject_Event_user_7 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "00006ac1-0000-543e-0000-7c8f00000be7"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "0000355a-0000-2979-0000-083000002d5e"))) (Domain "faraway.example.com"))
     (read "1864-04-18 05:01:13.761 UTC")
     (EdTyping StoppedTyping)
@@ -132,6 +139,7 @@ testObject_Event_user_8 :: Event
 testObject_Event_user_8 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "000019e1-0000-1dc6-0000-68de0000246d"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "00000457-0000-0689-0000-77a00000021c"))) (Domain "faraway.example.com"))
     (read "1864-05-29 19:31:31.226 UTC")
     ( EdConversation
@@ -195,6 +203,7 @@ testObject_Event_user_9 :: Event
 testObject_Event_user_9 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "00000b98-0000-618d-0000-19e200004651"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "00004bee-0000-45a0-0000-2c0300005726"))) (Domain "faraway.example.com"))
     (read "1864-05-01 11:57:35.123 UTC")
     (EdConvReceiptModeUpdate (ConversationReceiptModeUpdate {cruReceiptMode = ReceiptMode {unReceiptMode = -10505}}))
@@ -203,6 +212,7 @@ testObject_Event_user_10 :: Event
 testObject_Event_user_10 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "00005e43-0000-3b56-0000-7c270000538c"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "00007f28-0000-40b1-0000-56ab0000748d"))) (Domain "faraway.example.com"))
     (read "1864-05-25 01:31:49.802 UTC")
     ( EdConnect
@@ -222,6 +232,7 @@ testObject_Event_user_11 :: Event
 testObject_Event_user_11 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "0000303b-0000-23a9-0000-25de00002f80"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "000043a6-0000-1627-0000-490300002017"))) (Domain "faraway.example.com"))
     (read "1864-04-12 01:28:25.705 UTC")
     ( EdMembersLeave
@@ -238,6 +249,7 @@ testObject_Event_user_12 :: Event
 testObject_Event_user_12 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "00000838-0000-1bc6-0000-686d00003565"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "0000114a-0000-7da8-0000-40cb00007fcf"))) (Domain "faraway.example.com"))
     (read "1864-05-12 20:29:47.483 UTC")
     ( EdMembersJoin
@@ -260,6 +272,7 @@ testObject_Event_user_13 :: Event
 testObject_Event_user_13 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "00000838-0000-1bc6-0000-686d00003565"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "0000114a-0000-7da8-0000-40cb00007fcf"))) (Domain "faraway.example.com"))
     (read "1864-05-12 20:29:47.483 UTC")
     (EdConvRename (ConversationRename "New conversation name"))
@@ -268,6 +281,7 @@ testObject_Event_user_14 :: Event
 testObject_Event_user_14 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "00000838-0000-1bc6-0000-686d00003565"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "0000114a-0000-7da8-0000-40cb00007fcf"))) (Domain "faraway.example.com"))
     (read "1864-05-12 20:29:47.483 UTC")
     (EdConvCodeUpdate cc)
@@ -283,6 +297,7 @@ testObject_Event_user_15 :: Event
 testObject_Event_user_15 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "7cd50991-3cdd-40ec-bb0f-63ae17b2309d"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "04e68c50-027e-4e84-a33a-e2e28a7b8ea3"))) (Domain "faraway.example.com"))
     (read "2021-11-10 05:39:44.297 UTC")
     (EdMLSMessage "hello world")
@@ -291,6 +306,7 @@ testObject_Event_user_16 :: Event
 testObject_Event_user_16 =
   Event
     (Qualified (Id (fromJust (UUID.fromString "6ec1c834-9ae6-4825-8809-61dde80be5ea"))) (Domain "faraway.example.com"))
+    Nothing
     (Qualified (Id (fromJust (UUID.fromString "e8f48b8f-fad3-4f60-98e3-a6df082c328d"))) (Domain "faraway.example.com"))
     (read "2021-05-12 13:12:01.005 UTC")
     (EdMLSWelcome "welcome message content")

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/RemoveBotResponse_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/RemoveBotResponse_user.hs
@@ -21,9 +21,10 @@ module Test.Wire.API.Golden.Generated.RemoveBotResponse_user where
 
 import Data.Domain
 import Data.Id (Id (Id))
+import Data.Maybe
 import Data.Qualified
 import qualified Data.UUID as UUID (fromString)
-import Imports (fromJust, read)
+import Imports (read)
 import Wire.API.Conversation.Bot (RemoveBotResponse (..))
 import Wire.API.Event.Conversation
 
@@ -33,6 +34,7 @@ testObject_RemoveBotResponse_user_1 =
     { rsRemoveBotEvent =
         Event
           (Qualified (Id (fromJust (UUID.fromString "00003ab8-0000-0cff-0000-427f000000df"))) (Domain "faraway.example.com"))
+          Nothing
           (Qualified (Id (fromJust (UUID.fromString "00004166-0000-1e32-0000-52cb0000428d"))) (Domain "faraway.example.com"))
           (read "1864-05-07 01:13:35.741 UTC")
           ( EdMembersLeave

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
@@ -24,6 +24,7 @@ import Test.Wire.API.Golden.Manual.ClientCapabilityList
 import Test.Wire.API.Golden.Manual.Contact
 import Test.Wire.API.Golden.Manual.ConvIdsPage
 import Test.Wire.API.Golden.Manual.ConversationCoverView
+import Test.Wire.API.Golden.Manual.ConversationEvent
 import Test.Wire.API.Golden.Manual.ConversationPagingState
 import Test.Wire.API.Golden.Manual.ConversationsResponse
 import Test.Wire.API.Golden.Manual.CreateScimToken
@@ -66,6 +67,10 @@ tests =
           [ (testObject_ConversationCoverView_1, "testObject_ConversationCoverView_1.json"),
             (testObject_ConversationCoverView_2, "testObject_ConversationCoverView_2.json"),
             (testObject_ConversationCoverView_3, "testObject_ConversationCoverView_3.json")
+          ],
+      testGroup "ConversationEvent" $
+        testObjects
+          [ (testObject_Event_conversation_manual_1, "testObject_Event_conversation_manual_1.json")
           ],
       testGroup "GetPaginatedConversationIds" $
         testObjects

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationEvent.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationEvent.hs
@@ -1,0 +1,37 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Wire.API.Golden.Manual.ConversationEvent where
+
+import Data.Domain (Domain (..))
+import Data.Id
+import Data.Qualified (Qualified (..))
+import Data.Time
+import qualified Data.UUID as UUID
+import Imports
+import Wire.API.Event.Conversation
+import Wire.API.MLS.SubConversation
+
+testObject_Event_conversation_manual_1 :: Event
+testObject_Event_conversation_manual_1 =
+  Event
+    { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "oym59-06.i423w"}},
+      evtSubConv = Just (SubConvId "call"),
+      evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "n8nl6tp.h5"}},
+      evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
+      evtData = EdConvCodeDelete
+    }

--- a/libs/wire-api/test/golden/testObject_Event_conversation_manual_1.json
+++ b/libs/wire-api/test/golden/testObject_Event_conversation_manual_1.json
@@ -1,0 +1,16 @@
+{
+    "conversation": "2126ea99-ca79-43ea-ad99-a59616468e8e",
+    "data": null,
+    "from": "2126ea99-ca79-43ea-ad99-a59616468e8e",
+    "qualified_conversation": {
+        "domain": "oym59-06.i423w",
+        "id": "2126ea99-ca79-43ea-ad99-a59616468e8e"
+    },
+    "qualified_from": {
+        "domain": "n8nl6tp.h5",
+        "id": "2126ea99-ca79-43ea-ad99-a59616468e8e"
+    },
+    "subconv": "call",
+    "time": "2018-01-01T00:00:00.000Z",
+    "type": "conversation.code-delete"
+}

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -519,6 +519,7 @@ test-suite wire-api-golden-tests
     Test.Wire.API.Golden.Manual.ClientCapabilityList
     Test.Wire.API.Golden.Manual.Contact
     Test.Wire.API.Golden.Manual.ConversationCoverView
+    Test.Wire.API.Golden.Manual.ConversationEvent
     Test.Wire.API.Golden.Manual.ConversationPagingState
     Test.Wire.API.Golden.Manual.ConversationsResponse
     Test.Wire.API.Golden.Manual.ConvIdsPage

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -694,7 +694,7 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
   now <- input
   let lcnv = fmap convId lconv
       conv = tUnqualified lconv
-      e = conversationActionToEvent tag now quid (tUntagged lcnv) action
+      e = conversationActionToEvent tag now quid (tUntagged lcnv) Nothing action
 
   let mkUpdate uids =
         ConversationUpdate
@@ -758,7 +758,7 @@ notifyRemoteConversationAction loc rconvUpdate con = do
   let event =
         case cuAction convUpdate of
           SomeConversationAction tag action ->
-            conversationActionToEvent tag (cuTime convUpdate) (cuOrigUserId convUpdate) (tUntagged rconvId) action
+            conversationActionToEvent tag (cuTime convUpdate) (cuOrigUserId convUpdate) (tUntagged rconvId) Nothing action
 
   -- Note: we generally do not send notifications to users that are not part of
   -- the conversation (from our point of view), to prevent spam from the remote

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -443,7 +443,7 @@ createConnectConversation lusr conn j = do
     create lcnv nc = do
       c <- E.createConversation lcnv nc
       now <- input
-      let e = Event (tUntagged lcnv) (tUntagged lusr) now (EdConnect j)
+      let e = Event (tUntagged lcnv) Nothing (tUntagged lusr) now (EdConnect j)
       notifyCreatedConversation Nothing lusr conn c
       for_ (newPushLocal ListComplete (tUnqualified lusr) (ConvEvent e) (recipient <$> Data.convLocalMembers c)) $ \p ->
         E.push1 $
@@ -483,7 +483,7 @@ createConnectConversation lusr conn j = do
               pure . Just $ fromRange x
             Nothing -> pure $ Data.convName conv
           t <- input
-          let e = Event (tUntagged lcnv) (tUntagged lusr) t (EdConnect j)
+          let e = Event (tUntagged lcnv) Nothing (tUntagged lusr) t (EdConnect j)
           for_ (newPushLocal ListComplete (tUnqualified lusr) (ConvEvent e) (recipient <$> Data.convLocalMembers conv)) $ \p ->
             E.push1 $
               p
@@ -561,7 +561,7 @@ notifyCreatedConversation dtime lusr conn c = do
     toPush t m = do
       let lconv = qualifyAs lusr (Data.convId c)
       c' <- conversationView (qualifyAs lusr (lmId m)) c
-      let e = Event (tUntagged lconv) (tUntagged lusr) t (EdConversation c')
+      let e = Event (tUntagged lconv) Nothing (tUntagged lusr) t (EdConversation c')
       pure $
         newPushLocal1 ListComplete (tUnqualified lusr) (ConvEvent e) (list1 (recipient m) [])
           & pushConn .~ conn

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -189,6 +189,7 @@ onConversationCreated domain rc = do
     let event =
           Event
             (tUntagged (F.ccCnvId qrcConnected))
+            Nothing
             (tUntagged (F.ccRemoteOrigUserId qrcConnected))
             (F.ccTime qrcConnected)
             (EdConversation c)
@@ -296,7 +297,7 @@ onConversationUpdated requestingDomain cu = do
 
   -- Send notifications
   for_ mActualAction $ \(SomeConversationAction tag action) -> do
-    let event = conversationActionToEvent tag (F.cuTime cu) (F.cuOrigUserId cu) qconvId action
+    let event = conversationActionToEvent tag (F.cuTime cu) (F.cuOrigUserId cu) qconvId Nothing action
         targets = nubOrd $ presentUsers <> extraTargets
     -- FUTUREWORK: support bots?
     pushConversationEvent Nothing event (qualifyAs loc targets) []
@@ -781,7 +782,7 @@ onMLSMessageSent domain rmm =
       let recipients = filter (\(u, _) -> Set.member u members) (F.rmmRecipients rmm)
       -- FUTUREWORK: support local bots
       let e =
-            Event (tUntagged rcnv) (F.rmmSender rmm) (F.rmmTime rmm) $
+            Event (tUntagged rcnv) Nothing (F.rmmSender rmm) (F.rmmTime rmm) $
               EdMLSMessage (fromBase64ByteString (F.rmmMessage rmm))
       let mkPush :: (UserId, ClientId) -> MessagePush 'NormalMessage
           mkPush uc = newMessagePush loc mempty Nothing (F.rmmMetadata rmm) uc e

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -717,6 +717,7 @@ rmUser lusr conn = do
               let e =
                     Event
                       (tUntagged (qualifyAs lusr (Data.convId c)))
+                      Nothing
                       (tUntagged lusr)
                       now
                       (EdMembersLeave (QualifiedUserIdList [qUser]))

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -71,7 +71,7 @@ propagateMessage qusr lconv cm con raw = do
   now <- input @UTCTime
   let lcnv = fmap Data.convId lconv
       qcnv = tUntagged lcnv
-      e = Event qcnv qusr now $ EdMLSMessage raw
+      e = Event qcnv Nothing qusr now $ EdMLSMessage raw
       mkPush :: UserId -> ClientId -> MessagePush 'NormalMessage
       mkPush u c = newMessagePush lcnv botMap con mm (u, c) e
   runMessagePush lconv (Just qcnv) $

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -127,7 +127,7 @@ sendLocalWelcomes con now rawWelcome lclients = do
       -- FUTUREWORK: use the conversation ID stored in the key package mapping table
       let lcnv = qualifyAs lclients (selfConv u)
           lusr = qualifyAs lclients u
-          e = Event (tUntagged lcnv) (tUntagged lusr) now $ EdMLSWelcome rawWelcome
+          e = Event (tUntagged lcnv) Nothing (tUntagged lusr) now $ EdMLSWelcome rawWelcome
        in newMessagePush lclients mempty con defMessageMetadata (u, c) e
 
 sendRemoteWelcomes ::

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -606,7 +606,7 @@ newMessageEvent ::
   Event
 newMessageEvent mconvId sender senderClient dat time (receiver, receiverClient) cipherText =
   let convId = fromMaybe (tUntagged (fmap selfConv receiver)) mconvId
-   in Event convId sender time . EdOtrMessage $
+   in Event convId Nothing sender time . EdOtrMessage $
         OtrMessage
           { otrSender = senderClient,
             otrRecipient = receiverClient,

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -471,7 +471,7 @@ uncheckedDeleteTeam lusr zcon tid = do
       -- all team users are deleted immediately after these events are sent
       -- and will thus never be able to see these events in practice.
       let mm = nonTeamMembers convMembs teamMembs
-      let e = Conv.Event qconvId (tUntagged lusr) now Conv.EdConvDelete
+      let e = Conv.Event qconvId Nothing (tUntagged lusr) now Conv.EdConvDelete
       -- This event always contains all the required recipients
       let p = newPushLocal ListComplete (tUnqualified lusr) (ConvEvent e) (map recipient mm)
       let ee' = bots `zip` repeat e
@@ -1056,7 +1056,7 @@ uncheckedDeleteTeamMember lusr zcon tid remove mems = do
       let qconvId = tUntagged $ qualifyAs lusr (Data.convId dc)
       let (bots, users) = localBotsAndUsers (Data.convLocalMembers dc)
       let x = filter (\m -> not (Conv.lmId m `Set.member` exceptTo)) users
-      let y = Conv.Event qconvId (tUntagged lusr) now edata
+      let y = Conv.Event qconvId Nothing (tUntagged lusr) now edata
       for_ (newPushLocal (mems ^. teamMemberListType) (tUnqualified lusr) (ConvEvent y) (recipient <$> x)) $ \p ->
         E.push1 $ p & pushConn .~ zcon
       E.deliverAsync (bots `zip` repeat y)

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -323,7 +323,7 @@ memberJoinEvent ::
   [RemoteMember] ->
   Event
 memberJoinEvent lorig qconv t lmems rmems =
-  Event qconv (tUntagged lorig) t $
+  Event qconv Nothing (tUntagged lorig) t $
     EdMembersJoin (SimpleMembers (map localToSimple lmems <> map remoteToSimple rmems))
   where
     localToSimple u = SimpleMember (tUntagged (qualifyAs lorig (lmId u))) (lmConvRoleName u)
@@ -892,7 +892,7 @@ isTyping qusr mcon lcnv ts = do
   mm <- getLocalMembers (tUnqualified lcnv)
   unless (qUnqualified qusr `isMember` mm) $ throwS @'ConvNotFound
   now <- input
-  let e = Event (tUntagged lcnv) qusr now (EdTyping ts)
+  let e = Event (tUntagged lcnv) Nothing qusr now (EdTyping ts)
   for_ (newPushLocal ListComplete (qUnqualified qusr) (ConvEvent e) (recipient <$> mm)) $ \p ->
     push1 $
       p

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1862,7 +1862,7 @@ decodeConvCode = responseJsonUnsafe
 
 decodeConvCodeEvent :: Response (Maybe Lazy.ByteString) -> ConversationCode
 decodeConvCodeEvent r = case responseJsonUnsafe r of
-  (Event _ _ _ (EdConvCodeUpdate c)) -> c
+  (Event _ _ _ _ (EdConvCodeUpdate c)) -> c
   _ -> error "Failed to parse ConversationCode from Event"
 
 decodeConvId :: HasCallStack => Response (Maybe Lazy.ByteString) -> ConvId
@@ -2310,7 +2310,6 @@ assertMismatchQualified failedToSend missing redundant deleted = do
   assertExpected "failed to send" failedToSend (fmap mssFailedToSend . responseJsonMaybe)
   assertExpected "missing" missing (fmap mssMissingClients . responseJsonMaybe)
   assertExpected "redundant" redundant (fmap mssRedundantClients . responseJsonMaybe)
-
   assertExpected "deleted" deleted (fmap mssDeletedClients . responseJsonMaybe)
 
 otrRecipients :: [(UserId, ClientId, Text)] -> OtrRecipients


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
