### PR TITLE
Add GET endpoint for MLS 1-1 conversations

### DIFF
--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -93,6 +93,7 @@ library
     Test.Demo
     Test.MLS
     Test.MLS.KeyPackage
+    Test.MLS.One2One
     Test.User
     Testlib.App
     Testlib.Assertions

--- a/integration/test/API/BrigInternal.hs
+++ b/integration/test/API/BrigInternal.hs
@@ -73,3 +73,12 @@ deleteOAuthClient user cid = do
   clientId <- objId cid
   req <- baseRequest user Brig Unversioned $ "i/oauth/clients/" <> clientId
   submit "DELETE" req
+
+getInvitationCode :: (HasCallStack, MakesValue user, MakesValue inv) => user -> inv -> App Response
+getInvitationCode user inv = do
+  tid <- user %. "team" & asString
+  invId <- inv %. "id" & asString
+  req <-
+    baseRequest user Brig Unversioned $
+      "i/teams/invitation-code?team=" <> tid <> "&invitation_id=" <> invId
+  submit "GET" req

--- a/integration/test/API/Common.hs
+++ b/integration/test/API/Common.hs
@@ -17,10 +17,25 @@ defPassword :: String
 defPassword = "hunter2!"
 
 randomEmail :: App String
-randomEmail = liftIO $ do
-  n <- randomRIO (8, 15)
-  u <- replicateM n pick
+randomEmail = do
+  u <- randomName
   pure $ u <> "@example.com"
+  where
+    chars :: Array.Array Int Char
+    chars = mkArray $ ['A' .. 'Z'] <> ['a' .. 'z'] <> ['0' .. '9']
+
+    mkArray :: [a] -> Array.Array Int a
+    mkArray l = Array.listArray (0, length l - 1) l
+
+    pick :: IO Char
+    pick = do
+      i <- randomRIO (Array.bounds chars)
+      pure (chars Array.! i)
+
+randomName :: App String
+randomName = liftIO $ do
+  n <- randomRIO (8, 15)
+  replicateM n pick
   where
     chars :: Array.Array Int Char
     chars = mkArray $ ['A' .. 'Z'] <> ['a' .. 'z'] <> ['0' .. '9']

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -200,3 +200,15 @@ deleteTeamConv team conv user = do
   convId <- objId conv
   req <- baseRequest user Galley Versioned (joinHttpPath ["teams", teamId, "conversations", convId])
   submit "DELETE" req
+
+getMLSOne2OneConversation ::
+  (HasCallStack, MakesValue self, MakesValue other) =>
+  self ->
+  other ->
+  App Response
+getMLSOne2OneConversation self other = do
+  (domain, uid) <- objQid other
+  req <-
+    baseRequest self Galley Versioned $
+      joinHttpPath ["conversations", "one2one", domain, uid]
+  submit "GET" req

--- a/integration/test/SetupHelpers.hs
+++ b/integration/test/SetupHelpers.hs
@@ -94,3 +94,11 @@ supportMLS u = do
   let prots' = "mls" : prots
   bindResponse (putUserSupportedProtocols u prots') $ \resp ->
     resp.status `shouldMatchInt` 200
+
+addUserToTeam :: (HasCallStack, MakesValue u) => u -> App Value
+addUserToTeam u = do
+  inv <- postInvitation u def >>= getJSON 201
+  email <- inv %. "email" & asString
+  resp <- getInvitationCode u inv >>= getJSON 200
+  code <- resp %. "code" & asString
+  addUser u def {email = Just email, teamCode = Just code} >>= getJSON 201

--- a/integration/test/Test/MLS/One2One.hs
+++ b/integration/test/Test/MLS/One2One.hs
@@ -1,0 +1,37 @@
+module Test.MLS.One2One where
+
+import API.Galley
+import SetupHelpers
+import Testlib.Prelude
+
+testGetMLSOne2One :: HasCallStack => Domain -> App ()
+testGetMLSOne2One otherDomain = do
+  [alice, bob] <- createAndConnectUsers [OwnDomain, otherDomain]
+
+  conv <- getMLSOne2OneConversation alice bob >>= getJSON 200
+
+  conv %. "type" `shouldMatchInt` 2
+  others <- conv %. "members.others" & asList
+  other <- assertOne others
+  other %. "conversation_role" `shouldMatch` "wire_member"
+  other %. "qualified_id" `shouldMatch` (bob %. "qualified_id")
+
+  conv %. "members.self.conversation_role" `shouldMatch` "wire_member"
+  conv %. "members.self.qualified_id" `shouldMatch` (alice %. "qualified_id")
+
+  convId <- conv %. "qualified_id"
+
+  -- check that the conversation has the same ID on the other side
+  conv2 <- bindResponse (getMLSOne2OneConversation bob alice) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json
+
+  conv2 %. "type" `shouldMatchInt` 2
+  conv2 %. "qualified_id" `shouldMatch` convId
+
+testGetMLSOne2OneUnconnected :: HasCallStack => Domain -> App ()
+testGetMLSOne2OneUnconnected otherDomain = do
+  [alice, bob] <- for [OwnDomain, otherDomain] $ \domain -> randomUser domain def
+
+  bindResponse (getMLSOne2OneConversation alice bob) $ \resp ->
+    resp.status `shouldMatchInt` 403

--- a/integration/test/Test/MLS/One2One.hs
+++ b/integration/test/Test/MLS/One2One.hs
@@ -35,3 +35,9 @@ testGetMLSOne2OneUnconnected otherDomain = do
 
   bindResponse (getMLSOne2OneConversation alice bob) $ \resp ->
     resp.status `shouldMatchInt` 403
+
+testGetMLSOne2OneSameTeam :: App ()
+testGetMLSOne2OneSameTeam = do
+  (alice, _) <- createTeam OwnDomain
+  bob <- addUserToTeam alice
+  void $ getMLSOne2OneConversation alice bob >>= getJSON 200

--- a/libs/galley-types/src/Galley/Types/Conversations/One2One.hs
+++ b/libs/galley-types/src/Galley/Types/Conversations/One2One.hs
@@ -30,6 +30,7 @@ import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.Tagged as U
 import Imports
+import Wire.API.User
 
 -- | The hash function used to obtain the 1-1 conversation ID for a pair of users.
 --
@@ -39,8 +40,9 @@ hash = convert . Crypto.hash @ByteString @Crypto.SHA256
 
 -- | A randomly-generated UUID to use as a namespace for the UUIDv5 of 1-1
 -- conversation IDs
-namespace :: UUID
-namespace = UUID.fromWords 0x9a51edb8 0x060c0d9a 0x0c2950a8 0x5d152982
+namespace :: BaseProtocolTag -> UUID
+namespace BaseProtocolProteusTag = UUID.fromWords 0x9a51edb8 0x060c0d9a 0x0c2950a8 0x5d152982
+namespace BaseProtocolMLSTag = UUID.fromWords 0x95589dd5 0xb04540dc 0xa6aadd9c 0x4fad1c2f
 
 compareDomains :: Ord a => Qualified a -> Qualified a -> Ordering
 compareDomains (Qualified a1 dom1) (Qualified a2 dom2) =
@@ -88,13 +90,13 @@ quidToByteString (Qualified uid domain) = toByteString' uid <> toByteString' dom
 -- the most significant bit of the octet at index 16) is 0, and B otherwise.
 -- This is well-defined, because we assumed the number of bits of x to be
 -- strictly larger than 128.
-one2OneConvId :: Qualified UserId -> Qualified UserId -> Qualified ConvId
-one2OneConvId a b = case compareDomains a b of
-  GT -> one2OneConvId b a
+one2OneConvId :: BaseProtocolTag -> Qualified UserId -> Qualified UserId -> Qualified ConvId
+one2OneConvId protocol a b = case compareDomains a b of
+  GT -> one2OneConvId protocol b a
   _ ->
     let c =
           mconcat
-            [ L.toStrict (UUID.toByteString namespace),
+            [ L.toStrict (UUID.toByteString (namespace protocol)),
               quidToByteString a,
               quidToByteString b
             ]

--- a/libs/wire-api/src/Wire/API/Conversation/Member.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Member.hs
@@ -23,8 +23,10 @@ module Wire.API.Conversation.Member
 
     -- * Member
     Member (..),
+    defMember,
     MutedStatus (..),
     OtherMember (..),
+    defOtherMember,
 
     -- * Member Update
     MemberUpdate (..),
@@ -88,6 +90,20 @@ data Member = Member
   deriving (Arbitrary) via (GenericUniform Member)
   deriving (FromJSON, ToJSON, S.ToSchema) via Schema Member
 
+defMember :: Qualified UserId -> Member
+defMember uid =
+  Member
+    { memId = uid,
+      memService = Nothing,
+      memOtrMutedStatus = Nothing,
+      memOtrMutedRef = Nothing,
+      memOtrArchived = False,
+      memOtrArchivedRef = Nothing,
+      memHidden = False,
+      memHiddenRef = Nothing,
+      memConvRoleName = roleNameWireMember
+    }
+
 instance ToSchema Member where
   schema =
     object "Member" $
@@ -132,6 +148,14 @@ data OtherMember = OtherMember
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform OtherMember)
   deriving (FromJSON, ToJSON, S.ToSchema) via Schema OtherMember
+
+defOtherMember :: Qualified UserId -> OtherMember
+defOtherMember uid =
+  OtherMember
+    { omQualifiedId = uid,
+      omService = Nothing,
+      omConvRoleName = roleNameWireMember
+    }
 
 instance ToSchema OtherMember where
   schema =

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -588,6 +588,16 @@ type ConversationAPI =
                :> ReqBody '[JSON] NewConv
                :> ConversationVerb
            )
+    :<|> Named
+           "get-one-to-one-mls-conversation"
+           ( Summary "Get an MLS 1:1 conversation"
+               :> ZLocalUser
+               :> CanThrow 'MLSNotEnabled
+               :> "conversations"
+               :> "one2one"
+               :> QualifiedCapture "usr" UserId
+               :> MultiVerb1 'GET '[JSON] (Respond 200 "MLS 1-1 conversation" Conversation)
+           )
     -- This endpoint can lead to the following events being sent:
     -- - MemberJoin event to members
     :<|> Named

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -593,6 +593,7 @@ type ConversationAPI =
            ( Summary "Get an MLS 1:1 conversation"
                :> ZLocalUser
                :> CanThrow 'MLSNotEnabled
+               :> CanThrow 'NotConnected
                :> "conversations"
                :> "one2one"
                :> QualifiedCapture "usr" UserId

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -253,7 +253,7 @@ localAndRemoteUserWithConvId brig shouldBeLocal = do
   quid <- userQualifiedId <$> randomUser brig
   let go = do
         other <- Qualified <$> randomId <*> pure (Domain "far-away.example.com")
-        let convId = one2OneConvId quid other
+        let convId = one2OneConvId BaseProtocolProteusTag quid other
             isLocal = qDomain quid == qDomain convId
         if shouldBeLocal == isLocal
           then pure (qUnqualified quid, other, convId)

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -476,10 +476,10 @@ performConversationJoin qusr lconv (ConversationJoin invited role) = do
           <$> E.selectTeamMembers tid newUsers
       let userMembershipMap = map (id &&& flip Map.lookup tms) newUsers
       ensureAccessRole (convAccessRoles conv) userMembershipMap
-      ensureConnectedOrSameTeam lusr newUsers
+      ensureConnectedToLocalsOrSameTeam lusr newUsers
     checkLocals lusr Nothing newUsers = do
       ensureAccessRole (convAccessRoles conv) (zip newUsers $ repeat Nothing)
-      ensureConnectedOrSameTeam lusr newUsers
+      ensureConnectedToLocalsOrSameTeam lusr newUsers
 
     checkRemotes ::
       ( Member BrigAccess r,

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -79,6 +79,7 @@ import Wire.API.Team
 import Wire.API.Team.LegalHold (LegalholdProtectee (LegalholdPlusFederationNotImplemented))
 import Wire.API.Team.Member
 import Wire.API.Team.Permission hiding (self)
+import Wire.API.User
 
 ----------------------------------------------------------------------------
 -- Group conversations
@@ -422,7 +423,7 @@ createOne2OneConversationUnchecked self zcon name mtid other = do
           self
           createOne2OneConversationLocally
           createOne2OneConversationRemotely
-  create (one2OneConvId (tUntagged self) other) self zcon name mtid other
+  create (one2OneConvId BaseProtocolProteusTag (tUntagged self) other) self zcon name mtid other
 
 createOne2OneConversationLocally ::
   ( Member ConversationStore r,

--- a/services/galley/src/Galley/API/One2One.hs
+++ b/services/galley/src/Galley/API/One2One.hs
@@ -35,7 +35,8 @@ import Galley.Types.UserList
 import Imports
 import Polysemy
 import Wire.API.Conversation hiding (Member)
-import Wire.API.Routes.Internal.Galley.ConversationsIntra (Actor (..), DesiredMembership (..), UpsertOne2OneConversationRequest (..), UpsertOne2OneConversationResponse (..))
+import Wire.API.Routes.Internal.Galley.ConversationsIntra
+import Wire.API.User
 
 newConnectConversationWithRemote ::
   Local UserId ->
@@ -59,7 +60,14 @@ iUpsertOne2OneConversation ::
   UpsertOne2OneConversationRequest ->
   Sem r UpsertOne2OneConversationResponse
 iUpsertOne2OneConversation UpsertOne2OneConversationRequest {..} = do
-  let convId = fromMaybe (one2OneConvId (tUntagged uooLocalUser) (tUntagged uooRemoteUser)) uooConvId
+  let convId =
+        fromMaybe
+          ( one2OneConvId
+              BaseProtocolProteusTag
+              (tUntagged uooLocalUser)
+              (tUntagged uooRemoteUser)
+          )
+          uooConvId
 
   let dolocal :: Local ConvId -> Sem r ()
       dolocal lconvId = do

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -57,6 +57,7 @@ conversationAPI =
     <@> mkNamedAPI @"get-subconversation-group-info" (callsFed getSubConversationGroupInfo)
     <@> mkNamedAPI @"create-one-to-one-conversation@v2" (callsFed createOne2OneConversation)
     <@> mkNamedAPI @"create-one-to-one-conversation" (callsFed createOne2OneConversation)
+    <@> mkNamedAPI @"get-one-to-one-mls-conversation" getMLSOne2OneConversation
     <@> mkNamedAPI @"add-members-to-conversation-unqualified" (callsFed addMembersUnqualified)
     <@> mkNamedAPI @"add-members-to-conversation-unqualified2" (callsFed addMembersUnqualifiedV2)
     <@> mkNamedAPI @"add-members-to-conversation" (callsFed addMembers)

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -745,14 +745,18 @@ getMLSSelfConversation lusr = do
 -- fly, but not persisted. The conversation will only be stored in the database
 -- when its first commit arrives.
 getMLSOne2OneConversation ::
-  ( Member (Input Env) r,
-    Member (ErrorS 'MLSNotEnabled) r
+  ( Member BrigAccess r,
+    Member (Input Env) r,
+    Member (ErrorS 'MLSNotEnabled) r,
+    Member (ErrorS 'NotConnected) r,
+    Member TeamStore r
   ) =>
   Local UserId ->
   Qualified UserId ->
   Sem r Conversation
 getMLSOne2OneConversation lself qother = do
   assertMLSEnabled
+  ensureConnectedOrSameTeam lself [qother]
   let convId = one2OneConvId BaseProtocolMLSTag (tUntagged lself) qother
       metadata =
         ( defConversationMetadata

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -37,6 +37,7 @@ module Galley.API.Query
     ensureConvAdmin,
     getMLSSelfConversation,
     getMLSSelfConversationWithError,
+    getMLSOne2OneConversation,
   )
 where
 
@@ -733,6 +734,20 @@ getMLSSelfConversation lusr = do
   mconv <- E.getConversation selfConvId
   cnv <- maybe (E.createMLSSelfConversation lusr) pure mconv
   conversationView lusr cnv
+
+-- | Get an MLS 1-1 conversation. The conversation object is created on the
+-- fly, but not persisted. The conversation will only be stored in the database
+-- when its first commit arrives.
+getMLSOne2OneConversation ::
+  ( Member (Input Env) r,
+    Member (ErrorS 'MLSNotEnabled) r
+  ) =>
+  Local UserId ->
+  Qualified UserId ->
+  Sem r Conversation
+getMLSOne2OneConversation _lusr _qtarget = do
+  assertMLSEnabled
+  pure (error "TODO")
 
 -------------------------------------------------------------------------------
 -- Helpers

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2863,7 +2863,7 @@ generateRemoteAndConvId = generateRemoteAndConvIdWithDomain (Domain "far-away.ex
 generateRemoteAndConvIdWithDomain :: Domain -> Bool -> Local UserId -> TestM (Remote UserId, Qualified ConvId)
 generateRemoteAndConvIdWithDomain remoteDomain shouldBeLocal lUserId = do
   other <- Qualified <$> randomId <*> pure remoteDomain
-  let convId = one2OneConvId (tUntagged lUserId) other
+  let convId = one2OneConvId BaseProtocolProteusTag (tUntagged lUserId) other
       isLocal = tDomain lUserId == qDomain convId
   if shouldBeLocal == isLocal
     then pure (qTagUnsafe other, convId)

--- a/services/galley/test/unit/Test/Galley/API/One2One.hs
+++ b/services/galley/test/unit/Test/Galley/API/One2One.hs
@@ -26,6 +26,7 @@ import Imports
 import Test.Tasty
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 import Test.Tasty.QuickCheck
+import Wire.API.User
 
 tests :: TestTree
 tests =
@@ -35,8 +36,8 @@ tests =
       testCase "non-collision" one2OneConvIdNonCollision
     ]
 
-one2OneConvIdSymmetry :: Qualified UserId -> Qualified UserId -> Property
-one2OneConvIdSymmetry quid1 quid2 = one2OneConvId quid1 quid2 === one2OneConvId quid2 quid1
+one2OneConvIdSymmetry :: BaseProtocolTag -> Qualified UserId -> Qualified UserId -> Property
+one2OneConvIdSymmetry proto quid1 quid2 = one2OneConvId proto quid1 quid2 === one2OneConvId proto quid2 quid1
 
 -- | Make sure that we never get the same conversation ID for a pair of
 -- (assumingly) distinct qualified user IDs
@@ -46,5 +47,5 @@ one2OneConvIdNonCollision = do
   -- A generator of lists of length 'len' of qualified user ID pairs
   let gen = vectorOf len arbitrary
   quids <- nubOrd <$> generate gen
-  let hashes = nubOrd (fmap (uncurry one2OneConvId) quids)
+  let hashes = nubOrd (fmap (uncurry (one2OneConvId BaseProtocolProteusTag)) quids)
   length hashes @?= length quids


### PR DESCRIPTION
This adds an endpoint `GET /conversations/one2one/:domain/:uid` to fetch an MLS 1-1 conversation with another user.

https://wearezeta.atlassian.net/browse/WPB-1926

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
