### PR TITLE
Make flaky test less flaky.

### DIFF
--- a/services/brig/brig.integration.yaml
+++ b/services/brig/brig.integration.yaml
@@ -156,7 +156,7 @@ optSettings:
   setUserCookieLimit: 5
   setUserCookieThrottle:
     stdDev: 5
-    retryAfter: 1
+    retryAfter: 3
   setLimitFailedLogins:
     timeout: 5  # seconds.  if you reach the limit, how long do you have to wait to try again.
     retryLimit: 5  # how many times can you have a failed login in that timeframe.

--- a/services/brig/test/integration/API/Federation.hs
+++ b/services/brig/test/integration/API/Federation.hs
@@ -389,8 +389,8 @@ testRemoteUserGetsDeleted opts brig cannon fedBrigClient = do
       runFedClient @"on-user-deleted-connections" fedBrigClient (qDomain remoteUser) $
         UserDeletedConnectionsNotification (qUnqualified remoteUser) (unsafeRange localUsers)
 
-    WS.assertMatchN_ (60 # Second) [cc] $ matchDeleteUserNotification remoteUser
-    WS.assertNoEvent (1 # Second) [pc, bc, uc]
+    retryT $ WS.assertMatchN_ (60 # Second) [cc] $ matchDeleteUserNotification remoteUser
+    retryT $ WS.assertNoEvent (1 # Second) [pc, bc, uc]
 
   for_ localUsers $ \u ->
     getConnectionQualified brig u remoteUser !!! do

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -1092,6 +1092,9 @@ aFewTimes
       (\_ -> pure . not . good)
       (const action)
 
+retryT :: (MonadIO m, MonadMask m) => m a -> m a
+retryT = recoverAll (exponentialBackoff 8000 <> limitRetries 3) . const
+
 assertOne :: (HasCallStack, MonadIO m, Show a) => [a] -> m a
 assertOne [a] = pure a
 assertOne xs = liftIO . assertFailure $ "Expected exactly one element, found " <> show xs


### PR DESCRIPTION
I'm double-fixing this because i don't want to think about the legacy integration tests any more.  The `recoverAll` is probably not needed, but I don't see how it hurts either.

## Checklist

 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
