### PR TITLE
flaky_tests.py add --discover option

### DIFF
--- a/flaky-tests.yaml
+++ b/flaky-tests.yaml
@@ -18,14 +18,11 @@
                 assertion. Let's see if this helps.
 
 -
-  test_name: "GET /mls/key-packages/claim/local/:user - self claim"
+  test_name: "Brig API Integration.MLS.GET /mls/key-packages/claim/local/:user"
   comments: |
-    2023-03-24:
+      Same error as for teset "GET /mls/key-packages/claim/local/:user - self claim"
 
-      Alls three runs: on 2023-03-21- 2023-03-22 failed with
       Error executing request: /bin/sh: createProcess: posix_spawnp: failed (Bad address)
-      It's present on the mls and 4.34.0-hotfix branch, so I'm assuming it's also present on develop.
-
 -
    test_name: "max active tokens"
    comments: |

--- a/flaky-tests.yaml
+++ b/flaky-tests.yaml
@@ -16,3 +16,32 @@
                 might take longer for the event to happen than in other cases.
                 I've increased the timeout from 4 to 7 seconds for that one
                 assertion. Let's see if this helps.
+
+-
+  test_name: "GET /mls/key-packages/claim/local/:user - self claim"
+  comments: |
+    2023-03-24:
+
+      Alls three runs: on 2023-03-21- 2023-03-22 failed with
+      Error executing request: /bin/sh: createProcess: posix_spawnp: failed (Bad address)
+      It's present on the mls and 4.34.0-hotfix branch, so I'm assuming it's also present on develop.
+
+-
+   test_name: "max active tokens"
+   comments: |
+      CallStack (from HasCallStack):
+        assertFailure, called at ./Test/Tasty/HUnit/Orig.hs:71:30 in tasty-hunit-0.10.0.3-BA9Dg64ujOjHrKq3kYOvGI:Test.Tasty.HUnit.Orig
+        assertBool, called at test/integration/API/OAuth.hs:473:16 in main:API.OAuth
+      Use -p '(!/turn/&&!/user.auth.cookies.limit/)&&/max active tokens/' to rerun this test only.
+
+-
+  test_name: "send billing events to some owners in large teams (indexedBillingTeamMembers disabled)"
+  comments: |
+    Error message: create team: Expected 1 TeamActivate, got nothing
+
+    CallStack (from HasCallStack):
+      assertFailure, called at test/integration/API/SQS.hs:74:32 in main:API.SQS
+      tActivate, called at test/integration/API/SQS.hs:78:47 in main:API.SQS
+      assertTeamActivate, called at test/integration/API/Util.hs:191:3 in main:API.Util
+      createBindingTeam', called at test/integration/API/Util.hs:183:20 in main:API.Util
+      createBindingTeam, called at test/integration/API/Teams.hs:1546:25 in main:API.Teams


### PR DESCRIPTION
This PR adds `--discover` to `flaky_tests.py` that can help you manually discover flaky tests.
This PR also adds two more flaky tests discovered through it.
