### PR TITLE
Tweak retry policy for pulling federation remotes from brig.

### DIFF
--- a/libs/wire-api/src/Wire/API/FederationUpdate.hs
+++ b/libs/wire-api/src/Wire/API/FederationUpdate.hs
@@ -34,7 +34,7 @@ initialize :: L.Logger -> ClientEnv -> IO FederationDomainConfigs
 initialize logger clientEnv =
   let -- keep trying every 3s for one minute
       policy :: R.RetryPolicy
-      policy = R.constantDelay 3_081_003 <> R.limitRetries 20
+      policy = R.capDelay 30_000_000 $ R.exponentialBackoff 3_000
 
       go :: IO (Maybe FederationDomainConfigs)
       go = do


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-3007

timing of `./services/run-services date`:

- without fix, with federation enabled: `real 0m7.475s`
- without fix, with federation disabled: `real 0m3.912s`
- with fix, with federation enabled: `real 0m2.934s`
- with fix, with federation disabled: `real 0m1.659s`

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
