### PR TITLE
Update webapp version in Helm chart [skip ci]

### DIFF
--- a/changelog.d/0-release-notes/webapp-upgrade
+++ b/changelog.d/0-release-notes/webapp-upgrade
@@ -1,1 +1,1 @@
-Upgrade webapp version to 2023-05-30-production.0-v0.31.16-0-1b2370b
+Upgrade webapp version to 2023-07-13-production.0-v0.31.16-0-a9b67c6

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -9,7 +9,7 @@ resources:
     cpu: "1"
 image:
   repository: quay.io/wire/webapp
-  tag: "2023-05-30-production.0-v0.31.16-0-1b2370b"
+  tag: "2023-07-13-production.0-v0.31.16-0-a9b67c6"
 service:
   https:
     externalPort: 443


### PR DESCRIPTION
Image tag: `2023-07-13-production.0-v0.31.16-0-a9b67c6`
Release: [`2023-07-13-production.0`](https://github.com/wireapp/wire-webapp/releases/tag/2023-07-13-production.0)