### PR TITLE
Integration suite: Fix bug in local setup: wrong port for nginz http2

### DIFF
--- a/integration/test/Testlib/ModService.hs
+++ b/integration/test/Testlib/ModService.hs
@@ -288,7 +288,7 @@ startBackend resource overrides services = do
         env <- ask
         case env.servicesCwdBase of
           Nothing -> startNginzK8s domain serviceMap
-          Just _ -> startNginzLocal domain resource.berNginzSslPort resource.berNginzSslPort serviceMap
+          Just _ -> startNginzLocal domain resource.berNginzHttp2Port resource.berNginzSslPort serviceMap
       srv -> do
         readServiceConfig srv
           >>= updateServiceMapInConfig srv


### PR DESCRIPTION
## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
