### PR TITLE
[FS-51] Fix Swagger for failed_to_send in Proteus

### DIFF
--- a/changelog.d/4-docs/fs-51-proteus-failed-to-send
+++ b/changelog.d/4-docs/fs-51-proteus-failed-to-send
@@ -1,0 +1,1 @@
+Fix the Swagger documentation for the failed_to_send field in the response of the Proteus message sending endpoint

--- a/libs/wire-api/src/Wire/API/Message.hs
+++ b/libs/wire-api/src/Wire/API/Message.hs
@@ -526,7 +526,6 @@ instance ToSchema MessageSendingStatus where
     object "MessageSendingStatus" $
       MessageSendingStatus
         <$> mssTime
-          -- TODO(md): fix this one as well as the description doesn't show up
           .= fieldWithDocModifier
             "time"
             (description ?~ "Time of sending message.")

--- a/libs/wire-api/src/Wire/API/Message.hs
+++ b/libs/wire-api/src/Wire/API/Message.hs
@@ -523,47 +523,42 @@ data MessageSendingStatus = MessageSendingStatus
 
 instance ToSchema MessageSendingStatus where
   schema =
-    object "MessageSendingStatus" $
-      MessageSendingStatus
-        <$> mssTime
-          .= fieldWithDocModifier
-            "time"
-            (description ?~ "Time of sending message.")
-            schema
-        <*> mssMissingClients
-          .= qualifiedUserClientsFieldWithDesc
-            "missing"
-            "Clients that the message /should/ have been encrypted for, but wasn't."
-        <*> mssRedundantClients
-          .= qualifiedUserClientsFieldWithDesc
-            "redundant"
-            "Clients that the message /should not/ have been encrypted for, but was."
-        <*> mssDeletedClients
-          .= qualifiedUserClientsFieldWithDesc
-            "deleted"
-            "Clients that were deleted."
-        <*> mssFailedToSend
-          .= qualifiedUserClientsFieldWithDesc
-            "failed_to_send"
-            "When message sending fails for some clients but succeeds for others, \
-            \e.g., because a remote backend is unreachable, \
-            \this field will contain the list of clients for which the message sending \
-            \failed. This list should be empty when message sending is not even tried, \
-            \like when some clients are missing."
+    objectWithDocModifier
+      "MessageSendingStatus"
+      (description ?~ combinedDesc)
+      $ MessageSendingStatus
+        <$> mssTime .= field "time" schema
+        <*> mssMissingClients .= field "missing" schema
+        <*> mssRedundantClients .= field "redundant" schema
+        <*> mssDeletedClients .= field "deleted" schema
+        <*> mssFailedToSend .= field "failed_to_send" schema
     where
-      -- This is to ensure that the Swagger model has a unique name, thereby
-      -- allowing for a description specific to that field instead of having it
-      -- overwritten by other models of the same type.
-      qualifiedUserClientsFieldWithDesc name desc =
-        field
-          name
-          ( named
-              ( "QualifiedUserClients ("
-                  <> name
-                  <> ")"
-              )
-              $ (S.schema . description ?~ desc) qualifiedUserClientsValueSchema
-          )
+      combinedDesc =
+        "The Proteus message sending status. It has these fields:\n\
+        \- `time`: "
+          <> timeDesc
+          <> "\n\
+             \- `missing`: "
+          <> missingDesc
+          <> "\n\
+             \- `redundant`: "
+          <> redundantDesc
+          <> "\n\
+             \- `deleted`: "
+          <> deletedDesc
+          <> "\n\
+             \- `failed_to_send`: "
+          <> failedToSendDesc
+      timeDesc = "Time of sending message."
+      missingDesc = "Clients that the message /should/ have been encrypted for, but wasn't."
+      redundantDesc = "Clients that the message /should not/ have been encrypted for, but was."
+      deletedDesc = "Clients that were deleted."
+      failedToSendDesc =
+        "When message sending fails for some clients but succeeds for others, \
+        \e.g., because a remote backend is unreachable, \
+        \this field will contain the list of clients for which the message sending \
+        \failed. This list should be empty when message sending is not even tried, \
+        \like when some clients are missing."
 
 -- QueryParams
 

--- a/libs/wire-api/src/Wire/API/User/Client.hs
+++ b/libs/wire-api/src/Wire/API/User/Client.hs
@@ -39,6 +39,7 @@ module Wire.API.User.Client
     UserClients (..),
     mkUserClients,
     QualifiedUserClients (..),
+    qualifiedUserClientsValueSchema,
     filterClients,
     filterClientsFull,
 
@@ -401,9 +402,13 @@ instance Monoid QualifiedUserClients where
 instance Arbitrary QualifiedUserClients where
   arbitrary = QualifiedUserClients <$> mapOf' arbitrary (mapOf' arbitrary (setOf' arbitrary))
 
+qualifiedUserClientsValueSchema :: ValueSchema SwaggerDoc QualifiedUserClients
+qualifiedUserClientsValueSchema =
+  QualifiedUserClients <$> qualifiedUserClients .= map_ (map_ (set schema))
+
 instance ToSchema QualifiedUserClients where
   schema =
-    addDoc . named "QualifiedUserClients" $ QualifiedUserClients <$> qualifiedUserClients .= map_ (map_ (set schema))
+    addDoc . named "QualifiedUserClients" $ qualifiedUserClientsValueSchema
     where
       addDoc sch =
         sch


### PR DESCRIPTION
The response to the `POST /conversations/:domain/:cnv/proteus/messages` endpoint contains the `failed_to_send` field, but the rendered Swagger documentation for the filed was overwritten by another field's documentation. This PR fixes the documentation for that and other response fields listing clients.

Tracked by https://wearezeta.atlassian.net/browse/FS-51.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
