### PR TITLE
stern: make api version check a unit test

### DIFF
--- a/changelog.d/3-bug-fixes/stern-api-check
+++ b/changelog.d/3-bug-fixes/stern-api-check
@@ -1,0 +1,1 @@
+Remove overly restricte api check

--- a/tools/stern/default.nix
+++ b/tools/stern/default.nix
@@ -33,6 +33,8 @@
 , split
 , string-conversions
 , swagger2
+, tasty
+, tasty-hunit
 , text
 , tinylog
 , transformers
@@ -107,6 +109,7 @@ mkDerivation {
     types-common
     unliftio
   ];
+  testHaskellDepends = [ base tasty tasty-hunit wire-api ];
   license = lib.licenses.agpl3Only;
   mainProgram = "stern";
 }

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -74,7 +74,6 @@ default (ByteString)
 start :: Opts -> IO ()
 start o = do
   e <- newEnv o
-  runAppT e $ Intra.assertBackendApiVersion
   s <- Server.newSettings (server e)
   Server.runSettingsWithShutdown s (servantApp e) Nothing
   where

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -22,7 +22,7 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Stern.Intra
-  ( assertBackendApiVersion,
+  ( backendApiVersion,
     putUser,
     putUserStatus,
     getContacts,
@@ -67,7 +67,6 @@ import qualified Bilge
 import Bilge.RPC
 import Brig.Types.Intra
 import Control.Error
-import Control.Exception (ErrorCall (ErrorCall))
 import Control.Lens (view, (^.))
 import Control.Monad.Reader
 import Data.Aeson hiding (Error)
@@ -95,7 +94,6 @@ import Stern.Types
 import System.Logger.Class hiding (Error, name, (.=))
 import qualified System.Logger.Class as Log
 import UnliftIO.Exception hiding (Handler)
-import UnliftIO.Retry (constantDelay, limitRetries, recoverAll)
 import Wire.API.Connection
 import Wire.API.Conversation
 import Wire.API.Internal.Notification
@@ -120,17 +118,6 @@ import Wire.API.User.Search
 
 backendApiVersion :: Version
 backendApiVersion = V2
-
--- | Make sure the backend supports `backendApiVersion`.  Crash if it doesn't.  (This is called
--- in `Stern.API` so problems make `./services/run-service` crash.)
-assertBackendApiVersion :: App ()
-assertBackendApiVersion = recoverAll (constantDelay 1000000 <> limitRetries 5) $ \_retryStatus -> do
-  b <- view brig
-  vinfo :: VersionInfo <-
-    responseJsonError
-      =<< rpc' "brig" b (method GET . Bilge.path "/api-version" . contentJson . expect2xx)
-  unless (maximum (vinfoSupported vinfo) == backendApiVersion) $ do
-    throwIO . ErrorCall $ "newest supported backend api version must be " <> show backendApiVersion
 
 path :: ByteString -> Request -> Request
 path = Bilge.path . ((toPathComponent backendApiVersion <> "/") <>)

--- a/tools/stern/stern.cabal
+++ b/tools/stern/stern.cabal
@@ -178,3 +178,17 @@ executable stern
     ld-options: -static
 
   default-language:   Haskell2010
+
+test-suite stern-tests
+  type:           exitcode-stdio-1.0
+  main-is:        Main.hs
+
+  -- cabal-fmt: expand test/unit
+  other-modules:  Main
+  hs-source-dirs: test/unit
+  build-depends:
+      base
+    , stern
+    , tasty
+    , tasty-hunit
+    , wire-api

--- a/tools/stern/test/unit/Main.hs
+++ b/tools/stern/test/unit/Main.hs
@@ -1,0 +1,37 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Main where
+
+import qualified Stern.Intra as Intra
+import Test.Tasty
+import Test.Tasty.HUnit
+import Wire.API.Routes.Version (supportedVersions)
+
+main :: IO ()
+main =
+  defaultMain $
+    testGroup
+      "Tests"
+      [ testCase "testSupportedAPIVersion" testSupportedAPIVersion
+      ]
+
+testSupportedAPIVersion :: IO ()
+testSupportedAPIVersion =
+  assertBool
+    "Stern requires an API version that is unsupported"
+    (Intra.backendApiVersion `elem` supportedVersions)


### PR DESCRIPTION
This PR removes the runtime check introduced https://github.com/wireapp/wire-server/pull/3036 and replaces it with a unit test.

Also the overly restrictive test condition
```
maximum (vinfoSupported vinfo) == backendApiVersion
```

is replaced with
```
backendApiVersion `elem` (vinfoSupported vinfo)
```
