### PR TITLE
Removing domain sync threads where not currently used.

### DIFF
--- a/changelog.d/0-release-notes/domain-sync-thread-cleanup
+++ b/changelog.d/0-release-notes/domain-sync-thread-cleanup
@@ -1,0 +1,1 @@
+Removed brig configuration value from gundeck.

--- a/charts/gundeck/templates/configmap.yaml
+++ b/charts/gundeck/templates/configmap.yaml
@@ -13,10 +13,6 @@ data:
       host: 0.0.0.0
       port: {{ $.Values.service.internalPort }}
 
-    brig:
-      host: brig
-      port: 8080
-
     cassandra:
       endpoint:
         host: {{ .cassandra.host }}

--- a/libs/wire-api/src/Wire/API/FederationUpdate.hs
+++ b/libs/wire-api/src/Wire/API/FederationUpdate.hs
@@ -32,9 +32,9 @@ syncFedDomainConfigs (Endpoint h p) log' cb = do
 -- | Initial function for getting the set of domains from brig, and an update interval
 initialize :: L.Logger -> ClientEnv -> IO FederationDomainConfigs
 initialize logger clientEnv =
-  let -- keep trying every 3s for one minute
+  let -- An initial value of 100000 is used throughout services. Another commonly used value is 50000
       policy :: R.RetryPolicy
-      policy = R.constantDelay 3_081_003 <> R.limitRetries 20
+      policy = R.exponentialBackoff 100000 <> R.limitRetries 20
 
       go :: IO (Maybe FederationDomainConfigs)
       go = do

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -108,7 +108,6 @@ import qualified UnliftIO.Exception as UnliftIO
 import Util.Options
 import Wire.API.Error
 import Wire.API.Federation.Error
-import Wire.API.Routes.FederationDomainConfig
 import qualified Wire.Sem.Logger
 
 -- Effects needed by the interpretation of other effects
@@ -156,8 +155,8 @@ validateOptions l o = do
     (Just _, Nothing) -> error "Federator is specified and RabbitMQ config is not, please specify both or none"
     _ -> pure ()
 
-createEnv :: Metrics -> Opts -> Logger -> IORef FederationDomainConfigs -> IO Env
-createEnv m o l r = do
+createEnv :: Metrics -> Opts -> Logger -> IO Env
+createEnv m o l = do
   cass <- initCassandra o l
   mgr <- initHttpManager o
   h2mgr <- initHttp2Manager
@@ -168,7 +167,6 @@ createEnv m o l r = do
     <*> maybe (pure Nothing) (fmap Just . Aws.mkEnv l mgr) (o ^. optJournal)
     <*> loadAllMLSKeys (fold (o ^. optSettings . setMlsPrivateKeyPaths))
     <*> traverse (mkRabbitMqChannelMVar l) (o ^. optRabbitmq)
-    <*> pure r
 
 initCassandra :: Opts -> Logger -> IO ClientState
 initCassandra o l = do

--- a/services/galley/src/Galley/Env.hs
+++ b/services/galley/src/Galley/Env.hs
@@ -42,7 +42,6 @@ import System.Logger
 import Util.Options
 import Wire.API.MLS.Credential
 import Wire.API.MLS.Keys
-import Wire.API.Routes.FederationDomainConfig (FederationDomainConfigs)
 import Wire.API.Team.Member
 
 data DeleteItem = TeamItem TeamId UserId (Maybe ConnId)
@@ -63,8 +62,7 @@ data Env = Env
     _extEnv :: ExtEnv,
     _aEnv :: Maybe Aws.Env,
     _mlsKeys :: SignaturePurpose -> MLSKeys,
-    _rabbitmqChannel :: Maybe (MVar Q.Channel),
-    _fedDomains :: IORef FederationDomainConfigs
+    _rabbitmqChannel :: Maybe (MVar Q.Channel)
   }
 
 -- | Environment specific to the communication with external

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -61,14 +61,13 @@ import Servant hiding (route)
 import qualified System.Logger as Log
 import System.Logger.Extended (mkLogger)
 import Util.Options
-import Wire.API.FederationUpdate
 import Wire.API.Routes.API
 import qualified Wire.API.Routes.Public.Galley as GalleyAPI
 import Wire.API.Routes.Version.Wai
 
 run :: Opts -> IO ()
 run opts = lowerCodensity $ do
-  (app, env, syndFedDomainConfigsThread) <- mkApp opts
+  (app, env) <- mkApp opts
   settings <-
     lift $
       newSettings $
@@ -82,15 +81,14 @@ run opts = lowerCodensity $ do
     void $ Codensity $ Async.withAsync $ collectAuthMetrics (env ^. monitor) (aws ^. awsEnv)
   void $ Codensity $ Async.withAsync $ runApp env deleteLoop
   void $ Codensity $ Async.withAsync $ runApp env refreshMetrics
-  lift $ finally (runSettingsWithShutdown settings app Nothing) (closeApp env syndFedDomainConfigsThread)
+  lift $ finally (runSettingsWithShutdown settings app Nothing) (closeApp env)
 
-mkApp :: Opts -> Codensity IO (Application, Env, Async.Async ())
+mkApp :: Opts -> Codensity IO (Application, Env)
 mkApp opts =
   do
     logger <- lift $ mkLogger (opts ^. optLogLevel) (opts ^. optLogNetStrings) (opts ^. optLogFormat)
-    (fedDoms, syndFedDomainConfigsThread) <- lift $ syncFedDomainConfigs (opts ^. optBrig) logger emptySyncFedDomainConfigsCallback
     metrics <- lift $ M.metrics
-    env <- lift $ App.createEnv metrics opts logger fedDoms
+    env <- lift $ App.createEnv metrics opts logger
     lift $ runClient (env ^. cstate) $ versionCheck schemaVersion
     let middlewares =
           versionMiddleware (opts ^. optSettings . setDisabledAPIVersions . traverse)
@@ -102,7 +100,7 @@ mkApp opts =
       Log.info logger $ Log.msg @Text "Galley application finished."
       Log.flush logger
       Log.close logger
-    pure (middlewares $ servantApp env, env, syndFedDomainConfigsThread)
+    pure (middlewares $ servantApp env, env)
   where
     rtree = compile API.sitemap
     runGalley e r k = evalGalleyToIO e (route rtree r k)
@@ -125,10 +123,9 @@ mkApp opts =
     lookupReqId :: Request -> RequestId
     lookupReqId = maybe def RequestId . lookup requestIdName . requestHeaders
 
-closeApp :: Env -> Async.Async () -> IO ()
-closeApp env syndFedDomainConfigsThread = do
+closeApp :: Env -> IO ()
+closeApp env = do
   shutdown (env ^. cstate)
-  Async.cancel syndFedDomainConfigsThread
 
 customFormatters :: Servant.ErrorFormatters
 customFormatters =

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2467,7 +2467,7 @@ instance HasSettingsOverrides TestM where
     ts :: TestSetup <- ask
     let opts = f (ts ^. tsGConf)
     liftIO . lowerCodensity $ do
-      (galleyApp, _env, _thread) <- Run.mkApp opts -- FUTUREWORK: always call Run.closeApp at the end.
+      (galleyApp, _env) <- Run.mkApp opts -- FUTUREWORK: always call Run.closeApp at the end.
       port' <- withMockServer galleyApp
       liftIO $
         runReaderT

--- a/services/gundeck/gundeck.integration.yaml
+++ b/services/gundeck/gundeck.integration.yaml
@@ -2,10 +2,6 @@ gundeck:
   host: 0.0.0.0
   port: 8086
 
-brig:
-  host: 0.0.0.0
-  port: 8082
-
 cassandra:
   endpoint:
     host: 127.0.0.1

--- a/services/gundeck/src/Gundeck/Options.hs
+++ b/services/gundeck/src/Gundeck/Options.hs
@@ -116,7 +116,6 @@ deriveFromJSON toOptionFieldName ''Settings
 data Opts = Opts
   { -- | Hostname and port to bind to
     _optGundeck :: !Endpoint,
-    _optBrig :: !Endpoint,
     _optCassandra :: !CassandraOpts,
     _optRedis :: !RedisEndpoint,
     _optRedisAdditionalWrite :: !(Maybe RedisEndpoint),

--- a/services/gundeck/src/Gundeck/Run.hs
+++ b/services/gundeck/src/Gundeck/Run.hs
@@ -52,7 +52,6 @@ import qualified Servant
 import qualified System.Logger as Log
 import qualified UnliftIO.Async as Async
 import Util.Options
-import Wire.API.FederationUpdate
 import Wire.API.Routes.Public.Gundeck (GundeckAPI)
 import Wire.API.Routes.Version.Wai
 
@@ -66,9 +65,6 @@ run o = do
   s <- newSettings $ defaultServer (unpack $ o ^. optGundeck . epHost) (o ^. optGundeck . epPort) l m
   let throttleMillis = fromMaybe defSqsThrottleMillis $ o ^. (optSettings . setSqsThrottleMillis)
 
-  -- Get the federation domain list from Brig and start the updater loop
-  (_, updateDomainsThread) <- syncFedDomainConfigs (o ^. optBrig) l emptySyncFedDomainConfigsCallback
-
   lst <- Async.async $ Aws.execute (e ^. awsEnv) (Aws.listen throttleMillis (runDirect e . onEvent))
   wtbs <- forM (e ^. threadBudgetState) $ \tbs -> Async.async $ runDirect e $ watchThreadBudgetState m tbs 10
   wCollectAuth <- Async.async (collectAuthMetrics m (Aws._awsEnv (Env._awsEnv e)))
@@ -77,7 +73,6 @@ run o = do
     shutdown (e ^. cstate)
     Async.cancel lst
     Async.cancel wCollectAuth
-    Async.cancel updateDomainsThread
     forM_ wtbs Async.cancel
     forM_ rThreads Async.cancel
     Redis.disconnect =<< takeMVar (e ^. rstate)


### PR DESCRIPTION
- Remove the domain sync thread from galley and gundeck.
- Remove the brig config value from gundeck.

## Checklist

 - [:heavy_check_mark:] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [:heavy_check_mark:] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
