### PR TITLE
Add a client API version bump checklist

### DIFF
--- a/changelog.d/4-docs/client-api-version-bump-checklist
+++ b/changelog.d/4-docs/client-api-version-bump-checklist
@@ -1,0 +1,1 @@
+Add a client API version bump checklist

--- a/docs/src/developer/developer/api-versioning.md
+++ b/docs/src/developer/developer/api-versioning.md
@@ -103,6 +103,21 @@ by this system. It is still possible to implement them, but they will appear as
 different endpoints (and have different names) on the same path, and with
 non-overlapping version ranges.
 
+### Version bump checklist
+
+When making the client API version bump, i.e., when finalising a version, there
+are several steps to make apart from deciding what endpoint changes are part of
+the version:
+
+ - In `wire-api` extend the `Version` type with a new version by appending the
+   new version to the end, e.g., by adding `V4`. Make sure to update its
+   `ToSchema` instance,
+ - In the same `Version` module update the `developmentVersions` value to list
+   only the new version,
+ - Should it be desired, update the `backendApiVersion` value in Stern, which is
+   unit-tested by checking if it is listed as supported in the response to `GET
+   /api-version`.
+
 ### Examples of endpoint evolution
 
 In the following, we present some examples of API changes and how they might be

--- a/docs/src/developer/developer/api-versioning.md
+++ b/docs/src/developer/developer/api-versioning.md
@@ -114,7 +114,7 @@ the version:
    `ToSchema` instance,
  - In the same `Version` module update the `developmentVersions` value to list
    only the new version,
- - Should it be desired, update the `backendApiVersion` value in Stern, which is
+ - Consider updating the `backendApiVersion` value in Stern, which is
    unit-tested by checking if it is listed as supported in the response to `GET
    /api-version`.
 

--- a/libs/wire-api/src/Wire/API/Routes/Version.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Version.hs
@@ -60,6 +60,7 @@ import Wire.API.VersionInfo
 
 -- | Version of the public API. Check the documentation in the *docs* directory
 -- for a checklist when adding a new version.
+-- https://docs.wire.com/developer/developer/api-versioning.html#version-bump-checklist
 data Version = V0 | V1 | V2 | V3 | V4
   deriving stock (Eq, Ord, Bounded, Enum, Show)
   deriving (FromJSON, ToJSON) via (Schema Version)

--- a/libs/wire-api/src/Wire/API/Routes/Version.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Version.hs
@@ -58,7 +58,8 @@ import Servant.Swagger
 import Wire.API.Routes.Named
 import Wire.API.VersionInfo
 
--- | Version of the public API.
+-- | Version of the public API. Check the documentation in the *docs* directory
+-- for a checklist when adding a new version.
 data Version = V0 | V1 | V2 | V3 | V4
   deriving stock (Eq, Ord, Bounded, Enum, Show)
   deriving (FromJSON, ToJSON) via (Schema Version)


### PR DESCRIPTION
This is a small PR adding a checklist for a client API version bump. Please expand/modify as you see fit!

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
