### PR TITLE
Helm hook type

### DIFF
--- a/changelog.d/5-internal/helm-test
+++ b/changelog.d/5-internal/helm-test
@@ -1,1 +1,1 @@
-charts: Mark all test resources to be only created while running tests
+charts: Mark all service/secret/configmap test resources to be re-created by defining them as helm hooks (#3037, #3049)

--- a/charts/brig/templates/tests/brig-integration.yaml
+++ b/charts/brig/templates/tests/brig-integration.yaml
@@ -3,7 +3,8 @@ kind: Service
 metadata:
   name: "brig-integration"
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app: brig-integration
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/brig/templates/tests/configmap.yaml
+++ b/charts/brig/templates/tests/configmap.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: "brig-integration"
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   integration.yaml: |
     brig:

--- a/charts/brig/templates/tests/nginz-service.yaml
+++ b/charts/brig/templates/tests/nginz-service.yaml
@@ -6,7 +6,8 @@ kind: Service
 metadata:
   name: nginz-integration-http
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   type: ClusterIP
   ports:

--- a/charts/brig/templates/tests/secret.yaml
+++ b/charts/brig/templates/tests/secret.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: brig-integration-secrets
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   # These "secrets" are only used in tests and are therefore safe to be stored unencrypted
   provider-privatekey.pem: |

--- a/charts/cargohold/templates/tests/configmap.yaml
+++ b/charts/cargohold/templates/tests/configmap.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: "cargohold-integration"
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   integration.yaml: |
     cargohold:

--- a/charts/federator/templates/tests/configmap.yaml
+++ b/charts/federator/templates/tests/configmap.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: "federator-integration"
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   integration.yaml: |
     federatorInternal:

--- a/charts/galley/templates/tests/configmap.yaml
+++ b/charts/galley/templates/tests/configmap.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: "galley-integration"
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   integration.yaml: |
     galley:

--- a/charts/galley/templates/tests/galley-integration.yaml
+++ b/charts/galley/templates/tests/galley-integration.yaml
@@ -3,7 +3,8 @@ kind: Service
 metadata:
   name: "galley-integration"
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app: galley-integration
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/galley/templates/tests/secret.yaml
+++ b/charts/galley/templates/tests/secret.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: galley-integration-secrets
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   # These "secrets" are only used in tests and are therefore safe to be stored unencrypted
   provider-privatekey.pem: |

--- a/charts/gundeck/templates/tests/configmap.yaml
+++ b/charts/gundeck/templates/tests/configmap.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: "gundeck-integration"
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   integration.yaml: |
     gundeck:

--- a/charts/spar/templates/tests/configmap.yaml
+++ b/charts/spar/templates/tests/configmap.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: "spar-integration"
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   integration.yaml: |
     brig:


### PR DESCRIPTION
Defining configmaps/secrets/services as helm hook type of "test" has the disadvantage of not being able to use `helm test --filter name=...` as done in #3040 

Originally, the motivation for #3037 was to be able to go from a clusterIP-based service to a headless service. marking these as hooks with a delete policy should achieve the same result.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
