### PR TITLE
Re-revert: multi ingress ingress services

### DIFF
--- a/changelog.d/2-features/multi-ingress-support-nginx-ingress-services
+++ b/changelog.d/2-features/multi-ingress-support-nginx-ingress-services
@@ -1,0 +1,1 @@
+Add configuration options to setup instances of the `nginx-ingress-services` chart to act as additional ingresses (with sourrounding infrastructure) to provide additional domains for the same backend.

--- a/charts/nginx-ingress-services/templates/_helpers.tpl
+++ b/charts/nginx-ingress-services/templates/_helpers.tpl
@@ -106,3 +106,16 @@ nginx-ingress
 {{- else -}}
 nginx-ingress-{{ .Values.ingressName }}
 {{- end -}}
+
+{{/*
+Name of the certificate 'Issuer'. Especially, used in 'issuerRef's.
+In multi-domain backends (multi-ingress), the 'ingressName' is used as postfix
+of the name to ensure that certificates aren't accidentally all issued by the
+same issuer; which may leak a hint about a common origin.
+*/}}
+{{- define "nginx-ingress-services.getIssuerName" -}}
+{{- if (eq .Values.ingressName "") -}}
+{{ .Values.tls.issuer.name }}
+{{- else -}}
+{{ .Values.tls.issuer.name }}-{{ .Values.ingressName }}
+{{- end -}}

--- a/charts/nginx-ingress-services/templates/_helpers.tpl
+++ b/charts/nginx-ingress-services/templates/_helpers.tpl
@@ -94,3 +94,15 @@ Returns the Letsencrypt API server URL based on whether testMode is enabled or d
 {{- define "ingress.FieldNotAnnotation" -}}
   {{- (semverCompare ">= 1.27-0" (include "kubeVersion" .)) -}}
 {{- end -}}
+
+{{/*
+Name of the ingress. Extracted as helper to reduce the complexity in the template
+itself. The default name is 'nginx-ingress' for backwards compatibility (it has
+been this name in previous versions.)
+*/}}
+{{- define "nginx-ingress-services.getIngressName" -}}
+{{- if (eq .Values.ingressName "") -}}
+nginx-ingress
+{{- else -}}
+nginx-ingress-{{ .Values.ingressName }}
+{{- end -}}

--- a/charts/nginx-ingress-services/templates/_helpers.tpl
+++ b/charts/nginx-ingress-services/templates/_helpers.tpl
@@ -106,6 +106,7 @@ nginx-ingress
 {{- else -}}
 nginx-ingress-{{ .Values.ingressName }}
 {{- end -}}
+{{- end -}}
 
 {{/*
 Name of the certificate 'Issuer'. Especially, used in 'issuerRef's.
@@ -118,4 +119,5 @@ same issuer; which may leak a hint about a common origin.
 {{ .Values.tls.issuer.name }}
 {{- else -}}
 {{ .Values.tls.issuer.name }}-{{ .Values.ingressName }}
+{{- end -}}
 {{- end -}}

--- a/charts/nginx-ingress-services/templates/ca_federator.yaml
+++ b/charts/nginx-ingress-services/templates/ca_federator.yaml
@@ -6,6 +6,9 @@ secret because cert-manager interferes with the ca.crt field when setting the
 certificate in a secret. */ -}}
 
 {{- if .Values.federator.enabled -}}
+{{- if .Values.config.isAdditionalIngress -}}
+  {{ fail "Federation and multi-backend-domain (multi-ingress) cannot be configured together." }}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/nginx-ingress-services/templates/certificate.yaml
+++ b/charts/nginx-ingress-services/templates/certificate.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   issuerRef:
-    name: {{ .Values.tls.issuer.name }}
+    name: {{ include "nginx-ingress-services.getIssuerName" . | quote }}
     kind: {{ .Values.tls.issuer.kind }}
   usages:
     - server auth

--- a/charts/nginx-ingress-services/templates/certificate_federator.yaml
+++ b/charts/nginx-ingress-services/templates/certificate_federator.yaml
@@ -1,6 +1,9 @@
 {{- if and .Values.federator.enabled (not .Values.tls.enabled) }}
 {{- fail "TLS is required by federator. Either disable federation or enable tls." }}
 {{- end }}
+{{- if and .Values.federator.enabled .Values.config.isAdditionalIngress -}}
+  {{ fail "Federation and multi-backend-domain (multi-ingress) cannot be configured together." }}
+{{- end -}}
 {{- if and .Values.federator.enabled (and .Values.tls.enabled .Values.tls.useCertManager) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/nginx-ingress-services/templates/certificate_federator.yaml
+++ b/charts/nginx-ingress-services/templates/certificate_federator.yaml
@@ -16,7 +16,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   issuerRef:
-    name: {{ .Values.tls.issuer.name }}
+    name: {{ include "nginx-ingress-services.getIssuerName" . | quote }}
     kind: {{ .Values.tls.issuer.kind }}
   usages:
     - server auth

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- if not $ingressFieldNotAnnotation }}
     kubernetes.io/ingress.class: "{{ .Values.config.ingressClass }}"
     {{- end }}
+    {{ if .Values.config.renderCSPInIngress }}
+    {{ if ne .Values.config.ingressClass "nginx"}}
+        {{ fail "In ingress CSP header setting only works with 'nginx' controller." }}
+    {{ end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       set $CSP "connect-src 'self' blob: data: https://*.giphy.com https://{{ .Values.config.dns.https }}";
       {{if .Values.websockets.enabled}}
@@ -22,7 +26,7 @@ metadata:
       set $CSP "${CSP} manifest-src 'self';";
       set $CSP "${CSP} media-src 'self' blob: data:;";
       set $CSP "${CSP} object-src 'none';";
-      set $CSP "${CSP} script-src 'self' 'unsafe-eval' https://*.{{ .Values.config.dns.base }}; ";
+      set $CSP "${CSP} script-src 'self' 'unsafe-eval' https://*.{{ required "Need a 'base' domain for CSP headers." .Values.config.dns.base }}; ";
       set $CSP "${CSP} style-src 'self' 'unsafe-inline';";
       set $CSP "${CSP} worker-src 'self' blob:;";
       set $CSP "${CSP} base-uri 'self';";
@@ -31,6 +35,7 @@ metadata:
       set $CSP "${CSP} script-src-attr 'none';";
       set $CSP "${CSP} upgrade-insecure-requests";
       more_set_headers "content-security-policy: $CSP";
+    {{ end }}
 spec:
   {{- if $ingressFieldNotAnnotation }}
   ingressClassName: "{{ .Values.config.ingressClass }}"

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -4,11 +4,33 @@
 apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: nginx-ingress
+  name: nginx-ingress-{{ .Values.color }}
   annotations:
     {{- if not $ingressFieldNotAnnotation }}
     kubernetes.io/ingress.class: "{{ .Values.config.ingressClass }}"
     {{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      set $CSP "connect-src 'self' blob: data: https://*.giphy.com https://{{ .Values.config.dns.https }}";
+      {{if .Values.websockets.enabled}}
+      set $CSP "${CSP} wss://{{ .Values.config.dns.ssl }}";
+      {{end}}
+      set $CSP "${CSP} https://*.{{ .Values.config.dns.base }};";
+      set $CSP "${CSP} default-src 'self';";
+      set $CSP "${CSP} font-src 'self' data:;";
+      set $CSP "${CSP} frame-src https://*.soundcloud.com https://*.spotify.com https://*.vimeo.com https://*.youtube-nocookie.com;";
+      set $CSP "${CSP} img-src 'self' blob: data: https://*.giphy.com https://*.{{ .Values.config.dns.base }};";
+      set $CSP "${CSP} manifest-src 'self';";
+      set $CSP "${CSP} media-src 'self' blob: data:;";
+      set $CSP "${CSP} object-src 'none';";
+      set $CSP "${CSP} script-src 'self' 'unsafe-eval' https://*.{{ .Values.config.dns.base }}; ";
+      set $CSP "${CSP} style-src 'self' 'unsafe-inline';";
+      set $CSP "${CSP} worker-src 'self' blob:;";
+      set $CSP "${CSP} base-uri 'self';";
+      set $CSP "${CSP} form-action 'self';";
+      set $CSP "${CSP} frame-ancestors 'self';";
+      set $CSP "${CSP} script-src-attr 'none';";
+      set $CSP "${CSP} upgrade-insecure-requests";
+      more_set_headers "content-security-policy: $CSP";
 spec:
   {{- if $ingressFieldNotAnnotation }}
   ingressClassName: "{{ .Values.config.ingressClass }}"

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -10,8 +10,8 @@ metadata:
     kubernetes.io/ingress.class: "{{ .Values.config.ingressClass }}"
     {{- end }}
     {{ if .Values.config.renderCSPInIngress }}
-    {{ if ne .Values.config.ingressClass "nginx"}}
-        {{ fail "In ingress CSP header setting only works with 'nginx' controller." }}
+    {{ if not (contains .Values.config.ingressClass "nginx") }}
+        {{ fail "In ingress CSP header setting only works with a 'nginx' controller. (Rename it to 'nginx-*' if it is one.)" }}
     {{ end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       set $CSP "connect-src 'self' blob: data: https://*.giphy.com https://{{ .Values.config.dns.https }}";

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -4,7 +4,7 @@
 apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: nginx-ingress-{{ .Values.color }}
+  name: nginx-ingress-{{ .Values.ingressName }}
   annotations:
     {{- if not $ingressFieldNotAnnotation }}
     kubernetes.io/ingress.class: "{{ .Values.config.ingressClass }}"

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -4,7 +4,7 @@
 apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: nginx-ingress-{{ .Values.ingressName }}
+  name: {{ include "nginx-ingress-services.getIngressName" . | quote }}
   annotations:
     {{- if not $ingressFieldNotAnnotation }}
     kubernetes.io/ingress.class: "{{ .Values.config.ingressClass }}"

--- a/charts/nginx-ingress-services/templates/ingress_federator.yaml
+++ b/charts/nginx-ingress-services/templates/ingress_federator.yaml
@@ -2,6 +2,9 @@
 {{- $ingressFieldNotAnnotation := eq (include "ingress.FieldNotAnnotation" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
 {{- if .Values.federator.enabled }}
+{{- if .Values.config.isAdditionalIngress -}}
+  {{ fail "Federation and multi-backend-domain (multi-ingress) cannot be configured together." }}
+{{- end -}}
 # We use a separate ingress for federator so that we can require client
 # certificates only for federation requests
 apiVersion: {{ include "ingress.apiVersion" . }}

--- a/charts/nginx-ingress-services/templates/issuer.yaml
+++ b/charts/nginx-ingress-services/templates/issuer.yaml
@@ -6,7 +6,7 @@ kind: "{{ .Values.tls.issuer.kind }}"
 {{- fail (cat ".tls.issuer.kind can only be one of Issuer or ClusterIssuer, got: " .tls.issuer.kind )}}
 {{- end }}
 metadata:
-  name: {{ .Values.tls.issuer.name }}
+  name: {{ .Values.tls.issuer.name }}-{{ .Values.color }}
   {{- if eq .Values.tls.issuer.kind "Issuer" }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/charts/nginx-ingress-services/templates/issuer.yaml
+++ b/charts/nginx-ingress-services/templates/issuer.yaml
@@ -6,7 +6,7 @@ kind: "{{ .Values.tls.issuer.kind }}"
 {{- fail (cat ".tls.issuer.kind can only be one of Issuer or ClusterIssuer, got: " .tls.issuer.kind )}}
 {{- end }}
 metadata:
-  name: {{ .Values.tls.issuer.name }}-{{ .Values.color }}
+  name: {{ .Values.tls.issuer.name }}-{{ .Values.ingressName }}
   {{- if eq .Values.tls.issuer.kind "Issuer" }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/charts/nginx-ingress-services/templates/issuer.yaml
+++ b/charts/nginx-ingress-services/templates/issuer.yaml
@@ -6,7 +6,7 @@ kind: "{{ .Values.tls.issuer.kind }}"
 {{- fail (cat ".tls.issuer.kind can only be one of Issuer or ClusterIssuer, got: " .tls.issuer.kind )}}
 {{- end }}
 metadata:
-  name: {{ .Values.tls.issuer.name }}-{{ .Values.ingressName }}
+  name: {{ include "nginx-ingress-services.getIssuerName" . | quote }}
   {{- if eq .Values.tls.issuer.kind "Issuer" }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/charts/nginx-ingress-services/templates/issuer.yaml
+++ b/charts/nginx-ingress-services/templates/issuer.yaml
@@ -20,7 +20,7 @@ spec:
     email: {{ required "Missing value: certmasterEmail" .Values.certManager.certmasterEmail | quote }}
     # NOTE: this secret doesnt need to be created, it only gets a name with this
     privateKeySecretRef:
-      name: letsencrypt-http01-account-key
+      name: {{ include "nginx-ingress-services.getIssuerName" . -}}-account-key
     solvers:
 {{- if .Values.certManager.customSolvers }}
 {{ toYaml .Values.certManager.customSolvers | indent 6 }}

--- a/charts/nginx-ingress-services/templates/secret_federator.yaml
+++ b/charts/nginx-ingress-services/templates/secret_federator.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.federator.enabled (not .Values.tls.useCertManager) }}
+{{- if .Values.config.isAdditionalIngress -}}
+  {{ fail "Federation and multi-backend-domain (multi-ingress) cannot be configured together." }}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/nginx-ingress-services/templates/service.yaml
+++ b/charts/nginx-ingress-services/templates/service.yaml
@@ -1,4 +1,5 @@
 # FUTUREWORK: move services into the respective charts
+{{- if not .Values.config.isAdditionalIngress }}
 {{- if .Values.webapp.enabled }}
 ---
 apiVersion: v1
@@ -54,4 +55,5 @@ spec:
       targetPort: 8080
   selector:
     app: account-pages
+{{- end }}
 {{- end }}

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -42,6 +42,14 @@ tls:
     name: letsencrypt-http01
     kind: Issuer # Issuer | ClusterIssuer
 
+# Name of the ingress.
+#
+# If there is only one backend domain to be served, this can stay 'default'
+# (doesn't need to be changed.) If there are multiple backend domains
+# (multi-ingress setup), use a descriptive name per backend domain. Technically,
+# this value can be any string.
+ingressName: default
+
 certManager:
   # Indicates whether Letsencrypt's staging API server is used and therefore certificates are NOT trusted
   # default: production API server is used and certificates are trusted

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -95,6 +95,7 @@ config:
   ingressClass: "nginx"
 # You will need to supply some DNS names, namely
 #   dns:
+#     base: <domain>
 #     https: nginz-https.<domain>
 #     ssl: nginz-ssl.<domain> # For websockets
 #     ^ ssl is ignored if websockets.enabled == false

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -104,6 +104,7 @@ config:
 # You will need to supply some DNS names, namely
 #   dns:
 #     base: <domain>
+#     ^ base is only needed to render multi-backend-domain (multi-ingress) CSP headers
 #     https: nginz-https.<domain>
 #     ssl: nginz-ssl.<domain> # For websockets
 #     ^ ssl is ignored if websockets.enabled == false
@@ -139,3 +140,15 @@ config:
 #       we do not want to create yet another service here but rather
 #       use that service instead in the ingress
 #     serviceName: minio-external
+
+# Configure CSP headers directly in the ingress.
+#
+# This is only suggested / needed in setups with multiple backend domains
+# (multi-ingress), because the webapps can only provide CSP headers for one
+# (root) domain.
+  renderCSPInIngress: false
+# Is this a chart instantiation for an additional backend domain (multi-ingress)?
+#
+# If 'true' some resources aren't created because they're expected to already
+# exist. There must be one non-additional instantiation per deployment!
+  isAdditionalIngress: false

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -44,11 +44,11 @@ tls:
 
 # Name of the ingress.
 #
-# If there is only one backend domain to be served, this can stay 'default'
-# (doesn't need to be changed.) If there are multiple backend domains
+# If there is only one backend domain to be served, this can stay the empty
+# string (doesn't need to be changed.) If there are multiple backend domains
 # (multi-ingress setup), use a descriptive name per backend domain. Technically,
 # this value can be any string.
-ingressName: default
+ingressName: ""
 
 certManager:
   # Indicates whether Letsencrypt's staging API server is used and therefore certificates are NOT trusted

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -39,6 +39,10 @@ tls:
   verify_depth: 1
   createIssuer: true
   issuer:
+    # In a multi-domain backend (multi-ingress) setup, this name will be
+    # augmented with the 'ingressName' (e.g. 'letsencrypt-http01-<ingressName>')
+    # to ensure that certificates aren't created by the same issuer, which would
+    # leak a hint about a common origin.
     name: letsencrypt-http01
     kind: Issuer # Issuer | ClusterIssuer
 


### PR DESCRIPTION
Brings back the changes reverted with https://github.com/wireapp/wire-server/pull/3399 (which reverted https://github.com/wireapp/wire-server/pull/3375 .)

Add backwards compatibility to existing deployments by ensuring that the existing ingress is replaced when the default settings are applied. This happens by using the same name.
(Helm isn't smart enough to understand that the ingress had a changed name.)

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
