### PR TITLE
integration tests fixup: use nodeport

### DIFF
--- a/hack/helm_vars/ingress-nginx-controller/values.yaml.gotmpl
+++ b/hack/helm_vars/ingress-nginx-controller/values.yaml.gotmpl
@@ -8,6 +8,7 @@ ingress-nginx:
     kind: Deployment
     replicaCount: 1
     service:
+      type: NodePort
       nodePorts:
         # choose a random free port
         https: null


### PR DESCRIPTION
Using load balancer could work also, but requires additional annotations that are environment-specific. This is a fix to a previous PR which was first tested, then refactored without properly being tested, which is why the intended `type: Nodeport` line was missing.