### PR TITLE
coturn helm chart: use a memory-backed mount

### DIFF
--- a/changelog.d/3-bug-fixes/coturn-interal-db
+++ b/changelog.d/3-bug-fixes/coturn-interal-db
@@ -1,0 +1,1 @@
+coturn helm chart: use a memory-backed folder to store sqllite DB to improve performance

--- a/charts/coturn/templates/statefulset.yaml
+++ b/charts/coturn/templates/statefulset.yaml
@@ -49,6 +49,10 @@ spec:
         - name: secrets
           secret:
             secretName: coturn
+        - name: coturndb
+          emptyDir:
+            medium: Memory
+            sizeLimit: 128Mi # observed size: 80 kilobytes
         {{- if .Values.tls.enabled }}
         - name: secrets-tls
           secret:
@@ -102,6 +106,11 @@ spec:
             - name: secrets
               mountPath: /secrets/
               readOnly: true
+            # > By default, Coturn Docker image persists its data in /var/lib/coturn/ directory.
+            # > You can speedup Coturn simply by using tmpfs for that.
+            # We use a memory-backed emptyDir here instead.
+            - name: coturndb
+              mountPath: /var/lib/coturn
           {{- if .Values.tls.enabled }}
             - name: secrets-tls
               mountPath: /secrets-tls/


### PR DESCRIPTION
Add memory-backed mount /var/lib/coturn to store sqllite DB to improve performance, as described on https://github.com/wireapp/coturn/tree/master/docker/coturn#persistence

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
