### PR TITLE
K8s integration tests: Disable persistence for `redis-cluster` and `rabbitmq`

### DIFF
--- a/charts/redis-cluster/requirements.yaml
+++ b/charts/redis-cluster/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis-cluster
-  version: 8.6.0
+  version: 8.6.6
   repository: https://charts.bitnami.com/bitnami

--- a/charts/redis-cluster/requirements.yaml
+++ b/charts/redis-cluster/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis-cluster
-  version: 7.6.4
+  version: 8.6.0
   repository: https://charts.bitnami.com/bitnami

--- a/hack/helm_vars/rabbitmq/values.yaml.gotmpl
+++ b/hack/helm_vars/rabbitmq/values.yaml.gotmpl
@@ -1,9 +1,6 @@
-global:
-  storageClass: {{ .Values.storageClass }}
-
 rabbitmq:
   persistence:
-    size: 100Mi
+    enabled: false
   auth:
     username: {{ .Values.rabbitmqUsername }}
     password: {{ .Values.rabbitmqPassword }}

--- a/hack/helm_vars/rabbitmq/values.yaml.gotmpl
+++ b/hack/helm_vars/rabbitmq/values.yaml.gotmpl
@@ -1,6 +1,9 @@
+global:
+  storageClass: {{ .Values.storageClass }}
+
 rabbitmq:
   persistence:
-    enabled: false
+    size: 100Mi
   auth:
     username: {{ .Values.rabbitmqUsername }}
     password: {{ .Values.rabbitmqPassword }}

--- a/hack/helm_vars/redis-cluster/values.yaml.gotmpl
+++ b/hack/helm_vars/redis-cluster/values.yaml.gotmpl
@@ -1,8 +1,3 @@
-global:
-  storageClass: {{ .Values.storageClass }}
-
 redis-cluster:
   persistence:
-    size: 100Mi
-  volumePermissions:
-    enabled: true
+    enabled: false

--- a/hack/helm_vars/redis-cluster/values.yaml.gotmpl
+++ b/hack/helm_vars/redis-cluster/values.yaml.gotmpl
@@ -1,3 +1,9 @@
+global:
+  storageClass: {{ .Values.storageClass }}
+
 redis-cluster:
   persistence:
     enabled: false
+
+ volumePermissions:
+   enabled: true


### PR DESCRIPTION
Motivation: Disable persistence for `redis-cluster` and `rabbitmq` for k8s run integration tests.

Disabling persistence became a feature of `redis-cluster` in chart version `8.3.0`: https://github.com/bitnami/charts/commit/eba6b1bc10f4bcf6bb2748c1106be94a17fcc439
but `8.3.0` is not available in the repo. I found `8.6.6` is available.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
