### PR TITLE
Revert "Use openssl instead of tls in federator http2 client"

### DIFF
--- a/libs/wire-api-federation/default.nix
+++ b/libs/wire-api-federation/default.nix
@@ -15,7 +15,6 @@
 , errors
 , exceptions
 , gitignoreSource
-, HsOpenSSL
 , hspec
 , hspec-discover
 , http-media
@@ -68,7 +67,6 @@ mkDerivation {
     either
     errors
     exceptions
-    HsOpenSSL
     http-media
     http-types
     http2

--- a/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
@@ -47,7 +47,6 @@ import Data.Domain
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Streaming.Network
-import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text
 import qualified Data.Text.Lazy.Encoding as LText
@@ -59,9 +58,8 @@ import qualified Network.HTTP.Media as HTTP
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.HTTP2.Client as HTTP2
 import qualified Network.Socket as NS
+import qualified Network.TLS as TLS
 import qualified Network.Wai.Utilities.Error as Wai
-import OpenSSL.Session (SSL, SSLContext)
-import qualified OpenSSL.Session as SSL
 import Servant.Client
 import Servant.Client.Core
 import Servant.Types.SourceT
@@ -124,7 +122,7 @@ connectSocket hostname port =
     $ getSocketFamilyTCP hostname port NS.AF_UNSPEC
 
 performHTTP2Request ::
-  Maybe SSLContext ->
+  Maybe TLS.ClientParams ->
   HTTP2.Request ->
   ByteString ->
   Int ->
@@ -140,42 +138,34 @@ performHTTP2Request mtlsConfig req hostname port = try $ do
     pure $ resp $> foldMap byteString b
 
 withHTTP2Request ::
-  Maybe SSLContext ->
+  Maybe TLS.ClientParams ->
   HTTP2.Request ->
   ByteString ->
   Int ->
   (StreamingResponse -> IO a) ->
   IO a
-withHTTP2Request mSSLCtx req hostname port k = do
+withHTTP2Request mtlsConfig req hostname port k = do
   let clientConfig =
         HTTP2.ClientConfig
-          { HTTP2.scheme = "https",
-            HTTP2.authority = hostname,
-            HTTP2.cacheLimit = 20
-          }
+          "https"
+          hostname
+          {- cacheLimit: -} 20
   E.handle (E.throw . FederatorClientHTTP2Exception) $
     bracket (connectSocket hostname port) NS.close $ \sock -> do
-      let withHTTP2Config k' = case mSSLCtx of
+      let withHTTP2Config k' = case mtlsConfig of
             Nothing -> bracket (HTTP2.allocSimpleConfig sock 4096) HTTP2.freeSimpleConfig k'
-            Just sslCtx -> do
-              ssl <- E.handle (E.throw . FederatorClientTLSException) $ do
-                ssl <- SSL.connection sslCtx sock
-                -- We need to strip trailing dot because openssl doesn't ignore
-                -- it. https://github.com/openssl/openssl/issues/11560
-                let hostnameStr =
-                      Text.unpack $ case Text.decodeUtf8 hostname of
-                        (Text.stripSuffix "." -> Just withoutTrailingDot) -> withoutTrailingDot
-                        noTrailingDot -> noTrailingDot
-                SSL.setTlsextHostName ssl hostnameStr
-                SSL.enableHostnameValidation ssl hostnameStr
-                SSL.connect ssl
-                pure ssl
-              bracket (allocTLSConfig ssl 4096) freeTLSConfig k'
+            -- FUTUREWORK(federation): Use openssl
+            Just tlsConfig -> do
+              ctx <- E.handle (E.throw . FederatorClientTLSException) $ do
+                ctx <- TLS.contextNew sock tlsConfig
+                TLS.handshake ctx
+                pure ctx
+              bracket (allocTLSConfig ctx 4096) freeTLSConfig k'
       withHTTP2Config $ \conf -> do
         HTTP2.run clientConfig conf $ \sendRequest ->
           sendRequest req $ \resp -> do
             let headers = headersFromTable (HTTP2.responseHeaders resp)
-                result = fromAction BS.null $ HTTP2.getResponseBodyChunk resp
+                result = fromAction BS.null (HTTP2.getResponseBodyChunk resp)
             case HTTP2.responseStatus resp of
               Nothing -> E.throw FederatorClientNoStatusCode
               Just status ->
@@ -361,23 +351,31 @@ versionNegotiation =
 freeTLSConfig :: HTTP2.Config -> IO ()
 freeTLSConfig cfg = free (HTTP2.confWriteBuffer cfg)
 
-allocTLSConfig :: SSL -> HTTP2.BufferSize -> IO HTTP2.Config
-allocTLSConfig ssl bufsize = do
+allocTLSConfig :: TLS.Context -> HTTP2.BufferSize -> IO HTTP2.Config
+allocTLSConfig ctx bufsize = do
   buf <- mallocBytes bufsize
   timmgr <- System.TimeManager.initialize $ 30 * 1000000
+  ref <- newIORef mempty
   let readData :: Int -> IO ByteString
-      -- Sometimes the frame header says that the payload length is 0. Reading 0
-      -- bytes multiple times seems to be causing errors in openssl. I cannot
-      -- figure out why. The previous implementation didn't try to read from the
-      -- socket when trying to read 0 bytes, so special handling for 0 maintains
-      -- that behaviour.
-      readData 0 = pure ""
-      readData n = SSL.read ssl n `catch` \(_ :: SSL.ConnectionAbruptlyTerminated) -> pure mempty
+      readData n = do
+        chunk <- readIORef ref
+        if BS.length chunk >= n
+          then case BS.splitAt n chunk of
+            (result, chunk') -> do
+              writeIORef ref chunk'
+              pure result
+          else do
+            chunk' <- TLS.recvData ctx
+            if BS.null chunk'
+              then pure chunk
+              else do
+                modifyIORef ref (<> chunk')
+                readData n
   pure
     HTTP2.Config
       { HTTP2.confWriteBuffer = buf,
         HTTP2.confBufferSize = bufsize,
-        HTTP2.confSendAll = SSL.write ssl,
+        HTTP2.confSendAll = TLS.sendData ctx . LBS.fromStrict,
         HTTP2.confReadN = readData,
         HTTP2.confPositionReadMaker = HTTP2.defaultPositionReadMaker,
         HTTP2.confTimeoutManager = timmgr

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -85,8 +85,8 @@ import Imports
 import Network.HTTP.Types.Status
 import qualified Network.HTTP.Types.Status as HTTP
 import qualified Network.HTTP2.Frame as HTTP2
+import Network.TLS
 import qualified Network.Wai.Utilities.Error as Wai
-import OpenSSL.Session (SomeSSLException)
 import Servant.Client
 import Wire.API.Error
 
@@ -94,7 +94,7 @@ import Wire.API.Error
 data FederatorClientHTTP2Error
   = FederatorClientNoStatusCode
   | FederatorClientHTTP2Exception HTTP2.HTTP2Error
-  | FederatorClientTLSException SomeSSLException
+  | FederatorClientTLSException TLSException
   | FederatorClientConnectionError IOException
   deriving (Show, Typeable)
 
@@ -213,7 +213,7 @@ federationRemoteHTTP2Error (FederatorClientTLSException e) =
   Wai.mkError
     (HTTP.mkStatus 525 "SSL Handshake Failure")
     "federation-tls-error"
-    (LT.pack (displayException e))
+    (LT.fromStrict (displayTLSException e))
 federationRemoteHTTP2Error (FederatorClientConnectionError e) =
   Wai.mkError
     federatorConnectionRefusedStatus
@@ -240,6 +240,22 @@ federationRemoteResponseError status =
     ( "A remote federator failed with status code "
         <> LT.pack (show (HTTP.statusCode status))
     )
+
+displayTLSException :: TLSException -> Text
+displayTLSException (Terminated _ reason err) = T.pack reason <> ": " <> displayTLSError err
+displayTLSException (HandshakeFailed err) = T.pack "handshake failed: " <> displayTLSError err
+displayTLSException ConnectionNotEstablished = T.pack "connection not established"
+
+displayTLSError :: TLSError -> Text
+displayTLSError (Error_Misc msg) = T.pack msg
+displayTLSError (Error_Protocol (msg, _, _)) = "protocol error: " <> T.pack msg
+displayTLSError (Error_Certificate msg) = "certificate error: " <> T.pack msg
+displayTLSError (Error_HandshakePolicy msg) = "handshake policy error: " <> T.pack msg
+displayTLSError Error_EOF = "end-of-file error"
+displayTLSError (Error_Packet msg) = "packet error: " <> T.pack msg
+displayTLSError (Error_Packet_unexpected actual expected) =
+  "unexpected packet: " <> T.pack expected <> ", " <> "got " <> T.pack actual
+displayTLSError (Error_Packet_Parsing msg) = "packet parsing error: " <> T.pack msg
 
 federationServantErrorToWai :: ClientError -> Wai.Error
 federationServantErrorToWai (DecodeFailure msg _) = federationInvalidBody msg

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -86,7 +86,6 @@ library
     , either
     , errors
     , exceptions
-    , HsOpenSSL
     , http-media
     , http-types
     , http2

--- a/services/federator/default.nix
+++ b/services/federator/default.nix
@@ -25,7 +25,6 @@
 , filepath
 , gitignoreSource
 , hinotify
-, HsOpenSSL
 , hspec
 , http-client
 , http-client-openssl
@@ -105,7 +104,6 @@ mkDerivation {
     extended
     filepath
     hinotify
-    HsOpenSSL
     http-client
     http-client-openssl
     http-media
@@ -168,7 +166,6 @@ mkDerivation {
     extended
     filepath
     hinotify
-    HsOpenSSL
     hspec
     http-client
     http-client-openssl
@@ -236,7 +233,6 @@ mkDerivation {
     extended
     filepath
     hinotify
-    HsOpenSSL
     http-client
     http-client-openssl
     http-media

--- a/services/federator/exec/Main.hs
+++ b/services/federator/exec/Main.hs
@@ -22,11 +22,10 @@ where
 
 import Federator.Run (run)
 import Imports
-import OpenSSL
 import Util.Options (getOptions)
 
 main :: IO ()
-main = withOpenSSL $ do
+main = do
   let desc = "Federation Service"
       defaultPath = "/etc/wire/federator/conf/federator.yaml"
   options <- getOptions desc Nothing defaultPath

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -116,7 +116,6 @@ library
     , extended
     , filepath
     , hinotify
-    , HsOpenSSL
     , http-client
     , http-client-openssl
     , http-media
@@ -211,11 +210,63 @@ executable federator
     -Wredundant-constraints
 
   build-depends:
-      base
+      aeson
+    , async
+    , base
+    , bilge
+    , binary
+    , bytestring
+    , bytestring-conversion
+    , constraints
+    , containers
+    , data-default
+    , dns
+    , dns-util
+    , either
+    , exceptions
+    , extended
     , federator
-    , HsOpenSSL
+    , filepath
+    , hinotify
+    , http-client
+    , http-client-openssl
+    , http-media
+    , http-types
+    , http2
     , imports
+    , kan-extensions
+    , lens
+    , metrics-core
+    , metrics-wai
+    , mtl
+    , network
+    , network-uri
+    , pem
+    , polysemy
+    , polysemy-wire-zoo
+    , retry
+    , servant
+    , servant-client-core
+    , streaming-commons
+    , string-conversions
+    , text
+    , time-manager
+    , tinylog
+    , tls
     , types-common
+    , unix
+    , uri-bytestring
+    , uuid
+    , wai
+    , wai-utilities
+    , warp
+    , warp-tls
+    , wire-api
+    , wire-api-federation
+    , x509
+    , x509-store
+    , x509-system
+    , x509-validation
 
   default-language:   Haskell2010
 
@@ -272,7 +323,7 @@ executable federator-integration
   ghc-options:
     -O2 -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wpartial-fields -fwarn-tabs -optP-Wno-nonportable-include-path
-    -Wredundant-constraints -threaded -with-rtsopts=-N1
+    -Wredundant-constraints
 
   build-depends:
       aeson
@@ -296,7 +347,6 @@ executable federator-integration
     , federator
     , filepath
     , hinotify
-    , HsOpenSSL
     , hspec
     , http-client
     , http-client-openssl
@@ -428,7 +478,6 @@ test-suite federator-tests
     , federator
     , filepath
     , hinotify
-    , HsOpenSSL
     , http-client
     , http-client-openssl
     , http-media

--- a/services/federator/src/Federator/Env.hs
+++ b/services/federator/src/Federator/Env.hs
@@ -24,14 +24,20 @@ module Federator.Env where
 import Bilge (RequestId)
 import Control.Lens (makeLenses)
 import Data.Metrics (Metrics)
+import Data.X509.CertificateStore
 import Federator.Options (RunSettings)
 import Imports
 import Network.DNS.Resolver (Resolver)
 import qualified Network.HTTP.Client as HTTP
-import OpenSSL.Session (SSLContext)
+import qualified Network.TLS as TLS
 import qualified System.Logger.Class as LC
 import Util.Options
 import Wire.API.Federation.Component
+
+data TLSSettings = TLSSettings
+  { _caStore :: CertificateStore,
+    _creds :: TLS.Credential
+  }
 
 data Env = Env
   { _metrics :: Metrics,
@@ -41,7 +47,8 @@ data Env = Env
     _runSettings :: RunSettings,
     _service :: Component -> Endpoint,
     _httpManager :: HTTP.Manager,
-    _sslContext :: IORef SSLContext
+    _tls :: IORef TLSSettings
   }
 
+makeLenses ''TLSSettings
 makeLenses ''Env

--- a/services/federator/src/Federator/Monitor.hs
+++ b/services/federator/src/Federator/Monitor.hs
@@ -23,20 +23,20 @@ module Federator.Monitor
 where
 
 import Control.Exception (bracket, throw)
+import Federator.Env (TLSSettings (..))
 import Federator.Monitor.Internal
 import Federator.Options (RunSettings (..))
 import Imports
-import OpenSSL.Session (SSLContext)
 import qualified Polysemy
 import qualified Polysemy.Error as Polysemy
 import System.Logger (Logger)
 
-mkTLSSettingsOrThrow :: RunSettings -> IO SSLContext
-mkTLSSettingsOrThrow = Polysemy.runM . runEither . Polysemy.runError @FederationSetupError . mkSSLContext
+mkTLSSettingsOrThrow :: RunSettings -> IO TLSSettings
+mkTLSSettingsOrThrow = Polysemy.runM . runEither . Polysemy.runError @FederationSetupError . mkTLSSettings
   where
     runEither = (either (Polysemy.embed @IO . throw) pure =<<)
 
-withMonitor :: Logger -> IORef SSLContext -> RunSettings -> IO a -> IO a
+withMonitor :: Logger -> IORef TLSSettings -> RunSettings -> IO a -> IO a
 withMonitor logger tlsVar rs action =
   bracket
     ( runSemDefault

--- a/services/federator/src/Federator/Remote.hs
+++ b/services/federator/src/Federator/Remote.hs
@@ -23,23 +23,32 @@ module Federator.Remote
     RemoteError (..),
     interpretRemote,
     discoverAndCall,
+    blessedCiphers,
   )
 where
 
 import qualified Control.Exception as E
+import Control.Lens ((^.))
 import Control.Monad.Codensity
 import Data.Binary.Builder
+import Data.ByteString.Conversion (toByteString')
 import qualified Data.ByteString.Lazy as LBS
+import Data.Default (def)
 import Data.Domain
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text
+import qualified Data.X509 as X509
+import qualified Data.X509.Validation as X509
 import Federator.Discovery
+import Federator.Env (TLSSettings, caStore, creds)
 import Federator.Error
+import Federator.Validation
 import Imports
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.HTTP2.Client as HTTP2
-import OpenSSL.Session (SSLContext)
+import Network.TLS as TLS
+import qualified Network.TLS.Extra.Cipher as TLS
 import Polysemy
 import Polysemy.Error
 import Polysemy.Input
@@ -101,25 +110,26 @@ interpretRemote ::
     Member DiscoverFederator r,
     Member (Error DiscoveryFailure) r,
     Member (Error RemoteError) r,
-    Member (Input SSLContext) r
+    Member (Input TLSSettings) r
   ) =>
   Sem (Remote ': r) a ->
   Sem r a
 interpretRemote = interpret $ \case
   DiscoverAndCall domain component rpc headers body -> do
     target@(SrvTarget hostname port) <- discoverFederatorWithError domain
+    settings <- input
     let path =
           LBS.toStrict . toLazyByteString $
             HTTP.encodePathSegments ["federation", componentName component, rpc]
         -- filter out Host header, because the HTTP2 client adds it back
         headers' = filter ((/= "Host") . fst) headers
         req' = HTTP2.requestBuilder HTTP.methodPost path headers' body
+        tlsConfig = mkTLSConfig settings hostname port
 
-    sslCtx <- input
     resp <- mapError (RemoteError target) . (fromEither @FederatorClientHTTP2Error =<<) . embed $
       Codensity $ \k ->
         E.catch
-          (withHTTP2Request (Just sslCtx) req' hostname (fromIntegral port) (k . Right))
+          (withHTTP2Request (Just tlsConfig) req' hostname (fromIntegral port) (k . Right))
           (k . Left)
 
     unless (HTTP.statusIsSuccessful (responseStatusCode resp)) $ do
@@ -130,3 +140,46 @@ interpretRemote = interpret $ \case
           (responseStatusCode resp)
           (toLazyByteString bdy)
     pure resp
+
+mkTLSConfig :: TLSSettings -> ByteString -> Word16 -> TLS.ClientParams
+mkTLSConfig settings hostname port =
+  ( defaultParamsClient
+      (Text.unpack (Text.decodeUtf8With Text.lenientDecode hostname))
+      (toByteString' port)
+  )
+    { TLS.clientSupported =
+        def
+          { TLS.supportedCiphers = blessedCiphers,
+            -- FUTUREWORK: Figure out if we can drop TLS 1.2
+            TLS.supportedVersions = [TLS.TLS12, TLS.TLS13]
+          },
+      TLS.clientHooks =
+        def
+          { TLS.onServerCertificate =
+              X509.validate
+                X509.HashSHA256
+                X509.defaultHooks {X509.hookValidateName = validateDomainName}
+                X509.defaultChecks {X509.checkLeafKeyPurpose = [X509.KeyUsagePurpose_ServerAuth]},
+            TLS.onCertificateRequest = \_ -> pure (Just (settings ^. creds)),
+            TLS.onSuggestALPN = pure (Just ["h2"]) -- we only support HTTP2
+          },
+      TLS.clientShared = def {TLS.sharedCAStore = settings ^. caStore}
+    }
+
+-- Context and possible future work see
+-- https://wearezeta.atlassian.net/browse/FS-33
+-- https://wearezeta.atlassian.net/browse/FS-444
+-- https://wearezeta.atlassian.net/browse/FS-443
+--
+-- The current list is compliant to TR-02102-2
+-- https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.html
+blessedCiphers :: [Cipher]
+blessedCiphers =
+  [ TLS.cipher_TLS13_AES128CCM8_SHA256,
+    TLS.cipher_TLS13_AES128CCM_SHA256,
+    TLS.cipher_TLS13_AES128GCM_SHA256,
+    TLS.cipher_TLS13_AES256GCM_SHA384,
+    -- For TLS 1.2 (copied from default nginx ingress config):
+    TLS.cipher_ECDHE_ECDSA_AES256GCM_SHA384,
+    TLS.cipher_ECDHE_RSA_AES256GCM_SHA384
+  ]

--- a/services/federator/src/Federator/Response.hs
+++ b/services/federator/src/Federator/Response.hs
@@ -42,7 +42,6 @@ import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Utilities.Error as Wai
 import qualified Network.Wai.Utilities.Server as Wai
-import OpenSSL.Session (SSLContext)
 import Polysemy
 import Polysemy.Embed
 import Polysemy.Error
@@ -118,7 +117,7 @@ type AllEffects =
      DNSLookup, -- needed by DiscoverFederator
      ServiceStreaming,
      Input RunSettings,
-     Input SSLContext, -- needed by Remote
+     Input TLSSettings, -- needed by Remote
      Input Env, -- needed by Service
      Error ValidationError,
      Error RemoteError,
@@ -143,7 +142,7 @@ runFederator env =
           DiscoveryFailure
         ]
     . runInputConst env
-    . runInputSem (embed @IO (readIORef (view sslContext env)))
+    . runInputSem (embed @IO (readIORef (view tls env)))
     . runInputConst (view runSettings env)
     . interpretServiceHTTP
     . runDNSLookupWithResolver (view dnsResolver env)

--- a/services/federator/src/Federator/Run.hs
+++ b/services/federator/src/Federator/Run.hs
@@ -64,7 +64,7 @@ run opts = do
     bracket (newEnv opts res) closeEnv $ \env -> do
       let externalServer = serveInward env portExternal
           internalServer = serveOutward env portInternal
-      withMonitor (env ^. applog) (env ^. sslContext) (optSettings opts) $ do
+      withMonitor (env ^. applog) (env ^. tls) (optSettings opts) $ do
         internalServerThread <- async internalServer
         externalServerThread <- async externalServer
         void $ waitAnyCancel [internalServerThread, externalServerThread]
@@ -97,7 +97,7 @@ newEnv o _dnsResolver = do
       _service Galley = Opt.galley o
       _service Cargohold = Opt.cargohold o
   _httpManager <- initHttpManager
-  _sslContext <- mkTLSSettingsOrThrow _runSettings >>= newIORef
+  _tls <- mkTLSSettingsOrThrow _runSettings >>= newIORef
   pure Env {..}
 
 closeEnv :: Env -> IO ()

--- a/services/federator/test/integration/Main.hs
+++ b/services/federator/test/integration/Main.hs
@@ -22,7 +22,6 @@ where
 
 import Data.String.Conversions
 import Imports
-import OpenSSL (withOpenSSL)
 import System.Environment (withArgs)
 import qualified Test.Federator.IngressSpec
 import qualified Test.Federator.InwardSpec
@@ -30,7 +29,7 @@ import Test.Federator.Util (TestEnv, mkEnvFromOptions)
 import Test.Hspec
 
 main :: IO ()
-main = withOpenSSL $ do
+main = do
   (wireArgs, hspecArgs) <- partitionArgs <$> getArgs
   env <- withArgs wireArgs mkEnvFromOptions
   -- withArgs hspecArgs . hspec $ do

--- a/services/federator/test/integration/Test/Federator/Util.hs
+++ b/services/federator/test/integration/Test/Federator/Util.hs
@@ -43,12 +43,12 @@ import qualified Data.Text as Text
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID
 import qualified Data.Yaml as Yaml
+import Federator.Env
 import Federator.Options
 import Federator.Run
 import Imports
 import qualified Network.Connection
 import Network.HTTP.Client.TLS
-import OpenSSL.Session (SSLContext)
 import qualified Options.Applicative as OPA
 import Polysemy
 import Polysemy.Error
@@ -91,15 +91,13 @@ runTestFederator env = flip runReaderT env . unwrapTestFederator
 -- | See 'mkEnv' about what's in here.
 data TestEnv = TestEnv
   { _teMgr :: Manager,
-    _teSSLContext :: SSLContext,
+    _teTLSSettings :: TLSSettings,
     _teBrig :: BrigReq,
     _teCargohold :: CargoholdReq,
     -- | federator config
     _teOpts :: Opts,
     -- | integration test config
-    _teTstOpts :: IntegrationConfig,
-    -- | Settings passed to the federator
-    _teSettings :: RunSettings
+    _teTstOpts :: IntegrationConfig
   }
 
 type Select = TestEnv -> (Request -> Request)
@@ -155,9 +153,7 @@ mkEnv _teTstOpts _teOpts = do
   _teMgr :: Manager <- newManager managerSettings
   let _teBrig = endpointToReq (cfgBrig _teTstOpts)
       _teCargohold = endpointToReq (cfgCargohold _teTstOpts)
-  -- _teTLSSettings <- mkTLSSettingsOrThrow (optSettings _teOpts)
-  _teSSLContext <- mkTLSSettingsOrThrow (optSettings _teOpts)
-  let _teSettings = optSettings _teOpts
+  _teTLSSettings <- mkTLSSettingsOrThrow (optSettings _teOpts)
   pure TestEnv {..}
 
 destroyEnv :: HasCallStack => TestEnv -> IO ()

--- a/services/federator/test/unit/Main.hs
+++ b/services/federator/test/unit/Main.hs
@@ -21,7 +21,6 @@ module Main
 where
 
 import Imports
-import OpenSSL (withOpenSSL)
 import qualified Test.Federator.Client
 import qualified Test.Federator.ExternalServer
 import qualified Test.Federator.InternalServer
@@ -34,16 +33,15 @@ import Test.Tasty
 
 main :: IO ()
 main =
-  withOpenSSL $
-    defaultMain $
-      testGroup
-        "Tests"
-        [ Test.Federator.Options.tests,
-          Test.Federator.Validation.tests,
-          Test.Federator.Client.tests,
-          Test.Federator.InternalServer.tests,
-          Test.Federator.ExternalServer.tests,
-          Test.Federator.Monitor.tests,
-          Test.Federator.Remote.tests,
-          Test.Federator.Response.tests
-        ]
+  defaultMain $
+    testGroup
+      "Tests"
+      [ Test.Federator.Options.tests,
+        Test.Federator.Validation.tests,
+        Test.Federator.Client.tests,
+        Test.Federator.InternalServer.tests,
+        Test.Federator.ExternalServer.tests,
+        Test.Federator.Monitor.tests,
+        Test.Federator.Remote.tests,
+        Test.Federator.Response.tests
+      ]

--- a/services/federator/test/unit/Test/Federator/Remote.hs
+++ b/services/federator/test/unit/Test/Federator/Remote.hs
@@ -21,6 +21,7 @@ import Control.Exception (bracket)
 import Control.Monad.Codensity
 import Data.Domain
 import Federator.Discovery
+import Federator.Env (TLSSettings)
 import Federator.Options
 import Federator.Remote
 import Federator.Run (mkTLSSettingsOrThrow)
@@ -30,7 +31,6 @@ import Network.Wai
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.WarpTLS as Warp
 import Network.Wai.Utilities.MockServer (startMockServer)
-import OpenSSL.Session (SSLContext)
 import Polysemy
 import Polysemy.Embed
 import Polysemy.Error
@@ -62,29 +62,30 @@ settings =
       remoteCAStore = Just "test/resources/unit/unit-ca.pem"
     }
 
-discoverLocalhost :: ByteString -> Int -> Sem (DiscoverFederator ': r) a -> Sem r a
-discoverLocalhost hostname port = interpret $ \case
+discoverLocalhost :: Int -> Sem (DiscoverFederator ': r) a -> Sem r a
+discoverLocalhost port = interpret $ \case
   DiscoverAllFederators (Domain "localhost") ->
-    pure (Right (pure (SrvTarget hostname (fromIntegral port))))
+    pure (Right (pure (SrvTarget "localhost" (fromIntegral port))))
   DiscoverAllFederators _ -> pure (Left (DiscoveryFailureSrvNotAvailable "only localhost is supported"))
   DiscoverFederator (Domain "localhost") ->
-    pure (Right (SrvTarget hostname (fromIntegral port)))
+    pure (Right (SrvTarget "localhost" (fromIntegral port)))
   DiscoverFederator _ -> pure (Left (DiscoveryFailureSrvNotAvailable "only localhost is supported"))
 
-assertNoRemoteError :: Either RemoteError x -> IO x
-assertNoRemoteError = \case
-  Left err -> assertFailure $ "Unexpected remote error: " <> show err
-  Right x -> pure x
+assertNoRemoteError :: IO (Either RemoteError x) -> IO x
+assertNoRemoteError action =
+  action >>= \case
+    Left err -> assertFailure $ "Unexpected remote error: " <> show err
+    Right x -> pure x
 
-mkTestCall :: SSLContext -> ByteString -> Int -> Codensity IO (Either RemoteError ())
-mkTestCall sslCtx hostname port =
+mkTestCall :: TLSSettings -> Int -> IO (Either RemoteError ())
+mkTestCall tlsSettings port =
   runM
-    . runEmbedded @IO @(Codensity IO) liftIO
     . runError @RemoteError
     . void
-    . runInputConst sslCtx
-    . discoverLocalhost hostname port
+    . runInputConst tlsSettings
+    . discoverLocalhost port
     . assertNoError @DiscoveryFailure
+    . runEmbedded @(Codensity IO) @IO lowerCodensity
     . interpretRemote
     $ discoverAndCall (Domain "localhost") Brig "test" [] mempty
 
@@ -104,23 +105,17 @@ testValidatesCertificateSuccess =
     [ testCase "when hostname=localhost and certificate-for=localhost" $
         withMockServer certForLocalhost $ \port -> do
           tlsSettings <- mkTLSSettingsOrThrow settings
-          runCodensity (mkTestCall tlsSettings "localhost" port) assertNoRemoteError,
+          assertNoRemoteError (mkTestCall tlsSettings port),
       testCase "when hostname=localhost. and certificate-for=localhost" $
         withMockServer certForLocalhost $ \port -> do
           tlsSettings <- mkTLSSettingsOrThrow settings
-          runCodensity (mkTestCall tlsSettings "localhost." port) assertNoRemoteError,
-      -- It is not very clear how to handle this, this test just exists to
-      -- document what we do.
-      -- Some discussion from author of curl:
-      -- https://lists.w3.org/Archives/Public/ietf-http-wg/2016JanMar/0430.html
-      --
-      -- Perhaps it is also not possible to get a publically verifiable
-      -- certificate like this from any of the CAs:
-      -- https://github.com/certbot/certbot/issues/3718
+          assertNoRemoteError (mkTestCall tlsSettings port),
+      -- This is a limitation of the TLS library, this test just exists to document that.
       testCase "when hostname=localhost. and certificate-for=localhost." $
         withMockServer certForLocalhostDot $ \port -> do
           tlsSettings <- mkTLSSettingsOrThrow settings
-          runCodensity (mkTestCall tlsSettings "localhost." port) $ \case
+          eitherClient <- mkTestCall tlsSettings port
+          case eitherClient of
             Left _ -> pure ()
             Right _ -> assertFailure "Congratulations, you fixed a known issue!"
     ]
@@ -138,14 +133,16 @@ testValidatesCertificateWrongHostname =
     [ testCase "when the server's certificate doesn't match the hostname" $
         withMockServer certForWrongDomain $ \port -> do
           tlsSettings <- mkTLSSettingsOrThrow settings
-          runCodensity (mkTestCall tlsSettings "localhost" port) $ \case
+          eitherClient <- mkTestCall tlsSettings port
+          case eitherClient of
             Left (RemoteError _ (FederatorClientTLSException _)) -> pure ()
             Left x -> assertFailure $ "Expected TLS failure, got: " <> show x
             Right _ -> assertFailure "Expected connection with the server to fail",
       testCase "when the server's certificate does not have the server key usage flag" $
         withMockServer certWithoutServerKeyUsage $ \port -> do
           tlsSettings <- mkTLSSettingsOrThrow settings
-          runCodensity (mkTestCall tlsSettings "localhost" port) $ \case
+          eitherClient <- mkTestCall tlsSettings port
+          case eitherClient of
             Left (RemoteError _ (FederatorClientTLSException _)) -> pure ()
             Left x -> assertFailure $ "Expected TLS failure, got: " <> show x
             Right _ -> assertFailure "Expected connection with the server to fail"
@@ -156,7 +153,8 @@ testValidatesCertificateWrongHostname =
 testConnectionError :: TestTree
 testConnectionError = testCase "connection failures are reported correctly" $ do
   tlsSettings <- mkTLSSettingsOrThrow settings
-  runCodensity (mkTestCall tlsSettings "localhost" 1) $ \case
+  result <- mkTestCall tlsSettings 1
+  case result of
     Left (RemoteError _ (FederatorClientConnectionError _)) -> pure ()
     Left x -> assertFailure $ "Expected connection error, got: " <> show x
     Right _ -> assertFailure "Expected connection with the server to fail"


### PR DESCRIPTION
Reverts wireapp/wire-server#3051
Context https://wearezeta.atlassian.net/browse/FS-1609