### PR TITLE
integration-setup: Pass --skip-deps to helmfile sync

### DIFF
--- a/hack/bin/integration-setup-federation.sh
+++ b/hack/bin/integration-setup-federation.sh
@@ -49,7 +49,7 @@ export FEDERATION_DOMAIN_2="federation-test-helper.$FEDERATION_DOMAIN_BASE"
 
 echo "Installing charts..."
 
-helmfile --environment "$HELMFILE_ENV" --file "${TOP_LEVEL}/hack/helmfile.yaml" sync
+helmfile --environment "$HELMFILE_ENV" --file "${TOP_LEVEL}/hack/helmfile.yaml" sync --skip-deps
 
 # wait for fakeSNS to create resources. TODO, cleaner: make initiate-fake-aws-sns a post hook. See cassandra-migrations chart for an example.
 resourcesReady() {


### PR DESCRIPTION
We run `helm dep update` right before running the helmfile command, so this shouldn't be required.
This saves 1.5 mins in CI.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`! No changelog
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
