### PR TITLE
Create subconversations on first commit

### DIFF
--- a/changelog.d/5-internal/mls-subconv-creation
+++ b/changelog.d/5-internal/mls-subconv-creation
@@ -1,0 +1,1 @@
+Subconversations are now created on their first commit

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -94,6 +94,7 @@ library
     Test.MLS
     Test.MLS.KeyPackage
     Test.MLS.One2One
+    Test.MLS.SubConversation
     Test.User
     Testlib.App
     Testlib.Assertions

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -117,6 +117,21 @@ getSubConversation user conv sub = do
         ]
   submit "GET" req
 
+deleteSubConversation ::
+  (HasCallStack, MakesValue user, MakesValue sub) =>
+  user ->
+  sub ->
+  App Response
+deleteSubConversation user sub = do
+  (conv, Just subId) <- objSubConv sub
+  (domain, convId) <- objQid conv
+  groupId <- sub %. "group_id" & asString
+  epoch :: Int <- sub %. "epoch" & asIntegral
+  req <-
+    baseRequest user Galley Versioned $
+      joinHttpPath ["conversations", domain, convId, "subconversations", subId]
+  submit "DELETE" $ req & addJSONObject ["group_id" .= groupId, "epoch" .= epoch]
+
 getSelfConversation :: (HasCallStack, MakesValue user) => user -> App Response
 getSelfConversation user = do
   req <- baseRequest user Galley Versioned "/conversations/mls-self"

--- a/integration/test/MLS/Util.hs
+++ b/integration/test/MLS/Util.hs
@@ -193,9 +193,16 @@ createGroup cid conv = do
     Nothing -> pure ()
   resetGroup cid conv
 
+createSubConv :: ClientIdentity -> String -> App ()
+createSubConv cid subId = do
+  mls <- getMLSState
+  sub <- getSubConversation cid mls.convId subId >>= getJSON 200
+  resetGroup cid sub
+  void $ createPendingProposalCommit cid >>= sendAndConsumeCommitBundle
+
 resetGroup :: MakesValue conv => ClientIdentity -> conv -> App ()
 resetGroup cid conv = do
-  convId <- make conv
+  convId <- objSubConvObject conv
   groupId <- conv %. "group_id" & asString
   modifyMLSState $ \s ->
     s

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -351,17 +351,11 @@ testJoinSubConv = do
   traverse_ uploadNewKeyPackage [bob1, bob2]
   (_, qcnv) <- createNewGroup alice1
   void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
-
-  sub <- bindResponse (getSubConversation bob qcnv "conference") $ \resp -> do
-    resp.status `shouldMatchInt` 200
-    resp.json
-  resetGroup bob1 sub
+  void $ createSubConv bob1 "conference"
 
   -- bob adds his first client to the subconversation
   void $ createPendingProposalCommit bob1 >>= sendAndConsumeCommitBundle
-  sub' <- bindResponse (getSubConversation bob qcnv "conference") $ \resp -> do
-    resp.status `shouldMatchInt` 200
-    resp.json
+  sub' <- getSubConversation bob qcnv "conference" >>= getJSON 200
   do
     tm <- sub' %. "epoch_timestamp"
     assertBool "Epoch timestamp should not be null" (tm /= Null)
@@ -381,11 +375,7 @@ testDeleteParentOfSubConv secondDomain = do
   traverse_ uploadNewKeyPackage [alice1, bob1]
   (_, qcnv) <- createNewGroup alice1
   void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
-
-  sub <- bindResponse (getSubConversation bob qcnv "conference") $ \resp -> do
-    resp.status `shouldMatchInt` 200
-    resp.json
-  resetGroup bob1 sub
+  void $ createSubConv bob1 "conference"
 
   -- bob adds his client to the subconversation
   void $ createPendingProposalCommit bob1 >>= sendAndConsumeCommitBundle

--- a/integration/test/Test/MLS/SubConversation.hs
+++ b/integration/test/Test/MLS/SubConversation.hs
@@ -1,0 +1,98 @@
+module Test.MLS.SubConversation where
+
+import API.Galley
+import MLS.Util
+import SetupHelpers
+import Testlib.Prelude
+
+testJoinSubConv :: App ()
+testJoinSubConv = do
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
+  [alice1, bob1, bob2] <- traverse createMLSClient [alice, bob, bob]
+  traverse_ uploadNewKeyPackage [bob1, bob2]
+  (_, qcnv) <- createNewGroup alice1
+  void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
+  createSubConv bob1 "conference"
+
+  -- bob adds his first client to the subconversation
+  void $ createPendingProposalCommit bob1 >>= sendAndConsumeCommitBundle
+  sub' <- getSubConversation bob qcnv "conference" >>= getJSON 200
+  do
+    tm <- sub' %. "epoch_timestamp"
+    assertBool "Epoch timestamp should not be null" (tm /= Null)
+
+  -- now alice joins with her own client
+  void $
+    createExternalCommit alice1 Nothing
+      >>= sendAndConsumeCommitBundle
+
+testDeleteParentOfSubConv :: HasCallStack => Domain -> App ()
+testDeleteParentOfSubConv secondDomain = do
+  (alice, tid) <- createTeam OwnDomain
+  bob <- randomUser secondDomain def
+  connectUsers [alice, bob]
+
+  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  traverse_ uploadNewKeyPackage [alice1, bob1]
+  (_, qcnv) <- createNewGroup alice1
+  void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
+  createSubConv bob1 "conference"
+
+  -- bob adds his client to the subconversation
+  void $ createPendingProposalCommit bob1 >>= sendAndConsumeCommitBundle
+
+  -- alice joins with her own client
+  void $ createExternalCommit alice1 Nothing >>= sendAndConsumeCommitBundle
+
+  -- bob sends a message to the subconversation
+  do
+    mp <- createApplicationMessage bob1 "hello, alice"
+    void . bindResponse (postMLSMessage mp.sender mp.message) $ \resp -> do
+      resp.status `shouldMatchInt` 201
+
+  -- alice sends a message to the subconversation
+  do
+    mp <- createApplicationMessage bob1 "hello, bob"
+    void . bindResponse (postMLSMessage mp.sender mp.message) $ \resp -> do
+      resp.status `shouldMatchInt` 201
+
+  -- alice deletes main conversation
+  void . bindResponse (deleteTeamConv tid qcnv alice) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+
+  -- bob fails to send a message to the subconversation
+  do
+    mp <- createApplicationMessage bob1 "hello, alice"
+    void . bindResponse (postMLSMessage mp.sender mp.message) $ \resp -> do
+      resp.status `shouldMatchInt` 404
+      case secondDomain of
+        OwnDomain -> resp.json %. "label" `shouldMatch` "no-conversation"
+        OtherDomain -> resp.json %. "label" `shouldMatch` "no-conversation-member"
+
+  -- alice fails to send a message to the subconversation
+  do
+    mp <- createApplicationMessage alice1 "hello, bob"
+    void . bindResponse (postMLSMessage mp.sender mp.message) $ \resp -> do
+      resp.status `shouldMatchInt` 404
+      resp.json %. "label" `shouldMatch` "no-conversation"
+
+testDeleteSubConversation :: HasCallStack => Domain -> App ()
+testDeleteSubConversation otherDomain = do
+  [alice, bob] <- createAndConnectUsers [OwnDomain, otherDomain]
+  charlie <- randomUser OwnDomain def
+  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  void $ uploadNewKeyPackage bob1
+  (_, qcnv) <- createNewGroup alice1
+  void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
+
+  createSubConv alice1 "conference1"
+  sub1 <- getSubConversation alice qcnv "conference1" >>= getJSON 200
+  void $ deleteSubConversation charlie sub1 >>= getBody 403
+  void $ deleteSubConversation alice sub1 >>= getBody 200
+
+  createSubConv alice1 "conference2"
+  sub2 <- getSubConversation alice qcnv "conference2" >>= getJSON 200
+  void $ deleteSubConversation bob sub2 >>= getBody 200
+
+  sub2' <- getSubConversation alice1 qcnv "conference2" >>= getJSON 200
+  sub2 `shouldNotMatch` sub2'

--- a/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
@@ -72,6 +72,9 @@ getExternalCommitData senderIdentity lConvOrSub epoch commit = do
       curEpoch = cnvmlsEpoch convOrSub.meta
       groupId = cnvmlsGroupId convOrSub.meta
   when (epoch /= curEpoch) $ throwS @'MLSStaleMessage
+  when (epoch == Epoch 0) $
+    throw $
+      mlsProtocolError "The first commit in a group cannot be external"
   proposals <- traverse getInlineProposal commit.proposals
 
   -- According to the spec, an external commit must contain:

--- a/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
@@ -38,6 +38,7 @@ import qualified Galley.Data.Conversation.Types as Data
 import Galley.Effects
 import Galley.Effects.MemberStore
 import Galley.Effects.ProposalStore
+import Galley.Effects.SubConversationStore
 import Galley.Types.Conversations.Members
 import Imports
 import Polysemy
@@ -164,6 +165,24 @@ processInternalCommit senderIdentity con lConvOrSub epoch action commit = do
                         throwS @'MLSClientMismatch
                     pure Nothing
           for_ (unreachableFromList failedAddFetching) throwUnreachableUsers
+
+          -- Some types of conversations are created lazily on the first
+          -- commit. We do that here, with the commit lock held, but before
+          -- applying changes to the member list.
+          case convOrSub.id of
+            SubConv cnv sub | epoch == Epoch 0 -> do
+              -- create subconversation if it doesn't exist
+              msub' <- getSubConversation cnv sub
+              when (isNothing msub') $
+                void $
+                  createSubConversation
+                    cnv
+                    sub
+                    convOrSub.meta.cnvmlsCipherSuite
+                    convOrSub.meta.cnvmlsGroupId
+
+              pure ()
+            _ -> pure () -- FUTUREWORK: create 1-1 conversation at epoch 0
 
           -- remove users from the conversation and send events
           removeEvents <-

--- a/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
@@ -180,8 +180,6 @@ processInternalCommit senderIdentity con lConvOrSub epoch action commit = do
                     sub
                     convOrSub.meta.cnvmlsCipherSuite
                     convOrSub.meta.cnvmlsGroupId
-
-              pure ()
             _ -> pure () -- FUTUREWORK: create 1-1 conversation at epoch 0
 
           -- remove users from the conversation and send events

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -205,7 +205,9 @@ postMLSCommitBundleToLocalConv qusr c conn bundle lConvOrSubId = do
 
   (events, newClients) <- case bundle.sender of
     SenderMember _index -> do
+      -- extract added/removed clients from bundle
       action <- getCommitData senderIdentity lConvOrSub bundle.epoch bundle.commit.value
+      -- process additions and removals
       events <-
         processInternalCommit
           senderIdentity
@@ -445,7 +447,8 @@ fetchConvOrSub qusr convOrSubId = for convOrSubId $ \case
   SubConv convId sconvId -> do
     let lconv = qualifyAs convOrSubId convId
     c <- getMLSConv qusr lconv
-    subconv <- getSubConversation convId sconvId >>= noteS @'ConvNotFound
+    msubconv <- getSubConversation convId sconvId
+    let subconv = fromMaybe (newSubConversationFromParent lconv sconvId (mcMLSData c)) msubconv
     pure (SubConv c subconv)
   where
     getMLSConv :: Qualified UserId -> Local ConvId -> Sem r MLSConversation

--- a/services/galley/src/Galley/API/MLS/Types.hs
+++ b/services/galley/src/Galley/API/MLS/Types.hs
@@ -30,7 +30,9 @@ import Galley.Types.Conversations.Members
 import Imports
 import Wire.API.Conversation
 import Wire.API.Conversation.Protocol
+import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Credential
+import Wire.API.MLS.Group.Serialisation
 import Wire.API.MLS.LeafNode
 import Wire.API.MLS.SubConversation
 
@@ -145,6 +147,35 @@ data SubConversation = SubConversation
     scIndexMap :: IndexMap
   }
   deriving (Eq, Show)
+
+newSubConversation :: ConvId -> SubConvId -> CipherSuiteTag -> GroupId -> SubConversation
+newSubConversation convId subConvId suite groupId =
+  SubConversation
+    { scParentConvId = convId,
+      scSubConvId = subConvId,
+      scMLSData =
+        ConversationMLSData
+          { cnvmlsGroupId = groupId,
+            cnvmlsEpoch = Epoch 0,
+            cnvmlsEpochTimestamp = Nothing,
+            cnvmlsCipherSuite = suite
+          },
+      scMembers = mkClientMap [],
+      scIndexMap = mempty
+    }
+
+newSubConversationFromParent ::
+  Local ConvId ->
+  SubConvId ->
+  ConversationMLSData ->
+  SubConversation
+newSubConversationFromParent lconv sconv mlsMeta =
+  let groupId =
+        convToGroupId
+          . groupIdParts RegularConv
+          $ flip SubConv sconv <$> tUntagged lconv
+      suite = cnvmlsCipherSuite mlsMeta
+   in newSubConversation (tUnqualified lconv) sconv suite groupId
 
 toPublicSubConv :: Qualified SubConversation -> PublicSubConversation
 toPublicSubConv (Qualified (SubConversation {..}) domain) =

--- a/services/galley/src/Galley/Effects/SubConversationStore.hs
+++ b/services/galley/src/Galley/Effects/SubConversationStore.hs
@@ -30,7 +30,7 @@ import Wire.API.MLS.GroupInfo
 import Wire.API.MLS.SubConversation
 
 data SubConversationStore m a where
-  CreateSubConversation :: ConvId -> SubConvId -> CipherSuiteTag -> Epoch -> GroupId -> Maybe GroupInfoData -> SubConversationStore m ()
+  CreateSubConversation :: ConvId -> SubConvId -> CipherSuiteTag -> GroupId -> SubConversationStore m SubConversation
   GetSubConversation :: ConvId -> SubConvId -> SubConversationStore m (Maybe SubConversation)
   GetSubConversationGroupInfo :: ConvId -> SubConvId -> SubConversationStore m (Maybe GroupInfoData)
   GetSubConversationEpoch :: ConvId -> SubConvId -> SubConversationStore m (Maybe Epoch)


### PR DESCRIPTION
This PR changes the way subconversations are created to be consistent with the approach used for MLS 1-1 conversations. Namely, instead of the GET endpoint creating the conversation when it doesn't exist, creation happens within the commit lock of the first commit.

This also fixes a latent race condition where one thread could "create" an existing conversation which had already progressed to epoch 1, thereby resetting its epoch to 0 and breaking it.

https://wearezeta.atlassian.net/browse/WPB-1927

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
