### PR TITLE
federator: fix ServiceMonitor name and app label

### DIFF
--- a/charts/federator/templates/servicemonitor.yaml
+++ b/charts/federator/templates/servicemonitor.yaml
@@ -2,9 +2,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: gundeck
+  name: federator
   labels:
-    app: gundeck
+    app: federator
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}


### PR DESCRIPTION
copy-paste error from another component.

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
