### PR TITLE
Check validity of notification IDs

### DIFF
--- a/changelog.d/5-internal/notification-500
+++ b/changelog.d/5-internal/notification-500
@@ -1,0 +1,1 @@
+Check validity of notification IDs in the notification API

--- a/integration/test/SetupHelpers.hs
+++ b/integration/test/SetupHelpers.hs
@@ -10,6 +10,7 @@ import Data.Aeson.Types qualified as Aeson
 import Data.Default
 import Data.Function
 import Data.List qualified as List
+import Data.UUID.V1 (nextUUID)
 import Data.UUID.V4 (nextRandom)
 import GHC.Stack
 import Testlib.Prelude
@@ -83,8 +84,10 @@ resetFedConns owndom = do
     Internal.deleteFedConn' owndom `mapM_` rdoms
 
 randomId :: HasCallStack => App String
-randomId = do
-  liftIO (show <$> nextRandom)
+randomId = liftIO (show <$> nextRandom)
+
+randomUUIDv1 :: HasCallStack => App String
+randomUUIDv1 = liftIO (show . fromJust <$> nextUUID)
 
 randomUserId :: (HasCallStack, MakesValue domain) => domain -> App Value
 randomUserId domain = do

--- a/integration/test/Test/Notifications.hs
+++ b/integration/test/Test/Notifications.hs
@@ -61,3 +61,22 @@ testLastNotification = do
 
   lastNotif <- getLastNotification user "c" >>= getJSON 200
   lastNotif %. "payload" `shouldMatch` [object ["client" .= "c"]]
+
+testInvalidNotification :: HasCallStack => App ()
+testInvalidNotification = do
+  user <- randomUserId OwnDomain
+  let client = "deadbeef"
+
+  -- test uuid v4 as "since"
+  do
+    notifId <- randomId
+    void $
+      getNotifications user client def {since = Just notifId}
+        >>= getJSON 400
+
+  -- test arbitrary uuid v1 as "since"
+  do
+    notifId <- randomUUIDv1
+    void $
+      getNotifications user client def {since = Just notifId}
+        >>= getJSON 404

--- a/libs/wire-api/src/Wire/API/Notification.hs
+++ b/libs/wire-api/src/Wire/API/Notification.hs
@@ -20,6 +20,7 @@
 
 module Wire.API.Notification
   ( NotificationId,
+    isValidNotificationId,
     RawNotificationId (..),
     Event,
 
@@ -41,6 +42,7 @@ import Control.Lens (makeLenses, (.~))
 import Control.Lens.Operators ((?~))
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Aeson.Types qualified as Aeson
+import Data.Bits
 import Data.HashMap.Strict.InsOrd qualified as InsOrdHashMap
 import Data.Id
 import Data.Json.Util
@@ -50,6 +52,7 @@ import Data.Schema
 import Data.Swagger (ToParamSchema (..))
 import Data.Swagger qualified as S
 import Data.Time.Clock (UTCTime)
+import Data.UUID qualified as UUID
 import Imports
 import Servant
 import Wire.API.Routes.MultiVerb
@@ -79,6 +82,12 @@ eventSchema = mkSchema sdoc Aeson.parseJSON (Just . Aeson.toJSON)
                 S.Inline (S.toSchema (Proxy @Text) & S.description ?~ "Event type")
               )
             ]
+
+isValidNotificationId :: NotificationId -> Bool
+isValidNotificationId (Id uuid) =
+  -- check that the version bits are set to 1
+  case UUID.toWords uuid of
+    (_, w, _, _) -> (w `shiftR` 12) .&. 0xf == 1
 
 --------------------------------------------------------------------------------
 -- QueuedNotification

--- a/services/gundeck/src/Gundeck/Monad.hs
+++ b/services/gundeck/src/Gundeck/Monad.hs
@@ -45,9 +45,9 @@ where
 import Bilge hiding (Request, header, options, statusCode)
 import Bilge.RPC
 import Cassandra
-import Control.Error hiding (err)
+import Control.Error
 import Control.Exception (throwIO)
-import Control.Lens hiding ((.=))
+import Control.Lens
 import Control.Monad.Catch hiding (tryJust)
 import Data.Aeson (FromJSON)
 import Data.Default (def)
@@ -61,7 +61,7 @@ import Network.Wai
 import Network.Wai.Utilities
 import System.Logger qualified as Log
 import System.Logger qualified as Logger
-import System.Logger.Class hiding (Error, info)
+import System.Logger.Class
 import UnliftIO (async)
 
 -- | TODO: 'Client' already has an 'Env'.  Why do we need two?  How does this even work?  We should


### PR DESCRIPTION
UUIDs passed as the `since` parameter of `GET /notifications` should be v1. Before this PR, passing a UUID of the wrong version would result in a 500. With this change, the UUID is validated and a 400 is returned if its version is not 1.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
