### PR TITLE
[FS-1541] After the last leaver the subconversation should be reset

### DIFF
--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -146,7 +146,10 @@ type GalleyApi =
            DeleteSubConversationFedRequest
            DeleteSubConversationResponse
     :<|> FedEndpointWithMods
-           '[MakesFederatedCall 'Galley "on-mls-message-sent"]
+           '[ MakesFederatedCall 'Galley "on-mls-message-sent",
+              MakesFederatedCall 'Galley "on-delete-mls-conversation",
+              MakesFederatedCall 'Galley "on-new-remote-subconversation"
+            ]
            "leave-sub-conversation"
            LeaveSubConversationRequest
            LeaveSubConversationResponse

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -424,9 +424,13 @@ type ConversationAPI =
            ( Summary "Leave an MLS subconversation"
                :> MakesFederatedCall 'Galley "on-mls-message-sent"
                :> MakesFederatedCall 'Galley "leave-sub-conversation"
+               :> MakesFederatedCall 'Galley "on-delete-mls-conversation"
+               :> MakesFederatedCall 'Galley "on-new-remote-subconversation"
                :> CanThrow 'ConvNotFound
                :> CanThrow 'ConvAccessDenied
                :> CanThrow 'MLSProtocolErrorTag
+               :> CanThrow 'MLSStaleMessage
+               :> CanThrow 'MLSNotEnabled
                :> ZLocalUser
                :> ZClient
                :> "conversations"

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -932,7 +932,12 @@ getSubConversationForRemoteUser domain GetSubConversationsRequest {..} =
 
 leaveSubConversation ::
   ( HasLeaveSubConversationEffects r,
-    Members '[Input (Local ())] r
+    Members
+      '[ Input (Local ()),
+         Resource,
+         SubConversationSupply
+       ]
+      r
   ) =>
   Domain ->
   LeaveSubConversationRequest ->

--- a/services/galley/src/Galley/API/MLS/Types.hs
+++ b/services/galley/src/Galley/API/MLS/Types.hs
@@ -49,7 +49,9 @@ cmRemoveClient cid cm = case Map.lookup (cidQualifiedUser cid) cm of
   Nothing -> cm
   Just clients ->
     let clients' = Map.delete (ciClient cid) clients
-     in Map.insert (cidQualifiedUser cid) clients' cm
+     in if Map.null clients'
+          then Map.delete (cidQualifiedUser cid) cm
+          else Map.insert (cidQualifiedUser cid) clients' cm
 
 isClientMember :: ClientIdentity -> ClientMap -> Bool
 isClientMember ci = isJust . cmLookupRef ci

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -223,6 +223,7 @@ tests s =
               test s "reset a subconversation as a non-member" (testDeleteSubConv False),
               test s "fail to reset a subconversation with wrong epoch" testDeleteSubConvStale,
               test s "leave a subconversation" testLeaveSubConv,
+              test s "last to leave a subconversation" testLastLeaverSubConv,
               test s "leave a subconversation as a non-member" testLeaveSubConvNonMember,
               test s "remove user from parent conversation" testRemoveUserParent,
               test s "remove creator from parent conversation" testRemoveCreatorParent,
@@ -2909,6 +2910,38 @@ testDeleteRemoteSubConv isAMember = do
     let req :: Maybe DeleteSubConversationFedRequest =
           Aeson.decode (frBody actualReq)
     liftIO $ req @?= Just expectedReq
+
+testLastLeaverSubConv :: TestM ()
+testLastLeaverSubConv = do
+  alice <- randomQualifiedUser
+
+  runMLSTest $ do
+    [alice1, alice2] <- traverse createMLSClient [alice, alice]
+    void $ uploadNewKeyPackage alice2
+    (_, qcnv) <- setupMLSGroup alice1
+    void $ createAddCommit alice1 [alice] >>= sendAndConsumeCommitBundle
+
+    let subId = SubConvId "conference"
+    qsub <- createSubConv qcnv alice1 subId
+    prePsc <-
+      liftTest $
+        responseJsonError
+          =<< getSubConv (qUnqualified alice) qcnv subId
+            <!! do
+              const 200 === statusCode
+    void $ leaveCurrentConv alice1 qsub
+
+    psc <-
+      liftTest $
+        responseJsonError
+          =<< getSubConv (qUnqualified alice) qcnv subId
+            <!! do
+              const 200 === statusCode
+    liftIO $ do
+      pscEpoch psc @?= Epoch 0
+      pscEpochTimestamp psc @?= Nothing
+      assertBool "group ID unchanged" $ pscGroupId prePsc /= pscGroupId psc
+      length (pscMembers psc) @?= 0
 
 testLeaveSubConv :: TestM ()
 testLeaveSubConv = do


### PR DESCRIPTION
According to https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/641171479/Conferencing+in+MLS+Subconversations#Hangup, a subconversation's epoch should be reset to zero once its last member leaves. The test case in this PR shows the code doesn't currently do that. It additionally asserts there should be no members after the last member leaves, which is a reasonable expectation.

Tracked by https://wearezeta.atlassian.net/browse/FS-1541.

## Checklist

 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
