### PR TITLE
Reproduce the error `parsing set of AccessRole failed`

### DIFF
--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -83,6 +83,7 @@ import Data.Id
 import Data.Int
 import Data.List.Split (chunksOf)
 import qualified Data.Map as Map
+import Wire.API.Routes.Versioned
 import Data.Qualified (qUnqualified)
 import Data.Text (strip)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
@@ -769,7 +770,7 @@ getUserConversations uid = do
                 . maybe id (queryItem "start" . toByteString') start
                 . expect2xx
             )
-      parseResponse (mkError status502 "bad-upstream") r
+      unVersioned @'V2 <$> parseResponse (mkError status502 "bad-upstream") r
     batchSize = 100 :: Int
 
 getUserClients :: UserId -> Handler [Client]

--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -108,7 +108,6 @@ import qualified Wire.API.Routes.Internal.Brig.EJPD as EJPD
 import Wire.API.Routes.Internal.Galley.TeamsIntra
 import qualified Wire.API.Routes.Internal.Galley.TeamsIntra as Team
 import Wire.API.Routes.Version
-import Wire.API.Routes.Versioned
 import Wire.API.Team
 import Wire.API.Team.Feature
 import qualified Wire.API.Team.Feature as Public
@@ -770,7 +769,7 @@ getUserConversations uid = do
                 . maybe id (queryItem "start" . toByteString') start
                 . expect2xx
             )
-      unVersioned @'V2 <$> parseResponse (mkError status502 "bad-upstream") r
+      parseResponse (mkError status502 "bad-upstream") r
     batchSize = 100 :: Int
 
 getUserClients :: UserId -> Handler [Client]

--- a/tools/stern/test/integration/API.hs
+++ b/tools/stern/test/integration/API.hs
@@ -137,11 +137,13 @@ testSearchVisibility = do
 
 testGetUserMetaInfo :: TestM ()
 testGetUserMetaInfo = do
-  uid <- randomUser
+  (uid, tid, member : _) <- createTeamWithNMembers 2
+  _ <- Util.createTeamConv uid tid [member]
   let k = fromMaybe (error "invalid property key") $ fromByteString "WIRE_RECEIPT_MODE"
   putUserProperty uid k "bar"
   -- Just make sure this returns a 200
-  void $ getUserMetaInfo uid
+  r <- getUserMetaInfo uid
+  print r
 
 testPutPhone :: TestM ()
 testPutPhone = do

--- a/tools/stern/test/integration/API.hs
+++ b/tools/stern/test/integration/API.hs
@@ -139,6 +139,7 @@ testGetUserMetaInfo :: TestM ()
 testGetUserMetaInfo = do
   (uid, tid, member : _) <- createTeamWithNMembers 2
   _ <- Util.createTeamConv uid tid [member]
+  void $ addClient uid
   let k = fromMaybe (error "invalid property key") $ fromByteString "WIRE_RECEIPT_MODE"
   putUserProperty uid k "bar"
   -- Just make sure this returns a 200


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-2888

Tried to reproduce the error that occurs on staging and when calling https://staging-backoffice.ops.zinfra.io/swagger-ui/index.html#/default/post_i_user_meta_info by including user conversations and clients. But couldn't reproduce it so far.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
