### PR TITLE
[feat] add support for ghc-flakr's hs-run executable

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -16,13 +16,16 @@ env_dir=./.env
 [[ -d "$layout_dir" ]] || mkdir -p "$layout_dir"
 
 if [[ ! -d "$env_dir" || ! -f "$layout_dir/nix-rebuild" || "$store_paths" != $(< "$layout_dir/nix-rebuild" ) ]]; then
+  bcmd=nix
   if command -v nom &> /dev/null; then
     if [[ "${USE_NOM}" != "0" ]]; then
-      nom build -f nix wireServer.devEnv --out-link ./.env
+      bcmd=nom
     fi
-  else
-    nix build -f nix wireServer.devEnv -Lv --out-link ./.env
   fi
+  echo "🔧 Building environment"
+  $bcmd build -f nix wireServer.devEnv -Lv --out-link ./.env
+  echo "🔧 Building hs-run"
+  $bcmd build github:wireapp/ghc-flakr -Lv --out-link ./.env
   echo "$store_paths" > "$layout_dir/nix-rebuild"
 fi
 

--- a/changelog.d/5-internal/add-ghc-flakr
+++ b/changelog.d/5-internal/add-ghc-flakr
@@ -1,0 +1,1 @@
+adds a new executable, hs-run, to quickly run haskell scripts

--- a/hack/bin/.envrc
+++ b/hack/bin/.envrc
@@ -1,0 +1,1 @@
+use flake github:wireapp/ghc-flakr -Lv


### PR DESCRIPTION
This PR is according to our discussion in C&D from November 14, 2023.

Mind that the pinning is done by `ghc-flakr` itself to ensure caching. 

https://github.com/wireapp/ghc-flakr

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
