### PR TITLE
Streamline team feature ExposeInvitationURLsToTeamAdminConfig implementation

### DIFF
--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -135,7 +135,8 @@ import Wire.Arbitrary (Arbitrary, GenericUniform (..))
 --
 -- 5. Implement 'GetFeatureConfig' and 'SetFeatureConfig' in
 -- Galley.API.Teams.Features which defines the main business logic for getting
--- and setting (with side-effects).
+-- and setting (with side-effects). Note that we don't have to check the lockstatus inside 'setConfigForTeam'
+-- because the lockstatus is checked in 'setFeatureStatus' before which is the public API for setting the feature status.
 --
 -- 6. Add public routes to Routes.Public.Galley: 'FeatureStatusGet',
 -- 'FeatureStatusPut' (optional) and by by user: 'FeatureConfigGet'. Then

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -675,8 +675,6 @@ instance GetFeatureConfig db ValidateSAMLEmailsConfig where
 instance SetFeatureConfig db ValidateSAMLEmailsConfig where
   setConfigForTeam tid wsnl = persistAndPushEvent @db tid wsnl
 
--- FUTUREWORK: we may also want to get a default from the server config file here, like for
--- sso, and team search visibility.
 instance GetFeatureConfig db DigitalSignaturesConfig
 
 instance SetFeatureConfig db DigitalSignaturesConfig where


### PR DESCRIPTION
Changed the code a little that was introduced by https://github.com/wireapp/wire-server/pull/2684 to streamline the feature flag implementation.

## Checklist

 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
