### PR TITLE
Add bash/sh interpreters to development environment

### DIFF
--- a/hack/bin/python3.sh
+++ b/hack/bin/python3.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # You can use this wrapper when configurating your editor's linter integration
 

--- a/integration/scripts/integration-dynamic-backends-brig-index.sh
+++ b/integration/scripts/integration-dynamic-backends-brig-index.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # shellcheck disable=SC3040
 #
 set -eo pipefail

--- a/integration/scripts/integration-dynamic-backends-db-schemas.sh
+++ b/integration/scripts/integration-dynamic-backends-db-schemas.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # shellcheck disable=SC3040,SC3045,SC3057
 
 set -eo pipefail

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -389,6 +389,8 @@ in
   devEnv = pkgs.buildEnv {
     name = "wire-server-dev-env";
     paths = commonTools ++ [
+      pkgs.bash
+      pkgs.dash
       (pkgs.haskell-language-server.override { supportedGhcVersions = [ "92" ]; })
       pkgs.ghcid
       pkgs.kind


### PR DESCRIPTION
I've tested that scripts with

```
#!/usr/bin/env bash
```

(or `sh`) will use the interpreter in `.env/bin/bash` (or `.env/bin/sh`). Even though in my shell `which bash` doesn't point to the executable in `.env/bin`.
