### PR TITLE
changelog: drop changelog.d/gundeck-integration-test-docs

### DIFF
--- a/changelog.d/gundeck-integration-test-docs
+++ b/changelog.d/gundeck-integration-test-docs
@@ -1,1 +1,0 @@
-Documentation on what SNS platform applications the gundeck integration test expects was added.


### PR DESCRIPTION
This probably should have gotten into one of the subdirectories (internal maybe), but considering the PR was already released, there's no point including this in a future changelog, so best to just remove it now.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
