### PR TITLE
WPB-1103: Adding relative URLs to swagger docs.

### DIFF
--- a/changelog.d/4-docs/WPB-1103
+++ b/changelog.d/4-docs/WPB-1103
@@ -1,1 +1,1 @@
-Adding relative URLs to Swagger and OpenApi documentation to reflect the API versions.
+Fix: support api versions other than v0 in swagger docs.

--- a/changelog.d/4-docs/WPB-1103
+++ b/changelog.d/4-docs/WPB-1103
@@ -1,0 +1,1 @@
+Adding relative URLs to Swagger and OpenApi documentation to reflect the API versions.

--- a/services/brig/docs/swagger-v0.json
+++ b/services/brig/docs/swagger-v0.json
@@ -1,4 +1,5 @@
 {
+  "basePath": "/v0",
   "definitions": {
     "ASCII": {
       "example": "aGVsbG8",

--- a/services/brig/docs/swagger-v1.json
+++ b/services/brig/docs/swagger-v1.json
@@ -1,4 +1,5 @@
 {
+  "basePath": "/v1",
   "definitions": {
     "ASCII": {
       "example": "aGVsbG8",

--- a/services/brig/docs/swagger-v2.json
+++ b/services/brig/docs/swagger-v2.json
@@ -1,4 +1,5 @@
 {
+  "basePath": "/v2",
   "definitions": {
     "ASCII": {
       "example": "aGVsbG8",

--- a/services/brig/docs/swagger-v3.json
+++ b/services/brig/docs/swagger-v3.json
@@ -1,4 +1,5 @@
 {
+  "basePath": "/v3",
   "definitions": {
     "": {
       "description": "Username to use for authenticating against the given TURN servers",

--- a/services/brig/docs/swagger-v4.json
+++ b/services/brig/docs/swagger-v4.json
@@ -1,4 +1,5 @@
 {
+  "basePath": "/v4",
   "definitions": {
     "": {
       "description": "Username to use for authenticating against the given TURN servers",

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -184,6 +184,7 @@ versionedSwaggerDocsAPI (Just (VersionNumber V5)) =
     )
       & S.info . S.title .~ "Wire-Server API"
       & S.info . S.description ?~ $(embedText =<< makeRelativeToProject "docs/swagger.md")
+      & S.servers .~ [S.Server ("/" <> toUrlPiece V5) Nothing mempty]
       & cleanupSwagger
 versionedSwaggerDocsAPI (Just (VersionNumber V0)) = swaggerPregenUIServer $(pregenSwagger V0)
 versionedSwaggerDocsAPI (Just (VersionNumber V1)) = swaggerPregenUIServer $(pregenSwagger V1)


### PR DESCRIPTION
Adding relative paths to the OpenApi generation code so that it matches with any URL that the server is using.
Adding basePath values to the older swagger files reflecting their versions. This is essentially the same as the OpenApi relative server URLs.

## Checklist

 - [:heavy_check_mark:] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [:heavy_check_mark:] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
