### PR TITLE
Revert "Hotfix: Fixing how mls-test-cli is called (#3690)"

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-5330
+++ b/changelog.d/3-bug-fixes/WPB-5330
@@ -1,1 +1,0 @@
-Updating tests to fix an issue calling `mls-test-cli`

--- a/integration/test/MLS/Util.hs
+++ b/integration/test/MLS/Util.hs
@@ -724,7 +724,7 @@ createApplicationMessage cid messageContent = do
   message <-
     mlscli
       cid
-      ["message", "--group", "<group-in>", messageContent]
+      ["message", "--group-in", "<group-in>", messageContent, "--group-out", "<group-out>"]
       Nothing
 
   pure

--- a/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
+++ b/libs/wire-api/test/unit/Test/Wire/API/MLS.hs
@@ -123,7 +123,7 @@ testParseApplication = do
   msgData <- withSystemTempDirectory "mls" $ \tmp -> do
     void $ spawn (cli qcid tmp ["init", qcid]) Nothing
     groupJSON <- spawn (cli qcid tmp ["group", "create", "Zm9v"]) Nothing
-    spawn (cli qcid tmp ["message", "--group", "-", "hello"]) (Just groupJSON)
+    spawn (cli qcid tmp ["message", "--group-in", "-", "hello"]) (Just groupJSON)
 
   msg <- case decodeMLS' @Message msgData of
     Left err -> assertFailure (T.unpack err)

--- a/services/galley/test/integration/API/MLS/Util.hs
+++ b/services/galley/test/integration/API/MLS/Util.hs
@@ -647,7 +647,7 @@ createApplicationMessage cid messageContent = do
   message <-
     mlscli
       cid
-      ["message", "--group", "<group-in>", messageContent]
+      ["message", "--group-in", "<group-in>", messageContent, "--group-out", "<group-out>"]
       Nothing
 
   pure $


### PR DESCRIPTION
This reverts commit 58bcc0c03c99519442ce7979dff12a4bf2cd6d9a.

The PR ran without the usual CI checks, and it broke the `develop` branch: https://concourse.ops.zinfra.io/teams/main/pipelines/staging/jobs/wire-server-compile-nix/builds/822

## Checklist

 - [x] No changelog
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
