### PR TITLE
charts/galley/configmap: remove duplicate feature flag searchVisibilityInbound

### DIFF
--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -111,10 +111,6 @@ data:
         conversationGuestLinks:
           {{- toYaml .settings.featureFlags.conversationGuestLinks | nindent 10 }}
         {{- end }}
-        {{- if .settings.featureFlags.searchVisibilityInbound }}
-        searchVisibilityInbound:
-          {{- toYaml .settings.featureFlags.searchVisibilityInbound | nindent 10 }}
-        {{- end }}
         {{- if .settings.featureFlags.mls }}
         mls:
           {{- toYaml .settings.featureFlags.mls | nindent 10 }}


### PR DESCRIPTION
Flag configuration already exists in [LOCs L90-L93](https://github.com/wireapp/wire-server/blob/develop/charts/galley/templates/configmap.yaml#L90-L93). Accidentally introduced in https://github.com/wireapp/wire-server/pull/2494.