### PR TITLE
Reject stale application messages

### DIFF
--- a/changelog.d/2-features/mls-stale-app-messages
+++ b/changelog.d/2-features/mls-stale-app-messages
@@ -1,0 +1,1 @@
+MLS application messages for older epochs are now rejected

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -392,10 +392,10 @@ postMLSMessageToLocalConv qusr c con msg ctype convOrSubId = do
         throwS @'MLSUnsupportedMessage
 
       -- reject application messages older than 2 epochs
+      let epochInt :: Epoch -> Integer
+          epochInt = fromIntegral . epochNumber
       when
-        ( msg.epoch.epochNumber
-            < convOrSub.mlsMeta.cnvmlsEpoch.epochNumber - 2
-        )
+        (epochInt msg.epoch < epochInt convOrSub.mlsMeta.cnvmlsEpoch - 2)
         $ throwS @'MLSStaleMessage
 
   unreachables <- propagateMessage qusr (Just c) lConvOrSub con msg.rawMessage (tUnqualified lConvOrSub).members


### PR DESCRIPTION
An application message is considered stale if its epoch is 2 or more epochs behind the current epoch. This PR makes it so that stale application messages are rejected. Note that proposal message are still stale as soon as their epoch is older than the current one.

https://wearezeta.atlassian.net/browse/WPB-505

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
