### PR TITLE
Add postConversation test suite and some helpers

### DIFF
--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -1,1 +1,118 @@
 module API.Galley where
+
+import qualified Data.Aeson as Aeson
+import Testlib.Prelude
+
+data CreateConv = CreateConv
+  { qualifiedUsers :: [Value],
+    name :: Maybe String,
+    access :: Maybe [String],
+    accessRole :: Maybe [String],
+    team :: Maybe String,
+    messageTimer :: Maybe Int,
+    receiptMode :: Maybe Int,
+    newUsersRole :: String,
+    protocol :: String
+  }
+
+defProteus :: CreateConv
+defProteus =
+  CreateConv
+    { qualifiedUsers = [],
+      name = Nothing,
+      access = Nothing,
+      accessRole = Nothing,
+      team = Nothing,
+      messageTimer = Nothing,
+      receiptMode = Nothing,
+      newUsersRole = "wire_admin",
+      protocol = "proteus"
+    }
+
+defMLS :: CreateConv
+defMLS = defProteus {protocol = "mls"}
+
+instance MakesValue CreateConv where
+  make cc = do
+    quids <- for (cc.qualifiedUsers) objQidObject
+    pure $
+      Aeson.object $
+        ( [ "qualified_users" .= quids,
+            "conversation_role" .= cc.newUsersRole,
+            "protocol" .= cc.protocol
+          ]
+            <> catMaybes
+              [ "name" .=? cc.name,
+                "access" .=? cc.access,
+                "access_role_v2" .=? cc.access,
+                "team" .=? (cc.team <&> \tid -> Aeson.object ["teamid" .= tid, "managed" .= False]),
+                "message_timer" .=? cc.messageTimer,
+                "receipt_mode" .=? cc.receiptMode
+              ]
+        )
+
+postConversation ::
+  ( HasCallStack,
+    MakesValue user,
+    MakesValue client
+  ) =>
+  user ->
+  Maybe client ->
+  CreateConv ->
+  App Response
+postConversation user mclient cc = do
+  uid <- objId user
+  domain <- objDomain user
+  mcid <- for mclient objId
+  req <- baseRequest domain Galley Versioned "/conversations"
+  ccv <- make cc
+  submit "POST" $
+    req
+      & zUser uid
+      & maybe id zClient mcid
+      & zConnection "conn"
+      & addJSON ccv
+
+putConversationProtocol ::
+  ( HasCallStack,
+    MakesValue user,
+    MakesValue qcnv,
+    MakesValue conn,
+    MakesValue protocol
+  ) =>
+  user ->
+  qcnv ->
+  Maybe conn ->
+  protocol ->
+  App Response
+putConversationProtocol user qcnv mconn protocol = do
+  mconn' <- for mconn asString
+  (domain, cnv) <- objQid qcnv
+  p <- asString protocol
+  uid <- objId user
+  req <- baseRequest user Galley Versioned (joinHttpPath ["conversations", domain, cnv, "protocol"])
+  submit
+    "PUT"
+    ( req
+        & zUser uid
+        & zConnection (fromMaybe "conn" mconn')
+        & addJSONObject ["protocol" .= p]
+    )
+
+getConversation ::
+  ( HasCallStack,
+    MakesValue user,
+    MakesValue qcnv
+  ) =>
+  user ->
+  qcnv ->
+  App Response
+getConversation user qcnv = do
+  (domain, cnv) <- objQid qcnv
+  uid <- objId user
+  req <- baseRequest user Galley Versioned (joinHttpPath ["conversations", domain, cnv])
+  submit
+    "GET"
+    ( req
+        & zUser uid
+    )

--- a/integration/test/SetupHelpers.hs
+++ b/integration/test/SetupHelpers.hs
@@ -36,7 +36,7 @@ connectUsers alice bob = do
   bindResponse (Public.postConnection alice bob) (\resp -> resp.status `shouldMatchInt` 201)
   bindResponse (Public.putConnection bob alice "accepted") (\resp -> resp.status `shouldMatchInt` 200)
 
-createAndConnectUsers :: HasCallStack => [String] -> App [Value]
+createAndConnectUsers :: (HasCallStack, MakesValue domain) => [domain] -> App [Value]
 createAndConnectUsers domains = do
   users <- for domains (flip randomUser def)
   let userPairs = do

--- a/integration/test/Testlib/Assertions.hs
+++ b/integration/test/Testlib/Assertions.hs
@@ -115,8 +115,7 @@ prettierCallStack cstack = do
   where
     isTestlibEntry :: (String, SrcLoc) -> Bool
     isTestlibEntry (_, SrcLoc {..}) =
-      isInfixOf "/Testlib/" srcLocFile
-        || isInfixOf "RunAllTests.hs" srcLocFile
+      "RunAllTests.hs" `isInfixOf` srcLocFile
 
 prettierCallStackLines :: CallStack -> IO String
 prettierCallStackLines cstack =

--- a/integration/test/Testlib/Cannon.hs
+++ b/integration/test/Testlib/Cannon.hs
@@ -77,7 +77,7 @@ data WSConnect = WSConnect
   }
 
 class ToWSConnect a where
-  toWSConnect :: a -> App WSConnect
+  toWSConnect :: HasCallStack => a -> App WSConnect
 
 instance {-# OVERLAPPING #-} ToWSConnect WSConnect where
   toWSConnect = pure
@@ -183,7 +183,7 @@ close ws = liftIO $ do
   putMVar (wsCloseLatch ws) ()
   void $ waitCatch (wsAppThread ws)
 
-withWebSocket :: HasCallStack => ToWSConnect w => w -> (WebSocket -> App a) -> App a
+withWebSocket :: (HasCallStack, ToWSConnect w) => w -> (WebSocket -> App a) -> App a
 withWebSocket w k = do
   wsConnect <- toWSConnect w
   Catch.bracket (connect wsConnect) close k

--- a/integration/test/Testlib/HTTP.hs
+++ b/integration/test/Testlib/HTTP.hs
@@ -29,7 +29,7 @@ joinHttpPath = intercalate "/"
 addJSONObject :: [Aeson.Pair] -> HTTP.Request -> HTTP.Request
 addJSONObject = addJSON . Aeson.object
 
-addJSON :: Aeson.Value -> HTTP.Request -> HTTP.Request
+addJSON :: Aeson.ToJSON a => a -> HTTP.Request -> HTTP.Request
 addJSON obj req =
   req
     { HTTP.requestBody = HTTP.RequestBodyLBS (Aeson.encode obj),
@@ -51,6 +51,9 @@ zUser = addHeader "Z-User"
 
 zConnection :: String -> HTTP.Request -> HTTP.Request
 zConnection = addHeader "Z-Connection"
+
+zClient :: String -> HTTP.Request -> HTTP.Request
+zClient = addHeader "Z-Client"
 
 zType :: String -> HTTP.Request -> HTTP.Request
 zType = addHeader "Z-Type"


### PR DESCRIPTION
This PR adds `postConversation` to the new integration test suite as well as a small helpers.

This PR also removes some filtering of callstack items, that turned out not to be helpful: In case of missing callstack information you can end up with an empty callstack and almost no clue where to begin your search.
