### PR TITLE
integration-tests: Allow generating tests results in ant xml format

### DIFF
--- a/changelog.d/5-internal/xml-reports
+++ b/changelog.d/5-internal/xml-reports
@@ -1,0 +1,9 @@
+All integration tests can generate XML reports.
+
+To generate the report in brig-integration, galley-integration,
+cargohold-integration, gundeck-integration, stern-integration and the new
+integration suite pass `--xml=<outfile>` to generate the XML file.
+
+For spar-integration and federator-integration pass `-f junit` and set
+`JUNIT_OUTPUT_DIRECTORY` and `JUNIT_SUITE_NAME` environment variables. The XML
+report will be generated at `$JUNIT_OUTPUT_DIRECTORY/junit.xml`.

--- a/integration/default.nix
+++ b/integration/default.nix
@@ -42,6 +42,8 @@
 , proto-lens
 , random
 , raw-strings-qq
+, regex-base
+, regex-tdfa
 , retry
 , scientific
 , split
@@ -59,6 +61,7 @@
 , vector
 , websockets
 , wire-message-proto-lens
+, xml
 , yaml
 }:
 mkDerivation {
@@ -105,6 +108,8 @@ mkDerivation {
     proto-lens
     random
     raw-strings-qq
+    regex-base
+    regex-tdfa
     retry
     scientific
     split
@@ -122,6 +127,7 @@ mkDerivation {
     vector
     websockets
     wire-message-proto-lens
+    xml
     yaml
   ];
   license = lib.licenses.agpl3Only;

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -130,6 +130,7 @@ library
     Testlib.Run
     Testlib.RunServices
     Testlib.Types
+    Testlib.XML
 
   build-depends:
     , aeson
@@ -168,6 +169,8 @@ library
     , proto-lens
     , random
     , raw-strings-qq
+    , regex-base
+    , regex-tdfa
     , retry
     , scientific
     , split
@@ -185,4 +188,5 @@ library
     , vector
     , websockets
     , wire-message-proto-lens
+    , xml
     , yaml

--- a/integration/test/Testlib/Options.hs
+++ b/integration/test/Testlib/Options.hs
@@ -9,6 +9,7 @@ data TestOptions = TestOptions
   { includeTests :: [String],
     excludeTests :: [String],
     listTests :: Bool,
+    xmlReport :: Maybe FilePath,
     configFile :: String
   }
 
@@ -32,6 +33,13 @@ parser =
           )
       )
     <*> switch (long "list" <> short 'l' <> help "Only list tests.")
+    <*> optional
+      ( strOption
+          ( long "xml"
+              <> metavar "FILE"
+              <> help "Generate XML report for the tests"
+          )
+      )
     <*> strOption
       ( long "config"
           <> short 'c'
@@ -53,12 +61,16 @@ getOptions :: IO TestOptions
 getOptions = do
   defaultsInclude <- maybe [] (splitOn ",") <$> lookupEnv "TEST_INCLUDE"
   defaultsExclude <- maybe [] (splitOn ",") <$> lookupEnv "TEST_EXCLUDE"
+  defaultsXMLReport <- lookupEnv "TEST_XML"
   opts <- execParser optInfo
   pure
     opts
       { includeTests = includeTests opts `orFromEnv` defaultsInclude,
-        excludeTests = excludeTests opts `orFromEnv` defaultsExclude
+        excludeTests = excludeTests opts `orFromEnv` defaultsExclude,
+        xmlReport = xmlReport opts `orFromEnv` defaultsXMLReport
       }
   where
-    orFromEnv [] fromEnv = fromEnv
-    orFromEnv patterns _ = patterns
+    orFromEnv fromArgs fromEnv =
+      if null fromArgs
+        then fromEnv
+        else fromArgs

--- a/integration/test/Testlib/Types.hs
+++ b/integration/test/Testlib/Types.hs
@@ -26,6 +26,7 @@ import Data.Set qualified as Set
 import Data.String
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
+import Data.Time
 import Data.Word
 import GHC.Generics (Generic)
 import GHC.Records
@@ -440,3 +441,17 @@ data BackendName
 
 allServices :: [Service]
 allServices = [minBound .. maxBound]
+
+newtype TestSuiteReport = TestSuiteReport {cases :: [TestCaseReport]}
+  deriving (Eq, Show)
+  deriving newtype (Semigroup, Monoid)
+
+data TestCaseReport = TestCaseReport
+  { name :: String,
+    result :: TestResult,
+    time :: NominalDiffTime
+  }
+  deriving (Eq, Show)
+
+data TestResult = TestSuccess | TestFailure String
+  deriving (Eq, Show)

--- a/integration/test/Testlib/XML.hs
+++ b/integration/test/Testlib/XML.hs
@@ -1,0 +1,60 @@
+module Testlib.XML where
+
+import Data.Array qualified as Array
+import Data.Fixed
+import Data.Time
+import Testlib.Types
+import Text.Regex.Base qualified as Regex
+import Text.Regex.TDFA.String qualified as Regex
+import Text.XML.Light
+import Prelude
+
+saveXMLReport :: TestSuiteReport -> FilePath -> IO ()
+saveXMLReport report output =
+  writeFile output $ showTopElement $ xmlReport report
+
+xmlReport :: TestSuiteReport -> Element
+xmlReport report =
+  unode
+    "testsuites"
+    ( Attr (unqual "name") "wire-server",
+      testSuiteElements
+    )
+  where
+    testSuiteElements =
+      unode
+        "testsuite"
+        ( attrs,
+          map encodeTestCase report.cases
+        )
+    attrs =
+      [ Attr (unqual "name") "integration",
+        Attr (unqual "tests") $ show $ length report.cases,
+        Attr (unqual "failures") $ show $ length $ filter (\testCase -> testCase.result /= TestSuccess) report.cases,
+        Attr (unqual "time") $ showFixed True $ nominalDiffTimeToSeconds $ sum $ map (.time) report.cases
+      ]
+
+encodeTestCase :: TestCaseReport -> Element
+encodeTestCase TestCaseReport {..} =
+  unode "testcase" (attrs, content)
+  where
+    attrs =
+      [ Attr (unqual "name") name,
+        Attr (unqual "time") (showFixed True (nominalDiffTimeToSeconds time))
+      ]
+    content = case result of
+      TestSuccess -> []
+      TestFailure msg -> [failure msg]
+    failure msg = unode "failure" (blank_cdata {cdData = dropConsoleFormatting msg})
+
+    -- Drops ANSI control characters which might be used to set colors.
+    -- Including these breaks XML, there is not much point encoding them.
+    dropConsoleFormatting input =
+      let regex = Regex.makeRegex "\x1b\\[[0-9;]*[mGKHF]" :: Regex.Regex
+          matches = Regex.matchAll regex input
+          dropMatch (offset, len) input' =
+            let (begining, rest) = splitAt offset input'
+                (_, end) = splitAt len rest
+             in begining <> end
+          matchTuples = map (Array.! 0) matches
+       in foldr dropMatch input matchTuples

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -212,6 +212,14 @@ let
         sha256 = "sha256-+rHcS+BwEFsXqPAHX/KZDIgv9zfk1dZl0LlZJ57Com4=";
       };
     };
+    # PR: https://github.com/freckle/hspec-junit-formatter/pull/24
+    hspec-junit-formatter = {
+      src = fetchgit {
+        url = "https://github.com/akshaymankar/hspec-junit-formatter";
+        rev = "acec31822cc4f90489d9940bad23b3fd6d1d7c75";
+        sha256 = "sha256-4xGW3KHQKbTL+6+Q/gzfaMBP+J0npUe7tP5ZCQCB5+s=";
+      };
+    };
   };
   hackagePins = {
     # Major re-write upstream, we should get rid of this dependency rather than

--- a/nix/haskell-pins.nix
+++ b/nix/haskell-pins.nix
@@ -204,6 +204,14 @@ let
         sha256 = "sha256-htEIJY+LmIMACVZrflU60+X42/g14NxUyFM7VJs4E6w=";
       };
     };
+    # PR: https://github.com/ocharles/tasty-ant-xml/pull/32
+    tasty-ant-xml = {
+      src = fetchgit {
+        url = "https://github.com/akshaymankar/tasty-ant-xml";
+        rev = "34ff294d805e62e73678dccc0be9d3da13540fbe";
+        sha256 = "sha256-+rHcS+BwEFsXqPAHX/KZDIgv9zfk1dZl0LlZJ57Com4=";
+      };
+    };
   };
   hackagePins = {
     # Major re-write upstream, we should get rid of this dependency rather than

--- a/nix/manual-overrides.nix
+++ b/nix/manual-overrides.nix
@@ -27,6 +27,9 @@ hself: hsuper: {
   wai-middleware-prometheus = hlib.doJailbreak hsuper.wai-middleware-prometheus;
   wai-predicates = hlib.markUnbroken hsuper.wai-predicates;
 
+  # PR with fix: https://github.com/freckle/hspec-junit-formatter/pull/23
+  hspec-junit-formatter = hlib.markUnbroken (hlib.dontCheck hsuper.hspec-junit-formatter);
+
   # Some test seems to be broken
   hsaml2 = hlib.dontCheck hsuper.hsaml2;
   saml2-web-sso = hlib.dontCheck hsuper.saml2-web-sso;

--- a/services/brig/brig.cabal
+++ b/services/brig/brig.cabal
@@ -595,6 +595,7 @@ executable brig-integration
     , spar
     , streaming-commons
     , tasty                  >=1.0
+    , tasty-ant-xml
     , tasty-cannon           >=0.3.4
     , tasty-hunit            >=0.2
     , temporary              >=1.2.1

--- a/services/brig/default.nix
+++ b/services/brig/default.nix
@@ -122,6 +122,7 @@
 , streaming-commons
 , swagger2
 , tasty
+, tasty-ant-xml
 , tasty-cannon
 , tasty-hunit
 , tasty-quickcheck
@@ -354,6 +355,7 @@ mkDerivation {
     spar
     streaming-commons
     tasty
+    tasty-ant-xml
     tasty-cannon
     tasty-hunit
     temporary

--- a/services/brig/test/integration/Main.hs
+++ b/services/brig/test/integration/Main.hs
@@ -64,6 +64,9 @@ import System.Environment (withArgs)
 import System.Logger qualified as Logger
 import Test.Tasty
 import Test.Tasty.HUnit
+import Test.Tasty.Ingredients
+import Test.Tasty.Runners
+import Test.Tasty.Runners.AntXML
 import Util
 import Util.Options
 import Util.Test
@@ -165,7 +168,7 @@ runTests iConf brigOpts otherArgs = do
       mlsApi = MLS.tests mg b brigOpts
       oauthAPI = API.OAuth.tests mg db b n brigOpts
 
-  withArgs otherArgs . defaultMain
+  withArgs otherArgs . defaultMainWithIngredients (listingTests : (composeReporters antXMLRunner consoleTestReporter) : defaultIngredients)
     $ testGroup
       "Brig API Integration"
     $ [ testCase "sitemap" $

--- a/services/cargohold/cargohold.cabal
+++ b/services/cargohold/cargohold.cabal
@@ -289,6 +289,7 @@ executable cargohold-integration
     , servant-client
     , tagged                 >=0.8
     , tasty                  >=1.0
+    , tasty-ant-xml
     , tasty-hunit            >=0.9
     , text                   >=1.1
     , time                   >=1.5

--- a/services/cargohold/default.nix
+++ b/services/cargohold/default.nix
@@ -50,6 +50,7 @@
 , servant-server
 , tagged
 , tasty
+, tasty-ant-xml
 , tasty-hunit
 , text
 , time
@@ -154,6 +155,7 @@ mkDerivation {
     servant-client
     tagged
     tasty
+    tasty-ant-xml
     tasty-hunit
     text
     time

--- a/services/cargohold/test/integration/Main.hs
+++ b/services/cargohold/test/integration/Main.hs
@@ -30,7 +30,10 @@ import Imports hiding (local)
 import qualified Metrics
 import Options.Applicative
 import Test.Tasty
+import Test.Tasty.Ingredients
 import Test.Tasty.Options
+import Test.Tasty.Runners
+import Test.Tasty.Runners.AntXML
 import TestSetup
 import Util.Test
 
@@ -75,4 +78,6 @@ main = do
         [ Option (Proxy :: Proxy ServiceConfigFile),
           Option (Proxy :: Proxy IntegrationConfigFile)
         ]
+        : listingTests
+        : composeReporters antXMLRunner consoleTestReporter
         : defaultIngredients

--- a/services/federator/default.nix
+++ b/services/federator/default.nix
@@ -23,6 +23,8 @@
 , hinotify
 , HsOpenSSL
 , hspec
+, hspec-core
+, hspec-junit-formatter
 , http-client
 , http-client-tls
 , http-media
@@ -125,6 +127,7 @@ mkDerivation {
   ];
   executableHaskellDepends = [
     aeson
+    async
     base
     bilge
     binary
@@ -136,6 +139,8 @@ mkDerivation {
     exceptions
     HsOpenSSL
     hspec
+    hspec-core
+    hspec-junit-formatter
     http-client-tls
     http-types
     http2-manager

--- a/services/federator/federator.cabal
+++ b/services/federator/federator.cabal
@@ -275,6 +275,7 @@ executable federator-integration
 
   build-depends:
       aeson
+    , async
     , base
     , bilge
     , binary
@@ -287,6 +288,8 @@ executable federator-integration
     , federator
     , HsOpenSSL
     , hspec
+    , hspec-core
+    , hspec-junit-formatter
     , http-client-tls
     , http-types
     , http2-manager

--- a/services/galley/default.nix
+++ b/services/galley/default.nix
@@ -90,6 +90,7 @@
 , streaming-commons
 , tagged
 , tasty
+, tasty-ant-xml
 , tasty-cannon
 , tasty-hunit
 , tasty-quickcheck
@@ -282,6 +283,7 @@ mkDerivation {
     streaming-commons
     tagged
     tasty
+    tasty-ant-xml
     tasty-cannon
     tasty-hunit
     temporary

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -489,6 +489,7 @@ executable galley-integration
     , streaming-commons
     , tagged
     , tasty                  >=0.8
+    , tasty-ant-xml
     , tasty-cannon           >=0.3.2
     , tasty-hunit            >=0.9
     , temporary

--- a/services/galley/test/integration/Main.hs
+++ b/services/galley/test/integration/Main.hs
@@ -49,7 +49,10 @@ import Options.Applicative
 import System.Logger.Class qualified as Logger
 import Test.Tasty
 import Test.Tasty.HUnit
+import Test.Tasty.Ingredients
+import Test.Tasty.Ingredients.Basic
 import Test.Tasty.Options
+import Test.Tasty.Runners.AntXML
 import TestHelpers (test)
 import TestSetup
 import Util.Options
@@ -84,6 +87,8 @@ runTests run = defaultMainWithIngredients ings $
         [ Option (Proxy :: Proxy ServiceConfigFile),
           Option (Proxy :: Proxy IntegrationConfigFile)
         ]
+        : listingTests
+        : composeReporters antXMLRunner consoleTestReporter
         : defaultIngredients
 
 main :: IO ()

--- a/services/gundeck/default.nix
+++ b/services/gundeck/default.nix
@@ -59,6 +59,7 @@
 , servant-server
 , tagged
 , tasty
+, tasty-ant-xml
 , tasty-hunit
 , tasty-quickcheck
 , text
@@ -171,6 +172,7 @@ mkDerivation {
     safe
     tagged
     tasty
+    tasty-ant-xml
     tasty-hunit
     text
     tinylog

--- a/services/gundeck/gundeck.cabal
+++ b/services/gundeck/gundeck.cabal
@@ -303,6 +303,7 @@ executable gundeck-integration
     , safe
     , tagged
     , tasty                  >=1.0
+    , tasty-ant-xml
     , tasty-hunit            >=0.9
     , text
     , tinylog

--- a/services/gundeck/test/integration/Main.hs
+++ b/services/gundeck/test/integration/Main.hs
@@ -39,7 +39,10 @@ import OpenSSL (withOpenSSL)
 import Options.Applicative
 import System.Logger qualified as Logger
 import Test.Tasty
+import Test.Tasty.Ingredients
 import Test.Tasty.Options
+import Test.Tasty.Runners
+import Test.Tasty.Runners.AntXML
 import TestSetup
 import Util.Options
 import Util.Test
@@ -83,6 +86,8 @@ runTests run = defaultMainWithIngredients ings $
         [ Option (Proxy :: Proxy ServiceConfigFile),
           Option (Proxy :: Proxy IntegrationConfigFile)
         ]
+        : listingTests
+        : composeReporters antXMLRunner consoleTestReporter
         : defaultIngredients
 
 main :: IO ()

--- a/services/spar/default.nix
+++ b/services/spar/default.nix
@@ -5,6 +5,7 @@
 { mkDerivation
 , aeson
 , aeson-qq
+, async
 , base
 , base64-bytestring
 , bilge
@@ -27,7 +28,9 @@
 , hscim
 , HsOpenSSL
 , hspec
+, hspec-core
 , hspec-discover
+, hspec-junit-formatter
 , hspec-wai
 , http-api-data
 , http-client
@@ -136,6 +139,7 @@ mkDerivation {
   executableHaskellDepends = [
     aeson
     aeson-qq
+    async
     base
     base64-bytestring
     bilge
@@ -156,6 +160,8 @@ mkDerivation {
     hscim
     HsOpenSSL
     hspec
+    hspec-core
+    hspec-junit-formatter
     hspec-wai
     http-api-data
     http-client

--- a/services/spar/spar.cabal
+++ b/services/spar/spar.cabal
@@ -313,6 +313,7 @@ executable spar-integration
   build-depends:
       aeson
     , aeson-qq
+    , async
     , base
     , base64-bytestring
     , bilge
@@ -331,6 +332,8 @@ executable spar-integration
     , hscim
     , HsOpenSSL
     , hspec
+    , hspec-core
+    , hspec-junit-formatter
     , hspec-wai
     , http-api-data
     , http-client

--- a/tools/stern/default.nix
+++ b/tools/stern/default.nix
@@ -40,6 +40,7 @@
 , swagger2
 , tagged
 , tasty
+, tasty-ant-xml
 , tasty-hunit
 , text
 , tinylog
@@ -119,6 +120,7 @@ mkDerivation {
     schema-profunctor
     tagged
     tasty
+    tasty-ant-xml
     tasty-hunit
     text
     tinylog

--- a/tools/stern/stern.cabal
+++ b/tools/stern/stern.cabal
@@ -270,6 +270,7 @@ executable stern-integration
     , stern
     , tagged
     , tasty                  >=0.8
+    , tasty-ant-xml
     , tasty-hunit            >=0.9
     , text
     , tinylog

--- a/tools/stern/test/integration/Main.hs
+++ b/tools/stern/test/integration/Main.hs
@@ -34,7 +34,10 @@ import OpenSSL (withOpenSSL)
 import Options.Applicative
 import System.Logger qualified as Logger
 import Test.Tasty
+import Test.Tasty.Ingredients
 import Test.Tasty.Options
+import Test.Tasty.Runners
+import Test.Tasty.Runners.AntXML
 import TestSetup
 import Util.Options (Endpoint (Endpoint))
 import Util.Test
@@ -74,6 +77,8 @@ runTests run = defaultMainWithIngredients ings $
         [ Option (Proxy :: Proxy ServiceConfigFile),
           Option (Proxy :: Proxy IntegrationConfigFile)
         ]
+        : listingTests
+        : composeReporters antXMLRunner consoleTestReporter
         : defaultIngredients
 
 main :: IO ()


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-4267

For tasty tests (i.e. brig, cargohold, gundeck and stern) pass `--xml=<outfile>` to generate an xml report.
For hspec tests (i.e. federator and spar) pass `-f junit` and set environment variables `JUNIT_OUTPUT_DIRECTORY` and `JUNIT_SUITE_NAME`. The report will be at `$JUNIT_OUTPUT_DIRECTORY/junit.xml` 
For the integration test suite pass `--xml <outfile>` to generate an xml report.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
