### PR TITLE
fixup to federator ingress helm chart syntax from the changes in #3002

### DIFF
--- a/changelog.d/3-bug-fixes/ingress-fixup-3034
+++ b/changelog.d/3-bug-fixes/ingress-fixup-3034
@@ -1,0 +1,1 @@
+Fix a bug in the helm chart's nginx-ingress-services / federator Ingress resource introduced in the last release.

--- a/charts/nginx-ingress-services/templates/ingress_federator.yaml
+++ b/charts/nginx-ingress-services/templates/ingress_federator.yaml
@@ -25,7 +25,11 @@ spec:
     - host: {{ .Values.config.dns.federator }}
       http:
         paths:
-          - backend:
+          - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
+            backend:
               {{- if $apiIsStable }}
               service:
                 name: federator


### PR DESCRIPTION
Fixup to #3002 - at least since that PR was merged develop->mls branch, federator's ingress does not deploy properly on the federation environments anymore [concourse logs](https://concourse.ops.zinfra.io/teams/main/pipelines/federation-staging/jobs/deploy-bella/builds/620).

this may fix the problem. Should I make this PR to mls branch? Or to develop, then do a develop->mls merge?

I did not test this fix, just applied the same syntax as in the other working ingress resources.