### PR TITLE
Track federated calls

### DIFF
--- a/changelog.d/5-internal/federated-calls-brig
+++ b/changelog.d/5-internal/federated-calls-brig
@@ -1,0 +1,1 @@
+Added typeclasses to track uses of federated calls across the codebase.

--- a/changelog.d/5-internal/pr-2940
+++ b/changelog.d/5-internal/pr-2940
@@ -1,0 +1,1 @@
+Track federated calls in types across the codebase.

--- a/libs/wire-api-federation/src/Wire/API/Federation/API.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API.hs
@@ -53,6 +53,8 @@ type HasFedEndpoint comp api name = ('Just api ~ LookupEndpoint (FedApi comp) na
 
 class CallsFed (comp :: Component) (name :: Symbol)
 
+instance CallsFed comp name
+
 -- | Return a client for a named endpoint.
 fedClient ::
   forall (comp :: Component) (name :: Symbol) m api.

--- a/libs/wire-api-federation/src/Wire/API/Federation/API.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API.hs
@@ -20,6 +20,7 @@ module Wire.API.Federation.API
     HasFedEndpoint,
     fedClient,
     fedClientIn,
+    CallsFed,
 
     -- * Re-exports
     Component (..),
@@ -48,12 +49,14 @@ type instance FedApi 'Brig = BrigApi
 
 type instance FedApi 'Cargohold = CargoholdApi
 
-type HasFedEndpoint comp api name = ('Just api ~ LookupEndpoint (FedApi comp) name)
+type HasFedEndpoint comp api name = ('Just api ~ LookupEndpoint (FedApi comp) name, CallsFed comp name)
+
+class CallsFed (comp :: Component) (name :: Symbol)
 
 -- | Return a client for a named endpoint.
 fedClient ::
   forall (comp :: Component) (name :: Symbol) m api.
-  (HasFedEndpoint comp api name, HasClient m api, m ~ FederatorClient comp) =>
+  (CallsFed comp name, HasFedEndpoint comp api name, HasClient m api, m ~ FederatorClient comp) =>
   Client m api
 fedClient = clientIn (Proxy @api) (Proxy @m)
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/API.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API.hs
@@ -53,8 +53,6 @@ type HasFedEndpoint comp api name = ('Just api ~ LookupEndpoint (FedApi comp) na
 
 class CallsFed (comp :: Component) (name :: Symbol)
 
-instance CallsFed comp name
-
 -- | Return a client for a named endpoint.
 fedClient ::
   forall (comp :: Component) (name :: Symbol) m api.

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -32,21 +32,23 @@ import Brig.Effects.UserPendingActivationStore (UserPendingActivationStore)
 import qualified Data.Swagger.Build.Api as Doc
 import Network.Wai.Routing (Routes)
 import Polysemy
-import Wire.Sem.Concurrency
 import Wire.API.Federation.API
+import Wire.Sem.Concurrency
 
 sitemap ::
   forall r p.
-  (Members
-    '[ BlacklistPhonePrefixStore,
-       BlacklistStore,
-       GalleyProvider,
-       CodeStore,
-       Concurrency 'Unsafe,
-       PasswordResetStore,
-       UserPendingActivationStore p
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ BlacklistPhonePrefixStore,
+         BlacklistStore,
+         GalleyProvider,
+         CodeStore,
+         Concurrency 'Unsafe,
+         PasswordResetStore,
+         UserPendingActivationStore p
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   Routes Doc.ApiBuilder (Handler r) ()
 sitemap = do
   Public.sitemap

--- a/services/brig/src/Brig/API.hs
+++ b/services/brig/src/Brig/API.hs
@@ -33,10 +33,11 @@ import qualified Data.Swagger.Build.Api as Doc
 import Network.Wai.Routing (Routes)
 import Polysemy
 import Wire.Sem.Concurrency
+import Wire.API.Federation.API
 
 sitemap ::
   forall r p.
-  Members
+  (Members
     '[ BlacklistPhonePrefixStore,
        BlacklistStore,
        GalleyProvider,
@@ -45,7 +46,7 @@ sitemap ::
        PasswordResetStore,
        UserPendingActivationStore p
      ]
-    r =>
+    r, CallsFed 'Brig "on-user-deleted-connections") =>
   Routes Doc.ApiBuilder (Handler r) ()
 sitemap = do
   Public.sitemap

--- a/services/brig/src/Brig/API/Auth.hs
+++ b/services/brig/src/Brig/API/Auth.hs
@@ -43,12 +43,12 @@ import Network.HTTP.Types
 import Network.Wai.Utilities ((!>>))
 import qualified Network.Wai.Utilities.Error as Wai
 import Polysemy
+import Wire.API.Federation.API
 import Wire.API.User
 import Wire.API.User.Auth hiding (access)
 import Wire.API.User.Auth.LegalHold
 import Wire.API.User.Auth.ReAuth
 import Wire.API.User.Auth.Sso
-import Wire.API.Federation.API
 
 accessH ::
   CallsFed 'Brig "on-user-deleted-connections" =>

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -93,6 +93,7 @@ import Polysemy (Member, Members)
 import Servant (Link, ToHttpApiData (toUrlPiece))
 import System.Logger.Class (field, msg, val, (~~))
 import qualified System.Logger.Class as Log
+import Wire.API.Federation.API
 import Wire.API.Federation.API.Brig (GetUserClients (GetUserClients))
 import Wire.API.Federation.Error
 import Wire.API.MLS.Credential (ClientIdentity (..))
@@ -108,7 +109,6 @@ import Wire.API.UserMap (QualifiedUserMap (QualifiedUserMap, qualifiedUserMap), 
 import Wire.Sem.Concurrency
 import Wire.Sem.FromUTC (FromUTC (fromUTCTime))
 import Wire.Sem.Now as Now
-import Wire.API.Federation.API
 
 lookupLocalClient :: UserId -> ClientId -> (AppT r) (Maybe Client)
 lookupLocalClient uid = wrapClient . Data.lookupClient uid
@@ -266,7 +266,9 @@ claimLocalPrekey protectee user client = do
 claimRemotePrekey ::
   ( MonadReader Env m,
     Log.MonadLogger m,
-    MonadClient m, CallsFed 'Brig "claim-prekey") =>
+    MonadClient m,
+    CallsFed 'Brig "claim-prekey"
+  ) =>
   Qualified UserId ->
   ClientId ->
   ExceptT ClientError m (Maybe ClientPrekey)

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -61,6 +61,7 @@ import Wire.API.Conversation
 import Wire.API.Error
 import qualified Wire.API.Error.Brig as E
 import Wire.API.Routes.Public.Util (ResponseForExistedCreated (..))
+import Wire.API.Federation.API
 
 ensureIsActivated :: Local UserId -> MaybeT (AppT r) ()
 ensureIsActivated lusr = do
@@ -75,7 +76,7 @@ ensureNotSameTeam self target = do
     throwE ConnectSameBindingTeamUsers
 
 createConnection ::
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "send-connection-action") =>
   Local UserId ->
   ConnId ->
   Qualified UserId ->
@@ -210,6 +211,7 @@ checkLegalholdPolicyConflict uid1 uid2 = do
   oneway status2 status1
 
 updateConnection ::
+  CallsFed 'Brig "send-connection-action" =>
   Local UserId ->
   Qualified UserId ->
   Relation ->

--- a/services/brig/src/Brig/API/Connection.hs
+++ b/services/brig/src/Brig/API/Connection.hs
@@ -60,8 +60,8 @@ import Wire.API.Connection hiding (relationWithHistory)
 import Wire.API.Conversation
 import Wire.API.Error
 import qualified Wire.API.Error.Brig as E
-import Wire.API.Routes.Public.Util (ResponseForExistedCreated (..))
 import Wire.API.Federation.API
+import Wire.API.Routes.Public.Util (ResponseForExistedCreated (..))
 
 ensureIsActivated :: Local UserId -> MaybeT (AppT r) ()
 ensureIsActivated lusr = do

--- a/services/brig/src/Brig/API/Connection/Remote.hs
+++ b/services/brig/src/Brig/API/Connection/Remote.hs
@@ -39,12 +39,12 @@ import Galley.Types.Conversations.Intra (Actor (..), DesiredMembership (..), Ups
 import Imports
 import Network.Wai.Utilities.Error
 import Wire.API.Connection
+import Wire.API.Federation.API
 import Wire.API.Federation.API.Brig
   ( NewConnectionResponse (..),
     RemoteConnectionAction (..),
   )
 import Wire.API.Routes.Public.Util (ResponseForExistedCreated (..))
-import Wire.API.Federation.API
 
 data LocalConnectionAction
   = LocalConnect

--- a/services/brig/src/Brig/API/Connection/Remote.hs
+++ b/services/brig/src/Brig/API/Connection/Remote.hs
@@ -44,6 +44,7 @@ import Wire.API.Federation.API.Brig
     RemoteConnectionAction (..),
   )
 import Wire.API.Routes.Public.Util (ResponseForExistedCreated (..))
+import Wire.API.Federation.API
 
 data LocalConnectionAction
   = LocalConnect
@@ -187,6 +188,7 @@ pushEvent self mzcon connection = do
   Intra.onConnectionEvent (tUnqualified self) mzcon event
 
 performLocalAction ::
+  CallsFed 'Brig "send-connection-action" =>
   Local UserId ->
   Maybe ConnId ->
   Remote UserId ->
@@ -251,6 +253,7 @@ performRemoteAction self other mconnection action = do
     reaction _ = Nothing
 
 createConnectionToRemoteUser ::
+  CallsFed 'Brig "send-connection-action" =>
   Local UserId ->
   ConnId ->
   Remote UserId ->
@@ -260,6 +263,7 @@ createConnectionToRemoteUser self zcon other = do
   fst <$> performLocalAction self (Just zcon) other mconnection LocalConnect
 
 updateConnectionToRemoteUser ::
+  CallsFed 'Brig "send-connection-action" =>
   Local UserId ->
   Remote UserId ->
   Relation ->

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -87,6 +87,7 @@ import UnliftIO.Async
 import Wire.API.Connection
 import Wire.API.Error
 import qualified Wire.API.Error.Brig as E
+import Wire.API.Federation.API
 import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
 import Wire.API.MLS.Serialisation
@@ -100,18 +101,19 @@ import Wire.API.User.Activation
 import Wire.API.User.Client
 import Wire.API.User.Password
 import Wire.API.User.RichInfo
-import Wire.API.Federation.API
 
 ---------------------------------------------------------------------------
 -- Sitemap (servant)
 
 servantSitemap ::
-  (Members
-    '[ BlacklistStore,
-       GalleyProvider,
-       UserPendingActivationStore p
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ BlacklistStore,
+         GalleyProvider,
+         UserPendingActivationStore p
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   ServerT BrigIRoutes.API (Handler r)
 servantSitemap =
   ejpdAPI
@@ -151,12 +153,14 @@ mlsAPI =
     :<|> Named @"put-key-package-add" upsertKeyPackage
 
 accountAPI ::
-  (Members
-    '[ BlacklistStore,
-       GalleyProvider,
-       UserPendingActivationStore p
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ BlacklistStore,
+         GalleyProvider,
+         UserPendingActivationStore p
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   ServerT BrigIRoutes.AccountAPI (Handler r)
 accountAPI =
   Named @"createUserNoVerify" createUserNoVerify
@@ -285,15 +289,17 @@ swaggerDocsAPI = swaggerSchemaUIServer BrigIRoutes.swaggerDoc
 -- Sitemap (wai-route)
 
 sitemap ::
-  (Members
-    '[ CodeStore,
-       PasswordResetStore,
-       BlacklistStore,
-       BlacklistPhonePrefixStore,
-       GalleyProvider,
-       UserPendingActivationStore p
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ CodeStore,
+         PasswordResetStore,
+         BlacklistStore,
+         BlacklistPhonePrefixStore,
+         GalleyProvider,
+         UserPendingActivationStore p
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   Routes a (Handler r) ()
 sitemap = do
   get "/i/status" (continue $ const $ pure empty) true
@@ -457,10 +463,12 @@ sitemap = do
 
 -- | Add a client without authentication checks
 addClientInternalH ::
-  (Members
-    '[ GalleyProvider
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ GalleyProvider
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   UserId ::: Maybe Bool ::: JsonRequest NewClient ::: Maybe ConnId ::: JSON ->
   (Handler r) Response
 addClientInternalH (usr ::: mSkipReAuth ::: req ::: connId ::: _) = do
@@ -468,10 +476,12 @@ addClientInternalH (usr ::: mSkipReAuth ::: req ::: connId ::: _) = do
   setStatus status201 . json <$> addClientInternal usr mSkipReAuth new connId
 
 addClientInternal ::
-  (Members
-    '[ GalleyProvider
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ GalleyProvider
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   UserId ->
   Maybe Bool ->
   NewClient ->
@@ -512,12 +522,14 @@ internalListFullClients (UserSet usrs) =
   UserClientsFull <$> wrapClient (Data.lookupClientsBulk (Set.toList usrs))
 
 createUserNoVerify ::
-  (Members
-    '[ BlacklistStore,
-       GalleyProvider,
-       UserPendingActivationStore p
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ BlacklistStore,
+         GalleyProvider,
+         UserPendingActivationStore p
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   NewUser ->
   (Handler r) (Either RegisterError SelfProfile)
 createUserNoVerify uData = lift . runExceptT $ do
@@ -534,10 +546,12 @@ createUserNoVerify uData = lift . runExceptT $ do
   pure . SelfProfile $ usr
 
 createUserNoVerifySpar ::
-  (Members
-    '[ GalleyProvider
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ GalleyProvider
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   NewUserSpar ->
   (Handler r) (Either CreateUserSparError SelfProfile)
 createUserNoVerifySpar uData =

--- a/services/brig/src/Brig/API/MLS/KeyPackages.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages.hs
@@ -55,6 +55,7 @@ uploadKeyPackages lusr cid (kpuKeyPackages -> kps) = do
   lift . wrapClient $ Data.insertKeyPackages (tUnqualified lusr) cid kps'
 
 claimKeyPackages ::
+  CallsFed 'Brig "claim-key-packages" =>
   Local UserId ->
   Qualified UserId ->
   Maybe ClientId ->
@@ -96,6 +97,7 @@ claimLocalKeyPackages qusr skipOwn target = do
           <$> wrapClientM (Data.claimKeyPackage target c)
 
 claimRemoteKeyPackages ::
+  CallsFed 'Brig "claim-key-packages" =>
   Local UserId ->
   Remote UserId ->
   Handler r KeyPackageBundle

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -90,6 +90,7 @@ module Brig.API.User
   )
 where
 
+import Wire.API.Federation.API
 import Bilge.IO (MonadHttp)
 import Bilge.RPC (HasRequestId)
 import qualified Brig.API.Error as Error
@@ -227,10 +228,10 @@ verifyUniquenessAndCheckBlacklist uk = do
 
 createUserSpar ::
   forall r.
-  Members
+  (Members
     '[ GalleyProvider
      ]
-    r =>
+    r, CallsFed 'Brig "on-user-deleted-connections") =>
   NewUserSpar ->
   ExceptT CreateUserSparError (AppT r) CreateUserResult
 createUserSpar new = do
@@ -293,12 +294,12 @@ createUserSpar new = do
 -- docs/reference/user/registration.md {#RefRegistration}
 createUser ::
   forall r p.
-  Members
+  (Members
     '[ BlacklistStore,
        GalleyProvider,
        UserPendingActivationStore p
      ]
-    r =>
+    r, CallsFed 'Brig "on-user-deleted-connections") =>
   NewUser ->
   ExceptT RegisterError (AppT r) CreateUserResult
 createUser new = do
@@ -582,7 +583,7 @@ checkRestrictedUserCreation new = do
 -------------------------------------------------------------------------------
 -- Update Profile
 
-updateUser :: UserId -> Maybe ConnId -> UserUpdate -> AllowSCIMUpdates -> ExceptT UpdateProfileError (AppT r) ()
+updateUser :: CallsFed 'Brig "on-user-deleted-connections" => UserId -> Maybe ConnId -> UserUpdate -> AllowSCIMUpdates -> ExceptT UpdateProfileError (AppT r) ()
 updateUser uid mconn uu allowScim = do
   for_ (uupName uu) $ \newName -> do
     mbUser <- lift . wrapClient $ Data.lookupUser WithPendingInvitations uid
@@ -600,7 +601,7 @@ updateUser uid mconn uu allowScim = do
 -------------------------------------------------------------------------------
 -- Update Locale
 
-changeLocale :: UserId -> ConnId -> LocaleUpdate -> (AppT r) ()
+changeLocale :: CallsFed 'Brig "on-user-deleted-connections" => UserId -> ConnId -> LocaleUpdate -> (AppT r) ()
 changeLocale uid conn (LocaleUpdate loc) = do
   wrapClient $ Data.updateLocale uid loc
   wrapHttpClient $ Intra.onUserEvent uid (Just conn) (localeUpdate uid loc)
@@ -608,7 +609,7 @@ changeLocale uid conn (LocaleUpdate loc) = do
 -------------------------------------------------------------------------------
 -- Update ManagedBy
 
-changeManagedBy :: UserId -> ConnId -> ManagedByUpdate -> (AppT r) ()
+changeManagedBy :: CallsFed 'Brig "on-user-deleted-connections" => UserId -> ConnId -> ManagedByUpdate -> (AppT r) ()
 changeManagedBy uid conn (ManagedByUpdate mb) = do
   wrapClient $ Data.updateManagedBy uid mb
   wrapHttpClient $ Intra.onUserEvent uid (Just conn) (managedByUpdate uid mb)
@@ -616,7 +617,7 @@ changeManagedBy uid conn (ManagedByUpdate mb) = do
 --------------------------------------------------------------------------------
 -- Change Handle
 
-changeHandle :: UserId -> Maybe ConnId -> Handle -> AllowSCIMUpdates -> ExceptT ChangeHandleError (AppT r) ()
+changeHandle :: CallsFed 'Brig "on-user-deleted-connections" => UserId -> Maybe ConnId -> Handle -> AllowSCIMUpdates -> ExceptT ChangeHandleError (AppT r) ()
 changeHandle uid mconn hdl allowScim = do
   when (isBlacklistedHandle hdl) $
     throwE ChangeHandleInvalid
@@ -774,7 +775,7 @@ changePhone u phone = do
 -------------------------------------------------------------------------------
 -- Remove Email
 
-removeEmail :: UserId -> ConnId -> ExceptT RemoveIdentityError (AppT r) ()
+removeEmail :: CallsFed 'Brig "on-user-deleted-connections" => UserId -> ConnId -> ExceptT RemoveIdentityError (AppT r) ()
 removeEmail uid conn = do
   ident <- lift $ fetchUserIdentity uid
   case ident of
@@ -788,7 +789,7 @@ removeEmail uid conn = do
 -------------------------------------------------------------------------------
 -- Remove Phone
 
-removePhone :: UserId -> ConnId -> ExceptT RemoveIdentityError (AppT r) ()
+removePhone :: CallsFed 'Brig "on-user-deleted-connections" => UserId -> ConnId -> ExceptT RemoveIdentityError (AppT r) ()
 removePhone uid conn = do
   ident <- lift $ fetchUserIdentity uid
   case ident of
@@ -806,7 +807,7 @@ removePhone uid conn = do
 -------------------------------------------------------------------------------
 -- Forcefully revoke a verified identity
 
-revokeIdentity :: Either Email Phone -> AppT r ()
+revokeIdentity :: CallsFed 'Brig "on-user-deleted-connections" => Either Email Phone -> AppT r ()
 revokeIdentity key = do
   let uk = either userEmailKey userPhoneKey key
   mu <- wrapClient $ Data.lookupKey uk
@@ -850,8 +851,7 @@ changeAccountStatus ::
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
-    MonadUnliftIO m
-  ) =>
+    MonadUnliftIO m, CallsFed 'Brig "on-user-deleted-connections") =>
   List1 UserId ->
   AccountStatus ->
   ExceptT AccountStatusError m ()
@@ -876,8 +876,7 @@ changeSingleAccountStatus ::
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
-    MonadUnliftIO m
-  ) =>
+    MonadUnliftIO m, CallsFed 'Brig "on-user-deleted-connections") =>
   UserId ->
   AccountStatus ->
   ExceptT AccountStatusError m ()
@@ -901,7 +900,7 @@ mkUserEvent usrs status =
 -- Activation
 
 activate ::
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "on-user-deleted-connections") =>
   ActivationTarget ->
   ActivationCode ->
   -- | The user for whom to activate the key.
@@ -910,7 +909,7 @@ activate ::
 activate tgt code usr = activateWithCurrency tgt code usr Nothing
 
 activateWithCurrency ::
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "on-user-deleted-connections") =>
   ActivationTarget ->
   ActivationCode ->
   -- | The user for whom to activate the key.
@@ -941,7 +940,8 @@ activateWithCurrency tgt code usr cur = do
 
 preverify ::
   ( MonadClient m,
-    MonadReader Env m
+    MonadReader Env m,
+    CallsFed 'Brig "on-user-deleted-connections"
   ) =>
   ActivationTarget ->
   ActivationCode ->
@@ -950,7 +950,7 @@ preverify tgt code = do
   key <- mkActivationKey tgt
   void $ Data.verifyCode key code
 
-onActivated :: ActivationEvent -> (AppT r) (UserId, Maybe UserIdentity, Bool)
+onActivated :: CallsFed 'Brig "on-user-deleted-connections" => ActivationEvent -> (AppT r) (UserId, Maybe UserIdentity, Bool)
 onActivated (AccountActivated account) = do
   let uid = userId (accountUser account)
   Log.debug $ field "user" (toByteString uid) . field "action" (Log.val "User.onActivated")
@@ -1167,10 +1167,10 @@ mkPasswordResetKey ident = case ident of
 -- TODO: communicate deletions of SSO users to SSO service.
 deleteSelfUser ::
   forall r.
-  Members
+  (Members
     '[ GalleyProvider
      ]
-    r =>
+    r, CallsFed 'Brig "on-user-deleted-connections") =>
   UserId ->
   Maybe PlainTextPassword ->
   ExceptT DeleteUserError (AppT r) (Maybe Timeout)
@@ -1246,7 +1246,7 @@ deleteSelfUser uid pwd = do
 
 -- | Conclude validation and scheduling of user's deletion request that was initiated in
 -- 'deleteUser'.  Called via @post /delete@.
-verifyDeleteUser :: VerifyDeleteUser -> ExceptT DeleteUserError (AppT r) ()
+verifyDeleteUser :: CallsFed 'Brig "on-user-deleted-connections" => VerifyDeleteUser -> ExceptT DeleteUserError (AppT r) ()
 verifyDeleteUser d = do
   let key = verifyDeleteUserKey d
   let code = verifyDeleteUserCode d
@@ -1270,8 +1270,7 @@ ensureAccountDeleted ::
     HasRequestId m,
     MonadUnliftIO m,
     MonadClient m,
-    MonadReader Env m
-  ) =>
+    MonadReader Env m, CallsFed 'Brig "on-user-deleted-connections") =>
   UserId ->
   m DeleteUserResult
 ensureAccountDeleted uid = do
@@ -1315,8 +1314,7 @@ deleteAccount ::
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,
-    MonadClient m
-  ) =>
+    MonadClient m, CallsFed 'Brig "on-user-deleted-connections") =>
   UserAccount ->
   m ()
 deleteAccount account@(accountUser -> user) = do
@@ -1422,7 +1420,7 @@ userGC u = case userExpire u of
     pure u
 
 lookupProfile ::
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "get-users-by-ids") =>
   Local UserId ->
   Qualified UserId ->
   ExceptT FederationError (AppT r) (Maybe UserProfile)
@@ -1438,11 +1436,11 @@ lookupProfile self other =
 -- Otherwise only the 'PublicProfile' is accessible for user 'self'.
 -- If 'self' is an unknown 'UserId', return '[]'.
 lookupProfiles ::
-  Members
+  (Members
     '[ GalleyProvider,
        Concurrency 'Unsafe
      ]
-    r =>
+    r, CallsFed 'Brig "get-users-by-ids") =>
   -- | User 'self' on whose behalf the profiles are requested.
   Local UserId ->
   -- | The users ('others') for which to obtain the profiles.
@@ -1455,7 +1453,7 @@ lookupProfiles self others =
       (bucketQualified others)
 
 lookupProfilesFromDomain ::
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "get-users-by-ids") =>
   Local UserId ->
   Qualified [UserId] ->
   ExceptT FederationError (AppT r) [UserProfile]
@@ -1468,8 +1466,7 @@ lookupProfilesFromDomain self =
 lookupRemoteProfiles ::
   ( MonadIO m,
     MonadReader Env m,
-    MonadLogger m
-  ) =>
+    MonadLogger m, CallsFed 'Brig "get-users-by-ids") =>
   Remote [UserId] ->
   ExceptT FederationError m [UserProfile]
 lookupRemoteProfiles (tUntagged -> Qualified uids domain) =

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -90,7 +90,6 @@ module Brig.API.User
   )
 where
 
-import Wire.API.Federation.API
 import Bilge.IO (MonadHttp)
 import Bilge.RPC (HasRequestId)
 import qualified Brig.API.Error as Error
@@ -173,6 +172,7 @@ import UnliftIO.Async
 import Wire.API.Connection
 import Wire.API.Error
 import qualified Wire.API.Error.Brig as E
+import Wire.API.Federation.API
 import Wire.API.Federation.Error
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Team hiding (newTeam)
@@ -228,10 +228,12 @@ verifyUniquenessAndCheckBlacklist uk = do
 
 createUserSpar ::
   forall r.
-  (Members
-    '[ GalleyProvider
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ GalleyProvider
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   NewUserSpar ->
   ExceptT CreateUserSparError (AppT r) CreateUserResult
 createUserSpar new = do
@@ -294,12 +296,14 @@ createUserSpar new = do
 -- docs/reference/user/registration.md {#RefRegistration}
 createUser ::
   forall r p.
-  (Members
-    '[ BlacklistStore,
-       GalleyProvider,
-       UserPendingActivationStore p
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ BlacklistStore,
+         GalleyProvider,
+         UserPendingActivationStore p
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   NewUser ->
   ExceptT RegisterError (AppT r) CreateUserResult
 createUser new = do
@@ -851,7 +855,9 @@ changeAccountStatus ::
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
-    MonadUnliftIO m, CallsFed 'Brig "on-user-deleted-connections") =>
+    MonadUnliftIO m,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   List1 UserId ->
   AccountStatus ->
   ExceptT AccountStatusError m ()
@@ -876,7 +882,9 @@ changeSingleAccountStatus ::
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
-    MonadUnliftIO m, CallsFed 'Brig "on-user-deleted-connections") =>
+    MonadUnliftIO m,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   UserId ->
   AccountStatus ->
   ExceptT AccountStatusError m ()
@@ -1167,10 +1175,12 @@ mkPasswordResetKey ident = case ident of
 -- TODO: communicate deletions of SSO users to SSO service.
 deleteSelfUser ::
   forall r.
-  (Members
-    '[ GalleyProvider
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ GalleyProvider
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   UserId ->
   Maybe PlainTextPassword ->
   ExceptT DeleteUserError (AppT r) (Maybe Timeout)
@@ -1270,7 +1280,9 @@ ensureAccountDeleted ::
     HasRequestId m,
     MonadUnliftIO m,
     MonadClient m,
-    MonadReader Env m, CallsFed 'Brig "on-user-deleted-connections") =>
+    MonadReader Env m,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   UserId ->
   m DeleteUserResult
 ensureAccountDeleted uid = do
@@ -1314,7 +1326,9 @@ deleteAccount ::
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,
-    MonadClient m, CallsFed 'Brig "on-user-deleted-connections") =>
+    MonadClient m,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   UserAccount ->
   m ()
 deleteAccount account@(accountUser -> user) = do
@@ -1436,11 +1450,13 @@ lookupProfile self other =
 -- Otherwise only the 'PublicProfile' is accessible for user 'self'.
 -- If 'self' is an unknown 'UserId', return '[]'.
 lookupProfiles ::
-  (Members
-    '[ GalleyProvider,
-       Concurrency 'Unsafe
-     ]
-    r, CallsFed 'Brig "get-users-by-ids") =>
+  ( Members
+      '[ GalleyProvider,
+         Concurrency 'Unsafe
+       ]
+      r,
+    CallsFed 'Brig "get-users-by-ids"
+  ) =>
   -- | User 'self' on whose behalf the profiles are requested.
   Local UserId ->
   -- | The users ('others') for which to obtain the profiles.
@@ -1466,7 +1482,9 @@ lookupProfilesFromDomain self =
 lookupRemoteProfiles ::
   ( MonadIO m,
     MonadReader Env m,
-    MonadLogger m, CallsFed 'Brig "get-users-by-ids") =>
+    MonadLogger m,
+    CallsFed 'Brig "get-users-by-ids"
+  ) =>
   Remote [UserId] ->
   ExceptT FederationError m [UserProfile]
 lookupRemoteProfiles (tUntagged -> Qualified uids domain) =

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -47,6 +47,7 @@ import Wire.API.UserMap
 getUserHandleInfo ::
   ( MonadReader Env m,
     MonadIO m,
+    CallsFed 'Brig "get-user-by-handle",
     Log.MonadLogger m
   ) =>
   Remote Handle ->
@@ -58,6 +59,7 @@ getUserHandleInfo (tUntagged -> Qualified handle domain) = do
 getUsersByIds ::
   ( MonadReader Env m,
     MonadIO m,
+    CallsFed 'Brig "get-users-by-ids",
     Log.MonadLogger m
   ) =>
   Domain ->
@@ -68,7 +70,7 @@ getUsersByIds domain uids = do
   runBrigFederatorClient domain $ fedClient @'Brig @"get-users-by-ids" uids
 
 claimPrekey ::
-  (MonadReader Env m, MonadIO m, Log.MonadLogger m) =>
+  (MonadReader Env m, MonadIO m, Log.MonadLogger m, CallsFed 'Brig "claim-prekey") =>
   Qualified UserId ->
   ClientId ->
   ExceptT FederationError m (Maybe ClientPrekey)
@@ -79,6 +81,7 @@ claimPrekey (Qualified user domain) client = do
 claimPrekeyBundle ::
   ( MonadReader Env m,
     MonadIO m,
+    CallsFed 'Brig "claim-prekey-bundle",
     Log.MonadLogger m
   ) =>
   Qualified UserId ->
@@ -90,7 +93,8 @@ claimPrekeyBundle (Qualified user domain) = do
 claimMultiPrekeyBundle ::
   ( Log.MonadLogger m,
     MonadReader Env m,
-    MonadIO m
+    MonadIO m,
+    CallsFed 'Brig "claim-multi-prekey-bundle"
   ) =>
   Domain ->
   UserClients ->
@@ -102,7 +106,8 @@ claimMultiPrekeyBundle domain uc = do
 searchUsers ::
   ( MonadReader Env m,
     MonadIO m,
-    Log.MonadLogger m
+    Log.MonadLogger m,
+    CallsFed 'Brig "search-users"
   ) =>
   Domain ->
   SearchRequest ->
@@ -114,7 +119,8 @@ searchUsers domain searchTerm = do
 getUserClients ::
   ( MonadReader Env m,
     MonadIO m,
-    Log.MonadLogger m
+    Log.MonadLogger m,
+    CallsFed 'Brig "get-user-clients"
   ) =>
   Domain ->
   GetUserClients ->
@@ -124,7 +130,7 @@ getUserClients domain guc = do
   runBrigFederatorClient domain $ fedClient @'Brig @"get-user-clients" guc
 
 sendConnectionAction ::
-  (MonadReader Env m, MonadIO m, Log.MonadLogger m) =>
+  (MonadReader Env m, MonadIO m, Log.MonadLogger m, CallsFed 'Brig "send-connection-action") =>
   Local UserId ->
   Remote UserId ->
   RemoteConnectionAction ->

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -47,6 +47,7 @@ module Brig.IO.Intra
   )
 where
 
+import Wire.API.Federation.API
 import Bilge hiding (head, options, requestId)
 import Bilge.RPC
 import Bilge.Retry
@@ -117,7 +118,8 @@ onUserEvent ::
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,
-    MonadClient m
+    MonadClient m,
+    CallsFed 'Brig "on-user-deleted-connections"
   ) =>
   UserId ->
   Maybe ConnId ->
@@ -249,7 +251,8 @@ dispatchNotifications ::
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,
-    MonadClient m
+    MonadClient m,
+    CallsFed 'Brig "on-user-deleted-connections"
   ) =>
   UserId ->
   Maybe ConnId ->
@@ -285,6 +288,7 @@ notifyUserDeletionLocals ::
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,
+    CallsFed 'Brig "on-user-deleted-connections",
     MonadClient m
   ) =>
   UserId ->
@@ -299,7 +303,8 @@ notifyUserDeletionRemotes ::
   forall m.
   ( MonadReader Env m,
     MonadClient m,
-    MonadLogger m
+    MonadLogger m,
+    CallsFed 'Brig "on-user-deleted-connections"
   ) =>
   UserId ->
   m ()

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -47,7 +47,6 @@ module Brig.IO.Intra
   )
 where
 
-import Wire.API.Federation.API
 import Bilge hiding (head, options, requestId)
 import Bilge.RPC
 import Bilge.Retry
@@ -99,6 +98,7 @@ import qualified System.Logger.Extended as ExLog
 import Wire.API.Connection
 import Wire.API.Conversation
 import Wire.API.Event.Conversation (Connect (Connect))
+import Wire.API.Federation.API
 import Wire.API.Federation.API.Brig
 import Wire.API.Federation.Error
 import Wire.API.Properties

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -53,7 +53,9 @@ onEvent ::
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,
-    MonadClient m, CallsFed 'Brig "on-user-deleted-connections") =>
+    MonadClient m,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   InternalNotification ->
   m ()
 onEvent n = handleTimeout $ case n of

--- a/services/brig/src/Brig/InternalEvent/Process.hs
+++ b/services/brig/src/Brig/InternalEvent/Process.hs
@@ -39,6 +39,7 @@ import Imports
 import System.Logger.Class (field, msg, val, (~~))
 import qualified System.Logger.Class as Log
 import UnliftIO (timeout)
+import Wire.API.Federation.API
 
 -- | Handle an internal event.
 --
@@ -52,8 +53,7 @@ onEvent ::
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,
-    MonadClient m
-  ) =>
+    MonadClient m, CallsFed 'Brig "on-user-deleted-connections") =>
   InternalNotification ->
   m ()
 onEvent n = handleTimeout $ case n of

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -74,12 +74,12 @@ import qualified Servant
 import System.Logger (msg, val, (.=), (~~))
 import System.Logger.Class (MonadLogger, err)
 import Util.Options
+import Wire.API.Federation.API
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Brig
 import Wire.API.Routes.Version
 import Wire.API.Routes.Version.Wai
 import qualified Wire.Sem.Paging as P
-import Wire.API.Federation.API
 
 -- | Orphan instance to satisfy 'CallsFeds' constraints, which we otherwise use
 -- to track federation calls across the codebase.

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -83,7 +83,7 @@ import qualified Wire.Sem.Paging as P
 
 -- | Orphan instance to satisfy 'CallsFeds' constraints, which we otherwise use
 -- to track federation calls across the codebase.
-instance CallsFed comp name
+instance {-# OVERLAPPING #-} CallsFed 'Brig name
 
 -- FUTUREWORK: If any of these async threads die, we will have no clue about it
 -- and brig could start misbehaving. We should ensure that brig dies whenever a

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NumericUnderscores #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- This file is part of the Wire Server implementation.
 --
@@ -78,6 +79,11 @@ import Wire.API.Routes.Public.Brig
 import Wire.API.Routes.Version
 import Wire.API.Routes.Version.Wai
 import qualified Wire.Sem.Paging as P
+import Wire.API.Federation.API
+
+-- | Orphan instance to satisfy 'CallsFeds' constraints, which we otherwise use
+-- to track federation calls across the codebase.
+instance CallsFed comp name
 
 -- FUTUREWORK: If any of these async threads die, we will have no clue about it
 -- and brig could start misbehaving. We should ensure that brig dies whenever a
@@ -114,7 +120,7 @@ run o = do
     endpoint = brig o
     server e = defaultServer (unpack $ endpoint ^. epHost) (endpoint ^. epPort) (e ^. applog) (e ^. metrics)
 
-mkApp :: Opts -> IO (Wai.Application, Env)
+mkApp :: (HasCallStack) => Opts -> IO (Wai.Application, Env)
 mkApp o = do
   e <- newEnv o
   pure (middleware e $ \reqId -> servantApp (e & requestId .~ reqId), e)

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -120,7 +120,7 @@ run o = do
     endpoint = brig o
     server e = defaultServer (unpack $ endpoint ^. epHost) (endpoint ^. epPort) (e ^. applog) (e ^. metrics)
 
-mkApp :: (HasCallStack) => Opts -> IO (Wai.Application, Env)
+mkApp :: Opts -> IO (Wai.Application, Env)
 mkApp o = do
   e <- newEnv o
   pure (middleware e $ \reqId -> servantApp (e & requestId .~ reqId), e)

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -83,7 +83,7 @@ import qualified Wire.Sem.Paging as P
 
 -- | Orphan instance to satisfy 'CallsFeds' constraints, which we otherwise use
 -- to track federation calls across the codebase.
-instance {-# OVERLAPPING #-} CallsFed 'Brig name
+instance {-# OVERLAPPING #-} CallsFed comp name
 
 -- FUTUREWORK: If any of these async threads die, we will have no clue about it
 -- and brig could start misbehaving. We should ensure that brig dies whenever a

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -67,6 +67,7 @@ import qualified System.Logger.Class as Log
 import Util.Logging (logFunction, logTeam)
 import Wire.API.Error
 import qualified Wire.API.Error.Brig as E
+import Wire.API.Federation.API
 import Wire.API.Routes.Named
 import Wire.API.Routes.Public.Brig
 import Wire.API.Team
@@ -79,7 +80,6 @@ import Wire.API.Team.Role
 import qualified Wire.API.Team.Role as Public
 import Wire.API.User hiding (fromEmail)
 import qualified Wire.API.User as Public
-import Wire.API.Federation.API
 
 servantAPI ::
   Members
@@ -98,12 +98,14 @@ servantAPI =
     :<|> Named @"get-team-size" teamSizePublic
 
 routesInternal ::
-  (Members
-    '[ BlacklistStore,
-       GalleyProvider,
-       UserPendingActivationStore p
-     ]
-    r, CallsFed 'Brig "on-user-deleted-connections") =>
+  ( Members
+      '[ BlacklistStore,
+         GalleyProvider,
+         UserPendingActivationStore p
+       ]
+      r,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   Routes a (Handler r) ()
 routesInternal = do
   get "/i/teams/invitations/by-email" (continue getInvitationByEmailH) $

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -79,6 +79,7 @@ import Wire.API.Team.Role
 import qualified Wire.API.Team.Role as Public
 import Wire.API.User hiding (fromEmail)
 import qualified Wire.API.User as Public
+import Wire.API.Federation.API
 
 servantAPI ::
   Members
@@ -97,12 +98,12 @@ servantAPI =
     :<|> Named @"get-team-size" teamSizePublic
 
 routesInternal ::
-  Members
+  (Members
     '[ BlacklistStore,
        GalleyProvider,
        UserPendingActivationStore p
      ]
-    r =>
+    r, CallsFed 'Brig "on-user-deleted-connections") =>
   Routes a (Handler r) ()
 routesInternal = do
   get "/i/teams/invitations/by-email" (continue getInvitationByEmailH) $
@@ -377,25 +378,25 @@ getInvitationByEmail email = do
   inv <- lift $ wrapClient $ DB.lookupInvitationByEmail HideInvitationUrl email
   maybe (throwStd (notFound "Invitation not found")) pure inv
 
-suspendTeamH :: Members '[GalleyProvider] r => JSON ::: TeamId -> (Handler r) Response
+suspendTeamH :: (Members '[GalleyProvider] r, CallsFed 'Brig "on-user-deleted-connections") => JSON ::: TeamId -> (Handler r) Response
 suspendTeamH (_ ::: tid) = do
   empty <$ suspendTeam tid
 
-suspendTeam :: Members '[GalleyProvider] r => TeamId -> (Handler r) ()
+suspendTeam :: (Members '[GalleyProvider] r, CallsFed 'Brig "on-user-deleted-connections") => TeamId -> (Handler r) ()
 suspendTeam tid = do
   changeTeamAccountStatuses tid Suspended
   lift $ wrapClient $ DB.deleteInvitations tid
   lift $ liftSem $ GalleyProvider.changeTeamStatus tid Team.Suspended Nothing
 
 unsuspendTeamH ::
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "on-user-deleted-connections") =>
   JSON ::: TeamId ->
   (Handler r) Response
 unsuspendTeamH (_ ::: tid) = do
   empty <$ unsuspendTeam tid
 
 unsuspendTeam ::
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "on-user-deleted-connections") =>
   TeamId ->
   (Handler r) ()
 unsuspendTeam tid = do
@@ -406,7 +407,7 @@ unsuspendTeam tid = do
 -- Internal
 
 changeTeamAccountStatuses ::
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "on-user-deleted-connections") =>
   TeamId ->
   AccountStatus ->
   (Handler r) ()

--- a/services/brig/src/Brig/User/API/Handle.hs
+++ b/services/brig/src/Brig/User/API/Handle.hs
@@ -39,11 +39,11 @@ import Imports
 import Network.Wai.Utilities ((!>>))
 import Polysemy
 import qualified System.Logger.Class as Log
+import Wire.API.Federation.API
 import Wire.API.User
 import qualified Wire.API.User as Public
 import Wire.API.User.Search
 import qualified Wire.API.User.Search as Public
-import Wire.API.Federation.API
 
 getHandleInfo ::
   (Members '[GalleyProvider] r, CallsFed 'Brig "get-user-by-handle", CallsFed 'Brig "get-users-by-ids") =>

--- a/services/brig/src/Brig/User/API/Handle.hs
+++ b/services/brig/src/Brig/User/API/Handle.hs
@@ -43,9 +43,10 @@ import Wire.API.User
 import qualified Wire.API.User as Public
 import Wire.API.User.Search
 import qualified Wire.API.User.Search as Public
+import Wire.API.Federation.API
 
 getHandleInfo ::
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "get-user-by-handle", CallsFed 'Brig "get-users-by-ids") =>
   UserId ->
   Qualified Handle ->
   (Handler r) (Maybe Public.UserProfile)
@@ -57,7 +58,7 @@ getHandleInfo self handle = do
     getRemoteHandleInfo
     handle
 
-getRemoteHandleInfo :: Remote Handle -> (Handler r) (Maybe Public.UserProfile)
+getRemoteHandleInfo :: CallsFed 'Brig "get-user-by-handle" => Remote Handle -> (Handler r) (Maybe Public.UserProfile)
 getRemoteHandleInfo handle = do
   lift . Log.info $
     Log.msg (Log.val "getHandleInfo - remote lookup")
@@ -65,7 +66,7 @@ getRemoteHandleInfo handle = do
   Federation.getUserHandleInfo handle !>> fedError
 
 getLocalHandleInfo ::
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "get-users-by-ids") =>
   Local UserId ->
   Handle ->
   (Handler r) (Maybe Public.UserProfile)

--- a/services/brig/src/Brig/User/API/Search.hs
+++ b/services/brig/src/Brig/User/API/Search.hs
@@ -50,13 +50,13 @@ import Polysemy
 import System.Logger (field, msg)
 import System.Logger.Class (val, (~~))
 import qualified System.Logger.Class as Log
+import Wire.API.Federation.API
 import qualified Wire.API.Federation.API.Brig as FedBrig
 import qualified Wire.API.Federation.API.Brig as S
 import qualified Wire.API.Team.Permission as Public
 import Wire.API.Team.SearchVisibility (TeamSearchVisibility (..))
 import Wire.API.User.Search
 import qualified Wire.API.User.Search as Public
-import Wire.API.Federation.API
 
 routesInternal :: Routes a (Handler r) ()
 routesInternal = do

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -78,13 +78,13 @@ import Network.Wai.Utilities.Error ((!>>))
 import Polysemy
 import System.Logger (field, msg, val, (~~))
 import qualified System.Logger.Class as Log
+import Wire.API.Federation.API
 import Wire.API.Team.Feature
 import qualified Wire.API.Team.Feature as Public
 import Wire.API.User
 import Wire.API.User.Auth
 import Wire.API.User.Auth.LegalHold
 import Wire.API.User.Auth.Sso
-import Wire.API.Federation.API
 
 sendLoginCode ::
   ( MonadClient m,
@@ -252,7 +252,9 @@ renewAccess ::
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
-    MonadUnliftIO m, CallsFed 'Brig "on-user-deleted-connections") =>
+    MonadUnliftIO m,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   List1 (ZAuth.Token u) ->
   Maybe (ZAuth.Token a) ->
   Maybe ClientId ->
@@ -289,7 +291,9 @@ catchSuspendInactiveUser ::
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,
-    Log.MonadLogger m, CallsFed 'Brig "on-user-deleted-connections") =>
+    Log.MonadLogger m,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   UserId ->
   e ->
   ExceptT e m ()
@@ -320,7 +324,9 @@ newAccess ::
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
-    MonadUnliftIO m, CallsFed 'Brig "on-user-deleted-connections") =>
+    MonadUnliftIO m,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   UserId ->
   Maybe ClientId ->
   CookieType ->
@@ -440,7 +446,9 @@ ssoLogin ::
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
-    MonadUnliftIO m, CallsFed 'Brig "on-user-deleted-connections") =>
+    MonadUnliftIO m,
+    CallsFed 'Brig "on-user-deleted-connections"
+  ) =>
   SsoLogin ->
   CookieType ->
   ExceptT LoginError m (Access ZAuth.User)

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -84,6 +84,7 @@ import Wire.API.User
 import Wire.API.User.Auth
 import Wire.API.User.Auth.LegalHold
 import Wire.API.User.Auth.Sso
+import Wire.API.Federation.API
 
 sendLoginCode ::
   ( MonadClient m,
@@ -134,7 +135,7 @@ lookupLoginCode phone =
 
 login ::
   forall r.
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "on-user-deleted-connections") =>
   Login ->
   CookieType ->
   ExceptT LoginError (AppT r) (Access ZAuth.User)
@@ -251,8 +252,7 @@ renewAccess ::
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
-    MonadUnliftIO m
-  ) =>
+    MonadUnliftIO m, CallsFed 'Brig "on-user-deleted-connections") =>
   List1 (ZAuth.Token u) ->
   Maybe (ZAuth.Token a) ->
   Maybe ClientId ->
@@ -289,8 +289,7 @@ catchSuspendInactiveUser ::
     MonadHttp m,
     HasRequestId m,
     MonadUnliftIO m,
-    Log.MonadLogger m
-  ) =>
+    Log.MonadLogger m, CallsFed 'Brig "on-user-deleted-connections") =>
   UserId ->
   e ->
   ExceptT e m ()
@@ -321,8 +320,7 @@ newAccess ::
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
-    MonadUnliftIO m
-  ) =>
+    MonadUnliftIO m, CallsFed 'Brig "on-user-deleted-connections") =>
   UserId ->
   Maybe ClientId ->
   CookieType ->
@@ -442,8 +440,7 @@ ssoLogin ::
     MonadMask m,
     MonadHttp m,
     HasRequestId m,
-    MonadUnliftIO m
-  ) =>
+    MonadUnliftIO m, CallsFed 'Brig "on-user-deleted-connections") =>
   SsoLogin ->
   CookieType ->
   ExceptT LoginError m (Access ZAuth.User)
@@ -463,7 +460,7 @@ ssoLogin (SsoLogin uid label) typ = do
 
 -- | Log in as a LegalHold service, getting LegalHoldUser/Access Tokens.
 legalHoldLogin ::
-  Members '[GalleyProvider] r =>
+  (Members '[GalleyProvider] r, CallsFed 'Brig "on-user-deleted-connections") =>
   LegalHoldLogin ->
   CookieType ->
   ExceptT LegalHoldLoginError (AppT r) (Access ZAuth.LegalHoldUser)

--- a/services/cargohold/src/CargoHold/API/Public.hs
+++ b/services/cargohold/src/CargoHold/API/Public.hs
@@ -38,8 +38,9 @@ import Wire.API.Asset
 import Wire.API.Routes.AssetBody
 import Wire.API.Routes.Internal.Cargohold
 import Wire.API.Routes.Public.Cargohold
+import Wire.API.Federation.API
 
-servantSitemap :: ServerT ServantAPI Handler
+servantSitemap :: (CallsFed 'Cargohold "get-asset", CallsFed 'Cargohold "stream-asset") => ServerT ServantAPI Handler
 servantSitemap =
   renewTokenV3
     :<|> deleteTokenV3
@@ -147,6 +148,7 @@ downloadAssetV3 usr key tok1 tok2 = do
   AssetLocation <$$> V3.download (mkPrincipal usr) key (tok1 <|> tok2)
 
 downloadAssetV4 ::
+  (CallsFed 'Cargohold "get-asset", CallsFed 'Cargohold "stream-asset") =>
   Local UserId ->
   Qualified AssetKey ->
   Maybe AssetToken ->

--- a/services/cargohold/src/CargoHold/API/Public.hs
+++ b/services/cargohold/src/CargoHold/API/Public.hs
@@ -35,10 +35,10 @@ import Servant.API
 import Servant.Server hiding (Handler)
 import URI.ByteString
 import Wire.API.Asset
+import Wire.API.Federation.API
 import Wire.API.Routes.AssetBody
 import Wire.API.Routes.Internal.Cargohold
 import Wire.API.Routes.Public.Cargohold
-import Wire.API.Federation.API
 
 servantSitemap :: (CallsFed 'Cargohold "get-asset", CallsFed 'Cargohold "stream-asset") => ServerT ServantAPI Handler
 servantSitemap =

--- a/services/cargohold/src/CargoHold/Federation.hs
+++ b/services/cargohold/src/CargoHold/Federation.hs
@@ -48,6 +48,7 @@ import Wire.API.Federation.Error
 -- is streamed back through our outward federator, as well as the remote one.
 
 downloadRemoteAsset ::
+  (CallsFed 'Cargohold "get-asset", CallsFed 'Cargohold "stream-asset") =>
   Local UserId ->
   Remote AssetKey ->
   Maybe AssetToken ->

--- a/services/cargohold/src/CargoHold/Run.hs
+++ b/services/cargohold/src/CargoHold/Run.hs
@@ -51,11 +51,11 @@ import Servant.API
 import Servant.Server hiding (Handler, runHandler)
 import qualified UnliftIO.Async as Async
 import Util.Options
+import Wire.API.Federation.API
 import Wire.API.Routes.API
 import Wire.API.Routes.Internal.Cargohold
 import Wire.API.Routes.Public.Cargohold
 import Wire.API.Routes.Version.Wai
-import Wire.API.Federation.API
 
 type CombinedAPI = FederationAPI :<|> ServantAPI :<|> InternalAPI
 

--- a/services/cargohold/src/CargoHold/Run.hs
+++ b/services/cargohold/src/CargoHold/Run.hs
@@ -15,6 +15,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 {-# LANGUAGE NumericUnderscores #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module CargoHold.Run
   ( run,
@@ -54,8 +55,11 @@ import Wire.API.Routes.API
 import Wire.API.Routes.Internal.Cargohold
 import Wire.API.Routes.Public.Cargohold
 import Wire.API.Routes.Version.Wai
+import Wire.API.Federation.API
 
 type CombinedAPI = FederationAPI :<|> ServantAPI :<|> InternalAPI
+
+instance CallsFed comp name
 
 run :: Opts -> IO ()
 run o = lowerCodensity $ do

--- a/services/federator/test/unit/Test/Federator/Client.hs
+++ b/services/federator/test/unit/Test/Federator/Client.hs
@@ -14,6 +14,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Federator.Client (tests) where
 
@@ -49,6 +50,8 @@ import Wire.API.Federation.Client
 import Wire.API.Federation.Component
 import Wire.API.Federation.Error
 import Wire.API.User (UserProfile)
+
+instance CallsFed comp name
 
 targetDomain :: Domain
 targetDomain = Domain "target.example.com"

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -86,7 +86,7 @@ import Wire.API.Conversation.Role
 import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Event.Conversation
-import Wire.API.Federation.API (Component (Galley), fedClient, CallsFed)
+import Wire.API.Federation.API (CallsFed, Component (Galley), fedClient)
 import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error
 import Wire.API.Team.LegalHold
@@ -276,8 +276,11 @@ ensureAllowed tag loc action conv origUser = do
 -- and also returns the (possible modified) action that was performed
 performAction ::
   forall tag r.
-  (HasConversationActionEffects tag r, CallsFed 'Galley "on-mls-message-sent",
-  CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( HasConversationActionEffects tag r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Sing tag ->
   Qualified UserId ->
   Local Conversation ->
@@ -345,8 +348,11 @@ performAction tag origUser lconv action = do
       pure (bm, act)
 
 performConversationJoin ::
-  (HasConversationActionEffects 'ConversationJoinTag r,
-    CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( HasConversationActionEffects 'ConversationJoinTag r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Qualified UserId ->
   Local Conversation ->
   ConversationJoin ->
@@ -472,8 +478,11 @@ performConversationJoin qusr lconv (ConversationJoin invited role) = do
     checkLHPolicyConflictsRemote _remotes = pure ()
 
 performConversationAccessData ::
-  (HasConversationActionEffects 'ConversationAccessDataTag r,
-  CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( HasConversationActionEffects 'ConversationAccessDataTag r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Qualified UserId ->
   Local Conversation ->
   ConversationAccessData ->
@@ -571,7 +580,11 @@ updateLocalConversation ::
        ]
       r,
     HasConversationActionEffects tag r,
-    SingI tag, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "on-conversation-updated") =>
+    SingI tag,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-conversation-updated"
+  ) =>
   Local ConvId ->
   Qualified UserId ->
   Maybe ConnId ->
@@ -607,7 +620,11 @@ updateLocalConversationUnchecked ::
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
-    HasConversationActionEffects tag r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "on-conversation-updated") =>
+    HasConversationActionEffects tag r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-conversation-updated"
+  ) =>
   Local Conversation ->
   Qualified UserId ->
   Maybe ConnId ->
@@ -682,8 +699,10 @@ addMembersToLocalConversation lcnv users role = do
 
 notifyConversationAction ::
   forall tag r.
-  (Members '[FederatorAccess, ExternalAccess, GundeckAccess, Input UTCTime] r,
-  CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "on-conversation-updated") =>
+  ( Members '[FederatorAccess, ExternalAccess, GundeckAccess, Input UTCTime] r,
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-conversation-updated"
+  ) =>
   Sing tag ->
   Qualified UserId ->
   Bool ->
@@ -799,7 +818,11 @@ kickMember ::
     Member (Input UTCTime) r,
     Member (Input Env) r,
     Member MemberStore r,
-    Member TinyLog r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
+    Member TinyLog r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Qualified UserId ->
   Local Conversation ->
   BotsAndMembers ->

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -86,7 +86,7 @@ import Wire.API.Conversation.Role
 import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Event.Conversation
-import Wire.API.Federation.API (Component (Galley), fedClient)
+import Wire.API.Federation.API (Component (Galley), fedClient, CallsFed)
 import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error
 import Wire.API.Team.LegalHold
@@ -276,7 +276,8 @@ ensureAllowed tag loc action conv origUser = do
 -- and also returns the (possible modified) action that was performed
 performAction ::
   forall tag r.
-  (HasConversationActionEffects tag r) =>
+  (HasConversationActionEffects tag r, CallsFed 'Galley "on-mls-message-sent",
+  CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
   Sing tag ->
   Qualified UserId ->
   Local Conversation ->
@@ -344,7 +345,8 @@ performAction tag origUser lconv action = do
       pure (bm, act)
 
 performConversationJoin ::
-  (HasConversationActionEffects 'ConversationJoinTag r) =>
+  (HasConversationActionEffects 'ConversationJoinTag r,
+    CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
   Qualified UserId ->
   Local Conversation ->
   ConversationJoin ->
@@ -470,7 +472,8 @@ performConversationJoin qusr lconv (ConversationJoin invited role) = do
     checkLHPolicyConflictsRemote _remotes = pure ()
 
 performConversationAccessData ::
-  (HasConversationActionEffects 'ConversationAccessDataTag r) =>
+  (HasConversationActionEffects 'ConversationAccessDataTag r,
+  CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
   Qualified UserId ->
   Local Conversation ->
   ConversationAccessData ->
@@ -568,8 +571,7 @@ updateLocalConversation ::
        ]
       r,
     HasConversationActionEffects tag r,
-    SingI tag
-  ) =>
+    SingI tag, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "on-conversation-updated") =>
   Local ConvId ->
   Qualified UserId ->
   Maybe ConnId ->
@@ -605,8 +607,7 @@ updateLocalConversationUnchecked ::
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
-    HasConversationActionEffects tag r
-  ) =>
+    HasConversationActionEffects tag r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "on-conversation-updated") =>
   Local Conversation ->
   Qualified UserId ->
   Maybe ConnId ->
@@ -681,7 +682,8 @@ addMembersToLocalConversation lcnv users role = do
 
 notifyConversationAction ::
   forall tag r.
-  Members '[FederatorAccess, ExternalAccess, GundeckAccess, Input UTCTime] r =>
+  (Members '[FederatorAccess, ExternalAccess, GundeckAccess, Input UTCTime] r,
+  CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "on-conversation-updated") =>
   Sing tag ->
   Qualified UserId ->
   Bool ->
@@ -797,8 +799,7 @@ kickMember ::
     Member (Input UTCTime) r,
     Member (Input Env) r,
     Member MemberStore r,
-    Member TinyLog r
-  ) =>
+    Member TinyLog r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
   Qualified UserId ->
   Local Conversation ->
   BotsAndMembers ->

--- a/services/galley/src/Galley/API/Clients.hs
+++ b/services/galley/src/Galley/API/Clients.hs
@@ -104,7 +104,10 @@ rmClientH ::
          ProposalStore,
          P.TinyLog
        ]
-      r, CallsFed 'Galley "on-client-removed", CallsFed 'Galley "on-mls-message-sent") =>
+      r,
+    CallsFed 'Galley "on-client-removed",
+    CallsFed 'Galley "on-mls-message-sent"
+  ) =>
   UserId ::: ClientId ->
   Sem r Response
 rmClientH (usr ::: cid) = do

--- a/services/galley/src/Galley/API/Clients.hs
+++ b/services/galley/src/Galley/API/Clients.hs
@@ -104,8 +104,7 @@ rmClientH ::
          ProposalStore,
          P.TinyLog
        ]
-      r
-  ) =>
+      r, CallsFed 'Galley "on-client-removed", CallsFed 'Galley "on-mls-message-sent") =>
   UserId ::: ClientId ->
   Sem r Response
 rmClientH (usr ::: cid) = do

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -71,6 +71,7 @@ import Wire.API.Conversation.Protocol
 import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Event.Conversation
+import Wire.API.Federation.API
 import Wire.API.Federation.Error
 import Wire.API.Routes.Public.Galley.Conversation
 import Wire.API.Routes.Public.Util
@@ -78,36 +79,37 @@ import Wire.API.Team
 import Wire.API.Team.LegalHold (LegalholdProtectee (LegalholdPlusFederationNotImplemented))
 import Wire.API.Team.Member
 import Wire.API.Team.Permission hiding (self)
-import Wire.API.Federation.API
 
 ----------------------------------------------------------------------------
 -- Group conversations
 
 -- | The public-facing endpoint for creating group conversations.
 createGroupConversation ::
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       MemberStore,
-       ErrorS 'ConvAccessDenied,
-       Error InternalError,
-       Error InvalidInput,
-       ErrorS 'NotATeamMember,
-       ErrorS OperationDenied,
-       ErrorS 'NotConnected,
-       ErrorS 'MLSNotEnabled,
-       ErrorS 'MLSNonEmptyMemberList,
-       ErrorS 'MissingLegalholdConsent,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input Opts,
-       Input UTCTime,
-       LegalHoldStore,
-       TeamStore,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-created") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         MemberStore,
+         ErrorS 'ConvAccessDenied,
+         Error InternalError,
+         Error InvalidInput,
+         ErrorS 'NotATeamMember,
+         ErrorS OperationDenied,
+         ErrorS 'NotConnected,
+         ErrorS 'MLSNotEnabled,
+         ErrorS 'MLSNonEmptyMemberList,
+         ErrorS 'MissingLegalholdConsent,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input Opts,
+         Input UTCTime,
+         LegalHoldStore,
+         TeamStore,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-created"
+  ) =>
   Local UserId ->
   ConnId ->
   NewConv ->
@@ -219,29 +221,31 @@ createProteusSelfConversation lusr = do
 
 createOne2OneConversation ::
   forall r.
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       ErrorS 'ConvAccessDenied,
-       Error FederationError,
-       Error InternalError,
-       Error InvalidInput,
-       ErrorS 'ConvAccessDenied,
-       ErrorS 'NotATeamMember,
-       ErrorS 'NonBindingTeam,
-       ErrorS 'NoBindingTeamMembers,
-       ErrorS OperationDenied,
-       ErrorS 'TeamNotFound,
-       ErrorS 'InvalidOperation,
-       ErrorS 'NotConnected,
-       ErrorS 'MissingLegalholdConsent,
-       FederatorAccess,
-       GundeckAccess,
-       Input UTCTime,
-       TeamStore,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-created") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         ErrorS 'ConvAccessDenied,
+         Error FederationError,
+         Error InternalError,
+         Error InvalidInput,
+         ErrorS 'ConvAccessDenied,
+         ErrorS 'NotATeamMember,
+         ErrorS 'NonBindingTeam,
+         ErrorS 'NoBindingTeamMembers,
+         ErrorS OperationDenied,
+         ErrorS 'TeamNotFound,
+         ErrorS 'InvalidOperation,
+         ErrorS 'NotConnected,
+         ErrorS 'MissingLegalholdConsent,
+         FederatorAccess,
+         GundeckAccess,
+         Input UTCTime,
+         TeamStore,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-created"
+  ) =>
   Local UserId ->
   ConnId ->
   NewConv ->
@@ -286,16 +290,18 @@ createOne2OneConversation lusr zcon j = do
         Nothing -> throwS @'TeamNotFound
 
 createLegacyOne2OneConversationUnchecked ::
-  (Members
-    '[ ConversationStore,
-       Error InternalError,
-       Error InvalidInput,
-       FederatorAccess,
-       GundeckAccess,
-       Input UTCTime,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-created") =>
+  ( Members
+      '[ ConversationStore,
+         Error InternalError,
+         Error InvalidInput,
+         FederatorAccess,
+         GundeckAccess,
+         Input UTCTime,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-created"
+  ) =>
   Local UserId ->
   ConnId ->
   Maybe (Range 1 256 Text) ->
@@ -325,17 +331,19 @@ createLegacyOne2OneConversationUnchecked self zcon name mtid other = do
       conversationCreated self c
 
 createOne2OneConversationUnchecked ::
-  (Members
-    '[ ConversationStore,
-       Error FederationError,
-       Error InternalError,
-       ErrorS 'MissingLegalholdConsent,
-       FederatorAccess,
-       GundeckAccess,
-       Input UTCTime,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-created") =>
+  ( Members
+      '[ ConversationStore,
+         Error FederationError,
+         Error InternalError,
+         ErrorS 'MissingLegalholdConsent,
+         FederatorAccess,
+         GundeckAccess,
+         Input UTCTime,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-created"
+  ) =>
   Local UserId ->
   ConnId ->
   Maybe (Range 1 256 Text) ->
@@ -351,16 +359,18 @@ createOne2OneConversationUnchecked self zcon name mtid other = do
   create (one2OneConvId (tUntagged self) other) self zcon name mtid other
 
 createOne2OneConversationLocally ::
-  (Members
-    '[ ConversationStore,
-       Error InternalError,
-       ErrorS 'MissingLegalholdConsent,
-       FederatorAccess,
-       GundeckAccess,
-       Input UTCTime,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-created") =>
+  ( Members
+      '[ ConversationStore,
+         Error InternalError,
+         ErrorS 'MissingLegalholdConsent,
+         FederatorAccess,
+         GundeckAccess,
+         Input UTCTime,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-created"
+  ) =>
   Local ConvId ->
   Local UserId ->
   ConnId ->
@@ -402,21 +412,23 @@ createOne2OneConversationRemotely _ _ _ _ _ _ =
   throw FederationNotImplemented
 
 createConnectConversation ::
-  (Members
-    '[ ConversationStore,
-       ErrorS 'ConvNotFound,
-       Error FederationError,
-       Error InternalError,
-       Error InvalidInput,
-       ErrorS 'InvalidOperation,
-       ErrorS 'NotConnected,
-       FederatorAccess,
-       GundeckAccess,
-       Input UTCTime,
-       MemberStore,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-created") =>
+  ( Members
+      '[ ConversationStore,
+         ErrorS 'ConvNotFound,
+         Error FederationError,
+         Error InternalError,
+         Error InvalidInput,
+         ErrorS 'InvalidOperation,
+         ErrorS 'NotConnected,
+         FederatorAccess,
+         GundeckAccess,
+         Input UTCTime,
+         MemberStore,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-created"
+  ) =>
   Local UserId ->
   Maybe ConnId ->
   Connect ->
@@ -539,8 +551,9 @@ conversationCreated ::
 conversationCreated lusr cnv = Created <$> conversationView lusr cnv
 
 notifyCreatedConversation ::
-  (Members '[Error InternalError, FederatorAccess, GundeckAccess, Input UTCTime, P.TinyLog] r,
-  CallsFed 'Galley "on-conversation-created") =>
+  ( Members '[Error InternalError, FederatorAccess, GundeckAccess, Input UTCTime, P.TinyLog] r,
+    CallsFed 'Galley "on-conversation-created"
+  ) =>
   Maybe UTCTime ->
   Local UserId ->
   Maybe ConnId ->

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -100,8 +100,18 @@ import Wire.API.ServantProto
 type FederationAPI = "federation" :> FedApi 'Galley
 
 -- | Convert a polysemy handler to an 'API' value.
-federationSitemap :: (CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-mls-message-sent", CallsFed 'Brig "get-mls-clients", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "send-mls-message", CallsFed 'Galley "mls-welcome", CallsFed 'Galley "send-mls-commit-bundle", CallsFed 'Galley "on-message-sent", CallsFed 'Brig "get-user-clients") => ServerT FederationAPI (Sem GalleyEffects)
+federationSitemap ::
+  ( CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Brig "get-mls-clients",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "send-mls-message",
+    CallsFed 'Galley "mls-welcome",
+    CallsFed 'Galley "send-mls-commit-bundle",
+    CallsFed 'Galley "on-message-sent",
+    CallsFed 'Brig "get-user-clients"
+  ) =>
+  ServerT FederationAPI (Sem GalleyEffects)
 federationSitemap =
   Named @"on-conversation-created" onConversationCreated
     :<|> Named @"on-new-remote-conversation" onNewRemoteConversation
@@ -134,7 +144,8 @@ onClientRemoved ::
          ProposalStore,
          TinyLog
        ]
-      r, CallsFed 'Galley "on-mls-message-sent"
+      r,
+    CallsFed 'Galley "on-mls-message-sent"
   ) =>
   Domain ->
   ClientRemovedRequest ->
@@ -331,21 +342,25 @@ addLocalUsersToRemoteConv remoteConvId qAdder localUsers = do
 
 -- as of now this will not generate the necessary events on the leaver's domain
 leaveConversation ::
-  (Members
-    '[ ConversationStore,
-       Error InternalError,
-       Error InvalidInput,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input (Local ()),
-       Input UTCTime,
-       MemberStore,
-       ProposalStore,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         Error InternalError,
+         Error InvalidInput,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input (Local ()),
+         Input UTCTime,
+         MemberStore,
+         ProposalStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Domain ->
   F.LeaveConversationRequest ->
   Sem r F.LeaveConversationResponse
@@ -434,22 +449,25 @@ onMessageSent domain rmUnqualified = do
       (Map.filterWithKey (\(uid, _) _ -> Set.member uid members) msgs)
 
 sendMessage ::
-  (Members
-    '[ BrigAccess,
-       ClientStore,
-       ConversationStore,
-       Error InvalidInput,
-       FederatorAccess,
-       GundeckAccess,
-       Input (Local ()),
-       Input Opts,
-       Input UTCTime,
-       ExternalAccess,
-       MemberStore,
-       TeamStore,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "on-message-sent", CallsFed 'Brig "get-user-clients") =>
+  ( Members
+      '[ BrigAccess,
+         ClientStore,
+         ConversationStore,
+         Error InvalidInput,
+         FederatorAccess,
+         GundeckAccess,
+         Input (Local ()),
+         Input Opts,
+         Input UTCTime,
+         ExternalAccess,
+         MemberStore,
+         TeamStore,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-message-sent",
+    CallsFed 'Brig "get-user-clients"
+  ) =>
   Domain ->
   F.ProteusMessageSendRequest ->
   Sem r F.MessageSendResponse
@@ -462,21 +480,25 @@ sendMessage originDomain msr = do
     throwErr = throw . InvalidPayload . LT.pack
 
 onUserDeleted ::
-  (Members
-    '[ ConversationStore,
-       FederatorAccess,
-       FireAndForget,
-       ExternalAccess,
-       GundeckAccess,
-       Error InternalError,
-       Input (Local ()),
-       Input UTCTime,
-       Input Env,
-       MemberStore,
-       ProposalStore,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         FederatorAccess,
+         FireAndForget,
+         ExternalAccess,
+         GundeckAccess,
+         Error InternalError,
+         Input (Local ()),
+         Input UTCTime,
+         Input Env,
+         MemberStore,
+         ProposalStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Domain ->
   F.UserDeletedConversationsNotification ->
   Sem r EmptyResponse
@@ -539,7 +561,11 @@ updateConversation ::
          ConversationStore,
          Input (Local ())
        ]
-      r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Domain ->
   F.ConversationUpdateRequest ->
   Sem r ConversationUpdateResponse
@@ -620,7 +646,14 @@ sendMLSCommitBundle ::
         P.TinyLog,
         ProposalStore
       ]
-      r, CallsFed 'Galley "mls-welcome", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "send-mls-commit-bundle", CallsFed 'Brig "get-mls-clients") =>
+      r,
+    CallsFed 'Galley "mls-welcome",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "send-mls-commit-bundle",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Domain ->
   F.MLSMessageSendRequest ->
   Sem r F.MLSMessageResponse
@@ -663,7 +696,13 @@ sendMLSMessage ::
         P.TinyLog,
         ProposalStore
       ]
-      r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "send-mls-message", CallsFed 'Brig "get-mls-clients") =>
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "send-mls-message",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Domain ->
   F.MLSMessageSendRequest ->
   Sem r F.MLSMessageResponse

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -14,7 +14,6 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
-
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Galley.API.Internal

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -15,6 +15,8 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Galley.API.Internal
   ( internalSitemap,
     internalAPI,
@@ -111,6 +113,8 @@ import Wire.API.Team.Member
 import Wire.API.Team.SearchVisibility
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
+
+instance CallsFed comp name
 
 type LegalHoldFeatureStatusChangeErrors =
   '( 'ActionDenied 'RemoveConversationMember,

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -83,6 +83,7 @@ import Wire.API.Team.Member
 import Wire.API.User.Client.Prekey
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
+import Wire.API.Federation.API
 
 assertLegalHoldEnabledForTeam ::
   forall db r.
@@ -184,7 +185,7 @@ getSettings lzusr tid = do
 
 removeSettingsInternalPaging ::
   forall db r.
-  Members
+  (Members
     '[ BotAccess,
        BrigAccess,
        CodeStore,
@@ -217,7 +218,7 @@ removeSettingsInternalPaging ::
        TeamStore,
        WaiRoutes
      ]
-    r =>
+    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   Local UserId ->
   TeamId ->
@@ -261,8 +262,7 @@ removeSettings ::
          TeamMemberStore p,
          TeamStore
        ]
-      r
-  ) =>
+      r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   UserId ->
   TeamId ->
@@ -320,8 +320,7 @@ removeSettings' ::
          ProposalStore,
          P.TinyLog
        ]
-      r
-  ) =>
+      r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
   TeamId ->
   Sem r ()
 removeSettings' tid =
@@ -388,7 +387,7 @@ getUserStatus _lzusr tid uid = do
 -- @withdrawExplicitConsentH@ (lots of corner cases we'd have to implement for that to pan
 -- out).
 grantConsent ::
-  Members
+  (Members
     '[ BrigAccess,
        ConversationStore,
        Error InternalError,
@@ -409,7 +408,7 @@ grantConsent ::
        P.TinyLog,
        TeamStore
      ]
-    r =>
+    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
   Local UserId ->
   TeamId ->
   Sem r GrantConsentResult
@@ -427,7 +426,7 @@ grantConsent lusr tid = do
 -- | Request to provision a device on the legal hold service for a user
 requestDevice ::
   forall db r.
-  Members
+  (Members
     '[ BrigAccess,
        ConversationStore,
        Error InternalError,
@@ -456,7 +455,7 @@ requestDevice ::
        TeamFeatureStore db,
        TeamStore
      ]
-    r =>
+    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   Local UserId ->
   TeamId ->
@@ -507,7 +506,7 @@ requestDevice lzusr tid uid = do
 -- since they are replaced if needed when registering new LH devices.
 approveDevice ::
   forall db r.
-  Members
+  (Members
     '[ BrigAccess,
        ConversationStore,
        Error AuthenticationError,
@@ -536,7 +535,7 @@ approveDevice ::
        TeamFeatureStore db,
        TeamStore
      ]
-    r =>
+    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   Local UserId ->
   ConnId ->
@@ -588,7 +587,7 @@ approveDevice lzusr connId tid uid (Public.ApproveLegalHoldForUserRequest mPassw
 
 disableForUser ::
   forall r.
-  Members
+  (Members
     '[ BrigAccess,
        ConversationStore,
        Error AuthenticationError,
@@ -612,7 +611,7 @@ disableForUser ::
        P.TinyLog,
        TeamStore
      ]
-    r =>
+    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
   Local UserId ->
   TeamId ->
   UserId ->
@@ -646,7 +645,7 @@ disableForUser lzusr tid uid (Public.DisableLegalHoldForUserRequest mPassword) =
 -- or disabled, make sure the affected connections are screened for policy conflict (anybody
 -- with no-consent), and put those connections in the appropriate blocked state.
 changeLegalholdStatus ::
-  Members
+  (Members
     '[ BrigAccess,
        ConversationStore,
        Error InternalError,
@@ -665,7 +664,7 @@ changeLegalholdStatus ::
        ProposalStore,
        P.TinyLog
      ]
-    r =>
+    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
   TeamId ->
   Local UserId ->
   UserLegalHoldStatus ->
@@ -766,7 +765,7 @@ unsetTeamLegalholdWhitelistedH tid = do
 -- contains the hypothetical new LH status of `uid`'s so it can be consulted instead of the
 -- one from the database.
 handleGroupConvPolicyConflicts ::
-  Members
+  (Members
     '[ ConversationStore,
        Error InternalError,
        ErrorS ('ActionDenied 'RemoveConversationMember),
@@ -781,7 +780,7 @@ handleGroupConvPolicyConflicts ::
        P.TinyLog,
        TeamStore
      ]
-    r =>
+    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
   Local UserId ->
   UserLegalHoldStatus ->
   Sem r ()

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -72,6 +72,7 @@ import Wire.API.Conversation (ConvType (..))
 import Wire.API.Conversation.Role
 import Wire.API.Error
 import Wire.API.Error.Galley
+import Wire.API.Federation.API
 import Wire.API.Provider.Service
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Routes.Public.Galley.LegalHold
@@ -83,7 +84,6 @@ import Wire.API.Team.Member
 import Wire.API.User.Client.Prekey
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
-import Wire.API.Federation.API
 
 assertLegalHoldEnabledForTeam ::
   forall db r.
@@ -185,40 +185,44 @@ getSettings lzusr tid = do
 
 removeSettingsInternalPaging ::
   forall db r.
-  (Members
-    '[ BotAccess,
-       BrigAccess,
-       CodeStore,
-       ConversationStore,
-       Error AuthenticationError,
-       Error InternalError,
-       ErrorS ('ActionDenied 'RemoveConversationMember),
-       ErrorS 'InvalidOperation,
-       ErrorS 'LegalHoldCouldNotBlockConnections,
-       ErrorS 'LegalHoldDisableUnimplemented,
-       ErrorS 'LegalHoldNotEnabled,
-       ErrorS 'LegalHoldServiceNotRegistered,
-       ErrorS 'NotATeamMember,
-       ErrorS OperationDenied,
-       ErrorS 'UserLegalHoldIllegalOperation,
-       ExternalAccess,
-       FederatorAccess,
-       FireAndForget,
-       GundeckAccess,
-       Input Env,
-       Input (Local ()),
-       Input UTCTime,
-       LegalHoldStore,
-       ListItems LegacyPaging ConvId,
-       MemberStore,
-       ProposalStore,
-       P.TinyLog,
-       TeamFeatureStore db,
-       TeamMemberStore InternalPaging,
-       TeamStore,
-       WaiRoutes
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ BotAccess,
+         BrigAccess,
+         CodeStore,
+         ConversationStore,
+         Error AuthenticationError,
+         Error InternalError,
+         ErrorS ('ActionDenied 'RemoveConversationMember),
+         ErrorS 'InvalidOperation,
+         ErrorS 'LegalHoldCouldNotBlockConnections,
+         ErrorS 'LegalHoldDisableUnimplemented,
+         ErrorS 'LegalHoldNotEnabled,
+         ErrorS 'LegalHoldServiceNotRegistered,
+         ErrorS 'NotATeamMember,
+         ErrorS OperationDenied,
+         ErrorS 'UserLegalHoldIllegalOperation,
+         ExternalAccess,
+         FederatorAccess,
+         FireAndForget,
+         GundeckAccess,
+         Input Env,
+         Input (Local ()),
+         Input UTCTime,
+         LegalHoldStore,
+         ListItems LegacyPaging ConvId,
+         MemberStore,
+         ProposalStore,
+         P.TinyLog,
+         TeamFeatureStore db,
+         TeamMemberStore InternalPaging,
+         TeamStore,
+         WaiRoutes
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   Local UserId ->
   TeamId ->
@@ -262,7 +266,11 @@ removeSettings ::
          TeamMemberStore p,
          TeamStore
        ]
-      r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   UserId ->
   TeamId ->
@@ -320,7 +328,11 @@ removeSettings' ::
          ProposalStore,
          P.TinyLog
        ]
-      r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   TeamId ->
   Sem r ()
 removeSettings' tid =
@@ -387,28 +399,32 @@ getUserStatus _lzusr tid uid = do
 -- @withdrawExplicitConsentH@ (lots of corner cases we'd have to implement for that to pan
 -- out).
 grantConsent ::
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       Error InternalError,
-       ErrorS ('ActionDenied 'RemoveConversationMember),
-       ErrorS 'InvalidOperation,
-       ErrorS 'LegalHoldCouldNotBlockConnections,
-       ErrorS 'TeamMemberNotFound,
-       ErrorS 'UserLegalHoldIllegalOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       LegalHoldStore,
-       ListItems LegacyPaging ConvId,
-       MemberStore,
-       ProposalStore,
-       P.TinyLog,
-       TeamStore
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         Error InternalError,
+         ErrorS ('ActionDenied 'RemoveConversationMember),
+         ErrorS 'InvalidOperation,
+         ErrorS 'LegalHoldCouldNotBlockConnections,
+         ErrorS 'TeamMemberNotFound,
+         ErrorS 'UserLegalHoldIllegalOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         LegalHoldStore,
+         ListItems LegacyPaging ConvId,
+         MemberStore,
+         ProposalStore,
+         P.TinyLog,
+         TeamStore
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   TeamId ->
   Sem r GrantConsentResult
@@ -426,36 +442,40 @@ grantConsent lusr tid = do
 -- | Request to provision a device on the legal hold service for a user
 requestDevice ::
   forall db r.
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       Error InternalError,
-       ErrorS ('ActionDenied 'RemoveConversationMember),
-       ErrorS 'LegalHoldCouldNotBlockConnections,
-       ErrorS 'LegalHoldNotEnabled,
-       ErrorS 'LegalHoldServiceBadResponse,
-       ErrorS 'LegalHoldServiceNotRegistered,
-       ErrorS 'NotATeamMember,
-       ErrorS 'NoUserLegalHoldConsent,
-       ErrorS OperationDenied,
-       ErrorS 'TeamMemberNotFound,
-       ErrorS 'UserLegalHoldAlreadyEnabled,
-       ErrorS 'UserLegalHoldIllegalOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input (Local ()),
-       Input Env,
-       Input UTCTime,
-       LegalHoldStore,
-       ListItems LegacyPaging ConvId,
-       MemberStore,
-       ProposalStore,
-       P.TinyLog,
-       TeamFeatureStore db,
-       TeamStore
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         Error InternalError,
+         ErrorS ('ActionDenied 'RemoveConversationMember),
+         ErrorS 'LegalHoldCouldNotBlockConnections,
+         ErrorS 'LegalHoldNotEnabled,
+         ErrorS 'LegalHoldServiceBadResponse,
+         ErrorS 'LegalHoldServiceNotRegistered,
+         ErrorS 'NotATeamMember,
+         ErrorS 'NoUserLegalHoldConsent,
+         ErrorS OperationDenied,
+         ErrorS 'TeamMemberNotFound,
+         ErrorS 'UserLegalHoldAlreadyEnabled,
+         ErrorS 'UserLegalHoldIllegalOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input (Local ()),
+         Input Env,
+         Input UTCTime,
+         LegalHoldStore,
+         ListItems LegacyPaging ConvId,
+         MemberStore,
+         ProposalStore,
+         P.TinyLog,
+         TeamFeatureStore db,
+         TeamStore
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   Local UserId ->
   TeamId ->
@@ -506,36 +526,40 @@ requestDevice lzusr tid uid = do
 -- since they are replaced if needed when registering new LH devices.
 approveDevice ::
   forall db r.
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       Error AuthenticationError,
-       Error InternalError,
-       ErrorS 'AccessDenied,
-       ErrorS ('ActionDenied 'RemoveConversationMember),
-       ErrorS 'LegalHoldCouldNotBlockConnections,
-       ErrorS 'LegalHoldNotEnabled,
-       ErrorS 'LegalHoldServiceNotRegistered,
-       ErrorS 'NoLegalHoldDeviceAllocated,
-       ErrorS 'NotATeamMember,
-       ErrorS 'UserLegalHoldAlreadyEnabled,
-       ErrorS 'UserLegalHoldIllegalOperation,
-       ErrorS 'UserLegalHoldNotPending,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input (Local ()),
-       Input Env,
-       Input UTCTime,
-       LegalHoldStore,
-       ListItems LegacyPaging ConvId,
-       MemberStore,
-       ProposalStore,
-       P.TinyLog,
-       TeamFeatureStore db,
-       TeamStore
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         Error AuthenticationError,
+         Error InternalError,
+         ErrorS 'AccessDenied,
+         ErrorS ('ActionDenied 'RemoveConversationMember),
+         ErrorS 'LegalHoldCouldNotBlockConnections,
+         ErrorS 'LegalHoldNotEnabled,
+         ErrorS 'LegalHoldServiceNotRegistered,
+         ErrorS 'NoLegalHoldDeviceAllocated,
+         ErrorS 'NotATeamMember,
+         ErrorS 'UserLegalHoldAlreadyEnabled,
+         ErrorS 'UserLegalHoldIllegalOperation,
+         ErrorS 'UserLegalHoldNotPending,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input (Local ()),
+         Input Env,
+         Input UTCTime,
+         LegalHoldStore,
+         ListItems LegacyPaging ConvId,
+         MemberStore,
+         ProposalStore,
+         P.TinyLog,
+         TeamFeatureStore db,
+         TeamStore
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   Local UserId ->
   ConnId ->
@@ -587,31 +611,35 @@ approveDevice lzusr connId tid uid (Public.ApproveLegalHoldForUserRequest mPassw
 
 disableForUser ::
   forall r.
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       Error AuthenticationError,
-       Error InternalError,
-       ErrorS ('ActionDenied 'RemoveConversationMember),
-       ErrorS 'LegalHoldCouldNotBlockConnections,
-       ErrorS 'LegalHoldServiceNotRegistered,
-       ErrorS 'NotATeamMember,
-       ErrorS OperationDenied,
-       ErrorS 'UserLegalHoldIllegalOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input (Local ()),
-       Input UTCTime,
-       LegalHoldStore,
-       ListItems LegacyPaging ConvId,
-       MemberStore,
-       ProposalStore,
-       P.TinyLog,
-       TeamStore
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         Error AuthenticationError,
+         Error InternalError,
+         ErrorS ('ActionDenied 'RemoveConversationMember),
+         ErrorS 'LegalHoldCouldNotBlockConnections,
+         ErrorS 'LegalHoldServiceNotRegistered,
+         ErrorS 'NotATeamMember,
+         ErrorS OperationDenied,
+         ErrorS 'UserLegalHoldIllegalOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input (Local ()),
+         Input UTCTime,
+         LegalHoldStore,
+         ListItems LegacyPaging ConvId,
+         MemberStore,
+         ProposalStore,
+         P.TinyLog,
+         TeamStore
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   TeamId ->
   UserId ->
@@ -645,26 +673,30 @@ disableForUser lzusr tid uid (Public.DisableLegalHoldForUserRequest mPassword) =
 -- or disabled, make sure the affected connections are screened for policy conflict (anybody
 -- with no-consent), and put those connections in the appropriate blocked state.
 changeLegalholdStatus ::
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       Error InternalError,
-       ErrorS ('ActionDenied 'RemoveConversationMember),
-       ErrorS 'LegalHoldCouldNotBlockConnections,
-       ErrorS 'UserLegalHoldIllegalOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       LegalHoldStore,
-       ListItems LegacyPaging ConvId,
-       MemberStore,
-       TeamStore,
-       ProposalStore,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         Error InternalError,
+         ErrorS ('ActionDenied 'RemoveConversationMember),
+         ErrorS 'LegalHoldCouldNotBlockConnections,
+         ErrorS 'UserLegalHoldIllegalOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         LegalHoldStore,
+         ListItems LegacyPaging ConvId,
+         MemberStore,
+         TeamStore,
+         ProposalStore,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   TeamId ->
   Local UserId ->
   UserLegalHoldStatus ->
@@ -765,22 +797,26 @@ unsetTeamLegalholdWhitelistedH tid = do
 -- contains the hypothetical new LH status of `uid`'s so it can be consulted instead of the
 -- one from the database.
 handleGroupConvPolicyConflicts ::
-  (Members
-    '[ ConversationStore,
-       Error InternalError,
-       ErrorS ('ActionDenied 'RemoveConversationMember),
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       ListItems LegacyPaging ConvId,
-       MemberStore,
-       ProposalStore,
-       P.TinyLog,
-       TeamStore
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         Error InternalError,
+         ErrorS ('ActionDenied 'RemoveConversationMember),
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         ListItems LegacyPaging ConvId,
+         MemberStore,
+         ProposalStore,
+         P.TinyLog,
+         TeamStore
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   UserLegalHoldStatus ->
   Sem r ()

--- a/services/galley/src/Galley/API/MLS/GroupInfo.hs
+++ b/services/galley/src/Galley/API/MLS/GroupInfo.hs
@@ -45,14 +45,14 @@ type MLSGroupInfoStaticErrors =
    ]
 
 getGroupInfo ::
-  Members
+  (Members
     '[ ConversationStore,
        Error FederationError,
        FederatorAccess,
        Input Env,
        MemberStore
      ]
-    r =>
+    r, CallsFed 'Galley "query-group-info") =>
   Members MLSGroupInfoStaticErrors r =>
   Local UserId ->
   Qualified ConvId ->
@@ -81,7 +81,7 @@ getGroupInfoFromLocalConv qusr lcnvId = do
     >>= noteS @'MLSMissingGroupInfo
 
 getGroupInfoFromRemoteConv ::
-  Members '[Error FederationError, FederatorAccess] r =>
+  (Members '[Error FederationError, FederatorAccess] r, CallsFed 'Galley "query-group-info") =>
   Members MLSGroupInfoStaticErrors r =>
   Local UserId ->
   Remote ConvId ->

--- a/services/galley/src/Galley/API/MLS/GroupInfo.hs
+++ b/services/galley/src/Galley/API/MLS/GroupInfo.hs
@@ -45,14 +45,16 @@ type MLSGroupInfoStaticErrors =
    ]
 
 getGroupInfo ::
-  (Members
-    '[ ConversationStore,
-       Error FederationError,
-       FederatorAccess,
-       Input Env,
-       MemberStore
-     ]
-    r, CallsFed 'Galley "query-group-info") =>
+  ( Members
+      '[ ConversationStore,
+         Error FederationError,
+         FederatorAccess,
+         Input Env,
+         MemberStore
+       ]
+      r,
+    CallsFed 'Galley "query-group-info"
+  ) =>
   Members MLSGroupInfoStaticErrors r =>
   Local UserId ->
   Qualified ConvId ->

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -140,7 +140,13 @@ postMLSMessageFromLocalUserV1 ::
          Resource,
          TinyLog
        ]
-      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "send-mls-message", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
+      r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "send-mls-message",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Local UserId ->
   Maybe ClientId ->
   ConnId ->
@@ -177,7 +183,13 @@ postMLSMessageFromLocalUser ::
          Resource,
          TinyLog
        ]
-      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "send-mls-message", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
+      r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "send-mls-message",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Local UserId ->
   Maybe ClientId ->
   ConnId ->
@@ -207,7 +219,14 @@ postMLSCommitBundle ::
          Resource,
          TinyLog
        ]
-      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "mls-welcome", CallsFed 'Galley "send-mls-commit-bundle", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
+      r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "mls-welcome",
+    CallsFed 'Galley "send-mls-commit-bundle",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Local x ->
   Qualified UserId ->
   Maybe ClientId ->
@@ -238,7 +257,14 @@ postMLSCommitBundleFromLocalUser ::
          Resource,
          TinyLog
        ]
-      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "mls-welcome", CallsFed 'Galley "send-mls-commit-bundle", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
+      r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "mls-welcome",
+    CallsFed 'Galley "send-mls-commit-bundle",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Local UserId ->
   Maybe ClientId ->
   ConnId ->
@@ -268,7 +294,13 @@ postMLSCommitBundleToLocalConv ::
          Resource,
          TinyLog
        ]
-      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "mls-welcome", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
+      r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "mls-welcome",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Qualified UserId ->
   Maybe ClientId ->
   Maybe ConnId ->
@@ -332,7 +364,9 @@ postMLSCommitBundleToRemoteConv ::
          MemberStore,
          TinyLog
        ]
-      r, CallsFed 'Galley "send-mls-commit-bundle") =>
+      r,
+    CallsFed 'Galley "send-mls-commit-bundle"
+  ) =>
   Local x ->
   Qualified UserId ->
   Maybe ConnId ->
@@ -386,7 +420,13 @@ postMLSMessage ::
          Resource,
          TinyLog
        ]
-      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "send-mls-message", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
+      r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "send-mls-message",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Local x ->
   Qualified UserId ->
   Maybe ClientId ->
@@ -471,7 +511,12 @@ postMLSMessageToLocalConv ::
          Resource,
          TinyLog
        ]
-      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
+      r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Qualified UserId ->
   Maybe ClientId ->
   Maybe ConnId ->
@@ -509,7 +554,9 @@ postMLSMessageToLocalConv qusr senderClient con smsg lcnv = case rmValue smsg of
 postMLSMessageToRemoteConv ::
   ( Members MLSMessageStaticErrors r,
     Members '[Error FederationError, TinyLog] r,
-    HasProposalEffects r, CallsFed 'Galley "send-mls-message") =>
+    HasProposalEffects r,
+    CallsFed 'Galley "send-mls-message"
+  ) =>
   Local x ->
   Qualified UserId ->
   Maybe ClientId ->
@@ -633,7 +680,12 @@ processCommit ::
     Member (Input (Local ())) r,
     Member ProposalStore r,
     Member BrigAccess r,
-    Member Resource r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
+    Member Resource r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Qualified UserId ->
   Maybe ClientId ->
   Maybe ConnId ->
@@ -650,26 +702,28 @@ processCommit qusr senderClient con lconv mlsMeta cm epoch sender commit = do
 
 processExternalCommit ::
   forall r.
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       Error MLSProtocolError,
-       ErrorS 'ConvNotFound,
-       ErrorS 'MLSClientSenderUserMismatch,
-       ErrorS 'MLSKeyPackageRefNotFound,
-       ErrorS 'MLSStaleMessage,
-       ErrorS 'MLSMissingSenderClient,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       MemberStore,
-       ProposalStore,
-       Resource,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "on-mls-message-sent") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         Error MLSProtocolError,
+         ErrorS 'ConvNotFound,
+         ErrorS 'MLSClientSenderUserMismatch,
+         ErrorS 'MLSKeyPackageRefNotFound,
+         ErrorS 'MLSStaleMessage,
+         ErrorS 'MLSMissingSenderClient,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         MemberStore,
+         ProposalStore,
+         Resource,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-mls-message-sent"
+  ) =>
   Qualified UserId ->
   Maybe ClientId ->
   Local Data.Conversation ->
@@ -774,7 +828,12 @@ processCommitWithAction ::
     Member (Input (Local ())) r,
     Member ProposalStore r,
     Member BrigAccess r,
-    Member Resource r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
+    Member Resource r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Qualified UserId ->
   Maybe ClientId ->
   Maybe ConnId ->
@@ -808,7 +867,12 @@ processInternalCommit ::
     Member (Input (Local ())) r,
     Member ProposalStore r,
     Member BrigAccess r,
-    Member Resource r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
+    Member Resource r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Qualified UserId ->
   Maybe ClientId ->
   Maybe ConnId ->
@@ -1141,7 +1205,12 @@ executeProposalAction ::
     Member MemberStore r,
     Member ProposalStore r,
     Member TeamStore r,
-    Member TinyLog r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
+    Member TinyLog r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Qualified UserId ->
   Maybe ConnId ->
   Local Data.Conversation ->
@@ -1279,8 +1348,9 @@ handleNoChanges :: Monoid a => Sem (Error NoChanges ': r) a -> Sem r a
 handleNoChanges = fmap fold . runError
 
 getClientInfo ::
-  (Members '[BrigAccess, FederatorAccess] r,
-  CallsFed 'Brig "get-mls-clients") =>
+  ( Members '[BrigAccess, FederatorAccess] r,
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Local x ->
   Qualified UserId ->
   SignatureSchemeTag ->
@@ -1288,8 +1358,9 @@ getClientInfo ::
 getClientInfo loc = foldQualified loc getLocalMLSClients getRemoteMLSClients
 
 getRemoteMLSClients ::
-  (Member FederatorAccess r,
-  CallsFed 'Brig "get-mls-clients") =>
+  ( Member FederatorAccess r,
+    CallsFed 'Brig "get-mls-clients"
+  ) =>
   Remote UserId ->
   SignatureSchemeTag ->
   Sem r (Set ClientInfo)

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -140,8 +140,7 @@ postMLSMessageFromLocalUserV1 ::
          Resource,
          TinyLog
        ]
-      r
-  ) =>
+      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "send-mls-message", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
   Local UserId ->
   Maybe ClientId ->
   ConnId ->
@@ -178,8 +177,7 @@ postMLSMessageFromLocalUser ::
          Resource,
          TinyLog
        ]
-      r
-  ) =>
+      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "send-mls-message", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
   Local UserId ->
   Maybe ClientId ->
   ConnId ->
@@ -209,8 +207,7 @@ postMLSCommitBundle ::
          Resource,
          TinyLog
        ]
-      r
-  ) =>
+      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "mls-welcome", CallsFed 'Galley "send-mls-commit-bundle", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
   Local x ->
   Qualified UserId ->
   Maybe ClientId ->
@@ -241,8 +238,7 @@ postMLSCommitBundleFromLocalUser ::
          Resource,
          TinyLog
        ]
-      r
-  ) =>
+      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "mls-welcome", CallsFed 'Galley "send-mls-commit-bundle", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
   Local UserId ->
   Maybe ClientId ->
   ConnId ->
@@ -272,8 +268,7 @@ postMLSCommitBundleToLocalConv ::
          Resource,
          TinyLog
        ]
-      r
-  ) =>
+      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "mls-welcome", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
   Qualified UserId ->
   Maybe ClientId ->
   Maybe ConnId ->
@@ -337,8 +332,7 @@ postMLSCommitBundleToRemoteConv ::
          MemberStore,
          TinyLog
        ]
-      r
-  ) =>
+      r, CallsFed 'Galley "send-mls-commit-bundle") =>
   Local x ->
   Qualified UserId ->
   Maybe ConnId ->
@@ -392,8 +386,7 @@ postMLSMessage ::
          Resource,
          TinyLog
        ]
-      r
-  ) =>
+      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "send-mls-message", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
   Local x ->
   Qualified UserId ->
   Maybe ClientId ->
@@ -478,8 +471,7 @@ postMLSMessageToLocalConv ::
          Resource,
          TinyLog
        ]
-      r
-  ) =>
+      r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
   Qualified UserId ->
   Maybe ClientId ->
   Maybe ConnId ->
@@ -517,8 +509,7 @@ postMLSMessageToLocalConv qusr senderClient con smsg lcnv = case rmValue smsg of
 postMLSMessageToRemoteConv ::
   ( Members MLSMessageStaticErrors r,
     Members '[Error FederationError, TinyLog] r,
-    HasProposalEffects r
-  ) =>
+    HasProposalEffects r, CallsFed 'Galley "send-mls-message") =>
   Local x ->
   Qualified UserId ->
   Maybe ClientId ->
@@ -642,8 +633,7 @@ processCommit ::
     Member (Input (Local ())) r,
     Member ProposalStore r,
     Member BrigAccess r,
-    Member Resource r
-  ) =>
+    Member Resource r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
   Qualified UserId ->
   Maybe ClientId ->
   Maybe ConnId ->
@@ -660,7 +650,7 @@ processCommit qusr senderClient con lconv mlsMeta cm epoch sender commit = do
 
 processExternalCommit ::
   forall r.
-  Members
+  (Members
     '[ BrigAccess,
        ConversationStore,
        Error MLSProtocolError,
@@ -679,7 +669,7 @@ processExternalCommit ::
        Resource,
        TinyLog
      ]
-    r =>
+    r, CallsFed 'Galley "on-mls-message-sent") =>
   Qualified UserId ->
   Maybe ClientId ->
   Local Data.Conversation ->
@@ -784,8 +774,7 @@ processCommitWithAction ::
     Member (Input (Local ())) r,
     Member ProposalStore r,
     Member BrigAccess r,
-    Member Resource r
-  ) =>
+    Member Resource r, CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
   Qualified UserId ->
   Maybe ClientId ->
   Maybe ConnId ->
@@ -819,8 +808,7 @@ processInternalCommit ::
     Member (Input (Local ())) r,
     Member ProposalStore r,
     Member BrigAccess r,
-    Member Resource r
-  ) =>
+    Member Resource r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
   Qualified UserId ->
   Maybe ClientId ->
   Maybe ConnId ->
@@ -1153,8 +1141,7 @@ executeProposalAction ::
     Member MemberStore r,
     Member ProposalStore r,
     Member TeamStore r,
-    Member TinyLog r
-  ) =>
+    Member TinyLog r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Brig "get-mls-clients") =>
   Qualified UserId ->
   Maybe ConnId ->
   Local Data.Conversation ->
@@ -1292,7 +1279,8 @@ handleNoChanges :: Monoid a => Sem (Error NoChanges ': r) a -> Sem r a
 handleNoChanges = fmap fold . runError
 
 getClientInfo ::
-  Members '[BrigAccess, FederatorAccess] r =>
+  (Members '[BrigAccess, FederatorAccess] r,
+  CallsFed 'Brig "get-mls-clients") =>
   Local x ->
   Qualified UserId ->
   SignatureSchemeTag ->
@@ -1300,7 +1288,8 @@ getClientInfo ::
 getClientInfo loc = foldQualified loc getLocalMLSClients getRemoteMLSClients
 
 getRemoteMLSClients ::
-  Member FederatorAccess r =>
+  (Member FederatorAccess r,
+  CallsFed 'Brig "get-mls-clients") =>
   Remote UserId ->
   SignatureSchemeTag ->
   Sem r (Set ClientInfo)

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -52,7 +52,9 @@ propagateMessage ::
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
-    Member TinyLog r, CallsFed 'Galley "on-mls-message-sent") =>
+    Member TinyLog r,
+    CallsFed 'Galley "on-mls-message-sent"
+  ) =>
   Qualified UserId ->
   Local Data.Conversation ->
   ClientMap ->

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -52,8 +52,7 @@ propagateMessage ::
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
-    Member TinyLog r
-  ) =>
+    Member TinyLog r, CallsFed 'Galley "on-mls-message-sent") =>
   Qualified UserId ->
   Local Data.Conversation ->
   ClientMap ->

--- a/services/galley/src/Galley/API/MLS/Removal.hs
+++ b/services/galley/src/Galley/API/MLS/Removal.hs
@@ -44,11 +44,11 @@ import Polysemy.Input
 import Polysemy.TinyLog
 import qualified System.Logger as Log
 import Wire.API.Conversation.Protocol
+import Wire.API.Federation.API
 import Wire.API.MLS.KeyPackage
 import Wire.API.MLS.Message
 import Wire.API.MLS.Proposal
 import Wire.API.MLS.Serialisation
-import Wire.API.Federation.API
 
 -- | Send remove proposals for a set of clients to clients in the ClientMap.
 removeClientsWithClientMap ::
@@ -62,7 +62,9 @@ removeClientsWithClientMap ::
          Input Env
        ]
       r,
-    Traversable t, CallsFed 'Galley "on-mls-message-sent") =>
+    Traversable t,
+    CallsFed 'Galley "on-mls-message-sent"
+  ) =>
   Local Data.Conversation ->
   t KeyPackageRef ->
   ClientMap ->
@@ -102,7 +104,8 @@ removeClient ::
          ProposalStore,
          TinyLog
        ]
-      r, CallsFed 'Galley "on-mls-message-sent"
+      r,
+    CallsFed 'Galley "on-mls-message-sent"
   ) =>
   Local Data.Conversation ->
   Qualified UserId ->
@@ -128,7 +131,8 @@ removeUserWithClientMap ::
          ProposalStore,
          Input Env
        ]
-      r, CallsFed 'Galley "on-mls-message-sent"
+      r,
+    CallsFed 'Galley "on-mls-message-sent"
   ) =>
   Local Data.Conversation ->
   ClientMap ->
@@ -150,7 +154,8 @@ removeUser ::
          ProposalStore,
          TinyLog
        ]
-      r, CallsFed 'Galley "on-mls-message-sent"
+      r,
+    CallsFed 'Galley "on-mls-message-sent"
   ) =>
   Local Data.Conversation ->
   Qualified UserId ->

--- a/services/galley/src/Galley/API/MLS/Removal.hs
+++ b/services/galley/src/Galley/API/MLS/Removal.hs
@@ -48,6 +48,7 @@ import Wire.API.MLS.KeyPackage
 import Wire.API.MLS.Message
 import Wire.API.MLS.Proposal
 import Wire.API.MLS.Serialisation
+import Wire.API.Federation.API
 
 -- | Send remove proposals for a set of clients to clients in the ClientMap.
 removeClientsWithClientMap ::
@@ -61,8 +62,7 @@ removeClientsWithClientMap ::
          Input Env
        ]
       r,
-    Traversable t
-  ) =>
+    Traversable t, CallsFed 'Galley "on-mls-message-sent") =>
   Local Data.Conversation ->
   t KeyPackageRef ->
   ClientMap ->
@@ -102,7 +102,7 @@ removeClient ::
          ProposalStore,
          TinyLog
        ]
-      r
+      r, CallsFed 'Galley "on-mls-message-sent"
   ) =>
   Local Data.Conversation ->
   Qualified UserId ->
@@ -128,7 +128,7 @@ removeUserWithClientMap ::
          ProposalStore,
          Input Env
        ]
-      r
+      r, CallsFed 'Galley "on-mls-message-sent"
   ) =>
   Local Data.Conversation ->
   ClientMap ->
@@ -150,7 +150,7 @@ removeUser ::
          ProposalStore,
          TinyLog
        ]
-      r
+      r, CallsFed 'Galley "on-mls-message-sent"
   ) =>
   Local Data.Conversation ->
   Qualified UserId ->

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -55,7 +55,7 @@ import Wire.API.MLS.Welcome
 import Wire.API.Message
 
 postMLSWelcome ::
-  Members
+  (Members
     '[ BrigAccess,
        FederatorAccess,
        GundeckAccess,
@@ -63,7 +63,7 @@ postMLSWelcome ::
        Input UTCTime,
        P.TinyLog
      ]
-    r =>
+    r, CallsFed 'Galley "mls-welcome") =>
   Local x ->
   Maybe ConnId ->
   RawMLS Welcome ->
@@ -76,7 +76,7 @@ postMLSWelcome loc con wel = do
   sendRemoteWelcomes (rmRaw wel) remotes
 
 postMLSWelcomeFromLocalUser ::
-  Members
+  (Members
     '[ BrigAccess,
        FederatorAccess,
        GundeckAccess,
@@ -86,7 +86,7 @@ postMLSWelcomeFromLocalUser ::
        Input Env,
        P.TinyLog
      ]
-    r =>
+    r, CallsFed 'Galley "mls-welcome") =>
   Local x ->
   ConnId ->
   RawMLS Welcome ->
@@ -131,11 +131,11 @@ sendLocalWelcomes con now rawWelcome lclients = do
        in newMessagePush lclients mempty con defMessageMetadata (u, c) e
 
 sendRemoteWelcomes ::
-  Members
+  (Members
     '[ FederatorAccess,
        P.TinyLog
      ]
-    r =>
+    r, CallsFed 'Galley "mls-welcome") =>
   ByteString ->
   [Remote (UserId, ClientId)] ->
   Sem r ()

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -55,15 +55,17 @@ import Wire.API.MLS.Welcome
 import Wire.API.Message
 
 postMLSWelcome ::
-  (Members
-    '[ BrigAccess,
-       FederatorAccess,
-       GundeckAccess,
-       ErrorS 'MLSKeyPackageRefNotFound,
-       Input UTCTime,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "mls-welcome") =>
+  ( Members
+      '[ BrigAccess,
+         FederatorAccess,
+         GundeckAccess,
+         ErrorS 'MLSKeyPackageRefNotFound,
+         Input UTCTime,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "mls-welcome"
+  ) =>
   Local x ->
   Maybe ConnId ->
   RawMLS Welcome ->
@@ -76,17 +78,19 @@ postMLSWelcome loc con wel = do
   sendRemoteWelcomes (rmRaw wel) remotes
 
 postMLSWelcomeFromLocalUser ::
-  (Members
-    '[ BrigAccess,
-       FederatorAccess,
-       GundeckAccess,
-       ErrorS 'MLSKeyPackageRefNotFound,
-       ErrorS 'MLSNotEnabled,
-       Input UTCTime,
-       Input Env,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "mls-welcome") =>
+  ( Members
+      '[ BrigAccess,
+         FederatorAccess,
+         GundeckAccess,
+         ErrorS 'MLSKeyPackageRefNotFound,
+         ErrorS 'MLSNotEnabled,
+         Input UTCTime,
+         Input Env,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "mls-welcome"
+  ) =>
   Local x ->
   ConnId ->
   RawMLS Welcome ->
@@ -131,11 +135,13 @@ sendLocalWelcomes con now rawWelcome lclients = do
        in newMessagePush lclients mempty con defMessageMetadata (u, c) e
 
 sendRemoteWelcomes ::
-  (Members
-    '[ FederatorAccess,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "mls-welcome") =>
+  ( Members
+      '[ FederatorAccess,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "mls-welcome"
+  ) =>
   ByteString ->
   [Remote (UserId, ClientId)] ->
   Sem r ()

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -357,21 +357,24 @@ postBroadcast lusr con msg = runError $ do
       pure (mems ^. teamMembers)
 
 postQualifiedOtrMessage ::
-  (Members
-    '[ BrigAccess,
-       ClientStore,
-       ConversationStore,
-       FederatorAccess,
-       GundeckAccess,
-       ExternalAccess,
-       Input (Local ()), -- FUTUREWORK: remove this
-       Input Opts,
-       Input UTCTime,
-       MemberStore,
-       TeamStore,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "on-message-sent", CallsFed 'Brig "get-user-clients") =>
+  ( Members
+      '[ BrigAccess,
+         ClientStore,
+         ConversationStore,
+         FederatorAccess,
+         GundeckAccess,
+         ExternalAccess,
+         Input (Local ()), -- FUTUREWORK: remove this
+         Input Opts,
+         Input UTCTime,
+         MemberStore,
+         TeamStore,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-message-sent",
+    CallsFed 'Brig "get-user-clients"
+  ) =>
   UserType ->
   Qualified UserId ->
   Maybe ConnId ->
@@ -473,7 +476,9 @@ makeUserMap keys = (<> Map.fromSet (const mempty) keys)
 sendMessages ::
   forall t r.
   ( t ~ 'NormalMessage,
-    Members '[GundeckAccess, ExternalAccess, FederatorAccess, P.TinyLog] r, CallsFed 'Galley "on-message-sent") =>
+    Members '[GundeckAccess, ExternalAccess, FederatorAccess, P.TinyLog] r,
+    CallsFed 'Galley "on-message-sent"
+  ) =>
   UTCTime ->
   Qualified UserId ->
   ClientId ->

--- a/services/galley/src/Galley/API/Public/Bot.hs
+++ b/services/galley/src/Galley/API/Public/Bot.hs
@@ -19,10 +19,13 @@ module Galley.API.Public.Bot where
 
 import Galley.API.Update
 import Galley.App
+import Wire.API.Federation.API
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.Bot
-import Wire.API.Federation.API
 
-botAPI :: (CallsFed 'Galley "on-message-sent",
-  CallsFed 'Brig "get-user-clients") => API BotAPI GalleyEffects
+botAPI ::
+  ( CallsFed 'Galley "on-message-sent",
+    CallsFed 'Brig "get-user-clients"
+  ) =>
+  API BotAPI GalleyEffects
 botAPI = mkNamedAPI @"post-bot-message-unqualified" postBotMessageUnqualified

--- a/services/galley/src/Galley/API/Public/Bot.hs
+++ b/services/galley/src/Galley/API/Public/Bot.hs
@@ -21,6 +21,8 @@ import Galley.API.Update
 import Galley.App
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.Bot
+import Wire.API.Federation.API
 
-botAPI :: API BotAPI GalleyEffects
+botAPI :: (CallsFed 'Galley "on-message-sent",
+  CallsFed 'Brig "get-user-clients") => API BotAPI GalleyEffects
 botAPI = mkNamedAPI @"post-bot-message-unqualified" postBotMessageUnqualified

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -26,8 +26,10 @@ import Galley.App
 import Galley.Cassandra.TeamFeatures
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.Conversation
+import Wire.API.Federation.API
 
-conversationAPI :: API ConversationAPI GalleyEffects
+conversationAPI :: (CallsFed 'Galley "get-conversations",
+    CallsFed 'Galley "query-group-info", CallsFed 'Galley "on-typing-indicator-updated", CallsFed 'Galley "on-conversation-created", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "leave-conversation", CallsFed 'Galley "update-conversation") => API ConversationAPI GalleyEffects
 conversationAPI =
   mkNamedAPI @"get-unqualified-conversation" getUnqualifiedConversation
     <@> mkNamedAPI @"get-unqualified-conversation-legalhold-alias" getUnqualifiedConversation

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -24,12 +24,22 @@ import Galley.API.Query
 import Galley.API.Update
 import Galley.App
 import Galley.Cassandra.TeamFeatures
+import Wire.API.Federation.API
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.Conversation
-import Wire.API.Federation.API
 
-conversationAPI :: (CallsFed 'Galley "get-conversations",
-    CallsFed 'Galley "query-group-info", CallsFed 'Galley "on-typing-indicator-updated", CallsFed 'Galley "on-conversation-created", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "leave-conversation", CallsFed 'Galley "update-conversation") => API ConversationAPI GalleyEffects
+conversationAPI ::
+  ( CallsFed 'Galley "get-conversations",
+    CallsFed 'Galley "query-group-info",
+    CallsFed 'Galley "on-typing-indicator-updated",
+    CallsFed 'Galley "on-conversation-created",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "leave-conversation",
+    CallsFed 'Galley "update-conversation"
+  ) =>
+  API ConversationAPI GalleyEffects
 conversationAPI =
   mkNamedAPI @"get-unqualified-conversation" getUnqualifiedConversation
     <@> mkNamedAPI @"get-unqualified-conversation-legalhold-alias" getUnqualifiedConversation

--- a/services/galley/src/Galley/API/Public/Feature.hs
+++ b/services/galley/src/Galley/API/Public/Feature.hs
@@ -22,13 +22,17 @@ import Galley.API.Teams.Features
 import Galley.App
 import Galley.Cassandra.TeamFeatures
 import Imports
+import Wire.API.Federation.API
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.Feature
 import Wire.API.Team.Feature
-import Wire.API.Federation.API
 
-featureAPI :: (CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") => API FeatureAPI GalleyEffects
+featureAPI ::
+  ( CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
+  API FeatureAPI GalleyEffects
 featureAPI =
   mkNamedAPI @'("get", SSOConfig) (getFeatureStatus @Cassandra . DoAuth)
     <@> mkNamedAPI @'("get", LegalholdConfig) (getFeatureStatus @Cassandra . DoAuth)

--- a/services/galley/src/Galley/API/Public/Feature.hs
+++ b/services/galley/src/Galley/API/Public/Feature.hs
@@ -25,8 +25,10 @@ import Imports
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.Feature
 import Wire.API.Team.Feature
+import Wire.API.Federation.API
 
-featureAPI :: API FeatureAPI GalleyEffects
+featureAPI :: (CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") => API FeatureAPI GalleyEffects
 featureAPI =
   mkNamedAPI @'("get", SSOConfig) (getFeatureStatus @Cassandra . DoAuth)
     <@> mkNamedAPI @'("get", LegalholdConfig) (getFeatureStatus @Cassandra . DoAuth)

--- a/services/galley/src/Galley/API/Public/LegalHold.hs
+++ b/services/galley/src/Galley/API/Public/LegalHold.hs
@@ -20,12 +20,16 @@ module Galley.API.Public.LegalHold where
 import Galley.API.LegalHold
 import Galley.App
 import Galley.Cassandra.TeamFeatures
+import Wire.API.Federation.API
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.LegalHold
-import Wire.API.Federation.API
 
-legalHoldAPI :: (CallsFed 'Galley "on-conversation-updated",
-  CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") => API LegalHoldAPI GalleyEffects
+legalHoldAPI ::
+  ( CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
+  API LegalHoldAPI GalleyEffects
 legalHoldAPI =
   mkNamedAPI @"create-legal-hold-settings" (createSettings @Cassandra)
     <@> mkNamedAPI @"get-legal-hold-settings" (getSettings @Cassandra)

--- a/services/galley/src/Galley/API/Public/LegalHold.hs
+++ b/services/galley/src/Galley/API/Public/LegalHold.hs
@@ -22,8 +22,10 @@ import Galley.App
 import Galley.Cassandra.TeamFeatures
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.LegalHold
+import Wire.API.Federation.API
 
-legalHoldAPI :: API LegalHoldAPI GalleyEffects
+legalHoldAPI :: (CallsFed 'Galley "on-conversation-updated",
+  CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") => API LegalHoldAPI GalleyEffects
 legalHoldAPI =
   mkNamedAPI @"create-legal-hold-settings" (createSettings @Cassandra)
     <@> mkNamedAPI @"get-legal-hold-settings" (getSettings @Cassandra)

--- a/services/galley/src/Galley/API/Public/MLS.hs
+++ b/services/galley/src/Galley/API/Public/MLS.hs
@@ -21,8 +21,10 @@ import Galley.API.MLS
 import Galley.App
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.MLS
+import Wire.API.Federation.API
 
-mlsAPI :: API MLSAPI GalleyEffects
+mlsAPI :: (CallsFed 'Galley "mls-welcome",
+  CallsFed 'Brig "get-mls-clients", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "send-mls-message", CallsFed 'Galley "send-mls-commit-bundle") => API MLSAPI GalleyEffects
 mlsAPI =
   mkNamedAPI @"mls-welcome-message" postMLSWelcomeFromLocalUser
     <@> mkNamedAPI @"mls-message-v1" postMLSMessageFromLocalUserV1

--- a/services/galley/src/Galley/API/Public/MLS.hs
+++ b/services/galley/src/Galley/API/Public/MLS.hs
@@ -19,12 +19,20 @@ module Galley.API.Public.MLS where
 
 import Galley.API.MLS
 import Galley.App
+import Wire.API.Federation.API
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.MLS
-import Wire.API.Federation.API
 
-mlsAPI :: (CallsFed 'Galley "mls-welcome",
-  CallsFed 'Brig "get-mls-clients", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "send-mls-message", CallsFed 'Galley "send-mls-commit-bundle") => API MLSAPI GalleyEffects
+mlsAPI ::
+  ( CallsFed 'Galley "mls-welcome",
+    CallsFed 'Brig "get-mls-clients",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "send-mls-message",
+    CallsFed 'Galley "send-mls-commit-bundle"
+  ) =>
+  API MLSAPI GalleyEffects
 mlsAPI =
   mkNamedAPI @"mls-welcome-message" postMLSWelcomeFromLocalUser
     <@> mkNamedAPI @"mls-message-v1" postMLSMessageFromLocalUserV1

--- a/services/galley/src/Galley/API/Public/Messaging.hs
+++ b/services/galley/src/Galley/API/Public/Messaging.hs
@@ -21,8 +21,10 @@ import Galley.API.Update
 import Galley.App
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.Messaging
+import Wire.API.Federation.API
 
-messagingAPI :: API MessagingAPI GalleyEffects
+messagingAPI :: (CallsFed 'Brig "get-user-clients",
+  CallsFed 'Galley "on-message-sent", CallsFed 'Galley "send-message") => API MessagingAPI GalleyEffects
 messagingAPI =
   mkNamedAPI @"post-otr-message-unqualified" postOtrMessageUnqualified
     <@> mkNamedAPI @"post-otr-broadcast-unqualified" postOtrBroadcastUnqualified

--- a/services/galley/src/Galley/API/Public/Messaging.hs
+++ b/services/galley/src/Galley/API/Public/Messaging.hs
@@ -19,12 +19,16 @@ module Galley.API.Public.Messaging where
 
 import Galley.API.Update
 import Galley.App
+import Wire.API.Federation.API
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.Messaging
-import Wire.API.Federation.API
 
-messagingAPI :: (CallsFed 'Brig "get-user-clients",
-  CallsFed 'Galley "on-message-sent", CallsFed 'Galley "send-message") => API MessagingAPI GalleyEffects
+messagingAPI ::
+  ( CallsFed 'Brig "get-user-clients",
+    CallsFed 'Galley "on-message-sent",
+    CallsFed 'Galley "send-message"
+  ) =>
+  API MessagingAPI GalleyEffects
 messagingAPI =
   mkNamedAPI @"post-otr-message-unqualified" postOtrMessageUnqualified
     <@> mkNamedAPI @"post-otr-broadcast-unqualified" postOtrBroadcastUnqualified

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -28,12 +28,29 @@ import Galley.API.Public.Team
 import Galley.API.Public.TeamConversation
 import Galley.API.Public.TeamMember
 import Galley.App
+import Wire.API.Federation.API
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley
-import Wire.API.Federation.API
 
-servantSitemap :: (CallsFed 'Galley "get-conversations",
-  CallsFed 'Galley "leave-conversation", CallsFed 'Galley "on-conversation-created", CallsFed 'Galley "on-conversation-updated", CallsFed 'Brig "get-user-clients", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "on-typing-indicator-updated", CallsFed 'Galley "send-message", CallsFed 'Brig "get-mls-clients", CallsFed 'Galley "query-group-info", CallsFed 'Galley "mls-welcome", CallsFed 'Galley "update-conversation", CallsFed 'Galley "send-mls-commit-bundle", CallsFed 'Galley "send-mls-message") => API ServantAPI GalleyEffects
+servantSitemap ::
+  ( CallsFed 'Galley "get-conversations",
+    CallsFed 'Galley "leave-conversation",
+    CallsFed 'Galley "on-conversation-created",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Brig "get-user-clients",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-typing-indicator-updated",
+    CallsFed 'Galley "send-message",
+    CallsFed 'Brig "get-mls-clients",
+    CallsFed 'Galley "query-group-info",
+    CallsFed 'Galley "mls-welcome",
+    CallsFed 'Galley "update-conversation",
+    CallsFed 'Galley "send-mls-commit-bundle",
+    CallsFed 'Galley "send-mls-message"
+  ) =>
+  API ServantAPI GalleyEffects
 servantSitemap =
   conversationAPI
     <@> teamConversationAPI

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -30,8 +30,10 @@ import Galley.API.Public.TeamMember
 import Galley.App
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley
+import Wire.API.Federation.API
 
-servantSitemap :: API ServantAPI GalleyEffects
+servantSitemap :: (CallsFed 'Galley "get-conversations",
+  CallsFed 'Galley "leave-conversation", CallsFed 'Galley "on-conversation-created", CallsFed 'Galley "on-conversation-updated", CallsFed 'Brig "get-user-clients", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "on-typing-indicator-updated", CallsFed 'Galley "send-message", CallsFed 'Brig "get-mls-clients", CallsFed 'Galley "query-group-info", CallsFed 'Galley "mls-welcome", CallsFed 'Galley "update-conversation", CallsFed 'Galley "send-mls-commit-bundle", CallsFed 'Galley "send-mls-message") => API ServantAPI GalleyEffects
 servantSitemap =
   conversationAPI
     <@> teamConversationAPI

--- a/services/galley/src/Galley/API/Public/TeamConversation.hs
+++ b/services/galley/src/Galley/API/Public/TeamConversation.hs
@@ -21,8 +21,10 @@ import Galley.API.Teams
 import Galley.App
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.TeamConversation
+import Wire.API.Federation.API
 
-teamConversationAPI :: API TeamConversationAPI GalleyEffects
+teamConversationAPI :: (CallsFed 'Galley "on-conversation-updated",
+  CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") => API TeamConversationAPI GalleyEffects
 teamConversationAPI =
   mkNamedAPI @"get-team-conversation-roles" getTeamConversationRoles
     <@> mkNamedAPI @"get-team-conversations" getTeamConversations

--- a/services/galley/src/Galley/API/Public/TeamConversation.hs
+++ b/services/galley/src/Galley/API/Public/TeamConversation.hs
@@ -19,12 +19,16 @@ module Galley.API.Public.TeamConversation where
 
 import Galley.API.Teams
 import Galley.App
+import Wire.API.Federation.API
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley.TeamConversation
-import Wire.API.Federation.API
 
-teamConversationAPI :: (CallsFed 'Galley "on-conversation-updated",
-  CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") => API TeamConversationAPI GalleyEffects
+teamConversationAPI ::
+  ( CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
+  API TeamConversationAPI GalleyEffects
 teamConversationAPI =
   mkNamedAPI @"get-team-conversation-roles" getTeamConversationRoles
     <@> mkNamedAPI @"get-team-conversations" getTeamConversations

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -141,16 +141,18 @@ getUnqualifiedConversation lusr cnv = do
 
 getConversation ::
   forall r.
-  (Members
-    '[ ConversationStore,
-       ErrorS 'ConvNotFound,
-       ErrorS 'ConvAccessDenied,
-       Error FederationError,
-       Error InternalError,
-       FederatorAccess,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "get-conversations") =>
+  ( Members
+      '[ ConversationStore,
+         ErrorS 'ConvNotFound,
+         ErrorS 'ConvAccessDenied,
+         Error FederationError,
+         Error InternalError,
+         FederatorAccess,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "get-conversations"
+  ) =>
   Local UserId ->
   Qualified ConvId ->
   Sem r Public.Conversation
@@ -171,14 +173,16 @@ getConversation lusr cnv = do
         _convs -> throw $ FederationUnexpectedBody "expected one conversation, got multiple"
 
 getRemoteConversations ::
-  (Members
-    '[ ConversationStore,
-       Error FederationError,
-       ErrorS 'ConvNotFound,
-       FederatorAccess,
-       P.TinyLog
-     ]
-    r, CallsFed 'Galley "get-conversations") =>
+  ( Members
+      '[ ConversationStore,
+         Error FederationError,
+         ErrorS 'ConvNotFound,
+         FederatorAccess,
+         P.TinyLog
+       ]
+      r,
+    CallsFed 'Galley "get-conversations"
+  ) =>
   Local UserId ->
   [Remote ConvId] ->
   Sem r [Public.Conversation]
@@ -224,8 +228,9 @@ partitionGetConversationFailures = bimap concat concat . partitionEithers . map 
     split (FailedGetConversation convs (FailedGetConversationRemotely _)) = Right convs
 
 getRemoteConversationsWithFailures ::
-  (Members '[ConversationStore, FederatorAccess, P.TinyLog] r,
-  CallsFed 'Galley "get-conversations") =>
+  ( Members '[ConversationStore, FederatorAccess, P.TinyLog] r,
+    CallsFed 'Galley "get-conversations"
+  ) =>
   Local UserId ->
   [Remote ConvId] ->
   Sem r ([FailedGetConversation], [Public.Conversation])

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -141,7 +141,7 @@ getUnqualifiedConversation lusr cnv = do
 
 getConversation ::
   forall r.
-  Members
+  (Members
     '[ ConversationStore,
        ErrorS 'ConvNotFound,
        ErrorS 'ConvAccessDenied,
@@ -150,7 +150,7 @@ getConversation ::
        FederatorAccess,
        P.TinyLog
      ]
-    r =>
+    r, CallsFed 'Galley "get-conversations") =>
   Local UserId ->
   Qualified ConvId ->
   Sem r Public.Conversation
@@ -171,14 +171,14 @@ getConversation lusr cnv = do
         _convs -> throw $ FederationUnexpectedBody "expected one conversation, got multiple"
 
 getRemoteConversations ::
-  Members
+  (Members
     '[ ConversationStore,
        Error FederationError,
        ErrorS 'ConvNotFound,
        FederatorAccess,
        P.TinyLog
      ]
-    r =>
+    r, CallsFed 'Galley "get-conversations") =>
   Local UserId ->
   [Remote ConvId] ->
   Sem r [Public.Conversation]
@@ -224,7 +224,8 @@ partitionGetConversationFailures = bimap concat concat . partitionEithers . map 
     split (FailedGetConversation convs (FailedGetConversationRemotely _)) = Right convs
 
 getRemoteConversationsWithFailures ::
-  Members '[ConversationStore, FederatorAccess, P.TinyLog] r =>
+  (Members '[ConversationStore, FederatorAccess, P.TinyLog] r,
+  CallsFed 'Galley "get-conversations") =>
   Local UserId ->
   [Remote ConvId] ->
   Sem r ([FailedGetConversation], [Public.Conversation])
@@ -476,7 +477,7 @@ getConversationsInternal luser mids mstart msize = do
       | otherwise = pure True
 
 listConversations ::
-  Members '[ConversationStore, Error InternalError, FederatorAccess, P.TinyLog] r =>
+  (Members '[ConversationStore, Error InternalError, FederatorAccess, P.TinyLog] r, CallsFed 'Galley "get-conversations") =>
   Local UserId ->
   Public.ListConversations ->
   Sem r Public.ConversationsResponse

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -132,6 +132,7 @@ import Wire.API.Error
 import Wire.API.Error.Galley
 import qualified Wire.API.Event.Conversation as Conv
 import Wire.API.Event.Team
+import Wire.API.Federation.API
 import Wire.API.Federation.Error
 import qualified Wire.API.Message as Conv
 import qualified Wire.API.Notification as Public
@@ -155,7 +156,6 @@ import Wire.API.User.Identity (UserSSOId (UserSSOId))
 import Wire.API.User.RichInfo (RichInfo)
 import qualified Wire.Sem.Paging as E
 import Wire.Sem.Paging.Cassandra
-import Wire.API.Federation.API
 
 getTeamH ::
   forall r.
@@ -1102,23 +1102,27 @@ getTeamConversation zusr tid cid = do
     >>= noteS @'ConvNotFound
 
 deleteTeamConversation ::
-  (Members
-    '[ CodeStore,
-       ConversationStore,
-       Error FederationError,
-       Error InvalidInput,
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ErrorS 'NotATeamMember,
-       ErrorS ('ActionDenied 'DeleteConversation),
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       TeamStore
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ CodeStore,
+         ConversationStore,
+         Error FederationError,
+         Error InvalidInput,
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ErrorS 'NotATeamMember,
+         ErrorS ('ActionDenied 'DeleteConversation),
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         TeamStore
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   TeamId ->

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -155,6 +155,7 @@ import Wire.API.User.Identity (UserSSOId (UserSSOId))
 import Wire.API.User.RichInfo (RichInfo)
 import qualified Wire.Sem.Paging as E
 import Wire.Sem.Paging.Cassandra
+import Wire.API.Federation.API
 
 getTeamH ::
   forall r.
@@ -1101,7 +1102,7 @@ getTeamConversation zusr tid cid = do
     >>= noteS @'ConvNotFound
 
 deleteTeamConversation ::
-  Members
+  (Members
     '[ CodeStore,
        ConversationStore,
        Error FederationError,
@@ -1117,7 +1118,7 @@ deleteTeamConversation ::
        Input UTCTime,
        TeamStore
      ]
-    r =>
+    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
   Local UserId ->
   ConnId ->
   TeamId ->

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -76,12 +76,12 @@ import Wire.API.Conversation.Role (Action (RemoveConversationMember))
 import Wire.API.Error (ErrorS, throwS)
 import Wire.API.Error.Galley
 import qualified Wire.API.Event.FeatureConfig as Event
+import Wire.API.Federation.API
 import qualified Wire.API.Routes.Internal.Galley.TeamFeatureNoConfigMulti as Multi
 import Wire.API.Team.Feature
 import Wire.API.Team.Member
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
-import Wire.API.Federation.API
 
 data DoAuth = DoAuth UserId | DontDoAuth
 
@@ -708,10 +708,13 @@ instance GetFeatureConfig db LegalholdConfig where
         False -> FeatureStatusDisabled
     pure $ setStatus status defFeatureStatus
 
-instance (CallsFed 'Galley "on-conversation-updated"
-         ,CallsFed 'Galley "on-mls-message-sent"
-         ,CallsFed 'Galley "on-new-remote-conversation"
-         ) => SetFeatureConfig db LegalholdConfig where
+instance
+  ( CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
+  SetFeatureConfig db LegalholdConfig
+  where
   type
     SetConfigForTeamConstraints db LegalholdConfig (r :: EffectRow) =
       ( Bounded (PagingBounds InternalPaging TeamMember),

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -81,6 +81,7 @@ import Wire.API.Team.Feature
 import Wire.API.Team.Member
 import Wire.Sem.Paging
 import Wire.Sem.Paging.Cassandra
+import Wire.API.Federation.API
 
 data DoAuth = DoAuth UserId | DontDoAuth
 
@@ -707,7 +708,10 @@ instance GetFeatureConfig db LegalholdConfig where
         False -> FeatureStatusDisabled
     pure $ setStatus status defFeatureStatus
 
-instance SetFeatureConfig db LegalholdConfig where
+instance (CallsFed 'Galley "on-conversation-updated"
+         ,CallsFed 'Galley "on-mls-message-sent"
+         ,CallsFed 'Galley "on-new-remote-conversation"
+         ) => SetFeatureConfig db LegalholdConfig where
   type
     SetConfigForTeamConstraints db LegalholdConfig (r :: EffectRow) =
       ( Bounded (PagingBounds InternalPaging TeamMember),

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -290,8 +290,11 @@ type UpdateConversationAccessEffects =
    ]
 
 updateConversationAccess ::
-  (Members UpdateConversationAccessEffects r,
-    CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "on-conversation-updated") =>
+  ( Members UpdateConversationAccessEffects r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-conversation-updated"
+  ) =>
   Local UserId ->
   ConnId ->
   Qualified ConvId ->
@@ -303,8 +306,11 @@ updateConversationAccess lusr con qcnv update = do
     updateLocalConversation @'ConversationAccessDataTag lcnv (tUntagged lusr) (Just con) update
 
 updateConversationAccessUnqualified ::
-  (Members UpdateConversationAccessEffects r,
-    CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "on-conversation-updated") =>
+  ( Members UpdateConversationAccessEffects r,
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-conversation-updated"
+  ) =>
   Local UserId ->
   ConnId ->
   ConvId ->
@@ -319,23 +325,28 @@ updateConversationAccessUnqualified lusr con cnv update =
       update
 
 updateConversationReceiptMode ::
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       Error FederationError,
-       ErrorS ('ActionDenied 'ModifyConversationReceiptMode),
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input (Local ()),
-       Input Env,
-       Input UTCTime,
-       MemberStore,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "update-conversation") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         Error FederationError,
+         ErrorS ('ActionDenied 'ModifyConversationReceiptMode),
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input (Local ()),
+         Input Env,
+         Input UTCTime,
+         MemberStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "update-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   Qualified ConvId ->
@@ -371,7 +382,9 @@ updateRemoteConversation ::
       r,
     Members (HasConversationActionGalleyErrors tag) r,
     RethrowErrors (HasConversationActionGalleyErrors tag) (Error NoChanges : r),
-    SingI tag, CallsFed 'Galley "update-conversation") =>
+    SingI tag,
+    CallsFed 'Galley "update-conversation"
+  ) =>
   Remote ConvId ->
   Local UserId ->
   ConnId ->
@@ -394,23 +407,28 @@ updateRemoteConversation rcnv lusr conn action = getUpdateResult $ do
   notifyRemoteConversationAction lusr (qualifyAs rcnv convUpdate) (Just conn)
 
 updateConversationReceiptModeUnqualified ::
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       Error FederationError,
-       ErrorS ('ActionDenied 'ModifyConversationReceiptMode),
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input (Local ()),
-       Input Env,
-       Input UTCTime,
-       MemberStore,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation", CallsFed 'Galley "update-conversation") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         Error FederationError,
+         ErrorS ('ActionDenied 'ModifyConversationReceiptMode),
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input (Local ()),
+         Input Env,
+         Input UTCTime,
+         MemberStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "update-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   ConvId ->
@@ -419,19 +437,23 @@ updateConversationReceiptModeUnqualified ::
 updateConversationReceiptModeUnqualified lusr zcon cnv = updateConversationReceiptMode lusr zcon (tUntagged (qualifyAs lusr cnv))
 
 updateConversationMessageTimer ::
-  (Members
-    '[ ConversationStore,
-       ErrorS ('ActionDenied 'ModifyConversationMessageTimer),
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       Error FederationError,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         ErrorS ('ActionDenied 'ModifyConversationMessageTimer),
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         Error FederationError,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   Qualified ConvId ->
@@ -454,19 +476,23 @@ updateConversationMessageTimer lusr zcon qcnv update =
       qcnv
 
 updateConversationMessageTimerUnqualified ::
-  (Members
-    '[ ConversationStore,
-       ErrorS ('ActionDenied 'ModifyConversationMessageTimer),
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       Error FederationError,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         ErrorS ('ActionDenied 'ModifyConversationMessageTimer),
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         Error FederationError,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   ConvId ->
@@ -475,22 +501,26 @@ updateConversationMessageTimerUnqualified ::
 updateConversationMessageTimerUnqualified lusr zcon cnv = updateConversationMessageTimer lusr zcon (tUntagged (qualifyAs lusr cnv))
 
 deleteLocalConversation ::
-  (Members
-    '[ CodeStore,
-       ConversationStore,
-       Error FederationError,
-       ErrorS 'NotATeamMember,
-       ErrorS ('ActionDenied 'DeleteConversation),
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       TeamStore
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ CodeStore,
+         ConversationStore,
+         Error FederationError,
+         ErrorS 'NotATeamMember,
+         ErrorS ('ActionDenied 'DeleteConversation),
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         TeamStore
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   Local ConvId ->
@@ -698,7 +728,10 @@ joinConversationByReusableCode ::
          TeamFeatureStore db
        ]
       r,
-    FeaturePersistentConstraint db GuestLinksConfig, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
+    FeaturePersistentConstraint db GuestLinksConfig,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   ConversationCode ->
@@ -728,7 +761,10 @@ joinConversationById ::
          TeamStore,
          TeamFeatureStore db
        ]
-      r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   ConvId ->
@@ -738,23 +774,26 @@ joinConversationById lusr zcon cnv = do
   joinConversation @db lusr zcon conv LinkAccess
 
 joinConversation ::
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       FederatorAccess,
-       ErrorS 'ConvAccessDenied,
-       ErrorS 'InvalidOperation,
-       ErrorS 'NotATeamMember,
-       ErrorS 'TooManyMembers,
-       ExternalAccess,
-       GundeckAccess,
-       Input Opts,
-       Input UTCTime,
-       MemberStore,
-       TeamStore,
-       TeamFeatureStore db
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         FederatorAccess,
+         ErrorS 'ConvAccessDenied,
+         ErrorS 'InvalidOperation,
+         ErrorS 'NotATeamMember,
+         ErrorS 'TooManyMembers,
+         ExternalAccess,
+         GundeckAccess,
+         Input Opts,
+         Input UTCTime,
+         MemberStore,
+         TeamStore,
+         TeamFeatureStore db
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   Data.Conversation ->
@@ -784,33 +823,37 @@ joinConversation lusr zcon conv access = do
         action
 
 addMembers ::
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       Error FederationError,
-       Error InternalError,
-       ErrorS ('ActionDenied 'AddConversationMember),
-       ErrorS ('ActionDenied 'LeaveConversation),
-       ErrorS 'ConvAccessDenied,
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ErrorS 'NotConnected,
-       ErrorS 'NotATeamMember,
-       ErrorS 'TooManyMembers,
-       ErrorS 'MissingLegalholdConsent,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input Opts,
-       Input UTCTime,
-       LegalHoldStore,
-       MemberStore,
-       ProposalStore,
-       TeamStore,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         Error FederationError,
+         Error InternalError,
+         ErrorS ('ActionDenied 'AddConversationMember),
+         ErrorS ('ActionDenied 'LeaveConversation),
+         ErrorS 'ConvAccessDenied,
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ErrorS 'NotConnected,
+         ErrorS 'NotATeamMember,
+         ErrorS 'TooManyMembers,
+         ErrorS 'MissingLegalholdConsent,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input Opts,
+         Input UTCTime,
+         LegalHoldStore,
+         MemberStore,
+         ProposalStore,
+         TeamStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   Qualified ConvId ->
@@ -823,33 +866,37 @@ addMembers lusr zcon qcnv (InviteQualified users role) = do
       ConversationJoin users role
 
 addMembersUnqualifiedV2 ::
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       Error FederationError,
-       Error InternalError,
-       ErrorS ('ActionDenied 'AddConversationMember),
-       ErrorS ('ActionDenied 'LeaveConversation),
-       ErrorS 'ConvAccessDenied,
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ErrorS 'NotConnected,
-       ErrorS 'NotATeamMember,
-       ErrorS 'TooManyMembers,
-       ErrorS 'MissingLegalholdConsent,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input Opts,
-       Input UTCTime,
-       LegalHoldStore,
-       MemberStore,
-       ProposalStore,
-       TeamStore,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         Error FederationError,
+         Error InternalError,
+         ErrorS ('ActionDenied 'AddConversationMember),
+         ErrorS ('ActionDenied 'LeaveConversation),
+         ErrorS 'ConvAccessDenied,
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ErrorS 'NotConnected,
+         ErrorS 'NotATeamMember,
+         ErrorS 'TooManyMembers,
+         ErrorS 'MissingLegalholdConsent,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input Opts,
+         Input UTCTime,
+         LegalHoldStore,
+         MemberStore,
+         ProposalStore,
+         TeamStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   ConvId ->
@@ -862,33 +909,37 @@ addMembersUnqualifiedV2 lusr zcon cnv (InviteQualified users role) = do
       ConversationJoin users role
 
 addMembersUnqualified ::
-  (Members
-    '[ BrigAccess,
-       ConversationStore,
-       Error FederationError,
-       Error InternalError,
-       ErrorS ('ActionDenied 'AddConversationMember),
-       ErrorS ('ActionDenied 'LeaveConversation),
-       ErrorS 'ConvAccessDenied,
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ErrorS 'NotConnected,
-       ErrorS 'NotATeamMember,
-       ErrorS 'TooManyMembers,
-       ErrorS 'MissingLegalholdConsent,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input Opts,
-       Input UTCTime,
-       LegalHoldStore,
-       MemberStore,
-       ProposalStore,
-       TeamStore,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ BrigAccess,
+         ConversationStore,
+         Error FederationError,
+         Error InternalError,
+         ErrorS ('ActionDenied 'AddConversationMember),
+         ErrorS ('ActionDenied 'LeaveConversation),
+         ErrorS 'ConvAccessDenied,
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ErrorS 'NotConnected,
+         ErrorS 'NotATeamMember,
+         ErrorS 'TooManyMembers,
+         ErrorS 'MissingLegalholdConsent,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input Opts,
+         Input UTCTime,
+         LegalHoldStore,
+         MemberStore,
+         ProposalStore,
+         TeamStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   ConvId ->
@@ -967,21 +1018,25 @@ updateUnqualifiedSelfMember lusr zcon cnv update = do
   updateSelfMember lusr zcon (tUntagged lcnv) update
 
 updateOtherMemberLocalConv ::
-  (Members
-    '[ ConversationStore,
-       ErrorS ('ActionDenied 'ModifyOtherConversationMember),
-       ErrorS 'InvalidTarget,
-       ErrorS 'InvalidOperation,
-       ErrorS 'ConvNotFound,
-       ErrorS 'ConvMemberNotFound,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       MemberStore
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         ErrorS ('ActionDenied 'ModifyOtherConversationMember),
+         ErrorS 'InvalidTarget,
+         ErrorS 'InvalidOperation,
+         ErrorS 'ConvNotFound,
+         ErrorS 'ConvMemberNotFound,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         MemberStore
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local ConvId ->
   Local UserId ->
   ConnId ->
@@ -995,21 +1050,25 @@ updateOtherMemberLocalConv lcnv lusr con qvictim update = void . getUpdateResult
     ConversationMemberUpdate qvictim update
 
 updateOtherMemberUnqualified ::
-  (Members
-    '[ ConversationStore,
-       ErrorS ('ActionDenied 'ModifyOtherConversationMember),
-       ErrorS 'InvalidTarget,
-       ErrorS 'InvalidOperation,
-       ErrorS 'ConvNotFound,
-       ErrorS 'ConvMemberNotFound,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       MemberStore
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         ErrorS ('ActionDenied 'ModifyOtherConversationMember),
+         ErrorS 'InvalidTarget,
+         ErrorS 'InvalidOperation,
+         ErrorS 'ConvNotFound,
+         ErrorS 'ConvMemberNotFound,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         MemberStore
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   ConvId ->
@@ -1022,22 +1081,26 @@ updateOtherMemberUnqualified lusr zcon cnv victim update = do
   updateOtherMemberLocalConv lcnv lusr zcon (tUntagged lvictim) update
 
 updateOtherMember ::
-  (Members
-    '[ ConversationStore,
-       Error FederationError,
-       ErrorS ('ActionDenied 'ModifyOtherConversationMember),
-       ErrorS 'InvalidTarget,
-       ErrorS 'InvalidOperation,
-       ErrorS 'ConvNotFound,
-       ErrorS 'ConvMemberNotFound,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       MemberStore
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         Error FederationError,
+         ErrorS ('ActionDenied 'ModifyOtherConversationMember),
+         ErrorS 'InvalidTarget,
+         ErrorS 'InvalidOperation,
+         ErrorS 'ConvNotFound,
+         ErrorS 'ConvMemberNotFound,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         MemberStore
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   Qualified ConvId ->
@@ -1059,22 +1122,27 @@ updateOtherMemberRemoteConv ::
 updateOtherMemberRemoteConv _ _ _ _ _ = throw FederationNotImplemented
 
 removeMemberUnqualified ::
-  (Members
-    '[ ConversationStore,
-       Error InternalError,
-       ErrorS ('ActionDenied 'RemoveConversationMember),
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       MemberStore,
-       ProposalStore,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "leave-conversation", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         Error InternalError,
+         ErrorS ('ActionDenied 'RemoveConversationMember),
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         MemberStore,
+         ProposalStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "leave-conversation",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   ConvId ->
@@ -1086,22 +1154,27 @@ removeMemberUnqualified lusr con cnv victim = do
   removeMemberQualified lusr con (tUntagged lcnv) (tUntagged lvictim)
 
 removeMemberQualified ::
-  (Members
-    '[ ConversationStore,
-       Error InternalError,
-       ErrorS ('ActionDenied 'RemoveConversationMember),
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       MemberStore,
-       ProposalStore,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "leave-conversation", CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         Error InternalError,
+         ErrorS ('ActionDenied 'RemoveConversationMember),
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         MemberStore,
+         ProposalStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "leave-conversation",
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   Qualified ConvId ->
@@ -1117,13 +1190,15 @@ removeMemberQualified lusr con qcnv victim =
       victim
 
 removeMemberFromRemoteConv ::
-  (Members
-    '[ FederatorAccess,
-       ErrorS ('ActionDenied 'RemoveConversationMember),
-       ErrorS 'ConvNotFound,
-       Input UTCTime
-     ]
-    r, CallsFed 'Galley "leave-conversation") =>
+  ( Members
+      '[ FederatorAccess,
+         ErrorS ('ActionDenied 'RemoveConversationMember),
+         ErrorS 'ConvNotFound,
+         Input UTCTime
+       ]
+      r,
+    CallsFed 'Galley "leave-conversation"
+  ) =>
   Remote ConvId ->
   Local UserId ->
   Qualified UserId ->
@@ -1154,23 +1229,27 @@ removeMemberFromRemoteConv cnv lusr victim
 
 -- | Remove a member from a local conversation.
 removeMemberFromLocalConv ::
-  (Members
-    '[ ConversationStore,
-       Error InternalError,
-       ErrorS ('ActionDenied 'LeaveConversation),
-       ErrorS ('ActionDenied 'RemoveConversationMember),
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime,
-       MemberStore,
-       ProposalStore,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         Error InternalError,
+         ErrorS ('ActionDenied 'LeaveConversation),
+         ErrorS ('ActionDenied 'RemoveConversationMember),
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime,
+         MemberStore,
+         ProposalStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local ConvId ->
   Local UserId ->
   Maybe ConnId ->
@@ -1192,21 +1271,25 @@ removeMemberFromLocalConv lcnv lusr con victim
 -- OTR
 
 postProteusMessage ::
-  (Members
-    '[ BotAccess,
-       BrigAccess,
-       ClientStore,
-       ConversationStore,
-       FederatorAccess,
-       GundeckAccess,
-       ExternalAccess,
-       Input Opts,
-       Input UTCTime,
-       MemberStore,
-       TeamStore,
-       TinyLog
-     ]
-    r, CallsFed 'Brig "get-user-clients", CallsFed 'Galley "on-message-sent", CallsFed 'Galley "send-message") =>
+  ( Members
+      '[ BotAccess,
+         BrigAccess,
+         ClientStore,
+         ConversationStore,
+         FederatorAccess,
+         GundeckAccess,
+         ExternalAccess,
+         Input Opts,
+         Input UTCTime,
+         MemberStore,
+         TeamStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Brig "get-user-clients",
+    CallsFed 'Galley "on-message-sent",
+    CallsFed 'Galley "send-message"
+  ) =>
   Local UserId ->
   ConnId ->
   Qualified ConvId ->
@@ -1291,7 +1374,10 @@ postBotMessageUnqualified ::
          TinyLog,
          Input UTCTime
        ]
-      r, CallsFed 'Galley "on-message-sent", CallsFed 'Brig "get-user-clients") =>
+      r,
+    CallsFed 'Galley "on-message-sent",
+    CallsFed 'Brig "get-user-clients"
+  ) =>
   BotId ->
   ConvId ->
   Maybe IgnoreMissing ->
@@ -1334,21 +1420,24 @@ postOtrBroadcastUnqualified sender zcon =
     (postBroadcast sender (Just zcon))
 
 postOtrMessageUnqualified ::
-  (Members
-    '[ BotAccess,
-       BrigAccess,
-       ClientStore,
-       ConversationStore,
-       FederatorAccess,
-       GundeckAccess,
-       ExternalAccess,
-       MemberStore,
-       Input Opts,
-       Input UTCTime,
-       TeamStore,
-       TinyLog
-     ]
-    r, CallsFed 'Galley "on-message-sent", CallsFed 'Brig "get-user-clients") =>
+  ( Members
+      '[ BotAccess,
+         BrigAccess,
+         ClientStore,
+         ConversationStore,
+         FederatorAccess,
+         GundeckAccess,
+         ExternalAccess,
+         MemberStore,
+         Input Opts,
+         Input UTCTime,
+         TeamStore,
+         TinyLog
+       ]
+      r,
+    CallsFed 'Galley "on-message-sent",
+    CallsFed 'Brig "get-user-clients"
+  ) =>
   Local UserId ->
   ConnId ->
   ConvId ->
@@ -1363,20 +1452,24 @@ postOtrMessageUnqualified sender zcon cnv =
         (runLocalInput sender . postQualifiedOtrMessage User (tUntagged sender) (Just zcon) lcnv)
 
 updateConversationName ::
-  (Members
-    '[ ConversationStore,
-       Error FederationError,
-       Error InvalidInput,
-       ErrorS ('ActionDenied 'ModifyConversationName),
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         Error FederationError,
+         Error InvalidInput,
+         ErrorS ('ActionDenied 'ModifyConversationName),
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   Qualified ConvId ->
@@ -1391,19 +1484,23 @@ updateConversationName lusr zcon qcnv convRename = do
     convRename
 
 updateUnqualifiedConversationName ::
-  (Members
-    '[ ConversationStore,
-       Error InvalidInput,
-       ErrorS ('ActionDenied 'ModifyConversationName),
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         Error InvalidInput,
+         ErrorS ('ActionDenied 'ModifyConversationName),
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   ConvId ->
@@ -1414,19 +1511,23 @@ updateUnqualifiedConversationName lusr zcon cnv rename = do
   updateLocalConversationName lusr zcon lcnv rename
 
 updateLocalConversationName ::
-  (Members
-    '[ ConversationStore,
-       Error InvalidInput,
-       ErrorS ('ActionDenied 'ModifyConversationName),
-       ErrorS 'ConvNotFound,
-       ErrorS 'InvalidOperation,
-       ExternalAccess,
-       FederatorAccess,
-       GundeckAccess,
-       Input Env,
-       Input UTCTime
-     ]
-    r, CallsFed 'Galley "on-conversation-updated", CallsFed 'Galley "on-mls-message-sent", CallsFed 'Galley "on-new-remote-conversation") =>
+  ( Members
+      '[ ConversationStore,
+         Error InvalidInput,
+         ErrorS ('ActionDenied 'ModifyConversationName),
+         ErrorS 'ConvNotFound,
+         ErrorS 'InvalidOperation,
+         ExternalAccess,
+         FederatorAccess,
+         GundeckAccess,
+         Input Env,
+         Input UTCTime
+       ]
+      r,
+    CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-mls-message-sent",
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Local UserId ->
   ConnId ->
   Local ConvId ->
@@ -1437,16 +1538,18 @@ updateLocalConversationName lusr zcon lcnv rename =
     updateLocalConversation @'ConversationRenameTag lcnv (tUntagged lusr) (Just zcon) rename
 
 isTypingQualified ::
-  (Members
-    '[ GundeckAccess,
-       ErrorS 'ConvNotFound,
-       Input (Local ()),
-       Input UTCTime,
-       MemberStore,
-       FederatorAccess,
-       WaiRoutes
-     ]
-    r, CallsFed 'Galley "on-typing-indicator-updated") =>
+  ( Members
+      '[ GundeckAccess,
+         ErrorS 'ConvNotFound,
+         Input (Local ()),
+         Input UTCTime,
+         MemberStore,
+         FederatorAccess,
+         WaiRoutes
+       ]
+      r,
+    CallsFed 'Galley "on-typing-indicator-updated"
+  ) =>
   Local UserId ->
   ConnId ->
   Qualified ConvId ->

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -721,7 +721,7 @@ fromConversationCreated loc rc@ConversationCreated {..} =
 
 -- | Notify remote users of being added to a new conversation
 registerRemoteConversationMemberships ::
-  Member FederatorAccess r =>
+  (Member FederatorAccess r, CallsFed 'Galley "on-conversation-created") =>
   -- | The time stamp when the conversation was created
   UTCTime ->
   -- | The domain of the user that created the conversation


### PR DESCRIPTION
As part of gracefully handling offline backends, we want to make sure we have all of our bases covered when it comes to tracking what changes need to happen on the federation side. But it's unclear which endpoints call which federated endpoints. 

This PR tracks federated calls in the type system, ensuring all code paths (including endpoints) document which federated calls they make. For the time being, these constraints get eliminated by orphan instances at the very edge of the APIs, but #2950 follows up on this change, adding a servant combinator for better dissolution of the new `CallsFed` constraints, ensuring they get documented in swagger. 

The relevant change is in `Wire.API.Federation.API`, adding `CallsFed`. Everything else was done automatically in a tireless cycle of asking HLS to add a necessary constraint until the project compiled again.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
