### PR TITLE
wire-api: Remove explicit dependency on the `pretty` package

### DIFF
--- a/libs/wire-api/default.nix
+++ b/libs/wire-api/default.nix
@@ -63,7 +63,6 @@
 , openapi3
 , pem
 , polysemy
-, pretty
 , process
 , proto-lens
 , protobuf
@@ -235,7 +234,6 @@ mkDerivation {
     metrics-wai
     openapi3
     pem
-    pretty
     process
     proto-lens
     QuickCheck

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Runner.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Runner.hs
@@ -32,12 +32,11 @@ import Data.ByteString qualified as ByteString
 import Data.ByteString.Lazy qualified as LBS
 import Data.ProtoLens.Encoding (decodeMessage, encodeMessage)
 import Data.ProtoLens.Message (Message)
-import Data.ProtoLens.TextFormat (pprintMessage, readMessage)
+import Data.ProtoLens.TextFormat (readMessage, showMessage)
 import Data.Text.Lazy.IO qualified as LText
 import Imports
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit
-import Text.PrettyPrint (render)
 import Type.Reflection (typeRep)
 import Wire.API.ServantProto
 
@@ -93,7 +92,7 @@ protoTestObject ::
 protoTestObject obj path = do
   let actual = toProto obj
   msg <- assertRight (decodeMessage @m actual)
-  let pretty = render (pprintMessage msg)
+  let pretty = showMessage msg
       dir = "test/golden"
       fullPath = dir <> "/" <> path
   createDirectoryIfMissing True dir

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -605,7 +605,6 @@ test-suite wire-api-golden-tests
     , iso639
     , lens
     , pem
-    , pretty
     , proto-lens
     , tasty
     , tasty-hunit


### PR DESCRIPTION
`proto-lens` already provides wrappers around the usage, so we should stick to those.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
