### PR TITLE
Port MLS test framework to new integration suite

### DIFF
--- a/changelog.d/5-internal/mls-integration
+++ b/changelog.d/5-internal/mls-integration
@@ -1,0 +1,1 @@
+Port MLS test framework to new integration suite

--- a/integration/default.nix
+++ b/integration/default.nix
@@ -8,6 +8,7 @@
 , array
 , async
 , base
+, base64-bytestring
 , bytestring
 , bytestring-conversion
 , Cabal
@@ -18,8 +19,10 @@
 , exceptions
 , filepath
 , gitignoreSource
+, hex
 , http-client
 , http-types
+, kan-extensions
 , lib
 , mtl
 , network
@@ -34,10 +37,13 @@
 , stm
 , string-conversions
 , tagged
+, temporary
 , text
 , time
 , transformers
+, unix
 , unliftio
+, uuid
 , websockets
 , yaml
 }:
@@ -54,6 +60,7 @@ mkDerivation {
     array
     async
     base
+    base64-bytestring
     bytestring
     bytestring-conversion
     case-insensitive
@@ -62,8 +69,10 @@ mkDerivation {
     directory
     exceptions
     filepath
+    hex
     http-client
     http-types
+    kan-extensions
     mtl
     network
     network-uri
@@ -77,10 +86,13 @@ mkDerivation {
     stm
     string-conversions
     tagged
+    temporary
     text
     time
     transformers
+    unix
     unliftio
+    uuid
     websockets
     yaml
   ];

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -140,6 +140,7 @@ library
     , text
     , time
     , transformers
+    , unix
     , unliftio
     , uuid
     , websockets

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -84,6 +84,7 @@ library
     API.Common
     API.Galley
     API.GalleyInternal
+    MLS.Util
     RunAllTests
     SetupHelpers
     Test.B2B
@@ -109,6 +110,7 @@ library
     , array
     , async
     , base
+    , base64-bytestring
     , bytestring
     , bytestring-conversion
     , case-insensitive
@@ -117,8 +119,10 @@ library
     , directory
     , exceptions
     , filepath
+    , hex
     , http-client
     , http-types
+    , kan-extensions
     , mtl
     , network
     , network-uri
@@ -132,9 +136,11 @@ library
     , stm
     , string-conversions
     , tagged
+    , temporary
     , text
     , time
     , transformers
     , unliftio
+    , uuid
     , websockets
     , yaml

--- a/integration/test/API/Brig.hs
+++ b/integration/test/API/Brig.hs
@@ -78,15 +78,16 @@ updateClient ::
 updateClient cid args = do
   uid <- objId cid
   req <- baseRequest cid Brig Versioned $ "/clients/" <> cid.client
-  submit "PUT" . zUser uid $
-    addJSONObject
-      ( ["prekeys" .= args.prekeys]
-          <> ["lastkey" .= k | k <- toList args.lastPrekey]
-          <> ["label" .= l | l <- toList args.label]
-          <> ["capabilities" .= c | c <- toList args.capabilities]
-          <> ["mls_public_keys" .= k | k <- toList args.mlsPublicKeys]
-      )
-      req
+  submit "PUT" $
+    req
+      & zUser uid
+      & addJSONObject
+        ( ["prekeys" .= args.prekeys]
+            <> ["lastkey" .= k | k <- toList args.lastPrekey]
+            <> ["label" .= l | l <- toList args.label]
+            <> ["capabilities" .= c | c <- toList args.capabilities]
+            <> ["mls_public_keys" .= k | k <- toList args.mlsPublicKeys]
+        )
 
 deleteClient ::
   (HasCallStack, MakesValue user, MakesValue client) =>

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -140,6 +140,12 @@ getSubConversation user conv sub = do
         ]
   submit "GET" $ req & zUser uid
 
+getSelfConversation :: (HasCallStack, MakesValue user) => user -> App Response
+getSelfConversation user = do
+  uid <- objId user
+  req <- baseRequest user Galley Versioned "/conversations/mls-self"
+  submit "GET" $ req & zUser uid & zConnection "conn"
+
 data ListConversationIds = ListConversationIds {pagingState :: Maybe String, size :: Maybe Int}
 
 instance Default ListConversationIds where

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -117,6 +117,29 @@ getConversation user qcnv = do
         & zUser uid
     )
 
+getSubConversation ::
+  ( HasCallStack,
+    MakesValue user,
+    MakesValue conv
+  ) =>
+  user ->
+  conv ->
+  String ->
+  App Response
+getSubConversation user conv sub = do
+  uid <- objId user
+  (cnvDomain, cnvId) <- objQid conv
+  req <-
+    baseRequest user Galley Versioned $
+      joinHttpPath
+        [ "conversations",
+          cnvDomain,
+          cnvId,
+          "subconversations",
+          sub
+        ]
+  submit "GET" $ req & zUser uid
+
 data ListConversationIds = ListConversationIds {pagingState :: Maybe String, size :: Maybe Int}
 
 instance Default ListConversationIds where

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -179,3 +179,18 @@ postMLSCommitBundle cid msg = do
   uid <- objId cid
   c <- cid %. "client_id" & asString
   submit "POST" (addMLS msg req & zUser uid & zClient c & zConnection "conn")
+
+getGroupInfo ::
+  (HasCallStack, MakesValue user, MakesValue conv) =>
+  user ->
+  conv ->
+  App Response
+getGroupInfo user conv = do
+  (qcnv, mSub) <- objSubConv conv
+  (convDomain, convId) <- objQid qcnv
+  let path = joinHttpPath $ case mSub of
+        Nothing -> ["conversations", convDomain, convId, "groupinfo"]
+        Just sub -> ["conversations", convDomain, convId, "subconversations", sub, "groupinfo"]
+  req <- baseRequest user Galley Versioned path
+  uid <- objId user
+  submit "GET" (req & zUser uid & zConnection "conn")

--- a/integration/test/MLS/Util.hs
+++ b/integration/test/MLS/Util.hs
@@ -1,0 +1,437 @@
+{-# OPTIONS_GHC -Wno-ambiguous-fields #-}
+
+module MLS.Util where
+
+import API.Brig
+import API.Galley
+import Control.Concurrent.Async hiding (link)
+import Control.Monad
+import Control.Monad.IO.Class
+import Data.Aeson (Value, object)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Char8 as B8
+import Data.Default
+import Data.Foldable
+import Data.Function
+import Data.Hex
+import qualified Data.Map as Map
+import Data.Maybe
+import qualified Data.Set as Set
+import qualified Data.Text.Encoding as T
+import Data.Traversable
+import qualified Data.UUID as UUID
+import qualified Data.UUID.V4 as UUIDV4
+import GHC.Stack
+import System.Directory
+import System.Exit
+import System.FilePath
+import System.IO
+import System.IO.Temp
+import System.Process
+import Testlib.App
+import Testlib.Assertions
+import Testlib.Env
+import Testlib.HTTP
+import Testlib.JSON
+import Testlib.Types
+
+mkClientIdentity :: (MakesValue u, MakesValue c) => u -> c -> App ClientIdentity
+mkClientIdentity u c = do
+  (domain, user) <- objQid u
+  client <- c %. "id" & asString
+  pure $ ClientIdentity {domain = domain, user = user, client = client}
+
+cid2Str :: ClientIdentity -> String
+cid2Str cid = cid.user <> ":" <> cid.client <> "@" <> cid.domain
+
+data MessagePackage = MessagePackage
+  { sender :: ClientIdentity,
+    message :: ByteString,
+    welcome :: Maybe ByteString,
+    groupInfo :: Maybe ByteString
+  }
+
+getConvId :: App String
+getConvId = do
+  mls <- getMLSState
+  maybe (assertFailure "Uninitialised test conversation") pure mls.convId
+
+toRandomFile :: ByteString -> App FilePath
+toRandomFile bs = do
+  p <- randomFileName
+  liftIO $ BS.writeFile p bs
+  pure p
+
+randomFileName :: App FilePath
+randomFileName = do
+  bd <- getBaseDir
+  (bd </>) . UUID.toString <$> liftIO UUIDV4.nextRandom
+
+mlscli :: HasCallStack => ClientIdentity -> [String] -> Maybe ByteString -> App ByteString
+mlscli qcid args mbstdin = do
+  bd <- getBaseDir
+  let cdir = bd </> cid2Str qcid
+
+  groupOut <- randomFileName
+  let substOut = argSubst "<group-out>" groupOut
+
+  hasState <- hasClientGroupState qcid
+  substIn <-
+    if hasState
+      then do
+        gs <- getClientGroupState qcid
+        fn <- toRandomFile gs
+        pure (argSubst "<group-in>" fn)
+      else pure id
+
+  out <-
+    spawn
+      ( proc
+          "mls-test-cli"
+          ( ["--store", cdir </> "store"]
+              <> map (substIn . substOut) args
+          )
+      )
+      mbstdin
+
+  groupOutWritten <- liftIO $ doesFileExist groupOut
+  when groupOutWritten $ do
+    gs <- liftIO (BS.readFile groupOut)
+    setClientGroupState qcid gs
+  pure out
+
+argSubst :: String -> String -> String -> String
+argSubst from to_ s =
+  if s == from then to_ else s
+
+createWireClient :: (MakesValue u, HasCallStack) => u -> App ClientIdentity
+createWireClient u = do
+  lpk <- getLastPrekey
+  c <- addClient u def {lastPrekey = Just lpk}
+  mkClientIdentity u c
+
+initMLSClient :: HasCallStack => ClientIdentity -> App ()
+initMLSClient cid = do
+  bd <- getBaseDir
+  liftIO $ createDirectory (bd </> cid2Str cid)
+  void $ mlscli cid ["init", cid2Str cid] Nothing
+
+-- | Create new mls client and register with backend.
+createMLSClient :: (MakesValue u, HasCallStack) => u -> App ClientIdentity
+createMLSClient u = do
+  cid <- createWireClient u
+  initMLSClient cid
+
+  -- set public key
+  pkey <- mlscli cid ["public-key"] Nothing
+  bindResponse
+    ( updateClient
+        cid
+        def
+          { mlsPublicKeys =
+              Just (object ["ed25519" .= T.decodeUtf8 (Base64.encode pkey)])
+          }
+    )
+    $ \resp -> resp.status `shouldMatchInt` 200
+  pure cid
+
+-- | create and upload to backend
+uploadNewKeyPackage :: HasCallStack => ClientIdentity -> App String
+uploadNewKeyPackage cid = do
+  (kp, ref) <- generateKeyPackage cid
+
+  -- upload key package
+  bindResponse (uploadKeyPackage cid kp) $ \resp ->
+    resp.status `shouldMatchInt` 201
+
+  pure ref
+
+generateKeyPackage :: HasCallStack => ClientIdentity -> App (ByteString, String)
+generateKeyPackage cid = do
+  kp <- mlscli cid ["key-package", "create"] Nothing
+  ref <- B8.unpack . hex <$> mlscli cid ["key-package", "ref", "-"] (Just kp)
+  fp <- keyPackageFile cid ref
+  liftIO $ BS.writeFile fp kp
+  pure (kp, ref)
+
+groupFileLink :: HasCallStack => ClientIdentity -> App FilePath
+groupFileLink cid = do
+  bd <- getBaseDir
+  pure $ bd </> cid2Str cid </> "group.latest"
+
+currentGroupFile :: HasCallStack => ClientIdentity -> App FilePath
+currentGroupFile = liftIO . getSymbolicLinkTarget <=< groupFileLink
+
+parseGroupFileName :: FilePath -> App (FilePath, Int)
+parseGroupFileName fp = do
+  let base = takeFileName fp
+  (prefix, version) <- case break (== '.') base of
+    (p, '.' : v) -> pure (p, v)
+    _ -> assertFailure "invalid group file name"
+  n <- case reads version of
+    [(v, "")] -> pure (v :: Int)
+    _ -> assertFailure "could not parse group file version"
+  pure $ (prefix, n)
+
+-- sets symlink and creates empty file
+nextGroupFile :: HasCallStack => ClientIdentity -> App FilePath
+nextGroupFile qcid = do
+  bd <- getBaseDir
+  link <- groupFileLink qcid
+  exists <- liftIO $ doesFileExist link
+  base' <-
+    if exists
+      then -- group file exists, bump version and update link
+      do
+        (prefix, n) <- parseGroupFileName =<< liftIO (getSymbolicLinkTarget link)
+        liftIO $ removeFile link
+        pure $ prefix <> "." <> show (n + 1)
+      else -- group file does not exist yet, point link to version 0
+        pure "group.0"
+
+  let groupFile = bd </> cid2Str qcid </> base'
+  liftIO $ createFileLink groupFile link
+  pure groupFile
+
+-- | Create conversation and corresponding group.
+setupMLSGroup :: HasCallStack => ClientIdentity -> App (String, Value)
+setupMLSGroup cid = do
+  conv <- bindResponse (postConversation cid (Just cid.client) defMLS) $ \resp -> do
+    resp.status `shouldMatchInt` 201
+    pure resp.json
+  groupId <- conv %. "group_id" & asString
+  convId <- conv %. "qualified_id"
+  createGroup cid groupId
+  pure (groupId, convId)
+
+createGroup :: ClientIdentity -> String -> App ()
+createGroup cid gid = do
+  mls <- getMLSState
+  case mls.groupId of
+    Just _ -> assertFailure "only one group can be created"
+    Nothing -> pure ()
+
+  groupJSON <- mlscli cid ["group", "create", gid] Nothing
+  g <- nextGroupFile cid
+  liftIO $ BS.writeFile g groupJSON
+  setMLSState $
+    mls
+      { groupId = Just gid,
+        members = Set.singleton cid
+      }
+
+keyPackageFile :: HasCallStack => ClientIdentity -> String -> App FilePath
+keyPackageFile cid ref = do
+  bd <- getBaseDir
+  pure $ bd </> cid2Str cid </> ref
+
+bundleKeyPackages :: Value -> App [(ClientIdentity, FilePath)]
+bundleKeyPackages bundle = do
+  let entryIdentity be = do
+        d <- be %. "domain" & asString
+        u <- be %. "user" & asString
+        c <- be %. "client" & asString
+        pure $ ClientIdentity {domain = d, user = u, client = c}
+
+  bundleEntries <- bundle %. "key_packages" & asList
+  for bundleEntries $ \be -> do
+    kp64 <- be %. "key_package" & asString
+    kp <- assertOne . toList . Base64.decode . B8.pack $ kp64
+    ref <-
+      fmap (B8.unpack . hex . Base64.decodeLenient . B8.pack) $
+        be %. "key_package_ref" & asString
+    cid <- entryIdentity be
+    fn <- keyPackageFile cid ref
+    liftIO $ BS.writeFile fn kp
+    pure (cid, fn)
+
+-- | Claim keypackages and create a commit/welcome pair on a given client.
+-- Note that this alters the state of the group immediately. If we want to test
+-- a scenario where the commit is rejected by the backend, we can restore the
+-- group to the previous state by using an older version of the group file.
+createAddCommit :: HasCallStack => ClientIdentity -> [Value] -> App MessagePackage
+createAddCommit cid users = do
+  kps <- fmap concat . for users $ \user -> do
+    bundle <- bindResponse (claimKeyPackages cid user) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      resp.json
+    bundleKeyPackages bundle
+  createAddCommitWithKeyPackages cid kps
+
+createAddCommitWithKeyPackages ::
+  ClientIdentity ->
+  [(ClientIdentity, FilePath)] ->
+  App MessagePackage
+createAddCommitWithKeyPackages qcid clientsAndKeyPackages = do
+  bd <- getBaseDir
+  g <- currentGroupFile qcid
+  gNew <- nextGroupFile qcid
+  welcomeFile <- liftIO $ emptyTempFile bd "welcome"
+  giFile <- liftIO $ emptyTempFile bd "pgs"
+  commit <-
+    mlscli
+      qcid
+      ( [ "member",
+          "add",
+          "--group",
+          g,
+          "--welcome-out",
+          welcomeFile,
+          "--group-info-out",
+          giFile,
+          "--group-out",
+          gNew
+        ]
+          <> map snd clientsAndKeyPackages
+      )
+      Nothing
+
+  modifyMLSState $ \mls ->
+    mls
+      { newMembers = Set.fromList (map fst clientsAndKeyPackages)
+      }
+
+  welcome <- liftIO $ BS.readFile welcomeFile
+  gi <- liftIO $ BS.readFile giFile
+  pure $
+    MessagePackage
+      { sender = qcid,
+        message = commit,
+        welcome = Just welcome,
+        groupInfo = Just gi
+      }
+
+createAddProposalWithKeyPackage ::
+  ClientIdentity ->
+  (ClientIdentity, FilePath) ->
+  App MessagePackage
+createAddProposalWithKeyPackage cid (_, kp) = do
+  g <- currentGroupFile cid
+  gNew <- nextGroupFile cid
+  prop <-
+    mlscli
+      cid
+      ["proposal", "--group-in", g, "--group-out", gNew, "add", kp]
+      Nothing
+  pure
+    MessagePackage
+      { sender = cid,
+        message = prop,
+        welcome = Nothing,
+        groupInfo = Nothing
+      }
+
+-- | Make all member clients consume a given message.
+consumeMessage :: HasCallStack => MessagePackage -> App ()
+consumeMessage msg = do
+  mls <- getMLSState
+  for_ (Set.delete msg.sender mls.members) $ \cid ->
+    consumeMessage1 cid msg.message
+
+consumeMessage1 :: HasCallStack => ClientIdentity -> ByteString -> App ()
+consumeMessage1 cid msg = do
+  bd <- getBaseDir
+  g <- currentGroupFile cid
+  gNew <- nextGroupFile cid
+  void $
+    mlscli
+      cid
+      [ "consume",
+        "--group",
+        g,
+        "--group-out",
+        gNew,
+        "--signer-key",
+        bd </> "removal.key",
+        "-"
+      ]
+      (Just msg)
+
+-- | Send an MLS message and simulate clients receiving it. If the message is a
+-- commit, the 'sendAndConsumeCommit' function should be used instead.
+sendAndConsumeMessage :: HasCallStack => MessagePackage -> App Value
+sendAndConsumeMessage mp = do
+  r <- bindResponse (postMLSMessage mp.sender mp.message) $ \resp -> do
+    resp.status `shouldMatchInt` 201
+    resp.json
+  consumeMessage mp
+  pure r
+
+-- | Send an MLS commit bundle, simulate clients receiving it, and update the
+-- test state accordingly.
+sendAndConsumeCommitBundle :: HasCallStack => MessagePackage -> App Value
+sendAndConsumeCommitBundle mp = do
+  resp <- bindResponse (postMLSCommitBundle mp.sender (mkBundle mp)) $ \resp -> do
+    resp.status `shouldMatchInt` 201
+    resp.json
+  consumeMessage mp
+  traverse_ consumeWelcome mp.welcome
+
+  -- increment epoch and add new clients
+  modifyMLSState $ \mls ->
+    mls
+      { epoch = epoch mls + 1,
+        members = members mls <> newMembers mls,
+        newMembers = mempty
+      }
+
+  pure resp
+
+consumeWelcome :: HasCallStack => ByteString -> App ()
+consumeWelcome welcome = do
+  mls <- getMLSState
+  for_ mls.newMembers $ \cid -> do
+    hasState <- hasClientGroupState cid
+    assertBool "Existing clients in a conversation should not consume welcomes" (not hasState)
+    void $
+      mlscli
+        cid
+        [ "group",
+          "from-welcome",
+          "--group-out",
+          "<group-out>",
+          "-"
+        ]
+        (Just welcome)
+
+mkBundle :: MessagePackage -> ByteString
+mkBundle mp = mp.message <> foldMap mkGroupInfoMessage mp.groupInfo <> fold mp.welcome
+
+mkGroupInfoMessage :: ByteString -> ByteString
+mkGroupInfoMessage gi = BS.pack [0x00, 0x01, 0x00, 0x04] <> gi
+
+spawn :: HasCallStack => CreateProcess -> Maybe ByteString -> App ByteString
+spawn cp minput = do
+  (mout, ex) <- liftIO
+    $ withCreateProcess
+      cp
+        { std_out = CreatePipe,
+          std_in = if isJust minput then CreatePipe else Inherit
+        }
+    $ \minh mouth _ ph ->
+      let writeInput = for_ ((,) <$> minput <*> minh) $ \(input, inh) ->
+            BS.hPutStr inh input >> hClose inh
+          readOutput = (,) <$> traverse BS.hGetContents mouth <*> waitForProcess ph
+       in snd <$> concurrently writeInput readOutput
+  case (mout, ex) of
+    (Just out, ExitSuccess) -> pure out
+    _ -> assertFailure "Failed spawning process"
+
+hasClientGroupState :: HasCallStack => ClientIdentity -> App Bool
+hasClientGroupState cid = do
+  mls <- getMLSState
+  pure $ Map.member cid mls.clientGroupState
+
+getClientGroupState :: HasCallStack => ClientIdentity -> App ByteString
+getClientGroupState cid = do
+  mls <- getMLSState
+  case Map.lookup cid mls.clientGroupState of
+    Nothing -> assertFailure ("Attempted to get non-existing group state for client " <> cid2Str cid)
+    Just g -> pure g
+
+setClientGroupState :: HasCallStack => ClientIdentity -> ByteString -> App ()
+setClientGroupState cid g =
+  modifyMLSState $ \s ->
+    s {clientGroupState = Map.insert cid g (clientGroupState s)}

--- a/integration/test/Testlib/Assertions.hs
+++ b/integration/test/Testlib/Assertions.hs
@@ -62,7 +62,12 @@ a `shouldNotMatch` b = do
   unless (jsonType xa == jsonType xb) $ do
     pa <- prettyJSON xa
     pb <- prettyJSON xb
-    assertFailure $ "Compared values are not of the same type:\n" <> "Left side:\n" <> pa <> "Right side:\n" <> pb
+    assertFailure $
+      "Compared values are not of the same type:\n"
+        <> "Left side:\n"
+        <> pa
+        <> "\nRight side:\n"
+        <> pb
 
   when (xa == xb) $ do
     pa <- prettyJSON xa

--- a/integration/test/Testlib/Assertions.hs
+++ b/integration/test/Testlib/Assertions.hs
@@ -46,7 +46,7 @@ a `shouldMatch` b = do
   unless (xa == xb) $ do
     pa <- prettyJSON xa
     pb <- prettyJSON xb
-    assertFailure $ "Expected:\n" <> pb <> "\n" <> "Actual:\n" <> pa
+    assertFailure $ "Actual:\n" <> pa <> "\nExpected:\n" <> pb
 
 shouldNotMatch ::
   (MakesValue a, MakesValue b, HasCallStack) =>
@@ -102,6 +102,13 @@ printFailureDetails (AssertionFailure stack mbResponse msg) = do
       : colored red msg
       : "\n" <> s
       : toList (fmap prettyResponse mbResponse)
+
+printExceptionDetails :: SomeException -> IO String
+printExceptionDetails e = do
+  pure . unlines $
+    [ colored yellow "exception:",
+      colored red (displayException e)
+    ]
 
 prettierCallStack :: CallStack -> IO String
 prettierCallStack cstack = do

--- a/integration/test/Testlib/Cannon.hs
+++ b/integration/test/Testlib/Cannon.hs
@@ -82,10 +82,12 @@ class ToWSConnect a where
 instance {-# OVERLAPPING #-} ToWSConnect WSConnect where
   toWSConnect = pure
 
-instance {-# OVERLAPPABLE #-} (MakesValue user) => ToWSConnect user where
+instance {-# OVERLAPPABLE #-} MakesValue user => ToWSConnect user where
   toWSConnect u = do
     uid <- objId u & asString
-    pure (WSConnect uid Nothing Nothing)
+    mc <- lookupField u "client_id"
+    c <- traverse asString mc
+    pure (WSConnect uid c Nothing)
 
 instance (MakesValue user, MakesValue conn) => ToWSConnect (user, conn) where
   toWSConnect (u, c) = do
@@ -183,7 +185,7 @@ withWebSocket w k = do
   wsConnect <- toWSConnect w
   Catch.bracket (connect wsConnect) close k
 
-withWebSockets :: forall a w. (HasCallStack, (ToWSConnect w)) => [w] -> ([WebSocket] -> App a) -> App a
+withWebSockets :: forall a w. (HasCallStack, ToWSConnect w) => [w] -> ([WebSocket] -> App a) -> App a
 withWebSockets twcs k = do
   wcs <- for twcs toWSConnect
   go wcs []

--- a/integration/test/Testlib/Cannon.hs
+++ b/integration/test/Testlib/Cannon.hs
@@ -138,7 +138,7 @@ run wsConnect app = do
 
   let path =
         "/await"
-          <> ( case client wsConnect of
+          <> ( case wsConnect.client of
                  Nothing -> ""
                  Just client -> fromJust . fromByteString $ Http.queryString (Http.setQueryString [("client", Just (toByteString' client))] Http.defaultRequest)
              )

--- a/integration/test/Testlib/HTTP.hs
+++ b/integration/test/Testlib/HTTP.hs
@@ -4,6 +4,7 @@ import qualified Control.Exception as E
 import Control.Monad.Reader
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy as L
 import qualified Data.CaseInsensitive as CI
@@ -35,6 +36,15 @@ addJSON obj req =
     { HTTP.requestBody = HTTP.RequestBodyLBS (Aeson.encode obj),
       HTTP.requestHeaders =
         (fromString "Content-Type", fromString "application/json")
+          : HTTP.requestHeaders req
+    }
+
+addMLS :: ByteString -> HTTP.Request -> HTTP.Request
+addMLS bytes req =
+  req
+    { HTTP.requestBody = HTTP.RequestBodyLBS (L.fromStrict bytes),
+      HTTP.requestHeaders =
+        (fromString "Content-Type", fromString "message/mls")
           : HTTP.requestHeaders req
     }
 

--- a/integration/test/Testlib/JSON.hs
+++ b/integration/test/Testlib/JSON.hs
@@ -18,6 +18,7 @@ import qualified Data.Scientific as Sci
 import Data.String
 import qualified Data.Text as T
 import GHC.Stack
+import Testlib.Env
 import Testlib.Types
 
 -- | All library functions should use this typeclass for all untyped value
@@ -277,3 +278,12 @@ objDomain x = do
     Object _ob -> fst <$> objQid v
     String t -> pure (T.unpack t)
     other -> assertFailureWithJSON other (typeWasExpectedButGot "Object or String" other)
+
+instance MakesValue ClientIdentity where
+  make cid =
+    pure $
+      object
+        [ "domain" .= cid.domain,
+          "id" .= cid.user,
+          "client_id" .= cid.client
+        ]

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -42,10 +42,8 @@ runTest ge action = lowerCodensity $ do
   env <- mkEnv ge
   liftIO $
     (Right <$> runAppWithEnv env action)
-      `E.catches` [ E.Handler
-                      ( \(e :: AssertionFailure) -> do
-                          Left <$> printFailureDetails e
-                      ),
+      `E.catches` [ E.Handler -- AssertionFailure
+                      (fmap Left . printFailureDetails),
                     E.Handler
                       (fmap Left . printExceptionDetails)
                   ]

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -5,15 +5,20 @@ import Control.Exception as E
 import Control.Monad
 import Control.Monad.Codensity
 import Control.Monad.IO.Class
+import Control.Monad.Reader
 import Data.Foldable
+import Data.Function
 import Data.Functor
 import Data.List
 import Data.Time.Clock
 import RunAllTests
 import System.Directory
 import System.Environment
+import System.FilePath
+import Testlib.App
 import Testlib.Assertions
 import Testlib.Env
+import Testlib.JSON
 import Testlib.Options
 import Testlib.Printing
 import Testlib.Types
@@ -32,17 +37,17 @@ instance Semigroup TestReport where
 instance Monoid TestReport where
   mempty = TestReport 0 mempty
 
-runTest :: GlobalEnv -> App () -> IO (Maybe String)
+runTest :: GlobalEnv -> App a -> IO (Either String a)
 runTest ge action = lowerCodensity $ do
   env <- mkEnv ge
   liftIO $
-    (runAppWithEnv env action $> Nothing)
+    (Right <$> runAppWithEnv env action)
       `E.catches` [ E.Handler
                       ( \(e :: AssertionFailure) -> do
-                          Just <$> printFailureDetails e
+                          Left <$> printFailureDetails e
                       ),
                     E.Handler
-                      (\e -> Just <$> printExceptionDetails e)
+                      (\e -> Left <$> printExceptionDetails e)
                   ]
 
 pluralise :: Int -> String -> String
@@ -104,15 +109,27 @@ main = do
   let f = testFilter opts
       cfg = opts.configFile
 
-  env <- mkGlobalEnv cfg
+  genv0 <- mkGlobalEnv cfg
+
+  -- save removal key to a file
+  genv <- lowerCodensity $ do
+    env <- mkEnv genv0
+    liftIO . runAppWithEnv env $ do
+      config <- readServiceConfig Galley
+      relPath <- config %. "settings.mlsPrivateKeyPaths.removal.ed25519" & asString
+      path <-
+        asks (.servicesCwdBase) <&> \case
+          Nothing -> relPath
+          Just dir -> dir </> "galley" </> relPath
+      pure genv0 {gRemovalKeyPath = path}
 
   withAsync displayOutput $ \displayThread -> do
     report <- fmap mconcat $ pooledForConcurrently tests $ \(name, action) -> do
       if f name
         then do
-          (mErr, tm) <- withTime (runTest env action)
+          (mErr, tm) <- withTime (runTest genv action)
           case mErr of
-            Just err -> do
+            Left err -> do
               writeOutput $
                 "----- "
                   <> name
@@ -123,7 +140,7 @@ main = do
                   <> err
                   <> "\n"
               pure (TestReport 1 [name])
-            Nothing -> do
+            Right _ -> do
               writeOutput $ name <> colored green " OK" <> " (" <> printTime tm <> ")" <> "\n"
               pure (TestReport 1 [])
         else pure (TestReport 0 [])

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -47,7 +47,7 @@ runTest ge action = lowerCodensity $ do
                           Left <$> printFailureDetails e
                       ),
                     E.Handler
-                      (\e -> Left <$> printExceptionDetails e)
+                      (fmap Left . printExceptionDetails)
                   ]
 
 pluralise :: Int -> String -> String

--- a/integration/test/Testlib/Types.hs
+++ b/integration/test/Testlib/Types.hs
@@ -11,6 +11,8 @@ import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy as L
 import qualified Data.CaseInsensitive as CI
 import Data.Functor
+import Data.Hex
+import Data.IORef
 import Data.List
 import qualified Data.Map as Map
 import qualified Data.Text as T
@@ -64,7 +66,7 @@ prettyResponse r =
             [ colored yellow "request body:",
               T.unpack . T.decodeUtf8 $ case Aeson.decode (L.fromStrict b) of
                 Just v -> L.toStrict (Aeson.encodePretty (v :: Aeson.Value))
-                Nothing -> b
+                Nothing -> hex b
             ],
         pure $ colored blue "response status: " <> show r.status,
         pure $ colored blue "response body:",
@@ -108,6 +110,24 @@ getServiceMap fedDomain = do
   env <- ask
   assertJust ("Could not find service map for federation domain: " <> fedDomain) (Map.lookup fedDomain (env.serviceMap))
 
+getMLSState :: App MLSState
+getMLSState = do
+  ref <- asks (.mls)
+  liftIO $ readIORef ref
+
+setMLSState :: MLSState -> App ()
+setMLSState s = do
+  ref <- asks (.mls)
+  liftIO $ writeIORef ref s
+
+modifyMLSState :: (MLSState -> MLSState) -> App ()
+modifyMLSState f = do
+  ref <- asks (.mls)
+  liftIO $ modifyIORef ref f
+
+getBaseDir :: App FilePath
+getBaseDir = fmap (.baseDir) getMLSState
+
 data AppFailure = AppFailure String
 
 instance Show AppFailure where
@@ -133,7 +153,7 @@ assertJust _ (Just x) = pure x
 assertJust msg Nothing = assertFailure msg
 
 addFailureContext :: String -> App a -> App a
-addFailureContext msg = modifyFailureMsg (\m -> m <> "\nThis failure happend in this context:\n" <> msg)
+addFailureContext msg = modifyFailureMsg (\m -> m <> "\nThis failure happened in this context:\n" <> msg)
 
 modifyFailureMsg :: (String -> String) -> App a -> App a
 modifyFailureMsg modMessage = modifyFailure (\e -> e {msg = modMessage e.msg})


### PR DESCRIPTION
This PR copies and adapts the MLS test code in the galley integration suite to the new integration tests. This is necessary in order to write new MLS tests.

A copy of this PR for the MLS branch can be found [here](https://github.com/wireapp/wire-server/pull/3286).

https://wearezeta.atlassian.net/browse/FS-1937

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
