### PR TITLE
Use string-typed client field in message protobuf

### DIFF
--- a/changelog.d/3-bug-fixes/fix-client-id-types
+++ b/changelog.d/3-bug-fixes/fix-client-id-types
@@ -1,0 +1,1 @@
+Use string-typed client field in message protobuf

--- a/integration/test/API/Galley.hs
+++ b/integration/test/API/Galley.hs
@@ -13,8 +13,8 @@ import Data.ByteString.Char8 qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import Data.ProtoLens qualified as Proto
 import Data.ProtoLens.Labels ()
+import Data.Text qualified as T
 import Data.UUID qualified as UUID
-import Numeric.Lens
 import Proto.Otr as Proto
 import Testlib.Prelude
 
@@ -244,7 +244,7 @@ mkProteusRecipients dom userClients msg = do
           & #user . #uuid .~ userId
           & #clients .~ clientEntries
     mkClientEntry client = do
-      clientId <- (^?! hex) <$> objId client
+      clientId <- T.pack <$> asString client
       pure $
         Proto.defMessage
           & #client . #client .~ clientId

--- a/integration/test/Test/Federation.hs
+++ b/integration/test/Test/Federation.hs
@@ -9,8 +9,8 @@ import Control.Monad.Codensity
 import Control.Monad.Reader
 import Data.ProtoLens qualified as Proto
 import Data.ProtoLens.Labels ()
+import Data.Text qualified as T
 import Notifications
-import Numeric.Lens
 import Proto.Otr qualified as Proto
 import Proto.Otr_Fields qualified as Proto
 import SetupHelpers
@@ -51,7 +51,7 @@ testNotificationsForOfflineBackends = do
       successfulMsgForDownUser <- mkProteusRecipient downUser1 downClient1 "success message for down user"
       let successfulMsg =
             Proto.defMessage @Proto.QualifiedNewOtrMessage
-              & #sender . Proto.client .~ (delClient ^?! hex)
+              & #sender . Proto.client .~ T.pack delClient
               & #recipients .~ [successfulMsgForOtherUsers, successfulMsgForDownUser]
               & #reportAll .~ Proto.defMessage
       bindResponse (postProteusMessage delUser upBackendConv successfulMsg) assertSuccess
@@ -61,7 +61,7 @@ testNotificationsForOfflineBackends = do
       failedMsgForDownUser <- mkProteusRecipient downUser1 downClient1 "failed message for down user"
       let failedMsg =
             Proto.defMessage @Proto.QualifiedNewOtrMessage
-              & #sender . Proto.client .~ (delClient ^?! hex)
+              & #sender . Proto.client .~ T.pack delClient
               & #recipients .~ [failedMsgForOtherUser, failedMsgForDownUser]
               & #reportAll .~ Proto.defMessage
       bindResponse (postProteusMessage delUser downBackendConv failedMsg) $ \resp ->

--- a/libs/types-common/src/Data/Id.hs
+++ b/libs/types-common/src/Data/Id.hs
@@ -43,6 +43,7 @@ module Data.Id
     -- * Client IDs
     ClientId (..),
     newClientId,
+    clientIdFromText,
 
     -- * Other IDs
     ConnId (..),
@@ -315,13 +316,13 @@ newtype ClientId = ClientId
   deriving (FromJSON, ToJSON, S.ToSchema) via Schema ClientId
 
 instance ToSchema ClientId where
-  schema = client .= parsedText "ClientId" clientIdFromByteString
+  schema = client .= parsedText "ClientId" clientIdFromText
 
 newClientId :: Word64 -> ClientId
 newClientId = ClientId . toStrict . toLazyText . hexadecimal
 
-clientIdFromByteString :: Text -> Either String ClientId
-clientIdFromByteString txt =
+clientIdFromText :: Text -> Either String ClientId
+clientIdFromText txt =
   if T.length txt <= 20 && T.all isHexDigit txt
     then Right $ ClientId txt
     else Left "Invalid ClientId"
@@ -329,10 +330,10 @@ clientIdFromByteString txt =
 instance FromByteString ClientId where
   parser = do
     bs <- Atto.takeByteString
-    either fail pure $ clientIdFromByteString (cs bs)
+    either fail pure $ clientIdFromText (cs bs)
 
 instance A.FromJSONKey ClientId where
-  fromJSONKey = A.FromJSONKeyTextParser $ either fail pure . clientIdFromByteString
+  fromJSONKey = A.FromJSONKeyTextParser $ either fail pure . clientIdFromText
 
 deriving instance Cql ClientId
 

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -314,6 +314,7 @@ library
     , tagged
     , text                       >=0.11
     , time                       >=1.4
+    , transformers
     , transitive-anns
     , types-common               >=0.16
     , unordered-containers       >=0.2


### PR DESCRIPTION
This makes the backend use the string-typed field for the client ID in a protobuf message envelope.

https://wearezeta.atlassian.net/browse/WPB-5430

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
