### PR TITLE
Fix gundeck leak

### DIFF
--- a/changelog.d/5-internal/pr-3136
+++ b/changelog.d/5-internal/pr-3136
@@ -1,0 +1,1 @@
+Fix a memory leak in `gundeck` when Redis is offline

--- a/services/gundeck/src/Gundeck/Redis.hs
+++ b/services/gundeck/src/Gundeck/Redis.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NumDecimals #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
+
 {-# LANGUAGE TypeApplications #-}
 
 -- This file is part of the Wire Server implementation.
@@ -96,7 +96,7 @@ connectRobust l retryStrategy connectLowLevel = do
 runRobust :: (MonadUnliftIO m, MonadLogger m, Catch.MonadMask m) => RobustConnection -> Redis a -> m a
 runRobust mvar action = retry $ do
   robustConnection <- readMVar mvar
-  liftIO $ runRedis (robustConnection) action
+  liftIO $ runRedis robustConnection action
   where
     retryStrategy = capDelay 1000000 (exponentialBackoff 50000)
     retry =

--- a/services/gundeck/src/Gundeck/Redis.hs
+++ b/services/gundeck/src/Gundeck/Redis.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NumDecimals #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-
 {-# LANGUAGE TypeApplications #-}
 
 -- This file is part of the Wire Server implementation.

--- a/services/gundeck/src/Gundeck/Run.hs
+++ b/services/gundeck/src/Gundeck/Run.hs
@@ -41,7 +41,6 @@ import qualified Gundeck.Env as Env
 import Gundeck.Monad
 import Gundeck.Options
 import Gundeck.React
-import qualified Gundeck.Redis as Redis
 import Gundeck.ThreadBudget
 import Imports hiding (head)
 import Network.Wai as Wai

--- a/services/gundeck/src/Gundeck/Run.hs
+++ b/services/gundeck/src/Gundeck/Run.hs
@@ -58,7 +58,7 @@ import Wire.API.Routes.Version.Wai
 run :: Opts -> IO ()
 run o = do
   m <- metrics
-  e <- createEnv m o
+  (rThreads, e) <- createEnv m o
   runClient (e ^. cstate) $
     versionCheck schemaVersion
   let l = e ^. applog
@@ -73,6 +73,7 @@ run o = do
     Async.cancel lst
     Async.cancel wCollectAuth
     forM_ wtbs Async.cancel
+    forM_ rThreads Async.cancel
     Redis.disconnect =<< takeMVar (e ^. rstate)
     whenJust (e ^. rstateAdditionalWrite) $ (=<<) Redis.disconnect . takeMVar
     Log.close (e ^. applog)

--- a/services/gundeck/src/Gundeck/Run.hs
+++ b/services/gundeck/src/Gundeck/Run.hs
@@ -74,8 +74,8 @@ run o = do
     Async.cancel lst
     Async.cancel wCollectAuth
     forM_ wtbs Async.cancel
-    Redis.disconnect . (^. Redis.rrConnection) =<< takeMVar (e ^. rstate)
-    whenJust (e ^. rstateAdditionalWrite) $ (=<<) (Redis.disconnect . (^. Redis.rrConnection)) . takeMVar
+    Redis.disconnect =<< takeMVar (e ^. rstate)
+    whenJust (e ^. rstateAdditionalWrite) $ (=<<) Redis.disconnect . takeMVar
     Log.close (e ^. applog)
   where
     middleware :: Env -> Wai.Middleware

--- a/services/gundeck/test/integration/Util.hs
+++ b/services/gundeck/test/integration/Util.hs
@@ -24,7 +24,7 @@ withSettingsOverrides f action = do
   ts <- ask
   let opts = f (view tsOpts ts)
   m <- metrics
-  env <- liftIO $ createEnv m opts
+  (_rThreads, env) <- liftIO $ createEnv m opts
   liftIO . lowerCodensity $ do
     let app = mkApp env
     p <- withMockServer app


### PR DESCRIPTION
This PR fixes a memory leak in gundeck caused by its reconnection logic when Redis is down. The heap before this PR:

![image](https://user-images.githubusercontent.com/307223/223549181-3901dd8c-91e5-4d00-bab3-63d70db2d40f.png)

and after:

![image](https://user-images.githubusercontent.com/307223/223549268-24bb35fd-888d-432a-a4db-2a269286a650.png)

Each spike here is a series of requests sent to gundeck while redis is down; the resulting taper-off in both charts is when redis comes back online.

It's unclear exactly what is causing this behavior in HEAD, but the original logic is highly suspicious. An `MVar` is created with the redis connection and is always assumed to be full. Subsequent requests to Redis then catch any exceptions they might see, and trigger a reconnection event, where they spin, attempting to reconnect. Only one thread may spin on this reconnection event, but the others are all blocked on it, and all will be in contention to update the `MVar` --- ironically, they will all be attempting to update it to the same value. My assumption is the old, bad behavior is caused by new threads attempting to talk to Redis, even though the application knows the connection has been lost, and then jumping in to do pointless work. Due to the `MVar` contention, all threads will keep the expensive `Connection` object on the stack attempting to update the value.

Furthermore, the problem is exacerbated by nothing pining redis, so by the time we discover it's down, we already have work we'd like to accomplish.

This PR instead creates a new thread who is responsible for maintaining the connection to redis. It pings redis every second, and if that ever fails, it immediately empties the `MVar Connection`, so that other requests to Redis will block until it has been refilled. This new thread will then spin, attempting to reconnect to redis, and will fill the `MVar` as soon as it's back online, which will unblock the other threads. This makes it extremely clear who is responsible for what, and prevents the weird recursive `retry` loops and `MVar` update races.

---

Additionally, you'll notice a ~140MB allocation spike at the beginning of each new reconnection in the new logic. This is a caused by insane stupidity in hedis' implementation that I found while diagnosing this problem. It wouldn't be very much work to fix if we're at all concerned about it.

---

My debugging trials and tribulations are documented [here](https://github.com/isovector/wire-server/raw/gundeck-oom/space-leak.pdf) if anyone is interested in all the things that *didn't help* in diagnosing this problem :)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
