### PR TITLE
Add conversation.protocol-update event

### DIFF
--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -89,6 +89,7 @@ library
     Test.B2B
     Test.Brig
     Test.Demo
+    Test.MLS
     Testlib.App
     Testlib.Assertions
     Testlib.Cannon

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -1,0 +1,30 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Test.MLS where
+
+import qualified API.Galley as Public
+import SetupHelpers
+import Testlib.Prelude
+
+testMixedProtocolUpgrade :: HasCallStack => App ()
+testMixedProtocolUpgrade = do
+  [alice, bob] <- createAndConnectUsers [ownDomain, ownDomain]
+
+  qcnv <- bindResponseR (Public.postConversation alice noValue Public.defProteus {Public.qualifiedUsers = [bob]}) $ \resp -> do
+    resp.status `shouldMatchInt` 201
+
+  withWebSocket alice $ \wsAlice -> do
+    bindResponse (Public.putConversationProtocol bob qcnv noValue "mixed") $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      resp %. "conversation" `shouldMatch` (qcnv %. "id")
+      resp %. "data.protocol" `shouldMatch` "mixed"
+
+    n <- awaitMatch 3 (\value -> nPayload value %. "type" `isEqual` "conversation.protocol-update") wsAlice
+    nPayload n %. "data.protocol" `shouldMatch` "mixed"
+
+  bindResponse (Public.getConversation alice qcnv) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp %. "protocol" `shouldMatch` "mixed"
+
+  bindResponse (Public.putConversationProtocol alice qcnv noValue "mixed") $ \resp -> do
+    resp.status `shouldMatchInt` 204

--- a/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
@@ -158,6 +158,8 @@ protocolDataSchema ProtocolMLSTag = tag _ProtocolMLS mlsDataSchema
 protocolDataSchema ProtocolMixedTag = tag _ProtocolMixed mlsDataSchema
 
 newtype ProtocolUpdate = ProtocolUpdate {unProtocolUpdate :: ProtocolTag}
+  deriving (Show, Eq, Generic)
+  deriving (Arbitrary) via GenericUniform ProtocolUpdate
 
 instance ToSchema ProtocolUpdate where
   schema = object "ProtocolUpdate" (ProtocolUpdate <$> unProtocolUpdate .= protocolTagSchema)

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -1260,9 +1260,5 @@ type ConversationAPI =
                :> QualifiedCapture' '[Description "Conversation ID"] "cnv" ConvId
                :> "protocol"
                :> ReqBody '[JSON] ProtocolUpdate
-               :> MultiVerb
-                    'PUT
-                    '[JSON]
-                    '[RespondEmpty 200 "Update successful"]
-                    ()
+               :> MultiVerb 'PUT '[Servant.JSON] ConvUpdateResponses (UpdateResult Event)
            )

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
@@ -73,7 +73,8 @@ tests =
           ],
       testGroup "ConversationEvent" $
         testObjects
-          [ (testObject_Event_conversation_manual_1, "testObject_Event_conversation_manual_1.json")
+          [ (testObject_Event_conversation_manual_1, "testObject_Event_conversation_manual_1.json"),
+            (testObject_Event_conversation_manual_2, "testObject_Event_conversation_manual_2.json")
           ],
       testGroup "GetPaginatedConversationIds" $
         testObjects

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationEvent.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationEvent.hs
@@ -23,6 +23,7 @@ import Data.Qualified (Qualified (..))
 import Data.Time
 import qualified Data.UUID as UUID
 import Imports
+import qualified Wire.API.Conversation.Protocol as P
 import Wire.API.Event.Conversation
 import Wire.API.MLS.SubConversation
 
@@ -34,4 +35,14 @@ testObject_Event_conversation_manual_1 =
       evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "n8nl6tp.h5"}},
       evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
       evtData = EdConvCodeDelete
+    }
+
+testObject_Event_conversation_manual_2 :: Event
+testObject_Event_conversation_manual_2 =
+  Event
+    { evtConv = Qualified {qUnqualified = Id (fromJust (UUID.fromString "2126ea99-ca79-43ea-ad99-a59616468e8e")), qDomain = Domain {_domainText = "example.com"}},
+      evtSubConv = Nothing,
+      evtFrom = Qualified {qUnqualified = Id (fromJust (UUID.fromString "a471447c-aa30-4592-81b0-dec6c1c02bca")), qDomain = Domain {_domainText = "example.com"}},
+      evtTime = UTCTime {utctDay = ModifiedJulianDay 58119, utctDayTime = 0},
+      evtData = EdProtocolUpdate (P.ProtocolUpdate P.ProtocolMixedTag)
     }

--- a/libs/wire-api/test/golden/testObject_Event_conversation_manual_2.json
+++ b/libs/wire-api/test/golden/testObject_Event_conversation_manual_2.json
@@ -1,0 +1,17 @@
+{
+    "conversation": "2126ea99-ca79-43ea-ad99-a59616468e8e",
+    "data": {
+        "protocol": "mixed"
+    },
+    "from": "a471447c-aa30-4592-81b0-dec6c1c02bca",
+    "qualified_conversation": {
+        "domain": "example.com",
+        "id": "2126ea99-ca79-43ea-ad99-a59616468e8e"
+    },
+    "qualified_from": {
+        "domain": "example.com",
+        "id": "a471447c-aa30-4592-81b0-dec6c1c02bca"
+    },
+    "time": "2018-01-01T00:00:00.000Z",
+    "type": "conversation.protocol-update"
+}

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -261,8 +261,7 @@ tests s =
         ],
       testGroup
         "MixedProtocol"
-        [ test s "Upgrade a conv from proteus to mixed" testMixedUpgrade,
-          test s "Add clients to a mixed conversation and send proteus message" testMixedAddClients
+        [ test s "Add clients to a mixed conversation and send proteus message" testMixedAddClients
         ]
     ]
 
@@ -3467,35 +3466,6 @@ testCreatorRemovesUserFromParent = do
               )
               (sort [alice1, charlie1, charlie2])
               (sort $ pscMembers sub2)
-
-testMixedUpgrade :: TestM ()
-testMixedUpgrade = do
-  [alice, bob] <- createAndConnectUsers (replicate 2 Nothing)
-
-  runMLSTest $ do
-    [alice1] <- traverse createMLSClient [alice]
-
-    qcnv <-
-      cnvQualifiedId
-        <$> liftTest
-          ( postConvQualified (qUnqualified alice) Nothing defNewProteusConv {newConvQualifiedUsers = [bob]}
-              >>= responseJsonError
-          )
-
-    putConversationProtocol (qUnqualified alice) (ciClient alice1) qcnv ProtocolMixedTag
-      !!! const 200 === statusCode
-
-    conv <-
-      responseJsonError
-        =<< getConvQualified (qUnqualified alice) qcnv
-          <!! const 200 === statusCode
-
-    mlsData <- assertMixedProtocol conv
-
-    liftIO $ assertEqual "" (cnvmlsEpoch mlsData) (Epoch 0)
-
-    putConversationProtocol (qUnqualified alice) (ciClient alice1) qcnv ProtocolMixedTag
-      !!! const 200 === statusCode
 
 testMixedAddClients :: TestM ()
 testMixedAddClients = do


### PR DESCRIPTION
This PR adds sending a `conversation.update-protocol` event to all conversation participants when the protocol is switched.
