### PR TITLE
kube-integration-teardown: Ignore failures in `helmfile destroy`

### DIFF
--- a/hack/bin/integration-teardown-federation.sh
+++ b/hack/bin/integration-teardown-federation.sh
@@ -22,7 +22,6 @@ else
 fi
 
 . "$DIR/helm_overrides.sh"
-helmfile --file "${TOP_LEVEL}/hack/helmfile.yaml" destroy --skip-deps --skip-charts --concurrency 0
+helmfile --file "${TOP_LEVEL}/hack/helmfile.yaml" destroy --skip-deps --skip-charts --concurrency 0 || echo "Failed to delete helm deployments, ignoring this failure as next steps will the destroy namespaces anyway."
 
-kubectl delete namespace "$NAMESPACE_1"
-kubectl delete namespace "$NAMESPACE_2"
+kubectl delete namespace "$NAMESPACE_1" "$NAMESPACE_2"


### PR DESCRIPTION
This can happen due to some credentials being missing, the steps afterwards delete the whole namespace anyway.

Also in this commit:

Use 1 kubectl command to delete both namespaces, its faster like this because kubectl deletes them in parallel and kubeneretes can destroy resources inside in parallel.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
