### PR TITLE
Fix defederate loop - the easy part

### DIFF
--- a/changelog.d/3-bug-fixes/pr-3477
+++ b/changelog.d/3-bug-fixes/pr-3477
@@ -1,0 +1,1 @@
+Fix: When defederating, don't crash on already-deleted conversations.

--- a/changelog.d/6-federation/pr-3477
+++ b/changelog.d/6-federation/pr-3477
@@ -1,0 +1,1 @@
+Fix: When defederating, don't crash on already-deleted conversations.

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -554,6 +554,7 @@ internalDeleteFederationDomainH (domain ::: _) = do
 
 -- Remove remote members from local conversations
 deleteFederationDomainRemoteUserFromLocalConversations ::
+  forall r.
   ( Member (Input Env) r,
     Member (P.Logger (Msg -> Msg)) r,
     Member (Error InternalError) r,
@@ -578,7 +579,6 @@ deleteFederationDomainRemoteUserFromLocalConversations dom = do
     -- clients. Maybe suppress and send out a bulk version?
     -- All errors, either exceptions or Either e, get thrown into IO
     mapToRuntimeError @F.RemoveFromConversationError (InternalErrorWithDescription "Federation domain removal: Remove from conversation error")
-      . mapToRuntimeError @'ConvNotFound (InternalErrorWithDescription "Federation domain removal: Conversation not found")
       . mapToRuntimeError @('ActionDenied 'RemoveConversationMember) (InternalErrorWithDescription "Federation domain removal: Action denied, remove conversation member")
       . mapToRuntimeError @'InvalidOperation (InternalErrorWithDescription "Federation domain removal: Invalid operation")
       . mapToRuntimeError @'NotATeamMember (InternalErrorWithDescription "Federation domain removal: Not a team member")
@@ -588,9 +588,24 @@ deleteFederationDomainRemoteUserFromLocalConversations dom = do
       -- DOS our users if a large and deeply interconnected federation
       -- member is removed. Sending out hundreds or thousands of events
       -- to each client isn't something we want to be doing.
-      . getConversation lCnvId
-      >>= maybe (pure () {- conv already gone, nothing to do -})
-      $ \conv -> do
+      $ getConversation (tUnqualified lCnvId)
+        >>= maybe (pure () {- conv already gone, nothing to do -}) (delConv localDomain rUsers)
+  where
+    delConv ::
+      Domain ->
+      N.NonEmpty RemoteMember ->
+      Galley.Data.Conversation.Types.Conversation ->
+      Sem
+        ( Error NoChanges
+            : ErrorS 'NotATeamMember
+            : ErrorS 'InvalidOperation
+            : ErrorS ('ActionDenied 'RemoveConversationMember)
+            : ErrorS RemoveFromConversationError
+            : r
+        )
+        ()
+    delConv localDomain rUsers conv =
+      do
         let lConv = toLocalUnsafe localDomain conv
         updateLocalConversationUserUnchecked
           @'ConversationRemoveMembersTag

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -588,8 +588,9 @@ deleteFederationDomainRemoteUserFromLocalConversations dom = do
       -- DOS our users if a large and deeply interconnected federation
       -- member is removed. Sending out hundreds or thousands of events
       -- to each client isn't something we want to be doing.
-      $ do
-        conv <- getConversationWithError lCnvId
+      . getConversation lCnvId
+      >>= maybe (pure () {- conv already gone, nothing to do -})
+      $ \conv -> do
         let lConv = toLocalUnsafe localDomain conv
         updateLocalConversationUserUnchecked
           @'ConversationRemoveMembersTag


### PR DESCRIPTION
if the main defederation background process fails to remove a remote conversation because it's already gone, it crashes, gives the job back to rabbitMQ, and picks it up again immediately.  this PR avoids this particular situation by gracefully ignoring already-removed conversations.

there are more exceptions that can lead to crash loops, work in progress in https://github.com/wireapp/wire-server/pull/3477 and by @lepsa.

https://wearezeta.atlassian.net/browse/WPB-3631

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
