### PR TITLE
FS-902: Fix empty client set & set subconv field in message propagation

### DIFF
--- a/changelog.d/5-internal/mls-subconv-messages
+++ b/changelog.d/5-internal/mls-subconv-messages
@@ -1,0 +1,1 @@
+Propagate messages in MLS subconversations

--- a/charts/redis-cluster/requirements.yaml
+++ b/charts/redis-cluster/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis-cluster
-  version: 7.4.8
+  version: 7.6.4
   repository: https://charts.bitnami.com/bitnami

--- a/libs/wire-api/src/Wire/API/Error/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Error/Galley.hs
@@ -87,6 +87,7 @@ data GalleyError
   | MLSMissingSenderClient
   | MLSUnexpectedSenderClient
   | MLSSubConvUnsupportedConvType
+  | MLSSubConvClientNotInParent
   | --
     NoBindingTeamMembers
   | NoBindingTeam
@@ -220,6 +221,8 @@ type instance MapError 'MLSMissingGroupInfo = 'StaticError 404 "mls-missing-grou
 type instance MapError 'MLSMissingSenderClient = 'StaticError 403 "mls-missing-sender-client" "The client has to refresh their access token and provide their client ID"
 
 type instance MapError 'MLSSubConvUnsupportedConvType = 'StaticError 403 "mls-subconv-unsupported-convtype" "MLS subconversations are only supported for regular conversations"
+
+type instance MapError 'MLSSubConvClientNotInParent = 'StaticError 403 "mls-subconv-join-parent-missing" "MLS client cannot join the subconversation because it is not member of the parent conversation"
 
 type instance MapError 'NoBindingTeamMembers = 'StaticError 403 "non-binding-team-members" "Both users must be members of the same binding team"
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
@@ -66,6 +66,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MLSGroupConversationMismatch
                :> CanThrow 'MLSMissingSenderClient
                :> CanThrow 'MissingLegalholdConsent
+               :> CanThrow 'MLSSubConvClientNotInParent
                :> CanThrow MLSProposalFailure
                :> "messages"
                :> ZOptClient
@@ -95,6 +96,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MLSGroupConversationMismatch
                :> CanThrow 'MLSMissingSenderClient
                :> CanThrow 'MissingLegalholdConsent
+               :> CanThrow 'MLSSubConvClientNotInParent
                :> CanThrow MLSProposalFailure
                :> "messages"
                :> ZOptClient
@@ -125,6 +127,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MLSMissingSenderClient
                :> CanThrow 'MLSWelcomeMismatch
                :> CanThrow 'MissingLegalholdConsent
+               :> CanThrow 'MLSSubConvClientNotInParent
                :> CanThrow MLSProposalFailure
                :> "commit-bundles"
                :> ZOptClient

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -2371,19 +2371,12 @@ testSendMessageSubConv = do
 
       let subname = "conference"
       void $ createSubConv qcnv bob1 subname
-
       let qcs = convsub qcnv (Just subname)
 
-      void $
-        createExternalCommit alice1 Nothing qcs
-          >>= sendAndConsumeCommitBundle
-
-      void $
-        createExternalCommit bob2 Nothing qcs
-          >>= sendAndConsumeCommitBundle
+      void $ createExternalCommit alice1 Nothing qcs >>= sendAndConsumeCommitBundle
+      void $ createExternalCommit bob2 Nothing qcs >>= sendAndConsumeCommitBundle
 
       message <- createApplicationMessage alice1 "some text"
-
       mlsBracket [bob1, bob2] $ \wss -> do
         events <- sendAndConsumeMessage message
         liftIO $ events @?= []

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -2370,7 +2370,7 @@ testSendMessageSubConv = do
       void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommit
 
       let subname = "conference"
-      void $ createSubConv qcnv bob1 subname
+      createSubConv qcnv bob1 subname
       let qcs = convsub qcnv (Just subname)
 
       void $ createExternalCommit alice1 Nothing qcs >>= sendAndConsumeCommitBundle

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -467,12 +467,8 @@ createSubConv qcnv creator name = do
       responseJsonError
         =<< getSubConv (ciUser creator) qcnv subId
           <!! const 200 === statusCode
-
   resetGroup creator (pscGroupId sub)
-
-  void $
-    createPendingProposalCommit creator >>= sendAndConsumeCommitBundle
-
+  void $ createPendingProposalCommit creator >>= sendAndConsumeCommitBundle
   pure sub
 
 -- | Create a local group only without a conversation. This simulates creating

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -459,7 +459,7 @@ resetGroup cid gid = do
         mlsNewMembers = mempty
       }
 
-createSubConv :: Qualified ConvId -> ClientIdentity -> Text -> MLSTest PublicSubConversation
+createSubConv :: Qualified ConvId -> ClientIdentity -> Text -> MLSTest ()
 createSubConv qcnv creator name = do
   let subId = SubConvId name
   sub <-
@@ -469,7 +469,6 @@ createSubConv qcnv creator name = do
           <!! const 200 === statusCode
   resetGroup creator (pscGroupId sub)
   void $ createPendingProposalCommit creator >>= sendAndConsumeCommitBundle
-  pure sub
 
 -- | Create a local group only without a conversation. This simulates creating
 -- an MLS conversation on a remote backend.


### PR DESCRIPTION
This PR:

- Fixes a bug: on the first commit the creator's client is not added to member clients of the subconversation
- MLS message are propagated with the `subconv` field populated

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
