### PR TITLE
Add subconversation ID to RemoteMLSMessage

### DIFF
--- a/changelog.d/6-federation/FS-1868
+++ b/changelog.d/6-federation/FS-1868
@@ -1,0 +1,1 @@
+Add subconversation ID to onMLSMessageSent request payload.

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -353,6 +353,7 @@ data RemoteMLSMessage = RemoteMLSMessage
     rmmMetadata :: MessageMetadata,
     rmmSender :: Qualified UserId,
     rmmConversation :: ConvId,
+    rmmSubConversation :: Maybe SubConvId,
     rmmRecipients :: [(UserId, ClientId)],
     rmmMessage :: Base64ByteString
   }

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -783,7 +783,7 @@ onMLSMessageSent domain rmm =
       let recipients = filter (\(u, _) -> Set.member u members) (F.rmmRecipients rmm)
       -- FUTUREWORK: support local bots
       let e =
-            Event (tUntagged rcnv) Nothing (F.rmmSender rmm) (F.rmmTime rmm) $
+            Event (tUntagged rcnv) (F.rmmSubConversation rmm) (F.rmmSender rmm) (F.rmmTime rmm) $
               EdMLSMessage (fromBase64ByteString (F.rmmMessage rmm))
       let mkPush :: (UserId, ClientId) -> MessagePush 'NormalMessage
           mkPush uc = newMessagePush loc mempty Nothing (F.rmmMetadata rmm) uc e

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -95,6 +95,7 @@ propagateMessage qusr lConvOrSub con msg cm = do
             rmmSender = qusr,
             rmmMetadata = mm,
             rmmConversation = qUnqualified qcnv,
+            rmmSubConversation = sconv,
             rmmRecipients = rs >>= remoteMemberMLSClients,
             rmmMessage = Base64ByteString msg.raw
           }

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1206,6 +1206,7 @@ testRemoteToRemote = do
             rmmMetadata = defMessageMetadata,
             rmmSender = qbob,
             rmmConversation = conv,
+            rmmSubConversation = Nothing,
             rmmRecipients = rcpts,
             rmmMessage = Base64ByteString txt
           }

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -253,6 +253,10 @@ tests s =
               test s "delete subconversation as a remote member" (testRemoteMemberDeleteSubConv True),
               test s "delete subconversation as a remote non-member" (testRemoteMemberDeleteSubConv False),
               test s "delete parent conversation of a remote subconversation" testDeleteRemoteParentOfSubConv
+            ],
+          testGroup
+            "Remote Sender/Remote SubConversation"
+            [ test s "on-mls-message-sent in subconversation" testRemoteToRemoteInSub
             ]
         ],
       testGroup
@@ -1218,6 +1222,62 @@ testRemoteToRemote = do
       -- alice should receive the message on her first client
       WS.assertMatch_ (5 # Second) wsA1 $ \n -> wsAssertMLSMessage (fmap Conv qconv) qbob txt n
       WS.assertMatch_ (5 # Second) wsA2 $ \n -> wsAssertMLSMessage (fmap Conv qconv) qbob txt n
+
+      -- eve should not receive the message
+      WS.assertNoEvent (1 # Second) [wsE]
+
+testRemoteToRemoteInSub :: TestM ()
+testRemoteToRemoteInSub = do
+  localDomain <- viewFederationDomain
+  c <- view tsCannon
+  alice <- randomUser
+  eve <- randomUser
+  bob <- randomId
+  conv <- randomId
+  let subConvId = SubConvId "conference"
+      aliceC1 = newClientId 0
+      aliceC2 = newClientId 1
+      eveC = newClientId 0
+      bdom = Domain "bob.example.com"
+      qconv = Qualified conv bdom
+      qbob = Qualified bob bdom
+      qalice = Qualified alice localDomain
+  now <- liftIO getCurrentTime
+  fedGalleyClient <- view tsFedGalleyClient
+
+  -- only add alice to the remote conversation
+  connectWithRemoteUser alice qbob
+  let cu =
+        ConversationUpdate
+          { cuTime = now,
+            cuOrigUserId = qbob,
+            cuConvId = conv,
+            cuAlreadyPresentUsers = [],
+            cuAction =
+              SomeConversationAction (sing @'ConversationJoinTag) (ConversationJoin (pure qalice) roleNameWireMember)
+          }
+  runFedClient @"on-conversation-updated" fedGalleyClient bdom cu
+
+  let txt = "Hello from another backend"
+      rcpts = [(alice, aliceC1), (alice, aliceC2), (eve, eveC)]
+      rm =
+        RemoteMLSMessage
+          { rmmTime = now,
+            rmmMetadata = defMessageMetadata,
+            rmmSender = qbob,
+            rmmConversation = conv,
+            rmmSubConversation = Just subConvId,
+            rmmRecipients = rcpts,
+            rmmMessage = Base64ByteString txt
+          }
+
+  -- send message to alice and check reception
+  WS.bracketAsClientRN c [(alice, aliceC1), (alice, aliceC2), (eve, eveC)] $ \[wsA1, wsA2, wsE] -> do
+    void $ runFedClient @"on-mls-message-sent" fedGalleyClient bdom rm
+    liftIO $ do
+      -- alice should receive the message on her first client
+      WS.assertMatch_ (5 # Second) wsA1 $ \n -> wsAssertMLSMessage (fmap (flip SubConv subConvId) qconv) qbob txt n
+      WS.assertMatch_ (5 # Second) wsA2 $ \n -> wsAssertMLSMessage (fmap (flip SubConv subConvId) qconv) qbob txt n
 
       -- eve should not receive the message
       WS.assertNoEvent (1 # Second) [wsE]


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)

See also https://github.com/wireapp/wire-server/pull/3271.