### PR TITLE
websocket ping-pong

### DIFF
--- a/services/cannon/src/Cannon/App.hs
+++ b/services/cannon/src/Cannon/App.hs
@@ -141,7 +141,7 @@ readLoop ws s = do
         ControlMessage (Ping p) -> do
           adjustPingFreq p
           reset counter s 0
-          Log.debug l $ Log.msg $ Log.val "control level ping received"
+          Log.debug l $ Log.msg (Log.val "control level ping received") . Log.field "incoming ping" p . Log.field "outgoing answer" (show $ pong p)
           send (connection ws) (pong p)
           loop l
         ControlMessage (Close _ _) -> pure ()

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -856,7 +856,6 @@ testDataPingPong = do
 testControlPingPongWithData :: TestM ()
 testControlPingPongWithData = do
   ca <- view tsCannon
-  logger <- view tsLogger
   uid :: UserId <- randomId
   connid :: ConnId <- randomConnId
   [(_, [(chread, chPingWrite)] :: [(TChan WS.Message, TChan ByteString)])] <-
@@ -864,10 +863,10 @@ testControlPingPongWithData = do
   liftIO $ do
     let pingPayload = "pi 3e4ac0590d55a24af7298b po"
     atomically $ writeTChan chPingWrite pingPayload
-    msg <- waitForMessageRaw chread -- this is a server-sent ping; we'll ignore this
-    msg2 <- waitForMessageRaw chread
+    _msg <- waitForMessageRaw chread -- this is a server-sent ping; we'll ignore this
+    msg <- waitForMessageRaw chread
     let expected = Just (WS.ControlMessage $ WS.Pong $ fromStrict pingPayload)
-    assertBool "no pong with the same payload" $ msg2 == expected
+    assertBool "no pong with the same payload" $ msg == expected
 
 testNoPingNoPong :: TestM ()
 testNoPingNoPong = do

--- a/services/gundeck/test/integration/API.hs
+++ b/services/gundeck/test/integration/API.hs
@@ -116,7 +116,7 @@ tests s =
         ],
       testGroup
         "Websocket pingpong"
-        [ test s "data-level pings produce pongs" testPingPong,
+        [ test s "data-level pings produce pongs" testDataPingPong,
           test s "control pings with payload produce pongs with the same payload" testControlPingPongWithData,
           test s "data pings with payload produce pongs with the same payload" testPingPongWithData,
           test s "data non-pings are ignored" testNoPingNoPong
@@ -842,8 +842,8 @@ testUnregisterPushToken = do
   void $ retryWhileN 12 (not . null) (listPushTokens uid)
   unregisterPushToken uid (tkn ^. token) !!! const 404 === statusCode
 
-testPingPong :: TestM ()
-testPingPong = do
+testDataPingPong :: TestM ()
+testDataPingPong = do
   ca <- view tsCannon
   uid :: UserId <- randomId
   connid :: ConnId <- randomConnId
@@ -894,9 +894,10 @@ testPingPongWithData = do
     connectUsersAndDevicesWithSendingClients ca [(uid, [connid])]
   liftIO $ do
     let pingPayload = "ping 3e4ac0590d55a24af7298b ping"
+    let pongPayload = "pong 3e4ac0590d55a24af7298b ping"
     atomically $ writeTChan chwrite pingPayload
     msg <- waitForMessage chread
-    assertBool "no pong with the same payload" $ msg == Just pingPayload
+    assertBool "no pong with the same payload" $ msg == Just pongPayload
 
 testNoPingNoPong :: TestM ()
 testNoPingNoPong = do


### PR DESCRIPTION
* introduces an integration test / regression test to check that control-level pings with a payload result in a control-level pong with the same payload as specified in the [RFC](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2)

This is about debugging https://wearezeta.atlassian.net/browse/FS-1489

(related ping-pong prior work: https://github.com/wireapp/wire-server/pull/561 and prior discussion: https://github.com/wireapp/wire-server/issues/560)