### PR TITLE
Disable persistence for redis-cluster in tests (upgrade helm chart with overwritten image)

### DIFF
--- a/charts/redis-cluster/requirements.yaml
+++ b/charts/redis-cluster/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis-cluster
-  version: 7.6.4
+  version: 8.6.6
   repository: https://charts.bitnami.com/bitnami

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -1,3 +1,5 @@
 redis-cluster:
   usePassword: false
   fullnameOverride: "redis-cluster"
+  image:
+    tag: 6.2.13

--- a/hack/helm_vars/redis-cluster/values.yaml.gotmpl
+++ b/hack/helm_vars/redis-cluster/values.yaml.gotmpl
@@ -4,6 +4,5 @@ global:
 redis-cluster:
   persistence:
     enabled: false
-
- volumePermissions:
-   enabled: true
+  volumePermissions:
+    enabled: true

--- a/hack/helm_vars/redis-cluster/values.yaml.gotmpl
+++ b/hack/helm_vars/redis-cluster/values.yaml.gotmpl
@@ -3,6 +3,7 @@ global:
 
 redis-cluster:
   persistence:
-    size: 100Mi
-  volumePermissions:
-    enabled: true
+    enabled: false
+
+ volumePermissions:
+   enabled: true


### PR DESCRIPTION
## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
