### PR TITLE
spar tests deflake: do an ES refresh, not reindex

### DIFF
--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -736,9 +736,7 @@ testCreateUserNoIdP = do
 -- | ES is only refreshed occasionally; we don't want to wait for that in tests.
 refreshIndex :: BrigReq -> TestSpar ()
 refreshIndex brig = do
-  call $ void $ post (brig . path "/i/index/reindex" . expect2xx)
-  -- wait for async reindexing to complete (hopefully)
-  lift $ threadDelay 3_000_000
+  call $ void $ post (brig . path "/i/index/refresh" . expect2xx)
 
 testCreateUserNoIdPNoEmail :: TestSpar ()
 testCreateUserNoIdPNoEmail = do


### PR DESCRIPTION
The function called refresh should do a refresh, not a full reindexing.

Some tests inserting data into elasticsearch need the index to be up-to-date, not re-created from cassandra. This should also avoid the arbitrary wait for 3 seconds.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
