### PR TITLE
Fix dpop access token test

### DIFF
--- a/changelog.d/5-internal/pr-3125
+++ b/changelog.d/5-internal/pr-3125
@@ -1,0 +1,1 @@
+Fixed test of jwt-tools Rust FFI

--- a/libs/jwt-tools/test/Spec.hs
+++ b/libs/jwt-tools/test/Spec.hs
@@ -25,7 +25,7 @@ main :: IO ()
 main = hspec $ do
   describe "generateDpopToken FFI when passing valid inputs" $ do
     it "should return an access token" $ do
-      actual <- callFFIWithValidValues
+      actual <- callFFIWithValidValuesValidUntil2038
       isRight actual `shouldBe` True
   describe "generateDpopToken FFI when passing nonsense values" $ do
     it "should return an error" $ do
@@ -98,25 +98,25 @@ callFFIWithNonsenseValues =
         \MCowBQYDK2VwAyEACPvhIdimF20tOPjbb+fXJrwS2RKDp7686T90AZ0+Th8=\n\
         \-----END PUBLIC KEY-----\n"
 
-callFFIWithValidValues :: IO (Either DPoPTokenGenerationError ByteString)
-callFFIWithValidValues =
+callFFIWithValidValuesValidUntil2038 :: IO (Either DPoPTokenGenerationError ByteString)
+callFFIWithValidValuesValidUntil2038 =
   runExceptT $ generateDpopToken proof uid cid domain nonce uri method maxSkewSecs expires now pem
   where
-    proof = Proof "eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiZzQwakI3V3pmb2ZCdkxCNVlybmlZM2ZPZU1WVGtfNlpfVnNZM0tBbnpOUSJ9fQ.eyJpYXQiOjE2Nzc2NzAwODEsImV4cCI6MTY3Nzc1NjQ4MSwibmJmIjoxNjc3NjcwMDgxLCJzdWIiOiJpbXBwOndpcmVhcHA9WldKa01qY3labUk0TW1aa05ETXlZamczTm1NM1lXSmtZVFUwWkdSaU56VS8xODllNDhjNmNhODZiNWQ0QGV4YW1wbGUub3JnIiwianRpIjoiZDE5ZWExYmItNWI0Ny00ZGJiLWE1MTktNjU0ZWRmMjU0MTQ0Iiwibm9uY2UiOiJZMkZVTjJaTlExUnZSV0l6Ympsa2RGRjFjWGhHZDJKbWFXUlRiamhXZVdRIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHA6Ly9sb2NhbGhvc3Q6NjQwNTQvIiwiY2hhbCI6IkJpMkpkUGk1eWVTTVdhZjA5TnJEZTVUQXFjZ0FnQmE3In0._PrwHUTS7EoAflXyNDlPNqGMbjKu-JuSXwkNPyryBQdg2gDIb20amsH05Ocih78Josz9h7lAB6FvAWsXKQB1Dw"
-    uid = UserId "ebd272fb-82fd-432b-876c-7abda54ddb75"
-    cid = ClientId 1773935321869104596
-    domain = Domain "example.org"
-    nonce = Nonce "Y2FUN2ZNQ1RvRWIzbjlkdFF1cXhGd2JmaWRTbjhWeWQ"
-    uri = Uri "http://localhost:64054/"
+    proof = Proof "eyJhbGciOiJFZERTQSIsInR5cCI6ImRwb3Arand0IiwiandrIjp7Imt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiZ0tYSHpIV3QtRUh1N2ZQbmlWMXFXWGV2Rmk1eFNKd3RNcHJlSjBjdTZ3SSJ9fQ.eyJpYXQiOjE2NzgxMDcwMDksImV4cCI6MjA4ODA3NTAwOSwibmJmIjoxNjc4MTA3MDA5LCJzdWIiOiJpbXBwOndpcmVhcHA9WXpWbE1qRTVNelpqTTJKak5EQXdOMkpsWTJJd1lXTm1OVGszTW1FMVlqTS9lYWZhMDI1NzMwM2Q0MDYwQHdpcmUuY29tIiwianRpIjoiMmQzNzAzYTItNTc4Yi00MmRjLWE2MGUtYmM0NzA3OWVkODk5Iiwibm9uY2UiOiJRV1J4T1VaUVpYVnNTMlJZYjBGS05sWkhXbGgwYUV4amJUUmpTM2M1U2xnIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHBzOi8vd2lyZS5leGFtcGxlLmNvbS9jbGllbnRzLzE2OTMxODQ4MzIyNTQ3NTMxODcyL2FjY2Vzcy10b2tlbiIsImNoYWwiOiJZVE5HTkRSNlRqZHFabGRRZUVGYWVrMTZWMmhqYXpCVmJ6UlFWVXRWUlZJIn0.0J2sx5y0ubZ4NwmQhbKXDj6i5UWTx3cvuTPKbeXXOJFDamr-iFtE6sOnAQT90kfTx1cEoIyDfoUkj3h5GEanAA"
+    uid = UserId "c5e21936-c3bc-4007-becb-0acf5972a5b3"
+    cid = ClientId 16931848322547531872
+    domain = Domain "wire.com"
+    nonce = Nonce "QWRxOUZQZXVsS2RYb0FKNlZHWlh0aExjbTRjS3c5Slg"
+    uri = Uri "https://wire.example.com/clients/16931848322547531872/access-token"
     method = POST
-    maxSkewSecs = MaxSkewSecs 2
+    maxSkewSecs = MaxSkewSecs 5
     now = NowEpoch 5435234232
-    expires = ExpiryEpoch $ 2082008461
+    expires = ExpiryEpoch $ 2136351646
     pem =
       PemBundle $
         "-----BEGIN PRIVATE KEY-----\n\
-        \MC4CAQAwBQYDK2VwBCIEIKW3jzXCsRVgnclmiTu53Pu1/r6AUmnKDoghOOVMjozQ\n\
+        \MC4CAQAwBQYDK2VwBCIEIMROyHqEinw8EvFSNXp0X0suu6gMQvd9i/l9v9R9UnhH\n\
         \-----END PRIVATE KEY-----\n\
         \-----BEGIN PUBLIC KEY-----\n\
-        \MCowBQYDK2VwAyEA7t9veqi02mPhllm44JXWga8m/l4JxUeQm3qPyMlerxY=\n\
+        \MCowBQYDK2VwAyEA5pDR/Yo4pkKUIxIody2fEQ56eIOW7UqeDeF7FG7WudA=\n\
         \-----END PUBLIC KEY-----\n"


### PR DESCRIPTION
In the test for the `jwt-tools` rust FFI we used a hard coded proof with a very short expiration time.

Replaced it with a proof with max expiration time (until 2038).

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
