### PR TITLE
Avoid generating client IDs with leading zeros

### DIFF
--- a/changelog.d/3-bug-fixes/client-id-leading-zeros
+++ b/changelog.d/3-bug-fixes/client-id-leading-zeros
@@ -1,0 +1,1 @@
+Prevent client IDs with leading zeros from being generated. This works around a type mismatch in the protobuf API, where client IDs are represented as uint64.

--- a/libs/wire-api/src/Wire/API/User/Client/Prekey.hs
+++ b/libs/wire-api/src/Wire/API/User/Client/Prekey.hs
@@ -40,6 +40,7 @@ import Data.ByteString.Conversion (toByteString')
 import Data.Id
 import Data.OpenApi qualified as S
 import Data.Schema
+import Data.Text qualified as T
 import Data.Text.Ascii (encodeBase16)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Imports
@@ -70,6 +71,7 @@ instance ToSchema Prekey where
 clientIdFromPrekey :: Prekey -> ClientId
 clientIdFromPrekey =
   ClientId
+    . T.dropWhile (== '0')
     . decodeUtf8
     . toByteString'
     . encodeBase16


### PR DESCRIPTION
Leading zeros in client IDs expose an issue with the protobuf messaging API, since there client IDs are represented as uint64. This commit works around th eissue by removing any leading zeros when generating a new client ID.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
