### PR TITLE
[chore] Add default suite to make ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,12 +97,10 @@ endif
 .PHONY: ci
 ci: c db-migrate
 ifeq ("$(package)", "all")
-	 make c
 	./hack/bin/cabal-run-integration.sh all
 	./hack/bin/cabal-run-integration.sh integration
 endif
 ifeq ("$(package)", "integration")
-	make c package=integration
 	./hack/bin/cabal-run-integration.sh integration
 else
 	make c package=$(package)

--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,7 @@ ifeq ("$(package)", "all")
 	./hack/bin/cabal-run-integration.sh all
 	./hack/bin/cabal-run-integration.sh integration
 endif
-ifeq ("$(package)", "integration")
-	./hack/bin/cabal-run-integration.sh integration
-else
 	./hack/bin/cabal-run-integration.sh $(package)
-endif
 
 # Compile and run services
 # Usage: make crun `OR` make crun package=galley

--- a/Makefile
+++ b/Makefile
@@ -98,30 +98,16 @@ endif
 .PHONY: ci
 ci: c db-migrate
 ifeq ("$(package)", "all")
-    ifneq ("$(suite)", "new")
-		./hack/bin/cabal-run-integration.sh all
-    endif
-    ifneq ("$(suite)", "old")
-		make c package=integration
-		./hack/bin/cabal-run-integration.sh integration
-    endif
-else
-  ifeq ("$(package)", "integration")
+	 make c
+	./hack/bin/cabal-run-integration.sh all
 	./hack/bin/cabal-run-integration.sh integration
-  else
-    ifeq ("$(suite)", "old")
-		./hack/bin/cabal-run-integration.sh $(package)
-    else
-      ifeq ("$(suite)", "new")
-		make c package=integration
-		./hack/bin/cabal-run-integration.sh integration
-      else
-		make c package=integration
-		./hack/bin/cabal-run-integration.sh $(package)
-		./hack/bin/cabal-run-integration.sh integration
-      endif
-    endif
-  endif
+endif
+ifeq ("$(package)", "integration")
+	make c package=integration
+	./hack/bin/cabal-run-integration.sh integration
+else
+	make c package=$(package)
+	./hack/bin/cabal-run-integration.sh $(package)
 endif
 
 # Compile and run services

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ endif
 
 # ci here doesn't refer to continuous integration, but to cabal-run-integration.sh
 # Usage: make ci                        - build & run all tests, excluding integration
-#        make ci all                    - build & run all tests, including integration
+#        make ci package=all            - build & run all tests, including integration
 #        make ci package=brig           - build brig & run "brig-integration" 
 #        make ci package=integration    - build & run "integration"
 #

--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,9 @@ endif
 	./hack/bin/cabal-install-artefacts.sh $(package)
 
 # ci here doesn't refer to continuous integration, but to cabal-run-integration.sh
-# Usage: make ci                        - build & run all tests
-#        make ci package=brig           - build brig & run "brig-integration" and "integration"
-#        make ci package=brig suite=old - build brig & run "brig-integration"
-#        make ci package=brig suite=new - build brig & run "integration"
+# Usage: make ci                        - build & run all tests, excluding integration
+#        make ci all                    - build & run all tests, including integration
+#        make ci package=brig           - build brig & run "brig-integration" 
 #        make ci package=integration    - build & run "integration"
 #
 # You can pass environment variables to all the suites, like so

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,6 @@ endif
 ifeq ("$(package)", "integration")
 	./hack/bin/cabal-run-integration.sh integration
 else
-	make c package=$(package)
 	./hack/bin/cabal-run-integration.sh $(package)
 endif
 


### PR DESCRIPTION
This should restore the previous behaviour of calling a bare `make ci`.
