### PR TITLE
Update container images in coturn Helm chart

### DIFF
--- a/changelog.d/0-release-notes/coturn-beta
+++ b/changelog.d/0-release-notes/coturn-beta
@@ -1,0 +1,1 @@
+The coturn Helm chart has been promoted to *beta* level stability.

--- a/changelog.d/2-features/coturn-image-update
+++ b/changelog.d/2-features/coturn-image-update
@@ -1,0 +1,6 @@
+The coturn container image included in the coturn Helm chart was updated to
+version `4.6.0-wireapp.3`.
+
+With this version of coturn, the Prometheus metrics endpoint has been
+updated, and the `turn_active_allocations` metric label has been *renamed* to
+`turn_total_allocations`.

--- a/changelog.d/3-bug-fixes/coturn-config-reloader
+++ b/changelog.d/3-bug-fixes/coturn-config-reloader
@@ -1,0 +1,3 @@
+The container image used for handling online TLS certificate updates in the
+coturn Helm chart was updated to a version with metadata compatible with
+containerd.

--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -11,4 +11,4 @@ version: 0.0.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.5.2-wireapp.8
+appVersion: 4.6.0-wireapp.3

--- a/charts/coturn/README.md
+++ b/charts/coturn/README.md
@@ -1,4 +1,4 @@
-**Warning**: this chart is currently considered alpha. Use at your own risk!
+**Warning**: this chart is currently considered beta. Use at your own risk!
 
 This chart deploys Wire's fork of [coturn](https://github.com/coturn/coturn),
 a STUN and TURN server, with some additional features developed by Wire (see

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -36,7 +36,7 @@ tls:
     # for handling runtime certificate reloads.
     repository: quay.io/wire/config-reloader-sidecar
     pullPolicy: IfNotPresent
-    tag: 1aa6cbbf2ce3a5182ec47e3579bbcb8f47e22fdc
+    tag: 72c3c8434660bd157d42012b0bcd67f338fc5c7a
 
 metrics:
   serviceMonitor:


### PR DESCRIPTION
This updates the default version of coturn in the Helm chart to the latest stable version currently in use in our cloud environments. Also, the config reloader sidecar image has been updated to a version with metadata which is compatible with containerd.

The Helm chart is also promoted from alpha to beta stability, given that we now have this deployed in our cloud environments.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
