### PR TITLE
[chore]: Ensure hlint config accounts for record-dot-syntax.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,5 +1,5 @@
 # We need quasi quotes support.
-- arguments: [ -XQuasiQuotes, --color ]
+- arguments: [ -XQuasiQuotes, -XOverloadedRecordDot, --color ]
 
 # Used to enforce ormolu styling. Can be revisited if we change formatters.
 - ignore: { name: Redundant $ }


### PR DESCRIPTION
What it says on the tin. Without this we were getting false positives, specifically when using parentheses.

```haskell
(someF someA).fieldAccess
```