### PR TITLE
Update team-settings version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/team-settings-upgrade
+++ b/changelog.d/0-release-notes/team-settings-upgrade
@@ -1,0 +1,1 @@
+Upgrade team-settings version to 4.15.0-v0.31.16-0-8138d2e

--- a/charts/team-settings/values.yaml
+++ b/charts/team-settings/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/team-settings
-  tag: "4.14.0-v0.31.9-0-bf82b46"
+  tag: "4.15.0-v0.31.16-0-8138d2e"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `4.15.0-v0.31.16-0-8138d2e`
Release: [`v4.15.0`](https://github.com/wireapp/wire-team-settings/releases/tag/v4.15.0)