### PR TITLE
[FS-1488] Fix self-conversation creator key package mapping

### DIFF
--- a/changelog.d/3-bug-fixes/mls-self-conv-creator-ref
+++ b/changelog.d/3-bug-fixes/mls-self-conv-creator-ref
@@ -1,0 +1,1 @@
+Map the MLS self-conversation creator's key package reference in Brig

--- a/services/brig/src/Brig/Data/MLS/KeyPackage.hs
+++ b/services/brig/src/Brig/Data/MLS/KeyPackage.hs
@@ -45,7 +45,6 @@ import Data.Id
 import Data.Qualified
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
-import Debug.Trace
 import Imports
 import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
@@ -187,8 +186,7 @@ keyPackageRefSetConvId ref convId = do
     q = "UPDATE mls_key_package_refs SET conv_domain = ?, conv = ? WHERE ref = ? IF EXISTS"
 
 addKeyPackageRef :: MonadClient m => KeyPackageRef -> NewKeyPackageRef -> m ()
-addKeyPackageRef ref nkpr = do
-  traceM ("addKeyPackageRef " <> show ref)
+addKeyPackageRef ref nkpr =
   retry x5 $
     write
       q
@@ -205,13 +203,12 @@ addKeyPackageRef ref nkpr = do
 -- FUTUREWORK: this function has to be extended if a table mapping (client,
 -- conversation) to key package ref is added, for instance, when implementing
 -- external delete proposals.
-updateKeyPackageRef :: (MonadClient m) => KeyPackageRef -> KeyPackageRef -> m ()
+updateKeyPackageRef :: MonadClient m => KeyPackageRef -> KeyPackageRef -> m ()
 updateKeyPackageRef prevRef newRef =
   void . runMaybeT $ do
     backup <- backupKeyPackageMeta prevRef
     lift $ do
       restoreKeyPackageMeta newRef backup
-      traceM ("updateKeyPackageRef: calling deleteKeyPackage with ref " <> show prevRef)
       deleteKeyPackage prevRef
 
 --------------------------------------------------------------------------------

--- a/services/galley/src/Galley/API/Clients.hs
+++ b/services/galley/src/Galley/API/Clients.hs
@@ -85,6 +85,9 @@ addClientH (usr ::: clt) = do
   E.createClient usr clt
   pure empty
 
+-- | Remove a client from conversations it is part of according to the
+-- conversation protocol (Proteus or MLS). In addition, remove the client from
+-- the "clients" table in Galley.
 rmClientH ::
   forall p1 r.
   ( p1 ~ CassandraPaging,

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -929,6 +929,8 @@ processInternalCommit qusr senderClient con lConvOrSub epoch action senderRef co
             (True, SelfConv, [], Conv _) -> do
               creatorClient <- noteS @'MLSMissingSenderClient senderClient
               let creatorRef = fromMaybe senderRef updatePathRef
+              addKeyPackageRef creatorRef qusr creatorClient $
+                tUntagged (convOfConvOrSub . idForConvOrSub <$> lConvOrSub)
               addMLSClients
                 (cnvmlsGroupId mlsMeta)
                 qusr

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -27,7 +27,6 @@ module Galley.API.MLS.Message
 where
 
 import Control.Arrow ((>>>))
-import Debug.Trace
 import Control.Comonad
 import Control.Error.Util (hush)
 import Control.Lens (forOf_, preview)
@@ -476,9 +475,7 @@ getSenderClient qusr SMLSPlainText msg = case msgSender msg of
   PreconfiguredSender _ -> pure Nothing
   NewMemberSender -> pure Nothing
   MemberSender ref -> do
-    traceM "getSenderClient before"
     cid <- derefKeyPackage ref
-    traceM "getSenderClient after"
     when (fmap fst (cidQualifiedClient cid) /= qusr) $
       throwS @'MLSClientSenderUserMismatch
     pure (Just (ciClient cid))
@@ -822,9 +819,7 @@ processExternalCommit qusr mSenderClient lConvOrSub epoch action updatePath = wi
         unless (user == u) $
           throwS @'MLSClientSenderUserMismatch
         ref <- ensureSingleton clients
-        traceM "derefUser before"
         ci <- derefKeyPackage ref
-        traceM "derefUser after"
         unless (cidQualifiedUser ci == user) $
           throwS @'MLSClientSenderUserMismatch
         pure (ci, ref)
@@ -1078,9 +1073,7 @@ applyProposal convOrSubConvId groupId (AddProposal kp) = do
       addMLSClients groupId qusr (Set.singleton (ciClient cid, ref))
       pure cid
 applyProposal _convOrSubConvId _groupId (RemoveProposal ref) = do
-  traceM "applyProposal before"
   qclient <- cidQualifiedClient <$> derefKeyPackage ref
-  traceM "applyProposal after"
   pure (paRemoveClient ((,ref) <$$> qclient))
 applyProposal _convOrSubConvId _groupId (ExternalInitProposal _) =
   -- only record the fact there was an external init proposal, but do not

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -815,6 +815,7 @@ processExternalCommit qusr mSenderClient lConvOrSub epoch action updatePath = wi
   kpRefs <- getPendingBackendRemoveProposals (cnvmlsGroupId . mlsMetaConvOrSub . tUnqualified $ lConvOrSub') epoch
   -- requeue backend remove proposals for the current epoch
   removeClientsWithClientMap lConvOrSub' kpRefs qusr
+  createAndSendRemoveProposals lConvOrSub' kpRefs qusr
   where
     derefUser :: ClientMap -> Qualified UserId -> Sem r (ClientIdentity, KeyPackageRef)
     derefUser cm user = case Map.assocs cm of

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -814,7 +814,6 @@ processExternalCommit qusr mSenderClient lConvOrSub epoch action updatePath = wi
   -- fetch backend remove proposals of the previous epoch
   kpRefs <- getPendingBackendRemoveProposals (cnvmlsGroupId . mlsMetaConvOrSub . tUnqualified $ lConvOrSub') epoch
   -- requeue backend remove proposals for the current epoch
-  removeClientsWithClientMap lConvOrSub' kpRefs qusr
   createAndSendRemoveProposals lConvOrSub' kpRefs qusr
   where
     derefUser :: ClientMap -> Qualified UserId -> Sem r (ClientIdentity, KeyPackageRef)

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -951,13 +951,7 @@ processInternalCommit qusr senderClient con lConvOrSub epoch action senderRef co
               unless (isClientMember (mkClientIdentity qusr creatorClient) (mcMembers parentConv)) $
                 throwS @'MLSSubConvClientNotInParent
               let creatorRef = fromMaybe senderRef updatePathRef
-              addKeyPackageRef creatorRef qusr creatorClient $
-                tUntagged (convOfConvOrSub . idForConvOrSub <$> lConvOrSub)
-              addMLSClients
-                (cnvmlsGroupId mlsMeta)
-                qusr
-                (Set.singleton (creatorClient, creatorRef))
-            -- uninitialised conversations should contain exactly one client
+              updateKeyPackageMapping lConvOrSub qusr creatorClient Nothing creatorRef
             (_, _, _, _) ->
               throw (InternalErrorWithDescription "Unexpected creator client set")
           pure $ pure () -- no key package ref update necessary

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -27,6 +27,7 @@ module Galley.API.MLS.Message
 where
 
 import Control.Arrow ((>>>))
+import Debug.Trace
 import Control.Comonad
 import Control.Error.Util (hush)
 import Control.Lens (forOf_, preview)
@@ -475,7 +476,9 @@ getSenderClient qusr SMLSPlainText msg = case msgSender msg of
   PreconfiguredSender _ -> pure Nothing
   NewMemberSender -> pure Nothing
   MemberSender ref -> do
+    traceM "getSenderClient before"
     cid <- derefKeyPackage ref
+    traceM "getSenderClient after"
     when (fmap fst (cidQualifiedClient cid) /= qusr) $
       throwS @'MLSClientSenderUserMismatch
     pure (Just (ciClient cid))
@@ -819,7 +822,9 @@ processExternalCommit qusr mSenderClient lConvOrSub epoch action updatePath = wi
         unless (user == u) $
           throwS @'MLSClientSenderUserMismatch
         ref <- ensureSingleton clients
+        traceM "derefUser before"
         ci <- derefKeyPackage ref
+        traceM "derefUser after"
         unless (cidQualifiedUser ci == user) $
           throwS @'MLSClientSenderUserMismatch
         pure (ci, ref)
@@ -1082,7 +1087,9 @@ applyProposal convOrSubConvId groupId (AddProposal kp) = do
       addMLSClients groupId qusr (Set.singleton (ciClient cid, ref))
       pure cid
 applyProposal _convOrSubConvId _groupId (RemoveProposal ref) = do
+  traceM "applyProposal before"
   qclient <- cidQualifiedClient <$> derefKeyPackage ref
+  traceM "applyProposal after"
   pure (paRemoveClient ((,ref) <$$> qclient))
 applyProposal _convOrSubConvId _groupId (ExternalInitProposal _) =
   -- only record the fact there was an external init proposal, but do not

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -928,12 +928,7 @@ processInternalCommit qusr senderClient con lConvOrSub epoch action senderRef co
             (True, SelfConv, [], Conv _) -> do
               creatorClient <- noteS @'MLSMissingSenderClient senderClient
               let creatorRef = fromMaybe senderRef updatePathRef
-              addKeyPackageRef creatorRef qusr creatorClient $
-                tUntagged (convOfConvOrSub . idForConvOrSub <$> lConvOrSub)
-              addMLSClients
-                (cnvmlsGroupId mlsMeta)
-                qusr
-                (Set.singleton (creatorClient, creatorRef))
+              updateKeyPackageMapping lConvOrSub qusr creatorClient Nothing creatorRef
             (True, SelfConv, _, _) ->
               -- this is a newly created (sub)conversation, and it should
               -- contain exactly one client (the creator)

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -28,7 +28,6 @@ import Data.Id
 import Data.Json.Util
 import Data.Qualified
 import Data.Time
-import Debug.Trace
 import Galley.API.MLS.Enabled
 import Galley.API.MLS.KeyPackage
 import Galley.API.Push
@@ -111,12 +110,7 @@ welcomeRecipients ::
 welcomeRecipients =
   traverse
     ( fmap cidQualifiedClient
-        . ( \x -> do
-              traceM "welcomeRecipients before"
-              res <- derefKeyPackage x
-              traceM "welcomeRecipients after"
-              pure res
-          )
+        . derefKeyPackage
         . gsNewMember
     )
     . welSecrets

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -28,6 +28,7 @@ import Data.Id
 import Data.Json.Util
 import Data.Qualified
 import Data.Time
+import Debug.Trace
 import Galley.API.MLS.Enabled
 import Galley.API.MLS.KeyPackage
 import Galley.API.Push
@@ -110,7 +111,12 @@ welcomeRecipients ::
 welcomeRecipients =
   traverse
     ( fmap cidQualifiedClient
-        . derefKeyPackage
+        . ( \x -> do
+              traceM "welcomeRecipients before"
+              res <- derefKeyPackage x
+              traceM "welcomeRecipients after"
+              pure res
+          )
         . gsNewMember
     )
     . welSecrets

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -45,6 +45,7 @@ import Data.Singletons
 import Data.String.Conversions
 import qualified Data.Text as T
 import Data.Time
+import Debug.Trace
 import Federator.MockServer hiding (withTempMockFederator)
 import Imports
 import qualified Network.Wai.Utilities.Error as Wai
@@ -1593,6 +1594,7 @@ testBackendRemoveProposalRecreateClient = do
     void $ createPendingProposalCommit alice1 >>= sendAndConsumeCommitBundle
 
     (_, ref) <- assertOne =<< getClientsFromGroupState alice1 alice
+    traceM ("test: the ref " <> show ref)
     liftTest $
       deleteClient (qUnqualified alice) (ciClient alice1) (Just defPassword)
         !!! const 200 === statusCode
@@ -1607,6 +1609,7 @@ testBackendRemoveProposalRecreateClient = do
 
     consumeMessage1 alice2 proposal
 
+    -- this fails with 404 mls-key-package-ref-not-found
     void $ createPendingProposalCommit alice2 >>= sendAndConsumeCommitBundle
 
     void $ createApplicationMessage alice1 "hello" >>= sendAndConsumeMessage

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -45,7 +45,6 @@ import Data.Singletons
 import Data.String.Conversions
 import qualified Data.Text as T
 import Data.Time
-import Debug.Trace
 import Federator.MockServer hiding (withTempMockFederator)
 import Imports
 import qualified Network.Wai.Utilities.Error as Wai
@@ -1594,7 +1593,7 @@ testBackendRemoveProposalRecreateClient = do
     void $ createPendingProposalCommit alice1 >>= sendAndConsumeCommitBundle
 
     (_, ref) <- assertOne =<< getClientsFromGroupState alice1 alice
-    traceM ("test: the ref " <> show ref)
+
     liftTest $
       deleteClient (qUnqualified alice) (ciClient alice1) (Just defPassword)
         !!! const 200 === statusCode
@@ -1612,8 +1611,6 @@ testBackendRemoveProposalRecreateClient = do
         wsAssertBackendRemoveProposal alice qcnv ref
 
     consumeMessage1 alice2 proposal
-
-    -- this fails with 404 mls-key-package-ref-not-found
     void $ createPendingProposalCommit alice2 >>= sendAndConsumeCommitBundle
 
     void $ createApplicationMessage alice2 "hello" >>= sendAndConsumeMessage

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -162,6 +162,7 @@ tests s =
       testGroup
         "Backend-side External Remove Proposals"
         [ test s "local conversation, local user deleted" testBackendRemoveProposalLocalConvLocalUser,
+          test s "local conversation, recreate client" testBackendRemoveProposalRecreateClient,
           test s "local conversation, remote user deleted" testBackendRemoveProposalLocalConvRemoteUser,
           test s "local conversation, creator leaving" testBackendRemoveProposalLocalConvLocalLeaverCreator,
           test s "local conversation, local committer leaving" testBackendRemoveProposalLocalConvLocalLeaverCommitter,
@@ -1580,6 +1581,36 @@ propUnsupported = do
     -- support AppAck proposals
     postMessage alice1 msgData !!! const 201 === statusCode
 
+testBackendRemoveProposalRecreateClient :: TestM ()
+testBackendRemoveProposalRecreateClient = do
+  alice <- randomQualifiedUser
+  runMLSTest $ do
+    alice1 <- createMLSClient alice
+    (_, qcnv) <- setupMLSSelfGroup alice1
+
+    let cnv = Conv <$> qcnv
+
+    void $ createPendingProposalCommit alice1 >>= sendAndConsumeCommitBundle
+
+    (_, ref) <- assertOne =<< getClientsFromGroupState alice1 alice
+    liftTest $
+      deleteClient (qUnqualified alice) (ciClient alice1) (Just defPassword)
+        !!! const 200 === statusCode
+
+    alice2 <- createMLSClient alice
+    proposal <- mlsBracket [alice2] $ \[wsA] -> do
+      void $
+        createExternalCommit alice2 Nothing cnv
+          >>= sendAndConsumeCommitBundle
+      WS.assertMatch (5 # WS.Second) wsA $
+        wsAssertBackendRemoveProposal alice qcnv ref
+
+    consumeMessage1 alice2 proposal
+
+    void $ createPendingProposalCommit alice2 >>= sendAndConsumeCommitBundle
+
+    void $ createApplicationMessage alice1 "hello" >>= sendAndConsumeMessage
+
 testBackendRemoveProposalLocalConvLocalUser :: TestM ()
 testBackendRemoveProposalLocalConvLocalUser = do
   [alice, bob] <- createAndConnectUsers (replicate 2 Nothing)
@@ -2049,6 +2080,9 @@ testRemoteUserPostsCommitBundle = do
 
         pure ()
 
+-- FUTUREWORK: New clients should be adding themselves via external commits, and
+-- they shouldn't be added by another client. Change the test so external
+-- commits are used.
 testSelfConversation :: TestM ()
 testSelfConversation = do
   alice <- randomQualifiedUser

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1598,6 +1598,10 @@ testBackendRemoveProposalRecreateClient = do
     liftTest $
       deleteClient (qUnqualified alice) (ciClient alice1) (Just defPassword)
         !!! const 200 === statusCode
+    State.modify $ \mls ->
+      mls
+        { mlsMembers = Set.difference (mlsMembers mls) (Set.singleton alice1)
+        }
 
     alice2 <- createMLSClient alice
     proposal <- mlsBracket [alice2] $ \[wsA] -> do
@@ -1612,7 +1616,7 @@ testBackendRemoveProposalRecreateClient = do
     -- this fails with 404 mls-key-package-ref-not-found
     void $ createPendingProposalCommit alice2 >>= sendAndConsumeCommitBundle
 
-    void $ createApplicationMessage alice1 "hello" >>= sendAndConsumeMessage
+    void $ createApplicationMessage alice2 "hello" >>= sendAndConsumeMessage
 
 testBackendRemoveProposalLocalConvLocalUser :: TestM ()
 testBackendRemoveProposalLocalConvLocalUser = do


### PR DESCRIPTION
As reported in https://wearezeta.atlassian.net/browse/FS-1488, when a device of a creator of an MLS self-conversation is deleted, the device cannot be successfully removed from an MLS self-conversation. This was the case because there was no mapping of the creator client key package reference in Brig. This PR fixes that.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
