### PR TITLE
add missing changelog for nonroot containers

### DIFF
--- a/changelog.d/5-internal/containers-nonroot
+++ b/changelog.d/5-internal/containers-nonroot
@@ -1,0 +1,1 @@
+Containers now run as non-root, to improve compatibility with default PodSecurityPolicies in more recent versions of Kubernetes. (#3352)


### PR DESCRIPTION
This was missed to stage during #3352.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d` (this time for real)
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
