### PR TITLE
[FS-1334] Reset a Subconversation

### DIFF
--- a/changelog.d/1-api-changes/delete-subconversation
+++ b/changelog.d/1-api-changes/delete-subconversation
@@ -1,0 +1,1 @@
+Introduce an endpoint for deleting a subconversation

--- a/changelog.d/2-features/delete-subconversation
+++ b/changelog.d/2-features/delete-subconversation
@@ -1,0 +1,1 @@
+Introduce support for resetting a subconversation

--- a/libs/wire-api/src/Wire/API/MLS/SubConversation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/SubConversation.hs
@@ -23,7 +23,7 @@ module Wire.API.MLS.SubConversation where
 import Control.Lens (makePrisms, (?~))
 import Control.Lens.Tuple (_1)
 import Control.Monad.Except
-import qualified Crypto.Hash as Crypto
+import Crypto.Hash as Crypto
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Aeson as A
 import Data.ByteArray

--- a/libs/wire-api/src/Wire/API/MLS/SubConversation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/SubConversation.hs
@@ -163,3 +163,20 @@ deriving via Schema ConvOrSubConvId instance FromJSON ConvOrSubConvId
 deriving via Schema ConvOrSubConvId instance ToJSON ConvOrSubConvId
 
 deriving via Schema ConvOrSubConvId instance S.ToSchema ConvOrSubConvId
+
+-- | The body of the delete subconversation request
+data DeleteSubConversation = DeleteSubConversation
+  { dscGroupId :: GroupId,
+    dscEpoch :: Epoch
+  }
+  deriving (Eq, Show)
+  deriving (A.ToJSON, A.FromJSON, S.ToSchema) via (Schema DeleteSubConversation)
+
+instance ToSchema DeleteSubConversation where
+  schema =
+    objectWithDocModifier
+      "DeleteSubConversation"
+      (description ?~ "Delete an MLS subconversation")
+      $ DeleteSubConversation
+        <$> dscGroupId .= field "group_id" schema
+        <*> dscEpoch .= field "epoch" schema

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -406,6 +406,24 @@ type ConversationAPI =
                     )
            )
     :<|> Named
+           "delete-subconversation"
+           ( Summary "Delete an MLS subconversation"
+               :> CanThrow 'ConvAccessDenied
+               :> CanThrow 'ConvNotFound
+               :> CanThrow 'MLSNotEnabled
+               :> CanThrow 'MLSStaleMessage
+               :> ZLocalUser
+               :> "conversations"
+               :> QualifiedCapture "cnv" ConvId
+               :> "subconversations"
+               :> Capture "subconv" SubConvId
+               :> ReqBody '[JSON] DeleteSubConversation
+               :> MultiVerb1
+                    'DELETE
+                    '[JSON]
+                    (Respond 200 "Deletion successful" ())
+           )
+    :<|> Named
            "get-subconversation-group-info"
            ( Summary "Get MLS group information of subconversation"
                :> MakesFederatedCall 'Galley "query-group-info"

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -111,6 +111,8 @@ library
     Galley.Effects.ServiceStore
     Galley.Effects.SparAccess
     Galley.Effects.SubConversationStore
+    Galley.Effects.SubConversationSupply
+    Galley.Effects.SubConversationSupply.Random
     Galley.Effects.TeamFeatureStore
     Galley.Effects.TeamMemberStore
     Galley.Effects.TeamNotificationStore

--- a/services/galley/src/Galley/API/MLS/SubConversation.hs
+++ b/services/galley/src/Galley/API/MLS/SubConversation.hs
@@ -15,8 +15,17 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module Galley.API.MLS.SubConversation where
+module Galley.API.MLS.SubConversation
+  ( getSubConversation,
+    getLocalSubConversation,
+    deleteSubConversation,
+    getSubConversationGroupInfo,
+    getSubConversationGroupInfoFromLocalConv,
+    MLSGetSubConvStaticErrors,
+  )
+where
 
+import Control.Arrow
 import Data.Id
 import Data.Qualified
 import Galley.API.MLS
@@ -29,9 +38,10 @@ import qualified Galley.Data.Conversation as Data
 import Galley.Data.Conversation.Types
 import Galley.Effects
 import Galley.Effects.FederatorAccess
-import Galley.Effects.SubConversationStore
+import Galley.Effects.SubConversationStore (SubConversationStore)
 import qualified Galley.Effects.SubConversationStore as Eff
 import Imports
+import qualified Network.Wai.Utilities.Error as Wai
 import Polysemy
 import Polysemy.Error
 import Polysemy.Input
@@ -41,7 +51,7 @@ import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Galley (GetSubConversationsRequest (..), GetSubConversationsResponse (..))
-import Wire.API.Federation.Error (FederationError)
+import Wire.API.Federation.Error
 import Wire.API.MLS.PublicGroupState
 import Wire.API.MLS.SubConversation
 
@@ -103,8 +113,8 @@ getLocalSubConversation qusr lconv sconv = do
       let groupId = initialGroupId lconv sconv
           epoch = Epoch 0
           suite = cnvmlsCipherSuite mlsMeta
-      createSubConversation (tUnqualified lconv) sconv suite epoch groupId Nothing
-      setGroupIdForSubConversation groupId (tUntagged lconv) sconv
+      Eff.createSubConversation (tUnqualified lconv) sconv suite epoch groupId Nothing
+      Eff.setGroupIdForSubConversation groupId (tUntagged lconv) sconv
       let sub =
             SubConversation
               { scParentConvId = tUnqualified lconv,
@@ -191,5 +201,58 @@ getSubConversationGroupInfoFromLocalConv ::
   Sem r OpaquePublicGroupState
 getSubConversationGroupInfoFromLocalConv qusr subConvId lcnvId = do
   void $ getLocalConvForUser qusr lcnvId
-  getSubConversationPublicGroupState (tUnqualified lcnvId) subConvId
+  Eff.getSubConversationPublicGroupState (tUnqualified lcnvId) subConvId
     >>= noteS @'MLSMissingGroupInfo
+
+deleteSubConversation ::
+  Members
+    '[ ConversationStore,
+       ErrorS 'ConvAccessDenied,
+       ErrorS 'ConvNotFound,
+       ErrorS 'MLSNotEnabled,
+       ErrorS 'MLSStaleMessage,
+       Error Wai.Error,
+       Input Env,
+       MemberStore,
+       SubConversationStore
+     ]
+    r =>
+  Local UserId ->
+  Qualified ConvId ->
+  SubConvId ->
+  DeleteSubConversation ->
+  Sem r ()
+deleteSubConversation lusr qconv sconv dsc = do
+  assertMLSEnabled
+  foldQualified
+    lusr
+    (\lcnv -> deleteLocalSubConversation lusr lcnv sconv dsc)
+    (\_rcnv -> throw federationNotImplemented)
+    qconv
+
+deleteLocalSubConversation ::
+  Members
+    '[ ConversationStore,
+       ErrorS 'ConvAccessDenied,
+       ErrorS 'ConvNotFound,
+       ErrorS 'MLSStaleMessage,
+       MemberStore,
+       SubConversationStore
+     ]
+    r =>
+  Local UserId ->
+  Local ConvId ->
+  SubConvId ->
+  DeleteSubConversation ->
+  Sem r ()
+deleteLocalSubConversation lusr lcnvId scnvId dsc = do
+  void $ getConversationAndCheckMembership (tUntagged lusr) lcnvId
+  sconv <-
+    Eff.getSubConversation (tUnqualified lcnvId) scnvId
+      >>= noteS @'ConvNotFound
+  let (gid, epoch) = (cnvmlsGroupId &&& cnvmlsEpoch) (scMLSData sconv)
+  unless (dscGroupId dsc == gid) $ throwS @'ConvNotFound
+  unless (dscEpoch dsc == epoch) $ throwS @'MLSStaleMessage
+  Eff.deleteSubConversationPublicGroupState (tUnqualified lcnvId) scnvId
+
+-- TODO(md): reset the group ID to some random group ID

--- a/services/galley/src/Galley/API/MLS/SubConversation.hs
+++ b/services/galley/src/Galley/API/MLS/SubConversation.hs
@@ -40,6 +40,8 @@ import Galley.Effects
 import Galley.Effects.FederatorAccess
 import Galley.Effects.SubConversationStore (SubConversationStore)
 import qualified Galley.Effects.SubConversationStore as Eff
+import Galley.Effects.SubConversationSupply (SubConversationSupply)
+import qualified Galley.Effects.SubConversationSupply as Eff
 import Imports
 import qualified Network.Wai.Utilities.Error as Wai
 import Polysemy
@@ -216,7 +218,8 @@ deleteSubConversation ::
        Input Env,
        MemberStore,
        Resource,
-       SubConversationStore
+       SubConversationStore,
+       SubConversationSupply
      ]
     r =>
   Local UserId ->
@@ -240,7 +243,8 @@ deleteLocalSubConversation ::
        ErrorS 'MLSStaleMessage,
        MemberStore,
        Resource,
-       SubConversationStore
+       SubConversationStore,
+       SubConversationSupply
      ]
     r =>
   Local UserId ->
@@ -259,4 +263,5 @@ deleteLocalSubConversation lusr lcnvId scnvId dsc = do
     unless (dscEpoch dsc == epoch) $ throwS @'MLSStaleMessage
     Eff.deleteSubConversationPublicGroupState (tUnqualified lcnvId) scnvId
 
--- TODO(md): reset the group ID to some random group ID
+    newGid <- Eff.makeFreshGroupId
+    Eff.setGroupIdForSubConversation newGid (tUntagged lcnvId) scnvId

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -50,6 +50,7 @@ conversationAPI =
     <@> mkNamedAPI @"create-self-conversation" createProteusSelfConversation
     <@> mkNamedAPI @"get-mls-self-conversation" getMLSSelfConversationWithError
     <@> mkNamedAPI @"get-subconversation" (callsFed getSubConversation)
+    <@> mkNamedAPI @"delete-subconversation" deleteSubConversation
     <@> mkNamedAPI @"get-subconversation-group-info" (callsFed getSubConversationGroupInfo)
     <@> mkNamedAPI @"create-one-to-one-conversation@v2" (callsFed createOne2OneConversation)
     <@> mkNamedAPI @"create-one-to-one-conversation" (callsFed createOne2OneConversation)

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -76,6 +76,7 @@ import Galley.Cassandra.TeamFeatures
 import Galley.Cassandra.TeamNotifications
 import Galley.Effects
 import Galley.Effects.FireAndForget (interpretFireAndForget)
+import Galley.Effects.SubConversationSupply.Random
 import Galley.Effects.WaiRoutes.IO
 import Galley.Env
 import Galley.External
@@ -107,6 +108,7 @@ import Util.Options
 import Wire.API.Error
 import Wire.API.Federation.Error
 import qualified Wire.Sem.Logger
+import Wire.Sem.Random.IO
 
 -- Effects needed by the interpretation of other effects
 type GalleyEffects0 =
@@ -258,6 +260,8 @@ evalGalley e =
     . interpretMemberStoreToCassandra
     . interpretLegalHoldStoreToCassandra lh
     . interpretCustomBackendStoreToCassandra
+    . randomToIO
+    . interpretSubConversationSupplyToRandom
     . interpretSubConversationStoreToCassandra
     . interpretConversationStoreToCassandra
     . interpretProposalStoreToCassandra

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -356,6 +356,10 @@ removeMLSClients groupId (Qualified usr domain) cs = retry x5 . batch $ do
   for_ cs $ \c ->
     addPrepQuery Cql.removeMLSClient (groupId, domain, usr, c)
 
+removeAllMLSClients :: GroupId -> Client ()
+removeAllMLSClients groupId = do
+  retry x5 $ write Cql.removeAllMLSClients (params LocalQuorum (Identity groupId))
+
 interpretMemberStoreToCassandra ::
   Members '[Embed IO, Input ClientState] r =>
   Sem (MemberStore ': r) a ->
@@ -380,4 +384,5 @@ interpretMemberStoreToCassandra = interpret $ \case
       removeLocalMembersFromRemoteConv rcnv uids
   AddMLSClients lcnv quid cs -> embedClient $ addMLSClients lcnv quid cs
   RemoveMLSClients lcnv quid cs -> embedClient $ removeMLSClients lcnv quid cs
+  RemoveAllMLSClients gid -> embedClient $ removeAllMLSClients gid
   LookupMLSClients lcnv -> embedClient $ lookupMLSClients lcnv

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -334,6 +334,9 @@ updateSubConvPublicGroupState = "INSERT INTO subconversation (conv_id, subconv_i
 selectSubConvPublicGroupState :: PrepQuery R (ConvId, SubConvId) (Identity (Maybe OpaquePublicGroupState))
 selectSubConvPublicGroupState = "SELECT public_group_state FROM subconversation WHERE conv_id = ? AND subconv_id = ?"
 
+deletePublicGroupState :: PrepQuery W (ConvId, SubConvId) ()
+deletePublicGroupState = "DELETE FROM subconversation WHERE conv_id = ? AND subconv_id = ?"
+
 insertGroupIdForSubConversation :: PrepQuery W (GroupId, ConvId, Domain, SubConvId) ()
 insertGroupIdForSubConversation = "INSERT INTO group_id_conv_id (group_id, conv_id, domain, subconv_id) VALUES (?, ?, ?, ?)"
 

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -334,8 +334,8 @@ updateSubConvPublicGroupState = "INSERT INTO subconversation (conv_id, subconv_i
 selectSubConvPublicGroupState :: PrepQuery R (ConvId, SubConvId) (Identity (Maybe OpaquePublicGroupState))
 selectSubConvPublicGroupState = "SELECT public_group_state FROM subconversation WHERE conv_id = ? AND subconv_id = ?"
 
-deletePublicGroupState :: PrepQuery W (ConvId, SubConvId) ()
-deletePublicGroupState = "DELETE FROM subconversation WHERE conv_id = ? AND subconv_id = ?"
+deleteGroupIdForSubconv :: PrepQuery W (Identity GroupId) ()
+deleteGroupIdForSubconv = "DELETE FROM group_id_conv_id WHERE group_id = ?"
 
 insertGroupIdForSubConversation :: PrepQuery W (GroupId, ConvId, Domain, SubConvId) ()
 insertGroupIdForSubConversation = "INSERT INTO group_id_conv_id (group_id, conv_id, domain, subconv_id) VALUES (?, ?, ?, ?)"
@@ -451,6 +451,9 @@ addMLSClient = "insert into mls_group_member_client (group_id, user_domain, user
 
 removeMLSClient :: PrepQuery W (GroupId, Domain, UserId, ClientId) ()
 removeMLSClient = "delete from mls_group_member_client where group_id = ? and user_domain = ? and user = ? and client = ?"
+
+removeAllMLSClients :: PrepQuery W (Identity GroupId) ()
+removeAllMLSClients = "DELETE FROM mls_group_member_client WHERE group_id = ?"
 
 lookupMLSClients :: PrepQuery R (Identity GroupId) (Domain, UserId, ClientId, KeyPackageRef)
 lookupMLSClients = "select user_domain, user, client, key_package_ref from mls_group_member_client where group_id = ?"

--- a/services/galley/src/Galley/Cassandra/SubConversation.hs
+++ b/services/galley/src/Galley/Cassandra/SubConversation.hs
@@ -72,6 +72,10 @@ setEpochForSubConversation :: ConvId -> SubConvId -> Epoch -> Client ()
 setEpochForSubConversation cid sconv epoch =
   retry x5 (write Cql.insertEpochForSubConversation (params LocalQuorum (epoch, cid, sconv)))
 
+deletePublicGroupState :: ConvId -> SubConvId -> Client ()
+deletePublicGroupState convId subConvId =
+  retry x5 $ write Cql.deletePublicGroupState (params LocalQuorum (convId, subConvId))
+
 interpretSubConversationStoreToCassandra ::
   Members '[Embed IO, Input ClientState] r =>
   Sem (SubConversationStore ': r) a ->
@@ -83,3 +87,4 @@ interpretSubConversationStoreToCassandra = interpret $ \case
   GetSubConversationPublicGroupState convId subConvId -> embedClient (selectSubConvPublicGroupState convId subConvId)
   SetGroupIdForSubConversation gId cid sconv -> embedClient $ setGroupIdForSubConversation gId cid sconv
   SetSubConversationEpoch cid sconv epoch -> embedClient $ setEpochForSubConversation cid sconv epoch
+  DeleteSubConversationPublicGroupState convId subConvId -> embedClient $ deletePublicGroupState convId subConvId

--- a/services/galley/src/Galley/Cassandra/SubConversation.hs
+++ b/services/galley/src/Galley/Cassandra/SubConversation.hs
@@ -72,9 +72,9 @@ setEpochForSubConversation :: ConvId -> SubConvId -> Epoch -> Client ()
 setEpochForSubConversation cid sconv epoch =
   retry x5 (write Cql.insertEpochForSubConversation (params LocalQuorum (epoch, cid, sconv)))
 
-deletePublicGroupState :: ConvId -> SubConvId -> Client ()
-deletePublicGroupState convId subConvId =
-  retry x5 $ write Cql.deletePublicGroupState (params LocalQuorum (convId, subConvId))
+deleteGroupId :: GroupId -> Client ()
+deleteGroupId groupId =
+  retry x5 $ write Cql.deleteGroupIdForSubconv (params LocalQuorum (Identity groupId))
 
 interpretSubConversationStoreToCassandra ::
   Members '[Embed IO, Input ClientState] r =>
@@ -87,4 +87,4 @@ interpretSubConversationStoreToCassandra = interpret $ \case
   GetSubConversationPublicGroupState convId subConvId -> embedClient (selectSubConvPublicGroupState convId subConvId)
   SetGroupIdForSubConversation gId cid sconv -> embedClient $ setGroupIdForSubConversation gId cid sconv
   SetSubConversationEpoch cid sconv epoch -> embedClient $ setEpochForSubConversation cid sconv epoch
-  DeleteSubConversationPublicGroupState convId subConvId -> embedClient $ deletePublicGroupState convId subConvId
+  DeleteGroupIdForSubConversation groupId -> embedClient $ deleteGroupId groupId

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -82,6 +82,7 @@ import Galley.Effects.SearchVisibilityStore
 import Galley.Effects.ServiceStore
 import Galley.Effects.SparAccess
 import Galley.Effects.SubConversationStore
+import Galley.Effects.SubConversationSupply
 import Galley.Effects.TeamFeatureStore
 import Galley.Effects.TeamMemberStore
 import Galley.Effects.TeamNotificationStore
@@ -95,6 +96,7 @@ import Polysemy.Input
 import Polysemy.TinyLog
 import Wire.API.Error
 import Wire.Sem.Paging.Cassandra
+import Wire.Sem.Random
 
 -- All the possible high-level effects.
 type GalleyEffects1 =
@@ -110,6 +112,8 @@ type GalleyEffects1 =
      ProposalStore,
      ConversationStore,
      SubConversationStore,
+     SubConversationSupply,
+     Random,
      CustomBackendStore,
      LegalHoldStore,
      MemberStore,

--- a/services/galley/src/Galley/Effects/MemberStore.hs
+++ b/services/galley/src/Galley/Effects/MemberStore.hs
@@ -40,6 +40,7 @@ module Galley.Effects.MemberStore
     setOtherMember,
     addMLSClients,
     removeMLSClients,
+    removeAllMLSClients,
     lookupMLSClients,
 
     -- * Delete members
@@ -78,6 +79,7 @@ data MemberStore m a where
   DeleteMembersInRemoteConversation :: Remote ConvId -> [UserId] -> MemberStore m ()
   AddMLSClients :: GroupId -> Qualified UserId -> Set (ClientId, KeyPackageRef) -> MemberStore m ()
   RemoveMLSClients :: GroupId -> Qualified UserId -> Set ClientId -> MemberStore m ()
+  RemoveAllMLSClients :: GroupId -> MemberStore m ()
   LookupMLSClients :: GroupId -> MemberStore m ClientMap
 
 makeSem ''MemberStore

--- a/services/galley/src/Galley/Effects/SubConversationStore.hs
+++ b/services/galley/src/Galley/Effects/SubConversationStore.hs
@@ -37,6 +37,6 @@ data SubConversationStore m a where
   GetSubConversationPublicGroupState :: ConvId -> SubConvId -> SubConversationStore m (Maybe OpaquePublicGroupState)
   SetGroupIdForSubConversation :: GroupId -> Qualified ConvId -> SubConvId -> SubConversationStore m ()
   SetSubConversationEpoch :: ConvId -> SubConvId -> Epoch -> SubConversationStore m ()
-  DeleteSubConversationPublicGroupState :: ConvId -> SubConvId -> SubConversationStore m ()
+  DeleteGroupIdForSubConversation :: GroupId -> SubConversationStore m ()
 
 makeSem ''SubConversationStore

--- a/services/galley/src/Galley/Effects/SubConversationStore.hs
+++ b/services/galley/src/Galley/Effects/SubConversationStore.hs
@@ -37,5 +37,6 @@ data SubConversationStore m a where
   GetSubConversationPublicGroupState :: ConvId -> SubConvId -> SubConversationStore m (Maybe OpaquePublicGroupState)
   SetGroupIdForSubConversation :: GroupId -> Qualified ConvId -> SubConvId -> SubConversationStore m ()
   SetSubConversationEpoch :: ConvId -> SubConvId -> Epoch -> SubConversationStore m ()
+  DeleteSubConversationPublicGroupState :: ConvId -> SubConvId -> SubConversationStore m ()
 
 makeSem ''SubConversationStore

--- a/services/galley/src/Galley/Effects/SubConversationSupply.hs
+++ b/services/galley/src/Galley/Effects/SubConversationSupply.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.SubConversationSupply where
+
+import Polysemy
+import Wire.API.MLS.Group
+
+data SubConversationSupply m a where
+  -- | Generate a fresh group ID. This is used for subconversations, but the
+  -- generator does not depend on a subconversation.
+  MakeFreshGroupId :: SubConversationSupply m GroupId
+
+makeSem ''SubConversationSupply

--- a/services/galley/src/Galley/Effects/SubConversationSupply/Random.hs
+++ b/services/galley/src/Galley/Effects/SubConversationSupply/Random.hs
@@ -1,0 +1,40 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Galley.Effects.SubConversationSupply.Random
+  ( interpretSubConversationSupplyToRandom,
+  )
+where
+
+import qualified Crypto.Hash as Crypto
+import Data.ByteArray (convert)
+import Galley.Effects.SubConversationSupply
+import Imports
+import Polysemy
+import Wire.API.MLS.Group
+import Wire.Sem.Random
+
+interpretSubConversationSupplyToRandom ::
+  Member Random r =>
+  Sem (SubConversationSupply ': r) a ->
+  Sem r a
+interpretSubConversationSupplyToRandom = interpret $ \case
+  MakeFreshGroupId -> freshGroupId
+
+freshGroupId :: Member Random r => Sem r GroupId
+freshGroupId =
+  GroupId . convert . Crypto.hash @ByteString @Crypto.SHA256 <$> bytes 100

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -204,7 +204,8 @@ tests s =
         [ test s "cannot create MLS conversations" postMLSConvDisabled,
           test s "cannot send an MLS message" postMLSMessageDisabled,
           test s "cannot send a commit bundle" postMLSBundleDisabled,
-          test s "cannot get group info" getGroupInfoDisabled
+          test s "cannot get group info" getGroupInfoDisabled,
+          test s "cannot delete a subconversation" deleteSubConversationDisabled
         ],
       testGroup
         "SubConversation"
@@ -2306,6 +2307,18 @@ getGroupInfoDisabled = do
     withMLSDisabled $
       getGroupInfo (qUnqualified alice) (fmap Conv qcnv)
         !!! assertMLSNotEnabled
+
+deleteSubConversationDisabled :: TestM ()
+deleteSubConversationDisabled = do
+  alice <- randomUser
+  cnvId <- Qualified <$> randomId <*> pure (Domain "www.example.com")
+  let scnvId = SubConvId "conference"
+      dsc =
+        DeleteSubConversation
+          (GroupId "MLS")
+          (Epoch 0)
+  withMLSDisabled $
+    deleteSubConv alice cnvId scnvId dsc !!! assertMLSNotEnabled
 
 testCreateSubConv :: Bool -> TestM ()
 testCreateSubConv parentIsMLSConv = do

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -1096,6 +1096,27 @@ getSubConv u qcnv sconv = do
         ]
       . zUser u
 
+deleteSubConv ::
+  UserId ->
+  Qualified ConvId ->
+  SubConvId ->
+  DeleteSubConversation ->
+  TestM ResponseLBS
+deleteSubConv u qcnv sconv dsc = do
+  g <- viewGalley
+  delete $
+    g
+      . paths
+        [ "conversations",
+          toByteString' (qDomain qcnv),
+          toByteString' (qUnqualified qcnv),
+          "subconversations",
+          LBS.toStrict (toLazyByteString (toEncodedUrlPiece sconv))
+        ]
+      . zUser u
+      . contentJson
+      . json dsc
+
 convsub :: Qualified ConvId -> Maybe Text -> Qualified ConvOrSubConvId
 convsub qcnv Nothing = Conv <$> qcnv
 convsub qcnv (Just subname) = flip SubConv (SubConvId subname) <$> qcnv


### PR DESCRIPTION
Per https://wearezeta.atlassian.net/browse/FS-1334, the PR introduces a DELETE endpoint for resetting a subconversation.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
