### PR TITLE
[WPB-5208] Allow adding users to conversations when other backends are unreachable

### DIFF
--- a/changelog.d/6-federation/wpb-5208-add-users-when-others-unreachable
+++ b/changelog.d/6-federation/wpb-5208-add-users-when-others-unreachable
@@ -1,0 +1,1 @@
+Make sure that remote users can be added to both a Proteus and an MLS conversation when other users are unreachable

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -308,24 +308,38 @@ testAddUnreachableUserFromFederatingBackend :: HasCallStack => App ()
 testAddUnreachableUserFromFederatingBackend = do
   resourcePool <- asks resourcePool
   runCodensity (acquireResources 1 resourcePool) $ \[cDom] -> do
-    (alice, chadId, conv) <- runCodensity (startDynamicBackend cDom mempty) $ \_ -> do
+    (alice, chad, chad1, qcnv) <- runCodensity (startDynamicBackend cDom mempty) $ \_ -> do
       ownDomain <- make OwnDomain & asString
       otherDomain <- make OtherDomain & asString
       [alice, bob, charlie, chad] <-
         createAndConnectUsers [ownDomain, otherDomain, cDom.berDomain, cDom.berDomain]
+      chad1 <- objId $ bindResponse (addClient chad def) $ getJSON 201
 
-      conv <- withWebSockets [bob, charlie] $ \wss -> do
+      qcnv <- withWebSockets [bob, charlie] $ \wss -> do
         conv <-
           postConversation alice (defProteus {qualifiedUsers = [bob, charlie]})
             >>= getJSON 201
         forM_ wss $ awaitMatch 5 isMemberJoinNotif
-        pure conv
-      chadId <- chad %. "qualified_id"
-      pure (alice, chadId, conv)
+        let qcnv = conv %. "qualified_id"
+        pure qcnv
+      pure (alice, chad, chad1, qcnv)
 
-    bindResponse (addMembers alice conv def {users = [chadId]}) $ \resp -> do
-      resp.status `shouldMatchInt` 533
-      resp.jsonBody %. "unreachable_backends" `shouldMatchSet` [cDom.berDomain]
+    chadId <- chad %. "qualified_id"
+    bindResponse (addMembers alice qcnv def {users = [chad]}) $ \resp -> do
+      resp.status `shouldMatchInt` 200
+      let event = resp.jsonBody
+      shouldMatch (event %. "qualified_conversation") qcnv
+      shouldMatch (event %. "type") "conversation.member-join"
+      shouldMatch (event %. "from") (objId alice)
+      members <- event %. "data.users" & asList
+      memberQids <- for members (%. "qualified_id")
+      memberQids `shouldMatch` [chadId]
+
+    runCodensity (startDynamicBackend cDom mempty) $ \_ -> do
+      n <- awaitNotification chad chad1 noValue 10 isMemberJoinNotif
+      members <- n %. "payload.0.data.users" & asList
+      memberQids <- for members (%. "qualified_id")
+      memberQids `shouldMatch` [chadId]
 
 testAddUnreachable :: HasCallStack => App ()
 testAddUnreachable = do

--- a/integration/test/Test/MLS/Unreachable.hs
+++ b/integration/test/Test/MLS/Unreachable.hs
@@ -78,7 +78,7 @@ testAddUnreachableUserFromFederatingBackend :: HasCallStack => App ()
 testAddUnreachableUserFromFederatingBackend = do
   resourcePool <- asks resourcePool
   runCodensity (acquireResources 1 resourcePool) $ \[cDom] -> do
-    ((alice, chad), mp, qcnv) <- runCodensity (startDynamicBackend cDom mempty) $ \_ -> do
+    ((alice, chad, chad1), mp, qcnv) <- runCodensity (startDynamicBackend cDom mempty) $ \_ -> do
       ownDomain <- make OwnDomain & asString
       otherDomain <- make OtherDomain & asString
       [alice, bob, charlie, chad] <-
@@ -91,9 +91,9 @@ testAddUnreachableUserFromFederatingBackend = do
         void $ createAddCommit alice1 [bob, charlie] >>= sendAndConsumeCommitBundle
         forM_ wss $ awaitMatch 5 isMemberJoinNotif
       mp <- createAddCommit alice1 [chad]
-      pure ((alice, chad), mp, qcnv)
+      pure ((alice, chad, chad1), mp, qcnv)
 
-    resp <- sendAndConsumeCommitBundle mp
+    resp <- postMLSCommitBundle mp.sender (mkBundle mp) >>= getJSON 201
     chadId <- chad %. "qualified_id"
     events <- resp %. "events" & asList
     do
@@ -101,11 +101,12 @@ testAddUnreachableUserFromFederatingBackend = do
       shouldMatch (event %. "qualified_conversation") qcnv
       shouldMatch (event %. "type") "conversation.member-join"
       shouldMatch (event %. "from") (objId alice)
-      members <- event %. "data" %. "users" & asList
-      memberQids <- for members $ \mem -> mem %. "qualified_id"
+      members <- event %. "data.users" & asList
+      memberQids <- for members $ (%. "qualified_id")
       shouldMatch memberQids [chadId]
 
-    runCodensity (startDynamicBackend cDom mempty) $ \_ ->
-      withWebSocket chad $ \ws -> do
-        n <- awaitMatch 10 isMemberJoinNotif ws
-        n %. "data.qualified_target" `shouldMatch` chadId
+    runCodensity (startDynamicBackend cDom mempty) $ \_ -> do
+      n <- awaitNotification chad chad1 noValue 10 isMemberJoinNotif
+      members <- n %. "payload.0.data.users" & asList
+      memberQids <- for members (%. "qualified_id")
+      memberQids `shouldMatch` [chadId]

--- a/integration/test/Test/MLS/Unreachable.hs
+++ b/integration/test/Test/MLS/Unreachable.hs
@@ -78,7 +78,7 @@ testAddUnreachableUserFromFederatingBackend :: HasCallStack => App ()
 testAddUnreachableUserFromFederatingBackend = do
   resourcePool <- asks resourcePool
   runCodensity (acquireResources 1 resourcePool) $ \[cDom] -> do
-    ((alice, chad), mp, qcnv) <- runCodensity (startDynamicBackend cDom mempty) $ \_ -> do
+    mp <- runCodensity (startDynamicBackend cDom mempty) $ \_ -> do
       ownDomain <- make OwnDomain & asString
       otherDomain <- make OtherDomain & asString
       [alice, bob, charlie, chad] <-
@@ -86,26 +86,12 @@ testAddUnreachableUserFromFederatingBackend = do
 
       [alice1, bob1, charlie1, chad1] <- traverse (createMLSClient def) [alice, bob, charlie, chad]
       traverse_ uploadNewKeyPackage [bob1, charlie1, chad1]
-      qcnv <- snd <$> createNewGroup alice1
+      void $ createNewGroup alice1
       withWebSockets [bob, charlie] $ \wss -> do
         void $ createAddCommit alice1 [bob, charlie] >>= sendAndConsumeCommitBundle
         forM_ wss $ awaitMatch 5 isMemberJoinNotif
-      mp <- createAddCommit alice1 [chad]
-      pure ((alice, chad), mp, qcnv)
+      createAddCommit alice1 [chad]
 
-    resp <- sendAndConsumeCommitBundle mp
-    chadId <- chad %. "qualified_id"
-    events <- resp %. "events" & asList
-    do
-      event <- assertOne events
-      shouldMatch (event %. "qualified_conversation") qcnv
-      shouldMatch (event %. "type") "conversation.member-join"
-      shouldMatch (event %. "from") (objId alice)
-      members <- event %. "data" %. "users" & asList
-      memberQids <- for members $ \mem -> mem %. "qualified_id"
-      shouldMatch memberQids [chadId]
-
-    runCodensity (startDynamicBackend cDom mempty) $ \_ ->
-      withWebSocket chad $ \ws -> do
-        n <- awaitMatch 10 isMemberJoinNotif ws
-        n %. "data.qualified_target" `shouldMatch` chadId
+    bindResponse (postMLSCommitBundle mp.sender (mkBundle mp)) $ \resp -> do
+      resp.status `shouldMatchInt` 533
+      resp.jsonBody %. "unreachable_backends" `shouldMatchSet` [cDom.berDomain]

--- a/libs/wire-api/src/Wire/API/FederationStatus.hs
+++ b/libs/wire-api/src/Wire/API/FederationStatus.hs
@@ -11,12 +11,14 @@ import Data.Aeson qualified as A
 import Data.Aeson.Types qualified as A
 import Data.Domain
 import Data.OpenApi qualified as S
+import Data.Qualified
 import Data.Schema
+import Data.Set qualified as Set
 import Imports
 import Wire.Arbitrary
 
 newtype RemoteDomains = RemoteDomains
-  { rdDomains :: Set Domain
+  { rdDomains :: Set (Remote ())
   }
   deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform RemoteDomains)
@@ -26,7 +28,8 @@ instance ToSchema RemoteDomains where
   schema =
     objectWithDocModifier "RemoteDomains" (description ?~ "A set of remote domains") $
       RemoteDomains
-        <$> rdDomains .= field "domains" (set schema)
+        <$> (Set.map tDomain . rdDomains)
+          .= field "domains" (Set.map (flip toRemoteUnsafe ()) <$> set schema)
 
 -- | This value expresses if the requested remote domains are fully connected or not.
 -- If not the response will contain the first pair of domains found

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/FederationStatus.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/FederationStatus.hs
@@ -18,8 +18,9 @@
 module Test.Wire.API.Golden.Manual.FederationStatus where
 
 import Data.Domain (Domain (..))
+import Data.Qualified
 import Data.Set qualified as Set
-import Imports (Monoid (mempty), ($))
+import Imports
 import Wire.API.FederationStatus
 
 testObject_FederationStatus_1 :: FederationStatus
@@ -29,7 +30,9 @@ testObject_FederationStatus_2 :: FederationStatus
 testObject_FederationStatus_2 = NotConnectedDomains (Domain "d.example.com") (Domain "e.example.com")
 
 testObject_RemoteDomains_1 :: RemoteDomains
-testObject_RemoteDomains_1 = RemoteDomains $ Set.fromList [Domain "a.example.com", Domain "b.example.com"]
+testObject_RemoteDomains_1 =
+  RemoteDomains . Set.fromList $
+    flip toRemoteUnsafe () <$> [Domain "a.example.com", Domain "b.example.com"]
 
 testObject_RemoteDomains_2 :: RemoteDomains
 testObject_RemoteDomains_2 = RemoteDomains mempty

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -115,7 +115,7 @@ import Wire.API.Federation.API.Brig
 import Wire.API.Federation.API.Galley
 import Wire.API.Federation.API.Galley qualified as F
 import Wire.API.Federation.Error
-import Wire.API.FederationStatus (FederationStatus (FullyConnected, NotConnectedDomains), RemoteDomains (..))
+import Wire.API.FederationStatus
 import Wire.API.MLS.CipherSuite
 import Wire.API.Routes.Internal.Brig.Connection
 import Wire.API.Team.Feature
@@ -346,8 +346,11 @@ getFederationStatus req = do
   fmap firstConflictOrFullyConnected
     . (ensureNoUnreachableBackends =<<)
     $ E.runFederatedConcurrentlyEither
-      (flip toRemoteUnsafe () <$> Set.toList req.rdDomains)
-      (\qds -> fedClient @'Brig @"get-not-fully-connected-backends" (DomainSet (tDomain qds `Set.delete` req.rdDomains)))
+      (Set.toList req.rdDomains)
+      ( \qds ->
+          fedClient @'Brig @"get-not-fully-connected-backends"
+            (DomainSet . Set.map tDomain $ void qds `Set.delete` req.rdDomains)
+      )
 
 -- | "conflict" here means two remote domains that we are connected to
 -- but are not connected to each other.
@@ -519,13 +522,11 @@ performConversationJoin qusr lconv (ConversationJoin invited role) = do
 
   addMembersToLocalConversation (fmap (.convId) lconv) newMembers role
   where
-    checkRemoteBackendsConnected ::
-      Local UserId ->
-      Sem r ()
-    checkRemoteBackendsConnected lusr = do
-      let invitedRemoteUsers = filter ((/= tDomain lconv) . tDomain) $ snd (partitionQualified lusr $ NE.toList invited)
-          invitedRemoteDomains = Set.fromList $ tDomain <$> invitedRemoteUsers
-          existingRemoteDomains = Set.fromList $ tDomain . rmId <$> convRemoteMembers (tUnqualified lconv)
+    checkRemoteBackendsConnected :: Local x -> Sem r ()
+    checkRemoteBackendsConnected loc = do
+      let invitedRemoteUsers = snd . partitionQualified loc . NE.toList $ invited
+          invitedRemoteDomains = Set.fromList $ void <$> invitedRemoteUsers
+          existingRemoteDomains = Set.fromList $ void . rmId <$> convRemoteMembers (tUnqualified lconv)
           allInvitedAlreadyInConversation = null $ invitedRemoteDomains \\ existingRemoteDomains
 
       if not allInvitedAlreadyInConversation

--- a/services/galley/src/Galley/API/Action.hs
+++ b/services/galley/src/Galley/API/Action.hs
@@ -529,12 +529,8 @@ performConversationJoin qusr lconv (ConversationJoin invited role) = do
           existingRemoteDomains = Set.fromList $ void . rmId <$> convRemoteMembers (tUnqualified lconv)
           allInvitedAlreadyInConversation = null $ invitedRemoteDomains \\ existingRemoteDomains
 
-      if not allInvitedAlreadyInConversation
-        then checkFederationStatus (RemoteDomains (invitedRemoteDomains <> existingRemoteDomains))
-        else -- even if there are no new remotes, we still need to check they are reachable
-        void . (ensureNoUnreachableBackends =<<) $
-          E.runFederatedConcurrentlyEither @_ @'Brig invitedRemoteUsers $ \_ ->
-            pure ()
+      unless allInvitedAlreadyInConversation $
+        checkFederationStatus (RemoteDomains (invitedRemoteDomains <> existingRemoteDomains))
 
     conv :: Data.Conversation
     conv = tUnqualified lconv

--- a/services/galley/src/Galley/API/Create.hs
+++ b/services/galley/src/Galley/API/Create.hs
@@ -155,7 +155,7 @@ createGroupConversation ::
   NewConv ->
   Sem r CreateGroupConversationResponse
 createGroupConversation lusr conn newConv = do
-  let remoteDomains = tDomain <$> snd (partitionQualified lusr $ newConv.newConvQualifiedUsers)
+  let remoteDomains = void <$> snd (partitionQualified lusr $ newConv.newConvQualifiedUsers)
   checkFederationStatus (RemoteDomains $ Set.fromList remoteDomains)
   cnv <-
     createGroupConversationGeneric


### PR DESCRIPTION
This ended up changing no logic in the application code. However, tests have been extended to confirm the expected behavior.

Tracked by https://wearezeta.atlassian.net/browse/WPB-5208.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
