### PR TITLE
fix: forward original http host to proxy request in nginz as `Z-Host`

### DIFF
--- a/changelog.d/3-bug-fixes/pr-3263
+++ b/changelog.d/3-bug-fixes/pr-3263
@@ -1,0 +1,1 @@
+Correct http host is passed to proxy request

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -310,6 +310,7 @@ http {
         proxy_set_header   Z-Bot          $zauth_bot;
         proxy_set_header   Z-Conversation $zauth_conversation;
         proxy_set_header   Request-Id     $request_id;
+        proxy_set_header   Z-Host         $host;
 
             {{- if ($location.allow_credentials) }}
         more_set_headers 'Access-Control-Allow-Credentials: true';

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -793,11 +793,11 @@ type CreateAccessToken =
                \The access token will be returned as JWT DPoP token in the `DPoP` header."
              )
         :> ZUser
+        :> ZHost
         :> "clients"
         :> CaptureClientId "cid"
         :> "access-token"
         :> Header' '[Required, Strict] "DPoP" Proof
-        :> Header "Host" Text
         :> MultiVerb1
              'POST
              '[JSON]

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -87,7 +87,6 @@ import Data.Misc (PlainTextPassword6)
 import Data.Qualified
 import qualified Data.Set as Set
 import Data.String.Conversions (cs)
-import qualified Data.Text as Text
 import Imports
 import Network.HTTP.Types.Method (StdMethod)
 import Network.Wai.Utilities
@@ -486,10 +485,10 @@ createAccessToken ::
   StdMethod ->
   Link ->
   Proof ->
-  Maybe Text ->
+  Text ->
   ExceptT CertEnrollmentError (AppT r) (DPoPAccessTokenResponse, CacheControl)
-createAccessToken uid cid method link proof mHostHeader = do
-  domain <- maybe (throwE MisconfiguredRequestUrl) (pure . Domain) $ mHostHeader <&> Text.splitOn ":" >>= headMay
+createAccessToken uid cid method link proof host = do
+  let domain = Domain host
   nonce <- ExceptT $ note NonceNotFound <$> wrapClient (Nonce.lookupAndDeleteNonce uid (cs $ toByteString cid))
   httpsUrl <- do
     let urlBs = "https://" <> toByteString' domain <> "/" <> cs (toUrlPiece link)

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -629,13 +629,13 @@ createAccessToken ::
   ) =>
   StdMethod ->
   UserId ->
+  Text ->
   ClientId ->
   Proof ->
-  Maybe Text ->
   (Handler r) (DPoPAccessTokenResponse, CacheControl)
-createAccessToken method uid cid proof mHost = do
+createAccessToken method uid host cid proof = do
   let link = safeLink (Proxy @api) (Proxy @endpoint) cid
-  API.createAccessToken uid cid method link proof mHost !>> certEnrollmentError
+  API.createAccessToken uid cid method link proof host !>> certEnrollmentError
 
 -- | docs/reference/user/registration.md {#RefRegistration}
 createUser ::

--- a/services/brig/test/integration/API/User.hs
+++ b/services/brig/test/integration/API/User.hs
@@ -66,7 +66,7 @@ tests e conf fbc fgc p b c ch g n aws db userJournalWatcher = do
   pure $
     testGroup
       "user"
-      [ API.User.Client.tests e cl at conf p db b c g,
+      [ API.User.Client.tests e cl at conf p db n b c g,
         API.User.Account.tests cl at conf p b c ch g aws userJournalWatcher,
         API.User.Auth.tests conf p z db b g n,
         API.User.Connection.tests cl at conf p b c g fbc fgc db,

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -28,7 +28,7 @@ import Brig.Effects.CodeStore
 import Brig.Effects.CodeStore.Cassandra
 import Brig.Options (Opts)
 import Brig.Types.Team.LegalHold (LegalHoldClientRequest (..))
-import qualified Brig.ZAuth
+import Brig.ZAuth (Token)
 import qualified Cassandra as DB
 import qualified Codec.MIME.Type as MIME
 import Control.Lens (preview, (^?))
@@ -47,6 +47,7 @@ import qualified Data.List1 as List1
 import Data.Misc
 import Data.Qualified
 import Data.Range (unsafeRange)
+import Data.String.Conversions (cs)
 import qualified Data.Text.Ascii as Ascii
 import qualified Data.Vector as Vec
 import qualified Data.ZAuth.Token as ZAuth
@@ -212,7 +213,7 @@ preparePasswordReset ::
   UserId ->
   PlainTextPassword8 ->
   m CompletePasswordReset
-preparePasswordReset brig cs email uid newpw = do
+preparePasswordReset brig cState email uid newpw = do
   let qry = queryItem "email" (toByteString' email)
   r <- get $ brig . path "/i/users/password-reset-code" . qry
   let lbs = fromMaybe "" $ responseBody r
@@ -221,7 +222,7 @@ preparePasswordReset brig cs email uid newpw = do
   let complete = CompletePasswordReset ident pwcode newpw
   pure complete
   where
-    runSem = liftIO . runFinal @IO . interpretClientToIO cs . codeStoreToCassandra @DB.Client
+    runSem = liftIO . runFinal @IO . interpretClientToIO cState . codeStoreToCassandra @DB.Client
 
 completePasswordReset :: Brig -> CompletePasswordReset -> MonadHttp m => m ResponseLBS
 completePasswordReset brig passwordResetData =
@@ -583,11 +584,20 @@ nonce m brig uid cid =
         . zUser uid
     )
 
-createAccessToken :: (MonadHttp m, HasCallStack) => Brig -> UserId -> ClientId -> Maybe Proof -> m ResponseLBS
-createAccessToken brig uid cid mProof =
-  post
-    ( brig
-        . paths ["clients", toByteString' cid, "access-token"]
-        . zUser uid
-        . maybe id (header "DPoP" . toByteString') mProof
-    )
+createAccessToken :: (MonadHttp m, HasCallStack) => Brig -> UserId -> Text -> ClientId -> Maybe Proof -> m ResponseLBS
+createAccessToken brig uid h cid mProof =
+  post $
+    brig
+      . paths ["clients", toByteString' cid, "access-token"]
+      . zUser uid
+      . header "Z-Host" (cs h)
+      . maybe id (header "DPoP" . toByteString') mProof
+
+createAccessTokenNginz :: (MonadHttp m, HasCallStack) => Nginz -> ZAuth.Token ZAuth.Access -> ClientId -> Maybe Proof -> m ResponseLBS
+createAccessTokenNginz n t cid mProof =
+  post $
+    unversioned
+      . n
+      . paths ["clients", toByteString' cid, "access-token"]
+      . header "Authorization" ("Bearer " <> toByteString' t)
+      . maybe id (header "DPoP" . toByteString') mProof

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -144,7 +144,7 @@ runTests iConf brigOpts otherArgs = do
   emailAWSOpts <- parseEmailAWSOpts
   awsEnv <- AWS.mkEnv lg awsOpts emailAWSOpts mg
   mUserJournalWatcher <- for (view AWS.userJournalQueue awsEnv) $ SQS.watchSQSQueue (view AWS.amazonkaEnv awsEnv)
-  userApi <- User.tests (brig iConf) brigOpts fedBrigClient fedGalleyClient mg b c ch g n awsEnv db mUserJournalWatcher
+  userApi <- User.tests (nginz iConf) brigOpts fedBrigClient fedGalleyClient mg b c ch g n awsEnv db mUserJournalWatcher
   providerApi <- Provider.tests localDomain (provider iConf) mg db b c g
   searchApis <- Search.tests brigOpts mg g b
   teamApis <- Team.tests brigOpts mg n b c g mUserJournalWatcher

--- a/services/nginz/integration-test/conf/nginz/common_response_with_zauth.conf
+++ b/services/nginz/integration-test/conf/nginz/common_response_with_zauth.conf
@@ -1,2 +1,3 @@
     include common_response.conf;
     proxy_set_header   Authorization  "";
+    proxy_set_header   Z-Host  $host;

--- a/services/nginz/integration-test/conf/nginz/nginx.conf
+++ b/services/nginz/integration-test/conf/nginz/nginx.conf
@@ -249,7 +249,7 @@ http {
       proxy_pass http://brig;
     }
 
-    location ~* ^(/v[0-9]+)?/clients$ {
+    location ~* ^(/v[0-9]+)?/clients {
       include common_response_with_zauth.conf;
       proxy_pass http://brig;
     }


### PR DESCRIPTION
To create a valid DPoP access token for the client's e2eid CSR we have to pass the correct domain to the crypto library.

We can extract the domain from the request via the HTTP host header.

However, with `nginz` in front of `brig` the host header is automatically redefined as `$proxy_host`. (see <http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header>)

To pass the original header, a new header `Z-Host` is defined and set to the original HTTP host header value via `$host`.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
