### PR TITLE
In CI, use redis-ephemeral master mode

### DIFF
--- a/changelog.d/5-internal/ci-redis-ephemeral
+++ b/changelog.d/5-internal/ci-redis-ephemeral
@@ -1,0 +1,1 @@
+In CI integration tests, use redis-ephemeral in master mode (may be reverted in the future, see PR details)

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -222,8 +222,8 @@ gundeck:
       host: cassandra-ephemeral
       replicaCount: 1
     redis:
-      host: redis-cluster
-      connectionMode: cluster
+      host: redis-ephemeral-master
+      connectionMode: master
     aws:
       account: "123456789012"
       region: eu-west-1

--- a/hack/helmfile.yaml
+++ b/hack/helmfile.yaml
@@ -55,18 +55,6 @@ releases:
     namespace: '{{ .Values.namespace2 }}'
     chart: '../.local/charts/databases-ephemeral'
 
-  - name: 'redis-cluster'
-    namespace: '{{ .Values.namespace1 }}'
-    chart: '../.local/charts/redis-cluster'
-    values:
-      - './helm_vars/redis-cluster/values.yaml.gotmpl'
-
-  - name: 'redis-cluster'
-    namespace: '{{ .Values.namespace2 }}'
-    chart: '../.local/charts/redis-cluster'
-    values:
-      - './helm_vars/redis-cluster/values.yaml.gotmpl'
-
   - name: 'rabbitmq'
     namespace: '{{ .Values.namespace1 }}'
     chart: '../.local/charts/rabbitmq'


### PR DESCRIPTION
We wish to avoid needing persistence during CI runs, as we run into limits of volume creation, which causes integration test setup failures.

This PR can be reverted at some point in the future when:

- hedis code is both compatible with current redis version AND redis version 7 and its tests pass, and it is released to hackage / nixpkgs.
- (or temporarily if you make changes to redis and/or redis code in gundeck and wish to test these changes on CI)

Then:

- Step 1. We can use latest hedis code (and merge this to develop, ensuring this works on staging)
- Step 2: Subsequently this PR can be reverted, and the redis-cluster helm chart bumped, and persistence disabled. See also #3444
- ensure to do steps 1 and 2 on *separate* PRs, to avoid requiring a redis helm chart update concurrently with a code update - that would not work well in production and cause downtime.

Context:

- https://wearezeta.atlassian.net/browse/WPB-2824
- https://wearezeta.atlassian.net/browse/WPB-2783
- https://github.com/wireapp/wire-server/pull/3427
- https://github.com/wireapp/wire-server/pull/3444
- https://github.com/wireapp/wire-server/pull/3445

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
