### PR TITLE
skip pending proposals included in external commit

### DIFF
--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -801,7 +801,10 @@ processExternalCommit qusr mSenderClient lConvOrSub epoch action updatePath =
     lConvOrSub' <- for lConvOrSub incrementEpoch
 
     -- fetch backend remove proposals of the previous epoch
-    kpRefs <- getPendingBackendRemoveProposals (cnvmlsGroupId . mlsMetaConvOrSub . tUnqualified $ lConvOrSub') epoch
+    kpRefs <-
+      -- skip remove proposals of already removed by the external commit
+      filter (maybe (const True) (/=) remRef)
+        <$> getPendingBackendRemoveProposals (cnvmlsGroupId . mlsMetaConvOrSub . tUnqualified $ lConvOrSub') epoch
     -- requeue backend remove proposals for the current epoch
     let cm = membersConvOrSub (tUnqualified lConvOrSub')
     createAndSendRemoveProposals lConvOrSub' kpRefs qusr cm


### PR DESCRIPTION
External proposals can contain remove proposals to remove key packages
of the same client, "resync" in CoreCrypto speak.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
