### PR TITLE
Port MLS test framework to new integration suite

### DIFF
--- a/changelog.d/5-internal/mls-tests
+++ b/changelog.d/5-internal/mls-tests
@@ -1,0 +1,1 @@
+Move some MLS tests to new integration suite


### PR DESCRIPTION
This PR moves some of galley's MLS tests to the new integration suite.

Based on the work [here](https://github.com/wireapp/wire-server/pull/3288).

https://wearezeta.atlassian.net/browse/FS-1937

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
