### PR TITLE
Fix calendar integration setting in backoffice / stern

### DIFF
--- a/changelog.d/5-internal/WPB-5541
+++ b/changelog.d/5-internal/WPB-5541
@@ -1,1 +1,1 @@
-Fix calenter integration setting in backoffice / stern.
+Fix calendar integration setting in backoffice / stern

--- a/changelog.d/5-internal/WPB-5541
+++ b/changelog.d/5-internal/WPB-5541
@@ -1,0 +1,1 @@
+Fix calenter integration setting in backoffice / stern.

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -494,12 +494,9 @@ invalidTTLErrorString = "Invalid FeatureTTLSeconds: must be a positive integer o
 -- LockStatus
 
 data LockStatus = LockStatusLocked | LockStatusUnlocked
-  deriving stock (Eq, Generic)
+  deriving stock (Eq, Show, Generic)
   deriving (Arbitrary) via (GenericUniform LockStatus)
   deriving (ToJSON, FromJSON, S.ToSchema) via (Schema LockStatus)
-
-instance Show LockStatus where
-  show = cs . toByteString'
 
 instance FromHttpApiData LockStatus where
   parseUrlPiece = maybeToEither "Invalid lock status" . fromByteString . cs

--- a/libs/wire-api/src/Wire/API/Team/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Team/Feature.hs
@@ -494,9 +494,12 @@ invalidTTLErrorString = "Invalid FeatureTTLSeconds: must be a positive integer o
 -- LockStatus
 
 data LockStatus = LockStatusLocked | LockStatusUnlocked
-  deriving stock (Eq, Show, Generic)
+  deriving stock (Eq, Generic)
   deriving (Arbitrary) via (GenericUniform LockStatus)
   deriving (ToJSON, FromJSON, S.ToSchema) via (Schema LockStatus)
+
+instance Show LockStatus where
+  show = cs . toByteString'
 
 instance FromHttpApiData LockStatus where
   parseUrlPiece = maybeToEither "Invalid lock status" . fromByteString . cs
@@ -509,7 +512,8 @@ instance ToSchema LockStatus where
           element "unlocked" LockStatusUnlocked
         ]
 
-instance S.ToParamSchema LockStatus
+instance S.ToParamSchema LockStatus where
+  toParamSchema _ = mempty & S.type_ ?~ S.OpenApiString & S.enum_ ?~ ["locked", "unlocked"]
 
 instance ToByteString LockStatus where
   builder LockStatusLocked = "locked"

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -157,6 +157,7 @@ sitemap' =
     :<|> Named @"get-search-visibility" getSearchVisibility
     :<|> Named @"put-search-visibility" setSearchVisibility
     :<|> Named @"get-route-outlook-cal-config" (mkFeatureGetRoute @OutlookCalIntegrationConfig)
+    :<|> Named @"lock-unlock-route-outlook-cal-config" (mkFeatureLockUnlockRouteTrivialConfigNoTTL @OutlookCalIntegrationConfig)
     :<|> Named @"put-route-outlook-cal-config" (mkFeaturePutRouteTrivialConfigNoTTL @OutlookCalIntegrationConfig)
     :<|> Named @"get-team-invoice" getTeamInvoice
     :<|> Named @"get-team-billing-info" getTeamBillingInfo
@@ -334,6 +335,10 @@ type MkFeaturePutConstraints cfg =
 mkFeaturePutRouteTrivialConfigNoTTL ::
   forall cfg. (MkFeaturePutConstraints cfg) => TeamId -> FeatureStatus -> Handler NoContent
 mkFeaturePutRouteTrivialConfigNoTTL tid status = mkFeaturePutRouteTrivialConfig @cfg tid status Nothing
+
+mkFeatureLockUnlockRouteTrivialConfigNoTTL ::
+  forall cfg. (MkFeaturePutConstraints cfg) => TeamId -> LockStatus -> Handler NoContent
+mkFeatureLockUnlockRouteTrivialConfigNoTTL tid lstat = NoContent <$ Intra.setTeamFeatureLockStatus @cfg tid lstat
 
 mkFeaturePutRouteTrivialConfigWithTTL ::
   forall cfg. (MkFeaturePutConstraints cfg) => TeamId -> FeatureStatus -> FeatureTTLDays -> Handler NoContent

--- a/tools/stern/src/Stern/API/Routes.hs
+++ b/tools/stern/src/Stern/API/Routes.hs
@@ -320,6 +320,7 @@ type SternAPI =
                :> Put '[JSON] NoContent
            )
     :<|> Named "get-route-outlook-cal-config" (MkFeatureGetRoute OutlookCalIntegrationConfig)
+    :<|> Named "lock-unlock-route-outlook-cal-config" (MkFeatureLockUnlockRouteTrivialConfigNoTTL OutlookCalIntegrationConfig)
     :<|> Named "put-route-outlook-cal-config" (MkFeaturePutRouteTrivialConfigNoTTL OutlookCalIntegrationConfig)
     :<|> Named
            "get-team-invoice"
@@ -517,6 +518,16 @@ type MkFeaturePutRouteTrivialConfigWithTTL (feature :: Type) =
     :> FeatureSymbol feature
     :> QueryParam' [Required, Strict] "status" FeatureStatus
     :> QueryParam' [Required, Strict, Description "team feature time to live, given in days, or 'unlimited' (default)."] "ttl" FeatureTTLDays
+    :> Put '[JSON] NoContent
+
+type MkFeatureLockUnlockRouteTrivialConfigNoTTL (feature :: Type) =
+  Summary "Lock / unlock status for a given feature / team (en-/disable should happen in team settings)"
+    :> "teams"
+    :> Capture "tid" TeamId
+    :> "features"
+    :> FeatureSymbol feature
+    :> "lockOrUnlock"
+    :> QueryParam' [Required, Strict] "lock-status" LockStatus
     :> Put '[JSON] NoContent
 
 type MkFeaturePutRoute (feature :: Type) =

--- a/tools/stern/test/integration/API.hs
+++ b/tools/stern/test/integration/API.hs
@@ -92,6 +92,7 @@ tests s =
       test s "/teams/:tid/features/mls" $ testFeatureConfig @MLSConfig,
       test s "GET /teams/:tid/features/classifiedDomains" $ testGetFeatureConfig @ClassifiedDomainsConfig (Just FeatureStatusEnabled),
       test s "GET /teams/:tid/features/outlookCalIntegration" $ testFeatureStatus @OutlookCalIntegrationConfig,
+      test s "PUT /teams/:tid/features/outlookCalIntegration{,'?lockOrUnlock'}" $ testFeatureStatusWithLock @OutlookCalIntegrationConfig,
       test s "GET /i/consent" testGetConsentLog,
       test s "GET /teams/:id" testGetTeamInfo,
       test s "GET i/user/meta-info?id=..." testGetUserMetaInfo,
@@ -336,6 +337,46 @@ testFeatureStatusOptTtl mTtl = do
   void $ putFeatureStatus @cfg tid newStatus mTtl
   cfg' <- getFeatureConfig @cfg tid
   liftIO $ wsStatus cfg' @?= newStatus
+
+testFeatureStatusWithLock ::
+  forall cfg.
+  ( KnownSymbol (FeatureSymbol cfg),
+    ToSchema cfg,
+    Typeable cfg,
+    IsFeatureConfig cfg,
+    Eq cfg,
+    Show cfg
+  ) =>
+  TestM ()
+testFeatureStatusWithLock = do
+  let mTtl = Nothing -- this function can become a variant of `testFeatureStatusOptTtl` if we need one.
+  (_, tid, _) <- createTeamWithNMembers 10
+  getFeatureConfig @cfg tid >>= \cfg -> liftIO $ do
+    cfg @?= defFeatureStatus @cfg
+    -- if either of these two lines fails, it's probably because the default is surprising.
+    -- in that case, make the text more flexible.
+    wsLockStatus cfg @?= LockStatusLocked
+    wsStatus cfg @?= FeatureStatusDisabled
+
+  void $ putFeatureStatusLock @cfg tid LockStatusUnlocked mTtl
+  getFeatureConfig @cfg tid >>= \cfg -> liftIO $ do
+    wsLockStatus cfg @?= LockStatusUnlocked
+    wsStatus cfg @?= FeatureStatusDisabled
+
+  void $ putFeatureStatus @cfg tid FeatureStatusEnabled Nothing
+  getFeatureConfig @cfg tid >>= \cfg -> liftIO $ do
+    wsLockStatus cfg @?= LockStatusUnlocked
+    wsStatus cfg @?= FeatureStatusEnabled
+
+  void $ putFeatureStatusLock @cfg tid LockStatusLocked mTtl
+  getFeatureConfig @cfg tid >>= \cfg -> liftIO $ do
+    wsLockStatus cfg @?= LockStatusLocked
+    wsStatus cfg @?= FeatureStatusDisabled
+
+  void $ putFeatureStatusLock @cfg tid LockStatusUnlocked mTtl
+  getFeatureConfig @cfg tid >>= \cfg -> liftIO $ do
+    wsLockStatus cfg @?= LockStatusUnlocked
+    wsStatus cfg @?= FeatureStatusEnabled
 
 testGetConsentLog :: TestM ()
 testGetConsentLog = do
@@ -615,6 +656,31 @@ putFeatureStatus ::
 putFeatureStatus tid status mTtl = do
   s <- view tsStern
   put (s . paths ["teams", toByteString' tid, "features", Public.featureNameBS @cfg] . queryItem "status" (toByteString' status) . mkTtlQueryParam mTtl . contentJson)
+  where
+    mkTtlQueryParam :: Maybe FeatureTTL -> Request -> Request
+    mkTtlQueryParam = maybe id (queryItem "ttl" . toByteString')
+
+putFeatureStatusLock ::
+  forall cfg.
+  ( KnownSymbol (FeatureSymbol cfg),
+    ToSchema cfg,
+    Typeable cfg,
+    IsFeatureConfig cfg
+  ) =>
+  TeamId ->
+  LockStatus ->
+  Maybe FeatureTTL ->
+  TestM ResponseLBS
+putFeatureStatusLock tid lockStatus mTtl = do
+  s <- view tsStern
+  put
+    ( s
+        . paths ["teams", toByteString' tid, "features", Public.featureNameBS @cfg, "lockOrUnlock"]
+        . queryItem "lock-status" (toByteString' lockStatus)
+        . mkTtlQueryParam mTtl
+        . contentJson
+        . expect2xx
+    )
   where
     mkTtlQueryParam :: Maybe FeatureTTL -> Request -> Request
     mkTtlQueryParam = maybe id (queryItem "ttl" . toByteString')


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-5541

stern has end-points for changing a number of team feature.  outlook calendar integration is a feature that can be enabled / disabled by the team admin, but also locked / unlocked by the site admin (in order to prevent / allow team admins to use the feature).

this PR adds the missing lock/unlock end-point for outlook calendar integration to stern.

![2023-12-05-101649_1920x1080_scrot](https://github.com/wireapp/wire-server/assets/10210727/aae71be6-ace2-471c-b04d-3fec79d80755)
![2023-12-05-101716_1920x1080_scrot](https://github.com/wireapp/wire-server/assets/10210727/9c2219dd-d3d6-484e-a0fb-d509439680c6)
![2023-12-05-101728_1920x1080_scrot](https://github.com/wireapp/wire-server/assets/10210727/58b66218-2774-4cd7-967d-be6b3ee5df6b)

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
