### PR TITLE
WPB-1928: Add members to MLS one2one conversations

### DIFF
--- a/changelog.d/2-features/mls-one-to-one
+++ b/changelog.d/2-features/mls-one-to-one
@@ -1,0 +1,1 @@
+Added support for MSL 1-1 conversations

--- a/integration/test/Test/MLS/One2One.hs
+++ b/integration/test/Test/MLS/One2One.hs
@@ -13,10 +13,7 @@ testGetMLSOne2One otherDomain = do
 
   conv <- getMLSOne2OneConversation alice bob >>= getJSON 200
   conv %. "type" `shouldMatchInt` 2
-  others <- conv %. "members.others" & asList
-  other <- assertOne others
-  other %. "conversation_role" `shouldMatch` "wire_member"
-  other %. "qualified_id" `shouldMatch` (bob %. "qualified_id")
+  shouldBeEmpty (conv %. "members.others")
 
   conv %. "members.self.conversation_role" `shouldMatch` "wire_member"
   conv %. "members.self.qualified_id" `shouldMatch` (alice %. "qualified_id")

--- a/integration/test/Testlib/Assertions.hs
+++ b/integration/test/Testlib/Assertions.hs
@@ -108,6 +108,9 @@ shouldMatchSet a b = do
   lb <- fmap sort (asList b)
   la `shouldMatch` lb
 
+shouldBeEmpty :: (MakesValue a, HasCallStack) => a -> App ()
+shouldBeEmpty a = a `shouldMatch` (mempty :: [Value])
+
 shouldContainString ::
   HasCallStack =>
   -- | The actual value

--- a/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
+++ b/libs/api-client/src/Network/Wire/Client/API/Conversation.hs
@@ -48,6 +48,7 @@ import Wire.API.Conversation.Protocol as M
 import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.Event.Conversation as M (MemberUpdateData)
 import Wire.API.Message as M
+import qualified Wire.API.User as M
 
 postOtrMessage :: MonadSession m => ConvId -> NewOtrMessage -> m ClientMismatch
 postOtrMessage cnv msg = sessionRequest req rsc readBody
@@ -141,6 +142,6 @@ createConv users name = sessionRequest req rsc readBody
       method POST
         . path "conversations"
         . acceptJson
-        . json (NewConv users [] (name >>= checked) mempty Nothing Nothing Nothing Nothing roleNameWireAdmin M.ProtocolCreateProteusTag)
+        . json (NewConv users [] (name >>= checked) mempty Nothing Nothing Nothing Nothing roleNameWireAdmin M.BaseProtocolProteusTag)
         $ empty
     rsc = status201 :| []

--- a/libs/wire-api/src/Wire/API/User.hs
+++ b/libs/wire-api/src/Wire/API/User.hs
@@ -119,6 +119,7 @@ module Wire.API.User
 
     -- * Protocol preferences
     BaseProtocolTag (..),
+    baseProtocolToProtocol,
     SupportedProtocolUpdate (..),
     defSupportedProtocols,
     protocolSetBits,
@@ -169,6 +170,7 @@ import Servant (FromHttpApiData (..), ToHttpApiData (..), type (.++))
 import qualified Test.QuickCheck as QC
 import URI.ByteString (serializeURIRef)
 import qualified Web.Cookie as Web
+import Wire.API.Conversation.Protocol
 import Wire.API.Error
 import Wire.API.Error.Brig
 import qualified Wire.API.Error.Brig as E
@@ -1634,6 +1636,10 @@ data BaseProtocolTag = BaseProtocolProteusTag | BaseProtocolMLSTag
 baseProtocolMask :: BaseProtocolTag -> Word32
 baseProtocolMask BaseProtocolProteusTag = 1
 baseProtocolMask BaseProtocolMLSTag = 2
+
+baseProtocolToProtocol :: BaseProtocolTag -> ProtocolTag
+baseProtocolToProtocol BaseProtocolProteusTag = ProtocolProteusTag
+baseProtocolToProtocol BaseProtocolMLSTag = ProtocolMLSTag
 
 instance ToSchema BaseProtocolTag where
   schema =

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/ConversationList_20Conversation_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/ConversationList_20Conversation_user.hs
@@ -42,7 +42,7 @@ testObject_ConversationList_20Conversation_user_1 =
               cnvMetadata =
                 ConversationMetadata
                   { cnvmType = RegularConv,
-                    cnvmCreator = Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000000000001")),
+                    cnvmCreator = Just (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000000000001"))),
                     cnvmAccess = [],
                     cnvmAccessRoles = Set.empty,
                     cnvmName = Just "",

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Conversation_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Conversation_user.hs
@@ -41,7 +41,7 @@ testObject_Conversation_user_1 =
       cnvMetadata =
         ConversationMetadata
           { cnvmType = One2OneConv,
-            cnvmCreator = Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000200000001")),
+            cnvmCreator = Just (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000200000001"))),
             cnvmAccess = [],
             cnvmAccessRoles = Set.empty,
             cnvmName = Just " 0",
@@ -75,7 +75,7 @@ testObject_Conversation_user_2 =
       cnvMetadata =
         ConversationMetadata
           { cnvmType = SelfConv,
-            cnvmCreator = Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000200000001")),
+            cnvmCreator = Just (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000200000001"))),
             cnvmAccess =
               [ InviteAccess,
                 InviteAccess,

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
@@ -148,7 +148,7 @@ testObject_Event_user_8 =
               cnvMetadata =
                 ConversationMetadata
                   { cnvmType = RegularConv,
-                    cnvmCreator = Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000200000001")),
+                    cnvmCreator = Just (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000200000001"))),
                     cnvmAccess =
                       [InviteAccess, PrivateAccess, LinkAccess, InviteAccess, InviteAccess, InviteAccess, LinkAccess],
                     cnvmAccessRoles = Set.fromList [TeamMemberAccessRole, GuestAccessRole, ServiceAccessRole],

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/NewConv_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/NewConv_user.hs
@@ -27,6 +27,7 @@ import qualified Data.UUID as UUID (fromString)
 import Imports
 import Wire.API.Conversation
 import Wire.API.Conversation.Role
+import Wire.API.User
 
 testDomain :: Domain
 testDomain = Domain "testdomain.example.com"
@@ -51,7 +52,7 @@ testObject_NewConv_user_1 =
       newConvMessageTimer = Just (Ms {ms = 3320987366258987}),
       newConvReceiptMode = Just (ReceiptMode {unReceiptMode = 1}),
       newConvUsersRole = fromJust (parseRoleName "8tp2gs7b6"),
-      newConvProtocol = ProtocolCreateProteusTag
+      newConvProtocol = BaseProtocolProteusTag
     }
 
 testObject_NewConv_user_3 :: NewConv
@@ -70,5 +71,5 @@ testObject_NewConv_user_3 =
           ( parseRoleName
               "y3otpiwu615lvvccxsq0315jj75jquw01flhtuf49t6mzfurvwe3_sh51f4s257e2x47zo85rif_xyiyfldpan3g4r6zr35rbwnzm0k"
           ),
-      newConvProtocol = ProtocolCreateMLSTag
+      newConvProtocol = BaseProtocolMLSTag
     }

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationsResponse.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationsResponse.hs
@@ -58,7 +58,7 @@ conv1 =
       cnvMetadata =
         ConversationMetadata
           { cnvmType = One2OneConv,
-            cnvmCreator = Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000200000001")),
+            cnvmCreator = Just (Id (fromJust (UUID.fromString "00000001-0000-0001-0000-000200000001"))),
             cnvmAccess = [],
             cnvmAccessRoles = Set.empty,
             cnvmName = Just " 0",
@@ -92,7 +92,7 @@ conv2 =
       cnvMetadata =
         ConversationMetadata
           { cnvmType = SelfConv,
-            cnvmCreator = Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000200000001")),
+            cnvmCreator = Just (Id (fromJust (UUID.fromString "00000000-0000-0000-0000-000200000001"))),
             cnvmAccess =
               [ InviteAccess,
                 InviteAccess,

--- a/services/brig/test/integration/API/OAuth.hs
+++ b/services/brig/test/integration/API/OAuth.hs
@@ -52,7 +52,7 @@ import Text.RawString.QQ
 import URI.ByteString
 import Util
 import Web.FormUrlEncoded
-import Wire.API.Conversation (Access (..), Conversation (cnvQualifiedId), ProtocolCreateTag (..))
+import Wire.API.Conversation
 import qualified Wire.API.Conversation as Conv
 import Wire.API.Conversation.Code (CreateConversationCodeRequest (CreateConversationCodeRequest))
 import qualified Wire.API.Conversation.Role as Role
@@ -701,7 +701,7 @@ createTeamConv ::
   Http ResponseLBS
 createTeamConv svc mkHeader token tid name = do
   let tinfo = Conv.ConvTeamInfo tid
-  let conv = Conv.NewConv [] [] (checked name) (Set.fromList [CodeAccess]) Nothing (Just tinfo) Nothing Nothing Role.roleNameWireAdmin ProtocolCreateProteusTag
+  let conv = Conv.NewConv [] [] (checked name) (Set.fromList [CodeAccess]) Nothing (Just tinfo) Nothing Nothing Role.roleNameWireAdmin BaseProtocolProteusTag
   post $
     svc
       . path "conversations"

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -1413,7 +1413,7 @@ createConvWithAccessRoles ars g u us =
       . contentJson
       . body (RequestBodyLBS (encode conv))
   where
-    conv = NewConv us [] Nothing Set.empty ars Nothing Nothing Nothing roleNameWireAdmin ProtocolCreateProteusTag
+    conv = NewConv us [] Nothing Set.empty ars Nothing Nothing Nothing roleNameWireAdmin BaseProtocolProteusTag
 
 postMessage ::
   Galley ->

--- a/services/brig/test/integration/API/Team/Util.hs
+++ b/services/brig/test/integration/API/Team/Util.hs
@@ -234,7 +234,7 @@ createTeamConvWithRole role g tid u us mtimer = do
           mtimer
           Nothing
           role
-          ProtocolCreateProteusTag
+          BaseProtocolProteusTag
   r <-
     post
       ( g

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -281,7 +281,7 @@ testAddRemoteUsersToLocalConv brig1 galley1 brig2 galley2 = do
           Nothing
           Nothing
           roleNameWireAdmin
-          ProtocolCreateProteusTag
+          BaseProtocolProteusTag
   convId <-
     fmap cnvQualifiedId . responseJsonError
       =<< post

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -735,7 +735,7 @@ createMLSConversation galley zusr c = do
           Nothing
           Nothing
           roleNameWireAdmin
-          ProtocolCreateMLSTag
+          BaseProtocolMLSTag
   post $
     galley
       . path "/conversations"
@@ -776,7 +776,7 @@ createConversation galley zusr usersToAdd = do
           Nothing
           Nothing
           roleNameWireAdmin
-          ProtocolCreateProteusTag
+          BaseProtocolProteusTag
   post $
     galley
       . path "/conversations"

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -937,7 +937,15 @@ addLocalUsersToRemoteConv ::
 addLocalUsersToRemoteConv remoteConvId qAdder localUsers = do
   connStatus <- E.getConnections localUsers (Just [qAdder]) (Just Accepted)
   let localUserIdsSet = Set.fromList localUsers
-      connected = Set.fromList $ fmap csv2From connStatus
+      adder = qUnqualified qAdder
+      -- If alice@A creates a 1-1 conversation on B, it can appear as if alice is
+      -- adding herself to a remote conversation. To make sure this is allowed, we
+      -- always consider a user as connected to themself.
+      connected =
+        Set.fromList (fmap csv2From connStatus)
+          <> if Set.member adder localUserIdsSet
+            then Set.singleton adder
+            else mempty
       unconnected = Set.difference localUserIdsSet connected
       connectedList = Set.toList connected
 

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -294,7 +294,7 @@ createProteusSelfConversation lusr = do
     create lcnv = do
       let nc =
             NewConversation
-              { ncMetadata = (defConversationMetadata (tUnqualified lusr)) {cnvmType = SelfConv},
+              { ncMetadata = (defConversationMetadata (Just (tUnqualified lusr))) {cnvmType = SelfConv},
                 ncUsers = ulFromLocals [toUserRole (tUnqualified lusr)],
                 ncProtocol = ProtocolCreateProteusTag
               }
@@ -383,7 +383,7 @@ createLegacyOne2OneConversationUnchecked ::
 createLegacyOne2OneConversationUnchecked self zcon name mtid other = do
   lcnv <- localOne2OneConvId self other
   let meta =
-        (defConversationMetadata (tUnqualified self))
+        (defConversationMetadata (Just (tUnqualified self)))
           { cnvmType = One2OneConv,
             cnvmTeam = mtid,
             cnvmName = fmap fromRange name
@@ -447,7 +447,7 @@ createOne2OneConversationLocally lcnv self zcon name mtid other = do
     Just c -> conversationExisted self c
     Nothing -> do
       let meta =
-            (defConversationMetadata (tUnqualified self))
+            (defConversationMetadata (Just (tUnqualified self)))
               { cnvmType = One2OneConv,
                 cnvmTeam = mtid,
                 cnvmName = fmap fromRange name
@@ -495,7 +495,7 @@ createConnectConversation lusr conn j = do
   lrecipient <- ensureLocal lusr (cRecipient j)
   n <- rangeCheckedMaybe (cName j)
   let meta =
-        (defConversationMetadata (tUnqualified lusr))
+        (defConversationMetadata (Just (tUnqualified lusr)))
           { cnvmType = ConnectConv,
             cnvmName = fmap fromRange n
           }
@@ -588,7 +588,7 @@ newRegularConversation lusr newConv = do
           { ncMetadata =
               ConversationMetadata
                 { cnvmType = RegularConv,
-                  cnvmCreator = tUnqualified lusr,
+                  cnvmCreator = Just (tUnqualified lusr),
                   cnvmAccess = access newConv,
                   cnvmAccessRoles = accessRoles newConv,
                   cnvmName = fmap fromRange (newConvName newConv),
@@ -649,7 +649,7 @@ notifyCreatedConversation lusr conn c = do
   now <- input
   -- Ask remote server to store conversation membership and notify remote users
   -- of being added to a conversation
-  failedToNotify <- registerRemoteConversationMemberships now (tDomain lusr) c
+  failedToNotify <- registerRemoteConversationMemberships now lusr c
   let allRemotes = Data.convRemoteMembers c
       notifiedRemotes =
         filter

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -559,13 +559,14 @@ sendMLSCommitBundle remoteDomain msr =
           decodeMLS' (fromBase64ByteString (F.mmsrRawMessage msr))
 
       ibundle <- noteS @'MLSUnsupportedMessage $ mkIncomingBundle bundle
-      qConvOrSub <- getConvFromGroupId ibundle.groupId
+      (ctype, qConvOrSub) <- getConvFromGroupId ibundle.groupId
       when (qUnqualified qConvOrSub /= F.mmsrConvOrSubId msr) $ throwS @'MLSGroupConversationMismatch
       uncurry F.MLSMessageResponseUpdates . (,mempty) . map lcuUpdate
         <$> postMLSCommitBundle
           loc
           (tUntagged sender)
           (mmsrSenderClient msr)
+          ctype
           qConvOrSub
           Nothing
           ibundle
@@ -606,13 +607,14 @@ sendMLSMessage remoteDomain msr =
       let sender = toRemoteUnsafe remoteDomain (F.mmsrSender msr)
       raw <- either (throw . mlsProtocolError) pure $ decodeMLS' (fromBase64ByteString (F.mmsrRawMessage msr))
       msg <- noteS @'MLSUnsupportedMessage $ mkIncomingMessage raw
-      qConvOrSub <- getConvFromGroupId msg.groupId
+      (ctype, qConvOrSub) <- getConvFromGroupId msg.groupId
       when (qUnqualified qConvOrSub /= F.mmsrConvOrSubId msr) $ throwS @'MLSGroupConversationMismatch
       uncurry F.MLSMessageResponseUpdates . first (map lcuUpdate)
         <$> postMLSMessage
           loc
           (tUntagged sender)
           (mmsrSenderClient msr)
+          ctype
           qConvOrSub
           Nothing
           msg

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -837,7 +837,7 @@ getOne2OneConversation domain (GetOne2OneConversationRequest self other) =
       let getLocal lconv = do
             mconv <- E.getConversation (tUnqualified lconv)
             fmap GetOne2OneConversationOk $ case mconv of
-              Nothing -> pure (localMLSOne2OneConversationAsRemote rself lother lconv)
+              Nothing -> pure (localMLSOne2OneConversationAsRemote lother lconv)
               Just conv ->
                 note
                   (InternalErrorWithDescription "Unexpected member list in 1-1 conversation")

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -839,7 +839,7 @@ getOne2OneConversation domain (GetOne2OneConversationRequest self other) =
       let getLocal lconv = do
             mconv <- E.getConversation (tUnqualified lconv)
             fmap GetOne2OneConversationOk $ case mconv of
-              Nothing -> pure (localMLSOne2OneConversationAsRemote lother lconv)
+              Nothing -> pure (localMLSOne2OneConversationAsRemote lconv)
               Just conv ->
                 note
                   (InternalErrorWithDescription "Unexpected member list in 1-1 conversation")

--- a/services/galley/src/Galley/API/MLS/Commit/Core.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/Core.hs
@@ -96,15 +96,15 @@ getCommitData ::
   Sem r ProposalAction
 getCommitData senderIdentity lConvOrSub epoch commit = do
   let convOrSub = tUnqualified lConvOrSub
-      groupId = cnvmlsGroupId convOrSub.meta
+      groupId = cnvmlsGroupId convOrSub.mlsMeta
 
   evalState convOrSub.indexMap $ do
     creatorAction <-
       if epoch == Epoch 0
         then addProposedClient senderIdentity
         else mempty
-    proposals <- traverse (derefOrCheckProposal convOrSub.meta groupId epoch) commit.proposals
-    action <- applyProposals convOrSub.meta groupId proposals
+    proposals <- traverse (derefOrCheckProposal convOrSub.mlsMeta groupId epoch) commit.proposals
+    action <- applyProposals convOrSub.mlsMeta groupId proposals
     pure (creatorAction <> action)
 
 incrementEpoch ::

--- a/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/ExternalCommit.hs
@@ -69,8 +69,8 @@ getExternalCommitData ::
   Sem r ExternalCommitAction
 getExternalCommitData senderIdentity lConvOrSub epoch commit = do
   let convOrSub = tUnqualified lConvOrSub
-      curEpoch = cnvmlsEpoch convOrSub.meta
-      groupId = cnvmlsGroupId convOrSub.meta
+      curEpoch = cnvmlsEpoch convOrSub.mlsMeta
+      groupId = cnvmlsGroupId convOrSub.mlsMeta
   when (epoch /= curEpoch) $ throwS @'MLSStaleMessage
   when (epoch == Epoch 0) $
     throw $
@@ -94,7 +94,7 @@ getExternalCommitData senderIdentity lConvOrSub epoch commit = do
 
   evalState convOrSub.indexMap $ do
     -- process optional removal
-    propAction <- applyProposals convOrSub.meta groupId proposals
+    propAction <- applyProposals convOrSub.mlsMeta groupId proposals
     removedIndex <- case cmAssocs (paRemove propAction) of
       [(cid, idx)]
         | cid /= senderIdentity ->
@@ -146,8 +146,8 @@ processExternalCommit senderIdentity lConvOrSub epoch action updatePath = do
       <$> note
         (mlsProtocolError "External commits need an update path")
         updatePath
-  let cs = cnvmlsCipherSuite (tUnqualified lConvOrSub).meta
-  let groupId = cnvmlsGroupId convOrSub.meta
+  let cs = cnvmlsCipherSuite (tUnqualified lConvOrSub).mlsMeta
+  let groupId = cnvmlsGroupId convOrSub.mlsMeta
   let extra = LeafNodeTBSExtraCommit groupId action.add
   case validateLeafNode cs (Just senderIdentity) extra leafNode.value of
     Left errMsg ->
@@ -182,7 +182,7 @@ executeExternalCommitAction ::
   ExternalCommitAction ->
   Sem r ()
 executeExternalCommitAction lconvOrSub senderIdentity action = do
-  let mlsMeta = (tUnqualified lconvOrSub).meta
+  let mlsMeta = (tUnqualified lconvOrSub).mlsMeta
 
   -- Remove deprecated sender client from conversation state.
   for_ action.remove $ \_ ->

--- a/services/galley/src/Galley/API/MLS/Conversation.hs
+++ b/services/galley/src/Galley/API/MLS/Conversation.hs
@@ -17,15 +17,19 @@
 
 module Galley.API.MLS.Conversation
   ( mkMLSConversation,
+    newMLSConversation,
     mcConv,
   )
 where
 
+import Data.Id
+import Data.Qualified
 import Galley.API.MLS.Types
 import Galley.Data.Conversation.Types as Data
 import Galley.Effects.MemberStore
 import Imports
 import Polysemy
+import Wire.API.Conversation hiding (Member)
 import Wire.API.Conversation.Protocol
 
 mkMLSConversation ::
@@ -46,6 +50,20 @@ mkMLSConversation conv =
           mcIndexMap = im,
           mcMigrationState = migrationState
         }
+
+-- | Creates a new MLS conversation with members but no clients.
+newMLSConversation :: Local ConvId -> ConversationMetadata -> ConversationMLSData -> MLSConversation
+newMLSConversation lcnv meta mlsData =
+  MLSConversation
+    { mcId = tUnqualified lcnv,
+      mcMetadata = meta,
+      mcMLSData = mlsData,
+      mcLocalMembers = [],
+      mcRemoteMembers = [],
+      mcMembers = mempty,
+      mcIndexMap = mempty,
+      mcMigrationState = MLSMigrationMLS
+    }
 
 mcConv :: MLSConversation -> Data.Conversation
 mcConv mlsConv =

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -336,7 +336,7 @@ getSenderIdentity ::
   Sem r ClientIdentity
 getSenderIdentity qusr c mSender lConvOrSubConv = do
   let cid = mkClientIdentity qusr c
-  let epoch = epochNumber . cnvmlsEpoch . (.meta) . tUnqualified $ lConvOrSubConv
+  let epoch = epochNumber . cnvmlsEpoch . (.mlsMeta) . tUnqualified $ lConvOrSubConv
   case mSender of
     SenderMember idx | epoch > 0 -> do
       cid' <- note (mlsProtocolError "unknown sender leaf index") $ imLookup (tUnqualified lConvOrSubConv).indexMap idx

--- a/services/galley/src/Galley/API/MLS/One2One.hs
+++ b/services/galley/src/Galley/API/MLS/One2One.hs
@@ -45,14 +45,13 @@ import Wire.API.User
 -- (possibly remote) user.
 localMLSOne2OneConversation ::
   Local UserId ->
-  Qualified UserId ->
   Local ConvId ->
   Conversation
-localMLSOne2OneConversation lself qother (tUntagged -> convId) =
+localMLSOne2OneConversation lself (tUntagged -> convId) =
   let members =
         ConvMembers
           { cmSelf = defMember (tUntagged lself),
-            cmOthers = [defOtherMember qother]
+            cmOthers = []
           }
       (metadata, mlsData) = localMLSOne2OneConversationMetadata convId
    in Conversation
@@ -65,14 +64,13 @@ localMLSOne2OneConversation lself qother (tUntagged -> convId) =
 -- | Construct a 'RemoteConversation' structure for a local MLS 1-1
 -- conversation to be returned to a remote backend.
 localMLSOne2OneConversationAsRemote ::
-  Local UserId ->
   Local ConvId ->
   RemoteConversation
-localMLSOne2OneConversationAsRemote lother lcnv =
+localMLSOne2OneConversationAsRemote lcnv =
   let members =
         RemoteConvMembers
           { rcmSelfRole = roleNameWireMember,
-            rcmOthers = [defOtherMember (tUntagged lother)]
+            rcmOthers = []
           }
       (metadata, mlsData) = localMLSOne2OneConversationMetadata (tUntagged lcnv)
    in RemoteConversation
@@ -111,7 +109,7 @@ remoteMLSOne2OneConversation lself rother rc =
   let members =
         ConvMembers
           { cmSelf = defMember (tUntagged lself),
-            cmOthers = [defOtherMember (tUntagged rother)]
+            cmOthers = []
           }
    in Conversation
         { cnvQualifiedId = tUntagged (qualifyAs rother (rcnvId rc)),

--- a/services/galley/src/Galley/API/MLS/One2One.hs
+++ b/services/galley/src/Galley/API/MLS/One2One.hs
@@ -46,7 +46,7 @@ localMLSOne2OneConversation lself qother (tUntagged -> convId) =
           { cmSelf = defMember (tUntagged lself),
             cmOthers = [defOtherMember qother]
           }
-      (metadata, protocol) = localMLSOne2OneConversationMetadata (tUntagged lself) convId
+      (metadata, protocol) = localMLSOne2OneConversationMetadata convId
    in Conversation
         { cnvQualifiedId = convId,
           cnvMetadata = metadata,
@@ -57,17 +57,16 @@ localMLSOne2OneConversation lself qother (tUntagged -> convId) =
 -- | Construct a 'RemoteConversation' structure for a local MLS 1-1
 -- conversation to be returned to a remote backend.
 localMLSOne2OneConversationAsRemote ::
-  Remote UserId ->
   Local UserId ->
   Local ConvId ->
   RemoteConversation
-localMLSOne2OneConversationAsRemote rself lother lcnv =
+localMLSOne2OneConversationAsRemote lother lcnv =
   let members =
         RemoteConvMembers
           { rcmSelfRole = roleNameWireMember,
             rcmOthers = [defOtherMember (tUntagged lother)]
           }
-      (metadata, protocol) = localMLSOne2OneConversationMetadata (tUntagged rself) (tUntagged lcnv)
+      (metadata, protocol) = localMLSOne2OneConversationMetadata (tUntagged lcnv)
    in RemoteConversation
         { rcnvId = tUnqualified lcnv,
           rcnvMetadata = metadata,
@@ -76,14 +75,11 @@ localMLSOne2OneConversationAsRemote rself lother lcnv =
         }
 
 localMLSOne2OneConversationMetadata ::
-  Qualified UserId ->
   Qualified ConvId ->
   (ConversationMetadata, Protocol)
-localMLSOne2OneConversationMetadata self convId =
+localMLSOne2OneConversationMetadata convId =
   let metadata =
-        ( defConversationMetadata
-            (qUnqualified self)
-        )
+        (defConversationMetadata Nothing)
           { cnvmType = One2OneConv
           }
       groupId = convToGroupId $ groupIdParts One2OneConv (fmap Conv convId)

--- a/services/galley/src/Galley/API/MLS/One2One.hs
+++ b/services/galley/src/Galley/API/MLS/One2One.hs
@@ -39,6 +39,7 @@ import Wire.API.Federation.API.Galley
 import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Group.Serialisation
 import Wire.API.MLS.SubConversation
+import Wire.API.User
 
 -- | Construct a local MLS 1-1 'Conversation' between a local user and another
 -- (possibly remote) user.
@@ -133,5 +134,5 @@ createMLSOne2OneConversation self other lconv = do
     Data.NewConversation
       { ncMetadata = mcMetadata (tUnqualified lconv),
         ncUsers = fmap (,roleNameWireMember) (toUserList lconv [self, other]),
-        ncProtocol = ProtocolCreateMLSTag
+        ncProtocol = BaseProtocolMLSTag
       }

--- a/services/galley/src/Galley/API/MLS/Proposal.hs
+++ b/services/galley/src/Galley/API/MLS/Proposal.hs
@@ -239,7 +239,7 @@ processProposal ::
   RawMLS Proposal ->
   Sem r ()
 processProposal qusr lConvOrSub groupId epoch pub prop = do
-  let mlsMeta = (tUnqualified lConvOrSub).meta
+  let mlsMeta = (tUnqualified lConvOrSub).mlsMeta
   -- Check if the epoch number matches that of a conversation
   unless (epoch == cnvmlsEpoch mlsMeta) $ throwS @'MLSStaleMessage
   -- Check if the group ID matches that of a conversation

--- a/services/galley/src/Galley/API/MLS/Removal.hs
+++ b/services/galley/src/Galley/API/MLS/Removal.hs
@@ -78,7 +78,7 @@ createAndSendRemoveProposals ::
   ClientMap ->
   Sem r ()
 createAndSendRemoveProposals lConvOrSubConv indices qusr cm = do
-  let meta = (tUnqualified lConvOrSubConv).meta
+  let meta = (tUnqualified lConvOrSubConv).mlsMeta
   mKeyPair <- getMLSRemovalKey
   case mKeyPair of
     Nothing -> do

--- a/services/galley/src/Galley/API/MLS/Types.hs
+++ b/services/galley/src/Galley/API/MLS/Types.hs
@@ -192,7 +192,7 @@ toPublicSubConv (Qualified (SubConversation {..}) domain) =
 
 type ConvOrSubConv = ConvOrSubChoice MLSConversation SubConversation
 
-instance HasField "meta" ConvOrSubConv ConversationMLSData where
+instance HasField "mlsMeta" ConvOrSubConv ConversationMLSData where
   getField (Conv c) = mcMLSData c
   getField (SubConv _ s) = scMLSData s
 

--- a/services/galley/src/Galley/API/MLS/Types.hs
+++ b/services/galley/src/Galley/API/MLS/Types.hs
@@ -192,6 +192,9 @@ toPublicSubConv (Qualified (SubConversation {..}) domain) =
 
 type ConvOrSubConv = ConvOrSubChoice MLSConversation SubConversation
 
+instance HasField "meta" ConvOrSubConv ConversationMetadata where
+  getField x = x.conv.mcMetadata
+
 instance HasField "mlsMeta" ConvOrSubConv ConversationMLSData where
   getField (Conv c) = mcMLSData c
   getField (SubConv _ s) = scMLSData s

--- a/services/galley/src/Galley/API/One2One.hs
+++ b/services/galley/src/Galley/API/One2One.hs
@@ -49,7 +49,7 @@ newConnectConversationWithRemote creator users =
           { cnvmType = One2OneConv
           },
       ncUsers = fmap toUserRole users,
-      ncProtocol = ProtocolCreateProteusTag
+      ncProtocol = BaseProtocolProteusTag
     }
 
 iUpsertOne2OneConversation ::

--- a/services/galley/src/Galley/API/One2One.hs
+++ b/services/galley/src/Galley/API/One2One.hs
@@ -45,7 +45,7 @@ newConnectConversationWithRemote ::
 newConnectConversationWithRemote creator users =
   NewConversation
     { ncMetadata =
-        (defConversationMetadata (tUnqualified creator))
+        (defConversationMetadata (Just (tUnqualified creator)))
           { cnvmType = One2OneConv
           },
       ncUsers = fmap toUserRole users,

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -767,7 +767,7 @@ getMLSOne2OneConversation lself qother = do
   let convId = one2OneConvId BaseProtocolMLSTag (tUntagged lself) qother
   foldQualified
     lself
-    (getLocalMLSOne2OneConversation lself qother)
+    (getLocalMLSOne2OneConversation lself)
     (getRemoteMLSOne2OneConversation lself qother)
     convId
 
@@ -777,13 +777,12 @@ getLocalMLSOne2OneConversation ::
     Member P.TinyLog r
   ) =>
   Local UserId ->
-  Qualified UserId ->
   Local ConvId ->
   Sem r Conversation
-getLocalMLSOne2OneConversation lself qother lconv = do
+getLocalMLSOne2OneConversation lself lconv = do
   mconv <- E.getConversation (tUnqualified lconv)
   case mconv of
-    Nothing -> pure (localMLSOne2OneConversation lself qother lconv)
+    Nothing -> pure (localMLSOne2OneConversation lself lconv)
     Just conv -> conversationView lself conv
 
 getRemoteMLSOne2OneConversation ::

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -59,6 +59,7 @@ import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Group.Serialisation
 import Wire.API.MLS.GroupInfo
 import Wire.API.MLS.SubConversation
+import Wire.API.User
 
 createMLSSelfConversation ::
   Local UserId ->
@@ -71,7 +72,7 @@ createMLSSelfConversation lusr = do
           { ncMetadata =
               (defConversationMetadata (Just usr)) {cnvmType = SelfConv},
             ncUsers = ulFromLocals [toUserRole usr],
-            ncProtocol = ProtocolCreateMLSTag
+            ncProtocol = BaseProtocolMLSTag
           }
       meta = ncMetadata nc
       gid = convToGroupId . groupIdParts meta.cnvmType . fmap Conv . tUntagged . qualifyAs lusr $ cnv
@@ -121,8 +122,8 @@ createConversation :: Local ConvId -> NewConversation -> Client Conversation
 createConversation lcnv nc = do
   let meta = ncMetadata nc
       (proto, mgid, mep, mcs) = case ncProtocol nc of
-        ProtocolCreateProteusTag -> (ProtocolProteus, Nothing, Nothing, Nothing)
-        ProtocolCreateMLSTag ->
+        BaseProtocolProteusTag -> (ProtocolProteus, Nothing, Nothing, Nothing)
+        BaseProtocolMLSTag ->
           let gid = convToGroupId . groupIdParts meta.cnvmType $ Conv <$> tUntagged lcnv
               ep = Epoch 0
               cs = MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
@@ -156,7 +157,7 @@ createConversation lcnv nc = do
         cnvmTeam meta,
         cnvmMessageTimer meta,
         cnvmReceiptMode meta,
-        protocolCreateToProtocolTag (ncProtocol nc),
+        baseProtocolToProtocol (ncProtocol nc),
         mgid,
         mep,
         mcs

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -227,7 +227,7 @@ selectReceiptMode = "select receipt_mode from conversation where conv = ?"
 isConvDeleted :: PrepQuery R (Identity ConvId) (Identity (Maybe Bool))
 isConvDeleted = "select deleted from conversation where conv = ?"
 
-insertConv :: PrepQuery W (ConvId, ConvType, UserId, C.Set Access, C.Set AccessRole, Maybe Text, Maybe TeamId, Maybe Milliseconds, Maybe ReceiptMode, ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuiteTag) ()
+insertConv :: PrepQuery W (ConvId, ConvType, Maybe UserId, C.Set Access, C.Set AccessRole, Maybe Text, Maybe TeamId, Maybe Milliseconds, Maybe ReceiptMode, ProtocolTag, Maybe GroupId, Maybe Epoch, Maybe CipherSuiteTag) ()
 insertConv = "insert into conversation (conv, type, creator, access, access_roles_v2, name, team, message_timer, receipt_mode, protocol, group_id, epoch, cipher_suite) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
 insertMLSSelfConv ::
@@ -235,7 +235,7 @@ insertMLSSelfConv ::
     W
     ( ConvId,
       ConvType,
-      UserId,
+      Maybe UserId,
       C.Set Access,
       C.Set AccessRole,
       Maybe Text,

--- a/services/galley/src/Galley/Data/Conversation.hs
+++ b/services/galley/src/Galley/Data/Conversation.hs
@@ -86,7 +86,7 @@ convAccessData c =
     (Set.fromList (convAccess c))
     (convAccessRoles c)
 
-convCreator :: Conversation -> UserId
+convCreator :: Conversation -> Maybe UserId
 convCreator = cnvmCreator . convMetadata
 
 convName :: Conversation -> Maybe Text

--- a/services/galley/src/Galley/Data/Conversation/Types.hs
+++ b/services/galley/src/Galley/Data/Conversation/Types.hs
@@ -24,6 +24,7 @@ import Imports
 import Wire.API.Conversation hiding (Conversation)
 import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
+import Wire.API.User
 
 -- | Internal conversation type, corresponding directly to database schema.
 -- Should never be sent to users (and therefore doesn't have 'FromJSON' or
@@ -41,7 +42,7 @@ data Conversation = Conversation
 data NewConversation = NewConversation
   { ncMetadata :: ConversationMetadata,
     ncUsers :: UserList (UserId, RoleName),
-    ncProtocol :: ProtocolCreateTag
+    ncProtocol :: BaseProtocolTag
   }
 
 data MLSMigrationState

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -341,7 +341,7 @@ postProteusConvOk = do
     rsp <-
       postConv alice [bob, jane] (Just nameMaxSize) [] Nothing Nothing
         <!! const 201 === statusCode
-    qcid <- assertConv rsp RegularConv alice qalice [qbob, qjane] (Just nameMaxSize) Nothing
+    qcid <- assertConv rsp RegularConv (Just alice) qalice [qbob, qjane] (Just nameMaxSize) Nothing
     let cid = qUnqualified qcid
     cvs <- mapM (convView cid) [alice, bob, jane]
     liftIO $ mapM_ WS.assertSuccess =<< Async.mapConcurrently (checkWs qalice) (zip cvs [wsA, wsB, wsJ])
@@ -400,7 +400,7 @@ postConvWithRemoteUsersOk rbs = do
       assertConv
         rsp
         RegularConv
-        alice
+        (Just alice)
         qAlice
         shouldBePresent
         (Just nameMaxSize)
@@ -2491,8 +2491,8 @@ postSelfConvOk = do
   let alice = qUnqualified qalice
   m <- postSelfConv alice <!! const 200 === statusCode
   n <- postSelfConv alice <!! const 200 === statusCode
-  mId <- assertConv m SelfConv alice qalice [] Nothing Nothing
-  nId <- assertConv n SelfConv alice qalice [] Nothing Nothing
+  mId <- assertConv m SelfConv (Just alice) qalice [] Nothing Nothing
+  nId <- assertConv n SelfConv (Just alice) qalice [] Nothing Nothing
   liftIO $ mId @=? nId
 
 postO2OConvOk :: TestM ()
@@ -2502,8 +2502,8 @@ postO2OConvOk = do
   connectUsers alice (singleton bob)
   a <- postO2OConv alice bob Nothing <!! const 200 === statusCode
   c <- postO2OConv alice bob Nothing <!! const 200 === statusCode
-  aId <- assertConv a One2OneConv alice qalice [qbob] Nothing Nothing
-  cId <- assertConv c One2OneConv alice qalice [qbob] Nothing Nothing
+  aId <- assertConv a One2OneConv (Just alice) qalice [qbob] Nothing Nothing
+  cId <- assertConv c One2OneConv (Just alice) qalice [qbob] Nothing Nothing
   liftIO $ aId @=? cId
 
 postConvO2OFailWithSelf :: TestM ()
@@ -2526,8 +2526,8 @@ postConnectConvOk = do
   n <-
     postConnectConv alice bob "Alice" "connect with me!" Nothing
       <!! const 200 === statusCode
-  mId <- assertConv m ConnectConv alice qalice [] (Just "Alice") Nothing
-  nId <- assertConv n ConnectConv alice qalice [] (Just "Alice") Nothing
+  mId <- assertConv m ConnectConv (Just alice) qalice [] (Just "Alice") Nothing
+  nId <- assertConv n ConnectConv (Just alice) qalice [] (Just "Alice") Nothing
   liftIO $ mId @=? nId
 
 postConnectConvOk2 :: TestM ()
@@ -2572,13 +2572,13 @@ postMutualConnectConvOk = do
   ac <-
     postConnectConv alice bob "A" "a" Nothing
       <!! const 201 === statusCode
-  acId <- assertConv ac ConnectConv alice qalice [] (Just "A") Nothing
+  acId <- assertConv ac ConnectConv (Just alice) qalice [] (Just "A") Nothing
   bc <-
     postConnectConv bob alice "B" "b" Nothing
       <!! const 200 === statusCode
   -- The connect conversation was simply accepted, thus the
   -- conversation name and message sent in Bob's request ignored.
-  bcId <- assertConv bc One2OneConv alice qbob [qalice] (Just "A") Nothing
+  bcId <- assertConv bc One2OneConv (Just alice) qbob [qalice] (Just "A") Nothing
   liftIO $ acId @=? bcId
 
 postRepeatConnectConvCancel :: TestM ()
@@ -2709,7 +2709,7 @@ accessConvMeta = do
   let meta =
         ConversationMetadata
           RegularConv
-          alice
+          (Just alice)
           [InviteAccess]
           (Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole, ServiceAccessRole])
           (Just "gossip")

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2482,7 +2482,7 @@ postConvQualifiedFederationNotEnabled = do
 -- FUTUREWORK: figure out how to use functions in the TestM monad inside withSettingsOverrides and remove this duplication
 postConvHelper :: MonadHttp m => (Request -> Request) -> UserId -> [Qualified UserId] -> m ResponseLBS
 postConvHelper g zusr newUsers = do
-  let conv = NewConv [] newUsers (checked "gossip") (Set.fromList []) Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolCreateProteusTag
+  let conv = NewConv [] newUsers (checked "gossip") (Set.fromList []) Nothing Nothing Nothing Nothing roleNameWireAdmin BaseProtocolProteusTag
   post $ g . path "/conversations" . zUser zusr . zConn "conn" . zType "access" . json conv
 
 postSelfConvOk :: TestM ()
@@ -2510,7 +2510,7 @@ postConvO2OFailWithSelf :: TestM ()
 postConvO2OFailWithSelf = do
   g <- viewGalley
   alice <- randomUser
-  let inv = NewConv [alice] [] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolCreateProteusTag
+  let inv = NewConv [alice] [] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin BaseProtocolProteusTag
   post (g . path "/conversations/one2one" . zUser alice . zConn "conn" . zType "access" . json inv) !!! do
     const 403 === statusCode
     const (Just "invalid-op") === fmap label . responseJsonUnsafe

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -1152,7 +1152,7 @@ updateConversationByRemoteAdmin = do
         postConvQualified alice Nothing defNewProteusConv {newConvName = checked convName, newConvQualifiedUsers = [qbob, qcharlie]}
           <!! const 201 === statusCode
 
-    cnv <- assertConv rsp RegularConv alice qalice [qbob, qcharlie] (Just convName) Nothing
+    cnv <- assertConv rsp RegularConv (Just alice) qalice [qbob, qcharlie] (Just convName) Nothing
 
     let newReceiptMode = ReceiptMode 41
     let action = SomeConversationAction (sing @'ConversationReceiptModeUpdateTag) (ConversationReceiptModeUpdate newReceiptMode)

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -276,7 +276,7 @@ postMLSConvOk = do
     pure rsp !!! do
       const 201 === statusCode
       const Nothing === fmap Wai.label . responseJsonError
-    qcid <- assertConv rsp RegularConv alice qalice [] (Just nameMaxSize) Nothing
+    qcid <- assertConv rsp RegularConv (Just alice) qalice [] (Just nameMaxSize) Nothing
     checkConvCreateEvent (qUnqualified qcid) wsA
 
 testSenderNotInConversation :: TestM ()

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -80,7 +80,7 @@ messageTimerInit mtimer = do
   rsp <-
     postConv alice [bob, jane] Nothing [] Nothing mtimer
       <!! const 201 === statusCode
-  cid <- assertConv rsp RegularConv alice qalice [qbob, qjane] Nothing mtimer
+  cid <- assertConv rsp RegularConv (Just alice) qalice [qbob, qjane] Nothing mtimer
   -- Check that the timer is indeed what it should be
   getConvQualified jane cid
     !!! const mtimer === (cnvMessageTimer <=< responseJsonUnsafe)
@@ -93,7 +93,7 @@ messageTimerChange = do
   rsp <-
     postConv alice [bob, jane] Nothing [] Nothing Nothing
       <!! const 201 === statusCode
-  qcid <- assertConv rsp RegularConv alice qalice [qbob, qjane] Nothing Nothing
+  qcid <- assertConv rsp RegularConv (Just alice) qalice [qbob, qjane] Nothing Nothing
   let cid = qUnqualified qcid
   -- Set timer to null and observe 204
   putMessageTimerUpdate alice cid (ConversationMessageTimerUpdate Nothing)
@@ -122,7 +122,7 @@ messageTimerChangeQualified = do
   rsp <-
     postConv alice [bob, jane] Nothing [] Nothing Nothing
       <!! const 201 === statusCode
-  qcid <- assertConv rsp RegularConv alice qalice [qbob, qjane] Nothing Nothing
+  qcid <- assertConv rsp RegularConv (Just alice) qalice [qbob, qjane] Nothing Nothing
   -- Set timer to null and observe 204
   putMessageTimerUpdateQualified alice qcid (ConversationMessageTimerUpdate Nothing)
     !!! const 204 === statusCode
@@ -255,7 +255,7 @@ messageTimerChangeO2O = do
   rsp <-
     postO2OConv alice bob Nothing
       <!! const 200 === statusCode
-  qcid <- assertConv rsp One2OneConv alice qalice [qbob] Nothing Nothing
+  qcid <- assertConv rsp One2OneConv (Just alice) qalice [qbob] Nothing Nothing
   let cid = qUnqualified qcid
   -- Try to change the timer and observe failure
   putMessageTimerUpdate alice cid (ConversationMessageTimerUpdate timer1sec) !!! do
@@ -273,7 +273,7 @@ messageTimerEvent = do
   rsp <-
     postConv alice [bob] Nothing [] Nothing Nothing
       <!! const 201 === statusCode
-  qcid <- assertConv rsp RegularConv alice qalice [qbob] Nothing Nothing
+  qcid <- assertConv rsp RegularConv (Just alice) qalice [qbob] Nothing Nothing
   let cid = qUnqualified qcid
   -- Set timer to 1 second and check that all participants got the event
   WS.bracketR2 ca alice bob $ \(wsA, wsB) -> do

--- a/services/galley/test/integration/API/Roles.hs
+++ b/services/galley/test/integration/API/Roles.hs
@@ -97,7 +97,7 @@ handleConversationRoleAdmin = do
   let role = roleNameWireAdmin
   cid <- WS.bracketR3 c alice bob chuck $ \(wsA, wsB, wsC) -> do
     rsp <- postConvWithRole alice [bob, chuck] (Just "gossip") [] Nothing Nothing role
-    void $ assertConvWithRole rsp RegularConv alice qalice [qbob, qchuck] (Just "gossip") Nothing role
+    void $ assertConvWithRole rsp RegularConv (Just alice) qalice [qbob, qchuck] (Just "gossip") Nothing role
     let cid = decodeConvId rsp
         qcid = Qualified cid localDomain
     -- Make sure everyone gets the correct event
@@ -138,7 +138,7 @@ handleConversationRoleMember = do
   let role = roleNameWireMember
   cid <- WS.bracketR3 c alice bob chuck $ \(wsA, wsB, wsC) -> do
     rsp <- postConvWithRole alice [bob, chuck] (Just "gossip") [] Nothing Nothing role
-    void $ assertConvWithRole rsp RegularConv alice qalice [qbob, qchuck] (Just "gossip") Nothing role
+    void $ assertConvWithRole rsp RegularConv (Just alice) qalice [qbob, qchuck] (Just "gossip") Nothing role
     let cid = decodeConvId rsp
         qcid = Qualified cid localDomain
     -- Make sure everyone gets the correct event

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -622,7 +622,7 @@ createTeamConvAccessRaw u tid us name acc role mtimer convRole = do
   g <- viewGalley
   let tinfo = ConvTeamInfo tid
   let conv =
-        NewConv us [] (name >>= checked) (fromMaybe (Set.fromList []) acc) role (Just tinfo) mtimer Nothing (fromMaybe roleNameWireAdmin convRole) ProtocolCreateProteusTag
+        NewConv us [] (name >>= checked) (fromMaybe (Set.fromList []) acc) role (Just tinfo) mtimer Nothing (fromMaybe roleNameWireAdmin convRole) BaseProtocolProteusTag
   post
     ( g
         . path "/conversations"
@@ -658,7 +658,7 @@ createMLSTeamConv lusr c tid users name access role timer convRole = do
             newConvMessageTimer = timer,
             newConvUsersRole = fromMaybe roleNameWireAdmin convRole,
             newConvReceiptMode = Nothing,
-            newConvProtocol = ProtocolCreateMLSTag
+            newConvProtocol = BaseProtocolMLSTag
           }
   r <-
     post
@@ -689,7 +689,7 @@ createOne2OneTeamConv :: UserId -> UserId -> Maybe Text -> TeamId -> TestM Respo
 createOne2OneTeamConv u1 u2 n tid = do
   g <- viewGalley
   let conv =
-        NewConv [u2] [] (n >>= checked) mempty Nothing (Just $ ConvTeamInfo tid) Nothing Nothing roleNameWireAdmin ProtocolCreateProteusTag
+        NewConv [u2] [] (n >>= checked) mempty Nothing (Just $ ConvTeamInfo tid) Nothing Nothing roleNameWireAdmin BaseProtocolProteusTag
   post $ g . path "/conversations/one2one" . zUser u1 . zConn "conn" . zType "access" . json conv
 
 postConv ::
@@ -703,12 +703,12 @@ postConv ::
 postConv u us name a r mtimer = postConvWithRole u us name a r mtimer roleNameWireAdmin
 
 defNewProteusConv :: NewConv
-defNewProteusConv = NewConv [] [] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolCreateProteusTag
+defNewProteusConv = NewConv [] [] Nothing mempty Nothing Nothing Nothing Nothing roleNameWireAdmin BaseProtocolProteusTag
 
 defNewMLSConv :: NewConv
 defNewMLSConv =
   defNewProteusConv
-    { newConvProtocol = ProtocolCreateMLSTag
+    { newConvProtocol = BaseProtocolMLSTag
     }
 
 postConvQualified ::
@@ -747,7 +747,7 @@ postConvWithRemoteUsers u c n =
 postTeamConv :: TeamId -> UserId -> [UserId] -> Maybe Text -> [Access] -> Maybe (Set AccessRole) -> Maybe Milliseconds -> TestM ResponseLBS
 postTeamConv tid u us name a r mtimer = do
   g <- viewGalley
-  let conv = NewConv us [] (name >>= checked) (Set.fromList a) r (Just (ConvTeamInfo tid)) mtimer Nothing roleNameWireAdmin ProtocolCreateProteusTag
+  let conv = NewConv us [] (name >>= checked) (Set.fromList a) r (Just (ConvTeamInfo tid)) mtimer Nothing roleNameWireAdmin BaseProtocolProteusTag
   post $ g . path "/conversations" . zUser u . zConn "conn" . zType "access" . json conv
 
 deleteTeamConv :: (HasGalley m, MonadIO m, MonadHttp m) => TeamId -> ConvId -> UserId -> m ResponseLBS
@@ -785,7 +785,7 @@ postConvWithRole u members name access arole timer role =
 postConvWithReceipt :: UserId -> [UserId] -> Maybe Text -> [Access] -> Maybe (Set AccessRole) -> Maybe Milliseconds -> ReceiptMode -> TestM ResponseLBS
 postConvWithReceipt u us name a r mtimer rcpt = do
   g <- viewGalley
-  let conv = NewConv us [] (name >>= checked) (Set.fromList a) r Nothing mtimer (Just rcpt) roleNameWireAdmin ProtocolCreateProteusTag
+  let conv = NewConv us [] (name >>= checked) (Set.fromList a) r Nothing mtimer (Just rcpt) roleNameWireAdmin BaseProtocolProteusTag
   post $ g . path "/conversations" . zUser u . zConn "conn" . zType "access" . json conv
 
 postSelfConv :: UserId -> TestM ResponseLBS
@@ -796,7 +796,7 @@ postSelfConv u = do
 postO2OConv :: UserId -> UserId -> Maybe Text -> TestM ResponseLBS
 postO2OConv u1 u2 n = do
   g <- viewGalley
-  let conv = NewConv [u2] [] (n >>= checked) mempty Nothing Nothing Nothing Nothing roleNameWireAdmin ProtocolCreateProteusTag
+  let conv = NewConv [u2] [] (n >>= checked) mempty Nothing Nothing Nothing Nothing roleNameWireAdmin BaseProtocolProteusTag
   post $ g . path "/conversations/one2one" . zUser u1 . zConn "conn" . zType "access" . json conv
 
 postConnectConv :: UserId -> UserId -> Text -> Text -> Maybe Text -> TestM ResponseLBS

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -1595,7 +1595,7 @@ assertConv ::
   HasCallStack =>
   Response (Maybe Lazy.ByteString) ->
   ConvType ->
-  UserId ->
+  Maybe UserId ->
   Qualified UserId ->
   [Qualified UserId] ->
   Maybe Text ->
@@ -1607,7 +1607,7 @@ assertConvWithRole ::
   HasCallStack =>
   Response (Maybe Lazy.ByteString) ->
   ConvType ->
-  UserId ->
+  Maybe UserId ->
   Qualified UserId ->
   [Qualified UserId] ->
   Maybe Text ->
@@ -2428,7 +2428,7 @@ mkProteusConv cnvId creator selfRole otherMembers =
     cnvId
     ( ConversationMetadata
         RegularConv
-        creator
+        (Just creator)
         []
         (Set.fromList [TeamMemberAccessRole, NonTeamMemberAccessRole])
         (Just "federated gossip")


### PR DESCRIPTION
## TODO

 - [x] Merge `ProtocolCreateTag` and `BaseProtocolTag`
 - [x] Make GET endpoint return an empty list of members

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
