### PR TITLE
fix 2 integration tests in new integration test suite

### DIFF
--- a/integration/test/Test/Brig.hs
+++ b/integration/test/Test/Brig.hs
@@ -136,6 +136,42 @@ testCrudOAuthClient = do
     resp.status `shouldMatchInt` 404
 
 -- | See https://docs.wire.com/understand/api-client-perspective/swagger.html
+-- TODO: this test fails for brig's internal swagger docs with `brig-swagger.json` not found.
+-- other internal swagger docs are fine.
+-- the offending commit that introduced the error is https://github.com/wireapp/wire-server/commit/f33f1e0a3837c1113377a4fae5c6724e8fe7de75
+-- ----- Brig.testSwagger FAIL (0.47 s) -----
+-- assertion failure:
+-- Actual:
+-- 500
+-- Expected:
+-- 200
+
+-- call stack:
+-- 1. assertFailure at test/Testlib/Assertions.hs:50
+--      assertFailure $ "Actual:\n" <> pa <> "\nExpected:\n" <> pb
+
+-- 2. shouldMatch at test/Testlib/Assertions.hs:85
+--      shouldMatchInt = shouldMatch
+
+-- 3. shouldMatchInt at test/Test/Brig.hs:182
+--      resp.status `shouldMatchInt` 200
+
+
+
+-- request:
+-- GET http://127.0.0.1:8080/api-internal/swagger-ui/brig-swagger.json
+-- request headers:
+
+-- request body:
+
+-- response status: 500
+-- response body:
+-- {
+--     "code": 500,
+--     "label": "server-error",
+--     "message": "Server Error"
+-- }
+
 testSwagger :: HasCallStack => App ()
 testSwagger = do
   let existingVersions :: [Int]

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -44,7 +44,7 @@ testDynamicBackendsNotFederating = do
         $ bindResponse
           (API.getFederationStatus uidA [domainB, domainC])
         $ \resp -> do
-          resp.status `shouldMatchInt` 400
+          resp.status `shouldMatchInt` 422
           resp.json %. "label" `shouldMatch` "federation-denied"
 
 testDynamicBackendsFullyConnectedWhenAllowDynamic :: HasCallStack => App ()

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -44,7 +44,7 @@ testDynamicBackendsNotFederating = do
         $ bindResponse
           (API.getFederationStatus uidA [domainB, domainC])
         $ \resp -> do
-          resp.status `shouldMatchInt` 422
+          resp.status `shouldMatchInt` 400
           resp.json %. "label" `shouldMatch` "federation-denied"
 
 testDynamicBackendsFullyConnectedWhenAllowDynamic :: HasCallStack => App ()

--- a/services/federator/src/Federator/Validation.hs
+++ b/services/federator/src/Federator/Validation.hs
@@ -87,7 +87,7 @@ validationErrorStatus :: ValidationError -> HTTP.Status
 -- the FederationDenied case is handled differently, because it may be caused
 -- by wrong input in the original request, so we let this error propagate to the
 -- client
-validationErrorStatus (FederationDenied _) = HTTP.status422
+validationErrorStatus (FederationDenied _) = HTTP.status400
 validationErrorStatus _ = HTTP.status403
 
 -- | Validates an already-parsed domain against the allow list (stored in


### PR DESCRIPTION
2 integration tests from new test suite are failing locally.

- `testSwagger`
  - Not fixed, but the offending commit was found, see code comment above the test
- `testDynamicBackendsNotFederating`
  - `fedration-denied` status code changed from 400 to 422, it is not obvious why, so I changed it back. If that is wrong, we need to update the test instead

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
