### PR TITLE
fix: explicitly disallow negative timestamps in libzauth tokens

### DIFF
--- a/changelog.d/5-internal/libzauth-timestamps
+++ b/changelog.d/5-internal/libzauth-timestamps
@@ -1,0 +1,1 @@
+Explicitly disallow negative timestamps in libzauth tokens when validating if a token is stil valid

--- a/libs/libzauth/libzauth/src/zauth.rs
+++ b/libs/libzauth/libzauth/src/zauth.rs
@@ -187,6 +187,10 @@ impl<'r> Token<'r> {
     }
 
     fn is_expired(&self) -> bool {
+        // negative timestamps are always considered as expired
+        if self.timestamp < 0 {
+            return false;
+        }
         let expiration = UNIX_EPOCH + Duration::from_secs(self.timestamp as u64);
         expiration < SystemTime::now()
     }


### PR DESCRIPTION
`timestamp` in `Token` is a signed integer, but is required to be an unsigned integer for `Duration`.

Since `is_expired` will always only be used on tokens with non negative values, we can safely reject all attempts to verify a token with negative `timestamp` values.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
