### PR TITLE
[WPB 5356] fix brig flaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ result-*
 
 services/nginz/third_party/headers-more-nginx-module
 services/nginz/third_party/nginx-module-vts
+
+# dumped out by running tests in kind
+logs-integration

--- a/changelog.d/3-bug-fixes/brig-flake
+++ b/changelog.d/3-bug-fixes/brig-flake
@@ -1,0 +1,1 @@
+don't use shell when communicating with mls-test-cli

--- a/services/brig/test/integration/API/MLS/Util.hs
+++ b/services/brig/test/integration/API/MLS/Util.hs
@@ -51,9 +51,10 @@ data KeyingInfo = KeyingInfo
 instance Default KeyingInfo where
   def = KeyingInfo SetKey Nothing
 
-cliCmd :: FilePath -> ClientIdentity -> [String]
-cliCmd tmp qcid =
-  ["mls-test-cli", "--store", tmp </> (show qcid <> ".db")]
+cliCmd :: FilePath -> ClientIdentity -> [String] -> CreateProcess
+cliCmd tmp qcid cmnds =
+  proc "mls-test-cli" $
+    ["--store", tmp </> (show qcid <> ".db")] <> cmnds
 
 initStore ::
   HasCallStack =>
@@ -62,9 +63,8 @@ initStore ::
   ClientIdentity ->
   m ()
 initStore tmp qcid = do
-  let cmd0 = cliCmd tmp qcid
-  void . liftIO . flip spawn Nothing . shell . unwords $
-    cmd0 <> ["init", show qcid]
+  void . liftIO . flip spawn Nothing $
+    cliCmd tmp qcid ["init", show qcid]
 
 generateKeyPackage ::
   HasCallStack =>
@@ -74,13 +74,12 @@ generateKeyPackage ::
   Maybe Timeout ->
   m (RawMLS KeyPackage, KeyPackageRef)
 generateKeyPackage tmp qcid lifetime = do
-  let cmd0 = cliCmd tmp qcid
   kp <-
     liftIO $
-      decodeMLSError <=< (flip spawn Nothing . shell . unwords) $
-        cmd0
-          <> ["key-package", "create"]
-          <> (("--lifetime " <>) . show . (#> Second) <$> maybeToList lifetime)
+      decodeMLSError <=< flip spawn Nothing $
+        cliCmd tmp qcid $
+          ["key-package", "create"]
+            <> (("--lifetime " <>) . show . (#> Second) <$> maybeToList lifetime)
   let ref = fromJust (kpRef' kp)
   pure (kp, ref)
 
@@ -94,22 +93,22 @@ uploadKeyPackages ::
   Int ->
   Http ()
 uploadKeyPackages brig tmp KeyingInfo {..} u c n = do
-  let cmd0 = cliCmd tmp cid
-      cid = mkClientIdentity u c
+  let cid = mkClientIdentity u c
   initStore tmp cid
   kps <- replicateM n (fst <$> generateKeyPackage tmp cid kiLifetime)
   when (kiSetKey == SetKey) $
     do
       pk <-
-        liftIO . flip spawn Nothing . shell . unwords $
-          cmd0 <> ["public-key"]
+        liftIO . flip spawn Nothing $
+          cliCmd tmp cid ["public-key"]
       put
         ( brig
             . paths ["clients", toByteString' c]
             . zUser (qUnqualified u)
             . json defUpdateClient {updateClientMLSPublicKeys = Map.fromList [(Ed25519, pk)]}
         )
-      !!! const 200 === statusCode
+      !!! const 200
+        === statusCode
   let upload = object ["key_packages" .= toJSON (map (Base64ByteString . raw) kps)]
   post
     ( brig
@@ -117,7 +116,8 @@ uploadKeyPackages brig tmp KeyingInfo {..} u c n = do
         . zUser (qUnqualified u)
         . json upload
     )
-    !!! const (case kiSetKey of SetKey -> 201; DontSetKey -> 400) === statusCode
+    !!! const (case kiSetKey of SetKey -> 201; DontSetKey -> 400)
+      === statusCode
 
 getKeyPackageCount :: HasCallStack => Brig -> Qualified UserId -> ClientId -> Http KeyPackageCount
 getKeyPackageCount brig u c =
@@ -127,7 +127,8 @@ getKeyPackageCount brig u c =
           . paths ["mls", "key-packages", "self", toByteString' c, "count"]
           . zUser (qUnqualified u)
       )
-      <!! const 200 === statusCode
+      <!! const 200
+        === statusCode
 
 decodeMLSError :: ParseMLS a => ByteString -> IO a
 decodeMLSError s = case decodeMLS' s of


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-5356

Not entirely sure this fixes it but it's the only thing we're doing differently so it might be worth a shot :) 

> [!NOTE]
> I investigated into one of the flaking tests. As the flake only occurs with theses tests I can basically localise the flaking to one location, the issue being that I cannot reproduce it locally. Neither in the normal testsuite nor in a local cluster.
> Due to what the error says I’m suspecting some sort of memory corruption, normally you get this error when you pass an unitialised buffer or a null pointer.
> As I cannot reproduce, Akshays guess was that it’s somehow influenced by other tests. (Which is hard to test again because I cannot run the entire test suite 100 times locally) so what I’m going to try today is replace the shelling out part and then see whether that fixes it and perhaps read some relevant GHC code as Paolo suggested it might be a bug in GHC code for shelling out

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
