### PR TITLE
[FS-1558] Add a test: delete a subconversation as a conversation member

### DIFF
--- a/changelog.d/1-api-changes/delete-subconversation
+++ b/changelog.d/1-api-changes/delete-subconversation
@@ -1,1 +1,1 @@
-Introduce an endpoint for deleting a subconversation
+Introduce an endpoint for deleting a subconversation (#2956, #3119)


### PR DESCRIPTION
This adds a test for deleting a subconversation where a user that is in the parent conversation, but not in the subconversation successfully deletes the subconversation. This is an important functionality that allows to delete a subconversation with members that have crashed and never cleaned it up.

Tracked by https://wearezeta.atlassian.net/browse/FS-1588.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
