### PR TITLE
Make use of deduplication for MLS

### DIFF
--- a/hack/bin/performance.py
+++ b/hack/bin/performance.py
@@ -75,8 +75,8 @@ def simplify_body(content):
             else:
                 return content
         except Exception:
-            b = b64encode(content).decode("utf8")
-            return {"base64data": b, "comment": "binary blob has been replaced"}
+            b = b64encode(content).decode("utf8")[:1000]
+            return {"base64data": b, "comment": "binary blob has been replaced (and truncated)"}
 
 
 def simplify_response(response):
@@ -323,7 +323,7 @@ def save(res, path):
     if not os.path.exists(d):
         os.makedirs(d)
     save_json_file(b, path)
-    print(f"Saving to {path}")
+    # print(f"Saving to {path}")
     return b
 
 
@@ -816,13 +816,14 @@ def main_send(basedir):
 
         msg = random_msg()
         log.log("message_send_begin")
+        msg = create_application_message(admin_client_state, msg)["message"]
+        tbefore = time.time()
         res_test_msg = save(
-            api.mls_send_message(
-                ctx, create_application_message(admin_client_state, msg)["message"],
-                client=client_id
-            ),
+            api.mls_send_message(ctx, msg, client=client_id),
             j(ud, "res_test_msg.json"),
         )
+        tafter = time.time()
+        print(f'Message sending took {tafter-tbefore}')
         log.log("message_send_end")
         simple_expect_status(201, res_test_msg)
 

--- a/hack/python/wire/api.py
+++ b/hack/python/wire/api.py
@@ -4,6 +4,7 @@ way that it can be used in multiple contexts. Generality is achieved via the
 """
 
 from base64 import b64encode
+import time
 import json
 import random
 import requests
@@ -134,13 +135,17 @@ def mls_welcome(ctx, user, welcome):
 
 def mls_post_commit_bundle(ctx, client, commit_bundle):
     url = ctx.mkurl("galley", f"/mls/commit-bundles")
-    return ctx.request(
+    tbefore = time.time()
+    res = ctx.request(
         "POST",
         url,
         headers={"Content-Type": "message/mls"},
         client=client,
         data=commit_bundle,
     )
+    tafter = time.time()
+    print(f'posting commit bundle took {tafter-tbefore:.0f} seconds')
+    return res
 
 
 def mls_send_message(ctx, msg, **kwargs):

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -680,10 +680,8 @@ onMLSMessageSent domain rmm =
             Event (tUntagged rcnv) (F.rmmSubConversation rmm) (F.rmmSender rmm) (F.rmmTime rmm) $
               EdMLSMessage (fromBase64ByteString (F.rmmMessage rmm))
 
-      -- FUTUREWORK: Send only 1 push, after broken Eq, Ord instances of Recipient is fixed. Find other place via tag [FTRPUSHORD]
-      for_ recipients $ \(u, c) -> do
-        runMessagePush loc (Just (tUntagged rcnv)) $
-          newMessagePush mempty Nothing (F.rmmMetadata rmm) [(u, c)] e
+      runMessagePush loc (Just (tUntagged rcnv)) $
+        newMessagePush mempty Nothing (F.rmmMetadata rmm) recipients e
 
 queryGroupInfo ::
   ( Member ConversationStore r,

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -85,10 +85,8 @@ propagateMessage qusr mSenderClient lConvOrSub con msg cm = do
       sconv = snd (qUnqualified qt)
       e = Event qcnv sconv qusr now $ EdMLSMessage msg.raw
 
-  -- FUTUREWORK: Send only 1 push, after broken Eq, Ord instances of Recipient is fixed. Find other place via tag [FTRPUSHORD]
-  for_ (lmems >>= localMemberMLSClients mlsConv) $ \(u, c) ->
-    runMessagePush lConvOrSub (Just qcnv) $
-      newMessagePush botMap con mm [(u, c)] e
+  runMessagePush lConvOrSub (Just qcnv) $
+    newMessagePush botMap con mm (lmems >>= localMemberMLSClients mlsConv) e
 
   -- send to remotes
   unreachableFromList . concat

--- a/services/galley/src/Galley/API/MLS/Welcome.hs
+++ b/services/galley/src/Galley/API/MLS/Welcome.hs
@@ -87,10 +87,8 @@ sendLocalWelcomes ::
   Sem r ()
 sendLocalWelcomes qcnv qusr con now welcome lclients = do
   let e = Event qcnv Nothing qusr now $ EdMLSWelcome welcome.raw
-  -- FUTUREWORK: Send only 1 push, after broken Eq, Ord instances of Recipient is fixed. Find other place via tag [FTRPUSHORD]
-  for_ (tUnqualified lclients) $ \(u, c) ->
-    runMessagePush lclients (Just qcnv) $
-      newMessagePush mempty con defMessageMetadata [(u, c)] e
+  runMessagePush lclients (Just qcnv) $
+    newMessagePush mempty con defMessageMetadata (tUnqualified lclients) e
 
 sendRemoteWelcomes ::
   ( Member FederatorAccess r,


### PR DESCRIPTION
This PR changes the way welcomes and all mls messages are stored for fanned out to recipients in gundeck: Message payloads are only saved once per push:
https://github.com/wireapp/wire-server/pull/3403
