### PR TITLE
WPB-4406 federator logging

### DIFF
--- a/changelog.d/5-internal/WPB-4406
+++ b/changelog.d/5-internal/WPB-4406
@@ -1,0 +1,3 @@
+Extending the information returned in errors for Federator.
+
+Paths and response bodies, if available, are included in error logs.

--- a/changelog.d/6-federation/FOO
+++ b/changelog.d/6-federation/FOO
@@ -1,1 +1,0 @@
-Changing `federation-remote-error` to include the domain of the federator that 

--- a/changelog.d/6-federation/FOO
+++ b/changelog.d/6-federation/FOO
@@ -1,0 +1,1 @@
+Changing `federation-remote-error` to include the domain of the federator that 

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Error.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Error.hs
@@ -50,12 +50,13 @@ instance Exception Error
 
 data ErrorData = FederationErrorData
   { federrDomain :: !Domain,
-    federrPath :: !Text
+    federrPath :: !Text,
+    federrResp :: !(Maybe LByteString)
   }
   deriving (Eq, Show, Typeable)
 
 instance ToJSON ErrorData where
-  toJSON (FederationErrorData d p) =
+  toJSON (FederationErrorData d p _) =
     object
       [ "type" .= ("federation" :: Text),
         "domain" .= d,
@@ -67,6 +68,7 @@ instance FromJSON ErrorData where
     FederationErrorData
       <$> o .: "domain"
       <*> o .: "path"
+      <*> pure Nothing
 
 -- | Assumes UTF-8 encoding.
 byteStringError :: Status -> LByteString -> LByteString -> Error

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -398,7 +398,7 @@ logErrorMsg (Wai.Error c l m md) =
     . maybe id logErrorData md
     . msg (val "\"" +++ m +++ val "\"")
   where
-    logErrorData (Wai.FederationErrorData d p) =
+    logErrorData (Wai.FederationErrorData d p _) =
       field "domain" (domainText d)
         . field "path" p
 

--- a/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
+++ b/libs/wai-utilities/src/Network/Wai/Utilities/Server.hs
@@ -398,9 +398,10 @@ logErrorMsg (Wai.Error c l m md) =
     . maybe id logErrorData md
     . msg (val "\"" +++ m +++ val "\"")
   where
-    logErrorData (Wai.FederationErrorData d p _) =
+    logErrorData (Wai.FederationErrorData d p b) =
       field "domain" (domainText d)
         . field "path" p
+        . field "response" (fromMaybe "" b)
 
 logErrorMsgWithRequest :: Maybe ByteString -> Wai.Error -> Msg -> Msg
 logErrorMsgWithRequest mr e =

--- a/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
@@ -254,7 +254,8 @@ mkFailureResponse status domain path body
                 { Wai.federrDomain = domain,
                   Wai.federrPath =
                     "/federation"
-                      <> Text.decodeUtf8With Text.lenientDecode (LBS.toStrict path)
+                      <> Text.decodeUtf8With Text.lenientDecode (LBS.toStrict path),
+                  Wai.federrResp = pure body
                 }
         }
   where

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -215,28 +215,28 @@ federationRemoteHTTP2Error domain path FederatorClientNoStatusCode =
           unexpectedFederationResponseStatus
           "federation-http2-error"
           "No status code in HTTP2 response"
-   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path}
+   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path Nothing}
 federationRemoteHTTP2Error domain path (FederatorClientHTTP2Exception e) =
   let err =
         Wai.mkError
           unexpectedFederationResponseStatus
           "federation-http2-error"
           (LT.pack (displayException e))
-   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path}
+   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path Nothing}
 federationRemoteHTTP2Error domain path (FederatorClientTLSException e) =
   let err =
         Wai.mkError
           (HTTP.mkStatus 525 "SSL Handshake Failure")
           "federation-tls-error"
           (LT.pack (displayException e))
-   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path}
+   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path Nothing}
 federationRemoteHTTP2Error domain path (FederatorClientConnectionError e) =
   let err =
         Wai.mkError
           federatorConnectionRefusedStatus
           "federation-connection-refused"
           (LT.pack (displayException e))
-   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path}
+   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path Nothing}
 
 federationClientHTTP2Error :: FederatorClientHTTP2Error -> Wai.Error
 federationClientHTTP2Error (FederatorClientConnectionError e) =
@@ -253,7 +253,7 @@ federationClientHTTP2Error e =
 federationRemoteResponseError :: Domain -> Text -> HTTP.Status -> LByteString -> Wai.Error
 federationRemoteResponseError domain path status resp =
   err
-    { Wai.errorData = pure $ Wai.FederationErrorData domain path
+    { Wai.errorData = pure $ Wai.FederationErrorData domain path $ pure resp
     }
   where
     err =

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -83,9 +83,11 @@ module Wire.API.Federation.Error
   )
 where
 
+import Data.Domain (Domain (..))
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.Text.Lazy qualified as LT
+import Data.Text.Lazy qualified as TL
 import Imports
 import Network.HTTP.Types.Status
 import Network.HTTP.Types.Status qualified as HTTP
@@ -206,27 +208,35 @@ federationClientErrorToWai FederatorClientVersionMismatch =
     "internal-error"
     "Endpoint version mismatch in federation client"
 
-federationRemoteHTTP2Error :: FederatorClientHTTP2Error -> Wai.Error
-federationRemoteHTTP2Error FederatorClientNoStatusCode =
-  Wai.mkError
-    unexpectedFederationResponseStatus
-    "federation-http2-error"
-    "No status code in HTTP2 response"
-federationRemoteHTTP2Error (FederatorClientHTTP2Exception e) =
-  Wai.mkError
-    unexpectedFederationResponseStatus
-    "federation-http2-error"
-    (LT.pack (displayException e))
-federationRemoteHTTP2Error (FederatorClientTLSException e) =
-  Wai.mkError
-    (HTTP.mkStatus 525 "SSL Handshake Failure")
-    "federation-tls-error"
-    (LT.pack (displayException e))
-federationRemoteHTTP2Error (FederatorClientConnectionError e) =
-  Wai.mkError
-    federatorConnectionRefusedStatus
-    "federation-connection-refused"
-    (LT.pack (displayException e))
+federationRemoteHTTP2Error :: Domain -> Text -> FederatorClientHTTP2Error -> Wai.Error
+federationRemoteHTTP2Error domain path FederatorClientNoStatusCode =
+  let err =
+        Wai.mkError
+          unexpectedFederationResponseStatus
+          "federation-http2-error"
+          "No status code in HTTP2 response"
+   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path}
+federationRemoteHTTP2Error domain path (FederatorClientHTTP2Exception e) =
+  let err =
+        Wai.mkError
+          unexpectedFederationResponseStatus
+          "federation-http2-error"
+          (LT.pack (displayException e))
+   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path}
+federationRemoteHTTP2Error domain path (FederatorClientTLSException e) =
+  let err =
+        Wai.mkError
+          (HTTP.mkStatus 525 "SSL Handshake Failure")
+          "federation-tls-error"
+          (LT.pack (displayException e))
+   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path}
+federationRemoteHTTP2Error domain path (FederatorClientConnectionError e) =
+  let err =
+        Wai.mkError
+          federatorConnectionRefusedStatus
+          "federation-connection-refused"
+          (LT.pack (displayException e))
+   in err {Wai.errorData = pure $ Wai.FederationErrorData domain path}
 
 federationClientHTTP2Error :: FederatorClientHTTP2Error -> Wai.Error
 federationClientHTTP2Error (FederatorClientConnectionError e) =
@@ -240,14 +250,21 @@ federationClientHTTP2Error e =
     "federation-local-error"
     (LT.pack (displayException e))
 
-federationRemoteResponseError :: HTTP.Status -> Wai.Error
-federationRemoteResponseError status =
-  Wai.mkError
-    unexpectedFederationResponseStatus
-    "federation-remote-error"
-    ( "A remote federator failed with status code "
-        <> LT.pack (show (HTTP.statusCode status))
-    )
+federationRemoteResponseError :: Domain -> Text -> HTTP.Status -> LByteString -> Wai.Error
+federationRemoteResponseError domain path status resp =
+  err
+    { Wai.errorData = pure $ Wai.FederationErrorData domain path
+    }
+  where
+    err =
+      Wai.mkError
+        unexpectedFederationResponseStatus
+        "federation-remote-error"
+        ( "A remote federator ("
+            <> TL.fromStrict domain._domainText
+            <> ") failed with status code "
+            <> LT.pack (show (HTTP.statusCode status))
+        )
 
 federationServantErrorToWai :: ClientError -> Wai.Error
 federationServantErrorToWai (DecodeFailure msg _) = federationInvalidBody msg

--- a/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Error.hs
@@ -87,7 +87,6 @@ import Data.Domain (Domain (..))
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.Text.Lazy qualified as LT
-import Data.Text.Lazy qualified as TL
 import Imports
 import Network.HTTP.Types.Status
 import Network.HTTP.Types.Status qualified as HTTP
@@ -261,7 +260,7 @@ federationRemoteResponseError domain path status resp =
         unexpectedFederationResponseStatus
         "federation-remote-error"
         ( "A remote federator ("
-            <> TL.fromStrict domain._domainText
+            <> LT.fromStrict domain._domainText
             <> ") failed with status code "
             <> LT.pack (show (HTTP.statusCode status))
         )

--- a/services/federator/default.nix
+++ b/services/federator/default.nix
@@ -41,6 +41,7 @@
 , pem
 , polysemy
 , polysemy-wire-zoo
+, prometheus-client
 , QuickCheck
 , random
 , servant
@@ -105,6 +106,7 @@ mkDerivation {
     pem
     polysemy
     polysemy-wire-zoo
+    prometheus-client
     servant
     servant-client-core
     servant-server

--- a/services/federator/test/integration/Test/Federator/IngressSpec.hs
+++ b/services/federator/test/integration/Test/Federator/IngressSpec.hs
@@ -106,7 +106,7 @@ spec env = do
               (Aeson.fromEncoding (Aeson.toEncoding hdl))
         liftToCodensity . embed $ case r of
           Right _ -> expectationFailure "Expected client certificate error, got response"
-          Left (RemoteError _ _ _) ->
+          Left (RemoteError {}) ->
             expectationFailure "Expected client certificate error, got remote error"
           Left (RemoteErrorResponse _ _ status _) -> status `shouldBe` HTTP.status400
 

--- a/services/federator/test/integration/Test/Federator/IngressSpec.hs
+++ b/services/federator/test/integration/Test/Federator/IngressSpec.hs
@@ -106,9 +106,9 @@ spec env = do
               (Aeson.fromEncoding (Aeson.toEncoding hdl))
         liftToCodensity . embed $ case r of
           Right _ -> expectationFailure "Expected client certificate error, got response"
-          Left (RemoteError _ _) ->
+          Left (RemoteError _ _ _) ->
             expectationFailure "Expected client certificate error, got remote error"
-          Left (RemoteErrorResponse _ status _) -> status `shouldBe` HTTP.status400
+          Left (RemoteErrorResponse _ _ status _) -> status `shouldBe` HTTP.status400
 
 -- FUTUREWORK: ORMOLU_DISABLE
 -- @END

--- a/services/federator/test/unit/Test/Federator/Remote.hs
+++ b/services/federator/test/unit/Test/Federator/Remote.hs
@@ -142,14 +142,14 @@ testValidatesCertificateWrongHostname =
         withMockServer certForWrongDomain $ \port -> do
           tlsSettings <- mkTLSSettingsOrThrow settings
           runCodensity (mkTestCall tlsSettings "localhost" port) $ \case
-            Left (RemoteError _ (FederatorClientTLSException _)) -> pure ()
+            Left (RemoteError _ _ (FederatorClientTLSException _)) -> pure ()
             Left x -> assertFailure $ "Expected TLS failure, got: " <> show x
             Right _ -> assertFailure "Expected connection with the server to fail",
       testCase "when the server's certificate does not have the server key usage flag" $
         withMockServer certWithoutServerKeyUsage $ \port -> do
           tlsSettings <- mkTLSSettingsOrThrow settings
           runCodensity (mkTestCall tlsSettings "localhost" port) $ \case
-            Left (RemoteError _ (FederatorClientTLSException _)) -> pure ()
+            Left (RemoteError _ _ (FederatorClientTLSException _)) -> pure ()
             Left x -> assertFailure $ "Expected TLS failure, got: " <> show x
             Right _ -> assertFailure "Expected connection with the server to fail"
     ]
@@ -160,7 +160,7 @@ testConnectionError :: TestTree
 testConnectionError = testCase "connection failures are reported correctly" $ do
   tlsSettings <- mkTLSSettingsOrThrow settings
   runCodensity (mkTestCall tlsSettings "localhost" 1) $ \case
-    Left (RemoteError _ (FederatorClientConnectionError _)) -> pure ()
+    Left (RemoteError _ _ (FederatorClientConnectionError _)) -> pure ()
     Left x -> assertFailure $ "Expected connection error, got: " <> show x
     Right _ -> assertFailure "Expected connection with the server to fail"
 

--- a/services/federator/test/unit/Test/Federator/Response.hs
+++ b/services/federator/test/unit/Test/Federator/Response.hs
@@ -95,6 +95,7 @@ testRemoteError =
         $ throw
           ( RemoteError
               (SrvTarget "example.com" 7777)
+              ""
               FederatorClientNoStatusCode
           )
     body <- Wai.lazyResponseBody resp


### PR DESCRIPTION
# Changes
- Adding a response field to `Network.Wai.Utilities.ErrorData` to hold responses, if they exist.
- Extending federation error functions to track paths and responses.
- Added a no-op metrics interpreter for the testing frameworks.
- Logging all outbound calls in federator. This is set at the debug log level.

## Checklist

 - [:heavy_check_mark:] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [:heavy_check_mark:] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
