### PR TITLE
Run containers as non-root

### DIFF
--- a/charts/cannon/templates/conf/_nginx.conf.tpl
+++ b/charts/cannon/templates/conf/_nginx.conf.tpl
@@ -1,5 +1,4 @@
 {{- define "cannon_nginz_nginx.conf" }}
-user {{ .Values.nginx_conf.user }} {{ .Values.nginx_conf.group }};
 worker_processes {{ .Values.nginx_conf.worker_processes }};
 worker_rlimit_nofile {{ .Values.nginx_conf.worker_rlimit_nofile | default 1024 }};
 pid /var/run/nginz.pid;

--- a/charts/cannon/values.yaml
+++ b/charts/cannon/values.yaml
@@ -31,8 +31,6 @@ metrics:
     enabled: false
 
 nginx_conf:
-  user: nginx
-  group: nginx
   zauth_keystore: /etc/wire/nginz/secrets/zauth.conf
   zauth_acl: /etc/wire/nginz/conf/zauth.acl
   worker_processes: auto

--- a/charts/nginz/templates/conf/_nginx.conf.tpl
+++ b/charts/nginz/templates/conf/_nginx.conf.tpl
@@ -1,5 +1,4 @@
 {{- define "nginz_nginx.conf" }}
-user {{ .Values.nginx_conf.user }} {{ .Values.nginx_conf.group }};
 worker_processes {{ .Values.nginx_conf.worker_processes }};
 worker_rlimit_nofile {{ .Values.nginx_conf.worker_rlimit_nofile | default 1024 }};
 pid /var/run/nginz.pid;

--- a/charts/nginz/values.yaml
+++ b/charts/nginz/values.yaml
@@ -24,8 +24,6 @@ config:
     useProxyProtocol: true
 terminationGracePeriodSeconds: 30
 nginx_conf:
-  user: nginx
-  group: nginx
   upstream_config: /etc/wire/nginz/upstreams/upstreams.conf
   zauth_keystore: /etc/wire/nginz/secrets/zauth.conf
   zauth_acl: /etc/wire/nginz/conf/zauth.acl

--- a/nix/nginz-disco.nix
+++ b/nix/nginz-disco.nix
@@ -32,10 +32,13 @@ let
     contents = [
       bashInteractive
       coreutils
+      dockerTools.usrBinEnv
+      dockerTools.fakeNss
       which
     ];
     config = {
       Entrypoint = [ "${dumb-init}/bin/dumb-init" "--" "${nginz-disco}/bin/nginz_disco.sh" ];
+      User = "nobody";
     };
   };
 in

--- a/nix/nginz.nix
+++ b/nix/nginz.nix
@@ -30,40 +30,13 @@ let
     '';
   };
 
-  # copied from nixpkgs fakeNss, but using nginx as username
-  nginxFakeNss = symlinkJoin {
-    name = "fake-nss";
-    paths = [
-      (writeTextDir "etc/passwd" ''
-        root:x:0:0:root user:/var/empty:/bin/sh
-        nginx:x:101:101:nginx:/var/empty:/bin/sh
-        nobody:x:65534:65534:nobody:/var/empty:/bin/sh
-      '')
-      (writeTextDir "etc/group" ''
-        root:x:0:
-        nginx:x:101:
-        nobody:x:65534:
-      '')
-      (writeTextDir "etc/nsswitch.conf" ''
-        hosts: files dns
-      '')
-      (runCommand "var-empty" { } ''
-        mkdir -p $out/var/empty
-      '')
-      # it seems nginx still tries to log, and doesn't create
-      # these directories automatically
-      (runCommand "nginx-misc" { } ''
-        mkdir -p $out/var/log/nginx
-        mkdir -p $out/var/cache/nginx
-      '')
-    ];
-  };
-
   # Docker tools doesn't create tmp directories but nginx needs this and so we
   # have to create it ourself.
   tmpDir = runCommand "tmp-dir" { } ''
     mkdir -p $out/tmp
     mkdir -p $out/var/tmp
+    mkdir -p $out/var/log/nginx
+    mkdir -p $out/var/cache/nginx
   '';
 
   nginzImage = dockerTools.streamLayeredImage {
@@ -75,7 +48,8 @@ let
       gnugrep
       which
       coreutils
-      nginxFakeNss
+      dockerTools.fakeNss
+      dockerTools.usrBinEnv
       nginz # so preStop lifecycle hook in cannon can nginx -c … quit
       tmpDir
     ];
@@ -88,6 +62,7 @@ let
     config = {
       Entrypoint = [ "${dumb-init}/bin/dumb-init" "--" "${nginzWithReloader}/bin/nginz_reload.sh" "-g" "daemon off;" "-c" "/etc/wire/nginz/conf/nginx.conf" ];
       Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ];
+      User = "nobody";
     };
   };
 in

--- a/nix/nginz.nix
+++ b/nix/nginz.nix
@@ -58,6 +58,9 @@ let
     fakeRootCommands = ''
       chmod 1777 tmp
       chmod 1777 var/tmp
+      chmod 1777 var/run
+      chmod 1777 var/log/nginx
+      chmod 1777 var/cache/nginx
     '';
     config = {
       Entrypoint = [ "${dumb-init}/bin/dumb-init" "--" "${nginzWithReloader}/bin/nginz_reload.sh" "-g" "daemon off;" "-c" "/etc/wire/nginz/conf/nginx.conf" ];

--- a/nix/nginz.nix
+++ b/nix/nginz.nix
@@ -34,9 +34,10 @@ let
   # have to create it ourself.
   tmpDir = runCommand "tmp-dir" { } ''
     mkdir -p $out/tmp
-    mkdir -p $out/var/tmp
-    mkdir -p $out/var/log/nginx
     mkdir -p $out/var/cache/nginx
+    mkdir -p $out/var/log/nginx
+    mkdir -p $out/var/run
+    mkdir -p $out/var/tmp
   '';
 
   nginzImage = dockerTools.streamLayeredImage {

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -307,11 +307,14 @@ let
       pkgs.coreutils
       pkgs.bashInteractive
       pkgs.dumb-init
+      pkgs.dockerTools.fakeNss
+      pkgs.dockerTools.usrBinEnv
       hoogle
     ];
     config = {
       Entrypoint = [ "${pkgs.dumb-init}/bin/dumb-init" "--" "${hoogle}/bin/hoogle" "server" "--local" "--host=*" ];
       Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ];
+      User = "nobody";
     };
   };
 

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -253,6 +253,8 @@ let
             pkgs.cacert
             pkgs.iana-etc
             pkgs.dumb-init
+            pkgs.dockerTools.fakeNss
+            pkgs.dockerTools.usrBinEnv
             drv
             tmpDir
           ] ++ debugUtils ++ pkgs.lib.optionals (builtins.hasAttr execName (extraContents exes)) (builtins.getAttr execName (extraContents exes));
@@ -265,6 +267,7 @@ let
           config = {
             Entrypoint = [ "${pkgs.dumb-init}/bin/dumb-init" "--" "${drv}/bin/${execName}" ];
             Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ];
+            User = "nobody";
           };
         }
       )


### PR DESCRIPTION
Containers now run as non-root, to improve compatibility with default PodSecurityPolicies in more recent versions of Kubernetes.

This is part of [WPB-1234](https://wearezeta.atlassian.net/browse/WPB-1234)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)


[WPB-1234]: https://wearezeta.atlassian.net/browse/WPB-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ