### PR TITLE
Wpb 3842 federation completeness check

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-3842-federation-completeness-checks
+++ b/changelog.d/3-bug-fixes/WPB-3842-federation-completeness-checks
@@ -1,0 +1,1 @@
+Adding users to a conversation now enforces that all federation domains that will be in the conversation are federated with each other.

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -364,7 +364,7 @@ testAddReachableWithUnreachableRemoteUsers = do
   let overrides =
         def {dbBrig = setField "optSettings.setFederationStrategy" "allowAll"}
           <> fullSearchWithAll
-  ([alex, bob], conv) <-
+  ([alex, bob], conv, domains) <-
     startDynamicBackends [overrides, overrides] $ \domains -> do
       own <- make OwnDomain & asString
       other <- make OtherDomain & asString
@@ -373,7 +373,7 @@ testAddReachableWithUnreachableRemoteUsers = do
 
       let newConv = defProteus {qualifiedUsers = [alex, charlie, dylan]}
       conv <- postConversation alice newConv >>= getJSON 201
-      pure ([alex, bob], conv)
+      pure ([alex, bob], conv, domains)
 
   bobId <- bob %. "qualified_id"
   bindResponse (addMembers alex conv [bobId]) $ \resp -> do
@@ -383,7 +383,7 @@ testAddReachableWithUnreachableRemoteUsers = do
     -- to ensure that users from domains that aren't federating are not directly
     -- connected to each other.
     resp.status `shouldMatchInt` 533
-    resp.jsonBody %. "unreachable_backends" `shouldMatchSet` ["d1.example.com", "d2.example.com"]
+    resp.jsonBody %. "unreachable_backends" `shouldMatchSet` domains
 
 testAddUnreachable :: HasCallStack => App ()
 testAddUnreachable = do

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -425,3 +425,4 @@ testAddingUserNonFullyConnectedFederation = do
     charlieId <- charlie %. "qualified_id"
     bindResponse (addMembers alex conv [bobId, charlieId]) $ \resp -> do
       resp.status `shouldMatchInt` 409
+      resp.json %. "non_federating_backends" `shouldMatchSet` (other : domains)

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -11,6 +11,7 @@ import Data.Function
 import Data.Functor
 import Data.List
 import Data.Time.Clock
+import Data.Traversable (for)
 import RunAllTests
 import System.Directory
 import System.Environment
@@ -134,7 +135,7 @@ runTests tests cfg = do
   genv <- createGlobalEnv cfg
 
   withAsync displayOutput $ \displayThread -> do
-    report <- fmap mconcat $ pooledForConcurrently tests $ \(qname, _, _, action) -> do
+    report <- fmap mconcat $ for tests $ \(qname, _, _, action) -> do
       do
         (mErr, tm) <- withTime (runTest genv action)
         case mErr of


### PR DESCRIPTION
## Changes
- Improving the completeness check for federation sub-graphs that are or will be involved in a given conversation.
- Updating tests that were relying on the old semantics where exiting domains in a conversation weren't considered in the completeness check.
- Adding the test from the Jira ticket, thanks @pcapriotti!

## Checklist

 - [:heavy_check_mark:] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [:heavy_check_mark:] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
