### PR TITLE
deflake: wait 1 extra second before attempting to renew a cookie.

### DIFF
--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -945,7 +945,7 @@ getAndTestDBSupersededCookieAndItsValidSuccessor :: Opts.Opts -> Brig -> Nginz -
 getAndTestDBSupersededCookieAndItsValidSuccessor config b n = do
   u <- randomUser b
   let renewAge = Opts.setUserCookieRenewAge $ Opts.optSettings config
-  let minAge = fromIntegral $ renewAge * 1000000 + 1
+  let minAge = fromIntegral $ (renewAge + 1) * 1000000
       Just email = userEmail u
   _rs <-
     login n (emailLogin email defPassword (Just "nexus1")) PersistentCookie


### PR DESCRIPTION
The failure:

```
nginz-login-multiple-cookies: FAIL
            Exception: Assertions failed:
             2: Nothing === Nothing
```
occurs on the check for the header
```haskell
  -- Refresh tokens
  _rs <-
    post (unversioned . n . path "/access" . cookie c) <!! do
      const 200 === statusCode
      const Nothing =/= getHeader "Set-Cookie"  -- FAILURE
      const (Just "access_token") =~= responseBody
```
context: you only get a fresh user cookie after the renew age (2 seconds) have elapsed. Before that, only the access token is renewed, but you don't get a fresh cookie. As this is based on time, it's possible the timestamp used to decide whether you get a fresh token isn't reached yet. So we wait 1 extra second (3 in total, instead of 2.00001 seconds).

Only time will tell if this is actually deflaking the test in question.

https://wearezeta.atlassian.net/browse/BE-555