### PR TITLE
cabal.project: Add -Werror for integration tests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -96,6 +96,8 @@ package hscim
     ghc-options: -Werror
 package http2-manager
     ghc-options: -Werror
+package integration
+    ghc-options: -Werror
 package imports
     ghc-options: -Werror
 package jwt-tools


### PR DESCRIPTION
The CI runs this build with -Werror, local compilation should also follow that as we do for all the other packages.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
