### PR TITLE
Grepinclude sphinx directive

### DIFF
--- a/changelog.d/4-docs/grepinclude
+++ b/changelog.d/4-docs/grepinclude
@@ -1,0 +1,1 @@
+Add 'grepinclude' sphinx directive to document with some code snippets.

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -11,7 +11,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import requests
+import sys
 
 # unset SOURCE_DATE_EPOCH to aviod side effects caused by sphinx
 if 'SOURCE_DATE_EPOCH' in os.environ:
@@ -29,6 +29,8 @@ release = version
 
 # -- General configuration ---------------------------------------------------
 
+sys.path.insert(0, os.path.abspath('.')) # for local extensions like grepinclude
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
@@ -40,6 +42,7 @@ extensions = [
     'sphinx_multiversion',
     'sphinx_reredirects',
     'sphinx_copybutton',
+    'grepinclude',
 ]
 
 # Grouping the document tree into PDF files. List of tuples

--- a/docs/src/grepinclude.py
+++ b/docs/src/grepinclude.py
@@ -1,0 +1,56 @@
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+from sphinx.directives.code import container_wrapper
+import re
+
+# A bit like 'literalinclude', but using a keyword to highlight some code so as
+# to be a little more resilient to code moving lines with time.
+# Usage:
+# ```{eval-rst}
+# .. grepinclude:: ../charts/coturn/values.yaml ciphers:
+#    :lines-before: 3
+#    :lines-after: 0
+#    :language: yaml
+# ```
+class GrepInclude(SphinxDirective):
+    required_arguments = 2
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {
+        'lines-before': int,
+        'lines-after': int,
+        'language': str,
+    }
+
+    def run(self):
+        file_path, keyword = self.arguments
+        lines_before = self.options.get('lines-before', 0)
+        lines_after = self.options.get('lines-after', 0)
+        language = self.options.get('language', 'none')
+
+        try:
+            with open(file_path, 'r') as f:
+                content = f.readlines()
+        except FileNotFoundError:
+            return [nodes.error(
+                None, nodes.paragraph(text="Unable to open file: %s" % file_path)
+            )]
+
+        filtered_lines = []
+        for i, line in enumerate(content):
+            if re.search(keyword, line):
+                start = max(0, i - lines_before)
+                end = min(len(content), i + 1 + lines_after)
+                filtered_lines.extend(content[start:end])
+
+        text = ''.join(filtered_lines)
+        code_node = nodes.literal_block(text, text)
+        code_node['language'] = language
+        caption = file_path
+        code_node = container_wrapper(self, code_node, caption)
+        self.add_name(code_node)
+
+        return [code_node]
+
+def setup(app):
+    app.add_directive('grepinclude', GrepInclude)

--- a/docs/src/grepinclude.py
+++ b/docs/src/grepinclude.py
@@ -6,6 +6,16 @@ import re
 # A bit like 'literalinclude', but using a keyword to highlight some code so as
 # to be a little more resilient to code moving lines with time.
 # Usage:
+# ```{grepinclude} ../charts/coturn/values.yaml ciphers:
+# ---
+# lines-before: 3
+# lines-after: 0
+# language: yaml
+# ---
+# ```
+#
+# or alternatively
+#
 # ```{eval-rst}
 # .. grepinclude:: ../charts/coturn/values.yaml ciphers:
 #    :lines-before: 3

--- a/docs/src/how-to/install/tls.md
+++ b/docs/src/how-to/install/tls.md
@@ -40,6 +40,17 @@ The list of TLS ciphers for incoming SFT requests (and metrics) are defined in a
 SFTD deployed via kubernetes uses `kubernetes.io/ingress` for ingress traffic, configured in [ingress.yaml](https://github.com/wireapp/wire-server/blob/develop/charts/sftd/templates/ingress.yaml).
 Kubernetes based deployments make use of the settings from {ref}`ingress-traffic`.
 
+## Coturn (kubernetes)
+
+The list of TLS ciphers for "TLS over TCP" TURN are defined in the [coturn helm chart](https://github.com/wireapp/wire-server/blob/master/charts/coturn/)
+
+```{eval-rst}
+.. grepinclude:: ../charts/coturn/values.yaml ciphers:
+   :lines-before: 3
+   :lines-after: 0
+   :language: yaml
+```
+
 ## Restund (ansible)
 
 The list of TLS ciphers for "TLS over TCP" TURN (and metrics) are defined in ansible templates [nginx-stream.conf.j2](https://github.com/wireapp/ansible-restund/blob/master/templates/nginx-stream.conf.j2#L25) and [nginx-metrics.conf.j2](https://github.com/wireapp/ansible-restund/blob/master/templates/nginx-metrics.conf.j2#L15).

--- a/docs/src/how-to/install/tls.md
+++ b/docs/src/how-to/install/tls.md
@@ -44,11 +44,12 @@ Kubernetes based deployments make use of the settings from {ref}`ingress-traffic
 
 The list of TLS ciphers for "TLS over TCP" TURN are defined in the [coturn helm chart](https://github.com/wireapp/wire-server/blob/master/charts/coturn/)
 
-```{eval-rst}
-.. grepinclude:: ../charts/coturn/values.yaml ciphers:
-   :lines-before: 3
-   :lines-after: 0
-   :language: yaml
+```{grepinclude} ../charts/coturn/values.yaml ciphers:
+---
+lines-before: 3
+lines-after: 0
+language: yaml
+---
 ```
 
 ## Restund (ansible)


### PR DESCRIPTION
Some python to include pieces of code inside docs.wire.com that auto-updates and in somewhat resilient to minor moving lines up and down.

Also document TLS ciphers used for coturn.

![coturn-docs](https://user-images.githubusercontent.com/2112744/234903894-93944451-3a9f-4f8c-bfc7-6c9ea800f998.png)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
