### PR TITLE
Fix MLS message notification bug

### DIFF
--- a/changelog.d/3-bug-fixes/mls-notification-bug
+++ b/changelog.d/3-bug-fixes/mls-notification-bug
@@ -1,0 +1,1 @@
+Fix bug where notifications for MLS messages were not showing up in all notification streams of clients

--- a/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
+++ b/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
@@ -125,6 +125,12 @@ data RecipientClients
     RecipientClientsSome (List1 ClientId)
   deriving (Eq, Show, Ord)
 
+instance Semigroup RecipientClients where
+  RecipientClientsAll <> _ = RecipientClientsAll
+  _ <> RecipientClientsAll = RecipientClientsAll
+  RecipientClientsSome cs1 <> RecipientClientsSome cs2 =
+    RecipientClientsSome (cs1 <> cs2)
+
 makeLenses ''Recipient
 
 recipient :: UserId -> Route -> Recipient

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -21,6 +21,7 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.Domain
 import Data.Id
 import Data.Json.Util
+import Data.List.NonEmpty (NonEmpty)
 import Data.Misc (Milliseconds)
 import Data.Qualified
 import Data.Range
@@ -348,7 +349,7 @@ data RemoteMLSMessage = RemoteMLSMessage
     sender :: Qualified UserId,
     conversation :: ConvId,
     subConversation :: Maybe SubConvId,
-    recipients :: [(UserId, ClientId)],
+    recipients :: Map UserId (NonEmpty ClientId),
     message :: Base64ByteString
   }
   deriving stock (Eq, Show, Generic)

--- a/services/galley/src/Galley/API/MLS/Propagate.hs
+++ b/services/galley/src/Galley/API/MLS/Propagate.hs
@@ -100,8 +100,6 @@ propagateMessage qusr mSenderClient lConvOrSub con msg cm = do
               Map.fromList $
                 tUnqualified rs
                   >>= toList . remoteMemberMLSClients,
-            -- Map.fromList $
-            --   rs >>= toList . remoteMemberMLSClients,
             message = Base64ByteString msg.raw
           }
   where

--- a/services/galley/src/Galley/API/Push.hs
+++ b/services/galley/src/Galley/API/Push.hs
@@ -71,14 +71,10 @@ newMessagePush ::
   Event ->
   MessagePush
 newMessagePush botMap mconn mm userOrBots event =
-  let (recipients, botMembers) =
-        foldMap
-          ( \r ->
-              case Map.lookup (_recipientUserId r) botMap of
-                Just botMember -> ([], [botMember])
-                Nothing -> ([r], [])
-          )
-          (map toRecipient userOrBots)
+  let toPair r = case Map.lookup (_recipientUserId r) botMap of
+        Just botMember -> ([], [botMember])
+        Nothing -> ([r], [])
+      (recipients, botMembers) = foldMap (toPair . toRecipient) userOrBots
    in MessagePush mconn mm recipients botMembers event
 
 runMessagePush ::

--- a/services/galley/src/Galley/Intra/Push/Internal.hs
+++ b/services/galley/src/Galley/Intra/Push/Internal.hs
@@ -24,6 +24,7 @@ import Control.Lens (makeLenses, set, view, (.~))
 import Data.Aeson (Object)
 import Data.Id (ConnId, UserId)
 import Data.Json.Util
+import Data.List.Extra
 import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import Data.List1
 import Data.Qualified

--- a/services/galley/test/integration/API/MLS.hs
+++ b/services/galley/test/integration/API/MLS.hs
@@ -32,6 +32,7 @@ import Data.Aeson qualified as Aeson
 import Data.Domain
 import Data.Id
 import Data.Json.Util hiding ((#))
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.List1 hiding (head)
 import Data.Map qualified as Map
 import Data.Qualified
@@ -890,7 +891,7 @@ testRemoteToRemoteInSub = do
   void $ runFedClient @"on-conversation-updated" fedGalleyClient bdom cu
 
   let txt = "Hello from another backend"
-      rcpts = [(alice, aliceC1), (alice, aliceC2), (eve, eveC)]
+      rcpts = Map.fromList [(alice, aliceC1 :| [aliceC2]), (eve, eveC :| [])]
       rm =
         RemoteMLSMessage
           { time = now,


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-3867

This PR fixes a bug where some clients do not see MLS message notifications when fetching them with a `client` query parameter. The problem is that MLS message notifications are sent to gundeck as a single push, which will in general contain different `Recipient` objects for different clients of the same users. This makes the entries conflict with one another in cassandra, and therefore only one client ends up being stored in the database.

~The fix here is "condensing" consecutive `Recipient` items relating to the same user by joining them together into a single `Recipient` object. This works because because recipient lists are generated by user.~

This is now fixed by overloading `newMessagePush` so that it can work both with simple `(User, Client)` pairs - employed by Proteus messaging code - and with actual `Recipient` objects (i.e. one user, multiple clients) - used by MLS.

## TODO

- [x] Fix bug for remote notifications

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
