### PR TITLE
Fix bug: integration tests suite has incorrect exit code

### DIFF
--- a/charts/integration/templates/integration-integration.yaml
+++ b/charts/integration/templates/integration-integration.yaml
@@ -137,6 +137,15 @@ spec:
     - name: "spar-config"
       mountPath: "/etc/wire/spar/conf"
 
+    - name: "federator-config"
+      mountPath: "/etc/wire/federator/conf"
+
+    - name: "federator-secrets"
+      mountPath: "/etc/wire/federator/secrets"
+
+    - name: "federator-ca"
+      mountPath: "/etc/wire/federator/ca"
+
     env:
     # these dummy values are necessary for Amazonka's "Discover"
     - name: AWS_ACCESS_KEY_ID

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -37,14 +37,16 @@ summary() {
     echo "==============="
     echo "=== summary ==="
     echo "==============="
-    printf '%s\n' "${tests[@]}" | parallel echo "=== tail {}: ===" ';' tail -2 logs-{}
-
     for t in "${tests[@]}"; do
         x=$(cat "stat-$t")
         if ((x > 0)); then
             echo "$t-integration FAILED ❌. pfff..."
+            echo "=== tail $t: ==="
+            tail -10 "logs-$t"
         else
             echo "$t-integration passed ✅."
+            echo "=== tail $t: ==="
+            tail -2 "logs-$t"
         fi
     done
 }


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
