### PR TITLE
Update group state after application messages

### DIFF
--- a/changelog.d/5-internal/multiple-messages
+++ b/changelog.d/5-internal/multiple-messages
@@ -1,0 +1,1 @@
+Update group state after application message

--- a/integration/test/MLS/Util.hs
+++ b/integration/test/MLS/Util.hs
@@ -724,7 +724,7 @@ createApplicationMessage cid messageContent = do
   message <-
     mlscli
       cid
-      ["message", "--group", "<group-in>", messageContent]
+      ["message", "--group-in", "<group-in>", messageContent, "--group-out", "<group-out>"]
       Nothing
 
   pure

--- a/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
@@ -123,7 +123,7 @@ testParseApplication = do
   msgData <- withSystemTempDirectory "mls" $ \tmp -> do
     void $ spawn (cli qcid tmp ["init", qcid]) Nothing
     groupJSON <- spawn (cli qcid tmp ["group", "create", "Zm9v"]) Nothing
-    spawn (cli qcid tmp ["message", "--group", "-", "hello"]) (Just groupJSON)
+    spawn (cli qcid tmp ["message", "--group-in", "-", "hello"]) (Just groupJSON)
 
   msg <- case decodeMLS' @Message msgData of
     Left err -> assertFailure (T.unpack err)

--- a/nix/pkgs/mls-test-cli/default.nix
+++ b/nix/pkgs/mls-test-cli/default.nix
@@ -11,8 +11,8 @@ let
   src = fetchFromGitHub {
     owner = "wireapp";
     repo = "mls-test-cli";
-    rev = "e6e6ce0c29f0e48e84b4ccef058130aca0625492";
-    sha256 = "sha256-J9M8w3GJnULH3spKEuPGCL/t43zb2Wd+YfZ0LY3YITo=";
+    rev = "baaa5c78411a5bf6d697803276b991523c111631";
+    sha256 = "sha256-M6bWB5hWl+WSblcH6L+AyGD+7ef9TvRs8wKYq7lJyS8=";
   };
   cargoLockFile = builtins.toFile "cargo.lock" (builtins.readFile "${src}/Cargo.lock");
 in rustPlatform.buildRustPackage rec {
@@ -23,7 +23,7 @@ in rustPlatform.buildRustPackage rec {
     lockFile = cargoLockFile;
     outputHashes = {
       "hpke-0.10.0" = "sha256-T1+BFwX6allljNZ/8T3mrWhOejnUU27BiWQetqU+0fY=";
-      "openmls-1.0.0" = "sha256-s1ejM/aicFGvsKY7ajEun1Mc645/k8QVrE8YSbyD3Fg=";
+      "openmls-1.0.0" = "sha256-tAIm8+IgubNnU2M2A5cxHY5caiEQmisw73I9/cqfvUc=";
       "safe_pqc_kyber-0.6.0" = "sha256-Ch1LA+by+ezf5RV0LDSQGC1o+IWKXk8IPvkwSrAos68=";
       "tls_codec-0.3.0" = "sha256-IO6tenXKkC14EoUDp/+DtFNOVzDfOlLu8K1EJI7sOzs=";
     };

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -647,7 +647,7 @@ createApplicationMessage cid messageContent = do
   message <-
     mlscli
       cid
-      ["message", "--group", "<group-in>", messageContent]
+      ["message", "--group-in", "<group-in>", messageContent, "--group-out", "<group-out>"]
       Nothing
 
   pure $


### PR DESCRIPTION
After an application message the ratchet is updated, therefore we need to save the updated group state so that future messages are generated correctly.

This PR includes an mls-test-cli update. The new mls-test-cli version modifies the `message` command to include both `group-in` and `group-out` options, as other similar commands already do.

https://wearezeta.atlassian.net/browse/WPB-5002

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
