### PR TITLE
[FS-1147] Proteus: Support creating a conversation when remote backends are unavailable

### DIFF
--- a/changelog.d/1-api-changes/create-conv-failed-to-add
+++ b/changelog.d/1-api-changes/create-conv-failed-to-add
@@ -1,0 +1,1 @@
+List failed-to-add remote users in response to `POST /conversations`

--- a/changelog.d/6-federation/create-conversation-dos
+++ b/changelog.d/6-federation/create-conversation-dos
@@ -1,0 +1,1 @@
+Do not cause denial of service when creating a conversation with users from an unreachable backend

--- a/libs/types-common/src/Data/Qualified.hs
+++ b/libs/types-common/src/Data/Qualified.hs
@@ -167,9 +167,10 @@ deprecatedSchema :: S.HasDescription doc (Maybe Text) => Text -> ValueSchema doc
 deprecatedSchema new = doc . description ?~ ("Deprecated, use " <> new)
 
 qualifiedSchema ::
+  HasSchemaRef doc =>
   Text ->
   Text ->
-  ValueSchema NamedSwaggerDoc a ->
+  ValueSchema doc a ->
   ValueSchema NamedSwaggerDoc (Qualified a)
 qualifiedSchema name fieldName sch =
   object ("Qualified_" <> name) $

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -310,7 +310,7 @@ instance ToSchema CreateGroupConversation where
     where
       toFlatList :: Map Domain (Set a) -> [Qualified a]
       toFlatList m =
-        join $ (\(d, s) -> flip Qualified d <$> Set.toList s) <$> Map.assocs m
+        (\(d, s) -> flip Qualified d <$> Set.toList s) =<< Map.assocs m
       fromFlatList :: Ord a => [Qualified a] -> Map Domain (Set a)
       fromFlatList = fmap Set.fromList . indexQualified
 

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -420,7 +420,7 @@ type ConversationAPI =
                :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
                :> ZLocalUser
                :> ZOptClient
-               :> ZConn
+               :> ZOptConn
                :> "conversations"
                :> ReqBody '[Servant.JSON] NewConv
                :> CreateGroupConversationVerb

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -21,6 +21,7 @@ import qualified Data.Code as Code
 import Data.CommaSeparatedList
 import Data.Id
 import Data.Range
+import Data.SOP (I (..), NS (..))
 import Imports hiding (head)
 import Servant hiding (WithStatus)
 import Servant.Swagger.Internal.Orphans ()
@@ -45,6 +46,23 @@ import Wire.API.Team.Feature
 
 type ConversationResponse = ResponseForExistedCreated Conversation
 
+-- | A type similar to 'ConversationResponse' introduced to allow for a failure
+-- to add remote members while creating a conversation.
+data CreateGroupConversationResponse
+  = GroupConversationExisted Conversation
+  | GroupConversationCreated CreateGroupConversation
+
+instance
+  (ResponseType r1 ~ Conversation, ResponseType r2 ~ CreateGroupConversation) =>
+  AsUnion '[r1, r2] CreateGroupConversationResponse
+  where
+  toUnion (GroupConversationExisted x) = Z (I x)
+  toUnion (GroupConversationCreated x) = S (Z (I x))
+
+  fromUnion (Z (I x)) = GroupConversationExisted x
+  fromUnion (S (Z (I x))) = GroupConversationCreated x
+  fromUnion (S (S x)) = case x of {}
+
 type ConversationHeaders = '[DescHeader "Location" "Conversation ID" ConvId]
 
 type ConversationVerb =
@@ -61,6 +79,21 @@ type ConversationVerb =
          (Respond 201 "Conversation created" Conversation)
      ]
     ConversationResponse
+
+type CreateGroupConversationVerb =
+  MultiVerb
+    'POST
+    '[JSON]
+    '[ WithHeaders
+         ConversationHeaders
+         Conversation
+         (Respond 200 "Conversation existed" Conversation),
+       WithHeaders
+         ConversationHeaders
+         CreateGroupConversation
+         (Respond 201 "Conversation created" CreateGroupConversation)
+     ]
+    CreateGroupConversationResponse
 
 type ConversationV2Verb =
   MultiVerb
@@ -350,11 +383,11 @@ type ConversationAPI =
                :> ConversationV2Verb
            )
     :<|> Named
-           "create-group-conversation"
+           "create-group-conversation@v3"
            ( Summary "Create a new conversation"
                :> DescriptionOAuthScope 'WriteConversations
                :> MakesFederatedCall 'Galley "on-conversation-created"
-               :> From 'V3
+               :> Until 'V4
                :> CanThrow 'ConvAccessDenied
                :> CanThrow 'MLSMissingSenderClient
                :> CanThrow 'MLSNonEmptyMemberList
@@ -370,6 +403,27 @@ type ConversationAPI =
                :> "conversations"
                :> ReqBody '[Servant.JSON] NewConv
                :> ConversationVerb
+           )
+    :<|> Named
+           "create-group-conversation"
+           ( Summary "Create a new conversation"
+               :> MakesFederatedCall 'Galley "on-conversation-created"
+               :> From 'V4
+               :> CanThrow 'ConvAccessDenied
+               :> CanThrow 'MLSMissingSenderClient
+               :> CanThrow 'MLSNonEmptyMemberList
+               :> CanThrow 'MLSNotEnabled
+               :> CanThrow 'NotConnected
+               :> CanThrow 'NotATeamMember
+               :> CanThrow OperationDenied
+               :> CanThrow 'MissingLegalholdConsent
+               :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
+               :> ZLocalUser
+               :> ZOptClient
+               :> ZConn
+               :> "conversations"
+               :> ReqBody '[Servant.JSON] NewConv
+               :> CreateGroupConversationVerb
            )
     :<|> Named
            "create-self-conversation@v2"

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
@@ -27,6 +27,7 @@ import Test.Wire.API.Golden.Manual.ConversationCoverView
 import Test.Wire.API.Golden.Manual.ConversationEvent
 import Test.Wire.API.Golden.Manual.ConversationPagingState
 import Test.Wire.API.Golden.Manual.ConversationsResponse
+import Test.Wire.API.Golden.Manual.CreateGroupConversation
 import Test.Wire.API.Golden.Manual.CreateScimToken
 import Test.Wire.API.Golden.Manual.FeatureConfigEvent
 import Test.Wire.API.Golden.Manual.GetPaginatedConversationIds
@@ -144,5 +145,11 @@ tests =
           [ (testObject_TeamSize_1, "testObject_TeamSize_1.json"),
             (testObject_TeamSize_2, "testObject_TeamSize_2.json"),
             (testObject_TeamSize_3, "testObject_TeamSize_3.json")
+          ],
+      testGroup "CreateGroupConversation" $
+        testObjects
+          [ (testObject_CreateGroupConversation_1, "testObject_CreateGroupConversation_1.json"),
+            (testObject_CreateGroupConversation_2, "testObject_CreateGroupConversation_2.json"),
+            (testObject_CreateGroupConversation_3, "testObject_CreateGroupConversation_3.json")
           ]
     ]

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/CreateGroupConversation.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/CreateGroupConversation.hs
@@ -1,0 +1,61 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Wire.API.Golden.Manual.CreateGroupConversation where
+
+import Data.Domain
+import Data.Id
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Data.UUID as UUID (fromString)
+import Imports
+import Test.Wire.API.Golden.Generated.Conversation_user
+import Wire.API.Conversation
+
+unreachableDomain1, unreachableDomain2 :: Domain
+unreachableDomain1 = Domain "golden-unreachable-1.example.com"
+unreachableDomain2 = Domain "golden-unreachable-2.example.com"
+
+user1, user2 :: UserId
+user1 = Id (fromJust (UUID.fromString "a0000001-0000-0001-0000-000200000007"))
+user2 = Id (fromJust (UUID.fromString "f0000001-b000-0001-0000-000200060005"))
+
+testObject_CreateGroupConversation_1 :: CreateGroupConversation
+testObject_CreateGroupConversation_1 =
+  CreateGroupConversation
+    { cgcConversation = testObject_Conversation_user_1,
+      cgcFailedToAdd = Map.empty
+    }
+
+testObject_CreateGroupConversation_2 :: CreateGroupConversation
+testObject_CreateGroupConversation_2 =
+  CreateGroupConversation
+    { cgcConversation = testObject_Conversation_user_1,
+      cgcFailedToAdd =
+        Map.singleton unreachableDomain1 $ Set.fromList $ [user1, user2]
+    }
+
+testObject_CreateGroupConversation_3 :: CreateGroupConversation
+testObject_CreateGroupConversation_3 =
+  CreateGroupConversation
+    { cgcConversation = testObject_Conversation_user_1,
+      cgcFailedToAdd =
+        Map.fromList
+          [ (unreachableDomain1, Set.singleton user1),
+            (unreachableDomain2, Set.singleton user2)
+          ]
+    }

--- a/libs/wire-api/test/golden/testObject_CreateGroupConversation_1.json
+++ b/libs/wire-api/test/golden/testObject_CreateGroupConversation_1.json
@@ -1,0 +1,40 @@
+{
+    "access": [],
+    "access_role": [],
+    "creator": "00000001-0000-0001-0000-000200000001",
+    "failed_to_add": [],
+    "id": "00000001-0000-0000-0000-000000000000",
+    "last_event": "0.0",
+    "last_event_time": "1970-01-01T00:00:00.000Z",
+    "members": {
+        "others": [],
+        "self": {
+            "conversation_role": "rhhdzf0j0njilixx0g0vzrp06b_5us",
+            "hidden": false,
+            "hidden_ref": "",
+            "id": "00000001-0000-0001-0000-000100000000",
+            "otr_archived": false,
+            "otr_archived_ref": "",
+            "otr_muted_ref": null,
+            "otr_muted_status": null,
+            "qualified_id": {
+                "domain": "golden.example.com",
+                "id": "00000001-0000-0001-0000-000100000000"
+            },
+            "service": null,
+            "status": 0,
+            "status_ref": "0.0",
+            "status_time": "1970-01-01T00:00:00.000Z"
+        }
+    },
+    "message_timer": null,
+    "name": " 0",
+    "protocol": "proteus",
+    "qualified_id": {
+        "domain": "golden.example.com",
+        "id": "00000001-0000-0000-0000-000000000000"
+    },
+    "receipt_mode": -2,
+    "team": "00000001-0000-0001-0000-000100000002",
+    "type": 2
+}

--- a/libs/wire-api/test/golden/testObject_CreateGroupConversation_2.json
+++ b/libs/wire-api/test/golden/testObject_CreateGroupConversation_2.json
@@ -1,0 +1,49 @@
+{
+    "access": [],
+    "access_role": [],
+    "creator": "00000001-0000-0001-0000-000200000001",
+    "failed_to_add": [
+        {
+            "domain": "golden-unreachable-1.example.com",
+            "id": "a0000001-0000-0001-0000-000200000007"
+        },
+        {
+            "domain": "golden-unreachable-1.example.com",
+            "id": "f0000001-b000-0001-0000-000200060005"
+        }
+    ],
+    "id": "00000001-0000-0000-0000-000000000000",
+    "last_event": "0.0",
+    "last_event_time": "1970-01-01T00:00:00.000Z",
+    "members": {
+        "others": [],
+        "self": {
+            "conversation_role": "rhhdzf0j0njilixx0g0vzrp06b_5us",
+            "hidden": false,
+            "hidden_ref": "",
+            "id": "00000001-0000-0001-0000-000100000000",
+            "otr_archived": false,
+            "otr_archived_ref": "",
+            "otr_muted_ref": null,
+            "otr_muted_status": null,
+            "qualified_id": {
+                "domain": "golden.example.com",
+                "id": "00000001-0000-0001-0000-000100000000"
+            },
+            "service": null,
+            "status": 0,
+            "status_ref": "0.0",
+            "status_time": "1970-01-01T00:00:00.000Z"
+        }
+    },
+    "message_timer": null,
+    "name": " 0",
+    "protocol": "proteus",
+    "qualified_id": {
+        "domain": "golden.example.com",
+        "id": "00000001-0000-0000-0000-000000000000"
+    },
+    "receipt_mode": -2,
+    "team": "00000001-0000-0001-0000-000100000002",
+    "type": 2
+}

--- a/libs/wire-api/test/golden/testObject_CreateGroupConversation_3.json
+++ b/libs/wire-api/test/golden/testObject_CreateGroupConversation_3.json
@@ -1,0 +1,49 @@
+{
+    "access": [],
+    "access_role": [],
+    "creator": "00000001-0000-0001-0000-000200000001",
+    "failed_to_add": [
+        {
+            "domain": "golden-unreachable-1.example.com",
+            "id": "a0000001-0000-0001-0000-000200000007"
+        },
+        {
+            "domain": "golden-unreachable-2.example.com",
+            "id": "f0000001-b000-0001-0000-000200060005"
+        }
+    ],
+    "id": "00000001-0000-0000-0000-000000000000",
+    "last_event": "0.0",
+    "last_event_time": "1970-01-01T00:00:00.000Z",
+    "members": {
+        "others": [],
+        "self": {
+            "conversation_role": "rhhdzf0j0njilixx0g0vzrp06b_5us",
+            "hidden": false,
+            "hidden_ref": "",
+            "id": "00000001-0000-0001-0000-000100000000",
+            "otr_archived": false,
+            "otr_archived_ref": "",
+            "otr_muted_ref": null,
+            "otr_muted_status": null,
+            "qualified_id": {
+                "domain": "golden.example.com",
+                "id": "00000001-0000-0001-0000-000100000000"
+            },
+            "service": null,
+            "status": 0,
+            "status_ref": "0.0",
+            "status_time": "1970-01-01T00:00:00.000Z"
+        }
+    },
+    "message_timer": null,
+    "name": " 0",
+    "protocol": "proteus",
+    "qualified_id": {
+        "domain": "golden.example.com",
+        "id": "00000001-0000-0000-0000-000000000000"
+    },
+    "receipt_mode": -2,
+    "team": "00000001-0000-0001-0000-000100000002",
+    "type": 2
+}

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -539,6 +539,7 @@ test-suite wire-api-golden-tests
     Test.Wire.API.Golden.Manual.ConversationPagingState
     Test.Wire.API.Golden.Manual.ConversationsResponse
     Test.Wire.API.Golden.Manual.ConvIdsPage
+    Test.Wire.API.Golden.Manual.CreateGroupConversation
     Test.Wire.API.Golden.Manual.CreateScimToken
     Test.Wire.API.Golden.Manual.FeatureConfigEvent
     Test.Wire.API.Golden.Manual.GetPaginatedConversationIds

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -660,14 +660,7 @@ notifyCreatedConversation lusr conn c = do
   -- of being added to a conversation
   failedToNotify <- registerRemoteConversationMemberships now (tDomain lusr) c
   -- Notify local users
-  let remoteOthers = map remoteMemberToOther $ Data.convRemoteMembers c -- TODO(md):
-  -- should
-  -- 'failedToNotify'
-  -- be
-  -- filtered
-  -- out
-  -- from
-  -- 'remoteOthers'?
+  let remoteOthers = map remoteMemberToOther $ Data.convRemoteMembers c
       localOthers = map (localMemberToOther (tDomain lusr)) $ Data.convLocalMembers c
   E.push =<< mapM (toPush now remoteOthers localOthers) (Data.convLocalMembers c)
   pure failedToNotify

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -23,7 +23,7 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 module Galley.API.Create
-  ( createGroupConversationV3,
+  ( createGroupConversationUpToV3,
     createGroupConversation,
     createProteusSelfConversation,
     createOne2OneConversation,
@@ -86,7 +86,7 @@ import Wire.API.Team.Permission hiding (self)
 
 -- | The public-facing endpoint for creating group conversations in the client
 -- API up to and including version 3.
-createGroupConversationV3 ::
+createGroupConversationUpToV3 ::
   ( Member BrigAccess r,
     Member ConversationStore r,
     Member MemberStore r,
@@ -114,7 +114,7 @@ createGroupConversationV3 ::
   Maybe ConnId ->
   NewConv ->
   Sem r ConversationResponse
-createGroupConversationV3 lusr mCreatorClient conn newConv =
+createGroupConversationUpToV3 lusr mCreatorClient conn newConv =
   createGroupConversationGeneric
     lusr
     mCreatorClient

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -44,7 +44,8 @@ conversationAPI =
     <@> mkNamedAPI @"list-conversations@v2" (callsFed (exposeAnnotations listConversations))
     <@> mkNamedAPI @"list-conversations" (callsFed (exposeAnnotations listConversations))
     <@> mkNamedAPI @"get-conversation-by-reusable-code" (getConversationByReusableCode @Cassandra)
-    <@> mkNamedAPI @"create-group-conversation@v2" (callsFed (exposeAnnotations createGroupConversation))
+    <@> mkNamedAPI @"create-group-conversation@v2" (callsFed (exposeAnnotations createGroupConversationV3))
+    <@> mkNamedAPI @"create-group-conversation@v3" (callsFed (exposeAnnotations createGroupConversationV3))
     <@> mkNamedAPI @"create-group-conversation" (callsFed (exposeAnnotations createGroupConversation))
     <@> mkNamedAPI @"create-self-conversation@v2" createProteusSelfConversation
     <@> mkNamedAPI @"create-self-conversation" createProteusSelfConversation

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -44,8 +44,8 @@ conversationAPI =
     <@> mkNamedAPI @"list-conversations@v2" (callsFed (exposeAnnotations listConversations))
     <@> mkNamedAPI @"list-conversations" (callsFed (exposeAnnotations listConversations))
     <@> mkNamedAPI @"get-conversation-by-reusable-code" (getConversationByReusableCode @Cassandra)
-    <@> mkNamedAPI @"create-group-conversation@v2" (callsFed (exposeAnnotations createGroupConversationV3))
-    <@> mkNamedAPI @"create-group-conversation@v3" (callsFed (exposeAnnotations createGroupConversationV3))
+    <@> mkNamedAPI @"create-group-conversation@v2" (callsFed (exposeAnnotations createGroupConversationUpToV3))
+    <@> mkNamedAPI @"create-group-conversation@v3" (callsFed (exposeAnnotations createGroupConversationUpToV3))
     <@> mkNamedAPI @"create-group-conversation" (callsFed (exposeAnnotations createGroupConversation))
     <@> mkNamedAPI @"create-self-conversation@v2" createProteusSelfConversation
     <@> mkNamedAPI @"create-self-conversation" createProteusSelfConversation

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -429,7 +429,7 @@ postConvWithRemoteUsersOk rbs = do
     mockUnreachable unreachable = do
       r <- getRequest
       if Set.member (frTargetDomain r) unreachable
-        then mockFail "not reachable"
+        then throw (MockErrorResponse HTTP.status503 "Down for maintenance.")
         else mockReply ()
     connectBackend :: UserId -> Remote Backend -> TestM [Qualified UserId]
     connectBackend usr (tDomain &&& bUsers . tUnqualified -> (d, c)) = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -121,23 +121,6 @@ tests s =
       API.MLS.tests s
     ]
   where
-    rb1, rb2 :: Remote Backend
-    rb1 =
-      toRemoteUnsafe
-        (Domain "c.example.com")
-        ( Backend
-            { bReachable = BackendReachable,
-              bUsers = 2
-            }
-        )
-    rb2 =
-      toRemoteUnsafe
-        (Domain "d.example.com")
-        ( Backend
-            { bReachable = BackendReachable,
-              bUsers = 1
-            }
-        )
     mainTests =
       testGroup
         "Main Conversations API"
@@ -146,6 +129,7 @@ tests s =
           test s "fetch conversation by qualified ID (v2)" testGetConvQualifiedV2,
           test s "create Proteus conversation" postProteusConvOk,
           test s "create conversation with remote users" (postConvWithRemoteUsersOk $ Set.fromList [rb1, rb2]),
+          test s "create conversation with remote users (some unreachable)" (postConvWithRemoteUsersOk $ Set.fromList [rb1, rb2, rb3]),
           test s "get empty conversations" getConvsOk,
           test s "get conversations by ids" getConvsOk2,
           test s "fail to get >500 conversations with v2 API" getConvsFailMaxSizeV2,
@@ -269,6 +253,31 @@ tests s =
               test s "send typing indicators with invalid pyaload" postTypingIndicatorsHandlesNonsense
             ]
         ]
+    rb1, rb2, rb3 :: Remote Backend
+    rb1 =
+      toRemoteUnsafe
+        (Domain "c.example.com")
+        ( Backend
+            { bReachable = BackendReachable,
+              bUsers = 2
+            }
+        )
+    rb2 =
+      toRemoteUnsafe
+        (Domain "d.example.com")
+        ( Backend
+            { bReachable = BackendReachable,
+              bUsers = 1
+            }
+        )
+    rb3 =
+      toRemoteUnsafe
+        (Domain "e.example.com")
+        ( Backend
+            { bReachable = BackendUnreachable,
+              bUsers = 2
+            }
+        )
 
 -------------------------------------------------------------------------------
 -- API Tests

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -25,6 +25,7 @@ where
 
 import qualified API.CustomBackend as CustomBackend
 import qualified API.Federation as Federation
+import API.Federation.Util
 import qualified API.MLS
 import qualified API.MessageTimer as MessageTimer
 import qualified API.Roles as Roles
@@ -66,7 +67,6 @@ import qualified Data.Text.Ascii as Ascii
 import Data.Time.Clock (getCurrentTime)
 import Federator.Discovery (DiscoveryFailure (..))
 import Federator.MockServer
-import GHC.TypeLits
 import Galley.API.Mapping
 import Galley.Options (optFederator)
 import Galley.Types.Conversations.Members
@@ -340,18 +340,6 @@ postProteusConvOk = do
       case evtData e of
         EdConversation c' -> assertConvEquals cnv c'
         _ -> assertFailure "Unexpected event data"
-
-data BackendReachability = BackendReachable | BackendUnreachable
-  deriving (Eq, Ord)
-
-data Backend = Backend
-  { bReachable :: BackendReachability,
-    bUsers :: Nat
-  }
-  deriving (Eq, Ord)
-
-rbReachable :: Remote Backend -> BackendReachability
-rbReachable = bReachable . tUnqualified
 
 postConvWithRemoteUsersOk :: Set (Remote Backend) -> TestM ()
 postConvWithRemoteUsersOk rbs = do

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -418,7 +418,7 @@ postConvWithRemoteUsersOk rbs = do
         @?= Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole, ServiceAccessRole]
       F.ccCnvName fedReqBody @?= Just nameMaxSize
       assertBool "Notifying an incorrect set of conversation members" $
-        shouldBePresentSet `Set.isSubsetOf` (F.ccNonCreatorMembers fedReqBody)
+        shouldBePresentSet `Set.isSubsetOf` F.ccNonCreatorMembers fedReqBody
       F.ccMessageTimer fedReqBody @?= Nothing
       F.ccReceiptMode fedReqBody @?= Nothing
 

--- a/services/galley/test/integration/API/Federation/Util.hs
+++ b/services/galley/test/integration/API/Federation/Util.hs
@@ -15,9 +15,18 @@
 -- You should have received a copy of the GNU Affero General Public License along
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
-module API.Federation.Util (mkHandler) where
+module API.Federation.Util
+  ( mkHandler,
+
+    -- * the remote backend type
+    BackendReachability (..),
+    Backend (..),
+    rbReachable,
+  )
+where
 
 import Data.Kind
+import Data.Qualified
 import Data.SOP
 import Data.String.Conversions (cs)
 import GHC.TypeLits
@@ -101,3 +110,18 @@ instance
   PartialAPI (Named (name :: Symbol) endpoint :<|> api) (Named name h)
   where
   mkHandler h = h :<|> mkHandler @api EmptyAPI
+
+--------------------------------------------------------------------------------
+-- The remote backend type
+
+data BackendReachability = BackendReachable | BackendUnreachable
+  deriving (Eq, Ord)
+
+data Backend = Backend
+  { bReachable :: BackendReachability,
+    bUsers :: Nat
+  }
+  deriving (Eq, Ord)
+
+rbReachable :: Remote Backend -> BackendReachability
+rbReachable = bReachable . tUnqualified


### PR DESCRIPTION
Tracked by https://wearezeta.atlassian.net/browse/FS-1147.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
