### PR TITLE
Upgrade cachix to 1.3.1

### DIFF
--- a/libs/wire-api/src/Wire/API/User/Profile.hs
+++ b/libs/wire-api/src/Wire/API/User/Profile.hs
@@ -71,7 +71,6 @@ import Wire.Arbitrary (Arbitrary (arbitrary), GenericUniform (..))
 -- Name
 
 -- | Usually called display name.
---
 -- Length is between 1 and 128 characters.
 newtype Name = Name
   {fromName :: Text}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,6 +10,8 @@ let
     ];
   };
 
+  pkgsCachix = import sources.nixpkgs-cachix {};
+
   profileEnv = pkgs.writeTextFile {
     name = "profile-env";
     destination = "/.profile";
@@ -20,7 +22,7 @@ let
     '';
   };
 
-  wireServer = import ./wire-server.nix pkgs;
+  wireServer = import ./wire-server.nix pkgs pkgsCachix;
   nginz = pkgs.callPackage ./nginz.nix { };
   nginz-disco = pkgs.callPackage ./nginz-disco.nix { };
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -10,5 +10,17 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/8c619a1f3cedd16ea172146e30645e703d21bfc1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgs-cachix": {
+        "branch": "nixpkgs-unstable",
+        "description": "Nix Packages collection",
+        "homepage": "https://github.com/NixOS/nixpkgs",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b38db2c901b30a37d345751f4f6418d416e7e46e",
+        "sha256": "0g8qks6pqxagqiwaxz1n4fd82bvadli8gamas3j9c0al4bw9vv7r",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/b38db2c901b30a37d345751f4f6418d416e7e46e.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -42,7 +42,7 @@
 # Using thse tweaks we can get a haskell package set which has wire-server
 # components and the required dependencies. We then use this package set along
 # with nixpkgs' dockerTools to make derivations for docker images that we need.
-pkgs:
+pkgs: pkgsCachix:
 let
   lib = pkgs.lib;
   hlib = pkgs.haskell.lib;
@@ -329,7 +329,8 @@ let
     # deterministically on a specific image.
     tag = null;
     bundleNixpkgs = false;
-    extraPkgs = commonTools ++ [ pkgs.cachix ];
+    # FUTUREWORK: Use pkgs.cachix here when we update `nixpkgs` to latest nixpkgs-unstable
+    extraPkgs = commonTools ++ [ pkgsCachix.cachix ];
     nixConf = {
       experimental-features = "nix-command";
     };


### PR DESCRIPTION
This PR updates to cachix 1.3.1 in hopes of solving the issue https://github.com/cachix/cachix/issues/509

I've added a separate nixpkgs pin for cachix to avoid having to upgrade all the things and quickly try out if upgrading solves the issue.
If this PR fixes it we can take some time to upgrade our main `nixpkgs` pin and use cachix from there. If not we can consider reverting this PR.
