### PR TITLE
[SQSERVICES-937] Email templates use image links from old web site new web site broke those links

### DIFF
--- a/changelog.d/3-bug-fixes/pr-3354
+++ b/changelog.d/3-bug-fixes/pr-3354
@@ -1,0 +1,1 @@
+Brand logo url for email templates fixed in brig settings

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -44,7 +44,7 @@ config:
         brand: Wire
         brandUrl: https://wire.com
         brandLabelUrl: wire.com
-        brandLogoUrl: https://wire.com/p/img/email/logo-email-black.png
+        brandLogoUrl: https://wire.com/wp-content/uploads/2021/08/wire-logo.svg
         brandService: Wire Service Provider
         copyright: © WIRE SWISS GmbH
         misuse: misuse@wire.com


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
