### PR TITLE
[chore, fix] `RunServices` support git-worktree

### DIFF
--- a/integration/test/Testlib/RunServices.hs
+++ b/integration/test/Testlib/RunServices.hs
@@ -11,6 +11,7 @@ import System.Process
 import Testlib.Prelude
 import Testlib.ResourcePool
 import Testlib.Run (createGlobalEnv)
+import Control.Monad.Extra (orM)
 
 parentDir :: FilePath -> Maybe FilePath
 parentDir path =
@@ -20,8 +21,9 @@ parentDir path =
         else Just $ joinPath (init dirs)
 
 containsGit :: FilePath -> IO Bool
-containsGit path =
-  doesDirectoryExist $ joinPath [path, ".git"]
+containsGit path = do
+  let gitPath = joinPath [path, ".git"]
+  orM [doesDirectoryExist gitPath, doesFileExist gitPath]
 
 findProjectRoot :: FilePath -> IO (Maybe FilePath)
 findProjectRoot path = do


### PR DESCRIPTION
If you create a new git worktree folder, it will contain `.git` file and not a directory which would cause `RunServices` to fail.

## Checklist

 - ~[ ] Add a new entry in an appropriate subdirectory of `changelog.d`~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
