### PR TITLE
Make /api/swagger{-ui,.json} TOC html pages to all versions.

### DIFF
--- a/changelog.d/4-docs/swagger-ui-toc
+++ b/changelog.d/4-docs/swagger-ui-toc
@@ -1,0 +1,1 @@
+Make /api/swagger{-ui,.json} TOC html pages to all versions

--- a/docs/src/understand/api-client-perspective/swagger.md
+++ b/docs/src/understand/api-client-perspective/swagger.md
@@ -31,20 +31,13 @@ docs.
 - Version `v2`:
     - [**public**
     endpoints](https://staging-nginz-https.zinfra.io/v2/api/swagger-ui/)
-- Version `v3`:
-    - [**public**
-    endpoints](https://staging-nginz-https.zinfra.io/v3/api/swagger-ui/)
-- Unversioned:
-    - [**public**
-    endpoints](https://staging-nginz-https.zinfra.io/api/swagger-ui/)
+- ...
 
-The first part of the URL's path is the version. No specified version means
-Swagger docs of the *latest* API version. This differs from other API endpoints
-where no version means `v0`!
+The first part of the URL's path is the version.
 
 New versions are added from time to time. If you
 would like to look at the docs of another version (which did not exist at the
-time of writing): Just update the first path element of an existing link.
+time of writing this): Just update the first path element of an existing link.
 The URL pattern is `https://<nginz-host>/v<version>/api/swagger-ui/`. To figure
 out which versions are supported by your backend, query
 `https://<nginz-host>/<version>/api-version`.
@@ -63,11 +56,11 @@ supports, execute:
 
 ```sh
 curl https://staging-nginz-https.zinfra.io/api-version
-{"development":[3],"domain":"staging.zinfra.io","federation":false,"supported":[0,1,2]}
+{"development":[4],"domain":"staging.zinfra.io","federation":false,"supported":[0,1,2]}
 ```
 
-The URL to open in your browser for the development version `3` is
-`https://staging-nginz-https.zinfra.io/v3/api/swagger-ui/`.
+The URL to open in your browser for the development version `4` is
+`https://staging-nginz-https.zinfra.io/v4/api/swagger-ui/`.
 
 ### Internal endpoints
 

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -89,6 +89,7 @@ import Data.Misc (IpAddr (..))
 import Data.Nonce (Nonce, randomNonce)
 import Data.Qualified
 import Data.Range
+import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as Text
 import qualified Data.Text.Ascii as Ascii
@@ -185,7 +186,27 @@ versionedSwaggerDocsAPI (Just (VersionNumber V0)) = swaggerPregenUIServer $(preg
 versionedSwaggerDocsAPI (Just (VersionNumber V1)) = swaggerPregenUIServer $(pregenSwagger V1)
 versionedSwaggerDocsAPI (Just (VersionNumber V2)) = swaggerPregenUIServer $(pregenSwagger V2)
 versionedSwaggerDocsAPI (Just (VersionNumber V3)) = swaggerPregenUIServer $(pregenSwagger V3)
-versionedSwaggerDocsAPI Nothing = versionedSwaggerDocsAPI (Just maxBound)
+versionedSwaggerDocsAPI Nothing = allroutes (throwError listAllVersionsResp)
+  where
+    allroutes ::
+      (forall a. Servant.Handler a) ->
+      Servant.Server (SwaggerSchemaUI "swagger-ui" "swagger.json")
+    allroutes action =
+      -- why?  see 'SwaggerSchemaUI' type.
+      action :<|> action :<|> action :<|> error (cs listAllVersionsHTML)
+
+    listAllVersionsResp :: ServerError
+    listAllVersionsResp = ServerError 200 mempty listAllVersionsHTML [("Content-Type", "text/html;charset=utf-8")]
+
+    listAllVersionsHTML :: LByteString
+    listAllVersionsHTML =
+      "<html><head></head><body><h2>please pick an api version</h2>"
+        <> mconcat
+          [ let url = "/" <> toQueryParam v <> "/api/swagger-ui/"
+             in "<a href=\"" <> cs url <> "\">" <> cs url <> "</a><br>"
+            | v <- [minBound :: Version ..]
+          ]
+        <> "</body>"
 
 -- | Serves Swagger docs for internal endpoints
 --

--- a/services/brig/test/integration/API/Swagger.hs
+++ b/services/brig/test/integration/API/Swagger.hs
@@ -29,7 +29,7 @@ import Util
 
 tests :: Manager -> Opts -> Brig -> TestTree
 tests p _opts brigNoImplicitVersion =
-  testGroup "version" $
+  testGroup "swagger" $
     [ testGroup "public" $
         [ test p "GET /api/swagger.json" $ testSwaggerJson brigNoImplicitVersion "",
           test p "GET /api/swagger-ui" $ testSwaggerUI brigNoImplicitVersion "",

--- a/services/brig/test/integration/API/Swagger.hs
+++ b/services/brig/test/integration/API/Swagger.hs
@@ -51,7 +51,7 @@ tests p _opts brigNoImplicitVersion =
               r <- get (brigNoImplicitVersion . path pth . expect2xx)
               liftIO $ assertEqual "toc is intact" (responseBody r) (Just "<html><head></head><body><h2>please pick an api version</h2><a href=\"/v0/api/swagger-ui/\">/v0/api/swagger-ui/</a><br><a href=\"/v1/api/swagger-ui/\">/v1/api/swagger-ui/</a><br><a href=\"/v2/api/swagger-ui/\">/v2/api/swagger-ui/</a><br><a href=\"/v3/api/swagger-ui/\">/v3/api/swagger-ui/</a><br><a href=\"/v4/api/swagger-ui/\">/v4/api/swagger-ui/</a><br></body>")
               -- are all versions listed?
-              forM_ [minBound :: Version ..] $ \v -> liftIO $ assertBool (show v) ((cs (toQueryParam v) :: String) `isInfixOf` (cs $ fromJust $ responseBody r))
+              forM_ [minBound :: Version ..] $ \v -> liftIO $ assertBool (show v) ((cs (toQueryParam v) :: String) `isInfixOf` (cs . fromJust . responseBody $ r))
               -- FUTUREWORK: maybe test that no invalid versions are listed?  (that wouldn't
               -- be too terrible, though, just some dead links that aren't supposed to be
               -- there to begin with)

--- a/services/brig/test/integration/API/Swagger.hs
+++ b/services/brig/test/integration/API/Swagger.hs
@@ -21,30 +21,46 @@ import Bilge
 import Brig.Options
 import Control.Lens
 import Data.Aeson.Lens
+import Data.ByteString.Conversion (toByteString')
 import Data.String.Conversions
 import Imports
+import Servant.API (toQueryParam)
 import Test.Tasty
 import Test.Tasty.HUnit
 import Util
+import Wire.API.Routes.Version (Version)
 
 tests :: Manager -> Opts -> Brig -> TestTree
 tests p _opts brigNoImplicitVersion =
   testGroup "swagger" $
     [ testGroup "public" $
-        [ test p "GET /api/swagger.json" $ testSwaggerJson brigNoImplicitVersion "",
-          test p "GET /api/swagger-ui" $ testSwaggerUI brigNoImplicitVersion "",
-          test p "GET /v2/api/swagger.json" $ testSwaggerJson brigNoImplicitVersion "/v2",
-          test p "GET /v2/api/swagger-ui" $ testSwaggerUI brigNoImplicitVersion "/v2"
-        ],
+        join
+          [ [ test p ("GET /" <> show v <> "/api/swagger.json") $ testSwaggerJson brigNoImplicitVersion (toByteString' v),
+              test p ("GET /" <> show v <> "/api/swagger-ui") $ testSwaggerUI brigNoImplicitVersion (toByteString' v)
+            ]
+            | v <- [minBound :: Version ..]
+          ],
       testGroup "internal" $
         [ test p "GET /v2/api-internal/swagger-ui/brig" $ void (get (brigNoImplicitVersion . path "/v2/api-internal/swagger-ui/brig" . expect4xx)),
           test p "GET /v2/api-internal/swagger-ui/gundeck" $ void (get (brigNoImplicitVersion . path "/v2/api-internal/swagger-ui/gundeck" . expect4xx)),
           test p "GET /v2/i/status" $ void (get (brigNoImplicitVersion . path "/v2/i/status" . expect4xx))
+        ],
+      testGroup "toc" $
+        [ test p "toc" $ do
+            forM_ ["/api/swagger-ui", "/api/swagger-ui/index.html", "/api/swagger.json"] $ \pth -> do
+              r <- get (brigNoImplicitVersion . path pth . expect2xx)
+              liftIO $ assertEqual "toc is intact" (responseBody r) (Just "<html><head></head><body><h2>please pick an api version</h2><a href=\"/v0/api/swagger-ui/\">/v0/api/swagger-ui/</a><br><a href=\"/v1/api/swagger-ui/\">/v1/api/swagger-ui/</a><br><a href=\"/v2/api/swagger-ui/\">/v2/api/swagger-ui/</a><br><a href=\"/v3/api/swagger-ui/\">/v3/api/swagger-ui/</a><br><a href=\"/v4/api/swagger-ui/\">/v4/api/swagger-ui/</a><br></body>")
+              -- are all versions listed?
+              forM_ [minBound :: Version ..] $ \v -> liftIO $ assertBool (show v) ((cs (toQueryParam v) :: String) `isInfixOf` (cs $ fromJust $ responseBody r))
+              -- FUTUREWORK: maybe test that no invalid versions are listed?  (that wouldn't
+              -- be too terrible, though, just some dead links that aren't supposed to be
+              -- there to begin with)
         ]
     ]
 
 testSwaggerJson :: Brig -> ByteString -> Http ()
 testSwaggerJson brig version = do
+  -- if you change the request paths here, make sure to change test group "toc" below to contain live links!
   r <- get (brig . path (version <> "/api/swagger.json") . expect2xx)
   liftIO $ assertBool "json body" (isJust $ ((^? _Object) <=< responseBody) r)
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-1910

![2023-04-28-131222_1600x900_scrot](https://user-images.githubusercontent.com/10210727/235133482-e52e9c2d-8269-4526-9f10-cf6ea20aecad.png)


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
