### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,1 +1,1 @@
-Upgrade webapp version to 2023-03-07-production.0-v0.31.12-0-1449738
+Upgrade webapp version to 2023-03-27-production.0-v0.31.12-0-663b521

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2023-03-07-production.0-v0.31.12-0-1449738"
+  tag: "2023-03-27-production.0-v0.31.12-0-663b521"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2023-03-27-production.0-v0.31.12-0-663b521`
Release: [`2023-03-27-production.0`](https://github.com/wireapp/wire-webapp/releases/tag/2023-03-27-production.0)