### PR TITLE
add unit test for unique internal route IDs in swagger

### DIFF
--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -736,6 +736,7 @@ test-suite brig-tests
     Test.Brig.InternalNotification
     Test.Brig.MLS
     Test.Brig.Roundtrip
+    Test.Brig.Swagger
     Test.Brig.User.Search.Index.Types
 
   hs-source-dirs:     test/unit

--- a/services/brig/test/unit/Main.hs
+++ b/services/brig/test/unit/Main.hs
@@ -26,6 +26,7 @@ import qualified Test.Brig.Calling.Internal
 import qualified Test.Brig.InternalNotification
 import qualified Test.Brig.MLS
 import qualified Test.Brig.Roundtrip
+import qualified Test.Brig.Swagger
 import qualified Test.Brig.User.Search.Index.Types
 import Test.Tasty
 
@@ -34,10 +35,11 @@ main =
   defaultMain $
     testGroup
       "Tests"
-      [ Test.Brig.User.Search.Index.Types.tests,
+      [ Test.Brig.Calling.Internal.tests,
         Test.Brig.Calling.tests,
-        Test.Brig.Calling.Internal.tests,
-        Test.Brig.Roundtrip.tests,
+        Test.Brig.InternalNotification.tests,
         Test.Brig.MLS.tests,
-        Test.Brig.InternalNotification.tests
+        Test.Brig.Roundtrip.tests,
+        Test.Brig.Swagger.tests,
+        Test.Brig.User.Search.Index.Types.tests
       ]

--- a/services/brig/test/unit/Test/Brig/Swagger.hs
+++ b/services/brig/test/unit/Test/Brig/Swagger.hs
@@ -1,0 +1,47 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Brig.Swagger (tests) where
+
+import Brig.API.Public (DocsAPI, docsAPI)
+import Data.Aeson (FromJSON, ToJSON, parseJSON, toJSON)
+import Data.Aeson.Types (parseEither)
+import Imports
+import Servant.Client (client, runClientM)
+import Test.Tasty
+import Test.Tasty.HUnit
+import Type.Reflection (typeRep)
+
+tests :: TestTree
+tests =
+  localOption (Timeout (60 * 1000000) "60s") . testGroup "Swagger" $
+    [ testCase "no internal routing ID duplicates" $ do
+        pure ()
+    ]
+
+{- TODO:
+
+- write clients for all swagger end-points
+- use hspec-wai to run the swagger end-points so we can call them in a unit test
+- call all the swagger.json ones and string-concatenate the responses
+- grep responses for internal route IDs, and return a list
+- assert (list == nub list)
+- it's slightly more complicated: V1 and V2 often contain the same end-point with the same route ID.  just check for every version separately?
+
+-}
+
+position :<|> hello :<|> marketing = client (Proxy @DocsAPI)


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-2957

follow-up to https://github.com/wireapp/wire-server/pull/3319: add a unit test to wire-api to ensure that internal route IDs remain unique.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
