### PR TITLE
[WIP] Remove lenses from galley options

### DIFF
--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -26,25 +26,8 @@ module Galley.Types.Teams
   ( TeamCreationTime (..),
     tcTime,
     FeatureFlags (..),
-    flagSSO,
-    flagLegalHold,
-    flagTeamSearchVisibility,
-    flagFileSharing,
-    flagAppLockDefaults,
-    flagClassifiedDomains,
-    flagConferenceCalling,
-    flagSelfDeletingMessages,
-    flagConversationGuestLinks,
-    flagsTeamFeatureValidateSAMLEmailsStatus,
-    flagTeamFeatureSndFactorPasswordChallengeStatus,
-    flagTeamFeatureSearchVisibilityInbound,
-    flagOutlookCalIntegration,
-    flagMLS,
-    flagMlsE2EId,
     Defaults (..),
     ImplicitLockStatus (..),
-    unImplicitLockStatus,
-    unDefaults,
     FeatureSSO (..),
     FeatureLegalHold (..),
     FeatureTeamSearchVisibilityAvailability (..),
@@ -139,25 +122,25 @@ newtype TeamCreationTime = TeamCreationTime
   }
 
 data FeatureFlags = FeatureFlags
-  { _flagSSO :: !FeatureSSO,
-    _flagLegalHold :: !FeatureLegalHold,
-    _flagTeamSearchVisibility :: !FeatureTeamSearchVisibilityAvailability,
-    _flagAppLockDefaults :: !(Defaults (ImplicitLockStatus AppLockConfig)),
-    _flagClassifiedDomains :: !(ImplicitLockStatus ClassifiedDomainsConfig),
-    _flagFileSharing :: !(Defaults (WithStatus FileSharingConfig)),
-    _flagConferenceCalling :: !(Defaults (ImplicitLockStatus ConferenceCallingConfig)),
-    _flagSelfDeletingMessages :: !(Defaults (WithStatus SelfDeletingMessagesConfig)),
-    _flagConversationGuestLinks :: !(Defaults (WithStatus GuestLinksConfig)),
-    _flagsTeamFeatureValidateSAMLEmailsStatus :: !(Defaults (ImplicitLockStatus ValidateSAMLEmailsConfig)),
-    _flagTeamFeatureSndFactorPasswordChallengeStatus :: !(Defaults (WithStatus SndFactorPasswordChallengeConfig)),
-    _flagTeamFeatureSearchVisibilityInbound :: !(Defaults (ImplicitLockStatus SearchVisibilityInboundConfig)),
-    _flagMLS :: !(Defaults (ImplicitLockStatus MLSConfig)),
-    _flagOutlookCalIntegration :: !(Defaults (WithStatus OutlookCalIntegrationConfig)),
-    _flagMlsE2EId :: !(Defaults (WithStatus MlsE2EIdConfig))
+  { sso :: !FeatureSSO,
+    legalHold :: !FeatureLegalHold,
+    teamSearchVisibility :: !FeatureTeamSearchVisibilityAvailability,
+    appLockDefaults :: !(Defaults (ImplicitLockStatus AppLockConfig)),
+    classifiedDomains :: !(ImplicitLockStatus ClassifiedDomainsConfig),
+    fileSharing :: !(Defaults (WithStatus FileSharingConfig)),
+    conferenceCalling :: !(Defaults (ImplicitLockStatus ConferenceCallingConfig)),
+    selfDeletingMessages :: !(Defaults (WithStatus SelfDeletingMessagesConfig)),
+    conversationGuestLinks :: !(Defaults (WithStatus GuestLinksConfig)),
+    teamFeatureValidateSAMLEmailsStatus :: !(Defaults (ImplicitLockStatus ValidateSAMLEmailsConfig)),
+    teamFeatureSndFactorPasswordChallengeStatus :: !(Defaults (WithStatus SndFactorPasswordChallengeConfig)),
+    teamFeatureSearchVisibilityInbound :: !(Defaults (ImplicitLockStatus SearchVisibilityInboundConfig)),
+    mls :: !(Defaults (ImplicitLockStatus MLSConfig)),
+    outlookCalIntegration :: !(Defaults (WithStatus OutlookCalIntegrationConfig)),
+    mlsE2EId :: !(Defaults (WithStatus MlsE2EIdConfig))
   }
   deriving (Eq, Show, Generic)
 
-newtype Defaults a = Defaults {_unDefaults :: a}
+newtype Defaults a = Defaults {unDefaults :: a}
   deriving (Eq, Ord, Show, Enum, Bounded, Generic, Functor)
   deriving newtype (Arbitrary)
 

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 -- This file is part of the Wire Server implementation.
 --
@@ -81,13 +79,12 @@ module Wire.API.Team.Feature
     OutlookCalIntegrationConfig (..),
     MlsE2EIdConfig (..),
     AllFeatureConfigs (..),
-    unImplicitLockStatus,
     ImplicitLockStatus (..),
   )
 where
 
 import qualified Cassandra.CQL as Cass
-import Control.Lens (makeLenses, (?~))
+import Control.Lens ((?~))
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Types as A
 import qualified Data.Attoparsec.ByteString as Parser
@@ -538,7 +535,7 @@ instance ToSchema LockStatusResponse where
       LockStatusResponse
         <$> _unlockStatus .= field "lockStatus" schema
 
-newtype ImplicitLockStatus (cfg :: Type) = ImplicitLockStatus {_unImplicitLockStatus :: WithStatus cfg}
+newtype ImplicitLockStatus (cfg :: Type) = ImplicitLockStatus {unImplicitLockStatus :: WithStatus cfg}
   deriving newtype (Eq, Show, Arbitrary)
 
 instance (IsFeatureConfig a, ToSchema a) => ToJSON (ImplicitLockStatus a) where
@@ -1107,5 +1104,3 @@ instance Arbitrary AllFeatureConfigs where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-
-makeLenses ''ImplicitLockStatus

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -427,7 +427,7 @@ rmUser lusr conn = do
 
 deleteLoop :: App ()
 deleteLoop = do
-  q <- view deleteQueue
+  q <- asks deleteQueue
   safeForever "deleteLoop" $ do
     i@(TeamItem tid usr con) <- Q.pop q
     env <- ask

--- a/services/galley/src/Galley/API/LegalHold/Conflicts.hs
+++ b/services/galley/src/Galley/API/LegalHold/Conflicts.hs
@@ -84,8 +84,8 @@ guardLegalholdPolicyConflicts ::
 guardLegalholdPolicyConflicts LegalholdPlusFederationNotImplemented _otherClients = pure ()
 guardLegalholdPolicyConflicts UnprotectedBot _otherClients = pure ()
 guardLegalholdPolicyConflicts (ProtectedUser self) otherClients = do
-  opts <- input
-  case view (optSettings . setFeatureFlags . flagLegalHold) opts of
+  opts <- input @Opts
+  case opts.settings.featureFlags.legalHold of
     FeatureLegalHoldDisabledPermanently -> case FutureWork @'LegalholdPlusFederationNotImplemented () of
       FutureWork () -> pure () -- FUTUREWORK: if federation is enabled, we still need to run the guard!
     FeatureLegalHoldDisabledByDefault -> guardLegalholdPolicyConflictsUid self otherClients

--- a/services/galley/src/Galley/API/MLS.hs
+++ b/services/galley/src/Galley/API/MLS.hs
@@ -27,7 +27,6 @@ module Galley.API.MLS
   )
 where
 
-import Control.Lens (view)
 import Data.Id
 import Data.Qualified
 import Galley.API.MLS.Enabled
@@ -49,5 +48,5 @@ getMLSPublicKeys ::
   Sem r MLSPublicKeys
 getMLSPublicKeys _ = do
   assertMLSEnabled
-  keys <- inputs (view mlsKeys)
+  keys <- inputs mlsKeys
   pure $ mlsKeysToPublic keys

--- a/services/galley/src/Galley/API/MLS/Keys.hs
+++ b/services/galley/src/Galley/API/MLS/Keys.hs
@@ -17,7 +17,6 @@
 
 module Galley.API.MLS.Keys (getMLSRemovalKey) where
 
-import Control.Lens (view)
 import Crypto.PubKey.Ed25519 (PublicKey, SecretKey)
 import Galley.Env
 import Imports
@@ -27,4 +26,4 @@ import Wire.API.MLS.Credential (SignaturePurpose (RemovalPurpose))
 import Wire.API.MLS.Keys
 
 getMLSRemovalKey :: Member (Input Env) r => Sem r (Maybe (SecretKey, PublicKey))
-getMLSRemovalKey = mlsKeyPair_ed25519 <$> (inputs (view mlsKeys) <*> pure RemovalPurpose)
+getMLSRemovalKey = mlsKeyPair_ed25519 <$> (inputs mlsKeys <*> pure RemovalPurpose)

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -407,7 +407,7 @@ postQualifiedOtrMessage senderType sender mconn lcnv msg =
             Set.fromList $
               map (tUntagged . qualifyAs lcnv) localMemberIds
                 <> map (tUntagged . rmId) (convRemoteMembers conv)
-      isInternal <- view (optSettings . setIntraListing) <$> input
+      isInternal <- inputs @Opts (.settings.intraListing)
 
       -- check if the sender is part of the conversation
       unless (Set.member sender members) $

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -689,7 +689,7 @@ getConversationGuestLinksFeatureStatus ::
   Maybe TeamId ->
   Sem r (WithStatus GuestLinksConfig)
 getConversationGuestLinksFeatureStatus mbTid = do
-  defaultStatus :: WithStatus GuestLinksConfig <- input <&> view (optSettings . setFeatureFlags . flagConversationGuestLinks . unDefaults)
+  defaultStatus :: WithStatus GuestLinksConfig <- inputs @Opts (.settings.featureFlags.conversationGuestLinks.unDefaults)
   case mbTid of
     Nothing -> pure defaultStatus
     Just tid -> do

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -442,10 +442,10 @@ uncheckedDeleteTeam lusr zcon tid = do
   where
     pushDeleteEvents :: [TeamMember] -> Event -> [Push] -> Sem r ()
     pushDeleteEvents membs e ue = do
-      o <- inputs (view optSettings)
+      o <- inputs settings
       let r = list1 (userRecipient (tUnqualified lusr)) (membersToRecipients (Just (tUnqualified lusr)) membs)
       -- To avoid DoS on gundeck, send team deletion events in chunks
-      let chunkSize = fromMaybe defConcurrentDeletionEvents (o ^. setConcurrentDeletionEvents)
+      let chunkSize = fromMaybe defConcurrentDeletionEvents (o.concurrentDeletionEvents)
       let chunks = List.chunksOf chunkSize (toList r)
       forM_ chunks $ \case
         [] -> pure ()
@@ -1216,9 +1216,9 @@ ensureNotTooLarge ::
   TeamId ->
   Sem r TeamSize
 ensureNotTooLarge tid = do
-  o <- input
+  o <- input @Opts
   (TeamSize size) <- E.getSize tid
-  unless (size < fromIntegral (o ^. optSettings . setMaxTeamSize)) $
+  unless (size < fromIntegral o.settings.maxTeamSize) $
     throwS @'TooManyTeamMembers
   pure $ TeamSize size
 

--- a/services/galley/src/Galley/API/Teams/Features/Get.hs
+++ b/services/galley/src/Galley/API/Teams/Features/Get.hs
@@ -356,7 +356,7 @@ genericGetConfigForUser uid = do
 instance GetFeatureConfig SSOConfig where
   getConfigForServer = do
     status <-
-      inputs (view (optSettings . setFeatureFlags . flagSSO)) <&> \case
+      inputs @Opts (.settings.featureFlags.sso) <&> \case
         FeatureSSOEnabledByDefault -> FeatureStatusEnabled
         FeatureSSODisabledByDefault -> FeatureStatusDisabled
     pure $ setStatus status defFeatureStatus
@@ -366,14 +366,14 @@ instance GetFeatureConfig SSOConfig where
 instance GetFeatureConfig SearchVisibilityAvailableConfig where
   getConfigForServer = do
     status <-
-      inputs (view (optSettings . setFeatureFlags . flagTeamSearchVisibility)) <&> \case
+      inputs @Opts (.settings.featureFlags.teamSearchVisibility) <&> \case
         FeatureTeamSearchVisibilityAvailableByDefault -> FeatureStatusEnabled
         FeatureTeamSearchVisibilityUnavailableByDefault -> FeatureStatusDisabled
     pure $ setStatus status defFeatureStatus
 
 instance GetFeatureConfig ValidateSAMLEmailsConfig where
   getConfigForServer =
-    inputs (view (optSettings . setFeatureFlags . flagsTeamFeatureValidateSAMLEmailsStatus . unDefaults . unImplicitLockStatus))
+    inputs @Opts (.settings.featureFlags.teamFeatureValidateSAMLEmailsStatus.unDefaults.unImplicitLockStatus)
 
 instance GetFeatureConfig DigitalSignaturesConfig
 
@@ -405,15 +405,15 @@ instance GetFeatureConfig LegalholdConfig where
 
 instance GetFeatureConfig FileSharingConfig where
   getConfigForServer =
-    input <&> view (optSettings . setFeatureFlags . flagFileSharing . unDefaults)
+    input @Opts <&> (.settings.featureFlags.fileSharing.unDefaults)
 
 instance GetFeatureConfig AppLockConfig where
   getConfigForServer =
-    input <&> view (optSettings . setFeatureFlags . flagAppLockDefaults . unDefaults . unImplicitLockStatus)
+    input @Opts <&> (.settings.featureFlags.appLockDefaults.unDefaults.unImplicitLockStatus)
 
 instance GetFeatureConfig ClassifiedDomainsConfig where
   getConfigForServer =
-    input <&> view (optSettings . setFeatureFlags . flagClassifiedDomains . unImplicitLockStatus)
+    input @Opts <&> (.settings.featureFlags.classifiedDomains.unImplicitLockStatus)
 
 instance GetFeatureConfig ConferenceCallingConfig where
   type
@@ -428,7 +428,7 @@ instance GetFeatureConfig ConferenceCallingConfig where
       )
 
   getConfigForServer =
-    input <&> view (optSettings . setFeatureFlags . flagConferenceCalling . unDefaults . unImplicitLockStatus)
+    input @Opts <&> (.settings.featureFlags.conferenceCalling.unDefaults.unImplicitLockStatus)
 
   getConfigForUser uid = do
     wsnl <- getAccountConferenceCallingConfigClient uid
@@ -436,27 +436,27 @@ instance GetFeatureConfig ConferenceCallingConfig where
 
 instance GetFeatureConfig SelfDeletingMessagesConfig where
   getConfigForServer =
-    input <&> view (optSettings . setFeatureFlags . flagSelfDeletingMessages . unDefaults)
+    input @Opts <&> (.settings.featureFlags.selfDeletingMessages.unDefaults)
 
 instance GetFeatureConfig GuestLinksConfig where
   getConfigForServer =
-    input <&> view (optSettings . setFeatureFlags . flagConversationGuestLinks . unDefaults)
+    input @Opts <&> (.settings.featureFlags.conversationGuestLinks.unDefaults)
 
 instance GetFeatureConfig SndFactorPasswordChallengeConfig where
   getConfigForServer =
-    input <&> view (optSettings . setFeatureFlags . flagTeamFeatureSndFactorPasswordChallengeStatus . unDefaults)
+    input @Opts <&> (.settings.featureFlags.teamFeatureSndFactorPasswordChallengeStatus.unDefaults)
 
 instance GetFeatureConfig SearchVisibilityInboundConfig where
   getConfigForServer =
-    input <&> view (optSettings . setFeatureFlags . flagTeamFeatureSearchVisibilityInbound . unDefaults . unImplicitLockStatus)
+    input @Opts <&> (.settings.featureFlags.teamFeatureSearchVisibilityInbound.unDefaults.unImplicitLockStatus)
 
 instance GetFeatureConfig MLSConfig where
   getConfigForServer =
-    input <&> view (optSettings . setFeatureFlags . flagMLS . unDefaults . unImplicitLockStatus)
+    input @Opts <&> (.settings.featureFlags.mls.unDefaults.unImplicitLockStatus)
 
 instance GetFeatureConfig ExposeInvitationURLsToTeamAdminConfig where
   getConfigForTeam tid = do
-    allowList <- input <&> view (optSettings . setExposeInvitationURLsTeamAllowlist . to (fromMaybe []))
+    allowList <- fromMaybe [] <$> inputs @Opts (.settings.exposeInvitationURLsTeamAllowlist)
     mbOldStatus <- TeamFeatures.getFeatureConfig FeatureSingletonExposeInvitationURLsToTeamAdminConfig tid <&> fmap wssStatus
     let teamAllowed = tid `elem` allowList
     pure $ computeConfigForTeam teamAllowed (fromMaybe FeatureStatusDisabled mbOldStatus)
@@ -477,11 +477,11 @@ instance GetFeatureConfig ExposeInvitationURLsToTeamAdminConfig where
 
 instance GetFeatureConfig OutlookCalIntegrationConfig where
   getConfigForServer =
-    input <&> view (optSettings . setFeatureFlags . flagOutlookCalIntegration . unDefaults)
+    input @Opts <&> (.settings.featureFlags.outlookCalIntegration.unDefaults)
 
 instance GetFeatureConfig MlsE2EIdConfig where
   getConfigForServer =
-    input <&> view (optSettings . setFeatureFlags . flagMlsE2EId . unDefaults)
+    input @Opts <&> (.settings.featureFlags.mlsE2EId.unDefaults)
 
 -- -- | If second factor auth is enabled, make sure that end-points that don't support it, but should, are blocked completely.  (This is a workaround until we have 2FA for those end-points as well.)
 -- --

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -828,8 +828,8 @@ anyLegalholdActivated ::
   [UserId] ->
   Sem r Bool
 anyLegalholdActivated uids = do
-  opts <- input
-  case view (optSettings . setFeatureFlags . flagLegalHold) opts of
+  opts <- input @Opts
+  case opts.settings.featureFlags.legalHold of
     FeatureLegalHoldDisabledPermanently -> pure False
     FeatureLegalHoldDisabledByDefault -> check
     FeatureLegalHoldWhitelistTeamsAndImplicitConsent -> check
@@ -847,8 +847,8 @@ allLegalholdConsentGiven ::
   [UserId] ->
   Sem r Bool
 allLegalholdConsentGiven uids = do
-  opts <- input
-  case view (optSettings . setFeatureFlags . flagLegalHold) opts of
+  opts <- input @Opts
+  case opts.settings.featureFlags.legalHold of
     FeatureLegalHoldDisabledPermanently -> pure False
     FeatureLegalHoldDisabledByDefault -> do
       flip allM (chunksOf 32 uids) $ \uidsPage -> do
@@ -892,9 +892,8 @@ ensureMemberLimit ::
   f a ->
   Sem r ()
 ensureMemberLimit old new = do
-  o <- input
-  let maxSize = fromIntegral (o ^. optSettings . setMaxConvSize)
-  when (length old + length new > maxSize) $
+  o <- input @Opts
+  when (length old + length new > fromIntegral o.settings.maxConvSize) $
     throwS @'TooManyMembers
 
 conversationExisted ::

--- a/services/galley/src/Galley/Cassandra/Client.hs
+++ b/services/galley/src/Galley/Cassandra/Client.hs
@@ -69,4 +69,4 @@ interpretClientStoreToCassandra = interpret $ \case
   CreateClient uid cid -> embedClient $ updateClient True uid cid
   DeleteClient uid cid -> embedClient $ updateClient False uid cid
   DeleteClients uid -> embedClient $ eraseClients uid
-  UseIntraClientListing -> embedApp . view $ options . optSettings . setIntraListing
+  UseIntraClientListing -> embedApp $ asks (.options.settings.intraListing)

--- a/services/galley/src/Galley/Cassandra/Code.hs
+++ b/services/galley/src/Galley/Cassandra/Code.hs
@@ -21,7 +21,6 @@ module Galley.Cassandra.Code
 where
 
 import Cassandra
-import Control.Lens
 import Data.Code
 import qualified Galley.Cassandra.Queries as Cql
 import Galley.Cassandra.Store
@@ -49,7 +48,7 @@ interpretCodeStoreToCassandra = interpret $ \case
   MakeKey cid -> Code.mkKey cid
   GenerateCode cid s t -> Code.generate cid s t
   GetConversationCodeURI ->
-    view (options . optSettings . setConversationCodeURI) <$> input
+    inputs @Env (.options.settings.conversationCodeURI)
 
 -- | Insert a conversation code
 insertCode :: Code -> Maybe Password -> Client ()

--- a/services/galley/src/Galley/Cassandra/Team.hs
+++ b/services/galley/src/Galley/Cassandra/Team.hs
@@ -48,7 +48,6 @@ import Galley.Effects.ListItems
 import Galley.Effects.TeamMemberStore
 import Galley.Effects.TeamStore (TeamStore (..))
 import Galley.Env
-import Galley.Monad
 import Galley.Options
 import Galley.Types.Teams
 import Imports hiding (Set, max)
@@ -96,11 +95,11 @@ interpretTeamStoreToCassandra lh = interpret $ \case
   DeleteTeamConversation tid cid -> embedClient $ removeTeamConv tid cid
   SetTeamData tid upd -> embedClient $ updateTeam tid upd
   SetTeamStatus tid st -> embedClient $ updateTeamStatus tid st
-  FanoutLimit -> embedApp $ currentFanoutLimit <$> view options
+  FanoutLimit -> inputs @Env $ (\env -> currentFanoutLimit env.options)
   GetLegalHoldFlag ->
-    view (options . optSettings . setFeatureFlags . flagLegalHold) <$> input
+    inputs @Env (.options.settings.featureFlags.legalHold)
   EnqueueTeamEvent e -> do
-    menv <- inputs (view aEnv)
+    menv <- inputs @Env (.awsEnv)
     for_ menv $ \env ->
       embed @IO $ Aws.execute env (Aws.enqueue e)
 

--- a/services/galley/src/Galley/External.hs
+++ b/services/galley/src/Galley/External.hs
@@ -150,7 +150,7 @@ urlPort (HttpsUrl u) = do
 
 sendMessage :: [Fingerprint Rsa] -> (Request -> Request) -> App ()
 sendMessage fprs reqBuilder = do
-  (man, verifyFingerprints) <- view (extEnv . extGetManager)
+  (man, verifyFingerprints) <- asks (.extEnv.extGetManager)
   liftIO . withVerifiedSslConnection (verifyFingerprints fprs) man reqBuilder $ \req ->
     Http.withResponse req man (const $ pure ())
 

--- a/services/galley/src/Galley/External/LegalHoldService/Internal.hs
+++ b/services/galley/src/Galley/External/LegalHoldService/Internal.hs
@@ -23,7 +23,6 @@ where
 
 import qualified Bilge
 import Bilge.Retry
-import Control.Lens (view)
 import Control.Monad.Catch
 import Control.Retry
 import qualified Data.ByteString as BS
@@ -81,7 +80,7 @@ makeVerifiedRequest ::
   (Http.Request -> Http.Request) ->
   App (Http.Response LC8.ByteString)
 makeVerifiedRequest fpr url reqBuilder = do
-  (mgr, verifyFingerprints) <- view (extEnv . extGetManager)
+  (mgr, verifyFingerprints) <- asks (.extEnv.extGetManager)
   makeVerifiedRequestWithManager mgr verifyFingerprints fpr url reqBuilder
 
 -- | NOTE: Use this function wisely - this creates a new manager _every_ time it is called.

--- a/services/galley/src/Galley/Intra/Federator.hs
+++ b/services/galley/src/Galley/Intra/Federator.hs
@@ -45,16 +45,16 @@ interpretFederatorAccess = interpret $ \case
   RunFederatedConcurrentlyEither rs f ->
     embedApp $
       runFederatedConcurrentlyEither rs f
-  IsFederationConfigured -> embedApp $ isJust <$> view federator
+  IsFederationConfigured -> embedApp $ isJust <$> asks (.federator)
 
 runFederatedEither ::
   Remote x ->
   FederatorClient c a ->
   App (Either FederationError a)
 runFederatedEither (tDomain -> remoteDomain) rpc = do
-  ownDomain <- view (options . optSettings . setFederationDomain)
-  mfedEndpoint <- view federator
-  mgr <- view http2Manager
+  ownDomain <- asks (.options.settings.federationDomain)
+  mfedEndpoint <- asks (.federator)
+  mgr <- asks http2Manager
   case mfedEndpoint of
     Nothing -> pure (Left FederationNotConfigured)
     Just fedEndpoint -> do

--- a/services/galley/src/Galley/Intra/Journal.hs
+++ b/services/galley/src/Galley/Intra/Journal.hs
@@ -138,14 +138,9 @@ getBillingUserIds ::
   Maybe TeamMemberList ->
   Sem r [UserId]
 getBillingUserIds tid maybeMemberList = do
-  opts <- input
+  opts <- input @Opts.Opts
   let enableIndexedBillingTeamMembers =
-        view
-          ( Opts.optSettings
-              . Opts.setEnableIndexedBillingTeamMembers
-              . to (fromMaybe False)
-          )
-          opts
+        fromMaybe False $ opts.settings.enableIndexedBillingTeamMembers
   case maybeMemberList of
     Nothing ->
       if enableIndexedBillingTeamMembers

--- a/services/galley/src/Galley/Intra/Push/Internal.hs
+++ b/services/galley/src/Galley/Intra/Push/Internal.hs
@@ -20,7 +20,7 @@
 module Galley.Intra.Push.Internal where
 
 import Bilge hiding (options)
-import Control.Lens (makeLenses, set, view, (.~))
+import Control.Lens (makeLenses, set, (.~))
 import Data.Aeson (Object)
 import Data.Id (ConnId, UserId)
 import Data.Json.Util
@@ -95,7 +95,7 @@ push ps = do
 -- more than 128 recipients.
 pushLocal :: NonEmpty (PushTo UserId) -> App ()
 pushLocal ps = do
-  opts <- view options
+  opts <- asks (.options)
   let limit = currentFanoutLimit opts
   -- Do not fan out for very large teams
   let (asyncs, syncs) = partition _pushAsync (removeIfLargeFanout limit $ toList ps)
@@ -188,7 +188,7 @@ newConversationEventPush e users =
 
 pushSlowly :: Foldable f => f Push -> App ()
 pushSlowly ps = do
-  mmillis <- view (options . optSettings . setDeleteConvThrottleMillis)
+  mmillis <- asks (.options.settings.deleteConvThrottleMillis)
   let delay = 1000 * fromMaybe defDeleteConvThrottleMillis mmillis
   forM_ ps $ \p -> do
     push [p]

--- a/services/galley/src/Galley/Intra/User.hs
+++ b/services/galley/src/Galley/Intra/User.hs
@@ -40,7 +40,7 @@ import Bilge.RPC
 import Brig.Types.Connection (UpdateConnectionsInternal, cUsers)
 import qualified Brig.Types.Intra as Brig
 import Control.Error hiding (bool, isRight)
-import Control.Lens (view, (^.))
+import Control.Lens ((^.))
 import Control.Monad.Catch
 import Data.ByteString.Char8 (pack)
 import qualified Data.ByteString.Char8 as BSC
@@ -251,8 +251,8 @@ updateSearchVisibilityInbound =
 
 runHereClientM :: HasCallStack => Client.ClientM a -> App (Either Client.ClientError a)
 runHereClientM action = do
-  mgr <- view manager
-  brigep <- view brig
+  mgr <- asks (.manager)
+  brigep <- asks (.brig)
   let env = Client.mkClientEnv mgr baseurl
       baseurl = Client.BaseUrl Client.Http (cs $ brigep ^. epHost) (fromIntegral $ brigep ^. epPort) ""
   liftIO $ Client.runClientM action env

--- a/services/galley/src/Galley/Intra/Util.hs
+++ b/services/galley/src/Galley/Intra/Util.hs
@@ -25,7 +25,6 @@ where
 import Bilge hiding (getHeader, options, statusCode)
 import Bilge.RPC
 import Bilge.Retry
-import Control.Lens (view, (^.))
 import Control.Monad.Catch
 import Control.Retry
 import qualified Data.ByteString.Lazy as LB
@@ -51,14 +50,14 @@ componentName Gundeck = "gundeck"
 
 componentRequest :: IntraComponent -> Opts -> Request -> Request
 componentRequest Brig o =
-  host (encodeUtf8 (o ^. optBrig . epHost))
-    . port (portNumber (fromIntegral (o ^. optBrig . epPort)))
+  host (encodeUtf8 (o.brig._epHost))
+    . port (portNumber (fromIntegral (o.brig._epPort)))
 componentRequest Spar o =
-  host (encodeUtf8 (o ^. optSpar . epHost))
-    . port (portNumber (fromIntegral (o ^. optSpar . epPort)))
+  host (encodeUtf8 (o.spar._epHost))
+    . port (portNumber (fromIntegral (o.spar._epPort)))
 componentRequest Gundeck o =
-  host (encodeUtf8 $ o ^. optGundeck . epHost)
-    . port (portNumber $ fromIntegral (o ^. optGundeck . epPort))
+  host (encodeUtf8 $ o.gundeck._epHost)
+    . port (portNumber $ fromIntegral (o.gundeck._epPort))
     . method POST
     . path "/i/push/v2"
     . expect2xx
@@ -73,7 +72,7 @@ call ::
   (Request -> Request) ->
   App (Response (Maybe LB.ByteString))
 call comp r = do
-  o <- view options
+  o <- asks (.options)
   let r0 = componentRequest comp o
   let n = LT.pack (componentName comp)
   recovering (componentRetryPolicy comp) rpcHandlers (const (rpc n (r . r0)))

--- a/services/galley/src/Galley/Validation.hs
+++ b/services/galley/src/Galley/Validation.hs
@@ -62,7 +62,7 @@ checkedConvSize ::
   Sem r (ConvSizeChecked f a)
 checkedConvSize o x = do
   let minV :: Integer = 0
-      limit = o ^. optSettings . setMaxConvSize - 1
+      limit = o.settings.maxConvSize - 1
   if length x <= fromIntegral limit
     then pure (ConvSizeChecked x)
     else throwErr (errorMsg minV limit "")

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -26,7 +26,7 @@ import Bilge
 import Bilge.Assert
 import Control.Arrow ((&&&))
 import Control.Error.Util
-import Control.Lens (preview, to, view, (.~), (^..))
+import Control.Lens (preview, to, view, (^..))
 import Control.Monad.Catch
 import Control.Monad.State (StateT, evalStateT)
 import qualified Control.Monad.State as State
@@ -51,7 +51,6 @@ import Data.Time.Clock (getCurrentTime)
 import qualified Data.Tuple.Extra as Tuple
 import Galley.Keys
 import Galley.Options
-import qualified Galley.Options as Opts
 import Imports hiding (getSymbolicLinkTarget)
 import System.Directory (getSymbolicLinkTarget)
 import System.FilePath
@@ -191,7 +190,7 @@ mkAppAckProposalMessage gid epoch ref mrs priv pub = do
 
 saveRemovalKey :: FilePath -> TestM ()
 saveRemovalKey fp = do
-  keys <- fromJust <$> view (tsGConf . optSettings . setMlsPrivateKeyPaths)
+  keys <- fromJust <$> asks (._tsGConf.settings.mlsPrivateKeyPaths)
   keysByPurpose <- liftIO $ loadAllMLSKeys keys
   let (_, pub) = fromJust (mlsKeyPair_ed25519 (keysByPurpose RemovalPurpose))
   liftIO $ BS.writeFile fp (BA.convert pub)
@@ -1057,4 +1056,4 @@ getSelfConv u = do
 withMLSDisabled :: HasSettingsOverrides m => m a -> m a
 withMLSDisabled = withSettingsOverrides noMLS
   where
-    noMLS = Opts.optSettings . Opts.setMlsPrivateKeyPaths .~ Nothing
+    noMLS opts = opts {settings = opts.settings {mlsPrivateKeyPaths = Nothing}}

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -62,7 +62,7 @@ import qualified Data.UUID.V1 as UUID
 import qualified Data.Vector as V
 import GHC.TypeLits (KnownSymbol)
 import qualified Galley.Env as Galley
-import Galley.Options (optSettings, setEnableIndexedBillingTeamMembers, setFeatureFlags, setMaxConvSize, setMaxFanoutSize)
+import Galley.Options
 import Galley.Types.Conversations.Roles
 import Galley.Types.Teams
 import Imports
@@ -421,7 +421,7 @@ testEnableSSOPerTeam = do
         liftIO $ do
           assertEqual "bad status" status403 status
           assertEqual "bad label" "not-implemented" label
-  featureSSO <- view (tsGConf . optSettings . setFeatureFlags . flagSSO)
+  featureSSO <- asks (._tsGConf.settings.featureFlags.sso)
   case featureSSO of
     FeatureSSOEnabledByDefault -> check "Teams should start with SSO enabled" Public.FeatureStatusEnabled
     FeatureSSODisabledByDefault -> check "Teams should start with SSO disabled" Public.FeatureStatusDisabled

--- a/services/galley/test/integration/API/Teams/LegalHold.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold.hs
@@ -50,7 +50,7 @@ import Galley.Cassandra.Client (lookupClients)
 import Galley.Cassandra.LegalHold
 import qualified Galley.Cassandra.LegalHold as LegalHoldData
 import qualified Galley.Env as Galley
-import Galley.Options (optSettings, setFeatureFlags)
+import Galley.Options
 import qualified Galley.Types.Clients as Clients
 import Galley.Types.Teams
 import Imports
@@ -83,7 +83,7 @@ import qualified Wire.API.User.Client as Client
 
 onlyIfLhWhitelisted :: TestM () -> TestM ()
 onlyIfLhWhitelisted action = do
-  featureLegalHold <- view (tsGConf . optSettings . setFeatureFlags . flagLegalHold)
+  featureLegalHold <- asks (._tsGConf.settings.featureFlags.legalHold)
   case featureLegalHold of
     FeatureLegalHoldDisabledPermanently ->
       liftIO $ hPutStrLn stderr errmsg

--- a/services/galley/test/integration/API/Teams/LegalHold/Util.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold/Util.hs
@@ -642,7 +642,7 @@ instance IsTest LHTest where
   run :: OptionSet -> LHTest -> (Progress -> IO ()) -> IO Result
   run _ (LHTest expectedFlag setupAction testAction) _ = do
     setup <- setupAction
-    let featureLegalHold = setup ^. tsGConf . optSettings . setFeatureFlags . flagLegalHold
+    let featureLegalHold = setup._tsGConf.settings.featureFlags.legalHold
     if featureLegalHold == expectedFlag
       then do
         hunitResult <- try $ void . flip runReaderT setup . runTestM $ testAction

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2609,7 +2609,7 @@ withTempMockFederator' resp action = do
     [("Content-Type", "application/json")]
     mock
     $ \mockPort -> do
-      withSettingsOverrides (\opts -> opts & Opts.optFederator ?~ Endpoint "127.0.0.1" (fromIntegral mockPort)) action
+      withSettingsOverrides (\opts -> opts {Opts.federator = Just $ Endpoint "127.0.0.1" (fromIntegral mockPort)}) action
 
 -- Starts a servant Application in Network.Wai.Test session and runs the
 -- FederatedRequest against it.

--- a/services/galley/test/integration/API/Util/TeamFeature.hs
+++ b/services/galley/test/integration/API/Util/TeamFeature.hs
@@ -23,7 +23,7 @@ module API.Util.TeamFeature where
 import API.Util (HasGalley (viewGalley), zUser)
 import qualified API.Util as Util
 import Bilge
-import Control.Lens ((.~), (^?))
+import Control.Lens ((^?))
 import Control.Monad.Catch (MonadThrow)
 import Data.Aeson (FromJSON, Result (Success), ToJSON, Value, fromJSON)
 import qualified Data.Aeson.Key as Key
@@ -32,7 +32,7 @@ import Data.ByteString.Conversion (toByteString')
 import Data.Id (ConvId, TeamId, UserId)
 import Data.Schema
 import GHC.TypeLits (KnownSymbol)
-import Galley.Options (optSettings, setFeatureFlags)
+import Galley.Options
 import Galley.Types.Teams
 import Imports
 import TestSetup
@@ -40,7 +40,7 @@ import qualified Wire.API.Team.Feature as Public
 
 withCustomSearchFeature :: FeatureTeamSearchVisibilityAvailability -> TestM () -> TestM ()
 withCustomSearchFeature flag action = do
-  Util.withSettingsOverrides (\opts -> opts & optSettings . setFeatureFlags . flagTeamSearchVisibility .~ flag) action
+  Util.withSettingsOverrides (\opts -> opts {settings = opts.settings {featureFlags = opts.settings.featureFlags {teamSearchVisibility = flag}}}) action
 
 getTeamSearchVisibilityAvailable :: HasCallStack => (Request -> Request) -> UserId -> TeamId -> MonadHttp m => m ResponseLBS
 getTeamSearchVisibilityAvailable = getTeamFeatureFlagWithGalley @Public.SearchVisibilityAvailableConfig

--- a/services/galley/test/integration/TestHelpers.hs
+++ b/services/galley/test/integration/TestHelpers.hs
@@ -19,12 +19,11 @@
 
 module TestHelpers where
 
-import Control.Lens (view)
 import Control.Monad.Catch (MonadMask)
 import Control.Retry
 import Data.Domain (Domain)
 import Data.Qualified
-import Galley.Options (optSettings, setFederationDomain)
+import Galley.Options
 import Imports
 import Test.Tasty (TestName, TestTree)
 import Test.Tasty.HUnit (Assertion, testCase)
@@ -39,7 +38,7 @@ test s n h = testCase n runTest
       void . flip runReaderT setup . runTestM $ h
 
 viewFederationDomain :: TestM Domain
-viewFederationDomain = view (tsGConf . optSettings . setFederationDomain)
+viewFederationDomain = asks (._tsGConf.settings.federationDomain)
 
 qualifyLocal :: a -> TestM (Local a)
 qualifyLocal x = do


### PR DESCRIPTION
The RecordDotUpdate extension is experimental and requires special instances of the `HasField` class. Without this, doing all this work is pointless, so perhaps we should wait for the new `HasField` class to be standardized.

This PR might or might not be useful in the future.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
