### PR TITLE
[FS-1844] Deploy RabbitMQ for development (docker-compose)

### DIFF
--- a/deploy/dockerephemeral/docker-compose.yaml
+++ b/deploy/dockerephemeral/docker-compose.yaml
@@ -198,6 +198,18 @@ services:
     networks:
       - demo_wire
 
+  rabbitmq:
+    container_name: rabbitmq
+    image: rabbitmq:3-management-alpine
+    environment:
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest
+    ports:
+      - '5672:5672'
+      - '15672:15672'
+    networks:
+      - demo_wire
+
   # FIXME: replace aws_cli with an image that we build.
   aws_cli:
     image: mesosphere/aws-cli:1.14.5

--- a/docs/src/developer/developer/how-to.md
+++ b/docs/src/developer/developer/how-to.md
@@ -154,9 +154,9 @@ To update the release with brig's local image run
 ```
 
 
-## 3 Run multi-backend tests
+### 3 Run multi-backend tests
 
-### Run all integration tests on kubernetes
+#### Run all integration tests on kubernetes
 
 * takes ~10 minutes to run
 * test output is delayed until all tests have run. You will have to scroll the output to find the relevant multi-backend test output.
@@ -167,7 +167,7 @@ To update the release with brig's local image run
 make kube-integration-test
 ```
 
-### Run only the multi-backend tests
+#### Run only the multi-backend tests
 
 * runs faster (~ half a minute)
 * test output is shown dynamically as tests run
@@ -187,7 +187,7 @@ Note that this runs your *locally* compiled `brig-integration`, so this allows t
 2. recompile: `make -C services/brig fast`
 3. run `./services/brig/federation-tests.sh test-$USER` again.
 
-### Run selected integration tests on kuberentes
+#### Run selected integration tests on kuberentes
 
 To run selective tests from brig-integration:
 
@@ -199,7 +199,7 @@ helm -n $NAMESPACE get hooks $NAMESPACE-wire-server | yq '.' | jq -r 'select(.me
 kubectl apply -n $NAMESPACE -f /tmp/integration-pod
 ```
 
-## 4 Teardown
+### 4 Teardown
 
 To destroy all the resources on the kubernetes cluster that have been created run
 
@@ -208,3 +208,9 @@ To destroy all the resources on the kubernetes cluster that have been created ru
 ```
 
 Note: Simply deleting the namespaces is insufficient, because it leaves some resources (of kind ClusterRole, ClusterRoleBinding) that cause problems when redeploying to the same namespace via helm.
+
+## Manage RabbitMQ
+
+We support two different ways of managing the docker-compose instance of rabbitmq: 
+* A web console interface is available [here](http://localhost:15672) 
+* `rabbitmqadmin` CLI is made avaiable in the dev environment

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -100,4 +100,6 @@ self: super: {
 
     inherit (super) stdenv fetchurl;
   };
+
+  rabbitmqadmin = super.callPackage ./pkgs/rabbitmqadmin {};
 }

--- a/nix/pkgs/rabbitmqadmin/default.nix
+++ b/nix/pkgs/rabbitmqadmin/default.nix
@@ -1,0 +1,19 @@
+{stdenv, python3, fetchgit}:
+stdenv.mkDerivation rec {
+  name = "rabbitmqadmin";
+  version = "3.11.13";
+
+  src = fetchgit {
+    url = "https://github.com/rabbitmq/rabbitmq-server";
+    rev = "v${version}";
+    sha256 = "sha256-lbOuxJz66xlGlgodbz8Xlb3hcaewVFMqf9R/5XlqaAY=";
+  };
+
+  propagatedBuildInputs = [python3];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm755 "$src/deps/rabbitmq_management/bin/rabbitmqadmin" "$out/bin/rabbitmqadmin"
+  '';
+}

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -391,6 +391,7 @@ in
       pkgs.wget
       pkgs.yq
       pkgs.nginz
+      pkgs.rabbitmqadmin
 
       pkgs.cabal-install
       pkgs.haskellPackages.cabal-plan


### PR DESCRIPTION
This adds rabbitmq as part of the docker-compose environment as well as making `rabbitmqadmin` (a Python3 script from rabbitmq themselves) that allows us to interact with the running process via CLI.

A web interface is also available under `http://localhost:5672`.