### PR TITLE
[WPB-4792] Port ticket changes from `develop` to `mandarin`

### DIFF
--- a/changelog.d/6-federation/tcp-timeout
+++ b/changelog.d/6-federation/tcp-timeout
@@ -1,0 +1,3 @@
+federator: Allow setting TCP connection timeout for HTTP2 requests
+
+The helm chart defaults it to 5s which should be best for most installations.

--- a/charts/federator/templates/configmap.yaml
+++ b/charts/federator/templates/configmap.yaml
@@ -51,5 +51,6 @@ data:
       clientCertificate: "/etc/wire/federator/secrets/tls.crt"
       clientPrivateKey: "/etc/wire/federator/secrets/tls.key"
       useSystemCAStore: {{ .useSystemCAStore }}
+      tcpConnectionTimeout: {{ .tcpConnectionTimeout }}
     {{- end }}
     {{- end }}

--- a/charts/federator/values.yaml
+++ b/charts/federator/values.yaml
@@ -41,6 +41,8 @@ config:
     # A client certificate and corresponding private key can be specified
     # similarly to a custom CA store.
     useSystemCAStore: true
+    # In microseconds, default is 5s.
+    tcpConnectionTimeout: 5000000
 
 podSecurityContext:
   allowPrivilegeEscalation: false

--- a/libs/http2-manager/src/HTTP2/Client/Manager.hs
+++ b/libs/http2-manager/src/HTTP2/Client/Manager.hs
@@ -3,6 +3,7 @@ module HTTP2.Client.Manager
     setCacheLimit,
     setSSLContext,
     setSSLRemoveTrailingDot,
+    setTCPConnectionTimeout,
     TLSEnabled,
     HostName,
     Port,

--- a/services/federator/federator.integration.yaml
+++ b/services/federator/federator.integration.yaml
@@ -24,5 +24,6 @@ optSettings:
   useSystemCAStore: false
   clientCertificate: "test/resources/integration-leaf.pem"
   clientPrivateKey: "test/resources/integration-leaf-key.pem"
+  tcpConnectionTimeout: 5000000
   dnsHost: "127.0.0.1"
   dnsPort: 9053

--- a/services/federator/src/Federator/Env.hs
+++ b/services/federator/src/Federator/Env.hs
@@ -62,6 +62,8 @@ onNewSSLContext :: Env -> SSLContext -> IO ()
 onNewSSLContext env ctx =
   atomicModifyIORef' (_http2Manager env) $ \mgr -> (setSSLContext ctx mgr, ())
 
-mkHttp2Manager :: SSLContext -> IO Http2Manager
-mkHttp2Manager sslContext =
-  setSSLRemoveTrailingDot True <$> http2ManagerWithSSLCtx sslContext
+mkHttp2Manager :: Int -> SSLContext -> IO Http2Manager
+mkHttp2Manager tcpConnectionTimeout sslContext =
+  setTCPConnectionTimeout tcpConnectionTimeout
+    . setSSLRemoveTrailingDot True
+    <$> http2ManagerWithSSLCtx sslContext

--- a/services/federator/src/Federator/Options.hs
+++ b/services/federator/src/Federator/Options.hs
@@ -31,6 +31,9 @@ data RunSettings = RunSettings
     remoteCAStore :: Maybe FilePath,
     clientCertificate :: FilePath,
     clientPrivateKey :: FilePath,
+    -- | Timeout for making TCP connections (for http2) with remote federators
+    -- and local components. In microseconds.
+    tcpConnectionTimeout :: Int,
     dnsHost :: Maybe String,
     dnsPort :: Maybe Word16
   }

--- a/services/federator/src/Federator/Run.hs
+++ b/services/federator/src/Federator/Run.hs
@@ -104,7 +104,7 @@ newEnv o _dnsResolver _applog _domainConfigs = do
       _internalPort = o.federatorInternal._port
   _httpManager <- initHttpManager
   sslContext <- mkTLSSettingsOrThrow _runSettings
-  _http2Manager <- newIORef =<< mkHttp2Manager sslContext
+  _http2Manager <- newIORef =<< mkHttp2Manager o.optSettings.tcpConnectionTimeout sslContext
   _federatorMetrics <- mkFederatorMetrics
   pure Env {..}
 

--- a/services/federator/test/unit/Test/Federator/Options.hs
+++ b/services/federator/test/unit/Test/Federator/Options.hs
@@ -39,6 +39,7 @@ defRunSettings client key =
       remoteCAStore = Nothing,
       clientCertificate = client,
       clientPrivateKey = key,
+      tcpConnectionTimeout = 1000,
       dnsHost = Nothing,
       dnsPort = Nothing
     }
@@ -66,6 +67,7 @@ testSettings =
                   allowAll:
                 clientCertificate: client.pem
                 clientPrivateKey: client-key.pem
+                tcpConnectionTimeout: 1000
                 useSystemCAStore: true|]
           ),
       testCase "parse configuration example (closed federation)" $ do
@@ -79,6 +81,7 @@ testSettings =
             allowedDomains:
               - server2.example.com
           useSystemCAStore: false
+          tcpConnectionTimeout: 1000
           clientCertificate: client.pem
           clientPrivateKey: client-key.pem|],
       testCase "succefully read client credentials" $ do
@@ -89,6 +92,7 @@ testSettings =
         assertParsesAs settings . B8.pack $
           [QQ.i|
           useSystemCAStore: true
+          tcpConnectionTimeout: 1000
           federationStrategy:
             allowAll: null
           clientCertificate: test/resources/unit/localhost.pem
@@ -98,12 +102,14 @@ testSettings =
         assertParseFailure @RunSettings . B8.pack $
           [QQ.i|
           useSystemCAStore: true
+          tcpConnectionTimeout: 1000
           federationStrategy:
             allowAll: null|],
       testCase "fail on missing client private key" $ do
         assertParseFailure @RunSettings . B8.pack $
           [QQ.i|
           useSystemCAStore: true
+          tcpConnectionTimeout: 1000
           federationStrategy:
             allowAll: null
           clientCertificate: test/resources/unit/localhost.pem|],
@@ -111,6 +117,7 @@ testSettings =
         assertParseFailure @RunSettings . B8.pack $
           [QQ.i|
           useSystemCAStore: true
+          tcpConnectionTimeout: 1000
           federationStrategy:
             allowAll: null
           clientPrivateKey: test/resources/unit/localhost-key.pem|],
@@ -119,6 +126,7 @@ testSettings =
         assertParsesAs settings . B8.pack $
           [QQ.i|
           useSystemCAStore: true
+          tcpConnectionTimeout: 1000
           federationStrategy:
             allowAll: null
           clientCertificate: non-existent
@@ -140,6 +148,7 @@ testSettings =
         assertParsesAs settings . B8.pack $
           [QQ.i|
           useSystemCAStore: true
+          tcpConnectionTimeout: 1000
           federationStrategy:
             allowAll: null
           clientCertificate: test/resources/unit/invalid.pem
@@ -161,6 +170,7 @@ testSettings =
         assertParsesAs settings . B8.pack $
           [QQ.i|
           useSystemCAStore: true
+          tcpConnectionTimeout: 1000
           federationStrategy:
             allowAll: null
           clientCertificate: test/resources/unit/localhost.pem

--- a/services/federator/test/unit/Test/Federator/Remote.hs
+++ b/services/federator/test/unit/Test/Federator/Remote.hs
@@ -80,7 +80,7 @@ assertNoRemoteError = \case
 
 mkTestCall :: SSLContext -> ByteString -> Int -> Codensity IO (Either RemoteError ())
 mkTestCall sslCtx hostname port = do
-  mgr <- liftIO $ mkHttp2Manager sslCtx
+  mgr <- liftIO $ mkHttp2Manager 1_000_000 sslCtx
   runM
     . runEmbedded @IO @(Codensity IO) liftIO
     . runError @RemoteError


### PR DESCRIPTION
This ports (cherry-picks) the changes for the TCP connection timeout per PR #3595  from `develop` to `mandarin`.

Tracked by https://wearezeta.atlassian.net/browse/WPB-4792.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
