### PR TITLE
Export Data.String.Conversions.cs from Imports

### DIFF
--- a/changelog.d/4-docs/pr-3320
+++ b/changelog.d/4-docs/pr-3320
@@ -1,0 +1,1 @@
+ Export `Data.String.Conversions.cs` from `Imports`

--- a/libs/api-bot/src/Network/Wire/Bot/Report.hs
+++ b/libs/api-bot/src/Network/Wire/Bot/Report.hs
@@ -48,7 +48,7 @@ where
 import qualified Data.HashMap.Strict as HashMap
 import Data.Metrics
 import Data.Time.Clock
-import Imports
+import Imports hiding (cs)
 import Network.Wire.Bot.Metrics
 import Network.Wire.Client.API.Push (EventType (..), eventTypeText)
 

--- a/libs/bilge/src/Bilge/Request.hs
+++ b/libs/bilge/src/Bilge/Request.hs
@@ -82,7 +82,7 @@ import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.ByteString.Lazy.Char8 as LC
 import Data.CaseInsensitive (original)
 import Data.Id (RequestId (..))
-import Imports hiding (intercalate)
+import Imports hiding (cs, intercalate)
 import Network.HTTP.Client (Cookie, GivesPopper, Request, RequestBody (..))
 import qualified Network.HTTP.Client as Rq
 import Network.HTTP.Client.Internal (CookieJar (..), brReadSome, throwHttp)

--- a/libs/brig-types/brig-types.cabal
+++ b/libs/brig-types/brig-types.cabal
@@ -85,7 +85,6 @@ library
     , imports
     , QuickCheck             >=2.9
     , schema-profunctor
-    , string-conversions
     , swagger2               >=2.5
     , text                   >=0.11
     , time                   >=1.1

--- a/libs/brig-types/default.nix
+++ b/libs/brig-types/default.nix
@@ -15,7 +15,6 @@
 , lib
 , QuickCheck
 , schema-profunctor
-, string-conversions
 , swagger2
 , tasty
 , tasty-hunit
@@ -41,7 +40,6 @@ mkDerivation {
     imports
     QuickCheck
     schema-profunctor
-    string-conversions
     swagger2
     text
     time

--- a/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
+++ b/libs/brig-types/src/Brig/Types/Test/Arbitrary.hs
@@ -24,7 +24,6 @@ where
 
 import Brig.Types.Common
 import Brig.Types.Team.LegalHold
-import Data.String.Conversions (cs)
 import Imports
 import Test.QuickCheck
 import Wire.Arbitrary

--- a/libs/extended/default.nix
+++ b/libs/extended/default.nix
@@ -26,7 +26,6 @@
 , servant
 , servant-server
 , servant-swagger
-, string-conversions
 , temporary
 , text
 , tinylog
@@ -56,19 +55,11 @@ mkDerivation {
     servant
     servant-server
     servant-swagger
-    string-conversions
     text
     tinylog
     wai
   ];
-  testHaskellDepends = [
-    aeson
-    base
-    hspec
-    imports
-    string-conversions
-    temporary
-  ];
+  testHaskellDepends = [ aeson base hspec imports temporary ];
   testToolDepends = [ hspec-discover ];
   description = "Extended versions of common modules";
   license = lib.licenses.agpl3Only;

--- a/libs/extended/extended.cabal
+++ b/libs/extended/extended.cabal
@@ -94,7 +94,6 @@ library
     , servant
     , servant-server
     , servant-swagger
-    , string-conversions
     , text
     , tinylog
     , wai
@@ -164,7 +163,6 @@ test-suite extended-tests
     , extended
     , hspec
     , imports
-    , string-conversions
     , temporary
 
   default-language:   Haskell2010

--- a/libs/extended/src/Servant/API/Extended.hs
+++ b/libs/extended/src/Servant/API/Extended.hs
@@ -23,7 +23,6 @@ import qualified Data.ByteString.Lazy as BL
 import Data.EitherR (fmapL)
 import Data.Kind
 import Data.Metrics.Servant
-import Data.String.Conversions (cs)
 import Data.Typeable
 import GHC.TypeLits
 import Imports

--- a/libs/extended/src/System/Logger/Extended.hs
+++ b/libs/extended/src/System/Logger/Extended.hs
@@ -40,7 +40,6 @@ import qualified Data.Aeson.Key as Key
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.Map.Lazy as Map
-import Data.String.Conversions (cs)
 import GHC.Generics
 import Imports
 import System.Logger as Log

--- a/libs/extended/test/Test/System/Logger/ExtendedSpec.hs
+++ b/libs/extended/test/Test/System/Logger/ExtendedSpec.hs
@@ -19,7 +19,6 @@ module Test.System.Logger.ExtendedSpec where
 
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
-import Data.String.Conversions (cs)
 import Imports
 import System.IO.Temp
 import System.Logger.Extended hiding ((.=))

--- a/libs/galley-types/default.nix
+++ b/libs/galley-types/default.nix
@@ -17,7 +17,6 @@
 , memory
 , QuickCheck
 , schema-profunctor
-, string-conversions
 , tasty
 , tasty-hunit
 , tasty-quickcheck
@@ -43,7 +42,6 @@ mkDerivation {
     memory
     QuickCheck
     schema-profunctor
-    string-conversions
     text
     types-common
     uuid

--- a/libs/galley-types/galley-types.cabal
+++ b/libs/galley-types/galley-types.cabal
@@ -83,7 +83,6 @@ library
     , memory
     , QuickCheck
     , schema-profunctor
-    , string-conversions
     , text                   >=0.11
     , types-common           >=0.16
     , uuid

--- a/libs/galley-types/src/Galley/Types.hs
+++ b/libs/galley-types/src/Galley/Types.hs
@@ -26,7 +26,7 @@ where
 import Data.Aeson
 import Data.Id (ClientId, UserId)
 import qualified Data.Map.Strict as Map
-import Imports
+import Imports hiding (cs)
 import Wire.API.Message
 
 --------------------------------------------------------------------------------

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -68,7 +68,6 @@ import Data.Id (UserId)
 import qualified Data.Maybe as Maybe
 import qualified Data.Schema as Schema
 import qualified Data.Set as Set
-import Data.String.Conversions (cs)
 import Imports
 import Test.QuickCheck (Arbitrary)
 import Wire.API.Error.Galley

--- a/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
+++ b/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
@@ -83,7 +83,7 @@ import qualified Data.List1 as List1
 import Data.Range
 import qualified Data.Range as Range
 import qualified Data.Set as Set
-import Imports
+import Imports hiding (cs)
 import Wire.API.Message (Priority (..))
 import Wire.API.Push.V2.Token
 

--- a/libs/imports/default.nix
+++ b/libs/imports/default.nix
@@ -11,6 +11,7 @@
 , gitignoreSource
 , lib
 , mtl
+, string-conversions
 , text
 , transformers
 , unliftio
@@ -28,6 +29,7 @@ mkDerivation {
     deepseq
     extra
     mtl
+    string-conversions
     text
     transformers
     unliftio

--- a/libs/imports/imports.cabal
+++ b/libs/imports/imports.cabal
@@ -75,6 +75,7 @@ library
     , deepseq
     , extra
     , mtl
+    , string-conversions
     , text
     , transformers
     , unliftio

--- a/libs/imports/src/Imports.hs
+++ b/libs/imports/src/Imports.hs
@@ -114,6 +114,7 @@ module Imports
     -- * Extra Helpers
     whenM,
     unlessM,
+    cs,
 
     -- * Functor
     (<$$>),
@@ -164,6 +165,7 @@ import Data.Ord
 import Data.Semigroup hiding (diff)
 import Data.Set (Set)
 import Data.String
+import Data.String.Conversions (cs)
 import Data.Text (Text)
 import qualified Data.Text.Lazy
 import Data.Traversable

--- a/libs/jwt-tools/default.nix
+++ b/libs/jwt-tools/default.nix
@@ -11,7 +11,6 @@
 , imports
 , lib
 , rusty_jwt_tools_ffi
-, string-conversions
 , transformers
 }:
 mkDerivation {
@@ -23,16 +22,10 @@ mkDerivation {
     bytestring-conversion
     http-types
     imports
-    string-conversions
     transformers
   ];
   librarySystemDepends = [ rusty_jwt_tools_ffi ];
-  testHaskellDepends = [
-    hspec
-    imports
-    string-conversions
-    transformers
-  ];
+  testHaskellDepends = [ hspec imports transformers ];
   description = "FFI to rusty-jwt-tools";
   license = lib.licenses.agpl3Only;
 }

--- a/libs/jwt-tools/jwt-tools.cabal
+++ b/libs/jwt-tools/jwt-tools.cabal
@@ -67,7 +67,6 @@ library
     , bytestring-conversion
     , http-types
     , imports
-    , string-conversions
     , transformers
 
   default-language:   Haskell2010
@@ -83,7 +82,6 @@ test-suite jwt-tools-tests
       hspec
     , imports
     , jwt-tools
-    , string-conversions
     , transformers
 
   hs-source-dirs:     test

--- a/libs/jwt-tools/src/Data/Jwt/Tools.hs
+++ b/libs/jwt-tools/src/Data/Jwt/Tools.hs
@@ -39,7 +39,6 @@ where
 import Control.Exception
 import Control.Monad.Trans.Except
 import Data.ByteString.Conversion
-import Data.String.Conversions (cs)
 import Foreign.C.String (CString, newCString, peekCString)
 import Foreign.Ptr (Ptr, nullPtr)
 import Imports

--- a/libs/jwt-tools/test/Spec.hs
+++ b/libs/jwt-tools/test/Spec.hs
@@ -17,7 +17,6 @@
 
 import Control.Monad.Trans.Except
 import Data.Jwt.Tools
-import Data.String.Conversions (cs)
 import Imports
 import Test.Hspec
 

--- a/libs/metrics-wai/default.nix
+++ b/libs/metrics-wai/default.nix
@@ -15,7 +15,6 @@
 , metrics-core
 , servant
 , servant-multipart
-, string-conversions
 , text
 , wai
 , wai-middleware-prometheus
@@ -35,7 +34,6 @@ mkDerivation {
     metrics-core
     servant
     servant-multipart
-    string-conversions
     text
     wai
     wai-middleware-prometheus

--- a/libs/metrics-wai/metrics-wai.cabal
+++ b/libs/metrics-wai/metrics-wai.cabal
@@ -78,7 +78,6 @@ library
     , metrics-core               >=0.3
     , servant
     , servant-multipart
-    , string-conversions
     , text                       >=0.11
     , wai                        >=3
     , wai-middleware-prometheus

--- a/libs/metrics-wai/src/Data/Metrics/Servant.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Servant.hs
@@ -31,7 +31,6 @@ import Data.Metrics.Types
 import qualified Data.Metrics.Types as Metrics
 import Data.Metrics.WaiRoute (treeToPaths)
 import Data.Proxy
-import Data.String.Conversions
 import Data.Tree
 import GHC.TypeLits
 import Imports

--- a/libs/metrics-wai/src/Data/Metrics/Test.hs
+++ b/libs/metrics-wai/src/Data/Metrics/Test.hs
@@ -18,7 +18,6 @@
 module Data.Metrics.Test where
 
 import Data.Metrics.Types
-import Data.String.Conversions (cs)
 import qualified Data.Text as Text
 import qualified Data.Tree as Tree
 import Imports

--- a/libs/polysemy-wire-zoo/default.nix
+++ b/libs/polysemy-wire-zoo/default.nix
@@ -20,7 +20,6 @@
 , polysemy-plugin
 , QuickCheck
 , saml2-web-sso
-, string-conversions
 , time
 , tinylog
 , types-common
@@ -46,7 +45,6 @@ mkDerivation {
     polysemy-plugin
     QuickCheck
     saml2-web-sso
-    string-conversions
     time
     tinylog
     types-common

--- a/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
+++ b/libs/polysemy-wire-zoo/polysemy-wire-zoo.cabal
@@ -82,7 +82,7 @@ library
 
   build-depends:
       aeson
-    , base                >=4.6 && <5.0
+    , base             >=4.6 && <5.0
     , bytestring
     , cassandra-util
     , HsOpenSSL
@@ -94,7 +94,6 @@ library
     , polysemy-plugin
     , QuickCheck
     , saml2-web-sso
-    , string-conversions
     , time
     , tinylog
     , types-common

--- a/libs/polysemy-wire-zoo/src/Wire/Sem/Jwk.hs
+++ b/libs/polysemy-wire-zoo/src/Wire/Sem/Jwk.hs
@@ -6,7 +6,6 @@ import Control.Exception
 import Crypto.JOSE.JWK
 import Data.Aeson
 import qualified Data.ByteString as BS
-import Data.String.Conversions (cs)
 import Imports
 import Polysemy
 

--- a/libs/types-common/default.nix
+++ b/libs/types-common/default.nix
@@ -40,7 +40,6 @@
 , random
 , schema-profunctor
 , servant-server
-, string-conversions
 , swagger2
 , tagged
 , tasty
@@ -95,7 +94,6 @@ mkDerivation {
     random
     schema-profunctor
     servant-server
-    string-conversions
     swagger2
     tagged
     tasty
@@ -118,7 +116,6 @@ mkDerivation {
     cereal
     imports
     protobuf
-    string-conversions
     tasty
     tasty-hunit
     tasty-quickcheck

--- a/libs/types-common/src/Data/Code.hs
+++ b/libs/types-common/src/Data/Code.hs
@@ -34,7 +34,6 @@ import Data.Json.Util
 import Data.Proxy (Proxy (Proxy))
 import Data.Range
 import Data.Schema
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import Data.Swagger.ParamSchema
 import Data.Text (pack)

--- a/libs/types-common/src/Data/Domain.hs
+++ b/libs/types-common/src/Data/Domain.hs
@@ -32,7 +32,6 @@ import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Char8 as BS.Char8
 import Data.ByteString.Conversion
 import Data.Schema
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text.E

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -74,7 +74,6 @@ import Data.Hashable (Hashable)
 import Data.ProtocolBuffers.Internal
 import Data.Proxy
 import Data.Schema
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import Data.Swagger.Internal.ParamSchema (ToParamSchema (..))
 import qualified Data.Text as T

--- a/libs/types-common/src/Data/Json/Util.hs
+++ b/libs/types-common/src/Data/Json/Util.hs
@@ -63,7 +63,6 @@ import qualified Data.ByteString.Conversion as BS
 import qualified Data.ByteString.Lazy as L
 import Data.Fixed
 import Data.Schema
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text

--- a/libs/types-common/src/Data/Misc.hs
+++ b/libs/types-common/src/Data/Misc.hs
@@ -79,7 +79,6 @@ import Data.ByteString.Lazy (toStrict)
 import Data.IP (IP (IPv4, IPv6), toIPv4, toIPv6b)
 import Data.Range
 import Data.Schema
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)

--- a/libs/types-common/src/Data/Nonce.hs
+++ b/libs/types-common/src/Data/Nonce.hs
@@ -33,7 +33,6 @@ import Data.ByteString.Conversion
 import Data.ByteString.Lazy (fromStrict, toStrict)
 import Data.Proxy (Proxy (Proxy))
 import Data.Schema
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import Data.Swagger.ParamSchema
 import Data.UUID as UUID (UUID, fromByteString, toByteString)

--- a/libs/types-common/src/Util/Logging.hs
+++ b/libs/types-common/src/Util/Logging.hs
@@ -20,7 +20,6 @@ module Util.Logging where
 import Crypto.Hash (SHA256, hash)
 import Data.Handle (Handle (fromHandle))
 import Data.Id (TeamId, UserId)
-import Data.String.Conversions (cs)
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Imports

--- a/libs/types-common/test/Test/Data/PEMKeys.hs
+++ b/libs/types-common/test/Test/Data/PEMKeys.hs
@@ -22,7 +22,6 @@ where
 
 import Data.ByteString.Conversion
 import Data.PEMKeys
-import Data.String.Conversions (cs)
 import Imports
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/libs/types-common/test/Test/Properties.hs
+++ b/libs/types-common/test/Test/Properties.hs
@@ -39,7 +39,6 @@ import qualified Data.Json.Util as Util
 import Data.Nonce (Nonce)
 import Data.ProtocolBuffers.Internal
 import Data.Serialize
-import Data.String.Conversions (cs)
 import Data.Text.Ascii
 import qualified Data.Text.Ascii as Ascii
 import Data.Time

--- a/libs/types-common/types-common.cabal
+++ b/libs/types-common/types-common.cabal
@@ -124,7 +124,6 @@ library
     , random                 >=1.1
     , schema-profunctor
     , servant-server
-    , string-conversions
     , swagger2
     , tagged                 >=0.8
     , tasty                  >=0.11
@@ -209,7 +208,6 @@ test-suite tests
     , cereal
     , imports
     , protobuf
-    , string-conversions
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/libs/wai-utilities/default.nix
+++ b/libs/wai-utilities/default.nix
@@ -22,7 +22,6 @@
 , prometheus-client
 , servant-server
 , streaming-commons
-, string-conversions
 , swagger2
 , text
 , tinylog
@@ -56,7 +55,6 @@ mkDerivation {
     prometheus-client
     servant-server
     streaming-commons
-    string-conversions
     swagger2
     text
     tinylog

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Headers.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Headers.hs
@@ -18,7 +18,6 @@
 module Network.Wai.Utilities.Headers where
 
 import Data.ByteString.Conversion (FromByteString (..), ToByteString (..), fromByteString', toByteString')
-import Data.String.Conversions (cs)
 import Data.Swagger.ParamSchema (ToParamSchema (..))
 import Data.Text as T
 import Imports

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -59,7 +59,6 @@ import Data.Domain (domainText)
 import Data.Metrics.GC (spawnGCMetricsCollector)
 import Data.Metrics.Middleware
 import Data.Streaming.Zlib (ZlibException (..))
-import Data.String.Conversions (cs)
 import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.Text.Lazy.Encoding as LT
 import Imports

--- a/libs/wai-utilities/wai-utilities.cabal
+++ b/libs/wai-utilities/wai-utilities.cabal
@@ -89,7 +89,6 @@ library
     , prometheus-client
     , servant-server
     , streaming-commons      >=0.1
-    , string-conversions
     , swagger2
     , text                   >=0.11
     , tinylog                >=0.8

--- a/libs/wire-api/default.nix
+++ b/libs/wire-api/default.nix
@@ -84,7 +84,6 @@
 , singletons-base
 , singletons-th
 , sop-core
-, string-conversions
 , swagger2
 , tagged
 , tasty
@@ -185,7 +184,6 @@ mkDerivation {
     singletons-base
     singletons-th
     sop-core
-    string-conversions
     swagger2
     tagged
     text
@@ -241,7 +239,6 @@ mkDerivation {
     schema-profunctor
     servant
     servant-server
-    string-conversions
     swagger2
     tasty
     tasty-hspec

--- a/libs/wire-api/src/Wire/API/Call/Config.hs
+++ b/libs/wire-api/src/Wire/API/Call/Config.hs
@@ -82,7 +82,6 @@ import qualified Data.IP as IP
 import Data.List.NonEmpty (NonEmpty)
 import Data.Misc (HttpsUrl (..), IpAddr (IpAddr), Port (..))
 import Data.Schema
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as Text
 import Data.Text.Ascii

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -101,7 +101,6 @@ import Data.Range (Range, fromRange, rangedSchema)
 import Data.SOP
 import Data.Schema
 import qualified Data.Set as Set
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUIDV5

--- a/libs/wire-api/src/Wire/API/Internal/Notification.hs
+++ b/libs/wire-api/src/Wire/API/Internal/Notification.hs
@@ -47,7 +47,7 @@ import Data.Id
 import Data.List1
 import qualified Data.Schema as S
 import qualified Data.Swagger as Swagger
-import Imports
+import Imports hiding (cs)
 import Wire.API.Notification
 
 -------------------------------------------------------------------------------

--- a/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
+++ b/libs/wire-api/src/Wire/API/MLS/KeyPackage.hs
@@ -52,7 +52,7 @@ import Data.Json.Util
 import Data.Qualified
 import Data.Schema
 import qualified Data.Swagger as S
-import Imports
+import Imports hiding (cs)
 import Test.QuickCheck
 import Web.HttpApiData
 import Wire.API.MLS.CipherSuite

--- a/libs/wire-api/src/Wire/API/MLS/Message.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Message.hs
@@ -54,7 +54,7 @@ import Data.Kind
 import Data.Schema
 import Data.Singletons.TH
 import qualified Data.Swagger as S
-import Imports
+import Imports hiding (cs)
 import Test.QuickCheck hiding (label)
 import Wire.API.Event.Conversation
 import Wire.API.MLS.CipherSuite

--- a/libs/wire-api/src/Wire/API/MLS/Proposal.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Proposal.hs
@@ -26,7 +26,7 @@ import Data.Binary
 import Data.Binary.Get
 import Data.Binary.Put
 import qualified Data.ByteString.Lazy as LBS
-import Imports
+import Imports hiding (cs)
 import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Context
 import Wire.API.MLS.Extension

--- a/libs/wire-api/src/Wire/API/MLS/Welcome.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Welcome.hs
@@ -18,7 +18,7 @@
 module Wire.API.MLS.Welcome where
 
 import qualified Data.Swagger as S
-import Imports
+import Imports hiding (cs)
 import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Commit
 import Wire.API.MLS.Extension

--- a/libs/wire-api/src/Wire/API/Notification.hs
+++ b/libs/wire-api/src/Wire/API/Notification.hs
@@ -47,7 +47,6 @@ import Data.Json.Util
 import Data.List.NonEmpty (NonEmpty)
 import Data.SOP
 import Data.Schema
-import Data.String.Conversions (cs)
 import Data.Swagger (ToParamSchema (..))
 import qualified Data.Swagger as S
 import Data.Time.Clock (UTCTime)

--- a/libs/wire-api/src/Wire/API/OAuth.hs
+++ b/libs/wire-api/src/Wire/API/OAuth.hs
@@ -34,7 +34,6 @@ import Data.Id as Id
 import Data.Range
 import Data.Schema
 import qualified Data.Set as Set
-import Data.String.Conversions (cs)
 import Data.Swagger (ToParamSchema (..))
 import qualified Data.Swagger as S
 import qualified Data.Text as T

--- a/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiTablePaging/State.hs
@@ -28,7 +28,6 @@ import qualified Data.ByteString.Base64.URL as Base64Url
 import Data.Either.Combinators (mapLeft)
 import Data.Proxy
 import Data.Schema
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text

--- a/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
+++ b/libs/wire-api/src/Wire/API/Routes/MultiVerb.hs
@@ -71,7 +71,7 @@ import qualified Data.Text.Encoding as Text
 import Data.Typeable
 import GHC.TypeLits
 import Generics.SOP as GSOP
-import Imports
+import Imports hiding (cs)
 import qualified Network.HTTP.Media as M
 import Network.HTTP.Types (hContentType)
 import qualified Network.HTTP.Types as HTTP

--- a/libs/wire-api/src/Wire/API/Routes/Public.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public.hs
@@ -43,7 +43,6 @@ import Data.Id as Id
 import Data.Kind
 import Data.Metrics.Servant
 import Data.Qualified
-import Data.String.Conversions
 import Data.Swagger hiding (Header)
 import GHC.Base (Symbol)
 import GHC.TypeLits (KnownSymbol)

--- a/libs/wire-api/src/Wire/API/Routes/Version/Wai.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Version/Wai.hs
@@ -20,7 +20,6 @@ module Wire.API.Routes.Version.Wai (versionMiddleware) where
 import Control.Monad.Except (throwError)
 import Data.ByteString.Conversion
 import Data.EitherR (fmapL)
-import Data.String.Conversions (cs)
 import qualified Data.Text as T
 import Imports
 import qualified Network.HTTP.Types as HTTP

--- a/libs/wire-api/src/Wire/API/Team/Export.hs
+++ b/libs/wire-api/src/Wire/API/Team/Export.hs
@@ -26,7 +26,6 @@ import Data.Handle (Handle)
 import Data.Id (UserId)
 import Data.Json.Util (UTCTimeMillis)
 import Data.Misc (HttpsUrl)
-import Data.String.Conversions (cs)
 import Data.Vector (fromList)
 import Imports
 import Test.QuickCheck (Arbitrary)

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -101,7 +101,6 @@ import Data.Misc (HttpsUrl)
 import Data.Proxy
 import Data.Schema
 import Data.Scientific (toBoundedInteger)
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -137,7 +137,6 @@ import Data.Qualified
 import Data.Range
 import Data.SOP
 import Data.Schema
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as T
 import Data.Text.Ascii

--- a/libs/wire-api/src/Wire/API/User/Client/DPoPAccessToken.hs
+++ b/libs/wire-api/src/Wire/API/User/Client/DPoPAccessToken.hs
@@ -24,7 +24,6 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.ByteString.Conversion (FromByteString (..), ToByteString (..), fromByteString', toByteString')
 import Data.SOP
 import Data.Schema
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import Data.Swagger.ParamSchema (ToParamSchema (..))
 import Data.Text as T

--- a/libs/wire-api/src/Wire/API/User/Identity.hs
+++ b/libs/wire-api/src/Wire/API/User/Identity.hs
@@ -62,7 +62,6 @@ import Data.Bifunctor (first)
 import Data.ByteString.Conversion
 import qualified Data.CaseInsensitive as CI
 import Data.Schema
-import Data.String.Conversions (cs)
 import Data.Swagger (ToParamSchema (..))
 import qualified Data.Swagger as S
 import qualified Data.Text as Text

--- a/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
+++ b/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
@@ -31,7 +31,6 @@ import Data.HashMap.Strict.InsOrd (InsOrdHashMap)
 import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 import Data.Id (TeamId)
 import Data.Proxy (Proxy (Proxy))
-import Data.String.Conversions
 import Data.Swagger
 import Imports
 import Network.HTTP.Media ((//))

--- a/libs/wire-api/src/Wire/API/User/RichInfo.hs
+++ b/libs/wire-api/src/Wire/API/User/RichInfo.hs
@@ -53,7 +53,6 @@ import qualified Data.CaseInsensitive as CI
 import Data.List.Extra (nubOrdOn)
 import qualified Data.Map as Map
 import Data.Schema
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as Text
 import Imports

--- a/libs/wire-api/src/Wire/API/User/Saml.hs
+++ b/libs/wire-api/src/Wire/API/User/Saml.hs
@@ -31,9 +31,8 @@ import Data.Aeson.TH hiding (fieldLabelModifier)
 import qualified Data.ByteString.Builder as Builder
 import Data.Id (UserId)
 import Data.Proxy (Proxy (Proxy))
-import Data.String.Conversions
 import Data.Swagger
-import qualified Data.Text as ST
+import qualified Data.Text as T
 import Data.Time
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import GHC.Types (Symbol)
@@ -71,17 +70,17 @@ mkVerdictGrantedFormatMobile before cky uid =
     . substituteVar "userid" (cs . show $ uid)
     $ renderURI before
 
-mkVerdictDeniedFormatMobile :: MonadError String m => URI -> ST -> m URI
+mkVerdictDeniedFormatMobile :: MonadError String m => URI -> Text -> m URI
 mkVerdictDeniedFormatMobile before lbl =
   parseURI'
     . substituteVar "label" lbl
     $ renderURI before
 
-substituteVar :: ST -> ST -> ST -> ST
+substituteVar :: Text -> Text -> Text -> Text
 substituteVar var val = substituteVar' ("$" <> var) val . substituteVar' ("%24" <> var) val
 
-substituteVar' :: ST -> ST -> ST -> ST
-substituteVar' var val = ST.intercalate val . ST.splitOn var
+substituteVar' :: Text -> Text -> Text -> Text
+substituteVar' var val = T.intercalate val . T.splitOn var
 
 -- | (seconds)
 newtype TTL (tablename :: Symbol) = TTL {fromTTL :: Int32}

--- a/libs/wire-api/src/Wire/API/User/Scim.hs
+++ b/libs/wire-api/src/Wire/API/User/Scim.hs
@@ -60,7 +60,6 @@ import Data.Json.Util ((#))
 import qualified Data.Map as Map
 import Data.Misc (PlainTextPassword6)
 import Data.Proxy
-import Data.String.Conversions (cs)
 import Data.Swagger hiding (Operation)
 import Data.Text.Encoding (encodeUtf8)
 import Data.Time.Clock (UTCTime)

--- a/libs/wire-api/src/Wire/API/User/Search.hs
+++ b/libs/wire-api/src/Wire/API/User/Search.hs
@@ -46,7 +46,6 @@ import Data.Json.Util (UTCTimeMillis)
 import Data.Proxy
 import Data.Qualified
 import Data.Schema
-import Data.String.Conversions (cs)
 import Data.Swagger (ToParamSchema (..))
 import qualified Data.Swagger as S
 import qualified Data.Text as T

--- a/libs/wire-api/test/unit/Test/Wire/API/Routes/Version.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Routes/Version.hs
@@ -3,7 +3,6 @@ module Test.Wire.API.Routes.Version where
 import Data.Aeson as Aeson
 import Data.Binary.Builder
 import Data.ByteString.Conversion
-import Data.String.Conversions (cs)
 import Imports
 import Servant.API
 import Test.Tasty

--- a/libs/wire-api/test/unit/Test/Wire/API/Routes/Version/Wai.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/Routes/Version/Wai.hs
@@ -2,7 +2,6 @@ module Test.Wire.API.Routes.Version.Wai where
 
 import Data.Proxy
 import qualified Data.Set as Set
-import Data.String.Conversions
 import Data.Text as T
 import Imports
 import Network.HTTP.Types.Status (status200, status400)

--- a/libs/wire-api/test/unit/Test/Wire/API/User/Search.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/User/Search.hs
@@ -20,7 +20,6 @@ module Test.Wire.API.User.Search where
 import Data.Aeson (encode, toJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
-import Data.String.Conversions (cs)
 import Imports
 import qualified Test.Tasty as T
 import Test.Tasty.QuickCheck (counterexample, testProperty)

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -283,7 +283,6 @@ library
     , singletons-base
     , singletons-th
     , sop-core
-    , string-conversions
     , swagger2
     , tagged
     , text                       >=0.11
@@ -742,7 +741,6 @@ test-suite wire-api-tests
     , schema-profunctor
     , servant
     , servant-server
-    , string-conversions
     , swagger2
     , tasty
     , tasty-hspec

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -277,7 +277,6 @@ library
     , ssl-util
     , statistics                 >=0.13
     , stomp-queue                >=0.3
-    , string-conversions
     , swagger2
     , template                   >=0.2
     , template-haskell
@@ -586,7 +585,6 @@ executable brig-integration
     , servant-client-core
     , spar
     , streaming-commons
-    , string-conversions
     , tasty                  >=1.0
     , tasty-cannon           >=0.3.4
     , tasty-hunit            >=0.2

--- a/services/brig/default.nix
+++ b/services/brig/default.nix
@@ -119,7 +119,6 @@
 , statistics
 , stomp-queue
 , streaming-commons
-, string-conversions
 , swagger2
 , tasty
 , tasty-cannon
@@ -257,7 +256,6 @@ mkDerivation {
     ssl-util
     statistics
     stomp-queue
-    string-conversions
     swagger2
     template
     template-haskell
@@ -352,7 +350,6 @@ mkDerivation {
     servant-client-core
     spar
     streaming-commons
-    string-conversions
     tasty
     tasty-cannon
     tasty-hunit

--- a/services/brig/src/Brig/API/Client.hs
+++ b/services/brig/src/Brig/API/Client.hs
@@ -86,7 +86,6 @@ import qualified Data.Map.Strict as Map
 import Data.Misc (PlainTextPassword6)
 import Data.Qualified
 import qualified Data.Set as Set
-import Data.String.Conversions (cs)
 import Imports
 import Network.HTTP.Types.Method (StdMethod)
 import Network.Wai.Utilities

--- a/services/brig/src/Brig/API/Error.hs
+++ b/services/brig/src/Brig/API/Error.hs
@@ -26,7 +26,6 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import Data.ByteString.Conversion
 import Data.Domain (Domain)
 import Data.Jwt.Tools (DPoPTokenGenerationError (..))
-import Data.String.Conversions (cs)
 import qualified Data.ZAuth.Validation as ZAuth
 import Imports
 import Network.HTTP.Types.Header

--- a/services/brig/src/Brig/API/Internal.hs
+++ b/services/brig/src/Brig/API/Internal.hs
@@ -70,7 +70,7 @@ import Data.Id as Id
 import qualified Data.Map.Strict as Map
 import Data.Qualified
 import qualified Data.Set as Set
-import Imports hiding (head)
+import Imports hiding (cs, head)
 import Network.HTTP.Types.Status
 import Network.Wai (Response)
 import Network.Wai.Predicate hiding (result, setStatus)

--- a/services/brig/src/Brig/API/MLS/KeyPackages/Validation.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages/Validation.hs
@@ -38,7 +38,7 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Qualified
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
-import Imports
+import Imports hiding (cs)
 import Wire.API.Error
 import Wire.API.Error.Brig
 import Wire.API.MLS.CipherSuite

--- a/services/brig/src/Brig/API/OAuth.hs
+++ b/services/brig/src/Brig/API/OAuth.hs
@@ -38,7 +38,6 @@ import Data.Domain
 import Data.Id
 import Data.Misc
 import qualified Data.Set as Set
-import Data.String.Conversions (cs)
 import Data.Text.Ascii
 import Data.Time
 import Imports hiding (exp)

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -89,7 +89,6 @@ import Data.Misc (IpAddr (..))
 import Data.Nonce (Nonce, randomNonce)
 import Data.Qualified
 import Data.Range
-import Data.String.Conversions (cs)
 import qualified Data.Swagger as S
 import qualified Data.Text as Text
 import qualified Data.Text.Ascii as Ascii

--- a/services/brig/src/Brig/API/User.hs
+++ b/services/brig/src/Brig/API/User.hs
@@ -161,7 +161,7 @@ import Data.Qualified
 import Data.Time.Clock (addUTCTime, diffUTCTime)
 import Data.UUID.V4 (nextRandom)
 import qualified Galley.Types.Teams as Team
-import Imports
+import Imports hiding (cs)
 import Network.Wai.Utilities
 import Polysemy
 import System.Logger.Class (MonadLogger)

--- a/services/brig/src/Brig/API/Util.hs
+++ b/services/brig/src/Brig/API/Util.hs
@@ -52,7 +52,6 @@ import Data.Handle (Handle, parseHandle)
 import Data.Id
 import Data.Maybe
 import Data.Qualified
-import Data.String.Conversions (cs)
 import Data.Text.Ascii (AsciiText (toText))
 import Imports
 import Polysemy

--- a/services/brig/src/Brig/Calling.hs
+++ b/services/brig/src/Brig/Calling.hs
@@ -61,7 +61,6 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Misc
 import Data.Range
-import Data.String.Conversions (cs)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as Text

--- a/services/brig/src/Brig/Data/Instances.hs
+++ b/services/brig/src/Brig/Data/Instances.hs
@@ -35,7 +35,6 @@ import Data.Domain (Domain, domainText, mkDomain)
 import Data.Handle (Handle (..))
 import Data.Id ()
 import Data.Range ()
-import Data.String.Conversions (LBS, ST, cs)
 import Data.Text.Ascii ()
 import Data.Text.Encoding (encodeUtf8)
 import Imports
@@ -88,7 +87,7 @@ instance Cql UserSSOId where
     Left msg -> Left $ "fromCql: Invalid UserSSOId: " ++ msg
   fromCql _ = Left "fromCql: UserSSOId: CqlText expected"
 
-  toCql = toCql . cs @LBS @ST . encode
+  toCql = toCql . cs @LByteString @Text . encode
 
 instance Cql RelationWithHistory where
   ctype = Tagged IntColumn

--- a/services/brig/src/Brig/Effects/JwtTools.hs
+++ b/services/brig/src/Brig/Effects/JwtTools.hs
@@ -11,7 +11,6 @@ import qualified Data.Jwt.Tools as Jwt
 import Data.Misc (HttpsUrl)
 import Data.Nonce (Nonce)
 import Data.PEMKeys
-import Data.String.Conversions (cs)
 import Imports
 import Network.HTTP.Types (StdMethod (..))
 import Numeric (readHex)

--- a/services/brig/src/Brig/Effects/SFT.hs
+++ b/services/brig/src/Brig/Effects/SFT.hs
@@ -32,7 +32,6 @@ import Data.ByteString.Conversion
 import qualified Data.Map as Map
 import Data.Misc
 import Data.Schema
-import Data.String.Conversions (cs)
 import Imports hiding (fromException, intercalate)
 import Network.HTTP.Client
 import Polysemy

--- a/services/brig/src/Brig/Index/Eval.hs
+++ b/services/brig/src/Brig/Index/Eval.hs
@@ -33,7 +33,6 @@ import Control.Retry
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.Metrics as Metrics
-import Data.String.Conversions (cs)
 import qualified Database.Bloodhound as ES
 import Imports
 import Network.HTTP.Client as HTTP

--- a/services/brig/src/Brig/Run.hs
+++ b/services/brig/src/Brig/Run.hs
@@ -54,7 +54,6 @@ import Data.Id (RequestId (..))
 import Data.Metrics.AWS (gaugeTokenRemaing)
 import qualified Data.Metrics.Servant as Metrics
 import Data.Proxy (Proxy (Proxy))
-import Data.String.Conversions (cs)
 import Data.Text (unpack)
 import Imports hiding (head)
 import qualified Network.HTTP.Media as HTTPMedia

--- a/services/brig/src/Brig/Team/API.hs
+++ b/services/brig/src/Brig/Team/API.hs
@@ -51,7 +51,6 @@ import Data.ByteString.Conversion (toByteString')
 import Data.Id
 import qualified Data.List1 as List1
 import Data.Range
-import Data.String.Conversions (cs)
 import qualified Galley.Types.Teams as Team
 import Imports hiding (head)
 import Network.HTTP.Types.Status

--- a/services/brig/src/Brig/User/Auth/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie.hs
@@ -56,7 +56,7 @@ import qualified Data.Metrics as Metrics
 import Data.Proxy
 import Data.RetryAfter
 import Data.Time.Clock
-import Imports
+import Imports hiding (cs)
 import Network.Wai (Response)
 import Network.Wai.Utilities.Response (addHeader)
 import System.Logger.Class (field, msg, val, (~~))

--- a/services/brig/src/Brig/User/Auth/Cookie/Limit.hs
+++ b/services/brig/src/Brig/User/Auth/Cookie/Limit.hs
@@ -22,7 +22,7 @@ import Data.RetryAfter
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 import qualified Data.Vector as Vector
-import Imports
+import Imports hiding (cs)
 import qualified Statistics.Sample as Stats
 import Wire.API.User.Auth
 

--- a/services/brig/src/Brig/User/Auth/DB/Cookie.hs
+++ b/services/brig/src/Brig/User/Auth/DB/Cookie.hs
@@ -23,7 +23,7 @@ import Brig.User.Auth.DB.Instances ()
 import Cassandra
 import Data.Id
 import Data.Time.Clock
-import Imports
+import Imports hiding (cs)
 import Wire.API.User.Auth
 
 newtype TTL = TTL {ttlSeconds :: Int32}

--- a/services/brig/src/Brig/User/Search/Index.hs
+++ b/services/brig/src/Brig/User/Search/Index.hs
@@ -77,7 +77,6 @@ import Data.Handle (Handle)
 import Data.Id
 import qualified Data.Map as Map
 import Data.Metrics
-import Data.String.Conversions (cs)
 import qualified Data.Text as T
 import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)

--- a/services/brig/src/Brig/User/Search/TeamUserSearch.hs
+++ b/services/brig/src/Brig/User/Search/TeamUserSearch.hs
@@ -36,7 +36,6 @@ import Control.Monad.Catch (MonadThrow (throwM))
 import Data.Aeson (decode', encode)
 import Data.Id (TeamId, idToText)
 import Data.Range (Range (..))
-import Data.String.Conversions (cs)
 import Data.Text.Ascii (decodeBase64Url, encodeBase64Url)
 import qualified Database.Bloodhound as ES
 import Imports hiding (log, searchable)

--- a/services/brig/test/integration/API/Calling.hs
+++ b/services/brig/test/integration/API/Calling.hs
@@ -32,7 +32,6 @@ import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Misc (Port (..), mkHttpsUrl)
 import qualified Data.Set as Set
-import Data.String.Conversions
 import Imports
 import System.FilePath ((</>))
 import Test.Tasty

--- a/services/brig/test/integration/API/Internal/Util.hs
+++ b/services/brig/test/integration/API/Internal/Util.hs
@@ -39,7 +39,6 @@ import Data.Id
 import qualified Data.List1 as List1
 import Data.Proxy (Proxy (Proxy))
 import qualified Data.Set as Set
-import Data.String.Conversions (cs)
 import qualified Data.Text.Encoding as T
 import Imports
 import Servant.API ((:>))

--- a/services/brig/test/integration/API/OAuth.hs
+++ b/services/brig/test/integration/API/OAuth.hs
@@ -37,7 +37,6 @@ import Data.Id
 import Data.Qualified (Qualified (qUnqualified))
 import Data.Range
 import Data.Set as Set hiding (delete, null, (\\))
-import Data.String.Conversions (cs)
 import Data.Text.Ascii (encodeBase16)
 import qualified Data.Text.Encoding as T
 import Data.Time

--- a/services/brig/test/integration/API/Search.hs
+++ b/services/brig/test/integration/API/Search.hs
@@ -42,7 +42,6 @@ import Data.Handle (fromHandle)
 import Data.Id
 import qualified Data.Map.Strict as Map
 import Data.Qualified (Qualified (qDomain, qUnqualified))
-import Data.String.Conversions (cs)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Database.Bloodhound as ES

--- a/services/brig/test/integration/API/Search/Util.hs
+++ b/services/brig/test/integration/API/Search/Util.hs
@@ -26,7 +26,6 @@ import Data.Domain (Domain)
 import Data.Id
 import Data.Qualified (Qualified (..))
 import Data.Range (Range)
-import Data.String.Conversions (cs)
 import Data.Text.Encoding (encodeUtf8)
 import Imports
 import Test.Tasty.HUnit

--- a/services/brig/test/integration/API/Swagger.hs
+++ b/services/brig/test/integration/API/Swagger.hs
@@ -22,7 +22,6 @@ import Brig.Options
 import Control.Lens
 import Data.Aeson.Lens
 import Data.ByteString.Conversion (toByteString')
-import Data.String.Conversions
 import Imports
 import Servant.API (toQueryParam)
 import Test.Tasty

--- a/services/brig/test/integration/API/SystemSettings.hs
+++ b/services/brig/test/integration/API/SystemSettings.hs
@@ -24,7 +24,6 @@ import Control.Lens
 import qualified Data.ByteString.Char8 as BS
 import Data.ByteString.Conversion (toByteString')
 import Data.Id
-import Data.String.Conversions (cs)
 import Imports
 import Network.Wai.Test as WaiTest
 import Test.Tasty

--- a/services/brig/test/integration/API/TeamUserSearch.hs
+++ b/services/brig/test/integration/API/TeamUserSearch.hs
@@ -28,7 +28,6 @@ import Data.ByteString.Conversion (toByteString)
 import Data.Handle (fromHandle)
 import Data.Id (TeamId, UserId)
 import Data.Range (unsafeRange)
-import Data.String.Conversions (cs)
 import Imports
 import System.Random.Shuffle (shuffleM)
 import Test.Tasty (TestTree, testGroup)

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -58,7 +58,6 @@ import Data.Proxy
 import Data.Qualified
 import Data.Range
 import qualified Data.Set as Set
-import Data.String.Conversions (cs)
 import qualified Data.Text as T
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as T

--- a/services/brig/test/integration/API/User/Auth.hs
+++ b/services/brig/test/integration/API/User/Auth.hs
@@ -59,7 +59,7 @@ import qualified Data.Text.Lazy as Lazy
 import Data.Time.Clock
 import qualified Data.UUID.V4 as UUID
 import qualified Data.ZAuth.Token as ZAuth
-import Imports
+import Imports hiding (cs)
 import Network.HTTP.Client (equivCookie)
 import qualified Network.Wai.Utilities.Error as Error
 import Test.Tasty

--- a/services/brig/test/integration/API/User/Client.hs
+++ b/services/brig/test/integration/API/User/Client.hs
@@ -53,7 +53,6 @@ import Data.Nonce (isValidBase64UrlEncodedUUID)
 import Data.Qualified (Qualified (..))
 import Data.Range (unsafeRange)
 import qualified Data.Set as Set
-import Data.String.Conversions (cs)
 import Data.Text (replace)
 import Data.Text.Ascii (AsciiChars (validate))
 import Data.Time (addUTCTime)

--- a/services/brig/test/integration/API/User/PasswordReset.hs
+++ b/services/brig/test/integration/API/User/PasswordReset.hs
@@ -30,7 +30,7 @@ import qualified Cassandra as DB
 import Data.Aeson as A
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Misc
-import Imports
+import Imports hiding (cs)
 import Test.Tasty hiding (Timeout)
 import Util
 import Wire.API.User

--- a/services/brig/test/integration/API/User/Property.hs
+++ b/services/brig/test/integration/API/User/Property.hs
@@ -27,7 +27,6 @@ import Brig.Options
 import qualified Brig.Options as Opt
 import Data.Aeson
 import qualified Data.ByteString.Char8 as C
-import Data.String.Conversions (cs)
 import qualified Data.Text as T
 import Imports
 import qualified Network.Wai.Utilities.Error as Error

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -47,7 +47,6 @@ import qualified Data.List1 as List1
 import Data.Misc
 import Data.Qualified
 import Data.Range (unsafeRange)
-import Data.String.Conversions (cs)
 import qualified Data.Text.Ascii as Ascii
 import qualified Data.Vector as Vec
 import qualified Data.ZAuth.Token as ZAuth

--- a/services/brig/test/integration/API/UserPendingActivation.hs
+++ b/services/brig/test/integration/API/UserPendingActivation.hs
@@ -38,7 +38,6 @@ import Data.Aeson.Lens (key, _String)
 import Data.ByteString.Conversion (fromByteString, toByteString')
 import Data.Id (InvitationId, TeamId, UserId)
 import Data.Range (unsafeRange)
-import Data.String.Conversions (cs)
 import Data.Text.Encoding (encodeUtf8)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -43,7 +43,7 @@ import Data.Range (checked)
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import Federation.Util (connectUsersEnd2End, generateClientPrekeys, getConvQualified)
-import Imports
+import Imports hiding (cs)
 import System.FilePath
 import qualified System.Logger as Log
 import System.Process

--- a/services/brig/test/integration/Federation/Util.hs
+++ b/services/brig/test/integration/Federation/Util.hs
@@ -39,7 +39,6 @@ import Data.Handle (fromHandle)
 import Data.Id
 import qualified Data.Map.Strict as Map
 import Data.Qualified (Qualified (..))
-import Data.String.Conversions (cs)
 import qualified Data.Text as Text
 import qualified Database.Bloodhound as ES
 import qualified Federator.MockServer as Mock

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -63,7 +63,6 @@ import Data.Proxy
 import Data.Qualified hiding (isLocal)
 import Data.Range
 import qualified Data.Sequence as Seq
-import Data.String.Conversions (cs)
 import qualified Data.Text as T
 import qualified Data.Text as Text
 import qualified Data.Text.Ascii as Ascii
@@ -1242,11 +1241,11 @@ instance VersionedMonad v WaiTestFedClient where
 
 fromServantRequest :: Domain -> Servant.Request -> WaiTest.SRequest
 fromServantRequest domain r =
-  let pathBS = "/federation" <> Data.String.Conversions.cs (toLazyByteString (Servant.requestPath r))
+  let pathBS = "/federation" <> cs (toLazyByteString (Servant.requestPath r))
       bodyBS = case Servant.requestBody r of
         Nothing -> ""
         Just (bdy, _) -> case bdy of
-          Servant.RequestBodyLBS lbs -> Data.String.Conversions.cs lbs
+          Servant.RequestBodyLBS lbs -> cs lbs
           Servant.RequestBodyBS bs -> bs
           Servant.RequestBodySource _ -> error "fromServantRequest: not implemented for RequestBodySource"
 
@@ -1279,7 +1278,7 @@ fromServantRequest domain r =
                 <> headers
                 <> [(originDomainHeaderName, T.encodeUtf8 (domainText domain))],
             Wai.isSecure = True,
-            Wai.pathInfo = filter (not . T.null) (map Data.String.Conversions.cs (B8.split '/' pathBS)),
+            Wai.pathInfo = filter (not . T.null) (map cs (B8.split '/' pathBS)),
             Wai.queryString = toList (Servant.requestQueryString r)
           }
    in WaiTest.SRequest req (cs bodyBS)

--- a/services/cannon/src/Cannon/WS.hs
+++ b/services/cannon/src/Cannon/WS.hs
@@ -68,7 +68,7 @@ import Data.List.Extra (chunksOf)
 import Data.Text.Encoding (decodeUtf8)
 import Data.Timeout (TimeoutUnit (..), (#))
 import Gundeck.Types
-import Imports hiding (threadDelay)
+import Imports hiding (cs, threadDelay)
 import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status
 import Network.Wai.Utilities.Error

--- a/services/federator/default.nix
+++ b/services/federator/default.nix
@@ -46,7 +46,6 @@
 , servant
 , servant-client
 , servant-client-core
-, string-conversions
 , tasty
 , tasty-hunit
 , tasty-quickcheck
@@ -107,7 +106,6 @@ mkDerivation {
     polysemy-wire-zoo
     servant
     servant-client-core
-    string-conversions
     text
     tinylog
     transformers
@@ -145,7 +143,6 @@ mkDerivation {
     QuickCheck
     random
     servant-client-core
-    string-conversions
     tasty-hunit
     text
     types-common
@@ -179,7 +176,6 @@ mkDerivation {
     servant
     servant-client
     servant-client-core
-    string-conversions
     tasty
     tasty-hunit
     tasty-quickcheck

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -133,7 +133,6 @@ library
     , polysemy-wire-zoo
     , servant
     , servant-client-core
-    , string-conversions
     , text
     , tinylog
     , transformers
@@ -293,7 +292,6 @@ executable federator-integration
     , QuickCheck
     , random
     , servant-client-core
-    , string-conversions
     , tasty-hunit
     , text
     , types-common
@@ -394,7 +392,6 @@ test-suite federator-tests
     , servant
     , servant-client
     , servant-client-core
-    , string-conversions
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/services/federator/src/Federator/Discovery.hs
+++ b/services/federator/src/Federator/Discovery.hs
@@ -21,7 +21,6 @@ module Federator.Discovery where
 import Data.Domain (Domain, domainText)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
-import Data.String.Conversions (cs)
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy as LText
 import Federator.Error

--- a/services/federator/src/Federator/Service.hs
+++ b/services/federator/src/Federator/Service.hs
@@ -34,7 +34,6 @@ import Control.Monad.Codensity
 import qualified Data.ByteString as BS
 import Data.Domain
 import qualified Data.Sequence as Seq
-import Data.String.Conversions (cs)
 import qualified Data.Text.Encoding as Text
 import Federator.Env
 import Imports

--- a/services/federator/test/integration/Main.hs
+++ b/services/federator/test/integration/Main.hs
@@ -20,7 +20,6 @@ module Main
   )
 where
 
-import Data.String.Conversions
 import Imports
 import OpenSSL (withOpenSSL)
 import System.Environment (withArgs)

--- a/services/federator/test/integration/Test/Federator/IngressSpec.hs
+++ b/services/federator/test/integration/Test/Federator/IngressSpec.hs
@@ -25,7 +25,6 @@ import Data.Binary.Builder
 import Data.Domain
 import Data.Handle
 import Data.LegalHold (UserLegalHoldStatus (UserLegalHoldNoConsent))
-import Data.String.Conversions (cs)
 import qualified Data.Text.Encoding as Text
 import Federator.Discovery
 import Federator.Monitor (FederationSetupError)

--- a/services/federator/test/integration/Test/Federator/Util.hs
+++ b/services/federator/test/integration/Test/Federator/Util.hs
@@ -38,7 +38,6 @@ import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString.Char8 as C8
 import Data.Id
 import Data.Misc
-import Data.String.Conversions
 import qualified Data.Text as Text
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID

--- a/services/federator/test/unit/Test/Federator/ExternalServer.hs
+++ b/services/federator/test/unit/Test/Federator/ExternalServer.hs
@@ -22,7 +22,6 @@ module Test.Federator.ExternalServer where
 import qualified Data.ByteString as BS
 import Data.Default
 import Data.Domain
-import Data.String.Conversions (cs)
 import qualified Data.Text.Encoding as Text
 import Federator.Discovery
 import Federator.Error.ServerError (ServerError (..))

--- a/services/galley/default.nix
+++ b/services/galley/default.nix
@@ -90,7 +90,6 @@
 , ssl-util
 , stm
 , streaming-commons
-, string-conversions
 , tagged
 , tasty
 , tasty-cannon
@@ -196,7 +195,6 @@ mkDerivation {
     split
     ssl-util
     stm
-    string-conversions
     tagged
     text
     time
@@ -287,7 +285,6 @@ mkDerivation {
     sop-core
     ssl-util
     streaming-commons
-    string-conversions
     tagged
     tasty
     tasty-cannon

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -255,7 +255,6 @@ library
     , split                  >=0.2
     , ssl-util               >=0.1
     , stm                    >=2.4
-    , string-conversions
     , tagged
     , text                   >=0.11
     , time                   >=1.4
@@ -484,7 +483,6 @@ executable galley-integration
     , sop-core
     , ssl-util
     , streaming-commons
-    , string-conversions
     , tagged
     , tasty                  >=0.8
     , tasty-cannon           >=0.3.2

--- a/services/galley/src/Galley/API/Clients.hs
+++ b/services/galley/src/Galley/API/Clients.hs
@@ -28,7 +28,6 @@ import Data.Id
 import Data.Proxy
 import Data.Qualified
 import Data.Range
-import Data.String.Conversions
 import qualified Data.Text as T
 import Data.Time
 import Galley.API.Error

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -31,7 +31,6 @@ import Data.List1 (maybeList1)
 import Data.Qualified
 import Data.Range
 import Data.Singletons
-import Data.String.Conversions (cs)
 import Data.Time
 import qualified Galley.API.Clients as Clients
 import qualified Galley.API.Create as Create

--- a/services/galley/src/Galley/API/MLS/Removal.hs
+++ b/services/galley/src/Galley/API/MLS/Removal.hs
@@ -36,7 +36,7 @@ import Galley.Effects
 import Galley.Effects.MemberStore
 import Galley.Effects.ProposalStore
 import Galley.Env
-import Imports
+import Imports hiding (cs)
 import Polysemy
 import Polysemy.Input
 import Polysemy.TinyLog

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -72,7 +72,7 @@ import Galley.Env
 import Galley.Options
 import Galley.Types.Conversations.Members
 import Galley.Types.Teams
-import Imports
+import Imports hiding (cs)
 import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Predicate hiding (Error, result, setStatus)

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -42,7 +42,6 @@ import Data.Id
 import Data.Kind
 import Data.Qualified (Local)
 import Data.Schema
-import Data.String.Conversions (cs)
 import Data.Time (UTCTime)
 import GHC.TypeLits (KnownSymbol)
 import Galley.API.Error (InternalError)

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -45,7 +45,7 @@ import Galley.Effects.ConversationStore (ConversationStore (..))
 import Galley.Types.Conversations.Members
 import Galley.Types.ToUserRole
 import Galley.Types.UserList
-import Imports
+import Imports hiding (cs)
 import Polysemy
 import Polysemy.Input
 import Polysemy.TinyLog

--- a/services/galley/src/Galley/Cassandra/Conversation/Members.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation/Members.hs
@@ -41,7 +41,7 @@ import Galley.Effects.MemberStore (MemberStore (..))
 import Galley.Types.Conversations.Members
 import Galley.Types.ToUserRole
 import Galley.Types.UserList
-import Imports hiding (Set)
+import Imports hiding (Set, cs)
 import Polysemy
 import Polysemy.Input
 import qualified UnliftIO

--- a/services/galley/src/Galley/Cassandra/Store.hs
+++ b/services/galley/src/Galley/Cassandra/Store.hs
@@ -21,7 +21,7 @@ module Galley.Cassandra.Store
 where
 
 import Cassandra
-import Imports
+import Imports hiding (cs)
 import Polysemy
 import Polysemy.Input
 

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -47,7 +47,6 @@ import qualified Data.ByteString.Char8 as BSC
 import Data.ByteString.Conversion
 import Data.Id
 import Data.Qualified
-import Data.String.Conversions
 import qualified Data.Text.Lazy as Lazy
 import Galley.API.Error
 import Galley.Env

--- a/services/galley/src/Galley/Monad.hs
+++ b/services/galley/src/Galley/Monad.hs
@@ -26,7 +26,7 @@ import Control.Lens
 import Control.Monad.Catch
 import Control.Monad.Except
 import Galley.Env
-import Imports hiding (log)
+import Imports hiding (cs, log)
 import Polysemy
 import Polysemy.Input
 import System.Logger

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -39,7 +39,6 @@ import Data.Metrics.AWS (gaugeTokenRemaing)
 import qualified Data.Metrics.Middleware as M
 import Data.Metrics.Servant (servantPlusWAIPrometheusMiddleware)
 import Data.Misc (portNumber)
-import Data.String.Conversions (cs)
 import Data.Text (unpack)
 import qualified Galley.API as API
 import Galley.API.Federation (FederationAPI, federationSitemap)

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -37,7 +37,6 @@ import Data.Qualified
 import Data.Range
 import qualified Data.Set as Set
 import Data.Singletons
-import Data.String.Conversions
 import Data.Time.Clock
 import Data.Timeout (TimeoutUnit (..), (#))
 import Data.UUID.V4 (nextRandom)

--- a/services/galley/test/integration/API/Federation/Util.hs
+++ b/services/galley/test/integration/API/Federation/Util.hs
@@ -28,7 +28,6 @@ where
 import Data.Kind
 import Data.Qualified
 import Data.SOP
-import Data.String.Conversions (cs)
 import GHC.TypeLits
 import Imports
 import Servant

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -43,7 +43,6 @@ import Data.Qualified
 import Data.Range
 import qualified Data.Set as Set
 import Data.Singletons
-import Data.String.Conversions
 import qualified Data.Text as T
 import Data.Time
 import Federator.MockServer hiding (withTempMockFederator)

--- a/services/galley/test/integration/API/Teams/LegalHold/DisabledByDefault.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold/DisabledByDefault.hs
@@ -42,7 +42,6 @@ import qualified Data.Map.Strict as Map
 import Data.PEM
 import Data.Range
 import qualified Data.Set as Set
-import Data.String.Conversions (LBS)
 import Galley.Cassandra.Client
 import Galley.Cassandra.LegalHold
 import qualified Galley.Cassandra.LegalHold as LegalHoldData
@@ -772,7 +771,7 @@ testClaimKeys testcase = do
 --------------------------------------------------------------------
 -- setup helpers
 
-withDummyTestServiceForTeam' :: HasCallStack => UserId -> TeamId -> (Warp.Port -> Chan (Wai.Request, LBS) -> TestM a) -> TestM a
+withDummyTestServiceForTeam' :: HasCallStack => UserId -> TeamId -> (Warp.Port -> Chan (Wai.Request, LByteString) -> TestM a) -> TestM a
 withDummyTestServiceForTeam' owner tid go = do
   withDummyTestServiceForTeamNoService $ \lhPort chan -> do
     newService <- newLegalHoldService lhPort

--- a/services/galley/test/integration/API/Teams/LegalHold/Util.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold/Util.hs
@@ -32,7 +32,6 @@ import qualified Data.List1 as List1
 import Data.Misc (PlainTextPassword6)
 import Data.PEM
 import Data.Streaming.Network (bindRandomPortTCP)
-import Data.String.Conversions (LBS, cs)
 import Data.Tagged
 import Data.Text.Encoding (encodeUtf8)
 import Galley.Options
@@ -95,7 +94,7 @@ withDummyTestServiceForTeam ::
   UserId ->
   TeamId ->
   -- | the test
-  (Chan (Wai.Request, LBS) -> TestM a) ->
+  (Chan (Wai.Request, LByteString) -> TestM a) ->
   TestM a
 withDummyTestServiceForTeam owner tid go =
   withDummyTestServiceForTeamNoService $ \lhPort chan -> do
@@ -109,12 +108,12 @@ withDummyTestServiceForTeamNoService ::
   forall a.
   HasCallStack =>
   -- | the test
-  (Warp.Port -> Chan (Wai.Request, LBS) -> TestM a) ->
+  (Warp.Port -> Chan (Wai.Request, LByteString) -> TestM a) ->
   TestM a
 withDummyTestServiceForTeamNoService go = do
   withTestService dummyService go
   where
-    dummyService :: Chan (Wai.Request, LBS) -> Wai.Application
+    dummyService :: Chan (Wai.Request, LByteString) -> Wai.Application
     dummyService ch req cont = do
       reqBody <- Wai.strictRequestBody req
       writeChan ch (req, reqBody)
@@ -558,7 +557,7 @@ assertNotification ws predicate =
 assertNoNotification :: (HasCallStack, MonadIO m) => WS.WebSocket -> m ()
 assertNoNotification ws = void . liftIO $ WS.assertNoEvent (5 WS.# WS.Second) [ws]
 
-assertMatchJSON :: (HasCallStack, FromJSON a, MonadCatch m, MonadIO m) => Chan (Wai.Request, LBS) -> (a -> m ()) -> m ()
+assertMatchJSON :: (HasCallStack, FromJSON a, MonadCatch m, MonadIO m) => Chan (Wai.Request, LByteString) -> (a -> m ()) -> m ()
 assertMatchJSON c match = do
   assertMatchChan c $ \(_, reqBody) -> do
     case Aeson.eitherDecode reqBody of

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -65,7 +65,6 @@ import Data.Range
 import Data.Serialize (runPut)
 import qualified Data.Set as Set
 import Data.Singletons
-import Data.String.Conversions (ST, cs)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy.Encoding as T
@@ -1856,7 +1855,7 @@ testResponse status mlabel = do
     Just label -> responseJsonEither === const (Right label)
     Nothing -> (isLeft <$> responseJsonEither @TestErrorLabel) === const True
 
-newtype TestErrorLabel = TestErrorLabel {fromTestErrorLabel :: ST}
+newtype TestErrorLabel = TestErrorLabel {fromTestErrorLabel :: Text}
   deriving (Eq, Show)
 
 instance IsString TestErrorLabel where

--- a/services/gundeck/default.nix
+++ b/services/gundeck/default.nix
@@ -57,7 +57,6 @@
 , safe-exceptions
 , scientific
 , servant-server
-, string-conversions
 , tagged
 , tasty
 , tasty-hunit
@@ -203,7 +202,6 @@ mkDerivation {
     quickcheck-instances
     quickcheck-state-machine
     scientific
-    string-conversions
     tasty
     tasty-hunit
     tasty-quickcheck

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -474,7 +474,6 @@ test-suite gundeck-tests
     , quickcheck-instances
     , quickcheck-state-machine
     , scientific
-    , string-conversions
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/services/gundeck/src/Gundeck/Notification/Data.hs
+++ b/services/gundeck/src/Gundeck/Notification/Data.hs
@@ -34,7 +34,7 @@ import Data.Range (Range, fromRange)
 import Data.Sequence (Seq, ViewL (..), ViewR (..), (<|), (><))
 import qualified Data.Sequence as Seq
 import Gundeck.Options (NotificationTTL (..))
-import Imports
+import Imports hiding (cs)
 import UnliftIO (pooledForConcurrentlyN_)
 import Wire.API.Internal.Notification
 

--- a/services/gundeck/src/Gundeck/Push.hs
+++ b/services/gundeck/src/Gundeck/Push.hs
@@ -62,7 +62,7 @@ import Gundeck.ThreadBudget
 import Gundeck.Types
 import qualified Gundeck.Types.Presence as Presence
 import Gundeck.Util
-import Imports
+import Imports hiding (cs)
 import Network.HTTP.Types
 import Network.Wai.Utilities
 import System.Logger.Class (msg, val, (+++), (.=), (~~))

--- a/services/gundeck/src/Gundeck/Push/Websocket.hs
+++ b/services/gundeck/src/Gundeck/Push/Websocket.hs
@@ -44,7 +44,7 @@ import Gundeck.Monad
 import qualified Gundeck.Presence.Data as Presence
 import Gundeck.Types.Presence
 import Gundeck.Util
-import Imports
+import Imports hiding (cs)
 import Network.HTTP.Client (HttpExceptionContent (..))
 import qualified Network.HTTP.Client.Internal as Http
 import Network.HTTP.Types (StdMethod (POST), status200, status410)

--- a/services/gundeck/test/unit/MockGundeck.hs
+++ b/services/gundeck/test/unit/MockGundeck.hs
@@ -60,7 +60,6 @@ import Data.Misc (Milliseconds (Ms))
 import Data.Range
 import qualified Data.Scientific as Scientific
 import qualified Data.Set as Set
-import Data.String.Conversions
 import Gundeck.Aws.Arn as Aws
 import Gundeck.Options
 import Gundeck.Push

--- a/services/gundeck/test/unit/ThreadBudget.hs
+++ b/services/gundeck/test/unit/ThreadBudget.hs
@@ -29,7 +29,6 @@ import Control.Concurrent.Async
 import Control.Lens
 import Control.Monad.Catch (MonadCatch, catch)
 import Data.Metrics.Middleware (metrics)
-import Data.String.Conversions (cs)
 import Data.Time
 import GHC.Generics
 import Gundeck.Options

--- a/services/spar/default.nix
+++ b/services/spar/default.nix
@@ -56,7 +56,6 @@
 , servant-server
 , servant-swagger
 , silently
-, string-conversions
 , swagger2
 , tasty-hunit
 , text
@@ -119,7 +118,6 @@ mkDerivation {
     saml2-web-sso
     servant-multipart
     servant-server
-    string-conversions
     text
     text-latin1
     time
@@ -180,7 +178,6 @@ mkDerivation {
     servant
     servant-server
     silently
-    string-conversions
     tasty-hunit
     text
     time
@@ -221,7 +218,6 @@ mkDerivation {
     saml2-web-sso
     servant
     servant-swagger
-    string-conversions
     swagger2
     time
     tinylog

--- a/services/spar/migrate-data/src/Spar/DataMigration/V2_UserV2.hs
+++ b/services/spar/migrate-data/src/Spar/DataMigration/V2_UserV2.hs
@@ -27,7 +27,6 @@ import Data.Conduit.Internal (zipSources)
 import qualified Data.Conduit.List as CL
 import Data.Id
 import qualified Data.Map.Strict as Map
-import Data.String.Conversions (cs)
 import Data.Time (UTCTime)
 import Imports
 import qualified SAML2.WebSSO as SAML

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -162,7 +162,6 @@ library
     , saml2-web-sso          >=0.19
     , servant-multipart
     , servant-server
-    , string-conversions
     , text
     , text-latin1
     , time
@@ -355,7 +354,6 @@ executable spar-integration
     , servant-server
     , silently
     , spar
-    , string-conversions
     , tasty-hunit
     , text
     , time
@@ -445,7 +443,6 @@ executable spar-migrate-data
     , optparse-applicative
     , saml2-web-sso         >=0.19
     , spar
-    , string-conversions
     , text
     , time
     , tinylog
@@ -629,7 +626,6 @@ test-suite spec
     , servant
     , servant-swagger
     , spar
-    , string-conversions
     , swagger2
     , time
     , tinylog

--- a/services/spar/src/Spar/API.hs
+++ b/services/spar/src/Spar/API.hs
@@ -56,7 +56,6 @@ import Data.Id
 import Data.Proxy
 import Data.Range
 import qualified Data.Set as Set
-import Data.String.Conversions
 import Data.Time
 import Galley.Types.Teams (HiddenPerm (CreateUpdateDeleteIdp, ReadIdp))
 import Imports
@@ -217,7 +216,7 @@ apiINTERNAL =
     :<|> internalPutSsoSettings
     :<|> internalGetScimUserInfo
 
-appName :: ST
+appName :: Text
 appName = "spar"
 
 ----------------------------------------------------------------------------

--- a/services/spar/src/Spar/Data.hs
+++ b/services/spar/src/Spar/Data.hs
@@ -37,7 +37,6 @@ import Control.Lens
 import Control.Monad.Except
 import Data.CaseInsensitive (foldCase)
 import qualified Data.CaseInsensitive as CI
-import Data.String.Conversions
 import Data.Time
 import GHC.TypeLits (KnownSymbol)
 import Imports
@@ -114,7 +113,7 @@ instance Cql NormalizedUNameID where
 normalizeUnqualifiedNameId :: SAML.UnqualifiedNameID -> NormalizedUNameID
 normalizeUnqualifiedNameId = NormalizedUNameID . foldCase . nameIdTxt
   where
-    nameIdTxt :: SAML.UnqualifiedNameID -> ST
+    nameIdTxt :: SAML.UnqualifiedNameID -> Text
     nameIdTxt (SAML.UNameIDUnspecified txt) = SAML.unsafeFromXmlText txt
     nameIdTxt (SAML.UNameIDEmail email) = SAMLEmail.render $ CI.original email
     nameIdTxt (SAML.UNameIDX509 txt) = SAML.unsafeFromXmlText txt

--- a/services/spar/src/Spar/Data/Instances.hs
+++ b/services/spar/src/Spar/Data/Instances.hs
@@ -33,7 +33,6 @@ where
 
 import Cassandra as Cas
 import Data.ByteString.Conversion (fromByteString, toByteString)
-import Data.String.Conversions
 import Data.X509 (SignedCertificate)
 import Imports
 import SAML2.Util (parseURI')

--- a/services/spar/src/Spar/Error.hs
+++ b/services/spar/src/Spar/Error.hs
@@ -45,7 +45,6 @@ import Bilge (ResponseLBS, responseBody, responseJsonMaybe)
 import qualified Bilge
 import Control.Monad.Except
 import Data.Aeson
-import Data.String.Conversions
 import Data.Typeable (typeRep)
 import GHC.Stack (callStack, prettyCallStack)
 import Imports
@@ -68,43 +67,43 @@ throwSpar :: MonadError SparError m => SparCustomError -> m a
 throwSpar = throwError . SAML.CustomError
 
 data SparCustomError
-  = SparIdPNotFound LT
+  = SparIdPNotFound LText
   | SparSamlCredentialsNotFound
   | SparMissingZUsr
   | SparNotInTeam
-  | SparNoPermission LT
+  | SparNoPermission LText
   | SparSSODisabled
   | SparNoSuchRequest
-  | SparNoRequestRefInResponse LT
-  | SparCouldNotSubstituteSuccessURI LT
-  | SparCouldNotSubstituteFailureURI LT
-  | SparBadInitiateLoginQueryParams LT
-  | SparUserRefInNoOrMultipleTeams LT
-  | SparBadUserName LT
-  | SparCannotCreateUsersOnReplacedIdP LT
-  | SparCouldNotParseRfcResponse LT LT
+  | SparNoRequestRefInResponse LText
+  | SparCouldNotSubstituteSuccessURI LText
+  | SparCouldNotSubstituteFailureURI LText
+  | SparBadInitiateLoginQueryParams LText
+  | SparUserRefInNoOrMultipleTeams LText
+  | SparBadUserName LText
+  | SparCannotCreateUsersOnReplacedIdP LText
+  | SparCouldNotParseRfcResponse LText LText
   | SparReAuthRequired
   | SparReAuthCodeAuthFailed
   | SparReAuthCodeAuthRequired
   | SparCouldNotRetrieveCookie
-  | SparCassandraError LT
+  | SparCassandraError LText
   | SparCassandraTTLError TTLError
-  | SparNewIdPBadMetadata LT
+  | SparNewIdPBadMetadata LText
   | SparNewIdPPubkeyMismatch
-  | SparNewIdPAlreadyInUse LT
-  | SparNewIdPWantHttps LT
+  | SparNewIdPAlreadyInUse LText
+  | SparNewIdPWantHttps LText
   | SparIdPHasBoundUsers
   | SparIdPIssuerInUse
   | SparIdPCannotDeleteOwnIdp
   | IdpDbError IdpDbError
-  | SparProvisioningMoreThanOneIdP LT
+  | SparProvisioningMoreThanOneIdP LText
   | SparProvisioningTokenLimitReached
   | -- | FUTUREWORK(fisx): This constructor is used in exactly one place (see
     -- "Spar.Sem.SAML2.Library"), for an error that immediately gets caught.
     -- Instead, we could just use an IO exception, and catch it with
     -- 'catchErrors' (see "Spar.Run"). Maybe we want to remove this case
     -- altogether? Not sure.
-    SparInternalError LT
+    SparInternalError LText
   | -- | All errors returned from SCIM handlers are wrapped into 'SparScimError'
     SparScimError Scim.ScimError
   deriving (Eq, Show)
@@ -230,12 +229,12 @@ rethrow serviceName resp = do
           )
           (SAML.CustomServant . waiToServant)
 
-parseResponse :: forall a m. (FromJSON a, MonadError SparError m, Typeable a) => LT -> ResponseLBS -> m a
+parseResponse :: forall a m. (FromJSON a, MonadError SparError m, Typeable a) => LText -> ResponseLBS -> m a
 parseResponse serviceName resp = do
-  let typeinfo :: LT
+  let typeinfo :: LText
       typeinfo = cs $ show (typeRep ([] @a)) <> ": "
 
-      err :: forall a'. LT -> m a'
+      err :: forall a'. LText -> m a'
       err = throwSpar . SparCouldNotParseRfcResponse serviceName . (typeinfo <>)
 
   bdy <- maybe (err "no body") pure $ responseBody resp

--- a/services/spar/src/Spar/Intra/BrigApp.hs
+++ b/services/spar/src/Spar/Intra/BrigApp.hs
@@ -52,7 +52,6 @@ import Data.ByteString.Conversion
 import qualified Data.CaseInsensitive as CI
 import Data.Handle (Handle (Handle))
 import Data.Id (TeamId, UserId)
-import Data.String.Conversions
 import Galley.Types.Teams (HiddenPerm (CreateReadDeleteScimToken), IsPerm)
 import Imports
 import Polysemy

--- a/services/spar/src/Spar/Intra/Galley.hs
+++ b/services/spar/src/Spar/Intra/Galley.hs
@@ -26,7 +26,6 @@ import Control.Lens
 import Control.Monad.Except
 import Data.ByteString.Conversion
 import Data.Id (TeamId, UserId)
-import Data.String.Conversions (cs)
 import Galley.Types.Teams
 import Imports
 import Network.HTTP.Types.Method

--- a/services/spar/src/Spar/Options.hs
+++ b/services/spar/src/Spar/Options.hs
@@ -35,7 +35,6 @@ import Control.Lens
 import Control.Monad.Except
 import Data.Aeson hiding (fieldLabelModifier)
 import qualified Data.ByteString as SBS
-import Data.String.Conversions
 import Data.Time
 import qualified Data.Yaml as Yaml
 import Imports

--- a/services/spar/src/Spar/Orphans.hs
+++ b/services/spar/src/Spar/Orphans.hs
@@ -24,7 +24,6 @@ module Spar.Orphans
   )
 where
 
-import Data.String.Conversions (cs)
 import Imports
 import qualified SAML2.WebSSO as SAML
 import Servant (MimeRender (..), PlainText)

--- a/services/spar/src/Spar/Run.hs
+++ b/services/spar/src/Spar/Run.hs
@@ -37,7 +37,6 @@ import Data.Default (def)
 import Data.List.NonEmpty as NE
 import Data.Metrics.Servant (servantPrometheusMiddleware)
 import Data.Proxy (Proxy (Proxy))
-import Data.String.Conversions
 import Imports
 import Network.Wai (Application)
 import qualified Network.Wai as Wai

--- a/services/spar/src/Spar/Scim.hs
+++ b/services/spar/src/Spar/Scim.hs
@@ -62,7 +62,6 @@ module Spar.Scim
   )
 where
 
-import Data.String.Conversions (cs)
 import Imports
 import Polysemy
 import Polysemy.Error (Error, fromExceptionSem, runError, throw, try)

--- a/services/spar/src/Spar/Scim/Auth.hs
+++ b/services/spar/src/Spar/Scim/Auth.hs
@@ -38,7 +38,6 @@ where
 import Control.Lens hiding (Strict, (.=))
 import qualified Data.ByteString.Base64 as ES
 import Data.Id (ScimTokenId, UserId)
-import Data.String.Conversions (cs)
 import Imports
 -- FUTUREWORK: these imports are not very handy.  split up Spar.Scim into
 -- Spar.Scim.{Core,User,Group} to avoid at least some of the hscim name clashes?

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -57,7 +57,6 @@ import Data.ByteString.Conversion (fromByteString, toByteString, toByteString')
 import Data.Handle (Handle (Handle), parseHandle)
 import Data.Id (Id (..), TeamId, UserId, idToText)
 import Data.Json.Util (UTCTimeMillis, fromUTCTimeMillis, toUTCTimeMillis)
-import Data.String.Conversions (cs)
 import qualified Data.Text as Text
 import qualified Data.UUID as UUID
 import qualified Galley.Types.Teams as Galley

--- a/services/spar/src/Spar/Sem/IdPRawMetadataStore/Cassandra.hs
+++ b/services/spar/src/Spar/Sem/IdPRawMetadataStore/Cassandra.hs
@@ -25,7 +25,6 @@ where
 
 import Cassandra as Cas
 import Control.Lens
-import Data.String.Conversions
 import Imports
 import Polysemy
 import qualified SAML2.WebSSO as SAML
@@ -47,22 +46,22 @@ idpRawMetadataStoreToCassandra =
 storeIdPRawMetadata ::
   (HasCallStack, MonadClient m) =>
   SAML.IdPId ->
-  ST ->
+  Text ->
   m ()
 storeIdPRawMetadata idp raw = retry x5 . write ins $ params LocalQuorum (idp, raw)
   where
-    ins :: PrepQuery W (SAML.IdPId, ST) ()
+    ins :: PrepQuery W (SAML.IdPId, Text) ()
     ins = "INSERT INTO idp_raw_metadata (id, metadata) VALUES (?, ?)"
 
 getIdPRawMetadata ::
   (HasCallStack, MonadClient m) =>
   SAML.IdPId ->
-  m (Maybe ST)
+  m (Maybe Text)
 getIdPRawMetadata idp =
   runIdentity
     <$$> (retry x1 . query1 sel $ params LocalQuorum (Identity idp))
   where
-    sel :: PrepQuery R (Identity SAML.IdPId) (Identity ST)
+    sel :: PrepQuery R (Identity SAML.IdPId) (Identity Text)
     sel = "SELECT metadata FROM idp_raw_metadata WHERE id = ?"
 
 deleteIdPRawMetadata ::

--- a/services/spar/src/Spar/Sem/SAML2.hs
+++ b/services/spar/src/Spar/Sem/SAML2.hs
@@ -27,10 +27,9 @@ module Spar.Sem.SAML2
 where
 
 import Data.Id (TeamId)
-import Data.String.Conversions (SBS, ST)
 import Data.Time (NominalDiffTime)
 import GHC.TypeLits (KnownSymbol)
-import Imports (Maybe)
+import Imports (ByteString, Maybe, Text)
 import Polysemy
 import SAML2.WebSSO hiding (meta, toggleCookie)
 import URI.ByteString (URI)
@@ -49,11 +48,11 @@ data SAML2 m a where
     (AuthnResponse -> IdP -> AccessVerdict -> m resp) ->
     AuthnResponseBody ->
     SAML2 m resp
-  Meta :: ST -> m Issuer -> m URI -> SAML2 m SPMetadata
+  Meta :: Text -> m Issuer -> m URI -> SAML2 m SPMetadata
   ToggleCookie ::
     KnownSymbol name =>
-    SBS ->
-    Maybe (ST, NominalDiffTime) ->
+    ByteString ->
+    Maybe (Text, NominalDiffTime) ->
     SAML2 m (SimpleSetCookie name)
 
 -- TODO(sandy): Inline this definition --- no TH

--- a/services/spar/src/Spar/Sem/SAML2/Library.hs
+++ b/services/spar/src/Spar/Sem/SAML2/Library.hs
@@ -24,7 +24,6 @@ module Spar.Sem.SAML2.Library (saml2ToSaml2WebSso) where
 import qualified Control.Monad.Catch as Catch
 import Control.Monad.Except
 import Data.Id (TeamId)
-import Data.String.Conversions (cs)
 import Imports
 import Polysemy
 import Polysemy.Error

--- a/services/spar/src/Spar/Sem/Utils.hs
+++ b/services/spar/src/Spar/Sem/Utils.hs
@@ -30,7 +30,6 @@ import Bilge
 import Cassandra as Cas
 import qualified Control.Monad.Catch as Catch
 import Control.Monad.Except
-import Data.String.Conversions
 import Imports hiding (log)
 import Polysemy
 import Polysemy.Error

--- a/services/spar/test-integration/Main.hs
+++ b/services/spar/test-integration/Main.hs
@@ -30,7 +30,6 @@
 module Main where
 
 import Control.Lens ((.~), (^.))
-import Data.String.Conversions
 import Data.Text (pack)
 import Imports
 import Servant.API (toHeader)

--- a/services/spar/test-integration/Test/LoggingSpec.hs
+++ b/services/spar/test-integration/Test/LoggingSpec.hs
@@ -21,7 +21,6 @@ module Test.LoggingSpec
 where
 
 import Control.Lens
-import Data.String.Conversions (cs)
 import Imports
 import Network.HTTP.Types.Status (statusCode)
 import qualified Network.Wai.Test as HW

--- a/services/spar/test-integration/Test/MetricsSpec.hs
+++ b/services/spar/test-integration/Test/MetricsSpec.hs
@@ -25,7 +25,6 @@ where
 
 import Bilge
 import Control.Lens
-import Data.String.Conversions (cs)
 import Imports
 import Util
 

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -37,7 +37,6 @@ import Data.Id
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Misc
 import Data.Proxy
-import Data.String.Conversions
 import qualified Data.Text as ST
 import qualified Data.Text as T
 import Data.Text.Ascii (decodeBase64, validateBase64)
@@ -218,7 +217,7 @@ specFinalizeLogin = do
         sparresp <- submitAuthnResponse tid authnresp
         liftIO $ do
           statusCode sparresp `shouldBe` 200
-          let bdy = maybe "" (cs @LBS @String) (responseBody sparresp)
+          let bdy = maybe "" (cs @LByteString @String) (responseBody sparresp)
           bdy `shouldContain` "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
           bdy `shouldContain` "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">"
           bdy `shouldContain` "<title>wire:sso:error:forbidden</title>"
@@ -235,7 +234,7 @@ specFinalizeLogin = do
       let loginSuccess :: HasCallStack => ResponseLBS -> TestSpar ()
           loginSuccess sparresp = liftIO $ do
             statusCode sparresp `shouldBe` 200
-            let bdy = maybe "" (cs @LBS @String) (responseBody sparresp)
+            let bdy = maybe "" (cs @LByteString @String) (responseBody sparresp)
             bdy `shouldContain` "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
             bdy `shouldContain` "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">"
             bdy `shouldContain` "<title>wire:sso:success</title>"
@@ -245,7 +244,7 @@ specFinalizeLogin = do
       let loginFailure :: HasCallStack => ResponseLBS -> TestSpar ()
           loginFailure sparresp = liftIO $ do
             statusCode sparresp `shouldBe` 200
-            let bdy = maybe "" (cs @LBS @String) (responseBody sparresp)
+            let bdy = maybe "" (cs @LByteString @String) (responseBody sparresp)
             bdy `shouldContain` "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
             bdy `shouldContain` "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">"
             bdy `shouldNotContain` "<title>wire:sso:error:success</title>"
@@ -927,7 +926,7 @@ specCRUDIdentityProvider = do
             sparresp <- submitAuthnResponse tid idpresp
             liftIO $ do
               statusCode sparresp `shouldBe` expectedStatus
-              let bdy = maybe "" (cs @LBS @String) (responseBody sparresp)
+              let bdy = maybe "" (cs @LByteString @String) (responseBody sparresp)
               bdy `shouldContain` expectedHtmlTitle
               hasPersistentCookieHeader sparresp `shouldBe` expectedCookie
       it "uses those certs on next auth handshake" $ do
@@ -1270,7 +1269,7 @@ specScimAndSAML = do
     accessresp <- call . post $ (env ^. teBrig) . path "/access" . ckyraw
     token :: Text <- liftIO $ do
       statusCode accessresp `shouldBe` 200
-      bdy :: LBS <- maybe (error "no body") pure $ responseBody accessresp
+      bdy :: LByteString <- maybe (error "no body") pure $ responseBody accessresp
       val :: Value <- either error pure $ eitherDecode bdy
       maybe (error "no access token") pure $ val ^? key "access_token" . _String
     -- token should contain the expected userid
@@ -1287,7 +1286,7 @@ specScimAndSAML = do
           . header "Z-User" (toByteString' userid'')
     selfbdy :: SelfProfile <-
       do
-        bdy :: LBS <- maybe (error "no self body") pure $ responseBody self
+        bdy :: LByteString <- maybe (error "no self body") pure $ responseBody self
         either error pure $ eitherDecode bdy
     liftIO $ userId (selfUser selfbdy) `shouldBe` userid
   it "SCIM-provisioned users can login with any qualifiers to NameId" $ do

--- a/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/AuthSpec.hs
@@ -37,7 +37,6 @@ import qualified Data.Code as Code
 import Data.Id (ScimTokenId, TeamId, UserId, randomId)
 import Data.Misc
 import Data.Range (unsafeRange)
-import Data.String.Conversions (cs)
 import Data.Text.Ascii (AsciiChars (validate))
 import Data.Time (UTCTime)
 import Data.Time.Clock (getCurrentTime)

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -51,7 +51,6 @@ import Data.Id (TeamId, UserId, randomId)
 import Data.Ix (inRange)
 import Data.LanguageCodes (ISO639_1 (..))
 import Data.Misc (HttpsUrl, mkHttpsUrl)
-import Data.String.Conversions (cs)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import qualified Data.Vector as V
 import qualified Data.ZAuth.Token as ZAuth

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -30,7 +30,6 @@ import qualified Data.ByteString.Lazy as Lazy
 import Data.Handle (Handle (Handle))
 import Data.Id
 import Data.LanguageCodes (ISO639_1 (EN))
-import Data.String.Conversions (cs)
 import qualified Data.Text.Lazy as Lazy
 import Data.Time
 import Data.UUID as UUID

--- a/services/spar/test-integration/Util/Types.hs
+++ b/services/spar/test-integration/Util/Types.hs
@@ -49,7 +49,6 @@ import Crypto.Random.Types (MonadRandom (..))
 import Data.Aeson
 import qualified Data.Aeson as Aeson
 import Data.Aeson.TH
-import Data.String.Conversions
 import Imports
 import SAML2.WebSSO.Types.TH (deriveJSONOptions)
 import Spar.API ()
@@ -105,7 +104,7 @@ deriveFromJSON deriveJSONOptions ''IntegrationConfig
 
 makeLenses ''TestEnv
 
-newtype TestErrorLabel = TestErrorLabel {fromTestErrorLabel :: ST}
+newtype TestErrorLabel = TestErrorLabel {fromTestErrorLabel :: Text}
   deriving (Eq, Show, IsString)
 
 instance FromJSON TestErrorLabel where

--- a/services/spar/test/Arbitrary.hs
+++ b/services/spar/test/Arbitrary.hs
@@ -26,7 +26,6 @@ module Arbitrary where
 import Data.Aeson
 import Data.Id (TeamId, UserId)
 import Data.Proxy
-import Data.String.Conversions (cs)
 import Data.Swagger hiding (Header (..))
 import Imports
 import SAML2.WebSSO.Test.Arbitrary ()

--- a/services/spar/test/Test/Spar/Intra/BrigSpec.hs
+++ b/services/spar/test/Test/Spar/Intra/BrigSpec.hs
@@ -21,7 +21,6 @@ module Test.Spar.Intra.BrigSpec where
 
 import Arbitrary ()
 import Control.Lens ((^.))
-import Data.String.Conversions (ST, cs)
 import Imports
 import SAML2.WebSSO as SAML
 import Spar.Intra.BrigApp
@@ -31,7 +30,7 @@ import URI.ByteString (URI, laxURIParserOptions, parseURI)
 import Wire.API.User.Identity (UserSSOId (UserSSOId))
 import Wire.API.User.Scim
 
-mkuri :: ST -> URI
+mkuri :: Text -> URI
 mkuri = either (error . show) id . parseURI laxURIParserOptions . cs
 
 spec :: Spec

--- a/tools/db/inconsistencies/default.nix
+++ b/tools/db/inconsistencies/default.nix
@@ -16,7 +16,6 @@
 , imports
 , lib
 , optparse-applicative
-, string-conversions
 , text
 , tinylog
 , types-common
@@ -41,7 +40,6 @@ mkDerivation {
     extra
     imports
     optparse-applicative
-    string-conversions
     text
     tinylog
     types-common

--- a/tools/db/inconsistencies/inconsistencies.cabal
+++ b/tools/db/inconsistencies/inconsistencies.cabal
@@ -80,7 +80,6 @@ executable inconsistencies
     , extra
     , imports
     , optparse-applicative
-    , string-conversions
     , text
     , tinylog
     , types-common

--- a/tools/db/inconsistencies/src/DanglingHandles.hs
+++ b/tools/db/inconsistencies/src/DanglingHandles.hs
@@ -32,7 +32,6 @@ import Data.Conduit.Internal (zipSources)
 import qualified Data.Conduit.List as C
 import Data.Handle
 import Data.Id
-import Data.String.Conversions (cs)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Imports

--- a/tools/db/inconsistencies/src/DanglingUserKeys.hs
+++ b/tools/db/inconsistencies/src/DanglingUserKeys.hs
@@ -35,7 +35,6 @@ import qualified Data.ByteString as BS
 import Data.Conduit.Internal (zipSources)
 import qualified Data.Conduit.List as C
 import Data.Id
-import Data.String.Conversions (cs)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Imports

--- a/tools/db/inconsistencies/src/EmailLessUsers.hs
+++ b/tools/db/inconsistencies/src/EmailLessUsers.hs
@@ -35,7 +35,6 @@ import Data.Conduit.Internal (zipSources)
 import qualified Data.Conduit.List as C
 import Data.Either.Extra
 import Data.Id
-import Data.String.Conversions (cs)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Imports

--- a/tools/db/inconsistencies/src/HandleLessUsers.hs
+++ b/tools/db/inconsistencies/src/HandleLessUsers.hs
@@ -32,7 +32,6 @@ import Data.Conduit.Internal (zipSources)
 import qualified Data.Conduit.List as C
 import Data.Handle
 import Data.Id
-import Data.String.Conversions (cs)
 import Imports
 import System.Logger
 import qualified System.Logger as Log

--- a/tools/db/move-team/src/ParseSchema.hs
+++ b/tools/db/move-team/src/ParseSchema.hs
@@ -26,7 +26,7 @@ import Data.Aeson (ToJSON, object, (.=))
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy.IO as TIO
-import Imports
+import Imports hiding (cs)
 import qualified Options.Applicative as OA
 import System.Environment (withArgs)
 import System.Exit (exitFailure)

--- a/tools/db/repair-handles/default.nix
+++ b/tools/db/repair-handles/default.nix
@@ -14,7 +14,6 @@
 , lib
 , mtl
 , optparse-applicative
-, string-conversions
 , text
 , tinylog
 , types-common
@@ -36,7 +35,6 @@ mkDerivation {
     lens
     mtl
     optparse-applicative
-    string-conversions
     text
     tinylog
     types-common

--- a/tools/db/repair-handles/repair-handles.cabal
+++ b/tools/db/repair-handles/repair-handles.cabal
@@ -75,7 +75,6 @@ executable repair-handles
     , lens
     , mtl
     , optparse-applicative
-    , string-conversions
     , text
     , tinylog
     , types-common

--- a/tools/db/repair-handles/src/Options.hs
+++ b/tools/db/repair-handles/src/Options.hs
@@ -20,7 +20,6 @@ module Options where
 import Brig.Data.Instances ()
 import Cassandra hiding (Set)
 import Data.Id
-import Data.String.Conversions (cs)
 import Data.UUID
 import Imports
 import Options.Applicative hiding (action)

--- a/tools/db/repair-handles/src/Work.hs
+++ b/tools/db/repair-handles/src/Work.hs
@@ -30,7 +30,6 @@ import qualified Data.Conduit.Combinators as C
 import Data.Handle (Handle)
 import Data.Id
 import qualified Data.Map.Strict as Map
-import Data.String.Conversions (cs)
 import qualified Data.Text as T
 import Imports
 import Options

--- a/tools/stern/default.nix
+++ b/tools/stern/default.nix
@@ -37,7 +37,6 @@
 , servant-swagger
 , servant-swagger-ui
 , split
-, string-conversions
 , swagger2
 , tagged
 , tasty
@@ -86,7 +85,6 @@ mkDerivation {
     servant-swagger
     servant-swagger-ui
     split
-    string-conversions
     swagger2
     text
     tinylog
@@ -121,7 +119,6 @@ mkDerivation {
     random
     retry
     schema-profunctor
-    string-conversions
     tagged
     tasty
     tasty-hunit

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -40,7 +40,6 @@ import Data.Id
 import Data.Proxy (Proxy (..))
 import Data.Range
 import Data.Schema hiding ((.=))
-import Data.String.Conversions (cs)
 import Data.Text (unpack)
 import qualified Data.Text as T
 import GHC.TypeLits (KnownSymbol)

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -84,7 +84,6 @@ import Data.Int
 import Data.List.Split (chunksOf)
 import qualified Data.Map as Map
 import Data.Qualified (qUnqualified)
-import Data.String.Conversions (cs)
 import Data.Text (strip)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Text.Lazy (pack)

--- a/tools/stern/stern.cabal
+++ b/tools/stern/stern.cabal
@@ -98,7 +98,6 @@ library
     , servant-swagger
     , servant-swagger-ui
     , split                  >=0.2
-    , string-conversions
     , swagger2
     , text                   >=1.1
     , tinylog                >=0.10
@@ -271,7 +270,6 @@ executable stern-integration
     , retry
     , schema-profunctor
     , stern
-    , string-conversions
     , tagged
     , tasty                  >=0.8
     , tasty-hunit            >=0.9

--- a/tools/stern/test/integration/API.hs
+++ b/tools/stern/test/integration/API.hs
@@ -34,7 +34,6 @@ import Data.Id
 import Data.Range (unsafeRange)
 import Data.Schema
 import qualified Data.Set as Set
-import Data.String.Conversions
 import GHC.TypeLits
 import Imports
 import Stern.API.Routes (UserConnectionGroups (..))

--- a/tools/stern/test/integration/Util.hs
+++ b/tools/stern/test/integration/Util.hs
@@ -34,7 +34,6 @@ import Data.Id
 import Data.Misc
 import Data.Qualified
 import Data.Range
-import Data.String.Conversions
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Data.Tuple.Extra


### PR DESCRIPTION
changes:

- b0964bcdd30d9e8637c405a38b191a58f73efedc
- `s/SBS/ByteString/g`
- `s/LBS/LByteString/g`
- `s/ST/Text/g`
- `s/LT/LText/g`
- remove `import Data.String.Conversions.*`  (at least in most places...)
- hide `cs` from `Imports` imports in a few places to avoid name shadowing

cs is technically not always safe, because it can crash when trying to convert a bytestring elf binary into text.  but first of all, we already use cs everywhere, and furthermore, unpack does exactly the same thing, so we wouldn't be any safer without cs.  (i think.)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
