### PR TITLE
[chore] Fix flaky offline backend notification integration test.

### DIFF
--- a/integration/test/Test/Federation.hs
+++ b/integration/test/Test/Federation.hs
@@ -130,5 +130,5 @@ testNotificationsForOfflineBackends = do
       -- void $ awaitNotification downUser1 downClient1 (Just newMsgNotif) 1 isOtherUser2LeaveUpConvNotif
       -- void $ awaitNotification otherUser otherClient (Just newMsgNotif) 1 isDelUserLeaveDownConvNotif
 
-      delUserDeletedNotif <- nPayload $ awaitNotification downUser1 downClient1 (Just newMsgNotif) 5 isDeleteUserNotif
+      delUserDeletedNotif <- nPayload $ awaitNotification downUser1 downClient1 (Just newMsgNotif) 1 isDeleteUserNotif
       objQid delUserDeletedNotif `shouldMatch` objQid delUser

--- a/integration/test/Test/Federation.hs
+++ b/integration/test/Test/Federation.hs
@@ -124,11 +124,11 @@ testNotificationsForOfflineBackends = do
                 isNotifConv downBackendConv,
                 isNotifForUser delUser
               ]
-      void $ awaitNotification downUser1 downClient1 (Just newMsgNotif) 1 isDelUserLeaveDownConvNotif
+      void $ awaitNotification downUser1 downClient1 (Just newMsgNotif) 5 isDelUserLeaveDownConvNotif
 
       -- FUTUREWORK: Uncomment after fixing this bug: https://wearezeta.atlassian.net/browse/WPB-3664
       -- void $ awaitNotification downUser1 downClient1 (Just newMsgNotif) 1 isOtherUser2LeaveUpConvNotif
       -- void $ awaitNotification otherUser otherClient (Just newMsgNotif) 1 isDelUserLeaveDownConvNotif
 
-      delUserDeletedNotif <- nPayload $ awaitNotification downUser1 downClient1 (Just newMsgNotif) 1 isDeleteUserNotif
+      delUserDeletedNotif <- nPayload $ awaitNotification downUser1 downClient1 (Just newMsgNotif) 5 isDeleteUserNotif
       objQid delUserDeletedNotif `shouldMatch` objQid delUser


### PR DESCRIPTION
It seems the timeout was too aggressive. After testing extensively locally, I could no longer reproduce the flakiness after bumping the timeout. (I could reproduce the flakiness by running the test continuously until failure, pre-bump).