### PR TITLE
Develop cassndra: use only 1GB instead of 4GB of heap

### DIFF
--- a/deploy/dockerephemeral/docker-compose.yaml
+++ b/deploy/dockerephemeral/docker-compose.yaml
@@ -188,8 +188,7 @@ services:
       nofile: 100000
       nproc: 32768
     environment:
-      # what's present in the jvm.options file by default:
-      - "CS_JAVA_OPTIONS=-Xmx1024M -Xms1024M -Xmn200M"
+      - "CS_JVM_OPTIONS=-Xmx1024M -Xms1024M -Xmn200M"
 
       # on nixos, you also may need to run
       #   sysctl -w vm.max_map_count=1048576


### PR DESCRIPTION
Follow-up to https://github.com/wireapp/wire-server/pull/3350 which seems accidentaly increased -Xms3806 instead of the intended 1GB. The name of the environment variable was not correct in the original PR
