### PR TITLE
[WPB-3640] Disallow partial success and fix reporting of unreachable backends when creating a Proteus conversation

### DIFF
--- a/changelog.d/1-api-changes/no-partial-success-in-creating-conv
+++ b/changelog.d/1-api-changes/no-partial-success-in-creating-conv
@@ -1,0 +1,1 @@
+The `POST /conversations` endpoint now in case of the Proteus protocol gives a 503 error response listing unreachable backends in case there were any, instead of a 2xx response by adding only members from reachable backends.

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -70,6 +70,7 @@ module Wire.API.Federation.Error
     FederatorClientError (..),
     FederationError (..),
     VersionNegotiationError (..),
+    UnreachableBackendsError (..),
     federationErrorToWai,
     federationRemoteHTTP2Error,
     federationRemoteResponseError,
@@ -167,6 +168,9 @@ data FederationError
     -- needed until we start disregarding the config file.
     FederationUnexpectedError Text
   | -- | One or more remote backends is unreachable
+    --
+    -- FUTUREWORK: Remove this data constructor and rely on the
+    -- 'UnreachableBackendsError' error type instead.
     FederationUnreachableDomainsOld (Set Domain)
   deriving (Show, Typeable)
 
@@ -175,6 +179,12 @@ data VersionNegotiationError
   | RemoteTooOld
   | RemoteTooNew
   deriving (Show, Typeable)
+
+-- | A new error type in federation that describes a collection of unreachable
+-- backends by providing their domains.
+newtype UnreachableBackendsError = UnreachableBackendsError
+  { unUnreachableBackendsError :: Set Domain
+  }
 
 versionNegotiationErrorMessage :: VersionNegotiationError -> LText
 versionNegotiationErrorMessage InvalidVersionInfo =

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -167,7 +167,7 @@ data FederationError
     -- needed until we start disregarding the config file.
     FederationUnexpectedError Text
   | -- | One or more remote backends is unreachable
-    FederationUnreachableDomains (Set Domain)
+    FederationUnreachableDomainsOld (Set Domain)
   deriving (Show, Typeable)
 
 data VersionNegotiationError
@@ -195,7 +195,7 @@ federationErrorToWai FederationNotConfigured = federationNotConfigured
 federationErrorToWai (FederationCallFailure err) = federationClientErrorToWai err
 federationErrorToWai (FederationUnexpectedBody s) = federationUnexpectedBody s
 federationErrorToWai (FederationUnexpectedError t) = federationUnexpectedError t
-federationErrorToWai (FederationUnreachableDomains ds) = federationUnreachableError ds
+federationErrorToWai (FederationUnreachableDomainsOld ds) = federationUnreachableError ds
 
 federationClientErrorToWai :: FederatorClientError -> Wai.Error
 federationClientErrorToWai (FederatorClientHTTP2Error e) =
@@ -366,4 +366,4 @@ throwUnreachableUsers =
     . unreachableUsers
 
 throwUnreachableDomains :: Member (P.Error FederationError) r => Set Domain -> Sem r a
-throwUnreachableDomains = P.throw . FederationUnreachableDomains
+throwUnreachableDomains = P.throw . FederationUnreachableDomainsOld

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -196,6 +196,7 @@ type InternalAPIBase =
     :<|> Named
            "connect"
            ( Summary "Create a connect conversation (deprecated)"
+               :> MakesFederatedCall 'Brig "api-version"
                :> MakesFederatedCall 'Galley "on-conversation-created"
                :> MakesFederatedCall 'Galley "on-conversation-updated"
                :> CanThrow 'ConvNotFound
@@ -206,7 +207,7 @@ type InternalAPIBase =
                :> "conversations"
                :> "connect"
                :> ReqBody '[Servant.JSON] Connect
-               :> ConversationVerb
+               :> ExtendedConversationVerb
            )
     :<|> Named
            "guard-legalhold-policy-conflicts"

--- a/services/federator/src/Federator/MockServer.hs
+++ b/services/federator/src/Federator/MockServer.hs
@@ -44,7 +44,7 @@ import Control.Monad.Catch hiding (fromException)
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Maybe
 import Data.Aeson qualified as Aeson
-import Data.Domain (Domain)
+import Data.Domain
 import Data.Text qualified as Text
 import Data.Text.Lazy qualified as LText
 import Federator.Error
@@ -72,12 +72,22 @@ import Wire.Sem.Logger.TinyLog
 
 -- | This can be thrown by actions passed to mock federator to simulate
 -- failures either in federator itself, or in the services it calls.
-data MockException = MockErrorResponse HTTP.Status LText
+data MockException
+  = MockErrorResponse HTTP.Status LText
+  | MockUnreachableBackendErrorResponse Domain
   deriving (Eq, Show, Typeable)
 
 instance AsWai MockException where
   toWai (MockErrorResponse status message) = Wai.mkError status "mock-error" message
+  toWai (MockUnreachableBackendErrorResponse d) =
+    Wai.mkError HTTP.status503 "mock-error" (unreachableMsg d)
   waiErrorDescription (MockErrorResponse _ message) = LText.toStrict message
+  waiErrorDescription (MockUnreachableBackendErrorResponse d) =
+    LText.toStrict . unreachableMsg $ d
+
+unreachableMsg :: Domain -> LText
+unreachableMsg (LText.fromStrict . domainText -> d) =
+  "unreachable_backend: " <> d
 
 instance Exception MockException
 
@@ -124,8 +134,8 @@ mockInternalRequest ::
   Wai.Request ->
   Sem r Wai.Response
 mockInternalRequest remoteCalls headers resp targetDomain component (RPC path) req = do
-  domainText <- note NoOriginDomain $ lookup originDomainHeaderName (Wai.requestHeaders req)
-  originDomain <- parseDomain domainText
+  domainTxt <- note NoOriginDomain $ lookup originDomainHeaderName (Wai.requestHeaders req)
+  originDomain <- parseDomain domainTxt
   reqBody <- embed $ Wai.lazyRequestBody req
   let fedRequest =
         ( FederatedRequest
@@ -238,13 +248,12 @@ guardComponent c = do
 mockReply :: Aeson.ToJSON a => a -> Mock LByteString
 mockReply = pure . Aeson.encode
 
--- | Provide a mock reply simulating unreachable backends given by their
--- domains.
+-- | Provide a mock reply simulating an unreachable backend.
 mockUnreachableFor :: Set Domain -> Mock LByteString
 mockUnreachableFor backends = do
   target <- frTargetDomain <$> getRequest
   guard (target `elem` backends)
-  throw (MockErrorResponse HTTP.status503 "Down for maintenance.")
+  throw (MockUnreachableBackendErrorResponse target)
 
 -- | Abort the mock with an error.
 mockFail :: Text -> Mock a

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -773,10 +773,6 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
         logError
           "api-version"
           "An error occurred while communicating with federated server: "
-      -- TODO(md): accumulate all 'FederationUnreachableDomains' errors by
-      -- making a union of all the domains from all the requests, and not just
-      -- the domains (or actually just one domain) received from a single
-      -- request. Throw the collected domains after unioning them all.
       for_ failedNotifies $ \case
         -- rethrow invalid-domain errors and mis-configured federation errors
         (_, ex@(FederationCallFailure (FederatorClientError (Wai.Error (Wai.Status 422 _) _ _ _)))) -> throw ex

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -761,36 +761,42 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
           . bmRemotes
           $ targets
   update <- do
-    notifyEithers <-
-      E.runFederatedConcurrentlyEither (toList newRemotes) $ \_ -> do
-        void $ fedClient @'Brig @"api-version" ()
-    -- For now these users will not be able to join the conversation until
-    -- queueing and retrying is implemented.
-    let failedNotifies = lefts notifyEithers
-    for_ failedNotifies $
-      logError
-        "api-version"
-        "An error occurred while communicating with federated server: "
-    for_ failedNotifies $ \case
-      -- rethrow invalid-domain errors and mis-configured federation errors
-      (_, ex@(FederationCallFailure (FederatorClientError (Wai.Error (Wai.Status 422 _) _ _ _)))) -> throw ex
-      -- FUTUREWORK: This error occurs when federation strategy is set to `allowDynamic`
-      -- and the remote domain is not in the allow list
-      -- Is it ok to throw all 400 errors?
-      (_, ex@(FederationCallFailure (FederatorClientError (Wai.Error (Wai.Status 400 _) _ _ _)))) -> throw ex
-      (_, ex@(FederationCallFailure (FederatorClientHTTP2Error (FederatorClientConnectionError _)))) -> throw ex
-      -- FUTUREWORK: Default case (`_ -> pure ()`) is now explicit. Do we really want to ignore all these errors?
-      (_, FederationCallFailure (FederatorClientHTTP2Error _)) -> pure ()
-      (_, FederationCallFailure (FederatorClientError _)) -> pure ()
-      (_, FederationCallFailure FederatorClientStreamingNotSupported) -> pure ()
-      (_, FederationCallFailure (FederatorClientServantError _)) -> pure ()
-      (_, FederationCallFailure (FederatorClientVersionNegotiationError _)) -> pure ()
-      (_, FederationCallFailure FederatorClientVersionMismatch) -> pure ()
-      (_, FederationNotImplemented) -> pure ()
-      (_, FederationNotConfigured) -> pure ()
-      (_, FederationUnexpectedBody _) -> pure ()
-      (_, FederationUnexpectedError _) -> pure ()
-      (_, ex@(FederationUnreachableDomains _)) -> throw ex
+    do
+      -- ping new remote backends
+      notifyEithers <-
+        E.runFederatedConcurrentlyEither (toList newRemotes) $ \_ -> do
+          void $ fedClient @'Brig @"api-version" ()
+      -- For now these users will not be able to join the conversation until
+      -- queueing and retrying is implemented.
+      let failedNotifies = lefts notifyEithers
+      for_ failedNotifies $
+        logError
+          "api-version"
+          "An error occurred while communicating with federated server: "
+      -- TODO(md): accumulate all 'FederationUnreachableDomains' errors by
+      -- making a union of all the domains from all the requests, and not just
+      -- the domains (or actually just one domain) received from a single
+      -- request. Throw the collected domains after unioning them all.
+      for_ failedNotifies $ \case
+        -- rethrow invalid-domain errors and mis-configured federation errors
+        (_, ex@(FederationCallFailure (FederatorClientError (Wai.Error (Wai.Status 422 _) _ _ _)))) -> throw ex
+        -- FUTUREWORK: This error occurs when federation strategy is set to `allowDynamic`
+        -- and the remote domain is not in the allow list
+        -- Is it ok to throw all 400 errors?
+        (_, ex@(FederationCallFailure (FederatorClientError (Wai.Error (Wai.Status 400 _) _ _ _)))) -> throw ex
+        (_, ex@(FederationCallFailure (FederatorClientHTTP2Error (FederatorClientConnectionError _)))) -> throw ex
+        -- FUTUREWORK: Default case (`_ -> pure ()`) is now explicit. Do we really want to ignore all these errors?
+        (_, FederationCallFailure (FederatorClientHTTP2Error _)) -> pure ()
+        (_, FederationCallFailure (FederatorClientError _)) -> pure ()
+        (_, FederationCallFailure FederatorClientStreamingNotSupported) -> pure ()
+        (_, FederationCallFailure (FederatorClientServantError _)) -> pure ()
+        (_, FederationCallFailure (FederatorClientVersionNegotiationError _)) -> pure ()
+        (_, FederationCallFailure FederatorClientVersionMismatch) -> pure ()
+        (_, FederationNotImplemented) -> pure ()
+        (_, FederationNotConfigured) -> pure ()
+        (_, FederationUnexpectedBody _) -> pure ()
+        (_, FederationUnexpectedError _) -> pure ()
+        (_, ex@(FederationUnreachableDomainsOld _)) -> throw ex
     updates <-
       E.runFederatedConcurrentlyEither (toList (bmRemotes targets)) $
         \ruids -> do

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -259,7 +259,7 @@ leaveConversation requestingDomain lc = do
                 Nothing
                 ()
         case outcome of
-          Left e@(FederationUnreachableDomains _) -> throw e
+          Left e@(FederationUnreachableDomainsOld _) -> throw e
           Left e -> do
             logFederationError lcnv e
             throw . internalErr $ e
@@ -282,7 +282,7 @@ leaveConversation requestingDomain lc = do
               botsAndMembers
               ()
         case outcome of
-          Left e@(FederationUnreachableDomains _) -> throw e
+          Left e@(FederationUnreachableDomainsOld _) -> throw e
           Left e -> do
             logFederationError lcnv e
             throw . internalErr $ e
@@ -421,7 +421,7 @@ onUserDeleted origDomain udcn = do
                     botsAndMembers
                     ()
               case outcome of
-                Left e@(FederationUnreachableDomains _) -> throw e
+                Left e@(FederationUnreachableDomainsOld _) -> throw e
                 Left e -> logFederationError lc e
                 Right _ -> pure ()
   pure EmptyResponse

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -783,7 +783,7 @@ registerRemoteConversationMemberships now lc = do
       $ unreachableBackends
 
   do
-    -- let remote backends now about a subset of new joiners
+    -- let remote backends know about a subset of new joiners
     failedToNotify :: Set Domain <- fmap (Set.fromList . foldMap (either (pure . tDomain . fst) mempty)) $
       runFederatedConcurrentlyEither allRemoteMembersQualified $
         \rrms ->

--- a/services/galley/src/Galley/Data/Types.hs
+++ b/services/galley/src/Galley/Data/Types.hs
@@ -27,7 +27,6 @@ module Galley.Data.Types
     generate,
     mkKey,
     LockAcquired (..),
-    MemberAddFailed,
   )
 where
 
@@ -35,7 +34,6 @@ import Data.ByteString qualified as BS
 import Data.ByteString.Conversion
 import Data.Code
 import Data.Id
-import Data.Qualified
 import Data.Range
 import Data.Text.Ascii qualified as Ascii
 import Galley.Data.Conversation
@@ -101,7 +99,3 @@ data LockAcquired
   = Acquired
   | NotAcquired
   deriving (Show, Eq)
-
--- | Set of users that could not be notified of their addition to a new conversation, and
--- should be removed from the conv for consistency.
-type MemberAddFailed = Set (Remote UserId)

--- a/services/galley/test/integration/API/Federation/Util.hs
+++ b/services/galley/test/integration/API/Federation/Util.hs
@@ -22,6 +22,7 @@ module API.Federation.Util
     BackendReachability (..),
     Backend (..),
     rbReachable,
+    participating,
   )
 where
 
@@ -124,3 +125,9 @@ data Backend = Backend
 
 rbReachable :: Remote Backend -> BackendReachability
 rbReachable = bReachable . tUnqualified
+
+participating :: Remote Backend -> [a] -> [a]
+participating rb users =
+  if rbReachable rb == BackendReachable
+    then users
+    else []

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -20,6 +20,7 @@
 
 module API.Util where
 
+import API.Federation.Util
 import API.SQS qualified as SQS
 import Bilge hiding (timeout)
 import Bilge.Assert
@@ -3019,4 +3020,10 @@ createAndConnectUsers domains = do
       (True, False) -> connectWithRemoteUser (qUnqualified a) b
       (False, True) -> connectWithRemoteUser (qUnqualified b) a
       (False, False) -> pure ()
+  pure users
+
+connectBackend :: UserId -> Remote Backend -> TestM [Qualified UserId]
+connectBackend usr (tDomain &&& bUsers . tUnqualified -> (d, c)) = do
+  users <- replicateM (fromIntegral c) (randomQualifiedId d)
+  mapM_ (connectWithRemoteUser usr) users
   pure users


### PR DESCRIPTION
Instead of partially succeeding when creating a Proteus conversation with unreachable remote users, now the `POST /conversations` endpoint returns a 503 error listing unreachable backends, as documented at https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/28837389/Use+Case+Create+a+group+conversation.

Tracked by https://wearezeta.atlassian.net/browse/WPB-3640.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
