### PR TITLE
Fixup to brig chart from #3351 when geoip enabled

### DIFF
--- a/charts/brig/templates/deployment.yaml
+++ b/charts/brig/templates/deployment.yaml
@@ -79,6 +79,7 @@ spec:
         {{- if eq (include "includeSecurityContext" .) "true" }}
           securityContext:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}
+            runAsUser: 1000 # see https://github.com/maxmind/geoipupdate/issues/233
         {{- end }}
       containers:
         - name: brig
@@ -179,6 +180,7 @@ spec:
         {{- if eq (include "includeSecurityContext" .) "true" }}
           securityContext:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}
+            runAsUser: 1000 # see https://github.com/maxmind/geoipupdate/issues/233
         {{- end }}
           volumeMounts:
           - name: "geoip"

--- a/charts/brig/values.yaml
+++ b/charts/brig/values.yaml
@@ -110,7 +110,7 @@ config:
     enabled: false
     image:
       repository: docker.io/maxmindinc/geoipupdate
-      tag: v4.9
+      tag: v5.1.1
 turnStatic:
   v1:
   - turn:localhost:3478


### PR DESCRIPTION
The geoipupdate image runs as root by default, preventing brig from starting up. Here we upgrade image version & set user=geoipupdate=1000

This change was tested manually. CI does not have geopip enabled, as that would require credentials. (hence this problem only appeared during deployment).

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
