### PR TITLE
WPB-4835 call-between-web-and-android-cant-be-established-when-one-backend-is-not-available

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-4835
+++ b/changelog.d/3-bug-fixes/WPB-4835
@@ -1,0 +1,1 @@
+list-clients returns with partial success even if one of the remote backends is unreachable

--- a/integration/test/API/Brig.hs
+++ b/integration/test/API/Brig.hs
@@ -153,6 +153,12 @@ getClientsQualified user domain otherUser = do
         <> "/clients"
   submit "GET" req
 
+listUsersClients :: (HasCallStack, MakesValue user, MakesValue qualifiedUserIds) => user -> [qualifiedUserIds] -> App Response
+listUsersClients usr qualifiedUserIds = do
+  qUsers <- mapM objQidObject qualifiedUserIds
+  req <- baseRequest usr Brig Versioned $ joinHttpPath ["users", "list-clients"]
+  submit "POST" (req & addJSONObject ["qualified_users" .= qUsers])
+
 searchContacts ::
   ( MakesValue user,
     MakesValue searchTerm,

--- a/integration/test/Test/Client.hs
+++ b/integration/test/Test/Client.hs
@@ -1,13 +1,26 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
 module Test.Client where
 
 import API.Brig
+import API.Brig qualified as API
+import API.BrigInternal qualified as API
 import API.Gundeck
+import Control.Lens hiding ((.=))
+import Control.Monad.Codensity
+import Control.Monad.Reader
 import Data.Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.ProtoLens.Labels ()
+import Data.String.Conversions
 import Data.Time.Clock.POSIX
 import Data.Time.Clock.System
 import Data.Time.Format
+import Data.Vector qualified as Vector
 import SetupHelpers
-import Testlib.Prelude
+import Testlib.Prelude hiding ((.=))
+import Testlib.ResourcePool
 
 testClientLastActive :: HasCallStack => App ()
 testClientLastActive = do
@@ -32,3 +45,65 @@ testClientLastActive = do
       . utcTimeToPOSIXSeconds
       <$> parseTimeM False defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" tm1
   assertBool "last_active is earlier than expected" $ ts1 >= now
+
+testListClientsIfBackendIsOffline :: HasCallStack => App ()
+testListClientsIfBackendIsOffline = do
+  resourcePool <- asks (.resourcePool)
+  ownDomain <- asString OwnDomain
+  otherDomain <- asString OtherDomain
+  [ownUser1, ownUser2] <- createAndConnectUsers [OwnDomain, OtherDomain]
+  ownClient1 <- objId $ bindResponse (API.addClient ownUser1 def) $ getJSON 201
+  ownClient2 <- objId $ bindResponse (API.addClient ownUser2 def) $ getJSON 201
+  ownUser1Id <- objId ownUser1
+  ownUser2Id <- objId ownUser2
+
+  let c1 =
+        Object
+          ( KeyMap.fromList
+              [ ( Key.fromText $ cs ownUser1Id,
+                  Array $ Vector.fromList [Object (KeyMap.fromList [(Key.fromText (cs "id"), String (cs ownClient1))])]
+                )
+              ]
+          )
+  let c2 =
+        Object
+          ( KeyMap.fromList
+              [ ( Key.fromText $ cs ownUser2Id,
+                  Array $ Vector.fromList [Object (KeyMap.fromList [(Key.fromText (cs "id"), String (cs ownClient2))])]
+                )
+              ]
+          )
+  let expectedResponse =
+        Object
+          ( KeyMap.fromList
+              [ (Key.fromText $ cs ownDomain, c1),
+                (Key.fromText $ cs otherDomain, c2)
+              ]
+          )
+
+  let qualifiedUsers = [ownUser1, ownUser2]
+  bindResponse (listUsersClients ownUser1 qualifiedUsers) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "qualified_user_map" `shouldMatch` expectedResponse
+
+  runCodensity (acquireResources 1 resourcePool) $ \[downBackend] -> do
+    downUser <- runCodensity (startDynamicBackend downBackend mempty) $ \_ -> do
+      do
+        let domains = [ownDomain, otherDomain, downBackend.berDomain]
+        sequence_
+          [ API.createFedConn x (API.FedConn y "full_search")
+            | x <- domains,
+              y <- domains,
+              x /= y
+          ]
+
+      downUser <- randomUser downBackend.berDomain def
+      _downClient <- objId $ bindResponse (API.addClient downUser def) $ getJSON 201
+      connectUsers ownUser1 downUser
+      connectUsers ownUser2 downUser
+
+      pure (downUser)
+    let qualifiedUsersIncludingDownUser = [ownUser1, ownUser2, downUser]
+    bindResponse (listUsersClients ownUser1 qualifiedUsersIncludingDownUser) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      resp.json %. "qualified_user_map" `shouldMatch` expectedResponse

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -920,6 +920,7 @@ type ClientAPI =
     :<|> Named
            "list-clients-bulk@v2"
            ( Summary "List all clients for a set of user ids"
+               :> Description "If a backend is unreachable, the clients from this backend will be omitted from the response"
                :> From 'V2
                :> MakesFederatedCall 'Brig "get-user-clients"
                :> ZUser

--- a/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Brig.hs
@@ -920,7 +920,7 @@ type ClientAPI =
     :<|> Named
            "list-clients-bulk@v2"
            ( Summary "List all clients for a set of user ids"
-               :> Description "If a backend is unreachable, the clients from this backend will be omitted from the response"
+               :> Description "If a backend is unreachable, the clients from that backend will be omitted from the response"
                :> From 'V2
                :> MakesFederatedCall 'Brig "get-user-clients"
                :> ZUser


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-4835

Implementation according to https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/897712162/Use+Case+Fetching+the+clients+of+a+user

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
