### PR TITLE
Reduce the size for CI image by getting rid of 2 GHCs

### DIFF
--- a/changelog.d/5-internal/reduce-ci-image-size
+++ b/changelog.d/5-internal/reduce-ci-image-size
@@ -1,0 +1,3 @@
+Remove apply-refact from CI image
+
+This gets rid of GHC in the image, making the image smaller.

--- a/nix/wire-server.nix
+++ b/nix/wire-server.nix
@@ -410,13 +410,12 @@ let
     pkgs.kubernetes-helm
     pkgs.helmfile
     pkgs.hlint
-    (hlib.justStaticExecutables pkgs.haskellPackages.apply-refact)
     pkgs.jq
     pkgs.kubectl
     pkgs.kubelogin-oidc
     pkgs.nixpkgs-fmt
     pkgs.openssl
-    ormolu
+    (hlib.justStaticExecutables ormolu)
     pkgs.shellcheck
     pkgs.treefmt
     pkgs.gawk
@@ -495,6 +494,7 @@ in
       pkgs.kind
       pkgs.netcat
       pkgs.niv
+      (hlib.justStaticExecutables pkgs.haskellPackages.apply-refact)
       (pkgs.python3.withPackages
         (ps: with ps; [
           black


### PR DESCRIPTION
apply-refact refers to the GHC that it builds with by using the GHC.Paths module. This tool is actually not required in CI.

ormolu was referring to GHC and all its haskell dependencies as "propagatedBuildInputs". Using `hlib.justStaticExecutables` we can get rid of these.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
