### PR TITLE
Welcome messages should not be sent to creator

### DIFF
--- a/changelog.d/3-bug-fixes/sender-welcome
+++ b/changelog.d/3-bug-fixes/sender-welcome
@@ -1,0 +1,1 @@
+Welcome messages are not sent anymore to the creator of an MLS group on the first commit

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -111,13 +111,12 @@ testMixedProtocolAddUsers secondDomain = do
 
   traverse_ uploadNewKeyPackage [bob1]
 
-  withWebSockets [alice, bob] $ \wss -> do
+  withWebSocket bob $ \ws -> do
     mp <- createAddCommit alice1 [bob]
     welcome <- assertJust "should have welcome" mp.welcome
     void $ sendAndConsumeCommitBundle mp
-    for_ wss $ \ws -> do
-      n <- awaitMatch 3 (\n -> nPayload n %. "type" `isEqual` "conversation.mls-welcome") ws
-      nPayload n %. "data" `shouldMatch` T.decodeUtf8 (Base64.encode welcome)
+    n <- awaitMatch 3 (\n -> nPayload n %. "type" `isEqual` "conversation.mls-welcome") ws
+    nPayload n %. "data" `shouldMatch` T.decodeUtf8 (Base64.encode welcome)
 
 testMixedProtocolUserLeaves :: HasCallStack => Domain -> App ()
 testMixedProtocolUserLeaves secondDomain = do

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -221,7 +221,10 @@ postMLSCommitBundleToLocalConv qusr c conn bundle ctype lConvOrSubId = do
           bundle.epoch
           action
           bundle.commit.value
-      pure (events, cmIdentities (paAdd action))
+      -- the sender client is included in the Add action on the first commit,
+      -- but it doesn't need to get a welcome message, so we filter it out here
+      let newClients = filter ((/=) senderIdentity) (cmIdentities (paAdd action))
+      pure (events, newClients)
     SenderExternal _ -> throw (mlsProtocolError "Unexpected sender")
     SenderNewMemberProposal -> throw (mlsProtocolError "Unexpected sender")
     SenderNewMemberCommit -> do


### PR DESCRIPTION
This fixes a bug where welcome messages were sent to the creator of a group on the first commit.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
