### PR TITLE
hack/bin/upload-image: Retry despite `set -e`

### DIFF
--- a/hack/bin/upload-image.sh
+++ b/hack/bin/upload-image.sh
@@ -35,29 +35,24 @@ function retry {
     local maxAttempts=$1
     local secondsDelay=1
     local attemptCount=1
-    local output=
     shift 1
 
     while [ $attemptCount -le "$maxAttempts" ]; do
-        output=$("$@")
-        local status=$?
-
-        if [ $status -eq 0 ]; then
+        if "$@"; then
             break
-        fi
-
-        if [ $attemptCount -lt "$maxAttempts" ]; then
-            echo "Command [$*] failed after attempt $attemptCount of $maxAttempts. Retrying in $secondsDelay second(s)." >&2
-            sleep $secondsDelay
-        elif [ $attemptCount -eq "$maxAttempts" ]; then
-            echo "Command [$*] failed after $attemptCount attempt(s)" >&2
-            return $status
+        else
+            local status=$?
+            if [ $attemptCount -lt "$maxAttempts" ]; then
+                echo "Command [$*] failed after attempt $attemptCount of $maxAttempts. Retrying in $secondsDelay second(s)." >&2
+                sleep $secondsDelay
+            elif [ $attemptCount -eq "$maxAttempts" ]; then
+                echo "Command [$*] failed after $attemptCount attempt(s)" >&2
+                return $status
+            fi
         fi
         attemptCount=$((attemptCount + 1))
         secondsDelay=$((secondsDelay * 2))
     done
-
-    echo "$output"
 }
 
 tmp_link_store=$(mktemp -d)


### PR DESCRIPTION
Executing `"$@"` within first argument of `if` prevents `set -e` from immediately failing the whole script.

It could also be written as `while ! "$@"; do ...`, but then getting status of `"$@"` is more complicated as `! "$@"` has status=0 and overwrites the value of `$?`.

## Checklist

 - [x] No changelog
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
