### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,1 +1,1 @@
-Upgrade webapp version to 2022-11-30-production.0-v0.31.9-0-43726e9
+Upgrade webapp version to 2022-12-19-production.0-v0.31.9-0-6b2f2bf

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2022-11-30-production.0-v0.31.9-0-43726e9"
+  tag: "2022-12-19-production.0-v0.31.9-0-6b2f2bf"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2022-12-19-production.0-v0.31.9-0-6b2f2bf`
Release: [`2022-12-19-production.0`](https://github.com/wireapp/wire-webapp/releases/tag/2022-12-19-production.0)