### PR TITLE
Wpb 2824 disable redis persistence (upgrade hedis)

### DIFF
--- a/charts/redis-cluster/requirements.yaml
+++ b/charts/redis-cluster/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis-cluster
-  version: 7.6.4
+  version: 8.6.6
   repository: https://charts.bitnami.com/bitnami

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -1,3 +1,5 @@
 redis-cluster:
   usePassword: false
   fullnameOverride: "redis-cluster"
+  image:
+    tag: 6.2.13

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -1,5 +1,3 @@
 redis-cluster:
   usePassword: false
   fullnameOverride: "redis-cluster"
-  image:
-    tag: 6.2.13

--- a/hack/helm_vars/redis-cluster/values.yaml.gotmpl
+++ b/hack/helm_vars/redis-cluster/values.yaml.gotmpl
@@ -4,6 +4,5 @@ global:
 redis-cluster:
   persistence:
     enabled: false
-
- volumePermissions:
-   enabled: true
+  volumePermissions:
+    enabled: true

--- a/hack/helm_vars/redis-cluster/values.yaml.gotmpl
+++ b/hack/helm_vars/redis-cluster/values.yaml.gotmpl
@@ -3,6 +3,7 @@ global:
 
 redis-cluster:
   persistence:
-    size: 100Mi
-  volumePermissions:
-    enabled: true
+    enabled: false
+
+ volumePermissions:
+   enabled: true

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -188,6 +188,14 @@ let
         sha256 = "sha256-yiw6hg3guRWS6CVdrUY8wyIDxoqfGjIVMrEtP+Fys0Y=";
       };
     };
+    # latest master from 2023-06-13, but not released to hackage yet.
+    hedis = {
+      src = fetchgit {
+        url = "https://github.com/informatikr/hedis.git";
+        rev = "1e7fbf4e52664e3cce3bca35783f11d20f0b1efb";
+        sha256 = "sha256-Ddw9SInJ6oCerg9Se2nFV/OOoaKLEfMTEV00mfTf6/g=";
+      };
+    };
     # Not tested/relased yet
     # https://github.com/dylex/invertible/commit/e203c6a729fde87b1f903c3f468f739a085fb446
     invertible = {


### PR DESCRIPTION
Just to see what breaks - if anything - when we pin hedis to latest version. Follow-up from https://github.com/wireapp/wire-server/pull/3427

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
