### PR TITLE
[WPB-2565] Extend a team conversation test with event assertions

### DIFF
--- a/changelog.d/2-features/WPB-2565-member-updates
+++ b/changelog.d/2-features/WPB-2565-member-updates
@@ -1,1 +1,1 @@
-Events for a member update, join and leave are not sent to everyone in the team any longer. Only team admins get them.
+Events for a member update, join and leave are not sent to everyone in the team any longer. Only team admins get them. (#3703, #3731)


### PR DESCRIPTION
The PR extends an existing test with a team conversation by joining and deleting members and asserting on the expected events.

Tracked by https://wearezeta.atlassian.net/browse/WPB-2565.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
