### PR TITLE
Better errors in golden tests.

### DIFF
--- a/changelog.d/5-internal/better-golden-errors
+++ b/changelog.d/5-internal/better-golden-errors
@@ -1,0 +1,1 @@
+Better errors in golden tests

--- a/libs/wire-api/default.nix
+++ b/libs/wire-api/default.nix
@@ -4,6 +4,7 @@
 # dependencies are added or removed.
 { mkDerivation
 , aeson
+, aeson-diff
 , aeson-pretty
 , aeson-qq
 , async
@@ -206,6 +207,7 @@ mkDerivation {
   ];
   testHaskellDepends = [
     aeson
+    aeson-diff
     aeson-pretty
     aeson-qq
     async

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Runner.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Runner.hs
@@ -26,6 +26,7 @@ module Test.Wire.API.Golden.Runner
 where
 
 import Data.Aeson
+import qualified Data.Aeson.Diff as AD
 import Data.Aeson.Encode.Pretty (Config (..), defConfig, encodePretty')
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as LBS
@@ -53,11 +54,19 @@ testObject obj path = do
   exists <- doesFileExist fullPath
   unless exists $ ByteString.writeFile fullPath (LBS.toStrict actualJson)
 
-  expectedValue <- assertRight =<< eitherDecodeFileStrict fullPath
-  assertEqual
-    (show (typeRep @a) <> ": ToJSON should match golden file: " <> path)
-    expectedValue
-    actualValue
+  expectedValue :: Value <- assertRight =<< eitherDecodeFileStrict fullPath
+  assertBool
+    ( show (typeRep @a)
+        <> ": ToJSON should match golden file: "
+        <> path
+        <> "\n\nexpected:\n"
+        <> cs (encodePretty' config expectedValue)
+        <> "\n\nactual:\n"
+        <> cs (encodePretty' config actualValue)
+        <> "\n\ndiff:\n"
+        <> cs (encodePretty' config (AD.diff expectedValue actualValue))
+    )
+    (expectedValue == actualValue)
   assertEqual
     (show (typeRep @a) <> ": FromJSON of " <> path <> " should match object")
     (Success obj)

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -611,6 +611,7 @@ test-suite wire-api-golden-tests
 
   build-depends:
       aeson                    >=2.0.1.0
+    , aeson-diff
     , aeson-pretty
     , base
     , bytestring


### PR DESCRIPTION
before:

```
      testObject_RichInfoMapAndList_user_19.json: FAIL
        Error message: RichInfoMapAndList: ToJSON should match golden file: testObject_RichInfoMapAndList_user_19.json
        expected: Object (fromList [("urn:ietf:params:scim:schemas:extension:wire:1.0:User",Object (fromList [("\DC3\DC2\1026333vS\t\NUL\DC4\1073519<\EM\539\DLE<\NULxR\SUBU\FSx\SYN\\JtiN?&\1092138",String "\1000631\1058954x\23412\&3\n\18517\1040637\20472\r0e\DLE\1029504"),("l%\35922\ACK\DC4b\82954\119943\EM$\1011647\&5~f\37664H",String "d\34056\1074598)A\18354k@\SUB\1097784<\1054362\132080I\1003614\DC1}:\SYN\1085924\994398$\v\EM\DC2&OMW")])),("urn:wire:scim:schemas:profile:1.0",Object (fromList [("wrongName",Object (fromList [("fields",Array [Object (fromList [("type",String "l%\35922\ACK\DC4b\82954\119943\EM$\1011647\&5~f\37664H"),("value",String "d\34056\1074598)A\18354k@\SUB\1097784<\1054362\132080I\1003614\DC1}:\SYN\1085924\994398$\v\EM\DC2&OMW")]),Object (fromList [("type",String "\DC3\DC2\1026333vS\t\NUL\DC4\1073519<\EM\539\DLE<\NULxR\SUBU\FSx\SYN\\JtiN?&\1092138"),("value",String "\1000631\1058954x\23412\&3\n\18517\1040637\20472\r0e\DLE\1029504")])]),("version",Number 0.0)]))]))])
         but got: Object (fromList [("urn:ietf:params:scim:schemas:extension:wire:1.0:User",Object (fromList [("\DC3\DC2\1026333vS\t\NUL\DC4\1073519<\EM\539\DLE<\NULxR\SUBU\FSx\SYN\\JtiN?&\1092138",String "\1000631\1058954x\23412\&3\n\18517\1040637\20472\r0e\DLE\1029504"),("l%\35922\ACK\DC4b\82954\119943\EM$\1011647\&5~f\37664H",String "d\34056\1074598)A\18354k@\SUB\1097784<\1054362\132080I\1003614\DC1}:\SYN\1085924\994398$\v\EM\DC2&OMW")])),("urn:wire:scim:schemas:profile:1.0",Object (fromList [("richInfo",Object (fromList [("fields",Array [Object (fromList [("type",String "l%\35922\ACK\DC4b\82954\119943\EM$\1011647\&5~f\37664H"),("value",String "d\34056\1074598)A\18354k@\SUB\1097784<\1054362\132080I\1003614\DC1}:\SYN\1085924\994398$\v\EM\DC2&OMW")]),Object (fromList [("type",String "\DC3\DC2\1026333vS\t\NUL\DC4\1073519<\EM\539\DLE<\NULxR\SUBU\FSx\SYN\\JtiN?&\1092138"),("value",String "\1000631\1058954x\23412\&3\n\18517\1040637\20472\r0e\DLE\1029504")])]),("version",Number 0.0)]))]))])
        
        CallStack (from HasCallStack):
          assertFailure, called at ./Test/Tasty/HUnit/Orig.hs:86:32 in tasty-hunit-0.10.0.3-5gW5br1avVmDRoG1UA3lIa:Test.Tasty.HUnit.Orig
          assertEqual, called at test/golden/Test/Wire/API/Golden/Runner.hs:57:3 in main:Test.Wire.API.Golden.Runner
        Use -p '/RichInfo/&&/testObject_RichInfoMapAndList_user_19.json/' to rerun this test only.
```

after:

```
      testObject_RichInfoMapAndList_user_19.json: FAIL
        Error message: RichInfoMapAndList: ToJSON should match golden file: testObject_RichInfoMapAndList_user_19.json
        
        expected:
        {
            "urn:ietf:params:scim:schemas:extension:wire:1.0:User": {
                "\u0013\u0012󺤝vS\t\u0000\u0014􆅯<\u0019ț\u0010<\u0000xR\u001aU\u001cx\u0016\\JtiN?&􊨪": "󴒷􂢊x孴3\n䡕󾃽俸\r0e\u0010󻖀",
                "l%豒\u0006\u0014b𔐊𝒇\u0019$󶾿5~f錠H": "d蔈􆖦)A䞲k@\u001a􌀸<􁚚𠏰I󵁞\u0011}:\u0016􉇤󲱞$\u000b\u0019\u0012&OMW"
            },
            "urn:wire:scim:schemas:profile:1.0": {
                "wrongName": {
                    "fields": [
                        {
                            "type": "l%豒\u0006\u0014b𔐊𝒇\u0019$󶾿5~f錠H",
                            "value": "d蔈􆖦)A䞲k@\u001a􌀸<􁚚𠏰I󵁞\u0011}:\u0016􉇤󲱞$\u000b\u0019\u0012&OMW"
                        },
                        {
                            "type": "\u0013\u0012󺤝vS\t\u0000\u0014􆅯<\u0019ț\u0010<\u0000xR\u001aU\u001cx\u0016\\JtiN?&􊨪",
                            "value": "󴒷􂢊x孴3\n䡕󾃽俸\r0e\u0010󻖀"
                        }
                    ],
                    "version": 0
                }
            }
        }
        
        
        actual:
        {
            "urn:ietf:params:scim:schemas:extension:wire:1.0:User": {
                "\u0013\u0012󺤝vS\t\u0000\u0014􆅯<\u0019ț\u0010<\u0000xR\u001aU\u001cx\u0016\\JtiN?&􊨪": "󴒷􂢊x孴3\n䡕󾃽俸\r0e\u0010󻖀",
                "l%豒\u0006\u0014b𔐊𝒇\u0019$󶾿5~f錠H": "d蔈􆖦)A䞲k@\u001a􌀸<􁚚𠏰I󵁞\u0011}:\u0016􉇤󲱞$\u000b\u0019\u0012&OMW"
            },
            "urn:wire:scim:schemas:profile:1.0": {
                "richInfo": {
                    "fields": [
                        {
                            "type": "l%豒\u0006\u0014b𔐊𝒇\u0019$󶾿5~f錠H",
                            "value": "d蔈􆖦)A䞲k@\u001a􌀸<􁚚𠏰I󵁞\u0011}:\u0016􉇤󲱞$\u000b\u0019\u0012&OMW"
                        },
                        {
                            "type": "\u0013\u0012󺤝vS\t\u0000\u0014􆅯<\u0019ț\u0010<\u0000xR\u001aU\u001cx\u0016\\JtiN?&􊨪",
                            "value": "󴒷􂢊x孴3\n䡕󾃽俸\r0e\u0010󻖀"
                        }
                    ],
                    "version": 0
                }
            }
        }
        
        
        diff:
        [
            {
                "op": "remove",
                "path": "/urn:wire:scim:schemas:profile:1.0/wrongName"
            },
            {
                "op": "add",
                "path": "/urn:wire:scim:schemas:profile:1.0/richInfo",
                "value": {
                    "fields": [
                        {
                            "type": "l%豒\u0006\u0014b𔐊𝒇\u0019$󶾿5~f錠H",
                            "value": "d蔈􆖦)A䞲k@\u001a􌀸<􁚚𠏰I󵁞\u0011}:\u0016􉇤󲱞$\u000b\u0019\u0012&OMW"
                        },
                        {
                            "type": "\u0013\u0012󺤝vS\t\u0000\u0014􆅯<\u0019ț\u0010<\u0000xR\u001aU\u001cx\u0016\\JtiN?&􊨪",
                            "value": "󴒷􂢊x孴3\n䡕󾃽俸\r0e\u0010󻖀"
                        }
                    ],
                    "version": 0
                }
            }
        ]
        
        
        CallStack (from HasCallStack):
          assertFailure, called at ./Test/Tasty/HUnit/Orig.hs:71:30 in tasty-hunit-0.10.0.3-5gW5br1avVmDRoG1UA3lIa:Test.Tasty.HUnit.Orig
          assertBool, called at test/golden/Test/Wire/API/Golden/Runner.hs:58:3 in main:Test.Wire.API.Golden.Runner
        Use -p '/RichInfo/&&/testObject_RichInfoMapAndList_user_19.json/' to rerun this test only.
```

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
