### PR TITLE
Coturn container image update errata

### DIFF
--- a/changelog.d/2-features/coturn-image-update
+++ b/changelog.d/2-features/coturn-image-update
@@ -1,5 +1,5 @@
 The coturn container image included in the coturn Helm chart was updated to
-version `4.6.0-wireapp.3`.
+version `4.6.0-wireapp.4`.
 
 With this version of coturn, the Prometheus metrics endpoint has been
 updated, and the `turn_active_allocations` metric label has been *renamed* to

--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -11,4 +11,4 @@ version: 0.0.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.6.0-wireapp.3
+appVersion: 4.6.0-wireapp.4


### PR DESCRIPTION
This is a follow-up to #3078. The pre-stop hook script was not updated when some metrics were relabeled in the update from 4.5.2 to 4.6.0, which would mean that the script would inadvertently exit while there were still active TURN sessions in the coturn process. This change updates the coturn image to a version with a fixed pre-stop hook script.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
