### PR TITLE
Upload test results to AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ kube-integration-setup: charts-integration
 
 .PHONY: kube-integration-test
 kube-integration-test:
-	export NAMESPACE=$(NAMESPACE); export HELM_PARALLELISM=$(HELM_PARALLELISM); ./hack/bin/integration-test.sh
+	export NAMESPACE=$(NAMESPACE); export HELM_PARALLELISM=$(HELM_PARALLELISM); export OUTPUT_DIR=${OUTPUT_DIR} ./hack/bin/integration-test.sh
 
 .PHONY: kube-integration-teardown
 kube-integration-teardown:

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ kube-integration-setup: charts-integration
 
 .PHONY: kube-integration-test
 kube-integration-test:
-	export NAMESPACE=$(NAMESPACE); export HELM_PARALLELISM=$(HELM_PARALLELISM); export OUTPUT_DIR=${OUTPUT_DIR} ./hack/bin/integration-test.sh
+	export NAMESPACE=$(NAMESPACE); export HELM_PARALLELISM=$(HELM_PARALLELISM); export OUTPUT_DIR=${OUTPUT_DIR}; ./hack/bin/integration-test.sh
 
 .PHONY: kube-integration-teardown
 kube-integration-teardown:

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ kube-integration-setup: charts-integration
 
 .PHONY: kube-integration-test
 kube-integration-test:
-	export NAMESPACE=$(NAMESPACE); export HELM_PARALLELISM=$(HELM_PARALLELISM); ./hack/bin/integration-test.sh
+	export NAMESPACE=$(NAMESPACE); export HELM_PARALLELISM=$(HELM_PARALLELISM); export DOCKER_TAG=${DOCKER_TAG}; ./hack/bin/integration-test.sh
 
 .PHONY: kube-integration-teardown
 kube-integration-teardown:

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,11 @@ kube-integration-setup: charts-integration
 
 .PHONY: kube-integration-test
 kube-integration-test:
-	export NAMESPACE=$(NAMESPACE); export HELM_PARALLELISM=$(HELM_PARALLELISM); export OUTPUT_DIR=${OUTPUT_DIR}; ./hack/bin/integration-test.sh
+	export NAMESPACE=$(NAMESPACE); \
+	export HELM_PARALLELISM=$(HELM_PARALLELISM); \
+	export VERSION=${DOCKER_TAG}; \
+	export UPLOAD_LOGS=${UPLOAD_LOGS}; \
+	./hack/bin/integration-test.sh
 
 .PHONY: kube-integration-teardown
 kube-integration-teardown:

--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,7 @@ kube-integration-test:
 	export NAMESPACE=$(NAMESPACE); \
 	export HELM_PARALLELISM=$(HELM_PARALLELISM); \
 	export VERSION=${DOCKER_TAG}; \
+	export UPLOAD_LOGS=${UPLOAD_LOGS} \
 	./hack/bin/integration-test.sh
 
 .PHONY: kube-integration-teardown

--- a/Makefile
+++ b/Makefile
@@ -348,9 +348,6 @@ kube-integration-test:
 	export NAMESPACE=$(NAMESPACE); \
 	export HELM_PARALLELISM=$(HELM_PARALLELISM); \
 	export VERSION=${DOCKER_TAG}; \
-	export UPLOAD_LOGS=${UPLOAD_LOGS}; \
-	export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}; \
-	export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
 	./hack/bin/integration-test.sh
 
 .PHONY: kube-integration-teardown

--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,8 @@ kube-integration-test:
 	export HELM_PARALLELISM=$(HELM_PARALLELISM); \
 	export VERSION=${DOCKER_TAG}; \
 	export UPLOAD_LOGS=${UPLOAD_LOGS}; \
+	export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}; \
+	export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
 	./hack/bin/integration-test.sh
 
 .PHONY: kube-integration-teardown

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ kube-integration-setup: charts-integration
 
 .PHONY: kube-integration-test
 kube-integration-test:
-	export NAMESPACE=$(NAMESPACE); export HELM_PARALLELISM=$(HELM_PARALLELISM); export DOCKER_TAG=${DOCKER_TAG}; ./hack/bin/integration-test.sh
+	export NAMESPACE=$(NAMESPACE); export HELM_PARALLELISM=$(HELM_PARALLELISM); ./hack/bin/integration-test.sh
 
 .PHONY: kube-integration-teardown
 kube-integration-teardown:

--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,7 @@ kube-integration-test:
 	export NAMESPACE=$(NAMESPACE); \
 	export HELM_PARALLELISM=$(HELM_PARALLELISM); \
 	export VERSION=${DOCKER_TAG}; \
-	export UPLOAD_LOGS=${UPLOAD_LOGS} \
+	export UPLOAD_LOGS=${UPLOAD_LOGS}; \
 	./hack/bin/integration-test.sh
 
 .PHONY: kube-integration-teardown

--- a/changelog.d/5-internal/upload-integration-test-logs-s3
+++ b/changelog.d/5-internal/upload-integration-test-logs-s3
@@ -1,0 +1,1 @@
+Add an option (`UPLOAD_LOGS`) to upload integration test logs to AWS S3.

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -6,6 +6,7 @@ NAMESPACE=${NAMESPACE:-test-integration}
 # set to 1 to disable running helm tests in parallel
 HELM_PARALLELISM=${HELM_PARALLELISM:-1}
 CLEANUP_LOCAL_FILES=${CLEANUP_LOCAL_FILES:-1} # set to 0 to keep files
+UPLOAD_LOGS=${UPLOAD_LOGS:-1}
 
 echo "Running integration tests on wire-server with parallelism=${HELM_PARALLELISM} ..."
 
@@ -23,12 +24,11 @@ cleanup() {
 
 # Copy to the concourse output (indetified by $OUTPUT_DIR) for propagation to
 # following steps.
-copyToOutputDir(){
-    echo "\$OUTPUT_DIR is set to $OUTPUT_DIR"
-    if [ -n "$OUTPUT_DIR" ]; then
+copyToAwsS3(){
+    if (( UPLOAD_LOGS > 0 )); then
         for t in "${tests[@]}"; do
-            echo "Copy logs-$t to $OUTPUT_DIR"
-            cp "logs-$t" "$OUTPUT_DIR"
+            echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION.log"
+            aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION.log"
         done
     fi
 }
@@ -95,7 +95,7 @@ if ((exit_code > 0)); then
     summary
 fi
 
-copyToOutputDir
+copyToAwsS3
 cleanup
 
 if ((exit_code > 0)); then

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -6,7 +6,7 @@ NAMESPACE=${NAMESPACE:-test-integration}
 # set to 1 to disable running helm tests in parallel
 HELM_PARALLELISM=${HELM_PARALLELISM:-1}
 CLEANUP_LOCAL_FILES=${CLEANUP_LOCAL_FILES:-1} # set to 0 to keep files
-OUTPUT_DIR=./test-logs
+OUTPUT_DIR=${OUTPUT_DIR:-test-logs}
 
 echo "Running integration tests on wire-server with parallelism=${HELM_PARALLELISM} ..."
 
@@ -84,6 +84,9 @@ if ((exit_code > 0)); then
 fi
 
 cleanup
+
+echo "Debug output dir"
+ls -l "$OUTPUT_DIR"
 
 if ((exit_code > 0)); then
     echo "Tests failed."

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -21,6 +21,12 @@ cleanup() {
     fi
 }
 
+awsUploadLogs() {
+    for t in "${tests[@]}"; do
+        aws cp "logs-$t" "s3://wire-server-test-logs/$t.log"
+    done
+}
+
 summary() {
     echo "==============="
     echo "=== summary ==="
@@ -83,6 +89,7 @@ if ((exit_code > 0)); then
     summary
 fi
 
+awsUploadLogs
 cleanup
 
 if ((exit_code > 0)); then

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -6,7 +6,6 @@ NAMESPACE=${NAMESPACE:-test-integration}
 # set to 1 to disable running helm tests in parallel
 HELM_PARALLELISM=${HELM_PARALLELISM:-1}
 CLEANUP_LOCAL_FILES=${CLEANUP_LOCAL_FILES:-1} # set to 0 to keep files
-DOCKER_TAG=${DOCKER_TAG:-no-tag}
 
 echo "Running integration tests on wire-server with parallelism=${HELM_PARALLELISM} ..."
 
@@ -20,12 +19,6 @@ cleanup() {
             rm -f "logs-$t"
         done
     fi
-}
-
-awsUploadLogs() {
-    for t in "${tests[@]}"; do
-        aws cp "logs-$t" "s3://wire-server-test-logs/$t-$DOCKER_TAG.log"
-    done
 }
 
 summary() {
@@ -43,9 +36,6 @@ summary() {
         fi
     done
 }
-
-# TODO: Remove me! This line is only here for checking AWS access in this script.
-aws s3 ls s3://wire-server-test-logs/
 
 # Run tests in parallel using GNU parallel (see https://www.gnu.org/software/parallel/)
 # The below commands are a little convoluted, but we wish to:
@@ -93,7 +83,6 @@ if ((exit_code > 0)); then
     summary
 fi
 
-awsUploadLogs
 cleanup
 
 if ((exit_code > 0)); then

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -44,6 +44,9 @@ summary() {
     done
 }
 
+# TODO: Remove me! This line is only here for checking AWS access in this script.
+aws s3 ls s3://wire-server-test-logs/
+
 # Run tests in parallel using GNU parallel (see https://www.gnu.org/software/parallel/)
 # The below commands are a little convoluted, but we wish to:
 # - run integration tests. If they fail, keep track of this, but still go and get logs, so we see what failed

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -45,7 +45,7 @@ mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 printf '%s\n' "${tests[@]}" | parallel echo "Running helm tests for {}..."
 printf '%s\n' "${tests[@]}" | parallel -P "${HELM_PARALLELISM}" \
     helm test -n "${NAMESPACE}" "${NAMESPACE}-${CHART}" --timeout 900s --filter name="${NAMESPACE}-${CHART}-{}-integration" "> $OUTPUT_DIR/logs-{};" \
-    echo '$? > stat-{};' \
+    echo "$? >  $OUTPUT_DIR/stat-{};" \
     echo "==== Done testing {}. ====" '};' \
     kubectl -n "${NAMESPACE}" logs "${NAMESPACE}-${CHART}-{}-integration" ">> $OUTPUT_DIR/logs-{};"
 

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -6,7 +6,7 @@ NAMESPACE=${NAMESPACE:-test-integration}
 # set to 1 to disable running helm tests in parallel
 HELM_PARALLELISM=${HELM_PARALLELISM:-1}
 CLEANUP_LOCAL_FILES=${CLEANUP_LOCAL_FILES:-1} # set to 0 to keep files
-UPLOAD_LOGS=${UPLOAD_LOGS:-1}
+UPLOAD_LOGS=${UPLOAD_LOGS:-0}
 
 echo "Running integration tests on wire-server with parallelism=${HELM_PARALLELISM} ..."
 

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -6,6 +6,7 @@ NAMESPACE=${NAMESPACE:-test-integration}
 # set to 1 to disable running helm tests in parallel
 HELM_PARALLELISM=${HELM_PARALLELISM:-1}
 CLEANUP_LOCAL_FILES=${CLEANUP_LOCAL_FILES:-1} # set to 0 to keep files
+DOCKER_TAG=${DOCKER_TAG:"no-tag"}
 
 echo "Running integration tests on wire-server with parallelism=${HELM_PARALLELISM} ..."
 
@@ -23,7 +24,7 @@ cleanup() {
 
 awsUploadLogs() {
     for t in "${tests[@]}"; do
-        aws cp "logs-$t" "s3://wire-server-test-logs/$t.log"
+        aws cp "logs-$t" "s3://wire-server-test-logs/$t-$DOCKER_TAG.log"
     done
 }
 

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -13,7 +13,8 @@ echo "Running integration tests on wire-server with parallelism=${HELM_PARALLELI
 CHART=wire-server
 tests=(galley cargohold gundeck federator spar brig)
 
-mkdir -p $OUTPUT_DIR
+echo "Create $OUTPUT_DIR (if it doesn't exist)"
+mkdir -p "$OUTPUT_DIR"
 
 cleanup() {
     if (( CLEANUP_LOCAL_FILES > 0 )); then

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -6,7 +6,7 @@ NAMESPACE=${NAMESPACE:-test-integration}
 # set to 1 to disable running helm tests in parallel
 HELM_PARALLELISM=${HELM_PARALLELISM:-1}
 CLEANUP_LOCAL_FILES=${CLEANUP_LOCAL_FILES:-1} # set to 0 to keep files
-DOCKER_TAG=${DOCKER_TAG:"no-tag"}
+DOCKER_TAG=${DOCKER_TAG:no-tag}
 
 echo "Running integration tests on wire-server with parallelism=${HELM_PARALLELISM} ..."
 

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -6,7 +6,7 @@ NAMESPACE=${NAMESPACE:-test-integration}
 # set to 1 to disable running helm tests in parallel
 HELM_PARALLELISM=${HELM_PARALLELISM:-1}
 CLEANUP_LOCAL_FILES=${CLEANUP_LOCAL_FILES:-1} # set to 0 to keep files
-DOCKER_TAG=${DOCKER_TAG:no-tag}
+DOCKER_TAG=${DOCKER_TAG:-no-tag}
 
 echo "Running integration tests on wire-server with parallelism=${HELM_PARALLELISM} ..."
 

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -312,6 +312,7 @@ let
     pkgs.treefmt
     pkgs.gawk
     pkgs.cfssl
+    pkgs.awscli2
     (hlib.justStaticExecutables pkgs.haskellPackages.cabal-fmt)
   ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
     pkgs.skopeo


### PR DESCRIPTION
Add a flag `UPLOAD_LOGS` to enable/disable uploading integration test run logs to AWS S3.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
