### PR TITLE
Fix extra remove proposal bug

### DIFF
--- a/changelog.d/3-bug-fixes/extra-remove-proposals
+++ b/changelog.d/3-bug-fixes/extra-remove-proposals
@@ -1,0 +1,1 @@
+Extra remove proposals were being sent when a user was removed from a conversation

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -425,14 +425,14 @@ performAction tag origUser lconv action = do
       let victims = [origUser]
       lconv' <- traverse (convDeleteMembers (toUserList lconv victims)) lconv
       -- send remove proposals in the MLS case
-      traverse_ (removeUser lconv') victims
+      traverse_ (removeUser lconv' RemoveUserIncludeMain) victims
       pure (mempty, action)
     SConversationRemoveMembersTag -> do
       let presentVictims = filter (isConvMemberL lconv) (toList action)
       when (null presentVictims) noChanges
       traverse_ (convDeleteMembers (toUserList lconv presentVictims)) lconv
       -- send remove proposals in the MLS case
-      traverse_ (removeUser lconv) presentVictims
+      traverse_ (removeUser lconv RemoveUserExcludeMain) presentVictims
       pure (mempty, action) -- FUTUREWORK: should we return the filtered action here?
     SConversationMemberUpdateTag -> do
       void $ ensureOtherMember lconv (cmuTarget action) conv

--- a/services/galley/src/Galley/API/Federation.hs
+++ b/services/galley/src/Galley/API/Federation.hs
@@ -414,7 +414,7 @@ onUserDeleted origDomain udcn = do
             Public.SelfConv -> pure ()
             Public.RegularConv -> do
               let botsAndMembers = convBotsAndMembers conv
-              removeUser (qualifyAs lc conv) (tUntagged deletedUser)
+              removeUser (qualifyAs lc conv) RemoveUserIncludeMain (tUntagged deletedUser)
               outcome <-
                 runError @FederationError $
                   notifyConversationAction

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -376,7 +376,7 @@ rmUser lusr conn = do
         ConnectConv -> E.deleteMembers (Data.convId c) (UserList [tUnqualified lusr] []) $> Nothing
         RegularConv
           | tUnqualified lusr `isMember` Data.convLocalMembers c -> do
-              runError (removeUser (qualifyAs lusr c) (tUntagged lusr)) >>= \case
+              runError (removeUser (qualifyAs lusr c) RemoveUserIncludeMain (tUntagged lusr)) >>= \case
                 Left e -> P.err $ Log.msg ("failed to send remove proposal: " <> internalErrorDescription e)
                 Right _ -> pure ()
               E.deleteMembers (Data.convId c) (UserList [tUnqualified lusr] [])

--- a/services/galley/src/Galley/API/MLS/Removal.hs
+++ b/services/galley/src/Galley/API/MLS/Removal.hs
@@ -196,9 +196,17 @@ removeClient lc qusr c = do
     let getClients = fmap (cid,) . cmLookupIndex cid . (.members)
     removeClientsWithClientMapRecursively (qualifyAs lc mlsConv) getClients qusr
 
+-- | A flag to determine whether 'removeUser' should operate on the parent
+-- conversation as well as all the subconversations.
 data RemoveUserIncludeMain
-  = RemoveUserIncludeMain
-  | RemoveUserExcludeMain
+  = -- | Remove user clients from all subconversations, including the parent.
+    RemoveUserIncludeMain
+  | -- | Remove user clients from all subconversations, but not the parent.
+    --
+    -- This can be used when the clients are already in the process of being
+    -- removed from the main conversation, for example as a result of a commit
+    -- containing a remove proposal.
+    RemoveUserExcludeMain
 
 -- | Send remove proposals for all clients of the user to the local conversation.
 removeUser ::


### PR DESCRIPTION
We were sending external remove proposals for each client of a user that was kicked out of a conversation following a remove commit. This was caused by some overgeneralisation of the mechanism that removes clients from subconversations when a user is deleted from the main.

I haven't added a test for this behaviour, but the upcoming PR #3671 is able to catch this problem (which is how I discovered it in the first place), so it should be covered when that one is merged.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
