### PR TITLE
Remove client check for subconversations

### DIFF
--- a/changelog.d/3-bug-fixes/fix-subconv-client-check
+++ b/changelog.d/3-bug-fixes/fix-subconv-client-check
@@ -1,0 +1,1 @@
+Remove client check for subconversations


### PR DESCRIPTION
There should be no client completeness check for subconversations. The reason the tests were not catching this so far is that we are often uploading a single key package per client, so by the time we would get to the completeness check, all key packages are exhausted and the check would succeed trivially.

https://wearezeta.atlassian.net/browse/WPB-5226

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
