### PR TITLE
nginx-ingress-services: Add optional webapp2 ingress

### DIFF
--- a/changelog.d/2-features/secondary-webapp
+++ b/changelog.d/2-features/secondary-webapp
@@ -1,0 +1,1 @@
+Add optional ingress for a second webapp

--- a/charts/nginx-ingress-services/templates/certificate.yaml
+++ b/charts/nginx-ingress-services/templates/certificate.yaml
@@ -33,6 +33,9 @@ spec:
     {{- if .Values.webapp.enabled }}
     - {{ .Values.config.dns.webapp }}
     {{- end }}
+    {{- if .Values.webapp2.enabled }}
+    - {{ .Values.config.dns.webapp2 }}
+    {{- end }}
     {{- if .Values.fakeS3.enabled }}
     - {{ .Values.config.dns.fakeS3 }}
     {{- end }}

--- a/charts/nginx-ingress-services/templates/ingress.yaml
+++ b/charts/nginx-ingress-services/templates/ingress.yaml
@@ -117,6 +117,25 @@ spec:
               servicePort: {{ .Values.service.webapp.externalPort }}
               {{- end }}
 {{- end }}
+{{- if .Values.webapp2.enabled }}
+    - host: {{ .Values.config.dns.webapp2 }}
+      http:
+        paths:
+          - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if $apiIsStable }}
+              service:
+                name: webapp2-http
+                port:
+                  number: {{ .Values.service.webapp2.externalPort }}
+              {{- else }}
+              serviceName: webapp2-http
+              servicePort: {{ .Values.service.webapp2.externalPort }}
+              {{- end }}
+{{- end }}
 {{- if .Values.fakeS3.enabled }}
     - host: {{ .Values.config.dns.fakeS3 }}
       http:

--- a/charts/nginx-ingress-services/values.yaml
+++ b/charts/nginx-ingress-services/values.yaml
@@ -10,6 +10,8 @@ websockets:
   enabled: true
 webapp:
   enabled: true
+webapp2:
+  enabled: false
 fakeS3:
   enabled: true
 federator:


### PR DESCRIPTION
This PR adds an option to `nginx-ingress-services` chart that enables a second ingress for the webapp (disabled by default).
The ingress will will forward traffick to a service labeled `webapp2-http`. There are not helm charts provided to deploy such a service. The intention is to use leave this service to be manually deployed for testing purposes, namely upgrade paths for the webapp.
Tracked in https://wearezeta.atlassian.net/browse/WPB-3577.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
