### PR TITLE
[WPB-3865] Conversation creation and member adding: change error response status code to 533

### DIFF
--- a/changelog.d/1-api-changes/WPB-3640
+++ b/changelog.d/1-api-changes/WPB-3640
@@ -1,1 +1,1 @@
-Conversation creation endpoints can now return `unreachable_backends` error responses with status code 503 if any of the involved backends are unreachable. The conversation is not created in that case.
+Conversation creation endpoints can now return `unreachable_backends` error responses with status code 533 if any of the involved backends are unreachable. The conversation is not created in that case.

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -51,7 +51,7 @@ testDynamicBackendsNotFederating = do
         $ bindResponse
           (getFederationStatus uidA [domainB, domainC])
         $ \resp -> do
-          resp.status `shouldMatchInt` 503
+          resp.status `shouldMatchInt` 533
           resp.json %. "unreachable_backends" `shouldMatchSet` [domainB, domainC]
 
 testDynamicBackendsFullyConnectedWhenAllowDynamic :: HasCallStack => App ()
@@ -123,7 +123,7 @@ testFederationStatus = do
   bindResponse
     (getFederationStatus uid [invalidDomain])
     $ \resp -> do
-      resp.status `shouldMatchInt` 503
+      resp.status `shouldMatchInt` 533
       resp.json %. "unreachable_backends" `shouldMatchSet` [invalidDomain]
 
   bindResponse
@@ -386,5 +386,5 @@ testAddUnreachable = do
 
   charlieId <- charlie %. "qualified_id"
   bindResponse (addMembers alex conv [charlieId]) $ \resp -> do
-    resp.status `shouldMatchInt` 503
+    resp.status `shouldMatchInt` 533
     resp.json %. "unreachable_backends" `shouldMatchSet` [charlieDomain]

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -342,7 +342,7 @@ testConvWithUnreachableRemoteUsers = do
 
   let newConv = defProteus {qualifiedUsers = [alex, bob, charlie, dylan]}
   bindResponse (postConversation alice newConv) $ \resp -> do
-    resp.status `shouldMatchInt` 503
+    resp.status `shouldMatchInt` 533
     resp.json %. "unreachable_backends" `shouldMatchSet` domains
 
   convs <- getAllConvs alice >>= asList

--- a/libs/wire-api/src/Wire/API/Error/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Error/Galley.hs
@@ -477,7 +477,7 @@ instance APIError UnreachableBackends where
       }
 
 unreachableBackendsStatus :: HTTP.Status
-unreachableBackendsStatus = HTTP.status503
+unreachableBackendsStatus = HTTP.mkStatus 533 "Unreachable backends"
 
 instance ToSchema UnreachableBackends where
   schema =

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -423,7 +423,7 @@ postConvWithUnreachableRemoteUsers rbs = do
           { newConvName = checked convName,
             newConvQualifiedUsers = joiners
           }
-        <!! const 503 === statusCode
+        <!! const 533 === statusCode
     groupConvs <- filter ((== RegularConv) . cnvmType . cnvMetadata) <$> getAllConvs alice
     liftIO $
       assertEqual
@@ -2334,7 +2334,7 @@ postConvQualifiedNonExistentDomain = do
             alice
             Nothing
             defNewProteusConv {newConvQualifiedUsers = [bob]}
-            !!! do const 503 === statusCode
+            !!! do const 533 === statusCode
       )
 
 postConvQualifiedFederationNotEnabled :: TestM ()
@@ -2352,7 +2352,7 @@ postConvQualifiedFederationNotEnabled = do
     unreachable :: UnreachableBackends <-
       responseJsonError
         =<< postConvHelper g alice [bob] <!! do
-          const 503 === statusCode
+          const 533 === statusCode
     liftIO $ unreachable.backends @?= [domain]
 
 -- like postConvQualified
@@ -2935,7 +2935,7 @@ testAddRemoteMemberInvalidDomain = do
     responseJsonError
       =<< postQualifiedMembers alice (remoteBob :| []) qconvId
         <!! do
-          const 503 === statusCode
+          const 533 === statusCode
   liftIO $ e.backends @?= [domain]
 
 -- This test is a safeguard to ensure adding remote members will fail
@@ -2979,7 +2979,7 @@ testAddRemoteMemberFederationUnavailable = do
     e :: UnreachableBackends <-
       responseJsonError
         =<< postQualifiedMembers alice (remoteBob :| []) qconvId <!! do
-          const 503 === statusCode
+          const 533 === statusCode
     liftIO $ e.backends @?= [domain]
 
   -- since on member add the check of connection between remote backends will fail, the member is not actually added to the conversation


### PR DESCRIPTION
To avoid alerting instance operators in case a remote backend is unreachable, change the error status code when creating a conversation or adding members from 503 to 533.

Tracked by https://wearezeta.atlassian.net/browse/WPB-3865.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
