### PR TITLE
[WPB-5883] Feature flag for a limited event fanout

### DIFF
--- a/cassandra-schema.cql
+++ b/cassandra-schema.cql
@@ -1200,6 +1200,7 @@ CREATE TABLE galley_test.team_features (
     guest_links_lock_status int,
     guest_links_status int,
     legalhold_status int,
+    limited_event_fanout_status int,
     mls_allowed_ciphersuites set<int>,
     mls_default_ciphersuite int,
     mls_default_protocol int,

--- a/changelog.d/2-features/WPB-5883
+++ b/changelog.d/2-features/WPB-5883
@@ -1,0 +1,1 @@
+Introduce a feature flag that controls whether the limited event fanout should be used when a team member is deleted

--- a/charts/galley/templates/configmap.yaml
+++ b/charts/galley/templates/configmap.yaml
@@ -141,5 +141,9 @@ data:
         mlsMigration:
           {{- toYaml .settings.featureFlags.mlsMigration | nindent 10 }}
         {{- end }}
+        {{- if .settings.featureFlags.limitedEventFanout }}
+        limitedEventFanout:
+          {{- toYaml .settings.featureFlags.limitedEventFanout | nindent 10 }}
+        {{- end }}
       {{- end }}
   {{- end }}

--- a/charts/galley/values.yaml
+++ b/charts/galley/values.yaml
@@ -132,6 +132,9 @@ config:
             usersThreshold: 100
             clientsThreshold: 100
           lockStatus: locked
+      limitedEventFanout:
+        defaults:
+          status: disabled
 
   aws:
     region: "eu-west-1"

--- a/docs/src/developer/reference/config-options.md
+++ b/docs/src/developer/reference/config-options.md
@@ -425,7 +425,7 @@ federator:
     clientPrivateKey: client-key.pem
 ```
 
-### Outlook calalendar integration
+### Outlook calendar integration
 
 This feature setting only applies to the Outlook Calendar extension for Wire. As it is an external service, it should only be configured through this feature flag and otherwise ignored by the backend.
 
@@ -448,6 +448,23 @@ To set the validity duration of conversation guest links set `guestLinkTTLSecond
 config:
   settings:
     GuestLinkTTLSeconds: 604800
+```
+
+### Limited Event Fanout
+
+To maintain compatibility with clients and their versions that do not implement
+the limited event fanout when a team member is deleted, the limited event fanout
+flag is used. Its default value `disabled` means that the old-style full event
+fanout will take place when a team member is deleted. Set the flag to `enabled`
+to send team events only to team owners and administrators.
+
+Example configuration:
+
+```yaml
+# galley.yaml
+limitedEventFanout:
+  defaults:
+    status: disabled
 ```
 
 ## Settings in brig

--- a/hack/helm_vars/wire-server/values.yaml.gotmpl
+++ b/hack/helm_vars/wire-server/values.yaml.gotmpl
@@ -235,6 +235,9 @@ galley:
               usersThreshold: 100
               clientsThreshold: 50
             lockStatus: locked
+        limitedEventFanout:
+            defaults:
+            status: disabled
     journal:
       endpoint: http://fake-aws-sqs:4568
       queueName: integration-team-events.fifo

--- a/integration/integration.cabal
+++ b/integration/integration.cabal
@@ -119,6 +119,7 @@ library
     Test.Demo
     Test.Errors
     Test.ExternalPartner
+    Test.FeatureFlags
     Test.Federation
     Test.Federator
     Test.MessageTimer

--- a/integration/test/Notifications.hs
+++ b/integration/test/Notifications.hs
@@ -139,3 +139,9 @@ assertLeaveNotification fromUser conv user client leaver =
             isNotifFromUser fromUser
           ]
       )
+
+assertConvUserDeletedNotif :: MakesValue leaverId => WebSocket -> leaverId -> App ()
+assertConvUserDeletedNotif ws leaverId = do
+  n <- awaitMatch isConvLeaveNotif ws
+  nPayload n %. "data.qualified_user_ids.0" `shouldMatch` leaverId
+  nPayload n %. "data.reason" `shouldMatch` "user-deleted"

--- a/integration/test/Test/Conversation.hs
+++ b/integration/test/Test/Conversation.hs
@@ -742,6 +742,10 @@ testLeaveConversationSuccess = do
     assertLeaveNotification chad conv bob bClient chad
     assertLeaveNotification chad conv eve eClient chad
 
+-- The test relies on the default value for the 'limitedEventFanout' flag, which
+-- is disabled by default. The counterpart test
+-- 'testDeleteTeamMemberLimitedEventFanout' enables the flag and tests the
+-- limited fanout.
 testDeleteTeamMemberFullEventFanout :: HasCallStack => App ()
 testDeleteTeamMemberFullEventFanout = do
   (alice, team, [alex, alison]) <- createTeam OwnDomain 3
@@ -758,8 +762,10 @@ testDeleteTeamMemberFullEventFanout = do
       n <- awaitMatch isTeamMemberLeaveNotif wsAlice
       nPayload n %. "data.user" `shouldMatch` alexUId
     do
-      n <- awaitMatch isTeamMemberLeaveNotif wsAlison
-      nPayload n %. "data.user" `shouldMatch` alexUId
+      t <- awaitMatch isTeamMemberLeaveNotif wsAlison
+      nPayload t %. "data.user" `shouldMatch` alexUId
+      c <- awaitMatch isConvLeaveNotif wsAlison
+      nPayload c %. "data.qualified_user_ids" `shouldMatch` [alexId]
     do
       n <- awaitMatch isConvLeaveNotif wsAmy
       nPayload n %. "data.qualified_user_ids" `shouldMatch` [alexId]

--- a/integration/test/Test/FeatureFlags.hs
+++ b/integration/test/Test/FeatureFlags.hs
@@ -1,0 +1,35 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+
+module Test.FeatureFlags where
+
+import API.GalleyInternal
+import SetupHelpers
+import Testlib.Prelude
+
+testLimitedEventFanout :: HasCallStack => App ()
+testLimitedEventFanout = do
+  let featureName = "limitedEventFanout"
+  (_alice, team, _) <- createTeam OwnDomain 1
+  -- getTeamFeatureStatus OwnDomain team "limitedEventFanout" "enabled"
+  bindResponse (getTeamFeature OwnDomain featureName team) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "status" `shouldMatch` "disabled"
+  setTeamFeatureStatus OwnDomain team featureName "enabled"
+  bindResponse (getTeamFeature OwnDomain featureName team) $ \resp -> do
+    resp.status `shouldMatchInt` 200
+    resp.json %. "status" `shouldMatch` "enabled"

--- a/libs/galley-types/src/Galley/Types/Teams.hs
+++ b/libs/galley-types/src/Galley/Types/Teams.hs
@@ -43,6 +43,7 @@ module Galley.Types.Teams
     flagMlsE2EId,
     flagMlsMigration,
     flagEnforceFileDownloadLocation,
+    flagLimitedEventFanout,
     Defaults (..),
     ImplicitLockStatus (..),
     unImplicitLockStatus,
@@ -167,7 +168,8 @@ data FeatureFlags = FeatureFlags
     _flagOutlookCalIntegration :: !(Defaults (WithStatus OutlookCalIntegrationConfig)),
     _flagMlsE2EId :: !(Defaults (WithStatus MlsE2EIdConfig)),
     _flagMlsMigration :: !(Defaults (WithStatus MlsMigrationConfig)),
-    _flagEnforceFileDownloadLocation :: !(Defaults (WithStatus EnforceFileDownloadLocationConfig))
+    _flagEnforceFileDownloadLocation :: !(Defaults (WithStatus EnforceFileDownloadLocationConfig)),
+    _flagLimitedEventFanout :: !(Defaults (ImplicitLockStatus LimitedEventFanoutConfig))
   }
   deriving (Eq, Show, Generic)
 
@@ -221,6 +223,7 @@ instance FromJSON FeatureFlags where
       <*> (fromMaybe (Defaults (defFeatureStatus @MlsE2EIdConfig)) <$> (obj .:? "mlsE2EId"))
       <*> (fromMaybe (Defaults (defFeatureStatus @MlsMigrationConfig)) <$> (obj .:? "mlsMigration"))
       <*> (fromMaybe (Defaults (defFeatureStatus @EnforceFileDownloadLocationConfig)) <$> (obj .:? "enforceFileDownloadLocation"))
+      <*> withImplicitLockStatusOrDefault obj "limitedEventFanout"
     where
       withImplicitLockStatusOrDefault :: forall cfg. (IsFeatureConfig cfg, Schema.ToSchema cfg) => Object -> Key -> A.Parser (Defaults (ImplicitLockStatus cfg))
       withImplicitLockStatusOrDefault obj fieldName = fromMaybe (Defaults (ImplicitLockStatus (defFeatureStatus @cfg))) <$> obj .:? fieldName
@@ -245,6 +248,7 @@ instance ToJSON FeatureFlags where
         mlsE2EId
         mlsMigration
         enforceFileDownloadLocation
+        teamMemberDeletedLimitedEventFanout
       ) =
       object
         [ "sso" .= sso,
@@ -263,7 +267,8 @@ instance ToJSON FeatureFlags where
           "outlookCalIntegration" .= outlookCalIntegration,
           "mlsE2EId" .= mlsE2EId,
           "mlsMigration" .= mlsMigration,
-          "enforceFileDownloadLocation" .= enforceFileDownloadLocation
+          "enforceFileDownloadLocation" .= enforceFileDownloadLocation,
+          "limitedEventFanout" .= teamMemberDeletedLimitedEventFanout
         ]
 
 instance FromJSON FeatureSSO where

--- a/libs/galley-types/test/unit/Test/Galley/Types.hs
+++ b/libs/galley-types/test/unit/Test/Galley/Types.hs
@@ -100,7 +100,7 @@ instance Arbitrary FeatureFlags where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> fmap (fmap unlocked) arbitrary
     where
       unlocked :: ImplicitLockStatus a -> ImplicitLockStatus a
       unlocked = ImplicitLockStatus . Public.setLockStatus Public.LockStatusUnlocked . _unImplicitLockStatus

--- a/libs/galley-types/test/unit/Test/Galley/Types.hs
+++ b/libs/galley-types/test/unit/Test/Galley/Types.hs
@@ -100,6 +100,7 @@ instance Arbitrary FeatureFlags where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
     where
       unlocked :: ImplicitLockStatus a -> ImplicitLockStatus a
       unlocked = ImplicitLockStatus . Public.setLockStatus Public.LockStatusUnlocked . _unImplicitLockStatus

--- a/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Internal/Galley.hs
@@ -165,6 +165,10 @@ type IFeatureAPI =
     :<|> IFeatureStatusPutWithDesc '[] '() EnforceFileDownloadLocationConfig "<p><b>Custom feature: only supported for some decidated on-prem systems.</b></p>"
     :<|> IFeatureStatusPatchWithDesc '[] '() EnforceFileDownloadLocationConfig "<p><b>Custom feature: only supported for some decidated on-prem systems.</b></p>"
     :<|> IFeatureStatusLockStatusPutWithDesc EnforceFileDownloadLocationConfig "<p><b>Custom feature: only supported for some decidated on-prem systems.</b></p>"
+    -- LimitedEventFanoutConfig
+    :<|> IFeatureStatusGet LimitedEventFanoutConfig
+    :<|> IFeatureStatusPut '[] '() LimitedEventFanoutConfig
+    :<|> IFeatureStatusPatch '[] '() LimitedEventFanoutConfig
     -- all feature configs
     :<|> Named
            "feature-configs-internal"

--- a/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
+++ b/libs/wire-api/src/Wire/API/Routes/Public/Galley/Feature.hs
@@ -101,6 +101,7 @@ type FeatureAPI =
             '()
             EnforceFileDownloadLocationConfig
             "<p><b>Custom feature: only supported for some decidated on-prem systems.</b></p>"
+    :<|> From 'V5 ::> FeatureStatusGet LimitedEventFanoutConfig
     :<|> AllFeatureConfigsUserGet
     :<|> AllFeatureConfigsTeamGet
     :<|> FeatureConfigDeprecatedGet "The usage of this endpoint was removed in iOS in version 3.101. It is not used by team management, or webapp, and is potentially used by the old Android client as of June 2022" LegalholdConfig

--- a/services/galley/galley.cabal
+++ b/services/galley/galley.cabal
@@ -276,6 +276,7 @@ library
     Galley.Schema.V88_RemoveMemberClientAndTruncateMLSGroupMemberClient
     Galley.Schema.V89_MlsLockStatus
     Galley.Schema.V90_EnforceFileDownloadLocationConfig
+    Galley.Schema.V91_TeamMemberDeletedLimitedEventFanout
     Galley.Types.Clients
     Galley.Types.ToUserRole
     Galley.Types.UserList

--- a/services/galley/galley.integration.yaml
+++ b/services/galley/galley.integration.yaml
@@ -93,6 +93,9 @@ settings:
           usersThreshold: 100
           clientsThreshold: 50
         lockStatus: locked
+    limitedEventFanout:
+      defaults:
+        status: disabled
 
 logLevel: Warn
 logNetStrings: false

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -239,6 +239,9 @@ featureAPI =
     <@> mkNamedAPI @'("iput", EnforceFileDownloadLocationConfig) setFeatureStatusInternal
     <@> mkNamedAPI @'("ipatch", EnforceFileDownloadLocationConfig) patchFeatureStatusInternal
     <@> mkNamedAPI @'("ilock", EnforceFileDownloadLocationConfig) (updateLockStatus @EnforceFileDownloadLocationConfig)
+    <@> mkNamedAPI @'("iget", LimitedEventFanoutConfig) (getFeatureStatus DontDoAuth)
+    <@> mkNamedAPI @'("iput", LimitedEventFanoutConfig) setFeatureStatusInternal
+    <@> mkNamedAPI @'("ipatch", LimitedEventFanoutConfig) patchFeatureStatusInternal
     <@> mkNamedAPI @"feature-configs-internal" (maybe getAllFeatureConfigsForServer getAllFeatureConfigsForUser)
 
 waiInternalSitemap :: Routes a (Sem GalleyEffects) ()

--- a/services/galley/src/Galley/API/Internal.hs
+++ b/services/galley/src/Galley/API/Internal.hs
@@ -344,7 +344,7 @@ rmUser lusr conn = do
 
     leaveTeams page = for_ (pageItems page) $ \tid -> do
       admins <- E.getTeamAdmins tid
-      uncheckedDeleteTeamMember lusr conn tid (tUnqualified lusr) admins
+      uncheckedDeleteTeamMember lusr conn tid (tUnqualified lusr) (Left admins)
       page' <- listTeams @p2 (tUnqualified lusr) (Just (pageState page)) maxBound
       leaveTeams page'
 

--- a/services/galley/src/Galley/API/Public/Feature.hs
+++ b/services/galley/src/Galley/API/Public/Feature.hs
@@ -67,6 +67,7 @@ featureAPI =
     <@> mkNamedAPI @'("put", MlsMigrationConfig) (setFeatureStatus . DoAuth)
     <@> mkNamedAPI @'("get", EnforceFileDownloadLocationConfig) (getFeatureStatus . DoAuth)
     <@> mkNamedAPI @'("put", EnforceFileDownloadLocationConfig) (setFeatureStatus . DoAuth)
+    <@> mkNamedAPI @'("get", LimitedEventFanoutConfig) (getFeatureStatus . DoAuth)
     <@> mkNamedAPI @"get-all-feature-configs-for-user" getAllFeatureConfigsForUser
     <@> mkNamedAPI @"get-all-feature-configs-for-team" getAllFeatureConfigsForTeam
     <@> mkNamedAPI @'("get-config", LegalholdConfig) getFeatureStatusForUser

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -986,17 +986,8 @@ deleteTeamMember' lusr zcon tid remove mBody = do
               then 0
               else sizeBeforeDelete - 1
       E.deleteUser remove
-      toNotify <-
-        getFeatureStatus @LimitedEventFanoutConfig DontDoAuth tid
-          >>= ( \case
-                  FeatureStatusEnabled -> E.getBillingTeamMembers tid
-                  FeatureStatusDisabled -> do
-                    let filterFromMembers list =
-                          view userId <$> filter (`hasPermission` SetBilling) (list ^. teamMembers)
-                    filterFromMembers <$> getTeamMembersForFanout tid
-              )
-            . wsStatus
-      Journal.teamUpdate tid sizeAfterDelete $ filter (/= remove) toNotify
+      owners <- E.getBillingTeamMembers tid
+      Journal.teamUpdate tid sizeAfterDelete $ filter (/= remove) owners
       pure TeamMemberDeleteAccepted
     else do
       getFeatureStatus @LimitedEventFanoutConfig DontDoAuth tid

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -987,22 +987,28 @@ deleteTeamMember' lusr zcon tid remove mBody = do
               else sizeBeforeDelete - 1
       E.deleteUser remove
       toNotify <-
-        getFeatureStatus @LimitedEventFanoutConfig DontDoAuth tid >>= (\case
-          FeatureStatusEnabled -> E.getBillingTeamMembers tid
-          FeatureStatusDisabled -> do
-            let filterFromMembers list =
-                  view userId <$> filter (`hasPermission` SetBilling) (list ^. teamMembers)
-            filterFromMembers <$> getTeamMembersForFanout tid) . wsStatus
+        getFeatureStatus @LimitedEventFanoutConfig DontDoAuth tid
+          >>= ( \case
+                  FeatureStatusEnabled -> E.getBillingTeamMembers tid
+                  FeatureStatusDisabled -> do
+                    let filterFromMembers list =
+                          view userId <$> filter (`hasPermission` SetBilling) (list ^. teamMembers)
+                    filterFromMembers <$> getTeamMembersForFanout tid
+              )
+            . wsStatus
       Journal.teamUpdate tid sizeAfterDelete $ filter (/= remove) toNotify
       pure TeamMemberDeleteAccepted
     else do
-      getFeatureStatus @LimitedEventFanoutConfig DontDoAuth tid >>= (\case
-        FeatureStatusEnabled -> do
-          admins <- E.getTeamAdmins tid
-          uncheckedDeleteTeamMember lusr (Just zcon) tid remove (Left admins)
-        FeatureStatusDisabled -> do
-          mems <- getTeamMembersForFanout tid
-          uncheckedDeleteTeamMember lusr (Just zcon) tid remove (Right mems)) . wsStatus
+      getFeatureStatus @LimitedEventFanoutConfig DontDoAuth tid
+        >>= ( \case
+                FeatureStatusEnabled -> do
+                  admins <- E.getTeamAdmins tid
+                  uncheckedDeleteTeamMember lusr (Just zcon) tid remove (Left admins)
+                FeatureStatusDisabled -> do
+                  mems <- getTeamMembersForFanout tid
+                  uncheckedDeleteTeamMember lusr (Just zcon) tid remove (Right mems)
+            )
+          . wsStatus
       pure TeamMemberDeleteCompleted
 
 -- This function is "unchecked" because it does not validate that the user has the `RemoveTeamMember` permission.

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -992,10 +992,7 @@ deleteTeamMember' lusr zcon tid remove mBody = do
           FeatureStatusDisabled -> do
             let filterFromMembers list =
                   view userId <$> filter (`hasPermission` SetBilling) (list ^. teamMembers)
-            -- fmap (view userId) $ (list ^. teamMembers)
-            mems <- getTeamMembersForFanout tid
-            let res = filterFromMembers mems
-            pure res
+            filterFromMembers <$> getTeamMembersForFanout tid
       Journal.teamUpdate tid sizeAfterDelete $ filter (/= remove) toNotify
       pure TeamMemberDeleteAccepted
     else do

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -1065,7 +1065,7 @@ uncheckedDeleteTeamMember lusr zcon tid remove (Right mems) = do
               (userRecipient (tUnqualified lusr))
               (membersToRecipients (Just (tUnqualified lusr)) (mems ^. teamMembers))
       E.push1 $
-        newPushLocal1 (mems ^. teamMemberListType) (tUnqualified lusr) (TeamEvent e) r & pushConn .~ zcon
+        newPushLocal1 (mems ^. teamMemberListType) (tUnqualified lusr) (TeamEvent e) r & pushTransient .~ True
 
 removeFromConvsAndPushConvLeaveEvent ::
   forall r.

--- a/services/galley/src/Galley/API/Teams.hs
+++ b/services/galley/src/Galley/API/Teams.hs
@@ -86,6 +86,7 @@ import Data.Time.Clock (UTCTime)
 import Galley.API.Action
 import Galley.API.Error as Galley
 import Galley.API.LegalHold.Team
+import Galley.API.Teams.Features.Get
 import Galley.API.Teams.Notifications qualified as APITeamQueue
 import Galley.API.Update qualified as API
 import Galley.API.Util
@@ -141,6 +142,7 @@ import Wire.API.Team qualified as Public
 import Wire.API.Team.Conversation
 import Wire.API.Team.Conversation qualified as Public
 import Wire.API.Team.Export (TeamExportUser (..))
+import Wire.API.Team.Feature
 import Wire.API.Team.Member
 import Wire.API.Team.Member qualified as M
 import Wire.API.Team.Member qualified as Public
@@ -889,9 +891,11 @@ deleteTeamMember ::
     Member (ErrorS 'NotATeamMember) r,
     Member (ErrorS OperationDenied) r,
     Member ExternalAccess r,
+    Member (Input Opts) r,
     Member (Input UTCTime) r,
     Member GundeckAccess r,
     Member MemberStore r,
+    Member TeamFeatureStore r,
     Member TeamStore r,
     Member P.TinyLog r
   ) =>
@@ -915,9 +919,11 @@ deleteNonBindingTeamMember ::
     Member (ErrorS 'NotATeamMember) r,
     Member (ErrorS OperationDenied) r,
     Member ExternalAccess r,
+    Member (Input Opts) r,
     Member (Input UTCTime) r,
     Member GundeckAccess r,
     Member MemberStore r,
+    Member TeamFeatureStore r,
     Member TeamStore r,
     Member P.TinyLog r
   ) =>
@@ -941,9 +947,11 @@ deleteTeamMember' ::
     Member (ErrorS 'NotATeamMember) r,
     Member (ErrorS OperationDenied) r,
     Member ExternalAccess r,
+    Member (Input Opts) r,
     Member (Input UTCTime) r,
     Member GundeckAccess r,
     Member MemberStore r,
+    Member TeamFeatureStore r,
     Member TeamStore r,
     Member P.TinyLog r
   ) =>
@@ -982,8 +990,13 @@ deleteTeamMember' lusr zcon tid remove mBody = do
       Journal.teamUpdate tid sizeAfterDelete $ filter (/= remove) owners
       pure TeamMemberDeleteAccepted
     else do
-      admins <- E.getTeamAdmins tid
-      uncheckedDeleteTeamMember lusr (Just zcon) tid remove admins
+      wsStatus <$> getFeatureStatus @LimitedEventFanoutConfig DontDoAuth tid >>= \case
+        FeatureStatusEnabled -> do
+          admins <- E.getTeamAdmins tid
+          uncheckedDeleteTeamMember lusr (Just zcon) tid remove (Left admins)
+        FeatureStatusDisabled -> do
+          mems <- getTeamMembersForFanout tid
+          uncheckedDeleteTeamMember lusr (Just zcon) tid remove (Right mems)
       pure TeamMemberDeleteCompleted
 
 -- This function is "unchecked" because it does not validate that the user has the `RemoveTeamMember` permission.
@@ -1002,9 +1015,9 @@ uncheckedDeleteTeamMember ::
   Maybe ConnId ->
   TeamId ->
   UserId ->
-  [UserId] ->
+  Either [UserId] TeamMemberList ->
   Sem r ()
-uncheckedDeleteTeamMember lusr zcon tid remove admins = do
+uncheckedDeleteTeamMember lusr zcon tid remove (Left admins) = do
   now <- input
   pushMemberLeaveEvent now
   E.deleteTeamMember tid remove
@@ -1022,6 +1035,25 @@ uncheckedDeleteTeamMember lusr zcon tid remove admins = do
                 (filter (/= (tUnqualified lusr)) admins)
       E.push1 $
         newPushLocal1 ListComplete (tUnqualified lusr) (TeamEvent e) r & pushConn .~ zcon & pushTransient .~ True
+uncheckedDeleteTeamMember lusr zcon tid remove (Right mems) = do
+  now <- input
+  pushMemberLeaveEventToAll now
+  E.deleteTeamMember tid remove
+  -- notify all conversation members not in this team.
+  removeFromConvsAndPushConvLeaveEvent lusr zcon tid remove
+  where
+    -- notify all team members. This is to maintain compatibility with clients
+    -- relying on these events, but eventually they will catch up and this
+    -- function, and the corresponding feature flag, will be ready for removal.
+    pushMemberLeaveEventToAll :: UTCTime -> Sem r ()
+    pushMemberLeaveEventToAll now = do
+      let e = newEvent tid now (EdMemberLeave remove)
+      let r =
+            list1
+              (userRecipient (tUnqualified lusr))
+              (membersToRecipients (Just (tUnqualified lusr)) (mems ^. teamMembers))
+      E.push1 $
+        newPushLocal1 (mems ^. teamMemberListType) (tUnqualified lusr) (TeamEvent e) r & pushConn .~ zcon
 
 removeFromConvsAndPushConvLeaveEvent ::
   forall r.

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -81,7 +81,6 @@ patchFeatureStatusInternal ::
     GetConfigForTeamConstraints cfg r,
     SetConfigForTeamConstraints cfg r,
     Member (ErrorS 'NotATeamMember) r,
-    Member (ErrorS OperationDenied) r,
     Member (ErrorS 'TeamNotFound) r,
     Member TeamStore r,
     Member TeamFeatureStore r,

--- a/services/galley/src/Galley/API/Teams/Features.hs
+++ b/services/galley/src/Galley/API/Teams/Features.hs
@@ -395,3 +395,5 @@ instance SetFeatureConfig MlsMigrationConfig where
     persistAndPushEvent tid wsnl
 
 instance SetFeatureConfig EnforceFileDownloadLocationConfig
+
+instance SetFeatureConfig LimitedEventFanoutConfig

--- a/services/galley/src/Galley/API/Teams/Features/Get.hs
+++ b/services/galley/src/Galley/API/Teams/Features/Get.hs
@@ -115,8 +115,7 @@ getFeatureStatus ::
   forall cfg r.
   ( GetFeatureConfig cfg,
     GetConfigForTeamConstraints cfg r,
-    ( Member (ErrorS OperationDenied) r,
-      Member (ErrorS 'NotATeamMember) r,
+    ( Member (ErrorS 'NotATeamMember) r,
       Member (ErrorS 'TeamNotFound) r,
       Member TeamStore r
     )

--- a/services/galley/src/Galley/API/Teams/Features/Get.hs
+++ b/services/galley/src/Galley/API/Teams/Features/Get.hs
@@ -239,6 +239,7 @@ getAllFeatureConfigsForServer =
     <*> getConfigForServer @MlsE2EIdConfig
     <*> getConfigForServer @MlsMigrationConfig
     <*> getConfigForServer @EnforceFileDownloadLocationConfig
+    <*> getConfigForServer @LimitedEventFanoutConfig
 
 getAllFeatureConfigsUser ::
   forall r.
@@ -274,6 +275,7 @@ getAllFeatureConfigsUser uid =
     <*> getConfigForUser @MlsE2EIdConfig uid
     <*> getConfigForUser @MlsMigrationConfig uid
     <*> getConfigForUser @EnforceFileDownloadLocationConfig uid
+    <*> getConfigForUser @LimitedEventFanoutConfig uid
 
 getAllFeatureConfigsTeam ::
   forall r.
@@ -305,6 +307,7 @@ getAllFeatureConfigsTeam tid =
     <*> getConfigForTeam @MlsE2EIdConfig tid
     <*> getConfigForTeam @MlsMigrationConfig tid
     <*> getConfigForTeam @EnforceFileDownloadLocationConfig tid
+    <*> getConfigForTeam @LimitedEventFanoutConfig tid
 
 -- | Note: this is an internal function which doesn't cover all features, e.g. LegalholdConfig
 genericGetConfigForTeam ::
@@ -496,6 +499,10 @@ instance GetFeatureConfig MlsMigrationConfig where
 instance GetFeatureConfig EnforceFileDownloadLocationConfig where
   getConfigForServer =
     input <&> view (settings . featureFlags . flagEnforceFileDownloadLocation . unDefaults)
+
+instance GetFeatureConfig LimitedEventFanoutConfig where
+  getConfigForServer =
+    input <&> view (settings . featureFlags . flagLimitedEventFanout . unDefaults . unImplicitLockStatus)
 
 -- | If second factor auth is enabled, make sure that end-points that don't support it, but
 -- should, are blocked completely.  (This is a workaround until we have 2FA for those

--- a/services/galley/src/Galley/Cassandra/TeamFeatures.hs
+++ b/services/galley/src/Galley/Cassandra/TeamFeatures.hs
@@ -169,6 +169,8 @@ getFeatureConfig FeatureSingletonEnforceFileDownloadLocationConfig tid = do
   where
     select :: PrepQuery R (Identity TeamId) (Maybe FeatureStatus, Maybe Text)
     select = "select enforce_file_download_location_status, enforce_file_download_location from team_features where team_id = ?"
+getFeatureConfig FeatureSingletonLimitedEventFanoutConfig tid =
+  getTrivialConfigC "limited_event_fanout_status" tid
 
 setFeatureConfig :: MonadClient m => FeatureSingleton cfg -> TeamId -> WithStatusNoLock cfg -> m ()
 setFeatureConfig FeatureSingletonLegalholdConfig tid statusNoLock = setFeatureStatusC "legalhold_status" tid (wssStatus statusNoLock)
@@ -265,6 +267,8 @@ setFeatureConfig FeatureSingletonEnforceFileDownloadLocationConfig tid status = 
     insert :: PrepQuery W (TeamId, FeatureStatus, Maybe Text) ()
     insert =
       "insert into team_features (team_id, enforce_file_download_location_status, enforce_file_download_location) values (?, ?, ?)"
+setFeatureConfig FeatureSingletonLimitedEventFanoutConfig tid statusNoLock =
+  setFeatureStatusC "limited_event_fanout_status" tid (wssStatus statusNoLock)
 
 getFeatureLockStatus :: MonadClient m => FeatureSingleton cfg -> TeamId -> m (Maybe LockStatus)
 getFeatureLockStatus FeatureSingletonFileSharingConfig tid = getLockStatusC "file_sharing_lock_status" tid

--- a/services/galley/src/Galley/Schema/Run.hs
+++ b/services/galley/src/Galley/Schema/Run.hs
@@ -91,6 +91,7 @@ import Galley.Schema.V87_TeamFeatureSupportedProtocols qualified as V87_TeamFeat
 import Galley.Schema.V88_RemoveMemberClientAndTruncateMLSGroupMemberClient qualified as V88_RemoveMemberClientAndTruncateMLSGroupMemberClient
 import Galley.Schema.V89_MlsLockStatus qualified as V89_MlsLockStatus
 import Galley.Schema.V90_EnforceFileDownloadLocationConfig qualified as V90_EnforceFileDownloadLocationConfig
+import Galley.Schema.V91_TeamMemberDeletedLimitedEventFanout qualified as V91_TeamMemberDeletedLimitedEventFanout
 import Imports
 import Options.Applicative
 import System.Logger.Extended qualified as Log
@@ -182,7 +183,8 @@ migrations =
     V87_TeamFeatureSupportedProtocols.migration,
     V88_RemoveMemberClientAndTruncateMLSGroupMemberClient.migration,
     V89_MlsLockStatus.migration,
-    V90_EnforceFileDownloadLocationConfig.migration
+    V90_EnforceFileDownloadLocationConfig.migration,
+    V91_TeamMemberDeletedLimitedEventFanout.migration
     -- FUTUREWORK: once #1726 has made its way to master/production,
     -- the 'message' field in connections table can be dropped.
     -- See also https://github.com/wireapp/wire-server/pull/1747/files

--- a/services/galley/src/Galley/Schema/V91_TeamMemberDeletedLimitedEventFanout.hs
+++ b/services/galley/src/Galley/Schema/V91_TeamMemberDeletedLimitedEventFanout.hs
@@ -1,0 +1,30 @@
+-- This file is part of the Wire Server implementation.
+--
+-- Copyright (C) 2023 Wire Swiss GmbH <opensource@wire.com>
+--
+-- This program is free software: you can redistribute it and/or modify it under
+-- the terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option) any
+-- later version.
+--
+-- This program is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License along
+-- with this program. If not, see <https://www.gnu.org/licenses/>.
+module Galley.Schema.V91_TeamMemberDeletedLimitedEventFanout where
+
+import Cassandra.Schema
+import Imports
+import Text.RawString.QQ
+
+migration :: Migration
+migration =
+  Migration 91 "Add a field for the team member deleted limited event fanout" $
+    schema'
+      [r| ALTER TABLE team_features ADD (
+            limited_event_fanout_status int
+        )
+     |]

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -1065,7 +1065,7 @@ testAllFeatures = do
           afcMlsMigration = defaultMlsMigrationConfig,
           afcEnforceFileDownloadLocation = defaultEnforceFileDownloadLocationConfig,
           afcLimitedEventFanout =
-            withStatus FeatureStatusDisabled LockStatusLocked LimitedEventFanoutConfig FeatureTTLUnlimited
+            withStatus FeatureStatusDisabled LockStatusUnlocked LimitedEventFanoutConfig FeatureTTLUnlimited
         }
 
 testFeatureConfigConsistency :: TestM ()

--- a/services/galley/test/integration/API/Teams/Feature.hs
+++ b/services/galley/test/integration/API/Teams/Feature.hs
@@ -1063,7 +1063,9 @@ testAllFeatures = do
           afcOutlookCalIntegration = withStatus FeatureStatusDisabled LockStatusLocked OutlookCalIntegrationConfig FeatureTTLUnlimited,
           afcMlsE2EId = withStatus FeatureStatusDisabled LockStatusUnlocked (wsConfig defFeatureStatus) FeatureTTLUnlimited,
           afcMlsMigration = defaultMlsMigrationConfig,
-          afcEnforceFileDownloadLocation = defaultEnforceFileDownloadLocationConfig
+          afcEnforceFileDownloadLocation = defaultEnforceFileDownloadLocationConfig,
+          afcLimitedEventFanout =
+            withStatus FeatureStatusDisabled LockStatusLocked LimitedEventFanoutConfig FeatureTTLUnlimited
         }
 
 testFeatureConfigConsistency :: TestM ()


### PR DESCRIPTION
To maintain compatibility with old clients that do not implement the limited even fanout feature when a team member is deleted, this PR puts the limited fanout behind a feature flag. The flag is disabled by default to maintain compatibility with old clients that rely on the full fanout.

Tracked by https://wearezeta.atlassian.net/browse/WPB-5883.

## Checklist

 - [x] Add a new entry in an appropriate subdirectory of `changelog.d`
 - [x] Read and follow the [PR guidelines](https://docs.wire.com/developer/developer/pr-guidelines.html)

- [X] Have two integration tests (the enabled case already exists), each having a different flag value (enabled vs. disabled), that assert on events that a team owner and other team members get, but also non-team users get.
  - [X] For the disabled case, create another Git branch that is based on the parent of the commit corresponding to PR #3434. Write an integration test that asserts on the events when a team member is deleted. Once the test is
    done, port it to the current PR branch. That way we make sure the behavior is as before. Otherwise it would be hard to know what are the expected semantics given that PR #3434 made some changes without writing tests.
- [X] Have a simple test just to make sure the feature flag's endpoints for getting and setting work.
- [x] Fix old Galley integration test "send billing events to owners even in large teams"
