### PR TITLE
wire-api-federation: Disconnect from federator after consuming the response

### DIFF
--- a/changelog.d/3-bug-fixes/federator-disconnect
+++ b/changelog.d/3-bug-fixes/federator-disconnect
@@ -1,0 +1,1 @@
+Fix memory and TCP connection leak in brig, galley, caroghold and background-worker.

--- a/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Client.hs
@@ -126,7 +126,8 @@ withNewHttpRequest target req k = do
   sendReqMVar <- newEmptyMVar
   thread <- liftIO . async $ H2Manager.startPersistentHTTP2Connection ctx target cacheLimit sslRemoveTrailingDot tcpConnectionTimeout sendReqMVar
   let newConn = H2Manager.HTTP2Conn thread (putMVar sendReqMVar H2Manager.CloseConnection) sendReqMVar
-  H2Manager.sendRequestWithConnection newConn req k
+  H2Manager.sendRequestWithConnection newConn req $ \resp -> do
+    k resp <* newConn.disconnect
 
 performHTTP2Request ::
   Http2Manager ->


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-5116

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
