### PR TITLE
MLS integration testing: make client group state transparent in state

### DIFF
--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -353,7 +353,7 @@ mlscli qcid args mbstdin = do
         ( proc
             "mls-test-cli"
             ( ["--store", cdir </> "store"]
-                <> map (appEndo (substIn <> substOut)) args
+                <> map (substIn . substOut) args
             )
         )
         mbstdin
@@ -364,8 +364,8 @@ mlscli qcid args mbstdin = do
     setClientGroupState qcid gs
   pure out
 
-argSubst :: String -> String -> Endo String
-argSubst from to_ = Endo $ \s ->
+argSubst :: String -> String -> String -> String
+argSubst from to_ s =
   if s == from then to_ else s
 
 createWireClient :: HasCallStack => Qualified UserId -> MLSTest ClientIdentity


### PR DESCRIPTION
This PR changes the way `MLSTest` monad manages client's group state: The client's group state is now transparently availble in the monad's state instead of in the file system.
