### PR TITLE
[WPB-1226] Servantify internal Galley conversation endpoints

### DIFF
--- a/changelog.d/5-internal/WPB-1226-servantify-internal-galley-conv-endpoints
+++ b/changelog.d/5-internal/WPB-1226-servantify-internal-galley-conv-endpoints
@@ -1,0 +1,1 @@
+Migrate to Servant the Galley conversation internal endpoints

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -505,6 +505,14 @@ type IConversationAPI =
                :> "unblock"
                :> Put '[Servant.JSON] Conversation
            )
+    :<|> Named
+           "conversation-meta"
+           ( CanThrow 'ConvNotFound
+               :> "conversations"
+               :> Capture "cnv" ConvId
+               :> "meta"
+               :> Get '[Servant.JSON] ConversationMetadata
+           )
 
 swaggerDoc :: OpenApi
 swaggerDoc =

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -456,6 +456,14 @@ type IConversationAPI =
         :> "channel"
         :> Put '[Servant.JSON] ()
     )
+    :<|> Named
+           "conversation-get-member"
+           ( "conversations"
+               :> Capture "cnv" ConvId
+               :> "members"
+               :> Capture "usr" UserId
+               :> Get '[Servant.JSON] (Maybe Member)
+           )
 
 swaggerDoc :: OpenApi
 swaggerDoc =

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -449,21 +449,13 @@ type IFederationAPI =
 
 type IConversationAPI =
   Named
-    "conversation-channel"
-    ( ZLocalUser
-        :> "conversations"
+    "conversation-get-member"
+    ( "conversations"
         :> Capture "cnv" ConvId
-        :> "channel"
-        :> Put '[Servant.JSON] ()
+        :> "members"
+        :> Capture "usr" UserId
+        :> Get '[Servant.JSON] (Maybe Member)
     )
-    :<|> Named
-           "conversation-get-member"
-           ( "conversations"
-               :> Capture "cnv" ConvId
-               :> "members"
-               :> Capture "usr" UserId
-               :> Get '[Servant.JSON] (Maybe Member)
-           )
     -- This endpoint can lead to the following events being sent:
     -- - MemberJoin event to you, if the conversation existed and had < 2 members before
     -- - MemberJoin event to other, if the conversation existed and only the other was member

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -464,6 +464,22 @@ type IConversationAPI =
                :> Capture "usr" UserId
                :> Get '[Servant.JSON] (Maybe Member)
            )
+    -- This endpoint can lead to the following events being sent:
+    -- - MemberJoin event to you, if the conversation existed and had < 2 members before
+    -- - MemberJoin event to other, if the conversation existed and only the other was member
+    --   before
+    :<|> Named
+           "conversation-accept-v2"
+           ( CanThrow 'InvalidOperation
+               :> CanThrow 'ConvNotFound
+               :> ZLocalUser
+               :> ZOptConn
+               :> "conversations"
+               :> Capture "cnv" ConvId
+               :> "accept"
+               :> "v2"
+               :> Put '[Servant.JSON] Conversation
+           )
 
 swaggerDoc :: OpenApi
 swaggerDoc =

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -480,6 +480,16 @@ type IConversationAPI =
                :> "v2"
                :> Put '[Servant.JSON] Conversation
            )
+    :<|> Named
+           "conversation-block"
+           ( CanThrow 'InvalidOperation
+               :> CanThrow 'ConvNotFound
+               :> ZUser
+               :> "conversations"
+               :> Capture "cnv" ConvId
+               :> "block"
+               :> Put '[Servant.JSON] ()
+           )
 
 swaggerDoc :: OpenApi
 swaggerDoc =

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -490,6 +490,21 @@ type IConversationAPI =
                :> "block"
                :> Put '[Servant.JSON] ()
            )
+    -- This endpoint can lead to the following events being sent:
+    -- - MemberJoin event to you, if the conversation existed and had < 2 members before
+    -- - MemberJoin event to other, if the conversation existed and only the other was member
+    --   before
+    :<|> Named
+           "conversation-unblock"
+           ( CanThrow 'InvalidOperation
+               :> CanThrow 'ConvNotFound
+               :> ZLocalUser
+               :> ZOptConn
+               :> "conversations"
+               :> Capture "cnv" ConvId
+               :> "unblock"
+               :> Put '[Servant.JSON] Conversation
+           )
 
 swaggerDoc :: OpenApi
 swaggerDoc =

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -250,6 +250,7 @@ type InternalAPIBase =
            )
     :<|> IFeatureAPI
     :<|> IFederationAPI
+    :<|> IConversationAPI
 
 type ILegalholdWhitelistedTeamsAPI =
   "legalhold"
@@ -444,6 +445,16 @@ type IFederationAPI =
         :> "federation-status"
         :> ReqBody '[Servant.JSON] RemoteDomains
         :> Get '[Servant.JSON] FederationStatus
+    )
+
+type IConversationAPI =
+  Named
+    "conversation-channel"
+    ( ZLocalUser
+        :> "conversations"
+        :> Capture "cnv" ConvId
+        :> "channel"
+        :> Put '[Servant.JSON] ()
     )
 
 swaggerDoc :: OpenApi

--- a/services/galley/src/Galley/API.hs
+++ b/services/galley/src/Galley/API.hs
@@ -16,7 +16,7 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Galley.API
-  ( sitemap,
+  ( waiSitemap,
     servantSitemap,
   )
 where
@@ -28,7 +28,7 @@ import Galley.App (GalleyEffects)
 import Network.Wai.Routing (Routes)
 import Polysemy
 
-sitemap :: Routes () (Sem GalleyEffects) ()
-sitemap = do
+waiSitemap :: Routes () (Sem GalleyEffects) ()
+waiSitemap = do
   Public.sitemap
-  internalSitemap
+  waiInternalSitemap

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -124,8 +124,7 @@ federationAPI =
 
 conversationAPI :: API IConversationAPI GalleyEffects
 conversationAPI =
-  mkNamedAPI @"conversation-channel" (const mempty)
-    <@> mkNamedAPI @"conversation-get-member" Query.internalGetMember
+  mkNamedAPI @"conversation-get-member" Query.internalGetMember
     <@> mkNamedAPI @"conversation-accept-v2" Update.acceptConv
     <@> mkNamedAPI @"conversation-block" Update.blockConv
     <@> mkNamedAPI @"conversation-unblock" Update.unblockConv

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -129,6 +129,7 @@ conversationAPI =
     <@> mkNamedAPI @"conversation-accept-v2" Update.acceptConv
     <@> mkNamedAPI @"conversation-block" Update.blockConv
     <@> mkNamedAPI @"conversation-unblock" Update.unblockConv
+    <@> mkNamedAPI @"conversation-meta" Query.getConversationMeta
 
 legalholdWhitelistedTeamsAPI :: API ILegalholdWhitelistedTeamsAPI GalleyEffects
 legalholdWhitelistedTeamsAPI = mkAPI $ \tid -> hoistAPIHandler Imports.id (base tid)
@@ -238,11 +239,6 @@ featureAPI =
 
 waiInternalSitemap :: Routes a (Sem GalleyEffects) ()
 waiInternalSitemap = unsafeCallsFed @'Galley @"on-client-removed" $ unsafeCallsFed @'Galley @"on-mls-message-sent" $ do
-  -- Conversation API (internal) ----------------------------------------
-
-  get "/i/conversations/:cnv/meta" (continue Query.getConversationMetaH) $
-    capture "cnv"
-
   -- Misc API (internal) ------------------------------------------------
 
   get "/i/users/:uid/team/members" (continueE Teams.getBindingTeamMembersH) $

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -127,6 +127,7 @@ conversationAPI =
   mkNamedAPI @"conversation-channel" (const mempty)
     <@> mkNamedAPI @"conversation-get-member" Query.internalGetMember
     <@> mkNamedAPI @"conversation-accept-v2" Update.acceptConv
+    <@> mkNamedAPI @"conversation-block" Update.blockConv
 
 legalholdWhitelistedTeamsAPI :: API ILegalholdWhitelistedTeamsAPI GalleyEffects
 legalholdWhitelistedTeamsAPI = mkAPI $ \tid -> hoistAPIHandler Imports.id (base tid)
@@ -237,10 +238,6 @@ featureAPI =
 waiInternalSitemap :: Routes a (Sem GalleyEffects) ()
 waiInternalSitemap = unsafeCallsFed @'Galley @"on-client-removed" $ unsafeCallsFed @'Galley @"on-mls-message-sent" $ do
   -- Conversation API (internal) ----------------------------------------
-
-  put "/i/conversations/:cnv/block" (continueE Update.blockConvH) $
-    zauthUserId
-      .&. capture "cnv"
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberJoin event to you, if the conversation existed and had < 2 members before

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -128,6 +128,7 @@ conversationAPI =
     <@> mkNamedAPI @"conversation-get-member" Query.internalGetMember
     <@> mkNamedAPI @"conversation-accept-v2" Update.acceptConv
     <@> mkNamedAPI @"conversation-block" Update.blockConv
+    <@> mkNamedAPI @"conversation-unblock" Update.unblockConv
 
 legalholdWhitelistedTeamsAPI :: API ILegalholdWhitelistedTeamsAPI GalleyEffects
 legalholdWhitelistedTeamsAPI = mkAPI $ \tid -> hoistAPIHandler Imports.id (base tid)
@@ -238,15 +239,6 @@ featureAPI =
 waiInternalSitemap :: Routes a (Sem GalleyEffects) ()
 waiInternalSitemap = unsafeCallsFed @'Galley @"on-client-removed" $ unsafeCallsFed @'Galley @"on-mls-message-sent" $ do
   -- Conversation API (internal) ----------------------------------------
-
-  -- This endpoint can lead to the following events being sent:
-  -- - MemberJoin event to you, if the conversation existed and had < 2 members before
-  -- - MemberJoin event to other, if the conversation existed and only the other was member
-  --   before
-  put "/i/conversations/:cnv/unblock" (continueE Update.unblockConvH) $
-    zauthUserId
-      .&. opt zauthConnId
-      .&. capture "cnv"
 
   get "/i/conversations/:cnv/meta" (continue Query.getConversationMetaH) $
     capture "cnv"

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -126,6 +126,7 @@ conversationAPI :: API IConversationAPI GalleyEffects
 conversationAPI =
   mkNamedAPI @"conversation-channel" (const mempty)
     <@> mkNamedAPI @"conversation-get-member" Query.internalGetMember
+    <@> mkNamedAPI @"conversation-accept-v2" Update.acceptConv
 
 legalholdWhitelistedTeamsAPI :: API ILegalholdWhitelistedTeamsAPI GalleyEffects
 legalholdWhitelistedTeamsAPI = mkAPI $ \tid -> hoistAPIHandler Imports.id (base tid)
@@ -236,15 +237,6 @@ featureAPI =
 waiInternalSitemap :: Routes a (Sem GalleyEffects) ()
 waiInternalSitemap = unsafeCallsFed @'Galley @"on-client-removed" $ unsafeCallsFed @'Galley @"on-mls-message-sent" $ do
   -- Conversation API (internal) ----------------------------------------
-
-  -- This endpoint can lead to the following events being sent:
-  -- - MemberJoin event to you, if the conversation existed and had < 2 members before
-  -- - MemberJoin event to other, if the conversation existed and only the other was member
-  --   before
-  put "/i/conversations/:cnv/accept/v2" (continueE Update.acceptConvH) $
-    zauthUserId
-      .&. opt zauthConnId
-      .&. capture "cnv"
 
   put "/i/conversations/:cnv/block" (continueE Update.blockConvH) $
     zauthUserId

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -16,7 +16,7 @@
 -- with this program. If not, see <https://www.gnu.org/licenses/>.
 
 module Galley.API.Internal
-  ( internalSitemap,
+  ( waiInternalSitemap,
     internalAPI,
     InternalAPI,
     deleteLoop,
@@ -228,8 +228,8 @@ featureAPI =
     <@> mkNamedAPI @'("ilock", MlsMigrationConfig) (updateLockStatus @MlsMigrationConfig)
     <@> mkNamedAPI @"feature-configs-internal" (maybe getAllFeatureConfigsForServer getAllFeatureConfigsForUser)
 
-internalSitemap :: Routes a (Sem GalleyEffects) ()
-internalSitemap = unsafeCallsFed @'Galley @"on-client-removed" $ unsafeCallsFed @'Galley @"on-mls-message-sent" $ do
+waiInternalSitemap :: Routes a (Sem GalleyEffects) ()
+waiInternalSitemap = unsafeCallsFed @'Galley @"on-client-removed" $ unsafeCallsFed @'Galley @"on-mls-message-sent" $ do
   -- Conversation API (internal) ----------------------------------------
   put "/i/conversations/:cnv/channel" (continue $ const (pure empty)) $
     zauthUserId

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -125,6 +125,7 @@ federationAPI =
 conversationAPI :: API IConversationAPI GalleyEffects
 conversationAPI =
   mkNamedAPI @"conversation-channel" (const mempty)
+    <@> mkNamedAPI @"conversation-get-member" Query.internalGetMember
 
 legalholdWhitelistedTeamsAPI :: API ILegalholdWhitelistedTeamsAPI GalleyEffects
 legalholdWhitelistedTeamsAPI = mkAPI $ \tid -> hoistAPIHandler Imports.id (base tid)
@@ -235,10 +236,6 @@ featureAPI =
 waiInternalSitemap :: Routes a (Sem GalleyEffects) ()
 waiInternalSitemap = unsafeCallsFed @'Galley @"on-client-removed" $ unsafeCallsFed @'Galley @"on-mls-message-sent" $ do
   -- Conversation API (internal) ----------------------------------------
-
-  get "/i/conversations/:cnv/members/:usr" (continue Query.internalGetMemberH) $
-    capture "cnv"
-      .&. capture "usr"
 
   -- This endpoint can lead to the following events being sent:
   -- - MemberJoin event to you, if the conversation existed and had < 2 members before

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -29,7 +29,7 @@ module Galley.API.Query
     listConversations,
     iterateConversations,
     getLocalSelf,
-    internalGetMemberH,
+    internalGetMember,
     getConversationMetaH,
     getConversationByReusableCode,
     ensureGuestLinksEnabled,
@@ -577,16 +577,17 @@ iterateConversations luid pageSize handleConvs = go Nothing
         _ -> pure []
       pure $ resultHead : resultTail
 
-internalGetMemberH ::
+internalGetMember ::
   ( Member ConversationStore r,
     Member (Input (Local ())) r,
     Member MemberStore r
   ) =>
-  ConvId ::: UserId ->
-  Sem r Response
-internalGetMemberH (cnv ::: usr) = do
+  ConvId ->
+  UserId ->
+  Sem r (Maybe Public.Member)
+internalGetMember cnv usr = do
   lusr <- qualifyLocal usr
-  json <$> getLocalSelf lusr cnv
+  getLocalSelf lusr cnv
 
 getLocalSelf ::
   ( Member ConversationStore r,

--- a/services/galley/src/Galley/API/Query.hs
+++ b/services/galley/src/Galley/API/Query.hs
@@ -30,7 +30,7 @@ module Galley.API.Query
     iterateConversations,
     getLocalSelf,
     internalGetMember,
-    getConversationMetaH,
+    getConversationMeta,
     getConversationByReusableCode,
     ensureGuestLinksEnabled,
     getConversationGuestLinksStatus,
@@ -43,6 +43,7 @@ where
 
 import Cassandra qualified as C
 import Control.Lens
+import Control.Monad.Extra
 import Data.ByteString.Lazy qualified as LBS
 import Data.Code
 import Data.CommaSeparatedList
@@ -77,7 +78,6 @@ import Galley.Options
 import Galley.Types.Conversations.Members
 import Galley.Types.Teams
 import Imports hiding (cs)
-import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Predicate hiding (Error, result, setStatus)
 import Network.Wai.Utilities hiding (Error)
@@ -603,26 +603,17 @@ getLocalSelf lusr cnv = do
       then Mapping.localMemberToSelf lusr <$$> E.getLocalMember cnv (tUnqualified lusr)
       else Nothing <$ E.deleteConversation cnv
 
-getConversationMetaH ::
-  Member ConversationStore r =>
-  ConvId ->
-  Sem r Response
-getConversationMetaH cnv = do
-  getConversationMeta cnv <&> \case
-    Nothing -> setStatus status404 empty
-    Just meta -> json meta
-
 getConversationMeta ::
-  Member ConversationStore r =>
+  ( Member ConversationStore r,
+    Member (ErrorS 'ConvNotFound) r
+  ) =>
   ConvId ->
-  Sem r (Maybe ConversationMetadata)
-getConversationMeta cnv = do
-  alive <- E.isConversationAlive cnv
-  if alive
-    then E.getConversationMetadata cnv
-    else do
-      E.deleteConversation cnv
-      pure Nothing
+  Sem r ConversationMetadata
+getConversationMeta cnv =
+  ifM
+    (E.isConversationAlive cnv)
+    (E.getConversationMetadata cnv >>= noteS @'ConvNotFound)
+    (E.deleteConversation cnv >> throwS @'ConvNotFound)
 
 getConversationByReusableCode ::
   forall r.

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -19,8 +19,8 @@
 
 module Galley.API.Update
   ( -- * Managing Conversations
-    blockConvH,
     acceptConv,
+    blockConv,
     unblockConvH,
     checkReusableCode,
     joinConversationByReusableCode,
@@ -163,17 +163,6 @@ acceptConv lusr conn cnv = do
     E.getConversation cnv >>= noteS @'ConvNotFound
   conv' <- acceptOne2One lusr conv conn
   conversationView lusr conv'
-
-blockConvH ::
-  ( Member ConversationStore r,
-    Member (ErrorS 'ConvNotFound) r,
-    Member (ErrorS 'InvalidOperation) r,
-    Member MemberStore r
-  ) =>
-  UserId ::: ConvId ->
-  Sem r Response
-blockConvH (zusr ::: cnv) =
-  empty <$ blockConv zusr cnv
 
 blockConv ::
   ( Member ConversationStore r,

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -19,8 +19,8 @@
 
 module Galley.API.Update
   ( -- * Managing Conversations
-    acceptConvH,
     blockConvH,
+    acceptConv,
     unblockConvH,
     checkReusableCode,
     joinConversationByReusableCode,
@@ -143,23 +143,6 @@ import Wire.API.Routes.Public.Util (UpdateResult (..))
 import Wire.API.ServantProto (RawProto (..))
 import Wire.API.Team.Member
 import Wire.API.User.Client
-
-acceptConvH ::
-  ( Member ConversationStore r,
-    Member (Error InternalError) r,
-    Member (ErrorS 'ConvNotFound) r,
-    Member (ErrorS 'InvalidOperation) r,
-    Member GundeckAccess r,
-    Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
-    Member MemberStore r,
-    Member TinyLog r
-  ) =>
-  UserId ::: Maybe ConnId ::: ConvId ->
-  Sem r Response
-acceptConvH (usr ::: conn ::: cnv) = do
-  lusr <- qualifyLocal usr
-  setStatus status200 . json <$> acceptConv lusr conn cnv
 
 acceptConv ::
   ( Member ConversationStore r,

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -21,7 +21,7 @@ module Galley.API.Update
   ( -- * Managing Conversations
     acceptConv,
     blockConv,
-    unblockConvH,
+    unblockConv,
     checkReusableCode,
     joinConversationByReusableCode,
     joinConversationById,
@@ -180,23 +180,6 @@ blockConv zusr cnv = do
   let mems = Data.convLocalMembers conv
   when (zusr `isMember` mems) $
     E.deleteMembers cnv (UserList [zusr] [])
-
-unblockConvH ::
-  ( Member ConversationStore r,
-    Member (Error InternalError) r,
-    Member (ErrorS 'ConvNotFound) r,
-    Member (ErrorS 'InvalidOperation) r,
-    Member GundeckAccess r,
-    Member (Input (Local ())) r,
-    Member (Input UTCTime) r,
-    Member MemberStore r,
-    Member TinyLog r
-  ) =>
-  UserId ::: Maybe ConnId ::: ConvId ->
-  Sem r Response
-unblockConvH (usr ::: conn ::: cnv) = do
-  lusr <- qualifyLocal usr
-  setStatus status200 . json <$> unblockConv lusr conn cnv
 
 unblockConv ::
   ( Member ConversationStore r,

--- a/services/galley/src/Galley/Run.hs
+++ b/services/galley/src/Galley/Run.hs
@@ -94,7 +94,7 @@ mkApp opts =
     lift $ runClient (env ^. cstate) $ versionCheck schemaVersion
     let middlewares =
           versionMiddleware (opts ^. settings . disabledAPIVersions . traverse)
-            . servantPlusWAIPrometheusMiddleware API.sitemap (Proxy @CombinedAPI)
+            . servantPlusWAIPrometheusMiddleware API.waiSitemap (Proxy @CombinedAPI)
             . GZip.gunzip
             . GZip.gzip GZip.def
             . catchErrors logger [Right metrics]
@@ -104,7 +104,7 @@ mkApp opts =
       Log.close logger
     pure (middlewares $ servantApp env, env)
   where
-    rtree = compile API.sitemap
+    rtree = compile API.waiSitemap
     runGalley e r k = evalGalleyToIO e (route rtree r k)
     -- the servant API wraps the one defined using wai-routing
     servantApp e0 r =

--- a/services/galley/test/integration/Run.hs
+++ b/services/galley/test/integration/Run.hs
@@ -36,7 +36,7 @@ import Data.Text (pack)
 import Data.Text.Encoding (encodeUtf8)
 import Data.Yaml (decodeFileEither)
 import Federation
-import Galley.API (sitemap)
+import Galley.API
 import Galley.Aws qualified as Aws
 import Galley.Options hiding (endpoint)
 import Galley.Options qualified as O
@@ -101,7 +101,7 @@ main = withOpenSSL $ runTests go
             assertEqual
               "inconsistent sitemap"
               mempty
-              (pathsConsistencyCheck . treeToPaths . compile $ Galley.API.sitemap),
+              (pathsConsistencyCheck . treeToPaths . compile $ Galley.API.waiSitemap),
           API.tests setup,
           test setup "isConvMemberL" isConvMemberLTests
         ]


### PR DESCRIPTION
The PR servantifies a few internal Galley endpoints.

Tracked by https://wearezeta.atlassian.net/browse/WPB-1226.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
