### PR TITLE
[FS-1534] A subconversation leaver gets a remove proposal

### DIFF
--- a/changelog.d/2-features/subconv-leave
+++ b/changelog.d/2-features/subconv-leave
@@ -1,1 +1,1 @@
-Implement endpoint for leaving a subconversation
+Implement endpoint for leaving a subconversation (#2969, #3080)

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -357,7 +357,8 @@ postMLSCommitBundleToLocalConv qusr mc conn bundle lConvOrSubId = do
     ApplicationMessage _ -> throwS @'MLSUnsupportedMessage
     ProposalMessage _ -> throwS @'MLSUnsupportedMessage
 
-  propagateMessage qusr lConvOrSub conn (rmRaw (cbCommitMsg bundle))
+  let cm = membersConvOrSub (tUnqualified lConvOrSub)
+  propagateMessage qusr lConvOrSub conn (rmRaw (cbCommitMsg bundle)) cm
 
   for_ (cbWelcome bundle) $
     postMLSWelcome lConvOrSub conn
@@ -574,7 +575,8 @@ postMLSMessageToLocalConv qusr senderClient con smsg convOrSubId = case rmValue 
         Right ApplicationMessageTag -> pure mempty
         Left _ -> throwS @'MLSUnsupportedMessage
 
-    propagateMessage qusr lConvOrSub con (rmRaw smsg)
+    let cm = membersConvOrSub (tUnqualified lConvOrSub)
+    propagateMessage qusr lConvOrSub con (rmRaw smsg) cm
 
     pure events
 
@@ -833,7 +835,8 @@ processExternalCommit qusr mSenderClient lConvOrSub epoch action updatePath = wi
   -- fetch backend remove proposals of the previous epoch
   kpRefs <- getPendingBackendRemoveProposals (cnvmlsGroupId . mlsMetaConvOrSub . tUnqualified $ lConvOrSub') epoch
   -- requeue backend remove proposals for the current epoch
-  createAndSendRemoveProposals lConvOrSub' kpRefs qusr
+  let cm = membersConvOrSub (tUnqualified lConvOrSub')
+  createAndSendRemoveProposals lConvOrSub' kpRefs qusr cm
   where
     derefUser :: ClientMap -> Qualified UserId -> Sem r (ClientIdentity, KeyPackageRef)
     derefUser cm user = case Map.assocs cm of

--- a/services/galley/src/Galley/API/MLS/SubConversation.hs
+++ b/services/galley/src/Galley/API/MLS/SubConversation.hs
@@ -412,10 +412,13 @@ leaveLocalSubConversation cid lcnv sub = do
   kp <-
     note (mlsProtocolError "Client is not a member of the subconversation") $
       cmLookupRef cid (scMembers subConv)
+  -- remove the leaver from the member list
+  let cm = cmRemoveClient cid (scMembers subConv)
   createAndSendRemoveProposals
     (qualifyAs lcnv (SubConv mlsConv subConv))
     (Identity kp)
     (cidQualifiedUser cid)
+    cm
 
 leaveRemoteSubConversation ::
   ( Members

--- a/services/galley/src/Galley/API/MLS/Types.hs
+++ b/services/galley/src/Galley/API/MLS/Types.hs
@@ -44,6 +44,13 @@ cmLookupRef cid cm = do
   clients <- Map.lookup (cidQualifiedUser cid) cm
   Map.lookup (ciClient cid) clients
 
+cmRemoveClient :: ClientIdentity -> ClientMap -> ClientMap
+cmRemoveClient cid cm = case Map.lookup (cidQualifiedUser cid) cm of
+  Nothing -> cm
+  Just clients ->
+    let clients' = Map.delete (ciClient cid) clients
+     in Map.insert (cidQualifiedUser cid) clients' cm
+
 isClientMember :: ClientIdentity -> ClientMap -> Bool
 isClientMember ci = isJust . cmLookupRef ci
 

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -2791,6 +2791,7 @@ testLeaveSubConv = do
     (qsub, _) <- withTempMockFederator'
       ( receiveCommitMock [charlie1]
           <|> welcomeMock
+          <|> ("on-mls-message-sent" ~> RemoteMLSMessageOk)
       )
       $ do
         void $ createAddCommit alice1 [bob, charlie] >>= sendAndConsumeCommit


### PR DESCRIPTION
This fixes a bug identified in https://wearezeta.atlassian.net/browse/FS-1534. A client leaving a subconversation would get a backend-created remove proposal, while it should not. The fix makes the application logic consistent with the MLS conversation leaving case where the leaving user gets no backend-created proposals.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
