### PR TITLE
Expose internal verification-code endpoint in QA envs

### DIFF
--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -301,6 +301,12 @@ nginx_conf:
       disable_zauth: true
       basic_auth: true
       versioned: false
+    - path: /i/users/([^/]*)/verification-code/([^/])*
+      envs:
+      - staging
+      disable_zauth: true
+      basic_auth: true
+      versioned: false
     - path: /i/teams/([^/]*)/suspend
       envs:
       - staging


### PR DESCRIPTION
For reference this is how it is called from within the integration tests:

https://github.com/wireapp/wire-server/blob/e3f8b9c0d2a85ad275d97152858469b3e2e0fefc/services/galley/test/integration/API/Teams.hs?plain=1#L1146