### PR TITLE
wire-server.nix: Add aws cli to all integration test docker images

### DIFF
--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -254,8 +254,13 @@ let
   # extraContents :: Map Exe Derivation -> Map Text [Derivation]
   extraContents = exes: {
     brig = [ brig-templates ];
-    brig-integration = [ brig-templates pkgs.mls-test-cli ];
-    galley-integration = [ pkgs.mls-test-cli ];
+    brig-integration = [brig-templates pkgs.mls-test-cli pkgs.awscli2];
+    galley-integration = [pkgs.mls-test-cli pkgs.awscli2];
+    stern-integration = [ pkgs.awscli2 ];
+    gundeck-integration = [ pkgs.awscli2 ];
+    cargohold-integration = [ pkgs.awscli2 ];
+    spar-integration = [ pkgs.awscli2 ];
+    federator-integration = [ pkgs.awscli2 ];
     integration = with exes; [
       brig
       brig-index
@@ -275,6 +280,7 @@ let
       background-worker
       pkgs.nginz
       pkgs.mls-test-cli
+      pkgs.awscli2
       integration-dynamic-backends-db-schemas
       integration-dynamic-backends-brig-index
       integration-dynamic-backends-sqs


### PR DESCRIPTION
Required for https://github.com/wireapp/wire-server/pull/3633
https://wearezeta.atlassian.net/browse/WPB-4267

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
