### PR TITLE
extend on-new-remote-conversation by the subconv ID

### DIFF
--- a/changelog.d/6-federation/on-new-remote-subconversation
+++ b/changelog.d/6-federation/on-new-remote-subconversation
@@ -1,0 +1,4 @@
+Split federation endpoint into on-new-remote-conversation and on-new-remote-subconversation
+Call on-new-remote-subconversation when a new subconversation is created
+Call on-new-remote-subconversation for all existing subconversations when a new backend gets involved
+Call on-new-remote-subconversation when a subconversation is reset

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -220,6 +220,8 @@ ccRemoteOrigUserId cc = qualifyAs (ccCnvId cc) (ccOrigUserId cc)
 data NewRemoteConversation = NewRemoteConversation
   { -- | The conversation ID, local to the backend invoking the RPC.
     nrcConvId :: ConvId,
+    -- | The subconversation, if set.
+    nrcSubConvId :: Maybe SubConvId,
     -- | The conversation protocol.
     nrcProtocol :: Protocol
   }

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -128,7 +128,11 @@ type GalleyApi =
            EmptyResponse
     :<|> FedEndpoint "on-typing-indicator-updated" TypingDataUpdateRequest EmptyResponse
     :<|> FedEndpoint "get-sub-conversation" GetSubConversationsRequest GetSubConversationsResponse
-    :<|> FedEndpoint "delete-sub-conversation" DeleteSubConversationRequest DeleteSubConversationResponse
+    :<|> FedEndpointWithMods
+           '[MakesFederatedCall 'Galley "on-new-remote-conversation"]
+           "delete-sub-conversation"
+           DeleteSubConversationRequest
+           DeleteSubConversationResponse
 
 data TypingDataUpdateRequest = TypingDataUpdateRequest
   { tdurTypingStatus :: TypingStatus,

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -327,6 +327,7 @@ data MLSMessageSendRequest = MLSMessageSendRequest
     -- | Sender is assumed to be owned by the origin domain, this allows us to
     -- protect against spoofing attacks
     mmsrSender :: UserId,
+    mmsrSenderClient :: ClientId,
     mmsrRawMessage :: Base64ByteString
   }
   deriving stock (Eq, Show, Generic)

--- a/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
@@ -61,6 +61,34 @@ data ConversationMLSData = ConversationMLSData
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via GenericUniform ConversationMLSData
+  deriving (ToJSON, FromJSON) via Schema ConversationMLSData
+
+mlsDataSchema :: ObjectSchema SwaggerDoc ConversationMLSData
+mlsDataSchema =
+  ConversationMLSData
+    <$> cnvmlsGroupId
+      .= fieldWithDocModifier
+        "group_id"
+        (description ?~ "An MLS group identifier (at most 256 bytes long)")
+        schema
+    <*> cnvmlsEpoch
+      .= fieldWithDocModifier
+        "epoch"
+        (description ?~ "The epoch number of the corresponding MLS group")
+        schema
+    <*> cnvmlsEpochTimestamp
+      .= fieldWithDocModifier
+        "epoch_timestamp"
+        (description ?~ "The timestamp of the epoch number")
+        schemaEpochTimestamp
+    <*> cnvmlsCipherSuite
+      .= fieldWithDocModifier
+        "cipher_suite"
+        (description ?~ "The cipher suite of the corresponding MLS group")
+        schema
+
+instance ToSchema ConversationMLSData where
+  schema = object "ConversationMLSData" mlsDataSchema
 
 -- | Conversation protocol and protocol-specific data.
 data Protocol
@@ -116,27 +144,3 @@ deriving via (Schema Protocol) instance ToJSON Protocol
 protocolDataSchema :: ProtocolTag -> ObjectSchema SwaggerDoc Protocol
 protocolDataSchema ProtocolProteusTag = tag _ProtocolProteus (pure ())
 protocolDataSchema ProtocolMLSTag = tag _ProtocolMLS mlsDataSchema
-
-mlsDataSchema :: ObjectSchema SwaggerDoc ConversationMLSData
-mlsDataSchema =
-  ConversationMLSData
-    <$> cnvmlsGroupId
-      .= fieldWithDocModifier
-        "group_id"
-        (description ?~ "An MLS group identifier (at most 256 bytes long)")
-        schema
-    <*> cnvmlsEpoch
-      .= fieldWithDocModifier
-        "epoch"
-        (description ?~ "The epoch number of the corresponding MLS group")
-        schema
-    <*> cnvmlsEpochTimestamp
-      .= fieldWithDocModifier
-        "epoch_timestamp"
-        (description ?~ "The timestamp of the epoch number")
-        schemaEpochTimestamp
-    <*> cnvmlsCipherSuite
-      .= fieldWithDocModifier
-        "cipher_suite"
-        (description ?~ "The cipher suite of the corresponding MLS group")
-        schema

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -423,6 +423,7 @@ type ConversationAPI =
            "delete-subconversation"
            ( Summary "Delete an MLS subconversation"
                :> MakesFederatedCall 'Galley "delete-sub-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-conversation"
                :> CanThrow 'ConvAccessDenied
                :> CanThrow 'ConvNotFound
                :> CanThrow 'MLSNotEnabled

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -424,6 +424,7 @@ type ConversationAPI =
            ( Summary "Delete an MLS subconversation"
                :> MakesFederatedCall 'Galley "delete-sub-conversation"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow 'ConvAccessDenied
                :> CanThrow 'ConvNotFound
                :> CanThrow 'MLSNotEnabled
@@ -514,6 +515,7 @@ type ConversationAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> Until 'V2
                :> CanThrow ('ActionDenied 'AddConversationMember)
                :> CanThrow ('ActionDenied 'LeaveConversation)
@@ -538,6 +540,7 @@ type ConversationAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> Until 'V2
                :> CanThrow ('ActionDenied 'AddConversationMember)
                :> CanThrow ('ActionDenied 'LeaveConversation)
@@ -563,6 +566,7 @@ type ConversationAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> From 'V2
                :> CanThrow ('ActionDenied 'AddConversationMember)
                :> CanThrow ('ActionDenied 'LeaveConversation)
@@ -588,6 +592,7 @@ type ConversationAPI =
            ( Summary "Join a conversation by its ID (if link access enabled)"
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow 'ConvAccessDenied
                :> CanThrow 'ConvNotFound
                :> CanThrow 'InvalidOperation
@@ -610,6 +615,7 @@ type ConversationAPI =
                \Note that this is currently inconsistent (for backwards compatibility reasons) with `POST /conversations/code-check` which responds with 404 CodeNotFound if guest links are disabled."
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow 'CodeNotFound
                :> CanThrow 'ConvAccessDenied
                :> CanThrow 'ConvNotFound
@@ -740,6 +746,7 @@ type ConversationAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> Until 'V2
                :> ZLocalUser
                :> ZConn
@@ -761,6 +768,7 @@ type ConversationAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> ZLocalUser
                :> ZConn
                :> CanThrow ('ActionDenied 'RemoveConversationMember)
@@ -780,6 +788,7 @@ type ConversationAPI =
                :> Description "Use `PUT /conversations/:cnv_domain/:cnv/members/:usr_domain/:usr` instead"
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> ZLocalUser
                :> ZConn
                :> CanThrow 'ConvNotFound
@@ -804,6 +813,7 @@ type ConversationAPI =
                :> Description "**Note**: at least one field has to be provided."
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> ZLocalUser
                :> ZConn
                :> CanThrow 'ConvNotFound
@@ -830,6 +840,7 @@ type ConversationAPI =
                :> Description "Use `/conversations/:domain/:conv/name` instead."
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow ('ActionDenied 'ModifyConversationName)
                :> CanThrow 'ConvNotFound
                :> CanThrow 'InvalidOperation
@@ -850,6 +861,7 @@ type ConversationAPI =
                :> Description "Use `/conversations/:domain/:conv/name` instead."
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow ('ActionDenied 'ModifyConversationName)
                :> CanThrow 'ConvNotFound
                :> CanThrow 'InvalidOperation
@@ -870,6 +882,7 @@ type ConversationAPI =
            ( Summary "Update conversation name"
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow ('ActionDenied 'ModifyConversationName)
                :> CanThrow 'ConvNotFound
                :> CanThrow 'InvalidOperation
@@ -893,6 +906,7 @@ type ConversationAPI =
                :> Description "Use `/conversations/:domain/:cnv/message-timer` instead."
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> ZLocalUser
                :> ZConn
                :> CanThrow ('ActionDenied 'ModifyConversationMessageTimer)
@@ -914,6 +928,7 @@ type ConversationAPI =
            ( Summary "Update the message timer for a conversation"
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> ZLocalUser
                :> ZConn
                :> CanThrow ('ActionDenied 'ModifyConversationMessageTimer)
@@ -938,6 +953,7 @@ type ConversationAPI =
                :> Description "Use `PUT /conversations/:domain/:cnv/receipt-mode` instead."
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> MakesFederatedCall 'Galley "update-conversation"
                :> ZLocalUser
                :> ZConn
@@ -960,6 +976,7 @@ type ConversationAPI =
            ( Summary "Update receipt mode for a conversation"
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> MakesFederatedCall 'Galley "update-conversation"
                :> ZLocalUser
                :> ZConn
@@ -986,6 +1003,7 @@ type ConversationAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> Until 'V3
                :> Description "Use PUT `/conversations/:domain/:cnv/access` instead."
                :> ZLocalUser
@@ -1012,6 +1030,7 @@ type ConversationAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> Until 'V3
                :> ZLocalUser
                :> ZConn
@@ -1037,6 +1056,7 @@ type ConversationAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> From 'V3
                :> ZLocalUser
                :> ZConn

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
@@ -39,7 +39,8 @@ type FeatureAPI =
     :<|> FeatureStatusPut
            '[ MakesFederatedCall 'Galley "on-conversation-updated",
               MakesFederatedCall 'Galley "on-mls-message-sent",
-              MakesFederatedCall 'Galley "on-new-remote-conversation"
+              MakesFederatedCall 'Galley "on-new-remote-conversation",
+              MakesFederatedCall 'Galley "on-new-remote-subconversation"
             ]
            '( 'ActionDenied 'RemoveConversationMember,
               '( AuthenticationError,

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/LegalHold.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/LegalHold.hs
@@ -66,6 +66,7 @@ type LegalHoldAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow AuthenticationError
                :> CanThrow OperationDenied
                :> CanThrow 'NotATeamMember
@@ -105,6 +106,7 @@ type LegalHoldAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow ('ActionDenied 'RemoveConversationMember)
                :> CanThrow 'InvalidOperation
                :> CanThrow 'TeamMemberNotFound
@@ -123,6 +125,7 @@ type LegalHoldAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow ('ActionDenied 'RemoveConversationMember)
                :> CanThrow 'NotATeamMember
                :> CanThrow OperationDenied
@@ -154,6 +157,7 @@ type LegalHoldAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow AuthenticationError
                :> CanThrow ('ActionDenied 'RemoveConversationMember)
                :> CanThrow 'NotATeamMember
@@ -183,6 +187,7 @@ type LegalHoldAPI =
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow AuthenticationError
                :> CanThrow 'AccessDenied
                :> CanThrow ('ActionDenied 'RemoveConversationMember)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
@@ -54,6 +54,7 @@ type MLSMessagingAPI =
                :> MakesFederatedCall 'Galley "send-mls-message"
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> MakesFederatedCall 'Brig "get-mls-clients"
                :> Until 'V2
                :> CanThrow 'ConvAccessDenied
@@ -90,6 +91,7 @@ type MLSMessagingAPI =
                :> MakesFederatedCall 'Galley "send-mls-message"
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> MakesFederatedCall 'Brig "get-mls-clients"
                :> From 'V2
                :> CanThrow 'ConvAccessDenied
@@ -127,6 +129,7 @@ type MLSMessagingAPI =
                :> MakesFederatedCall 'Galley "send-mls-commit-bundle"
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> MakesFederatedCall 'Brig "get-mls-clients"
                :> From 'V3
                :> CanThrow 'ConvAccessDenied

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamConversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamConversation.hs
@@ -70,6 +70,7 @@ type TeamConversationAPI =
            ( Summary "Remove a team conversation"
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> MakesFederatedCall 'Galley "on-new-remote-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow ('ActionDenied 'DeleteConversation)
                :> CanThrow 'ConvNotFound
                :> CanThrow 'InvalidOperation

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -60,9 +60,12 @@ import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 import Wire.API.Event.Conversation
 import Wire.API.Internal.Notification (ntfTransient)
+import Wire.API.MLS.CommitBundle
 import Wire.API.MLS.Credential
+import Wire.API.MLS.GroupInfoBundle
 import Wire.API.MLS.KeyPackage
 import Wire.API.MLS.Serialisation
+import Wire.API.MLS.SubConversation
 import Wire.API.Message
 import Wire.API.Routes.MultiTablePaging
 import Wire.API.User hiding (assetKey)
@@ -118,7 +121,9 @@ spec _brigOpts mg brig galley cargohold cannon _federator brigTwo galleyTwo carg
         test mg "download remote asset" $ testRemoteAsset brig brigTwo cargohold cargoholdTwo,
         test mg "claim remote key packages" $ claimRemoteKeyPackages brig brigTwo,
         test mg "send an MLS message to a remote user" $
-          testSendMLSMessage brig brigTwo galley galleyTwo cannon cannonTwo
+          testSendMLSMessage brig brigTwo galley galleyTwo cannon cannonTwo,
+        test mg "send an MLS message to a federated user" $
+          testSendMLSMessageToSubConversation brig brigTwo galley galleyTwo cannon cannonTwo
       ]
 
 -- | Path covered by this test:
@@ -905,6 +910,376 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
         evtType e @?= MLSWelcome
         evtFrom e @?= userQualifiedId alice
         evtData e @?= EdMLSWelcome welcome
+
+      -- verify that alice receives a join event
+      WS.assertMatch_ (5 # Second) wsAlice $ \n -> do
+        let e = List1.head (WS.unpackPayload n)
+        evtConv e @?= qconvId
+        evtType e @?= MemberJoin
+        evtFrom e @?= userQualifiedId bob
+        fmap (sort . mMembers) (evtData e ^? _EdMembersJoin)
+          @?= Just [SimpleMember (userQualifiedId alice) roleNameWireMember]
+
+      -- verify that alice receives the dove
+      WS.assertMatch_ (5 # Second) wsAlice $ \n -> do
+        let e = List1.head (WS.unpackPayload n)
+        ntfTransient n @?= False
+        evtConv e @?= qconvId
+        evtType e @?= MLSMessageAdd
+        evtFrom e @?= userQualifiedId bob
+        evtData e @?= EdMLSMessage dove
+
+    -- send the reply and assert reception
+    WS.bracketR cannon2 (userId bob) $ \wsBob -> do
+      post
+        ( galley1
+            . paths
+              ["mls", "messages"]
+            . zUser (userId alice)
+            . zConn "conn"
+            . header "Z-Type" "access"
+            . content "message/mls"
+            . bytes reply
+        )
+        !!! const 201 === statusCode
+
+      -- verify that bob receives the reply
+      WS.assertMatch_ (5 # Second) wsBob $ \n -> do
+        let e = List1.head (WS.unpackPayload n)
+        ntfTransient n @?= False
+        evtConv e @?= qconvId
+        evtType e @?= MLSMessageAdd
+        evtFrom e @?= userQualifiedId alice
+        evtData e @?= EdMLSMessage reply
+
+-- bob creates an MLS conversation on domain 2 with alice on domain 1, then
+-- creates a subconversation, and finally sends a message to alice
+testSendMLSMessageToSubConversation :: Brig -> Brig -> Galley -> Galley -> Cannon -> Cannon -> Http ()
+testSendMLSMessageToSubConversation brig1 brig2 galley1 galley2 cannon1 cannon2 = do
+  let cli :: String -> FilePath -> [String] -> CreateProcess
+      cli store tmp args =
+        proc "mls-test-cli" $
+          ["--store", tmp </> (store <> ".db")] <> args
+
+  -- create alice user and client on domain 1
+  alice <- randomUser brig1
+  aliceClient <-
+    clientId . responseJsonUnsafe
+      <$> addClient
+        brig1
+        (userId alice)
+        (defNewClient PermanentClientType [] (Imports.head someLastPrekeys))
+  let aliceClientId =
+        show (userId alice)
+          <> ":"
+          <> T.unpack (client aliceClient)
+          <> "@"
+          <> T.unpack (domainText (qDomain (userQualifiedId alice)))
+
+  -- create bob user and client on domain 2
+  bob <- randomUser brig2
+  bobClient <-
+    clientId . responseJsonUnsafe
+      <$> addClient
+        brig2
+        (userId bob)
+        (defNewClient PermanentClientType [] (someLastPrekeys !! 1))
+  let bobClientId =
+        show (userId bob)
+          <> ":"
+          <> T.unpack (client bobClient)
+          <> "@"
+          <> T.unpack (domainText (qDomain (userQualifiedId bob)))
+
+  withSystemTempDirectory "mls" $ \tmp -> do
+    -- create alice's key package
+    void . liftIO $ spawn (cli aliceClientId tmp ["init", aliceClientId]) Nothing
+    kpMLS <- liftIO $ spawn (cli aliceClientId tmp ["key-package", "create"]) Nothing
+    aliceKP <- liftIO $ case decodeMLS' kpMLS of
+      Right kp -> pure kp
+      Left e -> assertFailure $ "Could not decode alice Key Package: " <> T.unpack e
+
+    -- set public key
+    let update =
+          defUpdateClient
+            { updateClientMLSPublicKeys =
+                Map.singleton
+                  Ed25519
+                  (bcSignatureKey (kpCredential (rmValue aliceKP)))
+            }
+    put
+      ( brig1
+          . paths ["clients", toByteString' aliceClient]
+          . zUser (qUnqualified (userQualifiedId alice))
+          . json update
+      )
+      !!! const 200 === statusCode
+
+    -- upload key package
+    post
+      ( brig1
+          . paths ["mls", "key-packages", "self", toByteString' aliceClient]
+          . zUser (qUnqualified (userQualifiedId alice))
+          . json (KeyPackageUpload [aliceKP])
+      )
+      !!! const 201 === statusCode
+
+    -- create bob's client state
+    void . liftIO $ spawn (cli bobClientId tmp ["init", bobClientId]) Nothing
+
+    connectUsersEnd2End brig1 brig2 (userQualifiedId alice) (userQualifiedId bob)
+
+    -- bob claims alice's key package
+    void $
+      post
+        ( brig2
+            . paths
+              [ "mls",
+                "key-packages",
+                "claim",
+                toByteString' (qDomain (userQualifiedId alice)),
+                toByteString' (qUnqualified (userQualifiedId alice))
+              ]
+            . zUser (qUnqualified (userQualifiedId bob))
+        )
+        <!! const 200 === statusCode
+    -- Note: we are ignoring the claimed key package here, because we have already
+    -- saved it to a file. We still need to claim because that ensures that the
+    -- backend can add the appropriate key package ref mapping.
+
+    -- create conversation on domain 2
+    conv <-
+      responseJsonError
+        =<< createMLSConversation galley2 (userId bob) bobClient
+          <!! const 201 === statusCode
+    groupId <- case cnvProtocol conv of
+      ProtocolMLS p -> pure (unGroupId (cnvmlsGroupId p))
+      ProtocolProteus -> liftIO $ assertFailure "Expected MLS conversation"
+    let qconvId = cnvQualifiedId conv
+    groupJSON <-
+      liftIO $
+        spawn
+          ( cli
+              bobClientId
+              tmp
+              [ "group",
+                "create",
+                T.unpack (toBase64Text groupId)
+              ]
+          )
+          Nothing
+    liftIO $ BS.writeFile (tmp </> "group.json") groupJSON
+
+    -- invite alice
+    liftIO $ BS.writeFile (tmp </> aliceClientId) (rmRaw aliceKP)
+    commit <-
+      liftIO $
+        spawn
+          ( cli
+              bobClientId
+              tmp
+              [ "member",
+                "add",
+                "--in-place",
+                "--group",
+                tmp </> "group.json",
+                "--welcome-out",
+                tmp </> "welcome",
+                tmp </> aliceClientId
+              ]
+          )
+          Nothing
+    welcome <- liftIO $ BS.readFile (tmp </> "welcome")
+
+    -- send welcome and commit
+    WS.bracketR cannon1 (userId alice) $ \wsAlice -> do
+      post
+        ( galley2
+            . paths
+              ["mls", "messages"]
+            . zUser (userId bob)
+            . zConn "conn"
+            . header "Z-Type" "access"
+            . content "message/mls"
+            . bytes commit
+        )
+        !!! const 201 === statusCode
+
+      post
+        ( galley2
+            . paths
+              ["mls", "welcome"]
+            . zUser (userId bob)
+            . zConn "conn"
+            . header "Z-Type" "access"
+            . content "message/mls"
+            . bytes welcome
+        )
+        !!! const 201 === statusCode
+
+      -- verify that alice receives the welcome message
+      WS.assertMatch_ (5 # Second) wsAlice $ \n -> do
+        let e = List1.head (WS.unpackPayload n)
+        ntfTransient n @?= False
+        evtType e @?= MLSWelcome
+        evtFrom e @?= userQualifiedId alice -- TODO(SB) why not bob?
+        evtData e @?= EdMLSWelcome welcome
+
+      -- verify that alice receives a join event
+      WS.assertMatch_ (5 # Second) wsAlice $ \n -> do
+        let e = List1.head (WS.unpackPayload n)
+        evtConv e @?= qconvId
+        evtType e @?= MemberJoin
+        evtFrom e @?= userQualifiedId bob
+        fmap (sort . mMembers) (evtData e ^? _EdMembersJoin)
+          @?= Just [SimpleMember (userQualifiedId alice) roleNameWireMember]
+
+    -- alice creates the group
+    void . liftIO $
+      spawn
+        ( cli
+            aliceClientId
+            tmp
+            [ "group",
+              "from-welcome",
+              "--group-out",
+              tmp </> "groupA.json",
+              tmp </> "welcome"
+            ]
+        )
+        Nothing
+
+    -- SUBCONVERSATION
+    -- create subconversation on domain 2
+    subConv <-
+      responseJsonError
+        =<< createMLSSubConversation galley2 (userId bob) qconvId (SubConvId "sub")
+          <!! const 200 === statusCode
+    subGroupId <- case cnvProtocol subConv of
+      ProtocolMLS p -> pure (unGroupId (cnvmlsGroupId p))
+      ProtocolProteus -> liftIO $ assertFailure "Expected MLS conversation"
+    subGroupJSON <-
+      liftIO $
+        spawn
+          ( cli
+              bobClientId
+              tmp
+              [ "group",
+                "create",
+                T.unpack (toBase64Text subGroupId)
+              ]
+          )
+          Nothing
+    liftIO $ BS.writeFile (tmp </> "subgroup.json") subGroupJSON
+
+    do
+      -- invite alice to subconversation
+      subCommitRaw <-
+        liftIO $
+          spawn
+            ( cli
+                bobClientId
+                tmp
+                [ "commit",
+                  "--in-place",
+                  "--group",
+                  tmp </> "subgroup.json",
+                  "--group-state-out",
+                  tmp </> "subgroupstate.mls"
+                ]
+            )
+            Nothing
+
+      -- send welcome and commit bundle
+      subGroupStateRaw <- liftIO $ BS.readFile $ tmp </> "subgroupstate.mls"
+      subGroupState <- either (liftIO . assertFailure . T.unpack) pure . decodeMLS' $ subGroupStateRaw
+      subCommit <- either (liftIO . assertFailure . T.unpack) pure . decodeMLS' $ subCommitRaw
+      let subGroupBundle = CommitBundle subCommit Nothing (GroupInfoBundle UnencryptedGroupInfo TreeFull subGroupState)
+      let subGroupBundleRaw = serializeCommitBundle subGroupBundle
+      post
+        ( galley2
+            . paths
+              ["mls", "commit-bundles"]
+            . zUser (userId bob)
+            . zClient bobClient
+            . zConn "conn"
+            . header "Z-Type" "access"
+            . content "application/x-protobuf"
+            . bytes subGroupBundleRaw
+        )
+        !!! const 201 === statusCode
+
+    do
+      -- TODO(SB) create function
+      -- alice creates the group for the subconversation
+      subCommitRaw <-
+        liftIO $
+          spawn
+            ( cli
+                aliceClientId
+                tmp
+                [ "external-commit",
+                  "--group-out",
+                  tmp </> "subgroupA.json",
+                  "--group-state-in",
+                  tmp </> "subgroupstate.mls",
+                  "--group-state-out",
+                  tmp </> "subgroupstateA.mls"
+                ]
+            )
+            Nothing
+
+      subGroupStateRaw <- liftIO $ BS.readFile $ tmp </> "subgroupstateA.mls"
+      subGroupState <- either (liftIO . assertFailure . T.unpack) pure . decodeMLS' $ subGroupStateRaw
+      subCommit <- either (liftIO . assertFailure . T.unpack) pure . decodeMLS' $ subCommitRaw
+      let subGroupBundle = CommitBundle subCommit Nothing (GroupInfoBundle UnencryptedGroupInfo TreeFull subGroupState)
+      let subGroupBundleRaw = serializeCommitBundle subGroupBundle
+      post
+        ( galley1
+            . paths
+              ["mls", "commit-bundles"]
+            . zUser (userId alice)
+            . zClient aliceClient
+            . zConn "conn"
+            . header "Z-Type" "access"
+            . content "application/x-protobuf"
+            . bytes subGroupBundleRaw
+        )
+        !!! const 201 === statusCode
+
+    -- send a message to the group
+    dove <-
+      liftIO $
+        spawn
+          ( cli
+              bobClientId
+              tmp
+              ["message", "--group", tmp </> "subgroup.json", "dove"]
+          )
+          Nothing
+
+    reply <-
+      liftIO $
+        spawn
+          ( cli
+              aliceClientId
+              tmp
+              ["message", "--group", tmp </> "subgroupA.json", "raven"]
+          )
+          Nothing
+
+    WS.bracketR cannon1 (userId alice) $ \wsAlice -> do
+      post
+        ( galley2
+            . paths
+              ["mls", "messages"]
+            . zUser (userId bob)
+            . zConn "conn"
+            . header "Z-Type" "access"
+            . content "message/mls"
+            . bytes dove
+        )
+        !!! const 201 === statusCode
 
       -- verify that alice receives a join event
       WS.assertMatch_ (5 # Second) wsAlice $ \n -> do

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -741,6 +741,7 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
       ( brig1
           . paths ["clients", toByteString' aliceClient]
           . zUser (qUnqualified (userQualifiedId alice))
+          . zClient aliceClient
           . json update
       )
       !!! const 200 === statusCode
@@ -750,6 +751,7 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
       ( brig1
           . paths ["mls", "key-packages", "self", toByteString' aliceClient]
           . zUser (qUnqualified (userQualifiedId alice))
+          . zClient aliceClient
           . json (KeyPackageUpload [aliceKP])
       )
       !!! const 201 === statusCode
@@ -784,6 +786,7 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
                 toByteString' (qUnqualified (userQualifiedId alice))
               ]
             . zUser (qUnqualified (userQualifiedId bob))
+            . zClient bobClient
         )
         <!! const 200 === statusCode
     -- Note: we are ignoring the claimed key package here, because we have already
@@ -872,6 +875,7 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
             . paths
               ["mls", "messages"]
             . zUser (userId bob)
+            . zClient bobClient
             . zConn "conn"
             . header "Z-Type" "access"
             . content "message/mls"
@@ -884,6 +888,7 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
             . paths
               ["mls", "welcome"]
             . zUser (userId bob)
+            . zClient bobClient
             . zConn "conn"
             . header "Z-Type" "access"
             . content "message/mls"
@@ -896,6 +901,7 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
             . paths
               ["mls", "messages"]
             . zUser (userId bob)
+            . zClient bobClient
             . zConn "conn"
             . header "Z-Type" "access"
             . content "message/mls"
@@ -936,6 +942,7 @@ testSendMLSMessage brig1 brig2 galley1 galley2 cannon1 cannon2 = do
             . paths
               ["mls", "messages"]
             . zUser (userId alice)
+            . zClient aliceClient
             . zConn "conn"
             . header "Z-Type" "access"
             . content "message/mls"
@@ -1020,6 +1027,7 @@ testSendMLSMessageToSubConversation brig1 brig2 galley1 galley2 cannon1 cannon2 
       ( brig1
           . paths ["mls", "key-packages", "self", toByteString' aliceClient]
           . zUser (qUnqualified (userQualifiedId alice))
+          . zClient aliceClient
           . json (KeyPackageUpload [aliceKP])
       )
       !!! const 201 === statusCode
@@ -1041,6 +1049,7 @@ testSendMLSMessageToSubConversation brig1 brig2 galley1 galley2 cannon1 cannon2 
                 toByteString' (qUnqualified (userQualifiedId alice))
               ]
             . zUser (qUnqualified (userQualifiedId bob))
+            . zClient bobClient
         )
         <!! const 200 === statusCode
     -- Note: we are ignoring the claimed key package here, because we have already
@@ -1098,6 +1107,7 @@ testSendMLSMessageToSubConversation brig1 brig2 galley1 galley2 cannon1 cannon2 
             . paths
               ["mls", "messages"]
             . zUser (userId bob)
+            . zClient bobClient
             . zConn "conn"
             . header "Z-Type" "access"
             . content "message/mls"
@@ -1110,6 +1120,7 @@ testSendMLSMessageToSubConversation brig1 brig2 galley1 galley2 cannon1 cannon2 
             . paths
               ["mls", "welcome"]
             . zUser (userId bob)
+            . zClient bobClient
             . zConn "conn"
             . header "Z-Type" "access"
             . content "message/mls"
@@ -1272,21 +1283,13 @@ testSendMLSMessageToSubConversation brig1 brig2 galley1 galley2 cannon1 cannon2 
             . paths
               ["mls", "messages"]
             . zUser (userId bob)
+            . zClient bobClient
             . zConn "conn"
             . header "Z-Type" "access"
             . content "message/mls"
             . bytes dove
         )
         !!! const 201 === statusCode
-
-      -- verify that alice receives a join event
-      WS.assertMatch_ (5 # Second) wsAlice $ \n -> do
-        let e = List1.head (WS.unpackPayload n)
-        evtConv e @?= qconvId
-        evtType e @?= MemberJoin
-        evtFrom e @?= userQualifiedId bob
-        fmap (sort . mMembers) (evtData e ^? _EdMembersJoin)
-          @?= Just [SimpleMember (userQualifiedId alice) roleNameWireMember]
 
       -- verify that alice receives the dove
       WS.assertMatch_ (5 # Second) wsAlice $ \n -> do
@@ -1304,6 +1307,7 @@ testSendMLSMessageToSubConversation brig1 brig2 galley1 galley2 cannon1 cannon2 
             . paths
               ["mls", "messages"]
             . zUser (userId alice)
+            . zClient aliceClient
             . zConn "conn"
             . header "Z-Type" "access"
             . content "message/mls"

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -122,7 +122,7 @@ spec _brigOpts mg brig galley cargohold cannon _federator brigTwo galleyTwo carg
         test mg "claim remote key packages" $ claimRemoteKeyPackages brig brigTwo,
         test mg "send an MLS message to a remote user" $
           testSendMLSMessage brig brigTwo galley galleyTwo cannon cannonTwo,
-        test mg "send an MLS message to a federated user" $
+        test mg "send an MLS subconversation message to a federated user" $
           testSendMLSMessageToSubConversation brig brigTwo galley galleyTwo cannon cannonTwo
       ]
 
@@ -1155,9 +1155,7 @@ testSendMLSMessageToSubConversation brig1 brig2 galley1 galley2 cannon1 cannon2 
       responseJsonError
         =<< createMLSSubConversation galley2 (userId bob) qconvId (SubConvId "sub")
           <!! const 200 === statusCode
-    subGroupId <- case cnvProtocol subConv of
-      ProtocolMLS p -> pure (unGroupId (cnvmlsGroupId p))
-      ProtocolProteus -> liftIO $ assertFailure "Expected MLS conversation"
+    let subGroupId = unGroupId . pscGroupId $ subConv
     subGroupJSON <-
       liftIO $
         spawn

--- a/services/brig/test/integration/Federation/Util.hs
+++ b/services/brig/test/integration/Federation/Util.hs
@@ -33,6 +33,7 @@ import Control.Monad.Trans.Except
 import Control.Retry
 import Data.Aeson (FromJSON, Value, decode, (.=))
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
 import Data.ByteString.Conversion (toByteString')
 import Data.Domain (Domain (Domain))
 import Data.Handle (fromHandle)
@@ -40,6 +41,7 @@ import Data.Id
 import qualified Data.Map.Strict as Map
 import Data.Qualified (Qualified (..))
 import Data.String.Conversions (cs)
+import qualified Data.Text as T
 import qualified Data.Text as Text
 import qualified Database.Bloodhound as ES
 import qualified Federator.MockServer as Mock
@@ -52,6 +54,7 @@ import Network.Socket
 import Network.Wai.Handler.Warp (Port)
 import Network.Wai.Test (Session)
 import qualified Network.Wai.Test as WaiTest
+import System.FilePath
 import Test.QuickCheck (Arbitrary (arbitrary), generate)
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -63,6 +66,9 @@ import Wire.API.Connection
 import Wire.API.Conversation (Conversation (cnvMembers))
 import Wire.API.Conversation.Member (OtherMember (OtherMember), cmOthers)
 import Wire.API.Conversation.Role (roleNameWireAdmin)
+import Wire.API.MLS.CommitBundle
+import Wire.API.MLS.GroupInfoBundle
+import Wire.API.MLS.Serialisation
 import Wire.API.Team.Feature (FeatureStatus (..))
 import Wire.API.User
 import Wire.API.User.Client
@@ -111,3 +117,23 @@ connectUsersEnd2End brig1 brig2 quid1 quid2 = do
     !!! const 201 === statusCode
   putConnectionQualified brig2 (qUnqualified quid2) quid1 Accepted
     !!! const 200 === statusCode
+
+sendCommitBundle :: FilePath -> FilePath -> Galley -> UserId -> ClientId -> ByteString -> Http ()
+sendCommitBundle tmp subGroupStateFn galley uid cid commit = do
+  subGroupStateRaw <- liftIO $ BS.readFile $ tmp </> subGroupStateFn
+  subGroupState <- either (liftIO . assertFailure . T.unpack) pure . decodeMLS' $ subGroupStateRaw
+  subCommit <- either (liftIO . assertFailure . T.unpack) pure . decodeMLS' $ commit
+  let subGroupBundle = CommitBundle subCommit Nothing (GroupInfoBundle UnencryptedGroupInfo TreeFull subGroupState)
+  let subGroupBundleRaw = serializeCommitBundle subGroupBundle
+  post
+    ( galley
+        . paths
+          ["mls", "commit-bundles"]
+        . zUser uid
+        . zClient cid
+        . zConn "conn"
+        . header "Z-Type" "access"
+        . content "application/x-protobuf"
+        . bytes subGroupBundleRaw
+    )
+    !!! const 201 === statusCode

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -51,7 +51,6 @@ import Data.ByteString.Builder (toLazyByteString)
 import Data.ByteString.Char8 (pack)
 import qualified Data.ByteString.Char8 as B8
 import Data.ByteString.Conversion
-import qualified Data.ByteString.Lazy as LBS
 import Data.Domain (Domain (..), domainText, mkDomain)
 import Data.Handle (Handle (..))
 import Data.Id
@@ -758,7 +757,7 @@ createMLSSubConversation galley zusr qcnv sconv =
           toByteString' (qDomain qcnv),
           toByteString' (qUnqualified qcnv),
           "subconversations",
-          LBS.toStrict (toLazyByteString (toEncodedUrlPiece sconv))
+          toHeader sconv
         ]
       . zUser zusr
 

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -51,6 +51,7 @@ import Data.ByteString.Builder (toLazyByteString)
 import Data.ByteString.Char8 (pack)
 import qualified Data.ByteString.Char8 as B8
 import Data.ByteString.Conversion
+import qualified Data.ByteString.Lazy as LBS
 import Data.Domain (Domain (..), domainText, mkDomain)
 import Data.Handle (Handle (..))
 import Data.Id
@@ -102,6 +103,7 @@ import Test.Tasty.HUnit
 import Text.Printf (printf)
 import qualified UnliftIO.Async as Async
 import Util.Options
+import Web.Internal.HttpApiData
 import Wire.API.Connection
 import Wire.API.Conversation
 import Wire.API.Conversation.Protocol
@@ -109,6 +111,7 @@ import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.Federation.API
 import Wire.API.Federation.Domain
 import Wire.API.Internal.Notification
+import Wire.API.MLS.SubConversation
 import Wire.API.Routes.MultiTablePaging
 import Wire.API.Team.Member hiding (userId)
 import Wire.API.User
@@ -740,6 +743,25 @@ createMLSConversation galley zusr c = do
       . zConn "conn"
       . json conv
 
+createMLSSubConversation ::
+  (MonadIO m, MonadHttp m) =>
+  Galley ->
+  UserId ->
+  Qualified ConvId ->
+  SubConvId ->
+  m ResponseLBS
+createMLSSubConversation galley zusr qcnv sconv =
+  get $
+    galley
+      . paths
+        [ "conversations",
+          toByteString' (qDomain qcnv),
+          toByteString' (qUnqualified qcnv),
+          "subconversations",
+          LBS.toStrict (toLazyByteString (toEncodedUrlPiece sconv))
+        ]
+      . zUser zusr
+
 createConversation :: (MonadIO m, MonadHttp m) => Galley -> UserId -> [Qualified UserId] -> m ResponseLBS
 createConversation galley zusr usersToAdd = do
   let conv =
@@ -843,6 +865,9 @@ zAuthAccess u c = header "Z-Type" "access" . zUser u . zConn c
 
 zUser :: UserId -> Request -> Request
 zUser = header "Z-User" . B8.pack . show
+
+zClient :: ClientId -> Request -> Request
+zClient = header "Z-Client" . toByteString'
 
 zConn :: ByteString -> Request -> Request
 zConn = header "Z-Connection"

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -750,6 +750,7 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
   let nrc =
         NewRemoteConversation
           { nrcConvId = convId conv,
+            nrcSubConvId = Nothing,
             nrcProtocol = convProtocol conv
           }
   E.runFederatedConcurrently_ (toList newDomains) $ \_ -> do

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -123,7 +123,7 @@ federationSitemap =
     :<|> Named @"on-client-removed" (callsFed onClientRemoved)
     :<|> Named @"on-typing-indicator-updated" onTypingIndicatorUpdated
     :<|> Named @"get-sub-conversation" getSubConversationForRemoteUser
-    :<|> Named @"delete-sub-conversation" deleteSubConversationForRemoteUser
+    :<|> Named @"delete-sub-conversation" (callsFed deleteSubConversationForRemoteUser)
 
 onClientRemoved ::
   ( Members
@@ -928,16 +928,19 @@ getSubConversationForRemoteUser domain GetSubConversationsRequest {..} =
       getLocalSubConversation qusr lconv gsreqSubConv
 
 deleteSubConversationForRemoteUser ::
-  Members
-    '[ ConversationStore,
-       Input (Local ()),
-       Input Env,
-       MemberStore,
-       Resource,
-       SubConversationStore,
-       SubConversationSupply
-     ]
-    r =>
+  ( Members
+      '[ ConversationStore,
+         FederatorAccess,
+         Input (Local ()),
+         Input Env,
+         MemberStore,
+         Resource,
+         SubConversationStore,
+         SubConversationSupply
+       ]
+      r,
+    CallsFed 'Galley "on-new-remote-conversation"
+  ) =>
   Domain ->
   DeleteSubConversationRequest ->
   Sem r DeleteSubConversationResponse

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -362,6 +362,7 @@ leaveConversation ::
          Input UTCTime,
          MemberStore,
          ProposalStore,
+         SubConversationStore,
          TinyLog
        ]
       r,
@@ -500,6 +501,7 @@ onUserDeleted ::
          Input Env,
          MemberStore,
          ProposalStore,
+         SubConversationStore,
          TinyLog
        ]
       r,
@@ -548,26 +550,27 @@ onUserDeleted origDomain udcn = do
 updateConversation ::
   forall r.
   ( Members
-      '[ BrigAccess,
+      '[ BotAccess,
+         BrigAccess,
          CodeStore,
-         BotAccess,
-         FireAndForget,
+         ConversationStore,
          Error FederationError,
+         Error InternalError,
          Error InvalidInput,
          ExternalAccess,
          FederatorAccess,
-         Error InternalError,
+         FireAndForget,
          GundeckAccess,
          Input Env,
+         Input (Local ()),
          Input Opts,
          Input UTCTime,
          LegalHoldStore,
          MemberStore,
          ProposalStore,
+         SubConversationStore,
          TeamStore,
-         TinyLog,
-         ConversationStore,
-         Input (Local ())
+         TinyLog
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -686,7 +686,13 @@ sendMLSCommitBundle remoteDomain msr =
       qConvOrSub <- E.lookupConvByGroupId (msgGroupId msg) >>= noteS @'ConvNotFound
       when (qUnqualified qConvOrSub /= F.mmsrConvOrSubId msr) $ throwS @'MLSGroupConversationMismatch
       F.MLSMessageResponseUpdates . map lcuUpdate
-        <$> postMLSCommitBundle loc (tUntagged sender) Nothing qConvOrSub Nothing bundle
+        <$> postMLSCommitBundle
+          loc
+          (tUntagged sender)
+          (Just (mmsrSenderClient msr))
+          qConvOrSub
+          Nothing
+          bundle
 
 sendMLSMessage ::
   ( Members
@@ -737,7 +743,13 @@ sendMLSMessage remoteDomain msr =
           qConvOrSub <- E.lookupConvByGroupId (msgGroupId msg) >>= noteS @'ConvNotFound
           when (qUnqualified qConvOrSub /= F.mmsrConvOrSubId msr) $ throwS @'MLSGroupConversationMismatch
           F.MLSMessageResponseUpdates . map lcuUpdate
-            <$> postMLSMessage loc (tUntagged sender) Nothing qConvOrSub Nothing raw
+            <$> postMLSMessage
+              loc
+              (tUntagged sender)
+              (Just (mmsrSenderClient msr))
+              qConvOrSub
+              Nothing
+              raw
 
 class ToGalleyRuntimeError (effs :: EffectRow) r where
   mapToGalleyError ::

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -133,7 +133,8 @@ type LegalHoldFeatureStatusChangeErrors =
 type LegalHoldFeaturesStatusChangeFederatedCalls =
   '[ MakesFederatedCall 'Galley "on-conversation-updated",
      MakesFederatedCall 'Galley "on-mls-message-sent",
-     MakesFederatedCall 'Galley "on-new-remote-conversation"
+     MakesFederatedCall 'Galley "on-new-remote-conversation",
+     MakesFederatedCall 'Galley "on-new-remote-subconversation"
    ]
 
 type IFeatureAPI =

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -222,7 +222,8 @@ removeSettingsInternalPaging ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   Local UserId ->
@@ -271,7 +272,8 @@ removeSettings ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   UserId ->
@@ -334,7 +336,8 @@ removeSettings' ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   TeamId ->
   Sem r ()
@@ -427,7 +430,8 @@ grantConsent ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   TeamId ->
@@ -479,7 +483,8 @@ requestDevice ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   Local UserId ->
@@ -564,7 +569,8 @@ approveDevice ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   TeamFeatures.FeaturePersistentConstraint db Public.LegalholdConfig =>
   Local UserId ->
@@ -645,7 +651,8 @@ disableForUser ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   TeamId ->
@@ -703,7 +710,8 @@ changeLegalholdStatus ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   TeamId ->
   Local UserId ->
@@ -824,7 +832,8 @@ handleGroupConvPolicyConflicts ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   UserLegalHoldStatus ->

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -213,6 +213,7 @@ removeSettingsInternalPaging ::
          MemberStore,
          ProposalStore,
          P.TinyLog,
+         SubConversationStore,
          TeamFeatureStore db,
          TeamMemberStore InternalPaging,
          TeamStore,
@@ -262,6 +263,7 @@ removeSettings ::
          MemberStore,
          ProposalStore,
          P.TinyLog,
+         SubConversationStore,
          TeamFeatureStore db,
          TeamMemberStore p,
          TeamStore
@@ -326,7 +328,8 @@ removeSettings' ::
          TeamMemberStore p,
          TeamStore,
          ProposalStore,
-         P.TinyLog
+         P.TinyLog,
+         SubConversationStore
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
@@ -418,6 +421,7 @@ grantConsent ::
          MemberStore,
          ProposalStore,
          P.TinyLog,
+         SubConversationStore,
          TeamStore
        ]
       r,
@@ -468,6 +472,7 @@ requestDevice ::
          MemberStore,
          ProposalStore,
          P.TinyLog,
+         SubConversationStore,
          TeamFeatureStore db,
          TeamStore
        ]
@@ -552,6 +557,7 @@ approveDevice ::
          MemberStore,
          ProposalStore,
          P.TinyLog,
+         SubConversationStore,
          TeamFeatureStore db,
          TeamStore
        ]
@@ -633,6 +639,7 @@ disableForUser ::
          MemberStore,
          ProposalStore,
          P.TinyLog,
+         SubConversationStore,
          TeamStore
        ]
       r,
@@ -690,7 +697,8 @@ changeLegalholdStatus ::
          MemberStore,
          TeamStore,
          ProposalStore,
-         P.TinyLog
+         P.TinyLog,
+         SubConversationStore
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
@@ -810,6 +818,7 @@ handleGroupConvPolicyConflicts ::
          MemberStore,
          ProposalStore,
          P.TinyLog,
+         SubConversationStore,
          TeamStore
        ]
       r,

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -1343,6 +1343,24 @@ executeProposalAction qusr con lconvOrSub action = do
   for_ (Map.assocs (paRemove action)) $ \(qtarget, clients) -> do
     removeMLSClients (cnvmlsGroupId mlsMeta) qtarget (Map.keysSet clients)
 
+  -- call `on-new-remote-conversation` on all the remote backends involved in
+  -- the main conversation
+  forOf_ _SubConv convOrSub $ \(mlsConv, subConv) -> do
+    let remoteDomains =
+          Set.fromList
+            ( map
+                (void . rmId)
+                (mcRemoteMembers mlsConv)
+            )
+    let nrc =
+          NewRemoteConversation
+            { nrcConvId = mcId mlsConv,
+              nrcSubConvId = Just . scSubConvId $ subConv,
+              nrcProtocol = ProtocolMLS (mcMLSData mlsConv)
+            }
+    runFederatedConcurrently_ (toList remoteDomains) $ \_ -> do
+      void $ fedClient @'Galley @"on-new-remote-conversation" nrc
+
   pure (addEvents <> removeEvents)
   where
     checkRemoval ::

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -1358,6 +1358,7 @@ executeProposalAction qusr con lconvOrSub action = do
   for_ (Map.assocs (paRemove action)) $ \(qtarget, clients) -> do
     removeMLSClients (cnvmlsGroupId mlsMeta) qtarget (Map.keysSet clients)
 
+  -- TODO: only do this for new subconversations (i.e. Epoch 1)
   -- call `on-new-remote-conversation` on all the remote backends involved in
   -- the main conversation
   forOf_ _SubConv convOrSub $ \(mlsConv, subConv) -> do
@@ -1371,7 +1372,7 @@ executeProposalAction qusr con lconvOrSub action = do
           NewRemoteConversation
             { nrcConvId = mcId mlsConv,
               nrcSubConvId = Just . scSubConvId $ subConv,
-              nrcProtocol = ProtocolMLS (mcMLSData mlsConv)
+              nrcProtocol = ProtocolMLS (scMLSData subConv)
             }
     runFederatedConcurrently_ (toList remoteDomains) $ \_ -> do
       void $ fedClient @'Galley @"on-new-remote-conversation" nrc

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -151,6 +151,7 @@ postMLSMessageFromLocalUserV1 ::
     CallsFed 'Galley "send-mls-message",
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Brig "get-mls-clients"
   ) =>
   Local UserId ->
@@ -196,6 +197,7 @@ postMLSMessageFromLocalUser ::
     CallsFed 'Galley "send-mls-message",
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Brig "get-mls-clients"
   ) =>
   Local UserId ->
@@ -234,6 +236,7 @@ postMLSCommitBundle ::
     CallsFed 'Galley "send-mls-commit-bundle",
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Brig "get-mls-clients"
   ) =>
   Local x ->
@@ -273,6 +276,7 @@ postMLSCommitBundleFromLocalUser ::
     CallsFed 'Galley "send-mls-commit-bundle",
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Brig "get-mls-clients"
   ) =>
   Local UserId ->
@@ -311,6 +315,7 @@ postMLSCommitBundleToLocalConv ::
     CallsFed 'Galley "mls-welcome",
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Brig "get-mls-clients"
   ) =>
   Qualified UserId ->
@@ -446,6 +451,7 @@ postMLSMessage ::
     CallsFed 'Galley "send-mls-message",
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Brig "get-mls-clients"
   ) =>
   Local x ->
@@ -541,6 +547,7 @@ postMLSMessageToLocalConv ::
     CallsFed 'Galley "on-mls-message-sent",
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Brig "get-mls-clients"
   ) =>
   Qualified UserId ->
@@ -713,6 +720,7 @@ processCommit ::
     Member SubConversationStore r,
     CallsFed 'Galley "on-mls-message-sent",
     CallsFed 'Galley "on-conversation-updated",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Galley "on-new-remote-conversation",
     CallsFed 'Brig "get-mls-clients"
   ) =>
@@ -868,6 +876,7 @@ processCommitWithAction ::
     CallsFed 'Galley "on-mls-message-sent",
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Brig "get-mls-clients"
   ) =>
   Qualified UserId ->
@@ -907,6 +916,7 @@ processInternalCommit ::
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Brig "get-mls-clients"
   ) =>
   Qualified UserId ->
@@ -1258,7 +1268,8 @@ type HasProposalActionEffects r =
     Member TinyLog r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   )
 
 executeProposalAction ::
@@ -1369,13 +1380,13 @@ executeProposalAction qusr con lconvOrSub action = do
                 (mcRemoteMembers mlsConv)
             )
     let nrc =
-          NewRemoteConversation
-            { nrcConvId = mcId mlsConv,
-              nrcSubConvId = Just . scSubConvId $ subConv,
-              nrcProtocol = ProtocolMLS (scMLSData subConv)
+          NewRemoteSubConversation
+            { nrscConvId = mcId mlsConv,
+              nrscSubConvId = scSubConvId subConv,
+              nrscMlsData = scMLSData subConv
             }
     runFederatedConcurrently_ (toList remoteDomains) $ \_ -> do
-      void $ fedClient @'Galley @"on-new-remote-conversation" nrc
+      void $ fedClient @'Galley @"on-new-remote-subconversation" nrc
 
   pure (addEvents <> removeEvents)
   where

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -1239,6 +1239,7 @@ type HasProposalActionEffects r =
     Member LegalHoldStore r,
     Member MemberStore r,
     Member ProposalStore r,
+    Member SubConversationStore r,
     Member TeamStore r,
     Member TinyLog r,
     CallsFed 'Galley "on-conversation-updated",

--- a/services/galley/src/Galley/API/MLS/SubConversation.hs
+++ b/services/galley/src/Galley/API/MLS/SubConversation.hs
@@ -41,7 +41,6 @@ import Galley.Data.Conversation.Types
 import Galley.Effects
 import Galley.Effects.FederatorAccess
 import qualified Galley.Effects.MemberStore as Eff
-import Galley.Effects.SubConversationStore (SubConversationStore)
 import qualified Galley.Effects.SubConversationStore as Eff
 import Galley.Effects.SubConversationSupply (SubConversationSupply)
 import qualified Galley.Effects.SubConversationSupply as Eff

--- a/services/galley/src/Galley/API/MLS/SubConversation.hs
+++ b/services/galley/src/Galley/API/MLS/SubConversation.hs
@@ -30,7 +30,6 @@ where
 import Control.Arrow
 import Data.Id
 import Data.Qualified
-import qualified Data.Set as Set
 import Galley.API.MLS
 import Galley.API.MLS.GroupInfo
 import Galley.API.MLS.Types
@@ -296,8 +295,8 @@ deleteLocalSubConversation qusr lcnvId scnvId dsc = do
     pure (scMLSData sconv)
 
   -- notify all backends that the subconversation has a new ID
-  let remotes = Set.fromList (map (void . rmId) (convRemoteMembers cnv))
-  Eff.runFederatedConcurrently_ (toList remotes) $ \_ -> do
+  let remotes = bucketRemote (map rmId (convRemoteMembers cnv))
+  Eff.runFederatedConcurrently_ remotes $ \_ -> do
     fedClient @'Galley @"on-new-remote-subconversation"
       NewRemoteSubConversation
         { nrscConvId = cnvId,

--- a/services/galley/src/Galley/API/MLS/SubConversation.hs
+++ b/services/galley/src/Galley/API/MLS/SubConversation.hs
@@ -236,7 +236,7 @@ deleteSubConversation ::
        ]
       r,
     CallsFed 'Galley "delete-sub-conversation",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   Qualified ConvId ->
@@ -265,7 +265,7 @@ deleteLocalSubConversation ::
          SubConversationSupply
        ]
       r,
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Qualified UserId ->
   Local ConvId ->
@@ -298,11 +298,11 @@ deleteLocalSubConversation qusr lcnvId scnvId dsc = do
   -- notify all backends that the subconversation has a new ID
   let remotes = Set.fromList (map (void . rmId) (convRemoteMembers cnv))
   Eff.runFederatedConcurrently_ (toList remotes) $ \_ -> do
-    fedClient @'Galley @"on-new-remote-conversation"
-      NewRemoteConversation
-        { nrcConvId = cnvId,
-          nrcSubConvId = Just scnvId,
-          nrcProtocol = ProtocolMLS mlsData
+    fedClient @'Galley @"on-new-remote-subconversation"
+      NewRemoteSubConversation
+        { nrscConvId = cnvId,
+          nrscSubConvId = scnvId,
+          nrscMlsData = mlsData
         }
 
 deleteRemoteSubConversation ::

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -1121,7 +1121,8 @@ deleteTeamConversation ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -1116,6 +1116,7 @@ deleteTeamConversation ::
          GundeckAccess,
          Input Env,
          Input UTCTime,
+         SubConversationStore,
          TeamStore
        ]
       r,

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -749,6 +749,7 @@ instance
              ListItems LegacyPaging ConvId,
              MemberStore,
              ProposalStore,
+             SubConversationStore,
              TeamFeatureStore db,
              TeamStore,
              TeamMemberStore InternalPaging,

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -715,7 +715,8 @@ instance GetFeatureConfig db LegalholdConfig where
 instance
   ( CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   SetFeatureConfig db LegalholdConfig
   where

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -285,6 +285,7 @@ type UpdateConversationAccessEffects =
      Input UTCTime,
      MemberStore,
      ProposalStore,
+     SubConversationStore,
      TeamStore,
      TinyLog
    ]
@@ -339,6 +340,7 @@ updateConversationReceiptMode ::
          Input Env,
          Input UTCTime,
          MemberStore,
+         SubConversationStore,
          TinyLog
        ]
       r,
@@ -419,6 +421,7 @@ updateConversationReceiptModeUnqualified ::
          Input Env,
          Input UTCTime,
          MemberStore,
+         SubConversationStore,
          TinyLog
        ]
       r,
@@ -444,7 +447,8 @@ updateConversationMessageTimer ::
          FederatorAccess,
          GundeckAccess,
          Input Env,
-         Input UTCTime
+         Input UTCTime,
+         SubConversationStore
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
@@ -482,7 +486,8 @@ updateConversationMessageTimerUnqualified ::
          FederatorAccess,
          GundeckAccess,
          Input Env,
-         Input UTCTime
+         Input UTCTime,
+         SubConversationStore
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
@@ -509,6 +514,7 @@ deleteLocalConversation ::
          GundeckAccess,
          Input Env,
          Input UTCTime,
+         SubConversationStore,
          TeamStore
        ]
       r,
@@ -718,6 +724,7 @@ joinConversationByReusableCode ::
          Input Opts,
          Input UTCTime,
          MemberStore,
+         SubConversationStore,
          TeamStore,
          TeamFeatureStore db
        ]
@@ -752,6 +759,7 @@ joinConversationById ::
          Input Opts,
          Input UTCTime,
          MemberStore,
+         SubConversationStore,
          TeamStore,
          TeamFeatureStore db
        ]
@@ -781,6 +789,7 @@ joinConversation ::
          Input Opts,
          Input UTCTime,
          MemberStore,
+         SubConversationStore,
          TeamStore,
          TeamFeatureStore db
        ]
@@ -840,6 +849,7 @@ addMembers ::
          LegalHoldStore,
          MemberStore,
          ProposalStore,
+         SubConversationStore,
          TeamStore,
          TinyLog
        ]
@@ -883,6 +893,7 @@ addMembersUnqualifiedV2 ::
          LegalHoldStore,
          MemberStore,
          ProposalStore,
+         SubConversationStore,
          TeamStore,
          TinyLog
        ]
@@ -926,6 +937,7 @@ addMembersUnqualified ::
          LegalHoldStore,
          MemberStore,
          ProposalStore,
+         SubConversationStore,
          TeamStore,
          TinyLog
        ]
@@ -1024,7 +1036,8 @@ updateOtherMemberLocalConv ::
          GundeckAccess,
          Input Env,
          Input UTCTime,
-         MemberStore
+         MemberStore,
+         SubConversationStore
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
@@ -1055,7 +1068,8 @@ updateOtherMemberUnqualified ::
          GundeckAccess,
          Input Env,
          Input UTCTime,
-         MemberStore
+         MemberStore,
+         SubConversationStore
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
@@ -1086,7 +1100,8 @@ updateOtherMember ::
          GundeckAccess,
          Input Env,
          Input UTCTime,
-         MemberStore
+         MemberStore,
+         SubConversationStore
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
@@ -1126,6 +1141,7 @@ removeMemberUnqualified ::
          Input UTCTime,
          MemberStore,
          ProposalStore,
+         SubConversationStore,
          TinyLog
        ]
       r,
@@ -1158,6 +1174,7 @@ removeMemberQualified ::
          Input UTCTime,
          MemberStore,
          ProposalStore,
+         SubConversationStore,
          TinyLog
        ]
       r,
@@ -1234,6 +1251,7 @@ removeMemberFromLocalConv ::
          Input UTCTime,
          MemberStore,
          ProposalStore,
+         SubConversationStore,
          TinyLog
        ]
       r,
@@ -1454,7 +1472,8 @@ updateConversationName ::
          FederatorAccess,
          GundeckAccess,
          Input Env,
-         Input UTCTime
+         Input UTCTime,
+         SubConversationStore
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
@@ -1484,7 +1503,8 @@ updateUnqualifiedConversationName ::
          FederatorAccess,
          GundeckAccess,
          Input Env,
-         Input UTCTime
+         Input UTCTime,
+         SubConversationStore
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
@@ -1510,7 +1530,8 @@ updateLocalConversationName ::
          FederatorAccess,
          GundeckAccess,
          Input Env,
-         Input UTCTime
+         Input UTCTime,
+         SubConversationStore
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -294,6 +294,7 @@ updateConversationAccess ::
   ( Members UpdateConversationAccessEffects r,
     CallsFed 'Galley "on-mls-message-sent",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Galley "on-conversation-updated"
   ) =>
   Local UserId ->
@@ -310,6 +311,7 @@ updateConversationAccessUnqualified ::
   ( Members UpdateConversationAccessEffects r,
     CallsFed 'Galley "on-mls-message-sent",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Galley "on-conversation-updated"
   ) =>
   Local UserId ->
@@ -346,6 +348,7 @@ updateConversationReceiptMode ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Galley "update-conversation"
   ) =>
   Local UserId ->
@@ -427,6 +430,7 @@ updateConversationReceiptModeUnqualified ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation",
     CallsFed 'Galley "update-conversation"
   ) =>
   Local UserId ->
@@ -452,7 +456,8 @@ updateConversationMessageTimer ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -491,7 +496,8 @@ updateConversationMessageTimerUnqualified ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -519,7 +525,8 @@ deleteLocalConversation ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -731,7 +738,8 @@ joinConversationByReusableCode ::
       r,
     FeaturePersistentConstraint db GuestLinksConfig,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -765,7 +773,8 @@ joinConversationById ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -795,7 +804,8 @@ joinConversation ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -856,7 +866,8 @@ addMembers ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -900,7 +911,8 @@ addMembersUnqualifiedV2 ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -944,7 +956,8 @@ addMembersUnqualified ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -1041,7 +1054,8 @@ updateOtherMemberLocalConv ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local ConvId ->
   Local UserId ->
@@ -1073,7 +1087,8 @@ updateOtherMemberUnqualified ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -1105,7 +1120,8 @@ updateOtherMember ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -1148,7 +1164,8 @@ removeMemberUnqualified ::
     CallsFed 'Galley "leave-conversation",
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -1181,7 +1198,8 @@ removeMemberQualified ::
     CallsFed 'Galley "leave-conversation",
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -1257,7 +1275,8 @@ removeMemberFromLocalConv ::
       r,
     CallsFed 'Galley "on-conversation-updated",
     CallsFed 'Galley "on-mls-message-sent",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local ConvId ->
   Local UserId ->
@@ -1477,7 +1496,8 @@ updateConversationName ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -1508,7 +1528,8 @@ updateUnqualifiedConversationName ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->
@@ -1535,7 +1556,8 @@ updateLocalConversationName ::
        ]
       r,
     CallsFed 'Galley "on-conversation-updated",
-    CallsFed 'Galley "on-new-remote-conversation"
+    CallsFed 'Galley "on-new-remote-conversation",
+    CallsFed 'Galley "on-new-remote-subconversation"
   ) =>
   Local UserId ->
   ConnId ->

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -347,6 +347,9 @@ lookupGroupIdForSubConversation = "SELECT conv_id, domain, subconv_id from group
 insertEpochForSubConversation :: PrepQuery W (Epoch, ConvId, SubConvId) ()
 insertEpochForSubConversation = "UPDATE subconversation set epoch = ? WHERE conv_id = ? AND subconv_id = ?"
 
+listSubConversations :: PrepQuery R (Identity ConvId) (SubConvId, CipherSuiteTag, Epoch, Writetime Epoch, GroupId)
+listSubConversations = "SELECT subconv_id, cipher_suite, epoch, WRITETIME(epoch), group_id FROM subconversation WHERE conv_id = ?"
+
 -- Members ------------------------------------------------------------------
 
 type MemberStatus = Int32

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -36,6 +36,7 @@ module Galley.Effects
     ClientStore,
     CodeStore,
     ConversationStore,
+    SubConversationStore,
     CustomBackendStore,
     LegalHoldStore,
     MemberStore,

--- a/services/galley/src/Galley/Effects/FederatorAccess.hs
+++ b/services/galley/src/Galley/Effects/FederatorAccess.hs
@@ -65,6 +65,6 @@ makeSem ''FederatorAccess
 runFederatedConcurrently_ ::
   (KnownComponent c, Foldable f, Functor f, Member FederatorAccess r) =>
   f (Remote a) ->
-  (Remote [a] -> FederatorClient c ()) ->
+  (Remote [a] -> FederatorClient c x) ->
   Sem r ()
 runFederatedConcurrently_ xs = void . runFederatedConcurrently xs

--- a/services/galley/src/Galley/Effects/SubConversationStore.hs
+++ b/services/galley/src/Galley/Effects/SubConversationStore.hs
@@ -24,8 +24,8 @@ import Data.Qualified
 import Galley.API.MLS.Types
 import Imports
 import Polysemy
+import Wire.API.Conversation.Protocol
 import Wire.API.MLS.CipherSuite
-import Wire.API.MLS.Epoch
 import Wire.API.MLS.Group
 import Wire.API.MLS.PublicGroupState
 import Wire.API.MLS.SubConversation
@@ -38,5 +38,6 @@ data SubConversationStore m a where
   SetGroupIdForSubConversation :: GroupId -> Qualified ConvId -> SubConvId -> SubConversationStore m ()
   SetSubConversationEpoch :: ConvId -> SubConvId -> Epoch -> SubConversationStore m ()
   DeleteGroupIdForSubConversation :: GroupId -> SubConversationStore m ()
+  ListSubConversations :: ConvId -> SubConversationStore m (Map SubConvId ConversationMLSData)
 
 makeSem ''SubConversationStore

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2954,8 +2954,10 @@ deleteRemoteMemberConvLocalQualifiedOk = do
       Left err -> assertFailure err
       Right e -> assertLeaveEvent qconvId qAlice [qChad] e
 
-  let [remote1GalleyFederatedRequest] = fedRequestsForDomain remoteDomain1 Galley federatedRequests
-      [remote2GalleyFederatedRequest] = fedRequestsForDomain remoteDomain2 Galley federatedRequests
+  remote1GalleyFederatedRequest <-
+    assertOne (filter ((== "on-conversation-updated") . frRPC) (fedRequestsForDomain remoteDomain1 Galley federatedRequests))
+  remote2GalleyFederatedRequest <-
+    assertOne (filter ((== "on-conversation-updated") . frRPC) (fedRequestsForDomain remoteDomain2 Galley federatedRequests))
   assertRemoveUpdate remote1GalleyFederatedRequest qconvId qAlice [qUnqualified qChad, qUnqualified qDee] qChad
   assertRemoveUpdate remote2GalleyFederatedRequest qconvId qAlice [qUnqualified qEve] qChad
 

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -2446,6 +2446,15 @@ testRemoteUserJoinSubConv = do
             <!! const 200 === statusCode
       liftIO $ Set.fromList (pscMembers psc') @?= Set.fromList [alice1, bob1]
 
+    -- check that on-new-remote-subconversation is not called on further commits
+    (_, reqs') <-
+      withTempMockFederator' mock $
+        createPendingProposalCommit alice1 >>= sendAndConsumeCommitBundle
+
+    liftIO $
+      assertBool "Unexpected on-new-remote-subconversation" $
+        all ((/= "on-new-remote-subconversation") . frRPC) reqs'
+
 testSendMessageSubConv :: TestM ()
 testSendMessageSubConv = do
   [alice, bob] <- createAndConnectUsers [Nothing, Nothing]

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1226,6 +1226,7 @@ testRemoteToLocal = do
           MLSMessageSendRequest
             { mmsrConvOrSubId = Conv (qUnqualified qcnv),
               mmsrSender = qUnqualified bob,
+              mmsrSenderClient = ciClient bob1,
               mmsrRawMessage = Base64ByteString (mpMessage message)
             }
 
@@ -1269,6 +1270,7 @@ testRemoteToLocalWrongConversation = do
           MLSMessageSendRequest
             { mmsrConvOrSubId = Conv randomConfId,
               mmsrSender = qUnqualified bob,
+              mmsrSenderClient = ciClient bob1,
               mmsrRawMessage = Base64ByteString (mpMessage message)
             }
 
@@ -1302,6 +1304,7 @@ testRemoteNonMemberToLocal = do
           MLSMessageSendRequest
             { mmsrConvOrSubId = Conv (qUnqualified qcnv),
               mmsrSender = qUnqualified bob,
+              mmsrSenderClient = ciClient bob1,
               mmsrRawMessage = Base64ByteString (mpMessage message)
             }
 
@@ -2041,7 +2044,14 @@ testRemoteUserPostsCommitBundle = do
         commitAddCharlie <- createAddCommit bob1 [charlie]
         commitBundle <- createBundle commitAddCharlie
 
-        let msr = MLSMessageSendRequest (Conv (qUnqualified qcnv)) (qUnqualified bob) (Base64ByteString commitBundle)
+        let msr =
+              MLSMessageSendRequest
+                { mmsrConvOrSubId = (Conv (qUnqualified qcnv)),
+                  mmsrSender = qUnqualified bob,
+                  mmsrSenderClient = ciClient bob1,
+                  mmsrRawMessage = Base64ByteString commitBundle
+                }
+
         -- we can't fully test it, because remote admins are not implemeted, but
         -- at least this proves that proposal processing has started on the
         -- backend

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -226,7 +226,7 @@ tests s =
             [ test s "get subconversation of remote conversation - member" (testGetRemoteSubConv True),
               test s "get subconversation of remote conversation - not member" (testGetRemoteSubConv False),
               test s "join remote subconversation" testJoinRemoteSubConv,
-              test s "backends and notified about subconvs when a user joins" testRemoteSubConvNotificationWhenUserJoins,
+              test s "backends are notified about subconvs when a user joins" testRemoteSubConvNotificationWhenUserJoins,
               test s "reset a subconversation - member" (testDeleteRemoteSubConv True),
               test s "reset a subconversation - not member" (testDeleteRemoteSubConv False)
             ],

--- a/services/galley/test/integration/API/MLS/Mocks.hs
+++ b/services/galley/test/integration/API/MLS/Mocks.hs
@@ -56,7 +56,11 @@ welcomeMock :: Mock LByteString
 welcomeMock = "mls-welcome" ~> MLSWelcomeSent
 
 sendMessageMock :: Mock LByteString
-sendMessageMock = "send-mls-message" ~> MLSMessageResponseUpdates []
+sendMessageMock =
+  asum
+    [ "send-mls-message" ~> MLSMessageResponseUpdates [],
+      "send-mls-commit-bundle" ~> MLSMessageResponseUpdates []
+    ]
 
 claimKeyPackagesMock :: KeyPackageBundle -> Mock LByteString
 claimKeyPackagesMock kpb = "claim-key-packages" ~> kpb

--- a/services/galley/test/integration/API/MLS/Mocks.hs
+++ b/services/galley/test/integration/API/MLS/Mocks.hs
@@ -43,6 +43,7 @@ receiveCommitMock clients =
   asum
     [ "on-conversation-updated" ~> (),
       "on-new-remote-conversation" ~> EmptyResponse,
+      "on-new-remote-subconversation" ~> EmptyResponse,
       "get-mls-clients" ~>
         Set.fromList
           ( map (flip ClientInfo True . ciClient) clients

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -1062,12 +1062,11 @@ receiveNewRemoteConv qcs gid = do
     SubConv c s -> do
       let nrc =
             NewRemoteSubConversation c s $
-              ( ConversationMLSData
-                  gid
-                  (Epoch 1)
-                  (Just (UTCTime (fromGregorian 2020 8 29) 0))
-                  MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-              )
+              ConversationMLSData
+                gid
+                (Epoch 1)
+                (Just (UTCTime (fromGregorian 2020 8 29) 0))
+                MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
       void $
         runFedClient
           @"on-new-remote-subconversation"

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -981,7 +981,7 @@ receiveNewRemoteConv ::
 receiveNewRemoteConv conv gid = do
   client <- view tsFedGalleyClient
   let nrc =
-        NewRemoteConversation (qUnqualified conv) $
+        NewRemoteConversation (qUnqualified conv) Nothing $
           ProtocolMLS
             ( ConversationMLSData
                 gid


### PR DESCRIPTION
When a subconversation is created, all backends involved in the main conversation need to be notified, so that they create a group ID → subconversation mapping. Otherwise, commits coming from clients on those backends cannot be routed.

Similarly, when a user from a new backend B joins a conversation containing non-empty subconversations, it needs to be informed of those subconversations, so that (external) commits for those subconversations coming from clients in B can be routed.

https://wearezeta.atlassian.net/browse/FS-1451

## TODO

 - [x] Split federation endpoint into `on-new-remote-conversation` and `on-new-remote-subconversation`
 - [x] Call `on-new-remote-subconversation` when a new subconversation is created
 - [x] Call `on-new-remote-subconversation` for all existing subconversations when a new backend gets involved
 - [x] Call `on-new-remote-subconversation` when a subconversation is reset
 - [x] Integration tests
 - [x] Subconversation End-to-end tests
 - [ ] (optional) Split `executeProposalAction` into one function for conversations and one for subconversations

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
