### PR TITLE
Fix bug in galley chart: incorrect nesting of ifs

### DIFF
--- a/charts/galley/templates/secret.yaml
+++ b/charts/galley/templates/secret.yaml
@@ -13,8 +13,9 @@ data:
   {{- if .Values.secrets.mlsPrivateKeys.removal.ed25519 }}
   removal_ed25519.pem: {{ .Values.secrets.mlsPrivateKeys.removal.ed25519 | b64enc | quote }}
   {{- end -}}
+  {{- end -}}
+
   {{- if $.Values.config.enableFederation }}
   rabbitmqUsername: {{ .Values.secrets.rabbitmq.username | b64enc | quote }}
   rabbitmqPassword: {{ .Values.secrets.rabbitmq.password | b64enc | quote }}
   {{- end }}
-  {{- end -}}


### PR DESCRIPTION
Without this PR federation won't work unless a MLS removal key is speicified.
