### PR TITLE
Fix: Use the mls_migration_lock_status DB column when storing the MLS migration status

### DIFF
--- a/services/galley/src/Galley/Cassandra/TeamFeatures.hs
+++ b/services/galley/src/Galley/Cassandra/TeamFeatures.hs
@@ -263,7 +263,7 @@ setFeatureLockStatus FeatureSingletonSelfDeletingMessagesConfig tid status = set
 setFeatureLockStatus FeatureSingletonGuestLinksConfig tid status = setLockStatusC "guest_links_lock_status" tid status
 setFeatureLockStatus FeatureSingletonSndFactorPasswordChallengeConfig tid status = setLockStatusC "snd_factor_password_challenge_lock_status" tid status
 setFeatureLockStatus FeatureSingletonMlsE2EIdConfig tid status = setLockStatusC "mls_e2eid_lock_status" tid status
-setFeatureLockStatus FeatureSingletonMlsMigration tid status = setLockStatusC "outlook_cal_integration_lock_status" tid status
+setFeatureLockStatus FeatureSingletonMlsMigration tid status = setLockStatusC "mls_migration_lock_status" tid status
 setFeatureLockStatus FeatureSingletonOutlookCalIntegrationConfig tid status = setLockStatusC "outlook_cal_integration_lock_status" tid status
 setFeatureLockStatus _ _tid _status = pure ()
 


### PR DESCRIPTION
This was a merge mistake that is fixed now. No changelog.