### PR TITLE
FS-1959: Setup schemas and ES indices for dynamic backend tests

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -25,6 +25,7 @@ PATH_add "./.env/bin"
 path_add "PKG_CONFIG_PATH" "./.env/lib/pkgconfig"
 path_add "LIBRARY_PATH" "./.env/lib"
 path_add "PYTHONPATH" "./hack/python"
+PATH_add "./dist"
 
 # source .profile from `$env`. This sets NIX_PATH to pkgs defined in
 # ./nix/default.nix. Tis is useful for nix tooling that runs inside this direnv,
@@ -41,3 +42,6 @@ export LANG=en_US.UTF-8
 # RabbitMQ
 export RABBITMQ_USERNAME=guest
 export RABBITMQ_PASSWORD=alpaca-grapefruit
+
+# Integration tests
+export INTEGRATION_DYNAMIC_BACKENDS_POOLSIZE=3

--- a/Makefile
+++ b/Makefile
@@ -291,17 +291,10 @@ db-migrate-package:
 	@echo "Deprecated! Please use 'db-migrate' instead"
 	$(MAKE) db-migrate package=$(package)
 
-# Usage:
-#
-# Migrate all keyspaces and reset the ES index
-# make db-migrate
-#
-# Migrate keyspace for only one service, say galley:
-# make db-migrate package=galley
+# Reset all keyspaces and reset the ES index
 .PHONY: db-reset
 db-reset: c
 	@echo "Make sure you have ./deploy/dockerephemeral/run.sh running in another window!"
-ifeq ($(package), all)
 	./dist/brig-schema --keyspace brig_test --replication-factor 1 --reset
 	./dist/galley-schema --keyspace galley_test --replication-factor 1 --reset
 	./dist/gundeck-schema --keyspace gundeck_test --replication-factor 1 --reset
@@ -310,20 +303,14 @@ ifeq ($(package), all)
 	./dist/galley-schema --keyspace galley_test2 --replication-factor 1 --reset
 	./dist/gundeck-schema --keyspace gundeck_test2 --replication-factor 1 --reset
 	./dist/spar-schema --keyspace spar_test2 --replication-factor 1 --reset
-else
-	$(EXE_SCHEMA) --keyspace $(package)_test --replication-factor 1 --reset
-	$(EXE_SCHEMA) --keyspace $(package)_test2 --replication-factor 1 --reset
-endif
+	./integration/scripts/integration-dynamic-backends-db-schemas.sh --replication-factor 1 --reset
 	./dist/brig-index reset --elasticsearch-index-prefix directory --elasticsearch-server http://localhost:9200 > /dev/null
 	./dist/brig-index reset --elasticsearch-index-prefix directory2 --elasticsearch-server http://localhost:9200 > /dev/null
+	./integration/scripts/integration-dynamic-backends-brig-index.sh --elasticsearch-server http://localhost:9200 > /dev/null
 
-# Usage:
-#
+
+
 # Migrate all keyspaces and reset the ES index
-# make db-migrate
-#
-# Migrate keyspace for only one service, say galley:
-# make db-migrate package=galley
 .PHONY: db-migrate
 db-migrate: c
 	./dist/brig-schema --keyspace brig_test --replication-factor 1 > /dev/null
@@ -334,8 +321,10 @@ db-migrate: c
 	./dist/galley-schema --keyspace galley_test2 --replication-factor 1 > /dev/null
 	./dist/gundeck-schema --keyspace gundeck_test2 --replication-factor 1 > /dev/null
 	./dist/spar-schema --keyspace spar_test2 --replication-factor 1 > /dev/null
+	./integration/scripts/integration-dynamic-backends-db-schemas.sh --replication-factor 1 > /dev/null
 	./dist/brig-index reset --elasticsearch-index-prefix directory --elasticsearch-server http://localhost:9200 > /dev/null
 	./dist/brig-index reset --elasticsearch-index-prefix directory2 --elasticsearch-server http://localhost:9200 > /dev/null
+	./integration/scripts/integration-dynamic-backends-brig-index.sh --elasticsearch-server http://localhost:9200 > /dev/null
 
 #################################
 ## dependencies

--- a/charts/integration/templates/integration-integration.yaml
+++ b/charts/integration/templates/integration-integration.yaml
@@ -34,6 +34,24 @@ spec:
         name: "turn"
 
   restartPolicy: Never
+
+  initContainers:
+  - name: integration-scripts
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    env:
+    - name: INTEGRATION_DYNAMIC_BACKENDS_POOLSIZE
+      value: "{{ .Values.config.dynamicBackendsPoolsize }}"
+    command:
+      - /bin/sh
+      - -c
+      - >-
+        integration-dynamic-backends-db-schemas.sh --host {{ .Values.config.cassandra.host }} --port 9042 --replication-factor {{ .Values.config.cassandra.replicationFactor }};
+        integration-dynamic-backends-brig-index.sh --elasticsearch-server http://{{ .Values.config.elasticsearch.host }}:9200
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "2"
+
   containers:
   - name: integration
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/integration/templates/integration-integration.yaml
+++ b/charts/integration/templates/integration-integration.yaml
@@ -36,7 +36,7 @@ spec:
   restartPolicy: Never
 
   initContainers:
-  - name: integration-scripts
+  - name: integration-setup
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
     env:
     - name: INTEGRATION_DYNAMIC_BACKENDS_POOLSIZE

--- a/charts/integration/values.yaml
+++ b/charts/integration/values.yaml
@@ -1,3 +1,13 @@
 image:
   repository: quay.io/wire/integration
   tag: do-not-use
+
+config:
+  dynamicBackendsPoolsize: 3
+
+  cassandra:
+    host: cassandra-ephemeral
+    replicationFactor: 1
+
+  elasticsearch:
+    host: elasticsearch-ephemeral

--- a/integration/scripts/integration-dynamic-backends-brig-index.sh
+++ b/integration/scripts/integration-dynamic-backends-brig-index.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+# shellcheck disable=SC3040
+#
+set -eo pipefail
+
+for i in $(seq "$INTEGRATION_DYNAMIC_BACKENDS_POOLSIZE"); do
+    cmd="brig-index reset --elasticsearch-index-prefix directory_dyn_$i $*"
+    echo "$cmd"
+    $cmd
+done

--- a/integration/scripts/integration-dynamic-backends-db-schemas.sh
+++ b/integration/scripts/integration-dynamic-backends-db-schemas.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+# shellcheck disable=SC3040,SC3045,SC3057
+
+set -eo pipefail
+
+genargs() {
+    for service in brig galley gundeck spar; do
+        for i in $(seq "$INTEGRATION_DYNAMIC_BACKENDS_POOLSIZE"); do
+            echo "$service"/"$service"_test_dyn_"$i"
+        done
+    done
+}
+
+migrate_schema() {
+    cmd="$1-schema --keyspace $2 ${*:3}"
+    $cmd
+}
+
+export -f migrate_schema
+
+genargs | parallel -P 1 migrate_schema "{1//}" "{1/}" "$@"

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -202,13 +202,18 @@ let
     '';
   };
 
-  integration-scripts = pkgs.stdenvNoCC.mkDerivation {
-    name = "integration-scripts";
-    src = ../integration/scripts;
-    installPhase = ''
-      mkdir -p $out/bin
-      cp $src/* $out/bin
-    '';
+  integration-dynamic-backends-db-schemas = pkgs.writeShellApplication {
+    name = "integration-dynamic-backends-db-schemas.sh";
+    text = "${builtins.readFile ../integration/scripts/integration-dynamic-backends-db-schemas.sh}";
+    runtimeInputs = [ pkgs.parallel ];
+    checkPhase = "";
+  };
+
+  integration-dynamic-backends-brig-index = pkgs.writeShellApplication {
+    name = "integration-dynamic-backends-brig-index.sh";
+    text = "${builtins.readFile ../integration/scripts/integration-dynamic-backends-brig-index.sh}";
+    runtimeInputs = [ pkgs.parallel ];
+    checkPhase = "";
   };
 
   # Some images require extra things which is not possible to specify using
@@ -219,7 +224,7 @@ let
     brig = [ brig-templates ];
     brig-integration = [ brig-templates pkgs.mls-test-cli ];
     galley-integration = [ pkgs.mls-test-cli ];
-    integration = with exes; [ brig brig-index brig-schema cannon cargohold federator galley galley-schema gundeck gundeck-schema proxy spar spar-schema stern brig-templates integration-scripts pkgs.parallel ];
+    integration = with exes; [ brig brig-index brig-schema cannon cargohold federator galley galley-schema gundeck gundeck-schema proxy spar spar-schema stern brig-templates integration-dynamic-backends-db-schemas integration-dynamic-backends-brig-index ];
   };
 
   # useful to poke around a container during a 'kubectl exec'
@@ -368,7 +373,7 @@ let
 in
 {
 
-  inherit integration-scripts ciImage hoogleImage;
+  inherit ciImage hoogleImage;
 
   images = images localModsEnableAll;
   imagesUnoptimizedNoDocs = images localModsOnlyTests;

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -202,6 +202,15 @@ let
     '';
   };
 
+  integration-scripts = pkgs.stdenvNoCC.mkDerivation {
+    name = "integration-scripts";
+    src = ../integration/scripts;
+    installPhase = ''
+      mkdir -p $out/bin
+      cp $src/* $out/bin
+    '';
+  };
+
   # Some images require extra things which is not possible to specify using
   # cabal file dependencies, so cabal2nix cannot automatically add these.
   #
@@ -210,7 +219,7 @@ let
     brig = [ brig-templates ];
     brig-integration = [ brig-templates pkgs.mls-test-cli ];
     galley-integration = [ pkgs.mls-test-cli ];
-    integration = with exes; [ brig cannon cargohold federator galley gundeck proxy spar stern brig-templates ];
+    integration = with exes; [ brig brig-index brig-schema cannon cargohold federator galley galley-schema gundeck gundeck-schema proxy spar spar-schema stern brig-templates integration-scripts pkgs.parallel ];
   };
 
   # useful to poke around a container during a 'kubectl exec'
@@ -358,7 +367,8 @@ let
   };
 in
 {
-  inherit ciImage hoogleImage;
+
+  inherit integration-scripts ciImage hoogleImage;
 
   images = images localModsEnableAll;
   imagesUnoptimizedNoDocs = images localModsOnlyTests;


### PR DESCRIPTION
This PR sets up separate cassandra schemas and ES indices to be used by integration tests.
The number of backends can be controlled by `INTEGRATION_DYNAMIC_BACKENDS_POOLSIZE` for the local dev environment and `config.dynamicBackendsPoolsize` in the `integration` helm chart.

The db schemas will be named `brig_test_dyn_X`, `galley_test_dyn_X`, etc; the ES index is named `directory_dyn_X_test`, where `X` ranges from 1 to the poolsize.
