### PR TITLE
brig: Allow multiple threads to run simulaneously

### DIFF
--- a/changelog.d/5-internal/brig-multi-core
+++ b/changelog.d/5-internal/brig-multi-core
@@ -1,0 +1,1 @@
+brig: Allow multiple threads to run simulaneously

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -361,7 +361,7 @@ executable brig
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -funbox-strict-fields -threaded -with-rtsopts=-N1 -with-rtsopts=-T
+    -funbox-strict-fields -threaded -with-rtsopts=-N -with-rtsopts=-T
     -rtsopts
 
   build-depends:


### PR DESCRIPTION
`-with-rtsopts=-N1` was set very long time ago when brig started depending on http-client-openssl. It doesn't seem relevant anymore and using multiple cores should improve performance.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
