### PR TITLE
WPB-3611: Notifying remote domains about defederation.

### DIFF
--- a/changelog.d/1-api-changes/WPB-3611
+++ b/changelog.d/1-api-changes/WPB-3611
@@ -1,0 +1,5 @@
+Added a new notification event type, "federation.connectionRemoved"
+This event contains a pair of domains that are no longer federating, and is used to inform other federation members of the change.
+This notification is sent twice to local clients of federation members who receive this notification. Once before and once after cleaning up local conversaions where users from both domains are present.
+
+Added a new Galley federation endpoint "/federation/on-connection-removed" to receive the connection removed notification.

--- a/changelog.d/6-federation/WPB-3611
+++ b/changelog.d/6-federation/WPB-3611
@@ -1,0 +1,1 @@
+Defederating from a remote server will now inform all other servers that you are federated with of your defederation so they can clean up their local conversations and inform their clients.

--- a/libs/schema-profunctor/src/Data/Schema.hs
+++ b/libs/schema-profunctor/src/Data/Schema.hs
@@ -62,6 +62,7 @@ module Data.Schema
     fieldOverF,
     fieldWithDocModifierF,
     array,
+    pair,
     set,
     nonEmptyArray,
     map_,
@@ -462,6 +463,24 @@ array sch = SchemaP (SchemaDoc s) (SchemaIn r) (SchemaOut w)
     r = A.withArray (T.unpack name) $ \arr -> mapM (schemaIn sch) $ V.toList arr
     s = mkArray (schemaDoc sch)
     w x = A.Array . V.fromList <$> mapM (schemaOut sch) x
+
+-- | A schema for a JSON pair.
+-- This is serialised as JSON array of exactly 2 elements
+-- of the same type. Any more or less is an error.
+pair ::
+  (HasArray ndoc doc, HasName ndoc) =>
+  ValueSchema ndoc a ->
+  ValueSchema doc (a, a)
+pair sch = SchemaP (SchemaDoc s) (SchemaIn r) (SchemaOut w)
+  where
+    name = maybe "pair" ("pair of " <>) (getName (schemaDoc sch))
+    r = A.withArray (T.unpack name) $ \arr -> do
+      l <- mapM (schemaIn sch) $ V.toList arr
+      case l of
+        [a, b] -> pure (a, b)
+        _ -> fail $ "Expected exactly 2 elements, but got " <> show (length l)
+    s = mkArray (schemaDoc sch)
+    w (a, b) = A.Array . V.fromList <$> mapM (schemaOut sch) [a, b]
 
 set ::
   (HasArray ndoc doc, HasName ndoc, Ord a) =>

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -131,6 +131,7 @@ type GalleyApi =
            TypingDataUpdateRequest
            TypingDataUpdateResponse
     :<|> FedEndpoint "on-typing-indicator-updated" TypingDataUpdated EmptyResponse
+    :<|> FedEndpoint "on-connection-removed" Domain EmptyResponse
 
 data TypingDataUpdateRequest = TypingDataUpdateRequest
   { tdurTypingStatus :: TypingStatus,

--- a/libs/wire-api/src/Wire/API/Event/Federation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Federation.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module Wire.API.Event.Federation
   ( Event (..),
-    EventType (..),
+    EventData (..),
   )
 where
 
+import Control.Arrow ((&&&))
+import Control.Lens (makePrisms)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Aeson qualified as A
 import Data.Aeson.KeyMap qualified as KeyMap
@@ -12,38 +16,81 @@ import Data.Json.Util (ToJSONObject (toJSONObject))
 import Data.Schema
 import Data.Swagger qualified as S
 import Imports
+import Test.QuickCheck.Gen
 import Wire.Arbitrary
 
 data Event = Event
-  { _eventType :: EventType,
-    _eventDomain :: Domain
+  { _eventData :: EventData
   }
-  deriving (Eq, Show, Ord, Generic)
+  deriving (Eq, Show, Generic)
+
+data EventData
+  = FederationDelete Domain
+  | FederationConnectionRemoved (Domain, Domain)
+  deriving stock (Eq, Show, Generic)
+
+$(makePrisms ''EventData)
+
+instance Arbitrary EventData where
+  arbitrary =
+    oneof
+      [ FederationDelete <$> arbitrary,
+        FederationConnectionRemoved <$> arbitrary
+      ]
 
 instance Arbitrary Event where
-  arbitrary =
-    Event
-      <$> arbitrary
-      <*> arbitrary
+  arbitrary = Event <$> arbitrary
 
 data EventType
-  = FederationDelete
-  deriving (Eq, Show, Ord, Generic)
+  = FederationTypeDelete
+  | FederationTypeConnectionRemoved
+  deriving (Eq, Show, Ord, Enum, Bounded, Generic)
   deriving (Arbitrary) via (GenericUniform EventType)
   deriving (A.FromJSON, A.ToJSON, S.ToSchema) via Schema EventType
 
 instance ToSchema EventType where
   schema =
-    enum @Text "EventType" $
+    enum @Text "FederationEventType" $
       mconcat
-        [ element "federation.delete" FederationDelete
+        [ element "federation.delete" FederationTypeDelete,
+          element "federation.connectionRemoved" FederationTypeConnectionRemoved
         ]
 
+eventType :: Event -> EventType
+eventType = eventDataType . _eventData
+
+eventDataType :: EventData -> EventType
+eventDataType (FederationDelete _) = FederationTypeDelete
+eventDataType (FederationConnectionRemoved _) = FederationTypeConnectionRemoved
+
+taggedEventDataSchema :: ObjectSchema SwaggerDoc (EventType, EventData)
+taggedEventDataSchema =
+  bind
+    (fst .= field "type" schema)
+    -- The fields we need to look at change based on the event
+    -- type, so we need to dispatch here to get monadic-ish behaviour.
+    --
+    -- federation.delete is expecting a "domain" field that contains a bare domain string.
+    -- federation.connectionRemoved is expecting a "doamins" field that contains exactly a pair of domains in a list
+    ( snd .= dispatch dataSchema
+    )
+  where
+    dataSchema :: EventType -> ObjectSchema SwaggerDoc EventData
+    dataSchema FederationTypeDelete = tag _FederationDelete deleteSchema
+    dataSchema FederationTypeConnectionRemoved = tag _FederationConnectionRemoved connectionRemovedSchema
+
+-- These schemas have different fields they are targeting.
+deleteSchema :: ObjectSchema SwaggerDoc Domain
+deleteSchema = field "domain" schema
+
+connectionRemovedSchema :: ObjectSchema SwaggerDoc (Domain, Domain)
+connectionRemovedSchema = field "domains" (pair schema)
+
+-- Schemas for the events, as they have different structures.
 eventObjectSchema :: ObjectSchema SwaggerDoc Event
 eventObjectSchema =
-  Event
-    <$> _eventType .= field "type" schema
-    <*> _eventDomain .= field "domain" schema
+  Event . snd
+    <$> (eventType &&& _eventData) .= taggedEventDataSchema
 
 instance ToSchema Event where
   schema = object "Event" eventObjectSchema

--- a/services/background-worker/src/Wire/BackgroundWorker/Env.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker/Env.hs
@@ -12,6 +12,7 @@ import Data.Map.Strict qualified as Map
 import Data.Metrics qualified as Metrics
 import HTTP2.Client.Manager
 import Imports
+import Network.AMQP (Channel)
 import Network.AMQP.Extended
 import Network.HTTP.Client
 import Network.RabbitMqAdmin qualified as RabbitMqAdmin
@@ -49,6 +50,10 @@ data Env = Env
     remoteDomains :: IORef FederationDomainConfigs,
     remoteDomainsChan :: Chan FederationDomainConfigs,
     backendNotificationMetrics :: BackendNotificationMetrics,
+    -- This is needed so that the defederation worker can push
+    -- channel-removed notifications into the notifications channels.
+    -- This allows us to reuse existing code. This only pushes.
+    notificationChannel :: MVar Channel,
     statuses :: IORef (Map Worker IsWorking)
   }
 
@@ -95,6 +100,7 @@ mkEnv opts = do
         ]
   metrics <- Metrics.metrics
   backendNotificationMetrics <- mkBackendNotificationMetrics
+  notificationChannel <- mkRabbitMqChannelMVar logger $ demoteOpts opts.rabbitmq
   pure (Env {..}, syncThread)
 
 initHttp2Manager :: IO Http2Manager

--- a/services/background-worker/src/Wire/BackgroundWorker/Env.hs
+++ b/services/background-worker/src/Wire/BackgroundWorker/Env.hs
@@ -51,7 +51,7 @@ data Env = Env
     remoteDomainsChan :: Chan FederationDomainConfigs,
     backendNotificationMetrics :: BackendNotificationMetrics,
     -- This is needed so that the defederation worker can push
-    -- channel-removed notifications into the notifications channels.
+    -- connection-removed notifications into the notifications channels.
     -- This allows us to reuse existing code. This only pushes.
     notificationChannel :: MVar Channel,
     statuses :: IORef (Map Worker IsWorking)

--- a/services/background-worker/src/Wire/Defederation.hs
+++ b/services/background-worker/src/Wire/Defederation.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards #-}
+
 {-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module Wire.Defederation where
@@ -97,12 +97,11 @@ notifyOtherBackends defederationDomain = do
     -- Just to be safe! distributed systems and all that.
     for_ (filter (/= defederationDomain) remoteDomains) $ \remoteDomain ->
       liftIO
-        .
         -- Push the notificiation into the queue
         -- We're using the origin domain as part of our effective payload
         -- to help reduce network traffic.
         -- We still need to explicitly send the domain that is being defederated.
-        enqueue chan ownDomain remoteDomain Q.Persistent
+        . enqueue chan ownDomain remoteDomain Q.Persistent
         . void
         $ fedQueueClient @'Galley @"on-connection-removed" defederationDomain
 

--- a/services/background-worker/src/Wire/Defederation.hs
+++ b/services/background-worker/src/Wire/Defederation.hs
@@ -1,12 +1,18 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wno-unused-local-binds #-}
+
 module Wire.Defederation where
 
 import Bilge.Retry
 import Control.Concurrent.Async
+import Control.Exception (throwIO)
 import Control.Lens (to, (^.))
 import Control.Monad.Catch
 import Control.Retry
 import Data.Aeson qualified as A
 import Data.ByteString.Conversion
+import Data.Domain
+import Data.Text (unpack)
 import Data.Text.Encoding
 import Imports
 import Network.AMQP qualified as Q
@@ -14,9 +20,14 @@ import Network.AMQP.Extended
 import Network.AMQP.Lifted qualified as QL
 import Network.HTTP.Client
 import Network.HTTP.Types
+import Servant.Client (BaseUrl (..), ClientEnv, Scheme (Http), mkClientEnv, runClientM)
 import System.Logger.Class qualified as Log
 import Util.Options
+import Wire.API.Federation.API
 import Wire.API.Federation.BackendNotifications
+import Wire.API.Routes.FederationDomainConfig qualified as Fed
+import Wire.API.Routes.Named (namedClient)
+import Wire.API.Routes.Version (VersionAPI, vinfoDomain)
 import Wire.BackgroundWorker.Env
 import Wire.BackgroundWorker.Util
 
@@ -47,42 +58,107 @@ deleteFederationDomainInner' go (msg, envelope) = do
         Log.msg (Log.val "Failed to delete federation domain")
           . Log.field "error" err
 
+mkBrigEnv :: AppT IO ClientEnv
+mkBrigEnv = do
+  Endpoint brigHost brigPort <- asks brig
+  mkClientEnv
+    <$> asks httpManager
+    <*> pure (BaseUrl Http (unpack brigHost) (fromIntegral brigPort) "")
+
+getRemoteDomains :: AppT IO [Domain]
+getRemoteDomains = do
+  ref <- asks remoteDomains
+  fmap Fed.domain . Fed.remotes <$> readIORef ref
+
+-- Call out to Brig to get the API version information.
+-- It contains the local federaion domain string, which
+-- means we don't need to add another config line here.
+getOwnDomain :: AppT IO Domain
+getOwnDomain = do
+  env <- mkBrigEnv
+  vInfo <- liftIO $ runClientM (namedClient @VersionAPI @"get-version") env
+  either
+    ( \e -> do
+        Log.err $ Log.msg @String "Could not fetch API version information from Brig" . Log.field "error" (show e)
+        -- Throw the error into IO to match the other functions and to prevent the
+        -- message from rabbit being ACKed.
+        liftIO $ throwIO e
+    )
+    (pure . vinfoDomain)
+    vInfo
+
+-- Use the notification pusher to push out these notifications to remote domains
+notifyOtherBackends :: Domain -> AppT IO ()
+notifyOtherBackends defederationDomain = do
+  remoteDomains <- getRemoteDomains
+  ownDomain <- getOwnDomain
+  mChan <- asks notificationChannel
+  withMVar mChan $ \chan ->
+    -- Just to be safe! distributed systems and all that.
+    for_ (filter (/= defederationDomain) remoteDomains) $ \remoteDomain ->
+      liftIO
+        .
+        -- Push the notificiation into the queue
+        -- We're using the origin domain as part of our effective payload
+        -- to help reduce network traffic.
+        -- We still need to explicitly send the domain that is being defederated.
+        enqueue chan ownDomain remoteDomain Q.Persistent
+        . void
+        $ fedQueueClient @'Galley @"on-connection-removed" defederationDomain
+
+callGalleyDelete ::
+  ( MonadReader Env m,
+    MonadMask m,
+    ToByteString a,
+    RabbitMQEnvelope e,
+    MonadIO m
+  ) =>
+  MVar () ->
+  e ->
+  a ->
+  m ()
+callGalleyDelete runningFlag envelope domain = do
+  env <- ask
+  -- Jittered exponential backoff with 10ms as starting delay and 60s as max
+  -- delay. When 60 is reached, every retry will happen after 60s.
+  let policy = capDelay 60_000_000 $ fullJitterBackoff 10000
+      manager = httpManager env
+  recovering policy httpHandlers $ \_ ->
+    bracket_ (takeMVar runningFlag) (putMVar runningFlag ()) $ do
+      -- Non 2xx responses will throw an exception
+      -- So we are relying on that to be caught by recovering
+      resp <- liftIO $ httpLbs (req env domain) manager
+      let code = statusCode $ responseStatus resp
+      if code >= 200 && code <= 299
+        then do
+          liftIO $ ack envelope
+        else -- ensure that the message is requeued
+        -- This message was able to be parsed but something
+        -- else in our stack failed and we should try again.
+          liftIO $ reject envelope True
+
+req :: ToByteString a => Env -> a -> Request
+req env dom =
+  defaultRequest
+    { method = methodDelete,
+      secure = False,
+      host = galley env ^. epHost . to encodeUtf8,
+      port = galley env ^. epPort . to fromIntegral,
+      path = "/i/federation/" <> toByteString' dom,
+      requestHeaders = ("Accept", "application/json") : requestHeaders defaultRequest,
+      responseTimeout = defederationTimeout env
+    }
+
 -- What should we do with non-recoverable (unparsable) errors/messages?
 -- should we deadletter, or do something else?
 -- Deadlettering has a privacy implication -- FUTUREWORK.
-deleteFederationDomainInner :: (RabbitMQEnvelope e) => MVar () -> (Q.Message, e) -> AppT IO ()
+deleteFederationDomainInner :: RabbitMQEnvelope e => MVar () -> (Q.Message, e) -> AppT IO ()
 deleteFederationDomainInner runningFlag (msg, envelope) =
-  deleteFederationDomainInner' (const callGalley) (msg, envelope)
+  deleteFederationDomainInner' go (msg, envelope)
   where
-    callGalley domain = do
-      env <- ask
-      -- Jittered exponential backoff with 10ms as starting delay and 60s as max
-      -- delay. When 60 is reached, every retry will happen after 60s.
-      let policy = capDelay 60_000_000 $ fullJitterBackoff 10000
-          manager = httpManager env
-      recovering policy httpHandlers $ \_ ->
-        bracket_ (takeMVar runningFlag) (putMVar runningFlag ()) $ do
-          -- Non 2xx responses will throw an exception
-          -- So we are relying on that to be caught by recovering
-          resp <- liftIO $ httpLbs (req env domain) manager
-          let code = statusCode $ responseStatus resp
-          if code >= 200 && code <= 299
-            then do
-              liftIO $ ack envelope
-            else -- ensure that the message is requeued
-            -- This message was able to be parsed but something
-            -- else in our stack failed and we should try again.
-              liftIO $ reject envelope True
-    req env dom =
-      defaultRequest
-        { method = methodDelete,
-          secure = False,
-          host = galley env ^. epHost . to encodeUtf8,
-          port = galley env ^. epPort . to fromIntegral,
-          path = "/i/federation/" <> toByteString' dom,
-          requestHeaders = ("Accept", "application/json") : requestHeaders defaultRequest,
-          responseTimeout = defederationTimeout env
-        }
+    go _ defederationDomain = do
+      notifyOtherBackends defederationDomain
+      callGalleyDelete runningFlag envelope defederationDomain
 
 startDefederator :: IORef (Maybe (Q.ConsumerTag, MVar ())) -> Q.Channel -> AppT IO ()
 startDefederator consumerRef chan = do

--- a/services/background-worker/test/Test/Wire/BackendNotificationPusherSpec.hs
+++ b/services/background-worker/test/Test/Wire/BackendNotificationPusherSpec.hs
@@ -91,6 +91,44 @@ spec = do
       getVectorWith env.backendNotificationMetrics.pushedCounter getCounter
         `shouldReturn` [(domainText targetDomain, 1)]
 
+    it "should push on-connection-removed notifications" $ do
+      let returnSuccess _ = pure ("application/json", Aeson.encode EmptyResponse)
+      let origDomain = Domain "origin.example.com"
+          targetDomain = Domain "target.example.com"
+          defederatedDomain = Domain "defederated.example.com"
+      let notif =
+            BackendNotification
+              { targetComponent = Galley,
+                ownDomain = origDomain,
+                path = "/on-connection-removed",
+                body = RawJson $ Aeson.encode defederatedDomain
+              }
+      envelope <- newMockEnvelope
+      let msg =
+            Q.newMsg
+              { Q.msgBody = Aeson.encode notif,
+                Q.msgContentType = Just "application/json"
+              }
+      runningFlag <- newMVar ()
+      (env, fedReqs) <-
+        withTempMockFederator [] returnSuccess . runTestAppT $ do
+          wait =<< pushNotification runningFlag targetDomain (msg, envelope)
+          ask
+
+      readIORef envelope.acks `shouldReturn` 1
+      readIORef envelope.rejections `shouldReturn` []
+      fedReqs
+        `shouldBe` [ FederatedRequest
+                       { frTargetDomain = targetDomain,
+                         frOriginDomain = origDomain,
+                         frComponent = Galley,
+                         frRPC = "on-connection-removed",
+                         frBody = Aeson.encode defederatedDomain
+                       }
+                   ]
+      getVectorWith env.backendNotificationMetrics.pushedCounter getCounter
+        `shouldReturn` [(domainText targetDomain, 1)]
+
     it "should reject invalid notifications" $ do
       let returnSuccess _ = pure ("application/json", Aeson.encode EmptyResponse)
       envelope <- newMockEnvelope
@@ -183,6 +221,7 @@ spec = do
       httpManager <- newManager defaultManagerSettings
       remoteDomains <- newIORef defFederationDomainConfigs
       remoteDomainsChan <- newChan
+      notificationChannel <- newEmptyMVar
       let federatorInternal = Endpoint "localhost" 8097
           http2Manager = undefined
           statuses = undefined
@@ -204,6 +243,7 @@ spec = do
       httpManager <- newManager defaultManagerSettings
       remoteDomains <- newIORef defFederationDomainConfigs
       remoteDomainsChan <- newChan
+      notificationChannel <- newEmptyMVar
       let federatorInternal = Endpoint "localhost" 8097
           http2Manager = undefined
           statuses = undefined

--- a/services/background-worker/test/Test/Wire/Util.hs
+++ b/services/background-worker/test/Test/Wire/Util.hs
@@ -21,6 +21,7 @@ testEnv = do
   httpManager <- newManager defaultManagerSettings
   remoteDomains <- newIORef defFederationDomainConfigs
   remoteDomainsChan <- newChan
+  notificationChannel <- newEmptyMVar
   let federatorInternal = Endpoint "localhost" 0
       rabbitmqAdminClient = undefined
       rabbitmqVHost = undefined

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -751,7 +751,7 @@ onTypingIndicatorUpdated origDomain TypingDataUpdated {..} = do
   pushTypingIndicatorEvents tudOrigUserId tudTime tudUsersInConv Nothing qcnv tudTypingStatus
   pure EmptyResponse
 
--- Since we already have to origin domain where the defederation event started,
+-- Since we already have the origin domain where the defederation event started,
 -- all it needs to carry in addition is the domain it is defederating from. This
 -- is all the information that we need to cleanup the database and notify clients.
 onFederationConnectionRemoved ::
@@ -778,7 +778,7 @@ onFederationConnectionRemoved originDomain targetDomain = do
 -- for all conversations owned by backend C, only if there are users from both A and B,
 -- remove users from A and B from those conversations
 -- This is similar to Galley.API.Internal.deleteFederationDomain
--- However it has some important differences, such as we only remove from our conversation
+-- However it has some important differences, such as we only remove from our conversations
 -- where users for both domains are in the same conversation.
 cleanupRemovedConnections ::
   forall r.

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -44,7 +44,7 @@ import Galley.API.Clients qualified as Clients
 import Galley.API.Create qualified as Create
 import Galley.API.CustomBackend qualified as CustomBackend
 import Galley.API.Error
-import Galley.API.Federation (onConversationUpdated)
+import Galley.API.Federation (insertIntoMap, onConversationUpdated)
 import Galley.API.LegalHold (unsetTeamLegalholdWhitelistedH)
 import Galley.API.LegalHold.Conflicts
 import Galley.API.MLS.Removal
@@ -495,10 +495,6 @@ guardLegalholdPolicyConflictsH ::
 guardLegalholdPolicyConflictsH glh = do
   mapError @LegalholdConflicts (const $ Tagged @'MissingLegalholdConsent ()) $
     guardLegalholdPolicyConflicts (glhProtectee glh) (glhUserClients glh)
-
--- Build the map, keyed by conversations to the list of members
-insertIntoMap :: (ConvId, a) -> Map ConvId (N.NonEmpty a) -> Map ConvId (N.NonEmpty a)
-insertIntoMap (cnvId, user) m = Map.alter (pure . maybe (pure user) (N.cons user)) cnvId m
 
 -- Bundle all of the deletes together for easy calling
 -- Errors & exceptions are thrown to IO to stop the message being ACKed, eventually timing it

--- a/services/galley/src/Galley/Effects/DefederationNotifications.hs
+++ b/services/galley/src/Galley/Effects/DefederationNotifications.hs
@@ -3,6 +3,7 @@
 module Galley.Effects.DefederationNotifications
   ( DefederationNotifications (..),
     sendDefederationNotifications,
+    sendOnConnectionRemovedNotifications,
   )
 where
 
@@ -11,5 +12,6 @@ import Polysemy
 
 data DefederationNotifications m a where
   SendDefederationNotifications :: Domain -> DefederationNotifications m ()
+  SendOnConnectionRemovedNotifications :: Domain -> Domain -> DefederationNotifications m ()
 
 makeSem ''DefederationNotifications

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -4475,8 +4475,6 @@ testConnectionRemovedNotifications = do
 
   let remoteDomain1 = Domain "far-away.example.com"
       remoteDomain2 = Domain "far-away-2.example.com"
-  -- This variable should be commented out if the below
-  -- section is used to insert users to the database.
   -- dee and erin are remote guests
   dee <- Qualified <$> randomId <*> pure remoteDomain1
   erin <- Qualified <$> randomId <*> pure remoteDomain2
@@ -4577,8 +4575,6 @@ testConnectionRemovedNotificationsNoopDomainA = do
 
   let remoteDomain1 = Domain "far-away.example.com"
       remoteDomain2 = Domain "far-away-2.example.com"
-  -- This variable should be commented out if the below
-  -- section is used to insert users to the database.
   -- dee is a remote guest
   dee <- Qualified <$> randomId <*> pure remoteDomain1
 
@@ -4631,8 +4627,6 @@ testConnectionRemovedNotificationsNoopDomainB = do
 
   let remoteDomain1 = Domain "far-away.example.com"
       remoteDomain2 = Domain "far-away-2.example.com"
-  -- This variable should be commented out if the below
-  -- section is used to insert users to the database.
   -- erin is a remote guest
   erin <- Qualified <$> randomId <*> pure remoteDomain2
 


### PR DESCRIPTION
During defederation, remaining federation members will now be notified about the defederation by a new notification type
"federation.connectionRemoved" that carries the domains that were involved in the defederation. This allows federation members to clean up their conversations where users from both domains are present. Additionally, this is sent out to all of their local clients so they can also clean up. Normal notifications are suppressed for these operations, similar to "federation.delete" handling.

Changes:
- Added a new federation event type.
- Added a new federation endpoint in galley. This route cleans up local conversations and notifies local clients of the defederation using the new event type.
- Updated background-worker to send notifications to federation members.
- Added tests for the new notifications, and that local conversations are cleaned up as expected.

## Checklist

 - [:heavy_check_mark:]  Add a new entry in an appropriate subdirectory of `changelog.d`
 - [:heavy_check_mark:] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
