### PR TITLE
Update inbucket (fake smtp server) chart dependency

### DIFF
--- a/changelog.d/3-bug-fixes/update-inbucket-chart-dependency
+++ b/changelog.d/3-bug-fixes/update-inbucket-chart-dependency
@@ -1,0 +1,1 @@
+Update `inbucket` (fake smtp server) chart dependency: The prior version relied on an image that has been removed from docker hub. Thus, our own `inbucket` chart could not be deployed anymore.

--- a/charts/inbucket/requirements.yaml
+++ b/charts/inbucket/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: inbucket
-  version: 2.0.1
+  version: 2.1.0
   repository: https://inbucket.github.io/inbucket-community


### PR DESCRIPTION
The prior version relied on an image that has been removed from docker hub.

For details, please refer to the [corresponding PR at `inbucket`](https://github.com/inbucket/inbucket-community/pull/5).

I've tested this on my `sven-test` test environment: http://inbucket.sven-test.wire.link/m/foobar@example.com/2

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
