### PR TITLE
add read-only securitycontext to brig containers and volume mounts

### DIFF
--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -52,9 +52,12 @@ spec:
         - name: geoipdownload
           image: "{{ .Values.config.geoip.image.repository }}:{{ .Values.config.geoip.image.tag }}"
           imagePullPolicy: {{ default "" .Values.config.geoip.imagePullPolicy | quote }}
+          securityContext:
+            readOnlyRootFilesystem: true
           volumeMounts:
           - name: "geoip"
             mountPath: "/usr/share/GeoIP"
+            readOnly: true
           # The environment variables are documented at:
           # https://github.com/maxmind/geoipupdate/blob/62b34e648a842dc03ccf4ad3f61e2d85eaec98fc/doc/docker.md
           env:
@@ -80,18 +83,24 @@ spec:
         - name: brig
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+          securityContext:
+            readOnlyRootFilesystem: true
           volumeMounts:
           - name: "brig-secrets"
             mountPath: "/etc/wire/brig/secrets"
+            readOnly: true
           - name: "brig-config"
             mountPath: "/etc/wire/brig/conf"
+            readOnly: true
           {{- if eq $.Values.turn.serversSource "files" }}
           - name: "turn-servers"
             mountPath: "/etc/wire/brig/turn"
+            readOnly: true
           {{- end }}
           {{- if .Values.config.geoip.enabled }}
           - name: "geoip"
             mountPath: "/usr/share/GeoIP"
+            readOnly: true
           {{- end }}
           env:
           - name: LOG_LEVEL
@@ -155,10 +164,13 @@ spec:
         {{- if .Values.config.geoip.enabled }}
         - name: geoipupdate
           image: "{{ .Values.config.geoip.image.repository }}:{{ .Values.config.geoip.image.tag }}"
+          securityContext:
+            readOnlyRootFilesystem: true
           imagePullPolicy: {{ default "" .Values.config.geoip.imagePullPolicy | quote }}
           volumeMounts:
           - name: "geoip"
             mountPath: "/usr/share/GeoIP"
+            readOnly: true
           # The environment variables are documented at:
           # https://github.com/maxmind/geoipupdate/blob/62b34e648a842dc03ccf4ad3f61e2d85eaec98fc/doc/docker.md
           env:

--- a/charts/brig/templates/tests/brig-integration.yaml
+++ b/charts/brig/templates/tests/brig-integration.yaml
@@ -54,15 +54,21 @@ spec:
     # The other test, "user.auth.cookies.limit", is skipped as it is flaky.
     # This is tracked in https://github.com/zinfra/backend-issues/issues/1150.
     command: [ "brig-integration", "--pattern", "!/turn/ && !/user.auth.cookies.limit/" ]
+    securityContext:
+      readOnlyRootFilesystem: true
     volumeMounts:
     - name: "brig-integration"
       mountPath: "/etc/wire/integration"
+      readOnly: true
     - name: "brig-config"
       mountPath: "/etc/wire/brig/conf"
+      readOnly: true
     - name: "brig-secrets"
       mountPath: "/etc/wire/brig/secrets"
+      readOnly: true
     - name: "turn-servers"
       mountPath: "/etc/wire/brig/turn"
+      readOnly: true
     - name: "brig-integration-secrets"
       # TODO: Maybe we should put integration yaml also under
       #       `/integration/conf` by default? Note that currently
@@ -70,6 +76,7 @@ spec:
       #       non-default locations
       #       (see corresp. TODO in galley.)
       mountPath: "/etc/wire/integration-secrets"
+      readOnly: true
 
     env:
     # these dummy values are necessary for Amazonka's "Discover"


### PR DESCRIPTION
## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
