### PR TITLE
[WPB-3394] Sending proteus messages when a remote backend is offline (update)

### DIFF
--- a/changelog.d/2-features/pr-3460
+++ b/changelog.d/2-features/pr-3460
@@ -1,1 +1,1 @@
-When a proteus message is send and a remote user's backend is offline, the message will be enqueued and reported as `failed_to_confirm_clients`
+When a proteus message is send and a remote user's backend is offline, the message will be enqueued and reported as `failed_to_confirm_clients` (#3460, #3474)

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -492,17 +492,12 @@ postQualifiedOtrMessage senderType sender mconn lcnv msg =
           predicate (d, (u, _)) = any (\(d', (u', _)) -> d == d' && u == u') failed'
           -- Failed users/clients aren't redundant
           (failed, redundant) = partition predicate redundant'
+          collectedFailedToSend = collectFailedToSend [qualifiedUserClients failedToSend, toDomMap unconfirmedUnknownClients, fromDomUserClient failed]
       pure
         otrResult
-          { mssFailedToSend =
-              QualifiedUserClients $
-                collectFailedToSend
-                  [ qualifiedUserClients failedToSend,
-                    toDomMap unconfirmedUnknownClients,
-                    fromDomUserClient failed
-                  ],
+          { mssFailedToSend = QualifiedUserClients collectedFailedToSend,
             mssRedundantClients = QualifiedUserClients $ fromDomUserClient redundant,
-            mssFailedToConfirmClients = QualifiedUserClients $ toDomMap unconfirmedKnownClients
+            mssFailedToConfirmClients = QualifiedUserClients $ collectFailedToSend $ [toDomMap unconfirmedKnownClients, collectedFailedToSend]
           }
   where
     -- Get the triples for domains, users, and clients so we can easily filter

--- a/services/galley/src/Galley/API/Message.hs
+++ b/services/galley/src/Galley/API/Message.hs
@@ -533,6 +533,7 @@ postQualifiedOtrMessage senderType sender mconn lcnv msg =
                 qualifiedOtrRecipientsMap $
                   qualifiedNewOtrRecipients msg
 
+-- FUTUREWORK: This is just a workaround and would not be needed if we had a proper monoid/semigroup instance for Map where the values have a monoid instance.
 collectFailedToSend ::
   Foldable f =>
   f (Map Domain (Map UserId (Set ClientId))) ->

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -1152,18 +1152,12 @@ postMessageQualifiedFailedToSendFetchingClients = do
 
   (resp2, _requests) <- postProteusMessageQualifiedWithMockFederator aliceUnqualified aliceClient convId message "data" Message.MismatchReportAll mock
 
-  let qUsrClients quid cids =
+  let failedToSend = QualifiedUserClients $ Map.fromList [(qDomain deeRemote, Map.fromList [(qUnqualified deeRemote, mempty)])]
+      failedToConfirm =
         QualifiedUserClients $
           Map.fromList
-            [ ( qDomain quid,
-                Map.fromList
-                  [ (qUnqualified quid, Set.fromList cids)
-                  ]
-              )
+            [ (qDomain bobRemote, Map.fromList [(qUnqualified bobRemote, Set.fromList [bobClient]), (qUnqualified deeRemote, mempty)])
             ]
-
-      failedToSend = qUsrClients deeRemote []
-      failedToConfirm = qUsrClients bobRemote [bobClient]
 
   pure resp2 !!! do
     const 201 === statusCode


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-3394

This is an update to https://github.com/wireapp/wire-server/pull/3460

Users that are in `failed_to_send` are now also included in `failed_to_confirm_clients`.

No need to update change log.

## Checklist

 - [ ] ~Add a new entry in an appropriate subdirectory of `changelog.d`~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
