### PR TITLE
Deflake metrics test

### DIFF
--- a/changelog.d/5-internal/deflake-metrics
+++ b/changelog.d/5-internal/deflake-metrics
@@ -1,0 +1,1 @@
+Deflake integration test: metrics


### PR DESCRIPTION
example case where this test failed: https://concourse.ops.zinfra.io/teams/main/pipelines/staging/jobs/test/builds/342

output of failing test:
```
  metrics
    prometheus:                                                                              OK (0.02s)
    work:                                                                                    FAIL (1.06s)
      Error message: /login was called twice
      expected: 2
       but got: 3

      CallStack (from HasCallStack):
        assertFailure, called at ./Test/Tasty/HUnit/Orig.hs:86:32 in tasty-hunit-0.10.0.3-KJER1RJhmod6e0raY4U8z6:Test.Tasty.HUnit.Orig
        assertEqual, called at test/integration/API/Metrics.hs:78:12 in main:API.Metrics
      Use -p '(!/turn/&&!/user.auth.cookies.limit/)&&/metrics.work/' to rerun this test only.
```

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
