### PR TITLE
Tweak docker-ephemeral/run.sh

### DIFF
--- a/deploy/dockerephemeral/run.sh
+++ b/deploy/dockerephemeral/run.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+set -x
+
 # run.sh should work no matter what is the current directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DOCKER_FILE="$SCRIPT_DIR/docker-compose.yaml"
 
-docker-compose --file "$DOCKER_FILE" up
+docker compose --file "$DOCKER_FILE" up
+docker compose --file "$DOCKER_FILE" down


### PR DESCRIPTION
Needed to put docker into a consistent state somehow more reliably after shutdown.  This works as you'd expect for a single `^C`.  If you press ^C twice, you're on your own!