### PR TITLE
Validate public key in an x509 credential

### DIFF
--- a/changelog.d/2-features/mls-x509-improvements
+++ b/changelog.d/2-features/mls-x509-improvements
@@ -1,0 +1,1 @@
+The public key in an x509 credential is now checked against that of the client

--- a/nix/pkgs/mls-test-cli/default.nix
+++ b/nix/pkgs/mls-test-cli/default.nix
@@ -13,8 +13,8 @@ let
   src = fetchFromGitHub {
     owner = "wireapp";
     repo = "mls-test-cli";
-    rev = "d16b4e9d4e93b731e81cd04a00620f2c6a36e696";
-    sha256 = "sha256-2p5m6R80dnyJShAvjmO+ZbX8wxMtuFmvPnp9uX4eezc=";
+    rev = "e6e6ce0c29f0e48e84b4ccef058130aca0625492";
+    sha256 = "sha256-J9M8w3GJnULH3spKEuPGCL/t43zb2Wd+YfZ0LY3YITo=";
   };
   cargoLockFile = builtins.toFile "cargo.lock" (builtins.readFile "${src}/Cargo.lock");
 in rustPlatform.buildRustPackage rec {


### PR DESCRIPTION
Followup to #3532.

See corresponding change in mls-test-cli: https://github.com/wireapp/mls-test-cli/commit/e6e6ce0c29f0e48e84b4ccef058130aca0625492.

https://wearezeta.atlassian.net/browse/WPB-3787

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
