### PR TITLE
Fix bug in integration: federator host is not set

### DIFF
--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -161,7 +161,7 @@ startDynamicBackend resource staticPorts beOverrides = do
                   >=> setKeyspace srv
                   >=> setEsIndex srv
                   >=> setFederationSettings srv
-                  >=> setAwsAdnQueuesConfigs srv
+                  >=> setAwsConfigs srv
                   >=> setLogLevel srv
             )
             defaultServiceOverridesToMap
@@ -176,20 +176,18 @@ startDynamicBackend resource staticPorts beOverrides = do
          in Map.insert resource.berDomain (setFederatorPorts resource $ updateServiceMap ports templateBackend) sm
     )
   where
-    setAwsAdnQueuesConfigs :: Service -> Value -> App Value
-    setAwsAdnQueuesConfigs = \case
+    setAwsConfigs :: Service -> Value -> App Value
+    setAwsConfigs = \case
       Brig ->
         setField "aws.userJournalQueue" resource.berAwsUserJournalQueue
           >=> setField "aws.prekeyTable" resource.berAwsPrekeyTable
           >=> setField "internalEvents.queueName" resource.berBrigInternalEvents
           >=> setField "emailSMS.email.sesQueue" resource.berEmailSMSSesQueue
           >=> setField "emailSMS.general.emailSender" resource.berEmailSMSEmailSender
-          >=> setField "rabbitmq.vHost" resource.berVHost
       Cargohold -> setField "aws.s3Bucket" resource.berAwsS3Bucket
       Gundeck -> setField "aws.queueName" resource.berAwsQueueName
       Galley ->
         setField "journal.queueName" resource.berGalleyJournal
-          >=> setField "rabbitmq.vHost" resource.berVHost
       _ -> pure
 
     setFederationSettings :: Service -> Value -> App Value
@@ -197,21 +195,24 @@ startDynamicBackend resource staticPorts beOverrides = do
       \case
         Brig ->
           setField "optSettings.setFederationDomain" resource.berDomain
-            >=> setField
-              "optSettings.setFederationDomainConfigs"
-              ([] :: [Value])
+            >=> setField "optSettings.setFederationDomainConfigs" ([] :: [Value])
             >=> setField "federatorInternal.port" resource.berFederatorInternal
             >=> setField "federatorInternal.host" ("127.0.0.1" :: String)
+            >=> setField "rabbitmq.vHost" resource.berVHost
         Cargohold ->
           setField "settings.federationDomain" resource.berDomain
+            >=> setField "federator.host" ("127.0.0.1" :: String)
             >=> setField "federator.port" resource.berFederatorInternal
         Galley ->
           setField "settings.federationDomain" resource.berDomain
             >=> setField "settings.featureFlags.classifiedDomains.config.domains" [resource.berDomain]
+            >=> setField "federator.host" ("127.0.0.1" :: String)
             >=> setField "federator.port" resource.berFederatorInternal
+            >=> setField "rabbitmq.vHost" resource.berVHost
         Gundeck -> setField "settings.federationDomain" resource.berDomain
         BackgroundWorker ->
           setField "federatorInternal.port" resource.berFederatorInternal
+            >=> setField "federatorInternal.host" ("127.0.0.1" :: String)
             >=> setField "rabbitmq.vHost" resource.berVHost
         _ -> pure
 


### PR DESCRIPTION
This PR fixes a bug in `integration` where the federator host is incorrect for dyamic backends.
With this PR the test `testDefederationNonFullyConnectedGraph` can be added again and passes on CI.
