### PR TITLE
Stern: Reduce batch size to 50 when GetNotifications

### DIFF
--- a/tools/stern/src/Stern/Intra.hs
+++ b/tools/stern/src/Stern/Intra.hs
@@ -856,7 +856,7 @@ getUserNotifications uid = do
         200 -> parseResponse (mkError status502 "bad-upstream") r
         404 -> parseResponse (mkError status502 "bad-upstream") r
         _ -> throwE (mkError status502 "bad-upstream" "")
-    batchSize = 100 :: Int
+    batchSize = 50 :: Int
 
 registerOAuthClient :: OAuthClientConfig -> Handler OAuthClientCredentials
 registerOAuthClient conf = do


### PR DESCRIPTION
[WPB-2888](https://wearezeta.atlassian.net/browse/WPB-2888)

We observed failed requests to galley with batch size = 100 for the user: 241f3fc8-f022-46b3-8c6e-21d0bf297da9

This might be caused by the size of the returning payload for this user.

According to SWAG best practise batch=50 might help

[WPB-2888]: https://wearezeta.atlassian.net/browse/WPB-2888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ