### PR TITLE
Patch image digest of ingress-nginx

### DIFF
--- a/changelog.d/5-internal/patch-ingress-nginx-image-digests
+++ b/changelog.d/5-internal/patch-ingress-nginx-image-digests
@@ -1,0 +1,3 @@
+Image digests are not supported by our wire-server-deploy machinery. They cannot
+be correctly dumped to tar files and then be loaded by containerd. Thus, we're
+removing (by overriding) them from `ingress-nginx` default values.

--- a/charts/ingress-nginx-controller/values.yaml
+++ b/charts/ingress-nginx-controller/values.yaml
@@ -32,6 +32,17 @@ ingress-nginx:
         # ports.
         https: 31773
         http: 31772
+    # Image digests are not supported by our `wire-server-deploy` machinery. They
+    # cannot be correctly dumped to tar files an then be loaded by `containerd`.
+    image:
+      tag: "v1.6.4"
+      digest: ""
+      digestChroot: ""
+    admissionWebhooks:
+      patch:
+        image:
+          tag: "v20220916-gd32f8c343"
+          digest: ""
     config:
       # NOTE: These are some sane defaults (compliant to TR-02102-2), you may
       # want to overrride them on your own installation For TR-02102-2 see

--- a/charts/sftd/Chart.yaml
+++ b/charts/sftd/Chart.yaml
@@ -11,4 +11,4 @@ version: 0.0.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.1.3
+appVersion: 3.1.13


### PR DESCRIPTION
Image digests are not supported by our `wire-server-deploy` machinery. They cannot be correctly dumped to tar files and then be loaded by `containerd`.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
