### PR TITLE
fix: do not decrease login retry limit for 2fa code

### DIFF
--- a/changelog.d/3-bug-fixes/pr-3198
+++ b/changelog.d/3-bug-fixes/pr-3198
@@ -1,0 +1,1 @@
+Decrease only 2FA limit after failed attempt, and not failed login attempt

--- a/services/brig/src/Brig/User/Auth.hs
+++ b/services/brig/src/Brig/User/Auth.hs
@@ -156,9 +156,9 @@ login (PasswordLogin (PasswordLoginData li pw label code)) typ = do
     verifyLoginCode mbCode uid =
       verifyCode mbCode Login uid
         `catchE` \case
-          VerificationCodeNoPendingCode -> wrapHttpClientE $ loginFailedWith LoginCodeInvalid uid
-          VerificationCodeRequired -> wrapHttpClientE $ loginFailedWith LoginCodeRequired uid
-          VerificationCodeNoEmail -> wrapHttpClientE $ loginFailed uid
+          VerificationCodeNoPendingCode -> wrapHttpClientE $ throwE LoginCodeInvalid
+          VerificationCodeRequired -> wrapHttpClientE $ throwE LoginCodeRequired
+          VerificationCodeNoEmail -> wrapHttpClientE $ throwE LoginFailed
 login (SmsLogin (SmsLoginData phone code label)) typ = do
   uid <- wrapHttpClientE $ resolveLoginId (LoginByPhone phone)
   lift . Log.debug $ field "user" (toByteString uid) . field "action" (Log.val "User.login")


### PR DESCRIPTION
On a failed 2FA attempt, the retry limits for login decreased by the call to `loginFailedWith`. This has not effect if `setLimitFailedLogins` is not set or less strict. However, 2FA code verification has its own retry limits config and mechanism and the two should not be mixed.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
