### PR TITLE
[FS-1336] Extend a test: everyone gets notified about leaving

### DIFF
--- a/changelog.d/2-features/subconv-leave
+++ b/changelog.d/2-features/subconv-leave
@@ -1,1 +1,1 @@
-Implement endpoint for leaving a subconversation
+Implement endpoint for leaving a subconversation (#2969, #3073)

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -2791,6 +2791,7 @@ testLeaveSubConv = do
     (qsub, _) <- withTempMockFederator'
       ( receiveCommitMock [charlie1]
           <|> welcomeMock
+          <|> ("on-mls-message-sent" ~> RemoteMLSMessageOk)
       )
       $ do
         void $ createAddCommit alice1 [bob, charlie] >>= sendAndConsumeCommit


### PR DESCRIPTION
This is a follow-up to #2969 and an extension to a test for leaving a subconversation where everyone in the subconversation, including the leaver, gets the backend-created remove propsal.

Tracked by https://wearezeta.atlassian.net/browse/FS-1336.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
