### PR TITLE
Fix error in conf when SOURCE_DATE_EPOCH is unset

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -14,7 +14,8 @@ import os
 import requests
 
 # unset SOURCE_DATE_EPOCH to aviod side effects caused by sphinx
-del os.environ['SOURCE_DATE_EPOCH']
+if 'SOURCE_DATE_EPOCH' in os.environ:
+    del os.environ['SOURCE_DATE_EPOCH']
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
## Checklist

 - [x] No changelog entry
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
