### PR TITLE
.envrc: don't enable flakes extra-experimental-feature

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -13,7 +13,7 @@ store_paths=$(echo "$nix_files" | xargs nix-store --add ./nix)
 layout_dir=$(direnv_layout_dir)
 env_dir=./.env
 
-export NIX_CONFIG='extra-experimental-features = nix-command flakes'
+export NIX_CONFIG='extra-experimental-features = nix-command'
 
 [[ -d "$layout_dir" ]] || mkdir -p "$layout_dir"
 

--- a/hack/bin/bombon.hs
+++ b/hack/bin/bombon.hs
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S nix -Lv run github:wireapp/ghc-flakr/ecb1f45f1549e06c92d71164e305ce501eb0e36e
+#!/usr/bin/env -S nix --extra-experimental-features flakes -Lv run github:wireapp/ghc-flakr/ecb1f45f1549e06c92d71164e305ce501eb0e36e
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}


### PR DESCRIPTION
There's nothing in this repository using flakes, and setting this causes my system to just block entirely:

```
❯ cd dev/wire/wire-server
direnv: error /home/flokli/dev/wire/wire-server/.envrc is blocked. Run `direnv allow` to approve its content
❯ direnv allow
direnv: loading ~/dev/wire/wire-server/.envrc
🔧 Building environment
warning: unknown experimental feature 'flakes'
warning: unknown experimental feature 'flakes'
⏱ 4sdirenv: ([/nix/store/0lf6mkfaqx4zmsni9yys650qx573zfcw-direnv-2.33.0/bin/direnv export zsh]) is taking a while to execute. Use CTRL-C to give up.
⏱ 8s^C
^C^X^C^C^C
```

## Checklist

 - [ ] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [ ] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
