### PR TITLE
Hotfix: Fixing how mls-test-cli is called

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-5330
+++ b/changelog.d/3-bug-fixes/WPB-5330
@@ -1,0 +1,1 @@
+Updating tests to fix an issue calling `mls-test-cli`

--- a/integration/test/MLS/Util.hs
+++ b/integration/test/MLS/Util.hs
@@ -724,7 +724,7 @@ createApplicationMessage cid messageContent = do
   message <-
     mlscli
       cid
-      ["message", "--group-in", "<group-in>", messageContent, "--group-out", "<group-out>"]
+      ["message", "--group", "<group-in>", messageContent]
       Nothing
 
   pure

--- a/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
@@ -123,7 +123,7 @@ testParseApplication = do
   msgData <- withSystemTempDirectory "mls" $ \tmp -> do
     void $ spawn (cli qcid tmp ["init", qcid]) Nothing
     groupJSON <- spawn (cli qcid tmp ["group", "create", "Zm9v"]) Nothing
-    spawn (cli qcid tmp ["message", "--group-in", "-", "hello"]) (Just groupJSON)
+    spawn (cli qcid tmp ["message", "--group", "-", "hello"]) (Just groupJSON)
 
   msg <- case decodeMLS' @Message msgData of
     Left err -> assertFailure (T.unpack err)

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -647,7 +647,7 @@ createApplicationMessage cid messageContent = do
   message <-
     mlscli
       cid
-      ["message", "--group-in", "<group-in>", messageContent, "--group-out", "<group-out>"]
+      ["message", "--group", "<group-in>", messageContent]
       Nothing
 
   pure $


### PR DESCRIPTION
## Changes
Removing command args that were causing `mls-test-cli` to throw errors in the test suites.

## Checklist

 - [:heavy_check_mark:] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [:heavy_check_mark:] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
