### PR TITLE
Use docker-compose in run.sh

### DIFF
--- a/deploy/dockerephemeral/run.sh
+++ b/deploy/dockerephemeral/run.sh
@@ -6,5 +6,5 @@ set -x
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DOCKER_FILE="$SCRIPT_DIR/docker-compose.yaml"
 
-docker compose --file "$DOCKER_FILE" up
-docker compose --file "$DOCKER_FILE" down
+docker-compose --file "$DOCKER_FILE" up
+docker-compose --file "$DOCKER_FILE" down


### PR DESCRIPTION
Follow up to #3068. Using `docker compose` caused problems in multiple developer's dev envs.
