### PR TITLE
Cleanup error logs on shutdown

### DIFF
--- a/changelog.d/5-internal/shutdown-cleanup
+++ b/changelog.d/5-internal/shutdown-cleanup
@@ -1,0 +1,1 @@
+Avoid unnecessary error logs on service shutdown

--- a/integration/test/Testlib/RunServices.hs
+++ b/integration/test/Testlib/RunServices.hs
@@ -3,7 +3,7 @@
 module Testlib.RunServices where
 
 import Control.Concurrent
-import Control.Monad.Codensity (lowerCodensity)
+import Control.Monad.Codensity
 import System.Directory
 import System.Environment (getArgs)
 import System.Exit (exitWith)
@@ -44,7 +44,6 @@ main = do
       pure $ joinPath [projectRoot, "services/integration.yaml"]
 
   genv <- createGlobalEnv cfg
-  env <- lowerCodensity $ mkEnv genv
 
   args <- getArgs
 
@@ -57,10 +56,11 @@ main = do
           (_, _, _, ph) <- createProcess cp
           exitWith =<< waitForProcess ph
 
-  runAppWithEnv env $ do
-    lowerCodensity $ do
-      _modifyEnv <-
-        traverseConcurrentlyCodensity
-          (`startDynamicBackend` def)
-          [backendA, backendB]
-      liftIO run
+  runCodensity (mkEnv genv) $ \env ->
+    runAppWithEnv env $
+      lowerCodensity $ do
+        _modifyEnv <-
+          traverseConcurrentlyCodensity
+            (`startDynamicBackend` def)
+            [backendA, backendB]
+        liftIO run


### PR DESCRIPTION
Avoid unnecessary error logs on service shutdown.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
