### PR TITLE
Federation API versioning

### DIFF
--- a/changelog.d/1-api-changes/fed-api-versioning
+++ b/changelog.d/1-api-changes/fed-api-versioning
@@ -1,0 +1,1 @@
+The federation API can now be versioned. Multiple versions of an RPC can be defined on the same path. After version negotiation, the federation client now sets the `X-Wire-API-Version` header, and federator propagates it to the destination service.

--- a/libs/wire-api-federation/default.nix
+++ b/libs/wire-api-federation/default.nix
@@ -36,7 +36,7 @@
 , servant-openapi3
 , servant-server
 , singletons
-, singletons-th
+, singletons-base
 , text
 , time
 , transformers
@@ -77,7 +77,7 @@ mkDerivation {
     servant-client-core
     servant-openapi3
     servant-server
-    singletons-th
+    singletons-base
     text
     time
     transformers

--- a/libs/wire-api-federation/src/Wire/API/Federation/API.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API.hs
@@ -48,6 +48,7 @@ import Wire.API.Federation.API.Galley
 import Wire.API.Federation.BackendNotifications
 import Wire.API.Federation.Client
 import Wire.API.Federation.Component
+import Wire.API.Federation.Endpoint
 import Wire.API.Federation.HasNotificationEndpoint
 import Wire.API.MakesFederatedCall
 import Wire.API.Routes.Named
@@ -77,8 +78,13 @@ type HasUnsafeFedEndpoint comp api name = 'Just api ~ LookupEndpoint (FedApi com
 -- 'Wire.API.MakesFederatedCall.exposeAnnotations' for a better understanding
 -- of the information flow here.
 fedClient ::
-  forall (comp :: Component) (name :: Symbol) m (showcomp :: Symbol) api x.
-  (AddAnnotation 'Remote showcomp name x, showcomp ~ ShowComponent comp, HasFedEndpoint comp api name, HasClient m api, m ~ FederatorClient comp) =>
+  forall (comp :: Component) name m (showcomp :: Symbol) api x.
+  ( AddAnnotation 'Remote showcomp (FedPath name) x,
+    showcomp ~ ShowComponent comp,
+    HasFedEndpoint comp api name,
+    HasClient m api,
+    m ~ FederatorClient comp
+  ) =>
   Client m api
 fedClient = clientIn (Proxy @api) (Proxy @m)
 

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -43,6 +43,7 @@ import Wire.API.User.Client.Prekey (ClientPrekey, PrekeyBundle)
 import Wire.API.User.Search
 import Wire.API.UserMap (UserMap)
 import Wire.API.Util.Aeson (CustomEncoded (..))
+import Wire.API.VersionInfo
 import Wire.Arbitrary (GenericUniform (..))
 
 data SearchRequest = SearchRequest
@@ -85,7 +86,7 @@ type BrigApi =
     -- (handles can be up to 256 chars currently)
     :<|> FedEndpoint "search-users" SearchRequest SearchResponse
     :<|> FedEndpoint "get-user-clients" GetUserClients (UserMap (Set PubClient))
-    :<|> FedEndpoint (Versioned 'V0 "get-mls-clients") MLSClientsRequestV0 (Set ClientInfo)
+    :<|> FedEndpointWithMods '[Until V1] (Versioned 'V0 "get-mls-clients") MLSClientsRequestV0 (Set ClientInfo)
     :<|> FedEndpoint "get-mls-clients" MLSClientsRequest (Set ClientInfo)
     :<|> FedEndpoint "send-connection-action" NewConnectionRequest NewConnectionResponse
     :<|> FedEndpoint "claim-key-packages" ClaimKeyPackageRequest (Maybe KeyPackageBundle)

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -87,7 +87,7 @@ type BrigApi =
     :<|> FedEndpoint "search-users" SearchRequest SearchResponse
     :<|> FedEndpoint "get-user-clients" GetUserClients (UserMap (Set PubClient))
     :<|> FedEndpointWithMods '[Until V1] (Versioned 'V0 "get-mls-clients") MLSClientsRequestV0 (Set ClientInfo)
-    :<|> FedEndpoint "get-mls-clients" MLSClientsRequest (Set ClientInfo)
+    :<|> FedEndpointWithMods '[From V1] "get-mls-clients" MLSClientsRequest (Set ClientInfo)
     :<|> FedEndpoint "send-connection-action" NewConnectionRequest NewConnectionResponse
     :<|> FedEndpoint "claim-key-packages" ClaimKeyPackageRequest (Maybe KeyPackageBundle)
     :<|> FedEndpoint "get-not-fully-connected-backends" DomainSet NonConnectedBackends

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Brig.hs
@@ -36,6 +36,7 @@ import Wire.API.Federation.Endpoint
 import Wire.API.Federation.Version
 import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.KeyPackage
+import Wire.API.Routes.SpecialiseToVersion
 import Wire.API.User (UserProfile)
 import Wire.API.User.Client
 import Wire.API.User.Client.Prekey (ClientPrekey, PrekeyBundle)
@@ -195,4 +196,4 @@ data ClaimKeyPackageRequest = ClaimKeyPackageRequest
 instance ToSchema ClaimKeyPackageRequest
 
 swaggerDoc :: OpenApi
-swaggerDoc = toOpenApi (Proxy @BrigApi)
+swaggerDoc = toOpenApi (Proxy @(SpecialiseToVersion 'V1 BrigApi))

--- a/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/API/Galley.hs
@@ -43,11 +43,14 @@ import Wire.API.Error.Galley
 import Wire.API.Federation.API.Common
 import Wire.API.Federation.API.Galley.Notifications as Notifications
 import Wire.API.Federation.Endpoint
+import Wire.API.Federation.Version
 import Wire.API.MLS.SubConversation
 import Wire.API.MakesFederatedCall
 import Wire.API.Message
 import Wire.API.Routes.Public.Galley.Messaging
+import Wire.API.Routes.SpecialiseToVersion
 import Wire.API.Util.Aeson (CustomEncoded (..))
+import Wire.API.VersionInfo
 import Wire.Arbitrary (Arbitrary, GenericUniform (..))
 
 -- FUTUREWORK: data types, json instances, more endpoints. See
@@ -121,20 +124,27 @@ type GalleyApi =
            TypingDataUpdateRequest
            TypingDataUpdateResponse
     :<|> FedEndpoint "on-typing-indicator-updated" TypingDataUpdated EmptyResponse
-    :<|> FedEndpoint "get-sub-conversation" GetSubConversationsRequest GetSubConversationsResponse
     :<|> FedEndpointWithMods
-           '[
+           '[ From 'V1
+            ]
+           "get-sub-conversation"
+           GetSubConversationsRequest
+           GetSubConversationsResponse
+    :<|> FedEndpointWithMods
+           '[ From 'V1
             ]
            "delete-sub-conversation"
            DeleteSubConversationFedRequest
            DeleteSubConversationResponse
     :<|> FedEndpointWithMods
-           '[ MakesFederatedCall 'Galley "on-mls-message-sent"
+           '[ MakesFederatedCall 'Galley "on-mls-message-sent",
+              From 'V1
             ]
            "leave-sub-conversation"
            LeaveSubConversationRequest
            LeaveSubConversationResponse
-    :<|> FedEndpoint
+    :<|> FedEndpointWithMods
+           '[From 'V1]
            "get-one2one-conversation"
            GetOne2OneConversationRequest
            GetOne2OneConversationResponse
@@ -514,4 +524,4 @@ data DeleteSubConversationResponse
 instance ToSchema DeleteSubConversationResponse
 
 swaggerDoc :: OpenApi
-swaggerDoc = toOpenApi (Proxy @GalleyApi)
+swaggerDoc = toOpenApi (Proxy @(SpecialiseToVersion 'V1 GalleyApi))

--- a/libs/wire-api-federation/src/Wire/API/Federation/Domain.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Domain.hs
@@ -31,6 +31,7 @@ import Servant.OpenApi (HasOpenApi (toOpenApi))
 import Servant.Server
 import Servant.Server.Internal (MkContextWithErrorFormatter)
 import Wire.API.Routes.ClientAlgebra
+import Wire.API.Routes.SpecialiseToVersion
 
 type OriginDomainHeaderName = "Wire-Origin-Domain" :: Symbol
 
@@ -38,6 +39,10 @@ data OriginDomainHeader
 
 instance RoutesToPaths api => RoutesToPaths (OriginDomainHeader :> api) where
   getRoutes = getRoutes @api
+
+type instance
+  SpecialiseToVersion v (OriginDomainHeader :> api) =
+    OriginDomainHeader :> SpecialiseToVersion v api
 
 instance HasClient m api => HasClient m (OriginDomainHeader :> api) where
   type Client m (OriginDomainHeader :> api) = Client m api

--- a/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Endpoint.hs
@@ -22,6 +22,7 @@ module Wire.API.Federation.Endpoint
 where
 
 import Data.Kind
+import GHC.TypeLits
 import Servant.API
 import Wire.API.ApplyMods
 import Wire.API.Federation.API.Common
@@ -29,12 +30,23 @@ import Wire.API.Federation.Domain
 import Wire.API.Federation.HasNotificationEndpoint
 import Wire.API.Routes.Named
 
+data Versioned v name
+
+instance {-# OVERLAPPING #-} RenderableSymbol a => RenderableSymbol (Versioned v a) where
+  renderSymbol = renderSymbol @a
+
+type family FedPath (name :: k) :: Symbol
+
+type instance FedPath (name :: Symbol) = name
+
+type instance FedPath (Versioned v name) = name
+
 type FedEndpointWithMods (mods :: [Type]) name input output =
   Named
     name
     ( ApplyMods
         mods
-        (name :> OriginDomainHeader :> ReqBody '[JSON] input :> Post '[JSON] output)
+        (FedPath name :> OriginDomainHeader :> ReqBody '[JSON] input :> Post '[JSON] output)
     )
 
 type NotificationFedEndpointWithMods (mods :: [Type]) name input =

--- a/libs/wire-api-federation/src/Wire/API/Federation/Version.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Version.hs
@@ -24,12 +24,12 @@ import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.OpenApi qualified as S
 import Data.Schema
 import Data.Set qualified as Set
-import Data.Singletons.TH
+import Data.Singletons.Base.TH
 import Imports
 import Wire.API.VersionInfo
 
 data Version = V0 | V1
-  deriving stock (Eq, Ord, Bounded, Enum, Show)
+  deriving stock (Eq, Ord, Bounded, Enum, Show, Generic)
   deriving (FromJSON, ToJSON) via (Schema Version)
 
 instance ToSchema Version where
@@ -63,3 +63,5 @@ versionInfo :: VersionInfo
 versionInfo = VersionInfo (toList supportedVersions)
 
 $(genSingletons [''Version])
+
+$(promoteOrdInstances [''Version])

--- a/libs/wire-api-federation/src/Wire/API/Federation/Version.hs
+++ b/libs/wire-api-federation/src/Wire/API/Federation/Version.hs
@@ -32,6 +32,10 @@ data Version = V0 | V1
   deriving stock (Eq, Ord, Bounded, Enum, Show, Generic)
   deriving (FromJSON, ToJSON) via (Schema Version)
 
+versionInt :: Version -> Int
+versionInt V0 = 0
+versionInt V1 = 1
+
 instance ToSchema Version where
   schema =
     enum @Integer "Version" . mconcat $

--- a/libs/wire-api-federation/wire-api-federation.cabal
+++ b/libs/wire-api-federation/wire-api-federation.cabal
@@ -109,7 +109,7 @@ library
     , servant-client-core
     , servant-openapi3
     , servant-server
-    , singletons-th
+    , singletons-base
     , text                   >=0.11
     , time                   >=1.8
     , transformers

--- a/libs/wire-api/src/Wire/API/Error.hs
+++ b/libs/wire-api/src/Wire/API/Error.hs
@@ -71,7 +71,7 @@ import Servant.Client.Core.HasClient (hoistClientMonad)
 import Servant.Client.Streaming (HasClient (clientWithRoute))
 import Servant.OpenApi
 import Wire.API.Routes.MultiVerb
-import Wire.API.Routes.Named (UntypedNamed)
+import Wire.API.Routes.Named (Named)
 import Wire.API.Routes.Version
 
 -- | Runtime representation of a statically-known error.
@@ -217,7 +217,7 @@ type family DeclaredErrorEffects api :: EffectRow where
   DeclaredErrorEffects (CanThrowMany '(e, es) :> api) =
     DeclaredErrorEffects (CanThrow e :> CanThrowMany es :> api)
   DeclaredErrorEffects (x :> api) = DeclaredErrorEffects api
-  DeclaredErrorEffects (UntypedNamed n api) = DeclaredErrorEffects api
+  DeclaredErrorEffects (Named n api) = DeclaredErrorEffects api
   DeclaredErrorEffects api = '[]
 
 errorResponseSwagger :: forall e. (Typeable e, KnownError e) => S.Response

--- a/libs/wire-api/src/Wire/API/MLS/CipherSuite.hs
+++ b/libs/wire-api/src/Wire/API/MLS/CipherSuite.hs
@@ -268,3 +268,6 @@ instance ToJSON SignatureSchemeTag where
 
 instance ToJSONKey SignatureSchemeTag where
   toJSONKey = Aeson.toJSONKeyText signatureSchemeName
+
+instance S.ToSchema SignatureSchemeTag where
+  declareNamedSchema _ = S.declareNamedSchema (Proxy @Text)

--- a/libs/wire-api/src/Wire/API/MakesFederatedCall.hs
+++ b/libs/wire-api/src/Wire/API/MakesFederatedCall.hs
@@ -349,7 +349,7 @@ appendName :: String -> FedCallFrom -> FedCallFrom
 appendName toAppend s = s {name = pure $ maybe toAppend (<> toAppend) $ name s}
 
 -- All of the boring instances live here.
-instance (RenderableSymbol name, HasFeds rest) => HasFeds (UntypedNamed name rest) where
+instance (RenderableSymbol name, HasFeds rest) => HasFeds (Named name rest) where
   getFedCalls _ = getFedCalls $ Proxy @rest
 
 instance HasFeds rest => HasFeds (Header' mods name a :> rest) where

--- a/libs/wire-api/src/Wire/API/Routes/Named.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Named.hs
@@ -33,15 +33,7 @@ import Servant.Client.Core (clientIn)
 import Servant.OpenApi
 
 -- | See http://docs.wire.com/developer/developer/servant.html#named-and-internal-route-ids-in-swagger
---
--- as 'UntypedNamed' is of kind $k -> Type -> Type$, we can pass any
--- argument to it, however, most commonly we want to pass a 'Symbol' to
--- it. To avoid mistakes, we make it possible to rule out untyped arguments
--- like 'Type', this is done by the 'IsStronglyTyped' TyFam that will throw
--- a type error when passed a 'Type'
-type Named name = UntypedNamed (IsStronglyTyped name)
-
-newtype UntypedNamed name x = Named {unnamed :: x}
+newtype Named name x = Named {unnamed :: x}
   deriving (Functor)
 
 -- | For 'HasSwagger' instance of 'Named'.  'KnownSymbol' isn't enough because we're using
@@ -55,12 +47,7 @@ instance {-# OVERLAPPABLE #-} KnownSymbol a => RenderableSymbol a where
 instance {-# OVERLAPPING #-} (RenderableSymbol a, RenderableSymbol b) => RenderableSymbol '(a, b) where
   renderSymbol = "(" <> (renderSymbol @a) <> ", " <> (renderSymbol @b) <> ")"
 
-type IsStronglyTyped :: forall k. k -> k
-type family IsStronglyTyped typ where
-  IsStronglyTyped (typ :: Type) = TypeError ('Text "Please don't use \"Type\" as first parameter to \"Named\"")
-  IsStronglyTyped typ = typ
-
-instance (HasOpenApi api, RenderableSymbol name) => HasOpenApi (UntypedNamed name api) where
+instance (HasOpenApi api, RenderableSymbol name) => HasOpenApi (Named name api) where
   toOpenApi _ =
     toOpenApi (Proxy @api)
       & allOperations . description %~ (Just (dscr <> "\n\n") <>)
@@ -71,27 +58,27 @@ instance (HasOpenApi api, RenderableSymbol name) => HasOpenApi (UntypedNamed nam
           <> cs (renderSymbol @name)
           <> "]"
 
-instance HasServer api ctx => HasServer (UntypedNamed name api) ctx where
-  type ServerT (UntypedNamed name api) m = UntypedNamed name (ServerT api m)
+instance HasServer api ctx => HasServer (Named name api) ctx where
+  type ServerT (Named name api) m = Named name (ServerT api m)
 
   route _ ctx action = route (Proxy @api) ctx (fmap unnamed action)
   hoistServerWithContext _ ctx f =
     fmap (hoistServerWithContext (Proxy @api) ctx f)
 
-instance HasLink endpoint => HasLink (UntypedNamed name endpoint) where
-  type MkLink (UntypedNamed name endpoint) a = MkLink endpoint a
+instance HasLink endpoint => HasLink (Named name endpoint) where
+  type MkLink (Named name endpoint) a = MkLink endpoint a
   toLink toA _ = toLink toA (Proxy @endpoint)
 
-instance RoutesToPaths api => RoutesToPaths (UntypedNamed name api) where
+instance RoutesToPaths api => RoutesToPaths (Named name api) where
   getRoutes = getRoutes @api
 
-instance HasClient m api => HasClient m (UntypedNamed n api) where
-  type Client m (UntypedNamed n api) = Client m api
+instance HasClient m api => HasClient m (Named n api) where
+  type Client m (Named n api) = Client m api
   clientWithRoute pm _ req = clientWithRoute pm (Proxy @api) req
   hoistClientMonad pm _ f = hoistClientMonad pm (Proxy @api) f
 
 type family FindName n (api :: Type) :: (n, Type) where
-  FindName n (UntypedNamed name api) = '(name, api)
+  FindName n (Named name api) = '(name, api)
   FindName n (x :> api) = AddPrefix x (FindName n api)
   FindName n api = '(TypeError ('Text "Named combinator not found"), api)
 
@@ -129,7 +116,7 @@ type family FMap (f :: a -> b) (m :: Maybe a) :: Maybe b where
   FMap f ('Just a) = 'Just (f a)
 
 type family LookupEndpoint api name :: Maybe Type where
-  LookupEndpoint (UntypedNamed name endpoint) name = 'Just endpoint
+  LookupEndpoint (Named name endpoint) name = 'Just endpoint
   LookupEndpoint (api1 :<|> api2) name =
     MappendMaybe
       (LookupEndpoint api1 name)
@@ -155,5 +142,5 @@ namedClient = clientIn (Proxy @endpoint) (Proxy @m)
 type family x ::> api
 
 type instance
-  x ::> (UntypedNamed name api) =
+  x ::> (Named name api) =
     Named name (x :> api)

--- a/libs/wire-api/src/Wire/API/Routes/SpecialiseToVersion.hs
+++ b/libs/wire-api/src/Wire/API/Routes/SpecialiseToVersion.hs
@@ -43,7 +43,7 @@ type instance
     s :> SpecialiseToVersion v api
 
 type instance
-  SpecialiseToVersion v (UntypedNamed n api) =
+  SpecialiseToVersion v (Named n api) =
     Named n (SpecialiseToVersion v api)
 
 type instance

--- a/libs/wire-api/src/Wire/API/Routes/SpecialiseToVersion.hs
+++ b/libs/wire-api/src/Wire/API/Routes/SpecialiseToVersion.hs
@@ -1,0 +1,99 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+-- | Version-aware swagger generation
+module Wire.API.Routes.SpecialiseToVersion where
+
+import Data.Singletons.Base.TH
+import GHC.TypeLits
+import Servant
+import Servant.API.Extended.RawM
+import Wire.API.Deprecated
+import Wire.API.MakesFederatedCall
+import Wire.API.Routes.MultiVerb
+import Wire.API.Routes.Named
+import Wire.API.VersionInfo
+
+type family SpecialiseToVersion (v :: k) api
+
+type instance
+  SpecialiseToVersion v (From w :> api) =
+    If (v < w) EmptyAPI (SpecialiseToVersion v api)
+
+type instance
+  SpecialiseToVersion v (Until w :> api) =
+    If (v < w) (SpecialiseToVersion v api) EmptyAPI
+
+type instance
+  SpecialiseToVersion v ((s :: Symbol) :> api) =
+    s :> SpecialiseToVersion v api
+
+type instance
+  SpecialiseToVersion v (UntypedNamed n api) =
+    Named n (SpecialiseToVersion v api)
+
+type instance
+  SpecialiseToVersion v (Capture' mod sym a :> api) =
+    Capture' mod sym a :> SpecialiseToVersion v api
+
+type instance
+  SpecialiseToVersion v (Summary s :> api) =
+    Summary s :> SpecialiseToVersion v api
+
+type instance
+  SpecialiseToVersion v (Deprecated :> api) =
+    Deprecated :> SpecialiseToVersion v api
+
+type instance
+  SpecialiseToVersion v (Verb m s t r) =
+    Verb m s t r
+
+type instance
+  SpecialiseToVersion v (MultiVerb m t r x) =
+    MultiVerb m t r x
+
+type instance SpecialiseToVersion v RawM = RawM
+
+type instance
+  SpecialiseToVersion v (ReqBody t x :> api) =
+    ReqBody t x :> SpecialiseToVersion v api
+
+type instance
+  SpecialiseToVersion v (QueryParam' mods l x :> api) =
+    QueryParam' mods l x :> SpecialiseToVersion v api
+
+type instance
+  SpecialiseToVersion v (Header' opts l x :> api) =
+    Header' opts l x :> SpecialiseToVersion v api
+
+type instance
+  SpecialiseToVersion v (Description desc :> api) =
+    Description desc :> SpecialiseToVersion v api
+
+type instance
+  SpecialiseToVersion v (MakesFederatedCall comp rpc :> api) =
+    MakesFederatedCall comp rpc :> SpecialiseToVersion v api
+
+type instance
+  SpecialiseToVersion v (StreamBody' opts f t x :> api) =
+    StreamBody' opts f t x :> SpecialiseToVersion v api
+
+type instance SpecialiseToVersion v EmptyAPI = EmptyAPI
+
+type instance
+  SpecialiseToVersion v (api1 :<|> api2) =
+    SpecialiseToVersion v api1 :<|> SpecialiseToVersion v api2

--- a/libs/wire-api/src/Wire/API/Routes/Version.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Version.hs
@@ -29,6 +29,7 @@ module Wire.API.Routes.Version
 
     -- * Version
     Version (..),
+    versionInt,
     VersionNumber (..),
     supportedVersions,
     isDevelopmentVersion,

--- a/libs/wire-api/src/Wire/API/Routes/Version.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Version.hs
@@ -220,7 +220,7 @@ type instance
     s :> SpecialiseToVersion v api
 
 type instance
-  SpecialiseToVersion v (UntypedNamed n api) =
+  SpecialiseToVersion v (Named n api) =
     Named n (SpecialiseToVersion v api)
 
 type instance

--- a/libs/wire-api/src/Wire/API/Routes/Version/Wai.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Version/Wai.hs
@@ -86,5 +86,5 @@ removeVersionHeader req =
 addVersionHeader :: Version -> Request -> Request
 addVersionHeader v req =
   req
-    { requestHeaders = (versionHeader, toByteString' (fromEnum v)) : requestHeaders req
+    { requestHeaders = (versionHeader, toByteString' (versionInt v :: Int)) : requestHeaders req
     }

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -190,6 +190,7 @@ library
     Wire.API.Routes.Public.Spar
     Wire.API.Routes.Public.Util
     Wire.API.Routes.QualifiedCapture
+    Wire.API.Routes.SpecialiseToVersion
     Wire.API.Routes.Version
     Wire.API.Routes.Version.Wai
     Wire.API.Routes.Versioned

--- a/services/brig/src/Brig/API/Federation.hs
+++ b/services/brig/src/Brig/API/Federation.hs
@@ -60,6 +60,7 @@ import UnliftIO.Async (pooledForConcurrentlyN_)
 import Wire.API.Connection
 import Wire.API.Federation.API.Brig hiding (searchPolicy)
 import Wire.API.Federation.API.Common
+import Wire.API.Federation.Endpoint
 import Wire.API.Federation.Version
 import Wire.API.MLS.KeyPackage
 import Wire.API.Routes.FederationDomainConfig as FD
@@ -90,6 +91,7 @@ federationSitemap =
     :<|> Named @"claim-multi-prekey-bundle" claimMultiPrekeyBundle
     :<|> Named @"search-users" (\d sr -> searchUsers d sr)
     :<|> Named @"get-user-clients" getUserClients
+    :<|> Named @(Versioned 'V0 "get-mls-clients") getMLSClientsV0
     :<|> Named @"get-mls-clients" getMLSClients
     :<|> Named @"send-connection-action" sendConnectionAction
     :<|> Named @"claim-key-packages" fedClaimKeyPackages
@@ -248,6 +250,9 @@ getUserClients _ (GetUserClients uids) = API.lookupLocalPubClientsBulk uids !>> 
 getMLSClients :: Domain -> MLSClientsRequest -> Handler r (Set ClientInfo)
 getMLSClients _domain mcr = do
   Internal.getMLSClients mcr.userId mcr.cipherSuite
+
+getMLSClientsV0 :: Domain -> MLSClientsRequestV0 -> Handler r (Set ClientInfo)
+getMLSClientsV0 domain mcr0 = getMLSClients domain (mlsClientsRequestFromV0 mcr0)
 
 onUserDeleted :: Domain -> UserDeletedConnectionsNotification -> (Handler r) EmptyResponse
 onUserDeleted origDomain udcn = lift $ do

--- a/services/brig/src/Brig/API/OAuth.hs
+++ b/services/brig/src/Brig/API/OAuth.hs
@@ -48,7 +48,7 @@ import Wire.API.Error
 import Wire.API.OAuth as OAuth
 import Wire.API.Password (Password, mkSafePassword)
 import Wire.API.Routes.Internal.Brig.OAuth qualified as I
-import Wire.API.Routes.Named (UntypedNamed (Named))
+import Wire.API.Routes.Named (Named (Named))
 import Wire.API.Routes.Public.Brig.OAuth
 import Wire.Sem.Jwk
 import Wire.Sem.Jwk qualified as Jwk

--- a/services/brig/src/Brig/API/Public.hs
+++ b/services/brig/src/Brig/API/Public.hs
@@ -124,7 +124,7 @@ import Wire.API.Routes.Internal.Cargohold qualified as CargoholdInternalAPI
 import Wire.API.Routes.Internal.Galley qualified as GalleyInternalAPI
 import Wire.API.Routes.Internal.Spar qualified as SparInternalAPI
 import Wire.API.Routes.MultiTablePaging qualified as Public
-import Wire.API.Routes.Named (UntypedNamed (Named))
+import Wire.API.Routes.Named (Named (Named))
 import Wire.API.Routes.Public.Brig
 import Wire.API.Routes.Public.Brig.OAuth
 import Wire.API.Routes.Public.Cannon

--- a/services/brig/src/Brig/Provider/API.hs
+++ b/services/brig/src/Brig/Provider/API.hs
@@ -113,7 +113,7 @@ import Wire.API.Provider.External qualified as Ext
 import Wire.API.Provider.Service
 import Wire.API.Provider.Service qualified as Public
 import Wire.API.Provider.Service.Tag qualified as Public
-import Wire.API.Routes.Named (UntypedNamed (Named))
+import Wire.API.Routes.Named (Named (Named))
 import Wire.API.Routes.Public.Brig.Bot (BotAPI)
 import Wire.API.Routes.Public.Brig.Provider (ProviderAPI)
 import Wire.API.Routes.Public.Brig.Services (ServicesAPI)

--- a/services/brig/test/integration/Util.hs
+++ b/services/brig/test/integration/Util.hs
@@ -107,6 +107,7 @@ import Wire.API.Conversation
 import Wire.API.Conversation.Role (roleNameWireAdmin)
 import Wire.API.Federation.API
 import Wire.API.Federation.Domain
+import Wire.API.Federation.Version
 import Wire.API.Internal.Notification
 import Wire.API.MLS.SubConversation
 import Wire.API.Routes.MultiTablePaging
@@ -197,7 +198,10 @@ runFedClient (FedClient mgr ep) domain =
       let req' = Servant.defaultMakeClientRequest burl req
        in req'
             { HTTP.requestHeaders =
-                HTTP.requestHeaders req' <> [(originDomainHeaderName, toByteString' originDomain)]
+                HTTP.requestHeaders req'
+                  <> [ (originDomainHeaderName, toByteString' originDomain),
+                       (versionHeader, toByteString' (versionInt (maxBound :: Version)))
+                     ]
             }
 
 instance ToJSON SESBounceType where

--- a/services/federator/src/Federator/ExternalServer.hs
+++ b/services/federator/src/Federator/ExternalServer.hs
@@ -67,6 +67,7 @@ import System.Logger.Message qualified as Log
 import Wire.API.Federation.Component
 import Wire.API.Federation.Domain
 import Wire.API.Routes.FederationDomainConfig
+import Wire.API.VersionInfo
 import Wire.Sem.Logger (info)
 
 -- | Used to get PEM encoded certificate out of an HTTP header
@@ -175,7 +176,8 @@ callInward component (RPC rpc) mReqId originDomain (CertHeader cert) wreq = do
   let path = LBS.toStrict (toLazyByteString (HTTP.encodePathSegments ["federation", rpc]))
 
   body <- embed $ Wai.lazyRequestBody wreq
-  resp <- serviceCall component path body rid validatedDomain
+  let headers = filter ((== versionHeader) . fst) (Wai.requestHeaders wreq)
+  resp <- serviceCall component path headers body rid validatedDomain
   Log.debug $
     Log.msg ("Inward Request response" :: ByteString)
       . Log.field "status" (show (responseStatusCode resp))

--- a/services/galley/src/Galley/API/MLS/Commit/Core.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/Core.hs
@@ -53,7 +53,9 @@ import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Brig
+import Wire.API.Federation.Endpoint
 import Wire.API.Federation.Error
+import Wire.API.Federation.Version
 import Wire.API.MLS.CipherSuite
 import Wire.API.MLS.Commit
 import Wire.API.MLS.Credential
@@ -148,12 +150,14 @@ getRemoteMLSClients ::
   CipherSuiteTag ->
   Sem r (Either FederationError (Set ClientInfo))
 getRemoteMLSClients rusr suite = do
+  let mcr =
+        MLSClientsRequest
+          { userId = tUnqualified rusr,
+            cipherSuite = tagCipherSuite suite
+          }
   runFederatedEither rusr $
-    fedClient @'Brig @"get-mls-clients" $
-      MLSClientsRequest
-        { userId = tUnqualified rusr,
-          cipherSuite = tagCipherSuite suite
-        }
+    fedClient @'Brig @"get-mls-clients" mcr
+      <|> fedClient @'Brig @(Versioned 'V0 "get-mls-clients") (mlsClientsRequestToV0 mcr)
 
 --------------------------------------------------------------------------------
 -- Error handling of proposal execution

--- a/services/galley/test/integration/API/Federation/Util.hs
+++ b/services/galley/test/integration/API/Federation/Util.hs
@@ -64,7 +64,7 @@ instance HasTrivialHandler api => HasTrivialHandler (From v :> api) where
 trivialNamedHandler ::
   forall (name :: Symbol) api.
   (KnownSymbol name, HasTrivialHandler api) =>
-  Server (UntypedNamed name api)
+  Server (Named name api)
 trivialNamedHandler = Named (trivialHandler @api (symbolVal (Proxy @name)))
 
 -- | Generate a servant handler from an incomplete list of handlers of named
@@ -74,40 +74,40 @@ class PartialAPI (api :: Type) (hs :: Type) where
 
 instance
   (KnownSymbol name, HasTrivialHandler endpoint) =>
-  PartialAPI (UntypedNamed (name :: Symbol) endpoint) EmptyAPI
+  PartialAPI (Named (name :: Symbol) endpoint) EmptyAPI
   where
   mkHandler _ = trivialNamedHandler @name @endpoint
 
 instance
   {-# OVERLAPPING #-}
   (KnownSymbol name, HasTrivialHandler endpoint, PartialAPI api EmptyAPI) =>
-  PartialAPI (UntypedNamed (name :: Symbol) endpoint :<|> api) EmptyAPI
+  PartialAPI (Named (name :: Symbol) endpoint :<|> api) EmptyAPI
   where
   mkHandler h = trivialNamedHandler @name @endpoint :<|> mkHandler @api h
 
 instance
   {-# OVERLAPPING #-}
   (h ~ Server endpoint, PartialAPI api hs) =>
-  PartialAPI (UntypedNamed (name :: Symbol) endpoint :<|> api) (UntypedNamed name h :<|> hs)
+  PartialAPI (Named (name :: Symbol) endpoint :<|> api) (Named name h :<|> hs)
   where
   mkHandler (h :<|> hs) = h :<|> mkHandler @api hs
 
 instance
   (KnownSymbol name, HasTrivialHandler endpoint, PartialAPI api hs) =>
-  PartialAPI (UntypedNamed (name :: Symbol) endpoint :<|> api) hs
+  PartialAPI (Named (name :: Symbol) endpoint :<|> api) hs
   where
   mkHandler hs = trivialNamedHandler @name @endpoint :<|> mkHandler @api hs
 
 instance
   (h ~ Server endpoint) =>
-  PartialAPI (UntypedNamed (name :: Symbol) endpoint) (UntypedNamed name h)
+  PartialAPI (Named (name :: Symbol) endpoint) (Named name h)
   where
   mkHandler = id
 
 instance
   {-# OVERLAPPING #-}
   (h ~ Server endpoint, PartialAPI api EmptyAPI) =>
-  PartialAPI (UntypedNamed (name :: Symbol) endpoint :<|> api) (UntypedNamed name h)
+  PartialAPI (Named (name :: Symbol) endpoint :<|> api) (Named name h)
   where
   mkHandler h = h :<|> mkHandler @api EmptyAPI
 

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 -- Disabling to stop warnings on HasCallStack
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 {-# OPTIONS_GHC -fprint-potential-instances #-}
@@ -60,6 +61,7 @@ import Galley.Options (Opts)
 import Imports
 import Network.HTTP.Client qualified as HTTP
 import Proto.TeamEvents (TeamEvent)
+import Servant.Client
 import Servant.Client qualified as Servant
 import Servant.Client.Core qualified as Servant
 import Test.Tasty.HUnit
@@ -67,6 +69,7 @@ import Util.Options
 import Util.Test.SQS qualified as SQS
 import Wire.API.Federation.API
 import Wire.API.Federation.Domain
+import Wire.API.VersionInfo
 
 type GalleyR = Request -> Request
 
@@ -132,6 +135,9 @@ instance MonadHttp TestM where
   handleRequestWithCont req handler = do
     manager <- view tsManager
     liftIO $ withResponse req manager handler
+
+instance VersionedMonad v ClientM where
+  guardVersion _ = pure ()
 
 runFedClient ::
   forall (name :: Symbol) comp m api.

--- a/services/galley/test/integration/TestSetup.hs
+++ b/services/galley/test/integration/TestSetup.hs
@@ -69,6 +69,7 @@ import Util.Options
 import Util.Test.SQS qualified as SQS
 import Wire.API.Federation.API
 import Wire.API.Federation.Domain
+import Wire.API.Federation.Version
 import Wire.API.VersionInfo
 
 type GalleyR = Request -> Request
@@ -169,5 +170,8 @@ runFedClient (FedClient mgr ep) domain =
       let req' = Servant.defaultMakeClientRequest burl req
        in req'
             { HTTP.requestHeaders =
-                HTTP.requestHeaders req' <> [(originDomainHeaderName, toByteString' originDomain)]
+                HTTP.requestHeaders req'
+                  <> [ (originDomainHeaderName, toByteString' originDomain),
+                       (versionHeader, toByteString' (versionInt (maxBound :: Version)))
+                     ]
             }

--- a/services/gundeck/src/Gundeck/API/Public.hs
+++ b/services/gundeck/src/Gundeck/API/Public.hs
@@ -31,7 +31,7 @@ import Gundeck.Push qualified as Push
 import Imports
 import Servant (HasServer (..), (:<|>) (..))
 import Wire.API.Notification qualified as Public
-import Wire.API.Routes.Named (UntypedNamed (Named))
+import Wire.API.Routes.Named (Named (Named))
 import Wire.API.Routes.Public.Gundeck
 
 -------------------------------------------------------------------------------

--- a/tools/stern/src/Stern/API.hs
+++ b/tools/stern/src/Stern/API.hs
@@ -63,7 +63,7 @@ import Wire.API.Internal.Notification (QueuedNotification)
 import Wire.API.Routes.Internal.Brig.Connection (ConnectionStatus)
 import Wire.API.Routes.Internal.Brig.EJPD qualified as EJPD
 import Wire.API.Routes.Internal.Galley.TeamsIntra qualified as Team
-import Wire.API.Routes.Named (UntypedNamed (Named))
+import Wire.API.Routes.Named (Named (Named))
 import Wire.API.Team.Feature hiding (setStatus)
 import Wire.API.Team.SearchVisibility
 import Wire.API.User


### PR DESCRIPTION
This PR implements the missing pieces to make federation API versioning possible for synchronous endpoints. Version information is communicated via the usual header (`X-Wire-API-Version`) and federator takes care of propagating the header. Federation endpoints can now be given different version "tags" in order to distinguish multiple endpoints with non-overlapping version ranges on the same path.

It also moves the MLS federation endpoints coming from the old `mls` branch to version 1.

https://wearezeta.atlassian.net/browse/WPB-185

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
