### PR TITLE
Refactor getOptions

### DIFF
--- a/changelog.d/5-internal/refactor-get-options
+++ b/changelog.d/5-internal/refactor-get-options
@@ -1,0 +1,1 @@
+Refactor getOptions


### PR DESCRIPTION
We can combine the two parsers instead of invoking them both. This way we get a help text even if no configuration file is passed.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
