### PR TITLE
Implement schema for UpdateConnectionsInternal

### DIFF
--- a/changelog.d/1-api-changes/connection-update
+++ b/changelog.d/1-api-changes/connection-update
@@ -1,0 +1,1 @@
+The `connection-update` internal Brig endpoint has a different JSON format for its request body. See the swagger documentation for details.


### PR DESCRIPTION
This fixes an integration test failure on develop.

Note that the change breaks the format of the request body for one internal Brig endpoint. The previous format included a heterogenous JSON array, which is currently not supported by schema-profunctor.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
