### PR TITLE
Add parametrised tests

### DIFF
--- a/changelog.d/5-internal/ptests
+++ b/changelog.d/5-internal/ptests
@@ -1,0 +1,1 @@
+Add parametrised tests

--- a/integration/Setup.hs
+++ b/integration/Setup.hs
@@ -116,7 +116,7 @@ testHooks hooks =
                   unlines (map ("import qualified " <>) modules),
                   "allTests :: [Test]",
                   "allTests =",
-                  "  " <> intercalate " <>\n  " (map (\(m, n, s, f) -> "mkTests " <> intercalate " " [show m, show n, show s, show f, m <> "." <> n]) tests)
+                  "  " <> intercalate " <>\n  " (map (\(m, n, s, f) -> "mkTests " <> unwords [show m, show n, show s, show f, m <> "." <> n]) tests)
                 ]
             )
           pure ()

--- a/integration/Setup.hs
+++ b/integration/Setup.hs
@@ -111,14 +111,12 @@ testHooks hooks =
             dest
             ( unlines
                 [ "module RunAllTests where",
-                  "import Testlib.Types",
+                  "import Testlib.PTest",
                   "import Prelude",
                   unlines (map ("import qualified " <>) modules),
-                  "allTests :: [(String, String, String, String, App ())]",
+                  "allTests :: [Test]",
                   "allTests =",
-                  "  [",
-                  "    " <> intercalate ",\n    " (map (\(m, n, s, f) -> "(" <> intercalate ", " [show m, show n, show s, show f, m <> "." <> n] <> ")") tests),
-                  "  ]"
+                  "  " <> intercalate " <>\n  " (map (\(m, n, s, f) -> "mkTests " <> intercalate " " [show m, show n, show s, show f, m <> "." <> n]) tests)
                 ]
             )
           pure ()

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -102,6 +102,7 @@ library
     Testlib.Prekeys
     Testlib.Prelude
     Testlib.Printing
+    Testlib.PTest
     Testlib.Run
     Testlib.Types
 

--- a/integration/test/Testlib/PTest.hs
+++ b/integration/test/Testlib/PTest.hs
@@ -1,0 +1,27 @@
+module Testlib.PTest where
+
+import Data.Aeson (Value (..))
+import qualified Data.Text as T
+import Testlib.App
+import Testlib.JSON
+import Testlib.Types
+import Prelude
+
+type Test = (String, String, String, String, App ())
+
+class HasTests x where
+  mkTests :: String -> String -> String -> String -> x -> [Test]
+
+instance HasTests (App ()) where
+  mkTests m n s f x = [(m, n, s, f, x)]
+
+data Domain = OwnDomain | OtherDomain
+
+instance MakesValue Domain where
+  make OwnDomain = String . T.pack <$> ownDomain
+  make OtherDomain = String . T.pack <$> otherDomain
+
+instance HasTests x => HasTests (Domain -> x) where
+  mkTests m n s f x =
+    mkTests m (n <> "[domain=own]") s f (x OwnDomain)
+      <> mkTests m (n <> "[domain=other]") s f (x OtherDomain)

--- a/integration/test/Testlib/Prelude.hs
+++ b/integration/test/Testlib/Prelude.hs
@@ -7,6 +7,7 @@ module Testlib.Prelude
     module Testlib.ModService,
     module Testlib.HTTP,
     module Testlib.JSON,
+    module Testlib.PTest,
     module Data.Aeson,
     module Prelude,
     module Control.Applicative,
@@ -117,6 +118,7 @@ import Testlib.Env
 import Testlib.HTTP
 import Testlib.JSON
 import Testlib.ModService
+import Testlib.PTest
 import Testlib.Types
 import UnliftIO.Exception
 import Prelude


### PR DESCRIPTION
Add support for parametrised tests to the integration test suite. At the moment, it only supports parametrised tests of the form `Domain -> App ()`, which are then instantiated with both domain ('own' and 'other').

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
