### PR TITLE
Helm: Push rabbitmq-external to Helm repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CHARTS_INTEGRATION    := wire-server databases-ephemeral redis-cluster rabbitmq 
 # (e.g. move charts/brig to charts/wire-server/brig)
 # this list could be generated from the folder names under ./charts/ like so:
 # CHARTS_RELEASE := $(shell find charts/ -maxdepth 1 -type d | xargs -n 1 basename | grep -v charts)
-CHARTS_RELEASE := wire-server redis-ephemeral redis-cluster rabbitmq databases-ephemeral	\
+CHARTS_RELEASE := wire-server redis-ephemeral redis-cluster rabbitmq rabbitmq-external databases-ephemeral	\
 fake-aws fake-aws-s3 fake-aws-sqs aws-ingress fluent-bit kibana backoffice		\
 calling-test demo-smtp elasticsearch-curator elasticsearch-external				\
 elasticsearch-ephemeral minio-external cassandra-external						\

--- a/changelog.d/2-features/rabbitmq-external_helm_chart
+++ b/changelog.d/2-features/rabbitmq-external_helm_chart
@@ -1,0 +1,1 @@
+Add Helm chart (`rabbitmq-external`) to interface RabbitMQ instances outside of the Kubernetes cluster.


### PR DESCRIPTION
Otherwise, it's not available in deployments, CI pipelines, etc..

## Checklist

 - [X] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [X] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
