### PR TITLE
Fix shell.nix

### DIFF
--- a/changelog.d/5-internal/fix-shell_nix
+++ b/changelog.d/5-internal/fix-shell_nix
@@ -1,0 +1,1 @@
+Use existing attribute in `shell.nix` (used to create ad-hoc development environments.)

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-(import ./nix).pkgs.wireServer.devShell
+(import ./nix).wireServer.devEnv


### PR DESCRIPTION
The previous attribute path didn't exist and led to error:

```
➜  wire-server git:(develop) nix-shell --pure shell.nix
error: attribute 'wireServer' missing

       at /home/sven/src/wire-server/shell.nix:1:1:

            1| (import ./nix).pkgs.wireServer.devShell
             | ^
            2|
(use '--show-trace' to show detailed location information)
```