### PR TITLE
retry-integration-tests-once

### DIFF
--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -42,11 +42,11 @@ summary() {
 # - run integration tests. If they fail, keep track of this, but still go and get logs, so we see what failed
 # - run all tests. Perhaps multiple flaky tests in multiple services exist, if so, we wish to see all problems
 mkdir -p ~/.parallel && touch ~/.parallel/will-cite
-printf '%s\n' "${tests[@]}" | parallel echo "Running helm tests for {}..."
-printf '%s\n' "${tests[@]}" | parallel -P "${HELM_PARALLELISM}" \
+printf '%s\n' "${tests[@]}" | parallel -P "${HELM_PARALLELISM}" --retries 1 \
+    echo "Running helm tests for {}..." ';' \
     helm test -n "${NAMESPACE}" "${NAMESPACE}-${CHART}" --timeout 900s --filter name="${NAMESPACE}-${CHART}-{}-integration" '> logs-{};' \
     echo '$? > stat-{};' \
-    echo "==== Done testing {}. ====" '};' \
+    echo "==== Done testing {}. ====" ';' \
     kubectl -n "${NAMESPACE}" logs "${NAMESPACE}-${CHART}-{}-integration" '>> logs-{};'
 
 summary


### PR DESCRIPTION
This might be a bad idea. If we introduce this, it has the advantage of not needing to manually retrigger the integration tests if they fail due to a (rare) flake.

Ideally we would try and improve those tests which are flaky. Right now we don't have a process that works very well for this however (might be too hard; no time; working on other things; not feeling responsible; etc). So we could combine this PR with e.g. a regular "let's deflake existing tests" effort happening e.g. weekly or bi-weekly (just an idea).

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
