### PR TITLE
discover kubernetes clusters versions containing non-digit characters…

### DIFF
--- a/hack/bin/integration-setup-federation.sh
+++ b/hack/bin/integration-setup-federation.sh
@@ -29,6 +29,7 @@ echo "Generating self-signed certificates..."
 
 KUBERNETES_VERSION_MAJOR="$(kubectl version -o json | jq -r .serverVersion.major)"
 KUBERNETES_VERSION_MINOR="$(kubectl version -o json | jq -r .serverVersion.minor)"
+KUBERNETES_VERSION_MINOR="${KUBERNETES_VERSION_MINOR//[!0-9]/}" # some clusters report minor versions as a string like '27+'. Strip any non-digit characters.
 export KUBERNETES_VERSION="$KUBERNETES_VERSION_MAJOR.$KUBERNETES_VERSION_MINOR"
 if (( KUBERNETES_VERSION_MAJOR > 1 || KUBERNETES_VERSION_MAJOR == 1 && KUBERNETES_VERSION_MINOR >= 23 )); then
     export INGRESS_CHART="ingress-nginx-controller"

--- a/hack/bin/integration-setup.sh
+++ b/hack/bin/integration-setup.sh
@@ -20,6 +20,7 @@ printf '%s\n' "${charts[@]}" | parallel -P "${HELM_PARALLELISM}" "$DIR/update.sh
 
 KUBERNETES_VERSION_MAJOR="$(kubectl version -o json | jq -r .serverVersion.major)"
 KUBERNETES_VERSION_MINOR="$(kubectl version -o json | jq -r .serverVersion.minor)"
+KUBERNETES_VERSION_MINOR="${KUBERNETES_VERSION_MINOR//[!0-9]/}" # some clusters report minor versions as a string like '27+'. Strip any non-digit characters.
 export KUBERNETES_VERSION="$KUBERNETES_VERSION_MAJOR.$KUBERNETES_VERSION_MINOR"
 if (( KUBERNETES_VERSION_MAJOR > 1 || KUBERNETES_VERSION_MAJOR == 1 && KUBERNETES_VERSION_MINOR >= 23 )); then
     export INGRESS_CHART="ingress-nginx-controller"

--- a/hack/bin/integration-teardown-federation.sh
+++ b/hack/bin/integration-teardown-federation.sh
@@ -12,7 +12,9 @@ export NAMESPACE_2="$NAMESPACE-fed2"
 export FEDERATION_DOMAIN_1="."
 export FEDERATION_DOMAIN_2="."
 
+KUBERNETES_VERSION_MAJOR="$(kubectl version -o json | jq -r .serverVersion.major)"
 KUBERNETES_VERSION_MINOR="$(kubectl version -o json | jq -r .serverVersion.minor)"
+KUBERNETES_VERSION_MINOR="${KUBERNETES_VERSION_MINOR//[!0-9]/}" # some clusters report minor versions as a string like '27+'. Strip any non-digit characters.
 if (( KUBERNETES_VERSION_MAJOR > 1 || KUBERNETES_VERSION_MAJOR == 1 && KUBERNETES_VERSION_MINOR >= 23 )); then
     export INGRESS_CHART="ingress-nginx-controller"
 else

--- a/hack/bin/integration-teardown.sh
+++ b/hack/bin/integration-teardown.sh
@@ -6,7 +6,9 @@ TOP_LEVEL="$DIR/../.."
 NAMESPACE=${NAMESPACE:-test-integration}
 # doesn't matter for destruction but needs to be set
 export FEDERATION_DOMAIN="."
+KUBERNETES_VERSION_MAJOR="$(kubectl version -o json | jq -r .serverVersion.major)"
 KUBERNETES_VERSION_MINOR="$(kubectl version -o json | jq -r .serverVersion.minor)"
+KUBERNETES_VERSION_MINOR="${KUBERNETES_VERSION_MINOR//[!0-9]/}" # some clusters report minor versions as a string like '27+'. Strip any non-digit characters.
 if (( KUBERNETES_VERSION_MAJOR > 1 || KUBERNETES_VERSION_MAJOR == 1 && KUBERNETES_VERSION_MINOR >= 23 )); then
     export INGRESS_CHART="ingress-nginx-controller"
 else


### PR DESCRIPTION
… correctly.

For example with this:


`kubectl version -o json`

```json
{
  "clientVersion": {
    "major": "1",
    "minor": "26",
  },
  "serverVersion": {
    "major": "1",
    "minor": "27+",
    "gitVersion": "v1.27.0-rc.1",
    "gitCommit": "80bc6ffd0df789bfcb9b2eda3bcdc597e012e0d0",
    "gitTreeState": "clean",
    "buildDate": "2023-04-06T19:52:27Z",
    "goVersion": "go1.20.3",
    "compiler": "gc",
    "platform": "linux/amd64"
  }
}
```

The bash script was evaluating `(( 27+ >= 23 ))` as false. Duh. Should be fixed now.