### PR TITLE
WPB 2565 remove indexed billing members feature flag

### DIFF
--- a/changelog.d/2-features/remove-indexed-billing-members-feature
+++ b/changelog.d/2-features/remove-indexed-billing-members-feature
@@ -1,0 +1,1 @@
+Enable indexed billing members by default and remove the feature flag

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -60,9 +60,6 @@ data:
       exposeInvitationURLsTeamAllowlist: {{ .settings.exposeInvitationURLsTeamAllowlist }}
       {{- end }}
       conversationCodeURI: {{ .settings.conversationCodeURI | quote }}
-      {{- if .settings.enableIndexedBillingTeamMembers }}
-      enableIndexedBillingTeamMembers: {{ .settings.enableIndexedBillingTeamMembers }}
-      {{- end }}
       federationDomain: {{ .settings.federationDomain }}
       {{- if $.Values.secrets.mlsPrivateKeys }}
       mlsPrivateKeyPaths:

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -34,9 +34,6 @@ config:
     exposeInvitationURLsTeamAllowlist: []
     maxConvSize: 500
     intraListing: true
-    # Before making indexedBillingTeamMember true while upgrading, please
-    # refer to notes here: https://github.com/wireapp/wire-server-deploy/releases/tag/v2020-05-15
-    indexedBillingTeamMember: false
     # Disable one ore more API versions. Please make sure the configuration value is the same in all these charts:
     # brig, cannon, cargohold, galley, gundeck, proxy, spar.
     # disabledAPIVersions: [ v3 ]

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -9,25 +9,6 @@ the Wire backend services.
 
 ## Settings in galley
 
-```
-# [galley.yaml]
-settings:
-  enableIndexedBillingTeamMembers: false
-```
-
-### Indexed Billing Team Members
-
-Use indexed billing team members for journaling. When `enabled`,
-galley would use the `billing_team_member` table to send billing
-events with user ids of team owners (who have the `SetBilling`
-permission). Before enabling this flag, the `billing_team_member`
-table must be backfilled.
-
-Even when the flag is `disabled`, galley will keep writing to the
-`biling_team_member` table, this flag only affects the reads and has
-been added in order to deploy new code and backfill data in
-production.
-
 ### MLS private key paths
 
 Note: This developer documentation. Documentation for site operators can be found here: {ref}`mls-message-layer-security`

--- a/flaky-tests.yaml
+++ b/flaky-tests.yaml
@@ -39,18 +39,6 @@
       Use -p '(!/turn/&&!/user.auth.cookies.limit/)&&/max active tokens/' to rerun this test only.
 
 -
-  test_name: "send billing events to some owners in large teams (indexedBillingTeamMembers disabled)"
-  comments: |
-    Error message: create team: Expected 1 TeamActivate, got nothing
-
-    CallStack (from HasCallStack):
-      assertFailure, called at test/integration/API/SQS.hs:74:32 in main:API.SQS
-      tActivate, called at test/integration/API/SQS.hs:78:47 in main:API.SQS
-      assertTeamActivate, called at test/integration/API/Util.hs:191:3 in main:API.Util
-      createBindingTeam', called at test/integration/API/Util.hs:183:20 in main:API.Util
-      createBindingTeam, called at test/integration/API/Teams.hs:1546:25 in main:API.Teams
-
--
   test_name: "delete team conversation"
   comments: |
     Exception: unexpected notification received

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -184,7 +184,6 @@ galley:
       maxFanoutSize: 18
       maxConvSize: 16
       conversationCodeURI: https://kube-staging-nginz-https.zinfra.io/conversation-join/
-      enableIndexedBillingTeamMembers: true
       # See helmfile for the real value
       federationDomain: integration.example.com
       featureFlags:

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -40,7 +40,6 @@ settings:
   conversationCodeURI: https://account.wire.com/conversation-join/
   concurrentDeletionEvents: 1024
   deleteConvThrottleMillis: 0
-  enableIndexedBillingTeamMembers: true
   #   Federation domain is used to qualify local IDs and handles,
   #   e.g. 0c4d8944-70fa-480e-a8b7-9d929862d18c@wire.com and somehandle@wire.com.
   #   It should also match the SRV DNS records under which other wire-server installations can find this backend:

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -132,19 +132,6 @@ validateOptions :: Logger -> Opts -> IO ()
 validateOptions l o = do
   let settings = view optSettings o
       optFanoutLimit = fromIntegral . fromRange $ currentFanoutLimit o
-  when
-    ( isJust (o ^. optJournal)
-        && settings ^. setMaxTeamSize > optFanoutLimit
-    )
-    $ Logger.warn
-      l
-      ( msg
-          . val
-          $ "You're journaling events for teams larger than "
-            <> toByteString' optFanoutLimit
-            <> " may have some admin user ids missing. \
-               \ This is fine for testing purposes but NOT for production use!!"
-      )
   when (settings ^. setMaxConvSize > fromIntegral optFanoutLimit) $
     error "setMaxConvSize cannot be > setTruncationLimit"
   when (settings ^. setMaxTeamSize < optFanoutLimit) $

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -50,7 +50,6 @@ import qualified Cassandra as C
 import qualified Cassandra.Settings as C
 import Control.Error hiding (err)
 import Control.Lens hiding ((.=))
-import Data.ByteString.Conversion (toByteString')
 import Data.Default (def)
 import qualified Data.List.NonEmpty as NE
 import Data.Metrics.Middleware
@@ -128,8 +127,8 @@ type GalleyEffects0 =
 type GalleyEffects = Append GalleyEffects1 GalleyEffects0
 
 -- Define some invariants for the options used
-validateOptions :: Logger -> Opts -> IO ()
-validateOptions l o = do
+validateOptions :: Opts -> IO ()
+validateOptions o = do
   let settings = view optSettings o
       optFanoutLimit = fromIntegral . fromRange $ currentFanoutLimit o
   when (settings ^. setMaxConvSize > fromIntegral optFanoutLimit) $
@@ -146,7 +145,7 @@ createEnv m o l = do
   cass <- initCassandra o l
   mgr <- initHttpManager o
   h2mgr <- initHttp2Manager
-  validateOptions l o
+  validateOptions o
   Env def m o l mgr h2mgr (o ^. optFederator) (o ^. optBrig) cass
     <$> Q.new 16000
     <*> initExtEnv

--- a/services/galley/src/Galley/App.hs
+++ b/services/galley/src/Galley/App.hs
@@ -135,7 +135,6 @@ validateOptions l o = do
   when
     ( isJust (o ^. optJournal)
         && settings ^. setMaxTeamSize > optFanoutLimit
-        && not (settings ^. setEnableIndexedBillingTeamMembers . to (fromMaybe False))
     )
     $ Logger.warn
       l

--- a/services/galley/src/Galley/Options.hs
+++ b/services/galley/src/Galley/Options.hs
@@ -30,7 +30,6 @@ module Galley.Options
     setConcurrentDeletionEvents,
     setDeleteConvThrottleMillis,
     setFederationDomain,
-    setEnableIndexedBillingTeamMembers,
     setMlsPrivateKeyPaths,
     setFeatureFlags,
     defConcurrentDeletionEvents,
@@ -114,7 +113,6 @@ data Settings = Settings
     -- When false, billing information for large teams is not guaranteed to have all
     -- the owners.
     -- Defaults to false.
-    _setEnableIndexedBillingTeamMembers :: !(Maybe Bool),
     _setMlsPrivateKeyPaths :: !(Maybe MLSPrivateKeyPaths),
     -- | FUTUREWORK: 'setFeatureFlags' should be renamed to 'setFeatureConfigs' in all types.
     _setFeatureFlags :: !FeatureFlags,


### PR DESCRIPTION
No release notes necessary because the only affected deployment is Wire Cloud (on-prem don't track billing) which has this feature flag already enabled.
