### PR TITLE
fake-aws-s3 chart: Upgrade to minio 5.0.13

### DIFF
--- a/charts/fake-aws-s3/requirements.yaml
+++ b/charts/fake-aws-s3/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: minio
-  version: 3.2.0
+  version: 5.0.13
   repository: https://charts.min.io/

--- a/charts/fake-aws-s3/values.yaml
+++ b/charts/fake-aws-s3/values.yaml
@@ -1,9 +1,4 @@
-# See defaults in https://github.com/helm/charts/tree/master/stable/minio
 minio:
-  mcImage:
-    repository: quay.io/minio/mc
-    tag: RELEASE.2021-10-07T04-19-58Z
-    pullPolicy: IfNotPresent
   fullnameOverride: fake-aws-s3
   service:
     port: "9000"

--- a/charts/fake-aws-s3/values.yaml
+++ b/charts/fake-aws-s3/values.yaml
@@ -1,3 +1,4 @@
+# See defaults in https://github.com/minio/minio/blob/RELEASE.2023-07-07T07-13-57Z/helm/minio/values.yaml
 minio:
   fullnameOverride: fake-aws-s3
   service:

--- a/deploy/dockerephemeral/docker-compose.yaml
+++ b/deploy/dockerephemeral/docker-compose.yaml
@@ -57,10 +57,9 @@ services:
 
   fake_s3:
     container_name: demo_wire_s3
-#    image: minio/minio:RELEASE.2018-05-25T19-49-13Z
-    image: julialongtin/minio:0.0.9
+    image: minio/minio:RELEASE.2023-07-07T07-13-57Z
     ports:
-     - "127.0.0.1:4570:9000"
+     - "127.0.0.1:9000:9000"
     environment:
       MINIO_ACCESS_KEY: dummykey
       MINIO_SECRET_KEY: dummysecret # minio requires a secret of at least 8 chars

--- a/deploy/dockerephemeral/docker-compose.yaml
+++ b/deploy/dockerephemeral/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
     container_name: demo_wire_s3
     image: minio/minio:RELEASE.2023-07-07T07-13-57Z
     ports:
-     - "127.0.0.1:9000:9000"
+     - "127.0.0.1:4570:9000"
     environment:
       MINIO_ACCESS_KEY: dummykey
       MINIO_SECRET_KEY: dummysecret # minio requires a secret of at least 8 chars


### PR DESCRIPTION
This PR upgrades the minio chart version from `3.2.0` to `5.0.13` in the `fake-aws-s3` chart.

This amounts to upgrading from https://github.com/minio/minio/commit/082755de1a436c63a06793541b29b08701161fcc to https://github.com/minio/minio/commit/af3d99e35fe6e811bb3cb191bed604c7ca471bb2 (diff 
https://github.com/minio/minio/compare/082755d...af3d99e), a upgrade to `RELEASE.2023-07-07T07-13-57Z`
