### PR TITLE
brig: Make RabbitMQ config optional

### DIFF
--- a/services/brig/src/Brig/Options.hs
+++ b/services/brig/src/Brig/Options.hs
@@ -442,8 +442,8 @@ data Opts = Opts
     cassandra :: !CassandraOpts,
     -- | ElasticSearch settings
     elasticsearch :: !ElasticSearchOpts,
-    -- | RabbitMQ settings
-    rabbitmq :: !RabbitMqOpts,
+    -- | RabbitMQ settings, required when federation is enabled.
+    rabbitmq :: !(Maybe RabbitMqOpts),
     -- | AWS settings
     aws :: !AWSOpts,
     -- | Enable Random Prekey Strategy


### PR DESCRIPTION
It is only required when federation is enabled.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
