### PR TITLE
WPB-4910 include build timestamp in s3 upload path for test logs

### DIFF
--- a/changelog.d/5-internal/WPB-4910
+++ b/changelog.d/5-internal/WPB-4910
@@ -1,0 +1,1 @@
+Include timestamp in s3 upload path for test logs

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -25,11 +25,11 @@ cleanup() {
 # Copy to the concourse output (indetified by $OUTPUT_DIR) for propagation to
 # following steps.
 copyToAwsS3() {
-    build_uuid=$(./.env/bin/uuidgen)
+    build_ts=$(date +%s)
     if ((UPLOAD_LOGS > 0)); then
         for t in "${tests[@]}"; do
-            echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$build_uuid.log"
-            aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$build_uuid.log"
+            echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$build_ts.log"
+            aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$build_ts.log"
         done
     fi
 }

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -27,8 +27,8 @@ cleanup() {
 copyToAwsS3(){
     if (( UPLOAD_LOGS > 0 )); then
         for t in "${tests[@]}"; do
-            echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION.log"
-            aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION.log"
+            echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$BUILD_NAME.log"
+            aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$BUILD_NAME.log"
         done
     fi
 }

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -28,8 +28,8 @@ copyToAwsS3() {
     build_ts=$(date +%s)
     if ((UPLOAD_LOGS > 0)); then
         for t in "${tests[@]}"; do
-            echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$build_ts.log"
-            aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$build_ts.log"
+            echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION-$build_ts.log"
+            aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION-$build_ts.log"
         done
     fi
 }

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -25,7 +25,7 @@ cleanup() {
 # Copy to the concourse output (indetified by $OUTPUT_DIR) for propagation to
 # following steps.
 copyToAwsS3(){
-    build_uuid = uuidgen
+    build_uuid=$(uuidgen)
     if (( UPLOAD_LOGS > 0 )); then
         for t in "${tests[@]}"; do
             echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$build_uuid.log"

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -27,8 +27,8 @@ cleanup() {
 copyToAwsS3(){
     if (( UPLOAD_LOGS > 0 )); then
         for t in "${tests[@]}"; do
-            echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$BUILD_NAME.log"
-            aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$BUILD_NAME.log"
+            echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$BUILD_ID.log"
+            aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$BUILD_ID.log"
         done
     fi
 }

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -14,7 +14,7 @@ CHART=wire-server
 tests=(integration stern galley cargohold gundeck federator spar brig)
 
 cleanup() {
-    if (( CLEANUP_LOCAL_FILES > 0 )); then
+    if ((CLEANUP_LOCAL_FILES > 0)); then
         for t in "${tests[@]}"; do
             rm -f "stat-$t"
             rm -f "logs-$t"
@@ -24,9 +24,9 @@ cleanup() {
 
 # Copy to the concourse output (indetified by $OUTPUT_DIR) for propagation to
 # following steps.
-copyToAwsS3(){
-    build_uuid=$(uuidgen)
-    if (( UPLOAD_LOGS > 0 )); then
+copyToAwsS3() {
+    build_uuid=$(./.env/bin/uuidgen)
+    if ((UPLOAD_LOGS > 0)); then
         for t in "${tests[@]}"; do
             echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$build_uuid.log"
             aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$build_uuid.log"
@@ -90,7 +90,7 @@ if ((exit_code > 0)); then
         x=$(cat "stat-$t")
         if ((x > 0)); then
             echo "=== (relevant) logs for failed $t-integration ==="
-            "$DIR/integration-logs-relevant-bits.sh" < "logs-$t"
+            "$DIR/integration-logs-relevant-bits.sh" <"logs-$t"
         fi
     done
     summary

--- a/hack/bin/integration-test.sh
+++ b/hack/bin/integration-test.sh
@@ -25,10 +25,11 @@ cleanup() {
 # Copy to the concourse output (indetified by $OUTPUT_DIR) for propagation to
 # following steps.
 copyToAwsS3(){
+    build_uuid = uuidgen
     if (( UPLOAD_LOGS > 0 )); then
         for t in "${tests[@]}"; do
-            echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$BUILD_ID.log"
-            aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$BUILD_ID.log"
+            echo "Copy logs-$t to s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$build_uuid.log"
+            aws s3 cp "logs-$t" "s3://wire-server-test-logs/test-logs-$VERSION/$t-$VERSION/$build_uuid.log"
         done
     fi
 }

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -448,7 +448,6 @@ in
   devEnv = pkgs.buildEnv {
     name = "wire-server-dev-env";
     paths = commonTools ++ [
-      pkgs.libuuid
       pkgs.bash
       pkgs.dash
       (pkgs.haskell-language-server.override { supportedGhcVersions = [ "92" ]; })

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -448,6 +448,7 @@ in
   devEnv = pkgs.buildEnv {
     name = "wire-server-dev-env";
     paths = commonTools ++ [
+      pkgs.libuuid
       pkgs.bash
       pkgs.dash
       (pkgs.haskell-language-server.override { supportedGhcVersions = [ "92" ]; })


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-4910

Results in logs like this:

```
Copy logs-integration to s3://wire-server-test-logs/test-logs-0.0.2-pr.5027/integration-0.0.2-pr.5027-1695992949.log
upload: ./logs-integration to s3://wire-server-test-logs/test-logs-0.0.2-pr.5027/integration-0.0.2-pr.5027-1695992949.log
```

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
