### PR TITLE
Merge remote conversation update handlers

### DIFF
--- a/changelog.d/6-federation/remote-conv-update-handlers
+++ b/changelog.d/6-federation/remote-conv-update-handlers
@@ -1,0 +1,1 @@
+Make remote conversation update handling more consistent across the various kinds of updates

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -254,10 +254,11 @@ data ConversationUpdate = ConversationUpdate
   { cuTime :: UTCTime,
     cuOrigUserId :: Qualified UserId,
     -- | The unqualified ID of the conversation where the update is happening.
-    -- The ID is local to prevent putting arbitrary domain that is different
-    -- than that of the backend making a conversation membership update request.
+    -- The ID is local to the sender to prevent putting arbitrary domain that
+    -- is different than that of the backend making a conversation membership
+    -- update request.
     cuConvId :: ConvId,
-    -- | A list of users from a remote backend that need to be sent
+    -- | A list of users from the receiving backend that need to be sent
     -- notifications about this change. This is required as we do not expect a
     -- non-conversation owning backend to have an indexed mapping of
     -- conversation to users.

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -36,6 +36,8 @@ module Galley.API.Action
     addMembersToLocalConversation,
     notifyConversationAction,
     notifyRemoteConversationAction,
+    updateLocalStateOfRemoteConv,
+    addLocalUsersToRemoteConv,
     ConversationUpdate,
   )
 where
@@ -43,10 +45,12 @@ where
 import Control.Arrow ((&&&))
 import Control.Lens
 import Data.ByteString.Conversion (toByteString')
+import Data.Domain
 import Data.Id
 import Data.Kind
 import qualified Data.List as List
-import Data.List.NonEmpty (nonEmpty)
+import Data.List.Extra (nubOrd)
+import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import qualified Data.Map as Map
 import Data.Misc
 import Data.Qualified
@@ -86,6 +90,7 @@ import Polysemy.Input
 import Polysemy.TinyLog
 import qualified Polysemy.TinyLog as P
 import qualified System.Logger as Log
+import Wire.API.Connection (Relation (Accepted))
 import Wire.API.Conversation hiding (Conversation, Member)
 import Wire.API.Conversation.Action
 import Wire.API.Conversation.Protocol
@@ -96,7 +101,9 @@ import Wire.API.Error.Galley
 import Wire.API.Event.Conversation
 import Wire.API.Federation.API (Component (Galley), fedClient)
 import Wire.API.Federation.API.Galley
+import qualified Wire.API.Federation.API.Galley as F
 import Wire.API.Federation.Error
+import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Team.LegalHold
 import Wire.API.Team.Member
 import Wire.API.Unreachable
@@ -839,6 +846,113 @@ notifyRemoteConversationAction loc rconvUpdate con = do
   let bots = []
 
   pushConversationEvent con event localPresentUsers bots $> event
+
+-- | Update the local database with information on conversation members joining
+-- or leaving. Finally, push out notifications to local users.
+updateLocalStateOfRemoteConv ::
+  ( Member BrigAccess r,
+    Member GundeckAccess r,
+    Member ExternalAccess r,
+    Member (Input (Local ())) r,
+    Member MemberStore r,
+    Member P.TinyLog r
+  ) =>
+  Domain ->
+  F.ConversationUpdate ->
+  Sem r ()
+updateLocalStateOfRemoteConv requestingDomain cu = do
+  loc <- qualifyLocal ()
+  let rconvId = toRemoteUnsafe requestingDomain (F.cuConvId cu)
+      qconvId = tUntagged rconvId
+
+  -- Note: we generally do not send notifications to users that are not part of
+  -- the conversation (from our point of view), to prevent spam from the remote
+  -- backend. See also the comment below.
+  (presentUsers, allUsersArePresent) <-
+    E.selectRemoteMembers (F.cuAlreadyPresentUsers cu) rconvId
+
+  -- Perform action, and determine extra notification targets.
+  --
+  -- When new users are being added to the conversation, we consider them as
+  -- notification targets. Since we check connections before letting
+  -- people being added, this is safe against spam. However, if users that
+  -- are not in the conversations are being removed or have their membership state
+  -- updated, we do **not** add them to the list of targets, because we have no
+  -- way to make sure that they are actually supposed to receive that notification.
+
+  (mActualAction :: Maybe SomeConversationAction, extraTargets :: [UserId]) <- case F.cuAction cu of
+    sca@(SomeConversationAction singTag action) -> case singTag of
+      SConversationJoinTag -> do
+        let ConversationJoin toAdd role = action
+        let (localUsers, remoteUsers) = partitionQualified loc toAdd
+        addedLocalUsers <- Set.toList <$> addLocalUsersToRemoteConv rconvId (F.cuOrigUserId cu) localUsers
+        let allAddedUsers = map (tUntagged . qualifyAs loc) addedLocalUsers <> map tUntagged remoteUsers
+        case allAddedUsers of
+          [] -> pure (Nothing, []) -- If no users get added, its like no action was performed.
+          (u : us) -> pure (Just (SomeConversationAction (sing @'ConversationJoinTag) (ConversationJoin (u :| us) role)), addedLocalUsers)
+      SConversationLeaveTag -> do
+        let users = foldQualified loc (pure . tUnqualified) (const []) (F.cuOrigUserId cu)
+        E.deleteMembersInRemoteConversation rconvId users
+        pure (Just sca, [])
+      SConversationRemoveMembersTag -> do
+        let localUsers = getLocalUsers (tDomain loc) action
+        E.deleteMembersInRemoteConversation rconvId localUsers
+        pure (Just sca, [])
+      SConversationMemberUpdateTag ->
+        pure (Just sca, [])
+      SConversationDeleteTag -> do
+        E.deleteMembersInRemoteConversation rconvId presentUsers
+        pure (Just sca, [])
+      SConversationRenameTag -> pure (Just sca, [])
+      SConversationMessageTimerUpdateTag -> pure (Just sca, [])
+      SConversationReceiptModeUpdateTag -> pure (Just sca, [])
+      SConversationAccessDataTag -> pure (Just sca, [])
+
+  unless allUsersArePresent $
+    P.warn $
+      Log.field "conversation" (toByteString' (F.cuConvId cu))
+        . Log.field "domain" (toByteString' requestingDomain)
+        . Log.msg
+          ( "Attempt to send notification about conversation update \
+            \to users not in the conversation" ::
+              ByteString
+          )
+
+  -- Send notifications
+  for_ mActualAction $ \(SomeConversationAction tag action) -> do
+    let event = conversationActionToEvent tag (F.cuTime cu) (F.cuOrigUserId cu) qconvId Nothing action
+        targets = nubOrd $ presentUsers <> extraTargets
+    -- FUTUREWORK: support bots?
+    pushConversationEvent Nothing event (qualifyAs loc targets) []
+
+addLocalUsersToRemoteConv ::
+  ( Member BrigAccess r,
+    Member MemberStore r,
+    Member P.TinyLog r
+  ) =>
+  Remote ConvId ->
+  Qualified UserId ->
+  [UserId] ->
+  Sem r (Set UserId)
+addLocalUsersToRemoteConv remoteConvId qAdder localUsers = do
+  connStatus <- E.getConnections localUsers (Just [qAdder]) (Just Accepted)
+  let localUserIdsSet = Set.fromList localUsers
+      connected = Set.fromList $ fmap csv2From connStatus
+      unconnected = Set.difference localUserIdsSet connected
+      connectedList = Set.toList connected
+
+  -- FUTUREWORK: Consider handling the discrepancy between the views of the
+  -- conversation-owning backend and the local backend
+  unless (Set.null unconnected) $
+    P.warn $
+      Log.msg ("A remote user is trying to add unconnected local users to a remote conversation" :: Text)
+        . Log.field "remote_user" (show qAdder)
+        . Log.field "local_unconnected_users" (show unconnected)
+
+  -- Update the local view of the remote conversation by adding only those local
+  -- users that are connected to the adder
+  E.createMembersInRemoteConversation remoteConvId connectedList
+  pure connected
 
 -- | Kick a user from a conversation and send notifications.
 --

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -227,7 +227,9 @@ onConversationUpdated ::
   Domain ->
   F.ConversationUpdate ->
   Sem r ()
-onConversationUpdated requestingDomain cu = updateLocalStateOfRemoteConv requestingDomain cu
+onConversationUpdated requestingDomain cu = do
+  let rcu = toRemoteUnsafe requestingDomain cu
+  void $ updateLocalStateOfRemoteConv rcu Nothing
 
 -- as of now this will not generate the necessary events on the leaver's domain
 leaveConversation ::

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -49,7 +49,6 @@ import Galley.API.MLS.Welcome
 import qualified Galley.API.Mapping as Mapping
 import Galley.API.Message
 import Galley.API.Push
-import Galley.API.Update
 import Galley.API.Util
 import Galley.App
 import qualified Galley.Data.Conversation as Data

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -68,6 +68,7 @@ import Polysemy
 import Polysemy.Error
 import Polysemy.Input
 import Polysemy.Internal
+import Polysemy.Output
 import Polysemy.Resource (Resource, bracket)
 import Polysemy.TinyLog
 import Wire.API.Conversation hiding (Member)
@@ -326,17 +327,17 @@ postMLSCommitBundleToLocalConv qusr mc conn bundle lcnv = do
   pure events
 
 postMLSCommitBundleToRemoteConv ::
-  ( Members MLSBundleStaticErrors r,
-    ( Member (Error FederationError) r,
-      Member (Error InternalError) r,
-      Member (Error MLSProtocolError) r,
-      Member (Error MLSProposalFailure) r,
-      Member ExternalAccess r,
-      Member FederatorAccess r,
-      Member GundeckAccess r,
-      Member MemberStore r,
-      Member TinyLog r
-    )
+  ( Member BrigAccess r,
+    Members MLSBundleStaticErrors r,
+    Member (Error FederationError) r,
+    Member (Error InternalError) r,
+    Member (Error MLSProtocolError) r,
+    Member (Error MLSProposalFailure) r,
+    Member ExternalAccess r,
+    Member FederatorAccess r,
+    Member GundeckAccess r,
+    Member MemberStore r,
+    Member TinyLog r
   ) =>
   Local x ->
   Qualified UserId ->
@@ -370,9 +371,10 @@ postMLSCommitBundleToRemoteConv loc qusr con bundle rcnv = do
           \non-empty list of users an application message could not be \
           \sent to. The remote end returned: "
             <> LT.pack (intercalate ", " (show <$> NE.toList (unreachableUsers us)))
-      for updates $ \update -> do
-        e <- notifyRemoteConversationAction loc (qualifyAs rcnv update) con
-        pure (LocalConversationUpdate e update)
+      fmap fst . runOutputList . runInputConst (void loc) $
+        for_ updates $ \update -> do
+          me <- updateLocalStateOfRemoteConv (qualifyAs rcnv update) con
+          for_ me $ \e -> output (LocalConversationUpdate e update)
 
 postMLSMessage ::
   ( HasProposalEffects r,
@@ -512,9 +514,7 @@ postMLSMessageToLocalConv qusr senderClient con smsg lcnv =
 
 postMLSMessageToRemoteConv ::
   ( Members MLSMessageStaticErrors r,
-    ( Member (Error FederationError) r,
-      Member TinyLog r
-    ),
+    Member (Error FederationError) r,
     HasProposalEffects r
   ) =>
   Local x ->
@@ -550,9 +550,10 @@ postMLSMessageToRemoteConv loc qusr _senderClient con smsg rcnv = do
         \sent to. The remote end returned: "
           <> LT.pack (intercalate ", " (show <$> Set.toList (Set.map domainText ds)))
     MLSMessageResponseUpdates updates unreachables -> do
-      lcus <- for updates $ \update -> do
-        e <- notifyRemoteConversationAction loc (qualifyAs rcnv update) con
-        pure (LocalConversationUpdate e update)
+      lcus <- fmap fst . runOutputList $
+        for_ updates $ \update -> do
+          me <- updateLocalStateOfRemoteConv (qualifyAs rcnv update) con
+          for_ me $ \e -> output (LocalConversationUpdate e update)
 
       pure (lcus, unreachables)
 

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -53,7 +53,6 @@ module Galley.API.Update
     removeMemberUnqualified,
     removeMemberFromLocalConv,
     removeMemberFromRemoteConv,
-    addLocalUsersToRemoteConv,
 
     -- * Talking
     postProteusMessage,
@@ -75,13 +74,9 @@ where
 import Control.Error.Util (hush)
 import Control.Lens
 import Control.Monad.State
-import Data.ByteString.Conversion
 import Data.Code
-import Data.Domain
 import Data.Id
 import Data.Json.Util
-import Data.List.Extra (nubOrd)
-import Data.List.NonEmpty (NonEmpty (..))
 import Data.List1
 import qualified Data.Map.Strict as Map
 import Data.Qualified
@@ -99,7 +94,6 @@ import qualified Galley.Data.Conversation as Data
 import Galley.Data.Services as Data
 import Galley.Data.Types hiding (Conversation)
 import Galley.Effects
-import qualified Galley.Effects.BrigAccess as E
 import qualified Galley.Effects.ClientStore as E
 import qualified Galley.Effects.CodeStore as E
 import qualified Galley.Effects.ConversationStore as E
@@ -125,10 +119,7 @@ import Polysemy
 import Polysemy.Error
 import Polysemy.Input
 import Polysemy.TinyLog
-import qualified Polysemy.TinyLog as P
 import System.Logger (Msg)
-import qualified System.Logger.Class as Log
-import Wire.API.Connection (Relation (Accepted))
 import Wire.API.Conversation hiding (Member)
 import Wire.API.Conversation.Action
 import Wire.API.Conversation.Code
@@ -139,12 +130,10 @@ import Wire.API.Error.Galley
 import Wire.API.Event.Conversation
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Galley
-import qualified Wire.API.Federation.API.Galley as F
 import Wire.API.Federation.Error
 import Wire.API.Message
 import Wire.API.Password (mkSafePassword)
 import Wire.API.Provider.Service (ServiceRef)
-import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Routes.Public.Galley.Messaging
 import Wire.API.Routes.Public.Util (UpdateResult (..))
 import Wire.API.ServantProto (RawProto (..))
@@ -1609,113 +1598,6 @@ rmBot lusr zcon b = do
         E.deleteClients (botUserId (b ^. rmBotId))
         E.deliverAsync (bots `zip` repeat e)
         pure $ Updated e
-
--- | Update the local database with information on conversation members joining
--- or leaving. Finally, push out notifications to local users.
-updateLocalStateOfRemoteConv ::
-  ( Member BrigAccess r,
-    Member GundeckAccess r,
-    Member ExternalAccess r,
-    Member (Input (Local ())) r,
-    Member MemberStore r,
-    Member P.TinyLog r
-  ) =>
-  Domain ->
-  F.ConversationUpdate ->
-  Sem r ()
-updateLocalStateOfRemoteConv requestingDomain cu = do
-  loc <- qualifyLocal ()
-  let rconvId = toRemoteUnsafe requestingDomain (F.cuConvId cu)
-      qconvId = tUntagged rconvId
-
-  -- Note: we generally do not send notifications to users that are not part of
-  -- the conversation (from our point of view), to prevent spam from the remote
-  -- backend. See also the comment below.
-  (presentUsers, allUsersArePresent) <-
-    E.selectRemoteMembers (F.cuAlreadyPresentUsers cu) rconvId
-
-  -- Perform action, and determine extra notification targets.
-  --
-  -- When new users are being added to the conversation, we consider them as
-  -- notification targets. Since we check connections before letting
-  -- people being added, this is safe against spam. However, if users that
-  -- are not in the conversations are being removed or have their membership state
-  -- updated, we do **not** add them to the list of targets, because we have no
-  -- way to make sure that they are actually supposed to receive that notification.
-
-  (mActualAction :: Maybe SomeConversationAction, extraTargets :: [UserId]) <- case F.cuAction cu of
-    sca@(SomeConversationAction singTag action) -> case singTag of
-      SConversationJoinTag -> do
-        let ConversationJoin toAdd role = action
-        let (localUsers, remoteUsers) = partitionQualified loc toAdd
-        addedLocalUsers <- Set.toList <$> addLocalUsersToRemoteConv rconvId (F.cuOrigUserId cu) localUsers
-        let allAddedUsers = map (tUntagged . qualifyAs loc) addedLocalUsers <> map tUntagged remoteUsers
-        case allAddedUsers of
-          [] -> pure (Nothing, []) -- If no users get added, its like no action was performed.
-          (u : us) -> pure (Just (SomeConversationAction (sing @'ConversationJoinTag) (ConversationJoin (u :| us) role)), addedLocalUsers)
-      SConversationLeaveTag -> do
-        let users = foldQualified loc (pure . tUnqualified) (const []) (F.cuOrigUserId cu)
-        E.deleteMembersInRemoteConversation rconvId users
-        pure (Just sca, [])
-      SConversationRemoveMembersTag -> do
-        let localUsers = getLocalUsers (tDomain loc) action
-        E.deleteMembersInRemoteConversation rconvId localUsers
-        pure (Just sca, [])
-      SConversationMemberUpdateTag ->
-        pure (Just sca, [])
-      SConversationDeleteTag -> do
-        E.deleteMembersInRemoteConversation rconvId presentUsers
-        pure (Just sca, [])
-      SConversationRenameTag -> pure (Just sca, [])
-      SConversationMessageTimerUpdateTag -> pure (Just sca, [])
-      SConversationReceiptModeUpdateTag -> pure (Just sca, [])
-      SConversationAccessDataTag -> pure (Just sca, [])
-
-  unless allUsersArePresent $
-    P.warn $
-      Log.field "conversation" (toByteString' (F.cuConvId cu))
-        . Log.field "domain" (toByteString' requestingDomain)
-        . Log.msg
-          ( "Attempt to send notification about conversation update \
-            \to users not in the conversation" ::
-              ByteString
-          )
-
-  -- Send notifications
-  for_ mActualAction $ \(SomeConversationAction tag action) -> do
-    let event = conversationActionToEvent tag (F.cuTime cu) (F.cuOrigUserId cu) qconvId Nothing action
-        targets = nubOrd $ presentUsers <> extraTargets
-    -- FUTUREWORK: support bots?
-    pushConversationEvent Nothing event (qualifyAs loc targets) []
-
-addLocalUsersToRemoteConv ::
-  ( Member BrigAccess r,
-    Member MemberStore r,
-    Member P.TinyLog r
-  ) =>
-  Remote ConvId ->
-  Qualified UserId ->
-  [UserId] ->
-  Sem r (Set UserId)
-addLocalUsersToRemoteConv remoteConvId qAdder localUsers = do
-  connStatus <- E.getConnections localUsers (Just [qAdder]) (Just Accepted)
-  let localUserIdsSet = Set.fromList localUsers
-      connected = Set.fromList $ fmap csv2From connStatus
-      unconnected = Set.difference localUserIdsSet connected
-      connectedList = Set.toList connected
-
-  -- FUTUREWORK: Consider handling the discrepancy between the views of the
-  -- conversation-owning backend and the local backend
-  unless (Set.null unconnected) $
-    P.warn $
-      Log.msg ("A remote user is trying to add unconnected local users to a remote conversation" :: Text)
-        . Log.field "remote_user" (show qAdder)
-        . Log.field "local_unconnected_users" (show unconnected)
-
-  -- Update the local view of the remote conversation by adding only those local
-  -- users that are connected to the adder
-  E.createMembersInRemoteConversation remoteConvId connectedList
-  pure connected
 
 -------------------------------------------------------------------------------
 -- Helpers

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -370,8 +370,7 @@ updateRemoteConversation rcnv lusr conn action = getUpdateResult $ do
     ConversationUpdateResponseError err' -> rethrowErrors @(HasConversationActionGalleyErrors tag) err'
     ConversationUpdateResponseUpdate convUpdate _failedToProcess -> pure convUpdate
 
-  updateLocalStateOfRemoteConv (tDomain rcnv) convUpdate
-  notifyRemoteConversationAction lusr (qualifyAs rcnv convUpdate) (Just conn)
+  updateLocalStateOfRemoteConv (qualifyAs rcnv convUpdate) (Just conn) >>= note NoChanges
 
 updateConversationReceiptModeUnqualified ::
   ( Member BrigAccess r,


### PR DESCRIPTION
The two functions `updateLocalStateOfRemoteConv` and `notifyRemoteConversationAction` were pretty similar and used inconsistently. This commit makes `updateLocalStateOfRemoteConv` both handle the remote update and return the event to be written in the response.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
