### PR TITLE
Increase SQS timeout in galley integration

### DIFF
--- a/changelog.d/5-internal/increase-sqs-timeout
+++ b/changelog.d/5-internal/increase-sqs-timeout
@@ -1,0 +1,1 @@
+Increase timeout for waiting for SQS notifications in galley's integration tests

--- a/libs/types-common-aws/src/Util/Test/SQS.hs
+++ b/libs/types-common-aws/src/Util/Test/SQS.hs
@@ -90,12 +90,12 @@ waitForMessage watcher seconds predicate = timeout (seconds * 1_000_000) poll
           (x : _) -> (delete x events, Just x)
       maybe (threadDelay 10000 >> poll) pure matched
 
--- | First waits for a message matching a given predicate for 3 seconds (this
+-- | First waits for a message matching a given predicate for 10 seconds (this
 -- number could be chosen more scientifically) and then uses a callback to make
 -- an assertion on such a message.
 assertMessage :: (MonadUnliftIO m, Eq a, HasCallStack) => SQSWatcher a -> String -> (a -> Bool) -> (String -> Maybe a -> m ()) -> m ()
 assertMessage watcher label predicate callback = do
-  matched <- waitForMessage watcher 3 predicate
+  matched <- waitForMessage watcher 10 predicate
   callback label matched
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
It seems 3 seconds is not enough sometimes, and it was causing flakiness of legalhold tests in CI.

https://wearezeta.atlassian.net/browse/WPB-5359

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
