### PR TITLE
Remove MLS endpoints from v4 in the mls branch

### DIFF
--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Conversation.hs
@@ -612,6 +612,7 @@ type ConversationAPI =
     :<|> Named
            "get-one-to-one-mls-conversation"
            ( Summary "Get an MLS 1:1 conversation"
+               :> From 'V5
                :> ZLocalUser
                :> CanThrow 'MLSNotEnabled
                :> CanThrow 'NotConnected
@@ -1256,6 +1257,7 @@ type ConversationAPI =
     :<|> Named
            "update-conversation-protocol"
            ( Summary "Update the protocol of the conversation"
+               :> From 'V5
                :> Description "**Note**: Only proteus->mixed upgrade is supported."
                :> CanThrow 'ConvNotFound
                :> CanThrow 'ConvInvalidProtocolTransition

--- a/services/brig/docs/swagger-v4.json
+++ b/services/brig/docs/swagger-v4.json
@@ -219,6 +219,9 @@
         "mlsE2EId": {
           "$ref": "#/definitions/MlsE2EIdConfig.WithStatus"
         },
+        "mlsMigration": {
+          "$ref": "#/definitions/MlsMigration.WithStatus"
+        },
         "outlookCalIntegration": {
           "$ref": "#/definitions/OutlookCalIntegrationConfig.WithStatus"
         },
@@ -258,7 +261,8 @@
         "mls",
         "exposeInvitationURLsToTeamAdmin",
         "outlookCalIntegration",
-        "mlsE2EId"
+        "mlsE2EId",
+        "mlsMigration"
       ],
       "type": "object"
     },
@@ -1062,6 +1066,9 @@
           "minimum": 0,
           "type": "integer"
         },
+        "epoch_timestamp": {
+          "$ref": "#/definitions/Epoch Timestamp"
+        },
         "group_id": {
           "$ref": "#/definitions/GroupId"
         },
@@ -1110,11 +1117,11 @@
       "required": [
         "qualified_id",
         "type",
-        "creator",
         "access",
         "members",
         "group_id",
         "epoch",
+        "epoch_timestamp",
         "cipher_suite"
       ],
       "type": "object"
@@ -1446,6 +1453,9 @@
           "minimum": 0,
           "type": "integer"
         },
+        "epoch_timestamp": {
+          "$ref": "#/definitions/Epoch Timestamp"
+        },
         "failed_to_add": {
           "items": {
             "$ref": "#/definitions/Qualified_UserId"
@@ -1500,12 +1510,12 @@
       "required": [
         "qualified_id",
         "type",
-        "creator",
         "access",
         "access_role",
         "members",
         "group_id",
         "epoch",
+        "epoch_timestamp",
         "cipher_suite",
         "failed_to_add"
       ],
@@ -1736,6 +1746,12 @@
       ],
       "type": "object"
     },
+    "Epoch Timestamp": {
+      "description": "The timestamp of the epoch number",
+      "example": "2021-05-12T10:52:02.671Z",
+      "format": "yyyy-mm-ddThh:MM:ss.qqq",
+      "type": "string"
+    },
     "Event": {
       "properties": {
         "conversation": {
@@ -1785,6 +1801,9 @@
               "maximum": 18446744073709552000,
               "minimum": 0,
               "type": "integer"
+            },
+            "epoch_timestamp": {
+              "$ref": "#/definitions/Epoch Timestamp"
             },
             "group_id": {
               "$ref": "#/definitions/GroupId"
@@ -1918,10 +1937,10 @@
             "has_password",
             "qualified_id",
             "type",
-            "creator",
             "members",
             "group_id",
             "epoch",
+            "epoch_timestamp",
             "cipher_suite",
             "qualified_recipient",
             "receipt_mode",
@@ -1977,7 +1996,8 @@
         "conversation.typing",
         "conversation.otr-message-add",
         "conversation.mls-message-add",
-        "conversation.mls-welcome"
+        "conversation.mls-welcome",
+        "conversation.protocol-update"
       ],
       "type": "string"
     },
@@ -2647,13 +2667,20 @@
             "$ref": "#/definitions/UUID"
           },
           "type": "array"
+        },
+        "supportedProtocols": {
+          "items": {
+            "$ref": "#/definitions/Protocol"
+          },
+          "type": "array"
         }
       },
       "required": [
         "protocolToggleUsers",
         "defaultProtocol",
         "allowedCipherSuites",
-        "defaultCipherSuite"
+        "defaultCipherSuite",
+        "supportedProtocols"
       ],
       "type": "object"
     },
@@ -2883,6 +2910,42 @@
       ],
       "type": "object"
     },
+    "MlsMigration": {
+      "properties": {
+        "finaliseRegardlessAfter": {
+          "$ref": "#/definitions/UTCTime"
+        },
+        "startTime": {
+          "$ref": "#/definitions/UTCTime"
+        }
+      },
+      "type": "object"
+    },
+    "MlsMigration.WithStatus": {
+      "properties": {
+        "config": {
+          "$ref": "#/definitions/MlsMigration"
+        },
+        "lockStatus": {
+          "$ref": "#/definitions/LockStatus"
+        },
+        "status": {
+          "$ref": "#/definitions/FeatureStatus"
+        },
+        "ttl": {
+          "example": "unlimited",
+          "maximum": 18446744073709552000,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "status",
+        "lockStatus",
+        "config"
+      ],
+      "type": "object"
+    },
     "NameIDFormat": {
       "enum": [
         "NameIDFUnspecified",
@@ -3011,7 +3074,7 @@
           "type": "string"
         },
         "protocol": {
-          "$ref": "#/definitions/Protocol"
+          "$ref": "#/definitions/BaseProtocol"
         },
         "qualified_users": {
           "description": "List of qualified user IDs (excluding the requestor) to be part of this conversation",
@@ -3584,9 +3647,18 @@
     "Protocol": {
       "enum": [
         "proteus",
-        "mls"
+        "mls",
+        "mixed"
       ],
       "type": "string"
+    },
+    "ProtocolUpdate": {
+      "properties": {
+        "protocol": {
+          "$ref": "#/definitions/Protocol"
+        }
+      },
+      "type": "object"
     },
     "PubClient": {
       "properties": {
@@ -8301,7 +8373,7 @@
             "description": "Invalid `body`\n\nMLS is not configured on this backend. See docs.wire.com for instructions on how to enable it (label: `mls-not-enabled`)\n\nAttempting to add group members outside MLS (label: `non-empty-member-list`)"
           },
           "403": {
-            "description": "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent (label: `missing-legalhold-consent`)\n\nInsufficient permissions (label: `operation-denied`)\n\nRequesting user is not a team member (label: `no-team-member`)\n\nUsers are not connected (label: `not-connected`)\n\nThe client has to refresh their access token and provide their client ID (label: `mls-missing-sender-client`)\n\nConversation access denied (label: `access-denied`)",
+            "description": "Failed to connect to a user or to invite a user to a group because somebody is under legalhold and somebody else has not granted consent (label: `missing-legalhold-consent`)\n\nInsufficient permissions (label: `operation-denied`)\n\nRequesting user is not a team member (label: `no-team-member`)\n\nUsers are not connected (label: `not-connected`)\n\nConversation access denied (label: `access-denied`)",
             "schema": {
               "example": {
                 "code": 403,
@@ -8321,7 +8393,6 @@
                     "operation-denied",
                     "no-team-member",
                     "not-connected",
-                    "mls-missing-sender-client",
                     "access-denied"
                   ],
                   "type": "string"
@@ -9416,6 +9487,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -9717,6 +9792,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       },
@@ -9852,6 +9931,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -9981,6 +10064,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -10109,6 +10196,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -10376,6 +10467,10 @@
           [
             "galley",
             "update-conversation"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -10664,6 +10759,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -11366,6 +11465,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -11489,6 +11592,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -11611,6 +11718,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -11875,6 +11986,10 @@
           [
             "galley",
             "update-conversation"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -16274,6 +16389,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       },
@@ -19567,6 +19686,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -19690,6 +19813,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       },
@@ -19955,6 +20082,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       },
@@ -20204,6 +20335,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }
@@ -20430,6 +20565,10 @@
           [
             "galley",
             "on-mls-message-sent"
+          ],
+          [
+            "brig",
+            "get-users-by-ids"
           ]
         ]
       }


### PR DESCRIPTION
This PR removes some remaining MLS endpoints (only present in the mls branch) from v4 and regenerates the v4 swagger documentation.

## Checklist

 - [x] No CHANGELOG entry
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
