### PR TITLE
Align connectUsers to mls branch

### DIFF
--- a/integration/test/SetupHelpers.hs
+++ b/integration/test/SetupHelpers.hs
@@ -64,7 +64,7 @@ createTeamMember inviter tid = do
       <&> addJSONObject registerJSON
   getJSON 201 =<< submit "POST" registerReq
 
-connectUsers2 ::
+connectTwoUsers ::
   ( HasCallStack,
     MakesValue alice,
     MakesValue bob
@@ -72,12 +72,12 @@ connectUsers2 ::
   alice ->
   bob ->
   App ()
-connectUsers2 alice bob = do
+connectTwoUsers alice bob = do
   bindResponse (Brig.postConnection alice bob) (\resp -> resp.status `shouldMatchInt` 201)
   bindResponse (Brig.putConnection bob alice "accepted") (\resp -> resp.status `shouldMatchInt` 200)
 
 connectUsers :: HasCallStack => [Value] -> App ()
-connectUsers users = traverse_ (uncurry connectUsers2) $ do
+connectUsers users = traverse_ (uncurry connectTwoUsers) $ do
   t <- tails users
   (a, others) <- maybeToList (uncons t)
   b <- others

--- a/integration/test/Test/AccessUpdate.hs
+++ b/integration/test/Test/AccessUpdate.hs
@@ -37,7 +37,7 @@ testAccessUpdateGuestRemoved = do
   (alice, tid, [bob]) <- createTeam OwnDomain 2
   charlie <- randomUser OwnDomain def
   dee <- randomUser OtherDomain def
-  mapM_ (connectUsers2 alice) [charlie, dee]
+  mapM_ (connectTwoUsers alice) [charlie, dee]
   [aliceClient, bobClient, charlieClient, deeClient] <-
     mapM
       (\user -> objId $ bindResponse (addClient user def) $ getJSON 201)
@@ -70,7 +70,7 @@ testAccessUpdateGuestRemovedUnreachableRemotes = do
   resourcePool <- asks resourcePool
   (alice, tid, [bob]) <- createTeam OwnDomain 2
   charlie <- randomUser OwnDomain def
-  connectUsers2 alice charlie
+  connectTwoUsers alice charlie
   [aliceClient, bobClient, charlieClient] <-
     mapM
       (\user -> objId $ bindResponse (addClient user def) $ getJSON 201)
@@ -78,7 +78,7 @@ testAccessUpdateGuestRemovedUnreachableRemotes = do
   (conv, dee) <- runCodensity (acquireResources 1 resourcePool) $ \[dynBackend] ->
     runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
       dee <- randomUser dynBackend.berDomain def
-      connectUsers2 alice dee
+      connectTwoUsers alice dee
       conv <-
         postConversation
           alice
@@ -104,8 +104,8 @@ testAccessUpdateGuestRemovedUnreachableRemotes = do
 testAccessUpdateWithRemotes :: HasCallStack => App ()
 testAccessUpdateWithRemotes = do
   [alice, bob, charlie] <- createUsers [OwnDomain, OtherDomain, OwnDomain]
-  connectUsers2 alice bob
-  connectUsers2 alice charlie
+  connectTwoUsers alice bob
+  connectTwoUsers alice charlie
   conv <-
     postConversation alice (defProteus {qualifiedUsers = [bob, charlie]})
       >>= getJSON 201

--- a/integration/test/Test/AccessUpdate.hs
+++ b/integration/test/Test/AccessUpdate.hs
@@ -37,7 +37,7 @@ testAccessUpdateGuestRemoved = do
   (alice, tid, [bob]) <- createTeam OwnDomain 2
   charlie <- randomUser OwnDomain def
   dee <- randomUser OtherDomain def
-  mapM_ (connectUsers alice) [charlie, dee]
+  mapM_ (connectUsers2 alice) [charlie, dee]
   [aliceClient, bobClient, charlieClient, deeClient] <-
     mapM
       (\user -> objId $ bindResponse (addClient user def) $ getJSON 201)
@@ -70,7 +70,7 @@ testAccessUpdateGuestRemovedUnreachableRemotes = do
   resourcePool <- asks resourcePool
   (alice, tid, [bob]) <- createTeam OwnDomain 2
   charlie <- randomUser OwnDomain def
-  connectUsers alice charlie
+  connectUsers2 alice charlie
   [aliceClient, bobClient, charlieClient] <-
     mapM
       (\user -> objId $ bindResponse (addClient user def) $ getJSON 201)
@@ -78,7 +78,7 @@ testAccessUpdateGuestRemovedUnreachableRemotes = do
   (conv, dee) <- runCodensity (acquireResources 1 resourcePool) $ \[dynBackend] ->
     runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
       dee <- randomUser dynBackend.berDomain def
-      connectUsers alice dee
+      connectUsers2 alice dee
       conv <-
         postConversation
           alice
@@ -104,8 +104,8 @@ testAccessUpdateGuestRemovedUnreachableRemotes = do
 testAccessUpdateWithRemotes :: HasCallStack => App ()
 testAccessUpdateWithRemotes = do
   [alice, bob, charlie] <- createUsers [OwnDomain, OtherDomain, OwnDomain]
-  connectUsers alice bob
-  connectUsers alice charlie
+  connectUsers2 alice bob
+  connectUsers2 alice charlie
   conv <-
     postConversation alice (defProteus {qualifiedUsers = [bob, charlie]})
       >>= getJSON 201

--- a/integration/test/Test/Client.hs
+++ b/integration/test/Test/Client.hs
@@ -46,7 +46,7 @@ testListClientsIfBackendIsOffline = do
   resourcePool <- asks (.resourcePool)
   ownDomain <- asString OwnDomain
   otherDomain <- asString OtherDomain
-  (ownUser1, ownUser2) <- createAndConnectUsers OwnDomain OtherDomain
+  [ownUser1, ownUser2] <- createAndConnectUsers [OwnDomain, OtherDomain]
   ownClient1 <- objId $ bindResponse (API.addClient ownUser1 def) $ getJSON 201
   ownClient2 <- objId $ bindResponse (API.addClient ownUser2 def) $ getJSON 201
   ownUser1Id <- objId ownUser1

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -140,8 +140,8 @@ testCreateConversationFullyConnected :: HasCallStack => App ()
 testCreateConversationFullyConnected = do
   startDynamicBackends [def, def, def] $ \[domainA, domainB, domainC] -> do
     [u1, u2, u3] <- createUsers [domainA, domainB, domainC]
-    connectUsers u1 u2
-    connectUsers u1 u3
+    connectUsers2 u1 u2
+    connectUsers2 u1 u3
     bindResponse (postConversation u1 (defProteus {qualifiedUsers = [u2, u3]})) $ \resp -> do
       resp.status `shouldMatchInt` 201
 
@@ -158,8 +158,8 @@ testCreateConversationNonFullyConnected = do
     u1 <- randomUser domainA def
     u2 <- randomUser domainB def
     u3 <- randomUser domainC def
-    connectUsers u1 u2
-    connectUsers u1 u3
+    connectUsers2 u1 u2
+    connectUsers2 u1 u3
 
     bindResponse (postConversation u1 (defProteus {qualifiedUsers = [u2, u3]})) $ \resp -> do
       resp.status `shouldMatchInt` 409
@@ -169,8 +169,8 @@ testAddMembersFullyConnectedProteus :: HasCallStack => App ()
 testAddMembersFullyConnectedProteus = do
   startDynamicBackends [def, def, def] $ \[domainA, domainB, domainC] -> do
     [u1, u2, u3] <- createUsers [domainA, domainB, domainC]
-    connectUsers u1 u2
-    connectUsers u1 u3
+    connectUsers2 u1 u2
+    connectUsers2 u1 u3
     -- create conversation with no users
     cid <- postConversation u1 (defProteus {qualifiedUsers = []}) >>= getJSON 201
     -- add members from remote backends
@@ -194,8 +194,8 @@ testAddMembersNonFullyConnectedProteus = do
     u1 <- randomUser domainA def
     u2 <- randomUser domainB def
     u3 <- randomUser domainC def
-    connectUsers u1 u2
-    connectUsers u1 u3
+    connectUsers2 u1 u2
+    connectUsers2 u1 u3
 
     -- create conversation with no users
     cid <- postConversation u1 (defProteus {qualifiedUsers = []}) >>= getJSON 201
@@ -217,7 +217,7 @@ testAddMember = do
   bindResponse addMember $ \resp -> do
     resp.status `shouldMatchInt` 403
     resp.json %. "label" `shouldMatch` "not-connected"
-  connectUsers alice bob
+  connectUsers2 alice bob
   bindResponse addMember $ \resp -> do
     resp.status `shouldMatchInt` 200
     resp.json %. "type" `shouldMatch` "conversation.member-join"
@@ -244,7 +244,7 @@ testAddMember = do
 
 testAddMemberV1 :: HasCallStack => Domain -> App ()
 testAddMemberV1 domain = do
-  (alice, bob) <- createAndConnectUsers OwnDomain domain
+  [alice, bob] <- createAndConnectUsers [OwnDomain, domain]
   conv <- postConversation alice defProteus >>= getJSON 201
   bobId <- bob %. "qualified_id"
   let opts =
@@ -268,7 +268,7 @@ testConvWithUnreachableRemoteUsers = do
       own <- make OwnDomain & asString
       other <- make OtherDomain & asString
       users@(alice : others) <- createUsers $ [own, own, other] <> domains
-      forM_ others $ connectUsers alice
+      forM_ others $ connectUsers2 alice
       pure (users, domains)
 
   let newConv = defProteus {qualifiedUsers = [alex, bob, charlie, dylan]}
@@ -287,11 +287,11 @@ testAddReachableWithUnreachableRemoteUsers = do
       own <- make OwnDomain & asString
       other <- make OtherDomain & asString
       [alice, alex, bob, charlie, dylan] <- createUsers $ [own, own, other] <> domains
-      forM_ [alex, bob, charlie, dylan] $ connectUsers alice
+      forM_ [alex, bob, charlie, dylan] $ connectUsers2 alice
 
       let newConv = defProteus {qualifiedUsers = [alex, charlie, dylan]}
       conv <- postConversation alice newConv >>= getJSON 201
-      connectUsers alex bob
+      connectUsers2 alex bob
       pure ([alex, bob], conv, domains)
 
   bobId <- bob %. "qualified_id"
@@ -310,11 +310,11 @@ testAddUnreachable = do
     startDynamicBackends [def, def] $ \domains -> do
       own <- make OwnDomain & asString
       [alice, alex, charlie, dylan] <- createUsers $ [own, own] <> domains
-      forM_ [alex, charlie, dylan] $ connectUsers alice
+      forM_ [alex, charlie, dylan] $ connectUsers2 alice
 
       let newConv = defProteus {qualifiedUsers = [alex, dylan]}
       conv <- postConversation alice newConv >>= getJSON 201
-      connectUsers alex charlie
+      connectUsers2 alex charlie
       pure ([alex, charlie], domains, conv)
 
   charlieId <- charlie %. "qualified_id"
@@ -344,7 +344,7 @@ testAddingUserNonFullyConnectedFederation = do
     charlie <- randomUser dynBackend def
     -- We use retryT here so the dynamic federated connection changes can take
     -- some time to be propagated. Remove after fixing https://wearezeta.atlassian.net/browse/WPB-3797
-    mapM_ (retryT . connectUsers alice) [bob, charlie]
+    mapM_ (retryT . connectUsers2 alice) [bob, charlie]
 
     let newConv = defProteus {qualifiedUsers = []}
     conv <- postConversation alice newConv >>= getJSON 201
@@ -445,7 +445,7 @@ testAddUserWhenOtherBackendOffline = do
     startDynamicBackends [def] $ \domains -> do
       own <- make OwnDomain & asString
       [alice, alex, charlie] <- createUsers $ [own, own] <> domains
-      forM_ [alex, charlie] $ connectUsers alice
+      forM_ [alex, charlie] $ connectUsers2 alice
 
       let newConv = defProteus {qualifiedUsers = [charlie]}
       conv <- postConversation alice newConv >>= getJSON 201
@@ -456,13 +456,13 @@ testAddUserWhenOtherBackendOffline = do
 testSynchroniseUserRemovalNotification :: HasCallStack => App ()
 testSynchroniseUserRemovalNotification = do
   resourcePool <- asks resourcePool
-  (alice, bob) <- createAndConnectUsers OwnDomain OtherDomain
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OtherDomain]
   runCodensity (acquireResources 1 resourcePool) $ \[dynBackend] -> do
     (conv, charlie, client) <-
       runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
         charlie <- randomUser dynBackend.berDomain def
         client <- objId $ bindResponse (addClient charlie def) $ getJSON 201
-        mapM_ (connectUsers charlie) [alice, bob]
+        mapM_ (connectUsers2 charlie) [alice, bob]
         conv <-
           postConversation alice (defProteus {qualifiedUsers = [bob, charlie]})
             >>= getJSON 201
@@ -482,7 +482,7 @@ testSynchroniseUserRemovalNotification = do
 
 testConvRenaming :: HasCallStack => App ()
 testConvRenaming = do
-  (alice, bob) <- createAndConnectUsers OwnDomain OtherDomain
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OtherDomain]
   conv <-
     postConversation alice (defProteus {qualifiedUsers = [bob]})
       >>= getJSON 201
@@ -496,7 +496,7 @@ testConvRenaming = do
 
 testReceiptModeWithRemotesOk :: HasCallStack => App ()
 testReceiptModeWithRemotesOk = do
-  (alice, bob) <- createAndConnectUsers OwnDomain OtherDomain
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OtherDomain]
   conv <-
     postConversation alice (defProteus {qualifiedUsers = [bob]})
       >>= getJSON 201
@@ -514,7 +514,7 @@ testReceiptModeWithRemotesUnreachable = do
   alice <- randomUser ownDomain def
   conv <- startDynamicBackends [mempty] $ \[dynBackend] -> do
     bob <- randomUser dynBackend def
-    connectUsers alice bob
+    connectUsers2 alice bob
     postConversation alice (defProteus {qualifiedUsers = [bob]})
       >>= getJSON 201
   withWebSocket alice $ \ws -> do
@@ -527,8 +527,8 @@ testReceiptModeWithRemotesUnreachable = do
 testDeleteLocalMember :: HasCallStack => App ()
 testDeleteLocalMember = do
   [alice, alex, bob] <- createUsers [OwnDomain, OwnDomain, OtherDomain]
-  connectUsers alice alex
-  connectUsers alice bob
+  connectUsers2 alice alex
+  connectUsers2 alice bob
   conv <-
     postConversation alice (defProteus {qualifiedUsers = [alex, bob]})
       >>= getJSON 201
@@ -546,8 +546,8 @@ testDeleteLocalMember = do
 testDeleteRemoteMember :: HasCallStack => App ()
 testDeleteRemoteMember = do
   [alice, alex, bob] <- createUsers [OwnDomain, OwnDomain, OtherDomain]
-  connectUsers alice alex
-  connectUsers alice bob
+  connectUsers2 alice alex
+  connectUsers2 alice bob
   conv <-
     postConversation alice (defProteus {qualifiedUsers = [alex, bob]})
       >>= getJSON 201
@@ -567,9 +567,9 @@ testDeleteRemoteMemberRemoteUnreachable = do
   [alice, bob, bart] <- createUsers [OwnDomain, OtherDomain, OtherDomain]
   conv <- startDynamicBackends [mempty] $ \[dynBackend] -> do
     charlie <- randomUser dynBackend def
-    connectUsers alice bob
-    connectUsers alice bart
-    connectUsers alice charlie
+    connectUsers2 alice bob
+    connectUsers2 alice bart
+    connectUsers2 alice charlie
     postConversation
       alice
       (defProteus {qualifiedUsers = [bob, bart, charlie]})
@@ -591,7 +591,7 @@ testDeleteTeamConversationWithRemoteMembers = do
   (alice, team, _) <- createTeam OwnDomain 1
   conv <- postConversation alice (defProteus {team = Just team}) >>= getJSON 201
   bob <- randomUser OtherDomain def
-  connectUsers alice bob
+  connectUsers2 alice bob
   mem <- bob %. "qualified_id"
   void $ addMembers alice conv def {users = [mem]} >>= getBody 200
 
@@ -617,7 +617,7 @@ testDeleteTeamConversationWithUnreachableRemoteMembers = do
     (bob, bobClient) <- runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
       bob <- randomUser dynBackend.berDomain def
       bobClient <- objId $ bindResponse (addClient bob def) $ getJSON 201
-      connectUsers alice bob
+      connectUsers2 alice bob
       mem <- bob %. "qualified_id"
       void $ addMembers alice conv def {users = [mem]} >>= getBody 200
       pure (bob, bobClient)
@@ -637,7 +637,7 @@ testLeaveConversationSuccess = do
   startDynamicBackends [def] $ \[dynDomain] -> do
     eve <- randomUser dynDomain def
     eClient <- objId $ bindResponse (addClient eve def) $ getJSON 201
-    forM_ [bob, chad, dee, eve] $ connectUsers alice
+    forM_ [bob, chad, dee, eve] $ connectUsers2 alice
     conv <-
       postConversation
         alice
@@ -656,7 +656,7 @@ testOnUserDeletedConversations = do
   startDynamicBackends [def] $ \[dynDomain] -> do
     [ownDomain, otherDomain] <- forM [OwnDomain, OtherDomain] asString
     [alice, alex, bob, bart, chad] <- createUsers [ownDomain, ownDomain, otherDomain, otherDomain, dynDomain]
-    forM_ [alex, bob, bart, chad] $ connectUsers alice
+    forM_ [alex, bob, bart, chad] $ connectUsers2 alice
     bobId <- bob %. "qualified_id"
     ooConvId <- do
       l <- getAllConvs alice
@@ -693,8 +693,8 @@ testOnUserDeletedConversations = do
 testUpdateConversationByRemoteAdmin :: HasCallStack => App ()
 testUpdateConversationByRemoteAdmin = do
   [alice, bob, charlie] <- createUsers [OwnDomain, OtherDomain, OtherDomain]
-  connectUsers alice bob
-  connectUsers alice charlie
+  connectUsers2 alice bob
+  connectUsers2 alice charlie
   conv <-
     postConversation alice (defProteus {qualifiedUsers = [bob, charlie]})
       >>= getJSON 201

--- a/integration/test/Test/Demo.hs
+++ b/integration/test/Test/Demo.hs
@@ -145,7 +145,7 @@ testIndependentESIndices = do
   u1 <- randomUser OwnDomain def
   u2 <- randomUser OwnDomain def
   uid2 <- objId u2
-  connectUsers2 u1 u2
+  connectTwoUsers u1 u2
   BrigI.refreshIndex OwnDomain
   bindResponse (BrigP.searchContacts u1 (u2 %. "name") OwnDomain) $ \resp -> do
     resp.status `shouldMatchInt` 200
@@ -163,7 +163,7 @@ testIndependentESIndices = do
       null docs `shouldMatch` True
     uD2 <- randomUser dynDomain def
     uidD2 <- objId uD2
-    connectUsers2 uD1 uD2
+    connectTwoUsers uD1 uD2
     BrigI.refreshIndex dynDomain
     -- searching for uD2 on the dyn backend should yield a result
     bindResponse (BrigP.searchContacts uD1 (uD2 %. "name") dynDomain) $ \resp -> do

--- a/integration/test/Test/Demo.hs
+++ b/integration/test/Test/Demo.hs
@@ -145,7 +145,7 @@ testIndependentESIndices = do
   u1 <- randomUser OwnDomain def
   u2 <- randomUser OwnDomain def
   uid2 <- objId u2
-  connectUsers u1 u2
+  connectUsers2 u1 u2
   BrigI.refreshIndex OwnDomain
   bindResponse (BrigP.searchContacts u1 (u2 %. "name") OwnDomain) $ \resp -> do
     resp.status `shouldMatchInt` 200
@@ -163,7 +163,7 @@ testIndependentESIndices = do
       null docs `shouldMatch` True
     uD2 <- randomUser dynDomain def
     uidD2 <- objId uD2
-    connectUsers uD1 uD2
+    connectUsers2 uD1 uD2
     BrigI.refreshIndex dynDomain
     -- searching for uD2 on the dyn backend should yield a result
     bindResponse (BrigP.searchContacts uD1 (uD2 %. "name") dynDomain) $ \resp -> do
@@ -176,7 +176,7 @@ testIndependentESIndices = do
 testDynamicBackendsFederation :: HasCallStack => App ()
 testDynamicBackendsFederation = do
   startDynamicBackends [def, def] $ \[aDynDomain, anotherDynDomain] -> do
-    (u1, u2) <- createAndConnectUsers aDynDomain anotherDynDomain
+    [u1, u2] <- createAndConnectUsers [aDynDomain, anotherDynDomain]
     bindResponse (BrigP.getConnection u1 u2) assertSuccess
     bindResponse (BrigP.getConnection u2 u1) assertSuccess
 

--- a/integration/test/Test/Federation.hs
+++ b/integration/test/Test/Federation.hs
@@ -34,11 +34,11 @@ testNotificationsForOfflineBackends = do
       downUser2 <- randomUser downBackend.berDomain def
       downClient1 <- objId $ bindResponse (BrigP.addClient downUser1 def) $ getJSON 201
 
-      connectUsers delUser otherUser
-      connectUsers delUser otherUser2
-      connectUsers delUser downUser1
-      connectUsers delUser downUser2
-      connectUsers downUser1 otherUser
+      connectUsers2 delUser otherUser
+      connectUsers2 delUser otherUser2
+      connectUsers2 delUser downUser1
+      connectUsers2 delUser downUser2
+      connectUsers2 downUser1 otherUser
 
       upBackendConv <- bindResponse (postConversation delUser (defProteus {qualifiedUsers = [otherUser, otherUser2, downUser1]})) $ getJSON 201
       downBackendConv <- bindResponse (postConversation downUser1 (defProteus {qualifiedUsers = [otherUser, delUser]})) $ getJSON 201
@@ -79,7 +79,7 @@ testNotificationsForOfflineBackends = do
       -- however, if the backend of the user to be added is already part of the conversation, we do not need to do the check
       -- and the user can be added as long as the backend is reachable
       otherUser3 <- randomUser OtherDomain def
-      connectUsers delUser otherUser3
+      connectUsers2 delUser otherUser3
       bindResponse (addMembers delUser upBackendConv def {users = [otherUser3]}) $ \resp ->
         resp.status `shouldMatchInt` 200
 

--- a/integration/test/Test/Federation.hs
+++ b/integration/test/Test/Federation.hs
@@ -34,11 +34,11 @@ testNotificationsForOfflineBackends = do
       downUser2 <- randomUser downBackend.berDomain def
       downClient1 <- objId $ bindResponse (BrigP.addClient downUser1 def) $ getJSON 201
 
-      connectUsers2 delUser otherUser
-      connectUsers2 delUser otherUser2
-      connectUsers2 delUser downUser1
-      connectUsers2 delUser downUser2
-      connectUsers2 downUser1 otherUser
+      connectTwoUsers delUser otherUser
+      connectTwoUsers delUser otherUser2
+      connectTwoUsers delUser downUser1
+      connectTwoUsers delUser downUser2
+      connectTwoUsers downUser1 otherUser
 
       upBackendConv <- bindResponse (postConversation delUser (defProteus {qualifiedUsers = [otherUser, otherUser2, downUser1]})) $ getJSON 201
       downBackendConv <- bindResponse (postConversation downUser1 (defProteus {qualifiedUsers = [otherUser, delUser]})) $ getJSON 201
@@ -79,7 +79,7 @@ testNotificationsForOfflineBackends = do
       -- however, if the backend of the user to be added is already part of the conversation, we do not need to do the check
       -- and the user can be added as long as the backend is reachable
       otherUser3 <- randomUser OtherDomain def
-      connectUsers2 delUser otherUser3
+      connectTwoUsers delUser otherUser3
       bindResponse (addMembers delUser upBackendConv def {users = [otherUser3]}) $ \resp ->
         resp.status `shouldMatchInt` 200
 

--- a/integration/test/Test/MessageTimer.hs
+++ b/integration/test/Test/MessageTimer.hs
@@ -28,7 +28,7 @@ import Testlib.ResourcePool
 
 testMessageTimerChangeWithRemotes :: HasCallStack => App ()
 testMessageTimerChangeWithRemotes = do
-  (alice, bob) <- createAndConnectUsers OwnDomain OtherDomain
+  [alice, bob] <- createAndConnectUsers [OwnDomain, OtherDomain]
   conv <- postConversation alice defProteus {qualifiedUsers = [bob]} >>= getJSON 201
   withWebSockets [alice, bob] $ \wss -> do
     void $ updateMessageTimer alice conv 1000 >>= getBody 200
@@ -44,7 +44,7 @@ testMessageTimerChangeWithUnreachableRemotes = do
   conv <- runCodensity (acquireResources 1 resourcePool) $ \[dynBackend] ->
     runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
       bob <- randomUser dynBackend.berDomain def
-      connectUsers alice bob
+      connectUsers2 alice bob
       postConversation alice (defProteus {qualifiedUsers = [bob]}) >>= getJSON 201
   withWebSocket alice $ \ws -> do
     void $ updateMessageTimer alice conv 1000 >>= getBody 200

--- a/integration/test/Test/MessageTimer.hs
+++ b/integration/test/Test/MessageTimer.hs
@@ -44,7 +44,7 @@ testMessageTimerChangeWithUnreachableRemotes = do
   conv <- runCodensity (acquireResources 1 resourcePool) $ \[dynBackend] ->
     runCodensity (startDynamicBackend dynBackend mempty) $ \_ -> do
       bob <- randomUser dynBackend.berDomain def
-      connectUsers2 alice bob
+      connectTwoUsers alice bob
       postConversation alice (defProteus {qualifiedUsers = [bob]}) >>= getJSON 201
   withWebSocket alice $ \ws -> do
     void $ updateMessageTimer alice conv 1000 >>= getBody 200

--- a/integration/test/Test/Roles.hs
+++ b/integration/test/Test/Roles.hs
@@ -27,8 +27,8 @@ import Testlib.Prelude
 testRoleUpdateWithRemotesOk :: HasCallStack => App ()
 testRoleUpdateWithRemotesOk = do
   [bob, charlie, alice] <- createUsers [OwnDomain, OwnDomain, OtherDomain]
-  connectUsers2 bob charlie
-  connectUsers2 bob alice
+  connectTwoUsers bob charlie
+  connectTwoUsers bob alice
   conv <-
     postConversation bob (defProteus {qualifiedUsers = [charlie, alice]})
       >>= getJSON 201
@@ -50,8 +50,8 @@ testRoleUpdateWithRemotesUnreachable = do
   [bob, charlie] <- createUsers [OwnDomain, OwnDomain]
   startDynamicBackends [mempty] $ \[dynBackend] -> do
     alice <- randomUser dynBackend def
-    connectUsers2 bob alice
-    connectUsers2 bob charlie
+    connectTwoUsers bob alice
+    connectTwoUsers bob charlie
     conv <-
       postConversation bob (defProteus {qualifiedUsers = [charlie, alice]})
         >>= getJSON 201

--- a/integration/test/Test/Roles.hs
+++ b/integration/test/Test/Roles.hs
@@ -27,8 +27,8 @@ import Testlib.Prelude
 testRoleUpdateWithRemotesOk :: HasCallStack => App ()
 testRoleUpdateWithRemotesOk = do
   [bob, charlie, alice] <- createUsers [OwnDomain, OwnDomain, OtherDomain]
-  connectUsers bob charlie
-  connectUsers bob alice
+  connectUsers2 bob charlie
+  connectUsers2 bob alice
   conv <-
     postConversation bob (defProteus {qualifiedUsers = [charlie, alice]})
       >>= getJSON 201
@@ -50,8 +50,8 @@ testRoleUpdateWithRemotesUnreachable = do
   [bob, charlie] <- createUsers [OwnDomain, OwnDomain]
   startDynamicBackends [mempty] $ \[dynBackend] -> do
     alice <- randomUser dynBackend def
-    connectUsers bob alice
-    connectUsers bob charlie
+    connectUsers2 bob alice
+    connectUsers2 bob charlie
     conv <-
       postConversation bob (defProteus {qualifiedUsers = [charlie, alice]})
         >>= getJSON 201


### PR DESCRIPTION
There have been some diverging changes on the mls branch related to the way users are created and connected in tests. This aligns the version on develop with that on mls.

## Checklist

 - [x] No CHANGELOG entry
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
