### PR TITLE
Coturn helm chart: Increase liveness timeout

### DIFF
--- a/changelog.d/3-bug-fixes/coturn-liveness
+++ b/changelog.d/3-bug-fixes/coturn-liveness
@@ -1,0 +1,1 @@
+Coturn helm chart: Increase the default timeout of liveness/readiness probe and make it configurable

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -143,11 +143,15 @@ spec:
               protocol: TCP
 
           livenessProbe:
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             httpGet:
               path: /
               port: status-http
 
           readinessProbe:
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             httpGet:
               path: /
               port: status-http

--- a/charts/coturn/values.yaml
+++ b/charts/coturn/values.yaml
@@ -53,3 +53,11 @@ coturnGracefulTermination: false
 # terminated. This setting is only effective when coturnGracefulTermination is
 # set to true.
 coturnGracePeriodSeconds: 86400 # one day
+
+livenessProbe:
+  timeoutSeconds: 5
+  failureThreshold: 5
+
+readinessProbe:
+  timeoutSeconds: 5
+  failureThreshold: 5


### PR DESCRIPTION
Increase default of liveness/readiness probe and make it configurable.

Under high load, the default of failureThreshold=3 timeoutSeconds=1 can lead to restarts of the coturn pod due to the http port being temporarily starved of CPU, leading to an unnecessary restart of the coturn pods. This change should make this less frequent and improve call stability.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
