### PR TITLE
Development: Make sure ES schema is reset before test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,12 +245,12 @@ db-migrate-package:
 db-reset: c
 	@echo "Make sure you have ./deploy/dockerephemeral/run.sh running in another window!"
 ifeq ($(package), all)
-	./dist/brig-schema --keyspace brig_test --replication-factor 1 --reset > /dev/null
-	./dist/galley-schema --keyspace galley_test --replication-factor 1 --reset > /dev/null
-	./dist/gundeck-schema --keyspace gundeck_test --replication-factor 1 --reset > /dev/null
-	./dist/spar-schema --keyspace spar_test --replication-factor 1 --reset > /dev/null
+	./dist/brig-schema --keyspace brig_test --replication-factor 1 --reset
+	./dist/galley-schema --keyspace galley_test --replication-factor 1 --reset
+	./dist/gundeck-schema --keyspace gundeck_test --replication-factor 1 --reset
+	./dist/spar-schema --keyspace spar_test --replication-factor 1 --reset
 else
-	$(EXE_SCHEMA) --keyspace $(package)_test --replication-factor 1 --reset > /dev/null
+	$(EXE_SCHEMA) --keyspace $(package)_test --replication-factor 1 --reset
 endif
 	./dist/brig-index reset --elasticsearch-server http://localhost:9200 > /dev/null
 

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ db-migrate-package:
 
 # Usage:
 #
-# Reset all keyspaces
+# Reset all keyspaces and reset the ES index
 # make db-reset
 #
 # Reset keyspace for only one service, say galley:
@@ -245,35 +245,29 @@ db-migrate-package:
 db-reset: c
 	@echo "Make sure you have ./deploy/dockerephemeral/run.sh running in another window!"
 ifeq ($(package), all)
-	./dist/brig-schema --keyspace brig_test --replication-factor 1 --reset
-	./dist/galley-schema --keyspace galley_test --replication-factor 1 --reset
-	./dist/gundeck-schema --keyspace gundeck_test --replication-factor 1 --reset
-	./dist/spar-schema --keyspace spar_test --replication-factor 1 --reset
+	./dist/brig-schema --keyspace brig_test --replication-factor 1 --reset > /dev/null
+	./dist/galley-schema --keyspace galley_test --replication-factor 1 --reset > /dev/null
+	./dist/gundeck-schema --keyspace gundeck_test --replication-factor 1 --reset > /dev/null
+	./dist/spar-schema --keyspace spar_test --replication-factor 1 --reset > /dev/null
 else
-	$(EXE_SCHEMA) --keyspace $(package)_test --replication-factor 1 --reset
+	$(EXE_SCHEMA) --keyspace $(package)_test --replication-factor 1 --reset > /dev/null
 endif
+	./dist/brig-index reset --elasticsearch-server http://localhost:9200 > /dev/null
 
 # Usage:
 #
-# Migrate all keyspaces
+# Migrate all keyspaces and reset the ES index
 # make db-migrate
 #
 # Migrate keyspace for only one service, say galley:
 # make db-migrate package=galley
 .PHONY: db-migrate
 db-migrate: c
-ifeq ($(package), all)
-	./dist/brig-schema --keyspace brig_test --replication-factor 1
-	./dist/galley-schema --keyspace galley_test --replication-factor 1
-	./dist/gundeck-schema --keyspace gundeck_test --replication-factor 1
-	./dist/spar-schema --keyspace spar_test --replication-factor 1
-# How this check works: https://stackoverflow.com/a/9802777
-else ifeq ($(package), $(filter $(package),brig galley gundeck spar))
-	$(EXE_SCHEMA) --keyspace $(package)_test --replication-factor 1
-else
-	@echo No schema migrations for $(package)
-endif
-
+	./dist/brig-schema --keyspace brig_test --replication-factor 1 > /dev/null
+	./dist/galley-schema --keyspace galley_test --replication-factor 1 > /dev/null
+	./dist/gundeck-schema --keyspace gundeck_test --replication-factor 1 > /dev/null
+	./dist/spar-schema --keyspace spar_test --replication-factor 1 > /dev/null
+	./dist/brig-index reset --elasticsearch-server http://localhost:9200 > /dev/null
 
 #################################
 ## dependencies

--- a/libs/types-common/src/Util/Options.hs
+++ b/libs/types-common/src/Util/Options.hs
@@ -32,7 +32,6 @@ import Imports
 import Options.Applicative
 import Options.Applicative.Types
 import System.Exit (die)
-import System.IO (hPutStrLn)
 import URI.ByteString
 import Util.Options.Common
 
@@ -137,10 +136,6 @@ getOptions desc pars defaultPath = do
         Right o -> pure o
     -- Config doesn't exist but at least we have a CLI options parser
     (False, Just p) -> do
-      hPutStrLn stderr $
-        "Config file at "
-          ++ path
-          ++ " does not exist, falling back to command-line arguments. \n"
       execParser (info (helper <*> p) mkDesc)
     -- No config, no parser :(
     (False, Nothing) -> do


### PR DESCRIPTION
Follow up to https://github.com/wireapp/wire-server/issues/2791

This PR updates local development test setup:

- the ES schema is always reset before any local integration tests are run
- all DB schemas are migrated when you run any test suite (was only the DB for the test suite's service before). This is most likely what we want.

This PR also removes am unhelpful warning in the -schema binaries.
