### PR TITLE
Array support in JSON selectors

### DIFF
--- a/integration/test/Testlib/JSON.hs
+++ b/integration/test/Testlib/JSON.hs
@@ -9,6 +9,8 @@ import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.Key as KM
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.Aeson.Types as Aeson
+import Data.ByteString hiding ((!?))
+import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy.Char8 as LC8
 import Data.Foldable
 import Data.Function
@@ -17,6 +19,8 @@ import Data.List.Split (splitOn)
 import qualified Data.Scientific as Sci
 import Data.String
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import Data.Vector ((!?))
 import GHC.Stack
 import Testlib.Env
 import Testlib.Types
@@ -109,31 +113,19 @@ asBool x =
     v -> assertFailureWithJSON x ("Bool" `typeWasExpectedButGot` v)
 
 -- | Get a (nested) field of a JSON object
--- Raise an AssertionFailure if the field at the (nested) key is missing.
+-- Raise an AssertionFailure if the field at the (nested) key is missing. See
+-- 'lookupField' for details.
 (%.) ::
   (HasCallStack, MakesValue a) =>
   a ->
   -- | A plain key, e.g. "id", or a nested key "user.profile.id"
   String ->
   App Value
-(%.) val selector = do
-  v <- make val
-  vp <- prettyJSON v
-  addFailureContext ("Getting (nested) field \"" <> selector <> "\" of object:\n" <> vp) $ do
-    let keys = splitOn "." selector
-    case keys of
-      (k : ks) -> go k ks v
-      [] -> assertFailure "No key provided"
-  where
-    go k [] v = l k v
-    go k (k2 : ks) v = do
-      r <- l k v
-      go k2 ks r
-    l k v = do
-      ob <- asObject v
-      case KM.lookup (KM.fromString k) ob of
-        Nothing -> assertFailureWithJSON ob $ "Field \"" <> k <> "\" is missing from object:"
-        Just x -> pure x
+(%.) x k = lookupField x k >>= assertField x k
+
+assertField :: (HasCallStack, MakesValue a) => a -> String -> Maybe Value -> App Value
+assertField x k Nothing = assertFailureWithJSON x $ "Field \"" <> k <> "\" is missing from object:"
+assertField _ _ (Just x) = pure x
 
 -- | Look up (nested) field of a JSON object
 --
@@ -144,6 +136,8 @@ asBool x =
 -- if the last component of the key field selector is missing from nested
 -- object. If any other component is missing this function raises an
 -- AssertionFailure.
+--
+-- Objects and arrays are supported. Array keys should be integers.
 lookupField ::
   (HasCallStack, MakesValue a) =>
   a ->
@@ -159,16 +153,17 @@ lookupField val selector = do
       (k : ks) -> go k ks v
       [] -> assertFailure "No key provided"
   where
-    go k [] v = do
-      ob <- asObject v
-      pure (KM.lookup (KM.fromString k) ob)
-    go k (k2 : ks) v = do
-      ob <- asObject v
-      r <-
-        case KM.lookup (KM.fromString k) ob of
-          Nothing -> assertFailureWithJSON ob $ "Field \"" <> k <> "\" is missing from object:"
-          Just x -> pure x
-      go k2 ks r
+    get v k = do
+      make v >>= \case
+        -- index object
+        Object ob -> pure (KM.lookup (KM.fromString k) ob)
+        -- index array
+        Array arr -> case reads k of
+          [(i, "")] -> pure (arr !? i)
+          _ -> assertFailureWithJSON arr $ "Invalid array index \"" <> k <> "\""
+        x -> assertFailureWithJSON x ("Object or Array" `typeWasExpectedButGot` x)
+    go k [] v = get v k
+    go k (k2 : ks) v = get v k >>= assertField v k >>= go k2 ks
 
 -- Update nested fields
 -- E.g. ob & "foo.bar.baz" %.= ("quux" :: String)


### PR DESCRIPTION
Add support for selecting elements of JSON arrays in the integration test suite.

## Checklist

 - [x] No CHANGELOG entry
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
