### PR TITLE
Render `Named` names as "internal route ID" in swagger UI.

### DIFF
--- a/changelog.d/4-docs/pr-3319-swagger-named-names
+++ b/changelog.d/4-docs/pr-3319-swagger-named-names
@@ -1,0 +1,1 @@
+Render `Named` names as "internal route ID" in swagger UI.

--- a/docs/src/developer/developer/servant.md
+++ b/docs/src/developer/developer/servant.md
@@ -33,6 +33,21 @@ Note that error types can also be turned into `MultiVerb` responses using the `E
 
 This is a capture combinator for a path that looks like `/:domain/:value`, where `value` is of some arbitrary type `a`. The value is returned as a value of type `Qualified a`, which can then be used in federation-aware endpoints.
 
+(named-and-internal-route-ids)=
+
+## `Named`, and internal route IDs in swagger
+
+There is also a combinator `Named` that allows developers to jump back
+and forth between the swagger docs (see {ref}`swagger-api-docs`) and
+source code: from the swagger docs, copy the *internal route ID* and
+full-text-search it in `wire-server/{libs,services}`.  That will give
+you both the routing table type and the handler.
+
+Route internal IDs need to instantiate the `Renderable` class in order
+to be inserted into the swagger docs.  The instance should satisfy the
+property that the ID, as rendered can be copied and fed to grep to
+find its occurrances behind `Named`s in the source code.
+
 ## Error handling
 
 Several layers of error handling are involved when serving a request. A handler in service code (e.g. Brig or Galley) can:

--- a/docs/src/developer/developer/servant.md
+++ b/docs/src/developer/developer/servant.md
@@ -48,6 +48,10 @@ to be inserted into the swagger docs.  The instance should satisfy the
 property that the ID, as rendered can be copied and fed to grep to
 find its occurrances behind `Named`s in the source code.
 
+The initial reason to introduce `Named` was increased type safety: if
+two handlers have the same type, they can have be `Named` differently
+and thus confusing them will be caught by the type checker.
+
 ## Error handling
 
 Several layers of error handling are involved when serving a request. A handler in service code (e.g. Brig or Galley) can:

--- a/docs/src/understand/api-client-perspective/swagger.md
+++ b/docs/src/understand/api-client-perspective/swagger.md
@@ -89,3 +89,8 @@ The URL pattern is similar to that of public endpoints for latest version:
 
 If you want to get the raw json of the swagger:
 `https://<nginz-host>/api-internal/swagger-ui/<service>-swagger.json`.
+
+### Finding the source code for an end-point
+
+A *route internal ID* is provided for every end-point.  See
+{ref}`named-and-internal-route-ids` for details and usage.

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -19,7 +19,7 @@
 
 module Wire.API.Routes.Named where
 
-import Control.Lens ((?~))
+import Control.Lens ((%~))
 import Data.Kind
 import Data.Metrics.Servant
 import Data.Proxy
@@ -48,7 +48,11 @@ instance {-# OVERLAPPING #-} (RenderableSymbol a, RenderableSymbol b) => Rendera
 instance (HasSwagger api, RenderableSymbol name) => HasSwagger (Named name api) where
   toSwagger _ =
     toSwagger (Proxy @api)
-      & (info . description) ?~ ("internal route ID: " <> cs (renderSymbol @name))
+      & allOperations . summary %~ (<> Just dscr)
+      & allOperations . description %~ (Just (dscr <> "\n\n") <>)
+    where
+      dscr :: Text
+      dscr = " [internal route ID: " <> cs (renderSymbol @name) <> "]"
 
 instance HasServer api ctx => HasServer (Named name api) ctx where
   type ServerT (Named name api) m = Named name (ServerT api m)

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -25,7 +25,6 @@ import Data.Metrics.Servant
 import Data.Proxy
 import Data.String.Conversions (cs)
 import Data.Swagger
-import Data.Typeable
 import GHC.TypeLits
 import Imports
 import Servant
@@ -44,8 +43,8 @@ class RenderableSymbol a where
 instance {-# OVERLAPPABLE #-} KnownSymbol a => RenderableSymbol a where
   renderSymbol = cs $ symbolVal (Proxy @a)
 
-instance {-# OVERLAPPING #-} (RenderableSymbol a, Typeable b) => RenderableSymbol (a, b) where
-  renderSymbol = "(" <> renderSymbol @a <> ", " <> (cs . show . typeRep $ (Proxy @b)) <> ")"
+instance {-# OVERLAPPING #-} (RenderableSymbol a, RenderableSymbol b) => RenderableSymbol (a, b) where
+  renderSymbol = "(" <> (renderSymbol @a) <> ", " <> (renderSymbol @b) <> ")"
 
 instance (HasSwagger api, RenderableSymbol name) => HasSwagger (Named name api) where
   toSwagger _ =

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -23,7 +23,6 @@ import Control.Lens ((?~))
 import Data.Kind
 import Data.Metrics.Servant
 import Data.Proxy
-import Data.String.Conversions (cs)
 import Data.Swagger
 import GHC.TypeLits
 import Imports

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -42,7 +42,7 @@ class RenderableSymbol a where
 instance {-# OVERLAPPABLE #-} KnownSymbol a => RenderableSymbol a where
   renderSymbol = cs $ symbolVal (Proxy @a)
 
-instance {-# OVERLAPPING #-} (RenderableSymbol a, RenderableSymbol b) => RenderableSymbol (a, b) where
+instance {-# OVERLAPPING #-} (RenderableSymbol a, RenderableSymbol b) => RenderableSymbol '(a, b) where
   renderSymbol = "(" <> (renderSymbol @a) <> ", " <> (renderSymbol @b) <> ")"
 
 instance (HasSwagger api, RenderableSymbol name) => HasSwagger (Named name api) where

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -48,7 +48,6 @@ instance {-# OVERLAPPING #-} (RenderableSymbol a, RenderableSymbol b) => Rendera
 instance (HasSwagger api, RenderableSymbol name) => HasSwagger (Named name api) where
   toSwagger _ =
     toSwagger (Proxy @api)
-      & allOperations . summary %~ (<> Just dscr)
       & allOperations . description %~ (Just (dscr <> "\n\n") <>)
     where
       dscr :: Text

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -40,7 +40,7 @@ class RenderableSymbol a where
   renderSymbol :: Text
 
 instance {-# OVERLAPPABLE #-} KnownSymbol a => RenderableSymbol a where
-  renderSymbol = cs $ symbolVal (Proxy @a)
+  renderSymbol = cs . show $ symbolVal (Proxy @a)
 
 instance {-# OVERLAPPING #-} (RenderableSymbol a, RenderableSymbol b) => RenderableSymbol '(a, b) where
   renderSymbol = "(" <> (renderSymbol @a) <> ", " <> (renderSymbol @b) <> ")"

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -31,6 +31,7 @@ import Servant.Client
 import Servant.Client.Core (clientIn)
 import Servant.Swagger
 
+-- | See http://docs.wire.com/developer/developer/servant.html#named-and-internal-route-ids-in-swagger
 newtype Named name x = Named {unnamed :: x}
   deriving (Functor)
 
@@ -51,7 +52,10 @@ instance (HasSwagger api, RenderableSymbol name) => HasSwagger (Named name api) 
       & allOperations . description %~ (Just (dscr <> "\n\n") <>)
     where
       dscr :: Text
-      dscr = " [internal route ID: " <> cs (renderSymbol @name) <> "]"
+      dscr =
+        " [<a href=\"https://docs.wire.com/developer/developer/servant.html#named-and-internal-route-ids\">internal route ID:</a> "
+          <> cs (renderSymbol @name)
+          <> "]"
 
 instance HasServer api ctx => HasServer (Named name api) ctx where
   type ServerT (Named name api) m = Named name (ServerT api m)

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -114,6 +114,7 @@ import Test.QuickCheck.Arbitrary (arbitrary)
 import Test.QuickCheck.Gen (suchThat)
 import Wire.API.Conversation.Protocol (ProtocolTag (ProtocolProteusTag))
 import Wire.API.MLS.CipherSuite (CipherSuiteTag (MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519))
+import Wire.API.Routes.Named (RenderableSymbol (renderSymbol))
 import Wire.Arbitrary (Arbitrary, GenericUniform (..))
 
 ----------------------------------------------------------------------
@@ -567,6 +568,9 @@ data GuestLinksConfig = GuestLinksConfig
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform GuestLinksConfig)
 
+instance RenderableSymbol GuestLinksConfig where
+  renderSymbol = "GuestLinksConfig"
+
 instance ToSchema GuestLinksConfig where
   schema = object "GuestLinksConfig" objectSchema
 
@@ -587,6 +591,9 @@ data LegalholdConfig = LegalholdConfig
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform LegalholdConfig)
 
+instance RenderableSymbol LegalholdConfig where
+  renderSymbol = "LegalholdConfig"
+
 instance IsFeatureConfig LegalholdConfig where
   type FeatureSymbol LegalholdConfig = "legalhold"
   defFeatureStatus = withStatus FeatureStatusDisabled LockStatusUnlocked LegalholdConfig FeatureTTLUnlimited
@@ -605,6 +612,9 @@ instance FeatureTrivialConfig LegalholdConfig where
 data SSOConfig = SSOConfig
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform SSOConfig)
+
+instance RenderableSymbol SSOConfig where
+  renderSymbol = "SSOConfig"
 
 instance IsFeatureConfig SSOConfig where
   type FeatureSymbol SSOConfig = "sso"
@@ -626,6 +636,9 @@ instance FeatureTrivialConfig SSOConfig where
 data SearchVisibilityAvailableConfig = SearchVisibilityAvailableConfig
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform SearchVisibilityAvailableConfig)
+
+instance RenderableSymbol SearchVisibilityAvailableConfig where
+  renderSymbol = "SearchVisibilityAvailableConfig"
 
 instance IsFeatureConfig SearchVisibilityAvailableConfig where
   type FeatureSymbol SearchVisibilityAvailableConfig = "searchVisibility"
@@ -649,6 +662,9 @@ data ValidateSAMLEmailsConfig = ValidateSAMLEmailsConfig
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform ValidateSAMLEmailsConfig)
 
+instance RenderableSymbol ValidateSAMLEmailsConfig where
+  renderSymbol = "ValidateSAMLEmailsConfig"
+
 instance ToSchema ValidateSAMLEmailsConfig where
   schema = object "ValidateSAMLEmailsConfig" objectSchema
 
@@ -670,6 +686,9 @@ instance FeatureTrivialConfig ValidateSAMLEmailsConfig where
 data DigitalSignaturesConfig = DigitalSignaturesConfig
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform DigitalSignaturesConfig)
+
+instance RenderableSymbol DigitalSignaturesConfig where
+  renderSymbol = "DigitalSignaturesConfig"
 
 instance IsFeatureConfig DigitalSignaturesConfig where
   type FeatureSymbol DigitalSignaturesConfig = "digitalSignatures"
@@ -693,6 +712,9 @@ data ConferenceCallingConfig = ConferenceCallingConfig
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform ConferenceCallingConfig)
 
+instance RenderableSymbol ConferenceCallingConfig where
+  renderSymbol = "ConferenceCallingConfig"
+
 instance IsFeatureConfig ConferenceCallingConfig where
   type FeatureSymbol ConferenceCallingConfig = "conferenceCalling"
   defFeatureStatus = withStatus FeatureStatusEnabled LockStatusUnlocked ConferenceCallingConfig FeatureTTLUnlimited
@@ -711,6 +733,9 @@ instance FeatureTrivialConfig ConferenceCallingConfig where
 data SndFactorPasswordChallengeConfig = SndFactorPasswordChallengeConfig
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform SndFactorPasswordChallengeConfig)
+
+instance RenderableSymbol SndFactorPasswordChallengeConfig where
+  renderSymbol = "SndFactorPasswordChallengeConfig"
 
 instance ToSchema SndFactorPasswordChallengeConfig where
   schema = object "SndFactorPasswordChallengeConfig" objectSchema
@@ -732,6 +757,9 @@ data SearchVisibilityInboundConfig = SearchVisibilityInboundConfig
   deriving (Arbitrary) via (GenericUniform SearchVisibilityInboundConfig)
   deriving (S.ToSchema) via Schema SearchVisibilityInboundConfig
 
+instance RenderableSymbol SearchVisibilityInboundConfig where
+  renderSymbol = "SearchVisibilityInboundConfig"
+
 instance IsFeatureConfig SearchVisibilityInboundConfig where
   type FeatureSymbol SearchVisibilityInboundConfig = "searchVisibilityInbound"
   defFeatureStatus = withStatus FeatureStatusDisabled LockStatusUnlocked SearchVisibilityInboundConfig FeatureTTLUnlimited
@@ -752,6 +780,9 @@ data ClassifiedDomainsConfig = ClassifiedDomainsConfig
   }
   deriving stock (Show, Eq, Generic)
   deriving (ToJSON, FromJSON, S.ToSchema) via (Schema ClassifiedDomainsConfig)
+
+instance RenderableSymbol ClassifiedDomainsConfig where
+  renderSymbol = "ClassifiedDomainsConfig"
 
 deriving via (GenericUniform ClassifiedDomainsConfig) instance Arbitrary ClassifiedDomainsConfig
 
@@ -783,6 +814,9 @@ data AppLockConfig = AppLockConfig
   deriving stock (Eq, Show, Generic)
   deriving (FromJSON, ToJSON, S.ToSchema) via (Schema AppLockConfig)
   deriving (Arbitrary) via (GenericUniform AppLockConfig)
+
+instance RenderableSymbol AppLockConfig where
+  renderSymbol = "AppLockConfig"
 
 instance ToSchema AppLockConfig where
   schema =
@@ -818,6 +852,9 @@ data FileSharingConfig = FileSharingConfig
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform FileSharingConfig)
 
+instance RenderableSymbol FileSharingConfig where
+  renderSymbol = "FileSharingConfig"
+
 instance IsFeatureConfig FileSharingConfig where
   type FeatureSymbol FileSharingConfig = "fileSharing"
   defFeatureStatus = withStatus FeatureStatusEnabled LockStatusUnlocked FileSharingConfig FeatureTTLUnlimited
@@ -839,6 +876,9 @@ newtype SelfDeletingMessagesConfig = SelfDeletingMessagesConfig
   deriving stock (Eq, Show, Generic)
   deriving (FromJSON, ToJSON, S.ToSchema) via (Schema SelfDeletingMessagesConfig)
   deriving (Arbitrary) via (GenericUniform SelfDeletingMessagesConfig)
+
+instance RenderableSymbol SelfDeletingMessagesConfig where
+  renderSymbol = "SelfDeletingMessagesConfig"
 
 instance ToSchema SelfDeletingMessagesConfig where
   schema =
@@ -869,6 +909,9 @@ data MLSConfig = MLSConfig
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform MLSConfig)
 
+instance RenderableSymbol MLSConfig where
+  renderSymbol = "MLSConfig"
+
 instance ToSchema MLSConfig where
   schema =
     object "MLSConfig" $
@@ -893,6 +936,9 @@ data ExposeInvitationURLsToTeamAdminConfig = ExposeInvitationURLsToTeamAdminConf
   deriving stock (Show, Eq, Generic)
   deriving (Arbitrary) via (GenericUniform ExposeInvitationURLsToTeamAdminConfig)
 
+instance RenderableSymbol ExposeInvitationURLsToTeamAdminConfig where
+  renderSymbol = "ExposeInvitationURLsToTeamAdminConfig"
+
 instance IsFeatureConfig ExposeInvitationURLsToTeamAdminConfig where
   type FeatureSymbol ExposeInvitationURLsToTeamAdminConfig = "exposeInvitationURLsToTeamAdmin"
   defFeatureStatus = withStatus FeatureStatusDisabled LockStatusLocked ExposeInvitationURLsToTeamAdminConfig FeatureTTLUnlimited
@@ -914,6 +960,9 @@ data OutlookCalIntegrationConfig = OutlookCalIntegrationConfig
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform OutlookCalIntegrationConfig)
 
+instance RenderableSymbol OutlookCalIntegrationConfig where
+  renderSymbol = "OutlookCalIntegrationConfig"
+
 instance IsFeatureConfig OutlookCalIntegrationConfig where
   type FeatureSymbol OutlookCalIntegrationConfig = "outlookCalIntegration"
   defFeatureStatus = withStatus FeatureStatusDisabled LockStatusLocked OutlookCalIntegrationConfig FeatureTTLUnlimited
@@ -934,6 +983,9 @@ data MlsE2EIdConfig = MlsE2EIdConfig
     acmeDiscoveryUrl :: Maybe HttpsUrl
   }
   deriving stock (Eq, Show, Generic)
+
+instance RenderableSymbol MlsE2EIdConfig where
+  renderSymbol = "MlsE2EIdConfig"
 
 instance Arbitrary MlsE2EIdConfig where
   arbitrary =


### PR DESCRIPTION
This should make jumping from swagger docs into the source code by grepping for the ID much easier.

![2023-05-30-222505_1600x900_scrot](https://github.com/wireapp/wire-server/assets/10210727/b1f5d64d-d525-44c0-b9c3-7a1193a21474)
![2023-05-30-222522_1600x900_scrot](https://github.com/wireapp/wire-server/assets/10210727/2d791e7f-299c-459a-97f3-ea56252f7a80)


## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
