### PR TITLE
Avoid MLS messages in sender client's event stream

### DIFF
--- a/changelog.d/5-internal/dont-return-to-sender
+++ b/changelog.d/5-internal/dont-return-to-sender
@@ -1,0 +1,1 @@
+Avoid including MLS application messages in the sender client's event stream.

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -28,9 +28,16 @@ testSendMessageNoReturnToSender = do
     for_ wss $ \ws -> do
       n <- awaitMatch 3 (\n -> nPayload n %. "type" `isEqual` "conversation.mls-message-add") ws
       nPayload n %. "data" `shouldMatch` T.decodeUtf8 (Base64.encode mp.message)
-    expectFailure (const $ pure ()) $ do
-      n <- awaitMatch 3 (\n -> nPayload n %. "type" `isEqual` "conversation.mls-message-add") wsSender
-      nPayload n %. "data" `shouldMatch` T.decodeUtf8 (Base64.encode mp.message)
+    expectFailure (const $ pure ()) $
+      awaitMatch
+        3
+        ( \n ->
+            liftM2
+              (&&)
+              (nPayload n %. "type" `isEqual` "conversation.mls-message-add")
+              (nPayload n %. "data" `isEqual` T.decodeUtf8 (Base64.encode mp.message))
+        )
+        wsSender
 
 testMixedProtocolUpgrade :: HasCallStack => Domain -> App ()
 testMixedProtocolUpgrade secondDomain = do

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -11,6 +11,27 @@ import MLS.Util
 import SetupHelpers
 import Testlib.Prelude
 
+testSendMessageNoReturnToSender :: HasCallStack => App ()
+testSendMessageNoReturnToSender = do
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
+  [alice1, alice2, bob1, bob2] <- traverse createMLSClient [alice, alice, bob, bob]
+  traverse_ uploadNewKeyPackage [alice2, bob1, bob2]
+  void $ createNewGroup alice1
+  void $ createAddCommit alice1 [alice, bob] >>= sendAndConsumeCommitBundle
+
+  -- alice1 sends a message to the conversation, all clients but alice1 receive
+  -- the message
+  withWebSockets [alice1, alice2, bob1, bob2] $ \(wsSender : wss) -> do
+    mp <- createApplicationMessage alice1 "hello, bob"
+    void . bindResponse (postMLSMessage mp.sender mp.message) $ \resp -> do
+      resp.status `shouldMatchInt` 201
+    for_ wss $ \ws -> do
+      n <- awaitMatch 3 (\n -> nPayload n %. "type" `isEqual` "conversation.mls-message-add") ws
+      nPayload n %. "data" `shouldMatch` T.decodeUtf8 (Base64.encode mp.message)
+    expectFailure (const $ pure ()) $ do
+      n <- awaitMatch 3 (\n -> nPayload n %. "type" `isEqual` "conversation.mls-message-add") wsSender
+      nPayload n %. "data" `shouldMatch` T.decodeUtf8 (Base64.encode mp.message)
+
 testMixedProtocolUpgrade :: HasCallStack => Domain -> App ()
 testMixedProtocolUpgrade secondDomain = do
   (alice, tid) <- createTeam OwnDomain

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -232,7 +232,7 @@ postMLSCommitBundleToLocalConv qusr c conn bundle lConvOrSubId = do
 
   storeGroupInfo (tUnqualified lConvOrSub).id bundle.groupInfo
 
-  propagateMessage qusr lConvOrSub conn bundle.rawMessage (tUnqualified lConvOrSub).members
+  propagateMessage qusr (Just c) lConvOrSub conn bundle.rawMessage (tUnqualified lConvOrSub).members
     >>= mapM_ throwUnreachableUsers
 
   for_ bundle.welcome $ \welcome ->
@@ -375,7 +375,7 @@ postMLSMessageToLocalConv qusr c con msg convOrSubId = do
       when ((tUnqualified lConvOrSub).migrationState == MLSMigrationMixed) $
         throwS @'MLSUnsupportedMessage
 
-  unreachables <- propagateMessage qusr lConvOrSub con msg.rawMessage (tUnqualified lConvOrSub).members
+  unreachables <- propagateMessage qusr (Just c) lConvOrSub con msg.rawMessage (tUnqualified lConvOrSub).members
   pure ([], unreachables)
 
 postMLSMessageToRemoteConv ::

--- a/services/galley/src/Galley/API/MLS/Removal.hs
+++ b/services/galley/src/Galley/API/MLS/Removal.hs
@@ -101,7 +101,7 @@ createAndSendRemoveProposals lConvOrSubConv indices qusr cm = do
           (publicMessageRef (cnvmlsCipherSuite meta) pmsg)
           ProposalOriginBackend
           proposal
-        propagateMessage qusr lConvOrSubConv Nothing msg cm
+        propagateMessage qusr Nothing lConvOrSubConv Nothing msg cm
 
 removeClientsWithClientMapRecursively ::
   ( Members


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
