### PR TITLE
[WPB-5936] Send `conversation.member-leave` events to team admins

### DIFF
--- a/changelog.d/2-features/WPB-5936
+++ b/changelog.d/2-features/WPB-5936
@@ -1,0 +1,1 @@
+Send a `conversation.member-leave` event to team admins for each conversation the deleted team member used to be part of

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -671,11 +671,12 @@ testDeleteTeamMember = do
   conv <- postConversation alice nc >>= getJSON 201
   withWebSockets [alice, amy, bob] $ \[wsAlice, wsAmy, wsBob] -> do
     void $ deleteTeamMember team alice alex >>= getBody 202
+    assertConvLeaveNotif wsAmy alexId
     do
       n <- awaitMatch isTeamMemberLeaveNotif wsAlice
       alexUId <- alex %. "id"
       nPayload n %. "data.user" `shouldMatch` alexUId
-    assertConvLeaveNotif wsAmy alexId
+      assertConvLeaveNotif wsAlice alexId
     do
       bindResponse (getConversation bob conv) $ \resp -> do
         resp.status `shouldMatchInt` 200

--- a/services/brig/src/Brig/IO/Intra.hs
+++ b/services/brig/src/Brig/IO/Intra.hs
@@ -844,7 +844,8 @@ upsertOne2OneConversation urequest = do
 -------------------------------------------------------------------------------
 -- User management
 
--- | Calls 'Galley.API.rmUserH', as well as gundeck and cargohold.
+-- | Calls Galley's endpoint with the internal route ID "delete-user", as well
+-- as gundeck and cargohold.
 rmUser ::
   ( MonadReader Env m,
     MonadIO m,

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -1009,7 +1009,7 @@ uncheckedDeleteTeamMember lusr zcon tid remove admins = do
   pushMemberLeaveEvent now
   E.deleteTeamMember tid remove
   -- notify all conversation members not in this team.
-  removeFromConvsAndPushConvLeaveEvent lusr zcon tid remove admins
+  removeFromConvsAndPushConvLeaveEvent lusr zcon tid remove
   where
     -- notify team admins
     pushMemberLeaveEvent :: UTCTime -> Sem r ()
@@ -1038,10 +1038,8 @@ removeFromConvsAndPushConvLeaveEvent ::
   Maybe ConnId ->
   TeamId ->
   UserId ->
-  [UserId] ->
   Sem r ()
-removeFromConvsAndPushConvLeaveEvent lusr zcon tid remove admins = do
-  let teamAdmins = Set.fromList admins
+removeFromConvsAndPushConvLeaveEvent lusr zcon tid remove = do
   cc <- E.getTeamConversations tid
   for_ cc $ \c ->
     E.getConversation (c ^. conversationId) >>= \conv ->
@@ -1049,13 +1047,9 @@ removeFromConvsAndPushConvLeaveEvent lusr zcon tid remove admins = do
         when (remove `isMember` Data.convLocalMembers dc) $ do
           E.deleteMembers (c ^. conversationId) (UserList [remove] [])
           let (bots, allLocUsers) = localBotsAndUsers (Data.convLocalMembers dc)
-              notAdmins =
-                foldMap
-                  (\m -> guard (not (Conv.lmId m `Set.member` teamAdmins)) $> Conv.lmId m)
-                  allLocUsers
               targets =
                 BotsAndMembers
-                  (Set.fromList notAdmins)
+                  (Set.fromList $ Conv.lmId <$> allLocUsers)
                   (Set.fromList $ Conv.rmId <$> Data.convRemoteMembers dc)
                   (Set.fromList bots)
           void $


### PR DESCRIPTION
Send a `conversation.member-leave` event to team admins for each conversation the deleted team member used to be part of.

Tracked by https://wearezeta.atlassian.net/browse/WPB-5936.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
