### PR TITLE
Integration tests: use static ports

### DIFF
--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -119,6 +119,7 @@ library
     Testlib.JSON
     Testlib.ModService
     Testlib.Options
+    Testlib.Ports
     Testlib.Prekeys
     Testlib.Prelude
     Testlib.Printing
@@ -126,6 +127,7 @@ library
     Testlib.ResourcePool
     Testlib.Run
     Testlib.RunServices
+    Testlib.Service
     Testlib.Types
 
   build-depends:

--- a/integration/test/API/Cargohold.hs
+++ b/integration/test/API/Cargohold.hs
@@ -122,11 +122,8 @@ buildMultipartBody header body bodyMimeType =
           MIME.mime_val_content = MIME.Single ((decodeUtf8 . LBS.toStrict) c)
         }
 
--- downloadAsset :: (HasCallStack, MakesValue user, MakesValue assetDomain, MakesValue key) => user -> assetDomain -> key -> (HTTP.Request -> HTTP.Request) -> App Response
--- downloadAsset user assetDomain key trans = downloadAsset' user assetDomain key "nginz-https.example.com" trans
-
-downloadAsset' :: (HasCallStack, MakesValue user, MakesValue key, MakesValue assetDomain) => user -> assetDomain -> key -> String -> (HTTP.Request -> HTTP.Request) -> App Response
-downloadAsset' user assetDomain key zHostHeader trans = do
+downloadAsset :: (HasCallStack, MakesValue user, MakesValue key, MakesValue assetDomain) => user -> assetDomain -> key -> String -> (HTTP.Request -> HTTP.Request) -> App Response
+downloadAsset user assetDomain key zHostHeader trans = do
   uid <- objId user
   domain <- objDomain assetDomain
   key' <- asString key

--- a/integration/test/API/Cargohold.hs
+++ b/integration/test/API/Cargohold.hs
@@ -122,8 +122,8 @@ buildMultipartBody header body bodyMimeType =
           MIME.mime_val_content = MIME.Single ((decodeUtf8 . LBS.toStrict) c)
         }
 
-downloadAsset :: (HasCallStack, MakesValue user, MakesValue assetDomain, MakesValue key) => user -> assetDomain -> key -> (HTTP.Request -> HTTP.Request) -> App Response
-downloadAsset user assetDomain key trans = downloadAsset' user assetDomain key "nginz-https.example.com" trans
+-- downloadAsset :: (HasCallStack, MakesValue user, MakesValue assetDomain, MakesValue key) => user -> assetDomain -> key -> (HTTP.Request -> HTTP.Request) -> App Response
+-- downloadAsset user assetDomain key trans = downloadAsset' user assetDomain key "nginz-https.example.com" trans
 
 downloadAsset' :: (HasCallStack, MakesValue user, MakesValue key, MakesValue assetDomain) => user -> assetDomain -> key -> String -> (HTTP.Request -> HTTP.Request) -> App Response
 downloadAsset' user assetDomain key zHostHeader trans = do

--- a/integration/test/API/GalleyInternal.hs
+++ b/integration/test/API/GalleyInternal.hs
@@ -32,9 +32,9 @@ putTeamMember user team perms = do
       ]
       req
 
-getTeamFeature :: HasCallStack => String -> String -> App Response
-getTeamFeature featureName tid = do
-  req <- baseRequest OwnDomain Galley Unversioned $ joinHttpPath ["i", "teams", tid, "features", featureName]
+getTeamFeature :: (HasCallStack, MakesValue domain_) => domain_ -> String -> String -> App Response
+getTeamFeature domain_ featureName tid = do
+  req <- baseRequest domain_ Galley Unversioned $ joinHttpPath ["i", "teams", tid, "features", featureName]
   submit "GET" $ req
 
 getFederationStatus ::

--- a/integration/test/SetupHelpers.hs
+++ b/integration/test/SetupHelpers.hs
@@ -106,7 +106,7 @@ addFullSearchFor domains val =
 fullSearchWithAll :: ServiceOverrides
 fullSearchWithAll =
   def
-    { dbBrig = \val -> do
+    { brigCfg = \val -> do
         ownDomain <- asString =<< val %. "optSettings.setFederationDomain"
         env <- ask
         let remoteDomains = List.delete ownDomain $ [env.domain1, env.domain2] <> env.dynamicDomains
@@ -120,9 +120,9 @@ withFederatingBackendsAllowDynamic n k = do
           >=> removeField "optSettings.setFederationDomainConfigs"
           >=> setField "optSettings.setFederationDomainConfigsUpdateFreq" (Aeson.Number 1)
   startDynamicBackends
-    [ def {dbBrig = setFederationConfig},
-      def {dbBrig = setFederationConfig},
-      def {dbBrig = setFederationConfig}
+    [ def {brigCfg = setFederationConfig},
+      def {brigCfg = setFederationConfig},
+      def {brigCfg = setFederationConfig}
     ]
     $ \dynDomains -> do
       domains@[domainA, domainB, domainC] <- pure dynDomains

--- a/integration/test/Test/AssetDownload.hs
+++ b/integration/test/Test/AssetDownload.hs
@@ -15,7 +15,7 @@ testDownloadAsset = do
     resp.status `shouldMatchInt` 201
     resp.json %. "key"
 
-  bindResponse (downloadAsset user user key id) $ \resp -> do
+  bindResponse (downloadAsset' user user key "nginz-https.example.com" id) $ \resp -> do
     resp.status `shouldMatchInt` 200
     assertBool
       ("Expect 'Hello World!' as text asset content. Got: " ++ show resp.body)
@@ -27,27 +27,42 @@ testDownloadAssetMultiIngressS3DownloadUrl = do
 
   -- multi-ingress disabled
   key <- doUploadAsset user
-  checkAssetDownload user key
 
-  withModifiedService Cargohold modifyConfig $ \_ -> do
-    -- multi-ingress enabled
-    key' <- doUploadAsset user
-    checkAssetDownload user key'
+  bindResponse (downloadAsset' user user key "nginz-https.example.com" noRedirects) $ \resp -> do
+    resp.status `shouldMatchInt` 302
+
+  bindResponse (downloadAsset' user user key "red.example.com" noRedirects) $ \resp -> do
+    resp.status `shouldMatchInt` 302
+    locationHeaderHost resp `shouldMatch` "localhost"
+
+  bindResponse (downloadAsset' user user key "green.example.com" noRedirects) $ \resp -> do
+    resp.status `shouldMatchInt` 302
+    locationHeaderHost resp `shouldMatch` "localhost"
+
+  bindResponse (downloadAsset' user user key "unknown.example.com" noRedirects) $ \resp -> do
+    resp.status `shouldMatchInt` 302
+    locationHeaderHost resp `shouldMatch` "localhost"
+
+  -- multi-ingress enabled
+  withModifiedBackend modifyConfig $ \domain -> do
+    user' <- randomUser domain def
+    key' <- doUploadAsset user'
+
+    bindResponse (downloadAsset' user' user' key' "nginz-https.example.com" noRedirects) $ \resp -> do
+      resp.status `shouldMatchInt` 404
+
+    bindResponse (downloadAsset' user' user' key' "red.example.com" noRedirects) $ \resp -> do
+      resp.status `shouldMatchInt` 302
+      locationHeaderHost resp `shouldMatch` "s3-download.red.example.com"
+
+    bindResponse (downloadAsset' user' user' key' "green.example.com" noRedirects) $ \resp -> do
+      resp.status `shouldMatchInt` 302
+      locationHeaderHost resp `shouldMatch` "s3-download.green.example.com"
+
+    bindResponse (downloadAsset' user' user' key' "unknown.example.com" noRedirects) $ \resp -> do
+      resp.status `shouldMatchInt` 404
+      resp.json %. "label" `shouldMatch` "not-found"
   where
-    checkAssetDownload :: HasCallStack => Value -> Value -> App ()
-    checkAssetDownload user key = withModifiedService Cargohold modifyConfig $ \_ -> do
-      bindResponse (downloadAsset user user key noRedirects) $ \resp -> do
-        resp.status `shouldMatchInt` 404
-      bindResponse (downloadAsset' user user key "red.example.com" noRedirects) $ \resp -> do
-        resp.status `shouldMatchInt` 302
-        locationHeaderHost resp `shouldMatch` "s3-download.red.example.com"
-      bindResponse (downloadAsset' user user key "green.example.com" noRedirects) $ \resp -> do
-        resp.status `shouldMatchInt` 302
-        locationHeaderHost resp `shouldMatch` "s3-download.green.example.com"
-      bindResponse (downloadAsset' user user key "unknown.example.com" noRedirects) $ \resp -> do
-        resp.status `shouldMatchInt` 404
-        resp.json %. "label" `shouldMatch` "not-found"
-
     noRedirects :: HTTP.Request -> HTTP.Request
     noRedirects req = (req {redirectCount = 0})
 

--- a/integration/test/Test/AssetDownload.hs
+++ b/integration/test/Test/AssetDownload.hs
@@ -33,15 +33,12 @@ testDownloadAssetMultiIngressS3DownloadUrl = do
 
   bindResponse (downloadAsset' user user key "red.example.com" noRedirects) $ \resp -> do
     resp.status `shouldMatchInt` 302
-    locationHeaderHost resp `shouldMatch` "localhost"
 
   bindResponse (downloadAsset' user user key "green.example.com" noRedirects) $ \resp -> do
     resp.status `shouldMatchInt` 302
-    locationHeaderHost resp `shouldMatch` "localhost"
 
   bindResponse (downloadAsset' user user key "unknown.example.com" noRedirects) $ \resp -> do
     resp.status `shouldMatchInt` 302
-    locationHeaderHost resp `shouldMatch` "localhost"
 
   -- multi-ingress enabled
   withModifiedBackend modifyConfig $ \domain -> do
@@ -50,6 +47,7 @@ testDownloadAssetMultiIngressS3DownloadUrl = do
 
     bindResponse (downloadAsset' user' user' key' "nginz-https.example.com" noRedirects) $ \resp -> do
       resp.status `shouldMatchInt` 404
+      resp.json %. "label" `shouldMatch` "not-found"
 
     bindResponse (downloadAsset' user' user' key' "red.example.com" noRedirects) $ \resp -> do
       resp.status `shouldMatchInt` 302

--- a/integration/test/Test/AssetDownload.hs
+++ b/integration/test/Test/AssetDownload.hs
@@ -51,13 +51,16 @@ testDownloadAssetMultiIngressS3DownloadUrl = do
     noRedirects :: HTTP.Request -> HTTP.Request
     noRedirects req = (req {redirectCount = 0})
 
-    modifyConfig :: Value -> App Value
+    modifyConfig :: ServiceOverrides
     modifyConfig =
-      setField "aws.multiIngress" $
-        object
-          [ "red.example.com" .= "http://s3-download.red.example.com",
-            "green.example.com" .= "http://s3-download.green.example.com"
-          ]
+      def
+        { dbCargohold =
+            setField "aws.multiIngress" $
+              object
+                [ "red.example.com" .= "http://s3-download.red.example.com",
+                  "green.example.com" .= "http://s3-download.green.example.com"
+                ]
+        }
 
     doUploadAsset :: HasCallStack => Value -> App Value
     doUploadAsset user = bindResponse (uploadAsset user) $ \resp -> do

--- a/integration/test/Test/AssetDownload.hs
+++ b/integration/test/Test/AssetDownload.hs
@@ -54,7 +54,7 @@ testDownloadAssetMultiIngressS3DownloadUrl = do
     modifyConfig :: ServiceOverrides
     modifyConfig =
       def
-        { dbCargohold =
+        { cargoholdCfg =
             setField "aws.multiIngress" $
               object
                 [ "red.example.com" .= "http://s3-download.red.example.com",

--- a/integration/test/Test/AssetDownload.hs
+++ b/integration/test/Test/AssetDownload.hs
@@ -15,7 +15,7 @@ testDownloadAsset = do
     resp.status `shouldMatchInt` 201
     resp.json %. "key"
 
-  bindResponse (downloadAsset' user user key "nginz-https.example.com" id) $ \resp -> do
+  bindResponse (downloadAsset user user key "nginz-https.example.com" id) $ \resp -> do
     resp.status `shouldMatchInt` 200
     assertBool
       ("Expect 'Hello World!' as text asset content. Got: " ++ show resp.body)
@@ -28,16 +28,16 @@ testDownloadAssetMultiIngressS3DownloadUrl = do
   -- multi-ingress disabled
   key <- doUploadAsset user
 
-  bindResponse (downloadAsset' user user key "nginz-https.example.com" noRedirects) $ \resp -> do
+  bindResponse (downloadAsset user user key "nginz-https.example.com" noRedirects) $ \resp -> do
     resp.status `shouldMatchInt` 302
 
-  bindResponse (downloadAsset' user user key "red.example.com" noRedirects) $ \resp -> do
+  bindResponse (downloadAsset user user key "red.example.com" noRedirects) $ \resp -> do
     resp.status `shouldMatchInt` 302
 
-  bindResponse (downloadAsset' user user key "green.example.com" noRedirects) $ \resp -> do
+  bindResponse (downloadAsset user user key "green.example.com" noRedirects) $ \resp -> do
     resp.status `shouldMatchInt` 302
 
-  bindResponse (downloadAsset' user user key "unknown.example.com" noRedirects) $ \resp -> do
+  bindResponse (downloadAsset user user key "unknown.example.com" noRedirects) $ \resp -> do
     resp.status `shouldMatchInt` 302
 
   -- multi-ingress enabled
@@ -45,19 +45,19 @@ testDownloadAssetMultiIngressS3DownloadUrl = do
     user' <- randomUser domain def
     key' <- doUploadAsset user'
 
-    bindResponse (downloadAsset' user' user' key' "nginz-https.example.com" noRedirects) $ \resp -> do
+    bindResponse (downloadAsset user' user' key' "nginz-https.example.com" noRedirects) $ \resp -> do
       resp.status `shouldMatchInt` 404
       resp.json %. "label" `shouldMatch` "not-found"
 
-    bindResponse (downloadAsset' user' user' key' "red.example.com" noRedirects) $ \resp -> do
+    bindResponse (downloadAsset user' user' key' "red.example.com" noRedirects) $ \resp -> do
       resp.status `shouldMatchInt` 302
       locationHeaderHost resp `shouldMatch` "s3-download.red.example.com"
 
-    bindResponse (downloadAsset' user' user' key' "green.example.com" noRedirects) $ \resp -> do
+    bindResponse (downloadAsset user' user' key' "green.example.com" noRedirects) $ \resp -> do
       resp.status `shouldMatchInt` 302
       locationHeaderHost resp `shouldMatch` "s3-download.green.example.com"
 
-    bindResponse (downloadAsset' user' user' key' "unknown.example.com" noRedirects) $ \resp -> do
+    bindResponse (downloadAsset user' user' key' "unknown.example.com" noRedirects) $ \resp -> do
       resp.status `shouldMatchInt` 404
       resp.json %. "label" `shouldMatch` "not-found"
   where

--- a/integration/test/Test/Brig.hs
+++ b/integration/test/Test/Brig.hs
@@ -31,7 +31,7 @@ testCrudFederationRemotes = do
   otherDomain <- asString OtherDomain
   let overrides =
         def
-          { dbBrig =
+          { brigCfg =
               setField
                 "optSettings.setFederationDomainConfigs"
                 [object ["domain" .= otherDomain, "search_policy" .= "full_search"]]
@@ -187,7 +187,7 @@ testRemoteUserSearch = do
         setField "optSettings.setFederationStrategy" "allowDynamic"
           >=> removeField "optSettings.setFederationDomainConfigs"
           >=> setField "optSettings.setFederationDomainConfigsUpdateFreq" (Aeson.Number 1)
-  startDynamicBackends [def {dbBrig = overrides}, def {dbBrig = overrides}] $ \dynDomains -> do
+  startDynamicBackends [def {brigCfg = overrides}, def {brigCfg = overrides}] $ \dynDomains -> do
     domains@[d1, d2] <- pure dynDomains
     connectAllDomainsAndWaitToSync 1 domains
     [u1, u2] <- createAndConnectUsers [d1, d2]

--- a/integration/test/Test/Brig.hs
+++ b/integration/test/Test/Brig.hs
@@ -30,10 +30,12 @@ testCrudFederationRemotes :: HasCallStack => App ()
 testCrudFederationRemotes = do
   otherDomain <- asString OtherDomain
   let overrides =
-        ( setField
-            "optSettings.setFederationDomainConfigs"
-            [object ["domain" .= otherDomain, "search_policy" .= "full_search"]]
-        )
+        def
+          { dbBrig =
+              setField
+                "optSettings.setFederationDomainConfigs"
+                [object ["domain" .= otherDomain, "search_policy" .= "full_search"]]
+          }
   withModifiedService Brig overrides $ \_ -> do
     let parseFedConns :: HasCallStack => Response -> App [Value]
         parseFedConns resp =

--- a/integration/test/Test/Brig.hs
+++ b/integration/test/Test/Brig.hs
@@ -36,7 +36,7 @@ testCrudFederationRemotes = do
                 "optSettings.setFederationDomainConfigs"
                 [object ["domain" .= otherDomain, "search_policy" .= "full_search"]]
           }
-  withModifiedService Brig overrides $ \_ -> do
+  withModifiedBackend overrides $ \_ -> do
     let parseFedConns :: HasCallStack => Response -> App [Value]
         parseFedConns resp =
           -- Pick out the list of federation domain configs

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -18,7 +18,7 @@ import Testlib.Prelude
 testDynamicBackendsFullyConnectedWhenAllowAll :: HasCallStack => App ()
 testDynamicBackendsFullyConnectedWhenAllowAll = do
   let overrides =
-        def {dbBrig = setField "optSettings.setFederationStrategy" "allowAll"}
+        def {brigCfg = setField "optSettings.setFederationStrategy" "allowAll"}
           <> fullSearchWithAll
   startDynamicBackends [overrides, overrides, overrides] $ \dynDomains -> do
     [domainA, domainB, domainC] <- pure dynDomains
@@ -41,7 +41,7 @@ testDynamicBackendsNotFederating :: HasCallStack => App ()
 testDynamicBackendsNotFederating = do
   let overrides =
         def
-          { dbBrig =
+          { brigCfg =
               setField "optSettings.setFederationStrategy" "allowNone"
           }
   startDynamicBackends [overrides, overrides, overrides] $
@@ -62,9 +62,9 @@ testDynamicBackendsFullyConnectedWhenAllowDynamic = do
           >=> removeField "optSettings.setFederationDomainConfigs"
           >=> setField "optSettings.setFederationDomainConfigsUpdateFreq" (Aeson.Number 1)
   startDynamicBackends
-    [ def {dbBrig = overrides},
-      def {dbBrig = overrides},
-      def {dbBrig = overrides}
+    [ def {brigCfg = overrides},
+      def {brigCfg = overrides},
+      def {brigCfg = overrides}
     ]
     $ \dynDomains -> do
       domains@[domainA, domainB, domainC] <- pure dynDomains
@@ -86,7 +86,7 @@ testDynamicBackendsNotFullyConnected :: HasCallStack => App ()
 testDynamicBackendsNotFullyConnected = do
   let overrides =
         def
-          { dbBrig =
+          { brigCfg =
               setField "optSettings.setFederationStrategy" "allowDynamic"
                 >=> removeField "optSettings.setFederationDomainConfigs"
                 >=> setField "optSettings.setFederationDomainConfigsUpdateFreq" (Aeson.Number 1)
@@ -140,9 +140,9 @@ testCreateConversationFullyConnected = do
           >=> removeField "optSettings.setFederationDomainConfigs"
           >=> setField "optSettings.setFederationDomainConfigsUpdateFreq" (Aeson.Number 1)
   startDynamicBackends
-    [ def {dbBrig = setFederationConfig},
-      def {dbBrig = setFederationConfig},
-      def {dbBrig = setFederationConfig}
+    [ def {brigCfg = setFederationConfig},
+      def {brigCfg = setFederationConfig},
+      def {brigCfg = setFederationConfig}
     ]
     $ \dynDomains -> do
       domains@[domainA, domainB, domainC] <- pure dynDomains
@@ -158,9 +158,9 @@ testCreateConversationNonFullyConnected = do
           >=> removeField "optSettings.setFederationDomainConfigs"
           >=> setField "optSettings.setFederationDomainConfigsUpdateFreq" (Aeson.Number 1)
   startDynamicBackends
-    [ def {dbBrig = setFederationConfig},
-      def {dbBrig = setFederationConfig},
-      def {dbBrig = setFederationConfig}
+    [ def {brigCfg = setFederationConfig},
+      def {brigCfg = setFederationConfig},
+      def {brigCfg = setFederationConfig}
     ]
     $ \dynDomains -> do
       domains@[domainA, domainB, domainC] <- pure dynDomains
@@ -181,8 +181,8 @@ testDefederationGroupConversation = do
           >=> removeField "optSettings.setFederationDomainConfigs"
           >=> setField "optSettings.setFederationDomainConfigsUpdateFreq" (Aeson.Number 1)
   startDynamicBackends
-    [ def {dbBrig = setFederationConfig},
-      def {dbBrig = setFederationConfig}
+    [ def {brigCfg = setFederationConfig},
+      def {brigCfg = setFederationConfig}
     ]
     $ \dynDomains -> do
       domains@[domainA, domainB] <- pure dynDomains
@@ -247,8 +247,8 @@ testDefederationOneOnOne = do
           >=> removeField "optSettings.setFederationDomainConfigs"
           >=> setField "optSettings.setFederationDomainConfigsUpdateFreq" (Aeson.Number 1)
   startDynamicBackends
-    [ def {dbBrig = setFederationConfig},
-      def {dbBrig = setFederationConfig}
+    [ def {brigCfg = setFederationConfig},
+      def {brigCfg = setFederationConfig}
     ]
     $ \dynDomains -> do
       domains@[domainA, domainB] <- pure dynDomains
@@ -342,7 +342,7 @@ testAddMembersNonFullyConnectedProteus = do
 testConvWithUnreachableRemoteUsers :: HasCallStack => App ()
 testConvWithUnreachableRemoteUsers = do
   let overrides =
-        def {dbBrig = setField "optSettings.setFederationStrategy" "allowAll"}
+        def {brigCfg = setField "optSettings.setFederationStrategy" "allowAll"}
           <> fullSearchWithAll
   ([alice, alex, bob, charlie, dylan], domains) <-
     startDynamicBackends [overrides, overrides] $ \domains -> do
@@ -363,7 +363,7 @@ testConvWithUnreachableRemoteUsers = do
 testAddReachableWithUnreachableRemoteUsers :: HasCallStack => App ()
 testAddReachableWithUnreachableRemoteUsers = do
   let overrides =
-        def {dbBrig = setField "optSettings.setFederationStrategy" "allowAll"}
+        def {brigCfg = setField "optSettings.setFederationStrategy" "allowAll"}
           <> fullSearchWithAll
   ([alex, bob], conv, domains) <-
     startDynamicBackends [overrides, overrides] $ \domains -> do
@@ -389,7 +389,7 @@ testAddReachableWithUnreachableRemoteUsers = do
 testAddUnreachable :: HasCallStack => App ()
 testAddUnreachable = do
   let overrides =
-        def {dbBrig = setField "optSettings.setFederationStrategy" "allowAll"}
+        def {brigCfg = setField "optSettings.setFederationStrategy" "allowAll"}
           <> fullSearchWithAll
   ([alex, charlie], [charlieDomain, dylanDomain], conv) <-
     startDynamicBackends [overrides, overrides] $ \domains -> do
@@ -412,7 +412,7 @@ testAddingUserNonFullyConnectedFederation :: HasCallStack => App ()
 testAddingUserNonFullyConnectedFederation = do
   let overrides =
         def
-          { dbBrig =
+          { brigCfg =
               setField "optSettings.setFederationStrategy" "allowDynamic"
                 >=> removeField "optSettings.setFederationDomainConfigs"
           }

--- a/integration/test/Test/Defederation.hs
+++ b/integration/test/Test/Defederation.hs
@@ -33,9 +33,9 @@ testDefederationNonFullyConnectedGraph = do
           >=> removeField "optSettings.setFederationDomainConfigs"
           >=> setField "optSettings.setFederationDomainConfigsUpdateFreq" (Aeson.Number 1)
   startDynamicBackends
-    [ def {dbBrig = setFederationConfig},
-      def {dbBrig = setFederationConfig},
-      def {dbBrig = setFederationConfig}
+    [ def {brigCfg = setFederationConfig},
+      def {brigCfg = setFederationConfig},
+      def {brigCfg = setFederationConfig}
     ]
     $ \dynDomains -> do
       domains@[domainA, domainB, domainC] <- pure dynDomains

--- a/integration/test/Test/Demo.hs
+++ b/integration/test/Test/Demo.hs
@@ -35,7 +35,7 @@ testModifiedBrig :: HasCallStack => App ()
 testModifiedBrig = do
   withModifiedService
     Brig
-    (def {dbBrig = setField "optSettings.setFederationDomain" "overridden.example.com"})
+    (def {brigCfg = setField "optSettings.setFederationDomain" "overridden.example.com"})
     $ \domain -> do
       bindResponse (Public.getAPIVersion domain)
       $ \resp -> do
@@ -56,7 +56,7 @@ testModifiedGalley = do
 
   withModifiedService
     Galley
-    def {dbGalley = setField "settings.featureFlags.teamSearchVisibility" "enabled-by-default"}
+    def {galleyCfg = setField "settings.featureFlags.teamSearchVisibility" "enabled-by-default"}
     $ \_ -> getFeatureStatus `shouldMatch` "enabled"
 
 testModifiedCannon :: HasCallStack => App ()
@@ -79,8 +79,8 @@ testModifiedServices :: HasCallStack => App ()
 testModifiedServices = do
   let serviceMap =
         def
-          { dbBrig = setField "optSettings.setFederationDomain" "overridden.example.com",
-            dbGalley = setField "settings.featureFlags.teamSearchVisibility" "enabled-by-default"
+          { brigCfg = setField "optSettings.setFederationDomain" "overridden.example.com",
+            galleyCfg = setField "settings.featureFlags.teamSearchVisibility" "enabled-by-default"
           }
 
   runCodensity (withModifiedServices serviceMap [Brig, Galley]) $ \_domain -> do

--- a/integration/test/Test/Demo.hs
+++ b/integration/test/Test/Demo.hs
@@ -37,8 +37,8 @@ testModifiedBrig = do
   withModifiedService
     Brig
     (setField "optSettings.setFederationDomain" "overridden.example.com")
-    $ \_domain -> do
-      bindResponse (Public.getAPIVersion OwnDomain)
+    $ \domain -> do
+      bindResponse (Public.getAPIVersion domain)
       $ \resp -> do
         resp.status `shouldMatchInt` 200
         (resp.json %. "domain") `shouldMatch` "overridden.example.com"

--- a/integration/test/Test/Federation.hs
+++ b/integration/test/Test/Federation.hs
@@ -30,7 +30,7 @@ testNotificationsForOfflineBackends = do
   -- We call it 'downBackend' because it is down for the most of this test
   -- except for setup and assertions. Perhaps there is a better name.
   runCodensity (acquireResources 1 resourcePool) $ \[downBackend] -> do
-    (downUser1, downClient1, downUser2, upBackendConv, downBackendConv) <- runCodensity (startDynamicBackend downBackend mempty mempty) $ \_ -> do
+    (downUser1, downClient1, downUser2, upBackendConv, downBackendConv) <- runCodensity (startDynamicBackend downBackend mempty) $ \_ -> do
       downUser1 <- randomUser downBackend.berDomain def
       downUser2 <- randomUser downBackend.berDomain def
       downClient1 <- objId $ bindResponse (API.addClient downUser1 def) $ getJSON 201
@@ -103,7 +103,7 @@ testNotificationsForOfflineBackends = do
       delUserDeletedNotif <- nPayload $ awaitNotification otherUser otherClient (Just newMsgNotif) 1 isDeleteUserNotif
       objQid delUserDeletedNotif `shouldMatch` objQid delUser
 
-    runCodensity (startDynamicBackend downBackend mempty mempty) $ \_ -> do
+    runCodensity (startDynamicBackend downBackend mempty) $ \_ -> do
       newMsgNotif <- awaitNotification downUser1 downClient1 noValue 5 isNewMessageNotif
       newMsgNotif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject upBackendConv
       newMsgNotif %. "payload.0.data.text" `shouldMatchBase64` "success message for down user"

--- a/integration/test/Testlib/App.hs
+++ b/integration/test/Testlib/App.hs
@@ -12,6 +12,7 @@ import GHC.Stack (HasCallStack)
 import System.FilePath
 import Testlib.Env
 import Testlib.JSON
+import Testlib.Service
 import Testlib.Types
 import Prelude
 

--- a/integration/test/Testlib/Cannon.hs
+++ b/integration/test/Testlib/Cannon.hs
@@ -68,6 +68,7 @@ import Testlib.Env
 import Testlib.HTTP
 import Testlib.JSON
 import Testlib.Printing
+import Testlib.Service
 import Testlib.Types
 import Prelude
 

--- a/integration/test/Testlib/Env.hs
+++ b/integration/test/Testlib/Env.hs
@@ -23,6 +23,7 @@ import System.IO
 import System.IO.Temp
 import Testlib.Prekeys
 import Testlib.ResourcePool
+import Testlib.Service
 import Prelude
 
 -- | Initialised once per test.
@@ -106,42 +107,6 @@ data HostPort = HostPort
   deriving (Show, Generic)
 
 instance FromJSON HostPort
-
-data Service = Brig | Galley | Cannon | Gundeck | Cargohold | Nginz | Spar | BackgroundWorker | Stern | FederatorInternal
-  deriving
-    ( Show,
-      Eq,
-      Ord,
-      Enum,
-      Bounded
-    )
-
-serviceName :: Service -> String
-serviceName = \case
-  Brig -> "brig"
-  Galley -> "galley"
-  Cannon -> "cannon"
-  Gundeck -> "gundeck"
-  Cargohold -> "cargohold"
-  Nginz -> "nginz"
-  Spar -> "spar"
-  BackgroundWorker -> "backgroundWorker"
-  Stern -> "stern"
-  FederatorInternal -> "federator"
-
--- | Converts the service name to kebab-case.
-configName :: Service -> String
-configName = \case
-  Brig -> "brig"
-  Galley -> "galley"
-  Cannon -> "cannon"
-  Gundeck -> "gundeck"
-  Cargohold -> "cargohold"
-  Nginz -> "nginz"
-  Spar -> "spar"
-  BackgroundWorker -> "background-worker"
-  Stern -> "stern"
-  FederatorInternal -> "federator"
 
 serviceHostPort :: ServiceMap -> Service -> HostPort
 serviceHostPort m Brig = m.brig

--- a/integration/test/Testlib/HTTP.hs
+++ b/integration/test/Testlib/HTTP.hs
@@ -25,6 +25,7 @@ import Network.URI (URI (..), URIAuth (..), parseURI)
 import Testlib.Assertions
 import Testlib.Env
 import Testlib.JSON
+import Testlib.Service
 import Testlib.Types
 import Prelude
 

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -162,42 +162,42 @@ startDynamicBackend resource beOverrides = do
     setAwsConfigs :: ServiceOverrides
     setAwsConfigs =
       def
-        { dbBrig =
+        { brigCfg =
             setField "aws.userJournalQueue" resource.berAwsUserJournalQueue
               >=> setField "aws.prekeyTable" resource.berAwsPrekeyTable
               >=> setField "internalEvents.queueName" resource.berBrigInternalEvents
               >=> setField "emailSMS.email.sesQueue" resource.berEmailSMSSesQueue
               >=> setField "emailSMS.general.emailSender" resource.berEmailSMSEmailSender,
-          dbCargohold = setField "aws.s3Bucket" resource.berAwsS3Bucket,
-          dbGundeck = setField "aws.queueName" resource.berAwsQueueName,
-          dbGalley = setField "journal.queueName" resource.berGalleyJournal
+          cargoholdCfg = setField "aws.s3Bucket" resource.berAwsS3Bucket,
+          gundeckCfg = setField "aws.queueName" resource.berAwsQueueName,
+          galleyCfg = setField "journal.queueName" resource.berGalleyJournal
         }
 
     setFederationSettings :: ServiceOverrides
     setFederationSettings =
       def
-        { dbBrig =
+        { brigCfg =
             setField "optSettings.setFederationDomain" resource.berDomain
               >=> setField "optSettings.setFederationDomainConfigs" ([] :: [Value])
               >=> setField "federatorInternal.port" resource.berFederatorInternal
               >=> setField "federatorInternal.host" ("127.0.0.1" :: String)
               >=> setField "rabbitmq.vHost" resource.berVHost,
-          dbCargohold =
+          cargoholdCfg =
             setField "settings.federationDomain" resource.berDomain
               >=> setField "federator.host" ("127.0.0.1" :: String)
               >=> setField "federator.port" resource.berFederatorInternal,
-          dbGalley =
+          galleyCfg =
             setField "settings.federationDomain" resource.berDomain
               >=> setField "settings.featureFlags.classifiedDomains.config.domains" [resource.berDomain]
               >=> setField "federator.host" ("127.0.0.1" :: String)
               >=> setField "federator.port" resource.berFederatorInternal
               >=> setField "rabbitmq.vHost" resource.berVHost,
-          dbGundeck = setField "settings.federationDomain" resource.berDomain,
-          dbBackgroundWorker =
+          gundeckCfg = setField "settings.federationDomain" resource.berDomain,
+          backgroundWorkerCfg =
             setField "federatorInternal.port" resource.berFederatorInternal
               >=> setField "federatorInternal.host" ("127.0.0.1" :: String)
               >=> setField "rabbitmq.vHost" resource.berVHost,
-          dbFederatorInternal =
+          federatorInternalCfg =
             setField "federatorInternal.port" resource.berFederatorInternal
               >=> setField "federatorExternal.port" resource.berFederatorExternal
               >=> setField "optSettings.setFederationDomain" resource.berDomain
@@ -206,31 +206,31 @@ startDynamicBackend resource beOverrides = do
     setKeyspace :: ServiceOverrides
     setKeyspace =
       def
-        { dbGalley = setField "cassandra.keyspace" resource.berGalleyKeyspace,
-          dbBrig = setField "cassandra.keyspace" resource.berBrigKeyspace,
-          dbSpar = setField "cassandra.keyspace" resource.berSparKeyspace,
-          dbGundeck = setField "cassandra.keyspace" resource.berGundeckKeyspace
+        { galleyCfg = setField "cassandra.keyspace" resource.berGalleyKeyspace,
+          brigCfg = setField "cassandra.keyspace" resource.berBrigKeyspace,
+          sparCfg = setField "cassandra.keyspace" resource.berSparKeyspace,
+          gundeckCfg = setField "cassandra.keyspace" resource.berGundeckKeyspace
         }
 
     setEsIndex :: ServiceOverrides
     setEsIndex =
       def
-        { dbBrig = setField "elasticsearch.index" resource.berElasticsearchIndex
+        { brigCfg = setField "elasticsearch.index" resource.berElasticsearchIndex
         }
 
     setLogLevel :: ServiceOverrides
     setLogLevel =
       def
-        { dbSpar = setField "saml.logLevel" ("Warn" :: String),
-          dbBrig = setField "logLevel" ("Warn" :: String),
-          dbCannon = setField "logLevel" ("Warn" :: String),
-          dbCargohold = setField "logLevel" ("Warn" :: String),
-          dbGalley = setField "logLevel" ("Warn" :: String),
-          dbGundeck = setField "logLevel" ("Warn" :: String),
-          dbNginz = setField "logLevel" ("Warn" :: String),
-          dbBackgroundWorker = setField "logLevel" ("Warn" :: String),
-          dbStern = setField "logLevel" ("Warn" :: String),
-          dbFederatorInternal = setField "logLevel" ("Warn" :: String)
+        { sparCfg = setField "saml.logLevel" ("Warn" :: String),
+          brigCfg = setField "logLevel" ("Warn" :: String),
+          cannonCfg = setField "logLevel" ("Warn" :: String),
+          cargoholdCfg = setField "logLevel" ("Warn" :: String),
+          galleyCfg = setField "logLevel" ("Warn" :: String),
+          gundeckCfg = setField "logLevel" ("Warn" :: String),
+          nginzCfg = setField "logLevel" ("Warn" :: String),
+          backgroundWorkerCfg = setField "logLevel" ("Warn" :: String),
+          sternCfg = setField "logLevel" ("Warn" :: String),
+          federatorInternalCfg = setField "logLevel" ("Warn" :: String)
         }
 
 withModifiedServices :: ServiceOverrides -> [Service] -> Codensity App String

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -283,7 +283,7 @@ startBackend resource overrides services = do
                 nginz = g Nginz,
                 spar = g Spar,
                 -- FUREWORK: Set to g Proxy, when we add Proxy to spawned services
-                proxy = HostPort "127.0.0.1" 9999,
+                proxy = HostPort "127.0.0.1" 9087,
                 stern = g Stern
               }
 

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -52,6 +52,7 @@ import Testlib.HTTP
 import Testlib.JSON
 import Testlib.Printing
 import Testlib.ResourcePool
+import Testlib.Service
 import Testlib.Types
 import Text.RawString.QQ
 import Prelude

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -54,12 +54,7 @@ import Prelude
 
 withModifiedBackend :: HasCallStack => ServiceOverrides -> (HasCallStack => String -> App a) -> App a
 withModifiedBackend overrides k =
-  startDynamicBackends
-    [overrides]
-    ( \domains -> do
-        [domain] <- pure domains
-        k domain
-    )
+  startDynamicBackends [overrides] (\domains -> k (head domains))
 
 copyDirectoryRecursively :: FilePath -> FilePath -> IO ()
 copyDirectoryRecursively from to = do

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -443,6 +443,7 @@ startNginzLocal domain http2Port sslPort sm = do
   -- override port configuration
   let portConfigTemplate =
         [r|listen {localPort};
+listen {http2_port} http2;
 listen {ssl_port} ssl http2;
 listen [::]:{ssl_port} ssl http2;
 |]

--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -277,7 +277,7 @@ startBackend resource overrides services = do
                 gundeck = g Gundeck,
                 nginz = g Nginz,
                 spar = g Spar,
-                -- FUREWORK: Set to g Proxy, when we add Proxy to spawned services
+                -- FUTUREWORK: Set to g Proxy, when we add Proxy to spawned services
                 proxy = HostPort "127.0.0.1" 9087,
                 stern = g Stern
               }

--- a/integration/test/Testlib/Ports.hs
+++ b/integration/test/Testlib/Ports.hs
@@ -5,11 +5,13 @@ import Prelude
 
 data PortNamespace
   = NginzSSL
+  | NginzHttp2
   | FederatorExternal
   | ServiceInternal Service.Service
 
 port :: Num a => PortNamespace -> Service.BackendName -> a
 port NginzSSL bn = mkPort 8443 bn
+port NginzHttp2 bn = mkPort 8099 bn
 port FederatorExternal bn = mkPort 8098 bn
 port (ServiceInternal Service.BackgroundWorker) bn = mkPort 8089 bn
 port (ServiceInternal Service.Brig) bn = mkPort 8082 bn

--- a/integration/test/Testlib/Ports.hs
+++ b/integration/test/Testlib/Ports.hs
@@ -1,0 +1,37 @@
+module Testlib.Ports where
+
+import Testlib.Service qualified as Service
+import Prelude
+
+data PortNamespace
+  = NginzSSL
+  | FederatorExternal
+  | ServiceInternal Service.Service
+
+port :: Num a => PortNamespace -> Service.BackendName -> a
+port NginzSSL bn = mkPort 8443 bn
+port FederatorExternal bn = mkPort 8098 bn
+port (ServiceInternal Service.BackgroundWorker) bn = mkPort 8089 bn
+port (ServiceInternal Service.Brig) bn = mkPort 8082 bn
+port (ServiceInternal Service.Cannon) bn = mkPort 8083 bn
+port (ServiceInternal Service.Cargohold) bn = mkPort 8084 bn
+port (ServiceInternal Service.FederatorInternal) bn = mkPort 8097 bn
+port (ServiceInternal Service.Galley) bn = mkPort 8085 bn
+port (ServiceInternal Service.Gundeck) bn = mkPort 8086 bn
+port (ServiceInternal Service.Nginz) bn = mkPort 8080 bn
+port (ServiceInternal Service.Spar) bn = mkPort 8088 bn
+port (ServiceInternal Service.Stern) bn = mkPort 8091 bn
+
+portForDyn :: Num a => PortNamespace -> Int -> a
+portForDyn ns i = port ns (Service.DynamicBackend i)
+
+mkPort :: Num a => Int -> Service.BackendName -> a
+mkPort basePort bn =
+  let i = case bn of
+        Service.BackendA -> 0
+        Service.BackendB -> 1
+        (Service.DynamicBackend k) -> 1 + k
+   in fromIntegral basePort + (fromIntegral i) * 1000
+
+internalServicePorts :: Num a => Service.BackendName -> Service.Service -> a
+internalServicePorts backend service = port (ServiceInternal service) backend

--- a/integration/test/Testlib/Prelude.hs
+++ b/integration/test/Testlib/Prelude.hs
@@ -8,6 +8,7 @@ module Testlib.Prelude
     module Testlib.HTTP,
     module Testlib.JSON,
     module Testlib.PTest,
+    module Testlib.Service,
     module Data.Aeson,
     module Prelude,
     module Control.Applicative,
@@ -120,6 +121,7 @@ import Testlib.HTTP
 import Testlib.JSON
 import Testlib.ModService
 import Testlib.PTest
+import Testlib.Service
 import Testlib.Types
 import UnliftIO.Exception
 import Prelude

--- a/integration/test/Testlib/ResourcePool.hs
+++ b/integration/test/Testlib/ResourcePool.hs
@@ -5,6 +5,8 @@ module Testlib.ResourcePool
     backendResources,
     createBackendResourcePool,
     acquireResources,
+    backendA,
+    backendB,
   )
 where
 
@@ -73,6 +75,7 @@ data BackendResource = BackendResource
     berGalleyJournal :: String,
     berVHost :: String,
     berNginzSslPort :: Word16,
+    berNginzHttp2Port :: Word16,
     berInternalServicePorts :: forall a. Num a => Service -> a
   }
 
@@ -115,6 +118,7 @@ backendResources dynConfs =
                     berGalleyJournal = "integration-team-events.fifo" <> suffix i,
                     berVHost = dynConf.domain,
                     berNginzSslPort = Ports.portForDyn Ports.NginzSSL i,
+                    berNginzHttp2Port = Ports.portForDyn Ports.NginzHttp2 i,
                     berInternalServicePorts = Ports.internalServicePorts name
                   }
         )
@@ -122,3 +126,58 @@ backendResources dynConfs =
   where
     suffix :: (Show a, Num a) => a -> String
     suffix i = show $ i + 2
+
+backendA :: BackendResource
+backendA =
+  BackendResource
+    { berName = BackendA,
+      berBrigKeyspace = "brig_test",
+      berGalleyKeyspace = "galley_test",
+      berSparKeyspace = "spar_test",
+      berGundeckKeyspace = "gundeck_test",
+      berElasticsearchIndex = "directory_test",
+      berFederatorInternal = Ports.port (Ports.ServiceInternal FederatorInternal) BackendA,
+      berFederatorExternal = Ports.port Ports.FederatorExternal BackendA,
+      berDomain = "example.com",
+      berAwsUserJournalQueue = "integration-user-events.fifo",
+      berAwsPrekeyTable = "integration-brig-prekeys",
+      berAwsS3Bucket = "dummy-bucket",
+      berAwsQueueName = "integration-gundeck-events",
+      berBrigInternalEvents = "integration-brig-events-internal",
+      berEmailSMSSesQueue = "integration-brig-events",
+      berEmailSMSEmailSender = "backend-integration@wire.com",
+      berGalleyJournal = "integration-team-events.fifo",
+      berVHost = "backendA",
+      berNginzSslPort = Ports.port Ports.NginzSSL BackendA,
+      berInternalServicePorts = Ports.internalServicePorts BackendA,
+      berNginzHttp2Port = Ports.port Ports.NginzHttp2 BackendA
+    }
+
+backendB :: BackendResource
+backendB =
+  BackendResource
+    { berName = BackendB,
+      berBrigKeyspace = "brig_test2",
+      berGalleyKeyspace = "galley_test2",
+      berSparKeyspace = "spar_test2",
+      berGundeckKeyspace = "gundeck_test2",
+      berElasticsearchIndex = "directory2_test",
+      berFederatorInternal = Ports.port (Ports.ServiceInternal FederatorInternal) BackendB,
+      berFederatorExternal = Ports.port Ports.FederatorExternal BackendB,
+      berDomain = "b.example.com",
+      berAwsUserJournalQueue = "integration-user-events.fifo2",
+      berAwsPrekeyTable = "integration-brig-prekeys2",
+      berAwsS3Bucket = "dummy-bucket2",
+      berAwsQueueName = "integration-gundeck-events2",
+      berBrigInternalEvents = "integration-brig-events-internal2",
+      berEmailSMSSesQueue = "integration-brig-events2",
+      berEmailSMSEmailSender = "backend-integration2@wire.com",
+      berGalleyJournal = "integration-team-events.fifo2",
+      -- FUTUREWORK: set up vhosts in dev/ci for example.com and b.example.com
+      -- in case we want backendA and backendB to federate with a third backend
+      -- (because otherwise both queues will overlap)
+      berVHost = "backendB",
+      berNginzSslPort = Ports.port Ports.NginzSSL BackendB,
+      berInternalServicePorts = Ports.internalServicePorts BackendB,
+      berNginzHttp2Port = Ports.port Ports.NginzHttp2 BackendB
+    }

--- a/integration/test/Testlib/Run.hs
+++ b/integration/test/Testlib/Run.hs
@@ -23,6 +23,7 @@ import Testlib.Env
 import Testlib.JSON
 import Testlib.Options
 import Testlib.Printing
+import Testlib.Service
 import Testlib.Types
 import Text.Printf
 import UnliftIO.Async

--- a/integration/test/Testlib/RunServices.hs
+++ b/integration/test/Testlib/RunServices.hs
@@ -12,6 +12,7 @@ import System.Exit (exitWith)
 import System.FilePath
 import System.Posix (getWorkingDirectory)
 import System.Process
+import Testlib.Ports qualified as Ports
 import Testlib.Prelude
 import Testlib.ResourcePool
 import Testlib.Run (createGlobalEnv)
@@ -19,13 +20,14 @@ import Testlib.Run (createGlobalEnv)
 backendA :: BackendResource
 backendA =
   BackendResource
-    { berBrigKeyspace = "brig_test",
+    { berName = BackendA,
+      berBrigKeyspace = "brig_test",
       berGalleyKeyspace = "galley_test",
       berSparKeyspace = "spar_test",
       berGundeckKeyspace = "gundeck_test",
       berElasticsearchIndex = "directory_test",
-      berFederatorInternal = 8097,
-      berFederatorExternal = 8098,
+      berFederatorInternal = Ports.port (Ports.ServiceInternal FederatorInternal) BackendA,
+      berFederatorExternal = Ports.port Ports.FederatorExternal BackendA,
       berDomain = "example.com",
       berAwsUserJournalQueue = "integration-user-events.fifo",
       berAwsPrekeyTable = "integration-brig-prekeys",
@@ -36,7 +38,8 @@ backendA =
       berEmailSMSEmailSender = "backend-integration@wire.com",
       berGalleyJournal = "integration-team-events.fifo",
       berVHost = "backendA",
-      berNginzSslPort = 8443
+      berNginzSslPort = Ports.port Ports.NginzSSL BackendA,
+      berInternalServicePorts = Ports.internalServicePorts BackendA
     }
 
 staticPortsA :: Map.Map Service Word16
@@ -56,13 +59,14 @@ staticPortsA =
 backendB :: BackendResource
 backendB =
   BackendResource
-    { berBrigKeyspace = "brig_test2",
+    { berName = BackendB,
+      berBrigKeyspace = "brig_test2",
       berGalleyKeyspace = "galley_test2",
       berSparKeyspace = "spar_test2",
       berGundeckKeyspace = "gundeck_test2",
       berElasticsearchIndex = "directory2_test",
-      berFederatorInternal = 9097,
-      berFederatorExternal = 9098,
+      berFederatorInternal = Ports.port (Ports.ServiceInternal FederatorInternal) BackendB,
+      berFederatorExternal = Ports.port Ports.FederatorExternal BackendB,
       berDomain = "b.example.com",
       berAwsUserJournalQueue = "integration-user-events.fifo2",
       berAwsPrekeyTable = "integration-brig-prekeys2",
@@ -76,7 +80,8 @@ backendB =
       -- in case we want backendA and backendB to federate with a third backend
       -- (because otherwise both queues will overlap)
       berVHost = "backendB",
-      berNginzSslPort = 9443
+      berNginzSslPort = Ports.port Ports.NginzSSL BackendB,
+      berInternalServicePorts = Ports.internalServicePorts BackendB
     }
 
 staticPortsB :: Map.Map Service Word16

--- a/integration/test/Testlib/RunServices.hs
+++ b/integration/test/Testlib/RunServices.hs
@@ -4,7 +4,6 @@ module Testlib.RunServices where
 
 import Control.Concurrent
 import Control.Monad.Codensity (lowerCodensity)
-import Data.Map qualified as Map
 import SetupHelpers
 import System.Directory
 import System.Environment (getArgs)
@@ -12,91 +11,9 @@ import System.Exit (exitWith)
 import System.FilePath
 import System.Posix (getWorkingDirectory)
 import System.Process
-import Testlib.Ports qualified as Ports
 import Testlib.Prelude
 import Testlib.ResourcePool
 import Testlib.Run (createGlobalEnv)
-
-backendA :: BackendResource
-backendA =
-  BackendResource
-    { berName = BackendA,
-      berBrigKeyspace = "brig_test",
-      berGalleyKeyspace = "galley_test",
-      berSparKeyspace = "spar_test",
-      berGundeckKeyspace = "gundeck_test",
-      berElasticsearchIndex = "directory_test",
-      berFederatorInternal = Ports.port (Ports.ServiceInternal FederatorInternal) BackendA,
-      berFederatorExternal = Ports.port Ports.FederatorExternal BackendA,
-      berDomain = "example.com",
-      berAwsUserJournalQueue = "integration-user-events.fifo",
-      berAwsPrekeyTable = "integration-brig-prekeys",
-      berAwsS3Bucket = "dummy-bucket",
-      berAwsQueueName = "integration-gundeck-events",
-      berBrigInternalEvents = "integration-brig-events-internal",
-      berEmailSMSSesQueue = "integration-brig-events",
-      berEmailSMSEmailSender = "backend-integration@wire.com",
-      berGalleyJournal = "integration-team-events.fifo",
-      berVHost = "backendA",
-      berNginzSslPort = Ports.port Ports.NginzSSL BackendA,
-      berInternalServicePorts = Ports.internalServicePorts BackendA
-    }
-
-staticPortsA :: Map.Map Service Word16
-staticPortsA =
-  Map.fromList
-    [ (Brig, 8082),
-      (Galley, 8085),
-      (Gundeck, 8086),
-      (Cannon, 8083),
-      (Cargohold, 8084),
-      (Spar, 8088),
-      (BackgroundWorker, 8089),
-      (Nginz, 8080),
-      (Stern, 8091)
-    ]
-
-backendB :: BackendResource
-backendB =
-  BackendResource
-    { berName = BackendB,
-      berBrigKeyspace = "brig_test2",
-      berGalleyKeyspace = "galley_test2",
-      berSparKeyspace = "spar_test2",
-      berGundeckKeyspace = "gundeck_test2",
-      berElasticsearchIndex = "directory2_test",
-      berFederatorInternal = Ports.port (Ports.ServiceInternal FederatorInternal) BackendB,
-      berFederatorExternal = Ports.port Ports.FederatorExternal BackendB,
-      berDomain = "b.example.com",
-      berAwsUserJournalQueue = "integration-user-events.fifo2",
-      berAwsPrekeyTable = "integration-brig-prekeys2",
-      berAwsS3Bucket = "dummy-bucket2",
-      berAwsQueueName = "integration-gundeck-events2",
-      berBrigInternalEvents = "integration-brig-events-internal2",
-      berEmailSMSSesQueue = "integration-brig-events2",
-      berEmailSMSEmailSender = "backend-integration2@wire.com",
-      berGalleyJournal = "integration-team-events.fifo2",
-      -- FUTUREWORK: set up vhosts in dev/ci for example.com and b.example.com
-      -- in case we want backendA and backendB to federate with a third backend
-      -- (because otherwise both queues will overlap)
-      berVHost = "backendB",
-      berNginzSslPort = Ports.port Ports.NginzSSL BackendB,
-      berInternalServicePorts = Ports.internalServicePorts BackendB
-    }
-
-staticPortsB :: Map.Map Service Word16
-staticPortsB =
-  Map.fromList
-    [ (Brig, 9082),
-      (Galley, 9085),
-      (Gundeck, 9086),
-      (Cannon, 9083),
-      (Cargohold, 9084),
-      (Spar, 9088),
-      (BackgroundWorker, 9089),
-      (Nginz, 9080),
-      (Stern, 9091)
-    ]
 
 parentDir :: FilePath -> Maybe FilePath
 parentDir path =
@@ -145,10 +62,10 @@ main = do
     lowerCodensity $ do
       _modifyEnv <-
         traverseConcurrentlyCodensity
-          ( \(res, staticPorts) ->
+          ( \resource ->
               -- We add the 'fullSerachWithAll' overrrides is a hack to get
               -- around https://wearezeta.atlassian.net/browse/WPB-3796
-              startDynamicBackend res staticPorts fullSearchWithAll
+              startDynamicBackend resource fullSearchWithAll
           )
-          [(backendA, staticPortsA), (backendB, staticPortsB)]
+          [backendA, backendB]
       liftIO run

--- a/integration/test/Testlib/Service.hs
+++ b/integration/test/Testlib/Service.hs
@@ -44,3 +44,6 @@ data BackendName
   | -- | 1..
     DynamicBackend Int
   deriving (Show, Eq, Ord)
+
+allServices :: [Service]
+allServices = [minBound .. maxBound]

--- a/integration/test/Testlib/Service.hs
+++ b/integration/test/Testlib/Service.hs
@@ -1,0 +1,46 @@
+module Testlib.Service where
+
+import Prelude
+
+data Service = Brig | Galley | Cannon | Gundeck | Cargohold | Nginz | Spar | BackgroundWorker | Stern | FederatorInternal
+  deriving
+    ( Show,
+      Eq,
+      Ord,
+      Enum,
+      Bounded
+    )
+
+serviceName :: Service -> String
+serviceName = \case
+  Brig -> "brig"
+  Galley -> "galley"
+  Cannon -> "cannon"
+  Gundeck -> "gundeck"
+  Cargohold -> "cargohold"
+  Nginz -> "nginz"
+  Spar -> "spar"
+  BackgroundWorker -> "backgroundWorker"
+  Stern -> "stern"
+  FederatorInternal -> "federator"
+
+-- | Converts the service name to kebab-case.
+configName :: Service -> String
+configName = \case
+  Brig -> "brig"
+  Galley -> "galley"
+  Cannon -> "cannon"
+  Gundeck -> "gundeck"
+  Cargohold -> "cargohold"
+  Nginz -> "nginz"
+  Spar -> "spar"
+  BackgroundWorker -> "background-worker"
+  Stern -> "stern"
+  FederatorInternal -> "federator"
+
+data BackendName
+  = BackendA
+  | BackendB
+  | -- | 1..
+    DynamicBackend Int
+  deriving (Show, Eq, Ord)

--- a/integration/test/Testlib/Service.hs
+++ b/integration/test/Testlib/Service.hs
@@ -41,7 +41,7 @@ configName = \case
 data BackendName
   = BackendA
   | BackendB
-  | -- | 1..
+  | -- | The index of dynamic backends begin with 1
     DynamicBackend Int
   deriving (Show, Eq, Ord)
 

--- a/integration/test/Testlib/Types.hs
+++ b/integration/test/Testlib/Types.hs
@@ -29,6 +29,7 @@ import Network.HTTP.Types qualified as HTTP
 import Network.URI
 import Testlib.Env
 import Testlib.Printing
+import Testlib.Service
 import UnliftIO (MonadUnliftIO)
 import Prelude
 

--- a/integration/test/Testlib/Types.hs
+++ b/integration/test/Testlib/Types.hs
@@ -241,4 +241,14 @@ defaultServiceOverrides =
     }
 
 lookupConfigOverride :: ServiceOverrides -> Service -> (Value -> App Value)
-lookupConfigOverride = error "TODO"
+lookupConfigOverride overrides = \case
+  Brig -> overrides.brigCfg
+  Cannon -> overrides.cannonCfg
+  Cargohold -> overrides.cargoholdCfg
+  Galley -> overrides.galleyCfg
+  Gundeck -> overrides.gundeckCfg
+  Nginz -> overrides.nginzCfg
+  Spar -> overrides.sparCfg
+  BackgroundWorker -> overrides.backgroundWorkerCfg
+  Stern -> overrides.sternCfg
+  FederatorInternal -> overrides.federatorInternalCfg

--- a/integration/test/Testlib/Types.hs
+++ b/integration/test/Testlib/Types.hs
@@ -192,16 +192,16 @@ modifyFailure modifyAssertion action = do
     )
 
 data ServiceOverrides = ServiceOverrides
-  { dbBrig :: Value -> App Value,
-    dbCannon :: Value -> App Value,
-    dbCargohold :: Value -> App Value,
-    dbGalley :: Value -> App Value,
-    dbGundeck :: Value -> App Value,
-    dbNginz :: Value -> App Value,
-    dbSpar :: Value -> App Value,
-    dbBackgroundWorker :: Value -> App Value,
-    dbStern :: Value -> App Value,
-    dbFederatorInternal :: Value -> App Value
+  { brigCfg :: Value -> App Value,
+    cannonCfg :: Value -> App Value,
+    cargoholdCfg :: Value -> App Value,
+    galleyCfg :: Value -> App Value,
+    gundeckCfg :: Value -> App Value,
+    nginzCfg :: Value -> App Value,
+    sparCfg :: Value -> App Value,
+    backgroundWorkerCfg :: Value -> App Value,
+    sternCfg :: Value -> App Value,
+    federatorInternalCfg :: Value -> App Value
   }
 
 instance Default ServiceOverrides where
@@ -210,16 +210,16 @@ instance Default ServiceOverrides where
 instance Semigroup ServiceOverrides where
   a <> b =
     ServiceOverrides
-      { dbBrig = dbBrig a >=> dbBrig b,
-        dbCannon = dbCannon a >=> dbCannon b,
-        dbCargohold = dbCargohold a >=> dbCargohold b,
-        dbGalley = dbGalley a >=> dbGalley b,
-        dbGundeck = dbGundeck a >=> dbGundeck b,
-        dbNginz = dbNginz a >=> dbNginz b,
-        dbSpar = dbSpar a >=> dbSpar b,
-        dbBackgroundWorker = dbBackgroundWorker a >=> dbBackgroundWorker b,
-        dbStern = dbStern a >=> dbStern b,
-        dbFederatorInternal = dbFederatorInternal a >=> dbFederatorInternal b
+      { brigCfg = brigCfg a >=> brigCfg b,
+        cannonCfg = cannonCfg a >=> cannonCfg b,
+        cargoholdCfg = cargoholdCfg a >=> cargoholdCfg b,
+        galleyCfg = galleyCfg a >=> galleyCfg b,
+        gundeckCfg = gundeckCfg a >=> gundeckCfg b,
+        nginzCfg = nginzCfg a >=> nginzCfg b,
+        sparCfg = sparCfg a >=> sparCfg b,
+        backgroundWorkerCfg = backgroundWorkerCfg a >=> backgroundWorkerCfg b,
+        sternCfg = sternCfg a >=> sternCfg b,
+        federatorInternalCfg = federatorInternalCfg a >=> federatorInternalCfg b
       }
 
 instance Monoid ServiceOverrides where
@@ -228,16 +228,16 @@ instance Monoid ServiceOverrides where
 defaultServiceOverrides :: ServiceOverrides
 defaultServiceOverrides =
   ServiceOverrides
-    { dbBrig = pure,
-      dbCannon = pure,
-      dbCargohold = pure,
-      dbGalley = pure,
-      dbGundeck = pure,
-      dbNginz = pure,
-      dbSpar = pure,
-      dbBackgroundWorker = pure,
-      dbStern = pure,
-      dbFederatorInternal = pure
+    { brigCfg = pure,
+      cannonCfg = pure,
+      cargoholdCfg = pure,
+      galleyCfg = pure,
+      gundeckCfg = pure,
+      nginzCfg = pure,
+      sparCfg = pure,
+      backgroundWorkerCfg = pure,
+      sternCfg = pure,
+      federatorInternalCfg = pure
     }
 
 lookupConfigOverride :: ServiceOverrides -> Service -> (Value -> App Value)

--- a/integration/test/Testlib/Types.hs
+++ b/integration/test/Testlib/Types.hs
@@ -128,7 +128,7 @@ appToIOKleisli k = do
   env <- ask
   pure $ \a -> runAppWithEnv env (k a)
 
-getServiceMap :: String -> App ServiceMap
+getServiceMap :: HasCallStack => String -> App ServiceMap
 getServiceMap fedDomain = do
   env <- ask
   assertJust ("Could not find service map for federation domain: " <> fedDomain) (Map.lookup fedDomain (env.serviceMap))

--- a/integration/test/Testlib/Types.hs
+++ b/integration/test/Testlib/Types.hs
@@ -28,6 +28,7 @@ import Network.HTTP.Types qualified as HTTP
 import Network.URI
 import Testlib.Env
 import Testlib.Printing
+import Testlib.Service
 import UnliftIO (MonadUnliftIO)
 import Prelude
 
@@ -238,3 +239,6 @@ defaultServiceOverrides =
       dbStern = pure,
       dbFederatorInternal = pure
     }
+
+lookupConfigOverride :: ServiceOverrides -> Service -> (Value -> App Value)
+lookupConfigOverride = error "TODO"


### PR DESCRIPTION
This PR changes the `integration` test suite:

- changes random port allocation to fixed ports for all services. This should reduce some flakiness caused by re-using radom ports.
- removes `withModifiedService(s)`: force all overriding backend configuration override testing to run in separated backends (`withModifiedBackend`)

This PR also heavily refactors the `ModService` module with the goal of simplification: duplication and lots of arguments are removed, `ServiceOverrides` is used everywhere instead of maps.
