### PR TITLE
Mock combinators

### DIFF
--- a/changelog.d/5-internal/mock-utilities
+++ b/changelog.d/5-internal/mock-utilities
@@ -1,0 +1,1 @@
+Add combinators for creating mocked federator responses in integration tests

--- a/services/federator/default.nix
+++ b/services/federator/default.nix
@@ -129,6 +129,7 @@ mkDerivation {
     time-manager
     tinylog
     tls
+    transformers
     types-common
     unix
     uri-bytestring

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -140,6 +140,7 @@ library
     , time-manager
     , tinylog
     , tls
+    , transformers
     , types-common
     , unix
     , uri-bytestring

--- a/services/federator/src/Federator/MockServer.hs
+++ b/services/federator/src/Federator/MockServer.hs
@@ -150,7 +150,7 @@ withTempMockFederator headers resp action = do
 --------------------------------------------------------------------------------
 -- Mock creation utilities
 
--- | This is monad that can be used to create mocked reponses. It is a very
+-- | This is a monad that can be used to create mocked responses. It is a very
 -- minimalistic web framework. One can expect a certain request (using
 -- 'guardRPC') and reply accordingly (using 'mockReply'). Multiple possible
 -- requests and responses can be combined using the 'Alternative' instance.  In

--- a/services/federator/src/Federator/MockServer.hs
+++ b/services/federator/src/Federator/MockServer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- This file is part of the Wire Server implementation.
@@ -18,17 +19,33 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Federator.MockServer
-  ( MockException (..),
+  ( -- * Federator mock server
+    MockException (..),
     withTempMockFederator,
     FederatedRequest (..),
+
+    -- * Mock utilities
+    Mock,
+    runMock,
+    mockReply,
+    mockFail,
+    guardRPC,
+    guardComponent,
+    (~>),
+    getRequest,
+    getRequestRPC,
+    getRequestBody,
   )
 where
 
 import qualified Control.Exception as Exception
 import Control.Exception.Base (throw)
 import Control.Monad.Catch hiding (fromException)
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Maybe
 import qualified Data.Aeson as Aeson
 import Data.Domain (Domain)
+import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LText
 import Federator.Error
 import Federator.Error.ServerError
@@ -129,3 +146,70 @@ withTempMockFederator headers resp action = do
       (\(_close, port) -> action port)
   calls <- readIORef remoteCalls
   pure (result, calls)
+
+--------------------------------------------------------------------------------
+-- Mock creation utilities
+
+-- | This is monad that can be used to create mocked reponses. It is a very
+-- minimalistic web framework. One can expect a certain request (using
+-- 'guardRPC') and reply accordingly (using 'mockReply'). Multiple possible
+-- requests and responses can be combined using the 'Alternative' instance.  In
+-- simple cases, one can also use the infix '(~>)' combinator, which concisely
+-- binds a request to a hardcoded pure response.
+newtype Mock a = Mock {unMock :: ReaderT FederatedRequest (MaybeT (ExceptT Text IO)) a}
+  deriving newtype (Functor, Applicative, Alternative, Monad, MonadIO)
+
+-- | Convert a mocked response to a function which can be used as input to
+-- 'tempMockFederator'.
+runMock :: (Text -> IO a) -> Mock a -> FederatedRequest -> IO a
+runMock err m req =
+  runExceptT (runMaybeT (runReaderT (unMock m) req)) >>= \case
+    Right Nothing -> err ("unmocked endpoint called: " <> frRPC req)
+    Right (Just x) -> pure x
+    Left e -> err e
+
+-- | Retrieve the current request.
+getRequest :: Mock FederatedRequest
+getRequest = Mock $ ReaderT pure
+
+-- | Retrieve the RPC of the current request.
+getRequestRPC :: Mock Text
+getRequestRPC = frRPC <$> getRequest
+
+-- | Retrieve and deserialise the body of the current request.
+getRequestBody :: Aeson.FromJSON a => Mock a
+getRequestBody = do
+  b <- frBody <$> getRequest
+  case Aeson.eitherDecode b of
+    Left e -> do
+      rpc <- getRequestRPC
+      mockFail ("Parse failure in " <> rpc <> ": " <> Text.pack e)
+    Right x -> pure x
+
+-- | Expect a given RPC. If the current request does not match, the whole
+-- action fails. This can be used in combination with the 'Alternative'
+-- instance to provide responses for multiple requests.
+guardRPC :: Text -> Mock ()
+guardRPC rpc = do
+  rpc' <- getRequestRPC
+  guard (rpc' == rpc)
+
+guardComponent :: Component -> Mock ()
+guardComponent c = do
+  c' <- frComponent <$> getRequest
+  guard (c == c')
+
+-- | Serialise and return a response.
+mockReply :: Aeson.ToJSON a => a -> Mock LByteString
+mockReply = pure . Aeson.encode
+
+-- | Abort the mock with an error.
+mockFail :: Text -> Mock a
+mockFail = Mock . lift . lift . throwE
+
+infixl 5 ~>
+
+-- | Expect a given RPC and simply return a pure response when the current
+-- request matches.
+(~>) :: Aeson.ToJSON a => Text -> a -> Mock LByteString
+(~>) rpc x = guardRPC rpc *> mockReply x

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -375,6 +375,7 @@ executable galley-integration
     API.Federation.Util
     API.MessageTimer
     API.MLS
+    API.MLS.Mocks
     API.MLS.Util
     API.Roles
     API.SQS

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -664,7 +664,7 @@ leaveConversationSuccess = do
 
   (_, federatedRequests) <-
     WS.bracketR2 c alice bob $ \(wsAlice, wsBob) -> do
-      withTempMockFederator' mock $ do
+      withTempMockFederator' (mock <|> mockReply ()) $ do
         g <- viewGalley
         let leaveRequest = FedGalley.LeaveConversationRequest convId (qUnqualified qChad)
         respBS <-

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -838,10 +838,7 @@ sendMessage = do
   connectWithRemoteUser aliceId bob
   connectWithRemoteUser aliceId chad
   -- conversation
-  let responses1 = do
-        comp <- frComponent <$> getRequest
-        guard (comp == Brig)
-        mockReply [bobProfile, chadProfile]
+  let responses1 = guardComponent Brig *> mockReply [bobProfile, chadProfile]
   (convId, requests1) <-
     withTempMockFederator' (responses1 <|> mockReply ()) $
       fmap decodeConvId $
@@ -875,8 +872,7 @@ sendMessage = do
             FedGalley.pmsrRawMessage = Base64ByteString (Protolens.encodeMessage msg)
           }
   let mock = do
-        comp <- frComponent <$> getRequest
-        guard (comp == Brig)
+        guardComponent Brig
         mockReply $
           Map.fromList
             [ (chadId, Set.singleton (PubClient chadClient Nothing)),

--- a/services/galley/test/integration/API/MLS/Mocks.hs
+++ b/services/galley/test/integration/API/MLS/Mocks.hs
@@ -1,0 +1,71 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module API.MLS.Mocks
+  ( receiveCommitMock,
+    messageSentMock,
+    welcomeMock,
+    sendMessageMock,
+    claimKeyPackagesMock,
+    queryGroupStateMock,
+  )
+where
+
+import Data.Id
+import Data.Json.Util
+import Data.Qualified
+import qualified Data.Set as Set
+import Federator.MockServer
+import Imports
+import Wire.API.Error.Galley
+import Wire.API.Federation.API.Common
+import Wire.API.Federation.API.Galley
+import Wire.API.MLS.Credential
+import Wire.API.MLS.KeyPackage
+import Wire.API.User.Client
+
+receiveCommitMock :: [ClientIdentity] -> Mock LByteString
+receiveCommitMock clients =
+  asum
+    [ "on-conversation-updated" ~> (),
+      "on-new-remote-conversation" ~> EmptyResponse,
+      "get-mls-clients" ~>
+        Set.fromList
+          ( map (flip ClientInfo True . ciClient) clients
+          )
+    ]
+
+messageSentMock :: Mock LByteString
+messageSentMock = "on-mls-message-sent" ~> RemoteMLSMessageOk
+
+welcomeMock :: Mock LByteString
+welcomeMock = "mls-welcome" ~> MLSWelcomeSent
+
+sendMessageMock :: Mock LByteString
+sendMessageMock = "send-mls-message" ~> MLSMessageResponseUpdates []
+
+claimKeyPackagesMock :: KeyPackageBundle -> Mock LByteString
+claimKeyPackagesMock kpb = "claim-key-packages" ~> kpb
+
+queryGroupStateMock :: ByteString -> Qualified UserId -> Mock LByteString
+queryGroupStateMock gs qusr = do
+  guardRPC "query-group-info"
+  uid <- ggireqSender <$> getRequestBody
+  mockReply $
+    if uid == qUnqualified qusr
+      then GetGroupInfoResponseState (Base64ByteString gs)
+      else GetGroupInfoResponseError ConvNotFound

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -32,7 +32,7 @@ import qualified Data.List1 as List1
 import Data.Misc
 import Data.Qualified
 import Data.Singletons
-import Federator.MockServer (FederatedRequest (..))
+import Federator.MockServer
 import Imports hiding (head)
 import Network.Wai.Utilities.Error
 import Test.Tasty
@@ -156,7 +156,7 @@ messageTimerChangeWithRemotes = do
 
   WS.bracketR c bob $ \wsB -> do
     (_, requests) <-
-      withTempMockFederator (const ()) $
+      withTempMockFederator' (mockReply ()) $
         putMessageTimerUpdateQualified bob qconv (ConversationMessageTimerUpdate timer1sec)
           !!! const 200 === statusCode
 

--- a/services/galley/test/integration/API/Roles.hs
+++ b/services/galley/test/integration/API/Roles.hs
@@ -30,7 +30,7 @@ import qualified Data.List1 as List1
 import Data.Qualified
 import qualified Data.Set as Set
 import Data.Singletons
-import Federator.MockServer (FederatedRequest (..))
+import Federator.MockServer
 import Imports
 import Network.Wai.Utilities.Error
 import Test.Tasty
@@ -175,7 +175,7 @@ roleUpdateRemoteMember = do
 
   WS.bracketR c bob $ \wsB -> do
     (_, requests) <-
-      withTempMockFederator (const ()) $
+      withTempMockFederator' (mockReply ()) $
         putOtherMemberQualified
           bob
           qcharlie
@@ -244,7 +244,7 @@ roleUpdateWithRemotes = do
 
   WS.bracketR2 c bob charlie $ \(wsB, wsC) -> do
     (_, requests) <-
-      withTempMockFederator (const ()) $
+      withTempMockFederator' (mockReply ()) $
         putOtherMemberQualified
           bob
           qcharlie
@@ -303,7 +303,7 @@ accessUpdateWithRemotes = do
   let access = ConversationAccessData (Set.singleton CodeAccess) (Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole, GuestAccessRole, ServiceAccessRole])
   WS.bracketR2 c bob charlie $ \(wsB, wsC) -> do
     (_, requests) <-
-      withTempMockFederator (const ()) $
+      withTempMockFederator' (mockReply ()) $
         putQualifiedAccessUpdate bob qconv access
           !!! const 200 === statusCode
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2746,8 +2746,7 @@ checkTimeout = 3 # Second
 -- responses by Brig on the mocked side of federation.
 mockedFederatedBrigResponse :: [(Qualified UserId, Text)] -> Mock LByteString
 mockedFederatedBrigResponse users = do
-  comp <- frComponent <$> getRequest
-  guard (comp == Brig)
+  guardComponent Brig
   mockReply [mkProfile mem (Name name) | (mem, name) <- users]
 
 fedRequestsForDomain :: HasCallStack => Domain -> Component -> [FederatedRequest] -> [FederatedRequest]


### PR DESCRIPTION
This PR introduces a very simple system for specifying federation mocks in a composable way. This replaces previous attempts (in Galley) that were only adopted in a few tests. All instances of mocked federator are now using the new system.

The system itself is a super-minimalistic "web framework" of sorts, based on a `ReaderT FederatedRequest MaybeT` monad transformer. You use `guard` to expect a certain request, and the `Alternative` combinators to specify multiple responses based on various criteria.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
