### PR TITLE
Chart compatibility kubernetes 1.22

### DIFF
--- a/changelog.d/0-release-notes/chart-compatibility
+++ b/changelog.d/0-release-notes/chart-compatibility
@@ -1,0 +1,1 @@
+wire-server helm charts using Ingress resources are now compatible with kubernetes versions 1.22, 1.23 and 1.24.

--- a/changelog.d/0-release-notes/chart-compatibility
+++ b/changelog.d/0-release-notes/chart-compatibility
@@ -1,1 +1,1 @@
-wire-server helm charts using Ingress resources are now compatible with kubernetes versions 1.22, 1.23 and 1.24.
+wire-server helm charts using Ingress resources are now compatible with kubernetes versions 1.22, 1.23 and 1.24 (but keep being compatible with older versions of kubernetes).

--- a/charts/elasticsearch-ephemeral/templates/_helpers.tpl
+++ b/charts/elasticsearch-ephemeral/templates/_helpers.tpl
@@ -15,13 +15,3 @@ We truncate at 53 chars (63 - len("-discovery")) because some Kubernetes name fi
 {{- printf "%s" $name | trunc 53 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/*
-Return the appropriate apiVersion for Curactor cron job.
-*/}}
-{{- define "curator.cronJob.apiVersion" -}}
-{{- if ge .Capabilities.KubeVersion.Minor "8" -}}
-"batch/v1beta1"
-{{- else -}}
-"batch/v2alpha1"
-{{- end -}}
-{{- end -}}

--- a/charts/inbucket/templates/_helpers.tpl
+++ b/charts/inbucket/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/* Allow KubeVersion to be overridden. */}}
 {{- define "kubeVersion" -}}
   {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
-{{- end -
+{{- end -}}
 
 {{/* Get Ingress API Version */}}
 {{- define "ingress.apiVersion" -}}

--- a/charts/inbucket/templates/_helpers.tpl
+++ b/charts/inbucket/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/* Allow KubeVersion to be overridden. */}}
+{{- define "kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+{{- end -
+
+{{/* Get Ingress API Version */}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" (include "kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Check Ingress stability */}}
+{{- define "ingress.isStable" -}}
+  {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/* Check Ingress supports pathType */}}
+{{/* pathType was added to networking.k8s.io/v1beta1 in Kubernetes 1.18 */}}
+{{- define "ingress.supportsPathType" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" (include "kubeVersion" .))) -}}
+{{- end -}}

--- a/charts/inbucket/templates/ingress.yaml
+++ b/charts/inbucket/templates/ingress.yaml
@@ -1,4 +1,6 @@
-apiVersion: extensions/v1beta1
+{{- $apiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: "inbucket"
@@ -14,6 +16,16 @@ spec:
       http:
         paths:
           - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
             backend:
+                {{- if $apiIsStable }}
+                service:
+                  name: {{ include "inbucket.fullname" . }}
+                  port:
+                    name: http
+                {{- else }}
                 serviceName: {{ include "inbucket.fullname" . }}
                 servicePort: http
+                {{- end }}

--- a/charts/ldap-scim-bridge/templates/_helpers.tpl
+++ b/charts/ldap-scim-bridge/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/* Allow KubeVersion to be overridden. */}}
+{{- define "kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+{{- end -
+
+{{/* Get Batch API Version */}}
+{{- define "batch.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "batch/v1") (semverCompare ">= 1.21-0" (include "kubeVersion" .)) -}}
+      {{- print "batch/v1" -}}
+  {{- else -}}
+    {{- print "batch/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/ldap-scim-bridge/templates/_helpers.tpl
+++ b/charts/ldap-scim-bridge/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/* Allow KubeVersion to be overridden. */}}
 {{- define "kubeVersion" -}}
   {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
-{{- end -
+{{- end -}}
 
 {{/* Get Batch API Version */}}
 {{- define "batch.apiVersion" -}}

--- a/charts/ldap-scim-bridge/templates/cronjob.yaml
+++ b/charts/ldap-scim-bridge/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: {{ include "batch.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}

--- a/charts/legalhold/templates/_helpers.tpl
+++ b/charts/legalhold/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/* Allow KubeVersion to be overridden. */}}
 {{- define "kubeVersion" -}}
   {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
-{{- end -
+{{- end -}}
 
 {{/* Get Ingress API Version */}}
 {{- define "ingress.apiVersion" -}}

--- a/charts/legalhold/templates/_helpers.tpl
+++ b/charts/legalhold/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/* Allow KubeVersion to be overridden. */}}
+{{- define "kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+{{- end -
+
+{{/* Get Ingress API Version */}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" (include "kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Check Ingress stability */}}
+{{- define "ingress.isStable" -}}
+  {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/* Check Ingress supports pathType */}}
+{{/* pathType was added to networking.k8s.io/v1beta1 in Kubernetes 1.18 */}}
+{{- define "ingress.supportsPathType" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" (include "kubeVersion" .))) -}}
+{{- end -}}

--- a/charts/legalhold/templates/ingress.yaml
+++ b/charts/legalhold/templates/ingress.yaml
@@ -1,4 +1,6 @@
-apiVersion: extensions/v1beta1
+{{- $apiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: hold
@@ -16,6 +18,16 @@ spec:
       http:
         paths:
           - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: "{{ .Release.Name }}-hold"
+                port:
+                  number: 8080
+              {{- else }}
               serviceName: "{{ .Release.Name }}-hold"
               servicePort: 8080
+              {{- end }}

--- a/charts/nginx-ingress-services/templates/_helpers.tpl
+++ b/charts/nginx-ingress-services/templates/_helpers.tpl
@@ -59,3 +59,30 @@ Returns the Letsencrypt API server URL based on whether testMode is enabled or d
 {{- $hostnameParts = append $hostnameParts "v02" -}}
 {{- join "-" $hostnameParts | printf "https://%s.api.letsencrypt.org/directory" -}}
 {{- end -}}
+
+{{/* Allow KubeVersion to be overridden. */}}
+{{- define "kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+{{- end -
+
+{{/* Get Ingress API Version */}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" (include "kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Check Ingress stability */}}
+{{- define "ingress.isStable" -}}
+  {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/* Check Ingress supports pathType */}}
+{{/* pathType was added to networking.k8s.io/v1beta1 in Kubernetes 1.18 */}}
+{{- define "ingress.supportsPathType" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" (include "kubeVersion" .))) -}}
+{{- end -}}

--- a/charts/nginx-ingress-services/templates/_helpers.tpl
+++ b/charts/nginx-ingress-services/templates/_helpers.tpl
@@ -63,7 +63,7 @@ Returns the Letsencrypt API server URL based on whether testMode is enabled or d
 {{/* Allow KubeVersion to be overridden. */}}
 {{- define "kubeVersion" -}}
   {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
-{{- end -
+{{- end -}}
 
 {{/* Get Ingress API Version */}}
 {{- define "ingress.apiVersion" -}}

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -1,4 +1,6 @@
-apiVersion: extensions/v1beta1
+{{- $apiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: nginx-ingress
@@ -31,51 +33,111 @@ spec:
       http:
         paths:
           - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: nginz
+                port:
+                  name: http
+              {{- else }}
               serviceName: nginz
               servicePort: http
+              {{- end }}
 {{- if .Values.websockets.enabled }}
     - host: {{ .Values.config.dns.ssl }}
       http:
         paths:
           - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: nginz
+                port:
+                  name: ws
+              {{- else }}
               serviceName: nginz
               servicePort: ws
+              {{- end }}
 {{- end }}
 {{- if .Values.webapp.enabled }}
     - host: {{ .Values.config.dns.webapp }}
       http:
         paths:
           - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: webapp-http
+                port:
+                  number: {{ .Values.service.webapp.externalPort }}
+              {{- else }}
               serviceName: webapp-http
               servicePort: {{ .Values.service.webapp.externalPort }}
+              {{- end }}
 {{- end }}
 {{- if .Values.fakeS3.enabled }}
     - host: {{ .Values.config.dns.fakeS3 }}
       http:
         paths:
           - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ .Values.service.s3.serviceName }}
+                port:
+                  number: {{ .Values.service.s3.externalPort }}
+              {{- else }}
               serviceName: {{ .Values.service.s3.serviceName }}
               servicePort: {{ .Values.service.s3.externalPort }}
+              {{- end }}
 {{- end }}
 {{- if .Values.teamSettings.enabled }}
     - host: {{ .Values.config.dns.teamSettings }}
       http:
         paths:
           - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: team-settings-http
+                port:
+                  number: {{ .Values.service.teamSettings.externalPort }}
+              {{- else }}
               serviceName: team-settings-http
               servicePort: {{ .Values.service.teamSettings.externalPort }}
+              {{- end }}
 {{- end }}
 {{- if .Values.accountPages.enabled }}
     - host: {{ .Values.config.dns.accountPages }}
       http:
         paths:
           - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: account-pages-http
+                port:
+                  number: {{ .Values.service.accountPages.externalPort }}
+              {{- else }}
               serviceName: account-pages-http
               servicePort: {{ .Values.service.accountPages.externalPort }}
+              {{- end }}
 {{- end }}

--- a/charts/nginx-ingress-services/templates/ingress_federator.yaml
+++ b/charts/nginx-ingress-services/templates/ingress_federator.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.federator.enabled }}
 # We use a separate ingress for federator so that we can require client
 # certificates only for federation requests
-apiVersion: extensions/v1beta1
+{{- $apiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: federator-ingress
@@ -24,6 +26,13 @@ spec:
       http:
         paths:
           - backend:
+              {{- if $apiIsStable }}
+              service:
+                name: federator
+                port:
+                  name: federator-ext
+              {{- else }}
               serviceName: federator
               servicePort: federator-ext # name must be below 15 chars
+              {{- end }}
 {{- end }}

--- a/charts/nginx-ingress-services/templates/ingress_federator.yaml
+++ b/charts/nginx-ingress-services/templates/ingress_federator.yaml
@@ -1,8 +1,8 @@
+{{- $apiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
 {{- if .Values.federator.enabled }}
 # We use a separate ingress for federator so that we can require client
 # certificates only for federation requests
-{{- $apiIsStable := eq (include "ingress.isStable" .) "true" -}}
-{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
 apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:

--- a/charts/sftd/templates/_helpers.tpl
+++ b/charts/sftd/templates/_helpers.tpl
@@ -58,3 +58,30 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/name: join-call
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/* Allow KubeVersion to be overridden. */}}
+{{- define "kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+{{- end -
+
+{{/* Get Ingress API Version */}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" (include "kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Check Ingress stability */}}
+{{- define "ingress.isStable" -}}
+  {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/* Check Ingress supports pathType */}}
+{{/* pathType was added to networking.k8s.io/v1beta1 in Kubernetes 1.18 */}}
+{{- define "ingress.supportsPathType" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" (include "kubeVersion" .))) -}}
+{{- end -}}

--- a/charts/sftd/templates/_helpers.tpl
+++ b/charts/sftd/templates/_helpers.tpl
@@ -62,7 +62,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/* Allow KubeVersion to be overridden. */}}
 {{- define "kubeVersion" -}}
   {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
-{{- end -
+{{- end -}}
 
 {{/* Get Ingress API Version */}}
 {{- define "ingress.apiVersion" -}}

--- a/charts/sftd/templates/ingress.yaml
+++ b/charts/sftd/templates/ingress.yaml
@@ -1,4 +1,6 @@
-apiVersion: extensions/v1beta1
+{{- $apiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: "{{ include "sftd.fullname" . }}"
@@ -18,14 +20,44 @@ spec:
       http:
         paths:
           - path: /sft/
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ include "sftd.fullname" . }}
+                port:
+                  name: sft
+              {{- else }}
               serviceName: "{{ include "sftd.fullname" . }}"
               servicePort: sft
+              {{- end }}
           - path: /sfts/
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: "{{ include "sftd.fullname" . }}-join-call"
+                port:
+                  name: http
+              {{- else }}
               serviceName: "{{ include "sftd.fullname" . }}-join-call"
               servicePort: http
+              {{- end }}
           - path: /sft_servers_all.json
+            {{- if $ingressSupportsPathType }}
+            pathType: Exact
+            {{- end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: "{{ include "sftd.fullname" . }}-join-call"
+                port:
+                  name: http
+              {{- else }}
               serviceName: "{{ include "sftd.fullname" . }}-join-call"
               servicePort: http
+              {{- end }}


### PR DESCRIPTION
Ingress compatibility k8s 1.22 and beyond
    
See https://kubernetes.io/docs/reference/using-api/deprecation-guide/ and https://www.sobyte.net/post/2021-11/helm-chart-compatible-different-kube-versio/

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
