### PR TITLE
CI: Increase memory limit for brig to 1Gi

### DIFF
--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -34,7 +34,7 @@ brig:
   resources:
     requests: {}
     limits:
-      memory: 512Mi
+      memory: 1Gi
   config:
     externalUrls:
       nginz: https://kube-staging-nginz-https.zinfra.io


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-5554

Brig is running out of memory in CI since GHC 9.4 upgrade. We need to look into this soon. But this will unblock the rest of the team, so we do this right now.

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
