### PR TITLE
inbucket Helm chart: TLS and basic authentication

### DIFF
--- a/changelog.d/2-features/inbucket-tls-and-basic-auth
+++ b/changelog.d/2-features/inbucket-tls-and-basic-auth
@@ -1,0 +1,1 @@
+Add TLS and basic authentication to the inbucket (fake webmailer) ingress.

--- a/charts/inbucket/templates/basic-auth-secret.yaml
+++ b/charts/inbucket/templates/basic-auth-secret.yaml
@@ -1,0 +1,15 @@
+{{- if (hasKey .Values "basicAuthSecret") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: inbucket-basic-auth
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "inbucket.chart" . }}
+type: Opaque
+data:
+  auth: {{ .Values.basicAuthSecret | b64enc | quote }}
+{{- end }}

--- a/charts/inbucket/templates/cert.yaml
+++ b/charts/inbucket/templates/cert.yaml
@@ -1,0 +1,28 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "letsencrypt-inbucket-csr"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  issuerRef:
+    name: letsencrypt-http01
+    kind: Issuer
+  usages:
+    - server auth
+  duration: 2160h     # 90d, Letsencrypt default; NOTE: changes are ignored by Letsencrypt
+  renewBefore: 360h   # 15d
+  isCA: false
+  secretName: letsencrypt-inbucket-secret
+
+  privateKey:
+    algorithm: ECDSA
+    size: 384         # 521 is not supported by Letsencrypt
+    encoding: PKCS1
+    rotationPolicy: Always
+
+  dnsNames:
+    - {{ .Values.host }}

--- a/charts/inbucket/templates/cert.yaml
+++ b/charts/inbucket/templates/cert.yaml
@@ -7,9 +7,13 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    # The issuer changes when it's configured to use staging or prod ACME
+    # servers.
+    checksum/issuer: {{ include (print .Template.BasePath "/issuer.yaml") . | sha256sum }}
 spec:
   issuerRef:
-    name: letsencrypt-http01
+    name: letsencrypt-inbucket
     kind: Issuer
   usages:
     - server auth

--- a/charts/inbucket/templates/ingress.yaml
+++ b/charts/inbucket/templates/ingress.yaml
@@ -10,7 +10,16 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "inbucket.chart" . }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+# {{- if (hasKey .Values "ipAllowList") }}
+#     nginx.ingress.kubernetes.io/whitelist-source-range: {{- .Values.ipAllowList }}
+# {{- end }}
 spec:
+  tls:
+    - hosts:
+        - {{ required "must specify host" .Values.host | quote }}
+      secretName: letsencrypt-inbucket-secret
   rules:
     - host: {{ required "must specify host" .Values.host | quote }}
       http:

--- a/charts/inbucket/templates/ingress.yaml
+++ b/charts/inbucket/templates/ingress.yaml
@@ -12,9 +12,11 @@ metadata:
     helm.sh/chart: {{ include "inbucket.chart" . }}
   annotations:
     kubernetes.io/ingress.class: nginx
-# {{- if (hasKey .Values "ipAllowList") }}
-#     nginx.ingress.kubernetes.io/whitelist-source-range: {{- .Values.ipAllowList }}
-# {{- end }}
+{{- if (hasKey .Values "basicAuthSecret") }}
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: inbucket-basic-auth
+    nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - inbucket'
+{{- end }}
 spec:
   tls:
     - hosts:

--- a/charts/inbucket/templates/issuer.yaml
+++ b/charts/inbucket/templates/issuer.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-inbucket
+  namespace: {{ .Release.Namespace }}
+spec:
+  acme:
+    # TODO: Replace with prod ACME server
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: {{ required "must specify certManager.certmasterEmail" .Values.certManager.certmasterEmail | quote }}
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-inbucket-key
+    # Enable the HTTP-01 challenge provider
+    solvers:
+    - http01:
+        ingress:
+          class:  nginx

--- a/charts/inbucket/templates/issuer.yaml
+++ b/charts/inbucket/templates/issuer.yaml
@@ -3,10 +3,18 @@ kind: Issuer
 metadata:
   name: letsencrypt-inbucket
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "inbucket.chart" . }}
 spec:
   acme:
-    # TODO: Replace with prod ACME server
+{{- if .Values.useStagingACMEServer }}
     server: https://acme-staging-v02.api.letsencrypt.org/directory
+{{- else }}
+    server: https://acme-v02.api.letsencrypt.org/directory
+{{- end }}
     # Email address used for ACME registration
     email: {{ required "must specify certManager.certmasterEmail" .Values.certManager.certmasterEmail | quote }}
     # Name of a secret used to store the ACME account private key

--- a/charts/inbucket/values.yaml
+++ b/charts/inbucket/values.yaml
@@ -11,3 +11,12 @@ inbucket:
     INBUCKET_WEB_GREETINGFILE: "/config/greeting.html"
     INBUCKET_MAILBOXNAMING: full
     INBUCKET_STORAGE_RETENTIONPERIOD: "72h"
+
+# The production ACME server of let's encrypt has a very strict rate limiting
+# and bans for weeks. Better try with the staging ACME server first.
+useStagingACMEServer: true
+
+# Enables and configures HTTP Basic Auth secret as e.g. created with
+# `htpasswd -bc auth username password`.
+#
+# basicAuthSecret: username:$apr1$3jXFMMZX$z6OOf4eUn1wU.NYJt246u1

--- a/charts/nginx-ingress-services/templates/certificate.yaml
+++ b/charts/nginx-ingress-services/templates/certificate.yaml
@@ -4,10 +4,6 @@ kind: Certificate
 metadata:
   name: "{{ include "nginx-ingress-services.zone" . | replace "." "-" }}-csr"
   namespace: {{ .Release.Namespace }}
-  labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
 spec:
   issuerRef:
     name: {{ .Values.tls.issuer.name }}

--- a/charts/nginx-ingress-services/templates/certificate.yaml
+++ b/charts/nginx-ingress-services/templates/certificate.yaml
@@ -4,6 +4,10 @@ kind: Certificate
 metadata:
   name: "{{ include "nginx-ingress-services.zone" . | replace "." "-" }}-csr"
   namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
   issuerRef:
     name: {{ .Values.tls.issuer.name }}


### PR DESCRIPTION
As discussed with QA and security: This adds TLS (HTTPS) and HTTP basic authentication to the `inbucket` Helm chart. (It was: No authentication, no HTTPS.)

I tried to separate the `cert-manager` stuff of `nginx-ingress-service` from this chart, because this should really just be a help for testing and not interfere with production things.

The branch name is a bit misleading, because we switched the goal from ip allow listing to basic authentication.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
