### PR TITLE
[WPB-3664] Port changes from `develop` to `mandarin`

### DIFF
--- a/changelog.d/3-bug-fixes/remote-member-removal-notification
+++ b/changelog.d/3-bug-fixes/remote-member-removal-notification
@@ -1,0 +1,1 @@
+This fixes a bug where a remote member is removed from a conversation while their backend is unreachable, and the backend does not receive the removal notification once it is reachable again.

--- a/integration/default.nix
+++ b/integration/default.nix
@@ -19,6 +19,7 @@
 , cql-io
 , cryptonite
 , data-default
+, data-timeout
 , directory
 , errors
 , exceptions
@@ -86,6 +87,7 @@ mkDerivation {
     cql-io
     cryptonite
     data-default
+    data-timeout
     directory
     errors
     exceptions

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -100,6 +100,7 @@ library
     Notifications
     RunAllTests
     SetupHelpers
+    Test.AccessUpdate
     Test.AssetDownload
     Test.B2B
     Test.Brig
@@ -108,8 +109,10 @@ library
     Test.Demo
     Test.Federation
     Test.Federator
+    Test.MessageTimer
     Test.Notifications
     Test.Presence
+    Test.Roles
     Test.User
     Testlib.App
     Testlib.Assertions
@@ -146,6 +149,7 @@ library
     , cql-io
     , cryptonite
     , data-default
+    , data-timeout
     , directory
     , errors
     , exceptions

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -5,6 +5,7 @@ module API.Galley where
 import Control.Lens hiding ((.=))
 import Control.Monad.Reader
 import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as Aeson
 import Data.ByteString.Lazy qualified as LBS
 import Data.ProtoLens qualified as Proto
 import Data.ProtoLens.Labels ()
@@ -72,6 +73,21 @@ postConversation user cc = do
   req <- baseRequest user Galley Versioned "/conversations"
   ccv <- make cc
   submit "POST" $ req & addJSON ccv
+
+deleteTeamConversation ::
+  ( HasCallStack,
+    MakesValue user,
+    MakesValue conv
+  ) =>
+  String ->
+  conv ->
+  user ->
+  App Response
+deleteTeamConversation tid qcnv user = do
+  cnv <- snd <$> objQid qcnv
+  let path = joinHttpPath ["teams", tid, "conversations", cnv]
+  req <- baseRequest user Galley Versioned path
+  submit "DELETE" req
 
 putConversationProtocol ::
   ( HasCallStack,
@@ -210,12 +226,39 @@ getGroupInfo user conv = do
   req <- baseRequest user Galley Versioned path
   submit "GET" req
 
-addMembers :: (HasCallStack, MakesValue user, MakesValue conv) => user -> conv -> [Value] -> App Response
-addMembers usr qcnv newMembers = do
+data AddMembers = AddMembers
+  { users :: [Value],
+    role :: Maybe String,
+    version :: Maybe Int
+  }
+
+instance Default AddMembers where
+  def = AddMembers {users = [], role = Nothing, version = Nothing}
+
+addMembers ::
+  (HasCallStack, MakesValue user, MakesValue conv) =>
+  user ->
+  conv ->
+  AddMembers ->
+  App Response
+addMembers usr qcnv opts = do
   (convDomain, convId) <- objQid qcnv
-  qUsers <- mapM objQidObject newMembers
-  req <- baseRequest usr Galley Versioned (joinHttpPath ["conversations", convDomain, convId, "members"])
-  submit "POST" (req & addJSONObject ["qualified_users" .= qUsers])
+  qUsers <- mapM objQidObject opts.users
+  let path = case opts.version of
+        Just v | v <= 1 -> ["conversations", convId, "members", "v2"]
+        _ -> ["conversations", convDomain, convId, "members"]
+  req <-
+    baseRequest
+      usr
+      Galley
+      (maybe Versioned ExplicitVersion opts.version)
+      (joinHttpPath path)
+  submit "POST" $
+    req
+      & addJSONObject
+        ( ["qualified_users" .= qUsers]
+            <> ["conversation_role" .= r | r <- toList opts.role]
+        )
 
 removeMember :: (HasCallStack, MakesValue remover, MakesValue conv, MakesValue removed) => remover -> conv -> removed -> App Response
 removeMember remover qcnv removed = do
@@ -223,3 +266,122 @@ removeMember remover qcnv removed = do
   (removedDomain, removedId) <- objQid removed
   req <- baseRequest remover Galley Versioned (joinHttpPath ["conversations", convDomain, convId, "members", removedDomain, removedId])
   submit "DELETE" req
+
+postConversationCode ::
+  (HasCallStack, MakesValue user, MakesValue conv) =>
+  user ->
+  conv ->
+  Maybe String ->
+  Maybe String ->
+  App Response
+postConversationCode user conv mbpassword mbZHost = do
+  convId <- objId conv
+  req <- baseRequest user Galley Versioned (joinHttpPath ["conversations", convId, "code"])
+  submit
+    "POST"
+    ( req
+        & addJSONObject ["password" .= pw | pw <- maybeToList mbpassword]
+        & maybe id zHost mbZHost
+    )
+
+getConversationCode ::
+  (HasCallStack, MakesValue user, MakesValue conv) =>
+  user ->
+  conv ->
+  Maybe String ->
+  App Response
+getConversationCode user conv mbZHost = do
+  convId <- objId conv
+  req <- baseRequest user Galley Versioned (joinHttpPath ["conversations", convId, "code"])
+  submit
+    "GET"
+    ( req
+        & addQueryParams [("cnv", convId)]
+        & maybe id zHost mbZHost
+    )
+
+changeConversationName ::
+  (HasCallStack, MakesValue user, MakesValue conv, MakesValue name) =>
+  user ->
+  conv ->
+  name ->
+  App Response
+changeConversationName user qcnv name = do
+  (convDomain, convId) <- objQid qcnv
+  let path = joinHttpPath ["conversations", convDomain, convId, "name"]
+  nameReq <- make name
+  req <- baseRequest user Galley Versioned path
+  submit "PUT" (req & addJSONObject ["name" .= nameReq])
+
+updateRole ::
+  ( HasCallStack,
+    MakesValue callerUser,
+    MakesValue targetUser,
+    MakesValue roleUpdate,
+    MakesValue qcnv
+  ) =>
+  callerUser ->
+  targetUser ->
+  roleUpdate ->
+  qcnv ->
+  App Response
+updateRole caller target role qcnv = do
+  (cnvDomain, cnvId) <- objQid qcnv
+  (tarDomain, tarId) <- objQid target
+  roleReq <- make role
+  req <-
+    baseRequest
+      caller
+      Galley
+      Versioned
+      ( joinHttpPath ["conversations", cnvDomain, cnvId, "members", tarDomain, tarId]
+      )
+  submit "PUT" (req & addJSONObject ["conversation_role" .= roleReq])
+
+updateReceiptMode ::
+  ( HasCallStack,
+    MakesValue user,
+    MakesValue conv,
+    MakesValue mode
+  ) =>
+  user ->
+  conv ->
+  mode ->
+  App Response
+updateReceiptMode user qcnv mode = do
+  (cnvDomain, cnvId) <- objQid qcnv
+  modeReq <- make mode
+  let path = joinHttpPath ["conversations", cnvDomain, cnvId, "receipt-mode"]
+  req <- baseRequest user Galley Versioned path
+  submit "PUT" (req & addJSONObject ["receipt_mode" .= modeReq])
+
+updateAccess ::
+  ( HasCallStack,
+    MakesValue user,
+    MakesValue conv
+  ) =>
+  user ->
+  conv ->
+  [Aeson.Pair] ->
+  App Response
+updateAccess user qcnv update = do
+  (cnvDomain, cnvId) <- objQid qcnv
+  let path = joinHttpPath ["conversations", cnvDomain, cnvId, "access"]
+  req <- baseRequest user Galley Versioned path
+  submit "PUT" (req & addJSONObject update)
+
+updateMessageTimer ::
+  ( HasCallStack,
+    MakesValue user,
+    MakesValue conv
+  ) =>
+  user ->
+  conv ->
+  Word64 ->
+  App Response
+updateMessageTimer user qcnv update = do
+  (cnvDomain, cnvId) <- objQid qcnv
+  updateReq <- make update
+  let path = joinHttpPath ["conversations", cnvDomain, cnvId, "message-timer"]
+  req <- baseRequest user Galley Versioned path
+  submit "PUT" (addJSONObject ["message_timer" .= updateReq] req)

--- a/integration/test/SetupHelpers.hs
+++ b/integration/test/SetupHelpers.hs
@@ -4,6 +4,7 @@ module SetupHelpers where
 
 import API.Brig qualified as Brig
 import API.BrigInternal qualified as Internal
+import API.Common
 import API.Galley
 import Control.Concurrent (threadDelay)
 import Control.Monad.Reader
@@ -31,15 +32,43 @@ deleteUser user = bindResponse (Brig.deleteUser user) $ \resp -> do
   resp.status `shouldMatchInt` 200
 
 -- | returns (user, team id)
-createTeam :: (HasCallStack, MakesValue domain) => domain -> App (Value, String)
-createTeam domain = do
+createTeam :: (HasCallStack, MakesValue domain) => domain -> Int -> App (Value, String, [Value])
+createTeam domain memberCount = do
   res <- Internal.createUser domain def {Internal.team = True}
-  user <- res.json
-  tid <- user %. "team" & asString
-  -- TODO
-  -- SQS.assertTeamActivate "create team" tid
-  -- refreshIndex
-  pure (user, tid)
+  owner <- res.json
+  tid <- owner %. "team" & asString
+  members <- for [2 .. memberCount] $ \_ -> createTeamMember owner tid
+  pure (owner, tid, members)
+
+createTeamMember ::
+  (HasCallStack, MakesValue inviter) =>
+  inviter ->
+  String ->
+  App Value
+createTeamMember inviter tid = do
+  newUserEmail <- randomEmail
+  let invitationJSON = ["role" .= "member", "email" .= newUserEmail]
+  invitationReq <-
+    baseRequest inviter Brig Versioned $
+      joinHttpPath ["teams", tid, "invitations"]
+  invitation <- getJSON 201 =<< submit "POST" (addJSONObject invitationJSON invitationReq)
+  invitationId <- objId invitation
+  invitationCodeReq <-
+    rawBaseRequest inviter Brig Unversioned "/i/teams/invitation-code"
+      <&> addQueryParams [("team", tid), ("invitation_id", invitationId)]
+  invitationCode <- bindResponse (submit "GET" invitationCodeReq) $ \res -> do
+    res.status `shouldMatchInt` 200
+    res.json %. "code" & asString
+  let registerJSON =
+        [ "name" .= newUserEmail,
+          "email" .= newUserEmail,
+          "password" .= defPassword,
+          "team_code" .= invitationCode
+        ]
+  registerReq <-
+    rawBaseRequest inviter Brig Versioned "/register"
+      <&> addJSONObject registerJSON
+  getJSON 201 =<< submit "POST" registerReq
 
 connectUsers ::
   ( HasCallStack,

--- a/integration/test/Test/AccessUpdate.hs
+++ b/integration/test/Test/AccessUpdate.hs
@@ -1,0 +1,122 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.AccessUpdate where
+
+import API.Brig
+import API.Galley
+import Control.Monad.Codensity
+import Control.Monad.Reader
+import GHC.Stack
+import Notifications
+import SetupHelpers
+import Testlib.Prelude
+import Testlib.ResourcePool
+
+-- @SF.Federation @SF.Separation @TSFI.RESTfulAPI @S2
+--
+-- The test asserts that, among others, remote users are removed from a
+-- conversation when an access update occurs that disallows guests from
+-- accessing.
+testAccessUpdateGuestRemoved :: HasCallStack => App ()
+testAccessUpdateGuestRemoved = do
+  (alice, tid, [bob]) <- createTeam OwnDomain 2
+  charlie <- randomUser OwnDomain def
+  dee <- randomUser OtherDomain def
+  mapM_ (connectUsers alice) [charlie, dee]
+  [aliceClient, bobClient, charlieClient, deeClient] <-
+    mapM
+      (\user -> objId $ bindResponse (addClient user def) $ getJSON 201)
+      [alice, bob, charlie, dee]
+  conv <-
+    postConversation
+      alice
+      defProteus
+        { qualifiedUsers = [bob, charlie, dee],
+          team = Just tid
+        }
+      >>= getJSON 201
+
+  let update = ["access" .= ([] :: [String]), "access_role" .= ["team_member"]]
+  void $ updateAccess alice conv update >>= getJSON 200
+
+  mapM_ (assertLeaveNotification alice conv alice aliceClient) [charlie, dee]
+  mapM_ (assertLeaveNotification alice conv bob bobClient) [charlie, dee]
+  mapM_ (assertLeaveNotification alice conv charlie charlieClient) [charlie, dee]
+  mapM_ (assertLeaveNotification alice conv dee deeClient) [charlie, dee]
+
+  bindResponse (getConversation alice conv) $ \res -> do
+    res.status `shouldMatchInt` 200
+    res.json %. "members.others.0.qualified_id" `shouldMatch` objQidObject bob
+
+-- @END
+
+testAccessUpdateGuestRemovedUnreachableRemotes :: HasCallStack => App ()
+testAccessUpdateGuestRemovedUnreachableRemotes = do
+  resourcePool <- asks resourcePool
+  (alice, tid, [bob]) <- createTeam OwnDomain 2
+  charlie <- randomUser OwnDomain def
+  connectUsers alice charlie
+  [aliceClient, bobClient, charlieClient] <-
+    mapM
+      (\user -> objId $ bindResponse (addClient user def) $ getJSON 201)
+      [alice, bob, charlie]
+  (conv, dee) <- runCodensity (acquireResources 1 resourcePool) $ \[dynBackend] ->
+    runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
+      dee <- randomUser dynBackend.berDomain def
+      connectUsers alice dee
+      conv <-
+        postConversation
+          alice
+          ( defProteus
+              { qualifiedUsers = [bob, charlie, dee],
+                team = Just tid
+              }
+          )
+          >>= getJSON 201
+      pure (conv, dee)
+
+  let update = ["access" .= ([] :: [String]), "access_role" .= ["team_member"]]
+  void $ updateAccess alice conv update >>= getJSON 200
+
+  mapM_ (assertLeaveNotification alice conv alice aliceClient) [charlie, dee]
+  mapM_ (assertLeaveNotification alice conv bob bobClient) [charlie, dee]
+  mapM_ (assertLeaveNotification alice conv charlie charlieClient) [charlie, dee]
+
+  bindResponse (getConversation alice conv) $ \res -> do
+    res.status `shouldMatchInt` 200
+    res.json %. "members.others.0.qualified_id" `shouldMatch` objQidObject bob
+
+testAccessUpdateWithRemotes :: HasCallStack => App ()
+testAccessUpdateWithRemotes = do
+  [alice, bob, charlie] <- createAndConnectUsers [OwnDomain, OtherDomain, OwnDomain]
+  conv <-
+    postConversation alice (defProteus {qualifiedUsers = [bob, charlie]})
+      >>= getJSON 201
+  let update_access_value = ["code"]
+      update_access_role_value = ["team_member", "non_team_member", "guest", "service"]
+      update = ["access" .= update_access_value, "access_role" .= update_access_role_value]
+  withWebSockets [alice, bob, charlie] $ \wss -> do
+    void $ updateAccess alice conv update >>= getJSON 200
+    for_ wss $ \ws -> do
+      notif <- awaitMatch 10 isConvAccessUpdateNotif ws
+      notif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+      notif %. "payload.0.qualified_from" `shouldMatch` objQidObject alice
+      notif %. "payload.0.data.access" `shouldMatch` update_access_value
+      notif %. "payload.0.data.access_role_v2" `shouldMatch` update_access_role_value

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -1,19 +1,40 @@
 {-# OPTIONS_GHC -Wno-ambiguous-fields #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
 module Test.Conversation where
 
-import API.Brig (getConnections, postConnection)
-import API.BrigInternal as Internal
+import API.Brig
+import API.BrigInternal
 import API.Galley
 import API.GalleyInternal
 import Control.Applicative
 import Control.Concurrent (threadDelay)
+import Control.Monad.Codensity
+import Control.Monad.Reader
 import Data.Aeson qualified as Aeson
 import GHC.Stack
-import SetupHelpers
+import Notifications
+import SetupHelpers hiding (deleteUser)
 import Testlib.One2One (generateRemoteAndConvIdWithDomain)
 import Testlib.Prelude
+import Testlib.ResourcePool
 
 testDynamicBackendsFullyConnectedWhenAllowAll :: HasCallStack => App ()
 testDynamicBackendsFullyConnectedWhenAllowAll = do
@@ -183,7 +204,7 @@ testAddMembersFullyConnectedProteus = do
     cid <- postConversation u1 (defProteus {qualifiedUsers = []}) >>= getJSON 201
     -- add members from remote backends
     members <- for [u2, u3] (%. "qualified_id")
-    bindResponse (addMembers u1 cid members) $ \resp -> do
+    bindResponse (addMembers u1 cid def {users = members}) $ \resp -> do
       resp.status `shouldMatchInt` 200
       users <- resp.json %. "data.users" >>= asList
       addedUsers <- forM users (%. "qualified_id")
@@ -209,9 +230,65 @@ testAddMembersNonFullyConnectedProteus = do
     cid <- postConversation u1 (defProteus {qualifiedUsers = []}) >>= getJSON 201
     -- add members from remote backends
     members <- for [u2, u3] (%. "qualified_id")
-    bindResponse (addMembers u1 cid members) $ \resp -> do
+    bindResponse (addMembers u1 cid def {users = members}) $ \resp -> do
       resp.status `shouldMatchInt` 409
       resp.json %. "non_federating_backends" `shouldMatchSet` [domainB, domainC]
+
+testAddMember :: HasCallStack => App ()
+testAddMember = do
+  alice <- randomUser OwnDomain def
+  aliceId <- alice %. "qualified_id"
+  -- create conversation with no users
+  cid <- postConversation alice defProteus >>= getJSON 201
+  bob <- randomUser OwnDomain def
+  bobId <- bob %. "qualified_id"
+  let addMember = addMembers alice cid def {role = Just "wire_member", users = [bobId]}
+  bindResponse addMember $ \resp -> do
+    resp.status `shouldMatchInt` 403
+    resp.json %. "label" `shouldMatch` "not-connected"
+  connectUsers alice bob
+  bindResponse addMember $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "type" `shouldMatch` "conversation.member-join"
+    resp.json %. "qualified_from" `shouldMatch` objQidObject alice
+    resp.json %. "qualified_conversation" `shouldMatch` objQidObject cid
+    users <- resp.json %. "data.users" >>= asList
+    addedUsers <- forM users (%. "qualified_id")
+    addedUsers `shouldMatchSet` [bobId]
+
+  -- check that both users can see the conversation
+  bindResponse (getConversation alice cid) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    mems <- resp.json %. "members.others" & asList
+    mem <- assertOne mems
+    mem %. "qualified_id" `shouldMatch` bobId
+    mem %. "conversation_role" `shouldMatch` "wire_member"
+
+  bindResponse (getConversation bob cid) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    mems <- resp.json %. "members.others" & asList
+    mem <- assertOne mems
+    mem %. "qualified_id" `shouldMatch` aliceId
+    mem %. "conversation_role" `shouldMatch` "wire_admin"
+
+testAddMemberV1 :: HasCallStack => Domain -> App ()
+testAddMemberV1 domain = do
+  [alice, bob] <- createAndConnectUsers [OwnDomain, domain]
+  conv <- postConversation alice defProteus >>= getJSON 201
+  bobId <- bob %. "qualified_id"
+  let opts =
+        def
+          { version = Just 1,
+            role = Just "wire_member",
+            users = [bobId]
+          }
+  bindResponse (addMembers alice conv opts) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "type" `shouldMatch` "conversation.member-join"
+    resp.json %. "qualified_from" `shouldMatch` objQidObject alice
+    resp.json %. "qualified_conversation" `shouldMatch` objQidObject conv
+    users <- resp.json %. "data.users" >>= asList
+    traverse (%. "qualified_id") users `shouldMatchSet` [bobId]
 
 testConvWithUnreachableRemoteUsers :: HasCallStack => App ()
 testConvWithUnreachableRemoteUsers = do
@@ -249,7 +326,7 @@ testAddReachableWithUnreachableRemoteUsers = do
       pure ([alex, bob], conv, domains)
 
   bobId <- bob %. "qualified_id"
-  bindResponse (addMembers alex conv [bobId]) $ \resp -> do
+  bindResponse (addMembers alex conv def {users = [bobId]}) $ \resp -> do
     -- This test is updated to reflect the changes in `performConversationJoin`
     -- `performConversationJoin` now does a full check between all federation members
     -- that will be in the conversation when adding users to a conversation. This is
@@ -273,7 +350,7 @@ testAddUnreachable = do
       pure ([alex, charlie], domains, conv)
 
   charlieId <- charlie %. "qualified_id"
-  bindResponse (addMembers alex conv [charlieId]) $ \resp -> do
+  bindResponse (addMembers alex conv def {users = [charlieId]}) $ \resp -> do
     resp.status `shouldMatchInt` 533
     -- All of the domains that are in the conversation, or will be in the conversation,
     -- need to be reachable so we can check that the graph for those domains is fully connected.
@@ -306,7 +383,7 @@ testAddingUserNonFullyConnectedFederation = do
 
     bobId <- bob %. "qualified_id"
     charlieId <- charlie %. "qualified_id"
-    bindResponse (addMembers alice conv [bobId, charlieId]) $ \resp -> do
+    bindResponse (addMembers alice conv def {users = [bobId, charlieId]}) $ \resp -> do
       resp.status `shouldMatchInt` 409
       resp.json %. "non_federating_backends" `shouldMatchSet` [other, dynBackend]
 
@@ -341,5 +418,264 @@ testAddUserWhenOtherBackendOffline = do
       let newConv = defProteus {qualifiedUsers = [charlie]}
       conv <- postConversation alice newConv >>= getJSON 201
       pure ([alice, alex], conv)
-  bindResponse (addMembers alice conv [alex]) $ \resp -> do
+  bindResponse (addMembers alice conv def {users = [alex]}) $ \resp -> do
     resp.status `shouldMatchInt` 200
+
+testSynchroniseUserRemovalNotification :: HasCallStack => App ()
+testSynchroniseUserRemovalNotification = do
+  resourcePool <- asks resourcePool
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OtherDomain]
+  runCodensity (acquireResources 1 resourcePool) $ \[dynBackend] -> do
+    (conv, charlie, client) <-
+      runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
+        charlie <- randomUser dynBackend.berDomain def
+        client <- objId $ bindResponse (addClient charlie def) $ getJSON 201
+        mapM_ (connectUsers charlie) [alice, bob]
+        conv <-
+          postConversation alice (defProteus {qualifiedUsers = [bob, charlie]})
+            >>= getJSON 201
+        pure (conv, charlie, client)
+
+    let newConvName = "The new conversation name"
+    bindResponse (changeConversationName alice conv newConvName) $ \resp ->
+      resp.status `shouldMatchInt` 200
+    bindResponse (removeMember alice conv charlie) $ \resp ->
+      resp.status `shouldMatchInt` 200
+    runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
+      nameNotif <- awaitNotification charlie client noValue 2 isConvNameChangeNotif
+      nameNotif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+      nameNotif %. "payload.0.data.name" `shouldMatch` newConvName
+      leaveNotif <- awaitNotification charlie client noValue 2 isConvLeaveNotif
+      leaveNotif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+
+testConvRenaming :: HasCallStack => App ()
+testConvRenaming = do
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OtherDomain]
+  conv <-
+    postConversation alice (defProteus {qualifiedUsers = [bob]})
+      >>= getJSON 201
+  let newConvName = "The new conversation name"
+  withWebSockets [alice, bob] $ \wss -> do
+    for_ wss $ \ws -> do
+      void $ changeConversationName alice conv newConvName >>= getBody 200
+      nameNotif <- awaitMatch 10 isConvNameChangeNotif ws
+      nameNotif %. "payload.0.data.name" `shouldMatch` newConvName
+      nameNotif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+
+testReceiptModeWithRemotesOk :: HasCallStack => App ()
+testReceiptModeWithRemotesOk = do
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OtherDomain]
+  conv <-
+    postConversation alice (defProteus {qualifiedUsers = [bob]})
+      >>= getJSON 201
+  withWebSockets [alice, bob] $ \wss -> do
+    void $ updateReceiptMode alice conv (43 :: Int) >>= getBody 200
+    for_ wss $ \ws -> do
+      notif <- awaitMatch 10 isReceiptModeUpdateNotif ws
+      notif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+      notif %. "payload.0.qualified_from" `shouldMatch` objQidObject alice
+      notif %. "payload.0.data.receipt_mode" `shouldMatchInt` 43
+
+testReceiptModeWithRemotesUnreachable :: HasCallStack => App ()
+testReceiptModeWithRemotesUnreachable = do
+  ownDomain <- asString OwnDomain
+  alice <- randomUser ownDomain def
+  conv <- startDynamicBackends [mempty] $ \[dynBackend] -> do
+    bob <- randomUser dynBackend def
+    connectUsers alice bob
+    postConversation alice (defProteus {qualifiedUsers = [bob]})
+      >>= getJSON 201
+  withWebSocket alice $ \ws -> do
+    void $ updateReceiptMode alice conv (43 :: Int) >>= getBody 200
+    notif <- awaitMatch 10 isReceiptModeUpdateNotif ws
+    notif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+    notif %. "payload.0.qualified_from" `shouldMatch` objQidObject alice
+    notif %. "payload.0.data.receipt_mode" `shouldMatchInt` 43
+
+testDeleteLocalMember :: HasCallStack => App ()
+testDeleteLocalMember = do
+  [alice, alex, bob] <- createAndConnectUsers [OwnDomain, OwnDomain, OtherDomain]
+  conv <-
+    postConversation alice (defProteus {qualifiedUsers = [alex, bob]})
+      >>= getJSON 201
+  bindResponse (removeMember alice conv alex) $ \resp -> do
+    r <- getJSON 200 resp
+    r %. "type" `shouldMatch` "conversation.member-leave"
+    r %. "qualified_conversation" `shouldMatch` objQidObject conv
+    r %. "qualified_from" `shouldMatch` objQidObject alice
+    r %. "data.qualified_user_ids.0" `shouldMatch` objQidObject alex
+  -- Now that Alex is gone, try removing her once again
+  bindResponse (removeMember alice conv alex) $ \r -> do
+    r.status `shouldMatchInt` 204
+    r.jsonBody `shouldMatch` (Nothing @Aeson.Value)
+
+testDeleteRemoteMember :: HasCallStack => App ()
+testDeleteRemoteMember = do
+  [alice, alex, bob] <- createAndConnectUsers [OwnDomain, OwnDomain, OtherDomain]
+  conv <-
+    postConversation alice (defProteus {qualifiedUsers = [alex, bob]})
+      >>= getJSON 201
+  bindResponse (removeMember alice conv bob) $ \resp -> do
+    r <- getJSON 200 resp
+    r %. "type" `shouldMatch` "conversation.member-leave"
+    r %. "qualified_conversation" `shouldMatch` objQidObject conv
+    r %. "qualified_from" `shouldMatch` objQidObject alice
+    r %. "data.qualified_user_ids.0" `shouldMatch` objQidObject bob
+  -- Now that Bob is gone, try removing him once again
+  bindResponse (removeMember alice conv bob) $ \r -> do
+    r.status `shouldMatchInt` 204
+    r.jsonBody `shouldMatch` (Nothing @Aeson.Value)
+
+testDeleteRemoteMemberRemoteUnreachable :: HasCallStack => App ()
+testDeleteRemoteMemberRemoteUnreachable = do
+  [alice, bob, bart] <- createAndConnectUsers [OwnDomain, OtherDomain, OtherDomain]
+  conv <- startDynamicBackends [mempty] $ \[dynBackend] -> do
+    charlie <- randomUser dynBackend def
+    connectUsers alice charlie
+    postConversation
+      alice
+      (defProteus {qualifiedUsers = [bob, bart, charlie]})
+      >>= getJSON 201
+  void $ withWebSockets [alice, bob] $ \wss -> do
+    void $ removeMember alice conv bob >>= getBody 200
+    for wss $ \ws -> do
+      leaveNotif <- awaitMatch 10 isConvLeaveNotif ws
+      leaveNotif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+      leaveNotif %. "payload.0.qualified_from" `shouldMatch` objQidObject alice
+      leaveNotif %. "payload.0.data.qualified_user_ids.0" `shouldMatch` objQidObject bob
+  -- Now that Bob is gone, try removing him once again
+  bindResponse (removeMember alice conv bob) $ \r -> do
+    r.status `shouldMatchInt` 204
+    r.jsonBody `shouldMatch` (Nothing @Aeson.Value)
+
+testDeleteTeamConversationWithRemoteMembers :: HasCallStack => App ()
+testDeleteTeamConversationWithRemoteMembers = do
+  (alice, team, _) <- createTeam OwnDomain 1
+  conv <- postConversation alice (defProteus {team = Just team}) >>= getJSON 201
+  bob <- randomUser OtherDomain def
+  connectUsers alice bob
+  mem <- bob %. "qualified_id"
+  void $ addMembers alice conv def {users = [mem]} >>= getBody 200
+
+  void $ withWebSockets [alice, bob] $ \wss -> do
+    void $ deleteTeamConversation team conv alice >>= getBody 200
+    for wss $ \ws -> do
+      notif <- awaitMatch 10 isConvDeleteNotif ws
+      notif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+      notif %. "payload.0.qualified_from" `shouldMatch` objQidObject alice
+
+testDeleteTeamConversationWithUnreachableRemoteMembers :: HasCallStack => App ()
+testDeleteTeamConversationWithUnreachableRemoteMembers = do
+  resourcePool <- asks resourcePool
+  (alice, team, _) <- createTeam OwnDomain 1
+  conv <- postConversation alice (defProteus {team = Just team}) >>= getJSON 201
+
+  let assertNotification :: (HasCallStack, MakesValue n) => n -> App ()
+      assertNotification notif = do
+        notif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+        notif %. "payload.0.qualified_from" `shouldMatch` objQidObject alice
+
+  runCodensity (acquireResources 1 resourcePool) $ \[dynBackend] -> do
+    (bob, bobClient) <- runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
+      -- FUTUREWORK: get rid of this once the background worker is able to listen to all queues
+      do
+        ownDomain <- make OwnDomain & asString
+        otherDomain <- make OtherDomain & asString
+        let domains = [ownDomain, otherDomain, dynBackend.berDomain]
+        sequence_
+          [ createFedConn x (FedConn y "full_search")
+            | x <- domains,
+              y <- domains,
+              x /= y
+          ]
+
+      bob <- randomUser dynBackend.berDomain def
+      bobClient <- objId $ bindResponse (addClient bob def) $ getJSON 201
+      connectUsers alice bob
+      mem <- bob %. "qualified_id"
+      void $ addMembers alice conv def {users = [mem]} >>= getBody 200
+      pure (bob, bobClient)
+    withWebSocket alice $ \ws -> do
+      void $ deleteTeamConversation team conv alice >>= getBody 200
+      notif <- awaitMatch 10 isConvDeleteNotif ws
+      assertNotification notif
+    void $ runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
+      notif <- awaitNotification bob bobClient noValue 2 isConvDeleteNotif
+      assertNotification notif
+
+testLeaveConversationSuccess :: HasCallStack => App ()
+testLeaveConversationSuccess = do
+  [alice, bob, chad, dee] <-
+    createAndConnectUsers [OwnDomain, OwnDomain, OtherDomain, OtherDomain]
+  [aClient, bClient] <- forM [alice, bob] $ \user ->
+    objId $ bindResponse (addClient user def) $ getJSON 201
+  let overrides =
+        def {brigCfg = setField "optSettings.setFederationStrategy" "allowAll"}
+  startDynamicBackends [overrides] $ \[dynDomain] -> do
+    eve <- randomUser dynDomain def
+    eClient <- objId $ bindResponse (addClient eve def) $ getJSON 201
+    connectUsers alice eve
+    conv <-
+      postConversation
+        alice
+        ( defProteus
+            { qualifiedUsers = [bob, chad, dee, eve]
+            }
+        )
+        >>= getJSON 201
+    void $ removeMember chad conv chad >>= getBody 200
+    assertLeaveNotification chad conv alice aClient chad
+    assertLeaveNotification chad conv bob bClient chad
+    assertLeaveNotification chad conv eve eClient chad
+
+testOnUserDeletedConversations :: HasCallStack => App ()
+testOnUserDeletedConversations = do
+  let overrides =
+        def {brigCfg = setField "optSettings.setFederationStrategy" "allowAll"}
+  startDynamicBackends [overrides] $ \[dynDomain] -> do
+    [ownDomain, otherDomain] <- forM [OwnDomain, OtherDomain] asString
+    [alice, alex, bob, bart, chad] <-
+      createAndConnectUsers [ownDomain, ownDomain, otherDomain, otherDomain, dynDomain]
+    bobId <- bob %. "qualified_id"
+    ooConvId <- do
+      l <- getAllConvs alice
+      let isWith users c = do
+            t <- (==) <$> (c %. "type" & asInt) <*> pure 2
+            others <- c %. "members.others" & asList
+            qIds <- for others (%. "qualified_id")
+            pure $ qIds == users && t
+      c <- head <$> filterM (isWith [bobId]) l
+      c %. "qualified_id"
+
+    mainConvBefore <-
+      postConversation alice (defProteus {qualifiedUsers = [alex, bob, bart, chad]})
+        >>= getJSON 201
+
+    void $ withWebSocket alex $ \ws -> do
+      void $ deleteUser bob >>= getBody 200
+      n <- awaitMatch 10 isConvLeaveNotif ws
+      n %. "payload.0.qualified_from" `shouldMatch` bobId
+      n %. "payload.0.qualified_conversation" `shouldMatch` (mainConvBefore %. "qualified_id")
+
+      do
+        -- Bob is not in the one-to-one conversation with Alice any more
+        conv <- getConversation alice ooConvId >>= getJSON 200
+        shouldBeEmpty $ conv %. "members.others"
+      do
+        -- Bob is not in the main conversation any more
+        mainConvAfter <- getConversation alice (mainConvBefore %. "qualified_id") >>= getJSON 200
+        mems <- mainConvAfter %. "members.others" & asList
+        memIds <- for mems (%. "qualified_id")
+        expectedIds <- for [alex, bart, chad] (%. "qualified_id")
+        memIds `shouldMatchSet` expectedIds
+
+testUpdateConversationByRemoteAdmin :: HasCallStack => App ()
+testUpdateConversationByRemoteAdmin = do
+  [alice, bob, charlie] <- createAndConnectUsers [OwnDomain, OtherDomain, OtherDomain]
+  conv <-
+    postConversation alice (defProteus {qualifiedUsers = [bob, charlie]})
+      >>= getJSON 201
+  void $ updateRole alice bob "wire_admin" (conv %. "qualified_id") >>= getBody 200
+  void $ withWebSockets [alice, bob, charlie] $ \wss -> do
+    void $ updateReceiptMode bob conv (41 :: Int) >>= getBody 200
+    for_ wss $ \ws -> awaitMatch 10 isReceiptModeUpdateNotif ws

--- a/integration/test/Test/Demo.hs
+++ b/integration/test/Test/Demo.hs
@@ -43,7 +43,7 @@ testModifiedBrig = do
 
 testModifiedGalley :: HasCallStack => App ()
 testModifiedGalley = do
-  (_user, tid) <- createTeam OwnDomain
+  (_user, tid, _) <- createTeam OwnDomain 1
 
   let getFeatureStatus :: (MakesValue domain) => domain -> String -> App Value
       getFeatureStatus domain team = do
@@ -56,7 +56,7 @@ testModifiedGalley = do
   withModifiedBackend
     def {galleyCfg = setField "settings.featureFlags.teamSearchVisibility" "enabled-by-default"}
     $ \domain -> do
-      (_user, tid') <- createTeam domain
+      (_user, tid', _) <- createTeam domain 1
       getFeatureStatus domain tid' `shouldMatch` "enabled"
 
 testModifiedCannon :: HasCallStack => App ()
@@ -84,7 +84,7 @@ testModifiedServices = do
           }
 
   withModifiedBackend serviceMap $ \domain -> do
-    (_user, tid) <- createTeam domain
+    (_user, tid, _) <- createTeam domain 1
     bindResponse (Internal.getTeamFeature domain "searchVisibility" tid) $ \res -> do
       res.status `shouldMatchInt` 200
       res.json %. "status" `shouldMatch` "enabled"

--- a/integration/test/Test/Federation.hs
+++ b/integration/test/Test/Federation.hs
@@ -4,6 +4,7 @@
 module Test.Federation where
 
 import API.Brig qualified as API
+import API.BrigInternal qualified as API
 import API.Galley
 import Control.Lens
 import Control.Monad.Codensity
@@ -27,10 +28,22 @@ testNotificationsForOfflineBackends = do
   otherClient <- objId $ bindResponse (API.addClient otherUser def) $ getJSON 201
   otherClient2 <- objId $ bindResponse (API.addClient otherUser2 def) $ getJSON 201
 
-  -- We call it 'downBackend' because it is down for the most of this test
+  -- We call it 'downBackend' because it is down for most of this test
   -- except for setup and assertions. Perhaps there is a better name.
   runCodensity (acquireResources 1 resourcePool) $ \[downBackend] -> do
     (downUser1, downClient1, downUser2, upBackendConv, downBackendConv) <- runCodensity (startDynamicBackend downBackend mempty) $ \_ -> do
+      -- FUTUREWORK: get rid of this once the background worker is able to listen to all queues
+      do
+        ownDomain <- make OwnDomain & asString
+        otherDomain <- make OtherDomain & asString
+        let domains = [ownDomain, otherDomain, downBackend.berDomain]
+        sequence_
+          [ API.createFedConn x (API.FedConn y "full_search")
+            | x <- domains,
+              y <- domains,
+              x /= y
+          ]
+
       downUser1 <- randomUser downBackend.berDomain def
       downUser2 <- randomUser downBackend.berDomain def
       downClient1 <- objId $ bindResponse (API.addClient downUser1 def) $ getJSON 201
@@ -41,69 +54,74 @@ testNotificationsForOfflineBackends = do
       downBackendConv <- bindResponse (postConversation downUser1 (defProteus {qualifiedUsers = [otherUser, delUser]})) $ getJSON 201
       pure (downUser1, downClient1, downUser2, upBackendConv, downBackendConv)
 
-    -- Even when a participating backend is down, messages to conversations
-    -- owned by other backends should go.
-    successfulMsgForOtherUsers <- mkProteusRecipients otherUser [(otherUser, [otherClient]), (otherUser2, [otherClient2])] "success message for other user"
-    successfulMsgForDownUser <- mkProteusRecipient downUser1 downClient1 "success message for down user"
-    let successfulMsg =
-          Proto.defMessage @Proto.QualifiedNewOtrMessage
-            & #sender . Proto.client .~ (delClient ^?! hex)
-            & #recipients .~ [successfulMsgForOtherUsers, successfulMsgForDownUser]
-            & #reportAll .~ Proto.defMessage
-    bindResponse (postProteusMessage delUser upBackendConv successfulMsg) assertSuccess
+    withWebSocket otherUser $ \ws -> do
+      -- Even when a participating backend is down, messages to conversations
+      -- owned by other backends should go.
+      successfulMsgForOtherUsers <- mkProteusRecipients otherUser [(otherUser, [otherClient]), (otherUser2, [otherClient2])] "success message for other user"
+      successfulMsgForDownUser <- mkProteusRecipient downUser1 downClient1 "success message for down user"
+      let successfulMsg =
+            Proto.defMessage @Proto.QualifiedNewOtrMessage
+              & #sender . Proto.client .~ (delClient ^?! hex)
+              & #recipients .~ [successfulMsgForOtherUsers, successfulMsgForDownUser]
+              & #reportAll .~ Proto.defMessage
+      bindResponse (postProteusMessage delUser upBackendConv successfulMsg) assertSuccess
 
-    -- When conversation owning backend is down, messages will fail to be sent.
-    failedMsgForOtherUser <- mkProteusRecipient otherUser otherClient "failed message for other user"
-    failedMsgForDownUser <- mkProteusRecipient downUser1 downClient1 "failed message for down user"
-    let failedMsg =
-          Proto.defMessage @Proto.QualifiedNewOtrMessage
-            & #sender . Proto.client .~ (delClient ^?! hex)
-            & #recipients .~ [failedMsgForOtherUser, failedMsgForDownUser]
-            & #reportAll .~ Proto.defMessage
-    bindResponse (postProteusMessage delUser downBackendConv failedMsg) $ \resp ->
-      -- Due to the way federation breaks in local env vs K8s, it can return 521
-      -- (local) or 533 (K8s).
-      resp.status `shouldMatchOneOf` [Number 521, Number 533]
+      -- When the conversation owning backend is down, messages will fail to be sent.
+      failedMsgForOtherUser <- mkProteusRecipient otherUser otherClient "failed message for other user"
+      failedMsgForDownUser <- mkProteusRecipient downUser1 downClient1 "failed message for down user"
+      let failedMsg =
+            Proto.defMessage @Proto.QualifiedNewOtrMessage
+              & #sender . Proto.client .~ (delClient ^?! hex)
+              & #recipients .~ [failedMsgForOtherUser, failedMsgForDownUser]
+              & #reportAll .~ Proto.defMessage
+      bindResponse (postProteusMessage delUser downBackendConv failedMsg) $ \resp ->
+        -- Due to the way federation breaks in local env vs K8s, it can return 521
+        -- (local) or 533 (K8s).
+        resp.status `shouldMatchOneOf` [Number 521, Number 533]
 
-    -- Conversation creation with people from down backend should fail
-    bindResponse (postConversation delUser (defProteus {qualifiedUsers = [otherUser, downUser1]})) $ \resp ->
-      resp.status `shouldMatchInt` 533
+      -- Conversation creation with people from down backend should fail
+      bindResponse (postConversation delUser (defProteus {qualifiedUsers = [otherUser, downUser1]})) $ \resp ->
+        resp.status `shouldMatchInt` 533
 
-    -- Adding users to an up backend conversation should not work when one of
-    -- the participating backends is down. This is due to not being able to
-    -- check non-fully connected graph between all participating backends
-    -- however, if the backend of the user to be added is already part of the conversation, we do not need to do the check
-    -- and the user can be added as long as the backend is reachable
-    otherUser3 <- randomUser OtherDomain def
-    connectUsers delUser otherUser3
-    bindResponse (addMembers delUser upBackendConv [otherUser3]) $ \resp ->
-      resp.status `shouldMatchInt` 200
+      -- Adding users to an up backend conversation should not work when one of
+      -- the participating backends is down. This is due to not being able to
+      -- check non-fully connected graph between all participating backends
+      -- however, if the backend of the user to be added is already part of the conversation, we do not need to do the check
+      -- and the user can be added as long as the backend is reachable
+      otherUser3 <- randomUser OtherDomain def
+      connectUsers delUser otherUser3
+      bindResponse (addMembers delUser upBackendConv def {users = [otherUser3]}) $ \resp ->
+        resp.status `shouldMatchInt` 200
 
-    -- Adding users from down backend to a conversation should also fail
-    bindResponse (addMembers delUser upBackendConv [downUser2]) $ \resp ->
-      resp.status `shouldMatchInt` 533
+      -- Adding users from down backend to a conversation should fail
+      bindResponse (addMembers delUser upBackendConv def {users = [downUser2]}) $ \resp ->
+        resp.status `shouldMatchInt` 533
 
-    -- Removing users from an up backend conversation should work even when one
-    -- of the participating backends is down.
-    bindResponse (removeMember delUser upBackendConv otherUser2) $ \resp ->
-      resp.status `shouldMatchInt` 200
+      -- Removing users from an up backend conversation should work even when one
+      -- of the participating backends is down.
+      bindResponse (removeMember delUser upBackendConv otherUser2) $ \resp ->
+        resp.status `shouldMatchInt` 200
 
-    -- User deletions should eventually make it to the other backend.
-    deleteUser delUser
+      -- Even removing a user from the down backend itself should work.
+      bindResponse (removeMember delUser upBackendConv delUser) $ \resp ->
+        resp.status `shouldMatchInt` 200
 
-    let isOtherUser2LeaveUpConvNotif = allPreds [isConvLeaveNotif, isNotifConv upBackendConv, isNotifForUser otherUser2]
-        isDelUserLeaveUpConvNotif = allPreds [isConvLeaveNotif, isNotifConv upBackendConv, isNotifForUser delUser]
+      -- User deletions should eventually make it to the other backend.
+      deleteUser delUser
 
-    do
-      newMsgNotif <- awaitNotification otherUser otherClient noValue 1 isNewMessageNotif
-      newMsgNotif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject upBackendConv
-      newMsgNotif %. "payload.0.data.text" `shouldMatchBase64` "success message for other user"
+      let isOtherUser2LeaveUpConvNotif = allPreds [isConvLeaveNotif, isNotifConv upBackendConv, isNotifForUser otherUser2]
+          isDelUserLeaveUpConvNotif = allPreds [isConvLeaveNotif, isNotifConv upBackendConv, isNotifForUser delUser]
 
-      void $ awaitNotification otherUser otherClient (Just newMsgNotif) 1 isOtherUser2LeaveUpConvNotif
-      void $ awaitNotification otherUser otherClient (Just newMsgNotif) 1 isDelUserLeaveUpConvNotif
+      do
+        newMsgNotif <- awaitMatch 10 isNewMessageNotif ws
+        newMsgNotif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject upBackendConv
+        newMsgNotif %. "payload.0.data.text" `shouldMatchBase64` "success message for other user"
 
-      delUserDeletedNotif <- nPayload $ awaitNotification otherUser otherClient (Just newMsgNotif) 1 isDeleteUserNotif
-      objQid delUserDeletedNotif `shouldMatch` objQid delUser
+        void $ awaitMatch 10 isOtherUser2LeaveUpConvNotif ws
+        void $ awaitMatch 10 isDelUserLeaveUpConvNotif ws
+
+        delUserDeletedNotif <- nPayload $ awaitMatch 10 isDeleteUserNotif ws
+        objQid delUserDeletedNotif `shouldMatch` objQid delUser
 
     runCodensity (startDynamicBackend downBackend mempty) $ \_ -> do
       newMsgNotif <- awaitNotification downUser1 downClient1 noValue 5 isNewMessageNotif
@@ -124,8 +142,3 @@ testNotificationsForOfflineBackends = do
 
       delUserDeletedNotif <- nPayload $ awaitNotification downUser1 downClient1 (Just newMsgNotif) 1 isDeleteUserNotif
       objQid delUserDeletedNotif `shouldMatch` objQid delUser
-
-allPreds :: (Applicative f) => [a -> f Bool] -> a -> f Bool
-allPreds [] _ = pure True
-allPreds [p] x = p x
-allPreds (p1 : ps) x = (&&) <$> p1 x <*> allPreds ps x

--- a/integration/test/Test/MessageTimer.hs
+++ b/integration/test/Test/MessageTimer.hs
@@ -1,0 +1,55 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.MessageTimer where
+
+import API.Galley
+import Control.Monad.Codensity
+import Control.Monad.Reader
+import GHC.Stack
+import Notifications
+import SetupHelpers
+import Testlib.Prelude
+import Testlib.ResourcePool
+
+testMessageTimerChangeWithRemotes :: HasCallStack => App ()
+testMessageTimerChangeWithRemotes = do
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OtherDomain]
+  conv <- postConversation alice defProteus {qualifiedUsers = [bob]} >>= getJSON 201
+  withWebSockets [alice, bob] $ \wss -> do
+    void $ updateMessageTimer alice conv 1000 >>= getBody 200
+    for_ wss $ \ws -> do
+      notif <- awaitMatch 10 isConvMsgTimerUpdateNotif ws
+      notif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+      notif %. "payload.0.qualified_from" `shouldMatch` objQidObject alice
+
+testMessageTimerChangeWithUnreachableRemotes :: HasCallStack => App ()
+testMessageTimerChangeWithUnreachableRemotes = do
+  resourcePool <- asks resourcePool
+  alice <- randomUser OwnDomain def
+  conv <- runCodensity (acquireResources 1 resourcePool) $ \[dynBackend] ->
+    runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
+      bob <- randomUser dynBackend.berDomain def
+      connectUsers alice bob
+      postConversation alice (defProteus {qualifiedUsers = [bob]}) >>= getJSON 201
+  withWebSocket alice $ \ws -> do
+    void $ updateMessageTimer alice conv 1000 >>= getBody 200
+    notif <- awaitMatch 10 isConvMsgTimerUpdateNotif ws
+    notif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+    notif %. "payload.0.qualified_from" `shouldMatch` objQidObject alice

--- a/integration/test/Test/Roles.hs
+++ b/integration/test/Test/Roles.hs
@@ -1,0 +1,65 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Roles where
+
+import API.Galley
+import Control.Monad.Reader
+import GHC.Stack
+import Notifications
+import SetupHelpers
+import Testlib.Prelude
+
+testRoleUpdateWithRemotesOk :: HasCallStack => App ()
+testRoleUpdateWithRemotesOk = do
+  [bob, charlie, alice] <- createAndConnectUsers [OwnDomain, OwnDomain, OtherDomain]
+  conv <-
+    postConversation bob (defProteus {qualifiedUsers = [charlie, alice]})
+      >>= getJSON 201
+  adminRole <- make "wire_admin"
+
+  withWebSockets [bob, charlie, alice] $ \wss -> do
+    void $ updateRole bob charlie adminRole conv >>= getBody 200
+    bindResponse (getConversation bob conv) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      resp.json %. "members.others.0.qualified_id" `shouldMatch` objQidObject charlie
+      resp.json %. "members.others.0.conversation_role" `shouldMatch` "wire_admin"
+    for_ wss $ \ws -> do
+      notif <- awaitMatch 10 isMemberUpdateNotif ws
+      notif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+      notif %. "payload.0.qualified_from" `shouldMatch` objQidObject bob
+
+testRoleUpdateWithRemotesUnreachable :: HasCallStack => App ()
+testRoleUpdateWithRemotesUnreachable = do
+  [bob, charlie] <- createAndConnectUsers [OwnDomain, OwnDomain]
+  startDynamicBackends [mempty] $ \[dynBackend] -> do
+    alice <- randomUser dynBackend def
+    mapM_ (connectUsers alice) [bob, charlie]
+    conv <-
+      postConversation bob (defProteus {qualifiedUsers = [charlie, alice]})
+        >>= getJSON 201
+    adminRole <- make "wire_admin"
+
+    withWebSockets [bob, charlie] $ \wss -> do
+      void $ updateRole bob charlie adminRole conv >>= getBody 200
+
+      for_ wss $ \ws -> do
+        notif <- awaitMatch 10 isMemberUpdateNotif ws
+        notif %. "payload.0.qualified_conversation" `shouldMatch` objQidObject conv
+        notif %. "payload.0.qualified_from" `shouldMatch` objQidObject bob

--- a/integration/test/Testlib/Assertions.hs
+++ b/integration/test/Testlib/Assertions.hs
@@ -4,6 +4,7 @@ module Testlib.Assertions where
 
 import Control.Exception as E
 import Control.Monad.Reader
+import Data.Aeson (Value)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Encode.Pretty qualified as Aeson
 import Data.ByteString.Base64 qualified as B64
@@ -126,6 +127,9 @@ shouldMatchSet a b = do
   la <- fmap sort (asList a)
   lb <- fmap sort (asList b)
   la `shouldMatch` lb
+
+shouldBeEmpty :: (MakesValue a, HasCallStack) => a -> App ()
+shouldBeEmpty a = a `shouldMatch` (mempty :: [Value])
 
 shouldMatchOneOf ::
   (MakesValue a, MakesValue b, HasCallStack) =>

--- a/integration/test/Testlib/Prelude.hs
+++ b/integration/test/Testlib/Prelude.hs
@@ -66,6 +66,9 @@ module Testlib.Prelude
     -- * Functor
     (<$$>),
     (<$$$>),
+
+    -- * Applicative
+    allPreds,
   )
 where
 
@@ -222,3 +225,11 @@ infix 4 <$$>
 (<$$$>) = fmap . fmap . fmap
 
 infix 4 <$$$>
+
+----------------------------------------------------------------------
+-- Applicative
+
+allPreds :: (Applicative f) => [a -> f Bool] -> a -> f Bool
+allPreds [] _ = pure True
+allPreds [p] x = p x
+allPreds (p1 : ps) x = (&&) <$> p1 x <*> allPreds ps x

--- a/libs/wire-api-federation/src/Wire/API/Federation/BackendNotifications.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/BackendNotifications.hs
@@ -77,7 +77,7 @@ sendNotification env component path body =
       runFederatorClient env . void $
         clientIn (Proxy @BackendNotificationAPI) (Proxy @(FederatorClient c)) (withoutFirstSlash path) body
 
-enqueue :: Q.Channel -> Domain -> Domain -> Q.DeliveryMode -> FedQueueClient c () -> IO ()
+enqueue :: Q.Channel -> Domain -> Domain -> Q.DeliveryMode -> FedQueueClient c a -> IO a
 enqueue channel originDomain targetDomain deliveryMode (FedQueueClient action) =
   runReaderT action FedQueueEnv {..}
 

--- a/libs/wire-api/src/Wire/API/Conversation/Action.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Action.hs
@@ -69,7 +69,11 @@ data SomeConversationAction where
 
 instance Show SomeConversationAction where
   show (SomeConversationAction tag action) =
-    $(sCases ''ConversationActionTag [|tag|] [|show action|])
+    "SomeConversationAction {tag = "
+      <> show (fromSing tag)
+      <> ", action = "
+      <> $(sCases ''ConversationActionTag [|tag|] [|show action|])
+      <> "}"
 
 instance Eq SomeConversationAction where
   (SomeConversationAction tag1 action1) == (SomeConversationAction tag2 action2) =

--- a/services/brig/src/Brig/Federation/Client.hs
+++ b/services/brig/src/Brig/Federation/Client.hs
@@ -154,7 +154,9 @@ notifyUserDeleted self remotes = do
       remoteDomain = tDomain remotes
   view rabbitmqChannel >>= \case
     Just chanVar -> do
-      enqueueNotification (tDomain self) remoteDomain Q.Persistent chanVar $ void $ fedQueueClient @'Brig @"on-user-deleted-connections" notif
+      enqueueNotification (tDomain self) remoteDomain Q.Persistent chanVar $
+        void $
+          fedQueueClient @'Brig @"on-user-deleted-connections" notif
     Nothing ->
       Log.err $
         Log.msg ("Federation error while notifying remote backends of a user deletion." :: ByteString)
@@ -163,7 +165,7 @@ notifyUserDeleted self remotes = do
           . Log.field "error" (show FederationNotConfigured)
 
 -- | Enqueues notifications in RabbitMQ. Retries 3 times with a delay of 1s.
-enqueueNotification :: (MonadReader Env m, MonadIO m, MonadMask m, Log.MonadLogger m) => Domain -> Domain -> Q.DeliveryMode -> MVar Q.Channel -> FedQueueClient c () -> m ()
+enqueueNotification :: (MonadIO m, MonadMask m, Log.MonadLogger m) => Domain -> Domain -> Q.DeliveryMode -> MVar Q.Channel -> FedQueueClient c () -> m ()
 enqueueNotification ownDomain remoteDomain deliveryMode chanVar action = do
   let policy = limitRetries 3 <> constantDelay 1_000_000
   recovering policy [logRetries (const $ pure True) logError] (const go)

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -71,6 +71,7 @@ import Galley.Data.Conversation qualified as Data
 import Galley.Data.Scope (Scope (ReusableCode))
 import Galley.Data.Services
 import Galley.Effects
+import Galley.Effects.BackendNotificationQueueAccess
 import Galley.Effects.BotAccess qualified as E
 import Galley.Effects.BrigAccess qualified as E
 import Galley.Effects.CodeStore qualified as E
@@ -88,6 +89,7 @@ import Galley.Types.Conversations.Members
 import Galley.Types.UserList
 import Galley.Validation
 import Imports hiding ((\\))
+import Network.AMQP qualified as Q
 import Polysemy
 import Polysemy.Error
 import Polysemy.Input
@@ -349,6 +351,7 @@ ensureAllowed tag loc action conv origUser = do
 performAction ::
   forall tag r.
   ( HasConversationActionEffects tag r,
+    Member BackendNotificationQueueAccess r,
     Member (Error FederationError) r
   ) =>
   Sing tag ->
@@ -419,7 +422,8 @@ performAction tag origUser lconv action = do
 
 performConversationJoin ::
   forall r.
-  ( HasConversationActionEffects 'ConversationJoinTag r
+  ( HasConversationActionEffects 'ConversationJoinTag r,
+    Member BackendNotificationQueueAccess r
   ) =>
   Qualified UserId ->
   Local Conversation ->
@@ -529,7 +533,8 @@ performConversationJoin qusr lconv (ConversationJoin invited role) = do
 
 performConversationAccessData ::
   ( HasConversationActionEffects 'ConversationAccessDataTag r,
-    Member (Error FederationError) r
+    Member (Error FederationError) r,
+    Member BackendNotificationQueueAccess r
   ) =>
   Qualified UserId ->
   Local Conversation ->
@@ -615,13 +620,13 @@ data LocalConversationUpdate = LocalConversationUpdate
 
 updateLocalConversation ::
   forall tag r.
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error FederationError) r,
     Member (ErrorS ('ActionDenied (ConversationActionPermission tag))) r,
     Member (ErrorS 'InvalidOperation) r,
     Member (ErrorS 'ConvNotFound) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member (Logger (Log.Msg -> Log.Msg)) r,
@@ -656,12 +661,12 @@ updateLocalConversation lcnv qusr con action = do
 updateLocalConversationUnchecked ::
   forall tag r.
   ( SingI tag,
+    Member BackendNotificationQueueAccess r,
     Member (Error FederationError) r,
     Member (ErrorS ('ActionDenied (ConversationActionPermission tag))) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member (Logger (Log.Msg -> Log.Msg)) r,
@@ -704,6 +709,7 @@ updateLocalConversationUserUnchecked ::
   forall tag r.
   ( SingI tag,
     HasConversationActionEffects tag r,
+    Member BackendNotificationQueueAccess r,
     Member (Error FederationError) r
   ) =>
   Local Conversation ->
@@ -762,7 +768,7 @@ addMembersToLocalConversation lcnv users role = do
 
 notifyConversationAction ::
   forall tag r.
-  ( Member FederatorAccess r,
+  ( Member BackendNotificationQueueAccess r,
     Member ExternalAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
@@ -790,24 +796,23 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
           (SomeConversationAction tag action)
 
   update <- do
+    let remoteTargets = toList (bmRemotes targets)
     updates <-
-      E.runFederatedConcurrentlyEither (toList (bmRemotes targets)) $
-        \ruids -> do
-          let update = mkUpdate (tUnqualified ruids)
-          -- if notifyOrigDomain is false, filter out user from quid's domain,
-          -- because quid's backend will update local state and notify its users
-          -- itself using the ConversationUpdate returned by this function
-          if notifyOrigDomain || tDomain ruids /= qDomain quid
-            then fedClient @'Galley @"on-conversation-updated" update $> Nothing
-            else pure (Just update)
-    let f = fromMaybe (mkUpdate []) . asum . map tUnqualified . rights
-        update = f updates
-        failedUpdates = lefts updates
-    for_ failedUpdates $
-      logError
-        "on-conversation-updated"
-        "An error occurred while communicating with federated server: "
-    pure update
+      enqueueNotificationsConcurrently Q.Persistent remoteTargets $ \ruids -> do
+        let update = mkUpdate (tUnqualified ruids)
+        -- if notifyOrigDomain is false, filter out user from quid's domain,
+        -- because quid's backend will update local state and notify its users
+        -- itself using the ConversationUpdate returned by this function
+        if notifyOrigDomain || tDomain ruids /= qDomain quid
+          then fedQueueClient @'Galley @"on-conversation-updated" update $> Nothing
+          else pure (Just update)
+    case partitionEithers updates of
+      (ls :: [Remote ([UserId], FederationError)], rs) -> do
+        for_ ls $
+          logError
+            "on-conversation-updated"
+            "An error occurred while communicating with federated server: "
+        pure $ fromMaybe (mkUpdate []) . asum . map tUnqualified $ rs
 
   -- notify local participants and bots
   pushConversationEvent con e (qualifyAs lcnv (bmLocals targets)) (bmBots targets)
@@ -816,10 +821,12 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
   -- to the originating domain (if it is remote)
   pure $ LocalConversationUpdate e update
   where
-    logError :: (Show a) => String -> String -> (a, FederationError) -> Sem r ()
+    logError :: String -> String -> Remote (a, FederationError) -> Sem r ()
     logError field msg e =
       P.warn $
-        Log.field "federation call" field . Log.msg (msg <> show e)
+        Log.field "federation call" field
+          . Log.field "domain" (_domainText (tDomain e))
+          . Log.msg (msg <> displayException (snd (tUnqualified e)))
 
 -- | Update the local database with information on conversation members joining
 -- or leaving. Finally, push out notifications to local users.
@@ -938,7 +945,8 @@ addLocalUsersToRemoteConv remoteConvId qAdder localUsers = do
 -- leave, but then sends notifications as if the user was removed by someone
 -- else.
 kickMember ::
-  ( Member (Error FederationError) r,
+  ( Member BackendNotificationQueueAccess r,
+    Member (Error FederationError) r,
     Member (Error InternalError) r,
     Member ExternalAccess r,
     Member FederatorAccess r,

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -51,7 +51,6 @@ import Galley.API.Util
 import Galley.App
 import Galley.Data.Conversation qualified as Data
 import Galley.Effects
-import Galley.Effects.BackendNotificationQueueAccess
 import Galley.Effects.ConversationStore qualified as E
 import Galley.Effects.FireAndForget qualified as E
 import Galley.Effects.MemberStore qualified as E
@@ -219,7 +218,8 @@ onConversationUpdated requestingDomain cu = do
 
 -- as of now this will not generate the necessary events on the leaver's domain
 leaveConversation ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error InternalError) r,
     Member ExternalAccess r,
     Member FederatorAccess r,
@@ -365,7 +365,8 @@ sendMessage originDomain msr = do
     throwErr = throw . InvalidPayload . LT.pack
 
 onUserDeleted ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member FederatorAccess r,
     Member FireAndForget r,
     Member ExternalAccess r,
@@ -421,7 +422,8 @@ onUserDeleted origDomain udcn = do
 
 updateConversation ::
   forall r.
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member CodeStore r,
     Member BotAccess r,
     Member FireAndForget r,
@@ -535,7 +537,8 @@ handleMLSMessageErrors =
     . mapToGalleyError @MLSBundleStaticErrors
 
 sendMLSCommitBundle ::
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member ExternalAccess r,
     Member (Error FederationError) r,
@@ -568,7 +571,8 @@ sendMLSCommitBundle remoteDomain msr = handleMLSMessageErrors $ do
     <$> postMLSCommitBundle loc (tUntagged sender) Nothing qcnv Nothing bundle
 
 sendMLSMessage ::
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member ExternalAccess r,
     Member (Error FederationError) r,

--- a/services/galley/src/Galley/API/LegalHold.hs
+++ b/services/galley/src/Galley/API/LegalHold.hs
@@ -139,7 +139,8 @@ getSettings lzusr tid = do
 
 removeSettingsInternalPaging ::
   forall r.
-  ( Member BotAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BotAccess r,
     Member BrigAccess r,
     Member CodeStore r,
     Member ConversationStore r,
@@ -181,7 +182,8 @@ removeSettings ::
   forall p r.
   ( Paging p,
     Bounded (PagingBounds p TeamMember),
-    ( Member BotAccess r,
+    ( Member BackendNotificationQueueAccess r,
+      Member BotAccess r,
       Member BrigAccess r,
       Member CodeStore r,
       Member ConversationStore r,
@@ -243,7 +245,8 @@ removeSettings' ::
   forall p r.
   ( Paging p,
     Bounded (PagingBounds p TeamMember),
-    ( Member BotAccess r,
+    ( Member BackendNotificationQueueAccess r,
+      Member BotAccess r,
       Member BrigAccess r,
       Member CodeStore r,
       Member ConversationStore r,
@@ -335,7 +338,8 @@ getUserStatus _lzusr tid uid = do
 -- @withdrawExplicitConsentH@ (lots of corner cases we'd have to implement for that to pan
 -- out).
 grantConsent ::
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
@@ -372,7 +376,8 @@ grantConsent lusr tid = do
 -- | Request to provision a device on the legal hold service for a user
 requestDevice ::
   forall r.
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
@@ -450,7 +455,8 @@ requestDevice lzusr tid uid = do
 -- since they are replaced if needed when registering new LH devices.
 approveDevice ::
   forall r.
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error AuthenticationError) r,
     Member (Error FederationError) r,
@@ -528,7 +534,8 @@ approveDevice lzusr connId tid uid (Public.ApproveLegalHoldForUserRequest mPassw
 
 disableForUser ::
   forall r.
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error AuthenticationError) r,
     Member (Error FederationError) r,
@@ -585,7 +592,8 @@ disableForUser lzusr tid uid (Public.DisableLegalHoldForUserRequest mPassword) =
 -- or disabled, make sure the affected connections are screened for policy conflict (anybody
 -- with no-consent), and put those connections in the appropriate blocked state.
 changeLegalholdStatus ::
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
@@ -702,7 +710,8 @@ unsetTeamLegalholdWhitelistedH tid = do
 -- contains the hypothetical new LH status of `uid`'s so it can be consulted instead of the
 -- one from the database.
 handleGroupConvPolicyConflicts ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
     Member (ErrorS ('ActionDenied 'RemoveConversationMember)) r,

--- a/services/galley/src/Galley/API/MLS/Message.hs
+++ b/services/galley/src/Galley/API/MLS/Message.hs
@@ -547,7 +547,8 @@ postMLSMessageToRemoteConv loc qusr _senderClient con smsg rcnv = do
     MLSMessageResponseNonFederatingBackends e -> throw e
 
 type HasProposalEffects r =
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error InternalError) r,
     Member (Error MLSProposalFailure) r,
@@ -1094,7 +1095,8 @@ checkExternalProposalUser qusr prop = do
 
 executeProposalAction ::
   forall r.
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error InternalError) r,
     Member (ErrorS 'ConvNotFound) r,

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -1082,7 +1082,8 @@ getTeamConversation zusr tid cid = do
     >>= noteS @'ConvNotFound
 
 deleteTeamConversation ::
-  ( Member CodeStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member CodeStore r,
     Member ConversationStore r,
     Member (Error FederationError) r,
     Member (ErrorS 'ConvNotFound) r,
@@ -1090,7 +1091,6 @@ deleteTeamConversation ::
     Member (ErrorS 'NotATeamMember) r,
     Member (ErrorS ('ActionDenied 'DeleteConversation)) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member TeamStore r,

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -284,6 +284,7 @@ instance SetFeatureConfig LegalholdConfig where
   type
     SetConfigForTeamConstraints LegalholdConfig (r :: EffectRow) =
       ( Bounded (PagingBounds InternalPaging TeamMember),
+        Member BackendNotificationQueueAccess r,
         Member BotAccess r,
         Member BrigAccess r,
         Member CodeStore r,

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -94,7 +94,6 @@ import Galley.Data.Conversation qualified as Data
 import Galley.Data.Services as Data
 import Galley.Data.Types hiding (Conversation)
 import Galley.Effects
-import Galley.Effects.BackendNotificationQueueAccess
 import Galley.Effects.ClientStore qualified as E
 import Galley.Effects.CodeStore qualified as E
 import Galley.Effects.ConversationStore qualified as E
@@ -253,7 +252,8 @@ handleUpdateResult = \case
   Unchanged -> empty & setStatus status204
 
 type UpdateConversationAccessEffects =
-  '[ BotAccess,
+  '[ BackendNotificationQueueAccess,
+     BotAccess,
      BrigAccess,
      CodeStore,
      ConversationStore,
@@ -307,7 +307,8 @@ updateConversationAccessUnqualified lusr con cnv update =
       update
 
 updateConversationReceiptMode ::
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
@@ -380,7 +381,8 @@ updateRemoteConversation rcnv lusr conn action = getUpdateResult $ do
   updateLocalStateOfRemoteConv (qualifyAs rcnv convUpdate) (Just conn) >>= note NoChanges
 
 updateConversationReceiptModeUnqualified ::
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
@@ -403,13 +405,13 @@ updateConversationReceiptModeUnqualified ::
 updateConversationReceiptModeUnqualified lusr zcon cnv = updateConversationReceiptMode lusr zcon (tUntagged (qualifyAs lusr cnv))
 
 updateConversationMessageTimer ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (ErrorS ('ActionDenied 'ModifyConversationMessageTimer)) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member (Error FederationError) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member (Logger (Msg -> Msg)) r
@@ -436,13 +438,13 @@ updateConversationMessageTimer lusr zcon qcnv update =
       qcnv
 
 updateConversationMessageTimerUnqualified ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (ErrorS ('ActionDenied 'ModifyConversationMessageTimer)) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member (Error FederationError) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member (Logger (Msg -> Msg)) r
@@ -455,7 +457,8 @@ updateConversationMessageTimerUnqualified ::
 updateConversationMessageTimerUnqualified lusr zcon cnv = updateConversationMessageTimer lusr zcon (tUntagged (qualifyAs lusr cnv))
 
 deleteLocalConversation ::
-  ( Member CodeStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member CodeStore r,
     Member ConversationStore r,
     Member (Error FederationError) r,
     Member (ErrorS 'NotATeamMember) r,
@@ -463,7 +466,6 @@ deleteLocalConversation ::
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member TeamStore r,
@@ -672,7 +674,8 @@ checkReusableCode convCode = do
 
 joinConversationByReusableCode ::
   forall r.
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member CodeStore r,
     Member ConversationStore r,
     Member (ErrorS 'CodeNotFound) r,
@@ -683,7 +686,6 @@ joinConversationByReusableCode ::
     Member (ErrorS 'InvalidOperation) r,
     Member (ErrorS 'NotATeamMember) r,
     Member (ErrorS 'TooManyMembers) r,
-    Member FederatorAccess r,
     Member ExternalAccess r,
     Member GundeckAccess r,
     Member (Input Opts) r,
@@ -705,8 +707,8 @@ joinConversationByReusableCode lusr zcon req = do
 
 joinConversationById ::
   forall r.
-  ( Member BrigAccess r,
-    Member FederatorAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (ErrorS 'ConvAccessDenied) r,
     Member (ErrorS 'ConvNotFound) r,
@@ -731,8 +733,8 @@ joinConversationById lusr zcon cnv = do
 
 joinConversation ::
   forall r.
-  ( Member BrigAccess r,
-    Member FederatorAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member (ErrorS 'ConvAccessDenied) r,
     Member (ErrorS 'InvalidOperation) r,
     Member (ErrorS 'NotATeamMember) r,
@@ -774,7 +776,8 @@ joinConversation lusr zcon conv access = do
         action
 
 addMembers ::
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error InternalError) r,
     Member (ErrorS ('ActionDenied 'AddConversationMember)) r,
@@ -813,7 +816,8 @@ addMembers lusr zcon qcnv (InviteQualified users role) = do
       ConversationJoin users role
 
 addMembersUnqualifiedV2 ::
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
@@ -852,7 +856,8 @@ addMembersUnqualifiedV2 lusr zcon cnv (InviteQualified users role) = do
       ConversationJoin users role
 
 addMembersUnqualified ::
-  ( Member BrigAccess r,
+  ( Member BackendNotificationQueueAccess r,
+    Member BrigAccess r,
     Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
@@ -953,7 +958,8 @@ updateUnqualifiedSelfMember lusr zcon cnv update = do
   updateSelfMember lusr zcon (tUntagged lcnv) update
 
 updateOtherMemberLocalConv ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error FederationError) r,
     Member (ErrorS ('ActionDenied 'ModifyOtherConversationMember)) r,
     Member (ErrorS 'InvalidTarget) r,
@@ -961,7 +967,6 @@ updateOtherMemberLocalConv ::
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'ConvMemberNotFound) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member MemberStore r,
@@ -980,7 +985,8 @@ updateOtherMemberLocalConv lcnv lusr con qvictim update = void . getUpdateResult
     ConversationMemberUpdate qvictim update
 
 updateOtherMemberUnqualified ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error FederationError) r,
     Member (ErrorS ('ActionDenied 'ModifyOtherConversationMember)) r,
     Member (ErrorS 'InvalidTarget) r,
@@ -988,7 +994,6 @@ updateOtherMemberUnqualified ::
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'ConvMemberNotFound) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member MemberStore r,
@@ -1006,7 +1011,8 @@ updateOtherMemberUnqualified lusr zcon cnv victim update = do
   updateOtherMemberLocalConv lcnv lusr zcon (tUntagged lvictim) update
 
 updateOtherMember ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error FederationError) r,
     Member (ErrorS ('ActionDenied 'ModifyOtherConversationMember)) r,
     Member (ErrorS 'InvalidTarget) r,
@@ -1014,7 +1020,6 @@ updateOtherMember ::
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'ConvMemberNotFound) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member MemberStore r,
@@ -1041,7 +1046,8 @@ updateOtherMemberRemoteConv ::
 updateOtherMemberRemoteConv _ _ _ _ _ = throw FederationNotImplemented
 
 removeMemberUnqualified ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
     Member (ErrorS ('ActionDenied 'RemoveConversationMember)) r,
@@ -1067,7 +1073,8 @@ removeMemberUnqualified lusr con cnv victim = do
   removeMemberQualified lusr con (tUntagged lcnv) (tUntagged lvictim)
 
 removeMemberQualified ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
     Member (ErrorS ('ActionDenied 'RemoveConversationMember)) r,
@@ -1134,7 +1141,8 @@ removeMemberFromRemoteConv cnv lusr victim
 
 -- | Remove a member from a local conversation.
 removeMemberFromLocalConv ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InternalError) r,
     Member (ErrorS ('ActionDenied 'LeaveConversation)) r,
@@ -1326,14 +1334,14 @@ postOtrMessageUnqualified sender zcon cnv =
         (runLocalInput sender . postQualifiedOtrMessage User (tUntagged sender) (Just zcon) lcnv)
 
 updateConversationName ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InvalidInput) r,
     Member (ErrorS ('ActionDenied 'ModifyConversationName)) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member (Logger (Msg -> Msg)) r
@@ -1352,14 +1360,14 @@ updateConversationName lusr zcon qcnv convRename = do
     convRename
 
 updateUnqualifiedConversationName ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InvalidInput) r,
     Member (ErrorS ('ActionDenied 'ModifyConversationName)) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member (Logger (Msg -> Msg)) r
@@ -1374,14 +1382,14 @@ updateUnqualifiedConversationName lusr zcon cnv rename = do
   updateLocalConversationName lusr zcon lcnv rename
 
 updateLocalConversationName ::
-  ( Member ConversationStore r,
+  ( Member BackendNotificationQueueAccess r,
+    Member ConversationStore r,
     Member (Error FederationError) r,
     Member (Error InvalidInput) r,
     Member (ErrorS ('ActionDenied 'ModifyConversationName)) r,
     Member (ErrorS 'ConvNotFound) r,
     Member (ErrorS 'InvalidOperation) r,
     Member ExternalAccess r,
-    Member FederatorAccess r,
     Member GundeckAccess r,
     Member (Input UTCTime) r,
     Member (Logger (Msg -> Msg)) r

--- a/services/galley/src/Galley/Effects.hs
+++ b/services/galley/src/Galley/Effects.hs
@@ -56,6 +56,9 @@ module Galley.Effects
     -- * Polysemy re-exports
     Member,
     Members,
+
+    -- * Queueing effects
+    BackendNotificationQueueAccess,
   )
 where
 

--- a/services/galley/src/Galley/Effects/BackendNotificationQueueAccess.hs
+++ b/services/galley/src/Galley/Effects/BackendNotificationQueueAccess.hs
@@ -15,7 +15,13 @@ data BackendNotificationQueueAccess m a where
     KnownComponent c =>
     Remote x ->
     Q.DeliveryMode ->
-    FedQueueClient c () ->
-    BackendNotificationQueueAccess m (Either FederationError ())
+    FedQueueClient c a ->
+    BackendNotificationQueueAccess m (Either FederationError a)
+  EnqueueNotificationsConcurrently ::
+    (KnownComponent c, Foldable f, Functor f) =>
+    Q.DeliveryMode ->
+    f (Remote x) ->
+    (Remote [x] -> FedQueueClient c a) ->
+    BackendNotificationQueueAccess m [Either (Remote ([x], FederationError)) (Remote a)]
 
 makeSem ''BackendNotificationQueueAccess

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -23,7 +23,6 @@ import Bilge hiding (head)
 import Bilge.Assert
 import Control.Exception
 import Control.Lens hiding ((#))
-import Data.Aeson qualified as A
 import Data.ByteString.Conversion (toByteString')
 import Data.Domain
 import Data.Id
@@ -34,7 +33,6 @@ import Data.List1 qualified as List1
 import Data.Map qualified as Map
 import Data.ProtoLens qualified as Protolens
 import Data.Qualified
-import Data.Range
 import Data.Set qualified as Set
 import Data.Singletons
 import Data.Time.Clock
@@ -83,13 +81,10 @@ tests s =
       test s "POST /federation/on-conversation-updated : Notify local user about receipt mode update" notifyReceiptMode,
       test s "POST /federation/on-conversation-updated : Notify local user about access update" notifyAccess,
       test s "POST /federation/on-conversation-updated : Notify local users about a deleted conversation" notifyDeletedConversation,
-      test s "POST /federation/leave-conversation : Success" leaveConversationSuccess,
       test s "POST /federation/leave-conversation : Non-existent" leaveConversationNonExistent,
       test s "POST /federation/leave-conversation : Invalid type" leaveConversationInvalidType,
       test s "POST /federation/on-message-sent : Receive a message from another backend" onMessageSent,
       test s "POST /federation/send-message : Post a message sent from another backend" sendMessage,
-      test s "POST /federation/on-user-deleted-conversations : Remove deleted remote user from local conversations" onUserDeleted,
-      test s "POST /federation/update-conversation : Update local conversation by a remote admin " updateConversationByRemoteAdmin,
       test s "POST /federation/on-conversation-updated : Notify local user about conversation rename with an unavailable federator" notifyConvRenameUnavailable,
       test s "POST /federation/on-conversation-updated : Notify local user about message timer update with an unavailable federator" notifyMessageTimerUnavailable,
       test s "POST /federation/on-conversation-updated : Notify local user about receipt mode update with an unavailable federator" notifyReceiptModeUnavailable,
@@ -711,69 +706,6 @@ addRemoteUser = do
       WS.assertNoEvent (1 # Second) [wsC]
       WS.assertNoEvent (1 # Second) [wsF]
 
-leaveConversationSuccess :: TestM ()
-leaveConversationSuccess = do
-  localDomain <- viewFederationDomain
-  c <- view tsCannon
-  [alice, bob] <- randomUsers 2
-  let qBob = Qualified bob localDomain
-      remoteDomain1 = Domain "far-away-1.example.com"
-      remoteDomain2 = Domain "far-away-2.example.com"
-  qChad <- (`Qualified` remoteDomain1) <$> randomId
-  qDee <- (`Qualified` remoteDomain1) <$> randomId
-  qEve <- (`Qualified` remoteDomain2) <$> randomId
-  connectUsers alice (singleton bob)
-  connectWithRemoteUser alice qChad
-  connectWithRemoteUser alice qDee
-  connectWithRemoteUser alice qEve
-
-  let mock = do
-        guardRPC "get-users-by-ids"
-        d <- frTargetDomain <$> getRequest
-        asum
-          [ guard (d == remoteDomain1)
-              *> mockReply [mkProfile qChad (Name "Chad"), mkProfile qDee (Name "Dee")],
-            guard (d == remoteDomain2)
-              *> mockReply [mkProfile qEve (Name "Eve")]
-          ]
-
-  convId <-
-    decodeConvId
-      <$> postConvWithRemoteUsersGeneric
-        (mock <|> mockReply EmptyResponse)
-        alice
-        Nothing
-        defNewProteusConv
-          { newConvQualifiedUsers = [qBob, qChad, qDee, qEve]
-          }
-  let qconvId = Qualified convId localDomain
-
-  (_, federatedRequests) <-
-    WS.bracketR2 c alice bob $ \(wsAlice, wsBob) -> do
-      withTempMockFederator' ("get-not-fully-connected-backends" ~> NonConnectedBackends mempty <|> mock <|> mockReply EmptyResponse) $ do
-        g <- viewGalley
-        let leaveRequest = FedGalley.LeaveConversationRequest convId (qUnqualified qChad)
-        respBS <-
-          post
-            ( g
-                . paths ["federation", "leave-conversation"]
-                . content "application/json"
-                . header "Wire-Origin-Domain" (toByteString' remoteDomain1)
-                . json leaveRequest
-            )
-            <!! const 200 === statusCode
-        parsedResp :: LeaveConversationResponse <- responseJsonError respBS
-        liftIO $ do
-          parsedResp.response @?= Right mempty
-          void . WS.assertMatch (3 # Second) wsAlice $
-            wsAssertMembersLeave qconvId qChad [qChad]
-          void . WS.assertMatch (3 # Second) wsBob $
-            wsAssertMembersLeave qconvId qChad [qChad]
-
-  liftIO $ fedRequestsForDomain remoteDomain1 Galley federatedRequests @?= []
-  let [remote2GalleyFederatedRequest] = fedRequestsForDomain remoteDomain2 Galley federatedRequests
-  assertLeaveUpdate remote2GalleyFederatedRequest qconvId qChad [qUnqualified qEve]
-
 leaveConversationNonExistent :: TestM ()
 leaveConversationNonExistent = do
   let remoteDomain = Domain "far-away.example.com"
@@ -987,232 +919,6 @@ sendMessage = do
       -- check that alice received the message
       WS.assertMatch_ (5 # Second) ws $
         wsAssertOtr' "" conv bob bobClient aliceClient (toBase64Text "hi alice")
-
--- | There are 3 backends in action here:
---
--- - Backend A (local) has Alice and Alex
--- - Backend B has Bob and Bart
--- - Backend C has Carl
---
--- Bob is in these convs:
--- - One2One Conv with Alice (ooConvId)
--- - Group conv with all users (groupConvId)
---
--- When bob gets deleted, backend A gets an RPC from bDomain stating that bob is
--- deleted and they would like bob to leave these converstaions:
--- - ooConvId -> Causes Alice to be notified
--- - groupConvId -> Causes Alice and Alex to be notified
--- - extraConvId -> Ignored
--- - noBobConvId -> Ignored
-onUserDeleted :: TestM ()
-onUserDeleted = do
-  cannon <- view tsCannon
-  let bDomain = Domain "b.far-away.example.com"
-      cDomain = Domain "c.far-away.example.com"
-
-  alice <- qTagUnsafe <$> randomQualifiedUser
-  alex <- randomQualifiedUser
-  (bob, ooConvId) <- generateRemoteAndConvIdWithDomain bDomain True alice
-  bart <- randomQualifiedId bDomain
-  carl <- randomQualifiedId cDomain
-
-  connectWithRemoteUser (tUnqualified alice) (tUntagged bob)
-  connectUsers (tUnqualified alice) (pure (qUnqualified alex))
-  connectWithRemoteUser (tUnqualified alice) bart
-  connectWithRemoteUser (tUnqualified alice) carl
-
-  -- create 1-1 conversation between alice and bob
-  createOne2OneConvWithRemote alice bob
-
-  -- create group conversation with everybody
-  groupConvId <- WS.bracketR cannon (tUnqualified alice) $ \wsAlice -> do
-    convId <-
-      decodeQualifiedConvId
-        <$> ( postConvWithRemoteUsers
-                (tUnqualified alice)
-                Nothing
-                defNewProteusConv {newConvQualifiedUsers = [tUntagged bob, alex, bart, carl]}
-                <!! const 201 === statusCode
-            )
-    WS.assertMatch_ (5 # Second) wsAlice $
-      wsAssertConvCreate convId (tUntagged alice)
-    pure convId
-
-  -- extraneous conversation
-  extraConvId <- randomId
-
-  -- conversation without bob
-  noBobConvId <-
-    WS.bracketR cannon (tUnqualified alice) $ \wsAlice -> do
-      convId <-
-        fmap decodeQualifiedConvId $
-          postConvQualified
-            (tUnqualified alice)
-            Nothing
-            defNewProteusConv {newConvQualifiedUsers = [alex]}
-            <!! const 201 === statusCode
-      WS.assertMatch_ (5 # Second) wsAlice $
-        wsAssertConvCreate convId (tUntagged alice)
-      pure convId
-
-  WS.bracketR2 cannon (tUnqualified alice) (qUnqualified alex) $ \(wsAlice, wsAlex) -> do
-    (resp, rpcCalls) <- withTempMockFederator' (mockReply EmptyResponse) $ do
-      let udcn =
-            FedGalley.UserDeletedConversationsNotification
-              { FedGalley.user = tUnqualified bob,
-                FedGalley.conversations =
-                  unsafeRange
-                    [ qUnqualified ooConvId,
-                      qUnqualified groupConvId,
-                      extraConvId,
-                      qUnqualified noBobConvId
-                    ]
-              }
-      g <- viewGalley
-      responseJsonError
-        =<< post
-          ( g
-              . paths ["federation", "on-user-deleted-conversations"]
-              . content "application/json"
-              . header "Wire-Origin-Domain" (toByteString' (tDomain bob))
-              . json udcn
-          )
-          <!! const 200 === statusCode
-
-    ooConvAfterDel <- responseJsonError =<< getConvQualified (tUnqualified alice) ooConvId <!! const 200 === statusCode
-    groupConvAfterDel <- responseJsonError =<< getConvQualified (tUnqualified alice) groupConvId <!! const 200 === statusCode
-
-    liftIO $ do
-      resp @?= EmptyResponse
-
-      -- Assert that bob gets removed from the conversation
-      cmOthers (cnvMembers ooConvAfterDel) @?= []
-      sort (map omQualifiedId (cmOthers (cnvMembers groupConvAfterDel))) @?= sort [alex, bart, carl]
-
-      -- Assert that local user's get notifications only for the conversation
-      -- bob was part of and it wasn't a One2OneConv
-      void . WS.assertMatch (3 # Second) wsAlice $
-        wsAssertMembersLeave groupConvId (tUntagged bob) [tUntagged bob]
-      void . WS.assertMatch (3 # Second) wsAlex $
-        wsAssertMembersLeave groupConvId (tUntagged bob) [tUntagged bob]
-      -- Alice shouldn't get any other notifications because we don't notify
-      -- on One2One convs.
-      --
-      -- Alex shouldn't get any other notifications because alex was
-      -- not part of any other conversations with bob.
-      WS.assertNoEvent (1 # Second) [wsAlice, wsAlex]
-
-      -- There should be only 1 RPC call made to eve's domain for groupConvId.
-      -- Bob's domain does not get a notification, because it's the one making
-      -- the request.
-      assertEqual ("Expected 1 RPC calls, got: " <> show rpcCalls) 1 (length rpcCalls)
-
-      -- Assertions about RPC to 'cDomain'
-      cDomainRPC <- assertOne $ filter (\c -> frTargetDomain c == cDomain) rpcCalls
-      cDomainRPCReq <- assertRight $ parseFedRequest cDomainRPC
-      FedGalley.cuOrigUserId cDomainRPCReq @?= tUntagged bob
-      FedGalley.cuConvId cDomainRPCReq @?= qUnqualified groupConvId
-      FedGalley.cuAlreadyPresentUsers cDomainRPCReq @?= [qUnqualified carl]
-      FedGalley.cuAction cDomainRPCReq @?= SomeConversationAction (sing @'ConversationLeaveTag) ()
-
--- | We test only ReceiptMode update here
---
--- A : local domain, owns the conversation
--- B : bob is an admin of the converation
--- C : charlie is a regular member of the conversation
-updateConversationByRemoteAdmin :: TestM ()
-updateConversationByRemoteAdmin = do
-  c <- view tsCannon
-  (alice, qalice) <- randomUserTuple
-
-  let bdomain = Domain "b.example.com"
-      cdomain = Domain "c.example.com"
-  qbob <- randomQualifiedId bdomain
-  qcharlie <- randomQualifiedId cdomain
-  mapM_ (connectWithRemoteUser alice) [qbob, qcharlie]
-
-  let convName = "Test Conv"
-  WS.bracketR c alice $ \wsAlice -> do
-    (rsp, _federatedRequests) <- do
-      let mock = ("get-not-fully-connected-backends" ~> NonConnectedBackends mempty) <|> mockReply EmptyResponse
-      withTempMockFederator' mock $ do
-        postConvQualified alice Nothing defNewProteusConv {newConvName = checked convName, newConvQualifiedUsers = [qbob, qcharlie]}
-          <!! const 201 === statusCode
-
-    cnv <- assertConv rsp RegularConv alice qalice [qbob, qcharlie] (Just convName) Nothing
-
-    let newReceiptMode = ReceiptMode 41
-    let action = SomeConversationAction (sing @'ConversationReceiptModeUpdateTag) (ConversationReceiptModeUpdate newReceiptMode)
-
-    (_, federatedRequests) <-
-      withTempMockFederator' (mockReply EmptyResponse) $ do
-        -- promote chad to admin
-        putOtherMemberQualified alice qbob (OtherMemberUpdate (Just roleNameWireAdmin)) cnv
-          !!! const 200 === statusCode
-
-        -- bob updates the conversation
-        let cnvUpdateRequest =
-              ConversationUpdateRequest
-                { user = qUnqualified qbob,
-                  convId = qUnqualified cnv,
-                  action = action
-                }
-        resp <- do
-          fedGalleyClient <- view tsFedGalleyClient
-          runFedClient @"update-conversation" fedGalleyClient bdomain cnvUpdateRequest
-
-        cnvUpdate' <- liftIO $ case resp of
-          ConversationUpdateResponseError err -> assertFailure ("Expected ConversationUpdateResponseUpdate but got " <> show err)
-          ConversationUpdateResponseNoChanges -> assertFailure "Expected ConversationUpdateResponseUpdate but got ConversationUpdateResponseNoChanges"
-          ConversationUpdateResponseUpdate up -> pure up
-          ConversationUpdateResponseNonFederatingBackends _ -> assertFailure "Expected ConversationUpdateResponseUpdate but got ConversationUpdateResponseNonFederatingBackends"
-          ConversationUpdateResponseUnreachableBackends _ -> assertFailure "Expected ConversationUpdateResponseUpdate but got ConversationUpdateResponseUnreachableBackends"
-
-        liftIO $ do
-          cuOrigUserId cnvUpdate' @?= qbob
-          cuAlreadyPresentUsers cnvUpdate' @?= [qUnqualified qbob]
-          cuAction cnvUpdate' @?= action
-
-    -- backend A generates a notification for alice
-    void $
-      WS.awaitMatch (5 # Second) wsAlice $ \n -> do
-        liftIO $ wsAssertConvReceiptModeUpdate cnv qalice newReceiptMode n
-
-    -- backend B does *not* get notified of the conversation update ony of bob's promotion
-    liftIO $ do
-      [(_fr, cUpdate)] <- mapM parseConvUpdate $ filter (\r -> frTargetDomain r == bdomain) federatedRequests
-      assertBool "Action is not a ConversationMemberUpdate" (isJust (getConvAction (sing @'ConversationMemberUpdateTag) (cuAction cUpdate)))
-
-    -- conversation has been modified by action
-    updatedConv :: Conversation <- fmap responseJsonUnsafe $ getConvQualified alice cnv <!! const 200 === statusCode
-    liftIO $
-      (cnvmReceiptMode . cnvMetadata) updatedConv @?= Just newReceiptMode
-
-    -- backend C gets notified of the conversation update and bob's promotion
-    liftIO $ do
-      dUpdates <- mapM parseConvUpdate $ filter (\r -> frTargetDomain r == cdomain) federatedRequests
-
-      (_fr1, _cu1, _up1) <- assertOne $ mapMaybe (\(fr, up) -> getConvAction (sing @'ConversationMemberUpdateTag) (cuAction up) <&> (fr,up,)) dUpdates
-
-      (_fr2, convUpdate, receiptModeUpdate) <- assertOne $ mapMaybe (\(fr, up) -> getConvAction (sing @'ConversationReceiptModeUpdateTag) (cuAction up) <&> (fr,up,)) dUpdates
-
-      cruReceiptMode receiptModeUpdate @?= newReceiptMode
-      cuOrigUserId convUpdate @?= qbob
-      cuConvId convUpdate @?= qUnqualified cnv
-      cuAlreadyPresentUsers convUpdate @?= [qUnqualified qcharlie]
-
-    WS.assertMatch_ (5 # Second) wsAlice $ \n -> do
-      wsAssertConvReceiptModeUpdate cnv qbob newReceiptMode n
-  where
-    _toOtherMember qid = OtherMember qid Nothing roleNameWireAdmin
-    _convView cnv usr = responseJsonUnsafeWithMsg "conversation" <$> getConv usr cnv
-
-    parseConvUpdate :: FederatedRequest -> IO (FederatedRequest, ConversationUpdate)
-    parseConvUpdate rpc = do
-      frComponent rpc @?= Galley
-      frRPC rpc @?= "on-conversation-updated"
-      let convUpdate :: ConversationUpdate = fromRight (error $ "Could not parse ConversationUpdate from " <> show (frBody rpc)) $ A.eitherDecode (frBody rpc)
-      pure (rpc, convUpdate)
 
 getConvAction :: Sing tag -> SomeConversationAction -> Maybe (ConversationAction tag)
 getConvAction tquery (SomeConversationAction tag action) =

--- a/services/galley/test/integration/API/MessageTimer.hs
+++ b/services/galley/test/integration/API/MessageTimer.hs
@@ -23,34 +23,19 @@ where
 import API.Util
 import Bilge hiding (timeout)
 import Bilge.Assert
-import Control.Exception
 import Control.Lens (view)
-import Data.Aeson (eitherDecode)
-import Data.Domain
-import Data.Id
 import Data.List1
-import Data.List1 qualified as List1
 import Data.Misc
 import Data.Qualified
-import Data.Singletons
-import Federator.MockServer
 import Imports hiding (head)
-import Network.HTTP.Types qualified as Http
 import Network.Wai.Utilities.Error
 import Test.Tasty
 import Test.Tasty.Cannon (TimeoutUnit (..), (#))
 import Test.Tasty.Cannon qualified as WS
-import Test.Tasty.HUnit
 import TestHelpers
 import TestSetup
 import Wire.API.Conversation
-import Wire.API.Conversation.Action
 import Wire.API.Conversation.Role
-import Wire.API.Event.Conversation
-import Wire.API.Federation.API.Common
-import Wire.API.Federation.API.Galley qualified as F
-import Wire.API.Federation.Component
-import Wire.API.Internal.Notification (Notification (..))
 
 tests :: IO TestSetup -> TestTree
 tests s =
@@ -63,8 +48,6 @@ tests s =
         ],
       test s "timer can be changed" messageTimerChange,
       test s "timer can be changed with the qualified endpoint" messageTimerChangeQualified,
-      test s "timer changes are propagated to remote users" messageTimerChangeWithRemotes,
-      test s "timer changes unavailable remotes" messageTimerUnavailableRemotes,
       test s "timer can't be set by conv member without allowed action" messageTimerChangeWithoutAllowedAction,
       test s "timer can't be set in 1:1 conversations" messageTimerChangeO2O,
       test s "setting the timer generates an event" messageTimerEvent
@@ -142,86 +125,6 @@ messageTimerChangeQualified = do
     !!! const 200 === statusCode
   getConvQualified jane qcid
     !!! const timer1year === (cnvMessageTimer <=< responseJsonUnsafe)
-
-messageTimerChangeWithRemotes :: TestM ()
-messageTimerChangeWithRemotes = do
-  c <- view tsCannon
-  let remoteDomain = Domain "alice.example.com"
-  qalice <- Qualified <$> randomId <*> pure remoteDomain
-  qbob <- randomQualifiedUser
-  let bob = qUnqualified qbob
-  connectWithRemoteUser bob qalice
-
-  resp <-
-    postConvWithRemoteUsers
-      bob
-      Nothing
-      defNewProteusConv {newConvQualifiedUsers = [qalice]}
-  let qconv = decodeQualifiedConvId resp
-
-  WS.bracketR c bob $ \wsB -> do
-    (_, requests) <-
-      withTempMockFederator' (mockReply EmptyResponse) $
-        putMessageTimerUpdateQualified bob qconv (ConversationMessageTimerUpdate timer1sec)
-          !!! const 200 === statusCode
-
-    req <- assertOne requests
-    liftIO $ do
-      frTargetDomain req @?= remoteDomain
-      frComponent req @?= Galley
-      frRPC req @?= "on-conversation-updated"
-      Right cu <- pure . eitherDecode . frBody $ req
-      F.cuConvId cu @?= qUnqualified qconv
-      F.cuAction cu
-        @?= SomeConversationAction (sing @'ConversationMessageTimerUpdateTag) (ConversationMessageTimerUpdate timer1sec)
-
-    void . liftIO . WS.assertMatch (5 # Second) wsB $ \n -> do
-      let e = List1.head (WS.unpackPayload n)
-      ntfTransient n @?= False
-      evtConv e @?= qconv
-      evtType e @?= ConvMessageTimerUpdate
-      evtFrom e @?= qbob
-      evtData e @?= EdConvMessageTimerUpdate (ConversationMessageTimerUpdate timer1sec)
-
-messageTimerUnavailableRemotes :: TestM ()
-messageTimerUnavailableRemotes = do
-  c <- view tsCannon
-  let remoteDomain = Domain "alice.example.com"
-  qalice <- Qualified <$> randomId <*> pure remoteDomain
-  qbob <- randomQualifiedUser
-  let bob = qUnqualified qbob
-  connectWithRemoteUser bob qalice
-
-  resp <-
-    postConvWithRemoteUsers
-      bob
-      Nothing
-      defNewProteusConv {newConvQualifiedUsers = [qalice]}
-  let qconv = decodeQualifiedConvId resp
-
-  WS.bracketR c bob $ \wsB -> do
-    (_, requests) <-
-      withTempMockFederator' (throw $ MockErrorResponse Http.status503 "Down for maintenance") $
-        putMessageTimerUpdateQualified bob qconv (ConversationMessageTimerUpdate timer1sec)
-          !!! const 200 === statusCode
-
-    req <- assertOne requests
-    liftIO $ do
-      frTargetDomain req @?= remoteDomain
-      frComponent req @?= Galley
-      frRPC req @?= "on-conversation-updated"
-      Right cu <- pure . eitherDecode . frBody $ req
-      F.cuConvId cu @?= qUnqualified qconv
-      F.cuAction cu
-        @?= SomeConversationAction (sing @'ConversationMessageTimerUpdateTag) (ConversationMessageTimerUpdate timer1sec)
-
-    void . liftIO . WS.assertMatch (5 # Second) wsB $ \n -> do
-      let e = List1.head (WS.unpackPayload n)
-      ntfTransient n @?= False
-      evtConv e @?= qconv
-      evtType e @?= ConvMessageTimerUpdate
-      evtFrom e @?= qbob
-      evtData e @?= EdConvMessageTimerUpdate (ConversationMessageTimerUpdate timer1sec)
 
 messageTimerChangeWithoutAllowedAction :: TestM ()
 messageTimerChangeWithoutAllowedAction = do


### PR DESCRIPTION
This ports the PR #3537 from `develop` to `mandarin`.

Tracked by https://wearezeta.atlassian.net/browse/WPB-3664.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
