### PR TITLE
Support post-quantum MLS ciphersuite

### DIFF
--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -222,9 +222,10 @@ CREATE TABLE brig_test.user_cookies (
 CREATE TABLE brig_test.mls_key_packages (
     user uuid,
     client text,
+    cipher_suite int,
     ref blob,
     data blob,
-    PRIMARY KEY ((user, client), ref)
+    PRIMARY KEY ((user, client, cipher_suite), ref)
 ) WITH CLUSTERING ORDER BY (ref ASC)
     AND bloom_filter_fp_chance = 0.1
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}

--- a/changelog.d/1-api-changes/mls-key-package-ciphersuites
+++ b/changelog.d/1-api-changes/mls-key-package-ciphersuites
@@ -1,0 +1,1 @@
+The key package API has gained a `ciphersuite` query parameter, which should be the hexadecimal value of an MLS ciphersuite, defaulting to `0x0001`. The `ciphersuite` parameter is used by the claim and count endpoints. For uploads, the API is unchanged, and the ciphersuite is taken directly from the uploaded key package.

--- a/changelog.d/2-features/mls-ciphersuites
+++ b/changelog.d/2-features/mls-ciphersuites
@@ -1,0 +1,1 @@
+Added support for post-quantum ciphersuite 0xf031. Correspondingly, MLS groups with a non-default ciphersuite are now supported. The first commit in a group determines the group ciphersuite.

--- a/integration/test/API/Brig.hs
+++ b/integration/test/API/Brig.hs
@@ -264,10 +264,12 @@ claimKeyPackages suite u v = do
     req
       & addQueryParams [("ciphersuite", suite.code)]
 
-countKeyPackages :: ClientIdentity -> App Response
-countKeyPackages cid = do
-  baseRequest cid Brig Versioned ("/mls/key-packages/self/" <> cid.client <> "/count")
-    >>= submit "GET"
+countKeyPackages :: Ciphersuite -> ClientIdentity -> App Response
+countKeyPackages suite cid = do
+  req <- baseRequest cid Brig Versioned ("/mls/key-packages/self/" <> cid.client <> "/count")
+  submit "GET" $
+    req
+      & addQueryParams [("ciphersuite", suite.code)]
 
 deleteKeyPackages :: ClientIdentity -> [String] -> App Response
 deleteKeyPackages cid kps = do

--- a/integration/test/API/Brig.hs
+++ b/integration/test/API/Brig.hs
@@ -254,13 +254,15 @@ uploadKeyPackage cid kp = do
         & addJSONObject ["key_packages" .= [T.decodeUtf8 (Base64.encode kp)]]
     )
 
-claimKeyPackages :: (MakesValue u, MakesValue v) => u -> v -> App Response
-claimKeyPackages u v = do
+claimKeyPackages :: (MakesValue u, MakesValue v) => Ciphersuite -> u -> v -> App Response
+claimKeyPackages suite u v = do
   (targetDom, targetUid) <- objQid v
   req <-
     baseRequest u Brig Versioned $
       "/mls/key-packages/claim/" <> targetDom <> "/" <> targetUid
-  submit "POST" req
+  submit "POST" $
+    req
+      & addQueryParams [("ciphersuite", suite.code)]
 
 countKeyPackages :: ClientIdentity -> App Response
 countKeyPackages cid = do

--- a/integration/test/MLS/Util.hs
+++ b/integration/test/MLS/Util.hs
@@ -131,8 +131,9 @@ createWireClient u = do
 initMLSClient :: HasCallStack => ClientIdentity -> App ()
 initMLSClient cid = do
   bd <- getBaseDir
+  mls <- getMLSState
   liftIO $ createDirectory (bd </> cid2Str cid)
-  void $ mlscli cid ["init", cid2Str cid] Nothing
+  void $ mlscli cid ["init", "--ciphersuite", mls.ciphersuite.code, cid2Str cid] Nothing
 
 -- | Create new mls client and register with backend.
 createMLSClient :: (MakesValue u, HasCallStack) => u -> App ClientIdentity

--- a/integration/test/MLS/Util.hs
+++ b/integration/test/MLS/Util.hs
@@ -373,6 +373,21 @@ createAddProposals cid users = do
   kps <- concat <$> traverse unbundleKeyPackages bundles
   traverse (createAddProposalWithKeyPackage cid) kps
 
+createReInitProposal :: HasCallStack => ClientIdentity -> App MessagePackage
+createReInitProposal cid = do
+  prop <-
+    mlscli
+      cid
+      ["proposal", "--group-in", "<group-in>", "--group-out", "<group-out>", "re-init"]
+      Nothing
+  pure
+    MessagePackage
+      { sender = cid,
+        message = prop,
+        welcome = Nothing,
+        groupInfo = Nothing
+      }
+
 createAddProposalWithKeyPackage ::
   ClientIdentity ->
   (ClientIdentity, ByteString) ->

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -203,7 +203,7 @@ testMixedProtocolAddPartialClients secondDomain = do
 
   -- create add commit for only one of bob's two clients
   do
-    bundle <- claimKeyPackages alice1 bob >>= getJSON 200
+    bundle <- claimKeyPackages def alice1 bob >>= getJSON 200
     kps <- unbundleKeyPackages bundle
     kp1 <- assertOne (filter ((== bob1) . fst) kps)
     mp <- createAddCommitWithKeyPackages alice1 [kp1]
@@ -212,7 +212,7 @@ testMixedProtocolAddPartialClients secondDomain = do
   -- this tests that bob's backend has a mapping of group id to the remote conv
   -- this test is only interesting when bob is on OtherDomain
   do
-    bundle <- claimKeyPackages bob1 bob >>= getJSON 200
+    bundle <- claimKeyPackages def bob1 bob >>= getJSON 200
     kps <- unbundleKeyPackages bundle
     kp2 <- assertOne (filter ((== bob2) . fst) kps)
     mp <- createAddCommitWithKeyPackages bob1 [kp2]
@@ -311,8 +311,10 @@ testMLSProtocolUpgrade secondDomain = do
     resp.status `shouldMatchInt` 200
     resp.json %. "protocol" `shouldMatch` "mls"
 
-testAddUser :: HasCallStack => App ()
-testAddUser = do
+testAddUserSimple :: HasCallStack => Ciphersuite -> App ()
+testAddUserSimple suite = do
+  setMLSCiphersuite suite
+
   [alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
 
   [alice1, bob1, bob2] <- traverse createMLSClient [alice, bob, bob]
@@ -378,8 +380,9 @@ testRemoteRemoveClient = do
     msg %. "message.content.body.Proposal.Remove.removed" `shouldMatchInt` leafIndexBob
     msg %. "message.content.sender.External" `shouldMatchInt` 0
 
-testCreateSubConv :: HasCallStack => App ()
-testCreateSubConv = do
+testCreateSubConv :: HasCallStack => Ciphersuite -> App ()
+testCreateSubConv suite = do
+  setMLSCiphersuite suite
   alice <- randomUser OwnDomain def
   alice1 <- createMLSClient alice
   (_, conv) <- createNewGroup alice1
@@ -499,7 +502,7 @@ testFirstCommitAllowsPartialAdds = do
 
   (_, _qcnv) <- createNewGroup alice1
 
-  bundle <- claimKeyPackages alice1 alice >>= getJSON 200
+  bundle <- claimKeyPackages def alice1 alice >>= getJSON 200
   kps <- unbundleKeyPackages bundle
 
   -- first commit only adds kp for alice2 (not alice2 and alice3)
@@ -525,7 +528,7 @@ testAddUserPartial = do
 
   -- alice sends a commit now, and should get a conflict error
   kps <- fmap concat . for [bob, charlie] $ \user -> do
-    bundle <- claimKeyPackages alice1 user >>= getJSON 200
+    bundle <- claimKeyPackages def alice1 user >>= getJSON 200
     unbundleKeyPackages bundle
   mp <- createAddCommitWithKeyPackages alice1 kps
 

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -316,11 +316,8 @@ testAddUserSimple suite = do
   setMLSCiphersuite suite
 
   [alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
-
   [alice1, bob1, bob2] <- traverse createMLSClient [alice, bob, bob]
-
   traverse_ uploadNewKeyPackage [bob1, bob2]
-
   (_, qcnv) <- createNewGroup alice1
 
   resp <- createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -740,3 +740,16 @@ testCommitNotReferencingAllProposals = do
   bindResponse (postMLSCommitBundle alice1 (mkBundle commit)) $ \resp -> do
     resp.status `shouldMatchInt` 400
     resp.json %. "label" `shouldMatch` "mls-commit-missing-references"
+
+testUnsupportedCiphersuite :: HasCallStack => App ()
+testUnsupportedCiphersuite = do
+  setMLSCiphersuite (Ciphersuite "0x0002")
+  alice <- randomUser OwnDomain def
+  alice1 <- createMLSClient alice
+  void $ createNewGroup alice1
+
+  mp <- createPendingProposalCommit alice1
+
+  bindResponse (postMLSCommitBundle alice1 (mkBundle mp)) $ \resp -> do
+    resp.status `shouldMatchInt` 400
+    resp.json %. "label" `shouldMatch` "mls-protocol-error"

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -669,3 +669,18 @@ testPropInvalidEpoch = do
   setClientGroupState alice1 gsBackup2
   createAddProposals alice1 [dee] >>= traverse_ sendAndConsumeMessage
   void $ createPendingProposalCommit alice1 >>= sendAndConsumeCommitBundle
+
+--- | This test submits a ReInit proposal, which is currently ignored by the
+-- backend, in order to check that unsupported proposal types are accepted.
+testPropUnsupported :: HasCallStack => App ()
+testPropUnsupported = do
+  users@[_alice, bob] <- createAndConnectUsers (replicate 2 OwnDomain)
+  [alice1, bob1] <- traverse createMLSClient users
+  void $ uploadNewKeyPackage bob1
+  void $ createNewGroup alice1
+  void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
+
+  mp <- createReInitProposal alice1
+
+  -- we cannot consume this message, because the membership tag is fake
+  void $ postMLSMessage mp.sender mp.message >>= getJSON 201

--- a/integration/test/Test/MLS/KeyPackage.hs
+++ b/integration/test/Test/MLS/KeyPackage.hs
@@ -46,3 +46,13 @@ testKeyPackageMultipleCiphersuites = do
   bindResponse (countKeyPackages suite alice2) $ \resp -> do
     resp.status `shouldMatchInt` 200
     resp.json %. "count" `shouldMatchInt` 1
+
+testUnsupportedCiphersuite :: HasCallStack => App ()
+testUnsupportedCiphersuite = do
+  setMLSCiphersuite (Ciphersuite "0x0002")
+  bob <- randomUser OwnDomain def
+  bob1 <- createMLSClient bob
+  (kp, _) <- generateKeyPackage bob1
+  bindResponse (uploadKeyPackage bob1 kp) $ \resp -> do
+    resp.status `shouldMatchInt` 400
+    resp.json %. "label" `shouldMatch` "mls-protocol-error"

--- a/integration/test/Testlib/Env.hs
+++ b/integration/test/Testlib/Env.hs
@@ -6,6 +6,7 @@ import Control.Monad.Codensity
 import Control.Monad.IO.Class
 import Data.Aeson hiding ((.=))
 import Data.ByteString (ByteString)
+import Data.Default
 import Data.Functor
 import Data.IORef
 import Data.Map (Map)
@@ -233,6 +234,15 @@ data ClientGroupState = ClientGroupState
 emptyClientGroupState :: ClientGroupState
 emptyClientGroupState = ClientGroupState Nothing Nothing
 
+newtype Ciphersuite = Ciphersuite {code :: String}
+  deriving (Eq, Ord, Show)
+
+instance Default Ciphersuite where
+  def = Ciphersuite "0x0001"
+
+allCiphersuites :: [Ciphersuite]
+allCiphersuites = map Ciphersuite ["0x0001", "0xf031"]
+
 data MLSState = MLSState
   { baseDir :: FilePath,
     members :: Set ClientIdentity,
@@ -241,7 +251,8 @@ data MLSState = MLSState
     groupId :: Maybe String,
     convId :: Maybe Value,
     clientGroupState :: Map ClientIdentity ClientGroupState,
-    epoch :: Word64
+    epoch :: Word64,
+    ciphersuite :: Ciphersuite
   }
   deriving (Show)
 
@@ -256,7 +267,8 @@ mkMLSState = Codensity $ \k ->
           groupId = Nothing,
           convId = Nothing,
           clientGroupState = mempty,
-          epoch = 0
+          epoch = 0,
+          ciphersuite = def
         }
 
 data ClientIdentity = ClientIdentity

--- a/integration/test/Testlib/Env.hs
+++ b/integration/test/Testlib/Env.hs
@@ -224,6 +224,15 @@ create ioRef =
         Nothing -> error "No resources available"
         Just (r, s') -> (s', r)
 
+data ClientGroupState = ClientGroupState
+  { group :: Maybe ByteString,
+    keystore :: Maybe ByteString
+  }
+  deriving (Show)
+
+emptyClientGroupState :: ClientGroupState
+emptyClientGroupState = ClientGroupState Nothing Nothing
+
 data MLSState = MLSState
   { baseDir :: FilePath,
     members :: Set ClientIdentity,
@@ -231,7 +240,7 @@ data MLSState = MLSState
     newMembers :: Set ClientIdentity,
     groupId :: Maybe String,
     convId :: Maybe Value,
-    clientGroupState :: Map ClientIdentity ByteString,
+    clientGroupState :: Map ClientIdentity ClientGroupState,
     epoch :: Word64
   }
   deriving (Show)

--- a/integration/test/Testlib/PTest.hs
+++ b/integration/test/Testlib/PTest.hs
@@ -1,6 +1,7 @@
 module Testlib.PTest where
 
 import Testlib.App
+import Testlib.Env
 import Testlib.Types
 import Prelude
 
@@ -16,3 +17,10 @@ instance HasTests x => HasTests (Domain -> x) where
   mkTests m n s f x =
     mkTests m (n <> "[domain=own]") s f (x OwnDomain)
       <> mkTests m (n <> "[domain=other]") s f (x OtherDomain)
+
+instance HasTests x => HasTests (Ciphersuite -> x) where
+  mkTests m n s f x =
+    mconcat
+      [ mkTests m (n <> "[suite=" <> suite.code <> "]") s f (x suite)
+        | suite <- allCiphersuites
+      ]

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -97,7 +97,7 @@ newtype GetUserClients = GetUserClients
 
 data MLSClientsRequest = MLSClientsRequest
   { userId :: UserId, -- implicitly qualified by the local domain
-    signatureScheme :: SignatureSchemeTag
+    cipherSuite :: CipherSuite
   }
   deriving stock (Eq, Show, Generic)
   deriving (ToJSON, FromJSON) via (CustomEncoded MLSClientsRequest)
@@ -160,7 +160,9 @@ data ClaimKeyPackageRequest = ClaimKeyPackageRequest
     claimant :: UserId,
     -- | The user whose key packages are being claimed, implictly qualified by
     -- the target domain.
-    target :: UserId
+    target :: UserId,
+    -- | The ciphersuite of the key packages being claimed.
+    cipherSuite :: CipherSuite
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform ClaimKeyPackageRequest)

--- a/libs/wire-api/src/Wire/API/MLS/CipherSuite.hs
+++ b/libs/wire-api/src/Wire/API/MLS/CipherSuite.hs
@@ -101,9 +101,10 @@ instance ToSchema CipherSuiteTag where
 
 -- | See https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#table-5.
 cipherSuiteTag :: CipherSuite -> Maybe CipherSuiteTag
-cipherSuiteTag (CipherSuite n) = case n of
-  1 -> pure MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-  _ -> Nothing
+cipherSuiteTag cs = listToMaybe $ do
+  t <- [minBound .. maxBound]
+  guard (tagCipherSuite t == cs)
+  pure t
 
 -- | Inverse of 'cipherSuiteTag'
 tagCipherSuite :: CipherSuiteTag -> CipherSuite

--- a/libs/wire-api/src/Wire/API/MLS/Validation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Validation.hs
@@ -23,6 +23,9 @@ module Wire.API.MLS.Validation
 where
 
 import Control.Applicative
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Builder as LT
+import qualified Data.Text.Lazy.Builder.Int as LT
 import Imports hiding (cs)
 import Wire.API.MLS.Capabilities
 import Wire.API.MLS.CipherSuite
@@ -41,7 +44,11 @@ validateKeyPackage mIdentity kp = do
   -- get ciphersuite
   cs <-
     maybe
-      (Left "Unsupported ciphersuite")
+      ( Left
+          ( "Unsupported ciphersuite 0x"
+              <> LT.toStrict (LT.toLazyText (LT.hexadecimal kp.cipherSuite.cipherSuiteNumber))
+          )
+      )
       pure
       $ cipherSuiteTag kp.cipherSuite
 

--- a/libs/wire-api/src/Wire/API/MLS/Validation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Validation.hs
@@ -23,9 +23,9 @@ module Wire.API.MLS.Validation
 where
 
 import Control.Applicative
-import qualified Data.Text.Lazy as LT
-import qualified Data.Text.Lazy.Builder as LT
-import qualified Data.Text.Lazy.Builder.Int as LT
+import Data.Text.Lazy qualified as LT
+import Data.Text.Lazy.Builder qualified as LT
+import Data.Text.Lazy.Builder.Int qualified as LT
 import Imports hiding (cs)
 import Wire.API.MLS.Capabilities
 import Wire.API.MLS.CipherSuite

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Brig.hs
@@ -54,7 +54,7 @@ import Servant.Swagger.Internal.Orphans ()
 import Wire.API.Connection
 import Wire.API.Error
 import Wire.API.Error.Brig
-import Wire.API.MLS.CipherSuite (SignatureSchemeTag)
+import Wire.API.MLS.CipherSuite
 import Wire.API.MakesFederatedCall
 import Wire.API.Routes.FederationDomainConfig
 import Wire.API.Routes.Internal.Brig.Connection
@@ -64,7 +64,7 @@ import Wire.API.Routes.Internal.Brig.SearchIndex (ISearchIndexAPI)
 import Wire.API.Routes.Internal.Galley.TeamFeatureNoConfigMulti qualified as Multi
 import Wire.API.Routes.MultiVerb
 import Wire.API.Routes.Named
-import Wire.API.Routes.Public (ZUser {- yes, this is a bit weird -})
+import Wire.API.Routes.Public (ZUser)
 import Wire.API.Team.Feature
 import Wire.API.Team.LegalHold.Internal
 import Wire.API.User
@@ -500,7 +500,7 @@ type GetMLSClients =
     :> "clients"
     :> CanThrow 'UserNotFound
     :> Capture "user" UserId
-    :> QueryParam' '[Required, Strict] "sig_scheme" SignatureSchemeTag
+    :> QueryParam' '[Required, Strict] "ciphersuite" CipherSuite
     :> MultiVerb1
          'GET
          '[Servant.JSON]

--- a/nix/pkgs/mls-test-cli/default.nix
+++ b/nix/pkgs/mls-test-cli/default.nix
@@ -13,8 +13,8 @@ let
   src = fetchFromGitHub {
     owner = "wireapp";
     repo = "mls-test-cli";
-    rev = "87845faa7d5ee69652747ceaf1664baa8198c0d8";
-    sha256 = "sha256-DoQ6brp1KvglVVCDp4vC5zaRx76IUywu3Rcu/TzJlvo=";
+    rev = "cc815d71a1d9485265b7ae158daf7b27badedee6";
+    sha256 = "sha256-CJoc20pOtsxAQNCA3qhv8NtPbzZ4yCIMvuhlgcqPrds=";
   };
   cargoLockFile = builtins.toFile "cargo.lock" (builtins.readFile "${src}/Cargo.lock");
 in rustPlatform.buildRustPackage rec {
@@ -24,8 +24,10 @@ in rustPlatform.buildRustPackage rec {
   cargoLock = {
     lockFile = cargoLockFile;
     outputHashes = {
-      "hpke-0.10.0" = "sha256-XYkG72ZeQ3nM4JjgNU5Fe0HqNGkBGcI70rE1Kbz/6vs=";
-      "openmls-0.20.0" = "sha256-i5xNTYP1wPzwlnqz+yPu8apKCibRZacz4OV5VVZwY5Y=";
+      "hpke-0.10.0" = "sha256-6zyTb2c2DU4mXn9vRQe+lXNaeQ3JOVUz+BS15Xb2E+Y=";
+      "openmls-0.20.2" = "sha256-QgQb5Ts8TB2nwfxMss4qHCz096ijMXBxyq7q2ITyEGg=";
+      "safe_pqc_kyber-0.6.0" = "sha256-Ch1LA+by+ezf5RV0LDSQGC1o+IWKXk8IPvkwSrAos68=";
+      "tls_codec-0.3.0" = "sha256-IO6tenXKkC14EoUDp/+DtFNOVzDfOlLu8K1EJI7sOzs=";
     };
   };
 

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -82,6 +82,7 @@ library
     Brig.API.Federation
     Brig.API.Handler
     Brig.API.Internal
+    Brig.API.MLS.CipherSuite
     Brig.API.MLS.KeyPackages
     Brig.API.MLS.KeyPackages.Validation
     Brig.API.MLS.Util
@@ -537,6 +538,7 @@ executable brig-schema
     V77_FederationRemotes
     V78_ClientLastActive
     V79_ConnectionRemoteIndex
+    V80_KeyPackageCiphersuite
     V_FUTUREWORK
 
   hs-source-dirs:     schema/src

--- a/services/brig/schema/src/Run.hs
+++ b/services/brig/schema/src/Run.hs
@@ -59,6 +59,7 @@ import V76_AddSupportedProtocols qualified
 import V77_FederationRemotes qualified
 import V78_ClientLastActive qualified
 import V79_ConnectionRemoteIndex qualified
+import V80_KeyPackageCiphersuite qualified
 
 main :: IO ()
 main = do
@@ -105,7 +106,8 @@ main = do
       V76_AddSupportedProtocols.migration,
       V77_FederationRemotes.migration,
       V78_ClientLastActive.migration,
-      V79_ConnectionRemoteIndex.migration
+      V79_ConnectionRemoteIndex.migration,
+      V80_KeyPackageCiphersuite.migration
       -- When adding migrations here, don't forget to update
       -- 'schemaVersion' in Brig.App
 

--- a/services/brig/schema/src/V80_KeyPackageCiphersuite.hs
+++ b/services/brig/schema/src/V80_KeyPackageCiphersuite.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module V80_KeyPackageCiphersuite
+  ( migration,
+  )
+where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+-- Index key packages by ciphersuite as well as user and client.
+
+-- Note: this migration recreates the mls_key_packages table from scratch, and
+-- therefore loses all the data it contains. That means clients will need to
+-- re-upload key packages after this migration is run.
+
+migration :: Migration
+migration =
+  Migration 80 "Recreate mls_key_packages table" $ do
+    schema' [r| DROP TABLE IF EXISTS mls_key_packages; |]
+    schema'
+      [r|
+        CREATE TABLE mls_key_packages
+            ( user uuid
+            , client text
+            , cipher_suite int
+            , ref blob
+            , data blob
+            , PRIMARY KEY ((user, client, cipher_suite), ref)
+        ) WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
+          AND gc_grace_seconds = 864000;
+     |]

--- a/services/brig/src/Brig/API/MLS/CipherSuite.hs
+++ b/services/brig/src/Brig/API/MLS/CipherSuite.hs
@@ -1,0 +1,29 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Brig.API.MLS.CipherSuite (getCipherSuite) where
+
+import Brig.API.Handler
+import Brig.API.MLS.KeyPackages.Validation
+import Imports
+import Wire.API.MLS.CipherSuite
+
+getCipherSuite :: Maybe CipherSuite -> Handler r CipherSuiteTag
+getCipherSuite mSuite = case mSuite of
+  Nothing -> pure defCipherSuite
+  Just x ->
+    maybe (mlsProtocolError "Unknown ciphersuite") pure (cipherSuiteTag x)

--- a/services/brig/src/Brig/API/MLS/KeyPackages.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages.hs
@@ -26,6 +26,7 @@ where
 
 import Brig.API.Error
 import Brig.API.Handler
+import Brig.API.MLS.CipherSuite
 import Brig.API.MLS.KeyPackages.Validation
 import Brig.API.MLS.Util
 import Brig.API.Types
@@ -42,6 +43,7 @@ import Data.Set qualified as Set
 import Imports
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Brig
+import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Credential
 import Wire.API.MLS.KeyPackage
 import Wire.API.MLS.Serialisation
@@ -57,23 +59,26 @@ uploadKeyPackages lusr cid kps = do
 
 claimKeyPackages ::
   Local UserId ->
-  Qualified UserId ->
   Maybe ClientId ->
+  Qualified UserId ->
+  Maybe CipherSuite ->
   Handler r KeyPackageBundle
-claimKeyPackages lusr target skipOwn = do
+claimKeyPackages lusr mClient target mSuite = do
   assertMLSEnabled
+  suite <- getCipherSuite mSuite
   foldQualified
     lusr
-    (withExceptT clientError . claimLocalKeyPackages (tUntagged lusr) skipOwn)
-    (claimRemoteKeyPackages lusr)
+    (withExceptT clientError . claimLocalKeyPackages (tUntagged lusr) mClient suite)
+    (claimRemoteKeyPackages lusr (tagCipherSuite suite))
     target
 
 claimLocalKeyPackages ::
   Qualified UserId ->
   Maybe ClientId ->
+  CipherSuiteTag ->
   Local UserId ->
   ExceptT ClientError (AppT r) KeyPackageBundle
-claimLocalKeyPackages qusr skipOwn target = do
+claimLocalKeyPackages qusr skipOwn suite target = do
   -- skip own client when the target is the requesting user itself
   let own = guard (qusr == tUntagged target) *> skipOwn
   clients <- map clientId <$> wrapClientE (Data.lookupClients (tUnqualified target))
@@ -94,13 +99,14 @@ claimLocalKeyPackages qusr skipOwn target = do
       runMaybeT $ do
         guard $ Just c /= own
         uncurry (KeyPackageBundleEntry (tUntagged target) c)
-          <$> wrapClientM (Data.claimKeyPackage target c)
+          <$> wrapClientM (Data.claimKeyPackage target c suite)
 
 claimRemoteKeyPackages ::
   Local UserId ->
+  CipherSuite ->
   Remote UserId ->
   Handler r KeyPackageBundle
-claimRemoteKeyPackages lusr target = do
+claimRemoteKeyPackages lusr suite target = do
   bundle <-
     withExceptT clientError
       . (handleFailure =<<)
@@ -109,7 +115,8 @@ claimRemoteKeyPackages lusr target = do
       $ fedClient @'Brig @"claim-key-packages"
       $ ClaimKeyPackageRequest
         { claimant = tUnqualified lusr,
-          target = tUnqualified target
+          target = tUnqualified target,
+          cipherSuite = suite
         }
 
   -- validate all claimed key packages
@@ -121,7 +128,7 @@ claimRemoteKeyPackages lusr target = do
         . decodeMLS'
         . kpData
         $ e.keyPackage
-    (refVal, _) <- validateUploadedKeyPackage cid kpRaw
+    (refVal, _, _) <- validateUploadedKeyPackage cid kpRaw
     unless (refVal == e.ref)
       . throwE
       . clientDataError
@@ -132,18 +139,21 @@ claimRemoteKeyPackages lusr target = do
     handleFailure :: Monad m => Maybe x -> ExceptT ClientError m x
     handleFailure = maybe (throwE (ClientUserNotFound (tUnqualified target))) pure
 
-countKeyPackages :: Local UserId -> ClientId -> Handler r KeyPackageCount
-countKeyPackages lusr c = do
+countKeyPackages :: Local UserId -> ClientId -> Maybe CipherSuite -> Handler r KeyPackageCount
+countKeyPackages lusr c mSuite = do
   assertMLSEnabled
+  suite <- getCipherSuite mSuite
   lift $
     KeyPackageCount . fromIntegral
-      <$> wrapClient (Data.countKeyPackages lusr c)
+      <$> wrapClient (Data.countKeyPackages lusr c suite)
 
 deleteKeyPackages ::
   Local UserId ->
   ClientId ->
+  Maybe CipherSuite ->
   DeleteKeyPackages ->
   Handler r ()
-deleteKeyPackages lusr c (unDeleteKeyPackages -> refs) = do
+deleteKeyPackages lusr c mSuite (unDeleteKeyPackages -> refs) = do
   assertMLSEnabled
-  lift $ wrapClient (Data.deleteKeyPackages (tUnqualified lusr) c refs)
+  suite <- getCipherSuite mSuite
+  lift $ wrapClient (Data.deleteKeyPackages (tUnqualified lusr) c suite refs)

--- a/services/brig/src/Brig/API/MLS/KeyPackages/Validation.hs
+++ b/services/brig/src/Brig/API/MLS/KeyPackages/Validation.hs
@@ -47,7 +47,7 @@ import Wire.API.MLS.Validation
 validateUploadedKeyPackage ::
   ClientIdentity ->
   RawMLS KeyPackage ->
-  Handler r (KeyPackageRef, KeyPackageData)
+  Handler r (KeyPackageRef, CipherSuiteTag, KeyPackageData)
 validateUploadedKeyPackage identity kp = do
   (cs, lt) <- either mlsProtocolError pure $ validateKeyPackage (Just identity) kp.value
 
@@ -77,7 +77,7 @@ validateUploadedKeyPackage identity kp = do
     (cidQualifiedClient identity)
 
   let kpd = KeyPackageData kp.raw
-  pure (kpRef cs kpd, kpd)
+  pure (kpRef cs kpd, cs, kpd)
 
 validateLifetime :: Lifetime -> Handler r ()
 validateLifetime lt = do

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -384,7 +384,7 @@ servantSitemap =
     mlsAPI :: ServerT MLSAPI (Handler r)
     mlsAPI =
       Named @"mls-key-packages-upload" uploadKeyPackages
-        :<|> Named @"mls-key-packages-claim" (callsFed (exposeAnnotations claimKeyPackages))
+        :<|> Named @"mls-key-packages-claim" claimKeyPackages
         :<|> Named @"mls-key-packages-count" countKeyPackages
         :<|> Named @"mls-key-packages-delete" deleteKeyPackages
 

--- a/services/brig/src/Brig/Data/Instances.hs
+++ b/services/brig/src/Brig/Data/Instances.hs
@@ -39,6 +39,7 @@ import Data.Text.Encoding (encodeUtf8)
 import Imports
 import Wire.API.Asset (AssetKey, assetKeyToText, nilAssetKey)
 import Wire.API.Connection (RelationWithHistory (..))
+import Wire.API.MLS.CipherSuite
 import Wire.API.Properties
 import Wire.API.User
 import Wire.API.User.Activation
@@ -306,3 +307,13 @@ instance Cql (Imports.Set BaseProtocolTag) where
   toCql = CqlInt . fromIntegral . protocolSetBits
   fromCql (CqlInt bits) = pure $ protocolSetFromBits (fromIntegral bits)
   fromCql _ = Left "Protocol set: Int expected"
+
+instance Cql CipherSuiteTag where
+  ctype = Tagged IntColumn
+  toCql = CqlInt . fromIntegral . cipherSuiteNumber . tagCipherSuite
+
+  fromCql (CqlInt index) =
+    case cipherSuiteTag (CipherSuite (fromIntegral index)) of
+      Just tag -> Right tag
+      Nothing -> Left "CipherSuiteTag: unexpected index"
+  fromCql _ = Left "CipherSuiteTag: int expected"

--- a/services/brig/test/integration/API/Federation.hs
+++ b/services/brig/test/integration/API/Federation.hs
@@ -53,6 +53,7 @@ import Wire.API.Federation.API.Brig qualified as FedBrig
 import Wire.API.Federation.API.Brig qualified as S
 import Wire.API.Federation.Component
 import Wire.API.Federation.Version
+import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.KeyPackage
 import Wire.API.Routes.FederationDomainConfig as FD
 import Wire.API.User
@@ -420,7 +421,10 @@ testClaimKeyPackages brig fedBrigClient = do
 
   Just bundle <-
     runFedClient @"claim-key-packages" fedBrigClient (qDomain alice) $
-      ClaimKeyPackageRequest (qUnqualified alice) (qUnqualified bob)
+      ClaimKeyPackageRequest
+        (qUnqualified alice)
+        (qUnqualified bob)
+        (tagCipherSuite defCipherSuite)
 
   liftIO $
     Set.map (\e -> (e.user, e.client)) bundle.entries
@@ -440,6 +444,9 @@ testClaimKeyPackagesMLSDisabled opts brig = do
     withSettingsOverrides (opts & Opt.optionSettings . Opt.enableMLS ?~ False) $
       runWaiTestFedClient (qDomain alice) $
         createWaiTestFedClient @"claim-key-packages" @'Brig $
-          ClaimKeyPackageRequest (qUnqualified alice) (qUnqualified bob)
+          ClaimKeyPackageRequest
+            (qUnqualified alice)
+            (qUnqualified bob)
+            (tagCipherSuite defCipherSuite)
 
   liftIO $ mbundle @?= Nothing

--- a/services/brig/test/integration/API/MLS.hs
+++ b/services/brig/test/integration/API/MLS.hs
@@ -149,8 +149,8 @@ testKeyPackageSelfClaim brig = do
         =<< post
           ( brig
               . paths ["mls", "key-packages", "claim", toByteString' (qDomain u), toByteString' (qUnqualified u)]
-              . queryItem "skip_own" (toByteString' c1)
               . zUser (qUnqualified u)
+              . zClient c1
           )
           <!! const 200 === statusCode
     liftIO $ Set.map (\e -> (e.user, e.client)) bundle.entries @?= Set.fromList [(u, c2)]

--- a/services/galley/default.nix
+++ b/services/galley/default.nix
@@ -233,7 +233,6 @@ mkDerivation {
     conduit
     containers
     cookie
-    cryptonite
     currency-codes
     data-default
     data-timeout

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -415,7 +415,6 @@ executable galley-integration
     , cereal
     , containers
     , cookie
-    , cryptonite
     , currency-codes
     , data-default
     , data-timeout

--- a/services/galley/src/Galley/API/MLS/Commit/Core.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/Core.hs
@@ -135,7 +135,7 @@ getClientInfo ::
   ) =>
   Local x ->
   Qualified UserId ->
-  SignatureSchemeTag ->
+  CipherSuiteTag ->
   Sem r (Either FederationError (Set ClientInfo))
 getClientInfo loc =
   foldQualified loc (\lusr -> fmap Right . getLocalMLSClients lusr) getRemoteMLSClients
@@ -144,14 +144,14 @@ getRemoteMLSClients ::
   ( Member FederatorAccess r
   ) =>
   Remote UserId ->
-  SignatureSchemeTag ->
+  CipherSuiteTag ->
   Sem r (Either FederationError (Set ClientInfo))
-getRemoteMLSClients rusr ss = do
+getRemoteMLSClients rusr suite = do
   runFederatedEither rusr $
     fedClient @'Brig @"get-mls-clients" $
       MLSClientsRequest
         { userId = tUnqualified rusr,
-          signatureScheme = ss
+          cipherSuite = tagCipherSuite suite
         }
 
 --------------------------------------------------------------------------------

--- a/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
@@ -53,7 +53,6 @@ import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 import Wire.API.Error
 import Wire.API.Error.Galley
-import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Commit
 import Wire.API.MLS.Credential
 import Wire.API.MLS.Proposal qualified as Proposal
@@ -83,7 +82,7 @@ processInternalCommit senderIdentity con lConvOrSub epoch action commit = do
   let convOrSub = tUnqualified lConvOrSub
       qusr = cidQualifiedUser senderIdentity
       cm = convOrSub.members
-      ss = csSignatureScheme (cnvmlsCipherSuite convOrSub.mlsMeta)
+      suite = cnvmlsCipherSuite convOrSub.mlsMeta
       newUserClients = Map.assocs (paAdd action)
 
   -- check all pending proposals are referenced in the commit
@@ -145,7 +144,7 @@ processInternalCommit senderIdentity con lConvOrSub epoch action commit = do
                 -- final set of clients in the conversation
                 let clients = Map.keysSet (newclients <> Map.findWithDefault mempty qtarget cm)
                 -- get list of mls clients from Brig (local or remote)
-                getClientInfo lConvOrSub qtarget ss >>= \case
+                getClientInfo lConvOrSub qtarget suite >>= \case
                   Left _e -> pure (Just qtarget)
                   Right clientInfo -> do
                     let allClients = Set.map ciId clientInfo

--- a/services/galley/src/Galley/API/MLS/IncomingMessage.hs
+++ b/services/galley/src/Galley/API/MLS/IncomingMessage.hs
@@ -69,7 +69,7 @@ data IncomingBundle = IncomingBundle
     commit :: RawMLS Commit,
     rawMessage :: RawMLS Message,
     welcome :: Maybe (RawMLS Welcome),
-    groupInfo :: GroupInfoData,
+    groupInfo :: RawMLS GroupInfo,
     serialized :: ByteString
   }
 
@@ -126,6 +126,6 @@ mkIncomingBundle bundle = do
         commit = commit,
         rawMessage = bundle.value.commitMsg,
         welcome = bundle.value.welcome,
-        groupInfo = GroupInfoData bundle.value.groupInfo.raw,
+        groupInfo = bundle.value.groupInfo,
         serialized = bundle.raw
       }

--- a/services/galley/src/Galley/API/MLS/Types.hs
+++ b/services/galley/src/Galley/API/MLS/Types.hs
@@ -27,7 +27,7 @@ import Data.Qualified
 import GHC.Records (HasField (..))
 import Galley.Data.Conversation.Types
 import Galley.Types.Conversations.Members
-import Imports
+import Imports hiding (cs)
 import Wire.API.Conversation
 import Wire.API.Conversation.Protocol
 import Wire.API.MLS.CipherSuite
@@ -214,3 +214,15 @@ instance HasField "id" ConvOrSubConv ConvOrSubConvId where
 instance HasField "migrationState" ConvOrSubConv MLSMigrationState where
   getField (Conv c) = c.mcMigrationState
   getField (SubConv _ _) = MLSMigrationMLS
+
+convOrSubConvSetCipherSuite :: CipherSuiteTag -> ConvOrSubConv -> ConvOrSubConv
+convOrSubConvSetCipherSuite cs (Conv c) =
+  Conv $
+    c
+      { mcMLSData = (mcMLSData c) {cnvmlsCipherSuite = cs}
+      }
+convOrSubConvSetCipherSuite cs (SubConv c s) =
+  SubConv c $
+    s
+      { scMLSData = (scMLSData s) {cnvmlsCipherSuite = cs}
+      }

--- a/services/galley/src/Galley/Cassandra/Conversation.hs
+++ b/services/galley/src/Galley/Cassandra/Conversation.hs
@@ -244,6 +244,13 @@ getConvEpoch cid =
 updateConvEpoch :: ConvId -> Epoch -> Client ()
 updateConvEpoch cid epoch = retry x5 $ write Cql.updateConvEpoch (params LocalQuorum (epoch, cid))
 
+updateConvCipherSuite :: ConvId -> CipherSuiteTag -> Client ()
+updateConvCipherSuite cid cs =
+  retry x5 $
+    write
+      Cql.updateConvCipherSuite
+      (params LocalQuorum (cs, cid))
+
 setGroupInfo :: ConvId -> GroupInfoData -> Client ()
 setGroupInfo conv gid =
   write Cql.updateGroupInfo (params LocalQuorum (gid, conv))
@@ -460,6 +467,7 @@ interpretConversationStoreToCassandra = interpret $ \case
   SetConversationReceiptMode cid value -> embedClient $ updateConvReceiptMode cid value
   SetConversationMessageTimer cid value -> embedClient $ updateConvMessageTimer cid value
   SetConversationEpoch cid epoch -> embedClient $ updateConvEpoch cid epoch
+  SetConversationCipherSuite cid cs -> embedClient $ updateConvCipherSuite cid cs
   DeleteConversation cid -> embedClient $ deleteConversation cid
   SetGroupInfo cid gib -> embedClient $ setGroupInfo cid gib
   AcquireCommitLock gId epoch ttl -> embedClient $ acquireCommitLock gId epoch ttl

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -296,6 +296,9 @@ getConvEpoch = "select epoch from conversation where conv = ?"
 updateConvEpoch :: PrepQuery W (Epoch, ConvId) ()
 updateConvEpoch = {- `IF EXISTS`, but that requires benchmarking -} "update conversation set epoch = ? where conv = ?"
 
+updateConvCipherSuite :: PrepQuery W (CipherSuiteTag, ConvId) ()
+updateConvCipherSuite = "update conversation set cipher_suite = ? where conv = ?"
+
 deleteConv :: PrepQuery W (Identity ConvId) ()
 deleteConv = "delete from conversation using timestamp 32503680000000000 where conv = ?"
 
@@ -355,6 +358,9 @@ selectSubConvEpoch = "SELECT epoch FROM subconversation WHERE conv_id = ? AND su
 
 insertEpochForSubConversation :: PrepQuery W (Epoch, ConvId, SubConvId) ()
 insertEpochForSubConversation = "UPDATE subconversation set epoch = ? WHERE conv_id = ? AND subconv_id = ?"
+
+insertCipherSuiteForSubConversation :: PrepQuery W (CipherSuiteTag, ConvId, SubConvId) ()
+insertCipherSuiteForSubConversation = "UPDATE subconversation set cipher_suite = ? WHERE conv_id = ? AND subconv_id = ?"
 
 listSubConversations :: PrepQuery R (Identity ConvId) (SubConvId, CipherSuiteTag, Epoch, Writetime Epoch, GroupId)
 listSubConversations = "SELECT subconv_id, cipher_suite, epoch, WRITETIME(epoch), group_id FROM subconversation WHERE conv_id = ?"

--- a/services/galley/src/Galley/Cassandra/Queries.hs
+++ b/services/galley/src/Galley/Cassandra/Queries.hs
@@ -341,7 +341,7 @@ deleteUserConv = "delete from user where user = ? and conv = ?"
 
 -- MLS SubConversations -----------------------------------------------------
 
-selectSubConversation :: PrepQuery R (ConvId, SubConvId) (CipherSuiteTag, Epoch, Writetime Epoch, GroupId)
+selectSubConversation :: PrepQuery R (ConvId, SubConvId) (Maybe CipherSuiteTag, Maybe Epoch, Maybe (Writetime Epoch), Maybe GroupId)
 selectSubConversation = "SELECT cipher_suite, epoch, WRITETIME(epoch), group_id FROM subconversation WHERE conv_id = ? and subconv_id = ?"
 
 insertSubConversation :: PrepQuery W (ConvId, SubConvId, CipherSuiteTag, Epoch, GroupId, Maybe GroupInfoData) ()

--- a/services/galley/src/Galley/Cassandra/SubConversation.hs
+++ b/services/galley/src/Galley/Cassandra/SubConversation.hs
@@ -22,6 +22,8 @@ where
 
 import Cassandra
 import Cassandra.Util
+import Control.Error.Util
+import Control.Monad.Trans.Maybe
 import Data.Id
 import Data.Map qualified as Map
 import Data.Time.Clock
@@ -40,24 +42,29 @@ import Wire.API.MLS.GroupInfo
 import Wire.API.MLS.SubConversation
 
 selectSubConversation :: ConvId -> SubConvId -> Client (Maybe SubConversation)
-selectSubConversation convId subConvId = do
-  m <- retry x5 (query1 Cql.selectSubConversation (params LocalQuorum (convId, subConvId)))
-  for m $ \(suite, epoch, epochWritetime, groupId) -> do
-    (cm, im) <- lookupMLSClientLeafIndices groupId
-    pure $
-      SubConversation
-        { scParentConvId = convId,
-          scSubConvId = subConvId,
-          scMLSData =
-            ConversationMLSData
-              { cnvmlsGroupId = groupId,
-                cnvmlsEpoch = epoch,
-                cnvmlsEpochTimestamp = epochTimestamp epoch epochWritetime,
-                cnvmlsCipherSuite = suite
-              },
-          scMembers = cm,
-          scIndexMap = im
-        }
+selectSubConversation convId subConvId = runMaybeT $ do
+  (mSuite, mEpoch, mEpochWritetime, mGroupId) <-
+    MaybeT $
+      retry x5 (query1 Cql.selectSubConversation (params LocalQuorum (convId, subConvId)))
+  suite <- hoistMaybe mSuite
+  epoch <- hoistMaybe mEpoch
+  epochWritetime <- hoistMaybe mEpochWritetime
+  groupId <- hoistMaybe mGroupId
+  (cm, im) <- lift $ lookupMLSClientLeafIndices groupId
+  pure $
+    SubConversation
+      { scParentConvId = convId,
+        scSubConvId = subConvId,
+        scMLSData =
+          ConversationMLSData
+            { cnvmlsGroupId = groupId,
+              cnvmlsEpoch = epoch,
+              cnvmlsEpochTimestamp = epochTimestamp epoch epochWritetime,
+              cnvmlsCipherSuite = suite
+            },
+        scMembers = cm,
+        scIndexMap = im
+      }
 
 insertSubConversation ::
   ConvId ->

--- a/services/galley/src/Galley/Cassandra/SubConversation.hs
+++ b/services/galley/src/Galley/Cassandra/SubConversation.hs
@@ -93,6 +93,10 @@ setEpochForSubConversation :: ConvId -> SubConvId -> Epoch -> Client ()
 setEpochForSubConversation cid sconv epoch =
   retry x5 (write Cql.insertEpochForSubConversation (params LocalQuorum (epoch, cid, sconv)))
 
+setCipherSuiteForSubConversation :: ConvId -> SubConvId -> CipherSuiteTag -> Client ()
+setCipherSuiteForSubConversation cid sconv cs =
+  retry x5 (write Cql.insertCipherSuiteForSubConversation (params LocalQuorum (cs, cid, sconv)))
+
 deleteSubConversation :: ConvId -> SubConvId -> Client ()
 deleteSubConversation cid sconv =
   retry x5 $ write Cql.deleteSubConversation (params LocalQuorum (cid, sconv))
@@ -124,6 +128,7 @@ interpretSubConversationStoreToCassandra = interpret $ \case
   GetSubConversationEpoch convId subConvId -> embedClient (selectSubConvEpoch convId subConvId)
   SetSubConversationGroupInfo convId subConvId mPgs -> embedClient (updateSubConvGroupInfo convId subConvId mPgs)
   SetSubConversationEpoch cid sconv epoch -> embedClient $ setEpochForSubConversation cid sconv epoch
+  SetSubConversationCipherSuite cid sconv cs -> embedClient $ setCipherSuiteForSubConversation cid sconv cs
   ListSubConversations cid -> embedClient $ listSubConversations cid
   DeleteSubConversation convId subConvId -> embedClient $ deleteSubConversation convId subConvId
 

--- a/services/galley/src/Galley/Effects/BrigAccess.hs
+++ b/services/galley/src/Galley/Effects/BrigAccess.hs
@@ -123,7 +123,7 @@ data BrigAccess m a where
     BrigAccess m (Either AuthenticationError ClientId)
   RemoveLegalHoldClientFromUser :: UserId -> BrigAccess m ()
   GetAccountConferenceCallingConfigClient :: UserId -> BrigAccess m (WithStatusNoLock ConferenceCallingConfig)
-  GetLocalMLSClients :: Local UserId -> SignatureSchemeTag -> BrigAccess m (Set ClientInfo)
+  GetLocalMLSClients :: Local UserId -> CipherSuiteTag -> BrigAccess m (Set ClientInfo)
   UpdateSearchVisibilityInbound ::
     Multi.TeamStatus SearchVisibilityInboundConfig ->
     BrigAccess m ()

--- a/services/galley/src/Galley/Effects/ConversationStore.hs
+++ b/services/galley/src/Galley/Effects/ConversationStore.hs
@@ -43,6 +43,7 @@ module Galley.Effects.ConversationStore
     setConversationReceiptMode,
     setConversationMessageTimer,
     setConversationEpoch,
+    setConversationCipherSuite,
     acceptConnectConversation,
     setGroupInfo,
     updateToMixedProtocol,
@@ -96,6 +97,7 @@ data ConversationStore m a where
   SetConversationReceiptMode :: ConvId -> ReceiptMode -> ConversationStore m ()
   SetConversationMessageTimer :: ConvId -> Maybe Milliseconds -> ConversationStore m ()
   SetConversationEpoch :: ConvId -> Epoch -> ConversationStore m ()
+  SetConversationCipherSuite :: ConvId -> CipherSuiteTag -> ConversationStore m ()
   SetGroupInfo :: ConvId -> GroupInfoData -> ConversationStore m ()
   AcquireCommitLock :: GroupId -> Epoch -> NominalDiffTime -> ConversationStore m LockAcquired
   ReleaseCommitLock :: GroupId -> Epoch -> ConversationStore m ()

--- a/services/galley/src/Galley/Effects/SubConversationStore.hs
+++ b/services/galley/src/Galley/Effects/SubConversationStore.hs
@@ -36,6 +36,7 @@ data SubConversationStore m a where
   GetSubConversationEpoch :: ConvId -> SubConvId -> SubConversationStore m (Maybe Epoch)
   SetSubConversationGroupInfo :: ConvId -> SubConvId -> Maybe GroupInfoData -> SubConversationStore m ()
   SetSubConversationEpoch :: ConvId -> SubConvId -> Epoch -> SubConversationStore m ()
+  SetSubConversationCipherSuite :: ConvId -> SubConvId -> CipherSuiteTag -> SubConversationStore m ()
   ListSubConversations :: ConvId -> SubConversationStore m (Map SubConvId ConversationMLSData)
   DeleteSubConversation :: ConvId -> SubConvId -> SubConversationStore m ()
 

--- a/services/galley/src/Galley/Intra/Client.hs
+++ b/services/galley/src/Galley/Intra/Client.hs
@@ -50,6 +50,7 @@ import Polysemy
 import Polysemy.Error
 import Polysemy.Input
 import Polysemy.TinyLog qualified as P
+import Servant.API
 import System.Logger.Class qualified as Logger
 import Wire.API.Error.Galley
 import Wire.API.MLS.CipherSuite
@@ -184,10 +185,7 @@ getLocalMLSClients lusr suite =
           ]
         . queryItem
           "ciphersuite"
-          ( "0x"
-              <> toByteString'
-                (Hex (cipherSuiteNumber (tagCipherSuite suite)))
-          )
+          (toHeader (tagCipherSuite suite))
         . expect2xx
     )
     >>= parseResponse (mkError status502 "server-error")

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -661,6 +661,7 @@ createApplicationMessage cid messageContent = do
       }
 
 createAddCommitWithKeyPackages ::
+  HasCallStack =>
   ClientIdentity ->
   [(ClientIdentity, ByteString)] ->
   MLSTest MessagePackage


### PR DESCRIPTION
This PR adds support for MLS ciphersuite `MLS_128_X25519Kyber768Draft00_AES128GCM_SHA256_Ed25519`.

https://wearezeta.atlassian.net/browse/WPB-2862

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
