### PR TITLE
docs: remove invalid scheme from example socks5 host

### DIFF
--- a/docs/src/how-to/associate/deeplink.rst
+++ b/docs/src/how-to/associate/deeplink.rst
@@ -109,7 +109,7 @@ As of release ``2.117.0`` from ``2021-10-29`` (see `release notes<release-notes>
             accountsURL: "https://account.example.com"
             blackListURL: "https://clientblacklist.wire.com/prod"
             websiteURL: "https://wire.com"
-          apiProxy: (optional)
+          apiProxy: # (optional)
             host: "socks5.proxy.com"
             port: 1080
             needsAuthentication: true

--- a/docs/src/how-to/associate/deeplink.rst
+++ b/docs/src/how-to/associate/deeplink.rst
@@ -110,7 +110,7 @@ As of release ``2.117.0`` from ``2021-10-29`` (see `release notes<release-notes>
             blackListURL: "https://clientblacklist.wire.com/prod"
             websiteURL: "https://wire.com"
           apiProxy: (optional)
-            host: "https://socks5.proxy.com"
+            host: "socks5.proxy.com"
             port: 1080
             needsAuthentication: true
           title: "My Custom Wire Backend"
@@ -146,7 +146,7 @@ Otherwise you need to create a ``.json`` file, and host it somewhere users can g
          "websiteURL" : "https://wire.com"
       },
       "apiProxy" : {
-         "host" : "https://socks5.proxy.com",
+         "host" : "socks5.proxy.com",
          "port" : 1080,
          "needsAuthentication" : true
       },


### PR DESCRIPTION
The documentation contains a typo using the https scheme for the socks proxy configuration, this scheme is wrong and also a scheme is not necessary.