### PR TITLE
Turn UnreachableBackends response into a Polysemy error

### DIFF
--- a/changelog.d/1-api-changes/WPB-2542
+++ b/changelog.d/1-api-changes/WPB-2542
@@ -1,6 +1,0 @@
-list unavailable backends as JSON on federation-unreachable-domains-error
-- extend `federation-unreachable-domains-error` by `FederationErrorData`
-- add `domains` field in `FederationErrorData`, containing the list of failing
-  domains
-- deprecate `domain` field in `FederationErrorData` which now contains the first
-  element of `domains`

--- a/changelog.d/1-api-changes/WPB-3640
+++ b/changelog.d/1-api-changes/WPB-3640
@@ -1,0 +1,1 @@
+Conversation creation endpoints can now return `unreachable_backends` error responses with status code 503 if any of the involved backends are unreachable. The conversation is not created in that case.

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -51,8 +51,8 @@ testDynamicBackendsNotFederating = do
         $ bindResponse
           (getFederationStatus uidA [domainB, domainC])
         $ \resp -> do
-          resp.status `shouldMatchInt` 422
-          resp.json %. "label" `shouldMatch` "federation-denied"
+          resp.status `shouldMatchInt` 503
+          resp.json %. "unreachable_backends" `shouldMatchSet` [domainB, domainC]
 
 testDynamicBackendsFullyConnectedWhenAllowDynamic :: HasCallStack => App ()
 testDynamicBackendsFullyConnectedWhenAllowDynamic = do
@@ -123,8 +123,8 @@ testFederationStatus = do
   bindResponse
     (getFederationStatus uid [invalidDomain])
     $ \resp -> do
-      resp.status `shouldMatchInt` 422
-      resp.json %. "label" `shouldMatch` "invalid-domain"
+      resp.status `shouldMatchInt` 503
+      resp.json %. "unreachable_backends" `shouldMatchSet` [invalidDomain]
 
   bindResponse
     (getFederationStatus uid [federatingRemoteDomain])

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Error.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Error.hs
@@ -31,8 +31,6 @@ import Control.Error
 import Data.Aeson hiding (Error)
 import Data.Aeson.Types (Pair)
 import Data.Domain
-import Data.List.NonEmpty (NonEmpty)
-import Data.List.NonEmpty qualified as NE
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Imports
 import Network.HTTP.Types
@@ -51,24 +49,23 @@ mkError c l m = Error c l m Nothing
 instance Exception Error
 
 data ErrorData = FederationErrorData
-  { federrDomains :: NonEmpty Domain,
+  { federrDomain :: !Domain,
     federrPath :: !Text
   }
   deriving (Eq, Show, Typeable)
 
 instance ToJSON ErrorData where
-  toJSON (FederationErrorData ds p) =
+  toJSON (FederationErrorData d p) =
     object
       [ "type" .= ("federation" :: Text),
-        "domain" .= NE.head ds, -- deprecated in favour for `domains`
-        "domains" .= ds,
+        "domain" .= d,
         "path" .= p
       ]
 
 instance FromJSON ErrorData where
   parseJSON = withObject "ErrorData" $ \o ->
     FederationErrorData
-      <$> o .: "domains"
+      <$> o .: "domain"
       <*> o .: "path"
 
 -- | Assumes UTF-8 encoding.

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -57,11 +57,9 @@ import Data.ByteString.Builder
 import Data.ByteString.Char8 qualified as C
 import Data.ByteString.Lazy qualified as LBS
 import Data.Domain (domainText)
-import Data.List.NonEmpty qualified as NE
 import Data.Metrics.GC (spawnGCMetricsCollector)
 import Data.Metrics.Middleware
 import Data.Streaming.Zlib (ZlibException (..))
-import Data.Text qualified as T
 import Data.Text.Encoding.Error (lenientDecode)
 import Data.Text.Lazy.Encoding qualified as LT
 import Imports
@@ -400,13 +398,8 @@ logErrorMsg (Wai.Error c l m md) =
     . maybe id logErrorData md
     . msg (val "\"" +++ m +++ val "\"")
   where
-    logErrorData (Wai.FederationErrorData (NE.toList -> d) p) =
-      field
-        "domains"
-        ( val "["
-            +++ T.intercalate ", " (map domainText d)
-            +++ val "]"
-        )
+    logErrorData (Wai.FederationErrorData d p) =
+      field "domain" (domainText d)
         . field "path" p
 
 logErrorMsgWithRequest :: Maybe ByteString -> Wai.Error -> Msg -> Msg

--- a/libs/wire-api-federation/default.nix
+++ b/libs/wire-api-federation/default.nix
@@ -26,7 +26,6 @@
 , lib
 , metrics-wai
 , mtl
-, polysemy
 , QuickCheck
 , schema-profunctor
 , servant
@@ -67,7 +66,6 @@ mkDerivation {
     lens
     metrics-wai
     mtl
-    polysemy
     QuickCheck
     schema-profunctor
     servant

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -391,6 +391,7 @@ data ConversationUpdateResponse
   | ConversationUpdateResponseUpdate ConversationUpdate
   | ConversationUpdateResponseNoChanges
   | ConversationUpdateResponseNonFederatingBackends NonFederatingBackends
+  | ConversationUpdateResponseUnreachableBackends UnreachableBackends
   deriving stock (Eq, Show, Generic)
   deriving
     (ToJSON, FromJSON)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -275,6 +275,7 @@ data RemoveFromConversationError
   = RemoveFromConversationErrorRemovalNotAllowed
   | RemoveFromConversationErrorNotFound
   | RemoveFromConversationErrorUnchanged
+  | RemoveFromConversationErrorUnreachable UnreachableBackends
   deriving stock (Eq, Show, Generic)
   deriving
     (ToJSON, FromJSON)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -275,7 +275,6 @@ data RemoveFromConversationError
   = RemoveFromConversationErrorRemovalNotAllowed
   | RemoveFromConversationErrorNotFound
   | RemoveFromConversationErrorUnchanged
-  | RemoveFromConversationErrorUnreachable UnreachableBackends
   deriving stock (Eq, Show, Generic)
   deriving
     (ToJSON, FromJSON)

--- a/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
@@ -44,7 +44,6 @@ import Data.ByteString.Builder
 import Data.ByteString.Conversion (toByteString')
 import Data.ByteString.Lazy qualified as LBS
 import Data.Domain
-import Data.List.NonEmpty (NonEmpty)
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set
 import Data.Text.Encoding qualified as Text
@@ -226,13 +225,13 @@ withHTTP2StreamingRequest successfulStatus req handleResponse = do
         FederatorClientError
           ( mkFailureResponse
               (responseStatusCode resp)
-              [ceTargetDomain env]
+              (ceTargetDomain env)
               (toLazyByteString (requestPath req))
               (toLazyByteString bdy)
           )
 
-mkFailureResponse :: HTTP.Status -> NonEmpty Domain -> LByteString -> LByteString -> Wai.Error
-mkFailureResponse status domains path body
+mkFailureResponse :: HTTP.Status -> Domain -> LByteString -> LByteString -> Wai.Error
+mkFailureResponse status domain path body
   -- If the outward federator fails with 403, that means that there was an
   -- error at the level of the local federator (most likely due to a bug somewhere
   -- in wire-server). It does not make sense to return this error directly to the
@@ -252,7 +251,7 @@ mkFailureResponse status domains path body
         { Wai.errorData =
             Just
               Wai.FederationErrorData
-                { Wai.federrDomains = domains,
+                { Wai.federrDomain = domain,
                   Wai.federrPath =
                     "/federation"
                       <> Text.decodeUtf8With Text.lenientDecode (LBS.toStrict path)

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -66,27 +66,23 @@
 -- error response from services during a federated call should be considered a bug
 -- in the implementation of the federation API, and is therefore wrapped in a 533.
 module Wire.API.Federation.Error
-  ( FederatorClientHTTP2Error (..),
+  ( -- * Federation errors
+    FederatorClientHTTP2Error (..),
     FederatorClientError (..),
     FederationError (..),
     VersionNegotiationError (..),
-    UnreachableBackendsError (..),
     federationErrorToWai,
     federationRemoteHTTP2Error,
     federationRemoteResponseError,
     federationNotImplemented,
     federationNotConfigured,
 
-    -- * utilities
-    throwUnreachableUsers,
-    throwUnreachableDomains,
+    -- * Error status codes
+    unexpectedFederationResponseStatus,
+    federatorConnectionRefusedStatus,
   )
 where
 
-import Data.Domain
-import Data.List.NonEmpty qualified as NE
-import Data.Qualified
-import Data.Set qualified as Set
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.Text.Lazy qualified as LT
@@ -96,11 +92,8 @@ import Network.HTTP.Types.Status qualified as HTTP
 import Network.HTTP2.Client qualified as HTTP2
 import Network.Wai.Utilities.Error qualified as Wai
 import OpenSSL.Session (SomeSSLException)
-import Polysemy
-import Polysemy.Error qualified as P
 import Servant.Client
 import Wire.API.Error
-import Wire.API.Unreachable
 
 -- | Transport-layer errors in federator client.
 data FederatorClientHTTP2Error
@@ -166,11 +159,6 @@ data FederationError
     -- like "can't delete remote domains from config file", which is only
     -- needed until we start disregarding the config file.
     FederationUnexpectedError Text
-  | -- | One or more remote backends is unreachable
-    --
-    -- FUTUREWORK: Remove this data constructor and rely on the
-    -- 'UnreachableBackendsError' error type instead.
-    FederationUnreachableDomainsOld (Set Domain)
   deriving (Show, Typeable)
 
 data VersionNegotiationError
@@ -178,12 +166,6 @@ data VersionNegotiationError
   | RemoteTooOld
   | RemoteTooNew
   deriving (Show, Typeable)
-
--- | A new error type in federation that describes a collection of unreachable
--- backends by providing their domains.
-newtype UnreachableBackendsError = UnreachableBackendsError
-  { unUnreachableBackendsError :: Set Domain
-  }
 
 versionNegotiationErrorMessage :: VersionNegotiationError -> LText
 versionNegotiationErrorMessage InvalidVersionInfo =
@@ -204,7 +186,6 @@ federationErrorToWai FederationNotConfigured = federationNotConfigured
 federationErrorToWai (FederationCallFailure err) = federationClientErrorToWai err
 federationErrorToWai (FederationUnexpectedBody s) = federationUnexpectedBody s
 federationErrorToWai (FederationUnexpectedError t) = federationUnexpectedError t
-federationErrorToWai (FederationUnreachableDomainsOld ds) = federationUnreachableError ds
 
 federationClientErrorToWai :: FederatorClientError -> Wai.Error
 federationClientErrorToWai (FederatorClientHTTP2Error e) =
@@ -331,16 +312,6 @@ federationUnexpectedError msg =
     "federation-unexpected-wai-error"
     ("Could parse body, but got an unexpected error response: " <> LT.fromStrict msg)
 
-federationUnreachableError :: Set Domain -> Wai.Error
-federationUnreachableError (Set.map domainText -> ds) =
-  Wai.mkError
-    status
-    "federation-unreachable-domains-error"
-    ("The following domains are unreachable: " <> (LT.pack . show . Set.toList) ds)
-  where
-    status :: Status
-    status = HTTP.Status 503 "Unreachable federated domains"
-
 federationNotConfigured :: Wai.Error
 federationNotConfigured =
   Wai.mkError
@@ -361,17 +332,3 @@ federationUnknownError =
     unexpectedFederationResponseStatus
     "unknown-federation-error"
     "Unknown federation error"
-
---------------------------------------------------------------------------------
--- Utilities
-
-throwUnreachableUsers :: Member (P.Error FederationError) r => UnreachableUsers -> Sem r a
-throwUnreachableUsers =
-  throwUnreachableDomains
-    . Set.fromList
-    . NE.toList
-    . fmap qDomain
-    . unreachableUsers
-
-throwUnreachableDomains :: Member (P.Error FederationError) r => Set Domain -> Sem r a
-throwUnreachableDomains = P.throw . FederationUnreachableDomainsOld

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -94,7 +94,6 @@ import Imports
 import Network.HTTP.Types.Status
 import Network.HTTP.Types.Status qualified as HTTP
 import Network.HTTP2.Client qualified as HTTP2
-import Network.Wai.Utilities.Error
 import Network.Wai.Utilities.Error qualified as Wai
 import OpenSSL.Session (SomeSSLException)
 import Polysemy
@@ -333,12 +332,11 @@ federationUnexpectedError msg =
     ("Could parse body, but got an unexpected error response: " <> LT.fromStrict msg)
 
 federationUnreachableError :: Set Domain -> Wai.Error
-federationUnreachableError (Set.toList -> ds) =
-  Wai.Error
+federationUnreachableError (Set.map domainText -> ds) =
+  Wai.mkError
     status
     "federation-unreachable-domains-error"
-    ("The following domains are unreachable: " <> (LT.pack . show . map domainText) ds)
-    (flip FederationErrorData T.empty <$> NE.nonEmpty ds)
+    ("The following domains are unreachable: " <> (LT.pack . show . Set.toList) ds)
   where
     status :: Status
     status = HTTP.Status 503 "Unreachable federated domains"

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -97,7 +97,6 @@ library
     , lens
     , metrics-wai
     , mtl
-    , polysemy
     , QuickCheck             >=2.13
     , schema-profunctor
     , servant                >=0.16

--- a/libs/wire-api/src/Wire/API/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Conversation.hs
@@ -35,7 +35,6 @@ module Wire.API.Conversation
     cnvReceiptMode,
     cnvAccessRoles,
     CreateGroupConversation (..),
-    CreateConversationUnreachableBackends (..),
     ConversationCoverView (..),
     ConversationList (..),
     ListConversations (..),
@@ -313,22 +312,6 @@ instance ToSchema CreateGroupConversation where
         (\(d, s) -> flip Qualified d <$> Set.toList s) =<< Map.assocs m
       fromFlatList :: Ord a => [Qualified a] -> Map Domain (Set a)
       fromFlatList = fmap Set.fromList . indexQualified
-
-newtype CreateConversationUnreachableBackends = CreateConversationUnreachableBackends
-  { createConvUnreachableBackends :: Set Domain
-  }
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via (GenericUniform CreateConversationUnreachableBackends)
-  deriving (ToJSON, FromJSON, S.ToSchema) via Schema CreateConversationUnreachableBackends
-
-instance ToSchema CreateConversationUnreachableBackends where
-  schema =
-    objectWithDocModifier
-      "CreateConversationUnreachableBackends"
-      (description ?~ "A federated conversation cannot be created because there are unreachable backends")
-      $ CreateConversationUnreachableBackends
-        <$> (Set.toList . createConvUnreachableBackends)
-          .= field "unreachable_backends" (Set.fromList <$> array schema)
 
 -- | Limited view of a 'Conversation'. Is used to inform users with an invite
 -- link about the conversation.

--- a/libs/wire-api/src/Wire/API/Error/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Error/Galley.hs
@@ -27,13 +27,18 @@ module Wire.API.Error.Galley
     TeamFeatureError (..),
     MLSProposalFailure (..),
     NonFederatingBackends (..),
+    UnreachableBackends (..),
+    unreachableUsersToUnreachableBackends,
+    UnreachableBackendsLegacy (..),
   )
 where
 
 import Control.Lens ((%~), (.~), (?~))
 import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Containers.ListUtils
 import Data.Domain
 import Data.Proxy
+import Data.Qualified
 import Data.Schema
 import Data.Singletons.TH (genSingletons)
 import Data.Swagger qualified as S
@@ -41,6 +46,7 @@ import Data.Tagged
 import GHC.TypeLits
 import Imports
 import Network.HTTP.Types.Status qualified as HTTP
+import Network.Wai.Utilities.Error qualified as Wai
 import Network.Wai.Utilities.JSONResponse
 import Polysemy
 import Polysemy.Error
@@ -51,6 +57,7 @@ import Wire.API.Error.Brig qualified as BrigError
 import Wire.API.Routes.API
 import Wire.API.Team.Member
 import Wire.API.Team.Permission
+import Wire.API.Unreachable
 import Wire.API.Util.Aeson (CustomEncoded (..))
 
 data GalleyError
@@ -451,4 +458,67 @@ instance IsSwaggerError NonFederatingBackends where
 type instance ErrorEffect NonFederatingBackends = Error NonFederatingBackends
 
 instance Member (Error JSONResponse) r => ServerEffect (Error NonFederatingBackends) r where
+  interpretServerEffect = mapError toResponse
+
+--------------------------------------------------------------------------------
+-- Unreachable backends
+
+-- | This is returned when adding members to the conversation is not possible
+-- because the backends involved do not form a fully connected graph.
+data UnreachableBackends = UnreachableBackends {backends :: [Domain]}
+  deriving stock (Eq, Show, Generic)
+  deriving (FromJSON, ToJSON, S.ToSchema) via Schema UnreachableBackends
+
+instance APIError UnreachableBackends where
+  toResponse e =
+    JSONResponse
+      { status = unreachableBackendsStatus,
+        value = toJSON e
+      }
+
+unreachableBackendsStatus :: HTTP.Status
+unreachableBackendsStatus = HTTP.status503
+
+instance ToSchema UnreachableBackends where
+  schema =
+    object "UnreachableBackends" $
+      UnreachableBackends
+        <$> (.backends) .= field "unreachable_backends" (array schema)
+
+instance IsSwaggerError UnreachableBackends where
+  addToSwagger =
+    addErrorResponseToSwagger (HTTP.statusCode unreachableBackendsStatus) $
+      mempty
+        & S.description .~ "Some domains are unreachable"
+        & S.schema ?~ S.Inline (S.toSchema (Proxy @UnreachableBackends))
+
+type instance ErrorEffect UnreachableBackends = Error UnreachableBackends
+
+instance Member (Error JSONResponse) r => ServerEffect (Error UnreachableBackends) r where
+  interpretServerEffect = mapError toResponse
+
+unreachableUsersToUnreachableBackends :: UnreachableUsers -> UnreachableBackends
+unreachableUsersToUnreachableBackends =
+  UnreachableBackends
+    . nubOrd
+    . map qDomain
+    . toList
+    . unreachableUsers
+
+-- | A newtype wrapper to preserve backward compatibility of the error response
+-- for older versions.
+newtype UnreachableBackendsLegacy = UnreachableBackendsLegacy UnreachableBackends
+  deriving (IsSwaggerError)
+
+instance APIError UnreachableBackendsLegacy where
+  toResponse _ =
+    toResponse $
+      Wai.mkError
+        unreachableBackendsStatus
+        "federation-connection-refused"
+        "Some backends are unreachable"
+
+type instance ErrorEffect UnreachableBackendsLegacy = Error UnreachableBackendsLegacy
+
+instance Member (Error JSONResponse) r => ServerEffect (Error UnreachableBackendsLegacy) r where
   interpretServerEffect = mapError toResponse

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -208,7 +208,7 @@ type InternalAPIBase =
                :> "conversations"
                :> "connect"
                :> ReqBody '[Servant.JSON] Connect
-               :> ExtendedConversationVerb
+               :> ConversationVerb
            )
     :<|> Named
            "guard-legalhold-policy-conflicts"

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -419,6 +419,7 @@ type IFederationAPI =
   Named
     "get-federation-status"
     ( Summary "Get the federation status (only needed for integration/QA tests at the time of writing it)"
+        :> CanThrow UnreachableBackends
         :> ZLocalUser
         :> "federation-status"
         :> ReqBody '[Servant.JSON] RemoteDomains

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -202,6 +202,7 @@ type InternalAPIBase =
                :> CanThrow 'ConvNotFound
                :> CanThrow 'InvalidOperation
                :> CanThrow 'NotConnected
+               :> CanThrow UnreachableBackends
                :> ZLocalUser
                :> ZOptConn
                :> "conversations"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -451,6 +451,7 @@ type ConversationAPI =
                :> CanThrow 'NotATeamMember
                :> CanThrow OperationDenied
                :> CanThrow 'MissingLegalholdConsent
+               :> CanThrow UnreachableBackendsLegacy
                :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
                :> ZLocalUser
                :> ZOptClient
@@ -480,6 +481,7 @@ type ConversationAPI =
                :> CanThrow 'NotATeamMember
                :> CanThrow OperationDenied
                :> CanThrow 'MissingLegalholdConsent
+               :> CanThrow UnreachableBackendsLegacy
                :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
                :> ZLocalUser
                :> ZOptClient
@@ -505,6 +507,7 @@ type ConversationAPI =
                :> CanThrow OperationDenied
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow NonFederatingBackends
+               :> CanThrow UnreachableBackends
                :> Description "This returns 201 when a new conversation is created, and 200 when the conversation already existed"
                :> ZLocalUser
                :> ZOptClient
@@ -566,6 +569,7 @@ type ConversationAPI =
                :> CanThrow OperationDenied
                :> CanThrow 'TeamNotFound
                :> CanThrow 'MissingLegalholdConsent
+               :> CanThrow UnreachableBackendsLegacy
                :> ZLocalUser
                :> ZConn
                :> "conversations"
@@ -591,6 +595,7 @@ type ConversationAPI =
                :> CanThrow OperationDenied
                :> CanThrow 'TeamNotFound
                :> CanThrow 'MissingLegalholdConsent
+               :> CanThrow UnreachableBackendsLegacy
                :> ZLocalUser
                :> ZConn
                :> "conversations"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -543,6 +543,7 @@ type ConversationAPI =
                :> CanThrow 'NotConnected
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow NonFederatingBackends
+               :> CanThrow UnreachableBackends
                :> ZLocalUser
                :> ZConn
                :> "conversations"
@@ -567,6 +568,7 @@ type ConversationAPI =
                :> CanThrow 'NotConnected
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow NonFederatingBackends
+               :> CanThrow UnreachableBackends
                :> ZLocalUser
                :> ZConn
                :> "conversations"
@@ -592,6 +594,7 @@ type ConversationAPI =
                :> CanThrow 'NotConnected
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow NonFederatingBackends
+               :> CanThrow UnreachableBackends
                :> ZLocalUser
                :> ZConn
                :> "conversations"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
@@ -148,6 +148,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow MLSProposalFailure
                :> CanThrow NonFederatingBackends
+               :> CanThrow UnreachableBackends
                :> "commit-bundles"
                :> ZLocalUser
                :> ZOptClient

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/MLS.hs
@@ -76,6 +76,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow MLSProposalFailure
                :> CanThrow NonFederatingBackends
+               :> CanThrow UnreachableBackends
                :> "messages"
                :> ZLocalUser
                :> ZOptClient
@@ -111,6 +112,7 @@ type MLSMessagingAPI =
                :> CanThrow 'MissingLegalholdConsent
                :> CanThrow MLSProposalFailure
                :> CanThrow NonFederatingBackends
+               :> CanThrow UnreachableBackends
                :> "messages"
                :> ZLocalUser
                :> ZOptClient

--- a/services/brig/docs/swagger.md
+++ b/services/brig/docs/swagger.md
@@ -49,8 +49,7 @@ For errors that are more likely to be transient, we suggest clients to retry wha
 **Note**: when a failure occurs as a result of making a federated RPC to another backend, the error response contains the following extra fields:
 
  - `type`: "federation" (just the literal string in quotes, which can be used as an error type identifier when parsing errors)
- - `domain`: the target backend of the RPC that failed (deprecated in favour for `domains`);
- - `domains`: the target backends of the RPC which failed;
+ - `domain`: the target backend of the RPC that failed;
  - `path`: the path of the RPC that failed.
 
 ### Domain errors
@@ -58,7 +57,6 @@ For errors that are more likely to be transient, we suggest clients to retry wha
 Errors in this category result from trying to communicate with a backend that is considered non-existent or invalid. They can result from invalid user input or client issues, but they can also be a symptom of misconfiguration in one or multiple backends. These errors have a 4xx status code.
 
  - **Remote backend not found** (status: 422, label: `invalid-domain`): This backend attempted to contact a backend which does not exist or is not properly configured. For the most part, clients can consider this error equivalent to a domain not existing, although it should be noted that certain mistakes in the DNS configuration on a remote backend can lead to the backend not being recognized, and hence to this error. It is therefore not advisable to take any destructive action upon encountering this error, such as deleting remote users from conversations.
- - **Remote backend unreachable** (status: 503, label: `federation-unreachable-domains-error`): Similar to `invalid-domain`.
  - **Federation denied locally** (status: 400, label: `federation-denied`): This backend attempted an RPC to a non-whitelisted backend. Similar considerations as for the previous error apply.
  - **Federation not enabled** (status: 400, label: `federation-not-enabled`): Federation has not been configured for this backend. This will happen if a federation-aware client tries to talk to a backend for which federation is disabled, or if federation was disabled on the backend after reaching a federation-specific state (e.g. conversations with remote users). There is no way to cleanly recover from these errors at this point.
 

--- a/services/brig/test/integration/API/User/Account.hs
+++ b/services/brig/test/integration/API/User/Account.hs
@@ -64,7 +64,6 @@ import Data.Time (UTCTime, getCurrentTime)
 import Data.Time.Clock (diffUTCTime)
 import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUID
-import Data.Vector qualified as V
 import Federator.MockServer (FederatedRequest (..), MockException (..))
 import Imports hiding (head)
 import Imports qualified
@@ -634,8 +633,8 @@ testUserInvalidDomain brig = do
       const 422 === statusCode
       const (Just "/federation/api-version")
         === preview (ix "data" . ix "path") . responseJsonUnsafe @Value
-      const (Just (Array (V.fromList ["invalid.example.com"])))
-        === preview (ix "data" . ix "domains") . responseJsonUnsafe @Value
+      const (Just "invalid.example.com")
+        === preview (ix "data" . ix "domain") . responseJsonUnsafe @Value
 
 testExistingUserUnqualified :: Brig -> Http ()
 testExistingUserUnqualified brig = do

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -806,7 +806,6 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
         (_, FederationNotConfigured) -> pure ()
         (_, FederationUnexpectedBody _) -> pure ()
         (_, FederationUnexpectedError _) -> pure ()
-        (_, ex@(FederationUnreachableDomainsOld _)) -> throw ex
     updates <-
       E.runFederatedConcurrentlyEither (toList (bmRemotes targets)) $
         \ruids -> do

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -40,6 +40,7 @@ module Galley.API.Action
     addLocalUsersToRemoteConv,
     ConversationUpdate,
     getFederationStatus,
+    checkFederationStatus,
     firstConflictOrFullyConnected,
   )
 where
@@ -131,6 +132,7 @@ type family HasConversationActionEffects (tag :: ConversationActionTag) r :: Con
       Member (ErrorS 'TooManyMembers) r,
       Member (ErrorS 'MissingLegalholdConsent) r,
       Member (Error NonFederatingBackends) r,
+      Member (Error UnreachableBackends) r,
       Member ExternalAccess r,
       Member FederatorAccess r,
       Member GundeckAccess r,
@@ -264,10 +266,29 @@ type family HasConversationActionGalleyErrors (tag :: ConversationActionTag) :: 
        ErrorS 'ConvNotFound
      ]
 
-getFederationStatus :: Member FederatorAccess r => Local UserId -> RemoteDomains -> Sem r FederationStatus
-getFederationStatus _ req = do
-  firstConflictOrFullyConnected
-    <$> E.runFederatedConcurrently
+checkFederationStatus ::
+  ( Member (Error UnreachableBackends) r,
+    Member (Error NonFederatingBackends) r,
+    Member FederatorAccess r
+  ) =>
+  RemoteDomains ->
+  Sem r ()
+checkFederationStatus req = do
+  status <- getFederationStatus req
+  case status of
+    FullyConnected -> pure ()
+    NotConnectedDomains dom1 dom2 -> throw (NonFederatingBackends dom1 dom2)
+
+getFederationStatus ::
+  ( Member (Error UnreachableBackends) r,
+    Member FederatorAccess r
+  ) =>
+  RemoteDomains ->
+  Sem r FederationStatus
+getFederationStatus req = do
+  fmap firstConflictOrFullyConnected
+    . (ensureNoUnreachableBackends =<<)
+    $ E.runFederatedConcurrentlyEither
       (flip toRemoteUnsafe () <$> Set.toList req.rdDomains)
       (\qds -> fedClient @'Brig @"get-not-fully-connected-backends" (DomainSet (tDomain qds `Set.delete` req.rdDomains)))
 
@@ -424,9 +445,7 @@ performConversationJoin qusr lconv (ConversationJoin invited role) = do
       Sem r ()
     checkRemoteBackendsConnected lusr = do
       let remoteDomains = tDomain <$> snd (partitionQualified lusr $ NE.toList invited)
-      getFederationStatus lusr (RemoteDomains $ Set.fromList remoteDomains) >>= \case
-        NotConnectedDomains a b -> throw (NonFederatingBackends a b)
-        FullyConnected -> pure ()
+      checkFederationStatus (RemoteDomains $ Set.fromList remoteDomains)
 
     conv :: Data.Conversation
     conv = tUnqualified lconv

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -32,7 +32,6 @@ module Galley.API.Create
 where
 
 import Control.Lens hiding ((??))
-import Data.Domain
 import Data.Id
 import Data.List1 (list1)
 import Data.Misc (FutureWork (FutureWork))
@@ -104,6 +103,7 @@ createGroupConversationUpToV3 ::
     Member (ErrorS 'MLSNonEmptyMemberList) r,
     Member (ErrorS 'MLSMissingSenderClient) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
+    Member (Error UnreachableBackendsLegacy) r,
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input Env) r,
@@ -118,13 +118,15 @@ createGroupConversationUpToV3 ::
   Maybe ConnId ->
   NewConv ->
   Sem r ExtendedConversationResponse
-createGroupConversationUpToV3 lusr mCreatorClient conn newConv =
-  createGroupConversationGeneric
-    lusr
-    mCreatorClient
-    conn
-    newConv
-    (\_ds lu conv -> toExtended <$> conversationCreated lu conv)
+createGroupConversationUpToV3 lusr mCreatorClient conn newConv = mapError UnreachableBackendsLegacy $
+  do
+    conv <-
+      createGroupConversationGeneric
+        lusr
+        mCreatorClient
+        conn
+        newConv
+    toExtended <$> conversationCreated lusr conv
 
 -- | The public-facing endpoint for creating group conversations in the client
 -- API in version 4 and above.
@@ -144,6 +146,7 @@ createGroupConversation ::
     Member (ErrorS 'MLSNonEmptyMemberList) r,
     Member (ErrorS 'MLSMissingSenderClient) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
+    Member (Error UnreachableBackends) r,
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input Env) r,
@@ -160,15 +163,19 @@ createGroupConversation ::
   Sem r CreateGroupConversationResponse
 createGroupConversation lusr mCreatorClient conn newConv = do
   let remoteDomains = tDomain <$> snd (partitionQualified lusr $ newConv.newConvQualifiedUsers)
+  -- TODO: make getFederationStatus throw instead of returning the error
   getFederationStatus lusr (RemoteDomains $ Set.fromList remoteDomains) >>= \case
     NotConnectedDomains rd1 rd2 -> throw $ NonFederatingBackends rd1 rd2
-    FullyConnected ->
-      createGroupConversationGeneric
-        lusr
-        mCreatorClient
-        conn
-        newConv
-        groupConversationCreated
+    FullyConnected -> do
+      cnv <-
+        createGroupConversationGeneric
+          lusr
+          mCreatorClient
+          conn
+          newConv
+      conv <- conversationView lusr cnv
+      pure . GroupConversationCreated $
+        CreateGroupConversation conv mempty
 
 createGroupConversationGeneric ::
   ( Member BrigAccess r,
@@ -185,6 +192,7 @@ createGroupConversationGeneric ::
     Member (ErrorS 'MLSNonEmptyMemberList) r,
     Member (ErrorS 'MLSMissingSenderClient) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
+    Member (Error UnreachableBackends) r,
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input Env) r,
@@ -198,12 +206,8 @@ createGroupConversationGeneric ::
   Maybe ClientId ->
   Maybe ConnId ->
   NewConv ->
-  -- | The function that incorporates unreachable backends in the response. In
-  -- the client API up to and including V3 this function simply ignores the
-  -- first argument.
-  (Set Domain -> Local UserId -> Conversation -> Sem r resp) ->
-  Sem r resp
-createGroupConversationGeneric lusr mCreatorClient conn newConv convRespond = do
+  Sem r Conversation
+createGroupConversationGeneric lusr mCreatorClient conn newConv = do
   (nc, fromConvSize -> allUsers) <- newRegularConversation lusr newConv
   let tinfo = newConvTeam newConv
   checkCreateConvPermissions lusr newConv tinfo allUsers
@@ -230,17 +234,9 @@ createGroupConversationGeneric lusr mCreatorClient conn newConv convRespond = do
       (ProtocolMLS _mlsMeta, Nothing) -> throwS @'MLSMissingSenderClient
 
     -- NOTE: We only send (conversation) events to members of the conversation
-    runError @UnreachableBackendsError
-      (notifyCreatedConversation lusr conn conv)
-      >>= \case
-        Left (UnreachableBackendsError ds) -> do
-          E.deleteConversation . Data.convId $ conv
-          convRespond ds lusr conv
-        Right () -> do
-          c <-
-            E.getConversation (tUnqualified lcnv)
-              >>= note (BadConvState (tUnqualified lcnv))
-          convRespond Set.empty lusr c
+    notifyCreatedConversation lusr conn conv
+    E.getConversation (tUnqualified lcnv)
+      >>= note (BadConvState (tUnqualified lcnv))
 
 ensureNoLegalholdConflicts ::
   ( Member (ErrorS 'MissingLegalholdConsent) r,
@@ -323,7 +319,6 @@ createProteusSelfConversation lusr = do
       conversationCreated lusr c
 
 createOne2OneConversation ::
-  forall r.
   ( Member BrigAccess r,
     Member ConversationStore r,
     Member (Error FederationError) r,
@@ -336,6 +331,7 @@ createOne2OneConversation ::
     Member (ErrorS 'TeamNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member (ErrorS 'NotConnected) r,
+    Member (Error UnreachableBackendsLegacy) r,
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
@@ -346,31 +342,45 @@ createOne2OneConversation ::
   ConnId ->
   NewConv ->
   Sem r ExtendedConversationResponse
-createOne2OneConversation lusr zcon j = do
-  let allUsers = newConvMembers lusr j
-  other <- ensureOne (ulAll lusr allUsers)
-  when (tUntagged lusr == other) $
-    throwS @'InvalidOperation
-  mtid <- case newConvTeam j of
-    Just ti -> do
-      foldQualified
-        lusr
-        (\lother -> checkBindingTeamPermissions lother (cnvTeamId ti))
-        (const (pure Nothing))
-        other
-    Nothing -> ensureConnected lusr allUsers $> Nothing
-  foldQualified
-    lusr
-    (fmap toExtended <$> createLegacyOne2OneConversationUnchecked lusr zcon (newConvName j) mtid)
-    (createOne2OneConversationUnchecked lusr zcon (newConvName j) mtid . tUntagged)
-    other
+createOne2OneConversation lusr zcon j =
+  mapError @UnreachableBackends @UnreachableBackendsLegacy UnreachableBackendsLegacy $ do
+    let allUsers = newConvMembers lusr j
+    other <- ensureOne (ulAll lusr allUsers)
+    when (tUntagged lusr == other) $
+      throwS @'InvalidOperation
+    mtid <- case newConvTeam j of
+      Just ti -> do
+        foldQualified
+          lusr
+          (\lother -> checkBindingTeamPermissions lother (cnvTeamId ti))
+          (const (pure Nothing))
+          other
+      Nothing -> ensureConnected lusr allUsers $> Nothing
+    foldQualified
+      lusr
+      (fmap toExtended <$> createLegacyOne2OneConversationUnchecked lusr zcon (newConvName j) mtid)
+      (createOne2OneConversationUnchecked lusr zcon (newConvName j) mtid . tUntagged)
+      other
   where
-    verifyMembership :: TeamId -> UserId -> Sem r ()
+    verifyMembership ::
+      ( Member (ErrorS 'NoBindingTeamMembers) r,
+        Member TeamStore r
+      ) =>
+      TeamId ->
+      UserId ->
+      Sem r ()
     verifyMembership tid u = do
       membership <- E.getTeamMember tid u
       when (isNothing membership) $
         throwS @'NoBindingTeamMembers
     checkBindingTeamPermissions ::
+      ( Member (ErrorS 'NoBindingTeamMembers) r,
+        Member (ErrorS 'NonBindingTeam) r,
+        Member (ErrorS 'NotATeamMember) r,
+        Member (ErrorS OperationDenied) r,
+        Member (ErrorS 'TeamNotFound) r,
+        Member TeamStore r
+      ) =>
       Local UserId ->
       TeamId ->
       Sem r (Maybe TeamId)
@@ -420,10 +430,9 @@ createLegacyOne2OneConversationUnchecked self zcon name mtid other = do
     Just c -> conversationExisted self c
     Nothing -> do
       c <- E.createConversation lcnv nc
-      runError @UnreachableBackendsError (notifyCreatedConversation self (Just zcon) c)
+      runError @UnreachableBackends (notifyCreatedConversation self (Just zcon) c)
         >>= \case
-          Left (UnreachableBackendsError _) -> do
-            E.deleteConversation (Data.convId c)
+          Left _ -> do
             throw . InternalErrorWithDescription $
               "A one-to-one conversation on one backend cannot involve unreachable backends"
           Right () -> conversationCreated self c
@@ -432,6 +441,7 @@ createOne2OneConversationUnchecked ::
   ( Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
+    Member (Error UnreachableBackends) r,
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
@@ -455,6 +465,7 @@ createOne2OneConversationLocally ::
   ( Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
+    Member (Error UnreachableBackends) r,
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
@@ -485,15 +496,8 @@ createOne2OneConversationLocally lcnv self zcon name mtid other = do
                 ncProtocol = ProtocolProteusTag
               }
       c <- E.createConversation lcnv nc
-      runError @UnreachableBackendsError (notifyCreatedConversation self (Just zcon) c)
-        >>= \case
-          Left (UnreachableBackendsError ds) -> do
-            E.deleteConversation (Data.convId c)
-            pure
-              . ConversationResponseUnreachableBackends
-              . CreateConversationUnreachableBackends
-              $ ds
-          Right () -> toExtended <$> conversationCreated self c
+      notifyCreatedConversation self (Just zcon) c
+      toExtended <$> conversationCreated self c
 
 createOne2OneConversationRemotely ::
   Member (Error FederationError) r =>
@@ -514,6 +518,7 @@ createConnectConversation ::
     Member (Error InternalError) r,
     Member (Error InvalidInput) r,
     Member (ErrorS 'InvalidOperation) r,
+    Member (Error UnreachableBackends) r,
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
@@ -548,21 +553,13 @@ createConnectConversation lusr conn j = do
       c <- E.createConversation lcnv nc
       now <- input
       let e = Event (tUntagged lcnv) Nothing (tUntagged lusr) now (EdConnect j)
-      runError @UnreachableBackendsError (notifyCreatedConversation lusr conn c)
-        >>= \case
-          Left (UnreachableBackendsError ds) -> do
-            E.deleteConversation (Data.convId c)
-            pure
-              . ConversationResponseUnreachableBackends
-              . CreateConversationUnreachableBackends
-              $ ds
-          Right () -> do
-            for_ (newPushLocal ListComplete (tUnqualified lusr) (ConvEvent e) (recipient <$> Data.convLocalMembers c)) $ \p ->
-              E.push1 $
-                p
-                  & pushRoute .~ RouteDirect
-                  & pushConn .~ conn
-            toExtended <$> conversationCreated lusr c
+      notifyCreatedConversation lusr conn c
+      for_ (newPushLocal ListComplete (tUnqualified lusr) (ConvEvent e) (recipient <$> Data.convLocalMembers c)) $ \p ->
+        E.push1 $
+          p
+            & pushRoute .~ RouteDirect
+            & pushConn .~ conn
+      toExtended <$> conversationCreated lusr c
     update n conv = do
       let mems = Data.convLocalMembers conv
        in fmap toExtended . conversationExisted lusr
@@ -658,34 +655,15 @@ conversationCreated ::
   Sem r ConversationResponse
 conversationCreated lusr cnv = Created <$> conversationView lusr cnv
 
-groupConversationCreated ::
-  ( Member (Error InternalError) r,
-    Member P.TinyLog r
-  ) =>
-  Set Domain ->
-  Local UserId ->
-  Data.Conversation ->
-  Sem r CreateGroupConversationResponse
-groupConversationCreated ds lusr cnv = do
-  if Set.null ds
-    then do
-      conv <- conversationView lusr cnv
-      pure . GroupConversationCreated $
-        CreateGroupConversation conv mempty
-    else
-      pure
-        . GroupConversationUnreachableBackends
-        . CreateConversationUnreachableBackends
-        $ ds
-
 -- | The return set contains all the remote users that could not be contacted.
 -- Consequently, the unreachable users are not added to the member list. This
 -- behavior might be changed later on when a message/event queue per remote
 -- backend is implemented.
 notifyCreatedConversation ::
-  ( Member (Error FederationError) r,
+  ( Member ConversationStore r,
+    Member (Error FederationError) r,
     Member (Error InternalError) r,
-    Member (Error UnreachableBackendsError) r,
+    Member (Error UnreachableBackends) r,
     Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -247,7 +247,6 @@ leaveConversation requestingDomain lc = do
       . mapToRuntimeError @('ActionDenied 'LeaveConversation) F.RemoveFromConversationErrorRemovalNotAllowed
       . mapToRuntimeError @'InvalidOperation F.RemoveFromConversationErrorRemovalNotAllowed
       . mapError @NoChanges (const F.RemoveFromConversationErrorUnchanged)
-      . mapError @UnreachableBackends F.RemoveFromConversationErrorUnreachable
       $ do
         (conv, _self) <- getConversationAndMemberWithError @'ConvNotFound leaver lcnv
         outcome <-

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -508,6 +508,8 @@ updateConversation origDomain updateRequest = do
         . runError @NoChanges
         . fmap (either F.ConversationUpdateResponseNonFederatingBackends id)
         . runError @NonFederatingBackends
+        . fmap (either F.ConversationUpdateResponseUnreachableBackends id)
+        . runError @UnreachableBackends
         . fmap F.ConversationUpdateResponseUpdate
 
 handleMLSMessageErrors ::

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -133,7 +133,7 @@ internalAPI =
 
 federationAPI :: API IFederationAPI GalleyEffects
 federationAPI =
-  mkNamedAPI @"get-federation-status" getFederationStatus
+  mkNamedAPI @"get-federation-status" (const getFederationStatus)
 
 legalholdWhitelistedTeamsAPI :: API ILegalholdWhitelistedTeamsAPI GalleyEffects
 legalholdWhitelistedTeamsAPI = mkAPI $ \tid -> hoistAPIHandler id (base tid)

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -141,6 +141,7 @@ postMLSMessageFromLocalUserV1 ::
       Member (ErrorS 'MLSStaleMessage) r,
       Member (ErrorS 'MLSUnsupportedMessage) r,
       Member (Error NonFederatingBackends) r,
+      Member (Error UnreachableBackends) r,
       Member (Input (Local ())) r,
       Member ProposalStore r,
       Member Resource r,
@@ -178,6 +179,7 @@ postMLSMessageFromLocalUser ::
       Member (ErrorS 'MLSStaleMessage) r,
       Member (ErrorS 'MLSUnsupportedMessage) r,
       Member (Error NonFederatingBackends) r,
+      Member (Error UnreachableBackends) r,
       Member (Input (Local ())) r,
       Member ProposalStore r,
       Member Resource r,
@@ -376,6 +378,7 @@ postMLSMessage ::
       Member (ErrorS 'MLSStaleMessage) r,
       Member (ErrorS 'MLSUnsupportedMessage) r,
       Member (Error NonFederatingBackends) r,
+      Member (Error UnreachableBackends) r,
       Member (Input (Local ())) r,
       Member ProposalStore r,
       Member Resource r,
@@ -457,6 +460,7 @@ postMLSMessageToLocalConv ::
       Member (ErrorS 'MLSStaleMessage) r,
       Member (ErrorS 'MLSUnsupportedMessage) r,
       Member (Error NonFederatingBackends) r,
+      Member (Error UnreachableBackends) r,
       Member ProposalStore r,
       Member Resource r,
       Member TinyLog r
@@ -624,6 +628,7 @@ processCommit ::
     Member (ErrorS 'MLSStaleMessage) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
     Member (Error NonFederatingBackends) r,
+    Member (Error UnreachableBackends) r,
     Member Resource r
   ) =>
   Qualified UserId ->
@@ -759,6 +764,7 @@ processCommitWithAction ::
     Member (ErrorS 'MLSStaleMessage) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
     Member (Error NonFederatingBackends) r,
+    Member (Error UnreachableBackends) r,
     Member Resource r
   ) =>
   Qualified UserId ->
@@ -788,6 +794,7 @@ processInternalCommit ::
     Member (ErrorS 'MLSStaleMessage) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
     Member (Error NonFederatingBackends) r,
+    Member (Error UnreachableBackends) r,
     Member Resource r
   ) =>
   Qualified UserId ->
@@ -1097,6 +1104,7 @@ executeProposalAction ::
     Member (ErrorS 'MLSUnsupportedProposal) r,
     Member (ErrorS 'MLSSelfRemovalNotAllowed) r,
     Member (Error NonFederatingBackends) r,
+    Member (Error UnreachableBackends) r,
     Member ExternalAccess r,
     Member FederatorAccess r,
     Member GundeckAccess r,

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1127,7 +1127,6 @@ removeMemberFromRemoteConv cnv lusr victim
       throwS @('ActionDenied 'RemoveConversationMember)
     handleError RemoveFromConversationErrorNotFound = throwS @'ConvNotFound
     handleError RemoveFromConversationErrorUnchanged = pure Nothing
-    handleError (RemoveFromConversationErrorUnreachable _) = pure Nothing
 
     handleSuccess :: (Member (Input UTCTime) r) => () -> Sem r (Maybe Event)
     handleSuccess _ = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -1121,6 +1121,7 @@ removeMemberFromRemoteConv cnv lusr victim
       throwS @('ActionDenied 'RemoveConversationMember)
     handleError RemoveFromConversationErrorNotFound = throwS @'ConvNotFound
     handleError RemoveFromConversationErrorUnchanged = pure Nothing
+    handleError (RemoveFromConversationErrorUnreachable _) = pure Nothing
 
     handleSuccess :: (Member (Input UTCTime) r) => () -> Sem r (Maybe Event)
     handleSuccess _ = do

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -328,8 +328,9 @@ updateConversationReceiptMode ::
   ConversationReceiptModeUpdate ->
   Sem r (UpdateResult Event)
 updateConversationReceiptMode lusr zcon qcnv update =
-  mapError @NonFederatingBackends @InternalError (\_ -> InternalErrorWithDescription "Unexpected NonFederatingBackends error when updating remote receipt mode") $
-    foldQualified
+  mapError @UnreachableBackends @InternalError (\_ -> InternalErrorWithDescription "Unexpected UnreachableBackends error when updating remote receipt mode")
+    . mapError @NonFederatingBackends @InternalError (\_ -> InternalErrorWithDescription "Unexpected NonFederatingBackends error when updating remote receipt mode")
+    $ foldQualified
       lusr
       ( \lcnv ->
           getUpdateResult . fmap lcuEvent $
@@ -353,6 +354,7 @@ updateRemoteConversation ::
     Member MemberStore r,
     Member TinyLog r,
     Member (Error NonFederatingBackends) r,
+    Member (Error UnreachableBackends) r,
     RethrowErrors (HasConversationActionGalleyErrors tag) (Error NoChanges : r),
     SingI tag
   ) =>
@@ -374,6 +376,7 @@ updateRemoteConversation rcnv lusr conn action = getUpdateResult $ do
     ConversationUpdateResponseError err' -> rethrowErrors @(HasConversationActionGalleyErrors tag) err'
     ConversationUpdateResponseUpdate convUpdate -> pure convUpdate
     ConversationUpdateResponseNonFederatingBackends e -> throw e
+    ConversationUpdateResponseUnreachableBackends e -> throw e
   updateLocalStateOfRemoteConv (qualifyAs rcnv convUpdate) (Just conn) >>= note NoChanges
 
 updateConversationReceiptModeUnqualified ::
@@ -788,6 +791,7 @@ addMembers ::
     Member (ErrorS 'MissingLegalholdConsent) r,
     Member (Error FederationError) r,
     Member (Error NonFederatingBackends) r,
+    Member (Error UnreachableBackends) r,
     Member ExternalAccess r,
     Member FederatorAccess r,
     Member GundeckAccess r,
@@ -826,6 +830,7 @@ addMembersUnqualifiedV2 ::
     Member (ErrorS 'TooManyMembers) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
     Member (Error NonFederatingBackends) r,
+    Member (Error UnreachableBackends) r,
     Member ExternalAccess r,
     Member FederatorAccess r,
     Member GundeckAccess r,
@@ -864,6 +869,7 @@ addMembersUnqualified ::
     Member (ErrorS 'TooManyMembers) r,
     Member (ErrorS 'MissingLegalholdConsent) r,
     Member (Error NonFederatingBackends) r,
+    Member (Error UnreachableBackends) r,
     Member ExternalAccess r,
     Member FederatorAccess r,
     Member GundeckAccess r,

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -24,7 +24,6 @@ module API
   )
 where
 
-import Data.Vector qualified as V
 import API.CustomBackend qualified as CustomBackend
 import API.Federation qualified as Federation
 import API.Federation.Util
@@ -67,6 +66,7 @@ import Data.Singletons
 import Data.Text qualified as T
 import Data.Text.Ascii qualified as Ascii
 import Data.Time.Clock (getCurrentTime)
+import Data.Vector qualified as V
 import Federator.Discovery (DiscoveryFailure (..))
 import Federator.MockServer
 import Galley.API.Mapping

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -24,6 +24,7 @@ module API
   )
 where
 
+import Data.Vector qualified as V
 import API.CustomBackend qualified as CustomBackend
 import API.Federation qualified as Federation
 import API.Federation.Util
@@ -66,7 +67,6 @@ import Data.Singletons
 import Data.Text qualified as T
 import Data.Text.Ascii qualified as Ascii
 import Data.Time.Clock (getCurrentTime)
-import Data.Vector qualified as V
 import Federator.Discovery (DiscoveryFailure (..))
 import Federator.MockServer
 import Galley.API.Mapping

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -1165,6 +1165,7 @@ updateConversationByRemoteAdmin = do
           ConversationUpdateResponseNoChanges -> assertFailure "Expected ConversationUpdateResponseUpdate but got ConversationUpdateResponseNoChanges"
           ConversationUpdateResponseUpdate up -> pure up
           ConversationUpdateResponseNonFederatingBackends _ -> assertFailure "Expected ConversationUpdateResponseUpdate but got ConversationUpdateResponseNonFederatingBackends"
+          ConversationUpdateResponseUnreachableBackends _ -> assertFailure "Expected ConversationUpdateResponseUpdate but got ConversationUpdateResponseUnreachableBackends"
 
         liftIO $ do
           cuOrigUserId cnvUpdate' @?= qbob


### PR DESCRIPTION
This PR introduces an `UnreachableBackends` error type which behaves similarly to `NonFederatingBackends` from https://github.com/wireapp/wire-server/pull/3483.

https://wearezeta.atlassian.net/browse/WPB-3640

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
