### PR TITLE
federator: allow creating ServiceMonitor resources

### DIFF
--- a/changelog.d/5-internal/WPB-4406
+++ b/changelog.d/5-internal/WPB-4406
@@ -1,2 +1,2 @@
 - Extending the information returned in errors for Federator. Paths and response bodies, if available, are included in error logs.
-- Prometheus metrics for outgoing and incoming federation requests added.
+- Prometheus metrics for outgoing and incoming federation requests added. They can be enabled by setting `metrics.serviceMonitor.enabled`, like in other charts.

--- a/charts/federator/templates/servicemonitor.yaml
+++ b/charts/federator/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gundeck
+  labels:
+    app: gundeck
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: internal
+      path: /i/metrics
+  selector:
+    matchLabels:
+      app: federator
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/federator/values.yaml
+++ b/charts/federator/values.yaml
@@ -8,6 +8,10 @@ service:
   internalFederatorPort: 8080
   externalFederatorPort: 8081
 
+metrics:
+  serviceMonitor:
+    enabled: false
+
 tls:
   # if enabled, federator will get its client certificate and private key from
   # the secret used by the federator ingress


### PR DESCRIPTION
This will mark federator Metrics for scraping, if
`metrics.serviceMonitor.enabled` is set to true, similar to all other charts.

WPB-4778

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
