### PR TITLE
Remove duplicated Makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,35 +236,6 @@ db-migrate-package:
 
 # Usage:
 #
-# Reset all keyspaces and reset the ES index
-# make db-reset
-#
-# Reset keyspace for only one service, say galley:
-# make db-reset package=galley
-.PHONY: db-reset
-db-reset: c
-	@echo "Make sure you have ./deploy/dockerephemeral/run.sh running in another window!"
-ifeq ($(package), all)
-	./dist/brig-schema --keyspace brig_test --replication-factor 1 --reset
-	./dist/galley-schema --keyspace galley_test --replication-factor 1 --reset
-	./dist/gundeck-schema --keyspace gundeck_test --replication-factor 1 --reset
-	./dist/spar-schema --keyspace spar_test --replication-factor 1 --reset
-ifeq ($(INTEGRATION_FEDERATION_TESTS), 1)
-	./dist/brig-schema --keyspace brig_test2 --replication-factor 1 --reset
-	./dist/galley-schema --keyspace galley_test2 --replication-factor 1 --reset
-	./dist/gundeck-schema --keyspace gundeck_test2 --replication-factor 1 --reset
-	./dist/spar-schema --keyspace spar_test2 --replication-factor 1 --reset
-endif
-else
-	$(EXE_SCHEMA) --keyspace $(package)_test --replication-factor 1 --reset
-ifeq ($(INTEGRATION_FEDERATION_TESTS), 1)
-	$(EXE_SCHEMA) --keyspace $(package)_test2 --replication-factor 1 --reset
-endif
-endif
-	./dist/brig-index reset --elasticsearch-server http://localhost:9200 > /dev/null
-
-# Usage:
-#
 # Migrate all keyspaces and reset the ES index
 # make db-migrate
 #


### PR DESCRIPTION
This was probably the result of a broken conflict resolution.

## Checklist

 - [x] No CHANGELOG entry
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
