### PR TITLE
tasty-cannon: Delete awaitMatch_

### DIFF
--- a/libs/tasty-cannon/src/Test/Tasty/Cannon.hs
+++ b/libs/tasty-cannon/src/Test/Tasty/Cannon.hs
@@ -49,7 +49,6 @@ module Test.Tasty.Cannon
     MatchFailure (..),
     await,
     awaitMatch,
-    awaitMatch_,
     awaitMatchN,
     assertMatch,
     assertMatch_,
@@ -310,14 +309,6 @@ awaitMatch t ws match = go [] []
           refill buf
           pure (Left (MatchTimeout errs))
     refill = mapM_ (liftIO . atomically . writeTChan (wsChan ws))
-
-awaitMatch_ ::
-  (HasCallStack, MonadIO m, MonadCatch m) =>
-  Timeout ->
-  WebSocket ->
-  (Notification -> Assertion) ->
-  m ()
-awaitMatch_ t w = void . awaitMatch t w
 
 assertMatch ::
   (HasCallStack, MonadIO m, MonadCatch m) =>

--- a/services/galley/test/integration/API/Teams.hs
+++ b/services/galley/test/integration/API/Teams.hs
@@ -747,13 +747,12 @@ testAddTeamConvLegacy = do
 testAddTeamConvWithRole :: TestM ()
 testAddTeamConvWithRole = do
   c <- view tsCannon
-  (tid, owner, mem2 : _) <- Util.createBindingTeamWithMembers 2
+  (owner, tid) <- Util.createBindingTeam
   qOwner <- Qualified owner <$> viewFederationDomain
   extern <- Util.randomUser
   qExtern <- Qualified extern <$> viewFederationDomain
   Util.connectUsers owner (list1 extern [])
-  Util.connectUsers mem2 (list1 extern [])
-  WS.bracketRN c [owner, extern, mem2] $ \[wsOwner, wsExtern, wsMem2] -> do
+  WS.bracketRN c [owner, extern] $ \[wsOwner, wsExtern] -> do
     -- Regular conversation:
     cid2 <- Util.createTeamConvWithRole owner tid [extern] (Just "blaa") Nothing Nothing roleNameWireAdmin
     checkConvCreateEvent cid2 wsOwner
@@ -770,7 +769,6 @@ testAddTeamConvWithRole = do
 
     mem1 <- Util.addUserToTeam owner tid
     checkTeamMemberJoin tid (mem1 ^. userId) wsOwner
-    checkTeamMemberJoin tid (mem1 ^. userId) wsMem2
     -- ... but not to regular ones.
     Util.assertNotConvMember (mem1 ^. userId) cid2
 

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -2761,7 +2761,7 @@ checkUserDeleteEvent uid timeout_ w = WS.assertMatch_ timeout_ w $ \notif -> do
   euser @?= Just (UUID.toText (toUUID uid))
 
 checkTeamMemberJoin :: HasCallStack => TeamId -> UserId -> WS.WebSocket -> TestM ()
-checkTeamMemberJoin tid uid w = WS.awaitMatch_ checkTimeout w $ \notif -> do
+checkTeamMemberJoin tid uid w = WS.assertMatch_ checkTimeout w $ \notif -> do
   ntfTransient notif @?= True
   let e = List1.head (WS.unpackPayload notif)
   e ^. eventTeam @?= tid


### PR DESCRIPTION
This function doesn't tell the caller whether the expected event came or not and hence pointless to be used in testing. It is used only in 1 place (`checkTeamMemberJoin`) and that place should be using assertMatch_ instead.

The `checkTeamMemberJoin` function was used wrongly in 1 place, it has been deleted. 

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
