### PR TITLE
[FS-1075] Extend the Swagger documentation for federation error types

### DIFF
--- a/changelog.d/4-docs/federation-error-type
+++ b/changelog.d/4-docs/federation-error-type
@@ -1,0 +1,1 @@
+Extend the docs on the federation error type

--- a/services/brig/docs/swagger.md
+++ b/services/brig/docs/swagger.md
@@ -37,6 +37,7 @@ For errors that are more likely to be transient, we suggest clients to retry wha
 
 **Note**: when a failure occurs as a result of making a federated RPC to another backend, the error response contains the following extra fields:
 
+ - `type`: "federation" (just the literal string in quotes, which can be used as an error type identifier when parsing errors)
  - `domain`: the target backend of the RPC that failed;
  - `path`: the path of the RPC that failed.
 


### PR DESCRIPTION
This is a tiny update to the Swagger documentation so client developers know how to easily tell one federation error type from another (i.e., whether to blame the local or a remote backend for the error).

Tracked by https://wearezeta.atlassian.net/browse/FS-1075.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
