### PR TITLE
WPB-4262: Fixing federator tests

### DIFF
--- a/services/federator/federator.integration.yaml
+++ b/services/federator/federator.integration.yaml
@@ -26,3 +26,6 @@ optSettings:
   clientPrivateKey: "test/resources/integration-leaf-key.pem"
   dnsHost: "127.0.0.1"
   dnsPort: 9053
+
+backendTwo:
+  originDomain: b.example.com

--- a/services/federator/test/integration/Test/Federator/IngressSpec.hs
+++ b/services/federator/test/integration/Test/Federator/IngressSpec.hs
@@ -145,7 +145,7 @@ inwardBrigCallViaIngressWithSettings ::
 inwardBrigCallViaIngressWithSettings sslCtx requestPath payload =
   do
     Endpoint ingressHost ingressPort <- nginxIngress . view teTstOpts <$> input
-    originDomain <- originDomain . view teTstOpts <$> input
+    originDomain <- (.backendTwo.originDomain) . view teTstOpts <$> input
     let target = SrvTarget (cs ingressHost) ingressPort
         headers = [(originDomainHeaderName, Text.encodeUtf8 originDomain)]
     mgr <- liftToCodensity . liftIO $ http2ManagerWithSSLCtx sslCtx

--- a/services/federator/test/integration/Test/Federator/Util.hs
+++ b/services/federator/test/integration/Test/Federator/Util.hs
@@ -108,10 +108,17 @@ data IntegrationConfig = IntegrationConfig
     cargohold :: Endpoint,
     federatorExternal :: Endpoint,
     nginxIngress :: Endpoint,
-    originDomain :: Text
+    originDomain :: Text,
+    backendTwo :: BackendTwo
   }
   deriving (Show, Generic)
 
+data BackendTwo = BackendTwo
+  { originDomain :: Text
+  }
+  deriving (Show, Generic)
+
+deriveFromJSON deriveJSONOptions ''BackendTwo
 deriveFromJSON deriveJSONOptions ''IntegrationConfig
 
 makeLenses ''TestEnv


### PR DESCRIPTION
Updating the request origin domains for federator tests, as the server setup for tests doesn't allow a domain to search itself via inward calls, but can search other members of the federation.

## Checklist

 - [:heavy_check_mark:] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [:heavy_check_mark:] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
