### PR TITLE
wire-server chart: Disable integration chart by default

### DIFF
--- a/changelog.d/5-internal/disable-integration-chart
+++ b/changelog.d/5-internal/disable-integration-chart
@@ -1,0 +1,1 @@
+Disable `integration` subchart of `wire-server` by default

--- a/charts/wire-server/values.yaml
+++ b/charts/wire-server/values.yaml
@@ -13,3 +13,4 @@ tags:
   sftd: false
   backoffice: false
   mlsstats: false
+  integration: false

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -14,6 +14,7 @@ tags:
   account-pages: false
   legalhold: false
   sftd: false
+  integration: true
 
 cassandra-migrations:
   imagePullPolicy: {{ .Values.imagePullPolicy }}


### PR DESCRIPTION
Fixup to #3171. This PR updates the `wire-server` chart so that it doesn't include the `integration` chart by default.
Without this PR the [integration](https://github.com/wireapp/wire-server/tree/36bae6e2ce25b3cddeb9c7d72b2b48fb9d89b270/charts/integration) chart is installed, which creates an superfluous kubernetes objects, including an (internal) ingress for a subdomain of `svc.cluster.local`.

Disabling works because of [this tag](https://github.com/wireapp/wire-server/blob/f87b3b39803d79906e79ba573eed2df46b02e9ae/charts/wire-server/requirements.yaml#L131C1-L131C1)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
