### PR TITLE
Makefile: Avoid executing the hint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ clean-hint:
 	@echo -e "\n\n\n>>> PSA: if you get errors that are hard to explain,"
 	@echo -e ">>> try 'git submodule update --init --recursive' and 'make full-clean' and run your command again."
 	@echo -e ">>> see https://github.com/wireapp/wire-server/blob/develop/docs/developer/building.md#linker-errors-while-compiling"
-	@echo -e ">>> to never have to remember submodules again, try `git config --global submodule.recurse true`"
+	@echo -e ">>> to never have to remember submodules again, try 'git config --global submodule.recurse true'"
 	@echo -e "\n\n\n"
 
 .PHONY: cabal.project.local


### PR DESCRIPTION
Backticks execute the command even when they are in quotes.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
