### PR TITLE
Avoid empty pushes from galley

### DIFF
--- a/changelog.d/5-internal/empty-push
+++ b/changelog.d/5-internal/empty-push
@@ -1,0 +1,1 @@
+Avoid empty pushes when chunking pushes in galley

--- a/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
+++ b/libs/gundeck-types/src/Gundeck/Types/Push/V2.hs
@@ -86,6 +86,7 @@ import Data.Set qualified as Set
 import Imports hiding (cs)
 import Wire.API.Message (Priority (..))
 import Wire.API.Push.V2.Token
+import Wire.Arbitrary
 
 -----------------------------------------------------------------------------
 -- Route
@@ -97,7 +98,8 @@ data Route
     RouteAny
   | -- | Avoids causing push notification for mobile clients.
     RouteDirect
-  deriving (Eq, Ord, Enum, Bounded, Show)
+  deriving (Eq, Ord, Enum, Bounded, Show, Generic)
+  deriving (Arbitrary) via GenericUniform Route
 
 instance FromJSON Route where
   parseJSON (String "any") = pure RouteAny
@@ -116,14 +118,15 @@ data Recipient = Recipient
     _recipientRoute :: !Route,
     _recipientClients :: !RecipientClients
   }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
 
 data RecipientClients
   = -- | All clients of some user
     RecipientClientsAll
   | -- | An explicit list of clients
     RecipientClientsSome (List1 ClientId)
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Show, Ord, Generic)
+  deriving (Arbitrary) via GenericUniform RecipientClients
 
 makeLenses ''Recipient
 

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -66,6 +66,7 @@ import Data.Attoparsec.ByteString.Char8 qualified as Atto
 import Data.Bifunctor (first)
 import Data.Binary
 import Data.ByteString.Builder (byteString)
+import Data.ByteString.Char8 qualified as B8
 import Data.ByteString.Conversion
 import Data.ByteString.Lazy qualified as L
 import Data.Char qualified as Char
@@ -297,6 +298,9 @@ instance S.ToParamSchema ConnId where
 
 instance FromHttpApiData ConnId where
   parseUrlPiece = Right . ConnId . encodeUtf8
+
+instance Arbitrary ConnId where
+  arbitrary = ConnId . B8.pack <$> resize 10 (listOf arbitraryPrintableChar)
 
 -- ClientId --------------------------------------------------------------------
 

--- a/services/cannon/cannon.cabal
+++ b/services/cannon/cannon.cabal
@@ -249,7 +249,6 @@ test-suite cannon-tests
     , tasty             >=0.8
     , tasty-hunit       >=0.8
     , tasty-quickcheck  >=0.8
-    , types-common
     , uuid
     , wire-api
 

--- a/services/cannon/default.nix
+++ b/services/cannon/default.nix
@@ -109,7 +109,6 @@ mkDerivation {
     tasty
     tasty-hunit
     tasty-quickcheck
-    types-common
     uuid
     wire-api
   ];

--- a/services/cannon/test/Test/Cannon/Dict.hs
+++ b/services/cannon/test/Test/Cannon/Dict.hs
@@ -24,7 +24,6 @@ import Cannon.Dict qualified as D
 import Cannon.WS (Key, mkKey)
 import Control.Concurrent.Async
 import Data.ByteString.Lazy qualified as Lazy
-import Data.Id
 import Data.List qualified as List
 import Data.UUID hiding (fromString)
 import Data.UUID.V4
@@ -122,6 +121,3 @@ runProp = monadicIO . forAllM arbitrary
 
 instance Arbitrary Key where
   arbitrary = mkKey <$> arbitrary <*> arbitrary
-
-instance Arbitrary ConnId where
-  arbitrary = ConnId <$> arbitrary

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -628,6 +628,7 @@ test-suite galley-tests
     Test.Galley.API.Action
     Test.Galley.API.Message
     Test.Galley.API.One2One
+    Test.Galley.Intra.Push
     Test.Galley.Intra.User
     Test.Galley.Mapping
 

--- a/services/galley/src/Galley/Intra/Push/Internal.hs
+++ b/services/galley/src/Galley/Intra/Push/Internal.hs
@@ -43,6 +43,7 @@ import Wire.API.Event.FeatureConfig qualified as FeatureConfig
 import Wire.API.Event.Federation qualified as Federation
 import Wire.API.Event.Team qualified as Teams
 import Wire.API.Team.Member
+import Wire.Arbitrary
 
 data PushEvent
   = ConvEvent Event
@@ -60,7 +61,8 @@ data RecipientBy user = Recipient
   { _recipientUserId :: user,
     _recipientClients :: RecipientClients
   }
-  deriving stock (Functor, Foldable, Traversable, Show, Ord, Eq)
+  deriving stock (Functor, Foldable, Traversable, Show, Ord, Eq, Generic)
+  deriving (Arbitrary) via GenericUniform (RecipientBy user)
 
 makeLenses ''RecipientBy
 
@@ -77,7 +79,8 @@ data PushTo user = Push
     pushJson :: Object,
     pushRecipientListType :: ListType
   }
-  deriving stock (Functor, Foldable, Traversable, Show)
+  deriving stock (Eq, Generic, Functor, Foldable, Traversable, Show)
+  deriving (Arbitrary) via GenericUniform (PushTo user)
 
 makeLenses ''PushTo
 
@@ -93,6 +96,31 @@ push ps = do
       nonEmpty (toList (_pushRecipients p)) <&> \nonEmptyRecipients ->
         p {_pushRecipients = List1 nonEmptyRecipients}
 
+-- | Split a list of pushes into chunks with the given maximum number of
+-- recipients. maxRecipients must be strictly positive. Note that the order of
+-- pushes within a chunk is reversed compared to the order of the input list.
+chunkPushes :: Int -> [PushTo a] -> [[PushTo a]]
+chunkPushes maxRecipients | maxRecipients <= 0 = error "maxRecipients must be positive"
+chunkPushes maxRecipients = go 0 []
+  where
+    go _ [] [] = []
+    go _ acc [] = [acc]
+    go n acc (y : ys)
+      | n >= maxRecipients = acc : go 0 [] (y : ys)
+      | otherwise =
+          let totalLength = (n + length (_pushRecipients y))
+           in if totalLength > maxRecipients
+                then
+                  let (y1, y2) = splitPush (maxRecipients - n) y
+                   in go maxRecipients (y1 : acc) (y2 : ys)
+                else go totalLength (y : acc) ys
+
+    -- n must be strictly > 0 and < length (_pushRecipients p)
+    splitPush :: Int -> PushTo a -> (PushTo a, PushTo a)
+    splitPush n p =
+      let (r1, r2) = splitAt n (toList (_pushRecipients p))
+       in (p {_pushRecipients = fromJust $ maybeList1 r1}, p {_pushRecipients = fromJust $ maybeList1 r2})
+
 -- | Asynchronously send multiple pushes, aggregating them into as
 -- few requests as possible, such that no single request targets
 -- more than 128 recipients.
@@ -106,28 +134,7 @@ pushLocal ps = do
   mapConcurrently_ (call Gundeck <=< jsonChunkedIO) (pushes syncs)
   where
     pushes :: [PushTo UserId] -> [[Gundeck.Push]]
-    pushes = map (map (\p -> toPush p (recipientList p))) . chunk 0 []
-
-    chunk :: Int -> [PushTo a] -> [PushTo a] -> [[PushTo a]]
-    chunk _ acc [] = [acc]
-    chunk n acc (y : ys)
-      | n >= maxRecipients = acc : chunk 0 [] (y : ys)
-      | otherwise =
-          let totalLength = (n + length (_pushRecipients y))
-           in if totalLength > maxRecipients
-                then
-                  let (y1, y2) = splitPush (maxRecipients - n) y
-                   in chunk maxRecipients (y1 : acc) (y2 : ys)
-                else chunk totalLength (y : acc) ys
-
-    -- n must be strictly > 0 and < length (_pushRecipients p)
-    splitPush :: Int -> PushTo a -> (PushTo a, PushTo a)
-    splitPush n p =
-      let (r1, r2) = splitAt n (toList (_pushRecipients p))
-       in (p {_pushRecipients = fromJust $ maybeList1 r1}, p {_pushRecipients = fromJust $ maybeList1 r2})
-
-    maxRecipients :: Int
-    maxRecipients = 128
+    pushes = map (map (\p -> toPush p (recipientList p))) . chunkPushes 128
 
     recipientList :: PushTo UserId -> [Gundeck.Recipient]
     recipientList p = map (toRecipient p) . toList $ _pushRecipients p

--- a/services/galley/test/unit/Test/Galley/Intra/Push.hs
+++ b/services/galley/test/unit/Test/Galley/Intra/Push.hs
@@ -1,6 +1,6 @@
 -- This file is part of the Wire Server implementation.
 --
--- Copyright (C) 2022 Wire Swiss GmbH <opensource@wire.com>
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
 --
 -- This program is free software: you can redistribute it and/or modify it under
 -- the terms of the GNU Affero General Public License as published by the Free

--- a/services/galley/test/unit/Test/Galley/Intra/Push.hs
+++ b/services/galley/test/unit/Test/Galley/Intra/Push.hs
@@ -40,6 +40,8 @@ tests =
     "chunkPushes"
     [ testProperty "empty push" $ \(Positive limit) ->
         chunkPushes limit [] === ([] :: [[PushTo ()]]),
+      testProperty "no empty chunk" $ \(Positive limit) (pushes :: [PushTo Int]) ->
+        not (any null (chunkPushes limit pushes)),
       testProperty "concatenation" $ \(Positive limit) (pushes :: [PushTo Int]) ->
         (chunkPushes limit pushes >>= reverse >>= normalisePush)
           === (pushes >>= normalisePush),


### PR DESCRIPTION
This fixes the edge case of empty pushes being sent to gundeck from galley, due to a wrong base case in the chunk splitting function. It also adds some unit tests.

https://wearezeta.atlassian.net/browse/WPB-3169

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
