### PR TITLE
Fix SCIM role update

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-2959-fix-roles-in-scim
+++ b/changelog.d/3-bug-fixes/WPB-2959-fix-roles-in-scim
@@ -1,0 +1,1 @@
+If role is not set ([], null, or field missing) in scim-put-user, do not change role to default in brig

--- a/libs/wire-api/src/Wire/API/User/Scim.hs
+++ b/libs/wire-api/src/Wire/API/User/Scim.hs
@@ -326,7 +326,7 @@ data ValidScimUser = ValidScimUser
     _vsuRichInfo :: RI.RichInfo,
     _vsuActive :: Bool,
     _vsuLocale :: Maybe Locale,
-    _vsuRole :: Role
+    _vsuRole :: Maybe Role
   }
   deriving (Eq, Show)
 

--- a/services/spar/src/Spar/Scim/User.hs
+++ b/services/spar/src/Spar/Scim/User.hs
@@ -270,7 +270,7 @@ validateScimUser' errloc midp richInfoLimit user = do
   let active = Scim.active user
   lang <- maybe (throwError $ badRequest "Could not parse language. Expected format is ISO 639-1.") pure $ mapM parseLanguage $ Scim.preferredLanguage user
   mRole <- validateRole user
-  pure $ ST.ValidScimUser veid handl uname richInfo (maybe True Scim.unScimBool active) (flip Locale Nothing <$> lang) (fromMaybe defaultRole mRole)
+  pure $ ST.ValidScimUser veid handl uname richInfo (maybe True Scim.unScimBool active) (flip Locale Nothing <$> lang) mRole
   where
     validRoleNames :: Text
     validRoleNames = cs $ intercalate ", " $ map (cs . toByteString') [minBound @Role .. maxBound]
@@ -464,10 +464,10 @@ createValidScimUser tokeninfo@ScimTokenInfo {stiTeam} vsu@(ST.ValidScimUser veid
                     -- `createValidScimUser` into a function `createValidScimUserBrig` similar
                     -- to `createValidScimUserSpar`?
                     uid <- Id <$> Random.uuid
-                    BrigAccess.createSAML uref uid stiTeam name ManagedByScim (Just handl) (Just richInfo) language role
+                    BrigAccess.createSAML uref uid stiTeam name ManagedByScim (Just handl) (Just richInfo) language (fromMaybe defaultRole role)
               )
               ( \email -> do
-                  buid <- BrigAccess.createNoSAML email stiTeam name language role
+                  buid <- BrigAccess.createNoSAML email stiTeam name language (fromMaybe defaultRole role)
                   BrigAccess.setHandle buid handl -- FUTUREWORK: possibly do the same one req as we do for saml?
                   pure buid
               )
@@ -600,8 +600,9 @@ updateValidScimUser tokinfo@ScimTokenInfo {stiTeam} uid nvsu =
             when (oldValidScimUser ^. ST.vsuLocale /= newValidScimUser ^. ST.vsuLocale) $ do
               BrigAccess.setLocale uid (newValidScimUser ^. ST.vsuLocale)
 
-            when (oldValidScimUser ^. ST.vsuRole /= newValidScimUser ^. ST.vsuRole) $ do
-              GalleyAccess.updateTeamMember uid stiTeam (newValidScimUser ^. ST.vsuRole)
+            forM_ (newValidScimUser ^. ST.vsuRole) $ \newRole -> do
+              when (oldValidScimUser ^. ST.vsuRole /= Just newRole) $ do
+                GalleyAccess.updateTeamMember uid stiTeam newRole
 
             BrigAccess.getStatusMaybe uid >>= \case
               Nothing -> pure ()
@@ -929,7 +930,7 @@ synthesizeStoredUser usr veid =
           lastUpdatedAt
           baseuri
           (userLocale (accountUser usr))
-          role
+          (Just role)
       lift $ writeState accessTimes (userManagedBy (accountUser usr)) richInfo storedUser
       pure storedUser
   where
@@ -949,9 +950,9 @@ synthesizeStoredUser' ::
   UTCTimeMillis ->
   URIBS.URI ->
   Locale ->
-  Role ->
+  Maybe Role ->
   MonadError Scim.ScimError m => m (Scim.StoredUser ST.SparTag)
-synthesizeStoredUser' uid veid dname handle richInfo accStatus createdAt lastUpdatedAt baseuri locale role = do
+synthesizeStoredUser' uid veid dname handle richInfo accStatus createdAt lastUpdatedAt baseuri locale mbRole = do
   let scimUser :: Scim.User ST.SparTag
       scimUser =
         synthesizeScimUser
@@ -964,7 +965,7 @@ synthesizeStoredUser' uid veid dname handle richInfo accStatus createdAt lastUpd
               ST._vsuRichInfo = richInfo,
               ST._vsuActive = ST.scimActiveFlagFromAccountStatus accStatus,
               ST._vsuLocale = Just locale,
-              ST._vsuRole = role
+              ST._vsuRole = mbRole
             }
 
   pure $ toScimStoredUser' createdAt lastUpdatedAt baseuri uid (normalizeLikeStored scimUser)
@@ -977,8 +978,10 @@ synthesizeScimUser info =
           Scim.displayName = Just $ fromName (info ^. ST.vsuName),
           Scim.active = Just . Scim.ScimBool $ info ^. ST.vsuActive,
           Scim.preferredLanguage = lan2Text . lLanguage <$> info ^. ST.vsuLocale,
-          Scim.roles = (: []) . cs . toByteString $ info ^. ST.vsuRole
+          Scim.roles = maybe [] ((: []) . cs . toByteString) (info ^. ST.vsuRole)
         }
+
+-- TODO: now write a test, either in /integration or in spar, whichever is easier.  (spar)
 
 getUserById ::
   forall r.

--- a/services/spar/test-integration/Test/Spar/APISpec.hs
+++ b/services/spar/test-integration/Test/Spar/APISpec.hs
@@ -1349,7 +1349,7 @@ specProvisionScimAndSAMLUserWithRole = do
             _ <- ScimT.updateUser tok userId scimUserWithRole
             ScimT.checkTeamMembersRole tid owner userId role
       mapM_ testUpdateUserWithRole [minBound .. maxBound]
-    it "update user - default to member if no role given" $ do
+    it "update user - do not change current role if no role given" $ do
       (tok, (owner, tid, _idp, (_, _privcreds))) <- ScimT.registerIdPAndScimTokenWithMeta
       let testUpdateUserWithDefaultRole :: Role -> TestSpar ()
           testUpdateUserWithDefaultRole role = do
@@ -1358,7 +1358,7 @@ specProvisionScimAndSAMLUserWithRole = do
               pure $ u {Scim.roles = [cs $ toByteString $ role]}
             userId <- ScimT.scimUserId <$> ScimT.createUser tok scimUser
             _ <- ScimT.updateUser tok userId (scimUser {Scim.roles = []})
-            ScimT.checkTeamMembersRole tid owner userId RoleMember
+            ScimT.checkTeamMembersRole tid owner userId role
       mapM_ testUpdateUserWithDefaultRole [minBound .. maxBound]
     it "updated user - fail if more than one role given" $ do
       (tok, _) <- ScimT.registerIdPAndScimTokenWithMeta

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -2019,7 +2019,7 @@ testPatchRole replaceOrAdd = do
       -- also check if remove works
       let removeAttrib name = PatchOp.Operation PatchOp.Remove (Just (PatchOp.NormalPath (Filter.topLevelAttrPath name))) Nothing
       void $ patchUser tok userId $ PatchOp.PatchOp [removeAttrib "roles"]
-      checkTeamMembersRole tid owner userId initialRole
+      checkTeamMembersRole tid owner userId (fromMaybe initialRole mTargetRole)
 
 createScimUserWithRole :: BrigReq -> TeamId -> UserId -> ScimToken -> Role -> TestSpar UserId
 createScimUserWithRole brig tid owner tok initialRole = do

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -83,7 +83,7 @@ import qualified Web.Scim.Schema.User as Scim.User
 import qualified Wire.API.Team.Export as CsvExport
 import qualified Wire.API.Team.Feature as Feature
 import Wire.API.Team.Invitation (Invitation (..))
-import Wire.API.Team.Role (Role (RoleExternalPartner, RoleMember), defaultRole)
+import Wire.API.Team.Role (Role (..), defaultRole)
 import Wire.API.User hiding (scimExternalId)
 import Wire.API.User.IdentityProvider (IdP)
 import qualified Wire.API.User.IdentityProvider as User
@@ -1780,13 +1780,14 @@ testUpdateUserRole = do
   let galley = env ^. teGalley
   (owner, tid) <- call $ createUserWithTeam brig galley
   tok <- registerScimToken tid Nothing
-  let mTargetRoles = Nothing : map Just [minBound ..]
+  let mRoles = Nothing : map Just [minBound @Role ..]
   let testUpdate = testCreateUserWithInitalRoleAndUpdateToTargetRole brig tid owner tok
-  let testWithTarget = forM_ mTargetRoles . testUpdate
-  forM_ [minBound ..] testWithTarget
+  forM_ (catMaybes mRoles) $ \initialRole -> do
+    forM_ mRoles $ \mUpdateRole -> do
+      testUpdate initialRole mUpdateRole (fromMaybe initialRole mUpdateRole)
   where
-    testCreateUserWithInitalRoleAndUpdateToTargetRole :: BrigReq -> TeamId -> UserId -> ScimToken -> Role -> Maybe Role -> TestSpar ()
-    testCreateUserWithInitalRoleAndUpdateToTargetRole brig tid owner tok initialRole mTargetRole = do
+    testCreateUserWithInitalRoleAndUpdateToTargetRole :: BrigReq -> TeamId -> UserId -> ScimToken -> Role -> Maybe Role -> Role -> TestSpar ()
+    testCreateUserWithInitalRoleAndUpdateToTargetRole brig tid owner tok initialRole mUpdatedRole targetRoleExpected = do
       email <- randomEmail
       scimUser <-
         randomScimUser <&> \u ->
@@ -1804,8 +1805,8 @@ testUpdateUserRole = do
         Just inviteeCode <- call $ getInvitationCode brig tid (inInvitation inv)
         registerInvitation email userName inviteeCode True
       checkTeamMembersRole tid owner userid initialRole
-      _ <- updateUser tok userid (scimUser {Scim.User.roles = cs . toByteString <$> maybeToList mTargetRole})
-      checkTeamMembersRole tid owner userid (fromMaybe defaultRole mTargetRole)
+      _ <- updateUser tok userid (scimUser {Scim.User.roles = cs . toByteString <$> maybeToList mUpdatedRole})
+      checkTeamMembersRole tid owner userid targetRoleExpected
 
 ----------------------------------------------------------------------------
 -- Patching users

--- a/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
+++ b/services/spar/test-integration/Test/Spar/Scim/UserSpec.hs
@@ -2015,11 +2015,11 @@ testPatchRole replaceOrAdd = do
     testCreateUserWithInitialRoleAndPatchToTargetRole brig tid owner tok initialRole mTargetRole = do
       userId <- createScimUserWithRole brig tid owner tok initialRole
       void $ patchUser tok userId $ PatchOp.PatchOp [replaceOrAdd "roles" (maybeToList mTargetRole)]
-      checkTeamMembersRole tid owner userId (fromMaybe defaultRole mTargetRole)
+      checkTeamMembersRole tid owner userId (fromMaybe initialRole mTargetRole)
       -- also check if remove works
       let removeAttrib name = PatchOp.Operation PatchOp.Remove (Just (PatchOp.NormalPath (Filter.topLevelAttrPath name))) Nothing
       void $ patchUser tok userId $ PatchOp.PatchOp [removeAttrib "roles"]
-      checkTeamMembersRole tid owner userId defaultRole
+      checkTeamMembersRole tid owner userId initialRole
 
 createScimUserWithRole :: BrigReq -> TeamId -> UserId -> ScimToken -> Role -> TestSpar UserId
 createScimUserWithRole brig tid owner tok initialRole = do

--- a/services/spar/test-integration/Util/Scim.hs
+++ b/services/spar/test-integration/Util/Scim.hs
@@ -144,7 +144,11 @@ randomScimUserWithSubjectAndRichInfo richInfo = do
         { Scim.User.displayName = Just ("ScimUser" <> suffix),
           Scim.User.externalId = Just externalId,
           Scim.User.emails = emails,
-          Scim.User.phoneNumbers = phones
+          Scim.User.phoneNumbers = phones,
+          Scim.User.roles = ["member"]
+          -- if we don't add this role here explicitly, some tests may show confusing failures
+          -- involving [] or null being changed to ["member"] during a create or update
+          -- operation.
         },
       subj
     )


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-2959

reviewer: please read commit by commit.

without the fix, but with the test:

```
$ make ci-safe package=spar
[...]
  test-integration/Test/Spar/Scim/UserSpec.hs:1810:7:
  1) WireIdPAPIV1.Spar.Scim.User, PUT /Users/:id, updates role
       expected: Just RoleOwner
        but got: Just RoleMember

  To rerun use: --match "/WireIdPAPIV1/Spar.Scim.User/PUT /Users/:id/updates role/"

  test-integration/Test/Spar/Scim/UserSpec.hs:1810:7:
  2) WireIdPAPIV2.Spar.Scim.User, PUT /Users/:id, updates role
       expected: Just RoleOwner
        but got: Just RoleMember

  To rerun use: --match "/WireIdPAPIV2/Spar.Scim.User/PUT /Users/:id/updates role/"
[...]
```

with both:

```
$ make ci-safe package=spar
[...]
WireIdPAPIV1
  Spar.Scim.User
    PUT /Users/:id
      updates role [✔]
[...]
```

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
