### PR TITLE
[fix] fix discovery of directory

### DIFF
--- a/integration/test/Testlib/RunServices.hs
+++ b/integration/test/Testlib/RunServices.hs
@@ -21,7 +21,7 @@ parentDir path =
 
 containsGit :: FilePath -> IO Bool
 containsGit path =
-  doesDirectoryExist $ joinPath [path, ".git"]
+  doesPathExist $ joinPath [path, ".git"]
 
 findProjectRoot :: FilePath -> IO (Maybe FilePath)
 findProjectRoot path = do


### PR DESCRIPTION
Previously this looked for a directory, which is not correct, in git worktrees, the .git dir is shared between multiple directories, .git is merely a file that contains the path to the original .git dir.

## Checklist

 - n/a ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
