### PR TITLE
[SQSERVICES-1848] Flaky test team user search query with paging state

### DIFF
--- a/changelog.d/5-internal/sqservices-1848
+++ b/changelog.d/5-internal/sqservices-1848
@@ -1,0 +1,1 @@
+Fixed flaky team user search integration test

--- a/docs/convert/shell.nix
+++ b/docs/convert/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 (pkgs.buildFHSUserEnv {
   name = "pipzone";
   targetPkgs = pkgs: (with pkgs; [

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE StrictData #-}
 
 -- This file is part of the Wire Server implementation.

--- a/services/brig/test/integration/API/Internal.hs
+++ b/services/brig/test/integration/API/Internal.hs
@@ -14,7 +14,6 @@
 --
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
-{-# LANGUAGE NumericUnderscores #-}
 
 module API.Internal
   ( tests,

--- a/services/brig/test/integration/API/TeamUserSearch.hs
+++ b/services/brig/test/integration/API/TeamUserSearch.hs
@@ -144,7 +144,7 @@ testEmptyQuerySortedWithPagination :: TestConstraints m => Brig -> m ()
 testEmptyQuerySortedWithPagination brig = do
   (tid, userId -> ownerId, _) <- createPopulatedBindingTeamWithNamesAndHandles brig 20
   refreshIndex brig
-  let teamUserSearch mPs = executeTeamUserSearchWithMaybeState brig tid ownerId (Just "") Nothing (Just SortByRole) (Just SortOrderAsc) (Just $ unsafeRange 10) mPs
+  let teamUserSearch mPs = executeTeamUserSearchWithMaybeState brig tid ownerId (Just "") Nothing Nothing Nothing (Just $ unsafeRange 10) mPs
   searchResultFirst10 <- teamUserSearch Nothing
   searchResultNext10 <- teamUserSearch (searchPagingState searchResultFirst10)
   searchResultLast1 <- teamUserSearch (searchPagingState searchResultNext10)


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQSERVICES-1848

Using the default sort specification (`created_at`)  should fix the issue, as these values are unique for this integration test.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
