### PR TITLE
redis-cluster chart: bump to 7.6.4

### DIFF
--- a/charts/redis-cluster/requirements.yaml
+++ b/charts/redis-cluster/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis-cluster
-  version: 7.4.8
+  version: 7.6.4
   repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
The old version `version: 7.4.8` is no longer available on the upstream repository

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
