### PR TITLE
[WPB-5603] Fix the team member deleted event reason

### DIFF
--- a/changelog.d/3-bug-fixes/WPB-5603
+++ b/changelog.d/3-bug-fixes/WPB-5603
@@ -1,1 +1,1 @@
-Fix a bug where non-team conversation members that are remote would not get a `conversation.member-leave` event
+Fix a bug where non-team conversation members that are remote would not get a `conversation.member-leave` event (#3745, #3764)

--- a/libs/wire-api/src/Wire/API/Event/Conversation.hs
+++ b/libs/wire-api/src/Wire/API/Event/Conversation.hs
@@ -25,7 +25,6 @@ module Wire.API.Event.Conversation
     evtType,
     EventType (..),
     EventData (..),
-    EdMemberLeftReason (..),
     AddCodeResult (..),
 
     -- * Event lenses
@@ -87,6 +86,7 @@ import Wire.API.Conversation.Protocol (ProtocolUpdate (unProtocolUpdate))
 import Wire.API.Conversation.Protocol qualified as P
 import Wire.API.Conversation.Role
 import Wire.API.Conversation.Typing
+import Wire.API.Event.LeaveReason
 import Wire.API.MLS.SubConversation
 import Wire.API.Routes.MultiVerb
 import Wire.API.Routes.Version
@@ -163,30 +163,6 @@ instance ToSchema EventType where
           element "conversation.mls-message-add" MLSMessageAdd,
           element "conversation.mls-welcome" MLSWelcome,
           element "conversation.protocol-update" ProtocolUpdate
-        ]
-
---  | The reason for a member to leave
---    There are three reasons
---    - the member has left on their own
---    - the member was removed from the team
---    - the member was removed by another member
-data EdMemberLeftReason
-  = -- | The member has left on their own
-    EdReasonLeft
-  | -- | The member was removed from the team and/or deleted
-    EdReasonDeleted
-  | -- | The member was removed by another member
-    EdReasonRemoved
-  deriving stock (Eq, Show, Generic)
-  deriving (Arbitrary) via GenericUniform EdMemberLeftReason
-
-instance ToSchema EdMemberLeftReason where
-  schema =
-    enum @Text "EdMemberLeftReason" $
-      mconcat
-        [ element "left" EdReasonLeft,
-          element "user-deleted" EdReasonDeleted,
-          element "removed" EdReasonRemoved
         ]
 
 data EventData

--- a/libs/wire-api/src/Wire/API/Event/LeaveReason.hs
+++ b/libs/wire-api/src/Wire/API/Event/LeaveReason.hs
@@ -1,0 +1,46 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Wire.API.Event.LeaveReason where
+
+import Data.Schema
+import Imports
+import Wire.Arbitrary
+
+--  | The reason for a member to leave
+--    There are three reasons
+--    - the member has left on their own
+--    - the member was removed from the team
+--    - the member was removed by another member
+data EdMemberLeftReason
+  = -- | The member has left on their own
+    EdReasonLeft
+  | -- | The member was removed from the team and/or deleted
+    EdReasonDeleted
+  | -- | The member was removed by another member
+    EdReasonRemoved
+  deriving stock (Eq, Show, Generic)
+  deriving (Arbitrary) via GenericUniform EdMemberLeftReason
+
+instance ToSchema EdMemberLeftReason where
+  schema =
+    enum @Text "EdMemberLeftReason" $
+      mconcat
+        [ element "left" EdReasonLeft,
+          element "user-deleted" EdReasonDeleted,
+          element "removed" EdReasonRemoved
+        ]

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_conversation.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_conversation.hs
@@ -35,6 +35,7 @@ import Wire.API.Conversation.Code
 import Wire.API.Conversation.Role
 import Wire.API.Conversation.Typing
 import Wire.API.Event.Conversation
+import Wire.API.Event.LeaveReason
 
 testObject_Event_conversation_1 :: Event
 testObject_Event_conversation_1 =

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/Event_user.hs
@@ -34,6 +34,7 @@ import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role (parseRoleName)
 import Wire.API.Conversation.Typing
 import Wire.API.Event.Conversation
+import Wire.API.Event.LeaveReason
 import Wire.API.Provider.Service (ServiceRef (ServiceRef, _serviceRefId, _serviceRefProvider))
 
 domain :: Domain

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/RemoveBotResponse_user.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Generated/RemoveBotResponse_user.hs
@@ -27,6 +27,7 @@ import Data.UUID qualified as UUID (fromString)
 import Imports (read)
 import Wire.API.Conversation.Bot (RemoveBotResponse (..))
 import Wire.API.Event.Conversation
+import Wire.API.Event.LeaveReason
 
 testObject_RemoveBotResponse_user_1 :: RemoveBotResponse
 testObject_RemoveBotResponse_user_1 =

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual.hs
@@ -26,6 +26,7 @@ import Test.Wire.API.Golden.Manual.ConvIdsPage
 import Test.Wire.API.Golden.Manual.ConversationCoverView
 import Test.Wire.API.Golden.Manual.ConversationEvent
 import Test.Wire.API.Golden.Manual.ConversationPagingState
+import Test.Wire.API.Golden.Manual.ConversationRemoveMembers
 import Test.Wire.API.Golden.Manual.ConversationsResponse
 import Test.Wire.API.Golden.Manual.CreateGroupConversation
 import Test.Wire.API.Golden.Manual.CreateScimToken
@@ -186,5 +187,11 @@ tests =
           [ (testObject_FederationRestriction_1, "testObject_FederationRestriction_1.json"),
             (testObject_FederationRestriction_2, "testObject_FederationRestriction_2.json"),
             (testObject_FederationRestriction_3, "testObject_FederationRestriction_3.json")
+          ],
+      testGroup "ConversationRemoveMembers" $
+        testObjects
+          [ (testObject_ConversationRemoveMembers_1, "testObject_ConversationRemoveMembers_1.json"),
+            (testObject_ConversationRemoveMembers_2, "testObject_ConversationRemoveMembers_2.json"),
+            (testObject_ConversationRemoveMembers_3, "testObject_ConversationRemoveMembers_3.json")
           ]
     ]

--- a/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationRemoveMembers.hs
+++ b/libs/wire-api/test/golden/Test/Wire/API/Golden/Manual/ConversationRemoveMembers.hs
@@ -1,0 +1,56 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.Wire.API.Golden.Manual.ConversationRemoveMembers where
+
+import Data.Domain
+import Data.Id
+import Data.List.NonEmpty
+import Data.Qualified
+import Data.UUID qualified as UUID
+import Imports
+import Wire.API.Conversation
+import Wire.API.Event.LeaveReason
+
+domain1, domain2 :: Domain
+domain1 = Domain "example.com"
+domain2 = Domain "test.net"
+
+user1, user2 :: Qualified UserId
+user1 = Qualified (Id . fromJust $ UUID.fromString "4f201a43-935e-4e19-8fe0-0a878d3d6e74") domain1
+user2 = Qualified (Id . fromJust $ UUID.fromString "eb48b095-d96f-4a94-b4ec-2a1d61447e13") domain2
+
+testObject_ConversationRemoveMembers_1 :: ConversationRemoveMembers
+testObject_ConversationRemoveMembers_1 =
+  ConversationRemoveMembers
+    { crmTargets = pure user1,
+      crmReason = EdReasonLeft
+    }
+
+testObject_ConversationRemoveMembers_2 :: ConversationRemoveMembers
+testObject_ConversationRemoveMembers_2 =
+  ConversationRemoveMembers
+    { crmTargets = user1 :| [user2],
+      crmReason = EdReasonDeleted
+    }
+
+testObject_ConversationRemoveMembers_3 :: ConversationRemoveMembers
+testObject_ConversationRemoveMembers_3 =
+  ConversationRemoveMembers
+    { crmTargets = pure user2,
+      crmReason = EdReasonRemoved
+    }

--- a/libs/wire-api/test/golden/testObject_ConversationRemoveMembers_1.json
+++ b/libs/wire-api/test/golden/testObject_ConversationRemoveMembers_1.json
@@ -1,0 +1,9 @@
+{
+    "reason": "left",
+    "targets": [
+        {
+            "domain": "example.com",
+            "id": "4f201a43-935e-4e19-8fe0-0a878d3d6e74"
+        }
+    ]
+}

--- a/libs/wire-api/test/golden/testObject_ConversationRemoveMembers_2.json
+++ b/libs/wire-api/test/golden/testObject_ConversationRemoveMembers_2.json
@@ -1,0 +1,13 @@
+{
+    "reason": "user-deleted",
+    "targets": [
+        {
+            "domain": "example.com",
+            "id": "4f201a43-935e-4e19-8fe0-0a878d3d6e74"
+        },
+        {
+            "domain": "test.net",
+            "id": "eb48b095-d96f-4a94-b4ec-2a1d61447e13"
+        }
+    ]
+}

--- a/libs/wire-api/test/golden/testObject_ConversationRemoveMembers_3.json
+++ b/libs/wire-api/test/golden/testObject_ConversationRemoveMembers_3.json
@@ -1,0 +1,9 @@
+{
+    "reason": "removed",
+    "targets": [
+        {
+            "domain": "test.net",
+            "id": "eb48b095-d96f-4a94-b4ec-2a1d61447e13"
+        }
+    ]
+}

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -567,6 +567,7 @@ test-suite wire-api-golden-tests
     Test.Wire.API.Golden.Manual.ConversationCoverView
     Test.Wire.API.Golden.Manual.ConversationEvent
     Test.Wire.API.Golden.Manual.ConversationPagingState
+    Test.Wire.API.Golden.Manual.ConversationRemoveMembers
     Test.Wire.API.Golden.Manual.ConversationsResponse
     Test.Wire.API.Golden.Manual.ConvIdsPage
     Test.Wire.API.Golden.Manual.CreateGroupConversation

--- a/libs/wire-api/wire-api.cabal
+++ b/libs/wire-api/wire-api.cabal
@@ -93,6 +93,7 @@ library
     Wire.API.Event.Conversation
     Wire.API.Event.FeatureConfig
     Wire.API.Event.Federation
+    Wire.API.Event.LeaveReason
     Wire.API.Event.Team
     Wire.API.FederationStatus
     Wire.API.FederationUpdate

--- a/services/brig/test/integration/API/Provider.hs
+++ b/services/brig/test/integration/API/Provider.hs
@@ -86,6 +86,7 @@ import Wire.API.Conversation
 import Wire.API.Conversation.Bot
 import Wire.API.Conversation.Role
 import Wire.API.Event.Conversation
+import Wire.API.Event.LeaveReason
 import Wire.API.Internal.Notification
 import Wire.API.Provider
 import Wire.API.Provider.Bot qualified as Ext

--- a/services/brig/test/integration/API/User/Util.hs
+++ b/services/brig/test/integration/API/User/Util.hs
@@ -60,8 +60,8 @@ import Test.Tasty.HUnit
 import Util
 import Wire.API.Asset
 import Wire.API.Connection
-import Wire.API.Event.Conversation (EdMemberLeftReason)
 import Wire.API.Event.Conversation qualified as Conv
+import Wire.API.Event.LeaveReason
 import Wire.API.Federation.API.Brig qualified as F
 import Wire.API.Federation.Component
 import Wire.API.Internal.Notification (Notification (..))

--- a/services/brig/test/integration/Federation/End2end.hs
+++ b/services/brig/test/integration/Federation/End2end.hs
@@ -52,6 +52,7 @@ import Wire.API.Conversation
 import Wire.API.Conversation.Role
 import Wire.API.Conversation.Typing
 import Wire.API.Event.Conversation
+import Wire.API.Event.LeaveReason
 import Wire.API.Internal.Notification
 import Wire.API.MLS.KeyPackage
 import Wire.API.Message

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -89,6 +89,7 @@ import Wire.API.CustomBackend
 import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Event.Conversation
+import Wire.API.Event.LeaveReason
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error

--- a/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
+++ b/services/galley/src/Galley/API/MLS/Commit/InternalCommit.hs
@@ -53,6 +53,7 @@ import Wire.API.Conversation.Protocol
 import Wire.API.Conversation.Role
 import Wire.API.Error
 import Wire.API.Error.Galley
+import Wire.API.Event.LeaveReason
 import Wire.API.MLS.Commit
 import Wire.API.MLS.Credential
 import Wire.API.MLS.Proposal qualified as Proposal
@@ -303,6 +304,7 @@ removeMembers qusr con lConvOrSub users = case tUnqualified lConvOrSub of
           . handleMLSProposalFailures @ProposalErrors
           . fmap pure
           . updateLocalConversationUnchecked @'ConversationRemoveMembersTag lconv qusr con
+          . flip ConversationRemoveMembers EdReasonRemoved
       )
       . nonEmpty
       . filter (flip Set.member (existingMembers lconv))

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -123,11 +123,13 @@ import Polysemy.TinyLog qualified as P
 import SAML2.WebSSO qualified as SAML
 import System.Logger (Msg)
 import System.Logger qualified as Log
+import Wire.API.Conversation (ConversationRemoveMembers (..))
 import Wire.API.Conversation.Role (Action (DeleteConversation), wireConvRoles)
 import Wire.API.Conversation.Role qualified as Public
 import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Event.Conversation qualified as Conv
+import Wire.API.Event.LeaveReason
 import Wire.API.Event.Team
 import Wire.API.Federation.Error
 import Wire.API.Message qualified as Conv
@@ -1064,7 +1066,10 @@ removeFromConvsAndPushConvLeaveEvent lusr zcon tid remove admins = do
               zcon
               (qualifyAs lusr dc)
               targets
-              (pure . tUntagged . qualifyAs lusr $ remove)
+              ( ConversationRemoveMembers
+                  (pure . tUntagged . qualifyAs lusr $ remove)
+                  EdReasonDeleted
+              )
 
 getTeamConversations ::
   ( Member (ErrorS 'NotATeamMember) r,

--- a/services/galley/src/Galley/API/Update.hs
+++ b/services/galley/src/Galley/API/Update.hs
@@ -131,6 +131,7 @@ import Wire.API.Conversation.Typing
 import Wire.API.Error
 import Wire.API.Error.Galley
 import Wire.API.Event.Conversation
+import Wire.API.Event.LeaveReason
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Galley
 import Wire.API.Federation.Error
@@ -1200,9 +1201,11 @@ removeMemberFromLocalConv lcnv lusr con victim
   | otherwise =
       fmap (fmap lcuEvent . hush)
         . runError @NoChanges
-        . updateLocalConversation @'ConversationRemoveMembersTag lcnv (tUntagged lusr) con
-        . pure
-        $ victim
+        $ updateLocalConversation @'ConversationRemoveMembersTag
+          lcnv
+          (tUntagged lusr)
+          con
+          (ConversationRemoveMembers (pure victim) EdReasonRemoved)
 
 -- OTR
 

--- a/services/galley/test/integration/API.hs
+++ b/services/galley/test/integration/API.hs
@@ -91,6 +91,7 @@ import Wire.API.Conversation.Role
 import Wire.API.Conversation.Typing
 import Wire.API.Error.Galley
 import Wire.API.Event.Conversation
+import Wire.API.Event.LeaveReason
 import Wire.API.Federation.API
 import Wire.API.Federation.API.Brig
 import Wire.API.Federation.API.Common

--- a/services/galley/test/integration/API/Federation.hs
+++ b/services/galley/test/integration/API/Federation.hs
@@ -52,6 +52,7 @@ import Wire.API.Conversation qualified as Conv
 import Wire.API.Conversation.Action
 import Wire.API.Conversation.Role
 import Wire.API.Event.Conversation
+import Wire.API.Event.LeaveReason
 import Wire.API.Federation.API.Brig
 import Wire.API.Federation.API.Common
 import Wire.API.Federation.API.Galley
@@ -409,7 +410,9 @@ removeRemoteUser = do
             FedGalley.cuConvId = conv,
             FedGalley.cuAlreadyPresentUsers = [alice, charlie, dee],
             FedGalley.cuAction =
-              SomeConversationAction (sing @'ConversationRemoveMembersTag) (pure user)
+              SomeConversationAction
+                (sing @'ConversationRemoveMembersTag)
+                (ConversationRemoveMembers (pure user) EdReasonRemoved)
           }
 
   WS.bracketRN c [alice, charlie, dee, flo] $ \[wsA, wsC, wsD, wsF] -> do

--- a/services/galley/test/integration/API/Util.hs
+++ b/services/galley/test/integration/API/Util.hs
@@ -116,6 +116,7 @@ import Wire.API.Conversation.Typing
 import Wire.API.Event.Conversation
 import Wire.API.Event.Conversation qualified as Conv
 import Wire.API.Event.Federation qualified as Fed
+import Wire.API.Event.LeaveReason
 import Wire.API.Event.Team
 import Wire.API.Event.Team qualified as TE
 import Wire.API.Federation.API
@@ -1900,7 +1901,10 @@ assertRemoveUpdate req qconvId remover alreadyPresentUsers victim = liftIO $ do
   cuOrigUserId cu @?= remover
   cuConvId cu @?= qUnqualified qconvId
   sort (cuAlreadyPresentUsers cu) @?= sort alreadyPresentUsers
-  cuAction cu @?= SomeConversationAction (sing @'ConversationRemoveMembersTag) (pure victim)
+  cuAction cu
+    @?= SomeConversationAction
+      (sing @'ConversationRemoveMembersTag)
+      (ConversationRemoveMembers (pure victim) EdReasonRemoved)
 
 assertLeaveUpdate :: (MonadIO m, HasCallStack) => FederatedRequest -> Qualified ConvId -> Qualified UserId -> [UserId] -> m ()
 assertLeaveUpdate req qconvId remover alreadyPresentUsers = liftIO $ do


### PR DESCRIPTION
As reported by a client developer, the event reason when a team member is deleted was incorrectly "member removed", when it should have been "member deleted" (from a team). This PR fixes it.

Tracked by https://wearezeta.atlassian.net/browse/WPB-5603.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
