### PR TITLE
Use openssl instead of tls in federator http2 client

### DIFF
--- a/changelog.d/6-federation/openssl
+++ b/changelog.d/6-federation/openssl
@@ -1,0 +1,1 @@
+Use `HsOpenSSL` instead of `tls` for federation communication.

--- a/libs/wire-api-federation/default.nix
+++ b/libs/wire-api-federation/default.nix
@@ -15,6 +15,7 @@
 , errors
 , exceptions
 , gitignoreSource
+, HsOpenSSL
 , hspec
 , hspec-discover
 , http-media
@@ -67,6 +68,7 @@ mkDerivation {
     either
     errors
     exceptions
+    HsOpenSSL
     http-media
     http-types
     http2

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -86,6 +86,7 @@ library
     , either
     , errors
     , exceptions
+    , HsOpenSSL
     , http-media
     , http-types
     , http2

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -241,6 +241,14 @@ let
         sha256 = "sha256-htEIJY+LmIMACVZrflU60+X42/g14NxUyFM7VJs4E6w=";
       };
     };
+    # PR: https://github.com/haskell-cryptography/HsOpenSSL/pull/76
+    HsOpenSSL = {
+      src = fetchgit {
+        url = "https://github.com/wireapp/HsOpenSSL";
+        rev = "b36c063d44b8b8732f0e6334ad58d2235fedd92e";
+        sha256 = "sha256-NdWzTqWDQvCwyp3la3RGN9D1lGaLHHrxQuFxpk9R+lQ=";
+      };
+    };
   };
   hackagePins = {
     wai-route = {

--- a/services/federator/default.nix
+++ b/services/federator/default.nix
@@ -25,6 +25,7 @@
 , filepath
 , gitignoreSource
 , hinotify
+, HsOpenSSL
 , hspec
 , http-client
 , http-client-openssl
@@ -104,6 +105,7 @@ mkDerivation {
     extended
     filepath
     hinotify
+    HsOpenSSL
     http-client
     http-client-openssl
     http-media
@@ -166,6 +168,7 @@ mkDerivation {
     extended
     filepath
     hinotify
+    HsOpenSSL
     hspec
     http-client
     http-client-openssl
@@ -233,6 +236,7 @@ mkDerivation {
     extended
     filepath
     hinotify
+    HsOpenSSL
     http-client
     http-client-openssl
     http-media

--- a/services/federator/exec/Main.hs
+++ b/services/federator/exec/Main.hs
@@ -22,10 +22,11 @@ where
 
 import Federator.Run (run)
 import Imports
+import OpenSSL
 import Util.Options (getOptions)
 
 main :: IO ()
-main = do
+main = withOpenSSL $ do
   let desc = "Federation Service"
       defaultPath = "/etc/wire/federator/conf/federator.yaml"
   options <- getOptions desc Nothing defaultPath

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -211,63 +211,11 @@ executable federator
     -Wredundant-constraints
 
   build-depends:
-      aeson
-    , async
-    , base
-    , bilge
-    , binary
-    , bytestring
-    , bytestring-conversion
-    , constraints
-    , containers
-    , data-default
-    , dns
-    , dns-util
-    , either
-    , exceptions
-    , extended
+      base
     , federator
-    , filepath
-    , hinotify
-    , http-client
-    , http-client-openssl
-    , http-media
-    , http-types
-    , http2
+    , HsOpenSSL
     , imports
-    , kan-extensions
-    , lens
-    , metrics-core
-    , metrics-wai
-    , mtl
-    , network
-    , network-uri
-    , pem
-    , polysemy
-    , polysemy-wire-zoo
-    , retry
-    , servant
-    , servant-client-core
-    , streaming-commons
-    , string-conversions
-    , text
-    , time-manager
-    , tinylog
-    , tls
     , types-common
-    , unix
-    , uri-bytestring
-    , uuid
-    , wai
-    , wai-utilities
-    , warp
-    , warp-tls
-    , wire-api
-    , wire-api-federation
-    , x509
-    , x509-store
-    , x509-system
-    , x509-validation
 
   default-language:   Haskell2010
 

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -116,6 +116,7 @@ library
     , extended
     , filepath
     , hinotify
+    , HsOpenSSL
     , http-client
     , http-client-openssl
     , http-media
@@ -323,7 +324,7 @@ executable federator-integration
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -Wredundant-constraints
+    -Wredundant-constraints -threaded -with-rtsopts=-N1
 
   build-depends:
       aeson
@@ -347,6 +348,7 @@ executable federator-integration
     , federator
     , filepath
     , hinotify
+    , HsOpenSSL
     , hspec
     , http-client
     , http-client-openssl
@@ -478,6 +480,7 @@ test-suite federator-tests
     , federator
     , filepath
     , hinotify
+    , HsOpenSSL
     , http-client
     , http-client-openssl
     , http-media

--- a/services/federator/src/Federator/Env.hs
+++ b/services/federator/src/Federator/Env.hs
@@ -24,20 +24,14 @@ module Federator.Env where
 import Bilge (RequestId)
 import Control.Lens (makeLenses)
 import Data.Metrics (Metrics)
-import Data.X509.CertificateStore
 import Federator.Options (RunSettings)
 import Imports
 import Network.DNS.Resolver (Resolver)
 import qualified Network.HTTP.Client as HTTP
-import qualified Network.TLS as TLS
+import OpenSSL.Session (SSLContext)
 import qualified System.Logger.Class as LC
 import Util.Options
 import Wire.API.Federation.Component
-
-data TLSSettings = TLSSettings
-  { _caStore :: CertificateStore,
-    _creds :: TLS.Credential
-  }
 
 data Env = Env
   { _metrics :: Metrics,
@@ -47,8 +41,7 @@ data Env = Env
     _runSettings :: RunSettings,
     _service :: Component -> Endpoint,
     _httpManager :: HTTP.Manager,
-    _tls :: IORef TLSSettings
+    _sslContext :: IORef SSLContext
   }
 
-makeLenses ''TLSSettings
 makeLenses ''Env

--- a/services/federator/src/Federator/InternalServer.hs
+++ b/services/federator/src/Federator/InternalServer.hs
@@ -35,7 +35,7 @@ import qualified Data.Text.Encoding as Text
 import Data.X509.CertificateStore
 import Federator.App (runAppT)
 import Federator.Discovery (DiscoverFederator, DiscoveryFailure (DiscoveryFailureDNSError, DiscoveryFailureSrvNotAvailable), runFederatorDiscovery)
-import Federator.Env (Env, TLSSettings, applog, caStore, dnsResolver, runSettings, tls)
+import Federator.Env
 import Federator.Error.ServerError
 import Federator.Options (RunSettings)
 import Federator.Remote

--- a/services/federator/src/Federator/InternalServer.hs
+++ b/services/federator/src/Federator/InternalServer.hs
@@ -126,14 +126,14 @@ callOutward req = do
   rd <- parseRequestData req
   domain <- parseDomainText (rdTargetDomain rd)
   ensureCanFederateWith domain
-  resp <-
-    discoverAndCall
-      domain
-      (rdComponent rd)
-      (rdRPC rd)
-      (rdHeaders rd)
-      (fromLazyByteString (rdBody rd))
-  pure $ streamingResponseToWai resp
+  discoverAndCall
+    domain
+    (rdComponent rd)
+    (rdRPC rd)
+    (rdHeaders rd)
+    (fromLazyByteString (rdBody rd))
+    -- TODO: It doesn't look like this will actuallly consume the body before returning
+    (pure . streamingResponseToWai)
 
 serveOutward :: Env -> Int -> IO ()
 serveOutward = serve callOutward

--- a/services/federator/src/Federator/InternalServer.hs
+++ b/services/federator/src/Federator/InternalServer.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# OPTIONS_GHC -Wno-partial-type-signatures -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
 -- This file is part of the Wire Server implementation.
 --
@@ -20,58 +20,22 @@
 
 module Federator.InternalServer where
 
-import Control.Exception (bracketOnError)
-import qualified Control.Exception as E
-import Control.Lens (view)
 import Data.Binary.Builder
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as C8
-import qualified Data.ByteString.Lazy as LBS
-import Data.Default
-import Data.Domain (domainText)
-import Data.Either.Validation (Validation (..))
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import Data.X509.CertificateStore
-import Federator.App (runAppT)
-import Federator.Discovery (DiscoverFederator, DiscoveryFailure (DiscoveryFailureDNSError, DiscoveryFailureSrvNotAvailable), runFederatorDiscovery)
 import Federator.Env
 import Federator.Error.ServerError
 import Federator.Options (RunSettings)
 import Federator.Remote
 import Federator.Response
 import Federator.Validation
-import Foreign (mallocBytes)
-import Foreign.Marshal (free)
 import Imports
-import Network.HPACK (BufferSize)
-import Network.HTTP.Client.Internal (openSocketConnection)
-import Network.HTTP.Client.OpenSSL (withOpenSSL)
 import qualified Network.HTTP.Types as HTTP
-import qualified Network.HTTP2.Client as HTTP2
-import Network.Socket (Socket)
-import qualified Network.Socket as NS
-import Network.TLS
-import qualified Network.TLS as TLS
-import qualified Network.TLS.Extra.Cipher as TLS
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import Polysemy
 import Polysemy.Error
-import qualified Polysemy.Error as Polysemy
-import Polysemy.IO (embedToMonadIO)
 import Polysemy.Input
-import qualified Polysemy.Input as Polysemy
-import qualified Polysemy.Resource as Polysemy
-import Polysemy.TinyLog (TinyLog)
-import qualified Polysemy.TinyLog as Log
-import Servant.Client.Core
-import qualified System.TimeManager as T
-import qualified System.X509 as TLS
 import Wire.API.Federation.Component
-import Wire.Network.DNS.Effect (DNSLookup)
-import qualified Wire.Network.DNS.Effect as Lookup
-import Wire.Network.DNS.SRV (SrvTarget (..))
 
 data RequestData = RequestData
   { rdTargetDomain :: Text,

--- a/services/federator/src/Federator/InternalServer.hs
+++ b/services/federator/src/Federator/InternalServer.hs
@@ -90,14 +90,14 @@ callOutward req = do
   rd <- parseRequestData req
   domain <- parseDomainText (rdTargetDomain rd)
   ensureCanFederateWith domain
-  discoverAndCall
-    domain
-    (rdComponent rd)
-    (rdRPC rd)
-    (rdHeaders rd)
-    (fromLazyByteString (rdBody rd))
-    -- TODO: It doesn't look like this will actuallly consume the body before returning
-    (pure . streamingResponseToWai)
+  resp <-
+    discoverAndCall
+      domain
+      (rdComponent rd)
+      (rdRPC rd)
+      (rdHeaders rd)
+      (fromLazyByteString (rdBody rd))
+  pure $ streamingResponseToWai resp
 
 serveOutward :: Env -> Int -> IO ()
 serveOutward = serve callOutward

--- a/services/federator/src/Federator/Monitor.hs
+++ b/services/federator/src/Federator/Monitor.hs
@@ -23,20 +23,20 @@ module Federator.Monitor
 where
 
 import Control.Exception (bracket, throw)
-import Federator.Env (TLSSettings (..))
 import Federator.Monitor.Internal
 import Federator.Options (RunSettings (..))
 import Imports
+import OpenSSL.Session (SSLContext)
 import qualified Polysemy
 import qualified Polysemy.Error as Polysemy
 import System.Logger (Logger)
 
-mkTLSSettingsOrThrow :: RunSettings -> IO TLSSettings
-mkTLSSettingsOrThrow = Polysemy.runM . runEither . Polysemy.runError @FederationSetupError . mkTLSSettings
+mkTLSSettingsOrThrow :: RunSettings -> IO SSLContext
+mkTLSSettingsOrThrow = Polysemy.runM . runEither . Polysemy.runError @FederationSetupError . mkSSLContext
   where
     runEither = (either (Polysemy.embed @IO . throw) pure =<<)
 
-withMonitor :: Logger -> IORef TLSSettings -> RunSettings -> IO a -> IO a
+withMonitor :: Logger -> IORef SSLContext -> RunSettings -> IO a -> IO a
 withMonitor logger tlsVar rs action =
   bracket
     ( runSemDefault

--- a/services/federator/src/Federator/Monitor/Internal.hs
+++ b/services/federator/src/Federator/Monitor/Internal.hs
@@ -367,7 +367,6 @@ mkSSLContext settings = do
     SSL.contextAddOption ctx SSL.SSL_OP_NO_SSLv2
     SSL.contextAddOption ctx SSL.SSL_OP_NO_SSLv3
     SSL.contextAddOption ctx SSL.SSL_OP_NO_TLSv1
-    SSL.contextSetDefaultVerifyPaths ctx
 
     -- Settings TLS13 ciphers requires another call to openssl, this has not
     -- been implemented in HsOpenSSL yet.

--- a/services/federator/src/Federator/Monitor/Internal.hs
+++ b/services/federator/src/Federator/Monitor/Internal.hs
@@ -199,8 +199,6 @@ handleEvent runSem monitor wpath e = do
   -- to detect when some action has taken place
   unless (null actions) $
     -- we take the lock here, so that handlers never execute concurrently
-
-    -- we take the lock here, so that handlers never execute concurrently
     withMVar (monLock monitor) $ \_ ->
       runSem $ traverse_ (applyAction monitor) actions
 

--- a/services/federator/src/Federator/Monitor/Internal.hs
+++ b/services/federator/src/Federator/Monitor/Internal.hs
@@ -339,7 +339,7 @@ data FederationSetupError
   = InvalidCAStore FilePath String
   | InvalidClientCertificate String
   | InvalidClientPrivateKey String
-  | CertificateAndPrivateKeyDoNotMatch String String
+  | CertificateAndPrivateKeyDoNotMatch FilePath FilePath
   | SSLException SSL.SomeSSLException
   deriving (Show)
 

--- a/services/federator/src/Federator/Monitor/Internal.hs
+++ b/services/federator/src/Federator/Monitor/Internal.hs
@@ -409,7 +409,7 @@ mkSSLContextWithoutCert settings = do
 -- https://wearezeta.atlassian.net/browse/FS-444
 -- https://wearezeta.atlassian.net/browse/FS-443
 --
--- The current list is compliant to TR-02102-2
+-- The current list is compliant with TR-02102-2
 -- https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.html
 blessedTLS12Ciphers :: String
 blessedTLS12Ciphers =

--- a/services/federator/src/Federator/Monitor/Internal.hs
+++ b/services/federator/src/Federator/Monitor/Internal.hs
@@ -363,6 +363,7 @@ mkSSLContext ::
 mkSSLContext settings = do
   ctx <- embed $ SSL.context
   embed $ do
+    SSL.contextAddOption ctx SSL.SSL_OP_ALL
     SSL.contextAddOption ctx SSL.SSL_OP_NO_SSLv2
     SSL.contextAddOption ctx SSL.SSL_OP_NO_SSLv3
     SSL.contextAddOption ctx SSL.SSL_OP_NO_TLSv1
@@ -371,7 +372,9 @@ mkSSLContext settings = do
     -- Settings TLS13 ciphers requires another call to openssl, this has not
     -- been implemented in HsOpenSSL yet.
     SSL.contextSetCiphers ctx blessedTLS12Ciphers
+
     SSL.contextSetALPNProtos ctx ["h2"]
+
     SSL.contextSetVerificationMode ctx $
       SSL.VerifyPeer
         { -- vpFailIfNoPeerCert and vpClientOnce are only relevant for servers

--- a/services/federator/src/Federator/Remote.hs
+++ b/services/federator/src/Federator/Remote.hs
@@ -130,28 +130,3 @@ interpretRemote = interpret $ \case
           (responseStatusCode resp)
           (toLazyByteString bdy)
     pure resp
-
--- mkTLSConfig :: SSLContext -> ByteString -> Word16 -> TLS.ClientParams
--- mkTLSConfig settings hostname port =
---   ( defaultParamsClient
---       (Text.unpack (Text.decodeUtf8With Text.lenientDecode hostname))
---       (toByteString' port)
---   )
---     { TLS.clientSupported =
---         def
---           { TLS.supportedCiphers = blessedCiphers,
---             -- FUTUREWORK: Figure out if we can drop TLS 1.2
---             TLS.supportedVersions = [TLS.TLS12, TLS.TLS13]
---           },
---       TLS.clientHooks =
---         def
---           { TLS.onServerCertificate =
---               X509.validate
---                 X509.HashSHA256
---                 X509.defaultHooks {X509.hookValidateName = validateDomainName}
---                 X509.defaultChecks {X509.checkLeafKeyPurpose = [X509.KeyUsagePurpose_ServerAuth]},
---             TLS.onCertificateRequest = \_ -> pure (Just (settings ^. creds)),
---             TLS.onSuggestALPN = pure (Just ["h2"]) -- we only support HTTP2
---           },
---       TLS.clientShared = def {TLS.sharedCAStore = settings ^. caStore}
---     }

--- a/services/federator/src/Federator/Remote.hs
+++ b/services/federator/src/Federator/Remote.hs
@@ -27,7 +27,6 @@ module Federator.Remote
 where
 
 import qualified Control.Exception as E
-import Control.Monad.Codensity
 import Data.Binary.Builder
 import qualified Data.ByteString.Lazy as LBS
 import Data.Domain
@@ -92,12 +91,13 @@ data Remote m a where
     Text ->
     [HTTP.Header] ->
     Builder ->
-    Remote m StreamingResponse
+    (StreamingResponse -> IO a) ->
+    Remote m a
 
 makeSem ''Remote
 
 interpretRemote ::
-  ( Member (Embed (Codensity IO)) r,
+  ( Member (Embed IO) r,
     Member DiscoverFederator r,
     Member (Error DiscoveryFailure) r,
     Member (Error RemoteError) r,
@@ -106,7 +106,7 @@ interpretRemote ::
   Sem (Remote ': r) a ->
   Sem r a
 interpretRemote = interpret $ \case
-  DiscoverAndCall domain component rpc headers body -> do
+  DiscoverAndCall domain component rpc headers body respConsumer -> do
     target@(SrvTarget hostname port) <- discoverFederatorWithError domain
     let path =
           LBS.toStrict . toLazyByteString $
@@ -116,17 +116,13 @@ interpretRemote = interpret $ \case
         req' = HTTP2.requestBuilder HTTP.methodPost path headers' body
 
     sslCtx <- input
-    resp <- mapError (RemoteError target) . (fromEither @FederatorClientHTTP2Error =<<) . embed $
-      Codensity $ \k ->
-        E.catch
-          (withHTTP2Request (Just sslCtx) req' hostname (fromIntegral port) (k . Right))
-          (k . Left)
-
-    unless (HTTP.statusIsSuccessful (responseStatusCode resp)) $ do
-      bdy <- embed @(Codensity IO) . liftIO $ streamingResponseStrictBody resp
-      throw $
-        RemoteErrorResponse
-          target
-          (responseStatusCode resp)
-          (toLazyByteString bdy)
-    pure resp
+    (fromEither @RemoteError =<<)
+      . embed
+      . E.handle (pure . Left . RemoteError target)
+      $ withHTTP2Request (Just sslCtx) req' hostname (fromIntegral port)
+      $ \resp -> do
+        if HTTP.statusIsSuccessful (responseStatusCode resp)
+          then Right <$> respConsumer resp
+          else do
+            bdy <- streamingResponseStrictBody resp
+            pure . Left $ RemoteErrorResponse target (responseStatusCode resp) (toLazyByteString bdy)

--- a/services/federator/src/Federator/Remote.hs
+++ b/services/federator/src/Federator/Remote.hs
@@ -23,7 +23,6 @@ module Federator.Remote
     RemoteError (..),
     interpretRemote,
     discoverAndCall,
-    blessedCiphers,
   )
 where
 
@@ -156,23 +155,3 @@ interpretRemote = interpret $ \case
 --           },
 --       TLS.clientShared = def {TLS.sharedCAStore = settings ^. caStore}
 --     }
-
--- Context and possible future work see
--- https://wearezeta.atlassian.net/browse/FS-33
--- https://wearezeta.atlassian.net/browse/FS-444
--- https://wearezeta.atlassian.net/browse/FS-443
---
--- The current list is compliant to TR-02102-2
--- https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.html
-blessedCiphers :: String
-blessedCiphers =
-  intercalate
-    ","
-    [ "TLS_AES_128_CCM_8_SHA256",
-      "TLS_AES_128_CCM_SHA256",
-      "TLS_AES_128_GCM_SHA256",
-      "TLS_AES_128_GCM_SHA384",
-      -- For TLS 1.2 (copied from nginx ingress config):
-      "ECDHE-ECDSA-AES256-GCM-SHA384",
-      "ECDHE-RSA-AES256-GCM-SHA384"
-    ]

--- a/services/federator/src/Federator/Response.hs
+++ b/services/federator/src/Federator/Response.hs
@@ -42,6 +42,7 @@ import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Utilities.Error as Wai
 import qualified Network.Wai.Utilities.Server as Wai
+import OpenSSL.Session (SSLContext)
 import Polysemy
 import Polysemy.Embed
 import Polysemy.Error
@@ -117,7 +118,7 @@ type AllEffects =
      DNSLookup, -- needed by DiscoverFederator
      ServiceStreaming,
      Input RunSettings,
-     Input TLSSettings, -- needed by Remote
+     Input SSLContext, -- needed by Remote
      Input Env, -- needed by Service
      Error ValidationError,
      Error RemoteError,
@@ -142,7 +143,7 @@ runFederator env =
           DiscoveryFailure
         ]
     . runInputConst env
-    . runInputSem (embed @IO (readIORef (view tls env)))
+    . runInputSem (embed @IO (readIORef (view sslContext env)))
     . runInputConst (view runSettings env)
     . interpretServiceHTTP
     . runDNSLookupWithResolver (view dnsResolver env)

--- a/services/federator/src/Federator/Run.hs
+++ b/services/federator/src/Federator/Run.hs
@@ -64,7 +64,7 @@ run opts = do
     bracket (newEnv opts res) closeEnv $ \env -> do
       let externalServer = serveInward env portExternal
           internalServer = serveOutward env portInternal
-      withMonitor (env ^. applog) (env ^. tls) (optSettings opts) $ do
+      withMonitor (env ^. applog) (env ^. sslContext) (optSettings opts) $ do
         internalServerThread <- async internalServer
         externalServerThread <- async externalServer
         void $ waitAnyCancel [internalServerThread, externalServerThread]
@@ -97,7 +97,7 @@ newEnv o _dnsResolver = do
       _service Galley = Opt.galley o
       _service Cargohold = Opt.cargohold o
   _httpManager <- initHttpManager
-  _tls <- mkTLSSettingsOrThrow _runSettings >>= newIORef
+  _sslContext <- mkTLSSettingsOrThrow _runSettings >>= newIORef
   pure Env {..}
 
 closeEnv :: Env -> IO ()

--- a/services/federator/test/integration/Main.hs
+++ b/services/federator/test/integration/Main.hs
@@ -22,6 +22,7 @@ where
 
 import Data.String.Conversions
 import Imports
+import OpenSSL (withOpenSSL)
 import System.Environment (withArgs)
 import qualified Test.Federator.IngressSpec
 import qualified Test.Federator.InwardSpec
@@ -29,7 +30,7 @@ import Test.Federator.Util (TestEnv, mkEnvFromOptions)
 import Test.Hspec
 
 main :: IO ()
-main = do
+main = withOpenSSL $ do
   (wireArgs, hspecArgs) <- partitionArgs <$> getArgs
   env <- withArgs wireArgs mkEnvFromOptions
   -- withArgs hspecArgs . hspec $ do

--- a/services/federator/test/integration/Main.hs
+++ b/services/federator/test/integration/Main.hs
@@ -22,7 +22,6 @@ where
 
 import Data.String.Conversions
 import Imports
-import OpenSSL (withOpenSSL)
 import System.Environment (withArgs)
 import qualified Test.Federator.IngressSpec
 import qualified Test.Federator.InwardSpec
@@ -30,7 +29,7 @@ import Test.Federator.Util (TestEnv, mkEnvFromOptions)
 import Test.Hspec
 
 main :: IO ()
-main = withOpenSSL $ do
+main = do
   (wireArgs, hspecArgs) <- partitionArgs <$> getArgs
   env <- withArgs wireArgs mkEnvFromOptions
   -- withArgs hspecArgs . hspec $ do

--- a/services/federator/test/integration/Test/Federator/IngressSpec.hs
+++ b/services/federator/test/integration/Test/Federator/IngressSpec.hs
@@ -27,6 +27,7 @@ import Data.LegalHold (UserLegalHoldStatus (UserLegalHoldNoConsent))
 import Data.String.Conversions (cs)
 import qualified Data.Text.Encoding as Text
 import Federator.Discovery
+import Federator.Monitor.Internal (blessedTLS12Ciphers)
 import Federator.Options
 import Federator.Remote
 import Imports
@@ -113,7 +114,7 @@ mkSSLContextWithoutCert settings = liftIO $ do
   SSL.contextAddOption ctx SSL.SSL_OP_NO_SSLv2
   SSL.contextAddOption ctx SSL.SSL_OP_NO_SSLv3
   SSL.contextAddOption ctx SSL.SSL_OP_NO_TLSv1
-  SSL.contextSetCiphers ctx blessedCiphers
+  SSL.contextSetCiphers ctx blessedTLS12Ciphers
   SSL.contextSetDefaultVerifyPaths ctx
   SSL.contextSetALPNProtos ctx ["h2"]
 

--- a/services/federator/test/integration/Test/Federator/Util.hs
+++ b/services/federator/test/integration/Test/Federator/Util.hs
@@ -43,12 +43,12 @@ import qualified Data.Text as Text
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID
 import qualified Data.Yaml as Yaml
-import Federator.Env
 import Federator.Options
 import Federator.Run
 import Imports
 import qualified Network.Connection
 import Network.HTTP.Client.TLS
+import OpenSSL.Session (SSLContext)
 import qualified Options.Applicative as OPA
 import Polysemy
 import Polysemy.Error
@@ -91,13 +91,15 @@ runTestFederator env = flip runReaderT env . unwrapTestFederator
 -- | See 'mkEnv' about what's in here.
 data TestEnv = TestEnv
   { _teMgr :: Manager,
-    _teTLSSettings :: TLSSettings,
+    _teSSLContext :: SSLContext,
     _teBrig :: BrigReq,
     _teCargohold :: CargoholdReq,
     -- | federator config
     _teOpts :: Opts,
     -- | integration test config
-    _teTstOpts :: IntegrationConfig
+    _teTstOpts :: IntegrationConfig,
+    -- | Settings passed to the federator
+    _teSettings :: RunSettings
   }
 
 type Select = TestEnv -> (Request -> Request)
@@ -153,7 +155,9 @@ mkEnv _teTstOpts _teOpts = do
   _teMgr :: Manager <- newManager managerSettings
   let _teBrig = endpointToReq (cfgBrig _teTstOpts)
       _teCargohold = endpointToReq (cfgCargohold _teTstOpts)
-  _teTLSSettings <- mkTLSSettingsOrThrow (optSettings _teOpts)
+  -- _teTLSSettings <- mkTLSSettingsOrThrow (optSettings _teOpts)
+  _teSSLContext <- mkTLSSettingsOrThrow (optSettings _teOpts)
+  let _teSettings = optSettings _teOpts
   pure TestEnv {..}
 
 destroyEnv :: HasCallStack => TestEnv -> IO ()

--- a/services/federator/test/unit/Main.hs
+++ b/services/federator/test/unit/Main.hs
@@ -21,6 +21,7 @@ module Main
 where
 
 import Imports
+import OpenSSL (withOpenSSL)
 import qualified Test.Federator.Client
 import qualified Test.Federator.ExternalServer
 import qualified Test.Federator.InternalServer
@@ -33,15 +34,16 @@ import Test.Tasty
 
 main :: IO ()
 main =
-  defaultMain $
-    testGroup
-      "Tests"
-      [ Test.Federator.Options.tests,
-        Test.Federator.Validation.tests,
-        Test.Federator.Client.tests,
-        Test.Federator.InternalServer.tests,
-        Test.Federator.ExternalServer.tests,
-        Test.Federator.Monitor.tests,
-        Test.Federator.Remote.tests,
-        Test.Federator.Response.tests
-      ]
+  withOpenSSL $
+    defaultMain $
+      testGroup
+        "Tests"
+        [ Test.Federator.Options.tests,
+          Test.Federator.Validation.tests,
+          Test.Federator.Client.tests,
+          Test.Federator.InternalServer.tests,
+          Test.Federator.ExternalServer.tests,
+          Test.Federator.Monitor.tests,
+          Test.Federator.Remote.tests,
+          Test.Federator.Response.tests
+        ]

--- a/services/federator/test/unit/Test/Federator/Client.hs
+++ b/services/federator/test/unit/Test/Federator/Client.hs
@@ -240,7 +240,8 @@ withInfiniteMockServer k = bracket (startMockServer Nothing app) fst (k . snd)
       Wai.responseStream HTTP.ok200 mempty $ \write flush ->
         let go n = do
               when (n == 0) flush
-              write (byteString "Hello\n") *> go (if n == 0 then 100 else n - 1)
+              write (byteString "Hello\n")
+              go (if n == 0 then 100 else n - 1)
          in go (1000 :: Int)
 
 -- SourceT utilities

--- a/services/federator/test/unit/Test/Federator/Client.hs
+++ b/services/federator/test/unit/Test/Federator/Client.hs
@@ -240,8 +240,7 @@ withInfiniteMockServer k = bracket (startMockServer Nothing app) fst (k . snd)
       Wai.responseStream HTTP.ok200 mempty $ \write flush ->
         let go n = do
               when (n == 0) flush
-              write (byteString "Hello\n")
-              go (if n == 0 then 100 else n - 1)
+              write (byteString "Hello\n") *> go (if n == 0 then 100 else n - 1)
          in go (1000 :: Int)
 
 -- SourceT utilities

--- a/services/federator/test/unit/Test/Federator/InternalServer.hs
+++ b/services/federator/test/unit/Test/Federator/InternalServer.hs
@@ -75,13 +75,13 @@ federatedRequestSuccess =
           }
     let interpretCall :: Member (Embed IO) r => Sem (Remote ': r) a -> Sem r a
         interpretCall = interpret $ \case
-          DiscoverAndCall domain component rpc headers body -> embed @IO $ do
+          DiscoverAndCall domain component rpc headers body respConsumer -> embed @IO $ do
             domain @?= targetDomain
             component @?= Brig
             rpc @?= "get-user-by-handle"
             headers @?= requestHeaders
             toLazyByteString body @?= "\"foo\""
-            pure
+            respConsumer
               Response
                 { responseStatusCode = HTTP.ok200,
                   responseHeaders = mempty,
@@ -117,16 +117,17 @@ federatedRequestFailureAllowList =
             trExtraHeaders = headers
           }
 
-    let checkRequest :: Sem (Remote ': r) a -> Sem r a
+    let checkRequest :: Member (Embed IO) r => Sem (Remote ': r) a -> Sem r a
         checkRequest = interpret $ \case
-          DiscoverAndCall {} ->
-            pure
-              Response
-                { responseStatusCode = HTTP.ok200,
-                  responseHeaders = mempty,
-                  responseHttpVersion = HTTP.http20,
-                  responseBody = source ["\"bar\""]
-                }
+          DiscoverAndCall _domain _component _rpc _headers _body respConsumer ->
+            embed $
+              respConsumer
+                Response
+                  { responseStatusCode = HTTP.ok200,
+                    responseHeaders = mempty,
+                    responseHttpVersion = HTTP.http20,
+                    responseBody = source ["\"bar\""]
+                  }
 
     eith <-
       runM

--- a/services/federator/test/unit/Test/Federator/Monitor.hs
+++ b/services/federator/test/unit/Test/Federator/Monitor.hs
@@ -19,17 +19,15 @@ module Test.Federator.Monitor (tests) where
 
 import Control.Concurrent.Chan
 import Control.Exception (bracket)
-import Control.Lens (view)
 import Control.Monad.Trans.Cont
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Set as Set
-import Data.X509 (CertificateChain (..))
-import Federator.Env (TLSSettings (..), creds)
 import Federator.Monitor
 import Federator.Monitor.Internal
 import Federator.Options
 import Imports
+import OpenSSL.Session (SSLContext)
 import qualified Polysemy
 import qualified Polysemy.Error as Polysemy
 import System.FilePath
@@ -116,7 +114,7 @@ withKubernetesSettings = do
 withSilentMonitor ::
   Chan (Maybe FederationSetupError) ->
   RunSettings ->
-  ContT r IO (IORef TLSSettings)
+  ContT r IO (IORef SSLContext)
 withSilentMonitor reloads settings = do
   tlsVar <- liftIO $ newIORef (error "TLSSettings not updated before being read")
   void . ContT $
@@ -136,7 +134,7 @@ testMonitorChangeUpdate =
     reloads <- newChan
     evalContT $ do
       settings <- withSettings
-      tlsVar <- withSilentMonitor reloads settings
+      _ <- withSilentMonitor reloads settings
       liftIO $ do
         appendFile (clientCertificate settings) ""
         result <- timeout timeoutMicroseconds (readChan reloads)
@@ -146,11 +144,6 @@ testMonitorChangeUpdate =
             assertFailure
               ("unexpected exception " <> displayException err)
           _ -> pure ()
-        tls <- readIORef tlsVar
-        case view creds tls of
-          (CertificateChain [], _) ->
-            assertFailure "expected non-empty certificate chain"
-          _ -> pure ()
 
 testMonitorReplacedChangeUpdate :: TestTree
 testMonitorReplacedChangeUpdate =
@@ -158,12 +151,18 @@ testMonitorReplacedChangeUpdate =
     reloads <- newChan
     evalContT $ do
       settings <- withSettings
-      tlsVar <- withSilentMonitor reloads settings
+      _ <- withSilentMonitor reloads settings
       liftIO $ do
         -- first replace file with a different one
         copyFile
           "test/resources/unit/localhost-dot.pem"
           (clientCertificate settings)
+        -- This will always fail because now the certificate doesn't match the
+        -- private key
+        _result0 <- timeout timeoutMicroseconds (readChan reloads)
+        copyFile
+          "test/resources/unit/localhost-dot-key.pem"
+          (clientPrivateKey settings)
         result1 <- timeout timeoutMicroseconds (readChan reloads)
         case result1 of
           Nothing ->
@@ -184,11 +183,6 @@ testMonitorReplacedChangeUpdate =
             assertFailure
               ("unexpected exception " <> displayException err)
           _ -> pure ()
-        tls <- readIORef tlsVar
-        case view creds tls of
-          (CertificateChain [], _) ->
-            assertFailure "expected non-empty certificate chain"
-          _ -> pure ()
 
 testMonitorOverwriteUpdate :: TestTree
 testMonitorOverwriteUpdate =
@@ -196,22 +190,24 @@ testMonitorOverwriteUpdate =
     reloads <- newChan
     evalContT $ do
       settings <- withSettings
-      tlsVar <- withSilentMonitor reloads settings
+      _ <- withSilentMonitor reloads settings
       liftIO $ do
         copyFile
           "test/resources/unit/localhost-dot.pem"
           (clientCertificate settings)
+        -- This will always fail because now the certificate doesn't match the
+        -- private key
+        _result0 <- timeout timeoutMicroseconds (readChan reloads)
+
+        copyFile
+          "test/resources/unit/localhost-dot-key.pem"
+          (clientPrivateKey settings)
         result <- timeout timeoutMicroseconds (readChan reloads)
         case result of
           Nothing -> assertFailure "certificate not updated within the allotted time"
           Just (Just err) ->
             assertFailure
               ("unexpected exception " <> displayException err)
-          _ -> pure ()
-        tls <- readIORef tlsVar
-        case view creds tls of
-          (CertificateChain [], _) ->
-            assertFailure "expected non-empty certificate chain"
           _ -> pure ()
 
 testMonitorSymlinkUpdate :: TestTree
@@ -220,24 +216,28 @@ testMonitorSymlinkUpdate =
     reloads <- newChan
     evalContT $ do
       settings <- withSymlinkSettings
-      tlsVar <- withSilentMonitor reloads settings
+      _ <- withSilentMonitor reloads settings
       liftIO $ do
-        removeFile (clientCertificate settings)
         wd <- getWorkingDirectory
+
+        removeFile (clientCertificate settings)
         createSymbolicLink
           (wd </> "test/resources/unit/localhost-dot.pem")
           (clientCertificate settings)
+        -- This will always fail because now the certificate doesn't match the
+        -- private key
+        _result0 <- timeout timeoutMicroseconds (readChan reloads)
+
+        removeFile (clientPrivateKey settings)
+        createSymbolicLink
+          (wd </> "test/resources/unit/localhost-dot-key.pem")
+          (clientPrivateKey settings)
         result <- timeout timeoutMicroseconds (readChan reloads)
         case result of
           Nothing -> assertFailure "certificate not updated within the allotted time"
           Just (Just err) ->
             assertFailure
               ("unexpected exception " <> displayException err)
-          _ -> pure ()
-        tls <- readIORef tlsVar
-        case view creds tls of
-          (CertificateChain [], _) ->
-            assertFailure "expected non-empty certificate chain"
           _ -> pure ()
 
 testMonitorNestedUpdate :: TestTree
@@ -246,7 +246,7 @@ testMonitorNestedUpdate =
     reloads <- newChan
     evalContT $ do
       settings <- withNestedSettings 1
-      tlsVar <- withSilentMonitor reloads settings
+      _ <- withSilentMonitor reloads settings
       liftIO $ do
         -- make a new directory with other credentials
         let parent = takeDirectory (clientCertificate settings)
@@ -268,11 +268,6 @@ testMonitorNestedUpdate =
             assertFailure
               ("unexpected exception " <> displayException err)
           _ -> pure ()
-        tls <- readIORef tlsVar
-        case view creds tls of
-          (CertificateChain [], _) ->
-            assertFailure "expected non-empty certificate chain"
-          _ -> pure ()
 
 testMonitorDeepUpdate :: TestTree
 testMonitorDeepUpdate =
@@ -280,7 +275,7 @@ testMonitorDeepUpdate =
     reloads <- newChan
     evalContT $ do
       settings <- withNestedSettings 2
-      tlsVar <- withSilentMonitor reloads settings
+      _ <- withSilentMonitor reloads settings
       liftIO $ do
         -- make a new directory with other credentials
         let root = takeDirectory (takeDirectory (takeDirectory (clientCertificate settings)))
@@ -311,19 +306,13 @@ testMonitorDeepUpdate =
               ("unexpected exception " <> displayException err)
           _ -> pure ()
 
-        tls <- readIORef tlsVar
-        case view creds tls of
-          (CertificateChain [], _) ->
-            assertFailure "expected non-empty certificate chain"
-          _ -> pure ()
-
 testMonitorKubernetesUpdate :: TestTree
 testMonitorKubernetesUpdate = do
   testCase "monitor updates on a kubernetes secret mount" $ do
     reloads <- newChan
     evalContT $ do
       settings <- withKubernetesSettings
-      tlsVar <- withSilentMonitor reloads settings
+      _ <- withSilentMonitor reloads settings
       liftIO $ do
         let root = takeDirectory (clientCertificate settings)
         createDirectory (root </> "..foo2")
@@ -338,12 +327,6 @@ testMonitorKubernetesUpdate = do
           Just (Just err) ->
             assertFailure
               ("unexpected exception " <> displayException err)
-          _ -> pure ()
-
-        tls <- readIORef tlsVar
-        case view creds tls of
-          (CertificateChain [], _) ->
-            assertFailure "expected non-empty certificate chain"
           _ -> pure ()
 
 testMonitorError :: TestTree

--- a/services/federator/test/unit/Test/Federator/Options.hs
+++ b/services/federator/test/unit/Test/Federator/Options.hs
@@ -22,7 +22,6 @@
 module Test.Federator.Options where
 
 import Control.Exception (try)
-import Control.Lens
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Char8 as B8
@@ -30,7 +29,6 @@ import Data.ByteString.Lazy (toStrict)
 import Data.Domain (Domain (..), mkDomain)
 import Data.String.Interpolate as QQ
 import qualified Data.Yaml as Yaml
-import Federator.Env
 import Federator.Options
 import Federator.Run
 import Imports
@@ -167,10 +165,8 @@ testSettings =
             assertFailure $
               "expected invalid client certificate exception, got: "
                 <> show e
-          Right tlsSettings ->
-            assertFailure $
-              "expected failure for non-existing client certificate, got: "
-                <> show (tlsSettings ^. creds),
+          Right _ ->
+            assertFailure "expected failure for non-existing client certificate, got success",
       -- @SF.Federation @TSFI.Federate @S3 @S7
       testCase "failToStartWithInvalidServerCredentials" $ do
         let settings =
@@ -190,10 +186,8 @@ testSettings =
             assertFailure $
               "expected invalid client certificate exception, got: "
                 <> show e
-          Right tlsSettings ->
-            assertFailure $
-              "expected failure for invalid client certificate, got: "
-                <> show (tlsSettings ^. creds),
+          Right _ ->
+            assertFailure "expected failure for invalid client certificate, got success",
       -- @END
       testCase "fail on invalid private key" $ do
         let settings =
@@ -208,15 +202,13 @@ testSettings =
           clientCertificate: test/resources/unit/localhost.pem
           clientPrivateKey: test/resources/unit/invalid.pem|]
         try @FederationSetupError (mkTLSSettingsOrThrow settings) >>= \case
-          Left (InvalidClientCertificate _) -> pure ()
+          Left (InvalidClientPrivateKey _) -> pure ()
           Left e ->
             assertFailure $
               "expected invalid client certificate exception, got: "
                 <> show e
-          Right tlsSettings ->
-            assertFailure $
-              "expected failure for invalid private key, got: "
-                <> show (tlsSettings ^. creds)
+          Right _ ->
+            assertFailure "expected failure for invalid private key, got success"
     ]
 
 assertParsesAs :: (HasCallStack, Eq a, FromJSON a, Show a) => a -> ByteString -> Assertion


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
