### PR TITLE
Add Rabbitmq external chart

### DIFF
--- a/charts/rabbitmq-external/Chart.yaml
+++ b/charts/rabbitmq-external/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Refer to rabbitmq IPs located outside kubernetes by specifying IPs manually
+name: rabbitmq-external
+version: 0.0.42

--- a/charts/rabbitmq-external/templates/endpoint.yaml
+++ b/charts/rabbitmq-external/templates/endpoint.yaml
@@ -1,4 +1,4 @@
-# create a headless clusterIP service to create dns name "elasticsearch-external"
+# create a headless clusterIP service to create dns name "rabbitmq-external"
 # and a custom endpoint, thus forwarding traffic when resolving DNS to custom IPs
 kind: Service
 apiVersion: v1

--- a/charts/rabbitmq-external/templates/endpoint.yaml
+++ b/charts/rabbitmq-external/templates/endpoint.yaml
@@ -1,0 +1,38 @@
+# create a headless clusterIP service to create dns name "elasticsearch-external"
+# and a custom endpoint, thus forwarding traffic when resolving DNS to custom IPs
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ template "rabbitmq-external.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  clusterIP: None # headless service
+  ports:
+  - name: http
+    port: {{ .Values.portHttp }}
+    targetPort: {{ .Values.portHttp }}
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ template "rabbitmq-external.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subsets:
+  - addresses:
+      {{- range .Values.IPs }}
+      - ip: {{ . }}
+      {{- end }}
+    ports:
+      # port and name in the endpoint must match port and name in the service
+      # see also https://docs.openshift.com/enterprise/3.0/dev_guide/integrating_external_services.html
+      - name: http
+        port: {{ .Values.portHttp }}

--- a/charts/rabbitmq-external/templates/helpers.tpl
+++ b/charts/rabbitmq-external/templates/helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "rabbitmq-external.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rabbitmq-external.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/rabbitmq-external/values.yaml
+++ b/charts/rabbitmq-external/values.yaml
@@ -1,0 +1,6 @@
+portHttp: 9200
+
+## Configure this helm chart with:
+# IPs:
+#   - 1.2.3.4
+#   - 5.6.7.8

--- a/charts/rabbitmq-external/values.yaml
+++ b/charts/rabbitmq-external/values.yaml
@@ -1,4 +1,4 @@
-portHttp: 9200
+portHttp: 5672
 
 ## Configure this helm chart with:
 # IPs:


### PR DESCRIPTION
To connect with the ansible based rabbitmq cluster deployed outside kubernetes.

https://github.com/wireapp/wire-server-deploy/pull/643
