### PR TITLE
Delete shell.nix

### DIFF
--- a/changelog.d/5-internal/delete-shell_nix
+++ b/changelog.d/5-internal/delete-shell_nix
@@ -1,0 +1,1 @@
+Delete `shell.nix`. It has been broken for quite some time. The supported way to get a development nix environment is to use direnv.

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,0 @@
-(import ./nix).pkgs.wireServer.devShell


### PR DESCRIPTION
It's broken. And, the official way to get a nix env for this project is to use direnv.