### PR TITLE
Upgrade nix and cachix GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
      - uses: actions/checkout@v2
        with:
          submodules: true
-     - uses: cachix/install-nix-action@v14.1
-     - uses: cachix/cachix-action@v10
+     - uses: cachix/install-nix-action@v20
+     - uses: cachix/cachix-action@v12
        with:
          name: wire-server
          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
@@ -32,8 +32,8 @@ jobs:
      - uses: actions/checkout@v2
        with:
          submodules: true
-     - uses: cachix/install-nix-action@v14.1
-     - uses: cachix/cachix-action@v10
+     - uses: cachix/install-nix-action@v20
+     - uses: cachix/cachix-action@v12
        with:
          name: wire-server
          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'


### PR DESCRIPTION
This updates the nix and cachix GitHub actions to their latest versions. The cachix action was a few versions behind, and an upgrade of the nix action is necessary for compatibility with nix 1.14, as reported in cachix/install-nix-action#161.