### PR TITLE
Bump nixpkgs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-with-compiler: ghc-9.2.4
+with-compiler: ghc-9.2.7
 
 packages:
     libs/api-bot/

--- a/changelog.d/5-internal/nixpkgs-bump
+++ b/changelog.d/5-internal/nixpkgs-bump
@@ -1,0 +1,1 @@
+nixpkgs has been bumped to a more recent checkout (8c619a1f3cedd16ea172146e30645e703d21bfc1 -> 402cc3633cc60dfc50378197305c984518b30773, 2023-02-12 -> 2023-03-28).

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,8 +10,6 @@ let
     ];
   };
 
-  pkgsCachix = import sources.nixpkgs-cachix {};
-
   profileEnv = pkgs.writeTextFile {
     name = "profile-env";
     destination = "/.profile";
@@ -22,7 +20,7 @@ let
     '';
   };
 
-  wireServer = import ./wire-server.nix pkgs pkgsCachix;
+  wireServer = import ./wire-server.nix pkgs;
   nginz = pkgs.callPackage ./nginz.nix { };
   nginz-disco = pkgs.callPackage ./nginz-disco.nix { };
 

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -2,7 +2,7 @@
 # FUTUREWORK: Figure out a way to detect if some of these packages are not
 # actually marked broken, so we can cleanup this file on every nixpkgs bump.
 hself: hsuper: {
-  aeson = hsuper.aeson_2_1_2_1;
+  aeson = (hlib.doJailbreak hsuper.aeson_2_1_2_1);
   binary-parsers = hlib.markUnbroken (hlib.doJailbreak hsuper.binary-parsers);
   bytestring-arbitrary = hlib.markUnbroken (hlib.doJailbreak hsuper.bytestring-arbitrary);
   cql = hlib.markUnbroken hsuper.cql;

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -2,7 +2,7 @@
 # FUTUREWORK: Figure out a way to detect if some of these packages are not
 # actually marked broken, so we can cleanup this file on every nixpkgs bump.
 hself: hsuper: {
-  aeson = hsuper.aeson_2_1_1_0;
+  aeson = hsuper.aeson_2_1_2_1;
   binary-parsers = hlib.markUnbroken (hlib.doJailbreak hsuper.binary-parsers);
   bytestring-arbitrary = hlib.markUnbroken (hlib.doJailbreak hsuper.bytestring-arbitrary);
   cql = hlib.markUnbroken hsuper.cql;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c619a1f3cedd16ea172146e30645e703d21bfc1",
-        "sha256": "1zgm94b79yfqfdcqcj8bxfjzcl7gp9pd7jph9jnlxx8m36cgsn3a",
+        "rev": "402cc3633cc60dfc50378197305c984518b30773",
+        "sha256": "0yvlprdkqg1kizg83j7nivlc58zk7llrbf82jqvgjimrwhsva1m9",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/8c619a1f3cedd16ea172146e30645e703d21bfc1.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/402cc3633cc60dfc50378197305c984518b30773.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-cachix": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -10,17 +10,5 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/402cc3633cc60dfc50378197305c984518b30773.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nixpkgs-cachix": {
-        "branch": "nixpkgs-unstable",
-        "description": "Nix Packages collection",
-        "homepage": "https://github.com/NixOS/nixpkgs",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b38db2c901b30a37d345751f4f6418d416e7e46e",
-        "sha256": "0g8qks6pqxagqiwaxz1n4fd82bvadli8gamas3j9c0al4bw9vv7r",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b38db2c901b30a37d345751f4f6418d416e7e46e.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -42,7 +42,7 @@
 # Using thse tweaks we can get a haskell package set which has wire-server
 # components and the required dependencies. We then use this package set along
 # with nixpkgs' dockerTools to make derivations for docker images that we need.
-pkgs: pkgsCachix:
+pkgs:
 let
   lib = pkgs.lib;
   hlib = pkgs.haskell.lib;
@@ -331,8 +331,7 @@ let
     # deterministically on a specific image.
     tag = null;
     bundleNixpkgs = false;
-    # FUTUREWORK: Use pkgs.cachix here when we update `nixpkgs` to latest nixpkgs-unstable
-    extraPkgs = commonTools ++ [ pkgsCachix.cachix ];
+    extraPkgs = commonTools ++ [ pkgs.cachix ];
     nixConf = {
       experimental-features = "nix-command";
     };

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -27,7 +27,7 @@
 # 3.2: Version overrides: These are very similar to nix/haskell-pins.nix, but
 # the package set itself sometimes contains newer versions of a few packages
 # along with the old versions, e.g., the package set contains aeson and
-# aeson_2_1_1_0. We use the latest version provided by the pacakge set, so we
+# aeson_2_1_1_0. We use the latest version provided by the package set, so we
 # don't have to remember to update the version here, nixpkgs will take care of
 # giving us the latest version.
 #


### PR DESCRIPTION
This bumps nixpkgs to a more recent checkout (8c619a1f3cedd16ea172146e30645e703d21bfc1 -> 402cc3633cc60dfc50378197305c984518b30773, 2023-02-12 -> 2023-03-28).


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
