### PR TITLE
Move key package upload tests to new suite

### DIFF
--- a/integration/test/API/Brig.hs
+++ b/integration/test/API/Brig.hs
@@ -243,15 +243,15 @@ putConnection userFrom userTo status = do
   statusS <- asString status
   submit "POST" (req & addJSONObject ["status" .= statusS])
 
-uploadKeyPackage :: ClientIdentity -> ByteString -> App Response
-uploadKeyPackage cid kp = do
+uploadKeyPackages :: ClientIdentity -> [ByteString] -> App Response
+uploadKeyPackages cid kps = do
   req <-
     baseRequest cid Brig Versioned $
       "/mls/key-packages/self/" <> cid.client
   submit
     "POST"
     ( req
-        & addJSONObject ["key_packages" .= [T.decodeUtf8 (Base64.encode kp)]]
+        & addJSONObject ["key_packages" .= map (T.decodeUtf8 . Base64.encode) kps]
     )
 
 claimKeyPackages :: (MakesValue u, MakesValue v) => Ciphersuite -> u -> v -> App Response

--- a/integration/test/MLS/Util.hs
+++ b/integration/test/MLS/Util.hs
@@ -178,7 +178,7 @@ uploadNewKeyPackage cid = do
   (kp, ref) <- generateKeyPackage cid
 
   -- upload key package
-  bindResponse (uploadKeyPackage cid kp) $ \resp ->
+  bindResponse (uploadKeyPackages cid [kp]) $ \resp ->
     resp.status `shouldMatchInt` 201
 
   pure ref

--- a/integration/test/Test/MLS/KeyPackage.hs
+++ b/integration/test/Test/MLS/KeyPackage.hs
@@ -47,12 +47,31 @@ testKeyPackageMultipleCiphersuites = do
     resp.status `shouldMatchInt` 200
     resp.json %. "count" `shouldMatchInt` 1
 
+testKeyPackageCount :: HasCallStack => Ciphersuite -> App ()
+testKeyPackageCount cs = do
+  alice <- randomUser OwnDomain def
+  alice1 <- createMLSClient def alice
+
+  bindResponse (countKeyPackages cs alice1) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "count" `shouldMatchInt` 0
+
+  setMLSCiphersuite cs
+
+  let count = 10
+  kps <- map fst <$> replicateM count (generateKeyPackage alice1)
+  void $ uploadKeyPackages alice1 kps >>= getBody 201
+
+  bindResponse (countKeyPackages cs alice1) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "count" `shouldMatchInt` count
+
 testUnsupportedCiphersuite :: HasCallStack => App ()
 testUnsupportedCiphersuite = do
   setMLSCiphersuite (Ciphersuite "0x0002")
   bob <- randomUser OwnDomain def
   bob1 <- createMLSClient def bob
   (kp, _) <- generateKeyPackage bob1
-  bindResponse (uploadKeyPackage bob1 kp) $ \resp -> do
+  bindResponse (uploadKeyPackages bob1 [kp]) $ \resp -> do
     resp.status `shouldMatchInt` 400
     resp.json %. "label" `shouldMatch` "mls-protocol-error"

--- a/services/brig/test/integration/API/MLS.hs
+++ b/services/brig/test/integration/API/MLS.hs
@@ -45,24 +45,12 @@ tests :: Manager -> Brig -> Opts -> TestTree
 tests m b opts =
   testGroup
     "MLS"
-    [ test m "POST /mls/key-packages/self/:client" (testKeyPackageUpload b),
-      test m "POST /mls/key-packages/self/:client (no public keys)" (testKeyPackageUploadNoKey b),
-      test m "GET /mls/key-packages/self/:client/count" (testKeyPackageZeroCount b),
+    [ test m "POST /mls/key-packages/self/:client (no public keys)" (testKeyPackageUploadNoKey b),
       -- FUTUREWORK test m "GET /mls/key-packages/self/:client/count (expired package)" (testKeyPackageExpired b),
       test m "GET /mls/key-packages/claim/local/:user" (testKeyPackageClaim b),
       test m "GET /mls/key-packages/claim/local/:user - self claim" (testKeyPackageSelfClaim b),
       test m "GET /mls/key-packages/claim/remote/:user" (testKeyPackageRemoteClaim opts b)
     ]
-
-testKeyPackageUpload :: Brig -> Http ()
-testKeyPackageUpload brig = do
-  u <- userQualifiedId <$> randomUser brig
-  c <- createClient brig u 0
-  withSystemTempDirectory "mls" $ \tmp ->
-    uploadKeyPackages brig tmp def u c 5
-
-  count <- getKeyPackageCount brig u c
-  liftIO $ count @?= 5
 
 testKeyPackageUploadNoKey :: Brig -> Http ()
 testKeyPackageUploadNoKey brig = do
@@ -71,13 +59,6 @@ testKeyPackageUploadNoKey brig = do
   withSystemTempDirectory "mls" $ \tmp ->
     uploadKeyPackages brig tmp def {kiSetKey = DontSetKey} u c 5
 
-  count <- getKeyPackageCount brig u c
-  liftIO $ count @?= 0
-
-testKeyPackageZeroCount :: Brig -> Http ()
-testKeyPackageZeroCount brig = do
-  u <- userQualifiedId <$> randomUser brig
-  c <- randomClient
   count <- getKeyPackageCount brig u c
   liftIO $ count @?= 0
 


### PR DESCRIPTION
Simply moved some key package tests to the new integration suite, and made them parametric in the ciphersuite.

https://wearezeta.atlassian.net/browse/WPB-4297

## Checklist

 - [x] No CHANGELOG
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
