### PR TITLE
[WPB-1085] Resilient remote member adding in Proteus

### DIFF
--- a/changelog.d/1-api-changes/member-add-breaking-change
+++ b/changelog.d/1-api-changes/member-add-breaking-change
@@ -1,0 +1,1 @@
+The `POST /conversations/{cnv_domain}/{cnv}/members` endpoint has a breaking change in v4. The returned event can now be found under the "event" key.

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -400,7 +400,7 @@ data ConversationUpdateRequest = ConversationUpdateRequest
 
 data ConversationUpdateResponse
   = ConversationUpdateResponseError GalleyError
-  | ConversationUpdateResponseUpdate ConversationUpdate FailedToProcess
+  | ConversationUpdateResponseUpdate (Maybe ConversationUpdate) FailedToProcess
   | ConversationUpdateResponseNoChanges
   deriving stock (Eq, Show, Generic)
   deriving

--- a/libs/wire-api/src/Wire/API/Unreachable.hs
+++ b/libs/wire-api/src/Wire/API/Unreachable.hs
@@ -29,6 +29,7 @@ module Wire.API.Unreachable
     failedToAddMaybe,
     failedToRemove,
     failedToRemoveMaybe,
+    EventWithUnreachables (..),
   )
 where
 
@@ -41,6 +42,7 @@ import Data.Qualified
 import Data.Schema
 import qualified Data.Swagger as S
 import Imports
+import Wire.API.Event.Conversation
 
 newtype UnreachableUsers = UnreachableUsers {unreachableUsers :: NonEmpty (Qualified UserId)}
   deriving stock (Eq, Show)
@@ -125,3 +127,22 @@ failedToRemove = failedToRemoveMaybe . unreachableFromList
 
 failedToRemoveMaybe :: Maybe UnreachableUsers -> FailedToProcess
 failedToRemoveMaybe us = mempty {remove = us}
+
+data EventWithUnreachables = EventWithUnreachables
+  { event :: Maybe Event,
+    failedToProcess :: FailedToProcess
+  }
+  deriving (Eq, Show)
+  deriving (A.ToJSON, A.FromJSON, S.ToSchema) via Schema EventWithUnreachables
+
+instance ToSchema EventWithUnreachables where
+  schema =
+    objectWithDocModifier
+      "EventWithUnreachables"
+      ( description
+          ?~ "A collection of a conversation event and optional lists of users\
+             \ that could not be processed due to unreachable backends"
+      )
+      $ EventWithUnreachables
+        <$> event .= maybe_ (optField "event" (unnamed schema))
+        <*> failedToProcess .= failedToProcessObjectSchema

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
@@ -29,6 +29,7 @@ import Test.Wire.API.Golden.Manual.ConversationPagingState
 import Test.Wire.API.Golden.Manual.ConversationsResponse
 import Test.Wire.API.Golden.Manual.CreateGroupConversation
 import Test.Wire.API.Golden.Manual.CreateScimToken
+import Test.Wire.API.Golden.Manual.EventWithUnreachables
 import Test.Wire.API.Golden.Manual.FeatureConfigEvent
 import Test.Wire.API.Golden.Manual.FederationStatus
 import Test.Wire.API.Golden.Manual.GetPaginatedConversationIds
@@ -169,5 +170,11 @@ tests =
         testObjects
           [ (testObject_RemoteDomains_1, "testObject_RemoteDomains_1.json"),
             (testObject_RemoteDomains_2, "testObject_RemoteDomains_2.json")
+          ],
+      testGroup "EventWithUnreachables" $
+        testObjects
+          [ (testObject_EventWithUnreachables_1, "testObject_EventWithUnreachables_1.json"),
+            (testObject_EventWithUnreachables_2, "testObject_EventWithUnreachables_2.json"),
+            (testObject_EventWithUnreachables_3, "testObject_EventWithUnreachables_3.json")
           ]
     ]

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/EventWithUnreachables.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/EventWithUnreachables.hs
@@ -1,0 +1,36 @@
+module Test.Wire.API.Golden.Manual.EventWithUnreachables where
+
+import Data.Domain
+import Data.Id
+import Data.Qualified
+import qualified Data.UUID as UUID (fromString)
+import Imports
+import Test.Wire.API.Golden.Generated.Event_user
+import Wire.API.Unreachable
+
+testObject_EventWithUnreachables_1 :: EventWithUnreachables
+testObject_EventWithUnreachables_1 =
+  EventWithUnreachables
+    { event = Just testObject_Event_user_12,
+      failedToProcess = mempty
+    }
+
+userList :: Maybe UnreachableUsers
+userList =
+  unreachableFromList
+    [ Qualified (Id (fromJust (UUID.fromString "0000114a-0000-7da8-0000-40cb00007fcf"))) (Domain "faraway.example.com")
+    ]
+
+testObject_EventWithUnreachables_2 :: EventWithUnreachables
+testObject_EventWithUnreachables_2 =
+  EventWithUnreachables
+    { event = Just testObject_Event_user_12,
+      failedToProcess = mempty {add = userList}
+    }
+
+testObject_EventWithUnreachables_3 :: EventWithUnreachables
+testObject_EventWithUnreachables_3 =
+  EventWithUnreachables
+    { event = Nothing,
+      failedToProcess = mempty {add = userList}
+    }

--- a/libs/wire-api/test/golden/testObject_EventWithUnreachables_1.json
+++ b/libs/wire-api/test/golden/testObject_EventWithUnreachables_1.json
@@ -1,0 +1,40 @@
+{
+    "event": {
+        "conversation": "00000838-0000-1bc6-0000-686d00003565",
+        "data": {
+            "user_ids": [
+                "00000055-0000-004d-0000-005100000037",
+                "00000001-0000-001f-0000-001500000009"
+            ],
+            "users": [
+                {
+                    "conversation_role": "dlkagbmicz0f95d",
+                    "id": "00000055-0000-004d-0000-005100000037",
+                    "qualified_id": {
+                        "domain": "faraway.example.com",
+                        "id": "00000055-0000-004d-0000-005100000037"
+                    }
+                },
+                {
+                    "conversation_role": "2e",
+                    "id": "00000001-0000-001f-0000-001500000009",
+                    "qualified_id": {
+                        "domain": "faraway.example.com",
+                        "id": "00000001-0000-001f-0000-001500000009"
+                    }
+                }
+            ]
+        },
+        "from": "0000114a-0000-7da8-0000-40cb00007fcf",
+        "qualified_conversation": {
+            "domain": "faraway.example.com",
+            "id": "00000838-0000-1bc6-0000-686d00003565"
+        },
+        "qualified_from": {
+            "domain": "faraway.example.com",
+            "id": "0000114a-0000-7da8-0000-40cb00007fcf"
+        },
+        "time": "1864-05-12T20:29:47.483Z",
+        "type": "conversation.member-join"
+    }
+}

--- a/libs/wire-api/test/golden/testObject_EventWithUnreachables_2.json
+++ b/libs/wire-api/test/golden/testObject_EventWithUnreachables_2.json
@@ -1,0 +1,46 @@
+{
+    "event": {
+        "conversation": "00000838-0000-1bc6-0000-686d00003565",
+        "data": {
+            "user_ids": [
+                "00000055-0000-004d-0000-005100000037",
+                "00000001-0000-001f-0000-001500000009"
+            ],
+            "users": [
+                {
+                    "conversation_role": "dlkagbmicz0f95d",
+                    "id": "00000055-0000-004d-0000-005100000037",
+                    "qualified_id": {
+                        "domain": "faraway.example.com",
+                        "id": "00000055-0000-004d-0000-005100000037"
+                    }
+                },
+                {
+                    "conversation_role": "2e",
+                    "id": "00000001-0000-001f-0000-001500000009",
+                    "qualified_id": {
+                        "domain": "faraway.example.com",
+                        "id": "00000001-0000-001f-0000-001500000009"
+                    }
+                }
+            ]
+        },
+        "from": "0000114a-0000-7da8-0000-40cb00007fcf",
+        "qualified_conversation": {
+            "domain": "faraway.example.com",
+            "id": "00000838-0000-1bc6-0000-686d00003565"
+        },
+        "qualified_from": {
+            "domain": "faraway.example.com",
+            "id": "0000114a-0000-7da8-0000-40cb00007fcf"
+        },
+        "time": "1864-05-12T20:29:47.483Z",
+        "type": "conversation.member-join"
+    },
+    "failed_to_add": [
+        {
+            "domain": "faraway.example.com",
+            "id": "0000114a-0000-7da8-0000-40cb00007fcf"
+        }
+    ]
+}

--- a/libs/wire-api/test/golden/testObject_EventWithUnreachables_3.json
+++ b/libs/wire-api/test/golden/testObject_EventWithUnreachables_3.json
@@ -1,0 +1,8 @@
+{
+    "failed_to_add": [
+        {
+            "domain": "faraway.example.com",
+            "id": "0000114a-0000-7da8-0000-40cb00007fcf"
+        }
+    ]
+}

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -554,6 +554,7 @@ test-suite wire-api-golden-tests
     Test.Wire.API.Golden.Manual.ConvIdsPage
     Test.Wire.API.Golden.Manual.CreateGroupConversation
     Test.Wire.API.Golden.Manual.CreateScimToken
+    Test.Wire.API.Golden.Manual.EventWithUnreachables
     Test.Wire.API.Golden.Manual.FeatureConfigEvent
     Test.Wire.API.Golden.Manual.FederationStatus
     Test.Wire.API.Golden.Manual.GetPaginatedConversationIds

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -590,7 +590,7 @@ updateLocalConversation ::
   Qualified UserId ->
   Maybe ConnId ->
   ConversationAction tag ->
-  Sem r (LocalConversationUpdate, FailedToProcess)
+  Sem r (Maybe LocalConversationUpdate, FailedToProcess)
 updateLocalConversation lcnv qusr con action = do
   let tag = sing @tag
 
@@ -629,7 +629,7 @@ updateLocalConversationUnchecked ::
   Qualified UserId ->
   Maybe ConnId ->
   ConversationAction tag ->
-  Sem r (LocalConversationUpdate, FailedToProcess)
+  Sem r (Maybe LocalConversationUpdate, FailedToProcess)
 updateLocalConversationUnchecked lconv qusr con action = do
   let tag = sing @tag
       lcnv = fmap convId lconv
@@ -641,6 +641,10 @@ updateLocalConversationUnchecked lconv qusr con action = do
   -- perform checks
   ensureConversationActionAllowed (sing @tag) lcnv action conv self
 
+  -- TODO(md): Consider if the order of 'performAction' and
+  -- 'notifyConversationAction' can be swapped. If it can, then e.g. failing to
+  -- add all of the remotes should produce no event.
+
   -- perform action
   (extraTargets, action') <- performAction tag qusr lconv action
 
@@ -650,7 +654,7 @@ updateLocalConversationUnchecked lconv qusr con action = do
     False
     con
     lconv
-    (convBotsAndMembers conv <> extraTargets)
+    (convBotsAndMembers conv, extraTargets)
     action'
 
 -- --------------------------------------------------------------------------------
@@ -711,50 +715,42 @@ notifyConversationAction ::
   Bool ->
   Maybe ConnId ->
   Local Conversation ->
-  BotsAndMembers ->
+  (BotsAndMembers, BotsAndMembers) ->
   ConversationAction (tag :: ConversationActionTag) ->
-  Sem r (LocalConversationUpdate, FailedToProcess)
-notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
+  Sem r (Maybe LocalConversationUpdate, FailedToProcess)
+notifyConversationAction tag quid notifyOrigDomain con lconv (targets, extraTargets) action = do
   now <- input
   let lcnv = fmap convId lconv
       conv = tUnqualified lconv
       e = conversationActionToEvent tag now quid (tUntagged lcnv) Nothing action
 
-  let mkUpdate uids =
-        ConversationUpdate
-          now
-          quid
-          (tUnqualified lcnv)
-          uids
-          (SomeConversationAction tag action)
-
   -- call `on-new-remote-conversation` on backends that are seeing this
   -- conversation for the first time
   let newDomains =
         Set.difference
-          (Set.map void (bmRemotes targets))
+          (Set.map void (bmRemotes $ targets <> extraTargets))
           (Set.fromList (map (void . rmId) (convRemoteMembers conv)))
       newRemotes =
         Set.filter (\r -> Set.member (void r) newDomains)
           . bmRemotes
-          $ targets
+          $ targets <> extraTargets
   let nrc =
         NewRemoteConversation
           { nrcConvId = convId conv,
             nrcProtocol = convProtocol conv
           }
   (update, failedToProcess) <- do
-    notifyEithers <-
+    notifyNewConv <-
       E.runFederatedConcurrentlyEither (toList newRemotes) $ \_ -> do
         void $ fedClient @'Galley @"on-new-remote-conversation" nrc
     -- For now these users will not be able to join the conversation until
     -- queueing and retrying is implemented.
-    let failedNotifies = lefts notifyEithers
-    for_ failedNotifies $
+    let failedNewConvNotifies = lefts notifyNewConv
+    for_ failedNewConvNotifies $
       logError
         "on-new-remote-conversation"
         "An error occurred while communicating with federated server: "
-    for_ failedNotifies $ \case
+    for_ failedNewConvNotifies $ \case
       -- rethrow invalid-domain errors and mis-configured federation errors
       (_, ex@(FederationCallFailure (FederatorClientError (Wai.Error (Wai.Status 422 _) _ _ _)))) -> throw ex
       -- FUTUREWORK: This error occurs when federation strategy is set to `allowDynamic`
@@ -774,32 +770,35 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
       (_, FederationUnexpectedBody _) -> pure ()
       (_, FederationUnexpectedError _) -> pure ()
       (_, FederationUnreachableDomains _) -> pure ()
-    updates <-
-      E.runFederatedConcurrentlyEither (toList (bmRemotes targets)) $
-        \ruids -> do
-          let update = mkUpdate (tUnqualified ruids)
-          -- if notifyOrigDomain is false, filter out user from quid's domain,
-          -- because quid's backend will update local state and notify its users
-          -- itself using the ConversationUpdate returned by this function
-          if notifyOrigDomain || tDomain ruids /= qDomain quid
-            then fedClient @'Galley @"on-conversation-updated" update $> Nothing
-            else pure (Just update)
-    let f = fromMaybe (mkUpdate []) . asum . map tUnqualified . rights
-        update = f updates
-        failedUpdates = lefts updates
+
+    -- TODO(md): an update to 'extraTargetUpdates' should go first and if that
+    -- fails (completely?), the action should be undone and no event should be
+    -- fanned out. Also think of a scenario where some extra targets are
+    -- reachable and some are not and how that affects the outcome.
+
+    -- 'targetUpdates' and 'extraTargetUpdates' are sent the update separately
+    -- because they are treated differently in case of federation failures
+    -- (i.e., unreachable remote backends).
+    targetUpdates <- sendUpdate now targets
+    extraTargetUpdates <- sendUpdate now extraTargets
+    let f = fromMaybe (mkUpdate now []) . asum . map tUnqualified . rights
+        update = f targetUpdates
+        failedTargetUpdates = lefts targetUpdates
+        failedExtraTargetUpdates = lefts extraTargetUpdates
         toFailedToProcess :: [Qualified UserId] -> FailedToProcess
         toFailedToProcess us = case tag of
           SConversationJoinTag -> failedToAdd us
           SConversationLeaveTag -> failedToRemove us
           SConversationRemoveMembersTag -> failedToRemove us
           _ -> mempty
-    for_ failedUpdates $
+    for_ (failedTargetUpdates <> failedExtraTargetUpdates) $
       logError
         "on-conversation-updated"
         "An error occurred while communicating with federated server: "
     let totalFailedToProcess =
-          failedToAdd (qualifiedFails failedNotifies)
-            <> toFailedToProcess (qualifiedFails failedUpdates)
+          failedToSend (qualifiedFails failedNewConvNotifies)
+            <> failedToSend (qualifiedFails failedTargetUpdates)
+            <> toFailedToProcess (qualifiedFails failedExtraTargetUpdates)
     pure (update, totalFailedToProcess)
 
   -- notify local participants and bots
@@ -807,8 +806,26 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
 
   -- return both the event and the 'ConversationUpdate' structure corresponding
   -- to the originating domain (if it is remote)
-  pure $ (LocalConversationUpdate e update, failedToProcess)
+  pure (Just $ LocalConversationUpdate e update, failedToProcess)
   where
+    sendUpdate now recipients =
+      E.runFederatedConcurrentlyEither (toList (bmRemotes recipients)) $
+        \ruids -> do
+          let update = mkUpdate now (tUnqualified ruids)
+          -- if notifyOrigDomain is false, filter out user from quid's domain,
+          -- because quid's backend will update local state and notify its users
+          -- itself using the ConversationUpdate returned by this function
+          if notifyOrigDomain || tDomain ruids /= qDomain quid
+            then fedClient @'Galley @"on-conversation-updated" update $> Nothing
+            else pure (Just update)
+    mkUpdate now uids =
+      ConversationUpdate
+        now
+        quid
+        (tUnqualified . fmap convId $ lconv)
+        uids
+        (SomeConversationAction tag action)
+
     qualifiedFails :: [(QualifiedWithTag t [a], b)] -> [Qualified a]
     qualifiedFails = foldMap (sequenceA . tUntagged . fst)
     logError :: Show a => String -> String -> (a, FederationError) -> Sem r ()
@@ -962,7 +979,7 @@ kickMember qusr lconv targets victim = void . runError @NoChanges $ do
     True
     Nothing
     lconv
-    (targets <> extraTargets)
+    (targets, extraTargets)
     (pure victim)
 
 notifyTypingIndicator ::

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -641,10 +641,6 @@ updateLocalConversationUnchecked lconv qusr con action = do
   -- perform checks
   ensureConversationActionAllowed (sing @tag) lcnv action conv self
 
-  -- TODO(md): Consider if the order of 'performAction' and
-  -- 'notifyConversationAction' can be swapped. If it can, then e.g. failing to
-  -- add all of the remotes should produce no event.
-
   -- perform action
   (extraTargets, action') <- performAction tag qusr lconv action
 
@@ -779,8 +775,8 @@ notifyConversationAction tag quid notifyOrigDomain con lconv (targets, extraTarg
     -- 'targetUpdates' and 'extraTargetUpdates' are sent the update separately
     -- because they are treated differently in case of federation failures
     -- (i.e., unreachable remote backends).
-    targetUpdates <- sendUpdate now targets
     extraTargetUpdates <- sendUpdate now extraTargets
+    targetUpdates <- sendUpdate now targets
     let f = fromMaybe (mkUpdate now []) . asum . map tUnqualified . rights
         update = f targetUpdates
         failedTargetUpdates = lefts targetUpdates

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -264,7 +264,7 @@ leaveConversation requestingDomain lc = do
         (conv, _self) <- getConversationAndMemberWithError @'ConvNotFound leaver lcnv
         outcome <-
           runError @FederationError $
-            first lcuUpdate
+            first (fmap lcuUpdate)
               <$> updateLocalConversation
                 @'ConversationLeaveTag
                 lcnv
@@ -291,7 +291,7 @@ leaveConversation requestingDomain lc = do
               False
               Nothing
               (qualifyAs lcnv conv)
-              botsAndMembers
+              (botsAndMembers, mempty)
               ()
         case outcome of
           Left e -> do
@@ -429,7 +429,7 @@ onUserDeleted origDomain udcn = do
                     False
                     Nothing
                     (qualifyAs lc conv)
-                    botsAndMembers
+                    (botsAndMembers, mempty)
                     ()
               whenLeft outcome . logFederationError $ lc
   pure EmptyResponse
@@ -469,46 +469,46 @@ updateConversation origDomain updateRequest = do
     SomeConversationAction tag action -> case tag of
       SConversationJoinTag ->
         mapToGalleyError @(HasConversationActionGalleyErrors 'ConversationJoinTag)
-          . fmap (first lcuUpdate)
+          . fmap (first (fmap lcuUpdate))
           $ updateLocalConversation @'ConversationJoinTag lcnv (tUntagged rusr) Nothing action
       SConversationLeaveTag ->
         mapToGalleyError
           @(HasConversationActionGalleyErrors 'ConversationLeaveTag)
-          . fmap (first lcuUpdate)
+          . fmap (first (fmap lcuUpdate))
           $ updateLocalConversation @'ConversationLeaveTag lcnv (tUntagged rusr) Nothing action
       SConversationRemoveMembersTag ->
         mapToGalleyError
           @(HasConversationActionGalleyErrors 'ConversationRemoveMembersTag)
-          . fmap (first lcuUpdate)
+          . fmap (first (fmap lcuUpdate))
           $ updateLocalConversation @'ConversationRemoveMembersTag lcnv (tUntagged rusr) Nothing action
       SConversationMemberUpdateTag ->
         mapToGalleyError
           @(HasConversationActionGalleyErrors 'ConversationMemberUpdateTag)
-          . fmap (first lcuUpdate)
+          . fmap (first (fmap lcuUpdate))
           $ updateLocalConversation @'ConversationMemberUpdateTag lcnv (tUntagged rusr) Nothing action
       SConversationDeleteTag ->
         mapToGalleyError
           @(HasConversationActionGalleyErrors 'ConversationDeleteTag)
-          . fmap (first lcuUpdate)
+          . fmap (first (fmap lcuUpdate))
           $ updateLocalConversation @'ConversationDeleteTag lcnv (tUntagged rusr) Nothing action
       SConversationRenameTag ->
         mapToGalleyError
           @(HasConversationActionGalleyErrors 'ConversationRenameTag)
-          . fmap (first lcuUpdate)
+          . fmap (first (fmap lcuUpdate))
           $ updateLocalConversation @'ConversationRenameTag lcnv (tUntagged rusr) Nothing action
       SConversationMessageTimerUpdateTag ->
         mapToGalleyError
           @(HasConversationActionGalleyErrors 'ConversationMessageTimerUpdateTag)
-          . fmap (first lcuUpdate)
+          . fmap (first (fmap lcuUpdate))
           $ updateLocalConversation @'ConversationMessageTimerUpdateTag lcnv (tUntagged rusr) Nothing action
       SConversationReceiptModeUpdateTag ->
         mapToGalleyError @(HasConversationActionGalleyErrors 'ConversationReceiptModeUpdateTag)
-          . fmap (first lcuUpdate)
+          . fmap (first (fmap lcuUpdate))
           $ updateLocalConversation @'ConversationReceiptModeUpdateTag lcnv (tUntagged rusr) Nothing action
       SConversationAccessDataTag ->
         mapToGalleyError
           @(HasConversationActionGalleyErrors 'ConversationAccessDataTag)
-          . fmap (first lcuUpdate)
+          . fmap (first (fmap lcuUpdate))
           $ updateLocalConversation @'ConversationAccessDataTag lcnv (tUntagged rusr) Nothing action
   where
     mkResponse = fmap toResponse . runError @GalleyError . runError @NoChanges

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -1237,7 +1237,7 @@ executeProposalAction qusr con lconv mlsMeta cm action = do
       foldMap
         ( handleNoChanges
             . handleMLSProposalFailures @ProposalErrors
-            . fmap (pure . fst)
+            . fmap (maybeToList . fst)
             . updateLocalConversationUnchecked @'ConversationJoinTag lconv qusr con
             . flip ConversationJoin roleNameWireMember
         )
@@ -1250,7 +1250,7 @@ executeProposalAction qusr con lconv mlsMeta cm action = do
       foldMap
         ( handleNoChanges
             . handleMLSProposalFailures @ProposalErrors
-            . fmap (pure . fst)
+            . fmap (maybeToList . fst)
             . updateLocalConversationUnchecked @'ConversationRemoveMembersTag lconv qusr con
         )
         . nonEmpty

--- a/services/galley/src/Galley/API/Public/Conversation.hs
+++ b/services/galley/src/Galley/API/Public/Conversation.hs
@@ -54,6 +54,7 @@ conversationAPI =
     <@> mkNamedAPI @"create-one-to-one-conversation" (callsFed createOne2OneConversation)
     <@> mkNamedAPI @"add-members-to-conversation-unqualified" (callsFed addMembersUnqualified)
     <@> mkNamedAPI @"add-members-to-conversation-unqualified2" (callsFed addMembersUnqualifiedV2)
+    <@> mkNamedAPI @"add-members-to-conversation@v2" (callsFed addMembersV2)
     <@> mkNamedAPI @"add-members-to-conversation" (callsFed addMembers)
     <@> mkNamedAPI @"join-conversation-by-id-unqualified" (callsFed joinConversationById)
     <@> mkNamedAPI @"join-conversation-by-code-unqualified" (callsFed joinConversationByReusableCode)

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -2570,10 +2570,6 @@ testAddRemoteMember = do
             ]
         )
         $ postQualifiedMembers alice (remoteChad :| []) qconvId
-          -- TODO(md): this should likely be a 204 assertion (as Chad should not
-          -- be added to the conversation, hence no update). The empty response
-          -- of 204 should be changed to have a "failed_to_add" field and
-          -- probably "failed_to_send" too.
           <!! const 200 === statusCode
     EventWithUnreachables (Just e) ftp <- responseJsonError resp
     let chadMember = SimpleMember remoteChad roleNameWireAdmin

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -1160,7 +1160,7 @@ updateConversationByRemoteAdmin = do
           fedGalleyClient <- view tsFedGalleyClient
           runFedClient @"update-conversation" fedGalleyClient bdomain cnvUpdateRequest
 
-        cnvUpdate' <- liftIO $ case resp of
+        Just cnvUpdate' <- liftIO $ case resp of
           ConversationUpdateResponseError err -> assertFailure ("Expected ConversationUpdateResponseUpdate but got " <> show err)
           ConversationUpdateResponseNoChanges -> assertFailure "Expected ConversationUpdateResponseUpdate but got ConversationUpdateResponseNoChanges"
           ConversationUpdateResponseUpdate up _ftp -> pure up


### PR DESCRIPTION
This PR is a carved out part of https://github.com/wireapp/wire-server/pull/3324 that relates to member adding only.

The PR makes a breaking change to `POST /conversations/:domain/:cnv/members` by nesting the returned event under the `event` key. This is so that `failed_to_*` fields can be added to the response.

For details see https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/827785217/Offline+backend+handling+-+analysis+of+adding+participants+to+a+Proteus+conversation.

Tracked by https://wearezeta.atlassian.net/browse/WPB-1085. For the scope of the ticket please consult the Jira ticket.

What was done on June 13:

- The JSON instance for the `EventWithUnreachables` type has been defined. Take a look at the golden tests for the type for examples.
- Because there was a change in the return type of a key function in `Galley.API.Action`, this change propagated to a lot of functions in the `Galley.API.Update` module. This led to quite a few compilation errors, but that's been addressed.
- Compilation errors in integration tests have been fixed.

Things still to finish:

- [ ] Take a look at golden tests for the `EventWithUnreachables` type. This is the type of value returned by the member-add endpoint in v4. Maybe some case is missing and please add a test for it.
- [ ] In `Galley.API.Action.notifyConversationAction`, split the invocation of the "on-conversation-updated" endpoint into two. The first request should list only joiners from the conversation-owning backend and from the remote backend the request is sent to. Once responses from the first request for all the participating remote backends are collected, the backend sends another "on-conversation-updated" request listing the delta, i.e., it should notify about new joiners from other remote backends that confirmed the first request.
- [ ] Add a changelog entry for the federation API. There was a breaking change because a type that is used for the federation API has changed (an argument changed from `ConversationUpdate` to `Maybe ConversationUpdate`).
- [ ] Address all the TODOs in PR (search for "TODO(md)")
- [ ] Think of touched integration test cases. One unfinished is where bob@bob.example.com is already in, but chad@chad.example.com is unreachable and can't be added. Also test when bob@bob.xample.com is already in, but unreachable at the moment when a reachable chad@chad.example.com is added to a conversation.
- [ ] Document the API endpoint change in Confluence (the v3->v4 API changes page)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
