### PR TITLE
Support x509 credentials

### DIFF
--- a/changelog.d/1-api-changes/mls-x509
+++ b/changelog.d/1-api-changes/mls-x509
@@ -1,0 +1,1 @@
+Key packages and leaf nodes with x509 credentials are now supported

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -14,7 +14,7 @@ import Testlib.Prelude
 testSendMessageNoReturnToSender :: HasCallStack => App ()
 testSendMessageNoReturnToSender = do
   [alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
-  [alice1, alice2, bob1, bob2] <- traverse createMLSClient [alice, alice, bob, bob]
+  [alice1, alice2, bob1, bob2] <- traverse (createMLSClient def) [alice, alice, bob, bob]
   traverse_ uploadNewKeyPackage [alice2, bob1, bob2]
   void $ createNewGroup alice1
   void $ createAddCommit alice1 [alice, bob] >>= sendAndConsumeCommitBundle
@@ -43,7 +43,7 @@ testStaleApplicationMessage :: HasCallStack => Domain -> App ()
 testStaleApplicationMessage otherDomain = do
   [alice, bob, charlie, dave, eve] <-
     createAndConnectUsers [OwnDomain, otherDomain, OwnDomain, OwnDomain, OwnDomain]
-  [alice1, bob1, charlie1] <- traverse createMLSClient [alice, bob, charlie]
+  [alice1, bob1, charlie1] <- traverse (createMLSClient def) [alice, bob, charlie]
   traverse_ uploadNewKeyPackage [bob1, charlie1]
   void $ createNewGroup alice1
 
@@ -130,7 +130,7 @@ testMixedProtocolAddUsers secondDomain = do
   bindResponse (putConversationProtocol bob qcnv "mixed") $ \resp -> do
     resp.status `shouldMatchInt` 200
 
-  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
 
   bindResponse (getConversation alice qcnv) $ \resp -> do
     resp.status `shouldMatchInt` 200
@@ -158,7 +158,7 @@ testMixedProtocolUserLeaves secondDomain = do
   bindResponse (putConversationProtocol bob qcnv "mixed") $ \resp -> do
     resp.status `shouldMatchInt` 200
 
-  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
 
   bindResponse (getConversation alice qcnv) $ \resp -> do
     resp.status `shouldMatchInt` 200
@@ -193,7 +193,7 @@ testMixedProtocolAddPartialClients secondDomain = do
   bindResponse (putConversationProtocol bob qcnv "mixed") $ \resp -> do
     resp.status `shouldMatchInt` 200
 
-  [alice1, bob1, bob2] <- traverse createMLSClient [alice, bob, bob]
+  [alice1, bob1, bob2] <- traverse (createMLSClient def) [alice, bob, bob]
 
   bindResponse (getConversation alice qcnv) $ \resp -> do
     resp.status `shouldMatchInt` 200
@@ -231,7 +231,7 @@ testMixedProtocolRemovePartialClients secondDomain = do
   bindResponse (putConversationProtocol bob qcnv "mixed") $ \resp -> do
     resp.status `shouldMatchInt` 200
 
-  [alice1, bob1, bob2] <- traverse createMLSClient [alice, bob, bob]
+  [alice1, bob1, bob2] <- traverse (createMLSClient def) [alice, bob, bob]
 
   bindResponse (getConversation alice qcnv) $ \resp -> do
     resp.status `shouldMatchInt` 200
@@ -256,7 +256,7 @@ testMixedProtocolAppMessagesAreDenied secondDomain = do
   bindResponse (putConversationProtocol bob qcnv "mixed") $ \resp -> do
     resp.status `shouldMatchInt` 200
 
-  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
 
   traverse_ uploadNewKeyPackage [bob1]
 
@@ -277,7 +277,7 @@ testMLSProtocolUpgrade secondDomain = do
   charlie <- randomUser OwnDomain def
 
   -- alice creates MLS group and bob joins
-  [alice1, bob1, charlie1] <- traverse createMLSClient [alice, bob, charlie]
+  [alice1, bob1, charlie1] <- traverse (createMLSClient def) [alice, bob, charlie]
   createGroup alice1 conv
   void $ createPendingProposalCommit alice1 >>= sendAndConsumeCommitBundle
   void $ createExternalCommit bob1 Nothing >>= sendAndConsumeCommitBundle
@@ -316,7 +316,8 @@ testAddUserSimple suite = do
   setMLSCiphersuite suite
 
   [alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
-  [alice1, bob1, bob2] <- traverse createMLSClient [alice, bob, bob]
+  [alice1, bob1, bob2] <- traverse (createMLSClient def) [alice, bob, bob]
+
   traverse_ uploadNewKeyPackage [bob1, bob2]
   (_, qcnv) <- createNewGroup alice1
 
@@ -343,7 +344,7 @@ testAddUserSimple suite = do
 testRemoteAddUser :: HasCallStack => App ()
 testRemoteAddUser = do
   [alice, bob, charlie] <- createAndConnectUsers [OwnDomain, OtherDomain, OwnDomain]
-  [alice1, bob1, charlie1] <- traverse createMLSClient [alice, bob, charlie]
+  [alice1, bob1, charlie1] <- traverse (createMLSClient def) [alice, bob, charlie]
   traverse_ uploadNewKeyPackage [bob1, charlie1]
   (_, conv) <- createNewGroup alice1
   void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
@@ -360,7 +361,7 @@ testRemoteAddUser = do
 testRemoteRemoveClient :: HasCallStack => App ()
 testRemoteRemoveClient = do
   [alice, bob] <- createAndConnectUsers [OwnDomain, OtherDomain]
-  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
   void $ uploadNewKeyPackage bob1
   (_, conv) <- createNewGroup alice1
   void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
@@ -381,7 +382,7 @@ testCreateSubConv :: HasCallStack => Ciphersuite -> App ()
 testCreateSubConv suite = do
   setMLSCiphersuite suite
   alice <- randomUser OwnDomain def
-  alice1 <- createMLSClient alice
+  alice1 <- createMLSClient def alice
   (_, conv) <- createNewGroup alice1
   bindResponse (getSubConversation alice conv "conference") $ \resp -> do
     resp.status `shouldMatchInt` 200
@@ -403,7 +404,7 @@ testCreateSubConvProteus = do
 testSelfConversation :: App ()
 testSelfConversation = do
   alice <- randomUser OwnDomain def
-  creator : others <- traverse createMLSClient (replicate 3 alice)
+  creator : others <- traverse (createMLSClient def) (replicate 3 alice)
   traverse_ uploadNewKeyPackage others
   (_, cnv) <- createSelfGroup creator
   commit <- createAddCommit creator [alice]
@@ -421,7 +422,7 @@ testSelfConversation = do
 testJoinSubConv :: App ()
 testJoinSubConv = do
   [alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
-  [alice1, bob1, bob2] <- traverse createMLSClient [alice, bob, bob]
+  [alice1, bob1, bob2] <- traverse (createMLSClient def) [alice, bob, bob]
   traverse_ uploadNewKeyPackage [bob1, bob2]
   (_, qcnv) <- createNewGroup alice1
   void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
@@ -445,7 +446,7 @@ testDeleteParentOfSubConv secondDomain = do
   bob <- randomUser secondDomain def
   connectUsers [alice, bob]
 
-  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
   traverse_ uploadNewKeyPackage [alice1, bob1]
   (_, qcnv) <- createNewGroup alice1
   void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
@@ -494,7 +495,7 @@ testFirstCommitAllowsPartialAdds :: HasCallStack => App ()
 testFirstCommitAllowsPartialAdds = do
   alice <- randomUser OwnDomain def
 
-  [alice1, alice2, alice3] <- traverse createMLSClient [alice, alice, alice]
+  [alice1, alice2, alice3] <- traverse (createMLSClient def) [alice, alice, alice]
   traverse_ uploadNewKeyPackage [alice1, alice2, alice2, alice3, alice3]
 
   (_, _qcnv) <- createNewGroup alice1
@@ -513,9 +514,9 @@ testAddUserPartial = do
   [alice, bob, charlie] <- createAndConnectUsers (replicate 3 OwnDomain)
 
   -- Bob has 3 clients, Charlie has 2
-  alice1 <- createMLSClient alice
-  bobClients@[_bob1, _bob2, bob3] <- replicateM 3 (createMLSClient bob)
-  charlieClients <- replicateM 2 (createMLSClient charlie)
+  alice1 <- createMLSClient def alice
+  bobClients@[_bob1, _bob2, bob3] <- replicateM 3 (createMLSClient def bob)
+  charlieClients <- replicateM 2 (createMLSClient def charlie)
 
   -- Only the first 2 clients of Bob's have uploaded key packages
   traverse_ uploadNewKeyPackage (take 2 bobClients <> charlieClients)
@@ -540,7 +541,7 @@ testRemoveClientsIncomplete :: HasCallStack => App ()
 testRemoveClientsIncomplete = do
   [alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
 
-  [alice1, bob1, bob2] <- traverse createMLSClient [alice, bob, bob]
+  [alice1, bob1, bob2] <- traverse (createMLSClient def) [alice, bob, bob]
   traverse_ uploadNewKeyPackage [bob1, bob2]
   void $ createNewGroup alice1
   void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
@@ -552,7 +553,7 @@ testRemoveClientsIncomplete = do
 testAdminRemovesUserFromConv :: HasCallStack => App ()
 testAdminRemovesUserFromConv = do
   [alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
-  [alice1, bob1, bob2] <- traverse createMLSClient [alice, bob, bob]
+  [alice1, bob1, bob2] <- traverse (createMLSClient def) [alice, bob, bob]
   void $ createWireClient bob
   traverse_ uploadNewKeyPackage [bob1, bob2]
   (gid, qcnv) <- createNewGroup alice1
@@ -582,7 +583,7 @@ testLocalWelcome :: HasCallStack => App ()
 testLocalWelcome = do
   users@[alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
 
-  [alice1, bob1] <- traverse createMLSClient users
+  [alice1, bob1] <- traverse (createMLSClient def) users
 
   void $ uploadNewKeyPackage bob1
 
@@ -613,7 +614,7 @@ testStaleCommit = do
   (alice : users) <- createAndConnectUsers (replicate 5 OwnDomain)
   let (users1, users2) = splitAt 2 users
 
-  (alice1 : clients) <- traverse createMLSClient (alice : users)
+  (alice1 : clients) <- traverse (createMLSClient def) (alice : users)
   traverse_ uploadNewKeyPackage clients
   void $ createNewGroup alice1
 
@@ -633,7 +634,7 @@ testStaleCommit = do
 testPropInvalidEpoch :: HasCallStack => App ()
 testPropInvalidEpoch = do
   users@[_alice, bob, charlie, dee] <- createAndConnectUsers (replicate 4 OwnDomain)
-  [alice1, bob1, charlie1, dee1] <- traverse createMLSClient users
+  [alice1, bob1, charlie1, dee1] <- traverse (createMLSClient def) users
   void $ createNewGroup alice1
 
   -- Add bob -> epoch 1
@@ -675,7 +676,7 @@ testPropInvalidEpoch = do
 testPropUnsupported :: HasCallStack => App ()
 testPropUnsupported = do
   users@[_alice, bob] <- createAndConnectUsers (replicate 2 OwnDomain)
-  [alice1, bob1] <- traverse createMLSClient users
+  [alice1, bob1] <- traverse (createMLSClient def) users
   void $ uploadNewKeyPackage bob1
   void $ createNewGroup alice1
   void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
@@ -688,7 +689,7 @@ testPropUnsupported = do
 testAddUserBareProposalCommit :: HasCallStack => App ()
 testAddUserBareProposalCommit = do
   [alice, bob] <- createAndConnectUsers (replicate 2 OwnDomain)
-  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
   (_, qcnv) <- createNewGroup alice1
   void $ uploadNewKeyPackage bob1
   void $ createAddCommit alice1 [] >>= sendAndConsumeCommitBundle
@@ -710,7 +711,7 @@ testAddUserBareProposalCommit = do
 testPropExistingConv :: HasCallStack => App ()
 testPropExistingConv = do
   [alice, bob] <- createAndConnectUsers (replicate 2 OwnDomain)
-  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
   void $ uploadNewKeyPackage bob1
   void $ createNewGroup alice1
   void $ createAddCommit alice1 [] >>= sendAndConsumeCommitBundle
@@ -721,7 +722,7 @@ testCommitNotReferencingAllProposals :: HasCallStack => App ()
 testCommitNotReferencingAllProposals = do
   users@[_alice, bob, charlie] <- createAndConnectUsers (replicate 3 OwnDomain)
 
-  [alice1, bob1, charlie1] <- traverse createMLSClient users
+  [alice1, bob1, charlie1] <- traverse (createMLSClient def) users
   void $ createNewGroup alice1
   traverse_ uploadNewKeyPackage [bob1, charlie1]
   void $ createAddCommit alice1 [] >>= sendAndConsumeCommitBundle
@@ -745,7 +746,7 @@ testUnsupportedCiphersuite :: HasCallStack => App ()
 testUnsupportedCiphersuite = do
   setMLSCiphersuite (Ciphersuite "0x0002")
   alice <- randomUser OwnDomain def
-  alice1 <- createMLSClient alice
+  alice1 <- createMLSClient def alice
   void $ createNewGroup alice1
 
   mp <- createPendingProposalCommit alice1

--- a/integration/test/Test/MLS.hs
+++ b/integration/test/Test/MLS.hs
@@ -311,12 +311,11 @@ testMLSProtocolUpgrade secondDomain = do
     resp.status `shouldMatchInt` 200
     resp.json %. "protocol" `shouldMatch` "mls"
 
-testAddUserSimple :: HasCallStack => Ciphersuite -> App ()
-testAddUserSimple suite = do
+testAddUserSimple :: HasCallStack => Ciphersuite -> CredentialType -> App ()
+testAddUserSimple suite ctype = do
   setMLSCiphersuite suite
-
   [alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
-  [alice1, bob1, bob2] <- traverse (createMLSClient def) [alice, bob, bob]
+  [alice1, bob1, bob2] <- traverse (createMLSClient def {credType = ctype}) [alice, bob, bob]
 
   traverse_ uploadNewKeyPackage [bob1, bob2]
   (_, qcnv) <- createNewGroup alice1

--- a/integration/test/Test/MLS/KeyPackage.hs
+++ b/integration/test/Test/MLS/KeyPackage.hs
@@ -8,7 +8,7 @@ import Testlib.Prelude
 testDeleteKeyPackages :: App ()
 testDeleteKeyPackages = do
   alice <- randomUser OwnDomain def
-  alice1 <- createMLSClient alice
+  alice1 <- createMLSClient def alice
   kps <- replicateM 3 (uploadNewKeyPackage alice1)
 
   -- add an extra non-existing key package to the delete request
@@ -24,7 +24,7 @@ testDeleteKeyPackages = do
 testKeyPackageMultipleCiphersuites :: App ()
 testKeyPackageMultipleCiphersuites = do
   alice <- randomUser OwnDomain def
-  [alice1, alice2] <- replicateM 2 (createMLSClient alice)
+  [alice1, alice2] <- replicateM 2 (createMLSClient def alice)
 
   kp <- uploadNewKeyPackage alice2
 
@@ -51,7 +51,7 @@ testUnsupportedCiphersuite :: HasCallStack => App ()
 testUnsupportedCiphersuite = do
   setMLSCiphersuite (Ciphersuite "0x0002")
   bob <- randomUser OwnDomain def
-  bob1 <- createMLSClient bob
+  bob1 <- createMLSClient def bob
   (kp, _) <- generateKeyPackage bob1
   bindResponse (uploadKeyPackage bob1 kp) $ \resp -> do
     resp.status `shouldMatchInt` 400

--- a/integration/test/Test/MLS/One2One.hs
+++ b/integration/test/Test/MLS/One2One.hs
@@ -71,7 +71,7 @@ testMLSOne2One scenario = do
   let otherDomain = one2OneScenarioDomain scenario
       convDomain = one2OneScenarioConvDomain scenario
   bob <- createMLSOne2OnePartner otherDomain alice convDomain
-  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
   traverse_ uploadNewKeyPackage [bob1]
 
   conv <- getMLSOne2OneConversation alice bob >>= getJSON 200

--- a/integration/test/Test/MLS/SubConversation.hs
+++ b/integration/test/Test/MLS/SubConversation.hs
@@ -8,7 +8,7 @@ import Testlib.Prelude
 testJoinSubConv :: App ()
 testJoinSubConv = do
   [alice, bob] <- createAndConnectUsers [OwnDomain, OwnDomain]
-  [alice1, bob1, bob2] <- traverse createMLSClient [alice, bob, bob]
+  [alice1, bob1, bob2] <- traverse (createMLSClient def) [alice, bob, bob]
   traverse_ uploadNewKeyPackage [bob1, bob2]
   (_, qcnv) <- createNewGroup alice1
   void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
@@ -32,7 +32,7 @@ testDeleteParentOfSubConv secondDomain = do
   bob <- randomUser secondDomain def
   connectUsers [alice, bob]
 
-  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
   traverse_ uploadNewKeyPackage [alice1, bob1]
   (_, qcnv) <- createNewGroup alice1
   void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle
@@ -80,7 +80,7 @@ testDeleteSubConversation :: HasCallStack => Domain -> App ()
 testDeleteSubConversation otherDomain = do
   [alice, bob] <- createAndConnectUsers [OwnDomain, otherDomain]
   charlie <- randomUser OwnDomain def
-  [alice1, bob1] <- traverse createMLSClient [alice, bob]
+  [alice1, bob1] <- traverse (createMLSClient def) [alice, bob]
   void $ uploadNewKeyPackage bob1
   (_, qcnv) <- createNewGroup alice1
   void $ createAddCommit alice1 [bob] >>= sendAndConsumeCommitBundle

--- a/libs/wire-api/src/Wire/API/MLS/Validation.hs
+++ b/libs/wire-api/src/Wire/API/MLS/Validation.hs
@@ -99,13 +99,14 @@ validateLeafNode cs mIdentity extra leafNode = do
 
   validateCredential mIdentity leafNode.credential
   validateSource extra.tag leafNode.source
-  validateCapabilities leafNode.capabilities
+  validateCapabilities (credentialTag leafNode.credential) leafNode.capabilities
 
 validateCredential :: Maybe ClientIdentity -> Credential -> Either Text ()
-validateCredential mIdentity (BasicCredential cred) = do
+validateCredential mIdentity cred = do
+  -- FUTUREWORK: check signature in the case of an x509 credential
   identity <-
     either credentialError pure $
-      decodeMLS' cred
+      credentialIdentity cred
   unless (maybe True (identity ==) mIdentity) $
     Left "client identity does not match credential identity"
   where
@@ -126,7 +127,7 @@ validateSource t s = do
           <> t'.name
           <> "'"
 
-validateCapabilities :: Capabilities -> Either Text ()
-validateCapabilities caps =
-  unless (fromMLSEnum BasicCredentialTag `elem` caps.credentials) $
+validateCapabilities :: CredentialTag -> Capabilities -> Either Text ()
+validateCapabilities ctag caps =
+  unless (fromMLSEnum ctag `elem` caps.credentials) $
     Left "missing BasicCredential capability"

--- a/nix/pkgs/mls-test-cli/default.nix
+++ b/nix/pkgs/mls-test-cli/default.nix
@@ -13,8 +13,8 @@ let
   src = fetchFromGitHub {
     owner = "wireapp";
     repo = "mls-test-cli";
-    rev = "cc815d71a1d9485265b7ae158daf7b27badedee6";
-    sha256 = "sha256-CJoc20pOtsxAQNCA3qhv8NtPbzZ4yCIMvuhlgcqPrds=";
+    rev = "d16b4e9d4e93b731e81cd04a00620f2c6a36e696";
+    sha256 = "sha256-2p5m6R80dnyJShAvjmO+ZbX8wxMtuFmvPnp9uX4eezc=";
   };
   cargoLockFile = builtins.toFile "cargo.lock" (builtins.readFile "${src}/Cargo.lock");
 in rustPlatform.buildRustPackage rec {
@@ -24,8 +24,8 @@ in rustPlatform.buildRustPackage rec {
   cargoLock = {
     lockFile = cargoLockFile;
     outputHashes = {
-      "hpke-0.10.0" = "sha256-6zyTb2c2DU4mXn9vRQe+lXNaeQ3JOVUz+BS15Xb2E+Y=";
-      "openmls-0.20.2" = "sha256-QgQb5Ts8TB2nwfxMss4qHCz096ijMXBxyq7q2ITyEGg=";
+      "hpke-0.10.0" = "sha256-T1+BFwX6allljNZ/8T3mrWhOejnUU27BiWQetqU+0fY=";
+      "openmls-1.0.0" = "sha256-s1ejM/aicFGvsKY7ajEun1Mc645/k8QVrE8YSbyD3Fg=";
       "safe_pqc_kyber-0.6.0" = "sha256-Ch1LA+by+ezf5RV0LDSQGC1o+IWKXk8IPvkwSrAos68=";
       "tls_codec-0.3.0" = "sha256-IO6tenXKkC14EoUDp/+DtFNOVzDfOlLu8K1EJI7sOzs=";
     };


### PR DESCRIPTION
This PR adds minimal support for x509 credentials in MLS.

At the moment, this is based on the `x509` branch of `mls-test-cli`. 

https://wearezeta.atlassian.net/browse/WPB-3787

## Checklist

 - [x] Update nix package for mls-test-cli
 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
