### PR TITLE
 federator: Do no reuse connections when talking to remotes 

### DIFF
--- a/libs/http2-manager/src/HTTP2/Client/Manager.hs
+++ b/libs/http2-manager/src/HTTP2/Client/Manager.hs
@@ -11,6 +11,7 @@ module HTTP2.Client.Manager
     defaultHttp2Manager,
     http2ManagerWithSSLCtx,
     withHTTP2Request,
+    withHTTP2RequestOnSingleUseConn,
     connectIfNotAlreadyConnected,
     ConnectionAlreadyClosed (..),
     disconnectTarget,

--- a/services/federator/src/Federator/Remote.hs
+++ b/services/federator/src/Federator/Remote.hs
@@ -101,7 +101,7 @@ interpretRemote = interpret $ \case
     resp <- mapError (RemoteError target pathT) . (fromEither @FederatorClientHTTP2Error =<<) . embed $
       Codensity $ \k ->
         E.catches
-          (H2Manager.withHTTP2Request mgr (True, hostname, fromIntegral port) req' (consumeStreamingResponseWith $ k . Right))
+          (H2Manager.withHTTP2RequestOnSingleUseConn mgr (True, hostname, fromIntegral port) req' (consumeStreamingResponseWith $ k . Right))
           [ E.Handler $ k . Left,
             E.Handler $ k . Left . FederatorClientTLSException,
             E.Handler $ k . Left . FederatorClientHTTP2Exception,


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-5934

This comes with performance penalty but its required to get around this bug in
the http2 library: https://github.com/kazu-yamamoto/http2/issues/102

## Checklist

 - [x] ~Add a new entry in an appropriate subdirectory of `changelog.d`~ No changelog
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
