### PR TITLE
Add subconversation ID to RemoteMLSMessage

### DIFF
--- a/changelog.d/6-federation/FS-1868
+++ b/changelog.d/6-federation/FS-1868
@@ -1,0 +1,1 @@
+Add subconversation ID to onMLSMessageSent request payload.

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -353,6 +353,7 @@ data RemoteMLSMessage = RemoteMLSMessage
     rmmMetadata :: MessageMetadata,
     rmmSender :: Qualified UserId,
     rmmConversation :: ConvId,
+    rmmSubConversation :: Maybe SubConvId,
     rmmRecipients :: [(UserId, ClientId)],
     rmmMessage :: Base64ByteString
   }

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -795,7 +795,7 @@ onMLSMessageSent domain rmm =
       let recipients = filter (\(u, _) -> Set.member u members) (F.rmmRecipients rmm)
       -- FUTUREWORK: support local bots
       let e =
-            Event (tUntagged rcnv) Nothing (F.rmmSender rmm) (F.rmmTime rmm) $
+            Event (tUntagged rcnv) (F.rmmSubConversation rmm) (F.rmmSender rmm) (F.rmmTime rmm) $
               EdMLSMessage (fromBase64ByteString (F.rmmMessage rmm))
       let mkPush :: (UserId, ClientId) -> MessagePush 'NormalMessage
           mkPush uc = newMessagePush loc mempty Nothing (F.rmmMetadata rmm) uc e

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -94,6 +94,7 @@ propagateMessage qusr lConvOrSub con raw cm = do
             rmmSender = qusr,
             rmmMetadata = mm,
             rmmConversation = qUnqualified qcnv,
+            rmmSubConversation = sconv,
             rmmRecipients = rs >>= remoteMemberMLSClients,
             rmmMessage = Base64ByteString raw
           }

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -1269,6 +1269,7 @@ testRemoteToRemote = do
             rmmMetadata = defMessageMetadata,
             rmmSender = qbob,
             rmmConversation = conv,
+            rmmSubConversation = Nothing,
             rmmRecipients = rcpts,
             rmmMessage = Base64ByteString txt
           }


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)

See also https://github.com/wireapp/wire-server/pull/3270.