### PR TITLE
galley-integration: Give legalhold service longer to be connectable from galley

### DIFF
--- a/services/galley/test/integration/API/Teams/LegalHold/Util.hs
+++ b/services/galley/test/integration/API/Teams/LegalHold/Util.hs
@@ -18,7 +18,7 @@ import Control.Concurrent.Timeout hiding (threadDelay)
 import Control.Exception (asyncExceptionFromException)
 import Control.Lens hiding ((#))
 import Control.Monad.Catch
-import Control.Retry (RetryPolicy, RetryStatus, exponentialBackoff, limitRetries, retrying)
+import Control.Retry
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types (FromJSON, withObject, (.:))
 import Data.ByteString qualified as BS
@@ -330,7 +330,7 @@ postSettings uid tid new =
         . json new
   where
     policy :: RetryPolicy
-    policy = exponentialBackoff 50 <> limitRetries 5
+    policy = limitRetriesByCumulativeDelay 5_000_000 $ exponentialBackoff 50
     only412 :: RetryStatus -> ResponseLBS -> TestM Bool
     only412 _ resp = pure $ statusCode resp == 412
 


### PR DESCRIPTION
Earlier we gave it up to 3.15 milliseconds, now its up to 5 seconds.

https://wearezeta.atlassian.net/browse/WPB-5803

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog.
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
