### PR TITLE
Coturn: avoid name clashes when installing multiple times

### DIFF
--- a/changelog.d/5-internal/coturn-multiple-installations
+++ b/changelog.d/5-internal/coturn-multiple-installations
@@ -1,0 +1,1 @@
+Allow to install the coturn chart multiple times in multiple namespaces on the same cluster.

--- a/charts/coturn/templates/service-account.yaml
+++ b/charts/coturn/templates/service-account.yaml
@@ -12,7 +12,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: coturn
+  name: coturn-{{ .Release.Namespace }}
   labels:
     app: coturn
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -26,7 +26,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: coturn
+  name: coturn-{{ .Release.Namespace }}
   labels:
     app: coturn
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -35,7 +35,7 @@ metadata:
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  name: coturn
+  name: coturn-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: coturn


### PR DESCRIPTION
See also https://github.com/zinfra/cailleach/pull/1860 for prood of concept of this working.

In theory for other purposes, a Role and RoleBinding could be used. But that is not powerful enough to provide the "get nodes" permission which is scoped at the cluster level. To avoid helm tripping over objects installed in another release, create multiple of these roles and bindings.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
