### PR TITLE
[WPB-3867] Use queueing federation client for a federation API endpoint

### DIFF
--- a/changelog.d/6-federation/wpb-3867-queue-endpoints
+++ b/changelog.d/6-federation/wpb-3867-queue-endpoints
@@ -1,0 +1,1 @@
+Constrain which federation endpoints can be used via the queueing federation client

--- a/changelog.d/6-federation/wpb-3867-unreachable-users
+++ b/changelog.d/6-federation/wpb-3867-unreachable-users
@@ -1,0 +1,1 @@
+There is a breaking change in the "on-mls-message-sent" federation endpoint due to queueing. Now that there is retrying because of queueing, the endpoint can no longer respond with a list of unreachable users.

--- a/libs/wire-api-federation/src/Wire/API/Federation/API.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API.hs
@@ -37,10 +37,12 @@ import Data.Kind
 import Data.Proxy
 import GHC.TypeLits
 import Imports
+import Servant
 import Servant.Client
 import Servant.Client.Core
 import Wire.API.Federation.API.Brig
 import Wire.API.Federation.API.Cargohold
+import Wire.API.Federation.API.Common
 import Wire.API.Federation.API.Galley
 import Wire.API.Federation.BackendNotifications
 import Wire.API.Federation.Client
@@ -64,6 +66,20 @@ type HasFedEndpoint comp api name = (HasUnsafeFedEndpoint comp api name)
 -- you to forget about some federated calls.
 type HasUnsafeFedEndpoint comp api name = 'Just api ~ LookupEndpoint (FedApi comp) name
 
+-- | Constrains which endpoints can be used with FedQueueClient.
+--
+-- Since the servant client implementation underlying FedQueueClient is
+-- returning a "fake" response consisting of an empty object, we need to make
+-- sure that an API type is compatible with an empty response if we want to
+-- invoke it using `fedQueueClient`
+class HasEmptyResponse api
+
+instance HasEmptyResponse (Post '[JSON] EmptyResponse)
+
+instance HasEmptyResponse api => HasEmptyResponse (x :> api)
+
+instance HasEmptyResponse api => HasEmptyResponse (Named name api)
+
 -- | Return a client for a named endpoint.
 --
 -- This function introduces an 'AddAnnotation' constraint, which is
@@ -79,7 +95,11 @@ fedClient = clientIn (Proxy @api) (Proxy @m)
 
 fedQueueClient ::
   forall (comp :: Component) (name :: Symbol) m api.
-  (HasFedEndpoint comp api name, HasClient m api, m ~ FedQueueClient comp) =>
+  ( HasEmptyResponse api,
+    HasFedEndpoint comp api name,
+    HasClient m api,
+    m ~ FedQueueClient comp
+  ) =>
   Client m api
 fedQueueClient = clientIn (Proxy @api) (Proxy @m)
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -40,7 +40,6 @@ import Wire.API.MLS.SubConversation
 import Wire.API.MakesFederatedCall
 import Wire.API.Message
 import Wire.API.Routes.Public.Galley.Messaging
-import Wire.API.Unreachable
 import Wire.API.Util.Aeson (CustomEncoded (..), CustomEncodedLensable (..))
 import Wire.Arbitrary (Arbitrary, GenericUniform (..))
 
@@ -97,7 +96,7 @@ type GalleyApi =
            ConversationUpdateRequest
            ConversationUpdateResponse
     :<|> FedEndpoint "mls-welcome" MLSWelcomeRequest MLSWelcomeResponse
-    :<|> FedEndpoint "on-mls-message-sent" RemoteMLSMessage RemoteMLSMessageResponse
+    :<|> FedEndpoint "on-mls-message-sent" RemoteMLSMessage EmptyResponse
     :<|> FedEndpointWithMods
            '[ MakesFederatedCall 'Galley "on-conversation-updated",
               MakesFederatedCall 'Galley "on-mls-message-sent",
@@ -419,7 +418,7 @@ data MLSMessageResponse
     MLSMessageResponseUnreachableBackends (Set Domain)
   | -- | If the list of unreachable users is non-empty, it corresponds to users
     -- that an application message could not be sent to.
-    MLSMessageResponseUpdates [ConversationUpdate] (Maybe UnreachableUsers)
+    MLSMessageResponseUpdates [ConversationUpdate]
   | MLSMessageResponseNonFederatingBackends NonFederatingBackends
   deriving stock (Eq, Show, Generic)
   deriving (ToJSON, FromJSON) via (CustomEncoded MLSMessageResponse)

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -799,8 +799,8 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
 
   update <-
     fmap (fromMaybe (mkUpdate []))
-      . (>>= either handleError (pure . asum . map tUnqualified))
-      . enqueueNotificationsConcurrently Q.Persistent (toList (bmRemotes targets))
+      . (either handleError (pure . asum . map tUnqualified))
+      <=< enqueueNotificationsConcurrently Q.Persistent (toList (bmRemotes targets))
       $ \ruids -> do
         let update = mkUpdate (tUnqualified ruids)
         -- if notifyOrigDomain is false, filter out user from quid's domain,
@@ -816,7 +816,6 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
   -- return both the event and the 'ConversationUpdate' structure corresponding
   -- to the originating domain (if it is remote)
   pure $ LocalConversationUpdate e update
-  where
 
 -- | Update the local database with information on conversation members joining
 -- or leaving. Finally, push out notifications to local users.

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -786,19 +786,22 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
   now <- input
   let lcnv = fmap (.convId) lconv
       e = conversationActionToEvent tag now quid (tUntagged lcnv) Nothing action
-
-  let mkUpdate uids =
+      mkUpdate uids =
         ConversationUpdate
           now
           quid
           (tUnqualified lcnv)
           uids
           (SomeConversationAction tag action)
+      handleError :: FederationError -> Sem r (Maybe ConversationUpdate)
+      handleError fedErr =
+        logRemoteNotificationError @"on-conversation-updated" fedErr $> Nothing
 
-  update <- do
-    let remoteTargets = toList (bmRemotes targets)
-    updates <-
-      enqueueNotificationsConcurrently Q.Persistent remoteTargets $ \ruids -> do
+  update <-
+    fmap (fromMaybe (mkUpdate []))
+      . (>>= either handleError (pure . asum . map tUnqualified))
+      . enqueueNotificationsConcurrently Q.Persistent (toList (bmRemotes targets))
+      $ \ruids -> do
         let update = mkUpdate (tUnqualified ruids)
         -- if notifyOrigDomain is false, filter out user from quid's domain,
         -- because quid's backend will update local state and notify its users
@@ -806,13 +809,6 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
         if notifyOrigDomain || tDomain ruids /= qDomain quid
           then fedQueueClient @'Galley @"on-conversation-updated" update $> Nothing
           else pure (Just update)
-    case partitionEithers updates of
-      (ls :: [Remote ([UserId], FederationError)], rs) -> do
-        for_ ls $
-          logError
-            "on-conversation-updated"
-            "An error occurred while communicating with federated server: "
-        pure $ fromMaybe (mkUpdate []) . asum . map tUnqualified $ rs
 
   -- notify local participants and bots
   pushConversationEvent con e (qualifyAs lcnv (bmLocals targets)) (bmBots targets)
@@ -821,12 +817,6 @@ notifyConversationAction tag quid notifyOrigDomain con lconv targets action = do
   -- to the originating domain (if it is remote)
   pure $ LocalConversationUpdate e update
   where
-    logError :: String -> String -> Remote (a, FederationError) -> Sem r ()
-    logError field msg e =
-      P.warn $
-        Log.field "federation call" field
-          . Log.field "domain" (_domainText (tDomain e))
-          . Log.msg (msg <> displayException (snd (tUnqualified e)))
 
 -- | Update the local database with information on conversation members joining
 -- or leaving. Finally, push out notifications to local users.

--- a/services/galley/src/Galley/API/Util.hs
+++ b/services/galley/src/Galley/API/Util.hs
@@ -37,6 +37,7 @@ import Data.Set qualified as Set
 import Data.Singletons
 import Data.Text qualified as T
 import Data.Time
+import GHC.TypeLits
 import Galley.API.Error
 import Galley.API.Mapping
 import Galley.Data.Conversation qualified as Data
@@ -67,6 +68,7 @@ import Polysemy
 import Polysemy.Error
 import Polysemy.Input
 import Polysemy.TinyLog qualified as P
+import System.Logger qualified as Log
 import Wire.API.Connection
 import Wire.API.Conversation hiding (Member, cnvAccess, cnvAccessRoles, cnvName, cnvType)
 import Wire.API.Conversation qualified as Public
@@ -1008,3 +1010,13 @@ instance
     if err' == demote @e
       then throwS @e
       else rethrowErrors @effs @r err'
+
+logRemoteNotificationError ::
+  forall rpc r.
+  (Member P.TinyLog r, KnownSymbol rpc) =>
+  FederationError ->
+  Sem r ()
+logRemoteNotificationError e =
+  P.warn $
+    Log.field "federation call" (symbolVal (Proxy @rpc))
+      . Log.msg (displayException e)

--- a/services/galley/src/Galley/Effects/BackendNotificationQueueAccess.hs
+++ b/services/galley/src/Galley/Effects/BackendNotificationQueueAccess.hs
@@ -22,6 +22,6 @@ data BackendNotificationQueueAccess m a where
     Q.DeliveryMode ->
     f (Remote x) ->
     (Remote [x] -> FedQueueClient c a) ->
-    BackendNotificationQueueAccess m [Either (Remote ([x], FederationError)) (Remote a)]
+    BackendNotificationQueueAccess m (Either FederationError [Remote a])
 
 makeSem ''BackendNotificationQueueAccess

--- a/services/galley/test/integration/API/MLS/Mocks.hs
+++ b/services/galley/test/integration/API/MLS/Mocks.hs
@@ -80,7 +80,6 @@ sendMessageMock =
   "send-mls-message" ~>
     MLSMessageResponseUpdates
       []
-      mempty
 
 claimKeyPackagesMock :: KeyPackageBundle -> Mock LByteString
 claimKeyPackagesMock kpb = "claim-key-packages" ~> kpb


### PR DESCRIPTION
This ports changes from the MLS branch to `develop`. The changes are in using the queueing federation client for the `"on-mls-message-sent"` federation endpoint.

Tracked by https://wearezeta.atlassian.net/browse/WPB-3867.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
