### PR TITLE
Add rules on testing to github PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,6 @@
 ## Checklist
 
  - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
+ - [ ] All changes in this PR are covered by unit tests
+ - [ ] All changes in this PR are covered by integration tests
  - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)


### PR DESCRIPTION
This is a follow-up on our discussion on unit testing in the last C&D.

I propose to add testing check boxes to the checklist below.  Like with the changelog item, you can try to convince the reviewer that you didn't check them.  But it will at least keep it in front of our minds during PR creation that we want unit tests.

No need for a changelog entry.  :)

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
