### PR TITLE
[WPB-1908] Unverified user creating conversation

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-1908-guest-creating-conversation
+++ b/changelog.d/3-bug-fixes/WPB-1908-guest-creating-conversation
@@ -1,0 +1,1 @@
+Disable a guest user from creating a group conversation

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -689,3 +689,10 @@ testUpdateConversationByRemoteAdmin = do
   void $ withWebSockets [alice, bob, charlie] $ \wss -> do
     void $ updateReceiptMode bob conv (41 :: Int) >>= getBody 200
     for_ wss $ \ws -> awaitMatch 10 isReceiptModeUpdateNotif ws
+
+testGuestCreatesConversation :: HasCallStack => App ()
+testGuestCreatesConversation = do
+  alice <- randomUser OwnDomain def {activate = False}
+  bindResponse (postConversation alice defProteus) $ \resp -> do
+    resp.status `shouldMatchInt` 403
+    resp.json %. "label" `shouldMatch` "operation-denied"

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -52,6 +52,7 @@ import Galley.App (Env)
 import Galley.Data.Conversation qualified as Data
 import Galley.Data.Conversation.Types
 import Galley.Effects
+import Galley.Effects.BrigAccess
 import Galley.Effects.ConversationStore qualified as E
 import Galley.Effects.FederatorAccess qualified as E
 import Galley.Effects.GundeckAccess qualified as E
@@ -262,7 +263,9 @@ checkCreateConvPermissions ::
   Maybe ConvTeamInfo ->
   UserList UserId ->
   Sem r ()
-checkCreateConvPermissions lusr _newConv Nothing allUsers =
+checkCreateConvPermissions lusr _newConv Nothing allUsers = do
+  activated <- listToMaybe <$> lookupActivatedUsers [tUnqualified lusr]
+  void $ noteS @OperationDenied activated
   ensureConnected lusr allUsers
 checkCreateConvPermissions lusr newConv (Just tinfo) allUsers = do
   let convTeam = cnvTeamId tinfo


### PR DESCRIPTION
Make sure an unverified (guest) user cannot create a group conversation.

Tracked by https://wearezeta.atlassian.net/browse/WPB-1908.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
