### PR TITLE
helmfile sync: speedup

### DIFF
--- a/changelog.d/5-internal/helm-setup
+++ b/changelog.d/5-internal/helm-setup
@@ -1,0 +1,1 @@
+CI integration setup time should be reduced: tweak the way cassandra-ephemeral is started

--- a/charts/cassandra-ephemeral/values.yaml
+++ b/charts/cassandra-ephemeral/values.yaml
@@ -22,3 +22,14 @@ cassandra-ephemeral:
     seed_size: 1
     max_heap_size: 2048M
     heap_new_size: 1024M
+
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 15
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 15

--- a/hack/helmfile.yaml
+++ b/hack/helmfile.yaml
@@ -129,6 +129,8 @@ releases:
         value: {{ .Values.federationDomain }}
       - name: brig.config.optSettings.setFederationDomainConfigs[0].domain
         value: {{ .Values.federationDomainFed2 }}
+    needs:
+      - '{{ .Values.namespace }}-databases-ephemeral'
 
   - name: '{{ .Values.namespace }}-wire-server-2'
     namespace: '{{ .Values.namespaceFed2 }}'
@@ -145,3 +147,5 @@ releases:
         value: {{ .Values.federationDomainFed2 }}
       - name: brig.config.optSettings.setFederationDomainConfigs[0].domain
         value: {{ .Values.federationDomain }}
+    needs:
+      - '{{ .Values.namespace }}-databases-ephemeral-2'


### PR DESCRIPTION
- change liveness and readyness probes to start querying more quickly to see if cassandra is up. Instead of 90 - 120 seconds, if cassandra is up earlier that should manifest itself in the setup time of 'make kube-integration-setup'
- change helmfile for wire-server to wait for databases-ephemeral to be up before launching pods: cassandra-migration needs to have a working cassandra anyway - the crashloop-backoff strategy leads to a lot of waiting in between restarts; so it should be faster to wait for cassandra to be up before attempting schema migrations

Observed speedup: 30-60 seconds.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
