### PR TITLE
Revert "multi ingress ingress services"

### DIFF
--- a/changelog.d/2-features/multi-ingress-support-nginx-ingress-services
+++ b/changelog.d/2-features/multi-ingress-support-nginx-ingress-services
@@ -1,1 +1,0 @@
-Add configuration options to setup instances of the `nginx-ingress-services` chart to act as additional ingresses (with sourrounding infrastructure) to provide additional domains for the same backend.

--- a/charts/nginx-ingress-services/templates/ca_federator.yaml
+++ b/charts/nginx-ingress-services/templates/ca_federator.yaml
@@ -6,9 +6,6 @@ secret because cert-manager interferes with the ca.crt field when setting the
 certificate in a secret. */ -}}
 
 {{- if .Values.federator.enabled -}}
-{{- if .Values.config.isAdditionalIngress -}}
-  {{ fail "Federation and multi-backend-domain (multi-ingress) cannot be configured together." }}
-{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/nginx-ingress-services/templates/certificate_federator.yaml
+++ b/charts/nginx-ingress-services/templates/certificate_federator.yaml
@@ -1,9 +1,6 @@
 {{- if and .Values.federator.enabled (not .Values.tls.enabled) }}
 {{- fail "TLS is required by federator. Either disable federation or enable tls." }}
 {{- end }}
-{{- if and .Values.federator.enabled .Values.config.isAdditionalIngress -}}
-  {{ fail "Federation and multi-backend-domain (multi-ingress) cannot be configured together." }}
-{{- end -}}
 {{- if and .Values.federator.enabled (and .Values.tls.enabled .Values.tls.useCertManager) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -4,38 +4,11 @@
 apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: nginx-ingress-{{ .Values.ingressName }}
+  name: nginx-ingress
   annotations:
     {{- if not $ingressFieldNotAnnotation }}
     kubernetes.io/ingress.class: "{{ .Values.config.ingressClass }}"
     {{- end }}
-    {{ if .Values.config.renderCSPInIngress }}
-    {{ if not (contains .Values.config.ingressClass "nginx") }}
-        {{ fail "In ingress CSP header setting only works with a 'nginx' controller. (Rename it to 'nginx-*' if it is one.)" }}
-    {{ end }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      set $CSP "connect-src 'self' blob: data: https://*.giphy.com https://{{ .Values.config.dns.https }}";
-      {{if .Values.websockets.enabled}}
-      set $CSP "${CSP} wss://{{ .Values.config.dns.ssl }}";
-      {{end}}
-      set $CSP "${CSP} https://*.{{ .Values.config.dns.base }};";
-      set $CSP "${CSP} default-src 'self';";
-      set $CSP "${CSP} font-src 'self' data:;";
-      set $CSP "${CSP} frame-src https://*.soundcloud.com https://*.spotify.com https://*.vimeo.com https://*.youtube-nocookie.com;";
-      set $CSP "${CSP} img-src 'self' blob: data: https://*.giphy.com https://*.{{ .Values.config.dns.base }};";
-      set $CSP "${CSP} manifest-src 'self';";
-      set $CSP "${CSP} media-src 'self' blob: data:;";
-      set $CSP "${CSP} object-src 'none';";
-      set $CSP "${CSP} script-src 'self' 'unsafe-eval' https://*.{{ required "Need a 'base' domain for CSP headers." .Values.config.dns.base }}; ";
-      set $CSP "${CSP} style-src 'self' 'unsafe-inline';";
-      set $CSP "${CSP} worker-src 'self' blob:;";
-      set $CSP "${CSP} base-uri 'self';";
-      set $CSP "${CSP} form-action 'self';";
-      set $CSP "${CSP} frame-ancestors 'self';";
-      set $CSP "${CSP} script-src-attr 'none';";
-      set $CSP "${CSP} upgrade-insecure-requests";
-      more_set_headers "content-security-policy: $CSP";
-    {{ end }}
 spec:
   {{- if $ingressFieldNotAnnotation }}
   ingressClassName: "{{ .Values.config.ingressClass }}"

--- a/charts/nginx-ingress-services/templates/ingress_federator.yaml
+++ b/charts/nginx-ingress-services/templates/ingress_federator.yaml
@@ -2,9 +2,6 @@
 {{- $ingressFieldNotAnnotation := eq (include "ingress.FieldNotAnnotation" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
 {{- if .Values.federator.enabled }}
-{{- if .Values.config.isAdditionalIngress -}}
-  {{ fail "Federation and multi-backend-domain (multi-ingress) cannot be configured together." }}
-{{- end -}}
 # We use a separate ingress for federator so that we can require client
 # certificates only for federation requests
 apiVersion: {{ include "ingress.apiVersion" . }}

--- a/charts/nginx-ingress-services/templates/issuer.yaml
+++ b/charts/nginx-ingress-services/templates/issuer.yaml
@@ -6,7 +6,7 @@ kind: "{{ .Values.tls.issuer.kind }}"
 {{- fail (cat ".tls.issuer.kind can only be one of Issuer or ClusterIssuer, got: " .tls.issuer.kind )}}
 {{- end }}
 metadata:
-  name: {{ .Values.tls.issuer.name }}-{{ .Values.ingressName }}
+  name: {{ .Values.tls.issuer.name }}
   {{- if eq .Values.tls.issuer.kind "Issuer" }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/charts/nginx-ingress-services/templates/secret_federator.yaml
+++ b/charts/nginx-ingress-services/templates/secret_federator.yaml
@@ -1,7 +1,4 @@
 {{- if and .Values.federator.enabled (not .Values.tls.useCertManager) }}
-{{- if .Values.config.isAdditionalIngress -}}
-  {{ fail "Federation and multi-backend-domain (multi-ingress) cannot be configured together." }}
-{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/nginx-ingress-services/templates/service.yaml
+++ b/charts/nginx-ingress-services/templates/service.yaml
@@ -1,5 +1,4 @@
 # FUTUREWORK: move services into the respective charts
-{{- if not .Values.config.isAdditionalIngress }}
 {{- if .Values.webapp.enabled }}
 ---
 apiVersion: v1
@@ -55,5 +54,4 @@ spec:
       targetPort: 8080
   selector:
     app: account-pages
-{{- end }}
 {{- end }}

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -42,14 +42,6 @@ tls:
     name: letsencrypt-http01
     kind: Issuer # Issuer | ClusterIssuer
 
-# Name of the ingress.
-#
-# If there is only one backend domain to be served, this can stay 'default'
-# (doesn't need to be changed.) If there are multiple backend domains
-# (multi-ingress setup), use a descriptive name per backend domain. Technically,
-# this value can be any string.
-ingressName: default
-
 certManager:
   # Indicates whether Letsencrypt's staging API server is used and therefore certificates are NOT trusted
   # default: production API server is used and certificates are trusted
@@ -103,8 +95,6 @@ config:
   ingressClass: "nginx"
 # You will need to supply some DNS names, namely
 #   dns:
-#     base: <domain>
-#     ^ base is only needed to render multi-backend-domain (multi-ingress) CSP headers
 #     https: nginz-https.<domain>
 #     ssl: nginz-ssl.<domain> # For websockets
 #     ^ ssl is ignored if websockets.enabled == false
@@ -140,15 +130,3 @@ config:
 #       we do not want to create yet another service here but rather
 #       use that service instead in the ingress
 #     serviceName: minio-external
-
-# Configure CSP headers directly in the ingress.
-#
-# This is only suggested / needed in setups with multiple backend domains
-# (multi-ingress), because the webapps can only provide CSP headers for one
-# (root) domain.
-  renderCSPInIngress: false
-# Is this a chart instantiation for an additional backend domain (multi-ingress)?
-#
-# If 'true' some resources aren't created because they're expected to already
-# exist. There must be one non-additional instantiation per deployment!
-  isAdditionalIngress: false


### PR DESCRIPTION
Reverts wireapp/wire-server#3375

Staging deployment was broken because of conflicting ingresses.

https://concourse.ops.zinfra.io/teams/main/pipelines/staging/jobs/deploy-eks-staging/builds/512

Probably, the name for the default ingress has to stay the same.