### PR TITLE
Update group ID documentation

### DIFF
--- a/changelog.d/4-docs/group-id-docs
+++ b/changelog.d/4-docs/group-id-docs
@@ -1,0 +1,1 @@
+Update documentation of MLS group ID

--- a/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
+++ b/libs/wire-api/src/Wire/API/Conversation/Protocol.hs
@@ -75,7 +75,7 @@ mlsDataSchema =
     <$> cnvmlsGroupId
       .= fieldWithDocModifier
         "group_id"
-        (description ?~ "An MLS group identifier (at most 256 bytes long)")
+        (description ?~ "A base64-encoded MLS group ID")
         schema
     <*> cnvmlsEpoch
       .= fieldWithDocModifier


### PR DESCRIPTION
The MLS group ID is base64-encoded, and not anymore limited to 256 bytes.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
