### PR TITLE
Github Workflow: dont use environment for secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   treefmt:
    name: Run treefmt
-   environment: cachix # for secrets
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
@@ -25,7 +24,6 @@ jobs:
 
   build-docs:
     name: Build docs
-    environment: cachix
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
This should solve all these "temporarily deployed to cachix" messages in PR
