### PR TITLE
Pin polysemy to 1.8.0.0

### DIFF
--- a/changelog.d/5-internal/pr-2949
+++ b/changelog.d/5-internal/pr-2949
@@ -1,0 +1,1 @@
+Update nix pins to point at polysemy-1.8.0.0

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -203,17 +203,6 @@ let
         tasty-hunit = "hunit";
       };
     };
-    kind-generics = {
-      src = fetchgit {
-        url = "https://gitlab.com/trupill/kind-generics.git";
-        rev = "f4ad2bcfacc9c3dcecf64c069d086926465cab2c";
-        sha256 = "sha256-uvQMV8aTNyTN+ozrseohexbCneVPMO35Jf1eEhLPk78=";
-      };
-      packages = {
-        kind-generics = "kind-generics";
-        kind-generics-th = "kind-generics-th";
-      };
-    };
     # This can be removed once postie 0.6.0.3 (or later) is in nixpkgs
     postie = {
       src = fetchgit {
@@ -231,6 +220,14 @@ let
     partial-isomorphisms = {
       version = "0.2.2.1";
       sha256 = "sha256-TdsLB0ueaUUllLdvcGu3YNQXCfGRRk5WxP3deHEbHGI=";
+    };
+    kind-generics = {
+      version = "0.4.1.2";
+      sha256 = "sha256-orDfC5+QXRlAMVaqAhT1Fo7Eh/AnobROWeliZqEAXZU=";
+    };
+    kind-generics-th = {
+      version = "0.2.2.2";
+      sha256 = "sha256-nPuRq19UGVXe4YrITAZcF+U4TUBo5APMT2Nh9NqIkxQ=";
     };
     polysemy = {
       version = "1.8.0.0";

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -203,30 +203,6 @@ let
         tasty-hunit = "hunit";
       };
     };
-    polysemy = {
-      src = fetchgit {
-        url = "https://github.com/polysemy-research/polysemy.git";
-        rev = "3855786e58bf397ca8204f3a79d19c24485dabd4";
-        sha256 = "sha256-4ans30VWuSMC9HNFb6FWQyc30oxJd2dmFrMGu5/dLg0=";
-      };
-    };
-    polysemy-plugin = {
-      src = fetchgit {
-        url = "https://github.com/polysemy-research/polysemy.git";
-        rev = "3855786e58bf397ca8204f3a79d19c24485dabd4";
-        sha256 = "sha256-4ans30VWuSMC9HNFb6FWQyc30oxJd2dmFrMGu5/dLg0=";
-      };
-      packages = {
-        polysemy-plugin = "polysemy-plugin";
-      };
-    };
-    polysemy-check = {
-      src = fetchgit {
-        url = "https://github.com/polysemy-research/polysemy-check.git";
-        rev = "4c0d3ff929ae22ae68d962f7f3f7056f357bf7ac";
-        sha256 = "sha256-8XeCeJWbkdqrUf6tERFMoGM8xRI5l/nKNqI810kzMs0=";
-      };
-    };
     kind-generics = {
       src = fetchgit {
         url = "https://gitlab.com/trupill/kind-generics.git";
@@ -255,6 +231,18 @@ let
     partial-isomorphisms = {
       version = "0.2.2.1";
       sha256 = "sha256-TdsLB0ueaUUllLdvcGu3YNQXCfGRRk5WxP3deHEbHGI=";
+    };
+    polysemy = {
+      version = "1.8.0.0";
+      sha256 = "sha256-AdxxKWXdUjZiHLDj6iswMWpycs7mFB8eKhBR4ljF6kk=";
+    };
+    polysemy-check = {
+      version = "0.9.0.1";
+      sha256 = "sha256-CsL2vMxAmpvVVR/iUnZAkbcRLiy/a8ulJQ6QwtCYmRM=";
+    };
+    polysemy-plugin = {
+      version = "0.4.3.1";
+      sha256 = "sha256-0vkLYNZISr3fmmQvD8qdLkn2GHc80l1GzJuOmqjqXE4=";
     };
     singletons = {
       version = "2.7";


### PR DESCRIPTION
This PR uses newly-cut releases for polysemy/polysemy-plugin/polysemy-check that mitigate the issues from #2947, rather than depending on explicit git commits.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
