### PR TITLE
Fix version paths

### DIFF
--- a/changelog.d/3-bug-fixes/pr-3152
+++ b/changelog.d/3-bug-fixes/pr-3152
@@ -1,0 +1,1 @@
+Fix version parsing in swagger-ui end-points

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -452,6 +452,7 @@ executable brig-integration
     API.Search
     API.Search.Util
     API.Settings
+    API.Swagger
     API.SystemSettings
     API.Team
     API.Team.Util

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -163,7 +163,7 @@ docsAPI =
 --
 -- Dual to `internalEndpointsSwaggerDocsAPI`.
 versionedSwaggerDocsAPI :: Servant.Server VersionedSwaggerDocsAPI
-versionedSwaggerDocsAPI (Just V4) =
+versionedSwaggerDocsAPI (Just (VersionNumber V4)) =
   swaggerSchemaUIServer $
     ( brigSwagger
         <> versionSwagger
@@ -178,10 +178,10 @@ versionedSwaggerDocsAPI (Just V4) =
       & S.info . S.title .~ "Wire-Server API"
       & S.info . S.description ?~ $(embedText =<< makeRelativeToProject "docs/swagger.md")
       & cleanupSwagger
-versionedSwaggerDocsAPI (Just V0) = swaggerPregenUIServer $(pregenSwagger V0)
-versionedSwaggerDocsAPI (Just V1) = swaggerPregenUIServer $(pregenSwagger V1)
-versionedSwaggerDocsAPI (Just V2) = swaggerPregenUIServer $(pregenSwagger V2)
-versionedSwaggerDocsAPI (Just V3) = swaggerPregenUIServer $(pregenSwagger V3)
+versionedSwaggerDocsAPI (Just (VersionNumber V0)) = swaggerPregenUIServer $(pregenSwagger V0)
+versionedSwaggerDocsAPI (Just (VersionNumber V1)) = swaggerPregenUIServer $(pregenSwagger V1)
+versionedSwaggerDocsAPI (Just (VersionNumber V2)) = swaggerPregenUIServer $(pregenSwagger V2)
+versionedSwaggerDocsAPI (Just (VersionNumber V3)) = swaggerPregenUIServer $(pregenSwagger V3)
 versionedSwaggerDocsAPI Nothing = versionedSwaggerDocsAPI (Just maxBound)
 
 -- | Serves Swagger docs for internal endpoints
@@ -195,15 +195,15 @@ internalEndpointsSwaggerDocsAPI ::
   PortNumber ->
   S.Swagger ->
   Servant.Server (VersionedSwaggerDocsAPIBase service)
-internalEndpointsSwaggerDocsAPI service examplePort swagger (Just V4) =
+internalEndpointsSwaggerDocsAPI service examplePort swagger (Just (VersionNumber V4)) =
   swaggerSchemaUIServer $
     swagger
       & adjustSwaggerForInternalEndpoint service examplePort
       & cleanupSwagger
-internalEndpointsSwaggerDocsAPI _ _ _ (Just V0) = emptySwagger
-internalEndpointsSwaggerDocsAPI _ _ _ (Just V1) = emptySwagger
-internalEndpointsSwaggerDocsAPI _ _ _ (Just V2) = emptySwagger
-internalEndpointsSwaggerDocsAPI _ _ _ (Just V3) = emptySwagger
+internalEndpointsSwaggerDocsAPI _ _ _ (Just (VersionNumber V0)) = emptySwagger
+internalEndpointsSwaggerDocsAPI _ _ _ (Just (VersionNumber V1)) = emptySwagger
+internalEndpointsSwaggerDocsAPI _ _ _ (Just (VersionNumber V2)) = emptySwagger
+internalEndpointsSwaggerDocsAPI _ _ _ (Just (VersionNumber V3)) = emptySwagger
 internalEndpointsSwaggerDocsAPI service examplePort swagger Nothing =
   internalEndpointsSwaggerDocsAPI service examplePort swagger (Just maxBound)
 

--- a/services/brig/src/Brig/API/Public/Swagger.hs
+++ b/services/brig/src/Brig/API/Public/Swagger.hs
@@ -36,11 +36,11 @@ import Wire.API.Routes.Version
 
 type SwaggerDocsAPIBase = SwaggerSchemaUI "swagger-ui" "swagger.json"
 
-type VersionedSwaggerDocsAPI = "api" :> Header VersionHeader Version :> SwaggerDocsAPIBase
+type VersionedSwaggerDocsAPI = "api" :> Header VersionHeader VersionNumber :> SwaggerDocsAPIBase
 
 type ServiceSwaggerDocsAPIBase service = SwaggerSchemaUI service (AppendSymbol service "-swagger.json")
 
-type VersionedSwaggerDocsAPIBase service = Header VersionHeader Version :> ServiceSwaggerDocsAPIBase service
+type VersionedSwaggerDocsAPIBase service = Header VersionHeader VersionNumber :> ServiceSwaggerDocsAPIBase service
 
 type InternalEndpointsSwaggerDocsAPI =
   "api-internal"

--- a/services/brig/test/integration/API/Swagger.hs
+++ b/services/brig/test/integration/API/Swagger.hs
@@ -1,0 +1,47 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module API.Swagger (tests) where
+
+import Bilge
+import Brig.Options
+import Control.Lens
+import Data.Aeson.Lens
+import Data.String.Conversions
+import Imports
+import Test.Tasty
+import Test.Tasty.HUnit
+import Util
+
+tests :: Manager -> Opts -> Brig -> TestTree
+tests p _opts brigNoImplicitVersion =
+  testGroup "version" $
+    [ test p "GET /api/swagger.json" $ testSwaggerJson brigNoImplicitVersion "",
+      test p "GET /api/swagger-ui" $ testSwaggerUI brigNoImplicitVersion "",
+      test p "GET /v2/api/swagger.json" $ testSwaggerJson brigNoImplicitVersion "/v2",
+      test p "GET /v2/api/swagger-ui" $ testSwaggerUI brigNoImplicitVersion "/v2"
+    ]
+
+testSwaggerJson :: Brig -> ByteString -> Http ()
+testSwaggerJson brig version = do
+  r <- get (brig . path (version <> "/api/swagger.json") . expect2xx)
+  liftIO $ assertBool "json body" (isJust $ ((^? _Object) <=< responseBody) r)
+
+testSwaggerUI :: Brig -> ByteString -> Http ()
+testSwaggerUI brig version = do
+  r <- get (brig . path (version <> "/api/swagger-ui") . expect2xx)
+  liftIO $ assertBool "HTML body" ("<div id=\"swagger-ui\"></div>" `isInfixOf` (cs . fromJust . responseBody $ r))

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -29,6 +29,7 @@ import qualified API.OAuth
 import qualified API.Provider as Provider
 import qualified API.Search as Search
 import qualified API.Settings as Settings
+import qualified API.Swagger
 import qualified API.SystemSettings as SystemSettings
 import qualified API.Team as Team
 import qualified API.TeamUserSearch as TeamUserSearch
@@ -113,6 +114,7 @@ instance FromJSON Config
 runTests :: Config -> Opts.Opts -> [String] -> IO ()
 runTests iConf brigOpts otherArgs = do
   let b = mkVersionedRequest $ brig iConf
+      brigNoImplicitVersion = mkRequest $ brig iConf
       c = mkVersionedRequest $ cannon iConf
       gd = mkVersionedRequest $ gundeck iConf
       ch = mkVersionedRequest $ cargohold iConf
@@ -159,6 +161,7 @@ runTests iConf brigOpts otherArgs = do
 
   let smtp = SMTP.tests mg lg
       versionApi = API.Version.tests mg brigOpts b
+      swaggerApi = API.Swagger.tests mg brigOpts brigNoImplicitVersion
       mlsApi = MLS.tests mg b brigOpts
       oauthAPI = API.OAuth.tests mg db b n brigOpts
 
@@ -184,6 +187,7 @@ runTests iConf brigOpts otherArgs = do
         federationEndpoints,
         internalApi,
         versionApi,
+        swaggerApi,
         mlsApi,
         smtp,
         oauthAPI


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/SQPIT-1654

separate commits for (failing) test cases, for fix, and house keeping.

Before the fix:

```
$ make ci package=brig TASTY_PATTERN=/swagger/
[...]
Brig API Integration
  version
    GET /api/swagger.json:    OK (0.13s)
    GET /api/swagger-ui:      OK (0.03s)
    GET /v2/api/swagger.json: FAIL
      Exception: HttpExceptionRequest Request {
        host                 = "127.0.0.1"
        port                 = 8082
        secure               = False
        requestHeaders       = []
        path                 = "/v2/api/swagger.json"
        queryString          = ""
        method               = "GET"
        proxy                = Nothing
        rawBody              = False
        redirectCount        = 10
        responseTimeout      = ResponseTimeoutDefault
        requestVersion       = HTTP/1.1
      }
       (StatusCodeException (Response {responseStatus = Status {statusCode = 400, statusMessage = "Bad Request"}, responseVersion = HTTP/1.1, responseHeaders = [("Transfer-Encoding","chunked"),("Date","Mon, 27 Mar 2023 12:56:13 GMT"),("Server","Warp/3.3.23"),("Vary","Accept-Encoding")], responseBody = (), responseCookieJar = CJ {expose = []}, responseClose' = ResponseClose}) "Error parsing header X-Wire-API-Version failed: Unknown version: 2")
      Use -p '/swagger/&&/GET \/v2\/api\/swagger.json/' to rerun this test only.
    GET /v2/api/swagger-ui:   FAIL
      Exception: HttpExceptionRequest Request {
        host                 = "127.0.0.1"
        port                 = 8082
        secure               = False
        requestHeaders       = []
        path                 = "/v2/api/swagger-ui"
        queryString          = ""
        method               = "GET"
        proxy                = Nothing
        rawBody              = False
        redirectCount        = 10
        responseTimeout      = ResponseTimeoutDefault
        requestVersion       = HTTP/1.1
      }
       (StatusCodeException (Response {responseStatus = Status {statusCode = 400, statusMessage = "Bad Request"}, responseVersion = HTTP/1.1, responseHeaders = [("Transfer-Encoding","chunked"),("Date","Mon, 27 Mar 2023 12:56:13 GMT"),("Server","Warp/3.3.23"),("Vary","Accept-Encoding")], responseBody = (), responseCookieJar = CJ {expose = []}, responseClose' = ResponseClose}) "Error parsing header X-Wire-API-Version failed: Unknown version: 2")
      Use -p '/swagger/&&/GET \/v2\/api\/swagger-ui/' to rerun this test only.

2 out of 4 tests failed (0.13s)
[...]
```

After the fix:

```
$ make ci package=brig TASTY_PATTERN=/swagger/
[...]
Brig API Integration
  version
    GET /api/swagger.json:    OK (0.18s)
    GET /api/swagger-ui:      OK (0.01s)
    GET /v2/api/swagger.json: OK (0.15s)
    GET /v2/api/swagger-ui:   OK (0.01s)

All 4 tests passed (0.18s)
[...]
```

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
