### PR TITLE
Fix: SCIM user lookup after changing IdP issuer ID

### DIFF
--- a/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
+++ b/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
@@ -24,6 +24,7 @@ import Control.Lens (makeLenses, (.~), (?~))
 import Control.Monad.Except
 import Data.Aeson
 import Data.Aeson.TH
+import Data.Aeson.Types (parseMaybe)
 import Data.Attoparsec.ByteString qualified as AP
 import Data.Binary.Builder qualified as BSB
 import Data.ByteString.Conversion qualified as BSC
@@ -168,6 +169,10 @@ instance FromJSON IdPMetadataInfo where
 instance ToJSON IdPMetadataInfo where
   toJSON (IdPMetadataValue _ x) =
     object ["value" .= SAML.encode x]
+
+-- | (Returning 'Nothing' would be an internal error.)
+idPMetadataToInfo :: SAML.IdPMetadata -> Maybe IdPMetadataInfo
+idPMetadataToInfo = parseMaybe parseJSON . toJSON . IdPMetadataValue undefined
 
 -- Swagger instances
 

--- a/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
+++ b/libs/wire-api/src/Wire/API/User/IdentityProvider.hs
@@ -170,9 +170,11 @@ instance ToJSON IdPMetadataInfo where
   toJSON (IdPMetadataValue _ x) =
     object ["value" .= SAML.encode x]
 
--- | (Returning 'Nothing' would be an internal error.)
-idPMetadataToInfo :: SAML.IdPMetadata -> Maybe IdPMetadataInfo
-idPMetadataToInfo = parseMaybe parseJSON . toJSON . IdPMetadataValue undefined
+idPMetadataToInfo :: SAML.IdPMetadata -> IdPMetadataInfo
+idPMetadataToInfo =
+  -- 'undefined' is fine because `instance toJSON IdPMetadataValue` ignores it.  'fromJust' is
+  -- ok as long as 'parseJSON . toJSON' always yields a value and not 'Nothing'.
+  fromJust . parseMaybe parseJSON . toJSON . IdPMetadataValue undefined
 
 -- Swagger instances
 

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -1109,7 +1109,7 @@ specCRUDIdentityProvider = do
                   --
                   -- FUTUREWORK: deprecate POST!
                   if updateNotReplace
-                    then callIdpUpdate' (env ^. teSpar) (Just owner1) (idp1 ^. SAML.idpId) (fromJust $ idPMetadataToInfo idpmeta2)
+                    then callIdpUpdate' (env ^. teSpar) (Just owner1) (idp1 ^. SAML.idpId) (idPMetadataToInfo idpmeta2)
                     else callIdpCreateReplace (env ^. teWireIdPAPIVersion) (env ^. teSpar) (Just owner1) idpmeta2 (idp1 ^. SAML.idpId)
 
           idp1' <- call $ callIdpGet (env ^. teSpar) (Just owner1) (idp1 ^. SAML.idpId)

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -1061,8 +1061,8 @@ specCRUDIdentityProvider = do
         [ (h, u, e)
           | h <- [False, True], -- are users scim provisioned or via team management invitations?
             u <- [False, True], -- do we use update-by-put or update-by-post?  (see below)
-            e <- [False, True], -- is the externalId an email address?  (if not, it's a uuidv4, and the email address is stored in `emails`)
             (h, u) /= (True, False), -- scim doesn't not work with more than one idp (https://wearezeta.atlassian.net/browse/WPB-689)
+            e <- [False, True], -- is the externalId an email address?  (if not, it's a uuidv4, and the email address is stored in `emails`)
             (u, u, e) /= (True, True, False) -- TODO: this combination fails, see https://github.com/wireapp/wire-server/pull/3563)
         ]
       $ \(haveScim, updateNotReplace, externalIdIsEmail) -> do
@@ -1123,12 +1123,7 @@ specCRUDIdentityProvider = do
                                    . (idpExtraInfo . oldIssuers .~ [idp1 ^. idpMetadata . edIssuer])
                                else idpExtraInfo . replacedBy .~ idp1' ^. idpExtraInfo . replacedBy
                          )
-            idp2'
-              `shouldBe` ( idp2
-                             & if updateNotReplace
-                               then id
-                               else id
-                         )
+            idp2' `shouldBe` idp2
             idp1 ^. idpMetadata . SAML.edIssuer `shouldBe` (idpmeta1 ^. SAML.edIssuer)
             idp2 ^. idpMetadata . SAML.edIssuer `shouldBe` issuer2
             if updateNotReplace

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -727,7 +727,7 @@ specCRUDIdentityProvider = do
         callIdpUpdateWithHandle (env ^. teSpar) (Just owner) (idp ^. idpId) (IdPMetadataValue (cs $ SAML.encode metadata) undefined) expected
           `shouldRespondWith` ((== 200) . statusCode)
         callIdpGet (env ^. teSpar) (Just owner) (idp ^. idpId)
-          `shouldRespondWith` ((== expected) . (\idp' -> idp' ^. (SAML.idpExtraInfo . handle)))
+          `shouldRespondWith` ((== expected) . (\idp' -> idp' ^. (SAML.idpExtraInfo . handle))) -- wiHandle?
       it "updates IdP metadata and creates a new IdP with the first metadata" $ do
         env <- ask
         (owner, _) <- call $ createUserWithTeam (env ^. teBrig) (env ^. teGalley)
@@ -1054,6 +1054,7 @@ specCRUDIdentityProvider = do
             idp `shouldBe` idp'
             let prefix = "<EntityDescriptor xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:samla=\"urn:oasis:names"
             ST.take (ST.length prefix) rawmeta `shouldBe` prefix
+
     describe "replaces an existing idp" $ do
       it "creates new idp, setting old_issuer; sets replaced_by in old idp" $ do
         env <- ask
@@ -1100,6 +1101,7 @@ specCRUDIdentityProvider = do
           olduid `shouldBe` newuid
           (olduref ^. SAML.uidTenant) `shouldBe` issuer1
           (newuref ^. SAML.uidTenant) `shouldBe` issuer1
+
       it "migrates old users to new idp on their next login on new idp; after that, login on old won't work any more" $ do
         env <- ask
         (owner1, _, idp1, (IdPMetadataValue _ idpmeta1, privkey1)) <- registerTestIdPWithMeta
@@ -1120,6 +1122,7 @@ specCRUDIdentityProvider = do
           (olduref ^. SAML.uidTenant) `shouldBe` issuer1
           (newuref ^. SAML.uidTenant) `shouldBe` issuer2
         tryLoginFail privkey1 idp1 userSubject "cannont-provision-on-replaced-idp"
+
       it "creates non-existent users on new idp" $ do
         env <- ask
         (owner1, _, idp1, (IdPMetadataValue _ idpmeta1, privkey1)) <- registerTestIdPWithMeta

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -81,10 +81,11 @@ import Text.XML.DSig (SignPrivCreds, mkSignCredsWithCert)
 import qualified URI.ByteString as URI
 import URI.ByteString.QQ (uri)
 import Util.Core
-import Util.Scim (filterBy, listUsers, registerScimToken)
+import Util.Scim (createUser, filterBy, listUsers, randomScimUser, randomScimUserWithEmail, registerScimToken)
 import qualified Util.Scim as ScimT
 import Util.Types
 import qualified Web.Cookie as Cky
+import qualified Web.Scim.Class.User as Scim
 import qualified Web.Scim.Schema.User as Scim
 import Wire.API.Team.Member (newTeamMemberDeleteData)
 import Wire.API.Team.Permission hiding (self)
@@ -727,7 +728,7 @@ specCRUDIdentityProvider = do
         callIdpUpdateWithHandle (env ^. teSpar) (Just owner) (idp ^. idpId) (IdPMetadataValue (cs $ SAML.encode metadata) undefined) expected
           `shouldRespondWith` ((== 200) . statusCode)
         callIdpGet (env ^. teSpar) (Just owner) (idp ^. idpId)
-          `shouldRespondWith` ((== expected) . (\idp' -> idp' ^. (SAML.idpExtraInfo . handle))) -- wiHandle?
+          `shouldRespondWith` ((== expected) . (\idp' -> idp' ^. (SAML.idpExtraInfo . handle)))
       it "updates IdP metadata and creates a new IdP with the first metadata" $ do
         env <- ask
         (owner, _) <- call $ createUserWithTeam (env ^. teBrig) (env ^. teGalley)
@@ -1055,34 +1056,103 @@ specCRUDIdentityProvider = do
             let prefix = "<EntityDescriptor xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:samla=\"urn:oasis:names"
             ST.take (ST.length prefix) rawmeta `shouldBe` prefix
 
-    describe "replaces an existing idp" $ do
-      it "creates new idp, setting old_issuer; sets replaced_by in old idp" $ do
-        env <- ask
-        (owner1, _, idp1, (IdPMetadataValue _ idpmeta1, _)) <- registerTestIdPWithMeta
-        issuer2 <- makeIssuer
-        idp2 <-
-          let idpmeta2 = idpmeta1 & edIssuer .~ issuer2
-           in call $ callIdpCreateReplace (env ^. teWireIdPAPIVersion) (env ^. teSpar) (Just owner1) idpmeta2 (idp1 ^. SAML.idpId)
-        idp1' <- call $ callIdpGet (env ^. teSpar) (Just owner1) (idp1 ^. SAML.idpId)
-        idp2' <- call $ callIdpGet (env ^. teSpar) (Just owner1) (idp2 ^. SAML.idpId)
-        liftIO $ do
-          (idp1 & idpExtraInfo . replacedBy .~ (idp1' ^. idpExtraInfo . replacedBy)) `shouldBe` idp1'
-          idp2 `shouldBe` idp2'
-          idp1 ^. idpMetadata . SAML.edIssuer `shouldBe` (idpmeta1 ^. SAML.edIssuer)
-          idp2 ^. idpMetadata . SAML.edIssuer `shouldBe` issuer2
-          idp2 ^. idpId `shouldNotBe` idp1 ^. idpId
-          idp2 ^. idpExtraInfo . oldIssuers `shouldBe` [idpmeta1 ^. edIssuer]
-          idp1' ^. idpExtraInfo . replacedBy `shouldBe` Just (idp2 ^. idpId)
-          -- erase everything that is supposed to be different between idp1, idp2, and make
-          -- sure the result is equal.
-          let erase :: IdP -> IdP
-              erase =
-                (idpId .~ (idp1 ^. idpId))
-                  . (idpMetadata . edIssuer .~ (idp1 ^. idpMetadata . edIssuer))
-                  . (idpExtraInfo . oldIssuers .~ (idp1 ^. idpExtraInfo . oldIssuers))
-                  . (idpExtraInfo . replacedBy .~ (idp1 ^. idpExtraInfo . replacedBy))
-                  . (idpExtraInfo . handle .~ (idp1 ^. idpExtraInfo . handle))
-          erase idp1 `shouldBe` erase idp2
+    describe "replaces an existing idp"
+      $ forM_
+        [ (h, u, e)
+          | h <- [False, True], -- are users scim provisioned or via team management invitations?
+            u <- [False, True], -- do we use update-by-put or update-by-post?  (see below)
+            e <- [False, True], -- is the externalId an email address?  (if not, it's a uuidv4, and the email address is stored in `emails`)
+            (h, u) /= (True, False), -- scim doesn't not work with more than one idp (https://wearezeta.atlassian.net/browse/WPB-689)
+            (u, u, e) /= (True, True, False) -- TODO: this combination fails, see https://github.com/wireapp/wire-server/pull/3563)
+        ]
+      $ \(haveScim, updateNotReplace, externalIdIsEmail) -> do
+        it ("creates new idp, setting old_issuer; sets replaced_by in old idp; scim user search still works " <> show (haveScim, updateNotReplace, externalIdIsEmail)) $ do
+          env <- ask
+          (owner1, teamid, idp1, (IdPMetadataValue _ idpmeta1, _privCreds)) <- registerTestIdPWithMeta
+          let idp1id = idp1 ^. idpId
+
+          mbScimStuff :: Maybe (ScimToken, Scim.StoredUser SparTag, Scim.User SparTag) <-
+            if haveScim
+              then do
+                tok <- registerScimToken teamid (Just idp1id)
+                user <-
+                  if externalIdIsEmail
+                    then fst <$> randomScimUserWithEmail
+                    else randomScimUser
+                scimStoredUser <- createUser tok user
+                pure $ Just (tok, scimStoredUser, user)
+              else pure Nothing
+
+          let checkScimSearch ::
+                HasCallStack =>
+                (ScimToken, Scim.StoredUser SparTag, Scim.User SparTag) ->
+                ReaderT TestEnv IO ()
+              checkScimSearch (tok, target, searchKeys) = do
+                let Just externalId = Scim.externalId searchKeys
+                    handle' = Scim.userName searchKeys
+                respId <- listUsers tok (Just (filterBy "externalId" externalId))
+                respHandle <- listUsers tok (Just (filterBy "userName" handle'))
+                liftIO $ do
+                  respId `shouldBe` [target]
+                  respHandle `shouldBe` [target]
+
+          checkScimSearch `mapM_` mbScimStuff
+
+          issuer2 <- makeIssuer
+          idp2 <- do
+            let idpmeta2 = idpmeta1 & edIssuer .~ issuer2
+             in call $
+                  -- There are two mechanisms for re-aligning your team when your IdP metadata
+                  -- has changed: POST (create a new one, and mark it as replacing the old one),
+                  -- and PUT (updating the existing IdP's metadata).  The reason for having two
+                  -- ways to do this has been lost in history, but we're testing both here.
+                  --
+                  -- FUTUREWORK: deprecate POST?
+                  if updateNotReplace
+                    then callIdpUpdate' (env ^. teSpar) (Just owner1) (idp1 ^. SAML.idpId) (fromJust $ idPMetadataToInfo idpmeta2)
+                    else callIdpCreateReplace (env ^. teWireIdPAPIVersion) (env ^. teSpar) (Just owner1) idpmeta2 (idp1 ^. SAML.idpId)
+
+          idp1' <- call $ callIdpGet (env ^. teSpar) (Just owner1) (idp1 ^. SAML.idpId)
+          idp2' <- call $ callIdpGet (env ^. teSpar) (Just owner1) (idp2 ^. SAML.idpId)
+          liftIO $ do
+            idp1'
+              `shouldBe` ( idp1
+                             & if updateNotReplace
+                               then
+                                 (idpMetadata . edIssuer .~ (idp2' ^. idpMetadata . edIssuer))
+                                   . (idpExtraInfo . oldIssuers .~ [idp1 ^. idpMetadata . edIssuer])
+                               else idpExtraInfo . replacedBy .~ idp1' ^. idpExtraInfo . replacedBy
+                         )
+            idp2'
+              `shouldBe` ( idp2
+                             & if updateNotReplace
+                               then id
+                               else id
+                         )
+            idp1 ^. idpMetadata . SAML.edIssuer `shouldBe` (idpmeta1 ^. SAML.edIssuer)
+            idp2 ^. idpMetadata . SAML.edIssuer `shouldBe` issuer2
+            if updateNotReplace
+              then idp2 ^. idpId `shouldBe` idp1 ^. idpId
+              else idp2 ^. idpId `shouldNotBe` idp1 ^. idpId
+            idp2 ^. idpExtraInfo . oldIssuers `shouldBe` [idpmeta1 ^. edIssuer]
+            idp1' ^. idpExtraInfo . replacedBy
+              `shouldBe` if updateNotReplace
+                then Nothing
+                else Just (idp2 ^. idpId)
+            -- erase everything that is supposed to be different between idp1, idp2, and make
+            -- sure the result is equal.
+            let erase :: IdP -> IdP
+                erase =
+                  (idpId .~ (idp1 ^. idpId))
+                    . (idpMetadata . edIssuer .~ (idp1 ^. idpMetadata . edIssuer))
+                    . (idpExtraInfo . oldIssuers .~ (idp1 ^. idpExtraInfo . oldIssuers))
+                    . (idpExtraInfo . replacedBy .~ (idp1 ^. idpExtraInfo . replacedBy))
+                    . (idpExtraInfo . handle .~ (idp1 ^. idpExtraInfo . handle))
+            erase idp1 `shouldBe` erase idp2
+
+          checkScimSearch `mapM_` mbScimStuff
+
+    describe "replaces an existing idp (cont.)" $ do
       it "users can still login on old idp as before" $ do
         env <- ask
         (owner1, _, idp1, (IdPMetadataValue _ idpmeta1, privkey1)) <- registerTestIdPWithMeta

--- a/services/spar/test-integration/Util/Core.hs
+++ b/services/spar/test-integration/Util/Core.hs
@@ -111,6 +111,7 @@ module Util.Core
     callIdpCreateReplace,
     callIdpCreateReplace',
     callIdpCreateWithHandle,
+    callIdpUpdate',
     callIdpUpdate,
     callIdpUpdateWithHandle,
     callIdpDelete,
@@ -1163,6 +1164,12 @@ callIdpCreateReplace' apiversion sparreq_ muid metadata idpid = do
         ]
       . body (RequestBodyLBS . cs $ SAML.encode metadata)
       . header "Content-Type" "application/xml"
+
+callIdpUpdate' :: (Monad m, MonadIO m, MonadHttp m) => SparReq -> Maybe UserId -> IdPId -> IdPMetadataInfo -> m IdP
+callIdpUpdate' sparreq_ muid idpid metainfo = do
+  resp <- callIdpUpdate (sparreq_ . expect2xx) muid idpid metainfo
+  either (liftIO . throwIO . ErrorCall . show) pure $
+    responseJsonEither @IdP resp
 
 callIdpUpdate :: MonadHttp m => SparReq -> Maybe UserId -> IdPId -> IdPMetadataInfo -> m ResponseLBS
 callIdpUpdate sparreq_ muid idpid (IdPMetadataValue metadata _) = do

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -153,6 +153,12 @@ randomScimUserWithSubjectAndRichInfo richInfo = do
       subj
     )
 
+-- | Use the email address as externalId.
+--
+-- FUTUREWORK: since https://wearezeta.atlassian.net/browse/SQSERVICES-157 is done, we also
+-- support externalIds that are not emails, and storing email addresses in `emails` in the
+-- scim schema.  `randomScimUserWithEmail` is from a time where non-idp-authenticated users
+-- could only be provisioned with email as externalId.  we should probably rework all that.
 randomScimUserWithEmail :: MonadRandom m => m (Scim.User.User SparTag, Email)
 randomScimUserWithEmail = do
   suffix <- cs <$> replicateM 7 (getRandomR ('0', '9'))


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-3530

this only adds a set of integration test with one failing (and thus deactivated) instance.  fix coming up in #3563, but i'd rather merge this now and keep the other PR smaller.

## Checklist

 - [ ] ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
