### PR TITLE
Fix flaky test, add debugging to others

### DIFF
--- a/services/brig/test/integration/API/Federation.hs
+++ b/services/brig/test/integration/API/Federation.hs
@@ -40,6 +40,7 @@ import Data.Timeout
 import qualified Data.UUID.V4 as UUIDv4
 import Federation.Util (generateClientPrekeys)
 import Imports
+import qualified Network.Wai.Test as WaiTest
 import Test.QuickCheck hiding ((===))
 import Test.Tasty
 import qualified Test.Tasty.Cannon as WS
@@ -196,7 +197,8 @@ testSearchRestrictions opts brig = do
                  Opt.FederationDomainConfig domainFullSearch FullSearch
                ]
 
-  let expectSearch domain squery expectedUsers expectedSearchPolicy = do
+  let expectSearch :: HasCallStack => Domain -> Text -> [Qualified UserId] -> FederatedUserSearchPolicy -> WaiTest.Session ()
+      expectSearch domain squery expectedUsers expectedSearchPolicy = do
         searchResponse <-
           runWaiTestFedClient domain $
             createWaiTestFedClient @"search-users" @'Brig (SearchRequest squery)

--- a/services/brig/test/integration/API/MLS.hs
+++ b/services/brig/test/integration/API/MLS.hs
@@ -84,7 +84,7 @@ testKeyPackageZeroCount brig = do
 testKeyPackageExpired :: Brig -> Http ()
 testKeyPackageExpired brig = do
   u <- userQualifiedId <$> randomUser brig
-  let lifetime = 2 # Second
+  let lifetime = 3 # Second
   [c1, c2] <- for [(0, Just lifetime), (1, Nothing)] $ \(i, lt) -> do
     c <- createClient brig u i
     -- upload 1 key package for each client
@@ -95,7 +95,7 @@ testKeyPackageExpired brig = do
     count <- getKeyPackageCount brig u cid
     liftIO $ count @?= expectedCount
   -- wait for c1's key package to expire
-  threadDelay (fromIntegral ((lifetime + 3 # Second) #> MicroSecond))
+  threadDelay (fromIntegral ((lifetime + 4 # Second) #> MicroSecond))
 
   -- c1's key package has expired by now
   for_ [(c1, 0), (c2, 1)] $ \(cid, expectedCount) -> do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2741,7 +2741,7 @@ checkConvMemberLeaveEvent cid usr w = WS.assertMatch_ checkTimeout w $ \notif ->
     other -> assertFailure $ "Unexpected event data: " <> show other
 
 checkTimeout :: WS.Timeout
-checkTimeout = 3 # Second
+checkTimeout = 4 # Second
 
 -- | The function is used in conjuction with 'withTempMockFederator' to mock
 -- responses by Brig on the mocked side of federation.


### PR DESCRIPTION
This PR hopefully fixes this flaky test

https://wearezeta.atlassian.net/browse/BE-589

and maybe

https://wearezeta.atlassian.net/browse/BE-590

For https://wearezeta.atlassian.net/browse/BE-591 it adds callstack with the hopes of seing where it goes wrong.
