### PR TITLE
Use valid versions in URL path

### DIFF
--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -133,10 +133,10 @@ assertBackendApiVersion = recoverAll (constantDelay 1000000 <> limitRetries 5) $
     throwIO . ErrorCall $ "newest supported backend api version must be " <> show backendApiVersion
 
 path :: ByteString -> Request -> Request
-path = Bilge.path . ((toByteString' backendApiVersion <> "/") <>)
+path = Bilge.path . (("v" <> toByteString' backendApiVersion <> "/") <>)
 
 paths :: [ByteString] -> Request -> Request
-paths = Bilge.paths . (toByteString' backendApiVersion :)
+paths = Bilge.paths . ("v" <> toByteString' backendApiVersion :)
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
The pattern is `/v<number>/<path>`, not `/<number>/<path>`.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
