### PR TITLE
Servantify /teams/notifications

### DIFF
--- a/changelog.d/5-internal/servantify-teams-notifications
+++ b/changelog.d/5-internal/servantify-teams-notifications
@@ -1,0 +1,1 @@
+Migrate `/teams/notifications` to use the Servant library.

--- a/libs/wire-api/src/Wire/API/Error/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Error/Galley.hs
@@ -117,6 +117,8 @@ data GalleyError
   | UserLegalHoldNotPending
   | -- Team Member errors
     BulkGetMemberLimitExceeded
+  | -- Team Notification errors
+    InvalidTeamNotificationId
   deriving (Show, Eq, Generic)
   deriving (FromJSON, ToJSON) via (CustomEncoded GalleyError)
 
@@ -177,6 +179,8 @@ type instance MapError 'InvalidTarget = 'StaticError 403 "invalid-op" "Invalid t
 type instance MapError 'ConvNotFound = 'StaticError 404 "no-conversation" "Conversation not found"
 
 type instance MapError 'ConvAccessDenied = 'StaticError 403 "access-denied" "Conversation access denied"
+
+type instance MapError 'InvalidTeamNotificationId = 'StaticError 400 "invalid-notification-id" "Could not parse notification id (must be UUIDv1)."
 
 type instance
   MapError 'MLSNotEnabled =

--- a/libs/wire-api/src/Wire/API/Notification.hs
+++ b/libs/wire-api/src/Wire/API/Notification.hs
@@ -75,7 +75,9 @@ modelEvent = Doc.defineModel "NotificationEvent" $ do
   Doc.property "type" Doc.string' $
     Doc.description "Event type"
 
--- | A schema for an arbitrary JSON object.
+-- | Schema for an `Event` object.
+--
+-- This is basically a schema for a JSON object with some pre-defined structure.
 eventSchema :: ValueSchema NamedSwaggerDoc Event
 eventSchema = mkSchema sdoc Aeson.parseJSON (Just . Aeson.toJSON)
   where

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley.hs
@@ -35,6 +35,7 @@ import Wire.API.Routes.Public.Galley.Messaging
 import Wire.API.Routes.Public.Galley.Team
 import Wire.API.Routes.Public.Galley.TeamConversation
 import Wire.API.Routes.Public.Galley.TeamMember
+import Wire.API.Routes.Public.Galley.TeamNotification (TeamNotificationAPI)
 
 type ServantAPI =
   ConversationAPI
@@ -47,6 +48,7 @@ type ServantAPI =
     :<|> CustomBackendAPI
     :<|> LegalHoldAPI
     :<|> TeamMemberAPI
+    :<|> TeamNotificationAPI
 
 swaggerDoc :: Swagger.Swagger
 swaggerDoc = toSwagger (Proxy @ServantAPI)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamNotification.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamNotification.hs
@@ -1,0 +1,25 @@
+module Wire.API.Routes.Public.Galley.TeamNotification where
+
+import Servant
+import Wire.API.Routes.Public
+import Wire.API.Routes.Named
+import Imports
+import Wire.API.Notification
+import Data.Range
+import Wire.API.Error
+import Wire.API.Error.Galley
+
+type TeamNotificationAPI =
+  Named
+    "get-team-notifications"
+    ( "team"
+        :> "notifications"
+        :> ZUser
+        :> CanThrow 'TeamNotFound
+        :> CanThrow 'InvalidTeamNotificationId
+        -- :> CanThrow InvalidInput
+        -- TODO: Ensure/check this is a V1 UUID
+        :> QueryParam "since" NotificationId
+        :> QueryParam "size" (Range 1 10000 Int32)
+        :> Get '[Servant.JSON] QueuedNotificationList
+    )

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamNotification.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamNotification.hs
@@ -19,8 +19,6 @@ type TeamNotificationAPI =
         :> ZUser
         :> CanThrow 'TeamNotFound
         :> CanThrow 'InvalidTeamNotificationId
-        -- :> CanThrow InvalidInput
-        -- TODO: Ensure/check this is a V1 UUID
         :> QueryParam'
              [ Optional,
                Strict,

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamNotification.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamNotification.hs
@@ -44,7 +44,7 @@ type GetTeamNotificationsDescription =
   \\n\
   \- If there is a gap between the notification id requested with `since` and the \
   \available data, team queues respond with 200 and the data that could be found. \
-  \The do NOT respond with status 404, but valid data in the body.\
+  \They do NOT respond with status 404, but valid data in the body.\
   \\n\
   \- The notification with the id given via `since` is included in the \
   \response if it exists.  You should remove this and only use it to decide whether \

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamNotification.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamNotification.hs
@@ -1,25 +1,62 @@
 module Wire.API.Routes.Public.Galley.TeamNotification where
 
-import Servant
-import Wire.API.Routes.Public
-import Wire.API.Routes.Named
-import Imports
-import Wire.API.Notification
 import Data.Range
+import Imports
+import Servant
 import Wire.API.Error
 import Wire.API.Error.Galley
+import Wire.API.Notification
+import Wire.API.Routes.Named
+import Wire.API.Routes.Public
 
 type TeamNotificationAPI =
   Named
     "get-team-notifications"
-    ( "team"
+    ( Summary "Read recently added team members from team queue"
+        :> Description GetTeamNotificationsDescription
+        :> "teams"
         :> "notifications"
         :> ZUser
         :> CanThrow 'TeamNotFound
         :> CanThrow 'InvalidTeamNotificationId
         -- :> CanThrow InvalidInput
         -- TODO: Ensure/check this is a V1 UUID
-        :> QueryParam "since" NotificationId
-        :> QueryParam "size" (Range 1 10000 Int32)
+        :> QueryParam'
+             [ Optional,
+               Strict,
+               Description "Notification id to start with in the response (UUIDv1)"
+             ]
+             "since"
+             NotificationId
+        :> QueryParam'
+             [ Optional,
+               Strict,
+               Description "Maximum number of events to return (1..10000; default: 1000)"
+             ]
+             "size"
+             (Range 1 10000 Int32)
         :> Get '[Servant.JSON] QueuedNotificationList
     )
+
+type GetTeamNotificationsDescription =
+  "This is a work-around for scalability issues with gundeck user event fan-out. \
+  \It does not track all team-wide events, but only `member-join`.\
+  \\n\
+  \Note that `/teams/notifications` behaves different from `/notifications`:\
+  \\n\
+  \- If there is a gap between the notification id requested with `since` and the \
+  \available data, team queues respond with 200 and the data that could be found. \
+  \The do NOT respond with status 404, but valid data in the body.\
+  \\n\
+  \- The notification with the id given via `since` is included in the \
+  \response if it exists.  You should remove this and only use it to decide whether \
+  \there was a gap between your last request and this one.\
+  \\n\
+  \- If the notification id does *not* exist, you get the more recent events from the queue \
+  \(instead of all of them).  This can be done because a notification id is a UUIDv1, which \
+  \is essentially a time stamp.\
+  \\n\
+  \- There is no corresponding `/last` end-point to get only the most recent event. \
+  \That end-point was only useful to avoid having to pull the entire queue.  In team \
+  \queues, if you have never requested the queue before and \
+  \have no prior notification id, just pull with timestamp 'now'."

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamNotification.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/TeamNotification.hs
@@ -40,7 +40,7 @@ type GetTeamNotificationsDescription =
   "This is a work-around for scalability issues with gundeck user event fan-out. \
   \It does not track all team-wide events, but only `member-join`.\
   \\n\
-  \Note that `/teams/notifications` behaves different from `/notifications`:\
+  \Note that `/teams/notifications` behaves differently from `/notifications`:\
   \\n\
   \- If there is a gap between the notification id requested with `since` and the \
   \available data, team queues respond with 200 and the data that could be found. \

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -104,6 +104,7 @@ library
     Wire.API.Routes.Public.Galley.Team
     Wire.API.Routes.Public.Galley.TeamConversation
     Wire.API.Routes.Public.Galley.TeamMember
+    Wire.API.Routes.Public.Galley.TeamNotification
     Wire.API.Routes.Public.Gundeck
     Wire.API.Routes.Public.Proxy
     Wire.API.Routes.Public.Spar

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -54,6 +54,7 @@ library
     Galley.API.Public.Team
     Galley.API.Public.TeamConversation
     Galley.API.Public.TeamMember
+    Galley.API.Public.TeamNotification
     Galley.API.Push
     Galley.API.Query
     Galley.API.Teams

--- a/services/galley/src/Galley/API/Error.hs
+++ b/services/galley/src/Galley/API/Error.hs
@@ -62,14 +62,12 @@ data InvalidInput
   | InvalidRange LText
   | InvalidUUID4
   | InvalidPayload LText
-  | InvalidTeamNotificationId
 
 instance APIError InvalidInput where
   toWai CustomRolesNotSupported = badRequest "Custom roles not supported"
   toWai (InvalidRange t) = invalidRange t
   toWai InvalidUUID4 = invalidUUID4
   toWai (InvalidPayload t) = invalidPayload t
-  toWai InvalidTeamNotificationId = invalidTeamNotificationId
 
 ----------------------------------------------------------------------------
 -- Other errors

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -105,45 +105,45 @@ continueE h = continue (interpretServerEffects @ErrorEffects . h)
 
 sitemap :: Routes ApiBuilder (Sem GalleyEffects) ()
 sitemap = do
---  get "/teams/notifications" (continueE Teams.getTeamNotificationsH) $
---    zauthUserId
---      .&. opt (query "since")
---      .&. def (unsafeRange 1000) (query "size")
---      .&. accept "application" "json"
---  document "GET" "getTeamNotifications" $ do
---    summary "Read recently added team members from team queue"
---    notes
---      "This is a work-around for scalability issues with gundeck user event fan-out. \
---      \It does not track all team-wide events, but only `member-join`.\
---      \\n\
---      \Note that `/teams/notifications` behaves different from `/notifications`:\
---      \\n\
---      \- If there is a gap between the notification id requested with `since` and the \
---      \available data, team queues respond with 200 and the data that could be found. \
---      \The do NOT respond with status 404, but valid data in the body.\
---      \\n\
---      \- The notification with the id given via `since` is included in the \
---      \response if it exists.  You should remove this and only use it to decide whether \
---      \there was a gap between your last request and this one.\
---      \\n\
---      \- If the notification id does *not* exist, you get the more recent events from the queue \
---      \(instead of all of them).  This can be done because a notification id is a UUIDv1, which \
---      \is essentially a time stamp.\
---      \\n\
---      \- There is no corresponding `/last` end-point to get only the most recent event. \
---      \That end-point was only useful to avoid having to pull the entire queue.  In team \
---      \queues, if you have never requested the queue before and \
---      \have no prior notification id, just pull with timestamp 'now'."
---    parameter Query "since" bytes' $ do
---      optional
---      description "Notification id to start with in the response (UUIDv1)"
---    parameter Query "size" (int32 (Swagger.def 1000)) $ do
---      optional
---      description "Maximum number of events to return (1..10000; default: 1000)"
---    returns (ref Public.modelNotificationList)
---    response 200 "List of team notifications" end
---    errorSResponse @'TeamNotFound
---    errorResponse Error.invalidTeamNotificationId
+  --  get "/teams/notifications" (continueE Teams.getTeamNotificationsH) $
+  --    zauthUserId
+  --      .&. opt (query "since")
+  --      .&. def (unsafeRange 1000) (query "size")
+  --      .&. accept "application" "json"
+  --  document "GET" "getTeamNotifications" $ do
+  --    summary "Read recently added team members from team queue"
+  --    notes
+  --      "This is a work-around for scalability issues with gundeck user event fan-out. \
+  --      \It does not track all team-wide events, but only `member-join`.\
+  --      \\n\
+  --      \Note that `/teams/notifications` behaves different from `/notifications`:\
+  --      \\n\
+  --      \- If there is a gap between the notification id requested with `since` and the \
+  --      \available data, team queues respond with 200 and the data that could be found. \
+  --      \The do NOT respond with status 404, but valid data in the body.\
+  --      \\n\
+  --      \- The notification with the id given via `since` is included in the \
+  --      \response if it exists.  You should remove this and only use it to decide whether \
+  --      \there was a gap between your last request and this one.\
+  --      \\n\
+  --      \- If the notification id does *not* exist, you get the more recent events from the queue \
+  --      \(instead of all of them).  This can be done because a notification id is a UUIDv1, which \
+  --      \is essentially a time stamp.\
+  --      \\n\
+  --      \- There is no corresponding `/last` end-point to get only the most recent event. \
+  --      \That end-point was only useful to avoid having to pull the entire queue.  In team \
+  --      \queues, if you have never requested the queue before and \
+  --      \have no prior notification id, just pull with timestamp 'now'."
+  --    parameter Query "since" bytes' $ do
+  --      optional
+  --      description "Notification id to start with in the response (UUIDv1)"
+  --    parameter Query "size" (int32 (Swagger.def 1000)) $ do
+  --      optional
+  --      description "Maximum number of events to return (1..10000; default: 1000)"
+  --    returns (ref Public.modelNotificationList)
+  --    response 200 "List of team notifications" end
+  --    errorSResponse @'TeamNotFound
+  --    errorResponse Error.invalidTeamNotificationId
 
   -- Bot API ------------------------------------------------------------
 

--- a/services/galley/src/Galley/API/Public.hs
+++ b/services/galley/src/Galley/API/Public.hs
@@ -105,46 +105,6 @@ continueE h = continue (interpretServerEffects @ErrorEffects . h)
 
 sitemap :: Routes ApiBuilder (Sem GalleyEffects) ()
 sitemap = do
-  --  get "/teams/notifications" (continueE Teams.getTeamNotificationsH) $
-  --    zauthUserId
-  --      .&. opt (query "since")
-  --      .&. def (unsafeRange 1000) (query "size")
-  --      .&. accept "application" "json"
-  --  document "GET" "getTeamNotifications" $ do
-  --    summary "Read recently added team members from team queue"
-  --    notes
-  --      "This is a work-around for scalability issues with gundeck user event fan-out. \
-  --      \It does not track all team-wide events, but only `member-join`.\
-  --      \\n\
-  --      \Note that `/teams/notifications` behaves different from `/notifications`:\
-  --      \\n\
-  --      \- If there is a gap between the notification id requested with `since` and the \
-  --      \available data, team queues respond with 200 and the data that could be found. \
-  --      \The do NOT respond with status 404, but valid data in the body.\
-  --      \\n\
-  --      \- The notification with the id given via `since` is included in the \
-  --      \response if it exists.  You should remove this and only use it to decide whether \
-  --      \there was a gap between your last request and this one.\
-  --      \\n\
-  --      \- If the notification id does *not* exist, you get the more recent events from the queue \
-  --      \(instead of all of them).  This can be done because a notification id is a UUIDv1, which \
-  --      \is essentially a time stamp.\
-  --      \\n\
-  --      \- There is no corresponding `/last` end-point to get only the most recent event. \
-  --      \That end-point was only useful to avoid having to pull the entire queue.  In team \
-  --      \queues, if you have never requested the queue before and \
-  --      \have no prior notification id, just pull with timestamp 'now'."
-  --    parameter Query "since" bytes' $ do
-  --      optional
-  --      description "Notification id to start with in the response (UUIDv1)"
-  --    parameter Query "size" (int32 (Swagger.def 1000)) $ do
-  --      optional
-  --      description "Maximum number of events to return (1..10000; default: 1000)"
-  --    returns (ref Public.modelNotificationList)
-  --    response 200 "List of team notifications" end
-  --    errorSResponse @'TeamNotFound
-  --    errorResponse Error.invalidTeamNotificationId
-
   -- Bot API ------------------------------------------------------------
 
   get "/bot/conversation" (continueE (getBotConversationH @Cassandra)) $

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -30,6 +30,7 @@ import Galley.API.Public.TeamMember
 import Galley.App
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley
+import Galley.API.Public.TeamNotification
 
 servantSitemap :: API ServantAPI GalleyEffects
 servantSitemap =
@@ -43,3 +44,4 @@ servantSitemap =
     <@> customBackendAPI
     <@> legalHoldAPI
     <@> teamMemberAPI
+    <@> teamNotificationAPI

--- a/services/galley/src/Galley/API/Public/Servant.hs
+++ b/services/galley/src/Galley/API/Public/Servant.hs
@@ -27,10 +27,10 @@ import Galley.API.Public.Messaging
 import Galley.API.Public.Team
 import Galley.API.Public.TeamConversation
 import Galley.API.Public.TeamMember
+import Galley.API.Public.TeamNotification
 import Galley.App
 import Wire.API.Routes.API
 import Wire.API.Routes.Public.Galley
-import Galley.API.Public.TeamNotification
 
 servantSitemap :: API ServantAPI GalleyEffects
 servantSitemap =

--- a/services/galley/src/Galley/API/Public/TeamNotification.hs
+++ b/services/galley/src/Galley/API/Public/TeamNotification.hs
@@ -1,0 +1,52 @@
+module Galley.API.Public.TeamNotification where
+
+import Data.Id
+import Data.Range
+import qualified Data.UUID.Util as UUID
+import qualified Galley.API.Teams.Notifications as APITeamQueue
+import Galley.App
+import Galley.Effects
+import Imports
+import Polysemy
+import Wire.API.Error
+import Wire.API.Error.Galley
+import Wire.API.Internal.Notification
+import Wire.API.Routes.API
+import Wire.API.Routes.Public.Galley.TeamNotification
+
+teamNotificationAPI :: API TeamNotificationAPI GalleyEffects
+teamNotificationAPI =
+  mkNamedAPI @"get-team-notifications" getTeamNotifications
+
+type SizeRange = Range 1 10000 Int32
+
+-- | See also: 'Gundeck.API.Public.paginateH', but the semantics of this end-point is slightly
+-- less warped.  This is a work-around because we cannot send events to all of a large team.
+-- See haddocks of module "Galley.API.TeamNotifications" for details.
+getTeamNotifications ::
+  Members '[BrigAccess,
+            ErrorS 'TeamNotFound,
+            ErrorS 'InvalidTeamNotificationId,
+            TeamNotificationStore] r =>
+  UserId ->
+  Maybe NotificationId ->
+  Maybe SizeRange ->
+  Sem r QueuedNotificationList
+getTeamNotifications uid since size = do
+  since' <- checkSince since
+  APITeamQueue.getTeamNotifications
+    uid
+    since'
+    (fromMaybe defaultSize size)
+  where
+    checkSince ::
+      Member (ErrorS 'InvalidTeamNotificationId) r =>
+      Maybe NotificationId ->
+      Sem r (Maybe NotificationId)
+    checkSince Nothing = pure Nothing
+    checkSince (Just nid) | (UUID.version . toUUID) nid == 1 =
+                            (pure . Just) nid
+    checkSince (Just _) = throwS @'InvalidTeamNotificationId
+
+    defaultSize :: SizeRange
+    defaultSize = unsafeRange 1000

--- a/services/galley/src/Galley/API/Public/TeamNotification.hs
+++ b/services/galley/src/Galley/API/Public/TeamNotification.hs
@@ -24,10 +24,13 @@ type SizeRange = Range 1 10000 Int32
 -- less warped.  This is a work-around because we cannot send events to all of a large team.
 -- See haddocks of module "Galley.API.TeamNotifications" for details.
 getTeamNotifications ::
-  Members '[BrigAccess,
-            ErrorS 'TeamNotFound,
-            ErrorS 'InvalidTeamNotificationId,
-            TeamNotificationStore] r =>
+  Members
+    '[ BrigAccess,
+       ErrorS 'TeamNotFound,
+       ErrorS 'InvalidTeamNotificationId,
+       TeamNotificationStore
+     ]
+    r =>
   UserId ->
   Maybe NotificationId ->
   Maybe SizeRange ->
@@ -44,8 +47,9 @@ getTeamNotifications uid since size = do
       Maybe NotificationId ->
       Sem r (Maybe NotificationId)
     checkSince Nothing = pure Nothing
-    checkSince (Just nid) | (UUID.version . toUUID) nid == 1 =
-                            (pure . Just) nid
+    checkSince (Just nid)
+      | (UUID.version . toUUID) nid == 1 =
+          (pure . Just) nid
     checkSince (Just _) = throwS @'InvalidTeamNotificationId
 
     defaultSize :: SizeRange

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -30,7 +30,6 @@ module Galley.API.Teams
     deleteTeam,
     uncheckedDeleteTeam,
     addTeamMember,
-    getTeamNotificationsH,
     getTeamConversationRoles,
     getTeamMembers,
     getTeamMembersCSV,
@@ -83,8 +82,6 @@ import Data.Qualified
 import Data.Range as Range
 import qualified Data.Set as Set
 import Data.Time.Clock (UTCTime)
-import qualified Data.UUID as UUID
-import qualified Data.UUID.Util as UUID
 import Galley.API.Error as Galley
 import Galley.API.LegalHold
 import qualified Galley.API.Teams.Notifications as APITeamQueue
@@ -116,7 +113,6 @@ import Galley.Types.Teams.Intra
 import Galley.Types.UserList
 import Imports hiding (forkIO)
 import Network.Wai
-import Network.Wai.Predicate hiding (Error, or, result, setStatus)
 import Network.Wai.Utilities hiding (Error)
 import Polysemy
 import Polysemy.Error
@@ -135,7 +131,6 @@ import Wire.API.Event.Team
 import Wire.API.Federation.API
 import Wire.API.Federation.Error
 import qualified Wire.API.Message as Conv
-import qualified Wire.API.Notification as Public
 import Wire.API.Routes.MultiTablePaging (MultiTablePage (MultiTablePage), MultiTablePagingState (mtpsState))
 import Wire.API.Routes.Public.Galley.TeamMember
 import Wire.API.Team
@@ -1333,40 +1328,6 @@ addTeamMemberInternal tid origin originConn (ntmNewTeamMember -> new) memList = 
       list1
         (userRecipient (n ^. userId))
         (membersToRecipients Nothing (memList ^. teamMembers))
-
--- | See also: 'Gundeck.API.Public.paginateH', but the semantics of this end-point is slightly
--- less warped.  This is a work-around because we cannot send events to all of a large team.
--- See haddocks of module "Galley.API.TeamNotifications" for details.
-getTeamNotificationsH ::
-  Members
-    '[ BrigAccess,
-       ErrorS 'TeamNotFound,
-       Error InvalidInput,
-       TeamNotificationStore
-     ]
-    r =>
-  UserId
-    ::: Maybe ByteString {- NotificationId -}
-    ::: Range 1 10000 Int32
-    ::: JSON ->
-  Sem r Response
-getTeamNotificationsH (zusr ::: sinceRaw ::: size ::: _) = do
-  since <- parseSince
-  json @Public.QueuedNotificationList
-    <$> APITeamQueue.getTeamNotifications zusr since size
-  where
-    parseSince :: Member (Error InvalidInput) r => Sem r (Maybe Public.NotificationId)
-    parseSince = maybe (pure Nothing) (fmap Just . parseUUID) sinceRaw
-
-    parseUUID :: Member (Error InvalidInput) r => ByteString -> Sem r Public.NotificationId
-    parseUUID raw =
-      maybe
-        (throw InvalidTeamNotificationId)
-        (pure . Id)
-        ((UUID.fromASCIIBytes >=> isV1UUID) raw)
-
-    isV1UUID :: UUID.UUID -> Maybe UUID.UUID
-    isV1UUID u = if UUID.version u == 1 then Just u else Nothing
 
 finishCreateTeam ::
   Members '[GundeckAccess, Input UTCTime, TeamStore] r =>


### PR DESCRIPTION
I left the old Swagger `Doc` models untouched. But, I migrated the existing Swagger fields as good as possible. Removing old Swagger from our code base (including related `Doc` models) will be the next step.


[**Ticket**](https://wearezeta.atlassian.net/browse/SQPIT-1479)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
