### PR TITLE
MLS: Remove incorrect check

### DIFF
--- a/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
@@ -90,9 +90,6 @@ processInternalCommit senderIdentity con lConvOrSub epoch action commit = do
     throwS @'MLSCommitMissingReferences
 
   withCommitLock (fmap idForConvOrSub lConvOrSub) (cnvmlsGroupId (mlsMetaConvOrSub convOrSub)) epoch $ do
-    -- FUTUREWORK: remove this check after remote admins are implemented in federation https://wearezeta.atlassian.net/browse/FS-216
-    foldQualified lConvOrSub (\_ -> pure ()) (\_ -> throwS @'MLSUnsupportedProposal) qusr
-
     -- no client can be directly added to a subconversation
     when (is _SubConv convOrSub && any ((senderIdentity /=) . fst) (cmAssocs (paAdd action))) $
       throw (mlsProtocolError "Add proposals in subconversations are not supported")


### PR DESCRIPTION
This check is incorrect because the committer can be anyone from the
conversation. If it all this check should be applied at the level of the proposal.
