### PR TITLE
[FS-901] Update the key package reference mapping of the creator of the subconversation

### DIFF
--- a/changelog.d/5-internal/subconv-update-path
+++ b/changelog.d/5-internal/subconv-update-path
@@ -1,0 +1,1 @@
+Via the update path update the key package of the committer in epoch 0 of a subconversation

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -949,6 +949,8 @@ processInternalCommit qusr senderClient con lConvOrSub epoch action senderRef co
               unless (isClientMember (mkClientIdentity qusr creatorClient) (mcMembers parentConv)) $
                 throwS @'MLSSubConvClientNotInParent
               let creatorRef = fromMaybe senderRef updatePathRef
+              addKeyPackageRef creatorRef qusr creatorClient $
+                tUntagged (convOfConvOrSub . idForConvOrSub <$> lConvOrSub)
               addMLSClients
                 (cnvmlsGroupId mlsMeta)
                 qusr

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -2362,9 +2362,15 @@ testJoinSubConv = do
 
       resetGroup bob1 (pscGroupId sub)
 
+      bobRefsBefore <- getClientsFromGroupState bob1 bob
       -- bob adds his first client to the subconversation
       void $
         createPendingProposalCommit bob1 >>= sendAndConsumeCommitBundle
+      bobRefsAfter <- getClientsFromGroupState bob1 bob
+      liftIO $
+        assertBool
+          "Bob's key package has not been updated via the update path"
+          (bobRefsBefore /= bobRefsAfter)
 
       -- now alice joins with her own client
       void $


### PR DESCRIPTION
There is a bug in that when the first member of a subconversation is adding themselves to the subconversation, the key package reference mapping was not performed. This PR fixes that.

Tracked by https://wearezeta.atlassian.net/browse/FS-901.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
