### PR TITLE
bump coturn version

### DIFF
--- a/changelog.d/3-bug-fixes/coturn-bum
+++ b/changelog.d/3-bug-fixes/coturn-bum
@@ -1,0 +1,1 @@
+Bump coturn default image to upstream coturn 4.6.2 + custom Wire code including a bugfix for a bug that resulted in unstable operation during higher load.

--- a/charts/coturn/Chart.yaml
+++ b/charts/coturn/Chart.yaml
@@ -11,4 +11,4 @@ version: 0.0.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.6.0-wireapp.4
+appVersion: 4.6.2-wireapp.2


### PR DESCRIPTION
DO NOT MERGE YET - AWAITING FURTHER TESTS.

Bump coturn default image to upstream coturn 4.6.2 + custom Wire code including a bugfix for a bug that resulted in unstable operation during higher load.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
