### PR TITLE
FS-1467: Make conversation metadata APIs fault tolerant to federation errors

### DIFF
--- a/changelog.d/1-api-changes/FS-1467
+++ b/changelog.d/1-api-changes/FS-1467
@@ -1,0 +1,1 @@
+Updating conversation meta-data APIs to be fault tolerant of unavailable federation servers.

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -37,6 +37,7 @@ module Galley.API.Action
     notifyConversationAction,
     notifyRemoteConversationAction,
     ConversationUpdate,
+    FederationFailEarly (..),
   )
 where
 
@@ -632,10 +633,16 @@ updateLocalConversationUnchecked lconv qusr con action = do
   (extraTargets, action') <- performAction tag qusr lconv action
 
   notifyConversationAction
-    -- Removing members should be fault tolerant.
     ( case tag of
-        SConversationRemoveMembersTag -> False
-        _ -> True
+        -- Removing members should be fault tolerant.
+        SConversationRemoveMembersTag -> FaultTolerant
+        -- Conversation metadata updates should be fault tolerant.
+        SConversationRenameTag -> FaultTolerant
+        SConversationMessageTimerUpdateTag -> FaultTolerant
+        SConversationReceiptModeUpdateTag -> FaultTolerant
+        SConversationAccessDataTag -> FaultTolerant
+        SConversationMemberUpdateTag -> FaultTolerant
+        _ -> FailEarly
     )
     (sing @tag)
     qusr
@@ -689,6 +696,11 @@ addMembersToLocalConversation lcnv users role = do
   let action = ConversationJoin neUsers role
   pure (bmFromMembers lmems rmems, action)
 
+data FederationFailEarly
+  = FailEarly
+  | FaultTolerant
+  deriving (Eq, Show)
+
 notifyConversationAction ::
   forall tag r.
   ( Member FederatorAccess r,
@@ -697,7 +709,7 @@ notifyConversationAction ::
     Member (Input UTCTime) r,
     Member (Logger (Log.Msg -> Log.Msg)) r
   ) =>
-  Bool ->
+  FederationFailEarly ->
   Sing tag ->
   Qualified UserId ->
   Bool ->
@@ -769,7 +781,9 @@ notifyConversationAction failEarly tag quid notifyOrigDomain con lconv targets a
             "An error occurred while communicating with federated server: "
         pure update
 
-  update <- if failEarly then errorIntolerant else errorTolerant
+  update <- case failEarly of
+    FailEarly -> errorIntolerant
+    FaultTolerant -> errorTolerant
 
   -- notify local participants and bots
   pushConversationEvent con e (qualifyAs lcnv (bmLocals targets)) (bmBots targets)
@@ -856,7 +870,7 @@ kickMember qusr lconv targets victim = void . runError @NoChanges $ do
       lconv
       ()
   notifyConversationAction
-    False
+    FaultTolerant
     (sing @'ConversationRemoveMembersTag)
     qusr
     True

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -372,7 +372,7 @@ leaveConversation requestingDomain lc = do
       let botsAndMembers = BotsAndMembers mempty (Set.fromList remotes) mempty
       _ <-
         notifyConversationAction
-          False
+          FaultTolerant
           SConversationLeaveTag
           (tUntagged leaver)
           False
@@ -500,7 +500,7 @@ onUserDeleted origDomain udcn = do
               removeUser (qualifyAs lc conv) (tUntagged deletedUser)
               void $
                 notifyConversationAction
-                  False
+                  FaultTolerant
                   (sing @'ConversationLeaveTag)
                   untaggedDeletedUser
                   False

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -766,7 +766,7 @@ joinConversation lusr zcon conv access = do
       addMembersToLocalConversation lcnv (UserList users []) roleNameWireMember
     lcuEvent
       <$> notifyConversationAction
-        False
+        FaultTolerant
         (sing @'ConversationJoinTag)
         (tUntagged lusr)
         False

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -21,6 +21,7 @@ module API.Federation where
 import API.Util
 import Bilge hiding (head)
 import Bilge.Assert
+import Control.Exception
 import Control.Lens hiding ((#))
 import qualified Data.Aeson as A
 import Data.ByteString.Conversion (toByteString')
@@ -42,6 +43,7 @@ import Data.Timeout (TimeoutUnit (..), (#))
 import Data.UUID.V4 (nextRandom)
 import Federator.MockServer
 import Imports
+import qualified Network.HTTP.Types as Http
 import Test.QuickCheck (arbitrary, generate)
 import Test.Tasty
 import qualified Test.Tasty.Cannon as WS
@@ -86,7 +88,11 @@ tests s =
       test s "POST /federation/on-message-sent : Receive a message from another backend" onMessageSent,
       test s "POST /federation/send-message : Post a message sent from another backend" sendMessage,
       test s "POST /federation/on-user-deleted-conversations : Remove deleted remote user from local conversations" onUserDeleted,
-      test s "POST /federation/update-conversation : Update local conversation by a remote admin " updateConversationByRemoteAdmin
+      test s "POST /federation/update-conversation : Update local conversation by a remote admin " updateConversationByRemoteAdmin,
+      test s "POST /federation/on-conversation-updated : Notify local user about conversation rename with an unavailable federator" notifyConvRenameUnavailable,
+      test s "POST /federation/on-conversation-updated : Notify local user about message timer update with an unavailable federator" notifyMessageTimerUnavailable,
+      test s "POST /federation/on-conversation-updated : Notify local user about receipt mode update with an unavailable federator" notifyReceiptModeUnavailable,
+      test s "POST /federation/on-conversation-updated : Notify local user about access update with an unavailable federator" notifyAccessUnavailable
     ]
 
 getConversationsAllFound :: TestM ()
@@ -473,6 +479,50 @@ notifyUpdate extras action etype edata = do
         evtData e @?= edata
       WS.assertNoEvent (1 # Second) [wsC]
 
+notifyUpdateUnavailable :: [Qualified UserId] -> SomeConversationAction -> EventType -> EventData -> TestM ()
+notifyUpdateUnavailable extras action etype edata = do
+  c <- view tsCannon
+  qalice <- randomQualifiedUser
+  let alice = qUnqualified qalice
+  bob <- randomId
+  charlie <- randomUser
+  conv <- randomId
+  let bdom = Domain "bob.example.com"
+      qbob = Qualified bob bdom
+      qconv = Qualified conv bdom
+      mkMember quid = OtherMember quid Nothing roleNameWireMember
+  fedGalleyClient <- view tsFedGalleyClient
+
+  connectWithRemoteUser alice qbob
+  registerRemoteConv
+    qconv
+    bob
+    (Just "gossip")
+    (Set.fromList (map mkMember (qalice : extras)))
+
+  now <- liftIO getCurrentTime
+  let cu =
+        FedGalley.ConversationUpdate
+          { FedGalley.cuTime = now,
+            FedGalley.cuOrigUserId = qbob,
+            FedGalley.cuConvId = conv,
+            FedGalley.cuAlreadyPresentUsers = [alice, charlie],
+            FedGalley.cuAction = action
+          }
+  WS.bracketR2 c alice charlie $ \(wsA, wsC) -> do
+    ((), _fedRequests) <-
+      withTempMockFederator' (throw $ MockErrorResponse Http.status500 "Down for maintenance") $
+        runFedClient @"on-conversation-updated" fedGalleyClient bdom cu
+    liftIO $ do
+      WS.assertMatch_ (5 # Second) wsA $ \n -> do
+        let e = List1.head (WS.unpackPayload n)
+        ntfTransient n @?= False
+        evtConv e @?= qconv
+        evtType e @?= etype
+        evtFrom e @?= qbob
+        evtData e @?= edata
+      WS.assertNoEvent (1 # Second) [wsC]
+
 notifyConvRename :: TestM ()
 notifyConvRename = do
   let d = ConversationRename "gossip++"
@@ -500,6 +550,38 @@ notifyAccess :: TestM ()
 notifyAccess = do
   let d = ConversationAccessData (Set.fromList [InviteAccess, LinkAccess]) (Set.fromList [TeamMemberAccessRole])
   notifyUpdate
+    []
+    (SomeConversationAction (sing @'ConversationAccessDataTag) d)
+    ConvAccessUpdate
+    (EdConvAccessUpdate d)
+
+notifyConvRenameUnavailable :: TestM ()
+notifyConvRenameUnavailable = do
+  let d = ConversationRename "gossip++"
+  notifyUpdateUnavailable [] (SomeConversationAction (sing @'ConversationRenameTag) d) ConvRename (EdConvRename d)
+
+notifyMessageTimerUnavailable :: TestM ()
+notifyMessageTimerUnavailable = do
+  let d = ConversationMessageTimerUpdate (Just 5000)
+  notifyUpdateUnavailable
+    []
+    (SomeConversationAction (sing @'ConversationMessageTimerUpdateTag) d)
+    ConvMessageTimerUpdate
+    (EdConvMessageTimerUpdate d)
+
+notifyReceiptModeUnavailable :: TestM ()
+notifyReceiptModeUnavailable = do
+  let d = ConversationReceiptModeUpdate (ReceiptMode 42)
+  notifyUpdateUnavailable
+    []
+    (SomeConversationAction (sing @'ConversationReceiptModeUpdateTag) d)
+    ConvReceiptModeUpdate
+    (EdConvReceiptModeUpdate d)
+
+notifyAccessUnavailable :: TestM ()
+notifyAccessUnavailable = do
+  let d = ConversationAccessData (Set.fromList [InviteAccess, LinkAccess]) (Set.fromList [TeamMemberAccessRole])
+  notifyUpdateUnavailable
     []
     (SomeConversationAction (sing @'ConversationAccessDataTag) d)
     ConvAccessUpdate

--- a/services/galley/test/integration/API/Roles.hs
+++ b/services/galley/test/integration/API/Roles.hs
@@ -20,6 +20,7 @@ module API.Roles where
 import API.Util
 import Bilge hiding (timeout)
 import Bilge.Assert
+import Control.Exception
 import Control.Lens (view)
 import Data.Aeson hiding (json)
 import Data.ByteString.Conversion (toByteString')
@@ -32,6 +33,7 @@ import qualified Data.Set as Set
 import Data.Singletons
 import Federator.MockServer
 import Imports
+import qualified Network.HTTP.Types as Http
 import Network.Wai.Utilities.Error
 import Test.Tasty
 import Test.Tasty.Cannon (TimeoutUnit (..), (#))
@@ -54,6 +56,7 @@ tests s =
     [ test s "conversation roles admin (and downgrade)" handleConversationRoleAdmin,
       test s "conversation roles member (and upgrade)" handleConversationRoleMember,
       test s "conversation role update with remote users present" roleUpdateWithRemotes,
+      test s "conversation role update with remote users present remotes unavailable" roleUpdateWithRemotesUnavailable,
       test s "conversation access update with remote users present" accessUpdateWithRemotes,
       test s "conversation role update of remote member" roleUpdateRemoteMember,
       test s "get all conversation roles" testAllConversationRoles,
@@ -247,6 +250,65 @@ roleUpdateWithRemotes = do
   WS.bracketR2 c bob charlie $ \(wsB, wsC) -> do
     (_, requests) <-
       withTempMockFederator' (mockReply ()) $
+        putOtherMemberQualified
+          bob
+          qcharlie
+          (OtherMemberUpdate (Just roleNameWireAdmin))
+          qconv
+          !!! const 200 === statusCode
+
+    req <- assertOne requests
+    let mu =
+          MemberUpdateData
+            { misTarget = qcharlie,
+              misOtrMutedStatus = Nothing,
+              misOtrMutedRef = Nothing,
+              misOtrArchived = Nothing,
+              misOtrArchivedRef = Nothing,
+              misHidden = Nothing,
+              misHiddenRef = Nothing,
+              misConvRoleName = Just roleNameWireAdmin
+            }
+    liftIO $ do
+      frTargetDomain req @?= remoteDomain
+      frComponent req @?= Galley
+      frRPC req @?= "on-conversation-updated"
+      Right cu <- pure . eitherDecode . frBody $ req
+      F.cuConvId cu @?= qUnqualified qconv
+      F.cuAction cu
+        @?= SomeConversationAction (sing @'ConversationMemberUpdateTag) (ConversationMemberUpdate qcharlie (OtherMemberUpdate (Just roleNameWireAdmin)))
+      F.cuAlreadyPresentUsers cu @?= [qUnqualified qalice]
+
+    liftIO . WS.assertMatchN_ (5 # Second) [wsB, wsC] $ \n -> do
+      let e = List1.head (WS.unpackPayload n)
+      ntfTransient n @?= False
+      evtConv e @?= qconv
+      evtType e @?= MemberStateUpdate
+      evtFrom e @?= qbob
+      evtData e @?= EdMemberUpdate mu
+
+roleUpdateWithRemotesUnavailable :: TestM ()
+roleUpdateWithRemotesUnavailable = do
+  c <- view tsCannon
+  let remoteDomain = Domain "alice.example.com"
+  qalice <- Qualified <$> randomId <*> pure remoteDomain
+  qbob <- randomQualifiedUser
+  qcharlie <- randomQualifiedUser
+  let bob = qUnqualified qbob
+      charlie = qUnqualified qcharlie
+
+  connectUsers bob (singleton charlie)
+  connectWithRemoteUser bob qalice
+  resp <-
+    postConvWithRemoteUsers
+      bob
+      Nothing
+      defNewProteusConv {newConvQualifiedUsers = [qalice, qcharlie]}
+  let qconv = decodeQualifiedConvId resp
+
+  WS.bracketR2 c bob charlie $ \(wsB, wsC) -> do
+    (_, requests) <-
+      withTempMockFederator' (throw $ MockErrorResponse Http.status503 "Down for maintenance") $
         putOtherMemberQualified
           bob
           qcharlie


### PR DESCRIPTION
This just merges PR #3229 from `develop` into `mls`.

---------

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
