### PR TITLE
WPB-240: Fixing tests by making defederation tests run last.

### DIFF
--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -267,7 +267,12 @@ tests s =
               test s "send typing indicators without domain" postTypingIndicatorsV2,
               test s "send typing indicators with invalid pyaload" postTypingIndicatorsHandlesNonsense
             ],
-          test s "delete federation notifications" testDefederationNotifications
+          -- NOTE: These federation notification tests need to run after all of the other tests are finished.
+          -- This is because they will send notifications to _ALL_ registered clients for the local domain.
+          -- As a lot of these tests are waiting on specific notifications to come through in a specified
+          -- order, these tests will cause them to fail.
+          -- See the Tasty docs on patterns. https://hackage.haskell.org/package/tasty-1.4.3#patterns
+          after AllFinish "$0 !~ /delete federation notifications/" $ test s "delete federation notifications" API.testDefederationNotifications
         ]
     rb1, rb2, rb3 :: Remote Backend
     rb1 =


### PR DESCRIPTION
Making the defederation notification tests run last.

If these tests run in parallel with other tests, it will cause them to break because it is sending a notification to every registered client. The other tests don't know how to deal with these notifications, so they break. Running this last will sidestep that issue.

## Checklist

 - [:heavy_check_mark:] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [:heavy_check_mark:] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
