### PR TITLE
Add a futurework note on the order of actions when creating a conversation

### DIFF
--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -129,6 +129,10 @@ createGroupConversation lusr conn newConv = do
     ProtocolProteusTag -> pure ()
 
   lcnv <- traverse (const E.createConversationId) lusr
+  -- FUTUREWORK: Invoke the creating a conversation action only once
+  -- protocol-specific validation is successful. Otherwise we might write the
+  -- conversation to the database, and throw a validation error when the
+  -- conversation is already in the database.
   conv <- E.createConversation lcnv nc
 
   -- set creator client for MLS conversations


### PR DESCRIPTION
As the note in the changed file reads:

> FUTUREWORK: Invoke the creating a conversation action only once
> protocol-specific validation is successful. Otherwise we might write the
> conversation to the database, and throw a validation error when the
> conversation is already in the database.

I believe the PR does not need a changelog.

## Checklist

 - [x] No changelog entry
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
