### PR TITLE
YesImportQualifiedPost in /integration

### DIFF
--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -51,7 +51,6 @@ common common-all
     MultiWayIf
     NamedFieldPuns
     NoImplicitPrelude
-    NoImportQualifiedPost
     OverloadedLabels
     OverloadedRecordDot
     PackageImports


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-5803

We should either support this extension in both /integration and everywhere else, or nowhere.  I'm very much in favor of "everywhere".  Note that the extension allows for the old *and* the new syntax.

(I'm also curious: why was it disabled?)

## Checklist

 - [x] ~~Add a new entry in an appropriate subdirectory of `changelog.d`~~
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)
