### PR TITLE
Swagger docs: new line after fed call tag

### DIFF
--- a/changelog.d/5-internal/WPB-4853
+++ b/changelog.d/5-internal/WPB-4853
@@ -1,1 +1,1 @@
-The fedcalls tool no longer walks the Swagger/OpenAPI structure when generating call graphs. These graphs are now generated directly from the Servant API types.
+The fedcalls tool no longer walks the Swagger/OpenAPI structure when generating call graphs. These graphs are now generated directly from the Servant API types. (#3674, #3691)

--- a/libs/wire-api/src/Wire/API/MakesFederatedCall.hs
+++ b/libs/wire-api/src/Wire/API/MakesFederatedCall.hs
@@ -185,7 +185,7 @@ instance (HasOpenApi api, KnownSymbol name, KnownSymbol (ShowComponent comp)) =>
     toOpenApi (Proxy @api)
       -- Append federated call line to the description of routes
       -- that perform calls to federation members.
-      & S.allOperations . S.description %~ pure . maybe call (\d -> d <> "\n" <> call)
+      & S.allOperations . S.description %~ pure . maybe call (\d -> d <> "<br>" <> call)
     where
       call :: Text
       call =


### PR DESCRIPTION
## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)

before:

![image](https://github.com/wireapp/wire-server/assets/3968185/efedd912-7198-4e71-a959-7371f48f8c83)

after:

![image](https://github.com/wireapp/wire-server/assets/3968185/312007e5-7af2-42cd-b6eb-25e4a29d1e0b)
