### PR TITLE
add kind-logs Makefile target for end2end tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -500,6 +500,14 @@ kind-restart-%: .local/kind-kubeconfig
 	kubectl delete pod -n $(NAMESPACE) -l app=$(*) && \
 	kubectl delete pod -n $(NAMESPACE)-fed2 -l app=$(*)
 
+.PHONY: kind-logs
+kind-logs-%:
+	export KUBECONFIG=$(CURDIR)/.local/kind-kubeconfig && \
+	echo "-- fed 1" && \
+	kubectl logs -n $(NAMESPACE) -l app=$(*) && \
+	echo "-- fed 2" && \
+	kubectl logs -n $(NAMESPACE)-fed2 -l app=$(*)
+
 # This target can be used to template a helm chart with values filled in from
 # hack/helm_vars (what CI uses) as overrrides, if available. This allows debugging helm
 # templating issues without actually installing anything, and without needing

--- a/changelog.d/5-internal/kind-log
+++ b/changelog.d/5-internal/kind-log
@@ -1,0 +1,1 @@
+Add kind-logs-<name> Makefile target to inspect service logs after running end2end tests.

--- a/docs/src/developer/developer/how-to.md
+++ b/docs/src/developer/developer/how-to.md
@@ -123,6 +123,7 @@ FUTUREWORK: this process is in development (update this section after it's confi
 2. Install wire-server using `make kind-integration-setup`.
 3. Run tests using `make kind-integration-test`.
 4. Run end2end integration tests: `make kind-integration-e2e`.
+5. Check service logs: `make kind-logs-<name>`.
 
 
 


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
