### PR TITLE
Downgrade to our fork of http2

### DIFF
--- a/changelog.d/5-internal/downgrade-http2
+++ b/changelog.d/5-internal/downgrade-http2
@@ -1,0 +1,1 @@
+Depend on http2 fork instead of version 4.0.0

--- a/libs/wai-utilities/src/Network/Wai/Utilities/MockServer.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/MockServer.hs
@@ -21,12 +21,10 @@ module Network.Wai.Utilities.MockServer where
 
 import qualified Control.Concurrent.Async as Async
 import Control.Exception (throw)
-import qualified Control.Exception as E
 import Control.Monad.Catch
 import Control.Monad.Codensity
 import Data.Streaming.Network (bindRandomPortTCP)
 import Imports
-import qualified Network.HTTP2.Client as HTTP2
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.WarpTLS as Warp
@@ -46,10 +44,10 @@ withMockServer app = Codensity $ \k ->
     (liftIO . fst)
     (k . fromIntegral . snd)
 
+-- FUTUREWORK: Ignore HTTP2.ConnectionIsClosed after upgrading to more recent
+-- http2 library.
 ignoreHTTP2NonError :: Maybe Wai.Request -> SomeException -> IO ()
-ignoreHTTP2NonError mr e
-  | Just HTTP2.ConnectionIsClosed <- E.fromException e = pure ()
-  | otherwise = Warp.defaultOnException mr e
+ignoreHTTP2NonError = Warp.defaultOnException
 
 -- | Start a mock warp server on a random port, serving the given Wai application.
 --

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -84,7 +84,7 @@ import qualified Data.Text.Lazy as LT
 import Imports
 import Network.HTTP.Types.Status
 import qualified Network.HTTP.Types.Status as HTTP
-import qualified Network.HTTP2.Client as HTTP2
+import qualified Network.HTTP2.Frame as HTTP2
 import qualified Network.Wai.Utilities.Error as Wai
 import OpenSSL.Session (SomeSSLException)
 import Servant.Client

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -119,6 +119,13 @@ let
         http-conduit = "http-conduit";
       };
     };
+    http2 = {
+      src = fetchgit {
+        url = "https://github.com/wireapp/http2";
+        rev = "aa3501ad58e1abbd196781fac25a84f41ec2a787";
+        sha256 = "09h86fkk8p7szq08x0iszaq16mhbylxivfc0apvj58d98wl8l6lq";
+      };
+    };
     hspec-wai = {
       src = fetchgit {
         url = "https://github.com/wireapp/hspec-wai";
@@ -212,10 +219,6 @@ let
     HsOpenSSL = {
       version = "0.11.7.5";
       sha256 = "sha256-CfH1YJSGuF4O1aUfdJwUZKRrVzv5nSPhwoI7mf9ewEg=";
-    };
-    http2 = {
-      version = "4.0.0";
-      sha256 = "sha256-9rBhklwuuKZXWH4yV4tb7Sp5chR9AmBAMRBztDjx0uI=";
     };
   };
   # Name -> Source -> Maybe Subpath -> Drv


### PR DESCRIPTION
Downgrade http2 library.

https://wearezeta.atlassian.net/browse/FS-1609

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
